### PR TITLE
[ImportVerilog] Add global variable support

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -325,6 +325,50 @@ def ReadOp : MooreOp<"read", [
   }];
 }
 
+def GlobalVariableOp : MooreOp<"global_variable", [
+  IsolatedFromAbove,
+  NoRegionArguments,
+  SingleBlock,
+  Symbol,
+]> {
+  let summary = "A global variable declaration";
+  let description = [{
+    Defines a global or package variable.
+
+    See IEEE 1800-2017 § 6.8 "Variable declarations".
+  }];
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<UnpackedType>:$type
+  );
+  let regions = (region MaxSizedRegion<1>:$initRegion);
+  let assemblyFormat = [{
+    $sym_name attr-dict `:` $type (`init` $initRegion^)?
+  }];
+  let hasRegionVerifier = 1;
+  let extraClassDeclaration = [{
+    Block *getInitBlock();
+  }];
+}
+
+def GetGlobalVariableOp : MooreOp<"get_global_variable", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  Pure,
+]> {
+  let summary = "Get a reference to a global variable";
+  let arguments = (ins FlatSymbolRefAttr:$global_name);
+  let results = (outs RefType:$result);
+  let assemblyFormat = [{
+    $global_name attr-dict `:` type($result)
+  }];
+  let builders = [
+    OpBuilder<(ins "moore::GlobalVariableOp":$global), [{
+      build($_builder, $_state,
+        RefType::get(global.getType()), global.getSymName());
+    }]>,
+  ];
+}
+
 //===----------------------------------------------------------------------===//
 // Assignments
 //===----------------------------------------------------------------------===//
@@ -1778,7 +1822,7 @@ def ConditionalOp : MooreOp<"conditional",[
 def YieldOp : MooreOp<"yield", [
   Pure,
   Terminator,
-  HasParent<"ConditionalOp">
+  ParentOneOf<["ConditionalOp", "GlobalVariableOp"]>,
 ]> {
   let summary = "conditional yield and termination operation";
   let description = [{

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -122,6 +122,7 @@ struct Context {
   LogicalResult finalizeFunctionBodyCaptures(FunctionLowering &lowering);
   LogicalResult convertClassDeclaration(const slang::ast::ClassType &classdecl);
   ClassLowering *declareClass(const slang::ast::ClassType &cls);
+  LogicalResult convertGlobalVariable(const slang::ast::VariableSymbol &var);
 
   /// Checks whether one class (actualTy) is derived from another class
   /// (baseTy). True if it's a subclass, false otherwise.
@@ -284,6 +285,14 @@ struct Context {
       llvm::ScopedHashTable<const slang::ast::ValueSymbol *, Value>;
   using ValueSymbolScope = ValueSymbols::ScopeTy;
   ValueSymbols valueSymbols;
+
+  /// A table of defined global variables that may be referred to by name in
+  /// expressions.
+  DenseMap<const slang::ast::ValueSymbol *, moore::GlobalVariableOp>
+      globalVariables;
+  /// A list of global variables that still need their initializers to be
+  /// converted.
+  SmallVector<const slang::ast::ValueSymbol *> globalVariableWorklist;
 
   /// Collect all hierarchical names used for the per module/instance.
   DenseMap<const slang::ast::InstanceBodySymbol *, SmallVector<HierPathInfo>>

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3715,3 +3715,21 @@ module RejectInnerCapture(input bit u, output bit v);
     foo = a;
   endfunction
 endmodule
+
+// CHECK-LABEL: moore.global_variable @rootGlobal1 : !moore.i42
+bit [41:0] rootGlobal1;
+// CHECK-LABEL: moore.global_variable @rootGlobal2 : !moore.i42 init {
+// CHECK-NEXT: [[TMP1:%.+]] = moore.get_global_variable @"PackageGlobal::packageGlobal2" : <i42>
+// CHECK-NEXT: [[TMP2:%.+]] = moore.read [[TMP1]] : <i42>
+// CHECK-NEXT: moore.yield [[TMP2]] : i42
+bit [41:0] rootGlobal2 = PackageGlobal::packageGlobal2;
+
+package PackageGlobal;
+  // CHECK-LABEL: moore.global_variable @"PackageGlobal::packageGlobal1" : !moore.i42
+  bit [41:0] packageGlobal1;
+  // CHECK-LABEL: moore.global_variable @"PackageGlobal::packageGlobal2" : !moore.i42 init {
+  // CHECK-NEXT: [[TMP1:%.+]] = moore.get_global_variable @"PackageGlobal::packageGlobal1" : <i42>
+  // CHECK-NEXT: [[TMP2:%.+]] = moore.read [[TMP1]] : <i42>
+  // CHECK-NEXT: moore.yield [[TMP2]] : i42
+  bit [41:0] packageGlobal2 = packageGlobal1;
+endpackage

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -471,18 +471,35 @@ func.func @TimeConversion(%arg0: !moore.time, %arg1: !moore.l64) {
 
 // CHECK-LABEL: func.func @RealConversion32(%arg0: !moore.f32, %arg1: !moore.i42)
 func.func @RealConversion32(%arg0: !moore.f32, %arg1: !moore.i42) {
-  // CHECK: %0 = moore.real_to_int %arg0 : f32 -> i42
+  // CHECK: moore.real_to_int %arg0 : f32 -> i42
   %0 = moore.real_to_int %arg0 : f32 -> i42
-  // CHECK: %1 = moore.int_to_real %arg1 : i42 -> f32
+  // CHECK: moore.int_to_real %arg1 : i42 -> f32
   %1 = moore.int_to_real %arg1 : i42 -> f32
   return
 }
 
 // CHECK-LABEL: func.func @RealConversion64(%arg0: !moore.f64, %arg1: !moore.i42)
 func.func @RealConversion64(%arg0: !moore.f64, %arg1: !moore.i42) {
-  // CHECK: %0 = moore.real_to_int %arg0 : f64 -> i42
+  // CHECK: moore.real_to_int %arg0 : f64 -> i42
   %0 = moore.real_to_int %arg0 : f64 -> i42
-  // CHECK: %1 = moore.int_to_real %arg1 : i42 -> f64
+  // CHECK: moore.int_to_real %arg1 : i42 -> f64
   %1 = moore.int_to_real %arg1 : i42 -> f64
   return
 }
+
+// CHECK-LABEL: moore.global_variable @GlobalVar1 : !moore.i42
+moore.global_variable @GlobalVar1 : !moore.i42
+
+// CHECK: moore.get_global_variable @GlobalVar1 : <i42>
+moore.get_global_variable @GlobalVar1 : <i42>
+
+// CHECK-LABEL: moore.global_variable @GlobalVar2 : !moore.i42
+moore.global_variable @GlobalVar2 : !moore.i42 init {
+  // CHECK-NEXT: moore.constant
+  %0 = moore.constant 9001 : i42
+  // CHECK-NEXT: moore.yield
+  moore.yield %0 : !moore.i42
+}
+
+// CHECK: moore.get_global_variable @GlobalVar2 : <i42>
+moore.get_global_variable @GlobalVar2 : <i42>


### PR DESCRIPTION
Add new `moore.global_variable` and `moore.get_global_variable` ops to the Moore dialect, which define global variables as a symbol and return a reference to a global variable given its symbol, respectively.

Add support for variables at the root level and within packages in SV inputs. Both of these get converted to `moore.global_variable`s. When referring to a global variable by name, create `get_global_variable` ops to resolve the symbol name to a `!moore.ref<T>` which can then be read.

Lowering to the core dialects is not yet supported. We very likely need an equivalent global signal construct in LLHD.