### PR TITLE
[circt-test] Add dynamic progress display; various usability tweaks

### DIFF
--- a/integration_test/circt-test/basic-circt-bmc.mlir
+++ b/integration_test/circt-test/basic-circt-bmc.mlir
@@ -1,3 +1,3 @@
-// RUN: env Z3LIB=%libz3 not circt-test %S/basic.mlir -d %t -r \circt-bmc 2>&1 | FileCheck %S/basic.mlir
+// RUN: env Z3LIB=%libz3 not circt-test %S/basic.mlir -d %t -r \circt-bmc 2>&1 | FileCheck %S/basic.mlir --check-prefixes=CHECK,CHECK-CIRCT-BMC
 // REQUIRES: libz3
 // REQUIRES: circt-bmc-jit

--- a/integration_test/circt-test/basic-sby.mlir
+++ b/integration_test/circt-test/basic-sby.mlir
@@ -1,2 +1,2 @@
-// RUN: not circt-test %S/basic.mlir -d %t -r \sby 2>&1 | FileCheck %S/basic.mlir
+// RUN: not circt-test %S/basic.mlir -d %t -r \sby 2>&1 | FileCheck %S/basic.mlir --check-prefixes=CHECK,CHECK-SBY
 // REQUIRES: sby

--- a/integration_test/circt-test/basic-verilator-fail.mlir
+++ b/integration_test/circt-test/basic-verilator-fail.mlir
@@ -1,8 +1,8 @@
 // RUN: not circt-test %s -d %t -r \verilator 2>&1 | FileCheck %s
 // REQUIRES: verilator
 
-// CHECK: test Foo failed
-// CHECK: 1 tests FAILED
+// CHECK: test Foo ... FAILED
+// CHECK: 1 of 1 tests FAILED; 0 passed
 
 verif.simulation @Foo {} {
 ^bb0(%clock: !seq.clock, %init: i1):

--- a/integration_test/circt-test/basic-verilator-pass.mlir
+++ b/integration_test/circt-test/basic-verilator-pass.mlir
@@ -1,7 +1,8 @@
 // RUN: circt-test %s -d %t -r \verilator 2>&1 | FileCheck %s
 // REQUIRES: verilator
 
-// CHECK: 1 tests passed
+// CHECK: test Foo ... passed
+// CHECK: all 1 tests passed
 
 verif.simulation @Foo {} {
 ^bb0(%clock: !seq.clock, %init: i1):

--- a/integration_test/circt-test/basic.mlir
+++ b/integration_test/circt-test/basic.mlir
@@ -1,8 +1,6 @@
 // See other `basic-*.mlir` files for run lines.
 // RUN: true
 
-// CHECK: 1 tests FAILED, 9 passed, 1 ignored, 3 unsupported
-
 hw.module @FullAdder(in %a: i1, in %b: i1, in %ci: i1, out s: i1, out co: i1) {
   %0 = comb.xor %a, %b : i1
   %1 = comb.xor %0, %ci : i1
@@ -35,6 +33,7 @@ hw.module @CustomAdder(in %a: i4, in %b: i4, out z: i4) {
   hw.output %z : i4
 }
 
+// CHECK: test ZeroLhs ... passed
 verif.formal @ZeroLhs {} {
   %c0_i4 = hw.constant 0 : i4
   %x = verif.symbolic_value : i4
@@ -43,6 +42,7 @@ verif.formal @ZeroLhs {} {
   verif.assert %eq : i1
 }
 
+// CHECK: test ZeroRhs ... passed
 verif.formal @ZeroRhs {} {
   %c0_i4 = hw.constant 0 : i4
   %x = verif.symbolic_value : i4
@@ -51,6 +51,7 @@ verif.formal @ZeroRhs {} {
   verif.assert %eq : i1
 }
 
+// CHECK: test CustomAdderWorks ... passed
 verif.formal @CustomAdderWorks {} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
@@ -76,6 +77,7 @@ hw.module @ALU(in %a: i4, in %b: i4, in %sub: i1, out z: i4) {
   hw.output %z : i4
 }
 
+// CHECK: test ALUCanAdd ... passed
 verif.formal @ALUCanAdd {} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
@@ -86,6 +88,7 @@ verif.formal @ALUCanAdd {} {
   verif.assert %eq : i1
 }
 
+// CHECK: test ALUCanSub ... passed
 verif.formal @ALUCanSub {mode = "cover,induction"} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
@@ -96,6 +99,7 @@ verif.formal @ALUCanSub {mode = "cover,induction"} {
   verif.assert %eq : i1
 }
 
+// CHECK: test ALUWorks ... passed
 verif.formal @ALUWorks {mode = "cover,bmc", depth = 5} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
@@ -114,6 +118,7 @@ verif.formal @ALUWorks {mode = "cover,bmc", depth = 5} {
   verif.assert %eq : i1
 }
 
+// CHECK: test ALUIgnoreFailure ... ignored
 verif.formal @ALUIgnoreFailure {ignore = true} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
@@ -132,6 +137,7 @@ verif.formal @ALUIgnoreFailure {ignore = true} {
   verif.assert %ne : i1
 }
 
+// CHECK: test ALUFailure ... FAILED
 verif.formal @ALUFailure {depth = 3} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
@@ -150,31 +156,41 @@ verif.formal @ALUFailure {depth = 3} {
   verif.assert %ne : i1
 }
 
+// CHECK: test RunnerRequireEither ... pass
 verif.formal @RunnerRequireEither {require_runners = ["sby", "circt-bmc"]} {
   %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
+// CHECK-SBY: test RunnerRequireSby ... pass
+// CHECK-CIRCT-BMC: test RunnerRequireSby ... unsupported
 verif.formal @RunnerRequireSby {require_runners = ["sby"]} {
   %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
+// CHECK-SBY: test RunnerRequireCirctBmc ... unsupported
+// CHECK-CIRCT-BMC: test RunnerRequireCirctBmc ... pass
 verif.formal @RunnerRequireCirctBmc {require_runners = ["circt-bmc"]} {
   %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
+// CHECK: test RunnerExcludeEither ... unsupported
 verif.formal @RunnerExcludeEither {exclude_runners = ["sby", "circt-bmc"]} {
   %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
+// CHECK-SBY: test RunnerExcludeSby ... unsupported
+// CHECK-CIRCT-BMC: test RunnerExcludeSby ... pass
 verif.formal @RunnerExcludeSby {exclude_runners = ["sby"]} {
   %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
 }
 
+// CHECK-SBY: test RunnerExcludeCirctBmc ... pass
+// CHECK-CIRCT-BMC: test RunnerExcludeCirctBmc ... unsupported
 verif.formal @RunnerExcludeCirctBmc {exclude_runners = ["circt-bmc"]} {
   %0 = hw.instance "dummy" @DummyModule() -> (z: i1)
   verif.assert %0 : i1
@@ -186,3 +202,5 @@ hw.module @DummyModule(out z: i1) {
   %true = hw.constant true
   hw.output %true : i1
 }
+
+// CHECK: 1 of 10 tests FAILED; 9 passed; 1 ignored; 3 unsupported

--- a/integration_test/circt-test/contracts.mlir
+++ b/integration_test/circt-test/contracts.mlir
@@ -1,7 +1,5 @@
 // RUN: true
 
-// CHECK: 3 tests FAILED, 3 passed
-
 hw.module @FullAdder(in %a: i1, in %b: i1, in %ci: i1, out s: i1, out co: i1) {
   %0 = comb.xor %a, %b : i1
   %1 = comb.xor %0, %ci : i1
@@ -31,6 +29,7 @@ hw.module @Add4C(in %a: i4, in %b: i4, in %ci: i1, out z: i4, out co: i1) {
 hw.module @Adder4(in %a: i4, in %b: i4, out z: i4) {
   %false = hw.constant false
   %z, %co = hw.instance "adder" @Add4C(a: %a: i4, b: %b: i4, ci: %false: i1) -> (z: i4, co: i1)
+  // CHECK: test Adder4{{.*}} ... passed
   %0 = verif.contract %z :i4 {
     %1 = comb.add %a, %b : i4
     %2 = comb.icmp eq %0, %1 : i4
@@ -42,6 +41,7 @@ hw.module @Adder4(in %a: i4, in %b: i4, out z: i4) {
 hw.module @Adder4Failed(in %a: i4, in %b: i4, out z: i4) {
   %false = hw.constant false
   %z, %co = hw.instance "adder" @Add4C(a: %a: i4, b: %b: i4, ci: %false: i1) -> (z: i4, co: i1)
+  // CHECK: test Adder4Failed{{.*}} ... FAILED
   %0 = verif.contract %z :i4 {
     // BUG: adding a to itself is incorrect
     %1 = comb.add %a, %a : i4
@@ -69,6 +69,7 @@ hw.module @Mul3(in %a: i2, in %b: i2, out z: i4) {
   %x = comb.concat %false, %a1b1, %a0b1, %false : i1, i1, i1, i1
   %y = hw.instance "adder" @Adder4(a: %w : i4, b: %x: i4) -> (z: i4)
 
+  // CHECK: test Mul3{{.*}} ... passed
   %z = verif.contract %y : i4 {
     %c = comb.concat %false, %false, %a : i1, i1, i2
     %d = comb.concat %false, %false, %b : i1, i1, i2
@@ -97,6 +98,7 @@ hw.module @Mul3Failed(in %a: i2, in %b: i2, out z: i4) {
   %x = comb.concat %false, %a1b1, %a0b1, %false : i1, i1, i1, i1
   %y = hw.instance "adder" @Adder4(a: %w : i4, b: %x: i4) -> (z: i4)
 
+  // CHECK: test Mul3Failed{{.*}} ... FAILED
   %z = verif.contract %y : i4 {
     %true = hw.constant true
     // BUG: Wrong concat value
@@ -114,7 +116,6 @@ hw.module @HalfAdder(in %a: i1, in %b: i1, out s: i1, out co: i1) {
   %1 = comb.and %a, %b : i1
   hw.output %0, %1 : i1, i1
 }
-
 
 hw.module @BoothMul(in %a: i4, in %b: i4, out z: i8) {
   %a0 = comb.extract %a from 0 : (i4) -> i1
@@ -163,6 +164,7 @@ hw.module @BoothMul(in %a: i4, in %b: i4, out z: i8) {
   %z_6, %z_7 = hw.instance "f7" @FullAdder(a: %c_10: i1, b: %c_8: i1, ci: %p3_3: i1) -> (s: i1, co: i1)
 
   %y = comb.concat %z_7, %z_6, %z_5, %z_4, %z_3, %z_2, %z_1, %p0_0: i1, i1, i1, i1, i1, i1, i1, i1 
+  // CHECK: test BoothMul{{.*}} ... passed
   %z = verif.contract %y :i8 {
     %false = hw.constant false
     %0 = comb.concat %false, %false, %false, %false, %a : i1, i1, i1, i1, i4
@@ -221,6 +223,7 @@ hw.module @BoothMulFailed(in %a: i4, in %b: i4, out z: i8) {
   %z_6, %z_7 = hw.instance "f7" @FullAdder(a: %c_10: i1, b: %c_8: i1, ci: %p3_3: i1) -> (s: i1, co: i1)
 
   %y = comb.concat %z_7, %z_6, %z_5, %z_4, %z_3, %z_2, %z_1, %p0_0: i1, i1, i1, i1, i1, i1, i1, i1 
+  // CHECK: test BoothMulFailed{{.*}} ... FAILED
   %z = verif.contract %y :i8 {
     %false = hw.constant false
     %true = hw.constant true
@@ -233,3 +236,5 @@ hw.module @BoothMulFailed(in %a: i4, in %b: i4, out z: i8) {
   }
   hw.output %z : i8
 }
+
+// CHECK: 3 of 6 tests FAILED; 3 passed

--- a/test/circt-test/commandline.mlir
+++ b/test/circt-test/commandline.mlir
@@ -1,3 +1,3 @@
 // RUN: circt-test --help | FileCheck %s
 
-// CHECK: OVERVIEW: Hardware unit testing tool
+// CHECK: OVERVIEW: Hardware unit test discovery and execution tool


### PR DESCRIPTION
Rework how circt-test executes the individual test cases to allow for better control of the multithreading and how progress is reported to the user. Instead of relying on the MLIR context's thread pool and MLIR diagnostics, spin up a custom set of long-lived threads that work through the tests. This allows us to have a `-j N` option for the user to control the number of tests run in parallel.

Add a new `ProgressDisplay` helper struct which deals with displaying the status of the tests interactively as they are being executed. Whenever a worker thread starts or finishes a test, it updates this progress display. The display keeps track of the finished and in-flight tests in the order they were found in the input. It uses this to print the tests as they are executed in source order. The range between the oldest unfinished and the most recently started test is printed to the terminal in a way that allows it to be erased and overwritten when the status updates. As a result, circt-test can display a live status as tests are executed, but still keep that list in source order.

The progress display also prints a small progress bar and list of test names currently running, modeling `cargo build` and `cargo test` to some degree.

Example output:
```
running 5 tests
test alu_adder ... passed  59 s
test alu_multiplier ... running  2:49
test alu_shifter ... passed  24 s
test axi_to_apb ... passed  1:16
test dcache_miss ... running  12 s

running 2:53 [██████····] 5/5: alu_multiplier, dcache_miss
```