### PR TITLE
[FIRRTL] Fix dedup looking up wrong op in inner ref target check

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -717,7 +717,7 @@ struct Equivalence {
         } else {
           // Otherwise make sure that they are targeting the same operation.
           if (!bTarget.isOpOnly() ||
-              aTarget.getOp() != data.map.lookup(bTarget.getOp()))
+              data.map.lookupOrNull(aTarget.getOp()) != bTarget.getOp())
             return error();
         }
         if (aTarget.getField() != bTarget.getField())


### PR DESCRIPTION
Fix an issue in the Dedup pass, where the pass would use `data.map.lookup(...)` to resolve the target operation of an inner reference from one module to another, but it would use op B as lookup key, while the map contains mappings from A to B.