### PR TITLE
[Tests][Arcilator] Move arcilator JIT tests to integration tests

### DIFF
--- a/integration_test/arcilator/JIT/args-multi-seq.mlir
+++ b/integration_test/arcilator/JIT/args-multi-seq.mlir
@@ -1,4 +1,5 @@
-// RUN: arcilator --run %s --jit-entry=entry --args=1,2 --args=3,4 | FileCheck %s
+// RUN: arcilator --run %s --jit-entry=entry --args=1,2 --args=3,4 | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
 
 module {
   func.func @entry(%arg0: i32, %arg1: i32) {

--- a/integration_test/arcilator/JIT/args.mlir
+++ b/integration_test/arcilator/JIT/args.mlir
@@ -1,4 +1,5 @@
-// RUN: arcilator --run %s --jit-entry=entry --args=0x10,0x1234567890ABCDEF1234567890ABC  | FileCheck %s
+// RUN: arcilator --run %s --jit-entry=entry --args=0x10,0x1234567890ABCDEF1234567890ABC  | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
 
 module {
   func.func @entry(%arg0: i32, %arg1: i116) {

--- a/integration_test/arcilator/JIT/emit-values.mlir
+++ b/integration_test/arcilator/JIT/emit-values.mlir
@@ -1,4 +1,6 @@
-// RUN: arcilator --run %s | FileCheck %s
+// RUN: arcilator --run %s | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
 module {
   func.func @entry() {
     // CHECK: a1 = 1


### PR DESCRIPTION
Move three recently added arcilator tests using the JIT runner from `test/arcilator` to `integration_test/arcilator/JIT` and align them with the existing tests in this directory.

This should unblock the musl libc release of firtool again (see #9260). It does not fix the underlying issue of `arc.sim.emit` apparently not working in this build. Arcilator is not actually shipped with this release of firtool and I'm currently not aware of any evidence that the JIT runs have ever been working in the statically linked musl build. 
