### PR TITLE
[Moore] Add WaitDelayOp, support delay control in ImportVerilog

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -481,6 +481,19 @@ def DetectEventOp : MooreOp<"detect_event", [
   }];
 }
 
+def WaitDelayOp : MooreOp<"wait_delay"> {
+  let summary = "Suspend execution for a given amount of time";
+  let description = [{
+    The `moore.wait_delay` op suspends execution of the current process for the
+    amount of time specified by its operand. Corresponds to the `#` delay
+    control in SystemVerilog.
+
+    See IEEE 1800-2017 § 9.4.1 "Delay control".
+  }];
+  let arguments = (ins TimeType:$delay);
+  let assemblyFormat = [{ $delay attr-dict }];
+}
+
 //===----------------------------------------------------------------------===//
 // Constants
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/TimingControls.cpp
+++ b/lib/Conversion/ImportVerilog/TimingControls.cpp
@@ -96,6 +96,16 @@ struct DelayControlVisitor {
   Location loc;
   OpBuilder &builder;
 
+  // Handle delays.
+  LogicalResult visit(const slang::ast::DelayControl &ctrl) {
+    auto delay = context.convertRvalueExpression(
+        ctrl.expr, moore::TimeType::get(builder.getContext()));
+    if (!delay)
+      return failure();
+    moore::WaitDelayOp::create(builder, loc, delay);
+    return success();
+  }
+
   // Emit an error for all other timing controls.
   template <typename T>
   LogicalResult visit(T &&ctrl) {

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -2081,6 +2081,19 @@ task automatic ImplicitEventControl(ref int x, ref int y);
   @* dummyD(x + y);
 endtask
 
+// CHECK-LABEL: func.func private @DelayControl(
+// CHECK-SAME: [[X:%[^:]+]]: !moore.time
+task automatic DelayControl(time x);
+  // CHECK: [[TMP:%.+]] = moore.constant_time 1234000 fs
+  // CHECK: moore.wait_delay [[TMP]]
+  // CHECK: call @dummyA()
+  #1.234ns dummyA();
+
+  // CHECK: moore.wait_delay [[X]]
+  // CHECK: call @dummyA()
+  #x dummyA();
+endtask
+
 // CHECK-LABEL: func.func private @SignalEventControl(
 // CHECK-SAME: [[X:%[^:]+]]: !moore.ref<i32>
 // CHECK-SAME: [[Y:%[^:]+]]: !moore.ref<i32>

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1001,6 +1001,31 @@ moore.module @EmptyWaitEvent(out out : !moore.l32) {
   moore.output %1 : !moore.l32
 }
 
+
+// CHECK-LABEL: hw.module @WaitDelay
+moore.module @WaitDelay(in %d: !moore.time) {
+  // CHECK: llhd.process {
+  // CHECK:   [[TMP:%.+]] = llhd.constant_time <1000000fs, 0d, 0e>
+  // CHECK:   func.call @dummyA()
+  // CHECK:   llhd.wait delay [[TMP]], ^[[RESUME1:.+]]
+  // CHECK: ^[[RESUME1]]:
+  // CHECK:   func.call @dummyB()
+  // CHECK:   llhd.wait delay %d, ^[[RESUME2:.+]]
+  // CHECK: ^[[RESUME2]]:
+  // CHECK:   func.call @dummyC()
+  // CHECK:   llhd.halt
+  // CHECK: }
+  moore.procedure initial {
+    %0 = moore.constant_time 1000000 fs
+    func.call @dummyA() : () -> ()
+    moore.wait_delay %0
+    func.call @dummyB() : () -> ()
+    moore.wait_delay %d
+    func.call @dummyC() : () -> ()
+    moore.return
+  }
+}
+
 // Just check that block without predecessors are handled without crashing
 // CHECK-LABEL: @NoPredecessorBlockErasure
 moore.module @NoPredecessorBlockErasure(in %clk_i : !moore.l1, in %raddr_i : !moore.array<2 x l5>, out rdata_o : !moore.array<2 x l32>, in %waddr_i : !moore.array<1 x l5>, in %wdata_i : !moore.array<1 x l32>, in %we_i : !moore.l1) {

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -366,6 +366,12 @@ func.func @WaitEvent(%arg0: !moore.i1, %arg1: !moore.i1) {
   return
 }
 
+// CHECK-LABEL: func.func @WaitDelay
+func.func @WaitDelay(%arg0: !moore.time) {
+  // CHECK: moore.wait_delay %arg0
+  moore.wait_delay %arg0
+  return
+}
 
 // CHECK-LABEL: func.func @FormatStrings
 // CHECK-SAME: %arg0: !moore.format_string


### PR DESCRIPTION
Add a `moore.wait_delay` operation to the Moore dialect. This op simply suspends execution for an amount of time determined by its operand. This lowers directly to `llhd.wait delay %0, ^bb0`. Make use of this new op in ImportVerilog by adding support for basic `#10ns` delay control statements.