### PR TITLE
[FIRRTL] Add layer colour verifiers to force and release ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -369,6 +369,7 @@ def RefForceOp : FIRRTLOp<"ref.force",[ForceRefTypeConstraint<"dest", "src">]> {
   let assemblyFormat =
     "$clock `,` $predicate `,` $dest `,` $src attr-dict `:` type($clock) `,` type($predicate) `,` qualified(type($dest)) `,` qualified(type($src))";
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
 }
 def RefForceInitialOp : FIRRTLOp<"ref.force_initial",[ForceRefTypeConstraint<"dest", "src">]> {
   let summary = "FIRRTL force_initial statement";
@@ -377,6 +378,7 @@ def RefForceInitialOp : FIRRTLOp<"ref.force_initial",[ForceRefTypeConstraint<"de
   let assemblyFormat =
     "$predicate `,` $dest `,` $src attr-dict `:` type($predicate) `,` qualified(type($dest)) `,` qualified(type($src))";
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
 }
 def RefReleaseOp : FIRRTLOp<"ref.release"> {
   let summary = "FIRRTL release statement";
@@ -385,6 +387,7 @@ def RefReleaseOp : FIRRTLOp<"ref.release"> {
   let assemblyFormat =
     "$clock `,` $predicate `,` $dest attr-dict `:` type($clock) `,` type($predicate) `,` qualified(type($dest))";
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
 }
 def RefReleaseInitialOp : FIRRTLOp<"ref.release_initial"> {
   let summary = "FIRRTL release_initial statement";
@@ -392,6 +395,7 @@ def RefReleaseInitialOp : FIRRTLOp<"ref.release_initial"> {
   let arguments = (ins UInt1Type:$predicate, RWProbe:$dest);
   let assemblyFormat = "$predicate `,` $dest attr-dict `:` type($predicate) `,` qualified(type($dest))";
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6346,6 +6346,67 @@ LogicalResult RWProbeOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
   return checkFinalType(symOp.getTargetResult().getType(), symOp.getLoc());
 }
 
+LogicalResult RefForceOp::verify() {
+  auto ambientLayers = getAmbientLayersAt(getOperation());
+  auto destLayers = getLayersFor(getDest());
+  SmallVector<SymbolRefAttr> missingLayers;
+  if (!isLayerSetCompatibleWith(destLayers, ambientLayers, missingLayers)) {
+    auto diag =
+        emitOpError("ambient layers are insufficient to force reference");
+    auto &note = diag.attachNote();
+    note << "missing layer requirements: ";
+    interleaveComma(missingLayers, note);
+    return failure();
+  }
+  return success();
+}
+
+LogicalResult RefForceInitialOp::verify() {
+  auto ambientLayers = getAmbientLayersAt(getOperation());
+  auto destLayers = getLayersFor(getDest());
+  SmallVector<SymbolRefAttr> missingLayers;
+  // Every layer in the target must be present in the ambient layers.
+  if (!isLayerSetCompatibleWith(destLayers, ambientLayers, missingLayers)) {
+    auto diag =
+        emitOpError("ambient layers are insufficient to force reference");
+    auto &note = diag.attachNote();
+    note << "missing layer requirements: ";
+    interleaveComma(missingLayers, note);
+    return failure();
+  }
+  return success();
+}
+
+LogicalResult RefReleaseOp::verify() {
+  auto ambientLayers = getAmbientLayersAt(getOperation());
+  auto destLayers = getLayersFor(getDest());
+  SmallVector<SymbolRefAttr> missingLayers;
+  if (!isLayerSetCompatibleWith(destLayers, ambientLayers, missingLayers)) {
+    auto diag =
+        emitOpError("ambient layers are insufficient to release reference");
+    auto &note = diag.attachNote();
+    note << "missing layer requirements: ";
+    interleaveComma(missingLayers, note);
+    return failure();
+  }
+  return success();
+}
+
+LogicalResult RefReleaseInitialOp::verify() {
+  auto ambientLayers = getAmbientLayersAt(getOperation());
+  auto destLayers = getLayersFor(getDest());
+  SmallVector<SymbolRefAttr> missingLayers;
+  if (!isLayerSetCompatibleWith(destLayers, ambientLayers, missingLayers)) {
+    auto diag =
+        emitOpError("ambient layers are insufficient to release reference");
+    auto &note = diag.attachNote();
+    note << "missing layer requirements: ";
+    interleaveComma(missingLayers, note);
+    return failure();
+  }
+  return success();
+}
+
 LogicalResult XMRRefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto *target = symbolTable.lookupNearestSymbolFrom(*this, getRefAttr());
   if (!target)

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6555,7 +6555,7 @@ LayerBlockOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
-// Format Sring operations
+// Format String operations
 //===----------------------------------------------------------------------===//
 
 void TimeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -560,16 +560,12 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
       return WalkResult::interrupt();
 
     // Strip layer requirements from any op that might represent a probe.
-    if (auto wire = dyn_cast<WireOp>(op)) {
-      removeLayersFromValue(wire.getResult());
-      return WalkResult::advance();
-    }
-    if (auto instance = dyn_cast<InstanceOp>(op)) {
+    for (auto result : op->getResults())
+      removeLayersFromValue(result);
+
+    // If the op is an instance, clear the enablelayers attribute.
+    if (auto instance = dyn_cast<InstanceOp>(op))
       instance.setLayers({});
-      for (auto result : instance.getResults())
-        removeLayersFromValue(result);
-      return WalkResult::advance();
-    }
 
     auto layerBlock = dyn_cast<LayerBlockOp>(op);
     if (!layerBlock)

--- a/test/Dialect/FIRRTL/layers-errors.mlir
+++ b/test/Dialect/FIRRTL/layers-errors.mlir
@@ -182,7 +182,7 @@ firrtl.circuit "Top" {
       %q = firrtl.ref.cast %wp : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint<1>, @A>
       firrtl.ref.define %p, %q : !firrtl.rwprobe<uint<1>, @A>
     }
-    // expected-error @below {{op ambient layers are insufficient to force reference}}
+    // expected-error @below {{has insufficient ambient layers to force its reference}}
     // expected-note @below {{missing layer requirements: @A}}
     firrtl.ref.force %c, %e, %p, %v : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>, @A>, !firrtl.uint<1>
   }
@@ -200,7 +200,7 @@ firrtl.circuit "Top" {
       %q = firrtl.ref.cast %wp : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint<1>, @A>
       firrtl.ref.define %p, %q : !firrtl.rwprobe<uint<1>, @A>
     }
-    // expected-error @below {{op ambient layers are insufficient to release reference}}
+    // expected-error @below {{has insufficient ambient layers to release its reference}}
     // expected-note @below {{missing layer requirements: @A}}
     firrtl.ref.release %c, %e, %p : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>, @A>
   }
@@ -217,7 +217,7 @@ firrtl.circuit "Top" {
       %q = firrtl.ref.cast %wp : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint<1>, @A>
       firrtl.ref.define %p, %q : !firrtl.rwprobe<uint<1>, @A>
     }
-    // expected-error @below {{op ambient layers are insufficient to force reference}}
+    // expected-error @below {{has insufficient ambient layers to force its reference}}
     // expected-note @below {{missing layer requirements: @A}}
     firrtl.ref.force_initial %e, %p, %v : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>, @A>, !firrtl.uint<1>
   }
@@ -235,7 +235,7 @@ firrtl.circuit "Top" {
       %q = firrtl.ref.cast %wp : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint<1>, @A>
       firrtl.ref.define %p, %q : !firrtl.rwprobe<uint<1>, @A>
     }
-    // expected-error @below {{op ambient layers are insufficient to release reference}}
+    // expected-error @below {{has insufficient ambient layers to release its reference}}
     // expected-note @below {{missing layer requirements: @A}}
     firrtl.ref.release_initial %e, %p : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>, @A>
   }

--- a/test/Dialect/FIRRTL/layers-errors.mlir
+++ b/test/Dialect/FIRRTL/layers-errors.mlir
@@ -172,38 +172,6 @@ firrtl.circuit "Top" {
 
 // -----
 
-// XMRRefOp's result type must have an appropriate color.
-firrtl.circuit "Top" {
-  firrtl.layer @A bind {}
-  hw.hierpath @xmr [@Top::@wire]
-  firrtl.module @Top(out %o : !firrtl.probe<uint<1>>) {
-    firrtl.layerblock @A {
-      %wire = firrtl.wire sym @wire : !firrtl.uint<1>
-    }
-    %0 = firrtl.xmr.ref @xmr : !firrtl.probe<uint<1>>
-  }
-}
-
-// -----
-
-// Driving an outer property from inside a layerblock is not allowed.
-firrtl.circuit "Top" {
-  firrtl.layer @A bind {}
-  firrtl.extmodule @WithInputProp(in i : !firrtl.string) attributes {knownLayers=[@A], layers=[@A]}
-  firrtl.module @Top(out %o : !firrtl.probe<uint<1>>) {
-    // expected-note @below {{operand is defined here}}
-    %foo_in = firrtl.instance foo @WithInputProp(in i : !firrtl.string)
-    // expected-error @below {{'firrtl.layerblock' op captures a property operand}}
-    firrtl.layerblock @A {
-      %str = firrtl.string "whatever"
-       // expected-note @below {{operand is used here}}
-      firrtl.propassign %foo_in, %str : !firrtl.string
-    }
-  }
-}
-
-// -----
-
 // Forcing a colored probe is not allowed (in an uncolored context).
 firrtl.circuit "Top" {
   firrtl.layer @A bind {}

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -311,7 +311,7 @@ firrtl.circuit "Test" {
   // XMR Ref ops used by force_initial are cloned.
   //
   // CHECK:      firrtl.module private @XmrRef_A()
-  // CHECK-NEXT:   %0 = firrtl.xmr.ref @XmrRef_path : !firrtl.rwprobe<uint<1>, @A>
+  // CHECK-NEXT:   %0 = firrtl.xmr.ref @XmrRef_path : !firrtl.rwprobe<uint<1>>
   // CHECK-NEXT:   %a = firrtl.wire
   // CHECK-NEXT:   %c1_ui1 = firrtl.constant 1
   // CHECK-NEXT:   firrtl.ref.force_initial %c1_ui1, %0, %c1_ui1


### PR DESCRIPTION
This PR adds layer verifiers to the probe force and release ops. During this work I notice that lower-layers does not remove colours from all ops (caught by the new verifiers), so I have fixed that here as well.