### PR TITLE
[Moore] [1/4] Implement ClassHandleType, ClassDeclarationOp

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2354,4 +2354,46 @@ def AtanhBIOp : RealMathFunc<"atanh"> {
   let summary = "Arc-hyperbolic tangent";
 }
 
+//===----------------------------------------------------------------------===//
+// Classes
+//===----------------------------------------------------------------------===//
+
+def ClassPropertyDeclOp
+    : MooreOp<"class.propertydecl", [Symbol, HasParent<"ClassDeclOp">]> {
+  let summary = "Declare a class property";
+  let description = [{
+  Declares a property within a class declaration.
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name, TypeAttr:$type);
+
+  let results = (outs);
+  let assemblyFormat = [{
+     $sym_name `:` $type  attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::Type getPropertyType() { return getTypeAttr().getValue(); }
+  }];
+}
+
+def ClassDeclOp
+    : MooreOp<"class.classdecl", [Symbol, SymbolTable, IsolatedFromAbove,
+    NoTerminator, SingleBlock]> {
+  let summary = "Class declaration";
+  let arguments = (ins SymbolNameAttr:$sym_name,
+      OptionalAttr<SymbolRefAttr>:$base,
+      OptionalAttr<SymbolRefArrayAttr>:$implementedInterfaces);
+  let results = (outs);
+  let regions = (region AnyRegion:$body);
+  let assemblyFormat = [{
+    $sym_name
+    (`extends` $base^)?
+    (`implements` $implementedInterfaces^)?
+    attr-dict-with-keyword $body
+  }];
+  let hasVerifier = 1;
+}
+
+
 #endif // CIRCT_DIALECT_MOORE_MOOREOPS

--- a/include/circt/Dialect/Moore/MooreTypes.h
+++ b/include/circt/Dialect/Moore/MooreTypes.h
@@ -43,6 +43,7 @@ class UnpackedArrayType;
 class UnpackedStructType;
 class UnpackedUnionType;
 class VoidType;
+class ClassHandleType;
 
 /// The number of values each bit of a type can assume.
 enum class Domain {
@@ -102,7 +103,8 @@ public:
   static bool classof(Type type) {
     return llvm::isa<PackedType, StringType, ChandleType, EventType, RealType,
                      UnpackedArrayType, OpenUnpackedArrayType, AssocArrayType,
-                     QueueType, UnpackedStructType, UnpackedUnionType>(type);
+                     QueueType, UnpackedStructType, UnpackedUnionType,
+                     ClassHandleType>(type);
   }
 
   /// Get the value domain of this type.

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -52,6 +52,19 @@ def EventType : MooreTypeDef<"Event", [], "moore::UnpackedType"> {
   let summary = "the SystemVerilog `event` type";
 }
 
+//===----------------------------------------------------------------------===//
+// ClassHandleType
+//===----------------------------------------------------------------------===//
+
+def ClassHandleType : MooreTypeDef<"ClassHandle", [], "moore::UnpackedType"> {
+  let mnemonic = "class";
+  let summary = "Class object handle type, pointing to an object on the heap.";
+  let description = [{
+      The `!moore.class<@C>` type represents a handle of a class instance of class `@C` living on the program's heap.
+  }];
+  let parameters = (ins AttrParameter<"::mlir::SymbolRefAttr", "class symbol">:$classSym);
+  let assemblyFormat = "`<` $classSym `>`";
+}
 
 //===----------------------------------------------------------------------===//
 // TimeType
@@ -559,4 +572,6 @@ def UnionRefType : SpecificRefType<UnionType>;
 def UnpackedUnionRefType : SpecificRefType<UnpackedUnionType>;
 def AnyUnionRefType : SpecificRefType<AnyUnionType>;
 
+/// Class references.
+def ClassHandleRefType : SpecificRefType<ClassHandleType>;
 #endif // CIRCT_DIALECT_MOORE_MOORETYPES

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -55,6 +55,11 @@ struct FunctionLowering {
   bool isConverting = false;
 };
 
+// Class lowering information.
+struct ClassLowering {
+  circt::moore::ClassDeclOp op;
+};
+
 /// Information about a loops continuation and exit blocks relevant while
 /// lowering the loop's body statements.
 struct LoopFrame {
@@ -115,6 +120,8 @@ struct Context {
   declareFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult convertFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult finalizeFunctionBodyCaptures(FunctionLowering &lowering);
+  LogicalResult convertClassDeclaration(const slang::ast::ClassType &classdecl);
+  ClassLowering *declareClass(const slang::ast::ClassType &cls);
 
   // Convert a statement AST node to MLIR ops.
   LogicalResult convertStatement(const slang::ast::Statement &stmt);
@@ -252,6 +259,10 @@ struct Context {
            std::unique_ptr<FunctionLowering>>
       functions;
 
+  /// Classes that have already been converted.
+  DenseMap<const slang::ast::ClassType *, std::unique_ptr<ClassLowering>>
+      classes;
+
   /// A table of defined values, such as variables, that may be referred to by
   /// name in expressions. The expressions use this table to lookup the MLIR
   /// value that was created for a given declaration in the Slang AST node.
@@ -298,5 +309,4 @@ struct Context {
 
 } // namespace ImportVerilog
 } // namespace circt
-
 #endif // CONVERSION_IMPORTVERILOG_IMPORTVERILOGINTERNALS_H

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -166,6 +166,15 @@ struct TypeVisitor {
     return moore::ChandleType::get(context.getContext());
   }
 
+  Type visit(const slang::ast::ClassType &type) {
+    if (auto *lowering = context.declareClass(type)) {
+      mlir::StringAttr symName = lowering->op.getSymNameAttr();
+      mlir::FlatSymbolRefAttr symRef = mlir::FlatSymbolRefAttr::get(symName);
+      return moore::ClassHandleType::get(context.getContext(), symRef);
+    }
+    return {};
+  }
+
   /// Emit an error for all other types.
   template <typename T>
   Type visit(T &&node) {

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -1367,6 +1367,28 @@ OpFoldResult DivSOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// Classes
+//===----------------------------------------------------------------------===//
+
+LogicalResult ClassDeclOp::verify() {
+  mlir::Region &body = getBody();
+  if (body.empty())
+    return mlir::success();
+
+  auto &block = body.front();
+  for (mlir::Operation &op : block) {
+
+    // allow only property and method decls
+    if (llvm::isa<circt::moore::ClassPropertyDeclOp>(&op))
+      continue;
+
+    return emitOpError()
+           << "body may only contain 'moore.class.propertydecl' operations";
+  }
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -1,0 +1,145 @@
+// RUN: circt-verilog %s --parse-only | FileCheck %s
+
+/// Flag tests
+
+// CHECK-LABEL: moore.class.classdecl @plain {
+// CHECK: }
+class plain;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @abstractOnly {
+// CHECK: }
+virtual class abstractOnly;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @interfaceTestClass {
+// CHECK: }
+interface class interfaceTestClass;
+endclass
+
+/// Interface tests
+
+// CHECK-LABEL: moore.class.classdecl @interfaceTestClass2 implements [@interfaceTestClass] {
+// CHECK: }
+class interfaceTestClass2 implements interfaceTestClass;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @interfaceTestClass3 implements [@interfaceTestClass] {
+// CHECK: }
+interface class interfaceTestClass3 extends interfaceTestClass;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @interfaceTestClass4 implements [@interfaceTestClass3] {
+// CHECK: }
+class interfaceTestClass4 implements interfaceTestClass3;
+endclass
+
+/// Inheritance tests
+
+// CHECK-LABEL: moore.class.classdecl @inheritanceTest {
+// CHECK: }
+class inheritanceTest;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @inheritanceTest2 extends @inheritanceTest {
+// CHECK: }
+class inheritanceTest2 extends inheritanceTest;
+endclass
+
+// Inheritance + interface tests
+
+// CHECK-LABEL: moore.class.classdecl @D extends @plain {
+// CHECK: }
+class D extends plain;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @Impl1 implements [@interfaceTestClass] {
+// CHECK: }
+class Impl1 implements interfaceTestClass;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @Impl2 implements [@interfaceTestClass, @interfaceTestClass3] {
+// CHECK: }
+class Impl2 implements interfaceTestClass, interfaceTestClass3;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @DI extends @D implements [@interfaceTestClass] {
+// CHECK: }
+class DI extends D implements interfaceTestClass;
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @IMulti implements [@interfaceTestClass, @interfaceTestClass3] {
+// CHECK: }
+interface class IMulti extends interfaceTestClass, interfaceTestClass3;
+endclass
+
+/// Property tests
+
+// CHECK-LABEL: moore.class.classdecl @PropertyCombo {
+// CHECK:   moore.class.propertydecl @pubAutoI32 : !moore.i32
+// CHECK-NEXT:   moore.class.propertydecl @protStatL18 : !moore.l18
+// CHECK-NEXT:   moore.class.propertydecl @localAutoI32 : !moore.i32
+// CHECK: }
+class PropertyCombo;
+  // public automatic int
+  int pubAutoI32;
+
+  // protected static logic [17:0]
+  protected static logic [17:0] protStatL18;
+
+  // local automatic int
+  local int localAutoI32;
+endclass
+
+// Ensure multiple propertys preserve declaration order
+// CHECK-LABEL: moore.class.classdecl @PropertyOrder {
+// CHECK:   moore.class.propertydecl @a : !moore.i32
+// CHECK-NEXT:   moore.class.propertydecl @b : !moore.i32
+// CHECK-NEXT:   moore.class.propertydecl @c : !moore.i32
+// CHECK: }
+class PropertyOrder;
+  int a;
+  int b;
+  int c;
+endclass
+
+// Classes within packages
+package testPackage;
+   // CHECK-LABEL: moore.class.classdecl @"testPackage::testPackageClass" {
+   class testPackageClass;
+   // CHECK: }
+   endclass
+endpackage
+
+// CHECK-LABEL: moore.module @testModule() {
+// CHECK: }
+// CHECK: moore.class.classdecl @"testModule::testModuleClass" {
+// CHECK: }
+module testModule #();
+   class testModuleClass;
+   endclass
+endmodule
+
+// CHECK-LABEL: moore.class.classdecl @testClass {
+// CHECK: }
+// CHECK: moore.class.classdecl @"testClass::testClass" {
+// CHECK: }
+class testClass;
+   class testClass;
+   endclass // testClass
+endclass
+
+/// Check handle variable
+
+// CHECK-LABEL:  moore.module @testModule2() {
+// CHECK-NEXT: [[OBJ:%.+]] = moore.variable : <class<@"testModule2::testModuleClass">>
+// CHECK-NEXT:     moore.output
+// CHECK-NEXT:   }
+// CHECK: moore.class.classdecl @"testModule2::testModuleClass" {
+// CHECK: }
+module testModule2 #();
+    class testModuleClass;
+    endclass // testModuleClass2
+    testModuleClass t;
+
+endmodule

--- a/test/Dialect/Moore/classes.mlir
+++ b/test/Dialect/Moore/classes.mlir
@@ -1,0 +1,84 @@
+// RUN: circt-opt --verify-diagnostics --verify-roundtrip %s | FileCheck %s
+
+module {
+// CHECK-LABEL: moore.class.classdecl @Plain {
+// CHECK: }
+moore.class.classdecl @Plain {
+}
+
+// CHECK-LABEL:   moore.class.classdecl @I {
+// CHECK:   }
+moore.class.classdecl @I {
+}
+
+// CHECK-LABEL:   moore.class.classdecl @Base {
+// CHECK:   }
+// CHECK:   moore.class.classdecl @Derived extends @Base {
+// CHECK:   }
+moore.class.classdecl @Base {
+}
+moore.class.classdecl @Derived extends @Base {
+}
+
+// CHECK-LABEL:   moore.class.classdecl @IBase {
+// CHECK:   }
+// CHECK:   moore.class.classdecl @IExt extends @IBase {
+// CHECK:   }
+
+moore.class.classdecl @IBase {
+}
+moore.class.classdecl @IExt extends @IBase {
+}
+
+// CHECK-LABEL:   moore.class.classdecl @IU {
+// CHECK:   }
+// CHECK:   moore.class.classdecl @C1 implements [@IU] {
+// CHECK:   }
+moore.class.classdecl @IU {
+}
+moore.class.classdecl @C1 implements [@IU] {
+}
+
+// CHECK-LABEL:   moore.class.classdecl @I1 {
+// CHECK:   }
+// CHECK:   moore.class.classdecl @I2 {
+// CHECK:   }
+// CHECK:   moore.class.classdecl @C2 implements [@I1, @I2] {
+// CHECK:   }
+moore.class.classdecl @I1 {
+}
+moore.class.classdecl @I2 {
+}
+moore.class.classdecl @C2 implements [@I1, @I2] {
+}
+
+// CHECK-LABEL:   moore.class.classdecl @B {
+// CHECK:   }
+// CHECK:   moore.class.classdecl @J1 {
+// CHECK:   }
+// CHECK:   moore.class.classdecl @J2 {
+// CHECK:   }
+// CHECK:   moore.class.classdecl @D extends @B implements [@J1, @J2] {
+// CHECK:   }
+moore.class.classdecl @B {
+}
+moore.class.classdecl @J1 {
+}
+moore.class.classdecl @J2 {
+}
+moore.class.classdecl @D extends @B implements [@J1, @J2] {
+}
+
+// CHECK-LABEL:   moore.class.classdecl @PropertyCombo {
+// CHECK-NEXT:     moore.class.propertydecl @pubAutoI32 : !moore.i32
+// CHECK-NEXT:     moore.class.propertydecl @protStatL18 : !moore.l18
+// CHECK-NEXT:     moore.class.propertydecl @localAutoI32 : !moore.i32
+// CHECK:   }
+moore.class.classdecl @PropertyCombo {
+  moore.class.propertydecl @pubAutoI32 : !moore.i32
+  moore.class.propertydecl @protStatL18 : !moore.l18
+  moore.class.propertydecl @localAutoI32 : !moore.i32
+}
+
+
+}


### PR DESCRIPTION
This change introduces first-class **class** support to the Moore dialect and teaches the Verilog importer to **recognize and lower SV classes** into that IR. It also adds an opaque **class handle type** for values of class objects.

- New **IR ops** for classes: declarations, properties, and a class-body terminator.
- New **type**: `!moore.class.object<@Sym>` (with `ref` variant).
- Importer now **creates symbols for classes**, wires up `extends`/`implements`, and lowers **class-typed values** to `!moore.class.object<…>`.
- Extensive **tests** for inheritance, interfaces, properties, scoping, and handle declarations.