### PR TITLE
[ImportVerilog] Add variableAssignCallback, allow LHS capture

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -282,6 +282,9 @@ struct Context {
   /// example to populate the list of observed signals in an implicit event
   /// control `@*`.
   std::function<void(moore::ReadOp)> rvalueReadCallback;
+  /// A listener called for every variable or net being assigned. This can be
+  /// used to collect all variables assigned in a task scope.
+  std::function<void(mlir::Operation *)> variableAssignCallback;
 
   /// The time scale currently in effect.
   slang::TimeScale timeScale;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3381,3 +3381,25 @@ module testFunctionCapture();
     // CHECK: [[CAPTUREDA:%.+]] = moore.read %arg0 : <l1>
     // CHECK: return [[CAPTUREDA]] : !moore.l1
 endmodule
+
+// CHECK: moore.module @testLHSTaskCapture() {
+module testLHSTaskCapture();
+
+    // CHECK: [[A:%.+]] = moore.variable : <l1>
+    logic a;
+
+    task testTaskCapture;
+        a = 0;
+    endtask
+
+    always @(posedge a) begin
+        // CHECK: func.call @testTaskCapture([[A]]) : (!moore.ref<l1>) -> ()
+        testTaskCapture;
+    end
+
+    // CHECK: func.func private @testTaskCapture(%arg0: !moore.ref<l1>) {
+    // CHECK: [[CONST:%.+]] = moore.constant 0 : l1
+    // CHECK: moore.blocking_assign %arg0, [[CONST]] : l1
+
+
+endmodule


### PR DESCRIPTION
This patch extends ImportVerilog’s capture mechanism to include write-side
(LHS) captures, complementing the existing read-side collection. Tasks and
functions that assign to variables in an enclosing scope now have those refs
added as explicit function parameters during lowering.

- **Context API**
  - Introduce `variableAssignCallback: std::function<void(mlir::Operation *)>`.
  - Both read and write callbacks are chained and restored via scope guards.

- **Capture collection**
  - **Reads**: keep existing `rvalueReadCallback` behavior.
  - **Writes**: new callback fires on `moore.blocking_assign`,
    `moore.nonblocking_assign`, and `moore.delayed_nonblocking_assign`.
    The LHS ref (`getDst()`) is captured when it originates outside the
    function’s region.

- **Lowering changes**
  - In `Expressions.cpp`, creation sites for blocking / (delayed) non-blocking
    assigns invoke `variableAssignCallback`.
  - In `Structure.cpp::convertFunction`, install both callbacks to accumulate
    `captures`/`captureIndex` for the function, covering **both** reads and
    writes.
  - Existing `finalizeFunctionBodyCaptures` retypes the function to include the
    new capture parameters and replaces internal uses with the new block args.

- **`testLHSTaskCapture`** in `basic.sv`:
  - Confirms that a task assigning to a parent variable correctly captures it as
    an additional function argument.
  - Ensures call sites and function bodies are lowered with consistent capture
    semantics even when the function is defined *after* its use.