### PR TITLE
[Arc][ArcToLLVM] Add RuntimeModelOp

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -643,8 +643,13 @@ def SimInstantiateOp : ArcOp<"sim.instantiate",
   }];
   let regions = (region SizedRegion<1>:$body);
 
+  let arguments = (ins OptionalAttr<FlatSymbolRefAttr>:$runtimeModel,
+                       OptionalAttr<StrAttr>:$runtimeArgs);
   let hasRegionVerifier = 1;
   let hasCustomAssemblyFormat = 1;
+  let builders = [OpBuilder<(ins), [{
+      build($_builder, $_state, FlatSymbolRefAttr{}, StringAttr{});
+    }]>];
 }
 
 def SimSetInputOp : ArcOp<"sim.set_input",
@@ -947,6 +952,25 @@ def VectorizeReturnOp : ArcOp<"vectorize.return", [
   let summary = "arc.vectorized terminator";
   let arguments = (ins AnyType:$value);
   let assemblyFormat = "operands attr-dict `:` qualified(type(operands))";
+}
+
+def RuntimeModelOp : ArcOp<"runtime.model", [
+  HasParent<"::mlir::ModuleOp">, Pure, Symbol
+]> {
+  let summary = "Provides static metadata of an Arc model used by the runtime";
+  let description = [{
+    Collection of static metadata for a specific Arc model accessed by the
+    arcilator runtime library:
+    - name: Name of the model
+    - numStateBytes: Number of bytes required to store the model's internal
+        state
+  }];
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       StrAttr:$name,
+                       I64Attr:$numStateBytes);
+  let assemblyFormat = [{
+    $sym_name $name `numStateBytes` $numStateBytes attr-dict
+  }];
 }
 
 #endif // CIRCT_DIALECT_ARC_ARCOPS_TD

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -308,4 +308,19 @@ func.func @issue9171(%arg0: !arc.state<!hw.array<4xi1>>, %idx: i2) -> (i1) {
   return %get : i1
 }
 
+// CHECK-LABEL: llvm.mlir.global
+// CHECK-SAME:  internal constant @[[NAMESYM:.+]]("fooModelName\00")
+// CHECK:  llvm.mlir.global external @arcRuntimeModel_fooModelSym() {addr_space = 0 : i32} : !llvm.struct<(i64, i64, ptr)> {
+// CHECK:    %0 = llvm.mlir.constant(0 : i64) : i64
+// CHECK:    %1 = llvm.mlir.constant(1234567 : i64) : i64
+// CHECK:    %2 = llvm.mlir.addressof @[[NAMESYM]] : !llvm.ptr
+// CHECK:    %3 = llvm.mlir.poison : !llvm.struct<(i64, i64, ptr)>
+// CHECK:    %4 = llvm.insertvalue %0, %3[0] : !llvm.struct<(i64, i64, ptr)>
+// CHECK:    %5 = llvm.insertvalue %1, %4[1] : !llvm.struct<(i64, i64, ptr)>
+// CHECK:    %6 = llvm.insertvalue %2, %5[2] : !llvm.struct<(i64, i64, ptr)>
+// CHECK:    llvm.return %6 : !llvm.struct<(i64, i64, ptr)>
+// CHECK:  }
+
+arc.runtime.model @arcRuntimeModel_fooModelSym "fooModelName" numStateBytes 1234567
+
 func.func private @Dummy(%arg0: i42, %arg1: !hw.array<4xi19>, %arg2: !arc.storage)

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -357,6 +357,21 @@ func.func @with_attr() {
   return
 }
 
+arc.runtime.model @rtFooModel "FooModel" numStateBytes 123
+
+// CHECK-LABEL: func.func @with_rt
+func.func @with_rt() {
+  // CHECK: arc.sim.instantiate @sim_test as %{{.*}} runtime @rtFooModel("args") {
+  // CHECK: arc.sim.instantiate @sim_test as %{{.*}} runtime @rtFooModel("args") attributes {foo = "foo"} {
+  // CHECK: arc.sim.instantiate @sim_test as %{{.*}} runtime @rtFooModel() {
+  // CHECK: arc.sim.instantiate @sim_test as %{{.*}} runtime ("args") {
+  arc.sim.instantiate @sim_test as %model runtime @rtFooModel("args") {}
+  arc.sim.instantiate @sim_test as %model runtime @rtFooModel("args") attributes {foo = "foo"} {}
+  arc.sim.instantiate @sim_test as %model runtime @rtFooModel() {}
+  arc.sim.instantiate @sim_test as %model runtime ("args") {}
+  return
+}
+
 // CHECK-LABEL: func.func @ReadsWrites(
 // CHECK-SAME: %arg0: !arc.state<i42>
 // CHECK-SAME: %arg1: i42

--- a/test/Dialect/Arc/sim-errors.mlir
+++ b/test/Dialect/Arc/sim-errors.mlir
@@ -29,6 +29,14 @@ func.func @model_not_found() {
     arc.sim.instantiate @unknown as %model {}
     return
 }
+// -----
+
+func.func @model_and_runtime_not_found() {
+    // expected-error @+2 {{runtime model not found}}
+    // expected-error @+1 {{model not found}}
+    arc.sim.instantiate @unknown as %model runtime @unknown() {}
+    return
+}
 
 // -----
 
@@ -42,6 +50,17 @@ func.func @port_not_found() {
         %res = arc.sim.get_port %model, "unknown" : i8, !arc.sim.instance<@id>
         arc.sim.emit "use", %res : i8
     }
+    return
+}
+// -----
+
+hw.module @id(in %i: i8, in %j: i8, out o: i8) {
+    hw.output %i : i8
+}
+
+func.func @no_runtime_model() {
+    // expected-error @+1 {{referenced runtime model is not a RuntimeModelOp}}
+    arc.sim.instantiate @id as %model runtime @id() {}
     return
 }
 


### PR DESCRIPTION
This PR:
* Adds the `RuntimeModelOp` to the Arc dialect
* Enables the `SimInstantiateOp` to optionally reference a runtime model
* Adds a conversion pattern to ArcToLLVM, directly mapping a `RuntimeModelOp` to a `LLVM::GlobalOp` describing an instance of the runtime's `ArcRuntimeModelInfo` struct. This struct is required to provide model metadata to the runtime library.