### PR TITLE
Bump Slang to v9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,9 +565,8 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG dd16a7947e0586d0541477f1b4b60eda7c986e35
-      # Shallow check-out doesn't work if the tag is ref spec is far from HEAD.
-      # GIT_SHALLOW ON
+      GIT_TAG v9.1
+      GIT_SHALLOW ON
     )
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
 
@@ -612,7 +611,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang)
     install(TARGETS slang_slang EXPORT CIRCTTargets)
   else()
-    find_package(slang 9.0 REQUIRED)
+    find_package(slang 9.1 REQUIRED)
   endif()
 endif()
 

--- a/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/LSPDiagnosticClient.h
+++ b/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/LSPDiagnosticClient.h
@@ -10,6 +10,7 @@
 #define LIB_CIRCT_TOOLS_CIRCT_VERILOG_LSP_SERVER_LSPDIAGNOSTICCLIENT_H_
 
 #include "VerilogDocument.h"
+#include "slang/diagnostics/DiagnosticClient.h"
 
 namespace circt {
 namespace lsp {

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1879,17 +1879,17 @@ module GenerateConstructs;
     // CHECK: [[TMP:%.+]] = moore.constant 0
     // CHECK: dbg.variable "i", [[TMP]]
     // CHECK: [[TMP:%.+]] = moore.constant 0
-    // CHECK: g1 = moore.variable [[TMP]]
+    // CHECK: %genblk1_0.g1 = moore.variable [[TMP]]
     // CHECK: [[TMP:%.+]] = moore.constant 1
     // CHECK: dbg.variable "i", [[TMP]]
     // CHECK: [[TMP:%.+]] = moore.constant 1
-    // CHECK: g1 = moore.variable [[TMP]]
+    // CHECK: %genblk1_1.g1 = moore.variable [[TMP]]
     for (i = 0; i < 2; i = i + 1) begin
       integer g1 = i;
     end
 
     // CHECK: [[TMP:%.+]] = moore.constant 2 : i32
-    // CHECK: g2 = moore.variable [[TMP]] : <i32>
+    // CHECK: %genblk2.g2 = moore.variable [[TMP]] : <i32>
     if (p == 2) begin
       int g2 = 2;
     end else begin
@@ -1897,7 +1897,7 @@ module GenerateConstructs;
     end
     
     // CHECK: [[TMP:%.+]] = moore.constant 2 : i32
-    // CHECK: g3 = moore.variable [[TMP]] : <i32>
+    // CHECK: %genblk3.g3 = moore.variable [[TMP]] : <i32>
     case (p)
       2: begin
         int g3 = 2;


### PR DESCRIPTION
Bump our Slang dependency to v9.1. We have been pointing at a commit after v9.0 to pick up a few bug fixes. These have landed in v9.1, such that we can go back to pointing at the released version again.

This release subtly changes the way generate blocks are named, which requires a few tweaks in ImportVerilog's handling of generate block name prefixes.