### PR TITLE
[ImportVerilog] Add support for program definitions

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -803,11 +803,12 @@ Context::convertModuleHeader(const slang::ast::InstanceBodySymbol *module) {
   auto loc = convertLocation(module->location);
   OpBuilder::InsertionGuard g(builder);
 
-  // We only support modules for now. Extension to interfaces and programs
+  // We only support modules and programs for now. Extension to interfaces
   // should be trivial though, since they are essentially the same thing with
   // only minor differences in semantics.
-  if (module->getDefinition().definitionKind !=
-      slang::ast::DefinitionKind::Module) {
+  auto kind = module->getDefinition().definitionKind;
+  if (kind != slang::ast::DefinitionKind::Module &&
+      kind != slang::ast::DefinitionKind::Program) {
     mlir::emitError(loc) << "unsupported definition: "
                          << module->getDefinition().getKindString();
     return {};

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3845,3 +3845,7 @@ module implicitCastsFunctionArguments;
     fn(q, r);
   end
 endmodule
+
+// CHECK-LABEL: moore.module @ProgramsAreMostlyModules
+program ProgramsAreMostlyModules;
+endprogram


### PR DESCRIPTION
Programs are essentially just modules. There are a few subtle semantic differences, but we aren't far enough down the simulation path to have those show up. For the time being, just treat programs as modules. We will add the necessary exit blocking mechanisms later on when we have sufficient simulation support in Arcilator.