### PR TITLE
[ESI][Runtime] Windows wheel: use flat directory structure

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -104,12 +104,6 @@ if (WHEEL_BUILD)
   message(STATUS "Setting up for a Python wheel build.")
 endif()
 
-if(WIN32)
-  set(LIB_DIR "bin")
-else()
-  set(LIB_DIR "lib")
-endif()
-
 ##===----------------------------------------------------------------------===//
 ## Overall target to build everything.
 ##===----------------------------------------------------------------------===//
@@ -202,8 +196,10 @@ if(NOT MSVC)
 endif()
 add_dependencies(ESIRuntime ESICppRuntime)
 if (WIN32)
+  set(ESIRT_INSTALL_BINDIR ".")
   set(ESIRT_INSTALL_LIBDIR ".")
 else()
+  set(ESIRT_INSTALL_BINDIR "bin")
   set(ESIRT_INSTALL_LIBDIR "lib")
 endif()
 
@@ -251,7 +247,7 @@ target_link_libraries(esiquery PRIVATE
 )
 add_dependencies(ESIRuntime esiquery)
 install(TARGETS esiquery
-  DESTINATION bin
+  DESTINATION ${ESIRT_INSTALL_BINDIR}
   COMPONENT ESIRuntime
 )
 

--- a/lib/Dialect/ESI/runtime/cosim_dpi_server/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/cosim_dpi_server/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(MtiPli PROPERTIES CXX_VISIBILITY_PRESET "default")
 # the simulator, but without it we get runtime link errors. TODO: figure out how
 # to do this properly such that we avoid packaging a dummy library.
 install(TARGETS MtiPli
-  DESTINATION lib
+  DESTINATION ${ESIRT_INSTALL_LIBDIR}
   COMPONENT ESIRuntime
 )
 
@@ -38,7 +38,7 @@ target_link_libraries(EsiCosimDpiServer
 
 add_dependencies(ESIRuntime EsiCosimDpiServer)
 install(TARGETS EsiCosimDpiServer
-  DESTINATION lib
+  DESTINATION ${ESIRT_INSTALL_LIBDIR}
   COMPONENT ESIRuntime
 )
 
@@ -73,7 +73,7 @@ endforeach()
 # ESI simple cosim runner.
 install(FILES
   esi-cosim.py
-  DESTINATION bin
+  DESTINATION ${ESIRT_INSTALL_BINDIR}
   PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
               GROUP_EXECUTE GROUP_READ
               WORLD_EXECUTE WORLD_READ

--- a/lib/Dialect/ESI/runtime/python/esiaccel/utils.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/utils.py
@@ -4,6 +4,7 @@
 
 from . import codegen
 
+import platform
 from pathlib import Path
 import subprocess
 import sys
@@ -13,16 +14,23 @@ _thisdir = Path(__file__).absolute().resolve().parent
 
 def run_esiquery():
   """Run the esiquery executable with the same arguments as this script."""
-  esiquery = _thisdir / "bin" / "esiquery"
+  if platform.system() == "Windows":
+    esiquery = _thisdir / "esiquery.exe"
+  else:
+    esiquery = _thisdir / "bin" / "esiquery"
   return subprocess.call([esiquery] + sys.argv[1:])
 
 
 def run_esi_cosim():
   """Run the esi-cosim.py script with the same arguments as this script."""
   import importlib.util
-  esi_cosim = _thisdir / "bin" / "esi-cosim.py"
+  if platform.system() == "Windows":
+    esi_cosim = _thisdir / "esi-cosim.py"
+  else:
+    esi_cosim = _thisdir / "bin" / "esi-cosim.py"
   spec = importlib.util.spec_from_file_location("esi_cosim", esi_cosim)
   assert spec is not None
+  assert spec.loader is not None
   cosim_import = importlib.util.module_from_spec(spec)
   spec.loader.exec_module(cosim_import)
   return cosim_import.__main__(sys.argv)


### PR DESCRIPTION
Windows has no notion of rpath. It just looks in the same directory as the executable/dll then the system search path. With the directory structure as is currently was, `esiquery` was unable to load ESICppRuntime.dll. It's not a great solution, but put everything in the same directory on Windows.