### PR TITLE
[ESI] Add missing `ensureValid` calls

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/lib/Types.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Types.cpp
@@ -158,6 +158,7 @@ void SIntType::ensureValid(const std::any &obj) const {
 }
 
 MutableBitVector SIntType::serialize(const std::any &obj) const {
+  ensureValid(obj);
   Int ival = getIntLikeFromAny(obj, getWidth());
   if (static_cast<uint64_t>(ival.width()) != getWidth())
     throw std::runtime_error("Int width mismatch for SIntType serialize");
@@ -185,6 +186,7 @@ void UIntType::ensureValid(const std::any &obj) const {
 }
 
 MutableBitVector UIntType::serialize(const std::any &obj) const {
+  ensureValid(obj);
   UInt uval = getUIntLikeFromAny(obj, getWidth());
   if (static_cast<uint64_t>(uval.width()) != getWidth())
     throw std::runtime_error("UInt width mismatch for UIntType serialize");


### PR DESCRIPTION
which got accidentally removed in the last ESI ser/de PR.