### PR TITLE
[ImportVerilog] Allow functions to capture values from parent scope

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -49,6 +49,8 @@ struct ModuleLowering {
 /// Function lowering information.
 struct FunctionLowering {
   mlir::func::FuncOp op;
+  llvm::SmallVector<Value, 4> captures;
+  llvm::DenseMap<Value, unsigned> captureIndex;
 };
 
 /// Information about a loops continuation and exit blocks relevant while
@@ -110,6 +112,7 @@ struct Context {
   FunctionLowering *
   declareFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult convertFunction(const slang::ast::SubroutineSymbol &subroutine);
+  LogicalResult finalizeFunctionBodyCaptures(FunctionLowering &lowering);
 
   // Convert a statement AST node to MLIR ops.
   LogicalResult convertStatement(const slang::ast::Statement &stmt);

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3360,3 +3360,24 @@ function automatic shortreal testShortrealLiteral();
     // CHECK-NEXT: return [[TMP]] : !moore.f32
    return test;
 endfunction
+
+// CHECK: moore.module @testFunctionCapture() {
+module testFunctionCapture();
+
+    // CHECK: [[A:%.+]] = moore.variable : <l1>
+    logic a;
+
+    function logic testCapture;
+        return a;
+    endfunction
+
+    // CHECK: [[RETURNEDA:%.+]] = func.call @testCapture([[A]]) : (!moore.ref<l1>) -> !moore.l1
+    // CHECK: [[B:%.+]] = moore.variable [[RETURNEDA]] : <l1>
+    logic b = testCapture();
+
+    // These checks need to be here since testCapture gets moved to after the variable decl,
+    // and file check only checks forward.
+    // CHECK: func.func private @testCapture(%arg0: !moore.ref<l1>) -> !moore.l1 {
+    // CHECK: [[CAPTUREDA:%.+]] = moore.read %arg0 : <l1>
+    // CHECK: return [[CAPTUREDA]] : !moore.l1
+endmodule


### PR DESCRIPTION
This patch teaches the ImportVerilog conversion to detect and plumb captured references from enclosing scopes into lowered MLIR functions.

- **FunctionLowering**
  - Added `captures` and `captureIndex` to record refs captured from outer scopes.
- **Context**
  - Added `finalizeFunctionBodyCaptures` to extend the function signature with captured `moore::RefType` inputs and replace their in-body uses with the new block arguments.
  - `convertFunction` now installs a temporary `rvalueReadCallback` that collects refs read from outside the function’s body.
- **Expressions**
  - When lowering subroutine calls, the visitor now appends any captured operands to the call argument list. Captures are verified to be `moore::RefType` values originating from the enclosing (module) region.

Together these changes allow nested or free functions to reference module-level signals (`logic`, etc.) correctly in the generated MLIR, with explicit function parameters modeling captured variables.