### PR TITLE
[Synth] Add CutRewriter framework and TechMapper pass

### DIFF
--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -26,4 +26,36 @@ def TestPriorityCuts : Pass<"synth-test-priority-cuts", "hw::HWModuleOp"> {
   ];
 }
 
+def TechMapper : Pass<"synth-tech-mapper", "mlir::ModuleOp"> {
+  let summary = "Technology mapping using cut rewriting";
+  let description = [{
+    This pass performs technology mapping by converting logic network
+    (AIG etc) representations into technology-specific gate implementations.
+    It uses cut-based rewriting with priority cuts and NPN canonical forms for
+    efficient pattern matching.
+
+    The pass serves dual purposes: providing practical technology mapping
+    capabilities and acting as a test vehicle for the cut rewriting framework,
+    since testing cut enumeration and pattern matching algorithms directly
+    would otherwise be difficult without a concrete application.
+
+    Supports both area and timing optimization strategies.
+  }];
+  let options = [
+    Option<"maxCutsPerRoot", "max-cuts-per-root", "int", "6",
+           "Maximum number of cuts to maintain per node">,
+    Option<"strategy", "strategy", "synth::OptimizationStrategy",
+           /*default=*/"synth::OptimizationStrategyTiming",
+           "Optimization strategy (area vs. timing)",
+           [{::llvm::cl::values(
+             clEnumValN(synth::OptimizationStrategyArea, "area",
+                        "Optimize for area"),
+             clEnumValN(synth::OptimizationStrategyTiming, "timing",
+                        "Optimize for timing")
+           )}]>,
+    Option<"test", "test", "bool", "false", "Attach timing to IR for testing">,
+  ];
+  let dependentDialects = ["circt::hw::HWDialect"];
+}
+
 #endif // CIRCT_DIALECT_SYNTH_TRANSFORMS_PASSES_TD

--- a/integration_test/circt-synth/mapping-lec.mlir
+++ b/integration_test/circt-synth/mapping-lec.mlir
@@ -1,0 +1,54 @@
+// REQUIRES: libz3
+// REQUIRES: circt-lec-jit
+
+// RUN: circt-synth %s -o %t1.mlir -convert-to-comb --top mul
+// RUN: cat %t1.mlir | FileCheck %s
+// RUN: circt-opt %s --convert-aig-to-comb -o %t2.mlir
+// RUN: circt-lec %t1.mlir %t2.mlir -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_TECHMAP
+
+// COMB_MUL_TECHMAP: c1 == c2
+
+// Set delay for binary and inv op to 5 so that others will be prioritized
+hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[5], [5]]}} {
+    %0 = aig.and_inv %a, %b : i1
+    hw.output %0 : i1
+}
+
+hw.module @and_inv_n(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[5], [5]]}} {
+    %0 = aig.and_inv not %a, %b : i1
+    hw.output %0 : i1
+}
+
+hw.module @and_inv_nn(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[5], [5]]}} {
+    %0 = aig.and_inv not %a, not %b : i1
+    hw.output %0 : i1
+}
+
+hw.module @nand_nand(in %a : i1, in %b : i1, in %c : i1, in %d: i1, out result : i1) attributes {hw.techlib.info = {area = 3.0 : f64, delay = [[1], [1], [1], [1]]}} {
+    %0 = aig.and_inv %a, %b : i1
+    %1 = aig.and_inv %c, %d : i1
+    %2 = aig.and_inv not %0, not %1 : i1
+    hw.output %2 : i1
+}
+
+hw.module @some(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+    %0 = aig.and_inv not %a, not %b : i1
+    %1 = aig.and_inv %a, %b : i1
+    %2 = aig.and_inv not %0, not %1 : i1
+    hw.output %2 : i1
+}
+
+// Make sure @mul is mapped to modules above.
+// CHECK-LABEL: hw.module @mul
+// CHECK-NOT: aig.and_inv
+// CHECK-NOT: comb.and
+// CHECK-NOT: comb.xor
+// CHECK-DAG: hw.instance {{".+"}} @and_inv
+// CHECK-DAG: hw.instance {{".+"}} @some
+// CHECK-DAG: hw.instance {{".+"}} @nand_nand
+// CHECK-DAG: hw.instance {{".+"}} @and_inv_n
+// CHECK-DAG: hw.instance {{".+"}} @and_inv_nn
+hw.module @mul(in %arg0: i4, in %arg1: i4, out add: i4) {
+  %0 = comb.mul %arg0, %arg1 : i4
+  hw.output %0 : i4
+}

--- a/lib/Dialect/Synth/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Synth/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_circt_dialect_library(CIRCTSynthTransforms
   CutRewriter.cpp
   SynthesisPipeline.cpp
+  TechMapper.cpp
   TestPriorityCuts.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -24,11 +24,13 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Support/LLVM.h"
 #include "circt/Support/NPNClass.h"
+#include "circt/Support/UnusedOpPruner.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/IR/Visitors.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/APInt.h"
@@ -38,6 +40,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/iterator.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <functional>
@@ -95,6 +98,22 @@ static bool isAlwaysCutInput(Value value) {
   return !isSupportedLogicOp(op);
 }
 
+// Return true if the new area/delay is better than the old area/delay in the
+// context of the given strategy.
+static bool compareDelayAndArea(OptimizationStrategy strategy, double newArea,
+                                ArrayRef<DelayType> newDelay, double oldArea,
+                                ArrayRef<DelayType> oldDelay) {
+  if (OptimizationStrategyArea == strategy) {
+    // Compare by area first.
+    return newArea < oldArea || (newArea == oldArea && newDelay < oldDelay);
+  }
+  if (OptimizationStrategyTiming == strategy) {
+    // Compare by delay first.
+    return newDelay < oldDelay || (newDelay == oldDelay && newArea < oldArea);
+  }
+  llvm_unreachable("Unknown mapping strategy");
+}
+
 LogicalResult
 circt::synth::topologicallySortLogicNetwork(mlir::Operation *topOp) {
 
@@ -125,6 +144,74 @@ circt::synth::topologicallySortLogicNetwork(mlir::Operation *topOp) {
     return mlir::emitError(topOp->getLoc(),
                            "failed to sort operations topologically");
   return success();
+}
+
+/// Get the truth table for an op.
+template <typename OpRange>
+FailureOr<BinaryTruthTable> static computeTruthTable(
+    mlir::ValueRange values, const OpRange &ops,
+    const llvm::SmallSetVector<mlir::Value, 4> &inputArgs) {
+  // Create a truth table for the operation
+  int64_t numInputs = inputArgs.size();
+  int64_t numOutputs = values.size();
+  if (LLVM_UNLIKELY(numOutputs != 1 || numInputs >= maxTruthTableInputs)) {
+    if (numOutputs == 0)
+      return BinaryTruthTable(numInputs, 0);
+    if (numInputs >= maxTruthTableInputs)
+      return mlir::emitError(values.front().getLoc(),
+                             "Truth table is too large");
+    return mlir::emitError(values.front().getLoc(),
+                           "Multiple outputs are not supported yet");
+  }
+
+  // Create a truth table with the given number of inputs and outputs
+  BinaryTruthTable truthTable(numInputs, numOutputs);
+  // The truth table size is 2^numInputs
+  uint32_t tableSize = 1 << numInputs;
+  // Create a map to evaluate the operation
+  DenseMap<Value, APInt> eval;
+  for (uint32_t i = 0; i < numInputs; ++i) {
+    // Create alternating bit pattern for input i
+    // For input i, bits alternate every 2^i positions
+    uint32_t blockSize = 1 << i;
+    // Create the repeating pattern: blockSize zeros followed by blockSize ones
+    uint32_t patternWidth = 2 * blockSize;
+    APInt pattern(patternWidth, 0);
+    assert(patternWidth <= tableSize && "Pattern width exceeds table size");
+    // Set the upper half of the pattern to 1s
+    pattern = APInt::getHighBitsSet(patternWidth, blockSize);
+    // Use getSplat to repeat this pattern across the full
+    // table size
+
+    eval[inputArgs[i]] = APInt::getSplat(tableSize, pattern);
+  }
+  // Simulate the operation
+  for (auto *op : ops) {
+    if (op->getNumResults() == 0)
+      continue; // Skip operations with no results
+    if (!isSupportedLogicOp(op))
+      return op->emitError("Unsupported operation for truth table simulation");
+
+    // Simulate the operation
+    simulateLogicOp(op, eval);
+  }
+  // TODO: Currently numOutputs is always 1, so we can just return the first
+  // one.
+  return BinaryTruthTable(numInputs, 1, eval[values[0]]);
+}
+
+FailureOr<BinaryTruthTable> circt::synth::getTruthTable(ValueRange values,
+                                                        Block *block) {
+  // Get the input arguments from the block
+  llvm::SmallSetVector<Value, 4> inputs;
+  for (auto arg : block->getArguments())
+    inputs.insert(arg);
+
+  // If there are no inputs, return an empty truth table
+  if (inputs.empty())
+    return BinaryTruthTable();
+
+  return computeTruthTable(values, llvm::make_pointer_range(*block), inputs);
 }
 
 //===----------------------------------------------------------------------===//
@@ -209,39 +296,9 @@ const BinaryTruthTable &Cut::getTruthTable() const {
     return *truthTable;
   }
 
-  int64_t numInputs = getInputSize();
-  int64_t numOutputs = getOutputSize();
-  assert(numInputs < 20 && "Truth table is too large");
+  // Create a truth table with the given number of inputs and outputs
+  truthTable = *computeTruthTable(getRoot()->getResults(), operations, inputs);
 
-  // Simulate the IR.
-  uint32_t tableSize = 1 << numInputs;
-  DenseMap<Value, APInt> eval;
-  for (uint32_t i = 0; i < numInputs; ++i) {
-    // Create alternating bit pattern for input i
-    // For input i, bits alternate every 2^i positions
-    uint32_t blockSize = 1 << i;
-
-    // Create the repeating pattern: blockSize zeros followed by blockSize ones
-    uint32_t patternWidth = 2 * blockSize;
-    APInt pattern(patternWidth, 0);
-    assert(patternWidth <= tableSize);
-    // Set the upper half of the pattern to 1s
-    pattern = APInt::getHighBitsSet(patternWidth, blockSize);
-    // Use getSplat to repeat this pattern across the full table size
-    eval[inputs[i]] = APInt::getSplat(tableSize, pattern);
-  }
-
-  // Simulate the operations in the cut
-  for (auto *op : operations)
-    simulateLogicOp(op, eval);
-
-  // Extract the truth table from the root operation
-  auto rootResults = getRoot()->getResults();
-  BinaryTruthTable result(numInputs, numOutputs);
-  assert(numOutputs == 1 &&
-         "Multiple outputs are not supported yet, must be rejected earlier");
-  result.table = eval.at(rootResults[0]);
-  truthTable = std::move(result);
   return *truthTable;
 }
 
@@ -365,8 +422,57 @@ Cut Cut::reRoot(Operation *root) const {
 }
 
 //===----------------------------------------------------------------------===//
+// MatchedPattern
+//===----------------------------------------------------------------------===//
+
+ArrayRef<DelayType> MatchedPattern::getArrivalTimes() const {
+  assert(pattern && "Pattern must be set to get arrival time");
+  return arrivalTimes;
+}
+
+DelayType MatchedPattern::getArrivalTime(unsigned index) const {
+  assert(pattern && "Pattern must be set to get arrival time");
+  return arrivalTimes[index];
+}
+
+const CutRewritePattern *MatchedPattern::getPattern() const {
+  assert(pattern && "Pattern must be set to get the pattern");
+  return pattern;
+}
+
+Cut *MatchedPattern::getCut() const {
+  assert(cut && "Cut must be set to get the cut");
+  return cut;
+}
+
+double MatchedPattern::getArea() const {
+  assert(pattern && "Pattern must be set to get area");
+  return pattern->getArea(*cut);
+}
+
+DelayType MatchedPattern::getDelay(unsigned inputIndex,
+                                   unsigned outputIndex) const {
+  assert(pattern && "Pattern must be set to get delay");
+  return pattern->getDelay(inputIndex, outputIndex);
+}
+
+//===----------------------------------------------------------------------===//
 // CutSet
 //===----------------------------------------------------------------------===//
+
+bool CutSet::isMatched() const {
+  return matchedPattern.has_value() && matchedPattern->getPattern();
+}
+
+std::optional<MatchedPattern> CutSet::getMatchedPattern() const {
+  return matchedPattern;
+}
+
+Cut *CutSet::getMatchedCut() {
+  assert(isMatched() &&
+         "Matched pattern must be set before getting matched cut");
+  return matchedPattern->getCut();
+}
 
 unsigned CutSet::size() const { return cuts.size(); }
 
@@ -377,7 +483,9 @@ void CutSet::addCut(Cut cut) {
 
 ArrayRef<Cut> CutSet::getCuts() const { return cuts; }
 
-void CutSet::finalize(const CutRewriterOptions &options) {
+void CutSet::finalize(
+    const CutRewriterOptions &options,
+    llvm::function_ref<std::optional<MatchedPattern>(Cut &)> matchCut) {
   DenseSet<std::pair<ArrayRef<Value>, Operation *>> uniqueCuts;
   unsigned uniqueCount = 0;
   for (unsigned i = 0; i < cuts.size(); ++i) {
@@ -424,7 +532,67 @@ void CutSet::finalize(const CutRewriterOptions &options) {
     cuts.resize(options.maxCutSizePerRoot);
   }
 
+  // Find the best matching pattern for this cut set
+  for (auto &cut : cuts) {
+    // Match the cut against the pattern set
+    auto matchResult = matchCut(cut);
+    if (!matchResult)
+      continue;
+
+    if (!matchedPattern ||
+        compareDelayAndArea(options.strategy, matchResult->getArea(),
+                            matchResult->getArrivalTimes(),
+                            matchedPattern->getArea(),
+                            matchedPattern->getArrivalTimes())) {
+      // Found a better matching pattern
+      matchedPattern = matchResult;
+    }
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Finalized cut set with " << cuts.size() << " cuts and "
+                 << (matchedPattern
+                         ? "matched pattern to " +
+                               matchedPattern->getPattern()->getPatternName()
+                         : "no matched pattern")
+                 << "\n";
+  });
+
   isFrozen = true; // Mark the cut set as frozen
+}
+
+//===----------------------------------------------------------------------===//
+// CutRewritePattern
+//===----------------------------------------------------------------------===//
+
+bool CutRewritePattern::useTruthTableMatcher(
+    SmallVectorImpl<NPNClass> &matchingNPNClasses) const {
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// CutRewritePatternSet
+//===----------------------------------------------------------------------===//
+
+CutRewritePatternSet::CutRewritePatternSet(
+    llvm::SmallVector<std::unique_ptr<CutRewritePattern>, 4> patterns)
+    : patterns(std::move(patterns)) {
+  // Initialize the NPN to pattern map
+  for (auto &pattern : this->patterns) {
+    SmallVector<NPNClass, 2> npnClasses;
+    if (pattern->useTruthTableMatcher(npnClasses)) {
+      for (auto npnClass : npnClasses) {
+        // Create a NPN class from the truth table
+        npnToPatternMap[{npnClass.truthTable.table,
+                         npnClass.truthTable.numInputs}]
+            .push_back(std::make_pair(std::move(npnClass), pattern.get()));
+      }
+    } else {
+      // If the pattern does not use truth table matcher, add it to the
+      // non-truth table patterns
+      nonTruthTablePatterns.push_back(pattern.get());
+    }
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -497,7 +665,7 @@ LogicalResult CutEnumerator::visitLogicOp(Operation *logicOp) {
   // Schedule cut set finalization when exiting this scope
   auto prune = llvm::make_scope_exit([&]() {
     // Finalize cut set: remove duplicates, limit size, and match patterns
-    resultCutSet->finalize(options);
+    resultCutSet->finalize(options, matchCut);
   });
 
   // Handle unary operations
@@ -577,4 +745,226 @@ const CutSet *CutEnumerator::getCutSet(Value value) {
   }
 
   return it->second.get();
+}
+
+//===----------------------------------------------------------------------===//
+// CutRewriter
+//===----------------------------------------------------------------------===//
+
+LogicalResult CutRewriter::run(Operation *topOp) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "Starting Cut Rewriter\n";
+    llvm::dbgs() << "Mode: "
+                 << (OptimizationStrategyArea == options.strategy ? "area"
+                                                                  : "timing")
+                 << "\n";
+    llvm::dbgs() << "Max input size: " << options.maxCutInputSize << "\n";
+    llvm::dbgs() << "Max cut size: " << options.maxCutSizePerRoot << "\n";
+    llvm::dbgs() << "Max cuts per node: " << options.maxCutSizePerRoot << "\n";
+  });
+
+  // Currrently we don't support patterns with multiple outputs.
+  // So check that.
+  // TODO: This must be removed when we support multiple outputs.
+  for (auto &pattern : patterns.patterns) {
+    if (pattern->getNumOutputs() > 1) {
+      return mlir::emitError(pattern->getLoc(),
+                             "Cut rewriter does not support patterns with "
+                             "multiple outputs yet");
+    }
+  }
+
+  // First sort the operations topologically to ensure we can process them
+  // in a valid order.
+  if (failed(topologicallySortLogicNetwork(topOp)))
+    return failure();
+
+  // Enumerate cuts for all nodes
+  if (failed(enumerateCuts(topOp)))
+    return failure();
+
+  // Select best cuts and perform mapping
+  if (failed(runBottomUpRewrite(topOp)))
+    return failure();
+
+  return success();
+}
+
+LogicalResult CutRewriter::enumerateCuts(Operation *topOp) {
+  LLVM_DEBUG(llvm::dbgs() << "Enumerating cuts...\n");
+
+  return cutEnumerator.enumerateCuts(
+      topOp, [&](Cut &cut) -> std::optional<MatchedPattern> {
+        // Match the cut against the patterns
+        return patternMatchCut(cut);
+      });
+}
+
+ArrayRef<std::pair<NPNClass, const CutRewritePattern *>>
+CutRewriter::getMatchingPatternFromTruthTable(const Cut &cut) const {
+  if (patterns.npnToPatternMap.empty())
+    return {};
+
+  auto &npnClass = cut.getNPNClass();
+  auto it = patterns.npnToPatternMap.find(
+      {npnClass.truthTable.table, npnClass.truthTable.numInputs});
+  if (it == patterns.npnToPatternMap.end())
+    return {};
+  return it->getSecond();
+}
+
+std::optional<MatchedPattern> CutRewriter::patternMatchCut(Cut &cut) {
+  if (cut.isTrivialCut())
+    return {};
+
+  const CutRewritePattern *bestPattern = nullptr;
+  SmallVector<DelayType, 4> inputArrivalTimes;
+  SmallVector<DelayType, 2> bestArrivalTimes;
+  inputArrivalTimes.reserve(cut.getInputSize());
+  bestArrivalTimes.reserve(cut.getOutputSize());
+
+  // Compute arrival times for each input.
+  for (auto input : cut.inputs) {
+    assert(input.getType().isInteger(1));
+    if (isAlwaysCutInput(input)) {
+      // If the input is a primary input, it has no delay.
+      // TODO: This doesn't consider a global delay. Need to capture
+      // `arrivalTime` on the IR to make the primary input delays visible.
+      inputArrivalTimes.push_back(0);
+      continue;
+    }
+    auto *cutSet = cutEnumerator.getCutSet(input);
+    assert(cutSet && "Input must have a valid cut set");
+
+    auto matchedPattern = cutSet->getMatchedPattern();
+    // If there is no matching pattern, it means it's not possilbe to use the
+    // input in the cut rewriting. So abort early.
+    if (!matchedPattern)
+      return {};
+
+    // This must be a block argument must have been a cut input.
+    auto resultNumber = cast<mlir::OpResult>(input);
+    inputArrivalTimes.push_back(
+        matchedPattern->getArrivalTime(resultNumber.getResultNumber()));
+  }
+
+  auto computeArrivalTimeAndPickBest =
+      [&](const CutRewritePattern *pattern,
+          llvm::function_ref<unsigned(unsigned)> mapIndex) {
+        SmallVector<DelayType, 2> outputArrivalTimes;
+        // Compute the maximum delay for each output from inputs.
+        for (unsigned outputIndex = 0, outputSize = cut.getOutputSize();
+             outputIndex < outputSize; ++outputIndex) {
+          // Compute the arrival time for this outpu.
+          DelayType outputArrivalTime = 0;
+          for (unsigned inputIndex = 0, inputSize = cut.getInputSize();
+               inputIndex < inputSize; ++inputIndex) {
+            // Map pattern input i to cut input through NPN transformations
+            unsigned cutOriginalInput = mapIndex(inputIndex);
+            outputArrivalTime =
+                std::max(outputArrivalTime,
+                         pattern->getDelay(cutOriginalInput, outputIndex) +
+                             inputArrivalTimes[cutOriginalInput]);
+          }
+
+          outputArrivalTimes.push_back(outputArrivalTime);
+        }
+
+        // Update the arrival time
+        if (!bestPattern ||
+            compareDelayAndArea(options.strategy, pattern->getArea(cut),
+                                outputArrivalTimes, bestPattern->getArea(cut),
+                                bestArrivalTimes)) {
+          LLVM_DEBUG({
+            llvm::dbgs() << "== Matched Pattern ==============\n";
+            llvm::dbgs() << "Matching cut: \n";
+            cut.dump(llvm::dbgs());
+            llvm::dbgs() << "Found better pattern: "
+                         << pattern->getPatternName();
+            llvm::dbgs() << " with area: " << pattern->getArea(cut);
+            llvm::dbgs() << " and input arrival times: ";
+            for (unsigned i = 0; i < inputArrivalTimes.size(); ++i) {
+              llvm::dbgs() << " " << inputArrivalTimes[i];
+            }
+            llvm::dbgs() << " and arrival times: ";
+
+            for (auto arrivalTime : outputArrivalTimes) {
+              llvm::dbgs() << " " << arrivalTime;
+            }
+            llvm::dbgs() << "\n";
+            llvm::dbgs() << "== Matched Pattern End ==============\n";
+          });
+
+          bestArrivalTimes = std::move(outputArrivalTimes);
+          bestPattern = pattern;
+        }
+      };
+
+  for (auto &[patternNPN, pattern] : getMatchingPatternFromTruthTable(cut)) {
+    assert(pattern->getNumInputs() == cut.getInputSize() &&
+           "Pattern input size must match cut input size");
+    if (!pattern->match(cut))
+      continue;
+    auto &cutNPN = cut.getNPNClass();
+
+    // Get the input mapping from pattern's NPN class to cut's NPN class
+    SmallVector<unsigned> inputMapping;
+    cutNPN.getInputPermutation(patternNPN, inputMapping);
+    computeArrivalTimeAndPickBest(pattern,
+                                  [&](unsigned i) { return inputMapping[i]; });
+  }
+
+  for (const CutRewritePattern *pattern : patterns.nonTruthTablePatterns)
+    if (pattern->getNumInputs() >= cut.getInputSize() || pattern->match(cut))
+      computeArrivalTimeAndPickBest(pattern, [&](unsigned i) { return i; });
+
+  if (!bestPattern)
+    return std::nullopt; // No matching pattern found
+
+  return MatchedPattern(bestPattern, &cut, std::move(bestArrivalTimes));
+}
+
+LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {
+  LLVM_DEBUG(llvm::dbgs() << "Performing cut-based rewriting...\n");
+  auto cutVector = cutEnumerator.takeVector();
+  cutEnumerator.clear();
+  UnusedOpPruner pruner;
+  PatternRewriter rewriter(top->getContext());
+  for (auto &[value, cutSet] : llvm::reverse(cutVector)) {
+    if (value.use_empty()) {
+      if (auto *op = value.getDefiningOp())
+        pruner.eraseNow(op);
+      continue;
+    }
+
+    if (isAlwaysCutInput(value)) {
+      // If the value is a primary input, skip it
+      LLVM_DEBUG(llvm::dbgs() << "Skipping inputs: " << value << "\n");
+      continue;
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "Cut set for value: " << value << "\n");
+    auto matchedPattern = cutSet->getMatchedPattern();
+    if (!matchedPattern) {
+      if (options.allowNoMatch)
+        continue; // No matching pattern found, skip this value
+      return emitError(value.getLoc(), "No matching cut found for value: ")
+             << value;
+    }
+
+    auto *cut = matchedPattern->getCut();
+    rewriter.setInsertionPoint(cut->getRoot());
+    auto result = matchedPattern->getPattern()->rewrite(rewriter, *cut);
+    if (failed(result))
+      return failure();
+
+    rewriter.replaceOp(cut->getRoot(), *result);
+
+    if (options.attachDebugTiming) {
+      auto array = rewriter.getI64ArrayAttr(matchedPattern->getArrivalTimes());
+      (*result)->setAttr("test.arrival_times", array);
+    }
+  }
+
+  return success();
 }

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -1,0 +1,255 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the TechMapper pass, which performs technology mapping
+// by converting logic network representations (AIG operations) into
+// technology-specific gate implementations using cut-based rewriting.
+//
+// The pass uses a cut-based algorithm with priority cuts and NPN canonical
+// forms for efficient pattern matching. It processes HWModuleOp instances with
+// "hw.techlib.info" attributes as technology library patterns and maps
+// non-library modules to optimal gate implementations based on area and timing
+// optimization strategies.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Synth/Transforms/CutRewriter.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Threading.h"
+#include "mlir/Support/WalkResult.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+namespace circt {
+namespace synth {
+#define GEN_PASS_DEF_TECHMAPPER
+#include "circt/Dialect/Synth/Transforms/SynthPasses.h.inc"
+} // namespace synth
+} // namespace circt
+
+using namespace circt;
+using namespace circt::synth;
+
+#define DEBUG_TYPE "synth-tech-mapper"
+
+//===----------------------------------------------------------------------===//
+// Tech Mapper Pass
+//===----------------------------------------------------------------------===//
+
+static llvm::FailureOr<NPNClass> getNPNClassFromModule(hw::HWModuleOp module) {
+  // Get input and output ports
+  auto inputTypes = module.getInputTypes();
+  auto outputTypes = module.getOutputTypes();
+
+  unsigned numInputs = inputTypes.size();
+  unsigned numOutputs = outputTypes.size();
+  if (numOutputs != 1)
+    return module->emitError(
+        "Modules with multiple outputs are not supported yet");
+
+  // Verify all ports are single bit
+  for (auto type : inputTypes) {
+    if (!type.isInteger(1))
+      return module->emitError("All input ports must be single bit");
+  }
+  for (auto type : outputTypes) {
+    if (!type.isInteger(1))
+      return module->emitError("All output ports must be single bit");
+  }
+
+  if (numInputs > maxTruthTableInputs)
+    return module->emitError("Too many inputs for truth table generation");
+
+  SmallVector<Value> results;
+  results.reserve(numOutputs);
+  // Get the body block of the module
+  auto *bodyBlock = module.getBodyBlock();
+  assert(bodyBlock && "Module must have a body block");
+  // Collect output values from the body block
+  for (auto result : bodyBlock->getTerminator()->getOperands())
+    results.push_back(result);
+
+  // Create a truth table for the module
+  FailureOr<BinaryTruthTable> truthTable = getTruthTable(results, bodyBlock);
+  if (failed(truthTable))
+    return failure();
+
+  return NPNClass::computeNPNCanonicalForm(*truthTable);
+}
+
+/// Simple technology library encoded as a HWModuleOp.
+struct TechLibraryPattern : public CutRewritePattern {
+  TechLibraryPattern(hw::HWModuleOp module, double area,
+                     SmallVector<SmallVector<DelayType, 2>, 4> delay,
+                     NPNClass npnClass)
+      : CutRewritePattern(module->getContext()), area(area),
+        delay(std::move(delay)), module(module), npnClass(std::move(npnClass)) {
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Created Tech Library Pattern for module: "
+                   << module.getModuleName() << "\n"
+                   << "NPN Class: " << npnClass.truthTable.table << "\n"
+                   << "Inputs: " << npnClass.inputPermutation.size() << "\n"
+                   << "Input Negation: " << npnClass.inputNegation << "\n"
+                   << "Output Negation: " << npnClass.outputNegation << "\n";
+    });
+  }
+
+  StringRef getPatternName() const override {
+    auto moduleCp = module;
+    return moduleCp.getModuleName();
+  }
+
+  /// Match the cut set against this library primitive
+  bool match(const Cut &cut) const override {
+    return cut.getNPNClass().equivalentOtherThanPermutation(npnClass);
+  }
+
+  /// Enable truth table matching for this pattern
+  bool useTruthTableMatcher(
+      SmallVectorImpl<NPNClass> &matchingNPNClasses) const override {
+    matchingNPNClasses.push_back(npnClass);
+    return true;
+  }
+
+  /// Rewrite the cut set using this library primitive
+  llvm::FailureOr<Operation *> rewrite(mlir::OpBuilder &builder,
+                                       Cut &cut) const override {
+    // Create a new instance of the module
+    SmallVector<Value> inputs;
+    cut.getPermutatedInputs(npnClass, inputs);
+
+    // TODO: Give a better name to the instance
+    auto instanceOp = builder.create<hw::InstanceOp>(
+        cut.getRoot()->getLoc(), module, "mapped", ArrayRef<Value>(inputs));
+    return instanceOp.getOperation();
+  }
+
+  double getArea(const Cut &cut) const override { return area; }
+
+  DelayType getDelay(unsigned inputIndex, unsigned outputIndex) const override {
+    return delay[inputIndex][outputIndex];
+  }
+
+  unsigned getNumInputs() const override {
+    return static_cast<hw::HWModuleOp>(module).getNumInputPorts();
+  }
+
+  unsigned getNumOutputs() const override {
+    return static_cast<hw::HWModuleOp>(module).getNumOutputPorts();
+  }
+
+  LocationAttr getLoc() const override {
+    auto module = this->module;
+    return module.getLoc();
+  }
+
+private:
+  const double area;
+  const SmallVector<SmallVector<DelayType, 2>, 4> delay;
+  hw::HWModuleOp module;
+  NPNClass npnClass;
+};
+
+namespace {
+struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
+  using TechMapperBase<TechMapperPass>::TechMapperBase;
+
+  void runOnOperation() override {
+    auto module = getOperation();
+
+    SmallVector<std::unique_ptr<CutRewritePattern>> libraryPatterns;
+
+    unsigned maxInputSize = 0;
+    // Consider modules with the "hw.techlib.info" attribute as library
+    // modules.
+    // TODO: This attribute should be replaced with a more structured
+    // representation of technology library information. Specifically, we should
+    // have a dedicated operation for technology library.
+    SmallVector<hw::HWModuleOp> nonLibraryModules;
+    for (auto hwModule : module.getOps<hw::HWModuleOp>()) {
+      auto techInfo =
+          hwModule->getAttrOfType<DictionaryAttr>("hw.techlib.info");
+      if (!techInfo) {
+        // If the module does not have the techlib info, it is not a library
+        // TODO: Run mapping only when the module is under the specific
+        // hierarchy.
+        nonLibraryModules.push_back(hwModule);
+        continue;
+      }
+
+      // Get area and delay attributes
+      auto areaAttr = techInfo.getAs<FloatAttr>("area");
+      auto delayAttr = techInfo.getAs<ArrayAttr>("delay");
+      if (!areaAttr || !delayAttr) {
+        mlir::emitError(hwModule.getLoc())
+            << "Library module " << hwModule.getModuleName()
+            << " must have 'area'(float) and 'delay' (2d array to represent "
+               "input-output pair delay) attributes";
+        signalPassFailure();
+        return;
+      }
+
+      double area = areaAttr.getValue().convertToDouble();
+
+      SmallVector<SmallVector<DelayType, 2>, 4> delay;
+      for (auto delayValue : delayAttr) {
+        auto delayArray = cast<ArrayAttr>(delayValue);
+        SmallVector<DelayType, 2> delayRow;
+        for (auto delayElement : delayArray) {
+          // FIXME: Currently we assume delay is given as integer attributes,
+          // this should be replaced once we have a proper cell op with
+          // dedicated timing attributes with units.
+          delayRow.push_back(
+              cast<mlir::IntegerAttr>(delayElement).getValue().getZExtValue());
+        }
+        delay.push_back(std::move(delayRow));
+      }
+      // Compute NPN Class for the module.
+      auto npnClass = getNPNClassFromModule(hwModule);
+      if (failed(npnClass)) {
+        signalPassFailure();
+        return;
+      }
+
+      // Create a CutRewritePattern for the library module
+      std::unique_ptr<CutRewritePattern> pattern =
+          std::make_unique<TechLibraryPattern>(hwModule, area, std::move(delay),
+                                               std::move(*npnClass));
+
+      // Update the maximum input size
+      maxInputSize = std::max(maxInputSize, pattern->getNumInputs());
+
+      // Add the pattern to the library
+      libraryPatterns.push_back(std::move(pattern));
+    }
+
+    if (libraryPatterns.empty())
+      return markAllAnalysesPreserved();
+
+    CutRewritePatternSet patternSet(std::move(libraryPatterns));
+    CutRewriterOptions options;
+    options.strategy = strategy;
+    options.maxCutInputSize = maxInputSize;
+    options.maxCutSizePerRoot = maxCutsPerRoot;
+    options.attachDebugTiming = test;
+    auto result = mlir::failableParallelForEach(
+        module.getContext(), nonLibraryModules, [&](hw::HWModuleOp hwModule) {
+          LLVM_DEBUG(llvm::dbgs() << "Processing non-library module: "
+                                  << hwModule.getName() << "\n");
+          CutRewriter rewriter(options, patternSet);
+          return rewriter.run(hwModule);
+        });
+    if (failed(result))
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/test/Dialect/Synth/tech-mapper-error.mlir
+++ b/test/Dialect/Synth/tech-mapper-error.mlir
@@ -1,0 +1,77 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(synth-tech-mapper)' %s --split-input-file --verify-diagnostics
+
+hw.module @do_nothing(in %a : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1]]}} {
+    hw.output %a : i1
+}
+
+hw.module @test(in %a : i1, in %b : i1, out result : i1) {
+    // expected-error-re@+1 {{No matching cut found for value: {{.*}}}}
+    %0 = aig.and_inv %a, %b : i1
+    hw.output %0 : i1
+}
+
+// -----
+
+hw.module @do_nothing(in %a : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1]]}} {
+    hw.output %a : i1
+}
+
+// No tech library found so pattern matching is failed.
+hw.module @test(in %a : i1, in %b : i1, out result : i1) {
+    // expected-error-re@+1 {{Cut enumeration supports at most 2 operands, found: 3}}
+    %0 = aig.and_inv %a, %b, %a : i1
+    hw.output %0 : i1
+}
+
+
+// -----
+
+// expected-error@+1 {{Modules with multiple outputs are not supported yet}}
+hw.module @multi_output(in %a : i1, out result1 : i1, out result2 : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+    hw.output %a, %a : i1, i1
+}
+
+hw.module @test(in %a : i1, out result : i1) {
+    hw.output %a : i1
+}
+
+
+// -----
+
+// expected-error@+1 {{All input ports must be single bit}}
+hw.module @multibit(in %a : i2, in %b: i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2]]}} {
+  hw.output %b: i1
+}
+
+// -----
+
+
+// expected-error@+1 {{All input ports must be single bit}}
+hw.module @multibit(in %a : i1, in %b: i2, out result : i2) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2]]}} {
+  hw.output %b: i2
+}
+
+// -----
+
+
+hw.module @multibit(in %a : i1, in %b: i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2]]}} {
+  // expected-error@+1 {{Unsupported operation for truth table simulation}}
+  %0 = comb.xor %a, %b : i1
+  hw.output %0: i1
+}
+
+// -----
+
+// expected-error@+1 {{Too many inputs for truth table generation}}
+hw.module @too_many_input_bits(in %a0 : i1, in %a1 : i1, in %a2 : i1, in %a3 : i1, in %a4 : i1,
+                               in %a5 : i1, in %a6 : i1, in %a7 : i1, in %a8 : i1, in %a9 : i1,
+                               in %a10 : i1, in %a11 : i1, in %a12 : i1, in %a13 : i1, in %a14 : i1,
+                               in %a15 : i1, in %a16 : i1,  out result : i1)
+  attributes {hw.techlib.info = {
+  area = 1.0 : f64,
+  delay = [[1], [1], [1], [1], [1], [1], [1], [1], [1], [1],
+           [1], [1], [1], [1], [1], [1], [1]]
+  }} {
+  %0 = aig.and_inv %a0, %a1 : i1
+  hw.output %0: i1
+}

--- a/test/Dialect/Synth/tech-mapper-error.mlir
+++ b/test/Dialect/Synth/tech-mapper-error.mlir
@@ -16,7 +16,7 @@ hw.module @do_nothing(in %a : i1, out result : i1) attributes {hw.techlib.info =
     hw.output %a : i1
 }
 
-// No tech library found so pattern matching is failed.
+// Test for too many operands in AIG operation
 hw.module @test(in %a : i1, in %b : i1, out result : i1) {
     // expected-error-re@+1 {{Cut enumeration supports at most 2 operands, found: 3}}
     %0 = aig.and_inv %a, %b, %a : i1
@@ -46,9 +46,10 @@ hw.module @multibit(in %a : i2, in %b: i1, out result : i1) attributes {hw.techl
 // -----
 
 
-// expected-error@+1 {{All input ports must be single bit}}
-hw.module @multibit(in %a : i1, in %b: i2, out result : i2) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2]]}} {
-  hw.output %b: i2
+// expected-error@+1 {{All output ports must be single bit}}
+hw.module @multibit(in %a : i1, in %b: i1, out result : i2) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2]]}} {
+  %0 = comb.concat %a, %b : i1, i1
+  hw.output %0: i2
 }
 
 // -----

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -83,7 +83,10 @@ hw.module @area_flow(in %a : i1, in %b : i1, in %c: i1, out result : i1) attribu
 }
 
 // This is a test that needs area-flow to get an optimal result.
+// Area-flow is an optimization technique that considers the area impact
+// of a gate choice on its fanout, not just the gate itself.
 // It produces sub-optimal mappings since currently area-flow is not implemented.
+// See "Heuristics for Area Minimization in LUT-Based FPGA Technology Mapping" for more details. 
 // CHECK-LABEL: @area_flow_test
 hw.module @area_flow_test(in %a : i1, in %b : i1, in %c: i1, out result : i1) {
     // FIXME: If area-flow is implemented, this should be mapped to @area_flow with area strategy.

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -1,0 +1,160 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(synth-tech-mapper{strategy=area test=true max-cuts-per-root=8})' %s | FileCheck %s --check-prefixes CHECK,AREA
+// RUN: circt-opt --pass-pipeline='builtin.module(synth-tech-mapper{strategy=timing test=true max-cuts-per-root=8})' %s | FileCheck %s --check-prefixes CHECK,TIMING
+
+hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+    %0 = aig.and_inv %a, %b : i1
+    hw.output %0 : i1
+}
+
+hw.module @and_inv_n(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+    %0 = aig.and_inv not %a, %b : i1
+    hw.output %0 : i1
+}
+
+hw.module @and_inv_nn(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+    %0 = aig.and_inv not %a, not %b : i1
+    hw.output %0 : i1
+}
+
+// Delay is shorter than @and_inv + @and_inv_n_n. Area is (significantly) larger than @and_inv_n + @and_inv_n_n.
+// Check that we use @and_inv_3 if strategy = timing, and @and_inv_n + @and_inv_n_n if strategy = area.
+hw.module @and_inv_3(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {hw.techlib.info = {area = 10.0 : f64, delay = [[1], [1], [1]]}} {
+    %0 = aig.and_inv %a, %b : i1
+    %1 = aig.and_inv not %0, %c : i1
+    hw.output %1 : i1
+}
+
+// CHECK-LABEL: @test_strategy
+hw.module @test_strategy(in %a : i1, in %b : i1, in %c : i1, out result : i1) {
+    // AREA-NEXT: %[[area_0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %a: i1, b: %b: i1) -> (result: i1) {test.arrival_times = [1]}
+    // AREA-NEXT: %[[area_1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_n(a: %[[area_0]]: i1, b: %c: i1) -> (result: i1) {test.arrival_times = [2]}
+    // AREA-NEXT: hw.output %[[area_1]] : i1
+    // TIMING-NEXT: %[[timing:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_3(a: %a: i1, b: %b: i1, c: %c: i1) -> (result: i1) {test.arrival_times = [1]}
+    // TIMING-NEXT: hw.output %[[timing]] : i1
+    %0 = aig.and_inv %a, %b : i1
+    %1 = aig.and_inv %c, not %0 : i1
+    hw.output %1 : i1
+}
+
+hw.module @permutation(in %a: i1, in %b: i1, in %c: i1, in %d: i1, out result: i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1], [1], [1]]}} {
+    %0 = aig.and_inv %a, not %b : i1
+    %1 = aig.and_inv %c, not %d : i1
+    %2 = aig.and_inv %0, not %1 : i1
+    hw.output %2 : i1
+}
+
+// CHECK-LABEL: hw.module @permutation_test(in %p : i1, in %q : i1, in %r : i1, in %s : i1, out result : i1) {
+hw.module @permutation_test(in %p: i1, in %q: i1, in %r: i1, in %s: i1, out result: i1) {
+    // {a -> s, b -> p, c -> q, d -> r}
+    // CHECK-NEXT: hw.instance "{{.+}}" @permutation(a: %s: i1, b: %p: i1, c: %q: i1, d: %r: i1) -> (result: i1) {test.arrival_times = [1]}
+    %0 = aig.and_inv %s, not %p : i1
+    %1 = aig.and_inv %q, not %r : i1
+    %2 = aig.and_inv %0, not %1 : i1
+    hw.output %2 : i1
+}
+
+hw.module @and_inv_5(in %a : i1, in %b : i1, in %c : i1, in %d : i1, in %e: i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2], [2], [2], [1]]}} {
+    %0 = aig.and_inv not %a, %b, not %c, %d, not %e : i1
+    hw.output %0 : i1
+}
+
+// Make sure truth value is computed correctly for @and_inv_5.
+// CHECK-LABEL: @and_inv_5_test
+hw.module @and_inv_5_test(in %a : i1, in %b : i1, in %c : i1, in %d : i1, in %e: i1, out o1 : i1, out o2 : i1) {
+    %0 = aig.and_inv not %a, %b : i1
+    %1 = aig.and_inv not %c, %d : i1
+    %2 = aig.and_inv %0, %1 : i1
+    %3 = aig.and_inv %2, not %e : i1
+    // CHECK-NEXT: %[[result_0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_5(a: %a: i1, b: %b: i1, c: %c: i1, d: %d: i1, e: %e: i1)
+    %4 = aig.and_inv not %a, not %d : i1
+    %5 = aig.and_inv not %b, %e : i1
+    %6 = aig.and_inv %5, %c : i1
+    %7 = aig.and_inv %6, %4 : i1
+    // CHECK-NEXT: %[[result_1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_5(a: %b: i1, b: %e: i1, c: %a: i1, d: %c: i1, e: %d: i1)
+    
+    hw.output %3, %7 : i1, i1
+    // CHECK-NEXT: hw.output %[[result_0]], %[[result_1]] : i1, i1
+}
+
+hw.module @area_flow(in %a : i1, in %b : i1, in %c: i1, out result : i1) attributes {hw.techlib.info = {area = 1.5 : f64, delay = [[10], [10], [10], [10], [10]]}} {
+    %0 = aig.and_inv not %a, not %b : i1
+    %1 = aig.and_inv not %c, %0 : i1
+    hw.output %1 : i1
+}
+
+// This is a test that needs area-flow to get an optimal result.
+// It produces sub-optimal mappings since currently area-flow is not implemented.
+// CHECK-LABEL: @area_flow_test
+hw.module @area_flow_test(in %a : i1, in %b : i1, in %c: i1, out result : i1) {
+    // FIXME: If area-flow is implemented, this should be mapped to @area_flow with area strategy.
+    // CHECK:       hw.instance {{.*}} @and_inv_nn(
+    // CHECK-NEXT:  hw.instance {{.*}} @and_inv_n(
+    %0 = aig.and_inv not %a, not %b : i1
+    %1 = aig.and_inv not %c, %0 : i1
+    hw.output %1 : i1
+}
+
+// Test primary inputs handling
+// CHECK-LABEL: @primary_inputs_test
+hw.module @primary_inputs_test(in %a : i1, in %b : i1, out result : i1) {
+    // Simple direct mapping - should use @and_inv
+    // CHECK-NEXT: %[[primary:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %a: i1, b: %b: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: hw.output %[[primary]] : i1
+    %0 = aig.and_inv %a, %b : i1
+    hw.output %0 : i1
+}
+
+// Test chain of operations for timing analysis
+// CHECK-LABEL: @timing_chain_test
+hw.module @timing_chain_test(in %a : i1, in %b : i1, in %c : i1, in %d : i1, out result : i1) {
+    // Test that timing is accumulated correctly through the chain
+    // CHECK: hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %a: i1, b: %b: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK: hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %c: i1, b: %d: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK: hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %{{.+}}: i1, b: %{{.+}}: i1) -> (result: i1) {test.arrival_times = [2]}
+    %0 = aig.and_inv %a, %b : i1
+    %1 = aig.and_inv %c, %d : i1
+    %2 = aig.and_inv %0, %1 : i1
+    hw.output %2 : i1
+}
+
+// Test comb.extract and comb.concat handling
+// CHECK-LABEL: @extract_concat_test
+hw.module @extract_concat_test(in %data : i4, in %ctrl : i2, out result : i3) {
+    // Extract individual bits from multi-bit inputs
+    %bit0 = comb.extract %data from 0 : (i4) -> i1
+    %bit1 = comb.extract %data from 1 : (i4) -> i1
+    %bit2 = comb.extract %data from 2 : (i4) -> i1
+    %bit3 = comb.extract %data from 3 : (i4) -> i1
+    
+    %ctrl0 = comb.extract %ctrl from 0 : (i2) -> i1
+    %ctrl1 = comb.extract %ctrl from 1 : (i2) -> i1
+    
+    // Apply some logic using AIG operations
+    %and0 = aig.and_inv %bit0, %bit1 : i1
+    %and1 = aig.and_inv %bit2, not %ctrl0 : i1
+    %and2 = aig.and_inv %bit3, %ctrl1 : i1
+    
+    // Further logic operations
+    %out0 = aig.and_inv %and0, %ctrl0 : i1
+    %out1 = aig.and_inv %and1, not %and0 : i1
+    %out2 = aig.and_inv %and2, %ctrl1 : i1
+    
+    // Concatenate results into multi-bit output
+    %result_concat = comb.concat %out2, %out1, %out0 : i1, i1, i1
+    
+    // CHECK:      %[[bit0:.+]] = comb.extract %data from 0
+    // CHECK-NEXT: %[[bit1:.+]] = comb.extract %data from 1
+    // CHECK-NEXT: %[[bit2:.+]] = comb.extract %data from 2
+    // CHECK-NEXT: %[[bit3:.+]] = comb.extract %data from 3
+    // CHECK-NEXT: %[[ctrl0:.+]] = comb.extract %ctrl from 0
+    // CHECK-NEXT: %[[ctrl1:.+]] = comb.extract %ctrl from 1
+    // CHECK-NEXT: %[[and0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %[[bit0]]: i1, b: %[[bit1]]: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: %[[and1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_n(a: %[[ctrl0]]: i1, b: %[[bit2]]: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: %[[out0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %[[and0]]: i1, b: %[[ctrl0]]: i1) -> (result: i1) {test.arrival_times = [2]}
+    // CHECK-NEXT: %[[out1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_n(a: %[[and0]]: i1, b: %[[and1]]: i1) -> (result: i1) {test.arrival_times = [2]}
+    // CHECK-NEXT: %[[out2:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %[[bit3]]: i1, b: %[[ctrl1]]: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: %[[result:.+]] = comb.concat %[[out2]], %[[out1]], %[[out0]] : i1, i1, i1
+    // CHECK-NEXT: hw.output %[[result]] : i3
+    
+    hw.output %result_concat : i3
+}


### PR DESCRIPTION
This commit implements a cut-based rewriting framework for combinational logic optimization 
and adds the TechMapper pass that uses NPN-equivalence matching with area and delay
metrics to map AIG circuits to technology libraries. The implementation is based on: 
* "Combinational and Sequential Mapping with Priority Cuts", Alan Mishchenko, Sungmin Cho, Satrajit Chatterjee and Robert Brayton, ICCAD 2007
* "Fast Boolean matching based on NPN classification",  Zheng Huang Lingli Wang Yakov Nasikovskiy and Alan Mishchenko, FPT 2013


The Technology Mapping Pass shows how to use this framework in practice by 
mapping generic logic operations to specific hardware gates from a technology 
library. This pass also serves as a test for the framework since 
testing the cut rewriting algorithms directly would be very difficult without 
a real application to exercise them.
The TechMapper pass processes `HWModuleOp` instances with `hw.techlib.info`
attributes as library patterns for now. This must be replaced with more well-designed representation.

The framework is designed to be easily extended with new optimization patterns 
and strategies while maintaining good performance for cut enumeration and 
pattern matching.