### PR TITLE
[ESI] Various tweaks to cosim scripts

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/simulator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/simulator.py
@@ -119,7 +119,8 @@ class Simulator:
                run_stderr_callback: Optional[Callable[[str], None]] = None,
                compile_stdout_callback: Optional[Callable[[str], None]] = None,
                compile_stderr_callback: Optional[Callable[[str], None]] = None,
-               make_default_logs: bool = True):
+               make_default_logs: bool = True,
+               macro_definitions: Optional[Dict[str, str]] = None):
     """Simulator base class.
 
     Optional sinks can be provided for capturing output. If not provided,
@@ -135,10 +136,13 @@ class Simulator:
       compile_stderr_callback: Line-based callback for compile stderr.
       make_default_logs: If True and corresponding callback is not supplied,
         create log file and emit via internally-created callback.
+      macro_definitions: Optional dictionary of macro definitions to be defined
+        during compilation.
     """
     self.sources = sources
     self.run_dir = run_dir
     self.debug = debug
+    self.macro_definitions = macro_definitions
 
     # Unified list of any log file handles we opened.
     self._default_files: List[IO[str]] = []

--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
@@ -4,7 +4,7 @@
 
 import os
 from pathlib import Path
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Dict
 
 from .simulator import CosimCollateralDir, Simulator, SourceFiles
 
@@ -14,23 +14,29 @@ class Verilator(Simulator):
 
   DefaultDriver = CosimCollateralDir / "driver.cpp"
 
-  def __init__(self,
-               sources: SourceFiles,
-               run_dir: Path,
-               debug: bool,
-               run_stdout_callback: Optional[Callable[[str], None]] = None,
-               run_stderr_callback: Optional[Callable[[str], None]] = None,
-               compile_stdout_callback: Optional[Callable[[str], None]] = None,
-               compile_stderr_callback: Optional[Callable[[str], None]] = None,
-               make_default_logs: bool = True):
-    super().__init__(sources=sources,
-                     run_dir=run_dir,
-                     debug=debug,
-                     run_stdout_callback=run_stdout_callback,
-                     run_stderr_callback=run_stderr_callback,
-                     compile_stdout_callback=compile_stdout_callback,
-                     compile_stderr_callback=compile_stderr_callback,
-                     make_default_logs=make_default_logs)
+  def __init__(
+      self,
+      sources: SourceFiles,
+      run_dir: Path,
+      debug: bool,
+      run_stdout_callback: Optional[Callable[[str], None]] = None,
+      run_stderr_callback: Optional[Callable[[str], None]] = None,
+      compile_stdout_callback: Optional[Callable[[str], None]] = None,
+      compile_stderr_callback: Optional[Callable[[str], None]] = None,
+      make_default_logs: bool = True,
+      macro_definitions: Optional[Dict[str, str]] = None,
+  ):
+    super().__init__(
+        sources=sources,
+        run_dir=run_dir,
+        debug=debug,
+        run_stdout_callback=run_stdout_callback,
+        run_stderr_callback=run_stderr_callback,
+        compile_stdout_callback=compile_stdout_callback,
+        compile_stderr_callback=compile_stderr_callback,
+        make_default_logs=make_default_logs,
+        macro_definitions=macro_definitions,
+    )
     self.verilator = "verilator"
     if "VERILATOR_PATH" in os.environ:
       self.verilator = os.environ["VERILATOR_PATH"]
@@ -39,6 +45,15 @@ class Verilator(Simulator):
     cmd: List[str] = [
         self.verilator,
         "--cc",
+    ]
+
+    if self.macro_definitions:
+      cmd += [
+          f"+define+{k}={v}" if v is not None else f"+define+{k}"
+          for k, v in self.macro_definitions.items()
+      ]
+
+    cmd += [
         "--top-module",
         self.sources.top,
         "-DSIMULATION",


### PR DESCRIPTION
A collection of small tweaks to the cosim scripts:

- Make questa write a waveform if `debug` is enabled for the `Simulator`
- Allow for providing a list of error codes for Questa to suppress during compilation
- Allow for providing a dictionary of macro definitions that the simulator(s) should include when compiling the simulation.