### PR TITLE
[LLHD] Fix HoistSignals with non-uniform drive delays

### DIFF
--- a/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
+++ b/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
@@ -494,12 +494,18 @@ void DriveHoister::hoistDrives() {
         .Case<TimeAttr>([&](auto attr) {
           auto &slot = materializedConstants[attr];
           if (!slot)
-            slot =
-                llhd::ConstantTimeOp::create(builder, processOp.getLoc(), attr);
+            slot = ConstantTimeOp::create(builder, processOp.getLoc(), attr);
           return slot;
         })
         .Case<Type>([&](auto type) {
           // TODO: This should probably create something like a `llhd.dontcare`.
+          if (isa<TimeType>(type)) {
+            auto attr = TimeAttr::get(builder.getContext(), 0, "ns", 0, 0);
+            auto &slot = materializedConstants[attr];
+            if (!slot)
+              slot = ConstantTimeOp::create(builder, processOp.getLoc(), attr);
+            return slot;
+          }
           auto numBits = hw::getBitWidth(type);
           assert(numBits >= 0);
           Value value = hw::ConstantOp::create(


### PR DESCRIPTION
Fix a bug in LLHD's HoistSignals pass where a process with multiple drives with different delays, and at least one `llhd.halt` operation, would not properly create a dummy zero-delay dontcare delay to be returned from the halt.

Fixes #9348.