### PR TITLE
[FIRRTL] Lower-Layers: capture operands of subaccess op

### DIFF
--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -219,6 +219,54 @@ firrtl.circuit "Test" {
     }
   }
 
+  // Test that subfield and subindex ops are captured as normal when the input is passive.
+  //
+  // CHECK:      hw.hierpath private @[[vec_path:.+]] [@SubOpsCapturingPassiveInput::@[[vec_sym:.+]]]
+  // CHECK-NEXT: hw.hierpath private @[[bun_path:.+]] [@SubOpsCapturingPassiveInput::@[[bun_sym:.+]]]
+  // CHECK-NEXT: firrtl.module private @SubOpsCapturingPassiveInput_A() {
+  // CHECK-NEXT:   %0 = firrtl.xmr.deref @[[bun_path]] : !firrtl.bundle<a: uint<1>>
+  // CHECK-NEXT:   %1 = firrtl.xmr.deref @[[vec_path]] : !firrtl.vector<uint<1>, 1>
+  // CHECK-NEXT:   %2 = firrtl.subindex %1[0] : !firrtl.vector<uint<1>, 1>
+  // CHECK-NEXT:   %3 = firrtl.subfield %0[a] : !firrtl.bundle<a: uint<1>>
+  // CHECK-NEXT: }
+  // CHECK:      firrtl.module @SubOpsCapturingPassiveInput(
+  // CHECK-SAME:     in %vec: !firrtl.vector<uint<1>, 1> sym @[[vec_sym]],
+  // CHECK-SAME:     in %bun: !firrtl.bundle<a: uint<1>> sym @[[bun_sym]]) {
+  // CHECK-NEXT:   firrtl.instance a {{.*}}
+  // CHECK-NEXT: }
+  firrtl.module @SubOpsCapturingPassiveInput (
+    in %vec: !firrtl.vector<uint<1>, 1>,
+    in %bun: !firrtl.bundle<a: uint<1>>
+  ) {
+    firrtl.layerblock @A {
+      %0 = firrtl.subindex %vec[0] : !firrtl.vector<uint<1>, 1>
+      %1 = firrtl.subfield %bun[a] : !firrtl.bundle<a: uint<1>>
+    }
+  }
+
+  // Test that subaccess op operands are captured as normal when the input is passive.
+  //
+  // CHECK:      hw.hierpath private @[[input_path:.+]] [@SubaccessOpCapturingPassiveInput::@[[input_sym:.+]]]
+  // CHECK-NEXT: hw.hierpath private @[[index_path:.+]] [@SubaccessOpCapturingPassiveInput::@[[index_sym:.+]]]
+  // CHECK-NEXT: firrtl.module private @SubaccessOpCapturingPassiveInput_A() {
+  // CHECK-NEXT:  %0 = firrtl.xmr.deref @[[index_path]] : !firrtl.uint<1>
+  // CHECK-NEXT:  %1 = firrtl.xmr.deref @[[input_path]] : !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT:  %2 = firrtl.subaccess %1[%0] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
+  // CHECK-NEXT: }
+  // CHECK:      firrtl.module @SubaccessOpCapturingPassiveInput(
+  // CHECK-SAME:    in %input: !firrtl.vector<uint<1>, 2> sym @[[input_sym]],
+  // CHECK-SAME:    in %index: !firrtl.uint<1> sym @[[index_sym]]) {
+  // CHECK-NEXT:  firrtl.instance a {{.*}}
+  // CHECK-NEXT: }
+  firrtl.module @SubaccessOpCapturingPassiveInput (
+    in %input: !firrtl.vector<uint<1>, 2>,
+    in %index: !firrtl.uint<1>
+  ) {
+    firrtl.layerblock @A {
+      %0 = firrtl.subaccess %input[%index] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
+    }
+  }
+
   // CHECK:      hw.hierpath private @[[CaptureWhen2_a_path:.+]] [@CaptureWhen2::@[[CaptureWhen2_a_sym:.+]]]
   // CHECK-NEXT: hw.hierpath private @[[CaptureWhen2_cond_path:.+]] [@CaptureWhen2::@[[CaptureWhen2_cond_sym:.+]]]
   // CHECK-NEXT: firrtl.module private @CaptureWhen2_A() {

--- a/test/firtool/lower-layers-with-1dvec-preservation.fir
+++ b/test/firtool/lower-layers-with-1dvec-preservation.fir
@@ -1,0 +1,44 @@
+; RUN: firtool --preserve-aggregate=1d-vec %s | FileCheck %s
+
+FIRRTL version 5.1.0
+
+; End-to-end test ensuring that 1d vector preservation works correctly with
+; lower-layers and the vector subaccess op.
+
+; CHECK: module Foo_Verification_Assert();
+; CHECK:   reg  hasBeenResetReg;
+; CHECK:   initial
+; CHECK:     hasBeenResetReg = 1'bx;
+; CHECK:   always @(posedge Foo.clock) begin
+; CHECK:     if (Foo.reset)
+; CHECK:       hasBeenResetReg <= 1'h1;
+; CHECK:   end // always @(posedge)
+; CHECK:   wire _GEN = ~(hasBeenResetReg === 1'h1 & Foo.reset === 1'h0);
+; CHECK:   assert property (@(posedge Foo.clock) disable iff (_GEN) Foo.in[Foo.addr] == 4'h0);
+; CHECK: endmodule
+
+circuit Foo :
+  layer Verification, bind, "verification" :
+    layer Assert, bind, "verification/assert" :
+
+  public module Foo :
+    input clock : Clock
+    input reset : UInt<1>
+    input in : UInt<4>[4]
+    input addr : UInt<2>
+    output out : UInt<4>[4]
+
+    connect out[0], in[0]
+    connect out[1], in[1]
+    connect out[2], in[2]
+    connect out[3], in[3]
+
+    node _T = eq(in[addr], UInt<1>(0h0))
+    node has_been_reset = intrinsic(circt_has_been_reset : UInt<1>, clock, reset)
+    node disable = eq(has_been_reset, UInt<1>(0h0))
+
+    layerblock Verification :
+      layerblock Assert :
+        node ltl_clock = intrinsic(circt_ltl_clock : UInt<1>, _T, clock)
+        node _T_1 = eq(disable, UInt<1>(0h0))
+        intrinsic(circt_verif_assert, ltl_clock, _T_1)


### PR DESCRIPTION
When we don't need to (or, aren't able to) hoist a subaccess op out of a layer block, because the input operand is passive, we still need to capture the operands.