### PR TITLE
[ESI] Set '--output-split' for verilator compilation

### DIFF
--- a/lib/Dialect/ESI/runtime/cosim_dpi_server/esi-cosim.py
+++ b/lib/Dialect/ESI/runtime/cosim_dpi_server/esi-cosim.py
@@ -264,6 +264,7 @@ class Verilator(Simulator):
         "-Wno-TIMESCALEMOD",
         "-Wno-fatal",
         "-sv",
+        "--output-split",
         "--build",
         "--exe",
         "--assert",


### PR DESCRIPTION
... which also enables parallel compilation and better ccache support.

E.g. an internal simple test:
- without split: 8.2s compile time
- with split: 1.3s compile time