### PR TITLE
[MooreToCore] Fix lowering of dynamic extracts of nested arrays

### DIFF
--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -345,6 +345,20 @@ func.func @ExtractRefArrayElement(%j: !moore.ref<array<1 x array<1 x l3>>>) -> (
   return %0 : !moore.ref<array<1 x l3>>
 }
 
+// CHECK-LABEL: DynExtractArrayElement
+func.func @DynExtractArrayElement(%j: !moore.array<2 x array<1 x l3>>, %idx: !moore.l1) -> (!moore.array<1 x l3>) {
+  // CHECK: hw.array_get
+  %0 = moore.dyn_extract %j from %idx : !moore.array<2 x array<1 x l3>>, !moore.l1 -> !moore.array<1 x l3>
+  return %0 : !moore.array<1 x l3>
+}
+
+// CHECK-LABEL: DynExtractRefArrayElement
+func.func @DynExtractRefArrayElement(%j: !moore.ref<array<2 x array<1 x l3>>>, %idx: !moore.l1) -> (!moore.ref<array<1 x l3>>) {
+  // CHECK: llhd.sig.array_get
+  %0 = moore.dyn_extract_ref %j from %idx : <array<2 x array<1 x l3>>>, !moore.l1 -> <array<1 x l3>>
+  return %0 : !moore.ref<array<1 x l3>>
+}
+
 // CHECK-LABEL: func @AdvancedConversion
 func.func @AdvancedConversion(%arg0: !moore.array<5 x struct<{exp_bits: i32, man_bits: i32}>>) -> (!moore.array<5 x struct<{exp_bits: i32, man_bits: i32}>>, !moore.i320) {
   // CHECK: [[V0:%.+]] = hw.constant 3978585893941511189997889893581765703992223160870725712510875979948892565035285336817671 : i320


### PR DESCRIPTION
Fixes the lowering of single element dynamic extracts from arrays of arrays in MooreToCore. Previously, an array typed result of an extract would always cause the emission of a slice operation instead of a get operation. This changes the logic to emit a get operation if the result type is equal to the input array's element type.

Effectively to what #8942 did for static extracts. Should fix #9246.