### PR TITLE
[Moore] Add builtin for $urandom

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1742,6 +1742,38 @@ class Builtin<string mnemonic, list<Trait> traits = []> :
     MooreOp<"builtin." # mnemonic, traits>;
 
 //===----------------------------------------------------------------------===//
+// Pseudo-Random Generators
+//===----------------------------------------------------------------------===//
+
+// Buildable alias for exactly !moore.i32
+def MooreI32 :
+  Type<CPred<
+    "(::llvm::isa<::circt::moore::IntType>($_self) && "
+    "::llvm::cast<::circt::moore::IntType>($_self).getWidth() == 32 && "
+    "::llvm::cast<::circt::moore::IntType>($_self).getDomain() == "
+    "::circt::moore::Domain::TwoValued)"
+  >, "!moore.i32"> {
+  let builderCall =
+    "::circt::moore::IntType::getInt($_builder.getContext(), 32)";
+}
+
+def UrandomBIOp : Builtin<"urandom"> {
+  let summary = "Generate a pseudo-random unsigned integer (optionally seeded)";
+  let description = [{
+    Corresponds to the `$urandom` system function. Returns a 32-bit
+    pseudo-random integer. The seed is optional; when provided, it initializes
+    the generator. If not provided, treat it as 0 in semantics/lowering.
+
+    See IEEE 1800-2023 § 18.13 "Random number system functions and methods".
+  }];
+
+  // Optional positional attribute for the seed
+  let arguments = (ins Optional<IntType>:$seed);
+  let results = (outs MooreI32:$result);
+  let assemblyFormat = "($seed^ `:` type($seed))? attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // Simulation Control Builtins
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1745,18 +1745,6 @@ class Builtin<string mnemonic, list<Trait> traits = []> :
 // Pseudo-Random Generators
 //===----------------------------------------------------------------------===//
 
-// Buildable alias for exactly !moore.i32
-def MooreI32 :
-  Type<CPred<
-    "(::llvm::isa<::circt::moore::IntType>($_self) && "
-    "::llvm::cast<::circt::moore::IntType>($_self).getWidth() == 32 && "
-    "::llvm::cast<::circt::moore::IntType>($_self).getDomain() == "
-    "::circt::moore::Domain::TwoValued)"
-  >, "!moore.i32"> {
-  let builderCall =
-    "::circt::moore::IntType::getInt($_builder.getContext(), 32)";
-}
-
 def UrandomBIOp : Builtin<"urandom"> {
   let summary = "Generate a pseudo-random unsigned integer (optionally seeded)";
   let description = [{
@@ -1768,9 +1756,9 @@ def UrandomBIOp : Builtin<"urandom"> {
   }];
 
   // Optional positional attribute for the seed
-  let arguments = (ins Optional<IntType>:$seed);
-  let results = (outs MooreI32:$result);
-  let assemblyFormat = "($seed^ `:` type($seed))? attr-dict";
+  let arguments = (ins Optional<TwoValuedI32>:$seed);
+  let results = (outs TwoValuedI32:$result);
+  let assemblyFormat = "($seed^)? attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -483,6 +483,13 @@ def FourValuedI64 : MooreType<CPred<[{
   let builderCall = "IntType::getLogic($_builder.getContext(), 64)";
 }
 
+// A 32-bit two-valued integer.
+def TwoValuedI32 : MooreType<CPred<[{
+    moore::isIntType($_self, 32, moore::Domain::TwoValued)
+  }]>, "32-bit two-valued integer type", "moore::IntType"> {
+  let builderCall = "IntType::getInt($_builder.getContext(), 32)";
+}
+
 /// A packed or unpacked array type with a fixed size.
 def AnyStaticArrayType : MooreType<
   Or<[ArrayType.predicate, UnpackedArrayType.predicate]>,

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1000,15 +1000,15 @@ struct RvalueExprVisitor : public ExprVisitor {
       break;
 
     default:
-      mlir::emitError(loc) << "unsupported system call `" << subroutine.name
-                           << "`";
-      return {};
+      break;
     }
 
     if (failed(result))
       return {};
     if (*result)
       return *result;
+    mlir::emitError(loc) << "unsupported system call `" << subroutine.name
+                         << "`";
     return {};
   }
 

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1592,7 +1592,7 @@ Context::convertSystemCallArity0(const slang::ast::SystemSubroutine &subroutine,
       llvm::StringSwitch<std::function<FailureOr<Value>()>>(subroutine.name)
           .Case("$urandom",
                 [&]() -> Value {
-                  return moore::UrandomBIOp::create(builder, loc, 0);
+                  return moore::UrandomBIOp::create(builder, loc, nullptr);
                 })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1590,7 +1590,6 @@ Context::convertSystemCallArity0(const slang::ast::SystemSubroutine &subroutine,
 
   auto systemCallRes =
       llvm::StringSwitch<std::function<FailureOr<Value>()>>(subroutine.name)
-          // Signed and unsigned system functions.
           .Case("$urandom",
                 [&]() -> Value {
                   return moore::UrandomBIOp::create(builder, loc, 0);

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -181,6 +181,11 @@ struct Context {
       moore::IntFormat defaultFormat = moore::IntFormat::Decimal,
       bool appendNewline = false);
 
+  /// Convert system function calls only have arity-0.
+  FailureOr<Value>
+  convertSystemCallArity0(const slang::ast::SystemSubroutine &subroutine,
+                          Location loc);
+
   /// Convert system function calls only have arity-1.
   FailureOr<Value>
   convertSystemCallArity1(const slang::ast::SystemSubroutine &subroutine,

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -263,3 +263,14 @@ function void MathBuiltins(int x, logic [41:0] y, real r);
   // CHECK:  moore.builtin.atanh [[R]] : real
   dummyB($atanh(r));
 endfunction
+
+// CHECK-LABEL: func.func private @RandomBuiltins(
+// CHECK-SAME: [[X:%.+]]: !moore.i32
+function RandomBuiltins(int x);
+   // CHECK: [[RAND0:%.+]] = moore.builtin.urandom
+   // CHECK-NEXT: call @dummyA([[RAND0]]) : (!moore.i32) -> ()
+   dummyA($urandom());
+    // CHECK: [[RAND1:%.+]] = moore.builtin.urandom [[X]]
+    // CHECK-NEXT: call @dummyA([[RAND1]]) : (!moore.i32) -> ()
+   dummyA($urandom(x));
+endfunction


### PR DESCRIPTION
First time I try to add a new Op, so let me know if I went wrong somewhere! 

This PR adds a new builtin in moore for the $urandom system call.
Per the newest version of the spec, $urandom may be called with or with a integer seed argument, and always returns an integer produced by a pseudo-random number generator.

As such I added an importer conversion and tests for both cases; the allowed expressions are 
```
moore.builtin.urandom
moore.builtin.urandom %arg : !moore.i32
```

I struggled a bit with constraining the output type of `moore.builtin.urandom`, since it is constant. I added
```
def MooreI32 :
  Type<CPred<
    "(::llvm::isa<::circt::moore::IntType>($_self) && "
    "::llvm::cast<::circt::moore::IntType>($_self).getWidth() == 32 && "
    "::llvm::cast<::circt::moore::IntType>($_self).getDomain() == "
    "::circt::moore::Domain::TwoValued)"
  >, "!moore.i32"> {
  let builderCall =
    "::circt::moore::IntType::getInt($_builder.getContext(), 32)";
}
```
in place to constrain an IntType to be exactly a moore.i32 for this purpose, but please let me know if there is a smarter way; this seems a bit cumbersome.