### PR TITLE
[RTG] Remove fixed_reg operation

### DIFF
--- a/frontends/PyRTG/src/pyrtg/resources.py
+++ b/frontends/PyRTG/src/pyrtg/resources.py
@@ -63,100 +63,100 @@ class IntegerRegister(Value):
         ]))
 
   def zero() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegZeroAttr.get())
+    return rtg.ConstantOp(rtgtest.RegZeroAttr.get())
 
   def ra() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegRaAttr.get())
+    return rtg.ConstantOp(rtgtest.RegRaAttr.get())
 
   def sp() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegSpAttr.get())
+    return rtg.ConstantOp(rtgtest.RegSpAttr.get())
 
   def gp() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegGpAttr.get())
+    return rtg.ConstantOp(rtgtest.RegGpAttr.get())
 
   def tp() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegTpAttr.get())
+    return rtg.ConstantOp(rtgtest.RegTpAttr.get())
 
   def t0() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegT0Attr.get())
+    return rtg.ConstantOp(rtgtest.RegT0Attr.get())
 
   def t1() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegT1Attr.get())
+    return rtg.ConstantOp(rtgtest.RegT1Attr.get())
 
   def t2() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegT2Attr.get())
+    return rtg.ConstantOp(rtgtest.RegT2Attr.get())
 
   def s0() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS0Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS0Attr.get())
 
   def s1() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS1Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS1Attr.get())
 
   def a0() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegA0Attr.get())
+    return rtg.ConstantOp(rtgtest.RegA0Attr.get())
 
   def a1() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegA1Attr.get())
+    return rtg.ConstantOp(rtgtest.RegA1Attr.get())
 
   def a2() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegA2Attr.get())
+    return rtg.ConstantOp(rtgtest.RegA2Attr.get())
 
   def a3() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegA3Attr.get())
+    return rtg.ConstantOp(rtgtest.RegA3Attr.get())
 
   def a4() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegA4Attr.get())
+    return rtg.ConstantOp(rtgtest.RegA4Attr.get())
 
   def a5() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegA5Attr.get())
+    return rtg.ConstantOp(rtgtest.RegA5Attr.get())
 
   def a6() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegA6Attr.get())
+    return rtg.ConstantOp(rtgtest.RegA6Attr.get())
 
   def a7() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegA7Attr.get())
+    return rtg.ConstantOp(rtgtest.RegA7Attr.get())
 
   def s2() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS2Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS2Attr.get())
 
   def s3() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS3Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS3Attr.get())
 
   def s4() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS4Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS4Attr.get())
 
   def s5() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS5Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS5Attr.get())
 
   def s6() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS6Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS6Attr.get())
 
   def s7() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS7Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS7Attr.get())
 
   def s8() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS8Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS8Attr.get())
 
   def s9() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS9Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS9Attr.get())
 
   def s10() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS10Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS10Attr.get())
 
   def s11() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegS11Attr.get())
+    return rtg.ConstantOp(rtgtest.RegS11Attr.get())
 
   def t3() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegT3Attr.get())
+    return rtg.ConstantOp(rtgtest.RegT3Attr.get())
 
   def t4() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegT4Attr.get())
+    return rtg.ConstantOp(rtgtest.RegT4Attr.get())
 
   def t5() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegT5Attr.get())
+    return rtg.ConstantOp(rtgtest.RegT5Attr.get())
 
   def t6() -> IntegerRegister:
-    return rtg.FixedRegisterOp(rtgtest.RegT6Attr.get())
+    return rtg.ConstantOp(rtgtest.RegT6Attr.get())
 
   def _get_ssa_value(self) -> ir.Value:
     return self._value

--- a/frontends/PyRTG/test/basic.py
+++ b/frontends/PyRTG/test/basic.py
@@ -298,11 +298,11 @@ def test2_labels(config):
 # MLIR-NEXT: [[IMM32:%.+]] = rtg.constant #rtg.isa.immediate<32, 32>
 # MLIR-NEXT: [[IMM21:%.+]] = rtg.constant #rtg.isa.immediate<21, 16>
 # MLIR-NEXT: [[IMM13:%.+]] = rtg.constant #rtg.isa.immediate<13, 9>
-# MLIR-NEXT: [[T2:%.+]] = rtg.fixed_reg #rtgtest.t2 : !rtgtest.ireg
+# MLIR-NEXT: [[T2:%.+]] = rtg.constant #rtgtest.t2 : !rtgtest.ireg
 # MLIR-NEXT: [[IMM5:%.+]] = rtg.constant #rtg.isa.immediate<5, 4>
-# MLIR-NEXT: [[T1:%.+]] = rtg.fixed_reg #rtgtest.t1 : !rtgtest.ireg
+# MLIR-NEXT: [[T1:%.+]] = rtg.constant #rtgtest.t1 : !rtgtest.ireg
 # MLIR-NEXT: [[IMM12:%.+]] = rtg.constant #rtg.isa.immediate<12, 8>
-# MLIR-NEXT: [[T0:%.+]] = rtg.fixed_reg #rtgtest.t0 : !rtgtest.ireg
+# MLIR-NEXT: [[T0:%.+]] = rtg.constant #rtgtest.t0 : !rtgtest.ireg
 # MLIR-NEXT: [[VREG:%.+]] = rtg.virtual_reg [#rtgtest.t0 : !rtgtest.ireg, #rtgtest.t1 : !rtgtest.ireg, #rtgtest.t2 : !rtgtest.ireg, #rtgtest.t3 : !rtgtest.ireg, #rtgtest.t4 : !rtgtest.ireg, #rtgtest.t5 : !rtgtest.ireg, #rtgtest.t6 : !rtgtest.ireg, #rtgtest.a7 : !rtgtest.ireg, #rtgtest.a6 : !rtgtest.ireg, #rtgtest.a5 : !rtgtest.ireg, #rtgtest.a4 : !rtgtest.ireg, #rtgtest.a3 : !rtgtest.ireg, #rtgtest.a2 : !rtgtest.ireg, #rtgtest.a1 : !rtgtest.ireg, #rtgtest.a0 : !rtgtest.ireg, #rtgtest.s1 : !rtgtest.ireg, #rtgtest.s2 : !rtgtest.ireg, #rtgtest.s3 : !rtgtest.ireg, #rtgtest.s4 : !rtgtest.ireg, #rtgtest.s5 : !rtgtest.ireg, #rtgtest.s6 : !rtgtest.ireg, #rtgtest.s7 : !rtgtest.ireg, #rtgtest.s8 : !rtgtest.ireg, #rtgtest.s9 : !rtgtest.ireg, #rtgtest.s10 : !rtgtest.ireg, #rtgtest.s11 : !rtgtest.ireg, #rtgtest.s0 : !rtgtest.ireg, #rtgtest.ra : !rtgtest.ireg, #rtgtest.sp : !rtgtest.ireg]
 # MLIR-NEXT: rtgtest.rv32i.addi [[VREG]], [[T0]], [[IMM12]]
 # MLIR-NEXT: rtgtest.rv32i.slli [[VREG]], [[T1]], [[IMM5]]
@@ -328,7 +328,7 @@ def test3_registers_and_immediates(config):
 
 
 # MLIR-LABEL: rtg.test @test4_integer_to_immediate()
-# MLIR-NEXT: [[V0:%.+]] = rtg.fixed_reg
+# MLIR-NEXT: [[V0:%.+]] = rtg.constant
 # MLIR-NEXT: [[V1:%.+]] = index.constant 2
 # MLIR-NEXT: [[V2:%.+]] = rtg.isa.int_to_immediate [[V1]] : !rtg.isa.immediate<12>
 # MLIR-NEXT: rtgtest.rv32i.addi [[V0]], [[V0]], [[V2]]
@@ -341,7 +341,7 @@ def test4_integer_to_immediate(config):
 
 
 # MLIR-LABEL: rtg.test @test6_memories
-# MLIR-NEXT: [[REG:%.+]] = rtg.fixed_reg #rtgtest.t0 : !rtgtest.ireg
+# MLIR-NEXT: [[REG:%.+]] = rtg.constant #rtgtest.t0 : !rtgtest.ireg
 # MLIR-NEXT: [[IDX8:%.+]] = index.constant 8
 # MLIR-NEXT: [[IDX4:%.+]] = index.constant 4
 # MLIR-NEXT: [[MEM:%.+]] = rtg.isa.memory_alloc %mem_blk, [[IDX8]], [[IDX4]] : !rtg.isa.memory_block<32>

--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -33,7 +33,8 @@ class RTGOp<string mnemonic, list<Trait> traits = []> :
 def ConstantOp : RTGOp<"constant", [
   Pure,
   ConstantLike,
-  DeclareOpInterfaceMethods<InferTypeOpInterface>
+  DeclareOpInterfaceMethods<InferTypeOpInterface>,
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
   let summary = "create an SSA value from an attribute";
 
@@ -677,25 +678,6 @@ def ConstraintOp : RTGOp<"constraint", []> {
 }
 
 //===- ISA Register Handling Operations -----------------------------------===//
-
-def FixedRegisterOp : RTGOp<"fixed_reg", [
-  Pure, ConstantLike,
-  DeclareOpInterfaceMethods<InferTypeOpInterface>,
-  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-]> {
-  let summary = "returns a value representing a fixed register";
-  let description = [{
-    This operation creates a value representing the register given as the 'reg'
-    attribute. This is always a concrete ISA register.
-    The return type always matches the register attribute type.
-  }];
-
-  let arguments = (ins RegisterAttrInterface:$reg);
-  let results = (outs RegisterTypeInterface:$result);
-
-  let assemblyFormat = "$reg attr-dict";
-  let hasFolder = 1;
-}
 
 def VirtualRegisterOp : RTGOp<"virtual_reg", [
   DeclareOpInterfaceMethods<InferTypeOpInterface>,

--- a/include/circt/Dialect/RTG/IR/RTGVisitors.h
+++ b/include/circt/Dialect/RTG/IR/RTGVisitors.h
@@ -42,7 +42,7 @@ public:
             // Labels
             LabelDeclOp, LabelUniqueDeclOp, LabelOp,
             // Registers
-            FixedRegisterOp, VirtualRegisterOp,
+            VirtualRegisterOp,
             // RTG tests
             TestOp, TargetOp, YieldOp, ValidateOp, TestSuccessOp, TestFailureOp,
             // Integers
@@ -136,7 +136,6 @@ public:
   HANDLE(ValidateOp, Unhandled);
   HANDLE(TestSuccessOp, Unhandled);
   HANDLE(TestFailureOp, Unhandled);
-  HANDLE(FixedRegisterOp, Unhandled);
   HANDLE(VirtualRegisterOp, Unhandled);
   HANDLE(IntToImmediateOp, Unhandled);
   HANDLE(ConcatImmediateOp, Unhandled);

--- a/integration_test/Bindings/Python/dialects/rtg.py
+++ b/integration_test/Bindings/Python/dialects/rtg.py
@@ -114,70 +114,70 @@ with Context() as ctx, Location.unknown():
   circt.register_dialects(ctx)
   m = Module.create()
   with InsertionPoint(m.body):
-    # CHECK: rtg.fixed_reg #rtgtest.zero
-    rtg.FixedRegisterOp(rtgtest.RegZeroAttr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.ra
-    rtg.FixedRegisterOp(rtgtest.RegRaAttr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.sp
-    rtg.FixedRegisterOp(rtgtest.RegSpAttr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.gp
-    rtg.FixedRegisterOp(rtgtest.RegGpAttr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.tp
-    rtg.FixedRegisterOp(rtgtest.RegTpAttr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.t0
-    rtg.FixedRegisterOp(rtgtest.RegT0Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.t1
-    rtg.FixedRegisterOp(rtgtest.RegT1Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.t2
-    rtg.FixedRegisterOp(rtgtest.RegT2Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s0
-    rtg.FixedRegisterOp(rtgtest.RegS0Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s1
-    rtg.FixedRegisterOp(rtgtest.RegS1Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.a0
-    rtg.FixedRegisterOp(rtgtest.RegA0Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.a1
-    rtg.FixedRegisterOp(rtgtest.RegA1Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.a2
-    rtg.FixedRegisterOp(rtgtest.RegA2Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.a3
-    rtg.FixedRegisterOp(rtgtest.RegA3Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.a4
-    rtg.FixedRegisterOp(rtgtest.RegA4Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.a5
-    rtg.FixedRegisterOp(rtgtest.RegA5Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.a6
-    rtg.FixedRegisterOp(rtgtest.RegA6Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.a7
-    rtg.FixedRegisterOp(rtgtest.RegA7Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s2
-    rtg.FixedRegisterOp(rtgtest.RegS2Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s3
-    rtg.FixedRegisterOp(rtgtest.RegS3Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s4
-    rtg.FixedRegisterOp(rtgtest.RegS4Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s5
-    rtg.FixedRegisterOp(rtgtest.RegS5Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s6
-    rtg.FixedRegisterOp(rtgtest.RegS6Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s7
-    rtg.FixedRegisterOp(rtgtest.RegS7Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s8
-    rtg.FixedRegisterOp(rtgtest.RegS8Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s9
-    rtg.FixedRegisterOp(rtgtest.RegS9Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s10
-    rtg.FixedRegisterOp(rtgtest.RegS10Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.s11
-    rtg.FixedRegisterOp(rtgtest.RegS11Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.t3
-    rtg.FixedRegisterOp(rtgtest.RegT3Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.t4
-    rtg.FixedRegisterOp(rtgtest.RegT4Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.t5
-    rtg.FixedRegisterOp(rtgtest.RegT5Attr.get())
-    # CHECK: rtg.fixed_reg #rtgtest.t6
-    rtg.FixedRegisterOp(rtgtest.RegT6Attr.get())
+    # CHECK: rtg.constant #rtgtest.zero
+    rtg.ConstantOp(rtgtest.RegZeroAttr.get())
+    # CHECK: rtg.constant #rtgtest.ra
+    rtg.ConstantOp(rtgtest.RegRaAttr.get())
+    # CHECK: rtg.constant #rtgtest.sp
+    rtg.ConstantOp(rtgtest.RegSpAttr.get())
+    # CHECK: rtg.constant #rtgtest.gp
+    rtg.ConstantOp(rtgtest.RegGpAttr.get())
+    # CHECK: rtg.constant #rtgtest.tp
+    rtg.ConstantOp(rtgtest.RegTpAttr.get())
+    # CHECK: rtg.constant #rtgtest.t0
+    rtg.ConstantOp(rtgtest.RegT0Attr.get())
+    # CHECK: rtg.constant #rtgtest.t1
+    rtg.ConstantOp(rtgtest.RegT1Attr.get())
+    # CHECK: rtg.constant #rtgtest.t2
+    rtg.ConstantOp(rtgtest.RegT2Attr.get())
+    # CHECK: rtg.constant #rtgtest.s0
+    rtg.ConstantOp(rtgtest.RegS0Attr.get())
+    # CHECK: rtg.constant #rtgtest.s1
+    rtg.ConstantOp(rtgtest.RegS1Attr.get())
+    # CHECK: rtg.constant #rtgtest.a0
+    rtg.ConstantOp(rtgtest.RegA0Attr.get())
+    # CHECK: rtg.constant #rtgtest.a1
+    rtg.ConstantOp(rtgtest.RegA1Attr.get())
+    # CHECK: rtg.constant #rtgtest.a2
+    rtg.ConstantOp(rtgtest.RegA2Attr.get())
+    # CHECK: rtg.constant #rtgtest.a3
+    rtg.ConstantOp(rtgtest.RegA3Attr.get())
+    # CHECK: rtg.constant #rtgtest.a4
+    rtg.ConstantOp(rtgtest.RegA4Attr.get())
+    # CHECK: rtg.constant #rtgtest.a5
+    rtg.ConstantOp(rtgtest.RegA5Attr.get())
+    # CHECK: rtg.constant #rtgtest.a6
+    rtg.ConstantOp(rtgtest.RegA6Attr.get())
+    # CHECK: rtg.constant #rtgtest.a7
+    rtg.ConstantOp(rtgtest.RegA7Attr.get())
+    # CHECK: rtg.constant #rtgtest.s2
+    rtg.ConstantOp(rtgtest.RegS2Attr.get())
+    # CHECK: rtg.constant #rtgtest.s3
+    rtg.ConstantOp(rtgtest.RegS3Attr.get())
+    # CHECK: rtg.constant #rtgtest.s4
+    rtg.ConstantOp(rtgtest.RegS4Attr.get())
+    # CHECK: rtg.constant #rtgtest.s5
+    rtg.ConstantOp(rtgtest.RegS5Attr.get())
+    # CHECK: rtg.constant #rtgtest.s6
+    rtg.ConstantOp(rtgtest.RegS6Attr.get())
+    # CHECK: rtg.constant #rtgtest.s7
+    rtg.ConstantOp(rtgtest.RegS7Attr.get())
+    # CHECK: rtg.constant #rtgtest.s8
+    rtg.ConstantOp(rtgtest.RegS8Attr.get())
+    # CHECK: rtg.constant #rtgtest.s9
+    rtg.ConstantOp(rtgtest.RegS9Attr.get())
+    # CHECK: rtg.constant #rtgtest.s10
+    rtg.ConstantOp(rtgtest.RegS10Attr.get())
+    # CHECK: rtg.constant #rtgtest.s11
+    rtg.ConstantOp(rtgtest.RegS11Attr.get())
+    # CHECK: rtg.constant #rtgtest.t3
+    rtg.ConstantOp(rtgtest.RegT3Attr.get())
+    # CHECK: rtg.constant #rtgtest.t4
+    rtg.ConstantOp(rtgtest.RegT4Attr.get())
+    # CHECK: rtg.constant #rtgtest.t5
+    rtg.ConstantOp(rtgtest.RegT5Attr.get())
+    # CHECK: rtg.constant #rtgtest.t6
+    rtg.ConstantOp(rtgtest.RegT6Attr.get())
 
   print(m)
 

--- a/lib/Dialect/RTG/IR/RTGOps.cpp
+++ b/lib/Dialect/RTG/IR/RTGOps.cpp
@@ -37,6 +37,13 @@ ConstantOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
 
 OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) { return getValueAttr(); }
 
+void ConstantOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  if (auto reg = dyn_cast<rtg::RegisterAttrInterface>(getValueAttr())) {
+    setNameFn(getResult(), reg.getRegisterAssembly());
+    return;
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // SequenceOp
 //===----------------------------------------------------------------------===//
@@ -415,25 +422,6 @@ LogicalResult TupleExtractOp::inferReturnTypes(
 
   inferredReturnTypes.push_back(tupleTy.getFieldTypes()[idx]);
   return success();
-}
-
-//===----------------------------------------------------------------------===//
-// FixedRegisterOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult FixedRegisterOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
-    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
-    SmallVectorImpl<Type> &inferredReturnTypes) {
-  inferredReturnTypes.push_back(
-      properties.as<Properties *>()->getReg().getType());
-  return success();
-}
-
-OpFoldResult FixedRegisterOp::fold(FoldAdaptor adaptor) { return getRegAttr(); }
-
-void FixedRegisterOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  setNameFn(getResult(), getReg().getRegisterAssembly());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
@@ -1613,10 +1613,6 @@ public:
     return DeletionKind::Delete;
   }
 
-  FailureOr<DeletionKind> visitOp(FixedRegisterOp op) {
-    return visitPureOp(op);
-  }
-
   FailureOr<DeletionKind> visitOp(VirtualRegisterOp op) {
     auto *val = sharedState.internalizer.create<VirtualRegisterStorage>(
         op.getAllowedRegsAttr(), op.getType());

--- a/lib/Dialect/RTG/Transforms/LinearScanRegisterAllocationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/LinearScanRegisterAllocationPass.cpp
@@ -87,7 +87,8 @@ void LinearScanRegisterAllocationPass::runOnOperation() {
   SmallVector<std::unique_ptr<RegisterLiveRange>> regRanges;
   SmallVector<RegisterLiveRange *> active;
   for (auto &op : getOperation()->getRegion(0).getBlocks().front()) {
-    if (!isa<rtg::FixedRegisterOp, rtg::VirtualRegisterOp>(&op))
+    if (!isa<rtg::ConstantOp, rtg::VirtualRegisterOp>(&op) ||
+        !isa<rtg::RegisterTypeInterface>(op.getResult(0).getType()))
       continue;
 
     RegisterLiveRange lr;
@@ -97,8 +98,14 @@ void LinearScanRegisterAllocationPass::runOnOperation() {
     if (auto regOp = dyn_cast<rtg::VirtualRegisterOp>(&op))
       lr.regOp = regOp;
 
-    if (auto regOp = dyn_cast<rtg::FixedRegisterOp>(&op))
-      lr.fixedReg = regOp.getReg();
+    if (auto regOp = dyn_cast<rtg::ConstantOp>(&op)) {
+      auto reg = dyn_cast<rtg::RegisterAttrInterface>(regOp.getValue());
+      if (!reg) {
+        op.emitError("expected register attribute");
+        return signalPassFailure();
+      }
+      lr.fixedReg = reg;
+    }
 
     for (auto *user : op.getUsers()) {
       if (!isa<rtg::InstructionOpInterface, rtg::ValidateOp>(user)) {
@@ -173,7 +180,6 @@ void LinearScanRegisterAllocationPass::runOnOperation() {
       continue;
 
     IRRewriter rewriter(reg->regOp);
-    rewriter.replaceOpWithNewOp<rtg::FixedRegisterOp>(reg->regOp,
-                                                      reg->fixedReg);
+    rewriter.replaceOpWithNewOp<rtg::ConstantOp>(reg->regOp, reg->fixedReg);
   }
 }

--- a/lib/Dialect/RTGTest/IR/RTGTestDialect.cpp
+++ b/lib/Dialect/RTGTest/IR/RTGTestDialect.cpp
@@ -46,18 +46,10 @@ void RTGTestDialect::initialize() {
 Operation *RTGTestDialect::materializeConstant(OpBuilder &builder,
                                                Attribute value, Type type,
                                                Location loc) {
-  return TypeSwitch<Attribute, Operation *>(value)
-      .Case<CPUAttr>([&](auto attr) -> Operation * {
-        if (isa<CPUType>(type))
-          return rtg::ConstantOp::create(builder, loc, attr);
-        return nullptr;
-      })
-      .Case<rtg::RegisterAttrInterface>([&](auto attr) -> Operation * {
-        if (isa<rtg::RegisterTypeInterface>(type))
-          return rtg::FixedRegisterOp::create(builder, loc, attr);
-        return nullptr;
-      })
-      .Default([](auto attr) { return nullptr; });
+  if (auto attr = dyn_cast<TypedAttr>(value))
+    if (type == attr.getType())
+      return rtg::ConstantOp::create(builder, loc, attr);
+  return nullptr;
 }
 
 #include "circt/Dialect/RTGTest/IR/RTGTestEnums.cpp.inc"

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -241,9 +241,9 @@ rtg.test @template() template "temp_name" target @target { }
 
 // CHECK-LABEL: rtg.test @validation()
 rtg.test @validation() {
-  // CHECK: [[V0:%.+]] = rtg.fixed_reg #rtgtest.t0
+  // CHECK: [[V0:%.+]] = rtg.constant #rtgtest.t0
   // CHECK: [[V1:%.+]] = rtg.constant #rtg.isa.immediate<32, 0>
-  %0 = rtg.fixed_reg #rtgtest.t0
+  %0 = rtg.constant #rtgtest.t0
   %1 = rtg.constant #rtg.isa.immediate<32, 0>
   // CHECK: rtg.validate [[V0]], [[V1]], "some_id" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   %2 = rtg.validate %0, %1, "some_id" : !rtgtest.ireg -> !rtg.isa.immediate<32>

--- a/test/Dialect/RTG/IR/errors.mlir
+++ b/test/Dialect/RTG/IR/errors.mlir
@@ -293,7 +293,7 @@ rtg.target @memoryBlockBaseAddressLargerThanEndAddress : !rtg.dict<> {
 // -----
 
 rtg.test @validate() {
-  %0 = rtg.fixed_reg #rtgtest.t0
+  %0 = rtg.constant #rtgtest.t0
   // expected-error @below {{result type must be a valid content type for the ref value}}
   %2 = rtg.validate %0, %0 : !rtgtest.ireg -> !rtgtest.ireg
 }

--- a/test/Dialect/RTG/Transform/elaboration.mlir
+++ b/test/Dialect/RTG/Transform/elaboration.mlir
@@ -73,20 +73,20 @@ rtg.test @setCartesianProduct(singleton = %none: index) {
   %true = index.bool.constant true
   %false = index.bool.constant false
   %1 = rtg.set_create %true, %false : i1
-  %s0 = rtg.fixed_reg #rtgtest.s0
-  %s1 = rtg.fixed_reg #rtgtest.s1
+  %s0 = rtg.constant #rtgtest.s0
+  %s1 = rtg.constant #rtgtest.s1
   %2 = rtg.set_create %s0, %s1 : !rtgtest.ireg
 
   // CHECK-DAG: [[IDX1:%.+]] = index.constant 1
   // CHECK-DAG: [[FALSE:%.+]] = index.bool.constant false
-  // CHECK-DAG: [[S1:%.+]] = rtg.fixed_reg #rtgtest.s1 : !rtgtest.ireg
+  // CHECK-DAG: [[S1:%.+]] = rtg.constant #rtgtest.s1 : !rtgtest.ireg
   // CHECK-DAG: [[T1:%.+]] = rtg.tuple_create [[IDX1]], [[FALSE]], [[S1]] : index, i1, !rtgtest.ireg
   // CHECK-DAG: [[IDX0:%.+]] = index.constant 0
   // CHECK-DAG: [[T2:%.+]] = rtg.tuple_create [[IDX0]], [[FALSE]], [[S1]] : index, i1, !rtgtest.ireg
   // CHECK-DAG: [[TRUE:%.+]] = index.bool.constant true
   // CHECK-DAG: [[T3:%.+]] = rtg.tuple_create [[IDX1]], [[TRUE]], [[S1]] : index, i1, !rtgtest.ireg
   // CHECK-DAG: [[T4:%.+]] = rtg.tuple_create [[IDX0]], [[TRUE]], [[S1]] : index, i1, !rtgtest.ireg
-  // CHECK-DAG: [[S0:%.+]] = rtg.fixed_reg #rtgtest.s0 : !rtgtest.ireg
+  // CHECK-DAG: [[S0:%.+]] = rtg.constant #rtgtest.s0 : !rtgtest.ireg
   // CHECK-DAG: [[T5:%.+]] = rtg.tuple_create [[IDX1]], [[FALSE]], [[S0]] : index, i1, !rtgtest.ireg
   // CHECK-DAG: [[T6:%.+]] = rtg.tuple_create [[IDX0]], [[FALSE]], [[S0]] : index, i1, !rtgtest.ireg
   // CHECK-DAG: [[T7:%.+]] = rtg.tuple_create [[IDX1]], [[TRUE]], [[S0]] : index, i1, !rtgtest.ireg
@@ -389,12 +389,12 @@ rtg.test @scfFor(singleton = %none: index) {
 
 // CHECK-LABEL: @fixedRegisters
 rtg.test @fixedRegisters(singleton = %none: index) {
-  // CHECK-NEXT: [[RA:%.+]] = rtg.fixed_reg #rtgtest.ra
-  // CHECK-NEXT: [[SP:%.+]] = rtg.fixed_reg #rtgtest.sp
+  // CHECK-NEXT: [[RA:%.+]] = rtg.constant #rtgtest.ra
+  // CHECK-NEXT: [[SP:%.+]] = rtg.constant #rtgtest.sp
   // CHECK-NEXT: [[IMM:%.+]] = rtg.constant #rtg.isa.immediate<12, 0>
   // CHECK-NEXT: rtgtest.rv32i.jalr [[RA]], [[SP]], [[IMM]]
-  %ra = rtg.fixed_reg #rtgtest.ra
-  %sp = rtg.fixed_reg #rtgtest.sp
+  %ra = rtg.constant #rtgtest.ra
+  %sp = rtg.constant #rtgtest.sp
   %imm = rtg.constant #rtg.isa.immediate<12, 0>
   rtgtest.rv32i.jalr %ra, %sp, %imm
 }
@@ -741,11 +741,11 @@ rtg.test @subtypeMatching(b = %b: index) {
 
 // CHECK-LABEL: rtg.test @validateOp
 rtg.test @validateOp(singleton = %none: index) {
-  // CHECK-NEXT: [[V0:%.+]] = rtg.fixed_reg #rtgtest.t0
+  // CHECK-NEXT: [[V0:%.+]] = rtg.constant #rtgtest.t0
   // CHECK-NEXT: [[V1:%.+]] = rtg.constant #rtg.isa.immediate<32, 0>
   // CHECK-NEXT: [[V2:%.+]] = rtg.validate [[V0]], [[V1]], "some_id" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   // CHECK-NEXT: func.call @dummy15([[V2]])
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %default = rtg.constant #rtg.isa.immediate<32, 0>
   %0 = rtg.validate %reg, %default, "some_id" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   func.call @dummy15(%0) : (!rtg.isa.immediate<32>) -> ()
@@ -794,7 +794,7 @@ rtg.test @immediateOps(singleton = %none: index) {
   // CHECK-NEXT: func.call @dummy16([[CONCAT]]) :
   // CHECK-NEXT: [[SLICE:%.+]] = rtg.isa.slice_immediate [[V1]] from 4 :
   // CHECK-NEXT: func.call @dummy6([[SLICE]]) :
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %def1 = rtg.constant #rtg.isa.immediate<6, 0>
   %val1 = rtg.validate %reg, %def1, "val1" : !rtgtest.ireg -> !rtg.isa.immediate<6>
   %concat = rtg.isa.concat_immediate %val1, %val1 : !rtg.isa.immediate<6>, !rtg.isa.immediate<6>

--- a/test/Dialect/RTG/Transform/embed-validation-values.mlir
+++ b/test/Dialect/RTG/Transform/embed-validation-values.mlir
@@ -5,11 +5,11 @@
 
 // CHECK-TEST0-LABEL: rtg.test @embed_value
 rtg.test @embed_value() {
-  // CHECK-TEST0-NEXT: [[REG:%.+]] = rtg.fixed_reg #rtgtest.t0
+  // CHECK-TEST0-NEXT: [[REG:%.+]] = rtg.constant #rtgtest.t0
   // CHECK-TEST0-NEXT: [[V0:%.+]] = rtg.constant #rtg.isa.immediate<32, 8192>
   // CHECK-TEST0-NEXT: rtgtest.rv32i.lui [[REG]], [[V0]] :
   // CHECK-TEST0-NEXT: }
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %imm = rtg.constant #rtg.isa.immediate<32, 0x1000>
   %exp_val = rtg.validate %reg, %imm, "id1" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   rtgtest.rv32i.lui %reg, %exp_val : !rtg.isa.immediate<32>
@@ -20,7 +20,7 @@ rtg.test @embed_value() {
 
 // CHECK-TEST1: validation-values-0.txt:1:4: error: cannot parse value of type '!rtg.isa.immediate<2>' from string '0x2000'
 rtg.test @value_parsing_error() {
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %imm = rtg.constant #rtg.isa.immediate<2, 0>
   %exp_val = rtg.validate %reg, %imm, "id1" : !rtgtest.ireg -> !rtg.isa.immediate<2>
 }
@@ -30,7 +30,7 @@ rtg.test @value_parsing_error() {
 
 // CHECK-TEST2: validation-values-1.txt:2:1: error: duplicate ID in input file: "id1"
 rtg.test @duplicate_id_in_file_error() {
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %imm = rtg.constant #rtg.isa.immediate<32, 0x1000>
   %exp_val = rtg.validate %reg, %imm, "id1" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   rtgtest.rv32i.lui %reg, %exp_val : !rtg.isa.immediate<32>
@@ -41,7 +41,7 @@ rtg.test @duplicate_id_in_file_error() {
 
 // CHECK-TEST3: validation-values-2.txt:2:4: error: no value for ID 'id0'
 rtg.test @no_value_for_id_error() {
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %imm = rtg.constant #rtg.isa.immediate<32, 0x1000>
   %exp_val = rtg.validate %reg, %imm, "id1" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   rtgtest.rv32i.lui %reg, %exp_val : !rtg.isa.immediate<32>
@@ -51,7 +51,7 @@ rtg.test @no_value_for_id_error() {
 // RUN: circt-opt %t/test4.mlir --rtg-embed-validation-values=filename=%S/validation-values-0.txt --verify-diagnostics
 
 rtg.test @duplicate_validate_id_error() {
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %imm = rtg.constant #rtg.isa.immediate<32, 0x1000>
   %exp_val = rtg.validate %reg, %imm, "id1" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   // expected-error @below {{at least two validate ops have the same ID: "id1"}}
@@ -65,11 +65,11 @@ rtg.test @duplicate_validate_id_error() {
 
 // CHECK-TEST5-LABEL: rtg.test @unmached_validate_stays
 rtg.test @unmached_validate_stays() {
-  // CHECK-TEST5-NEXT: [[REG:%.+]] = rtg.fixed_reg #rtgtest.t0
+  // CHECK-TEST5-NEXT: [[REG:%.+]] = rtg.constant #rtgtest.t0
   // CHECK-TEST5-NEXT: [[IMM:%.+]] = rtg.constant #rtg.isa.immediate<32, 4096>
   // CHECK-TEST5-NEXT: [[VAL:%.+]] = rtg.validate [[REG]], [[IMM]], "id10" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   // CHECK-TEST5-NEXT: rtgtest.rv32i.lui [[REG]], [[VAL]] : !rtg.isa.immediate<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %imm = rtg.constant #rtg.isa.immediate<32, 0x1000>
   %exp_val = rtg.validate %reg, %imm, "id10" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   rtgtest.rv32i.lui %reg, %exp_val : !rtg.isa.immediate<32>
@@ -80,7 +80,7 @@ rtg.test @unmached_validate_stays() {
 
 // CHECK-TEST6-LABEL: rtg.test @embed_value
 rtg.test @embed_value() {
-  // CHECK-TEST6-NEXT: [[REG:%.+]] = rtg.fixed_reg #rtgtest.t0
+  // CHECK-TEST6-NEXT: [[REG:%.+]] = rtg.constant #rtgtest.t0
   // CHECK-TEST6-NEXT: [[V1:%.+]] = rtg.constant #rtg.isa.immediate<32, 4>
   // CHECK-TEST6-NEXT: [[V2:%.+]] = rtg.constant #rtg.isa.immediate<32, 5>
   // CHECK-TEST6-NEXT: [[V0:%.+]] = rtg.constant #rtg.isa.immediate<32, 8192>
@@ -88,7 +88,7 @@ rtg.test @embed_value() {
   // CHECK-TEST6-NEXT: rtgtest.rv32i.lui [[REG]], [[V1]] :
   // CHECK-TEST6-NEXT: rtgtest.rv32i.lui [[REG]], [[V2]] :
   // CHECK-TEST6-NEXT: }
-  %0 = rtg.fixed_reg #rtgtest.t0
+  %0 = rtg.constant #rtgtest.t0
   %1 = rtg.constant #rtg.isa.immediate<32, 1>
   %2 = rtg.constant #rtg.isa.immediate<32, 2>
   %3 = rtg.constant #rtg.isa.immediate<32, 3>
@@ -105,10 +105,10 @@ rtg.test @embed_value() {
 
 // CHECK-TEST7-LABEL: rtg.test @embed_value
 rtg.test @embed_value() {
-  // CHECK-TEST7-NEXT: [[REG:%.+]] = rtg.fixed_reg #rtgtest.t0
+  // CHECK-TEST7-NEXT: [[REG:%.+]] = rtg.constant #rtgtest.t0
   // CHECK-TEST7-NEXT: [[IMM:%.+]] = rtg.constant #rtg.isa.immediate<32, 4096>
   // CHECK-TEST7-NEXT: rtgtest.rv32i.lui [[REG]], [[IMM]] : !rtg.isa.immediate<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   %imm = rtg.constant #rtg.isa.immediate<32, 0x1000>
   %exp_val = rtg.validate %reg, %imm, "id1" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   rtgtest.rv32i.lui %reg, %exp_val : !rtg.isa.immediate<32>

--- a/test/Dialect/RTG/Transform/emit-rtg-isa-assembly-errors.mlir
+++ b/test/Dialect/RTG/Transform/emit-rtg-isa-assembly-errors.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt --rtg-emit-isa-assembly=unsupported-instructions=rtgtest.rv32i.beq %s --split-input-file --verify-diagnostics
 
 emit.file "-" {
-  %rd = rtg.fixed_reg #rtgtest.ra
-  %rs = rtg.fixed_reg #rtgtest.s0
+  %rd = rtg.constant #rtgtest.ra
+  %rs = rtg.constant #rtgtest.s0
   %label = rtg.label_decl "label_name"
 
   // expected-error @below {{labels cannot be emitted as binary}}

--- a/test/Dialect/RTG/Transform/emit-rtg-isa-assembly-labels.mlir
+++ b/test/Dialect/RTG/Transform/emit-rtg-isa-assembly-labels.mlir
@@ -3,8 +3,8 @@
 emit.file "" {
   // CHECK:    # Begin of test0
   rtg.comment "Begin of test0"
-  %rd = rtg.fixed_reg #rtgtest.ra
-  %rs = rtg.fixed_reg #rtgtest.s0
+  %rd = rtg.constant #rtgtest.ra
+  %rs = rtg.constant #rtgtest.s0
   %label = rtg.label_decl "label_name"
 
   // CHECK-NEXT:    la ra, label_name

--- a/test/Dialect/RTG/Transform/emit-rtg-isa-assembly.mlir
+++ b/test/Dialect/RTG/Transform/emit-rtg-isa-assembly.mlir
@@ -12,8 +12,8 @@ emit.file "" {
   // CHECK-NEXT:    .space 8
   rtg.isa.space %idx8
 
-  %rd = rtg.fixed_reg #rtgtest.ra
-  %rs = rtg.fixed_reg #rtgtest.s0
+  %rd = rtg.constant #rtgtest.ra
+  %rs = rtg.constant #rtgtest.s0
   %imm = rtg.constant #rtg.isa.immediate<12, 0>
   %imm5 = rtg.constant #rtg.isa.immediate<5, 31>
   %imm21 = rtg.constant #rtg.isa.immediate<21, 0>

--- a/test/Dialect/RTG/Transform/inline-sequences.mlir
+++ b/test/Dialect/RTG/Transform/inline-sequences.mlir
@@ -59,8 +59,8 @@ rtg.test @interleaveSequences() {
 }
 
 rtg.sequence @nested0() {
-  %ra = rtg.fixed_reg #rtgtest.ra
-  %sp = rtg.fixed_reg #rtgtest.s0
+  %ra = rtg.constant #rtgtest.ra
+  %sp = rtg.constant #rtgtest.s0
   %imm = rtg.constant #rtg.isa.immediate<12, 1>
   rtgtest.rv32i.jalr %ra, %sp, %imm
 }
@@ -69,20 +69,20 @@ rtg.sequence @nested1() {
   %0 = rtg.get_sequence @nested0 : !rtg.sequence
   %1 = rtg.randomize_sequence %0
   rtg.embed_sequence %1
-  %ra = rtg.fixed_reg #rtgtest.ra
-  %sp = rtg.fixed_reg #rtgtest.sp
+  %ra = rtg.constant #rtgtest.ra
+  %sp = rtg.constant #rtgtest.sp
   %imm = rtg.constant #rtg.isa.immediate<12, 0>
   rtgtest.rv32i.jalr %ra, %sp, %imm
 }
 
 // CHECK-LABEL: @nestedSequences()
 rtg.test @nestedSequences() {
-  // CHECK-NEXT: [[RA0:%.+]] = rtg.fixed_reg #rtgtest.ra : !rtgtest.ireg
-  // CHECK-NEXT: [[S0:%.+]] = rtg.fixed_reg #rtgtest.s0 : !rtgtest.ireg
+  // CHECK-NEXT: [[RA0:%.+]] = rtg.constant #rtgtest.ra : !rtgtest.ireg
+  // CHECK-NEXT: [[S0:%.+]] = rtg.constant #rtgtest.s0 : !rtgtest.ireg
   // CHECK-NEXT: [[IMM1:%.+]] = rtg.constant #rtg.isa.immediate<12, 1>
   // CHECK-NEXT: rtgtest.rv32i.jalr [[RA0]], [[S0]], [[IMM1]]
-  // CHECK-NEXT: [[RA1:%.+]] = rtg.fixed_reg #rtgtest.ra : !rtgtest.ireg
-  // CHECK-NEXT: [[SP:%.+]] = rtg.fixed_reg #rtgtest.sp : !rtgtest.ireg
+  // CHECK-NEXT: [[RA1:%.+]] = rtg.constant #rtgtest.ra : !rtgtest.ireg
+  // CHECK-NEXT: [[SP:%.+]] = rtg.constant #rtgtest.sp : !rtgtest.ireg
   // CHECK-NEXT: [[IMM0:%.+]] = rtg.constant #rtg.isa.immediate<12, 0>
   // CHECK-NEXT: rtgtest.rv32i.jalr [[RA1]], [[SP]], [[IMM0]]
   %0 = rtg.get_sequence @nested1 : !rtg.sequence
@@ -91,7 +91,7 @@ rtg.test @nestedSequences() {
 }
 
 rtg.sequence @seqWithArgs(%imm: !rtg.isa.immediate<12>, %seq: !rtg.randomized_sequence) {
-  %sp = rtg.fixed_reg #rtgtest.sp
+  %sp = rtg.constant #rtgtest.sp
   rtgtest.rv32i.jalr %sp, %sp, %imm
   rtg.embed_sequence %seq
 }
@@ -99,10 +99,10 @@ rtg.sequence @seqWithArgs(%imm: !rtg.isa.immediate<12>, %seq: !rtg.randomized_se
 // CHECK-LABEL: @substitutions
 rtg.test @substitutions() {
   // CHECK-NEXT: [[IMM0:%.+]] = rtg.constant #rtg.isa.immediate<12, 0> : !rtg.isa.immediate<12>
-  // CHECK-NEXT: [[SP:%.+]] = rtg.fixed_reg #rtgtest.sp : !rtgtest.ireg
+  // CHECK-NEXT: [[SP:%.+]] = rtg.constant #rtgtest.sp : !rtgtest.ireg
   // CHECK-NEXT: rtgtest.rv32i.jalr [[SP]], [[SP]], [[IMM0]]
-  // CHECK-NEXT: [[RA:%.+]] = rtg.fixed_reg #rtgtest.ra : !rtgtest.ireg
-  // CHECK-NEXT: [[S0:%.+]] = rtg.fixed_reg #rtgtest.s0 : !rtgtest.ireg
+  // CHECK-NEXT: [[RA:%.+]] = rtg.constant #rtgtest.ra : !rtgtest.ireg
+  // CHECK-NEXT: [[S0:%.+]] = rtg.constant #rtgtest.s0 : !rtgtest.ireg
   // CHECK-NEXT: [[IMM1:%.+]] = rtg.constant #rtg.isa.immediate<12, 1> : !rtg.isa.immediate<12>
   // CHECK-NEXT: rtgtest.rv32i.jalr [[RA]], [[S0]], [[IMM1]]
   %imm = rtg.constant #rtg.isa.immediate<12, 0>

--- a/test/Dialect/RTG/Transform/linear-scan-register-allocation.mlir
+++ b/test/Dialect/RTG/Transform/linear-scan-register-allocation.mlir
@@ -2,10 +2,10 @@
 
 // CHECK-LABEL: @test0
 rtg.test @test0() {
-  // CHECK: [[V0:%.+]] = rtg.fixed_reg #rtgtest.ra
-  // CHECK: [[V1:%.+]] = rtg.fixed_reg #rtgtest.s1
-  // CHECK: [[V2:%.+]] = rtg.fixed_reg #rtgtest.s0
-  // CHECK: [[V3:%.+]] = rtg.fixed_reg #rtgtest.ra
+  // CHECK: [[V0:%.+]] = rtg.constant #rtgtest.ra
+  // CHECK: [[V1:%.+]] = rtg.constant #rtgtest.s1
+  // CHECK: [[V2:%.+]] = rtg.constant #rtgtest.s0
+  // CHECK: [[V3:%.+]] = rtg.constant #rtgtest.ra
   // CHECK: rtgtest.rv32i.jalr [[V0]], [[V2]]
   // CHECK: rtgtest.rv32i.jalr [[V1]], [[V0]]
   // CHECK: rtgtest.rv32i.jalr [[V3]], [[V1]]
@@ -23,17 +23,17 @@ rtg.test @test0() {
 
 // CHECK-LABEL: @withFixedRegs
 rtg.test @withFixedRegs() {
-  // CHECK: [[V0:%.+]] = rtg.fixed_reg #rtgtest.ra
-  // CHECK: [[V1:%.+]] = rtg.fixed_reg #rtgtest.s1
-  // CHECK: [[V2:%.+]] = rtg.fixed_reg #rtgtest.s0
-  // CHECK: [[V3:%.+]] = rtg.fixed_reg #rtgtest.ra
+  // CHECK: [[V0:%.+]] = rtg.constant #rtgtest.ra
+  // CHECK: [[V1:%.+]] = rtg.constant #rtgtest.s1
+  // CHECK: [[V2:%.+]] = rtg.constant #rtgtest.s0
+  // CHECK: [[V3:%.+]] = rtg.constant #rtgtest.ra
   // CHECK: rtgtest.rv32i.jalr [[V0]], [[V2]]
   // CHECK: rtgtest.rv32i.jalr [[V1]], [[V0]]
   // CHECK: rtgtest.rv32i.jalr [[V3]], [[V1]]
   // CHECK: rtgtest.rv32i.jalr [[V2]], [[V3]]
-  %0 = rtg.fixed_reg #rtgtest.ra
+  %0 = rtg.constant #rtgtest.ra
   %1 = rtg.virtual_reg [#rtgtest.ra, #rtgtest.s0, #rtgtest.s1]
-  %2 = rtg.fixed_reg #rtgtest.s0
+  %2 = rtg.constant #rtgtest.s0
   %3 = rtg.virtual_reg [#rtgtest.ra, #rtgtest.s0, #rtgtest.s1]
   %imm = rtg.constant #rtg.isa.immediate<12, 0>
   rtgtest.rv32i.jalr %0, %2, %imm

--- a/test/Dialect/RTG/Transform/lower-validate-to-labels.mlir
+++ b/test/Dialect/RTG/Transform/lower-validate-to-labels.mlir
@@ -2,13 +2,13 @@
 
 // CHECK-LABEL: rtg.test @basic
 rtg.test @basic() {
-  // CHECK-NEXT: [[REG:%.+]] = rtg.fixed_reg #rtgtest.t1
+  // CHECK-NEXT: [[REG:%.+]] = rtg.constant #rtgtest.t1
   // CHECK-NEXT: [[IMM0:%.+]] = rtg.constant #rtg.isa.immediate<32, 0>
   // CHECK-NEXT: [[LBL:%.+]] = rtg.label_decl "spike.pre.printreg.x5.id1"
   // CHECK-NEXT: rtg.label global [[LBL]]
   // CHECK-NEXT: rtgtest.rv32i.lui [[REG]], [[IMM0]] : !rtg.isa.immediate<32>
-  %0 = rtg.fixed_reg #rtgtest.t0
-  %1 = rtg.fixed_reg #rtgtest.t1
+  %0 = rtg.constant #rtgtest.t0
+  %1 = rtg.constant #rtgtest.t1
   %2 = rtg.constant #rtg.isa.immediate<32, 0>
   %3 = rtg.validate %0, %2, "id1" : !rtgtest.ireg -> !rtg.isa.immediate<32>
   rtgtest.rv32i.lui %1, %3 : !rtg.isa.immediate<32>
@@ -33,7 +33,7 @@ rtg.test @basic() {
 // -----
 
 rtg.test @no_id() {
-  %0 = rtg.fixed_reg #rtgtest.t0
+  %0 = rtg.constant #rtgtest.t0
   %1 = rtg.constant #rtg.isa.immediate<32, 0>
   // expected-error @below {{expected ID to be set}}
   %2 = rtg.validate %0, %1 : !rtgtest.ireg -> !rtg.isa.immediate<32>

--- a/test/Dialect/RTG/Transform/memory-allocation.mlir
+++ b/test/Dialect/RTG/Transform/memory-allocation.mlir
@@ -9,12 +9,12 @@ rtg.target @target : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
 // CHECK-LABEL: rtg.test @test
 rtg.test @test(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @target {
   // CHECK: [[IMM0:%.+]] = rtg.constant #rtg.isa.immediate<32, 0>
-  // CHECK: [[REG:%.+]] = rtg.fixed_reg
+  // CHECK: [[REG:%.+]] = rtg.constant
   // CHECK: rtgtest.rv32i.la [[REG]], [[IMM0]] : !rtg.isa.immediate<32>
   %idx4 = index.constant 4
   %idx7 = index.constant 7
   %0 = rtg.isa.memory_alloc %mem_blk, %idx7, %idx4 : !rtg.isa.memory_block<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
 
   // CHECK: [[IMM1:%.+]] = rtg.constant #rtg.isa.immediate<32, 8>
@@ -40,7 +40,7 @@ rtg.test @test_missing_block(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) targ
   %mem_block_unknown = func.call @passthrough(%mem_blk) : (!rtg.isa.memory_block<32>) -> !rtg.isa.memory_block<32>
   // expected-error @below {{memory block not found}}
   %0 = rtg.isa.memory_alloc %mem_block_unknown, %idx7, %idx4 : !rtg.isa.memory_block<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
 }
 
@@ -61,7 +61,7 @@ rtg.test @test_unknown_size(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) targe
   %idx4 = index.constant 4
   // expected-error @below {{could not determine memory allocation size}}
   %0 = rtg.isa.memory_alloc %mem_blk, %unknown, %idx4 : !rtg.isa.memory_block<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
 }
 
@@ -82,7 +82,7 @@ rtg.test @test_unknown_align(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) targ
   %unknown = func.call @const() : () -> index
   // expected-error @below {{could not determine memory allocation alignment}}
   %0 = rtg.isa.memory_alloc %mem_blk, %idx7, %unknown : !rtg.isa.memory_block<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
 }
 
@@ -98,7 +98,7 @@ rtg.test @test_zero_size(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @
   %idx4 = index.constant 4
   // expected-error @below {{memory allocation size must be greater than zero (was 0)}}
   %0 = rtg.isa.memory_alloc %mem_blk, %idx0, %idx4 : !rtg.isa.memory_block<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
 }
 
@@ -114,7 +114,7 @@ rtg.test @test_non_pow2_align(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) tar
   %idx3 = index.constant 3
   // expected-error @below {{memory allocation alignment must be a power of two (was 3)}}
   %0 = rtg.isa.memory_alloc %mem_blk, %idx7, %idx3 : !rtg.isa.memory_block<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
 }
 
@@ -130,7 +130,7 @@ rtg.test @test_exceed_size(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target
   %idx4 = index.constant 4
   // expected-error @below {{memory block not large enough to fit all allocations}}
   %0 = rtg.isa.memory_alloc %mem_blk, %idx16, %idx4 : !rtg.isa.memory_block<32>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
 }
 
@@ -146,7 +146,7 @@ rtg.test @test_truncate_error(mem_blk = %mem_blk: !rtg.isa.memory_block<8>) targ
   %idx4 = index.constant 4
   // expected-error @below {{cannot truncate APInt because value is too big to fit}}
   %0 = rtg.isa.memory_alloc %mem_blk, %idx256, %idx4 : !rtg.isa.memory_block<8>
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<8>
 }
 
@@ -168,7 +168,7 @@ rtg.test @test_entry_matching(
 ) target @target_multiple_entries {
   %idx8 = index.constant 8
   %idx4 = index.constant 4
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
 
   // CHECK: [[MEM_A:%.+]] = rtg.constant #rtg.isa.immediate<32, 0>
   %0 = rtg.isa.memory_alloc %mem_a, %idx8, %idx4 : !rtg.isa.memory_block<32>

--- a/test/Dialect/RTG/Transform/randomization-pipeline.mlir
+++ b/test/Dialect/RTG/Transform/randomization-pipeline.mlir
@@ -7,7 +7,7 @@ rtg.target @target : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
 
 // CHECK-LABEL: rtg.test @test_target
 rtg.test @test(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) {
-  // CHECK-NEXT: [[REG:%.+]] = rtg.fixed_reg
+  // CHECK-NEXT: [[REG:%.+]] = rtg.constant
   // CHECK-NEXT: [[IMM:%.+]] = rtg.constant #rtg.isa.immediate
   // CHECK-NEXT: rtgtest.rv32i.la [[REG]], [[IMM]] :
   %idx4 = index.constant 4

--- a/test/Dialect/RTG/Transform/simple-test-inliner.mlir
+++ b/test/Dialect/RTG/Transform/simple-test-inliner.mlir
@@ -42,7 +42,7 @@ emit.file "filename" {
 
 // expected-error @below {{cannot inline test with used arguments}}
 rtg.test @test(imm = %imm: !rtg.isa.immediate<32>) {
-  %reg = rtg.fixed_reg #rtgtest.t0
+  %reg = rtg.constant #rtgtest.t0
   rtgtest.rv32i.lui %reg, %imm : !rtg.isa.immediate<32>
 }
 

--- a/test/Dialect/RTG/Transform/unique-validate-ops.mlir
+++ b/test/Dialect/RTG/Transform/unique-validate-ops.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @validate
 rtg.test @validate() {
-  %0 = rtg.fixed_reg #rtgtest.t0
+  %0 = rtg.constant #rtgtest.t0
   %1 = rtg.constant #rtg.isa.immediate<32, 0>
 
   // CHECK: rtg.validate %{{.*}}, %{{.*}}, "validation_id_0"

--- a/test/Dialect/RTGTest/IR/basic.mlir
+++ b/test/Dialect/RTGTest/IR/basic.mlir
@@ -18,70 +18,70 @@ rtg.test @misc() {
 // CHECK-LABEL: rtg.test @registers
 // CHECK-SAME: !rtgtest.ireg
 rtg.test @registers(reg = %reg: !rtgtest.ireg) {
-  // CHECK: rtg.fixed_reg #rtgtest.zero : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.ra : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.sp : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.gp : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.tp : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.t0 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.t1 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.t2 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s0 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s1 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.a0 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.a1 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.a2 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.a3 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.a4 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.a5 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.a6 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.a7 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s2 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s3 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s4 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s5 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s6 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s7 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s8 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s9 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s10 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.s11 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.t3 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.t4 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.t5 : !rtgtest.ireg
-  // CHECK: rtg.fixed_reg #rtgtest.t6 : !rtgtest.ireg
-  rtg.fixed_reg #rtgtest.zero
-  rtg.fixed_reg #rtgtest.ra
-  rtg.fixed_reg #rtgtest.sp
-  rtg.fixed_reg #rtgtest.gp
-  rtg.fixed_reg #rtgtest.tp
-  rtg.fixed_reg #rtgtest.t0
-  rtg.fixed_reg #rtgtest.t1
-  rtg.fixed_reg #rtgtest.t2
-  rtg.fixed_reg #rtgtest.s0
-  rtg.fixed_reg #rtgtest.s1
-  rtg.fixed_reg #rtgtest.a0
-  rtg.fixed_reg #rtgtest.a1
-  rtg.fixed_reg #rtgtest.a2
-  rtg.fixed_reg #rtgtest.a3
-  rtg.fixed_reg #rtgtest.a4
-  rtg.fixed_reg #rtgtest.a5
-  rtg.fixed_reg #rtgtest.a6
-  rtg.fixed_reg #rtgtest.a7
-  rtg.fixed_reg #rtgtest.s2
-  rtg.fixed_reg #rtgtest.s3
-  rtg.fixed_reg #rtgtest.s4
-  rtg.fixed_reg #rtgtest.s5
-  rtg.fixed_reg #rtgtest.s6
-  rtg.fixed_reg #rtgtest.s7
-  rtg.fixed_reg #rtgtest.s8
-  rtg.fixed_reg #rtgtest.s9
-  rtg.fixed_reg #rtgtest.s10
-  rtg.fixed_reg #rtgtest.s11
-  rtg.fixed_reg #rtgtest.t3
-  rtg.fixed_reg #rtgtest.t4
-  rtg.fixed_reg #rtgtest.t5
-  rtg.fixed_reg #rtgtest.t6
+  // CHECK: rtg.constant #rtgtest.zero : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.ra : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.sp : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.gp : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.tp : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.t0 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.t1 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.t2 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s0 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s1 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.a0 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.a1 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.a2 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.a3 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.a4 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.a5 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.a6 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.a7 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s2 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s3 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s4 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s5 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s6 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s7 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s8 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s9 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s10 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.s11 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.t3 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.t4 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.t5 : !rtgtest.ireg
+  // CHECK: rtg.constant #rtgtest.t6 : !rtgtest.ireg
+  rtg.constant #rtgtest.zero
+  rtg.constant #rtgtest.ra
+  rtg.constant #rtgtest.sp
+  rtg.constant #rtgtest.gp
+  rtg.constant #rtgtest.tp
+  rtg.constant #rtgtest.t0
+  rtg.constant #rtgtest.t1
+  rtg.constant #rtgtest.t2
+  rtg.constant #rtgtest.s0
+  rtg.constant #rtgtest.s1
+  rtg.constant #rtgtest.a0
+  rtg.constant #rtgtest.a1
+  rtg.constant #rtgtest.a2
+  rtg.constant #rtgtest.a3
+  rtg.constant #rtgtest.a4
+  rtg.constant #rtgtest.a5
+  rtg.constant #rtgtest.a6
+  rtg.constant #rtgtest.a7
+  rtg.constant #rtgtest.s2
+  rtg.constant #rtgtest.s3
+  rtg.constant #rtgtest.s4
+  rtg.constant #rtgtest.s5
+  rtg.constant #rtgtest.s6
+  rtg.constant #rtgtest.s7
+  rtg.constant #rtgtest.s8
+  rtg.constant #rtgtest.s9
+  rtg.constant #rtgtest.s10
+  rtg.constant #rtgtest.s11
+  rtg.constant #rtgtest.t3
+  rtg.constant #rtgtest.t4
+  rtg.constant #rtgtest.t5
+  rtg.constant #rtgtest.t6
 
   // CHECK: rtg.virtual_reg [#rtgtest.ra : !rtgtest.ireg, #rtgtest.sp : !rtgtest.ireg]
   rtg.virtual_reg [#rtgtest.ra, #rtgtest.sp]

--- a/unittests/Dialect/RTGTest/MaterializerTest.cpp
+++ b/unittests/Dialect/RTGTest/MaterializerTest.cpp
@@ -42,7 +42,7 @@ TEST(MaterializerTest, RegisterAttr) {
   auto attr = RegZeroAttr::get(&context);
   auto *op = context.getLoadedDialect<RTGTestDialect>()->materializeConstant(
       builder, attr, attr.getType(), loc);
-  ASSERT_TRUE(op && isa<rtg::FixedRegisterOp>(op));
+  ASSERT_TRUE(op && isa<rtg::ConstantOp>(op));
 }
 
 } // namespace


### PR DESCRIPTION
There's not really a benefit in having this op. It was added before the general constant op existed. It's just a constant op where you can be sure that the attribute implements RegisterAttrInterface, but that's also easy to figure out with the general constant op.