### PR TITLE
[ImportVerilog] Add time literals

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -492,6 +492,13 @@ def ConstantOp : MooreOp<"constant", [Pure, ConstantLike]> {
   ];
 }
 
+def ConstantTimeOp : MooreOp<"constant_time", [Pure]> {
+  let summary = "A constant time value in femtoseconds";
+  let arguments = (ins UI64Attr:$value);
+  let results = (outs TimeType:$result);
+  let assemblyFormat = "$value `fs` attr-dict";
+}
+
 def StringConstantOp : MooreOp<"string_constant", [Pure]> {
   let summary = "Produce a constant string value";
   let description = [{

--- a/include/circt/Dialect/Moore/MooreTypes.h
+++ b/include/circt/Dialect/Moore/MooreTypes.h
@@ -36,6 +36,7 @@ class QueueType;
 class RealType;
 class StringType;
 class StructType;
+class TimeType;
 class UnionType;
 class UnpackedType;
 class UnpackedArrayType;
@@ -134,7 +135,7 @@ class PackedType : public UnpackedType {
 public:
   static bool classof(Type type) {
     return llvm::isa<VoidType, IntType, ArrayType, OpenArrayType, StructType,
-                     UnionType>(type);
+                     UnionType, TimeType>(type);
   }
 
   /// Get the value domain of this type.

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -54,6 +54,32 @@ def EventType : MooreTypeDef<"Event", [], "moore::UnpackedType"> {
 
 
 //===----------------------------------------------------------------------===//
+// TimeType
+//===----------------------------------------------------------------------===//
+
+def TimeType : MooreTypeDef<"Time", [], "moore::PackedType"> {
+  let mnemonic = "time";
+  let summary = "the SystemVerilog `time` and `realtime` type";
+  let description = [{
+    The `!moore.time` type represents a time value. Internally, the value is
+    represented as femtoseconds in `i64`.
+
+    Time values are a problematic part of the SystemVerilog language, since they
+    are multiplied by a scaling factor given by the current scope's `timeunit`
+    and then mapped to an 64 bit four-valued integer for `time`, or a real for
+    `realtime`. This means that a time value flowing from one module with one
+    timeunit to another module with a different timeunit will read as two
+    distinct delay values in the two modules.
+
+    To work around these issues, the Moore dialect maps all time values to
+    femtoseconds and represents them as an integer value. This allows us to have
+    time values exchanged between modules correctly, while locally casting from
+    and to `integer` and `real` with the correct local scaling factor.
+  }];
+}
+
+
+//===----------------------------------------------------------------------===//
 // IntType
 //===----------------------------------------------------------------------===//
 
@@ -75,7 +101,7 @@ def IntType : MooreTypeDef<"Int", [], "moore::PackedType"> {
     | `int`      | `!moore.i32`  |
     | `integer`  | `!moore.l32`  |
     | `longint`  | `!moore.i64`  |
-    | `time`     | `!moore.l64`  |
+    | `time`     | `!moore.time` |
   }];
   let parameters = (ins "unsigned":$width, "Domain":$domain);
 
@@ -112,7 +138,7 @@ def RealType : MooreTypeDef<"Real", [], "moore::UnpackedType"> {
     |-------------|---------------|
     | `shortreal` | `!moore.real` |
     | `real`      | `!moore.real` |
-    | `realtime`  | `!moore.real` |
+    | `realtime`  | `!moore.time` |
   }];
 }
 

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -248,6 +248,9 @@ struct Context {
   /// example to populate the list of observed signals in an implicit event
   /// control `@*`.
   std::function<void(moore::ReadOp)> rvalueReadCallback;
+
+  /// The time scale currently in effect.
+  slang::TimeScale timeScale;
 };
 
 } // namespace ImportVerilog

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -36,10 +36,14 @@ struct TypeVisitor {
   }
 
   Type visit(const slang::ast::FloatingType &type) {
+    if (type.floatKind == slang::ast::FloatingType::Kind::RealTime)
+      return moore::TimeType::get(context.getContext());
     return moore::RealType::get(context.getContext());
   }
 
   Type visit(const slang::ast::PredefinedIntegerType &type) {
+    if (type.integerKind == slang::ast::PredefinedIntegerType::Kind::Time)
+      return moore::TimeType::get(context.getContext());
     return getSimpleBitVectorType(type);
   }
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3028,3 +3028,33 @@ function void rangeSelectRValue(
   // CHECK: moore.dyn_extract %arg1 from [[TMP2]] : i8, i6 -> i5
   z = b[i-:5];  // b[i-5+1:i] = b[i-4:i] = bits[9-(i-4):9-i]; offset = 9-i
 endfunction
+
+// CHECK-LABEL: @TimeLiterals
+module TimeLiterals;
+  timeunit 1ns / 10ps; // round to 10ps
+  // CHECK: moore.constant_time 12000000 fs
+  time a0 = 12ns;
+  // CHECK: moore.constant_time 2350000 fs
+  time a1 = 2.345ns;
+  // CHECK: moore.constant_time 350000 fs
+  time a2 = 345ps;
+  // CHECK: moore.constant_time 45000000 fs
+  realtime b0 = 45ns;
+  // CHECK: moore.constant_time 5680000 fs
+  realtime b1 = 5.678ns;
+  // CHECK: moore.constant_time 680000 fs
+  realtime b2 = 678ps;
+
+  // CHECK-LABEL: moore.module private @InheritTimeunit
+  module InheritTimeunit;
+    // CHECK: moore.constant_time 790000 fs
+    time c0 = 789ps;
+  endmodule
+
+  // CHECK-LABEL: moore.module private @OverrideTimeunit
+  module OverrideTimeunit;
+    timeunit 1ps / 10fs;
+    // CHECK: moore.constant_time 89120 fs
+    time d0 = 89.1234ps;
+  endmodule
+endmodule

--- a/test/Conversion/ImportVerilog/default-timeunit.sv
+++ b/test/Conversion/ImportVerilog/default-timeunit.sv
@@ -1,0 +1,23 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// CHECK-LABEL: @DefaultTimeUnit1ns1ns
+module DefaultTimeUnit1ns1ns;
+  // CHECK: moore.constant_time 12000000 fs
+  time a0 = 12ns;
+  // CHECK: moore.constant_time 2000000 fs
+  time a1 = 2.345ns;
+  // CHECK: moore.constant_time 3000000 fs
+  time a2 = 3456ps;
+  // CHECK: moore.constant_time 45000000 fs
+  realtime b0 = 45ns;
+  // CHECK: moore.constant_time 6000000 fs
+  realtime b1 = 5.678ns;
+  // CHECK: moore.constant_time 7000000 fs
+  realtime b2 = 6789ps;
+endmodule
+

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -147,3 +147,9 @@ function Foo;
   // expected-error @below {{string format specifier with width not supported}}
   $write("%42s", "foo");
 endfunction
+
+// -----
+function time Foo;
+  // expected-error @below {{time value is larger than 18446744073709549568 fs}}
+  return 100000s;
+endfunction

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -27,7 +27,7 @@ module IntAtoms;
   // CHECK-NEXT: %d5 = moore.variable : <i64>
   // CHECK-NEXT: %d6 = moore.variable : <l32>
   // CHECK-NEXT: %d7 = moore.variable : <i8>
-  // CHECK-NEXT: %d8 = moore.variable : <l64>
+  // CHECK-NEXT: %d8 = moore.variable : <time>
   logic d0;
   bit d1;
   reg d2;
@@ -46,7 +46,7 @@ module IntAtoms;
   // CHECK-NEXT: %u5 = moore.variable : <i64>
   // CHECK-NEXT: %u6 = moore.variable : <l32>
   // CHECK-NEXT: %u7 = moore.variable : <i8>
-  // CHECK-NEXT: %u8 = moore.variable : <l64>
+  // CHECK-NEXT: %u8 = moore.variable : <time>
   logic unsigned u0;
   bit unsigned u1;
   reg unsigned u2;
@@ -65,7 +65,7 @@ module IntAtoms;
   // CHECK-NEXT: %s5 = moore.variable : <i64>
   // CHECK-NEXT: %s6 = moore.variable : <l32>
   // CHECK-NEXT: %s7 = moore.variable : <i8>
-  // CHECK-NEXT: %s8 = moore.variable : <l64>
+  // CHECK-NEXT: %s8 = moore.variable : <time>
   logic signed s0;
   bit signed s1;
   reg signed s2;
@@ -116,7 +116,7 @@ endmodule
 module RealType;
   // CHECK-NEXT: %d0 = moore.variable : <real>
   real d0;
-  // CHECK-NEXT: %d1 = moore.variable : <real>
+  // CHECK-NEXT: %d1 = moore.variable : <time>
   realtime d1;
   // CHECK-NEXT: %d2 = moore.variable : <real>
   shortreal d2;

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1181,3 +1181,12 @@ moore.module @blockArgAsObservedValue(in %in0: !moore.i32, in %in1: !moore.i32) 
       moore.return
   }
 }
+
+// CHECK-LABEL: @Time
+// CHECK-SAME: (%arg0: !llhd.time) -> (!llhd.time, !llhd.time)
+func.func @Time(%arg0: !moore.time) -> (!moore.time, !moore.time) {
+  // CHECK-NEXT: [[TMP:%.+]] = llhd.constant_time <1234000fs, 0d, 0e>
+  %0 = moore.constant_time 1234000 fs
+  // CHECK-NEXT: return %arg0, [[TMP]] : !llhd.time, !llhd.time
+  return %arg0, %0 : !moore.time, !moore.time
+}


### PR DESCRIPTION
Add support for time literal expressions such as `42us` or `1.234ns` to the ImportVerilog conversion.

Time values in SystemVerilog are pretty messy and easy to misuse because they are essentially just unit-less integers or doubles. To make the CIRCT's Verilog frontend a bit more robust, introduce a new `!moore.time` type that represents a time value. The `time` and `realtime` types in SV both map to this IR type.

All time values are converted and rounded to femtoseconds and then stored as an `i64`. A new `moore.constant_time` can be used to materialize a constant time value. This means that time values in the IR are represented with an unambiguous unit.

In contrast, SystemVerilog eagerly converts time values to the underlying integer or double by scaling the value by the `timeunit` specified by the user. This is problematic when time values are passed between modules that have different `timeunit` specifications. Since time values are packed and thus equivalent to an integer, a time value will flow across this module boundary _without_ having its units rescaled. This can lead to a value like `10ns` read as a `100ps` in another module due to a time unit mismatch.

Since the IR does not apply the time unit immediately when a time value is created, future cast operations from and to integers and doubles will have to apply this time unit scaling factor instead. As a result, time values become harder to abuse, and if the user never casts a time to an integer or double, all arithmetic on time values can be done directly on the `time` type without ever interacting with the local `timeunit` specification. We can later add a faithful-but-unsafe mode where we eagerly map time values to integers and doubles.