### PR TITLE
[ArithToComb] Avoid converting float constants to HW

### DIFF
--- a/test/Transforms/map-arith-to-comb.mlir
+++ b/test/Transforms/map-arith-to-comb.mlir
@@ -41,9 +41,16 @@ func.func @basics(%arg0: i32, %arg1: i32, %arg2: i1) {
   arith.trunci %arg1 : i32 to i16
   // CHECK: comb.icmp slt %arg0, %arg1 : i32
   arith.cmpi slt, %arg0, %arg1 : i32
+  // CHECK: return
+  return
+}
+
+// CHECK-LABEL: func @constants
+func.func @constants() {
   // CHECK: hw.constant 0 : i32
   arith.constant 0 : i32
-  // CHECK: return
+  // CHECK: arith.constant 0.000000e+00 : f32
+  arith.constant 0.000000e+00 : f32
   return
 }
 


### PR DESCRIPTION
The MapArithToComb pass currently breaks when the input contains an `arith.constant` with a float value. The pass would blindly try to map the op to an `hw.constant` and pass along the float attribute, which then fails verification. Instead, only convert integer-typed Arith constants to HW, and keep others as Arith constants.