### PR TITLE
[CI] Set timeout to individual lit tests

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Sanity Check
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/circt/images/circt-ci-build:20250515145637
+      image: ghcr.io/circt/images/circt-ci-build:20260107030736
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -134,7 +134,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-ci-build:20250515145637
+      image: ghcr.io/circt/images/circt-ci-build:20260107030736
       volumes:
         - /mnt:/__w/circt
     strategy:
@@ -220,7 +220,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DLLVM_LIT_ARGS="-v" \
+            -DLLVM_LIT_ARGS="-v --timeout 300" \
             -DCIRCT_SLANG_FRONTEND_ENABLED=ON
           CIRCT_OPT_CHECK_IR_ROUNDTRIP=1 ninja check-circt check-circt-unit -j$(nproc)
           ninja circt-doc

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -97,7 +97,7 @@ jobs:
             -DLLVM_USE_SPLIT_DWARF=ON \
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
             -DCIRCT_BINDINGS_PYTHON_ENABLED=ON \
-            -DLLVM_LIT_ARGS="-v --show-unsupported" \
+            -DLLVM_LIT_ARGS="-v --show-unsupported --timeout 300" \
             -DCIRCT_SLANG_FRONTEND_ENABLED=ON
 
             # Temporarily disable ESI runtime builds until we work out the Abseil conflict (#7236).


### PR DESCRIPTION
By default there is no timeout for tests, but I think it's reasonable to set loose time limit so that we can identify tests with infinite loops more easily (like an issue we saw in https://github.com/llvm/circt/pull/9340). There is no difference in Docker image other than `psutil`.