### PR TITLE
[ImportVerilog] Add support for %f/%F format specifier

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1617,17 +1617,11 @@ def FormatRealOp : MooreOp<"fmt.real", [Pure]> {
   }];
   let arguments = (ins
   RealType:$value,
-  RealFormatAttr:$format,
-  I32Attr:$width,
-  IntAlignAttr:$alignment,
-  IntPaddingAttr:$padding
+  RealFormatAttr:$format
   );
   let results = (outs FormatStringType:$result);
   let assemblyFormat = [{
       $format $value `,`
-      `width` $width `,`
-      `align` $alignment `,`
-      `pad` $padding
       attr-dict `:` type($value)
   }];
 }

--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -199,17 +199,10 @@ struct FormatStringParser {
     if (!value)
       return failure();
 
-    unsigned width;
-    if (options.width)
-      width = *options.width;
-    else
-      width = 64;
+    // TODO add support for specifics such as width etc
 
-    auto alignment = IntAlign::Left;
-    auto padding = IntPadding::Space;
-
-    fragments.push_back(moore::FormatRealOp::create(builder, loc, value, format,
-                                                    width, alignment, padding));
+    fragments.push_back(
+        moore::FormatRealOp::create(builder, loc, value, format));
 
     return success();
   }

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -89,10 +89,10 @@ function void DisplayAndSeverityBuiltins(int x, real r);
   // CHECK: moore.fmt.int octal [[X]], width 19, align left, pad zero : i32
   $write("%-19o", x);
 
-  // CHECK: moore.fmt.real float [[R]], width 64, align left, pad space : real
+  // CHECK: moore.fmt.real float [[R]]
   $write("%f", r);
   // CHECK: [[XR:%.+]] = moore.conversion [[X]] : !moore.i32 -> !moore.real
-  // CHECK: [[TMP:%.+]] = moore.fmt.real float [[XR]], width 64, align left, pad space : real
+  // CHECK: [[TMP:%.+]] = moore.fmt.real float [[XR]]
   // CHECK: moore.builtin.display [[TMP]]
   $write("%f", x);
 
@@ -160,7 +160,7 @@ function void DisplayAndSeverityBuiltins(int x, real r);
   // CHECK: moore.builtin.display [[TMP3]]
   $displayh(x);
 
-  // CHECK: [[TMP1:%.+]] = moore.fmt.real float [[R]], width 64, align left, pad space : real
+  // CHECK: [[TMP1:%.+]] = moore.fmt.real float [[R]]
   // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
   // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
   // CHECK: moore.builtin.display [[TMP3]]


### PR DESCRIPTION
This PR aims to add a FormatRealOp, similar to FormatIntOp, to the Moore dialect. I have tested it very briefly and will continue working on it tomorrow ~~but it should work okay in its current state (?)~~ (it did not). Opening as draft just to be safe for now.