### PR TITLE
[FIRRTL] Fix Dedup issue caused by name shadowing

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1821,7 +1821,7 @@ class DedupPass : public circt::firrtl::impl::DedupBase<DedupPass> {
           if (!canRemoveModule(original))
             continue;
           // Swap the canonical module in the dedup map.
-          for (auto &[originalName, dedupedName] : dedupMap)
+          for (auto &[_, dedupedName] : dedupMap)
             if (dedupedName == originalName)
               dedupedName = moduleName;
           // Update the module hash table to point to the new original, so all


### PR DESCRIPTION
Fix an issue in the Dedup pass where swapping a module in the dedup map would inadvertently make all non-deduped module dedup with the new canonical module.

Fixes #9335.