### PR TITLE
[ImportVerilog][Moore] Add real-to-int & int-to-real operators

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -703,6 +703,37 @@ def LogicToTimeOp : MooreOp<"logic_to_time", [Pure]> {
   let hasFolder = 1;
 }
 
+def RealToIntOp : MooreOp<"real_to_int", [
+  Pure
+]> {
+  let summary = "Convert a real value to a two-valued integer";
+  let description = [{
+    See IEEE 1800-2023 Section 6.24.1: "Cast operator" and 6.12:
+    "Real, shortreal and realtime data types". Accordingly,
+    output values are rounded.
+  }];
+  let arguments = (ins RealType:$input);
+  let results = (outs TwoValuedIntType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result)
+  }];
+}
+
+def IntToRealOp : MooreOp<"int_to_real", [
+  Pure
+]> {
+  let summary = "Convert an integer value to a real";
+  let description = [{
+    See IEEE 1800-2023 Section 6.24.1: "Cast operator" and 6.12:
+    "Real, shortreal and realtime data types".
+  }];
+  let arguments = (ins TwoValuedIntType:$input);
+  let results = (outs RealType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result)
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Resizing
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3308,3 +3308,39 @@ task NonBlockingAssignment(
   // CHECK-NEXT: moore.delayed_nonblocking_assign [[A]], [[NOTB]], [[TIME]]
   a <= #1ns ~b;
 endtask
+
+// CHECK-LABEL: func.func private @RealConversion(
+// CHECK-SAME: [[SR:%[^,]+]]: !moore.f32
+// CHECK-SAME: [[LR:%[^,]+]]: !moore.f64
+// CHECK-SAME: [[INT:%[^,]+]]: !moore.i42
+// CHECK-SAME: [[LINT:%[^,]+]]: !moore.i64
+function automatic void RealConversion(shortreal sr, real r, bit[41:0] i, longint longi);
+   // CHECK: [[INTTEST:%.+]] = moore.real_to_int [[SR]] : f32 -> i32
+   int intTest = int'(sr);
+    // CHECK: [[INTTEST2:%.+]] = moore.real_to_int [[LR]] : f64 -> i32
+   int intTest2 = int'(r);
+   // CHECK: [[LINTTEST:%.+]] = moore.real_to_int [[SR]] : f32 -> i64
+   longint longIntTest = longint'(sr);
+   // CHECK: [[LINTTEST2:%.+]] = moore.real_to_int [[LR]] : f64 -> i64
+   longint longIntTest2 = longint'(r);
+
+
+   // CHECK: [[SRTEST:%.+]] = moore.int_to_real [[INT]] : i42 -> f32
+   shortreal srTest = shortreal'(i);
+   // CHECK: [[SRTEST2:%.+]] = moore.int_to_real [[LINT]] : i64 -> f32
+   shortreal srTest2 = shortreal'(longi);
+   // CHECK: [[RTEST:%.+]] = moore.int_to_real [[INT]] : i42 -> f64
+   real rTest = real'(i);
+   // CHECK: [[RTEST2:%.+]] = moore.int_to_real [[LINT]] : i64 -> f64
+   real rTest2 = real'(longi);
+
+   // CHECK: [[IMM:%.+]] = moore.real_to_int [[LR]] : f64 -> i32
+   // CHECK-NEXT: [[F:%.+]] = moore.int_to_logic [[IMM]] : i32
+   // CHECK-NEXT: [[logicTest:%.+]] = moore.variable [[F]] : <l32>
+   logic [31:0] logicTest = r;
+
+   // CHECK: [[R:%.+]] = moore.read [[logicTest]] : <l32>
+   // CHECK-NEXT: [[IMM2:%.+]] = moore.logic_to_int [[R]] : l32
+   // CHECK-Next: [[F2:%.+]] = moore.int_to_real [[IMM2]] : i32 -> f64
+   real realTest = real'(logicTest);
+endfunction

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -92,7 +92,7 @@ function void DisplayAndSeverityBuiltins(int x, real r);
 
   // CHECK: moore.fmt.real float [[R]]
   $write("%f", r);
-  // CHECK: [[XR:%.+]] = moore.conversion [[X]] : !moore.i32 -> !moore.f64
+  // CHECK: [[XR:%.+]] = moore.int_to_real [[X]] : i32 -> f64
   // CHECK: [[TMP:%.+]] = moore.fmt.real float [[XR]]
   // CHECK: moore.builtin.display [[TMP]]
   $write("%f", x);

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -468,3 +468,21 @@ func.func @TimeConversion(%arg0: !moore.time, %arg1: !moore.l64) {
   moore.logic_to_time %arg1
   return
 }
+
+// CHECK-LABEL: func.func @RealConversion32(%arg0: !moore.f32, %arg1: !moore.i42)
+func.func @RealConversion32(%arg0: !moore.f32, %arg1: !moore.i42) {
+  // CHECK: %0 = moore.real_to_int %arg0 : f32 -> i42
+  %0 = moore.real_to_int %arg0 : f32 -> i42
+  // CHECK: %1 = moore.int_to_real %arg1 : i42 -> f32
+  %1 = moore.int_to_real %arg1 : i42 -> f32
+  return
+}
+
+// CHECK-LABEL: func.func @RealConversion64(%arg0: !moore.f64, %arg1: !moore.i42)
+func.func @RealConversion64(%arg0: !moore.f64, %arg1: !moore.i42) {
+  // CHECK: %0 = moore.real_to_int %arg0 : f64 -> i42
+  %0 = moore.real_to_int %arg0 : f64 -> i42
+  // CHECK: %1 = moore.int_to_real %arg1 : i42 -> f64
+  %1 = moore.int_to_real %arg1 : i42 -> f64
+  return
+}


### PR DESCRIPTION
This commit introduces explicit conversion operations between real and integer types in the Moore dialect, following IEEE 1800-2023 §6.24.1 *Cast operator* and §6.12 *Real, shortreal and realtime data types*. It also extends VerilogImport to recognize and materialize these conversions during AST translation.

- **Dialect (`MooreOps.td`)**
  - Added `RealToIntOp` for rounding real/shortreal values to two-valued integers.
  - Added `IntToRealOp` for widening integer values to real/shortreal.
  - Both ops marked `Pure` with explicit assembly formats.

- **Import logic (`Expressions.cpp`)**
  - Added conversion handling in `Context::materializeConversion`:
    - `RealType` -> `IntType` -> `RealToIntOp`
    - `IntType` -> `RealType` -> `IntToRealOp`

- **Tests**
  - **SystemVerilog import**
    - Added `basic.sv` tests verifying correct lowering of `real'(expr)` and `int'(expr)` casts for all real/int width combinations (`f32/i32`, `f64/i64`).
    - Updated `builtins.sv` to expect `moore.int_to_real` instead of a generic `conversion` op.
  - **Dialect MLIR**
    - Added `basic.mlir` tests ensuring proper parsing/printing and type mapping for 32- and 64-bit conversions.