### PR TITLE
[Synth][LongestPathAnalysis] Remove hack for passing top module name through IR attribute

### DIFF
--- a/include/circt-c/Dialect/Synth.h
+++ b/include/circt-c/Dialect/Synth.h
@@ -51,7 +51,7 @@ DEFINE_C_API_STRUCT(SynthLongestPathCollection, void);
 // Create a LongestPathAnalysis for the given module
 MLIR_CAPI_EXPORTED SynthLongestPathAnalysis synthLongestPathAnalysisCreate(
     MlirOperation module, bool collectDebugInfo, bool keepOnlyMaxDelayPaths,
-    bool lazyComputation);
+    bool lazyComputation, MlirStringRef topModuleName);
 
 // Destroy a LongestPathAnalysis
 MLIR_CAPI_EXPORTED void

--- a/include/circt/Dialect/Synth/Analysis/LongestPathAnalysis.h
+++ b/include/circt/Dialect/Synth/Analysis/LongestPathAnalysis.h
@@ -206,12 +206,18 @@ struct LongestPathAnalysisOptions {
   /// are needed rather than complete path enumeration.
   bool keepOnlyMaxDelayPaths = false;
 
+  /// Name of the top module for the analysis.
+  /// If empty, the top module is inferred from the instance graph.
+  StringAttr topModuleName = {};
+
   /// Construct analysis options with the specified settings.
   LongestPathAnalysisOptions(bool collectDebugInfo = false,
                              bool lazyComputation = false,
-                             bool keepOnlyMaxDelayPaths = false)
+                             bool keepOnlyMaxDelayPaths = false,
+                             StringAttr topModuleName = {})
       : collectDebugInfo(collectDebugInfo), lazyComputation(lazyComputation),
-        keepOnlyMaxDelayPaths(keepOnlyMaxDelayPaths) {}
+        keepOnlyMaxDelayPaths(keepOnlyMaxDelayPaths),
+        topModuleName(topModuleName) {}
 };
 
 // This analysis finds the longest paths in the dataflow graph across modules.
@@ -281,16 +287,6 @@ public:
 
   // Return the top nodes that were used for the analysis.
   llvm::ArrayRef<hw::HWModuleOp> getTopModules() const;
-
-  // This is the name of the attribute that can be attached to the module
-  // to specify the top module for the analysis. This is optional, if not
-  // specified, the analysis will infer the top module from the instance graph.
-  // However it's recommended to specify it, as the entire module tends to
-  // contain testbench or verification modules, which may have expensive paths
-  // that are not of interest.
-  static StringRef getTopModuleNameAttrName() {
-    return "synth.longest-path-analysis-top";
-  }
 
   MLIRContext *getContext() const { return ctx; }
 

--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -116,7 +116,10 @@ def PrintLongestPathAnalysis
                  Option<"showTopKPercent", "show-top-k-percent", "int", "5",
                         "The size of the longest paths to show.">,
                  Option<"emitJSON", "emit-json", "bool", "false",
-                        "Output analysis results in JSON format">];
+                        "Output analysis results in JSON format">,
+                 Option<"topModuleName", "top-module-name", "std::string", "",
+                        "Name of the top module to analyze (empty for automatic "
+                        "inference from instance graph)">];
 }
 
 class ExternalSolverPass<string name> : Pass<name, "hw::HWModuleOp"> {

--- a/integration_test/Bindings/Python/dialects/synth.py
+++ b/integration_test/Bindings/Python/dialects/synth.py
@@ -141,7 +141,8 @@ with Context() as ctx, Location.unknown():
     analysis = LongestPathAnalysis(test_child,
                                    collect_debug_info=True,
                                    keep_only_max_delay_paths=True,
-                                   lazy_computation=True)
+                                   lazy_computation=True,
+                                   top_module_name="test_child")
     c1 = analysis.get_paths(result0, 0)
     c2 = analysis.get_paths(result1, 0)
     # CHECK-NEXT: len(c1) = 1

--- a/lib/Bindings/Python/SynthModule.cpp
+++ b/lib/Bindings/Python/SynthModule.cpp
@@ -33,14 +33,15 @@ void circt::python::populateDialectSynthSubmodule(nb::module_ &m) {
           "__init__",
           [](SynthLongestPathAnalysis *self, MlirOperation module,
              bool collectDebugInfo, bool keepOnlyMaxDelayPaths,
-             bool lazyComputation) {
+             bool lazyComputation, const std::string &topModuleName) {
             new (self) SynthLongestPathAnalysis(synthLongestPathAnalysisCreate(
                 module, collectDebugInfo, keepOnlyMaxDelayPaths,
-                lazyComputation));
+                lazyComputation,
+                mlirStringRefCreateFromCString(topModuleName.c_str())));
           },
           nb::arg("module"), nb::arg("collect_debug_info") = false,
           nb::arg("keep_only_max_delay_paths") = false,
-          nb::arg("lazy_computation") = false)
+          nb::arg("lazy_computation") = false, nb::arg("top_module_name") = "")
       .def("__del__",
            [](SynthLongestPathAnalysis &self) {
              synthLongestPathAnalysisDestroy(self);

--- a/lib/Bindings/Python/dialects/synth.py
+++ b/lib/Bindings/Python/dialects/synth.py
@@ -352,7 +352,8 @@ class LongestPathAnalysis:
                module,
                collect_debug_info: bool = True,
                keep_only_max_delay_paths: bool = False,
-               lazy_computation: bool = False):
+               lazy_computation: bool = False,
+               top_module_name: str = ""):
     """
         Initialize the longest path analysis for a given module.
         Args:
@@ -365,7 +366,7 @@ class LongestPathAnalysis:
         """
     self.analysis = synth._LongestPathAnalysis(module, collect_debug_info,
                                                keep_only_max_delay_paths,
-                                               lazy_computation)
+                                               lazy_computation, top_module_name)
 
   def get_paths(self,
                 value,

--- a/lib/Bindings/Python/dialects/synth.py
+++ b/lib/Bindings/Python/dialects/synth.py
@@ -366,7 +366,8 @@ class LongestPathAnalysis:
         """
     self.analysis = synth._LongestPathAnalysis(module, collect_debug_info,
                                                keep_only_max_delay_paths,
-                                               lazy_computation, top_module_name)
+                                               lazy_computation,
+                                               top_module_name)
 
   def get_paths(self,
                 value,

--- a/lib/CAPI/Dialect/Synth.cpp
+++ b/lib/CAPI/Dialect/Synth.cpp
@@ -80,17 +80,19 @@ SynthLongestPathObject wrap(const DataflowPath::OutputPort *object) {
 
 SynthLongestPathAnalysis
 synthLongestPathAnalysisCreate(MlirOperation module, bool collectDebugInfo,
-                               bool keepOnlyMaxDelayPaths,
-                               bool lazyComputation) {
+                               bool keepOnlyMaxDelayPaths, bool lazyComputation,
+                               MlirStringRef topModuleName) {
   auto *op = unwrap(module);
   auto *wrapper = new LongestPathAnalysisWrapper();
   wrapper->analysisManager =
       std::make_unique<mlir::ModuleAnalysisManager>(op, nullptr);
   mlir::AnalysisManager am = *wrapper->analysisManager;
+  auto topModuleNameAttr =
+      StringAttr::get(op->getContext(), unwrap(topModuleName));
   wrapper->analysis = std::make_unique<LongestPathAnalysis>(
       op, am,
       LongestPathAnalysisOptions(collectDebugInfo, lazyComputation,
-                                 keepOnlyMaxDelayPaths));
+                                 keepOnlyMaxDelayPaths, topModuleNameAttr));
   return wrap(wrapper);
 }
 

--- a/lib/Dialect/Synth/Analysis/PrintLongestPathAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/PrintLongestPathAnalysis.cpp
@@ -280,7 +280,7 @@ void PrintLongestPathAnalysisPass::runOnOperation() {
           /*collectDebugInfo=*/showTopKPercent.getValue() > 0,
           /*lazyComputation=*/false,
           /*keepOnlyMaxDelayPaths=*/
-          !test));
+          !test, StringAttr::get(&getContext(), topModuleName.getValue())));
 
   igraph::InstancePathCache pathCache(
       getAnalysis<circt::igraph::InstanceGraph>());

--- a/test/CAPI/support.c
+++ b/test/CAPI/support.c
@@ -55,10 +55,10 @@ void testInstancePath(void) {
   // for testing purposes without needing to expose additional InstancePathCache
   // APIs.
 
-  SynthLongestPathAnalysis analysis =
-      synthLongestPathAnalysisCreate(moduleOp, true, false, false);
-
   MlirStringRef moduleName = mlirStringRefCreateFromCString("top");
+  SynthLongestPathAnalysis analysis =
+      synthLongestPathAnalysisCreate(moduleOp, true, false, false, moduleName);
+
   SynthLongestPathCollection collection =
       synthLongestPathAnalysisGetAllPaths(analysis, moduleName, true);
 

--- a/test/CAPI/synth.c
+++ b/test/CAPI/synth.c
@@ -60,8 +60,8 @@ void testLongestPathAnalysis(void) {
 
   // Test with debug points enabled
   {
-    SynthLongestPathAnalysis analysis =
-        synthLongestPathAnalysisCreate(moduleOp, true, false, false);
+    SynthLongestPathAnalysis analysis = synthLongestPathAnalysisCreate(
+        moduleOp, true, false, false, mlirStringRefCreateFromCString("top"));
 
     MlirStringRef moduleName = mlirStringRefCreateFromCString("top");
     SynthLongestPathCollection collection1 =
@@ -158,8 +158,8 @@ void testLongestPathAnalysis(void) {
 
   // Test without debug points
   {
-    SynthLongestPathAnalysis analysis =
-        synthLongestPathAnalysisCreate(moduleOp, false, false, false);
+    SynthLongestPathAnalysis analysis = synthLongestPathAnalysisCreate(
+        moduleOp, false, false, false, mlirStringRefCreateFromCString("top"));
 
     MlirStringRef moduleName = mlirStringRefCreateFromCString("top");
     SynthLongestPathCollection collection =
@@ -207,8 +207,8 @@ void testErrorHandling(void) {
 
   MlirOperation moduleOp = mlirModuleGetOperation(module);
 
-  SynthLongestPathAnalysis analysis =
-      synthLongestPathAnalysisCreate(moduleOp, true, false, false);
+  SynthLongestPathAnalysis analysis = synthLongestPathAnalysisCreate(
+      moduleOp, true, false, false, mlirStringRefCreateFromCString("test"));
 
   MlirStringRef invalidModuleName = mlirStringRefCreateFromCString("unknown");
   SynthLongestPathCollection invalidCollection =
@@ -245,10 +245,10 @@ void testGetPathsAndMerge(void) {
 
   // Create analysis (enable only-max-delay to keep collections small and
   // stable).
-  SynthLongestPathAnalysis analysis =
-      synthLongestPathAnalysisCreate(moduleOp, /*collectDebugInfo=*/false,
-                                     /*keepOnlyMaxDelayPaths=*/true,
-                                     /*lazyComputation=*/false);
+  SynthLongestPathAnalysis analysis = synthLongestPathAnalysisCreate(
+      moduleOp, /*collectDebugInfo=*/false,
+      /*keepOnlyMaxDelayPaths=*/true,
+      /*lazyComputation=*/false, mlirStringRefCreateFromCString("m"));
 
   // Navigate to @m body and grab the two synth.aig.and_inv results.
   MlirRegion topRegion0 = mlirOperationGetRegion(moduleOp, 0);

--- a/test/circt-synth/basic.mlir
+++ b/test/circt-synth/basic.mlir
@@ -6,7 +6,6 @@
 // RUN: circt-synth %s --top and --disable-word-to-bits | FileCheck %s --check-prefix=DISABLE_WORD
 // RUN: circt-synth %s --target-ir mig | FileCheck %s --check-prefix=MIG
 
-// TOP-LABEL: module attributes {"synth.longest-path-analysis-top" = @and}
 // AIG-LABEL: @and(
 // CHECK-LABEL: @and(
 // COMB-LABEL: @and(

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -329,13 +329,6 @@ static LogicalResult executeSynthesis(MLIRContext &context) {
             "circt-synth"));
   populateCIRCTSynthPipeline(pm);
 
-  if (!topName.empty()) {
-    // Set a top module name for the longest path analysis.
-    module.get()->setAttr(
-        circt::synth::LongestPathAnalysis::getTopModuleNameAttrName(),
-        FlatSymbolRefAttr::get(&context, topName));
-  }
-
   if (failed(pm.run(module.get())))
     return failure();
 


### PR DESCRIPTION
This removes a hack `synth.longest-path-analysis-top` which was put to IR in order to pass a top name to analysis. The top module name is now passed explicitly as a parameter to the LongestPathAnalysis constructor and related APIs instead of being stored as an IR attribute.