### PR TITLE
[CombToLLVM] Add conversion for comb::ReverseOp to LLVM dialect

### DIFF
--- a/lib/Conversion/CombToArith/CombToArith.cpp
+++ b/lib/Conversion/CombToArith/CombToArith.cpp
@@ -328,6 +328,8 @@ void ConvertCombToArithPass::runOnOperation() {
   // would result in undesirably complex logic, therefore, we mark it legal
   // here.
   target.addLegalOp<comb::ParityOp>();
+  // Arith does not have bitreverse, so we leave it for the CombToLLVM pass.
+  target.addLegalOp<comb::ReverseOp>();
   // This pass is intended to rewrite Comb ops into Arith ops. Other dialects
   // (e.g. LLVM) may legitimately be present when this pass is used in custom
   // pipelines. Treat all unknown operations as legal so we don't attempt to

--- a/lib/Conversion/CombToLLVM/CombToLLVM.cpp
+++ b/lib/Conversion/CombToLLVM/CombToLLVM.cpp
@@ -29,7 +29,6 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 /// Convert a comb::ParityOp to the LLVM dialect.
-/// This is the only Comb operation that doesn't have a Comb-to-Arith pattern.
 struct CombParityOpConversion : public ConvertToLLVMPattern {
   explicit CombParityOpConversion(MLIRContext *ctx,
                                   LLVMTypeConverter &typeConverter)
@@ -50,6 +49,20 @@ struct CombParityOpConversion : public ConvertToLLVMPattern {
   }
 };
 
+/// Convert a comb::ReverseOp to the LLVM dialect.
+struct CombReverseOpConversion
+    : public ConvertOpToLLVMPattern<comb::ReverseOp> {
+  using ConvertOpToLLVMPattern<comb::ReverseOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(comb::ReverseOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<LLVM::BitReverseOp>(
+        op, adaptor.getInput().getType(), adaptor.getInput());
+    return success();
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -62,4 +75,5 @@ void circt::populateCombToLLVMConversionPatterns(LLVMTypeConverter &converter,
   // Most Comb operations are handled by the Comb-to-Arith + Arith-to-LLVM
   // pipeline
   patterns.add<CombParityOpConversion>(patterns.getContext(), converter);
+  patterns.add<CombReverseOpConversion>(converter);
 }

--- a/test/Conversion/CombToLLVM/comb-to-llvm.mlir
+++ b/test/Conversion/CombToLLVM/comb-to-llvm.mlir
@@ -94,6 +94,15 @@ func.func @test_comb_parity(%arg0: i32) -> i1 {
   return %0 : i1
 }
 
+// CHECK-LABEL: llvm.func @test_comb_reverse
+func.func @test_comb_reverse(%arg0: i32) -> i32 {
+  // Reverse should use llvm.intr.bitreverse (no Comb->Arith pattern exists)
+  // CHECK: %{{.*}} = llvm.intr.bitreverse(%arg0) : (i32) -> i32
+  // CHECK: llvm.return
+  %0 = comb.reverse %arg0 : i32
+  return %0 : i32
+}
+
 // CHECK-LABEL: llvm.func @test_comb_shifts
 func.func @test_comb_shifts(%arg0: i32, %arg1: i32) -> (i32, i32, i32) {
   // Test shift operations (converted via Comb->Arith->LLVM)


### PR DESCRIPTION
This PR implements the lowering of `comb.reverse` to the LLVM dialect. Previously, this operation had no conversion path and would cause failures during the lowering pipeline.

Since the Arith dialect does not support bit reversal, this operation is now handled directly in `CombToLLVM` by mapping it to the `llvm.intr.bitreverse` intrinsic.