### PR TITLE
[ESI] Don't assume __dict__ attribute for all objects

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/types.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/types.py
@@ -245,6 +245,8 @@ class StructType(ESIType):
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     fields_count = 0
     if not isinstance(obj, dict):
+      if not hasattr(obj, "__dict__"):
+        return (False, "must be a dict or have __dict__ attribute")
       obj = obj.__dict__
 
     for (fname, ftype) in self.fields:


### PR DESCRIPTION
... when checking if a given object is valid for `StructType` serialization. E.g., `bytes` objects do not have a `__dict__` attribute.