### PR TITLE
[Verif] Always add clock trigger to HasBeenReset process

### DIFF
--- a/test/Conversion/VerifToSV/verif-to-sv.mlir
+++ b/test/Conversion/VerifToSV/verif-to-sv.mlir
@@ -15,8 +15,10 @@ hw.module @HasBeenResetAsync(in %clock: i1, in %reset: i1, out out: i1) {
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: sv.always posedge %reset {
-  // CHECK-NEXT:   sv.passign %hasBeenResetReg, %true : i1
+  // CHECK-NEXT: sv.always posedge %clock, posedge %reset {
+  // CHECK-NEXT:   sv.if %reset {
+  // CHECK-NEXT:     sv.passign %hasBeenResetReg, %true : i1
+  // CHECK-NEXT:   }
   // CHECK-NEXT: }
 
   // CHECK-NEXT: [[REG:%.+]] = sv.read_inout %hasBeenResetReg


### PR DESCRIPTION
Always add a `posedge clock` trigger to the always process created for `verif.has_been_reset` operations, even if the reset is asynchronous. Until now we would emit an `always @(posedge reset)` process, which some EDA tools do not process properly. With this commit, we produce `always @(posedge clock, posedge reset)` for asynchronous HBR ops, and `always @(posedge clock)` for synchronous HBR ops.