### PR TITLE
[Moore] Make names of constant ops more uniform

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -544,7 +544,8 @@ def ConstantOp : MooreOp<"constant", [Pure, ConstantLike]> {
   let builders = [
     OpBuilder<(ins "IntType":$type, "const FVInt &":$value)>,
     OpBuilder<(ins "IntType":$type, "const APInt &":$value)>,
-    OpBuilder<(ins "IntType":$type, "int64_t":$value, CArg<"bool", "true">:$isSigned)>,
+    OpBuilder<(
+      ins "IntType":$type, "int64_t":$value, CArg<"bool", "true">:$isSigned)>,
   ];
 }
 
@@ -556,54 +557,45 @@ def ConstantTimeOp : MooreOp<"constant_time", [Pure, ConstantLike]> {
   let hasFolder = 1;
 }
 
-def StringConstantOp : MooreOp<"string_constant", [Pure]> {
-  let summary = "Produce a constant string value";
+def ConstantStringOp : MooreOp<"constant_string", [Pure]> {
+  let summary = "A constant integer value defined by a string of bytes";
   let description = [{
-    Produces a constant value of string type.
+    Defines a constant integer value based on the bytes of a string. The
+    resulting integer contains 8 bits for each byte in the string. The first,
+    left-most character is placed in the most significnat bits; the last,
+    right-most character is placed in the least significant bits.
 
-    Example:
-    ```mlir
-    %0 = moore.string "hello world"
-    ```
+    Constant strings are represented as integers since they have a known width
+    and bit-pattern, which is often used in SV to assign strings to parameters,
+    or store strings in bit vectors. In contrast, the `string` type is a dynamic
+    string with runtime-known length. To obtain a constant `string` value, the
+    resulting integer should be converted to a `string`.
+
+    See IEEE 1800-2017 § 5.9 "String literals".
   }];
   let arguments = (ins StrAttr:$value);
   let results = (outs IntType:$result);
   let assemblyFormat = "$value attr-dict `:` type($result)";
 }
 
-def ShortrealLiteralOp : MooreOp<"shortreal_constant", [Pure]> {
-  let summary = "Produce a constant shortreal value";
-  let description = [{
-    Produces a constant value of shortreal type.
-
-    Example:
-    ```mlir
-    %0 = moore.shortreal_constant 1.23
-    ```
-    The shortreal type has fixed-point(1.2) and exponent(2.0e10) formats and
-    corresponds to IEEE 754 f32.
-    See IEEE 1800-2017 § 5.7.2 "Real literal constants".
-  }];
-  let arguments = (ins F32Attr:$value);
-  let results = (outs RealF32:$result);
-  let assemblyFormat = "$value attr-dict";
+def APFloatAttr : Attr<CPred<"isa<FloatAttr>($_self)">,
+                        "arbitrary float attribute"> {
+  let storageType = [{ mlir::FloatAttr }];
+  let returnType = [{ llvm::APFloat }];
 }
 
-def RealLiteralOp : MooreOp<"real_constant", [Pure]> {
-  let summary = "Produce a constant real value";
+def ConstantRealOp : MooreOp<"constant_real", [
+  DeclareOpInterfaceMethods<InferTypeOpInterface>,
+  Pure,
+]> {
+  let summary = "A constant real value";
   let description = [{
-    Produces a constant value of real type.
+    Produces a constant value of a real type.
 
-    Example:
-    ```mlir
-    %0 = moore.real_constant 1.23
-    ```
-    The real type has fixed-point(1.2) and exponent(2.0e10) formats and
-    corresponds to IEEE 754 f64.
     See IEEE 1800-2017 § 5.7.2 "Real literal constants".
   }];
-  let arguments = (ins F64Attr:$value);
-  let results = (outs RealF64:$result);
+  let arguments = (ins APFloatAttr:$value);
+  let results = (outs RealType:$result);
   let assemblyFormat = "$value attr-dict";
 }
 

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -633,31 +633,13 @@ struct ConstantOpConv : public OpConversionPattern<ConstantOp> {
   }
 };
 
-struct RealConstantOpConv : public OpConversionPattern<RealLiteralOp> {
+struct ConstantRealOpConv : public OpConversionPattern<ConstantRealOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(RealLiteralOp op, OpAdaptor adaptor,
+  matchAndRewrite(ConstantRealOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    llvm::APFloat apf = op.getValue();
-    Type outTy = rewriter.getF64Type();
-    auto attr = FloatAttr::get(outTy, apf);
-    rewriter.replaceOpWithNewOp<arith::ConstantOp>(op, attr);
-    return success();
-  }
-};
-
-struct ShortrealConstantOpConv
-    : public OpConversionPattern<ShortrealLiteralOp> {
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(ShortrealLiteralOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    llvm::APFloat apf = op.getValue();
-    Type outTy = rewriter.getF32Type();
-    auto attr = FloatAttr::get(outTy, apf);
-    rewriter.replaceOpWithNewOp<arith::ConstantOp>(op, attr);
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(op, op.getValueAttr());
     return success();
   }
 };
@@ -675,10 +657,10 @@ struct ConstantTimeOpConv : public OpConversionPattern<ConstantTimeOp> {
   }
 };
 
-struct StringConstantOpConv : public OpConversionPattern<StringConstantOp> {
+struct ConstantStringOpConv : public OpConversionPattern<ConstantStringOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
-  matchAndRewrite(moore::StringConstantOp op, OpAdaptor adaptor,
+  matchAndRewrite(moore::ConstantStringOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     const auto resultType =
         typeConverter->convertType(op.getResult().getType());
@@ -1956,8 +1938,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
 
     // Patterns of miscellaneous operations.
     ConstantOpConv,
-    RealConstantOpConv,
-    ShortrealConstantOpConv,
+    ConstantRealOpConv,
     ConcatOpConversion,
     ReplicateOpConversion,
     ConstantTimeOpConv,
@@ -1973,7 +1954,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     ArrayCreateOpConversion,
     YieldOpConversion,
     OutputOpConversion,
-    StringConstantOpConv,
+    ConstantStringOpConv,
 
     // Patterns of unary operations.
     ReduceAndOpConversion,

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -643,6 +643,21 @@ OpFoldResult ConstantTimeOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// ConstantRealOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ConstantRealOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::OpaqueProperties properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
+  ConstantRealOp::Adaptor adaptor(operands, attrs, properties);
+  results.push_back(RealType::get(
+      context, static_cast<RealWidth>(
+                   adaptor.getValueAttr().getType().getIntOrFloatBitWidth())));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConcatOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -168,13 +168,13 @@ module Basic;
   MyEnum ev1 = VariantA;
   MyEnum ev2 = VariantB;
 
-  // CHECK: [[STR_WELCOME:%.+]] = moore.string_constant "Welcome to Moore" : i128
+  // CHECK: [[STR_WELCOME:%.+]] = moore.constant_string "Welcome to Moore" : i128
   // CHECK: [[CONV_WELCOME:%.+]] = moore.conversion [[STR_WELCOME]] : !moore.i128 -> !moore.string
   // CHECK: [[VAR_S:%.+]] = moore.variable [[CONV_WELCOME]] : <string>
   string s = "Welcome to Moore";
 
   // CHECK: [[VAR_S1:%.+]] = moore.variable : <string>
-  // CHECK: [[STR_HELLO:%.+]] = moore.string_constant "Hello World" : i88
+  // CHECK: [[STR_HELLO:%.+]] = moore.constant_string "Hello World" : i88
   // CHECK: [[CONV_HELLO:%.+]] = moore.conversion [[STR_HELLO]] : !moore.i88 -> !moore.string
   // CHECK: moore.assign [[VAR_S1]], [[CONV_HELLO]] : string
   string s1; 
@@ -755,11 +755,11 @@ module Expressions;
   bit [31:0] arr2 [2];
   // CHECK: %m = moore.variable : <l4>
   logic [3:0] m;
-  // CHECK: [[STR_HELLO:%.+]] = moore.string_constant "Hello" : i40
+  // CHECK: [[STR_HELLO:%.+]] = moore.constant_string "Hello" : i40
   // CHECK: [[CONV_HELLO:%.+]] = moore.conversion [[STR_HELLO]] : !moore.i40 -> !moore.string
   // CHECK: [[VAR_S:%.+]] = moore.variable [[CONV_HELLO]] : <string>
   string s = "Hello";
-  // CHECK: [[STR_WORLD:%.+]] = moore.string_constant "World" : i40
+  // CHECK: [[STR_WORLD:%.+]] = moore.constant_string "World" : i40
   // CHECK: [[CONV_WORLD:%.+]] = moore.conversion [[STR_WORLD]] : !moore.i40 -> !moore.string
   // CHECK: [[VAR_S1:%.+]] = moore.variable [[CONV_WORLD]] : <string>
   string s1 = "World";
@@ -3347,7 +3347,7 @@ endfunction
 
 // CHECK: func.func private @testRealLiteral() -> !moore.f64 {
 function automatic real testRealLiteral();
-   // CHECK: [[TMP:%.+]] = moore.real_constant 1.234500e+00
+   // CHECK: [[TMP:%.+]] = moore.constant_real 1.234500e+00 : f64
    localparam test = 1.2345;
     // CHECK-NEXT: return [[TMP]] : !moore.f64
    return test;
@@ -3355,7 +3355,7 @@ endfunction
 
 // CHECK: func.func private @testShortrealLiteral() -> !moore.f32 {
 function automatic shortreal testShortrealLiteral();
-   // CHECK: [[TMP:%.+]] = moore.shortreal_constant 1.234500e+00
+   // CHECK: [[TMP:%.+]] = moore.constant_real 1.234500e+00 : f32
    localparam test = shortreal'(1.2345);
     // CHECK-NEXT: return [[TMP]] : !moore.f32
    return test;
@@ -3435,10 +3435,10 @@ endmodule
 
 // CHECK-LABEL: moore.module @RealLiteral() {
 module RealLiteral();
-   // CHECK-NEXT:  [[REALCONSTANT:%.+]] = moore.real_constant 5.000000e-01
+   // CHECK-NEXT:  [[REALCONSTANT:%.+]] = moore.constant_real 5.000000e-01 : f64
    // CHECK-NEXT: [[A:%.+]] = moore.variable [[REALCONSTANT]] : <f64>
    real a = 0.5;
-   // CHECK-NEXT: [[REALCONSTANT:%.+]] = moore.real_constant 5.000000e-01
+   // CHECK-NEXT: [[REALCONSTANT:%.+]] = moore.constant_real 5.000000e-01 : f64
    // CHECK-NEXT: [[SHORTREALCONSTANT:%.+]] = moore.conversion [[REALCONSTANT]] : !moore.f64 -> !moore.f32
    // CHECK-NEXT: [[B:%.+]] = moore.variable [[SHORTREALCONSTANT]] : <f32>
    shortreal b = 0.5;
@@ -3479,7 +3479,7 @@ endmodule
 // CHECK-LABEL: func.func private @testStrLiteralReturn()
 // CHECK-SAME: -> !moore.string {
 function string testStrLiteralReturn;
-    // CHECK-NEXT: [[INT:%.+]] = moore.string_constant "\22A string literal\22" : i127
+    // CHECK-NEXT: [[INT:%.+]] = moore.constant_string "\22A string literal\22" : i127
     // CHECK-NEXT: [[STR:%.+]] = moore.int_to_string [[INT]] : i127
     parameter string testStrLiteral = "A string literal";
     // CHECK-NEXT: return [[STR]] : !moore.string
@@ -3557,11 +3557,11 @@ function void testRealOps;
     test = (a >= b);
 
     // CHECK: [[OP:%.+]] = moore.read [[A]] : <f64>
-    // CHECK-NEXT: [[ONE:%.+]] = moore.real_constant 1.000000e+00
+    // CHECK-NEXT: [[ONE:%.+]] = moore.constant_real 1.000000e+00 : f64
     // CHECK-NEXT: [[ANEW:%.+]] = moore.fadd [[OP]], [[ONE]] : f64
     a++;
     // CHECK: [[OP:%.+]] = moore.read [[A]] : <f64>
-    // CHECK-NEXT: [[ONE:%.+]] = moore.real_constant 1.000000e+00
+    // CHECK-NEXT: [[ONE:%.+]] = moore.constant_real 1.000000e+00 : f64
     // CHECK-NEXT: [[ANEW:%.+]] = moore.fsub [[OP]], [[ONE]] : f64
     a--;
     // CHECK: [[OP:%.+]] = moore.read [[A]] : <f64>
@@ -3647,11 +3647,11 @@ function void testRealOps;
     test = (c >= d);
 
     // CHECK: [[OP:%.+]] = moore.read [[C]] : <f32>
-    // CHECK-NEXT: [[ONE:%.+]] = moore.shortreal_constant 1.000000e+00
+    // CHECK-NEXT: [[ONE:%.+]] = moore.constant_real 1.000000e+00 : f32
     // CHECK-NEXT: [[CNEW:%.+]] = moore.fadd [[OP]], [[ONE]] : f32
     c++;
     // CHECK: [[OP:%.+]] = moore.read [[C]] : <f32>
-    // CHECK-NEXT: [[ONE:%.+]] = moore.shortreal_constant 1.000000e+00
+    // CHECK-NEXT: [[ONE:%.+]] = moore.constant_real 1.000000e+00 : f32
     // CHECK-NEXT: [[CNEW:%.+]] = moore.fsub [[OP]], [[ONE]] : f32
     c--;
     // CHECK: [[OP:%.+]] = moore.read [[C]] : <f32>

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1107,25 +1107,23 @@ moore.module @Assert(in %cond : !moore.l1)  {
   }
 }
 
-// CHECK-LABEL: hw.module @StringConstant
-moore.module @StringConstant() {
-  moore.procedure initial {
-    // CHECK: hw.constant 1415934836 : i32
-    %str = moore.string_constant "Test" : i32
-    // CHECK: hw.constant 1415934836 : i36
-    %str1 = moore.string_constant "Test" : i36
-    // CHECK: hw.constant 116 : i8
-    %str2 = moore.string_constant "Test" : i8
-    // CHECK: hw.constant 0 : i7
-    %str_trunc = moore.string_constant "Test" : i7
-    // CHECK: hw.constant 29556 : i17
-    %str_trunc1 = moore.string_constant "Test" : i17
-    // CHECK: hw.constant 0 : i0
-    %str_empty = moore.string_constant "" : i0
-    // CHECK: hw.constant 0 : i8
-    %str_empty_zext = moore.string_constant "" : i8
-    moore.return
-  }
+// CHECK-LABEL: func.func @ConstantString
+func.func @ConstantString() {
+  // CHECK: hw.constant 1415934836 : i32
+  %str = moore.constant_string "Test" : i32
+  // CHECK: hw.constant 1415934836 : i36
+  %str1 = moore.constant_string "Test" : i36
+  // CHECK: hw.constant 116 : i8
+  %str2 = moore.constant_string "Test" : i8
+  // CHECK: hw.constant 0 : i7
+  %str_trunc = moore.constant_string "Test" : i7
+  // CHECK: hw.constant 29556 : i17
+  %str_trunc1 = moore.constant_string "Test" : i17
+  // CHECK: hw.constant 0 : i0
+  %str_empty = moore.constant_string "" : i0
+  // CHECK: hw.constant 0 : i8
+  %str_empty_zext = moore.constant_string "" : i8
+  return
 }
 
 // CHECK-LABEL: func.func @RecurciveConditional
@@ -1331,11 +1329,11 @@ func.func @NonBlockingAssignment(%arg0: !moore.ref<i42>, %arg1: !moore.i42, %arg
   return
 }
 
-// CHECK-LABEL: func.func @RealConstantOp
-func.func @RealConstantOp() {
-  // CHECK: [[REAL:%.+]] = arith.constant 1.234500e+00 : f64
-  %real = moore.real_constant 1.234500e+00
-  // CHECK: [[SHORTREAL:%.+]] = arith.constant 1.234500e+00 : f32
-  %shortreal = moore.shortreal_constant 1.234500e+00
+// CHECK-LABEL: func.func @ConstantReals
+func.func @ConstantReals() {
+  // CHECK: arith.constant 1.234500e+00 : f32
+  moore.constant_real 1.234500e+00 : f32
+  // CHECK: arith.constant 1.234500e+00 : f64
+  moore.constant_real 1.234500e+00 : f64
   return
 }

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -340,10 +340,10 @@ moore.module @Expressions(
   // CHECK: moore.struct_inject [[STRUCT1]], "a", [[B]] : struct<{a: i32, b: i32}>, i32
   moore.struct_inject %struct1, "a", %b : struct<{a: i32, b: i32}>, i32
 
-  // CHECK: moore.string_constant "Test" : i128
-  moore.string_constant "Test" : i128
-  // CHECK: moore.string_constant "" : i128
-  moore.string_constant "" : i128
+  // CHECK: moore.constant_string "Test" : i128
+  moore.constant_string "Test" : i128
+  // CHECK: moore.constant_string "" : i128
+  moore.constant_string "" : i128
   // CHECK: moore.string_cmp eq %s1, %s2 : string -> i1
   moore.string_cmp eq %s1, %s2 : string -> i1
   // CHECK: moore.string_cmp ne %s1, %s2 : string -> i1


### PR DESCRIPTION
Rename `StringConstantOp` to `ConstantStringOp`, and combine `RealConstantOp` and `ShortrealConstantOp` into one `ConstantRealOp`.