### PR TITLE
[ESI][Runtime] Fixing service uniquifaction

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -158,7 +158,7 @@ private:
 
   /// Cache services via a unique_ptr so they get free'd automatically when
   /// Accelerator objects get deconstructed.
-  using ServiceCacheKey = std::tuple<const std::type_info *, AppIDPath>;
+  using ServiceCacheKey = std::tuple<std::string, AppIDPath>;
   std::map<ServiceCacheKey, std::unique_ptr<Service>> serviceCache;
 
   std::unique_ptr<AcceleratorServiceThread> serviceThread;

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -80,7 +80,8 @@ services::Service *AcceleratorConnection::getService(Service::Type svcType,
                                                      std::string implName,
                                                      ServiceImplDetails details,
                                                      HWClientDetails clients) {
-  std::unique_ptr<Service> &cacheEntry = serviceCache[make_tuple(&svcType, id)];
+  std::unique_ptr<Service> &cacheEntry =
+      serviceCache[make_tuple(std::string(svcType.name()), id)];
   if (cacheEntry == nullptr) {
     Service *svc = createService(svcType, id, implName, details, clients);
     if (!svc)


### PR DESCRIPTION
This was broken on Windows. Something to do with linking I suspect. So let's just use a string.