### PR TITLE
[circt-test] Install test runners alongside circt-test

### DIFF
--- a/tools/circt-test/CMakeLists.txt
+++ b/tools/circt-test/CMakeLists.txt
@@ -29,8 +29,17 @@ target_link_libraries(circt-test PRIVATE ${libs})
 llvm_update_compile_flags(circt-test)
 mlir_check_all_link_libraries(circt-test)
 
-set(all_runner_paths "")
+#-------------------------------------------------------------------------------
+# Runners
+#-------------------------------------------------------------------------------
+
+add_custom_target(circt-test-runners)
+add_custom_target(install-circt-test-runners)
+
 foreach(runner sby circt-bmc)
+  set(name circt-test-runner-${runner})
+
+  # Copy the test runner script to the tools build directory.
   set(src_path ${CMAKE_CURRENT_SOURCE_DIR}/circt-test-runner-${runner}.py)
   set(dst_path ${CIRCT_TOOLS_DIR}/circt-test-runner-${runner}.py)
   add_custom_command(
@@ -38,7 +47,24 @@ foreach(runner sby circt-bmc)
     DEPENDS ${src_path}
     COMMAND ${CMAKE_COMMAND} -E copy ${src_path} ${dst_path}
   )
-  list(APPEND all_runner_paths ${dst_path})
+  add_custom_target(${name} DEPENDS ${dst_path})
+  add_dependencies(circt-test-runners ${name})
+
+  # Add an install target for the runner.
+  if (CIRCT_BUILD_TOOLS)
+    install(
+      PROGRAMS ${dst_path}
+      DESTINATION "${CIRCT_TOOLS_INSTALL_DIR}"
+      COMPONENT ${name}
+    )
+    if(NOT CMAKE_CONFIGURATION_TYPES)
+      add_llvm_install_targets(install-${name}
+        DEPENDS ${name}
+        COMPONENT ${name})
+    endif()
+    add_dependencies(install-circt-test-runners install-${name})
+  endif()
 endforeach()
-add_custom_target(circt-test-runners DEPENDS ${all_runner_paths})
+
 add_dependencies(circt-test circt-test-runners)
+add_dependencies(install-circt-test install-circt-test-runners)


### PR DESCRIPTION
Install the circt-test runner scripts as if they were any other CIRCT tool. Also add a corresponding new `install-circt-test-runners` target that installs all runners, and make `install-circt-test` depend on it. This causes the runners to be installed whenever circt-test is installed.