### PR TITLE
Reapply "[circt-lsp-server] Make time source injectable"

### DIFF
--- a/lib/Tools/circt-verilog-lsp-server/Utils/PendingChanges.cpp
+++ b/lib/Tools/circt-verilog-lsp-server/Utils/PendingChanges.cpp
@@ -48,9 +48,7 @@ void PendingChangesMap::debounceAndUpdate(
 
 void PendingChangesMap::enqueueChange(
     const llvm::lsp::DidChangeTextDocumentParams &params) {
-  // Key by normalized LSP file path. If your pipeline allows multiple
-  // spellings (symlinks/case), normalize upstream or canonicalize here.
-  const auto now = std::chrono::steady_clock::now();
+  const auto now = nowFn();
   const std::string key = params.textDocument.uri.file().str();
 
   std::scoped_lock<std::mutex> lock(mu);
@@ -71,7 +69,7 @@ void PendingChangesMap::debounceAndThen(
     DebounceOptions options,
     std::function<void(std::unique_ptr<PendingChanges>)> cb) {
   const std::string key = params.textDocument.uri.file().str();
-  const auto scheduleTime = std::chrono::steady_clock::now();
+  const auto scheduleTime = nowFn();
 
   // If debounce is disabled, run on main thread
   if (options.disableDebounce) {
@@ -87,8 +85,7 @@ void PendingChangesMap::debounceAndThen(
     // Simple timer: sleep min-quiet before checking. We rely on the fact
     // that newer edits can arrive while we sleep, updating lastChangeTime.
     if (options.debounceMinMs > 0)
-      std::this_thread::sleep_for(
-          std::chrono::milliseconds(options.debounceMinMs));
+      waitForMinMs(options.debounceMinMs, scheduleTime);
 
     std::unique_ptr<PendingChanges>
         result; // decided under lock, callback after
@@ -98,7 +95,7 @@ void PendingChangesMap::debounceAndThen(
       auto it = pending.find(key);
       if (it != pending.end()) {
         PendingChanges &pc = it->second;
-        const auto now = std::chrono::steady_clock::now();
+        const auto now = nowFn();
 
         // quietSinceSchedule: if no newer edits arrived after we scheduled
         // this task, then we consider the burst "quiet" and flush now.
@@ -140,6 +137,21 @@ PendingChangesMap::takeAndErase(llvm::StringMap<PendingChanges>::iterator it) {
   auto out = std::make_unique<PendingChanges>(std::move(it->second));
   pending.erase(it);
   return out;
+}
+
+void PendingChangesMap::waitForMinMs(uint64_t ms,
+                                     SteadyClock::time_point start) {
+  if (!ms)
+    return;
+  if (!useManualClock) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+    return;
+  }
+  // Manual clock: busy-wait with yields until now() reaches start + ms.
+  const auto target = start + std::chrono::milliseconds(ms);
+  while (nowFn() < target) {
+    std::this_thread::yield();
+  }
 }
 
 } // namespace lsp

--- a/lib/Tools/circt-verilog-lsp-server/Utils/PendingChanges.h
+++ b/lib/Tools/circt-verilog-lsp-server/Utils/PendingChanges.h
@@ -17,12 +17,16 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <thread>
 #include <vector>
 
 namespace circt {
 namespace lsp {
+
+using SteadyClock = std::chrono::steady_clock;
+using NowFn = std::function<SteadyClock::time_point()>;
 
 /// Build a pool strategy with a sensible minimum.
 static llvm::ThreadPoolStrategy makeStrategy(unsigned maxThreads) {
@@ -56,7 +60,16 @@ class PendingChangesMap {
 public:
   explicit PendingChangesMap(
       unsigned maxThreads = std::thread::hardware_concurrency())
-      : pool(makeStrategy(maxThreads)), tasks(pool) {}
+      : pool(makeStrategy(maxThreads)), tasks(pool),
+        nowFn([] { return SteadyClock::now(); }), useManualClock(false) {}
+
+  // Test-only path: provide a manual clock source.
+  explicit PendingChangesMap(unsigned maxThreads, NowFn now)
+      : pool(makeStrategy(maxThreads)), tasks(pool), nowFn(std::move(now)),
+        useManualClock(true) {}
+
+  /// Destructor ensures all pending work is cleared.
+  ~PendingChangesMap() {}
 
   /// Call during server shutdown; Erase all file changes, then clear file map.
   /// Thread-safe.
@@ -106,6 +119,13 @@ private:
   /// Internal concurrency used for sleeps + checks.
   llvm::StdThreadPool pool;
   llvm::ThreadPoolTaskGroup tasks;
+
+  /// Injectable time source for unit testing
+  NowFn nowFn;
+  bool useManualClock;
+
+  /// Test wrapper around a thread timeout
+  void waitForMinMs(uint64_t ms, SteadyClock::time_point start);
 };
 
 } // namespace lsp

--- a/unittests/Tools/circt-verilog-lsp-server/Utils/PendingChangesTest.cpp
+++ b/unittests/Tools/circt-verilog-lsp-server/Utils/PendingChangesTest.cpp
@@ -22,6 +22,20 @@ using namespace std::chrono_literals;
 
 namespace {
 
+/// Manual, monotonic clock for tests. Time is advanced manually to avoid race
+/// conditions in threads
+struct ManualClock {
+  SteadyClock::time_point t = SteadyClock::time_point{}; // start at epoch
+  SteadyClock::time_point now() const { return t; }
+  void advanceMs(std::chrono::milliseconds ms) { t += ms; }
+};
+
+static inline void advanceTestTime(ManualClock &clock,
+                                   std::chrono::milliseconds ms) {
+  clock.advanceMs(ms);
+  std::this_thread::yield(); // let the worker run
+}
+
 /// Tiny helper to await a single callback result in tests.
 struct CallbackCapture {
   std::mutex m;
@@ -39,9 +53,11 @@ struct CallbackCapture {
   }
 
   // Wait up to timeout for a callback; returns true if called.
-  bool waitFor(std::chrono::milliseconds timeout) {
+  bool waitFor() {
     std::unique_lock<std::mutex> lock(m);
-    return cv.wait_for(lock, timeout, [&] { return called; });
+    // Keep the timeout very small, as all time references are anyway driven
+    // from the unit tests
+    return cv.wait_for(lock, 1ms, [&] { return called; });
   }
 };
 
@@ -72,7 +88,8 @@ TEST(PendingChangesMapTest, ImmediateFlushWhenDisabled) {
   GTEST_SKIP() << "flaky on macOS";
 #endif
 
-  PendingChangesMap pcm(/*maxThreads=*/2);
+  ManualClock clock;
+  PendingChangesMap pcm(/*maxThreads=*/2, [&] { return clock.now(); });
   DebounceOptions opt;
   opt.disableDebounce = true;
   opt.debounceMinMs = 500;
@@ -86,10 +103,11 @@ TEST(PendingChangesMapTest, ImmediateFlushWhenDisabled) {
     cap.set(std::move(r));
   });
 
-  ASSERT_TRUE(cap.waitFor(200ms));
+  ASSERT_TRUE(cap.waitFor());
   ASSERT_TRUE(cap.got != nullptr);
   EXPECT_EQ(cap.got->version, 1);
   ASSERT_EQ(cap.got->changes.size(), 1u);
+  pcm.abort();
 }
 
 /// Check that changes are applied once debounce delay window is passed
@@ -99,7 +117,9 @@ TEST(PendingChangesMapTest, FlushAfterQuietMinWindow) {
   GTEST_SKIP() << "flaky on macOS";
 #endif
 
-  PendingChangesMap pcm(2);
+  ManualClock clock;
+  PendingChangesMap pcm(/*maxThreads=*/2, [&] { return clock.now(); });
+
   DebounceOptions opt;
   opt.disableDebounce = false;
   opt.debounceMinMs = 60; // small debounce
@@ -109,18 +129,21 @@ TEST(PendingChangesMapTest, FlushAfterQuietMinWindow) {
   pcm.enqueueChange(p);
 
   CallbackCapture cap;
-  auto start = std::chrono::steady_clock::now();
   pcm.debounceAndThen(p, opt, [&](std::unique_ptr<PendingChanges> r) {
     cap.set(std::move(r));
   });
 
-  // Expect callback to arrive after ~debounceMinMs; allow headroom.
-  ASSERT_TRUE(cap.waitFor(800ms));
+  // Let the worker's sleep elapse, and advance the manual clock accordingly.
+  advanceTestTime(clock, 60ms);
+
+  ASSERT_TRUE(cap.waitFor());
   ASSERT_TRUE(cap.got != nullptr);
-  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-      std::chrono::steady_clock::now() - start);
-  // Should be at least the min window (allowing scheduling jitter).
-  EXPECT_GE(elapsed.count(), static_cast<long long>(opt.debounceMinMs) - 5);
+  EXPECT_EQ(cap.got->version, 1);
+  EXPECT_EQ(cap.got->changes.size(), 1u);
+
+  // Signal all to all scheduled threads they are out of time.
+  advanceTestTime(clock, 1000ms);
+  pcm.abort();
 }
 
 /// Check that outdated edits are not applied and the thread is discarded.
@@ -130,7 +153,8 @@ TEST(PendingChangesMapTest, ObsoleteWhenNewerEditsArrive) {
   GTEST_SKIP() << "flaky on macOS";
 #endif
 
-  PendingChangesMap pcm(2);
+  ManualClock clock;
+  PendingChangesMap pcm(/*maxThreads=*/2, [&] { return clock.now(); });
   DebounceOptions opt;
   opt.disableDebounce = false;
   opt.debounceMinMs = 80; // first task sleeps 80ms
@@ -146,12 +170,15 @@ TEST(PendingChangesMapTest, ObsoleteWhenNewerEditsArrive) {
   });
 
   // While the first sleeper is waiting, enqueue a new edit to reset lastChange.
-  std::this_thread::sleep_for(30ms);
+  advanceTestTime(clock, 30ms);
   auto p2 = makeChangeParams(key, 2);
   pcm.enqueueChange(p2);
 
+  // Advance to the end of the quiet window so the first check runs.
+  advanceTestTime(clock, 50ms);
+
   // The first scheduled check should now be obsolete -> nullptr.
-  ASSERT_TRUE(first.waitFor(800ms));
+  ASSERT_TRUE(first.waitFor());
   ASSERT_EQ(first.got, nullptr);
 
   // Now schedule another check; with no more edits, it should flush.
@@ -160,57 +187,17 @@ TEST(PendingChangesMapTest, ObsoleteWhenNewerEditsArrive) {
     second.set(std::move(r));
   });
 
-  ASSERT_TRUE(second.waitFor(800ms));
+  advanceTestTime(clock, 80ms);
+
+  ASSERT_TRUE(second.waitFor());
   ASSERT_TRUE(second.got != nullptr);
   // Both edits should be present (burst merged)
   EXPECT_EQ(second.got->version, 2);
   EXPECT_EQ(second.got->changes.size(), 2u);
-}
 
-TEST(PendingChangesMapTest, MaxCapForcesFlushDuringContinuousTyping) {
-#if defined(__APPLE__)
-  // See https://github.com/llvm/circt/issues/9292.
-  GTEST_SKIP() << "flaky on macOS";
-#endif
-
-  PendingChangesMap pcm(2);
-  DebounceOptions opt;
-  opt.disableDebounce = false;
-  opt.debounceMinMs = 100; // quiet 100ms
-  opt.debounceMaxMs = 500; // cap 500ms
-
-  const auto *key = "d.sv";
-  auto p = makeChangeParams(key, 1);
-  pcm.enqueueChange(p);
-
-  // 1) First check at ~100ms: will be obsolete (new edits arrived).
-  CallbackCapture first;
-  pcm.debounceAndThen(p, opt, [&](std::unique_ptr<PendingChanges> r) {
-    first.set(std::move(r));
-  });
-
-  // Immediately enqueue a new edit to represent continuous typing.
-  pcm.enqueueChange(makeChangeParams(key, 2));
-
-  ASSERT_TRUE(first.waitFor(std::chrono::milliseconds(800)));
-  EXPECT_EQ(first.got, nullptr); // expected obsolete
-
-  // 2) After max-cap has passed, schedule another check -> must flush.
-  std::this_thread::sleep_for(
-      std::chrono::milliseconds(550)); // Total > 500ms cap
-  CallbackCapture second;
-  // Use the latest version for the schedule key; any params with same URI key
-  // is fine
-  auto p2 = makeChangeParams(key, /*version=*/999);
-  pcm.debounceAndThen(p2, opt, [&](std::unique_ptr<PendingChanges> r) {
-    second.set(std::move(r));
-  });
-
-  ASSERT_TRUE(second.waitFor(std::chrono::milliseconds(1500)));
-
-  ASSERT_TRUE(second.got != nullptr);
-  EXPECT_GE(second.got->version, 2);
-  EXPECT_GE(second.got->changes.size(), 1u);
+  // Signal all to all scheduled threads they are out of time.
+  advanceTestTime(clock, 1000ms);
+  pcm.abort();
 }
 
 /// Check that no update is queued if the change map is empty.
@@ -220,7 +207,8 @@ TEST(PendingChangesMapTest, MissingKeyYieldsNullptr) {
   GTEST_SKIP() << "flaky on macOS";
 #endif
 
-  PendingChangesMap pcm(2);
+  ManualClock clock;
+  PendingChangesMap pcm(/*maxThreads=*/2, [&] { return clock.now(); });
   DebounceOptions opt;
   opt.disableDebounce = false;
   opt.debounceMinMs = 30;
@@ -234,8 +222,13 @@ TEST(PendingChangesMapTest, MissingKeyYieldsNullptr) {
     cap.set(std::move(r));
   });
 
-  ASSERT_TRUE(cap.waitFor(400ms));
+  advanceTestTime(clock, 30ms);
+
+  ASSERT_TRUE(cap.waitFor());
   EXPECT_EQ(cap.got, nullptr);
+
+  // Signal all to all scheduled threads they are out of time.
+  advanceTestTime(clock, 1000ms);
 }
 
 TEST(PendingChangesMapTest, EraseByKeyAndUriAreIdempotent) {
@@ -244,7 +237,8 @@ TEST(PendingChangesMapTest, EraseByKeyAndUriAreIdempotent) {
   GTEST_SKIP() << "flaky on macOS";
 #endif
 
-  PendingChangesMap pcm(/*maxThreads=*/2);
+  ManualClock clock;
+  PendingChangesMap pcm(/*maxThreads=*/2, [&] { return clock.now(); });
 
   DebounceOptions opt;
   opt.disableDebounce = true; // immediate path exercises the keyed lookup
@@ -260,7 +254,7 @@ TEST(PendingChangesMapTest, EraseByKeyAndUriAreIdempotent) {
     pcm.debounceAndThen(a, opt, [&](std::unique_ptr<PendingChanges> r) {
       cap.set(std::move(r));
     });
-    ASSERT_TRUE(cap.waitFor(std::chrono::milliseconds(200)));
+    ASSERT_TRUE(cap.waitFor());
     // Nothing pending after erase -> nullptr
     EXPECT_EQ(cap.got, nullptr);
   }
@@ -275,7 +269,7 @@ TEST(PendingChangesMapTest, EraseByKeyAndUriAreIdempotent) {
     pcm.debounceAndThen(b, opt, [&](std::unique_ptr<PendingChanges> r) {
       cap.set(std::move(r));
     });
-    ASSERT_TRUE(cap.waitFor(std::chrono::milliseconds(200)));
+    ASSERT_TRUE(cap.waitFor());
     EXPECT_EQ(cap.got, nullptr);
   }
 
@@ -289,11 +283,15 @@ TEST(PendingChangesMapTest, EraseByKeyAndUriAreIdempotent) {
     pcm.debounceAndThen(c, opt, [&](std::unique_ptr<PendingChanges> r) {
       cap.set(std::move(r));
     });
-    ASSERT_TRUE(cap.waitFor(std::chrono::milliseconds(200)));
+    ASSERT_TRUE(cap.waitFor());
     ASSERT_NE(cap.got, nullptr);
     EXPECT_EQ(cap.got->version, 3);
     EXPECT_EQ(cap.got->changes.size(), 1u);
   }
+
+  // Signal all to all scheduled threads they are out of time.
+  advanceTestTime(clock, 1000ms);
+  pcm.abort();
 }
 
 TEST(PendingChangesMapTest, AbortClearsAll) {
@@ -302,7 +300,8 @@ TEST(PendingChangesMapTest, AbortClearsAll) {
   GTEST_SKIP() << "flaky on macOS";
 #endif
 
-  PendingChangesMap pcm(2);
+  ManualClock clock;
+  PendingChangesMap pcm(/*maxThreads=*/2, [&] { return clock.now(); });
 
   // Debounced path to also cover the async branch
   DebounceOptions opt;
@@ -330,8 +329,10 @@ TEST(PendingChangesMapTest, AbortClearsAll) {
       capB.set(std::move(r));
     });
 
-    ASSERT_TRUE(capA.waitFor(std::chrono::milliseconds(500)));
-    ASSERT_TRUE(capB.waitFor(std::chrono::milliseconds(500)));
+    advanceTestTime(clock, 50ms);
+
+    ASSERT_TRUE(capA.waitFor());
+    ASSERT_TRUE(capB.waitFor());
 
     EXPECT_EQ(capA.got, nullptr);
     EXPECT_EQ(capB.got, nullptr);
@@ -345,7 +346,7 @@ TEST(PendingChangesMapTest, AbortClearsAll) {
     pcm.debounceAndThen(c, opt, [&](std::unique_ptr<PendingChanges> r) {
       cap.set(std::move(r));
     });
-    ASSERT_TRUE(cap.waitFor(std::chrono::milliseconds(200)));
+    ASSERT_TRUE(cap.waitFor());
     // Still nullptr because we didn't enqueue after abort.
     EXPECT_EQ(cap.got, nullptr);
   }
@@ -357,11 +358,14 @@ TEST(PendingChangesMapTest, AbortClearsAll) {
     pcm.debounceAndThen(c, opt, [&](std::unique_ptr<PendingChanges> r) {
       cap.set(std::move(r));
     });
-    ASSERT_TRUE(cap.waitFor(std::chrono::milliseconds(200)));
+    ASSERT_TRUE(cap.waitFor());
     ASSERT_NE(cap.got, nullptr);
     EXPECT_EQ(cap.got->version, 2);
     EXPECT_EQ(cap.got->changes.size(), 1u);
   }
+
+  // Signal all to all scheduled threads they are out of time.
+  advanceTestTime(clock, 1000ms);
 }
 
 } // namespace


### PR DESCRIPTION
This reverts commit a570dbf5f150da78889e02551bc77ff5a56d0283 with removing suspicious RAII. It might be a root cause of infinite loop in https://github.com/llvm/circt/pull/9340. 