### PR TITLE
[HW] Verify inner symbols InnerSymbolTable ports.

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -614,7 +614,7 @@ def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
   ];
 
   let verify = [{
-    return verifyInnerSymAttr(cast<circt::hw::InnerSymbolOpInterface>(op));
+    return verifyInnerSymOp(cast<circt::hw::InnerSymbolOpInterface>($_op));
   }];
 }
 

--- a/lib/Dialect/HW/HWOpInterfaces.cpp
+++ b/lib/Dialect/HW/HWOpInterfaces.cpp
@@ -50,7 +50,70 @@ StringRef hw::PortInfo::getVerilogName() const {
   return name.getValue();
 }
 
-LogicalResult hw::verifyInnerSymAttr(InnerSymbolOpInterface op) {
+LogicalResult
+hw::verifyInnerSymAttr(InnerSymAttr innerSym, Type type,
+                       llvm::function_ref<InFlightDiagnostic()> emitError) {
+  assert(innerSym && "null inner symbol attribute provided");
+  // Tentatively accept empty inner symbol attributes.
+  // In the future we may prefer these over NULL.
+  if (innerSym.empty())
+    return success();
+
+  if (!type) {
+    // No "type" provided means must have zero or one inner symbols.
+    // If symbol is present, must have fieldID == 0.
+    // Scan and reject any with fieldID != 0.
+    for (auto prop : innerSym) {
+      if (prop.getFieldID() != 0)
+        return emitError() << "does not support per-field inner symbols, but "
+                              "has inner symbol '"
+                           << prop.getName().getValue()
+                           << "' with non-zero field id " << prop.getFieldID();
+    }
+    // If scan passed but there are multiple inner symbols for this target.
+    if (innerSym.size() > 1) {
+      // Multiple with fieldID == 0.
+      auto err = emitError() << "has more than one symbol defined: ";
+      llvm::interleaveComma(innerSym, err, [&](auto prop) {
+        err << "'" << prop.getName().getValue() << "'";
+      });
+      return err;
+    }
+    return success();
+  }
+
+  auto maxFields = FieldIdImpl::getMaxFieldID(type);
+  llvm::SmallBitVector indices(maxFields + 1);
+  llvm::SmallPtrSet<Attribute, 8> symNames;
+  // Ensure fieldID and symbol names are unique.
+  auto uniqSyms = [&](InnerSymPropertiesAttr p) {
+    if (maxFields < p.getFieldID()) {
+      emitError() << "field id " << p.getFieldID()
+                  << " is greater than the maximum field id " << maxFields;
+      return false;
+    }
+    if (indices.test(p.getFieldID())) {
+      emitError() << "cannot assign multiple symbol names to the field id "
+                  << p.getFieldID();
+      return false;
+    }
+    indices.set(p.getFieldID());
+    auto it = symNames.insert(p.getName());
+    if (!it.second) {
+      emitError() << "cannot reuse symbol name '" << p.getName().getValue()
+                  << "'";
+      return false;
+    }
+    return true;
+  };
+
+  if (!llvm::all_of(innerSym.getProps(), uniqSyms))
+    return failure();
+
+  return success();
+}
+
+LogicalResult hw::verifyInnerSymOp(InnerSymbolOpInterface op) {
   auto innerSym = op.getInnerSymAttr();
   // If does not have any inner sym then ignore.
   if (!innerSym)
@@ -59,50 +122,41 @@ LogicalResult hw::verifyInnerSymAttr(InnerSymbolOpInterface op) {
   if (innerSym.empty())
     return op->emitOpError("has empty list of inner symbols");
 
-  if (!op.supportsPerFieldSymbols()) {
-    // The inner sym can only be specified on fieldID=0.
-    if (innerSym.size() > 1 || !innerSym.getSymName()) {
-      op->emitOpError("does not support per-field inner symbols");
-      return failure();
-    }
-    return success();
-  }
+  if (!op.supportsPerFieldSymbols())
+    return verifyInnerSymAttr(innerSym, [op]() { return op->emitOpError(); });
 
-  auto result = op.getTargetResult();
   // If op supports per-field symbols, but does not have a target result,
   // its up to the operation to verify itself.
   // (there are no uses for this presently, but be open to this anyway.)
+  auto result = op.getTargetResult();
   if (!result)
     return success();
-  auto resultType = result.getType();
-  auto maxFields = FieldIdImpl::getMaxFieldID(resultType);
-  llvm::SmallBitVector indices(maxFields + 1);
-  llvm::SmallPtrSet<Attribute, 8> symNames;
-  // Ensure fieldID and symbol names are unique.
-  auto uniqSyms = [&](InnerSymPropertiesAttr p) {
-    if (maxFields < p.getFieldID()) {
-      op->emitOpError("field id:'" + Twine(p.getFieldID()) +
-                      "' is greater than the maximum field id:'" +
-                      Twine(maxFields) + "'");
-      return false;
-    }
-    if (indices.test(p.getFieldID())) {
-      op->emitOpError("cannot assign multiple symbol names to the field id:'" +
-                      Twine(p.getFieldID()) + "'");
-      return false;
-    }
-    indices.set(p.getFieldID());
-    auto it = symNames.insert(p.getName());
-    if (!it.second) {
-      op->emitOpError("cannot reuse symbol name:'" + p.getName().getValue() +
-                      "'");
-      return false;
-    }
-    return true;
-  };
 
-  if (!llvm::all_of(innerSym.getProps(), uniqSyms))
-    return failure();
+  return verifyInnerSymAttr(innerSym, result.getType(),
+                            [op]() { return op->emitOpError(); });
+}
+
+LogicalResult hw::verifyPortInnerSymsIfPortList(Operation *op) {
+  assert(op->hasTrait<OpTrait::InnerSymbolTable>());
+  PortList opWithPorts = dyn_cast<hw::PortList>(op);
+  // Skip if not a PortList.
+  if (!opWithPorts)
+    return success();
+
+  auto ports = opWithPorts.getPortList();
+  for (auto const &indexAndPort : llvm::enumerate(ports)) {
+    auto &pi = indexAndPort.value();
+    auto idx = indexAndPort.index();
+    Location loc = pi.loc ? Location(pi.loc) : opWithPorts.getLoc();
+    if (auto sym = pi.getSym())
+      if (failed(hw::verifyInnerSymAttr(sym, pi.type, [&]() {
+            return mlir::emitError(loc)
+                   << "verification of inner symbol"
+                   << (sym.size() > 1 ? "s" : "") << " failed on port " << idx
+                   << " with name " << pi.name << ": ";
+          })))
+        return failure();
+  }
 
   return success();
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -542,6 +542,24 @@ firrtl.circuit "CombMemPerFieldSym" {
 
 // -----
 
+firrtl.circuit "InstMultipleSyms" {
+  firrtl.module @Empty() {}
+  firrtl.module @InstMultipleSyms() {
+    // expected-error @below {{op has more than one symbol defined: 'x', 'y'}}
+    firrtl.instance empty sym [<@x,0,public>,<@y,0,public>] @Empty()
+  }
+}
+
+// -----
+
+firrtl.circuit "PortMultSymbol" {
+   // expected-error @below {{verification of inner symbols failed on port 0 with name "x": cannot assign multiple symbol names to the field id 0}}
+  firrtl.module @PortMultSymbol(in %x : !firrtl.uint<5>) attributes { portSymbols = [#hw<innerSym[<@foo,0,public>,<@bar,0,public>]>] } {
+  }
+}
+
+// -----
+
 firrtl.circuit "SeqMemInvalidReturnType" {
   firrtl.module @SeqMemInvalidReturnType() {
     // expected-error @+1 {{'chirrtl.seqmem' op result #0 must be a behavioral memory, but got '!firrtl.uint<1>'}}
@@ -562,7 +580,7 @@ firrtl.circuit "SeqMemNonPassiveReturnType" {
 
 firrtl.circuit "SeqMemPerFieldSym" {
   firrtl.module @SeqMemPerFieldSym() {
-    // expected-error @below {{op does not support per-field inner symbols}}
+    // expected-error @below {{does not support per-field inner symbols, but has inner symbol 'x' with non-zero field id 1}}
     %mem = chirrtl.seqmem sym [<@x,1,public>] Undefined : !chirrtl.cmemory<bundle<a: uint<1>>, 1>
   }
 }
@@ -1009,7 +1027,7 @@ firrtl.circuit "EnumNonExaustive" {
 
 firrtl.circuit "InnerSymAttr" {
   firrtl.module @InnerSymAttr() {
-    // expected-error @+1 {{cannot assign multiple symbol names to the field id:'2'}}
+    // expected-error @+1 {{cannot assign multiple symbol names to the field id 2}}
     %w3 = firrtl.wire sym [<@w3,2,public>,<@x2,2,private>,<@syh2,0,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
   }
 }
@@ -1018,7 +1036,7 @@ firrtl.circuit "InnerSymAttr" {
 
 firrtl.circuit "InnerSymAttr2" {
   firrtl.module @InnerSymAttr2() {
-    // expected-error @+1 {{cannot reuse symbol name:'w3'}}
+    // expected-error @+1 {{cannot reuse symbol name 'w3'}}
     %w4 = firrtl.wire sym [<@w3,1,public>,<@w3,2,private>,<@syh2,0,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>, d: uint<1>>
   }
 }
@@ -2299,7 +2317,7 @@ firrtl.circuit "InvalidDouble" {
 
 firrtl.circuit "InvalidInnerSymTooHigh" {
   firrtl.module @InvalidInnerSymTooHigh () {
-    // expected-error @below {{field id:'1' is greater than the maximum field id:'0'}}
+    // expected-error @below {{field id 1 is greater than the maximum field id 0}}
     %w = firrtl.wire sym [<@"test",1,public>] : !firrtl.uint<5>
   }
 }
@@ -2308,7 +2326,7 @@ firrtl.circuit "InvalidInnerSymTooHigh" {
 
 firrtl.circuit "InvalidInnerSymDupe" {
   firrtl.module @InvalidInnerSymDupe() {
-    // expected-error @below {{op cannot assign multiple symbol names to the field id:'0'}}
+    // expected-error @below {{op cannot assign multiple symbol names to the field id 0}}
     %w = firrtl.wire sym [<@"foo",0,public>,<@"bar",0,public>] : !firrtl.uint<5>
   }
 }


### PR DESCRIPTION
This extends to inner-symbol-defining ports the local verification of inner-symbol-defining "things" that already exists for InnerSymbol's.

For now, hang the verification on the IST verifier.

IST already looks for whether the operation is a PortList for getting the inner symbols defined by the IST operation itself.