### PR TITLE
[HWToLLVM] Ignore operations of other dialects

### DIFF
--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -879,6 +879,8 @@ void HWToLLVMLoweringPass::runOnOperation() {
 
   LLVMConversionTarget target(getContext());
   target.addIllegalDialect<hw::HWDialect>();
+  // Don't touch non-HW operations
+  target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 
   // Setup the conversion.
   populateHWToLLVMConversionPatterns(converter, patterns, globals,

--- a/test/Conversion/HWToLLVM/foreign_ops.mlir
+++ b/test/Conversion/HWToLLVM/foreign_ops.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt %s --convert-hw-to-llvm | FileCheck %s
+
+// Check that folding of non-HW operations is not attempted
+// CHECK-LABEL: func.func @issue9371
+func.func @issue9371(%arg: i32) -> (i32) {
+  // CHECK: arith.xori
+  %xor = arith.xori %arg, %arg : i32
+  return %xor : i32
+}


### PR DESCRIPTION
Consider all non-HW operations legal in HWToLLVM to prevent attempts of fold leglaization.

Should fix #9371.
#9394 did the same for CombToArith.