### PR TITLE
Put memories in the same directory as their parent

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3498,11 +3498,14 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
       memSummary.readUnderWrite, memSummary.writeUnderWrite, op.getNameAttr(),
       op.getInnerSymAttr(), memInit, op.getPrefixAttr(), Attribute{});
 
-  // If the module is outside the DUT, set the appropriate output directory for
-  // the memory.
-  if (!circuitState.isInDUT(theModule))
-    if (auto testBenchDir = circuitState.getTestBenchDirectory())
-      memDecl.setOutputFileAttr(testBenchDir);
+  if (auto parent = op->getParentOfType<hw::HWModuleOp>()) {
+    if (auto file = parent->getAttrOfType<hw::OutputFileAttr>("output_file")) {
+      auto dir = file;
+      if (!file.isDirectory())
+        dir = hw::OutputFileAttr::getAsDirectory(builder.getContext(), file.getDirectory());
+      memDecl.setOutputFileAttr(dir);
+    }
+  }
 
   // Memories return multiple structs, one for each port, which means we
   // have two layers of type to split apart.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3502,7 +3502,8 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
     if (auto file = parent->getAttrOfType<hw::OutputFileAttr>("output_file")) {
       auto dir = file;
       if (!file.isDirectory())
-        dir = hw::OutputFileAttr::getAsDirectory(builder.getContext(), file.getDirectory());
+        dir = hw::OutputFileAttr::getAsDirectory(builder.getContext(),
+                                                 file.getDirectory());
       memDecl.setOutputFileAttr(dir);
     }
   }

--- a/test/firtool/cmem-under-layerblock.fir
+++ b/test/firtool/cmem-under-layerblock.fir
@@ -1,0 +1,19 @@
+; RUN: firtool %s | FileCheck %s
+
+FIRRTL version 5.0.0
+circuit Top:
+  layer Verification, bind, "verification":
+
+  public module Top:
+    input  c : Clock
+    input  i : UInt<1>
+    input  j : UInt<1>
+    input  d : UInt<1>
+    layerblock Verification:
+      cmem memory : UInt<1>[2]
+      infer mport rd = memory[i], c
+      infer mport wr = memory[j], c
+      connect wr, d
+      assert(c, rd, UInt<1>(1), "hello")
+
+; CHECK: ----- 8< ----- FILE "verification/memory_2x1.sv" ----- 8< -----

--- a/test/firtool/cmem-under-layerblock.fir
+++ b/test/firtool/cmem-under-layerblock.fir
@@ -16,4 +16,4 @@ circuit Top:
       connect wr, d
       assert(c, rd, UInt<1>(1), "hello")
 
-; CHECK: ----- 8< ----- FILE "verification/memory_2x1.sv" ----- 8< -----
+; CHECK: ----- 8< ----- FILE "verification{{[/\]}}memory_2x1.sv" ----- 8< -----


### PR DESCRIPTION
By the time lower-to-hw runs, the directories have already been assigned. Colocate the memory module with its parent. Remove logic which would set the output directory to the testbench--this is not always right. This allows memories to be emitted into layer specific directories.