### PR TITLE
[circt-synth] Allow AIGER file to be an input file

### DIFF
--- a/test/circt-synth/aiger.mlir
+++ b/test/circt-synth/aiger.mlir
@@ -1,0 +1,8 @@
+// RUN: circt-translate --export-aiger %s | circt-synth --input-format=aiger | FileCheck %s
+// RUN: circt-translate --export-aiger %s -o %t.aig && circt-synth %t.aig | FileCheck %s
+// CHECK-LABEL: @aiger_top(
+// CHECK: synth.aig.and_inv %a, not %b : i1
+hw.module @and(in %a: i1, in %b: i1, out and: i1) {
+  %0 = synth.aig.and_inv %a, not %b : i1
+  hw.output %0 : i1
+}

--- a/tools/circt-synth/CMakeLists.txt
+++ b/tools/circt-synth/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(circt-synth
   CIRCTDebug
   CIRCTEmit
   CIRCTHW
+  CIRCTImportAIGER
   CIRCTLTL
   CIRCTOM
   CIRCTSeq


### PR DESCRIPTION
Similar to firtool taking fir file as an input file this commit changes circt-synth to parse an aiger file directly.