### PR TITLE
[ImportVerilog] Fix file locations for auto-discovered files

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -79,10 +79,9 @@ struct HierPathInfo {
 struct Context {
   Context(const ImportVerilogOptions &options,
           slang::ast::Compilation &compilation, mlir::ModuleOp intoModuleOp,
-          const slang::SourceManager &sourceManager,
-          SmallDenseMap<slang::BufferID, StringRef> &bufferFilePaths)
+          const slang::SourceManager &sourceManager)
       : options(options), compilation(compilation), intoModuleOp(intoModuleOp),
-        sourceManager(sourceManager), bufferFilePaths(bufferFilePaths),
+        sourceManager(sourceManager),
         builder(OpBuilder::atBlockEnd(intoModuleOp.getBody())),
         symbolTable(intoModuleOp) {}
   Context(const Context &) = delete;
@@ -188,7 +187,6 @@ struct Context {
   slang::ast::Compilation &compilation;
   mlir::ModuleOp intoModuleOp;
   const slang::SourceManager &sourceManager;
-  SmallDenseMap<slang::BufferID, StringRef> &bufferFilePaths;
 
   /// The builder used to create IR operations.
   OpBuilder builder;

--- a/test/circt-verilog/include/library_module.sv
+++ b/test/circt-verilog/include/library_module.sv
@@ -1,0 +1,6 @@
+// This module is used in the library locations test.
+// Empty `RUN` line such that it does not get picked up by lit.
+// RUN:
+
+module library_module;
+endmodule

--- a/test/circt-verilog/library-locations.sv
+++ b/test/circt-verilog/library-locations.sv
@@ -1,0 +1,21 @@
+// RUN: circt-verilog -y %S/include --mlir-print-debuginfo %s | FileCheck %s
+// REQUIRES: slang
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// See https://github.com/llvm/circt/pull/8840
+
+// CHECK-LABEL: hw.module @foo
+module foo;
+  // CHECK-NEXT: hw.instance
+  // CHECK-NEXT: hw.output
+  // CHECK-NEXT: } loc([[LOC1:#.+]])
+  library_module bar();
+endmodule
+
+// CHECK-LABEL: hw.module private @library_module
+// CHECK-NEXT: hw.output
+// CHECK-NEXT: } loc([[LOC2:#.+]])
+
+// CHECK: [[LOC1]] = loc("{{.*}}library-locations.sv"
+// CHECK: [[LOC2]] = loc("{{.*}}include/library_module.sv"

--- a/test/circt-verilog/preprocess-errors.sv
+++ b/test/circt-verilog/preprocess-errors.sv
@@ -1,4 +1,4 @@
-// RUN: circt-verilog %s -E --verify-diagnostics
+// RUN: circt-translate %s --import-verilog --verify-diagnostics --split-input-file
 // REQUIRES: slang
 
 // expected-error-re @below {{'unknown.sv': {{.+}}}}


### PR DESCRIPTION
The ImportVerilog conversion currently uses a hacky `bufferFilePaths` table to map from `slang::BufferID`s to the corresponding file path. This only works for files that we explicitly add to the source manager. Files discovered automatically by Slang, e.g. through the `-y` flag, have no entry in that table. As a result, any errors in such files will report their file path as `-`, which is not very helpful.

This commit fixes this by using whatever Slang's own `SourceManager::getFileName` returns for a given location. This removes the need for that `bufferFilePaths` table. As a result, errors in files discovered via `-y` will now properly show the file name.

While we're at it, also attach the include file stack as a note to any reported diagnostic. This makes it easier to understand how the compiler arrived at an error location.