### PR TITLE
[ESI] Bump zlib tag

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -64,11 +64,14 @@ set(ZLIB_BUILD_EXAMPLES OFF)
 FetchContent_Declare(
   ZLIB
   GIT_REPOSITORY https://github.com/madler/zlib.git
-  GIT_TAG        v1.3.1
+  # Note @mortbopet: The latest zlib release (v1.3.1) is fairly old (Jan 22. 2024)
+  # and is missing some key changes/fixes for building w/ a static library.
+  # For now, fixed by tagging to head of their development branch.
+  # Change once a new release is made that includes these fixes.
+  GIT_TAG        5a82f71ed1dfc0bec044d9702463dbdf84ea3b71
 )
 FetchContent_MakeAvailable(ZLIB)
 set(ZLIB_INCLUDE_DIR ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR})
-set(ZLIB_LIBRARY zlibstatic)
 if(UNIX)
   target_compile_options(zlibstatic
     PRIVATE
@@ -181,7 +184,7 @@ if (DEFINED ZLIB_INCLUDE_DIR)
 endif()
 
 target_link_libraries(ESICppRuntime PRIVATE
-  ${ZLIB_LIBRARY}
+  ZLIB::ZLIBSTATIC
   nlohmann_json::nlohmann_json
 )
 target_link_libraries(ESICppRuntime PRIVATE


### PR DESCRIPTION
The latest zlib release (v1.3.1) is fairly old (Jan 22. 2024) and is missing some key changes/fixes for building w/ a static library. This seems to be somewhat system/cmake version dependent. In any case, solved by bumping to head of their development branch (still a 7 month old commit) which cleans up their CMake build system, and introduces an alias target for the static library.