### PR TITLE
[circt-bmc] Move no assertions check into VerifToSMT

### DIFF
--- a/include/circt/Conversion/VerifToSMT.h
+++ b/include/circt/Conversion/VerifToSMT.h
@@ -19,10 +19,9 @@ class Namespace;
 #include "circt/Conversion/Passes.h.inc"
 
 /// Get the Verif to SMT conversion patterns.
-void populateVerifToSMTConversionPatterns(TypeConverter &converter,
-                                          RewritePatternSet &patterns,
-                                          Namespace &names,
-                                          bool risingClocksOnly);
+void populateVerifToSMTConversionPatterns(
+    TypeConverter &converter, RewritePatternSet &patterns, Namespace &names,
+    bool risingClocksOnly, SmallVectorImpl<Operation *> &propertylessBMCOps);
 
 } // namespace circt
 

--- a/integration_test/circt-bmc/comb.mlir
+++ b/integration_test/circt-bmc/comb.mlir
@@ -26,3 +26,11 @@ hw.module @demorgan(in %i0: i1, in %i1: i1) {
   %cond = comb.icmp bin eq %or, %nand : i1
   verif.assert %cond : i1
 }
+
+// Check that no violations are found with no assertions
+
+//  RUN: circt-bmc %s -b 10 --module Empty --shared-libs=%libz3 | FileCheck %s --check-prefix=NOASSERTS
+//  NOASSERTS: Bound reached with no violations!
+
+hw.module @Empty() {
+}

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -354,15 +354,28 @@ struct VerifBoundedModelCheckingOpConversion
     : OpConversionPattern<verif::BoundedModelCheckingOp> {
   using OpConversionPattern<verif::BoundedModelCheckingOp>::OpConversionPattern;
 
-  VerifBoundedModelCheckingOpConversion(TypeConverter &converter,
-                                        MLIRContext *context, Namespace &names,
-                                        bool risingClocksOnly)
+  VerifBoundedModelCheckingOpConversion(
+      TypeConverter &converter, MLIRContext *context, Namespace &names,
+      bool risingClocksOnly, SmallVectorImpl<Operation *> &propertylessBMCOps)
       : OpConversionPattern(converter, context), names(names),
-        risingClocksOnly(risingClocksOnly) {}
+        risingClocksOnly(risingClocksOnly),
+        propertylessBMCOps(propertylessBMCOps) {}
   LogicalResult
   matchAndRewrite(verif::BoundedModelCheckingOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
+
+    if (std::find(propertylessBMCOps.begin(), propertylessBMCOps.end(), op) !=
+        propertylessBMCOps.end()) {
+      // No properties to check, so we don't bother solving, we just return true
+      // (without this we would incorrectly find violations, since the solver
+      // will always return SAT)
+      Value trueVal =
+          arith::ConstantOp::create(rewriter, loc, rewriter.getBoolAttr(true));
+      rewriter.replaceOp(op, trueVal);
+      return success();
+    }
+
     SmallVector<Type> oldLoopInputTy(op.getLoop().getArgumentTypes());
     SmallVector<Type> oldCircuitInputTy(op.getCircuit().getArgumentTypes());
     // TODO: the init and loop regions should be able to be concrete instead of
@@ -642,6 +655,7 @@ struct VerifBoundedModelCheckingOpConversion
 
   Namespace &names;
   bool risingClocksOnly;
+  SmallVectorImpl<Operation *> &propertylessBMCOps;
 };
 
 } // namespace
@@ -658,16 +672,16 @@ struct ConvertVerifToSMTPass
 };
 } // namespace
 
-void circt::populateVerifToSMTConversionPatterns(TypeConverter &converter,
-                                                 RewritePatternSet &patterns,
-                                                 Namespace &names,
-                                                 bool risingClocksOnly) {
+void circt::populateVerifToSMTConversionPatterns(
+    TypeConverter &converter, RewritePatternSet &patterns, Namespace &names,
+    bool risingClocksOnly, SmallVectorImpl<Operation *> &propertylessBMCOps) {
   patterns.add<VerifAssertOpConversion, VerifAssumeOpConversion,
                LogicEquivalenceCheckingOpConversion,
                RefinementCheckingOpConversion>(converter,
                                                patterns.getContext());
   patterns.add<VerifBoundedModelCheckingOpConversion>(
-      converter, patterns.getContext(), names, risingClocksOnly);
+      converter, patterns.getContext(), names, risingClocksOnly,
+      propertylessBMCOps);
 }
 
 void ConvertVerifToSMTPass::runOnOperation() {
@@ -680,6 +694,7 @@ void ConvertVerifToSMTPass::runOnOperation() {
   // Check BMC ops contain only one assertion (done outside pattern to avoid
   // issues with whether assertions are/aren't lowered yet)
   SymbolTable symbolTable(getOperation());
+  SmallVector<Operation *> propertylessBMCOps;
   WalkResult assertionCheck = getOperation().walk(
       [&](Operation *op) { // Check there is exactly one assertion and clock
         if (auto bmcOp = dyn_cast<verif::BoundedModelCheckingOp>(op)) {
@@ -739,6 +754,11 @@ void ConvertVerifToSMTPass::runOnOperation() {
             if (numAssertions > 1)
               break;
           }
+          if (numAssertions == 0) {
+            op->emitWarning("no property provided to check in module - will "
+                            "trivially find no violations.");
+            propertylessBMCOps.push_back(bmcOp);
+          }
           if (numAssertions > 1) {
             op->emitError(
                 "bounded model checking problems with multiple assertions are "
@@ -762,7 +782,7 @@ void ConvertVerifToSMTPass::runOnOperation() {
   names.add(symCache);
 
   populateVerifToSMTConversionPatterns(converter, patterns, names,
-                                       risingClocksOnly);
+                                       risingClocksOnly, propertylessBMCOps);
 
   if (failed(mlir::applyPartialConversion(getOperation(), target,
                                           std::move(patterns))))

--- a/test/Conversion/VerifToSMT/bmc-clock-not-first.mlir
+++ b/test/Conversion/VerifToSMT/bmc-clock-not-first.mlir
@@ -22,6 +22,9 @@ func.func @test_bmc_clock_not_first() -> (i1) {
   }
   circuit {
   ^bb0(%arg0: i32, %clk: !seq.clock, %state0: i32):
+    // dummy property
+    %true = hw.constant true
+    verif.assert %true : i1
     %c-1_i32 = hw.constant -1 : i32
     %0 = comb.add %arg0, %state0 : i32
     // %state0 is the result of a seq.compreg taking %0 as input

--- a/test/Conversion/VerifToSMT/bmc-no-assertions.mlir
+++ b/test/Conversion/VerifToSMT/bmc-no-assertions.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt %s --convert-verif-to-smt --reconcile-unrealized-casts -allow-unregistered-dialect | FileCheck %s
+
+// CHECK-LABEL: func.func @test_bmc() -> i1
+// CHECK-NEXT: [[TRUE:%.+]] = arith.constant true
+// CHECK-NEXT: return [[TRUE]] : i1
+
+func.func @test_bmc() -> (i1) {
+  %bmc = verif.bmc bound 10 num_regs 0 initial_values [] attributes {ignore_asserts_until = 3 : i64}
+  init {
+  }
+  loop {
+  }
+  circuit {
+  ^bb0(%arg0: i32):
+    verif.yield %arg0 : i32
+  }
+  func.return %bmc : i1
+}

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -211,6 +211,8 @@ func.func @test_bmc() -> (i1) {
   }
   circuit {
   ^bb0(%clk: !seq.clock, %arg0: i32, %state0: i32, %state1: i32, %state2: !hw.array<2xi32>):
+    %true = hw.constant true
+    verif.assert %true : i1
     %c-1_i32 = hw.constant -1 : i32
     %0 = comb.add %arg0, %state0 : i32
     // %state0 is the result of a seq.compreg taking %0 as input

--- a/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
@@ -14,14 +14,6 @@ module {
 
 // -----
 
-// expected-warning @below {{no property provided to check in module - will trivially find no assertions.}}
-hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) attributes {num_regs = 0 : i32, initial_values = []} {
-  %0 = comb.add %in0, %in1 : i32
-  hw.output %0 : i32
-}
-
-// -----
-
 // expected-error @below {{no num_regs or initial_values attribute found - please run externalize registers pass first}}
 hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) {
   %0 = comb.add %in0, %in1 : i32


### PR DESCRIPTION
The circt-bmc flow currently checks whether there are no assertions in LowerToBMC, but checks that there aren't too many in VerifToSMT. This feels inconsistent, and both should probably be in VerifToSMT for a few reasons (e.g. how they're handled should be an implementation detail according to the BMC algorithm being used, and we already do the analysis of assertion count across modules there which was still a TODO in LowerToBMC). This just swaps over where we actually do that check.

Note that this requires adding a few dummy assertions where VerifToSMT tests weren't asserting anything.