### PR TITLE
[ImportVerilog] [1/2] Improve function capture lifecycle

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -971,6 +971,10 @@ struct RvalueExprVisitor : public ExprVisitor {
     if (!lowering)
       return {};
 
+    auto convertedFunction = context.convertFunction(*subroutine);
+    if (failed(convertedFunction))
+      return {};
+
     // Convert the call arguments. Input arguments are converted to an rvalue.
     // All other arguments are converted to lvalues and passed into the function
     // by reference.

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -51,6 +51,8 @@ struct FunctionLowering {
   mlir::func::FuncOp op;
   llvm::SmallVector<Value, 4> captures;
   llvm::DenseMap<Value, unsigned> captureIndex;
+  bool capturesFinalized = false;
+  bool isConverting = false;
 };
 
 /// Information about a loops continuation and exit blocks relevant while

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3403,3 +3403,10 @@ module testLHSTaskCapture();
 
 
 endmodule
+
+// CHECK: func.func private @testRecursive(%arg0: !moore.i32) -> !moore.i32 {
+function int testRecursive(input int n);
+    if (n <= 1) return 1;
+    // CHECK: [[REC:%.+]] = call @testRecursive({{.*}}) : (!moore.i32) -> !moore.i32
+    return n * testRecursive(n - 1);
+endfunction


### PR DESCRIPTION
This patch further improves robustness and determinism in how ImportVerilog lowers SystemVerilog subroutines. Functions are now *fully converted* — including capture discovery and finalization — **before any call to them is emitted**, even if their definitions appear textually *after* the call site in the source.

- **Function conversion ordering**
  - `visitCall` now explicitly invokes `context.convertFunction(*subroutine)` before materializing a `func.call`.
  - This guarantees that the callee’s body, captures, and function signature are finalized regardless of declaration order — fixing cases where a function was defined *after* its first call in source.
  - Recursive and mutually recursive calls are handled safely using the new reentrancy guards described below.

- **Function capture lifecycle**
  - Added two flags to `FunctionLowering`:
    - `isConverting`: marks a function currently being converted to avoid re-entrant conversion.
    - `capturesFinalized`: marks completion of capture finalization.
  - `convertFunction` now:
    - Skips re-entry when a function is already being converted.
    - Sets `isConverting` during body conversion and resets it afterward.
    - Marks `capturesFinalized` once `finalizeFunctionBodyCaptures` succeeds.