### PR TITLE
[FIRRTL] Update more symbol-sensitive ops after dedup

### DIFF
--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-dedup))' %s | FileCheck %s
+// RUN: circt-opt --firrtl-dedup %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.circuit "Empty"
 firrtl.circuit "Empty" {
@@ -866,4 +866,28 @@ firrtl.circuit "UninstantiatedClasses" attributes {annotations = [
   // CHECK-NOT: firrtl.class private @Eggs
   firrtl.class private @Spam() {}
   firrtl.class private @Eggs() {}
+}
+
+// CHECK-LABEL: "UpdateAttrsAndTypes"
+// Ops that contain references to symbols have to have the symbol references
+// updated after dedup.
+firrtl.circuit "UpdateAttrsAndTypes" {
+  // CHECK: @Foo()
+  // CHECK-NOT: @Bar()
+  firrtl.class private @Foo() {}
+  firrtl.class private @Bar() {}
+
+  // CHECK: @UpdateAttrsAndTypes()
+  firrtl.module @UpdateAttrsAndTypes() {
+    // CHECK-NEXT: firrtl.wire : !firrtl.class<@Foo()>
+    // CHECK-NEXT: firrtl.wire : !firrtl.class<@Foo()>
+    %wire1 = firrtl.wire : !firrtl.class<@Foo()>
+    %wire2 = firrtl.wire : !firrtl.class<@Bar()>
+
+    // Should work on attributes and types of arbitrary operations, too.
+    // CHECK-NEXT: builtin.unrealized_conversion_cast to !firrtl.class<@Foo()> {a = @Foo, b = [@Foo]}
+    // CHECK-NEXT: builtin.unrealized_conversion_cast to !firrtl.class<@Foo()> {a = @Foo, b = [@Foo]}
+    %0 = builtin.unrealized_conversion_cast to !firrtl.class<@Foo()> {a = @Foo, b = [@Foo]}
+    %1 = builtin.unrealized_conversion_cast to !firrtl.class<@Bar()> {a = @Bar, b = [@Bar]}
+  }
 }


### PR DESCRIPTION
The Dedup pass currently handles module instances and class objects explictly in order to update the referenced module/class after deduplication. This does not consider types and attributes on any other operations, such as wires with a `!firrtl.class<...>` type. These also need to be updated.

Instead of adding more special cases, make use of the attribute/type walker and replacer infrastructure of MLIR that now works properly with FIRRTL types. When hashing a module, take note of all operations that have a symbol name nested somewhere in their attributes of types, and store them in a `symbolSensitiveOps` list as part of the module info. Once deduplication is done, visit those ops and replace all occurrences of outdated symbols with their post-dedup replacement. This can get rid of the special handling of ClassOp and ObjectOp, and also covers WireOp and attributes/types on any other op.

This came up as a dedup failure in a real-world design.