### PR TITLE
[Arc] Add `onInitialized` runtime hook

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/ArcRuntime.h
+++ b/include/circt/Dialect/Arc/Runtime/ArcRuntime.h
@@ -66,6 +66,10 @@ ARC_RUNTIME_EXPORT void arcRuntimeDeleteInstance(struct ArcState *instance);
 /// Pre-Eval hook. Must be called by the driver once before every `eval` step.
 ARC_RUNTIME_EXPORT void arcRuntimeOnEval(struct ArcState *instance);
 
+/// Must be called by the driver after the model's `initial` function and
+/// before the first `onEval` call.
+ARC_RUNTIME_EXPORT void arcRuntimeOnInitialized(struct ArcState *instance);
+
 /// Return the API version of the runtime library.
 ARC_RUNTIME_EXPORT uint64_t arcRuntimeGetAPIVersion();
 

--- a/include/circt/Dialect/Arc/Runtime/JITBind.h
+++ b/include/circt/Dialect/Arc/Runtime/JITBind.h
@@ -31,11 +31,13 @@ struct APICallbacks {
                               const char *args);
   void (*fnDeleteInstance)(uint8_t *simState);
   void (*fnOnEval)(uint8_t *simState);
+  void (*fnOnInitialized)(uint8_t *simState);
   void (*fnFormat)(const FmtDescriptor *fmt, ...);
 
   static constexpr char symNameAllocInstance[] = "arcRuntimeIR_allocInstance";
   static constexpr char symNameDeleteInstance[] = "arcRuntimeIR_deleteInstance";
   static constexpr char symNameOnEval[] = "arcRuntimeIR_onEval";
+  static constexpr char symNameOnInitialized[] = "arcRuntimeIR_onInitialized";
   static constexpr char symNameFormat[] = "arcRuntimeIR_format";
 };
 

--- a/include/circt/Dialect/Arc/Runtime/ModelInstance.h
+++ b/include/circt/Dialect/Arc/Runtime/ModelInstance.h
@@ -35,6 +35,7 @@ public:
     return !!modelInfo->modelName ? modelInfo->modelName : "<NULL>";
   }
 
+  void onInitialized();
   void onEval() { ++stepCounter; }
 
 private:

--- a/integration_test/arcilator/JIT/runtime-lib.mlir
+++ b/integration_test/arcilator/JIT/runtime-lib.mlir
@@ -9,7 +9,10 @@
 // optionally emits debug prints.
 
 // DBGOFF-NOT: [ArcRuntime] Created instance of model "flipflop" with ID 0
+// DBGOFF-NOT: [ArcRuntime] Instance with ID 0 initialized
+
 // DBGON:      [ArcRuntime] Created instance of model "flipflop" with ID 0
+// DBGON-NEXT: [ArcRuntime] Instance with ID 0 initialized
 
 // CHECK:      d0 = 00
 // CHECK-NEXT: d0 = ca
@@ -18,7 +21,10 @@
 // DBGON-NEXT: [ArcRuntime] Deleting instance of model "flipflop" with ID 0 after 1 step(s)
 
 // DBGOFF-NOT: [ArcRuntime] Created instance of model "flipflop" with ID 1
+// DBGOFF-NOT: [ArcRuntime] Instance with ID 1 initialized
+
 // DBGON-NEXT: [ArcRuntime] Created instance of model "flipflop" with ID 1
+// DBGON-NEXT: [ArcRuntime] Instance with ID 1 initialized
 
 // CHECK:      d1 = 00
 // CHECK-NEXT: d1 = fe

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -462,6 +462,12 @@ struct SimInstantiateOpLowering
                            ValueRange{allocated});
     }
 
+    // Call the runtime's 'onInitialized' function if present.
+    if (useRuntime)
+      LLVM::CallOp::create(rewriter, loc, TypeRange{},
+                           runtime::APICallbacks::symNameOnInitialized,
+                           {allocated});
+
     // Execute the body.
     rewriter.inlineBlockBefore(&adaptor.getBody().getBlocks().front(), op,
                                {allocated});

--- a/lib/Dialect/Arc/Runtime/ArcRuntime.cpp
+++ b/lib/Dialect/Arc/Runtime/ArcRuntime.cpp
@@ -77,6 +77,10 @@ void arcRuntimeOnEval(ArcState *instance) {
   getModelInstance(instance)->onEval();
 }
 
+void arcRuntimeOnInitialized(ArcState *instance) {
+  getModelInstance(instance)->onInitialized();
+}
+
 ArcState *arcRuntimeGetStateFromModelState(uint8_t *modelState,
                                            uint64_t offset) {
   if (!modelState)
@@ -98,6 +102,10 @@ uint8_t *arcRuntimeIR_allocInstance(const ArcRuntimeModelInfo *model,
 
 void arcRuntimeIR_onEval(uint8_t *modelState) {
   arcRuntimeOnEval(arcRuntimeGetStateFromModelState(modelState, 0));
+}
+
+void arcRuntimeIR_onInitialized(uint8_t *modelState) {
+  arcRuntimeOnInitialized(arcRuntimeGetStateFromModelState(modelState, 0));
 }
 
 void arcRuntimeIR_deleteInstance(uint8_t *modelState) {
@@ -194,7 +202,7 @@ namespace circt::arc::runtime {
 
 static const APICallbacks apiCallbacksGlobal{
     &arcRuntimeIR_allocInstance, &arcRuntimeIR_deleteInstance,
-    &arcRuntimeIR_onEval, &arcRuntimeIR_format};
+    &arcRuntimeIR_onEval, &arcRuntimeIR_onInitialized, &arcRuntimeIR_format};
 
 const APICallbacks &getArcRuntimeAPICallbacks() { return apiCallbacksGlobal; }
 

--- a/lib/Dialect/Arc/Runtime/ModelInstance.cpp
+++ b/lib/Dialect/Arc/Runtime/ModelInstance.cpp
@@ -48,6 +48,14 @@ ModelInstance::~ModelInstance() {
   state->impl = nullptr;
 }
 
+void ModelInstance::onInitialized() {
+  if (verbose) {
+    std::cout << "[ArcRuntime] "
+              << "Instance with ID " << instanceID << " initialized"
+              << std::endl;
+  }
+}
+
 void ModelInstance::parseArgs(const char *args) {
   if (!args)
     return;

--- a/tools/arcilator/arcilator-header-cpp.py
+++ b/tools/arcilator/arcilator-header-cpp.py
@@ -84,6 +84,7 @@ public:
 {% if model.initialFnSym %}
     {{ model.initialFnSym }}(&storage[0]);
 {% endif %}
+    arcRuntimeOnInitialized(runtimeInstance);
   }
 
   ~{{ model.name }}() {

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -297,6 +297,9 @@ static void bindArcRuntimeSymbols(ExecutionEngine &executionEngine) {
                               runtimeCallbacks.symNameOnEval,
                               runtimeCallbacks.fnOnEval);
     bindExecutionEngineSymbol(symbolMap, interner,
+                              runtimeCallbacks.symNameOnInitialized,
+                              runtimeCallbacks.fnOnInitialized);
+    bindExecutionEngineSymbol(symbolMap, interner,
                               runtimeCallbacks.symNameFormat,
                               runtimeCallbacks.fnFormat);
     return symbolMap;

--- a/unittests/Dialect/Arc/Runtime/ArcRuntimeTest.cpp
+++ b/unittests/Dialect/Arc/Runtime/ArcRuntimeTest.cpp
@@ -33,6 +33,9 @@ TEST(ArcRuntimeTest, InstanceLifecycle) {
     notZero |= (state1->modelState[i] != 0);
   EXPECT_FALSE(notZero);
 
+  arcRuntimeOnInitialized(state1);
+  arcRuntimeOnInitialized(state0);
+
   for (auto i = 0; i < 24; ++i)
     arcRuntimeOnEval(state0);
 
@@ -88,6 +91,7 @@ TEST(ArcRuntimeTest, InstanceLifecycleIR) {
   for (uint64_t i = 0; i < bogusStateBytes; ++i)
     notZero |= (state->modelState[i] != 0);
   EXPECT_FALSE(notZero);
+  api.fnOnInitialized(modelState);
   for (auto i = 0; i < 128; ++i)
     api.fnOnEval(modelState);
   api.fnDeleteInstance(modelState);


### PR DESCRIPTION
Adds the `onInitialized` hook to the Arc runtime library. It is called after the model's own initialization function and before the first `eval` call. This provides a convenient location for the runtime lib to capture the instance's initial state.