### PR TITLE
[circt-test] Add supported test kind to runner config

### DIFF
--- a/test/circt-test/filter-runners.mlir
+++ b/test/circt-test/filter-runners.mlir
@@ -1,0 +1,19 @@
+// RUN: circt-test --dry-run %s | FileCheck %s
+
+// Since we only have formal runners at the moment, only the formal tests should run.
+
+// CHECK: TestA:
+verif.formal @TestA {} {}
+
+// CHECK: TestB:
+verif.formal @TestB {} {}
+
+// CHECK-NOT: TestC:
+verif.simulation @TestC {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %0 = hw.constant true
+  verif.yield %0, %0 : i1, i1
+}
+
+// CHECK: TestD:
+verif.formal @TestD {} {}

--- a/test/circt-test/list-runners.mlir
+++ b/test/circt-test/list-runners.mlir
@@ -1,0 +1,4 @@
+// RUN: circt-test --list-runners | FileCheck %s
+
+// CHECK-DAG: sby formal {{.*}}circt-test-runner-sby.py
+// CHECK-DAG: circt-bmc formal {{.*}}circt-test-runner-circt-bmc.py


### PR DESCRIPTION
Track whether a runner supports simulation or formal tests, and only pick runners that support a given test. To test this, also add a `--dry-run` option that simply prints the runner command line instead of executing it. This will allow us to test various filtering behavior in the future.