### PR TITLE
[LLHD] Add conversion ops between time and integer values

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDValueOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDValueOps.td
@@ -58,3 +58,21 @@ def CurrentTimeOp : LLHDOp<"current_time", [MemoryEffects<[MemRead]>]> {
   let results = (outs LLHDTimeType:$result);
   let assemblyFormat = "attr-dict";
 }
+
+def TimeToIntOp : LLHDOp<"time_to_int", [Pure]> {
+  let summary = "Convert a time to an integer number of femtoseconds";
+  let description = [{
+    If the time value converted to femtoseconds does not fit into an `i64`, the
+    result is undefined.
+  }];
+  let arguments = (ins LLHDTimeType:$input);
+  let results = (outs I64:$result);
+  let assemblyFormat = "$input attr-dict";
+}
+
+def IntToTimeOp : LLHDOp<"int_to_time", [Pure]> {
+  let summary = "Convert an integer number of femtoseconds to a time";
+  let arguments = (ins I64:$input);
+  let results = (outs LLHDTimeType:$result);
+  let assemblyFormat = "$input attr-dict";
+}

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2111,6 +2111,20 @@ static LogicalResult convert(TimeBIOp op, TimeBIOp::Adaptor adaptor,
   return success();
 }
 
+// moore.logic_to_time
+static LogicalResult convert(LogicToTimeOp op, LogicToTimeOp::Adaptor adaptor,
+                             ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<llhd::IntToTimeOp>(op, adaptor.getInput());
+  return success();
+}
+
+// moore.time_to_logic
+static LogicalResult convert(TimeToLogicOp op, TimeToLogicOp::Adaptor adaptor,
+                             ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<llhd::TimeToIntOp>(op, adaptor.getInput());
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Conversion Infrastructure
 //===----------------------------------------------------------------------===//
@@ -2456,6 +2470,8 @@ static void populateOpConversion(ConversionPatternSet &patterns,
 
   // Timing control
   patterns.add<TimeBIOp>(convert);
+  patterns.add<LogicToTimeOp>(convert);
+  patterns.add<TimeToLogicOp>(convert);
 
   mlir::populateAnyFunctionOpInterfaceTypeConversionPattern(patterns,
                                                             typeConverter);

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1421,3 +1421,13 @@ func.func @CurrentTime() -> !moore.time {
   // CHECK-NEXT: return [[TMP]] : !llhd.time
   return %0 : !moore.time
 }
+
+// CHECK-LABEL: func.func @TimeConversion
+func.func @TimeConversion(%arg0: !moore.l64, %arg1: !moore.time) -> (!moore.time, !moore.l64) {
+  // CHECK-NEXT: [[TMP0:%.+]] = llhd.int_to_time %arg0
+  %0 = moore.logic_to_time %arg0
+  // CHECK-NEXT: [[TMP1:%.+]] = llhd.time_to_int %arg1
+  %1 = moore.time_to_logic %arg1
+  // CHECK-NEXT: return [[TMP0]], [[TMP1]]
+  return %0, %1 : !moore.time, !moore.l64
+}

--- a/test/Dialect/LLHD/IR/basic.mlir
+++ b/test/Dialect/LLHD/IR/basic.mlir
@@ -204,3 +204,12 @@ func.func @CurrentTime() -> !llhd.time {
   %0 = llhd.current_time
   return %0 : !llhd.time
 }
+
+// CHECK-LABEL: @TimeConversion
+func.func @TimeConversion(%arg0: i64, %arg1: !llhd.time) -> (!llhd.time, i64) {
+  // CHECK: llhd.int_to_time %arg0
+  %0 = llhd.int_to_time %arg0
+  // CHECK: llhd.time_to_int %arg1
+  %1 = llhd.time_to_int %arg1
+  return %0, %1 : !llhd.time, i64
+}


### PR DESCRIPTION
Add the `llhd.time_to_int` and `llhd.int_to_time` conversion ops. These convert `!llhd.time` to and from an `i64` number of femtoseconds. This is useful since the Verilog frontend will often map time values to integers for printing or to give the user an integer value scaled by the local timeunit/timeprecision.

We might want to make this more flexible in the future, for example by allowing the integer to be of any bit width, or by allowing the exact time unit to be specified.

Make use of these new ops in the MooreToCore conversion pass to convert `moore.time_to_logic` and `moore.logic_to_time` ops.

---
Diff of `circt-tests/results/sv-tests/errors.txt`:
```
-28 error: failed to legalize operation 'moore.time_to_logic'
-23 error: failed to legalize operation 'moore.logic_to_time'
 +4 error: failed to legalize operation 'moore.fmt.real'
 +4 error: failed to legalize operation 'moore.fmt.time'
 +3 error: 'hw.constant' op requires attribute 'value'
 +2 error: 'llhd.wait' op expects parent op 'llhd.process'
 +2 error: failed to legalize operation 'moore.bool_cast'
 +1 error: integer bitwidth is limited to 16777215 bits
-35 total change
```