### PR TITLE
[ExportVerilog] Move declarations to the top of blocks when disallowDeclAssignments is set.

### DIFF
--- a/test/Conversion/ExportVerilog/decl-assignments.mlir
+++ b/test/Conversion/ExportVerilog/decl-assignments.mlir
@@ -3,11 +3,16 @@
 
 // CHECK-LABEL: module test(
 hw.module @test(in %v: i1) {
-  // ALLOW:    wire w = v;
-  // DISALLOW: wire w;
-  // DISALLOW: assign w = v;
+  // ALLOW:         wire w = v;
+  // DISALLOW:      wire w;
+  // DISALLOW-NEXT: wire u;
+  // DISALLOW-NEXT: wire x;
+  // DISALLOW-NEXT: assign w = v;
+  // DISALLOW-NEXT: assign u = v;
   %w = sv.wire : !hw.inout<i1>
   sv.assign %w, %v : i1
+  %u = sv.wire : !hw.inout<i1>
+  sv.assign %u, %v : i1
   // CHECK: initial begin
   sv.initial {
     // ALLOW:         automatic logic l = v;
@@ -16,4 +21,8 @@ hw.module @test(in %v: i1) {
     %l = sv.logic : !hw.inout<i1>
     sv.bpassign %l, %v : i1
   }
+  // ALLOW:         wire x = v;
+  // DISALLOW:      assign x = v;
+  %x = sv.wire : !hw.inout<i1>
+  sv.assign %x, %v : i1
 }


### PR DESCRIPTION
This patch implements the logic to move wire declarations to the beginning of blocks when the disallowDeclAssignments option is enabled. This is solely for readability not for correctness.