### PR TITLE
[Arcilator] Move pipeline into separate library.

### DIFF
--- a/include/circt/Tools/arcilator/pipelines.h
+++ b/include/circt/Tools/arcilator/pipelines.h
@@ -1,0 +1,111 @@
+//===- pipelines.h - Arcilator lowering pipelines -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the 'arcilator' lowering pipelines.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TOOLS_ARCILATOR_PIPELINES_H
+#define TOOLS_ARCILATOR_PIPELINES_H
+
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassOptions.h"
+#include "llvm/Support/CommandLine.h"
+
+namespace circt {
+
+// Pre-process the input such that it no longer contains any SV dialect ops
+// and external modules that are relevant to the arc transformation are
+// represented as intrinsic ops.
+struct ArcPreprocessingOptions
+    : mlir::PassPipelineOptions<ArcPreprocessingOptions> {
+  Option<bool> observePorts{*this, "observe-ports",
+                            llvm::cl::desc("Make all ports observable"),
+                            llvm::cl::init(false)};
+
+  Option<bool> observeWires{*this, "observe-wires",
+                            llvm::cl::desc("Make all wires observable"),
+                            llvm::cl::init(false)};
+
+  Option<bool> observeNamedValues{
+      *this, "observe-named-values",
+      llvm::cl::desc("Make values with `sv.namehint` observable"),
+      llvm::cl::init(false)};
+
+  Option<bool> observeMemories{
+      *this, "observe-memories",
+      llvm::cl::desc("Make all memory contents observable"),
+      llvm::cl::init(false)};
+};
+void populateArcPreprocessingPipeline(
+    mlir::OpPassManager &pm, const ArcPreprocessingOptions &options = {});
+
+// Restructure the input from a `hw.module` hierarchy to a collection of arcs.
+struct ArcConversionOptions : mlir::PassPipelineOptions<ArcConversionOptions> {
+  Option<bool> observeRegisters{*this, "observe-registers",
+                                llvm::cl::desc("Make all registers observable"),
+                                llvm::cl::init(false)};
+
+  Option<bool> shouldDedup{*this, "dedup", llvm::cl::desc("Deduplicate arcs"),
+                           llvm::cl::init(true)};
+};
+void populateArcConversionPipeline(mlir::OpPassManager &pm,
+                                   const ArcConversionOptions &options = {});
+
+// Perform arc-level optimizations that are not specific to software
+// simulation.
+struct ArcOptimizationOptions
+    : mlir::PassPipelineOptions<ArcOptimizationOptions> {
+  Option<bool> shouldDedup{*this, "dedup", llvm::cl::desc("Deduplicate arcs"),
+                           llvm::cl::init(true)};
+
+  Option<bool> shouldDetectEnables{
+      *this, "detect-enables",
+      llvm::cl::desc("Infer enable conditions for states to avoid computation"),
+      llvm::cl::init(true)};
+
+  Option<bool> shouldDetectResets{
+      *this, "detect-resets",
+      llvm::cl::desc("Infer reset conditions for states to avoid computation"),
+      llvm::cl::init(false)};
+
+  Option<bool> shouldMakeLUTs{
+      *this, "lookup-tables",
+      llvm::cl::desc("Optimize arcs into lookup tables"), llvm::cl::init(true)};
+};
+void populateArcOptimizationPipeline(
+    mlir::OpPassManager &pm, const ArcOptimizationOptions &options = {});
+
+// Lower stateful arcs into explicit state reads and writes.
+struct ArcStateLoweringOptions
+    : mlir::PassPipelineOptions<ArcStateLoweringOptions> {
+  Option<bool> shouldInline{*this, "inline", llvm::cl::desc("Inline arcs"),
+                            llvm::cl::init(true)};
+};
+void populateArcStateLoweringPipeline(
+    mlir::OpPassManager &pm, const ArcStateLoweringOptions &options = {});
+
+// Allocate states.
+struct ArcStateAllocationOptions
+    : mlir::PassPipelineOptions<ArcStateAllocationOptions> {
+  Option<unsigned> splitFuncsThreshold{
+      *this, "split-funcs-threshold",
+      llvm::cl::desc("Split large MLIR functions that occur above the given "
+                     "size threshold"),
+      llvm::cl::ValueOptional};
+};
+void populateArcStateAllocationPipeline(
+    mlir::OpPassManager &pm, const ArcStateAllocationOptions &options = {});
+
+// Lower the arcs and update functions to LLVM. This pipeline lowers modules to
+// LLVM IR.
+void populateArcToLLVMPipeline(mlir::OpPassManager &pm);
+
+} // namespace circt
+
+#endif // TOOLS_ARCILATOR_PIPELINE_H

--- a/lib/Tools/CMakeLists.txt
+++ b/lib/Tools/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(arcilator)
 add_subdirectory(circt-bmc)
 add_subdirectory(circt-lec)
 

--- a/lib/Tools/arcilator/CMakeLists.txt
+++ b/lib/Tools/arcilator/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_circt_library(CIRCTArcilator
+  pipelines.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/circt/Tools/arcilator
+
+  LINK_LIBS PUBLIC
+  CIRCTArc
+  CIRCTArcToLLVM
+  CIRCTArcTransforms
+  CIRCTCombToArith
+  CIRCTConvertToArcs
+  CIRCTEmitTransforms
+  CIRCTExportArc
+  CIRCTHWTransforms
+  CIRCTLLHD
+  CIRCTOMTransforms
+  CIRCTSeqToSV
+  CIRCTSeqTransforms
+  CIRCTSimTransforms
+  CIRCTSupport
+  CIRCTTransforms
+  CIRCTVerif
+  MLIRLLVMIRTransforms
+)

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -1,0 +1,142 @@
+//===- pipelines.cpp - Arcilator lowering pipelines -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the 'arcilator' lowering pipelines.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Tools/arcilator/pipelines.h"
+
+#include "circt/Conversion/ArcToLLVM.h"
+#include "circt/Conversion/CombToArith.h"
+#include "circt/Conversion/ConvertToArcs.h"
+#include "circt/Conversion/Passes.h"
+#include "circt/Conversion/SeqToSV.h"
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Emit/EmitPasses.h"
+#include "circt/Dialect/HW/HWPasses.h"
+#include "circt/Dialect/OM/OMPasses.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
+#include "circt/Dialect/Sim/SimPasses.h"
+#include "circt/Support/Passes.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+void circt::populateArcPreprocessingPipeline(
+    OpPassManager &pm, const ArcPreprocessingOptions &options) {
+  pm.addPass(om::createStripOMPass());
+  pm.addPass(emit::createStripEmitPass());
+  pm.addPass(createLowerFirMemPass());
+  pm.addPass(createLowerVerifSimulationsPass());
+  {
+    arc::AddTapsOptions opts;
+    opts.tapPorts = options.observePorts;
+    opts.tapWires = options.observeWires;
+    opts.tapNamedValues = options.observeNamedValues;
+    pm.addPass(arc::createAddTapsPass(opts));
+  }
+  pm.addPass(arc::createStripSVPass());
+  {
+    arc::InferMemoriesOptions opts;
+    opts.tapPorts = options.observePorts;
+    opts.tapMemories = options.observeMemories;
+    pm.addPass(arc::createInferMemoriesPass(opts));
+  }
+  pm.addPass(sim::createLowerDPIFunc());
+  pm.addPass(createCSEPass());
+  pm.addPass(arc::createArcCanonicalizerPass());
+}
+
+void circt::populateArcConversionPipeline(OpPassManager &pm,
+                                          const ArcConversionOptions &options) {
+  {
+    ConvertToArcsPassOptions opts;
+    opts.tapRegisters = options.observeRegisters;
+    pm.addPass(createConvertToArcsPass(opts));
+  }
+  if (options.shouldDedup)
+    pm.addPass(arc::createDedupPass());
+  pm.addPass(hw::createFlattenModules());
+  pm.addPass(createCSEPass());
+  pm.addPass(arc::createArcCanonicalizerPass());
+}
+
+void circt::populateArcOptimizationPipeline(
+    OpPassManager &pm, const ArcOptimizationOptions &options) {
+  // Perform arc-level optimizations that are not specific to software
+  // simulation.
+  pm.addPass(arc::createSplitLoopsPass());
+  if (options.shouldDedup)
+    pm.addPass(arc::createDedupPass());
+  {
+    arc::InferStatePropertiesOptions opts;
+    opts.detectEnables = options.shouldDetectEnables;
+    opts.detectResets = options.shouldDetectResets;
+    pm.addPass(arc::createInferStateProperties(opts));
+  }
+  pm.addPass(createCSEPass());
+  pm.addPass(arc::createArcCanonicalizerPass());
+  pm.addNestedPass<hw::HWModuleOp>(arc::createMergeTaps());
+  if (options.shouldMakeLUTs)
+    pm.addPass(arc::createMakeTablesPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(arc::createArcCanonicalizerPass());
+
+  // Now some arguments may be unused because reset conditions are not passed as
+  // inputs anymore pm.addPass(arc::createRemoveUnusedArcArgumentsPass());
+  // Because we replace a lot of StateOp inputs with constants in the enable
+  // patterns we may be able to sink a lot of them
+  // TODO: maybe merge RemoveUnusedArcArguments with SinkInputs?
+  // pm.addPass(arc::createSinkInputsPass());
+  // pm.addPass(createCSEPass());
+  // pm.addPass(createSimpleCanonicalizerPass());
+  // Removing some muxes etc. may lead to additional dedup opportunities
+  // if (options.shouldDedup)
+  // pm.addPass(arc::createDedupPass());
+}
+
+void circt::populateArcStateLoweringPipeline(
+    OpPassManager &pm, const ArcStateLoweringOptions &options) {
+  pm.addPass(arc::createLowerStatePass());
+
+  // TODO: LowerClocksToFuncsPass might not properly consider scf.if operations
+  // (or nested regions in general) and thus errors out when muxes are also
+  // converted in the hw.module or arc.model
+  // TODO: InlineArcs seems to not properly handle scf.if operations, thus the
+  // following is commented out
+  // pm.addPass(arc::createMuxToControlFlowPass());
+  if (options.shouldInline)
+    pm.addPass(arc::createInlineArcsPass());
+
+  pm.addPass(arc::createMergeIfsPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(arc::createArcCanonicalizerPass());
+}
+
+void circt::populateArcStateAllocationPipeline(
+    OpPassManager &pm, const ArcStateAllocationOptions &options) {
+  pm.addPass(arc::createLowerArcsToFuncsPass());
+  pm.nest<arc::ModelOp>().addPass(arc::createAllocateStatePass());
+  pm.addPass(arc::createLowerClocksToFuncsPass()); // no CSE between state alloc
+                                                   // and clock func lowering
+  if (options.splitFuncsThreshold.getNumOccurrences()) {
+    pm.addPass(arc::createSplitFuncs({options.splitFuncsThreshold}));
+  }
+  pm.addPass(createCSEPass());
+  pm.addPass(arc::createArcCanonicalizerPass());
+}
+
+void circt::populateArcToLLVMPipeline(OpPassManager &pm) {
+  pm.addPass(createLowerArcToLLVMPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(arc::createArcCanonicalizerPass());
+}

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -10,6 +10,7 @@ set(libs
   CIRCTArc
   CIRCTArcToLLVM
   CIRCTArcTransforms
+  CIRCTArcilator
   CIRCTCombToArith
   CIRCTConvertToArcs
   CIRCTEmitTransforms

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -36,6 +36,7 @@
 #include "circt/Dialect/Verif/VerifDialect.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
+#include "circt/Tools/arcilator/pipelines.h"
 #include "mlir/Bytecode/BytecodeReader.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -250,116 +251,49 @@ static void populateHwModuleToArcPipeline(PassManager &pm) {
   // represented as intrinsic ops.
   if (untilReached(UntilPreprocessing))
     return;
-  pm.addPass(om::createStripOMPass());
-  pm.addPass(emit::createStripEmitPass());
-  pm.addPass(createLowerFirMemPass());
-  pm.addPass(createLowerVerifSimulationsPass());
-  {
-    arc::AddTapsOptions opts;
-    opts.tapPorts = observePorts;
-    opts.tapWires = observeWires;
-    opts.tapNamedValues = observeNamedValues;
-    pm.addPass(arc::createAddTapsPass(opts));
-  }
-  pm.addPass(arc::createStripSVPass());
-  {
-    arc::InferMemoriesOptions opts;
-    opts.tapPorts = observePorts;
-    opts.tapMemories = observeMemories;
-    pm.addPass(arc::createInferMemoriesPass(opts));
-  }
-  pm.addPass(sim::createLowerDPIFunc());
-  pm.addPass(createCSEPass());
-  pm.addPass(arc::createArcCanonicalizerPass());
+
+  ArcPreprocessingOptions preprocessingOpt;
+  preprocessingOpt.observePorts = observePorts;
+  preprocessingOpt.observeWires = observeWires;
+  preprocessingOpt.observeNamedValues = observeNamedValues;
+  preprocessingOpt.observeMemories = observeMemories;
+  populateArcPreprocessingPipeline(pm, preprocessingOpt);
 
   // Restructure the input from a `hw.module` hierarchy to a collection of arcs.
   if (untilReached(UntilArcConversion))
     return;
-  {
-    ConvertToArcsPassOptions opts;
-    opts.tapRegisters = observeRegisters;
-    pm.addPass(createConvertToArcsPass(opts));
-  }
-  if (shouldDedup)
-    pm.addPass(arc::createDedupPass());
-  pm.addPass(hw::createFlattenModules());
-  pm.addPass(createCSEPass());
-  pm.addPass(arc::createArcCanonicalizerPass());
+
+  ArcConversionOptions conversionOpt;
+  conversionOpt.observeRegisters = observeRegisters;
+  conversionOpt.shouldDedup = shouldDedup;
+  populateArcConversionPipeline(pm, conversionOpt);
 
   // Perform arc-level optimizations that are not specific to software
   // simulation.
   if (untilReached(UntilArcOpt))
     return;
-  pm.addPass(arc::createSplitLoopsPass());
-  if (shouldDedup)
-    pm.addPass(arc::createDedupPass());
-  {
-    arc::InferStatePropertiesOptions opts;
-    opts.detectEnables = shouldDetectEnables;
-    opts.detectResets = shouldDetectResets;
-    pm.addPass(arc::createInferStateProperties(opts));
-  }
-  pm.addPass(createCSEPass());
-  pm.addPass(arc::createArcCanonicalizerPass());
-  pm.addNestedPass<hw::HWModuleOp>(arc::createMergeTaps());
-  if (shouldMakeLUTs)
-    pm.addPass(arc::createMakeTablesPass());
-  pm.addPass(createCSEPass());
-  pm.addPass(arc::createArcCanonicalizerPass());
 
-  // Now some arguments may be unused because reset conditions are not passed as
-  // inputs anymore pm.addPass(arc::createRemoveUnusedArcArgumentsPass());
-  // Because we replace a lot of StateOp inputs with constants in the enable
-  // patterns we may be able to sink a lot of them
-  // TODO: maybe merge RemoveUnusedArcArguments with SinkInputs?
-  // pm.addPass(arc::createSinkInputsPass());
-  // pm.addPass(createCSEPass());
-  // pm.addPass(createSimpleCanonicalizerPass());
-  // Removing some muxes etc. may lead to additional dedup opportunities
-  // if (shouldDedup)
-  // pm.addPass(arc::createDedupPass());
+  ArcOptimizationOptions optimizationOpt;
+  optimizationOpt.shouldDetectEnables = shouldDetectEnables;
+  optimizationOpt.shouldDetectResets = shouldDetectResets;
+  optimizationOpt.shouldMakeLUTs = shouldMakeLUTs;
+  populateArcOptimizationPipeline(pm, optimizationOpt);
 
   // Lower stateful arcs into explicit state reads and writes.
   if (untilReached(UntilStateLowering))
     return;
-  pm.addPass(arc::createLowerStatePass());
 
-  // TODO: LowerClocksToFuncsPass might not properly consider scf.if operations
-  // (or nested regions in general) and thus errors out when muxes are also
-  // converted in the hw.module or arc.model
-  // TODO: InlineArcs seems to not properly handle scf.if operations, thus the
-  // following is commented out
-  // pm.addPass(arc::createMuxToControlFlowPass());
-  if (shouldInline)
-    pm.addPass(arc::createInlineArcsPass());
-
-  pm.addPass(arc::createMergeIfsPass());
-  pm.addPass(createCSEPass());
-  pm.addPass(arc::createArcCanonicalizerPass());
+  ArcStateLoweringOptions loweringOpt;
+  loweringOpt.shouldInline = shouldInline;
+  populateArcStateLoweringPipeline(pm, loweringOpt);
 
   // Allocate states.
   if (untilReached(UntilStateAlloc))
     return;
-  pm.addPass(arc::createLowerArcsToFuncsPass());
-  pm.nest<arc::ModelOp>().addPass(arc::createAllocateStatePass());
-  pm.addPass(arc::createLowerClocksToFuncsPass()); // no CSE between state alloc
-                                                   // and clock func lowering
-  if (splitFuncsThreshold.getNumOccurrences()) {
-    pm.addPass(arc::createSplitFuncs({splitFuncsThreshold}));
-  }
-  pm.addPass(createCSEPass());
-  pm.addPass(arc::createArcCanonicalizerPass());
-}
 
-/// Populate a pass manager with the Arc to LLVM pipeline for the given
-/// command line options. This pipeline lowers modules to LLVM IR.
-static void populateArcToLLVMPipeline(PassManager &pm) {
-  // Lower the arcs and update functions to LLVM.
-  if (untilReached(UntilLLVMLowering))
-    return;
-  pm.addPass(createLowerArcToLLVMPass());
-  pm.addPass(createCSEPass());
-  pm.addPass(arc::createArcCanonicalizerPass());
+  ArcStateAllocationOptions allocationOpt;
+  allocationOpt.splitFuncsThreshold = splitFuncsThreshold;
+  populateArcStateAllocationPipeline(pm, allocationOpt);
 }
 
 static LogicalResult processBuffer(
@@ -411,7 +345,10 @@ static LogicalResult processBuffer(
     pmLlvm.addInstrumentation(
         std::make_unique<VerbosePassInstrumentation<mlir::ModuleOp>>(
             "arcilator"));
-  populateArcToLLVMPipeline(pmLlvm);
+
+  if (!untilReached(UntilLLVMLowering)) {
+    populateArcToLLVMPipeline(pmLlvm);
+  }
 
   if (printDebugInfo && outputFormat == OutputLLVM)
     pmLlvm.addPass(LLVM::createDIScopeForLLVMFuncOpPass());


### PR DESCRIPTION
Allow re-use of the arcilator library. Split up the large pipeline into finer grained stages and move into its own library.

populateHwModuleToArcPipeline is split into:
 - arcPreprocessingPipeline
 - arcConversionPipeline
 - arcOptimizationPipeline
 - arcStateLoweringPipeline and
 - arcStateAllocationPipeline

Flags to customize passes are moved from the binary into the corresponding pipeline options.