### PR TITLE
Update .clang-format to disable TableGen

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,9 @@
 BasedOnStyle: LLVM
 AlwaysBreakTemplateDeclarations: Yes
+
+---
+# Don't format .td files
+Language: TableGen
+DisableFormat: true
+SortIncludes: false
+---


### PR DESCRIPTION
Cherry-pick https://github.com/llvm/llvm-project/commit/2b30325fb34452f04cecc3c466a11b21bc009e3d

I also had encountered weird format changes in tablegen so it would be nice to disable for now. 