### PR TITLE
[FIRRTL] Make containingModule compatible with Chisel changes

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1050,7 +1050,7 @@ om::ClassLike LowerClassesPass::createClass(FModuleLike moduleLike,
       formalParamNames.push_back(port.name);
 
       // Check if we have a 'containingModule' field.
-      if (port.name.strref().starts_with(kContainingModuleName))
+      if (port.name.strref().contains(kContainingModuleName))
         hasContainingModule = true;
     }
   }
@@ -1118,7 +1118,7 @@ void LowerClassesPass::lowerClass(om::ClassOp classOp, FModuleLike moduleLike,
       inputProperties.push_back({index, port.name, port.type, port.loc});
 
       // Check if we have a 'containingModule' field.
-      if (port.name.strref().starts_with(kContainingModuleName))
+      if (port.name.strref().contains(kContainingModuleName))
         hasContainingModule = true;
     }
 
@@ -1297,7 +1297,7 @@ static LogicalResult updateObjectInClass(
             opsToErase.push_back(propassign);
 
             // Check if we have a 'containingModule' field.
-            if (firrtlClassType.getElement(index).name.strref().starts_with(
+            if (firrtlClassType.getElement(index).name.strref().contains(
                     kContainingModuleName)) {
               assert(!containingModuleRef &&
                      "expected exactly one containingModule");

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -552,21 +552,21 @@ firrtl.circuit "RTLPorts" {
     // CHECK: [[PORTS_LIST:%.+]] = om.list_create [[INPUT_OBJ]], [[OUTPUT_OBJ]]
 
     // CHECK: om.object @NeedsRTLPorts(%basepath, [[MODULE_PATH]], [[PORTS_LIST]])
-    %object = firrtl.object @NeedsRTLPorts(in containingModule_in: !firrtl.path, out containingModule: !firrtl.path)
-    %field = firrtl.object.subfield %object[containingModule_in] : !firrtl.class<@NeedsRTLPorts(in containingModule_in: !firrtl.path, out containingModule: !firrtl.path)>
+    %object = firrtl.object @NeedsRTLPorts(in __in_containingModule: !firrtl.path, out containingModule: !firrtl.path)
+    %field = firrtl.object.subfield %object[__in_containingModule] : !firrtl.class<@NeedsRTLPorts(in __in_containingModule: !firrtl.path, out containingModule: !firrtl.path)>
     firrtl.propassign %field, %path : !firrtl.path
 
     // Add a second instance to ensure the RtlPorts class is only declared once.
-    %object2 = firrtl.object @NeedsRTLPorts(in containingModule_in: !firrtl.path, out containingModule: !firrtl.path)
-    %field2 = firrtl.object.subfield %object2[containingModule_in] : !firrtl.class<@NeedsRTLPorts(in containingModule_in: !firrtl.path, out containingModule: !firrtl.path)>
+    %object2 = firrtl.object @NeedsRTLPorts(in __in_containingModule: !firrtl.path, out containingModule: !firrtl.path)
+    %field2 = firrtl.object.subfield %object2[__in_containingModule] : !firrtl.class<@NeedsRTLPorts(in __in_containingModule: !firrtl.path, out containingModule: !firrtl.path)>
     firrtl.propassign %field2, %path : !firrtl.path
   }
 
-  // CHECK: om.class @NeedsRTLPorts(%basepath: !om.basepath, %containingModule_in: !om.path, %ports: !om.list<!om.class.type<@RtlPort>>)
+  // CHECK: om.class @NeedsRTLPorts(%basepath: !om.basepath, %__in_containingModule: !om.path, %ports: !om.list<!om.class.type<@RtlPort>>)
   // CHECK-SAME: -> (containingModule: !om.path, ports: !om.list<!om.class.type<@RtlPort>>)
-  firrtl.class @NeedsRTLPorts(in %containingModule_in: !firrtl.path, out %containingModule: !firrtl.path) {
-    // CHECK: om.class.fields  %containingModule_in, %ports : !om.path, !om.list<!om.class.type<@RtlPort>>
-    firrtl.propassign %containingModule, %containingModule_in : !firrtl.path
+  firrtl.class @NeedsRTLPorts(in %__in_containingModule: !firrtl.path, out %containingModule: !firrtl.path) {
+    // CHECK: om.class.fields  %__in_containingModule, %ports : !om.path, !om.list<!om.class.type<@RtlPort>>
+    firrtl.propassign %containingModule, %__in_containingModule : !firrtl.path
   }
 
   // CHECK: om.class @RtlPort(%ref: !om.path, %direction: !om.string, %width: !om.integer)  -> (ref: !om.path, direction: !om.string, width: !om.integer)


### PR DESCRIPTION
Adjust the LowerClasses pass to make it match the `containingModule` field more generously. Some Chisel-side tweaks are going to change this name from `containingModule_in` to `__in_containingModule`, which the current code does not match.

It's a bit unfortunate that we have this weakly stringly-type interface in the compiler, but we need it at the moment for compatibility.