### PR TITLE
[ci] Change static build to use Rocky Linux 8

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstallStatic.yml
+++ b/.github/workflows/unifiedBuildTestAndInstallStatic.yml
@@ -1,11 +1,10 @@
 name: Unified Build, Test, and Install (Static)
 description: |
-  This reusable workflow is intended to be used to build completely static
-  tools.  This uses Alpine Linux to build CIRCT using musl libc which can be
-  used to make completely statically linked binaries.
-
-  This workflow should be used if you are trying to publish universal Linux
-  binaries.
+  This reusable workflow is intended to be used to build _mostly_ static tools.
+  This works like `unifiedBuildTestAndInstall.yml` except it uses a container of
+  Rocky Linux 8 in order to get an old glibc ABI.  The binaries produced by this
+  build should be compatible with operating systems supported (mandated) by EDA
+  vendors, like RHEL 8.
 
 on:
   workflow_dispatch:
@@ -70,22 +69,39 @@ on:
 jobs:
   build-test-and-install:
     runs-on: ubuntu-latest
-    container: "alpine"
+    container:
+      image: rockylinux:8
     permissions:
       contents: write # Upload assets to release.
     outputs:
       cache-key-pattern: ${{ steps.cache-key.outputs.pattern }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Generate cache key pattern
         id: cache-key
         run: |
-          CACHE_KEY="alpine-${{ inputs.cmake_build_type }}-${{ inputs.llvm_enable_assertions }}-${{ inputs.llvm_force_enable_stats}}"
+          CACHE_KEY="rockylinux8-${{ inputs.cmake_build_type }}-${{ inputs.llvm_enable_assertions }}-${{ inputs.llvm_force_enable_stats}}"
           echo "pattern=$CACHE_KEY" >> $GITHUB_OUTPUT
-# Per-operating system setup
-      - name: Setup (linux)
+# Operating system setup
+      - name: Setup (Rocky Linux 8)
         run: |
-          apk update
-          apk add bash clang19 cmake curl file git gzip perl-utils python3 samurai tar
+          dnf -y update
+          dnf install -y dnf-plugins-core
+          dnf config-manager --set-enabled powertools
+          dnf makecache --refresh
+          dnf -y groupinstall "Development Tools"
+          dnf -y install \
+            epel-release \
+            python3 \
+            cmake \
+            ninja-build \
+            clang \
+            lld \
+            which \
+            wget \
+            perl
 # Clone the repository
       - name: Clone llvm/circt
         uses: actions/checkout@v4
@@ -96,13 +112,6 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/circt/circt
           git fetch --unshallow --no-recurse-submodules
-      - name: Clone microsoft/mimalloc
-        uses: actions/checkout@v4
-        with:
-          repository: microsoft/mimalloc
-          fetch-depth: 1
-          ref: v3.1.5
-          path: build/mimalloc
 # Setup Caching
       - name: sccache
         if: inputs.cmake_build_type == 'release'
@@ -114,22 +123,14 @@ jobs:
       - name: Configure sccache
         id: configure-sccache
         if: inputs.cmake_build_type == 'release'
-        shell: bash
         run:
           echo enable_sccache="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_OUTPUT
-# Build static mimalloc
-      - name: Build microsoft/mimalloc
-        run: |
-          mkdir -p build/mimalloc/build
-          cd build/mimalloc/build
-          cmake ../ -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DMI_OVERRIDE=ON -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19
-          ninja
 # Configure
       - name: Configure CIRCT
         run: |
           mkdir -p build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" $EXTRA_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_BUILD_STATIC=ON -DLLVM_LINK_LLVM_DYLIB=OFF -DLLVM_ENABLE_PIC=OFF -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DCMAKE_EXE_LINKER_FLAGS_INIT="-Wl,-z,stack-size=8388608 -Wl,--whole-archive $(pwd)/../build/mimalloc/build/libmimalloc.a -Wl,--no-whole-archive"
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" $EXTRA_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_USE_LINKER=lld
 # Optionally test
       - name: Test CIRCT
         if: inputs.run_tests
@@ -144,7 +145,6 @@ jobs:
       - name: Name Install Directory
         id: name_dir
         if: inputs.install_target
-        shell: bash
         run: |
           BASE=$(git describe --tag)
           SANITIZED=$(echo -n $BASE | tr '/' '-')
@@ -167,7 +167,6 @@ jobs:
       - name: Name Archive
         id: name_archive
         if: inputs.install_target
-        shell: bash
         run: |
           NAME=${{ inputs.package_name_prefix }}-${{ steps.name_dir.outputs.os }}-${{ steps.name_dir.outputs.arch }}.${{ steps.name_dir.outputs.archive }}
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
@@ -178,7 +177,6 @@ jobs:
           ${{ steps.name_dir.outputs.tar }} ${{ steps.name_archive.outputs.name }} ${{ steps.name_dir.outputs.value }}
       - name: Show Tarball
         if: inputs.install_target
-        shell: bash
         run: |
           ls -l ${{ steps.name_archive.outputs.name }}
           ${{ steps.name_dir.outputs.sha256 }} ${{ steps.name_archive.outputs.name }} | cut -d ' ' -f1 > ${{ steps.name_archive.outputs.name }}.sha256


### PR DESCRIPTION
Switch the static build from "true static" via muslc/Alpine to use "mostly
static, but using an old 2.28 glibc" by building in a Rocky Linux 8
container.

This replaces the fully static Alpine Linux + muslc (and plethora of
workarounds to make this work) due to observed issues with Arcilator and
LLVM-JIT.  While this was nice if we could make this work, I have come to
the conclusion that it was too much trouble to make this work.

Note: if we do ever need an even older glibc ABI, we _can_ build on CentOS
7.  This was the original plan with this commit.  However, CentOS 7 is
end-of-life and it's more complicated to make it work, e.g., the standard
package repositories are not available.
