### PR TITLE
[FIRRTL][GrandCentral] Add -no-views option.

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -121,6 +121,9 @@ MLIR_CAPI_EXPORTED void
 circtFirtoolOptionsSetCompanionMode(CirctFirtoolFirtoolOptions options,
                                     CirctFirtoolCompanionMode value);
 
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetNoViews(CirctFirtoolFirtoolOptions options, bool value);
+
 MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableAggressiveMergeConnections(
     CirctFirtoolFirtoolOptions options, bool value);
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -458,7 +458,8 @@ def GrandCentral : Pass<"firrtl-grand-central", "CircuitOp"> {
                 "Instantiate companions in the design"),
               clEnumValN(CompanionMode::Drop, "drop",
                 "Remove companions from the design"))
-           }]>
+           }]>,
+    Option<"noViews", "no-views", "bool", "false", "Delete FIRRTL views">,
   ];
   let statistics = [
     Statistic<"numViews", "num-views-created",

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -64,6 +64,8 @@ public:
   }
   firrtl::CompanionMode getCompanionMode() const { return companionMode; }
 
+  bool getNoViews() const { return noViews; }
+
   seq::ExternalizeClockGateOptions getClockGateOptions() const {
     return {ckgModuleName, ckgInputName,      ckgOutputName,
             ckgEnableName, ckgTestEnableName, ckgInstName};
@@ -224,6 +226,11 @@ public:
 
   FirtoolOptions &setCompanionMode(firrtl::CompanionMode value) {
     companionMode = value;
+    return *this;
+  }
+
+  FirtoolOptions &setNoViews(bool value) {
+    noViews = value;
     return *this;
   }
 
@@ -413,6 +420,7 @@ private:
   bool noDedup;
   bool dedupClasses;
   firrtl::CompanionMode companionMode;
+  bool noViews;
   bool disableAggressiveMergeConnections;
   bool lowerMemories;
   std::string blackBoxRootPath;

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -164,6 +164,11 @@ void circtFirtoolOptionsSetCompanionMode(CirctFirtoolFirtoolOptions options,
   unwrap(options)->setCompanionMode(converted);
 }
 
+void circtFirtoolOptionsSetNoViews(CirctFirtoolFirtoolOptions options,
+                                   bool value) {
+  unwrap(options)->setNoViews(value);
+}
+
 void circtFirtoolOptionsSetDisableAggressiveMergeConnections(
     CirctFirtoolFirtoolOptions options, bool value) {
   unwrap(options)->setDisableAggressiveMergeConnections(value);

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1929,13 +1929,23 @@ void GrandCentralPass::runOnOperation() {
     llvm::dbgs() << "\n";
   });
 
+  bool changed = false;
+  if (noViews && !views.empty()) {
+    changed = true;
+    for (auto &view : views)
+      view.erase();
+    views.clear();
+  }
+
   // Exit immediately if no annotations indicative of interfaces that need to be
   // built exist.  However, still generate the YAML file if the annotation for
   // this was passed in because some flows expect this.
   if (worklist.empty() && views.empty()) {
     for (auto &[yamlPath, intfs] : interfaceYAMLMap)
       emitHierarchyYamlFile(yamlPath.getValue(), intfs);
-    return markAllAnalysesPreserved();
+    if (!changed)
+      markAllAnalysesPreserved();
+    return;
   }
 
   // Setup the builder to create ops _inside the FIRRTL circuit_.  This is

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -261,7 +261,8 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   // Run this after output directories are (otherwise) assigned,
   // so generated interfaces can be appropriately marked.
   pm.addNestedPass<firrtl::CircuitOp>(
-      firrtl::createGrandCentral({/*companionMode=*/opt.getCompanionMode()}));
+      firrtl::createGrandCentral({/*companionMode=*/opt.getCompanionMode(),
+                                  /*noViews*/ opt.getNoViews()}));
 
   // Read black box source files into the IR.
   StringRef blackBoxRoot = opt.getBlackBoxRootPath().empty()
@@ -575,6 +576,12 @@ struct FirtoolCmdOptions {
       llvm::cl::Hidden,
   };
 
+  llvm::cl::opt<bool> noViews{
+      "no-views",
+      llvm::cl::desc("Disable emission of FIRRTL views (delete them instead)"),
+      llvm::cl::init(false),
+  };
+
   llvm::cl::opt<bool> disableAggressiveMergeConnections{
       "disable-aggressive-merge-connections",
       llvm::cl::desc(
@@ -793,9 +800,9 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       buildMode(BuildModeRelease), disableLayerSink(false),
       disableOptimization(false), vbToBV(false), noDedup(false),
       dedupClasses(true), companionMode(firrtl::CompanionMode::Bind),
-      disableAggressiveMergeConnections(false), lowerMemories(false),
-      blackBoxRootPath(""), replSeqMem(false), replSeqMemFile(""),
-      extractTestCode(false), ignoreReadEnableMem(false),
+      noViews(false), disableAggressiveMergeConnections(false),
+      lowerMemories(false), blackBoxRootPath(""), replSeqMem(false),
+      replSeqMemFile(""), extractTestCode(false), ignoreReadEnableMem(false),
       disableRandom(RandomKind::None), outputAnnotationFilename(""),
       enableAnnotationWarning(false), addMuxPragmas(false),
       verificationFlavor(firrtl::VerificationFlavor::None),
@@ -828,6 +835,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   noDedup = clOptions->noDedup;
   dedupClasses = clOptions->dedupClasses;
   companionMode = clOptions->companionMode;
+  noViews = clOptions->noViews;
   disableAggressiveMergeConnections =
       clOptions->disableAggressiveMergeConnections;
   lowerMemories = clOptions->lowerMemories;

--- a/test/firtool/no-views.fir
+++ b/test/firtool/no-views.fir
@@ -1,0 +1,17 @@
+; RUN: firtool %s | FileCheck %s --check-prefix=ENABLE
+; RUN: firtool %s -no-views | FileCheck %s --check-prefix=DISABLE
+
+FIRRTL version 4.2.0
+circuit ViewInLayer:
+  layer Views, bind, "views/":
+
+  public module ViewInLayer:
+    input x : UInt<1>
+    input y : UInt<1>
+    intrinsic(circt_view<name="view", info="{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"Root\", \"elements\": [{\"name\": \"foo\", \"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}}]}">, x)
+
+    layerblock Views:
+        intrinsic(circt_view<name="view", info="{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"MyView\", \"elements\": [{\"name\": \"foo\", \"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}}]}">, x)
+
+; ENABLE: interface
+; DISABLE-NOT: interface


### PR DESCRIPTION
Instead of lowering firrtl.view's to SV interaces, when no-views is set simply delete them.

Intended for compatibility path for users that today use the companion mode "instantiate", combined with appropriate layer enabling.