### PR TITLE
[domaintool] Add `-assign u` support

### DIFF
--- a/test/Tools/domaintool/clock-spec-json.mlir
+++ b/test/Tools/domaintool/clock-spec-json.mlir
@@ -1,6 +1,6 @@
-// RUN: domaintool --module Foo --domain ClockDomain,A,10 --assign 0 %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
-// RUN: domaintool --module Foo --domain ClockDomain,A,10 --assign 0 --sifive-clock-domain-async=A %s | FileCheck %s --check-prefixes=CHECK,ASYNC
-// RUN: domaintool --module Foo --domain ClockDomain,A,10 --assign 0 --sifive-clock-domain-static=A %s | FileCheck %s --check-prefixes=CHECK,STATIC
+// RUN: domaintool --module Foo --domain ClockDomain,A,10 --assign 0 --assign u %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
+// RUN: domaintool --module Foo --domain ClockDomain,A,10 --assign 0 --assign u --sifive-clock-domain-async=A %s | FileCheck %s --check-prefixes=CHECK,ASYNC
+// RUN: domaintool --module Foo --domain ClockDomain,A,10 --assign 0 --assign u --sifive-clock-domain-static=A %s | FileCheck %s --check-prefixes=CHECK,STATIC
 
 om.class @ClockDomain(
   %basepath: !om.frozenbasepath,
@@ -26,9 +26,11 @@ om.class @ClockDomain_out(
 
 om.class @Foo_Class(
   %basepath: !om.frozenbasepath,
-  %A: !om.class.type<@ClockDomain>
+  %A: !om.class.type<@ClockDomain>,
+  %base_address: !om.integer
 )  -> (
-  A_out: !om.class.type<@ClockDomain_out>
+  A_out: !om.class.type<@ClockDomain_out>,
+  effective_address: !om.integer
 ) {
   %0 = om.object @ClockDomain_out(%basepath, %A, %3) : (
     !om.frozenbasepath,
@@ -38,7 +40,9 @@ om.class @Foo_Class(
   %1 = om.frozenpath_create reference %basepath "Foo>a"
   %2 = om.frozenpath_create reference %basepath "Foo>b"
   %3 = om.list_create %1, %2 : !om.frozenpath
-  om.class.fields %0 : !om.class.type<@ClockDomain_out>
+  %4 = om.constant #om.integer<1 : si4> : !om.integer
+  %5 = om.integer.add %base_address, %4 : !om.integer
+  om.class.fields %0, %5 : !om.class.type<@ClockDomain_out>, !om.integer
 }
 
 // CHECK:        {


### PR DESCRIPTION
To work around the problem of needing to evaluate a FIRRTL "ABI" class
that contains domain-lowered properties _and other non-domain properties_,
add the ability to instantiate an object with an "unknown" value
assignment via `-assign u`.

Previously, `domaintool` was unusable if the class being instantiated
contained any non-domain information.  This occurs in any internal,
non-trivial design.  This provides a mechanism, using the "unknown" value
added in #9247, to work around this.

Note: as mentioned on #9247, it would really be better if there was a way
to define a "domain function" that contained only the information that we
cared about.  However, the FIRRTL "ABI" for properties was not implemented
this way and only a single entry point is provided.

This is stacked on #9247.
