### PR TITLE
[ESI] Add type ser/de capability

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
@@ -20,6 +20,7 @@
 #include <any>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -113,6 +114,11 @@ public:
 
   using ChannelVector =
       std::vector<std::tuple<std::string, Direction, const Type *>>;
+  /// Create a bundle type with the given channels, registering it with the
+  /// context. If typeID is not provided, one is inferred from the channels.
+  static const BundleType *
+  create(Context &ctxt, const ChannelVector &channels,
+         std::optional<Type::ID> typeID = std::nullopt);
 
   BundleType(const ID &id, const ChannelVector &channels)
       : Type(id), channels(channels) {}
@@ -131,6 +137,12 @@ protected:
 class ChannelType : public Type {
 public:
   using Type::deserialize;
+  /// Create a channel type with the given inner type, registering it with the
+  /// context. If typeID is not provided, one is inferred from the inner type.
+  static const ChannelType *
+  create(Context &ctxt, const Type *inner,
+         std::optional<Type::ID> typeID = std::nullopt);
+
   ChannelType(const ID &id, const Type *inner) : Type(id), inner(inner) {}
   const Type *getInner() const { return inner; }
   std::ptrdiff_t getBitWidth() const override { return inner->getBitWidth(); };
@@ -147,6 +159,10 @@ private:
 class VoidType : public Type {
 public:
   using Type::deserialize;
+  /// Create a void type, registering it with the context.
+  static const VoidType *create(Context &ctxt,
+                                std::optional<Type::ID> typeID = std::nullopt);
+
   VoidType(const ID &id) : Type(id) {}
   // 'void' is 1 bit by convention.
   std::ptrdiff_t getBitWidth() const override { return 1; };
@@ -162,6 +178,9 @@ public:
 /// as it is in software.
 class AnyType : public Type {
 public:
+  /// Create an any type, registering it with the context.
+  static const AnyType *create(Context &ctxt);
+
   AnyType(const ID &id) : Type(id) {}
   std::ptrdiff_t getBitWidth() const override { return -1; };
 };
@@ -182,6 +201,11 @@ private:
 /// identified in the manifest as "signless" ints.
 class BitsType : public BitVectorType {
 public:
+  /// Create a bits type with the given width, registering it with the context.
+  /// If typeID is not provided, one is inferred from the width.
+  static const Type *create(Context &ctxt, uint64_t width,
+                            std::optional<Type::ID> typeID = std::nullopt);
+
   using BitVectorType::BitVectorType;
   using Type::deserialize;
 
@@ -200,6 +224,11 @@ public:
 /// Signed integer.
 class SIntType : public IntegerType {
 public:
+  /// Create a signed integer type with the given width, registering it with the
+  /// context. If typeID is not provided, one is inferred from the width.
+  static const Type *create(Context &ctxt, uint64_t width,
+                            std::optional<Type::ID> typeID = std::nullopt);
+
   using IntegerType::IntegerType;
   using Type::deserialize;
 
@@ -211,6 +240,11 @@ public:
 /// Unsigned integer.
 class UIntType : public IntegerType {
 public:
+  /// Create an unsigned integer type with the given width, registering it with
+  /// the context. If typeID is not provided, one is inferred from the width.
+  static const Type *create(Context &ctxt, uint64_t width,
+                            std::optional<Type::ID> typeID = std::nullopt);
+
   using IntegerType::IntegerType;
   using Type::deserialize;
 
@@ -224,6 +258,12 @@ class StructType : public Type {
 public:
   using FieldVector = std::vector<std::pair<std::string, const Type *>>;
   using Type::deserialize;
+
+  /// Create a struct type with the given fields, registering it with the
+  /// context. If typeID is not provided, one is inferred from the field types.
+  static const StructType *
+  create(Context &ctxt, const FieldVector &fields, bool reverse = true,
+         std::optional<Type::ID> typeID = std::nullopt);
 
   StructType(const ID &id, const FieldVector &fields, bool reverse = true)
       : Type(id), fields(fields), reverse(reverse) {}
@@ -259,6 +299,13 @@ private:
 /// Arrays have a compile time specified (static) size and an element type.
 class ArrayType : public Type {
 public:
+  /// Create an array type with the given element type and size, registering it
+  /// with the context. If typeID is not provided, one is inferred from the
+  /// element type and size.
+  static const ArrayType *create(Context &ctxt, const Type *elementType,
+                                 uint64_t size, bool reverse = true,
+                                 std::optional<Type::ID> typeID = std::nullopt);
+
   ArrayType(const ID &id, const Type *elementType, uint64_t size,
             bool reverse = true)
       : Type(id), elementType(elementType), size(size), reverse(reverse) {}

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Utils.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Utils.h
@@ -28,6 +28,14 @@ namespace utils {
 // Very basic base64 encoding.
 void encodeBase64(const void *data, size_t size, std::string &out);
 
+// Attempt to demangle a runtime type name.
+std::string demangle(const std::type_info &ti);
+
+template <typename T>
+std::string demangle() {
+  return demangle(typeid(T));
+}
+
 /// C++'s stdlib doesn't have a hash_combine function. This is a simple one.
 inline size_t hash_combine(size_t h1, size_t h2) {
   return h1 + 0x9e3779b9 + (h2 << 6) + (h2 >> 2);

--- a/lib/Dialect/ESI/runtime/cpp/lib/Types.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Types.cpp
@@ -30,119 +30,100 @@
 #pragma GCC diagnostic pop
 #endif
 
-//===----------------------------------------------------------------------===//
-// ESI Type Construction Helpers
-//===----------------------------------------------------------------------===//
-
-/// Generic helper to check for existing types in the context and register new
-/// ones.
-template <typename T>
-static const T *getOrCreateType(esi::Context &ctxt, const std::string &typeName,
-                                std::function<T *()> createFunc) {
-  std::optional<const esi::Type *> existing = ctxt.getType(typeName);
-  if (existing) {
-    const auto *existingTyped = dynamic_cast<const T *>(existing.value());
-    if (!existingTyped) {
-      throw std::runtime_error(std::format(
-          "Type ID '{}' already registered with a different type", typeName));
-    }
-    return existingTyped;
-  }
-
-  auto *newType = createFunc();
-  ctxt.registerType(newType);
-  return newType;
-}
-
-static const esi::VoidType *createVoidType(esi::Context &ctxt) {
-  std::string typeName = "void";
-  return getOrCreateType<esi::VoidType>(
-      ctxt, typeName, [&typeName]() { return new esi::VoidType(typeName); });
-}
-
-static const esi::Type *createBitsType(esi::Context &ctxt, size_t bitWidth) {
-  if (bitWidth == 0)
-    return createVoidType(ctxt);
-
-  std::string typeName = "bits" + std::to_string(bitWidth);
-  return getOrCreateType<esi::BitsType>(
-      ctxt, typeName, [&typeName, bitWidth]() {
-        return new esi::BitsType(typeName, bitWidth);
-      });
-}
-
-static const esi::Type *createIntType(esi::Context &ctxt, size_t bitWidth,
-                                      bool isSigned) {
-  if (bitWidth == 0)
-    return createVoidType(ctxt);
-
-  std::string typeName = std::format("{}i{}", isSigned ? "s" : "u", bitWidth);
-
-  if (isSigned) {
-    return getOrCreateType<esi::SIntType>(
-        ctxt, typeName, [&typeName, bitWidth]() {
-          return new esi::SIntType(typeName, bitWidth);
-        });
-  }
-
-  return getOrCreateType<esi::UIntType>(
-      ctxt, typeName, [&typeName, bitWidth]() {
-        return new esi::UIntType(typeName, bitWidth);
-      });
-}
-
-static const esi::Type *createUIntType(esi::Context &ctxt, size_t bitWidth) {
-  return createIntType(ctxt, bitWidth, false);
-}
-
-static const esi::Type *createSIntType(esi::Context &ctxt, size_t bitWidth) {
-  return createIntType(ctxt, bitWidth, true);
-}
-
-static const esi::ArrayType *createArrayType(esi::Context &ctxt,
-                                             const esi::Type *elementType,
-                                             size_t size, bool reverse = true) {
-  std::string typeName =
-      "array_" + std::to_string(size) + "_" + elementType->getID();
-
-  return getOrCreateType<esi::ArrayType>(
-      ctxt, typeName, [&typeName, elementType, size, reverse]() {
-        return new esi::ArrayType(typeName, elementType, size, reverse);
-      });
-}
-
-static const esi::StructType *
-createStructType(esi::Context &ctxt, const std::string &name,
-                 const esi::StructType::FieldVector &fields,
-                 bool reverse = true) {
-  return getOrCreateType<esi::StructType>(
-      ctxt, name, [&name, &fields, reverse]() {
-        return new esi::StructType(name, fields, reverse);
-      });
-}
-
-static const esi::ChannelType *createChannelType(esi::Context &ctxt,
-                                                 const esi::Type *inner) {
-  std::string channelTypeName = "channel_" + inner->getID();
-  return getOrCreateType<esi::ChannelType>(
-      ctxt, channelTypeName, [&channelTypeName, inner]() {
-        return new esi::ChannelType(channelTypeName, inner);
-      });
-}
-
-static const esi::BundleType *
-createFunctionBundleType(esi::Context &ctxt, const std::string &name,
-                         const esi::Type *argType,
-                         const esi::Type *resultType) {
-  esi::BundleType::ChannelVector channels;
-  channels.emplace_back("arg", esi::BundleType::Direction::To, argType);
-  channels.emplace_back("result", esi::BundleType::Direction::From, resultType);
-  auto *bundleType = new esi::BundleType(name, channels);
-  ctxt.registerType(bundleType);
-  return bundleType;
-}
-
 namespace esi {
+
+//===----------------------------------------------------------------------===//
+// ESI Type static 'create' methods
+//===----------------------------------------------------------------------===//
+
+const VoidType *VoidType::create(Context &ctxt,
+                                 std::optional<Type::ID> typeID) {
+  return ctxt.getOrCreateType<VoidType>(typeID.value_or("void"));
+}
+
+const Type *BitsType::create(Context &ctxt, uint64_t width,
+                             std::optional<Type::ID> typeID) {
+  if (width == 0)
+    return VoidType::create(ctxt);
+  return ctxt.getOrCreateType<BitsType>(
+      typeID.value_or("bits" + std::to_string(width)), width);
+}
+
+const Type *SIntType::create(Context &ctxt, uint64_t width,
+                             std::optional<Type::ID> typeID) {
+  if (width == 0)
+    return VoidType::create(ctxt);
+  return ctxt.getOrCreateType<SIntType>(
+      typeID.value_or(std::format("si{}", width)), width);
+}
+
+const Type *UIntType::create(Context &ctxt, uint64_t width,
+                             std::optional<Type::ID> typeID) {
+  if (width == 0)
+    return VoidType::create(ctxt);
+  return ctxt.getOrCreateType<UIntType>(
+      typeID.value_or(std::format("ui{}", width)), width);
+}
+
+const AnyType *AnyType::create(Context &ctxt) {
+  return ctxt.getOrCreateType<AnyType>("any");
+}
+
+const StructType *StructType::create(Context &ctxt, const FieldVector &fields,
+                                     bool reverse,
+                                     std::optional<Type::ID> typeID) {
+  if (!typeID.has_value()) {
+    // Infer type ID from field names and types.
+    typeID = "struct{";
+    for (size_t i = 0; i < fields.size(); ++i) {
+      if (i > 0)
+        *typeID += ",";
+      *typeID +=
+          std::format("{}:{}", fields[i].first, fields[i].second->getID());
+    }
+    *typeID += "}";
+  }
+  return ctxt.getOrCreateType<StructType>(*typeID, fields, reverse);
+}
+
+const ArrayType *ArrayType::create(Context &ctxt, const Type *elementType,
+                                   uint64_t size, bool reverse,
+                                   std::optional<Type::ID> typeID) {
+  return ctxt.getOrCreateType<ArrayType>(
+      typeID.value_or(std::format("array_{}_{}", size, elementType->getID())),
+      elementType, size, reverse);
+}
+
+const ChannelType *ChannelType::create(Context &ctxt, const Type *inner,
+                                       std::optional<Type::ID> typeID) {
+  return ctxt.getOrCreateType<ChannelType>(
+      typeID.value_or(std::format("channel_{}", inner->getID())), inner);
+}
+
+const BundleType *BundleType::create(Context &ctxt,
+                                     const ChannelVector &channels,
+                                     std::optional<Type::ID> typeID) {
+  Type::ID id;
+  if (typeID) {
+    id = *typeID;
+  } else {
+    // Infer type ID from channel names, directions, and types.
+    id = "bundle{";
+    for (size_t i = 0; i < channels.size(); ++i) {
+      if (i > 0)
+        id += ",";
+      const auto &[name, dir, type] = channels[i];
+      id += (dir == BundleType::To ? "to:" : "from:") + name + ":" +
+            type->getID();
+    }
+    id += "}";
+  }
+  return ctxt.getOrCreateType<BundleType>(id, channels);
+}
+
+//===----------------------------------------------------------------------===//
+// Type dump / toString
+//===----------------------------------------------------------------------===//
 
 // NOLINTNEXTLINE(misc-no-recursion)
 static void dumpType(std::ostream &os, const esi::Type *type, int level = 0,
@@ -219,18 +200,30 @@ void Type::dump(std::ostream &os, bool oneLine) const {
   dumpType(os, this, oneLine ? 0 : 0, oneLine);
 }
 
-// Deserialize the provided string to a type instance. The type (and any
-// nested types) are registered to the provided context. It is expected that
-// the type was serialized via the 'serialize' method.
+// Helper function to deserialize a single type from the type table.
 // NOLINTNEXTLINE(misc-no-recursion)
-const Type *Type::deserializeType(esi::Context &ctx, const std::string &data) {
-  nlohmann::json j = nlohmann::json::parse(data);
+static const Type *deserializeTypeFromTable(esi::Context &ctx,
+                                            const nlohmann::json &typeTable,
+                                            const Type::ID &typeID) {
+  // Check if already registered in context (handles caching/cycles).
+  std::optional<const esi::Type *> existing = ctx.getType(typeID);
+  if (existing)
+    return existing.value();
+
+  if (!typeTable.contains(typeID))
+    throw std::runtime_error(
+        std::format("Type ID '{}' not found in type table", typeID));
+
+  const nlohmann::json &j = typeTable.at(typeID);
 
   if (!j.is_object())
-    throw std::runtime_error("jsonObjToType: expected JSON object");
+    throw std::runtime_error("deserializeTypeFromTable: expected JSON object");
 
   std::string mnemonic = j.at("mnemonic").get<std::string>();
-  std::string id = j.value("id", "");
+  // Extract optional type ID from JSON (nullopt if empty or missing).
+  std::optional<Type::ID> id;
+  if (j.contains("id") && !j.at("id").get<std::string>().empty())
+    id = j.at("id").get<std::string>();
 
   // Helper to get bitwidth from either hwBitwidth or width field
   auto getBitwidth = [&j]() -> uint64_t {
@@ -243,53 +236,54 @@ const Type *Type::deserializeType(esi::Context &ctx, const std::string &data) {
   if (mnemonic == "int") {
     uint64_t width = getBitwidth();
     std::string signedness = j.value("signedness", "unsigned");
-    return createIntType(ctx, width, signedness == "signed");
+    if (signedness == "signed")
+      return SIntType::create(ctx, width, id);
+    return UIntType::create(ctx, width, id);
   }
   if (mnemonic == "uint") {
     // Legacy format support
     uint64_t width = getBitwidth();
-    return createUIntType(ctx, width);
+    return UIntType::create(ctx, width, id);
   }
   if (mnemonic == "sint") {
     // Legacy format support
     uint64_t width = getBitwidth();
-    return createSIntType(ctx, width);
+    return SIntType::create(ctx, width, id);
   }
   if (mnemonic == "bits") {
     uint64_t width = getBitwidth();
-    return createBitsType(ctx, width);
+    return BitsType::create(ctx, width, id);
   }
   if (mnemonic == "void") {
-    return createVoidType(ctx);
+    return VoidType::create(ctx);
   }
   if (mnemonic == "any") {
-    // AnyType doesn't have a create helper, create directly
-    std::string typeName = id.empty() ? "any" : id;
-    std::optional<const esi::Type *> existing = ctx.getType(typeName);
-    if (existing)
-      return existing.value();
-    auto *anyType = new esi::AnyType(typeName);
-    ctx.registerType(anyType);
-    return anyType;
+    return AnyType::create(ctx);
   }
   if (mnemonic == "struct") {
     esi::StructType::FieldVector fields;
     for (const auto &fieldObj : j.at("fields")) {
       std::string fieldName = fieldObj.at("name").get<std::string>();
-      const esi::Type *fieldType = deserializeType(ctx, fieldObj.at("type"));
+      Type::ID fieldTypeID = fieldObj.at("typeID").get<std::string>();
+      const esi::Type *fieldType =
+          deserializeTypeFromTable(ctx, typeTable, fieldTypeID);
       fields.emplace_back(fieldName, fieldType);
     }
-    std::string typeName = id.empty() ? "struct_auto" : id;
-    return createStructType(ctx, typeName, fields);
+    // Use the serialized ID if present, otherwise let create() infer one.
+    return StructType::create(ctx, fields, /*reverse=*/true, id);
   }
   if (mnemonic == "array") {
-    const esi::Type *elementType = deserializeType(ctx, j.at("element"));
+    Type::ID elementTypeID = j.at("element").get<std::string>();
+    const esi::Type *elementType =
+        deserializeTypeFromTable(ctx, typeTable, elementTypeID);
     uint64_t size = j.at("size").get<uint64_t>();
-    return createArrayType(ctx, elementType, size);
+    return ArrayType::create(ctx, elementType, size, /*reverse=*/true, id);
   }
   if (mnemonic == "channel") {
-    const esi::Type *innerType = deserializeType(ctx, j.at("inner"));
-    return createChannelType(ctx, innerType);
+    Type::ID innerTypeID = j.at("inner").get<std::string>();
+    const esi::Type *innerType =
+        deserializeTypeFromTable(ctx, typeTable, innerTypeID);
+    return ChannelType::create(ctx, innerType, id);
   }
   if (mnemonic == "bundle") {
     esi::BundleType::ChannelVector channels;
@@ -299,30 +293,51 @@ const Type *Type::deserializeType(esi::Context &ctx, const std::string &data) {
       esi::BundleType::Direction direction =
           (dirStr == "to") ? esi::BundleType::Direction::To
                            : esi::BundleType::Direction::From;
+      Type::ID channelTypeID = channelObj.at("typeID").get<std::string>();
       const esi::Type *channelType =
-          deserializeType(ctx, channelObj.at("type"));
+          deserializeTypeFromTable(ctx, typeTable, channelTypeID);
       channels.emplace_back(channelName, direction, channelType);
     }
-    std::string typeName = id.empty() ? "bundle_auto" : id;
-    // Check for existing type first
-    std::optional<const esi::Type *> existing = ctx.getType(typeName);
-    if (existing)
-      return existing.value();
-    auto *bundleType = new esi::BundleType(typeName, channels);
-    ctx.registerType(bundleType);
-    return bundleType;
+    // Use the serialized ID if present, otherwise let create() infer one.
+    return BundleType::create(ctx, channels, id);
   }
   throw std::runtime_error(
-      std::format("jsonObjToType: unknown mnemonic '{}'", mnemonic));
+      std::format("deserializeTypeFromTable: unknown mnemonic '{}'", mnemonic));
 }
 
+// Deserialize the provided string to a type instance. The type (and any
+// nested types) are registered to the provided context. It is expected that
+// the type was serialized via the 'serialize' method.
+const Type *Type::deserializeType(esi::Context &ctx, const std::string &data) {
+  nlohmann::json j = nlohmann::json::parse(data);
+
+  if (!j.is_object())
+    throw std::runtime_error("deserializeType: expected JSON object");
+
+  if (!j.contains("typeTable"))
+    throw std::runtime_error("deserializeType: missing typeTable field");
+
+  if (!j.contains("typeID"))
+    throw std::runtime_error("deserializeType: missing typeID field");
+
+  const nlohmann::json &typeTable = j.at("typeTable");
+  Type::ID rootTypeID = j.at("typeID").get<std::string>();
+  return deserializeTypeFromTable(ctx, typeTable, rootTypeID);
+}
+
+// Serializes the provided type into the provided type table object, and returns
+// the type ID of the serialized type.
 // NOLINTNEXTLINE(misc-no-recursion)
-std::string Type::serializeType(const esi::Type *type) {
-  if (!type)
-    throw std::runtime_error("Type::serializeType: null type provided");
+static esi::Type::ID serializeTypeToTable(const esi::Type *type,
+                                          nlohmann::json &table) {
+  // Check whether we've already visited this type. If so, return the typeID
+  // directly.
+  esi::Type::ID typeID = type->getID();
+  if (table.contains(typeID))
+    return typeID;
 
   nlohmann::json j;
-  j["id"] = type->getID();
+  j["id"] = typeID;
 
   if (auto *uintType = dynamic_cast<const esi::UIntType *>(type)) {
     j["mnemonic"] = "int";
@@ -345,17 +360,17 @@ std::string Type::serializeType(const esi::Type *type) {
     for (const auto &[name, fieldType] : structType->getFields()) {
       nlohmann::json fieldObj;
       fieldObj["name"] = name;
-      fieldObj["type"] = serializeType(fieldType);
+      fieldObj["typeID"] = serializeTypeToTable(fieldType, table);
       fieldsArr.push_back(fieldObj);
     }
     j["fields"] = fieldsArr;
   } else if (auto *arrayType = dynamic_cast<const esi::ArrayType *>(type)) {
     j["mnemonic"] = "array";
-    j["element"] = serializeType(arrayType->getElementType());
+    j["element"] = serializeTypeToTable(arrayType->getElementType(), table);
     j["size"] = arrayType->getSize();
   } else if (auto *channelType = dynamic_cast<const esi::ChannelType *>(type)) {
     j["mnemonic"] = "channel";
-    j["inner"] = serializeType(channelType->getInner());
+    j["inner"] = serializeTypeToTable(channelType->getInner(), table);
   } else if (auto *bundleType = dynamic_cast<const esi::BundleType *>(type)) {
     j["mnemonic"] = "bundle";
     nlohmann::json channelsArr = nlohmann::json::array();
@@ -365,7 +380,7 @@ std::string Type::serializeType(const esi::Type *type) {
       channelObj["name"] = name;
       channelObj["direction"] =
           (direction == esi::BundleType::Direction::To) ? "to" : "from";
-      channelObj["type"] = serializeType(channelType);
+      channelObj["typeID"] = serializeTypeToTable(channelType, table);
       channelsArr.push_back(channelObj);
     }
     j["channels"] = channelsArr;
@@ -373,6 +388,23 @@ std::string Type::serializeType(const esi::Type *type) {
     throw std::runtime_error(
         std::format("typeToJsonObj: unhandled type '{}'", type->getID()));
   }
+
+  // Inject into the type table.
+  table[type->getID()] = j;
+
+  return type->getID();
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+std::string Type::serializeType(const esi::Type *type) {
+  if (!type)
+    throw std::runtime_error("Type::serializeType: null type provided");
+
+  nlohmann::json j;
+  // Initialize the type table, which is a mapping from type IDs to serialized
+  // type objects.
+  auto &table = j["typeTable"];
+  j["typeID"] = serializeTypeToTable(type, table);
 
   return j.dump();
 }

--- a/lib/Dialect/ESI/runtime/cpp/lib/Utils.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Utils.cpp
@@ -15,6 +15,13 @@
 
 #include "esi/Utils.h"
 
+#ifdef __GNUG__
+#include <cstdlib>
+#include <cxxabi.h>
+#include <memory>
+
+#endif
+
 static constexpr char Table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                 "abcdefghijklmnopqrstuvwxyz"
                                 "0123456789+/";
@@ -48,4 +55,17 @@ void esi::utils::encodeBase64(const void *dataIn, size_t size,
     buffer[j + 2] = Table[(x >> 6) & 63];
     buffer[j + 3] = '=';
   }
+}
+
+std::string esi::utils::demangle(const std::type_info &ti) {
+#ifdef __GNUG__
+  int status = 0;
+  std::unique_ptr<char, void (*)(void *)> res{
+      abi::__cxa_demangle(ti.name(), nullptr, nullptr, &status), std::free};
+  return (status == 0) ? res.get() : ti.name();
+#elif defined(_MSC_VER)
+  return ti.name(); // MSVC already provides demangled names with typeid
+#else
+  return ti.name(); // Default: no demangling
+#endif
 }


### PR DESCRIPTION
This PR adds type ser/de capabilities for ESI runtime types. The ser/de format is inspired/copied from what is already now used in the manifest generation, although we do not use CIRCT type mnemonics, nor do we include CIRCT dialects in the serialized format. The intention is thus to _only_ map ESI runtime types.

If we indeed want a method for users to provide third-party types, the format used here could easily be extended to allow for external ser/de plugins to be hooked into these two functions.

All types are registered on the context upon construction. Likewise, we use the context as a cache for pre-existing types.