### PR TITLE
[FIRRT] Domains: Types Approach

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -597,4 +597,24 @@ def SimulationOp : FIRRTLOp<"simulation", [
   }];
 }
 
+def DomainOp : FIRRTLOp<"domain", [
+  DeclareOpInterfaceMethods<Symbol>,
+  HasParent<"firrtl::CircuitOp">,
+  NoTerminator,
+  SingleBlock
+]> {
+  let summary = "Define a domain type";
+  let description = [{
+    A `firrtl.domain` operation defines a type of domain that exists in this
+    circuit.  E.g., this can be used to delcare a `ClockDomain` type when
+    modeling clocks in FIRRTL Dialect.
+  }];
+  let arguments = (ins SymbolNameAttr:$sym_name);
+  let results = (outs);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    $sym_name attr-dict-with-keyword $body
+  }];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLSTRUCTURE_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -63,6 +63,7 @@ class BoolType;
 class DoubleType;
 class BaseTypeAliasType;
 class FStringType;
+class DomainType;
 
 /// A collection of bits indicating the recursive properties of a type.
 struct RecursiveTypeProperties {
@@ -186,7 +187,7 @@ public:
   static bool classof(Type type) {
     return llvm::isa<FIRRTLDialect>(type.getDialect()) &&
            !llvm::isa<PropertyType, RefType, LHSType, OpenBundleType,
-                      OpenVectorType, FStringType>(type);
+                      OpenVectorType, FStringType, DomainType>(type);
   }
 
   /// Returns true if this is a non-const "passive" that which is not analog.

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -253,4 +253,14 @@ def PrintfOperandType : FIRRTLDialectType<
     "a printf operand type (a FIRRTL base type or a format string type)",
     "::circt::firrtl::FIRRTLType">;
 
+//===----------------------------------------------------------------------===//
+// Domain Type
+//===----------------------------------------------------------------------===//
+
+def DomainType : FIRRTLDialectTypeHelper<
+  "DomainType",
+  "a domain type">,
+  BuildableType<"::circt::firrtl::DomainType::get($_builder.getContext())">;
+
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -607,4 +607,11 @@ def FStringImpl : FIRRTLImplType<"FString", [], "::circt::firrtl::FIRRTLType" > 
   let typeName = "firrtl.fstring";
 }
 
+def DomainTypeImpl : FIRRTLImplType<"Domain", [], "::circt::firrtl::FIRRTLType"> {
+  let summary = "A domain type";
+  let parameters = (ins "FlatSymbolRefAttr":$name);
+  let genStorageClass = true;
+  let typeName = "firrtl.domain";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -40,10 +40,18 @@ def SIntImpl : FIRRTLImplType<"SInt",
                               [WidthQualifiedTypeTrait],
                               "::circt::firrtl::IntType"> {
   let summary = "A signed integer type, whose width may not be known.";
-  let parameters = (ins "int32_t":$widthOrSentinel, "bool":$isConst);
+  let parameters = (
+    ins "int32_t":$widthOrSentinel,
+        "bool":$isConst,
+        "ArrayRef<FlatSymbolRefAttr>":$domains
+  );
   let storageClass = "WidthTypeStorage";
   let builders = [
-    TypeBuilder<(ins "std::optional<int32_t>":$width, CArg<"bool", "false">:$isConst)>,
+    TypeBuilder<(
+      ins "std::optional<int32_t>":$width,
+          CArg<"bool", "false">:$isConst,
+          CArg<"ArrayRef<FlatSymbolRefAttr>", "{}">:$domains
+    )>,
     TypeBuilder<(ins)>,
   ];
   let genVerifyDecl = true;
@@ -53,6 +61,7 @@ def SIntImpl : FIRRTLImplType<"SInt",
     using WidthQualifiedTypeTrait<SIntType>::hasWidth;
     int32_t getWidthOrSentinel() const;
     SIntType getConstType(bool isConst) const;
+    ArrayRef<FlatSymbolRefAttr> getDomains() const;
   }];
 }
 
@@ -60,10 +69,18 @@ def UIntImpl : FIRRTLImplType<"UInt",
                               [WidthQualifiedTypeTrait],
                               "::circt::firrtl::IntType"> {
   let summary = "An unsigned integer type, whose width may not be known.";
-  let parameters = (ins "int32_t":$widthOrSentinel, "bool":$isConst);
+  let parameters = (
+    ins "int32_t":$widthOrSentinel,
+        "bool":$isConst,
+        "ArrayRef<FlatSymbolRefAttr>":$domains
+  );
   let storageClass = "WidthTypeStorage";
   let builders = [
-    TypeBuilder<(ins "std::optional<int32_t>":$width, CArg<"bool", "false">:$isConst)>,
+    TypeBuilder<(
+      ins "std::optional<int32_t>":$width,
+          CArg<"bool", "false">:$isConst,
+          CArg<"ArrayRef<FlatSymbolRefAttr>", "{}">:$domains
+    )>,
     TypeBuilder<(ins)>,
   ];
   let genVerifyDecl = true;
@@ -73,6 +90,7 @@ def UIntImpl : FIRRTLImplType<"UInt",
     using WidthQualifiedTypeTrait<UIntType>::hasWidth;
     int32_t getWidthOrSentinel() const;
     UIntType getConstType(bool isConst) const;
+    ArrayRef<FlatSymbolRefAttr> getDomains() const;
   }];
 }
 
@@ -124,16 +142,25 @@ def AsyncResetTypeImpl : FIRRTLImplType<"AsyncReset"> {
 def AnalogTypeImpl : FIRRTLImplType<"Analog",
   [WidthQualifiedTypeTrait]> {
   let summary = "Analog signal";
-  let parameters = (ins "int32_t":$widthOrSentinel, "bool":$isConst);
+  let parameters = (
+    ins "int32_t":$widthOrSentinel,
+        "bool":$isConst,
+        "ArrayRef<FlatSymbolRefAttr>":$domains
+  );
   let storageClass = "WidthTypeStorage";
   let typeName = "firrtl.analog";
   let builders = [
-    TypeBuilder<(ins "std::optional<int32_t>":$width, CArg<"bool", "false">:$isConst)>,
+    TypeBuilder<(
+      ins "std::optional<int32_t>":$width,
+          CArg<"bool", "false">:$isConst,
+          CArg<"ArrayRef<FlatSymbolRefAttr>", "{}">:$domains
+    )>,
     TypeBuilder<(ins)>,
   ];
   let extraClassDeclaration = [{
     int32_t getWidthOrSentinel() const;
     AnalogType getConstType(bool isConst) const;
+    ArrayRef<FlatSymbolRefAttr> getDomains() const;
   }];
   let genVerifyDecl = true;
 }

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1367,7 +1367,14 @@ int32_t IntType::getWidthOrSentinel() const {
 struct circt::firrtl::detail::WidthTypeStorage : detail::FIRRTLBaseTypeStorage {
   WidthTypeStorage(int32_t width, bool isConst,
                    ArrayRef<FlatSymbolRefAttr> domains)
-      : FIRRTLBaseTypeStorage(isConst), width(width), domains(domains) {}
+      : FIRRTLBaseTypeStorage(isConst), width(width), domains(domains) {
+    // Domains must be sorted and uniqued.  This provides a canonical
+    // representation of domains that allows for pointer comparison of types.
+    llvm::sort(this->domains, [](FlatSymbolRefAttr lhs, FlatSymbolRefAttr rhs) {
+      return lhs.getValue() < rhs.getValue();
+    });
+    this->domains.erase(llvm::unique(this->domains), this->domains.end());
+  }
   using KeyTy = std::tuple<int32_t, char, ArrayRef<FlatSymbolRefAttr>>;
 
   bool operator==(const KeyTy &key) const { return key == getAsKey(); }

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -199,12 +199,21 @@ firrtl.module @Fprintf(
 // CHECK-LABEL: firrtl.domain @ClockDomain {
 // CHECK-NEXT:  }
 firrtl.domain @ClockDomain {}
+firrtl.domain @ResetDomain {}
 
 // CHECK-LABEL: firrtl.module @Domains(
-// CHECK-SAME:    in %clock_domain: !firrtl.domain<@ClockDomain>
+// CHECK-SAME:    in %clockDomain: !firrtl.domain<@ClockDomain> sym @clockDomainSym
+// CHECK-SAME:    in %resetDomain: !firrtl.domain<@ResetDomain> sym @resetDomainSym
 firrtl.module @Domains(
-  in %clock_domain: !firrtl.domain<@ClockDomain>
+  in %clockDomain: !firrtl.domain<@ClockDomain> sym @clockDomainSym,
+  in %resetDomain: !firrtl.domain<@ResetDomain> sym @resetDomainSym,
+  in %x : !firrtl.uint<1, [@clockDomainSym]>
 ) {
+  // CHECK-NEXT: %noDomain = firrtl.wire : !firrtl.uint<1>
+  %noDomain = firrtl.wire : !firrtl.uint<1, []>
+  // CHECK-NEXT: %oneDomain = firrtl.wire : !firrtl.uint<1, [@clockDomainSym]>
+  %oneDomain = firrtl.wire : !firrtl.uint<1, [@clockDomainSym]>
+  // CHECK-NEXT: %twoDomains = firrtl.wire : !firrtl.uint<1, [@clockDomainSym, @resetDomainSym]>
+  %twoDomains = firrtl.wire : !firrtl.uint<1, [@clockDomainSym, @resetDomainSym]>
 }
-
 }

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -215,5 +215,9 @@ firrtl.module @Domains(
   %oneDomain = firrtl.wire : !firrtl.uint<1, [@clockDomainSym]>
   // CHECK-NEXT: %twoDomains = firrtl.wire : !firrtl.uint<1, [@clockDomainSym, @resetDomainSym]>
   %twoDomains = firrtl.wire : !firrtl.uint<1, [@clockDomainSym, @resetDomainSym]>
+  // CHECK-NEXT: %sortedDomains = firrtl.wire : !firrtl.uint<1, [@clockDomainSym, @resetDomainSym]>
+  %sortedDomains = firrtl.wire : !firrtl.uint<1, [@resetDomainSym, @clockDomainSym]>
+  // CHECK-NEXT: %uniqueDomains = firrtl.wire : !firrtl.uint<1, [@clockDomainSym]>
+  %uniqueDomains = firrtl.wire : !firrtl.uint<1, [@clockDomainSym, @clockDomainSym]>
 }
 }

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -196,4 +196,15 @@ firrtl.module @Fprintf(
   firrtl.fprintf %clock, %a, "test%d.txt"(%a), "%x, %b"(%a, %reset) {name = "foo"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
 }
 
+// CHECK-LABEL: firrtl.domain @ClockDomain {
+// CHECK-NEXT:  }
+firrtl.domain @ClockDomain {}
+
+// CHECK-LABEL: firrtl.module @Domains(
+// CHECK-SAME:    in %clock_domain: !firrtl.domain<@ClockDomain>
+firrtl.module @Domains(
+  in %clock_domain: !firrtl.domain<@ClockDomain>
+) {
+}
+
 }


### PR DESCRIPTION
This is an experimental approach to add domains to FIRRTL.  This approach
sees what it looks like to put domain information into the MLIR type
system.

This gets very funky, very quickly because this is doing many things which
are very against the ethos of MLIR:

  1. Some types have symbol storage.
  2. Some types have inner symbol storage.

(2) is specifically working around the fact that MLIR provides no built-in
way to associate a value to a type.  (There are good reasons for this!)

This will be contrasted with a future approach that does an association of
domain information on a per-operation basis.

This is broken up into the following logical commits:

  - [FIRRTL] Add `firrtl.domain`
  - [FIRRTL] Add firrtl.domain type
  - [FIRRTL] Add domain information to types
  - [FIRRTL] Canonicalize domains on scalar types
