### PR TITLE
[circt-verilog-lsp] Move to Slang's src mngr, drop LLVM src mngr

### DIFF
--- a/test/Tools/circt-verilog-lsp-server/find-definition.test
+++ b/test/Tools/circt-verilog-lsp-server/find-definition.test
@@ -7,13 +7,13 @@
   "uri":"test:///foo.sv",
   "languageId":"verilog",
   "version":1,
-  "text":"module test(// @[include/test.mlir:2:5]\noutput out// @[include/test.mlir:2:{24,25}]\n); assign out = 1'h1; // @[include/test.mlir:3:14, :4:9]\nendmodule"
+  "text":"// 🙂😎🤖🔥🚀✨🐍🎉 emojis before module\nmodule test(// @[include/test.mlir:2:5]\noutput out// @[include/test.mlir:2:{24,25}]\n); assign out = 1'h1; // @[include/test.mlir:3:14, :4:9]\nendmodule"
 }}}
 // -----
 // Find definition of `out`
 {"jsonrpc":"2.0","id":1,"method":"textDocument/definition","params":{
   "textDocument":{"uri":"test:///foo.sv"},
-  "position":{"line":2,"character":10}
+  "position":{"line":3,"character":10}
 }}
 // CHECK:       "id": 1,
 // CHECK-NEXT:  "jsonrpc": "2.0",
@@ -22,11 +22,11 @@
 // CHECK-NEXT:      "range": {
 // CHECK-NEXT:        "end": {
 // CHECK-NEXT:          "character": 10,
-// CHECK-NEXT:          "line": 1
+// CHECK-NEXT:          "line": 2
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "start": {
 // CHECK-NEXT:          "character": 7,
-// CHECK-NEXT:          "line": 1
+// CHECK-NEXT:          "line": 2
 // CHECK-NEXT:        }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "uri": "test:///foo.sv"
@@ -36,7 +36,7 @@
 // Find definition of `include/test.mlir:2:5`
 {"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{
   "textDocument":{"uri":"test:///foo.sv"},
-  "position":{"line":0,"character":20}
+  "position":{"line":1,"character":20}
 }}
 // CHECK:       "id": 2,
 // CHECK-NEXT:  "jsonrpc": "2.0",
@@ -58,7 +58,7 @@
 // -----
 {"jsonrpc":"2.0","id":3,"method":"textDocument/definition","params":{
   "textDocument":{"uri":"test:///foo.sv"},
-  "position":{"line":1,"character":17}
+  "position":{"line":2,"character":17}
 }}
 // Find definition of `include/test.mlir:2:{24,25}`
 // CHECK:       "id": 3,
@@ -80,7 +80,7 @@
 // -----
 {"jsonrpc":"2.0","id":4,"method":"textDocument/definition","params":{
   "textDocument":{"uri":"test:///foo.sv"},
-  "position":{"line":1,"character":39}
+  "position":{"line":2,"character":39}
 }}
 // Find definition of `include/test.mlir:2:{24,25}`
 // CHECK:       "id": 4,


### PR DESCRIPTION
- **Use Slang buffers as source of truth**
  - Replace `llvm::SourceMgr`-centric code with direct use of `slang::SourceManager`.
  - Add `slang::BufferID mainBufferId` and expose `getMainBufferID()`.

- **Interval map now indexes Slang buffer pointers**
  - New typedef: `using SlangBufferPointer = char const *;`.
  - Change from `IntervalMap<const char*, …>` to `IntervalMap<SlangBufferPointer, …>` (half-open).
  - Lookups are computed from `slang::SourceManager::getSourceText(buf).data() + offset`.

- **Remove LLVM `SourceMgr` plumbing**
  - Drop members/APIs: `sourceMgr`, `bufferIDMap`, `getSMLoc(...)`.
  - Update `filePathMap` to store `(slang::BufferID, path)` pairs.
  - `getOrOpenFile(...)` now assigns text via Slang (`driver.sourceManager.assignText(...)`) and caches the returned `BufferID`.

- **Implement LSP UTF-16 to Slang UTF-8 conversion**
  - Add `decodeUtf8(...)` and `lspPositionToOffset(...)` helpers.
  - Use these helpers in `getLocationsOf(...)` and `findReferencesOf(...)` before interval lookups.
  - Clamp positions past end-of-line to buffer end; avoid OOB pointer math.

- **Definition & reference resolution updated**
  - `getLspLocation(slang::SourceLocation/Range)` now uses Slang line/column and compares `loc.buffer()` directly to `mainBufferId`.
  - `findReferencesOf(...)` / `getLocationsOf(...)` locate the interval by pointer into the **main** buffer.

- **Top module discovery via syntax trees**
  - Derive `driver.options.topModules` from `CompilationUnitSyntax` members by reading `ModuleDeclarationSyntax` headers (covers modules and packages).
  - Avoid creating a separate `Compilation` just to enumerate tops.