### PR TITLE
[FIRRTL] Firtool: Add option to emit bind files for private modules

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -734,6 +734,10 @@ def LowerLayers : Pass<"firrtl-lower-layers", "firrtl::CircuitOp"> {
     pass, all layer blocks and layers are removed.
   }];
   let dependentDialects = ["sv::SVDialect", "emit::EmitDialect"];
+  let options = [
+    Option<"emitAllBindFiles", "emit-all-bind-files", "bool", "false",
+      "Emit bind files for private modules.">
+  ];
 }
 
 def LayerMerge : Pass<"firrtl-layer-merge", "firrtl::FModuleOp"> {

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -145,6 +145,8 @@ public:
 
   bool getLintXmrsInDesign() const { return lintXmrsInDesign; }
 
+  bool getEmitAllBindFiles() const { return emitAllBindFiles; }
+
   // Setters, used by the CAPI
   FirtoolOptions &setOutputFilename(StringRef name) {
     outputFilename = name;
@@ -394,6 +396,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setEmitAllBindFiles(bool value) {
+    emitAllBindFiles = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
 
@@ -448,6 +455,7 @@ private:
   bool disableWireElimination;
   bool lintStaticAsserts;
   bool lintXmrsInDesign;
+  bool emitAllBindFiles;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -199,7 +199,7 @@ struct BindFileInfo {
 
 class LowerLayersPass
     : public circt::firrtl::impl::LowerLayersBase<LowerLayersPass> {
-  using LowerLayersBase::LowerLayersBase;
+  using Base::Base;
 
   hw::OutputFileAttr getOutputFile(SymbolRefAttr layerName) {
     auto layer = symbolToLayer.lookup(layerName);

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -199,6 +199,8 @@ struct BindFileInfo {
 
 class LowerLayersPass
     : public circt::firrtl::impl::LowerLayersBase<LowerLayersPass> {
+  using LowerLayersBase::LowerLayersBase;
+
   hw::OutputFileAttr getOutputFile(SymbolRefAttr layerName) {
     auto layer = symbolToLayer.lookup(layerName);
     if (!layer)
@@ -917,7 +919,7 @@ void LowerLayersPass::preprocessModule(CircuitNamespace &ns,
   llvm::SmallDenseSet<LayerOp> layersRequiringBindFiles;
 
   // If the module is public, create a bind file for all layers.
-  if (module.isPublic())
+  if (module.isPublic() || emitAllBindFiles)
     for (auto [_, layer] : symbolToLayer)
       if (layer.getConvention() == LayerConvention::Bind)
         layersRequiringBindFiles.insert(layer);

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -250,7 +250,8 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   // TODO: Improve LowerLayers to avoid the need for canonicalization. See:
   //   https://github.com/llvm/circt/issues/7896
 
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerLayers());
+  pm.nest<firrtl::CircuitOp>().addPass(
+      firrtl::createLowerLayers({opt.getEmitAllBindFiles()}));
   if (!opt.shouldDisableOptimization())
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createSimpleCanonicalizerPass());
@@ -766,6 +767,11 @@ struct FirtoolCmdOptions {
       "disable-wire-elimination", llvm::cl::desc("Disable wire elimination"),
       llvm::cl::init(false)};
 
+  llvm::cl::opt<bool> emitAllBindFiles{
+      "emit-all-bind-files",
+      llvm::cl::desc("Emit bindfiles for private modules"),
+      llvm::cl::init(false)};
+
   //===----------------------------------------------------------------------===
   // Lint options
   //===----------------------------------------------------------------------===
@@ -818,7 +824,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       disableCSEinClasses(false), selectDefaultInstanceChoice(false),
       symbolicValueLowering(verif::SymbolicValueLowering::ExtModule),
       disableWireElimination(false), lintStaticAsserts(true),
-      lintXmrsInDesign(true) {
+      lintXmrsInDesign(true), emitAllBindFiles(false) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -871,4 +877,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   disableWireElimination = clOptions->disableWireElimination;
   lintStaticAsserts = clOptions->lintStaticAsserts;
   lintXmrsInDesign = clOptions->lintXmrsInDesign;
+  emitAllBindFiles = clOptions->emitAllBindFiles;
 }


### PR DESCRIPTION
The spec does not guarantee the existence of layer bindfiles for private modules, but we have a need to use the verilog of internal/private modules of a circuit and it is helpful if their bindfiles always exist. This PR adds an option to firtool that forces lower layers to emit bindfiles for private modules, even when not necessary.