### PR TITLE
[README] Fix path to MLIR in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Then build and test *CIRCT*:
 cmake -G Ninja . -B build \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DLLVM_ENABLE_ASSERTIONS=ON \
-    -DMLIR_DIR=$PWD/../llvm/build/lib/cmake/mlir \
-    -DLLVM_DIR=$PWD/../llvm/build/lib/cmake/llvm
+    -DMLIR_DIR=$PWD/llvm/build/lib/cmake/mlir \
+    -DLLVM_DIR=$PWD/llvm/build/lib/cmake/llvm
 ninja -C build
 ninja -C build check-circt
 ninja -C build check-circt-integration


### PR DESCRIPTION
Hi, after #8851 PR path to `DMLIR_DIR` and `DLLVM_DIR` contain unnecessary `../`