### PR TITLE
[HWToSMT] Add option to assert equalities over module outputs

### DIFF
--- a/include/circt/Conversion/HWToSMT.h
+++ b/include/circt/Conversion/HWToSMT.h
@@ -19,7 +19,8 @@ namespace circt {
 
 /// Get the HW to SMT conversion patterns.
 void populateHWToSMTConversionPatterns(TypeConverter &converter,
-                                       RewritePatternSet &patterns);
+                                       RewritePatternSet &patterns,
+                                       bool assertModuleOutputs);
 
 /// Get the HW to SMT type conversions.
 void populateHWToSMTTypeConverter(TypeConverter &converter);

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -670,6 +670,12 @@ def ConvertCombToSMT : Pass<"convert-comb-to-smt"> {
 def ConvertHWToSMT : Pass<"convert-hw-to-smt", "mlir::ModuleOp"> {
   let summary = "Convert HW ops and constants to SMT ops";
   let dependentDialects = ["mlir::smt::SMTDialect", "mlir::func::FuncDialect"];
+  let options = [
+    Option<"assertModuleOutputs", "assert-module-outputs", "bool",
+           /*default=*/"false",
+           "For each output of each hw.module operation, instantiate a"
+           "constant and assert its equivalence to the output.">,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/CombToSMT/CombToSMT.cpp
+++ b/lib/Conversion/CombToSMT/CombToSMT.cpp
@@ -304,7 +304,7 @@ void ConvertCombToSMTPass::runOnOperation() {
   // Also add HW patterns because some 'comb' canonicalizers produce constant
   // operations, i.e., even if there is absolutely no HW operation present
   // initially, we might have to convert one.
-  populateHWToSMTConversionPatterns(converter, patterns);
+  populateHWToSMTConversionPatterns(converter, patterns, false);
   populateCombToSMTConversionPatterns(converter, patterns);
 
   if (failed(mlir::applyPartialConversion(getOperation(), target,

--- a/test/Conversion/HWToSMT/hw-to-smt.mlir
+++ b/test/Conversion/HWToSMT/hw-to-smt.mlir
@@ -1,4 +1,6 @@
 // RUN: circt-opt %s --convert-hw-to-smt | FileCheck %s
+// RUN: circt-opt %s --convert-hw-to-smt='assert-module-outputs' | FileCheck %s --check-prefix=CHECK-ASSERTOUTPUTS
+
 
 // CHECK-LABEL: func @test
 func.func @test() {
@@ -11,6 +13,11 @@ func.func @test() {
 
   return
 }
+
+// CHECK-ASSERTOUTPUTS: func.func @modA(%[[ARG0:.*]]: !smt.bv<32>) -> !smt.bv<32>
+// CHECK-ASSERTOUTPUTS-NEXT: %[[DECL:.*]] = smt.declare_fun : !smt.bv<32>
+// CHECK-ASSERTOUTPUTS-NEXT: %[[EQ:.*]] = smt.eq %[[ARG0]], %[[DECL]] : !smt.bv<32>
+// CHECK-ASSERTOUTPUTS-NEXT: smt.assert %[[EQ]]
 
 // CHECK-LABEL: func.func @modA(%{{.*}}: !smt.bv<32>) -> !smt.bv<32>
 hw.module @modA(in %in: i32, out out: i32) {
@@ -37,4 +44,18 @@ hw.module @inject(in %arr: !hw.array<3xi8>, in %index: i2, in %v: i8, out out: !
   // CHECK-NEXT: return %[[RESULT]] : !smt.array<[!smt.bv<2> -> !smt.bv<8>]>
   %arr_injected = hw.array_inject %arr[%index], %v : !hw.array<3xi8>, i2
   hw.output %arr_injected : !hw.array<3xi8>
+}
+
+// Check that output assertions are generated correctly with multiple outputs
+// CHECK-ASSERTOUTPUTS: func.func @modC(%[[ARG0:.*]]: !smt.bv<32>, %[[ARG1:.*]]: !smt.bv<32>)
+// CHECK-ASSERTOUTPUTS: %[[DECL1:.*]] = smt.declare_fun : !smt.bv<32>
+// CHECK-ASSERTOUTPUTS: %[[EQ1:.*]] = smt.eq %[[ARG0]], %[[DECL1]] : !smt.bv<32>
+// CHECK-ASSERTOUTPUTS: smt.assert %[[EQ1]]
+// CHECK-ASSERTOUTPUTS: %[[DECL2:.*]] = smt.declare_fun : !smt.bv<32>
+// CHECK-ASSERTOUTPUTS: %[[EQ2:.*]] = smt.eq %[[ARG1]], %[[DECL2]] : !smt.bv<32>
+// CHECK-ASSERTOUTPUTS: smt.assert %[[EQ2]]
+// CHECK-ASSERTOUTPUTS: return %[[ARG0]], %[[ARG1]]
+
+hw.module @modC(in %in1: i32, in %in2: i32, out out1: i32, out out2: i32) {
+  hw.output %in1, %in2 : i32, i32
 }


### PR DESCRIPTION
We've had a couple of requests (e.g. #7786, #9138) for a flow that will take some hardware input and produce directly a corresponding SMTLIB description - our existing flows don't work for this as without any `verif` dialect assertion ops, nothing is actually emitted to SMT assertions.

This is a step towards that by adding an option in HWToSMT to emit a (trivially satisfiable) assertion over every output when lowering an `hw.module`. This doesn't produce an interesting problem to solve, but produces some SMTLIB representative of the module that users can then go off and use in their own problems (which I assume is the ultimate use-case).

The remaining missing part after this PR is the introduction of the smt.solver op for ExportSMTLIB to consume. The answer to this is probably a pass that converts the top hw.module or func.func into a solver op (modules will also need to be inlined since we can't export the func.func ops that non-top modules are converted to into SMTLIB, but we can just use the existing `hw-flatten-modules` pass for that).