### PR TITLE
[FIRRTL] Added getExtModuleName to FExtModuleOp to get the appropriate module name

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -216,6 +216,7 @@ def FExtModuleOp : FIRRTLModuleLike<"extmodule"> {
   let extraModuleClassDeclaration = [{
     void getAsmBlockArgumentNames(mlir::Region &region,
                                   mlir::OpAsmSetValueNameFn setNameFn);
+    StringRef getExtModuleName();
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1932,6 +1932,12 @@ void FExtModuleOp::getAsmBlockArgumentNames(
   getAsmBlockArgumentNamesImpl(getOperation(), region, setNameFn);
 }
 
+StringRef FExtModuleOp::getExtModuleName() {
+  if (auto defname = getDefname(); defname && !defname->empty())
+    return *defname;
+  return getName();
+}
+
 void FIntModuleOp::getAsmBlockArgumentNames(
     mlir::Region &region, mlir::OpAsmSetValueNameFn setNameFn) {
   getAsmBlockArgumentNamesImpl(getOperation(), region, setNameFn);

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1066,8 +1066,7 @@ om::ClassLike LowerClassesPass::createClass(FModuleLike moduleLike,
 
   // Use the defname for external modules.
   if (auto externMod = dyn_cast<FExtModuleOp>(moduleLike.getOperation()))
-    if (auto defname = externMod.getDefname())
-      className = defname.value();
+    className = externMod.getExtModuleName();
 
   // If the op is a Module or ExtModule, the OM Class would conflict with the HW
   // Module, so give it a suffix. There is no formal ABI for this yet.
@@ -1410,8 +1409,7 @@ updateInstanceInClass(InstanceOp firrtlInstance, hw::HierPathOp hierPath,
 
   // Use the defname for external modules.
   if (auto externMod = dyn_cast<FExtModuleOp>(referencedModule.getOperation()))
-    if (auto defname = externMod.getDefname())
-      moduleName = defname.value();
+    moduleName = externMod.getExtModuleName();
 
   // Convert the FIRRTL Module name to an OM Class type.
   auto className = FlatSymbolRefAttr::get(

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -257,10 +257,6 @@ class LowerLayersPass
   void preprocessModule(CircuitNamespace &ns, InstanceGraphNode *node,
                         FModuleOp module);
 
-  /// Get the verilog name of an extmodule, which could be recorded in its
-  /// defname property.
-  StringRef getExtModuleName(FExtModuleOp extModule);
-
   /// Record the supposed bindfiles for any known layers of the ext module.
   void preprocessExtModule(CircuitNamespace &ns, InstanceGraphNode *node,
                            FExtModuleOp extModule);
@@ -1004,12 +1000,6 @@ void LowerLayersPass::preprocessModule(CircuitNamespace &ns,
       buildBindFile(ns, node, b, sym, layer);
 }
 
-StringRef LowerLayersPass::getExtModuleName(FExtModuleOp extModule) {
-  if (auto name = extModule.getDefnameAttr())
-    return name.getValue();
-  return extModule.getName();
-}
-
 void LowerLayersPass::preprocessExtModule(CircuitNamespace &ns,
                                           InstanceGraphNode *node,
                                           FExtModuleOp extModule) {
@@ -1022,7 +1012,7 @@ void LowerLayersPass::preprocessExtModule(CircuitNamespace &ns,
   if (known.empty())
     return;
 
-  auto moduleName = getExtModuleName(extModule);
+  auto moduleName = extModule.getExtModuleName();
   auto &files = bindFiles[extModule];
   SmallPtrSet<Operation *, 8> seen;
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -416,11 +416,8 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
   /// Generate the ABI ref_<module> prefix string into `prefix`.
   void getRefABIPrefix(FModuleLike mod, SmallVectorImpl<char> &prefix) {
     auto modName = mod.getModuleName();
-    if (auto ext = dyn_cast<FExtModuleOp>(*mod)) {
-      // Use defName for module portion, if set.
-      if (auto defname = ext.getDefname(); defname && !defname->empty())
-        modName = *defname;
-    }
+    if (auto ext = dyn_cast<FExtModuleOp>(*mod))
+      modName = ext.getExtModuleName();
     (Twine("ref_") + modName).toVector(prefix);
   }
 

--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -333,3 +333,19 @@ circuit Top:
     inst foo of Foo
 
 ; CHECK: `include "layers-Bar-A.sv"
+
+; // -----
+
+; Check that bindfile for Top should include layers-MyExt-A when defname is
+; empty, falling back to the module name.
+
+FIRRTL version 5.1.0
+circuit TopEmptyDefname:
+  layer A, bind:
+
+  extmodule MyExt knownlayer A:
+
+  public module TopEmptyDefname:
+    inst ext of MyExt
+
+; CHECK: `include "layers-MyExt-A.sv"


### PR DESCRIPTION
Adds a new helper method to FExtModuleOp that returns the appropriate module name (defname if present, otherwise the module name).

- Added `StringRef FExtModuleOp::getExtModuleName()` method
- Replaced code in LowerXMR, LowerClasses, and LowerLayers to use this new method to get module name
- Added test case in lower-layers.fir

Closes #8923
