### PR TITLE
[AIGLongestPathAnalysis] Allow comb.truth_table as a unit

### DIFF
--- a/lib/Dialect/AIG/Analysis/LongestPathAnalysis.cpp
+++ b/lib/Dialect/AIG/Analysis/LongestPathAnalysis.cpp
@@ -523,6 +523,8 @@ private:
                       SmallVectorImpl<OpenPath> &results);
   LogicalResult addLogicOp(Operation *op, size_t bitPos,
                            SmallVectorImpl<OpenPath> &results);
+  LogicalResult visit(comb::TruthTableOp op, size_t bitPos,
+                      SmallVectorImpl<OpenPath> &results);
 
   // Constants.
   LogicalResult visit(hw::ConstantOp op, size_t bitPos,
@@ -724,6 +726,16 @@ LogicalResult LocalVisitor::visit(comb::MuxOp op, size_t bitPos,
       failed(addEdge(op.getTrueValue(), bitPos, 1, results)) ||
       failed(addEdge(op.getFalseValue(), bitPos, 1, results)))
     return failure();
+  deduplicatePaths(results);
+  return success();
+}
+
+LogicalResult LocalVisitor::visit(comb::TruthTableOp op, size_t bitPos,
+                                  SmallVectorImpl<OpenPath> &results) {
+  for (auto input : op.getInputs()) {
+    if (failed(addEdge(input, 0, 1, results)))
+      return failure();
+  }
   deduplicatePaths(results);
   return success();
 }
@@ -940,25 +952,25 @@ LogicalResult LocalVisitor::visitValue(Value value, size_t bitPos,
       TypeSwitch<Operation *, LogicalResult>(op)
           .Case<comb::ConcatOp, comb::ExtractOp, comb::ReplicateOp,
                 aig::AndInverterOp, comb::AndOp, comb::OrOp, comb::MuxOp,
-                comb::XorOp, seq::FirRegOp, seq::CompRegOp, hw::ConstantOp,
-                seq::FirMemReadOp, seq::FirMemReadWriteOp, hw::WireOp>(
-              [&](auto op) {
-                size_t idx = results.size();
-                auto result = visit(op, bitPos, results);
-                if (ctx->doTraceDebugPoints())
-                  if (auto name = op->template getAttrOfType<StringAttr>(
-                          "sv.namehint")) {
+                comb::XorOp, comb::TruthTableOp, seq::FirRegOp, seq::CompRegOp,
+                hw::ConstantOp, seq::FirMemReadOp, seq::FirMemReadWriteOp,
+                hw::WireOp>([&](auto op) {
+            size_t idx = results.size();
+            auto result = visit(op, bitPos, results);
+            if (ctx->doTraceDebugPoints())
+              if (auto name =
+                      op->template getAttrOfType<StringAttr>("sv.namehint")) {
 
-                    for (auto i = idx, e = results.size(); i < e; ++i) {
-                      DebugPoint debugPoint({}, value, bitPos, results[i].delay,
-                                            "namehint");
-                      auto newHistory = debugPointFactory->add(
-                          debugPoint, results[i].history);
-                      results[i].history = newHistory;
-                    }
-                  }
-                return result;
-              })
+                for (auto i = idx, e = results.size(); i < e; ++i) {
+                  DebugPoint debugPoint({}, value, bitPos, results[i].delay,
+                                        "namehint");
+                  auto newHistory =
+                      debugPointFactory->add(debugPoint, results[i].history);
+                  results[i].history = newHistory;
+                }
+              }
+            return result;
+          })
           .Case<hw::InstanceOp>([&](hw::InstanceOp op) {
             return visit(op, bitPos, cast<OpResult>(value).getResultNumber(),
                          results);

--- a/test/Dialect/AIG/longest-paths.mlir
+++ b/test/Dialect/AIG/longest-paths.mlir
@@ -99,9 +99,12 @@ hw.module private @compreg(in %a : i1, in %clk : !seq.clock, out x : i1) {
 // expected-remark-re @below {{fanOut=Object($root.x[0]), fanIn=Object($root.cond[0], delay=1, history=[{{.+}}])}}
 // expected-remark-re @below {{fanOut=Object($root.x[0]), fanIn=Object($root.a[0], delay=1, history=[{{.+}}])}}
 // expected-remark-re @below {{fanOut=Object($root.x[0]), fanIn=Object($root.b[0], delay=1, history=[{{.+}}])}}
-hw.module private @comb(in %cond : i1, in %a : i1, in %b : i1, out x : i1) {
+// expected-remark-re @below {{fanOut=Object($root.y[0]), fanIn=Object($root.a[0], delay=1, history=[{{.+}}])}}
+// expected-remark-re @below {{fanOut=Object($root.y[0]), fanIn=Object($root.b[0], delay=1, history=[{{.+}}])}}
+hw.module private @comb(in %cond : i1, in %a : i1, in %b : i1, out x : i1, out y: i1) {
   %r = comb.mux %cond, %a, %b : i1
-  hw.output %r : i1
+  %table = comb.truth_table %a, %b -> [true, false, false, true]
+  hw.output %r, %table: i1, i1
 }
 
 // expected-remark-re @below {{fanOut=Object($root.x[0]), fanIn=Object($root.a[0], delay=2, history=[{{.+}}])}}

--- a/test/circt-synth/path-e2e.mlir
+++ b/test/circt-synth/path-e2e.mlir
@@ -1,10 +1,12 @@
-// RUN: circt-synth %s -output-longest-path=- -top counter | FileCheck %s
+// RUN: circt-synth %s -output-longest-path=- -top counter | FileCheck %s --check-prefixes COMMON,AIG
+// RUN: circt-synth %s -output-longest-path=- -top counter -lower-to-k-lut 6 | FileCheck %s --check-prefixes COMMON,LUT6
 // RUN: circt-synth %s -output-longest-path=- -top counter -output-longest-path-json | FileCheck %s --check-prefix JSON
 
-// CHECK-LABEL: # Longest Path Analysis result for "counter"
-// CHECK-NEXT: Found 288 paths
-// CHECK-NEXT: Found 32 unique fanout points
-// CHECK-NEXT: Maximum path delay: 42
+// COMMON-LABEL: # Longest Path Analysis result for "counter"
+// COMMON-NEXT: Found 288 paths
+// COMMON-NEXT: Found 32 unique fanout points
+// AIG-NEXT: Maximum path delay: 42
+// LUT6-NEXT: Maximum path delay: 17
 // Don't test detailed reports as they are not stable.
 
 // Make sure json is emitted.


### PR DESCRIPTION
This handles truth_tabe op as a unit in the analysis so that we can analysis the post-mapped result