### PR TITLE
[ImportVerilog] Use initializer list for Cases, fix deprecation.

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1236,7 +1236,7 @@ struct RvalueExprVisitor : public ExprVisitor {
     // LTLDialect; treat them there instead.
     bool isAssertionCall =
         llvm::StringSwitch<bool>(subroutine.name)
-            .Cases("$rose", "$fell", "$stable", "$past", true)
+            .Cases({"$rose", "$fell", "$stable", "$past"}, true)
             .Default(false);
 
     if (isAssertionCall)


### PR DESCRIPTION
See (and PR linked):
https://github.com/llvm/llvm-project/pull/165119