### PR TITLE
[Moore] [2/4] Implement new operator

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2395,5 +2395,22 @@ def ClassDeclOp
   let hasVerifier = 1;
 }
 
+def ClassNewOp
+    : MooreOp<
+          "class.new", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Allocate a new class instance";
+  let description = [{
+    Allocates a new instance of class @C. This op does not call the constructor.
+    The result is a non-null `!moore.class.object<@C>` handle.
+  }];
+
+  let arguments = (ins);
+  let results = (outs ClassHandleType:$result);
+
+  let assemblyFormat = [{
+     `:` type($result) attr-dict
+  }];
+  let hasVerifier = 1;
+}
 
 #endif // CIRCT_DIALECT_MOORE_MOOREOPS

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1559,6 +1559,22 @@ struct RvalueExprVisitor : public ExprVisitor {
     return context.convertAssertionExpression(expr.body, loc);
   }
 
+  Value visit(const slang::ast::NewClassExpression &expr) {
+    auto type = context.convertType(*expr.type);
+    auto classTy = dyn_cast<moore::ClassHandleType>(type);
+    if (!classTy)
+      return {};
+
+    auto newOp = moore::ClassNewOp::create(builder, loc, classTy, {});
+    auto constructor = expr.constructorCall();
+    if (!constructor)
+      return newOp.getResult();
+
+    mlir::emitError(loc) << "New expression requires constructor call, which "
+                            "is not yet implemented!";
+    return {};
+  }
+
   /// Emit an error for all other expressions.
   template <typename T>
   Value visit(T &&node) {

--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -143,3 +143,23 @@ module testModule2 #();
     testModuleClass t;
 
 endmodule
+
+/// Check calls to new without explicit constructor
+
+// CHECK-LABEL: moore.module @testModule3() {
+// CHECK: [[T:%.*]] = moore.variable : <class<@"testModule3::testModuleClass">>
+// CHECK: moore.procedure initial {
+// CHECK:   [[NEW:%.*]] = moore.class.new : <@"testModule3::testModuleClass">
+// CHECK:   moore.blocking_assign [[T]], [[NEW]] : class<@"testModule3::testModuleClass">
+// CHECK:   moore.return
+// CHECK: }
+// CHECK: moore.output
+
+module testModule3;
+    class testModuleClass;
+    endclass
+    testModuleClass t;
+    initial begin
+        t = new;
+    end
+endmodule


### PR DESCRIPTION
Adds heap allocation support for class objects.

- **New op:** `moore.class.new`
  - Allocates a new instance of a class symbol (`!moore.class.object<@C>`).
  - Implements `MemoryEffectsOpInterface` (reports `Allocate`).
  - Verifies that the referenced class symbol exists and is a valid `ClassDeclOp`.

- **Importer:**
  - `ImportVerilog/Expressions.cpp` now lowers `new` expressions to `moore.class.new`.
  - Emits an error if a constructor call is present (not yet supported).

- **Tests:**
  - Added `testModule3` in `classes.sv` to verify `new` lowering and expected IR.