### PR TITLE
[OM] Remove Pure from ObjectOp to preserve identity

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -184,15 +184,16 @@ def ClassExternOp : OMClassLike<"class.extern", [NoTerminator]> {
 // Object instantiations and fields
 //===----------------------------------------------------------------------===//
 
-def ObjectOp : OMOp<"object",
-    [DeclareOpInterfaceMethods<SymbolUserOpInterface>, Pure]> {
+def ObjectOp : OMOp<"object", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+]> {
   let arguments = (ins
     SymbolNameAttr:$className,
     Variadic<AnyType>:$actualParams
   );
 
   let results = (outs
-    ClassType:$result
+    Res<ClassType, "", [MemAlloc]>:$result
   );
 
   let builders = [

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -1,0 +1,24 @@
+// RUN: circt-opt --cse --canonicalize %s | FileCheck %s
+
+om.class @Foo() {
+  om.class.fields
+}
+
+// CHECK-LABEL: @ObjectsMustNotCSE
+func.func @ObjectsMustNotCSE() -> (!om.class.type<@Foo>, !om.class.type<@Foo>) {
+  // CHECK-NEXT: [[OBJ1:%.+]] = om.object @Foo
+  // CHECK-NEXT: [[OBJ2:%.+]] = om.object @Foo
+  // CHECK-NEXT: return [[OBJ1]], [[OBJ2]]
+  %obj1 = om.object @Foo() : () -> !om.class.type<@Foo>
+  %obj2 = om.object @Foo() : () -> !om.class.type<@Foo>
+  return %obj1, %obj2 : !om.class.type<@Foo>, !om.class.type<@Foo>
+}
+
+// Objects must DCE.
+// CHECK-LABEL: @ObjectsMustDCE
+func.func @ObjectsMustDCE() {
+  // CHECK-NOT: om.object
+  // CHECK-NEXT: return
+  om.object @Foo() : () -> !om.class.type<@Foo>
+  return
+}


### PR DESCRIPTION
Remove the `Pure` trait from `om.object`. With the op marked pure, the CSE pass will combine instances of the same class into a single instance. This is problematic, since users may expect distinct instances of the same class to be preserved as two separate instances instead of being deduplicated.

Instead, add the `MemAlloc` trait to the result of the `ObjectOp`. This causes the op to no longer CSE, but it allows unused objects to be erased.