### PR TITLE
[ImportVerilog][MooreToCore] Re-land Implement CHandle import and low…

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -494,6 +494,7 @@ def ConvertMooreToCore : Pass<"convert-moore-to-core", "mlir::ModuleOp"> {
     "mlir::cf::ControlFlowDialect",
     "mlir::scf::SCFDialect",
     "mlir::math::MathDialect",
+    "mlir::LLVM::LLVMDialect",
     "sim::SimDialect",
     "verif::VerifDialect",
   ];

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -162,6 +162,10 @@ struct TypeVisitor {
     return moore::StringType::get(context.getContext());
   }
 
+  Type visit(const slang::ast::CHandleType &type) {
+    return moore::ChandleType::get(context.getContext());
+  }
+
   /// Emit an error for all other types.
   template <typename T>
   Type visit(T &&node) {

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -21,6 +21,8 @@
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinDialect.h"
@@ -30,6 +32,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/IR/DerivedTypes.h"
 
 namespace circt {
 #define GEN_PASS_DEF_CONVERTMOORETOCORE
@@ -539,6 +542,18 @@ struct VariableOpConversion : public OpConversionPattern<VariableOp> {
     Type resultType = typeConverter->convertType(op.getResult().getType());
     if (!resultType)
       return rewriter.notifyMatchFailure(op.getLoc(), "invalid variable type");
+
+    // Handle CHandle types
+    if (isa<mlir::LLVM::LLVMPointerType>(resultType)) {
+      // Use converted initializer if present; otherwise synthesize null ptr.
+      Value init = adaptor.getInitial();
+      if (!init)
+        init = rewriter.create<mlir::LLVM::ZeroOp>(loc, resultType);
+
+      // For pointer-typed variables we produce the SSA pointer value directly.
+      rewriter.replaceOp(op, init);
+      return success();
+    }
 
     // Determine the initial value of the signal.
     Value init = adaptor.getInitial();
@@ -1712,6 +1727,7 @@ static void populateLegality(ConversionTarget &target,
   target.addLegalDialect<mlir::BuiltinDialect>();
   target.addLegalDialect<mlir::math::MathDialect>();
   target.addLegalDialect<sim::SimDialect>();
+  target.addLegalDialect<mlir::LLVM::LLVMDialect>();
   target.addLegalDialect<verif::VerifDialect>();
 
   target.addLegalOp<debug::ScopeOp>();
@@ -1798,10 +1814,28 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
         return hw::StructType::get(type.getContext(), fields);
       });
 
+  // Conversion of CHandle to LLVMPointerType
+  typeConverter.addConversion([&](ChandleType type) -> std::optional<Type> {
+    return LLVM::LLVMPointerType::get(type.getContext());
+  });
+
+  // Explicitly mark LLVMPointerType as a legal target
+  typeConverter.addConversion(
+      [](LLVM::LLVMPointerType t) -> std::optional<Type> { return t; });
+
   typeConverter.addConversion([&](RefType type) -> std::optional<Type> {
-    if (auto innerType = typeConverter.convertType(type.getNestedType()))
+    if (auto innerType = typeConverter.convertType(type.getNestedType())) {
       if (hw::isHWValueType(innerType))
         return hw::InOutType::get(innerType);
+      // TODO: There is some abstraction missing here to correctly return a
+      // reference of a CHandle; return an error for now.
+      if (isa<mlir::LLVM::LLVMPointerType>(innerType)) {
+        mlir::emitError(mlir::UnknownLoc::get(type.getContext()))
+            << "Emission of references of LLVMPointerType is currently "
+               "unsupported!";
+        return {};
+      }
+    }
     return {};
   });
 

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -153,3 +153,13 @@ module String;
   // CHECK-NEXT: %s = moore.variable : <string>
   string s;
 endmodule
+
+// CHECK-LABEL: moore.module @CHandle
+module CHandle;
+   // CHECK: %test = moore.variable : <chandle>
+   chandle test;
+endmodule
+
+// CHECK-LABEL: func.func private @takesCHandle(%arg0: !moore.chandle) {
+function automatic void takesCHandle(chandle test);
+endfunction

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1279,3 +1279,7 @@ func.func @SeverityToPrint() {
   return
 }
 
+// CHECK-LABEL: func.func @CHandle(%arg0: !llvm.ptr)
+func.func @CHandle(%arg0: !moore.chandle) {
+    return
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(circt-opt
   MLIRFuncInlinerExtension
   MLIRVectorDialect
   MLIRIndexDialect
+  MLIRLLVMIRTransforms
 )
 
 export_executable_symbols_for_plugins(circt-opt)

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -64,6 +65,7 @@ int main(int argc, char **argv) {
   circt::registerAllPasses();
 
   mlir::func::registerInlinerExtension(registry);
+  mlir::LLVM::registerInlinerInterface(registry);
 
   // Register the standard passes we want.
   mlir::registerCSEPass();

--- a/tools/circt-verilog/CMakeLists.txt
+++ b/tools/circt-verilog/CMakeLists.txt
@@ -22,6 +22,7 @@ set(libs
   MLIRSCFDialect
   MLIRSCFDialect
   MLIRSupport
+  MLIRLLVMIRTransforms
 )
 
 add_circt_tool(circt-verilog circt-verilog.cpp DEPENDS ${libs})

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -32,6 +32,8 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -611,12 +613,15 @@ int main(int argc, char **argv) {
     moore::MooreDialect,
     scf::SCFDialect,
     seq::SeqDialect,
-    verif::VerifDialect
+    verif::VerifDialect,
+    mlir::LLVM::LLVMDialect
   >();
   // clang-format on
 
   // Perform the actual work and use "exit" to avoid slow context teardown.
   mlir::func::registerInlinerExtension(registry);
+  mlir::LLVM::registerInlinerInterface(registry);
+
   MLIRContext context(registry);
   exit(failed(execute(&context)));
 }


### PR DESCRIPTION
Re-lands #9077 which was reverted because it was unsquashed.

Add end-to-end support for SystemVerilog `chandle`:
- Import from Slang as `moore.chandle`.
- Lower to `!llvm.ptr` in MooreToCore.
- Treat `ref<chandle>` as a *by-ref SSA* value (no `hw.inout`).
- Default-initialize to `llvm.mlir.zero : !llvm.ptr`.
