### PR TITLE
[FIRRTL][Dedup] Remove unnecessary NLA creation for BlackBox annotations

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1250,6 +1250,14 @@ private:
           newAnnotations.push_back(anno);
         continue;
       }
+      if (anno.isClass(blackBoxInlineAnnoClass) ||
+          anno.isClass(blackBoxPathAnnoClass)) {
+        // Remove the nonlocal field of the annotation if it has one, since this
+        // is a sticky annotation.
+        anno.removeMember("circt.nonlocal");
+        newAnnotations.push_back(anno);
+        continue;
+      }
       // If the annotation is already non-local, we add it as is.  It is already
       // added to the target map.
       if (auto nla = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {


### PR DESCRIPTION
Hi, I am new to the CIRCT project. This is my first PR, and it may be incorrect. If there are any issues, please feel free to point them out.

The problem comes from the firrtl file:

```verilog
FIRRTL version 6.0.0
circuit Foo :%[[
  {
    "class":"firrtl.transforms.DedupGroupAnnotation",
    "target":"~|BBox",
    "group":"BBox"
  },
  {
    "class":"firrtl.transforms.DedupGroupAnnotation",
    "target":"~|BBox_1",
    "group":"BBox"
  },
  {
    "class":"firrtl.transforms.DedupGroupAnnotation",
    "target":"~|Foo",
    "group":"Foo"
  },
  {
    "class":"firrtl.transforms.BlackBoxInlineAnno",
    "target":"~|BBox",
    "name":"BBox.sv",
    "text":""
  },
  {
    "class":"firrtl.transforms.BlackBoxInlineAnno",
    "target":"~|BBox_1",
    "name":"BBox.sv",
    "text":""
  }
]]
  layer Verification, bind, "verification" :
    layer Assert, bind, "verification/assert" :
    layer Assume, bind, "verification/assume" :
    layer Cover, bind, "verification/cover" :

  extmodule BBox :
    input in : UInt<8>
    output out : UInt<8>
    defname = BBox

  extmodule BBox_1 :
    input in : UInt<8>
    output out : UInt<8>
    defname = BBox

  public module Foo :
    input clock : Clock
    input reset : AsyncReset
    output io_bb : { flip in : UInt<8>, out : UInt<8>}
    output io_bb_2 : { flip in : UInt<8>, out : UInt<8>}

    inst bb of BBox
    connect bb.in, io_bb.in
    connect io_bb.out, bb.out
    inst bb2 of BBox_1
    connect bb2.in, io_bb_2.in
    connect io_bb_2.out, bb2.out
```
This firrtl file contains two `extmodules`, `BBox` and `BBox_1`, that are identical, which usually caused by calling `Module(new BBox)` twice in chisel. Both also carry the corresponding `firrtl.transforms.BlackBoxInlineAnno`. The generated HW dialect by firtool is:

```mlir
module {
  hw.hierpath private @nla_0 [@Foo::@sym_0, @BBox]
  hw.hierpath private @nla [@Foo::@sym, @BBox]
  hw.module.extern private @BBox(in %in : i8, out out : i8) attributes {verilogName = "BBox"}
  hw.module @Foo(in %clock : !seq.clock, in %reset : i1, in %io_bb_in : i8, out io_bb_out : i8, in %io_bb_2_in : i8, out io_bb_2_out : i8) {
    %bb.out = hw.instance "bb" sym @sym @BBox(in: %io_bb_in: i8) -> (out: i8) {sv.namehint = "io_bb_out"}
    %bb2.out = hw.instance "bb2" sym @sym_0 @BBox(in: %io_bb_2_in: i8) -> (out: i8) {sv.namehint = "io_bb_2_out"}
    hw.output %bb.out, %bb2.out : i8, i8
  }
  emit.file "./BBox.sv" sym @blackbox_BBox.sv {
    emit.verbatim ""
  }
  om.class @Foo_Class(%basepath: !om.basepath) {
    om.class.fields 
  }
}
```

The output contain two unused (and may also be useless?) `hw.hierpath` operations plus the innerSym nla they reference. This PR aims to eliminate them.

In the `copyAnnotations` function, all annotations were being processed through `makeAnnotationNonLocal` by default. However, BlackBox annotations are specific to the external module itself and not needed to be made non-local during deduplication.

So here I Added special handling for `BlackBoxInlineAnno` and `BlackBoxPathAnno` in the `copyAnnotations` function, similar to the existing handling for `DontTouchAnnotation`.