### PR TITLE
[arcilator] add option to treat async firreg resets as sync

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -48,7 +48,7 @@ std::unique_ptr<mlir::Pass> createMuxToControlFlowPass();
 std::unique_ptr<mlir::Pass> createPrintCostModelPass();
 std::unique_ptr<mlir::Pass> createSimplifyVariadicOpsPass();
 std::unique_ptr<mlir::Pass> createSplitLoopsPass();
-std::unique_ptr<mlir::Pass> createStripSVPass(bool ignoreAsync = false);
+std::unique_ptr<mlir::Pass> createStripSVPass(bool asyncResetsAsSync = false);
 
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/Arc/ArcPasses.h.inc"

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -366,7 +366,7 @@ def StripSV : Pass<"arc-strip-sv", "mlir::ModuleOp"> {
   let dependentDialects = ["arc::ArcDialect", "comb::CombDialect",
                            "hw::HWDialect", "seq::SeqDialect"];
   let options = [
-    Option<"ignoreAsync", "ignore-async", "bool", "false",
+    Option<"asyncResetsAsSync", "async-resets-as-sync", "bool", "false",
       "Treat asynchronous resets as synchronous.">
   ];
 }

--- a/include/circt/Tools/arcilator/pipelines.h
+++ b/include/circt/Tools/arcilator/pipelines.h
@@ -42,8 +42,8 @@ struct ArcPreprocessingOptions
       llvm::cl::desc("Make all memory contents observable"),
       llvm::cl::init(false)};
 
-  Option<bool> ignoreAsync{
-      *this, "ignore-async",
+  Option<bool> asyncResetsAsSync{
+      *this, "async-resets-as-sync",
       llvm::cl::desc("Treat asynchronous firreg resets as synchronous"),
       llvm::cl::init(false)};
 };

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -44,7 +44,7 @@ void circt::populateArcPreprocessingPipeline(
     opts.tapNamedValues = options.observeNamedValues;
     pm.addPass(arc::createAddTapsPass(opts));
   }
-  pm.addPass(arc::createStripSVPass(options.ignoreAsync));
+  pm.addPass(arc::createStripSVPass(options.asyncResetsAsSync));
   {
     arc::InferMemoriesOptions opts;
     opts.tapPorts = options.observePorts;

--- a/test/Dialect/Arc/strip-sv-ignore-async.mlir
+++ b/test/Dialect/Arc/strip-sv-ignore-async.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --arc-strip-sv='ignore-async' | FileCheck %s
+// RUN: circt-opt %s --arc-strip-sv='async-resets-as-sync' | FileCheck %s
 
 // CHECK: hw.module @AsyncReg(in [[CLK:%.+]] : !seq.clock, in [[RST:%.+]] : i1, in [[ARG0:%.+]] : i8) {
 // CHECK:  [[C0_I8:%.+]] = hw.constant 0 : i8

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -183,8 +183,8 @@ static llvm::cl::opt<unsigned> splitFuncsThreshold(
         "Split large MLIR functions that occur above the given size threshold"),
     llvm::cl::ValueOptional, llvm::cl::cat(mainCategory));
 
-static llvm::cl::opt<bool> ignoreAsync(
-    "ignore-async",
+static llvm::cl::opt<bool> asyncResetsAsSync(
+    "async-resets-as-sync",
     llvm::cl::desc("Treat asynchronous firreg resets as synchronous"),
     llvm::cl::init(false), llvm::cl::cat(mainCategory));
 
@@ -268,7 +268,7 @@ static void populateHwModuleToArcPipeline(PassManager &pm) {
   preprocessingOpt.observeWires = observeWires;
   preprocessingOpt.observeNamedValues = observeNamedValues;
   preprocessingOpt.observeMemories = observeMemories;
-  preprocessingOpt.ignoreAsync = ignoreAsync;
+  preprocessingOpt.asyncResetsAsSync = asyncResetsAsSync;
   populateArcPreprocessingPipeline(pm, preprocessingOpt);
 
   // Restructure the input from a `hw.module` hierarchy to a collection of arcs.


### PR DESCRIPTION
This adds an explicit option to treat async resets on firregs as synchronous - this was implicitly done before #9359, so this means we can still support the designs we could before without silently mutating circuit semantics.