### PR TITLE
[ArcIntegrationTests] Match only full output lines, NFC

### DIFF
--- a/integration_test/arcilator/JIT/basic.mlir
+++ b/integration_test/arcilator/JIT/basic.mlir
@@ -1,4 +1,4 @@
-// RUN: arcilator %s --run --jit-entry=main | FileCheck %s
+// RUN: arcilator %s --run --jit-entry=main | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
 
 // CHECK: output = 05

--- a/integration_test/arcilator/JIT/counter.mlir
+++ b/integration_test/arcilator/JIT/counter.mlir
@@ -1,7 +1,7 @@
-// RUN: arcilator %s --run --jit-entry=main | FileCheck %s
+// RUN: arcilator %s --run --jit-entry=main | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
 
-// CHECK: counter_value = 0
+// CHECK:      counter_value = 00
 // CHECK-NEXT: counter_value = 01
 // CHECK-NEXT: counter_value = 02
 // CHECK-NEXT: counter_value = 03

--- a/integration_test/arcilator/JIT/div-by-zero.mlir
+++ b/integration_test/arcilator/JIT/div-by-zero.mlir
@@ -1,9 +1,9 @@
-// RUN: arcilator %s --run --jit-entry=main | FileCheck %s
+// RUN: arcilator %s --run --jit-entry=main | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
-// CHECK: divu = 00{{$}}
-// CHECK: divs = 00{{$}}
-// CHECK: modu = 00{{$}}
-// CHECK: mods = 00{{$}}
+// CHECK: divu = 00
+// CHECK: divs = 00
+// CHECK: modu = 00
+// CHECK: mods = 00
 
 hw.module @Baz(in %a: i8, in %b: i8, out divu: i8, out divs: i8, out modu: i8, out mods: i8) {
   %zero = hw.constant 0 : i8

--- a/integration_test/arcilator/JIT/dpi.mlir
+++ b/integration_test/arcilator/JIT/dpi.mlir
@@ -1,6 +1,6 @@
 // RUN: split-file %s %t
 // RUN: %host_cc %t/shared_lib.c --shared -o %t/shared_lib.so
-// RUN: arcilator %t/dpi.mlir --run --jit-entry=main --shared-libs=%t/shared_lib.so | FileCheck %s
+// RUN: arcilator %t/dpi.mlir --run --jit-entry=main --shared-libs=%t/shared_lib.so | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
 
 

--- a/integration_test/arcilator/JIT/initial-shift-reg.mlir
+++ b/integration_test/arcilator/JIT/initial-shift-reg.mlir
@@ -1,11 +1,11 @@
-// RUN: arcilator %s --run --jit-entry=main | FileCheck %s
+// RUN: arcilator %s --run --jit-entry=main | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
 
 // CHECK-LABEL: output = ca
-// CHECK-NEXT: output = ca
-// CHECK-NEXT: output = 0
-// CHECK-NEXT: output = fe
-// CHECK-NEXT: output = ff
+// CHECK-NEXT:  output = ca
+// CHECK-NEXT:  output = 00
+// CHECK-NEXT:  output = fe
+// CHECK-NEXT:  output = ff
 
 module {
 

--- a/integration_test/arcilator/JIT/print.mlir
+++ b/integration_test/arcilator/JIT/print.mlir
@@ -1,4 +1,4 @@
-// RUN: arcilator %s --run | FileCheck %s
+// RUN: arcilator %s --run | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
 
 // CHECK: result = {{0*}}4

--- a/integration_test/arcilator/JIT/reg.mlir
+++ b/integration_test/arcilator/JIT/reg.mlir
@@ -1,4 +1,4 @@
-// RUN: arcilator %s --run --jit-entry=main | FileCheck %s
+// RUN: arcilator %s --run --jit-entry=main | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
 
 // CHECK:      o1 = 02


### PR DESCRIPTION
Minor tweak to the arcilator integration tests: Add the `--match-full-lines` argument to FileCheck to make sure it checks the entire range of the printed values, not just a prefix.