### PR TITLE
Use properlyDominates in AffineToLoopSchedule

### DIFF
--- a/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
+++ b/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
@@ -569,7 +569,7 @@ LogicalResult AffineToLoopSchedule::createLoopSchedulePipeline(
   // Create stages along with maps
   for (auto startTime : startTimes) {
     auto group = startGroups[startTime];
-    llvm::sort(group, [&](Operation* a, Operation* b) {
+    llvm::sort(group, [&](Operation *a, Operation *b) {
       return dom.properlyDominates(a, b);
     });
     auto stageTypes = registerTypes[startTime];

--- a/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
+++ b/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
@@ -569,8 +569,9 @@ LogicalResult AffineToLoopSchedule::createLoopSchedulePipeline(
   // Create stages along with maps
   for (auto startTime : startTimes) {
     auto group = startGroups[startTime];
-    llvm::sort(group,
-               [&](Operation *a, Operation *b) { return dom.dominates(a, b); });
+    llvm::sort(group, [&](Operation* a, Operation* b) {
+      return dom.properlyDominates(a, b);
+    });
     auto stageTypes = registerTypes[startTime];
     // Add the induction variable increment in the first stage.
     if (startTime == 0)


### PR DESCRIPTION
dominates does not satisfy strict weak ordering property.

Fixes #8897