### PR TITLE
[Comb] Replace BoolArrayAttr with DenseBoolArrayAttr in TruthTableOp

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -322,7 +322,7 @@ def TruthTableOp : CombOp<"truth_table", [Pure]> {
     be 'x' -- it should be the well-known result.
   }];
 
-  let arguments = (ins Variadic<I1>:$inputs, BoolArrayAttr:$lookupTable);
+  let arguments = (ins Variadic<I1>:$inputs, DenseBoolArrayAttr:$lookupTable);
   let results = (outs I1:$result);
 
   let assemblyFormat = [{

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -611,7 +611,7 @@ LogicalResult TruthTableOp::verify() {
     return emitOpError("Truth tables support a maximum of ")
            << sizeof(size_t) * 8 - 1 << " inputs on your platform";
 
-  ArrayAttr table = getLookupTable();
+  auto table = getLookupTable();
   if (table.size() != (1ull << numInputs))
     return emitOpError("Expected lookup table of 2^n length");
   return success();

--- a/lib/Dialect/Comb/Transforms/LowerComb.cpp
+++ b/lib/Dialect/Comb/Transforms/LowerComb.cpp
@@ -49,9 +49,7 @@ public:
   LogicalResult matchAndRewrite(TruthTableOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
-    SmallVector<bool> table(
-        llvm::map_range(op.getLookupTableAttr().getAsValueRange<IntegerAttr>(),
-                        [](const APInt &a) { return !a.isZero(); }));
+    auto table = op.getLookupTableAttr().asArrayRef();
     Value t =
         hw::ConstantOp::create(b, loc, b.getIntegerAttr(b.getI1Type(), 1));
     Value f =

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -77,15 +77,12 @@ struct GenericLUT : public CutRewritePattern {
     for (uint32_t i = 0; i < truthTable.table.getBitWidth(); ++i)
       lutTable.push_back(truthTable.table[i]);
 
-    auto arrayAttr = rewriter.getBoolArrayAttr(
-        lutTable); // Create a boolean array attribute.
-
     // Reverse the inputs to match the LUT input order
     SmallVector<Value> lutInputs(cut.inputs.rbegin(), cut.inputs.rend());
 
     // Generate comb.truth table operation.
     auto truthTableOp = comb::TruthTableOp::create(
-        rewriter, cut.getRoot()->getLoc(), lutInputs, arrayAttr);
+        rewriter, cut.getRoot()->getLoc(), lutInputs, lutTable);
 
     // Replace the root operation with the truth table operation
     return truthTableOp.getOperation();


### PR DESCRIPTION
Replace BoolArrayAttr with DenseBoolArrayAttr in TruthTableOp to simplify the API (and I believe it's simply better as far as I see the current use cases). This change updates the TruthTableOp's lookupTable argument type, simplifies type handling in CombOps.cpp and LowerComb.cpp by removing unnecessary casts and conversions, and updates GenericLUTMapper.cpp to pass ArrayRef<bool> directly instead of creating intermediate BoolArrayAttr objects.