### PR TITLE
[ImportVerilog] Harden SVReal materialization

### DIFF
--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3431,5 +3431,15 @@ module testRecursiveCaptureFunction();
     // CHECK: [[REC_CALL:%.*]] = call @fact({{.*}}, %arg1) : (!moore.i32, !moore.ref<i32>) -> !moore.i32
     return n * fact(n - 1);
   endfunction
+endmodule
 
+// CHECK-LABEL: moore.module @RealLiteral() {
+module RealLiteral();
+   // CHECK-NEXT:  [[REALCONSTANT:%.+]] = moore.real_constant 5.000000e-01
+   // CHECK-NEXT: [[A:%.+]] = moore.variable [[REALCONSTANT]] : <f64>
+   real a = 0.5;
+   // CHECK-NEXT: [[REALCONSTANT:%.+]] = moore.real_constant 5.000000e-01
+   // CHECK-NEXT: [[SHORTREALCONSTANT:%.+]] = moore.conversion [[REALCONSTANT]] : !moore.f64 -> !moore.f32
+   // CHECK-NEXT: [[B:%.+]] = moore.variable [[SHORTREALCONSTANT]] : <f32>
+   shortreal b = 0.5;
 endmodule


### PR DESCRIPTION
This patch makes real literal conversion safer and clearer, and adds tests.

- **Direct lowering for AST real literals**
  - `RvalueExprVisitor::visit(RealLiteral)` now emits a `moore.real_constant` via an MLIR `FloatAttr` (f64) directly, avoiding the older `materializeSVReal` path.

- **Safer constant folding for reals**
  - Reworked `Context::materializeSVReal(...)`:
    - Verifies the AST type is floating before proceeding.
    - **Coerces** `slang::ConstantValue` to the expected kind (`real`/`shortreal`) using Slang conversions.
    - Avoids calling `.real()` / `.shortReal()` unless the corresponding `is*()` predicate holds.
    - Emits `moore.real_literal` / `moore.shortreal_literal` with the correct MLIR float type (`f64`/`f32`).

- **`RealLiteral` module** in `basic.sv`
  - Checks emission of `moore.real_constant 5.000000e-01`
  - Verifies implicit conversion to `shortreal` via a `moore.conversion` from `!moore.f64` → `!moore.f32`
  - Confirms variable initializations for both `real` and `shortreal`.