### PR TITLE
[MooreToCore] Error out on conversions to unsupported types

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1493,6 +1493,10 @@ struct ConversionOpConversion : public OpConversionPattern<ConversionOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     Type resultType = typeConverter->convertType(op.getResult().getType());
+    if (!resultType) {
+      op.emitError("conversion result type is not currently supported");
+      return failure();
+    }
     int64_t inputBw = hw::getBitWidth(adaptor.getInput().getType());
     int64_t resultBw = hw::getBitWidth(resultType);
     if (inputBw == -1 || resultBw == -1)

--- a/test/Conversion/MooreToCore/errors.mlir
+++ b/test/Conversion/MooreToCore/errors.mlir
@@ -6,3 +6,13 @@ func.func @invalidType() {
 
   return
 }
+
+// -----
+
+func.func @unsupportedConversion() {
+    %0 = moore.constant_string "Test" : i32
+    // expected-error @below {{conversion result type is not currently supported}}
+    // expected-error @below {{failed to legalize operation 'moore.conversion'}}
+    %1 = moore.conversion %0 : !moore.i32 -> !moore.string
+  return
+}


### PR DESCRIPTION
Noticed we had some opaque crashes on failing sv-tests that turned out to be due to the MooreToCore pattern for ConversionOp trying to get the bitwidth of a null type by failing to check whether the result type was successfully converted. This just makes that into a proper error instead of an assertion failure.