### PR TITLE
Ignore additional property ports on firrtl.simulation target modules

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -554,8 +554,7 @@ def SimulationOp : FIRRTLOp<"simulation", [
     defines a unique symbol name that can be used to refer to it. The design to
     be tested and any necessary test harness is defined by the separate
     `firrtl.module` op referenced by `moduleName`. Additional parameters may be
-    specified for the unit test. The target module must have the following port
-    signature:
+    specified for the unit test. The target module's first four ports must be:
 
     ```mlir
     (
@@ -565,6 +564,9 @@ def SimulationOp : FIRRTLOp<"simulation", [
       out %success: !firrtl.uint<1>
     )
     ```
+
+    Any additional ports (index 4 and beyond) may only be property types and
+    are ignored.
 
     This operation may be used to mark unit tests in a FIRRTL design, which
     other tools may later pick up and run automatically. It is intended to lower

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2736,7 +2736,7 @@ firrtl.circuit "SimulationTargetInvalid" {
 
 firrtl.circuit "SimulationPortCount" {
   firrtl.extmodule @SimulationPortCount()
-  // expected-error @below {{op target @Foo must have 4 ports, got 0 instead}}
+  // expected-error @below {{op target @Foo must have at least 4 ports, got 0 instead}}
   firrtl.simulation @foo, @Foo {}
   // expected-note @below {{target defined here}}
   firrtl.extmodule @Foo()
@@ -2919,6 +2919,22 @@ firrtl.circuit "SimulationPortType3" {
     in init: !firrtl.uint<1>,
     out done: !firrtl.uint<1>,
     out success: !firrtl.reset
+  )
+}
+
+// -----
+
+firrtl.circuit "SimulationExtraHardwarePort" {
+  firrtl.extmodule @SimulationExtraHardwarePort()
+  // expected-error @below {{op target @Foo port 4 may only be a property type, got '!firrtl.uint<8>' instead}}
+  firrtl.simulation @foo, @Foo {}
+  // expected-note @below {{target defined here}}
+  firrtl.extmodule @Foo(
+    in clock: !firrtl.clock,
+    in init: !firrtl.uint<1>,
+    out done: !firrtl.uint<1>,
+    out success: !firrtl.uint<1>,
+    in extra: !firrtl.uint<8>
   )
 }
 

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -170,6 +170,18 @@ firrtl.extmodule @SimulationTop(
   out success: !firrtl.uint<1>
 )
 
+// Simulation targets may have additional property ports
+firrtl.simulation @mySimulationTestWithProps, @SimulationTopWithProps {}
+
+firrtl.extmodule @SimulationTopWithProps(
+  in clock: !firrtl.clock,
+  in init: !firrtl.uint<1>,
+  out done: !firrtl.uint<1>,
+  out success: !firrtl.uint<1>,
+  in someProp: !firrtl.string,
+  out anotherProp: !firrtl.integer
+)
+
 firrtl.module @Contracts(in %a: !firrtl.uint<42>, in %b: !firrtl.bundle<x: uint<1337>>) {
   firrtl.contract {}
   firrtl.contract %a, %b : !firrtl.uint<42>, !firrtl.bundle<x: uint<1337>> {


### PR DESCRIPTION
Users may be using properties to communicate side-band metadata about testharness or their internals while still wanting to use `circt-test`. This allows modules targeted by a `firrtl.simulation` to contain additional property ports provided their hardware interface is the expected `clock`, `init`, `done`, `success`.
