### PR TITLE
[MooreToCore] Lower $time to new LLHD current time op

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDValueOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDValueOps.td
@@ -44,3 +44,17 @@ def ConstantTimeOp : LLHDOp<"constant_time",
 
   let hasFolder = 1;
 }
+
+def CurrentTimeOp : LLHDOp<"current_time", [MemoryEffects<[MemRead]>]> {
+  let summary = "Get the current simulation time";
+  let description = [{
+    Materializes the current simulation time as an SSA value. This is equivalent
+    to the `$time`, `$stime`, and `$realtime` system tasks in SystemVerilog, and
+    the `now` keyword in VHDL.
+
+    This operation has a memory read side effect to avoid motion and CSE across
+    `llhd.wait` operations, and other operations that may suspend execution.
+  }];
+  let results = (outs LLHDTimeType:$result);
+  let assemblyFormat = "attr-dict";
+}

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2101,6 +2101,17 @@ static LogicalResult convert(FinishMessageBIOp op,
 }
 
 //===----------------------------------------------------------------------===//
+// Timing Control Conversion
+//===----------------------------------------------------------------------===//
+
+// moore.builtin.time
+static LogicalResult convert(TimeBIOp op, TimeBIOp::Adaptor adaptor,
+                             ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<llhd::CurrentTimeOp>(op);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Conversion Infrastructure
 //===----------------------------------------------------------------------===//
 
@@ -2442,6 +2453,9 @@ static void populateOpConversion(ConversionPatternSet &patterns,
   patterns.add<SeverityBIOp>(convert);
   patterns.add<FinishBIOp>(convert);
   patterns.add<FinishMessageBIOp>(convert);
+
+  // Timing control
+  patterns.add<TimeBIOp>(convert);
 
   mlir::populateAnyFunctionOpInterfaceTypeConversionPattern(patterns,
                                                             typeConverter);

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1413,3 +1413,11 @@ func.func @RealToIntLowering(%arg0: !moore.f32, %arg1: !moore.f64) {
   %1 = moore.real_to_int %arg1 : f64 -> i42
   return
 }
+
+// CHECK-LABEL: func.func @CurrentTime
+func.func @CurrentTime() -> !moore.time {
+  // CHECK-NEXT: [[TMP:%.+]] = llhd.current_time
+  %0 = moore.builtin.time
+  // CHECK-NEXT: return [[TMP]] : !llhd.time
+  return %0 : !moore.time
+}

--- a/test/Dialect/LLHD/Canonicalization/canonicalizers.mlir
+++ b/test/Dialect/LLHD/Canonicalization/canonicalizers.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @CanRemoveUnusedCurrentTime
+func.func @CanRemoveUnusedCurrentTime() {
+  // CHECK-NOT: llhd.current_time
+  llhd.current_time
+  // CHECK-NEXT: return
+  return
+}

--- a/test/Dialect/LLHD/Canonicalization/cse.mlir
+++ b/test/Dialect/LLHD/Canonicalization/cse.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt --cse %s | FileCheck %s
+
+// CHECK-LABEL: @CanCSECurrentTimeWithoutSideEffectsInBetween
+func.func @CanCSECurrentTimeWithoutSideEffectsInBetween() -> (!llhd.time, !llhd.time) {
+  // CHECK-NEXT: [[TMP0:%.+]] = llhd.current_time
+  %0 = llhd.current_time
+  // CHECK-NOT: llhd.current_time
+  %1 = llhd.current_time
+  // CHECK-NEXT: return [[TMP0]], [[TMP0]]
+  return %0, %1 : !llhd.time, !llhd.time
+}
+
+// CHECK-LABEL: @CannotCSECurrentTimeWithSideEffectsInBetween
+func.func @CannotCSECurrentTimeWithSideEffectsInBetween() -> (!llhd.time, !llhd.time) {
+  // CHECK-NEXT: [[TMP0:%.+]] = llhd.current_time
+  %0 = llhd.current_time
+  // CHECK-NEXT: call @UnknownSideEffects
+  call @UnknownSideEffects() : () -> ()
+  // CHECK-NEXT: [[TMP1:%.+]] = llhd.current_time
+  %1 = llhd.current_time
+  // CHECK-NEXT: return [[TMP0]], [[TMP1]]
+  return %0, %1 : !llhd.time, !llhd.time
+}
+
+func.func private @UnknownSideEffects()

--- a/test/Dialect/LLHD/IR/basic.mlir
+++ b/test/Dialect/LLHD/IR/basic.mlir
@@ -197,3 +197,10 @@ hw.module @CombinationalProcess(in %arg0: i1, in %arg1: i42, in %arg2: i9001, in
     llhd.yield %1, %2 : i42, i9001
   }
 }
+
+// CHECK-LABEL: @CurrentTime
+func.func @CurrentTime() -> !llhd.time {
+  // CHECK: llhd.current_time
+  %0 = llhd.current_time
+  return %0 : !llhd.time
+}


### PR DESCRIPTION
Add support for lowering the `moore.builtin.time` op to a new `llhd.current_time` op that simply materializes the current simulation time as an SSA value.

Error diff on circt-tests:
```diff
-37 error: failed to legalize operation 'moore.builtin.time'
+22 error: failed to legalize operation 'moore.time_to_logic'
+15 error: failed to legalize operation 'moore.fmt.time'
  0 total change
```