### PR TITLE
[circt-verilog] Add commandfile input option.

### DIFF
--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -138,6 +138,9 @@ struct ImportVerilogOptions {
 
   /// A list of library files to include in the compilation.
   std::vector<std::string> libraryFiles;
+
+  /// A list of command files to process for compilation.
+  std::vector<std::string> commandFiles;
 };
 
 /// Parse files in a source manager as Verilog source code and populate the

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -181,6 +181,11 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   auto diagClient = std::make_shared<MlirDiagnosticClient>(mlirContext);
   driver.diagEngine.addClient(diagClient);
 
+  for (const auto &value : options.commandFiles)
+    if (!driver.processCommandFiles(value, /*makeRelative=*/true,
+                                    /*separateUnit=*/true))
+      return failure();
+
   // Populate the source manager with the source files.
   // NOTE: This is a bit ugly since we're essentially copying the Verilog
   // source text in memory. At a later stage we'll want to extend slang's

--- a/test/circt-verilog/command-files.sv
+++ b/test/circt-verilog/command-files.sv
@@ -1,0 +1,4 @@
+// RUN: circt-verilog -C %S/include/filelist.f %s | FileCheck %s
+// REQUIRES: slang
+
+// CHECK: hw.module @library_module

--- a/test/circt-verilog/include/filelist.f
+++ b/test/circt-verilog/include/filelist.f
@@ -1,0 +1,2 @@
+library_module.sv
+other.sv

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -267,6 +267,13 @@ struct CLOptions {
           "One or more library files, which are separate compilation units "
           "where modules are not automatically instantiated."),
       cl::value_desc("filename"), cl::Prefix, cl::cat(cat)};
+
+  cl::list<std::string> commandFiles{
+      "C",
+      cl::desc(
+          "One or more library files, which are independent compilation units "
+          "where modules are automatically instantiated."),
+      cl::value_desc("filename"), cl::Prefix, cl::cat(cat)};
 };
 } // namespace
 
@@ -430,6 +437,7 @@ static LogicalResult executeWithSources(MLIRContext *context,
 
   options.singleUnit = opts.singleUnit;
   options.libraryFiles = opts.libraryFiles;
+  options.commandFiles = opts.commandFiles;
 
   // Open the output file.
   std::string errorMessage;
@@ -497,9 +505,11 @@ static LogicalResult executeWithSources(MLIRContext *context,
 }
 
 static LogicalResult execute(MLIRContext *context) {
-  // Default to reading from stdin if no files were provided.
-  if (opts.inputFilenames.empty())
+  // Default to reading from stdin if no files were provided except if
+  // commandfiles were.
+  if (opts.inputFilenames.empty() && opts.commandFiles.empty()) {
     opts.inputFilenames.push_back("-");
+  }
 
   // Auto-detect the input format if it was not explicitly specified.
   if (opts.format.getNumOccurrences() == 0) {
@@ -521,8 +531,12 @@ static LogicalResult execute(MLIRContext *context) {
       detectedFormat = format;
     }
     if (!detectedFormat) {
-      WithColor::error() << "cannot auto-detect input format; use --format\n";
-      return failure();
+      if (!opts.commandFiles.empty()) {
+        detectedFormat = Format::SV;
+      } else {
+        WithColor::error() << "cannot auto-detect input format; use --format\n";
+        return failure();
+      }
     }
     opts.format = *detectedFormat;
   }


### PR DESCRIPTION
This follow behavior of same flag in slang. Goal is to be able to use filelists as inputs rather than specify individual files.