### PR TITLE
[Synth] Refactor and improve cut rewriter infrastructure

### DIFF
--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -83,7 +83,7 @@ struct GenericLUT : public CutRewritePattern {
     return truthTableOp.getOperation();
   }
 
-  double getArea(const Cut &cut) const override {
+  double getArea() const override {
     // Each LUT has unit area regardless of the function it implements
     return 1.0;
   }
@@ -92,8 +92,6 @@ struct GenericLUT : public CutRewritePattern {
     // All LUTs have unit delay from any input to any output
     return 1;
   }
-
-  unsigned getNumInputs() const override { return k; }
 
   unsigned getNumOutputs() const override { return 1; }
 

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -132,13 +132,13 @@ struct TechLibraryPattern : public CutRewritePattern {
     return instanceOp.getOperation();
   }
 
-  double getArea(const Cut &cut) const override { return area; }
+  double getArea() const override { return area; }
 
   DelayType getDelay(unsigned inputIndex, unsigned outputIndex) const override {
     return delay[inputIndex][outputIndex];
   }
 
-  unsigned getNumInputs() const override {
+  unsigned getNumInputs() const {
     return static_cast<hw::HWModuleOp>(module).getNumInputPorts();
   }
 
@@ -220,7 +220,7 @@ struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
       }
 
       // Create a CutRewritePattern for the library module
-      std::unique_ptr<CutRewritePattern> pattern =
+      std::unique_ptr<TechLibraryPattern> pattern =
           std::make_unique<TechLibraryPattern>(hwModule, area, std::move(delay),
                                                std::move(*npnClass));
 

--- a/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
+++ b/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+#include <memory>
 
 namespace circt {
 namespace synth {
@@ -35,19 +36,22 @@ using namespace circt::synth;
 
 namespace {
 
-StringRef getTestVariableName(Value value) {
-  if (auto *op = value.getDefiningOp()) {
-    if (auto name = op->getAttrOfType<StringAttr>("sv.namehint"))
-      return name.getValue();
-    return "<unknown>";
+// Dummy pattern that matches any cut.
+struct DummyPattern : public CutRewritePattern {
+  DummyPattern(mlir::MLIRContext *ctx) : CutRewritePattern(ctx) {}
+  bool match(const Cut &cut) const override { return true; }
+  FailureOr<Operation *> rewrite(mlir::OpBuilder &builder,
+                                 Cut &cut) const override {
+    return failure();
   }
 
-  auto blockArg = cast<BlockArgument>(value);
-  auto hwOp = dyn_cast<hw::HWModuleOp>(blockArg.getOwner()->getParentOp());
-  if (!hwOp)
-    return "<unknown>";
-  return hwOp.getInputName(blockArg.getArgNumber());
-}
+  unsigned getNumOutputs() const override { return 1; }
+
+  double getArea() const override { return 1; }
+  DelayType getDelay(unsigned inputIndex, unsigned outputIndex) const override {
+    return 1;
+  }
+};
 
 struct TestPriorityCutsPass
     : public impl::TestPriorityCutsBase<TestPriorityCutsPass> {
@@ -66,42 +70,19 @@ struct TestPriorityCutsPass
     // Currently there is no behavioral difference between timing and area
     // so just test with timing strategy.
     options.strategy = circt::synth::OptimizationStrategyTiming;
-
-    // Create cut enumerator to test priority cuts
+    options.testPriorityCuts = true;
+    SmallVector<std::unique_ptr<CutRewritePattern>, 4> patterns;
+    patterns.push_back(std::make_unique<DummyPattern>(hwModule->getContext()));
+    CutRewritePatternSet patternSet(std::move(patterns));
+    CutRewriter rewriter(options, patternSet);
     CutEnumerator enumerator(options);
     llvm::outs() << "Enumerating cuts for module: " << hwModule.getModuleName()
                  << "\n";
 
-    // Test cut enumeration - this will generate and prioritize cuts
-    auto result = enumerator.enumerateCuts(hwModule);
-
-    if (failed(result)) {
-      LLVM_DEBUG(llvm::dbgs() << "Cut enumeration failed\n");
+    if (failed(rewriter.run(hwModule))) {
       signalPassFailure();
       return;
     }
-
-    // Get the enumerated cuts and report statistics
-    auto cutSets = enumerator.takeVector();
-    for (auto &[value, cutSetPtr] : cutSets) {
-      auto &cutSet = *cutSetPtr;
-      llvm::outs() << getTestVariableName(value) << " "
-                   << cutSet.getCuts().size() << " cuts:";
-      for (const Cut &cut : cutSet.getCuts()) {
-        llvm::outs() << " {";
-        llvm::interleaveComma(cut.inputs, llvm::outs(), [&](Value input) {
-          llvm::outs() << getTestVariableName(input);
-        });
-        llvm::outs() << "}"
-                     << "@t" << cut.getTruthTable().table.getZExtValue() << ""
-                     << "d" << cut.getDepth();
-      }
-      llvm::outs() << "\n";
-    }
-    llvm::outs() << "Cut enumeration completed successfully\n";
-
-    // This is a test pass, so we don't modify the IR
-    markAllAnalysesPreserved();
   }
 };
 

--- a/test/Dialect/Synth/priority-cuts.mlir
+++ b/test/Dialect/Synth/priority-cuts.mlir
@@ -60,19 +60,19 @@ hw.module @test(in %a : i4, in %b : i2, out result : i3) {
     // CHECK-NEXT: a3 1 cuts: {a3}@t2d0
     // CHECK-NEXT: b1 1 cuts: {b1}@t2d0
     // ROOT8-NEXT: and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
-    // ROOT8-NEXT: out0 3 cuts: {out0}@t2d0 {and0, b0}@t8d1 {a0, a1, b0}@t128d2
-    // ROOT8-NEXT: out1 5 cuts: {out1}@t2d0 {and1, and0}@t2d1 {a0, a1, and1}@t112d2 {a2, b0, and0}@t2d2 {a2, b0, a0, a1}@t546d2
-    // ROOT8-NEXT: out2 3 cuts: {out2}@t2d0 {and2, b1}@t8d1 {a3, b1}@t8d2
+    // ROOT8-NEXT: out0 3 cuts: {out0}@t2d0 {a0, a1, b0}@t128d1 {and0, b0}@t8d2
+    // ROOT8-NEXT: out1 5 cuts: {out1}@t2d0 {a2, b0, a0, a1}@t546d1 {and1, and0}@t2d2 {a0, a1, and1}@t112d2 {a2, b0, and0}@t2d2
+    // ROOT8-NEXT: out2 3 cuts: {out2}@t2d0 {a3, b1}@t8d1 {and2, b1}@t8d2
     // Check that the cuts are correctly limited when max-cuts-per-root is set to 2.
     // Currently (depth, input size) is used as the cut priority.
-    // ROOT2:      and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
-    // ROOT2-NEXT: out0 2 cuts: {out0}@t2d0 {and0, b0}@t8d1
-    // ROOT2-NEXT: out1 2 cuts: {out1}@t2d0 {and1, and0}@t2d1
-    // ROOT2-NEXT: out2 2 cuts: {out2}@t2d0 {and2, b1}@t8d1
+    // ROOT2-NEXT: and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
+    // ROOT2-NEXT: out0 2 cuts: {out0}@t2d0 {a0, a1, b0}@t128d1
+    // ROOT2-NEXT: out1 2 cuts: {out1}@t2d0 {a2, b0, a0, a1}@t546d1
+    // ROOT2-NEXT: out2 2 cuts: {out2}@t2d0 {a3, b1}@t8d1
     // INPUT2:    and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
-    // INPUT2-NEXT: out0 2 cuts: {out0}@t2d0 {and0, b0}@t8d1
-    // INPUT2-NEXT: out1 2 cuts: {out1}@t2d0 {and1, and0}@t2d1
-    // INPUT2-NEXT: out2 3 cuts: {out2}@t2d0 {and2, b1}@t8d1 {a3, b1}@t8d2
+    // INPUT2-NEXT: out0 2 cuts: {out0}@t2d0 {and0, b0}@t8d2
+    // INPUT2-NEXT: out1 2 cuts: {out1}@t2d0 {and1, and0}@t2d2
+    // INPUT2-NEXT: out2 3 cuts: {out2}@t2d0 {a3, b1}@t8d1 {and2, b1}@t8d2
     // CHECK-NEXT: Cut enumeration completed successfully
 
     // Extract individual bits from multi-bit inputs
@@ -101,11 +101,11 @@ hw.module @test(in %a : i4, in %b : i2, out result : i3) {
 // CHECK-LABEL: Enumerating cuts for module: Issue8885
 // ROOT8: xor0 3 cuts:
 // ROOT8-SAME: {xor0}
-// ROOT8-SAME: {and0, and1}
 // ROOT8-SAME: {b_0, a_0}
+// ROOT8-SAME: {and0, and1}
 // ROOT2: xor0 2 cuts:
 // ROOT2-SAME: {xor0}
-// ROOT2-SAME: {and0, and1}
+// ROOT2-SAME: {b_0, a_0}
 hw.module @Issue8885(in %a : i2, in %b : i2) {
   %0 = comb.extract %b from 0 {sv.namehint = "b_0"} : (i2) -> i1
   %1 = comb.extract %b from 1 {sv.namehint = "b_1"} : (i2) -> i1

--- a/test/circt-synth/path-e2e.mlir
+++ b/test/circt-synth/path-e2e.mlir
@@ -6,7 +6,7 @@
 // COMMON-NEXT: Found 288 paths
 // COMMON-NEXT: Found 32 unique fanout points
 // AIG-NEXT: Maximum path delay: 42
-// LUT6-NEXT: Maximum path delay: 17
+// LUT6-NEXT: Maximum path delay: 7
 // Don't test detailed reports as they are not stable.
 
 // Make sure json is emitted.


### PR DESCRIPTION
This commit refactors the cut rewriter and implements correct priority sort metric for depth. Previously `depth` of a cut represents a logic depth *within* a cut but this is not correct. What the original paper (ICCAD 2007) proposed was to use arrival time of cut outputs instead.

For that this commit changes to perform cut matching for each cut, and use worst arrival time as a priority of cuts.

LUT6 depth for 16-bit multiplier improved from 17 to 7, which is on per with Yosys/ABC.