### PR TITLE
[Arc][Python] Add Arc dialect type property getters to Python bindings

### DIFF
--- a/include/circt-c/Dialect/Arc.h
+++ b/include/circt-c/Dialect/Arc.h
@@ -1,4 +1,4 @@
-//===- Arc.h - C interface for the Arc dialect ------------------*- C -*-===//
+//===- Arc.h - C interface for the Arc dialect --------------------*- C -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -25,19 +25,27 @@ MLIR_CAPI_EXPORTED void registerArcPasses(void);
 MLIR_CAPI_EXPORTED bool arcTypeIsAState(MlirType type);
 MLIR_CAPI_EXPORTED MlirType arcStateTypeGet(MlirType innerType);
 MLIR_CAPI_EXPORTED MlirType arcStateTypeGetType(MlirType type);
+MLIR_CAPI_EXPORTED unsigned arcStateTypeGetBitWidth(MlirType type);
+MLIR_CAPI_EXPORTED unsigned arcStateTypeGetByteWidth(MlirType type);
 
 MLIR_CAPI_EXPORTED bool arcTypeIsAMemory(MlirType type);
 MLIR_CAPI_EXPORTED MlirType arcMemoryTypeGet(unsigned numWords,
                                              MlirType wordType,
                                              MlirType addressType);
+MLIR_CAPI_EXPORTED unsigned arcMemoryTypeGetNumWords(MlirType type);
+MLIR_CAPI_EXPORTED MlirType arcMemoryTypeGetWordType(MlirType type);
+MLIR_CAPI_EXPORTED MlirType arcMemoryTypeGetAddressType(MlirType type);
+MLIR_CAPI_EXPORTED unsigned arcMemoryTypeGetStride(MlirType type);
 
 MLIR_CAPI_EXPORTED bool arcTypeIsAStorage(MlirType type);
 MLIR_CAPI_EXPORTED MlirType arcStorageTypeGet(MlirContext ctx);
 MLIR_CAPI_EXPORTED MlirType arcStorageTypeGetWithSize(MlirContext ctx,
                                                       unsigned size);
+MLIR_CAPI_EXPORTED unsigned arcStorageTypeGetSize(MlirType type);
 
 MLIR_CAPI_EXPORTED bool arcTypeIsASimModelInstance(MlirType type);
 MLIR_CAPI_EXPORTED MlirType arcSimModelInstanceTypeGet(MlirAttribute model);
+MLIR_CAPI_EXPORTED MlirAttribute arcSimModelInstanceTypeGetModel(MlirType type);
 
 #ifdef __cplusplus
 }

--- a/integration_test/Bindings/Python/dialects/arc.py
+++ b/integration_test/Bindings/Python/dialects/arc.py
@@ -1,0 +1,67 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+import sys
+
+import circt
+from circt.dialects import arc, hw
+from circt.ir import Context, Location, FlatSymbolRefAttr, IntegerType
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+
+  i1 = IntegerType.get_signless(1)
+  i8 = IntegerType.get_signless(8)
+  i32 = IntegerType.get_signless(32)
+
+  # Test StateType
+  # CHECK: !arc.state<i32>
+  state_type = arc.StateType.get(i32)
+  print(state_type)
+
+  # CHECK: bit_width: 32
+  # CHECK: byte_width: 4
+  print(f"bit_width: {state_type.bit_width}")
+  print(f"byte_width: {state_type.byte_width}")
+
+  # CHECK: type: i32
+  print(f"type: {state_type.type}")
+
+  # Test MemoryType
+  # CHECK: !arc.memory<16 x i8, i8>
+  memory_type = arc.MemoryType.get(16, i8, i8)
+  print(memory_type)
+
+  # CHECK: num_words: 16
+  # CHECK: word_type: i8
+  # CHECK: address_type: i8
+  # CHECK: stride: 1
+  print(f"num_words: {memory_type.num_words}")
+  print(f"word_type: {memory_type.word_type}")
+  print(f"address_type: {memory_type.address_type}")
+  print(f"stride: {memory_type.stride}")
+
+  # Test StorageType without size
+  # CHECK: !arc.storage
+  storage_type_no_size = arc.StorageType.get(ctx)
+  print(storage_type_no_size)
+
+  # CHECK: size: 0
+  print(f"size: {storage_type_no_size.size}")
+
+  # Test StorageType with size
+  # CHECK: !arc.storage<256>
+  storage_type_with_size = arc.StorageType.get(ctx, 256)
+  print(storage_type_with_size)
+
+  # CHECK: size: 256
+  print(f"size: {storage_type_with_size.size}")
+
+  # Test SimModelInstanceType
+  # CHECK: !arc.sim.instance<@model_name>
+  sim_model_attr = FlatSymbolRefAttr.get("model_name")
+  sim_model_type = arc.SimModelInstanceType.get(sim_model_attr)
+  print(sim_model_type)
+
+  # CHECK: model: @model_name
+  print(f"model: {sim_model_type.model}")

--- a/lib/Bindings/Python/ArcModule.cpp
+++ b/lib/Bindings/Python/ArcModule.cpp
@@ -28,7 +28,13 @@ void circt::python::populateDialectArcSubmodule(nb::module_ &m) {
           },
           nb::arg("cls"), nb::arg("inner_type"))
       .def_property_readonly(
-          "type", [](MlirType self) { return arcStateTypeGetType(self); });
+          "type", [](MlirType self) { return arcStateTypeGetType(self); })
+      .def_property_readonly(
+          "bit_width",
+          [](MlirType self) { return arcStateTypeGetBitWidth(self); })
+      .def_property_readonly("byte_width", [](MlirType self) {
+        return arcStateTypeGetByteWidth(self);
+      });
 
   mlir_type_subclass(m, "MemoryType", arcTypeIsAMemory)
       .def_classmethod(
@@ -38,7 +44,18 @@ void circt::python::populateDialectArcSubmodule(nb::module_ &m) {
             return cls(arcMemoryTypeGet(numWords, wordType, addressType));
           },
           nb::arg("cls"), nb::arg("num_words"), nb::arg("word_type"),
-          nb::arg("address_type"));
+          nb::arg("address_type"))
+      .def_property_readonly(
+          "num_words",
+          [](MlirType self) { return arcMemoryTypeGetNumWords(self); })
+      .def_property_readonly(
+          "word_type",
+          [](MlirType self) { return arcMemoryTypeGetWordType(self); })
+      .def_property_readonly(
+          "address_type",
+          [](MlirType self) { return arcMemoryTypeGetAddressType(self); })
+      .def_property_readonly(
+          "stride", [](MlirType self) { return arcMemoryTypeGetStride(self); });
 
   mlir_type_subclass(m, "StorageType", arcTypeIsAStorage)
       .def_classmethod(
@@ -50,7 +67,9 @@ void circt::python::populateDialectArcSubmodule(nb::module_ &m) {
                 arcStorageTypeGetWithSize(ctx, nb::cast<unsigned>(size)));
           },
           nb::arg("cls"), nb::arg("context") = nb::none(),
-          nb::arg("size") = nb::none());
+          nb::arg("size") = nb::none())
+      .def_property_readonly(
+          "size", [](MlirType self) { return arcStorageTypeGetSize(self); });
 
   mlir_type_subclass(m, "SimModelInstanceType", arcTypeIsASimModelInstance)
       .def_classmethod(
@@ -58,5 +77,8 @@ void circt::python::populateDialectArcSubmodule(nb::module_ &m) {
           [](nb::object cls, MlirAttribute model) {
             return cls(arcSimModelInstanceTypeGet(model));
           },
-          nb::arg("cls"), nb::arg("model"));
+          nb::arg("cls"), nb::arg("model"))
+      .def_property_readonly("model", [](MlirType self) {
+        return arcSimModelInstanceTypeGetModel(self);
+      });
 }

--- a/lib/CAPI/Dialect/Arc.cpp
+++ b/lib/CAPI/Dialect/Arc.cpp
@@ -1,4 +1,4 @@
-//===- Arc.cpp - C interface for the Arc dialect ------------------------===//
+//===- Arc.cpp - C interface for the Arc dialect --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -36,6 +36,14 @@ MlirType arcStateTypeGetType(MlirType type) {
   return wrap(llvm::cast<StateType>(unwrap(type)).getType());
 }
 
+unsigned arcStateTypeGetBitWidth(MlirType type) {
+  return llvm::cast<StateType>(unwrap(type)).getBitWidth();
+}
+
+unsigned arcStateTypeGetByteWidth(MlirType type) {
+  return llvm::cast<StateType>(unwrap(type)).getByteWidth();
+}
+
 bool arcTypeIsAMemory(MlirType type) {
   return llvm::isa<MemoryType>(unwrap(type));
 }
@@ -46,6 +54,22 @@ MlirType arcMemoryTypeGet(unsigned numWords, MlirType wordType,
       MemoryType::get(unwrap(wordType).getContext(), numWords,
                       llvm::cast<mlir::IntegerType>(unwrap(wordType)),
                       llvm::cast<mlir::IntegerType>(unwrap(addressType))));
+}
+
+unsigned arcMemoryTypeGetNumWords(MlirType type) {
+  return llvm::cast<MemoryType>(unwrap(type)).getNumWords();
+}
+
+MlirType arcMemoryTypeGetWordType(MlirType type) {
+  return wrap(llvm::cast<MemoryType>(unwrap(type)).getWordType());
+}
+
+MlirType arcMemoryTypeGetAddressType(MlirType type) {
+  return wrap(llvm::cast<MemoryType>(unwrap(type)).getAddressType());
+}
+
+unsigned arcMemoryTypeGetStride(MlirType type) {
+  return llvm::cast<MemoryType>(unwrap(type)).getStride();
 }
 
 bool arcTypeIsAStorage(MlirType type) {
@@ -60,6 +84,10 @@ MlirType arcStorageTypeGetWithSize(MlirContext ctx, unsigned size) {
   return wrap(StorageType::get(unwrap(ctx), size));
 }
 
+unsigned arcStorageTypeGetSize(MlirType type) {
+  return llvm::cast<StorageType>(unwrap(type)).getSize();
+}
+
 bool arcTypeIsASimModelInstance(MlirType type) {
   return llvm::isa<SimModelInstanceType>(unwrap(type));
 }
@@ -67,4 +95,8 @@ bool arcTypeIsASimModelInstance(MlirType type) {
 MlirType arcSimModelInstanceTypeGet(MlirAttribute model) {
   auto attr = llvm::cast<mlir::FlatSymbolRefAttr>(unwrap(model));
   return wrap(SimModelInstanceType::get(attr.getContext(), attr));
+}
+
+MlirAttribute arcSimModelInstanceTypeGetModel(MlirType type) {
+  return wrap(llvm::cast<SimModelInstanceType>(unwrap(type)).getModel());
 }


### PR DESCRIPTION
This PR adds missing accessor methods for Arc dialect types in the Python bindings.