### PR TITLE
[FIRRTL] Add reduction that moves MustDedup onto children

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -48,6 +48,13 @@ struct TokenAnnoTarget {
     toVector(out);
     return std::string(out);
   }
+
+  /// Convert the annotation path to a StringAttr.
+  StringAttr toStringAttr(MLIRContext *context) const {
+    SmallString<32> out;
+    toVector(out);
+    return StringAttr::get(context, out);
+  }
 };
 
 // The potentially non-local resolved annotation.
@@ -141,9 +148,9 @@ struct AnnoTargetCache {
   AnnoTargetCache() = delete;
   AnnoTargetCache(const AnnoTargetCache &other) = default;
   AnnoTargetCache(AnnoTargetCache &&other)
-      : targets(std::move(other.targets)){};
+      : targets(std::move(other.targets)) {}
 
-  AnnoTargetCache(FModuleLike mod) { gatherTargets(mod); };
+  AnnoTargetCache(FModuleLike mod) { gatherTargets(mod); }
 
   /// Lookup the target for 'name', empty if not found.
   /// (check for validity using operator bool()).
@@ -359,7 +366,7 @@ struct ApplyState {
   IntegerAttr newID() {
     return IntegerAttr::get(IntegerType::get(circuit.getContext(), 64),
                             annotationID++);
-  };
+  }
 
 private:
   hw::InnerSymbolNamespaceCollection namespaces;

--- a/test/circt-reduce/must-dedup-children.mlir
+++ b/test/circt-reduce/must-dedup-children.mlir
@@ -1,0 +1,46 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include must-dedup-children | FileCheck %s
+
+// Test that MustDedup annotations are moved from parent modules to their child modules
+
+// CHECK: firrtl.circuit "Top" attributes {annotations = [
+// CHECK-DAG: {class = "firrtl.transforms.MustDeduplicateAnnotation", modules = ["~Top|ChildA", "~Top|ChildB"]}
+// CHECK-DAG: {class = "firrtl.transforms.MustDeduplicateAnnotation", modules = ["~Top|ChildC", "~Top|ChildD"]}
+// CHECK: ]}
+
+firrtl.circuit "Top" attributes {annotations = [{
+  class = "firrtl.transforms.MustDeduplicateAnnotation",
+  modules = ["~Top|ParentA", "~Top|ParentB"]
+}]} {
+  firrtl.module @Top() {
+    firrtl.instance parentA @ParentA()
+    firrtl.instance parentB @ParentB()
+  }
+
+  firrtl.module private @ParentA() {
+    firrtl.instance child1 @ChildA()
+    firrtl.instance child2 @ChildC()
+  }
+
+  firrtl.module private @ParentB() {
+    firrtl.instance child1 @ChildB()
+    firrtl.instance child2 @ChildD()
+  }
+
+  firrtl.module private @ChildA() {
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+
+  firrtl.module private @ChildB() {
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+
+  firrtl.module private @ChildC() {
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+
+  firrtl.module private @ChildD() {
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+}


### PR DESCRIPTION
Add the `MustDedupChildren` reduction which takes must dedup annotations and replaces them with must dedup annotations on child modules. More Claude Sonnet 4 magic!