### PR TITLE
[hw-flatten-modules] Add option to inline public modules

### DIFF
--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -65,6 +65,8 @@ def FlattenModules : Pass<"hw-flatten-modules", "mlir::ModuleOp"> {
            "Maximum number of operations for a module to be considered small">,
     Option<"inlineWithState", "hw-inline-with-state", "bool", "false",
            "Allow inlining of modules that contain state (seq.firreg operations)">,
+    Option<"inlinePublic", "hw-inline-public", "bool", "false",
+           "Inline public modules as well as private ones">,
     Option<"inlineAll", "hw-inline-all", "bool", "true",
            "Inline all private modules regardless of heuristics (default behavior)">
   ];

--- a/lib/Dialect/HW/Transforms/FlattenModules.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenModules.cpp
@@ -247,7 +247,7 @@ void FlattenModulesPass::runOnOperation() {
       // Only inline private `HWModuleOp`s (no extern or generated modules).
       auto module =
           dyn_cast_or_null<HWModuleOp>(node->getModule().getOperation());
-      if (!module || !module.isPrivate())
+      if (!module || (!module.isPrivate() && !this->inlinePublic))
         continue;
 
       // Do not inline a module if it is targeted by a module NLA.

--- a/test/Dialect/HW/hw-inliner-options.mlir
+++ b/test/Dialect/HW/hw-inliner-options.mlir
@@ -3,6 +3,7 @@
 // RUN: circt-opt %s --pass-pipeline='builtin.module(hw-flatten-modules{hw-inline-all=false hw-inline-single-use=false hw-inline-small=true hw-inline-empty=false hw-inline-no-outputs=false})' | FileCheck %s --check-prefix=SMALL
 // RUN: circt-opt %s --pass-pipeline='builtin.module(hw-flatten-modules{hw-inline-all=false hw-small-threshold=3 hw-inline-single-use=false})' | FileCheck %s --check-prefix=THRESHOLD
 // RUN: circt-opt %s --pass-pipeline='builtin.module(hw-flatten-modules{hw-inline-with-state=true})' | FileCheck %s --check-prefix=STATE
+// RUN: circt-opt %s --pass-pipeline='builtin.module(hw-flatten-modules{hw-inline-public=true})' | FileCheck %s --check-prefix=PUBLIC
 
 // Test that all inlining heuristics can be controlled via command line options
 
@@ -81,3 +82,15 @@ hw.module private @LargeModule(in %a: i4, out b: i4) {
   hw.output %7 : i4
 }
 
+// PUBLIC-LABEL: hw.module @TestPublic
+hw.module @TestPublic(in %x: i4, out y: i4) {
+  // PUBLIC-NEXT: %[[V0:.+]] = comb.add %x, %x
+  // PUBLIC-NEXT: hw.output %[[V0]]
+  %0 = hw.instance "public" @PublicModule(a: %x: i4) -> (b: i4)
+  hw.output %0 : i4
+}
+
+hw.module @PublicModule(in %a: i4, out b: i4) {
+  %0 = comb.add %a, %a : i4
+  hw.output %0 : i4
+}


### PR DESCRIPTION
AFAIU this should be safe to use in cases where we know for sure there's only one builtin.module SymbolTable op (such as pipelines that run over a builtin.module)