### PR TITLE
[MooreToCore] [1/4] Implement ClassDeclOp -> LLVMStructType conversion

### DIFF
--- a/test/Conversion/MooreToCore/classes.mlir
+++ b/test/Conversion/MooreToCore/classes.mlir
@@ -1,0 +1,19 @@
+// RUN: circt-opt %s --convert-moore-to-core --verify-diagnostics | FileCheck %s
+
+/// Check that a classdecl gets noop'd and handles are lowered to !llvm.ptr
+
+// CHECK-LABEL:   func.func @ClassType(%arg0: !llvm.ptr) {
+// CHECK:    return
+// CHECK:  }
+// CHECK-NOT: moore.class.classdecl
+// CHECK-NOT: moore.class<@PropertyCombo>
+
+moore.class.classdecl @PropertyCombo {
+  moore.class.propertydecl @pubAutoI32   : !moore.i32
+  moore.class.propertydecl @protStatL18  : !moore.l18
+  moore.class.propertydecl @localAutoI32 : !moore.i32
+}
+
+func.func @ClassType(%arg0: !moore.class<@PropertyCombo>) {
+  return
+}


### PR DESCRIPTION
Add support for converting `moore.class.classdecl` operations into identified LLVM struct types during the MooreToCore lowering.

- Introduced **`ClassTypeCache`** for mapping class symbols to LLVM structs and field paths.
- Added utilities:
  - `mangleClassName` generates `moore.class.<name>` identifiers.
  - `getOrCreateOpaqueStruct` creates identified LLVM struct types.
- Implemented `resolveClassStructBody` to:
  - Lay out classes in **base-first** order.
  - Convert class properties to LLVM member types.
  - Inherit base field paths.
- Added `ClassDeclOpConversion` to handle class lowering and removal.
- Extended type conversion:
  - `ClassHandleType` -> `!llvm.ptr`
- Integrated cache handling into `MooreToCorePass`.