### PR TITLE
[FIRRTL] Use type inference for domain anon op

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -777,21 +777,18 @@ def ObjectOp :  FIRRTLOp<"object", [
   }];
 }
 
-def DomainCreateAnonOp : FIRRTLOp<"domain.anon", [
-    ParentOneOf<[
-      "firrtl::ContractOp",
-      "firrtl::FModuleOp",
-      "firrtl::LayerBlockOp",
-      "firrtl::MatchOp",
-      "firrtl::WhenOp",
-      "sv::IfDefOp"
-    ]>,
-    DeclareOpInterfaceMethods<SymbolUserOpInterface>
-  ]> {
+def DomainCreateAnonOp
+    : FIRRTLOp<"domain.anon",
+               [ParentOneOf<["firrtl::ContractOp", "firrtl::FModuleOp",
+                             "firrtl::LayerBlockOp", "firrtl::MatchOp",
+                             "firrtl::WhenOp", "sv::IfDefOp"]>,
+                DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                DeclareOpInterfaceMethods<InferTypeOpInterface>,
+]> {
   let summary = "Create an anonymous domain, without parameters set";
   let arguments = (ins FlatSymbolRefAttr:$domain);
   let results = (outs DomainType:$result);
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{ attr-dict `:` type($result) `of` $domain }];
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLDECLARATIONS_TD

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -7043,27 +7043,6 @@ LogicalResult BindOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
 // Domain operations
 //===----------------------------------------------------------------------===//
 
-void DomainCreateAnonOp::print(OpAsmPrinter &p) {
-  p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"domain"});
-  p << " : ";
-  p.printType(getType());
-  printDomainKind(p, getDomainAttr());
-}
-
-ParseResult DomainCreateAnonOp::parse(OpAsmParser &parser,
-                                      OperationState &result) {
-  Type type;
-  FlatSymbolRefAttr domainKind;
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
-      parser.parseType(type) || parseDomainKind(parser, domainKind))
-    return failure();
-
-  result.getOrAddProperties<Properties>().setDomain(domainKind);
-  result.addTypes(type);
-
-  return success();
-}
-
 LogicalResult
 DomainCreateAnonOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto circuitOp = getOperation()->getParentOfType<CircuitOp>();


### PR DESCRIPTION
This is just a minor suggestion, we don't have to take it, but it simplifies the printing/parsing of the domain.anon op.