### PR TITLE
[RTG] Add VirtualRegisterConfigAttr

### DIFF
--- a/frontends/PyRTG/src/pyrtg/resources.py
+++ b/frontends/PyRTG/src/pyrtg/resources.py
@@ -25,41 +25,42 @@ class IntegerRegister(Value):
     self._value = value
 
   def virtual() -> IntegerRegister:
-    return rtg.VirtualRegisterOp([
-        # Choose temporaries with highest priority
-        rtgtest.RegT0Attr.get(),
-        rtgtest.RegT1Attr.get(),
-        rtgtest.RegT2Attr.get(),
-        rtgtest.RegT3Attr.get(),
-        rtgtest.RegT4Attr.get(),
-        rtgtest.RegT5Attr.get(),
-        rtgtest.RegT6Attr.get(),
-        # Function arguments in reverse order
-        rtgtest.RegA7Attr.get(),
-        rtgtest.RegA6Attr.get(),
-        rtgtest.RegA5Attr.get(),
-        rtgtest.RegA4Attr.get(),
-        rtgtest.RegA3Attr.get(),
-        rtgtest.RegA2Attr.get(),
-        rtgtest.RegA1Attr.get(),
-        rtgtest.RegA0Attr.get(),
-        # Callee saved temporaries
-        rtgtest.RegS1Attr.get(),
-        rtgtest.RegS2Attr.get(),
-        rtgtest.RegS3Attr.get(),
-        rtgtest.RegS4Attr.get(),
-        rtgtest.RegS5Attr.get(),
-        rtgtest.RegS6Attr.get(),
-        rtgtest.RegS7Attr.get(),
-        rtgtest.RegS8Attr.get(),
-        rtgtest.RegS9Attr.get(),
-        rtgtest.RegS10Attr.get(),
-        rtgtest.RegS11Attr.get(),
-        # Some special registers last
-        rtgtest.RegS0Attr.get(),
-        rtgtest.RegRaAttr.get(),
-        rtgtest.RegSpAttr.get(),
-    ])
+    return rtg.VirtualRegisterOp(
+        rtg.VirtualRegisterConfigAttr.get([
+            # Choose temporaries with highest priority
+            rtgtest.RegT0Attr.get(),
+            rtgtest.RegT1Attr.get(),
+            rtgtest.RegT2Attr.get(),
+            rtgtest.RegT3Attr.get(),
+            rtgtest.RegT4Attr.get(),
+            rtgtest.RegT5Attr.get(),
+            rtgtest.RegT6Attr.get(),
+            # Function arguments in reverse order
+            rtgtest.RegA7Attr.get(),
+            rtgtest.RegA6Attr.get(),
+            rtgtest.RegA5Attr.get(),
+            rtgtest.RegA4Attr.get(),
+            rtgtest.RegA3Attr.get(),
+            rtgtest.RegA2Attr.get(),
+            rtgtest.RegA1Attr.get(),
+            rtgtest.RegA0Attr.get(),
+            # Callee saved temporaries
+            rtgtest.RegS1Attr.get(),
+            rtgtest.RegS2Attr.get(),
+            rtgtest.RegS3Attr.get(),
+            rtgtest.RegS4Attr.get(),
+            rtgtest.RegS5Attr.get(),
+            rtgtest.RegS6Attr.get(),
+            rtgtest.RegS7Attr.get(),
+            rtgtest.RegS8Attr.get(),
+            rtgtest.RegS9Attr.get(),
+            rtgtest.RegS10Attr.get(),
+            rtgtest.RegS11Attr.get(),
+            # Some special registers last
+            rtgtest.RegS0Attr.get(),
+            rtgtest.RegRaAttr.get(),
+            rtgtest.RegSpAttr.get(),
+        ]))
 
   def zero() -> IntegerRegister:
     return rtg.FixedRegisterOp(rtgtest.RegZeroAttr.get())

--- a/include/circt-c/Dialect/RTG.h
+++ b/include/circt-c/Dialect/RTG.h
@@ -185,6 +185,23 @@ MLIR_CAPI_EXPORTED bool rtgAttrIsAAnyContextAttr(MlirAttribute attr);
 MLIR_CAPI_EXPORTED MlirAttribute rtgAnyContextAttrGet(MlirContext ctxt,
                                                       MlirType type);
 
+/// Checks if the attribute is an RTG virtual register config attribute.
+MLIR_CAPI_EXPORTED bool rtgAttrIsAVirtualRegisterConfig(MlirAttribute attr);
+
+/// Creates an RTG virtual register config attribute in the context.
+MLIR_CAPI_EXPORTED MlirAttribute rtgVirtualRegisterConfigAttrGet(
+    MlirContext ctxt, intptr_t numRegs, MlirAttribute const *allowedRegs);
+
+/// Returns the number of allowed registers in the RTG virtual register config
+/// attribute.
+MLIR_CAPI_EXPORTED intptr_t
+rtgVirtualRegisterConfigAttrGetNumRegisters(MlirAttribute attr);
+
+/// Returns the allowed register at the given index in the RTG virtual register
+/// config attribute.
+MLIR_CAPI_EXPORTED MlirAttribute
+rtgVirtualRegisterConfigAttrGetRegister(MlirAttribute attr, intptr_t index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/circt/Dialect/RTG/IR/RTGAttributes.h
+++ b/include/circt/Dialect/RTG/IR/RTGAttributes.h
@@ -10,6 +10,7 @@
 #define CIRCT_DIALECT_RTG_IR_RTGATTRIBUTES_H
 
 #include "circt/Dialect/RTG/IR/RTGAttrInterfaces.h"
+#include "circt/Dialect/RTG/IR/RTGISAAssemblyAttrInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGTypes.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"

--- a/include/circt/Dialect/RTG/IR/RTGAttributes.td
+++ b/include/circt/Dialect/RTG/IR/RTGAttributes.td
@@ -73,4 +73,18 @@ def ImmediateAttr : RTGISAAttrDef<"Immediate", [
   let genStorageClass = false;
 }
 
+def VirtualRegisterConfigAttr : RTGISAAttrDef<"VirtualRegisterConfig", [
+  DeclareAttrInterfaceMethods<TypedAttrInterface>,
+]> {
+  let summary = "an allowed register configuration for a virtual register";
+
+  let parameters = (ins ArrayRefParameter<"rtg::RegisterAttrInterface",
+                                          "allowed registers">:$allowedRegs);
+
+  let mnemonic = "virtual_register_config";
+  let assemblyFormat = "`[` $allowedRegs `]`";
+
+  let genVerifyDecl = true;
+}
+
 #endif // CIRCT_DIALECT_RTG_IR_RTGATTRIBUTES_TD

--- a/include/circt/Dialect/RTG/IR/RTGOps.h
+++ b/include/circt/Dialect/RTG/IR/RTGOps.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/Emit/EmitOpInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGAttrInterfaces.h"
+#include "circt/Dialect/RTG/IR/RTGAttributes.h"
 #include "circt/Dialect/RTG/IR/RTGDialect.h"
 #include "circt/Dialect/RTG/IR/RTGISAAssemblyAttrInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGISAAssemblyTypeInterfaces.h"

--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -19,6 +19,7 @@ include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "circt/Dialect/RTG/IR/RTGAttributes.td"
 include "circt/Dialect/RTG/IR/RTGInterfaces.td"
 include "circt/Dialect/RTG/IR/RTGISAAssemblyInterfaces.td"
 include "circt/Dialect/Emit/EmitOpInterfaces.td"
@@ -683,11 +684,10 @@ def VirtualRegisterOp : RTGOp<"virtual_reg", [
   }];
 
   // ArrayAttr of RegisterAttrInterfaces
-  let arguments = (ins ArrayAttr:$allowedRegs);
+  let arguments = (ins VirtualRegisterConfigAttr:$allowedRegs);
   let results = (outs RegisterTypeInterface:$result);
 
   let assemblyFormat = "$allowedRegs attr-dict";
-  let hasVerifier = 1;
 }
 
 //===- Test Specification Operations --------------------------------------===//

--- a/include/circt/Dialect/RTGTest/IR/RTGTestAttributes.td
+++ b/include/circt/Dialect/RTGTest/IR/RTGTestAttributes.td
@@ -89,4 +89,26 @@ def RegT4Attr   : IntegerRegisterAttrBase<"RegT4", "t4", 29>;
 def RegT5Attr   : IntegerRegisterAttrBase<"RegT5", "t5", 30>;
 def RegT6Attr   : IntegerRegisterAttrBase<"RegT6", "t6", 31>;
 
+class FloatRegisterAttrBase<string cppName, string name, int classIndex>
+  : RTGTestAttrDef<cppName, [RegisterAttrInterface]> {
+
+  let mnemonic = name;
+
+  let extraClassDeclaration = [{
+    unsigned getClassIndex() const {
+      return }] # classIndex # [{;
+    }
+
+    llvm::StringLiteral getRegisterAssembly() const {
+      return "}] # name # [{";
+    }
+
+    Type getType() const {
+      return FloatRegisterType::get(getContext());
+    }
+  }];
+}
+
+def RegF0Attr   : FloatRegisterAttrBase<"RegF0", "f0", 0>;
+
 #endif // CIRCT_DIALECT_RTGTEST_IR_RTGTESTATTRIBUTES_TD

--- a/include/circt/Dialect/RTGTest/IR/RTGTestTypes.td
+++ b/include/circt/Dialect/RTGTest/IR/RTGTestTypes.td
@@ -44,6 +44,15 @@ def IntegerRegisterType : TypeDef<RTGTestDialect, "IntegerRegister", [
   let assemblyFormat = "";
 }
 
-def RegisterType : AnyTypeOf<[IntegerRegisterType]>;
+def FloatRegisterType : TypeDef<RTGTestDialect, "FloatRegister", [
+  RegisterTypeInterface,
+]> {
+  let summary = "represents a floating-point register";
+
+  let mnemonic = "freg";
+  let assemblyFormat = "";
+}
+
+def RegisterType : AnyTypeOf<[IntegerRegisterType, FloatRegisterType]>;
 
 #endif // CIRCT_DIALECT_RTGTEST_IR_RTGTESTTYPES_TD

--- a/lib/Bindings/Python/RTGModule.cpp
+++ b/lib/Bindings/Python/RTGModule.cpp
@@ -227,4 +227,24 @@ void circt::python::populateDialectRTGSubmodule(nb::module_ &m) {
       .def_property_readonly("value", [](MlirAttribute self) {
         return rtgImmediateAttrGetValue(self);
       });
+
+  mlir_attribute_subclass(m, "VirtualRegisterConfigAttr",
+                          rtgAttrIsAVirtualRegisterConfig)
+      .def_classmethod(
+          "get",
+          [](nb::object cls, const std::vector<MlirAttribute> &allowedRegs,
+             MlirContext ctxt) {
+            return cls(rtgVirtualRegisterConfigAttrGet(ctxt, allowedRegs.size(),
+                                                       allowedRegs.data()));
+          },
+          nb::arg("self"), nb::arg("allowed_regs"), nb::arg("ctxt") = nullptr)
+      .def_property_readonly("regs", [](MlirAttribute self) {
+        std::vector<MlirAttribute> regs;
+        for (unsigned
+                 i = 0,
+                 numRegs = rtgVirtualRegisterConfigAttrGetNumRegisters(self);
+             i < numRegs; ++i)
+          regs.push_back(rtgVirtualRegisterConfigAttrGetRegister(self, i));
+        return regs;
+      });
 }

--- a/lib/CAPI/Dialect/RTG.cpp
+++ b/lib/CAPI/Dialect/RTG.cpp
@@ -282,6 +282,33 @@ MlirAttribute rtgAnyContextAttrGet(MlirContext ctxt, MlirType type) {
   return wrap(AnyContextAttr::get(unwrap(ctxt), unwrap(type)));
 }
 
+// VirtualRegConfigAttr
+//===----------------------------------------------------------------------===//
+
+bool rtgAttrIsAVirtualRegisterConfig(MlirAttribute attr) {
+  return isa<VirtualRegisterConfigAttr>(unwrap(attr));
+}
+
+MlirAttribute
+rtgVirtualRegisterConfigAttrGet(MlirContext ctxt, intptr_t numRegs,
+                                MlirAttribute const *allowedRegs) {
+  SmallVector<rtg::RegisterAttrInterface> regs;
+  for (intptr_t i = 0; i < numRegs; ++i)
+    regs.push_back(cast<rtg::RegisterAttrInterface>(unwrap(allowedRegs[i])));
+  return wrap(VirtualRegisterConfigAttr::get(unwrap(ctxt), regs));
+}
+
+intptr_t rtgVirtualRegisterConfigAttrGetNumRegisters(MlirAttribute attr) {
+  return cast<VirtualRegisterConfigAttr>(unwrap(attr)).getAllowedRegs().size();
+}
+
+MlirAttribute rtgVirtualRegisterConfigAttrGetRegister(MlirAttribute attr,
+                                                      intptr_t index) {
+  auto allowedRegs =
+      cast<VirtualRegisterConfigAttr>(unwrap(attr)).getAllowedRegs();
+  return wrap(allowedRegs[index]);
+}
+
 //===----------------------------------------------------------------------===//
 // Passes
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/RTG/IR/RTGAttributes.cpp
+++ b/lib/Dialect/RTG/IR/RTGAttributes.cpp
@@ -105,6 +105,25 @@ void ImmediateAttr::print(AsmPrinter &odsPrinter) const {
   odsPrinter << "<" << getValue().getBitWidth() << ", " << getValue() << ">";
 }
 
+Type VirtualRegisterConfigAttr::getType() const {
+  return getAllowedRegs()[0].getType();
+}
+
+LogicalResult VirtualRegisterConfigAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+    ArrayRef<rtg::RegisterAttrInterface> allowedRegs) {
+  if (allowedRegs.empty())
+    return emitError() << "must have at least one allowed register";
+
+  if (!llvm::all_of(allowedRegs, [&](auto reg) {
+        return reg.getType() == allowedRegs[0].getType();
+      })) {
+    return emitError() << "all allowed registers must be of the same type";
+  }
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/RTG/IR/RTGOps.cpp
+++ b/lib/Dialect/RTG/IR/RTGOps.cpp
@@ -436,44 +436,12 @@ OpFoldResult FixedRegisterOp::fold(FoldAdaptor adaptor) { return getRegAttr(); }
 // VirtualRegisterOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult VirtualRegisterOp::verify() {
-  if (getAllowedRegs().empty())
-    return emitOpError("must have at least one allowed register");
-
-  if (llvm::any_of(getAllowedRegs(), [](Attribute attr) {
-        return !isa<RegisterAttrInterface>(attr);
-      }))
-    return emitOpError("all elements must be of RegisterAttrInterface");
-
-  if (!llvm::all_equal(
-          llvm::map_range(getAllowedRegs().getAsRange<RegisterAttrInterface>(),
-                          [](auto attr) { return attr.getType(); })))
-    return emitOpError("all allowed registers must be of the same type");
-
-  return success();
-}
-
 LogicalResult VirtualRegisterOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   auto allowedRegs = properties.as<Properties *>()->getAllowedRegs();
-  if (allowedRegs.empty()) {
-    if (loc)
-      return mlir::emitError(*loc, "must have at least one allowed register");
-
-    return failure();
-  }
-
-  auto regAttr = dyn_cast<RegisterAttrInterface>(allowedRegs[0]);
-  if (!regAttr) {
-    if (loc)
-      return mlir::emitError(
-          *loc, "allowed register attributes must be of RegisterAttrInterface");
-
-    return failure();
-  }
-  inferredReturnTypes.push_back(regAttr.getType());
+  inferredReturnTypes.push_back(allowedRegs.getType());
   return success();
 }
 

--- a/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
@@ -427,7 +427,7 @@ struct IdentityValue {
 
 /// Represents a unique virtual register.
 struct VirtualRegisterStorage : IdentityValue {
-  VirtualRegisterStorage(ArrayAttr allowedRegs, Type type)
+  VirtualRegisterStorage(VirtualRegisterConfigAttr allowedRegs, Type type)
       : IdentityValue(type), allowedRegs(allowedRegs) {}
 
   // NOTE: we don't need an 'isEqual' function and 'hashcode' here because
@@ -435,7 +435,7 @@ struct VirtualRegisterStorage : IdentityValue {
 
   // The list of fixed registers allowed to be selected for this virtual
   // register.
-  const ArrayAttr allowedRegs;
+  const VirtualRegisterConfigAttr allowedRegs;
 };
 
 struct UniqueLabelStorage : IdentityValue {

--- a/lib/Dialect/RTG/Transforms/LinearScanRegisterAllocationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/LinearScanRegisterAllocationPass.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/RTG/IR/RTGAttributes.h"
 #include "circt/Dialect/RTG/IR/RTGISAAssemblyOpInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGOps.h"
 #include "circt/Dialect/RTG/Transforms/RTGPasses.h"
@@ -137,8 +138,10 @@ void LinearScanRegisterAllocationPass::runOnOperation() {
       continue;
 
     // Handle virtual registers.
+    auto configAttr =
+        cast<rtg::VirtualRegisterConfigAttr>(lr->regOp.getAllowedRegsAttr());
     rtg::RegisterAttrInterface availableReg;
-    for (auto reg : lr->regOp.getAllowedRegs()) {
+    for (auto reg : configAttr.getAllowedRegs()) {
       if (llvm::none_of(active, [&](auto *r) { return r->fixedReg == reg; })) {
         availableReg = cast<rtg::RegisterAttrInterface>(reg);
         break;

--- a/test/Dialect/RTGTest/IR/basic.mlir
+++ b/test/Dialect/RTGTest/IR/basic.mlir
@@ -197,13 +197,22 @@ rtg.test @instructions(imm = %imm: !rtg.isa.immediate<12>, imm13 = %imm13: !rtg.
 // -----
 
 rtg.test @emptyAllowed() {
-  // expected-error @below {{must have at least one allowed register}}
-  rtg.virtual_reg []
+  // expected-error @below {{expected attribute value}}
+  // expected-error @below {{failed to parse VirtualRegisterConfigAttr parameter 'allowedRegs' which is to be a `::llvm::ArrayRef<rtg::RegisterAttrInterface>`}}
+  rtg.virtual_reg #rtg.virtual_register_config[]
 }
 
 // -----
 
 rtg.test @invalidAllowedAttr() {
-  // expected-error @below {{allowed register attributes must be of RegisterAttrInterface}}
-  rtg.virtual_reg ["invalid"]
+  // expected-error @below {{invalid kind of attribute specified}}
+  // expected-error @below {{failed to parse VirtualRegisterConfigAttr parameter 'allowedRegs' which is to be a `::llvm::ArrayRef<rtg::RegisterAttrInterface>`}}
+  rtg.virtual_reg #rtg.virtual_register_config["invalid"]
+}
+
+// -----
+
+rtg.test @invalidAllowedAttr() {
+  // expected-error @below {{all allowed registers must be of the same type}}
+  rtg.virtual_reg #rtg.virtual_register_config[#rtgtest.a0, #rtgtest.f0]
 }

--- a/unittests/Dialect/RTG/AttrTests.cpp
+++ b/unittests/Dialect/RTG/AttrTests.cpp
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGAttributes.h"
+#include "circt/Dialect/RTG/IR/RTGDialect.h"
+#include "circt/Dialect/RTGTest/IR/RTGTestAttributes.h"
+#include "circt/Dialect/RTGTest/IR/RTGTestDialect.h"
+#include "mlir/IR/Builders.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace rtg;
+using namespace rtgtest;
+
+namespace {
+
+// Helper class to capture diagnostic messages
+class DiagnosticCapture {
+public:
+  DiagnosticCapture(MLIRContext *context) : context(context) {
+    handler =
+        context->getDiagEngine().registerHandler([this](Diagnostic &diag) {
+          messages.push_back(diag.str());
+          return success();
+        });
+  }
+
+  ~DiagnosticCapture() { context->getDiagEngine().eraseHandler(handler); }
+
+  const SmallVector<std::string> &getMessages() const { return messages; }
+
+  void clear() { messages.clear(); }
+
+private:
+  MLIRContext *context;
+  DiagnosticEngine::HandlerID handler;
+  SmallVector<std::string> messages;
+};
+
+TEST(VirtualRegisterConfigAttrTests, EmptyAllowedRegs) {
+  MLIRContext context;
+  context.loadDialect<RTGDialect>();
+  context.loadDialect<RTGTestDialect>();
+
+  DiagnosticCapture capture(&context);
+
+  VirtualRegisterConfigAttr::getChecked(
+      [&]() { return emitError(UnknownLoc::get(&context)); }, &context, {});
+
+  EXPECT_EQ(capture.getMessages().size(), 1UL);
+  EXPECT_STREQ(capture.getMessages()[0].c_str(),
+               "must have at least one allowed register");
+}
+
+TEST(VirtualRegisterConfigAttrTests, SameTypeAllowedRegs) {
+  MLIRContext context;
+  context.loadDialect<RTGDialect>();
+  context.loadDialect<RTGTestDialect>();
+
+  DiagnosticCapture capture(&context);
+
+  auto regA0 = RegA0Attr::get(&context);
+  auto regF0 = RegF0Attr::get(&context);
+
+  VirtualRegisterConfigAttr::getChecked(
+      [&]() { return emitError(UnknownLoc::get(&context)); }, &context,
+      {regA0, regF0});
+
+  EXPECT_EQ(capture.getMessages().size(), 1UL);
+  EXPECT_STREQ(capture.getMessages()[0].c_str(),
+               "all allowed registers must be of the same type");
+}
+
+} // namespace

--- a/unittests/Dialect/RTG/CMakeLists.txt
+++ b/unittests/Dialect/RTG/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_unittest(CIRCTRTGTests
+  AttrTests.cpp
   MaterializerTest.cpp
   OpTests.cpp
 )
@@ -6,5 +7,6 @@ add_circt_unittest(CIRCTRTGTests
 target_link_libraries(CIRCTRTGTests
   PRIVATE
   CIRCTRTGDialect
+  CIRCTRTGTestDialect
   MLIRIR
 )


### PR DESCRIPTION
This moves verifier code from the `rtg.virtual_reg` op to this new attribute. As a result, it is only run during attribute creation and internalization whereas now it is run for every virtual register op after every single pass. So, this can speed up compilation significantly if there are a lot of virtual registers. In the future we could cache this attribute in PyRTG (since the same selection of registers are used for most virtual regs) to avoid unnecessary attribute internalizations and thus speed things up further.