### PR TITLE
[FIRRTL] Remove -allow-adding-ports-on-public-modules.

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -85,9 +85,6 @@ MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableAnnotationsClassless(
 MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetLowerAnnotationsNoRefTypePorts(
     CirctFirtoolFirtoolOptions options, bool value);
 
-MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetAllowAddingPortsOnPublic(
-    CirctFirtoolFirtoolOptions options, bool value);
-
 MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetPreserveAggregate(
     CirctFirtoolFirtoolOptions options,
     CirctFirtoolPreserveAggregateMode value);

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -39,8 +39,6 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
       "Ignore unknown annotations.">,
     Option<"noRefTypePorts", "no-ref-type-ports", "bool", "false",
       "Create normal ports, not ref type ports.">,
-    Option<"allowAddingPortsOnPublic", "allow-adding-ports-on-public-modules", "bool", "false",
-      "Allow public modules to gain additional ports as a result of wiring.">,
   ];
   let dependentDialects = ["hw::HWDialect"];
   let statistics = [
@@ -54,8 +52,6 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
       "Number of unhandled annotations">,
     Statistic<"numReusedHierPathOps", "num-reused-hierpath",
       "Number of reused HierPathOp's">,
-    Statistic<"numPublicPortsWired", "num-public-ports-wired",
-      "Number of ports on public modules added due to wiring">,
   ];
 }
 

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -89,9 +89,6 @@ public:
   bool shouldLowerNoRefTypePortAnnotations() const {
     return lowerAnnotationsNoRefTypePorts;
   }
-  bool shouldAllowAddingPortsOnPublic() const {
-    return allowAddingPortsOnPublic;
-  }
   bool shouldConvertProbesToSignals() const { return probesToSignals; }
   bool shouldReplaceSequentialMemories() const { return replSeqMem; }
   bool shouldDisableLayerSink() const { return disableLayerSink; }
@@ -162,11 +159,6 @@ public:
 
   FirtoolOptions &setLowerAnnotationsNoRefTypePorts(bool value) {
     lowerAnnotationsNoRefTypePorts = value;
-    return *this;
-  }
-
-  FirtoolOptions &setAllowAddingPortsOnPublic(bool value) {
-    allowAddingPortsOnPublic = value;
     return *this;
   }
 
@@ -400,7 +392,6 @@ private:
   bool disableAnnotationsUnknown;
   bool disableAnnotationsClassless;
   bool lowerAnnotationsNoRefTypePorts;
-  bool allowAddingPortsOnPublic;
 
   bool probesToSignals;
   firrtl::PreserveAggregate::PreserveMode preserveAggregate;

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -51,11 +51,6 @@ void circtFirtoolOptionsSetLowerAnnotationsNoRefTypePorts(
   unwrap(options)->setLowerAnnotationsNoRefTypePorts(value);
 }
 
-void circtFirtoolOptionsSetAllowAddingPortsOnPublic(
-    CirctFirtoolFirtoolOptions options, bool value) {
-  unwrap(options)->setAllowAddingPortsOnPublic(value);
-}
-
 void circtFirtoolOptionsSetPreserveAggregate(
     CirctFirtoolFirtoolOptions options,
     CirctFirtoolPreserveAggregateMode value) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -1068,14 +1068,11 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
         auto inst = cast<InstanceOp>(*instNode);
         auto mod = inst.getReferencedModule<FModuleOp>(instanceGraph);
         if (mod.isPublic()) {
-          if (!allowAddingPortsOnPublic) {
-            auto diag = emitError(
-                mod.getLoc(), "cannot wire port through this public module");
-            diag.attachNote(source.getLoc()) << "source here";
-            diag.attachNote(sink.getLoc()) << "sink here";
-            return diag;
-          }
-          ++numPublicPortsWired;
+          auto diag = emitError(mod.getLoc(),
+                                "cannot wire port through this public module");
+          diag.attachNote(source.getLoc()) << "source here";
+          diag.attachNote(sink.getLoc()) << "sink here";
+          return diag;
         }
         if (name.empty()) {
           if (problem.newNameHint.empty())

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -37,8 +37,7 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerFIRRTLAnnotations(
       {/*ignoreAnnotationClassless=*/opt.shouldDisableClasslessAnnotations(),
        /*ignoreAnnotationUnknown=*/opt.shouldDisableUnknownAnnotations(),
-       /*noRefTypePorts=*/opt.shouldLowerNoRefTypePortAnnotations(),
-       /*allowAddingPortsOnPublic=*/opt.shouldAllowAddingPortsOnPublic()}));
+       /*noRefTypePorts=*/opt.shouldLowerNoRefTypePortAnnotations()}));
 
   if (opt.shouldEnableDebugInfo())
     pm.nest<firrtl::CircuitOp>().addNestedPass<firrtl::FModuleOp>(
@@ -482,11 +481,6 @@ struct FirtoolCmdOptions {
           "wiring problems inside the LowerAnnotations pass"),
       llvm::cl::init(false), llvm::cl::Hidden};
 
-  llvm::cl::opt<bool> allowAddingPortsOnPublic{
-      "allow-adding-ports-on-public-modules",
-      llvm::cl::desc("Allow adding ports to public modules"),
-      llvm::cl::init(false), llvm::cl::Hidden};
-
   llvm::cl::opt<bool> probesToSignals{
       "probes-to-signals",
       llvm::cl::desc("Convert probes to non-probe signals"),
@@ -787,7 +781,7 @@ void circt::firtool::registerFirtoolCLOptions() {
 circt::firtool::FirtoolOptions::FirtoolOptions()
     : outputFilename("-"), disableAnnotationsUnknown(false),
       disableAnnotationsClassless(false), lowerAnnotationsNoRefTypePorts(false),
-      allowAddingPortsOnPublic(false), probesToSignals(false),
+      probesToSignals(false),
       preserveAggregate(firrtl::PreserveAggregate::None),
       preserveMode(firrtl::PreserveValues::None), enableDebugInfo(false),
       buildMode(BuildModeRelease), disableLayerSink(false),
@@ -816,7 +810,6 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   disableAnnotationsUnknown = clOptions->disableAnnotationsUnknown;
   disableAnnotationsClassless = clOptions->disableAnnotationsClassless;
   lowerAnnotationsNoRefTypePorts = clOptions->lowerAnnotationsNoRefTypePorts;
-  allowAddingPortsOnPublic = clOptions->allowAddingPortsOnPublic;
   probesToSignals = clOptions->probesToSignals;
   preserveAggregate = clOptions->preserveAggregate;
   preserveMode = clOptions->preserveMode;

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -1,11 +1,7 @@
-; RUN: firtool --verilog --allow-adding-ports-on-public-modules %s | FileCheck %s
+; RUN: firtool --verilog %s | FileCheck %s
 
 FIRRTL version 4.0.0
 circuit Top : %[[
-  {
-    "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
-    "target":"~Top|DUTModule"
-  },
   {
     "class":"firrtl.transforms.DontTouchAnnotation",
     "target":"~Top|Top>memTap"

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,14 +1,10 @@
-; RUN: firtool --verilog -allow-adding-ports-on-public-modules %s | FileCheck %s
-; RUN: firtool --verilog -allow-adding-ports-on-public-modules -preserve-aggregate=1d-vec %s | FileCheck %s --check-prefix=AGGGREGATE
-; RUN: firtool --verilog -allow-adding-ports-on-public-modules -lower-annotations-no-ref-type-ports %s | FileCheck %s --check-prefix=NOREFS
-; RUN: firtool -allow-adding-ports-on-public-modules --parse-only %s | circt-opt --firrtl-probes-to-signals | firtool --verilog --format=mlir | FileCheck %s --check-prefix=PROBESTOSIGNALS
+; RUN: firtool --verilog %s | FileCheck %s
+; RUN: firtool --verilog -preserve-aggregate=1d-vec %s | FileCheck %s --check-prefix=AGGGREGATE
+; RUN: firtool --verilog -lower-annotations-no-ref-type-ports %s | FileCheck %s --check-prefix=NOREFS
+; RUN: firtool --parse-only %s | circt-opt --firrtl-probes-to-signals | firtool --verilog --format=mlir | FileCheck %s --check-prefix=PROBESTOSIGNALS
 
 FIRRTL version 4.0.0
 circuit Top : %[[
-  {
-    "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
-    "target":"~Top|DUTModule"
-  },
   {
     "class":"firrtl.transforms.DontTouchAnnotation",
     "target":"~Top|Top>memTap"

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-annotations{allow-adding-ports-on-public-modules=true}))'  --verify-diagnostics --split-input-file %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-annotations))'  --verify-diagnostics --split-input-file %s | FileCheck %s
 
 // circt.test copies the annotation to the target
 // circt.testNT puts the targetless annotation on the circuit
@@ -1439,11 +1439,11 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
     }
   ]
 } {
-  // CHECK:      firrtl.module @Companion
+  // CHECK:      firrtl.module private @Companion
   // CHECK-SAME:   in %[[port_0:[a-zA-Z0-9_]+]]: !firrtl.uint<1>
   // CHECK-SAME:   in %[[port_1:[a-zA-Z0-9_]+]]: !firrtl.uint<2>
   // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion", id = 0 : i64, name = "View"}
-  firrtl.module @Companion() {
+  firrtl.module private @Companion() {
     // CHECK-NEXT: firrtl.node %[[port_0]]
     // CHECK-SAME:   {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64}]}
     // CHECK-SAME:   !firrtl.uint<1>
@@ -1451,10 +1451,10 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
     // CHECK-SAME:   {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2 : i64}]}
     // CHECK-SAME:   !firrtl.uint<2>
   }
-  // CHECK:      firrtl.module @Bar
+  // CHECK:      firrtl.module private @Bar
   // CHECK-SAME:   out %[[refPort_0:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<1>>
   // CHECK-SAME:   out %[[refPort_1:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<2>>
-  firrtl.module @Bar() {
+  firrtl.module private @Bar() {
     %a = firrtl.wire interesting_name  : !firrtl.bundle<a: uint<1>, b: uint<2>>
     // CHECK:      %[[a_0:[a-zA-Z0-9_]+]] = firrtl.subfield %a[a]
     // CHECK-NEXT: %[[a_1:[a-zA-Z0-9_]+]] = firrtl.subfield %a[b]
@@ -1537,15 +1537,15 @@ firrtl.circuit "GrandCentralParentIsNotLCA"  attributes {
     }
   ]
 } {
-  // CHECK:        firrtl.module @Bar
+  // CHECK:        firrtl.module private @Bar
   // CHECK-SAME:     out %[[a_refPort:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<1>>
-  firrtl.module @Bar() {
+  firrtl.module private @Bar() {
     %a = firrtl.wire : !firrtl.uint<1>
     // CHECK:        %[[a_ref:[a-zA-Z0-9_]+]] = firrtl.ref.send %a
     // CHECK-NEXT:   firrtl.ref.define %[[a_refPort]], %[[a_ref]]
   }
-  // CHECK:        firrtl.module @Companion()
-  firrtl.module @Companion() {
+  // CHECK:        firrtl.module private @Companion()
+  firrtl.module private @Companion() {
     firrtl.instance bar @Bar()
     // CHECK-NEXT:   %[[bar_a_refPort:[a-zA-Z0-9_]+]] = firrtl.instance bar
     // CHECK-NEXT:   %[[b_refResolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_a_refPort]]


### PR DESCRIPTION
This controls whether to allow "wiring problems" to bore through public modules, adding new ports to the interface.

This was a transition option, and the statistic was used to track how many were left to fix.

Most wiring is now performed in Chisel.
Remaining wiring mechanisms:
* memory taps
* tapping for GC views Views already bore their own signals in Chisel, but GC Views code is still capable of wiring.
* legacy wiring

This option hasn't been used in flows for over a year.