### PR TITLE
[Comb] Fix mux canonicalizers for non-signless-ints

### DIFF
--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1950,3 +1950,10 @@ func.func @AndMaskToConcat(%arg0: i10, %arg1: i10, %arg2: i20) {
   call @use_i10(%f2) : (i10) -> ()
   return
 }
+
+hw.module @issue9403(in %sel: i1, out out1: ui1) {
+  %true = hwarith.constant 1 : ui1
+  %false = hwarith.constant 0 : ui1
+  %mux1 = comb.mux %sel, %true, %false : ui1
+  hw.output %mux1 : ui1
+}


### PR DESCRIPTION
A few of the mux canonicalizers assumed signless integers, which is not always the case. Detect when this is not the case and disable those canonicalizations.

Fixes #9043.