### PR TITLE
[ConvertToArcs] Add llhd.combinational conversion

### DIFF
--- a/include/circt/Conversion/ConvertToArcs.h
+++ b/include/circt/Conversion/ConvertToArcs.h
@@ -13,13 +13,8 @@
 #include <memory>
 
 namespace circt {
-
-#define GEN_PASS_DECL_CONVERTTOARCS
+#define GEN_PASS_DECL_CONVERTTOARCSPASS
 #include "circt/Conversion/Passes.h.inc"
-
-std::unique_ptr<OperationPass<ModuleOp>>
-createConvertToArcsPass(const ConvertToArcsOptions &options = {});
-
 } // namespace circt
 
 #endif // CIRCT_CONVERSION_CONVERTTOARCS_H

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -624,7 +624,7 @@ def HandshakeRemoveBlock : Pass<"handshake-remove-block-structure", "handshake::
 // ConvertToArcs
 //===----------------------------------------------------------------------===//
 
-def ConvertToArcs : Pass<"convert-to-arcs", "mlir::ModuleOp"> {
+def ConvertToArcsPass : Pass<"convert-to-arcs", "mlir::ModuleOp"> {
   let summary = "Outline logic between registers into state transfer arcs";
   let description = [{
     This pass outlines combinational logic between registers into state transfer
@@ -632,7 +632,6 @@ def ConvertToArcs : Pass<"convert-to-arcs", "mlir::ModuleOp"> {
     replaced with an arc invocation, where the register is now represented as a
     latency.
   }];
-  let constructor = "circt::createConvertToArcsPass()";
   let dependentDialects = ["circt::arc::ArcDialect", "circt::hw::HWDialect"];
   let options = [
     Option<"tapRegisters", "tap-registers", "bool", "true",

--- a/lib/Conversion/ConvertToArcs/CMakeLists.txt
+++ b/lib/Conversion/ConvertToArcs/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_conversion_library(CIRCTConvertToArcs
   LINK_LIBS PUBLIC
   CIRCTArc
   CIRCTHW
+  CIRCTLLHD
   CIRCTSeq
   CIRCTSim
   MLIRTransforms

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -302,9 +302,10 @@ hw.module @ObserveWires(in %in1: i32, in %in2: i32, out out: i32) {
 hw.module @OpsWithRegions(in %a: i42, in %b: i42, in %c: i42, in %d: i42, out z: i42) {
   // CHECK-DAG: [[ADD:%.+]] = arc.call [[ARC_ADD]](%a, %b)
   %0 = comb.add %a, %b : i42
-  // CHECK-DAG: [[COMB:%.+]] = llhd.combinational -> i42 {
-  // CHECK-DAG:   [[MUL:%.+]] = comb.mul [[ADD]], %c
-  // CHECK-DAG:   llhd.yield [[MUL]]
+  // CHECK-DAG: [[COMB:%.+]] = arc.execute ([[ADD]], %c : i42, i42) -> (i42) {
+  // CHECK-DAG: ^bb0(%arg0: i42, %arg1: i42):
+  // CHECK-DAG:   [[MUL:%.+]] = comb.mul %arg0, %arg1
+  // CHECK-DAG:   arc.output [[MUL]]
   %1 = llhd.combinational -> i42 {
     %3 = comb.mul %0, %c : i42
     llhd.yield %3 : i42

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -276,7 +276,7 @@ static void populateHwModuleToArcPipeline(PassManager &pm) {
   if (untilReached(UntilArcConversion))
     return;
   {
-    ConvertToArcsOptions opts;
+    ConvertToArcsPassOptions opts;
     opts.tapRegisters = observeRegisters;
     pm.addPass(createConvertToArcsPass(opts));
   }
@@ -640,7 +640,7 @@ int main(int argc, char **argv) {
 
     // Dialect passes:
     arc::registerPasses();
-    registerConvertToArcs();
+    registerConvertToArcsPass();
   }
 
   // Register any pass manager command line options.


### PR DESCRIPTION
Introduce a dialect conversion step into the `ConvertToArcs` pass. We'll use this to map various core dialect operations to Arc-specific ones in the future. As a starting point, add a conversion from `llhd.combinational` to `arc.execute`. This, alongside lowering to LLVM to be added in later PRs, will implement some basic LLHD support in the Arc dialect.