### PR TITLE
[ImportVerilog] Add support for specialized parametric classes

### DIFF
--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -167,6 +167,8 @@ struct TypeVisitor {
   }
 
   Type visit(const slang::ast::ClassType &type) {
+    if (failed(context.convertClassDeclaration(type)))
+      return {};
     if (auto *lowering = context.declareClass(type)) {
       mlir::StringAttr symName = lowering->op.getSymNameAttr();
       mlir::FlatSymbolRefAttr symRef = mlir::FlatSymbolRefAttr::get(symName);

--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -509,3 +509,35 @@ class testModuleClass3 extends testModuleClass2;
         super.new(a);
     endfunction
 endclass // testModuleClass
+
+/// Check specialized class decl lowering
+
+// CHECK-LABEL:  moore.module @testModuleParametrized() {
+// CHECK:    [[T:%.+]] = moore.variable : <class<@"testModuleParametrized::testModuleClass">>
+// CHECK:    [[T2:%.+]] = moore.variable : <class<@"testModuleParametrized::testModuleClass">>
+// CHECK:    [[T3:%.+]] = moore.variable : <class<@"testModuleParametrized::testModuleClass_0">>
+// CHECK:    moore.output
+// CHECK:  }
+// CHECK:  moore.class.classdecl @"testModuleParametrized::testModuleClass" {
+// CHECK:    moore.class.propertydecl @a : !moore.l32
+// CHECK:    moore.class.propertydecl @b : !moore.l4
+// CHECK:  }
+// CHECK:  moore.class.classdecl @"testModuleParametrized::testModuleClass_0" {
+// CHECK:    moore.class.propertydecl @a : !moore.l16
+// CHECK:    moore.class.propertydecl @b : !moore.l16
+// CHECK:  }
+
+module testModuleParametrized;
+
+    class testModuleClass #(
+        parameter int WIDTH=32,
+        parameter int Other=16
+    );
+       logic [WIDTH-1:0] a;
+       logic [Other-1:0] b;
+    endclass // testModuleClass
+
+   testModuleClass#(.WIDTH(32), .Other(4)) t;
+   testModuleClass#(.WIDTH(32), .Other(4)) t2;
+   testModuleClass#(.WIDTH(16)) t3;
+endmodule


### PR DESCRIPTION
- Add support for lowering **specialized** (instantiated) generic classes by embedding actual parameter values into the fully-qualified class symbol, e.g. `@"pkg::MyClass#(.P(1),.Q(8))"`.
- Explicitly **skip** `GenericClassDefSymbol` (unspecialized templates) per IEEE 1800-2023 §8.25; only specialized `ClassType` symbols are lowered.
- Ensure class bodies are emitted **once**.
- Make type lowering declare/convert the class declaration eagerly to keep symbol references consistent.