### PR TITLE
Use isa_and_nonnull for op->getDialect()

### DIFF
--- a/lib/Analysis/DebugAnalysis.cpp
+++ b/lib/Analysis/DebugAnalysis.cpp
@@ -39,7 +39,7 @@ void DebugAnalysisBuilder::run() {
   // Find all debug ops nested under the root op and mark them as debug-only
   // to kickstart the analysis.
   rootOp->walk([&](Operation *op) {
-    if (isa<debug::DebugDialect>(op->getDialect())) {
+    if (isa_and_nonnull<debug::DebugDialect>(op->getDialect())) {
       addDebugOp(op);
       return;
     }
@@ -64,7 +64,7 @@ void DebugAnalysisBuilder::run() {
     // configurable, since certain forms of debug info extraction would be able
     // to pull entire state machines out of the design. For now this just
     // represents the common denominator across all debug infos.
-    if (!isa<hw::HWDialect, comb::CombDialect>(op->getDialect()))
+    if (!isa_and_nonnull<hw::HWDialect, comb::CombDialect>(op->getDialect()))
       continue;
     if (op->hasAttr("name"))
       continue;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -823,7 +823,8 @@ enum class BlockStatementCount { Zero, One, TwoOrMore };
 static BlockStatementCount countStatements(Block &block) {
   unsigned numStatements = 0;
   block.walk([&](Operation *op) {
-    if (isVerilogExpression(op) || isa<ltl::LTLDialect>(op->getDialect()))
+    if (isVerilogExpression(op) ||
+        isa_and_nonnull<ltl::LTLDialect>(op->getDialect()))
       return WalkResult::advance();
     numStatements +=
         TypeSwitch<Operation *, unsigned>(op)
@@ -5777,7 +5778,7 @@ void StmtEmitter::emitStatement(Operation *op) {
 
   // Ignore LTL expressions as they are emitted as part of verification
   // statements. Ignore debug ops as they are emitted as part of debug info.
-  if (isa<ltl::LTLDialect, debug::DebugDialect>(op->getDialect()))
+  if (isa_and_nonnull<ltl::LTLDialect, debug::DebugDialect>(op->getDialect()))
     return;
 
   // Handle HW statements, SV statements.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3016,7 +3016,8 @@ void FIRRTLLowering::addIfProceduralBlock(Value cond,
 FIRRTLLowering::UnloweredOpResult
 FIRRTLLowering::handleUnloweredOp(Operation *op) {
   // FIRRTL operations must explicitly handle their regions.
-  if (!op->getRegions().empty() && isa<FIRRTLDialect>(op->getDialect())) {
+  if (!op->getRegions().empty() &&
+      isa_and_nonnull<FIRRTLDialect>(op->getDialect())) {
     op->emitOpError("must explicitly handle its regions");
     return LoweringFailure;
   }
@@ -3025,7 +3026,7 @@ FIRRTLLowering::handleUnloweredOp(Operation *op) {
   // lowered. This allows us to handled partially lowered inputs, and also allow
   // other FIRRTL operations to spawn additional already-lowered operations,
   // like `hw.output`.
-  if (!isa<FIRRTLDialect>(op->getDialect())) {
+  if (!isa_and_nonnull<FIRRTLDialect>(op->getDialect())) {
     // Push nested operations onto the worklist such that they are lowered.
     for (auto &region : op->getRegions())
       addToWorklist(region);
@@ -5401,7 +5402,8 @@ LogicalResult FIRRTLLowering::fixupLTLOps() {
     for (auto *user : op->getUsers()) {
       if (!usersReported.insert(user).second)
         continue;
-      if (isa<ltl::LTLDialect, verif::VerifDialect>(user->getDialect()))
+      if (isa_and_nonnull<ltl::LTLDialect, verif::VerifDialect>(
+              user->getDialect()))
         continue;
       if (isa<hw::WireOp>(user))
         continue;

--- a/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
+++ b/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
@@ -769,7 +769,7 @@ struct YieldOpLowering : public SMTLoweringPattern<YieldOp> {
       rewriter.replaceOpWithNewOp<LLVM::ReturnOp>(op, adaptor.getValues());
       return success();
     }
-    if (isa<scf::SCFDialect>(op->getParentOp()->getDialect())) {
+    if (isa_and_nonnull<scf::SCFDialect>(op->getParentOp()->getDialect())) {
       rewriter.replaceOpWithNewOp<scf::YieldOp>(op, adaptor.getValues());
       return success();
     }

--- a/lib/Dialect/Arc/Interfaces/RuntimeCostEstimateInterfaceImpl.cpp
+++ b/lib/Dialect/Arc/Interfaces/RuntimeCostEstimateInterfaceImpl.cpp
@@ -48,7 +48,7 @@ class CombRuntimeCostEstimateDialectInterface
       RuntimeCostEstimateDialectInterface;
 
   uint32_t getCostEstimate(mlir::Operation *op) const final {
-    assert(isa<CombDialect>(op->getDialect()));
+    assert(isa_and_nonnull<CombDialect>(op->getDialect()));
 
     return TypeSwitch<Operation *, uint32_t>(op)
         // ExtractOp is either lowered to shift+AND or only an AND operation.
@@ -78,7 +78,7 @@ class HWRuntimeCostEstimateDialectInterface
       RuntimeCostEstimateDialectInterface;
 
   uint32_t getCostEstimate(mlir::Operation *op) const final {
-    assert(circt::isa<HWDialect>(op->getDialect()));
+    assert(isa_and_nonnull<HWDialect>(op->getDialect()));
 
     return llvm::TypeSwitch<mlir::Operation *, uint32_t>(op)
         .Case<ConstantOp, EnumConstantOp, BitcastOp, AggregateConstantOp>(
@@ -97,7 +97,7 @@ class SCFRuntimeCostEstimateDialectInterface
       RuntimeCostEstimateDialectInterface;
 
   uint32_t getCostEstimate(mlir::Operation *op) const final {
-    assert(isa<scf::SCFDialect>(op->getDialect()));
+    assert(isa_and_nonnull<scf::SCFDialect>(op->getDialect()));
 
     return llvm::TypeSwitch<mlir::Operation *, uint32_t>(op)
         .Case<scf::YieldOp>([](auto op) { return 0; })

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -220,7 +220,7 @@ LogicalResult calyx::verifyControlLikeOp(Operation *op) {
   auto parent = op->getParentOp();
 
   if (isa<calyx::EnableOp>(op) &&
-      !isa<calyx::CalyxDialect>(parent->getDialect())) {
+      !isa_and_nonnull<calyx::CalyxDialect>(parent->getDialect())) {
     // Allow embedding calyx.enable ops within other dialects. This is motivated
     // by allowing experimentation with new styles of Calyx lowering. For more
     // info and the historical discussion, see:
@@ -1065,7 +1065,8 @@ static LogicalResult isCombinational(Value value, GroupInterface group) {
     return success();
 
   // Constants and logical operations are OK.
-  if (isa<comb::CombDialect, hw::HWDialect>(definingOp->getDialect()))
+  if (isa_and_nonnull<comb::CombDialect, hw::HWDialect>(
+          definingOp->getDialect()))
     return success();
 
   // Reads to MemoryOp and RegisterOp are combinational. Writes are not.

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -2352,7 +2352,7 @@ static bool assumeMuxCondInOperand(Value muxCond, Value muxValue,
   if (!muxValue.hasOneUse())
     return false;
   auto *op = muxValue.getDefiningOp();
-  if (!op || !isa<CombDialect>(op->getDialect()))
+  if (!op || !isa_and_nonnull<CombDialect>(op->getDialect()))
     return false;
   if (!llvm::is_contained(op->getOperands(), muxCond))
     return false;

--- a/lib/Dialect/LoopSchedule/LoopScheduleOps.cpp
+++ b/lib/Dialect/LoopSchedule/LoopScheduleOps.cpp
@@ -117,7 +117,7 @@ LogicalResult LoopSchedulePipelineOp::verify() {
   Block &conditionBlock = getCondition().front();
   Operation *nonCombinational;
   WalkResult conditionWalk = conditionBlock.walk([&](Operation *op) {
-    if (isa<LoopScheduleDialect>(op->getDialect()))
+    if (isa_and_nonnull<LoopScheduleDialect>(op->getDialect()))
       return WalkResult::advance();
 
     if (!isa<arith::AddIOp, arith::AndIOp, arith::BitcastOp, arith::CmpIOp,

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -369,13 +369,13 @@ LogicalResult PrintFormattedProcOp::verify() {
   if (!parentOp)
     return emitOpError("must be within a procedural region.");
 
-  if (isa<hw::HWDialect>(parentOp->getDialect())) {
+  if (isa_and_nonnull<hw::HWDialect>(parentOp->getDialect())) {
     if (!isa<hw::TriggeredOp>(parentOp))
       return emitOpError("must be within a procedural region.");
     return success();
   }
 
-  if (isa<sv::SVDialect>(parentOp->getDialect())) {
+  if (isa_and_nonnull<sv::SVDialect>(parentOp->getDialect())) {
     if (!parentOp->hasTrait<sv::ProceduralRegion>())
       return emitOpError("must be within a procedural region.");
     return success();


### PR DESCRIPTION
op->getDialect() returns nullptr for unregistered dialect so generally it's preferable to use isa_and_nonnull. 

Fix https://github.com/llvm/circt/issues/8873.