### PR TITLE
[circt-verilog-lsp] Add support for `-C` command files for Slang, project-wide defintion lookup

### DIFF
--- a/include/circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h
+++ b/include/circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h
@@ -35,13 +35,17 @@ namespace circt {
 namespace lsp {
 struct VerilogServerOptions {
   VerilogServerOptions(const std::vector<std::string> &libDirs,
-                       const std::vector<std::string> &extraSourceLocationDirs)
-      : libDirs(libDirs), extraSourceLocationDirs(extraSourceLocationDirs) {}
+                       const std::vector<std::string> &extraSourceLocationDirs,
+                       const std::vector<std::string> &commandFiles)
+      : libDirs(libDirs), extraSourceLocationDirs(extraSourceLocationDirs),
+        commandFiles(commandFiles) {}
   /// Additional list of RTL directories to search.
   const std::vector<std::string> &libDirs;
-
   /// Additional list of external source directories to search.
   const std::vector<std::string> &extraSourceLocationDirs;
+  /// Additional list of command files that reference dependencies of the
+  /// project.
+  const std::vector<std::string> &commandFiles;
 };
 // namespace lsp
 

--- a/lib/Tools/circt-verilog-lsp-server/LSPServer.cpp
+++ b/lib/Tools/circt-verilog-lsp-server/LSPServer.cpp
@@ -8,6 +8,7 @@
 
 #include "LSPServer.h"
 #include "VerilogServerImpl/VerilogServer.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/LSP/Protocol.h"
 #include "llvm/Support/LSP/Transport.h"
 #include <optional>

--- a/test/Tools/circt-verilog-lsp-server/command-files.test
+++ b/test/Tools/circt-verilog-lsp-server/command-files.test
@@ -1,0 +1,64 @@
+// RUN: cd %S && circt-verilog-lsp-server -lit-test -C %S/include/filelist.f < %s | FileCheck %s
+// REQUIRES: slang
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"verilog","capabilities":{},"trace":"off"}}
+// -----
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{
+  "uri":"test:///foo.sv",
+  "languageId":"verilog",
+  "version":1,
+  "text":"module test(output out\n);ifdef#()i_dut(.out(out));\nendmodule"
+}}}
+// -----
+// Find definition of `i_dut`
+{"jsonrpc":"2.0","id":1,"method":"textDocument/definition","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "position":{"line":1,"character":12}
+}}
+// -----
+// CHECK:  "id": 1,
+// CHECK-NEXT:  "jsonrpc": "2.0",
+// CHECK-NEXT:  "result": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "range": {
+// CHECK-NEXT:        "end": {
+// CHECK-NEXT:          "character": 12,
+// CHECK-NEXT:          "line": 0
+// CHECK-NEXT:        },
+// CHECK-NEXT:        "start": {
+// CHECK-NEXT:          "character": 7,
+// CHECK-NEXT:          "line": 0
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      "uri": "file:///{{.*}}/include/ifdef.sv"
+// CHECK-NEXT:    }
+// CHECK-NEXT:  ]
+// CHECK-NEXT:}
+// -----
+// Find definition of `ifdef`
+{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "position":{"line":1,"character":4}
+}}
+// -----
+// CHECK:  "id": 2,
+// CHECK-NEXT:  "jsonrpc": "2.0",
+// CHECK-NEXT:  "result": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "range": {
+// CHECK-NEXT:        "end": {
+// CHECK-NEXT:          "character": 12,
+// CHECK-NEXT:          "line": 0
+// CHECK-NEXT:        },
+// CHECK-NEXT:        "start": {
+// CHECK-NEXT:          "character": 7,
+// CHECK-NEXT:          "line": 0
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      "uri": "file:///{{.*}}/include/ifdef.sv"
+// CHECK-NEXT:    }
+// CHECK-NEXT:  ]
+// CHECK-NEXT:}
+// -----
+{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+// -----
+{"jsonrpc":"2.0","method":"exit"}

--- a/test/Tools/circt-verilog-lsp-server/include/filelist.f
+++ b/test/Tools/circt-verilog-lsp-server/include/filelist.f
@@ -1,0 +1,1 @@
+include/ifdef.sv

--- a/test/Tools/circt-verilog-lsp-server/include/ifdef.sv
+++ b/test/Tools/circt-verilog-lsp-server/include/ifdef.sv
@@ -1,0 +1,3 @@
+module ifdef(output out);
+   assign out = 1'b1;
+endmodule

--- a/tools/circt-verilog-lsp-server/circt-verilog-lsp-server.cpp
+++ b/tools/circt-verilog-lsp-server/circt-verilog-lsp-server.cpp
@@ -67,6 +67,19 @@ int main(int argc, char **argv) {
       llvm::cl::value_desc("directory"), llvm::cl::Prefix);
 
   //===--------------------------------------------------------------------===//
+  // Command files
+  //===--------------------------------------------------------------------===//
+
+  llvm::cl::list<std::string> commandFiles{
+      "C",
+      llvm::cl::desc(
+          "One or more command files, which are independent compilation units "
+          "where modules are automatically instantiated."),
+      llvm::cl::value_desc("filename"), llvm::cl::Prefix};
+  llvm::cl::alias commandFilesLong{
+      "command-file", llvm::cl::desc("Alias for -C"),
+      llvm::cl::aliasopt(commandFiles), llvm::cl::NotHidden};
+  //===--------------------------------------------------------------------===//
   // Testing
   //===--------------------------------------------------------------------===//
 
@@ -100,6 +113,7 @@ int main(int argc, char **argv) {
                                      prettyPrint);
 
   // Configure the servers and start the main language server.
-  circt::lsp::VerilogServerOptions options(libDirs, sourceLocationIncludeDirs);
+  circt::lsp::VerilogServerOptions options(libDirs, sourceLocationIncludeDirs,
+                                           commandFiles);
   return failed(circt::lsp::CirctVerilogLspServerMain(options, transport));
 }


### PR DESCRIPTION
This PR extends the CIRCT Verilog LSP server with support for project command files (`-C` / `--command-file`) and improves robustness around source locations and diagnostics.

- **Command file support**
  - Added `commandFiles` option to `VerilogServerOptions`.
  - Extended the CLI with `-C`/`--command-file` flags to pass one or more command files.
  - Each buffer’s `Driver` now processes command files, filtering out the current main buffer to avoid duplication.

- **Source location handling**
  - Improved absolute/real path resolution when constructing LSP URIs.
  - Fallbacks added for when `slang::SourceManager` has no full path info.

- **Compilation setup**
  - Ensure all definitions in the main buffer scope are treated as top modules.

- **Indexing improvements**
  - Skip top instances not defined in the current file.
  - Added guards against invalid or empty ranges (especially macro expansions).

~~Currently the main thing I am unhappy with is that two compilations are created, where the first one is only to determine all module names - this is necessary, since we index only instantiated modules, and only top modules are instantiated. I tried looking, but didn't find a flag to treat all module definitions as top modules. Maybe someone else has a deeper understanding of the Slang driver and knows a way around this?~~

~~The other thing that is a bit hacky is the mangling of the command file; this is necessary because we do definition lookups based on raw pointers, so if the main document is also in the command file the pointers do not match. To prevent this I currently scan the command file and remove the main file (if present). I think we could prevent this if instead of matching raw pointers we matched against a file id / filename + offset. However, this might be slower than the current solution since it adds another layer of indirection. Let me know if you have opinions!~~

Refactored top module determination to only process the main buffer file; this is sufficient, no need to compile twice. 
Also refactored command file mangling to instead not import the main buffer into slang compilation if it is present in any command file, and then after compilation bind it to the llvm source manager's buffer id.