### PR TITLE
[Arcilator] Print full values rather than truncating them.

### DIFF
--- a/integration_test/arcilator/JIT/basic.mlir
+++ b/integration_test/arcilator/JIT/basic.mlir
@@ -1,7 +1,7 @@
 // RUN: arcilator %s --run --jit-entry=main | FileCheck %s
 // REQUIRES: arcilator-jit
 
-// CHECK: output = 5
+// CHECK: output = 05
 
 hw.module @adder(in %a: i8, in %b: i8, out c: i8) {
   %res = comb.add %a, %b : i8

--- a/integration_test/arcilator/JIT/counter.mlir
+++ b/integration_test/arcilator/JIT/counter.mlir
@@ -2,16 +2,16 @@
 // REQUIRES: arcilator-jit
 
 // CHECK: counter_value = 0
-// CHECK-NEXT: counter_value = 1
-// CHECK-NEXT: counter_value = 2
-// CHECK-NEXT: counter_value = 3
-// CHECK-NEXT: counter_value = 4
-// CHECK-NEXT: counter_value = 5
-// CHECK-NEXT: counter_value = 6
-// CHECK-NEXT: counter_value = 7
-// CHECK-NEXT: counter_value = 8
-// CHECK-NEXT: counter_value = 9
-// CHECK-NEXT: counter_value = a
+// CHECK-NEXT: counter_value = 01
+// CHECK-NEXT: counter_value = 02
+// CHECK-NEXT: counter_value = 03
+// CHECK-NEXT: counter_value = 04
+// CHECK-NEXT: counter_value = 05
+// CHECK-NEXT: counter_value = 06
+// CHECK-NEXT: counter_value = 07
+// CHECK-NEXT: counter_value = 08
+// CHECK-NEXT: counter_value = 09
+// CHECK-NEXT: counter_value = 0a
 
 hw.module @counter(in %clk: i1, out o: i8) {
   %seq_clk = seq.to_clock %clk

--- a/integration_test/arcilator/JIT/div-by-zero.mlir
+++ b/integration_test/arcilator/JIT/div-by-zero.mlir
@@ -1,9 +1,9 @@
 // RUN: arcilator %s --run --jit-entry=main | FileCheck %s
 // REQUIRES: arcilator-jit
-// CHECK: divu = 0{{$}}
-// CHECK: divs = 0{{$}}
-// CHECK: modu = 0{{$}}
-// CHECK: mods = 0{{$}}
+// CHECK: divu = 00{{$}}
+// CHECK: divs = 00{{$}}
+// CHECK: modu = 00{{$}}
+// CHECK: mods = 00{{$}}
 
 hw.module @Baz(in %a: i8, in %b: i8, out divu: i8, out divs: i8, out modu: i8, out mods: i8) {
   %zero = hw.constant 0 : i8

--- a/integration_test/arcilator/JIT/dpi.mlir
+++ b/integration_test/arcilator/JIT/dpi.mlir
@@ -8,10 +8,10 @@
 void mul_shared(int a, int b, int *result) { *result = a * b; }
 
 //--- dpi.mlir
-// CHECK:      c = 0
-// CHECK-NEXT: d = 0
-// CHECK-NEXT: c = 5
-// CHECK-NEXT: d = 6
+// CHECK:      c = {{0*}}0
+// CHECK-NEXT: d = {{0*}}0
+// CHECK-NEXT: c = {{0*}}5
+// CHECK-NEXT: d = {{0*}}6
 sim.func.dpi @mul_shared(in %a : i32, in %b : i32, out c : i32)
 sim.func.dpi @add_mlir(in %a : i32, in %b : i32, out c : i32) attributes {verilogName = "add_mlir_impl"}
 func.func @add_mlir_impl(%arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {

--- a/integration_test/arcilator/JIT/print.mlir
+++ b/integration_test/arcilator/JIT/print.mlir
@@ -1,7 +1,7 @@
 // RUN: arcilator %s --run | FileCheck %s
 // REQUIRES: arcilator-jit
 
-// CHECK: result = 4
+// CHECK: result = {{0*}}4
 
 func.func @entry() {
   %four = arith.constant 4 : i32

--- a/integration_test/arcilator/JIT/reg.mlir
+++ b/integration_test/arcilator/JIT/reg.mlir
@@ -1,12 +1,12 @@
 // RUN: arcilator %s --run --jit-entry=main | FileCheck %s
 // REQUIRES: arcilator-jit
 
-// CHECK:      o1 = 2
-// CHECK-NEXT: o2 = 5
-// CHECK-NEXT: o1 = 3
-// CHECK-NEXT: o2 = 6
-// CHECK-NEXT: o1 = 4
-// CHECK-NEXT: o2 = 7
+// CHECK:      o1 = 02
+// CHECK-NEXT: o2 = 05
+// CHECK-NEXT: o1 = 03
+// CHECK-NEXT: o2 = 06
+// CHECK-NEXT: o1 = 04
+// CHECK-NEXT: o2 = 07
 
 func.func private @random() -> i32 {
   %0 = arith.constant 2 : i32

--- a/test/arcilator/emit-values.mlir
+++ b/test/arcilator/emit-values.mlir
@@ -1,0 +1,42 @@
+// RUN: arcilator --run %s | FileCheck %s
+module {
+  func.func @entry() {
+    // CHECK: a1 = 1
+    %a1 = arith.constant 0x1 : i4
+    arc.sim.emit "a1", %a1 : i4
+
+    // CHECK: v1 = 0001
+    %v1 = arith.constant 0x1 : i16
+    arc.sim.emit "v1", %v1 : i16
+
+    // CHECK: v2 = abcdef
+    %v2 = arith.constant 0xABCDEF : i24
+    arc.sim.emit "v2", %v2 : i24
+
+    // CHECK: v3 = 0123456789abcdef
+    %v3 = arith.constant 0x0123456789ABCDEF : i64
+    arc.sim.emit "v3", %v3 : i64
+
+    // CHECK: v4 = 0000000000000001
+    %v4 = arith.constant 1 : i64
+    arc.sim.emit "v4", %v4 : i64
+
+    // CHECK: v5 = 7a
+    %v5 = arith.constant 0x7A : i7
+    arc.sim.emit "v5", %v5 : i7
+
+    // CHECK: v6 = 10000000000b
+    %v6 = arith.constant 0x10000000000B : i47
+    arc.sim.emit "v6", %v6 : i47
+
+    // CHECK: v7 = 1
+    %v7 = arith.constant 0x1 : i1
+    arc.sim.emit "v7", %v7 : i1
+
+    // CHECK: v8 = 0fde6741e3a44d997e80d393ae643ee0fd9
+    %v8 = arith.constant 0xfde6741e3a44d997e80d393ae643ee0fd9 : i137
+    arc.sim.emit "v8", %v8 : i137
+
+    return
+  }
+}


### PR DESCRIPTION
Implemented by slicing the value into size_t chunks and passing them as variadic args to printf.

Example:
```
    // CHECK: v8 = fde6741e3a44d997e80d393ae643ee0fd9
    %v8 = arith.constant 0xfde6741e3a44d997e80d393ae643ee0fd9 : i137
    arc.sim.emit "v8", %v8 : i137
```