### PR TITLE
[FIRRTL] Various small reduction pattern tweaks

### DIFF
--- a/include/circt/Dialect/Emit/EmitReductions.h
+++ b/include/circt/Dialect/Emit/EmitReductions.h
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_EMIT_EMITREDUCTIONS_H
+#define CIRCT_DIALECT_EMIT_EMITREDUCTIONS_H
+
+#include "circt/Reduce/Reduction.h"
+
+namespace circt {
+namespace emit {
+
+/// Register the Emit Reduction pattern dialect interface to the given registry.
+void registerReducePatternDialectInterface(mlir::DialectRegistry &registry);
+
+} // namespace emit
+} // namespace circt
+
+#endif // CIRCT_DIALECT_EMIT_EMITREDUCTIONS_H

--- a/include/circt/Dialect/HW/InnerSymbolTable.h
+++ b/include/circt/Dialect/HW/InnerSymbolTable.h
@@ -181,12 +181,20 @@ public:
   /// A successful walk with no failures returns success.
   static LogicalResult walkSymbols(Operation *op, InnerSymCallbackFn callback);
 
+  /// Invoke the callback for all symbols in this table.
+  LogicalResult walkSymbols(InnerSymCallbackFn callback) const {
+    for (auto [name, target] : symbolTable)
+      if (failed(callback(name, target)))
+        return failure();
+    return success();
+  }
+
 private:
   using TableTy = DenseMap<StringAttr, InnerSymTarget>;
   /// Construct an inner symbol table for the given operation,
   /// with pre-populated table contents.
   explicit InnerSymbolTable(Operation *op, TableTy &&table)
-      : innerSymTblOp(op), symbolTable(table){};
+      : innerSymTblOp(op), symbolTable(table) {}
 
   /// This is the operation this table is constructed for, which must have the
   /// InnerSymbolTable trait.

--- a/include/circt/Reduce/ReductionUtils.h
+++ b/include/circt/Reduce/ReductionUtils.h
@@ -1,4 +1,4 @@
-//===- ReductionUtils.h - Reduction pattern utilities -----------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,6 +9,7 @@
 #ifndef CIRCT_REDUCE_REDUCTIONUTILS_H
 #define CIRCT_REDUCE_REDUCTIONUTILS_H
 
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Support/LLVM.h"
 
 namespace circt {
@@ -20,6 +21,25 @@ namespace reduce {
 /// Starting at the given `op`, traverse through it and its operands and erase
 /// operations that have no more uses.
 void pruneUnusedOps(Operation *initialOp, Reduction &reduction);
+
+/// A helper struct that scans a root operation and all its nested operations
+/// for `InnerRefAttr`s.
+struct InnerSymbolUses {
+  InnerSymbolUses(Operation *root);
+
+  InnerSymbolUses() = default;
+  InnerSymbolUses(const InnerSymbolUses &) = default;
+  InnerSymbolUses(InnerSymbolUses &&) = default;
+
+  InnerSymbolUses &operator=(const InnerSymbolUses &) = default;
+  InnerSymbolUses &operator=(InnerSymbolUses &&) = default;
+
+  bool hasUses(hw::InnerRefAttr inner) const;
+  bool hasUses(StringAttr mod, StringAttr sym) const;
+
+private:
+  DenseSet<std::pair<StringAttr, StringAttr>> uses;
+};
 
 } // namespace reduce
 } // namespace circt

--- a/include/circt/Reduce/ReductionUtils.h
+++ b/include/circt/Reduce/ReductionUtils.h
@@ -34,22 +34,35 @@ struct InnerSymbolUses {
   InnerSymbolUses &operator=(const InnerSymbolUses &) = default;
   InnerSymbolUses &operator=(InnerSymbolUses &&) = default;
 
-  /// Check whether an op is involved in an `InnerRefAttr`. Considers both the
+  /// Check whether an op is targeted by an inner ref. Considers both the
   /// `sym_name` and the `inner_sym` attributes on the given op.
-  bool hasUses(Operation *op) const;
-  /// Check if the given `InnerRefAttr` is used.
-  bool hasUses(hw::InnerRefAttr inner) const;
-  /// Check if the given module name is involved in an `InnerRefAttr`.
-  bool hasUses(StringAttr mod) const;
-  /// Check if the given module and inner symbol name is involved in an
-  /// `InnerRefAttr`.
-  bool hasUses(StringAttr mod, StringAttr sym) const;
+  bool hasInnerRef(Operation *op) const;
+  /// Check if the given inner ref is used.
+  bool hasInnerRef(hw::InnerRefAttr innerRef) const;
+  /// Check if the given symbol name is targeted by an inner ref.
+  bool hasInnerRef(StringAttr symbol) const;
+  /// Check if the given symbol and inner symbol name pair is targeted by an
+  /// inner ref.
+  bool hasInnerRef(StringAttr symbol, StringAttr innerSym) const;
+
+  /// Check whether the given symbol is targeted by a symbol ref.
+  bool hasSymbolRef(Operation *op) const;
+  /// Check whether the given symbol name is targeted by a symbol ref.
+  bool hasSymbolRef(StringAttr symbol) const;
+
+  /// Check whether the given symbol is targeted by a symbol ref or inner ref.
+  bool hasRef(Operation *op) const;
+  /// Check whether the given symbol name is targeted by a symbol ref or inner
+  /// ref.
+  bool hasRef(StringAttr symbol) const;
 
 private:
-  /// Module and inner symbol name pairs used in `InnerRefAttr`s.
-  DenseSet<std::pair<StringAttr, StringAttr>> uses;
-  /// Module names used in `InnerRefAttr`s.
-  DenseSet<StringAttr> moduleUses;
+  /// Symbol and inner symbol name pairs used in inner refs.
+  DenseSet<std::pair<StringAttr, StringAttr>> innerRefs;
+  /// Symbol names used in inner refs.
+  DenseSet<StringAttr> innerRefModules;
+  /// Symbol names used in symbol or inner refs.
+  DenseSet<StringAttr> symbolRefs;
 };
 
 } // namespace reduce

--- a/include/circt/Reduce/ReductionUtils.h
+++ b/include/circt/Reduce/ReductionUtils.h
@@ -34,11 +34,22 @@ struct InnerSymbolUses {
   InnerSymbolUses &operator=(const InnerSymbolUses &) = default;
   InnerSymbolUses &operator=(InnerSymbolUses &&) = default;
 
+  /// Check whether an op is involved in an `InnerRefAttr`. Considers both the
+  /// `sym_name` and the `inner_sym` attributes on the given op.
+  bool hasUses(Operation *op) const;
+  /// Check if the given `InnerRefAttr` is used.
   bool hasUses(hw::InnerRefAttr inner) const;
+  /// Check if the given module name is involved in an `InnerRefAttr`.
+  bool hasUses(StringAttr mod) const;
+  /// Check if the given module and inner symbol name is involved in an
+  /// `InnerRefAttr`.
   bool hasUses(StringAttr mod, StringAttr sym) const;
 
 private:
+  /// Module and inner symbol name pairs used in `InnerRefAttr`s.
   DenseSet<std::pair<StringAttr, StringAttr>> uses;
+  /// Module names used in `InnerRefAttr`s.
+  DenseSet<StringAttr> moduleUses;
 };
 
 } // namespace reduce

--- a/lib/Dialect/Emit/CMakeLists.txt
+++ b/lib/Dialect/Emit/CMakeLists.txt
@@ -6,10 +6,19 @@
 ##
 ##===----------------------------------------------------------------------===//
 
-add_circt_dialect_library(CIRCTEmit
+set(CIRCT_EMIT_Sources
   EmitDialect.cpp
   EmitOpInterfaces.cpp
   EmitOps.cpp
+)
+
+set(LLVM_OPTIONAL_SOURCES
+  ${CIRCT_EMIT_Sources}
+  EmitReductions.cpp
+)
+
+add_circt_dialect_library(CIRCTEmit
+  ${CIRCT_EMIT_Sources}
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Emit
@@ -25,6 +34,16 @@ add_circt_dialect_library(CIRCTEmit
   MLIRIR
   MLIRPass
   MLIRTransforms
+)
+
+add_circt_library(CIRCTEmitReductions
+  EmitReductions.cpp
+
+  LINK_LIBS PUBLIC
+  CIRCTReduceLib
+  CIRCTEmit
+  CIRCTHW
+  MLIRIR
 )
 
 add_subdirectory(Transforms)

--- a/lib/Dialect/Emit/EmitReductions.cpp
+++ b/lib/Dialect/Emit/EmitReductions.cpp
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Emit/EmitReductions.h"
+#include "circt/Dialect/Emit/EmitOps.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Reduce/ReductionUtils.h"
+#include "mlir/IR/SymbolTable.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "emit-reductions"
+
+using namespace circt;
+using namespace emit;
+
+//===----------------------------------------------------------------------===//
+// Reduction patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// A reduction pattern that erases emit dialect operations.
+struct EmitOpEraser : public Reduction {
+  void beforeReduction(mlir::ModuleOp op) override {
+    innerSymUses = reduce::InnerSymbolUses(op);
+  }
+
+  uint64_t match(Operation *op) override {
+    if (!isa<emit::EmitDialect>(op->getDialect()))
+      return 0;
+    if (innerSymUses.hasRef(op))
+      return 0;
+    return 1;
+  }
+
+  LogicalResult rewrite(Operation *op) override {
+    op->erase();
+    return success();
+  }
+
+  std::string getName() const override { return "emit-op-eraser"; }
+  bool acceptSizeIncrease() const override { return true; }
+
+  reduce::InnerSymbolUses innerSymUses;
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Reduction Registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// A dialect interface to provide reduction patterns to a reducer tool.
+struct EmitReducePatternDialectInterface
+    : public ReducePatternDialectInterface {
+  using ReducePatternDialectInterface::ReducePatternDialectInterface;
+  void populateReducePatterns(ReducePatternSet &patterns) const override {
+    patterns.add<EmitOpEraser, 1000>();
+  }
+};
+} // namespace
+
+void emit::registerReducePatternDialectInterface(
+    mlir::DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, EmitDialect *dialect) {
+    dialect->addInterfaces<EmitReducePatternDialectInterface>();
+  });
+}

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -204,7 +204,7 @@ struct FIRRTLModuleExternalizer : public OpReduction<FModuleOp> {
   void afterReduction(mlir::ModuleOp op) override { nlaRemover.remove(op); }
 
   uint64_t match(FModuleOp module) override {
-    if (innerSymUses.hasUses(module))
+    if (innerSymUses.hasInnerRef(module))
       return 0;
     return moduleSizes.getModuleSize(module, symbols);
   }
@@ -956,11 +956,9 @@ struct NodeSymbolRemover : public Reduction {
     if (!sym || sym.empty())
       return 0;
 
-    // Ignore ops whose inner symbol participates in an NLA.
-    if (auto mod = op->getParentOfType<FModuleLike>())
-      if (innerSymUses.hasUses(mod.getModuleNameAttr(), sym.getSymName()))
-        return 0;
-
+    // Only match ops that have no references to their inner symbol.
+    if (innerSymUses.hasInnerRef(op))
+      return 0;
     return 1;
   }
 

--- a/lib/Reduce/GenericReductions.cpp
+++ b/lib/Reduce/GenericReductions.cpp
@@ -107,8 +107,8 @@ static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
 void circt::populateGenericReducePatterns(MLIRContext *context,
                                           ReducePatternSet &patterns) {
   patterns.add<PassReduction, 103>(context, createSymbolDCEPass());
-  patterns.add<PassReduction, 102>(context, createCSEPass());
-  patterns.add<PassReduction, 101>(context, createSimpleCanonicalizerPass());
+  patterns.add<PassReduction, 102>(context, createSimpleCanonicalizerPass());
+  patterns.add<PassReduction, 101>(context, createCSEPass());
   patterns.add<MakeSymbolsPrivate, 100>();
   patterns.add<UnusedSymbolPruner, 99>();
   patterns.add<OperationPruner, 1>();

--- a/lib/Reduce/ReductionUtils.cpp
+++ b/lib/Reduce/ReductionUtils.cpp
@@ -19,7 +19,7 @@ void reduce::pruneUnusedOps(Operation *initialOp, Reduction &reduction) {
   worklist.push_back(initialOp);
   while (!worklist.empty()) {
     auto *op = worklist.pop_back_val();
-    if (!op->use_empty())
+    if (!op->use_empty() || op->hasAttr("inner_sym"))
       continue;
     for (auto arg : op->getOperands())
       if (auto *argOp = arg.getDefiningOp())

--- a/test/Dialect/Emit/Reduction/emit-op-eraser.mlir
+++ b/test/Dialect/Emit/Reduction/emit-op-eraser.mlir
@@ -1,0 +1,9 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --include emit-op-eraser --keep-best=0 | FileCheck %s
+
+// CHECK-NOT: emit.file
+emit.file "foo" {
+  // CHECK-NOT: emit.verbatim
+  emit.verbatim "bar"
+}

--- a/test/Dialect/Emit/Reduction/pattern-registration.mlir
+++ b/test/Dialect/Emit/Reduction/pattern-registration.mlir
@@ -1,0 +1,10 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+
+// This test checks that only the reduction patterns of dialects that occur in
+// the input file are registered
+
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg cat --list | FileCheck %s
+
+// CHECK-DAG: emit-op-eraser
+emit.file "test.sv" {}

--- a/test/Dialect/FIRRTL/Reduction/annotation-remover.mlir
+++ b/test/Dialect/FIRRTL/Reduction/annotation-remover.mlir
@@ -8,6 +8,7 @@
 // The test uses grep to look for annotation "a", so the reducer should keep that annotation
 // but remove annotations "b" and "c" that don't match the grep pattern.
 
+// CHECK-LABEL: firrtl.circuit "TestAnnotationRemover"
 firrtl.circuit "TestAnnotationRemover" {
   // CHECK: firrtl.module @TestAnnotationRemover
   // CHECK-A-SAME: [{class = "a"}]
@@ -26,4 +27,28 @@ firrtl.circuit "TestAnnotationRemover" {
       {class = "z"}
     ]} : !firrtl.uint<8>
   }
+}
+
+// CHECK-LABEL: firrtl.circuit "DontRemoveNLAsWithUsesOutsideOfAnnotations"
+firrtl.circuit "DontRemoveNLAsWithUsesOutsideOfAnnotations" {
+  firrtl.extmodule @DontRemoveNLAsWithUsesOutsideOfAnnotations()
+
+  // CHECK: hw.hierpath private @nla1
+  hw.hierpath private @nla1 [@Foo::@bar]
+  // CHECK-NOT: hw.hierpath private @nla2
+  hw.hierpath private @nla2 [@Foo::@bar]
+
+  // CHECK: firrtl.module @Foo
+  // CHECK-SAME: someSymbolUse = @nla1
+  firrtl.module @Foo() attributes {someSymbolUse = @nla1} {
+    // CHECK-NEXT: firrtl.instance bar
+    // CHECK-NOT: @nla1
+    // CHECK-NOT: @nla2
+    firrtl.instance bar sym @bar {annotations = [
+      {circt.nonlocal = @nla1},
+      {circt.nonlocal = @nla2}
+    ]} @Bar()
+  }
+
+  firrtl.extmodule @Bar()
 }

--- a/test/Dialect/FIRRTL/Reduction/connect-forwarder.mlir
+++ b/test/Dialect/FIRRTL/Reduction/connect-forwarder.mlir
@@ -1,0 +1,39 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg /usr/bin/env --test-arg true --keep-best=0 --include connect-forwarder | FileCheck %s
+
+firrtl.circuit "DontRemoveSyms" {
+  // CHECK-LABEL: firrtl.module @DontRemoveSyms
+  firrtl.module @DontRemoveSyms(in %input: !firrtl.uint<42>) {
+    // CHECK-NEXT: %wireWithSym = firrtl.wire
+    // CHECK-NOT: %wireWithoutSym = firrtl.wire
+    %wireWithSym = firrtl.wire sym @sym : !firrtl.uint<42>
+    %wireWithoutSym = firrtl.wire : !firrtl.uint<42>
+
+    // CHECK-NOT: firrtl.connect
+    firrtl.connect %wireWithSym, %input : !firrtl.uint<42>, !firrtl.uint<42>
+    firrtl.connect %wireWithoutSym, %input : !firrtl.uint<42>, !firrtl.uint<42>
+
+    // CHECK-NEXT: dbg.variable "wireWithSym", %input
+    // CHECK-NEXT: dbg.variable "wireWithoutSym", %input
+    dbg.variable "wireWithSym", %wireWithSym : !firrtl.uint<42>
+    dbg.variable "wireWithoutSym", %wireWithoutSym : !firrtl.uint<42>
+  }
+}
+
+firrtl.circuit "ForwardThroughRegs" {
+  // CHECK-LABEL: firrtl.module @ForwardThroughRegs
+  firrtl.module @ForwardThroughRegs(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %input: !firrtl.uint<42>) {
+    // CHECK-NOT: %reg0 = firrtl.reg
+    // CHECK-NOT: %reg1 = firrtl.regreset
+    %reg0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<42>
+    %reg1 = firrtl.regreset %clock, %reset, %input : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
+    // CHECK-NOT: firrtl.connect
+    firrtl.connect %reg0, %input : !firrtl.uint<42>, !firrtl.uint<42>
+    firrtl.connect %reg1, %input : !firrtl.uint<42>, !firrtl.uint<42>
+    // CHECK-NEXT: dbg.variable "reg0", %input
+    // CHECK-NEXT: dbg.variable "reg1", %input
+    dbg.variable "reg0", %reg0 : !firrtl.uint<42>
+    dbg.variable "reg1", %reg1 : !firrtl.uint<42>
+  }
+}

--- a/test/Dialect/FIRRTL/Reduction/constantifier.mlir
+++ b/test/Dialect/FIRRTL/Reduction/constantifier.mlir
@@ -1,0 +1,25 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include firrtl-constantifier | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "Simple"
+firrtl.circuit "Simple" {
+  // CHECK: firrtl.module @Simple
+  firrtl.module @Simple() {
+    // Don't touch existing constants.
+    // CHECK-NEXT: firrtl.constant 1337
+    %c1337_ui42 = firrtl.constant 1337 : !firrtl.uint<42>
+
+    // Turn basic operations into constants.
+    // CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.sint<43>
+    // CHECK-NEXT: dbg.variable "neg", [[TMP]]
+    %neg = firrtl.neg %c1337_ui42 : (!firrtl.uint<42>) -> !firrtl.sint<43>
+    dbg.variable "neg", %neg : !firrtl.sint<43>
+
+    // Don't touch operations with inner symbols.
+    // CHECK-NEXT: [[TMP:%.+]] = firrtl.not
+    // CHECK-NEXT: dbg.variable "not", [[TMP]]
+    %not = firrtl.not %c1337_ui42 {inner_sym = @foo} : (!firrtl.uint<42>) -> !firrtl.uint<42>
+    dbg.variable "not", %not : !firrtl.uint<42>
+  }
+}

--- a/test/Dialect/FIRRTL/Reduction/eager-inliner.mlir
+++ b/test/Dialect/FIRRTL/Reduction/eager-inliner.mlir
@@ -1,0 +1,50 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include firrtl-eager-inliner | FileCheck %s
+
+// Test that the EagerInliner reduction does not inline instances that participate in NLAs
+// CHECK-LABEL: firrtl.circuit "SkipInstancesWithNLAs"
+firrtl.circuit "SkipInstancesWithNLAs" {
+  // NLA that goes through the instance we want to preserve
+  hw.hierpath private @nla [@SkipInstancesWithNLAs::@sym, @Child]
+
+  // CHECK: firrtl.module @SkipInstancesWithNLAs
+  firrtl.module @SkipInstancesWithNLAs() {
+    // CHECK-NEXT: firrtl.instance with_nla
+    firrtl.instance with_nla sym @sym @Child()
+    // CHECK-NOT: firrtl.instance without_nla
+    firrtl.instance without_nla @Child()
+  }
+
+  firrtl.module private @Child() {}
+}
+
+// Test that EagerInliner does not inline instances if that leads to inner
+// symbol collisions.
+// CHECK-LABEL: firrtl.circuit "InnerSymCollisions"
+firrtl.circuit "InnerSymCollisions" {
+  // CHECK: firrtl.module @InnerSymCollisions
+  firrtl.module @InnerSymCollisions() {
+    // Cannot inline child1 because inner symbol @foo already defined.
+    // CHECK-NEXT: firrtl.instance child1
+    firrtl.instance child1 @ChildWithSymFoo()
+
+    // Can inline child2 because inner symbol @bar is new.
+    // CHECK-NOT: firrtl.instance child2
+    firrtl.instance child2 @ChildWithSymBar()
+
+    // Define a local @foo inner symbol.
+    firrtl.instance ext sym @foo @Ext()
+  }
+
+  firrtl.module private @ChildWithSymFoo() {
+    firrtl.instance ext sym @foo @Ext()
+  }
+
+  // CHECK-NOT: firrtl.module @ChildWithSymBar
+  firrtl.module private @ChildWithSymBar() {
+    firrtl.instance ext sym @bar @Ext()
+  }
+
+  firrtl.extmodule private @Ext()
+}

--- a/test/Dialect/FIRRTL/Reduction/module-externalizer.mlir
+++ b/test/Dialect/FIRRTL/Reduction/module-externalizer.mlir
@@ -1,0 +1,16 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce --test /usr/bin/env --test-arg true --include firrtl-module-externalizer --keep-best=0 %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "Externalize"
+firrtl.circuit "Externalize" {
+  // CHECK: firrtl.extmodule @Externalize()
+  firrtl.module @Externalize() {}
+
+  // CHECK: firrtl.module @SkipInnerRefs()
+  firrtl.module @SkipInnerRefs() {
+    firrtl.instance inst sym @sym {doNotPrint} @Externalize()
+  }
+
+  firrtl.bind <@SkipInnerRefs::@sym>
+}

--- a/test/Dialect/FIRRTL/Reduction/node-symbol-remover.mlir
+++ b/test/Dialect/FIRRTL/Reduction/node-symbol-remover.mlir
@@ -1,13 +1,13 @@
 // UNSUPPORTED: system-windows
 //   See https://github.com/llvm/circt/issues/4129
-// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "%anotherWire = firrtl.node" --keep-best=0 --include node-symbol-remover | FileCheck %s
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include node-symbol-remover | FileCheck %s
 
 firrtl.circuit "Foo" {
-  // CHECK: firrtl.module @Foo
-  // CHECK: %oneWire = firrtl.wire
+  // CHECK-LABEL: firrtl.module @Foo
+  // CHECK-NEXT: %oneWire = firrtl.wire :
   // CHECK-NEXT: %anotherWire = firrtl.node %oneWire
   firrtl.module @Foo() {
-    %oneWire = firrtl.wire : !firrtl.uint<1>
-    %anotherWire = firrtl.node sym @SYM %oneWire : !firrtl.uint<1>
+    %oneWire = firrtl.wire sym @sym1 : !firrtl.uint<1>
+    %anotherWire = firrtl.node sym @sym2 %oneWire : !firrtl.uint<1>
   }
 }

--- a/tools/circt-reduce/CMakeLists.txt
+++ b/tools/circt-reduce/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBS
   ${mlir_dialect_libs}
 
   CIRCTArcReductions
+  CIRCTEmitReductions
   CIRCTHWReductions
   CIRCTFIRRTLReductions
   CIRCTReduceLib

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Arc/ArcReductions.h"
+#include "circt/Dialect/Emit/EmitReductions.h"
 #include "circt/Dialect/FIRRTL/FIRRTLReductions.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWReductions.h"
@@ -518,6 +519,7 @@ int main(int argc, char **argv) {
   registry.insert<func::FuncDialect, scf::SCFDialect, cf::ControlFlowDialect,
                   LLVM::LLVMDialect>();
   arc::registerReducePatternDialectInterface(registry);
+  emit::registerReducePatternDialectInterface(registry);
   firrtl::registerReducePatternDialectInterface(registry);
   hw::registerReducePatternDialectInterface(registry);
 


### PR DESCRIPTION
- Make the eager inliner not remove instances that are part of an NLA.
- Make the annotation remover not remove NLAs that have remaining uses after some annotations referencing it were removed.
- Make the constantifier not match on existing constants, and not replace operations that have the "inner_sym" attribute.