### PR TITLE
[Firtool] Add FlattenModules pass with command-line options

### DIFF
--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -393,6 +393,57 @@ public:
     return *this;
   }
 
+  // HW FlattenModules options getters
+  bool shouldEnableHWFlattenModules() const { return enableHWFlattenModules; }
+  bool getHWInlineEmpty() const { return hwInlineEmpty; }
+  bool getHWInlineNoOutputs() const { return hwInlineNoOutputs; }
+  bool getHWInlineSingleUse() const { return hwInlineSingleUse; }
+  bool getHWInlineSmall() const { return hwInlineSmall; }
+  unsigned getHWSmallThreshold() const { return hwSmallThreshold; }
+  bool getHWInlineWithState() const { return hwInlineWithState; }
+  bool getHWInlineAll() const { return hwInlineAll; }
+
+  // HW FlattenModules options setters
+  FirtoolOptions &setEnableHWFlattenModules(bool value) {
+    enableHWFlattenModules = value;
+    return *this;
+  }
+
+  FirtoolOptions &setHWInlineEmpty(bool value) {
+    hwInlineEmpty = value;
+    return *this;
+  }
+
+  FirtoolOptions &setHWInlineNoOutputs(bool value) {
+    hwInlineNoOutputs = value;
+    return *this;
+  }
+
+  FirtoolOptions &setHWInlineSingleUse(bool value) {
+    hwInlineSingleUse = value;
+    return *this;
+  }
+
+  FirtoolOptions &setHWInlineSmall(bool value) {
+    hwInlineSmall = value;
+    return *this;
+  }
+
+  FirtoolOptions &setHWSmallThreshold(unsigned value) {
+    hwSmallThreshold = value;
+    return *this;
+  }
+
+  FirtoolOptions &setHWInlineWithState(bool value) {
+    hwInlineWithState = value;
+    return *this;
+  }
+
+  FirtoolOptions &setHWInlineAll(bool value) {
+    hwInlineAll = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
 
@@ -447,6 +498,16 @@ private:
   bool lintStaticAsserts;
   bool lintXmrsInDesign;
   bool emitAllBindFiles;
+
+  // HW FlattenModules options
+  bool enableHWFlattenModules;
+  bool hwInlineEmpty;
+  bool hwInlineNoOutputs;
+  bool hwInlineSingleUse;
+  bool hwInlineSmall;
+  unsigned hwSmallThreshold;
+  bool hwInlineWithState;
+  bool hwInlineAll;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -294,6 +294,17 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
     modulePM.addPass(createSimpleCanonicalizerPass());
   }
 
+  if (opt.shouldEnableHWFlattenModules()) {
+    pm.addPass(circt::hw::createFlattenModules(
+        {/*inlineEmpty=*/opt.getHWInlineEmpty(),
+         /*inlineNoOutputs=*/opt.getHWInlineNoOutputs(),
+         /*inlineSingleUse=*/opt.getHWInlineSingleUse(),
+         /*inlineSmall=*/opt.getHWInlineSmall(),
+         /*smallThreshold=*/opt.getHWSmallThreshold(),
+         /*inlineWithState=*/opt.getHWInlineWithState(),
+         /*inlineAll=*/opt.getHWInlineAll()}));
+  }
+
   // Check inner symbols and inner refs.
   pm.addPass(hw::createVerifyInnerRefNamespace());
 
@@ -759,6 +770,54 @@ struct FirtoolCmdOptions {
       llvm::cl::init(false)};
 
   //===----------------------------------------------------------------------===
+  // HW FlattenModules options
+  //===----------------------------------------------------------------------===
+
+  llvm::cl::opt<bool> hwInlineEmpty{
+      "hw-inline-empty",
+      llvm::cl::desc("Inline modules that are empty (only contain hw.output)"),
+      llvm::cl::init(true)};
+
+  llvm::cl::opt<bool> hwInlineNoOutputs{
+      "hw-inline-no-outputs",
+      llvm::cl::desc("Inline modules that have no output ports"),
+      llvm::cl::init(false)};
+
+  llvm::cl::opt<bool> hwInlineSingleUse{
+      "hw-inline-single-use",
+      llvm::cl::desc("Inline modules that have only one use"),
+      llvm::cl::init(false)};
+
+  llvm::cl::opt<bool> hwInlineSmall{
+      "hw-inline-small",
+      llvm::cl::desc("Inline modules that are small (fewer than smallThreshold "
+                     "operations)"),
+      llvm::cl::init(false)};
+
+  llvm::cl::opt<unsigned> hwSmallThreshold{
+      "hw-small-threshold",
+      llvm::cl::desc(
+          "Maximum number of operations for a module to be considered small"),
+      llvm::cl::init(8)};
+
+  llvm::cl::opt<bool> hwInlineWithState{
+      "hw-inline-with-state",
+      llvm::cl::desc("Allow inlining of modules that contain state (seq.firreg "
+                     "operations)"),
+      llvm::cl::init(false)};
+
+  llvm::cl::opt<bool> hwInlineAll{
+      "hw-inline-all",
+      llvm::cl::desc("Inline all private modules regardless of heuristics "
+                     "(default behavior)"),
+      llvm::cl::init(false)};
+
+  llvm::cl::opt<bool> enableHWFlattenModules{
+      "enable-hw-flatten-modules",
+      llvm::cl::desc("Enable the HW flatten modules pass"),
+      llvm::cl::init(false)};
+
+  //===----------------------------------------------------------------------===
   // Lint options
   //===----------------------------------------------------------------------===
 
@@ -809,7 +868,10 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       disableCSEinClasses(false), selectDefaultInstanceChoice(false),
       symbolicValueLowering(verif::SymbolicValueLowering::ExtModule),
       disableWireElimination(false), lintStaticAsserts(true),
-      lintXmrsInDesign(true), emitAllBindFiles(false) {
+      lintXmrsInDesign(true), emitAllBindFiles(false),
+      enableHWFlattenModules(false), hwInlineEmpty(true),
+      hwInlineNoOutputs(false), hwInlineSingleUse(false), hwInlineSmall(false),
+      hwSmallThreshold(8), hwInlineWithState(false), hwInlineAll(false) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -862,4 +924,12 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   lintStaticAsserts = clOptions->lintStaticAsserts;
   lintXmrsInDesign = clOptions->lintXmrsInDesign;
   emitAllBindFiles = clOptions->emitAllBindFiles;
+  enableHWFlattenModules = clOptions->enableHWFlattenModules;
+  hwInlineEmpty = clOptions->hwInlineEmpty;
+  hwInlineNoOutputs = clOptions->hwInlineNoOutputs;
+  hwInlineSingleUse = clOptions->hwInlineSingleUse;
+  hwInlineSmall = clOptions->hwInlineSmall;
+  hwSmallThreshold = clOptions->hwSmallThreshold;
+  hwInlineWithState = clOptions->hwInlineWithState;
+  hwInlineAll = clOptions->hwInlineAll;
 }

--- a/test/firtool/hw-flatten-modules.fir
+++ b/test/firtool/hw-flatten-modules.fir
@@ -1,0 +1,114 @@
+; Test the --enable-hw-flatten-modules flag and related options
+
+; RUN: firtool %s --ir-hw | FileCheck %s --check-prefix=DISABLED
+; RUN: firtool %s --ir-hw --enable-hw-flatten-modules | FileCheck %s --check-prefix=ENABLED-DEFAULT
+; RUN: firtool %s --ir-hw --enable-hw-flatten-modules --hw-inline-all | FileCheck %s --check-prefix=INLINE-ALL
+; RUN: firtool %s --ir-hw --enable-hw-flatten-modules --hw-inline-single-use | FileCheck %s --check-prefix=INLINE-SINGLE-USE
+; RUN: firtool %s --ir-hw --enable-hw-flatten-modules --hw-inline-small --hw-small-threshold=3 | FileCheck %s --check-prefix=INLINE-SMALL
+; RUN: firtool %s --ir-hw --enable-hw-flatten-modules --hw-inline-empty=false | FileCheck %s --check-prefix=NO-INLINE-EMPTY
+
+FIRRTL version 4.0.0
+
+circuit Top :
+  ; Private module that is empty (only has output, passes through input)
+  module EmptyChild :
+    input x : UInt<4>
+    output y : UInt<4>
+    connect y, x
+
+  ; Private module with single use
+  module SingleUseChild :
+    input a : UInt<4>
+    output b : UInt<4>
+    node temp = add(a, a)
+    connect b, temp
+
+  ; Private module with multiple uses
+  module MultiUseChild :
+    input p : UInt<4>
+    output q : UInt<4>
+    node result = mul(p, p)
+    connect q, result
+
+  public module Top :
+    input in : UInt<4>
+    output out : UInt<4>
+
+    inst empty of EmptyChild
+    connect empty.x, in
+
+    inst single of SingleUseChild
+    connect single.a, empty.y
+
+    inst multi1 of MultiUseChild
+    connect multi1.p, single.b
+
+    inst multi2 of MultiUseChild
+    connect multi2.p, single.b
+
+    node sum = add(multi1.q, multi2.q)
+    connect out, sum
+
+; When disabled, all modules should be present
+; DISABLED-LABEL: hw.module private @EmptyChild
+; DISABLED-LABEL: hw.module private @SingleUseChild
+; DISABLED-LABEL: hw.module private @MultiUseChild
+; DISABLED-LABEL: hw.module @Top
+; DISABLED: hw.instance "empty" @EmptyChild
+; DISABLED: hw.instance "single" @SingleUseChild
+; DISABLED: hw.instance "multi1" @MultiUseChild
+; DISABLED: hw.instance "multi2" @MultiUseChild
+
+; When enabled with default options (hwInlineEmpty=true by default), EmptyChild should be inlined
+; ENABLED-DEFAULT-NOT: hw.module private @EmptyChild
+; ENABLED-DEFAULT-LABEL: hw.module private @SingleUseChild
+; ENABLED-DEFAULT-LABEL: hw.module private @MultiUseChild
+; ENABLED-DEFAULT-LABEL: hw.module @Top
+; ENABLED-DEFAULT-NOT: hw.instance "empty"
+; ENABLED-DEFAULT: hw.instance "single" @SingleUseChild
+; ENABLED-DEFAULT: hw.instance "multi1" @MultiUseChild
+; ENABLED-DEFAULT: hw.instance "multi2" @MultiUseChild
+
+; When --hw-inline-all is set, all private modules should be inlined
+; INLINE-ALL-NOT: hw.module private @EmptyChild
+; INLINE-ALL-NOT: hw.module private @SingleUseChild
+; INLINE-ALL-NOT: hw.module private @MultiUseChild
+; INLINE-ALL-LABEL: hw.module @Top
+; INLINE-ALL-NOT: hw.instance "empty"
+; INLINE-ALL-NOT: hw.instance "single"
+; INLINE-ALL-NOT: hw.instance "multi1"
+; INLINE-ALL-NOT: hw.instance "multi2"
+
+; When --hw-inline-single-use is set, SingleUseChild and EmptyChild should be inlined
+; (EmptyChild is also single-use and hwInlineEmpty=true by default)
+; INLINE-SINGLE-USE-NOT: hw.module private @EmptyChild
+; INLINE-SINGLE-USE-NOT: hw.module private @SingleUseChild
+; INLINE-SINGLE-USE-LABEL: hw.module private @MultiUseChild
+; INLINE-SINGLE-USE-LABEL: hw.module @Top
+; INLINE-SINGLE-USE-NOT: hw.instance "empty"
+; INLINE-SINGLE-USE-NOT: hw.instance "single"
+; INLINE-SINGLE-USE: hw.instance "multi1" @MultiUseChild
+; INLINE-SINGLE-USE: hw.instance "multi2" @MultiUseChild
+
+; When --hw-inline-small is set with threshold=3, MultiUseChild should be inlined (has 2 ops)
+; but SingleUseChild should not (has 4 ops: constant, extract, concat, output)
+; EmptyChild should still be inlined (hwInlineEmpty=true by default)
+; INLINE-SMALL-NOT: hw.module private @EmptyChild
+; INLINE-SMALL-LABEL: hw.module private @SingleUseChild
+; INLINE-SMALL-NOT: hw.module private @MultiUseChild
+; INLINE-SMALL-LABEL: hw.module @Top
+; INLINE-SMALL-NOT: hw.instance "empty"
+; INLINE-SMALL: hw.instance "single" @SingleUseChild
+; INLINE-SMALL-NOT: hw.instance "multi1"
+; INLINE-SMALL-NOT: hw.instance "multi2"
+
+; When --hw-inline-empty=false is explicitly set, EmptyChild should NOT be inlined
+; NO-INLINE-EMPTY-LABEL: hw.module private @EmptyChild
+; NO-INLINE-EMPTY-LABEL: hw.module private @SingleUseChild
+; NO-INLINE-EMPTY-LABEL: hw.module private @MultiUseChild
+; NO-INLINE-EMPTY-LABEL: hw.module @Top
+; NO-INLINE-EMPTY: hw.instance "empty" @EmptyChild
+; NO-INLINE-EMPTY: hw.instance "single" @SingleUseChild
+; NO-INLINE-EMPTY: hw.instance "multi1" @MultiUseChild
+; NO-INLINE-EMPTY: hw.instance "multi2" @MultiUseChild
+


### PR DESCRIPTION
This PR adds the FlattenModules pass invocation to the `FIRRTLToHW` pipeline.

Changes in this PR:
- Add `--enable-hw-flatten-modules` flag to control the pass, defaulting to disabled
- Expose all 8 `FlattenModules` options with `--hw-inline-empty` defaulting to true
- Added comprehensive lit test with 6 test cases covering all major options