### PR TITLE
[FIRRTL] Type check in Cat operatnds in FIR parser

### DIFF
--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1831,7 +1831,9 @@ FIRRTL version 6.0.0
 circuit CatSign:
   public module CatExp:
     ; expected-error @below {{all operands must have same signedness}}
-    node n = cat(UInt<1>(0), SInt<1>(0))
+    node n = cat(UInt<1>(0),
+    ; expected-note @below {{operand with different signedness is here}}
+                 SInt<1>(0))
 
 // -----
 FIRRTL version 6.0.0
@@ -1839,4 +1841,6 @@ circuit CatSign:
   public module CatExp:
     input a: UInt<1>[1]
     ; expected-error @below {{all operands must be Int type}}
-    node n = cat(UInt<1>(0), a)
+    node n = cat(UInt<1>(0),
+    ; expected-note @below {{non-integer operand is here}}
+                 a)

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1825,3 +1825,18 @@ circuit ExtModuleKnownLayerSpecMissing2ndLayerName:
   layer A, bind:
   ; expected-error @below {{expected layer name}}
   extmodule ExtModuleKnownLayerSpecMissing2ndLayerName knownlayer A,:
+
+// -----
+FIRRTL version 6.0.0
+circuit CatSign:
+  public module CatExp:
+    ; expected-error @below {{all operands must have same signedness}}
+    node n = cat(UInt<1>(0), SInt<1>(0))
+
+// -----
+FIRRTL version 6.0.0
+circuit CatSign:
+  public module CatExp:
+    input a: UInt<1>[1]
+    ; expected-error @below {{all operands must be Int type}}
+    node n = cat(UInt<1>(0), a)


### PR DESCRIPTION
Parser crashes when cat is constructed with invalid type operands.