### PR TITLE
[Moore][ImportVerilog] Add VTableOps and CreateVTables pass

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2419,10 +2419,11 @@ def ClassMethodDeclOp
     : MooreOp<"class.methoddecl", [Symbol, HasParent<"ClassDeclOp">]> {
   let summary = "Declare a class method";
   let arguments = (ins SymbolNameAttr:$sym_name,
-      TypeAttrOf<FunctionType>:$function_type);
+      TypeAttrOf<FunctionType>:$function_type,
+      OptionalAttr<SymbolRefAttr>:$impl);
   let results = (outs);
   let assemblyFormat = [{
-      $sym_name `:` $function_type attr-dict
+      $sym_name (`->` $impl^)? `:` $function_type attr-dict
   }];
 }
 
@@ -2515,6 +2516,45 @@ def VTableLoadMethodOp
   let assemblyFormat =
     "$object `:` $methodSym `of` type($object) `->` type($result) attr-dict";
 }
+
+def VTableOp : MooreOp<"vtable",
+    [NoTerminator, SingleBlock, IsolatedFromAbove,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Virtual dispatch table";
+  let description = [{
+    Lives at module top-level. Contains `moore.vtable_entry` and nested
+    `moore.vtable` ops for base segments. Holds the dispatch targets for every
+    possible virtual method call of a class and its ancestors.
+  }];
+  let arguments = (ins
+    SymbolRefAttr:$sym_name
+  );
+
+  let results = (outs);
+  let regions = (region AnyRegion:$body);
+  let assemblyFormat = [{
+    $sym_name attr-dict-with-keyword $body
+  }];
+  let hasRegionVerifier = 1;
+}
+
+def VTableEntryOp : MooreOp<"vtable_entry", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "One vtable slot pointing to the selected implementation";
+  let description = [{
+    Each entry references the resolved implementation with a SymbolRefAttr.
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$name,
+    SymbolRefAttr:$target
+  );
+
+  let assemblyFormat = [{
+    $name `->` $target attr-dict
+  }];
+}
+
 
 //===----------------------------------------------------------------------===//
 // String Builtins

--- a/include/circt/Dialect/Moore/MoorePasses.h
+++ b/include/circt/Dialect/Moore/MoorePasses.h
@@ -24,6 +24,7 @@ namespace moore {
 
 std::unique_ptr<mlir::Pass> createSimplifyProceduresPass();
 std::unique_ptr<mlir::Pass> createLowerConcatRefPass();
+std::unique_ptr<mlir::Pass> createVTablesPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Moore/MoorePasses.td
+++ b/include/circt/Dialect/Moore/MoorePasses.td
@@ -39,4 +39,14 @@ def LowerConcatRef : Pass<"moore-lower-concatref", "moore::SVModuleOp"> {
     let constructor = "circt::moore::createLowerConcatRefPass()";
 }
 
+def CreateVTables : Pass<"moore-create-vtables", "mlir::ModuleOp"> {
+    let summary = "Lower moore.vtable ops";
+    let description = [{
+        It's used to compute vtables from classdeclops.
+        Needs to be run before any Symbol DCE pass is run.
+    }];
+    let constructor = "circt::moore::createVTablesPass()";
+}
+
+
 #endif // CIRCT_DIALECT_MOORE_MOOREPASSES_TD

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -413,6 +413,8 @@ void circt::populateVerilogToMoorePipeline(OpPassManager &pm) {
     anyPM.addPass(mlir::createCanonicalizerPass());
   }
 
+  pm.addPass(moore::createVTablesPass());
+
   // Remove unused symbols.
   pm.addPass(mlir::createSymbolDCEPass());
 

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1589,7 +1589,7 @@ struct ClassDeclVisitor {
       extraParams.push_back(handleTy);
 
       auto funcTy = getFunctionSignature(context, fn, extraParams);
-      moore::ClassMethodDeclOp::create(builder, loc, fn.name, funcTy);
+      moore::ClassMethodDeclOp::create(builder, loc, fn.name, funcTy, nullptr);
       return success();
     }
 
@@ -1610,7 +1610,8 @@ struct ClassDeclVisitor {
     // Grab the finalized function type from the lowered func.op.
     FunctionType fnTy = lowering->op.getFunctionType();
     // Emit the method decl into the class body, preserving source order.
-    moore::ClassMethodDeclOp::create(builder, loc, fn.name, fnTy);
+    moore::ClassMethodDeclOp::create(builder, loc, fn.name, fnTy,
+                                     SymbolRefAttr::get(lowering->op));
 
     return success();
   }

--- a/lib/Dialect/Moore/CMakeLists.txt
+++ b/lib/Dialect/Moore/CMakeLists.txt
@@ -22,6 +22,7 @@ add_circt_dialect_library(CIRCTMoore
   MLIRInferTypeOpInterface
   MLIRMemorySlotInterfaces
   MLIRCallInterfaces
+  MLIRFuncDialect
 )
 
 add_dependencies(circt-headers MLIRMooreIncGen)

--- a/lib/Dialect/Moore/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Moore/Transforms/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_circt_dialect_library(CIRCTMooreTransforms
 LowerConcatRef.cpp
 SimplifyProcedures.cpp
-
+CreateVTables.cpp
 
   DEPENDS
   CIRCTMooreTransformsIncGen

--- a/lib/Dialect/Moore/Transforms/CreateVTables.cpp
+++ b/lib/Dialect/Moore/Transforms/CreateVTables.cpp
@@ -1,0 +1,199 @@
+//===- CreateVTables.cpp - Create VTables from ClassDeclOps --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the CreateVTables pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Moore/MooreOps.h"
+#include "circt/Dialect/Moore/MoorePasses.h"
+
+namespace circt {
+namespace moore {
+#define GEN_PASS_DEF_CREATEVTABLES
+#include "circt/Dialect/Moore/MoorePasses.h.inc"
+} // namespace moore
+} // namespace circt
+
+using namespace circt;
+using namespace moore;
+using namespace llvm;
+using namespace mlir;
+
+namespace {
+using MethodMap = llvm::DenseMap<StringRef, std::optional<SymbolRefAttr>>;
+using ClassMap = llvm::DenseMap<ClassDeclOp, MethodMap>;
+
+struct CreateVTablesPass
+    : public circt::moore::impl::CreateVTablesBase<CreateVTablesPass> {
+  void runOnOperation() override;
+
+private:
+  /// Cache that stores the most derived virtual method for each class
+  ClassMap classToMethodMap;
+  /// Helper function to collect vtable info for every top-level classdecl
+  void collectClasses(ModuleOp mod, SymbolTable &symTab);
+  /// Recursive helper function to determine most derived virtual method impl
+  /// per class
+  void collectClassDependencies(ModuleOp mod, SymbolTable &symTab,
+                                ClassDeclOp &clsDecl,
+                                SymbolRefAttr dependencyName);
+
+  /// Function to emit VTable computed in classToMethodMap
+  void emitVTablePerClass(ModuleOp mod, SymbolTable &symTab,
+                          OpBuilder &builder);
+  void emitVTablePerDependencyClass(ModuleOp mod, SymbolTable &symTab,
+                                    OpBuilder &builder, ClassDeclOp &clsDecl,
+                                    SymbolRefAttr dependencyName);
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> circt::moore::createVTablesPass() {
+  return std::make_unique<CreateVTablesPass>();
+}
+
+void CreateVTablesPass::collectClassDependencies(ModuleOp mod,
+                                                 SymbolTable &symTab,
+                                                 ClassDeclOp &clsDecl,
+                                                 SymbolRefAttr dependencyName) {
+  auto dependencyDecl =
+      symTab.lookupNearestSymbolFrom<ClassDeclOp>(mod, dependencyName);
+
+  auto &clsMap = classToMethodMap[clsDecl];
+  for (auto methodDecl : dependencyDecl.getBody().getOps<ClassMethodDeclOp>()) {
+
+    // If a derived class already maps this method, continue
+    auto &mapEntry = clsMap[methodDecl.getSymName()];
+    if (mapEntry)
+      continue;
+
+    std::optional<SymbolRefAttr> impl;
+    if (methodDecl.getImpl().has_value()) {
+      impl = methodDecl.getImpl().value();
+    } else {
+      impl = std::nullopt;
+    }
+
+    mapEntry = impl;
+  }
+  if (dependencyDecl.getBase().has_value())
+    collectClassDependencies(mod, symTab, clsDecl,
+                             dependencyDecl.getBase().value());
+  if (dependencyDecl.getImplementedInterfaces().has_value())
+    for (auto intf : dependencyDecl.getImplementedInterfacesAttr())
+      collectClassDependencies(mod, symTab, clsDecl, cast<SymbolRefAttr>(intf));
+}
+
+void CreateVTablesPass::collectClasses(ModuleOp mod, SymbolTable &symTab) {
+  for (auto clsDecl : mod.getBodyRegion().getOps<ClassDeclOp>()) {
+    auto &clsMap = classToMethodMap[clsDecl];
+    // Don't override if already filled
+    if (!clsMap.empty())
+      continue;
+    collectClassDependencies(mod, symTab, clsDecl, SymbolRefAttr::get(clsDecl));
+  }
+}
+
+static bool noneHaveImpl(const MethodMap &methods) {
+  return llvm::all_of(methods,
+                      [](const auto &kv) { return !kv.second.has_value(); });
+}
+
+static bool allHaveImpl(const MethodMap &methods) {
+  return llvm::all_of(methods,
+                      [](const auto &kv) { return kv.second.has_value(); });
+}
+
+static inline SymbolRefAttr getVTableName(ClassDeclOp &clsDecl) {
+
+  auto base = SymbolRefAttr::get(clsDecl); // e.g. @MyClass
+  auto suffix = mlir::FlatSymbolRefAttr::get(clsDecl.getContext(), "vtable");
+  auto vTableName = mlir::SymbolRefAttr::get(base.getRootReference(), {suffix});
+  return vTableName;
+}
+
+void CreateVTablesPass::emitVTablePerDependencyClass(
+    ModuleOp mod, SymbolTable &symTab, OpBuilder &builder, ClassDeclOp &clsDecl,
+    SymbolRefAttr dependencyName) {
+
+  auto dependencyDecl =
+      symTab.lookupNearestSymbolFrom<ClassDeclOp>(mod, dependencyName);
+
+  auto clsMethodMap = classToMethodMap[clsDecl];
+  auto depMethodMap = classToMethodMap[dependencyDecl];
+
+  // If the VTable would be empty, don't emit it.
+  if (depMethodMap.empty())
+    return;
+
+  auto vTableName = getVTableName(dependencyDecl);
+
+  auto clsVTable =
+      VTableOp::create(builder, dependencyDecl.getLoc(), vTableName);
+  auto &region = clsVTable.getRegion();
+  auto &block = region.emplaceBlock();
+
+  OpBuilder::InsertionGuard g(builder);
+  builder.setInsertionPointToEnd(&block);
+
+  // First emit base class if available
+  if (dependencyDecl.getBase().has_value())
+    emitVTablePerDependencyClass(mod, symTab, builder, clsDecl,
+                                 dependencyDecl.getBase().value());
+
+  // Next emit interface classes if available
+  if (dependencyDecl.getImplementedInterfaces().has_value())
+    for (auto intf : dependencyDecl.getImplementedInterfacesAttr())
+      emitVTablePerDependencyClass(mod, symTab, builder, clsDecl,
+                                   cast<SymbolRefAttr>(intf));
+
+  // Last, emit any own method symbol entries
+  for (auto methodDecl : dependencyDecl.getBody().getOps<ClassMethodDeclOp>()) {
+    auto methodName = methodDecl.getSymName();
+    VTableEntryOp::create(builder, methodDecl.getLoc(), methodName,
+                          clsMethodMap[methodName].value());
+  }
+}
+
+void CreateVTablesPass::emitVTablePerClass(ModuleOp mod, SymbolTable &symTab,
+                                           OpBuilder &builder) {
+  // Check emission for every top-level class decl
+  for (auto [clsDecl, methodMap] : classToMethodMap) {
+
+    // Sanity check that either all methods are implemented or none are.
+    if (!(allHaveImpl(methodMap) || noneHaveImpl(methodMap))) {
+      clsDecl.emitError()
+          << "Class declaration " << clsDecl.getSymName()
+          << " is malformed; some methods are abstract and some are concrete, "
+             "which is not legal in System Verilog.";
+      return;
+    }
+
+    // Skip abstract classes
+    if (noneHaveImpl(methodMap))
+      continue;
+
+    auto vTableName = getVTableName(clsDecl);
+    // Don't try to emit a vtable if it already exists.
+    if (symTab.lookupNearestSymbolFrom<VTableOp>(mod, vTableName))
+      continue;
+
+    builder.setInsertionPointAfter(clsDecl);
+
+    emitVTablePerDependencyClass(mod, symTab, builder, clsDecl,
+                                 SymbolRefAttr::get(clsDecl));
+  }
+}
+
+void CreateVTablesPass::runOnOperation() {
+  ModuleOp mod = getOperation();
+  SymbolTable symTab(mod);
+  collectClasses(mod, symTab);
+  mlir::OpBuilder builder = mlir::OpBuilder::atBlockBegin(mod.getBody());
+  emitVTablePerClass(mod, symTab, builder);
+}

--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -587,7 +587,7 @@ class SpecializedFoo extends GenericBar #(x,y,z); endclass
 /// Check virtual attribute of methoddecl
 
 // CHECK-LABEL: moore.class.classdecl @testClassVirtual {
-// CHECK-NEXT:    moore.class.methoddecl @testFun : (!moore.class<@testClassVirtual>) -> ()
+// CHECK-NEXT:    moore.class.methoddecl @testFun -> @"testClassVirtual::testFun" : (!moore.class<@testClassVirtual>) -> ()
 // CHECK:  }
 // CHECK:  func.func private @"testClassVirtual::testFun"(%arg0: !moore.class<@testClassVirtual>) {
 // CHECK:    return
@@ -617,7 +617,7 @@ endfunction
 // CHECK:    moore.class.methoddecl @subroutine : (!moore.class<@virtualFunctionClass>)
 // CHECK:  }
 // CHECK:  moore.class.classdecl @realFunctionClass implements [@virtualFunctionClass] {
-// CHECK:    moore.class.methoddecl @subroutine : (!moore.class<@realFunctionClass>)
+// CHECK:    moore.class.methoddecl @subroutine -> @"realFunctionClass::subroutine" : (!moore.class<@realFunctionClass>)
 // CHECK:  }
 // CHECK:  func.func private @"realFunctionClass::subroutine"(%arg0: !moore.class<@realFunctionClass>) {
 // CHECK:    return

--- a/test/Dialect/Moore/classes.mlir
+++ b/test/Dialect/Moore/classes.mlir
@@ -80,5 +80,77 @@ moore.class.classdecl @PropertyCombo {
   moore.class.propertydecl @localAutoI32 : !moore.i32
 }
 
+/// Check that vtables roundtrip
+
+// CHECK-LABEL:  moore.vtable @testClass::@vtable {
+// CHECK:    moore.vtable @realFunctionClass::@vtable {
+// CHECK:      moore.vtable @virtualFunctionClass::@vtable {
+// CHECK:        moore.vtable_entry @subroutine -> @"testClass::subroutine"
+// CHECK:      }
+// CHECK:      moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+// CHECK:    }
+// CHECK:    moore.vtable_entry @subroutine -> @"testClass::subroutine"
+// CHECK:    moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+// CHECK:  }
+
+  moore.class.classdecl @virtualFunctionClass {
+    moore.class.methoddecl @subroutine : (!moore.class<@virtualFunctionClass>) -> ()
+  }
+  moore.class.classdecl @realFunctionClass implements [@virtualFunctionClass] {
+    moore.class.methoddecl @testSubroutine : (!moore.class<@realFunctionClass>) -> ()
+  }
+  moore.class.classdecl @testClass implements [@realFunctionClass] {
+    moore.class.methoddecl @subroutine -> @"testClass::subroutine" : (!moore.class<@testClass>) -> ()
+    moore.class.methoddecl @testSubroutine -> @"testClass::testSubroutine" : (!moore.class<@testClass>) -> ()
+  }
+  moore.vtable @testClass::@vtable {
+    moore.vtable @realFunctionClass::@vtable {
+      moore.vtable @virtualFunctionClass::@vtable {
+        moore.vtable_entry @subroutine -> @"testClass::subroutine"
+      }
+      moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+    }
+    moore.vtable_entry @subroutine -> @"testClass::subroutine"
+    moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+  }
+  func.func private @"testClass::subroutine"(%arg0: !moore.class<@testClass>) {
+    return
+  }
+  func.func private @"testClass::testSubroutine"(%arg0: !moore.class<@testClass>) {
+    return
+  }
+
+// CHECK-LABEL:  moore.vtable @tClass::@vtable {
+// CHECK:    moore.vtable @testClass::@vtable {
+// CHECK:      moore.vtable @realFunctionClass::@vtable {
+// CHECK:        moore.vtable @virtualFunctionClass::@vtable {
+// CHECK:          moore.vtable_entry @subroutine -> @"tClass::subroutine"
+// CHECK:        }
+// CHECK:        moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+// CHECK:      }
+// CHECK:      moore.vtable_entry @subroutine -> @"tClass::subroutine"
+// CHECK:      moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+// CHECK:    }
+// CHECK:    moore.vtable_entry @subroutine -> @"tClass::subroutine"
+// CHECK:  }
+  moore.class.classdecl @tClass extends @testClass {
+    moore.class.methoddecl @subroutine -> @"tClass::subroutine" : (!moore.class<@tClass>) -> ()
+  }
+  moore.vtable @tClass::@vtable {
+    moore.vtable @testClass::@vtable {
+      moore.vtable @realFunctionClass::@vtable {
+        moore.vtable @virtualFunctionClass::@vtable {
+          moore.vtable_entry @subroutine -> @"tClass::subroutine"
+        }
+        moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+      }
+      moore.vtable_entry @subroutine -> @"tClass::subroutine"
+      moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+    }
+    moore.vtable_entry @subroutine -> @"tClass::subroutine"
+  }
+  func.func private @"tClass::subroutine"(%arg0: !moore.class<@tClass>) {
+    return
+  }
 
 }

--- a/test/Dialect/Moore/vtables.mlir
+++ b/test/Dialect/Moore/vtables.mlir
@@ -1,0 +1,50 @@
+// RUN: circt-opt %s --moore-create-vtables --verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL:  moore.vtable @testClass::@vtable {
+// CHECK-NEXT:    moore.vtable @realFunctionClass::@vtable {
+// CHECK-NEXT:      moore.vtable @virtualFunctionClass::@vtable {
+// CHECK-NEXT:        moore.vtable_entry @subroutine -> @"testClass::subroutine"
+// CHECK-NEXT:      }
+// CHECK-NEXT:      moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+// CHECK-NEXT:    }
+// CHECK-NEXT:    moore.vtable_entry @subroutine -> @"testClass::subroutine"
+// CHECK-NEXT:    moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+// CHECK-NEXT:  }
+
+  moore.class.classdecl @virtualFunctionClass {
+    moore.class.methoddecl @subroutine : (!moore.class<@virtualFunctionClass>) -> ()
+  }
+  moore.class.classdecl @realFunctionClass implements [@virtualFunctionClass] {
+    moore.class.methoddecl @testSubroutine : (!moore.class<@realFunctionClass>) -> ()
+  }
+  moore.class.classdecl @testClass implements [@realFunctionClass] {
+    moore.class.methoddecl @subroutine -> @"testClass::subroutine" : (!moore.class<@testClass>) -> ()
+    moore.class.methoddecl @testSubroutine -> @"testClass::testSubroutine" : (!moore.class<@testClass>) -> ()
+  }
+  func.func private @"testClass::subroutine"(%arg0: !moore.class<@testClass>) {
+    return
+  }
+  func.func private @"testClass::testSubroutine"(%arg0: !moore.class<@testClass>) {
+    return
+  }
+
+// CHECK-LABEL:  moore.vtable @tClass::@vtable {
+// CHECK-NEXT:    moore.vtable @testClass::@vtable {
+// CHECK-NEXT:      moore.vtable @realFunctionClass::@vtable {
+// CHECK-NEXT:        moore.vtable @virtualFunctionClass::@vtable {
+// CHECK-NEXT:          moore.vtable_entry @subroutine -> @"tClass::subroutine"
+// CHECK-NEXT:        }
+// CHECK-NEXT:        moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+// CHECK-NEXT:      }
+// CHECK-NEXT:      moore.vtable_entry @subroutine -> @"tClass::subroutine"
+// CHECK-NEXT:      moore.vtable_entry @testSubroutine -> @"testClass::testSubroutine"
+// CHECK-NEXT:    }
+// CHECK-NEXT:    moore.vtable_entry @subroutine -> @"tClass::subroutine"
+// CHECK-NEXT:  }
+
+  moore.class.classdecl @tClass extends @testClass {
+    moore.class.methoddecl @subroutine -> @"tClass::subroutine" : (!moore.class<@tClass>) -> ()
+  }
+  func.func private @"tClass::subroutine"(%arg0: !moore.class<@tClass>) {
+    return
+  }


### PR DESCRIPTION
This patch introduces infrastructure and a lowering pass to build and verify virtual dispatch tables (`moore.vtable` / `moore.vtable_entry`) from `ClassDeclOp`s and their method declarations.

- Adds `moore.vtable` and `moore.vtable_entry` ops.
- Extends `ClassMethodDeclOp` with optional `impl` attribute.
- Adds basic verifiers for both ops.
- Introduces `CreateVTablesPass` (`--moore-create-virtual-dispatch-tables`) to build vtables from `ClassDeclOp`s and their method implementations.
- Wires into the `circt-verilog` pipeline before Symbol DCE.