### PR TITLE
[Synth][LowerVariaidc] Fix topological ordering and a pass phase ordering

### DIFF
--- a/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
+++ b/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
@@ -101,19 +101,18 @@ void circt::synth::buildCombLoweringPipeline(
 
 void circt::synth::buildSynthOptimizationPipeline(
     OpPassManager &pm, const SynthOptimizationPipelineOptions &options) {
-
-  pm.addPass(createLowerVariadicPass(options.timingAware));
-
   // LowerWordToBits may not be scalable for large designs so conditionally
   // disable it. It's also worth considering keeping word-level representation
   // for faster synthesis.
   if (!options.disableWordToBits)
     pm.addPass(synth::createLowerWordToBits());
   pm.addPass(createCSEPass());
+  // Run after LowerWordToBits for more precise timing-info & scalability.
+  pm.addPass(createLowerVariadicPass(options.timingAware));
   pm.addPass(createStructuralHash());
   pm.addPass(createSimpleCanonicalizerPass());
   pm.addPass(synth::createMaximumAndCover());
-  pm.addPass(synth::createLowerVariadic());
+  pm.addPass(createLowerVariadicPass(options.timingAware));
   pm.addPass(createStructuralHash());
 
   if (!options.abcCommands.empty()) {

--- a/test/Dialect/Synth/lower-variadic.mlir
+++ b/test/Dialect/Synth/lower-variadic.mlir
@@ -50,3 +50,14 @@ hw.module @Tree1(in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1, in %f: i
 
   hw.output %2 : i1
 }
+
+// COMMON-LABEL: hw.module @ChildRegion
+hw.module @ChildRegion(in %x: i4, in %y: i4, in %z: i4) {
+  // COMMON-NEXT: %[[TMP:.+]] = comb.or %x, %y : i4
+  // COMMON-NEXT: %[[OR:.+]] = comb.or %z, %[[TMP]] : i4
+  %0 = comb.or %x, %y, %z : i4
+  sv.initial {
+    // COMMON: comb.and %[[OR]], %y, %z : i4
+    %1 = comb.and %0, %y, %z : i4
+  }
+}


### PR DESCRIPTION
This commit fixes topological sorting issues and pass ordering problems in the LowerVariadic pass.

The main lowering loop is changed from walk-based iteration to direct iteration using make_early_inc_range over top-level operations only. This is necessary because topologically sorting operations across nested regions is challenging (when a child implicitly captures SSA values, the current MLIR topologically sorting doesn't work well) and the previous approach did not handle this correctly.

The pass now uses MLIR's standard sortTopologically utility with an enhanced predicate that properly handles HW dialect operations, treating hw::InstanceOp as an anchor while allowing Comb and Synth operations to be sorted.

In the synthesis pipeline, LowerVariadic is moved to run after LowerWordToBits for better timing precision and scalability.