### PR TITLE
Update to new builder format.

### DIFF
--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -165,8 +165,9 @@ void mlirMSFTAddPhysLocationAttr(MlirOperation cOp, const char *entityName,
   PhysLocationAttr loc = PhysLocationAttr::get(
       ctxt, PrimitiveTypeAttr::get(ctxt, type), x, y, num);
   StringAttr entity = StringAttr::get(ctxt, entityName);
-  OpBuilder(op).create<PDPhysLocationOp>(op->getLoc(), loc, entity,
-                                         FlatSymbolRefAttr::get(op));
+  auto builder = OpBuilder(op);
+  PDPhysLocationOp::create(builder, op->getLoc(), loc, entity,
+                           FlatSymbolRefAttr::get(op));
   op->setAttr(entity, loc);
 }
 

--- a/lib/Conversion/AIGToComb/AIGToComb.cpp
+++ b/lib/Conversion/AIGToComb/AIGToComb.cpp
@@ -39,7 +39,7 @@ struct AIGAndInverterOpConversion : OpConversionPattern<aig::AndInverterOp> {
     // Convert to comb.and + comb.xor + hw.constant
     auto width = op.getResult().getType().getIntOrFloatBitWidth();
     auto allOnes =
-        rewriter.create<hw::ConstantOp>(op.getLoc(), APInt::getAllOnes(width));
+        hw::ConstantOp::create(rewriter, op.getLoc(), APInt::getAllOnes(width));
     SmallVector<Value> operands;
     operands.reserve(op.getNumOperands());
     for (auto [input, inverted] : llvm::zip(op.getOperands(), op.getInverted()))

--- a/lib/Conversion/CalyxToFSM/MaterializeFSM.cpp
+++ b/lib/Conversion/CalyxToFSM/MaterializeFSM.cpp
@@ -87,7 +87,7 @@ struct MaterializeCalyxToFSMPass
         guardConjunction = guards.front();
       else
         guardConjunction =
-            b.create<comb::AndOp>(transition.getLoc(), guards, false);
+            comb::AndOp::create(b, transition.getLoc(), guards, false);
       guardOp.setOperand(guardConjunction);
     }
   }
@@ -99,7 +99,7 @@ struct MaterializeCalyxToFSMPass
 
     OpBuilder::InsertionGuard g(b);
     b.setInsertionPointToStart(&machineOp.getBody().front());
-    auto constantOp = b.create<hw::ConstantOp>(machineOp.getLoc(), value);
+    auto constantOp = hw::ConstantOp::create(b, machineOp.getLoc(), value);
     constants[value] = constantOp;
     return constantOp;
   }

--- a/lib/Conversion/CalyxToHW/CalyxToHW.cpp
+++ b/lib/Conversion/CalyxToHW/CalyxToHW.cpp
@@ -53,8 +53,8 @@ struct ConvertComponentOp : public OpConversionPattern<ComponentOp> {
     ModulePortInfo hwPortInfo(hwInputInfo);
 
     SmallVector<Value> argValues;
-    auto hwMod = rewriter.create<HWModuleOp>(
-        component.getLoc(), component.getNameAttr(), hwPortInfo,
+    auto hwMod = HWModuleOp::create(
+        rewriter, component.getLoc(), component.getNameAttr(), hwPortInfo,
         [&](OpBuilder &b, HWModulePortAccessor &ports) {
           for (auto [name, type, direction, _] : portInfo) {
             switch (direction) {
@@ -63,9 +63,9 @@ struct ConvertComponentOp : public OpConversionPattern<ComponentOp> {
               argValues.push_back(ports.getInput(name));
               break;
             case calyx::Direction::Output:
-              auto wire = b.create<sv::WireOp>(component.getLoc(), type, name);
+              auto wire = sv::WireOp::create(b, component.getLoc(), type, name);
               auto wireRead =
-                  b.create<sv::ReadInOutOp>(component.getLoc(), wire);
+                  sv::ReadInOutOp::create(b, component.getLoc(), wire);
               argValues.push_back(wireRead);
               ports.setOutput(name, wireRead);
               break;
@@ -131,15 +131,15 @@ struct ConvertAssignOp : public OpConversionPattern<calyx::AssignOp> {
     Value src = adaptor.getSrc();
     if (auto guard = adaptor.getGuard()) {
       auto zero =
-          rewriter.create<hw::ConstantOp>(assign.getLoc(), src.getType(), 0);
-      src = rewriter.create<MuxOp>(assign.getLoc(), guard, src, zero);
+          hw::ConstantOp::create(rewriter, assign.getLoc(), src.getType(), 0);
+      src = MuxOp::create(rewriter, assign.getLoc(), guard, src, zero);
       for (Operation *destUser :
            llvm::make_early_inc_range(assign.getDest().getUsers())) {
         if (destUser == assign)
           continue;
         if (auto otherAssign = dyn_cast<calyx::AssignOp>(destUser)) {
-          src = rewriter.create<MuxOp>(assign.getLoc(), otherAssign.getGuard(),
-                                       otherAssign.getSrc(), src);
+          src = MuxOp::create(rewriter, assign.getLoc(), otherAssign.getGuard(),
+                              otherAssign.getSrc(), src);
           rewriter.eraseOp(destUser);
         }
       }
@@ -250,7 +250,7 @@ private:
           auto fal = wireIn(op.getFal(), op.instanceName(),
                             op.portName(op.getFal()), b);
 
-          auto mux = b.create<MuxOp>(sel, tru, fal);
+          auto mux = MuxOp::create(b, sel, tru, fal);
 
           auto out =
               wireOut(mux, op.instanceName(), op.portName(op.getOut()), b);
@@ -282,12 +282,12 @@ private:
                             op.portName(op.getClk()), b);
           auto reset = wireIn(op.getReset(), op.instanceName(),
                               op.portName(op.getReset()), b);
-          auto seqClk = b.create<seq::ToClockOp>(clk);
+          auto seqClk = seq::ToClockOp::create(b, clk);
           auto doneReg =
               reg(writeEn, seqClk, reset, op.instanceName() + "_done_reg", b);
           auto done =
               wireOut(doneReg, op.instanceName(), op.portName(op.getDone()), b);
-          auto clockEn = b.create<AndOp>(writeEn, createOrFoldNot(done, b));
+          auto clockEn = AndOp::create(b, writeEn, createOrFoldNot(done, b));
           auto outReg =
               regCe(in, seqClk, clockEn, reset, op.instanceName() + "_reg", b);
           auto out = wireOut(outReg, op.instanceName(), "", b);
@@ -300,7 +300,7 @@ private:
               wireIn(op.getIn(), op.instanceName(), op.portName(op.getIn()), b);
           auto outWidth = op.getOut().getType().getIntOrFloatBitWidth();
 
-          auto extract = b.create<ExtractOp>(in, 0, outWidth);
+          auto extract = ExtractOp::create(b, in, 0, outWidth);
 
           auto out =
               wireOut(extract, op.instanceName(), op.portName(op.getOut()), b);
@@ -321,7 +321,7 @@ private:
           wires.append({wire.getInput(), wire});
         })
         .Case([&](UndefLibOp op) {
-          auto undef = b.create<sv::ConstantXOp>(op.getType());
+          auto undef = sv::ConstantXOp::create(b, op.getType());
           wires.append({undef});
         })
         .Case([&](PadLibOp op) {
@@ -329,8 +329,8 @@ private:
               wireIn(op.getIn(), op.instanceName(), op.portName(op.getIn()), b);
           auto srcWidth = in.getType().getIntOrFloatBitWidth();
           auto destWidth = op.getOut().getType().getIntOrFloatBitWidth();
-          auto zero = b.create<hw::ConstantOp>(op.getLoc(),
-                                               APInt(destWidth - srcWidth, 0));
+          auto zero = hw::ConstantOp::create(b, op.getLoc(),
+                                             APInt(destWidth - srcWidth, 0));
           auto padded = wireOut(b.createOrFold<comb::ConcatOp>(zero, in),
                                 op.instanceName(), op.portName(op.getOut()), b);
           wires.append({in.getInput(), padded});
@@ -354,7 +354,7 @@ private:
     auto right =
         wireIn(op.getRight(), op.instanceName(), op.portName(op.getRight()), b);
 
-    auto add = b.create<ResultTy>(left, right, false);
+    auto add = ResultTy::create(b, left, right, false);
 
     auto out = wireOut(add, op.instanceName(), op.portName(op.getOut()), b);
     wires.append({left.getInput(), right.getInput(), out});
@@ -369,7 +369,7 @@ private:
     auto right =
         wireIn(op.getRight(), op.instanceName(), op.portName(op.getRight()), b);
 
-    auto add = b.create<ICmpOp>(pred, left, right, false);
+    auto add = ICmpOp::create(b, pred, left, right, false);
 
     auto out = wireOut(add, op.instanceName(), op.portName(op.getOut()), b);
     wires.append({left.getInput(), right.getInput(), out});
@@ -395,11 +395,11 @@ private:
     auto done =
         wireOut(doneReg, op.instanceName(), op.portName(op.getDone()), b);
 
-    auto targetOp = b.create<TargetOpTy>(left, right, false);
+    auto targetOp = TargetOpTy::create(b, left, right, false);
     for (auto &&[targetRes, sourceRes] :
          llvm::zip(targetOp->getResults(), op.getOutputPorts())) {
       auto portName = op.portName(sourceRes);
-      auto clockEn = b.create<AndOp>(go, createOrFoldNot(done, b));
+      auto clockEn = AndOp::create(b, go, createOrFoldNot(done, b));
       auto resReg = regCe(targetRes, clk, clockEn, reset,
                           createName(op.instanceName(), portName), b);
       wires.push_back(wireOut(resReg, op.instanceName(), portName, b));
@@ -410,31 +410,31 @@ private:
 
   ReadInOutOp wireIn(Value source, StringRef instanceName, StringRef portName,
                      ImplicitLocOpBuilder &b) const {
-    auto wire = b.create<sv::WireOp>(source.getType(),
-                                     createName(instanceName, portName));
-    return b.create<ReadInOutOp>(wire);
+    auto wire = sv::WireOp::create(b, source.getType(),
+                                   createName(instanceName, portName));
+    return ReadInOutOp::create(b, wire);
   }
 
   ReadInOutOp wireOut(Value source, StringRef instanceName, StringRef portName,
                       ImplicitLocOpBuilder &b) const {
-    auto wire = b.create<sv::WireOp>(source.getType(),
-                                     createName(instanceName, portName));
-    b.create<sv::AssignOp>(wire, source);
-    return b.create<ReadInOutOp>(wire);
+    auto wire = sv::WireOp::create(b, source.getType(),
+                                   createName(instanceName, portName));
+    sv::AssignOp::create(b, wire, source);
+    return ReadInOutOp::create(b, wire);
   }
 
   CompRegOp reg(Value source, Value clock, Value reset, const Twine &name,
                 ImplicitLocOpBuilder &b) const {
-    auto resetValue = b.create<hw::ConstantOp>(source.getType(), 0);
-    return b.create<CompRegOp>(source, clock, reset, resetValue, name.str());
+    auto resetValue = hw::ConstantOp::create(b, source.getType(), 0);
+    return CompRegOp::create(b, source, clock, reset, resetValue, name.str());
   }
 
   CompRegClockEnabledOp regCe(Value source, Value clock, Value ce, Value reset,
                               const Twine &name,
                               ImplicitLocOpBuilder &b) const {
-    auto resetValue = b.create<hw::ConstantOp>(source.getType(), 0);
-    return b.create<CompRegClockEnabledOp>(source, clock, ce, reset, resetValue,
-                                           name.str());
+    auto resetValue = hw::ConstantOp::create(b, source.getType(), 0);
+    return CompRegClockEnabledOp::create(b, source, clock, ce, reset,
+                                         resetValue, name.str());
   }
 
   std::string createName(StringRef instanceName, StringRef portName) const {

--- a/lib/Conversion/CombToDatapath/CombToDatapath.cpp
+++ b/lib/Conversion/CombToDatapath/CombToDatapath.cpp
@@ -45,8 +45,8 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     }
 
     // Reduce to two values (carry,save)
-    auto results =
-        rewriter.create<datapath::CompressOp>(op.getLoc(), op.getOperands(), 2);
+    auto results = datapath::CompressOp::create(rewriter, op.getLoc(),
+                                                op.getOperands(), 2);
     // carry+saved
     rewriter.replaceOpWithNewOp<AddOp>(op, results.getResults(), true);
     return success();
@@ -66,8 +66,8 @@ struct CombMulOpConversion : OpConversionPattern<MulOp> {
 
     auto width = op.getType().getIntOrFloatBitWidth();
     // Create partial product rows - number of rows == width
-    auto pp = rewriter.create<datapath::PartialProductOp>(
-        op.getLoc(), op.getInputs(), width);
+    auto pp = datapath::PartialProductOp::create(rewriter, op.getLoc(),
+                                                 op.getInputs(), width);
     // Sum partial products
     rewriter.replaceOpWithNewOp<AddOp>(op, pp.getResults(), true);
     return success();

--- a/lib/Conversion/CombToLLVM/CombToLLVM.cpp
+++ b/lib/Conversion/CombToLLVM/CombToLLVM.cpp
@@ -36,7 +36,7 @@ struct CombParityOpConversion : public ConvertToLLVMPattern {
     auto parityOp = cast<comb::ParityOp>(op);
 
     auto popCount =
-        rewriter.create<LLVM::CtPopOp>(op->getLoc(), parityOp.getInput());
+        LLVM::CtPopOp::create(rewriter, op->getLoc(), parityOp.getInput());
     rewriter.replaceOpWithNewOp<LLVM::TruncOp>(
         op, IntegerType::get(rewriter.getContext(), 1), popCount);
 

--- a/lib/Conversion/CombToSMT/CombToSMT.cpp
+++ b/lib/Conversion/CombToSMT/CombToSMT.cpp
@@ -59,11 +59,11 @@ struct IcmpOpConversion : OpConversionPattern<ICmpOp> {
 
     Value result;
     if (adaptor.getPredicate() == ICmpPredicate::eq) {
-      result = rewriter.create<smt::EqOp>(op.getLoc(), adaptor.getLhs(),
-                                          adaptor.getRhs());
+      result = smt::EqOp::create(rewriter, op.getLoc(), adaptor.getLhs(),
+                                 adaptor.getRhs());
     } else if (adaptor.getPredicate() == ICmpPredicate::ne) {
-      result = rewriter.create<smt::DistinctOp>(op.getLoc(), adaptor.getLhs(),
-                                                adaptor.getRhs());
+      result = smt::DistinctOp::create(rewriter, op.getLoc(), adaptor.getLhs(),
+                                       adaptor.getRhs());
     } else {
       smt::BVCmpPredicate pred;
       switch (adaptor.getPredicate()) {
@@ -95,8 +95,8 @@ struct IcmpOpConversion : OpConversionPattern<ICmpOp> {
         llvm_unreachable("all cases handled above");
       }
 
-      result = rewriter.create<smt::BVCmpOp>(
-          op.getLoc(), pred, adaptor.getLhs(), adaptor.getRhs());
+      result = smt::BVCmpOp::create(rewriter, op.getLoc(), pred,
+                                    adaptor.getLhs(), adaptor.getRhs());
     }
 
     Value convVal = typeConverter->materializeTargetConversion(
@@ -148,7 +148,8 @@ struct SubOpConversion : OpConversionPattern<SubOp> {
   LogicalResult
   matchAndRewrite(SubOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value negRhs = rewriter.create<smt::BVNegOp>(op.getLoc(), adaptor.getRhs());
+    Value negRhs =
+        smt::BVNegOp::create(rewriter, op.getLoc(), adaptor.getRhs());
     rewriter.replaceOpWithNewOp<smt::BVAddOp>(op, adaptor.getLhs(), negRhs);
     return success();
   }
@@ -169,11 +170,11 @@ struct ParityOpConversion : OpConversionPattern<ParityOp> {
     // the type conversion should already fail.
     Type oneBitTy = smt::BitVectorType::get(getContext(), 1);
     Value runner =
-        rewriter.create<smt::ExtractOp>(loc, oneBitTy, 0, adaptor.getInput());
+        smt::ExtractOp::create(rewriter, loc, oneBitTy, 0, adaptor.getInput());
     for (unsigned i = 1; i < bitwidth; ++i) {
-      Value ext =
-          rewriter.create<smt::ExtractOp>(loc, oneBitTy, i, adaptor.getInput());
-      runner = rewriter.create<smt::BVXOrOp>(loc, runner, ext);
+      Value ext = smt::ExtractOp::create(rewriter, loc, oneBitTy, i,
+                                         adaptor.getInput());
+      runner = smt::BVXOrOp::create(rewriter, loc, runner, ext);
     }
 
     rewriter.replaceOp(op, runner);
@@ -218,11 +219,11 @@ struct DivisionOpConversion : OpConversionPattern<SourceOp> {
     auto resultType = OpConversionPattern<SourceOp>::typeConverter->convertType(
         op.getResult().getType());
     Value zero =
-        rewriter.create<smt::BVConstantOp>(loc, APInt(type.getWidth(), 0));
-    Value isZero = rewriter.create<smt::EqOp>(loc, adaptor.getRhs(), zero);
-    Value symbolicVal = rewriter.create<smt::DeclareFunOp>(loc, resultType);
+        smt::BVConstantOp::create(rewriter, loc, APInt(type.getWidth(), 0));
+    Value isZero = smt::EqOp::create(rewriter, loc, adaptor.getRhs(), zero);
+    Value symbolicVal = smt::DeclareFunOp::create(rewriter, loc, resultType);
     Value division =
-        rewriter.create<TargetOp>(loc, resultType, adaptor.getOperands());
+        TargetOp::create(rewriter, loc, resultType, adaptor.getOperands());
     rewriter.replaceOpWithNewOp<smt::IteOp>(op, isZero, symbolicVal, division);
     return success();
   }
@@ -245,7 +246,7 @@ struct VariadicToBinaryOpConversion : OpConversionPattern<SourceOp> {
 
     Value runner = operands[0];
     for (Value operand : operands.drop_front())
-      runner = rewriter.create<TargetOp>(op.getLoc(), runner, operand);
+      runner = TargetOp::create(rewriter, op.getLoc(), runner, operand);
 
     rewriter.replaceOp(op, runner);
     return success();

--- a/lib/Conversion/DatapathToSMT/DatapathToSMT.cpp
+++ b/lib/Conversion/DatapathToSMT/DatapathToSMT.cpp
@@ -46,14 +46,14 @@ struct CompressOpConversion : OpConversionPattern<CompressOp> {
     Value operandRunner = operands[0];
     for (Value operand : operands.drop_front())
       operandRunner =
-          rewriter.create<smt::BVAddOp>(op.getLoc(), operandRunner, operand);
+          smt::BVAddOp::create(rewriter, op.getLoc(), operandRunner, operand);
 
     // Create free variables
     SmallVector<Value, 2> newResults;
     newResults.reserve(results.size());
     for (Value result : results) {
-      auto declareFunOp = rewriter.create<smt::DeclareFunOp>(
-          op.getLoc(), typeConverter->convertType(result.getType()));
+      auto declareFunOp = smt::DeclareFunOp::create(
+          rewriter, op.getLoc(), typeConverter->convertType(result.getType()));
       newResults.push_back(declareFunOp.getResult());
     }
 
@@ -61,13 +61,13 @@ struct CompressOpConversion : OpConversionPattern<CompressOp> {
     Value resultRunner = newResults.front();
     for (auto freeVar : llvm::drop_begin(newResults, 1))
       resultRunner =
-          rewriter.create<smt::BVAddOp>(op.getLoc(), resultRunner, freeVar);
+          smt::BVAddOp::create(rewriter, op.getLoc(), resultRunner, freeVar);
 
     // Assert sum operands == sum results (free variables)
     auto premise =
-        rewriter.create<smt::EqOp>(op.getLoc(), operandRunner, resultRunner);
+        smt::EqOp::create(rewriter, op.getLoc(), operandRunner, resultRunner);
     // Encode via an assertion (could be relaxed to an assumption).
-    rewriter.create<smt::AssertOp>(op.getLoc(), premise);
+    smt::AssertOp::create(rewriter, op.getLoc(), premise);
 
     if (newResults.size() != results.size())
       return rewriter.notifyMatchFailure(op, "expected same number of results");
@@ -93,14 +93,14 @@ struct PartialProductOpConversion : OpConversionPattern<PartialProductOp> {
 
     // Multiply the operands
     auto mulResult =
-        rewriter.create<smt::BVMulOp>(op.getLoc(), operands[0], operands[1]);
+        smt::BVMulOp::create(rewriter, op.getLoc(), operands[0], operands[1]);
 
     // Create free variables
     SmallVector<Value, 2> newResults;
     newResults.reserve(results.size());
     for (Value result : results) {
-      auto declareFunOp = rewriter.create<smt::DeclareFunOp>(
-          op.getLoc(), typeConverter->convertType(result.getType()));
+      auto declareFunOp = smt::DeclareFunOp::create(
+          rewriter, op.getLoc(), typeConverter->convertType(result.getType()));
       newResults.push_back(declareFunOp.getResult());
     }
 
@@ -108,13 +108,13 @@ struct PartialProductOpConversion : OpConversionPattern<PartialProductOp> {
     Value resultRunner = newResults.front();
     for (auto freeVar : llvm::drop_begin(newResults, 1))
       resultRunner =
-          rewriter.create<smt::BVAddOp>(op.getLoc(), resultRunner, freeVar);
+          smt::BVAddOp::create(rewriter, op.getLoc(), resultRunner, freeVar);
 
     // Assert product of operands == sum results (free variables)
     auto premise =
-        rewriter.create<smt::EqOp>(op.getLoc(), mulResult, resultRunner);
+        smt::EqOp::create(rewriter, op.getLoc(), mulResult, resultRunner);
     // Encode via an assertion (could be relaxed to an assumption).
-    rewriter.create<smt::AssertOp>(op.getLoc(), premise);
+    smt::AssertOp::create(rewriter, op.getLoc(), premise);
 
     if (newResults.size() != results.size())
       return rewriter.notifyMatchFailure(op, "expected same number of results");

--- a/lib/Conversion/ExportVerilog/HWLowerInstanceChoices.cpp
+++ b/lib/Conversion/ExportVerilog/HWLowerInstanceChoices.cpp
@@ -83,20 +83,20 @@ LogicalResult ExportVerilog::lowerHWInstanceChoices(mlir::ModuleOp module) {
     auto symName = ns.newName(name);
     auto symNameAttr = declBuilder.getStringAttr(symName);
     auto symRef = FlatSymbolRefAttr::get(symNameAttr);
-    declBuilder.create<MacroDeclOp>(inst.getLoc(), symNameAttr,
-                                    /*args=*/ArrayAttr{},
-                                    /*verilogName=*/StringAttr{});
+    MacroDeclOp::create(declBuilder, inst.getLoc(), symNameAttr,
+                        /*args=*/ArrayAttr{},
+                        /*verilogName=*/StringAttr{});
 
     // This pass now generates the macros and attaches them to the instance
     // choice as an attribute. As a better solution, this pass should be moved
     // out of the umbrella of ExportVerilog and it should lower the `hw`
     // instance choices to a better SV-level representation of the operation.
     ImplicitLocOpBuilder builder(inst.getLoc(), inst);
-    builder.create<sv::IfDefOp>(
-        symName, [&] {},
+    sv::IfDefOp::create(
+        builder, symName, [&] {},
         [&] {
-          builder.create<sv::MacroDefOp>(
-              symRef, builder.getStringAttr("{{0}}"),
+          sv::MacroDefOp::create(
+              builder, symRef, builder.getStringAttr("{{0}}"),
               builder.getArrayAttr(
                   {FlatSymbolRefAttr::get(defaultModuleOp.getNameAttr())}));
         });

--- a/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
@@ -34,7 +34,7 @@ struct LegalizeAnonEnums
     auto topLevel = getOperation();
     if (!typeScope) {
       auto builder = OpBuilder::atBlockBegin(&topLevel.getRegion().front());
-      typeScope = builder.create<TypeScopeOp>(topLevel.getLoc(), "Enums");
+      typeScope = TypeScopeOp::create(builder, topLevel.getLoc(), "Enums");
       typeScope.getBodyRegion().push_back(new Block());
       mlir::SymbolTable symbolTable(topLevel);
       symbolTable.insert(typeScope);
@@ -52,7 +52,7 @@ struct LegalizeAnonEnums
     auto typeScope = getTypeScope();
     auto builder = OpBuilder::atBlockEnd(&typeScope.getRegion().front());
     auto declName = StringAttr::get(context, "enum" + Twine(enumCount++));
-    builder.create<TypedeclOp>(loc, declName, TypeAttr::get(type), nullptr);
+    TypedeclOp::create(builder, loc, declName, TypeAttr::get(type), nullptr);
     auto symRef = SymbolRefAttr::get(typeScope.getSymNameAttr(),
                                      FlatSymbolRefAttr::get(declName));
     typeAlias = TypeAliasType::get(symRef, type);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -133,8 +133,8 @@ static Value castToFIRRTLType(Value val, Type type,
     val = builder.createOrFold<HWStructCastOp>(bundle.getPassiveType(), val);
 
   if (type != val.getType())
-    val = builder.create<mlir::UnrealizedConversionCastOp>(type, val).getResult(
-        0);
+    val = mlir::UnrealizedConversionCastOp::create(builder, type, val)
+              .getResult(0);
 
   return val;
 }
@@ -145,17 +145,16 @@ static Value castFromFIRRTLType(Value val, Type type,
 
   if (hw::StructType structTy = dyn_cast<hw::StructType>(type)) {
     // Strip off Flip type if needed.
-    val =
-        builder
-            .create<mlir::UnrealizedConversionCastOp>(
-                type_cast<FIRRTLBaseType>(val.getType()).getPassiveType(), val)
-            .getResult(0);
+    val = mlir::UnrealizedConversionCastOp::create(
+              builder,
+              type_cast<FIRRTLBaseType>(val.getType()).getPassiveType(), val)
+              .getResult(0);
     val = builder.createOrFold<HWStructCastOp>(type, val);
     return val;
   }
 
   val =
-      builder.create<mlir::UnrealizedConversionCastOp>(type, val).getResult(0);
+      mlir::UnrealizedConversionCastOp::create(builder, type, val).getResult(0);
 
   return val;
 }
@@ -480,8 +479,8 @@ private:
         auto b = ImplicitLocOpBuilder::atBlockBegin(
             circuitOp.getLoc(),
             &circuitOp->getParentRegion()->getBlocks().back());
-        typeScope = b.create<hw::TypeScopeOp>(
-            b.getStringAttr(circuitOp.getName() + "__TYPESCOPE_"));
+        typeScope = hw::TypeScopeOp::create(
+            b, b.getStringAttr(circuitOp.getName() + "__TYPESCOPE_"));
         typeScope.getBodyRegion().push_back(new Block());
       }
       auto typeName = firAlias.getName();
@@ -494,8 +493,8 @@ private:
 
       auto typeScopeBuilder =
           ImplicitLocOpBuilder::atBlockEnd(typeLoc, typeScope.getBodyBlock());
-      auto typeDecl = typeScopeBuilder.create<hw::TypedeclOp>(typeLoc, typeName,
-                                                              rawType, nullptr);
+      auto typeDecl = hw::TypedeclOp::create(typeScopeBuilder, typeLoc,
+                                             typeName, rawType, nullptr);
       auto hwAlias = hw::TypeAliasType::get(
           SymbolRefAttr::get(typeScope.getSymNameAttr(),
                              {FlatSymbolRefAttr::get(typeDecl)}),
@@ -706,9 +705,9 @@ void FIRRTLModuleLowering::runOnOperation() {
             })
             .Case<FormalOp>([&](auto oldOp) {
               auto builder = OpBuilder::atBlockEnd(topLevelModule);
-              auto newOp = builder.create<verif::FormalOp>(
-                  oldOp.getLoc(), oldOp.getNameAttr(),
-                  oldOp.getParametersAttr());
+              auto newOp = verif::FormalOp::create(builder, oldOp.getLoc(),
+                                                   oldOp.getNameAttr(),
+                                                   oldOp.getParametersAttr());
               newOp.getBody().emplaceBlock();
               state.recordModuleMapping(oldOp, newOp);
               opsToProcess.push_back(newOp);
@@ -717,8 +716,8 @@ void FIRRTLModuleLowering::runOnOperation() {
             .Case<SimulationOp>([&](auto oldOp) {
               auto loc = oldOp.getLoc();
               auto builder = OpBuilder::atBlockEnd(topLevelModule);
-              auto newOp = builder.create<verif::SimulationOp>(
-                  loc, oldOp.getNameAttr(), oldOp.getParametersAttr());
+              auto newOp = verif::SimulationOp::create(
+                  builder, loc, oldOp.getNameAttr(), oldOp.getParametersAttr());
               auto &body = newOp.getRegion().emplaceBlock();
               body.addArgument(seq::ClockType::get(builder.getContext()), loc);
               body.addArgument(builder.getI1Type(), loc);
@@ -811,7 +810,7 @@ void FIRRTLModuleLowering::runOnOperation() {
   if (!state.macroDeclNames.empty()) {
     ImplicitLocOpBuilder b(UnknownLoc::get(&getContext()), circuit);
     for (auto name : state.macroDeclNames) {
-      b.create<sv::MacroDeclOp>(name);
+      sv::MacroDeclOp::create(b, name);
     }
   }
 
@@ -836,23 +835,22 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
                                StringRef defineFalse = StringRef()) {
     if (!defineFalse.data()) {
       assert(defineTrue.data() && "didn't define anything");
-      b.create<sv::IfDefOp>(
-          guard, [&]() { b.create<sv::MacroDefOp>(defName, defineTrue); });
+      sv::IfDefOp::create(
+          b, guard, [&]() { sv::MacroDefOp::create(b, defName, defineTrue); });
     } else {
-      b.create<sv::IfDefOp>(
-          guard,
+      sv::IfDefOp::create(
+          b, guard,
           [&]() {
             if (defineTrue.data())
-              b.create<sv::MacroDefOp>(defName, defineTrue);
+              sv::MacroDefOp::create(b, defName, defineTrue);
           },
-          [&]() { b.create<sv::MacroDefOp>(defName, defineFalse); });
+          [&]() { sv::MacroDefOp::create(b, defName, defineFalse); });
     }
   };
 
   // Helper function to emit #ifndef guard.
   auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
-    b.create<sv::IfDefOp>(
-        guard, []() {}, body);
+    sv::IfDefOp::create(b, guard, []() {}, body);
   };
 
   if (state.usedFileDescriptorLib) {
@@ -885,8 +883,8 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
         DictionaryAttr::get(b.getContext(), perArgumentsAttr)};
 
     // Create the function declaration
-    auto func = b.create<sv::FuncOp>(
-        /*sym_name=*/
+    auto func = sv::FuncOp::create(
+        b, /*sym_name=*/
         "__circt_lib_logging::FileDescriptor::get", moduleType,
         /*perArgumentAttrs=*/
         b.getArrayAttr(
@@ -899,11 +897,11 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
         b.getStringAttr("__circt_lib_logging::FileDescriptor::get"));
     func.setPrivate();
 
-    b.create<sv::MacroDeclOp>("__CIRCT_LIB_LOGGING");
+    sv::MacroDeclOp::create(b, "__CIRCT_LIB_LOGGING");
     // Create the fragment containing the FileDescriptor class.
-    b.create<emit::FragmentOp>("CIRCT_LIB_LOGGING_FRAGMENT", [&] {
+    emit::FragmentOp::create(b, "CIRCT_LIB_LOGGING_FRAGMENT", [&] {
       emitGuard("__CIRCT_LIB_LOGGING", [&]() {
-        b.create<sv::VerbatimOp>(R"(// CIRCT Logging Library
+        sv::VerbatimOp::create(b, R"(// CIRCT Logging Library
 package __circt_lib_logging;
   class FileDescriptor;
     static int global_id [string];
@@ -919,18 +917,18 @@ package __circt_lib_logging;
 endpackage
 )");
 
-        b.create<sv::MacroDefOp>("__CIRCT_LIB_LOGGING", "");
+        sv::MacroDefOp::create(b, "__CIRCT_LIB_LOGGING", "");
       });
     });
   }
 
   if (state.usedPrintf) {
-    b.create<sv::MacroDeclOp>("PRINTF_COND");
-    b.create<sv::MacroDeclOp>("PRINTF_COND_");
-    b.create<emit::FragmentOp>("PRINTF_COND_FRAGMENT", [&] {
-      b.create<sv::VerbatimOp>(
-          "\n// Users can define 'PRINTF_COND' to add an extra gate to "
-          "prints.");
+    sv::MacroDeclOp::create(b, "PRINTF_COND");
+    sv::MacroDeclOp::create(b, "PRINTF_COND_");
+    emit::FragmentOp::create(b, "PRINTF_COND_FRAGMENT", [&] {
+      sv::VerbatimOp::create(
+          b, "\n// Users can define 'PRINTF_COND' to add an extra gate to "
+             "prints.");
       emitGuard("PRINTF_COND_", [&]() {
         emitGuardedDefine("PRINTF_COND", "PRINTF_COND_", "(`PRINTF_COND)", "1");
       });
@@ -938,12 +936,12 @@ endpackage
   }
 
   if (state.usedAssertVerboseCond) {
-    b.create<sv::MacroDeclOp>("ASSERT_VERBOSE_COND");
-    b.create<sv::MacroDeclOp>("ASSERT_VERBOSE_COND_");
-    b.create<emit::FragmentOp>("ASSERT_VERBOSE_COND_FRAGMENT", [&] {
-      b.create<sv::VerbatimOp>(
-          "\n// Users can define 'ASSERT_VERBOSE_COND' to add an extra "
-          "gate to assert error printing.");
+    sv::MacroDeclOp::create(b, "ASSERT_VERBOSE_COND");
+    sv::MacroDeclOp::create(b, "ASSERT_VERBOSE_COND_");
+    emit::FragmentOp::create(b, "ASSERT_VERBOSE_COND_FRAGMENT", [&] {
+      sv::VerbatimOp::create(
+          b, "\n// Users can define 'ASSERT_VERBOSE_COND' to add an extra "
+             "gate to assert error printing.");
       emitGuard("ASSERT_VERBOSE_COND_", [&]() {
         emitGuardedDefine("ASSERT_VERBOSE_COND", "ASSERT_VERBOSE_COND_",
                           "(`ASSERT_VERBOSE_COND)", "1");
@@ -952,12 +950,12 @@ endpackage
   }
 
   if (state.usedStopCond) {
-    b.create<sv::MacroDeclOp>("STOP_COND");
-    b.create<sv::MacroDeclOp>("STOP_COND_");
-    b.create<emit::FragmentOp>("STOP_COND_FRAGMENT", [&] {
-      b.create<sv::VerbatimOp>(
-          "\n// Users can define 'STOP_COND' to add an extra gate "
-          "to stop conditions.");
+    sv::MacroDeclOp::create(b, "STOP_COND");
+    sv::MacroDeclOp::create(b, "STOP_COND_");
+    emit::FragmentOp::create(b, "STOP_COND_FRAGMENT", [&] {
+      sv::VerbatimOp::create(
+          b, "\n// Users can define 'STOP_COND' to add an extra gate "
+             "to stop conditions.");
       emitGuard("STOP_COND_", [&]() {
         emitGuardedDefine("STOP_COND", "STOP_COND_", "(`STOP_COND)", "1");
       });
@@ -1161,8 +1159,8 @@ FIRRTLModuleLowering::lowerExtModule(FExtModuleOp oldModule,
   // no known default values in the extmodule.  This ensures that the
   // hw.instance will print all the parameters when generating verilog.
   auto parameters = getHWParameters(oldModule, /*ignoreValues=*/true);
-  auto newModule = builder.create<hw::HWModuleExternOp>(
-      oldModule.getLoc(), nameAttr, ports, verilogName, parameters);
+  auto newModule = hw::HWModuleExternOp::create(
+      builder, oldModule.getLoc(), nameAttr, ports, verilogName, parameters);
   SymbolTable::setSymbolVisibility(newModule,
                                    SymbolTable::getSymbolVisibility(oldModule));
 
@@ -1194,8 +1192,8 @@ FIRRTLModuleLowering::lowerMemModule(FMemModuleOp oldModule,
 
   // Build the new hw.module op.
   auto builder = OpBuilder::atBlockEnd(topLevelModule);
-  auto newModule = builder.create<hw::HWModuleExternOp>(
-      oldModule.getLoc(), oldModule.getModuleNameAttr(), ports,
+  auto newModule = hw::HWModuleExternOp::create(
+      builder, oldModule.getLoc(), oldModule.getModuleNameAttr(), ports,
       oldModule.getModuleNameAttr());
   loweringState.processRemainingAnnotations(oldModule,
                                             AnnotationSet(oldModule));
@@ -1217,7 +1215,7 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
   auto builder = OpBuilder::atBlockEnd(topLevelModule);
   auto nameAttr = builder.getStringAttr(oldModule.getName());
   auto newModule =
-      builder.create<hw::HWModuleOp>(oldModule.getLoc(), nameAttr, ports);
+      hw::HWModuleOp::create(builder, oldModule.getLoc(), nameAttr, ports);
 
   if (auto comment = oldModule->getAttrOfType<StringAttr>("comment"))
     newModule.setCommentAttr(comment);
@@ -1357,12 +1355,12 @@ tryEliminatingConnectsToValue(Value flipValue, Operation *insertPoint,
 
   // Convert fliped sources to passive sources.
   if (!type_cast<FIRRTLBaseType>(connectSrc.getType()).isPassive())
-    connectSrc = builder
-                     .create<mlir::UnrealizedConversionCastOp>(
-                         type_cast<FIRRTLBaseType>(connectSrc.getType())
-                             .getPassiveType(),
-                         connectSrc)
-                     .getResult(0);
+    connectSrc =
+        mlir::UnrealizedConversionCastOp::create(
+            builder,
+            type_cast<FIRRTLBaseType>(connectSrc.getType()).getPassiveType(),
+            connectSrc)
+            .getResult(0);
 
   // We know it must be the destination operand due to the types, but the
   // source may not match the destination width.
@@ -1421,7 +1419,7 @@ LogicalResult FIRRTLModuleLowering::lowerModulePortsAndMoveBody(
   // move the new function body to.  This is important because we insert some
   // ops at the start of the function and some at the end, and the body is
   // currently empty to avoid iterator invalidation.
-  auto cursor = bodyBuilder.create<hw::ConstantOp>(APInt(1, 1));
+  auto cursor = hw::ConstantOp::create(bodyBuilder, APInt(1, 1));
   bodyBuilder.setInsertionPoint(cursor);
 
   // Insert argument casts, and re-vector users in the old body to use them.
@@ -1463,10 +1461,10 @@ LogicalResult FIRRTLModuleLowering::lowerModulePortsAndMoveBody(
     // We lower zero width inout and outputs to a wire that isn't connected to
     // anything outside the module.  Inputs are lowered to zero.
     if (isZeroWidth && port.isInput()) {
-      Value newArg = bodyBuilder
-                         .create<WireOp>(port.type, "." + port.getName().str() +
-                                                        ".0width_input")
-                         .getResult();
+      Value newArg =
+          WireOp::create(bodyBuilder, port.type,
+                         "." + port.getName().str() + ".0width_input")
+              .getResult();
       oldArg.replaceAllUsesWith(newArg);
       continue;
     }
@@ -1482,8 +1480,8 @@ LogicalResult FIRRTLModuleLowering::lowerModulePortsAndMoveBody(
 
     // Outputs need a temporary wire so they can be connect'd to, which we
     // then return.
-    auto newArg = bodyBuilder.create<WireOp>(
-        port.type, "." + port.getName().str() + ".output");
+    auto newArg = WireOp::create(bodyBuilder, port.type,
+                                 "." + port.getName().str() + ".output");
 
     // Switch all uses of the old operands to the new ones.
     oldArg.replaceAllUsesWith(newArg.getResult());
@@ -1538,11 +1536,11 @@ FIRRTLModuleLowering::lowerFormalBody(verif::FormalOp newOp,
   SmallVector<Value> symbolicInputs;
   for (auto arg : newModule.getBody().getArguments())
     symbolicInputs.push_back(
-        builder.create<verif::SymbolicValueOp>(arg.getLoc(), arg.getType()));
+        verif::SymbolicValueOp::create(builder, arg.getLoc(), arg.getType()));
 
   // Instantiate the module with the given symbolic inputs.
-  builder.create<hw::InstanceOp>(newOp.getLoc(), newModule,
-                                 newModule.getNameAttr(), symbolicInputs);
+  hw::InstanceOp::create(builder, newOp.getLoc(), newModule,
+                         newModule.getNameAttr(), symbolicInputs);
   return success();
 }
 
@@ -1565,9 +1563,9 @@ FIRRTLModuleLowering::lowerSimulationBody(verif::SimulationOp newOp,
   // and yield the module's outputs.
   SmallVector<Value> inputs(newOp.getBody()->args_begin(),
                             newOp.getBody()->args_end());
-  auto instOp = builder.create<hw::InstanceOp>(newOp.getLoc(), newModule,
-                                               newModule.getNameAttr(), inputs);
-  builder.create<verif::YieldOp>(newOp.getLoc(), instOp.getResults());
+  auto instOp = hw::InstanceOp::create(builder, newOp.getLoc(), newModule,
+                                       newModule.getNameAttr(), inputs);
+  verif::YieldOp::create(builder, newOp.getLoc(), instOp.getResults());
   return success();
 }
 
@@ -2016,7 +2014,7 @@ LogicalResult FIRRTLModuleLowering::lowerFileBody(emit::FileOp fileOp) {
   fileOp->walk([&](Operation *op) {
     if (auto bindOp = dyn_cast<BindOp>(op)) {
       b.setInsertionPointAfter(bindOp);
-      b.create<sv::BindOp>(bindOp.getLoc(), bindOp.getInstanceAttr());
+      sv::BindOp::create(b, bindOp.getLoc(), bindOp.getInstanceAttr());
       bindOp->erase();
     }
   });
@@ -2133,8 +2131,8 @@ LogicalResult FIRRTLLowering::run() {
         continue;
       if (!zeroI0) {
         auto builder = OpBuilder::atBlockBegin(theModule.getBodyBlock());
-        zeroI0 = builder.create<hw::ConstantOp>(op->getLoc(),
-                                                builder.getIntegerType(0), 0);
+        zeroI0 = hw::ConstantOp::create(builder, op->getLoc(),
+                                        builder.getIntegerType(0), 0);
         maybeUnusedValues.insert(zeroI0);
       }
       result.replaceAllUsesWith(zeroI0);
@@ -2188,7 +2186,7 @@ Value FIRRTLLowering::getOrCreateClockConstant(seq::ClockConst clock) {
     return entry;
 
   OpBuilder entryBuilder(&theModule.getBodyBlock()->front());
-  entry = entryBuilder.create<seq::ConstClockOp>(builder.getLoc(), attr);
+  entry = seq::ConstClockOp::create(entryBuilder, builder.getLoc(), attr);
   return entry;
 }
 
@@ -2203,7 +2201,7 @@ Value FIRRTLLowering::getOrCreateIntConstant(const APInt &value) {
     return entry;
 
   OpBuilder entryBuilder(&theModule.getBodyBlock()->front());
-  entry = entryBuilder.create<hw::ConstantOp>(builder.getLoc(), attr);
+  entry = hw::ConstantOp::create(entryBuilder, builder.getLoc(), attr);
   return entry;
 }
 
@@ -2262,8 +2260,8 @@ Value FIRRTLLowering::getOrCreateXConstant(unsigned numBits) {
     return entry;
 
   OpBuilder entryBuilder(&theModule.getBodyBlock()->front());
-  entry = entryBuilder.create<sv::ConstantXOp>(
-      builder.getLoc(), entryBuilder.getIntegerType(numBits));
+  entry = sv::ConstantXOp::create(entryBuilder, builder.getLoc(),
+                                  entryBuilder.getIntegerType(numBits));
   return entry;
 }
 
@@ -2271,7 +2269,7 @@ Value FIRRTLLowering::getOrCreateZConstant(Type type) {
   auto &entry = hwConstantZMap[type];
   if (!entry) {
     OpBuilder entryBuilder(&theModule.getBodyBlock()->front());
-    entry = entryBuilder.create<sv::ConstantZOp>(builder.getLoc(), type);
+    entry = sv::ConstantZOp::create(entryBuilder, builder.getLoc(), type);
   }
   return entry;
 }
@@ -2365,7 +2363,7 @@ Value FIRRTLLowering::getExtOrTruncAggregateValue(Value array,
                                           destVectorType.getNumElements());
                i != e; ++i) {
             auto iIdx = getOrCreateIntConstant(indexWidth, i);
-            auto arrayIndex = builder.create<hw::ArrayGetOp>(src, iIdx);
+            auto arrayIndex = hw::ArrayGetOp::create(builder, src, iIdx);
             if (failed(recurse(arrayIndex, srcVectorType.getElementType(),
                                destVectorType.getElementType())))
               return failure();
@@ -2387,7 +2385,7 @@ Value FIRRTLLowering::getExtOrTruncAggregateValue(Value array,
 
           for (auto elem : llvm::enumerate(destStructType)) {
             auto structExtract =
-                builder.create<hw::StructExtractOp>(src, elem.value().name);
+                hw::StructExtractOp::create(builder, src, elem.value().name);
             if (failed(recurse(structExtract,
                                srcStructType.getElementType(elem.index()),
                                destStructType.getElementType(elem.index()))))
@@ -2581,7 +2579,7 @@ std::optional<Value> FIRRTLLowering::getLoweredFmtOperand(Value operand) {
   // Handle special substitutions.
   if (type_isa<FStringType>(operand.getType())) {
     if (isa<TimeOp>(operand.getDefiningOp()))
-      return builder.create<sv::TimeOp>();
+      return sv::TimeOp::create(builder);
     if (isa<HierarchicalModuleNameOp>(operand.getDefiningOp()))
       return {nullptr};
   }
@@ -2598,8 +2596,8 @@ std::optional<Value> FIRRTLLowering::getLoweredFmtOperand(Value operand) {
   // it as signed decimal and have to wrap it in $signed().
   if (auto intTy = firrtl::type_cast<IntType>(operand.getType()))
     if (intTy.isSigned())
-      loweredValue = builder.create<sv::SystemFunctionOp>(
-          loweredValue.getType(), "signed", loweredValue);
+      loweredValue = sv::SystemFunctionOp::create(
+          builder, loweredValue.getType(), "signed", loweredValue);
 
   return loweredValue;
 }
@@ -2636,7 +2634,7 @@ LogicalResult FIRRTLLowering::lowerStatementWithFd(
       Value ifCond = cond;
       if (usePrintfCond) {
         ifCond =
-            builder.create<sv::MacroRefExprOp>(cond.getType(), "PRINTF_COND_");
+            sv::MacroRefExprOp::create(builder, cond.getType(), "PRINTF_COND_");
         ifCond = builder.createOrFold<comb::AndOp>(ifCond, cond, true);
       }
 
@@ -2646,7 +2644,7 @@ LogicalResult FIRRTLLowering::lowerStatementWithFd(
         Value fd;
         if (fileDescriptor.isDefaultFd()) {
           // Emit the sv.fwrite, writing to stderr by default.
-          fd = builder.create<hw::ConstantOp>(APInt(32, 0x80000002));
+          fd = hw::ConstantOp::create(builder, APInt(32, 0x80000002));
         } else {
           // Call the library function to get the FD.
           auto fdOrError = callFileDescriptorLib(fileDescriptor);
@@ -2674,21 +2672,19 @@ FIRRTLLowering::callFileDescriptorLib(const FileDescriptorInfo &info) {
     if (failed(loweredFmtOperands(info.getSubstitutions(), fileNameOperands)))
       return failure();
 
-    fileName = builder
-                   .create<sv::SFormatFOp>(info.getOutputFileFormat(),
-                                           fileNameOperands)
+    fileName = sv::SFormatFOp::create(builder, info.getOutputFileFormat(),
+                                      fileNameOperands)
                    .getResult();
   } else {
     // If substitution is not required, just use the output file name.
-    fileName = builder.create<sv::ConstantStrOp>(info.getOutputFileFormat())
+    fileName = sv::ConstantStrOp::create(builder, info.getOutputFileFormat())
                    .getResult();
   }
 
-  return builder
-      .create<sv::FuncCallProceduralOp>(
-          mlir::TypeRange{builder.getIntegerType(32)},
-          builder.getStringAttr("__circt_lib_logging::FileDescriptor::get"),
-          ValueRange{fileName})
+  return sv::FuncCallProceduralOp::create(
+             builder, mlir::TypeRange{builder.getIntegerType(32)},
+             builder.getStringAttr("__circt_lib_logging::FileDescriptor::get"),
+             ValueRange{fileName})
       ->getResult(0);
 }
 
@@ -2861,7 +2857,7 @@ Value FIRRTLLowering::getNonClockValue(Value v) {
   if (it.second) {
     ImplicitLocOpBuilder builder(v.getLoc(), v.getContext());
     builder.setInsertionPointAfterValue(v);
-    it.first->second = builder.create<seq::FromClockOp>(v);
+    it.first->second = seq::FromClockOp::create(builder, v);
   }
   return it.first->second;
 }
@@ -2895,24 +2891,23 @@ void FIRRTLLowering::addToAlwaysBlock(
       auto createIfOp = [&]() {
         // It is weird but intended. Here we want to create an empty sv.if
         // with an else block.
-        insideIfOp = builder.create<sv::IfOp>(
-            reset, []() {}, []() {});
+        insideIfOp = sv::IfOp::create(builder, reset, []() {}, []() {});
       };
       if (resetStyle == sv::ResetType::AsyncReset) {
         sv::EventControl events[] = {clockEdge, resetEdge};
         Value clocks[] = {clock, reset};
 
-        alwaysOp = builder.create<sv::AlwaysOp>(events, clocks, [&]() {
+        alwaysOp = sv::AlwaysOp::create(builder, events, clocks, [&]() {
           if (resetEdge == sv::EventControl::AtNegEdge)
             llvm_unreachable("negative edge for reset is not expected");
           createIfOp();
         });
       } else {
-        alwaysOp = builder.create<sv::AlwaysOp>(clockEdge, clock, createIfOp);
+        alwaysOp = sv::AlwaysOp::create(builder, clockEdge, clock, createIfOp);
       }
     } else {
       assert(!resetBody);
-      alwaysOp = builder.create<sv::AlwaysOp>(clockEdge, clock);
+      alwaysOp = sv::AlwaysOp::create(builder, clockEdge, clock);
       insideIfOp = nullptr;
     }
     alwaysBlocks[key] = {alwaysOp, insideIfOp};
@@ -2969,7 +2964,7 @@ void FIRRTLLowering::addToIfDefBlock(StringRef cond,
     op->moveBefore(builder.getInsertionBlock(), builder.getInsertionPoint());
   } else {
     ifdefBlocks[{builder.getBlock(), condAttr}] =
-        builder.create<sv::IfDefOp>(condAttr, thenCtor, elseCtor);
+        sv::IfDefOp::create(builder, condAttr, thenCtor, elseCtor);
   }
 }
 
@@ -2983,7 +2978,7 @@ void FIRRTLLowering::addToInitialBlock(std::function<void(void)> body) {
     // are defined ahead of the uses, which leads to better generated Verilog.
     op->moveBefore(builder.getInsertionBlock(), builder.getInsertionPoint());
   } else {
-    initialBlocks[builder.getBlock()] = builder.create<sv::InitialOp>(body);
+    initialBlocks[builder.getBlock()] = sv::InitialOp::create(builder, body);
   }
 }
 
@@ -3002,7 +2997,7 @@ void FIRRTLLowering::addIfProceduralBlock(Value cond,
       }
     }
 
-  builder.create<sv::IfOp>(cond, thenCtor, elseCtor);
+  sv::IfOp::create(builder, cond, thenCtor, elseCtor);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3230,10 +3225,10 @@ LogicalResult FIRRTLLowering::visitExpr(FEnumCreateOp op) {
   if (auto structType = dyn_cast<hw::StructType>(newType)) {
     auto tagType = structType.getFieldType("tag");
     auto tagValue = IntegerAttr::get(tagType, element.value.getValue());
-    auto tag = builder.create<sv::LocalParamOp>(op.getLoc(), tagType, tagValue,
-                                                tagName);
+    auto tag = sv::LocalParamOp::create(builder, op.getLoc(), tagType, tagValue,
+                                        tagName);
     auto bodyType = structType.getFieldType("body");
-    auto body = builder.create<hw::UnionCreateOp>(bodyType, tagName, input);
+    auto body = hw::UnionCreateOp::create(builder, bodyType, tagName, input);
     SmallVector<Value> operands = {tag.getResult(), body.getResult()};
     return setLoweringTo<hw::StructCreateOp>(op, structType, operands);
   }
@@ -3255,15 +3250,15 @@ LogicalResult FIRRTLLowering::visitExpr(IsTagOp op) {
   auto tagName = op.getFieldNameAttr();
   auto lhs = getLoweredValue(op.getInput());
   if (isa<hw::StructType>(lhs.getType()))
-    lhs = builder.create<hw::StructExtractOp>(lhs, "tag");
+    lhs = hw::StructExtractOp::create(builder, lhs, "tag");
 
   auto index = op.getFieldIndex();
   auto enumType = op.getInput().getType().base();
   auto tagValue = enumType.getElementValueAttr(index);
   auto tagValueType = IntegerType::get(op.getContext(), enumType.getTagWidth());
   auto loweredTagValue = IntegerAttr::get(tagValueType, tagValue.getValue());
-  auto rhs = builder.create<sv::LocalParamOp>(op.getLoc(), tagValueType,
-                                              loweredTagValue, tagName);
+  auto rhs = sv::LocalParamOp::create(builder, op.getLoc(), tagValueType,
+                                      loweredTagValue, tagName);
 
   Type resultType = builder.getIntegerType(1);
   return setLoweringTo<comb::ICmpOp>(op, resultType, ICmpPredicate::eq, lhs,
@@ -3277,7 +3272,7 @@ LogicalResult FIRRTLLowering::visitExpr(SubtagOp op) {
 
   auto tagName = op.getFieldNameAttr();
   auto input = getLoweredValue(op.getInput());
-  auto field = builder.create<hw::StructExtractOp>(input, "body");
+  auto field = hw::StructExtractOp::create(builder, input, "body");
   return setLoweringTo<hw::UnionExtractOp>(op, field, tagName);
 }
 
@@ -3331,8 +3326,8 @@ LogicalResult FIRRTLLowering::visitDecl(WireOp op) {
   auto name = op.getNameAttr();
   // This is not a temporary wire created by the compiler, so attach a symbol
   // name.
-  auto wire = builder.create<hw::WireOp>(
-      op.getLoc(), getOrCreateZConstant(resultType), name, innerSym);
+  auto wire = hw::WireOp::create(
+      builder, op.getLoc(), getOrCreateZConstant(resultType), name, innerSym);
 
   if (auto svAttrs = sv::getSVAttributes(op))
     sv::setSVAttributes(wire, svAttrs);
@@ -3382,12 +3377,12 @@ LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
   auto innerSym = lowerInnerSymbol(op);
 
   if (innerSym)
-    operand = builder.create<hw::WireOp>(operand, name, innerSym);
+    operand = hw::WireOp::create(builder, operand, name, innerSym);
 
   // Move SV attributes.
   if (auto svAttrs = sv::getSVAttributes(op)) {
     if (!innerSym)
-      operand = builder.create<hw::WireOp>(operand, name);
+      operand = hw::WireOp::create(builder, operand, name);
     sv::setSVAttributes(operand.getDefiningOp(), svAttrs);
   }
 
@@ -3408,8 +3403,8 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
   // Create a reg op, wiring itself to its input.
   auto innerSym = lowerInnerSymbol(op);
   Backedge inputEdge = backedgeBuilder.get(resultType);
-  auto reg = builder.create<seq::FirRegOp>(inputEdge, clockVal,
-                                           op.getNameAttr(), innerSym);
+  auto reg = seq::FirRegOp::create(builder, inputEdge, clockVal,
+                                   op.getNameAttr(), innerSym);
 
   // Pass along the start and end random initialization bits for this register.
   if (auto randomRegister = op->getAttr("firrtl.random_init_register"))
@@ -3449,8 +3444,8 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   bool isAsync = type_isa<AsyncResetType>(op.getResetSignal().getType());
   Backedge inputEdge = backedgeBuilder.get(resultType);
   auto reg =
-      builder.create<seq::FirRegOp>(inputEdge, clockVal, op.getNameAttr(),
-                                    resetSignal, resetValue, innerSym, isAsync);
+      seq::FirRegOp::create(builder, inputEdge, clockVal, op.getNameAttr(),
+                            resetSignal, resetValue, innerSym, isAsync);
 
   // Pass along the start and end random initialization bits for this register.
   if (auto randomRegister = op->getAttr("firrtl.random_init_register"))
@@ -3494,8 +3489,8 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
     memInit = seq::FirMemInitAttr::get(init.getContext(), init.getFilename(),
                                        init.getIsBinary(), init.getIsInline());
 
-  auto memDecl = builder.create<seq::FirMemOp>(
-      memType, memSummary.readLatency, memSummary.writeLatency,
+  auto memDecl = seq::FirMemOp::create(
+      builder, memType, memSummary.readLatency, memSummary.writeLatency,
       memSummary.readUnderWrite, memSummary.writeUnderWrite, op.getNameAttr(),
       op.getInnerSymAttr(), memInit, op.getPrefixAttr(), Attribute{});
 
@@ -3556,7 +3551,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
       auto addr = addInputPort("addr", op.getAddrBits());
       auto en = addInputPort("en", 1);
       auto clk = addClock("clk");
-      auto data = builder.create<seq::FirMemReadOp>(memDecl, addr, clk, en);
+      auto data = seq::FirMemReadOp::create(builder, memDecl, addr, clk, en);
       addOutput("data", memSummary.dataWidth, data);
     } else if (memportKind == MemOp::PortKind::ReadWrite) {
       auto addr = addInputPort("addr", op.getAddrBits());
@@ -3573,8 +3568,8 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
       Value mask;
       if (memSummary.isMasked)
         mask = addInputPort("wmask", memSummary.maskBits);
-      auto rdata = builder.create<seq::FirMemReadWriteOp>(
-          memDecl, addr, clk, en, wdata, mode, mask);
+      auto rdata = seq::FirMemReadWriteOp::create(builder, memDecl, addr, clk,
+                                                  en, wdata, mode, mask);
       addOutput("rdata", memSummary.dataWidth, rdata);
     } else {
       auto addr = addInputPort("addr", op.getAddrBits());
@@ -3590,7 +3585,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
       Value mask;
       if (memSummary.isMasked)
         mask = addInputPort("mask", memSummary.maskBits);
-      builder.create<seq::FirMemWriteOp>(memDecl, addr, clk, en, data, mask);
+      seq::FirMemWriteOp::create(builder, memDecl, addr, clk, en, data, mask);
     }
   }
 
@@ -3668,8 +3663,8 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
 
     // Create a wire for each inout operand, so there is something to connect
     // to. The instance becomes the sole driver of this wire.
-    auto wire = builder.create<sv::WireOp>(
-        portType, "." + port.getName().str() + ".wire");
+    auto wire = sv::WireOp::create(builder, portType,
+                                   "." + port.getName().str() + ".wire");
 
     // Know that the argument FIRRTL value is equal to this wire, allowing
     // connects to it to be lowered.
@@ -3689,8 +3684,8 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
           oldInstance.getContext(), oldInstance.getInnerSymAttr(), 0,
           [&]() -> hw::InnerSymbolNamespace & { return moduleNamespace; });
 
-    auto bindOp = builder.create<sv::BindOp>(theModule.getNameAttr(),
-                                             innerSym.getSymName());
+    auto bindOp = sv::BindOp::create(builder, theModule.getNameAttr(),
+                                     innerSym.getSymName());
     // If the lowered op already had output file information, then use that.
     // Otherwise, generate some default bind information.
     if (auto outputFile = oldInstance->getAttr("output_file"))
@@ -3701,8 +3696,9 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
   }
 
   // Create the new hw.instance operation.
-  auto newInstance = builder.create<hw::InstanceOp>(
-      newModule, oldInstance.getNameAttr(), operands, parameters, innerSym);
+  auto newInstance =
+      hw::InstanceOp::create(builder, newModule, oldInstance.getNameAttr(),
+                             operands, parameters, innerSym);
 
   if (oldInstance.getLowerToBind() || oldInstance.getDoNotPrint())
     newInstance.setDoNotPrintAttr(builder.getUnitAttr());
@@ -3741,7 +3737,7 @@ LogicalResult FIRRTLLowering::visitDecl(ContractOp oldOp) {
     types.push_back(lowered.getType());
   }
 
-  auto newOp = builder.create<verif::ContractOp>(types, inputs);
+  auto newOp = verif::ContractOp::create(builder, types, inputs);
   newOp->setDiscardableAttrs(oldOp->getDiscardableAttrDictionary());
   auto &body = newOp.getBody().emplaceBlock();
 
@@ -4127,7 +4123,7 @@ LogicalResult FIRRTLLowering::visitExpr(IsXIntrinsicOp op) {
 
 LogicalResult FIRRTLLowering::visitStmt(FPGAProbeIntrinsicOp op) {
   auto operand = getLoweredValue(op.getInput());
-  builder.create<hw::WireOp>(operand);
+  hw::WireOp::create(builder, operand);
   return success();
 }
 
@@ -4141,8 +4137,8 @@ LogicalResult FIRRTLLowering::visitExpr(PlusArgsValueIntrinsicOp op) {
   if (!type)
     return failure();
 
-  auto valueOp = builder.create<sim::PlusArgsValueOp>(
-      builder.getIntegerType(1), type, op.getFormatStringAttr());
+  auto valueOp = sim::PlusArgsValueOp::create(
+      builder, builder.getIntegerType(1), type, op.getFormatStringAttr());
   if (failed(setLowering(op.getResult(), valueOp.getResult())))
     return failure();
   if (failed(setLowering(op.getFound(), valueOp.getFound())))
@@ -4249,7 +4245,7 @@ template <typename TargetOp, typename IntrinsicOp>
 LogicalResult FIRRTLLowering::lowerVerifIntrinsicOp(IntrinsicOp op) {
   auto property = getLoweredValue(op.getProperty());
   auto enable = op.getEnable() ? getLoweredValue(op.getEnable()) : Value();
-  builder.create<TargetOp>(property, enable, op.getLabelAttr());
+  TargetOp::create(builder, property, enable, op.getLabelAttr());
   return success();
 }
 
@@ -4337,7 +4333,7 @@ LogicalResult FIRRTLLowering::visitExpr(InvalidValueOp op) {
     auto constant = getOrCreateIntConstant(*bitwidth, 0);
     // If the result is an aggregate value, we have to bitcast the constant.
     if (!type_isa<IntegerType>(resultTy))
-      constant = builder.create<hw::BitcastOp>(resultTy, constant);
+      constant = hw::BitcastOp::create(builder, resultTy, constant);
     return setLowering(op, constant);
   }
 
@@ -4429,8 +4425,8 @@ LogicalResult FIRRTLLowering::visitExpr(Mux2CellIntrinsicOp op) {
   if (!cond || !ifTrue || !ifFalse)
     return failure();
 
-  auto val = builder.create<comb::MuxOp>(ifTrue.getType(), cond, ifTrue,
-                                         ifFalse, true);
+  auto val = comb::MuxOp::create(builder, ifTrue.getType(), cond, ifTrue,
+                                 ifFalse, true);
   return setLowering(op, createValueWithMuxAnnotation(val, true));
 }
 
@@ -4443,8 +4439,8 @@ LogicalResult FIRRTLLowering::visitExpr(Mux4CellIntrinsicOp op) {
   if (!sel || !v3 || !v2 || !v1 || !v0)
     return failure();
   Value array[] = {v3, v2, v1, v0};
-  auto create = builder.create<hw::ArrayCreateOp>(array);
-  auto val = builder.create<hw::ArrayGetOp>(create, sel);
+  auto create = hw::ArrayCreateOp::create(builder, array);
+  auto val = hw::ArrayGetOp::create(builder, create, sel);
   return setLowering(op, createValueWithMuxAnnotation(val, false));
 }
 
@@ -4467,7 +4463,7 @@ LogicalResult FIRRTLLowering::visitExpr(Mux4CellIntrinsicOp op) {
 Value FIRRTLLowering::createValueWithMuxAnnotation(Operation *op, bool isMux2) {
   assert(op->getNumResults() == 1 && "only expect a single result");
   auto val = op->getResult(0);
-  auto valWire = builder.create<sv::WireOp>(val.getType());
+  auto valWire = sv::WireOp::create(builder, val.getType());
   // Use SV attributes to annotate pragmas.
   circt::sv::setSVAttributes(
       op, sv::SVAttributeAttr::get(builder.getContext(), "cadence map_to_mux",
@@ -4485,17 +4481,17 @@ Value FIRRTLLowering::createValueWithMuxAnnotation(Operation *op, bool isMux2) {
           op->getContext(), /*attr=*/nullptr, 0,
           [&]() -> hw::InnerSymbolNamespace & { return moduleNamespace; });
       auto wire =
-          builder.create<hw::WireOp>(operand, namehint + Twine(idx), innerSym);
+          hw::WireOp::create(builder, operand, namehint + Twine(idx), innerSym);
       op->setOperand(idx, wire);
     }
   }
 
-  auto assignOp = builder.create<sv::AssignOp>(valWire, val);
+  auto assignOp = sv::AssignOp::create(builder, valWire, val);
   sv::setSVAttributes(assignOp,
                       sv::SVAttributeAttr::get(builder.getContext(),
                                                "synopsys infer_mux_override",
                                                /*emitAsComment=*/true));
-  return builder.create<sv::ReadInOutOp>(valWire);
+  return sv::ReadInOutOp::create(builder, valWire);
 }
 
 Value FIRRTLLowering::createArrayIndexing(Value array, Value index) {
@@ -4507,14 +4503,14 @@ Value FIRRTLLowering::createArrayIndexing(Value array, Value index) {
   // optimization.
   if (!llvm::isPowerOf2_64(size)) {
     auto extElem = getOrCreateIntConstant(APInt(llvm::Log2_64_Ceil(size), 0));
-    auto extValue = builder.create<hw::ArrayGetOp>(array, extElem);
+    auto extValue = hw::ArrayGetOp::create(builder, array, extElem);
     SmallVector<Value> temp(llvm::NextPowerOf2(size) - size, extValue);
-    auto ext = builder.create<hw::ArrayCreateOp>(temp);
+    auto ext = hw::ArrayCreateOp::create(builder, temp);
     Value temp2[] = {ext.getResult(), array};
-    array = builder.create<hw::ArrayConcatOp>(temp2);
+    array = hw::ArrayConcatOp::create(builder, temp2);
   }
 
-  Value inBoundsRead = builder.create<hw::ArrayGetOp>(array, index);
+  Value inBoundsRead = hw::ArrayGetOp::create(builder, array, index);
 
   return inBoundsRead;
 }
@@ -4537,7 +4533,7 @@ LogicalResult FIRRTLLowering::visitExpr(MultibitMuxOp op) {
     loweredInputs.push_back(lowered);
   }
 
-  Value array = builder.create<hw::ArrayCreateOp>(loweredInputs);
+  Value array = hw::ArrayCreateOp::create(builder, loweredInputs);
   return setLowering(op, createArrayIndexing(array, index));
 }
 
@@ -4588,8 +4584,8 @@ LogicalResult FIRRTLLowering::visitExpr(XMRDerefOp op) {
   else
     xmrType = lowerType(op.getType());
 
-  auto xmr = builder.create<sv::XMRRefOp>(
-      sv::InOutType::get(xmrType), op.getRef(), op.getVerbatimSuffixAttr());
+  auto xmr = sv::XMRRefOp::create(builder, sv::InOutType::get(xmrType),
+                                  op.getRef(), op.getVerbatimSuffixAttr());
   auto readXmr = getReadValue(xmr);
   if (!isa<ClockType>(op.getType()))
     return setLowering(op, readXmr);
@@ -4624,7 +4620,7 @@ FailureOr<bool> FIRRTLLowering::lowerConnect(Value destVal, Value srcVal) {
   auto dstType = destVal.getType();
   if (srcType != dstType &&
       (isa<hw::TypeAliasType>(srcType) || isa<hw::TypeAliasType>(dstType))) {
-    srcVal = builder.create<hw::BitcastOp>(destVal.getType(), srcVal);
+    srcVal = hw::BitcastOp::create(builder, destVal.getType(), srcVal);
   }
   return TypeSwitch<Operation *, FailureOr<bool>>(destVal.getDefiningOp())
       .Case<hw::WireOp>([&](auto op) {
@@ -4672,7 +4668,7 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
   if (!isa<hw::InOutType>(destVal.getType()))
     return op.emitError("destination isn't an inout type");
 
-  builder.create<sv::AssignOp>(destVal, srcVal);
+  sv::AssignOp::create(builder, destVal, srcVal);
   return success();
 }
 
@@ -4700,7 +4696,7 @@ LogicalResult FIRRTLLowering::visitStmt(MatchingConnectOp op) {
   if (!isa<hw::InOutType>(destVal.getType()))
     return op.emitError("destination isn't an inout type");
 
-  builder.create<sv::AssignOp>(destVal, srcVal);
+  sv::AssignOp::create(builder, destVal, srcVal);
   return success();
 }
 
@@ -4719,7 +4715,7 @@ LogicalResult FIRRTLLowering::visitStmt(ForceOp op) {
   // #ifndef SYNTHESIS
   circuitState.addMacroDecl(builder.getStringAttr("SYNTHESIS"));
   addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
-    addToInitialBlock([&]() { builder.create<sv::ForceOp>(destVal, srcVal); });
+    addToInitialBlock([&]() { sv::ForceOp::create(builder, destVal, srcVal); });
   });
   return success();
 }
@@ -4740,7 +4736,7 @@ LogicalResult FIRRTLLowering::visitStmt(RefForceOp op) {
   addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToAlwaysBlock(clock, [&]() {
       addIfProceduralBlock(
-          pred, [&]() { builder.create<sv::ForceOp>(destVal, src); });
+          pred, [&]() { sv::ForceOp::create(builder, destVal, src); });
     });
   });
   return success();
@@ -4760,7 +4756,7 @@ LogicalResult FIRRTLLowering::visitStmt(RefForceInitialOp op) {
   addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToInitialBlock([&]() {
       addIfProceduralBlock(
-          pred, [&]() { builder.create<sv::ForceOp>(destVal, src); });
+          pred, [&]() { sv::ForceOp::create(builder, destVal, src); });
     });
   });
   return success();
@@ -4780,7 +4776,7 @@ LogicalResult FIRRTLLowering::visitStmt(RefReleaseOp op) {
   addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToAlwaysBlock(clock, [&]() {
       addIfProceduralBlock(pred,
-                           [&]() { builder.create<sv::ReleaseOp>(destVal); });
+                           [&]() { sv::ReleaseOp::create(builder, destVal); });
     });
   });
   return success();
@@ -4796,7 +4792,7 @@ LogicalResult FIRRTLLowering::visitStmt(RefReleaseInitialOp op) {
   addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
     addToInitialBlock([&]() {
       addIfProceduralBlock(pred,
-                           [&]() { builder.create<sv::ReleaseOp>(destVal); });
+                           [&]() { sv::ReleaseOp::create(builder, destVal); });
     });
   });
   return success();
@@ -4905,7 +4901,7 @@ LogicalResult FIRRTLLowering::visitPrintfLike(
     SmallVector<Value> operands;
     if (failed(loweredFmtOperands(op.getSubstitutions(), operands)))
       return failure();
-    builder.create<sv::FWriteOp>(op.getLoc(), fd, formatString, operands);
+    sv::FWriteOp::create(builder, op.getLoc(), fd, formatString, operands);
     return success();
   };
 
@@ -4933,7 +4929,7 @@ LogicalResult FIRRTLLowering::visitStmt(FFlushOp op) {
     return failure();
 
   auto fn = [&](Value fd) {
-    builder.create<sv::FFlushOp>(op.getLoc(), fd);
+    sv::FFlushOp::create(builder, op.getLoc(), fd);
     return success();
   };
 
@@ -4965,13 +4961,13 @@ LogicalResult FIRRTLLowering::visitStmt(StopOp op) {
   circuitState.addFragment(theModule, "STOP_COND_FRAGMENT");
 
   Value stopCond =
-      builder.create<sv::MacroRefExprOp>(cond.getType(), "STOP_COND_");
+      sv::MacroRefExprOp::create(builder, cond.getType(), "STOP_COND_");
   Value exitCond = builder.createOrFold<comb::AndOp>(stopCond, cond, true);
 
   if (op.getExitCode())
-    builder.create<sim::FatalOp>(clock, exitCond);
+    sim::FatalOp::create(builder, clock, exitCond);
   else
-    builder.create<sim::FinishOp>(clock, exitCond);
+    sim::FinishOp::create(builder, clock, exitCond);
 
   return success();
 }
@@ -4983,11 +4979,11 @@ template <typename... Args>
 static Operation *buildImmediateVerifOp(ImplicitLocOpBuilder &builder,
                                         StringRef opName, Args &&...args) {
   if (opName == "assert")
-    return builder.create<sv::AssertOp>(std::forward<Args>(args)...);
+    return sv::AssertOp::create(builder, std::forward<Args>(args)...);
   if (opName == "assume")
-    return builder.create<sv::AssumeOp>(std::forward<Args>(args)...);
+    return sv::AssumeOp::create(builder, std::forward<Args>(args)...);
   if (opName == "cover")
-    return builder.create<sv::CoverOp>(std::forward<Args>(args)...);
+    return sv::CoverOp::create(builder, std::forward<Args>(args)...);
   llvm_unreachable("unknown verification op");
 }
 
@@ -4998,11 +4994,11 @@ template <typename... Args>
 static Operation *buildConcurrentVerifOp(ImplicitLocOpBuilder &builder,
                                          StringRef opName, Args &&...args) {
   if (opName == "assert")
-    return builder.create<sv::AssertConcurrentOp>(std::forward<Args>(args)...);
+    return sv::AssertConcurrentOp::create(builder, std::forward<Args>(args)...);
   if (opName == "assume")
-    return builder.create<sv::AssumeConcurrentOp>(std::forward<Args>(args)...);
+    return sv::AssumeConcurrentOp::create(builder, std::forward<Args>(args)...);
   if (opName == "cover")
-    return builder.create<sv::CoverConcurrentOp>(std::forward<Args>(args)...);
+    return sv::CoverConcurrentOp::create(builder, std::forward<Args>(args)...);
   llvm_unreachable("unknown verification op");
 }
 
@@ -5086,7 +5082,7 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
       // assertion triggers.  (See SystemVerilog 2017 spec section 16.9.3 for
       // more information.)
       for (auto &loweredValue : messageOps)
-        loweredValue = builder.create<sv::SampledOp>(loweredValue);
+        loweredValue = sv::SampledOp::create(builder, loweredValue);
     }
   }
 
@@ -5123,12 +5119,12 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
             circuitState.addFragment(theModule, "ASSERT_VERBOSE_COND_FRAGMENT");
 
             addIfProceduralBlock(
-                builder.create<sv::MacroRefExprOp>(boolType,
-                                                   "ASSERT_VERBOSE_COND_"),
-                [&]() { builder.create<sv::ErrorOp>(message, messageOps); });
+                sv::MacroRefExprOp::create(builder, boolType,
+                                           "ASSERT_VERBOSE_COND_"),
+                [&]() { sv::ErrorOp::create(builder, message, messageOps); });
             addIfProceduralBlock(
-                builder.create<sv::MacroRefExprOp>(boolType, "STOP_COND_"),
-                [&]() { builder.create<sv::FatalOp>(); });
+                sv::MacroRefExprOp::create(builder, boolType, "STOP_COND_"),
+                [&]() { sv::FatalOp::create(builder); });
           });
         });
       });
@@ -5234,8 +5230,9 @@ LogicalResult FIRRTLLowering::visitStmt(UnclockedAssumeIntrinsicOp op) {
     messageOps.push_back(loweredValue);
   }
   return emitGuards(op.getLoc(), guards, [&]() {
-    builder.create<sv::AlwaysOp>(
-        ArrayRef(sv::EventControl::AtEdge), ArrayRef(predicate), [&]() {
+    sv::AlwaysOp::create(
+        builder, ArrayRef(sv::EventControl::AtEdge), ArrayRef(predicate),
+        [&]() {
           if (op.getMessageAttr().getValue().empty())
             buildImmediateVerifOp(
                 builder, "assume", predicate,
@@ -5311,28 +5308,29 @@ LogicalResult FIRRTLLowering::visitStmt(AttachOp op) {
         for (size_t i1 = 0, e = inoutValues.size(); i1 != e; ++i1) {
           for (size_t i2 = 0; i2 != e; ++i2)
             if (i1 != i2)
-              builder.create<sv::AssignOp>(inoutValues[i1], values[i2]);
+              sv::AssignOp::create(builder, inoutValues[i1], values[i2]);
         }
       },
       // In the non-synthesis case, we emit a SystemVerilog alias
       // statement.
       [&]() {
-        builder.create<sv::IfDefOp>(
-            "VERILATOR",
+        sv::IfDefOp::create(
+            builder, "VERILATOR",
             [&]() {
-              builder.create<sv::VerbatimOp>(
+              sv::VerbatimOp::create(
+                  builder,
                   "`error \"Verilator does not support alias and thus "
                   "cannot "
                   "arbitrarily connect bidirectional wires and ports\"");
             },
-            [&]() { builder.create<sv::AliasOp>(inoutValues); });
+            [&]() { sv::AliasOp::create(builder, inoutValues); });
       });
 
   return success();
 }
 
 LogicalResult FIRRTLLowering::visitStmt(BindOp op) {
-  builder.create<sv::BindOp>(op.getInstanceAttr());
+  sv::BindOp::create(builder, op.getInstanceAttr());
   return success();
 }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -850,7 +850,8 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
 
   // Helper function to emit #ifndef guard.
   auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
-    sv::IfDefOp::create(b, guard, []() {}, body);
+    sv::IfDefOp::create(
+        b, guard, []() {}, body);
   };
 
   if (state.usedFileDescriptorLib) {
@@ -2891,7 +2892,8 @@ void FIRRTLLowering::addToAlwaysBlock(
       auto createIfOp = [&]() {
         // It is weird but intended. Here we want to create an empty sv.if
         // with an else block.
-        insideIfOp = sv::IfOp::create(builder, reset, []() {}, []() {});
+        insideIfOp = sv::IfOp::create(
+            builder, reset, []() {}, []() {});
       };
       if (resetStyle == sv::ResetType::AsyncReset) {
         sv::EventControl events[] = {clockEdge, resetEdge};

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -90,13 +90,13 @@ static Value extendTypeWidth(OpBuilder &builder, Location loc, Value value,
         builder.createOrFold<comb::ReplicateOp>(loc, highBit, extensionLength);
   } else {
     // Zero extension
-    extensionBits = builder
-                        .create<hw::ConstantOp>(
-                            loc, builder.getIntegerType(extensionLength), 0)
-                        ->getOpResult(0);
+    extensionBits =
+        hw::ConstantOp::create(builder, loc,
+                               builder.getIntegerType(extensionLength), 0)
+            ->getOpResult(0);
   }
 
-  auto extOp = builder.create<comb::ConcatOp>(loc, extensionBits, value);
+  auto extOp = comb::ConcatOp::create(builder, loc, extensionBits, value);
   improveNamehint(value, extOp, [&](StringRef oldNamehint) {
     return (oldNamehint + "_" + (signExtension ? "sext_" : "zext_") +
             std::to_string(targetWidth))
@@ -210,10 +210,10 @@ struct DivOpLowering : public OpConversionPattern<DivOp> {
 
     Value divResult;
     if (signedDivision)
-      divResult = rewriter.create<comb::DivSOp>(loc, lhsValue, rhsValue, false)
+      divResult = comb::DivSOp::create(rewriter, loc, lhsValue, rhsValue, false)
                       ->getOpResult(0);
     else
-      divResult = rewriter.create<comb::DivUOp>(loc, lhsValue, rhsValue, false)
+      divResult = comb::DivUOp::create(rewriter, loc, lhsValue, rhsValue, false)
                       ->getOpResult(0);
 
     // Carry over any attributes from the original div op.
@@ -313,8 +313,8 @@ struct ICmpOpLowering : public OpConversionPattern<ICmpOp> {
     Value rhsValue = extendTypeWidth(rewriter, loc, adaptor.getRhs(), cmpWidth,
                                      rhsType.isSigned());
 
-    auto newOp = rewriter.create<comb::ICmpOp>(op->getLoc(), combPred, lhsValue,
-                                               rhsValue, false);
+    auto newOp = comb::ICmpOp::create(rewriter, op->getLoc(), combPred,
+                                      lhsValue, rhsValue, false);
     rewriter.modifyOpInPlace(
         newOp, [&]() { newOp->setDialectAttrs(op->getDialectAttrs()); });
     rewriter.replaceOp(op, newOp);
@@ -343,7 +343,7 @@ struct BinaryOpLowering : public OpConversionPattern<BinOp> {
     Value rhsValue = extendTypeWidth(rewriter, loc, adaptor.getInputs()[1],
                                      targetWidth, isRhsTypeSigned);
     auto newOp =
-        rewriter.create<ReplaceOp>(op.getLoc(), lhsValue, rhsValue, false);
+        ReplaceOp::create(rewriter, op.getLoc(), lhsValue, rhsValue, false);
     rewriter.modifyOpInPlace(
         newOp, [&]() { newOp->setDialectAttrs(op->getDialectAttrs()); });
     rewriter.replaceOp(op, newOp);
@@ -404,8 +404,8 @@ HWArithToHWTypeConverter::HWArithToHWTypeConverter() {
                                mlir::Location loc) -> mlir::Value {
     if (inputs.size() != 1)
       return Value();
-    return builder
-        .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+    return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                              inputs[0])
         ->getResult(0);
   });
 
@@ -414,8 +414,8 @@ HWArithToHWTypeConverter::HWArithToHWTypeConverter() {
                                mlir::Location loc) -> mlir::Value {
     if (inputs.size() != 1)
       return Value();
-    return builder
-        .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+    return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                              inputs[0])
         ->getResult(0);
   });
 }

--- a/lib/Conversion/HWToSV/HWToSV.cpp
+++ b/lib/Conversion/HWToSV/HWToSV.cpp
@@ -50,8 +50,8 @@ struct TriggeredOpConversionPattern : public OpConversionPattern<TriggeredOp> {
   LogicalResult
   matchAndRewrite(TriggeredOp op, OpAdaptor operands,
                   ConversionPatternRewriter &rewriter) const override {
-    auto alwaysOp = rewriter.create<AlwaysOp>(
-        op.getLoc(),
+    auto alwaysOp = AlwaysOp::create(
+        rewriter, op.getLoc(),
         llvm::SmallVector<sv::EventControl>{hwToSvEventControl(op.getEvent())},
         llvm::SmallVector<Value>{op.getTrigger()});
     rewriter.mergeBlocks(op.getBodyBlock(), alwaysOp.getBodyBlock(),

--- a/lib/Conversion/ImportAIGER/ImportAIGER.cpp
+++ b/lib/Conversion/ImportAIGER/ImportAIGER.cpp
@@ -723,15 +723,15 @@ Value AIGERParser::getLiteralValue(unsigned literal,
   // Handle constants
   if (literal == 0) {
     // FALSE constant
-    return builder.create<hw::ConstantOp>(
-        loc, builder.getI1Type(),
+    return hw::ConstantOp::create(
+        builder, loc, builder.getI1Type(),
         builder.getIntegerAttr(builder.getI1Type(), 0));
   }
 
   if (literal == 1) {
     // TRUE constant
-    return builder.create<hw::ConstantOp>(
-        loc, builder.getI1Type(),
+    return hw::ConstantOp::create(
+        builder, loc, builder.getI1Type(),
         builder.getIntegerAttr(builder.getI1Type(), 1));
   }
 
@@ -770,8 +770,8 @@ Value AIGERParser::getLiteralValue(unsigned literal,
   if (inverted) {
     // Create an inverter using aig.and_inv with single input
     SmallVector<bool> inverts = {true};
-    return builder.create<aig::AndInverterOp>(loc, builder.getI1Type(),
-                                              ValueRange{baseValue}, inverts);
+    return aig::AndInverterOp::create(builder, loc, builder.getI1Type(),
+                                      ValueRange{baseValue}, inverts);
   }
 
   return baseValue;
@@ -825,8 +825,9 @@ ParseResult AIGERParser::createModule() {
   }
 
   // Create the HW module
-  auto hwModule = builder.create<hw::HWModuleOp>(
-      builder.getUnknownLoc(), builder.getStringAttr(moduleName), ports);
+  auto hwModule =
+      hw::HWModuleOp::create(builder, builder.getUnknownLoc(),
+                             builder.getStringAttr(moduleName), ports);
 
   // Set insertion point inside the module
   builder.setInsertionPointToStart(hwModule.getBodyBlock());
@@ -865,8 +866,8 @@ ParseResult AIGERParser::createModule() {
     auto nextBackedge = bb.get(builder.getI1Type());
 
     // Create the register with the backedge as input
-    auto regValue = builder.create<seq::CompRegOp>(
-        lexer.translateLocation(loc), (Value)nextBackedge, clockValue);
+    auto regValue = seq::CompRegOp::create(
+        builder, lexer.translateLocation(loc), (Value)nextBackedge, clockValue);
     if (auto name = symbolTable.lookup({SymbolKind::Latch, i}))
       regValue.setNameAttr(name);
 
@@ -889,9 +890,9 @@ ParseResult AIGERParser::createModule() {
                                  static_cast<bool>(rhs1 % 2)};
 
     // Create AND gate with potential inversions
-    auto andResult = builder.create<aig::AndInverterOp>(
-        location, builder.getI1Type(), ValueRange{rhs0Value, rhs1Value},
-        inverts);
+    auto andResult =
+        aig::AndInverterOp::create(builder, location, builder.getI1Type(),
+                                   ValueRange{rhs0Value, rhs1Value}, inverts);
 
     // Set the backedge for this AND gate's result
     backedges[lhs].setValue(andResult);

--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -65,7 +65,7 @@ struct FormatStringParser {
       return Value{};
     if (fragments.size() == 1)
       return fragments[0];
-    return builder.create<moore::FormatConcatOp>(loc, fragments).getResult();
+    return moore::FormatConcatOp::create(builder, loc, fragments).getResult();
   }
 
   /// Parse a format string literal and consume and format the arguments
@@ -93,7 +93,7 @@ struct FormatStringParser {
 
   /// Emit a string literal that requires no additional formatting.
   void emitLiteral(StringRef literal) {
-    fragments.push_back(builder.create<moore::FormatLiteralOp>(loc, literal));
+    fragments.push_back(moore::FormatLiteralOp::create(builder, loc, literal));
   }
 
   /// Consume the next argument from the list and emit it according to the given
@@ -177,8 +177,8 @@ struct FormatStringParser {
     auto padding =
         format == IntFormat::Decimal ? IntPadding::Space : IntPadding::Zero;
 
-    fragments.push_back(builder.create<moore::FormatIntOp>(
-        loc, value, format, width, alignment, padding));
+    fragments.push_back(moore::FormatIntOp::create(builder, loc, value, format,
+                                                   width, alignment, padding));
     return success();
   }
 

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -56,30 +56,30 @@ struct StmtVisitor {
     if (!type)
       return failure();
 
-    Value initial = builder.create<moore::ConstantOp>(
-        loc, cast<moore::IntType>(type), loopDim.range->lower());
+    Value initial = moore::ConstantOp::create(
+        builder, loc, cast<moore::IntType>(type), loopDim.range->lower());
 
     // Create loop varirable in this dimension
-    Value varOp = builder.create<moore::VariableOp>(
-        loc, moore::RefType::get(cast<moore::UnpackedType>(type)),
+    Value varOp = moore::VariableOp::create(
+        builder, loc, moore::RefType::get(cast<moore::UnpackedType>(type)),
         builder.getStringAttr(iter->name), initial);
     context.valueSymbols.insertIntoScope(context.valueSymbols.getCurScope(),
                                          iter, varOp);
 
-    builder.create<cf::BranchOp>(loc, &checkBlock);
+    cf::BranchOp::create(builder, loc, &checkBlock);
     builder.setInsertionPointToEnd(&checkBlock);
 
     // When the loop variable is greater than the upper bound, goto exit
-    auto upperBound = builder.create<moore::ConstantOp>(
-        loc, cast<moore::IntType>(type), loopDim.range->upper());
+    auto upperBound = moore::ConstantOp::create(
+        builder, loc, cast<moore::IntType>(type), loopDim.range->upper());
 
-    auto var = builder.create<moore::ReadOp>(loc, varOp);
-    Value cond = builder.create<moore::SleOp>(loc, var, upperBound);
+    auto var = moore::ReadOp::create(builder, loc, varOp);
+    Value cond = moore::SleOp::create(builder, loc, var, upperBound);
     if (!cond)
       return failure();
     cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
-    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
-    builder.create<cf::CondBranchOp>(loc, cond, &bodyBlock, &exitBlock);
+    cond = moore::ConversionOp::create(builder, loc, builder.getI1Type(), cond);
+    cf::CondBranchOp::create(builder, loc, cond, &bodyBlock, &exitBlock);
 
     builder.setInsertionPointToEnd(&bodyBlock);
 
@@ -101,17 +101,17 @@ struct StmtVisitor {
         return failure();
     }
     if (!isTerminated())
-      builder.create<cf::BranchOp>(loc, &stepBlock);
+      cf::BranchOp::create(builder, loc, &stepBlock);
 
     builder.setInsertionPointToEnd(&stepBlock);
 
     // add one to loop variable
-    var = builder.create<moore::ReadOp>(loc, varOp);
+    var = moore::ReadOp::create(builder, loc, varOp);
     auto one =
-        builder.create<moore::ConstantOp>(loc, cast<moore::IntType>(type), 1);
-    auto postValue = builder.create<moore::AddOp>(loc, var, one).getResult();
-    builder.create<moore::BlockingAssignOp>(loc, varOp, postValue);
-    builder.create<cf::BranchOp>(loc, &checkBlock);
+        moore::ConstantOp::create(builder, loc, cast<moore::IntType>(type), 1);
+    auto postValue = moore::AddOp::create(builder, loc, var, one).getResult();
+    moore::BlockingAssignOp::create(builder, loc, varOp, postValue);
+    cf::BranchOp::create(builder, loc, &checkBlock);
 
     if (exitBlock.hasNoPredecessors()) {
       exitBlock.erase();
@@ -193,8 +193,8 @@ struct StmtVisitor {
     }
 
     // Collect local temporary variables.
-    auto varOp = builder.create<moore::VariableOp>(
-        loc, moore::RefType::get(cast<moore::UnpackedType>(type)),
+    auto varOp = moore::VariableOp::create(
+        builder, loc, moore::RefType::get(cast<moore::UnpackedType>(type)),
         builder.getStringAttr(var.name), initial);
     context.valueSymbols.insertIntoScope(context.valueSymbols.getCurScope(),
                                          &var, varOp);
@@ -215,27 +215,27 @@ struct StmtVisitor {
         return failure();
       cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
       if (allConds)
-        allConds = builder.create<moore::AndOp>(loc, allConds, cond);
+        allConds = moore::AndOp::create(builder, loc, allConds, cond);
       else
         allConds = cond;
     }
     assert(allConds && "slang guarantees at least one condition");
-    allConds =
-        builder.create<moore::ConversionOp>(loc, builder.getI1Type(), allConds);
+    allConds = moore::ConversionOp::create(builder, loc, builder.getI1Type(),
+                                           allConds);
 
     // Create the blocks for the true and false branches, and the exit block.
     Block &exitBlock = createBlock();
     Block *falseBlock = stmt.ifFalse ? &createBlock() : nullptr;
     Block &trueBlock = createBlock();
-    builder.create<cf::CondBranchOp>(loc, allConds, &trueBlock,
-                                     falseBlock ? falseBlock : &exitBlock);
+    cf::CondBranchOp::create(builder, loc, allConds, &trueBlock,
+                             falseBlock ? falseBlock : &exitBlock);
 
     // Generate the true branch.
     builder.setInsertionPointToEnd(&trueBlock);
     if (failed(context.convertStatement(stmt.ifTrue)))
       return failure();
     if (!isTerminated())
-      builder.create<cf::BranchOp>(loc, &exitBlock);
+      cf::BranchOp::create(builder, loc, &exitBlock);
 
     // Generate the false branch if present.
     if (stmt.ifFalse) {
@@ -243,7 +243,7 @@ struct StmtVisitor {
       if (failed(context.convertStatement(*stmt.ifFalse)))
         return failure();
       if (!isTerminated())
-        builder.create<cf::BranchOp>(loc, &exitBlock);
+        cf::BranchOp::create(builder, loc, &exitBlock);
     }
 
     // If control never reaches the exit block, remove it and mark control flow
@@ -298,26 +298,26 @@ struct StmtVisitor {
         Value cond;
         switch (caseStmt.condition) {
         case CaseStatementCondition::Normal:
-          cond = builder.create<moore::CaseEqOp>(itemLoc, caseExpr, value);
+          cond = moore::CaseEqOp::create(builder, itemLoc, caseExpr, value);
           break;
         case CaseStatementCondition::WildcardXOrZ:
-          cond = builder.create<moore::CaseXZEqOp>(itemLoc, caseExpr, value);
+          cond = moore::CaseXZEqOp::create(builder, itemLoc, caseExpr, value);
           break;
         case CaseStatementCondition::WildcardJustZ:
-          cond = builder.create<moore::CaseZEqOp>(itemLoc, caseExpr, value);
+          cond = moore::CaseZEqOp::create(builder, itemLoc, caseExpr, value);
           break;
         case CaseStatementCondition::Inside:
           mlir::emitError(loc, "unsupported set membership case statement");
           return failure();
         }
-        cond = builder.create<moore::ConversionOp>(itemLoc, builder.getI1Type(),
-                                                   cond);
+        cond = moore::ConversionOp::create(builder, itemLoc,
+                                           builder.getI1Type(), cond);
 
         // If the condition matches, branch to the match block. Otherwise
         // continue checking the next expression in a new block.
         auto &nextBlock = createBlock();
-        builder.create<mlir::cf::CondBranchOp>(itemLoc, cond, &matchBlock,
-                                               &nextBlock);
+        mlir::cf::CondBranchOp::create(builder, itemLoc, cond, &matchBlock,
+                                       &nextBlock);
         builder.setInsertionPointToEnd(&nextBlock);
       }
 
@@ -333,7 +333,7 @@ struct StmtVisitor {
         return failure();
       if (!isTerminated()) {
         auto loc = context.convertLocation(item.stmt->sourceRange);
-        builder.create<mlir::cf::BranchOp>(loc, &exitBlock);
+        mlir::cf::BranchOp::create(builder, loc, &exitBlock);
       }
     }
 
@@ -385,14 +385,14 @@ struct StmtVisitor {
     if ((twoStateExhaustive || (hasFullCaseAttr && !caseStmt.defaultCase)) &&
         lastMatchBlock &&
         caseStmt.condition == CaseStatementCondition::Normal) {
-      builder.create<mlir::cf::BranchOp>(loc, lastMatchBlock);
+      mlir::cf::BranchOp::create(builder, loc, lastMatchBlock);
     } else {
       // Generate the default case if present.
       if (caseStmt.defaultCase)
         if (failed(context.convertStatement(*caseStmt.defaultCase)))
           return failure();
       if (!isTerminated())
-        builder.create<mlir::cf::BranchOp>(loc, &exitBlock);
+        mlir::cf::BranchOp::create(builder, loc, &exitBlock);
     }
 
     // If control never reaches the exit block, remove it and mark control flow
@@ -418,7 +418,7 @@ struct StmtVisitor {
     auto &stepBlock = createBlock();
     auto &bodyBlock = createBlock();
     auto &checkBlock = createBlock();
-    builder.create<cf::BranchOp>(loc, &checkBlock);
+    cf::BranchOp::create(builder, loc, &checkBlock);
 
     // Push the blocks onto the loop stack such that we can continue and break.
     context.loopStack.push_back({&stepBlock, &exitBlock});
@@ -430,15 +430,15 @@ struct StmtVisitor {
     if (!cond)
       return failure();
     cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
-    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
-    builder.create<cf::CondBranchOp>(loc, cond, &bodyBlock, &exitBlock);
+    cond = moore::ConversionOp::create(builder, loc, builder.getI1Type(), cond);
+    cf::CondBranchOp::create(builder, loc, cond, &bodyBlock, &exitBlock);
 
     // Generate the loop body.
     builder.setInsertionPointToEnd(&bodyBlock);
     if (failed(context.convertStatement(stmt.body)))
       return failure();
     if (!isTerminated())
-      builder.create<cf::BranchOp>(loc, &stepBlock);
+      cf::BranchOp::create(builder, loc, &stepBlock);
 
     // Generate the step expressions.
     builder.setInsertionPointToEnd(&stepBlock);
@@ -446,7 +446,7 @@ struct StmtVisitor {
       if (!context.convertRvalueExpression(*stepExpr))
         return failure();
     if (!isTerminated())
-      builder.create<cf::BranchOp>(loc, &checkBlock);
+      cf::BranchOp::create(builder, loc, &checkBlock);
 
     // If control never reaches the exit block, remove it and mark control flow
     // as terminated. Otherwise we continue inserting ops in the exit block.
@@ -479,7 +479,7 @@ struct StmtVisitor {
     auto &bodyBlock = createBlock();
     auto &checkBlock = createBlock();
     auto currentCount = checkBlock.addArgument(count.getType(), count.getLoc());
-    builder.create<cf::BranchOp>(loc, &checkBlock, count);
+    cf::BranchOp::create(builder, loc, &checkBlock, count);
 
     // Push the blocks onto the loop stack such that we can continue and break.
     context.loopStack.push_back({&stepBlock, &exitBlock});
@@ -488,23 +488,23 @@ struct StmtVisitor {
     // Generate the loop condition check.
     builder.setInsertionPointToEnd(&checkBlock);
     auto cond = builder.createOrFold<moore::BoolCastOp>(loc, currentCount);
-    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
-    builder.create<cf::CondBranchOp>(loc, cond, &bodyBlock, &exitBlock);
+    cond = moore::ConversionOp::create(builder, loc, builder.getI1Type(), cond);
+    cf::CondBranchOp::create(builder, loc, cond, &bodyBlock, &exitBlock);
 
     // Generate the loop body.
     builder.setInsertionPointToEnd(&bodyBlock);
     if (failed(context.convertStatement(stmt.body)))
       return failure();
     if (!isTerminated())
-      builder.create<cf::BranchOp>(loc, &stepBlock);
+      cf::BranchOp::create(builder, loc, &stepBlock);
 
     // Decrement the current count and branch back to the check block.
     builder.setInsertionPointToEnd(&stepBlock);
-    auto one = builder.create<moore::ConstantOp>(
-        count.getLoc(), cast<moore::IntType>(count.getType()), 1);
+    auto one = moore::ConstantOp::create(
+        builder, count.getLoc(), cast<moore::IntType>(count.getType()), 1);
     Value nextCount =
-        builder.create<moore::SubOp>(count.getLoc(), currentCount, one);
-    builder.create<cf::BranchOp>(loc, &checkBlock, nextCount);
+        moore::SubOp::create(builder, count.getLoc(), currentCount, one);
+    cf::BranchOp::create(builder, loc, &checkBlock, nextCount);
 
     // If control never reaches the exit block, remove it and mark control flow
     // as terminated. Otherwise we continue inserting ops in the exit block.
@@ -525,7 +525,7 @@ struct StmtVisitor {
     auto &exitBlock = createBlock();
     auto &bodyBlock = createBlock();
     auto &checkBlock = createBlock();
-    builder.create<cf::BranchOp>(loc, atLeastOnce ? &bodyBlock : &checkBlock);
+    cf::BranchOp::create(builder, loc, atLeastOnce ? &bodyBlock : &checkBlock);
     if (atLeastOnce)
       bodyBlock.moveBefore(&checkBlock);
 
@@ -539,15 +539,15 @@ struct StmtVisitor {
     if (!cond)
       return failure();
     cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
-    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
-    builder.create<cf::CondBranchOp>(loc, cond, &bodyBlock, &exitBlock);
+    cond = moore::ConversionOp::create(builder, loc, builder.getI1Type(), cond);
+    cf::CondBranchOp::create(builder, loc, cond, &bodyBlock, &exitBlock);
 
     // Generate the loop body.
     builder.setInsertionPointToEnd(&bodyBlock);
     if (failed(context.convertStatement(bodyStmt)))
       return failure();
     if (!isTerminated())
-      builder.create<cf::BranchOp>(loc, &checkBlock);
+      cf::BranchOp::create(builder, loc, &checkBlock);
 
     // If control never reaches the exit block, remove it and mark control flow
     // as terminated. Otherwise we continue inserting ops in the exit block.
@@ -573,7 +573,7 @@ struct StmtVisitor {
     // Create the blocks for the loop body and exit.
     auto &exitBlock = createBlock();
     auto &bodyBlock = createBlock();
-    builder.create<cf::BranchOp>(loc, &bodyBlock);
+    cf::BranchOp::create(builder, loc, &bodyBlock);
 
     // Push the blocks onto the loop stack such that we can continue and break.
     context.loopStack.push_back({&bodyBlock, &exitBlock});
@@ -584,7 +584,7 @@ struct StmtVisitor {
     if (failed(context.convertStatement(stmt.body)))
       return failure();
     if (!isTerminated())
-      builder.create<cf::BranchOp>(loc, &bodyBlock);
+      cf::BranchOp::create(builder, loc, &bodyBlock);
 
     // If control never reaches the exit block, remove it and mark control flow
     // as terminated. Otherwise we continue inserting ops in the exit block.
@@ -608,9 +608,9 @@ struct StmtVisitor {
       auto expr = context.convertRvalueExpression(*stmt.expr);
       if (!expr)
         return failure();
-      builder.create<mlir::func::ReturnOp>(loc, expr);
+      mlir::func::ReturnOp::create(builder, loc, expr);
     } else {
-      builder.create<mlir::func::ReturnOp>(loc);
+      mlir::func::ReturnOp::create(builder, loc);
     }
     setTerminated();
     return success();
@@ -621,7 +621,7 @@ struct StmtVisitor {
     if (context.loopStack.empty())
       return mlir::emitError(loc,
                              "cannot `continue` without a surrounding loop");
-    builder.create<cf::BranchOp>(loc, context.loopStack.back().continueBlock);
+    cf::BranchOp::create(builder, loc, context.loopStack.back().continueBlock);
     setTerminated();
     return success();
   }
@@ -630,7 +630,7 @@ struct StmtVisitor {
   LogicalResult visit(const slang::ast::BreakStatement &stmt) {
     if (context.loopStack.empty())
       return mlir::emitError(loc, "cannot `break` without a surrounding loop");
-    builder.create<cf::BranchOp>(loc, context.loopStack.back().breakBlock);
+    cf::BranchOp::create(builder, loc, context.loopStack.back().breakBlock);
     setTerminated();
     return success();
   }
@@ -652,13 +652,13 @@ struct StmtVisitor {
 
       switch (stmt.assertionKind) {
       case slang::ast::AssertionKind::Assert:
-        builder.create<moore::AssertOp>(loc, defer, cond, StringAttr{});
+        moore::AssertOp::create(builder, loc, defer, cond, StringAttr{});
         return success();
       case slang::ast::AssertionKind::Assume:
-        builder.create<moore::AssumeOp>(loc, defer, cond, StringAttr{});
+        moore::AssumeOp::create(builder, loc, defer, cond, StringAttr{});
         return success();
       case slang::ast::AssertionKind::CoverProperty:
-        builder.create<moore::CoverOp>(loc, defer, cond, StringAttr{});
+        moore::CoverOp::create(builder, loc, defer, cond, StringAttr{});
         return success();
       default:
         break;
@@ -669,21 +669,21 @@ struct StmtVisitor {
     }
 
     // Regard assertion statements with an action block as the "if-else".
-    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
+    cond = moore::ConversionOp::create(builder, loc, builder.getI1Type(), cond);
 
     // Create the blocks for the true and false branches, and the exit block.
     Block &exitBlock = createBlock();
     Block *falseBlock = stmt.ifFalse ? &createBlock() : nullptr;
     Block &trueBlock = createBlock();
-    builder.create<cf::CondBranchOp>(loc, cond, &trueBlock,
-                                     falseBlock ? falseBlock : &exitBlock);
+    cf::CondBranchOp::create(builder, loc, cond, &trueBlock,
+                             falseBlock ? falseBlock : &exitBlock);
 
     // Generate the true branch.
     builder.setInsertionPointToEnd(&trueBlock);
     if (stmt.ifTrue && failed(context.convertStatement(*stmt.ifTrue)))
       return failure();
     if (!isTerminated())
-      builder.create<cf::BranchOp>(loc, &exitBlock);
+      cf::BranchOp::create(builder, loc, &exitBlock);
 
     if (stmt.ifFalse) {
       // Generate the false branch if present.
@@ -691,7 +691,7 @@ struct StmtVisitor {
       if (failed(context.convertStatement(*stmt.ifFalse)))
         return failure();
       if (!isTerminated())
-        builder.create<cf::BranchOp>(loc, &exitBlock);
+        cf::BranchOp::create(builder, loc, &exitBlock);
     }
 
     // If control never reaches the exit block, remove it and mark control flow
@@ -716,10 +716,10 @@ struct StmtVisitor {
     if (stmt.ifTrue && stmt.ifTrue->as_if<slang::ast::EmptyStatement>()) {
       switch (stmt.assertionKind) {
       case slang::ast::AssertionKind::Assert:
-        builder.create<verif::AssertOp>(loc, property, Value(), StringAttr{});
+        verif::AssertOp::create(builder, loc, property, Value(), StringAttr{});
         return success();
       case slang::ast::AssertionKind::Assume:
-        builder.create<verif::AssumeOp>(loc, property, Value(), StringAttr{});
+        verif::AssumeOp::create(builder, loc, property, Value(), StringAttr{});
         return success();
       default:
         break;
@@ -749,14 +749,14 @@ struct StmtVisitor {
 
     if (subroutine.name == "$stop") {
       createFinishMessage(args.size() >= 1 ? args[0] : nullptr);
-      builder.create<moore::StopBIOp>(loc);
+      moore::StopBIOp::create(builder, loc);
       return true;
     }
 
     if (subroutine.name == "$finish") {
       createFinishMessage(args.size() >= 1 ? args[0] : nullptr);
-      builder.create<moore::FinishBIOp>(loc, 0);
-      builder.create<moore::UnreachableOp>(loc);
+      moore::FinishBIOp::create(builder, loc, 0);
+      moore::UnreachableOp::create(builder, loc);
       setTerminated();
       return true;
     }
@@ -802,7 +802,7 @@ struct StmtVisitor {
         return failure();
       if (*message == Value{})
         return true;
-      builder.create<moore::DisplayBIOp>(loc, *message);
+      moore::DisplayBIOp::create(builder, loc, *message);
       return true;
     }
 
@@ -831,15 +831,15 @@ struct StmtVisitor {
       if (failed(message))
         return failure();
       if (*message == Value{})
-        *message = builder.create<moore::FormatLiteralOp>(loc, "");
+        *message = moore::FormatLiteralOp::create(builder, loc, "");
 
-      builder.create<moore::SeverityBIOp>(loc, *severity, *message);
+      moore::SeverityBIOp::create(builder, loc, *severity, *message);
 
       // Handle the `$fatal` case which behaves like a `$finish`.
       if (severity == Severity::Fatal) {
         createFinishMessage(verbosityExpr);
-        builder.create<moore::FinishBIOp>(loc, 1);
-        builder.create<moore::UnreachableOp>(loc);
+        moore::FinishBIOp::create(builder, loc, 1);
+        moore::UnreachableOp::create(builder, loc);
         setTerminated();
       }
       return true;
@@ -861,7 +861,7 @@ struct StmtVisitor {
     }
     if (verbosity == 0)
       return;
-    builder.create<moore::FinishMessageBIOp>(loc, verbosity > 1);
+    moore::FinishMessageBIOp::create(builder, loc, verbosity > 1);
   }
 
   /// Emit an error for all other statements.

--- a/lib/Conversion/ImportVerilog/TimingControls.cpp
+++ b/lib/Conversion/ImportVerilog/TimingControls.cpp
@@ -67,7 +67,7 @@ struct EventControlVisitor {
       if (!condition)
         return failure();
     }
-    builder.create<moore::DetectEventOp>(loc, edge, expr, condition);
+    moore::DetectEventOp::create(builder, loc, edge, expr, condition);
     return success();
   }
 
@@ -125,7 +125,7 @@ struct LTLClockControlVisitor {
     expr = context.convertToI1(expr);
     if (!expr)
       return Value{};
-    return builder.create<ltl::ClockOp>(loc, seqOrPro, edge, expr);
+    return ltl::ClockOp::create(builder, loc, seqOrPro, edge, expr);
   }
 
   template <typename T>
@@ -168,13 +168,13 @@ static LogicalResult handleRoot(Context &context,
     // empty wait op and let `Context::convertTimingControl` populate it once
     // the statement has been lowered.
   case TimingControlKind::ImplicitEvent:
-    implicitWaitOp = builder.create<moore::WaitEventOp>(loc);
+    implicitWaitOp = moore::WaitEventOp::create(builder, loc);
     return success();
 
     // Handle event control.
   case TimingControlKind::SignalEvent:
   case TimingControlKind::EventList: {
-    auto waitOp = builder.create<moore::WaitEventOp>(loc);
+    auto waitOp = moore::WaitEventOp::create(builder, loc);
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(&waitOp.getBody().emplaceBlock());
     EventControlVisitor visitor{context, loc, builder};
@@ -242,9 +242,9 @@ Context::convertTimingControl(const slang::ast::TimingControl &ctrl,
     builder.setInsertionPointToStart(&implicitWaitOp.getBody().emplaceBlock());
     for (auto readValue : readValues) {
       auto value =
-          builder.create<moore::ReadOp>(implicitWaitOp.getLoc(), readValue);
-      builder.create<moore::DetectEventOp>(
-          implicitWaitOp.getLoc(), moore::Edge::AnyChange, value, Value{});
+          moore::ReadOp::create(builder, implicitWaitOp.getLoc(), readValue);
+      moore::DetectEventOp::create(builder, implicitWaitOp.getLoc(),
+                                   moore::Edge::AnyChange, value, Value{});
     }
   }
 

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -58,21 +58,21 @@ static Value adjustIntegerWidth(OpBuilder &builder, Value value,
     return value;
 
   if (intWidth < targetWidth) {
-    Value zeroExt = builder.create<hw::ConstantOp>(
-        loc, builder.getIntegerType(targetWidth - intWidth), 0);
-    return builder.create<comb::ConcatOp>(loc, ValueRange{zeroExt, value});
+    Value zeroExt = hw::ConstantOp::create(
+        builder, loc, builder.getIntegerType(targetWidth - intWidth), 0);
+    return comb::ConcatOp::create(builder, loc, ValueRange{zeroExt, value});
   }
 
-  Value hi = builder.create<comb::ExtractOp>(loc, value, targetWidth,
-                                             intWidth - targetWidth);
-  Value zero = builder.create<hw::ConstantOp>(
-      loc, builder.getIntegerType(intWidth - targetWidth), 0);
-  Value isZero = builder.create<comb::ICmpOp>(loc, comb::ICmpPredicate::eq, hi,
-                                              zero, false);
-  Value lo = builder.create<comb::ExtractOp>(loc, value, 0, targetWidth);
-  Value max = builder.create<hw::ConstantOp>(
-      loc, builder.getIntegerType(targetWidth), -1);
-  return builder.create<comb::MuxOp>(loc, isZero, lo, max, false);
+  Value hi = comb::ExtractOp::create(builder, loc, value, targetWidth,
+                                     intWidth - targetWidth);
+  Value zero = hw::ConstantOp::create(
+      builder, loc, builder.getIntegerType(intWidth - targetWidth), 0);
+  Value isZero = comb::ICmpOp::create(builder, loc, comb::ICmpPredicate::eq, hi,
+                                      zero, false);
+  Value lo = comb::ExtractOp::create(builder, loc, value, 0, targetWidth);
+  Value max = hw::ConstantOp::create(builder, loc,
+                                     builder.getIntegerType(targetWidth), -1);
+  return comb::MuxOp::create(builder, loc, isZero, lo, max, false);
 }
 
 /// Get the ModulePortInfo from a SVModuleOp.
@@ -125,8 +125,8 @@ struct SVModuleOpConversion : public OpConversionPattern<SVModuleOp> {
 
     // Create the hw.module to replace moore.module
     auto hwModuleOp =
-        rewriter.create<hw::HWModuleOp>(op.getLoc(), op.getSymNameAttr(),
-                                        getModulePortInfo(*typeConverter, op));
+        hw::HWModuleOp::create(rewriter, op.getLoc(), op.getSymNameAttr(),
+                               getModulePortInfo(*typeConverter, op));
     // Make hw.module have the same visibility as the moore.module.
     // The entry/top level module is public, otherwise is private.
     SymbolTable::setSymbolVisibility(hwModuleOp,
@@ -166,9 +166,9 @@ struct InstanceOpConversion : public OpConversionPattern<InstanceOp> {
 
     // Create the new hw instanceOp to replace the original one.
     rewriter.setInsertionPoint(op);
-    auto instOp = rewriter.create<hw::InstanceOp>(
-        op.getLoc(), op.getResultTypes(), instName, moduleName, op.getInputs(),
-        op.getInputNamesAttr(), op.getOutputNamesAttr(),
+    auto instOp = hw::InstanceOp::create(
+        rewriter, op.getLoc(), op.getResultTypes(), instName, moduleName,
+        op.getInputs(), op.getInputNamesAttr(), op.getOutputNamesAttr(),
         /*Parameter*/ rewriter.getArrayAttr({}), /*InnerSymbol*/ nullptr,
         /*doNotPrint*/ nullptr);
 
@@ -190,7 +190,7 @@ static void getValuesToObserve(Region *region,
   auto probeIfSignal = [&](Value value) -> Value {
     if (!isa<hw::InOutType>(value.getType()))
       return value;
-    return rewriter.create<llhd::PrbOp>(loc, value);
+    return llhd::PrbOp::create(rewriter, loc, value);
   };
 
   region->getParentOp()->walk<WalkOrder::PreOrder, ForwardDominanceIterator<>>(
@@ -249,9 +249,9 @@ struct ProcedureOpConversion : public OpConversionPattern<ProcedureOp> {
         op.getKind() == ProcedureKind::Final) {
       Operation *newOp;
       if (op.getKind() == ProcedureKind::Initial)
-        newOp = rewriter.create<llhd::ProcessOp>(loc, TypeRange{});
+        newOp = llhd::ProcessOp::create(rewriter, loc, TypeRange{});
       else
-        newOp = rewriter.create<llhd::FinalOp>(loc);
+        newOp = llhd::FinalOp::create(rewriter, loc);
       auto &body = newOp->getRegion(0);
       rewriter.inlineRegionBefore(op.getBody(), body, body.end());
       for (auto returnOp :
@@ -264,14 +264,14 @@ struct ProcedureOpConversion : public OpConversionPattern<ProcedureOp> {
     }
 
     // All other procedures lower to a an `llhd.process`.
-    auto newOp = rewriter.create<llhd::ProcessOp>(loc, TypeRange{});
+    auto newOp = llhd::ProcessOp::create(rewriter, loc, TypeRange{});
 
     // We need to add an empty entry block because it is not allowed in MLIR to
     // branch back to the entry block. Instead we put the logic in the second
     // block and branch to that.
     rewriter.createBlock(&newOp.getBody());
     auto *block = &op.getBody().front();
-    rewriter.create<cf::BranchOp>(loc, block);
+    cf::BranchOp::create(rewriter, loc, block);
     rewriter.inlineRegionBefore(op.getBody(), newOp.getBody(),
                                 newOp.getBody().end());
 
@@ -284,8 +284,8 @@ struct ProcedureOpConversion : public OpConversionPattern<ProcedureOp> {
     if (op.getKind() == ProcedureKind::AlwaysComb ||
         op.getKind() == ProcedureKind::AlwaysLatch) {
       Block *waitBlock = rewriter.createBlock(&newOp.getBody());
-      rewriter.create<llhd::WaitOp>(loc, ValueRange{}, Value(), observedValues,
-                                    ValueRange{}, block);
+      llhd::WaitOp::create(rewriter, loc, ValueRange{}, Value(), observedValues,
+                           ValueRange{}, block);
       block = waitBlock;
     }
 
@@ -294,7 +294,7 @@ struct ProcedureOpConversion : public OpConversionPattern<ProcedureOp> {
     // `always_latch` procedures.
     for (auto returnOp : llvm::make_early_inc_range(newOp.getOps<ReturnOp>())) {
       rewriter.setInsertionPoint(returnOp);
-      rewriter.create<cf::BranchOp>(loc, block);
+      cf::BranchOp::create(rewriter, loc, block);
       rewriter.eraseOp(returnOp);
     }
 
@@ -360,7 +360,7 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
 
     auto loc = op.getLoc();
     rewriter.setInsertionPoint(op);
-    rewriter.create<cf::BranchOp>(loc, waitBlock);
+    cf::BranchOp::create(rewriter, loc, waitBlock);
 
     // We need to inline two copies of the `wait_event`'s body region: one is
     // used to determine the values going into `detect_event` ops before the
@@ -399,8 +399,8 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
     // Create the `llhd.wait` op that suspends the current process and waits for
     // a change in the interesting values listed in `observeValues`. When a
     // change is detected, execution resumes in the "check" block.
-    auto waitOp = rewriter.create<llhd::WaitOp>(
-        loc, ValueRange{}, Value(), observeValues, ValueRange{}, checkBlock);
+    auto waitOp = llhd::WaitOp::create(rewriter, loc, ValueRange{}, Value(),
+                                       observeValues, ValueRange{}, checkBlock);
     rewriter.inlineBlockBefore(&clonedOp.getBody().front(), waitOp);
     rewriter.eraseOp(clonedOp);
 
@@ -425,8 +425,8 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
         beforeType =
             IntType::get(rewriter.getContext(), 1, beforeType.getDomain());
         before =
-            rewriter.create<moore::ExtractOp>(loc, beforeType, before, LSB);
-        after = rewriter.create<moore::ExtractOp>(loc, beforeType, after, LSB);
+            moore::ExtractOp::create(rewriter, loc, beforeType, before, LSB);
+        after = moore::ExtractOp::create(rewriter, loc, beforeType, after, LSB);
       }
 
       auto intType = rewriter.getIntegerType(beforeType.getWidth());
@@ -436,25 +436,25 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
                                                          after);
 
       if (edge == Edge::AnyChange)
-        return rewriter.create<comb::ICmpOp>(loc, ICmpPredicate::ne, before,
-                                             after, true);
+        return comb::ICmpOp::create(rewriter, loc, ICmpPredicate::ne, before,
+                                    after, true);
 
       SmallVector<Value> disjuncts;
-      Value trueVal = rewriter.create<hw::ConstantOp>(loc, APInt(1, 1));
+      Value trueVal = hw::ConstantOp::create(rewriter, loc, APInt(1, 1));
 
       if (edge == Edge::PosEdge || edge == Edge::BothEdges) {
         Value notOldVal =
-            rewriter.create<comb::XorOp>(loc, before, trueVal, true);
+            comb::XorOp::create(rewriter, loc, before, trueVal, true);
         Value posedge =
-            rewriter.create<comb::AndOp>(loc, notOldVal, after, true);
+            comb::AndOp::create(rewriter, loc, notOldVal, after, true);
         disjuncts.push_back(posedge);
       }
 
       if (edge == Edge::NegEdge || edge == Edge::BothEdges) {
         Value notCurrVal =
-            rewriter.create<comb::XorOp>(loc, after, trueVal, true);
+            comb::XorOp::create(rewriter, loc, after, trueVal, true);
         Value posedge =
-            rewriter.create<comb::AndOp>(loc, before, notCurrVal, true);
+            comb::AndOp::create(rewriter, loc, before, notCurrVal, true);
         disjuncts.push_back(posedge);
       }
 
@@ -477,7 +477,8 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
         if (detectOp.getCondition()) {
           auto condition = typeConverter->materializeTargetConversion(
               rewriter, loc, rewriter.getI1Type(), detectOp.getCondition());
-          trigger = rewriter.create<comb::AndOp>(loc, trigger, condition, true);
+          trigger =
+              comb::AndOp::create(rewriter, loc, trigger, condition, true);
         }
         triggers.push_back(trigger);
       }
@@ -491,14 +492,15 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
       // block. If there are no detect_event operations in the wait event, the
       // 'llhd.wait' operation will not have any observed values and thus the
       // process will hang there forever.
-      rewriter.create<cf::BranchOp>(loc, resumeBlock);
+      cf::BranchOp::create(rewriter, loc, resumeBlock);
     } else {
       // If any `detect_event` op detected an event, branch to the "resume"
       // block which contains any code after the `wait_event` op. If no events
       // were detected, branch back to the "wait" block to wait for the next
       // change on the interesting signals.
       auto triggered = rewriter.createOrFold<comb::OrOp>(loc, triggers, true);
-      rewriter.create<cf::CondBranchOp>(loc, triggered, resumeBlock, waitBlock);
+      cf::CondBranchOp::create(rewriter, loc, triggered, resumeBlock,
+                               waitBlock);
     }
 
     return success();
@@ -531,7 +533,7 @@ struct VariableOpConversion : public OpConversionPattern<VariableOp> {
       // TODO: Once the core dialects support four-valued integers, this code
       // will additionally need to generate an all-X value for four-valued
       // variables.
-      Value constZero = rewriter.create<hw::ConstantOp>(loc, APInt(width, 0));
+      Value constZero = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
       init = rewriter.createOrFold<hw::BitcastOp>(loc, elementType, constZero);
     }
 
@@ -561,7 +563,7 @@ struct NetOpConversion : public OpConversionPattern<NetOp> {
     int64_t width = hw::getBitWidth(elementType);
     if (width == -1)
       return failure();
-    auto constZero = rewriter.create<hw::ConstantOp>(loc, APInt(width, 0));
+    auto constZero = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
     auto init =
         rewriter.createOrFold<hw::BitcastOp>(loc, elementType, constZero);
 
@@ -571,8 +573,8 @@ struct NetOpConversion : public OpConversionPattern<NetOp> {
     if (auto assignedValue = adaptor.getAssignment()) {
       auto timeAttr = llhd::TimeAttr::get(resultType.getContext(), 0U,
                                           llvm::StringRef("ns"), 0, 1);
-      auto time = rewriter.create<llhd::ConstantTimeOp>(loc, timeAttr);
-      rewriter.create<llhd::DrvOp>(loc, signal, assignedValue, time, Value{});
+      auto time = llhd::ConstantTimeOp::create(rewriter, loc, timeAttr);
+      llhd::DrvOp::create(rewriter, loc, signal, assignedValue, time, Value{});
     }
 
     return success();
@@ -668,8 +670,8 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
 
       SmallVector<Value> toConcat;
       if (low < 0)
-        toConcat.push_back(rewriter.create<hw::ConstantOp>(
-            op.getLoc(), APInt(std::min(-low, resultWidth), 0)));
+        toConcat.push_back(hw::ConstantOp::create(
+            rewriter, op.getLoc(), APInt(std::min(-low, resultWidth), 0)));
 
       if (low < inputWidth && high > 0) {
         int32_t lowIdx = std::max(low, 0);
@@ -684,7 +686,7 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
       int32_t diff = high - inputWidth;
       if (diff > 0) {
         Value val =
-            rewriter.create<hw::ConstantOp>(op.getLoc(), APInt(diff, 0));
+            hw::ConstantOp::create(rewriter, op.getLoc(), APInt(diff, 0));
         toConcat.push_back(val);
       }
 
@@ -708,8 +710,8 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
 
         SmallVector<Value> toConcat;
         if (low < 0) {
-          Value val = rewriter.create<hw::ConstantOp>(
-              op.getLoc(),
+          Value val = hw::ConstantOp::create(
+              rewriter, op.getLoc(),
               APInt(std::min((-low) * elementWidth, resWidth * elementWidth),
                     0));
           Value res = rewriter.createOrFold<hw::BitcastOp>(
@@ -720,8 +722,8 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
 
         if (low < inputWidth && high > 0) {
           int32_t lowIdx = std::max(0, low);
-          Value lowIdxVal = rewriter.create<hw::ConstantOp>(
-              op.getLoc(), rewriter.getIntegerType(width), lowIdx);
+          Value lowIdxVal = hw::ConstantOp::create(
+              rewriter, op.getLoc(), rewriter.getIntegerType(width), lowIdx);
           Value middle = rewriter.createOrFold<hw::ArraySliceOp>(
               op.getLoc(),
               hw::ArrayType::get(
@@ -733,11 +735,11 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
 
         int32_t diff = high - inputWidth;
         if (diff > 0) {
-          Value constZero = rewriter.create<hw::ConstantOp>(
-              op.getLoc(), APInt(diff * elementWidth, 0));
-          Value val = rewriter.create<hw::BitcastOp>(
-              op.getLoc(), hw::ArrayType::get(arrTy.getElementType(), diff),
-              constZero);
+          Value constZero = hw::ConstantOp::create(
+              rewriter, op.getLoc(), APInt(diff * elementWidth, 0));
+          Value val = hw::BitcastOp::create(
+              rewriter, op.getLoc(),
+              hw::ArrayType::get(arrTy.getElementType(), diff), constZero);
           toConcat.push_back(val);
         }
 
@@ -753,15 +755,16 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
         if (bw < 0)
           return failure();
 
-        Value val = rewriter.create<hw::ConstantOp>(op.getLoc(), APInt(bw, 0));
+        Value val = hw::ConstantOp::create(rewriter, op.getLoc(), APInt(bw, 0));
         Value bitcast =
             rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), resultType, val);
         rewriter.replaceOp(op, bitcast);
         return success();
       }
 
-      Value idx = rewriter.create<hw::ConstantOp>(
-          op.getLoc(), rewriter.getIntegerType(width), adaptor.getLowBit());
+      Value idx = hw::ConstantOp::create(rewriter, op.getLoc(),
+                                         rewriter.getIntegerType(width),
+                                         adaptor.getLowBit());
       rewriter.replaceOpWithNewOp<hw::ArrayGetOp>(op, adaptor.getInput(), idx);
       return success();
     }
@@ -786,8 +789,9 @@ struct ExtractRefOpConversion : public OpConversionPattern<ExtractRefOp> {
       if (width == -1)
         return failure();
 
-      Value lowBit = rewriter.create<hw::ConstantOp>(
-          op.getLoc(), rewriter.getIntegerType(llvm::Log2_64_Ceil(width)),
+      Value lowBit = hw::ConstantOp::create(
+          rewriter, op.getLoc(),
+          rewriter.getIntegerType(llvm::Log2_64_Ceil(width)),
           adaptor.getLowBit());
       rewriter.replaceOpWithNewOp<llhd::SigExtractOp>(
           op, resultType, adaptor.getInput(), lowBit);
@@ -795,8 +799,8 @@ struct ExtractRefOpConversion : public OpConversionPattern<ExtractRefOp> {
     }
 
     if (auto arrType = dyn_cast<hw::ArrayType>(inputType)) {
-      Value lowBit = rewriter.create<hw::ConstantOp>(
-          op.getLoc(),
+      Value lowBit = hw::ConstantOp::create(
+          rewriter, op.getLoc(),
           rewriter.getIntegerType(llvm::Log2_64_Ceil(arrType.getNumElements())),
           adaptor.getLowBit());
 
@@ -828,8 +832,8 @@ struct DynExtractOpConversion : public OpConversionPattern<DynExtractOp> {
     if (auto intType = dyn_cast<IntegerType>(inputType)) {
       Value amount = adjustIntegerWidth(rewriter, adaptor.getLowBit(),
                                         intType.getWidth(), op->getLoc());
-      Value value = rewriter.create<comb::ShrUOp>(op->getLoc(),
-                                                  adaptor.getInput(), amount);
+      Value value = comb::ShrUOp::create(rewriter, op->getLoc(),
+                                         adaptor.getInput(), amount);
 
       rewriter.replaceOpWithNewOp<comb::ExtractOp>(op, resultType, value, 0);
       return success();
@@ -956,7 +960,7 @@ struct ReduceAndOpConversion : public OpConversionPattern<ReduceAndOp> {
   matchAndRewrite(ReduceAndOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = typeConverter->convertType(op.getInput().getType());
-    Value max = rewriter.create<hw::ConstantOp>(op->getLoc(), resultType, -1);
+    Value max = hw::ConstantOp::create(rewriter, op->getLoc(), resultType, -1);
 
     rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::eq,
                                               adaptor.getInput(), max);
@@ -970,7 +974,7 @@ struct ReduceOrOpConversion : public OpConversionPattern<ReduceOrOp> {
   matchAndRewrite(ReduceOrOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = typeConverter->convertType(op.getInput().getType());
-    Value zero = rewriter.create<hw::ConstantOp>(op->getLoc(), resultType, 0);
+    Value zero = hw::ConstantOp::create(rewriter, op->getLoc(), resultType, 0);
 
     rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne,
                                               adaptor.getInput(), zero);
@@ -996,7 +1000,8 @@ struct BoolCastOpConversion : public OpConversionPattern<BoolCastOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = typeConverter->convertType(op.getInput().getType());
     if (isa_and_nonnull<IntegerType>(resultType)) {
-      Value zero = rewriter.create<hw::ConstantOp>(op->getLoc(), resultType, 0);
+      Value zero =
+          hw::ConstantOp::create(rewriter, op->getLoc(), resultType, 0);
       rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne,
                                                 adaptor.getInput(), zero);
       return success();
@@ -1012,7 +1017,7 @@ struct NotOpConversion : public OpConversionPattern<NotOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType =
         ConversionPattern::typeConverter->convertType(op.getResult().getType());
-    Value max = rewriter.create<hw::ConstantOp>(op.getLoc(), resultType, -1);
+    Value max = hw::ConstantOp::create(rewriter, op.getLoc(), resultType, -1);
 
     rewriter.replaceOpWithNewOp<comb::XorOp>(op, adaptor.getInput(), max);
     return success();
@@ -1026,7 +1031,7 @@ struct NegOpConversion : public OpConversionPattern<NegOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType =
         ConversionPattern::typeConverter->convertType(op.getResult().getType());
-    Value zero = rewriter.create<hw::ConstantOp>(op.getLoc(), resultType, 0);
+    Value zero = hw::ConstantOp::create(rewriter, op.getLoc(), resultType, 0);
 
     rewriter.replaceOpWithNewOp<comb::SubOp>(op, zero, adaptor.getInput());
     return success();
@@ -1098,7 +1103,7 @@ struct CaseXZEqOpConversion : public OpConversionPattern<SourceOp> {
     Value rhs = adaptor.getRhs();
     if (!ignoredBits.isZero()) {
       ignoredBits.flipAllBits();
-      auto maskOp = rewriter.create<hw::ConstantOp>(op.getLoc(), ignoredBits);
+      auto maskOp = hw::ConstantOp::create(rewriter, op.getLoc(), ignoredBits);
       lhs = rewriter.createOrFold<comb::AndOp>(op.getLoc(), lhs, maskOp);
       rhs = rewriter.createOrFold<comb::AndOp>(op.getLoc(), rhs, maskOp);
     }
@@ -1157,8 +1162,9 @@ struct ZExtOpConversion : public OpConversionPattern<ZExtOp> {
     auto targetWidth = op.getType().getWidth();
     auto inputWidth = op.getInput().getType().getWidth();
 
-    auto zeroExt = rewriter.create<hw::ConstantOp>(
-        op.getLoc(), rewriter.getIntegerType(targetWidth - inputWidth), 0);
+    auto zeroExt = hw::ConstantOp::create(
+        rewriter, op.getLoc(),
+        rewriter.getIntegerType(targetWidth - inputWidth), 0);
 
     rewriter.replaceOpWithNewOp<comb::ConcatOp>(
         op, ValueRange{zeroExt, adaptor.getInput()});
@@ -1326,14 +1332,14 @@ struct PowUOpConversion : public OpConversionPattern<PowUOp> {
 
     Location loc = op->getLoc();
 
-    Value zeroVal = rewriter.create<hw::ConstantOp>(loc, APInt(1, 0));
+    Value zeroVal = hw::ConstantOp::create(rewriter, loc, APInt(1, 0));
     // zero extend both LHS & RHS to ensure the unsigned integers are
     // interpreted correctly when calculating power
-    auto lhs = rewriter.create<comb::ConcatOp>(loc, zeroVal, adaptor.getLhs());
-    auto rhs = rewriter.create<comb::ConcatOp>(loc, zeroVal, adaptor.getRhs());
+    auto lhs = comb::ConcatOp::create(rewriter, loc, zeroVal, adaptor.getLhs());
+    auto rhs = comb::ConcatOp::create(rewriter, loc, zeroVal, adaptor.getRhs());
 
     // lower the exponentiation via MLIR's math dialect
-    auto pow = rewriter.create<mlir::math::IPowIOp>(loc, lhs, rhs);
+    auto pow = mlir::math::IPowIOp::create(rewriter, loc, lhs, rhs);
 
     rewriter.replaceOpWithNewOp<comb::ExtractOp>(op, resultType, pow, 0);
     return success();
@@ -1410,7 +1416,7 @@ struct AssignOpConversion : public OpConversionPattern<OpTy> {
     // this conversion.
     auto timeAttr = llhd::TimeAttr::get(
         op->getContext(), 0U, llvm::StringRef("ns"), DeltaTime, EpsilonTime);
-    auto time = rewriter.create<llhd::ConstantTimeOp>(op->getLoc(), timeAttr);
+    auto time = llhd::ConstantTimeOp::create(rewriter, op->getLoc(), timeAttr);
     rewriter.replaceOpWithNewOp<llhd::DrvOp>(op, adaptor.getDst(),
                                              adaptor.getSrc(), time, Value{});
     return success();
@@ -1466,7 +1472,7 @@ struct ConditionalOpConversion : public OpConversionPattern<ConditionalOp> {
     }
 
     auto ifOp =
-        rewriter.create<scf::IfOp>(op.getLoc(), type, adaptor.getCondition());
+        scf::IfOp::create(rewriter, op.getLoc(), type, adaptor.getCondition());
     rewriter.inlineRegionBefore(op.getTrueRegion(), ifOp.getThenRegion(),
                                 ifOp.getThenRegion().end());
     rewriter.inlineRegionBefore(op.getFalseRegion(), ifOp.getElseRegion(),
@@ -1723,8 +1729,8 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
           mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
         if (inputs.size() != 1 || !inputs[0])
           return Value();
-        return builder
-            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+        return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                                  inputs[0])
             .getResult(0);
       });
 
@@ -1733,8 +1739,8 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
           mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
         if (inputs.size() != 1)
           return Value();
-        return builder
-            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+        return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                                  inputs[0])
             ->getResult(0);
       });
 }

--- a/lib/Conversion/SeqToSV/FirRegLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirRegLowering.cpp
@@ -879,7 +879,8 @@ void FirRegLowering::addToAlwaysBlock(
       auto createIfOp = [&]() {
         // It is weird but intended. Here we want to create an empty sv.if
         // with an else block.
-        insideIfOp = sv::IfOp::create(builder, reset, []() {}, []() {});
+        insideIfOp = sv::IfOp::create(
+            builder, reset, []() {}, []() {});
       };
       if (resetStyle == sv::ResetType::AsyncReset) {
         sv::EventControl events[] = {clockEdge, resetEdge};

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -782,7 +782,8 @@ void SeqToSVPass::runOnOperation() {
 
   // Helper function to emit #ifndef guard.
   auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
-    sv::IfDefOp::create(b, guard, []() {}, body);
+    sv::IfDefOp::create(
+        b, guard, []() {}, body);
   };
 
   emit::FragmentOp::create(b, randomInitFragmentName.getAttr(), [&] {

--- a/lib/Dialect/AIG/AIGOps.cpp
+++ b/lib/Dialect/AIG/AIGOps.cpp
@@ -87,7 +87,7 @@ LogicalResult AndInverterOp::canonicalize(AndInverterOp op,
     return failure();
 
   if (!constValue.isAllOnes()) {
-    auto constOp = rewriter.create<hw::ConstantOp>(op.getLoc(), constValue);
+    auto constOp = hw::ConstantOp::create(rewriter, op.getLoc(), constValue);
     uniqueInverts.push_back(false);
     uniqueValues.push_back(constOp);
   }

--- a/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
+++ b/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
@@ -417,7 +417,7 @@ LogicalResult AIGERRunner::importFromAIGER(Converter &converter,
   mlir::OpBuilder builder(originalModule->getContext());
   builder.setInsertionPointToStart(&temporaryBlock);
   auto temporaryModule =
-      builder.create<mlir::ModuleOp>(builder.getUnknownLoc());
+      mlir::ModuleOp::create(builder, builder.getUnknownLoc());
 
   // Import the AIGER file into the temporary module
   if (failed(circt::aiger::importAIGER(sourceMgr, originalModule->getContext(),

--- a/lib/Dialect/AIG/Transforms/LowerVariadic.cpp
+++ b/lib/Dialect/AIG/Transforms/LowerVariadic.cpp
@@ -42,12 +42,12 @@ static Value lowerVariadicAndInverterOp(AndInverterOp op, OperandRange operands,
     break;
   case 1:
     if (inverts[0])
-      return rewriter.create<AndInverterOp>(op.getLoc(), operands[0], true);
+      return AndInverterOp::create(rewriter, op.getLoc(), operands[0], true);
     else
       return operands[0];
   case 2:
-    return rewriter.create<AndInverterOp>(op.getLoc(), operands[0], operands[1],
-                                          inverts[0], inverts[1]);
+    return AndInverterOp::create(rewriter, op.getLoc(), operands[0],
+                                 operands[1], inverts[0], inverts[1]);
   default:
     auto firstHalf = operands.size() / 2;
     auto lhs =
@@ -56,7 +56,7 @@ static Value lowerVariadicAndInverterOp(AndInverterOp op, OperandRange operands,
     auto rhs =
         lowerVariadicAndInverterOp(op, operands.drop_front(firstHalf),
                                    inverts.drop_front(firstHalf), rewriter);
-    return rewriter.create<AndInverterOp>(op.getLoc(), lhs, rhs);
+    return AndInverterOp::create(rewriter, op.getLoc(), lhs, rhs);
   }
 
   return Value();

--- a/lib/Dialect/AIG/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/AIG/Transforms/LowerWordToBits.cpp
@@ -64,10 +64,10 @@ struct WordRewritePattern : public OpRewritePattern<AndInverterOp> {
         }
         // Otherwise, we need to extract the bit.
         operands.push_back(
-            rewriter.create<comb::ExtractOp>(op.getLoc(), operand, i, 1));
+            comb::ExtractOp::create(rewriter, op.getLoc(), operand, i, 1));
       }
-      results.push_back(rewriter.create<AndInverterOp>(op.getLoc(), operands,
-                                                       op.getInvertedAttr()));
+      results.push_back(AndInverterOp::create(rewriter, op.getLoc(), operands,
+                                              op.getInvertedAttr()));
     }
 
     rewriter.replaceOpWithNewOp<comb::ConcatOp>(op, results);

--- a/lib/Dialect/Arc/ArcDialect.cpp
+++ b/lib/Dialect/Arc/ArcDialect.cpp
@@ -66,7 +66,7 @@ Operation *ArcDialect::materializeConstant(OpBuilder &builder, Attribute value,
   // Integer constants.
   if (auto intType = dyn_cast<IntegerType>(type))
     if (auto attrValue = dyn_cast<IntegerAttr>(value))
-      return builder.create<hw::ConstantOp>(loc, type, attrValue);
+      return hw::ConstantOp::create(builder, loc, type, attrValue);
 
   // Parameter expressions materialize into hw.param.value.
   auto *parentOp = builder.getBlock()->getParentOp();
@@ -74,7 +74,7 @@ Operation *ArcDialect::materializeConstant(OpBuilder &builder, Attribute value,
   if (!curModule)
     curModule = parentOp->getParentOfType<hw::HWModuleOp>();
   if (curModule && isValidParameterExpression(value, curModule))
-    return builder.create<hw::ParamValueOp>(loc, type, value);
+    return hw::ParamValueOp::create(builder, loc, type, value);
 
   return nullptr;
 }

--- a/lib/Dialect/Arc/ArcFolds.cpp
+++ b/lib/Dialect/Arc/ArcFolds.cpp
@@ -158,8 +158,8 @@ static bool removeUnusedClockDomainOutputs(ClockDomainOp op,
 
   rewriter.setInsertionPoint(op);
 
-  auto newDomain = rewriter.create<ClockDomainOp>(
-      op.getLoc(), resultTypes, op.getInputs(), op.getClock());
+  auto newDomain = ClockDomainOp::create(rewriter, op.getLoc(), resultTypes,
+                                         op.getInputs(), op.getClock());
   rewriter.inlineRegionBefore(op.getBody(), newDomain.getBody(),
                               newDomain->getRegion(0).begin());
 

--- a/lib/Dialect/Arc/ArcReductions.cpp
+++ b/lib/Dialect/Arc/ArcReductions.cpp
@@ -29,9 +29,9 @@ struct StateElimination : public OpReduction<StateOp> {
   LogicalResult rewrite(StateOp stateOp) override {
     OpBuilder builder(stateOp);
     ValueRange results =
-        builder
-            .create<arc::CallOp>(stateOp.getLoc(), stateOp->getResultTypes(),
-                                 stateOp.getArcAttr(), stateOp.getInputs())
+        arc::CallOp::create(builder, stateOp.getLoc(),
+                            stateOp->getResultTypes(), stateOp.getArcAttr(),
+                            stateOp.getInputs())
             ->getResults();
     stateOp.replaceAllUsesWith(results);
     stateOp.erase();

--- a/lib/Dialect/Arc/Transforms/AddTaps.cpp
+++ b/lib/Dialect/Arc/Transforms/AddTaps.cpp
@@ -66,7 +66,7 @@ struct AddTapsPass : public arc::impl::AddTapsBase<AddTapsPass> {
 
     OpBuilder builder(wireOp);
     if (!readOp)
-      readOp = builder.create<sv::ReadInOutOp>(wireOp.getLoc(), wireOp);
+      readOp = sv::ReadInOutOp::create(builder, wireOp.getLoc(), wireOp);
     buildTap(builder, readOp.getLoc(), readOp, wireOp.getName());
   }
 
@@ -95,7 +95,7 @@ struct AddTapsPass : public arc::impl::AddTapsBase<AddTapsPass> {
       return;
     if (isa<seq::ClockType>(value.getType()))
       value = builder.createOrFold<seq::FromClockOp>(loc, value);
-    builder.create<arc::TapOp>(loc, value, name);
+    arc::TapOp::create(builder, loc, value, name);
   }
 };
 } // namespace

--- a/lib/Dialect/Arc/Transforms/AllocateState.cpp
+++ b/lib/Dialect/Arc/Transforms/AllocateState.cpp
@@ -135,7 +135,7 @@ void AllocateStatePass::allocateOps(Value storage, Block *block,
       if (!getter || !result.getDefiningOp<AllocStorageOp>()) {
         ImplicitLocOpBuilder builder(result.getLoc(), user);
         getter =
-            builder.create<StorageGetOp>(result.getType(), storage, offset);
+            StorageGetOp::create(builder, result.getType(), storage, offset);
         getters.push_back(getter);
         opOrder[getter] = userOrder;
       } else if (userOrder < opOrder.lookup(getter)) {
@@ -152,8 +152,8 @@ void AllocateStatePass::allocateOps(Value storage, Block *block,
     storageOwner = cast<BlockArgument>(storage).getOwner()->getParentOp();
 
   if (storageOwner->isProperAncestor(block->getParentOp())) {
-    auto substorage = builder.create<AllocStorageOp>(
-        block->getParentOp()->getLoc(),
+    auto substorage = AllocStorageOp::create(
+        builder, block->getParentOp()->getLoc(),
         StorageType::get(&getContext(), currentByte), storage);
     for (auto *op : ops)
       op->replaceUsesOfWith(storage, substorage);

--- a/lib/Dialect/Arc/Transforms/FindInitialVectors.cpp
+++ b/lib/Dialect/Arc/Transforms/FindInitialVectors.cpp
@@ -219,7 +219,7 @@ Vectorizer::vectorize(FindInitialVectorsPass::StatisticVars &stat) {
     // Now construct the `VectorizeOp`
     ImplicitLocOpBuilder builder(ops[0]->getLoc(), ops[0]);
     auto vectorizeOp =
-        builder.create<VectorizeOp>(resultTypes, operandValueRanges);
+        VectorizeOp::create(builder, resultTypes, operandValueRanges);
 
     // Now we have the operands, results and attributes, now we need to get
     // the blocks.
@@ -245,7 +245,7 @@ Vectorizer::vectorize(FindInitialVectorsPass::StatisticVars &stat) {
 
     auto *clonedOp = builder.clone(*ops[0], argMapping);
     // `VectorizeReturnOp`
-    builder.create<VectorizeReturnOp>(clonedOp->getResult(0));
+    VectorizeReturnOp::create(builder, clonedOp->getResult(0));
 
     // Now replace the original ops with the vectorized ops
     for (auto [op, result] : llvm::zip(ops, vectorizeOp->getResults())) {

--- a/lib/Dialect/Arc/Transforms/InferStateProperties.cpp
+++ b/lib/Dialect/Arc/Transforms/InferStateProperties.cpp
@@ -148,10 +148,10 @@ static void setResetOperandOfStateOp(arc::StateOp stateOp,
   ImplicitLocOpBuilder builder(stateOp.getLoc(), stateOp);
 
   if (stateOp.getEnable())
-    resetCond = builder.create<comb::AndOp>(stateOp.getEnable(), resetCond);
+    resetCond = comb::AndOp::create(builder, stateOp.getEnable(), resetCond);
 
   if (stateOp.getReset())
-    resetCond = builder.create<comb::OrOp>(stateOp.getReset(), resetCond);
+    resetCond = comb::OrOp::create(builder, stateOp.getReset(), resetCond);
 
   stateOp.getResetMutable().assign(resetCond);
 }
@@ -192,25 +192,24 @@ applyEnableTransformation(arc::DefineOp arcOp, arc::StateOp stateOp,
 
   Value enableCond =
       stateOp.getInputs()[enableInfos[0].condition.getArgNumber()];
-  Value one = builder.create<hw::ConstantOp>(builder.getI1Type(), -1);
+  Value one = hw::ConstantOp::create(builder, builder.getI1Type(), -1);
   if (enableInfos[0].isDisable) {
     inputs[enableInfos[0].condition.getArgNumber()] =
-        builder.create<hw::ConstantOp>(builder.getI1Type(), 0);
-    enableCond = builder.create<comb::XorOp>(enableCond, one);
+        hw::ConstantOp::create(builder, builder.getI1Type(), 0);
+    enableCond = comb::XorOp::create(builder, enableCond, one);
   } else {
     inputs[enableInfos[0].condition.getArgNumber()] = one;
   }
 
   if (stateOp.getEnable())
-    enableCond = builder.create<comb::AndOp>(stateOp.getEnable(), enableCond);
+    enableCond = comb::AndOp::create(builder, stateOp.getEnable(), enableCond);
 
   stateOp.getEnableMutable().assign(enableCond);
 
   for (size_t i = 0, e = outputOp.getOutputs().size(); i < e; ++i) {
     if (enableInfos[i].selfArg.hasOneUse())
-      inputs[enableInfos[i].selfArg.getArgNumber()] =
-          builder.create<hw::ConstantOp>(stateOp.getLoc(),
-                                         enableInfos[i].selfArg.getType(), 0);
+      inputs[enableInfos[i].selfArg.getArgNumber()] = hw::ConstantOp::create(
+          builder, stateOp.getLoc(), enableInfos[i].selfArg.getType(), 0);
   }
 
   stateOp.getInputsMutable().assign(inputs);

--- a/lib/Dialect/Arc/Transforms/IsolateClocks.cpp
+++ b/lib/Dialect/Arc/Transforms/IsolateClocks.cpp
@@ -113,9 +113,9 @@ ClockDomainOp ClockDomain::materialize(OpBuilder &materializeBuilder,
   computeCrossingValues(inputs, outputs);
 
   // Add the terminator and clock domain outputs and rewire the SSA value uses
-  auto outputOp = builder.create<arc::OutputOp>(loc, outputs);
-  auto clockDomainOp = materializeBuilder.create<ClockDomainOp>(
-      loc, ValueRange(outputs).getTypes(), inputs, clock);
+  auto outputOp = arc::OutputOp::create(builder, loc, outputs);
+  auto clockDomainOp = ClockDomainOp::create(
+      materializeBuilder, loc, ValueRange(outputs).getTypes(), inputs, clock);
   for (auto [domainOutput, val] :
        llvm::zip(clockDomainOp.getOutputs(), outputOp->getOperands())) {
     val.replaceUsesWithIf(domainOutput, [&](OpOperand &operand) {

--- a/lib/Dialect/Arc/Transforms/LowerArcsToFuncs.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArcsToFuncs.cpp
@@ -42,8 +42,8 @@ struct DefineOpLowering : public OpConversionPattern<arc::DefineOp> {
   LogicalResult
   matchAndRewrite(arc::DefineOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto func = rewriter.create<mlir::func::FuncOp>(op.getLoc(), op.getName(),
-                                                    op.getFunctionType());
+    auto func = mlir::func::FuncOp::create(rewriter, op.getLoc(), op.getName(),
+                                           op.getFunctionType());
     func->setAttr(
         "llvm.linkage",
         LLVM::LinkageAttr::get(getContext(), LLVM::linkage::Linkage::Internal));

--- a/lib/Dialect/Arc/Transforms/LowerClocksToFuncs.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerClocksToFuncs.cpp
@@ -125,7 +125,7 @@ LogicalResult LowerClocksToFuncsPass::lowerClock(Operation *clockOp,
 
   // Add a return op to the end of the body.
   auto builder = OpBuilder::atBlockEnd(&clockRegion.front());
-  builder.create<func::ReturnOp>(clockOp->getLoc());
+  func::ReturnOp::create(builder, clockOp->getLoc());
 
   // Pick a name for the clock function.
   SmallString<32> funcName;
@@ -137,8 +137,8 @@ LogicalResult LowerClocksToFuncsPass::lowerClock(Operation *clockOp,
   else if (isa<FinalOp>(clockOp))
     funcName.append("_final");
 
-  auto funcOp = funcBuilder.create<func::FuncOp>(
-      clockOp->getLoc(), funcName,
+  auto funcOp = func::FuncOp::create(
+      funcBuilder, clockOp->getLoc(), funcName,
       builder.getFunctionType({modelStorageArg.getType()}, {}));
   symbolTable->insert(funcOp); // uniquifies the name
   LLVM_DEBUG(llvm::dbgs() << "  - Created function `" << funcOp.getSymName()

--- a/lib/Dialect/Arc/Transforms/MakeTables.cpp
+++ b/lib/Dialect/Arc/Transforms/MakeTables.cpp
@@ -119,7 +119,7 @@ void MakeTablesPass::runOnArc(DefineOp defineOp) {
   SmallVector<Value> inputsToConcat(defineOp.getArguments());
   std::reverse(inputsToConcat.begin(), inputsToConcat.end());
   auto concatInputs = inputsToConcat.size() > 1
-                          ? builder.create<comb::ConcatOp>(inputsToConcat)
+                          ? comb::ConcatOp::create(builder, inputsToConcat)
                           : inputsToConcat[0];
 
   // Compute a lookup table for every output.
@@ -170,10 +170,10 @@ void MakeTablesPass::runOnArc(DefineOp defineOp) {
   // Create the table lookup ops.
   for (auto [table, outputOperand] :
        llvm::zip(tables, outputOp->getOpOperands())) {
-    auto array = builder.create<hw::AggregateConstantOp>(
-        ArrayType::get(outputOperand.get().getType(), numTableEntries),
+    auto array = hw::AggregateConstantOp::create(
+        builder, ArrayType::get(outputOperand.get().getType(), numTableEntries),
         builder.getArrayAttr(table));
-    outputOperand.set(builder.create<hw::ArrayGetOp>(array, concatInputs));
+    outputOperand.set(hw::ArrayGetOp::create(builder, array, concatInputs));
   }
 
   for (auto *op : tabularizedOps) {

--- a/lib/Dialect/Arc/Transforms/MuxToControlFlow.cpp
+++ b/lib/Dialect/Arc/Transforms/MuxToControlFlow.cpp
@@ -185,13 +185,13 @@ static void doConversion(Operation *op, BranchInfo info,
 
   // Build the scf.if operation with the scf.yields inside.
   ImplicitLocOpBuilder builder(op->getLoc(), op);
-  mlir::scf::IfOp ifOp = builder.create<mlir::scf::IfOp>(
-      info.condition,
+  mlir::scf::IfOp ifOp = mlir::scf::IfOp::create(
+      builder, info.condition,
       [&](OpBuilder &builder, Location loc) {
-        builder.create<mlir::scf::YieldOp>(loc, info.trueValue);
+        mlir::scf::YieldOp::create(builder, loc, info.trueValue);
       },
       [&](OpBuilder &builder, Location loc) {
-        builder.create<mlir::scf::YieldOp>(loc, info.falseValue);
+        mlir::scf::YieldOp::create(builder, loc, info.falseValue);
       });
 
   op->getResult(0).replaceAllUsesWith(ifOp.getResult(0));

--- a/lib/Dialect/Arc/Transforms/SplitFuncs.cpp
+++ b/lib/Dialect/Arc/Transforms/SplitFuncs.cpp
@@ -112,7 +112,7 @@ LogicalResult SplitFuncsPass::lowerFunc(FuncOp funcOp) {
         outValues.push_back(el);
     });
     opBuilder.setInsertionPointToEnd(currentBlock);
-    opBuilder.create<ReturnOp>(funcOp->getLoc(), outValues);
+    ReturnOp::create(opBuilder, funcOp->getLoc(), outValues);
   }
   // Create and populate new FuncOps
   for (long unsigned i = 0; i < blocks.size() - 1; ++i) {
@@ -132,8 +132,8 @@ LogicalResult SplitFuncsPass::lowerFunc(FuncOp funcOp) {
     funcName.append("_split_func");
     funcName.append(std::to_string(i));
     auto newFunc =
-        opBuilder.create<FuncOp>(funcOp->getLoc(), funcName,
-                                 opBuilder.getFunctionType(argTypes, outTypes));
+        FuncOp::create(opBuilder, funcOp->getLoc(), funcName,
+                       opBuilder.getFunctionType(argTypes, outTypes));
     ++numFuncsCreated;
     symbolTable->insert(newFunc);
     auto *funcBlock = newFunc.addEntryBlock();
@@ -150,8 +150,8 @@ LogicalResult SplitFuncsPass::lowerFunc(FuncOp funcOp) {
     for (auto pair : argMap)
       replaceAllUsesInRegionWith(pair.first, pair.second, newFunc.getRegion());
     opBuilder.setInsertionPointToStart(blocks[i + 1]);
-    Operation *callOp = opBuilder.create<func::CallOp>(
-        funcOp->getLoc(), outTypes, funcName, args);
+    Operation *callOp = func::CallOp::create(opBuilder, funcOp->getLoc(),
+                                             outTypes, funcName, args);
     auto callResults = callOp->getResults();
     argMap.clear();
     for (unsigned long k = 0; k < outValues.size(); ++k)

--- a/lib/Dialect/Arc/Transforms/SplitLoops.cpp
+++ b/lib/Dialect/Arc/Transforms/SplitLoops.cpp
@@ -161,7 +161,7 @@ void Splitter::run(Block &block, DenseMap<Operation *, APInt> &coloring) {
 
   // Create the final `arc.output` op for each of the splits.
   for (auto &split : splits)
-    split->builder.create<arc::OutputOp>(loc, split->exportedValues);
+    arc::OutputOp::create(split->builder, loc, split->exportedValues);
 }
 
 /// Get or create the split for a given operation color.
@@ -291,10 +291,11 @@ void SplitLoopsPass::splitArc(Namespace &arcNamespace, DefineOp defOp,
     if (splitter.splits.size() > 1)
       splitName = arcNamespace.newName(defOp.getSymName() + "_split_" +
                                        Twine(split->index));
-    auto splitArc = builder.create<DefineOp>(
-        splitName, builder.getFunctionType(
-                       split->block->getArgumentTypes(),
-                       split->block->getTerminator()->getOperandTypes()));
+    auto splitArc =
+        DefineOp::create(builder, splitName,
+                         builder.getFunctionType(
+                             split->block->getArgumentTypes(),
+                             split->block->getTerminator()->getOperandTypes()));
     splitArc.getBody().push_back(split->block.release());
     splitArcs.push_back(splitArc);
     ++numArcsCreated;
@@ -365,7 +366,7 @@ void SplitLoopsPass::replaceArcUse(CallOpInterface arcUse,
     if (!getMappedValuesOrSchedule(split->importedValues, operands))
       continue;
 
-    auto newUse = builder.create<CallOp>(splitDef, operands);
+    auto newUse = CallOp::create(builder, splitDef, operands);
     allArcUses.insert(newUse);
     newUses[split->index] = newUse;
 

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -138,9 +138,8 @@ void StripSVPass::runOnOperation() {
         Value next;
         // Note: this register will have an sync reset regardless.
         if (reg.hasReset())
-          next = builder.create<comb::MuxOp>(reg.getLoc(), reg.getReset(),
-                                             reg.getResetValue(), reg.getNext(),
-                                             false);
+          next = comb::MuxOp::create(builder, reg.getLoc(), reg.getReset(),
+                                     reg.getResetValue(), reg.getNext(), false);
         else
           next = reg.getNext();
 
@@ -154,9 +153,9 @@ void StripSVPass::runOnOperation() {
               IntegerAttr::get(reg.getType(), *reg.getPreset()));
         }
 
-        Value compReg = builder.create<seq::CompRegOp>(
-            reg.getLoc(), next.getType(), next, reg.getClk(), reg.getNameAttr(),
-            Value{}, Value{}, /*initialValue*/ presetValue,
+        Value compReg = seq::CompRegOp::create(
+            builder, reg.getLoc(), next.getType(), next, reg.getClk(),
+            reg.getNameAttr(), Value{}, Value{}, /*initialValue*/ presetValue,
             reg.getInnerSymAttr());
         reg.replaceAllUsesWith(compReg);
         opsToDelete.push_back(reg);
@@ -169,9 +168,9 @@ void StripSVPass::runOnOperation() {
         auto modName = instOp.getModuleNameAttr().getAttr();
         ImplicitLocOpBuilder builder(instOp.getLoc(), instOp);
         if (clockGateModuleNames.contains(modName)) {
-          auto gated = builder.create<seq::ClockGateOp>(
-              instOp.getOperand(0), instOp.getOperand(1), instOp.getOperand(2),
-              hw::InnerSymAttr{});
+          auto gated = seq::ClockGateOp::create(
+              builder, instOp.getOperand(0), instOp.getOperand(1),
+              instOp.getOperand(2), hw::InnerSymAttr{});
           instOp.replaceAllUsesWith(gated);
           opsToDelete.push_back(instOp);
         }

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -601,9 +601,9 @@ static void buildComponentLike(OpBuilder &builder, OperationState &result,
   // Insert the WiresOp and ControlOp.
   IRRewriter::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(body);
-  builder.create<WiresOp>(result.location);
+  WiresOp::create(builder, result.location);
   if (!combinational)
-    builder.create<ControlOp>(result.location);
+    ControlOp::create(builder, result.location);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2437,12 +2437,12 @@ static LogicalResult commonTailPatternWithSeq(IfOpTy ifOp,
   // this IfOp is nested in a ParOp. This avoids unintentionally
   // parallelizing the pulled out EnableOps.
   rewriter.setInsertionPointAfter(ifOp);
-  SeqOpTy seqOp = rewriter.create<SeqOpTy>(ifOp.getLoc());
+  SeqOpTy seqOp = SeqOpTy::create(rewriter, ifOp.getLoc());
   Block *body = seqOp.getBodyBlock();
   ifOp->remove();
   body->push_back(ifOp);
   rewriter.setInsertionPointToEnd(body);
-  rewriter.create<EnableOp>(seqOp.getLoc(), lastThenEnableOp->getGroupName());
+  EnableOp::create(rewriter, seqOp.getLoc(), lastThenEnableOp->getGroupName());
 
   // Erase the common EnableOp from the Then and Else regions.
   rewriter.eraseOp(*lastThenEnableOp);
@@ -2496,7 +2496,7 @@ static LogicalResult commonTailPatternWithPar(OpTy controlOp,
   // the pulled out EnableOps.
   rewriter.setInsertionPointAfter(controlOp);
 
-  ParOpTy parOp = rewriter.create<ParOpTy>(controlOp.getLoc());
+  ParOpTy parOp = ParOpTy::create(rewriter, controlOp.getLoc());
   Block *body = parOp.getBodyBlock();
   controlOp->remove();
   body->push_back(controlOp);
@@ -2504,7 +2504,7 @@ static LogicalResult commonTailPatternWithPar(OpTy controlOp,
   // counterparts in the Then and Else regions.
   rewriter.setInsertionPointToEnd(body);
   for (StringRef groupName : groupNames)
-    rewriter.create<EnableOp>(parOp.getLoc(), groupName);
+    EnableOp::create(rewriter, parOp.getLoc(), groupName);
 
   return success();
 }

--- a/lib/Dialect/Calyx/Transforms/AffinePloopUnparallelize.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffinePloopUnparallelize.cpp
@@ -79,8 +79,8 @@ public:
     SmallVector<scf::IndexSwitchOp> simplifiableIndexSwitchOps =
         collectSimplifiableIndexSwitchOps(affineParallelOp, factor);
 
-    auto outerLoop = rewriter.create<affine::AffineForOp>(
-        loc, lowerBound, rewriter.getDimIdentityMap(), upperBound,
+    auto outerLoop = affine::AffineForOp::create(
+        rewriter, loc, lowerBound, rewriter.getDimIdentityMap(), upperBound,
         rewriter.getDimIdentityMap(), step * factor);
 
     rewriter.setInsertionPointToStart(outerLoop.getBody());
@@ -89,8 +89,8 @@ public:
         /*results=*/rewriter.getAffineConstantExpr(0), rewriter.getContext());
     AffineMap ubMap = AffineMap::get(
         0, 0, rewriter.getAffineConstantExpr(factor), rewriter.getContext());
-    auto innerParallel = rewriter.create<affine::AffineParallelOp>(
-        loc, /*resultTypes=*/TypeRange(),
+    auto innerParallel = affine::AffineParallelOp::create(
+        rewriter, loc, /*resultTypes=*/TypeRange(),
         /*reductions=*/SmallVector<arith::AtomicRMWKind>(),
         /*lowerBoundsMap=*/lbMap, /*lowerBoundsOperands=*/SmallVector<Value>(),
         /*upperBoundsMap=*/ubMap, /*upperBoundsOperands=*/SmallVector<Value>(),
@@ -109,8 +109,8 @@ public:
         2, 0, rewriter.getAffineDimExpr(0) + rewriter.getAffineDimExpr(1),
         rewriter.getContext());
 
-    auto newIndex = rewriter.create<affine::AffineApplyOp>(
-        loc, addMap,
+    auto newIndex = affine::AffineApplyOp::create(
+        rewriter, loc, addMap,
         ValueRange{outerLoop.getInductionVar(), innerParallel.getIVs()[0]});
 
     Block *srcBlock = affineParallelOp.getBody();
@@ -133,7 +133,7 @@ public:
     });
 
     rewriter.setInsertionPointToEnd(destBlock);
-    rewriter.create<affine::AffineYieldOp>(loc);
+    affine::AffineYieldOp::create(rewriter, loc);
 
     for (auto indexSwitchOp : simplifiableIndexSwitchOps) {
       indexSwitchOp.setOperand(innerParallel.getIVs().front());

--- a/lib/Dialect/Calyx/Transforms/AffineToSCF.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffineToSCF.cpp
@@ -56,7 +56,7 @@ public:
     Location loc = affineParallelOp.getLoc();
     SmallVector<Value, 8> steps;
     for (int64_t step : affineParallelSteps)
-      steps.push_back(rewriter.create<arith::ConstantIndexOp>(loc, step));
+      steps.push_back(arith::ConstantIndexOp::create(rewriter, loc, step));
 
     auto upperBoundTuple = mlir::affine::expandAffineMap(
         rewriter, loc, affineParallelOp.getUpperBoundsMap(),
@@ -69,8 +69,8 @@ public:
     auto affineParallelTerminator = cast<affine::AffineYieldOp>(
         affineParallelOp.getBody()->getTerminator());
 
-    scf::ParallelOp scfParallelOp = rewriter.create<scf::ParallelOp>(
-        loc, *lowerBoundTuple, *upperBoundTuple, steps,
+    scf::ParallelOp scfParallelOp = scf::ParallelOp::create(
+        rewriter, loc, *lowerBoundTuple, *upperBoundTuple, steps,
         /*bodyBuilderFn=*/nullptr);
     scfParallelOp->setAttr("calyx.unroll",
                            affineParallelOp->getAttr("calyx.unroll"));

--- a/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
@@ -24,7 +24,7 @@ calyx::RegisterOp createRegister(Location loc, OpBuilder &builder,
                                  Twine prefix) {
   OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(component.getBodyBlock());
-  return builder.create<RegisterOp>(loc, (prefix + "_reg").str(), width);
+  return RegisterOp::create(builder, loc, (prefix + "_reg").str(), width);
 }
 
 hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
@@ -32,8 +32,8 @@ hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
                               size_t value) {
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPointToStart(component.getBodyBlock());
-  return builder.create<hw::ConstantOp>(
-      loc, APInt(width, value, /*isSigned=*/false));
+  return hw::ConstantOp::create(builder, loc,
+                                APInt(width, value, /*isSigned=*/false));
 }
 
 calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
@@ -43,8 +43,8 @@ calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
                                  StringRef componentName) {
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPointToStart(component.getBodyBlock());
-  return builder.create<InstanceOp>(loc, resultTypes, instanceName,
-                                    componentName);
+  return InstanceOp::create(builder, loc, resultTypes, instanceName,
+                            componentName);
 }
 
 std::string getInstanceName(mlir::func::CallOp callOp) {

--- a/lib/Dialect/Calyx/Transforms/ClkResetInsertion.cpp
+++ b/lib/Dialect/Calyx/Transforms/ClkResetInsertion.cpp
@@ -45,7 +45,7 @@ static void doPortPassthrough(ComponentOp comp, Value fromPort,
     for (auto port : cell.getInputPorts()) {
       if (!cell.portInfo(port).hasAttribute(portID))
         continue;
-      builder.create<AssignOp>(cell.getLoc(), port, fromPort);
+      AssignOp::create(builder, cell.getLoc(), port, fromPort);
     }
   }
 }

--- a/lib/Dialect/Calyx/Transforms/GoInsertion.cpp
+++ b/lib/Dialect/Calyx/Transforms/GoInsertion.cpp
@@ -43,13 +43,13 @@ void GoInsertionPass::runOnOperation() {
 
   OpBuilder builder(wiresOp->getRegion(0));
   auto undefinedOp =
-      builder.create<UndefinedOp>(wiresOp->getLoc(), builder.getI1Type());
+      UndefinedOp::create(builder, wiresOp->getLoc(), builder.getI1Type());
 
   wiresOp.walk([&](GroupOp group) {
     OpBuilder builder(group->getRegion(0));
     // Since the source of a GroupOp's go signal isn't set until the
     // the Compile Control pass, use an undefined value.
-    auto goOp = builder.create<GroupGoOp>(group->getLoc(), undefinedOp);
+    auto goOp = GroupGoOp::create(builder, group->getLoc(), undefinedOp);
 
     updateGroupAssignmentGuards(builder, group, goOp);
   });

--- a/lib/Dialect/Calyx/Transforms/RemoveGroups.cpp
+++ b/lib/Dialect/Calyx/Transforms/RemoveGroups.cpp
@@ -54,8 +54,8 @@ static void modifyGroupOperations(ComponentOp component) {
       // Replace `calyx.group_done %0, %1 ? : i1`
       //    with `calyx.assign %done, %0, %1 ? : i1`
       auto assignOp =
-          builder.create<AssignOp>(group->getLoc(), component.getDonePort(),
-                                   groupDone.getSrc(), groupDone.getGuard());
+          AssignOp::create(builder, group->getLoc(), component.getDonePort(),
+                           groupDone.getSrc(), groupDone.getGuard());
       groupDone->replaceAllUsesWith(assignOp);
     } else {
       // Replace calyx.group_go's uses with its guard, e.g.

--- a/lib/Dialect/Comb/CombDialect.cpp
+++ b/lib/Dialect/Comb/CombDialect.cpp
@@ -44,15 +44,15 @@ Operation *CombDialect::materializeConstant(OpBuilder &builder, Attribute value,
   // Integer constants.
   if (auto intType = dyn_cast<IntegerType>(type))
     if (auto attrValue = dyn_cast<IntegerAttr>(value))
-      return builder.create<hw::ConstantOp>(loc, type, attrValue);
+      return hw::ConstantOp::create(builder, loc, type, attrValue);
 
   // Parameter expressions materialize into hw.param.value.
-  auto parentOp = builder.getBlock()->getParentOp();
+  auto *parentOp = builder.getBlock()->getParentOp();
   auto curModule = dyn_cast<hw::HWModuleOp>(parentOp);
   if (!curModule)
     curModule = parentOp->getParentOfType<hw::HWModuleOp>();
   if (curModule && isValidParameterExpression(value, curModule))
-    return builder.create<hw::ParamValueOp>(loc, type, value);
+    return hw::ParamValueOp::create(builder, loc, type, value);
 
   return nullptr;
 }

--- a/lib/Dialect/Comb/Transforms/IntRangeOptimizations.cpp
+++ b/lib/Dialect/Comb/Transforms/IntRangeOptimizations.cpp
@@ -89,16 +89,16 @@ struct CombOpNarrow : public OpRewritePattern<CombOpTy> {
 
     // Extract the lsbs from each operand
     auto extractLhsOp =
-        rewriter.create<comb::ExtractOp>(loc, replaceType, lhs, 0);
+        comb::ExtractOp::create(rewriter, loc, replaceType, lhs, 0);
     auto extractRhsOp =
-        rewriter.create<comb::ExtractOp>(loc, replaceType, rhs, 0);
-    auto narrowOp = rewriter.create<CombOpTy>(loc, extractLhsOp, extractRhsOp);
+        comb::ExtractOp::create(rewriter, loc, replaceType, rhs, 0);
+    auto narrowOp = CombOpTy::create(rewriter, loc, extractLhsOp, extractRhsOp);
 
     // Concatenate zeros to match the original operator width
     auto zero =
-        rewriter.create<hw::ConstantOp>(loc, APInt::getZero(removeWidth));
-    auto replaceOp = rewriter.create<comb::ConcatOp>(
-        loc, op.getType(), ValueRange{zero, narrowOp});
+        hw::ConstantOp::create(rewriter, loc, APInt::getZero(removeWidth));
+    auto replaceOp = comb::ConcatOp::create(rewriter, loc, op.getType(),
+                                            ValueRange{zero, narrowOp});
 
     rewriter.replaceOp(op, replaceOp);
     return success();

--- a/lib/Dialect/Comb/Transforms/LowerComb.cpp
+++ b/lib/Dialect/Comb/Transforms/LowerComb.cpp
@@ -42,7 +42,7 @@ private:
         getMux(loc, b, t, f, table.drop_front(half), inputs.drop_front());
     Value if0 =
         getMux(loc, b, t, f, table.drop_back(half), inputs.drop_front());
-    return b.create<MuxOp>(loc, inputs.front(), if1, if0, false);
+    return MuxOp::create(b, loc, inputs.front(), if1, if0, false);
   }
 
 public:
@@ -52,8 +52,10 @@ public:
     SmallVector<bool> table(
         llvm::map_range(op.getLookupTableAttr().getAsValueRange<IntegerAttr>(),
                         [](const APInt &a) { return !a.isZero(); }));
-    Value t = b.create<hw::ConstantOp>(loc, b.getIntegerAttr(b.getI1Type(), 1));
-    Value f = b.create<hw::ConstantOp>(loc, b.getIntegerAttr(b.getI1Type(), 0));
+    Value t =
+        hw::ConstantOp::create(b, loc, b.getIntegerAttr(b.getI1Type(), 1));
+    Value f =
+        hw::ConstantOp::create(b, loc, b.getIntegerAttr(b.getI1Type(), 0));
 
     Value tree = getMux(loc, b, t, f, table, op.getInputs());
     b.modifyOpInPlace(tree.getDefiningOp(), [&]() {

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -158,8 +158,8 @@ struct FoldAddIntoCompress : public OpRewritePattern<comb::AddOp> {
       return failure();
 
     // Create a new CompressOp with all collected operands
-    auto newCompressOp = rewriter.create<datapath::CompressOp>(
-        addOp.getLoc(), newCompressOperands, 2);
+    auto newCompressOp = datapath::CompressOp::create(rewriter, addOp.getLoc(),
+                                                      newCompressOperands, 2);
 
     // Replace the original AddOp with a new add(compress(inputs))
     rewriter.replaceOpWithNewOp<comb::AddOp>(addOp, newCompressOp.getResults(),
@@ -235,11 +235,11 @@ struct ReduceNumPartialProducts : public OpRewritePattern<PartialProductOp> {
       maxNonZeroBits = std::max(maxNonZeroBits, nonZeroBits);
     }
 
-    auto newPP = rewriter.create<datapath::PartialProductOp>(
-        op.getLoc(), op.getOperands(), maxNonZeroBits);
+    auto newPP = datapath::PartialProductOp::create(
+        rewriter, op.getLoc(), op.getOperands(), maxNonZeroBits);
 
-    auto zero = rewriter.create<hw::ConstantOp>(op.getLoc(),
-                                                APInt::getZero(inputWidth));
+    auto zero = hw::ConstantOp::create(rewriter, op.getLoc(),
+                                       APInt::getZero(inputWidth));
 
     // Collect newPP results and pad with zeros if needed
     SmallVector<Value> newResults(newPP.getResults().begin(),

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -42,7 +42,7 @@ void ESIDialect::initialize() {
 Operation *ESIDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                            Type type, Location loc) {
   if (isa<mlir::UnitAttr>(value))
-    return builder.create<hw::ConstantOp>(loc, builder.getI1Type(), 1);
+    return hw::ConstantOp::create(builder, loc, builder.getI1Type(), 1);
   return builder.getContext()
       ->getOrLoadDialect<hw::HWDialect>()
       ->materializeConstant(builder, value, type, loc);

--- a/lib/Dialect/ESI/ESIFolds.cpp
+++ b/lib/Dialect/ESI/ESIFolds.cpp
@@ -21,7 +21,7 @@ LogicalResult WrapValidReadyOp::fold(FoldAdaptor,
     return failure();
   OpBuilder builder(getContext());
   results.push_back(
-      builder.create<NullSourceOp>(getLoc(), getChanOutput().getType())
+      NullSourceOp::create(builder, getLoc(), getChanOutput().getType())
           .getOut());
   results.push_back(IntegerAttr::get(IntegerType::get(getContext(), 1), 1));
   return success();
@@ -51,7 +51,7 @@ LogicalResult WrapFIFOOp::fold(FoldAdaptor,
 
   OpBuilder builder(getContext());
   results.push_back(
-      builder.create<NullSourceOp>(getLoc(), getChanOutput().getType())
+      NullSourceOp::create(builder, getLoc(), getChanOutput().getType())
           .getOut());
   results.push_back(IntegerAttr::get(
       IntegerType::get(getContext(), 1, IntegerType::Signless), 0));

--- a/lib/Dialect/ESI/Passes/ESIAppIDHier.cpp
+++ b/lib/Dialect/ESI/Passes/ESIAppIDHier.cpp
@@ -41,19 +41,19 @@ private:
 
     // Check if we need to create a root node.
     if (path.getPath().empty()) {
-      auto rootOp = OpBuilder::atBlockEnd(getOperation().getBody())
-                        .create<AppIDHierRootOp>(UnknownLoc::get(&getContext()),
-                                                 path.getRoot());
+      auto builder = OpBuilder::atBlockEnd(getOperation().getBody());
+      auto rootOp = AppIDHierRootOp::create(
+          builder, UnknownLoc::get(&getContext()), path.getRoot());
       block = &rootOp.getChildren().emplaceBlock();
     } else {
       Block *parentBlock = getBlock(path.getParent(), opStack.drop_back());
       Operation *op = opStack.back();
       if (auto inst = dyn_cast<hw::InstanceOp>(op)) {
         // Create a normal node underneath the parent AppID.
-        auto node = OpBuilder::atBlockEnd(parentBlock)
-                        .create<AppIDHierNodeOp>(UnknownLoc::get(&getContext()),
-                                                 path.getPath().back(),
-                                                 inst.getModuleNameAttr());
+        auto builder = OpBuilder::atBlockEnd(parentBlock);
+        auto node = AppIDHierNodeOp::create(
+            builder, UnknownLoc::get(&getContext()), path.getPath().back(),
+            inst.getModuleNameAttr());
         block = &node.getChildren().emplaceBlock();
       } else {
         block = parentBlock;

--- a/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
+++ b/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
@@ -123,8 +123,8 @@ void ESIBuildManifestPass::runOnOperation() {
                     ->getRegion(0)
                     .front()
                     .getTerminator());
-    b.create<CompressedManifestOp>(b.getUnknownLoc(),
-                                   BlobAttr::get(ctxt, compressedManifest));
+    CompressedManifestOp::create(b, b.getUnknownLoc(),
+                                 BlobAttr::get(ctxt, compressedManifest));
   } else {
     mod->emitWarning()
         << "zlib not available but required for manifest support";

--- a/lib/Dialect/ESI/Passes/ESILowerBundles.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerBundles.cpp
@@ -85,8 +85,8 @@ void BundlePort::mapInputSignals(OpBuilder &b, Operation *inst, Value,
       }));
   SmallVector<Type, 5> toChannelTypes(llvm::map_range(
       newInputChannels, [](hw::PortInfo port) { return port.type; }));
-  auto unpack = b.create<UnpackBundleOp>(
-      origPort.loc,
+  auto unpack = UnpackBundleOp::create(
+      b, origPort.loc,
       /*bundle=*/inst->getOperand(origPort.argNum), fromChannels);
 
   // Connect the new instance inputs to the results of the unpack.
@@ -106,8 +106,8 @@ void BundlePort::mapOutputSignals(OpBuilder &b, Operation *inst, Value,
       }));
   SmallVector<Type, 5> fromChannelTypes(llvm::map_range(
       newInputChannels, [](hw::PortInfo port) { return port.type; }));
-  auto pack = b.create<PackBundleOp>(
-      origPort.loc, cast<ChannelBundleType>(origPort.type), toChannels);
+  auto pack = PackBundleOp::create(
+      b, origPort.loc, cast<ChannelBundleType>(origPort.type), toChannels);
 
   // Feed the fromChannels into the new instance.
   for (auto [idx, inPort] : llvm::enumerate(newInputChannels))
@@ -141,7 +141,7 @@ void BundlePort::buildInputSignals() {
   PackBundleOp pack;
   if (body) {
     ImplicitLocOpBuilder b(origPort.loc, body, body->begin());
-    pack = b.create<PackBundleOp>(bundleType, newInputValues);
+    pack = PackBundleOp::create(b, bundleType, newInputValues);
     body->getArgument(origPort.argNum).replaceAllUsesWith(pack.getBundle());
   }
 
@@ -179,10 +179,12 @@ void BundlePort::buildOutputSignals() {
   // For an output port, the original bundle must be unpacked into the
   // individual channel ports.
   UnpackBundleOp unpack;
-  if (body)
-    unpack = OpBuilder::atBlockTerminator(body).create<UnpackBundleOp>(
-        origPort.loc, body->getTerminator()->getOperand(origPort.argNum),
-        unpackChannels);
+  if (body) {
+    auto builder = OpBuilder::atBlockTerminator(body);
+    unpack = UnpackBundleOp::create(
+        builder, origPort.loc,
+        body->getTerminator()->getOperand(origPort.argNum), unpackChannels);
+  }
 
   // Build new ports and put the new port info directly into the member
   // variable.

--- a/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
@@ -80,7 +80,7 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
   circt::BackedgeBuilder back(rewriter, loc);
   circt::Backedge wrapReady = back.get(rewriter.getI1Type());
   auto unwrap =
-      rewriter.create<UnwrapValidReadyOp>(loc, stage.getInput(), wrapReady);
+      UnwrapValidReadyOp::create(rewriter, loc, stage.getInput(), wrapReady);
 
   StringRef pipeStageName = "pipelineStage";
   if (auto name = stage->getAttrOfType<StringAttr>("name"))
@@ -92,8 +92,8 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
   operands.push_back(unwrap.getRawOutput());
   operands.push_back(unwrap.getValid());
   operands.push_back(stageReady);
-  auto stageInst = rewriter.create<hw::InstanceOp>(
-      loc, stageModule, pipeStageName, operands, stageParams);
+  auto stageInst = hw::InstanceOp::create(rewriter, loc, stageModule,
+                                          pipeStageName, operands, stageParams);
   auto stageInstResults = stageInst.getResults();
 
   // Set a_ready (from the unwrap) back edge correctly to its output from
@@ -104,8 +104,8 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
   xValid = stageInstResults[2];
 
   // Wrap up the output of the HW stage module.
-  auto wrap = rewriter.create<WrapValidReadyOp>(
-      loc, chPort, rewriter.getI1Type(), x, xValid);
+  auto wrap = WrapValidReadyOp::create(rewriter, loc, chPort,
+                                       rewriter.getI1Type(), x, xValid);
   // Set the stages x_ready backedge correctly.
   stageReady.setValue(wrap.getReady());
 
@@ -134,12 +134,12 @@ LogicalResult NullSourceOpLowering::matchAndRewrite(
   if (width == -1)
     return rewriter.notifyMatchFailure(
         nullop, "NullOp lowering only supports hw types");
-  auto valid =
-      rewriter.create<hw::ConstantOp>(nullop.getLoc(), rewriter.getI1Type(), 0);
+  auto valid = hw::ConstantOp::create(rewriter, nullop.getLoc(),
+                                      rewriter.getI1Type(), 0);
   auto zero =
-      rewriter.create<hw::ConstantOp>(loc, rewriter.getIntegerType(width), 0);
-  auto typedZero = rewriter.create<hw::BitcastOp>(loc, innerType, zero);
-  auto wrap = rewriter.create<WrapValidReadyOp>(loc, typedZero, valid);
+      hw::ConstantOp::create(rewriter, loc, rewriter.getIntegerType(width), 0);
+  auto typedZero = hw::BitcastOp::create(rewriter, loc, innerType, zero);
+  auto wrap = WrapValidReadyOp::create(rewriter, loc, typedZero, valid);
   wrap->setAttr("name", rewriter.getStringAttr("nullsource"));
   rewriter.replaceOp(nullop, {wrap.getChanOutput()});
   return success();
@@ -160,8 +160,8 @@ public:
     UnwrapValidReadyOp unwrap = dyn_cast<UnwrapValidReadyOp>(op);
     if (wrap) {
       if (ChannelType::hasNoConsumers(wrap.getChanOutput())) {
-        auto c1 = rewriter.create<hw::ConstantOp>(wrap.getLoc(),
-                                                  rewriter.getI1Type(), 1);
+        auto c1 = hw::ConstantOp::create(rewriter, wrap.getLoc(),
+                                         rewriter.getI1Type(), 1);
         rewriter.replaceOp(wrap, {nullptr, c1});
         return success();
       }
@@ -276,8 +276,8 @@ public:
                    "Could not find 'unwrap'.");
 
       // Create transaction signal as valid AND ready
-      auto validAndReady = rewriter.create<comb::AndOp>(
-          op.getLoc(), wrapVR.getValid(), unwrapVR.getReady());
+      auto validAndReady = comb::AndOp::create(
+          rewriter, op.getLoc(), wrapVR.getValid(), unwrapVR.getReady());
 
       rewriter.replaceOp(op, {validAndReady, wrapVR.getRawInput()});
       return success();
@@ -298,12 +298,12 @@ public:
                    "Could not find 'unwrap'.");
 
       // Create transaction signal as !empty AND rden
-      auto notEmpty = rewriter.create<comb::XorOp>(
-          op.getLoc(), wrapFIFO.getEmpty(),
-          rewriter.create<hw::ConstantOp>(op.getLoc(),
-                                          rewriter.getBoolAttr(true)));
-      auto transaction = rewriter.create<comb::AndOp>(op.getLoc(), notEmpty,
-                                                      unwrapFIFO.getRden());
+      auto notEmpty = comb::XorOp::create(
+          rewriter, op.getLoc(), wrapFIFO.getEmpty(),
+          hw::ConstantOp::create(rewriter, op.getLoc(),
+                                 rewriter.getBoolAttr(true)));
+      auto transaction = comb::AndOp::create(rewriter, op.getLoc(), notEmpty,
+                                             unwrapFIFO.getRden());
 
       rewriter.replaceOp(op, {transaction, wrapFIFO.getData()});
       return success();
@@ -370,14 +370,15 @@ WrapInterfaceLower::matchAndRewrite(WrapSVInterfaceOp wrap, OpAdaptor adaptor,
     return failure();
 
   auto loc = wrap.getLoc();
-  auto validSignal = rewriter.create<ReadInterfaceSignalOp>(
-      loc, ifaceInstance, ESIHWBuilder::validStr);
+  auto validSignal = ReadInterfaceSignalOp::create(rewriter, loc, ifaceInstance,
+                                                   ESIHWBuilder::validStr);
   Value dataSignal;
-  dataSignal = rewriter.create<ReadInterfaceSignalOp>(loc, ifaceInstance,
-                                                      ESIHWBuilder::dataStr);
-  auto wrapVR = rewriter.create<WrapValidReadyOp>(loc, dataSignal, validSignal);
-  rewriter.create<AssignInterfaceSignalOp>(
-      loc, ifaceInstance, ESIHWBuilder::readyStr, wrapVR.getReady());
+  dataSignal = ReadInterfaceSignalOp::create(rewriter, loc, ifaceInstance,
+                                             ESIHWBuilder::dataStr);
+  auto wrapVR =
+      WrapValidReadyOp::create(rewriter, loc, dataSignal, validSignal);
+  AssignInterfaceSignalOp::create(rewriter, loc, ifaceInstance,
+                                  ESIHWBuilder::readyStr, wrapVR.getReady());
   rewriter.replaceOp(wrap, {wrapVR.getChanOutput()});
   return success();
 }
@@ -415,15 +416,16 @@ LogicalResult UnwrapInterfaceLower::matchAndRewrite(
     return failure();
 
   auto loc = unwrap.getLoc();
-  auto readySignal = rewriter.create<ReadInterfaceSignalOp>(
-      loc, ifaceInstance, ESIHWBuilder::readyStr);
+  auto readySignal = ReadInterfaceSignalOp::create(rewriter, loc, ifaceInstance,
+                                                   ESIHWBuilder::readyStr);
   auto unwrapVR =
-      rewriter.create<UnwrapValidReadyOp>(loc, operands[0], readySignal);
-  rewriter.create<AssignInterfaceSignalOp>(
-      loc, ifaceInstance, ESIHWBuilder::validStr, unwrapVR.getValid());
+      UnwrapValidReadyOp::create(rewriter, loc, operands[0], readySignal);
+  AssignInterfaceSignalOp::create(rewriter, loc, ifaceInstance,
+                                  ESIHWBuilder::validStr, unwrapVR.getValid());
 
-  rewriter.create<AssignInterfaceSignalOp>(
-      loc, ifaceInstance, ESIHWBuilder::dataStr, unwrapVR.getRawOutput());
+  AssignInterfaceSignalOp::create(rewriter, loc, ifaceInstance,
+                                  ESIHWBuilder::dataStr,
+                                  unwrapVR.getRawOutput());
   rewriter.eraseOp(unwrap);
   return success();
 }
@@ -468,14 +470,15 @@ LogicalResult CosimToHostLowering::matchAndRewrite(
   // Set up the egest route to drive the EP's toHost ports.
   auto sendReady = bb.get(rewriter.getI1Type());
   UnwrapValidReadyOp unwrapSend =
-      rewriter.create<UnwrapValidReadyOp>(loc, toHost, sendReady);
+      UnwrapValidReadyOp::create(rewriter, loc, toHost, sendReady);
   Value castedSendData;
   if (width > 0)
-    castedSendData = rewriter.create<hw::BitcastOp>(
-        loc, rewriter.getIntegerType(width), unwrapSend.getRawOutput());
+    castedSendData =
+        hw::BitcastOp::create(rewriter, loc, rewriter.getIntegerType(width),
+                              unwrapSend.getRawOutput());
   else
-    castedSendData = rewriter.create<hw::ConstantOp>(
-        loc, rewriter.getIntegerType(1), rewriter.getBoolAttr(false));
+    castedSendData = hw::ConstantOp::create(
+        rewriter, loc, rewriter.getIntegerType(1), rewriter.getBoolAttr(false));
 
   // Build or get the cached Cosim Endpoint module parameterization.
   Operation *symTable = ep->getParentWithTrait<OpTrait::SymbolTable>();
@@ -489,8 +492,9 @@ LogicalResult CosimToHostLowering::matchAndRewrite(
       unwrapSend.getValid(),
       castedSendData,
   };
-  auto cosimEpModule = rewriter.create<hw::InstanceOp>(
-      loc, endpoint, ep.getIdAttr(), operands, ArrayAttr::get(ctxt, params));
+  auto cosimEpModule =
+      hw::InstanceOp::create(rewriter, loc, endpoint, ep.getIdAttr(), operands,
+                             ArrayAttr::get(ctxt, params));
   sendReady.setValue(cosimEpModule.getResult(0));
 
   // Replace the CosimEndpointOp op.
@@ -547,22 +551,23 @@ LogicalResult CosimFromHostLowering::matchAndRewrite(
 
   // Create replacement Cosim_Endpoint instance.
   Value operands[] = {adaptor.getClk(), adaptor.getRst(), recvReady};
-  auto cosimEpModule = rewriter.create<hw::InstanceOp>(
-      loc, endpoint, ep.getIdAttr(), operands, ArrayAttr::get(ctxt, params));
+  auto cosimEpModule =
+      hw::InstanceOp::create(rewriter, loc, endpoint, ep.getIdAttr(), operands,
+                             ArrayAttr::get(ctxt, params));
 
   // Set up the injest path.
   Value recvDataFromCosim = cosimEpModule.getResult(1);
   Value recvValidFromCosim = cosimEpModule.getResult(0);
   Value castedRecvData;
   if (width > 0)
-    castedRecvData =
-        rewriter.create<hw::BitcastOp>(loc, type.getInner(), recvDataFromCosim);
+    castedRecvData = hw::BitcastOp::create(rewriter, loc, type.getInner(),
+                                           recvDataFromCosim);
   else
-    castedRecvData = rewriter.create<hw::ConstantOp>(
-        loc, rewriter.getIntegerType(0),
+    castedRecvData = hw::ConstantOp::create(
+        rewriter, loc, rewriter.getIntegerType(0),
         rewriter.getIntegerAttr(rewriter.getIntegerType(0), 0));
-  WrapValidReadyOp wrapRecv = rewriter.create<WrapValidReadyOp>(
-      loc, castedRecvData, recvValidFromCosim);
+  WrapValidReadyOp wrapRecv = WrapValidReadyOp::create(
+      rewriter, loc, castedRecvData, recvValidFromCosim);
   recvReady.setValue(wrapRecv.getReady());
 
   // Replace the CosimEndpointOp op.
@@ -615,8 +620,8 @@ LogicalResult ManifestRomLowering::createRomModule(
       {{rewriter.getStringAttr("data"), rewriter.getI64Type(),
         ModulePort::Direction::Output}},
   };
-  auto rom = rewriter.create<HWModuleOp>(
-      loc, rewriter.getStringAttr(manifestRomName), ports);
+  auto rom = HWModuleOp::create(rewriter, loc,
+                                rewriter.getStringAttr(manifestRomName), ports);
   Block *romBody = rom.getBodyBlock();
   rewriter.setInsertionPointToStart(romBody);
   Value clk = romBody->getArgument(0);
@@ -647,25 +652,26 @@ LogicalResult ManifestRomLowering::createRomModule(
   SmallVector<Attribute> wordAttrs;
   for (uint64_t word : words)
     wordAttrs.push_back(rewriter.getI64IntegerAttr(word));
-  auto manifestConstant = rewriter.create<hw::AggregateConstantOp>(
-      loc, hw::UnpackedArrayType::get(rewriter.getI64Type(), words.size()),
+  auto manifestConstant = hw::AggregateConstantOp::create(
+      rewriter, loc,
+      hw::UnpackedArrayType::get(rewriter.getI64Type(), words.size()),
       rewriter.getArrayAttr(wordAttrs));
   auto manifestReg =
-      rewriter.create<sv::RegOp>(loc, manifestConstant.getType());
-  rewriter.create<sv::AssignOp>(loc, manifestReg, manifestConstant);
+      sv::RegOp::create(rewriter, loc, manifestConstant.getType());
+  sv::AssignOp::create(rewriter, loc, manifestReg, manifestConstant);
 
   // Slim down the address, register it, do the lookup, and register the output.
   size_t addrBits = llvm::Log2_64_Ceil(words.size());
   auto slimmedIdx =
-      rewriter.create<comb::ExtractOp>(loc, inputAddress, 0, addrBits);
-  Value inputAddresReg = rewriter.create<seq::CompRegOp>(loc, slimmedIdx, clk);
+      comb::ExtractOp::create(rewriter, loc, inputAddress, 0, addrBits);
+  Value inputAddresReg = seq::CompRegOp::create(rewriter, loc, slimmedIdx, clk);
   auto readIdx =
-      rewriter.create<sv::ArrayIndexInOutOp>(loc, manifestReg, inputAddresReg);
-  auto readData = rewriter.create<sv::ReadInOutOp>(loc, readIdx);
-  Value readDataReg = rewriter.create<seq::CompRegOp>(loc, readData, clk);
+      sv::ArrayIndexInOutOp::create(rewriter, loc, manifestReg, inputAddresReg);
+  auto readData = sv::ReadInOutOp::create(rewriter, loc, readIdx);
+  Value readDataReg = seq::CompRegOp::create(rewriter, loc, readData, clk);
   if (auto *term = romBody->getTerminator())
     rewriter.eraseOp(term);
-  rewriter.create<hw::OutputOp>(loc, ValueRange{readDataReg});
+  hw::OutputOp::create(rewriter, loc, ValueRange{readDataReg});
   return success();
 }
 
@@ -717,38 +723,38 @@ LogicalResult CosimManifestLowering::matchAndRewrite(
   };
   rewriter.setInsertionPointToEnd(
       op->getParentOfType<mlir::ModuleOp>().getBody());
-  auto cosimManifestExternModule = rewriter.create<HWModuleExternOp>(
-      loc, rewriter.getStringAttr("Cosim_Manifest"), ports, "Cosim_Manifest",
-      ArrayAttr::get(ctxt, params));
+  auto cosimManifestExternModule = HWModuleExternOp::create(
+      rewriter, loc, rewriter.getStringAttr("Cosim_Manifest"), ports,
+      "Cosim_Manifest", ArrayAttr::get(ctxt, params));
 
   hw::ModulePortInfo portInfo({});
-  auto manifestMod = rewriter.create<hw::HWModuleOp>(
-      loc, rewriter.getStringAttr("__ESIManifest"), portInfo,
+  auto manifestMod = hw::HWModuleOp::create(
+      rewriter, loc, rewriter.getStringAttr("__ESIManifest"), portInfo,
       [&](OpBuilder &rewriter, const hw::HWModulePortAccessor &) {
         // Assemble the manifest data into a constant.
         SmallVector<Attribute> bytes;
         for (uint8_t b : op.getCompressedManifest().getData())
           bytes.push_back(rewriter.getI8IntegerAttr(b));
-        auto manifestConstant = rewriter.create<hw::AggregateConstantOp>(
-            loc, hw::ArrayType::get(rewriter.getI8Type(), bytes.size()),
+        auto manifestConstant = hw::AggregateConstantOp::create(
+            rewriter, loc,
+            hw::ArrayType::get(rewriter.getI8Type(), bytes.size()),
             rewriter.getArrayAttr(bytes));
         auto manifestLogic =
-            rewriter.create<sv::LogicOp>(loc, manifestConstant.getType());
-        rewriter.create<sv::AssignOp>(loc, manifestLogic, manifestConstant);
-        auto manifest = rewriter.create<sv::ReadInOutOp>(loc, manifestLogic);
+            sv::LogicOp::create(rewriter, loc, manifestConstant.getType());
+        sv::AssignOp::create(rewriter, loc, manifestLogic, manifestConstant);
+        auto manifest = sv::ReadInOutOp::create(rewriter, loc, manifestLogic);
 
         // Then instantiate the external module.
-        rewriter.create<hw::InstanceOp>(
-            loc, cosimManifestExternModule, "__manifest",
-            ArrayRef<Value>({manifest}),
-            rewriter.getArrayAttr({ParamDeclAttr::get(
-                "COMPRESSED_MANIFEST_SIZE",
-                rewriter.getI32IntegerAttr(bytes.size()))}));
+        hw::InstanceOp::create(rewriter, loc, cosimManifestExternModule,
+                               "__manifest", ArrayRef<Value>({manifest}),
+                               rewriter.getArrayAttr({ParamDeclAttr::get(
+                                   "COMPRESSED_MANIFEST_SIZE",
+                                   rewriter.getI32IntegerAttr(bytes.size()))}));
       });
 
   rewriter.setInsertionPoint(op);
-  rewriter.create<hw::InstanceOp>(loc, manifestMod, "__manifest",
-                                  ArrayRef<Value>({}));
+  hw::InstanceOp::create(rewriter, loc, manifestMod, "__manifest",
+                         ArrayRef<Value>({}));
 
   rewriter.eraseOp(op);
   return success();

--- a/lib/Dialect/ESI/Passes/ESILowerTypes.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerTypes.cpp
@@ -56,7 +56,7 @@ private:
                                          ValueRange inputs, Location loc) {
     if (inputs.size() != 1)
       return mlir::Value();
-    auto wrap = b.create<WrapWindow>(loc, resultType, inputs[0]);
+    auto wrap = WrapWindow::create(b, loc, resultType, inputs[0]);
     return wrap.getWindow();
   }
 
@@ -65,7 +65,7 @@ private:
                                            ValueRange inputs, Location loc) {
     if (inputs.size() != 1 || !isa<WindowType>(inputs[0].getType()))
       return mlir::Value();
-    auto unwrap = b.create<UnwrapWindow>(loc, resultType, inputs[0]);
+    auto unwrap = UnwrapWindow::create(b, loc, resultType, inputs[0]);
     return unwrap.getFrame();
   }
 };

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -58,39 +58,40 @@ Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
   // important that this goes first.
   if (auto attrValue = dyn_cast<BoolAttr>(value)) {
     if (isa<BoolType>(type))
-      return builder.create<BoolConstantOp>(loc, type, attrValue);
+      return BoolConstantOp::create(builder, loc, type, attrValue);
     assert((isa<ClockType, AsyncResetType, ResetType>(type) &&
             "BoolAttrs can only be materialized for special constant types."));
-    return builder.create<SpecialConstantOp>(loc, type, attrValue);
+    return SpecialConstantOp::create(builder, loc, type, attrValue);
   }
 
   // Integer constants.
   if (auto attrValue = dyn_cast<IntegerAttr>(value)) {
     if (isa<FIntegerType>(type))
-      return builder.create<FIntegerConstantOp>(loc, type, attrValue);
+      return FIntegerConstantOp::create(builder, loc, type, attrValue);
     // Integer attributes (ui1) might still be special constant types.
     if (attrValue.getValue().getBitWidth() == 1 &&
         isa<ClockType, AsyncResetType, ResetType>(type))
-      return builder.create<SpecialConstantOp>(
-          loc, type, builder.getBoolAttr(attrValue.getValue().isAllOnes()));
+      return SpecialConstantOp::create(
+          builder, loc, type,
+          builder.getBoolAttr(attrValue.getValue().isAllOnes()));
 
     assert((!type_cast<IntType>(type).hasWidth() ||
             (unsigned)type_cast<IntType>(type).getWidthOrSentinel() ==
                 attrValue.getValue().getBitWidth()) &&
            "type/value width mismatch materializing constant");
-    return builder.create<ConstantOp>(loc, type, attrValue);
+    return ConstantOp::create(builder, loc, type, attrValue);
   }
 
   // Aggregate constants.
   if (auto arrayAttr = dyn_cast<ArrayAttr>(value)) {
     if (isa<BundleType, FVectorType>(type))
-      return builder.create<AggregateConstantOp>(loc, type, arrayAttr);
+      return AggregateConstantOp::create(builder, loc, type, arrayAttr);
   }
 
   // String constants.
   if (auto stringAttr = dyn_cast<StringAttr>(value)) {
     if (type_isa<StringType>(type))
-      return builder.create<StringConstantOp>(loc, type, stringAttr);
+      return StringConstantOp::create(builder, loc, type, stringAttr);
   }
 
   return nullptr;

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -181,7 +181,7 @@ FailureOr<size_t> IntrinsicLowerings::lower(FModuleOp mod,
         !isTypeLarger(resultType, inputType))
       return {};
 
-    auto w = builder.create<WireOp>(loc, resultType).getResult();
+    auto w = WireOp::create(builder, loc, resultType).getResult();
     emitConnect(builder, loc, w, inputs.front());
     return w;
   };
@@ -265,8 +265,8 @@ public:
   void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor adaptor,
                PatternRewriter &rewriter) override {
     auto bty = gi.getOutputBundle().getType();
-    auto newop = rewriter.create<PlusArgsValueIntrinsicOp>(
-        gi.op.getLoc(), bty.getElementTypePreservingConst(0),
+    auto newop = PlusArgsValueIntrinsicOp::create(
+        rewriter, gi.op.getLoc(), bty.getElementTypePreservingConst(0),
         bty.getElementTypePreservingConst(1),
         gi.getParamValue<StringAttr>("FORMAT"));
     rewriter.replaceOpWithNewOp<BundleCreateOp>(

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2051,7 +2051,7 @@ void ClassOp::build(::mlir::OpBuilder &odsBuilder,
   auto args = body.getArguments();
   auto loc = odsState.location;
   for (unsigned i = 0, e = ports.size(); i != e; i += 2)
-    odsBuilder.create<PropAssignOp>(loc, args[i + 1], args[i]);
+    PropAssignOp::create(odsBuilder, loc, args[i + 1], args[i]);
 
   odsBuilder.restoreInsertionPoint(prevLoc);
 }
@@ -2413,11 +2413,11 @@ InstanceOp InstanceOp::erasePorts(OpBuilder &builder,
   SmallVector<Attribute> newPortAnnotations =
       removeElementsAtIndices(getPortAnnotations().getValue(), portIndices);
 
-  auto newOp = builder.create<InstanceOp>(
-      getLoc(), newResultTypes, getModuleName(), getName(), getNameKind(),
-      newPortDirections, newPortNames, getAnnotations().getValue(),
-      newPortAnnotations, getLayers(), getLowerToBind(), getDoNotPrint(),
-      getInnerSymAttr());
+  auto newOp = InstanceOp::create(
+      builder, getLoc(), newResultTypes, getModuleName(), getName(),
+      getNameKind(), newPortDirections, newPortNames,
+      getAnnotations().getValue(), newPortAnnotations, getLayers(),
+      getLowerToBind(), getDoNotPrint(), getInnerSymAttr());
 
   for (unsigned oldIdx = 0, newIdx = 0, numOldPorts = getNumResults();
        oldIdx != numOldPorts; ++oldIdx) {
@@ -2487,11 +2487,12 @@ InstanceOp::cloneAndInsertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
   }
 
   // Create a new instance op with the reset inserted.
-  return OpBuilder(*this).create<InstanceOp>(
-      getLoc(), newPortTypes, getModuleName(), getName(), getNameKind(),
-      newPortDirections, newPortNames, getAnnotations().getValue(),
-      newPortAnnos, getLayers(), getLowerToBind(), getDoNotPrint(),
-      getInnerSymAttr());
+  OpBuilder builder(*this);
+  return InstanceOp::create(builder, getLoc(), newPortTypes, getModuleName(),
+                            getName(), getNameKind(), newPortDirections,
+                            newPortNames, getAnnotations().getValue(),
+                            newPortAnnos, getLayers(), getLowerToBind(),
+                            getDoNotPrint(), getInnerSymAttr());
 }
 
 LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
@@ -2910,9 +2911,10 @@ InstanceChoiceOp::erasePorts(OpBuilder &builder,
   SmallVector<Attribute> newPortAnnotations =
       removeElementsAtIndices(getPortAnnotations().getValue(), portIndices);
 
-  auto newOp = builder.create<InstanceChoiceOp>(
-      getLoc(), newResultTypes, getModuleNames(), getCaseNames(), getName(),
-      getNameKind(), direction::packAttribute(getContext(), newPortDirections),
+  auto newOp = InstanceChoiceOp::create(
+      builder, getLoc(), newResultTypes, getModuleNames(), getCaseNames(),
+      getName(), getNameKind(),
+      direction::packAttribute(getContext(), newPortDirections),
       ArrayAttr::get(getContext(), newPortNames), getAnnotationsAttr(),
       ArrayAttr::get(getContext(), newPortAnnotations), getLayers(),
       getInnerSymAttr());

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -42,29 +42,29 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     // References use ref.define.  Add cast if types don't match.
     if (type_isa<RefType>(dstFType)) {
       if (dstFType != srcFType)
-        src = builder.create<RefCastOp>(dstFType, src);
-      builder.create<RefDefineOp>(dst, src);
+        src = RefCastOp::create(builder, dstFType, src);
+      RefDefineOp::create(builder, dst, src);
     } else if (type_isa<PropertyType>(dstFType) &&
                type_isa<PropertyType>(srcFType)) {
       // Properties use propassign.
-      builder.create<PropAssignOp>(dst, src);
+      PropAssignOp::create(builder, dst, src);
     } else {
       // Other types, give up and leave a connect
-      builder.create<ConnectOp>(dst, src);
+      ConnectOp::create(builder, dst, src);
     }
     return;
   }
 
   // More special connects
   if (isa<AnalogType>(dstType)) {
-    builder.create<AttachOp>(ArrayRef{dst, src});
+    AttachOp::create(builder, ArrayRef{dst, src});
     return;
   }
 
   // If the types are the exact same we can just connect them.
   if (dstType == srcType && dstType.isPassive() &&
       !dstType.hasUninferredWidth()) {
-    builder.create<MatchingConnectOp>(dst, src);
+    MatchingConnectOp::create(builder, dst, src);
     return;
   }
 
@@ -75,12 +75,12 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     // connect and let the verifier catch it.
     auto srcBundle = type_dyn_cast<BundleType>(srcType);
     if (!srcBundle || numElements != srcBundle.getNumElements()) {
-      builder.create<ConnectOp>(dst, src);
+      ConnectOp::create(builder, dst, src);
       return;
     }
     for (size_t i = 0; i < numElements; ++i) {
-      auto dstField = builder.create<SubfieldOp>(dst, i);
-      auto srcField = builder.create<SubfieldOp>(src, i);
+      auto dstField = SubfieldOp::create(builder, dst, i);
+      auto srcField = SubfieldOp::create(builder, src, i);
       if (dstBundle.getElement(i).isFlip)
         std::swap(dstField, srcField);
       emitConnect(builder, dstField, srcField);
@@ -95,12 +95,12 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     // connect and let the verifier catch it.
     auto srcVector = type_dyn_cast<FVectorType>(srcType);
     if (!srcVector || numElements != srcVector.getNumElements()) {
-      builder.create<ConnectOp>(dst, src);
+      ConnectOp::create(builder, dst, src);
       return;
     }
     for (size_t i = 0; i < numElements; ++i) {
-      auto dstField = builder.create<SubindexOp>(dst, i);
-      auto srcField = builder.create<SubindexOp>(src, i);
+      auto dstField = SubindexOp::create(builder, dst, i);
+      auto srcField = SubindexOp::create(builder, src, i);
       emitConnect(builder, dstField, srcField);
     }
     return;
@@ -109,7 +109,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   if ((dstType.hasUninferredReset() || srcType.hasUninferredReset()) &&
       dstType != srcType) {
     srcType = dstType.getConstType(srcType.isConst());
-    src = builder.create<UninferredResetCastOp>(srcType, src);
+    src = UninferredResetCastOp::create(builder, srcType, src);
   }
 
   // Handle passive types with possibly uninferred widths.
@@ -124,10 +124,10 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     //  can be const-cast'd, do so)
     if (dstType != srcType && dstType.getWidthlessType() != srcType &&
         areTypesConstCastable(dstType.getWidthlessType(), srcType)) {
-      src = builder.create<ConstCastOp>(dstType.getWidthlessType(), src);
+      src = ConstCastOp::create(builder, dstType.getWidthlessType(), src);
     }
 
-    builder.create<ConnectOp>(dst, src);
+    ConnectOp::create(builder, dst, src);
     return;
   }
 
@@ -140,29 +140,29 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     if (isSignedDest)
       tmpType =
           UIntType::get(dstType.getContext(), dstWidth, srcType.isConst());
-    src = builder.create<TailPrimOp>(tmpType, src, srcWidth - dstWidth);
+    src = TailPrimOp::create(builder, tmpType, src, srcWidth - dstWidth);
     // Insert the cast back to signed if needed.
     if (isSignedDest)
-      src = builder.create<AsSIntPrimOp>(
-          dstType.getConstType(tmpType.isConst()), src);
+      src = AsSIntPrimOp::create(builder,
+                                 dstType.getConstType(tmpType.isConst()), src);
   } else if (srcWidth < dstWidth) {
     // Need to extend arg.
-    src = builder.create<PadPrimOp>(src, dstWidth);
+    src = PadPrimOp::create(builder, src, dstWidth);
   }
 
   if (auto srcType = type_cast<FIRRTLBaseType>(src.getType());
       srcType && dstType != srcType &&
       areTypesConstCastable(dstType, srcType)) {
-    src = builder.create<ConstCastOp>(dstType, src);
+    src = ConstCastOp::create(builder, dstType, src);
   }
 
   // Strict connect requires the types to be completely equal, including
   // connecting uint<1> to abstract reset types.
   if (dstType == src.getType() && dstType.isPassive() &&
       !dstType.hasUninferredWidth()) {
-    builder.create<MatchingConnectOp>(dst, src);
+    MatchingConnectOp::create(builder, dst, src);
   } else
-    builder.create<ConnectOp>(dst, src);
+    ConnectOp::create(builder, dst, src);
 }
 
 IntegerAttr circt::firrtl::getIntAttr(Type type, const APInt &value) {
@@ -678,19 +678,19 @@ Value circt::firrtl::getValueByFieldID(ImplicitLocOpBuilder builder,
     FIRRTLTypeSwitch<Type, void>(value.getType())
         .Case<BundleType, OpenBundleType>([&](auto bundle) {
           auto index = bundle.getIndexForFieldID(fieldID);
-          value = builder.create<SubfieldOp>(value, index);
+          value = SubfieldOp::create(builder, value, index);
           fieldID -= bundle.getFieldID(index);
         })
         .Case<FVectorType, OpenVectorType>([&](auto vector) {
           auto index = vector.getIndexForFieldID(fieldID);
-          value = builder.create<SubindexOp>(value, index);
+          value = SubindexOp::create(builder, value, index);
           fieldID -= vector.getFieldID(index);
         })
         .Case<RefType>([&](auto reftype) {
           FIRRTLTypeSwitch<FIRRTLBaseType, void>(reftype.getType())
               .template Case<BundleType, FVectorType>([&](auto type) {
                 auto index = type.getIndexForFieldID(fieldID);
-                value = builder.create<RefSubOp>(value, index);
+                value = RefSubOp::create(builder, value, index);
                 fieldID -= type.getFieldID(index);
               })
               .Default([&](auto _) {
@@ -1087,5 +1087,5 @@ PathOp circt::firrtl::createPathRef(Operation *op, hw::HierPathOp nla,
   }
 
   // Create the path operation.
-  return builderOM.create<PathOp>(kind, id);
+  return PathOp::create(builderOM, kind, id);
 }

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -245,10 +245,10 @@ void BlackBoxReaderPass::runOnOperation() {
 
     auto fileName = ns.newName("blackbox_" + verilogName.getValue());
 
-    auto fileOp = builder.create<emit::FileOp>(
-        loc, annotationInfo.outputFileAttr.getFilename(), fileName,
+    auto fileOp = emit::FileOp::create(
+        builder, loc, annotationInfo.outputFileAttr.getFilename(), fileName,
         [&, text = annotationInfo.inlineText] {
-          builder.create<emit::VerbatimOp>(loc, text);
+          emit::VerbatimOp::create(builder, loc, text);
         });
 
     if (!annotationInfo.outputFileAttr.getExcludeFromFilelist().getValue())

--- a/lib/Dialect/FIRRTL/Transforms/CreateCompanionAssume.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateCompanionAssume.cpp
@@ -49,15 +49,16 @@ struct CreateCompanionAssumePass
       // Copy messages once we confirmed that it works well with UNR tools.
       if (isUnrOnlyAssert)
         // If UNROnly, use UnclockedAssumeIntrinsicOp.
-        assume = builder.create<firrtl::UnclockedAssumeIntrinsicOp>(
-            assertOp.getLoc(), assertOp.getPredicate(), assertOp.getEnable(),
-            emptyMessage, ValueRange{}, assertOp.getName());
+        assume = firrtl::UnclockedAssumeIntrinsicOp::create(
+            builder, assertOp.getLoc(), assertOp.getPredicate(),
+            assertOp.getEnable(), emptyMessage, ValueRange{},
+            assertOp.getName());
       else
         // Otherwise use concurrent assume.
-        assume = builder.create<firrtl::AssumeOp>(
-            assertOp.getLoc(), assertOp.getClock(), assertOp.getPredicate(),
-            assertOp.getEnable(), emptyMessage, ValueRange{},
-            assertOp.getName(),
+        assume = firrtl::AssumeOp::create(
+            builder, assertOp.getLoc(), assertOp.getClock(),
+            assertOp.getPredicate(), assertOp.getEnable(), emptyMessage,
+            ValueRange{}, assertOp.getName(),
             /*isConcurrent=*/true);
 
       // Add a guard "USE_PROPERTY_AS_CONSTRAINT" to companion assumes.

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -73,7 +73,7 @@ struct ObjectModelIR {
     }
 
     // Create the path operation.
-    return builderOM.create<PathOp>(kind, id);
+    return PathOp::create(builderOM, kind, id);
   }
 
   void createMemorySchema() {
@@ -92,8 +92,8 @@ struct ObjectModelIR {
     };
     StringRef extraPortFields[3] = {"name", "direction", "width"};
 
-    extraPortsClass = builderOM.create<ClassOp>(
-        "ExtraPortsMemorySchema", extraPortFields, extraPortsType);
+    extraPortsClass = ClassOp::create(builderOM, "ExtraPortsMemorySchema",
+                                      extraPortFields, extraPortsType);
 
     mlir::Type classFieldTypes[13] = {
         StringType::get(context),
@@ -113,14 +113,14 @@ struct ObjectModelIR {
         ListType::get(context, cast<PropertyType>(StringType::get(context))),
     };
 
-    memorySchemaClass = builderOM.create<ClassOp>(
-        "MemorySchema", memoryParamNames, classFieldTypes);
+    memorySchemaClass = ClassOp::create(builderOM, "MemorySchema",
+                                        memoryParamNames, classFieldTypes);
 
     // Now create the class that will instantiate metadata class with all the
     // memories of the circt.
     SmallVector<PortInfo> mports;
-    memoryMetadataClass = builderOM.create<ClassOp>(
-        builderOM.getStringAttr("MemoryMetadata"), mports);
+    memoryMetadataClass = ClassOp::create(
+        builderOM, builderOM.getStringAttr("MemoryMetadata"), mports);
   }
 
   void createRetimeModulesSchema() {
@@ -128,12 +128,13 @@ struct ObjectModelIR {
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         unknownLoc, circtOp.getBodyBlock());
     Type classFieldTypes[] = {StringType::get(context)};
-    retimeModulesSchemaClass = builderOM.create<ClassOp>(
-        "RetimeModulesSchema", retimeModulesParamNames, classFieldTypes);
+    retimeModulesSchemaClass =
+        ClassOp::create(builderOM, "RetimeModulesSchema",
+                        retimeModulesParamNames, classFieldTypes);
 
     SmallVector<PortInfo> mports;
-    retimeModulesMetadataClass = builderOM.create<ClassOp>(
-        builderOM.getStringAttr("RetimeModulesMetadata"), mports);
+    retimeModulesMetadataClass = ClassOp::create(
+        builderOM, builderOM.getStringAttr("RetimeModulesMetadata"), mports);
   }
 
   void addRetimeModule(FModuleLike module) {
@@ -144,12 +145,12 @@ struct ObjectModelIR {
 
     // Create the path operation.
     auto modEntry =
-        builderOM.create<StringConstantOp>(module.getModuleNameAttr());
-    auto object = builderOM.create<ObjectOp>(retimeModulesSchemaClass,
-                                             module.getModuleNameAttr());
+        StringConstantOp::create(builderOM, module.getModuleNameAttr());
+    auto object = ObjectOp::create(builderOM, retimeModulesSchemaClass,
+                                   module.getModuleNameAttr());
 
-    auto inPort = builderOM.create<ObjectSubfieldOp>(object, 0);
-    builderOM.create<PropAssignOp>(inPort, modEntry);
+    auto inPort = ObjectSubfieldOp::create(builderOM, object, 0);
+    PropAssignOp::create(builderOM, inPort, modEntry);
     auto portIndex = retimeModulesMetadataClass.getNumPorts();
     SmallVector<std::pair<unsigned, PortInfo>> newPorts = {
         {portIndex,
@@ -158,7 +159,7 @@ struct ObjectModelIR {
     retimeModulesMetadataClass.insertPorts(newPorts);
     auto blockarg = retimeModulesMetadataClass.getBodyBlock()->addArgument(
         object.getType(), module->getLoc());
-    builderOM.create<PropAssignOp>(blockarg, object);
+    PropAssignOp::create(builderOM, blockarg, object);
   }
 
   void addBlackBoxModulesSchema() {
@@ -169,11 +170,11 @@ struct ObjectModelIR {
         StringType::get(context), BoolType::get(context),
         ListType::get(context, cast<PropertyType>(StringType::get(context)))};
     blackBoxModulesSchemaClass =
-        builderOM.create<ClassOp>("SitestBlackBoxModulesSchema",
-                                  blackBoxModulesParamNames, classFieldTypes);
+        ClassOp::create(builderOM, "SitestBlackBoxModulesSchema",
+                        blackBoxModulesParamNames, classFieldTypes);
     SmallVector<PortInfo> mports;
-    blackBoxMetadataClass = builderOM.create<ClassOp>(
-        builderOM.getStringAttr("SitestBlackBoxMetadata"), mports);
+    blackBoxMetadataClass = ClassOp::create(
+        builderOM, builderOM.getStringAttr("SitestBlackBoxMetadata"), mports);
   }
 
   void addBlackBoxModule(FExtModuleOp module, bool inDut,
@@ -185,8 +186,9 @@ struct ObjectModelIR {
       return;
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         module.getLoc(), blackBoxMetadataClass.getBodyBlock());
-    auto modEntry = builderOM.create<StringConstantOp>(module.getDefnameAttr());
-    auto inDutAttr = builderOM.create<BoolConstantOp>(inDut);
+    auto modEntry =
+        StringConstantOp::create(builderOM, module.getDefnameAttr());
+    auto inDutAttr = BoolConstantOp::create(builderOM, inDut);
 
     SmallVector<Value> libValues;
     for (StringRef libName : libraries) {
@@ -194,28 +196,29 @@ struct ObjectModelIR {
       if (libName == defName) {
         libNameAttr = modEntry;
       } else {
-        libNameAttr = builderOM.create<StringConstantOp>(
-            builderOM.getStringAttr(libName));
+        libNameAttr = StringConstantOp::create(
+            builderOM, builderOM.getStringAttr(libName));
       }
       libValues.push_back(libNameAttr);
     }
-    auto blackBoxResourcesList = builderOM.create<ListCreateOp>(
+    auto blackBoxResourcesList = ListCreateOp::create(
+        builderOM,
         ListType::get(
             builderOM.getContext(),
             cast<PropertyType>(StringType::get(builderOM.getContext()))),
         libValues);
 
-    auto object = builderOM.create<ObjectOp>(blackBoxModulesSchemaClass,
-                                             module.getModuleNameAttr());
+    auto object = ObjectOp::create(builderOM, blackBoxModulesSchemaClass,
+                                   module.getModuleNameAttr());
 
-    auto inPortModuleName = builderOM.create<ObjectSubfieldOp>(object, 0);
-    builderOM.create<PropAssignOp>(inPortModuleName, modEntry);
-    auto inPortInDut = builderOM.create<ObjectSubfieldOp>(object, 2);
-    builderOM.create<PropAssignOp>(inPortInDut, inDutAttr);
+    auto inPortModuleName = ObjectSubfieldOp::create(builderOM, object, 0);
+    PropAssignOp::create(builderOM, inPortModuleName, modEntry);
+    auto inPortInDut = ObjectSubfieldOp::create(builderOM, object, 2);
+    PropAssignOp::create(builderOM, inPortInDut, inDutAttr);
     auto inPortBlackBoxResources =
-        builderOM.create<ObjectSubfieldOp>(object, 4);
-    builderOM.create<PropAssignOp>(inPortBlackBoxResources,
-                                   blackBoxResourcesList);
+        ObjectSubfieldOp::create(builderOM, object, 4);
+    PropAssignOp::create(builderOM, inPortBlackBoxResources,
+                         blackBoxResourcesList);
     auto portIndex = blackBoxMetadataClass.getNumPorts();
     SmallVector<std::pair<unsigned, PortInfo>> newPorts = {
         {portIndex,
@@ -224,7 +227,7 @@ struct ObjectModelIR {
     blackBoxMetadataClass.insertPorts(newPorts);
     auto blockarg = blackBoxMetadataClass.getBodyBlock()->addArgument(
         object.getType(), module->getLoc());
-    builderOM.create<PropAssignOp>(blockarg, object);
+    PropAssignOp::create(builderOM, blockarg, object);
   }
 
   void addMemory(FMemModuleOp mem) {
@@ -234,11 +237,11 @@ struct ObjectModelIR {
         mem.getLoc(), memoryMetadataClass.getBodyBlock());
     auto createConstField = [&](Attribute constVal) -> Value {
       if (auto boolConstant = dyn_cast_or_null<mlir::BoolAttr>(constVal))
-        return builderOM.create<BoolConstantOp>(boolConstant);
+        return BoolConstantOp::create(builderOM, boolConstant);
       if (auto intConstant = dyn_cast_or_null<mlir::IntegerAttr>(constVal))
-        return builderOM.create<FIntegerConstantOp>(intConstant);
+        return FIntegerConstantOp::create(builderOM, intConstant);
       if (auto strConstant = dyn_cast_or_null<mlir::StringAttr>(constVal))
-        return builderOM.create<StringConstantOp>(strConstant);
+        return StringConstantOp::create(builderOM, strConstant);
       return {};
     };
     auto nlaBuilder = OpBuilder::atBlockBegin(circtOp.getBodyBlock());
@@ -261,8 +264,8 @@ struct ObjectModelIR {
       for (auto memPath : memPaths) {
         {
           igraph::InstanceOpInterface finalInst = memPath.leaf();
-          finalInstanceNames.emplace_back(builderOM.create<StringConstantOp>(
-              finalInst.getInstanceNameAttr()));
+          finalInstanceNames.emplace_back(StringConstantOp::create(
+              builderOM, finalInst.getInstanceNameAttr()));
         }
         SmallVector<Attribute> namepath;
         bool foundDut = false;
@@ -293,8 +296,8 @@ struct ObjectModelIR {
         PathOp pathRef;
         if (!namepath.empty()) {
           // This is a path that is in the design.
-          auto nla = nlaBuilder.create<hw::HierPathOp>(
-              mem->getLoc(),
+          auto nla = hw::HierPathOp::create(
+              nlaBuilder, mem->getLoc(),
               nlaBuilder.getStringAttr(circtNamespace.newName("memNLA")),
               nlaBuilder.getArrayAttr(namepath));
           nla.setVisibility(SymbolTable::Visibility::Private);
@@ -310,15 +313,17 @@ struct ObjectModelIR {
         memoryHierPaths.push_back(pathRef);
       }
     }
-    auto finalInstNamesList = builderOM.create<ListCreateOp>(
+    auto finalInstNamesList = ListCreateOp::create(
+        builderOM,
         ListType::get(context, cast<PropertyType>(StringType::get(context))),
         finalInstanceNames);
-    auto hierpaths = builderOM.create<ListCreateOp>(
+    auto hierpaths = ListCreateOp::create(
+        builderOM,
         ListType::get(context, cast<PropertyType>(PathType::get(context))),
         memoryHierPaths);
     SmallVector<Value> memFields;
 
-    auto object = builderOM.create<ObjectOp>(memorySchemaClass, mem.getName());
+    auto object = ObjectOp::create(builderOM, memorySchemaClass, mem.getName());
     SmallVector<Value> extraPortsList;
     ClassType extraPortsType;
     for (auto attr : mem.getExtraPortsAttr()) {
@@ -328,18 +333,18 @@ struct ObjectModelIR {
       auto direction = createConstField(port.getAs<StringAttr>("direction"));
       auto width = createConstField(port.getAs<IntegerAttr>("width"));
       auto extraPortsObj =
-          builderOM.create<ObjectOp>(extraPortsClass, "extraPorts");
+          ObjectOp::create(builderOM, extraPortsClass, "extraPorts");
       extraPortsType = extraPortsObj.getType();
-      auto inPort = builderOM.create<ObjectSubfieldOp>(extraPortsObj, 0);
-      builderOM.create<PropAssignOp>(inPort, portName);
-      inPort = builderOM.create<ObjectSubfieldOp>(extraPortsObj, 2);
-      builderOM.create<PropAssignOp>(inPort, direction);
-      inPort = builderOM.create<ObjectSubfieldOp>(extraPortsObj, 4);
-      builderOM.create<PropAssignOp>(inPort, width);
+      auto inPort = ObjectSubfieldOp::create(builderOM, extraPortsObj, 0);
+      PropAssignOp::create(builderOM, inPort, portName);
+      inPort = ObjectSubfieldOp::create(builderOM, extraPortsObj, 2);
+      PropAssignOp::create(builderOM, inPort, direction);
+      inPort = ObjectSubfieldOp::create(builderOM, extraPortsObj, 4);
+      PropAssignOp::create(builderOM, inPort, width);
       extraPortsList.push_back(extraPortsObj);
     }
-    auto extraPorts = builderOM.create<ListCreateOp>(
-        memorySchemaClass.getPortType(22), extraPortsList);
+    auto extraPorts = ListCreateOp::create(
+        builderOM, memorySchemaClass.getPortType(22), extraPortsList);
     for (auto field : llvm::enumerate(memoryParamNames)) {
       auto propVal = createConstField(
           llvm::StringSwitch<TypedAttr>(field.value())
@@ -371,8 +376,8 @@ struct ObjectModelIR {
       // The following `2*index` translates the index to the memory schema input
       // port number.
       auto inPort =
-          builderOM.create<ObjectSubfieldOp>(object, 2 * field.index());
-      builderOM.create<PropAssignOp>(inPort, propVal);
+          ObjectSubfieldOp::create(builderOM, object, 2 * field.index());
+      PropAssignOp::create(builderOM, inPort, propVal);
     }
     auto portIndex = memoryMetadataClass.getNumPorts();
     SmallVector<std::pair<unsigned, PortInfo>> newPorts = {
@@ -381,7 +386,7 @@ struct ObjectModelIR {
     memoryMetadataClass.insertPorts(newPorts);
     auto blockarg = memoryMetadataClass.getBodyBlock()->addArgument(
         object.getType(), mem->getLoc());
-    builderOM.create<PropAssignOp>(blockarg, object);
+    PropAssignOp::create(builderOM, blockarg, object);
   }
 
   ObjectOp instantiateSifiveMetadata(FModuleOp topMod) {
@@ -391,8 +396,8 @@ struct ObjectModelIR {
     auto builder = mlir::ImplicitLocOpBuilder::atBlockEnd(
         mlir::UnknownLoc::get(circtOp->getContext()), circtOp.getBodyBlock());
     SmallVector<PortInfo> mports;
-    auto sifiveMetadataClass = builder.create<ClassOp>(
-        builder.getStringAttr("SiFive_Metadata"), mports);
+    auto sifiveMetadataClass = ClassOp::create(
+        builder, builder.getStringAttr("SiFive_Metadata"), mports);
     builder.setInsertionPointToStart(sifiveMetadataClass.getBodyBlock());
 
     auto addPort = [&](Value obj, StringRef fieldName) {
@@ -404,25 +409,23 @@ struct ObjectModelIR {
       sifiveMetadataClass.insertPorts(newPorts);
       auto blockarg = sifiveMetadataClass.getBodyBlock()->addArgument(
           obj.getType(), topMod->getLoc());
-      builder.create<PropAssignOp>(blockarg, obj);
+      PropAssignOp::create(builder, blockarg, obj);
     };
     if (blackBoxMetadataClass)
-      addPort(
-          builder.create<ObjectOp>(blackBoxMetadataClass,
-                                   builder.getStringAttr("blackbox_metadata")),
-          "blackbox");
+      addPort(ObjectOp::create(builder, blackBoxMetadataClass,
+                               builder.getStringAttr("blackbox_metadata")),
+              "blackbox");
 
     if (memoryMetadataClass)
-      addPort(
-          builder.create<ObjectOp>(memoryMetadataClass,
-                                   builder.getStringAttr("memory_metadata")),
-          "memory");
+      addPort(ObjectOp::create(builder, memoryMetadataClass,
+                               builder.getStringAttr("memory_metadata")),
+              "memory");
 
     if (retimeModulesMetadataClass)
-      addPort(builder.create<ObjectOp>(
-                  retimeModulesMetadataClass,
-                  builder.getStringAttr("retime_modules_metadata")),
-              "retime");
+      addPort(
+          ObjectOp::create(builder, retimeModulesMetadataClass,
+                           builder.getStringAttr("retime_modules_metadata")),
+          "retime");
 
     if (instanceInfo.hasDut()) {
       auto dutMod = instanceInfo.getDut();
@@ -447,8 +450,8 @@ struct ObjectModelIR {
         // actual DUT module!!).
         auto leafInst = dutPath.leaf();
         auto nlaBuilder = OpBuilder::atBlockBegin(circtOp.getBodyBlock());
-        auto nla = nlaBuilder.create<hw::HierPathOp>(
-            dutMod->getLoc(),
+        auto nla = hw::HierPathOp::create(
+            nlaBuilder, dutMod->getLoc(),
             nlaBuilder.getStringAttr(circtNamespace.newName("dutNLA")),
             nlaBuilder.getArrayAttr(namepath));
         nla.setVisibility(SymbolTable::Visibility::Private);
@@ -456,15 +459,16 @@ struct ObjectModelIR {
         pathOpsToDut.emplace_back(createPathRef(leafInst, nla, builder));
       }
       // Create the list of paths op and add it as a field of the class.
-      auto pathList = builder.create<ListCreateOp>(
+      auto pathList = ListCreateOp::create(
+          builder,
           ListType::get(context, cast<PropertyType>(PathType::get(context))),
           pathOpsToDut);
       addPort(pathList, "dutModulePath");
     }
 
     builder.setInsertionPointToEnd(topMod.getBodyBlock());
-    return builder.create<ObjectOp>(sifiveMetadataClass,
-                                    builder.getStringAttr("sifive_metadata"));
+    return ObjectOp::create(builder, sifiveMetadataClass,
+                            builder.getStringAttr("sifive_metadata"));
   }
 
   /// Get the cached namespace for a module.
@@ -699,9 +703,9 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
   {
     SmallString<128> seqMemsJsonPath(metadataDir);
     llvm::sys::path::append(seqMemsJsonPath, "seq_mems.json");
-    builder.create<emit::FileOp>(seqMemsJsonPath, [&] {
-      builder.create<sv::VerbatimOp>(dutJsonBuffer, ValueRange{},
-                                     builder.getArrayAttr(jsonSymbols));
+    emit::FileOp::create(builder, seqMemsJsonPath, [&] {
+      sv::VerbatimOp::create(builder, dutJsonBuffer, ValueRange{},
+                             builder.getArrayAttr(jsonSymbols));
     });
   }
 
@@ -714,9 +718,9 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
       return failure();
     }
 
-    builder.create<emit::FileOp>(replSeqMemFile, [&] {
-      builder.create<sv::VerbatimOp>(seqMemConfStr, ValueRange{},
-                                     builder.getArrayAttr(seqMemSymbols));
+    emit::FileOp::create(builder, replSeqMemFile, [&] {
+      sv::VerbatimOp::create(builder, seqMemConfStr, ValueRange{},
+                             builder.getArrayAttr(seqMemSymbols));
     });
   }
 
@@ -811,9 +815,9 @@ CreateSiFiveMetadataPass::emitRetimeModulesMetadata(ObjectModelIR &omir) {
   // Put the retime information in a verbatim operation.
   auto builder = ImplicitLocOpBuilder::atBlockEnd(UnknownLoc::get(context),
                                                   circuitOp.getBodyBlock());
-  builder.create<emit::FileOp>(filename, [&] {
-    builder.create<sv::VerbatimOp>(builder.getStringAttr(buffer), ValueRange{},
-                                   builder.getArrayAttr(symbols));
+  emit::FileOp::create(builder, filename, [&] {
+    sv::VerbatimOp::create(builder, builder.getStringAttr(buffer), ValueRange{},
+                           builder.getArrayAttr(symbols));
   });
   return success();
 }
@@ -916,8 +920,8 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
     auto builder = ImplicitLocOpBuilder::atBlockEnd(UnknownLoc::get(context),
                                                     circuitOp.getBodyBlock());
 
-    builder.create<emit::FileOp>(filename, [&] {
-      builder.create<emit::VerbatimOp>(StringAttr::get(context, buffer));
+    emit::FileOp::create(builder, filename, [&] {
+      emit::VerbatimOp::create(builder, StringAttr::get(context, buffer));
     });
   };
 
@@ -961,8 +965,9 @@ void CreateSiFiveMetadataPass::runOnOperation() {
       topMod.insertPorts(ports);
       auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
           topMod->getLoc(), topMod.getBodyBlock());
-      auto objectCast = builderOM.create<ObjectAnyRefCastOp>(objectOp);
-      builderOM.create<PropAssignOp>(topMod.getArgument(portIndex), objectCast);
+      auto objectCast = ObjectAnyRefCastOp::create(builderOM, objectOp);
+      PropAssignOp::create(builderOM, topMod.getArgument(portIndex),
+                           objectCast);
     }
 
   // This pass modifies the hierarchy, InstanceGraph is not preserved.

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1061,8 +1061,8 @@ private:
       // Check the NLA cache to see if we already have this NLA.
       auto &cacheEntry = nlaCache[arrayAttr];
       if (!cacheEntry) {
-        auto nla = OpBuilder::atBlockBegin(nlaBlock).create<hw::HierPathOp>(
-            loc, "nla", arrayAttr);
+        auto builder = OpBuilder::atBlockBegin(nlaBlock);
+        auto nla = hw::HierPathOp::create(builder, loc, "nla", arrayAttr);
         // Insert it into the symbol table to get a unique name.
         symbolTable.insert(nla);
         // Store it in the cache.
@@ -1560,8 +1560,8 @@ void fixupConnect(ImplicitLocOpBuilder &builder, Value dst, Value src) {
   auto dstBundle = type_cast<BundleType>(dstType);
   auto srcBundle = type_cast<BundleType>(srcType);
   for (unsigned i = 0; i < dstBundle.getNumElements(); ++i) {
-    auto dstField = builder.create<SubfieldOp>(dst, i);
-    auto srcField = builder.create<SubfieldOp>(src, i);
+    auto dstField = SubfieldOp::create(builder, dst, i);
+    auto srcField = SubfieldOp::create(builder, src, i);
     if (dstBundle.getElement(i).isFlip) {
       std::swap(srcBundle, dstBundle);
       std::swap(srcField, dstField);
@@ -1609,7 +1609,7 @@ void fixupAllModules(InstanceGraph &instanceGraph) {
         // If the type changed we transform it back to the old type with an
         // intermediate wire.
         auto wire =
-            builder.create<WireOp>(oldType, inst.getPortName(i)).getResult();
+            WireOp::create(builder, oldType, inst.getPortName(i)).getResult();
         result.replaceAllUsesWith(wire);
         result.setType(newType);
         if (inst.getPortDirection(i) == Direction::Out)

--- a/lib/Dialect/FIRRTL/Transforms/EliminateWires.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EliminateWires.cpp
@@ -83,9 +83,9 @@ void EliminateWiresPass::runOnOperation() {
 
   for (auto [wire, writer] : worklist) {
     mlir::ImplicitLocOpBuilder builder(wire->getLoc(), writer);
-    auto node = builder.create<NodeOp>(
-        writer.getSrc(), wire.getName(), wire.getNameKind(),
-        wire.getAnnotations(), wire.getInnerSymAttr(), wire.getForceable());
+    auto node = NodeOp::create(builder, writer.getSrc(), wire.getName(),
+                               wire.getNameKind(), wire.getAnnotations(),
+                               wire.getInnerSymAttr(), wire.getForceable());
     wire.replaceAllUsesWith(node);
     wire.erase();
     writer.erase();

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -288,7 +288,7 @@ public:
       newValue = b.createOrFold<MuxPrimOp>(fusedLoc, cond, whenTrue, whenFalse);
     else if (trueIsInvalid)
       newValue = whenFalse;
-    return b.create<ConnectOp>(loc, dest, newValue);
+    return ConnectOp::create(b, loc, dest, newValue);
   }
 
   void visitDecl(WireOp op) { declareSinks(op.getResult(), Flow::Duplex); }
@@ -301,14 +301,14 @@ public:
         .template Case<BundleType>([&](BundleType bundle) {
           for (auto i : llvm::seq(0u, (unsigned)bundle.getNumElements())) {
             auto subfield =
-                builder.create<SubfieldOp>(value.getLoc(), value, i);
+                SubfieldOp::create(builder, value.getLoc(), value, i);
             foreachSubelement(builder, subfield, fn);
           }
         })
         .template Case<FVectorType>([&](FVectorType vector) {
           for (auto i : llvm::seq((size_t)0, vector.getNumElements())) {
             auto subindex =
-                builder.create<SubindexOp>(value.getLoc(), value, i);
+                SubindexOp::create(builder, value.getLoc(), value, i);
             foreachSubelement(builder, subindex, fn);
           }
         })
@@ -320,7 +320,7 @@ public:
     // aggergate type, connect each ground type element.
     auto builder = OpBuilder(op->getBlock(), ++Block::iterator(op));
     auto fn = [&](Value value) {
-      auto connect = builder.create<ConnectOp>(value.getLoc(), value, value);
+      auto connect = ConnectOp::create(builder, value.getLoc(), value, value);
       driverMap[getFieldRefFromValue(value)] = connect;
     };
     foreachSubelement(builder, op.getResult(), fn);
@@ -331,7 +331,7 @@ public:
     // aggergate type, connect each ground type element.
     auto builder = OpBuilder(op->getBlock(), ++Block::iterator(op));
     auto fn = [&](Value value) {
-      auto connect = builder.create<ConnectOp>(value.getLoc(), value, value);
+      auto connect = ConnectOp::create(builder, value.getLoc(), value, value);
       driverMap[getFieldRefFromValue(value)] = connect;
     };
     foreachSubelement(builder, op.getResult(), fn);

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1123,7 +1123,7 @@ parseAugmentedType(ApplyState &state, DictionaryAttr augmentedType,
     auto sinkType = source->getType();
     if (auto baseSinkType = type_dyn_cast<FIRRTLBaseType>(sinkType))
       sinkType = baseSinkType.getPassiveType();
-    auto sink = builder.create<WireOp>(sinkType, name);
+    auto sink = WireOp::create(builder, sinkType, name);
     state.targetCaches.insertOp(sink);
     AnnotationSet annotations(context);
     annotations.addAnnotations(
@@ -2111,7 +2111,7 @@ void GrandCentralPass::runOnOperation() {
                   for (auto port : instance->getResults()) {
                     builder.setInsertionPointAfterValue(port);
                     auto wire =
-                        builder.create<WireOp>(port.getLoc(), port.getType());
+                        WireOp::create(builder, port.getLoc(), port.getType());
                     port.replaceAllUsesWith(wire.getResult());
                   }
                   i->erase();
@@ -2391,8 +2391,8 @@ void GrandCentralPass::runOnOperation() {
     // Generate gathered XMR's.
     for (auto xmrElem : xmrElems) {
       auto uloc = companionBuilder.getUnknownLoc();
-      companionBuilder.create<sv::VerbatimOp>(uloc, xmrElem.str, xmrElem.val,
-                                              xmrElem.syms);
+      sv::VerbatimOp::create(companionBuilder, uloc, xmrElem.str, xmrElem.val,
+                             xmrElem.syms);
     }
     numXMRs += xmrElems.size();
 
@@ -2401,7 +2401,7 @@ void GrandCentralPass::runOnOperation() {
       auto builder = OpBuilder::atBlockEnd(getOperation().getBodyBlock());
       auto loc = getOperation().getLoc();
       sv::InterfaceOp iface =
-          builder.create<sv::InterfaceOp>(loc, ifaceBuilder.iFaceName);
+          sv::InterfaceOp::create(builder, loc, ifaceBuilder.iFaceName);
       if (!topIface)
         topIface = iface;
       ++numInterfaces;
@@ -2429,8 +2429,9 @@ void GrandCentralPass::runOnOperation() {
         auto description = elem.description;
 
         if (description) {
-          auto descriptionOp = builder.create<sv::VerbatimOp>(
-              uloc, ("// " + cleanupDescription(description.getValue())));
+          auto descriptionOp = sv::VerbatimOp::create(
+              builder, uloc,
+              ("// " + cleanupDescription(description.getValue())));
 
           // If we need to generate a YAML representation of this interface,
           // then add an attribute indicating that this `sv::VerbatimOp` is
@@ -2440,8 +2441,8 @@ void GrandCentralPass::runOnOperation() {
                                    builder.getStringAttr("description"));
         }
         if (auto *str = std::get_if<VerbatimType>(&elem.elemType)) {
-          auto instanceOp = builder.create<sv::VerbatimOp>(
-              uloc, str->toStr(elem.elemName.getValue()));
+          auto instanceOp = sv::VerbatimOp::create(
+              builder, uloc, str->toStr(elem.elemName.getValue()));
 
           // If we need to generate a YAML representation of the interface, then
           // add attributes that describe what this `sv::VerbatimOp` is.
@@ -2463,8 +2464,8 @@ void GrandCentralPass::runOnOperation() {
         }
 
         auto tpe = std::get<Type>(elem.elemType);
-        builder.create<sv::InterfaceSignalOp>(uloc, elem.elemName.getValue(),
-                                              tpe);
+        sv::InterfaceSignalOp::create(builder, uloc, elem.elemName.getValue(),
+                                      tpe);
       }
     }
 
@@ -2475,8 +2476,8 @@ void GrandCentralPass::runOnOperation() {
 
     // Instantiate the interface inside the companion.
     builder.setInsertionPointToStart(companionModule.getBodyBlock());
-    builder.create<sv::InterfaceInstanceOp>(
-        getOperation().getLoc(), topIface.getInterfaceType(),
+    sv::InterfaceInstanceOp::create(
+        builder, getOperation().getLoc(), topIface.getInterfaceType(),
         companionIDMap.lookup(bundle.getID()).name,
         hw::InnerSymAttr::get(builder.getStringAttr(symbolName)));
 
@@ -2550,8 +2551,8 @@ void GrandCentralPass::runOnOperation() {
 
     // Generate gathered XMR's.
     for (auto xmrElem : xmrElems)
-      viewBuilder.create<sv::VerbatimOp>(xmrElem.str, xmrElem.val,
-                                         xmrElem.syms);
+      sv::VerbatimOp::create(viewBuilder, xmrElem.str, xmrElem.val,
+                             xmrElem.syms);
     numXMRs += xmrElems.size();
 
     sv::InterfaceOp topIface;
@@ -2562,7 +2563,7 @@ void GrandCentralPass::runOnOperation() {
       auto builder = OpBuilder::atBlockEnd(getOperation().getBodyBlock());
       auto loc = getOperation().getLoc();
       sv::InterfaceOp iface =
-          builder.create<sv::InterfaceOp>(loc, ifaceBuilder.iFaceName);
+          sv::InterfaceOp::create(builder, loc, ifaceBuilder.iFaceName);
       if (!topIface)
         topIface = iface;
       ++numInterfaces;
@@ -2584,8 +2585,9 @@ void GrandCentralPass::runOnOperation() {
         auto description = elem.description;
 
         if (description) {
-          auto descriptionOp = builder.create<sv::VerbatimOp>(
-              uloc, ("// " + cleanupDescription(description.getValue())));
+          auto descriptionOp = sv::VerbatimOp::create(
+              builder, uloc,
+              ("// " + cleanupDescription(description.getValue())));
 
           // If we need to generate a YAML representation of this interface,
           // then add an attribute indicating that this `sv::VerbatimOp` is
@@ -2595,8 +2597,8 @@ void GrandCentralPass::runOnOperation() {
                                    builder.getStringAttr("description"));
         }
         if (auto *str = std::get_if<VerbatimType>(&elem.elemType)) {
-          auto instanceOp = builder.create<sv::VerbatimOp>(
-              uloc, str->toStr(elem.elemName.getValue()));
+          auto instanceOp = sv::VerbatimOp::create(
+              builder, uloc, str->toStr(elem.elemName.getValue()));
 
           // If we need to generate a YAML representation of the interface, then
           // add attributes that describe what this `sv::VerbatimOp` is.
@@ -2618,8 +2620,8 @@ void GrandCentralPass::runOnOperation() {
         }
 
         auto tpe = std::get<Type>(elem.elemType);
-        builder.create<sv::InterfaceSignalOp>(uloc, elem.elemName.getValue(),
-                                              tpe);
+        sv::InterfaceSignalOp::create(builder, uloc, elem.elemName.getValue(),
+                                      tpe);
       }
     }
 
@@ -2631,8 +2633,8 @@ void GrandCentralPass::runOnOperation() {
     // Instantiate the interface before the view and the XMR's we inserted
     // above.
     viewBuilder.setInsertionPoint(view);
-    viewBuilder.create<sv::InterfaceInstanceOp>(
-        topIface.getInterfaceType(), view.getName(),
+    sv::InterfaceInstanceOp::create(
+        viewBuilder, topIface.getInterfaceType(), view.getName(),
         hw::InnerSymAttr::get(builder.getStringAttr(symbolName)));
 
     view.erase();
@@ -2659,7 +2661,7 @@ void GrandCentralPass::emitHierarchyYamlFile(
   yamlize(yout, intfs, true, yamlContext);
 
   auto builder = OpBuilder::atBlockBegin(circuitOp.getBodyBlock());
-  builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), yamlString)
+  sv::VerbatimOp::create(builder, builder.getUnknownLoc(), yamlString)
       ->setAttr("output_file", hw::OutputFileAttr::getFromFilename(
                                    &getContext(), yamlPath,
                                    /*excludeFromFileList=*/true));

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -976,7 +976,7 @@ void IMConstPropPass::rewriteModuleBody(FModuleOp module) {
 
   // Separate the constants we insert from the instructions we are folding and
   // processing. Leave these as-is until we're done.
-  auto cursor = builder.create<firrtl::ConstantOp>(module.getLoc(), APSInt(1));
+  auto cursor = firrtl::ConstantOp::create(builder, module.getLoc(), APSInt(1));
   builder.setInsertionPoint(cursor);
 
   // Unique constants per <Const,Type> pair, inserted at entry
@@ -1002,7 +1002,7 @@ void IMConstPropPass::rewriteModuleBody(FModuleOp module) {
              "Attempting to materialize rwprobe of constant, shouldn't happen");
       auto inner = getConst(constantValue, refType.getType(), loc);
       assert(inner);
-      cst = builder.create<RefSendOp>(loc, inner);
+      cst = RefSendOp::create(builder, loc, inner);
     } else
       cst = module->getDialect()->materializeConstant(builder, constantValue,
                                                       type, loc);

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -215,8 +215,8 @@ void InjectDUTHierarchy::runOnOperation() {
   // just created becomes the "DUT".
   auto oldDutNameAttr = dut.getNameAttr();
   wrapper = dut;
-  dut = b.create<FModuleOp>(dut.getLoc(), oldDutNameAttr,
-                            dut.getConventionAttr(), dut.getPorts());
+  dut = FModuleOp::create(b, dut.getLoc(), oldDutNameAttr,
+                          dut.getConventionAttr(), dut.getPorts());
 
   // Finish setting up the DUT and the Wrapper.  This depends on if we are in
   // `moveDut` mode or not.  If `moveDut=false` (the normal, legacy behavior),
@@ -275,11 +275,11 @@ void InjectDUTHierarchy::runOnOperation() {
   b.setInsertionPointToStart(dut.getBodyBlock());
   hw::InnerSymbolNamespace dutNS(dut);
   auto wrapperInst =
-      b.create<InstanceOp>(b.getUnknownLoc(), wrapper, wrapper.getModuleName(),
-                           NameKindEnum::DroppableName, ArrayRef<Attribute>{},
-                           ArrayRef<Attribute>{}, false, false,
-                           hw::InnerSymAttr::get(b.getStringAttr(
-                               dutNS.newName(wrapper.getModuleName()))));
+      InstanceOp::create(b, b.getUnknownLoc(), wrapper, wrapper.getModuleName(),
+                         NameKindEnum::DroppableName, ArrayRef<Attribute>{},
+                         ArrayRef<Attribute>{}, false, false,
+                         hw::InnerSymAttr::get(b.getStringAttr(
+                             dutNS.newName(wrapper.getModuleName()))));
   for (const auto &pair : llvm::enumerate(wrapperInst.getResults())) {
     Value lhs = dut.getArgument(pair.index());
     Value rhs = pair.value();

--- a/lib/Dialect/FIRRTL/Transforms/LinkCircuits.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LinkCircuits.cpp
@@ -194,8 +194,9 @@ LogicalResult LinkCircuitsPass::mergeCircuits() {
 
   auto builder = OpBuilder(module);
   builder.setInsertionPointToEnd(module.getBody());
-  auto mergedCircuit = builder.create<CircuitOp>(
-      module.getLoc(), StringAttr::get(&getContext(), baseCircuitName));
+  auto mergedCircuit =
+      CircuitOp::create(builder, module.getLoc(),
+                        StringAttr::get(&getContext(), baseCircuitName));
   SmallVector<Attribute> mergedAnnotations;
 
   for (auto circuit : circuits) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -877,9 +877,9 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     // Create RefSend/RefResolve if necessary.
     if (type_isa<RefType>(dest.getType()) != type_isa<RefType>(src.getType())) {
       if (type_isa<RefType>(dest.getType()))
-        src = builder.create<RefSendOp>(src);
+        src = RefSendOp::create(builder, src);
       else
-        src = builder.create<RefResolveOp>(src);
+        src = RefResolveOp::create(builder, src);
     }
 
     // If the sink is a wire with no users, then convert this to a node.
@@ -892,7 +892,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
           baseType && baseType.isPassive()) {
         // Note that the wire is replaced with the source type
         // regardless, continue this behavior.
-        builder.create<NodeOp>(src, destOp.getName())
+        NodeOp::create(builder, src, destOp.getName())
             .setAnnotationsAttr(destOp.getAnnotations());
         opsToErase.push_back(destOp);
         return success();

--- a/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMatches.cpp
@@ -46,8 +46,8 @@ static void lowerMatch(MatchOp match) {
   auto input = match.getInput();
   for (size_t i = 0; i < numCases - 1; ++i) {
     // Create a WhenOp which tests the enum's tag.
-    auto condition = b.create<IsTagOp>(input, match.getFieldIndexAttr(i));
-    auto when = b.create<WhenOp>(condition, /*withElse=*/true);
+    auto condition = IsTagOp::create(b, input, match.getFieldIndexAttr(i));
+    auto when = WhenOp::create(b, condition, /*withElse=*/true);
 
     // Move the case block to the WhenOp.
     auto *thenBlock = &when.getThenBlock();
@@ -57,7 +57,7 @@ static void lowerMatch(MatchOp match) {
 
     // Replace the block argument with a subtag op.
     b.setInsertionPointToStart(caseBlock);
-    auto data = b.create<SubtagOp>(input, match.getFieldIndexAttr(i));
+    auto data = SubtagOp::create(b, input, match.getFieldIndexAttr(i));
     caseBlock->getArgument(0).replaceAllUsesWith(data);
     caseBlock->eraseArgument(0);
 
@@ -69,7 +69,7 @@ static void lowerMatch(MatchOp match) {
   // if there was only 1 variant, right before the match operation.
 
   // Replace the block argument with a subtag op.
-  auto data = b.create<SubtagOp>(input, match.getFieldIndexAttr(numCases - 1));
+  auto data = SubtagOp::create(b, input, match.getFieldIndexAttr(numCases - 1));
 
   // Get the final block from the match statement, and splice it into the
   // current insertion point.

--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -445,7 +445,7 @@ LogicalResult Visitor::visitExpr(OpenSubfieldOp op) {
   assert(newFieldIndex.has_value());
 
   ImplicitLocOpBuilder builder(op.getLoc(), op);
-  auto newOp = builder.create<SubfieldOp>(newInput, *newFieldIndex);
+  auto newOp = SubfieldOp::create(builder, newInput, *newFieldIndex);
   if (auto name = op->getAttrOfType<StringAttr>("name"))
     newOp->setAttr("name", name);
 
@@ -485,7 +485,7 @@ LogicalResult Visitor::visitExpr(OpenSubindexOp op) {
   assert(newInput);
 
   ImplicitLocOpBuilder builder(op.getLoc(), op);
-  auto newOp = builder.create<SubindexOp>(newInput, op.getIndex());
+  auto newOp = SubindexOp::create(builder, newInput, op.getIndex());
   if (auto name = op->getAttrOfType<StringAttr>("name"))
     newOp->setAttr("name", name);
 
@@ -667,19 +667,16 @@ LogicalResult Visitor::visitDecl(WireOp op) {
   // Create the new HW wire.
   if (mappings.hwType)
     hwOnlyAggMap[op.getResult()] =
-        builder
-            .create<WireOp>(mappings.hwType, op.getName(), op.getNameKind(),
-                            op.getAnnotations(), mappings.newSym,
-                            op.getForceable())
+        WireOp::create(builder, mappings.hwType, op.getName(), op.getNameKind(),
+                       op.getAnnotations(), mappings.newSym, op.getForceable())
             .getResult();
 
   // Create the non-HW wires.  Non-HW wire names are always droppable.
   for (auto &[type, fieldID, _, suffix] : mappings.fields)
     nonHWValues[FieldRef(op.getResult(), fieldID)] =
-        builder
-            .create<WireOp>(type,
-                            builder.getStringAttr(Twine(op.getName()) + suffix),
-                            NameKindEnum::DroppableName)
+        WireOp::create(builder, type,
+                       builder.getStringAttr(Twine(op.getName()) + suffix),
+                       NameKindEnum::DroppableName)
             .getResult();
 
   for (auto fieldID : mappings.mapToNullInteriors)

--- a/lib/Dialect/FIRRTL/Transforms/LowerSignatures.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerSignatures.cpp
@@ -278,10 +278,9 @@ static LogicalResult lowerModuleSignature(FModuleLike module, Convention conv,
       if (p.fieldID != 0) {
         auto &wire = bounceWires[p.portID];
         if (!wire)
-          wire = theBuilder
-                     .create<WireOp>(module.getPortType(p.portID),
-                                     module.getPortNameAttr(p.portID),
-                                     NameKindEnum::InterestingName)
+          wire = WireOp::create(theBuilder, module.getPortType(p.portID),
+                                module.getPortNameAttr(p.portID),
+                                NameKindEnum::InterestingName)
                      .getResult();
       } else {
         bounceWires[p.portID] = newArg;
@@ -291,9 +290,8 @@ static LogicalResult lowerModuleSignature(FModuleLike module, Convention conv,
     // zero-length vectors.
     for (auto idx = 0U; idx < oldNumArgs; ++idx) {
       if (!bounceWires[idx]) {
-        bounceWires[idx] = theBuilder
-                               .create<WireOp>(module.getPortType(idx),
-                                               module.getPortNameAttr(idx))
+        bounceWires[idx] = WireOp::create(theBuilder, module.getPortType(idx),
+                                          module.getPortNameAttr(idx))
                                .getResult();
       }
       body->getArgument(idx).replaceAllUsesWith(bounceWires[idx]);
@@ -400,10 +398,10 @@ static void lowerModuleBody(FModuleOp mod,
       instPorts.push_back(p);
     }
     auto annos = inst.getAnnotations();
-    auto newOp = theBuilder.create<InstanceOp>(
-        instPorts, inst.getModuleName(), inst.getName(), inst.getNameKind(),
-        annos.getValue(), inst.getLayers(), inst.getLowerToBind(),
-        inst.getDoNotPrint(), inst.getInnerSymAttr());
+    auto newOp = InstanceOp::create(
+        theBuilder, instPorts, inst.getModuleName(), inst.getName(),
+        inst.getNameKind(), annos.getValue(), inst.getLayers(),
+        inst.getLowerToBind(), inst.getDoNotPrint(), inst.getInnerSymAttr());
 
     auto oldDict = inst->getDiscardableAttrDictionary();
     auto newDict = newOp->getDiscardableAttrDictionary();
@@ -423,8 +421,8 @@ static void lowerModuleBody(FModuleOp mod,
         continue;
       }
       if (!bounce[p.portID]) {
-        bounce[p.portID] = theBuilder.create<WireOp>(
-            inst.getResult(p.portID).getType(),
+        bounce[p.portID] = WireOp::create(
+            theBuilder, inst.getResult(p.portID).getType(),
             theBuilder.getStringAttr(
                 inst.getName() + "." +
                 cast<StringAttr>(oldNames[p.portID]).getValue()));

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -103,7 +103,7 @@ public:
     else
       builder.setInsertionPointToStart(body);
 
-    Value xmr = builder.create<XMRRefOp>(type, symbol, suffix);
+    Value xmr = XMRRefOp::create(builder, type, symbol, suffix);
     xmrRefCache.insert({{type, symbol, suffix}, xmr});
 
     xmrRefPoint = builder.saveInsertionPoint();
@@ -192,7 +192,7 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
                 nameKind = NameKindEnum::InterestingName;
               }
             }
-            xmrDef = b.create<NodeOp>(xmrDef, opName, nameKind).getResult();
+            xmrDef = NodeOp::create(b, xmrDef, opName, nameKind).getResult();
 
             // Create a new entry for this RefSendOp. The path is currently
             // local.
@@ -560,8 +560,8 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
       ImplicitLocOpBuilder builder(resolve.getLoc(), resolve);
       auto zeroUintType = UIntType::get(builder.getContext(), 0);
       auto zeroC = builder.createOrFold<BitCastOp>(
-          resolve.getType(), builder.create<ConstantOp>(
-                                 zeroUintType, getIntZerosAttr(zeroUintType)));
+          resolve.getType(), ConstantOp::create(builder, zeroUintType,
+                                                getIntZerosAttr(zeroUintType)));
       resolve.getResult().replaceAllUsesWith(zeroC);
       return success();
     }
@@ -572,7 +572,7 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
     if (failed(resolveReference(resolve.getRef(), builder, ref, str)))
       return failure();
 
-    Value result = builder.create<XMRDerefOp>(resolve.getType(), ref, str);
+    Value result = XMRDerefOp::create(builder, resolve.getType(), ref, str);
     resolve.getResult().replaceAllUsesWith(result);
     return success();
   }
@@ -702,7 +702,8 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
         getRefABIPrefix(module, circuitRefPrefix);
       auto macroName =
           getRefABIMacroForPort(module, portIndex, circuitRefPrefix);
-      declBuilder.create<sv::MacroDeclOp>(macroName, ArrayAttr(), StringAttr());
+      sv::MacroDeclOp::create(declBuilder, macroName, ArrayAttr(),
+                              StringAttr());
       ports.emplace_back(macroName, declBuilder.getStringAttr(formatString),
                          ref ? declBuilder.getArrayAttr({ref}) : ArrayAttr{});
     }
@@ -714,10 +715,10 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
     // The macros will be exported to a `ref_<module-name>.sv` file.
     // In the IR, the file is inserted before the module.
     auto fileBuilder = ImplicitLocOpBuilder(module.getLoc(), module);
-    fileBuilder.create<emit::FileOp>(circuitRefPrefix + ".sv", [&] {
+    emit::FileOp::create(fileBuilder, circuitRefPrefix + ".sv", [&] {
       for (auto [macroName, formatString, symbols] : ports) {
-        fileBuilder.create<sv::MacroDefOp>(FlatSymbolRefAttr::get(macroName),
-                                           formatString, symbols);
+        sv::MacroDefOp::create(fileBuilder, FlatSymbolRefAttr::get(macroName),
+                               formatString, symbols);
       }
     });
 
@@ -812,8 +813,8 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
           portAnnotations.push_back(mem.getPortAnnotation(res.index()));
           oldResults.push_back(res.value());
         }
-        auto newMem = builder.create<MemOp>(
-            resultTypes, mem.getReadLatency(), mem.getWriteLatency(),
+        auto newMem = MemOp::create(
+            builder, resultTypes, mem.getReadLatency(), mem.getWriteLatency(),
             mem.getDepth(), RUWAttr::Undefined,
             builder.getArrayAttr(resultNames), mem.getNameAttr(),
             mem.getNameKind(), mem.getAnnotations(),

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -208,8 +208,8 @@ public:
       else
         namepath.push_back(FlatSymbolRefAttr::get(modPart));
 
-      auto hp = b.create<hw::HierPathOp>(b.getUnknownLoc(), sym,
-                                         b.getArrayAttr(namepath));
+      auto hp = hw::HierPathOp::create(b, b.getUnknownLoc(), sym,
+                                       b.getArrayAttr(namepath));
       hp.setVisibility(nla.getVisibility());
       return hp;
     };
@@ -865,13 +865,12 @@ void Inliner::mapPortsToWires(StringRef prefix, InliningLevel &il,
     }
 
     Value wire =
-        il.mic.b
-            .create<WireOp>(
-                target.getLoc(), type,
-                StringAttr::get(context, (prefix + portInfo[i].getName())),
-                NameKindEnumAttr::get(context, NameKindEnum::DroppableName),
-                ArrayAttr::get(context, newAnnotations), newSymAttr,
-                /*forceable=*/UnitAttr{})
+        WireOp::create(
+            il.mic.b, target.getLoc(), type,
+            StringAttr::get(context, (prefix + portInfo[i].getName())),
+            NameKindEnumAttr::get(context, NameKindEnum::DroppableName),
+            ArrayAttr::get(context, newAnnotations), newSymAttr,
+            /*forceable=*/UnitAttr{})
             .getResult();
     il.wires.push_back(wire);
     mapper.map(arg, wire);
@@ -1363,8 +1362,8 @@ LogicalResult Inliner::inlineInstances(FModuleOp module) {
 
 void Inliner::createDebugScope(InliningLevel &il, InstanceOp instance,
                                Value parentScope) {
-  auto op = il.mic.b.create<debug::ScopeOp>(
-      instance.getLoc(), instance.getInstanceNameAttr(),
+  auto op = debug::ScopeOp::create(
+      il.mic.b, instance.getLoc(), instance.getInstanceNameAttr(),
       instance.getModuleNameAttr().getAttr(), parentScope);
   debugScopes.push_back(op);
   il.debugScope = op;

--- a/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
@@ -64,8 +64,9 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
 
   // Register is only written by itself, replace with invalid.
   if (con.getSrc() == reg.getResult()) {
-    auto inv = OpBuilder(reg).create<InvalidValueOp>(reg.getLoc(),
-                                                     reg.getResult().getType());
+    auto builder = OpBuilder(reg);
+    auto inv = InvalidValueOp::create(builder, reg.getLoc(),
+                                      reg.getResult().getType());
     reg.getResult().replaceAllUsesWith(inv.getResult());
     toErase.push_back(reg);
     toErase.push_back(con);
@@ -98,8 +99,9 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
         reg.getResult().replaceAllUsesWith(con.getSrc());
         toErase.push_back(con);
       } else {
-        auto bounce = OpBuilder(reg).create<WireOp>(reg.getLoc(),
-                                                    reg.getResult().getType());
+        auto builder = OpBuilder(reg);
+        auto bounce =
+            WireOp::create(builder, reg.getLoc(), reg.getResult().getType());
         reg.replaceAllUsesWith(bounce);
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -103,7 +103,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
         // Replace the port with a wire if it is unused.
         auto builder = ImplicitLocOpBuilder::atBlockBegin(
             arg.getLoc(), module.getBodyBlock());
-        auto wire = builder.create<WireOp>(arg.getType());
+        auto wire = WireOp::create(builder, arg.getType());
         arg.replaceAllUsesWith(wire.getResult());
         outputPortConstants.push_back(std::nullopt);
       } else if (arg.hasOneUse()) {
@@ -160,7 +160,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
       // If the port is input, replace the port with an unwritten wire
       // so that we can remove use-chains in SV dialect canonicalization.
       if (ports[index].isInput()) {
-        WireOp wire = builder.create<WireOp>(result.getType());
+        WireOp wire = WireOp::create(builder, result.getType());
 
         // Check that the input port is only written. Sometimes input ports are
         // used as temporary wires. In that case, we cannot erase connections.
@@ -191,9 +191,9 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
       auto portConstant = outputPortConstants[outputPortIndex++];
       Value value;
       if (portConstant)
-        value = builder.create<ConstantOp>(*portConstant);
+        value = ConstantOp::create(builder, *portConstant);
       else
-        value = builder.create<InvalidValueOp>(result.getType());
+        value = InvalidValueOp::create(builder, result.getType());
 
       result.replaceAllUsesWith(value);
     }

--- a/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
@@ -114,7 +114,7 @@ struct PathResolver {
       // - i.e. the id is not attached to any target.
       auto targetKind = TargetKindAttr::get(context, TargetKind::Reference);
       auto id = DistinctAttr::create(UnitAttr::get(context));
-      auto resolved = b.create<PathOp>(targetKind, id);
+      auto resolved = PathOp::create(b, targetKind, id);
       unresolved->replaceAllUsesWith(resolved);
       unresolved.erase();
       return success();
@@ -209,7 +209,7 @@ struct PathResolver {
     // Create a PathOp using the id in the annotation we added to the target.
     auto dictAttr = cast<DictionaryAttr>(annotation);
     auto id = cast<DistinctAttr>(dictAttr.get("id"));
-    auto resolved = b.create<PathOp>(targetKindAttr, id);
+    auto resolved = PathOp::create(b, targetKindAttr, id);
 
     // Replace the unresolved path with the PathOp.
     unresolved->replaceAllUsesWith(resolved);

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -417,9 +417,9 @@ void ResolveTracesPass::runOnOperation() {
   else
     fileAttr = builder.getStringAttr(outputAnnotationFilename);
 
-  builder.create<emit::FileOp>(fileAttr, [&] {
-    builder.create<sv::VerbatimOp>(jsonBuffer, ValueRange{},
-                                   builder.getArrayAttr(symbols));
+  emit::FileOp::create(builder, fileAttr, [&] {
+    sv::VerbatimOp::create(builder, jsonBuffer, ValueRange{},
+                           builder.getArrayAttr(symbols));
   });
 
   return markAllAnalysesPreserved();

--- a/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
@@ -79,8 +79,8 @@ struct SpecializeOptionPass
               target = inst.getTargetOrDefaultAttr(it->second);
 
             ImplicitLocOpBuilder builder(inst.getLoc(), inst);
-            auto newInst = builder.create<InstanceOp>(
-                inst->getResultTypes(), target, inst.getNameAttr(),
+            auto newInst = InstanceOp::create(
+                builder, inst->getResultTypes(), target, inst.getNameAttr(),
                 inst.getNameKindAttr(), inst.getPortDirectionsAttr(),
                 inst.getPortNamesAttr(), inst.getAnnotationsAttr(),
                 inst.getPortAnnotationsAttr(), builder.getArrayAttr({}),

--- a/lib/Dialect/FSM/FSMGraph.cpp
+++ b/lib/Dialect/FSM/FSMGraph.cpp
@@ -85,7 +85,7 @@ FSMStateNode *FSMGraph::createState(OpBuilder &builder, Location loc,
                                     StringRef name) {
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPointToEnd(&getMachine().getBody().front());
-  auto stateOp = builder.create<StateOp>(loc, name);
+  auto stateOp = StateOp::create(builder, loc, name);
   return getOrAddState(stateOp);
 }
 
@@ -96,7 +96,7 @@ FSMTransitionEdge *FSMGraph::createTransition(OpBuilder &builder, Location loc,
   OpBuilder::InsertionGuard g(builder);
   // Set the insertion point to the end of the transitions.
   builder.setInsertionPointToEnd(&from.getTransitions().getBlocks().front());
-  auto transition = builder.create<TransitionOp>(loc, to);
+  auto transition = TransitionOp::create(builder, loc, to);
   return currentStateNode->addTransitionEdge(nextStateNode, transition);
 }
 

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -315,7 +315,7 @@ void StateOp::build(OpBuilder &builder, OperationState &state,
   Region *output = state.addRegion();
   output->push_back(new Block());
   builder.setInsertionPointToEnd(&output->back());
-  builder.create<fsm::OutputOp>(state.location);
+  fsm::OutputOp::create(builder, state.location);
   Region *transitions = state.addRegion();
   transitions->push_back(new Block());
   state.addAttribute("sym_name", builder.getStringAttr(stateName));
@@ -327,7 +327,7 @@ void StateOp::build(OpBuilder &builder, OperationState &state,
   Region *output = state.addRegion();
   output->push_back(new Block());
   builder.setInsertionPointToEnd(&output->back());
-  builder.create<fsm::OutputOp>(state.location, outputs);
+  fsm::OutputOp::create(builder, state.location, outputs);
   Region *transitions = state.addRegion();
   transitions->push_back(new Block());
   state.addAttribute("sym_name", builder.getStringAttr(stateName));
@@ -382,7 +382,7 @@ Block *StateOp::ensureOutput(OpBuilder &builder) {
     auto *block = new Block();
     getOutput().push_back(block);
     builder.setInsertionPointToStart(block);
-    builder.create<fsm::OutputOp>(getLoc());
+    fsm::OutputOp::create(builder, getLoc());
   }
   return &getOutput().front();
 }
@@ -445,7 +445,7 @@ Block *TransitionOp::ensureGuard(OpBuilder &builder) {
     auto *block = new Block();
     getGuard().push_back(block);
     builder.setInsertionPointToStart(block);
-    builder.create<fsm::ReturnOp>(getLoc());
+    fsm::ReturnOp::create(builder, getLoc());
   }
   return &getGuard().front();
 }
@@ -492,7 +492,7 @@ LogicalResult TransitionOp::canonicalize(TransitionOp op,
           // Replace the original return op with a new one without any operands
           // if the constant is TRUE.
           rewriter.setInsertionPoint(guardReturn);
-          rewriter.create<fsm::ReturnOp>(guardReturn.getLoc());
+          fsm::ReturnOp::create(rewriter, guardReturn.getLoc());
           rewriter.eraseOp(guardReturn);
         } else {
           // Erase the whole transition op if the constant is FALSE, because the

--- a/lib/Dialect/HW/HWDialect.cpp
+++ b/lib/Dialect/HW/HWDialect.cpp
@@ -93,24 +93,24 @@ Operation *HWDialect::materializeConstant(OpBuilder &builder, Attribute value,
   // Integer constants can materialize into hw.constant
   if (auto intType = dyn_cast<IntegerType>(type))
     if (auto attrValue = dyn_cast<IntegerAttr>(value))
-      return builder.create<ConstantOp>(loc, type, attrValue);
+      return ConstantOp::create(builder, loc, type, attrValue);
 
   // Aggregate constants.
   if (auto arrayAttr = dyn_cast<ArrayAttr>(value)) {
     if (type_isa<StructType, ArrayType, UnpackedArrayType>(type))
-      return builder.create<AggregateConstantOp>(loc, type, arrayAttr);
+      return AggregateConstantOp::create(builder, loc, type, arrayAttr);
   }
 
   // Parameter expressions materialize into hw.param.value.
   Block *block = builder.getBlock();
   if (!block)
     return nullptr;
-  auto parentOp = block->getParentOp();
+  auto *parentOp = block->getParentOp();
   auto curModule = dyn_cast<HWModuleOp>(parentOp);
   if (!curModule)
     curModule = parentOp->getParentOfType<HWModuleOp>();
   if (curModule && isValidParameterExpression(value, curModule))
-    return builder.create<ParamValueOp>(loc, type, value);
+    return ParamValueOp::create(builder, loc, type, value);
 
   return nullptr;
 }

--- a/lib/Dialect/HW/HWReductions.cpp
+++ b/lib/Dialect/HW/HWReductions.cpp
@@ -68,9 +68,8 @@ struct ModuleExternalizer : public OpReduction<HWModuleOp> {
 
   LogicalResult rewrite(HWModuleOp op) override {
     OpBuilder builder(op);
-    builder.create<HWModuleExternOp>(op->getLoc(), op.getModuleNameAttr(),
-                                     op.getPortList(), StringRef(),
-                                     op.getParameters());
+    HWModuleExternOp::create(builder, op->getLoc(), op.getModuleNameAttr(),
+                             op.getPortList(), StringRef(), op.getParameters());
     op->erase();
     return success();
   }
@@ -126,7 +125,7 @@ struct HWConstantifier : public Reduction {
     OpBuilder builder(op);
     for (auto result : op->getResults()) {
       auto type = cast<IntegerType>(result.getType());
-      auto newOp = builder.create<hw::ConstantOp>(op->getLoc(), type, 0);
+      auto newOp = hw::ConstantOp::create(builder, op->getLoc(), type, 0);
       result.replaceAllUsesWith(newOp);
     }
     reduce::pruneUnusedOps(op, *this);

--- a/lib/Dialect/HW/HierPathCache.cpp
+++ b/lib/Dialect/HW/HierPathCache.cpp
@@ -53,8 +53,9 @@ HierPathOp HierPathCache::getOrCreatePath(ArrayAttr pathArray, Location loc,
   // Create the new HierPathOp and insert it into the pathCache.
   hw::HierPathOp path =
       pathCache
-          .insert({pathArray, builder.create<hw::HierPathOp>(
-                                  loc, ns->newName(nameHint), pathArray)})
+          .insert({pathArray,
+                   hw::HierPathOp::create(builder, loc, ns->newName(nameHint),
+                                          pathArray)})
           .first->second;
   path.setVisibility(SymbolTable::Visibility::Private);
 

--- a/lib/Dialect/HW/PortConverter.cpp
+++ b/lib/Dialect/HW/PortConverter.cpp
@@ -229,8 +229,8 @@ void PortConverterImpl::updateInstance(hw::InstanceOp inst) {
   assert(llvm::none_of(newOperands, [](Value v) { return !v; }));
   b.setInsertionPointAfter(inst);
   auto newInst =
-      b.create<InstanceOp>(mod, inst.getInstanceNameAttr(), newOperands,
-                           inst.getParameters(), inst.getInnerSymAttr());
+      InstanceOp::create(b, mod, inst.getInstanceNameAttr(), newOperands,
+                         inst.getParameters(), inst.getInnerSymAttr());
   newInst->setDialectAttrs(inst->getDialectAttrs());
 
   // Assign the backedges to the new results.

--- a/lib/Dialect/HW/Transforms/FlattenIO.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenIO.cpp
@@ -68,8 +68,8 @@ struct OutputOpConversion : public OpConversionPattern<hw::OutputOp> {
     // Flatten the operands.
     for (auto operand : adaptor.getOperands()) {
       if (auto structType = getStructType(operand.getType())) {
-        auto explodedStruct = rewriter.create<hw::StructExplodeOp>(
-            op.getLoc(), getInnerTypes(structType), operand);
+        auto explodedStruct = hw::StructExplodeOp::create(
+            rewriter, op.getLoc(), getInnerTypes(structType), operand);
         llvm::copy(explodedStruct.getResults(),
                    std::back_inserter(convOperands));
       } else {
@@ -91,8 +91,8 @@ struct OutputOpConversion : public OpConversionPattern<hw::OutputOp> {
     // Flatten the operands.
     for (auto operand : flattenValues(adaptor.getOperands())) {
       if (auto structType = getStructType(operand.getType())) {
-        auto explodedStruct = rewriter.create<hw::StructExplodeOp>(
-            op.getLoc(), getInnerTypes(structType), operand);
+        auto explodedStruct = hw::StructExplodeOp::create(
+            rewriter, op.getLoc(), getInnerTypes(structType), operand);
         llvm::copy(explodedStruct.getResults(),
                    std::back_inserter(convOperands));
       } else {
@@ -129,8 +129,8 @@ struct InstanceOpConversion : public OpConversionPattern<hw::InstanceOp> {
     llvm::SmallVector<Value> convOperands;
     for (auto operand : flattenValues(adaptor.getOperands())) {
       if (auto structType = getStructType(operand.getType())) {
-        auto explodedStruct = rewriter.create<hw::StructExplodeOp>(
-            loc, getInnerTypes(structType), operand);
+        auto explodedStruct = hw::StructExplodeOp::create(
+            rewriter, loc, getInnerTypes(structType), operand);
         llvm::copy(explodedStruct.getResults(),
                    std::back_inserter(convOperands));
       } else {
@@ -150,8 +150,8 @@ struct InstanceOpConversion : public OpConversionPattern<hw::InstanceOp> {
 
     // Create the new instance with the flattened module, attributes will be
     // adjusted later.
-    auto newInstance = rewriter.create<hw::InstanceOp>(
-        loc, newResultTypes, op.getInstanceNameAttr(),
+    auto newInstance = hw::InstanceOp::create(
+        rewriter, loc, newResultTypes, op.getInstanceNameAttr(),
         FlatSymbolRefAttr::get(referencedMod), convOperands,
         op.getArgNamesAttr(), op.getResultNamesAttr(), op.getParametersAttr(),
         op.getInnerSymAttr(), op.getDoNotPrintAttr());
@@ -164,8 +164,8 @@ struct InstanceOpConversion : public OpConversionPattern<hw::InstanceOp> {
       Type oldResultType = op.getResultTypes()[oldResultCntr];
       if (auto structType = getStructType(oldResultType)) {
         size_t nElements = structType.getElements().size();
-        auto implodedStruct = rewriter.create<hw::StructCreateOp>(
-            loc, structType,
+        auto implodedStruct = hw::StructCreateOp::create(
+            rewriter, loc, structType,
             newInstance.getResults().slice(resIndex, nElements));
         convResults.push_back(implodedStruct.getResult());
         resIndex += nElements - 1;
@@ -214,18 +214,18 @@ public:
       if (inputs.size() != 1 && !isStructType(inputs[0].getType()))
         return ValueRange();
 
-      auto explodeOp = builder.create<hw::StructExplodeOp>(loc, inputs[0]);
+      auto explodeOp = hw::StructExplodeOp::create(builder, loc, inputs[0]);
       return ValueRange(explodeOp.getResults());
     });
     addTargetMaterialization([](OpBuilder &builder, hw::StructType type,
                                 ValueRange inputs, Location loc) {
-      auto result = builder.create<hw::StructCreateOp>(loc, type, inputs);
+      auto result = hw::StructCreateOp::create(builder, loc, type, inputs);
       return result.getResult();
     });
 
     addTargetMaterialization([](OpBuilder &builder, hw::TypeAliasType type,
                                 ValueRange inputs, Location loc) {
-      auto result = builder.create<hw::StructCreateOp>(loc, type, inputs);
+      auto result = hw::StructCreateOp::create(builder, loc, type, inputs);
       return result.getResult();
     });
 
@@ -237,7 +237,7 @@ public:
     // which persist beyond the conversion.
     addSourceMaterialization([](OpBuilder &builder, hw::StructType type,
                                 ValueRange inputs, Location loc) {
-      auto result = builder.create<hw::StructCreateOp>(loc, type, inputs);
+      auto result = hw::StructCreateOp::create(builder, loc, type, inputs);
       return result.getResult();
     });
   }

--- a/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
+++ b/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
@@ -130,7 +130,7 @@ public:
       if (inputs.size() != 1)
         return Value();
 
-      return builder.create<hw::BitcastOp>(loc, resultType, inputs[0])
+      return hw::BitcastOp::create(builder, loc, resultType, inputs[0])
           ->getResult(0);
     });
 
@@ -140,7 +140,7 @@ public:
       if (inputs.size() != 1)
         return Value();
 
-      return builder.create<hw::BitcastOp>(loc, resultType, inputs[0])
+      return hw::BitcastOp::create(builder, loc, resultType, inputs[0])
           ->getResult(0);
     });
   }

--- a/lib/Dialect/HW/Transforms/HWSpecialize.cpp
+++ b/lib/Dialect/HW/Transforms/HWSpecialize.cpp
@@ -70,13 +70,11 @@ static FailureOr<Value> narrowValueToArrayWidth(OpBuilder &builder, Value array,
   unsigned hiBit = llvm::Log2_64_Ceil(arrayType.getNumElements());
 
   return hiBit == 0
-             ? builder
-                   .create<hw::ConstantOp>(value.getLoc(),
-                                           APInt(arrayType.getNumElements(), 0))
+             ? hw::ConstantOp::create(builder, value.getLoc(),
+                                      APInt(arrayType.getNumElements(), 0))
                    .getResult()
-             : builder
-                   .create<comb::ExtractOp>(value.getLoc(), value,
-                                            /*lowBit=*/0, hiBit)
+             : comb::ExtractOp::create(builder, value.getLoc(), value,
+                                       /*lowBit=*/0, hiBit)
                    .getResult();
 }
 
@@ -299,8 +297,8 @@ static LogicalResult specializeModule(
   }
 
   // Create the specialized module using the evaluated port info.
-  target = builder.create<HWModuleOp>(
-      source.getLoc(),
+  target = HWModuleOp::create(
+      builder, source.getLoc(),
       StringAttr::get(ctx, generateModuleName(ns, source, parameters)), ports);
 
   // Erase the default created hw.output op - we'll copy the correct operation

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -206,8 +206,8 @@ struct EliminateUnusedForkResultsPattern : mlir::OpRewritePattern<ForkOp> {
     // Create a new fork op, dropping the unused results.
     rewriter.setInsertionPoint(op);
     auto operand = op.getOperand();
-    auto newFork = rewriter.create<ForkOp>(
-        op.getLoc(), operand, op.getNumResults() - unusedIndexes.size());
+    auto newFork = ForkOp::create(rewriter, op.getLoc(), operand,
+                                  op.getNumResults() - unusedIndexes.size());
     unsigned i = 0;
     for (auto oldRes : llvm::enumerate(op.getResults()))
       if (unusedIndexes.count(oldRes.index()) == 0)
@@ -233,8 +233,9 @@ struct EliminateForkToForkPattern : mlir::OpRewritePattern<ForkOp> {
     unsigned totalNumOuts = op.getSize() + parentForkOp.getSize();
     /// Create a new parent fork op which produces all of the fork outputs and
     /// replace all of the uses of the old results.
-    auto newParentForkOp = rewriter.create<ForkOp>(
-        parentForkOp.getLoc(), parentForkOp.getOperand(), totalNumOuts);
+    auto newParentForkOp =
+        ForkOp::create(rewriter, parentForkOp.getLoc(),
+                       parentForkOp.getOperand(), totalNumOuts);
 
     for (auto it :
          llvm::zip(parentForkOp->getResults(), newParentForkOp.getResults()))
@@ -730,7 +731,7 @@ LogicalResult EliminateSimpleControlMergesPattern::matchAndRewrite(
       return failure();
   }
 
-  auto merge = rewriter.create<MergeOp>(op.getLoc(), op.getDataOperands());
+  auto merge = MergeOp::create(rewriter, op.getLoc(), op.getDataOperands());
 
   for (auto &use : llvm::make_early_inc_range(dataResult.getUses())) {
     auto *user = use.getOwner();

--- a/lib/Dialect/Handshake/HandshakeUtils.cpp
+++ b/lib/Dialect/Handshake/HandshakeUtils.cpp
@@ -256,9 +256,9 @@ void circt::handshake::insertFork(Value result, bool isLazy,
   auto forkSize = opsToProcess.size();
   Operation *newOp;
   if (isLazy)
-    newOp = rewriter.create<LazyForkOp>(result.getLoc(), result, forkSize);
+    newOp = LazyForkOp::create(rewriter, result.getLoc(), result, forkSize);
   else
-    newOp = rewriter.create<ForkOp>(result.getLoc(), result, forkSize);
+    newOp = ForkOp::create(rewriter, result.getLoc(), result, forkSize);
 
   // Modify operands of successor
   // opsToProcess may have multiple instances of same operand

--- a/lib/Dialect/Handshake/Transforms/Buffers.cpp
+++ b/lib/Dialect/Handshake/Transforms/Buffers.cpp
@@ -73,7 +73,7 @@ static void insertBuffer(Location loc, Value operand, OpBuilder &builder,
   auto ip = builder.saveInsertionPoint();
   builder.setInsertionPointAfterValue(operand);
   auto bufferOp =
-      builder.create<handshake::BufferOp>(loc, operand, numSlots, bufferType);
+      handshake::BufferOp::create(builder, loc, operand, numSlots, bufferType);
   operand.replaceUsesWithIf(
       bufferOp, function_ref<bool(OpOperand &)>([](OpOperand &operand) -> bool {
         return !isa<handshake::BufferOp>(operand.getOwner());

--- a/lib/Dialect/Handshake/Transforms/LegalizeMemrefs.cpp
+++ b/lib/Dialect/Handshake/Transforms/LegalizeMemrefs.cpp
@@ -71,25 +71,25 @@ struct HandshakeLegalizeMemrefsPass
 
       auto emitLoadStore = [&](Value index) {
         llvm::SmallVector<Value> indices = {index};
-        auto loadValue = b.create<memref::LoadOp>(loc, src, indices);
-        b.create<memref::StoreOp>(loc, loadValue, dst, indices);
+        auto loadValue = memref::LoadOp::create(b, loc, src, indices);
+        memref::StoreOp::create(b, loc, loadValue, dst, indices);
       };
 
       auto n = memrefType.getShape()[0];
 
       if (n > 1) {
-        auto lb = b.create<arith::ConstantIndexOp>(loc, 0).getResult();
-        auto ub = b.create<arith::ConstantIndexOp>(loc, n).getResult();
-        auto step = b.create<arith::ConstantIndexOp>(loc, 1).getResult();
+        auto lb = arith::ConstantIndexOp::create(b, loc, 0).getResult();
+        auto ub = arith::ConstantIndexOp::create(b, loc, n).getResult();
+        auto step = arith::ConstantIndexOp::create(b, loc, 1).getResult();
 
-        b.create<scf::ForOp>(
-            loc, lb, ub, step, llvm::SmallVector<Value>(),
+        scf::ForOp::create(
+            b, loc, lb, ub, step, llvm::SmallVector<Value>(),
             [&](OpBuilder &b, Location loc, Value iv, ValueRange loopState) {
               emitLoadStore(iv);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
       } else
-        emitLoadStore(b.create<arith::ConstantIndexOp>(loc, 0));
+        emitLoadStore(arith::ConstantIndexOp::create(b, loc, 0));
 
       copy.erase();
     }

--- a/lib/Dialect/Handshake/Transforms/LockFunctions.cpp
+++ b/lib/Dialect/Handshake/Transforms/LockFunctions.cpp
@@ -45,8 +45,8 @@ static LogicalResult lockRegion(Region &r, OpBuilder &rewriter) {
   BackedgeBuilder bebuilder(rewriter, loc);
   auto backEdge = bebuilder.get(rewriter.getNoneType());
 
-  auto buff = rewriter.create<handshake::BufferOp>(loc, backEdge, 1,
-                                                   BufferTypeEnum::seq);
+  auto buff = handshake::BufferOp::create(rewriter, loc, backEdge, 1,
+                                          BufferTypeEnum::seq);
 
   // Dummy value that causes a buffer initialization, but itself does not have a
   // semantic meaning.
@@ -55,7 +55,7 @@ static LogicalResult lockRegion(Region &r, OpBuilder &rewriter) {
   SmallVector<Value> inSyncOperands =
       llvm::to_vector_of<Value>(entry->getArguments());
   inSyncOperands.push_back(buff);
-  auto sync = rewriter.create<SyncOp>(loc, inSyncOperands);
+  auto sync = SyncOp::create(rewriter, loc, inSyncOperands);
 
   // replace all func arg usages with the synced ones
   // TODO is this UB?
@@ -67,7 +67,7 @@ static LogicalResult lockRegion(Region &r, OpBuilder &rewriter) {
   SmallVector<Value> endJoinOperands = llvm::to_vector(ret->getOperands());
   // Add the axilirary control signal output to the end-join
   endJoinOperands.push_back(sync.getResults().back());
-  auto endJoin = rewriter.create<JoinOp>(loc, endJoinOperands);
+  auto endJoin = JoinOp::create(rewriter, loc, endJoinOperands);
 
   backEdge.setValue(endJoin);
   return success();

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -152,8 +152,8 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
   b.setInsertionPoint(func);
   auto newPortInfo = handshake::getPortInfoForOpTypes(
       func, func.getArgumentTypes(), func.getResultTypes());
-  auto extMod = b.create<hw::HWModuleExternOp>(
-      loc, StringAttr::get(ctx, "__" + func.getName() + "_hw"), newPortInfo);
+  auto extMod = hw::HWModuleExternOp::create(
+      b, loc, StringAttr::get(ctx, "__" + func.getName() + "_hw"), newPortInfo);
 
   // Add an attribute to the original handshake function to indicate that it
   // needs to resolve to extMod in a later pass.
@@ -168,8 +168,8 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
                   [](auto &pair) { return pair.first; });
   for (auto i : llvm::reverse(argReplacementsIdxs))
     wrapperModPortInfo.eraseInput(i);
-  auto wrapperMod = b.create<hw::HWModuleOp>(
-      loc, StringAttr::get(ctx, func.getName() + "_esi_wrapper"),
+  auto wrapperMod = hw::HWModuleOp::create(
+      b, loc, StringAttr::get(ctx, func.getName() + "_esi_wrapper"),
       wrapperModPortInfo);
   Value clk = wrapperMod.getBodyBlock()->getArgument(
       wrapperMod.getBodyBlock()->getNumArguments() - 2);
@@ -204,8 +204,8 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
     auto dataType = memType.memRefType.getElementType();
     assert(memrefShape.size() == 1 && "Only 1D memrefs are supported");
     unsigned memrefSize = memrefShape[0];
-    auto memServiceDecl = b.create<esi::RandomAccessMemoryDeclOp>(
-        loc, origPortInfo.name, TypeAttr::get(dataType),
+    auto memServiceDecl = esi::RandomAccessMemoryDeclOp::create(
+        b, loc, origPortInfo.name, TypeAttr::get(dataType),
         b.getI64IntegerAttr(memrefSize));
     esi::ServicePortInfo writePortInfo = memServiceDecl.writePortInfo();
     esi::ServicePortInfo readPortInfo = memServiceDecl.readPortInfo();
@@ -218,11 +218,11 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
 
     // Load ports:
     for (unsigned i = 0; i < memType.loadPorts; ++i) {
-      auto req = b.create<esi::RequestConnectionOp>(
-          loc, readPortInfo.type, readPortInfo.port,
+      auto req = esi::RequestConnectionOp::create(
+          b, loc, readPortInfo.type, readPortInfo.port,
           esi::AppIDAttr::get(ctx, b.getStringAttr("load"), resIdx));
-      auto reqUnpack = b.create<esi::UnpackBundleOp>(
-          loc, req.getToClient(), ValueRange{backedges[resIdx]});
+      auto reqUnpack = esi::UnpackBundleOp::create(
+          b, loc, req.getToClient(), ValueRange{backedges[resIdx]});
       instanceArgsFromThisMem.push_back(
           reqUnpack.getToChannels()
               [esi::RandomAccessMemoryDeclOp::RespDirChannelIdx]);
@@ -231,11 +231,11 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
 
     // Store ports:
     for (unsigned i = 0; i < memType.storePorts; ++i) {
-      auto req = b.create<esi::RequestConnectionOp>(
-          loc, writePortInfo.type, writePortInfo.port,
+      auto req = esi::RequestConnectionOp::create(
+          b, loc, writePortInfo.type, writePortInfo.port,
           esi::AppIDAttr::get(ctx, b.getStringAttr("store"), resIdx));
-      auto reqUnpack = b.create<esi::UnpackBundleOp>(
-          loc, req.getToClient(), ValueRange{backedges[resIdx]});
+      auto reqUnpack = esi::UnpackBundleOp::create(
+          b, loc, req.getToClient(), ValueRange{backedges[resIdx]});
       instanceArgsFromThisMem.push_back(
           reqUnpack.getToChannels()
               [esi::RandomAccessMemoryDeclOp::RespDirChannelIdx]);
@@ -280,7 +280,7 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
 
   // Instantiate the inner module.
   auto instance =
-      b.create<hw::InstanceOp>(loc, extMod, func.getName(), instanceArgs);
+      hw::InstanceOp::create(b, loc, extMod, func.getName(), instanceArgs);
 
   // And resolve the backedges.
   for (auto [res, be] : llvm::zip(instance.getResults(), backedges))
@@ -291,8 +291,8 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
   auto outputOp =
       cast<hw::OutputOp>(wrapperMod.getBodyBlock()->getTerminator());
   b.setInsertionPoint(outputOp);
-  b.create<hw::OutputOp>(
-      outputOp.getLoc(),
+  hw::OutputOp::create(
+      b, outputOp.getLoc(),
       instance.getResults().take_front(wrapperMod.getNumOutputPorts()));
   outputOp.erase();
 
@@ -307,7 +307,7 @@ static Value truncateToMemoryWidth(Location loc, OpBuilder &b, Value v,
                                    MemRefType memRefType) {
   assert(isa<IndexType>(v.getType()) && "Expected an index-typed value");
   auto addrWidth = llvm::Log2_64_Ceil(memRefType.getShape().front());
-  return b.create<arith::IndexCastOp>(loc, b.getIntegerType(addrWidth), v);
+  return arith::IndexCastOp::create(b, loc, b.getIntegerType(addrWidth), v);
 }
 
 static Value plumbLoadPort(Location loc, OpBuilder &b,
@@ -316,11 +316,11 @@ static Value plumbLoadPort(Location loc, OpBuilder &b,
   // We need to feed both the load data and the load done outputs.
   // Fork the extracted load data into two, and 'join' the second one to
   // generate a none-typed output to drive the load done.
-  auto dataFork = b.create<ForkOp>(loc, loadData, 2);
+  auto dataFork = ForkOp::create(b, loc, loadData, 2);
 
   auto dataOut = dataFork.getResult()[0];
   llvm::SmallVector<Value> joinArgs = {dataFork.getResult()[1]};
-  auto dataDone = b.create<JoinOp>(loc, joinArgs);
+  auto dataDone = JoinOp::create(b, loc, joinArgs);
 
   ldif.dataOut.replaceAllUsesWith(dataOut);
   ldif.doneOut.replaceAllUsesWith(dataDone);
@@ -339,9 +339,8 @@ static Value plumbStorePort(Location loc, OpBuilder &b,
   llvm::SmallVector<Value> structArgs = {
       truncateToMemoryWidth(loc, b, stif.addressIn, memrefType), stif.dataIn};
 
-  return b
-      .create<hw::StructCreateOp>(loc, cast<hw::StructType>(outType),
-                                  structArgs)
+  return hw::StructCreateOp::create(b, loc, cast<hw::StructType>(outType),
+                                    structArgs)
       .getResult();
 }
 
@@ -469,7 +468,7 @@ HandshakeLowerExtmemToHWPass::lowerExtmemToHW(handshake::FuncOp func) {
     // Replace the return op of the function with a new one that returns the
     // memory output struct.
     b.setInsertionPoint(oldReturnOp);
-    b.create<ReturnOp>(arg.getLoc(), newReturnOperands);
+    ReturnOp::create(b, arg.getLoc(), newReturnOperands);
     oldReturnOp.erase();
 
     // Erase the extmemory operation since I/O plumbing has replaced all of its

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -43,7 +43,7 @@ using BlockValues = DenseMap<Block *, std::vector<Value>>;
 
 static void insertSink(Value val, OpBuilder &rewriter) {
   rewriter.setInsertionPointAfterValue(val);
-  rewriter.create<SinkOp>(val.getLoc(), val);
+  SinkOp::create(rewriter, val.getLoc(), val);
 }
 
 /// Insert Fork Operation for every operation and function argument with more

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaAddOperatorLibrary.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaAddOperatorLibrary.cpp
@@ -47,8 +47,8 @@ struct AddOperatorLibraryPass
 // avoid passing the builder around.
 template <typename TOp>
 void addOperator(ImplicitLocOpBuilder &b, int latency) {
-  b.create<ssp::OperatorTypeOp>(
-      b.getStringAttr(TOp::getOperationName()),
+  ssp::OperatorTypeOp::create(
+      b, b.getStringAttr(TOp::getOperationName()),
       b.getArrayAttr({b.getAttr<ssp::LatencyAttr>(latency)}));
 }
 
@@ -57,7 +57,7 @@ void addOperator(ImplicitLocOpBuilder &b, int latency) {
 void AddOperatorLibraryPass::runOnOperation() {
   auto b = ImplicitLocOpBuilder::atBlockBegin(getOperation().getLoc(),
                                               getOperation().getBody());
-  auto opLib = b.create<ssp::OperatorLibraryOp>();
+  auto opLib = ssp::OperatorLibraryOp::create(b);
   opLib.setSymNameAttr(b.getStringAttr(kKanagawaOperatorLibName));
   b.setInsertionPointToStart(opLib.getBodyBlock());
 

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaArgifyBlocksPass.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaArgifyBlocksPass.cpp
@@ -57,9 +57,9 @@ struct BlockConversionPattern : public OpConversionPattern<StaticBlockOp> {
     getExternallyDefinedOperands(blockOp, mapping);
     Block *bodyBlock = blockOp.getBodyBlock();
 
-    auto isolatedBlock = rewriter.create<IsolatedStaticBlockOp>(
-        blockOp.getLoc(), blockOp.getResultTypes(), blockOp.getOperands(),
-        blockOp.getMaxThreadsAttr());
+    auto isolatedBlock = IsolatedStaticBlockOp::create(
+        rewriter, blockOp.getLoc(), blockOp.getResultTypes(),
+        blockOp.getOperands(), blockOp.getMaxThreadsAttr());
     // Erase the default terminator.
     Block *isolatedBlockBody = isolatedBlock.getBodyBlock();
     rewriter.eraseOp(isolatedBlockBody->getTerminator());

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaCallPrep.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaCallPrep.cpp
@@ -140,8 +140,8 @@ MergeCallArgs::matchAndRewrite(CallOp call, OpAdaptor adaptor,
   auto [argStruct, argLoc] = argStructEntry->second;
 
   // Pack all of the operands into it.
-  auto newArg = rewriter.create<hw::StructCreateOp>(loc, argStruct,
-                                                    adaptor.getOperands());
+  auto newArg = hw::StructCreateOp::create(rewriter, loc, argStruct,
+                                           adaptor.getOperands());
   newArg->setAttr("sv.namehint",
                   rewriter.getStringAttr(call.getCallee().getName().getValue() +
                                          "_args_called_from_" +
@@ -190,8 +190,8 @@ MergeMethodArgs::matchAndRewrite(MethodOp func, OpAdaptor adaptor,
       FunctionType::get(ctxt, {argStruct}, funcType.getResults());
   auto newArgNames = ArrayAttr::get(ctxt, {StringAttr::get(ctxt, "arg")});
   auto newMethod =
-      rewriter.create<MethodOp>(loc, func.getInnerSym(), newFuncType,
-                                newArgNames, ArrayAttr(), ArrayAttr());
+      MethodOp::create(rewriter, loc, func.getInnerSym(), newFuncType,
+                       newArgNames, ArrayAttr(), ArrayAttr());
 
   if (func->getNumRegions() > 0) {
     // Create a body block with a struct explode to the arg struct into the
@@ -200,7 +200,7 @@ MergeMethodArgs::matchAndRewrite(MethodOp func, OpAdaptor adaptor,
         rewriter.createBlock(&newMethod.getRegion(), {}, {argStruct}, {argLoc});
     rewriter.setInsertionPointToStart(b);
     auto replacementArgs =
-        rewriter.create<hw::StructExplodeOp>(loc, b->getArgument(0));
+        hw::StructExplodeOp::create(rewriter, loc, b->getArgument(0));
 
     // Merge the original method body, rewiring the args.
     Block *funcBody = &func.getBody().front();

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaCleanSelfdrivers.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaCleanSelfdrivers.cpp
@@ -151,8 +151,8 @@ struct InputPortOpConversionPattern : public OpConversionPattern<InputPortOp> {
     }
 
     // Create a `hw.wire` to ensure that the input port name is maintained.
-    auto wire = rewriter.create<hw::WireOp>(op.getLoc(), writer.getValue(),
-                                            op.getInnerSymAttrName());
+    auto wire = hw::WireOp::create(rewriter, op.getLoc(), writer.getValue(),
+                                   op.getInnerSymAttrName());
 
     // Replace all reads of the input port with the wire.
     for (auto reader : readers)
@@ -176,9 +176,10 @@ struct InputPortOpConversionPattern : public OpConversionPattern<InputPortOp> {
       });
 
       if (anyOutsideReads) {
-        auto outputPort = rewriter.create<OutputPortOp>(
-            op.getLoc(), op.getInnerSym(), op.getType(), op.getNameAttr());
-        rewriter.create<PortWriteOp>(op.getLoc(), outputPort, wire);
+        auto outputPort =
+            OutputPortOp::create(rewriter, op.getLoc(), op.getInnerSym(),
+                                 op.getType(), op.getNameAttr());
+        PortWriteOp::create(rewriter, op.getLoc(), outputPort, wire);
       }
     }
 

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaContainerize.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaContainerize.cpp
@@ -53,16 +53,16 @@ struct OutlineContainerPattern : public OpConversionPattern<ContainerOp> {
     StringAttr newContainerName = rewriter.getStringAttr(
         ns.newName(parentClass.getInnerNameAttr().strref() + "_" +
                    op.getInnerNameAttr().strref()));
-    auto newContainer = rewriter.create<ContainerOp>(
-        op.getLoc(), newContainerName, /*isTopLevel=*/false);
+    auto newContainer = ContainerOp::create(
+        rewriter, op.getLoc(), newContainerName, /*isTopLevel=*/false);
 
     rewriter.mergeBlocks(op.getBodyBlock(), newContainer.getBodyBlock(), {});
 
     // Create a container instance op in the parent class.
     rewriter.setInsertionPoint(op);
-    rewriter.create<ContainerInstanceOp>(
-        parentClass.getLoc(), hw::InnerSymAttr::get(newContainerName),
-        newContainer.getInnerRef());
+    ContainerInstanceOp::create(rewriter, parentClass.getLoc(),
+                                hw::InnerSymAttr::get(newContainerName),
+                                newContainer.getInnerRef());
     rewriter.eraseOp(op);
     return success();
   }
@@ -78,8 +78,8 @@ struct ClassToContainerPattern : public OpConversionPattern<ClassOp> {
                   ConversionPatternRewriter &rewriter) const override {
     // Replace the class by a container of the same name.
     auto newContainer =
-        rewriter.create<ContainerOp>(op.getLoc(), op.getInnerSymAttr(),
-                                     /*topLevel*/ false, op.getNameAttr());
+        ContainerOp::create(rewriter, op.getLoc(), op.getInnerSymAttr(),
+                            /*topLevel*/ false, op.getNameAttr());
     rewriter.mergeBlocks(op.getBodyBlock(), newContainer.getBodyBlock(), {});
     rewriter.eraseOp(op);
     return success();

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaContainersToHW.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaContainersToHW.cpp
@@ -137,7 +137,7 @@ struct ContainerOpConversionPattern : public OpConversionPattern<ContainerOp> {
 
     const ContainerPortInfo &cpi = portOrder.at(op.getInnerRef());
     auto hwMod =
-        rewriter.create<hw::HWModuleOp>(op.getLoc(), hwmodName, *cpi.hwPorts);
+        hw::HWModuleOp::create(rewriter, op.getLoc(), hwmodName, *cpi.hwPorts);
     modSymMap[op.getInnerRef()] = hwMod.getSymNameAttr();
 
     hw::OutputOp outputOp =
@@ -183,7 +183,7 @@ struct ContainerOpConversionPattern : public OpConversionPattern<ContainerOp> {
     // Rewrite the hw.output op.
     rewriter.eraseOp(outputOp);
     rewriter.setInsertionPointToEnd(hwMod.getBodyBlock());
-    outputOp = rewriter.create<hw::OutputOp>(op.getLoc(), outputValues);
+    outputOp = hw::OutputOp::create(rewriter, op.getLoc(), outputValues);
     rewriter.eraseOp(op);
     return success();
   }
@@ -299,9 +299,9 @@ struct ContainerInstanceOpConversionPattern
 
     // Create the hw.instance op.
     StringRef moduleName = modSymMap[op.getTargetNameAttr()];
-    auto hwInst = rewriter.create<hw::InstanceOp>(
-        op.getLoc(), retTypes, op.getInnerSym().getSymName(), moduleName,
-        operands, rewriter.getArrayAttr(argNames),
+    auto hwInst = hw::InstanceOp::create(
+        rewriter, op.getLoc(), retTypes, op.getInnerSym().getSymName(),
+        moduleName, operands, rewriter.getArrayAttr(argNames),
         rewriter.getArrayAttr(resNames),
         /*parameters*/ rewriter.getArrayAttr({}), /*innerSym*/ nullptr);
 

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaConvertCFToHandshake.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaConvertCFToHandshake.cpp
@@ -52,8 +52,8 @@ LogicalResult ConvertCFToHandshakePass::convertMethod(MethodOp method) {
   newArgTypes.push_back(b.getNoneType());
   newResTypes.push_back(b.getNoneType());
   auto newFuncType = b.getFunctionType(newArgTypes, newResTypes);
-  auto dataflowMethodOp = b.create<DataflowMethodOp>(
-      method.getLoc(), method.getInnerSymAttr(), TypeAttr::get(newFuncType),
+  auto dataflowMethodOp = DataflowMethodOp::create(
+      b, method.getLoc(), method.getInnerSymAttr(), TypeAttr::get(newFuncType),
       method.getArgNamesAttr(), method.getArgAttrsAttr(),
       method.getResAttrsAttr());
   dataflowMethodOp.getFunctionBody().takeBody(method.getBody());

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaConvertHandshakeToDC.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaConvertHandshakeToDC.cpp
@@ -65,8 +65,8 @@ struct StaticBlockOpConversion
     if (failed(
             getTypeConverter()->convertTypes(op.getResultTypes(), resultTypes)))
       return failure();
-    auto dcBlock = rewriter.create<DCBlockOp>(op.getLoc(), resultTypes,
-                                              adaptor.getOperands());
+    auto dcBlock = DCBlockOp::create(rewriter, op.getLoc(), resultTypes,
+                                     adaptor.getOperands());
     rewriter.eraseOp(dcBlock.getBodyBlock()->getTerminator());
     rewriter.mergeBlocks(op.getBodyBlock(), dcBlock.getBodyBlock(),
                          dcBlock.getBodyBlock()->getArguments());

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaInlineSBlocksPass.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaInlineSBlocksPass.cpp
@@ -60,7 +60,7 @@ public:
     if (hasAttributes) {
       // Start the inline block...
       auto inlineStart =
-          rewriter.create<kanagawa::InlineStaticBlockBeginOp>(loc);
+          kanagawa::InlineStaticBlockBeginOp::create(rewriter, loc);
       inlineStart->setAttrs(op->getAttrs());
     }
 
@@ -77,7 +77,7 @@ public:
     if (hasAttributes) {
       // Close the inline block
       rewriter.setInsertionPoint(ret);
-      rewriter.create<kanagawa::InlineStaticBlockEndOp>(loc);
+      kanagawa::InlineStaticBlockEndOp::create(rewriter, loc);
     }
 
     rewriter.eraseOp(ret);

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaMethodsToContainers.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaMethodsToContainers.cpp
@@ -40,26 +40,29 @@ struct DataflowMethodOpConversion
   matchAndRewrite(DataflowMethodOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Replace the class by a container of the same name.
-    auto newContainer = rewriter.create<ContainerOp>(
-        op.getLoc(), op.getInnerSym(), /*isTopLevel=*/false);
+    auto newContainer = ContainerOp::create(
+        rewriter, op.getLoc(), op.getInnerSym(), /*isTopLevel=*/false);
     rewriter.setInsertionPointToStart(newContainer.getBodyBlock());
 
     // Create in- and output ports.
     llvm::SmallVector<Value> argValues;
     for (auto [arg, name] : llvm::zip_equal(
              op.getArguments(), op.getArgNames().getAsRange<StringAttr>())) {
-      auto port = rewriter.create<InputPortOp>(
-          arg.getLoc(), hw::InnerSymAttr::get(name), arg.getType(), name);
-      argValues.push_back(rewriter.create<PortReadOp>(arg.getLoc(), port));
+      auto port =
+          InputPortOp::create(rewriter, arg.getLoc(),
+                              hw::InnerSymAttr::get(name), arg.getType(), name);
+      argValues.push_back(PortReadOp::create(rewriter, arg.getLoc(), port));
     }
 
     ReturnOp returnOp = cast<ReturnOp>(op.getBodyBlock()->getTerminator());
     for (auto [idx, resType] : llvm::enumerate(
              cast<MethodLikeOpInterface>(op.getOperation()).getResultTypes())) {
       auto portName = rewriter.getStringAttr("out" + std::to_string(idx));
-      auto port = rewriter.create<OutputPortOp>(
-          op.getLoc(), hw::InnerSymAttr::get(portName), resType, portName);
-      rewriter.create<PortWriteOp>(op.getLoc(), port, returnOp.getOperand(idx));
+      auto port = OutputPortOp::create(rewriter, op.getLoc(),
+                                       hw::InnerSymAttr::get(portName), resType,
+                                       portName);
+      PortWriteOp::create(rewriter, op.getLoc(), port,
+                          returnOp.getOperand(idx));
     }
 
     rewriter.mergeBlocks(op.getBodyBlock(), newContainer.getBodyBlock(),

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaPrepareScheduling.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaPrepareScheduling.cpp
@@ -55,7 +55,7 @@ PrepareSchedulingPass::prepareSBlock(IsolatedStaticBlockOp sblock) {
   Location loc = sblock.getLoc();
   Block *bodyBlock = sblock.getBodyBlock();
   auto b = OpBuilder::atBlockBegin(bodyBlock);
-  auto ph = b.create<kanagawa::PipelineHeaderOp>(loc);
+  auto ph = kanagawa::PipelineHeaderOp::create(b, loc);
 
   // Create a pipeline.unscheduled operation which returns the same types
   // as that returned by the sblock.
@@ -69,8 +69,8 @@ PrepareSchedulingPass::prepareSBlock(IsolatedStaticBlockOp sblock) {
   for (size_t i = 0, e = retTypes.size(); i < e; ++i)
     outNames.push_back(b.getStringAttr("out" + std::to_string(i)));
 
-  auto pipeline = b.create<pipeline::UnscheduledPipelineOp>(
-      loc, retTypes, bodyBlock->getArguments(), b.getArrayAttr(inNames),
+  auto pipeline = pipeline::UnscheduledPipelineOp::create(
+      b, loc, retTypes, bodyBlock->getArguments(), b.getArrayAttr(inNames),
       b.getArrayAttr(outNames), ph.getClock(), ph.getGo(), ph.getReset(),
       ph.getStall());
   b.setInsertionPointToEnd(pipeline.getEntryStage());
@@ -81,7 +81,8 @@ PrepareSchedulingPass::prepareSBlock(IsolatedStaticBlockOp sblock) {
   // sblock is still being passed through the pipeline. While doing so, we
   // sneakily also set the pipeline return values so that it will reflect the
   // later value replacements.
-  auto pipelineRet = b.create<pipeline::ReturnOp>(loc, sblockRet.getOperands());
+  auto pipelineRet =
+      pipeline::ReturnOp::create(b, loc, sblockRet.getOperands());
   for (size_t i = 0, e = retTypes.size(); i < e; ++i)
     sblockRet.setOperand(i, pipeline.getResult(i));
 

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaReblockPass.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaReblockPass.cpp
@@ -121,7 +121,7 @@ LogicalResult ReblockPass::reblock(ArrayRef<Operation *> ops,
 
   auto b = OpBuilder(beginOp);
   auto kanagawaBlock =
-      b.create<StaticBlockOp>(beginOp->getLoc(), blockRetTypes, ValueRange{});
+      StaticBlockOp::create(b, beginOp->getLoc(), blockRetTypes, ValueRange{});
 
   // The new `kanagawa.sblock` should inherit the attributes of the block begin
   // op, if provided.

--- a/lib/Dialect/LLHD/IR/LLHDDialect.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDDialect.cpp
@@ -64,10 +64,10 @@ void LLHDDialect::initialize() {
 Operation *LLHDDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                             Type type, Location loc) {
   if (auto timeAttr = dyn_cast<TimeAttr>(value))
-    return builder.create<llhd::ConstantTimeOp>(loc, type, timeAttr);
+    return llhd::ConstantTimeOp::create(builder, loc, type, timeAttr);
 
   if (auto intAttr = dyn_cast<IntegerAttr>(value))
-    return builder.create<hw::ConstantOp>(loc, type, intAttr);
+    return hw::ConstantOp::create(builder, loc, type, intAttr);
 
   return nullptr;
 }

--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -1019,12 +1019,12 @@ void Deseq::implementRegister(DriveInfo &drive) {
   // negedge clocks.
   auto &clockCast = materializedClockCasts[drive.clock.clock];
   if (!clockCast)
-    clockCast = builder.create<seq::ToClockOp>(loc, drive.clock.clock);
+    clockCast = seq::ToClockOp::create(builder, loc, drive.clock.clock);
   auto clock = clockCast;
   if (!drive.clock.risingEdge) {
     auto &clockInv = materializedClockInverters[clock];
     if (!clockInv)
-      clockInv = builder.create<seq::ClockInverterOp>(loc, clock);
+      clockInv = seq::ClockInverterOp::create(builder, loc, clock);
     clock = clockInv;
   }
 
@@ -1041,8 +1041,8 @@ void Deseq::implementRegister(DriveInfo &drive) {
     if (!drive.reset.activeHigh) {
       auto &inv = materializedInverters[reset];
       if (!inv) {
-        auto one = builder.create<hw::ConstantOp>(loc, builder.getI1Type(), 1);
-        inv = builder.create<comb::XorOp>(loc, reset, one);
+        auto one = hw::ConstantOp::create(builder, loc, builder.getI1Type(), 1);
+        inv = comb::XorOp::create(builder, loc, reset, one);
       }
       reset = inv;
     }
@@ -1104,10 +1104,10 @@ void Deseq::implementRegister(DriveInfo &drive) {
     name = builder.getStringAttr("");
 
   // Create the register op.
-  auto reg =
-      builder.create<seq::FirRegOp>(loc, value, clock, name, hw::InnerSymAttr{},
-                                    /*preset=*/IntegerAttr{}, reset, resetValue,
-                                    /*isAsync=*/reset != Value{});
+  auto reg = seq::FirRegOp::create(builder, loc, value, clock, name,
+                                   hw::InnerSymAttr{},
+                                   /*preset=*/IntegerAttr{}, reset, resetValue,
+                                   /*isAsync=*/reset != Value{});
 
   // If the register has an enable, insert a self-mux in front of the register.
   // Set the `bin` flag on the mux specifically to make up for a subtle
@@ -1116,8 +1116,8 @@ void Deseq::implementRegister(DriveInfo &drive) {
   if (enable) {
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(reg);
-    reg.getNextMutable().assign(builder.create<comb::MuxOp>(
-        loc, enable, reg.getNext(), reg.getResult(), true));
+    reg.getNextMutable().assign(comb::MuxOp::create(
+        builder, loc, enable, reg.getNext(), reg.getResult(), true));
   }
 
   // Make the original `llhd.drv` drive the register value unconditionally.
@@ -1131,7 +1131,7 @@ void Deseq::implementRegister(DriveInfo &drive) {
       attr.getTime() == 0 && attr.getDelta() == 1 && attr.getEpsilon() == 0) {
     if (!epsilonDelay)
       epsilonDelay =
-          builder.create<ConstantTimeOp>(process.getLoc(), 0, "ns", 0, 1);
+          ConstantTimeOp::create(builder, process.getLoc(), 0, "ns", 0, 1);
     drive.op.getTimeMutable().assign(epsilonDelay);
   }
 }
@@ -1180,8 +1180,8 @@ ValueRange Deseq::specializeProcess(FixedValues fixedValues) {
   // the register operation that consumes the result of this specialized
   // process, such that we can make the process purely combinational.
   OpBuilder builder(process);
-  auto executeOp = builder.create<CombinationalOp>(process.getLoc(),
-                                                   process.getResultTypes());
+  auto executeOp = CombinationalOp::create(builder, process.getLoc(),
+                                           process.getResultTypes());
 
   IRMapping mapping;
   SmallVector<std::pair<Block *, Block *>> worklist;
@@ -1203,8 +1203,8 @@ ValueRange Deseq::specializeProcess(FixedValues fixedValues) {
   auto &entryBlock = executeOp.getRegion().emplaceBlock();
   builder.setInsertionPointToStart(&entryBlock);
   auto i1 = builder.getI1Type();
-  auto trueValue = builder.create<hw::ConstantOp>(process.getLoc(), i1, 1);
-  auto falseValue = builder.create<hw::ConstantOp>(process.getLoc(), i1, 0);
+  auto trueValue = hw::ConstantOp::create(builder, process.getLoc(), i1, 1);
+  auto falseValue = hw::ConstantOp::create(builder, process.getLoc(), i1, 0);
 
   SmallDenseMap<Value, std::pair<Value, Value>, 2> materializedFixedValues;
   for (auto fixedValue : fixedValues) {
@@ -1243,7 +1243,7 @@ ValueRange Deseq::specializeProcess(FixedValues fixedValues) {
           SmallVector<Value> operands;
           for (auto operand : waitOp.getYieldOperands())
             operands.push_back(mapping.lookupOrDefault(operand));
-          builder.create<YieldOp>(waitOp.getLoc(), operands);
+          YieldOp::create(builder, waitOp.getLoc(), operands);
           continue;
         }
 
@@ -1254,17 +1254,17 @@ ValueRange Deseq::specializeProcess(FixedValues fixedValues) {
           if (matchPattern(condition, m_NonZero())) {
             for (auto operand : condBranchOp.getTrueDestOperands())
               operands.push_back(mapping.lookupOrDefault(operand));
-            builder.create<cf::BranchOp>(
-                condBranchOp.getLoc(),
-                scheduleBlock(condBranchOp.getTrueDest()), operands);
+            cf::BranchOp::create(builder, condBranchOp.getLoc(),
+                                 scheduleBlock(condBranchOp.getTrueDest()),
+                                 operands);
             continue;
           }
           if (matchPattern(condition, m_Zero())) {
             for (auto operand : condBranchOp.getFalseOperands())
               operands.push_back(mapping.lookupOrDefault(operand));
-            builder.create<cf::BranchOp>(
-                condBranchOp.getLoc(),
-                scheduleBlock(condBranchOp.getFalseDest()), operands);
+            cf::BranchOp::create(builder, condBranchOp.getLoc(),
+                                 scheduleBlock(condBranchOp.getFalseDest()),
+                                 operands);
             continue;
           }
         }
@@ -1342,7 +1342,7 @@ ValueRange Deseq::specializeProcess(FixedValues fixedValues) {
     assert(pastValues.size() == wait.getDestOperands().size());
     for (auto pastValue : pastValues)
       destOperands.push_back(materializedFixedValues.lookup(pastValue).first);
-    builder.create<cf::BranchOp>(wait.getLoc(), dest, destOperands);
+    cf::BranchOp::create(builder, wait.getLoc(), dest, destOperands);
   }
 
   // Clone everything after the wait operation.

--- a/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
+++ b/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
@@ -55,8 +55,8 @@ void Lowering::lower() {
 
   // Replace the process.
   OpBuilder builder(processOp);
-  auto executeOp = builder.create<CombinationalOp>(processOp.getLoc(),
-                                                   processOp.getResultTypes());
+  auto executeOp = CombinationalOp::create(builder, processOp.getLoc(),
+                                           processOp.getResultTypes());
   executeOp.getRegion().takeBody(processOp.getBody());
   processOp.replaceAllUsesWith(executeOp);
   processOp.erase();
@@ -64,7 +64,7 @@ void Lowering::lower() {
 
   // Replace the `llhd.wait` with an `llhd.yield`.
   builder.setInsertionPoint(waitOp);
-  builder.create<YieldOp>(waitOp.getLoc(), waitOp.getYieldOperands());
+  YieldOp::create(builder, waitOp.getLoc(), waitOp.getYieldOperands());
   waitOp.erase();
 
   // Simplify the execute op body region since disconnecting the control flow

--- a/lib/Dialect/LLHD/Transforms/MemoryToBlockArgumentPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/MemoryToBlockArgumentPass.cpp
@@ -151,8 +151,8 @@ void MemoryToBlockArgumentPass::runOnProcess(llhd::ProcessOp operation) {
       for (Block *pred : jp->getPredecessors()) {
         // Set insertion point before terminator to insert the load operation
         builder.setInsertionPoint(pred->getTerminator());
-        Value load = builder.create<llhd::LoadOp>(
-            pred->getTerminator()->getLoc(),
+        Value load = llhd::LoadOp::create(
+            builder, pred->getTerminator()->getLoc(),
             cast<llhd::PtrType>(var.getType()).getElementType(), var);
         // Add the loaded value as additional block argument
         addBlockOperandToTerminator(pred->getTerminator(), jp, load);
@@ -160,7 +160,7 @@ void MemoryToBlockArgumentPass::runOnProcess(llhd::ProcessOp operation) {
       // Insert a store at the beginning of the join point to make removal of
       // all the memory operations easier later on
       builder.setInsertionPointToStart(jp);
-      builder.create<llhd::StoreOp>(jp->front().getLoc(), var, phi);
+      llhd::StoreOp::create(builder, jp->front().getLoc(), var, phi);
     }
 
     // Basically reaching definitions analysis and replacing the loaded values

--- a/lib/Dialect/LLHD/Transforms/RemoveControlFlow.cpp
+++ b/lib/Dialect/LLHD/Transforms/RemoveControlFlow.cpp
@@ -61,9 +61,9 @@ struct Condition {
   /// condition is a constant.
   Value materialize(OpBuilder &builder, Location loc) const {
     if (isTrue())
-      return builder.create<hw::ConstantOp>(loc, APInt(1, 1));
+      return hw::ConstantOp::create(builder, loc, APInt(1, 1));
     if (isFalse())
-      return builder.create<hw::ConstantOp>(loc, APInt(1, 0));
+      return hw::ConstantOp::create(builder, loc, APInt(1, 0));
     return pair.getPointer();
   }
 
@@ -223,11 +223,11 @@ void CFRemover::run() {
                                            yieldOps[0].getOperandTypes(), locs);
     sortedBlocks.push_back(yieldBlock);
     yieldOp =
-        builder.create<YieldOp>(region.getLoc(), yieldBlock->getArguments());
+        YieldOp::create(builder, region.getLoc(), yieldBlock->getArguments());
     for (auto yieldOp : yieldOps) {
       builder.setInsertionPoint(yieldOp);
-      builder.create<cf::BranchOp>(yieldOp.getLoc(), yieldBlock,
-                                   yieldOp.getOperands());
+      cf::BranchOp::create(builder, yieldOp.getLoc(), yieldBlock,
+                           yieldOp.getOperands());
       yieldOp.erase();
     }
   }

--- a/lib/Dialect/LLHD/Transforms/Sig2RegPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/Sig2RegPass.cpp
@@ -230,12 +230,12 @@ public:
     // Handle the writes by starting with the signal init value and injecting
     // the written values at the right offsets.
     for (auto interval : intervals) {
-      Value invMask = builder.create<hw::ConstantOp>(
-          loc, APInt::getAllOnes(interval.bitwidth));
+      Value invMask = hw::ConstantOp::create(
+          builder, loc, APInt::getAllOnes(interval.bitwidth));
 
       if (uint64_t(bw) > interval.bitwidth) {
-        Value pad = builder.create<hw::ConstantOp>(
-            loc, APInt::getZero(bw - interval.bitwidth));
+        Value pad = hw::ConstantOp::create(
+            builder, loc, APInt::getZero(bw - interval.bitwidth));
         invMask = builder.createOrFold<comb::ConcatOp>(loc, pad, invMask);
       }
 
@@ -243,7 +243,7 @@ public:
                                     interval.low.dynamic, bw);
       invMask = builder.createOrFold<comb::ShlOp>(loc, invMask, amt);
       Value allOnes =
-          builder.create<hw::ConstantOp>(loc, APInt::getAllOnes(bw));
+          hw::ConstantOp::create(builder, loc, APInt::getAllOnes(bw));
       Value mask = builder.createOrFold<comb::XorOp>(loc, invMask, allOnes);
       val = builder.createOrFold<comb::AndOp>(loc, val, mask);
 
@@ -251,8 +251,8 @@ public:
           loc, builder.getIntegerType(interval.bitwidth), interval.value);
 
       if (uint64_t(bw) > interval.bitwidth) {
-        Value pad = builder.create<hw::ConstantOp>(
-            loc, APInt::getZero(bw - interval.bitwidth));
+        Value pad = hw::ConstantOp::create(
+            builder, loc, APInt::getZero(bw - interval.bitwidth));
         assignVal = builder.createOrFold<comb::ConcatOp>(loc, pad, assignVal);
       }
 
@@ -299,13 +299,13 @@ private:
   Value buildDynamicIndex(OpBuilder &builder, Location loc,
                           uint64_t constOffset, ArrayRef<Value> indices,
                           uint64_t width) {
-    Value index = builder.create<hw::ConstantOp>(
-        loc, builder.getIntegerType(width), constOffset);
+    Value index = hw::ConstantOp::create(
+        builder, loc, builder.getIntegerType(width), constOffset);
 
     for (auto idx : indices) {
       auto bw = hw::getBitWidth(idx.getType());
       Value pad =
-          builder.create<hw::ConstantOp>(loc, APInt::getZero(width - bw));
+          hw::ConstantOp::create(builder, loc, APInt::getZero(width - bw));
       idx = builder.createOrFold<comb::ConcatOp>(loc, pad, idx);
       index = builder.createOrFold<comb::AddOp>(loc, index, idx);
     }

--- a/lib/Dialect/LLHD/Transforms/UnrollLoops.cpp
+++ b/lib/Dialect/LLHD/Transforms/UnrollLoops.cpp
@@ -268,7 +268,7 @@ void Loop::unroll(CFGLoopInfo &cfgLoopInfo) {
     pruner.eraseLaterIfUnused(iterIndVar);
     builder.setInsertionPointAfterValue(iterIndVar);
     iterIndVar.replaceAllUsesWith(
-        builder.create<hw::ConstantOp>(iterIndVar.getLoc(), indValue));
+        hw::ConstantOp::create(builder, iterIndVar.getLoc(), indValue));
 
     // Update all edges to the original loop header to point to the cloned loop
     // header. Leave the original back-edge untouched.
@@ -293,8 +293,8 @@ void Loop::unroll(CFGLoopInfo &cfgLoopInfo) {
       continueDestOperands = exitBranchOp.getFalseDestOperands();
     }
     builder.setInsertionPoint(exitBranchOp);
-    builder.create<cf::BranchOp>(exitBranchOp.getLoc(), continueDest,
-                                 continueDestOperands);
+    cf::BranchOp::create(builder, exitBranchOp.getLoc(), continueDest,
+                         continueDestOperands);
     pruner.eraseLaterIfUnused(exitBranchOp.getOperands());
     exitBranchOp.erase();
 
@@ -314,7 +314,7 @@ void Loop::unroll(CFGLoopInfo &cfgLoopInfo) {
   pruner.eraseLaterIfUnused(indVar);
   builder.setInsertionPointAfterValue(indVar);
   indVar.replaceAllUsesWith(
-      builder.create<hw::ConstantOp>(indVar.getLoc(), indValue));
+      hw::ConstantOp::create(builder, indVar.getLoc(), indValue));
   indVar = {};
 
   // Remove the continue edge of the exit branch in the loop body, since we
@@ -327,8 +327,8 @@ void Loop::unroll(CFGLoopInfo &cfgLoopInfo) {
     exitDestOperands = exitBranchOp.getFalseDestOperands();
   }
   builder.setInsertionPoint(exitBranchOp);
-  builder.create<cf::BranchOp>(exitBranchOp.getLoc(), exitDest,
-                               exitDestOperands);
+  cf::BranchOp::create(builder, exitBranchOp.getLoc(), exitDest,
+                       exitDestOperands);
   pruner.eraseLaterIfUnused(exitBranchOp.getOperands());
   exitBranchOp.erase();
   exitEdge = nullptr;

--- a/lib/Dialect/LLHD/Transforms/WrapProceduralOps.cpp
+++ b/lib/Dialect/LLHD/Transforms/WrapProceduralOps.cpp
@@ -34,11 +34,11 @@ void WrapProceduralOpsPass::runOnOperation() {
     if (!isa<scf::SCFDialect>(op.getDialect()) && !isa<func::CallOp>(op))
       continue;
     auto builder = OpBuilder(&op);
-    auto wrapperOp =
-        builder.create<llhd::CombinationalOp>(op.getLoc(), op.getResultTypes());
+    auto wrapperOp = llhd::CombinationalOp::create(builder, op.getLoc(),
+                                                   op.getResultTypes());
     op.replaceAllUsesWith(wrapperOp);
     builder.createBlock(&wrapperOp.getBody());
-    auto yieldOp = builder.create<llhd::YieldOp>(op.getLoc(), op.getResults());
+    auto yieldOp = llhd::YieldOp::create(builder, op.getLoc(), op.getResults());
     op.moveBefore(yieldOp);
     ++numOpsWrapped;
   }

--- a/lib/Dialect/LoopSchedule/LoopScheduleOps.cpp
+++ b/lib/Dialect/LoopSchedule/LoopScheduleOps.cpp
@@ -202,14 +202,15 @@ void LoopSchedulePipelineOp::build(OpBuilder &builder, OperationState &state,
     argLocs.push_back(arg.getLoc());
   condBlock.addArguments(iterArgs.getTypes(), argLocs);
   builder.setInsertionPointToEnd(&condBlock);
-  builder.create<LoopScheduleRegisterOp>(builder.getUnknownLoc(), ValueRange());
+  LoopScheduleRegisterOp::create(builder, builder.getUnknownLoc(),
+                                 ValueRange());
 
   Region *stagesRegion = state.addRegion();
   Block &stagesBlock = stagesRegion->emplaceBlock();
   stagesBlock.addArguments(iterArgs.getTypes(), argLocs);
   builder.setInsertionPointToEnd(&stagesBlock);
-  builder.create<LoopScheduleTerminatorOp>(builder.getUnknownLoc(),
-                                           ValueRange(), ValueRange());
+  LoopScheduleTerminatorOp::create(builder, builder.getUnknownLoc(),
+                                   ValueRange(), ValueRange());
 }
 
 //===----------------------------------------------------------------------===//
@@ -235,7 +236,8 @@ void LoopSchedulePipelineStageOp::build(OpBuilder &builder,
   Region *region = state.addRegion();
   Block &block = region->emplaceBlock();
   builder.setInsertionPointToEnd(&block);
-  builder.create<LoopScheduleRegisterOp>(builder.getUnknownLoc(), ValueRange());
+  LoopScheduleRegisterOp::create(builder, builder.getUnknownLoc(),
+                                 ValueRange());
 }
 
 unsigned LoopSchedulePipelineStageOp::getStageNumber() {

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -89,10 +89,9 @@ PDPhysLocationOp PlacementDB::place(DynamicInstanceOp inst,
   StringAttr subPathAttr;
   if (!subPath.empty())
     subPathAttr = StringAttr::get(inst->getContext(), subPath);
-  PDPhysLocationOp locOp =
-      OpBuilder(inst.getBody())
-          .create<PDPhysLocationOp>(srcLoc, loc, subPathAttr,
-                                    FlatSymbolRefAttr());
+  auto builder = OpBuilder(inst.getBody());
+  PDPhysLocationOp locOp = PDPhysLocationOp::create(
+      builder, srcLoc, loc, subPathAttr, FlatSymbolRefAttr());
   if (succeeded(insertPlacement(locOp, locOp.getLoc())))
     return locOp;
   locOp->erase();
@@ -101,9 +100,9 @@ PDPhysLocationOp PlacementDB::place(DynamicInstanceOp inst,
 PDRegPhysLocationOp PlacementDB::place(DynamicInstanceOp inst,
                                        LocationVectorAttr locs,
                                        Location srcLoc) {
+  auto builder = OpBuilder(inst.getBody());
   PDRegPhysLocationOp locOp =
-      OpBuilder(inst.getBody())
-          .create<PDRegPhysLocationOp>(srcLoc, locs, FlatSymbolRefAttr());
+      PDRegPhysLocationOp::create(builder, srcLoc, locs, FlatSymbolRefAttr());
   for (PhysLocationAttr loc : locs.getLocs())
     if (failed(insertPlacement(locOp, loc))) {
       locOp->erase();
@@ -136,10 +135,10 @@ PDPhysRegionOp PlacementDB::placeIn(DynamicInstanceOp inst,
   StringAttr subPathAttr;
   if (!subPath.empty())
     subPathAttr = StringAttr::get(inst->getContext(), subPath);
-  PDPhysRegionOp regOp =
-      OpBuilder::atBlockEnd(&inst.getBody().front())
-          .create<PDPhysRegionOp>(srcLoc, FlatSymbolRefAttr::get(physregion),
-                                  subPathAttr, FlatSymbolRefAttr());
+  auto builder = OpBuilder::atBlockEnd(&inst.getBody().front());
+  PDPhysRegionOp regOp = PDPhysRegionOp::create(
+      builder, srcLoc, FlatSymbolRefAttr::get(physregion), subPathAttr,
+      FlatSymbolRefAttr());
   regionPlacements.push_back(regOp);
   return regOp;
 }

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -335,9 +335,9 @@ LogicalResult TclEmitter::emit(Operation *hwMod, StringRef outputFile) {
   // Create a verbatim op containing the Tcl and symbol references.
   auto builder = ImplicitLocOpBuilder::atBlockEnd(
       UnknownLoc::get(hwMod->getContext()), hwMod->getBlock());
-  builder.create<emit::FileOp>(outputFile, [&] {
-    builder.create<sv::VerbatimOp>(os.str(), ValueRange{},
-                                   builder.getArrayAttr(state.symbolRefs));
+  emit::FileOp::create(builder, outputFile, [&] {
+    sv::VerbatimOp::create(builder, os.str(), ValueRange{},
+                           builder.getArrayAttr(state.symbolRefs));
   });
 
   return success();

--- a/lib/Dialect/MSFT/Transforms/MSFTLowerConstructs.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTLowerConstructs.cpp
@@ -87,9 +87,9 @@ public:
     for (size_t rowNum = 0, numRows = rowInputs.getNumElements();
          rowNum < numRows; ++rowNum) {
       Value rowNumVal =
-          rewriter.create<hw::ConstantOp>(loc, rowIdxType, rowNum);
-      auto rowValue =
-          rewriter.create<hw::ArrayGetOp>(loc, array.getRowInputs(), rowNumVal);
+          hw::ConstantOp::create(rewriter, loc, rowIdxType, rowNum);
+      auto rowValue = hw::ArrayGetOp::create(rewriter, loc,
+                                             array.getRowInputs(), rowNumVal);
       rowValue->setAttr("sv.namehint",
                         StringAttr::get(ctxt, "row_" + Twine(rowNum)));
       rowValues.push_back(rowValue);
@@ -105,9 +105,9 @@ public:
     for (size_t colNum = 0, numCols = colInputs.getNumElements();
          colNum < numCols; ++colNum) {
       Value colNumVal =
-          rewriter.create<hw::ConstantOp>(loc, colIdxType, colNum);
-      auto colValue =
-          rewriter.create<hw::ArrayGetOp>(loc, array.getColInputs(), colNumVal);
+          hw::ConstantOp::create(rewriter, loc, colIdxType, colNum);
+      auto colValue = hw::ArrayGetOp::create(rewriter, loc,
+                                             array.getColInputs(), colNumVal);
       colValue->setAttr("sv.namehint",
                         StringAttr::get(ctxt, "col_" + Twine(colNum)));
       colValues.push_back(colValue);
@@ -154,12 +154,12 @@ public:
       // vectors.
       std::reverse(colPEOutputs.begin(), colPEOutputs.end());
       peOutputs.push_back(
-          rewriter.create<hw::ArrayCreateOp>(loc, colPEOutputs));
+          hw::ArrayCreateOp::create(rewriter, loc, colPEOutputs));
     }
 
     std::reverse(peOutputs.begin(), peOutputs.end());
     rewriter.replaceOp(array,
-                       rewriter.create<hw::ArrayCreateOp>(loc, peOutputs));
+                       hw::ArrayCreateOp::create(rewriter, loc, peOutputs));
     return success();
   }
 };

--- a/lib/Dialect/MSFT/Transforms/MSFTLowerInstances.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTLowerInstances.cpp
@@ -73,7 +73,7 @@ LogicalResult LowerInstancesPass::lower(DynamicInstanceOp inst,
 
     // Create a hierpath to replace us.
     ArrayAttr hierPath = inst.getPath();
-    ref = b.create<hw::HierPathOp>(inst.getLoc(), refSym, hierPath);
+    ref = hw::HierPathOp::create(b, inst.getLoc(), refSym, hierPath);
 
     // Add the new symbol to the symbol cache.
     topSyms.addDefinition(refSym, ref);

--- a/lib/Dialect/Moore/MooreDialect.cpp
+++ b/lib/Dialect/Moore/MooreDialect.cpp
@@ -37,7 +37,7 @@ Operation *MooreDialect::materializeConstant(OpBuilder &builder,
                                              Location loc) {
   if (auto intType = dyn_cast<IntType>(type))
     if (auto intValue = dyn_cast<FVIntegerAttr>(value))
-      return builder.create<ConstantOp>(loc, intType, intValue);
+      return ConstantOp::create(builder, loc, intType, intValue);
   return nullptr;
 }
 

--- a/lib/Dialect/Moore/Transforms/LowerConcatRef.cpp
+++ b/lib/Dialect/Moore/Transforms/LowerConcatRef.cpp
@@ -64,14 +64,14 @@ struct ConcatRefLowering : public OpConversionPattern<OpTy> {
       // small or vice versa. Like "logic [7:0] or [0:7]".
 
       // Only able to correctly handle the situation like "[7:0]" now.
-      auto extract = rewriter.create<ExtractOp>(op.getLoc(), type, op.getSrc(),
-                                                srcWidth - width);
+      auto extract = ExtractOp::create(rewriter, op.getLoc(), type, op.getSrc(),
+                                       srcWidth - width);
 
       // Update the real bit width of RHS of assignment. Like "c" the above
       // description mentioned.
       srcWidth = srcWidth - width;
 
-      rewriter.create<OpTy>(op.getLoc(), operand, extract);
+      OpTy::create(rewriter, op.getLoc(), operand, extract);
     }
     rewriter.eraseOp(op);
     return success();

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -299,8 +299,8 @@ circt::om::ClassOp circt::om::ClassOp::buildSimpleClassOp(
     OpBuilder &odsBuilder, Location loc, Twine name,
     ArrayRef<StringRef> formalParamNames, ArrayRef<StringRef> fieldNames,
     ArrayRef<Type> fieldTypes) {
-  circt::om::ClassOp classOp = odsBuilder.create<circt::om::ClassOp>(
-      loc, odsBuilder.getStringAttr(name),
+  circt::om::ClassOp classOp = circt::om::ClassOp::create(
+      odsBuilder, loc, odsBuilder.getStringAttr(name),
       odsBuilder.getStrArrayAttr(formalParamNames),
       odsBuilder.getStrArrayAttr(fieldNames),
       odsBuilder.getDictionaryAttr(llvm::map_to_vector(
@@ -314,12 +314,13 @@ circt::om::ClassOp circt::om::ClassOp::buildSimpleClassOp(
 
   mlir::SmallVector<Attribute> locAttrs(fieldNames.size(), LocationAttr(loc));
 
-  odsBuilder.create<ClassFieldsOp>(
-      loc,
-      llvm::map_to_vector(
-          fieldTypes,
-          [&](Type type) -> Value { return body->addArgument(type, loc); }),
-      odsBuilder.getArrayAttr(locAttrs));
+  ClassFieldsOp::create(odsBuilder, loc,
+                        llvm::map_to_vector(fieldTypes,
+                                            [&](Type type) -> Value {
+                                              return body->addArgument(type,
+                                                                       loc);
+                                            }),
+                        odsBuilder.getArrayAttr(locAttrs));
 
   odsBuilder.restoreInsertionPoint(prevLoc);
 
@@ -442,8 +443,8 @@ void circt::om::ClassOp::addNewFieldsOp(mlir::OpBuilder &builder,
   }
   // Also store the locations incase there's some other analysis that might
   // be able to use the default FusedLoc representation.
-  builder.create<ClassFieldsOp>(builder.getFusedLoc(locs), values,
-                                builder.getArrayAttr(locAttrs));
+  ClassFieldsOp::create(builder, builder.getFusedLoc(locs), values,
+                        builder.getArrayAttr(locAttrs));
 }
 
 mlir::Location circt::om::ClassOp::getFieldLocByIndex(size_t i) {

--- a/lib/Dialect/OM/Transforms/FreezePaths.cpp
+++ b/lib/Dialect/OM/Transforms/FreezePaths.cpp
@@ -213,9 +213,9 @@ LogicalResult PathVisitor::process(PathCreateOp path) {
 
   // Replace the old path operation.
   OpBuilder builder(path);
-  auto frozenPath = builder.create<FrozenPathCreateOp>(
-      path.getLoc(), path.getTargetKindAttr(), path->getOperand(0), targetPath,
-      bottomModule, ref, field);
+  auto frozenPath = FrozenPathCreateOp::create(
+      builder, path.getLoc(), path.getTargetKindAttr(), path->getOperand(0),
+      targetPath, bottomModule, ref, field);
   path.replaceAllUsesWith(frozenPath.getResult());
   path->erase();
 
@@ -240,8 +240,8 @@ LogicalResult PathVisitor::process(BasePathCreateOp path) {
 
   // Replace the old path operation.
   OpBuilder builder(path);
-  auto frozenPath = builder.create<FrozenBasePathCreateOp>(
-      path.getLoc(), path->getOperand(0), targetPath);
+  auto frozenPath = FrozenBasePathCreateOp::create(
+      builder, path.getLoc(), path->getOperand(0), targetPath);
   path.replaceAllUsesWith(frozenPath.getResult());
   path->erase();
 
@@ -250,7 +250,7 @@ LogicalResult PathVisitor::process(BasePathCreateOp path) {
 
 LogicalResult PathVisitor::process(EmptyPathOp path) {
   OpBuilder builder(path);
-  auto frozenPath = builder.create<FrozenEmptyPathOp>(path.getLoc());
+  auto frozenPath = FrozenEmptyPathOp::create(builder, path.getLoc());
   path.replaceAllUsesWith(frozenPath.getResult());
   path->erase();
   return success();
@@ -290,8 +290,8 @@ LogicalResult PathVisitor::process(ObjectFieldOp objectFieldOp) {
 
   // Create a new op with the result type updated to replace path types.
   OpBuilder builder(objectFieldOp);
-  auto newObjectFieldOp = builder.create<ObjectFieldOp>(
-      objectFieldOp.getLoc(), newResultType, objectFieldOp.getObject(),
+  auto newObjectFieldOp = ObjectFieldOp::create(
+      builder, objectFieldOp.getLoc(), newResultType, objectFieldOp.getObject(),
       objectFieldOp.getFieldPath());
   objectFieldOp.replaceAllUsesWith(newObjectFieldOp.getResult());
   objectFieldOp->erase();

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -271,9 +271,9 @@ void ExplicitRegsPass::runOnPipeline(ScheduledPipelineOp pipeline) {
     StageOp terminator = cast<StageOp>(predecessorStage->getTerminator());
     b.setInsertionPoint(terminator);
     llvm::SmallVector<llvm::SmallVector<Value>> clockGates;
-    b.create<StageOp>(terminator.getLoc(), terminator.getNextStage(), regIns,
-                      passIns, clockGates, b.getArrayAttr(regNames),
-                      b.getArrayAttr(passNames));
+    StageOp::create(b, terminator.getLoc(), terminator.getNextStage(), regIns,
+                    passIns, clockGates, b.getArrayAttr(regNames),
+                    b.getArrayAttr(passNames));
     terminator.erase();
 
     // ... and add arguments to the next stage. Registers first, then

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -148,8 +148,8 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
 
   // Create the scheduled pipeline.
   b.setInsertionPoint(pipeline);
-  auto schedPipeline = b.template create<pipeline::ScheduledPipelineOp>(
-      pipeline.getLoc(), pipeline.getDataOutputs().getTypes(),
+  auto schedPipeline = pipeline::ScheduledPipelineOp::create(
+      b, pipeline.getLoc(), pipeline.getDataOutputs().getTypes(),
       pipeline.getInputs(), pipeline.getInputNames(), pipeline.getOutputNames(),
       pipeline.getClock(), pipeline.getGo(), pipeline.getReset(),
       pipeline.getStall(), pipeline.getNameAttr());
@@ -180,8 +180,8 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
       // Create a StageOp in the new stage, and branch it to the newly created
       // stage.
       b.setInsertionPointToEnd(currentStage);
-      b.create<pipeline::StageOp>(pipeline.getLoc(), newStage, ValueRange{},
-                                  ValueRange{});
+      pipeline::StageOp::create(b, pipeline.getLoc(), newStage, ValueRange{},
+                                ValueRange{});
       currentStage = newStage;
     }
   }
@@ -207,7 +207,7 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
       if (it == sourceOps.end()) {
         b.setInsertionPoint(opOperand.getOwner());
         it = sourceOps
-                 .try_emplace(v, b.create<SourceOp>(v.getLoc(), v).getResult())
+                 .try_emplace(v, SourceOp::create(b, v.getLoc(), v).getResult())
                  .first;
       }
       return it->second;

--- a/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
+++ b/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
@@ -159,9 +159,10 @@ void HWGeneratorCalloutPass::processGenerator(
   // Only extract the first line from the output.
   auto fileContent = (*bufferRead)->getBuffer().split('\n').first.str();
   OpBuilder builder(generatedModuleOp);
-  auto extMod = builder.create<hw::HWModuleExternOp>(
-      generatedModuleOp.getLoc(), generatedModuleOp.getVerilogModuleNameAttr(),
-      generatedModuleOp.getPortList());
+  auto extMod =
+      hw::HWModuleExternOp::create(builder, generatedModuleOp.getLoc(),
+                                   generatedModuleOp.getVerilogModuleNameAttr(),
+                                   generatedModuleOp.getPortList());
   // Attach an attribute to which file the definition of the external
   // module exists in.
   extMod->setAttr("filenames", builder.getStringAttr(fileContent));

--- a/lib/Dialect/SV/Transforms/HWEliminateInOutPorts.cpp
+++ b/lib/Dialect/SV/Transforms/HWEliminateInOutPorts.cpp
@@ -145,14 +145,14 @@ void HWInOutPortConversion::mapInputSignals(OpBuilder &b, Operation *inst,
     // Create a read_inout op at the instantiation point. This effectively
     // pushes the read_inout op from the module to the instantiation site.
     newOperands[readPort.argNum] =
-        b.create<ReadInOutOp>(inst->getLoc(), instValue).getResult();
+        ReadInOutOp::create(b, inst->getLoc(), instValue).getResult();
   }
 
   if (hasWriters()) {
     // Create a sv::AssignOp at the instantiation point. This effectively
     // pushes the write op from the module to the instantiation site.
     Value writeFromInsideMod = newResults[writePort.argNum];
-    b.create<sv::AssignOp>(inst->getLoc(), instValue, writeFromInsideMod);
+    sv::AssignOp::create(b, inst->getLoc(), instValue, writeFromInsideMod);
   }
 }
 

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -134,9 +134,9 @@ void HWExportModuleHierarchyPass::runOnOperation() {
 
       auto builder = ImplicitLocOpBuilder::atBlockEnd(
           UnknownLoc::get(mlirModule.getContext()), mlirModule.getBody());
-      builder.create<emit::FileOp>(file.getFilename(), [&] {
-        builder.create<sv::VerbatimOp>(jsonBuffer, ValueRange{},
-                                       builder.getArrayAttr(symbols));
+      emit::FileOp::create(builder, file.getFilename(), [&] {
+        sv::VerbatimOp::create(builder, jsonBuffer, ValueRange{},
+                               builder.getArrayAttr(symbols));
       });
     }
   }

--- a/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
@@ -45,15 +45,15 @@ void HWStubExternalModulesPass::runOnOperation() {
     if (auto module = dyn_cast<hw::HWModuleExternOp>(op)) {
       hw::ModulePortInfo ports(module.getPortList());
       auto nameAttr = module.getNameAttr();
-      auto newModule = builder.create<hw::HWModuleOp>(
-          module.getLoc(), nameAttr, ports, module.getParameters());
+      auto newModule = hw::HWModuleOp::create(
+          builder, module.getLoc(), nameAttr, ports, module.getParameters());
       auto outputOp = newModule.getBodyBlock()->getTerminator();
       OpBuilder innerBuilder(outputOp);
       SmallVector<Value, 8> outputs;
       // All output ports need values, use x
       for (auto &p : ports.getOutputs()) {
         outputs.push_back(
-            innerBuilder.create<sv::ConstantXOp>(outputOp->getLoc(), p.type));
+            sv::ConstantXOp::create(innerBuilder, outputOp->getLoc(), p.type));
       }
       outputOp->setOperands(outputs);
 

--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -151,9 +151,9 @@ bool PrettifyVerilogPass::splitStructAssignment(OpBuilder &builder,
       continue;
 
     auto &[loc, value] = it->second;
-    auto ref = builder.create<sv::StructFieldInOutOp>(loc, dst, name);
+    auto ref = sv::StructFieldInOutOp::create(builder, loc, dst, name);
     if (!splitAssignment(builder, ref, value))
-      builder.create<sv::PAssignOp>(loc, ref, value);
+      sv::PAssignOp::create(builder, loc, ref, value);
   }
   return true;
 }
@@ -173,11 +173,11 @@ bool PrettifyVerilogPass::splitArrayAssignment(OpBuilder &builder,
 
     Value value = op.getInputs()[0];
     auto loc = op.getLoc();
-    auto index = builder.create<hw::ConstantOp>(loc, zero);
+    auto index = hw::ConstantOp::create(builder, loc, zero);
 
-    auto field = builder.create<sv::ArrayIndexInOutOp>(loc, dst, index);
+    auto field = sv::ArrayIndexInOutOp::create(builder, loc, dst, index);
     if (!splitAssignment(builder, field, value))
-      builder.create<sv::PAssignOp>(loc, field, value);
+      sv::PAssignOp::create(builder, loc, field, value);
     return true;
   }
 
@@ -263,10 +263,10 @@ bool PrettifyVerilogPass::splitArrayAssignment(OpBuilder &builder,
   for (auto &[i, loc, value] : fields) {
     if (i == last)
       continue;
-    auto index = builder.create<hw::ConstantOp>(loc, i);
-    auto field = builder.create<sv::ArrayIndexInOutOp>(loc, dst, index);
+    auto index = hw::ConstantOp::create(builder, loc, i);
+    auto field = sv::ArrayIndexInOutOp::create(builder, loc, dst, index);
     if (!splitAssignment(builder, field, value))
-      builder.create<sv::PAssignOp>(loc, field, value);
+      sv::PAssignOp::create(builder, loc, field, value);
     last = i;
   }
   return true;

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -227,8 +227,8 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   }
 
   // Create the module, setting the output path if indicated.
-  auto newMod = b.create<hw::HWModuleOp>(
-      op.getLoc(),
+  auto newMod = hw::HWModuleOp::create(
+      b, op.getLoc(),
       b.getStringAttr(getVerilogModuleNameAttr(op).getValue() + suffix), ports);
   if (path)
     newMod->setAttr("output_file", path);
@@ -247,8 +247,8 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
 
   // Add an instance in the old module for the extracted module
   b = OpBuilder::atBlockTerminator(op.getBodyBlock());
-  auto inst = b.create<hw::InstanceOp>(
-      op.getLoc(), newMod, newMod.getName(), realInputs, ArrayAttr(),
+  auto inst = hw::InstanceOp::create(
+      b, op.getLoc(), newMod, newMod.getName(), realInputs, ArrayAttr(),
       hw::InnerSymAttr::get(b.getStringAttr(
           ("__ETC_" + getVerilogModuleNameAttr(op).getValue() + suffix)
               .str())));
@@ -256,8 +256,8 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   b = OpBuilder::atBlockEnd(
       &op->getParentOfType<mlir::ModuleOp>()->getRegion(0).front());
 
-  auto bindOp = b.create<sv::BindOp>(op.getLoc(), op.getNameAttr(),
-                                     inst.getInnerSymAttr().getSymName());
+  auto bindOp = sv::BindOp::create(b, op.getLoc(), op.getNameAttr(),
+                                   inst.getInnerSymAttr().getSymName());
   bindTable[op.getNameAttr()][inst.getInnerSymAttr().getSymName()] = bindOp;
   if (fileName)
     bindOp->setAttr("output_file", fileName);

--- a/lib/Dialect/SV/Transforms/SVTraceIVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/SVTraceIVerilog.cpp
@@ -74,7 +74,7 @@ void SVTraceIVerilogPass::runOnOperation() {
     ss << "initial begin\n  $dumpfile (\"" << directoryName.getValue()
        << modName << ".vcd\");\n  $dumpvars (0, " << modName
        << ");\n  #1;\nend\n";
-    builder.create<sv::VerbatimOp>(hwmod.getLoc(), ss.str());
+    sv::VerbatimOp::create(builder, hwmod.getLoc(), ss.str());
   }
 }
 

--- a/lib/Dialect/Seq/SeqDialect.cpp
+++ b/lib/Dialect/Seq/SeqDialect.cpp
@@ -47,11 +47,11 @@ Operation *SeqDialect::materializeConstant(OpBuilder &builder, Attribute value,
   // Integer constants.
   if (auto intType = dyn_cast<IntegerType>(type))
     if (auto attrValue = dyn_cast<IntegerAttr>(value))
-      return builder.create<hw::ConstantOp>(loc, type, attrValue);
+      return hw::ConstantOp::create(builder, loc, type, attrValue);
 
   if (isa<ClockType>(type))
     if (auto attrValue = dyn_cast<ClockConstAttr>(value))
-      return builder.create<seq::ConstClockOp>(loc, attrValue);
+      return seq::ConstClockOp::create(builder, loc, attrValue);
 
   return nullptr;
 }

--- a/lib/Dialect/Seq/Transforms/ExternalizeClockGate.cpp
+++ b/lib/Dialect/Seq/Transforms/ExternalizeClockGate.cpp
@@ -64,9 +64,9 @@ void ExternalizeClockGatePass::runOnOperation() {
     modulePorts.push_back({{builder.getStringAttr(testEnableName), i1Type,
                             ModulePort::Direction::Input}});
 
-  auto externModuleOp = builder.create<HWModuleExternOp>(
-      getOperation().getLoc(), builder.getStringAttr(moduleName), modulePorts,
-      moduleName);
+  auto externModuleOp = HWModuleExternOp::create(
+      builder, getOperation().getLoc(), builder.getStringAttr(moduleName),
+      modulePorts, moduleName);
   symtbl.insert(externModuleOp);
 
   // Replace all clock gates with an instance of the external module.
@@ -84,7 +84,7 @@ void ExternalizeClockGatePass::runOnOperation() {
       // constant 0 input.
       if (hasTestEnable && !testEnable) {
         if (!cstFalse) {
-          cstFalse = builder.create<ConstantOp>(i1Type, 0);
+          cstFalse = ConstantOp::create(builder, i1Type, 0);
         }
         testEnable = cstFalse;
       }
@@ -102,7 +102,7 @@ void ExternalizeClockGatePass::runOnOperation() {
         if (it.second) {
           ImplicitLocOpBuilder builder(input.getLoc(), &getContext());
           builder.setInsertionPointAfterValue(input);
-          it.first->second = builder.create<seq::FromClockOp>(input);
+          it.first->second = seq::FromClockOp::create(builder, input);
         }
         instPorts.push_back(it.first->second);
       } else {
@@ -112,13 +112,13 @@ void ExternalizeClockGatePass::runOnOperation() {
       if (testEnable)
         instPorts.push_back(testEnable);
 
-      auto instOp = builder.create<InstanceOp>(
-          externModuleOp, builder.getStringAttr(instName), instPorts,
+      auto instOp = InstanceOp::create(
+          builder, externModuleOp, builder.getStringAttr(instName), instPorts,
           builder.getArrayAttr({}), ckgOp.getInnerSymAttr());
 
       Value output = instOp.getResult(0);
       if (hw::type_isa<seq::ClockType>(input.getType()))
-        output = builder.create<seq::ToClockOp>(output);
+        output = seq::ToClockOp::create(builder, output);
       ckgOp.replaceAllUsesWith(output);
       ckgOp.erase();
 

--- a/lib/Dialect/Seq/Transforms/LowerSeqFIFO.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqFIFO.cpp
@@ -48,104 +48,107 @@ public:
     Backedge nextCount = bb.get(countType);
 
     // ====== Some constants ======
-    Value countTcFull = rewriter.create<hw::ConstantOp>(loc, countType, depth);
-    Value countTc1 = rewriter.create<hw::ConstantOp>(loc, countType, 1);
-    Value countTc0 = rewriter.create<hw::ConstantOp>(loc, countType, 0);
-    Value ptrTc0 = rewriter.create<hw::ConstantOp>(loc, ptrType, 0);
-    Value ptrTc1 = rewriter.create<hw::ConstantOp>(loc, ptrType, 1);
-    Value ptrTcFull = rewriter.create<hw::ConstantOp>(loc, ptrType, depth);
+    Value countTcFull = hw::ConstantOp::create(rewriter, loc, countType, depth);
+    Value countTc1 = hw::ConstantOp::create(rewriter, loc, countType, 1);
+    Value countTc0 = hw::ConstantOp::create(rewriter, loc, countType, 0);
+    Value ptrTc0 = hw::ConstantOp::create(rewriter, loc, ptrType, 0);
+    Value ptrTc1 = hw::ConstantOp::create(rewriter, loc, ptrType, 1);
+    Value ptrTcFull = hw::ConstantOp::create(rewriter, loc, ptrType, depth);
 
     // ====== Hardware units ======
-    Value count = rewriter.create<seq::CompRegOp>(
-        loc, nextCount, clk, rst,
-        rewriter.create<hw::ConstantOp>(loc, countType, 0), "fifo_count");
-    seq::HLMemOp hlmem = rewriter.create<seq::HLMemOp>(
-        loc, clk, rst, "fifo_mem",
+    Value count = seq::CompRegOp::create(
+        rewriter, loc, nextCount, clk, rst,
+        hw::ConstantOp::create(rewriter, loc, countType, 0), "fifo_count");
+    seq::HLMemOp hlmem = seq::HLMemOp::create(
+        rewriter, loc, clk, rst, "fifo_mem",
         llvm::SmallVector<int64_t>{static_cast<int64_t>(depth)}, eltType);
-    Value rdAddr = rewriter.create<seq::CompRegOp>(
-        loc, rdAddrNext, clk, rst,
-        rewriter.create<hw::ConstantOp>(loc, ptrType, 0), "fifo_rd_addr");
-    Value wrAddr = rewriter.create<seq::CompRegOp>(
-        loc, wrAddrNext, clk, rst,
-        rewriter.create<hw::ConstantOp>(loc, ptrType, 0), "fifo_wr_addr");
+    Value rdAddr = seq::CompRegOp::create(
+        rewriter, loc, rdAddrNext, clk, rst,
+        hw::ConstantOp::create(rewriter, loc, ptrType, 0), "fifo_rd_addr");
+    Value wrAddr = seq::CompRegOp::create(
+        rewriter, loc, wrAddrNext, clk, rst,
+        hw::ConstantOp::create(rewriter, loc, ptrType, 0), "fifo_wr_addr");
 
-    Value readData = rewriter.create<seq::ReadPortOp>(
-        loc, hlmem, llvm::SmallVector<Value>{rdAddr}, adaptor.getRdEn(),
-        mem.getRdLatency());
-    rewriter.create<seq::WritePortOp>(loc, hlmem,
-                                      llvm::SmallVector<Value>{wrAddr},
-                                      adaptor.getInput(), adaptor.getWrEn(),
-                                      /*latency*/ 1);
+    Value readData = seq::ReadPortOp::create(
+        rewriter, loc, hlmem, llvm::SmallVector<Value>{rdAddr},
+        adaptor.getRdEn(), mem.getRdLatency());
+    seq::WritePortOp::create(rewriter, loc, hlmem,
+                             llvm::SmallVector<Value>{wrAddr},
+                             adaptor.getInput(), adaptor.getWrEn(),
+                             /*latency*/ 1);
 
     // ====== some more constants =====
-    comb::ICmpOp fifoFull = rewriter.create<comb::ICmpOp>(
-        loc, comb::ICmpPredicate::eq, count, countTcFull);
+    comb::ICmpOp fifoFull = comb::ICmpOp::create(
+        rewriter, loc, comb::ICmpPredicate::eq, count, countTcFull);
     fifoFull->setAttr("sv.namehint", rewriter.getStringAttr("fifo_full"));
-    comb::ICmpOp fifoEmpty = rewriter.create<comb::ICmpOp>(
-        loc, comb::ICmpPredicate::eq, count, countTc0);
+    comb::ICmpOp fifoEmpty = comb::ICmpOp::create(
+        rewriter, loc, comb::ICmpPredicate::eq, count, countTc0);
     fifoEmpty->setAttr("sv.namehint", rewriter.getStringAttr("fifo_empty"));
 
     // ====== Next-state count ======
     auto notRdEn = comb::createOrFoldNot(loc, adaptor.getRdEn(), rewriter);
     auto notWrEn = comb::createOrFoldNot(loc, adaptor.getWrEn(), rewriter);
-    Value rdEnNandWrEn = rewriter.create<comb::AndOp>(loc, notRdEn, notWrEn);
+    Value rdEnNandWrEn = comb::AndOp::create(rewriter, loc, notRdEn, notWrEn);
     Value rdEnAndNotWrEn =
-        rewriter.create<comb::AndOp>(loc, adaptor.getRdEn(), notWrEn);
+        comb::AndOp::create(rewriter, loc, adaptor.getRdEn(), notWrEn);
     Value wrEnAndNotRdEn =
-        rewriter.create<comb::AndOp>(loc, adaptor.getWrEn(), notRdEn);
+        comb::AndOp::create(rewriter, loc, adaptor.getWrEn(), notRdEn);
 
-    auto countEqTcFull = rewriter.create<comb::ICmpOp>(
-        loc, comb::ICmpPredicate::eq, count, countTcFull);
-    auto addCountTc1 = rewriter.create<comb::AddOp>(loc, count, countTc1);
-    Value wrEnNext = rewriter.create<comb::MuxOp>(loc, countEqTcFull,
-                                                  // keep value
-                                                  count,
-                                                  // increment
-                                                  addCountTc1);
-    auto countEqTc0 = rewriter.create<comb::ICmpOp>(
-        loc, comb::ICmpPredicate::eq, count, countTc0);
-    auto subCountTc1 = rewriter.create<comb::SubOp>(loc, count, countTc1);
+    auto countEqTcFull = comb::ICmpOp::create(
+        rewriter, loc, comb::ICmpPredicate::eq, count, countTcFull);
+    auto addCountTc1 = comb::AddOp::create(rewriter, loc, count, countTc1);
+    Value wrEnNext = comb::MuxOp::create(rewriter, loc, countEqTcFull,
+                                         // keep value
+                                         count,
+                                         // increment
+                                         addCountTc1);
+    auto countEqTc0 = comb::ICmpOp::create(
+        rewriter, loc, comb::ICmpPredicate::eq, count, countTc0);
+    auto subCountTc1 = comb::SubOp::create(rewriter, loc, count, countTc1);
 
-    Value rdEnNext = rewriter.create<comb::MuxOp>(loc, countEqTc0,
-                                                  // keep value
-                                                  count,
-                                                  // decrement
-                                                  subCountTc1);
+    Value rdEnNext = comb::MuxOp::create(rewriter, loc, countEqTc0,
+                                         // keep value
+                                         count,
+                                         // decrement
+                                         subCountTc1);
 
     auto nextInnerMux =
-        rewriter.create<comb::MuxOp>(loc, rdEnAndNotWrEn, rdEnNext, count);
-    auto nextMux = rewriter.create<comb::MuxOp>(loc, wrEnAndNotRdEn, wrEnNext,
-                                                nextInnerMux);
-    nextCount.setValue(rewriter.create<comb::MuxOp>(
-        loc, rdEnNandWrEn, /*keep value*/ count, nextMux));
+        comb::MuxOp::create(rewriter, loc, rdEnAndNotWrEn, rdEnNext, count);
+    auto nextMux = comb::MuxOp::create(rewriter, loc, wrEnAndNotRdEn, wrEnNext,
+                                       nextInnerMux);
+    nextCount.setValue(comb::MuxOp::create(rewriter, loc, rdEnNandWrEn,
+                                           /*keep value*/ count, nextMux));
     static_cast<Value>(nextCount).getDefiningOp()->setAttr(
         "sv.namehint", rewriter.getStringAttr("fifo_count_next"));
 
     // ====== Read/write pointers ======
-    Value wrAndNotFull = rewriter.create<comb::AndOp>(
-        loc, adaptor.getWrEn(), comb::createOrFoldNot(loc, fifoFull, rewriter));
-    auto addWrAddrPtrTc1 = rewriter.create<comb::AddOp>(loc, wrAddr, ptrTc1);
+    Value wrAndNotFull =
+        comb::AndOp::create(rewriter, loc, adaptor.getWrEn(),
+                            comb::createOrFoldNot(loc, fifoFull, rewriter));
+    auto addWrAddrPtrTc1 = comb::AddOp::create(rewriter, loc, wrAddr, ptrTc1);
 
-    auto wrAddrNextNoRollover = rewriter.create<comb::MuxOp>(
-        loc, wrAndNotFull, addWrAddrPtrTc1, wrAddr);
-    auto isMaxAddrWr = rewriter.create<comb::ICmpOp>(
-        loc, comb::ICmpPredicate::eq, wrAddrNextNoRollover, ptrTcFull);
-    wrAddrNext.setValue(rewriter.create<comb::MuxOp>(loc, isMaxAddrWr, ptrTc0,
-                                                     wrAddrNextNoRollover));
+    auto wrAddrNextNoRollover = comb::MuxOp::create(rewriter, loc, wrAndNotFull,
+                                                    addWrAddrPtrTc1, wrAddr);
+    auto isMaxAddrWr =
+        comb::ICmpOp::create(rewriter, loc, comb::ICmpPredicate::eq,
+                             wrAddrNextNoRollover, ptrTcFull);
+    wrAddrNext.setValue(comb::MuxOp::create(rewriter, loc, isMaxAddrWr, ptrTc0,
+                                            wrAddrNextNoRollover));
     static_cast<Value>(wrAddrNext)
         .getDefiningOp()
         ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_wr_addr_next"));
 
     auto notFifoEmpty = comb::createOrFoldNot(loc, fifoEmpty, rewriter);
     Value rdAndNotEmpty =
-        rewriter.create<comb::AndOp>(loc, adaptor.getRdEn(), notFifoEmpty);
-    auto addRdAddrPtrTc1 = rewriter.create<comb::AddOp>(loc, rdAddr, ptrTc1);
-    auto rdAddrNextNoRollover = rewriter.create<comb::MuxOp>(
-        loc, rdAndNotEmpty, addRdAddrPtrTc1, rdAddr);
-    auto isMaxAddrRd = rewriter.create<comb::ICmpOp>(
-        loc, comb::ICmpPredicate::eq, rdAddrNextNoRollover, ptrTcFull);
-    rdAddrNext.setValue(rewriter.create<comb::MuxOp>(loc, isMaxAddrRd, ptrTc0,
-                                                     rdAddrNextNoRollover));
+        comb::AndOp::create(rewriter, loc, adaptor.getRdEn(), notFifoEmpty);
+    auto addRdAddrPtrTc1 = comb::AddOp::create(rewriter, loc, rdAddr, ptrTc1);
+    auto rdAddrNextNoRollover = comb::MuxOp::create(
+        rewriter, loc, rdAndNotEmpty, addRdAddrPtrTc1, rdAddr);
+    auto isMaxAddrRd =
+        comb::ICmpOp::create(rewriter, loc, comb::ICmpPredicate::eq,
+                             rdAddrNextNoRollover, ptrTcFull);
+    rdAddrNext.setValue(comb::MuxOp::create(rewriter, loc, isMaxAddrRd, ptrTc0,
+                                            rdAddrNextNoRollover));
     static_cast<Value>(rdAddrNext)
         .getDefiningOp()
         ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_rd_addr_next"));
@@ -161,37 +164,39 @@ public:
     results.push_back(fifoEmpty);
 
     if (auto almostFull = mem.getAlmostFullThreshold()) {
-      results.push_back(rewriter.create<comb::ICmpOp>(
-          loc, comb::ICmpPredicate::uge, count,
-          rewriter.create<hw::ConstantOp>(loc, countType, almostFull.value())));
+      results.push_back(
+          comb::ICmpOp::create(rewriter, loc, comb::ICmpPredicate::uge, count,
+                               hw::ConstantOp::create(rewriter, loc, countType,
+                                                      almostFull.value())));
       static_cast<Value>(results.back())
           .getDefiningOp()
           ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_almost_full"));
     }
 
     if (auto almostEmpty = mem.getAlmostEmptyThreshold()) {
-      results.push_back(rewriter.create<comb::ICmpOp>(
-          loc, comb::ICmpPredicate::ule, count,
-          rewriter.create<hw::ConstantOp>(loc, countType,
-                                          almostEmpty.value())));
+      results.push_back(
+          comb::ICmpOp::create(rewriter, loc, comb::ICmpPredicate::ule, count,
+                               hw::ConstantOp::create(rewriter, loc, countType,
+                                                      almostEmpty.value())));
       static_cast<Value>(results.back())
           .getDefiningOp()
           ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_almost_empty"));
     }
 
     // ====== Protocol checks =====
-    Value clkI1 = rewriter.create<seq::FromClockOp>(loc, clk);
+    Value clkI1 = seq::FromClockOp::create(rewriter, loc, clk);
     Value notEmptyAndRden = comb::createOrFoldNot(
-        loc, rewriter.create<comb::AndOp>(loc, adaptor.getRdEn(), fifoEmpty),
+        loc, comb::AndOp::create(rewriter, loc, adaptor.getRdEn(), fifoEmpty),
         rewriter);
-    rewriter.create<verif::ClockedAssertOp>(
-        loc, notEmptyAndRden, verif::ClockEdge::Pos, clkI1, /*enable=*/Value(),
+    verif::ClockedAssertOp::create(
+        rewriter, loc, notEmptyAndRden, verif::ClockEdge::Pos, clkI1,
+        /*enable=*/Value(),
         rewriter.getStringAttr("FIFO empty when read enabled"));
     Value notFullAndWren = comb::createOrFoldNot(
-        loc, rewriter.create<comb::AndOp>(loc, adaptor.getWrEn(), fifoFull),
+        loc, comb::AndOp::create(rewriter, loc, adaptor.getWrEn(), fifoFull),
         rewriter);
-    rewriter.create<verif::ClockedAssertOp>(
-        loc, notFullAndWren, verif::ClockEdge::Pos, clkI1,
+    verif::ClockedAssertOp::create(
+        rewriter, loc, notFullAndWren, verif::ClockEdge::Pos, clkI1,
         /*enable=*/Value(),
         rewriter.getStringAttr("FIFO full when write enabled"));
 

--- a/lib/Dialect/Seq/Transforms/LowerSeqShiftReg.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqShiftReg.cpp
@@ -51,8 +51,8 @@ public:
       StringAttr name;
       if (baseName.has_value())
         name = rewriter.getStringAttr(baseName.value() + "_sh" + Twine(i + 1));
-      in = rewriter.create<seq::CompRegClockEnabledOp>(
-          op.getLoc(), in, adaptor.getClk(), adaptor.getClockEnable(),
+      in = seq::CompRegClockEnabledOp::create(
+          rewriter, op.getLoc(), in, adaptor.getClk(), adaptor.getClockEnable(),
           adaptor.getReset(), adaptor.getResetValue(), name, init);
     }
 

--- a/lib/Dialect/Seq/Transforms/RegOfVecToMem.cpp
+++ b/lib/Dialect/Seq/Transforms/RegOfVecToMem.cpp
@@ -186,8 +186,8 @@ bool RegOfVecToMemPass::createFirMemory(MemoryPattern &pattern) {
   // Create FirMem
   auto memType =
       FirMemType::get(builder.getContext(), depth, width, /*maskWidth=*/1);
-  auto firMem = builder.create<seq::FirMemOp>(
-      memType, /*readLatency=*/0, /*writeLatency=*/1,
+  auto firMem = seq::FirMemOp::create(
+      builder, memType, /*readLatency=*/0, /*writeLatency=*/1,
       /*readUnderWrite=*/seq::RUW::Undefined,
       /*writeUnderWrite=*/seq::WUW::Undefined,
       /*name=*/builder.getStringAttr("mem"), /*innerSym=*/hw::InnerSymAttr{},
@@ -195,17 +195,17 @@ bool RegOfVecToMemPass::createFirMemory(MemoryPattern &pattern) {
       /*outputFile=*/Attribute{});
 
   // Create read port
-  Value readData = builder.create<FirMemReadOp>(
-      firMem, pattern.readAddr, pattern.clock,
-      /*enable=*/builder.create<hw::ConstantOp>(builder.getI1Type(), 1));
+  Value readData = FirMemReadOp::create(
+      builder, firMem, pattern.readAddr, pattern.clock,
+      /*enable=*/hw::ConstantOp::create(builder, builder.getI1Type(), 1));
 
   LLVM_DEBUG(llvm::dbgs() << "  Created read port\n"
                           << firMem << "\n " << readData);
 
   Value mask;
   // Create write port
-  builder.create<FirMemWriteOp>(firMem, pattern.writeAddr, pattern.clock,
-                                pattern.writeEnable, pattern.writeData, mask);
+  FirMemWriteOp::create(builder, firMem, pattern.writeAddr, pattern.clock,
+                        pattern.writeEnable, pattern.writeData, mask);
 
   LLVM_DEBUG(llvm::dbgs() << "  Created write port\n");
 

--- a/lib/Dialect/Sim/SimDialect.cpp
+++ b/lib/Dialect/Sim/SimDialect.cpp
@@ -41,7 +41,7 @@ Operation *SimDialect::materializeConstant(::mlir::OpBuilder &builder,
                                            ::mlir::Location loc) {
 
   if (auto fmtStrType = llvm::dyn_cast<FormatStringType>(type))
-    return builder.create<FormatLitOp>(loc, fmtStrType,
-                                       llvm::cast<StringAttr>(value));
+    return FormatLitOp::create(builder, loc, fmtStrType,
+                               llvm::cast<StringAttr>(value));
   return nullptr;
 }

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -332,7 +332,8 @@ CtorOp SCModuleOp::getOrCreateCtor() {
   if (ctor)
     return ctor;
 
-  return OpBuilder(getBody()).create<CtorOp>(getLoc());
+  auto builder = OpBuilder(getBody());
+  return CtorOp::create(builder, getLoc());
 }
 
 DestructorOp SCModuleOp::getOrCreateDestructor() {
@@ -347,7 +348,8 @@ DestructorOp SCModuleOp::getOrCreateDestructor() {
   if (destructor)
     return destructor;
 
-  return OpBuilder::atBlockEnd(getBodyBlock()).create<DestructorOp>(getLoc());
+  auto builder = OpBuilder::atBlockEnd(getBodyBlock());
+  return DestructorOp::create(builder, getLoc());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Verif/Transforms/LowerContracts.cpp
+++ b/lib/Dialect/Verif/Transforms/LowerContracts.cpp
@@ -49,10 +49,10 @@ Operation *replaceContractOp(OpBuilder &builder, RequireLike op,
 
   if ((isa<EnsureOp>(op) && !assumeContract) ||
       (isa<RequireOp>(op) && assumeContract))
-    return builder.create<AssertOp>(loc, property, enableValue, labelAttr);
+    return AssertOp::create(builder, loc, property, enableValue, labelAttr);
   if ((isa<EnsureOp>(op) && assumeContract) ||
       (isa<RequireOp>(op) && !assumeContract))
-    return builder.create<AssumeOp>(loc, property, enableValue, labelAttr);
+    return AssumeOp::create(builder, loc, property, enableValue, labelAttr);
   return nullptr;
 }
 
@@ -85,7 +85,7 @@ void assumeContractHolds(OpBuilder &builder, IRMapping &mapping,
   // contract ops with the assume variant
   for (auto result : contract.getResults()) {
     auto sym =
-        builder.create<SymbolicValueOp>(result.getLoc(), result.getType());
+        SymbolicValueOp::create(builder, result.getLoc(), result.getType());
     mapping.map(result, sym);
   }
   auto &contractOps = contract.getBody().front().getOperations();
@@ -107,8 +107,8 @@ void buildOpsToClone(OpBuilder &builder, IRMapping &mapping, Operation *op,
       workList.push(definingOp);
     } else {
       // Create symbolic values for arguments
-      auto sym = builder.create<verif::SymbolicValueOp>(operand.getLoc(),
-                                                        operand.getType());
+      auto sym = verif::SymbolicValueOp::create(builder, operand.getLoc(),
+                                                operand.getType());
       mapping.map(operand, sym);
     }
   }
@@ -174,7 +174,7 @@ LogicalResult inlineContract(ContractOp &contract, OpBuilder &builder,
     // Create symbolic values for results
     for (auto result : contract.getResults()) {
       auto sym =
-          builder.create<SymbolicValueOp>(result.getLoc(), result.getType());
+          SymbolicValueOp::create(builder, result.getLoc(), result.getType());
       mapping.map(result, sym);
     }
   } else {
@@ -214,8 +214,9 @@ LogicalResult runOnHWModule(HWModuleOp hwModule, ModuleOp mlirModule) {
     // Create verif.formal op
     auto name = mlirModuleBuilder.getStringAttr(
         hwModule.getNameAttr().getValue() + "_CheckContract_" + Twine(i));
-    auto formalOp = mlirModuleBuilder.create<verif::FormalOp>(
-        contract.getLoc(), name, mlirModuleBuilder.getDictionaryAttr({}));
+    auto formalOp =
+        verif::FormalOp::create(mlirModuleBuilder, contract.getLoc(), name,
+                                mlirModuleBuilder.getDictionaryAttr({}));
 
     // Fill in verif.formal body
     OpBuilder formalBuilder(formalOp);

--- a/lib/Dialect/Verif/Transforms/LowerFormalToHW.cpp
+++ b/lib/Dialect/Verif/Transforms/LowerFormalToHW.cpp
@@ -44,7 +44,7 @@ static LogicalResult lowerFormalToHW(FormalOp op) {
   }
 
   auto moduleOp =
-      rewriter.create<hw::HWModuleOp>(op.getLoc(), op.getNameAttr(), ports);
+      hw::HWModuleOp::create(rewriter, op.getLoc(), op.getNameAttr(), ports);
 
   rewriter.inlineBlockBefore(&op.getBody().front(),
                              &moduleOp.getBodyBlock()->front(),

--- a/lib/Dialect/Verif/VerifDialect.cpp
+++ b/lib/Dialect/Verif/VerifDialect.cpp
@@ -27,7 +27,7 @@ Operation *VerifDialect::materializeConstant(OpBuilder &builder,
                                              Location loc) {
   if (auto intType = dyn_cast<IntegerType>(type))
     if (auto attrValue = dyn_cast<IntegerAttr>(value))
-      return builder.create<hw::ConstantOp>(loc, type, attrValue);
+      return hw::ConstantOp::create(builder, loc, type, attrValue);
   return nullptr;
 }
 

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -40,7 +40,7 @@ LogicalResult BackedgeBuilder::clearOrEmitError() {
     if (!op->use_empty()) {
       auto diag = op->emitError("backedge of type ")
                   << op->getResult(0).getType() << " still in use";
-      for (auto user : op->getUsers())
+      for (auto *user : op->getUsers())
         diag.attachNote(user->getLoc()) << "used by " << *user;
       ++numInUse;
       continue;
@@ -65,8 +65,8 @@ BackedgeBuilder::BackedgeBuilder(PatternRewriter &rewriter, Location loc)
 Backedge BackedgeBuilder::get(Type t, mlir::LocationAttr optionalLoc) {
   if (!optionalLoc)
     optionalLoc = loc;
-  Operation *op = builder.create<mlir::UnrealizedConversionCastOp>(
-      optionalLoc, t, ValueRange{});
+  Operation *op = mlir::UnrealizedConversionCastOp::create(builder, optionalLoc,
+                                                           t, ValueRange{});
   edges.push_back(op);
   return Backedge(op);
 }

--- a/lib/Support/InstanceGraph.cpp
+++ b/lib/Support/InstanceGraph.cpp
@@ -183,7 +183,7 @@ InstanceGraph::getInferredTopLevelNodes() {
               return true;
             }
             marked.insert(node);
-            for (auto use : *node) {
+            for (auto *use : *node) {
               InstanceGraphNode *targetModule = use->getTarget();
               candidateTopLevels.remove(targetModule);
               if (cycleUtil(targetModule, trace))
@@ -195,7 +195,7 @@ InstanceGraph::getInferredTopLevelNodes() {
           };
 
   bool cyclic = false;
-  for (auto moduleIt : *this) {
+  for (auto *moduleIt : *this) {
     if (visited.contains(moduleIt))
       continue;
 

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -178,12 +178,12 @@ void ExternalizeRegistersPass::runOnOperation() {
           }
           SmallVector<Type> resTypes(instanceOp->getResultTypes());
           resTypes.append(newOutputs);
-          auto newInst = builder.create<InstanceOp>(
-              instanceOp.getLoc(), resTypes, instanceOp.getInstanceNameAttr(),
-              instanceOp.getModuleNameAttr(), instanceOp.getInputs(),
-              builder.getArrayAttr(argNames), builder.getArrayAttr(resultNames),
-              instanceOp.getParametersAttr(), instanceOp.getInnerSymAttr(),
-              instanceOp.getDoNotPrintAttr());
+          auto newInst = InstanceOp::create(
+              builder, instanceOp.getLoc(), resTypes,
+              instanceOp.getInstanceNameAttr(), instanceOp.getModuleNameAttr(),
+              instanceOp.getInputs(), builder.getArrayAttr(argNames),
+              builder.getArrayAttr(resultNames), instanceOp.getParametersAttr(),
+              instanceOp.getInnerSymAttr(), instanceOp.getDoNotPrintAttr());
           for (auto [output, name] :
                zip(newInst->getResults().take_back(newOutputs.size()),
                    newOutputNames))
@@ -244,8 +244,8 @@ LogicalResult ExternalizeRegistersPass::externalizeReg(
       return failure();
     }
     // Sync reset
-    auto mux = builder.create<comb::MuxOp>(op->getLoc(), regType, reset,
-                                           resetValue, next);
+    auto mux = comb::MuxOp::create(builder, op->getLoc(), regType, reset,
+                                   resetValue, next);
     module.appendOutput(newOutputName, mux);
   } else {
     // No reset

--- a/lib/Transforms/IndexSwitchToIf.cpp
+++ b/lib/Transforms/IndexSwitchToIf.cpp
@@ -49,12 +49,13 @@ struct SwitchToIfConversion : public OpConversionPattern<scf::IndexSwitchOp> {
         rewriter.setInsertionPointToStart(&prevIfOp.getElseRegion().front());
 
       Value caseValue =
-          rewriter.create<arith::ConstantIndexOp>(loc, caseValueInt);
-      Value cond = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::eq, switchOp.getOperand(), caseValue);
+          arith::ConstantIndexOp::create(rewriter, loc, caseValueInt);
+      Value cond =
+          arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
+                                switchOp.getOperand(), caseValue);
 
-      auto ifOp = rewriter.create<scf::IfOp>(loc, switchOp.getResultTypes(),
-                                             cond, /*hasElseRegion=*/true);
+      auto ifOp = scf::IfOp::create(rewriter, loc, switchOp.getResultTypes(),
+                                    cond, /*hasElseRegion=*/true);
 
       Region &caseRegion = switchOp.getCaseRegions()[i];
       rewriter.eraseBlock(&ifOp.getThenRegion().front());
@@ -69,7 +70,7 @@ struct SwitchToIfConversion : public OpConversionPattern<scf::IndexSwitchOp> {
 
       if (prevIfOp && hasResults) {
         rewriter.setInsertionPointToEnd(&prevIfOp.getElseRegion().front());
-        rewriter.create<scf::YieldOp>(loc, ifOp.getResult(0));
+        scf::YieldOp::create(rewriter, loc, ifOp.getResult(0));
       }
 
       if (i == 0 && hasResults)

--- a/lib/Transforms/InsertMergeBlocks.cpp
+++ b/lib/Transforms/InsertMergeBlocks.cpp
@@ -70,8 +70,8 @@ static FailureOr<Block *> buildMergeBlock(Block *b1, Block *b2, Block *oldSucc,
   SmallVector<Location> argLocs(blockArgTypes.size(), rewriter.getUnknownLoc());
 
   Block *res = rewriter.createBlock(oldSucc, blockArgTypes, argLocs);
-  rewriter.create<cf::BranchOp>(rewriter.getUnknownLoc(), oldSucc,
-                                res->getArguments());
+  cf::BranchOp::create(rewriter, rewriter.getUnknownLoc(), oldSucc,
+                       res->getArguments());
 
   if (failed(changeBranchTarget(b1, oldSucc, res, rewriter)))
     return failure();

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -86,10 +86,10 @@ public:
     size_t outWidth = op.getOut().getType().getIntOrFloatBitWidth();
     size_t inWidth = adaptor.getIn().getType().getIntOrFloatBitWidth();
 
-    rewriter.replaceOp(op, rewriter.create<comb::ConcatOp>(
-                               loc,
-                               rewriter.create<hw::ConstantOp>(
-                                   loc, APInt(outWidth - inWidth, 0)),
+    rewriter.replaceOp(op, comb::ConcatOp::create(
+                               rewriter, loc,
+                               hw::ConstantOp::create(
+                                   rewriter, loc, APInt(outWidth - inWidth, 0)),
                                adaptor.getIn()));
     return success();
   }


### PR DESCRIPTION
Updated post https://github.com/llvm/llvm-project/pull/147168. Basically did

set(CMAKE_CXX_CLANG_TIDY local/clang-tidy -checks=-*,llvm-use-new-mlir-op-builder -fix)

and then fixed O(10) cases where temporary OpBuilders were used as create requires it passed in by reference now.