### PR TITLE
[FIRRTL] Emit fopen calls to get fd's not mcd's.

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -909,7 +909,7 @@ package __circt_lib_logging;
     static int global_id [string];
     static function int get(string name);
       if (global_id.exists(name) == 32'h0) begin
-        global_id[name] = $fopen(name);
+        global_id[name] = $fopen(name, "w");
         if (global_id[name] == 32'h0)
           $error("Failed to open file %s", name);
       end

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -20,7 +20,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-SAME:             static int global_id [string];
   // CHECK-SAME:             static function int get(string name);
   // CHECK-SAME:               if (global_id.exists(name) == 32'h0)
-  // CHECK-SAME:                 global_id[name] = $fopen(name);
+  // CHECK-SAME:                 global_id[name] = $fopen(name, \22w\22);
   // CHECK-SAME:               return global_id[name];
   // CHECK-SAME:             endfunction
   // CHECK-SAME:           endclass

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -10,7 +10,7 @@ FIRRTL version 5.1.0
 ; CHECK-NEXT:       static int global_id [string];
 ; CHECK-NEXT:       static function int get(string name);
 ; CHECK-NEXT:         if (global_id.exists(name) == 32'h0) begin
-; CHECK-NEXT:           global_id[name] = $fopen(name);
+; CHECK-NEXT:           global_id[name] = $fopen(name, "w");
 ; CHECK-NEXT:           if (global_id[name] == 32'h0)
 ; CHECK-NEXT:             $error("Failed to open file %s", name);
 ; CHECK-NEXT:         end


### PR DESCRIPTION
Multichannel descriptors are limited to 30, where file descriptors usually have a much higher limit.

Specify opening files "w" which will truncate and is not binary; this may be a change depending on default behavior of mcd's.