### PR TITLE
[ESI] Allow single-file additions to SourceFiles

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/simulator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/simulator.py
@@ -39,6 +39,13 @@ class SourceFiles:
     # Name of the top module.
     self.top = top
 
+  def add_file(self, file: Path):
+    """Add a single RTL file to the source list."""
+    if file.is_file():
+      self.user.append(file)
+    else:
+      raise FileNotFoundError(f"File {file} does not exist")
+
   def add_dir(self, dir: Path):
     """Add all the RTL files in a directory to the source list."""
     for file in sorted(dir.iterdir()):


### PR DESCRIPTION
Extend `SourceFiles` to also allow single file additions to the source file list.

Small, but important addition, due to the perniciousness of verilog compilers(/simulators), in that e.g. type files have to have a strict ordering when they have inter-dependencies. Just scanning a directory and adding them in lexical order may or may not (...obviously) cause problems in that aspect. With this change, gives users control over the order in which these files are added to the source list.