### PR TITLE
[ESI][Runtime] Fixing MMIO to account for relative paths

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
@@ -49,7 +49,8 @@ class AppIDPath : public std::vector<AppID> {
 public:
   using std::vector<AppID>::vector;
 
-  AppIDPath operator+(const AppIDPath &b);
+  AppIDPath operator+(const AppIDPath &b) const;
+  AppIDPath parent() const;
   std::string toStr() const;
 };
 bool operator<(const AppIDPath &a, const AppIDPath &b);

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
@@ -124,7 +124,8 @@ public:
     uint32_t size;
   };
 
-  MMIO(AcceleratorConnection &, const HWClientDetails &clients);
+  MMIO(AcceleratorConnection &, const AppIDPath &idPath,
+       const HWClientDetails &clients);
   virtual ~MMIO() = default;
 
   /// Read a 64-bit value from the global MMIO space.

--- a/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
@@ -724,9 +724,16 @@ std::ostream &operator<<(std::ostream &os, const ModuleInfo &m) {
 }
 
 namespace esi {
-AppIDPath AppIDPath::operator+(const AppIDPath &b) {
+AppIDPath AppIDPath::operator+(const AppIDPath &b) const {
   AppIDPath ret = *this;
   ret.insert(ret.end(), b.begin(), b.end());
+  return ret;
+}
+
+AppIDPath AppIDPath::parent() const {
+  AppIDPath ret = *this;
+  if (!ret.empty())
+    ret.pop_back();
   return ret;
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -351,9 +351,9 @@ bool StubContainer::getChannelDesc(const std::string &channelName,
 namespace {
 class CosimMMIO : public MMIO {
 public:
-  CosimMMIO(CosimAccelerator &conn, Context &ctxt, StubContainer *rpcClient,
-            const HWClientDetails &clients)
-      : MMIO(conn, clients) {
+  CosimMMIO(CosimAccelerator &conn, Context &ctxt, const AppIDPath &idPath,
+            StubContainer *rpcClient, const HWClientDetails &clients)
+      : MMIO(conn, idPath, clients) {
     // We have to locate the channels ourselves since this service might be used
     // to retrieve the manifest.
     ChannelDesc cmdArg, cmdResp;
@@ -720,7 +720,7 @@ Service *CosimAccelerator::createService(Service::Type svcType,
                                          const ServiceImplDetails &details,
                                          const HWClientDetails &clients) {
   if (svcType == typeid(services::MMIO)) {
-    return new CosimMMIO(*this, getCtxt(), rpcClient, clients);
+    return new CosimMMIO(*this, getCtxt(), idPath, rpcClient, clients);
   } else if (svcType == typeid(services::HostMem)) {
     return new CosimHostMem(*this, getCtxt(), rpcClient);
   } else if (svcType == typeid(SysInfo)) {

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -257,8 +257,9 @@ void TraceAccelerator::createEngine(const std::string &dmaEngineName,
 
 class TraceMMIO : public MMIO {
 public:
-  TraceMMIO(TraceAccelerator &conn, const HWClientDetails &clients)
-      : MMIO(conn, clients), impl(conn.getImpl()) {}
+  TraceMMIO(TraceAccelerator &conn, const AppIDPath &idPath,
+            const HWClientDetails &clients)
+      : MMIO(conn, idPath, clients), impl(conn.getImpl()) {}
 
   virtual uint64_t read(uint32_t addr) const override {
     uint64_t data = rand();
@@ -339,7 +340,7 @@ Service *TraceAccelerator::createService(Service::Type svcType,
   if (svcType == typeid(SysInfo))
     return new TraceSysInfo(*this, getImpl().manifestJson);
   if (svcType == typeid(MMIO))
-    return new TraceMMIO(*this, clients);
+    return new TraceMMIO(*this, idPath, clients);
   if (svcType == typeid(HostMem))
     return new TraceHostMem(*this);
   return nullptr;

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
@@ -107,8 +107,9 @@ class XrtMMIO : public MMIO {
   constexpr static uint32_t IndirectMMIOReg = 0x20;
 
 public:
-  XrtMMIO(XrtAccelerator &conn, ::xrt::ip &ip, const HWClientDetails &clients)
-      : MMIO(conn, clients), ip(ip) {}
+  XrtMMIO(XrtAccelerator &conn, ::xrt::ip &ip, const AppIDPath &idPath,
+          const HWClientDetails &clients)
+      : MMIO(conn, idPath, clients), ip(ip) {}
 
   uint64_t read(uint32_t addr) const override {
     std::lock_guard<std::mutex> lock(m);
@@ -207,7 +208,7 @@ Service *XrtAccelerator::createService(Service::Type svcType, AppIDPath id,
                                        const ServiceImplDetails &details,
                                        const HWClientDetails &clients) {
   if (svcType == typeid(MMIO))
-    return new XrtMMIO(*this, impl->ip, clients);
+    return new XrtMMIO(*this, impl->ip, id, clients);
   else if (svcType == typeid(HostMem))
     return new XrtHostMem(*this, impl->device, impl->memoryGroup);
   else if (svcType == typeid(SysInfo))


### PR DESCRIPTION
Locating client ports was broken in the case of the MMIO service being not at the top level.