### PR TITLE
[FIRRTL] Make Domains ClassLike

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -323,7 +323,7 @@ def MatchOp : FIRRTLOp<"match", [SingleBlock, NoTerminator,
 }
 
 def PropAssignOp : FIRRTLOp<"propassign", [FConnectLike, SameTypeOperands,
-    ParentOneOf<["FModuleOp", "ClassOp", "LayerBlockOp"]>]> {
+    ParentOneOf<["FModuleOp", "ClassOp", "LayerBlockOp", "DomainOp"]>]> {
   let summary = "Assign to a sink property value.";
   let description = [{
     Assign an output property value. The types must match exactly.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -327,15 +327,22 @@ def FMemModuleOp : FIRRTLModuleLike<"memmodule"> {
   let hasCustomAssemblyFormat = 1;
 }
 
-def ClassOp : FIRRTLModuleLike<"class", [
-  SingleBlock, NoTerminator,
-  DeclareOpInterfaceMethods<FModuleLike, [
-    // Class Ops do not support port annotations or enabled layers.
-    // Override these methods to return an empty array attr.
-    "getPortAnnotationsAttr",
-    "getLayersAttr"]>,
-  DeclareOpInterfaceMethods<ClassLike>,
-  DeclareOpInterfaceMethods<Symbol, ["canDiscardOnUseEmpty"]>]> {
+class ClassLikeOp<string mnemonic, list<Trait> traits = []> :
+  FIRRTLModuleLike<mnemonic, traits # [
+    SingleBlock,
+    NoTerminator,
+    DeclareOpInterfaceMethods<FModuleLike, [
+      // ClassLikeOps do not support port annotations or enabled layers.
+      // Override these methods to return an empty array attr.
+      "getPortAnnotationsAttr",
+      "getLayersAttr"
+    ]>,
+    DeclareOpInterfaceMethods<ClassLike>,
+    DeclareOpInterfaceMethods<Symbol, ["canDiscardOnUseEmpty"]>
+  ]> {
+}
+
+def ClassOp : ClassLikeOp<"class"> {
   let summary = "FIRRTL Class";
   let description = [{
     The "firrtl.class" operation defines a class of property-only objects,
@@ -602,23 +609,54 @@ def SimulationOp : FIRRTLOp<"simulation", [
   }];
 }
 
-def DomainOp : FIRRTLOp<"domain", [
-  DeclareOpInterfaceMethods<Symbol>,
-  HasParent<"firrtl::CircuitOp">,
-  NoTerminator,
-  SingleBlock
-]> {
+def DomainOp : ClassLikeOp<"domain"> {
   let summary = "Define a domain type";
   let description = [{
     A `firrtl.domain` operation defines a type of domain that exists in this
     circuit.  E.g., this can be used to declare a `ClockDomain` type when
     modeling clocks in FIRRTL Dialect.
   }];
-  let arguments = (ins SymbolNameAttr:$sym_name);
+  let arguments = (
+    ins SymbolNameAttr:$sym_name,
+        DenseBoolArrayAttr:$portDirections,
+        ArrayRefAttr:$portNames,
+        ArrayRefAttr:$portTypes,
+        ArrayRefAttr:$portSymbols,
+        ArrayRefAttr:$portLocations,
+        DefaultValuedAttr<ArrayRefAttr, "{}">:$domainInfo
+  );
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
-  let assemblyFormat = [{
-    $sym_name attr-dict-with-keyword $body
+  let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      "StringAttr":$name,
+      "ArrayRef<PortInfo>":$ports)>,
+    ];
+
+  let extraModuleClassDeclaration = [{
+    Block *getBodyBlock() { return &getBody().front(); }
+
+    using iterator = Block::iterator;
+    iterator begin() { return getBodyBlock()->begin(); }
+    iterator end() { return getBodyBlock()->end(); }
+
+    Block::BlockArgListType getArguments() {
+      return getBodyBlock()->getArguments();
+    }
+
+    // Return the block argument for the port with the specified index.
+    BlockArgument getArgument(size_t portNumber);
+
+    OpBuilder getBodyBuilder() {
+      assert(!getBody().empty() && "Unexpected empty 'body' region.");
+      Block &bodyBlock = getBody().front();
+      return OpBuilder::atBlockEnd(&bodyBlock);
+    }
+
+    void getAsmBlockArgumentNames(mlir::Region &region,
+                                  mlir::OpAsmSetValueNameFn setNameFn);
   }];
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -44,6 +44,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <utility>
 
 using namespace circt;
@@ -5745,18 +5746,31 @@ ParseResult FIRCircuitParser::parseDomain(CircuitOp circuit, unsigned indent) {
   consumeToken(FIRToken::kw_domain);
 
   StringAttr name;
+  SmallVector<PortInfo, 8> portList;
+  SmallVector<SMLoc> portLocs;
   LocWithInfo info(getToken().getLoc(), this);
   if (parseId(name, "domain name") ||
       parseToken(FIRToken::colon, "expected ':' after domain definition") ||
-      info.parseOptionalInfo())
+      info.parseOptionalInfo() || parsePortList(portList, portLocs, indent))
     return failure();
 
-  auto builder = circuit.getBodyBuilder();
-  DomainOp::create(builder, info.getLoc(), name)
-      ->getRegion(0)
-      .push_back(new Block());
+  if (name == circuit.getName())
+    return mlir::emitError(info.getLoc(),
+                           "domain cannot be the top of a circuit");
 
-  return success();
+  for (auto &portInfo : portList)
+    if (!isa<PropertyType>(portInfo.type))
+      return mlir::emitError(portInfo.loc,
+                             "ports on domains must be properties");
+
+  auto builder = circuit.getBodyBuilder();
+  auto domainOp = DomainOp::create(builder, info.getLoc(), name, portList);
+  domainOp.setPublic();
+  deferredModules.emplace_back(DeferredModuleToParse{
+      domainOp, portLocs, getLexer().getCursor(), indent});
+  // domainOp->getRegion(0).push_back(new Block());
+
+  return skipToModuleEnd(indent);
 }
 
 /// extclass ::= 'extclass' id ':' info? INDENT portlist DEDENT

--- a/lib/Dialect/FIRRTL/Transforms/LowerDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerDomains.cpp
@@ -237,7 +237,9 @@ LogicalResult LowerModule::lowerModule() {
   }
 
   // Set new port annotations now that all deletions and insertions are done.
-  op.setPortAnnotationsAttr(ArrayAttr::get(context, portAnnotations));
+  // Only do this for modules which support port annotations.
+  if (!isa<ClassOp>(op))
+    op.setPortAnnotationsAttr(ArrayAttr::get(context, portAnnotations));
 
   LLVM_DEBUG({
     llvm::dbgs() << "    portMap:\n";
@@ -251,7 +253,9 @@ LogicalResult LowerModule::lowerModule() {
 LogicalResult LowerModule::lowerInstances(InstanceGraph &instanceGraph) {
   auto *node = instanceGraph.lookup(cast<igraph::ModuleOpInterface>(*op));
   for (auto *use : llvm::make_early_inc_range(node->uses())) {
-    auto instanceOp = cast<InstanceOp>(*use->getInstance());
+    auto instanceOp = dyn_cast<InstanceOp>(*use->getInstance());
+    if (!instanceOp)
+      continue;
     LLVM_DEBUG(llvm::dbgs()
                << "      - " << instanceOp.getInstanceName() << "\n");
 
@@ -330,6 +334,8 @@ LogicalResult LowerCircuit::lowerDomain(DomainOp op) {
   PropAssignOp::create(builder, classOut.getArgument(3),
                        classOut.getArgument(2));
   classes.insert({name, {classIn, classOut}});
+  instanceGraph.erase(instanceGraph.lookup(op));
+  instanceGraph.addModule(classIn);
   op.erase();
   return success();
 }

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -956,7 +956,7 @@ firrtl.circuit "Foo" {
   }
 
   // CHECK-LABEL: domain ClockDomain :
-  firrtl.domain @ClockDomain {}
+  firrtl.domain @ClockDomain() {}
 
   // CHECK-LABEL: module Domains :
   firrtl.module @Domains(

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -3047,7 +3047,7 @@ firrtl.circuit "WrongDomainKind" {
 // -----
 
 firrtl.circuit "DomainInfoNotArray" {
-  firrtl.domain @ClockDomain {}
+  firrtl.domain @ClockDomain() {}
   // expected-error @below {{requires valid port domains}}
   firrtl.module @WrongDomainPortInfo(
     in %A: !firrtl.domain of @ClockDomain
@@ -3057,7 +3057,7 @@ firrtl.circuit "DomainInfoNotArray" {
 // -----
 
 firrtl.circuit "WrongDomainPortInfo" {
-  firrtl.domain @ClockDomain {}
+  firrtl.domain @ClockDomain() {}
   // expected-error @below {{domain information for domain port 'A' must be a 'FlatSymbolRefAttr'}}
   firrtl.module @WrongDomainPortInfo(
     in %A: !firrtl.domain of @ClockDomain
@@ -3067,7 +3067,7 @@ firrtl.circuit "WrongDomainPortInfo" {
 // -----
 
 firrtl.circuit "WrongNonDomainPortInfo" {
-  firrtl.domain @ClockDomain {}
+  firrtl.domain @ClockDomain() {}
   // expected-error @below {{domain information for non-domain port 'a' must be an 'ArrayAttr<IntegerAttr>'}}
   firrtl.module @WrongNonDomainPortInfo(
     in %a: !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-domains.mlir
+++ b/test/Dialect/FIRRTL/lower-domains.mlir
@@ -16,7 +16,7 @@ firrtl.circuit "Foo" {
   // CHECK-SAME:    out %associations_out: !firrtl.list<path>
   // CHECK-NEXT:    firrtl.propassign %domainInfo_out, %domainInfo_in
   // CHECK-NEXT:    firrtl.propassign %associations_out, %associations_in
-  firrtl.domain @ClockDomain {}
+  firrtl.domain @ClockDomain() {}
   // CHECK-LABEL: firrtl.module @Foo(
   // CHECK-SAME:    in %A: !firrtl.class<@ClockDomain()>
   // CHECK-SAME:    out %A_out: !firrtl.class<@ClockDomain_out(
@@ -39,7 +39,7 @@ firrtl.circuit "Foo" {
 
 // Check the behavior of the lowering of an instance.
 firrtl.circuit "Foo" {
-  firrtl.domain @ClockDomain {}
+  firrtl.domain @ClockDomain() {}
   // CHECK-LABEL: firrtl.module @Bar(
   // CHECK-SAME:    in %A: !firrtl.class<@ClockDomain()>
   // CHECK-SAME:    out %A_out: !firrtl.class<@ClockDomain_out(
@@ -72,7 +72,7 @@ firrtl.circuit "Foo" {
 
 // Check the behavior of external modules.
 firrtl.circuit "Foo" {
-  firrtl.domain @ClockDomain {}
+  firrtl.domain @ClockDomain() {}
   // CHECK-LABEL: firrtl.extmodule @Bar(
   // CHECK-SAME:    in A: !firrtl.class<@ClockDomain()>
   // CHECK-SAME:    out A_out: !firrtl.class<@ClockDomain_out(

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2196,7 +2196,14 @@ circuit NullaryCat:
 FIRRTL version 5.1.0
 circuit Domains:
   ; CHECK-LABEL: firrtl.domain @ClockDomain
+  ; CHECK-SAME:    in %name_in: !firrtl.string
+  ; CHECK-SAME:    out %name_out: !firrtl.string
   domain ClockDomain:
+    input name_in: String
+    output name_out: String
+
+    ; CHECK-NEXT: firrtl.propassign %name_out, %name_in
+    propassign name_out, name_in
 
   module Foo:
     input A: Domain of ClockDomain

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -197,7 +197,14 @@ firrtl.module @Fprintf(
 }
 
 // CHECK-LABEL: firrtl.domain @ClockDomain
-firrtl.domain @ClockDomain {
+// CHECK-SAME:    in %name_in: !firrtl.string,
+// CHECK-SAME:    out %name_out: !firrtl.string
+firrtl.domain @ClockDomain(
+  in %name_in: !firrtl.string,
+  out %name_out: !firrtl.string
+) {
+  // CHECK-NEXT: firrtl.propassign %name_out, %name_in : !firrtl.string
+  firrtl.propassign %name_out, %name_in : !firrtl.string
 }
 
 firrtl.module @DomainsSubmodule(


### PR DESCRIPTION
Change domains to behave almost exactly like classes.  They now have
input and outputs (which can be used by their existing bodies).

This could alternatively be solved by using a simpler representation for
domains.  However, this would be better handled with a full cleanup of how
classes are modeled.
