### PR TITLE
[MooreToCore] Create implicit zero value for real variables

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -537,6 +537,12 @@ static Value createZeroValue(Type type, Location loc,
     return llhd::ConstantTimeOp::create(rewriter, loc, timeAttr);
   }
 
+  // Handle real values.
+  if (auto floatType = dyn_cast<FloatType>(type)) {
+    auto floatAttr = rewriter.getFloatAttr(floatType, 0.0);
+    return mlir::arith::ConstantOp::create(rewriter, loc, floatAttr);
+  }
+
   // Otherwise try to create a zero integer and bitcast it to the result type.
   int64_t width = hw::getBitWidth(type);
   if (width == -1)

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -495,6 +495,14 @@ moore.module @Variable() {
   %c42_fs = moore.constant_time 42 fs
   moore.variable %c42_fs : <!moore.time>
 
+  // CHECK: [[TMP:%.+]] = arith.constant {{0.*}} : f32
+  // CHECK: llhd.sig [[TMP]] : f32
+  moore.variable : <!moore.f32>
+
+  // CHECK: [[TMP:%.+]] = arith.constant {{0.*}} : f64
+  // CHECK: llhd.sig [[TMP]] : f64
+  moore.variable : <!moore.f64>
+
   // CHECK: hw.output
   moore.output
 }


### PR DESCRIPTION
Create an `arith.constant` op for real variables without an initial value.