### PR TITLE
[FIRRTL] Handle ClassTypes properly in Dedup

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -224,9 +224,25 @@ private:
   }
 
   // NOLINTNEXTLINE(misc-no-recursion)
+  void update(ClassType type) {
+    update(type.getTypeID());
+    // Don't hash the class name directly, since it may be replaced during
+    // dedup. Record the class name instead and lazily combine their hashes
+    // using the same mechanism as instances and modules.
+    referredModuleNames.push_back(type.getNameAttr().getAttr());
+    for (auto &element : type.getElements()) {
+      update(element.name.getAsOpaquePointer());
+      update(element.type);
+      update(static_cast<unsigned>(element.direction));
+    }
+  }
+
+  // NOLINTNEXTLINE(misc-no-recursion)
   void update(Type type) {
     if (auto bundle = type_dyn_cast<BundleType>(type))
       return update(bundle);
+    if (auto klass = type_dyn_cast<ClassType>(type))
+      return update(klass);
     update(type.getAsOpaquePointer());
   }
 

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -841,3 +841,29 @@ firrtl.circuit "NoDedupPublic" {
   firrtl.module @DUTLike() {}
   firrtl.module @NotDUT() {}
 }
+
+// CHECK-LABEL: "UninstantiatedClasses"
+// Classes that are only used in `!firrtl.class` types without concrete
+// instances should still be properly hashed and deduplicated.
+firrtl.circuit "UninstantiatedClasses" attributes {annotations = [
+  {class = "firrtl.transforms.MustDeduplicateAnnotation", modules = [
+    "~UninstantiatedClasses|Foo",
+    "~UninstantiatedClasses|Bar"
+  ]}
+]} {
+  // CHECK: @UninstantiatedClasses
+  firrtl.module @UninstantiatedClasses() {
+    // CHECK-NEXT: %x = firrtl.object @Foo
+    // CHECK-NEXT: %y = firrtl.object @Foo
+    %x = firrtl.object @Foo(out a: !firrtl.class<@Spam()>)
+    %y = firrtl.object @Bar(out a: !firrtl.class<@Eggs()>)
+  }
+  // CHECK:     firrtl.class private @Foo
+  // CHECK-NOT: firrtl.class private @Bar
+  firrtl.class private @Foo(out %a: !firrtl.class<@Spam()>) {}
+  firrtl.class private @Bar(out %a: !firrtl.class<@Eggs()>) {}
+  // CHECK:     firrtl.class private @Spam
+  // CHECK-NOT: firrtl.class private @Eggs
+  firrtl.class private @Spam() {}
+  firrtl.class private @Eggs() {}
+}


### PR DESCRIPTION
Add special handling for `!firrtl.class` types in dedup. These used to be treated just as regular types, which meant that `!firrtl.class<@A>` and `!firrtl.class<@B>` would be treated as distinct types, even when the pass deduplicates `@A` and `@B` everywhere else. We already have an established pattern to skip name references and tracking them separately. All that's needed applying this to `ClassType`.

This fixes a subtle OFIRRTL-related issue I've encountered in the wild.