### PR TITLE
[Arc] Consider array/struct field alignment when computing state size

### DIFF
--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -79,3 +79,21 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 }
+
+// CHECK-LABEL: arc.model @StructPadding
+// CHECK-NEXT: !arc.storage<4>
+arc.model @StructPadding io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // This !hw.struct is only 11 bits wide, but mapped to an !llvm.struct, each
+  // field gets byte-aligned.
+  arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.struct<tag: i5, sign_ext: i1, offset: i3, size: i2>>
+}
+
+// CHECK-LABEL: arc.model @ArrayPadding
+// CHECK-NEXT: !arc.storage<4>
+arc.model @ArrayPadding io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // This !hw.array is only 18 bits wide, but mapped to an !llvm.array, each
+  // element gets aligned to the next power-of-two.
+  arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.array<2xi9>>
+}


### PR DESCRIPTION
The `StateType` in the Arc dialect currently just defers to `hw::getBitWidth` to compute the number of bits that need to be allocated in the simulator state. This is problematic, since types like structs and arrays have field and element alignment requirements, making LLVM require more bytes for these types than the summed-up bit width would suggest. As a result, the AllocateState pass would allocate 2 bytes for `struct<tag: i5, sign_ext: i1, offset: i3, size: i2>`, even though LLVM would consider the individual fields to be aligned to the nearest byte, making the struct cover 4 bytes in memory.

To fix this issue, make `StateType` more carefully compute the actual number of bits required in simulator storage by requiring all elements of a array or struct to be at least byte-aligned, and to more carefully track the alignmenmt of individual fields. This allows us to predict how many bytes more accurately.

This fixes a few nasty simulation mismatches between Arcilator and Verilator due to the memory corruption that would result from not allocating sufficient storage for arrays and structs.