### PR TITLE
[HWLegalizeModules] add disallowClockedAssertions lowering flag

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -170,6 +170,12 @@ struct LoweringOptions {
   /// If true, add a dummy wire to empty modules to prevent tools from regarding
   /// the module as blackbox.
   bool fixUpEmptyModules = false;
+
+  // If true, wrap concurrent assertions with explicit clocking events into
+  // procedural form, by hoisting the clock event into an enclosing always
+  // block. The same transformation is applied to `assume property` and `cover
+  // property`.
+  bool disallowClockedAssertions = false;
 };
 } // namespace circt
 

--- a/include/circt/Support/LoweringOptionsParser.h
+++ b/include/circt/Support/LoweringOptionsParser.h
@@ -50,7 +50,7 @@ struct LoweringOptionsOption
                 "disallowPortDeclSharing, printDebugInfo, "
                 "disallowExpressionInliningInPorts, disallowMuxInlining, "
                 "emitWireInPort, emitBindComments, omitVersionComment, "
-                "caseInsensitiveKeywords"),
+                "caseInsensitiveKeywords, disallowClockedAssertions"),
             llvm::cl::cat(cat), llvm::cl::value_desc("option")} {}
 };
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -123,6 +123,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       emitVerilogLocations = true;
     } else if (option == "fixUpEmptyModules") {
       fixUpEmptyModules = true;
+    } else if (option == "disallowClockedAssertions") {
+      disallowClockedAssertions = true;
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
@@ -184,6 +186,8 @@ std::string LoweringOptions::toString() const {
     options += "emitVerilogLocations,";
   if (fixUpEmptyModules)
     options += "fixUpEmptyModules,";
+  if (disallowClockedAssertions)
+    options += "disallowClockedAssertions,";
 
   // Remove a trailing comma if present.
   if (!options.empty()) {

--- a/test/Dialect/SV/hw-legalize-clocked-assertions.mlir
+++ b/test/Dialect/SV/hw-legalize-clocked-assertions.mlir
@@ -1,0 +1,32 @@
+// RUN: circt-opt -hw-legalize-modules -verify-diagnostics %s | FileCheck %s
+
+module attributes {circt.loweringOptions = "disallowClockedAssertions"} {
+
+hw.module @clocked_assert(in %clock : i1, in %prop : i1) {
+  sv.assert_property %prop on posedge %clock : i1
+}
+
+// CHECK:      hw.module @clocked_assert(in %clock : i1, in %prop : i1) {
+// CHECK-NEXT:   sv.always posedge %clock {
+// CHECK-NEXT:     sv.assert_property %prop : i1
+// CHECK-NEXT:   }
+
+hw.module @clocked_assume(in %clock : i1, in %prop : i1) {
+  sv.assume_property %prop on posedge %clock : i1
+}
+
+// CHECK:      hw.module @clocked_assume(in %clock : i1, in %prop : i1) {
+// CHECK-NEXT:   sv.always posedge %clock {
+// CHECK-NEXT:     sv.assume_property %prop : i1
+// CHECK-NEXT:   }
+
+hw.module @clocked_cover(in %clock : i1, in %prop : i1) {
+  sv.cover_property %prop on posedge %clock : i1
+}
+
+// CHECK:      hw.module @clocked_cover(in %clock : i1, in %prop : i1) {
+// CHECK-NEXT:   sv.always posedge %clock {
+// CHECK-NEXT:     sv.cover_property %prop : i1
+// CHECK-NEXT:   }
+
+} // end builtin.module


### PR DESCRIPTION
This transforms SystemVerilog concurrent assertions with explicit clocking events into procedural form, by hoisting the clock event into an enclosing always block. For example:

```
assert property (@(posedge clk) prop);
```

is rewritten as:

```
always @(posedge clk) assert property (prop);
```

The same transformation is applied to `assume property` and `cover property`.

This lowers clocked properties into a form that avoids directly clocked concurrent assertions, which some downstream tools, like SBY, may not support.