### PR TITLE
[ESI][BSP] Introduce a pipelined channel demux and use it

### DIFF
--- a/frontends/PyCDE/src/pycde/bsp/common.py
+++ b/frontends/PyCDE/src/pycde/bsp/common.py
@@ -7,10 +7,10 @@ from math import ceil
 
 from ..common import Clock, Input, InputChannel, Output, OutputChannel, Reset
 from ..constructs import (AssignableSignal, ControlReg, Counter, Mux, NamedWire,
-                          Reg, Wire)
+                          Wire)
 from .. import esi
 from ..module import Module, generator, modparams
-from ..signals import BitsSignal, BundleSignal, ChannelSignal, ClockSignal
+from ..signals import BitsSignal, ChannelSignal, StructSignal
 from ..support import clog2
 from ..types import (Array, Bits, Bundle, BundledChannel, Channel,
                      ChannelDirection, StructType, Type, UInt)


### PR DESCRIPTION
Introduces a half-throughput channel demux. Use it in the ChannelMMIO implementation. Half-thoughput is acceptable since it only supports one message at a time anyway.

This was necessary to support even simple internal applications since they weren't anywhere close to meeting timing. Doubtless there'll be more timing enhancements coming down the pike.