### PR TITLE
[FIRRTL] Use the defname for deciding bindfile names of extmodules

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -257,6 +257,10 @@ class LowerLayersPass
   void preprocessModule(CircuitNamespace &ns, InstanceGraphNode *node,
                         FModuleOp module);
 
+  /// Get the verilog name of an extmodule, which could be recorded in its
+  /// defname property.
+  StringRef getExtModuleName(FExtModuleOp extModule);
+
   /// Record the supposed bindfiles for any known layers of the ext module.
   void preprocessExtModule(CircuitNamespace &ns, InstanceGraphNode *node,
                            FExtModuleOp extModule);
@@ -1000,6 +1004,12 @@ void LowerLayersPass::preprocessModule(CircuitNamespace &ns,
       buildBindFile(ns, node, b, sym, layer);
 }
 
+StringRef LowerLayersPass::getExtModuleName(FExtModuleOp extModule) {
+  if (auto name = extModule.getDefnameAttr())
+    return name.getValue();
+  return extModule.getName();
+}
+
 void LowerLayersPass::preprocessExtModule(CircuitNamespace &ns,
                                           InstanceGraphNode *node,
                                           FExtModuleOp extModule) {
@@ -1012,7 +1022,7 @@ void LowerLayersPass::preprocessExtModule(CircuitNamespace &ns,
   if (known.empty())
     return;
 
-  auto moduleName = extModule.getModuleName();
+  auto moduleName = getExtModuleName(extModule);
   auto &files = bindFiles[extModule];
   SmallPtrSet<Operation *, 8> seen;
 

--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -316,3 +316,20 @@ circuit Foo:
 
 ; CHECK: FILE "B{{[/\]}}layers-Foo-B.sv"
 ; CHECK: `include "layers-Bar-B.sv"
+
+; // -----
+
+; Check that bindfile for Top should include layers-Bar-A, not layers-Foo-A,
+; respecting the defname of an extmodule.
+
+FIRRTL version 5.1.0
+circuit Top:
+  layer A, bind:
+
+  extmodule Foo knownlayer A:
+    defname = Bar
+
+  public module Top:
+    inst foo of Foo
+
+; CHECK: `include "layers-Bar-A.sv"


### PR DESCRIPTION
Lowerlayers is using the name of an extmodule to determine the name of the extmodule's bindfiles. Instead, we should be using the defname.