### PR TITLE
[ESI] Extend dll dirs on esiaccel module load

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/__init__.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/__init__.py
@@ -2,6 +2,8 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import sys
+import os
 from .accelerator import AcceleratorConnection
 
 from .esiCppAccel import (AppID, Type, BundleType, ChannelType, ArrayType,
@@ -11,3 +13,9 @@ __all__ = [
     "AcceleratorConnection", "AppID", "Type", "BundleType", "ChannelType",
     "ArrayType", "StructType", "BitsType", "UIntType", "SIntType"
 ]
+
+if sys.platform == "win32":
+  # Ensure that ESI libraries are in the dll path on Windows, if users
+  # build against the esiaccel-provided prebuilt CMake/prebuilt libraries.
+  from .utils import get_cmake_dir
+  os.add_dll_directory(str(get_cmake_dir() / ".."))

--- a/lib/Dialect/ESI/runtime/python/esiaccel/__init__.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/__init__.py
@@ -1,7 +1,6 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
 import sys
 import os
 from .accelerator import AcceleratorConnection
@@ -15,7 +14,9 @@ __all__ = [
 ]
 
 if sys.platform == "win32":
-  # Ensure that ESI libraries are in the dll path on Windows, if users
-  # build against the esiaccel-provided prebuilt CMake/prebuilt libraries.
-  from .utils import get_cmake_dir
-  os.add_dll_directory(str(get_cmake_dir() / ".."))
+  """Ensure that ESI libraries are in the dll path on Windows. Necessary to
+  call when users build against the esiaccel-provided prebuilt CMake/prebuilt
+  libraries, before they are loaded via. python.
+  """
+  from .utils import get_dll_dir
+  os.add_dll_directory(str(get_dll_dir()))

--- a/lib/Dialect/ESI/runtime/python/esiaccel/utils.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/utils.py
@@ -40,11 +40,11 @@ def run_cppgen():
   return codegen.run()
 
 
-def get_cmake_dir():
+def get_cmake_dir() -> Path:
   return _thisdir / "cmake"
 
 
-def get_dll_dir():
+def get_dll_dir() -> Path:
   """Return the directory where the ESI dll's are located"""
   import sys
   import os

--- a/lib/Dialect/ESI/runtime/python/esiaccel/utils.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/utils.py
@@ -42,3 +42,13 @@ def run_cppgen():
 
 def get_cmake_dir():
   return _thisdir / "cmake"
+
+
+def get_dll_dir():
+  """Return the directory where the ESI dll's are located"""
+  import sys
+  import os
+  if sys.platform == "win32":
+    return _thisdir
+  else:
+    return _thisdir / "lib"


### PR DESCRIPTION
To ensure that things (especially other pybind packages) which build against ESI libraries have the `ESICppRuntime.dll` freely available upon load time, by adding the `esiaccel` directory to the `dll_directory` list.