### PR TITLE
[ImportVerilog] [2/2] Add support to materialize ctor call on new call

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -320,6 +320,10 @@ struct Context {
   /// The time scale currently in effect.
   slang::TimeScale timeScale;
 
+  /// Variable to track the value of the current function's implicit `this`
+  /// reference
+  Value currentThisRef = {};
+
 private:
   /// Helper function to extract the commonalities in lowering of functions and
   /// methods
@@ -327,9 +331,6 @@ private:
   declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
                       mlir::StringRef qualifiedName,
                       llvm::SmallVectorImpl<Type> &extraParams);
-  /// Variable to track the value of the current function's implicit `this`
-  /// reference
-  Value currentThisRef = {};
 };
 
 } // namespace ImportVerilog


### PR DESCRIPTION
This commit adds full lowering support for class constructor (`new`) and superclass constructor (`super.new`) calls.

- Enhanced lowering of `slang::ast::NewClassExpression`:
  - Detects whether the `new` call originates from within a class constructor.
  - Differentiates between normal object allocation (`moore.class.new`) and `super.new` calls, which reuse the current `this` handle instead of allocating a new object.
  - Tracks the implicit `this` reference via a newly public `Context::currentThisRef` field, ensuring correct behavior in nested constructor and superclass calls.
  - Automatically invokes the appropriate class constructor after allocation, binding the newly created handle as `%this` for the call.
