### PR TITLE
[ImportVerilog] Generalize materialization of constant real values

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -584,7 +584,7 @@ def RealLiteralOp : MooreOp<"real_constant", [Pure]> {
     See IEEE 1800-2017 § 5.7.2 "Real literal constants".
   }];
   let arguments = (ins F64Attr:$value);
-  let results = (outs RealF64:$result);
+  let results = (outs RealType:$result);
   let assemblyFormat = "$value attr-dict `:` type($result)";
 }
 

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -173,6 +173,10 @@ struct Context {
   Value materializeSVInt(const slang::SVInt &svint,
                          const slang::ast::Type &type, Location loc);
 
+  /// Helper function to materialize a real value as an SSA value.
+  Value materializeSVReal(const slang::ConstantValue &svreal,
+                          const slang::ast::Type &type, Location loc);
+
   /// Helper function to materialize an unpacked array of `SVInt`s as an SSA
   /// value.
   Value materializeFixedSizeUnpackedArrayType(

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3344,3 +3344,19 @@ function automatic void RealConversion(shortreal sr, real r, bit[41:0] i, longin
    // CHECK-Next: [[F2:%.+]] = moore.int_to_real [[IMM2]] : i32 -> f64
    real realTest = real'(logicTest);
 endfunction
+
+// CHECK: func.func private @testRealLiteral() -> !moore.f64 {
+function automatic real testRealLiteral();
+   // CHECK: [[TMP:%.+]] = moore.real_constant 1.234500e+00 : f64
+   localparam test = 1.2345;
+    // CHECK-NEXT: return [[TMP]] : !moore.f64
+   return test;
+endfunction
+
+// CHECK: func.func private @testShortrealLiteral() -> !moore.f32 {
+function automatic shortreal testShortrealLiteral();
+   // CHECK: [[TMP:%.+]] = moore.real_constant 1.2345000505447388 : f32
+   localparam test = shortreal'(1.2345);
+    // CHECK-NEXT: return [[TMP]] : !moore.f32
+   return test;
+endfunction


### PR DESCRIPTION
This patch teaches the ImportVerilog conversion to correctly lower SystemVerilog
real and shortreal constant values into `moore.real_constant` operations.

* **MooreOps.td**
  - Relax `RealLiteralOp` result type from fixed `RealF64` to generic
    `RealType` to support both 32-bit and 64-bit real kinds.

* **ImportVerilog/Expressions.cpp**
  - Add `Context::materializeSVReal()` helper to construct `RealLiteralOp`s from
    `slang::ConstantValue` reals.
  - Replace direct creation of an F64 literal with a call to the new helper.
  - Hook `materializeConstant()` to handle `ConstantValue::isReal()` and
    `isShortReal()`.

* **ImportVerilogInternals.h**
  - Declare `materializeSVReal()` alongside `materializeSVInt()`.

* **Tests**
  - Add `testRealLiteral` and `testShortrealLiteral` functions to verify that
    real and shortreal literals produce the expected `moore.real_constant`
    operations with `f64` and `f32` types.

Overall, this enables correct handling of floating-point literals in the
ImportVerilog pipeline.
