### PR TITLE
fix: prevent canonicalize looping for extremely long time

### DIFF
--- a/include/circt/Reduce/GenericReductions.h
+++ b/include/circt/Reduce/GenericReductions.h
@@ -10,13 +10,19 @@
 #define CIRCT_REDUCE_GENERICREDUCTIONS_H
 
 #include "circt/Reduce/Reduction.h"
+#include <optional>
 
 namespace circt {
 
 /// Populate reduction patterns that are not specific to certain operations or
-/// dialects
-void populateGenericReducePatterns(MLIRContext *context,
-                                   ReducePatternSet &patterns);
+/// dialects.
+///
+/// The optional `maxNumRewrites` parameter allows callers to override the
+/// greedy rewrite budget used by reductions that rely on the canonicalizer
+/// pass.
+void populateGenericReducePatterns(
+    MLIRContext *context, ReducePatternSet &patterns,
+    std::optional<int64_t> maxNumRewrites = std::nullopt);
 
 } // namespace circt
 

--- a/lib/Reduce/GenericReductions.cpp
+++ b/lib/Reduce/GenericReductions.cpp
@@ -11,9 +11,12 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace mlir;
 using namespace circt;
+
+extern llvm::cl::opt<int64_t> maxGreedyRewrites;
 
 //===----------------------------------------------------------------------===//
 // Reduction Patterns
@@ -101,6 +104,8 @@ static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
   config.setUseTopDownTraversal(true);
   config.setRegionSimplificationLevel(
       mlir::GreedySimplifyRegionLevel::Disabled);
+  if (maxGreedyRewrites >= 0)
+    config.setMaxNumRewrites(maxGreedyRewrites);
   return createCanonicalizerPass(config);
 }
 

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -104,6 +104,12 @@ static cl::opt<bool> verbose("v", cl::init(true),
                              cl::desc("Print reduction progress to stderr"),
                              cl::cat(mainCategory));
 
+cl::opt<int64_t> maxGreedyRewrites(
+    "max-greedy-rewrites", cl::init(-1),
+    cl::desc("Maximum number of rewrites GreedyPatternRewriteDriver may "
+             "apply (negative value keeps the default)"),
+    cl::cat(mainCategory));
+
 static cl::opt<unsigned>
     maxChunks("max-chunks", cl::init(0),
               cl::desc("Stop increasing granularity beyond this number of "

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -104,8 +104,8 @@ static cl::opt<bool> verbose("v", cl::init(true),
                              cl::desc("Print reduction progress to stderr"),
                              cl::cat(mainCategory));
 
-cl::opt<int64_t> maxGreedyRewrites(
-    "max-greedy-rewrites", cl::init(-1),
+cl::opt<int64_t> maxNumRewrites(
+    "max-num-rewrites", cl::init(-1),
     cl::desc("Maximum number of rewrites GreedyPatternRewriteDriver may "
              "apply (negative value keeps the default)"),
     cl::cat(mainCategory));
@@ -199,7 +199,10 @@ static LogicalResult execute(MLIRContext &context) {
 
   // Gather a list of reduction patterns that we should try.
   ReducePatternSet patterns;
-  populateGenericReducePatterns(&context, patterns);
+  std::optional<int64_t> maxNumRewritesOpt;
+  if (maxNumRewrites >= 0)
+    maxNumRewritesOpt = maxNumRewrites;
+  populateGenericReducePatterns(&context, patterns, maxNumRewritesOpt);
   ReducePatternInterfaceCollection reducePatternCollection(&context);
   reducePatternCollection.populateReducePatterns(patterns);
   auto reductionFilter = [&](const Reduction &reduction) {


### PR DESCRIPTION
A hanging bug can manifest with very large inputs to minimize at canonicalize pass. This is because if the maxNumRewrites is not set, it defaults to kNoLimit, which could be an arbitrary large number. This optional command line argument makes it possible to set the max number of rewrites for large input files to minimize.