### PR TITLE
[LLHD] Processes with timed waits are not combinational

### DIFF
--- a/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
+++ b/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
@@ -98,6 +98,11 @@ bool Lowering::matchControlFlow() {
                             << ": wait op has destination operands\n");
     return false;
   }
+  if (waitOp.getDelay()) {
+    LLVM_DEBUG(llvm::dbgs() << "Skipping process " << processOp.getLoc()
+                            << ": wait op has delay\n");
+    return false;
+  }
 
   // Helper function to skip across empty blocks with only a single successor.
   auto skipToMergePoint = [&](Block *block) -> std::pair<Block *, ValueRange> {


### PR DESCRIPTION
In the LowerProcesses pass, do not convert processes with a timed wait terminator such as `llhd.wait delay %0, ...` into `llhd.combinational` ops. Combinational ops are re-executed whenever any of the captured SSA values change. A timed wait causes the process to be re-executed after the given delay, which is not the same.