### PR TITLE
[LLHD] Simplify single-block llhd.process terminated by llhd.halt

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDStructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDStructureOps.td
@@ -205,7 +205,6 @@ def HaltOp : LLHDOp<"halt", [
     attr-dict
   }];
   let hasVerifier = 1;
-  let hasCanonicalizeMethod = 1;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This simplifies an `llhd.process` that has only a single basic block with an `llhd.halt` terminator.
1) Lifts constant-like yield operands of `llhd.halt` operation and replaces uses of `llhd.process` results with them directly.
2) Deduplicates the yield operands of `llhd.halt`.