### PR TITLE
[Synth] Add GenericLUTMapper pass for LUT mapping

### DIFF
--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -26,7 +26,24 @@ def TestPriorityCuts : Pass<"synth-test-priority-cuts", "hw::HWModuleOp"> {
   ];
 }
 
-def TechMapper : Pass<"synth-tech-mapper", "mlir::ModuleOp"> {
+class CutRewriterPassBase<string name, string op> : Pass<name, op> {
+  list<Option> baseOptions = [
+    Option<"maxCutsPerRoot", "max-cuts-per-root", "int", "6",
+           "Maximum number of cuts to maintain per node">,
+    Option<"strategy", "strategy", "synth::OptimizationStrategy",
+           /*default=*/"synth::OptimizationStrategyTiming",
+           "Optimization strategy (area vs. timing)",
+           [{::llvm::cl::values(
+             clEnumValN(synth::OptimizationStrategyArea, "area",
+                        "Optimize for area"),
+             clEnumValN(synth::OptimizationStrategyTiming, "timing",
+                        "Optimize for timing")
+           )}]>,
+    Option<"test", "test", "bool", "false", "Attach timing to IR for testing">
+  ];
+}
+
+def TechMapper : CutRewriterPassBase<"synth-tech-mapper", "mlir::ModuleOp"> {
   let summary = "Technology mapping using cut rewriting";
   let description = [{
     This pass performs technology mapping by converting logic network
@@ -41,21 +58,24 @@ def TechMapper : Pass<"synth-tech-mapper", "mlir::ModuleOp"> {
 
     Supports both area and timing optimization strategies.
   }];
-  let options = [
-    Option<"maxCutsPerRoot", "max-cuts-per-root", "int", "6",
-           "Maximum number of cuts to maintain per node">,
-    Option<"strategy", "strategy", "synth::OptimizationStrategy",
-           /*default=*/"synth::OptimizationStrategyTiming",
-           "Optimization strategy (area vs. timing)",
-           [{::llvm::cl::values(
-             clEnumValN(synth::OptimizationStrategyArea, "area",
-                        "Optimize for area"),
-             clEnumValN(synth::OptimizationStrategyTiming, "timing",
-                        "Optimize for timing")
-           )}]>,
-    Option<"test", "test", "bool", "false", "Attach timing to IR for testing">,
-  ];
-  let dependentDialects = ["circt::hw::HWDialect"];
+  let options = baseOptions;
+  let dependentDialects = ["hw::HWDialect"];
 }
+
+def GenericLutMapper : CutRewriterPassBase<"synth-generic-lut-mapper",
+                                           "hw::HWModuleOp"> {
+  let summary = "LUT mapping using generic K-input LUTs";
+  let description = [{
+    This pass performs technology mapping using generic K-input lookup tables
+    (LUTs). It converts combinational logic networks into implementations
+    using K-input LUTs (comb.truth_table) with unit area cost and delay.
+  }];
+  let options = baseOptions # [
+    Option<"maxLutSize", "max-lut-size", "unsigned", /*default=*/"6",
+           "Maximum number of inputs per LUT">
+  ];
+  let dependentDialects = ["comb::CombDialect"];
+}
+
 
 #endif // CIRCT_DIALECT_SYNTH_TRANSFORMS_PASSES_TD

--- a/integration_test/circt-synth/mapping-lec.mlir
+++ b/integration_test/circt-synth/mapping-lec.mlir
@@ -1,12 +1,20 @@
 // REQUIRES: libz3
 // REQUIRES: circt-lec-jit
 
+// RUN: circt-opt %s --convert-aig-to-comb -o %t.comb.mlir
+
 // RUN: circt-synth %s -o %t1.mlir -convert-to-comb --top mul
 // RUN: cat %t1.mlir | FileCheck %s
-// RUN: circt-opt %s --convert-aig-to-comb -o %t2.mlir
-// RUN: circt-lec %t1.mlir %t2.mlir -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_TECHMAP
+// RUN: circt-lec %t1.mlir %t.comb.mlir -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_TECHMAP
 
 // COMB_MUL_TECHMAP: c1 == c2
+
+// RUN: circt-synth %s -o %t.lut.mlir --top mul --lower-to-k-lut 6
+// RUN: cat %t.lut.mlir | FileCheck %s --check-prefix=LUT
+// RUN: circt-opt -convert-aig-to-comb -lower-comb %t.lut.mlir -o %t2.mlir
+// RUN: circt-lec %t2.mlir %t.comb.mlir -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_LUT
+
+// COMB_MUL_LUT: c1 == c2
 
 // Set delay for binary and inv op to 5 so that others will be prioritized
 hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[5], [5]]}} {
@@ -48,6 +56,12 @@ hw.module @some(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.
 // CHECK-DAG: hw.instance {{".+"}} @nand_nand
 // CHECK-DAG: hw.instance {{".+"}} @and_inv_n
 // CHECK-DAG: hw.instance {{".+"}} @and_inv_nn
+// LUT: hw.module @mul
+// LUT: comb.truth_table
+// LUT-NOT: aig.and_inv
+// LUT-NOT: comb.and
+// LUT-NOT: comb.xor
+// LUT-NOT: hw.instance
 hw.module @mul(in %arg0: i4, in %arg1: i4, out add: i4) {
   %0 = comb.mul %arg0, %arg1 : i4
   hw.output %0 : i4

--- a/lib/Dialect/Synth/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Synth/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_circt_dialect_library(CIRCTSynthTransforms
   CutRewriter.cpp
+  GenericLUTMapper.cpp
   SynthesisPipeline.cpp
   TechMapper.cpp
   TestPriorityCuts.cpp

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -581,14 +581,17 @@ CutRewritePatternSet::CutRewritePatternSet(
   for (auto &pattern : this->patterns) {
     SmallVector<NPNClass, 2> npnClasses;
     auto result = pattern->useTruthTableMatcher(npnClasses);
-    (void)result;
-    assert(result && "Currently all patterns must use truth table matcher");
-
-    for (auto npnClass : npnClasses) {
-      // Create a NPN class from the truth table
-      npnToPatternMap[{npnClass.truthTable.table,
-                       npnClass.truthTable.numInputs}]
-          .push_back(std::make_pair(std::move(npnClass), pattern.get()));
+    if (result) {
+      for (auto npnClass : npnClasses) {
+        // Create a NPN class from the truth table
+        npnToPatternMap[{npnClass.truthTable.table,
+                         npnClass.truthTable.numInputs}]
+            .push_back(std::make_pair(std::move(npnClass), pattern.get()));
+      }
+    } else {
+      // If the pattern does not provide NPN classes, we use a special key
+      // to indicate that it should be considered for all cuts.
+      nonTruthTablePatterns.push_back(pattern.get());
     }
   }
 }

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a generic LUT mapper pass using the cut-based rewriting
+// framework. It performs technology mapping by converting combinational logic
+// networks into implementations using K-input lookup tables (LUTs).
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Synth/Transforms/CutRewriter.h"
+#include "circt/Dialect/Synth/Transforms/SynthPasses.h"
+#include "circt/Support/LLVM.h"
+#include "circt/Support/NPNClass.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "synth-generic-lut-mapper"
+
+using namespace circt;
+using namespace circt::synth;
+
+namespace circt {
+namespace synth {
+#define GEN_PASS_DEF_GENERICLUTMAPPER
+#include "circt/Dialect/Synth/Transforms/SynthPasses.h.inc"
+} // namespace synth
+} // namespace circt
+
+//===----------------------------------------------------------------------===//
+// Generic LUT Pattern
+//===----------------------------------------------------------------------===//
+
+/// A generic K-input LUT pattern that can implement any boolean function
+/// with up to K inputs using a lookup table.
+struct GenericLUT : public CutRewritePattern {
+  unsigned k; // Maximum number of inputs for this LUT
+
+  GenericLUT(mlir::MLIRContext *context, unsigned k)
+      : CutRewritePattern(context), k(k) {}
+
+  bool match(const Cut &cut) const override {
+    // This pattern can implement any cut with at most k inputs
+    return cut.getInputSize() <= k && cut.getOutputSize() == 1;
+  }
+
+  llvm::FailureOr<Operation *> rewrite(mlir::OpBuilder &rewriter,
+                                       Cut &cut) const override {
+    // NOTE: Don't use NPN since it's unnecessary.
+    auto truthTable = cut.getTruthTable();
+    LLVM_DEBUG({
+      llvm::dbgs() << "Rewriting cut with " << cut.getInputSize()
+                   << " inputs and " << cut.getInputSize()
+                   << " operations to a generic LUT with " << k << " inputs.\n";
+      cut.dump(llvm::dbgs());
+      llvm::dbgs() << "Truth table details:\n";
+      truthTable.dump(llvm::dbgs());
+    });
+
+    SmallVector<bool> lutTable;
+    // Convert the truth table to a LUT table
+    for (uint32_t i = 0; i < truthTable.table.getBitWidth(); ++i)
+      lutTable.push_back(truthTable.table[i]);
+
+    auto arrayAttr = rewriter.getBoolArrayAttr(
+        lutTable); // Create a boolean array attribute.
+
+    // Reverse the inputs to match the LUT input order
+    SmallVector<Value> lutInputs(cut.inputs.rbegin(), cut.inputs.rend());
+
+    // Generate comb.truth table operation.
+    auto truthTableOp = rewriter.create<comb::TruthTableOp>(
+        cut.getRoot()->getLoc(), lutInputs, arrayAttr);
+
+    // Replace the root operation with the truth table operation
+    return truthTableOp.getOperation();
+  }
+
+  double getArea(const Cut &cut) const override {
+    // Each LUT has unit area regardless of the function it implements
+    return 1.0;
+  }
+
+  DelayType getDelay(unsigned inputIndex, unsigned outputIndex) const override {
+    // All LUTs have unit delay from any input to any output
+    return 1;
+  }
+
+  unsigned getNumInputs() const override { return k; }
+
+  unsigned getNumOutputs() const override { return 1; }
+
+  StringRef getPatternName() const override { return "GenericLUT"; }
+};
+
+//===----------------------------------------------------------------------===//
+// Generic LUT Mapper Pass
+//===----------------------------------------------------------------------===//
+
+struct GenericLUTMapperPass
+    : public impl::GenericLutMapperBase<GenericLUTMapperPass> {
+  using GenericLutMapperBase<GenericLUTMapperPass>::GenericLutMapperBase;
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    // Create the cut rewriter options
+    CutRewriterOptions options;
+    options.strategy = strategy;
+    options.maxCutInputSize = maxLutSize;
+    options.maxCutSizePerRoot = maxCutsPerRoot;
+    options.allowNoMatch = false;
+    options.attachDebugTiming = test;
+
+    // Create the pattern for generic K-LUT
+    SmallVector<std::unique_ptr<CutRewritePattern>, 4> patterns;
+    patterns.push_back(
+        std::make_unique<GenericLUT>(module->getContext(), maxLutSize));
+
+    // Create the pattern set
+    CutRewritePatternSet patternSet(std::move(patterns));
+
+    // Create the cut rewriter
+    CutRewriter rewriter(options, patternSet);
+
+    // Apply the rewriting
+    if (failed(rewriter.run(module)))
+      return signalPassFailure();
+  }
+};

--- a/test/Dialect/Synth/lut-mapper.mlir
+++ b/test/Dialect/Synth/lut-mapper.mlir
@@ -1,0 +1,43 @@
+// FIXME: max-cuts-per-root=20 is due to a lack of non-minimal cut filtering.
+// RUN: circt-opt --pass-pipeline='builtin.module(hw.module(synth-generic-lut-mapper{test=true max-cuts-per-root=20}))' %s | FileCheck %s --check-prefixes CHECK,LUT
+// RUN: circt-opt --pass-pipeline='builtin.module(hw.module(synth-generic-lut-mapper{test=true max-lut-size=2}))' %s | FileCheck %s --check-prefixes CHECK,LUT2
+
+// CHECK:      %[[B_0:.+]] = comb.extract %b from 0 : (i2) -> i1
+// CHECK-NEXT: %[[B_1:.+]] = comb.extract %b from 1 : (i2) -> i1
+// CHECK-NEXT: %[[A_0:.+]] = comb.extract %a from 0 : (i2) -> i1
+// CHECK-NEXT: %[[A_1:.+]] = comb.extract %a from 1 : (i2) -> i1
+
+// LUT-NEXT:   %[[C_0:.+]] = comb.truth_table %[[A_0]], %[[B_0]] -> [false, true, true, false]
+// LUT-SAME:   test.arrival_times = [1]
+// LUT-NEXT:   %[[C_1:.+]] = comb.truth_table %[[B_1]], %[[A_1]], %[[A_0]], %[[B_0]] ->  [false, false, false, true, true, true, true, false, true, true, true, false, false, false, false, true]
+// LUT-SAME:   test.arrival_times = [1]
+// LUT-NEXT:   %[[C_2:.+]] = comb.concat %[[C_1]], %[[C_0]] : i1, i1
+// LUT-NEXT:   hw.output %[[C_2]] : i2
+
+// LUT2:       %[[C_0:.+]] = comb.truth_table %[[A_0]], %[[B_0]] -> [false, false, false, true]
+// LUT2-SAME:   test.arrival_times = [1]
+// LUT2-NEXT:  %[[C_1:.+]] = comb.truth_table %[[A_0]], %[[B_0]] -> [false, true, true, false]
+// LUT2-SAME:  test.arrival_times = [1]
+// LUT2-NEXT:  %[[C_2:.+]] = comb.truth_table %[[C_0]], %[[A_1]] -> [false, true, true, false]
+// LUT2-SAME:  test.arrival_times = [2]
+// LUT2-NEXT:  %[[C_3:.+]] = comb.truth_table %[[C_2]], %[[B_1]] -> [false, true, true, false]
+// LUT2-SAME:  test.arrival_times = [3]
+// LUT2-NEXT:  %[[C_4:.+]] = comb.concat %[[C_3]], %[[C_1]] : i1, i1
+// LUT2-NEXT:  hw.output %[[C_4]] : i2
+hw.module @add(in %a : i2, in %b : i2, out result : i2) {
+  %0 = comb.extract %b from 0 : (i2) -> i1 
+  %1 = comb.extract %b from 1 : (i2) -> i1
+  %2 = comb.extract %a from 0 : (i2) -> i1
+  %3 = comb.extract %a from 1 : (i2) -> i1
+  %4 = aig.and_inv not %0, not %2 : i1
+  %5 = aig.and_inv %0, %2 : i1
+  %6 = aig.and_inv not %4, not %5 : i1
+  %7 = aig.and_inv not %3, not %5 : i1
+  %8 = aig.and_inv %3, %5 : i1
+  %9 = aig.and_inv not %7, not %8 : i1
+  %10 = aig.and_inv not %1, not %9 : i1
+  %11 = aig.and_inv %1, %9 : i1
+  %12 = aig.and_inv not %10, not %11 : i1
+  %13 = comb.concat %12, %6 : i1, i1
+  hw.output %13 : i2
+}

--- a/tools/circt-synth/CMakeLists.txt
+++ b/tools/circt-synth/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(circt-synth
   CIRCTAIGAnalysis
   CIRCTComb
   CIRCTCombToDatapath
+  CIRCTCombTransforms
   CIRCTDatapath
   CIRCTDatapathToComb
   CIRCTDebug


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/circt/pull/8868. 

This commit introduces a pass that performs technology-independent LUT mapping from logic network to generic lookup tables (comb.truth_table). The pass is primarily designed for benchmarking purposes and provides functionality equivalent to ABC's `if -K 6` command for K-LUT mapping.

The pass supports configurable LUT sizes and uses a cut-based rewriting approach to efficiently map combinational logic from AIG nodes to truth tables. It includes options for maximum LUT size and maximum cuts per root node to control the mapping quality and compilation time. The implementation provides technology-independent LUT mapping with configurable K-LUT support (default K=6), cut enumeration with configurable limits, truth table generation for optimal LUT utilization, and seamless integration with the existing synthesis pipeline.
