### PR TITLE
[circt-bmc] add hw-flatten-modules to pipeline

### DIFF
--- a/integration_test/circt-bmc/comb.mlir
+++ b/integration_test/circt-bmc/comb.mlir
@@ -47,3 +47,16 @@ hw.module @TwoAsserts(in %i0: i1, in %i1: i1) {
   verif.assert %cond : i1
   verif.assert %or0 : i1
 }
+
+// Test assert merging across module boundaries
+//  RUN: circt-bmc %s -b 10 --module ModuleAsserts --shared-libs=%libz3 | FileCheck %s --check-prefix=MODASSERTS
+//  MODASSERTS: Assertion can be violated!
+
+hw.module private @OneAssert(in %in: i1) {
+  verif.assert %in : i1
+}
+
+hw.module @ModuleAsserts(in %i0: i1, in %i1: i1) {
+  hw.instance "a" @OneAssert(in: %i0: i1) -> ()
+  hw.instance "b" @OneAssert(in: %i1: i1) -> ()
+}

--- a/integration_test/circt-bmc/split-asserts.mlir
+++ b/integration_test/circt-bmc/split-asserts.mlir
@@ -1,4 +1,4 @@
-//  RUN: not circt-bmc %s -b 10 --module ModuleAsserts --shared-libs=%libz3 2>&1 | FileCheck %s
+//  RUN: not circt-bmc %s -b 10 --module ModuleAsserts --shared-libs=%libz3 --flatten-modules=false 2>&1 | FileCheck %s
 //  CHECK: error: bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions
 
 hw.module @OneAssert(in %in: i1) {

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(circt-bmc
   CIRCTEmitTransforms
   CIRCTHW
   CIRCTHWToSMT
+  CIRCTHWTransforms
   CIRCTOMTransforms
   CIRCTSeq
   CIRCTSMTToZ3LLVM

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -19,6 +19,7 @@
 #include "circt/Dialect/Emit/EmitPasses.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/OM/OMPasses.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
@@ -30,6 +31,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
 #include "mlir/Dialect/SMT/IR/SMTDialect.h"
 #include "mlir/IR/BuiltinDialect.h"
@@ -118,6 +120,13 @@ static cl::opt<bool> risingClocksOnly(
     cl::desc("Only consider the circuit and property on rising clock edges"),
     cl::init(false), cl::cat(mainCategory));
 
+static cl::opt<bool> flattenModules(
+    "flatten-modules",
+    cl::desc("Flatten all module instances before processing (which will "
+             "increase code size but allows multiple assertions across module "
+             "boundaries to be supported)"),
+    cl::init(true), cl::cat(mainCategory));
+
 #ifdef CIRCT_BMC_ENABLE_JIT
 
 enum OutputFormat { OutputMLIR, OutputLLVM, OutputSMTLIB, OutputRunJIT };
@@ -191,6 +200,8 @@ static LogicalResult executeBMC(MLIRContext &context) {
   pm.addPass(om::createStripOMPass());
   pm.addPass(emit::createStripEmitPass());
   pm.addPass(verif::createLowerTestsPass());
+  if (flattenModules)
+    pm.addPass(hw::createFlattenModules());
   pm.addNestedPass<hw::HWModuleOp>(verif::createCombineAssertLikePass());
   pm.addPass(createExternalizeRegisters());
   LowerToBMCOptions lowerToBMCOptions;
@@ -353,6 +364,7 @@ int main(int argc, char **argv) {
   >();
   // clang-format on
   mlir::func::registerInlinerExtension(registry);
+  mlir::LLVM::registerInlinerInterface(registry);
   mlir::registerBuiltinDialectTranslation(registry);
   mlir::registerLLVMDialectTranslation(registry);
   MLIRContext context(registry);


### PR DESCRIPTION
This gives us multiple assertion support when assertions are spread across (inlineable) modules