### PR TITLE
[CombFolds] Fix crash in folding with non-integer attribute operands

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -830,17 +830,19 @@ OpFoldResult AndOp::fold(FoldAdaptor adaptor) {
 
   // and(x, 01, 10) -> 00 -- annulment.
   for (auto operand : inputs) {
-    if (!operand)
+    auto attr = dyn_cast_or_null<IntegerAttr>(operand);
+    if (!attr)
       continue;
-    value &= cast<IntegerAttr>(operand).getValue();
+    value &= attr.getValue();
     if (value.isZero())
       return getIntAttr(value, getContext());
   }
 
   // and(x, -1) -> x.
-  if (inputs.size() == 2 && inputs[1] &&
-      cast<IntegerAttr>(inputs[1]).getValue().isAllOnes())
-    return getInputs()[0];
+  if (inputs.size() == 2)
+    if (auto intAttr = dyn_cast_or_null<IntegerAttr>(inputs[1]))
+      if (intAttr.getValue().isAllOnes())
+        return getInputs()[0];
 
   // and(x, x, x) -> x.  This also handles and(x) -> x.
   if (llvm::all_of(getInputs(),
@@ -1115,17 +1117,19 @@ OpFoldResult OrOp::fold(FoldAdaptor adaptor) {
   auto inputs = adaptor.getInputs();
   // or(x, 10, 01) -> 11
   for (auto operand : inputs) {
-    if (!operand)
+    auto attr = dyn_cast_or_null<IntegerAttr>(operand);
+    if (!attr)
       continue;
-    value |= cast<IntegerAttr>(operand).getValue();
+    value |= attr.getValue();
     if (value.isAllOnes())
       return getIntAttr(value, getContext());
   }
 
   // or(x, 0) -> x
-  if (inputs.size() == 2 && inputs[1] &&
-      cast<IntegerAttr>(inputs[1]).getValue().isZero())
-    return getInputs()[0];
+  if (inputs.size() == 2)
+    if (auto intAttr = dyn_cast_or_null<IntegerAttr>(inputs[1]))
+      if (intAttr.getValue().isZero())
+        return getInputs()[0];
 
   // or(x, x, x) -> x.  This also handles or(x) -> x
   if (llvm::all_of(getInputs(),
@@ -1266,9 +1270,10 @@ OpFoldResult XorOp::fold(FoldAdaptor adaptor) {
     return IntegerAttr::get(getType(), 0);
 
   // xor(x, 0) -> x
-  if (inputs.size() == 2 && inputs[1] &&
-      cast<IntegerAttr>(inputs[1]).getValue().isZero())
-    return getInputs()[0];
+  if (inputs.size() == 2)
+    if (auto intAttr = dyn_cast_or_null<IntegerAttr>(inputs[1]))
+      if (intAttr.getValue().isZero())
+        return getInputs()[0];
 
   // xor(xor(x,1),1) -> x
   // but not self loop
@@ -1573,9 +1578,10 @@ OpFoldResult MulOp::fold(FoldAdaptor adaptor) {
 
   // mul(x, 0, 1) -> 0 -- annulment
   for (auto operand : inputs) {
-    if (!operand)
+    auto attr = dyn_cast_or_null<IntegerAttr>(operand);
+    if (!attr)
       continue;
-    value *= cast<IntegerAttr>(operand).getValue();
+    value *= attr.getValue();
     if (value.isZero())
       return getIntAttr(value, getContext());
   }

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -796,6 +796,21 @@ hw.module @fold_mux_tree1r(in %sel: i2, in %a: i8, in %b: i8, in %c: i8, in %d: 
   hw.output %5 : i8
 }
 
+// CHECK-LABEL: hw.module @parameter
+hw.module @parameter<in: i8> (in %a: i8, out o1: i8) {
+  %param = hw.param.value i8 = #hw.param.decl.ref<"in">
+  // CHECK-NEXT: %[[PARAM:.+]] = hw.param.value i8 = #hw.param.decl.ref<"in">
+  // CHECK-NEXT: comb.and %a, %[[PARAM]]
+  // CHECK-NEXT: comb.or %a, %[[PARAM]]
+  // CHECK-NEXT: comb.xor %a, %[[PARAM]]
+  // CHECK-NEXT: comb.mul %a, %[[PARAM]]
+  %0 = comb.and %a, %param : i8
+  %1 = comb.or %a, %param : i8
+  %2 = comb.xor %a, %param : i8
+  %3 = comb.mul %a, %param : i8
+  %result = comb.add %0, %1, %2, %3 : i8
+  hw.output %result : i8
+}
 
 // CHECK-LABEL: hw.module @fold_mux_tree2
 // This is a sparse tree with 5/8ths load.


### PR DESCRIPTION
This patch fixes a crash in the folding logic for `comb.and`, `comb.or`, `comb.xor`, and `comb.mul` operations. Previously, the code blindly cast operands to `IntegerAttr` without checking, which caused assertions or crashes when the operands were constant-like but not `IntegerAttr`, such as `hw.param.value`.

The fix involves using `dyn_cast_or_null<IntegerAttr>` to safely check the operand type before accessing its value.