### PR TITLE
[circt-test] Add simulation test discovery

### DIFF
--- a/test/circt-test/basic.mlir
+++ b/test/circt-test/basic.mlir
@@ -13,10 +13,20 @@
 // JSON-NEXT:   "name": "Some.TestB"
 // JSON-NEXT:   "kind": "formal"
 // JSON-NEXT: }
+// JSON-NEXT: {
+// JSON-NEXT:   "name": "Some.TestC"
+// JSON-NEXT:   "kind": "simulation"
+// JSON-NEXT: }
 // CHECK: Some.TestA formal {}
 // CHECK: Some.TestB formal {}
+// CHECK: Some.TestC simulation {}
 verif.formal @Some.TestA {} {}
 verif.formal @Some.TestB {} {}
+verif.simulation @Some.TestC {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %0 = hw.constant true
+  verif.yield %0, %0 : i1, i1
+}
 
 // JSON-NEXT: {
 // JSON-NEXT:   "name": "Attrs"

--- a/tools/circt-test/CMakeLists.txt
+++ b/tools/circt-test/CMakeLists.txt
@@ -1,23 +1,21 @@
+get_property(dialect_libs GLOBAL PROPERTY CIRCT_DIALECT_LIBS)
+
 set(libs
-  CIRCTComb
+  ${dialect_libs}
+
   CIRCTExportVerilog
-  CIRCTHW
-  CIRCTOM
-  CIRCTSeq
   CIRCTSeqToSV
-  CIRCTSim
   CIRCTSimToSV
-  CIRCTSV
   CIRCTSVTransforms
-  CIRCTVerif
   CIRCTVerifToSV
   CIRCTVerifTransforms
 
-  MLIRLLVMDialect
   MLIRArithDialect
   MLIRControlFlowDialect
   MLIRFuncDialect
+  MLIRLLVMDialect
   MLIRSCFDialect
+  MLIRSMT
 
   MLIRBytecodeReader
   MLIRIR


### PR DESCRIPTION
When looking for tests in an MLIR module, consider `verif.simulation` ops as simulation tests and include them in the test suite. This allows the tool to discover and list simulation tests. Later, we'll want it to be able to execute simulations as well.