### PR TITLE
[ImportVerilog] Add support for materializing `FixedSizeUnpackedArrayType` from `ConstantValue`

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1396,8 +1396,8 @@ Value Context::materializeFixedSizeUnpackedArrayType(
                                      anyHasUnknown || typeIsFourValued
                                          ? moore::Domain::FourValued
                                          : moore::Domain::TwoValued);
-  auto arrType =
-      moore::UnpackedArrayType::get(getContext(), maxBitWidth, intType);
+  auto arrType = moore::UnpackedArrayType::get(
+      getContext(), constant.elements().size(), intType);
 
   llvm::SmallVector<mlir::Value> elemVals;
   moore::ConstantOp constOp;

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -161,6 +161,11 @@ struct Context {
   Value materializeSVInt(const slang::SVInt &svint,
                          const slang::ast::Type &type, Location loc);
 
+  /// Helper function to materialize an unpacked array of `SVInt`s as an SSA value.
+  Value materializeFixedSizeUnpackedArrayType(const slang::ConstantValue &constant,
+                                 const slang::ast::FixedSizeUnpackedArrayType &astType,
+                                 Location loc);
+
   /// Helper function to materialize a `ConstantValue` as an SSA value. Returns
   /// null if the constant cannot be materialized.
   Value materializeConstant(const slang::ConstantValue &constant,

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3163,3 +3163,22 @@ module UnarySingleBitIncrement (
   end
 
 endmodule // UnarySingleBitIncrement
+
+// CHECK-LABEL: moore.module @UnpackedParameterArray(
+module UnpackedParameterArray #(
+    parameter int unsigned ParameterArray [2] = '{default: 0}
+) (
+    input  logic  clk_i,
+    input  logic  rst_ni
+);
+
+   function automatic int unsigned returnParameterArrayElement (int idx);
+      // CHECK: [[CONST0:%.+]] = moore.constant 0 : i32
+      // CHECK-NEXT: [[CONST1:%.+]] = moore.constant 0 : i32
+      // CHECK-NEXT: [[ARR:%.+]] = moore.array_create [[CONST0]], [[CONST1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+      // CHECK: [[RETURN:%.+]] = moore.dyn_extract [[ARR]] from {{%.+}} : uarray<2 x i32>, i32 -> i32
+      return ParameterArray[idx];
+   endfunction
+
+endmodule // UnpackedParameterArray
+


### PR DESCRIPTION
This PR adds support for materializing `slang::ast::FixedSizeUnpackedArrayType` as `moore::UnpackedArrayType`. 
Previously, only constant immediate`SVInt`s could be materialized, and working with RTL that used constant-valued, fixed-size unpacked arrays led to errors if they were used after declaration.

This conversion is necessary for supporting unpacked system verilog parameter arrays, e.g.:
`parameter int unsigned SomeParam [8] = {default: 0}`
This pattern is valid system verilog and widely used in the [snitch cluster](https://github.com/pulp-platform/snitch_cluster) repository, for example in the `snitch_cluster` and `snitch_cluster_wrapper` modules.

This implementation adds the function `Context::materializeFixedSizeUnpackedArrayType` as a target for `Context::materializeConstant` if the provided type can be safely cast to `slang::ast::FixedSizeUnpackedArrayType` (at runtime); otherwise the old logic is applied.
This PR also adds a test where the materialization conversion is applied on a module parameter and used in a function declared within the module body; it checks that the array is properly set up from constants and array access use a `moore::dyn_extract`.

I'm not fully sure the logic to extract the maximum bitwidth of all elements or inference of four-value logic is needed. Please let me know if you see a better way!
