### PR TITLE
[circt-test] Reuse firtool pipeline to emit split verilog

### DIFF
--- a/integration_test/circt-test/basic-circt-bmc.mlir
+++ b/integration_test/circt-test/basic-circt-bmc.mlir
@@ -1,4 +1,3 @@
 // RUN: env Z3LIB=%libz3 not circt-test %S/basic.mlir -d %t -r \circt-bmc 2>&1 | FileCheck %S/basic.mlir
 // REQUIRES: libz3
 // REQUIRES: circt-bmc-jit
-// XFAIL: *

--- a/integration_test/circt-test/basic-sby.mlir
+++ b/integration_test/circt-test/basic-sby.mlir
@@ -1,3 +1,2 @@
 // RUN: not circt-test %S/basic.mlir -d %t -r \sby 2>&1 | FileCheck %S/basic.mlir
 // REQUIRES: sby
-// XFAIL: *

--- a/integration_test/circt-test/basic.mlir
+++ b/integration_test/circt-test/basic.mlir
@@ -151,31 +151,38 @@ verif.formal @ALUFailure {depth = 3} {
 }
 
 verif.formal @RunnerRequireEither {require_runners = ["sby", "circt-bmc"]} {
-  %0 = hw.constant true
+  %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
 verif.formal @RunnerRequireSby {require_runners = ["sby"]} {
-  %0 = hw.constant true
+  %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
 verif.formal @RunnerRequireCirctBmc {require_runners = ["circt-bmc"]} {
-  %0 = hw.constant true
+  %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
 verif.formal @RunnerExcludeEither {exclude_runners = ["sby", "circt-bmc"]} {
-  %0 = hw.constant true
+  %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
 verif.formal @RunnerExcludeSby {exclude_runners = ["sby"]} {
-  %0 = hw.constant true
+  %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
 verif.formal @RunnerExcludeCirctBmc {exclude_runners = ["circt-bmc"]} {
-  %0 = hw.constant true
+  %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
+}
+
+// A dummy module to ensure that the trivially true `verif.assert` above don't
+// get optimized away, which makes circt-bmc unhappy at the moment.
+hw.module @DummyModule(out z: i1) {
+  %true = hw.constant true
+  hw.output %true : i1
 }

--- a/integration_test/circt-test/sby-ignore-cpp-files.mlir
+++ b/integration_test/circt-test/sby-ignore-cpp-files.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-test %s -d %t -r \sby 2>&1 | FileCheck %s
+// REQUIRES: sby
+
+// CHECK: 1 tests passed
+
+verif.formal @Foo {} {
+  %a = verif.symbolic_value : i42
+  %c3_i42 = hw.constant 3 : i42
+  %c9_i42 = hw.constant 9 : i42
+  %0 = comb.shl %a, %c3_i42 : i42
+  %1 = comb.add %a, %0 : i42
+  %2 = comb.mul %a, %c9_i42 : i42
+  %3 = comb.icmp eq %1, %2 : i42
+  // assert((a<<3)+a == a*9)
+  verif.assert %3 : i1
+}
+
+// This abuses verbatim SV quite a bit, but I've seen this in the wild when
+// people try to bundle C/C++/Rust code up with some DPI-based testbench.
+sv.verbatim "void someDummyFunction() {}" {output_file = #hw.output_file<"ignored.cpp">}

--- a/integration_test/circt-test/verilator-include-cpp-files.mlir
+++ b/integration_test/circt-test/verilator-include-cpp-files.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-test %s -d %t -r \verilator 2>&1 | FileCheck %s
+// REQUIRES: verilator
+
+// CHECK: 1 tests passed
+
+sim.func.dpi @someFunction()
+
+verif.simulation @Foo {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  sim.func.dpi.call @someFunction() clock %clock : () -> ()
+  %true = hw.constant true
+  verif.yield %true, %true : i1, i1
+}
+
+// This abuses verbatim SV quite a bit, but I've seen this in the wild when
+// people try to bundle C/C++/Rust code up with some DPI-based testbench.
+sv.verbatim "#include <iostream>\nextern \"C\" void someFunction() { std::cout << \"Hello from C++\\n\"; }" {output_file = #hw.output_file<"someFunction.cpp">}

--- a/tools/circt-test/CMakeLists.txt
+++ b/tools/circt-test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(libs
   ${dialect_libs}
 
   CIRCTExportVerilog
+  CIRCTFirtool
   CIRCTSeqToSV
   CIRCTSimToSV
   CIRCTSVTransforms

--- a/tools/circt-test/circt-test-runner-sby.py
+++ b/tools/circt-test/circt-test-runner-sby.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import argparse
+import os
 import shlex
 import subprocess
 import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument("verilog")
-parser.add_argument("-t", "--test")
-parser.add_argument("-d", "--directory")
+parser.add_argument("-t", "--test", required=True)
+parser.add_argument("-d", "--directory", required=True)
 parser.add_argument("-m", "--mode")
 parser.add_argument("-k", "--depth")
 args = parser.parse_args()
@@ -36,25 +37,48 @@ for task in tasks:
   --
 """
 
+# Collect the source files to be read in.
+source_files = []
+if source_path.is_dir():
+  with open(source_path / "filelist.f", "r") as filelist:
+    for line in filelist:
+      # Ignore empty lines in the file list.
+      line = line.strip()
+      if not line:
+        continue
+
+      # Ignore non-Verilog files. This is an ugly hack, but sometimes C/C++/Rust
+      # files get mixed into the filelist.
+      p = Path(line)
+      if p.suffix not in (".v", ".sv", ".vh", ".svh"):
+        continue
+
+      if not p.is_absolute():
+        p = source_path / p
+      source_files.append(p)
+else:
+  source_files.append(source_path)
+
+read_commands = ""
+for sf in source_files:
+  read_commands += f"read -formal {sf.absolute()}\n"
+
 # Generate the SymbiYosys script.
 script = """
-  [tasks]
-  {tasks}
+[tasks]
+{tasks}
 
 {options}
 
-  [engines]
-  smtbmc z3
+[engines]
+smtbmc z3
 
-  [script]
-  read -formal {source_path_name}
-  prep -top {test}
-
-  [files]
-  {source_path}
+[script]
+{read_commands}
+prep -top {test}
 """.format(tasks='\n  '.join(tasks),
            options=options,
-           source_path_name=source_path.name,
+           read_commands=read_commands,
            test=args.test,
            source_path=source_path)
 with open(script_path, "w") as f:


### PR DESCRIPTION
Until now the circt-test tool ran a very simple pass pipeline to generate a single Verilog output file. This doesn't work for most real use cases where designs are large and the output contains non-Verilog collateral files.

Reuse firtool's HW-to-SV and ExportSplitVerilog pipelines to produce an output directory populated with Verilog and other output files. This requires adjusting the SymbiYosys and Verilator test runners such that they properly handle an entire directory worth of output. For now this means using the generated `filelist.f` file. Later, we may want to use a more sophisticated method of gathering source files.

A somewhat hacky use of the filelist I've seen in the wild is to have C/C++ source files listed there, such that SV testbenches that rely on DPI calls automatically pass those files to Verilator for compilation. Make sure this use case is covered as an integration test. This also requires a bit of attention in the SymbiYosys runner such that we don't accidentally pass C/C++ files to sby/yosys.

This also re-enables the sby/circt-bmc integration tests for circt-test.