### PR TITLE
[FIRRTL][Dedup] Improve error messages for nested bundle type mismatches

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -516,8 +516,9 @@ struct Equivalence {
       }
 
       if (failed(check(diag,
-                       "bundle element \'" + aElement.name.getValue() + "'", a,
-                       aElement.type, b, bElement.type)))
+                       message + " -> bundle element \'" +
+                           aElement.name.getValue() + "'",
+                       a, aElement.type, b, bElement.type)))
         return failure();
     }
     return success();

--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -401,13 +401,13 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
       class = "firrtl.transforms.MustDeduplicateAnnotation",
       modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
     }]} {
-  // expected-note@below {{module port 'a' types don't match, first type is '!firrtl.uint<1>'}}
-  firrtl.module private @Test0(in %a : !firrtl.uint<1>) { }
+  // expected-note@below {{module port 'a' -> bundle element 'b' types don't match, first type is '!firrtl.uint<1>'}}
+  firrtl.module private @Test0(in %a : !firrtl.bundle<b: uint<1>>) { }
   // expected-note@below {{second type is '!firrtl.uint<2>'}}
-  firrtl.module private @Test1(in %a : !firrtl.uint<2>) { }
+  firrtl.module private @Test1(in %a : !firrtl.bundle<b: uint<2>>) { }
   firrtl.module @MustDedup() {
-    firrtl.instance test0 @Test0(in a : !firrtl.uint<1>)
-    firrtl.instance test1 @Test1(in a : !firrtl.uint<2>)
+    firrtl.instance test0 @Test0(in a : !firrtl.bundle<b: uint<1>>)
+    firrtl.instance test1 @Test1(in a : !firrtl.bundle<b: uint<2>>)
   }
 }
 


### PR DESCRIPTION
This change improves the diagnostic messages when deduplication fails due to type mismatches in bundle elements. Previously, when bundle elements had mismatched types, the error message would only show "bundle element 'name'" without context about which port or parent structure contained that bundle. Now the message is propagated through the recursion, showing the full path like "module port 'a' -> bundle element 'b'".

This makes it easier to identify the source of type mismatches in deeply nested bundle structures during deduplication.