### PR TITLE
[ImportVerilog] Bump slang to version 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,7 +564,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG v8.1
+      GIT_TAG v9.0
       GIT_SHALLOW ON)
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
 
@@ -608,7 +608,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang)
     install(TARGETS slang_slang EXPORT CIRCTTargets)
   else()
-    find_package(slang 8.1 REQUIRED)
+    find_package(slang 9.0 REQUIRED)
   endif()
 endif()
 

--- a/cmake/modules/SlangCompilerOptions.cmake
+++ b/cmake/modules/SlangCompilerOptions.cmake
@@ -2,12 +2,12 @@
 # with Slang must be built accordingly.
 set(CMAKE_CXX_STANDARD 20)
 
-# For ABI compatibility, define the DEBUG macro in debug builds. Slang sets this
-# internally. If we don't set this here as well, header-defined things like the
-# destructor of `Driver`, which is generated in ImportVerilog's compilation
-# unit, will destroy a different set of fields than what was potentially built
-# or modified by code compiled in the Slang compilation unit.
-add_compile_definitions($<$<CONFIG:Debug>:DEBUG>)
+# For ABI compatibility, define the SLANG_DEBUG macro in debug builds. Slang
+# sets this internally. If we don't set this here as well, header-defined things
+# like the destructor of `Driver`, which is generated in ImportVerilog's
+# compilation unit, will destroy a different set of fields than what was
+# potentially built or modified by code compiled in the Slang compilation unit.
+add_compile_definitions($<$<CONFIG:Debug>:SLANG_DEBUG>)
 
 # HACK: When the `OBJECT` argument is passed to `llvm_add_library()`,
 # `COMPILE_DEFINITIONS` are not correctly inherited. For that reason, we
@@ -16,16 +16,3 @@ if(TARGET Boost::headers)
   add_compile_definitions(
     $<TARGET_PROPERTY:Boost::headers,INTERFACE_COMPILE_DEFINITIONS>)
 endif()
-
-# Disable some compiler warnings caused by slang headers such that the
-# `ImportVerilog` build doesn't spew out a ton of warnings that are not related
-# to CIRCT.
-if (NOT MSVC)
-  # slang has some classes with virtual funcs but non-virtual destructor.
-  add_compile_options(-Wno-non-virtual-dtor)
-  # some other warnings we've seen
-  add_compile_options(-Wno-c++98-compat-extra-semi)
-  add_compile_options(-Wno-ctad-maybe-unsupported)
-  # visitor switch statements cover all cases but have default
-  add_compile_options(-Wno-covered-switch-default)
-endif ()

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -93,7 +93,7 @@ struct ExprVisitor {
     auto resultType =
         isLvalue ? moore::RefType::get(cast<moore::UnpackedType>(type)) : type;
     auto range = expr.value().type->getFixedRange();
-    if (auto *constValue = expr.selector().constant) {
+    if (auto *constValue = expr.selector().getConstant()) {
       assert(!constValue->hasUnknown());
       assert(constValue->size() <= 32);
 
@@ -126,9 +126,9 @@ struct ExprVisitor {
 
     std::optional<int32_t> constLeft;
     std::optional<int32_t> constRight;
-    if (auto *constant = expr.left().constant)
+    if (auto *constant = expr.left().getConstant())
       constLeft = constant->integer().as<int32_t>();
-    if (auto *constant = expr.right().constant)
+    if (auto *constant = expr.right().getConstant())
       constRight = constant->integer().as<int32_t>();
 
     // We need to determine the right bound of the range. This is the address of

--- a/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
+++ b/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
@@ -178,7 +178,7 @@ struct InstBodyVisitor {
     return success();
   }
 };
-}; // namespace
+} // namespace
 
 LogicalResult Context::traverseInstanceBody(const slang::ast::Symbol &symbol) {
   if (auto *instBodySymbol = symbol.as_if<slang::ast::InstanceBodySymbol>())

--- a/test/Tools/circt-verilog-lsp-server/diagnostic.test
+++ b/test/Tools/circt-verilog-lsp-server/diagnostic.test
@@ -8,7 +8,7 @@
   "uri":"test:///diagnostic.sv",
   "languageId":"verilog",
   "version":1,
-  "text":"module foo()\n wire bar;\nendmodule"
+  "text":"function foo()\n int bar = 0;\nendfunction"
 }}}
 // CHECK:      "method": "textDocument/publishDiagnostics",
 // CHECK-NEXT:   "params": {
@@ -17,11 +17,11 @@
 // CHECK-NEXT:         "message": "expected ';'",
 // CHECK-NEXT:         "range": {
 // CHECK-NEXT:           "end": {
-// CHECK-NEXT:             "character": 12,
+// CHECK-NEXT:             "character": 14,
 // CHECK-NEXT:             "line": 0
 // CHECK-NEXT:           },
 // CHECK-NEXT:           "start": {
-// CHECK-NEXT:             "character": 12,
+// CHECK-NEXT:             "character": 14,
 // CHECK-NEXT:             "line": 0
 // CHECK-NEXT:           }
 // CHECK-NEXT:         },
@@ -29,14 +29,14 @@
 // CHECK-NEXT:         "source": "slang"
 // CHECK-NEXT:       },
 // CHECK-NEXT:       {
-// CHECK-NEXT:         "message": "unused net 'bar'",
+// CHECK-NEXT:         "message": "initializing a static variable in a procedural context requires an explicit 'static' keyword",
 // CHECK-NEXT:         "range": {
 // CHECK-NEXT:           "end": {
-// CHECK-NEXT:             "character": 6,
+// CHECK-NEXT:             "character": 5,
 // CHECK-NEXT:             "line": 1
 // CHECK-NEXT:           },
 // CHECK-NEXT:           "start": {
-// CHECK-NEXT:             "character": 6,
+// CHECK-NEXT:             "character": 5,
 // CHECK-NEXT:             "line": 1
 // CHECK-NEXT:           }
 // CHECK-NEXT:         },

--- a/test/circt-verilog/commandline.sv
+++ b/test/circt-verilog/commandline.sv
@@ -3,4 +3,4 @@
 // REQUIRES: slang
 
 // CHECK-HELP: OVERVIEW: Verilog and SystemVerilog frontend
-// CHECK-VERSION: slang version 8.
+// CHECK-VERSION: slang version 9.


### PR DESCRIPTION
Update the Slang frontend to version 9. This removes quite a few warnings related to C++20 features, and pulls in all the shiny new things.