### PR TITLE
[Moore][ImportVerilog] Add real-valued ops + real-aware import; refactor logical handling

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -580,7 +580,8 @@ def ShortrealLiteralOp : MooreOp<"shortreal_constant", [Pure]> {
     ```mlir
     %0 = moore.shortreal_constant 1.23
     ```
-    The shortreal type has fixed-point(1.2) and exponent(2.0e10) formats and corresponds to IEEE 754 f32.
+    The shortreal type has fixed-point(1.2) and exponent(2.0e10) formats and
+    corresponds to IEEE 754 f32.
     See IEEE 1800-2017 § 5.7.2 "Real literal constants".
   }];
   let arguments = (ins F32Attr:$value);
@@ -592,12 +593,13 @@ def RealLiteralOp : MooreOp<"real_constant", [Pure]> {
   let summary = "Produce a constant real value";
   let description = [{
     Produces a constant value of real type.
-    
+
     Example:
     ```mlir
     %0 = moore.real_constant 1.23
     ```
-    The real type has fixed-point(1.2) and exponent(2.0e10) formats and corresponds to IEEE 754 f64.
+    The real type has fixed-point(1.2) and exponent(2.0e10) formats and
+    corresponds to IEEE 754 f64.
     See IEEE 1800-2017 § 5.7.2 "Real literal constants".
   }];
   let arguments = (ins F64Attr:$value);
@@ -856,6 +858,21 @@ def NegOp : MooreOp<"neg", [Pure, SameOperandsAndResultType]> {
   }];
   let arguments = (ins SimpleBitVectorType:$input);
   let results = (outs SimpleBitVectorType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input)
+  }];
+}
+
+def NegRealOp : MooreOp<"fneg", [Pure, SameOperandsAndResultType]> {
+  let summary = "Arithmetic negation";
+  let description = [{
+    Negate a real value.
+
+    See IEEE 1800-2017 § 11.4.3 "Arithmetic operators" and § 11.3.1 "Operators
+    with real operands"
+  }];
+  let arguments = (ins RealType:$input);
+  let results = (outs RealType:$result);
   let assemblyFormat = [{
     $input attr-dict `:` type($input)
   }];
@@ -1384,6 +1401,113 @@ def ReplicateOp : MooreOp<"replicate", [
   let assemblyFormat = [{
     $value attr-dict `:` type($value) `->` type($result)
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// Real Binary Operations
+//===----------------------------------------------------------------------===//
+
+class BinaryRealOpBase<string mnemonic, list<Trait> traits = []> :
+    MooreOp<mnemonic, traits # [Pure, SameOperandsAndResultType]> {
+  let arguments = (ins RealType:$lhs, RealType:$rhs);
+  let description = [{
+    See IEEE 1800-2017 § 11.4.3 "Arithmetic operators" and § 11.3.1 "Operators
+    with real operands"
+  }];
+  let results = (outs RealType:$result);
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` type($result)
+  }];
+}
+
+def AddRealOp : BinaryRealOpBase<"fadd"> {
+  let summary = "Addition; add two real operands.";
+}
+
+def SubRealOp : BinaryRealOpBase<"fsub"> {
+  let summary = [{Subtraction; subtract the RHS real operand from the LHS
+  real operand.}];
+}
+
+def DivRealOp : BinaryRealOpBase<"fdiv"> {
+  let summary = [{Division; Divide the LHS real operand by the LHS
+  real operand.}];
+}
+
+def MulRealOp : BinaryRealOpBase<"fmul"> {
+  let summary = [{Multiplication; Multiply the RHS real operand with the LHS
+  real operand.}];
+}
+
+def PowRealOp : BinaryRealOpBase<"fpow"> {
+  let summary = [{Power; Exponentiate the LHS real base with the RHS real
+  exponent.}];
+}
+
+class LogicalEqRealOpBase<string mnemonic> : MooreOp<mnemonic, [
+  Pure,
+  Commutative,
+  SameTypeOperands,
+  ResultIsSingleBitMatchingInputDomain<"result", "lhs">
+]> {
+  let description = [{
+    Compares the bits in the left- and right-hand side operand and returns a
+    single bit 0 or 1. If all corresponding bits in the left- and
+    right-hand side are equal, and all are 0 or 1, the two operands
+    are considered equal (`eq` returns 1, `ne` returns 0). If any bits are not
+    equal, but all are 0 or 1, the two operands are considered not equal (`eq`
+    returns 0, `ne` returns 1). `eq` corresponds to the `==` operator and `ne`
+    to the `!=` operator.
+
+    See IEEE 1800-2017 § 11.4.5 "Equality operators" and § 11.3.1 "Operators
+    with real operands".
+  }];
+  let arguments = (ins RealType:$lhs, RealType:$rhs);
+  let results = (outs BitType:$result);
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)
+  }];
+}
+
+def EqRealOp : LogicalEqRealOpBase<"feq"> { let summary = "Logical equality"; }
+def NeRealOp : LogicalEqRealOpBase<"fne"> { let summary = "Logical inequality"; }
+
+
+class RelationalRealOpBase<string mnemonic> : MooreOp<mnemonic, [
+  Pure,
+  SameTypeOperands,
+  ResultIsSingleBitMatchingInputDomain<"result", "lhs">
+]> {
+  let description = [{
+    Compares the left- and right-hand side operand and returns a single bit 0,
+    or 1 result. If all bits are 0 or 1, `flt`, `fle`, `fgt`, and
+    `fge` return whether the left-hand side is less than, less than or equal
+    to, greater than, or greater than or equal to the right-hand side,
+    respectively. `flt` corresponds to the `<` operator, `fle` to `<=`,
+    `fgt` to `>`, and `fge` to `>=`.
+
+    See IEEE 1800-2017 § 11.4.4 "Relational operators" and § 11.3.1 "Operators
+    with real operands".
+  }];
+  let arguments = (ins RealType:$lhs, RealType:$rhs);
+  let results = (outs BitType:$result);
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)
+  }];
+}
+
+
+def FltOp : RelationalRealOpBase<"flt"> {
+  let summary = "Real-valued less than comparison";
+}
+def FleOp : RelationalRealOpBase<"fle"> {
+  let summary = "Real-valued less than or equal comparison";
+}
+def FgtOp : RelationalRealOpBase<"fgt"> {
+  let summary = "Real-valued greater than comparison";
+}
+def FgeOp : RelationalRealOpBase<"fge"> {
+  let summary = "Real-valued greater than or equal comparison";
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3485,3 +3485,199 @@ function string testStrLiteralReturn;
     // CHECK-NEXT: return [[STR]] : !moore.string
     return testStrLiteral;
 endfunction // testStrLiteralReturn
+
+// CHECK-LABEL: func.func private @testRealOps()
+function void testRealOps;
+    // CHECK-NEXT: [[A:%.+]] = moore.variable : <f64>
+    // CHECK-NEXT: [[B:%.+]] = moore.variable : <f64>
+    // CHECK-NEXT: [[RESR:%.+]] = moore.variable : <f64>
+    real a, b, resr;
+    // CHECK-NEXT: [[C:%.+]] = moore.variable : <f32>
+    // CHECK-NEXT: [[D:%.+]] = moore.variable : <f32>
+    // CHECK-NEXT: [[RESSR:%.+]] = moore.variable : <f32>
+    shortreal c, d, ressr;
+    // CHECK-NEXT: [[TEST:%.+]] = moore.variable : <i1>
+    bit        test;
+
+
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fadd [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[RESR]], [[OUT]] : f64
+    resr = a + b;
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fsub [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[RESR]], [[OUT]] : f64
+    resr = a - b;
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fmul [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[RESR]], [[OUT]] : f64
+    resr = a * b;
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fdiv [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[RESR]], [[OUT]] : f64
+    resr = a / b;
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fpow [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[RESR]], [[OUT]] : f64
+    resr = a ** b;
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.feq [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (a == b);
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fne [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (a != b);
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.flt [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (a < b);
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fle [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (a <= b);
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fgt [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (a > b);
+    // CHECK: [[LHS:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fge [[LHS]], [[RHS]] : f64
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (a >= b);
+
+    // CHECK: [[OP:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[ONE:%.+]] = moore.real_constant 1.000000e+00
+    // CHECK-NEXT: [[ANEW:%.+]] = moore.fadd [[OP]], [[ONE]] : f64
+    a++;
+    // CHECK: [[OP:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[ONE:%.+]] = moore.real_constant 1.000000e+00
+    // CHECK-NEXT: [[ANEW:%.+]] = moore.fsub [[OP]], [[ONE]] : f64
+    a--;
+    // CHECK: [[OP:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[ANEW:%.+]] = moore.fneg [[OP]] : f64
+    a = -a;
+    // CHECK: [[OP:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: moore.blocking_assign [[A]], [[OP]] : f64
+    a = +a;
+    // CHECK: [[OP:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[BOOL:%.+]] = moore.bool_cast [[OP]] : f64 -> i1
+    // CHECK-NEXT: [[NOT:%.+]] = moore.not [[BOOL]] : i1
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[NOT]] : i1
+    test = !a;
+    // CHECK: [[RHS1:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS2:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[B1:%.+]] = moore.bool_cast [[RHS1]] : f64 -> i1
+    // CHECK-NEXT: [[B2:%.+]] = moore.bool_cast [[RHS2]] : f64 -> i1
+    // CHECK-NEXT: [[OUT:%.+]] = moore.and [[B1]], [[B2]] : i1
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = a && b;
+    // CHECK: [[RHS1:%.+]] = moore.read [[A]] : <f64>
+    // CHECK-NEXT: [[RHS2:%.+]] = moore.read [[B]] : <f64>
+    // CHECK-NEXT: [[B1:%.+]] = moore.bool_cast [[RHS1]] : f64 -> i1
+    // CHECK-NEXT: [[B2:%.+]] = moore.bool_cast [[RHS2]] : f64 -> i1
+    // CHECK-NEXT: [[OUT:%.+]] = moore.or [[B1]], [[B2]] : i1
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = a || b;
+
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fadd [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[RESSR]], [[OUT]] : f32
+    ressr = c + d;
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fsub [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[RESSR]], [[OUT]] : f32
+    ressr = c - d;
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fmul [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[RESSR]], [[OUT]] : f32
+    ressr = c * d;
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fdiv [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[RESSR]], [[OUT]] : f32
+    ressr = c / d;
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fpow [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[RESSR]], [[OUT]] : f32
+    ressr = c ** d;
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.feq [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (c == d);
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fne [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (c != d);
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.flt [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (c < d);
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fle [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (c <= d);
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fgt [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (c > d);
+    // CHECK: [[LHS:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[OUT:%.+]] = moore.fge [[LHS]], [[RHS]] : f32
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = (c >= d);
+
+    // CHECK: [[OP:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[ONE:%.+]] = moore.shortreal_constant 1.000000e+00
+    // CHECK-NEXT: [[CNEW:%.+]] = moore.fadd [[OP]], [[ONE]] : f32
+    c++;
+    // CHECK: [[OP:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[ONE:%.+]] = moore.shortreal_constant 1.000000e+00
+    // CHECK-NEXT: [[CNEW:%.+]] = moore.fsub [[OP]], [[ONE]] : f32
+    c--;
+    // CHECK: [[OP:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[CNEW:%.+]] = moore.fneg [[OP]] : f32
+    c = -c;
+    // CHECK: [[OP:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: moore.blocking_assign [[C]], [[OP]] : f32
+    c = +c;
+    // CHECK: [[OP:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[BOOL:%.+]] = moore.bool_cast [[OP]] : f32 -> i1
+    // CHECK-NEXT: [[NOT:%.+]] = moore.not [[BOOL]] : i1
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[NOT]] : i1
+    test = !c;
+    // CHECK: [[RHS1:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS2:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[B1:%.+]] = moore.bool_cast [[RHS1]] : f32 -> i1
+    // CHECK-NEXT: [[B2:%.+]] = moore.bool_cast [[RHS2]] : f32 -> i1
+    // CHECK-NEXT: [[OUT:%.+]] = moore.and [[B1]], [[B2]] : i1
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = c && d;
+    // CHECK: [[RHS1:%.+]] = moore.read [[C]] : <f32>
+    // CHECK-NEXT: [[RHS2:%.+]] = moore.read [[D]] : <f32>
+    // CHECK-NEXT: [[B1:%.+]] = moore.bool_cast [[RHS1]] : f32 -> i1
+    // CHECK-NEXT: [[B2:%.+]] = moore.bool_cast [[RHS2]] : f32 -> i1
+    // CHECK-NEXT: [[OUT:%.+]] = moore.or [[B1]], [[B2]] : i1
+    // CHECK-NEXT: moore.blocking_assign [[TEST]], [[OUT]] : i1
+    test = c || d;
+
+endfunction // testStrLiteralReturn


### PR DESCRIPTION

Introduce full **real (f32/f64)** operator support in the Moore dialect and the ImportVerilog conversion, including unary, arithmetic, equality, relational, logical, and ++/-- forms. Refactor logical operator lowering to a reusable helper and add comprehensive tests.

- **Dialect (`MooreOps.td`):**
  - New unary real op: `NegRealOp` -> `moore.fneg`.
  - Real binary op base: `BinaryRealOpBase` for typed f32/f64 operands/results.
  - Arithmetic: `AddRealOp` (`fadd`), `SubRealOp` (`fsub`), `MulRealOp` (`fmul`), `DivRealOp` (`fdiv`), `PowRealOp` (`fpow`).
  - Equality: `EqRealOp` (`feq`), `NeRealOp` (`fne`).
  - Relational: `FltOp` (`flt`), `FleOp` (`fle`), `FgtOp` (`fgt`), `FgeOp` (`fge`).
  - All ops follow IEEE 1800-2023 §11.3.1, §11.4.3–§11.4.5 semantics.

- **Import (`Expressions.cpp`):**
  - Add `visitRealUOp` and `visitRealBOp` to lower real-typed unary/binary expressions.
  - Implement pre/post **increment/decrement** for real variables via `fadd`/`fsub` with an exact `APFloat` **"1.0"** (IEEEsingle/IEEEdouble) constructor.
  - Add `moore.fneg` for unary minus; unary plus becomes a no-op.
  - Map real comparisons to `feq/fne/flt/fle/fgt/fge`.
  - **Refactor logical ops** into `buildLogicalBOp(...)` (optional `Domain` param), shared by int/real paths. (Short-circuit remains TODO.)
  - Route mixed/real expressions early to the real path; keep existing integral flow otherwise.

- **Tests (`basic.sv`):**
  - New end-to-end checks for f64/f32 arithmetic, comparisons, logicals, unary ops, and ++/--.
  - Assert exact opcode emission (`moore.fadd/fsub/fmul/fdiv/fpow/feq/fne/flt/fle/fgt/fge/fneg`) and constant forms for `1.0`.
