### PR TITLE
[Docs][NFC] Drop outdated hw comparison

### DIFF
--- a/docs/Dialects/HW/RationaleHW.md
+++ b/docs/Dialects/HW/RationaleHW.md
@@ -44,8 +44,7 @@ several major contributions:
  1) The `hw` dialect provides unifying structure and
     abstractions that are useful for a wide range of hardware modeling problems.
     It allows other dialects to "mix in" with it to provide higher level
-    functionality. `hw` is roughly akin to the "std" dialect in MLIR (but better
-    curated).
+    functionality.
  2) The `comb` dialect provides a common set of operations for combinational
     logic.  This dialect is designed to allow easy analysis and transformation.
  3) The `sv` dialect provides direct access to a wide variety


### PR DESCRIPTION
We still have a comparison between the `hw` dialect and the MLIR Standard dialect, which hasn't existed for a few years now [by the looks of things](https://discourse.llvm.org/t/standard-dialect-the-final-chapter/6061) (I believe most ops were distributed among other dialects, and the func dialect was created from the scraps)