### PR TITLE
[Moore] Add builtins for simulation time measurements

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1762,7 +1762,7 @@ def UrandomBIOp : Builtin<"urandom"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Time Formatting And Time Stamping
+// Simulation Time Measurement Builtins
 //===----------------------------------------------------------------------===//
 
 def TimeBIOp : Builtin<"time"> {
@@ -1776,10 +1776,9 @@ def TimeBIOp : Builtin<"time"> {
   }];
 
   // Optional positional attribute for the seed
-  let results = (outs TwoValuedI64:$result);
+  let results = (outs TimeType:$result);
   let assemblyFormat = "attr-dict";
 }
-
 
 //===----------------------------------------------------------------------===//
 // Simulation Control Builtins

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1762,6 +1762,26 @@ def UrandomBIOp : Builtin<"urandom"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Time Formatting And Time Stamping
+//===----------------------------------------------------------------------===//
+
+def TimeBIOp : Builtin<"time"> {
+  let summary = "Return the current simulation time";
+  let description = [{
+    Corresponds to the `$time` system function. Returns a int-rounded 64-bit
+    integer corresponding to the elapsed simulation time scaled by the
+    simulation's timescale.
+
+    See IEEE 1800-2023 § 20.3 "Simulation time system functions".
+  }];
+
+  // Optional positional attribute for the seed
+  let results = (outs TwoValuedI64:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+
+//===----------------------------------------------------------------------===//
 // Simulation Control Builtins
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -483,6 +483,13 @@ def FourValuedI64 : MooreType<CPred<[{
   let builderCall = "IntType::getLogic($_builder.getContext(), 64)";
 }
 
+// A 64-bit two-valued integer.
+def TwoValuedI64 : MooreType<CPred<[{
+    moore::isIntType($_self, 64, moore::Domain::TwoValued)
+  }]>, "64-bit two-valued integer type", "moore::IntType"> {
+  let builderCall = "IntType::getInt($_builder.getContext(), 64)";
+}
+
 // A 32-bit two-valued integer.
 def TwoValuedI32 : MooreType<CPred<[{
     moore::isIntType($_self, 32, moore::Domain::TwoValued)

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -483,13 +483,6 @@ def FourValuedI64 : MooreType<CPred<[{
   let builderCall = "IntType::getLogic($_builder.getContext(), 64)";
 }
 
-// A 64-bit two-valued integer.
-def TwoValuedI64 : MooreType<CPred<[{
-    moore::isIntType($_self, 64, moore::Domain::TwoValued)
-  }]>, "64-bit two-valued integer type", "moore::IntType"> {
-  let builderCall = "IntType::getInt($_builder.getContext(), 64)";
-}
-
 // A 32-bit two-valued integer.
 def TwoValuedI32 : MooreType<CPred<[{
     moore::isIntType($_self, 32, moore::Domain::TwoValued)

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1594,6 +1594,9 @@ Context::convertSystemCallArity0(const slang::ast::SystemSubroutine &subroutine,
                 [&]() -> Value {
                   return moore::UrandomBIOp::create(builder, loc, nullptr);
                 })
+          .Case(
+              "$time",
+              [&]() -> Value { return moore::TimeBIOp::create(builder, loc); })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();
 }

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1597,6 +1597,12 @@ Context::convertSystemCallArity0(const slang::ast::SystemSubroutine &subroutine,
           .Case(
               "$time",
               [&]() -> Value { return moore::TimeBIOp::create(builder, loc); })
+          .Case(
+              "$stime",
+              [&]() -> Value { return moore::TimeBIOp::create(builder, loc); })
+          .Case(
+              "$realtime",
+              [&]() -> Value { return moore::TimeBIOp::create(builder, loc); })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();
 }

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -276,13 +276,13 @@ function RandomBuiltins(int x);
 endfunction
 
 // CHECK-LABEL: func.func private @TimeBuiltins(
-function TimeBuiltins ();
-   // CHECK: [[TIME:%.+]] = moore.builtin.time
-   // CHECK-NEXT: [[TIMETOLOGIC:%.+]] = moore.time_to_logic [[TIME]]
-   dummyA($time());
-   // CHECK: [[STIME:%.+]] = moore.builtin.time
-    dummyA($stime());
-    // CHECK: [[REALTIME:%.+]] = moore.builtin.time
-    // TODO: There is no int-to-real conversion yet; change this to dummyB once int-to-real works!
-    dummyA($realtime());
+function TimeBuiltins();
+  // CHECK: [[TIME:%.+]] = moore.builtin.time
+  // CHECK-NEXT: [[TIMETOLOGIC:%.+]] = moore.time_to_logic [[TIME]]
+  dummyA($time());
+  // CHECK: [[STIME:%.+]] = moore.builtin.time
+  dummyA($stime());
+  // CHECK: [[REALTIME:%.+]] = moore.builtin.time
+  // TODO: There is no int-to-real conversion yet; change this to dummyB once int-to-real works!
+  dummyA($realtime());
 endfunction

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -278,7 +278,11 @@ endfunction
 // CHECK-LABEL: func.func private @TimeBuiltins(
 function TimeBuiltins ();
    // CHECK: [[TIME:%.+]] = moore.builtin.time
-   // CHECK-NEXT: [[TRUNCTIME:%.+]] = moore.trunc [[TIME]] : i64 -> i32
-   // CHECK-NEXT: call @dummyA([[TRUNCTIME]]) : (!moore.i32) -> ()
+   // CHECK-NEXT: [[TIMETOLOGIC:%.+]] = moore.time_to_logic [[TIME]]
    dummyA($time());
+   // CHECK: [[STIME:%.+]] = moore.builtin.time
+    dummyA($stime());
+    // CHECK: [[REALTIME:%.+]] = moore.builtin.time
+    // TODO: There is no int-to-real conversion yet; change this to dummyB once int-to-real works!
+    dummyA($realtime());
 endfunction

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -274,3 +274,11 @@ function RandomBuiltins(int x);
     // CHECK-NEXT: call @dummyA([[RAND1]]) : (!moore.i32) -> ()
    dummyA($urandom(x));
 endfunction
+
+// CHECK-LABEL: func.func private @TimeBuiltins(
+function TimeBuiltins ();
+   // CHECK: [[TIME:%.+]] = moore.builtin.time
+   // CHECK-NEXT: [[TRUNCTIME:%.+]] = moore.trunc [[TIME]] : i64 -> i32
+   // CHECK-NEXT: call @dummyA([[TRUNCTIME]]) : (!moore.i32) -> ()
+   dummyA($time());
+endfunction


### PR DESCRIPTION
This PR adds builtins for `$time`, `$stime` and `$realtime` in the `moore` Dialect.
All these builtins correspond to System Verilog system tasks and only slightly differ in their functionality.

To represent the return value of `$time`, this PR adds `TwoValueI64`, which represents a 64-Bit integer used to express the simulation time value in.

EDIT: Just spotted there is a `TimeType` in the MooreTypes as well - maybe that would be a better output target? 
An "added complication" in this matter is that `TimeType` currently does not enforce the spec's rounding / truncation / overflow semantics as far as I can see.
I'm thinking it might make sense to first introduce support for `$timeformat`, maybe by adding a `TimeFormatResource`?
Then these system calls can be resolved by checking the `TimeFormatResource` with `timetype_to_time`, `timetype_to_stime`, `timetype_to_real` helper ops, which can implement the exact rounding, truncations & overflow semantics.