### PR TITLE
[SV] Support expressions as case patterns

### DIFF
--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -55,7 +55,7 @@ char getLetter(CasePatternBit bit);
 class CasePattern {
 
 public:
-  enum CasePatternKind { CPK_bit, CPK_enum, CPK_default };
+  enum CasePatternKind { CPK_bit, CPK_enum, CPK_expr, CPK_default };
   CasePattern(CasePatternKind kind) : kind(kind) {}
   virtual ~CasePattern() {}
   CasePatternKind getKind() const { return kind; }
@@ -138,6 +138,21 @@ public:
 
 private:
   hw::EnumFieldAttr enumAttr;
+};
+
+class CaseExprPattern : public CasePattern {
+public:
+  CaseExprPattern(MLIRContext *ctx)
+      : CasePattern(CasePatternKind::CPK_expr),
+        exprAttr(CaseExprPatternAttr::get(ctx)) {}
+
+  Attribute attr() const override { return exprAttr; }
+
+  static bool classof(const CasePattern *S) { return S->getKind() == CPK_expr; }
+
+private:
+  // The expression pattern is recognized by a CaseExprPatternAttr
+  CaseExprPatternAttr exprAttr;
 };
 
 // This provides information about one case.

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -350,6 +350,11 @@ def CaseZStmt: I32EnumAttrCase<"CaseZStmt", 2, "casez">;
 def CaseStmtTypeAttr : I32EnumAttr<"CaseStmtType", "case type",
                                    [CaseStmt, CaseXStmt, CaseZStmt]>;
 
+def CaseExprPatternAttr : AttrDef<SVDialect, "CaseExprPattern"> {
+  let summary = "Represents a case expression pattern";
+  let mnemonic = "expr";
+}
+
 def ValidationQualifierPlain: I32EnumAttrCase<"ValidationQualifierPlain", 0, "plain">;
 def ValidationQualifierUnique: I32EnumAttrCase<"ValidationQualifierUnique", 1, "unique">;
 def ValidationQualifierUnique0: I32EnumAttrCase<"ValidationQualifierUnique0", 2, "unique0">;
@@ -373,6 +378,7 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
   let arguments = (ins DefaultValuedAttr<CaseStmtTypeAttr,
                                          "CaseStmtType::CaseStmt">:$caseStyle,
                        AnyType:$cond, ArrayAttr:$casePatterns,
+                       Variadic<AnyType>:$caseValues,
                        DefaultValuedAttr<ValidationQualifierTypeAttr,
                        "ValidationQualifierTypeEnum::ValidationQualifierPlain">:
                       $validationQualifier);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -5406,6 +5406,7 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
   });
   emitLocationInfoAndNewLine(ops);
 
+  size_t caseValueIndex = 0;
   ps.scopedBox(PP::bbox2, [&]() {
     for (auto &caseInfo : op.getCases()) {
       startStatement();
@@ -5424,6 +5425,9 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
           .Case<CaseEnumPattern>([&](auto enumPattern) {
             ps << PPExtString(emitter.fieldNameResolver.getEnumFieldName(
                 cast<hw::EnumFieldAttr>(enumPattern->attr())));
+          })
+          .Case<CaseExprPattern>([&](auto) {
+            emitExpression(op.getCaseValues()[caseValueIndex++], ops);
           })
           .Case<CaseDefaultPattern>([&](auto) { ps << "default"; })
           .Default([&](auto) { assert(false && "unhandled case pattern"); });

--- a/test/Dialect/SV/case.mlir
+++ b/test/Dialect/SV/case.mlir
@@ -1,0 +1,76 @@
+// RUN: circt-opt %s | FileCheck %s
+
+hw.type_scope @enum_typedecls {
+  hw.typedecl @enum0 : !hw.enum<A, B>
+}
+
+// CHECK-LABEL: hw.module @test_case_stmts() {
+hw.module @test_case_stmts() {
+  // CHECK: [[FD:%.*]] = hw.constant -2147483646 : i32
+  %fd = hw.constant 0x80000002 : i32
+
+  // Case bit pattern
+  // CHECK-NEXT: [[COND:%.*]] = hw.constant true
+  %0 = hw.constant 1 : i1
+  sv.initial {
+    sv.case %0 : i1
+    case b0: {
+      sv.fwrite %fd, "zero"
+    }
+    case b1: {
+      sv.fwrite %fd, "one"
+    }
+    default: {
+      sv.fwrite %fd, "default"
+    }
+  }
+
+  // Case enum pattern
+  %1 = hw.enum.constant A : !hw.typealias<@enum_typedecls::@enum0, !hw.enum<A, B>>
+  sv.initial {
+    sv.case %1 : !hw.typealias<@enum_typedecls::@enum0, !hw.enum<A, B>>
+    case A: {
+      sv.fwrite %fd, "A"
+    }
+    case B: {
+      sv.fwrite %fd, "B"
+    }
+    default: {
+      sv.fwrite %fd, "default"
+    }
+  }
+
+  // Case expr pattern
+  %foo = sv.wire : !hw.inout<i1>
+  %bar = sv.wire : !hw.inout<i1>
+  // CHECK: [[FOO:%.*]] = sv.read_inout %foo : !hw.inout<i1>
+  // CHECK: [[BAR:%.*]] = sv.read_inout %bar : !hw.inout<i1>
+  %2 = sv.read_inout %foo : !hw.inout<i1>
+  %3 = sv.read_inout %bar : !hw.inout<i1>
+  // CHECK-NEXT: sv.initial {
+  // CHECK-NEXT:   sv.case [[COND]] : i1
+  // CHECK-NEXT:   case [[FOO]]: {
+  // CHECK-NEXT:     sv.fwrite [[FD]], "foo"
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   case [[BAR]]: {
+  // CHECK-NEXT:     sv.fwrite [[FD]], "bar"
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   default: {
+  // CHECK-NEXT:     sv.fwrite [[FD]], "default"
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  sv.initial {
+    sv.case %0 : i1
+    case %2: {
+      sv.fwrite %fd, "foo"
+    }
+    case %3: {
+      sv.fwrite %fd, "bar"
+    }
+    default: {
+      sv.fwrite %fd, "default"
+    }
+  }
+
+  hw.output
+}


### PR DESCRIPTION
In the current version of CIRCT, constant expressions in case statements (see IEEE 1800-2017 §12.5.2) are not supported. This patch introduces a new case pattern kind, `CaseExprPattern`, which allows using expressions (SSA values) as case patterns. A simple test is included to validate this feature.

MLIR Assembly:

```mlir
%foo = sv.wire : !hw.inout<i1>
%bar = sv.wire : !hw.inout<i1>
%2 = sv.read_inout %foo : !hw.inout<i1>
%3 = sv.read_inout %bar : !hw.inout<i1>
sv.initial {
  sv.case %0 : i1
  case %2: {
    sv.fwrite %fd, "foo"
  }
  case %3: {
    sv.fwrite %fd, "bar"
  }
  default: {
    sv.fwrite %fd, "default"
  }
}
```

Exported Verilog:

```verilog
wire foo;
wire bar;
initial begin
  case (1'h1)
    foo:
      $fwrite(32'h80000002, "foo");
    bar:
      $fwrite(32'h80000002, "bar");
    default:
      $fwrite(32'h80000002, "default");
  endcase
end // initial
```

## Implementation Details

Case patterns are determined by the types of attributes attached to `sv::CaseOp`:

- `CaseDefaultPattern` : `mlir::UnitAttr`
- `CaseBitPattern` : `mlir::IntegerAttr`
- `CaseEnumPattern` : `hw::EnumFieldAttr`
- `CaseExprPattern` : `sv::CaseExprPatternAttr` (proposed)

This patch introduces `CaseExprPatternAttr` along with a variadic list of operands, `caseValues`, for `sv::CaseOp`. Each `CaseExprPatternAttr` corresponds, in order, to a value in `caseValues`. In the example below, `%5` and `%6` correspond to the first and second `#sv.expr`, respectively. Note: `%1` is the condition of the case statement.

```mlir
"sv.case"(%1, %5, %6) <{casePatterns = [#sv.expr, #sv.expr, unit], caseStyle = 0 : i32, validationQualifier = #sv<validation_qualifier plain>}> ({
  "sv.fwrite"(%0) <{format_string = "foo"}> : (i32) -> ()
}, {
  "sv.fwrite"(%0) <{format_string = "bar"}> : (i32) -> ()
}, {
  "sv.fwrite"(%0) <{format_string = "default"}> : (i32) -> ()
}) : (i1, i1, i1) -> ()
```