### PR TITLE
[FIRRTL] Update port insertion/erasure API for instance/instance-choice ops 

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -139,14 +139,20 @@ def InstanceOp : HardwareDeclOp<"instance", [
     /// Hooks for domain information.
     ArrayAttr getPortDomain(unsigned portIdx);
 
-    /// Builds a new instance with the ports listed in `portIndices` erased, and
-    /// updates any users of the remaining ports to point at the new instance.
-    InstanceOp erasePorts(OpBuilder &builder, const llvm::BitVector &portIndices);
+    /// Clone this instance with inserted ports.
+    InstanceOp cloneWithInsertedPorts(
+      ArrayRef<std::pair<unsigned, PortInfo>> insertions);
 
-    /// Clone the instance op and add ports.  This is usually used in
-    /// conjuction with adding ports to the referenced module. This will emit
-    /// the new InstanceOp to the same location.
-    InstanceOp cloneAndInsertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports);
+    /// Clone this instance with inserted ports, then replaces uses.
+    InstanceOp cloneWithInsertedPortsAndReplaceUses(
+      ArrayRef<std::pair<unsigned, PortInfo>> insertions);
+
+    /// Clone this instance with erased ports.
+    InstanceOp cloneWithErasedPorts(const llvm::BitVector &erasures);
+
+    /// Clone this instance with erased ports, then replaces uses.
+    InstanceOp cloneWithErasedPortsAndReplaceUses(
+      const llvm::BitVector &erasures);
 
     //===------------------------------------------------------------------===//
     // Instance graph methods
@@ -211,12 +217,6 @@ def InstanceChoiceOp : HardwareDeclOp<"instance_choice", [
     StringAttr getPortName(size_t resultNo) {
       return cast<StringAttr>(getPortNames()[resultNo]);
     }
-
-    /// Builds a new instance with the ports listed in `portIndices` erased, and
-    /// updates any users of the remaining ports to point at the new instance.
-    InstanceChoiceOp erasePorts(OpBuilder &builder,
-                                const llvm::BitVector &portIndices);
-
     /// Return the default target attribute.
     FlatSymbolRefAttr getDefaultTargetAttr() {
       return llvm::cast<FlatSymbolRefAttr>(getModuleNamesAttr()[0]);
@@ -233,6 +233,21 @@ def InstanceChoiceOp : HardwareDeclOp<"instance_choice", [
     /// Return the list of case-module mappings.
     SmallVector<std::pair<SymbolRefAttr, FlatSymbolRefAttr>, 1>
     getTargetChoices();
+
+    /// Clone this instance with inserted ports.
+    InstanceChoiceOp cloneWithInsertedPorts(
+      ArrayRef<std::pair<unsigned, PortInfo>> insertions);
+
+    /// Clone this instance with inserted ports, then replaces uses.
+    InstanceChoiceOp cloneWithInsertedPortsAndReplaceUses(
+      ArrayRef<std::pair<unsigned, PortInfo>> insertions);
+
+    /// Clone this instance with erased ports.
+    InstanceChoiceOp cloneWithErasedPorts(const llvm::BitVector &erasures);
+
+    /// Clone this instance with erased ports, then replaces uses.
+    InstanceChoiceOp cloneWithErasedPortsAndReplaceUses(
+      const llvm::BitVector &erasures);
   }];
 
   let builders = [

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -361,14 +361,14 @@ InstanceOp firrtl::addPortsToModule(FModuleLike mod, InstanceOp instOnPath,
   // Now update all the instances of `mod`.
   for (auto *use : instancePathcache.instanceGraph.lookup(mod)->uses()) {
     InstanceOp useInst = cast<InstanceOp>(use->getInstance());
-    auto clonedInst = useInst.cloneAndInsertPorts({{portNo, portInfo}});
+    auto clonedInst =
+        useInst.cloneWithInsertedPortsAndReplaceUses({{portNo, portInfo}});
     if (useInst == instOnPath)
       clonedInstOnPath = clonedInst;
     // Update all occurences of old instance.
     instancePathcache.replaceInstance(useInst, clonedInst);
     if (targetCaches)
       targetCaches->replaceOp(useInst, clonedInst);
-    useInst->replaceAllUsesWith(clonedInst.getResults().drop_back());
     useInst->erase();
   }
   return clonedInstOnPath;

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -234,9 +234,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp) {
       auto &subExtraPorts = subMemInfo.extraPorts;
 
       // Add the extra ports to the instance operation.
-      auto clone = inst.cloneAndInsertPorts(subExtraPorts);
-      inst.replaceAllUsesWith(
-          clone.getResults().drop_back(subExtraPorts.size()));
+      auto clone = inst.cloneWithInsertedPortsAndReplaceUses(subExtraPorts);
       instanceGraph->replaceInstance(inst, clone);
       inst->erase();
       inst = clone;
@@ -491,9 +489,7 @@ void AddSeqMemPortsPass::runOnOperation() {
           continue;
 
         // Add the extra ports to the instance operation.
-        auto clone = inst.cloneAndInsertPorts(subExtraPorts);
-        inst.replaceAllUsesWith(
-            clone.getResults().drop_back(subExtraPorts.size()));
+        auto clone = inst.cloneWithInsertedPortsAndReplaceUses(subExtraPorts);
         instanceGraph->replaceInstance(inst, clone);
         inst->erase();
         inst = clone;

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -751,7 +751,8 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
       liveElements.erase(oldResult);
 
     // Create a new instance op without dead ports.
-    auto newInstance = instance.erasePorts(builder, deadPortIndexes);
+    auto newInstance =
+        instance.cloneWithErasedPortsAndReplaceUses(deadPortIndexes);
 
     // Mark new results as alive.
     for (auto newResult : newInstance.getResults())

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1856,15 +1856,11 @@ void InferResetsPass::implementFullReset(Operation *op, FModuleOp module,
     Value instReset;
     if (!domain.localReset) {
       LLVM_DEBUG(llvm::dbgs() << "  - Adding new result as reset\n");
-
-      auto newInstOp = instOp.cloneAndInsertPorts(
+      auto newInstOp = instOp.cloneWithInsertedPortsAndReplaceUses(
           {{/*portIndex=*/0,
             {domain.resetName, type_cast<FIRRTLBaseType>(actualReset.getType()),
              Direction::In}}});
       instReset = newInstOp.getResult(0);
-
-      // Update the uses over to the new instance and drop the old instance.
-      instOp.replaceAllUsesWith(newInstOp.getResults().drop_front());
       instanceGraph->replaceInstance(instOp, newInstOp);
       instOp->erase();
       instOp = newInstOp;

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -1177,12 +1177,8 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     for (auto *inst : instanceGraph.lookup(fmodule)->uses()) {
       InstanceOp useInst = cast<InstanceOp>(inst->getInstance());
       auto enclosingModule = useInst->getParentOfType<FModuleOp>();
-      auto clonedInst = useInst.cloneAndInsertPorts(newPorts);
+      auto clonedInst = useInst.cloneWithInsertedPortsAndReplaceUses(newPorts);
       state.instancePathCache.replaceInstance(useInst, clonedInst);
-      // When RAUW-ing, ignore the new ports that we added when replacing (they
-      // cannot have uses).
-      useInst->replaceAllUsesWith(
-          clonedInst.getResults().drop_back(newPorts.size()));
       useInst->erase();
       // Record information in the moduleModifications strucutre for the module
       // _where this is instantiated_.  This is done so that when that module is

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1469,8 +1469,8 @@ updateInstanceInModule(InstanceOp firrtlInstance, InstanceGraph &instanceGraph,
     return success();
 
   // Create a new instance with the property ports removed.
-  OpBuilder builder(firrtlInstance);
-  InstanceOp newInstance = firrtlInstance.erasePorts(builder, portsToErase);
+  InstanceOp newInstance =
+      firrtlInstance.cloneWithErasedPortsAndReplaceUses(portsToErase);
 
   // Replace the instance in the instance graph. This is called from multiple
   // threads, but because the instance graph data structure is not mutated, and

--- a/lib/Dialect/FIRRTL/Transforms/LowerDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerDomains.cpp
@@ -437,14 +437,8 @@ LogicalResult LowerModule::lowerInstances() {
       if (failed(eraseDomainUsers(instanceOp.getResult(bit))))
         return failure();
 
-    ImplicitLocOpBuilder builder(instanceOp.getLoc(), instanceOp);
-    auto erased = instanceOp.erasePorts(builder, eraseVector);
-    auto inserted = erased.cloneAndInsertPorts(newPorts);
-    for (auto [oldIndex, newIndex] : resultMap) {
-      auto oldPort = erased.getResult(oldIndex);
-      auto newPort = inserted.getResult(newIndex);
-      oldPort.replaceAllUsesWith(newPort);
-    }
+    auto erased = instanceOp.cloneWithErasedPortsAndReplaceUses(eraseVector);
+    auto inserted = erased.cloneWithInsertedPortsAndReplaceUses(newPorts);
     instanceGraph.replaceInstance(instanceOp, inserted);
 
     instanceOp.erase();

--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -595,10 +595,9 @@ LogicalResult Visitor::visitDecl(InstanceOp op) {
   // Create new instance op with desired ports.
 
   // TODO: add and erase ports without intermediate + various array attributes.
-  auto tempOp = op.cloneAndInsertPorts(newPorts);
+  auto tempOp = op.cloneWithInsertedPorts(newPorts);
   opsToErase.push_back(tempOp);
-  ImplicitLocOpBuilder builder(op.getLoc(), op);
-  auto newInst = tempOp.erasePorts(builder, portsToErase);
+  auto newInst = tempOp.cloneWithErasedPorts(portsToErase);
 
   auto mappingResult = walkMappings(
       portMappings, /*includeErased=*/false,

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -794,8 +794,7 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
       else if (auto mod = dyn_cast<FExtModuleOp>(iter.getFirst()))
         mod.erasePorts(iter.getSecond());
       else if (auto inst = dyn_cast<InstanceOp>(iter.getFirst())) {
-        ImplicitLocOpBuilder b(inst.getLoc(), inst);
-        inst.erasePorts(b, iter.getSecond());
+        inst.cloneWithErasedPortsAndReplaceUses(iter.getSecond());
         inst.erase();
       } else if (auto mem = dyn_cast<MemOp>(iter.getFirst())) {
         // Remove all debug ports of the memory.

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -200,7 +200,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
     }
 
     // Create a new instance op without unused ports.
-    instance.erasePorts(builder, removalPortIndexes);
+    instance.cloneWithErasedPortsAndReplaceUses(removalPortIndexes);
     // Remove old one.
     instance.erase();
   }

--- a/lib/Dialect/FIRRTL/Transforms/SpecializeLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeLayers.cpp
@@ -379,9 +379,10 @@ struct SpecializeLayers {
     for (auto result : instance->getResults())
       if (!specializeValue(result))
         disabledPorts.set(result.getResultNumber());
+
     if (disabledPorts.any()) {
-      OpBuilder builder(instance);
-      auto newInstance = instance.erasePorts(builder, disabledPorts);
+      auto newInstance =
+          instance.cloneWithErasedPortsAndReplaceUses(disabledPorts);
       instance->erase();
       instance = newInstance;
     }
@@ -405,9 +406,8 @@ struct SpecializeLayers {
       if (!specializeValue(result))
         disabledPorts.set(result.getResultNumber());
     if (disabledPorts.any()) {
-      OpBuilder builder(instanceChoice);
       auto newInstanceChoice =
-          instanceChoice.erasePorts(builder, disabledPorts);
+          instanceChoice.cloneWithErasedPortsAndReplaceUses(disabledPorts);
       instanceChoice->erase();
       instanceChoice = newInstanceChoice;
     }


### PR DESCRIPTION
Align and flush out the functionality for port insertion and erasure on instance and instance-choice op.

Overview of new API for Port Insertions:
  - `cloneWithInsertedPorts`: create a clone of the op with additional inserted ports. Returns the clone. This API _must_ clone, even if no ports are inserted.
  - `cloneWithInsertedPortsAndReplaceUses`: replace the uses of this op with a clone created via the above API. This API _must_ clone, even if no ports are inserted.
  - ~`insertPorts`: the "do what I mean" API: clone with port insertions, replace uses, and then erase the old instance, but only if there are any ports being inserted.~

Then for port erasure, we have a parallel set of functions:
  - `cloneWithErasedPorts`
  - `cloneWithErasedPortsAndReplaceUses`
  - ~`erasePorts`~
  
All ~six~ four functions are implemented for both the InstanceOp and InstanceChoiceOp.
