### PR TITLE
[ImportVerilog] Add support for string materialization

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -751,6 +751,18 @@ def IntToRealOp : MooreOp<"int_to_real", [
   }];
 }
 
+def IntToStringOp : MooreOp<"int_to_string", [
+  Pure
+]> {
+  let summary = "Convert an integer to a string";
+  let arguments = (ins TwoValuedIntType:$input);
+  let results = (outs StringType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input)
+  }];
+}
+
+
 //===----------------------------------------------------------------------===//
 // Resizing
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -182,6 +182,10 @@ struct Context {
   Value materializeSVReal(const slang::ConstantValue &svreal,
                           const slang::ast::Type &type, Location loc);
 
+  /// Helper function to materialize a string as an SSA value.
+  Value materializeString(const slang::ConstantValue &string,
+                          const slang::ast::Type &astType, Location loc);
+
   /// Helper function to materialize an unpacked array of `SVInt`s as an SSA
   /// value.
   Value materializeFixedSizeUnpackedArrayType(

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3475,3 +3475,13 @@ module partselect_index_neg_le;
   logic [1:0] res = c[s-:2];
 
 endmodule
+
+// CHECK-LABEL: func.func private @testStrLiteralReturn()
+// CHECK-SAME: -> !moore.string {
+function string testStrLiteralReturn;
+    // CHECK-NEXT: [[INT:%.+]] = moore.string_constant "\22A string literal\22" : i127
+    // CHECK-NEXT: [[STR:%.+]] = moore.int_to_string [[INT]] : i127
+    parameter string testStrLiteral = "A string literal";
+    // CHECK-NEXT: return [[STR]] : !moore.string
+    return testStrLiteral;
+endfunction // testStrLiteralReturn


### PR DESCRIPTION
Extend ImportVerilog to lower SystemVerilog string constants by:
- Introducing `moore.int_to_string` to convert integer-backed literals to `!moore.string`.
- Materializing Slang string constants via a new `Context::materializeString` path.
- Integrating string handling into the general constant materialization flow.

- **Dialect**
  - Add `IntToStringOp` (`moore.int_to_string`) to `MooreOps.td` with:
    - `TwoValuedIntType` input -> `StringType` result

- **ImportVerilog conversion**
  - Implement `Context::materializeString(constant, type, loc)`:
    - Converts Slang `ConstantValue` string to an integer representation and creates a `moore.string_constant`, then wraps it with `moore.int_to_string`.
  - Update `materializeConstant` to recognize `constant.isString()` and route to the new helper.