### PR TITLE
[CI] Disable flaky Verilog LSP tests on macOS

### DIFF
--- a/unittests/Tools/circt-verilog-lsp-server/Utils/PendingChangesTest.cpp
+++ b/unittests/Tools/circt-verilog-lsp-server/Utils/PendingChangesTest.cpp
@@ -67,6 +67,11 @@ makeChangeParams(llvm::StringRef memName, int64_t version,
 
 /// Check that changes are done immediately if debounce is disabled
 TEST(PendingChangesMapTest, ImmediateFlushWhenDisabled) {
+#if defined(__APPLE__)
+  // See https://github.com/llvm/circt/issues/9292.
+  GTEST_SKIP() << "flaky on macOS";
+#endif
+
   PendingChangesMap pcm(/*maxThreads=*/2);
   DebounceOptions opt;
   opt.disableDebounce = true;
@@ -89,6 +94,11 @@ TEST(PendingChangesMapTest, ImmediateFlushWhenDisabled) {
 
 /// Check that changes are applied once debounce delay window is passed
 TEST(PendingChangesMapTest, FlushAfterQuietMinWindow) {
+#if defined(__APPLE__)
+  // See https://github.com/llvm/circt/issues/9292.
+  GTEST_SKIP() << "flaky on macOS";
+#endif
+
   PendingChangesMap pcm(2);
   DebounceOptions opt;
   opt.disableDebounce = false;
@@ -115,6 +125,11 @@ TEST(PendingChangesMapTest, FlushAfterQuietMinWindow) {
 
 /// Check that outdated edits are not applied and the thread is discarded.
 TEST(PendingChangesMapTest, ObsoleteWhenNewerEditsArrive) {
+#if defined(__APPLE__)
+  // See https://github.com/llvm/circt/issues/9292.
+  GTEST_SKIP() << "flaky on macOS";
+#endif
+
   PendingChangesMap pcm(2);
   DebounceOptions opt;
   opt.disableDebounce = false;
@@ -153,6 +168,11 @@ TEST(PendingChangesMapTest, ObsoleteWhenNewerEditsArrive) {
 }
 
 TEST(PendingChangesMapTest, MaxCapForcesFlushDuringContinuousTyping) {
+#if defined(__APPLE__)
+  // See https://github.com/llvm/circt/issues/9292.
+  GTEST_SKIP() << "flaky on macOS";
+#endif
+
   PendingChangesMap pcm(2);
   DebounceOptions opt;
   opt.disableDebounce = false;
@@ -195,6 +215,11 @@ TEST(PendingChangesMapTest, MaxCapForcesFlushDuringContinuousTyping) {
 
 /// Check that no update is queued if the change map is empty.
 TEST(PendingChangesMapTest, MissingKeyYieldsNullptr) {
+#if defined(__APPLE__)
+  // See https://github.com/llvm/circt/issues/9292.
+  GTEST_SKIP() << "flaky on macOS";
+#endif
+
   PendingChangesMap pcm(2);
   DebounceOptions opt;
   opt.disableDebounce = false;
@@ -214,6 +239,11 @@ TEST(PendingChangesMapTest, MissingKeyYieldsNullptr) {
 }
 
 TEST(PendingChangesMapTest, EraseByKeyAndUriAreIdempotent) {
+#if defined(__APPLE__)
+  // See https://github.com/llvm/circt/issues/9292.
+  GTEST_SKIP() << "flaky on macOS";
+#endif
+
   PendingChangesMap pcm(/*maxThreads=*/2);
 
   DebounceOptions opt;
@@ -267,6 +297,11 @@ TEST(PendingChangesMapTest, EraseByKeyAndUriAreIdempotent) {
 }
 
 TEST(PendingChangesMapTest, AbortClearsAll) {
+#if defined(__APPLE__)
+  // See https://github.com/llvm/circt/issues/9292.
+  GTEST_SKIP() << "flaky on macOS";
+#endif
+
   PendingChangesMap pcm(2);
 
   // Debounced path to also cover the async branch


### PR DESCRIPTION
Disable the PendingChangesTest of the Verilog LSP on macOS. These tend to fail arbitrarily during the release artifact upload CI job, and rerunning the job will get them to pass. Tracking this in #9292.