### PR TITLE
[FIRRTL] Add support for domain-connect driving instance-choice ports

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4278,6 +4278,14 @@ LogicalResult PropAssignOp::verify() {
   return success();
 }
 
+template <typename T>
+static FlatSymbolRefAttr getDomainTypeNameOfResult(T op, size_t i) {
+  auto info = op.getDomainInfo();
+  if (info.empty())
+    return {};
+  return dyn_cast<FlatSymbolRefAttr>(info[i]);
+}
+
 static FlatSymbolRefAttr getDomainTypeName(Value value) {
   if (!isa<DomainType>(value.getType()))
     return {};
@@ -4297,13 +4305,10 @@ static FlatSymbolRefAttr getDomainTypeName(Value value) {
 
   if (auto result = dyn_cast<OpResult>(value)) {
     auto *op = result.getDefiningOp();
-    if (auto instance = dyn_cast<InstanceOp>(op)) {
-      auto info = instance.getDomainInfo();
-      if (info.empty())
-        return {};
-      auto attr = info[result.getResultNumber()];
-      return dyn_cast<FlatSymbolRefAttr>(attr);
-    }
+    if (auto instance = dyn_cast<InstanceOp>(op))
+      return getDomainTypeNameOfResult(instance, result.getResultNumber());
+    if (auto instance = dyn_cast<InstanceChoiceOp>(op))
+      return getDomainTypeNameOfResult(instance, result.getResultNumber());
     return {};
   }
 


### PR DESCRIPTION
The domain define op needs to verify that the destination has the same domain-type as the source. To do this, it needs to be able to read the domain type off of either operand. There is no generic way to do this yet so we have to support specific ops on a case-by-case basis. This PR adds support for sources and destinations defined by the instance-choice op.

At some point in the future we'll likely standardize an interface for reading domain information for results and arguments, but I'll save that for a later PR.