### PR TITLE
[ImportVerilog] slang 8.0 -> 8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,7 +564,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG v8.0
+      GIT_TAG v8.1
       GIT_SHALLOW ON)
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
 
@@ -608,7 +608,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang)
     install(TARGETS slang_slang EXPORT CIRCTTargets)
   else()
-    find_package(slang 8.0 REQUIRED)
+    find_package(slang 8.1 REQUIRED)
   endif()
 endif()
 


### PR DESCRIPTION
Pull in latest v8 release for bug fixes.

https://github.com/MikePopoloski/slang/releases/tag/v8.1