### PR TITLE
[build] Update Slang dependency properties before installing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,12 +604,13 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
         get_target_property(dep_target ${dep_alias} ALIASED_TARGET)
         message(STATUS "Installing slang dependency ${dep_target}")
         set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS ${dep_target})
-        install(TARGETS ${dep_target} EXPORT CIRCTTargets)
 
         # Disable the installation of headers coming from third-party libraries.
         # We won't use those APIs directly. Just make them static libraries for
         # the sake of running slang normally.
         set_target_properties(${dep_target} PROPERTIES PUBLIC_HEADER "")
+
+        install(TARGETS ${dep_target} EXPORT CIRCTTargets)
       endif()
     endforeach()
     set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang)


### PR DESCRIPTION
The properties of Slang dependencies are updated to avoid installing their headers alongside our headers. However, the new properties are not correctly taken into account if we issue an `install` command before the update.

This PR fixes the update order in the main `CMakeLists.txt` file.