### PR TITLE
[LLHD] Add new RefType to replace hw::InOutType

### DIFF
--- a/include/circt-c/Dialect/LLHD.h
+++ b/include/circt-c/Dialect/LLHD.h
@@ -27,9 +27,16 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(LLHD, llhd);
 
 /// Check if a type is a time type.
 MLIR_CAPI_EXPORTED bool llhdTypeIsATimeType(MlirType);
+/// Check if a type is a reference type.
+MLIR_CAPI_EXPORTED bool llhdTypeIsARefType(MlirType);
 
 /// Create a time type.
 MLIR_CAPI_EXPORTED MlirType llhdTimeTypeGet(MlirContext ctx);
+/// Create a reference type.
+MLIR_CAPI_EXPORTED MlirType llhdRefTypeGet(MlirType element);
+
+/// Get the inner type of a reference.
+MLIR_CAPI_EXPORTED MlirType llhdRefTypeGetNestedType(MlirType);
 
 //===----------------------------------------------------------------------===//
 // Attributes

--- a/include/circt/Dialect/LLHD/IR/LLHDExtractOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDExtractOps.td
@@ -27,7 +27,7 @@ class SigPtrIndexBitWidthConstraint<string index, string input>
 class SigArrayElementTypeConstraint<string result, string input>
   : TypesMatchWith<"result must be a signal of the array element type",
                    input, result,
-                   "hw::InOutType::get(llhd::getLLHDElementType($_self))">;
+                   "RefType::get(llhd::getLLHDElementType($_self))">;
 
 class SameSigPtrArrayElementTypeConstraint<string result, string input>
   : PredOpTrait<"arrays element type must match",
@@ -44,11 +44,11 @@ class SmallerOrEqualResultTypeWidthConstraint<string result, string input>
 // Integer Operations
 //===----------------------------------------------------------------------===//
 
-def SigExtractOp : LLHDOp<"sig.extract",
-    [Pure,
-     SmallerOrEqualResultTypeWidthConstraint<"result", "input">,
-     SigPtrIndexBitWidthConstraint<"lowBit", "input">]> {
-
+def SigExtractOp : LLHDOp<"sig.extract", [
+  Pure,
+   SmallerOrEqualResultTypeWidthConstraint<"result", "input">,
+   SigPtrIndexBitWidthConstraint<"lowBit", "input">,
+ ]> {
   let summary = "Extract a range of bits from an integer signal";
   let description = [{
     The `llhd.sig.extract` operation allows to access a range of bits
@@ -56,12 +56,12 @@ def SigExtractOp : LLHDOp<"sig.extract",
     operand. The result length is defined by the result type.
   }];
 
-  let arguments = (ins InOutTypeOf<[HWIntegerType]>:$input,
+  let arguments = (ins RefTypeOf<HWIntegerType>:$input,
                        HWIntegerType:$lowBit);
-  let results = (outs InOutTypeOf<[HWIntegerType]>: $result);
+  let results = (outs RefTypeOf<HWIntegerType>: $result);
 
   let assemblyFormat = [{
-    $input `from` $lowBit attr-dict `:` functional-type($input, $result)
+    $input `from` $lowBit attr-dict `:` type($input) `->` type($result)
   }];
 
   let extraClassDeclaration = [{
@@ -75,12 +75,12 @@ def SigExtractOp : LLHDOp<"sig.extract",
 // Array Operations
 //===----------------------------------------------------------------------===//
 
-def SigArraySliceOp : LLHDOp<"sig.array_slice",
-    [Pure,
-     SmallerOrEqualResultTypeWidthConstraint<"result", "input">,
-     SameSigPtrArrayElementTypeConstraint<"result", "input">,
-     SigPtrIndexBitWidthConstraint<"lowIndex", "input">]> {
-
+def SigArraySliceOp : LLHDOp<"sig.array_slice", [
+  Pure,
+  SmallerOrEqualResultTypeWidthConstraint<"result", "input">,
+  SameSigPtrArrayElementTypeConstraint<"result", "input">,
+  SigPtrIndexBitWidthConstraint<"lowIndex", "input">,
+]> {
   let summary = "Get a range of consecutive values from a signal of an array";
   let description = [{
     The `llhd.sig.array_slice` operation allows to access a sub-range of the
@@ -98,41 +98,47 @@ def SigArraySliceOp : LLHDOp<"sig.array_slice",
 
     ```mlir
     %3 = llhd.sig.array_slice %input at %lowIndex :
-      (!hw.inout<array<4xi8>>) -> !hw.inout<array<2xi8>>
+      (!llhd.ref<!hw.array<4xi8>>) -> !llhd.ref<!hw.array<2xi8>>
     ```
   }];
 
-  let arguments = (ins InOutTypeOf<[ArrayType]>: $input,
+  let arguments = (ins RefTypeOf<ArrayType>: $input,
                        HWIntegerType: $lowIndex);
-  let results = (outs InOutTypeOf<[ArrayType]>: $result);
+  let results = (outs RefTypeOf<ArrayType>: $result);
 
   let assemblyFormat = [{
-    $input `at` $lowIndex attr-dict `:` functional-type($input, $result)
+    $input `at` $lowIndex attr-dict `:` type($input) `->` type($result)
   }];
 
   let extraClassDeclaration = [{
-    unsigned getResultWidth()  { return getLLHDTypeWidth(getResult().getType()); }
-    unsigned getInputWidth() { return getLLHDTypeWidth(getInput().getType()); }
+    unsigned getResultWidth() {
+      return getLLHDTypeWidth(getResult().getType());
+    }
+    unsigned getInputWidth() {
+      return getLLHDTypeWidth(getInput().getType());
+    }
     hw::ArrayType getInputArrayType() {
-      return llvm::cast<hw::ArrayType>(llvm::cast<hw::InOutType>(
-        getInput().getType()).getElementType());
+      return cast<hw::ArrayType>(
+        cast<RefType>(getInput().getType()).getNestedType()
+      );
     }
     hw::ArrayType getResultArrayType() {
-      return llvm::cast<hw::ArrayType>(llvm::cast<hw::InOutType>(
-        getResult().getType()).getElementType());
+      return cast<hw::ArrayType>(
+        cast<RefType>(getResult().getType()).getNestedType()
+      );
     }
   }];
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
 }
 
-def SigArrayGetOp : LLHDOp<"sig.array_get",
-    [Pure,
-     DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
-     DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
-     SigPtrIndexBitWidthConstraint<"index", "input">,
-     SigArrayElementTypeConstraint<"result", "input">]> {
-
+def SigArrayGetOp : LLHDOp<"sig.array_get", [
+  Pure,
+  DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+  DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
+  SigPtrIndexBitWidthConstraint<"index", "input">,
+  SigArrayElementTypeConstraint<"result", "input">,
+]> {
   let summary = "Extract an element from a signal of an array.";
   let description = [{
     The `llhd.sig.array_get` operation allows to access the element of the
@@ -142,20 +148,23 @@ def SigArrayGetOp : LLHDOp<"sig.array_get",
     Example:
 
     ```mlir
-    // Returns a !hw.inout<i8>
-    %0 = llhd.sig.array_get %arr[%index] : !hw.inout<array<4xi8>>
+    // Returns a !llhd.ref<i8>
+    %0 = llhd.sig.array_get %arr[%index] : !llhd.ref<!hw.array<4xi8>>
     ```
   }];
 
-  let arguments = (ins InOutTypeOf<[ArrayType]>:$input, HWIntegerType:$index);
-  let results = (outs InOutTypeOf<[HWNonInOutType]>: $result);
+  let arguments = (ins RefTypeOf<ArrayType>:$input, HWIntegerType:$index);
+  let results = (outs RefType: $result);
 
-  let assemblyFormat = "$input `[` $index `]` attr-dict `:` qualified(type($input))";
+  let assemblyFormat = [{
+    $input `[` $index `]` attr-dict `:` type($input)
+  }];
 
   let extraClassDeclaration = [{
     hw::ArrayType getArrayType() {
-      return llvm::cast<hw::ArrayType>(llvm::cast<hw::InOutType>(
-        getInput().getType()).getElementType());
+      return cast<hw::ArrayType>(
+        cast<RefType>(getInput().getType()).getNestedType()
+      );
     }
   }];
 }
@@ -164,10 +173,13 @@ def SigArrayGetOp : LLHDOp<"sig.array_get",
 // Structure Operations
 //===----------------------------------------------------------------------===//
 
-def SigStructExtractOp : LLHDOp<"sig.struct_extract", [Pure,
+def SigStructExtractOp : LLHDOp<"sig.struct_extract", [
+  Pure,
   DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
   DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
-  DeclareOpInterfaceMethods<InferTypeOpInterface>, InferTypeOpInterface]> {
+  DeclareOpInterfaceMethods<InferTypeOpInterface>,
+  InferTypeOpInterface,
+]> {
   let summary = "Extract a field from a signal of a struct.";
   let description = [{
     The `llhd.sig.struct_extract` operation allows access to the field of the
@@ -177,21 +189,24 @@ def SigStructExtractOp : LLHDOp<"sig.struct_extract", [Pure,
     Example:
 
     ```mlir
-    // Returns a !hw.inout<i8>
+    // Returns a !llhd.ref<i8>
     %0 = llhd.sig.struct_extract %struct["foo"]
-      : !hw.inout<struct<foo: i8, bar: i16>>
+      : !llhd.ref<!hw.struct<foo: i8, bar: i16>>
     ```
   }];
 
-  let arguments = (ins InOutTypeOf<[StructType]>:$input, StrAttr:$field);
-  let results = (outs InOutTypeOf<[HWNonInOutType]>:$result);
+  let arguments = (ins RefTypeOf<StructType>:$input, StrAttr:$field);
+  let results = (outs RefTypeOf<AnyType>:$result);
 
-  let assemblyFormat = "$input `[` $field `]` attr-dict `:` qualified(type($input))";
+  let assemblyFormat = [{
+    $input `[` $field `]` attr-dict `:` type($input)
+  }];
 
   let extraClassDeclaration = [{
     hw::StructType getStructType() {
-      return llvm::cast<hw::StructType>(llvm::cast<hw::InOutType>(
-        getInput().getType()).getElementType());
+      return cast<hw::StructType>(
+        cast<RefType>(getInput().getType()).getNestedType()
+      );
     }
   }];
 }

--- a/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
@@ -19,9 +19,7 @@ include "mlir/IR/OpAsmInterface.td"
 def SignalOp : LLHDOp<"sig", [
   DeclareOpInterfaceMethods<DestructurableAllocationOpInterface>,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  TypesMatchWith<
-    "type of 'init' and underlying type of 'signal' have to match.",
-    "init", "result", "hw::InOutType::get($_self)">
+  TypeMatchesRefNestedType<"init", "result">,
 ]> {
   let summary = "Create a signal.";
   let description = [{
@@ -43,23 +41,22 @@ def SignalOp : LLHDOp<"sig", [
   }];
   let arguments = (ins
     OptionalAttr<StrAttr>:$name,
-    HWValueType:$init
+    AnyType:$init
   );
-  let results = (outs Res<InOutType, "", [MemAlloc]>:$result);
+  let results = (outs Res<RefType, "", [MemAlloc]>:$result);
   let assemblyFormat = [{
     `` custom<ImplicitSSAName>($name) $init attr-dict
     `:` type($init)
   }];
 }
 
-def PrbOp : LLHDOp<"prb", [
-    DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
-    DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
-    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-    TypesMatchWith<
-      "type of 'result' and underlying type of 'signal' have to match.",
-      "signal", "result", "llvm::cast<hw::InOutType>($_self).getElementType()">
-  ]> {
+def ProbeOp : LLHDOp<"prb", [
+  DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+  DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  TypeMatchesRefNestedType<"result", "signal">,
+  RefNestedTypeMatchesType<"signal", "result">,
+]> {
   let summary = "Probe a signal.";
   let description = [{
     This operation probes a signal and returns the value it
@@ -73,21 +70,19 @@ def PrbOp : LLHDOp<"prb", [
     ```mlir
     %true = hw.constant true
     %sig_i1 = llhd.sig %true : i1
-    %prbd = llhd.prb %sig_i1 : !hw.inout<i1>
+    %prbd = llhd.prb %sig_i1 : i1
     ```
   }];
 
-  let arguments = (ins InOutType:$signal);
-  let results = (outs HWValueType:$result);
+  let arguments = (ins RefType:$signal);
+  let results = (outs AnyType:$result);
 
-  let assemblyFormat = "$signal attr-dict `:` qualified(type($signal))";
+  let assemblyFormat = "$signal attr-dict `:` type($result)";
 }
 
 def OutputOp : LLHDOp<"output", [
-    TypesMatchWith<
-      "type of 'value' and underlying type of 'result' have to match.",
-      "value", "result", "hw::InOutType::get($_self)">
-  ]> {
+  TypeMatchesRefNestedType<"value", "result">,
+]> {
   let summary = "Introduce a new signal and drive a value onto it.";
   let description = [{
     The `llhd.output` operation introduces a new signal and continuously
@@ -108,28 +103,26 @@ def OutputOp : LLHDOp<"output", [
     %value = hw.constant true
     %time = llhd.constant_time <1ns, 0d, 0e>
     %sig = llhd.sig "sigName" %value : i1
-    llhd.drv %sig, %value after %time : !hw.inout<i1>
+    llhd.drv %sig, %value after %time : i1
     ```
   }];
 
   let arguments = (ins OptionalAttr<StrAttr>: $name,
-                       HWValueType: $value,
+                       AnyType: $value,
                        LLHDTimeType: $time);
 
-  let results = (outs InOutType: $result);
+  let results = (outs RefType: $result);
 
   let assemblyFormat = [{
-    ( $name^ )? $value `after` $time attr-dict `:` qualified(type($value))
+    ( $name^ )? $value `after` $time attr-dict `:` type($value)
   }];
 }
 
-def DrvOp : LLHDOp<"drv", [
-    DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
-    DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
-    TypesMatchWith<
-      "type of 'value' and underlying type of 'signal' have to match.",
-      "signal", "value", "llvm::cast<hw::InOutType>($_self).getElementType()">
-  ]> {
+def DriveOp : LLHDOp<"drv", [
+  DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+  DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
+  TypeMatchesRefNestedType<"value", "signal">,
+]> {
   let summary = "Drive a value into a signal.";
   let description = [{
     The `llhd.drv` operation drives a new value onto a signal. A time
@@ -147,20 +140,20 @@ def DrvOp : LLHDOp<"drv", [
     %time = llhd.constant_time <1ns, 0d, 0e>
     %sig = llhd.sig %true : i1
 
-    llhd.drv %sig, %false after %time : !hw.inout<i1>
-    llhd.drv %sig, %false after %time if %true : !hw.inout<i1>
+    llhd.drv %sig, %false after %time : i1
+    llhd.drv %sig, %false after %time if %true : i1
     ```
   }];
 
-  let arguments = (ins Arg<InOutType, "the signal to drive to",
+  let arguments = (ins Arg<RefType, "the signal to drive to",
                            [MemWrite]>: $signal,
-                       HWValueType: $value,
+                       AnyType: $value,
                        LLHDTimeType: $time,
                        Optional<I1>: $enable);
 
   let assemblyFormat = [{
     $signal `,` $value `after` $time ( `if` $enable^ )? attr-dict `:`
-    qualified(type($signal))
+    type($value)
   }];
 
   let hasFolder = 1;

--- a/include/circt/Dialect/LLHD/IR/LLHDTypes.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDTypes.td
@@ -35,6 +35,46 @@ def LLHDTimeType : LLHDType<"Time"> {
   let mnemonic = "time";
 }
 
+def RefType : LLHDType<"Ref"> {
+  let summary = "a reference to a signal or variable";
+  let description = [{
+    Represents a reference to a value. Signals return a reference to the
+    underlying value, which allows them to be probed or driven.
+  }];
+  let mnemonic = "ref";
+  let parameters = (ins "Type":$nestedType);
+  let assemblyFormat = "`<` $nestedType `>`";
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "Type":$nestedType), [{
+      return $_get(nestedType.getContext(), nestedType);
+    }]>
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// Type Constraints
+//===----------------------------------------------------------------------===//
+
+
+/// A ref type with a specific nested type.
+class RefTypeOf<Type type> : ConfinedType<RefType,
+  [SubstLeaves<"$_self", "cast<llhd::RefType>($_self).getNestedType()",
+               type.predicate>],
+  "ref of " # type.summary, "llhd::RefType"
+> {
+  Type nestedType = type;
+}
+
+class TypeMatchesRefNestedType<string type, string refType> : TypesMatchWith<
+  type # " type must match " # refType # " ref element type",
+  type, refType, "RefType::get($_self)"
+>;
+
+class RefNestedTypeMatchesType<string refType, string type> : TypesMatchWith<
+  refType # " ref element type must match " # type # " type",
+  refType, type, "cast<RefType>($_self).getNestedType()"
+>;
+
 //===----------------------------------------------------------------------===//
 // Attribute declarations
 //===----------------------------------------------------------------------===//

--- a/lib/CAPI/Dialect/LLHD.cpp
+++ b/lib/CAPI/Dialect/LLHD.cpp
@@ -29,9 +29,22 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(LLHD, llhd, circt::llhd::LLHDDialect)
 /// Check if a type is a time type.
 bool llhdTypeIsATimeType(MlirType type) { return isa<TimeType>(unwrap(type)); }
 
+/// Check if a type is a reference type.
+bool llhdTypeIsARefType(MlirType type) { return isa<RefType>(unwrap(type)); }
+
 /// Create a time type.
 MlirType llhdTimeTypeGet(MlirContext ctx) {
   return wrap(TimeType::get(unwrap(ctx)));
+}
+
+/// Create a reference type.
+MlirType llhdRefTypeGet(MlirType element) {
+  return wrap(RefType::get(unwrap(element)));
+}
+
+/// Get the inner type of a reference.
+MlirType llhdRefTypeGetNestedType(MlirType type) {
+  return wrap(cast<RefType>(unwrap(type)).getNestedType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -235,7 +235,7 @@ bool Deseq::analyzeProcess() {
   // Ensure that all process results lead to conditional drive operations.
   SmallPtrSet<Operation *, 8> seenDrives;
   for (auto &use : process->getUses()) {
-    auto driveOp = dyn_cast<DrvOp>(use.getOwner());
+    auto driveOp = dyn_cast<DriveOp>(use.getOwner());
     if (!driveOp) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Skipping " << process.getLoc() << ": feeds non-drive "

--- a/lib/Dialect/LLHD/Transforms/DeseqUtils.h
+++ b/lib/Dialect/LLHD/Transforms/DeseqUtils.h
@@ -215,7 +215,7 @@ struct ClockInfo {
 /// multiple clocks or resets are skipped.
 struct DriveInfo {
   /// The drive operation.
-  DrvOp op;
+  DriveOp op;
   /// The clock that triggers a change to the driven value. Guaranteed to be
   /// non-null.
   ClockInfo clock;
@@ -224,7 +224,7 @@ struct DriveInfo {
   ResetInfo reset;
 
   DriveInfo() {}
-  explicit DriveInfo(DrvOp op) : op(op) {}
+  explicit DriveInfo(DriveOp op) : op(op) {}
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
+++ b/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
@@ -50,7 +50,7 @@ struct ProbeHoister {
   DenseSet<Value> liveAcrossWait;
 
   /// A lookup table of probes we have already hoisted, for deduplication.
-  DenseMap<Value, PrbOp> hoistedProbes;
+  DenseMap<Value, ProbeOp> hoistedProbes;
 };
 } // namespace
 
@@ -120,10 +120,10 @@ void ProbeHoister::findValuesLiveAcrossWait(Liveness &liveness) {
 void ProbeHoister::hoistProbes() {
   auto findExistingProbe = [&](Value signal) {
     for (auto *user : signal.getUsers())
-      if (auto probeOp = dyn_cast<PrbOp>(user))
+      if (auto probeOp = dyn_cast<ProbeOp>(user))
         if (probeOp->getParentRegion()->isProperAncestor(&region))
           return probeOp;
-    return PrbOp{};
+    return ProbeOp{};
   };
 
   for (auto &block : region) {
@@ -135,7 +135,7 @@ void ProbeHoister::hoistProbes() {
       continue;
 
     for (auto &op : llvm::make_early_inc_range(block)) {
-      auto probeOp = dyn_cast<PrbOp>(op);
+      auto probeOp = dyn_cast<ProbeOp>(op);
 
       // We can only hoist probes that have no side-effecting ops between
       // themselves and the beginning of a block. If we see a side-effecting op,
@@ -308,7 +308,7 @@ void DriveHoister::hoist() {
 /// cannot reason about.
 void DriveHoister::findHoistableSlots() {
   SmallPtrSet<Value, 8> seenSlots;
-  processOp.walk([&](DrvOp op) {
+  processOp.walk([&](DriveOp op) {
     auto slot = op.getSignal();
     if (!seenSlots.insert(slot).second)
       return;
@@ -325,7 +325,7 @@ void DriveHoister::findHoistableSlots() {
           // Ignore uses outside of the region.
           if (!processOp.getBody().isAncestor(user->getParentRegion()))
             return true;
-          return isa<PrbOp, DrvOp>(user);
+          return isa<ProbeOp, DriveOp>(user);
         }))
       return;
 
@@ -353,7 +353,7 @@ void DriveHoister::collectDriveSets() {
     SmallPtrSet<Value, 8> drivenSlots;
     for (auto &op : llvm::make_early_inc_range(
              llvm::reverse(block.without_terminator()))) {
-      auto driveOp = dyn_cast<DrvOp>(op);
+      auto driveOp = dyn_cast<DriveOp>(op);
 
       // We can only hoist drives that have no side-effecting ops between
       // themselves and the terminator of the block. If we see a side-effecting
@@ -405,8 +405,7 @@ void DriveHoister::finalizeDriveSets() {
     // terminator.
     for (auto *suspendOp : suspendOps) {
       auto operands = DriveOperands{
-          DriveValue::dontCare(
-              cast<hw::InOutType>(slot.getType()).getElementType()),
+          DriveValue::dontCare(cast<RefType>(slot.getType()).getNestedType()),
           DriveValue::dontCare(TimeType::get(processOp.getContext())),
           DriveValue(falseAttr),
       };
@@ -589,12 +588,12 @@ void DriveHoister::hoistDrives() {
                       ? useResultValue(driveSet.uniform.enable)
                       : Value{};
     [[maybe_unused]] auto newDrive =
-        DrvOp::create(builder, slot.getLoc(), slot, value, delay, enable);
+        DriveOp::create(builder, slot.getLoc(), slot, value, delay, enable);
     LLVM_DEBUG(llvm::dbgs() << "- Add " << newDrive << "\n");
 
     // Remove the old drives inside of the process.
     for (auto *oldOp : driveSet.ops) {
-      auto oldDrive = cast<DrvOp>(oldOp);
+      auto oldDrive = cast<DriveOp>(oldOp);
       LLVM_DEBUG(llvm::dbgs() << "- Remove " << oldDrive << "\n");
       auto delay = oldDrive.getTime();
       auto enable = oldDrive.getEnable();

--- a/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
+++ b/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
@@ -186,7 +186,7 @@ void Lowering::markObservedValues() {
 
     // Look through probe ops to mark the probe signal as well, just in case
     // there may be multiple probes of the same signal.
-    if (auto probeOp = dyn_cast<PrbOp>(op))
+    if (auto probeOp = dyn_cast<ProbeOp>(op))
       markObserved(probeOp.getSignal());
 
     // Look through operations that simply reshape incoming values into an
@@ -266,7 +266,7 @@ bool Lowering::isObserved(Value value) {
     for (auto operand : op->getOperands()) {
       if (observedValues.contains(operand))
         continue;
-      if (isa<hw::InOutType>(operand.getType()))
+      if (isa<RefType>(operand.getType()))
         return false;
       auto *defOp = operand.getDefiningOp();
       if (!defOp || !isMemoryEffectFree(defOp))

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -167,13 +167,13 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   moore.extract %arg5 from 6 : !moore.array<5 x i32> -> i32
 
   // CHECK-NEXT: [[V0:%.+]] = hw.constant 0 : i0
-  // CHECK-NEXT: llhd.sig.extract %arg6 from [[V0]] : (!hw.inout<i1>) -> !hw.inout<i1>
+  // CHECK-NEXT: llhd.sig.extract %arg6 from [[V0]] : <i1> -> <i1>
   moore.extract_ref %arg6 from 0 : !moore.ref<!moore.i1> -> !moore.ref<!moore.i1>
   // CHECK-NEXT: [[V0:%.+]] = hw.constant 2 : i3
-  // CHECK-NEXT: llhd.sig.array_slice %arg7 at [[V0]] : (!hw.inout<array<5xi32>>) -> !hw.inout<array<2xi32>>
+  // CHECK-NEXT: llhd.sig.array_slice %arg7 at [[V0]] : <!hw.array<5xi32>> -> <!hw.array<2xi32>>
   moore.extract_ref %arg7 from 2 : !moore.ref<!moore.array<5 x i32>> -> !moore.ref<!moore.array<2 x i32>>
   // CHECK-NEXT: [[V0:%.+]] = hw.constant 2 : i3
-  // CHECK-NEXT: llhd.sig.array_get %arg7[[[V0]]] : !hw.inout<array<5xi32>>
+  // CHECK-NEXT: llhd.sig.array_get %arg7[[[V0]]] : <!hw.array<5xi32>>
   moore.extract_ref %arg7 from 2 : !moore.ref<!moore.array<5 x i32>> -> !moore.ref<i32>
 
   // CHECK-NEXT: [[V21:%.+]] = comb.extract %c2_i32 from 6 : (i32) -> i26
@@ -208,7 +208,7 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: [[V23:%.+]] = comb.extract %c0_i32 from 0 : (i32) -> i0
   // CHECK-NEXT: [[MAX:%.+]] = hw.constant 0 : i0
   // CHECK-NEXT: [[V24:%.+]] = comb.mux [[V22]], [[V23]], [[MAX]] : i0
-  // CHECK-NEXT: llhd.sig.extract %arg6 from [[V24]] : (!hw.inout<i1>) -> !hw.inout<i1>
+  // CHECK-NEXT: llhd.sig.extract %arg6 from [[V24]] : <i1> -> <i1>
   moore.dyn_extract_ref %arg6 from %c0 : !moore.ref<!moore.i1>, !moore.i32 -> !moore.ref<!moore.i1>
   // CHECK-NEXT: [[V21:%.+]] = comb.extract %c2_i32 from 3 : (i32) -> i29
   // CHECK-NEXT: [[CONST_0:%.+]] = hw.constant 0 : i29
@@ -216,7 +216,7 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: [[V23:%.+]] = comb.extract %c2_i32 from 0 : (i32) -> i3
   // CHECK-NEXT: [[MAX:%.+]] = hw.constant -1 : i3
   // CHECK-NEXT: [[V24:%.+]] = comb.mux [[V22]], [[V23]], [[MAX]] : i3
-  // CHECK-NEXT: llhd.sig.array_slice %arg7 at [[V24]] : (!hw.inout<array<5xi32>>) -> !hw.inout<array<2xi32>>
+  // CHECK-NEXT: llhd.sig.array_slice %arg7 at [[V24]] : <!hw.array<5xi32>> -> <!hw.array<2xi32>>
   moore.dyn_extract_ref %arg7 from %2 : !moore.ref<!moore.array<5 x i32>>, !moore.i32 -> !moore.ref<!moore.array<2 x i32>>
   // CHECK-NEXT: [[V21:%.+]] = comb.extract %c2_i32 from 3 : (i32) -> i29
   // CHECK-NEXT: [[CONST_0:%.+]] = hw.constant 0 : i29
@@ -224,7 +224,7 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: [[V23:%.+]] = comb.extract %c2_i32 from 0 : (i32) -> i3
   // CHECK-NEXT: [[MAX:%.+]] = hw.constant -1 : i3
   // CHECK-NEXT: [[V24:%.+]] = comb.mux [[V22]], [[V23]], [[MAX]] : i3
-  // CHECK-NEXT: llhd.sig.array_get %arg7[[[V24]]] : !hw.inout<array<5xi32>>
+  // CHECK-NEXT: llhd.sig.array_get %arg7[[[V24]]] : <!hw.array<5xi32>>
   moore.dyn_extract_ref %arg7 from %2 : !moore.ref<!moore.array<5 x i32>>, !moore.i32 -> !moore.ref<!moore.i32>
 
   // CHECK-NEXT: [[V26:%.+]] = hw.constant -1 : i6
@@ -362,10 +362,10 @@ func.func @Statements(%arg0: !moore.i42) {
   // CHECK: %x = llhd.sig
   %x = moore.variable : <i42>
   // CHECK: [[TMP:%.+]] = llhd.constant_time <0ns, 0d, 1e>
-  // CHECK: llhd.drv %x, %arg0 after [[TMP]] : !hw.inout<i42>
+  // CHECK: llhd.drv %x, %arg0 after [[TMP]] : i42
   moore.blocking_assign %x, %arg0 : i42
   // CHECK: [[TMP:%.+]] = llhd.constant_time <0ns, 1d, 0e>
-  // CHECK: llhd.drv %x, %arg0 after [[TMP]] : !hw.inout<i42>
+  // CHECK: llhd.drv %x, %arg0 after [[TMP]] : i42
   moore.nonblocking_assign %x, %arg0 : i42
   // CHECK-NEXT: return
   return
@@ -462,7 +462,7 @@ moore.module @Variable() {
   // CHECK: %b1 = llhd.sig [[TMP1]] : i8
   %b1 = moore.variable : <i8>
 
-  // CHECK: [[PRB:%.+]] = llhd.prb %b1 : !hw.inout<i8>
+  // CHECK: [[PRB:%.+]] = llhd.prb %b1 : i8
   %0 = moore.read %b1 : <i8>
   // CHECK: %b2 = llhd.sig [[PRB]] : i8
   %b2 = moore.variable %0 : <i8>
@@ -479,8 +479,21 @@ moore.module @Variable() {
   %3 = moore.constant 10 : i32
   
   // CHECK: [[TIME:%.+]] = llhd.constant_time <0ns, 0d, 1e>
-  // CHECK: llhd.drv %a, [[TMP2]] after [[TIME]] : !hw.inout<i32>
+  // CHECK: llhd.drv %a, [[TMP2]] after [[TIME]] : i32
   moore.assign %a, %3 : i32
+
+  // CHECK: [[TMP:%.+]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: llhd.sig [[TMP]] : !llvm.ptr
+  moore.variable : <!moore.chandle>
+
+  // CHECK: [[TMP:%.+]] = llhd.constant_time <0
+  // CHECK: llhd.sig [[TMP]] : !llhd.time
+  moore.variable : <!moore.time>
+
+  // CHECK: [[TMP:%.+]] = llhd.constant_time
+  // CHECK: llhd.sig [[TMP]] : !llhd.time
+  %c42_fs = moore.constant_time 42 fs
+  moore.variable %c42_fs : <!moore.time>
 
   // CHECK: hw.output
   moore.output
@@ -492,19 +505,19 @@ moore.module @Net() {
   // CHECK: %a = llhd.sig [[TMP]] : i32
   %a = moore.net wire : <i32>
 
-  // CHECK: [[PRB:%.+]] = llhd.prb %a : !hw.inout<i32>
+  // CHECK: [[PRB:%.+]] = llhd.prb %a : i32
   %0 = moore.read %a : <i32>
 
   // CHECK: [[TMP:%.+]] = hw.constant 0 : i32
   // CHECK: %b = llhd.sig [[TMP]] : i32
   // CHECK: [[TIME:%.+]] = llhd.constant_time <0ns, 0d, 1e>
-  // CHECK: llhd.drv %b, [[PRB]] after [[TIME]] : !hw.inout<i32>
+  // CHECK: llhd.drv %b, [[PRB]] after [[TIME]] : i32
   %b = moore.net wire %0 : <i32>
 
   // CHECK: [[TMP:%.+]] = hw.constant 10 : i32
   %3 = moore.constant 10 : i32
   // CHECK: [[TIME:%.+]] = llhd.constant_time <0ns, 0d, 1e>
-  // CHECK: llhd.drv %a, [[TMP]] after [[TIME]] : !hw.inout<i32>
+  // CHECK: llhd.drv %a, [[TMP]] after [[TIME]] : i32
   moore.assign %a, %3 : i32
 }
 
@@ -523,7 +536,7 @@ moore.module @UnpackedArray(in %arr : !moore.uarray<2 x i32>, in %sel : !moore.i
   %2 = moore.variable : <uarray<4 x i32>>
 
   // CHECK: [[C1:%.+]] = hw.constant 1 : i2
-  // CHECK: llhd.sig.array_get [[SIG_0]][[[C1]]] : !hw.inout<array<4xi32>>
+  // CHECK: llhd.sig.array_get [[SIG_0]][[[C1]]] : <!hw.array<4xi32>>
   %3 = moore.extract_ref %2 from 1 : !moore.ref<!moore.uarray<4 x i32>> -> !moore.ref<!moore.i32>
   moore.assign %3, %0 : i32
 
@@ -540,7 +553,7 @@ moore.module @Struct(in %a : !moore.i32, in %b : !moore.i32, in %arg0 : !moore.s
   // CHECK: hw.struct_extract %arg0["exp_bits"] : !hw.struct<exp_bits: i32, man_bits: i32>
   %0 = moore.struct_extract %arg0, "exp_bits" : !moore.struct<{exp_bits: i32, man_bits: i32}> -> i32
 
-  // CHECK: llhd.sig.struct_extract %arg1["exp_bits"] : !hw.inout<struct<exp_bits: i32, man_bits: i32>>
+  // CHECK: llhd.sig.struct_extract %arg1["exp_bits"] : <!hw.struct<exp_bits: i32, man_bits: i32>>
   %ref = moore.struct_extract_ref %arg1, "exp_bits" : <!moore.struct<{exp_bits: i32, man_bits: i32}>> -> <i32>
   moore.assign %ref, %0 : !moore.i32
   
@@ -600,18 +613,18 @@ moore.module @UnpackedStruct() {
     %2 = moore.struct_create %1, %0 : !moore.i32, !moore.i32 -> ustruct<{a: i32, b: i32}>
 
     // CHECK: %[[TIME_0:.*]] = llhd.constant_time <0ns, 0d, 1e>
-    // CHECK: llhd.drv %[[USTRUCT]], %[[STRUCT_0]] after %[[TIME_0]] : !hw.inout<struct<a: i32, b: i32>>
+    // CHECK: llhd.drv %[[USTRUCT]], %[[STRUCT_0]] after %[[TIME_0]] : !hw.struct<a: i32, b: i32>
     moore.blocking_assign %ms, %2 : ustruct<{a: i32, b: i32}>
 
     // CHECK: %[[STRUCT_1:.*]] = hw.struct_create (%[[C1_32]], %[[C1_32]]) : !hw.struct<a: i32, b: i32>
     %3 = moore.struct_create %0, %0 : !moore.i32, !moore.i32 -> ustruct<{a: i32, b: i32}>
 
     // CHECK: %[[TIME_1:.*]] = llhd.constant_time <0ns, 0d, 1e>
-    // CHECK: llhd.drv %[[USTRUCT]], %[[STRUCT_1]] after %[[TIME_1]] : !hw.inout<struct<a: i32, b: i32>>
+    // CHECK: llhd.drv %[[USTRUCT]], %[[STRUCT_1]] after %[[TIME_1]] : !hw.struct<a: i32, b: i32>
     moore.blocking_assign %ms, %3 : ustruct<{a: i32, b: i32}>
 
     // CHECK: %[[TIME_2:.*]] = llhd.constant_time <0ns, 0d, 1e>
-    // CHECK: llhd.drv %[[USTRUCT]], %[[STRUCT_1]] after %[[TIME_2]] : !hw.inout<struct<a: i32, b: i32>>
+    // CHECK: llhd.drv %[[USTRUCT]], %[[STRUCT_1]] after %[[TIME_2]] : !hw.struct<a: i32, b: i32>
     moore.blocking_assign %ms, %3 : ustruct<{a: i32, b: i32}>
 
     // CHECK: llhd.halt
@@ -994,7 +1007,7 @@ moore.module @EmptyWaitEvent(out out : !moore.l32) {
   // CHECK:   llhd.halt
   // CHECK: ^bb{{.*}} // no predecessors
   // CHECK: }
-  // CHECK: [[PRB:%.+]] = llhd.prb [[OUT]] : !hw.inout<i32>
+  // CHECK: [[PRB:%.+]] = llhd.prb [[OUT]] : i32
   // CHECK: hw.output [[PRB]] : i32
   %0 = moore.constant 0 : l32
   %out = moore.variable : <l32>
@@ -1208,7 +1221,7 @@ moore.module @scfInsideProcess(in %in0: !moore.i32, in %in1: !moore.i32) {
 // CHECK-LABEL: @blockArgAsObservedValue
 moore.module @blockArgAsObservedValue(in %in0: !moore.i32, in %in1: !moore.i32) {
   %var = moore.variable : <!moore.i32>
-  // CHECK: [[PRB:%.+]] = llhd.prb %var : !hw.inout<i32>
+  // CHECK: [[PRB:%.+]] = llhd.prb %var : i32
   // CHECK: llhd.process
   moore.procedure always_comb {
       %0 = moore.add %in0, %in1 : !moore.i32

--- a/test/Dialect/LLHD/Canonicalization/constant.mlir
+++ b/test/Dialect/LLHD/Canonicalization/constant.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt %s -canonicalize='top-down=true region-simplify=aggressive' | FileCheck %s
 
 // CHECK-LABEL: @const_hoisting
-// CHECK-SAME: %[[SIG:.*]]: !hw.inout<i32>
-func.func @const_hoisting(%sig : !hw.inout<i32>) {
+// CHECK-SAME: %[[SIG:.*]]: !llhd.ref<i32>
+func.func @const_hoisting(%sig : !llhd.ref<i32>) {
   // CHECK-DAG: %[[C0:.*]] = hw.constant -1 : i32
   // CHECK-DAG: %[[TIME:.*]] = llhd.constant_time <1ns, 0d, 0e>
   // CHECK-NEXT: cf.br ^[[BB:.*]]
@@ -11,7 +11,7 @@ func.func @const_hoisting(%sig : !hw.inout<i32>) {
 ^bb1:
   %0 = hw.constant -1 : i32
   %1 = llhd.constant_time <1ns, 0d, 0e>
-  // CHECK-NEXT: llhd.drv %[[SIG]], %[[C0]] after %[[TIME]] : !hw.inout<i32>
-  llhd.drv %sig, %0 after %1 : !hw.inout<i32>
+  // CHECK-NEXT: llhd.drv %[[SIG]], %[[C0]] after %[[TIME]] : i32
+  llhd.drv %sig, %0 after %1 : i32
   cf.br ^bb1
 }

--- a/test/Dialect/LLHD/Canonicalization/extract.mlir
+++ b/test/Dialect/LLHD/Canonicalization/extract.mlir
@@ -1,21 +1,20 @@
 // RUN: circt-opt %s -canonicalize='top-down=true region-simplify=aggressive' | FileCheck %s
 
 // CHECK-LABEL: @sigExtractOp
-func.func @sigExtractOp(%arg0 : !hw.inout<i32>, %arg1: i5) -> (!hw.inout<i32>, !hw.inout<i32>) {
+func.func @sigExtractOp(%arg0 : !llhd.ref<i32>, %arg1: i5) -> (!llhd.ref<i32>, !llhd.ref<i32>) {
   %zero = hw.constant 0 : i5
 
-  // CHECK: %[[EXT:.*]] = llhd.sig.extract %arg0 from %arg1 : (!hw.inout<i32>) -> !hw.inout<i32>
-  %0 = llhd.sig.extract %arg0 from %arg1 : (!hw.inout<i32>) -> !hw.inout<i32>
+  // CHECK: %[[EXT:.*]] = llhd.sig.extract %arg0 from %arg1 : <i32> -> <i32>
+  %0 = llhd.sig.extract %arg0 from %arg1 : <i32> -> <i32>
 
-  %1 = llhd.sig.extract %arg0 from %zero : (!hw.inout<i32>) -> !hw.inout<i32>
+  %1 = llhd.sig.extract %arg0 from %zero : <i32> -> <i32>
 
-  // CHECK-NEXT: return %[[EXT]], %arg0 : !hw.inout<i32>, !hw.inout<i32>
-  return %0, %1 : !hw.inout<i32>, !hw.inout<i32>
+  // CHECK-NEXT: return %[[EXT]], %arg0 : !llhd.ref<i32>, !llhd.ref<i32>
+  return %0, %1 : !llhd.ref<i32>, !llhd.ref<i32>
 }
 
 // CHECK-LABEL: @sigArraySlice
-func.func @sigArraySliceOp(%arg0: !hw.inout<array<30xi32>>, %arg1: i5)
-    -> (!hw.inout<array<30xi32>>, !hw.inout<array<30xi32>>, !hw.inout<array<20xi32>>, !hw.inout<array<3xi32>>) {
+func.func @sigArraySliceOp(%arg0: !llhd.ref<!hw.array<30xi32>>, %arg1: i5) -> (!llhd.ref<!hw.array<30xi32>>, !llhd.ref<!hw.array<30xi32>>, !llhd.ref<!hw.array<20xi32>>, !llhd.ref<!hw.array<3xi32>>) {
   %zero = hw.constant 0 : i5
 
   // CHECK-NEXT: %c-13_i5 = hw.constant -13 : i5
@@ -23,16 +22,16 @@ func.func @sigArraySliceOp(%arg0: !hw.inout<array<30xi32>>, %arg1: i5)
   %a = hw.constant 3 : i5
   %b = hw.constant 16 : i5
 
-  // CHECK: %[[EXT:.*]] = llhd.sig.array_slice %arg0 at %arg1 : (!hw.inout<array<30xi32>>) -> !hw.inout<array<30xi32>>
-  %ext = llhd.sig.array_slice %arg0 at %arg1 : (!hw.inout<array<30xi32>>) -> !hw.inout<array<30xi32>>
+  // CHECK: %[[EXT:.*]] = llhd.sig.array_slice %arg0 at %arg1 : <!hw.array<30xi32>> -> <!hw.array<30xi32>>
+  %ext = llhd.sig.array_slice %arg0 at %arg1 : <!hw.array<30xi32>> -> <!hw.array<30xi32>>
 
-  %identity = llhd.sig.array_slice %arg0 at %zero : (!hw.inout<array<30xi32>>) -> !hw.inout<array<30xi32>>
+  %identity = llhd.sig.array_slice %arg0 at %zero : <!hw.array<30xi32>> -> <!hw.array<30xi32>>
 
   // CHECK-NEXT: %[[RES1:.*]] = llhd.sig.array_slice
-  // CHECK-NEXT: %[[RES2:.*]] = llhd.sig.array_slice %arg0 at %c-13_i5 : (!hw.inout<array<30xi32>>) -> !hw.inout<array<3xi32>>
-  %1 = llhd.sig.array_slice %arg0 at %a : (!hw.inout<array<30xi32>>) -> !hw.inout<array<20xi32>>
-  %2 = llhd.sig.array_slice %1 at %b : (!hw.inout<array<20xi32>>) -> !hw.inout<array<3xi32>>
+  // CHECK-NEXT: %[[RES2:.*]] = llhd.sig.array_slice %arg0 at %c-13_i5 : <!hw.array<30xi32>> -> <!hw.array<3xi32>>
+  %1 = llhd.sig.array_slice %arg0 at %a : <!hw.array<30xi32>> -> <!hw.array<20xi32>>
+  %2 = llhd.sig.array_slice %1 at %b : <!hw.array<20xi32>> -> <!hw.array<3xi32>>
 
-  // CHECK-NEXT: return %[[EXT]], %arg0, %[[RES1]], %[[RES2]] : !hw.inout<array<30xi32>>, !hw.inout<array<30xi32>>, !hw.inout<array<20xi32>>, !hw.inout<array<3xi32>>
-  return %ext, %identity, %1, %2 : !hw.inout<array<30xi32>>, !hw.inout<array<30xi32>>, !hw.inout<array<20xi32>>, !hw.inout<array<3xi32>>
+  // CHECK-NEXT: return %[[EXT]], %arg0, %[[RES1]], %[[RES2]] : !llhd.ref<!hw.array<30xi32>>, !llhd.ref<!hw.array<30xi32>>, !llhd.ref<!hw.array<20xi32>>, !llhd.ref<!hw.array<3xi32>>
+  return %ext, %identity, %1, %2 : !llhd.ref<!hw.array<30xi32>>, !llhd.ref<!hw.array<30xi32>>, !llhd.ref<!hw.array<20xi32>>, !llhd.ref<!hw.array<3xi32>>
 }

--- a/test/Dialect/LLHD/Canonicalization/probeCSE.mlir
+++ b/test/Dialect/LLHD/Canonicalization/probeCSE.mlir
@@ -1,43 +1,43 @@
 // RUN: circt-opt %s -cse | FileCheck %s
 
 // CHECK-LABEL: @checkPrbDceAndCseIn
-hw.module @checkPrbDceAndCseIn(inout %arg0 : i32, inout %arg1 : i32, inout %arg2 : i32) {
+hw.module @checkPrbDceAndCseIn(in %arg0: !llhd.ref<i32>, in %arg1: !llhd.ref<i32>, in %arg2: !llhd.ref<i32>) {
   // CHECK-NEXT: llhd.constant_time
   %time = llhd.constant_time <0ns, 1d, 0e>
 
   // CHECK-NEXT: [[P0:%.*]] = llhd.prb
-  %1 = llhd.prb %arg0 : !hw.inout<i32>
-  %2 = llhd.prb %arg0 : !hw.inout<i32>
-  %3 = llhd.prb %arg0 : !hw.inout<i32>
+  %1 = llhd.prb %arg0 : i32
+  %2 = llhd.prb %arg0 : i32
+  %3 = llhd.prb %arg0 : i32
 
   // CHECK-NEXT: llhd.drv %arg1, [[P0]]
   // CHECK-NEXT: llhd.drv %arg2, [[P0]]
-  llhd.drv %arg1, %1 after %time : !hw.inout<i32>
-  llhd.drv %arg2, %2 after %time : !hw.inout<i32>
+  llhd.drv %arg1, %1 after %time : i32
+  llhd.drv %arg2, %2 after %time : i32
 }
 
 // CHECK-LABEL: @checkPrbDceButNotCse
-hw.module @checkPrbDceButNotCse(inout %arg0 : i32, inout %arg1 : i32, inout %arg2 : i32) {
-  %prb = llhd.prb %arg0 : !hw.inout<i32>
+hw.module @checkPrbDceButNotCse(in %arg0: !llhd.ref<i32>, in %arg1: !llhd.ref<i32>, in %arg2: !llhd.ref<i32>) {
+  %prb = llhd.prb %arg0 : i32
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: llhd.constant_time
     %time = llhd.constant_time <0ns, 1d, 0e>
 
     // CHECK-NEXT: [[P1:%.*]] = llhd.prb
-    %1 = llhd.prb %arg0 : !hw.inout<i32>
+    %1 = llhd.prb %arg0 : i32
     // CHECK-NEXT: llhd.wait
     llhd.wait (%prb: i32), ^bb1
   // CHECK-NEXT: ^bb1:
   ^bb1:
     // CHECK-NEXT: [[P2:%.*]] = llhd.prb
-    %2 = llhd.prb %arg0 : !hw.inout<i32>
-    %3 = llhd.prb %arg0 : !hw.inout<i32>
+    %2 = llhd.prb %arg0 : i32
+    %3 = llhd.prb %arg0 : i32
 
     // CHECK-NEXT: llhd.drv %arg1, [[P1]]
     // CHECK-NEXT: llhd.drv %arg2, [[P2]]
-    llhd.drv %arg1, %1 after %time : !hw.inout<i32>
-    llhd.drv %arg2, %2 after %time : !hw.inout<i32>
+    llhd.drv %arg1, %1 after %time : i32
+    llhd.drv %arg2, %2 after %time : i32
     llhd.halt
   }
   hw.output

--- a/test/Dialect/LLHD/Canonicalization/signalOps.mlir
+++ b/test/Dialect/LLHD/Canonicalization/signalOps.mlir
@@ -1,21 +1,21 @@
 // RUN: circt-opt %s -canonicalize='top-down=true region-simplify=aggressive' | FileCheck %s
 
 // CHECK-LABEL: @drv_folding
-// CHECK-SAME: %[[SIG:.*]]: !hw.inout<i32>
+// CHECK-SAME: %[[SIG:.*]]: !llhd.ref<i32>
 // CHECK-SAME: %[[VAL:.*]]: i32
 // CHECK-SAME: %[[TIME:.*]]: !llhd.time
 // CHECK-SAME: %[[COND:.*]]: i1
-func.func @drv_folding(%sig: !hw.inout<i32>, %val: i32, %time: !llhd.time, %cond: i1) {
+func.func @drv_folding(%sig: !llhd.ref<i32>, %val: i32, %time: !llhd.time, %cond: i1) {
   %true = hw.constant 1 : i1
   %false = hw.constant 0 : i1
 
   // CHECK-NEXT: llhd.drv %[[SIG]], %[[VAL]] after %[[TIME]] :
-  llhd.drv %sig, %val after %time : !hw.inout<i32>
+  llhd.drv %sig, %val after %time : i32
   // CHECK-NEXT: llhd.drv %[[SIG]], %[[VAL]] after %[[TIME]] if %[[COND]] :
-  llhd.drv %sig, %val after %time if %cond : !hw.inout<i32>
-  llhd.drv %sig, %val after %time if %false : !hw.inout<i32>
+  llhd.drv %sig, %val after %time if %cond : i32
+  llhd.drv %sig, %val after %time if %false : i32
   // CHECK-NEXT: llhd.drv %[[SIG]], %[[VAL]] after %[[TIME]] :
-  llhd.drv %sig, %val after %time if %true : !hw.inout<i32>
+  llhd.drv %sig, %val after %time if %true : i32
 
   // CHECK-NEXT: return
   return

--- a/test/Dialect/LLHD/IR/basic.mlir
+++ b/test/Dialect/LLHD/IR/basic.mlir
@@ -1,5 +1,12 @@
 // RUN: circt-opt --verify-roundtrip %s | FileCheck %s
 
+// CHECK: to !llhd.time
+builtin.unrealized_conversion_cast to !llhd.time
+// CHECK: to !llhd.ref<i42>
+builtin.unrealized_conversion_cast to !llhd.ref<i42>
+// CHECK: to !llhd.ref<!llhd.time>
+builtin.unrealized_conversion_cast to !llhd.ref<!llhd.time>
+
 // CHECK-LABEL: @basic
 // CHECK-SAME: (in [[IN0:%.+]] : i32, out out0 : i32)
 hw.module @basic(in %in0 : i32, out out0 : i32) {
@@ -9,25 +16,25 @@ hw.module @basic(in %in0 : i32, out out0 : i32) {
 }
 
 // CHECK-LABEL: @sigExtract
-hw.module @sigExtract(inout %arg0 : i32, in %arg1 : i5) {
-  // CHECK-NEXT: %{{.*}} = llhd.sig.extract %arg0 from %arg1 : (!hw.inout<i32>) -> !hw.inout<i5>
-  %1 = llhd.sig.extract %arg0 from %arg1 : (!hw.inout<i32>) -> !hw.inout<i5>
+hw.module @sigExtract(in %arg0 : !llhd.ref<i32>, in %arg1 : i5) {
+  // CHECK-NEXT: %{{.*}} = llhd.sig.extract %arg0 from %arg1 : <i32> -> <i5>
+  %1 = llhd.sig.extract %arg0 from %arg1 : <i32> -> <i5>
 }
 
 // CHECK-LABEL: @sigArray
-hw.module @sigArray(inout %arg0 : !hw.array<5xi1>, in %arg1 : i3) {
-  // CHECK-NEXT: %{{.*}} = llhd.sig.array_slice %arg0 at %arg1 : (!hw.inout<array<5xi1>>) -> !hw.inout<array<3xi1>>
-  %0 = llhd.sig.array_slice %arg0 at %arg1 : (!hw.inout<array<5xi1>>) -> !hw.inout<array<3xi1>>
-  // CHECK-NEXT: %{{.*}} = llhd.sig.array_get %arg0[%arg1] : !hw.inout<array<5xi1>>
-  %1 = llhd.sig.array_get %arg0[%arg1] : !hw.inout<array<5xi1>>
+hw.module @sigArray(in %arg0 : !llhd.ref<!hw.array<5xi1>>, in %arg1 : i3) {
+  // CHECK-NEXT: %{{.*}} = llhd.sig.array_slice %arg0 at %arg1 : <!hw.array<5xi1>> -> <!hw.array<3xi1>>
+  %0 = llhd.sig.array_slice %arg0 at %arg1 : <!hw.array<5xi1>> -> <!hw.array<3xi1>>
+  // CHECK-NEXT: %{{.*}} = llhd.sig.array_get %arg0[%arg1] : <!hw.array<5xi1>>
+  %1 = llhd.sig.array_get %arg0[%arg1] : <!hw.array<5xi1>>
 }
 
 // CHECK-LABEL: @sigStructExtract
-hw.module @sigStructExtract(inout %arg0 : !hw.struct<foo: i1, bar: i2, baz: i3>) {
-  // CHECK-NEXT: %{{.*}} = llhd.sig.struct_extract %arg0["foo"] : !hw.inout<struct<foo: i1, bar: i2, baz: i3>>
-  %0 = llhd.sig.struct_extract %arg0["foo"] : !hw.inout<struct<foo: i1, bar: i2, baz: i3>>
-  // CHECK-NEXT: %{{.*}} = llhd.sig.struct_extract %arg0["baz"] : !hw.inout<struct<foo: i1, bar: i2, baz: i3>>
-  %1 = llhd.sig.struct_extract %arg0["baz"] : !hw.inout<struct<foo: i1, bar: i2, baz: i3>>
+hw.module @sigStructExtract(in %arg0 : !llhd.ref<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
+  // CHECK-NEXT: %{{.*}} = llhd.sig.struct_extract %arg0["foo"] : <!hw.struct<foo: i1, bar: i2, baz: i3>>
+  %0 = llhd.sig.struct_extract %arg0["foo"] : <!hw.struct<foo: i1, bar: i2, baz: i3>>
+  // CHECK-NEXT: %{{.*}} = llhd.sig.struct_extract %arg0["baz"] : <!hw.struct<foo: i1, bar: i2, baz: i3>>
+  %1 = llhd.sig.struct_extract %arg0["baz"] : <!hw.struct<foo: i1, bar: i2, baz: i3>>
 }
 
 // CHECK-LABEL: @checkSigInst
@@ -53,15 +60,20 @@ hw.module @checkSigInst() {
 }
 
 // CHECK-LABEL: @checkPrb
-hw.module @checkPrb(inout %arg0 : i1, inout %arg1 : i64, inout %arg2 : !hw.array<3xi8>, inout %arg3 : !hw.struct<foo: i1, bar: i2, baz: i4>) {
-  // CHECK: %{{.*}} = llhd.prb %arg0 : !hw.inout<i1>
-  %0 = llhd.prb %arg0 : !hw.inout<i1>
-  // CHECK-NEXT: %{{.*}} = llhd.prb %arg1 : !hw.inout<i64>
-  %1 = llhd.prb %arg1 : !hw.inout<i64>
-  // CHECK-NEXT: %{{.*}} = llhd.prb %arg2 : !hw.inout<array<3xi8>>
-  %2 = llhd.prb %arg2 : !hw.inout<array<3xi8>>
-  // CHECK-NEXT: %{{.*}} = llhd.prb %arg3 : !hw.inout<struct<foo: i1, bar: i2, baz: i4>>
-  %3 = llhd.prb %arg3 : !hw.inout<struct<foo: i1, bar: i2, baz: i4>>
+hw.module @checkPrb(
+  in %arg0 : !llhd.ref<i1>,
+  in %arg1 : !llhd.ref<i64>,
+  in %arg2 : !llhd.ref<!hw.array<3xi8>>,
+  in %arg3 : !llhd.ref<!hw.struct<foo: i1, bar: i2, baz: i4>>
+) {
+  // CHECK: %{{.*}} = llhd.prb %arg0 : i1
+  %0 = llhd.prb %arg0 : i1
+  // CHECK-NEXT: %{{.*}} = llhd.prb %arg1 : i64
+  %1 = llhd.prb %arg1 : i64
+  // CHECK-NEXT: %{{.*}} = llhd.prb %arg2 : !hw.array<3xi8>
+  %2 = llhd.prb %arg2 : !hw.array<3xi8>
+  // CHECK-NEXT: %{{.*}} = llhd.prb %arg3 : !hw.struct<foo: i1, bar: i2, baz: i4>
+  %3 = llhd.prb %arg3 : !hw.struct<foo: i1, bar: i2, baz: i4>
 }
 
 // CHECK-LABEL: @checkOutput
@@ -74,26 +86,31 @@ hw.module @checkOutput(in %arg0 : i32) {
 }
 
 // CHECK-LABEL: @checkDrv
-hw.module @checkDrv(inout %arg0 : i1, inout %arg1 : i64, in %arg2 : i1,
-    in %arg3 : i64, inout %arg5 : !hw.array<3xi8>,
-    inout %arg6 : !hw.struct<foo: i1, bar: i2, baz: i4>,
-    in %arg7 : !hw.array<3xi8>, in %arg8 : !hw.struct<foo: i1, bar: i2, baz: i4>) {
-
+hw.module @checkDrv(
+  in %arg0 : !llhd.ref<i1>,
+  in %arg1 : !llhd.ref<i64>,
+  in %arg2 : i1,
+  in %arg3 : i64,
+  in %arg5 : !llhd.ref<!hw.array<3xi8>>,
+  in %arg6 : !llhd.ref<!hw.struct<foo: i1, bar: i2, baz: i4>>,
+  in %arg7 : !hw.array<3xi8>,
+  in %arg8 : !hw.struct<foo: i1, bar: i2, baz: i4>
+) {
   %t = llhd.constant_time <0ns, 1d, 0e>
-  // CHECK: llhd.drv %arg0, %arg2 after %{{.*}} : !hw.inout<i1>
-  llhd.drv %arg0, %arg2 after %t : !hw.inout<i1>
-  // CHECK-NEXT: llhd.drv %arg1, %arg3 after %{{.*}} : !hw.inout<i64>
-  llhd.drv %arg1, %arg3 after %t : !hw.inout<i64>
-  // CHECK-NEXT: llhd.drv %arg1, %arg3 after %{{.*}} if %arg2 : !hw.inout<i64>
-  llhd.drv %arg1, %arg3 after %t if %arg2 : !hw.inout<i64>
-  // CHECK-NEXT: llhd.drv %arg5, %arg7 after %{{.*}} : !hw.inout<array<3xi8>>
-  llhd.drv %arg5, %arg7 after %t : !hw.inout<array<3xi8>>
-  // CHECK-NEXT: llhd.drv %arg6, %arg8 after %{{.*}} : !hw.inout<struct<foo: i1, bar: i2, baz: i4>>
-  llhd.drv %arg6, %arg8 after %t : !hw.inout<struct<foo: i1, bar: i2, baz: i4>>
+  // CHECK: llhd.drv %arg0, %arg2 after %{{.*}} : i1
+  llhd.drv %arg0, %arg2 after %t : i1
+  // CHECK-NEXT: llhd.drv %arg1, %arg3 after %{{.*}} : i64
+  llhd.drv %arg1, %arg3 after %t : i64
+  // CHECK-NEXT: llhd.drv %arg1, %arg3 after %{{.*}} if %arg2 : i64
+  llhd.drv %arg1, %arg3 after %t if %arg2 : i64
+  // CHECK-NEXT: llhd.drv %arg5, %arg7 after %{{.*}} : !hw.array<3xi8>
+  llhd.drv %arg5, %arg7 after %t : !hw.array<3xi8>
+  // CHECK-NEXT: llhd.drv %arg6, %arg8 after %{{.*}} : !hw.struct<foo: i1, bar: i2, baz: i4>
+  llhd.drv %arg6, %arg8 after %t : !hw.struct<foo: i1, bar: i2, baz: i4>
 }
 
 // CHECK-LABEL: @check_wait_0
-hw.module @check_wait_0 () {
+hw.module @check_wait_0() {
   // CHECK-NEXT: llhd.process
   llhd.process {
     // CHECK: llhd.wait ^[[BB:.*]]
@@ -105,7 +122,7 @@ hw.module @check_wait_0 () {
 }
 
 // CHECK-LABEL: @check_wait_1
-hw.module @check_wait_1 () {
+hw.module @check_wait_1() {
   // CHECK-NEXT: llhd.process
   llhd.process {
     // CHECK-NEXT: %[[TIME:.*]] = llhd.constant_time
@@ -118,36 +135,36 @@ hw.module @check_wait_1 () {
   }
 }
 
-// CHECK: @check_wait_2(inout %[[ARG0:.*]] : i64, inout %[[ARG1:.*]] : i1) {
-hw.module @check_wait_2 (inout %arg0 : i64, inout %arg1 : i1) {
+// CHECK-LABEL: @check_wait_2
+hw.module @check_wait_2(in %arg0 : !llhd.ref<i64>, in %arg1 : !llhd.ref<i1>) {
   // CHECK: [[PRB0:%.+]] = llhd.prb %arg0
-  %prb0 = llhd.prb %arg0 : !hw.inout<i64>
+  %prb0 = llhd.prb %arg0 : i64
   // CHECK: [[PRB1:%.+]] = llhd.prb %arg1
-  %prb1 = llhd.prb %arg1 : !hw.inout<i1>
+  %prb1 = llhd.prb %arg1 : i1
   // CHECK-NEXT: llhd.process
   llhd.process {
-    // CHECK-NEXT: llhd.wait ([[PRB0]], [[PRB1]] : i64, i1), ^[[BB:.*]](%[[ARG1]] : !hw.inout<i1>)
-    llhd.wait (%prb0, %prb1 : i64, i1), ^bb1(%arg1 : !hw.inout<i1>)
-    // CHECK: ^[[BB]](%[[A:.*]]: !hw.inout<i1>):
-  ^bb1(%a: !hw.inout<i1>):
+    // CHECK-NEXT: llhd.wait ([[PRB0]], [[PRB1]] : i64, i1), ^[[BB:.*]](%arg1 : !llhd.ref<i1>)
+    llhd.wait (%prb0, %prb1 : i64, i1), ^bb1(%arg1 : !llhd.ref<i1>)
+    // CHECK: ^[[BB]](%[[A:.*]]: !llhd.ref<i1>):
+  ^bb1(%a: !llhd.ref<i1>):
     llhd.halt
   }
 }
 
-// CHECK: hw.module @check_wait_3(inout %[[ARG0:.*]] : i64, inout %[[ARG1:.*]] : i1) {
-hw.module @check_wait_3 (inout %arg0 : i64, inout %arg1 : i1) {
+// CHECK-LABEL: @check_wait_3
+hw.module @check_wait_3(in %arg0 : !llhd.ref<i64>, in %arg1 : !llhd.ref<i1>) {
   // CHECK: [[PRB0:%.+]] = llhd.prb %arg0
-  %prb0 = llhd.prb %arg0 : !hw.inout<i64>
+  %prb0 = llhd.prb %arg0 : i64
   // CHECK: [[PRB1:%.+]] = llhd.prb %arg1
-  %prb1 = llhd.prb %arg1 : !hw.inout<i1>
+  %prb1 = llhd.prb %arg1 : i1
   // CHECK-NEXT: llhd.process
   llhd.process {
     // CHECK-NEXT: %[[TIME:.*]] = llhd.constant_time
     %time = llhd.constant_time #llhd.time<0ns, 0d, 0e>
-    // CHECK-NEXT: llhd.wait delay %[[TIME]], ([[PRB0]], [[PRB1]] : i64, i1), ^[[BB:.*]](%[[ARG1]], %[[ARG0]] : !hw.inout<i1>, !hw.inout<i64>)
-    llhd.wait delay %time, (%prb0, %prb1 : i64, i1), ^bb1(%arg1, %arg0 : !hw.inout<i1>, !hw.inout<i64>)
-    // CHECK: ^[[BB]](%[[A:.*]]: !hw.inout<i1>, %[[B:.*]]: !hw.inout<i64>):
-  ^bb1(%a: !hw.inout<i1>, %b: !hw.inout<i64>):
+    // CHECK-NEXT: llhd.wait delay %[[TIME]], ([[PRB0]], [[PRB1]] : i64, i1), ^[[BB:.*]](%arg1, %arg0 : !llhd.ref<i1>, !llhd.ref<i64>)
+    llhd.wait delay %time, (%prb0, %prb1 : i64, i1), ^bb1(%arg1, %arg0 : !llhd.ref<i1>, !llhd.ref<i64>)
+    // CHECK: ^[[BB]](%[[A:.*]]: !llhd.ref<i1>, %[[B:.*]]: !llhd.ref<i64>):
+  ^bb1(%a: !llhd.ref<i1>, %b: !llhd.ref<i64>):
     llhd.halt
   }
 }

--- a/test/Dialect/LLHD/IR/errors.mlir
+++ b/test/Dialect/LLHD/IR/errors.mlir
@@ -1,90 +1,29 @@
 // RUN: circt-opt %s --split-input-file --verify-diagnostics
 
-hw.module @errors(in %in0: i32, out out0: i8) {
-  // expected-error @below {{requires the same type for all operands and results}}
-  %0 = "llhd.delay"(%in0) {delay = #llhd.time<0ns, 1d, 0e>} : (i32) -> i8
-  hw.output %0 : i8
-}
-
-// -----
-
-hw.module @illegal_signal_to_array(inout %sig : !hw.array<3xi32>, in %ind : i2) {
-  // expected-error @+1 {{'llhd.sig.array_slice' op result #0 must be InOutType of an ArrayType values, but got '!hw.array<3xi32>'}}
-  %0 = llhd.sig.array_slice %sig at %ind : (!hw.inout<array<3xi32>>) -> !hw.array<3xi32>
-}
-
-// -----
-
-hw.module @illegal_array_element_type_mismatch(inout %sig : !hw.array<3xi32>, in %ind : i2) {
+hw.module @illegal_array_element_type_mismatch(in %sig : !llhd.ref<!hw.array<3xi32>>, in %ind : i2) {
   // expected-error @+1 {{arrays element type must match}}
-  %0 = llhd.sig.array_slice %sig at %ind : (!hw.inout<array<3xi32>>) -> !hw.inout<array<2xi1>>
+  %0 = llhd.sig.array_slice %sig at %ind : <!hw.array<3xi32>> -> <!hw.array<2xi1>>
 }
 
 // -----
 
-hw.module @illegal_result_array_too_big(inout %sig : !hw.array<3xi32>, in %ind : i2) {
+hw.module @illegal_result_array_too_big(in %sig : !llhd.ref<!hw.array<3xi32>>, in %ind : i2) {
   // expected-error @+1 {{width of result type has to be smaller than or equal to the input type}}
-  %0 = llhd.sig.array_slice %sig at %ind : (!hw.inout<array<3xi32>>) -> !hw.inout<array<4xi32>>
+  %0 = llhd.sig.array_slice %sig at %ind : <!hw.array<3xi32>> -> <!hw.array<4xi32>>
 }
 
 // -----
 
-hw.module @illegal_sig_to_int(inout %s : i32, in %ind : i5) {
-  // expected-error @+1 {{'llhd.sig.extract' op result #0 must be InOutType of a signless integer bitvector values, but got 'i10'}}
-  %0 = llhd.sig.extract %s from %ind : (!hw.inout<i32>) -> i10
-}
-
-// -----
-
-hw.module @illegal_sig_to_int_to_wide(inout %s : i32, in %ind : i5) {
+hw.module @illegal_sig_to_int_to_wide(in %s : !llhd.ref<i32>, in %ind : i5) {
   // expected-error @+1 {{width of result type has to be smaller than or equal to the input type}}
-  %0 = llhd.sig.extract %s from %ind : (!hw.inout<i32>) -> !hw.inout<i64>
+  %0 = llhd.sig.extract %s from %ind : <i32> -> <i64>
 }
 
 // -----
 
-hw.module @extract_element_tuple_index_out_of_bounds(inout %tup : !hw.struct<foo: i1, bar: i2, baz: i3>) {
+hw.module @extract_element_tuple_index_out_of_bounds(in %tup : !llhd.ref<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
   // expected-error @+1 {{invalid field name specified}}
-  %0 = llhd.sig.struct_extract %tup["foobar"] : !hw.inout<struct<foo: i1, bar: i2, baz: i3>>
-}
-
-// -----
-
-// expected-error @+1 {{unknown  type `illegaltype` in dialect `llhd`}}
-func.func @illegaltype(%arg0: !llhd.illegaltype) {
-    return
-}
-
-// -----
-
-// expected-error @+2 {{unknown attribute `illegalattr` in dialect `llhd`}}
-func.func @illegalattr() {
-    %0 = llhd.constant_time #llhd.illegalattr : i1
-    return
-}
-
-// -----
-
-// expected-error @+3 {{failed to verify that type of 'init' and underlying type of 'signal' have to match.}}
-hw.module @check_illegal_sig() {
-  %cI1 = hw.constant 0 : i1
-  %sig1 = "llhd.sig"(%cI1) {name="foo"} : (i1) -> !hw.inout<i32>
-}
-
-// -----
-
-// expected-error @+2 {{failed to verify that type of 'result' and underlying type of 'signal' have to match.}}
-hw.module @check_illegal_prb(inout %sig : i1) {
-  %prb = "llhd.prb"(%sig) {} : (!hw.inout<i1>) -> i32
-}
-
-// -----
-
-// expected-error @+4 {{failed to verify that type of 'value' and underlying type of 'signal' have to match.}}
-hw.module @check_illegal_drv(inout %sig : i1) {
-  %c = hw.constant 0 : i32
-  %time = llhd.constant_time #llhd.time<1ns, 0d, 0e>
-  "llhd.drv"(%sig, %c, %time) {} : (!hw.inout<i1>, i32, !llhd.time) -> ()
+  %0 = llhd.sig.struct_extract %tup["foobar"] : <!hw.struct<foo: i1, bar: i2, baz: i3>>
 }
 
 // -----

--- a/test/Dialect/LLHD/Transforms/combine-drives.mlir
+++ b/test/Dialect/LLHD/Transforms/combine-drives.mlir
@@ -16,21 +16,21 @@ hw.module @Basic(in %u0: i42, in %u1: i42, in %u2: i42, in %u3: i20, in %u4: i22
   // CHECK-NEXT: llhd.drv %s, [[STRUCT]] after {{%.+}}
   %s = llhd.sig %0 : !hw.struct<a: !hw.array<3xi42>, b: i42>
   // CHECK-NEXT: [[A]] = hw.array_create %u2, %u1, %u0
-  %a = llhd.sig.struct_extract %s["a"] : !hw.inout<struct<a: !hw.array<3xi42>, b: i42>>
-  %a12 = llhd.sig.array_slice %a at %c1_i2 : (!hw.inout<array<3xi42>>) -> !hw.inout<array<2xi42>>
-  %a0 = llhd.sig.array_get %a[%c0_i2] : !hw.inout<array<3xi42>>
-  %a1 = llhd.sig.array_get %a12[%false] : !hw.inout<array<2xi42>>
-  %a2 = llhd.sig.array_get %a12[%true] : !hw.inout<array<2xi42>>
-  llhd.drv %a0, %u0 after %1 : !hw.inout<i42>  // s.a[0] = u0
-  llhd.drv %a1, %u1 after %1 : !hw.inout<i42>  // s.a[2:1][0] = u1
-  llhd.drv %a2, %u2 after %1 : !hw.inout<i42>  // s.a[2:1][1] = u2
+  %a = llhd.sig.struct_extract %s["a"] : <!hw.struct<a: !hw.array<3xi42>, b: i42>>
+  %a12 = llhd.sig.array_slice %a at %c1_i2 : <!hw.array<3xi42>> -> <!hw.array<2xi42>>
+  %a0 = llhd.sig.array_get %a[%c0_i2] : <!hw.array<3xi42>>
+  %a1 = llhd.sig.array_get %a12[%false] : <!hw.array<2xi42>>
+  %a2 = llhd.sig.array_get %a12[%true] : <!hw.array<2xi42>>
+  llhd.drv %a0, %u0 after %1 : i42  // s.a[0] = u0
+  llhd.drv %a1, %u1 after %1 : i42  // s.a[2:1][0] = u1
+  llhd.drv %a2, %u2 after %1 : i42  // s.a[2:1][1] = u2
   // CHECK-NEXT: [[B]] = comb.concat %u4, %u3
-  %bX = llhd.sig.struct_extract %s["b"] : !hw.inout<struct<a: !hw.array<3xi42>, b: i42>>
-  %bY = llhd.sig.struct_extract %s["b"] : !hw.inout<struct<a: !hw.array<3xi42>, b: i42>>
-  %b0 = llhd.sig.extract %bX from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i20>
-  %b1 = llhd.sig.extract %bY from %c20_i6 : (!hw.inout<i42>) -> !hw.inout<i22>
-  llhd.drv %b0, %u3 after %1 : !hw.inout<i20>  // s.b[19:0] = u3
-  llhd.drv %b1, %u4 after %1 : !hw.inout<i22>  // s.b[41:20] = u4
+  %bX = llhd.sig.struct_extract %s["b"] : <!hw.struct<a: !hw.array<3xi42>, b: i42>>
+  %bY = llhd.sig.struct_extract %s["b"] : <!hw.struct<a: !hw.array<3xi42>, b: i42>>
+  %b0 = llhd.sig.extract %bX from %c0_i6 : <i42> -> <i20>
+  %b1 = llhd.sig.extract %bY from %c20_i6 : <i42> -> <i22>
+  llhd.drv %b0, %u3 after %1 : i20  // s.b[19:0] = u3
+  llhd.drv %b1, %u4 after %1 : i22  // s.b[41:20] = u4
 }
 
 // CHECK-LABEL: @DriveParameters
@@ -52,30 +52,30 @@ hw.module @DriveParameters(in %u: i21, in %v: i21, in %e: i1) {
   // CHECK-NEXT: llhd.drv %a, [[TMP]] after [[T1]] :
   // CHECK-NEXT: [[TMP:%.+]] = comb.concat %v, %v
   // CHECK-NEXT: llhd.drv %a, [[TMP]] after [[T1]] if %e :
-  %a0 = llhd.sig.extract %a from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i21>
-  %a1 = llhd.sig.extract %a from %c21_i6 : (!hw.inout<i42>) -> !hw.inout<i21>
-  llhd.drv %a0, %u after %0 : !hw.inout<i21>
-  llhd.drv %a1, %v after %0 : !hw.inout<i21>
-  llhd.drv %a0, %v after %0 if %e : !hw.inout<i21>
-  llhd.drv %a1, %u after %0 if %e : !hw.inout<i21>
-  llhd.drv %a0, %u after %1 : !hw.inout<i21>
-  llhd.drv %a1, %u after %1 : !hw.inout<i21>
-  llhd.drv %a0, %v after %1 if %e : !hw.inout<i21>
-  llhd.drv %a1, %v after %1 if %e : !hw.inout<i21>
+  %a0 = llhd.sig.extract %a from %c0_i6 : <i42> -> <i21>
+  %a1 = llhd.sig.extract %a from %c21_i6 : <i42> -> <i21>
+  llhd.drv %a0, %u after %0 : i21
+  llhd.drv %a1, %v after %0 : i21
+  llhd.drv %a0, %v after %0 if %e : i21
+  llhd.drv %a1, %u after %0 if %e : i21
+  llhd.drv %a0, %u after %1 : i21
+  llhd.drv %a1, %u after %1 : i21
+  llhd.drv %a0, %v after %1 if %e : i21
+  llhd.drv %a1, %v after %1 if %e : i21
 }
 
 // CHECK-LABEL: @DrivesToBlockArgSignals
-hw.module @DrivesToBlockArgSignals(inout %a: i42, in %u: i20, in %v: i22) {
+hw.module @DrivesToBlockArgSignals(in %a: !llhd.ref<i42>, in %u: i20, in %v: i22) {
   // CHECK-DAG: [[TMP:%.+]] = comb.concat %v, %u
   // CHECK-DAG: [[T:%.+]] = llhd.constant_time
   // CHECK-DAG: llhd.drv %a, [[TMP]] after [[T]]
   %c0_i6 = hw.constant 0 : i6
   %c20_i6 = hw.constant 20 : i6
   %0 = llhd.constant_time <0ns, 0d, 1e>
-  %1 = llhd.sig.extract %a from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i20>
-  %2 = llhd.sig.extract %a from %c20_i6 : (!hw.inout<i42>) -> !hw.inout<i22>
-  llhd.drv %1, %u after %0 : !hw.inout<i20>
-  llhd.drv %2, %v after %0 : !hw.inout<i22>
+  %1 = llhd.sig.extract %a from %c0_i6 : <i42> -> <i20>
+  %2 = llhd.sig.extract %a from %c20_i6 : <i42> -> <i22>
+  llhd.drv %1, %u after %0 : i20
+  llhd.drv %2, %v after %0 : i22
 }
 
 // CHECK-LABEL: @DrivesToOpaqueSignals
@@ -86,12 +86,12 @@ hw.module @DrivesToOpaqueSignals(in %u: i20, in %v: i22) {
   // CHECK-DAG: llhd.drv [[A]], [[TMP]] after [[T]]
   %c0_i6 = hw.constant 0 : i6
   %c20_i6 = hw.constant 20 : i6
-  %a = builtin.unrealized_conversion_cast to !hw.inout<i42>
+  %a = builtin.unrealized_conversion_cast to !llhd.ref<i42>
   %0 = llhd.constant_time <0ns, 0d, 1e>
-  %1 = llhd.sig.extract %a from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i20>
-  %2 = llhd.sig.extract %a from %c20_i6 : (!hw.inout<i42>) -> !hw.inout<i22>
-  llhd.drv %1, %u after %0 : !hw.inout<i20>
-  llhd.drv %2, %v after %0 : !hw.inout<i22>
+  %1 = llhd.sig.extract %a from %c0_i6 : <i42> -> <i20>
+  %2 = llhd.sig.extract %a from %c20_i6 : <i42> -> <i22>
+  llhd.drv %1, %u after %0 : i20
+  llhd.drv %2, %v after %0 : i22
 }
 
 // CHECK-LABEL: @SkipDynamicExtract
@@ -101,8 +101,8 @@ hw.module @SkipDynamicExtract(in %u: i6, in %v: i8) {
   %a = llhd.sig %1 : i42
   // CHECK: [[TMP:%.+]] = llhd.sig.extract %a from %u
   // CHECK: llhd.drv [[TMP]], %v
-  %2 = llhd.sig.extract %a from %u : (!hw.inout<i42>) -> !hw.inout<i8>
-  llhd.drv %2, %v after %0 : !hw.inout<i8>
+  %2 = llhd.sig.extract %a from %u : <i42> -> <i8>
+  llhd.drv %2, %v after %0 : i8
 }
 
 // CHECK-LABEL: @SkipDynamicArraySlice
@@ -112,8 +112,8 @@ hw.module @SkipDynamicArraySlice(in %u: i6, in %v: !hw.array<8xi42>) {
   %a = llhd.sig %1 : !hw.array<42xi42>
   // CHECK: [[TMP:%.+]] = llhd.sig.array_slice %a at %u
   // CHECK: llhd.drv [[TMP]], %v
-  %2 = llhd.sig.array_slice %a at %u : (!hw.inout<array<42xi42>>) -> !hw.inout<array<8xi42>>
-  llhd.drv %2, %v after %0 : !hw.inout<array<8xi42>>
+  %2 = llhd.sig.array_slice %a at %u : <!hw.array<42xi42>> -> <!hw.array<8xi42>>
+  llhd.drv %2, %v after %0 : !hw.array<8xi42>
 }
 
 // CHECK-LABEL: @SkipDynamicArrayGet
@@ -123,12 +123,12 @@ hw.module @SkipDynamicArrayGet(in %u: i6, in %v: i42) {
   %a = llhd.sig %1 : !hw.array<42xi42>
   // CHECK: [[TMP:%.+]] = llhd.sig.array_get %a[%u]
   // CHECK: llhd.drv [[TMP]], %v
-  %2 = llhd.sig.array_get %a[%u] : !hw.inout<array<42xi42>>
-  llhd.drv %2, %v after %0 : !hw.inout<i42>
+  %2 = llhd.sig.array_get %a[%u] : <!hw.array<42xi42>>
+  llhd.drv %2, %v after %0 : i42
 }
 
 // CHECK-LABEL: @SkipIfGapsPresentAndDefaultValueUnknown
-hw.module @SkipIfGapsPresentAndDefaultValueUnknown(inout %a: i42, in %u: i11, in %v: i30) {
+hw.module @SkipIfGapsPresentAndDefaultValueUnknown(in %a: !llhd.ref<i42>, in %u: i11, in %v: i30) {
   %c0_i6 = hw.constant 0 : i6
   %c12_i6 = hw.constant 12 : i6
   %0 = llhd.constant_time <0ns, 0d, 1e>
@@ -137,10 +137,10 @@ hw.module @SkipIfGapsPresentAndDefaultValueUnknown(inout %a: i42, in %u: i11, in
   // CHECK: [[TMP2:%.+]] = llhd.sig.extract %a from %c12_i6
   // CHECK: llhd.drv [[TMP1]], %u
   // CHECK: llhd.drv [[TMP2]], %v
-  %2 = llhd.sig.extract %a from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i11>
-  %3 = llhd.sig.extract %a from %c12_i6 : (!hw.inout<i42>) -> !hw.inout<i30>
-  llhd.drv %2, %u after %0 : !hw.inout<i11>
-  llhd.drv %3, %v after %0 : !hw.inout<i30>
+  %2 = llhd.sig.extract %a from %c0_i6 : <i42> -> <i11>
+  %3 = llhd.sig.extract %a from %c12_i6 : <i42> -> <i30>
+  llhd.drv %2, %u after %0 : i11
+  llhd.drv %3, %v after %0 : i30
 }
 
 // CHECK-LABEL: @SkipIfOverlapsPresent
@@ -155,10 +155,10 @@ hw.module @SkipIfOverlapsPresent(in %u: i13, in %v: i30) {
   // CHECK: [[TMP2:%.+]] = llhd.sig.extract %a from %c12_i6
   // CHECK: llhd.drv [[TMP1]], %u
   // CHECK: llhd.drv [[TMP2]], %v
-  %2 = llhd.sig.extract %a from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i13>
-  %3 = llhd.sig.extract %a from %c12_i6 : (!hw.inout<i42>) -> !hw.inout<i30>
-  llhd.drv %2, %u after %0 : !hw.inout<i13>
-  llhd.drv %3, %v after %0 : !hw.inout<i30>
+  %2 = llhd.sig.extract %a from %c0_i6 : <i42> -> <i13>
+  %3 = llhd.sig.extract %a from %c12_i6 : <i42> -> <i30>
+  llhd.drv %2, %u after %0 : i13
+  llhd.drv %3, %v after %0 : i30
 }
 
 // CHECK-LABEL: @RegressionOverlappingDrives
@@ -167,11 +167,11 @@ hw.module @RegressionOverlappingDrives(in %u: i153, in %v: i5) {
   %0 = llhd.constant_time <0ns, 0d, 1e>
   %a = llhd.sig %u : i153
   // CHECK: llhd.drv %a, %u
-  llhd.drv %a, %u after %0 : !hw.inout<i153>
+  llhd.drv %a, %u after %0 : i153
   // CHECK: [[TMP:%.+]] = llhd.sig.extract
   // CHECK: llhd.drv [[TMP]], %v
-  %1 = llhd.sig.extract %a from %c42_i8 : (!hw.inout<i153>) -> !hw.inout<i5>
-  llhd.drv %1, %v after %0 : !hw.inout<i5>
+  %1 = llhd.sig.extract %a from %c42_i8 : <i153> -> <i5>
+  llhd.drv %1, %v after %0 : i5
 }
 
 // CHECK-LABEL: @IgnoreNestedSignalUsers
@@ -184,26 +184,26 @@ hw.module @IgnoreNestedSignalUsers(in %u: i20, in %v: i22) {
   %a = llhd.sig %1 : i42
   // CHECK: [[TMP1:%.+]] = llhd.sig.extract %a from %c0_i6
   // CHECK: [[TMP2:%.+]] = llhd.sig.extract %a from %c20_i6
-  %2 = llhd.sig.extract %a from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i20>
-  %3 = llhd.sig.extract %a from %c20_i6 : (!hw.inout<i42>) -> !hw.inout<i22>
+  %2 = llhd.sig.extract %a from %c0_i6 : <i42> -> <i20>
+  %3 = llhd.sig.extract %a from %c20_i6 : <i42> -> <i22>
   // CHECK: llhd.drv [[TMP1]], %u
-  llhd.drv %2, %u after %0 : !hw.inout<i20>
+  llhd.drv %2, %u after %0 : i20
   llhd.process {
     // CHECK: llhd.drv [[TMP2]], %v
-    llhd.drv %3, %v after %0 : !hw.inout<i22>
+    llhd.drv %3, %v after %0 : i22
     llhd.halt
   }
 
   %b = llhd.sig %1 : i42
   // CHECK: [[TMP1:%.+]] = llhd.sig.extract %b from %c0_i6
-  %4 = llhd.sig.extract %b from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i20>
+  %4 = llhd.sig.extract %b from %c0_i6 : <i42> -> <i20>
   // CHECK: llhd.drv [[TMP1]], %u
-  llhd.drv %4, %u after %0 : !hw.inout<i20>
+  llhd.drv %4, %u after %0 : i20
   llhd.process {
     // CHECK: [[TMP2:%.+]] = llhd.sig.extract %b from %c20_i6
-    %5 = llhd.sig.extract %b from %c20_i6 : (!hw.inout<i42>) -> !hw.inout<i22>
+    %5 = llhd.sig.extract %b from %c20_i6 : <i42> -> <i22>
     // CHECK: llhd.drv [[TMP2]], %v
-    llhd.drv %5, %v after %0 : !hw.inout<i22>
+    llhd.drv %5, %v after %0 : i22
     llhd.halt
   }
 }
@@ -219,8 +219,8 @@ hw.module @RegressionSingleElementArray(in %u: i1) {
   // CHECK-NEXT: [[TMP:%.+]] = hw.array_create %u
   // CHECK-NEXT: llhd.drv %a, [[TMP]] after [[T]] :
   %a = llhd.sig %0 : !hw.array<1xi1>
-  %2 = llhd.sig.array_get %a[%c0_i0] : !hw.inout<array<1xi1>>
-  llhd.drv %2, %u after %1 : !hw.inout<i1>
+  %2 = llhd.sig.array_get %a[%c0_i0] : <!hw.array<1xi1>>
+  llhd.drv %2, %u after %1 : i1
 }
 
 // Driving a single struct field still requires an aggregate to be created.
@@ -234,8 +234,8 @@ hw.module @RegressionSingleFieldStruct(in %u: i1) {
   // CHECK-NEXT: [[TMP:%.+]] = hw.struct_create (%u)
   // CHECK-NEXT: llhd.drv %a, [[TMP]] after [[T]] :
   %a = llhd.sig %0 : !hw.struct<x: i1>
-  %2 = llhd.sig.struct_extract %a["x"] : !hw.inout<struct<x: i1>>
-  llhd.drv %2, %u after %1 : !hw.inout<i1>
+  %2 = llhd.sig.struct_extract %a["x"] : <!hw.struct<x: i1>>
+  llhd.drv %2, %u after %1 : i1
 }
 
 // Partially driven signals with no unknown uses and a known default value use
@@ -251,8 +251,8 @@ hw.module @FillIntegerGaps(in %u: i42) {
   // CHECK-NEXT: llhd.drv %a, [[TMP]] after [[T]] :
   // CHECK-NEXT: [[DEFAULT]] = comb.extract %c0_i126 from 42 : (i126) -> i84
   %a = llhd.sig %c0_i126 : i126
-  %1 = llhd.sig.extract %a from %c0_i7 : (!hw.inout<i126>) -> !hw.inout<i42>
-  llhd.drv %1, %u after %0 : !hw.inout<i42>
+  %1 = llhd.sig.extract %a from %c0_i7 : <i126> -> <i42>
+  llhd.drv %1, %u after %0 : i42
 }
 
 // Partially driven signals with no unknown uses and a known default value use
@@ -270,8 +270,8 @@ hw.module @FillStructGaps(in %u: i42) {
   // CHECK-NEXT: [[DEFAULT_B]] = hw.struct_extract [[INIT]]["b"]
   // CHECK-NEXT: [[DEFAULT_C]] = hw.struct_extract [[INIT]]["c"]
   %x = llhd.sig %0 : !hw.struct<a: i42, b: i41, c: i43>
-  %2 = llhd.sig.struct_extract %x["a"] : !hw.inout<struct<a: i42, b: i41, c: i43>>
-  llhd.drv %2, %u after %1 : !hw.inout<i42>
+  %2 = llhd.sig.struct_extract %x["a"] : <!hw.struct<a: i42, b: i41, c: i43>>
+  llhd.drv %2, %u after %1 : i42
 }
 
 // Partially driven signals with no unknown uses and a known default value use
@@ -290,8 +290,8 @@ hw.module @FillArrayGaps(in %u: i42) {
   // CHECK-NEXT: %c1_i2 = hw.constant 1 : i2
   // CHECK-NEXT: [[DEFAULT]] = hw.array_slice [[INIT]][%c1_i2]
   %a = llhd.sig %0 : !hw.array<3xi42>
-  %2 = llhd.sig.array_get %a[%c0_i2] : !hw.inout<array<3xi42>>
-  llhd.drv %2, %u after %1 : !hw.inout<i42>
+  %2 = llhd.sig.array_get %a[%c0_i2] : <!hw.array<3xi42>>
+  llhd.drv %2, %u after %1 : i42
 }
 
 // Don't use default value to fill gaps if there are unknown signal uses. These
@@ -308,10 +308,10 @@ hw.module @SkipGapsOnUnknownUse(in %u: i42) {
   // CHECK: [[TMP2:%.+]] = llhd.sig.extract %a from %c42_i7
   // CHECK: llhd.drv [[TMP1]], %u
   // CHECK: func.call @useSigI42([[TMP2]])
-  %1 = llhd.sig.extract %a from %c0_i7 : (!hw.inout<i126>) -> !hw.inout<i42>
-  %2 = llhd.sig.extract %a from %c42_i7 : (!hw.inout<i126>) -> !hw.inout<i42>
-  llhd.drv %1, %u after %0 : !hw.inout<i42>
-  func.call @useSigI42(%2) : (!hw.inout<i42>) -> ()
+  %1 = llhd.sig.extract %a from %c0_i7 : <i126> -> <i42>
+  %2 = llhd.sig.extract %a from %c42_i7 : <i126> -> <i42>
+  llhd.drv %1, %u after %0 : i42
+  func.call @useSigI42(%2) : (!llhd.ref<i42>) -> ()
 }
 
-func.func private @useSigI42(%arg0: !hw.inout<i42>)
+func.func private @useSigI42(%arg0: !llhd.ref<i42>)

--- a/test/Dialect/LLHD/Transforms/deseq.mlir
+++ b/test/Dialect/LLHD/Transforms/deseq.mlir
@@ -20,7 +20,7 @@ hw.module @ClockPosEdge(in %clock: i1, in %d: i42) {
   }
   %3 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ClockNegEdge(
@@ -44,7 +44,7 @@ hw.module @ClockNegEdge(in %clock: i1, in %d: i42) {
   }
   %3 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ClockPosEdgeWithActiveLowReset(
@@ -74,7 +74,7 @@ hw.module @ClockPosEdgeWithActiveLowReset(in %clock: i1, in %reset: i1, in %d: i
   }
   %3 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ClockNegEdgeWithActiveHighReset(
@@ -104,7 +104,7 @@ hw.module @ClockNegEdgeWithActiveHighReset(in %clock: i1, in %reset: i1, in %d: 
   }
   %3 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ClockWithEnable(
@@ -135,7 +135,7 @@ hw.module @ClockWithEnable(in %clock: i1, in %d: i42, in %en: i1) {
   // CHECK: [[MUX:%.+]] = comb.mux bin [[ER]]#1, [[ER]]#0, [[REG:%.+]] : i42
   // CHECK: [[REG]] = seq.firreg [[MUX]] clock [[CLK]] : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ClockWithEnableAndReset(
@@ -172,7 +172,7 @@ hw.module @ClockWithEnableAndReset(in %clock: i1, in %reset: i1, in %d: i42, in 
   // CHECK: [[MUX:%.+]] = comb.mux bin [[ER]]#1, [[ER]]#0, [[REG:%.+]] : i42
   // CHECK: [[REG]] = seq.firreg [[MUX]] clock [[CLK]] reset async %reset, %c42_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ChasePastValuesThroughControlFlow(
@@ -195,7 +195,7 @@ hw.module @ChasePastValuesThroughControlFlow(in %clock: i1, in %d: i42) {
     cf.cond_br %clock, ^bb1(%d, %true, %true : i42, i1, i1), ^bb1(%d, %true, %false : i42, i1, i1)
   }
   %3 = llhd.sig %c0_i42 : i42
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @AbortIfPastValueUnobserved(
@@ -216,7 +216,7 @@ hw.module @AbortIfPastValueUnobserved(in %clock: i1, in %d: i42) {
     cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
   }
   %3 = llhd.sig %c0_i42 : i42
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @AbortIfPastValueNotI1(
@@ -237,7 +237,7 @@ hw.module @AbortIfPastValueNotI1(in %clock: i1, in %d: i42) {
     cf.cond_br %8, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
   }
   %3 = llhd.sig %c0_i42 : i42
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @AbortIfPastValueLocal(
@@ -258,7 +258,7 @@ hw.module @AbortIfPastValueLocal(in %clock: i1, in %d: i42) {
     cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
   }
   %3 = llhd.sig %c0_i42 : i42
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @AbortIfMultipleClocks(
@@ -282,7 +282,7 @@ hw.module @AbortIfMultipleClocks(in %clock1: i1, in %clock2: i1, in %d: i42) {
     cf.cond_br %11, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
   }
   %3 = llhd.sig %c0_i42 : i42
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @AbortIfMultipleResets(
@@ -314,7 +314,7 @@ hw.module @AbortIfMultipleResets(in %clock: i1, in %reset1: i1, in %reset2: i1, 
     cf.cond_br %reset2, ^bb1(%c43_i42, %true : i42, i1), ^bb1(%d, %true : i42, i1)
   }
   %3 = llhd.sig %c0_i42 : i42
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @AbortOnAndOfMultipleEdges(
@@ -341,7 +341,7 @@ hw.module @AbortOnAndOfMultipleEdges(in %clock: i1, in %reset: i1, in %d: i42, i
     cf.cond_br %reset, ^bb1(%c42_i42, %true : i42, i1), ^bb1(%d, %true : i42, i1)
   }
   %3 = llhd.sig %c0_i42 : i42
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @AcceptMuxForReset(
@@ -371,7 +371,7 @@ hw.module @AcceptMuxForReset(in %clock: i1, in %reset: i1, in %d: i42) {
   }
   %3 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ComplexControlFlow(
@@ -425,7 +425,7 @@ hw.module @ComplexControlFlow(in %clock: i1, in %d: i42) {
   // CHECK: [[MUX:%.+]] = comb.mux bin [[ER]]#1, [[ER]]#0, [[REG:%.+]] : i42
   // CHECK: [[REG]] = seq.firreg [[MUX]] clock [[CLK]] : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ClockAndResetSameConst(
@@ -454,7 +454,7 @@ hw.module @ClockAndResetSameConst(in %clock: i1, in %reset: i1) {
   }
   %3 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @ClockAndResetDifferentConst(
@@ -483,7 +483,7 @@ hw.module @ClockAndResetDifferentConst(in %clock: i1, in %reset: i1) {
   }
   %3 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }
 
 // CHECK-LABEL: @NonConstButStaticReset(
@@ -514,7 +514,7 @@ hw.module @NonConstButStaticReset(in %clock: i1, in %reset: i1, in %d: i42) {
   }
   %5 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %5, %3 after %0 if %4 : !hw.inout<i42>
+  llhd.drv %5, %3 after %0 if %4 : i42
 }
 
 // The following example of a dual-port memory caused excessive memory usage and
@@ -894,41 +894,41 @@ hw.module @LargeControlFlowRegression(in %clk: i1, in %rstn: i1, in %a: i6, in %
   // CHECK: seq.firreg [[TMP]] clock [[CLK]] reset async [[RST]], %c0_i15
   // CHECK: [[TMP:%.+]] = comb.mux bin [[ER]]#69, [[ER]]#68, {{%.+}}
   // CHECK: seq.firreg [[TMP]] clock [[CLK]] reset async [[RST]], %c0_i15
-  llhd.drv %mem0, %1#0 after %0 if %1#1 : !hw.inout<i15>
-  llhd.drv %mem1, %1#2 after %0 if %1#3 : !hw.inout<i15>
-  llhd.drv %mem2, %1#4 after %0 if %1#5 : !hw.inout<i15>
-  llhd.drv %mem3, %1#6 after %0 if %1#7 : !hw.inout<i15>
-  llhd.drv %mem4, %1#8 after %0 if %1#9 : !hw.inout<i15>
-  llhd.drv %mem5, %1#10 after %0 if %1#11 : !hw.inout<i15>
-  llhd.drv %mem6, %1#12 after %0 if %1#13 : !hw.inout<i15>
-  llhd.drv %mem7, %1#14 after %0 if %1#15 : !hw.inout<i15>
-  llhd.drv %mem8, %1#16 after %0 if %1#17 : !hw.inout<i15>
-  llhd.drv %mem9, %1#18 after %0 if %1#19 : !hw.inout<i15>
-  llhd.drv %mem10, %1#20 after %0 if %1#21 : !hw.inout<i15>
-  llhd.drv %mem11, %1#22 after %0 if %1#23 : !hw.inout<i15>
-  llhd.drv %mem12, %1#24 after %0 if %1#25 : !hw.inout<i15>
-  llhd.drv %mem13, %1#26 after %0 if %1#27 : !hw.inout<i15>
-  llhd.drv %mem14, %1#28 after %0 if %1#29 : !hw.inout<i15>
-  llhd.drv %mem15, %1#30 after %0 if %1#31 : !hw.inout<i15>
-  llhd.drv %mem16, %1#32 after %0 if %1#33 : !hw.inout<i15>
-  llhd.drv %mem17, %1#34 after %0 if %1#35 : !hw.inout<i15>
-  llhd.drv %mem18, %1#36 after %0 if %1#37 : !hw.inout<i15>
-  llhd.drv %mem19, %1#38 after %0 if %1#39 : !hw.inout<i15>
-  llhd.drv %mem20, %1#40 after %0 if %1#41 : !hw.inout<i15>
-  llhd.drv %mem21, %1#42 after %0 if %1#43 : !hw.inout<i15>
-  llhd.drv %mem22, %1#44 after %0 if %1#45 : !hw.inout<i15>
-  llhd.drv %mem23, %1#46 after %0 if %1#47 : !hw.inout<i15>
-  llhd.drv %mem24, %1#48 after %0 if %1#49 : !hw.inout<i15>
-  llhd.drv %mem25, %1#50 after %0 if %1#51 : !hw.inout<i15>
-  llhd.drv %mem26, %1#52 after %0 if %1#53 : !hw.inout<i15>
-  llhd.drv %mem27, %1#54 after %0 if %1#55 : !hw.inout<i15>
-  llhd.drv %mem28, %1#56 after %0 if %1#57 : !hw.inout<i15>
-  llhd.drv %mem29, %1#58 after %0 if %1#59 : !hw.inout<i15>
-  llhd.drv %mem30, %1#60 after %0 if %1#61 : !hw.inout<i15>
-  llhd.drv %mem31, %1#62 after %0 if %1#63 : !hw.inout<i15>
-  llhd.drv %mem32, %1#64 after %0 if %1#65 : !hw.inout<i15>
-  llhd.drv %mem33, %1#66 after %0 if %1#67 : !hw.inout<i15>
-  llhd.drv %mem34, %1#68 after %0 if %1#69 : !hw.inout<i15>
+  llhd.drv %mem0, %1#0 after %0 if %1#1 : i15
+  llhd.drv %mem1, %1#2 after %0 if %1#3 : i15
+  llhd.drv %mem2, %1#4 after %0 if %1#5 : i15
+  llhd.drv %mem3, %1#6 after %0 if %1#7 : i15
+  llhd.drv %mem4, %1#8 after %0 if %1#9 : i15
+  llhd.drv %mem5, %1#10 after %0 if %1#11 : i15
+  llhd.drv %mem6, %1#12 after %0 if %1#13 : i15
+  llhd.drv %mem7, %1#14 after %0 if %1#15 : i15
+  llhd.drv %mem8, %1#16 after %0 if %1#17 : i15
+  llhd.drv %mem9, %1#18 after %0 if %1#19 : i15
+  llhd.drv %mem10, %1#20 after %0 if %1#21 : i15
+  llhd.drv %mem11, %1#22 after %0 if %1#23 : i15
+  llhd.drv %mem12, %1#24 after %0 if %1#25 : i15
+  llhd.drv %mem13, %1#26 after %0 if %1#27 : i15
+  llhd.drv %mem14, %1#28 after %0 if %1#29 : i15
+  llhd.drv %mem15, %1#30 after %0 if %1#31 : i15
+  llhd.drv %mem16, %1#32 after %0 if %1#33 : i15
+  llhd.drv %mem17, %1#34 after %0 if %1#35 : i15
+  llhd.drv %mem18, %1#36 after %0 if %1#37 : i15
+  llhd.drv %mem19, %1#38 after %0 if %1#39 : i15
+  llhd.drv %mem20, %1#40 after %0 if %1#41 : i15
+  llhd.drv %mem21, %1#42 after %0 if %1#43 : i15
+  llhd.drv %mem22, %1#44 after %0 if %1#45 : i15
+  llhd.drv %mem23, %1#46 after %0 if %1#47 : i15
+  llhd.drv %mem24, %1#48 after %0 if %1#49 : i15
+  llhd.drv %mem25, %1#50 after %0 if %1#51 : i15
+  llhd.drv %mem26, %1#52 after %0 if %1#53 : i15
+  llhd.drv %mem27, %1#54 after %0 if %1#55 : i15
+  llhd.drv %mem28, %1#56 after %0 if %1#57 : i15
+  llhd.drv %mem29, %1#58 after %0 if %1#59 : i15
+  llhd.drv %mem30, %1#60 after %0 if %1#61 : i15
+  llhd.drv %mem31, %1#62 after %0 if %1#63 : i15
+  llhd.drv %mem32, %1#64 after %0 if %1#65 : i15
+  llhd.drv %mem33, %1#66 after %0 if %1#67 : i15
+  llhd.drv %mem34, %1#68 after %0 if %1#69 : i15
   hw.output
 }
 
@@ -958,5 +958,5 @@ hw.module @OpOnConstantInputsMistakenlyPoison(in %clock: i1, in %d: i42) {
   }
   %3 = llhd.sig %c0_i42 : i42
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
-  llhd.drv %3, %1 after %0 if %2 : !hw.inout<i42>
+  llhd.drv %3, %1 after %0 if %2 : i42
 }

--- a/test/Dialect/LLHD/Transforms/hoist-signals.mlir
+++ b/test/Dialect/LLHD/Transforms/hoist-signals.mlir
@@ -9,14 +9,14 @@ hw.module @SimpleProbesInProcessOp() {
   // CHECK-NEXT: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.prb
-    %0 = llhd.prb %a : !hw.inout<i42>
+    %0 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[A]])
     func.call @use_i42(%0) : (i42) -> ()
     llhd.wait ^bb1
   ^bb1:
     // CHECK: ^bb1:
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[A]])
     func.call @use_i42(%1) : (i42) -> ()
     llhd.halt
@@ -32,7 +32,7 @@ hw.module @SimpleProbesInCombinationalOp() {
   // CHECK-NEXT: llhd.combinational -> i42
   llhd.combinational -> i42 {
     // CHECK-NOT: llhd.prb
-    %0 = llhd.prb %a : !hw.inout<i42>
+    %0 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[A]])
     func.call @use_i42(%0) : (i42) -> ()
     // CHECK-NEXT: llhd.yield [[A]]
@@ -48,21 +48,21 @@ hw.module @DontHoistProbesAcrossSideEffects() {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: llhd.drv
-    llhd.drv %a, %c0_i42 after %0 : !hw.inout<i42>
+    llhd.drv %a, %c0_i42 after %0 : i42
     // CHECK-NEXT: llhd.prb %a
-    llhd.prb %a : !hw.inout<i42>
+    llhd.prb %a : i42
     cf.br ^bb1
   ^bb1:
     // CHECK: ^bb1:
     // CHECK-NEXT: llhd.prb %a
-    llhd.prb %a : !hw.inout<i42>
+    llhd.prb %a : i42
     llhd.wait ^bb2
   ^bb2:
     // CHECK: ^bb2:
     // CHECK-NEXT: call @maybe_side_effecting
     func.call @maybe_side_effecting() : () -> ()
     // CHECK-NEXT: llhd.prb %a
-    llhd.prb %a : !hw.inout<i42>
+    llhd.prb %a : i42
     llhd.halt
   }
 }
@@ -74,7 +74,7 @@ hw.module @DontHoistProbesIfLeakingAcrossWait() {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
-    %0 = llhd.prb %a : !hw.inout<i42>
+    %0 = llhd.prb %a : i42
     llhd.wait ^bb1
   ^bb1:
     // CHECK: ^bb1:
@@ -85,7 +85,7 @@ hw.module @DontHoistProbesIfLeakingAcrossWait() {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: llhd.prb %a
-    %0 = llhd.prb %a : !hw.inout<i42>
+    %0 = llhd.prb %a : i42
     cf.br ^bb1(%0 : i42)
   ^bb1(%1: i42):
     // CHECK: ^bb1([[A:%.+]]: i42):
@@ -110,8 +110,8 @@ hw.module @DontHoistLocalSignals() {
     // CHECK: ^bb1:
     // CHECK-NEXT: llhd.prb %a
     // CHECK-NEXT: llhd.drv %a
-    llhd.prb %a : !hw.inout<i42>
-    llhd.drv %a, %c0_i42 after %0 : !hw.inout<i42>
+    llhd.prb %a : i42
+    llhd.drv %a, %c0_i42 after %0 : i42
     llhd.halt
   }
 }
@@ -134,10 +134,10 @@ hw.module @SimpleDrives(in %u: i42, in %v: i42, in %w: i42) {
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %b, %u after %0 : !hw.inout<i42>
-    llhd.drv %c, %u after %0 : !hw.inout<i42>
-    llhd.drv %d, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %b, %u after %0 : i42
+    llhd.drv %c, %u after %0 : i42
+    llhd.drv %d, %u after %0 : i42
     // CHECK-NEXT: llhd.wait yield (%w, %u, %u, %u, [[DEL]], %u, %true : i42, i42, i42, i42, !llhd.time, i42, i1), ^bb2
     llhd.wait yield (%w : i42), ^bb2
   ^bb2:
@@ -147,9 +147,9 @@ hw.module @SimpleDrives(in %u: i42, in %v: i42, in %w: i42) {
   ^bb3:
     // CHECK-NEXT: ^bb3:
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %b, %v after %0 : !hw.inout<i42>
-    llhd.drv %c, %u after %1 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %b, %v after %0 : i42
+    llhd.drv %c, %u after %1 : i42
     // CHECK-NEXT: llhd.halt %w, %u, %v, %u, [[EPS]], {{%c0_i42.*}}, %false : i42, i42, i42, i42, !llhd.time, i42, i1
     llhd.halt %w : i42
   }
@@ -170,7 +170,7 @@ hw.module @DontHoistDrivesAcrossSideEffects() {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: llhd.drv %a
-    llhd.drv %a, %c0_i42 after %0 : !hw.inout<i42>
+    llhd.drv %a, %c0_i42 after %0 : i42
     // CHECK-NEXT: call @maybe_side_effecting
     func.call @maybe_side_effecting() : () -> ()
     llhd.halt
@@ -178,34 +178,34 @@ hw.module @DontHoistDrivesAcrossSideEffects() {
 }
 
 // CHECK-LABEL: @DontHoistDrivesOfSlotsWithUnsavoryUsers
-hw.module @DontHoistDrivesOfSlotsWithUnsavoryUsers(inout %c: i42) {
+hw.module @DontHoistDrivesOfSlotsWithUnsavoryUsers(in %c: !llhd.ref<i42>) {
   %0 = llhd.constant_time <0ns, 0d, 1e>
   %c0_i42 = hw.constant 0 : i42
   %a = llhd.sig %c0_i42 : i42
   %b = llhd.sig %c0_i42 : i42
   // Unsavory uses outside of process don't affect hoistability.
   // CHECK: call @use_inout_i42(%a)
-  func.call @use_inout_i42(%a) : (!hw.inout<i42>) -> ()
+  func.call @use_inout_i42(%a) : (!llhd.ref<i42>) -> ()
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %c0_i42 after %0 : !hw.inout<i42>
+    llhd.drv %a, %c0_i42 after %0 : i42
     // CHECK-NEXT: llhd.halt
     llhd.halt
   }
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: call @use_inout_i42(%b)
-    func.call @use_inout_i42(%b) : (!hw.inout<i42>) -> ()
+    func.call @use_inout_i42(%b) : (!llhd.ref<i42>) -> ()
     // CHECK-NEXT: llhd.drv %b
-    llhd.drv %b, %c0_i42 after %0 : !hw.inout<i42>
+    llhd.drv %b, %c0_i42 after %0 : i42
     // CHECK-NEXT: llhd.halt
     llhd.halt
   }
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: llhd.drv %c
-    llhd.drv %c, %c0_i42 after %0 : !hw.inout<i42>
+    llhd.drv %c, %c0_i42 after %0 : i42
     // CHECK-NEXT: llhd.halt
     llhd.halt
   }
@@ -220,13 +220,13 @@ hw.module @OnlyHoistLastDrive(in %u: i42, in %v: i42) {
   // CHECK: [[RES:%.+]]:2 = llhd.process -> i42, i42
   llhd.process {
     // CHECK-NEXT: llhd.drv %a, %u
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NEXT: llhd.drv %b, %v
-    llhd.drv %b, %v after %0 : !hw.inout<i42>
+    llhd.drv %b, %v after %0 : i42
     // CHECK-NOT: llhd.drv %a, %v
-    llhd.drv %a, %v after %0 : !hw.inout<i42>
+    llhd.drv %a, %v after %0 : i42
     // CHECK-NOT: llhd.drv %b, %u
-    llhd.drv %b, %u after %0 : !hw.inout<i42>
+    llhd.drv %b, %u after %0 : i42
     // CHECK-NEXT: llhd.halt %v, %u : i42, i42
     llhd.halt
   }
@@ -242,18 +242,18 @@ hw.module @HoistProbesOutOfIf(in %u: i42, in %v: i1) {
   // CHECK-NEXT: scf.if
   scf.if %v {
     // CHECK-NOT: llhd.prb
-    %0 = llhd.prb %a : !hw.inout<i42>
+    %0 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[A]])
     func.call @use_i42(%0) : (i42) -> ()
     // CHECK-NEXT: } else {
   } else {
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[A]])
     func.call @use_i42(%1) : (i42) -> ()
   }
 }
 
 func.func private @use_i42(%arg0: i42)
-func.func private @use_inout_i42(%arg0: !hw.inout<i42>)
+func.func private @use_inout_i42(%arg0: !llhd.ref<i42>)
 func.func private @maybe_side_effecting()

--- a/test/Dialect/LLHD/Transforms/lower-processes.mlir
+++ b/test/Dialect/LLHD/Transforms/lower-processes.mlir
@@ -56,8 +56,8 @@ hw.module @SupportYieldOperands(in %a: i42) {
 hw.module @SupportSeparateProbesOfSameValue() {
   %c0_i42 = hw.constant 0 : i42
   %a = llhd.sig %c0_i42 : i42
-  %0 = llhd.prb %a : !hw.inout<i42>
-  %1 = llhd.prb %a : !hw.inout<i42>
+  %0 = llhd.prb %a : i42
+  %1 = llhd.prb %a : i42
   // CHECK: llhd.combinational
   llhd.process -> i42 {
     cf.br ^bb1

--- a/test/Dialect/LLHD/Transforms/mem2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/mem2reg.mlir
@@ -8,9 +8,9 @@ hw.module @Trivial(in %u: i42) {
   llhd.process {
     // CHECK-NOT: llhd.drv
     %0 = llhd.constant_time <0ns, 0d, 1e>
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%u)
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -22,9 +22,9 @@ hw.module @Trivial(in %u: i42) {
   llhd.combinational -> i42 {
     // CHECK-NOT: llhd.drv
     %0 = llhd.constant_time <0ns, 0d, 1e>
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%u)
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -42,7 +42,7 @@ hw.module @ReconvergentControlFlow(in %u: i42, in %bool: i1) {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NEXT: cf.cond_br
     cf.cond_br %bool, ^bb1, ^bb2
   ^bb1:
@@ -52,7 +52,7 @@ hw.module @ReconvergentControlFlow(in %u: i42, in %bool: i1) {
   ^bb3:
     // CHECK: ^bb3:
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%u)
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -70,9 +70,9 @@ hw.module @DriveMerging(in %u: i42, in %v: i42) {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%u)
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: cf.br ^bb2(%u : i42)
@@ -80,9 +80,9 @@ hw.module @DriveMerging(in %u: i42, in %v: i42) {
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %v after %0 : !hw.inout<i42>
+    llhd.drv %a, %v after %0 : i42
     // CHECK-NOT: llhd.prb
-    %2 = llhd.prb %a : !hw.inout<i42>
+    %2 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%v)
     func.call @use_i42(%2) : (i42) -> ()
     // CHECK-NEXT: cf.br ^bb2(%v : i42)
@@ -90,7 +90,7 @@ hw.module @DriveMerging(in %u: i42, in %v: i42) {
   ^bb2:
     // CHECK-NEXT: ^bb2([[TMP:%.+]]: i42):
     // CHECK-NOT: llhd.prb
-    %3 = llhd.prb %a : !hw.inout<i42>
+    %3 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[TMP]])
     func.call @use_i42(%3) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -114,9 +114,9 @@ hw.module @CompleteDefinitionOnSubset(in %u: i42, in %bool: i1) {
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%u)
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: cf.br ^bb2(%u, %true : i42, i1)
@@ -145,13 +145,13 @@ hw.module @IncompleteDefinitionOnSubset(in %u: i42, in %bool: i1) {
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NEXT: cf.br ^bb2(%u, %true : i42, i1)
     cf.br ^bb2
   ^bb2:
     // CHECK-NEXT: ^bb2([[A:%.+]]: i42, [[ACOND:%.+]]: i1):
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[A]])
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -177,7 +177,7 @@ hw.module @InsertProbeBlocks(in %u: i42) {
   ^bb1:
     // CHECK-NEXT: ^bb2([[TMP:%.+]]: i42):
     // CHECK-NOT: llhd.prb
-    %0 = llhd.prb %a : !hw.inout<i42>
+    %0 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[TMP]])
     func.call @use_i42(%0) : (i42) -> ()
     // CHECK-NEXT: llhd.wait ^bb1
@@ -193,7 +193,7 @@ hw.module @DontInsertDriveBlocksForProbes(in %u: i42, in %bool: i1) {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: llhd.prb %a
-    llhd.prb %a : !hw.inout<i42>
+    llhd.prb %a : i42
     // CHECK-NEXT: cf.cond_br %bool, ^bb1, ^bb3
     cf.cond_br %bool, ^bb1, ^bb3
   ^bb1:
@@ -219,21 +219,21 @@ hw.module @MultipleDrivesConverging(in %u: i42, in %v: i42) {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %b, %v after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %b, %v after %0 : i42
     // CHECK-NEXT: cf.br ^bb2(%u, %v : i42, i42)
     cf.br ^bb2
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %v after %0 : !hw.inout<i42>
-    llhd.drv %b, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %v after %0 : i42
+    llhd.drv %b, %u after %0 : i42
     // CHECK-NEXT: cf.br ^bb2(%v, %u : i42, i42)
     cf.br ^bb2
   ^bb2:
     // CHECK-NEXT: ^bb2([[A:%.+]]: i42, [[B:%.+]]: i42):
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[A]])
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: cf.br ^bb3
@@ -263,11 +263,11 @@ hw.module @ProbeDriveChains() {
     // CHECK-NEXT: [[TMP:%.+]] = llhd.prb %x
     // CHECK-NOT: llhd.prb
     // CHECK-NOT: llhd.drv
-    %1 = llhd.prb %x : !hw.inout<i42>
-    llhd.drv %y, %1 after %0 : !hw.inout<i42>
-    %2 = llhd.prb %y : !hw.inout<i42>
-    llhd.drv %z, %2 after %0 : !hw.inout<i42>
-    %3 = llhd.prb %z : !hw.inout<i42>
+    %1 = llhd.prb %x : i42
+    llhd.drv %y, %1 after %0 : i42
+    %2 = llhd.prb %y : i42
+    llhd.drv %z, %2 after %0 : i42
+    %3 = llhd.prb %z : i42
     // CHECK-NEXT: call @use_i42([[TMP]])
     func.call @use_i42(%3) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -297,23 +297,23 @@ hw.module @TrackDriveCondition(in %u: i42, in %v: i42) {
     // CHECK-NEXT: [[B:%.+]] = llhd.prb %b
     // CHECK-NEXT: [[C:%.+]] = llhd.prb %c
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NEXT: cf.br ^bb2(%u, [[B]], %false, [[C]] : i42, i42, i1, i42)
     cf.br ^bb2
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NEXT: [[C:%.+]] = llhd.prb %c
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %v after %0 : !hw.inout<i42>
-    llhd.drv %b, %v after %0 : !hw.inout<i42>
+    llhd.drv %a, %v after %0 : i42
+    llhd.drv %b, %v after %0 : i42
     // CHECK-NEXT: cf.br ^bb2(%v, %v, %true, [[C]] : i42, i42, i1, i42)
     cf.br ^bb2
   ^bb2:
     // CHECK-NEXT: ^bb2([[A:%.+]]: i42, [[B:%.+]]: i42, [[BCOND:%.+]]: i1, [[C:%.+]]: i42):
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
-    %2 = llhd.prb %b : !hw.inout<i42>
-    %3 = llhd.prb %c : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
+    %2 = llhd.prb %b : i42
+    %3 = llhd.prb %c : i42
     // CHECK-NEXT: call @use_i42([[A]])
     // CHECK-NEXT: call @use_i42([[B]])
     // CHECK-NEXT: call @use_i42([[C]])
@@ -343,7 +343,7 @@ hw.module @DefinitionsThroughLoops() {
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT: llhd.prb
-    %0 = llhd.prb %a : !hw.inout<i42>
+    %0 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[A]])
     func.call @use_i42(%0) : (i42) -> ()
     // CHECK-NEXT: cf.br ^bb1
@@ -366,11 +366,11 @@ hw.module @ReadModifyWriteLoop(in %u: i42) {
   ^bb1:
     // CHECK-NEXT: ^bb1([[A:%.+]]: i42):
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: [[ANEW:%.+]] = comb.add [[A]], %u
     %2 = comb.add %1, %u : i42
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %2 after %0 : !hw.inout<i42>
+    llhd.drv %a, %2 after %0 : i42
     // CHECK-NEXT: [[TMP:%.+]] = comb.icmp ult [[A]], %u
     %3 = comb.icmp ult %1, %u : i42
     // CHECK-NEXT: cf.cond_br [[TMP]], ^bb2, ^bb1([[ANEW]] : i42)
@@ -392,7 +392,7 @@ hw.module @OnlyConsiderUsesInRegionForPromotability(in %u: i42) {
   %a = llhd.sig %u : i42
   // CHECK: llhd.process
   llhd.process {
-    func.call @use_inout_i42(%a) : (!hw.inout<i42>) -> ()
+    func.call @use_ref_i42(%a) : (!llhd.ref<i42>) -> ()
     llhd.halt
   }
   // CHECK: llhd.process
@@ -400,8 +400,8 @@ hw.module @OnlyConsiderUsesInRegionForPromotability(in %u: i42) {
     // CHECK-NOT: llhd.drv
     // CHECK-NOT: llhd.prb
     %0 = llhd.constant_time <0ns, 0d, 1e>
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    %1 = llhd.prb %a : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%u)
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -422,7 +422,7 @@ hw.module @CaptureAcrossWaits(in %u: i42, in %bool: i1) {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: cf.cond_br %bool, ^bb1, ^bb5([[A]] : i42)
     cf.cond_br %bool, ^bb1, ^bb5
   ^bb1:
@@ -463,20 +463,20 @@ hw.module @ConditionalDrives(in %u: i42, in %v: i42, in %q: i1, in %r: i1) {
   llhd.process {
     // CHECK-NEXT: llhd.constant_time
     // CHECK-NEXT: llhd.drv %a, %u after {{%.+}} if %q
-    llhd.drv %a, %u after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %u after %0 if %q : i42
     // CHECK-NEXT: llhd.halt
     llhd.halt
   }
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %u after %0 if %q : i42
     // CHECK-NEXT: cf.br ^bb2(%u : i42)
     cf.br ^bb2
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %v after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %v after %0 if %q : i42
     // CHECK-NEXT: cf.br ^bb2(%v : i42)
     cf.br ^bb2
   ^bb2:
@@ -489,13 +489,13 @@ hw.module @ConditionalDrives(in %u: i42, in %v: i42, in %q: i1, in %r: i1) {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %u after %0 if %q : i42
     // CHECK-NEXT: cf.br ^bb2(%u, %q : i42, i1)
     cf.br ^bb2
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %v after %0 if %r : !hw.inout<i42>
+    llhd.drv %a, %v after %0 if %r : i42
     // CHECK-NEXT: cf.br ^bb2(%v, %r : i42, i1)
     cf.br ^bb2
   ^bb2:
@@ -517,11 +517,11 @@ hw.module @MultipleConditionalDrives(in %u: i42, in %v: i42, in %w: i42, in %q: 
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NEXT: [[DRV1:%.+]] = comb.mux %q, %v, %u : i42
-    llhd.drv %a, %v after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %v after %0 if %q : i42
     // CHECK-NEXT: [[DRV2:%.+]] = comb.mux %r, %w, [[DRV1]] : i42
-    llhd.drv %a, %w after %0 if %r : !hw.inout<i42>
+    llhd.drv %a, %w after %0 if %r : i42
     // CHECK-NEXT: llhd.constant_time
     // CHECK-NEXT: llhd.drv %a, [[DRV2]] after {{%.+}} :
     // CHECK-NEXT: llhd.halt
@@ -533,13 +533,13 @@ hw.module @MultipleConditionalDrives(in %u: i42, in %v: i42, in %w: i42, in %q: 
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %u after %0 if %q : i42
     // CHECK-NEXT: [[DRV1:%.+]] = comb.mux %r, %v, %u : i42
     // CHECK-NEXT: [[ENABLE1:%.+]] = comb.or %r, %q : i1
-    llhd.drv %a, %v after %0 if %r : !hw.inout<i42>
+    llhd.drv %a, %v after %0 if %r : i42
     // CHECK-NEXT: [[DRV2:%.+]] = comb.mux %s, %w, [[DRV1]] : i42
     // CHECK-NEXT: [[ENABLE2:%.+]] = comb.or %s, [[ENABLE1]] : i1
-    llhd.drv %a, %w after %0 if %s : !hw.inout<i42>
+    llhd.drv %a, %w after %0 if %s : i42
     // CHECK-NEXT: llhd.constant_time
     // CHECK-NEXT: llhd.drv %a, [[DRV2]] after {{%.+}} if [[ENABLE2]] :
     // CHECK-NEXT: llhd.halt
@@ -550,15 +550,15 @@ hw.module @MultipleConditionalDrives(in %u: i42, in %v: i42, in %w: i42, in %q: 
   llhd.process {
     // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
     // CHECK-NEXT: [[DRV1:%.+]] = comb.mux %q, %u, [[A]] : i42
-    llhd.drv %a, %u after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %u after %0 if %q : i42
     // CHECK-NEXT: [[DRV2:%.+]] = comb.mux %r, %v, [[DRV1]] : i42
     // CHECK-NEXT: [[ENABLE2:%.+]] = comb.or %r, %q : i1
-    llhd.drv %a, %v after %0 if %r : !hw.inout<i42>
+    llhd.drv %a, %v after %0 if %r : i42
     // CHECK-NEXT: [[DRV3:%.+]] = comb.mux %s, %w, [[DRV2]] : i42
     // CHECK-NEXT: [[ENABLE3:%.+]] = comb.or %s, [[ENABLE2]] : i1
-    llhd.drv %a, %w after %0 if %s : !hw.inout<i42>
+    llhd.drv %a, %w after %0 if %s : i42
     // CHECK-NEXT: call @use_i42([[DRV3]])
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
     // CHECK-NEXT: llhd.drv %a, [[DRV3]] after {{%.+}} if [[ENABLE3]] :
@@ -569,13 +569,13 @@ hw.module @MultipleConditionalDrives(in %u: i42, in %v: i42, in %w: i42, in %q: 
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NEXT: [[DRV1:%.+]] = comb.mux %q, %v, %u : i42
-    llhd.drv %a, %v after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %v after %0 if %q : i42
     // CHECK-NEXT: [[DRV2:%.+]] = comb.mux %r, %w, [[DRV1]] : i42
-    llhd.drv %a, %w after %0 if %r : !hw.inout<i42>
+    llhd.drv %a, %w after %0 if %r : i42
     // CHECK-NEXT: call @use_i42([[DRV2]])
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
     // CHECK-NEXT: llhd.drv %a, [[DRV2]] after {{%.+}} :
@@ -597,8 +597,8 @@ hw.module @DelayedDrives(in %u: i42, in %v: i42, in %bool: i1) {
     // CHECK-NEXT: llhd.drv %a, %u after [[T]]
     // CHECK-NEXT: [[T:%.+]] = llhd.constant_time <0ns, 1d, 0e>
     // CHECK-NEXT: llhd.drv %a, %v after [[T]]
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %a, %v after %1 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %a, %v after %1 : i42
     // CHECK-NEXT: llhd.halt
     llhd.halt
   }
@@ -608,15 +608,15 @@ hw.module @DelayedDrives(in %u: i42, in %v: i42, in %bool: i1) {
     // CHECK-NOT: llhd.drv %a, %u
     // CHECK-NEXT: [[T:%.+]] = llhd.constant_time <0ns, 0d, 1e>
     // CHECK-NEXT: llhd.drv %a, %v after [[T]]
-    llhd.drv %a, %u after %1 : !hw.inout<i42>
-    llhd.drv %a, %v after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %1 : i42
+    llhd.drv %a, %v after %0 : i42
     // CHECK-NEXT: llhd.halt
     llhd.halt
   }
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %1 : !hw.inout<i42>
+    llhd.drv %a, %u after %1 : i42
     // CHECK-NEXT: hw.constant 0 : i42
     // CHECK-NEXT: hw.constant false
     // CHECK-NEXT: cf.cond_br %bool, ^bb1, ^bb2({{%c0_i42.*}}, {{%false.*}}, %u, {{%true.*}} : i42, i1, i42, i1)
@@ -624,7 +624,7 @@ hw.module @DelayedDrives(in %u: i42, in %v: i42, in %bool: i1) {
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %v after %0 : !hw.inout<i42>
+    llhd.drv %a, %v after %0 : i42
     // CHECK-NEXT: hw.constant 0 : i42
     // CHECK-NEXT: hw.constant false
     // CHECK-NEXT: cf.br ^bb2(%v, {{%true.*}}, {{%c0_i42.*}}, {{%false.*}} : i42, i1, i42, i1)
@@ -647,11 +647,11 @@ hw.module @DelayedConditionalDrives(in %u: i42, in %v: i42, in %w: i42, in %q: i
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NEXT: [[DRV1:%.+]] = comb.mux %q, %v, %u : i42
-    llhd.drv %a, %v after %0 if %q : !hw.inout<i42>
+    llhd.drv %a, %v after %0 if %q : i42
     // CHECK-NEXT: [[DRV2:%.+]] = comb.mux %r, %w, [[DRV1]] : i42
-    llhd.drv %a, %w after %0 if %r : !hw.inout<i42>
+    llhd.drv %a, %w after %0 if %r : i42
     // CHECK-NEXT: llhd.constant_time <0ns, 1d, 0e>
     // CHECK-NEXT: llhd.drv %a, [[DRV2]] after {{%.+}} :
     // CHECK-NEXT: llhd.halt
@@ -668,11 +668,11 @@ hw.module @BasicProjectionProbe(in %u: !hw.array<4xi42>, in %v: i42, in %i: i2) 
   llhd.process {
     // CHECK-NOT: llhd.sig.array_get
     // CHECK-NOT: llhd.drv
-    %1 = llhd.sig.array_get %a[%i] : !hw.inout<array<4xi42>>
-    llhd.drv %a, %u after %0 : !hw.inout<array<4xi42>>
+    %1 = llhd.sig.array_get %a[%i] : <!hw.array<4xi42>>
+    llhd.drv %a, %u after %0 : !hw.array<4xi42>
     // CHECK-NOT: llhd.prb
     // CHECK-NEXT: [[TMP:%.+]] = hw.array_get %u[%i]
-    %2 = llhd.prb %1 : !hw.inout<i42>
+    %2 = llhd.prb %1 : i42
     // CHECK-NEXT: call @use_i42([[TMP]])
     func.call @use_i42(%2) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -690,14 +690,14 @@ hw.module @BasicProjectionDrive(in %u: !hw.array<4xi42>, in %v: i42, in %i: i2) 
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<array<4xi42>>
+    llhd.drv %a, %u after %0 : !hw.array<4xi42>
     // CHECK-NOT: llhd.sig.array_get
-    %1 = llhd.sig.array_get %a[%i] : !hw.inout<array<4xi42>>
+    %1 = llhd.sig.array_get %a[%i] : <!hw.array<4xi42>>
     // CHECK-NOT: llhd.drv
     // CHECK-NEXT: [[A:%.+]] = hw.array_inject %u[%i], %v
-    llhd.drv %1, %v after %0 : !hw.inout<i42>
+    llhd.drv %1, %v after %0 : i42
     // CHECK-NOT: llhd.prb
-    %2 = llhd.prb %a : !hw.inout<array<4xi42>>
+    %2 = llhd.prb %a : !hw.array<4xi42>
     // CHECK-NEXT: call @use_array_i42([[A]])
     func.call @use_array_i42(%2) : (!hw.array<4xi42>) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -715,20 +715,20 @@ hw.module @ConditionalProjectionDrive(in %u: !hw.array<4xi42>, in %v: i42, in %w
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.sig.array_get
-    %1 = llhd.sig.array_get %a[%i] : !hw.inout<array<4xi42>>
+    %1 = llhd.sig.array_get %a[%i] : <!hw.array<4xi42>>
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<array<4xi42>>
+    llhd.drv %a, %u after %0 : !hw.array<4xi42>
     // CHECK-NEXT: [[TMP:%.+]] = hw.array_get %u[%i]
     // CHECK-NEXT: [[FIELD1:%.+]] = comb.mux %q, %v, [[TMP]]
     // CHECK-NEXT: [[DRV1:%.+]] = hw.array_inject %u[%i], [[FIELD1]]
-    llhd.drv %1, %v after %0 if %q : !hw.inout<i42>
+    llhd.drv %1, %v after %0 if %q : i42
     // CHECK-NEXT: [[FIELD2:%.+]] = comb.mux %r, %w, [[FIELD1]]
     // CHECK-NEXT: [[DRV2:%.+]] = hw.array_inject [[DRV1]][%i], [[FIELD2]]
-    llhd.drv %1, %w after %0 if %r : !hw.inout<i42>
+    llhd.drv %1, %w after %0 if %r : i42
     // CHECK-NEXT: call @use_array_i42([[DRV2]])
     // CHECK-NEXT: call @use_i42([[FIELD2]])
-    %2 = llhd.prb %a : !hw.inout<array<4xi42>>
-    %3 = llhd.prb %1 : !hw.inout<i42>
+    %2 = llhd.prb %a : !hw.array<4xi42>
+    %3 = llhd.prb %1 : i42
     func.call @use_array_i42(%2) : (!hw.array<4xi42>) -> ()
     func.call @use_i42(%3) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -740,22 +740,22 @@ hw.module @ConditionalProjectionDrive(in %u: !hw.array<4xi42>, in %v: i42, in %w
   llhd.process {
     // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
     // CHECK-NOT: llhd.sig.array_get
-    %1 = llhd.sig.array_get %a[%i] : !hw.inout<array<4xi42>>
+    %1 = llhd.sig.array_get %a[%i] : <!hw.array<4xi42>>
     // CHECK-NEXT: [[DRV1:%.+]] = comb.mux %q, %u, [[A]]
-    llhd.drv %a, %u after %0 if %q : !hw.inout<array<4xi42>>
+    llhd.drv %a, %u after %0 if %q : !hw.array<4xi42>
     // CHECK-NEXT: [[TMP:%.+]] = hw.array_get [[DRV1]][%i]
     // CHECK-NEXT: [[FIELD2:%.+]] = comb.mux %r, %v, [[TMP]]
     // CHECK-NEXT: [[DRV2:%.+]] = hw.array_inject [[DRV1]][%i], [[FIELD2]]
     // CHECK-NEXT: [[ENABLE2:%.+]] = comb.or %r, %q
-    llhd.drv %1, %v after %0 if %r : !hw.inout<i42>
+    llhd.drv %1, %v after %0 if %r : i42
     // CHECK-NEXT: [[FIELD3:%.+]] = comb.mux %s, %w, [[FIELD2]]
     // CHECK-NEXT: [[DRV3:%.+]] = hw.array_inject [[DRV2]][%i], [[FIELD3]]
     // CHECK-NEXT: [[ENABLE3:%.+]] = comb.or %s, [[ENABLE2]]
-    llhd.drv %1, %w after %0 if %s : !hw.inout<i42>
+    llhd.drv %1, %w after %0 if %s : i42
     // CHECK-NEXT: call @use_array_i42([[DRV3]])
     // CHECK-NEXT: call @use_i42([[FIELD3]])
-    %2 = llhd.prb %a : !hw.inout<array<4xi42>>
-    %3 = llhd.prb %1 : !hw.inout<i42>
+    %2 = llhd.prb %a : !hw.array<4xi42>
+    %3 = llhd.prb %1 : i42
     func.call @use_array_i42(%2) : (!hw.array<4xi42>) -> ()
     func.call @use_i42(%3) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -775,9 +775,9 @@ hw.module @DelayedProjectionDrive(in %u: !hw.array<4xi42>, in %v: i42, in %i: i2
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
-    %1 = llhd.sig.array_get %a[%i] : !hw.inout<array<4xi42>>
+    %1 = llhd.sig.array_get %a[%i] : <!hw.array<4xi42>>
     // CHECK-NEXT: [[TMP:%.+]] = hw.array_inject [[A]][%i], %v
-    llhd.drv %1, %v after %0 : !hw.inout<i42>
+    llhd.drv %1, %v after %0 : i42
     // CHECK-NEXT: llhd.constant_time
     // CHECK-NEXT: llhd.drv %a, [[TMP]] after {{%.+}}
     // CHECK-NEXT: llhd.halt
@@ -791,15 +791,15 @@ hw.module @ProjectionThroughBlockArg(in %u: !hw.array<4xi42>, in %v: i42, in %i:
   %a = llhd.sig %u : !hw.array<4xi42>
   // CHECK: llhd.process
   llhd.process {
-    %1 = llhd.sig.array_get %a[%i] : !hw.inout<array<4xi42>>
+    %1 = llhd.sig.array_get %a[%i] : <!hw.array<4xi42>>
     // Pass projection through block argument
-    cf.br ^bb1(%1 : !hw.inout<i42>)
-  ^bb1(%2: !hw.inout<i42>):
-    // CHECK: ^bb1([[ARG:%.+]]: !hw.inout<i42>):
+    cf.br ^bb1(%1 : !llhd.ref<i42>)
+  ^bb1(%2: !llhd.ref<i42>):
+    // CHECK: ^bb1([[ARG:%.+]]: !llhd.ref<i42>):
     // CHECK-NEXT: llhd.prb [[ARG]]
-    %3 = llhd.prb %2 : !hw.inout<i42>
+    %3 = llhd.prb %2 : i42
     // CHECK-NEXT: llhd.drv [[ARG]]
-    llhd.drv %2, %v after %0 : !hw.inout<i42>
+    llhd.drv %2, %v after %0 : i42
     // CHECK-NEXT: llhd.halt
     llhd.halt
   }
@@ -813,19 +813,19 @@ hw.module @MultipleArrayGetsSameIndex(in %u: !hw.array<4xi42>, in %v: i42, in %w
   llhd.process {
     // Two separate array_gets for the same index
     // CHECK-NOT: llhd.sig.array_get
-    %get1 = llhd.sig.array_get %a[%i] : !hw.inout<array<4xi42>>
-    %get2 = llhd.sig.array_get %a[%i] : !hw.inout<array<4xi42>>
+    %get1 = llhd.sig.array_get %a[%i] : <!hw.array<4xi42>>
+    %get2 = llhd.sig.array_get %a[%i] : <!hw.array<4xi42>>
     // Drive both projections with different values
     // CHECK-NOT: llhd.drv
     // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
     // CHECK-NEXT: [[DRV1:%.+]] = hw.array_inject [[A]][%i], %v
     // CHECK-NEXT: [[DRV2:%.+]] = hw.array_inject [[DRV1]][%i], %w
-    llhd.drv %get1, %v after %0 : !hw.inout<i42>
-    llhd.drv %get2, %w after %0 : !hw.inout<i42>
+    llhd.drv %get1, %v after %0 : i42
+    llhd.drv %get2, %w after %0 : i42
     // Probe both projections
     // CHECK-NOT: llhd.prb
-    %prb1 = llhd.prb %get1 : !hw.inout<i42>
-    %prb2 = llhd.prb %get2 : !hw.inout<i42>
+    %prb1 = llhd.prb %get1 : i42
+    %prb2 = llhd.prb %get2 : i42
     // CHECK-NEXT: call @use_i42(%w)
     // CHECK-NEXT: call @use_i42(%w)
     func.call @use_i42(%prb1) : (i42) -> ()
@@ -848,18 +848,18 @@ hw.module @NestedArrayGet3D(
   llhd.process {
     // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
     // Three nested projections
-    %get1 = llhd.sig.array_get %a[%i] : !hw.inout<array<5xarray<6xarray<7xi42>>>>
-    %get2 = llhd.sig.array_get %get1[%j] : !hw.inout<array<6xarray<7xi42>>>
-    %get3 = llhd.sig.array_get %get2[%k] : !hw.inout<array<7xi42>>
+    %get1 = llhd.sig.array_get %a[%i] : <!hw.array<5xarray<6xarray<7xi42>>>>
+    %get2 = llhd.sig.array_get %get1[%j] : <!hw.array<6xarray<7xi42>>>
+    %get3 = llhd.sig.array_get %get2[%k] : <!hw.array<7xi42>>
     // Drive the innermost projection
     // CHECK-NEXT: [[GET3:%.+]] = hw.array_get [[A]][%i]
     // CHECK-NEXT: [[GET2:%.+]] = hw.array_get [[GET3]][%j]
     // CHECK-NEXT: [[INJECT1:%.+]] = hw.array_inject [[GET2]][%k], %v
     // CHECK-NEXT: [[INJECT2:%.+]] = hw.array_inject [[GET3]][%j], [[INJECT1]]
     // CHECK-NEXT: [[INJECT3:%.+]] = hw.array_inject [[A]][%i], [[INJECT2]]
-    llhd.drv %get3, %v after %0 : !hw.inout<i42>
+    llhd.drv %get3, %v after %0 : i42
     // Probe the innermost projection
-    %prb = llhd.prb %get3 : !hw.inout<i42>
+    %prb = llhd.prb %get3 : i42
     // CHECK-NEXT: call @use_i42(%v)
     func.call @use_i42(%prb) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -876,9 +876,9 @@ hw.module @BasicSigExtract(in %u: i42, in %v: i10, in %i: i6, in %q: i1) {
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
+    llhd.drv %a, %u after %0 : i42
     // CHECK-NOT: llhd.sig.extract
-    %1 = llhd.sig.extract %a from %i : (!hw.inout<i42>) -> !hw.inout<i10>
+    %1 = llhd.sig.extract %a from %i : <i42> -> <i10>
     // CHECK-NOT: llhd.drv
     // CHECK-NEXT: [[EXT1:%.+]] = hw.constant 0 : i36
     // CHECK-NEXT: [[EXT2:%.+]] = comb.concat [[EXT1]], %i : i36, i6
@@ -896,9 +896,9 @@ hw.module @BasicSigExtract(in %u: i42, in %v: i10, in %i: i6, in %q: i1) {
     // CHECK-NEXT: [[INJ9:%.+]] = comb.concat [[INJ8]], [[MUX]] : i32, i10
     // CHECK-NEXT: [[INJ10:%.+]] = comb.shl [[INJ9]], [[INJ2]] : i42
     // CHECK-NEXT: [[INJ11:%.+]] = comb.or [[INJ7]], [[INJ10]] : i42
-    llhd.drv %1, %v after %0 if %q : !hw.inout<i10>
+    llhd.drv %1, %v after %0 if %q : i10
     // CHECK-NOT: llhd.prb
-    %2 = llhd.prb %a : !hw.inout<i42>
+    %2 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42([[INJ11]])
     func.call @use_i42(%2) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -915,16 +915,16 @@ hw.module @BasicStructExtract(in %u: !hw.struct<f: i42>, in %v: i42, in %q: i1) 
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<struct<f: i42>>
+    llhd.drv %a, %u after %0 : !hw.struct<f: i42>
     // CHECK-NOT: llhd.sig.struct_extract
-    %1 = llhd.sig.struct_extract %a["f"] : !hw.inout<struct<f: i42>>
+    %1 = llhd.sig.struct_extract %a["f"] : <!hw.struct<f: i42>>
     // CHECK-NOT: llhd.drv
     // CHECK-NEXT: [[EXT:%.+]] = hw.struct_extract %u["f"]
     // CHECK-NEXT: [[MUX:%.+]] = comb.mux %q, %v, [[EXT]]
     // CHECK-NEXT: [[INJ:%.+]] = hw.struct_inject %u["f"], [[MUX]]
-    llhd.drv %1, %v after %0 if %q : !hw.inout<i42>
+    llhd.drv %1, %v after %0 if %q : i42
     // CHECK-NOT: llhd.prb
-    %2 = llhd.prb %1 : !hw.inout<i42>
+    %2 = llhd.prb %1 : i42
     // CHECK-NEXT: call @use_i42([[MUX]])
     func.call @use_i42(%2) : (i42) -> ()
     // CHECK-NEXT: llhd.constant_time
@@ -948,9 +948,9 @@ hw.module @CombCreateDynamicInject(in %u: i42, in %v: i10, in %q: i1) {
     // CHECK-NEXT: llhd.drv %a, [[TMP2]]
     // CHECK-NEXT: llhd.halt
     %c0_i6 = hw.constant 0 : i6
-    %1 = llhd.sig.extract %a from %c0_i6 : (!hw.inout<i42>) -> !hw.inout<i10>
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %1, %v after %0 : !hw.inout<i10>
+    %1 = llhd.sig.extract %a from %c0_i6 : <i42> -> <i10>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %1, %v after %0 : i10
     llhd.halt
   }
 
@@ -964,9 +964,9 @@ hw.module @CombCreateDynamicInject(in %u: i42, in %v: i10, in %q: i1) {
     // CHECK-NEXT: llhd.drv %a, [[TMP3]]
     // CHECK-NEXT: llhd.halt
     %c20_i6 = hw.constant 20 : i6
-    %1 = llhd.sig.extract %a from %c20_i6 : (!hw.inout<i42>) -> !hw.inout<i10>
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %1, %v after %0 : !hw.inout<i10>
+    %1 = llhd.sig.extract %a from %c20_i6 : <i42> -> <i10>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %1, %v after %0 : i10
     llhd.halt
   }
 
@@ -979,9 +979,9 @@ hw.module @CombCreateDynamicInject(in %u: i42, in %v: i10, in %q: i1) {
     // CHECK-NEXT: llhd.drv %a, [[TMP2]]
     // CHECK-NEXT: llhd.halt
     %c32_i6 = hw.constant 32 : i6
-    %1 = llhd.sig.extract %a from %c32_i6 : (!hw.inout<i42>) -> !hw.inout<i10>
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %1, %v after %0 : !hw.inout<i10>
+    %1 = llhd.sig.extract %a from %c32_i6 : <i42> -> <i10>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %1, %v after %0 : i10
     llhd.halt
   }
 
@@ -995,9 +995,9 @@ hw.module @CombCreateDynamicInject(in %u: i42, in %v: i10, in %q: i1) {
     // CHECK-NEXT: llhd.drv %a, [[TMP3]]
     // CHECK-NEXT: llhd.halt
     %c37_i6 = hw.constant 37 : i6
-    %1 = llhd.sig.extract %a from %c37_i6 : (!hw.inout<i42>) -> !hw.inout<i10>
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %1, %v after %0 : !hw.inout<i10>
+    %1 = llhd.sig.extract %a from %c37_i6 : <i42> -> <i10>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %1, %v after %0 : i10
     llhd.halt
   }
 
@@ -1008,15 +1008,15 @@ hw.module @CombCreateDynamicInject(in %u: i42, in %v: i10, in %q: i1) {
     // CHECK-NEXT: llhd.drv %a, %u
     // CHECK-NEXT: llhd.halt
     %c42_i6 = hw.constant 42 : i6
-    %1 = llhd.sig.extract %a from %c42_i6 : (!hw.inout<i42>) -> !hw.inout<i10>
-    llhd.drv %a, %u after %0 : !hw.inout<i42>
-    llhd.drv %1, %v after %0 : !hw.inout<i10>
+    %1 = llhd.sig.extract %a from %c42_i6 : <i42> -> <i10>
+    llhd.drv %a, %u after %0 : i42
+    llhd.drv %1, %v after %0 : i10
     llhd.halt
   }
 }
 
 func.func private @use_i42(%arg0: i42)
-func.func private @use_inout_i42(%arg0: !hw.inout<i42>)
+func.func private @use_ref_i42(%arg0: !llhd.ref<i42>)
 func.func private @use_array_i42(%arg0: !hw.array<4xi42>)
 
 // Regression test that verifies probe is inserted post use.
@@ -1025,7 +1025,7 @@ hw.module @ProbePostDef() {
   %2 = llhd.combinational -> i1 {
     %false = hw.constant false
     %e = llhd.sig %false : i1
-    %4 = llhd.prb %e : !hw.inout<i1>
+    %4 = llhd.prb %e : i1
     llhd.yield %4 : i1
   }
   hw.output
@@ -1048,7 +1048,7 @@ hw.module @DominanceTest1() {
   ^bb1:
     // CHECK-NEXT: ^bb1([[BBARG0:%.+]]: i1)
     // CHECK-NEXT: llhd.wait ([[BBARG0]] : i1), ^bb2
-    %5 = llhd.prb %clock_0 : !hw.inout<i1>
+    %5 = llhd.prb %clock_0 : i1
     llhd.wait (%5 : i1), ^bb3
   ^bb3:
     // CHECK-NEXT: ^bb2:
@@ -1056,8 +1056,8 @@ hw.module @DominanceTest1() {
     // CHECK-NEXT: cf.br ^bb1([[TMP1]] : i1)
     %c0_i4 = hw.constant 0 : i4
     %ready_T = llhd.sig %c0_i4 : i4
-    llhd.drv %ready_T, %c0_i4 after %3 : !hw.inout<i4>
-    %6 = llhd.prb %ready_T : !hw.inout<i4>
+    llhd.drv %ready_T, %c0_i4 after %3 : i4
+    %6 = llhd.prb %ready_T : i4
     cf.br ^bb1
   }
   hw.output
@@ -1074,10 +1074,10 @@ hw.module @DominanceTest2() {
   ^bb1:
     // CHECK-NEXT: ^bb1:
     // CHECK-NEXT: cf.br ^bb2
-    %0 = llhd.prb %b : !hw.inout<i1>
+    %0 = llhd.prb %b : i1
     %1 = llhd.constant_time <0ns, 0d, 1e>
     %g = llhd.sig %false : i1
-    llhd.drv %g, %0 after %1 : !hw.inout<i1>
+    llhd.drv %g, %0 after %1 : i1
     cf.br ^bb2
   ^bb2:
     // CHECK-NEXT: ^bb2
@@ -1096,9 +1096,9 @@ hw.module @ProjectionAndDriveInDifferentBlocks(in %u: !hw.struct<f: i42>, in %v:
   // CHECK: llhd.process
   llhd.process {
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %u after %0 : !hw.inout<struct<f: i42>>
+    llhd.drv %a, %u after %0 : !hw.struct<f: i42>
     // CHECK-NOT: llhd.sig.struct_extract
-    %1 = llhd.sig.struct_extract %a["f"] : !hw.inout<struct<f: i42>>
+    %1 = llhd.sig.struct_extract %a["f"] : <!hw.struct<f: i42>>
     // CHECK-NEXT: cf.br ^bb1
     cf.br ^bb1
   ^bb1:
@@ -1107,7 +1107,7 @@ hw.module @ProjectionAndDriveInDifferentBlocks(in %u: !hw.struct<f: i42>, in %v:
     // CHECK-NEXT: [[EXT:%.+]] = hw.struct_extract %u["f"]
     // CHECK-NEXT: [[MUX:%.+]] = comb.mux %q, %v, [[EXT]]
     // CHECK-NEXT: [[INJ:%.+]] = hw.struct_inject %u["f"], [[MUX]]
-    llhd.drv %1, %v after %0 if %q : !hw.inout<i42>
+    llhd.drv %1, %v after %0 if %q : i42
     // CHECK-NEXT: llhd.constant_time
     // CHECK-NEXT: llhd.drv %a, [[INJ]]
     // CHECK-NEXT: llhd.halt
@@ -1124,13 +1124,13 @@ hw.module @LocalSignals(in %u: i42, in %v: i42) {
     // CHECK-NOT: llhd.sig
     %a = llhd.sig %u : i42
     // CHECK-NOT: llhd.prb
-    %1 = llhd.prb %a : !hw.inout<i42>
+    %1 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%u)
     func.call @use_i42(%1) : (i42) -> ()
     // CHECK-NOT: llhd.drv
-    llhd.drv %a, %v after %0 : !hw.inout<i42>
+    llhd.drv %a, %v after %0 : i42
     // CHECK-NOT: llhd.prb
-    %2 = llhd.prb %a : !hw.inout<i42>
+    %2 = llhd.prb %a : i42
     // CHECK-NEXT: call @use_i42(%v)
     func.call @use_i42(%2) : (i42) -> ()
     // CHECK-NEXT: llhd.halt

--- a/test/Dialect/LLHD/Transforms/sig2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/sig2reg.mlir
@@ -26,31 +26,31 @@ hw.module @basic(in %init : i32, in %cond : i1, in %in0 : i32, in %in1 : i32, ou
   // Not promoted because of multiple drivers
   %sig7 = llhd.sig %init : i32
 
-  llhd.drv %sig1, %in0 after %epsilon : !hw.inout<i32>
+  llhd.drv %sig1, %in0 after %epsilon : i32
   // CHECK: [[DELAY:%.+]] = llhd.delay %in0 by <0ns, 1d, 0e> : i32
-  llhd.drv %sig2, %in0 after %delta : !hw.inout<i32>
-  llhd.drv %sig3, %in0 after %opaque_time : !hw.inout<i32>
+  llhd.drv %sig2, %in0 after %delta : i32
+  llhd.drv %sig3, %in0 after %opaque_time : i32
 
-  llhd.drv %sig5, %in0 after %epsilon if %cond : !hw.inout<i32>
+  llhd.drv %sig5, %in0 after %epsilon if %cond : i32
 
   scf.if %cond {
-    llhd.drv %sig6, %in0 after %epsilon : !hw.inout<i32>
+    llhd.drv %sig6, %in0 after %epsilon : i32
   }
   
-  llhd.drv %sig7, %in0 after %epsilon : !hw.inout<i32>
-  llhd.drv %sig7, %in1 after %delta : !hw.inout<i32>
+  llhd.drv %sig7, %in0 after %epsilon : i32
+  llhd.drv %sig7, %in1 after %delta : i32
 
-  %prb1 = llhd.prb %sig1 : !hw.inout<i32>
-  %prb2 = llhd.prb %sig2 : !hw.inout<i32>
+  %prb1 = llhd.prb %sig1 : i32
+  %prb2 = llhd.prb %sig2 : i32
   // CHECK: [[PRB3:%.+]] = llhd.prb %sig3
-  %prb3 = llhd.prb %sig3 : !hw.inout<i32>
-  %prb4 = llhd.prb %sig4 : !hw.inout<i32>
+  %prb3 = llhd.prb %sig3 : i32
+  %prb4 = llhd.prb %sig4 : i32
   // CHECK: [[PRB5:%.+]] = llhd.prb %sig5
-  %prb5 = llhd.prb %sig5 : !hw.inout<i32>
+  %prb5 = llhd.prb %sig5 : i32
   // CHECK: [[PRB6:%.+]] = llhd.prb %sig6
-  %prb6 = llhd.prb %sig6 : !hw.inout<i32>
+  %prb6 = llhd.prb %sig6 : i32
   // CHECK: [[PRB7:%.+]] = llhd.prb %sig7
-  %prb7 = llhd.prb %sig7 : !hw.inout<i32>
+  %prb7 = llhd.prb %sig7 : i32
 
   // CHECK: hw.output %in0, [[DELAY]], [[PRB3]], %init, [[PRB5]], [[PRB6]], [[PRB7]] :
   hw.output %prb1, %prb2, %prb3, %prb4, %prb5, %prb6, %prb7 : i32, i32, i32, i32, i32, i32, i32
@@ -82,14 +82,14 @@ hw.module @aliasStatic(in %init : i4, in %in0 : i1, in %in1 : i1, out out: i4) {
   %c0_c2 = hw.constant 0 : i2
   %false = hw.constant false
   %out = llhd.sig %init : i4
-  %3 = llhd.sig.extract %out from %c1_c2 : (!hw.inout<i4>) -> !hw.inout<i2>
-  %6 = llhd.sig.extract %3 from %false : (!hw.inout<i2>) -> !hw.inout<i1>
-  %7 = llhd.sig.extract %3 from %true : (!hw.inout<i2>) -> !hw.inout<i1>
-  llhd.drv %6, %in0 after %0 : !hw.inout<i1>
-  llhd.drv %7, %in1 after %0 : !hw.inout<i1>
-  %4 = llhd.sig.extract %out from %c0_c2 : (!hw.inout<i4>) -> !hw.inout<i1>
-  llhd.drv %4, %in1 after %0 : !hw.inout<i1>
-  %5 = llhd.prb %out : !hw.inout<i4>
+  %3 = llhd.sig.extract %out from %c1_c2 : <i4> -> <i2>
+  %6 = llhd.sig.extract %3 from %false : <i2> -> <i1>
+  %7 = llhd.sig.extract %3 from %true : <i2> -> <i1>
+  llhd.drv %6, %in0 after %0 : i1
+  llhd.drv %7, %in1 after %0 : i1
+  %4 = llhd.sig.extract %out from %c0_c2 : <i4> -> <i1>
+  llhd.drv %4, %in1 after %0 : i1
+  %5 = llhd.prb %out : i4
   hw.output %5 : i4
 }
 
@@ -124,14 +124,14 @@ hw.module @aliasDynamicSuccess(in %init : i8, in %in0 : i1, in %in1 : i1, in %id
   %c4_c3 = hw.constant 4 : i3
   %c0_c3 = hw.constant 0 : i3
   %out = llhd.sig %init : i8
-  %3 = llhd.sig.extract %out from %c0_c3 : (!hw.inout<i8>) -> !hw.inout<i4>
-  %4 = llhd.sig.extract %out from %c4_c3 : (!hw.inout<i8>) -> !hw.inout<i4>
-  %5 = llhd.sig.extract %3 from %idx0 : (!hw.inout<i4>) -> !hw.inout<i2>
-  %6 = llhd.sig.extract %5 from %idx1 : (!hw.inout<i2>) -> !hw.inout<i1>
-  %7 = llhd.sig.extract %4 from %idx0 : (!hw.inout<i4>) -> !hw.inout<i1>
-  llhd.drv %6, %in0 after %0 : !hw.inout<i1>
-  llhd.drv %7, %in1 after %0 : !hw.inout<i1>
-  %8 = llhd.prb %out : !hw.inout<i8>
+  %3 = llhd.sig.extract %out from %c0_c3 : <i8> -> <i4>
+  %4 = llhd.sig.extract %out from %c4_c3 : <i8> -> <i4>
+  %5 = llhd.sig.extract %3 from %idx0 : <i4> -> <i2>
+  %6 = llhd.sig.extract %5 from %idx1 : <i2> -> <i1>
+  %7 = llhd.sig.extract %4 from %idx0 : <i4> -> <i1>
+  llhd.drv %6, %in0 after %0 : i1
+  llhd.drv %7, %in1 after %0 : i1
+  %8 = llhd.prb %out : i8
   hw.output %8 : i8
 }
 
@@ -141,30 +141,30 @@ hw.module @aliasDynamicFailure(in %init : i4, in %in0 : i1, in %in1 : i1, in %id
   // CHECK-NEXT: [[C_2_I2:%.+]] = hw.constant -2 : i2
   // CHECK-NEXT: [[C0_I2:%.+]] = hw.constant 0 : i2
   // CHECK-NEXT: [[OUT:%.+]] = llhd.sig %init : i4
-  // CHECK-NEXT: [[V1:%.+]] = llhd.sig.extract [[OUT]] from [[C0_I2]] : (!hw.inout<i4>) -> !hw.inout<i2>
-  // CHECK-NEXT: [[V2:%.+]] = llhd.sig.extract [[OUT]] from [[C_2_I2]] : (!hw.inout<i4>) -> !hw.inout<i2>
-  // CHECK-NEXT: [[V3:%.+]] = llhd.sig.extract [[V1]] from %idx0 : (!hw.inout<i2>) -> !hw.inout<i1>
-  // CHECK-NEXT: [[V4:%.+]] = llhd.sig.extract [[V2]] from %idx0 : (!hw.inout<i2>) -> !hw.inout<i1>
-  // CHECK-NEXT: [[V5:%.+]] = llhd.sig.extract [[V2]] from %idx1 : (!hw.inout<i2>) -> !hw.inout<i1>
-  // CHECK-NEXT: llhd.drv [[V3]], %in0 after [[TIME]] : !hw.inout<i1>
-  // CHECK-NEXT: llhd.drv [[V4]], %in1 after [[TIME]] : !hw.inout<i1>
-  // CHECK-NEXT: llhd.drv [[V5]], %in0 after [[TIME]] : !hw.inout<i1>
-  // CHECK-NEXT: [[V6:%.+]] = llhd.prb [[OUT]] : !hw.inout<i4>
+  // CHECK-NEXT: [[V1:%.+]] = llhd.sig.extract [[OUT]] from [[C0_I2]] : <i4> -> <i2>
+  // CHECK-NEXT: [[V2:%.+]] = llhd.sig.extract [[OUT]] from [[C_2_I2]] : <i4> -> <i2>
+  // CHECK-NEXT: [[V3:%.+]] = llhd.sig.extract [[V1]] from %idx0 : <i2> -> <i1>
+  // CHECK-NEXT: [[V4:%.+]] = llhd.sig.extract [[V2]] from %idx0 : <i2> -> <i1>
+  // CHECK-NEXT: [[V5:%.+]] = llhd.sig.extract [[V2]] from %idx1 : <i2> -> <i1>
+  // CHECK-NEXT: llhd.drv [[V3]], %in0 after [[TIME]] : i1
+  // CHECK-NEXT: llhd.drv [[V4]], %in1 after [[TIME]] : i1
+  // CHECK-NEXT: llhd.drv [[V5]], %in0 after [[TIME]] : i1
+  // CHECK-NEXT: [[V6:%.+]] = llhd.prb [[OUT]] : i4
   // CHECK-NEXT: hw.output [[V6]] : i4
 
   %0 = llhd.constant_time <0ns, 0d, 1e>
   %c2_c2 = hw.constant 2 : i2
   %c0_c2 = hw.constant 0 : i2
   %out = llhd.sig %init : i4
-  %3 = llhd.sig.extract %out from %c0_c2 : (!hw.inout<i4>) -> !hw.inout<i2>
-  %4 = llhd.sig.extract %out from %c2_c2 : (!hw.inout<i4>) -> !hw.inout<i2>
-  %5 = llhd.sig.extract %3 from %idx0 : (!hw.inout<i2>) -> !hw.inout<i1>
-  %6 = llhd.sig.extract %4 from %idx0 : (!hw.inout<i2>) -> !hw.inout<i1>
-  %7 = llhd.sig.extract %4 from %idx1 : (!hw.inout<i2>) -> !hw.inout<i1>
-  llhd.drv %5, %in0 after %0 : !hw.inout<i1>
-  llhd.drv %6, %in1 after %0 : !hw.inout<i1>
-  llhd.drv %7, %in0 after %0 : !hw.inout<i1>
-  %8 = llhd.prb %out : !hw.inout<i4>
+  %3 = llhd.sig.extract %out from %c0_c2 : <i4> -> <i2>
+  %4 = llhd.sig.extract %out from %c2_c2 : <i4> -> <i2>
+  %5 = llhd.sig.extract %3 from %idx0 : <i2> -> <i1>
+  %6 = llhd.sig.extract %4 from %idx0 : <i2> -> <i1>
+  %7 = llhd.sig.extract %4 from %idx1 : <i2> -> <i1>
+  llhd.drv %5, %in0 after %0 : i1
+  llhd.drv %6, %in1 after %0 : i1
+  llhd.drv %7, %in0 after %0 : i1
+  %8 = llhd.prb %out : i4
   hw.output %8 : i4
 }
 
@@ -176,7 +176,7 @@ hw.module @RemoveDriveOnlySignals(in %d: i42, in %e: i1) {
   %a = llhd.sig %0 : i42
   %b = llhd.sig %0 : i42
   // CHECK-NOT: llhd.drv
-  llhd.drv %a, %d after %1 : !hw.inout<i42>
-  llhd.drv %b, %d after %1 if %e : !hw.inout<i42>
+  llhd.drv %a, %d after %1 : i42
+  llhd.drv %b, %d after %1 if %e : i42
   // CHECK: hw.output
 }

--- a/test/Dialect/LLHD/Transforms/sroa.mlir
+++ b/test/Dialect/LLHD/Transforms/sroa.mlir
@@ -15,15 +15,15 @@ hw.module @struct(in %init : !hw.struct<a: i32, b: i32>, in %v1 : i32, in %v2 : 
   // CHECK-NEXT: [[V4:%.+]] = llhd.prb [[V1]]
   // CHECK-NEXT: [[V5:%.+]] = llhd.prb [[V3]]
   // CHECK-NEXT: [[V6:%.+]] = hw.struct_create ([[V4]], [[V5]]) : !hw.struct<a: i32, b: i32>
-  %prb = llhd.prb %sig : !hw.inout<!hw.struct<a: i32, b: i32>>
+  %prb = llhd.prb %sig : !hw.struct<a: i32, b: i32>
 
-  %a = llhd.sig.struct_extract %sig["a"] : !hw.inout<!hw.struct<a: i32, b: i32>>
-  %b = llhd.sig.struct_extract %sig["b"] : !hw.inout<!hw.struct<a: i32, b: i32>>
+  %a = llhd.sig.struct_extract %sig["a"] : !llhd.ref<!hw.struct<a: i32, b: i32>>
+  %b = llhd.sig.struct_extract %sig["b"] : !llhd.ref<!hw.struct<a: i32, b: i32>>
 
   // CHECK-NEXT: llhd.drv [[V1]], %v1 after
   // CHECK-NEXT: llhd.drv [[V3]], %v2 after
-  llhd.drv %a, %v1 after %time : !hw.inout<i32>
-  llhd.drv %b, %v2 after %time : !hw.inout<i32>
+  llhd.drv %a, %v1 after %time : i32
+  llhd.drv %b, %v2 after %time : i32
 
   // CHECK-NEXT: [[V7:%.+]] = hw.struct_extract %init["a"] : !hw.struct<a: i32, b: i32>
   // CHECK-NEXT: [[V8:%.+]] = llhd.sig{{ }}
@@ -36,13 +36,13 @@ hw.module @struct(in %init : !hw.struct<a: i32, b: i32>, in %v1 : i32, in %v2 : 
   // CHECK-NEXT: [[V11:%.+]] = llhd.prb [[V8]]
   // CHECK-NEXT: [[V12:%.+]] = llhd.prb [[V10]]
   // CHECK-NEXT: [[V13:%.+]] = hw.struct_create ([[V11]], [[V12]]) : !hw.struct<a: i32, b: i32>
-  %prb2 = llhd.prb %sig2 : !hw.inout<!hw.struct<a: i32, b: i32>>
+  %prb2 = llhd.prb %sig2 : !hw.struct<a: i32, b: i32>
 
   //      CHECK: [[V14:%.+]] = hw.struct_extract %init["a"]
   // CHECK-NEXT: llhd.drv [[V8]], [[V14]] after
   //      CHECK: [[V15:%.+]] = hw.struct_extract %init["b"]
   // CHECK-NEXT: llhd.drv [[V10]], [[V15]] after
-  llhd.drv %sig2, %init after %time : !hw.inout<!hw.struct<a: i32, b: i32>>
+  llhd.drv %sig2, %init after %time : !hw.struct<a: i32, b: i32>
 
   // CHECK-NEXT: hw.output [[V6]], [[V13]] : !hw.struct<a: i32, b: i32>, !hw.struct<a: i32, b: i32>
   hw.output %prb, %prb2 : !hw.struct<a: i32, b: i32>, !hw.struct<a: i32, b: i32>
@@ -65,15 +65,15 @@ hw.module @array(in %init : !hw.array<2xi32>, in %v1 : i32, in %v2 : i32, out ou
   // CHECK-NEXT: [[V4:%.+]] = llhd.prb [[V1]]
   // CHECK-NEXT: [[V5:%.+]] = llhd.prb [[V3]]
   // CHECK-NEXT: [[V6:%.+]] = hw.array_create [[V4]], [[V5]] : i32
-  %prb = llhd.prb %sig : !hw.inout<!hw.array<2xi32>>
+  %prb = llhd.prb %sig : !hw.array<2xi32>
 
-  %a = llhd.sig.array_get %sig[%false] : !hw.inout<!hw.array<2xi32>>
-  %b = llhd.sig.array_get %sig[%true] : !hw.inout<!hw.array<2xi32>>
+  %a = llhd.sig.array_get %sig[%false] : !llhd.ref<!hw.array<2xi32>>
+  %b = llhd.sig.array_get %sig[%true] : !llhd.ref<!hw.array<2xi32>>
 
   // CHECK-NEXT: llhd.drv [[V1]], %v1 after
   // CHECK-NEXT: llhd.drv [[V3]], %v2 after
-  llhd.drv %a, %v1 after %time : !hw.inout<i32>
-  llhd.drv %b, %v2 after %time : !hw.inout<i32>
+  llhd.drv %a, %v1 after %time : i32
+  llhd.drv %b, %v2 after %time : i32
 
   //      CHECK: [[V7:%.+]] = hw.array_get %init[%false
   // CHECK-NEXT: [[V8:%.+]] = llhd.sig
@@ -86,13 +86,13 @@ hw.module @array(in %init : !hw.array<2xi32>, in %v1 : i32, in %v2 : i32, out ou
   // CHECK-NEXT: [[V11:%.+]] = llhd.prb [[V8]]
   // CHECK-NEXT: [[V12:%.+]] = llhd.prb [[V10]]
   // CHECK-NEXT: [[V13:%.+]] = hw.array_create [[V11]], [[V12]] : i32
-  %prb2 = llhd.prb %sig2 : !hw.inout<!hw.array<2xi32>>
+  %prb2 = llhd.prb %sig2 : !hw.array<2xi32>
 
   //      CHECK: [[V14:%.+]] = hw.array_get %init[%false
   // CHECK-NEXT: llhd.drv [[V8]], [[V14]] after
   //      CHECK: [[V15:%.+]] = hw.array_get %init[%true
   // CHECK-NEXT: llhd.drv [[V10]], [[V15]] after
-  llhd.drv %sig2, %init after %time : !hw.inout<!hw.array<2xi32>>
+  llhd.drv %sig2, %init after %time : !hw.array<2xi32>
 
   // CHECK-NEXT: hw.output [[V6]], [[V13]] : !hw.array<2xi32>, !hw.array<2xi32>
   hw.output %prb, %prb2 : !hw.array<2xi32>, !hw.array<2xi32>
@@ -112,11 +112,11 @@ hw.module @arrayDynamicAccess(in %init : !hw.array<2xi32>, in %v1 : i32, in %idx
   // CHECK-NEXT: llhd.drv [[V3]], %v1 after
   // CHECK-NEXT: hw.output [[V1]]
   %sig = llhd.sig %init : !hw.array<2xi32>
-  %prb = llhd.prb %sig : !hw.inout<!hw.array<2xi32>>
-  %a = llhd.sig.array_get %sig[%false] : !hw.inout<!hw.array<2xi32>>
-  %b = llhd.sig.array_get %sig[%idx] : !hw.inout<!hw.array<2xi32>>
-  llhd.drv %a, %v1 after %time : !hw.inout<i32>
-  llhd.drv %b, %v1 after %time : !hw.inout<i32>
+  %prb = llhd.prb %sig : !hw.array<2xi32>
+  %a = llhd.sig.array_get %sig[%false] : !llhd.ref<!hw.array<2xi32>>
+  %b = llhd.sig.array_get %sig[%idx] : !llhd.ref<!hw.array<2xi32>>
+  llhd.drv %a, %v1 after %time : i32
+  llhd.drv %b, %v1 after %time : i32
 
   hw.output %prb : !hw.array<2xi32>
 }
@@ -148,7 +148,7 @@ hw.module @nested(in %init : !hw.array<2x!hw.struct<a: i32, b: i32>>, out out : 
   // CHECK: [[V14:%.+]] = llhd.prb [[V9]]
   // CHECK: [[V15:%.+]] = hw.struct_create ([[V13]], [[V14]]) : !hw.struct<a: i32, b: i32>
   // CHECK: [[V16:%.+]] = hw.array_create [[V12]], [[V15]] :
-  %0 = llhd.prb %sig : !hw.inout<!hw.array<2x!hw.struct<a: i32, b: i32>>>
+  %0 = llhd.prb %sig : !hw.array<2x!hw.struct<a: i32, b: i32>>
 
   // CHECK: [[V17:%.+]] = hw.array_get %init[%false
   // CHECK: [[V18:%.+]] = hw.struct_extract [[V17]]["a"]
@@ -160,7 +160,7 @@ hw.module @nested(in %init : !hw.array<2x!hw.struct<a: i32, b: i32>>, out out : 
   // CHECK: llhd.drv [[V7]], [[V21]] after
   // CHECK: [[V22:%.+]] = hw.struct_extract [[V20]]["b"]
   // CHECK: llhd.drv [[V9]], [[V22]] after
-  llhd.drv %sig, %init after %time : !hw.inout<!hw.array<2x!hw.struct<a: i32, b: i32>>>
+  llhd.drv %sig, %init after %time : !hw.array<2x!hw.struct<a: i32, b: i32>>
 
   // CHECK: hw.output [[V16]] : !hw.array<2xstruct<a: i32, b: i32>>
   hw.output %0 : !hw.array<2x!hw.struct<a: i32, b: i32>>


### PR DESCRIPTION
Add a `RefType` to the LLHD dialect and replace all uses of HW's `InOutType` across the LLHD dialect and the ImportVerilog pipeline. We have been abusing the inout type to mean "signal/variable reference", which becomes problematic if we are trying to place `!llhd.time` or `!llvm.ptr` values behind such a reference. (The HW inout type requires the inner type to be a plain hardware value.)

This change now allows the circt-verilog frontend to generate variables with the `time` type and treat them just like any other type.

Most of the changes here are just systematic name replacements. I have also removed a few `qualified(...)` wrappers around types and made sure that when an op is known to accept or return a ref type, the printer would just print `<T>` instead of `!llhd.ref<T>`. This is the default behavior for unambiguous types, but sometimes this gets lost when explicitly askign for qualified types, or using `functional-type`.