### PR TITLE
[LLHD] Lower processes that have ops ahead of convergence block

### DIFF
--- a/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
+++ b/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
@@ -103,7 +103,8 @@ bool Lowering::matchControlFlow() {
   auto skipToMergePoint = [&](Block *block) -> std::pair<Block *, ValueRange> {
     ValueRange operands;
     while (auto branchOp = dyn_cast<cf::BranchOp>(block->getTerminator())) {
-      if (!block->without_terminator().empty())
+      if (llvm::any_of(block->without_terminator(),
+                       [](auto &op) { return !isMemoryEffectFree(&op); }))
         break;
       block = branchOp.getDest();
       operands = branchOp.getDestOperands();
@@ -115,8 +116,7 @@ bool Lowering::matchControlFlow() {
     return {block, operands};
   };
 
-  // Ensure that the entry block and wait op converge on the same block and with
-  // the same block arguments.
+  // Ensure that the entry block and wait op converge on the same block.
   auto &entry = processOp.getBody().front();
   auto [entryMergeBlock, entryMergeArgs] = skipToMergePoint(&entry);
   auto [waitMergeBlock, waitMergeArgs] = skipToMergePoint(waitOp.getDest());
@@ -126,7 +126,24 @@ bool Lowering::matchControlFlow() {
                << ": control from entry and wait does not converge\n");
     return false;
   }
-  if (entryMergeArgs != waitMergeArgs) {
+
+  // Helper function to check if two values are equivalent.
+  auto areValuesEquivalent = [](std::tuple<Value, Value> values) {
+    auto [a, b] = values;
+    if (a == b)
+      return true;
+    auto *opA = a.getDefiningOp();
+    auto *opB = b.getDefiningOp();
+    if (!opA || !opB)
+      return false;
+    return OperationEquivalence::isEquivalentTo(
+        opA, opB, OperationEquivalence::IgnoreLocations);
+  };
+
+  // Ensure that the entry block and wait op converge with equivalent block
+  // arguments.
+  if (!llvm::all_of(llvm::zip(entryMergeArgs, waitMergeArgs),
+                    areValuesEquivalent)) {
     LLVM_DEBUG(llvm::dbgs() << "Skipping process " << processOp.getLoc()
                             << ": control from entry and wait converges with "
                                "different block arguments\n");

--- a/test/Dialect/LLHD/Transforms/lower-processes.mlir
+++ b/test/Dialect/LLHD/Transforms/lower-processes.mlir
@@ -1,5 +1,7 @@
 // RUN: circt-opt --llhd-lower-processes %s | FileCheck %s
 
+func.func private @dummy()
+
 // CHECK-LABEL: @Trivial(
 hw.module @Trivial() {
   // CHECK:      llhd.combinational {
@@ -200,5 +202,38 @@ hw.module @SkipIfValueUnobserved(in %a: i42) {
   ^bb1:
     %0 = comb.add %a, %a : i42
     llhd.wait ^bb1
+  }
+}
+
+// CHECK-LABEL: @AllowEntryAndWaitToConvergeWithEquivalentBlockArgs(
+hw.module @AllowEntryAndWaitToConvergeWithEquivalentBlockArgs(in %a : i42) {
+  // CHECK:      llhd.combinational -> i42 {
+  // CHECK-NEXT:   [[ADD:%.+]] = comb.add %a, %a : i42
+  // CHECK-NEXT:   cf.br ^bb1
+  // CHECK-NEXT: ^bb1:
+  // CHECK-NEXT:   llhd.yield [[ADD]] : i42
+  // CHECK-NEXT: }
+  %0 = llhd.process -> i42 {
+    %1 = comb.add %a, %a : i42
+    cf.br ^bb2(%1 : i42)
+  ^bb1:
+    %2 = comb.add %a, %a : i42
+    cf.br ^bb2(%2 : i42)
+  ^bb2(%3: i42):
+    llhd.wait yield (%3 : i42), (%a : i42), ^bb1
+  }
+}
+
+// CHECK-LABEL: @SkipIfEntryAndWaitConvergeWithSideEffectingOps(
+hw.module @SkipIfEntryAndWaitConvergeWithSideEffectingOps(in %a : i42) {
+  // CHECK: llhd.process
+  %0 = llhd.process -> i42 {
+    func.call @dummy() : () -> ()
+    cf.br ^bb2
+  ^bb1:
+    func.call @dummy() : () -> ()
+    cf.br ^bb2
+  ^bb2:
+    llhd.wait yield (%a : i42), (%a : i42), ^bb1
   }
 }


### PR DESCRIPTION
Currently, the LowerProcesses pass does not allow for the control flow from the entry block and the wait op to contain any non-branch ops up to the point where they converge. This is very conservative, since ops like constants can make their way into the entry block in a way where the entry block and wait op do converge, but with distinct yet equivalent ops in the respective blocks leading up to the convergence point.

Fix this issue by allowing blocks up to the convergence point to contain any ops, as long as the block arguments passed to the convergence block are coming from equivalent (but possibly distinct) ops.

We should really have a flavor of `llhd.process` that does not require a wait and a control flow loop to describe combinational processes. That would make these passes a lot easier.

Fixes #8799.