### PR TITLE
[CombToDatapath] Lower comb::SubOp

### DIFF
--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -86,6 +86,10 @@ Value createDynamicInject(OpBuilder &builder, Location loc, Value value,
 Value createInject(OpBuilder &builder, Location loc, Value value,
                    unsigned offset, Value replacement);
 
+/// Replace a subtraction with an addition of the two's complement.
+LogicalResult convertSubToAdd(comb::SubOp subOp,
+                              mlir::PatternRewriter &rewriter);
+
 /// Enum for mux chain folding styles.
 enum MuxChainWithComparisonFoldingStyle { None, BalancedMuxTree, ArrayGet };
 /// Mux chain folding that converts chains of muxes with index

--- a/lib/Conversion/CombToDatapath/CombToDatapath.cpp
+++ b/lib/Conversion/CombToDatapath/CombToDatapath.cpp
@@ -92,6 +92,7 @@ struct ConvertCombToDatapathPass
 static void
 populateCombToDatapathConversionPatterns(RewritePatternSet &patterns) {
   patterns.add<CombAddOpConversion, CombMulOpConversion>(patterns.getContext());
+  patterns.add(comb::convertSubToAdd);
 }
 
 void ConvertCombToDatapathPass::runOnOperation() {
@@ -106,6 +107,7 @@ void ConvertCombToDatapathPass::runOnOperation() {
   // TODO: determine lowering of multi-input multipliers
   target.addDynamicallyLegalOp<comb::MulOp>(
       [](comb::MulOp op) { return op.getNumOperands() > 2; });
+  target.addIllegalOp<comb::SubOp>();
 
   RewritePatternSet patterns(&getContext());
   populateCombToDatapathConversionPatterns(patterns);

--- a/test/Conversion/CombToDatapath/comb-to-datapath.mlir
+++ b/test/Conversion/CombToDatapath/comb-to-datapath.mlir
@@ -26,4 +26,15 @@ hw.module @zero_width(in %arg0: i0, in %arg1: i0, in %arg2: i0) {
   // CHECK-NEXT: hw.constant 0 : i0
   %0 = comb.add %arg0, %arg1, %arg2 : i0
 }
+// CHECK-LABEL: @sub
+hw.module @sub(in %arg0: i4, in %arg1: i4, out out: i4) {
+  %0 = comb.sub %arg0, %arg1 : i4
+  // CHECK-NEXT: %[[C_NEG1:.+]] = hw.constant -1 : i4
+  // CHECK-NEXT: %[[XOR:.+]] = comb.xor %arg1, %[[C_NEG1]] : i4
+  // CHECK-NEXT: %[[C1:.+]] = hw.constant 1 : i4
+  // CHECK-NEXT: %[[COMP:.+]]:2 = datapath.compress %arg0, %[[XOR]], %[[C1]] : i4 [3 -> 2]
+  // CHECK-NEXT: %[[ADD:.+]] = comb.add bin %[[COMP]]#0, %[[COMP]]#1 : i4
+  // CHECK-NEXT: hw.output %[[ADD]] : i4
+  hw.output %0 : i4
+}
 

--- a/test/Conversion/CombToSynth/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToSynth/comb-to-aig-arith.mlir
@@ -146,9 +146,10 @@ hw.module @add_64(in %lhs: i64, in %rhs: i64, out out: i64) {
 
 // CHECK-LABEL: @sub
 // ALLOW_ADD-LABEL: @sub
-// ALLOW_ADD-NEXT: %[[NOT_RHS:.+]] = synth.aig.and_inv not %rhs
+// ALLOW_ADD-NEXT: %[[C_NEG1:.+]] = hw.constant -1 : i4
+// ALLOW_ADD-NEXT: %[[NOT_RHS:.+]] = comb.xor %rhs, %[[C_NEG1]] : i4
 // ALLOW_ADD-NEXT: %[[CONST:.+]] = hw.constant 1 : i4
-// ALLOW_ADD-NEXT: %[[ADD:.+]] = comb.add bin %lhs, %[[NOT_RHS]], %[[CONST]] {sv.namehint = "sub"}
+// ALLOW_ADD-NEXT: %[[ADD:.+]] = comb.add %lhs, %[[NOT_RHS]], %[[CONST]] {sv.namehint = "sub"}
 // ALLOW_ADD-NEXT: hw.output %[[ADD]]
 hw.module @sub(in %lhs: i4, in %rhs: i4, out out: i4) {
   %0 = comb.sub %lhs, %rhs {sv.namehint = "sub"} : i4


### PR DESCRIPTION
Adds support for lowering comb::SubOp in the CombToDatapath conversion pass by refactoring the SubOp-to-AddOp conversion into a shared utility function that can be reused across multiple conversion passes. This change makes SubOp it possible to leverage datapath optimizations

This commit extracts the subtraction lowering logic from CombToSynth into a dialect-agnostic utility function `comb::convertSubToAdd` that transforms `sub(lhs, rhs)` into `add(lhs, ~rhs, 1)` using two's complement representation.

AIG logic depth improved 29 -> 24 for i128 subtraction