### PR TITLE
[Datapath] Convert comparison operators to arithmetic - avoiding multiple carry propagate adders

### DIFF
--- a/integration_test/circt-synth/datapath-reduce-delay-lec.mlir
+++ b/integration_test/circt-synth/datapath-reduce-delay-lec.mlir
@@ -1,0 +1,39 @@
+// REQUIRES: libz3
+// REQUIRES: circt-lec-jit
+
+// RUN: circt-opt %s --datapath-reduce-delay -o %t.mlir
+// RUN: circt-lec %t.mlir %s -c1=add_compare -c2=add_compare --shared-libs=%libz3 | FileCheck %s --check-prefix=COMPARE
+// COMPARE: c1 == c2
+hw.module @add_compare(in %a : i16, in %b : i16, in %c : i16, out ugt : i1, out uge : i1, out ult : i1, out ule : i1) {
+  %false = hw.constant false
+  %0 = comb.concat %false, %a : i1, i16
+  %1 = comb.concat %false, %b : i1, i16
+  %2 = comb.add %0, %1 {comb.nuw} : i17 
+  %3 = comb.concat %false, %c : i1, i16
+  // Check that we don't apply transformation when overflow is possible
+  %4 = comb.add %0, %3 : i17
+  %ugt = comb.icmp ugt %2, %3 : i17
+  %uge = comb.icmp uge %2, %3 : i17
+  %ult = comb.icmp ult %1, %4 : i17
+  %ule = comb.icmp ule %1, %4 : i17
+  hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
+}
+
+// RUN: circt-lec %t.mlir %s -c1=add_mux -c2=add_mux --shared-libs=%libz3 | FileCheck %s --check-prefix=ADDMUX
+// ADDMUX: c1 == c2
+hw.module @add_mux(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4, in %sel : i1, out res : i4) {
+  %0 = comb.add %a, %b : i4
+  %1 = comb.add %c, %d, %e : i4
+  %2 = comb.mux %sel, %0, %1 : i4
+  %3 = comb.add %2, %e : i4
+  hw.output %3 : i4
+}
+
+// RUN: circt-lec %t.mlir %s -c1=fold_adds -c2=fold_adds --shared-libs=%libz3 | FileCheck %s --check-prefix=FOLDADD
+// FOLDADD: c1 == c2
+hw.module @fold_adds(in %a : i4, in %b : i4, in %c : i4, in %d : i4, out abc : i4, out abd : i4) {
+  %0 = comb.add %a, %b : i4
+  %1 = comb.add %0, %c : i4
+  %2 = comb.add %0, %d : i4
+  hw.output %1, %2 : i4, i4
+}

--- a/lib/Dialect/Datapath/Transforms/ReduceDelay.cpp
+++ b/lib/Dialect/Datapath/Transforms/ReduceDelay.cpp
@@ -211,8 +211,7 @@ struct ConvertCmpToAdd : public OpRewritePattern<comb::ICmpOp> {
     rhsExtend.push_back(hw::ConstantOp::create(
         rewriter, op.getLoc(), APInt(width + 1, rhsExtend.size())));
 
-    SmallVector<Value> allAddends;
-    llvm::append_range(allAddends, lhsExtend);
+    SmallVector<Value> allAddends = std::move(lhsExtend);
     llvm::append_range(allAddends, rhsExtend);
     auto add = comb::AddOp::create(rewriter, op.getLoc(), allAddends, false);
     auto msb = rewriter.createOrFold<comb::ExtractOp>(

--- a/test/Dialect/Datapath/datapath-reduce-delay.mlir
+++ b/test/Dialect/Datapath/datapath-reduce-delay.mlir
@@ -1,5 +1,68 @@
 // RUN: circt-opt %s --datapath-reduce-delay | FileCheck %s
 
+// CHECK-LABEL: @do_nothing
+hw.module @do_nothing(in %a : i4, in %b : i4, in %c : i4, in %sel : i1, out res : i4) {
+  // CHECK-NEXT: %[[MUX:.+]] = comb.mux %sel, %a, %b : i4
+  // CHECK-NEXT: %[[ADD:.+]] = comb.add %[[MUX]], %c : i4
+  // CHECK-NEXT: hw.output %[[ADD]] : i4
+  %0 = comb.mux %sel, %a, %b : i4
+  %1 = comb.add %0, %c : i4
+  hw.output %1 : i4
+}
+
+// CHECK-LABEL: @fold_adds
+hw.module @fold_adds(in %a : i4, in %b : i4, in %c : i4, in %d : i4, out abc : i4, out abd : i4) {
+  // CHECK-NEXT: %[[COMP_ABC:.+]]:2 = datapath.compress %a, %b, %c : i4 [3 -> 2]
+  // CHECK-NEXT: %[[ABC:.+]] = comb.add bin %[[COMP_ABC]]#0, %[[COMP_ABC]]#1 : i4
+  // CHECK-NEXT: %[[COMP_ABD:.+]]:2 = datapath.compress %a, %b, %d : i4 [3 -> 2]
+  // CHECK-NEXT: %[[ABD:.+]] = comb.add bin %[[COMP_ABD]]#0, %[[COMP_ABD]]#1 : i4
+  // CHECK-NEXT: hw.output %[[ABC]], %[[ABD]] : i4, i4
+  %0 = comb.add %a, %b : i4
+  %1 = comb.add %0, %c : i4
+  %2 = comb.add %0, %d : i4
+  hw.output %1, %2 : i4, i4
+}
+
+// CHECK-LABEL: @add_mux_left
+hw.module @add_mux_left(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %sel : i1, out res : i4) {
+  // CHECK-NEXT: %c0_i4 = hw.constant 0 : i4
+  // CHECK-NEXT: %[[LHS:.+]] = comb.mux %sel, %a, %c : i4
+  // CHECK-NEXT: %[[RHS:.+]] = comb.mux %sel, %b, %c0_i4 : i4
+  // CHECK-NEXT: %[[COMP:.+]]:2 = datapath.compress %[[LHS]], %[[RHS]], %d : i4 [3 -> 2]
+  // CHECK-NEXT: comb.add bin %[[COMP]]#0, %[[COMP]]#1 : i4
+  %0 = comb.add %a, %b : i4
+  %1 = comb.mux %sel, %0, %c : i4
+  %2 = comb.add %1, %d : i4
+  hw.output %2 : i4
+}
+
+// CHECK-LABEL: @add_mux_right
+hw.module @add_mux_right(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %sel : i1, out res : i4) {
+  // CHECK-NEXT: %c0_i4 = hw.constant 0 : i4
+  // CHECK-NEXT: %[[LHS:.+]] = comb.mux %sel, %a, %b : i4
+  // CHECK-NEXT: %[[RHS:.+]] = comb.mux %sel, %c0_i4, %c : i4
+  // CHECK-NEXT: %[[COMP:.+]]:2 = datapath.compress %[[LHS]], %[[RHS]], %d : i4 [3 -> 2]
+  // CHECK-NEXT: comb.add bin %[[COMP]]#0, %[[COMP]]#1 : i4
+  %0 = comb.add %b, %c : i4
+  %1 = comb.mux %sel, %a, %0 : i4
+  %2 = comb.add %1, %d : i4
+  hw.output %2 : i4
+}
+
+// CHECK-LABEL: @add_mux_both
+hw.module @add_mux_both(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4, in %sel : i1, out res : i4) {
+  // CHECK-NEXT: %c0_i4 = hw.constant 0 : i4
+  // CHECK-NEXT: %[[ARG0:.+]] = comb.mux %sel, %a, %c : i4
+  // CHECK-NEXT: %[[ARG1:.+]] = comb.mux %sel, %b, %d : i4
+  // CHECK-NEXT: %[[ARG2:.+]] = comb.mux %sel, %c0_i4, %e : i4
+  // CHECK-NEXT: %[[COMP:.+]]:2 = datapath.compress %[[ARG0]], %[[ARG1]], %[[ARG2]], %e : i4 [4 -> 2]
+  // CHECK-NEXT: comb.add bin %[[COMP]]#0, %[[COMP]]#1 : i4
+  %0 = comb.add %a, %b : i4
+  %1 = comb.add %c, %d, %e : i4
+  %2 = comb.mux %sel, %0, %1 : i4
+  %3 = comb.add %2, %e : i4
+  hw.output %3 : i4
+}
 
 // CHECK-LABEL: @add_compare
 hw.module @add_compare(in %a : i16, in %b : i16, in %c : i16, out ugt : i1, out uge : i1) {


### PR DESCRIPTION
Implement a delay reducing transformation that depends on the comb.nuw annotation to validate the transformation. This is the first example where we leverage analysis results to validate datapath optimisations, but there are many further transformations that will follow. 

An example transformation is:
```
a + b < c + d --> msb( {0,a} + {0,b} - {0,c} - {0,d} )**
```

If (a+b) were to have a truncated overflow bit, then we cannot safely zero-extend and truncate the result because now we've polluted the new addition {0,a} + {0,b} with a possibly non-zero carry-out bit...