### PR TITLE
[LowerToHW][firtool] Backport `-emit-chisel-asserts-as-sva` to 1.5

### DIFF
--- a/include/circt/Conversion/FIRRTLToHW.h
+++ b/include/circt/Conversion/FIRRTLToHW.h
@@ -24,7 +24,8 @@ class Pass;
 namespace circt {
 
 std::unique_ptr<mlir::Pass>
-createLowerFIRRTLToHWPass(bool enableAnnotationWarning = false);
+createLowerFIRRTLToHWPass(bool enableAnnotationWarning = false,
+                          bool emitChiselAssertsAsSVA = false);
 
 } // namespace circt
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -147,7 +147,9 @@ def LowerFIRRTLToHW : Pass<"lower-firrtl-to-hw", "mlir::ModuleOp"> {
   let options = [
     Option<"enableAnnotationWarning", "warn-on-unprocessed-annotations",
            "bool", "false",
-    "Emit warnings on unprocessed annotations during lower-to-hw pass">
+    "Emit warnings on unprocessed annotations during lower-to-hw pass">,
+    Option<"emitChiselAssertsAsSVA", "emit-chisel-asserts-as-sva",
+           "bool", "false","Convert all Chisel asserts to SVA">
   ];
 }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -258,9 +258,11 @@ struct CircuitLoweringState {
   std::atomic<bool> used_RANDOMIZE_GARBAGE_ASSIGN{false};
 
   CircuitLoweringState(CircuitOp circuitOp, bool enableAnnotationWarning,
+                       bool emitChiselAssertsAsSVA,
                        InstanceGraph *instanceGraph, NLATable *nlaTable)
       : circuitOp(circuitOp), instanceGraph(instanceGraph),
-        enableAnnotationWarning(enableAnnotationWarning), nlaTable(nlaTable) {
+        enableAnnotationWarning(enableAnnotationWarning),
+        emitChiselAssertsAsSVA(emitChiselAssertsAsSVA), nlaTable(nlaTable) {
     auto *context = circuitOp.getContext();
 
     // Get the testbench output directory.
@@ -352,6 +354,8 @@ private:
   StringSet<> pendingAnnotations;
   const bool enableAnnotationWarning;
   std::mutex annotationPrintingMtx;
+
+  const bool emitChiselAssertsAsSVA;
 
   // Records any sv::BindOps that are found during the course of execution.
   // This is unsafe to access directly and should only be used through addBind.
@@ -446,6 +450,7 @@ struct FIRRTLModuleLowering : public LowerFIRRTLToHWBase<FIRRTLModuleLowering> {
 
   void runOnOperation() override;
   void setEnableAnnotationWarning() { enableAnnotationWarning = true; }
+  void setEmitChiselAssertAsSVA() { emitChiselAssertsAsSVA = true; }
 
 private:
   void lowerFileHeader(CircuitOp op, CircuitLoweringState &loweringState);
@@ -475,10 +480,13 @@ private:
 
 /// This is the pass constructor.
 std::unique_ptr<mlir::Pass>
-circt::createLowerFIRRTLToHWPass(bool enableAnnotationWarning) {
+circt::createLowerFIRRTLToHWPass(bool enableAnnotationWarning,
+                                 bool emitChiselAssertsAsSVA) {
   auto pass = std::make_unique<FIRRTLModuleLowering>();
   if (enableAnnotationWarning)
     pass->setEnableAnnotationWarning();
+  if (emitChiselAssertsAsSVA)
+    pass->setEmitChiselAssertAsSVA();
   return pass;
 }
 
@@ -504,9 +512,9 @@ void FIRRTLModuleLowering::runOnOperation() {
 
   // Keep track of the mapping from old to new modules.  The result may be null
   // if lowering failed.
-  CircuitLoweringState state(circuit, enableAnnotationWarning,
-                             &getAnalysis<InstanceGraph>(),
-                             &getAnalysis<NLATable>());
+  CircuitLoweringState state(
+      circuit, enableAnnotationWarning, emitChiselAssertsAsSVA,
+      &getAnalysis<InstanceGraph>(), &getAnalysis<NLATable>());
 
   SmallVector<FModuleOp, 32> modulesToProcess;
 
@@ -3855,7 +3863,8 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
       // "ifElseFatal" variant is special cased because this isn't actually a
       // concurrent assertion.
       auto format = op->getAttrOfType<StringAttr>("format");
-      if (isConcurrent && (!format || format.getValue() != "ifElseFatal"))
+      if (isConcurrent && (!format || format.getValue() != "ifElseFatal" ||
+                           circuitState.emitChiselAssertsAsSVA))
         loweredValue = builder.create<sv::SampledOp>(loweredValue);
       messageOps.push_back(loweredValue);
     }
@@ -3882,7 +3891,8 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
     // TODO: This should *not* be part of the op, but rather a lowering
     // option that the user of this pass can choose.
     auto format = op->template getAttrOfType<StringAttr>("format");
-    if (format && format.getValue() == "ifElseFatal") {
+    if (format && (format.getValue() == "ifElseFatal" &&
+                   !circuitState.emitChiselAssertsAsSVA)) {
       predicate = comb::createOrFoldNot(predicate, builder);
       predicate = builder.createOrFold<comb::AndOp>(enable, predicate);
       addToIfDefBlock("SYNTHESIS", {}, [&]() {

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -1,0 +1,19 @@
+// RUN: circt-opt -lower-firrtl-to-hw=emit-chisel-asserts-as-sva %s | FileCheck %s
+
+firrtl.circuit "ifElseFatalToSVA" {
+  // CHECK-LABEL: hw.module @ifElseFatalToSVA
+  firrtl.module @ifElseFatalToSVA(
+    in %clock: !firrtl.clock,
+    in %cond: !firrtl.uint<1>,
+    in %enable: !firrtl.uint<1>
+  ) {
+    firrtl.assert %clock, %cond, %enable, "assert0" {isConcurrent = true, format = "ifElseFatal"}
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
+    // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
+    // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NEXT: }
+}
+}

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -1,4 +1,5 @@
 ; RUN: firtool --verify-diagnostics --verilog %s | FileCheck %s
+; RUN: firtool --verify-diagnostics --verilog --emit-chisel-asserts-as-sva %s | FileCheck %s --check-prefix=SVA
 ; Tests extracted from:
 ; - test/scala/firrtl/extractverif/ExtractAssertsSpec.scala
 
@@ -30,6 +31,10 @@ circuit Foo:
     ; CHECK-NEXT:   if (`STOP_COND_)
     ; CHECK-NEXT:     $fatal;
     ; CHECK-NEXT: end
+
+    ; SVA: wire _GEN = ~enable | predicate1 | reset;
+    ; SVA-NEXT: assert__verif_library: assert property (@(posedge clock) _GEN) else $error("Assertion failed (verification library): ");
+
     when not(or(predicate1, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): \"}</extraction-summary> bar")
       stop(clock, enable, 1)

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -97,6 +97,11 @@ static cl::opt<bool> enableAnnotationWarning(
     cl::desc("Warn about annotations that were not removed by lower-to-hw"),
     cl::init(false), cl::cat(mainCategory));
 
+static cl::opt<bool>
+    emitChiselAssertsAsSVA("emit-chisel-asserts-as-sva",
+                           cl::desc("Convert all chisel asserts into SVA"),
+                           cl::init(false), cl::cat(mainCategory));
+
 static cl::opt<bool> disableAnnotationsClassless(
     "disable-annotation-classless",
     cl::desc("Ignore annotations without a class when parsing"),
@@ -592,7 +597,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (outputFormat != OutputIRFir) {
-    pm.addPass(createLowerFIRRTLToHWPass(enableAnnotationWarning.getValue()));
+    pm.addPass(createLowerFIRRTLToHWPass(enableAnnotationWarning.getValue(),
+                                         emitChiselAssertsAsSVA.getValue()));
 
     if (outputFormat == OutputIRHW) {
       if (!disableOptimization) {


### PR DESCRIPTION
Backport the `-emit-chisel-asserts-as-sva` to 1.5 with the intention of creating a 1.5.8 release.

Original commit message:

This commit adds an option `emit-chisel-asserts-as-sva` to emit chisel asserts as SVA assertions at LowerToHW. Users sometimes want to emit  only SVA for verification purpose and therefore, this commit provides a command line option to emit "ifElseFatal" style assertion as SVA.