### PR TITLE
[ImportVerilog] Fix class property segfault and emit error

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -121,9 +121,14 @@ static Value visitClassProperty(Context &context,
       cast<moore::ClassHandleType>(instRef.getType());
 
   auto targetClassHandle =
-      context.getAncestorClassWithProperty(classTy, expr.name);
+      context.getAncestorClassWithProperty(classTy, expr.name, loc);
+  if (!targetClassHandle)
+    return {};
+
   auto upcastRef = context.materializeConversion(targetClassHandle, instRef,
                                                  false, instRef.getLoc());
+  if (!upcastRef)
+    return {};
 
   Value fieldRef = moore::ClassPropertyRefOp::create(builder, loc, fieldRefTy,
                                                      upcastRef, fieldSym);
@@ -400,17 +405,18 @@ struct ExprVisitor {
 
     // Handle classes.
     if (valueType->isClass()) {
-
       auto valTy = context.convertType(*valueType);
       if (!valTy)
         return {};
-      auto targetTy = dyn_cast<moore::ClassHandleType>(valTy);
+      auto targetTy = cast<moore::ClassHandleType>(valTy);
 
       // We need to pick the closest ancestor that declares a property with the
       // relevant name. System Verilog explicitly enforces lexical shadowing, as
       // shown in IEEE 1800-2023 Section 8.14 "Overridden members".
       auto upcastTargetTy =
-          context.getAncestorClassWithProperty(targetTy, expr.member.name);
+          context.getAncestorClassWithProperty(targetTy, expr.member.name, loc);
+      if (!upcastTargetTy)
+        return {};
 
       // Convert the class handle to the required target type for property
       // shadowing purposes.
@@ -2574,10 +2580,7 @@ bool Context::isClassDerivedFrom(const moore::ClassHandleType &actualTy,
 
 moore::ClassHandleType
 Context::getAncestorClassWithProperty(const moore::ClassHandleType &actualTy,
-                                      llvm::StringRef fieldName) {
-  if (!actualTy || fieldName.empty())
-    return {};
-
+                                      llvm::StringRef fieldName, Location loc) {
   // Start at the actual class symbol.
   mlir::SymbolRefAttr classSym = actualTy.getClassSym();
 
@@ -2606,5 +2609,6 @@ Context::getAncestorClassWithProperty(const moore::ClassHandleType &actualTy,
   }
 
   // No ancestor declares that property.
+  mlir::emitError(loc) << "unknown property `" << fieldName << "`";
   return {};
 }

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -129,11 +129,11 @@ struct Context {
   bool isClassDerivedFrom(const moore::ClassHandleType &actualTy,
                           const moore::ClassHandleType &baseTy);
 
-  /// Tries to find the closest base class of actualTy that carries
-  /// a property with name fieldName.
+  /// Tries to find the closest base class of actualTy that carries a property
+  /// with name fieldName. The location is used for error reporting.
   moore::ClassHandleType
   getAncestorClassWithProperty(const moore::ClassHandleType &actualTy,
-                               StringRef fieldName);
+                               StringRef fieldName, Location loc);
 
   Value getImplicitThisRef() const {
     return currentThisRef; // block arg added in declareFunction

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -169,12 +169,15 @@ struct TypeVisitor {
   Type visit(const slang::ast::ClassType &type) {
     if (failed(context.convertClassDeclaration(type)))
       return {};
-    if (auto *lowering = context.declareClass(type)) {
-      mlir::StringAttr symName = lowering->op.getSymNameAttr();
-      mlir::FlatSymbolRefAttr symRef = mlir::FlatSymbolRefAttr::get(symName);
-      return moore::ClassHandleType::get(context.getContext(), symRef);
+    auto *lowering = context.declareClass(type);
+    if (!lowering) {
+      mlir::emitError(loc) << "no lowering generated for class type `"
+                           << type.toString() << "`";
+      return {};
     }
-    return {};
+    mlir::StringAttr symName = lowering->op.getSymNameAttr();
+    mlir::FlatSymbolRefAttr symRef = mlir::FlatSymbolRefAttr::get(symName);
+    return moore::ClassHandleType::get(context.getContext(), symRef);
   }
 
   /// Emit an error for all other types.


### PR DESCRIPTION
Fix an issue around class property handling where code would not properly catch failures in the `getAncestorClassWithProperty()` and some other functions, and would instead try to access the null result.

Also add a missing error message if a class property cannot be resolved.

This caused about half of the segfaults in the sv-tests suite [1].

[1]: https://github.com/circt/circt-tests/blob/results/2025/2025-12-15-131140-main-82227de/sv-tests/segfaults.txt