### PR TITLE
[arcilator][HWToLLVM] Use HWConvertBitcasts pass in arcilator pipeline

### DIFF
--- a/integration_test/arcilator/JIT/bitcasts.mlir
+++ b/integration_test/arcilator/JIT/bitcasts.mlir
@@ -1,0 +1,110 @@
+// RUN: arcilator %s --run --jit-entry=orderTest | FileCheck %s --check-prefixes=ORDER
+// RUN: arcilator %s --run --jit-entry=roundtrip | FileCheck %s --check-prefixes=RTRIP
+// REQUIRES: arcilator-jit
+
+// --- Element order test ---
+
+// COM: Arrays: Low index = low bits
+// ORDER:      ae0 = b
+// ORDER-NEXT: ae1 = a
+// COM: Structs: Low index = high bits
+// ORDER-NEXT: se0 = a
+// ORDER-NEXT: se1 = b
+
+hw.module @arrayMod(in %raw: i8, out e0 : i4, out e1 : i4) {
+  %cst0 = hw.constant 0 : i1
+  %cst1 = hw.constant 1 : i1
+  %array = hw.bitcast %raw : (i8) -> !hw.array<2xi4>
+  %e0 = hw.array_get %array[%cst0] : !hw.array<2xi4>, i1
+  %e1 = hw.array_get %array[%cst1] : !hw.array<2xi4>, i1
+  hw.output %e0, %e1 : i4, i4
+}
+
+hw.module @structMod(in %raw: i8, out e0 : i4, out e1 : i4) {
+  %struct = hw.bitcast %raw : (i8) -> !hw.struct<a: i4, b: i4>
+  %e0 = hw.struct_extract %struct["a"] : !hw.struct<a: i4, b: i4>
+  %e1 = hw.struct_extract %struct["b"] :!hw.struct<a: i4, b: i4>
+  hw.output %e0, %e1 : i4, i4
+}
+
+func.func @orderTest() {
+  %cstAB = arith.constant 0xab : i8
+
+  arc.sim.instantiate @arrayMod as %model {
+    arc.sim.set_input %model, "raw" = %cstAB : i8, !arc.sim.instance<@arrayMod>
+    arc.sim.step %model : !arc.sim.instance<@arrayMod>
+    %e0 = arc.sim.get_port %model, "e0" : i4, !arc.sim.instance<@arrayMod>
+    %e1 = arc.sim.get_port %model, "e1" : i4, !arc.sim.instance<@arrayMod>
+    arc.sim.emit "ae0", %e0 : i4
+    arc.sim.emit "ae1", %e1 : i4
+  }
+
+  arc.sim.instantiate @structMod as %model {
+    arc.sim.set_input %model, "raw" = %cstAB : i8, !arc.sim.instance<@structMod>
+    arc.sim.step %model : !arc.sim.instance<@structMod>
+    %e0 = arc.sim.get_port %model, "e0" : i4, !arc.sim.instance<@structMod>
+    %e1 = arc.sim.get_port %model, "e1" : i4, !arc.sim.instance<@structMod>
+    arc.sim.emit "se0", %e0 : i4
+    arc.sim.emit "se1", %e1 : i4
+  }
+
+  return
+}
+
+// --- Roundtrip test ---
+
+// COM: Skip first two cycles
+// RTRIP-COUNT-2: match
+// RTRIP-COUNT-1024: match = 1
+
+hw.module @roundtripper(in %clk: i1, in %i: i10, out o: i10, out match: i1) {
+  %seq_clk = seq.to_clock %clk
+  %q = seq.compreg %i, %seq_clk : i10
+  %qq = seq.compreg %q, %seq_clk : i10
+  %array = hw.bitcast %i : (i10) -> !hw.array<5xi2>
+  %arrayReg = seq.compreg %array, %seq_clk : !hw.array<5xi2>
+  %struct = hw.bitcast %arrayReg : (!hw.array<5xi2>) -> !hw.struct<a: i1, b: !hw.array<7xi1>, c: i2>
+  %structReg = seq.compreg %struct, %seq_clk : !hw.struct<a: i1, b: !hw.array<7xi1>, c: i2>
+  %out = hw.bitcast %structReg : (!hw.struct<a: i1, b: !hw.array<7xi1>, c: i2>) -> i10
+  %match = comb.icmp eq %qq, %out: i10
+  hw.output %out, %match : i10, i1
+}
+
+func.func @roundtrip() {
+  %zero = arith.constant 0 : i1
+  %one = arith.constant 1 : i1
+  %lb = arith.constant 0 : index
+  %ub = arith.constant 1024 : index
+  %step = arith.constant 1 : index
+
+  arc.sim.instantiate @roundtripper as %model {
+    scf.for %i = %lb to %ub step %step {
+      %raw = arith.index_castui %i : index to i10
+      arc.sim.set_input %model, "i" = %raw : i10, !arc.sim.instance<@roundtripper>
+
+      arc.sim.set_input %model, "clk" = %one : i1, !arc.sim.instance<@roundtripper>
+      arc.sim.step %model : !arc.sim.instance<@roundtripper>
+      arc.sim.set_input %model, "clk" = %zero : i1, !arc.sim.instance<@roundtripper>
+      arc.sim.step %model : !arc.sim.instance<@roundtripper>
+
+      %res = arc.sim.get_port %model, "match" : i1, !arc.sim.instance<@roundtripper>
+      arc.sim.emit "match", %res : i1
+    }
+
+    arc.sim.set_input %model, "clk" = %one : i1, !arc.sim.instance<@roundtripper>
+    arc.sim.step %model : !arc.sim.instance<@roundtripper>
+    arc.sim.set_input %model, "clk" = %zero : i1, !arc.sim.instance<@roundtripper>
+    arc.sim.step %model : !arc.sim.instance<@roundtripper>
+    %res0 = arc.sim.get_port %model, "match" : i1, !arc.sim.instance<@roundtripper>
+    arc.sim.emit "match", %res0 : i1
+
+    arc.sim.set_input %model, "clk" = %one : i1, !arc.sim.instance<@roundtripper>
+    arc.sim.step %model : !arc.sim.instance<@roundtripper>
+    arc.sim.set_input %model, "clk" = %zero : i1, !arc.sim.instance<@roundtripper>
+    arc.sim.step %model : !arc.sim.instance<@roundtripper>
+    %res1 = arc.sim.get_port %model, "match" : i1, !arc.sim.instance<@roundtripper>
+    arc.sim.emit "match", %res1 : i1
+  }
+
+  return
+}

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -481,31 +481,6 @@ struct ArrayConcatOpConversion
 } // namespace
 
 //===----------------------------------------------------------------------===//
-// Bitwise conversions
-//===----------------------------------------------------------------------===//
-
-namespace {
-/// Lower an ArrayConcatOp operation to the LLVM dialect.
-/// Pattern: hw.bitcast(input) ==> load(bitcast_ptr(store(input, alloca)))
-/// This is necessary because we cannot bitcast aggregate types directly in
-/// LLVMIR.
-struct BitcastOpConversion : public ConvertOpToLLVMPattern<hw::BitcastOp> {
-  using ConvertOpToLLVMPattern<hw::BitcastOp>::ConvertOpToLLVMPattern;
-
-  LogicalResult
-  matchAndRewrite(hw::BitcastOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-
-    Type resultTy = typeConverter->convertType(op.getResult().getType());
-    auto ptr = spillValueOnStack(rewriter, op.getLoc(), adaptor.getInput());
-    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, resultTy, ptr);
-
-    return success();
-  }
-};
-} // namespace
-
-//===----------------------------------------------------------------------===//
 // Value creation conversions
 //===----------------------------------------------------------------------===//
 
@@ -839,9 +814,6 @@ void circt::populateHWToLLVMConversionPatterns(
       converter);
   patterns.add<AggregateConstantOpConversion>(
       converter, constAggregateGlobalsMap, globals, spillCacheOpt);
-
-  // Bitwise conversion patterns.
-  patterns.add<BitcastOpConversion>(converter);
 
   // Extraction operation conversion patterns.
   patterns.add<StructExplodeOpConversion, StructExtractOpConversion,

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -136,6 +136,11 @@ void circt::populateArcStateAllocationPipeline(
 }
 
 void circt::populateArcToLLVMPipeline(OpPassManager &pm) {
+  {
+    hw::HWConvertBitcastsOptions options;
+    options.allowPartialConversion = false;
+    pm.addPass(hw::createHWConvertBitcasts(options));
+  }
   pm.addPass(createLowerArcToLLVMPass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizerPass());

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -1,31 +1,5 @@
 // RUN: circt-opt %s --convert-hw-to-llvm=spill-arrays-early=false | FileCheck %s
 
-// CHECK-LABEL: @convertBitcast
-func.func @convertBitcast(%arg0 : i32, %arg1: !hw.array<2xi32>, %arg2: !hw.struct<foo: i32, bar: i32>) {
-  // CHECK-NEXT: %[[AARG2:.*]] = builtin.unrealized_conversion_cast %arg2 : !hw.struct<foo: i32, bar: i32> to !llvm.struct<(i32, i32)>
-  // CHECK-NEXT: %[[AARG1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-
-  // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[A1:.*]] = llvm.alloca %[[ONE1]] x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %arg0, %[[A1]] : i32, !llvm.ptr
-  // CHECK-NEXT: llvm.load %[[A1]] : !llvm.ptr -> !llvm.array<4 x i8>
-  %0 = hw.bitcast %arg0 : (i32) -> !hw.array<4xi8>
-
-  // CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[A2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[AARG1]], %[[A2]] : !llvm.array<2 x i32>, !llvm.ptr
-  // CHECK-NEXT: llvm.load %[[A2]] : !llvm.ptr -> i64
-  %1 = hw.bitcast %arg1 : (!hw.array<2xi32>) -> i64
-
-  // CHECK-NEXT: %[[ONE3:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[A3:.*]] = llvm.alloca %[[ONE3]] x !llvm.struct<(i32, i32)> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[AARG2]], %[[A3]] : !llvm.struct<(i32, i32)>, !llvm.ptr
-  // CHECK-NEXT: llvm.load %[[A3]] : !llvm.ptr -> i64
-  %2 = hw.bitcast %arg2 : (!hw.struct<foo: i32, bar: i32>) -> i64
-
-  return
-}
-
 // CHECK-LABEL: @convertArray
 func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
   // CHECK-NEXT: %[[CAST0:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>


### PR DESCRIPTION
This PR inserts the  HWConvertBitcasts into the arcilator pipeline and removes the incorrect lowering pattern for `hw.bitcast` from HWToLLVM. It also adds an integration test checking that bitcasts are handled correctly end to end.

Should fix #9417.