### PR TITLE
Bump slang to dd16a7947e0586d0541477f1b4b60eda7c986e35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,8 +564,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG dd16a7947e0586d0541477f1b4b60eda7c986e35 # v9.0
-      GIT_SHALLOW ON)
+      GIT_TAG dd16a7947e0586d0541477f1b4b60eda7c986e35)
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
 
     # Force Slang to be built as a static library to avoid messing around with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,7 +564,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG v9.0
+      GIT_TAG dd16a7947e0586d0541477f1b4b60eda7c986e35 # v9.0
       GIT_SHALLOW ON)
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,7 +564,10 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG dd16a7947e0586d0541477f1b4b60eda7c986e35)
+      GIT_TAG dd16a7947e0586d0541477f1b4b60eda7c986e35
+      # Shallow check-out doesn't work if the tag is ref spec is far from HEAD.
+      # GIT_SHALLOW ON
+    )
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
 
     # Force Slang to be built as a static library to avoid messing around with

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1869,7 +1869,7 @@ module GenerateConstructs;
     end
 
     // CHECK: [[TMP:%.+]] = moore.constant 2 : i32
-    // CHECK: %g2 = moore.variable [[TMP]] : <i32>
+    // CHECK: g2 = moore.variable [[TMP]] : <i32>
     if (p == 2) begin
       int g2 = 2;
     end else begin
@@ -1877,7 +1877,7 @@ module GenerateConstructs;
     end
     
     // CHECK: [[TMP:%.+]] = moore.constant 2 : i32
-    // CHECK: %g3 = moore.variable [[TMP]] : <i32>
+    // CHECK: g3 = moore.variable [[TMP]] : <i32>
     case (p)
       2: begin
         int g3 = 2;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1859,11 +1859,11 @@ module GenerateConstructs;
     // CHECK: [[TMP:%.+]] = moore.constant 0
     // CHECK: dbg.variable "i", [[TMP]]
     // CHECK: [[TMP:%.+]] = moore.constant 0
-    // CHECK: %g1 = moore.variable [[TMP]]
+    // CHECK: g1 = moore.variable [[TMP]]
     // CHECK: [[TMP:%.+]] = moore.constant 1
     // CHECK: dbg.variable "i", [[TMP]]
     // CHECK: [[TMP:%.+]] = moore.constant 1
-    // CHECK: moore.variable name "g1" [[TMP]]
+    // CHECK: g1 = moore.variable [[TMP]]
     for (i = 0; i < 2; i = i + 1) begin
       integer g1 = i;
     end


### PR DESCRIPTION
We encountered some failures that were addressed since 9.0 tag, given no API changes seemed like good to bump to new version.