### PR TITLE
[Moore] [3/4] Implement class member access, upcast

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2413,4 +2413,35 @@ def ClassNewOp
   let hasVerifier = 1;
 }
 
+
+def ClassPropertyRefOp
+    : MooreOp<"class.property_ref", [Pure,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,]> {
+  let summary = "Get a !moore.ref to a class property";
+  let description = [{
+    Construct a reference to a class instance's property field. Translates
+    to a fixed offset from the the class handle into its data struct.
+  }];
+  let arguments = (ins ClassHandleType:$instance,
+      FlatSymbolRefAttr:$property);
+  let results = (outs RefType:$propertyRef);
+  let assemblyFormat = "$instance`[`$property`]` `:` type($instance) `->` "
+                       "type($propertyRef) attr-dict";
+}
+
+def ClassUpcastOp
+    : MooreOp<"class.upcast", [Pure,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,]> {
+  let summary = "Upcast a derived handle to a base handle (zero-cost)";
+  let description = [{
+    Casts an instance of a class to one of its base classes.
+    The created instance points to the same underlying data struct as the original
+    instance, and modifying it will modify the spawning instance's data as well.
+  }];
+  let arguments = (ins ClassHandleType:$instance);
+  let results = (outs ClassHandleType:$result);
+  let assemblyFormat =
+      "$instance `:` type($instance) `to` type($result) attr-dict";
+}
+
 #endif // CIRCT_DIALECT_MOORE_MOOREOPS

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -123,6 +123,17 @@ struct Context {
   LogicalResult convertClassDeclaration(const slang::ast::ClassType &classdecl);
   ClassLowering *declareClass(const slang::ast::ClassType &cls);
 
+  /// Checks whether one class (actualTy) is derived from another class
+  /// (baseTy). True if it's a subclass, false otherwise.
+  bool isClassDerivedFrom(const moore::ClassHandleType &actualTy,
+                          const moore::ClassHandleType &baseTy);
+
+  /// Tries to find the closest base class of actualTy that carries
+  /// a property with name fieldName.
+  moore::ClassHandleType
+  getAncestorClassWithProperty(const moore::ClassHandleType &actualTy,
+                               StringRef fieldName);
+
   // Convert a statement AST node to MLIR ops.
   LogicalResult convertStatement(const slang::ast::Statement &stmt);
 

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -1417,6 +1417,110 @@ void ClassNewOp::getEffects(
   effects.emplace_back(MemoryEffects::Allocate::get());
 }
 
+LogicalResult
+ClassUpcastOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // 1) Type checks.
+  auto srcTy = dyn_cast<ClassHandleType>(getOperand().getType());
+  if (!srcTy)
+    return emitOpError() << "operand must be !moore.class<...>; got "
+                         << getOperand().getType();
+
+  auto dstTy = dyn_cast<ClassHandleType>(getResult().getType());
+  if (!dstTy)
+    return emitOpError() << "result must be !moore.class<...>; got "
+                         << getResult().getType();
+
+  if (srcTy == dstTy)
+    return success();
+
+  auto *op = getOperation();
+
+  auto *srcDeclOp =
+      symbolTable.lookupNearestSymbolFrom(op, srcTy.getClassSym());
+  auto *dstDeclOp =
+      symbolTable.lookupNearestSymbolFrom(op, dstTy.getClassSym());
+  if (!srcDeclOp || !dstDeclOp)
+    return emitOpError() << "failed to resolve class symbol(s): src="
+                         << srcTy.getClassSym()
+                         << ", dst=" << dstTy.getClassSym();
+
+  auto srcDecl = dyn_cast<ClassDeclOp>(srcDeclOp);
+  auto dstDecl = dyn_cast<ClassDeclOp>(dstDeclOp);
+  if (!srcDecl || !dstDecl)
+    return emitOpError()
+           << "symbol(s) do not name `moore.class.classdecl` ops: src="
+           << srcTy.getClassSym() << ", dst=" << dstTy.getClassSym();
+
+  auto cur = srcDecl;
+  while (cur) {
+    if (cur == dstDecl)
+      return success(); // legal upcast: dst is src or an ancestor
+
+    auto baseSym = cur.getBaseAttr();
+    if (!baseSym)
+      break;
+
+    auto *baseOp = symbolTable.lookupNearestSymbolFrom(op, baseSym);
+    cur = llvm::dyn_cast_or_null<ClassDeclOp>(baseOp);
+  }
+
+  return emitOpError() << "cannot upcast from " << srcTy.getClassSym() << " to "
+                       << dstTy.getClassSym()
+                       << " (destination is not a base class)";
+}
+LogicalResult
+ClassPropertyRefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // The operand is constrained to ClassHandleType in ODS; unwrap it.
+  Type instTy = getInstance().getType();
+  auto handleTy = dyn_cast<moore::ClassHandleType>(instTy);
+  if (!handleTy)
+    return emitOpError() << "instance must be a !moore.class<@C> value, got "
+                         << instTy;
+
+  // Extract the referenced class symbol from the handle type.
+  SymbolRefAttr classSym = handleTy.getClassSym();
+  if (!classSym)
+    return emitOpError("instance type is missing a class symbol");
+
+  // Resolve the class symbol starting from the nearest symbol table.
+  Operation *clsSym =
+      symbolTable.lookupNearestSymbolFrom(getOperation(), classSym);
+  if (!clsSym)
+    return emitOpError("referenced class symbol `")
+           << classSym << "` was not found";
+  auto classDecl = dyn_cast<ClassDeclOp>(clsSym);
+  if (!classDecl)
+    return emitOpError("symbol `")
+           << classSym << "` does not name a `moore.class.classdecl`";
+
+  // Look up the field symbol inside the class declaration's symbol table.
+  FlatSymbolRefAttr fieldSym = getPropertyAttr();
+  if (!fieldSym)
+    return emitOpError("missing field symbol");
+
+  Operation *fldSym = symbolTable.lookupSymbolIn(classDecl, fieldSym.getAttr());
+  if (!fldSym)
+    return emitOpError("no field `") << fieldSym << "` in class " << classSym;
+
+  auto fieldDecl = dyn_cast<ClassPropertyDeclOp>(fldSym);
+  if (!fieldDecl)
+    return emitOpError("symbol `")
+           << fieldSym << "` is not a `moore.class.propertydecl`";
+
+  // Result must be !moore.ref<T> where T matches the field's declared type.
+  auto resRefTy = cast<RefType>(getPropertyRef().getType());
+  if (!resRefTy)
+    return emitOpError("result must be a !moore.ref<T>");
+
+  Type expectedElemTy = fieldDecl.getPropertyType();
+  if (resRefTy.getNestedType() != expectedElemTy)
+    return emitOpError("result element type (")
+           << resRefTy.getNestedType() << ") does not match field type ("
+           << expectedElemTy << ")";
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -163,3 +163,105 @@ module testModule3;
         t = new;
     end
 endmodule
+
+/// Check property read access
+
+// CHECK-LABEL: moore.module @testModule4() {
+// CHECK: [[T:%.*]] = moore.variable : <class<@"testModule4::testModuleClass">>
+// CHECK: [[RESULT:%.+]] = moore.variable : <i32>
+// CHECK: moore.procedure initial {
+// CHECK:    [[NEW:%.*]] = moore.class.new : <@"testModule4::testModuleClass">
+// CHECK:    moore.blocking_assign [[T]], [[NEW]] : class<@"testModule4::testModuleClass">
+// CHECK:    [[CLASSHANDLE:%.+]] = moore.read [[T]] : <class<@"testModule4::testModuleClass">>
+// CHECK:    [[REF:%.+]] = moore.class.property_ref [[CLASSHANDLE]][@a] : <@"testModule4::testModuleClass"> -> <i32>
+// CHECK:    [[A:%.+]] = moore.read [[REF]]
+// CHECK:    moore.blocking_assign [[RESULT]], [[A]] : i32
+// CHECK:    moore.return
+// CHECK: }
+// CHECK: moore.output
+// CHECK: }
+
+// CHECK: moore.class.classdecl @"testModule4::testModuleClass" {
+// CHECK-NEXT: moore.class.propertydecl @a : !moore.i32
+// CHECK: }
+
+module testModule4;
+    class testModuleClass;
+       int a;
+    endclass
+    testModuleClass t;
+    int result;
+    initial begin
+        t = new;
+        result = t.a;
+    end
+endmodule
+
+/// Check property write access
+
+// CHECK-LABEL: moore.module @testModule5() {
+// CHECK: [[T:%.*]] = moore.variable : <class<@"testModule5::testModuleClass">>
+// CHECK: [[RESULT:%.+]] = moore.variable : <i32>
+// CHECK: moore.procedure initial {
+// CHECK:    [[NEW:%.*]] = moore.class.new : <@"testModule5::testModuleClass">
+// CHECK:    moore.blocking_assign [[T]], [[NEW]] : class<@"testModule5::testModuleClass">
+// CHECK:    [[CLASSHANDLE:%.+]] = moore.read [[T]] : <class<@"testModule5::testModuleClass">>
+// CHECK:    [[REF:%.+]] = moore.class.property_ref [[CLASSHANDLE]][@a] : <@"testModule5::testModuleClass"> -> <i32>
+// CHECK:    [[RESR:%.+]] = moore.read [[RESULT]] : <i32>
+// CHECK:    moore.blocking_assign [[REF]], [[RESR]] : i32
+// CHECK:    moore.return
+// CHECK: }
+// CHECK: moore.output
+// CHECK: }
+
+// CHECK: moore.class.classdecl @"testModule5::testModuleClass" {
+// CHECK-NEXT: moore.class.propertydecl @a : !moore.i32
+// CHECK: }
+
+module testModule5;
+    class testModuleClass;
+       int a;
+    endclass
+    testModuleClass t;
+    int result;
+    initial begin
+        t = new;
+        t.a = result;
+    end
+endmodule
+
+/// Check implicit upcast
+
+// CHECK-LABEL: moore.module @testModule6() {
+// CHECK: [[T:%.*]] = moore.variable : <class<@"testModule6::testModuleClass2">>
+// CHECK: [[RESULT:%.+]] = moore.variable : <i32>
+// CHECK: moore.procedure initial {
+// CHECK:    [[NEW:%.*]] = moore.class.new : <@"testModule6::testModuleClass2">
+// CHECK:    moore.blocking_assign [[T]], [[NEW]] : class<@"testModule6::testModuleClass2">
+// CHECK:    [[CLASSHANDLE:%.+]] = moore.read [[T]] : <class<@"testModule6::testModuleClass2">>
+// CHECK:    [[UPCAST:%.+]] = moore.class.upcast [[CLASSHANDLE]] : <@"testModule6::testModuleClass2"> to <@"testModule6::testModuleClass">
+// CHECK:    [[REF:%.+]] = moore.class.property_ref [[UPCAST]][@a] : <@"testModule6::testModuleClass"> -> <i32>
+// CHECK:    [[A:%.+]] = moore.read [[REF]]
+// CHECK:    moore.blocking_assign [[RESULT]], [[A]] : i32
+// CHECK:    moore.return
+// CHECK: }
+// CHECK: moore.output
+// CHECK: }
+
+// CHECK: moore.class.classdecl @"testModule6::testModuleClass" {
+// CHECK-NEXT: moore.class.propertydecl @a : !moore.i32
+// CHECK: }
+
+module testModule6;
+    class testModuleClass;
+       int a;
+    endclass
+    class testModuleClass2 extends testModuleClass;
+    endclass
+    testModuleClass2 t;
+    int result;
+    initial begin
+        t = new;
+        result = t.a;
+    end
+endmodule


### PR DESCRIPTION

- **New IR ops**
  - `moore.class.property_ref`: yields a `!moore.ref<T>` to a class property.
  - `moore.class.upcast`: converts a derived class handle to one of its base class handles (zero-cost).

- **Class handle utilities**
  - Added `Context::isSameOrDerivedFrom()` and `getAncestorClassWithProperty()` for inheritance and field lookup.
  - Added verifiers for both new ops ensuring valid symbols & types.

- `ImportVerilog/Expressions.cpp`:
  - Added implicit handle upcasting (`maybeUpcastHandle`).
  - Added lowering for `t.a` reads/writes via `moore.class.property_ref`.
  - Emits `moore.class.upcast` when accessing inherited fields.

- Added coverage for:
  - Property read/write (`t.a`, `t.a = x`).
  - Implicit upcast from derived -> base before member access.
