### PR TITLE
[ExportVerilog] Fix crash for variadic ops with a single operand

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -1196,7 +1196,7 @@ static LogicalResult legalizeHWModule(Block &block,
     // statements.
     // TODO: This is checking the Commutative property, which doesn't seem
     // right in general.  MLIR doesn't have a "fully associative" property.
-    if (op.getNumOperands() > 2 && op.getNumResults() == 1 &&
+    if (op.getNumOperands() != 2 && op.getNumResults() == 1 &&
         op.hasTrait<mlir::OpTrait::IsCommutative>() &&
         mlir::isMemoryEffectFree(&op) && op.getNumRegions() == 0 &&
         op.getNumSuccessors() == 0 &&
@@ -1211,7 +1211,8 @@ static LogicalResult legalizeHWModule(Block &block,
       op.erase();
 
       // Make sure we revisit the newly inserted operations.
-      opIterator = Block::iterator(newOps.front());
+      if (!newOps.empty())
+        opIterator = Block::iterator(newOps.front());
       continue;
     }
 

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -343,3 +343,13 @@ hw.module @temporaryWireForReg() {
   %b = sv.reg init %0 : !hw.inout<i1>
   %a = sv.reg init %1 : !hw.inout<i1>
 }
+
+// -----
+
+// CHECK-LABEL:   @VariadicSingleOperand
+// CHECK-SAME:      (in %[[A:.*]] : i1, out b : i1) {
+hw.module @VariadicSingleOperand(in %a : i1, out b: i1) {
+  %0 = comb.and %a : i1
+// CHECK:           hw.output %[[A]] : i1
+  hw.output %0 : i1
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/circt/issues/7698 and hopefully doesn't break anything else :upside_down_face: 