### PR TITLE
[CombToSynth] Use parallel-prefix tree for unsigned comparisons

### DIFF
--- a/integration_test/circt-synth/comb-lowering-compare.mlir
+++ b/integration_test/circt-synth/comb-lowering-compare.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: libz3
 // REQUIRES: circt-lec-jit
 
-// RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-synth --convert-synth-to-comb -o %t.mlir
+// RUN: circt-opt %s --convert-comb-to-synth --convert-synth-to-comb -o %t.mlir
 
 // RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_ripple_carry -c2=icmp_unsigned_ripple_carry --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_RIPPLE_CARRY
 // COMB_ICMP_UNSIGNED_RIPPLE_CARRY: c1 == c2

--- a/integration_test/circt-synth/comb-lowering-compare.mlir
+++ b/integration_test/circt-synth/comb-lowering-compare.mlir
@@ -1,0 +1,56 @@
+// REQUIRES: libz3
+// REQUIRES: circt-lec-jit
+
+// RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-synth --convert-synth-to-comb -o %t.mlir
+
+// RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_ripple_carry -c2=icmp_unsigned_ripple_carry --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_RIPPLE_CARRY
+// COMB_ICMP_UNSIGNED_RIPPLE_CARRY: c1 == c2
+hw.module @icmp_unsigned_ripple_carry(in %lhs: i3, in %rhs: i3, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
+  %ugt = comb.icmp ugt %lhs, %rhs {synth.test.arch = "RIPPLE-CARRY"} : i3
+  %uge = comb.icmp uge %lhs, %rhs {synth.test.arch = "RIPPLE-CARRY"} : i3
+  %ult = comb.icmp ult %lhs, %rhs {synth.test.arch = "RIPPLE-CARRY"} : i3
+  %ule = comb.icmp ule %lhs, %rhs {synth.test.arch = "RIPPLE-CARRY"} : i3
+  hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
+}
+
+// RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_sklanskey -c2=icmp_unsigned_sklanskey --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_SKLANSKEY
+// COMB_ICMP_UNSIGNED_SKLANSKEY: c1 == c2
+hw.module @icmp_unsigned_sklanskey(in %lhs: i3, in %rhs: i3, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
+  %ugt = comb.icmp ugt %lhs, %rhs {synth.test.arch = "SKLANSKEY"} : i3
+  %uge = comb.icmp uge %lhs, %rhs {synth.test.arch = "SKLANSKEY"} : i3
+  %ult = comb.icmp ult %lhs, %rhs {synth.test.arch = "SKLANSKEY"} : i3
+  %ule = comb.icmp ule %lhs, %rhs {synth.test.arch = "SKLANSKEY"} : i3
+  hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
+}
+
+// RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_kogge_stone -c2=icmp_unsigned_kogge_stone --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_KOGGE_STONE
+// COMB_ICMP_UNSIGNED_KOGGE_STONE: c1 == c2
+hw.module @icmp_unsigned_kogge_stone(in %lhs: i3, in %rhs: i3, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
+  %ugt = comb.icmp ugt %lhs, %rhs {synth.test.arch = "KOGGE-STONE"} : i3
+  %uge = comb.icmp uge %lhs, %rhs {synth.test.arch = "KOGGE-STONE"} : i3
+  %ult = comb.icmp ult %lhs, %rhs {synth.test.arch = "KOGGE-STONE"} : i3
+  %ule = comb.icmp ule %lhs, %rhs {synth.test.arch = "KOGGE-STONE"} : i3
+  hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
+}
+
+// RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_brent_kung -c2=icmp_unsigned_brent_kung --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_BRENT_KUNG
+// COMB_ICMP_UNSIGNED_BRENT_KUNG: c1 == c2
+hw.module @icmp_unsigned_brent_kung(in %lhs: i4, in %rhs: i4, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
+  %ugt = comb.icmp ugt %lhs, %rhs {synth.test.arch = "BRENT-KUNG"} : i4
+  %uge = comb.icmp uge %lhs, %rhs {synth.test.arch = "BRENT-KUNG"} : i4
+  %ult = comb.icmp ult %lhs, %rhs {synth.test.arch = "BRENT-KUNG"} : i4
+  %ule = comb.icmp ule %lhs, %rhs {synth.test.arch = "BRENT-KUNG"} : i4
+  hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
+}
+
+// RUN: circt-lec %t.mlir %s -c1=icmp_signed -c2=icmp_signed --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_SIGNED
+// COMB_ICMP_SIGNED: c1 == c2
+hw.module @icmp_signed(in %lhs: i4, in %rhs: i4, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
+  // Sign comparisons are just unsigned comparisons with inverted inputs and outputs.
+  // No need to test all architectures here.
+  %ugt = comb.icmp sgt %lhs, %rhs {synth.test.arch = "RIPPLE-CARRY"} : i4
+  %uge = comb.icmp sge %lhs, %rhs {synth.test.arch = "SKLANSKEY"} : i4
+  %ult = comb.icmp slt %lhs, %rhs {synth.test.arch = "KOGGE-STONE"} : i4
+  %ule = comb.icmp sle %lhs, %rhs {synth.test.arch = "BRENT-KUNG"} : i4
+  hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
+}

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -1076,6 +1076,11 @@ struct CombICmpOpConversion : OpConversionPattern<ICmpOp> {
   }
 
   // Compute prefix comparison using parallel prefix algorithm
+  // Note: This generates all intermediate prefix values even though we only
+  // need the final result. Optimizing this to skip intermediate computations
+  // is non-trivial because each iteration depends on results from previous
+  // iterations. We rely on DCE passes to remove unused operations.
+  // TODO: Lazily compute only the required prefix values.
   static Value computePrefixComparison(ConversionPatternRewriter &rewriter,
                                        Location loc, SmallVector<Value> pPrefix,
                                        SmallVector<Value> gPrefix,

--- a/test/Conversion/CombToSynth/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToSynth/comb-to-aig-arith.mlir
@@ -227,29 +227,29 @@ hw.module @icmp_unsigned_compare(in %lhs: i2, in %rhs: i2, out out_ugt: i1, out 
   %uge = comb.icmp uge %lhs, %rhs : i2
   %ult = comb.icmp ult %lhs, %rhs : i2
   %ule = comb.icmp ule %lhs, %rhs : i2
-  // CHECK-NEXT:   %[[LHS_0:.+]] = comb.extract %lhs from 0 : (i2) -> i1
-  // CHECK-NEXT:   %[[LHS_1:.+]] = comb.extract %lhs from 1 : (i2) -> i1
   // CHECK-NEXT:   %[[RHS_0:.+]] = comb.extract %rhs from 0 : (i2) -> i1
   // CHECK-NEXT:   %[[RHS_1:.+]] = comb.extract %rhs from 1 : (i2) -> i1
-  // CHECK-NEXT:   %[[LSB_NEQ:.+]] = comb.xor bin %[[LHS_0]], %[[RHS_0]]
-  // CHECK-NEXT:   %[[LSB_GT:.+]] = synth.aig.and_inv %[[LHS_0]], not %[[RHS_0]]
-  // CHECK-NEXT:   %[[MSB_NEQ:.+]] = comb.xor bin %[[LHS_1]], %[[RHS_1]]
-  // CHECK-NEXT:   %[[MSB_EQ:.+]] = synth.aig.and_inv not %[[MSB_NEQ]]
-  // CHECK-NEXT:   %[[MSB_GT:.+]] = synth.aig.and_inv %[[LHS_1]], not %[[RHS_1]]
-  // CHECK-NEXT:   %[[MSB_EQ_AND_LSB_GT:.+]] = comb.and bin %[[MSB_EQ]], %[[LSB_GT]]
-  // CHECK-NEXT:   %[[UGT:.+]] = comb.or bin %[[MSB_GT]], %[[MSB_EQ_AND_LSB_GT]]
-  // CHECK-NEXT:   %[[LSB_EQ:.+]] = synth.aig.and_inv not %[[LSB_NEQ]]
-  // CHECK-NEXT:   %[[LSB_UGE:.+]] = comb.or bin %[[LSB_GT]], %[[LSB_EQ]]
-  // CHECK-NEXT:   %[[MSB_EQ_AND_LSB_UGE:.+]] = comb.and bin %[[MSB_EQ]], %[[LSB_UGE]]
-  // CHECK-NEXT:   %[[UGE:.+]] = comb.or bin %[[MSB_GT]], %[[MSB_EQ_AND_LSB_UGE]]
-  // CHECK-NEXT:   %[[LSB_LT:.+]] = synth.aig.and_inv not %[[LHS_0]], %[[RHS_0]]
-  // CHECK-NEXT:   %[[MSB_LT:.+]] = synth.aig.and_inv not %[[LHS_1]], %[[RHS_1]]
-  // CHECK-NEXT:   %[[MSB_EQ_AND_LSB_LT:.+]] = comb.and bin %[[MSB_EQ]], %[[LSB_LT]]
-  // CHECK-NEXT:   %[[ULT:.+]] = comb.or bin %[[MSB_LT]], %[[MSB_EQ_AND_LSB_LT]]
-  // CHECK-NEXT:   %[[LSB_LE:.+]] = comb.or bin %[[LSB_LT]], %[[LSB_EQ]]
-  // CHECK-NEXT:   %[[MSB_EQ_AND_LSB_LE:.+]] = comb.and bin %[[MSB_EQ]], %[[LSB_LE]]
-  // CHECK-NEXT:   %[[ULE:.+]] = comb.or bin %[[MSB_LT]], %[[MSB_EQ_AND_LSB_LE]]
-  // CHECK-NEXT:   hw.output %[[UGT]], %[[UGE]], %[[ULT]], %[[ULE]]
+  // CHECK-NEXT:   %[[LHS_0:.+]] = comb.extract %lhs from 0 : (i2) -> i1
+  // CHECK-NEXT:   %[[LHS_1:.+]] = comb.extract %lhs from 1 : (i2) -> i1
+  // CHECK-NEXT:   %[[LSB_NEQ:.+]] = comb.xor bin %[[RHS_0]], %[[LHS_0]] : i1
+  // CHECK-NEXT:   %[[LSB_GT:.+]] = synth.aig.and_inv not %[[RHS_0]], %[[LHS_0]] : i1
+  // CHECK-NEXT:   %[[MSB_NEQ:.+]] = comb.xor bin %[[RHS_1]], %[[LHS_1]] : i1
+  // CHECK-NEXT:   %[[MSB_EQ:.+]] = synth.aig.and_inv not %[[MSB_NEQ]] : i1
+  // CHECK-NEXT:   %[[MSB_GT:.+]] = synth.aig.and_inv not %[[RHS_1]], %[[LHS_1]] : i1
+  // CHECK-NEXT:   %[[MSB_EQ_AND_LSB_GT:.+]] = comb.and bin %[[MSB_EQ]], %[[LSB_GT]] : i1
+  // CHECK-NEXT:   %[[UGT:.+]] = comb.or bin %[[MSB_GT]], %[[MSB_EQ_AND_LSB_GT]] : i1
+  // CHECK-NEXT:   %[[LSB_EQ:.+]] = synth.aig.and_inv not %[[LSB_NEQ]] : i1
+  // CHECK-NEXT:   %[[LSB_UGE:.+]] = comb.or bin %[[LSB_GT]], %[[LSB_EQ]] : i1
+  // CHECK-NEXT:   %[[MSB_EQ_AND_LSB_UGE:.+]] = comb.and bin %[[MSB_EQ]], %[[LSB_UGE]] : i1
+  // CHECK-NEXT:   %[[UGE:.+]] = comb.or bin %[[MSB_GT]], %[[MSB_EQ_AND_LSB_UGE]] : i1
+  // CHECK-NEXT:   %[[LSB_LT:.+]] = synth.aig.and_inv not %[[LHS_0]], %[[RHS_0]] : i1
+  // CHECK-NEXT:   %[[MSB_LT:.+]] = synth.aig.and_inv not %[[LHS_1]], %[[RHS_1]] : i1
+  // CHECK-NEXT:   %[[MSB_EQ_AND_LSB_LT:.+]] = comb.and bin %[[MSB_EQ]], %[[LSB_LT]] : i1
+  // CHECK-NEXT:   %[[ULT:.+]] = comb.or bin %[[MSB_LT]], %[[MSB_EQ_AND_LSB_LT]] : i1
+  // CHECK-NEXT:   %[[LSB_LE:.+]] = comb.or bin %[[LSB_LT]], %[[LSB_EQ]] : i1
+  // CHECK-NEXT:   %[[MSB_EQ_AND_LSB_LE:.+]] = comb.and bin %[[MSB_EQ]], %[[LSB_LE]] : i1
+  // CHECK-NEXT:   %[[ULE:.+]] = comb.or bin %[[MSB_LT]], %[[MSB_EQ_AND_LSB_LE]] : i1
+  // CHECK-NEXT:   hw.output %[[UGT]], %[[UGE]], %[[ULT]], %[[ULE]] : i1, i1, i1, i1
   // CHECK-NEXT: }
   hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
 }
@@ -260,12 +260,12 @@ hw.module @icmp_signed_compare(in %lhs: i2, in %rhs: i2, out out_sgt: i1, out ou
   %sge = comb.icmp sge %lhs, %rhs : i2
   %slt = comb.icmp slt %lhs, %rhs : i2
   %sle = comb.icmp sle %lhs, %rhs : i2
-  // CHECK-NEXT:   %[[LHS_0:.+]] = comb.extract %lhs from 0 : (i2) -> i1
   // CHECK-NEXT:   %[[LHS_1:.+]] = comb.extract %lhs from 1 : (i2) -> i1
-  // CHECK-NEXT:   %[[RHS_0:.+]] = comb.extract %rhs from 0 : (i2) -> i1
   // CHECK-NEXT:   %[[RHS_1:.+]] = comb.extract %rhs from 1 : (i2) -> i1
-  // CHECK-NEXT:   %[[LSB_NEQ:.+]] = comb.xor bin %[[LHS_0]], %[[RHS_0]]
-  // CHECK-NEXT:   %[[LSB_GT:.+]] = synth.aig.and_inv %[[LHS_0]], not %[[RHS_0]]
+  // CHECK-NEXT:   %[[LHS_0:.+]] = comb.extract %lhs from 0 : (i2) -> i1
+  // CHECK-NEXT:   %[[RHS_0:.+]] = comb.extract %rhs from 0 : (i2) -> i1
+  // CHECK-NEXT:   %[[LSB_NEQ:.+]] = comb.xor bin %[[RHS_0]], %[[LHS_0]]
+  // CHECK-NEXT:   %[[LSB_GT:.+]] = synth.aig.and_inv not %[[RHS_0]], %[[LHS_0]]
   // CHECK-NEXT:   %[[SIGN_NEQ:.+]] = comb.xor %[[LHS_1]], %[[RHS_1]]
   // CHECK-NEXT:   %[[SGT:.+]] = comb.mux %[[SIGN_NEQ]], %[[RHS_1]], %[[LSB_GT]]
   // CHECK-NEXT:   %[[LSB_EQ:.+]] = synth.aig.and_inv not %[[LSB_NEQ]]

--- a/test/Conversion/CombToSynth/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToSynth/comb-to-aig-arith.mlir
@@ -254,6 +254,36 @@ hw.module @icmp_unsigned_compare(in %lhs: i2, in %rhs: i2, out out_ugt: i1, out 
   hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
 }
 
+// CHECK-LABEL: @icmp_unsigned_compare_prefix_tree
+hw.module @icmp_unsigned_compare_prefix_tree(in %lhs: i3, in %rhs: i3, out out_ult: i1) {
+  %ult = comb.icmp ult %lhs, %rhs {synth.test.arch = "SKLANSKEY"}: i3
+  // CHECK:      %[[LHS_0:.+]] = comb.extract %lhs from 0 : (i3) -> i1
+  // CHECK-NEXT: %[[LHS_1:.+]] = comb.extract %lhs from 1 : (i3) -> i1
+  // CHECK-NEXT: %[[LHS_2:.+]] = comb.extract %lhs from 2 : (i3) -> i1
+  // CHECK-NEXT: %[[RHS_0:.+]] = comb.extract %rhs from 0 : (i3) -> i1
+  // CHECK-NEXT: %[[RHS_1:.+]] = comb.extract %rhs from 1 : (i3) -> i1
+  // CHECK-NEXT: %[[RHS_2:.+]] = comb.extract %rhs from 2 : (i3) -> i1
+  // CHECK-NEXT: %[[TRUE:.+]] = hw.constant true
+  // CHECK-NEXT: %[[LSB_NEQ:.+]] = comb.xor %[[LHS_0]], %[[RHS_0]] : i1
+  // CHECK-NEXT: %[[LSB_EQ:.+]] = comb.xor %[[LSB_NEQ]], %[[TRUE]] : i1
+  // CHECK-NEXT: %[[LHS_0_NOT:.+]] = comb.xor %[[LHS_0]], %[[TRUE]] : i1
+  // CHECK-NEXT: %[[LSB_LT:.+]] = comb.and %[[LHS_0_NOT]], %[[RHS_0]] : i1
+  // CHECK-NEXT: %[[BIT1_NEQ:.+]] = comb.xor %[[LHS_1]], %[[RHS_1]] : i1
+  // CHECK-NEXT: %[[BIT1_EQ:.+]] = comb.xor %[[BIT1_NEQ]], %[[TRUE]] : i1
+  // CHECK-NEXT: %[[LHS_1_NOT:.+]] = comb.xor %[[LHS_1]], %[[TRUE]] : i1
+  // CHECK-NEXT: %[[BIT1_LT:.+]] = comb.and %[[LHS_1_NOT]], %[[RHS_1]] : i1
+  // CHECK-NEXT: %[[MSB_NEQ:.+]] = comb.xor %[[LHS_2]], %[[RHS_2]] : i1
+  // CHECK-NEXT: %[[MSB_EQ:.+]] = comb.xor %[[MSB_NEQ]], %[[TRUE]] : i1
+  // CHECK-NEXT: %[[LHS_2_NOT:.+]] = comb.xor %[[LHS_2]], %[[TRUE]] : i1
+  // CHECK-NEXT: %[[MSB_LT:.+]] = comb.and %[[LHS_2_NOT]], %[[RHS_2]] : i1
+  // CHECK-NEXT: %[[BIT1_EQ_AND_LSB_LT:.+]] = comb.and %[[BIT1_EQ]], %[[LSB_LT]] : i1
+  // CHECK-NEXT: %[[BIT10_LT:.+]] = comb.or %[[BIT1_LT]], %[[BIT1_EQ_AND_LSB_LT]] : i1
+  // CHECK:      %[[MSB_EQ_AND_BIT10_LT:.+]] = comb.and %[[MSB_EQ]], %[[BIT10_LT]] : i1
+  // CHECK-NEXT: %[[ULT:.+]] = comb.or %[[MSB_LT]], %[[MSB_EQ_AND_BIT10_LT]] : i1
+  // CHECK-NEXT: hw.output %[[ULT]] : i1
+  hw.output %ult : i1
+}
+
 // CHECK-LABEL: @icmp_signed_compare
 hw.module @icmp_signed_compare(in %lhs: i2, in %rhs: i2, out out_sgt: i1, out out_sge: i1, out out_slt: i1, out out_sle: i1) {
   %sgt = comb.icmp sgt %lhs, %rhs : i2
@@ -432,4 +462,3 @@ hw.module @divmodu_power_of_two(in %lhs: i8, out out_divu: i8, out out_modu: i8)
   // ALLOW_ICMP-NEXT: hw.output %[[DIVU]], %[[MODU]] : i8, i8
   hw.output %0, %1 : i8, i8
 }
-


### PR DESCRIPTION
This commit extends the unsigned comparison lowering to support multiple parallel-prefix architectures (Sklanskey, Kogge-Stone, Brent-Kung) in addition to the existing ripple-carry implementation. No functional change in prefix-tree/adder lowering. 

Previously, all comparisons used a ripple-carry style implementation that processed bits sequentially from LSB to MSB, resulting in O(n) depth for n-bit comparisons. This was a significant performance bottleneck for wide comparisons. The comparison lowering is now refactored to use the same parallel-prefix tree algorithms as the adder, reducing depth to O(log n).

The comparison logic is formulated as a prefix computation where equal bits are computed as ~(a_i ^ b_i) and greater bits as ~a_i & b_i, with propagate and generate signals based on equality and greater-than conditions.

Integration tests for all architectures verify logical equivalence via circt-lec. 

before/after for 64-bit unsigned comparision. 
```
uenoku@pop-os ~/d/circt-synth (dev/hidetou/icmp-parallel) [1]> ../circt/build/bin/circt-synth bar.mlir -output-longest-path=- -o /dev/null
# Longest Path Analysis result for "icmp_unsigned"
Found 128 paths
Found 1 unique fanout points
Maximum path delay: 128
## Showing Levels
Level = 128       . Count = 1         . 100.00    %
## Top 0 (out of 1) fan-out points

uenoku@pop-os ~/d/circt-synth (dev/hidetou/icmp-parallel)> ./build/bin/circt-synth bar.mlir -output-longest-path=- -o /dev/null 
# Longest Path Analysis result for "icmp_unsigned"
Found 128 paths
Found 1 unique end points 
Maximum path delay: 14
## Showing Levels
Level = 14        . Count = 1         . 100.00    %
## Top 0 (out of 1) end points
```