### PR TITLE
[FIRRTL] Add anonymous domain create op

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -791,9 +791,7 @@ def DomainCreateAnonOp : FIRRTLOp<"domain.anon", [
   let summary = "Create an anonymous domain, without parameters set";
   let arguments = (ins FlatSymbolRefAttr:$domain);
   let results = (outs DomainType:$result);
-  let assemblyFormat = [{
-    $domain attr-dict-with-keyword `:` type($result)
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLDECLARATIONS_TD

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -110,6 +110,7 @@ struct Emitter {
   void emitStatement(RefReleaseInitialOp op);
   void emitStatement(LayerBlockOp op);
   void emitStatement(GenericIntrinsicOp op);
+  void emitStatement(DomainCreateAnonOp op);
 
   template <class T>
   void emitVerifStatement(T op, StringRef mnemonic);
@@ -755,7 +756,8 @@ void Emitter::emitStatementsInBlock(Block &block) {
               CombMemOp, MemoryPortOp, MemoryDebugPortOp, MemoryPortAccessOp,
               DomainDefineOp, RefDefineOp, RefForceOp, RefForceInitialOp,
               RefReleaseOp, RefReleaseInitialOp, LayerBlockOp,
-              GenericIntrinsicOp>([&](auto op) { emitStatement(op); })
+              GenericIntrinsicOp, DomainCreateAnonOp>(
+            [&](auto op) { emitStatement(op); })
         .Default([&](auto op) {
           startStatement();
           ps << "// operation " << PPExtString(op->getName().getStringRef());
@@ -1285,6 +1287,10 @@ void Emitter::emitStatement(MemoryPortAccessOp op) {
 }
 
 void Emitter::emitStatement(DomainDefineOp op) {
+  // If the source is an anonymous domain, then we can skip emitting this op.
+  if (isa_and_nonnull<DomainCreateAnonOp>(op.getSrc().getDefiningOp()))
+    return;
+
   startStatement();
   emitAssignLike([&]() { emitExpression(op.getDest()); },
                  [&]() { emitExpression(op.getSrc()); }, PPExtString("="),
@@ -1390,6 +1396,10 @@ void Emitter::emitStatement(GenericIntrinsicOp op) {
                    [&]() { emitGenericIntrinsic(op); });
   }
   emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(DomainCreateAnonOp op) {
+  // These ops are not emitted.
 }
 
 void Emitter::emitExpression(Value value) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4250,6 +4250,8 @@ static FlatSymbolRefAttr getDomainTypeName(Value value) {
       return getDomainTypeNameOfResult(instance, result.getResultNumber());
     if (auto instance = dyn_cast<InstanceChoiceOp>(op))
       return getDomainTypeNameOfResult(instance, result.getResultNumber());
+    if (auto anonDomain = dyn_cast<DomainCreateAnonOp>(op))
+      return anonDomain.getDomainAttr();
     return {};
   }
 
@@ -7027,6 +7029,30 @@ LogicalResult BindOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
 //===----------------------------------------------------------------------===//
 // Domain operations
 //===----------------------------------------------------------------------===//
+
+void DomainCreateAnonOp::print(OpAsmPrinter &p) {
+  p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"domain"});
+  p << " : ";
+  p.printType(getType());
+  p << " of ";
+  p.printAttributeWithoutType(getDomainAttr());
+}
+
+ParseResult DomainCreateAnonOp::parse(OpAsmParser &parser,
+                                      OperationState &result) {
+  Type type;
+  StringAttr domainKind;
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(type) || parser.parseKeyword("of") ||
+      parser.parseSymbolName(domainKind))
+    return failure();
+
+  auto domain = FlatSymbolRefAttr::get(result.getContext(), domainKind);
+  result.getOrAddProperties<Properties>().setDomain(domain);
+  result.addTypes(type);
+
+  return success();
+}
 
 LogicalResult
 DomainCreateAnonOp::verifySymbolUses(SymbolTableCollection &symbolTable) {

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -1009,4 +1009,20 @@ firrtl.circuit "Foo" {
     firrtl.domain.define %O, %ext_O
   }
 
+  // Test that anonymous domain create ops and their defines are elided.
+  firrtl.extmodule @AnonymousDomains_Foo(
+    in A: !firrtl.domain of @ClockDomain
+  )
+  // CHECK-LABEL: module AnonymousDomains :
+  firrtl.module @AnonymousDomains() {
+    // CHECK-NEXT: inst foo of AnonymousDomains_Foo
+    %0 = firrtl.domain.anon : !firrtl.domain of @ClockDomain
+    %foo_A = firrtl.instance foo @AnonymousDomains_Foo(
+      in A: !firrtl.domain of @ClockDomain
+    )
+    firrtl.domain.define %foo_A, %0
+    // CHECK-NEXT: wire end : UInt<1>
+    %end = firrtl.wire : !firrtl.uint<1>
+  }
+
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -3205,7 +3205,7 @@ firrtl.circuit "AnonDomainPointingAtNonDomain" {
   firrtl.extmodule @Foo()
   firrtl.module @UndefinedDomainInAnonDomain() {
     // expected-error @below {{references undefined domain '@Foo'}}
-    %0 = firrtl.domain.anon @Foo : !firrtl.domain
+    %0 = firrtl.domain.anon : !firrtl.domain of @Foo
   }
 }
 
@@ -3214,6 +3214,6 @@ firrtl.circuit "AnonDomainPointingAtNonDomain" {
 firrtl.circuit "UndefinedDomainInAnonDomain" {
   firrtl.module @UndefinedDomainInAnonDomain() {
     // expected-error @below {{references undefined domain '@Foo'}}
-    %0 = firrtl.domain.anon @Foo : !firrtl.domain
+    %0 = firrtl.domain.anon : !firrtl.domain of @Foo
   }
 }

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -277,9 +277,15 @@ firrtl.module @InstanceChoiceWithDomain(in %A: !firrtl.domain of @ClockDomain, i
 }
 
 // CHECK-LABEL: firrtl.module @CreateAnonDomain
+firrtl.extmodule @CreateAnonDomainChild(in A: !firrtl.domain of @ClockDomain)
 firrtl.module @CreateAnonDomain() {
-  // CHECK-NEXT: %0 = firrtl.domain.anon @ClockDomain : !firrtl.domain
-  %0 = firrtl.domain.anon @ClockDomain : !firrtl.domain
+  // CHECK-NEXT: %0 = firrtl.domain.anon : !firrtl.domain of @ClockDomain
+  %0 = firrtl.domain.anon : !firrtl.domain of @ClockDomain
+  %child_A = firrtl.instance child @CreateAnonDomainChild(
+    in A: !firrtl.domain of @ClockDomain
+  )
+  // CHECK: firrtl.domain.define %child_A, %0
+  firrtl.domain.define %child_A, %0
 }
 
 }


### PR DESCRIPTION
Add an anonymous domain create operation.  This is used to model domains
that are fully self-contained within a FIRRTL circuit and are not
reachable from any external port.
