### PR TITLE
[circt-synth] Disable test if yosys-abc unavailable

### DIFF
--- a/integration_test/circt-synth/abc.mlir
+++ b/integration_test/circt-synth/abc.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: yosys
+// REQUIRES: yosys-abc
 // RUN: circt-synth %s -abc-path %yosys-abc -abc-commands "balance" -top balanceTest | FileCheck %s
 // RUN: circt-opt %s --pass-pipeline='builtin.module(hw.module(synth-abc-runner{abc-path=%yosys-abc abc-commands="balance"}))' | FileCheck %s
 

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -99,6 +99,8 @@ if config.yosys_path != "":
   yosys_abc_path = os.path.join(yosys_dir, "yosys-abc")
   config.substitutions.append(('%yosys-abc', f'"{yosys_abc_path}"'))
   config.available_features.add('yosys')
+  if os.path.exists(yosys_abc_path):
+    config.available_features.add('yosys-abc')
 
 # Enable Icarus Verilog as a fallback if no other ieee-sim was detected.
 if config.iverilog_path != "":


### PR DESCRIPTION
I ran into a situation on my machine where yosys was installed, but yosys-abc was not. Since the `circt-synth/abc.mlir` test only requires yosys-abc, add a separate feature flag and perform and additional check to see if yosys-abc is installed alongside yosys. If it is not, disable that test.