### PR TITLE
[MooreToCore] [4/4] Add support for class.property_ref

### DIFF
--- a/test/Conversion/MooreToCore/classes.mlir
+++ b/test/Conversion/MooreToCore/classes.mlir
@@ -100,3 +100,25 @@ moore.class.classdecl @F extends @C {
   moore.class.propertydecl @b : !moore.l32
   moore.class.propertydecl @c : !moore.l32
 }
+
+/// Check that property_ref lowers to GEP
+
+// CHECK-LABEL: func.func private @test_new6
+// CHECK-SAME: (%arg0: !llvm.ptr) -> !llhd.ref<i32> {
+// CHECK:   [[CONSTIDX:%.+]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:   [[GEP:%.+]] = llvm.getelementptr %arg0[[[CONSTIDX]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"G", (struct<"C", (i32, i32, i32)>, i32, i32, i32)>
+// CHECK:   [[CONV:%.+]] = builtin.unrealized_conversion_cast [[GEP]] : !llvm.ptr to !llhd.ref<i32>
+// CHECK:   return [[CONV]] : !llhd.ref<i32>
+
+// CHECK-NOT: moore.class.property_ref
+// CHECK-NOT: moore.class.classdecl
+
+func.func private @test_new6(%arg0: !moore.class<@G>) -> !moore.ref<i32> {
+  %gep = moore.class.property_ref %arg0[@d] : <@G> -> !moore.ref<i32>
+  return %gep : !moore.ref<i32>
+}
+moore.class.classdecl @G extends @C {
+  moore.class.propertydecl @d : !moore.i32
+  moore.class.propertydecl @e : !moore.l32
+  moore.class.propertydecl @f : !moore.l32
+}


### PR DESCRIPTION
Add a conversion pattern to translate `moore.class.property_ref` into an LLVM `gep` over the identified class struct, bridging the resulting pointer back to `!llhd.ref<…>` via `unrealized_conversion_cast`.

- Implement `ClassPropertyRefOpConversion`:
  - Validates result lowers to `!llhd.ref<T>`.
  - Ensures instance is `!llvm.ptr`.
  - Resolves the class’s identified struct and per-field GEP path via `ClassTypeCache`.
  - Emits `llvm.getelementptr` with cached indices and wraps back to ref.
- Register the pattern in `populateOpConversion`.
- Extend `classes.mlir` to verify that `property_ref` lowers to GEP.
