### PR TITLE
[ImportVerilog] Replace FormatTimeOp with FormatIntOp

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2038,27 +2038,6 @@ def FormatRealOp : MooreOp<"fmt.real", [Pure]> {
   }];
 }
 
-def FormatTimeOp : MooreOp<"fmt.time", [Pure]> {
-  let summary = "Format a time value";
-  let description = [{
-  Format a time value as a string according to the format specified by the most recent
-  invocation of `$timeformat`.
-
-  See IEEE 1800-2023 § 21.2.1.1 "Format specifications" and
-  IEEE 1800-2023 § 20.4.3 "$timeformat".
-  }];
-  let arguments = (ins
-  TimeType:$value,
-  OptionalAttr<I32Attr>:$width
-  );
-  let results = (outs FormatStringType:$result);
-  let assemblyFormat = [{
-      $value
-      (`,` `width` $width^)?
-      attr-dict
-  }];
-}
-
 def FormatStringOp : MooreOp<"fmt.string", [Pure]> {
   let summary = "A dynamic string fragment";
   let description = [{

--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -231,32 +231,26 @@ struct FormatStringParser {
   }
 
   // Format an integer with the %t specifier according to IEEE 1800-2023
-  // § 20.4.3 "$timeformat"
+  // § 20.4.3 "$timeformat". We currently don't support user-defined time
+  // formats. Instead, we just convert the time to an integer and print it. This
+  // applies the local timeunit/timescale and seem to be inline with what
+  // Verilator does.
   LogicalResult emitTime(const slang::ast::Expression &arg,
                          const FormatOptions &options) {
-
-    // Only handle `TimeType` values.
+    // Handle the time argument and convert it to a 64 bit integer.
     auto value = context.convertRvalueExpression(
-        arg, moore::TimeType::get(context.getContext()));
+        arg, moore::IntType::getInt(context.getContext(), 64));
     if (!value)
       return failure();
 
-    mlir::IntegerAttr width = nullptr;
-    if (options.width) {
-      mlir::Type i32Ty =
-          mlir::IntegerType::get(context.getContext(), /*width=*/32);
-      width = mlir::IntegerAttr::get(i32Ty, options.width.value());
-    }
-
-    // Delegate actual formatting to `moore.fmt.time`, annotate width if
-    // provided
-    if (width) {
-      fragments.push_back(
-          moore::FormatTimeOp::create(builder, loc, value, width));
-    } else {
-      fragments.push_back(moore::FormatTimeOp::create(builder, loc, value));
-    }
-
+    // Create an integer formatting fragment.
+    uint32_t width = 20; // default $timeformat field width
+    if (options.width)
+      width = *options.width;
+    auto alignment = options.leftJustify ? IntAlign::Left : IntAlign::Right;
+    auto padding = options.zeroPad ? IntPadding::Zero : IntPadding::Space;
+    fragments.push_back(moore::FormatIntOp::create(
+        builder, loc, value, IntFormat::Decimal, width, alignment, padding));
     return success();
   }
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3222,26 +3222,21 @@ function automatic int unsigned returnParameterArrayElement (int idx);
 endfunction
 
 // CHECK-LABEL: func.func private @TimeFormat(
-function void TimeFormat();
-  // CHECK: [[TIME:%.+]] = moore.constant_time 100000000 fs
-  localparam time TestTime = 100ns;
-  // CHECK-NEXT: [[FMT:%.+]] = moore.fmt.time [[TIME]]
-  // CHECK-NEXT: [[LINEBREAK:%.+]] = moore.fmt.literal "\0A"
-  // CHECK-NEXT: [[CONCAT:%.+]] = moore.fmt.concat ([[FMT]], [[LINEBREAK]])
-  // CHECK-NEXT: moore.builtin.display [[CONCAT]]
-  $display("%t", TestTime);
-  // CHECK: [[SIMTIME:%.+]] = moore.builtin.time
-  // CHECK-NEXT: [[FMT2:%.+]] = moore.fmt.time [[SIMTIME]]
-  // CHECK-NEXT: [[LINEBREAK2:%.+]] = moore.fmt.literal "\0A"
-  // CHECK-NEXT: [[CONCAT2:%.+]] = moore.fmt.concat ([[FMT2]], [[LINEBREAK2]])
-  // CHECK-NEXT: moore.builtin.display [[CONCAT2]]
-  $display("%t", $time());
-  // CHECK: [[SIMTIME3:%.+]] = moore.builtin.time
-  // CHECK-NEXT: [[FMT3:%.+]] = moore.fmt.time [[SIMTIME3]], width 4
-  // CHECK-NEXT: [[LINEBREAK3:%.+]] = moore.fmt.literal "\0A"
-  // CHECK-NEXT: [[CONCAT3:%.+]] = moore.fmt.concat ([[FMT3]], [[LINEBREAK3]])
-  // CHECK-NEXT: moore.builtin.display [[CONCAT3]]
-  $display("%4t", $time());
+function void TimeFormat(time x);
+  // CHECK: [[TMP1:%.+]] = moore.time_to_logic
+  // CHECK: [[TMP2:%.+]] = moore.constant
+  // CHECK: [[TMP3:%.+]] = moore.divu [[TMP1]], [[TMP2]]
+  // CHECK: [[TMP4:%.+]] = moore.logic_to_int [[TMP3]]
+  // CHECK: moore.fmt.int decimal [[TMP4]], width 20, align right, pad space
+  $display("%t", x);
+  // CHECK: moore.fmt.int decimal {{%.+}}, width 42, align right, pad space
+  $display("%42t", x);
+  // CHECK: moore.fmt.int decimal {{%.+}}, width 42, align left, pad space
+  $display("%-42t", x);
+  // CHECK: moore.fmt.int decimal {{%.+}}, width 20, align right, pad zero
+  $display("%0t", x);
+  // CHECK: moore.fmt.int decimal {{%.+}}, width 0, align right, pad zero
+  $display("%00t", x);
 endfunction
 
 // CHECK-LABEL: func.func private @StructCreateConversion(


### PR DESCRIPTION
Remove the `FormatTimeOp` from the Moore dialect. Instead, use the `FormatIntOp` to handle the `%t` format specifier.

This is roughly what Verilator does. According to the SV spec, the time format specifier must use a global time format that the user can adjust with the `$timeformat` system task. By default, the time format is set to print time as an integer with the smallest timeprecision used anywhere in the input, and without any suffix string. If not specified alongside the `%t`, a width of 20 is used. (The largest 64 bit integer requires 20 characters.) Since we don't support `$timeformat` at the moment, we just format `%t` as a time value converted to an integer. This uses the local timeprecision instead of the globally minimal one, but that's close enough to get started.

---
Diff of `circt-tests/results/sv-tests/errors.txt`:
```
-17 error: failed to legalize operation 'moore.fmt.time'
+17 error: failed to legalize operation 'moore.time_to_logic'
  0 total change
```
This will stack nicely with #9405.