### PR TITLE
[Synth] Add support for mig.maj_inv in longest path analysis

### DIFF
--- a/test/Dialect/Synth/longest-paths.mlir
+++ b/test/Dialect/Synth/longest-paths.mlir
@@ -123,3 +123,11 @@ hw.module private @comb_others(in %a : i2, in %b : i2, out x : i1) {
   %0 = comb.icmp eq %a, %b : i2
   hw.output %0 : i1
 }
+
+// expected-remark-re @below {{fanOut=Object($root.x[0]), fanIn=Object($root.a[0], delay=1, history=[{{.+}}])}}
+// expected-remark-re @below {{fanOut=Object($root.y[0]), fanIn=Object($root.a[0], delay=2, history=[{{.+}}])}}
+hw.module private @mig(in %a : i1, out x : i1, out y : i1) {
+  %p = synth.mig.maj_inv %a, %a, %a : i1
+  %q = synth.mig.maj_inv %a, %a, %a, %a, %a : i1
+  hw.output %p, %q : i1, i1
+}

--- a/test/circt-synth/path-e2e.mlir
+++ b/test/circt-synth/path-e2e.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-synth %s -output-longest-path=- -top counter | FileCheck %s --check-prefixes COMMON,AIG
+// RUN: circt-synth %s -output-longest-path=- -top counter --target-ir mig | FileCheck %s --check-prefixes COMMON,MIG
 // RUN: circt-synth %s -output-longest-path=- -top counter -lower-to-k-lut 6 | FileCheck %s --check-prefixes COMMON,LUT6
 // RUN: circt-synth %s -output-longest-path=- -top counter -output-longest-path-json | FileCheck %s --check-prefix JSON
 
@@ -6,6 +7,7 @@
 // COMMON-NEXT: Found 168 paths
 // COMMON-NEXT: Found 32 unique fanout points
 // AIG-NEXT: Maximum path delay: 41
+// MIG-NEXT: Maximum path delay: 41
 // LUT6-NEXT: Maximum path delay: 7
 // Don't test detailed reports as they are not stable.
 


### PR DESCRIPTION
Extend LongestPathAnalysis to handle mig::MajorityInverterOp