### PR TITLE
Bump LLVM to 580860e8b7341783e8e53114f26b9a9659a3a3e1

### DIFF
--- a/include/circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h
+++ b/include/circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h
@@ -15,6 +15,7 @@
 #define CIRCT_TOOLS_CIRCT_VERILOG_LSP_SERVER_CIRCTVERILOGLSPSERVERMAIN_H
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/LSP/Transport.h"
 #include <memory>
 #include <optional>
 #include <string>
@@ -43,7 +44,7 @@ struct VerilogServerOptions {
 /// Implementation for tools like `circt-verilog-lsp-server`.
 llvm::LogicalResult
 CirctVerilogLspServerMain(const VerilogServerOptions &options,
-                          mlir::lsp::JSONTransport &transport);
+                          llvm::lsp::JSONTransport &transport);
 
 } // namespace lsp
 } // namespace circt

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -96,9 +96,10 @@ public:
   }
 
   std::optional<int64_t> getBound() override {
-    return constantTripCount(getOperation().getLowerBound(),
-                             getOperation().getUpperBound(),
-                             getOperation().getStep());
+    auto scfForOp = mlir::cast<scf::ForOp>(getOperation());
+    if (std::optional<APInt> bound = scfForOp.getStaticTripCount())
+      return bound->getZExtValue();
+    return std::nullopt;
   }
 };
 

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaInlineSBlocksPass.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaInlineSBlocksPass.cpp
@@ -71,8 +71,7 @@ public:
 
     // Replace the kanagawa.sblock return values with the values that were
     // defined (returned from) within the sblock body, and erase the return op.
-    for (auto [res, val] : llvm::zip(op.getResults(), ret.getRetValues()))
-      rewriter.replaceAllUsesWith(res, val);
+    rewriter.replaceOp(op, ret.getRetValues());
 
     if (hasAttributes) {
       // Close the inline block
@@ -81,7 +80,6 @@ public:
     }
 
     rewriter.eraseOp(ret);
-    rewriter.eraseOp(op);
     return success();
   }
 };

--- a/lib/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.cpp
+++ b/lib/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.cpp
@@ -9,14 +9,11 @@
 #include "circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h"
 #include "LSPServer.h"
 #include "VerilogServerImpl/VerilogServer.h"
-#include "mlir/Tools/lsp-server-support/Transport.h"
-
-using namespace mlir;
-using namespace mlir::lsp;
+#include "llvm/Support/LSP/Transport.h"
 
 llvm::LogicalResult circt::lsp::CirctVerilogLspServerMain(
     const circt::lsp::VerilogServerOptions &options,
-    mlir::lsp::JSONTransport &transport) {
+    llvm::lsp::JSONTransport &transport) {
   circt::lsp::VerilogServer server(options);
   return circt::lsp::runVerilogLSPServer(server, transport);
 }

--- a/lib/Tools/circt-verilog-lsp-server/LSPServer.cpp
+++ b/lib/Tools/circt-verilog-lsp-server/LSPServer.cpp
@@ -8,14 +8,14 @@
 
 #include "LSPServer.h"
 #include "VerilogServerImpl/VerilogServer.h"
-#include "mlir/Tools/lsp-server-support/Protocol.h"
-#include "mlir/Tools/lsp-server-support/Transport.h"
+#include "llvm/Support/LSP/Protocol.h"
+#include "llvm/Support/LSP/Transport.h"
 #include <optional>
 
 #define DEBUG_TYPE "circt-verilog-lsp-server"
 
-using namespace mlir;
-using namespace mlir::lsp;
+using namespace llvm;
+using namespace llvm::lsp;
 
 //===----------------------------------------------------------------------===//
 // LSPServer
@@ -31,7 +31,7 @@ struct LSPServer {
   //===--------------------------------------------------------------------===//
 
   void onInitialize(const InitializeParams &params,
-                    Callback<llvm::json::Value> reply);
+                    Callback<json::Value> reply);
   void onInitialized(const InitializedParams &params);
   void onShutdown(const NoParams &params, Callback<std::nullptr_t> reply);
 
@@ -65,19 +65,19 @@ struct LSPServer {
 //===----------------------------------------------------------------------===//
 
 void LSPServer::onInitialize(const InitializeParams &params,
-                             Callback<llvm::json::Value> reply) {
+                             Callback<json::Value> reply) {
   // Send a response with the capabilities of this server.
-  llvm::json::Object serverCaps{
+  json::Object serverCaps{
       {"textDocumentSync",
-       llvm::json::Object{
+       json::Object{
            {"openClose", true},
            {"change", (int)TextDocumentSyncKind::Incremental},
            {"save", true},
        }}};
 
-  llvm::json::Object result{
-      {{"serverInfo", llvm::json::Object{{"name", "circt-verilog-lsp-server"},
-                                         {"version", "0.0.1"}}},
+  json::Object result{
+      {{"serverInfo", json::Object{{"name", "circt-verilog-lsp-server"},
+                                   {"version", "0.0.1"}}},
        {"capabilities", std::move(serverCaps)}}};
   reply(std::move(result));
 }
@@ -153,9 +153,9 @@ LogicalResult circt::lsp::runVerilogLSPServer(VerilogServer &server,
           "textDocument/publishDiagnostics");
 
   // Run the main loop of the transport.
-  if (llvm::Error error = transport.run(messageHandler)) {
+  if (Error error = transport.run(messageHandler)) {
     Logger::error("Transport error: {0}", error);
-    llvm::consumeError(std::move(error));
+    consumeError(std::move(error));
     return failure();
   }
 

--- a/lib/Tools/circt-verilog-lsp-server/LSPServer.h
+++ b/lib/Tools/circt-verilog-lsp-server/LSPServer.h
@@ -9,6 +9,8 @@
 #ifndef LIB_CIRCT_TOOLS_CIRCT_VERILOG_LSP_LSPSERVER_H
 #define LIB_CIRCT_TOOLS_CIRCT_VERILOG_LSP_LSPSERVER_H
 
+#include "llvm/Support/LSP/Transport.h"
+
 #include <memory>
 
 namespace llvm {
@@ -27,7 +29,7 @@ class VerilogServer;
 /// Run the main loop of the LSP server using the given Verilog server and
 /// transport.
 llvm::LogicalResult runVerilogLSPServer(VerilogServer &server,
-                                        mlir::lsp::JSONTransport &transport);
+                                        llvm::lsp::JSONTransport &transport);
 
 } // namespace lsp
 } // namespace circt

--- a/lib/Tools/circt-verilog-lsp-server/Utils/LSPUtils.cpp
+++ b/lib/Tools/circt-verilog-lsp-server/Utils/LSPUtils.cpp
@@ -11,16 +11,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "LSPUtils.h"
-#include "mlir/Tools/lsp-server-support/Logging.h"
+#include "llvm/Support/LSP/Logging.h"
 
 void circt::lsp::Logger::error(Twine message) {
-  mlir::lsp::Logger::error("{}", message);
+  llvm::lsp::Logger::error("{}", message);
 }
 
 void circt::lsp::Logger::info(Twine message) {
-  mlir::lsp::Logger::info("{}", message);
+  llvm::lsp::Logger::info("{}", message);
 }
 
 void circt::lsp::Logger::debug(Twine message) {
-  mlir::lsp::Logger::debug("{}", message);
+  llvm::lsp::Logger::debug("{}", message);
 }

--- a/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogServer.h
+++ b/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogServer.h
@@ -14,8 +14,9 @@
 #ifndef LIB_CIRCT_TOOLS_CIRCT_VERILOG_LSP_SERVER_VERILOGSERVER_H_
 #define LIB_CIRCT_TOOLS_CIRCT_VERILOG_LSP_SERVER_VERILOGSERVER_H_
 
-#include "mlir/Support/LLVM.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/LSP/Protocol.h"
+
 #include <memory>
 #include <optional>
 #include <vector>
@@ -32,9 +33,9 @@ namespace circt {
 namespace lsp {
 struct VerilogServerOptions;
 using TextDocumentContentChangeEvent =
-    mlir::lsp::TextDocumentContentChangeEvent;
-using URIForFile = mlir::lsp::URIForFile;
-using Diagnostic = mlir::lsp::Diagnostic;
+    llvm::lsp::TextDocumentContentChangeEvent;
+using URIForFile = llvm::lsp::URIForFile;
+using Diagnostic = llvm::lsp::Diagnostic;
 
 /// This class implements all of the Verilog related functionality necessary for
 /// a language server. This class allows for keeping the Verilog specific logic

--- a/tools/circt-verilog-lsp-server/circt-verilog-lsp-server.cpp
+++ b/tools/circt-verilog-lsp-server/circt-verilog-lsp-server.cpp
@@ -12,14 +12,13 @@
 
 #include "circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h"
 
-#include "mlir/Tools/lsp-server-support/Logging.h"
-#include "mlir/Tools/lsp-server-support/Transport.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/LSP/Logging.h"
+#include "llvm/Support/LSP/Transport.h"
 #include "llvm/Support/Program.h"
 
-using namespace mlir;
-using namespace mlir::lsp;
+using namespace llvm::lsp;
 
 int main(int argc, char **argv) {
   //===--------------------------------------------------------------------===//
@@ -37,16 +36,16 @@ int main(int argc, char **argv) {
       llvm::cl::init(Logger::Level::Info),
   };
 
-  llvm::cl::opt<mlir::lsp::JSONStreamStyle> inputStyle{
+  llvm::cl::opt<llvm::lsp::JSONStreamStyle> inputStyle{
       "input-style",
       llvm::cl::desc("Input JSON stream encoding"),
-      llvm::cl::values(clEnumValN(mlir::lsp::JSONStreamStyle::Standard,
+      llvm::cl::values(clEnumValN(llvm::lsp::JSONStreamStyle::Standard,
                                   "standard", "usual LSP protocol"),
-                       clEnumValN(mlir::lsp::JSONStreamStyle::Delimited,
+                       clEnumValN(llvm::lsp::JSONStreamStyle::Delimited,
                                   "delimited",
                                   "messages delimited by `// -----` lines, "
                                   "with // comment support")),
-      llvm::cl::init(mlir::lsp::JSONStreamStyle::Standard),
+      llvm::cl::init(llvm::lsp::JSONStreamStyle::Standard),
       llvm::cl::Hidden,
   };
 
@@ -82,17 +81,17 @@ int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(argc, argv, "Verilog LSP Language Server");
 
   if (litTest) {
-    inputStyle = mlir::lsp::JSONStreamStyle::Delimited;
-    logLevel = mlir::lsp::Logger::Level::Debug;
+    inputStyle = llvm::lsp::JSONStreamStyle::Delimited;
+    logLevel = llvm::lsp::Logger::Level::Debug;
     prettyPrint = true;
   }
 
   // Configure the logger.
-  mlir::lsp::Logger::setLogLevel(logLevel);
+  llvm::lsp::Logger::setLogLevel(logLevel);
 
   // Configure the transport used for communication.
   (void)llvm::sys::ChangeStdinToBinary();
-  mlir::lsp::JSONTransport transport(stdin, llvm::outs(), inputStyle,
+  llvm::lsp::JSONTransport transport(stdin, llvm::outs(), inputStyle,
                                      prettyPrint);
 
   // Configure the servers and start the main language server.


### PR DESCRIPTION
Changes:

* The LSP support has moved from the MLIR to the LLVM namespace (https://github.com/llvm/llvm-project/commit/a3a25996b11401f7589d1429225dc048d8720da9) . 
* Remove another occurrence of `replaceAllUses`+`erase` in Kanagawa's InlineSBlocks pass (see #8989)
* Integrate the SCFToCalyx change of #8987