### PR TITLE
[ci] Release circt-{opt,synth,test} in firrtl-bin

### DIFF
--- a/.github/bin/uploadReleaseArtifacts.sh
+++ b/.github/bin/uploadReleaseArtifacts.sh
@@ -131,6 +131,19 @@ mapfile -t OPT_OS < <(echo "${OPT_OS[@]}" | tr ' ' '\n' | sort -u)
 # JSON snippets used to configure downstream workflows
 #-------------------------------------------------------------------------------
 
+# For non-full installs, install the following tools.
+binaries=(
+    circt-opt
+    circt-synth
+    circt-test
+    firtool
+    om-linker
+)
+binaryTargets=
+for bin in "${binaries[@]}"; do
+  binaryTargets="$binaryTargets install-$bin"
+done
+
 # Configuration for a run of the static UBTI script.
 configStatic=$(cat <<EOF
 [
@@ -139,7 +152,7 @@ configStatic=$(cat <<EOF
     "llvm_enable_assertions": "$OPT_ASSERTIONS",
     "llvm_force_enable_stats": "ON",
     "run_tests": $OPT_RUN_TESTS,
-    "install_target": "install-firtool install-om-linker",
+    "install_target": "$binaryTargets",
     "package_name_prefix": "firrtl-bin"
   }
 ]
@@ -213,7 +226,7 @@ configNativeFirtool=$(cat <<EOF
 [
   {
     "name": "firtool",
-    "install_target": "install-firtool install-om-linker",
+    "install_target": "$binaryTargets",
     "package_name_prefix": "firrtl-bin",
     "cmake_build_type":"$OPT_CMAKE_BUILD_TYPE",
     "llvm_enable_assertions":"$OPT_ASSERTIONS",


### PR DESCRIPTION
Add additional, useful tools as part of the `firrtl-bin` release package.
This will avoid users having to get one of the "full" installations (and
also deal with the fact that these installations are not truly static).

This has a cost of bloating the `firrtl-bin` tarball.  However, that seems
acceptable given that users may not have easy alternatives for how to get
these tools.
