### PR TITLE
[MooreToCore] Lower `moore.real_constant` to `arith.constant`

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -571,6 +571,23 @@ def StringConstantOp : MooreOp<"string_constant", [Pure]> {
   let assemblyFormat = "$value attr-dict `:` type($result)";
 }
 
+def ShortrealLiteralOp : MooreOp<"shortreal_constant", [Pure]> {
+  let summary = "Produce a constant shortreal value";
+  let description = [{
+    Produces a constant value of shortreal type.
+
+    Example:
+    ```mlir
+    %0 = moore.shortreal_constant 1.23
+    ```
+    The shortreal type has fixed-point(1.2) and exponent(2.0e10) formats and corresponds to IEEE 754 f32.
+    See IEEE 1800-2017 § 5.7.2 "Real literal constants".
+  }];
+  let arguments = (ins F32Attr:$value);
+  let results = (outs RealF32:$result);
+  let assemblyFormat = "$value attr-dict";
+}
+
 def RealLiteralOp : MooreOp<"real_constant", [Pure]> {
   let summary = "Produce a constant real value";
   let description = [{
@@ -580,12 +597,12 @@ def RealLiteralOp : MooreOp<"real_constant", [Pure]> {
     ```mlir
     %0 = moore.real_constant 1.23
     ```
-    The real type has fixed-point(1.2) and exponent(2.0e10) formats.
+    The real type has fixed-point(1.2) and exponent(2.0e10) formats and corresponds to IEEE 754 f64.
     See IEEE 1800-2017 § 5.7.2 "Real literal constants".
   }];
   let arguments = (ins F64Attr:$value);
-  let results = (outs RealType:$result);
-  let assemblyFormat = "$value attr-dict `:` type($result)";
+  let results = (outs RealF64:$result);
+  let assemblyFormat = "$value attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3347,7 +3347,7 @@ endfunction
 
 // CHECK: func.func private @testRealLiteral() -> !moore.f64 {
 function automatic real testRealLiteral();
-   // CHECK: [[TMP:%.+]] = moore.real_constant 1.234500e+00 : f64
+   // CHECK: [[TMP:%.+]] = moore.real_constant 1.234500e+00
    localparam test = 1.2345;
     // CHECK-NEXT: return [[TMP]] : !moore.f64
    return test;
@@ -3355,7 +3355,7 @@ endfunction
 
 // CHECK: func.func private @testShortrealLiteral() -> !moore.f32 {
 function automatic shortreal testShortrealLiteral();
-   // CHECK: [[TMP:%.+]] = moore.real_constant 1.2345000505447388 : f32
+   // CHECK: [[TMP:%.+]] = moore.shortreal_constant 1.234500e+00
    localparam test = shortreal'(1.2345);
     // CHECK-NEXT: return [[TMP]] : !moore.f32
    return test;

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1330,3 +1330,12 @@ func.func @NonBlockingAssignment(%arg0: !moore.ref<i42>, %arg1: !moore.i42, %arg
   moore.delayed_nonblocking_assign %arg0, %arg1, %arg2 : i42
   return
 }
+
+// CHECK-LABEL: func.func @RealConstantOp
+func.func @RealConstantOp() {
+  // CHECK: [[REAL:%.+]] = arith.constant 1.234500e+00 : f64
+  %real = moore.real_constant 1.234500e+00
+  // CHECK: [[SHORTREAL:%.+]] = arith.constant 1.234500e+00 : f32
+  %shortreal = moore.shortreal_constant 1.234500e+00
+  return
+}


### PR DESCRIPTION
This commit introduces explicit support for `shortreal` literals in the Moore dialect and unifies the lowering and import handling of real constants. It ensures correct mapping between SystemVerilog `real`/`shortreal` and MLIR `f64`/`f32` types across all relevant conversions.

Changes:

Dialect (MooreOps.td):
- Added `ShortrealLiteralOp`:
  - Accepts `F32Attr` and produces `RealF32`.
  - Represents IEEE-754 single-precision (SystemVerilog `shortreal`).
- Updated `RealLiteralOp`:
  - Now explicitly uses `F64Attr` and produces `RealF64`.
  - Simplified `assemblyFormat` by removing redundant result type.
  - Clarified description to indicate IEEE-754 double precision.

ImportVerilog (Expressions.cpp):
- Updated `materializeSVReal`:
  - Emits `ShortrealLiteralOp` for `shortreal` values.
  - Emits `RealLiteralOp` for `real` values.
  - Uses appropriate `FloatAttr` construction and result type selection.

MooreToCore Conversion (MooreToCore.cpp):
- Added conversion patterns:
  - `RealConstantOpConv` → lowers to `arith.constant` with `f64` type.
  - `ShortrealConstantOpConv` → lowers to `arith.constant` with `f32` type.
- Marked `arith::ArithDialect` as legal.
- Extended `TypeConverter` to map:
  - `moore::RealWidth::f32` → `mlir::Float32Type`
  - `moore::RealWidth::f64` → `mlir::Float64Type`

Tests:
- Updated `ImportVerilog` tests to expect `moore.shortreal_constant` and `moore.real_constant` without explicit result type suffixes.
- Added `MooreToCore` tests verifying correct lowering:
  - `moore.real_constant` → `arith.constant f64`
  - `moore.shortreal_constant` → `arith.constant f32`
