### PR TITLE
[circt-lsp-server] Only enable unit tests if feature is enabled

### DIFF
--- a/unittests/Tools/CMakeLists.txt
+++ b/unittests/Tools/CMakeLists.txt
@@ -1,1 +1,3 @@
-add_subdirectory(circt-verilog-lsp-server)
+if(CIRCT_SLANG_FRONTEND_ENABLED)
+  add_subdirectory(circt-verilog-lsp-server)
+endif()


### PR DESCRIPTION
Without this check, the unit tests will be compiled even if the feature is off, and the compilation will fail because the library `CIRCTVerilogLspServerUtils` will be missing.