### PR TITLE
[HW] Use multiple reduction matches in port pruner

### DIFF
--- a/lib/Dialect/HW/HWReductions.cpp
+++ b/lib/Dialect/HW/HWReductions.cpp
@@ -135,81 +135,156 @@ struct HWConstantifier : public Reduction {
   std::string getName() const override { return "hw-constantifier"; }
 };
 
-/// Remove the first or last output of the top-level module depending on the
-/// 'Front' template parameter.
-template <bool Front>
-struct ModuleOutputPruner : public OpReduction<HWModuleOp> {
+/// Remove unused module input ports.
+struct ModuleInputPruner : public Reduction {
   void beforeReduction(mlir::ModuleOp op) override {
-    useEmpty.clear();
-
-    SymbolTableCollection table;
-    SymbolUserMap users(table, op);
-    for (auto module : op.getOps<HWModuleOp>())
-      if (users.useEmpty(module))
-        useEmpty.insert(module);
+    symbolTables = std::make_unique<SymbolTableCollection>();
+    symbolUsers = std::make_unique<SymbolUserMap>(*symbolTables, op);
   }
 
-  uint64_t match(HWModuleOp op) override {
-    return op.getNumOutputPorts() != 0 && useEmpty.contains(op);
+  void matches(Operation *op,
+               llvm::function_ref<void(uint64_t, uint64_t)> addMatch) override {
+    auto module = dyn_cast<HWModuleLike>(op);
+    if (!module)
+      return;
+    auto moduleType = module.getHWModuleType();
+    if (moduleType.getNumInputs() == 0)
+      return;
+    auto users = symbolUsers->getUsers(op);
+    if (!llvm::all_of(users, [](auto *user) { return isa<InstanceOp>(user); }))
+      return;
+    auto *block = module.getBodyBlock();
+    for (unsigned idx = 0; idx < moduleType.getNumInputs(); ++idx)
+      if (!block || block->getArgument(idx).use_empty())
+        addMatch(1, idx);
   }
 
-  LogicalResult rewrite(HWModuleOp op) override {
-    Operation *terminator = op.getBody().front().getTerminator();
-    auto operands = terminator->getOperands();
-    ValueRange newOutputs = operands.drop_back();
-    unsigned portToErase = op.getNumOutputPorts() - 1;
-    if (Front) {
-      newOutputs = operands.drop_front();
-      portToErase = 0;
+  LogicalResult rewriteMatches(Operation *op,
+                               ArrayRef<uint64_t> matches) override {
+    auto module = cast<HWMutableModuleLike>(op);
+
+    // Remove the ports from the module.
+    SmallVector<unsigned> indexList;
+    BitVector indexSet(module.getNumInputPorts());
+    for (auto idx : matches) {
+      indexList.push_back(idx);
+      indexSet.set(idx);
     }
+    llvm::sort(indexList);
+    module.erasePorts(indexList, {});
+    if (auto *block = module.getBodyBlock())
+      block->eraseArguments(indexSet);
 
-    terminator->setOperands(newOutputs);
-    op.erasePorts({}, {portToErase});
-
-    return success();
-  }
-
-  std::string getName() const override {
-    return Front ? "hw-module-output-pruner-front"
-                 : "hw-module-output-pruner-back";
-  }
-
-  DenseSet<HWModuleOp> useEmpty;
-};
-
-/// Remove all input ports of the top-level module that have no users
-struct ModuleInputPruner : public OpReduction<HWModuleOp> {
-  void beforeReduction(mlir::ModuleOp op) override {
-    useEmpty.clear();
-
-    SymbolTableCollection table;
-    SymbolUserMap users(table, op);
-    for (auto module : op.getOps<HWModuleOp>())
-      if (users.useEmpty(module))
-        useEmpty.insert(module);
-  }
-
-  uint64_t match(HWModuleOp op) override { return useEmpty.contains(op); }
-
-  LogicalResult rewrite(HWModuleOp op) override {
-    SmallVector<unsigned> inputsToErase;
-    BitVector toErase(op.getNumPorts());
-    for (auto [i, arg] : llvm::enumerate(op.getBody().getArguments())) {
-      if (arg.use_empty()) {
-        toErase.set(i);
-        inputsToErase.push_back(i);
+    // Remove the ports from the instances.
+    for (auto *user : symbolUsers->getUsers(op)) {
+      auto instOp = cast<InstanceOp>(user);
+      SmallVector<Value> newOperands;
+      SmallVector<Attribute> newArgNames;
+      for (auto [idx, data] : llvm::enumerate(
+               llvm::zip(instOp.getInputs(), instOp.getArgNames()))) {
+        if (indexSet.test(idx))
+          continue;
+        auto [operand, argName] = data;
+        newOperands.push_back(operand);
+        newArgNames.push_back(argName);
       }
+      instOp.getInputsMutable().assign(newOperands);
+      instOp.setArgNamesAttr(ArrayAttr::get(op->getContext(), newArgNames));
     }
-
-    op.erasePorts(inputsToErase, {});
-    op.getBodyBlock()->eraseArguments(toErase);
 
     return success();
   }
 
   std::string getName() const override { return "hw-module-input-pruner"; }
 
-  DenseSet<HWModuleOp> useEmpty;
+  std::unique_ptr<SymbolTableCollection> symbolTables;
+  std::unique_ptr<SymbolUserMap> symbolUsers;
+};
+
+/// Remove unused module output ports.
+struct ModuleOutputPruner : public Reduction {
+  void beforeReduction(mlir::ModuleOp op) override {
+    symbolTables = std::make_unique<SymbolTableCollection>();
+    symbolUsers = std::make_unique<SymbolUserMap>(*symbolTables, op);
+  }
+
+  void matches(Operation *op,
+               llvm::function_ref<void(uint64_t, uint64_t)> addMatch) override {
+    auto module = dyn_cast<HWModuleLike>(op);
+    if (!module)
+      return;
+    auto moduleType = module.getHWModuleType();
+    if (moduleType.getNumOutputs() == 0)
+      return;
+    auto users = symbolUsers->getUsers(op);
+    if (!llvm::all_of(users, [](auto *user) { return isa<InstanceOp>(user); }))
+      return;
+    for (unsigned idx = 0; idx < moduleType.getNumOutputs(); ++idx)
+      if (llvm::all_of(users, [&](auto *user) {
+            return user->getResult(idx).use_empty();
+          }))
+        addMatch(1, idx);
+  }
+
+  LogicalResult rewriteMatches(Operation *op,
+                               ArrayRef<uint64_t> matches) override {
+    auto module = cast<HWMutableModuleLike>(op);
+
+    // Remove the ports from the module.
+    SmallVector<unsigned> indexList;
+    BitVector indexSet(module.getNumOutputPorts());
+    for (auto idx : matches) {
+      indexList.push_back(idx);
+      indexSet.set(idx);
+    }
+    llvm::sort(indexList);
+    module.erasePorts({}, indexList);
+
+    // Update the `hw.output` op.
+    if (auto *block = module.getBodyBlock()) {
+      auto outputOp = cast<OutputOp>(block->getTerminator());
+      SmallVector<Value> newOutputs;
+      for (auto [idx, output] : llvm::enumerate(outputOp.getOutputs()))
+        if (!indexSet.test(idx))
+          newOutputs.push_back(output);
+      outputOp.getOutputsMutable().assign(newOutputs);
+    }
+
+    // Remove the ports from the instances.
+    for (auto *user : symbolUsers->getUsers(op)) {
+      OpBuilder builder(user);
+      auto instOp = cast<InstanceOp>(user);
+      SmallVector<Value> oldResults;
+      SmallVector<Type> newResultTypes;
+      SmallVector<Attribute> newResultNames;
+      for (auto [idx, data] : llvm::enumerate(
+               llvm::zip(instOp.getResults(), instOp.getResultNames()))) {
+        if (indexSet.test(idx))
+          continue;
+        auto [result, resultName] = data;
+        oldResults.push_back(result);
+        newResultTypes.push_back(result.getType());
+        newResultNames.push_back(resultName);
+      }
+      auto newOp = InstanceOp::create(
+          builder, instOp.getLoc(), newResultTypes,
+          instOp.getInstanceNameAttr(), instOp.getModuleNameAttr(),
+          instOp.getInputs(), instOp.getArgNamesAttr(),
+          builder.getArrayAttr(newResultNames), instOp.getParametersAttr(),
+          instOp.getInnerSymAttr(), instOp.getDoNotPrintAttr());
+      for (auto [oldResult, newResult] :
+           llvm::zip(oldResults, newOp.getResults()))
+        oldResult.replaceAllUsesWith(newResult);
+      instOp.erase();
+    }
+
+    return success();
+  }
+
+  std::string getName() const override { return "hw-module-output-pruner"; }
+
+  std::unique_ptr<SymbolTableCollection> symbolTables;
+  std::unique_ptr<SymbolUserMap> symbolUsers;
 };
 
 //===----------------------------------------------------------------------===//
@@ -228,8 +303,7 @@ void HWReducePatternDialectInterface::populateReducePatterns(
   patterns.add<HWOperandForwarder<0>, 4>();
   patterns.add<HWOperandForwarder<1>, 3>();
   patterns.add<HWOperandForwarder<2>, 2>();
-  patterns.add<ModuleOutputPruner<true>, 2>();
-  patterns.add<ModuleOutputPruner<false>, 2>();
+  patterns.add<ModuleOutputPruner, 2>();
   patterns.add<ModuleInputPruner, 2>();
 }
 

--- a/test/Dialect/HW/Reduction/hw-module-input-pruner.mlir
+++ b/test/Dialect/HW/Reduction/hw-module-input-pruner.mlir
@@ -1,9 +1,17 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.output %arg" --keep-best=0 --include hw-module-input-pruner | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "dbg.variable" --keep-best=0 --include hw-module-input-pruner | FileCheck %s
 
-// CHECK-LABEL: hw.module @Foo(in %arg0 : i32, out out0 : i32)
+// CHECK-LABEL: hw.module @Foo(in %arg1 : i32, out out0 : i32)
 hw.module @Foo(in %arg0 : i32, in %arg1 : i32, in %arg2 : i32, out out0 : i32) {
-  // CHECK-NEXT: hw.output %arg0 : i32
-  hw.output %arg0 : i32
+  // CHECK-NEXT: hw.output %arg1 : i32
+  hw.output %arg1 : i32
+}
+
+// CHECK-LABEL: hw.module @Bar(in %arg1 : i32)
+hw.module @Bar(in %arg0 : i32, in %arg1 : i32, in %arg2 : i32) {
+  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "foo" @Foo(arg1: %arg1: i32) -> (out0: i32)
+  %0 = hw.instance "foo" @Foo(arg0: %arg0: i32, arg1: %arg1: i32, arg2: %arg2: i32) -> (out0: i32)
+  // CHECK-NEXT: dbg.variable "x", [[TMP]]
+  dbg.variable "x", %0 : i32
 }

--- a/test/Dialect/HW/Reduction/hw-module-output-pruner.mlir
+++ b/test/Dialect/HW/Reduction/hw-module-output-pruner.mlir
@@ -1,12 +1,19 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.output %arg" --keep-best=0 --include hw-module-output-pruner-back | FileCheck %s --check-prefix=CHECK-BACK
-// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "hw.output %arg" --keep-best=0 --include hw-module-output-pruner-front | FileCheck %s --check-prefix=CHECK-FRONT
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg -E --test-arg "dbg.variable" --keep-best=0 --include hw-module-output-pruner | FileCheck %s
 
-// CHECK-FRONT-LABEL: hw.module @Foo(in %arg0 : i32, in %arg1 : i32, in %arg2 : i32, out out2 : i32)
-// CHECK-BACK-LABEL: hw.module @Foo(in %arg0 : i32, in %arg1 : i32, in %arg2 : i32, out out0 : i32)
+// CHECK-LABEL: hw.module @Foo
+// CHECK-SAME: (in %arg0 : i32, in %arg1 : i32, in %arg2 : i32, out out1 : i32)
 hw.module @Foo(in %arg0 : i32, in %arg1 : i32, in %arg2 : i32, out out0 : i32, out out1 : i32, out out2 : i32) {
-  // CHECK-FRONT-NEXT: hw.output %arg2 : i32
-  // CHECK-BACK-NEXT: hw.output %arg0 : i32
+  // CHECK-NEXT: hw.output %arg1 : i32
   hw.output %arg0, %arg1, %arg2 : i32, i32, i32
+}
+
+// CHECK-LABEL: hw.module @Bar
+// CHECK-SAME: (in %arg0 : i32, in %arg1 : i32, in %arg2 : i32)
+hw.module @Bar(in %arg0 : i32, in %arg1 : i32, in %arg2 : i32) {
+  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "foo" @Foo(arg0: %arg0: i32, arg1: %arg1: i32, arg2: %arg2: i32) -> (out1: i32)
+  %0, %1, %2 = hw.instance "foo" @Foo(arg0: %arg0: i32, arg1: %arg1: i32, arg2: %arg2: i32) -> (out0 : i32, out1 : i32, out2 : i32)
+  // CHECK-NEXT: dbg.variable "x", [[TMP]]
+  dbg.variable "x", %1 : i32
 }

--- a/test/Dialect/HW/Reduction/pattern-registration.mlir
+++ b/test/Dialect/HW/Reduction/pattern-registration.mlir
@@ -13,8 +13,7 @@
 // CHECK-DAG: hw-operand1-forwarder
 // CHECK-DAG: canonicalize
 // CHECK-DAG: hw-operand2-forwarder
-// CHECK-DAG: hw-module-output-pruner-front
-// CHECK-DAG: hw-module-output-pruner-back
+// CHECK-DAG: hw-module-output-pruner
 // CHECK-DAG: hw-module-input-pruner
 // CHECK-DAG: operation-pruner
 hw.module @Foo(in %in : i1, out out : i1) {


### PR DESCRIPTION
Extend the HW reduction pattern that removes input and output ports. Since the reducer now supports multiple matches per op for a pattern, we can generate separate matches for every input and output port. The reducer then picks some of these and hands them back to the `rewriteMatches` function, where we can remove all the selected inputs and outputs of a module.

Also make the reductions adjust instance ops such that all modules can have their ports pruned, instead of just the top-level. Support extern modules as well, which are common due to the module externalizer reduction.

This allows the reducer to get rid of ports very aggressively.