### PR TITLE
[circt-bmc] don't error when no assertions are given

### DIFF
--- a/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
@@ -14,7 +14,7 @@ module {
 
 // -----
 
-// expected-error @below {{no property provided to check in module}}
+// expected-warning @below {{no property provided to check in module - will trivially find no assertions.}}
 hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) attributes {num_regs = 0 : i32, initial_values = []} {
   %0 = comb.add %in0, %in1 : i32
   hw.output %0 : i32


### PR DESCRIPTION
@fabianschuiki will this do the trick for getting your circt-test runner hooked in?

(we should tighten up the analysis on whether there's an assertion at some point, currently we don't check in instances but I'll fix that in a follow-up)