### PR TITLE
[circt-reduce] Support dialect plugins

### DIFF
--- a/tools/circt-reduce/CMakeLists.txt
+++ b/tools/circt-reduce/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBS
   MLIRIR
   MLIRBytecodeWriter
   MLIRParser
+  MLIRPluginsLib
   MLIRSupport
   MLIRTransforms
   MLIRReduceLib

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -21,13 +21,16 @@
 #include "circt/Reduce/Tester.h"
 #include "circt/Support/Version.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Support/FileUtilities.h"
+#include "mlir/Tools/Plugins/DialectPlugin.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/InitLLVM.h"
@@ -138,6 +141,11 @@ static cl::opt<bool> testMustFail(
     "test-must-fail", cl::init(false),
     cl::desc("Consider an input to be interesting on non-zero exit status."),
     cl::cat(mainCategory));
+
+static cl::list<std::string>
+    dialectPlugins("load-dialect-plugin",
+                   cl::desc("Load dialects from plugin library"),
+                   cl::cat(mainCategory));
 
 //===----------------------------------------------------------------------===//
 // Tool Implementation
@@ -514,6 +522,28 @@ int main(int argc, char **argv) {
   // llvm/circt and not llvm/llvm-project.
   setBugReportMsg(circtBugReportMsg);
 
+  // Register all the dialects.
+  mlir::DialectRegistry registry;
+  registerAllDialects(registry);
+  registry
+      .insert<func::FuncDialect, scf::SCFDialect, cf::ControlFlowDialect,
+              LLVM::LLVMDialect, index::IndexDialect, arith::ArithDialect>();
+  arc::registerReducePatternDialectInterface(registry);
+  emit::registerReducePatternDialectInterface(registry);
+  firrtl::registerReducePatternDialectInterface(registry);
+  hw::registerReducePatternDialectInterface(registry);
+
+  // Set up dialect plugin loading callback
+  dialectPlugins.setCallback([&](const std::string &pluginPath) {
+    auto plugin = mlir::DialectPlugin::load(pluginPath);
+    if (!plugin) {
+      llvm::errs() << "Failed to load dialect plugin from '" << pluginPath
+                   << "'. Request ignored.\n";
+      return;
+    }
+    plugin.get().registerDialectRegistryCallbacks(registry);
+  });
+
   // Register and hide default LLVM options, other than for this tool.
   registerMLIRContextCLOptions();
   registerAsmPrinterCLOptions();
@@ -521,16 +551,6 @@ int main(int argc, char **argv) {
 
   // Parse the command line options provided by the user.
   cl::ParseCommandLineOptions(argc, argv, "CIRCT test case reduction tool\n");
-
-  // Register all the dialects.
-  mlir::DialectRegistry registry;
-  registerAllDialects(registry);
-  registry.insert<func::FuncDialect, scf::SCFDialect, cf::ControlFlowDialect,
-                  LLVM::LLVMDialect>();
-  arc::registerReducePatternDialectInterface(registry);
-  emit::registerReducePatternDialectInterface(registry);
-  firrtl::registerReducePatternDialectInterface(registry);
-  hw::registerReducePatternDialectInterface(registry);
 
   // Create a context.
   mlir::MLIRContext context(registry);


### PR DESCRIPTION
This allows non-circt or mlir upstream dialects to be supported by circt-reduce including dialect plugins registering their own reduction patterns.

Also register index and arith dialects.