### PR TITLE
[Support] Add walkPostOrder and walkInversePostOrder to InstanceGraph

### DIFF
--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -16,6 +16,7 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
 #include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/DOTGraphTraits.h"
@@ -266,6 +267,22 @@ public:
   iterator begin() { return nodes.begin(); }
   iterator end() { return nodes.end(); }
 
+  /// Perform a post-order walk across the modules. Guaranteed to visit all
+  /// modules. Child modules are visited before their parent modules. If `Fn`
+  /// returns a `LogicalResult`, the walk can be interrupted by returning
+  /// `failure()` from the callback, in which case the overall walk will return
+  /// `failure()`.
+  template <typename Fn>
+  decltype(auto) walkPostOrder(Fn &&fn);
+
+  /// Perform an inverse-post-order walk across the modules. Guaranteed to visit
+  /// all modules. Child modules are visited before their parent modules. If
+  /// `Fn` returns a `LogicalResult`, the walk can be interrupted by returning
+  /// `failure()` from the callback, in which case the overall walk will return
+  /// `failure()`.
+  template <typename Fn>
+  decltype(auto) walkInversePostOrder(Fn &&fn);
+
   //===-------------------------------------------------------------------------
   // Methods to keep an InstanceGraph up to date.
   //
@@ -458,6 +475,16 @@ struct llvm::GraphTraits<llvm::Inverse<circt::igraph::InstanceGraphNode *>> {
 };
 
 /// Graph traits for the instance graph.
+///
+/// **Deprecated:** This uses `getTopLevelNode()` as the root node of the graph,
+/// which does not contain all modules in the instance graph. Instead, the
+/// behaviour is dependent on concrete subclasses of the instance graph. The HW
+/// and FIRRTL dialects define this to be variants of "the top module" and "all
+/// public modules", which is usually not what you want in a pass. You are more
+/// likely to want to visit _all_ modules in the IR in post order (children
+/// before parents), not just a subset of the modules depending on whether
+/// things are transitively instantiated. Use `walkPostOrder` or
+/// `walkInversePostOrder` on `InstanceGraph` instead.
 template <>
 struct llvm::GraphTraits<circt::igraph::InstanceGraph *>
     : public llvm::GraphTraits<circt::igraph::InstanceGraphNode *> {
@@ -498,6 +525,57 @@ struct llvm::DOTGraphTraits<circt::igraph::InstanceGraph *>
     return ("label=" + instanceOp.getInstanceName()).str();
   }
 };
+
+//===----------------------------------------------------------------------===//
+// Graph Iterators
+//===----------------------------------------------------------------------===//
+
+namespace circt {
+namespace igraph {
+
+// These are defined out-of-line here since they need the graph traits to have
+// been defined.
+
+template <typename Fn>
+decltype(auto) InstanceGraph::walkPostOrder(Fn &&fn) {
+  constexpr bool fallible =
+      std::is_invocable_r_v<LogicalResult, Fn &, InstanceGraphNode &>;
+  DenseSet<InstanceGraphNode *> visited;
+  for (auto &root : nodes) {
+    for (auto *node : llvm::post_order_ext(&root, visited)) {
+      if constexpr (fallible) {
+        if (failed(fn(*node)))
+          return failure();
+      } else {
+        fn(*node);
+      }
+    }
+  }
+  if constexpr (fallible)
+    return success();
+}
+
+template <typename Fn>
+decltype(auto) InstanceGraph::walkInversePostOrder(Fn &&fn) {
+  constexpr bool fallible =
+      std::is_invocable_r_v<LogicalResult, Fn &, InstanceGraphNode &>;
+  DenseSet<InstanceGraphNode *> visited;
+  for (auto &root : nodes) {
+    for (auto *node : llvm::inverse_post_order_ext(&root, visited)) {
+      if constexpr (fallible) {
+        if (failed(fn(*node)))
+          return failure();
+      } else {
+        fn(*node);
+      }
+    }
+  }
+  if constexpr (fallible)
+    return success();
+}
+
+} // namespace igraph
+} // namespace circt
 
 //===----------------------------------------------------------------------===//
 // Dense Map Traits

--- a/lib/Dialect/FIRRTL/Transforms/AssignOutputDirs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AssignOutputDirs.cpp
@@ -100,53 +100,50 @@ void AssignOutputDirsPass::runOnOperation() {
   bool changed = false;
 
   LLVM_DEBUG(llvm::dbgs() << "Updating modules:\n");
-  DenseSet<InstanceGraphNode *> visited;
-  for (auto *root : getAnalysis<InstanceGraph>()) {
-    for (auto *node : llvm::inverse_post_order_ext(root, visited)) {
-      FModuleLike moduleLike =
-          dyn_cast<FModuleLike>(node->getModule().getOperation());
-      if (!moduleLike || !isa<FModuleOp, FExtModuleOp>(moduleLike))
-        continue;
-      if (moduleLike->getAttrOfType<hw::OutputFileAttr>("output_file") ||
-          moduleLike.isPublic())
-        continue;
+  getAnalysis<InstanceGraph>().walkInversePostOrder([&](auto &node) {
+    FModuleLike moduleLike =
+        dyn_cast<FModuleLike>(node.getModule().getOperation());
+    if (!moduleLike || !isa<FModuleOp, FExtModuleOp>(moduleLike))
+      return;
+    if (moduleLike->getAttrOfType<hw::OutputFileAttr>("output_file") ||
+        moduleLike.isPublic())
+      return;
 
-      // Get the output directory of the first parent, and then fold the current
-      // output directory with the LCA of all other discovered output
-      // directories.
-      SmallString<64> moduleOutputDir;
-      auto i = node->usesBegin();
-      auto e = node->usesEnd();
-      for (; i != e; ++i) {
-        auto parent = (*i)->getParent()->getModule();
-        auto file = getOutputFile(parent);
-        if (file) {
-          moduleOutputDir = file.getDirectory();
-          makeAbsolute(outputDir, moduleOutputDir);
-        } else {
-          moduleOutputDir = outputDir;
-        }
-        ++i;
-        break;
+    // Get the output directory of the first parent, and then fold the current
+    // output directory with the LCA of all other discovered output
+    // directories.
+    SmallString<64> moduleOutputDir;
+    auto i = node.usesBegin();
+    auto e = node.usesEnd();
+    for (; i != e; ++i) {
+      auto parent = (*i)->getParent()->getModule();
+      auto file = getOutputFile(parent);
+      if (file) {
+        moduleOutputDir = file.getDirectory();
+        makeAbsolute(outputDir, moduleOutputDir);
+      } else {
+        moduleOutputDir = outputDir;
       }
-      for (; i != e; ++i) {
-        auto parent = (*i)->getParent()->getModule();
-        makeCommonPrefix(outputDir, moduleOutputDir, getOutputFile(parent));
-      }
-
-      tryMakeRelative(outputDir, moduleOutputDir);
-      if (!moduleOutputDir.empty()) {
-        auto f =
-            hw::OutputFileAttr::getAsDirectory(&getContext(), moduleOutputDir);
-        moduleLike->setAttr("output_file", f);
-        changed = true;
-        LLVM_DEBUG({
-          llvm::dbgs() << "  - name: " << moduleLike.getName() << "\n"
-                       << "    directory: " << f.getFilename() << "\n";
-        });
-      }
+      ++i;
+      break;
     }
-  }
+    for (; i != e; ++i) {
+      auto parent = (*i)->getParent()->getModule();
+      makeCommonPrefix(outputDir, moduleOutputDir, getOutputFile(parent));
+    }
+
+    tryMakeRelative(outputDir, moduleOutputDir);
+    if (!moduleOutputDir.empty()) {
+      auto f =
+          hw::OutputFileAttr::getAsDirectory(&getContext(), moduleOutputDir);
+      moduleLike->setAttr("output_file", f);
+      changed = true;
+      LLVM_DEBUG({
+        llvm::dbgs() << "  - name: " << moduleLike.getName() << "\n"
+                     << "    directory: " << f.getFilename() << "\n";
+      });
+    }
+  });
 
   if (!changed)
     markAllAnalysesPreserved();

--- a/lib/Dialect/FIRRTL/Transforms/CheckLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckLayers.cpp
@@ -109,13 +109,10 @@ public:
   static LogicalResult run(InstanceGraph &instanceGraph,
                            InstanceInfo &instanceInfo) {
     CheckLayers checkLayers(instanceGraph, instanceInfo);
-    DenseSet<InstanceGraphNode *> visited;
-    for (auto *root : instanceGraph) {
-      for (auto *node : llvm::post_order_ext(root, visited)) {
-        if (auto moduleOp = dyn_cast<FModuleOp>(node->getModule<Operation *>()))
-          checkLayers.run(moduleOp);
-      }
-    }
+    instanceGraph.walkPostOrder([&](auto &node) {
+      if (auto moduleOp = dyn_cast<FModuleOp>(*node.getModule()))
+        checkLayers.run(moduleOp);
+    });
     return failure(checkLayers.error);
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1684,10 +1684,11 @@ class DedupPass : public circt::firrtl::impl::DedupBase<DedupPass> {
     // We must iterate the modules from the bottom up so that we can properly
     // deduplicate the modules. We copy the list of modules into a vector first
     // to avoid iterator invalidation while we mutate the instance graph.
-    SmallVector<FModuleLike, 0> modules(
-        llvm::map_range(llvm::post_order(&instanceGraph), [](auto *node) {
-          return cast<FModuleLike>(*node->getModule());
-        }));
+    SmallVector<FModuleLike, 0> modules;
+    instanceGraph.walkPostOrder([&](auto &node) {
+      if (auto mod = dyn_cast<FModuleLike>(*node.getModule()))
+        modules.push_back(mod);
+    });
     LLVM_DEBUG(llvm::dbgs() << "Found " << modules.size() << " modules\n");
 
     SmallVector<std::optional<ModuleInfo>> moduleInfos(modules.size());

--- a/lib/Dialect/FIRRTL/Transforms/LayerSink.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LayerSink.cpp
@@ -88,13 +88,8 @@ namespace {
 class EffectInfo {
 public:
   EffectInfo(CircuitOp circuit, InstanceGraph &instanceGraph) {
-    DenseSet<InstanceGraphNode *> visited;
-    for (auto *root : instanceGraph) {
-      for (auto *node : llvm::post_order_ext(root, visited)) {
-        auto *op = node->getModule().getOperation();
-        update(op);
-      }
-    }
+    instanceGraph.walkPostOrder(
+        [&](auto &node) { update(node.getModule().getOperation()); });
   }
 
   /// True if the given operation is NOT moveable due to some effect.

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -1062,10 +1062,7 @@ void LowerLayersPass::preprocessModuleLike(CircuitNamespace &ns,
 /// Create the bind file skeleton for each layer, for each module.
 void LowerLayersPass::preprocessModules(CircuitNamespace &ns,
                                         InstanceGraph &ig) {
-  DenseSet<InstanceGraphNode *> visited;
-  for (auto *root : ig)
-    for (auto *node : llvm::post_order_ext(root, visited))
-      preprocessModuleLike(ns, node);
+  ig.walkPostOrder([&](auto &node) { preprocessModuleLike(ns, &node); });
 }
 
 /// Process a circuit to remove all layer blocks in each module and top-level

--- a/test/firtool/assign-output-dirs.fir
+++ b/test/firtool/assign-output-dirs.fir
@@ -19,26 +19,25 @@ FIRRTL version 4.0.0
 
 circuit Foo: %[[
   {"class": "circt.OutputDirAnnotation", "target": "~Foo|Bar", "dirname": "subdir"},
-  {"class": "circt.OutputDirAnnotation", "target": "~Foo|Baz", "dirname": ".."},
-  {"class": "firrtl.transforms.DontTouchAnnotation", "target": "~Foo|XFoo>w"},
-  {"class": "firrtl.transforms.DontTouchAnnotation", "target": "~Foo|XBar>w"},
-  {"class": "firrtl.transforms.DontTouchAnnotation", "target": "~Foo|XBaz>w"}
+  {"class": "circt.OutputDirAnnotation", "target": "~Foo|Baz", "dirname": ".."}
 ]]
-  module XFoo:
-    wire w : UInt<8>
-    invalidate w
-  module XBar:
-    wire w : UInt<8>
-    invalidate w
-  module XBaz:
-    wire w : UInt<8>
-    invalidate w
   public module Foo:
     inst x of XFoo
   public module Bar:
     inst x of XBar
   public module Baz:
     inst x of XBaz
+
+  module XFoo:
+    inst y of YFoo
+  module XBar:
+    inst y of YBar
+  module XBaz:
+    inst y of YBaz
+
+  extmodule YFoo:
+  extmodule YBar:
+  extmodule YBaz:
 
 ; FOO: module Foo();
 ; BAR: module Bar();

--- a/test/firtool/instchoice.fir
+++ b/test/firtool/instchoice.fir
@@ -1,6 +1,7 @@
 ; RUN: firtool %s --parse-only --select-instance-choice=Platform=ASIC | FileCheck %s
-; RUN: firtool %s --ir-hw --disable-opt --select-instance-choice=Platform=ASIC | FileCheck %s --check-prefix=ASIC
-; RUN: firtool %s --ir-hw --disable-opt --select-default-for-unspecified-instance-choice | FileCheck %s --check-prefixes=DEFAULT
+; RUN: firtool %s --ir-fir --select-default-for-unspecified-instance-choice | FileCheck %s --check-prefixes=DEFAULT
+; RUN: firtool %s --ir-fir --select-instance-choice=Platform=FPGA | FileCheck %s --check-prefix=FPGA
+; RUN: firtool %s --ir-fir --select-instance-choice=Platform=ASIC | FileCheck %s --check-prefix=ASIC
 
 FIRRTL version 5.1.0
 ; CHECK: firrtl.circuit "Foo"
@@ -15,12 +16,15 @@ circuit Foo:
 
   module DefaultTarget:
     input clock: Clock
+    inst ext of DefaultExt
 
   module FPGATarget:
     input clock: Clock
+    inst ext of FPGAExt
 
   module ASICTarget:
     input clock: Clock
+    inst ext of ASICExt
 
   public module Foo:
     input clock: Clock
@@ -30,10 +34,15 @@ circuit Foo:
     ; CHECK-SAME:   @FPGA -> @FPGATarget,
     ; CHECK-SAME:   @ASIC -> @ASICTarget
     ; CHECK-SAME: } (in clock: !firrtl.clock)
-    ; ASIC: hw.instance "inst" @ASICTarget
-    ; DEFAULT: hw.instance "inst" @DefaultTarget
+    ; DEFAULT: firrtl.instance inst @DefaultTarget
+    ; FPGA:    firrtl.instance inst @FPGATarget
+    ; ASIC:    firrtl.instance inst @ASICTarget
     instchoice inst of DefaultTarget, Platform :
       FPGA => FPGATarget
       ASIC => ASICTarget
 
     connect inst.clock, clock
+
+  extmodule DefaultExt:
+  extmodule FPGAExt:
+  extmodule ASICExt:


### PR DESCRIPTION
Add new helper functions to the `InstanceGraph` that implement a full post-order and inverse-post-order walk across _all_ modules. This pulls a common pattern into the instance graph itself, where a user would iterate over the graph's nodes and then use an `llvm::post_order_ext` iterator to not revisit prior nodes with an externally-held set.

The instance graph implements the graph traits, which makes using `llvm::post_order` it tempting. But this is usually not what we want. The graph does not have a unique root node. Instead, the FIRRTL flavor of the graph uses the "top" module as specified by the circuit, and the HW flavor of the graph uses a dummy node that points to all _public_ modules. In most passes we want to iterate over _all_ modules in the IR with a specific order, not just a subset of the modules. These new helper functions make this common use case more obvious and may allow us to remove the graph traits from `InstanceGraph` again in the future.

Most of this PR is just mechanical identation changes. One brittle test for instance choice needs to be updated since that relied on the fact that the dedup pass would ignore uninstantiated modules.