### PR TITLE
[circt-verilog-lsp] Minimize project-scope File IO

### DIFF
--- a/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogDocument.h
+++ b/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogDocument.h
@@ -37,9 +37,11 @@ struct VerilogServerContext;
 
 class VerilogDocument {
 public:
-  VerilogDocument(VerilogServerContext &globalContext,
-                  const llvm::lsp::URIForFile &uri, llvm::StringRef contents,
-                  std::vector<llvm::lsp::Diagnostic> &diagnostics);
+  VerilogDocument(
+      VerilogServerContext &globalContext, const llvm::lsp::URIForFile &uri,
+      llvm::StringRef contents, std::vector<llvm::lsp::Diagnostic> &diagnostics,
+      const slang::driver::Driver *projectDriver = nullptr,
+      const std::vector<std::string> &projectIncludeDirectories = {});
   VerilogDocument(const VerilogDocument &) = delete;
   VerilogDocument &operator=(const VerilogDocument &) = delete;
 

--- a/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogTextFile.h
+++ b/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogTextFile.h
@@ -64,10 +64,16 @@ private:
   void initialize(const llvm::lsp::URIForFile &uri, int64_t newVersion,
                   std::vector<llvm::lsp::Diagnostic> &diagnostics);
 
+  void initializeProjectDriver();
+
   VerilogServerContext &context;
 
   /// The full string contents of the file.
   std::string contents;
+
+  /// The project-scale driver
+  std::unique_ptr<slang::driver::Driver> projectDriver;
+  std::vector<std::string> projectIncludeDirectories;
 
   /// The version of this file.
   int64_t version = 0;


### PR DESCRIPTION
Reduce filesystem I/O overhead caused by repeated re-opening and reparsing of project files in the Verilog LSP server when using the `-C` option. For a large, SoC-scale project this approach reduces parsing time from ~1s to 0.75s.
This implementation also correctly indexes the editor-state rather than the file system state of the main buffer.

- **Introduced shared `projectDriver`:** A persistent `slang::driver::Driver` is now created once per project and passed to all `VerilogDocument` instances to reuse loaded files and avoid redundant disk access.
- **Refactored `VerilogDocument` initialization:**
  - Removed per-buffer command file parsing and main-file filtering logic.
  - Added `setTopModules()` and `copyBuffers()` helpers to extract top-level modules and reuse in-memory buffers from `projectDriver` instead of reading from disk.
- **Inheritance of project context:**
  - Copied defines/undefines directly from the shared driver.
  - Library search directories are now applied once at construction.
- **VerilogTextFile integration:**
  - Added `initializeProjectDriver()` to parse all command files once and hold a shared driver reference for reuse.
