### PR TITLE
[ImportVerilog] Cast func call arguments to types matching func decl

### DIFF
--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3826,3 +3826,22 @@ module subroutineResultValueCastedToCorrecType;
   // CHECK: moore.xor {{%.+}}, {{.*}} : i32
 	int a = $time && (25'h300a ^ $stime);
 endmodule
+
+// CHECK-LABEL: moore.module @implicitCastsFunctionArguments
+module implicitCastsFunctionArguments;
+  real r, q;
+
+  function void fn(output logic [3:0] o, input logic [3:0] val);
+    o = val;
+  endfunction
+
+  // CHECK: procedure initial
+  initial begin
+    // CHECK: [[TMP1:%.+]] = moore.conversion %q : !moore.ref<f64> -> !moore.ref<l4>
+    // CHECK: [[TMP2:%.+]] = moore.read %r : <f64>
+    // CHECK: [[TMP3:%.+]] = moore.real_to_int [[TMP2]] : f64 -> i4
+    // CHECK: [[TMP4:%.+]] = moore.int_to_logic [[TMP3]] : i4
+    // CHECK: func.call @fn([[TMP1]], [[TMP4]]) : (!moore.ref<l4>, !moore.l4) -> ()
+    fn(q, r);
+  end
+endmodule


### PR DESCRIPTION
errors.txt diff
```
3c3
<   59 error: failed to legalize operation 'moore.fmt.real'
---
>   62 error: failed to legalize operation 'moore.fmt.real'
8a9
>   37 error: failed to legalize operation 'moore.builtin.time'
10d10
<   36 error: failed to legalize operation 'moore.builtin.time'
69a70
>    4 error: failed to legalize operation 'moore.conversion'
125d125
<    2 error: failed to legalize operation 'moore.conversion'
269,274d268
<    1 error: 'func.call' op operand type mismatch: expected operand type '!moore.ref<l32>', but provided '!moore.ref<l1>' for operand number 0
<    1 error: 'func.call' op operand type mismatch: expected operand type '!moore.ref<l1>', but provided '!moore.ref<l32>' for operand number 0
<    1 error: 'func.call' op operand type mismatch: expected operand type '!moore.ref<i8>', but provided '!moore.ref<f64>' for operand number 0
<    1 error: 'func.call' op operand type mismatch: expected operand type '!moore.l4', but provided '!moore.i4' for operand number 1
<    1 error: 'func.call' op operand type mismatch: expected operand type '!moore.l4', but provided '!moore.i4' for operand number 0
<    1 error: 'func.call' op operand type mismatch: expected operand type '!moore.f64', but provided '!moore.time' for operand number 0
```