### PR TITLE
[SV] Include CallInterface

### DIFF
--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -22,6 +22,7 @@
 #include "circt/Dialect/SV/SVTypes.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -14,6 +14,7 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/RegionKindInterface.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "circt/Dialect/Emit/EmitOpInterfaces.td"
 

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -18,6 +18,7 @@ add_circt_dialect_library(CIRCTSV
   CIRCTHW
   CIRCTLTL
   CIRCTSupport
+  MLIRCallInterfaces
   MLIRIR
 )
 


### PR DESCRIPTION
sv::FuncCallOp uses CallInterface but CallInterface was not explicitly included/linked. I believe this fixes https://github.com/llvm/circt/issues/8954 (though not sure why the failure doesn't reproduce locally). 