### PR TITLE
[ImportVerilog] Convert realtime values to f64 before operations

### DIFF
--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3792,3 +3792,31 @@ package PackageGlobal;
   // CHECK-NEXT: moore.yield [[TMP2]] : i42
   bit [41:0] packageGlobal2 = packageGlobal1;
 endpackage
+
+// CHECK-LABEL: moore.module @realtimeOperations
+module realtimeOperations;
+  realtime x;
+  shortreal a = 0.3;
+
+  // CHECK: procedure initial
+  // CHECK: moore.fadd %{{.*}}, %{{.*}} : f64
+  // CHECK: moore.fgt %{{.*}}, %{{.*}} : f64 -> i1
+  initial begin
+    x = x + a;
+    if (x > 1.1001) begin
+      $finish;
+    end
+  end 
+  // CHECK: procedure initial
+  // CHECK: moore.constant_real
+  // CHECK: [[ONE:%.+]] = moore.constant_real 1.000000e+05 : f64
+  // CHECK: moore.fadd %{{.*}}, [[ONE]] : f64
+  initial begin
+    x = ++x;
+  end
+  // CHECK: procedure initial
+  // CHECK: moore.fneg %{{.*}} : f64
+  initial begin
+    x = -x;
+  end
+endmodule


### PR DESCRIPTION
errors.txt diff
```
8c8
<   38 error: failed to legalize operation 'moore.variable'
---
>   39 error: failed to legalize operation 'moore.variable'
12a13
>   34 error: failed to legalize operation 'moore.builtin.time'
14d14
<   31 error: failed to legalize operation 'moore.builtin.time'
19a20
>   23 error: failed to legalize operation 'moore.logic_to_time'
22d22
<   21 error: failed to legalize operation 'moore.logic_to_time'
89d88
<    3 error: 'moore.fne' op operand #0 must be a SystemVerilog real type, but got '!moore.time'
269,270d267
<    1 error: 'moore.fgt' op operand #0 must be a SystemVerilog real type, but got '!moore.time'
<    1 error: 'moore.feq' op operand #0 must be a SystemVerilog real type, but got '!moore.time'
```