### PR TITLE
[ImportVerilog] Add delayed assignment support

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -337,6 +337,16 @@ class AssignOpBase<string mnemonic, list<Trait> traits = []> :
   }];
 }
 
+class DelayedAssignOpBase<string mnemonic, list<Trait> traits = []> :
+    AssignOpBase<mnemonic, traits> {
+  let arguments = (ins RefType:$dst, UnpackedType:$src, TimeType:$delay);
+  let assemblyFormat = [{
+    $dst `,` $src `,` $delay attr-dict `:` type($src)
+  }];
+}
+
+// Continuous assignment
+
 def ContinuousAssignOp : AssignOpBase<"assign", [HasParent<"SVModuleOp">]> {
   let summary = "Continuous assignment within a module";
   let description = [{
@@ -347,6 +357,19 @@ def ContinuousAssignOp : AssignOpBase<"assign", [HasParent<"SVModuleOp">]> {
     See IEEE 1800-2017 § 10.3 "Continuous assignments".
   }];
 }
+
+def DelayedContinuousAssignOp :
+    DelayedAssignOpBase<"delayed_assign", [HasParent<"SVModuleOp">]> {
+  let summary = "Delayed continuous assignment within a module";
+  let description = [{
+    A continuous assignment with a delay.
+
+    See the `moore.assign` op.
+    See IEEE 1800-2017 § 10.3 "Continuous assignments".
+  }];
+}
+
+// Blocking assignment
 
 def BlockingAssignOp : AssignOpBase<"blocking_assign", [
   DeclareOpInterfaceMethods<PromotableMemOpInterface>
@@ -365,6 +388,8 @@ def BlockingAssignOp : AssignOpBase<"blocking_assign", [
   );
 }
 
+// Non-blocking assignment
+
 def NonBlockingAssignOp : AssignOpBase<"nonblocking_assign"> {
   let summary = "Nonblocking procedural assignment";
   let description = [{
@@ -375,6 +400,17 @@ def NonBlockingAssignOp : AssignOpBase<"nonblocking_assign"> {
     in a subsequent time step as dictated by the delay or event control.
 
     See IEEE 1800-2017 § 10.4.2 "Nonblocking procedural assignments".
+  }];
+}
+
+def DelayedNonBlockingAssignOp :
+    DelayedAssignOpBase<"delayed_nonblocking_assign"> {
+  let summary = "Delayed nonblocking procedural assignment";
+  let description = [{
+    A nonblocking procedural assignment with an intra-assignment delay control.
+
+    See the `moore.nonblocking_assign` op.
+    See IEEE 1800-2017 § 9.4.5 "Intra-assignment timing controls".
   }];
 }
 

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -134,7 +134,14 @@ struct Context {
                             const slang::ast::Symbol &outermostModule);
   LogicalResult traverseInstanceBody(const slang::ast::Symbol &symbol);
 
-  // Convert a slang timing control into an MLIR timing control.
+  // Convert timing controls into a corresponding set of ops that delay
+  // execution of the current block. Produces an error if the implicit event
+  // control `@*` or `@(*)` is used.
+  LogicalResult convertTimingControl(const slang::ast::TimingControl &ctrl);
+  // Convert timing controls into a corresponding set of ops that delay
+  // execution of the current block. Then converts the given statement, taking
+  // note of the rvalues it reads and adding them to a wait op in case an
+  // implicit event control `@*` or `@(*)` is used.
   LogicalResult convertTimingControl(const slang::ast::TimingControl &ctrl,
                                      const slang::ast::Statement &stmt);
 

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -41,15 +41,16 @@ endmodule
 // -----
 module Foo;
   int x;
-  // expected-error @below {{delayed assignments not supported}}
-  initial x <= #1ns x;
+  bit y;
+  // expected-error @below {{unsupported non-blocking assignment timing control: SignalEvent}}
+  initial x <= @y x;
 endmodule
 
 // -----
 module Foo;
   int x;
-  // expected-error @below {{delayed continuous assignments not supported}}
-  assign #1ns x = x;
+  // expected-error @below {{implicit events cannot be used here}}
+  initial x = @* x;
 endmodule
 
 // -----

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1305,3 +1305,28 @@ moore.module @MultiDimensionalSlice(in %in : !moore.array<2 x array<2 x l2>>, ou
   %0 = moore.extract %in from 0 : array<2 x array<2 x l2>> -> array<2 x l2>
   moore.output %0 : !moore.array<2 x l2>
 }
+
+// CHECK-LABEL: hw.module @ContinuousAssignment
+// CHECK-SAME: in %a : !llhd.ref<i42>
+// CHECK-SAME: in %b : i42
+// CHECK-SAME: in %c : !llhd.time
+moore.module @ContinuousAssignment(in %a: !moore.ref<i42>, in %b: !moore.i42, in %c: !moore.time) {
+  // CHECK-NEXT: [[DELTA:%.+]] = llhd.constant_time <0ns, 0d, 1e>
+  // CHECK-NEXT: llhd.drv %a, %b after [[DELTA]]
+  moore.assign %a, %b : i42
+  // CHECK-NEXT: llhd.drv %a, %b after %c
+  moore.delayed_assign %a, %b, %c : i42
+}
+
+// CHECK-LABEL: func.func @NonBlockingAssignment
+// CHECK-SAME: %arg0: !llhd.ref<i42>
+// CHECK-SAME: %arg1: i42
+// CHECK-SAME: %arg2: !llhd.time
+func.func @NonBlockingAssignment(%arg0: !moore.ref<i42>, %arg1: !moore.i42, %arg2: !moore.time) {
+  // CHECK-NEXT: [[DELTA:%.+]] = llhd.constant_time <0ns, 1d, 0e>
+  // CHECK-NEXT: llhd.drv %arg0, %arg1 after [[DELTA]]
+  moore.nonblocking_assign %arg0, %arg1 : i42
+  // CHECK-NEXT: llhd.drv %arg0, %arg1 after %arg2
+  moore.delayed_nonblocking_assign %arg0, %arg1, %arg2 : i42
+  return
+}

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -90,18 +90,37 @@ moore.module @Module() {
   moore.assign %v1, %2 : i1
 
   moore.procedure always {
-    // CHECK: %[[TMP1:.+]] = moore.read %v2
-    // CHECK: moore.blocking_assign %v1, %[[TMP1]] : i1
-    %3 = moore.read %v2 : <i1>
-    moore.blocking_assign %v1, %3 : i1
-    // CHECK: %[[TMP2:.+]] = moore.read %v2
-    // CHECK: moore.nonblocking_assign %v1, %[[TMP2]] : i1
-    %4 = moore.read %v2 : <i1>
-    moore.nonblocking_assign %v1, %4 : i1
     // CHECK: %a = moore.variable : <i32>
     %a = moore.variable : <i32>
     moore.return
   }
+}
+
+// CHECK-LABEL: moore.module @ContinuousAssignments
+moore.module @ContinuousAssignments(
+  in %arg0: !moore.ref<i42>,
+  in %arg1: !moore.i42,
+  in %arg2: !moore.time
+) {
+  // CHECK: moore.assign %arg0, %arg1 : i42
+  moore.assign %arg0, %arg1 : i42
+  // CHECK: moore.delayed_assign %arg0, %arg1, %arg2 : i42
+  moore.delayed_assign %arg0, %arg1, %arg2 : i42
+}
+
+// CHECK-LABEL: func.func @ProceduralAssignments
+func.func @ProceduralAssignments(
+  %arg0: !moore.ref<i42>,
+  %arg1: !moore.i42,
+  %arg2: !moore.time
+) {
+  // CHECK: moore.blocking_assign %arg0, %arg1 : i42
+  moore.blocking_assign %arg0, %arg1 : i42
+  // CHECK: moore.nonblocking_assign %arg0, %arg1 : i42
+  moore.nonblocking_assign %arg0, %arg1 : i42
+  // CHECK: moore.delayed_nonblocking_assign %arg0, %arg1, %arg2 : i42
+  moore.delayed_nonblocking_assign %arg0, %arg1, %arg2 : i42
+  return
 }
 
 // CHECK-LABEL: moore.module @Expressions


### PR DESCRIPTION
Add the `moore.delayed_assign` and `moore.delayed_nonblocking_assign` ops to represent `assign #1ns a = b` and `a <= #1ns b` in SystemVerilog, respectively.

Lower the new delay ops to `llhd.drv` with the appropriate delay value.

Add support for blocking assignments with intra-assignment timing control to the ImportVerilog conversion. These are pretty trivial, since the blocking effects of the timing control are simply inserted in between computing the right-hand side and assigning to the left-hand side.

Also add support for non-blocking assignments with intra-assignment delays. These require the new `moore.delayed_nonblocking_assign`, since the operation cannot suspend execution of the surrounding process. Instead, the assignment has to be added to the event queue and executed at a later point in time. Theoretically, the user could type wild things here, like `a <= repeat(5) @(posedge b or negedge c) d`, which would require us to spawn a separate "thread" to determine when all the events have occurred and the assignment can take place. We don't support any of that for now, because this is just utterly deranged.

Also add support for delayed continuous assignments. This is pretty trivial since SystemVerilog only allows for simple delay values, such as `assign #1ns a = b`. This requires the new `moore.delayed_assign` op.