### PR TITLE
[NFC][VerifToSMT] Clean up initial value checks

### DIFF
--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -708,16 +708,13 @@ void ConvertVerifToSMTPass::runOnOperation() {
               if (!isa<IntegerType>(regType)) {
                 op->emitError("initial values are currently only supported for "
                               "registers with integer types");
-                signalPassFailure();
                 return WalkResult::interrupt();
-              } else {
-                auto tyAttr = dyn_cast<TypedAttr>(initVal);
-                if (!tyAttr || tyAttr.getType() != regType) {
-                  op->emitError("type of initial value does not match type of "
-                                "initialized register");
-                  signalPassFailure();
-                  return WalkResult::interrupt();
-                }
+              }
+              auto tyAttr = dyn_cast<TypedAttr>(initVal);
+              if (!tyAttr || tyAttr.getType() != regType) {
+                op->emitError("type of initial value does not match type of "
+                              "initialized register");
+                return WalkResult::interrupt();
               }
             }
           }


### PR DESCRIPTION
Tiny cleanup (else after return + signalPassFailure being called twice), just PRing to sanity check CI