### PR TITLE
[Moore] [4/4] Implement direct class method calls

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.h
+++ b/include/circt/Dialect/Moore/MooreOps.h
@@ -18,7 +18,9 @@
 #include "circt/Dialect/Moore/MooreDialect.h"
 #include "circt/Dialect/Moore/MooreTypes.h"
 #include "mlir/IR/RegionKindInterface.h"
+#include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/MemorySlotInterfaces.h"
 

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -20,6 +20,7 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/MemorySlotInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 
 // Base class for the operations in this dialect.
 class MooreOp<string mnemonic, list<Trait> traits = []> :
@@ -2374,6 +2375,20 @@ def ClassPropertyDeclOp
 
   let extraClassDeclaration = [{
     ::mlir::Type getPropertyType() { return getTypeAttr().getValue(); }
+  }];
+}
+
+
+def ClassMethodDeclOp
+    : MooreOp<"class.methoddecl", [Symbol, HasParent<"ClassDeclOp">]> {
+  let summary = "Declare a class method";
+
+  let arguments = (ins SymbolNameAttr:$sym_name,
+      TypeAttrOf<FunctionType>:$function_type);
+
+  let results = (outs);
+  let assemblyFormat = [{
+      $sym_name `:` $function_type  attr-dict
   }];
 }
 

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -438,6 +438,37 @@ struct RvalueExprVisitor : public ExprVisitor {
       return value;
     }
 
+    // We're reading a class property.
+    if (auto *const property =
+            expr.symbol.as_if<slang::ast::ClassPropertySymbol>()) {
+      auto type = context.convertType(*expr.type);
+
+      // Get the scope's implicit this variable
+      mlir::Value instRef = context.getImplicitThisRef();
+      if (!instRef) {
+        mlir::emitError(loc) << "class property '" << property->name
+                             << "' referenced without an implicit 'this'";
+        return {};
+      }
+
+      auto fieldSym =
+          mlir::FlatSymbolRefAttr::get(builder.getContext(), property->name);
+      auto fieldTy = cast<moore::UnpackedType>(type);
+      auto fieldRefTy = moore::RefType::get(fieldTy);
+
+      moore::ClassHandleType classTy =
+          cast<moore::ClassHandleType>(instRef.getType());
+
+      auto targetClassHandle =
+          context.getAncestorClassWithProperty(classTy, property->name);
+      auto upcastRef = context.materializeConversion(targetClassHandle, instRef,
+                                                     false, instRef.getLoc());
+
+      Value fieldRef = moore::ClassPropertyRefOp::create(
+          builder, loc, fieldRefTy, upcastRef, fieldSym);
+      return moore::ReadOp::create(builder, loc, fieldRef).getResult();
+    }
+
     // Try to materialize constant values directly.
     auto constant = context.evaluateConstant(expr);
     if (auto value = context.materializeConstant(constant, *expr.type, loc))
@@ -1155,12 +1186,6 @@ struct RvalueExprVisitor : public ExprVisitor {
 
   /// Handle calls.
   Value visit(const slang::ast::CallExpression &expr) {
-    // Class method calls are currently not supported.
-    if (expr.thisClass()) {
-      mlir::emitError(loc, "unsupported class method call");
-      return {};
-    }
-
     // Try to materialize constant values directly.
     auto constant = context.evaluateConstant(expr);
     if (auto value = context.materializeConstant(constant, *expr.type, loc))
@@ -1171,9 +1196,77 @@ struct RvalueExprVisitor : public ExprVisitor {
         expr.subroutine);
   }
 
+  /// Get both the actual `this` argument of a method call and the required
+  /// class type.
+  std::pair<Value, moore::ClassHandleType>
+  getMethodReceiverTypeHandle(const slang::ast::CallExpression &expr) {
+
+    moore::ClassHandleType handleTy;
+    Value thisRef;
+
+    // Qualified call: t.m(...), extract from thisClass.
+    if (const slang::ast::Expression *recvExpr = expr.thisClass()) {
+      thisRef = context.convertRvalueExpression(*recvExpr);
+      if (!thisRef)
+        return {};
+    } else {
+      // Unqualified call inside a method body: try using implicit %this.
+      thisRef = context.getImplicitThisRef();
+      if (!thisRef) {
+        mlir::emitError(loc) << "method '" << expr.getSubroutineName()
+                             << "' called without an object";
+        return {};
+      }
+    }
+    handleTy = cast<moore::ClassHandleType>(thisRef.getType());
+    return {thisRef, handleTy};
+  }
+
+  /// Build a method call including implicit this argument.
+  mlir::func::CallOp
+  buildMethodCall(const slang::ast::SubroutineSymbol *subroutine,
+                  FunctionLowering *lowering,
+                  moore::ClassHandleType actualHandleTy, Value actualThisRef,
+                  SmallVector<Value> &arguments,
+                  SmallVector<Type> &resultTypes) {
+
+    // Get the expected receiver type from the lowered method
+    auto funcTy = lowering->op.getFunctionType();
+    auto expected0 = funcTy.getInput(0);
+    auto expectedHdlTy = cast<moore::ClassHandleType>(expected0);
+
+    // Upcast the handle as necessary.
+    auto implicitThisRef = context.materializeConversion(
+        expectedHdlTy, actualThisRef, false, actualThisRef.getLoc());
+
+    // Build an argument list where the this reference is the first argument.
+    SmallVector<Value> explicitArguments;
+    explicitArguments.reserve(arguments.size() + 1);
+    explicitArguments.push_back(implicitThisRef);
+    explicitArguments.append(arguments.begin(), arguments.end());
+
+    // Method call: choose direct vs virtual.
+    const bool isVirtual =
+        (subroutine->flags & slang::ast::MethodFlags::Virtual) != 0;
+
+    if (!isVirtual) {
+      // Direct (non-virtual) call -> moore.class.call
+      auto calleeSym =
+          SymbolRefAttr::get(context.getContext(), lowering->op.getSymName());
+      return mlir::func::CallOp::create(builder, loc, resultTypes, calleeSym,
+                                        explicitArguments);
+    }
+
+    mlir::emitError(loc) << "virtual method calls not supported";
+    return {};
+  }
+
   /// Handle subroutine calls.
   Value visitCall(const slang::ast::CallExpression &expr,
                   const slang::ast::SubroutineSymbol *subroutine) {
+
+    const bool isMethod = (subroutine->thisVar != nullptr);
+
     auto *lowering = context.declareFunction(*subroutine);
     if (!lowering)
       return {};
@@ -1254,20 +1347,34 @@ struct RvalueExprVisitor : public ExprVisitor {
       }
     }
 
-    // Create the call.
-    auto callOp =
-        mlir::func::CallOp::create(builder, loc, lowering->op, arguments);
+    // Determine result types from the declared/converted func op.
+    SmallVector<Type> resultTypes(
+        lowering->op.getFunctionType().getResults().begin(),
+        lowering->op.getFunctionType().getResults().end());
 
+    mlir::func::CallOp callOp;
+    if (isMethod) {
+      // Class functions -> build func.call with implicit this argument
+      auto [thisRef, tyHandle] = getMethodReceiverTypeHandle(expr);
+      callOp = buildMethodCall(subroutine, lowering, tyHandle, thisRef,
+                               arguments, resultTypes);
+    } else {
+      // Free function -> func.call
+      callOp =
+          mlir::func::CallOp::create(builder, loc, lowering->op, arguments);
+    }
+
+    auto result = resultTypes.size() > 0 ? callOp.getResult(0) : Value{};
     // For calls to void functions we need to have a value to return from this
     // function. Create a dummy `unrealized_conversion_cast`, which will get
     // deleted again later on.
-    if (callOp.getNumResults() == 0)
+    if (resultTypes.size() == 0)
       return mlir::UnrealizedConversionCastOp::create(
                  builder, loc, moore::VoidType::get(context.getContext()),
                  ValueRange{})
           .getResult(0);
 
-    return callOp.getResult(0);
+    return result;
   }
 
   /// Handle system calls.

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -134,6 +134,9 @@ struct Context {
   getAncestorClassWithProperty(const moore::ClassHandleType &actualTy,
                                StringRef fieldName);
 
+  Value getImplicitThisRef() const {
+    return currentThisRef; // block arg added in declareFunction
+  }
   // Convert a statement AST node to MLIR ops.
   LogicalResult convertStatement(const slang::ast::Statement &stmt);
 
@@ -316,6 +319,17 @@ struct Context {
 
   /// The time scale currently in effect.
   slang::TimeScale timeScale;
+
+private:
+  /// Helper function to extract the commonalities in lowering of functions and
+  /// methods
+  FunctionLowering *
+  declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
+                      mlir::StringRef qualifiedName,
+                      llvm::SmallVectorImpl<Type> &extraParams);
+  /// Variable to track the value of the current function's implicit `this`
+  /// reference
+  Value currentThisRef = {};
 };
 
 } // namespace ImportVerilog

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -979,7 +979,6 @@ Context::convertPackage(const slang::ast::PackageSymbol &package) {
 /// This does not convert the function body.
 FunctionLowering *
 Context::declareFunction(const slang::ast::SubroutineSymbol &subroutine) {
-  using slang::ast::ArgumentDirection;
 
   // Check if there already is a declaration for this function.
   auto &lowering = functions[&subroutine];
@@ -988,7 +987,65 @@ Context::declareFunction(const slang::ast::SubroutineSymbol &subroutine) {
       return {};
     return lowering.get();
   }
-  lowering = std::make_unique<FunctionLowering>();
+
+  if (!subroutine.thisVar) {
+
+    SmallString<64> name;
+    guessNamespacePrefix(subroutine.getParentScope()->asSymbol(), name);
+    name += subroutine.name;
+
+    SmallVector<Type, 1> noThis = {};
+    return declareCallableImpl(subroutine, name, noThis);
+  }
+
+  auto loc = convertLocation(subroutine.location);
+
+  // Extract 'this' type and ensure it's a class.
+  const slang::ast::Type &thisTy = subroutine.thisVar->getType();
+  moore::ClassDeclOp ownerDecl;
+
+  if (auto *classTy = thisTy.as_if<slang::ast::ClassType>()) {
+    auto &ownerLowering = classes[classTy];
+    ownerDecl = ownerLowering->op;
+  } else {
+    mlir::emitError(loc) << "expected 'this' to be a class type, got "
+                         << thisTy.toString();
+    return {};
+  }
+
+  if (subroutine.flags.has(slang::ast::MethodFlags::Virtual)) {
+    mlir::emitError(loc) << "Virtual methods are not yet supported!";
+    return {};
+  }
+
+  // Build qualified name: @"Pkg::Class"::subroutine
+  SmallString<64> qualName;
+  qualName += ownerDecl.getSymName(); // already qualified
+  qualName += "::";
+  qualName += subroutine.name;
+
+  // %this : class<@C>
+  SmallVector<Type, 1> extraParams;
+  {
+    auto classSym = mlir::FlatSymbolRefAttr::get(ownerDecl.getSymNameAttr());
+    auto handleTy = moore::ClassHandleType::get(getContext(), classSym);
+    extraParams.push_back(handleTy);
+  }
+
+  auto *fLowering = declareCallableImpl(subroutine, qualName, extraParams);
+  return fLowering;
+}
+
+/// Convert a function and its arguments to a function declaration in the IR.
+/// This does not convert the function body.
+FunctionLowering *
+Context::declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
+                             mlir::StringRef qualifiedName,
+                             llvm::SmallVectorImpl<Type> &extraParams) {
+  using slang::ast::ArgumentDirection;
+
+  std::unique_ptr<FunctionLowering> lowering =
+      std::make_unique<FunctionLowering>();
   auto loc = convertLocation(subroutine.location);
 
   // Pick an insertion point for this function according to the source file
@@ -1000,14 +1057,9 @@ Context::declareFunction(const slang::ast::SubroutineSymbol &subroutine) {
   else
     builder.setInsertionPoint(it->second);
 
-  // Class methods are currently not supported.
-  if (subroutine.thisVar) {
-    mlir::emitError(loc) << "unsupported class method";
-    return {};
-  }
-
   // Determine the function type.
   SmallVector<Type> inputTypes;
+  inputTypes.append(extraParams.begin(), extraParams.end());
   SmallVector<Type, 1> outputTypes;
 
   for (const auto *arg : subroutine.getArguments()) {
@@ -1031,14 +1083,9 @@ Context::declareFunction(const slang::ast::SubroutineSymbol &subroutine) {
 
   auto funcType = FunctionType::get(getContext(), inputTypes, outputTypes);
 
-  // Prefix the function name with the surrounding namespace to create somewhat
-  // sane names in the IR.
-  SmallString<64> funcName;
-  guessNamespacePrefix(subroutine.getParentScope()->asSymbol(), funcName);
-  funcName += subroutine.name;
-
   // Create a function declaration.
-  auto funcOp = mlir::func::FuncOp::create(builder, loc, funcName, funcType);
+  auto funcOp =
+      mlir::func::FuncOp::create(builder, loc, qualifiedName, funcType);
   SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
   orderedRootOps.insert(it, {subroutine.location, funcOp});
   lowering->op = funcOp;
@@ -1046,8 +1093,9 @@ Context::declareFunction(const slang::ast::SubroutineSymbol &subroutine) {
   // Add the function to the symbol table of the MLIR module, which uniquifies
   // its name.
   symbolTable.insert(funcOp);
+  functions[&subroutine] = std::move(lowering);
 
-  return lowering.get();
+  return functions[&subroutine].get();
 }
 
 /// Special case handling for recursive functions with captures;
@@ -1131,11 +1179,27 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
   if (lowering->capturesFinalized || lowering->isConverting)
     return success();
 
+  const bool isMethod = (subroutine.thisVar != nullptr);
+
   ValueSymbolScope scope(valueSymbols);
 
   // Create a function body block and populate it with block arguments.
   SmallVector<moore::VariableOp> argVariables;
   auto &block = lowering->op.getBody().emplaceBlock();
+
+  // If this is a class method, the first input is %this :
+  // !moore.class<@C>
+  unsigned inputIdx = 0;
+  if (isMethod) {
+    auto thisLoc = convertLocation(subroutine.location);
+    auto thisType = lowering->op.getFunctionType().getInput(inputIdx++);
+    auto thisArg = block.addArgument(thisType, thisLoc);
+
+    // Bind `this` so NamedValue/MemberAccess can find it.
+    valueSymbols.insert(subroutine.thisVar, thisArg);
+  }
+
+  // Add user-defined block arguments
   for (auto [astArg, type] :
        llvm::zip(subroutine.getArguments(),
                  lowering->op.getFunctionType().getInputs())) {
@@ -1223,6 +1287,10 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
         lowering->captures.push_back(dstRef);
     }
   };
+
+  auto savedThis = currentThisRef;
+  currentThisRef = valueSymbols.lookup(subroutine.thisVar);
+  auto restoreThis = llvm::make_scope_exit([&] { currentThisRef = savedThis; });
 
   lowering->isConverting = true;
   auto convertingGuard =
@@ -1429,7 +1497,25 @@ struct ClassDeclVisitor {
       remarkEmitted = true;
       return success();
     }
-    return failure();
+
+    auto loc = convertLocation(fn.location);
+    auto *lowering = context.declareFunction(fn);
+    if (!lowering)
+      return failure();
+
+    if (failed(context.convertFunction(fn)))
+      return failure();
+
+    if (!lowering->capturesFinalized)
+      return failure();
+
+    // Grab the finalized function type from the lowered func.op.
+    FunctionType fnTy = lowering->op.getFunctionType();
+
+    // Emit the method decl into the class body, preserving source order.
+    moore::ClassMethodDeclOp::create(builder, loc, fn.name, fnTy);
+
+    return success();
   }
 
   // Nested class definition, convert

--- a/lib/Dialect/Moore/CMakeLists.txt
+++ b/lib/Dialect/Moore/CMakeLists.txt
@@ -21,6 +21,7 @@ add_circt_dialect_library(CIRCTMoore
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRMemorySlotInterfaces
+  MLIRCallInterfaces
 )
 
 add_dependencies(circt-headers MLIRMooreIncGen)

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -1378,8 +1378,9 @@ LogicalResult ClassDeclOp::verify() {
   auto &block = body.front();
   for (mlir::Operation &op : block) {
 
-    // allow only property and method decls
-    if (llvm::isa<circt::moore::ClassPropertyDeclOp>(&op))
+    // allow only property and method decls and terminator
+    if (llvm::isa<circt::moore::ClassPropertyDeclOp,
+                  circt::moore::ClassMethodDeclOp>(&op))
       continue;
 
     return emitOpError()

--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -265,3 +265,154 @@ module testModule6;
         result = t.a;
     end
 endmodule
+
+/// Check concrete method calls
+
+// CHECK-LABEL: moore.module @testModule7() {
+// CHECK: [[T:%.*]] = moore.variable : <class<@"testModule7::testModuleClass">>
+// CHECK: [[RESULT:%.+]] = moore.variable : <i32>
+// CHECK: moore.procedure initial {
+// CHECK:    [[NEW:%.*]] = moore.class.new : <@"testModule7::testModuleClass">
+// CHECK:    moore.blocking_assign [[T]], [[NEW]] : class<@"testModule7::testModuleClass">
+// CHECK:    [[CALLREAD:%.+]] = moore.read [[T]] : <class<@"testModule7::testModuleClass">>
+// CHECK:    [[FUNCRET:%.+]] = func.call @"testModule7::testModuleClass::returnA"([[CALLREAD]]) : (!moore.class<@"testModule7::testModuleClass">) -> !moore.i32
+// CHECK:    moore.blocking_assign [[RESULT]], [[FUNCRET]] : i32
+// CHECK:    moore.return
+// CHECK: }
+// CHECK: moore.output
+// CHECK: }
+
+// CHECK: moore.class.classdecl @"testModule7::testModuleClass" {
+// CHECK-NEXT: moore.class.propertydecl @a : !moore.i32
+// CHECK-NEXT: moore.class.methoddecl @returnA : (!moore.class<@"testModule7::testModuleClass">) -> !moore.i32
+// CHECK: }
+
+// CHECK: func.func private @"testModule7::testModuleClass::returnA"
+// CHECK-SAME: ([[ARG:%.+]]: !moore.class<@"testModule7::testModuleClass">)
+// CHECK-SAME: -> !moore.i32 {
+// CHECK-NEXT: [[REF:%.+]] = moore.class.property_ref [[ARG]][@a] : <@"testModule7::testModuleClass"> -> <i32>
+// CHECK-NEXT: [[RETURN:%.+]] = moore.read [[REF]] : <i32>
+// CHECK-NEXT: return [[RETURN]] : !moore.i32
+// CHECK-NEXT: }
+
+module testModule7;
+    class testModuleClass;
+       int a;
+       function int returnA();
+          return a;
+       endfunction
+    endclass
+    testModuleClass t;
+    int result;
+    initial begin
+        t = new;
+        result = t.returnA();
+    end
+endmodule
+
+
+/// Check inherited property access
+
+ // CHECK-LABEL: moore.module @testModule8() {
+ // CHECK:    [[t:%.+]] = moore.variable : <class<@"testModule8::testModuleClass2">>
+ // CHECK:    [[result:%.+]] = moore.variable : <i32>
+ // CHECK:    moore.procedure initial {
+ // CHECK:      [[NEW:%.+]] = moore.class.new : <@"testModule8::testModuleClass2">
+ // CHECK:      moore.blocking_assign [[t]], [[NEW]] : class<@"testModule8::testModuleClass2">
+// CHECK:    [[CALLREAD:%.+]] = moore.read [[t]] : <class<@"testModule8::testModuleClass2">>
+// CHECK:       [[CALL:%.+]] = func.call @"testModule8::testModuleClass2::returnA"([[CALLREAD]]) : (!moore.class<@"testModule8::testModuleClass2">) -> !moore.i32
+// CHECK:       moore.blocking_assign [[result]], [[CALL]] : i32
+ // CHECK:      moore.return
+ // CHECK:    }
+ // CHECK:    moore.output
+ // CHECK:  }
+ // CHECK:  moore.class.classdecl @"testModule8::testModuleClass" {
+ // CHECK:    moore.class.propertydecl @a : !moore.i32
+ // CHECK:  }
+ // CHECK:  moore.class.classdecl @"testModule8::testModuleClass2" extends @"testModule8::testModuleClass" {
+ // CHECK:    moore.class.methoddecl @returnA : (!moore.class<@"testModule8::testModuleClass2">) -> !moore.i32
+ // CHECK:  }
+ // CHECK:  func.func private @"testModule8::testModuleClass2::returnA"([[ARG:%.+]]: !moore.class<@"testModule8::testModuleClass2">) -> !moore.i32 {
+ // CHECK:   [[UPCAST:%.+]] = moore.class.upcast [[ARG]] : <@"testModule8::testModuleClass2"> to <@"testModule8::testModuleClass">
+ // CHECK:   [[PROPREF:%.+]] = moore.class.property_ref [[UPCAST]][@a] : <@"testModule8::testModuleClass"> -> <i32>
+ // CHECK:   [[RET:%.+]] = moore.read [[PROPREF]] : <i32>
+ // CHECK:   return [[RET]] : !moore.i32
+ // CHECK: }
+
+module testModule8;
+
+    class testModuleClass;
+       int a;
+    endclass // testModuleClass
+
+   class testModuleClass2 extends testModuleClass;
+       function int returnA();
+          return a;
+       endfunction
+   endclass // testModuleClass2
+
+    testModuleClass2 t;
+    int result;
+    initial begin
+        t = new;
+        result = t.returnA();
+    end
+
+endmodule
+
+/// Check method lowering without qualified handle
+
+// CHECK-LABEL: moore.module @testModule9() {
+// CHECK: [[t:%.+]] = moore.variable : <class<@"testModule9::testModuleClass2">>
+// CHECK: [[result:%.+]] = moore.variable : <i32>
+// CHECK: moore.procedure initial {
+// CHECK:   [[new_obj:%.+]] = moore.class.new : <@"testModule9::testModuleClass2">
+// CHECK:   moore.blocking_assign [[t]], [[new_obj]] : class<@"testModule9::testModuleClass2">
+// CHECK:    [[CALLREAD:%.+]] = moore.read [[t]] : <class<@"testModule9::testModuleClass2">>
+// CHECK:   [[call_ret:%.+]] = func.call @"testModule9::testModuleClass2::returnA"([[CALLREAD]]) : (!moore.class<@"testModule9::testModuleClass2">) -> !moore.i32
+// CHECK:   moore.blocking_assign [[result]], [[call_ret]] : i32
+// CHECK:   moore.return
+// CHECK: }
+// CHECK: moore.output
+// CHECK: }
+// CHECK: moore.class.classdecl @"testModule9::testModuleClass" {
+// CHECK:   moore.class.propertydecl @a : !moore.i32
+// CHECK:   moore.class.methoddecl @myReturn : (!moore.class<@"testModule9::testModuleClass">) -> !moore.i32
+// CHECK: }
+// CHECK: func.func private @"testModule9::testModuleClass::myReturn"([[this_ref:%.+]]: !moore.class<@"testModule9::testModuleClass">) -> !moore.i32 {
+// CHECK:   [[prop_ref:%.+]] = moore.class.property_ref [[this_ref]][@a] : <@"testModule9::testModuleClass"> -> <i32>
+// CHECK:   [[read_val:%.+]] = moore.read [[prop_ref]] : <i32>
+// CHECK:   return [[read_val]] : !moore.i32
+// CHECK: }
+// CHECK: moore.class.classdecl @"testModule9::testModuleClass2" extends @"testModule9::testModuleClass" {
+// CHECK:   moore.class.methoddecl @returnA : (!moore.class<@"testModule9::testModuleClass2">) -> !moore.i32
+// CHECK: }
+// CHECK: func.func private @"testModule9::testModuleClass2::returnA"([[this_ref2:%.+]]: !moore.class<@"testModule9::testModuleClass2">) -> !moore.i32 {
+// CHECK:   [[upcast_ref:%.+]] = moore.class.upcast [[this_ref2]] : <@"testModule9::testModuleClass2"> to <@"testModule9::testModuleClass">
+// CHECK:   [[call_myReturn:%.+]] = call @"testModule9::testModuleClass::myReturn"([[upcast_ref]]) : (!moore.class<@"testModule9::testModuleClass">) -> !moore.i32
+// CHECK:   return [[call_myReturn]] : !moore.i32
+// CHECK: }
+
+module testModule9;
+
+    class testModuleClass;
+       int a;
+       function int myReturn();
+          return a;
+       endfunction; // myReturn
+    endclass // testModuleClass
+
+   class testModuleClass2 extends testModuleClass;
+       function int returnA();
+          return myReturn();
+       endfunction
+   endclass // testModuleClass2
+
+    testModuleClass2 t;
+    int result;
+    initial begin
+        t = new;
+        result = t.returnA();
+    end
+
+endmodule


### PR DESCRIPTION
Adds **class method declarations**, wires it into the importer, and supports implicit `this`, inherited property access, and upcasting.

- **New ops**
  - `moore.class.methoddecl`: declare methods inside `classdecl` (FunctionType).

- **Importer**
  - Lowers `t.m(...)` and unqualified `m(...)` (inside methods) to `func.call`.
  - Adds implicit `%this : !moore.class<@C>` as first block arg for methods.
  - Performs **implicit upcast** of the receiver when needed.
  - Resolves class properties via `class.property_ref` (now also for implicit `this`).
  - Clearer diag: prints SV type for unsupported member-access bases.

- **Lowering plumbing**
  - `declareFunction` split into `declareCallableImpl` to share logic; supports methods (qualified name `@"Pkg::Class"::method`).
  - Tracks `currentThisRef` in `Context` for implicit `this` in expressions.
  - `ClassDeclVisitor` emits `class.methoddecl` in source order after lowering the method body.

- **Verifiers / build**
  - `ClassDeclOp` verifier accepts `class.methoddecl`.
  - Includes/linkage for call interfaces (`MooreOps.h`, CMake).

- **Tests**
  - `classes.sv`: calls on concrete classes, inherited property access through upcast, and method decls reflected in IR.
