### PR TITLE
[Synth] LowerWordsToBits: Improve scalability with bit-sensitive constprop

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -38,6 +38,15 @@ struct AndInverterVariadicOpConversion
                   mlir::PatternRewriter &rewriter) const override;
 };
 
+/// This function performs a topological sort on the operations within each
+/// block of graph regions in the given operation. It uses MLIR's topological
+/// sort utility as a wrapper, ensuring that operations are ordered such that
+/// all operands are defined before their uses. The `isOperandReady` callback
+/// allows customization of when an operand is considered ready for sorting.
+LogicalResult topologicallySortGraphRegionBlocks(
+    mlir::Operation *op,
+    llvm::function_ref<bool(mlir::Value, mlir::Operation *)> isOperandReady);
+
 } // namespace synth
 } // namespace circt
 

--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -84,6 +84,14 @@ def LowerVariadic : Pass<"synth-lower-variadic", "hw::HWModuleOp"> {
 def LowerWordToBits : Pass<"synth-lower-word-to-bits", "hw::HWModuleOp"> {
   let summary = "Lower multi-bit AndInverter to single-bit ones";
   let dependentDialects = ["comb::CombDialect"];
+  let statistics = [
+    Statistic<"numLoweredBits", "num-lowered-bits",
+              "Number of total bits lowered including constant">,
+    Statistic<"numLoweredConstants", "num-lowered-constants",
+              "Number of total constant bits lowered">,
+    Statistic<"numLoweredOps", "num-lowered-ops",
+              "Number of total operations lowered">,
+  ];
 }
 
 def PrintLongestPathAnalysis

--- a/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
@@ -1,4 +1,4 @@
-//===- LowerWordToBits.cpp - Bit-Blasting Words to Bits ---------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass lowers multi-bit AIG operations to single-bit ones.
+// This pass implements bit-blasting for logic synthesis operations.
+// It converts multi-bit operations (AIG, MIG, combinatorial) into equivalent
+// single-bit operations, enabling more efficient synthesis and optimization.
 //
 //===----------------------------------------------------------------------===//
 
@@ -14,7 +16,14 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/Synth/SynthOps.h"
 #include "circt/Dialect/Synth/Transforms/SynthPasses.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/KnownBits.h"
+#include "llvm/Support/LogicalResult.h"
 
 #define DEBUG_TYPE "synth-lower-word-to-bits"
 
@@ -29,56 +38,358 @@ using namespace circt;
 using namespace synth;
 
 //===----------------------------------------------------------------------===//
-// Rewrite patterns
+// Utilities
 //===----------------------------------------------------------------------===//
 
+/// Check if an operation should be lowered to bit-level operations.
+static bool shouldLowerOperation(Operation *op) {
+  return isa<aig::AndInverterOp, mig::MajorityInverterOp, comb::AndOp,
+             comb::OrOp, comb::XorOp>(op);
+}
+
 namespace {
-template <typename OpTy>
-struct WordRewritePattern : public OpRewritePattern<OpTy> {
-  using OpRewritePattern<OpTy>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(OpTy op,
-                                PatternRewriter &rewriter) const override {
-    auto width = op.getType().getIntOrFloatBitWidth();
-    if (width <= 1)
-      return failure();
+//===----------------------------------------------------------------------===//
+// BitBlaster - Bit-level lowering implementation
+//===----------------------------------------------------------------------===//
 
-    SmallVector<Value> results;
-    // We iterate over the width in reverse order to match the endianness of
-    // `comb.concat`.
-    for (int64_t i = width - 1; i >= 0; --i) {
-      SmallVector<Value> operands;
-      for (auto operand : op.getOperands()) {
-        // Reuse bits if we can extract from `comb.concat` operands.
-        if (auto concat = operand.template getDefiningOp<comb::ConcatOp>()) {
-          // For the simplicity, we only handle the case where all the
-          // `comb.concat` operands are single-bit.
-          if (concat.getNumOperands() == width &&
-              llvm::all_of(concat.getOperandTypes(), [](Type type) {
-                return type.getIntOrFloatBitWidth() == 1;
-              })) {
-            // Be careful with the endianness here.
-            operands.push_back(concat.getOperand(width - i - 1));
-            continue;
-          }
-        }
-        // Otherwise, we need to extract the bit.
-        operands.push_back(
-            comb::ExtractOp::create(rewriter, op.getLoc(), operand, i, 1));
-      }
-      results.push_back(
-          OpTy::create(rewriter, op.getLoc(), operands, op.getInvertedAttr()));
-    }
+/// The BitBlaster class implements the core bit-blasting algorithm.
+/// It manages the lowering of multi-bit operations to single-bit operations
+/// while maintaining correctness and optimizing for constant propagation.
+class BitBlaster {
+public:
+  explicit BitBlaster(hw::HWModuleOp moduleOp) : moduleOp(moduleOp) {}
 
-    rewriter.replaceOpWithNewOp<comb::ConcatOp>(op, results);
-    return success();
+  /// Run the bit-blasting algorithm on the module.
+  LogicalResult run();
+
+  //===--------------------------------------------------------------------===//
+  // Statistics
+  //===--------------------------------------------------------------------===//
+
+  /// Number of bits that were lowered from multi-bit to single-bit operations
+  size_t numLoweredBits = 0;
+
+  /// Number of constant bits that were identified and optimized
+  size_t numLoweredConstants = 0;
+
+  /// Number of operations that were lowered
+  size_t numLoweredOps = 0;
+
+private:
+  //===--------------------------------------------------------------------===//
+  // Core Lowering Methods
+  //===--------------------------------------------------------------------===//
+
+  /// Lower a multi-bit value to individual bits.
+  /// This is the main entry point for bit-blasting a value.
+  ArrayRef<Value> lowerValueToBits(Value value);
+  template <typename OpTy>
+  ArrayRef<Value> lowerInvertibleOperations(OpTy op);
+  template <typename OpTy>
+  ArrayRef<Value> lowerCombOperations(OpTy op);
+  ArrayRef<Value>
+  lowerOp(Operation *op,
+          llvm::function_ref<Value(OpBuilder &builder, ValueRange)> createOp);
+
+  /// Extract a specific bit from a value.
+  /// Handles various IR constructs that can represent bit extraction.
+  Value extractBit(Value value, size_t index);
+
+  /// Compute and cache known bits for a value.
+  /// Uses operation-specific logic to determine which bits are constants.
+  const llvm::KnownBits &computeKnownBits(Value value);
+
+  /// Get or create a boolean constant (0 or 1).
+  /// Constants are cached to avoid duplication.
+  Value getBoolConstant(bool value);
+
+  //===--------------------------------------------------------------------===//
+  // Helper Methods
+  //===--------------------------------------------------------------------===//
+
+  /// Insert lowered bits into the cache.
+  ArrayRef<Value> insertBits(Value value, SmallVector<Value> bits) {
+    auto it = loweredValues.insert({value, std::move(bits)});
+    assert(it.second && "value already inserted");
+    return it.first->second;
   }
+
+  /// Insert computed known bits into the cache.
+  const llvm::KnownBits &insertKnownBits(Value value, llvm::KnownBits bits) {
+    auto it = knownBits.insert({value, std::move(bits)});
+    return it.first->second;
+  }
+
+  /// Cache for lowered values (multi-bit -> vector of single-bit values)
+  llvm::MapVector<Value, SmallVector<Value>> loweredValues;
+
+  /// Cache for computed known bits information
+  llvm::MapVector<Value, llvm::KnownBits> knownBits;
+
+  /// Cached boolean constants (false at index 0, true at index 1)
+  std::array<Value, 2> constants;
+
+  /// Reference to the module being processed
+  hw::HWModuleOp moduleOp;
 };
 
 } // namespace
 
 //===----------------------------------------------------------------------===//
-// Lower Word to Bits pass
+// BitBlaster Implementation
+//===----------------------------------------------------------------------===//
+
+const llvm::KnownBits &BitBlaster::computeKnownBits(Value value) {
+  // Check cache first
+  auto *it = knownBits.find(value);
+  if (it != knownBits.end())
+    return it->second;
+
+  auto width = hw::getBitWidth(value.getType());
+  auto *op = value.getDefiningOp();
+
+  // For block arguments, return unknown bits
+  if (!op)
+    return insertKnownBits(value, llvm::KnownBits(width));
+
+  llvm::KnownBits result(width);
+  if (auto aig = dyn_cast<aig::AndInverterOp>(op)) {
+    // Initialize to all ones for AND operation
+    result.One = APInt::getAllOnes(width);
+    result.Zero = APInt::getZero(width);
+
+    for (auto [operand, inverted] :
+         llvm::zip(aig.getInputs(), aig.getInverted())) {
+      auto operandKnownBits = computeKnownBits(operand);
+      if (inverted)
+        // Complement the known bits by swapping Zero and One
+        std::swap(operandKnownBits.Zero, operandKnownBits.One);
+      result &= operandKnownBits;
+    }
+  } else if (auto mig = dyn_cast<mig::MajorityInverterOp>(op)) {
+    // Give up if it's not a 3-input majority inverter.
+    if (mig.getNumOperands() == 3) {
+      std::array<llvm::KnownBits, 3> operandsKnownBits;
+      for (auto [i, operand, inverted] :
+           llvm::enumerate(mig.getInputs(), mig.getInverted())) {
+        operandsKnownBits[i] = computeKnownBits(operand);
+        // Complement the known bits by swapping Zero and One
+        if (inverted)
+          std::swap(operandsKnownBits[i].Zero, operandsKnownBits[i].One);
+      }
+
+      result = (operandsKnownBits[0] & operandsKnownBits[1]) |
+               (operandsKnownBits[0] & operandsKnownBits[2]) |
+               (operandsKnownBits[1] & operandsKnownBits[2]);
+    }
+  } else {
+    // For other operations, use the standard known bits computation
+    // TODO: This is not optimal as it has a depth limit and does not check
+    // cached results.
+    result = comb::computeKnownBits(value);
+  }
+
+  return insertKnownBits(value, std::move(result));
+}
+
+Value BitBlaster::extractBit(Value value, size_t index) {
+  if (hw::getBitWidth(value.getType()) <= 1)
+    return value;
+
+  auto *op = value.getDefiningOp();
+
+  // If the value is a block argument, extract the bit.
+  if (!op)
+    return lowerValueToBits(value)[index];
+
+  return TypeSwitch<Operation *, Value>(op)
+      .Case<comb::ConcatOp>([&](comb::ConcatOp op) {
+        for (auto operand : llvm::reverse(op.getOperands())) {
+          auto width = hw::getBitWidth(operand.getType());
+          assert(width >= 0 && "operand has zero width");
+          if (index < static_cast<size_t>(width))
+            return extractBit(operand, index);
+          index -= static_cast<size_t>(width);
+        }
+        llvm_unreachable("index out of bounds");
+      })
+      .Case<comb::ExtractOp>([&](comb::ExtractOp ext) {
+        return extractBit(ext.getInput(),
+                          static_cast<size_t>(ext.getLowBit()) + index);
+      })
+      .Case<comb::ReplicateOp>([&](comb::ReplicateOp op) {
+        return extractBit(op.getInput(),
+                          index % static_cast<size_t>(hw::getBitWidth(
+                                      op.getOperand().getType())));
+      })
+      .Case<hw::ConstantOp>([&](hw::ConstantOp op) {
+        auto value = op.getValue();
+        return getBoolConstant(value[index]);
+      })
+      .Default([&](auto op) { return lowerValueToBits(value)[index]; });
+}
+
+ArrayRef<Value> BitBlaster::lowerValueToBits(Value value) {
+  auto *it = loweredValues.find(value);
+  if (it != loweredValues.end())
+    return it->second;
+
+  auto width = hw::getBitWidth(value.getType());
+  if (width <= 1)
+    return insertBits(value, {value});
+
+  auto *op = value.getDefiningOp();
+  if (!op) {
+    SmallVector<Value> results;
+    OpBuilder builder(value.getContext());
+    builder.setInsertionPointAfterValue(value);
+    comb::extractBits(builder, value, results);
+    return insertBits(value, std::move(results));
+  }
+
+  return TypeSwitch<Operation *, ArrayRef<Value>>(op)
+      .Case<aig::AndInverterOp, mig::MajorityInverterOp>(
+          [&](auto op) { return lowerInvertibleOperations(op); })
+      .Case<comb::AndOp, comb::OrOp, comb::XorOp>(
+          [&](auto op) { return lowerCombOperations(op); })
+      .Default([&](auto op) {
+        OpBuilder builder(value.getContext());
+        builder.setInsertionPoint(op);
+        SmallVector<Value> results;
+        comb::extractBits(builder, value, results);
+
+        return insertBits(value, std::move(results));
+      });
+}
+
+LogicalResult BitBlaster::run() {
+  // Topologically sort operations in graph regions so that walk visits them in
+  // the topological order.
+  if (failed(topologicallySortGraphRegionBlocks(
+          moduleOp, [](Value value, Operation *op) -> bool {
+            // Otherthan target ops, all other ops are always ready.
+            return !(shouldLowerOperation(op) ||
+                     isa<comb::ExtractOp, comb::ReplicateOp, comb::ConcatOp,
+                         comb::ReplicateOp>(op));
+          }))) {
+    // If we failed to topologically sort operations we cannot proceed.
+    return mlir::emitError(moduleOp.getLoc(), "there is a combinational cycle");
+  }
+
+  // Lower target operations
+  moduleOp.walk([&](Operation *op) {
+    // If the block is in a graph region, topologically sort it first.
+    if (shouldLowerOperation(op))
+      (void)lowerValueToBits(op->getResult(0));
+  });
+
+  // Replace operations with concatenated results if needed
+  for (auto &[value, results] :
+       llvm::make_early_inc_range(llvm::reverse(loweredValues))) {
+    if (hw::getBitWidth(value.getType()) <= 1)
+      continue;
+
+    auto *op = value.getDefiningOp();
+    if (!op)
+      continue;
+
+    if (value.use_empty()) {
+      op->erase();
+      continue;
+    }
+
+    // If a target operation still has an use (e.g. connected to output or
+    // instance), replace the value with the concatenated result.
+    if (shouldLowerOperation(op)) {
+      OpBuilder builder(op);
+      std::reverse(results.begin(), results.end());
+      auto concat = builder.create<comb::ConcatOp>(value.getLoc(), results);
+      value.replaceAllUsesWith(concat);
+      op->erase();
+    }
+  }
+
+  return success();
+}
+
+Value BitBlaster::getBoolConstant(bool value) {
+  if (!constants[value]) {
+    auto builder = OpBuilder::atBlockBegin(moduleOp.getBodyBlock());
+    constants[value] = builder.create<hw::ConstantOp>(
+        builder.getUnknownLoc(), builder.getI1Type(), value);
+  }
+  return constants[value];
+}
+
+template <typename OpTy>
+ArrayRef<Value> BitBlaster::lowerInvertibleOperations(OpTy op) {
+  auto createOp = [&](OpBuilder &builder, ValueRange operands) {
+    return builder.createOrFold<OpTy>(op.getLoc(), operands, op.getInverted());
+  };
+  return lowerOp(op, createOp);
+}
+
+template <typename OpTy>
+ArrayRef<Value> BitBlaster::lowerCombOperations(OpTy op) {
+  auto createOp = [&](OpBuilder &builder, ValueRange operands) {
+    return builder.createOrFold<OpTy>(op.getLoc(), operands,
+                                      op.getTwoStateAttr());
+  };
+  return lowerOp(op, createOp);
+}
+
+ArrayRef<Value> BitBlaster::lowerOp(
+    Operation *op,
+    llvm::function_ref<Value(OpBuilder &builder, ValueRange)> createOp) {
+  auto value = op->getResult(0);
+  OpBuilder builder(op);
+  auto width = hw::getBitWidth(value.getType());
+  assert(width > 1 && "expected multi-bit operation");
+
+  auto known = computeKnownBits(value);
+  APInt knownMask = known.Zero | known.One;
+
+  // Update statistics
+  numLoweredConstants += knownMask.popcount();
+  numLoweredBits += width;
+  ++numLoweredOps;
+
+  SmallVector<Value> results;
+  results.reserve(width);
+
+  for (int64_t i = 0; i < width; ++i) {
+    SmallVector<Value> operands;
+    operands.reserve(op->getNumOperands());
+    if (knownMask[i]) {
+      // Use known constant value
+      results.push_back(getBoolConstant(known.One[i]));
+      continue;
+    }
+
+    // Extract the i-th bit from each operand
+    for (auto operand : op->getOperands())
+      operands.push_back(extractBit(operand, i));
+
+    // Create the single-bit operation
+    auto result = createOp(builder, operands);
+    results.push_back(result);
+
+    // Add name hint if present
+    if (auto name = op->getAttrOfType<StringAttr>("sv.namehint")) {
+      auto newName = StringAttr::get(
+          op->getContext(), name.getValue() + "[" + std::to_string(i) + "]");
+      if (auto *loweredOp = result.getDefiningOp())
+        loweredOp->setAttr("sv.namehint", newName);
+    }
+  }
+
+  assert(results.size() == static_cast<size_t>(width));
+  return insertBits(value, std::move(results));
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
 //===----------------------------------------------------------------------===//
 
 namespace {
@@ -89,16 +400,12 @@ struct LowerWordToBitsPass
 } // namespace
 
 void LowerWordToBitsPass::runOnOperation() {
-  RewritePatternSet patterns(&getContext());
-  patterns.add<WordRewritePattern<aig::AndInverterOp>,
-               WordRewritePattern<mig::MajorityInverterOp>>(&getContext());
-
-  mlir::FrozenRewritePatternSet frozenPatterns(std::move(patterns));
-  mlir::GreedyRewriteConfig config;
-  // Use top-down traversal to reuse bits from `comb.concat`.
-  config.setUseTopDownTraversal(true);
-
-  if (failed(
-          mlir::applyPatternsGreedily(getOperation(), frozenPatterns, config)))
+  BitBlaster driver(getOperation());
+  if (failed(driver.run()))
     return signalPassFailure();
+
+  // Update statistics
+  numLoweredBits += driver.numLoweredBits;
+  numLoweredConstants += driver.numLoweredConstants;
+  numLoweredOps += driver.numLoweredOps;
 }

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -3,30 +3,84 @@
 hw.module @Basic(in %a: i2, in %b: i2, out f: i2) {
   %0 = synth.aig.and_inv not %a, %b : i2
   %1 = synth.aig.and_inv not %0, not %0 : i2
-  // CHECK-NEXT: %[[EXTRACT_A_1:.+]] = comb.extract %a from 1
-  // CHECK-NEXT: %[[EXTRACT_B_1:.+]] = comb.extract %b from 1
-  // CHECK-NEXT: %[[AND_INV_0:.+]] = synth.aig.and_inv not %[[EXTRACT_A_1]], %[[EXTRACT_B_1]]
-  // CHECK-NEXT: %[[EXTRACT_A_0:.+]] = comb.extract %a from 0
-  // CHECK-NEXT: %[[EXTRACT_B_0:.+]] = comb.extract %b from 0
-  // CHECK-NEXT: %[[AND_INV_1:.+]] = synth.aig.and_inv not %[[EXTRACT_A_0]], %[[EXTRACT_B_0]]
-  // CHECK-NEXT: %[[AND_INV_2:.+]] = synth.aig.and_inv not %[[AND_INV_0]], not %[[AND_INV_0]]
-  // CHECK-NEXT: %[[AND_INV_3:.+]] = synth.aig.and_inv not %[[AND_INV_1]], not %[[AND_INV_1]]
-  // CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %[[AND_INV_2]], %[[AND_INV_3]]
+  // CHECK-DAG: %[[EXTRACT_A_1:.+]] = comb.extract %a from 1
+  // CHECK-DAG: %[[EXTRACT_B_1:.+]] = comb.extract %b from 1
+  // CHECK-DAG: %[[AND_INV_0:.+]] = synth.aig.and_inv not %[[EXTRACT_A_1]], %[[EXTRACT_B_1]]
+  // CHECK-DAG: %[[EXTRACT_A_0:.+]] = comb.extract %a from 0
+  // CHECK-DAG: %[[EXTRACT_B_0:.+]] = comb.extract %b from 0
+  // CHECK-DAG: %[[AND_INV_1:.+]] = synth.aig.and_inv not %[[EXTRACT_A_0]], %[[EXTRACT_B_0]]
+  // CHECK-DAG: %[[AND_INV_2:.+]] = synth.aig.and_inv not %[[AND_INV_0]], not %[[AND_INV_0]]
+  // CHECK-DAG: %[[AND_INV_3:.+]] = synth.aig.and_inv not %[[AND_INV_1]], not %[[AND_INV_1]]
+  // CHECK-DAG: %[[CONCAT:.+]] = comb.concat %[[AND_INV_2]], %[[AND_INV_3]]
   hw.output %1 : i2
 }
 
 // CHECK-LABEL: hw.module @Basic_MIG
 hw.module @Basic_MIG(in %a: i2, in %b: i2, in %c: i2, out f: i2) {
   %0 = synth.mig.maj_inv not %a, %b, %c : i2
-  // CHECK-NEXT: %[[EXTRACT_A_1:.+]] = comb.extract %a from 1 : (i2) -> i1
-  // CHECK-NEXT: %[[EXTRACT_B_1:.+]] = comb.extract %b from 1 : (i2) -> i1
-  // CHECK-NEXT: %[[EXTRACT_C_1:.+]] = comb.extract %c from 1 : (i2) -> i1
-  // CHECK-NEXT: %[[MAJ_INV_0:.+]] = synth.mig.maj_inv not %[[EXTRACT_A_1]], %[[EXTRACT_B_1]], %[[EXTRACT_C_1]] : i1
-  // CHECK-NEXT: %[[EXTRACT_A_0:.+]] = comb.extract %a from 0 : (i2) -> i1
-  // CHECK-NEXT: %[[EXTRACT_B_0:.+]] = comb.extract %b from 0 : (i2) -> i1
-  // CHECK-NEXT: %[[EXTRACT_C_0:.+]] = comb.extract %c from 0 : (i2) -> i1
-  // CHECK-NEXT: %[[MAJ_INV_1:.+]] = synth.mig.maj_inv not %[[EXTRACT_A_0]], %[[EXTRACT_B_0]], %[[EXTRACT_C_0]] : i1
-  // CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %[[MAJ_INV_0]], %[[MAJ_INV_1]] : i1, i1
-  // CHECK-NEXT: hw.output %[[CONCAT]] : i2
+  // CHECK-DAG: %[[EXTRACT_A_1:.+]] = comb.extract %a from 1 : (i2) -> i1
+  // CHECK-DAG: %[[EXTRACT_B_1:.+]] = comb.extract %b from 1 : (i2) -> i1
+  // CHECK-DAG: %[[EXTRACT_C_1:.+]] = comb.extract %c from 1 : (i2) -> i1
+  // CHECK-DAG: %[[MAJ_INV_0:.+]] = synth.mig.maj_inv not %[[EXTRACT_A_1]], %[[EXTRACT_B_1]], %[[EXTRACT_C_1]] : i1
+  // CHECK-DAG: %[[EXTRACT_A_0:.+]] = comb.extract %a from 0 : (i2) -> i1
+  // CHECK-DAG: %[[EXTRACT_B_0:.+]] = comb.extract %b from 0 : (i2) -> i1
+  // CHECK-DAG: %[[EXTRACT_C_0:.+]] = comb.extract %c from 0 : (i2) -> i1
+  // CHECK-DAG: %[[MAJ_INV_1:.+]] = synth.mig.maj_inv not %[[EXTRACT_A_0]], %[[EXTRACT_B_0]], %[[EXTRACT_C_0]] : i1
+  // CHECK-DAG: %[[CONCAT:.+]] = comb.concat %[[MAJ_INV_0]], %[[MAJ_INV_1]] : i1, i1
+  // CHECK-DAG: hw.output %[[CONCAT]] : i2
+  hw.output %0 : i2
+}
+
+// CHECK-LABEL: hw.module @Basic_Comb
+hw.module @Basic_Comb(in %a: i2, in %b: i2, out f: i2) {
+  %0 = comb.and %a, %b : i2
+  %1 = comb.or %a, %b : i2
+  %2 = comb.xor %a, %b : i2
+  // CHECK-DAG: %[[EXTRACT_A_1:.+]] = comb.extract %a from 1 : (i2) -> i1
+  // CHECK-DAG: %[[EXTRACT_B_1:.+]] = comb.extract %b from 1 : (i2) -> i1
+  // CHECK-DAG: %[[AND_0:.+]] = comb.and %[[EXTRACT_A_1]], %[[EXTRACT_B_1]]
+  // CHECK-DAG: %[[EXTRACT_A_0:.+]] = comb.extract %a from 0 : (i2) -> i1
+  // CHECK-DAG: %[[EXTRACT_B_0:.+]] = comb.extract %b from 0 : (i2) -> i1
+  // CHECK-DAG: %[[AND_1:.+]] = comb.and %[[EXTRACT_A_0]], %[[EXTRACT_B_0]]
+  // CHECK-DAG: %[[CONCAT:.+]] = comb.concat %[[AND_0]], %[[AND_1]]
+  // CHECK-DAG: hw.output %[[CONCAT]] : i2
+  hw.output %0 : i2
+}
+
+// CHECK-LABEL: hw.module @Constant_Propagation
+hw.module @Constant_Propagation(in %a: i2, out f: i2) {
+  // Create a scenario where some bits are known constants
+  %c0_i2 = hw.constant 0 : i2
+  %0 = synth.aig.and_inv %a, %c0_i2 : i2
+  // CHECK-NOT: synth.aig.and_inv
+  hw.output %0 : i2
+}
+
+
+// CHECK-LABEL: hw.module @Complex_Constant_Patterns
+hw.module @Complex_Constant_Patterns(in %a: i2, in %b: i2, out f: i2) {
+  // Test with mixed constant patterns
+  %c1_i2 = hw.constant 1 : i2 // 0b0101
+  %c2_i2 = hw.constant 2 : i2 // 0b1010
+  %0 = synth.aig.and_inv %a, %c1_i2 : i2 // should keep bits 0 'a', bits 1 is zero
+  %1 = synth.aig.and_inv not %b, not %c2_i2 : i2 // should keep bits 0 not 'b', bits 1 is zero
+  %2 = synth.mig.maj_inv %c2_i2, %0, %1 : i2  // bits 1 is 0
+  // CHECK-DAG: %false = hw.constant false
+  // CHECK-DAG: %[[EXTRACT_A_0:.+]] = comb.extract %a from 0 : (i2) -> i1
+  // CHECK-DAG: %[[EXTRACT_B_0:.+]] = comb.extract %b from 0 : (i2) -> i1
+  // CHECK-DAG: %[[AND_INV_0:.+]] = synth.aig.and_inv not %[[EXTRACT_B_0]], not %false : i1
+  // CHECK-DAG: %[[MAJ_INV_0:.+]] = synth.mig.maj_inv %false, %[[EXTRACT_A_0]], %[[AND_INV_0]] : i1
+  // CHECK-DAG: %[[CONCAT:.+]] = comb.concat %false, %[[MAJ_INV_0]] : i1, i1
+  // CHECK-DAG: hw.output %[[CONCAT]]
+  hw.output %2 : i2
+}
+
+// CHECK-LABEL: hw.module @Namehint
+hw.module @Namehint(in %a: i2, in %b: i2, out f: i2) {
+  %0 = synth.aig.and_inv %a, %b {sv.namehint = "foo"}: i2
+  // CHECK:      %[[AND_INV_0:.+]] = synth.aig.and_inv
+  // CHECK-SAME:  {sv.namehint = "foo[0]"} : i1
+  // CHECK-NEXT: %[[AND_INV_1:.+]] = synth.aig.and_inv
+  // CHECK-SAME:  {sv.namehint = "foo[1]"} : i1
   hw.output %0 : i2
 }

--- a/test/circt-synth/basic.mlir
+++ b/test/circt-synth/basic.mlir
@@ -18,7 +18,7 @@ hw.module @and(in %a: i2, in %b: i2, in %c: i2, in %d: i1, out and: i2) {
   // AIG-NEXT: hw.output %[[AND_INV]] : i2
   // CHECK-DAG: %[[B_1:.+]] = comb.extract %b from 1 : (i2) -> i1
   // CHECK-DAG: %[[C_1:.+]] = comb.extract %c from 1 : (i2) -> i1
-  // CHECK-DAG: %[[AND_INV_0:.+]] = synth.aig.and_inv %0, %[[C_1]] : i1
+  // CHECK-DAG: %[[AND_INV_0:.+]] = synth.aig.and_inv %[[B_1]], %[[C_1]] : i1
   // CHECK-DAG: %[[B_0:.+]] = comb.extract %b from 0 : (i2) -> i1
   // CHECK-DAG: %[[C_0:.+]] = comb.extract %c from 0 : (i2) -> i1
   // CHECK-DAG: %[[AND_INV_1:.+]] = synth.aig.and_inv %[[B_0]], %[[C_0]] : i1


### PR DESCRIPTION
Previously, GreedyPatternRewriter was naively used to bit-blast multi-bit values but it didn't scale well due to worklist iteration and unnecessary IR creation which occasionally ended up with constant values. Hence the pass was often not scalable for large designs.

This commit fixes the issue by applying constant propagation during the bit-blast process and replaces GreedyPatternRewriter with a manual one-shot walk with recursion. 
