### PR TITLE
[ArcToLLVM] Add arc.execute conversion

### DIFF
--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -641,6 +641,7 @@ int main(int argc, char **argv) {
     // Dialect passes:
     arc::registerPasses();
     registerConvertToArcsPass();
+    registerLowerArcToLLVMPass();
   }
 
   // Register any pass manager command line options.


### PR DESCRIPTION
Add a conversion from `arc.execute` to the LLVM dialect. The conversion mimics `scf.execute_region`, but tries to convert types and block signatures along the way. (No idea why SCF does not do this.) This allows `arc.execute` ops to be lowered to LLVM by inlining the control flow graph into the parent SSACFG region, most likely an `llvm.func`. This now allows Arcilator to simulate designs that contain `llhd.combinational` ops.