### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Switched MLIR OpBuilder create style.
+7f1c3399e46227cb20060b6c702990a84c8b87c7


### PR DESCRIPTION
Enables flagging skipping over more mechanical refactoring.

https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view