### PR TITLE
[LLHD] Propogate signal definitions only to dominated blocks in Mem2Reg

### DIFF
--- a/test/Dialect/LLHD/Transforms/mem2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/mem2reg.mlir
@@ -1014,16 +1014,26 @@ hw.module @DominanceTest1() {
   %false = hw.constant false
   %3 = llhd.constant_time <0ns, 0d, 1e>
   %clock_0 = llhd.sig name "clock" %false : i1
+  // CHECK: llhd.process
   llhd.process {
+    // CHECK-NEXT: [[TMP0:%.+]] = llhd.prb %clock
+    // CHECK-NEXT: cf.br ^bb1([[TMP0]] : i1)
     cf.br ^bb1
   ^bb1:
+    // CHECK-NEXT: ^bb1([[BBARG0:%.+]]: i1)
+    // CHECK-NEXT: llhd.wait ([[BBARG0]] : i1), ^bb2
     %5 = llhd.prb %clock_0 : !hw.inout<i1>
     llhd.wait (%5 : i1), ^bb3
   ^bb3:
-    %c2_i4 = hw.constant 0 : i4
-    %ready_T = llhd.sig %c2_i4 : i4
-    llhd.drv %ready_T, %c2_i4 after %3 : !hw.inout<i4>
-    %160 = llhd.prb %ready_T : !hw.inout<i4>
+    // CHECK-NEXT: ^bb2:
+    // CHECK-NEXT: [[TMP1:%.+]] = llhd.prb %clock
+    // CHECK: %ready_T = llhd.sig
+    // CHECK: llhd.drv %ready_T
+    // CHECK: cf.br ^bb1([[TMP1]] : i1)
+    %c0_i4 = hw.constant 0 : i4
+    %ready_T = llhd.sig %c0_i4 : i4
+    llhd.drv %ready_T, %c0_i4 after %3 : !hw.inout<i4>
+    %6 = llhd.prb %ready_T : !hw.inout<i4>
     cf.br ^bb1
   }
   hw.output
@@ -1033,15 +1043,24 @@ hw.module @DominanceTest1() {
 hw.module @DominanceTest2() {
   %false = hw.constant false
   %b = llhd.sig %false : i1
+  // CHECK: llhd.combinational
   llhd.combinational {
     cf.br ^bb3
+  // CHECK: ^bb1:
   ^bb1:
+    // CHECK-NEXT: [[PRB1:%.+]] = llhd.prb %b
+    // CHECK-NEXT: [[SIG1:%.+]] = llhd.sig %false
+    // CHECK-NEXT: cf.br ^bb2
     %0 = llhd.prb %b : !hw.inout<i1>
     %1 = llhd.constant_time <0ns, 0d, 1e>
     %g = llhd.sig %false : i1
     llhd.drv %g, %0 after %1 : !hw.inout<i1>
     cf.br ^bb2
   ^bb2:
+    // CHECK-NEXT: ^bb2
+    // CHECK-NEXT: [[TIME1:%.+]] = llhd.constant_time
+    // CHECK-NEXT: llhd.drv [[SIG1]], [[PRB1]]
+    // CHECK-NEXT: cf.br ^bb3
     cf.br ^bb3
   ^bb3:
     llhd.yield

--- a/test/Dialect/LLHD/Transforms/mem2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/mem2reg.mlir
@@ -1015,9 +1015,16 @@ hw.module @RelocatedSignal() {
   %c0_i4 = hw.constant 0 : i4
   %3 = llhd.constant_time <0ns, 0d, 1e>
   %clock_0 = llhd.sig name "clock" %false : i1
+  // CHECK: [[CLOCK:%clock]] = llhd.sig %false : i1
+  // CHECK-NEXT: llhd.process
   llhd.process {
+    // CHECK-NEXT: [[CON:%.+]] = hw.constant 0 : i4
+    // CHECK-NEXT: [[READY:%ready_T]] = llhd.sig [[CON]] : i4
     cf.br ^bb1
   ^bb1:
+    // CHECK: [[TIME:%.+]] = llhd.constant_time
+    // CHECK-NEXT: llhd.drv [[READY]], {{%.+}} after [[TIME]]
+    // CHECK-NEXT: llhd.wait
     %5 = llhd.prb %clock_0 : !hw.inout<i1>
     llhd.wait (%5 : i1), ^bb2
   ^bb2:


### PR DESCRIPTION
Currently, after Mem2Reg inserts drives and probes, it does not check whether `llhd.sig` (or the slot) still dominates all of its users. For cases where the operand is `hw.constant`, it should be safe to move the `llhd.sig` into region's entry block to ensure dominance, if it doesn't already. What do you think? 

Error, without the patch:
```
<stdin>:29:16: error: operand #0 does not dominate this use
    %ready_T = llhd.sig %c2_i4 : i4
               ^
<stdin>:29:16: note: see current operation: "llhd.drv"(%18, %9, %11, %10) : (!hw.inout<i4>, i4, !llhd.time, i1) -> ()
<stdin>:29:16: note: operand defined here (op in the same region)
```