### PR TITLE
[ImportVerilog] Enforce base class elaboration

### DIFF
--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -580,3 +580,15 @@ function void adder;
     a = a + 1;
 endfunction
 endclass
+
+/// Check that inheritance is enforced over specialized classes
+
+// CHECK-LABEL:  moore.class.classdecl @GenericBar {
+// CHECK:  }
+// CHECK:  moore.class.classdecl @SpecializedFoo extends @GenericBar {
+// CHECK:  }
+
+class GenericBar #(int X=0, int Y=1, int Z=2); endclass
+localparam x=3, y=4, z=5;
+
+class SpecializedFoo extends GenericBar #(x,y,z); endclass


### PR DESCRIPTION
Previously, the compiler could crash when encountering a specialized class extending and specializing a generic class, since no classdecl would be lowered for the generic class. This commit enforces the emission of a classdecl for the specialized version of the generic base class in such a case.