### PR TITLE
[ESI] Fix memory leak in wrap operation folders

### DIFF
--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -181,7 +181,7 @@ def WrapValidReadyOp : ESI_Op<"wrap.vr", [
   let arguments = (ins AnyType:$rawInput, I1:$valid);
   let results = (outs ChannelType:$chanOutput, I1:$ready);
   let hasCustomAssemblyFormat = 1;
-  let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
   let hasVerifier = 1;
 
   let builders = [
@@ -217,7 +217,6 @@ def WrapFIFOOp : ESI_Op<"wrap.fifo", [
   let arguments = (ins AnyType:$data, I1:$empty);
   let results = (outs ChannelType:$chanOutput, I1:$rden);
   let hasCanonicalizeMethod = true;
-  let hasFolder = true;
   let hasVerifier = 1;
 
   let assemblyFormat = [{


### PR DESCRIPTION
Fixes #9367

The `WrapValidReadyOp` and `WrapFIFOOp` `fold()` methods were creating new operations (`NullSourceOp`), which violates MLIR's design principle that fold methods must never create operations. This caused memory leaks as the operations weren't properly tracked by the rewriter.

## Changes:
- Removed `fold()` methods from `WrapValidReadyOp` and `WrapFIFOOp`
- Moved no-users handling to `canonicalize()` methods which can properly create operations using `PatternRewriter`
- Simplified canonicalizers to just erase unused operations instead of creating `NullSourceOp`
- Added handling for edge case where channel has no consumers but ready/rden signals do have consumers - drive them to appropriate constants (true for ready, false for rden)
- Removed `hasFolder` traits from operation definitions in tablegen

## Testing:
The memory leak reported in #9367 should no longer occur. The test case from the issue should pass without leaking memory.