### PR TITLE
[ImportVerilog] Insert type conversion for variable initializer

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -187,7 +187,7 @@ struct StmtVisitor {
 
     Value initial;
     if (const auto *init = var.getInitializer()) {
-      initial = context.convertRvalueExpression(*init);
+      initial = context.convertRvalueExpression(*init, type);
       if (!initial)
         return failure();
     }


### PR DESCRIPTION
Without type conversion the following code can't be lowered into `moore` dialect:
```
module example_with_automatic (
    input      [63:0] ex_rs_1,
    output reg [255:0] GEN_22_out
);
  always_comb begin
    automatic logic [3:0][63:0] _GEN_22 = {
      ex_rs_1,
      {2{ex_rs_1[31:0]}},
      {4{ex_rs_1[15:0]}},
      {8{ex_rs_1[7:0]}}
    };
    GEN_22_out = _GEN_22;
  end
endmodule
```
due to:
```
test.sv:6:33: error: 'moore.variable' op failed to verify that initial value and variable types match
    automatic logic [3:0][63:0] _GEN_22 = {
                                ^
test.sv:6:33: note: see current operation: %17 = "moore.variable"(%16) <{name = "_GEN_22"}> : (!moore.l256) -> !moore.ref<array<4 x l64>>
```