### PR TITLE
[Synth] Improve cut deduplication and non-minimal cut removal

### DIFF
--- a/integration_test/circt-synth/mapping-lec.mlir
+++ b/integration_test/circt-synth/mapping-lec.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: libz3
 // REQUIRES: circt-lec-jit
 
-// RUN: circt-synth %s -o %t1.mlir -convert-to-comb --top mul
+// RUN: circt-synth %s -o %t1.mlir -convert-to-comb
 // RUN: cat %t1.mlir | FileCheck %s
 // RUN: circt-opt %s --convert-aig-to-comb -o %t2.mlir
 // RUN: circt-lec %t1.mlir %t2.mlir -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_TECHMAP

--- a/integration_test/circt-synth/mapping-lec.mlir
+++ b/integration_test/circt-synth/mapping-lec.mlir
@@ -45,7 +45,8 @@ hw.module @some(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.
 // CHECK-NOT: comb.xor
 // CHECK-DAG: hw.instance {{".+"}} @and_inv
 // CHECK-DAG: hw.instance {{".+"}} @some
-// CHECK-DAG: hw.instance {{".+"}} @nand_nand
+// FIXME: To map @nand_nand it's necessary to implement supergate generation.
+// CHECK-NOT: hw.instance {{".+"}} @nand_nand
 // CHECK-DAG: hw.instance {{".+"}} @and_inv_n
 // CHECK-DAG: hw.instance {{".+"}} @and_inv_nn
 hw.module @mul(in %arg0: i4, in %arg1: i4, out add: i4) {

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -485,7 +485,7 @@ void CutSet::addCut(Cut cut) {
 ArrayRef<Cut> CutSet::getCuts() const { return cuts; }
 
 // Remove duplicate cuts and non-minimal cuts. A cut is non-minimal if there
-// exists another cut that is a subset of it We use a bitset to represent the
+// exists another cut that is a subset of it. We use a bitset to represent the
 // inputs of each cut for efficient subset checking.
 static void removeDuplicateAndNonMinimalCuts(SmallVectorImpl<Cut> &cuts) {
   // First sort the cuts by input size (ascending). This ensures that when we

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -34,6 +34,7 @@
 #include "mlir/IR/Visitors.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/Bitset.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
@@ -483,38 +484,72 @@ void CutSet::addCut(Cut cut) {
 
 ArrayRef<Cut> CutSet::getCuts() const { return cuts; }
 
-void CutSet::finalize(
-    const CutRewriterOptions &options,
-    llvm::function_ref<std::optional<MatchedPattern>(Cut &)> matchCut) {
-  DenseSet<std::pair<ArrayRef<Value>, Operation *>> uniqueCuts;
-  unsigned uniqueCount = 0;
+// Remove duplicate cuts and non-minimal cuts. A cut is non-minimal if there
+// exists another cut that is a subset of it We use a bitset to represent the
+// inputs of each cut for efficient subset checking.
+static void removeDuplicateAndNonMinimalCuts(SmallVectorImpl<Cut> &cuts) {
+  // First sort the cuts by input size (ascending). This ensures that when we
+  // iterate through the cuts, we always encounter smaller cuts first, allowing
+  // us to efficiently check for non-minimality. Stable sort to maintain
+  // relative order of cuts with the same input size.
+  std::stable_sort(cuts.begin(), cuts.end(), [](const Cut &a, const Cut &b) {
+    return a.getInputSize() < b.getInputSize();
+  });
+
+  llvm::SmallVector<llvm::Bitset<64>, 4> inputBitMasks;
+  DenseMap<Value, unsigned> inputIndices;
+  auto getIndex = [&](Value v) -> unsigned {
+    auto it = inputIndices.find(v);
+    if (it != inputIndices.end())
+      return it->second;
+    unsigned index = inputIndices.size();
+    if (LLVM_UNLIKELY(index >= 64))
+      llvm::report_fatal_error(
+          "Too many unique inputs across cuts. Max 64 supported. Consider "
+          "increasing the compile-time constant.");
+    inputIndices[v] = index;
+    return index;
+  };
+
   for (unsigned i = 0; i < cuts.size(); ++i) {
     auto &cut = cuts[i];
     // Create a unique identifier for the cut based on its inputs.
-    auto inputs = cut.inputs.getArrayRef();
+    llvm::Bitset<64> inputsMask;
+    for (auto input : cut.inputs.getArrayRef())
+      inputsMask.set(getIndex(input));
 
-    // If the cut is a duplicate, skip it.
-    if (uniqueCuts.contains({inputs, cut.getRoot()}))
+    bool isUnique = llvm::all_of(
+        inputBitMasks, [&](const llvm::Bitset<64> &existingCutInputMask) {
+          // If the bitset is a subset of the current inputsMask, it is not
+          // unique
+          return (existingCutInputMask & inputsMask) != existingCutInputMask;
+        });
+
+    if (!isUnique)
       continue;
 
-    if (i != uniqueCount) {
-      // Move the unique cut to the front of the vector
-      // This maintains the order of cuts while removing duplicates
-      // by swapping with the last unique cut found.
-      cuts[uniqueCount] = std::move(cuts[i]);
-    }
-
-    // Beaware of lifetime of ArrayRef. `cuts[uniqueCount]` is always valid
-    // after this point.
-    uniqueCuts.insert(
-        {cuts[uniqueCount].inputs.getArrayRef(), cuts[uniqueCount].getRoot()});
-    ++uniqueCount;
+    // If the cut is unique, keep it
+    size_t uniqueCount = inputBitMasks.size();
+    if (i != uniqueCount)
+      cuts[uniqueCount] = std::move(cut);
+    inputBitMasks.push_back(inputsMask);
   }
+
+  unsigned uniqueCount = inputBitMasks.size();
 
   LLVM_DEBUG(llvm::dbgs() << "Original cuts: " << cuts.size()
                           << " Unique cuts: " << uniqueCount << "\n");
+
   // Resize the cuts vector to the number of unique cuts found
   cuts.resize(uniqueCount);
+}
+
+void CutSet::finalize(
+    const CutRewriterOptions &options,
+    llvm::function_ref<std::optional<MatchedPattern>(Cut &)> matchCut) {
+
+  // First, remove duplicate and non-minimal cuts.
+  removeDuplicateAndNonMinimalCuts(cuts);
 
   // Maintain size limit by removing worst cuts
   if (cuts.size() > options.maxCutSizePerRoot) {
@@ -523,7 +558,7 @@ void CutSet::finalize(
     // TODO: Make this configurable.
     // TODO: Implement pruning based on dominance.
 
-    std::sort(cuts.begin(), cuts.end(), [](const Cut &a, const Cut &b) {
+    std::stable_sort(cuts.begin(), cuts.end(), [](const Cut &a, const Cut &b) {
       if (a.getDepth() == b.getDepth())
         return a.getInputSize() < b.getInputSize();
       return a.getDepth() < b.getDepth();

--- a/test/Dialect/Synth/priority-cuts.mlir
+++ b/test/Dialect/Synth/priority-cuts.mlir
@@ -97,3 +97,21 @@ hw.module @test(in %a : i4, in %b : i2, out result : i3) {
 
     hw.output %result_concat : i3
 }
+
+// CHECK-LABEL: Enumerating cuts for module: Issue8885
+// ROOT8: xor0 3 cuts:
+// ROOT8-SAME: {xor0}
+// ROOT8-SAME: {and0, and1}
+// ROOT8-SAME: {b_0, a_0}
+// ROOT2: xor0 2 cuts:
+// ROOT2-SAME: {xor0}
+// ROOT2-SAME: {and0, and1}
+hw.module @Issue8885(in %a : i2, in %b : i2) {
+  %0 = comb.extract %b from 0 {sv.namehint = "b_0"} : (i2) -> i1
+  %1 = comb.extract %b from 1 {sv.namehint = "b_1"} : (i2) -> i1
+  %2 = comb.extract %a from 0 {sv.namehint = "a_0"} : (i2) -> i1
+  %3 = comb.extract %a from 1 {sv.namehint = "a_1"} : (i2) -> i1
+  %4 = aig.and_inv not %0, not %2 {sv.namehint = "and0"} : i1
+  %5 = aig.and_inv %0, %2 {sv.namehint = "and1"} : i1
+  %6 = aig.and_inv not %4, not %5 {sv.namehint = "xor0"} : i1
+}


### PR DESCRIPTION
Improve cut deduplication by removing both duplicate and non-minimal cuts using efficient bitset representation. This reduces redundant cuts in the synthesis pipeline and improves performance. See section 3 of https://dl.acm.org/doi/10.1145/296399.296425.

Fix #8885.