### PR TITLE
[RTG] Add SetAttr and TupleAttr

### DIFF
--- a/include/circt/Dialect/RTG/IR/RTGAttributes.td
+++ b/include/circt/Dialect/RTG/IR/RTGAttributes.td
@@ -51,6 +51,52 @@ def AnyContextAttr : RTGAttrDef<"AnyContext", [
   let assemblyFormat = "";
 }
 
+// The accessor type is a pointer instead of a reference because references
+// cannot be reassigned (in the attribute 'construct' function).
+class DenseSetParameter<string setOf, string desc = "">
+    : AttrOrTypeParameter<"const ::llvm::DenseSet<" # setOf # "> *", desc> {
+  let allocator = [{
+    $_dst = new ($_allocator.allocate<DenseSet<}] # setOf # [{>>())
+      DenseSet<}] # setOf # [{>($_self->begin(), $_self->end());
+  }];
+  let cppStorageType = "::llvm::DenseSet<" # setOf # ">";
+}
+
+def SetAttr : RTGAttrDef<"Set", [
+  DeclareAttrInterfaceMethods<TypedAttrInterface>,
+]> {
+  let summary = "an unordered set of elements";
+
+  let parameters = (ins
+      AttributeSelfTypeParameter<"", "rtg::SetType">:$type,
+      DenseSetParameter<"TypedAttr", "elements">:$elements);
+
+  let builders = [
+    AttrBuilderWithInferredContext<
+      (ins "rtg::SetType":$type,
+           "const ::llvm::DenseSet<::mlir::TypedAttr> *":$elements), [{
+      return $_get(type.getContext(), type, elements);
+    }]>
+  ];
+
+  let mnemonic = "set";
+  let hasCustomAssemblyFormat = true;
+
+  let genVerifyDecl = true;
+}
+
+def TupleAttr : RTGAttrDef<"Tuple", [
+  DeclareAttrInterfaceMethods<TypedAttrInterface>,
+]> {
+  let summary = "a tuple";
+
+  let parameters =
+      (ins ArrayRefParameter<"::mlir::TypedAttr", "elements">:$elements);
+
+  let mnemonic = "tuple";
+  let assemblyFormat = "`<` $elements `>`";
+}
+
 //===----------------------------------------------------------------------===//
 // Attributes for ISA targets
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/RTG/IR/RTGDialect.cpp
+++ b/lib/Dialect/RTG/IR/RTGDialect.cpp
@@ -44,7 +44,7 @@ void RTGDialect::initialize() {
 /// constant value. Otherwise, it should return null on failure.
 Operation *RTGDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                            Type type, Location loc) {
-  if (auto attr = dyn_cast<ImmediateAttr>(value))
+  if (auto attr = dyn_cast<TypedAttr>(value))
     if (type == attr.getType())
       return ConstantOp::create(builder, loc, attr);
 

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -15,6 +15,24 @@ rtg.test @constants() {
 
   // CHECK-NEXT: rtg.isa.space [[V0]]
   rtg.isa.space %1
+
+  // CHECK-NEXT: rtg.constant #rtg.set<> : !rtg.set<i32>
+  rtg.constant #rtg.set<> : !rtg.set<i32>
+
+  // Test that set elements are printed in lexicographic order
+  // CHECK-NEXT: rtg.constant #rtg.set<#rtgtest.a0 : !rtgtest.ireg, #rtgtest.a1 : !rtgtest.ireg, #rtgtest.a2 : !rtgtest.ireg> : !rtg.set<!rtgtest.ireg>
+  rtg.constant #rtg.set<#rtgtest.a1, #rtgtest.a0, #rtgtest.a2> : !rtg.set<!rtgtest.ireg>
+
+  // Test set type inference 
+  // CHECK-NEXT: rtg.constant #rtg.set<0 : i32, 1 : i32, 2 : i32> : !rtg.set<i32>
+  rtg.constant #rtg.set<1 : i32, 0 : i32, 2 : i32>
+
+  // CHECK-NEXT: rtg.constant #rtg.tuple<0 : i32, 1 : index> : !rtg.tuple<i32, index>
+  rtg.constant #rtg.tuple<0 : i32, 1 : index> : !rtg.tuple<i32, index>
+
+  // Test set type inference 
+  // CHECK-NEXT: rtg.constant #rtg.tuple<0 : i32, 1 : index> : !rtg.tuple<i32, index>
+  rtg.constant #rtg.tuple<0 : i32, 1 : index>
 }
 
 // CHECK-LABEL: rtg.sequence @ranomizedSequenceType

--- a/test/Dialect/RTG/IR/errors.mlir
+++ b/test/Dialect/RTG/IR/errors.mlir
@@ -329,3 +329,24 @@ rtg.test @concatImmediateNonImmediateOperand() {
   // expected-error @below {{all operands must be of immediate type}}
   %1 = rtg.isa.concat_immediate %0 : index
 }
+
+// -----
+
+rtg.test @setAttrNotSetType() {
+  // expected-error @below {{type must be a an '!rtg.set' type}}
+  rtg.constant #rtg.set<> : !rtg.bag<i32>
+}
+
+// -----
+
+rtg.test @setAttrExplicitTypeRequired() {
+  // expected-error @below {{type must be explicitly provided: cannot infer set element type from empty set}}
+  rtg.constant #rtg.set<>
+}
+
+// -----
+
+rtg.test @setAttrExplicitTypeRequired() {
+  // expected-error @below {{all elements must be of the set element type 'i32'}}
+  rtg.constant #rtg.set<0 : index> : !rtg.set<i32>
+}


### PR DESCRIPTION
Allows aggregate constants like `hw.aggregate_constant`, but using attributes instead of a dedicated op.