### PR TITLE
[FIRRTL] Add a missing unrealized conversion cast in LowerClasses

### DIFF
--- a/test/Dialect/FIRRTL/lower-classes-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-classes-errors.mlir
@@ -82,3 +82,12 @@ firrtl.circuit "NotInstance" {
     %0 = firrtl.path instance distinct[0]<>
   }
 }
+
+// -----
+
+firrtl.circuit "DontCrashOnUnassignedWire" {
+  firrtl.module @DontCrashOnUnassignedWire() {
+    // expected-error @below {{failed to legalize operation}}
+    %wire = firrtl.wire : !firrtl.integer
+  }
+}


### PR DESCRIPTION
The `updateObjectInClass` function replaces all `firrtl.object` ops with `om.object` ops before any dialect conversion is done. Doing so replaces a `!firrtl.class<...>` with a `!om.class.type<...>`, which leads to invalid IR and the `WireOp` lowering later crashing because it asks a `firrtl.propassign` for its source operand, which is expected to be a FIRRTL type, which then crashes in an assertion failure.

To avoid this, add an `unrealized_conversion_cast` op to map the `!om.class.type<...>` back to `!firrtl.class<...>`, and then eliminate the cast during the dialect conversion.