### PR TITLE
[Moore] Add proper conversions between time and integer values

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -512,11 +512,12 @@ def ConstantOp : MooreOp<"constant", [Pure, ConstantLike]> {
   ];
 }
 
-def ConstantTimeOp : MooreOp<"constant_time", [Pure]> {
+def ConstantTimeOp : MooreOp<"constant_time", [Pure, ConstantLike]> {
   let summary = "A constant time value in femtoseconds";
   let arguments = (ins UI64Attr:$value);
   let results = (outs TimeType:$result);
   let assemblyFormat = "$value `fs` attr-dict";
+  let hasFolder = 1;
 }
 
 def StringConstantOp : MooreOp<"string_constant", [Pure]> {
@@ -552,7 +553,7 @@ def RealLiteralOp : MooreOp<"real_constant", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// Casting and Resizing
+// Casting
 //===----------------------------------------------------------------------===//
 
 def ConversionOp : MooreOp<"conversion", [Pure]> {
@@ -649,6 +650,26 @@ def ToBuiltinBoolOp : MooreOp<"to_builtin_bool", [Pure]> {
     $input attr-dict `:` type($input)
   }];
 }
+
+def TimeToLogicOp : MooreOp<"time_to_logic", [Pure]> {
+  let summary = "Convert a time type to an integer number of femtoseconds";
+  let arguments = (ins TimeType:$input);
+  let results = (outs FourValuedI64:$result);
+  let assemblyFormat = "$input attr-dict";
+  let hasFolder = 1;
+}
+
+def LogicToTimeOp : MooreOp<"logic_to_time", [Pure]> {
+  let summary = "Convert an integer number of femtoseconds to a time type";
+  let arguments = (ins FourValuedI64:$input);
+  let results = (outs TimeType:$result);
+  let assemblyFormat = "$input attr-dict";
+  let hasFolder = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Resizing
+//===----------------------------------------------------------------------===//
 
 def TruncOp : MooreOp<"trunc", [
   Pure,
@@ -839,7 +860,6 @@ def SubOp : BinaryOpBase<"sub"> {
 
     See IEEE 1800-2017 § 11.4.3 "Arithmetic operators".
   }];
-
   let hasFolder = 1;
 }
 
@@ -851,6 +871,7 @@ def MulOp : BinaryOpBase<"mul", [Commutative]> {
 
     See IEEE 1800-2017 § 11.4.3 "Arithmetic operators".
   }];
+  let hasFolder = 1;
 }
 
 class DivOpBase<string mnemonic> : BinaryOpBase<mnemonic> {
@@ -863,6 +884,7 @@ class DivOpBase<string mnemonic> : BinaryOpBase<mnemonic> {
 
     See IEEE 1800-2017 § 11.4.3 "Arithmetic operators".
   }];
+  let hasFolder = 1;
 }
 
 def DivUOp : DivOpBase<"divu">;

--- a/include/circt/Dialect/Moore/MooreTypes.h
+++ b/include/circt/Dialect/Moore/MooreTypes.h
@@ -52,6 +52,13 @@ enum class Domain {
   FourValued,
 };
 
+/// Check if a type is an `IntType` type of the given width.
+bool isIntType(Type type, unsigned width);
+/// Check if a type is an `IntType` type of the given domain.
+bool isIntType(Type type, Domain domain);
+/// Check if a type is an `IntType` type of the given width and domain.
+bool isIntType(Type type, unsigned width, Domain domain);
+
 //===----------------------------------------------------------------------===//
 // Unpacked Type
 //===----------------------------------------------------------------------===//
@@ -149,6 +156,10 @@ public:
   /// Get the simple bit vector type equivalent to this packed type. Returns
   /// null if the type does not have a known bit size.
   IntType getSimpleBitVector() const;
+
+  /// Check if this is a `TimeType`, or an aggregate that contains a nested
+  /// `TimeType`.
+  bool containsTimeType() const;
 
 protected:
   using UnpackedType::UnpackedType;

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -454,15 +454,12 @@ def SimpleBitVectorType : MooreType<CPred<[{
 
 /// A single two or four-valued bit.
 def AnySingleBitType : MooreType<CPred<[{
-    llvm::isa<moore::IntType>($_self) &&
-    llvm::cast<moore::IntType>($_self).getWidth() == 1
+    moore::isIntType($_self, 1)
   }]>, "single bit type", "moore::IntType">;
 
 /// A single two-valued bit.
 def BitType : MooreType<CPred<[{
-    llvm::isa<moore::IntType>($_self) &&
-    llvm::cast<moore::IntType>($_self).getWidth() == 1 &&
-    llvm::cast<moore::IntType>($_self).getDomain() == moore::Domain::TwoValued
+    moore::isIntType($_self, 1, moore::Domain::TwoValued)
   }]>, "`bit` type", "moore::IntType"> {
   let builderCall = [{
     IntType::getInt($_builder.getContext(), 1)
@@ -471,15 +468,20 @@ def BitType : MooreType<CPred<[{
 
 /// A two-valued integer.
 def TwoValuedIntType : MooreType<CPred<[{
-    llvm::isa<moore::IntType>($_self) &&
-    llvm::cast<moore::IntType>($_self).getDomain() == moore::Domain::TwoValued
+    moore::isIntType($_self, moore::Domain::TwoValued)
   }]>, "two-valued integer type", "moore::IntType">;
 
 /// A four-valued integer.
 def FourValuedIntType : MooreType<CPred<[{
-    llvm::isa<moore::IntType>($_self) &&
-    llvm::cast<moore::IntType>($_self).getDomain() == moore::Domain::FourValued
+    moore::isIntType($_self, moore::Domain::FourValued)
   }]>, "four-valued integer type", "moore::IntType">;
+
+/// A 64-bit four-valued integer.
+def FourValuedI64 : MooreType<CPred<[{
+    moore::isIntType($_self, 64, moore::Domain::FourValued)
+  }]>, "64-bit four-valued integer type", "moore::IntType"> {
+  let builderCall = "IntType::getLogic($_builder.getContext(), 64)";
+}
 
 /// A packed or unpacked array type with a fixed size.
 def AnyStaticArrayType : MooreType<

--- a/include/circt/Support/FVInt.h
+++ b/include/circt/Support/FVInt.h
@@ -44,6 +44,10 @@ public:
       : FVInt(APInt(numBits, value, isSigned)) {}
 
   /// Construct an `FVInt` from an `APInt`. The result has no X or Z bits.
+  FVInt(APInt &&value)
+      : value(value), unknown(APInt::getZero(value.getBitWidth())) {}
+
+  /// Construct an `FVInt` from an `APInt`. The result has no X or Z bits.
   FVInt(const APInt &value)
       : value(value), unknown(APInt::getZero(value.getBitWidth())) {}
 
@@ -541,6 +545,36 @@ public:
     auto v = *this;
     v *= other;
     return v;
+  }
+
+  /// Compute an unsigned division. If any bits in either integer are unknown,
+  /// the entire result is X. On division by zero the entire result is X. See
+  /// IEEE 1800-2017 § 11.4.3 Arithmetic operators.
+  FVInt udiv(const FVInt &other) const {
+    if (hasUnknown() || other.hasUnknown() || other.isZero())
+      return getAllX(getBitWidth());
+    return value.udiv(other.value);
+  }
+
+  FVInt udiv(uint64_t other) const {
+    if (hasUnknown() || other == 0)
+      return getAllX(getBitWidth());
+    return value.udiv(other);
+  }
+
+  /// Compute a signed division. If any bits in either integer are unknown,
+  /// the entire result is X. On division by zero the entire result is X. See
+  /// IEEE 1800-2017 § 11.4.3 Arithmetic operators.
+  FVInt sdiv(const FVInt &other) const {
+    if (hasUnknown() || other.hasUnknown() || other.isZero())
+      return getAllX(getBitWidth());
+    return value.sdiv(other.value);
+  }
+
+  FVInt sdiv(int64_t other) const {
+    if (hasUnknown() || other == 0)
+      return getAllX(getBitWidth());
+    return value.sdiv(other);
   }
 
   //===--------------------------------------------------------------------===//

--- a/lib/Dialect/Moore/MooreDialect.cpp
+++ b/lib/Dialect/Moore/MooreDialect.cpp
@@ -38,6 +38,9 @@ Operation *MooreDialect::materializeConstant(OpBuilder &builder,
   if (auto intType = dyn_cast<IntType>(type))
     if (auto intValue = dyn_cast<FVIntegerAttr>(value))
       return ConstantOp::create(builder, loc, intType, intValue);
+  if (auto timeType = dyn_cast<TimeType>(type))
+    if (auto timeValue = dyn_cast<IntegerAttr>(value))
+      return ConstantTimeOp::create(builder, loc, timeType, timeValue);
   return nullptr;
 }
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -833,9 +833,8 @@ module Expressions;
     // CHECK: [[TMP5:%.+]] = moore.zext [[TMP4]] : i6 -> i32
     // CHECK: moore.blocking_assign %a, [[TMP5]] : i32
     a = { << 4 { 6'b11_0101 }};
-    // CHECK: [[TMP1:%.+]] = moore.constant -11 : i6
-    // CHECK: [[TMP2:%.+]] = moore.zext [[TMP1]] : i6 -> i32
-    // CHECK: moore.blocking_assign %a, [[TMP2]] : i32
+    // CHECK: [[TMP1:%.+]] = moore.constant 53 : i32
+    // CHECK: moore.blocking_assign %a, [[TMP1]] : i32
     a = { >> 4 { 6'b11_0101 }};
     // CHECK: [[TMP1:%.+]] = moore.constant -3 : i4
     // CHECK: [[TMP2:%.+]] = moore.extract [[TMP1]] from 0 : i4 -> i1
@@ -867,9 +866,8 @@ module Expressions;
     // CHECK: moore.blocking_assign [[TMP1]], [[TMP2]] : i96
     {>>{ a, b, c }} = 96'b1;
     // CHECK: [[TMP1:%.+]] = moore.concat_ref %a, %b, %c : (!moore.ref<i32>, !moore.ref<i32>, !moore.ref<i32>) -> <i96>
-    // CHECK: [[TMP2:%.+]] = moore.constant 31 : i100
-    // CHECK: [[TMP3:%.+]] = moore.trunc [[TMP2]] : i100 -> i96
-    // CHECK: moore.blocking_assign [[TMP1]], [[TMP3]] : i96
+    // CHECK: [[TMP2:%.+]] = moore.constant 31 : i96
+    // CHECK: moore.blocking_assign [[TMP1]], [[TMP2]] : i96
     {>>{ a, b, c }} = 100'b11111;
     // CHECK: [[TMP1:%.+]] = moore.concat_ref %p1, %p2, %p3, %p4 : (!moore.ref<l11>, !moore.ref<l11>, !moore.ref<l11>, !moore.ref<l11>) -> <l44>
     // CHECK: [[TMP2:%.+]] = moore.read %up : <uarray<4 x l11>>
@@ -1525,15 +1523,12 @@ module Expressions;
     struct0 = '{43, 9002};
 
 
-    // CHECK: [[TMP0:%.+]] = moore.constant 43 : i32
-    // CHECK: [[TMP1:%.+]] = moore.sext [[TMP0]] : i32 -> i64
+    // CHECK: [[TMP1:%.+]] = moore.constant 43 : i64
     // CHECK: [[TMP2:%.+]] = moore.read %struct0 : <struct<{a: i32, b: i32}>>
     // CHECK: [[TMP3:%.+]] = moore.packed_to_sbv [[TMP2]] : struct<{a: i32, b: i32}>
     // CHECK: [[TMP4:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP3]] : i64 -> i1
     // CHECK: [[TMP5:%.+]] = moore.zext [[TMP4]] : i1 -> i32
-    // CHECK: [[TMP6:%.+]] = moore.int_to_logic [[TMP5]] : i32
-    // CHECK: [[TMP7:%.+]] = moore.logic_to_int [[TMP6]] : l32
-    // CHECK: moore.blocking_assign %c, [[TMP7]] : i32
+    // CHECK: moore.blocking_assign %c, [[TMP5]] : i32
     c = 43 inside {struct0};
 
     // CHECK: [[TMP0:%.+]] = moore.constant 44
@@ -1625,6 +1620,28 @@ module Conversion;
   // CHECK: [[TMP2:%.+]] = moore.sbv_to_packed [[TMP1]] : struct<{a: i32, b: i32}>
   // CHECK: %f = moore.variable [[TMP2]]
   struct packed { int a; int b; } f = '0;
+endmodule
+
+// CHECK-LABEL: moore.module @TimeConversion1
+module TimeConversion1;
+  timeunit 10fs / 1fs;
+  // CHECK-DAG: [[TMP:%.+]] = moore.constant_time 12340 fs
+  // CHECK: moore.variable [[TMP]] : <time>
+  time t = 1234;
+  // CHECK-DAG: [[TMP:%.+]] = moore.constant 1234 : i32
+  // CHECK: moore.variable [[TMP]] : <i32>
+  int i = 12.34ps;
+endmodule
+
+// CHECK-LABEL: moore.module @TimeConversion2
+module TimeConversion2;
+  timeunit 100fs / 1fs;
+  // CHECK-DAG: [[TMP:%.+]] = moore.constant_time 123400 fs
+  // CHECK: moore.variable [[TMP]] : <time>
+  time t = 1234;
+  // CHECK-DAG: [[TMP:%.+]] = moore.constant 123 : i32
+  // CHECK: moore.variable [[TMP]] : <i32>
+  int i = 12.34ps;
 endmodule
 
 // CHECK-LABEL: moore.module @PortsTop

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -173,3 +173,19 @@ function void foo;
   // expected-error @below {{unsupported expression: element select into}}
   a["foo"] = 1;
 endfunction
+
+// -----
+function void foo;
+  struct packed { time t; } a;
+  int b;
+  // expected-error @below {{contains a time type}}
+  a = b;
+endfunction
+
+// -----
+function void foo;
+  int a;
+  struct packed { time t; } b;
+  // expected-error @below {{contains a time type}}
+  a = b;
+endfunction

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -443,5 +443,9 @@ func.func @TimeConversion(%arg0: !moore.time, %arg1: !moore.l64) {
   moore.packed_to_sbv %arg0 : time
   // CHECK: moore.sbv_to_packed %arg1 : time
   moore.sbv_to_packed %arg1 : time
+  // CHECK: moore.time_to_logic %arg0
+  moore.time_to_logic %arg0
+  // CHECK: moore.logic_to_time %arg1
+  moore.logic_to_time %arg1
   return
 }

--- a/test/Dialect/Moore/canonicalizers.mlir
+++ b/test/Dialect/Moore/canonicalizers.mlir
@@ -105,6 +105,105 @@ func.func @ConstSExt() -> (!moore.i8, !moore.i8, !moore.l8, !moore.l8, !moore.l8
   return %ei0, %ei1, %el0, %el1, %el2, %el3 : !moore.i8, !moore.i8, !moore.l8, !moore.l8, !moore.l8, !moore.l8
 }
 
+// CHECK-LABEL: func.func @ConstTimeToLogic
+func.func @ConstTimeToLogic() -> !moore.l64 {
+  // CHECK-NEXT: moore.constant 1234 : l64
+  %0 = moore.constant_time 1234 fs
+  %1 = moore.time_to_logic %0
+  return %1 : !moore.l64
+}
+
+// CHECK-LABEL: func.func @ConstLogicToTime
+func.func @ConstLogicToTime() -> !moore.time {
+  // CHECK-NEXT: moore.constant_time 1234 fs
+  %0 = moore.constant 1234 : l64
+  %1 = moore.logic_to_time %0
+  return %1 : !moore.time
+}
+
+// CHECK-LABEL: func.func @RedundantTimeLogicConversions
+func.func @RedundantTimeLogicConversions(%arg0: !moore.time, %arg1: !moore.l64) -> (!moore.time, !moore.l64) {
+  // CHECK-NEXT: return %arg0, %arg1
+  %0 = moore.time_to_logic %arg0
+  %1 = moore.logic_to_time %0
+  %2 = moore.logic_to_time %arg1
+  %3 = moore.time_to_logic %2
+  return %1, %3 : !moore.time, !moore.l64
+}
+
+// CHECK-LABEL: func.func @ConstMul
+func.func @ConstMul() -> (!moore.i24, !moore.l24, !moore.l24) {
+  %c2_i24 = moore.constant 2 : i24
+  %c2_l24 = moore.constant 2 : l24
+  %c3_i24 = moore.constant 3 : i24
+  %c3_l24 = moore.constant 3 : l24
+  %cXZ_l24 = moore.constant bXZ : l24
+
+  // CHECK-DAG: [[V0:%.+]] = moore.constant 6 : i24
+  %0 = moore.mul %c2_i24, %c3_i24 : i24
+  // CHECK-DAG: [[V1:%.+]] = moore.constant 6 : l24
+  %1 = moore.mul %c2_l24, %c3_l24 : l24
+  // CHECK-DAG: [[V2:%.+]] = moore.constant hXXXXXX : l24
+  %2 = moore.mul %c2_l24, %cXZ_l24 : l24
+
+  // CHECK: return [[V0]], [[V1]], [[V2]]
+  return %0, %1, %2 : !moore.i24, !moore.l24, !moore.l24
+}
+
+// CHECK-LABEL: func.func @ConstDivU
+func.func @ConstDivU() -> (!moore.i24, !moore.l24, !moore.l24, !moore.l24) {
+  %c6_i24 = moore.constant 6 : i24
+  %c6_l24 = moore.constant 6 : l24
+  %c3_i24 = moore.constant 3 : i24
+  %c3_l24 = moore.constant 3 : l24
+  %cXZ_l24 = moore.constant bXZ : l24
+  %c0_l24 = moore.constant 0 : l24
+
+  // CHECK-DAG: [[I2:%.+]] = moore.constant 2 : i24
+  // CHECK-DAG: [[L2:%.+]] = moore.constant 2 : l24
+  // CHECK-DAG: [[X:%.+]] = moore.constant hXXXXXX : l24
+  %0 = moore.divu %c6_i24, %c3_i24 : i24
+  %1 = moore.divu %c6_l24, %c3_l24 : l24
+  %2 = moore.divu %c6_l24, %cXZ_l24 : l24
+  %3 = moore.divu %c6_l24, %c0_l24 : l24
+
+  // CHECK: return [[I2]], [[L2]], [[X]], [[X]]
+  return %0, %1, %2, %3 : !moore.i24, !moore.l24, !moore.l24, !moore.l24
+}
+
+// CHECK-LABEL: func.func @ConstDivS
+func.func @ConstDivS() -> (!moore.i24, !moore.l24, !moore.i24, !moore.l24, !moore.i24, !moore.l24, !moore.i24, !moore.l24, !moore.l24, !moore.l24) {
+  %c6_i24 = moore.constant 6 : i24
+  %c6_l24 = moore.constant 6 : l24
+  %c3_i24 = moore.constant 3 : i24
+  %c3_l24 = moore.constant 3 : l24
+  %c-6_i24 = moore.constant -6 : i24
+  %c-6_l24 = moore.constant -6 : l24
+  %c-3_i24 = moore.constant -3 : i24
+  %c-3_l24 = moore.constant -3 : l24
+  %cXZ_l24 = moore.constant bXZ : l24
+  %c0_l24 = moore.constant 0 : l24
+
+  // CHECK-DAG: [[I2:%.+]] = moore.constant 2 : i24
+  // CHECK-DAG: [[L2:%.+]] = moore.constant 2 : l24
+  // CHECK-DAG: [[IM2:%.+]] = moore.constant -2 : i24
+  // CHECK-DAG: [[LM2:%.+]] = moore.constant -2 : l24
+  // CHECK-DAG: [[X:%.+]] = moore.constant hXXXXXX : l24
+  %0 = moore.divs %c6_i24, %c3_i24 : i24
+  %1 = moore.divs %c6_l24, %c3_l24 : l24
+  %2 = moore.divs %c6_i24, %c-3_i24 : i24
+  %3 = moore.divs %c6_l24, %c-3_l24 : l24
+  %4 = moore.divs %c-6_i24, %c3_i24 : i24
+  %5 = moore.divs %c-6_l24, %c3_l24 : l24
+  %6 = moore.divs %c-6_i24, %c-3_i24 : i24
+  %7 = moore.divs %c-6_l24, %c-3_l24 : l24
+  %8 = moore.divs %c6_l24, %cXZ_l24 : l24
+  %9 = moore.divs %c6_l24, %c0_l24 : l24
+
+  // CHECK: return [[I2]], [[L2]], [[IM2]], [[LM2]], [[IM2]], [[LM2]], [[I2]], [[L2]], [[X]], [[X]]
+  return %0, %1, %2, %3, %4, %5, %6, %7, %8, %9: !moore.i24, !moore.l24, !moore.i24, !moore.l24, !moore.i24, !moore.l24, !moore.i24, !moore.l24, !moore.l24, !moore.l24
+}
+
 // CHECK-LABEL: moore.module @OptimizeUniquelyAssignedVars
 moore.module @OptimizeUniquelyAssignedVars(in %u: !moore.i42, in %v: !moore.i42, in %w: !moore.i42) {
   // Unique continuous assignments to variables should remove the `ref<T>`


### PR DESCRIPTION
Time values in Verilog are basically just plain 64 bit integers. This is an infinite source of frustration when trying to send time values between units with different timescales. The Moore dialect has a separate `!moore.time` type for this reason, allowing time values to be captured more precisely and converted to the equivalent `!llhd.time`.

To allow users to write `#5`, basically delaying execution for 5 times the local time scale value, add a `moore.time_to_int` and complementary `moore.int_to_time` operation. These allow time values to be cast from and to their equivalent integer number of femtoseconds.

Make type conversions in ImportVerilog more conservative by refusing any conversion between packed and simple bit vector types if the packed type has any nested time value. For trivial casts between an integer and a time value, use the new `moore.time_to_int` and `moore.int_to_time` operations together with a `moore.mul` or `moore.divu` of the integer value by the local timescale value.

Add unsigned and signed division operators to `FVInt`.

Add a bunch of constant folders to the Moore dialect and switch over to `createOrFold` in most conversion functions to produce already-folded IR where possible.

This now allows circt-verilog to process statements like `#5` or `time t = 42`.