### PR TITLE
[FIRRTL] Add fields to domains

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -209,4 +209,19 @@ def InternalPathArrayAttr
 
 def LayerArrayAttr : TypedArrayRefAttrBase<SymbolRefAttr, "an array of layers">;
 
+def DomainFieldAttr : AttrDef<FIRRTLDialect, "DomainField"> {
+  let mnemonic = "domain.field";
+  let summary = "A single field of a domain";
+  let parameters = (
+    ins "::mlir::StringAttr":$name,
+        "::mlir::TypeAttr":$type
+  );
+  let assemblyFormat = [{
+    `<` $name `,` $type `>`
+  }];
+}
+
+def DomainFieldArrayAttr :
+  TypedArrayAttrBase<DomainFieldAttr, "an array of domain fields">;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -614,11 +614,14 @@ def DomainOp : FIRRTLOp<"domain", [
     circuit.  E.g., this can be used to declare a `ClockDomain` type when
     modeling clocks in FIRRTL Dialect.
   }];
-  let arguments = (ins SymbolNameAttr:$sym_name);
+  let arguments = (
+    ins SymbolNameAttr:$sym_name,
+        DefaultValuedAttr<DomainFieldArrayAttr, "{}">:$fields
+  );
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{
-    $sym_name attr-dict-with-keyword $body
+    $sym_name ( $fields^ )? attr-dict-with-keyword $body
   }];
 }
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -644,6 +644,13 @@ void Emitter::emitDeclaration(DomainOp op) {
   startStatement();
   ps << "domain " << PPExtString(op.getSymName()) << " :";
   emitLocationAndNewLine(op);
+  ps.scopedBox(PP::bbox2, [&]() {
+    for (auto attr : op.getFields()) {
+      auto fieldAttr = cast<DomainFieldAttr>(attr);
+      ps << PP::newline << PPExtString(fieldAttr.getName()) << " : ";
+      emitType(fieldAttr.getType().getValue());
+    }
+  });
 }
 
 /// Emit a layer definition.

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -958,6 +958,16 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: domain ClockDomain :
   firrtl.domain @ClockDomain {}
 
+  // CHECK-LABEL: domain PowerDomain :
+  // CHECK-NEXT:    name : String
+  // CHECK-NEXT:    voltage : Integer
+  // CHECk-NEXT:    alwaysOn : Bool
+  firrtl.domain @PowerDomain [
+    #firrtl.domain.field<"name", !firrtl.string>,
+    #firrtl.domain.field<"voltage", !firrtl.integer>,
+    #firrtl.domain.field<"alwaysOn", !firrtl.bool>
+  ] {}
+
   // CHECK-LABEL: module Domains :
   firrtl.module @Domains(
     // CHECK-NEXT: input A : Domain of ClockDomain

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2195,8 +2195,18 @@ circuit NullaryCat:
 ;// -----
 FIRRTL version 5.1.0
 circuit Domains:
-  ; CHECK-LABEL: firrtl.domain @ClockDomain
+  ; CHECK-LABEL: firrtl.domain @ClockDomain {
   domain ClockDomain:
+
+  ; CHECK-LABEL: firrtl.domain @PowerDomain [
+  ; CHECK-SAME:    #firrtl.domain.field<"name", !firrtl.string>
+  ; CHECK-SAME:    #firrtl.domain.field<"voltage", !firrtl.integer>
+  ; CHECK-SAME:    #firrtl.domain.field<"alwaysOn", !firrtl.bool>
+  ; CHECK-SAME:  ] {
+  domain PowerDomain:
+    name : String
+    voltage : Integer
+    alwaysOn : Bool
 
   module Foo:
     input A: Domain of ClockDomain

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -196,9 +196,20 @@ firrtl.module @Fprintf(
   firrtl.fprintf %clock, %a, "test%d.txt"(%a), "%x, %b"(%a, %reset) {name = "foo"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
 }
 
-// CHECK-LABEL: firrtl.domain @ClockDomain
+// CHECK-LABEL: firrtl.domain @ClockDomain {
 firrtl.domain @ClockDomain {
 }
+
+// CHECK-LABEL: firrtl.domain @PowerDomain [
+// CHECK-SAME:    #firrtl.domain.field<"name", !firrtl.string>
+// CHECK-SAME:    #firrtl.domain.field<"voltage", !firrtl.integer>
+// CHECK-SAME:    #firrtl.domain.field<"alwaysOn", !firrtl.bool>
+// CHECK-SAME:  ] {
+firrtl.domain @PowerDomain [
+  #firrtl.domain.field<"name", !firrtl.string>,
+  #firrtl.domain.field<"voltage", !firrtl.integer>,
+  #firrtl.domain.field<"alwaysOn", !firrtl.bool>
+] {}
 
 firrtl.module @DomainsSubmodule(
   in %A: !firrtl.domain of @ClockDomain,


### PR DESCRIPTION
Extend domains to allow for them to contain fields.  These fields provide
a schema of information that all domains of certain kind must have.  This
models information that a user must provide for an input domain or is
provided for an output domain.

Opt for a "struct-like" representation as opposed to using input/output
ports like FIRRTL classes.  That said, these are intended to be lowered to
classes in a future patch.
