### PR TITLE
[SCFToCalyx] Adapt to upstream change in `LoopLikeOpInterface`.

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -96,9 +96,10 @@ public:
   }
 
   std::optional<int64_t> getBound() override {
-    return constantTripCount(getOperation().getLowerBound(),
-                             getOperation().getUpperBound(),
-                             getOperation().getStep());
+    auto scfForOp = mlir::cast<scf::ForOp>(getOperation());
+    if (std::optional<APInt> bound = scfForOp.getStaticTripCount())
+      return bound->getZExtValue();
+    return std::nullopt;
   }
 };
 


### PR DESCRIPTION
This PR adapts to a change in `LoopLikeOpInterface` from llvm/llvm-project#158679, which changed the API for getting a statically known iteration count. The PR adapts to the change by using the accessor of the `ForOp` for exactly that information instead of relying on a free function that takes the properties/operands of the op.