### PR TITLE
[Synth] Fix race condition and memory corruption in longest path analysis caching

### DIFF
--- a/lib/Dialect/Synth/Analysis/LongestPathAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/LongestPathAnalysis.cpp
@@ -1132,8 +1132,8 @@ FailureOr<ArrayRef<OpenPath>> LocalVisitor::getOrComputePaths(Value value,
   // Unique the results.
   filterPaths(*results, ctx->doKeepOnlyMaxDelayPaths(), ctx->isLocalScope());
   LLVM_DEBUG({
-    llvm::dbgs() << value << "[" << bitPos << "] " << "Found "
-                 << results->size() << " paths\n";
+    llvm::dbgs() << value << "[" << bitPos << "] "
+                 << "Found " << results->size() << " paths\n";
     llvm::dbgs() << "====Paths:\n";
     for (auto &path : *results) {
       path.print(llvm::dbgs());


### PR DESCRIPTION
This commit addresses a race condition and memory corruption issue in the LongestPathAnalysis where concurrent access to cached results could lead to iterator invalidation and memory corruption. The issue occurred when the cachedResults DenseMap was modified during iteration, causing existing iterators and references to become invalid and point to corrupted memory.

The fix changes the cachedResults map to store unique_ptr<SmallVector<OpenPath>> instead of SmallVector<OpenPath> directly. This ensures that the underlying SmallVector objects remain at stable memory locations even when the DenseMap is rehashed or modified, preventing iterator invalidation and memory corruption.

Additionally, in markRegEndPoint, we now preemptively call getOrComputePaths for the endpoint before recording paths. This ensures all necessary paths are computed and cached before any operations that might trigger map modifications, eliminating the race condition.

Additional unique_ptr is not ideal so eventually we might want to use BumpAllocator