### PR TITLE
[FIRRTL] Gate class deduplication behind an option

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -257,6 +257,10 @@ def Dedup : Pass<"firrtl-dedup", "firrtl::CircuitOp"> {
     Statistic<"erasedModules", "num-erased-modules",
       "Number of modules which were erased by deduplication">
   ];
+  let options = [
+    Option<"dedupClasses", "dedup-classes", "bool", "true",
+      "Deduplicate classes, violating their nominal typing.">
+  ];
 }
 
 def EliminateWires : Pass<"firrtl-eliminate-wires", "firrtl::FModuleOp"> {

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -98,6 +98,7 @@ public:
   bool shouldDisableOptimization() const { return disableOptimization; }
   bool shouldLowerMemories() const { return lowerMemories; }
   bool shouldDedup() const { return !noDedup; }
+  bool shouldDedupClasses() const { return dedupClasses; }
   bool shouldEnableDebugInfo() const { return enableDebugInfo; }
   bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
   bool shouldConvertVecOfBundle() const { return vbToBV; }
@@ -213,6 +214,11 @@ public:
 
   FirtoolOptions &setNoDedup(bool value) {
     noDedup = value;
+    return *this;
+  }
+
+  FirtoolOptions &setDedupClasses(bool value) {
+    dedupClasses = value;
     return *this;
   }
 
@@ -405,6 +411,7 @@ private:
   bool disableOptimization;
   bool vbToBV;
   bool noDedup;
+  bool dedupClasses;
   firrtl::CompanionMode companionMode;
   bool disableAggressiveMergeConnections;
   bool lowerMemories;

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1674,6 +1674,8 @@ static void fixupSymbolSensitiveOps(
 
 namespace {
 class DedupPass : public circt::firrtl::impl::DedupBase<DedupPass> {
+  using DedupBase::DedupBase;
+
   void runOnOperation() override {
     auto *context = &getContext();
     auto circuit = getOperation();
@@ -1755,6 +1757,10 @@ class DedupPass : public circt::firrtl::impl::DedupBase<DedupPass> {
           // Only dedup extmodule's with defname.
           if (auto ext = dyn_cast<FExtModuleOp>(*module);
               ext && !ext.getDefname().has_value())
+            return success();
+
+          // Only dedup classes if enabled.
+          if (isa<ClassOp>(*module) && !dedupClasses)
             return success();
 
           StructuralHasher hasher(hasherConstants);

--- a/test/Dialect/FIRRTL/dedup-nominal-classes.mlir
+++ b/test/Dialect/FIRRTL/dedup-nominal-classes.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt --firrtl-dedup=dedup-classes=0 %s | FileCheck %s
+
+// CHECK-LABEL: "DontDedupClasses"
+firrtl.circuit "DontDedupClasses" {
+  // CHECK: firrtl.class private @Foo()
+  // CHECK: firrtl.class private @Bar()
+  firrtl.class private @Foo() {}
+  firrtl.class private @Bar() {}
+
+  // CHECK: @DontDedupClasses()
+  firrtl.module @DontDedupClasses() {
+    // CHECK-NEXT: firrtl.wire : !firrtl.class<@Foo()>
+    // CHECK-NEXT: firrtl.wire : !firrtl.class<@Bar()>
+    %wire1 = firrtl.wire : !firrtl.class<@Foo()>
+    %wire2 = firrtl.wire : !firrtl.class<@Bar()>
+  }
+}

--- a/test/firtool/classes-dedupe.mlir
+++ b/test/firtool/classes-dedupe.mlir
@@ -1,0 +1,23 @@
+// RUN: firtool --ir-fir %s | FileCheck %s --check-prefixes=CHECK,CHECK-ON
+// RUN: firtool --ir-fir --dedup-classes=0 %s | FileCheck %s --check-prefixes=CHECK,CHECK-OFF
+// RUN: firtool --ir-fir --dedup-classes=1 %s | FileCheck %s --check-prefixes=CHECK,CHECK-ON
+
+// Check that the `--dedup-classes` flag actually does something.
+
+// CHECK-LABEL: "ClassDedup"
+firrtl.circuit "ClassDedup" {
+  // CHECK: firrtl.class private @Foo()
+  // CHECK-OFF: firrtl.class private @Bar()
+  // CHECK-ON-NOT: firrtl.class private @Bar()
+  firrtl.class private @Foo() {}
+  firrtl.class private @Bar() {}
+
+  // CHECK: @ClassDedup()
+  firrtl.module @ClassDedup() {
+    // CHECK-NEXT: firrtl.object @Foo()
+    // CHECK-OFF-NEXT: firrtl.object @Bar()
+    // CHECK-ON-NEXT: firrtl.object @Foo()
+    %obj1 = firrtl.object @Foo()
+    %obj2 = firrtl.object @Bar()
+  }
+}


### PR DESCRIPTION
Add a `dedupClasses` option to the Dedup pass, enabled by default. When the option is enabled, classes are deduplicated like modules, which makes their names unstable. Some current flows that use firtool require this behavior. If the option is disabled, classes are considered nominally typed (which they are intended to be), and are not deduplicated at all.

Add a corresponding `--dedup-classes` option to firtool, also enabled by default. This allows flows to continue relying on the current class deduplication behavior, but they can opt into proper nominally typed classes as they see fit.

Eventually we'll want to remove these options and make classes *not* dedup unconditionally. @dtzSiFive calls this a compiler chicken bit :rofl:.