### PR TITLE
[Sim] Rename FormatLitOp to FormatLiteralOp, NFC

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -151,7 +151,7 @@ def DPICallOp : SimOp<"func.dpi.call",
 // String Formatting
 //===----------------------------------------------------------------------===//
 
-def FormatLitOp : SimOp<"fmt.lit", [Pure, ConstantLike]> {
+def FormatLiteralOp : SimOp<"fmt.literal", [Pure, ConstantLike]> {
   let summary = "Literal string fragment";
   let description = [{
     Creates a constant, raw ASCII string literal for formatted printing.

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1586,7 +1586,7 @@ struct FormatLiteralOpConversion : public OpConversionPattern<FormatLiteralOp> {
   LogicalResult
   matchAndRewrite(FormatLiteralOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<sim::FormatLitOp>(op, adaptor.getLiteral());
+    rewriter.replaceOpWithNewOp<sim::FormatLiteralOp>(op, adaptor.getLiteral());
     return success();
   }
 };
@@ -1680,7 +1680,8 @@ static LogicalResult convert(SeverityBIOp op, SeverityBIOp::Adaptor adaptor,
     return failure();
   }
 
-  auto prefix = rewriter.create<sim::FormatLitOp>(op.getLoc(), severityString);
+  auto prefix =
+      rewriter.create<sim::FormatLiteralOp>(op.getLoc(), severityString);
   auto message = rewriter.create<sim::FormatStringConcatOp>(
       op.getLoc(), ValueRange{prefix, adaptor.getMessage()});
   rewriter.replaceOpWithNewOp<sim::PrintFormattedProcOp>(op, message);

--- a/lib/Dialect/Sim/SimDialect.cpp
+++ b/lib/Dialect/Sim/SimDialect.cpp
@@ -41,7 +41,7 @@ Operation *SimDialect::materializeConstant(::mlir::OpBuilder &builder,
                                            ::mlir::Location loc) {
 
   if (auto fmtStrType = llvm::dyn_cast<FormatStringType>(type))
-    return FormatLitOp::create(builder, loc, fmtStrType,
-                               llvm::cast<StringAttr>(value));
+    return FormatLiteralOp::create(builder, loc, fmtStrType,
+                                   llvm::cast<StringAttr>(value));
   return nullptr;
 }

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -110,7 +110,9 @@ void DPIFuncOp::print(OpAsmPrinter &p) {
        getPerArgumentAttrsAttrName(), getArgumentLocsAttrName()});
 }
 
-OpFoldResult FormatLitOp::fold(FoldAdaptor adaptor) { return getLiteralAttr(); }
+OpFoldResult FormatLiteralOp::fold(FoldAdaptor adaptor) {
+  return getLiteralAttr();
+}
 
 OpFoldResult FormatDecOp::fold(FoldAdaptor adaptor) {
   if (getValue().getType() == IntegerType::get(getContext(), 0U))
@@ -296,11 +298,11 @@ LogicalResult FormatStringConcatOp::canonicalize(FormatStringConcatOp op,
   SmallVector<StringRef> litSequence;
   SmallVector<Value> newOperands;
   newOperands.reserve(op.getNumOperands());
-  FormatLitOp prevLitOp;
+  FormatLiteralOp prevLitOp;
 
   auto oldOperands = hasBeenFlattened ? flatOperands : op.getOperands();
   for (auto operand : oldOperands) {
-    if (auto litOp = operand.getDefiningOp<FormatLitOp>()) {
+    if (auto litOp = operand.getDefiningOp<FormatLiteralOp>()) {
       if (!litOp.getLiteral().empty()) {
         prevLitOp = litOp;
         litSequence.push_back(litOp.getLiteral());
@@ -309,7 +311,7 @@ LogicalResult FormatStringConcatOp::canonicalize(FormatStringConcatOp op,
       if (!litSequence.empty()) {
         if (litSequence.size() > 1) {
           // Create a fused literal.
-          auto newLit = rewriter.createOrFold<FormatLitOp>(
+          auto newLit = rewriter.createOrFold<FormatLiteralOp>(
               op.getLoc(), fmtStrType,
               concatLiterals(op.getContext(), litSequence));
           newOperands.push_back(newLit);
@@ -327,7 +329,7 @@ LogicalResult FormatStringConcatOp::canonicalize(FormatStringConcatOp op,
   if (!litSequence.empty()) {
     if (litSequence.size() > 1) {
       // Create a fused literal.
-      auto newLit = rewriter.createOrFold<FormatLitOp>(
+      auto newLit = rewriter.createOrFold<FormatLiteralOp>(
           op.getLoc(), fmtStrType,
           concatLiterals(op.getContext(), litSequence));
       newOperands.push_back(newLit);
@@ -341,8 +343,8 @@ LogicalResult FormatStringConcatOp::canonicalize(FormatStringConcatOp op,
     return failure(); // Nothing changed
 
   if (newOperands.empty())
-    rewriter.replaceOpWithNewOp<FormatLitOp>(op, fmtStrType,
-                                             rewriter.getStringAttr(""));
+    rewriter.replaceOpWithNewOp<FormatLiteralOp>(op, fmtStrType,
+                                                 rewriter.getStringAttr(""));
   else if (newOperands.size() == 1)
     rewriter.replaceOp(op, newOperands);
   else
@@ -389,7 +391,7 @@ LogicalResult PrintFormattedProcOp::verify() {
 LogicalResult PrintFormattedProcOp::canonicalize(PrintFormattedProcOp op,
                                                  PatternRewriter &rewriter) {
   // Remove empty prints.
-  if (auto litInput = op.getInput().getDefiningOp<FormatLitOp>()) {
+  if (auto litInput = op.getInput().getDefiningOp<FormatLiteralOp>()) {
     if (litInput.getLiteral().empty()) {
       rewriter.eraseOp(op);
       return success();

--- a/lib/Dialect/Sim/Transforms/ProceduralizeSim.cpp
+++ b/lib/Dialect/Sim/Transforms/ProceduralizeSim.cpp
@@ -109,7 +109,7 @@ LogicalResult ProceduralizeSimPass::proceduralizePrintOps(
       fragmentList.push_back(fmtOp);
       // For non-literal fragments, the value to be formatted has to become an
       // argument.
-      if (!llvm::isa<FormatLitOp>(fmtOp)) {
+      if (!llvm::isa<FormatLiteralOp>(fmtOp)) {
         auto fmtVal = getFormattedValue(fmtOp);
         assert(!!fmtVal && "Unexpected foramtting fragment op.");
         arguments.insert(fmtVal);

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -373,7 +373,7 @@ func.func @Statements(%arg0: !moore.i42) {
 
 // CHECK-LABEL: func @FormatStrings
 func.func @FormatStrings(%arg0: !moore.i42) {
-  // CHECK: [[TMP:%.+]] = sim.fmt.lit "hello"
+  // CHECK: [[TMP:%.+]] = sim.fmt.literal "hello"
   %0 = moore.fmt.literal "hello"
   // CHECK: sim.fmt.concat ([[TMP]], [[TMP]])
   %1 = moore.fmt.concat (%0, %0)
@@ -1255,22 +1255,22 @@ func.func @SimulationControl() {
 
 // CHECK-LABEL: @SeverityToPrint
 func.func @SeverityToPrint() {
-  // CHECK: [[MSG:%.*]] = sim.fmt.lit "Fatal condition met!"
-  // CHECK-NEXT: [[PFX:%.*]] = sim.fmt.lit "Fatal: "
+  // CHECK: [[MSG:%.*]] = sim.fmt.literal "Fatal condition met!"
+  // CHECK-NEXT: [[PFX:%.*]] = sim.fmt.literal "Fatal: "
   // CHECK-NEXT: [[CONCAT:%.*]] = sim.fmt.concat ([[PFX]], [[MSG]])
   // CHECK-NEXT: sim.proc.print [[CONCAT]]
   %0 = moore.fmt.literal "Fatal condition met!"
   moore.builtin.severity fatal %0
 
-  // CHECK: [[MSG:%.*]] = sim.fmt.lit "Error condition met!"
-  // CHECK-NEXT: [[PFX:%.*]] = sim.fmt.lit "Error: "
+  // CHECK: [[MSG:%.*]] = sim.fmt.literal "Error condition met!"
+  // CHECK-NEXT: [[PFX:%.*]] = sim.fmt.literal "Error: "
   // CHECK-NEXT: [[CONCAT:%.*]] = sim.fmt.concat ([[PFX]], [[MSG]])
   // CHECK-NEXT: sim.proc.print [[CONCAT]]
   %1 = moore.fmt.literal "Error condition met!"
   moore.builtin.severity error %1
 
-  // CHECK: [[MSG:%.*]] = sim.fmt.lit "Warning condition met!"
-  // CHECK-NEXT: [[PFX:%.*]] = sim.fmt.lit "Warning: "
+  // CHECK: [[MSG:%.*]] = sim.fmt.literal "Warning condition met!"
+  // CHECK-NEXT: [[PFX:%.*]] = sim.fmt.literal "Warning: "
   // CHECK-NEXT: [[CONCAT:%.*]] = sim.fmt.concat ([[PFX]], [[MSG]])
   // CHECK-NEXT: sim.proc.print [[CONCAT]]
   %2 = moore.fmt.literal "Warning condition met!"

--- a/test/Dialect/Sim/format-strings.mlir
+++ b/test/Dialect/Sim/format-strings.mlir
@@ -1,10 +1,10 @@
 // RUN: circt-opt %s --canonicalize | FileCheck --strict-whitespace %s
 
 // CHECK-LABEL: hw.module @constant_fold0
-// CHECK: sim.fmt.lit ",0,0,;0,0, 0,0;1,1,-1,1;0011, 3, 3,3;01010,10, 10,0a;10000000,128,-128,80;0000001100101011111110,  51966,   51966,00cafe"
+// CHECK: sim.fmt.literal ",0,0,;0,0, 0,0;1,1,-1,1;0011, 3, 3,3;01010,10, 10,0a;10000000,128,-128,80;0000001100101011111110,  51966,   51966,00cafe"
 hw.module @constant_fold0(in %zeroWitdh: i0, out res: !sim.fstring) {
-  %comma = sim.fmt.lit ","
-  %semicolon = sim.fmt.lit ";"
+  %comma = sim.fmt.literal ","
+  %semicolon = sim.fmt.literal ";"
 
   %nocat = sim.fmt.concat ()
 
@@ -62,13 +62,13 @@ hw.module @constant_fold0(in %zeroWitdh: i0, out res: !sim.fstring) {
 }
 
 // CHECK-LABEL: hw.module @constant_fold1
-// CHECK: sim.fmt.lit " %b: '111111111111111111111111111111111111111111111111111000110100000010010001001010111001101011110010101010110010011011001001110' %u: '10633823966279322740806214058000332366' %d: '               -4242424242424242424242' %x: '7ffffffffffff1a04895cd79559364e'"
+// CHECK: sim.fmt.literal " %b: '111111111111111111111111111111111111111111111111111000110100000010010001001010111001101011110010101010110010011011001001110' %u: '10633823966279322740806214058000332366' %d: '               -4242424242424242424242' %x: '7ffffffffffff1a04895cd79559364e'"
 hw.module @constant_fold1(out res: !sim.fstring) {
-  %preb = sim.fmt.lit " %b: '"
-  %preu = sim.fmt.lit " %u: '"
-  %pres = sim.fmt.lit " %d: '"
-  %preh = sim.fmt.lit " %x: '"
-  %q = sim.fmt.lit "'"
+  %preb = sim.fmt.literal " %b: '"
+  %preu = sim.fmt.literal " %u: '"
+  %pres = sim.fmt.literal " %d: '"
+  %preh = sim.fmt.literal " %x: '"
+  %q = sim.fmt.literal "'"
 
   %cst42_123 = hw.constant -4242424242424242424242 : i123
   %w123b42 = sim.fmt.bin %cst42_123 : i123
@@ -82,14 +82,14 @@ hw.module @constant_fold1(out res: !sim.fstring) {
 
 // CHECK-LABEL: hw.module @constant_fold2
 hw.module @constant_fold2(in %foo: i1027, out res: !sim.fstring) {
-  // CHECK: [[SDS:%.+]] = sim.fmt.lit " - "
+  // CHECK: [[SDS:%.+]] = sim.fmt.literal " - "
   // CHECK: [[HEX:%.+]] = sim.fmt.hex %foo : i1027
   // CHECK: [[CAT:%.+]] = sim.fmt.concat ([[SDS]], [[HEX]], [[SDS]])
   // CHECK: hw.output [[CAT]] : !sim.fstring
 
-  %space = sim.fmt.lit " "
-  %dash = sim.fmt.lit "-"
-  %spaceDashSpace = sim.fmt.lit " - "
+  %space = sim.fmt.literal " "
+  %dash = sim.fmt.literal "-"
+  %spaceDashSpace = sim.fmt.literal " - "
   %hex = sim.fmt.hex %foo : i1027
 
   %res = sim.fmt.concat (%spaceDashSpace, %hex, %space, %dash, %space)
@@ -97,7 +97,7 @@ hw.module @constant_fold2(in %foo: i1027, out res: !sim.fstring) {
 }
 
 // CHECK-LABEL: hw.module @constant_fold3
-// CHECK: sim.fmt.lit "Foo\0A\0D\00Foo\00\C8"
+// CHECK: sim.fmt.literal "Foo\0A\0D\00Foo\00\C8"
 hw.module @constant_fold3(in %zeroWitdh: i0, out res: !sim.fstring) {
   %F = hw.constant 70 : i7
   %o = hw.constant 111 : i8
@@ -120,9 +120,9 @@ hw.module @constant_fold3(in %zeroWitdh: i0, out res: !sim.fstring) {
 
 
 // CHECK-LABEL: hw.module @flatten_concat1
-// CHECK-DAG:   %[[LH:.+]] = sim.fmt.lit "Hex: "
-// CHECK-DAG:   %[[LD:.+]] = sim.fmt.lit "Dec: "
-// CHECK-DAG:   %[[LB:.+]] = sim.fmt.lit "Bin: "
+// CHECK-DAG:   %[[LH:.+]] = sim.fmt.literal "Hex: "
+// CHECK-DAG:   %[[LD:.+]] = sim.fmt.literal "Dec: "
+// CHECK-DAG:   %[[LB:.+]] = sim.fmt.literal "Bin: "
 // CHECK-DAG:   %[[FH:.+]] = sim.fmt.hex %val : i8
 // CHECK-DAG:   %[[FD:.+]] = sim.fmt.dec %val : i8
 // CHECK-DAG:   %[[FB:.+]] = sim.fmt.bin %val : i8
@@ -130,17 +130,17 @@ hw.module @constant_fold3(in %zeroWitdh: i0, out res: !sim.fstring) {
 // CHECK:       hw.output %[[CAT]] : !sim.fstring
 
 hw.module @flatten_concat1(in %val : i8, out res: !sim.fstring) {
-  %binLit = sim.fmt.lit "Bin: "
+  %binLit = sim.fmt.literal "Bin: "
   %binVal = sim.fmt.bin %val : i8
   %binCat = sim.fmt.concat (%binLit, %binVal)
 
-  %decLit = sim.fmt.lit "Dec: "
+  %decLit = sim.fmt.literal "Dec: "
   %decVal = sim.fmt.dec %val : i8
   %decCat = sim.fmt.concat (%decLit, %decVal, %nocat)
 
   %nocat = sim.fmt.concat ()
 
-  %hexLit = sim.fmt.lit "Hex: "
+  %hexLit = sim.fmt.literal "Hex: "
   %hexVal = sim.fmt.hex %val : i8
   %hexCat = sim.fmt.concat (%hexLit, %hexVal)
 
@@ -149,14 +149,14 @@ hw.module @flatten_concat1(in %val : i8, out res: !sim.fstring) {
 }
 
 // CHECK-LABEL: hw.module @flatten_concat2
-// CHECK-DAG:   %[[F:.+]] = sim.fmt.lit "Foo"
-// CHECK-DAG:   %[[FF:.+]] = sim.fmt.lit "FooFoo"
+// CHECK-DAG:   %[[F:.+]] = sim.fmt.literal "Foo"
+// CHECK-DAG:   %[[FF:.+]] = sim.fmt.literal "FooFoo"
 // CHECK-DAG:   %[[CHR:.+]] = sim.fmt.char %val : i8
 // CHECK-DAG:   %[[CAT:.+]] = sim.fmt.concat (%[[F]], %[[CHR]], %[[FF]], %[[CHR]], %[[FF]], %[[CHR]], %[[FF]], %[[CHR]], %[[FF]], %[[CHR]], %[[F]])
 // CHECK:       hw.output %[[CAT]] : !sim.fstring
 
 hw.module @flatten_concat2(in %val : i8, out res: !sim.fstring) {
-  %foo = sim.fmt.lit "Foo"
+  %foo = sim.fmt.literal "Foo"
   %char = sim.fmt.char %val : i8
 
   %c = sim.fmt.concat (%foo, %char, %foo)

--- a/test/Dialect/Sim/print-canon.mlir
+++ b/test/Dialect/Sim/print-canon.mlir
@@ -4,7 +4,7 @@
 // CHECK-NOT: sim.print
 hw.module @always_disabled(in %clock: !seq.clock) {
   %false = hw.constant false
-  %lit = sim.fmt.lit "Foo"
+  %lit = sim.fmt.literal "Foo"
   sim.print %lit on %clock if %false
 }
 
@@ -12,7 +12,7 @@ hw.module @always_disabled(in %clock: !seq.clock) {
 // CHECK-NOT: sim.proc.print
 hw.module @emtpy_proc_print(in %trigger: i1) {
   hw.triggered posedge %trigger {
-    %epsilon = sim.fmt.lit ""
+    %epsilon = sim.fmt.literal ""
     sim.proc.print %epsilon
   }
 }

--- a/test/Dialect/Sim/proceduralize-sim.mlir
+++ b/test/Dialect/Sim/proceduralize-sim.mlir
@@ -3,13 +3,13 @@
 // CHECK-LABEL: @basic_print1
 // CHECK-NEXT:  %[[TRG:.*]] = seq.from_clock %clk
 // CHECK-NEXT:  hw.triggered posedge %[[TRG]] {
-// CHECK-NEXT:     %[[LIT:.*]] = sim.fmt.lit "Test"
+// CHECK-NEXT:     %[[LIT:.*]] = sim.fmt.literal "Test"
 // CHECK-NEXT:     sim.proc.print %[[LIT]]
 // CHECK-NEXT:   }
 
 hw.module @basic_print1(in %clk : !seq.clock) {
   %true = hw.constant true
-  %test = sim.fmt.lit "Test"
+  %test = sim.fmt.literal "Test"
   sim.print %test on %clk if %true
 }
 
@@ -17,8 +17,8 @@ hw.module @basic_print1(in %clk : !seq.clock) {
 // CHECK-NEXT:  %[[TRG:.*]] = seq.from_clock %clk
 // CHECK-NEXT:  hw.triggered posedge %[[TRG]](%cond) : i1 {
 // CHECK-NEXT:  ^bb0(%[[ARG:.*]]: i1):
-// CHECK-DAG:      %[[LIT1:.*]] = sim.fmt.lit "Not with a bang but a \00"
-// CHECK-DAG:      %[[LIT0:.*]] = sim.fmt.lit "This is the way the world ends\0A"
+// CHECK-DAG:      %[[LIT1:.*]] = sim.fmt.literal "Not with a bang but a \00"
+// CHECK-DAG:      %[[LIT0:.*]] = sim.fmt.literal "This is the way the world ends\0A"
 // CHECK:          scf.if %[[ARG]] {
 // CHECK-NEXT:       sim.proc.print %[[LIT0]]
 // CHECK-NEXT:       sim.proc.print %[[LIT0]]
@@ -28,8 +28,8 @@ hw.module @basic_print1(in %clk : !seq.clock) {
 // CHECK-NEXT:   }
 
 hw.module @basic_print2(in %clk : !seq.clock, in %cond : i1) {
-  %0 = sim.fmt.lit "Not with a bang but a \00"
-  %1 = sim.fmt.lit "This is the way the world ends\0A"
+  %0 = sim.fmt.literal "Not with a bang but a \00"
+  %1 = sim.fmt.literal "This is the way the world ends\0A"
 
   sim.print %1 on %clk if %cond
   sim.print %1 on %clk if %cond
@@ -41,9 +41,9 @@ hw.module @basic_print2(in %clk : !seq.clock, in %cond : i1) {
 // CHECK-NEXT:  %[[TRG:.*]] = seq.from_clock %clk
 // CHECK-NEXT:  hw.triggered posedge %[[TRG]](%val) : i32 {
 // CHECK-NEXT:  ^bb0(%[[ARG:.*]]: i32):
-// CHECK-DAG:      %[[LB:.*]] = sim.fmt.lit "Bin: "
-// CHECK-DAG:      %[[LD:.*]] = sim.fmt.lit ", Dec: "
-// CHECK-DAG:      %[[LH:.*]] = sim.fmt.lit ", Hex: "
+// CHECK-DAG:      %[[LB:.*]] = sim.fmt.literal "Bin: "
+// CHECK-DAG:      %[[LD:.*]] = sim.fmt.literal ", Dec: "
+// CHECK-DAG:      %[[LH:.*]] = sim.fmt.literal ", Hex: "
 // CHECK-DAG:      %[[FB:.*]] = sim.fmt.bin %[[ARG]] : i32
 // CHECK-DAG:      %[[FD:.*]] = sim.fmt.dec %[[ARG]] : i32
 // CHECK-DAG:      %[[FH:.*]] = sim.fmt.hex %[[ARG]] : i32
@@ -53,17 +53,17 @@ hw.module @basic_print2(in %clk : !seq.clock, in %cond : i1) {
 
 hw.module @basic_print3(in %clk : !seq.clock, in %val: i32) {
   %true = hw.constant true
-  %comma = sim.fmt.lit ", "
+  %comma = sim.fmt.literal ", "
 
-  %bin_lit = sim.fmt.lit "Bin: "
+  %bin_lit = sim.fmt.literal "Bin: "
   %bin_val = sim.fmt.bin %val : i32
   %bin_cat = sim.fmt.concat (%bin_lit, %bin_val)
 
-  %dec_lit = sim.fmt.lit "Dec: "
+  %dec_lit = sim.fmt.literal "Dec: "
   %dec_val = sim.fmt.dec %val : i32
   %dec_cat = sim.fmt.concat (%dec_lit, %dec_val)
 
-  %hex_lit = sim.fmt.lit "Hex: "
+  %hex_lit = sim.fmt.literal "Hex: "
   %hex_val = sim.fmt.hex %val : i32
   %hex_cat = sim.fmt.concat (%hex_lit, %hex_val)
 
@@ -76,7 +76,7 @@ hw.module @basic_print3(in %clk : !seq.clock, in %val: i32) {
 // CHECK-NEXT:  %[[TRG:.*]] = seq.from_clock %clk
 // CHECK-NEXT:  hw.triggered posedge %0(%a, %b, %c) : i8, i8, i8 {
 // CHECK-NEXT:  ^bb0(%[[ARG0:.*]]: i8, %[[ARG1:.*]]: i8, %[[ARG2:.*]]: i8):
-// CHECK-DAG:      %[[COM:.*]] = sim.fmt.lit ", "
+// CHECK-DAG:      %[[COM:.*]] = sim.fmt.literal ", "
 // CHECK-DAG:      %[[B0:.*]] = sim.fmt.bin %[[ARG0]] : i8
 // CHECK-DAG:      %[[H0:.*]] = sim.fmt.hex %[[ARG0]] : i8
 // CHECK-DAG:      %[[B1:.*]] = sim.fmt.bin %[[ARG1]] : i8
@@ -89,7 +89,7 @@ hw.module @basic_print3(in %clk : !seq.clock, in %val: i32) {
 
 hw.module @multi_args(in %clk : !seq.clock, in %a: i8, in %b: i8, in %c: i8) {
   %true = hw.constant true
-  %comma = sim.fmt.lit ", "
+  %comma = sim.fmt.literal ", "
 
   %bina = sim.fmt.bin %a : i8
   %binb = sim.fmt.bin %b : i8
@@ -108,8 +108,8 @@ hw.module @multi_args(in %clk : !seq.clock, in %a: i8, in %b: i8, in %c: i8) {
 // CHECK-NEXT:  %[[TRGA:.*]] = seq.from_clock %clka
 // CHECK-NEXT:  hw.triggered posedge %[[TRGA]](%val) : i32 {
 // CHECK-NEXT:  ^bb0(%[[ARGA:.*]]: i32):
-// CHECK-DAG:      %[[LA0:.*]] = sim.fmt.lit "Val is 0x"
-// CHECK-DAG:      %[[LA1:.*]] = sim.fmt.lit " on A."
+// CHECK-DAG:      %[[LA0:.*]] = sim.fmt.literal "Val is 0x"
+// CHECK-DAG:      %[[LA1:.*]] = sim.fmt.literal " on A."
 // CHECK-DAG:      %[[FA:.*]] = sim.fmt.hex %[[ARGA]] : i32
 // CHECK-DAG:      %[[CATA:.*]] = sim.fmt.concat (%[[LA0]], %[[FA]], %[[LA1]])
 // CHECK:          sim.proc.print %[[CATA]]
@@ -117,8 +117,8 @@ hw.module @multi_args(in %clk : !seq.clock, in %a: i8, in %b: i8, in %c: i8) {
 // CHECK-NEXT:  %[[TRGB:.*]] = seq.from_clock %clkb
 // CHECK-NEXT:  hw.triggered posedge %[[TRGB]](%val) : i32 {
 // CHECK-NEXT:  ^bb0(%[[ARGB:.*]]: i32):
-// CHECK-DAG:      %[[LB0:.*]] = sim.fmt.lit "Val is 0x"
-// CHECK-DAG:      %[[LB1:.*]] = sim.fmt.lit " on B."
+// CHECK-DAG:      %[[LB0:.*]] = sim.fmt.literal "Val is 0x"
+// CHECK-DAG:      %[[LB1:.*]] = sim.fmt.literal " on B."
 // CHECK-DAG:      %[[FB:.*]] = sim.fmt.hex %[[ARGB]] : i32
 // CHECK-DAG:      %[[CATB:.*]] = sim.fmt.concat (%[[LB0]], %[[FB]], %[[LB1]])
 // CHECK:          sim.proc.print %[[CATB]]
@@ -126,8 +126,8 @@ hw.module @multi_args(in %clk : !seq.clock, in %a: i8, in %b: i8, in %c: i8) {
 // CHECK-NEXT:  %[[TRGC:.*]] = seq.from_clock %clkc
 // CHECK-NEXT:  hw.triggered posedge %[[TRGC]](%val) : i32 {
 // CHECK-NEXT:  ^bb0(%[[ARGC:.*]]: i32):
-// CHECK-DAG:      %[[LC0:.*]] = sim.fmt.lit "Val is 0x"
-// CHECK-DAG:      %[[LC1:.*]] = sim.fmt.lit " on C."
+// CHECK-DAG:      %[[LC0:.*]] = sim.fmt.literal "Val is 0x"
+// CHECK-DAG:      %[[LC1:.*]] = sim.fmt.literal " on C."
 // CHECK-DAG:      %[[FC:.*]] = sim.fmt.hex %[[ARGC]] : i32
 // CHECK-DAG:      %[[CATC:.*]] = sim.fmt.concat (%[[LC0]], %[[FC]], %[[LC1]])
 // CHECK:          sim.proc.print %[[CATC]]
@@ -135,12 +135,12 @@ hw.module @multi_args(in %clk : !seq.clock, in %a: i8, in %b: i8, in %c: i8) {
 
 hw.module @multi_clock(in %clka : !seq.clock, in %clkb : !seq.clock, in %clkc : !seq.clock, in %val: i32) {
   %true = hw.constant true
-  %pre = sim.fmt.lit "Val is 0x"
+  %pre = sim.fmt.literal "Val is 0x"
   %hex_val = sim.fmt.hex %val : i32
 
-  %onA = sim.fmt.lit " on A."
-  %onB = sim.fmt.lit " on B."
-  %onC = sim.fmt.lit " on C."
+  %onA = sim.fmt.literal " on A."
+  %onB = sim.fmt.literal " on B."
+  %onC = sim.fmt.literal " on C."
 
   %catA = sim.fmt.concat (%pre, %hex_val, %onA)
   sim.print %catA on %clka if %true
@@ -156,12 +156,12 @@ hw.module @multi_clock(in %clka : !seq.clock, in %clkb : !seq.clock, in %clkc : 
 // CHECK-NEXT:  %[[TRG:.*]] = seq.from_clock %clk
 // CHECK-NEXT:  hw.triggered posedge %[[TRG]](%conda, %condb, %val) : i1, i1, i32 {
 // CHECK-NEXT:  ^bb0(%[[ARG0:.*]]: i1, %[[ARG1:.*]]: i1, %[[ARG2:.*]]: i32):
-// CHECK-DAG:      %[[L1:.*]] = sim.fmt.lit "#1"
-// CHECK-DAG:      %[[L2:.*]] = sim.fmt.lit "#2"
-// CHECK-DAG:      %[[L3:.*]] = sim.fmt.lit "#3"
-// CHECK-DAG:      %[[L4:.*]] = sim.fmt.lit "#4"
-// CHECK-DAG:      %[[L5:.*]] = sim.fmt.lit "#5"
-// CHECK-DAG:      %[[L6:.*]] = sim.fmt.lit "#6"
+// CHECK-DAG:      %[[L1:.*]] = sim.fmt.literal "#1"
+// CHECK-DAG:      %[[L2:.*]] = sim.fmt.literal "#2"
+// CHECK-DAG:      %[[L3:.*]] = sim.fmt.literal "#3"
+// CHECK-DAG:      %[[L4:.*]] = sim.fmt.literal "#4"
+// CHECK-DAG:      %[[L5:.*]] = sim.fmt.literal "#5"
+// CHECK-DAG:      %[[L6:.*]] = sim.fmt.literal "#6"
 // CHECK-DAG:      %[[BIN:.*]] = sim.fmt.bin %[[ARG2]] : i32
 // CHECK:          scf.if %[[ARG0]] {
 // CHECK-NEXT:       sim.proc.print %[[L1]]
@@ -184,21 +184,21 @@ hw.module @sequence(in %clk: !seq.clock, in %conda: i1, in %condb: i1, in %val :
   %true = hw.constant true
   %false = hw.constant false
 
-  %1 = sim.fmt.lit "#1"
+  %1 = sim.fmt.literal "#1"
   sim.print %1 on %clk if %conda
-  %2 = sim.fmt.lit "#2"
+  %2 = sim.fmt.literal "#2"
   sim.print %2 on %clk if %condb
-  %3 = sim.fmt.lit "#3"
+  %3 = sim.fmt.literal "#3"
   sim.print %3 on %clk if %condb
-  %cdis = sim.fmt.lit "--"
+  %cdis = sim.fmt.literal "--"
   sim.print %cdis on %clk if %false
-  %4 = sim.fmt.lit "#4"
+  %4 = sim.fmt.literal "#4"
   sim.print %4 on %clk if %condb
-  %5 = sim.fmt.lit "#5"
+  %5 = sim.fmt.literal "#5"
   sim.print %5 on %clk if %conda
   %cen = sim.fmt.bin %val : i32
   sim.print %cen on %clk if %true
-  %6 = sim.fmt.lit "#6"
+  %6 = sim.fmt.literal "#6"
   sim.print %6 on %clk if %conda
 }
 

--- a/test/Dialect/Sim/sim-errors.mlir
+++ b/test/Dialect/Sim/sim-errors.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt %s --split-input-file --verify-diagnostics --canonicalize
 
 hw.module @fmt_infinite_concat_verify() {
-  %lp = sim.fmt.lit ", {"
-  %rp = sim.fmt.lit "}"
+  %lp = sim.fmt.literal ", {"
+  %rp = sim.fmt.literal "}"
   // expected-error @below {{op is infinitely recursive.}}
   %ordinal = sim.fmt.concat (%ordinal, %lp, %ordinal, %rp)
 }
@@ -10,15 +10,15 @@ hw.module @fmt_infinite_concat_verify() {
 
 hw.module @fmt_infinite_concat_canonicalize(in %val : i8, out res: !sim.fstring) {
   %c = sim.fmt.char %val : i8
-  %0 = sim.fmt.lit "Here we go round the"
-  %1 = sim.fmt.lit "prickly pear"
+  %0 = sim.fmt.literal "Here we go round the"
+  %1 = sim.fmt.literal "prickly pear"
   // expected-warning @below {{Cyclic concatenation detected.}}
   %2 = sim.fmt.concat (%1, %c, %4)
   // expected-warning @below {{Cyclic concatenation detected.}}
   %3 = sim.fmt.concat (%1, %c, %1, %c, %2, %c)
   // expected-warning @below {{Cyclic concatenation detected.}}
   %4 = sim.fmt.concat (%0, %c, %3)
-  %5 = sim.fmt.lit "At five o'clock in the morning."
+  %5 = sim.fmt.literal "At five o'clock in the morning."
   // expected-warning @below {{Cyclic concatenation detected.}}
   %cat = sim.fmt.concat (%4, %c, %5)
   hw.output %cat : !sim.fstring
@@ -27,7 +27,7 @@ hw.module @fmt_infinite_concat_canonicalize(in %val : i8, out res: !sim.fstring)
 // -----
 
 hw.module @proc_print_hw() {
-  %lit = sim.fmt.lit "Nope"
+  %lit = sim.fmt.literal "Nope"
   // expected-error @below {{must be within a procedural region.}}
   sim.proc.print %lit
 }
@@ -36,7 +36,7 @@ hw.module @proc_print_hw() {
 
 sv.macro.decl @SOMEMACRO
 hw.module @proc_print_sv() {
-  %lit = sim.fmt.lit "Nope"
+  %lit = sim.fmt.literal "Nope"
   sv.ifdef  @SOMEMACRO {
     // expected-error @below {{must be within a procedural region.}}
     sim.proc.print %lit


### PR DESCRIPTION
Just a mechanical replacement.

I have grown up with DOS, so my brain is wired to not use more than three characters after a period. While the additional 4 bytes per literal op will no doubt hurt when storing large `.MLI` files on floppies, I am willing to make that sacrifice for the sake of clarity and consistency.