### PR TITLE
[MooreToCore] Support slicing of nested arrays

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -746,7 +746,8 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
       int32_t width = llvm::Log2_64_Ceil(arrTy.getNumElements());
       int32_t inputWidth = arrTy.getNumElements();
 
-      if (auto resArrTy = dyn_cast<hw::ArrayType>(resultType)) {
+      if (auto resArrTy = dyn_cast<hw::ArrayType>(resultType);
+          resArrTy && resArrTy != arrTy.getElementType()) {
         int32_t elementWidth = hw::getBitWidth(arrTy.getElementType());
         if (elementWidth < 0)
           return failure();

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1283,3 +1283,12 @@ func.func @SeverityToPrint() {
 func.func @CHandle(%arg0: !moore.chandle) {
     return
 }
+
+// CHECK-LABEL: @MultiDimensionalSlice
+moore.module @MultiDimensionalSlice(in %in : !moore.array<2 x array<2 x l2>>, out out : !moore.array<2 x l2>) {
+  // CHECK-NEXT: [[IDX:%.*]] = hw.constant false
+  // CHECK-NEXT: [[V:%.*]] = hw.array_get %in[[[IDX]]]
+  // CHECK-NEXT: hw.output [[V]] : !hw.array<2xi2>
+  %0 = moore.extract %in from 0 : array<2 x array<2 x l2>> -> array<2 x l2>
+  moore.output %0 : !moore.array<2 x l2>
+}


### PR DESCRIPTION
Added a testcase that is the result of parsing the following sv code:

```sv
module bug (
  input logic [1:0][1:0][1:0] in,
  output logic [1:0] out
);
assign out = in[0][0][1:0];

endmodule
```

The current MooreToCore pass translates the sv ode incorrectly to
```
hw.module @bug(in %in : !hw.array<2xarray<2xi2>>, out out : i2) {
  %false = hw.constant false
  %0 = builtin.unrealized_conversion_cast %in : !hw.array<2xarray<2xi2>> to !hw.array<2xi2>
  %1 = hw.array_get %0[%false] : !hw.array<2xi2>, i1
  hw.output %1 : i2
}
```

Adding a check if operand and result array have the same level of nesting in the ExtractOpConversion fixes the bug.