### PR TITLE
[Synth] Fix dependency in CMakeLists

### DIFF
--- a/lib/Dialect/Synth/Analysis/CMakeLists.txt
+++ b/lib/Dialect/Synth/Analysis/CMakeLists.txt
@@ -15,6 +15,7 @@ add_circt_dialect_library(CIRCTSynthAnalysis
 
   DEPENDS
   CIRCTSynthTransformsIncGen
+  CIRCTConversionPassIncGen
 
   LINK_COMPONENTS
   Support


### PR DESCRIPTION
This fixes the specified dependency.
It was not causing issues on some platforms because it is build order dependent and it may be build before this target.

Example of a build failure:
https://github.com/pineapplehunter/nixpkgs-review-gha/actions/runs/18114863001/job/51548560872