### PR TITLE
[Synth] Add an API to get value for Object

### DIFF
--- a/include/circt-c/Dialect/Synth.h
+++ b/include/circt-c/Dialect/Synth.h
@@ -157,6 +157,9 @@ synthLongestPathObjectName(SynthLongestPathObject object);
 MLIR_CAPI_EXPORTED size_t
 synthLongestPathObjectBitPos(SynthLongestPathObject object);
 
+MLIR_CAPI_EXPORTED MlirValue
+synthLongestPathObjectGetValue(SynthLongestPathObject object);
+
 #ifdef __cplusplus
 }
 #endif

--- a/integration_test/Bindings/Python/dialects/synth.py
+++ b/integration_test/Bindings/Python/dialects/synth.py
@@ -3,7 +3,7 @@
 
 import circt
 from circt.dialects import hw, comb, synth, seq
-from circt.ir import Context, Location, Module, InsertionPoint, IntegerType, ArrayAttr
+from circt.ir import Context, Location, Module, InsertionPoint, IntegerType, ArrayAttr, BlockArgument
 from circt.passmanager import PassManager
 from circt.dialects.synth import LongestPathAnalysis, LongestPathCollection, DataflowPath
 
@@ -127,6 +127,30 @@ with Context() as ctx, Location.unknown():
 
     # CHECK-NEXT: minus index slice: True
     print("minus index slice:", len(collection[:-2]) == len(collection) - 2)
+
+    # Test value and is_output_port properties
+    path = collection[0]
+    start_obj = path.start_point
+    end_obj = path.end_point
+
+    # CHECK-NEXT: start_point has value: True
+    print("start_point has value:", start_obj.value is not None)
+
+    # Test downcasting to BlockArgument and accessing owner
+    try:
+      block_arg = BlockArgument(start_obj.value)
+      # CHECK-NEXT: start_point is BlockArgument: True
+      print("start_point is BlockArgument:", True)
+    except ValueError:
+      pass
+
+    # CHECK-NEXT: start_point is_output_port: False
+    print("start_point is_output_port:", start_obj.is_output_port)
+
+    # CHECK-NEXT: end_point is_output_port: True
+    print("end_point is_output_port:", end_obj.is_output_port)
+    # CHECK-NEXT: end_point has no value: True
+    print("end_point has no value:", end_obj.value is None)
 
     # Test framegraph emission.
     # CHECK: top:test_aig;c[0] 0

--- a/lib/Bindings/Python/SynthModule.cpp
+++ b/lib/Bindings/Python/SynthModule.cpp
@@ -193,7 +193,14 @@ void circt::python::populateDialectSynthSubmodule(nb::module_ &m) {
                    [](SynthLongestPathObject &self) {
                      return synthLongestPathObjectName(self);
                    })
-      .def_prop_ro("bit_pos", [](SynthLongestPathObject &self) {
-        return synthLongestPathObjectBitPos(self);
+      .def_prop_ro("bit_pos",
+                   [](SynthLongestPathObject &self) {
+                     return synthLongestPathObjectBitPos(self);
+                   })
+      .def_prop_ro("value", [](SynthLongestPathObject &self) -> nb::object {
+        MlirValue value = synthLongestPathObjectGetValue(self);
+        if (!value.ptr)
+          return nb::none();
+        return nb::cast(value);
       });
 }

--- a/lib/Bindings/Python/dialects/synth.py
+++ b/lib/Bindings/Python/dialects/synth.py
@@ -5,9 +5,9 @@
 from . import synth, hw
 from ._synth_ops_gen import *
 from .._mlir_libs._circt._synth import _LongestPathAnalysis, _LongestPathCollection, _LongestPathDataflowPath, _LongestPathHistory, _LongestPathObject
-
+from ..ir import Value
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Optional
 
 # ============================================================================
 # Core Data Structures for Synth Longest Path Analysis
@@ -85,6 +85,16 @@ class Object:
     """Get the bit position for multi-bit signals."""
     return self._object.bit_pos
 
+  @property
+  def value(self) -> Optional[Value]:
+    """Get the MLIR value associated with this object, if any."""
+    return self._object.value
+
+  @property
+  def is_output_port(self) -> bool:
+    """Check if this object represents an output port."""
+    return self.value is None
+
 
 @dataclass
 class DebugPoint:
@@ -102,15 +112,6 @@ class DebugPoint:
   object: Object
   delay: int
   comment: str
-
-  @classmethod
-  def from_dict(cls, data: Dict[str, Any]) -> "DebugPoint":
-    """Create a DebugPoint from a dictionary representation."""
-    return cls(
-        object=Object.from_dict(data["object"]),
-        delay=data["delay"],
-        comment=data["comment"],
-    )
 
 
 @dataclass

--- a/lib/CAPI/Dialect/Synth.cpp
+++ b/lib/CAPI/Dialect/Synth.cpp
@@ -314,3 +314,11 @@ size_t synthLongestPathObjectBitPos(SynthLongestPathObject rawObject) {
     return object->bitPos;
   return std::get<2>(*dyn_cast<DataflowPath::OutputPort *>(ptr));
 }
+
+MlirValue synthLongestPathObjectGetValue(SynthLongestPathObject rawObject) {
+  auto ptr = unwrap(rawObject);
+  if (auto *object = dyn_cast<Object *>(ptr))
+    return wrap(object->value);
+  // Output ports don't have an associated value
+  return {nullptr};
+}

--- a/test/CAPI/synth.c
+++ b/test/CAPI/synth.c
@@ -120,6 +120,16 @@ void testLongestPathAnalysis(void) {
       // CHECK: StartPoint instance path size: 1
       // CHECK: EndPoint instance path size: 1
 
+      // Test value property
+      MlirValue startValue = synthLongestPathObjectGetValue(startPoint);
+      MlirValue endValue = synthLongestPathObjectGetValue(endPoint);
+      printf("StartPoint has value: %s\n",
+             !mlirValueIsNull(startValue) ? "true" : "false");
+      printf("EndPoint has value: %s\n",
+             !mlirValueIsNull(endValue) ? "true" : "false");
+      // CHECK: StartPoint has value: true
+      // CHECK: EndPoint has value: true
+
       // Test History API
       SynthLongestPathHistory history =
           synthLongestPathDataflowPathGetHistory(path);
@@ -167,6 +177,18 @@ void testLongestPathAnalysis(void) {
            synthLongestPathCollectionGetSize(collection4));
     // CHECK: Input-to-internal paths count: 0
     // CHECK-NEXT: Internal-to-output paths count: 2
+
+    // Test that output port endpoints have null values
+    if (synthLongestPathCollectionGetSize(collection4) > 0) {
+      SynthLongestPathDataflowPath outputPath =
+          synthLongestPathCollectionGetDataflowPath(collection4, 0);
+      SynthLongestPathObject outputEndPoint =
+          synthLongestPathDataflowPathGetEndPoint(outputPath);
+      MlirValue outputValue = synthLongestPathObjectGetValue(outputEndPoint);
+      printf("Output port endpoint has null value: %s\n",
+             mlirValueIsNull(outputValue) ? "true" : "false");
+      // CHECK-NEXT: Output port endpoint has null value: true
+    }
 
     printf("Path count before drop: %zu\n",
            synthLongestPathCollectionGetSize(collection1));


### PR DESCRIPTION
Add two properties to distinguish internal objects from output ports for LongestPathAnalysis
API. The value property returns the MLIR value for
internal objects or None for output ports. The is_output_port property
checks if an object represents a module output port by testing if value
is None.