### PR TITLE
[ImportLiberty] Treat space as logical AND in expression parser

### DIFF
--- a/lib/Conversion/ImportLiberty/ImportLiberty.cpp
+++ b/lib/Conversion/ImportLiberty/ImportLiberty.cpp
@@ -330,14 +330,19 @@ ParseResult ExpressionParser::parseXorExpr(Value &result) {
 }
 
 /// Parse AND expressions with highest precedence.
-/// AndExpr -> UnaryExpr { ('*'|'&') UnaryExpr }
+/// AndExpr -> UnaryExpr { ('*'|'&'|implicit) UnaryExpr }
 /// This implements left-associative parsing: A * B * C becomes (A * B) * C
+/// Space between expressions is treated as implicit AND.
 ParseResult ExpressionParser::parseAndExpr(Value &result) {
   Value lhs;
   if (parseUnaryExpr(lhs))
     return failure();
-  while (peek().kind == TokenKind::AND) {
-    auto loc = consume().loc;
+  while (peek().kind == TokenKind::AND ||
+         (peek().kind == TokenKind::ID || peek().kind == TokenKind::LPAREN ||
+          peek().kind == TokenKind::PREFIX_NOT)) {
+    auto loc = peek().loc;
+    if (peek().kind == TokenKind::AND)
+      consume();
     Value rhs;
     if (parseUnaryExpr(rhs))
       return failure();

--- a/test/Conversion/ImportLiberty/basic.lib
+++ b/test/Conversion/ImportLiberty/basic.lib
@@ -1,6 +1,6 @@
 // RUN: circt-translate --import-liberty %s -o %t.mlir
 // RUN: cat %t.mlir | FileCheck %s
-// RUN: circt-opt %t.mlir -cse -export-verilog | FileCheck %s --check-prefix=VERILOG
+// RUN: circt-opt %t.mlir -cse -prettify-verilog -export-verilog | FileCheck %s --check-prefix=VERILOG
 // CHECK: module attributes {synth.liberty.library = {
 // CHECK-DAG:   args = ["test"]
 // CHECK-DAG:   current_unit = "1uA"
@@ -17,14 +17,14 @@ library(test) {
   // CHECK-SAME: in %C : i1 {synth.liberty.pin = {}}
   // CHECK-SAME: out Z : i1 {synth.liberty.pin = {function = "A * !B + C"}}
   // CHECK-SAME: out PRECEDENCE : i1 {synth.liberty.pin = {function = "A * B ^ C"}}
-  // CHECK-SAME: out COMPLEX : i1 {synth.liberty.pin = {function = "(A + B) * (C + !A)"}}
+  // CHECK-SAME: out COMPLEX : i1 {synth.liberty.pin = {function = "(A + B) (C + !A) !A C"}}
   // CHECK-SAME: out POSTFIX_NOT : i1 {synth.liberty.pin = {function = "C'"}}
   // CHECK-SAME: out PAREN_POSTFIX : i1 {synth.liberty.pin = {function = "(C + B)'"}}
   // CHECK-SAME: inout %IO : i1 {synth.liberty.pin = {}})
   // VERILOG-LABEL: module Basic(
   // VERILOG:      assign Z = A & ~B | C;
   // VERILOG-NEXT: assign PRECEDENCE = A & B ^ C;
-  // VERILOG-NEXT: assign COMPLEX = (A | B) & (C | ~A);
+  // VERILOG-NEXT: assign COMPLEX = (A | B) & (C | ~A) & ~A & C;
   // VERILOG-NEXT: assign POSTFIX_NOT = ~C;
   // VERILOG-NEXT: assign PAREN_POSTFIX = ~(C | B);
   cell(Basic) {
@@ -51,7 +51,8 @@ library(test) {
     // Check complex expression
     pin(COMPLEX) {
       direction: output;
-      function: "(A + B) * (C + !A)";
+      // Check a space is treated as AND operator
+      function: "(A + B) (C + !A) !A C";
     }
     // Check postfix NOT
     pin(POSTFIX_NOT) {


### PR DESCRIPTION
Liberty format allows implicit AND between expressions when they are separated by whitespace. Modified parseAndExpr to handle juxtaposition of unary expressions as implicit AND operations, treating "A B C" the same as "A * B * C".