### PR TITLE
[ESI2Phy] Adapt usage of rewriter to upcoming version.

### DIFF
--- a/lib/Dialect/ESI/Passes/ESILowerPhysical.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerPhysical.cpp
@@ -249,9 +249,7 @@ PureModuleLowering::matchAndRewrite(ESIPureModuleOp pureMod, OpAdaptor adaptor,
       // the pure module verifier.
       auto existingPort = inputPortNames.find(port.getNameAttr());
       if (existingPort != inputPortNames.end()) {
-        rewriter.replaceAllUsesWith(port.getResult(),
-                                    existingPort->getSecond().getResult());
-        rewriter.eraseOp(port);
+        rewriter.replaceOp(port, existingPort->getSecond().getResult());
         continue;
       }
       // Normal port construction.
@@ -293,8 +291,7 @@ PureModuleLowering::matchAndRewrite(ESIPureModuleOp pureMod, OpAdaptor adaptor,
     rewriter.modifyOpInPlace(hwMod, [&]() {
       newArg = body->addArgument(input.getResult().getType(), input.getLoc());
     });
-    rewriter.replaceAllUsesWith(input.getResult(), newArg);
-    rewriter.eraseOp(input);
+    rewriter.replaceOp(input, newArg);
   }
 
   // Assemble the output values.


### PR DESCRIPTION
This PR changes the combination of `replaceAllUsesWith` followed by `eraseOp` with `replaceOp`, which has the same effect. The original pattern, however, will be unsupported by the upcoming version of the dialect conversion; see llvm/llvm-project#158298.