### PR TITLE
[ImportVerilog][Moore] Add len string builtin

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2451,4 +2451,21 @@ def ClassUpcastOp
       "$instance `:` type($instance) `to` type($result) attr-dict";
 }
 
+//===----------------------------------------------------------------------===//
+// String Builtins
+//===----------------------------------------------------------------------===//
+
+class StringBuiltin<string mnemonic, list<Trait> traits = []> :
+    MooreOp<"string." # mnemonic, traits>;
+
+def StringLenOp : StringBuiltin<"len"> {
+  let summary = "Get the length of a string";
+  let description = [{
+    Returns the number of characters in the given string.
+  }];
+  let arguments = (ins StringType:$str);
+  let results = (outs TwoValuedI32:$result);
+  let assemblyFormat = "$str attr-dict";
+}
+
 #endif // CIRCT_DIALECT_MOORE_MOOREOPS

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2408,6 +2408,12 @@ Context::convertSystemCallArity1(const slang::ast::SystemSubroutine &subroutine,
                   return moore::BitstoshortrealBIOp::create(builder, loc,
                                                             value);
                 })
+          .Case("len",
+                [&]() -> Value {
+                  if (isa<moore::StringType>(value.getType()))
+                    return moore::StringLenOp::create(builder, loc, value);
+                  return {};
+                })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();
 }

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -382,3 +382,10 @@ module SampleValueBuiltins #() (
   stable_clk: assert property (@(posedge clk_i) clk_i |=> $stable(clk_i));
 
 endmodule
+
+// CHECK-LABEL: func.func private @StringBuiltins(
+// CHECK-SAME: [[STR:%.+]]: !moore.string
+function void StringBuiltins(string string_in);
+  // CHECK: [[LEN:%.+]] = moore.string.len [[STR]]
+  dummyA(string_in.len());
+endfunction


### PR DESCRIPTION
Adds the string.len function as described in section 6.16 of IEEE 1800-2017.