### PR TITLE
[circt-test] Add Verilator test runner

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot build & test guidance
 
-- Default to the integration docker image in `CIRCT_INTEGRATION_IMAGE` (set by the Copilot setup workflow and the `utils/run-docker.sh` default; currently `ghcr.io/circt/images/circt-integration-test:v19.2`) when compiling or testing.
+- Default to the integration docker image in `CIRCT_INTEGRATION_IMAGE` (set by the Copilot setup workflow and the `utils/run-docker.sh` default; currently `ghcr.io/circt/images/circt-integration-test:v20`) when compiling or testing.
 - Run inside that image via `./utils/run-docker.sh ./utils/run-tests-docker.sh "$CIRCT_INTEGRATION_IMAGE"` or `docker run` with the repo root bind-mounted.
 - When cloning or checking out, ensure submodules are present (`git submodule update --init --recursive` if needed).
 - Configure builds from the repo root with Ninja, matching the README:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Pre-pull integration docker image
         env:
-          CIRCT_INTEGRATION_IMAGE: ghcr.io/circt/images/circt-integration-test:v19.2
+          CIRCT_INTEGRATION_IMAGE: ghcr.io/circt/images/circt-integration-test:v20
         run: |
           echo "CIRCT_INTEGRATION_IMAGE=$CIRCT_INTEGRATION_IMAGE" >> $GITHUB_ENV
           docker pull "$CIRCT_INTEGRATION_IMAGE"

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -19,7 +19,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v19.2
+      image: ghcr.io/circt/images/circt-integration-test:v20
       volumes:
         - /mnt:/__w/circt
     strategy:

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       cache-key-pattern: ${{ steps.cache-key.outputs.pattern }}
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v19.2
+      image: ghcr.io/circt/images/circt-integration-test:v20
       volumes:
         - /mnt:/__w/circt
     strategy:

--- a/integration_test/circt-test/basic-verilator-fail.mlir
+++ b/integration_test/circt-test/basic-verilator-fail.mlir
@@ -1,0 +1,12 @@
+// RUN: not circt-test %s -d %t -r \verilator 2>&1 | FileCheck %s
+// REQUIRES: verilator
+
+// CHECK: test Foo failed
+// CHECK: 1 tests FAILED
+
+verif.simulation @Foo {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %false = hw.constant false
+  %true = hw.constant true
+  verif.yield %true, %false : i1, i1
+}

--- a/integration_test/circt-test/basic-verilator-pass.mlir
+++ b/integration_test/circt-test/basic-verilator-pass.mlir
@@ -1,0 +1,10 @@
+// RUN: circt-test %s -d %t -r \verilator 2>&1 | FileCheck %s
+// REQUIRES: verilator
+
+// CHECK: 1 tests passed
+
+verif.simulation @Foo {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %true = hw.constant true
+  verif.yield %true, %true : i1, i1
+}

--- a/test/circt-test/filter-runners.mlir
+++ b/test/circt-test/filter-runners.mlir
@@ -1,14 +1,12 @@
 // RUN: circt-test --dry-run %s | FileCheck %s
 
-// Since we only have formal runners at the moment, only the formal tests should run.
-
 // CHECK: TestA:
 verif.formal @TestA {} {}
 
 // CHECK: TestB:
 verif.formal @TestB {} {}
 
-// CHECK-NOT: TestC:
+// CHECK: TestC:
 verif.simulation @TestC {} {
 ^bb0(%clock: !seq.clock, %init: i1):
   %0 = hw.constant true

--- a/tools/circt-test/CMakeLists.txt
+++ b/tools/circt-test/CMakeLists.txt
@@ -36,7 +36,7 @@ mlir_check_all_link_libraries(circt-test)
 add_custom_target(circt-test-runners)
 add_custom_target(install-circt-test-runners)
 
-foreach(runner sby circt-bmc)
+foreach(runner sby circt-bmc verilator)
   set(name circt-test-runner-${runner})
 
   # Copy the test runner script to the tools build directory.

--- a/tools/circt-test/circt-test-runner-verilator.py
+++ b/tools/circt-test/circt-test-runner-verilator.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("verilog")
+parser.add_argument("-t", "--test", required=True)
+parser.add_argument("-d", "--directory", required=True)
+args = parser.parse_args()
+
+directory = Path(args.directory)
+source_path = Path(args.verilog)
+build_path = directory / "build"
+testbench_path = directory / "testbench.sv"
+
+# Generate the Verilog top-level that interacts with the test module.
+testbench = f"""
+module circt_test;
+  bit clock = 0, init = 1, done, success;
+  {args.test} dut(.clock, .init, .done, .success);
+  initial begin
+    #1 clock = 1;
+    #1 clock = 0; init = 0;
+    #1 clock = 1;
+    while (!done) begin
+      #1 clock = 0;
+      #1 clock = 1;
+    end
+    if (success) $finish; else $fatal;
+  end
+endmodule
+"""
+with open(testbench_path, "w") as f:
+  f.write(testbench)
+
+# Verilate the test.
+cmd = [
+    "verilator",
+    "--cc",
+    "--exe",
+    "--main",
+    "--timing",
+    testbench_path,
+    "-Mdir",
+    build_path,
+    "--top-module",
+    "circt_test",
+]
+if source_path.is_dir():
+  cmd += ["-F", source_path / "filelist.f"]
+else:
+  cmd += [source_path]
+sys.stderr.write("# " + shlex.join(str(c) for c in cmd) + "\n")
+sys.stderr.flush()
+if subprocess.call(cmd):
+  sys.exit(1)
+
+# Compile the test.
+cmd = ["make", "-j", "-C", build_path, "-f", "Vcirct_test.mk"]
+if arg := os.environ.get("CC"):
+  cmd += ["CC=" + arg]
+if arg := os.environ.get("CXX"):
+  cmd += ["CXX=" + arg]
+sys.stderr.write("# " + shlex.join(str(c) for c in cmd) + "\n")
+sys.stderr.flush()
+if subprocess.call(cmd):
+  sys.exit(1)
+
+# Run the test.
+cmd = [build_path / "Vcirct_test"]
+sys.stderr.write("# " + shlex.join(str(c) for c in cmd) + "\n")
+sys.stderr.flush()
+result = subprocess.call(cmd)
+sys.exit(result)

--- a/utils/run-docker.sh
+++ b/utils/run-docker.sh
@@ -20,7 +20,7 @@
 ##===----------------------------------------------------------------------===##
 
 CMD=${1:-"./utils/run-tests-docker.sh"}
-VER=${2:-"v19.2"}
+VER=${2:-"v20"}
 REPO_ROOT=$(cd "$(dirname "$BASH_SOURCE[0]")/.." && pwd)
 
 cd $REPO_ROOT


### PR DESCRIPTION
Add basic Verilator support to circt-test. This commit introduces a new `verilator` runner for simulation tests, which calls out to a new `circt-test-runner-verilator.py` script. The runner is pretty simplistic, but this at least gets us started.