### PR TITLE
[Moore] Add support for $random system task

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1763,8 +1763,27 @@ class Builtin<string mnemonic, list<Trait> traits = []> :
     MooreOp<"builtin." # mnemonic, traits>;
 
 //===----------------------------------------------------------------------===//
-// Pseudo-Random Generators
+// True-Random and Pseudo-Random Generators
 //===----------------------------------------------------------------------===//
+
+def RandomBIOp : Builtin<"random"> {
+  let summary = "Generate a true random signed integer (optionally seeded)";
+  let description = [{
+    Corresponds to the `$random` system function. Returns a 32-bit
+    true random integer. The seed is optional; when provided, it initializes
+    the generator. If not provided, treat it as 0 in semantics/lowering.
+
+    `$random` is largely considered to be deprecated since it leads to
+    non-reproducible simulation results. Consider using `$urandom` instead.
+
+    See IEEE 1800-2023 § 20.14 "Probablistic distribution functions".
+  }];
+
+  // Optional positional attribute for the seed
+  let arguments = (ins Optional<TwoValuedI32>:$seed);
+  let results = (outs TwoValuedI32:$result);
+  let assemblyFormat = "($seed^)? attr-dict";
+}
 
 def UrandomBIOp : Builtin<"urandom"> {
   let summary = "Generate a pseudo-random unsigned integer (optionally seeded)";

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1594,6 +1594,10 @@ Context::convertSystemCallArity0(const slang::ast::SystemSubroutine &subroutine,
                 [&]() -> Value {
                   return moore::UrandomBIOp::create(builder, loc, nullptr);
                 })
+          .Case("$random",
+                [&]() -> Value {
+                  return moore::RandomBIOp::create(builder, loc, nullptr);
+                })
           .Case(
               "$time",
               [&]() -> Value { return moore::TimeBIOp::create(builder, loc); })
@@ -1699,6 +1703,10 @@ Context::convertSystemCallArity1(const slang::ast::SystemSubroutine &subroutine,
           .Case("$urandom",
                 [&]() -> Value {
                   return moore::UrandomBIOp::create(builder, loc, value);
+                })
+          .Case("$random",
+                [&]() -> Value {
+                  return moore::RandomBIOp::create(builder, loc, value);
                 })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -267,12 +267,18 @@ endfunction
 // CHECK-LABEL: func.func private @RandomBuiltins(
 // CHECK-SAME: [[X:%.+]]: !moore.i32
 function RandomBuiltins(int x);
-   // CHECK: [[RAND0:%.+]] = moore.builtin.urandom
-   // CHECK-NEXT: call @dummyA([[RAND0]]) : (!moore.i32) -> ()
-   dummyA($urandom());
-    // CHECK: [[RAND1:%.+]] = moore.builtin.urandom [[X]]
-    // CHECK-NEXT: call @dummyA([[RAND1]]) : (!moore.i32) -> ()
-   dummyA($urandom(x));
+  // CHECK: [[URAND0:%.+]] = moore.builtin.urandom
+  // CHECK-NEXT: call @dummyA([[URAND0]]) : (!moore.i32) -> ()
+  dummyA($urandom());
+  // CHECK: [[URAND1:%.+]] = moore.builtin.urandom [[X]]
+  // CHECK-NEXT: call @dummyA([[URAND1]]) : (!moore.i32) -> ()
+  dummyA($urandom(x));
+  // CHECK: [[RAND0:%.+]] = moore.builtin.random
+  // CHECK-NEXT: call @dummyA([[RAND0]]) : (!moore.i32) -> ()
+  dummyA($random());
+  // CHECK: [[RAND1:%.+]] = moore.builtin.random [[X]]
+  // CHECK-NEXT: call @dummyA([[RAND1]]) : (!moore.i32) -> ()
+  dummyA($random(x));
 endfunction
 
 // CHECK-LABEL: func.func private @TimeBuiltins(


### PR DESCRIPTION
This PR adds support for `$random` system calls and maps them to a new Moore builtin-op `RandomBIOp`.

Implementation is very much along the lines of [the $urandom implementation](https://github.com/llvm/circt/pull/8968).
I chose to not map $random and $urandom to the same builtin as they are semantically different, $urandom being pseudo-random, $random being true-random.
