### PR TITLE
[Synth] Add SOP balancing pass for delay optimization

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -78,6 +78,11 @@ public:
   bool isInverted() const { return value.getInt(); }
   int64_t getArrivalTime() const { return arrivalTime; }
 
+  ValueWithArrivalTime &flipInversion() {
+    value.setInt(!value.getInt());
+    return *this;
+  }
+
   /// Comparison operator for priority queue. Values with earlier arrival times
   /// have higher priority. When arrival times are equal, use value numbering
   /// for determinism.

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -213,6 +213,11 @@ public:
   void getPermutatedInputs(const NPNClass &patternNPN,
                            SmallVectorImpl<Value> &permutedInputs) const;
 
+  /// Get arrival times for each input of this cut.
+  /// Returns failure if any input doesn't have a valid matched pattern.
+  LogicalResult getInputArrivalTimes(CutEnumerator &enumerator,
+                                     SmallVectorImpl<DelayType> &results) const;
+
   /// Matched pattern for this cut.
   void setMatchedPattern(MatchedPattern pattern) {
     matchedPattern = std::move(pattern);

--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -201,4 +201,20 @@ def MaximumAndCover : Pass<"synth-maximum-and-cover", "hw::HWModuleOp"> {
   }];
 }
 
+def SOPBalancing : CutRewriterPassBase<"synth-sop-balancing", "hw::HWModuleOp"> {
+  let summary = "SOP (Sum-of-Products) balancing for delay optimization";
+  let description = [{
+    This pass optimizes delay by restructuring the logic network using balanced
+    sum-of-products expressions. It enumerates cuts, derives their SOP
+    representation, and selects the best cut based on delay and area.
+
+    The algorithm is based on "Delay Optimization Using SOP Balancing" by
+    Mishchenko et al. (ICCAD 2011).
+  }];
+  let options =
+      baseOptions#[Option<"maxCutInputSize", "max-cut-input-size", "unsigned",
+                          /*default=*/"6", "Maximum number of inputs per cut">];
+  let dependentDialects = ["synth::SynthDialect", "comb::CombDialect"];
+}
+
 #endif // CIRCT_DIALECT_SYNTH_TRANSFORMS_PASSES_TD

--- a/include/circt/Dialect/Synth/Transforms/SynthesisPipeline.h
+++ b/include/circt/Dialect/Synth/Transforms/SynthesisPipeline.h
@@ -73,6 +73,10 @@ struct SynthOptimizationPipelineOptions
       *this, "disable-word-to-bits",
       llvm::cl::desc("Disable LowerWordToBits pass"), llvm::cl::init(false)};
 
+  PassOptions::Option<bool> disableSOPBalancing{
+      *this, "disable-sop-balancing",
+      llvm::cl::desc("Disable SOPBalancing pass"), llvm::cl::init(true)};
+
   PassOptions::Option<bool> timingAware{
       *this, "timing-aware",
       llvm::cl::desc("Lower operators in a timing-aware fashion"),

--- a/integration_test/circt-synth/sop-balancing.mlir
+++ b/integration_test/circt-synth/sop-balancing.mlir
@@ -1,0 +1,13 @@
+// REQUIRES: libz3
+// REQUIRES: circt-lec-jit
+
+// RUN: circt-synth %s -o %t.before.mlir -convert-to-comb --output-longest-path=- | FileCheck %s --check-prefix=LONGEST_PATH_BEFORE
+// RUN: circt-synth %s -enable-sop-balancing -o %t.after.mlir -convert-to-comb --output-longest-path=- | FileCheck %s --check-prefix=LONGEST_PATH_AFTER
+// RUN: circt-lec %t.before.mlir %t.after.mlir -c1=add16 -c2=add16 --shared-libs=%libz3 | FileCheck %s --check-prefix=AND_INVERTER_LEC
+// AND_INVERTER_LEC: c1 == c2
+// LONGEST_PATH_BEFORE: delay: 12
+// LONGEST_PATH_AFTER:  delay: 10
+hw.module @add16(in %arg0: i16, in %arg1: i16, out add: i16) {
+  %0 = comb.add %arg0, %arg1 : i16
+  hw.output %0 : i16
+}

--- a/lib/Dialect/Synth/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Synth/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ add_circt_dialect_library(CIRCTSynthTransforms
   LowerVariadic.cpp
   LowerWordToBits.cpp
   MaximumAndCover.cpp
+  SOPBalancing.cpp
   StructuralHash.cpp
   SynthesisPipeline.cpp
   TechMapper.cpp

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -231,6 +231,38 @@ void Cut::getPermutatedInputs(const NPNClass &patternNPN,
   }
 }
 
+LogicalResult
+Cut::getInputArrivalTimes(CutEnumerator &enumerator,
+                          SmallVectorImpl<DelayType> &results) const {
+  results.reserve(getInputSize());
+
+  // Compute arrival times for each input.
+  for (auto input : inputs) {
+    if (isAlwaysCutInput(input)) {
+      // If the input is a primary input, it has no delay.
+      results.push_back(0);
+      continue;
+    }
+    auto *cutSet = enumerator.getCutSet(input);
+    assert(cutSet && "Input must have a valid cut set");
+
+    // If there is no matching pattern, it means it's not possible to use the
+    // input in the cut rewriting. Return empty vector to indicate failure.
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      return failure();
+
+    const auto &matchedPattern = *bestCut->getMatchedPattern();
+
+    // Otherwise, the cut input is an op result. Get the arrival time
+    // from the matched pattern.
+    results.push_back(matchedPattern.getArrivalTime(
+        cast<mlir::OpResult>(input).getResultNumber()));
+  }
+
+  return success();
+}
+
 void Cut::dump(llvm::raw_ostream &os) const {
   os << "// === Cut Dump ===\n";
   os << "Cut with " << getInputSize() << " inputs and " << operations.size()

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -1,0 +1,280 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements SOP (Sum-of-Products) balancing for delay optimization
+// based on "Delay Optimization Using SOP Balancing" by Mishchenko et al.
+// (ICCAD 2011).
+//
+// NOTE: Currently supports AIG but should be extended to other logic forms
+// (MIG, comb or/and) in the future.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Synth/SynthOps.h"
+#include "circt/Dialect/Synth/Transforms/CutRewriter.h"
+#include "circt/Dialect/Synth/Transforms/SynthPasses.h"
+#include "circt/Support/TruthTable.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "synth-sop-balancing"
+
+using namespace circt;
+using namespace circt::synth;
+using namespace mlir;
+
+namespace circt {
+namespace synth {
+#define GEN_PASS_DEF_SOPBALANCING
+#include "circt/Dialect/Synth/Transforms/SynthPasses.h.inc"
+} // namespace synth
+} // namespace circt
+
+using namespace circt::synth;
+
+//===----------------------------------------------------------------------===//
+// SOP Cache
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Expected maximum number of inputs for ISOP extraction, used as a hint for
+/// SmallVector capacity to avoid reallocations in common cases.
+constexpr unsigned expectedISOPInputs = 8;
+
+/// Cache for SOP extraction results, keyed by truth table.
+class SOPCache {
+public:
+  const SOPForm &getOrCompute(const APInt &truthTable, unsigned numVars) {
+    auto it = cache.find(truthTable);
+    if (it != cache.end())
+      return it->second;
+    return cache
+        .try_emplace(truthTable, circt::extractISOP(truthTable, numVars))
+        .first->second;
+  }
+
+private:
+  DenseMap<APInt, SOPForm> cache;
+};
+
+//===----------------------------------------------------------------------===//
+// Tree Building Helpers
+//===----------------------------------------------------------------------===//
+
+/// Simulate balanced tree and return output arrival time.
+static DelayType simulateBalancedTree(ArrayRef<DelayType> arrivalTimes) {
+  if (arrivalTimes.empty())
+    return 0;
+  return buildBalancedTreeWithArrivalTimes<DelayType>(
+      arrivalTimes, [](auto a, auto b) { return std::max(a, b) + 1; });
+}
+
+/// Build balanced AND tree.
+ValueWithArrivalTime
+buildBalancedAndTree(OpBuilder &builder, Location loc,
+                     SmallVectorImpl<ValueWithArrivalTime> &nodes) {
+  assert(!nodes.empty());
+
+  if (nodes.size() == 1)
+    return nodes[0];
+
+  size_t num = nodes.size();
+  auto result = buildBalancedTreeWithArrivalTimes<ValueWithArrivalTime>(
+      nodes, [&](const auto &n1, const auto &n2) {
+        Value v = aig::AndInverterOp::create(builder, loc, n1.getValue(),
+                                             n2.getValue(), n1.isInverted(),
+                                             n2.isInverted());
+        return ValueWithArrivalTime(
+            v, std::max(n1.getArrivalTime(), n2.getArrivalTime()) + 1, false,
+            num++);
+      });
+  return result;
+}
+
+/// Build balanced SOP structure.
+Value buildBalancedSOP(OpBuilder &builder, Location loc, const SOPForm &sop,
+                       ArrayRef<Value> inputs,
+                       ArrayRef<DelayType> inputArrivalTimes) {
+  SmallVector<ValueWithArrivalTime, expectedISOPInputs> productTerms, literals;
+
+  size_t num = 0;
+  for (const auto &cube : sop.cubes) {
+    for (unsigned i = 0; i < sop.numVars; ++i) {
+      if (cube.hasLiteral(i))
+        literals.push_back(ValueWithArrivalTime(
+            inputs[i], inputArrivalTimes[i], cube.isLiteralInverted(i), num++));
+    }
+
+    if (literals.empty())
+      continue;
+
+    // Get product term, and flip the inversion to construct OR afterwards.
+    productTerms.push_back(
+        buildBalancedAndTree(builder, loc, literals).flipInversion());
+
+    literals.clear();
+  }
+
+  assert(!productTerms.empty() && "No product terms");
+
+  auto andOfInverted =
+      buildBalancedAndTree(builder, loc, productTerms).flipInversion();
+  // Let's invert the output.
+  if (andOfInverted.isInverted())
+    return aig::AndInverterOp::create(builder, loc, andOfInverted.getValue(),
+                                      true);
+  return andOfInverted.getValue();
+}
+
+/// Compute SOP delays for cost estimation.
+void computeSOPDelays(const SOPForm &sop, ArrayRef<DelayType> inputArrivalTimes,
+                      SmallVectorImpl<DelayType> &delays) {
+  SmallVector<DelayType, expectedISOPInputs> productArrivalTimes, literalTimes;
+  for (const auto &cube : sop.cubes) {
+    for (unsigned i = 0; i < sop.numVars; ++i)
+      // No need to consider inverted literals separately for delay.
+      if (cube.hasLiteral(i))
+        literalTimes.push_back(inputArrivalTimes[i]);
+    if (!literalTimes.empty()) {
+      productArrivalTimes.push_back(simulateBalancedTree(literalTimes));
+      literalTimes.clear();
+    }
+  }
+
+  DelayType outputTime = simulateBalancedTree(productArrivalTimes);
+
+  delays.resize(sop.numVars, 0);
+  // Compute the delay contribution of each input to the output for cost
+  // estimation. The CutRewriter framework requires per-input delays, even
+  // though this is somewhat artificial for SOP balancing. This may be
+  // improved in future framework improvements.
+  //
+  // First, determine which variables are actually used in the SOP by
+  // collecting a bitmask from all cubes.
+  uint64_t mask = 0;
+  for (auto &cube : sop.cubes)
+    mask |= cube.mask;
+
+  // Compute delay for each used input variable.
+  for (unsigned i = 0; i < sop.numVars; ++i)
+    if (mask & (1u << i))
+      delays[i] = outputTime - inputArrivalTimes[i];
+}
+
+//===----------------------------------------------------------------------===//
+// SOP Balancing Pattern
+//===----------------------------------------------------------------------===//
+
+/// Pattern that performs SOP balancing on cuts.
+struct SOPBalancingPattern : public CutRewritePattern {
+  SOPBalancingPattern(MLIRContext *context) : CutRewritePattern(context) {}
+
+  std::optional<MatchResult> match(CutEnumerator &enumerator,
+                                   const Cut &cut) const override {
+    if (cut.isTrivialCut() || cut.getOutputSize() != 1)
+      return std::nullopt;
+
+    const auto &tt = cut.getTruthTable();
+    const SOPForm &sop = sopCache.getOrCompute(tt.table, tt.numInputs);
+    if (sop.cubes.empty())
+      return std::nullopt;
+
+    SmallVector<DelayType, expectedISOPInputs> arrivalTimes;
+    if (failed(cut.getInputArrivalTimes(enumerator, arrivalTimes)))
+      return std::nullopt;
+
+    // Compute area estimate
+    unsigned totalGates = 0;
+    for (const auto &cube : sop.cubes)
+      if (cube.size() > 1)
+        totalGates += cube.size() - 1;
+    if (sop.cubes.size() > 1)
+      totalGates += sop.cubes.size() - 1;
+
+    SmallVector<DelayType, expectedISOPInputs> delays;
+    computeSOPDelays(sop, arrivalTimes, delays);
+
+    MatchResult result;
+    result.area = static_cast<double>(totalGates);
+    result.setOwnedDelays(std::move(delays));
+    return result;
+  }
+
+  FailureOr<Operation *> rewrite(OpBuilder &builder, CutEnumerator &enumerator,
+                                 const Cut &cut) const override {
+    const auto &tt = cut.getTruthTable();
+    const SOPForm &sop = sopCache.getOrCompute(tt.table, tt.numInputs);
+    LLVM_DEBUG({
+      llvm::dbgs() << "Rewriting SOP:\n";
+      sop.dump(llvm::dbgs());
+    });
+
+    SmallVector<DelayType, expectedISOPInputs> arrivalTimes;
+    if (failed(cut.getInputArrivalTimes(enumerator, arrivalTimes)))
+      return failure();
+    // Construct the fused location.
+    SetVector<Location> inputLocs;
+    inputLocs.insert(cut.getRoot()->getLoc());
+    for (auto input : cut.inputs)
+      inputLocs.insert(input.getLoc());
+
+    auto loc = builder.getFusedLoc(inputLocs.getArrayRef());
+
+    Value result = buildBalancedSOP(builder, loc, sop, cut.inputs.getArrayRef(),
+                                    arrivalTimes);
+
+    auto *op = result.getDefiningOp();
+    if (!op)
+      op = aig::AndInverterOp::create(builder, loc, result, false);
+    return op;
+  }
+
+  unsigned getNumOutputs() const override { return 1; }
+  StringRef getPatternName() const override { return "sop-balancing"; }
+
+private:
+  // Cache for SOP extraction results. Hence the pattern is stateful and must
+  // not be used in parallelly.
+  mutable SOPCache sopCache;
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// SOP Balancing Pass
+//===----------------------------------------------------------------------===//
+
+struct SOPBalancingPass
+    : public circt::synth::impl::SOPBalancingBase<SOPBalancingPass> {
+  using SOPBalancingBase::SOPBalancingBase;
+
+  void runOnOperation() override {
+    auto module = getOperation();
+
+    CutRewriterOptions options;
+    options.strategy = strategy;
+    options.maxCutInputSize = maxCutInputSize;
+    options.maxCutSizePerRoot = maxCutsPerRoot;
+    options.allowNoMatch = true;
+
+    SmallVector<std::unique_ptr<CutRewritePattern>, 1> patterns;
+    patterns.push_back(
+        std::make_unique<SOPBalancingPattern>(module->getContext()));
+
+    CutRewritePatternSet patternSet(std::move(patterns));
+    CutRewriter rewriter(options, patternSet);
+    if (failed(rewriter.run(module)))
+      return signalPassFailure();
+  }
+};

--- a/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
+++ b/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
@@ -116,6 +116,18 @@ void circt::synth::buildSynthOptimizationPipeline(
   pm.addPass(createLowerVariadicPass(options.timingAware));
   pm.addPass(createStructuralHash());
 
+  // SOP balancing.
+  if (!options.disableSOPBalancing) {
+    SOPBalancingOptions sopOptions;
+    // FIXME: The following is very small compared to the default value of ABC
+    // (6/8) and mockturtle(4/25) due to inefficient implementation of
+    // CutRewriter.
+    sopOptions.maxCutInputSize = 4;
+    sopOptions.maxCutsPerRoot = 4;
+    pm.addPass(synth::createSOPBalancing(sopOptions));
+    pm.addPass(createStructuralHash());
+  }
+
   if (!options.abcCommands.empty()) {
     synth::ABCRunnerOptions abcOptions;
     abcOptions.abcPath = options.abcPath;

--- a/test/Dialect/Synth/sop-balancing.mlir
+++ b/test/Dialect/Synth/sop-balancing.mlir
@@ -1,0 +1,43 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(hw.module(synth-sop-balancing{max-cut-input-size=6}))' %s | FileCheck %s
+
+
+// Chain of ANDs gets balanced into a tree
+
+// CHECK-LABEL: hw.module @and_chain
+hw.module @and_chain(in %a : i1, in %b : i1, in %c : i1, in %d : i1, out result : i1) {
+    // Linear chain that should be balanced
+    // Original: ((a & b) & c) & d - depth 3
+    // Balanced: (a & b) & (c & d) - depth 2
+    %and0 = synth.aig.and_inv %a, %b : i1
+    %and1 = synth.aig.and_inv %and0, %c : i1
+    %and2 = synth.aig.and_inv %and1, %d : i1
+    
+    // CHECK-DAG: %[[LEFT:.*]] = synth.aig.and_inv %a, %b
+    // CHECK-DAG: %[[RIGHT:.*]] = synth.aig.and_inv %c, %d
+    // CHECK: %[[RESULT:.*]] = synth.aig.and_inv %[[LEFT]], %[[RIGHT]]
+    // CHECK: hw.output %[[RESULT]]
+    hw.output %and2 : i1
+}
+
+// Example from ICCAD paper Sec 3.2.
+// CHECK-LABEL: hw.module @balance
+hw.module @balance(in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1, in %f: i1, out o1: i1) {
+    // Original: ab + c(d + ef) - depth 4
+    // Balanced: (ab + cd) + cef - depth 3
+    %0 = synth.aig.and_inv %a, %b : i1
+    %1 = synth.aig.and_inv %e, %f : i1
+    %2 = synth.aig.and_inv not %d, not %1 : i1
+    %3 = synth.aig.and_inv %c, not %2 : i1
+    %4 = synth.aig.and_inv not %0, not %3 : i1
+    %5 = synth.aig.and_inv not %4 : i1
+    // CHECK-DAG: %[[AB:.*]] = synth.aig.and_inv %a, %b
+    // CHECK-DAG: %[[EF:.*]] = synth.aig.and_inv %e, %f
+    // CHECK-DAG: %[[CEF:.*]] = synth.aig.and_inv %[[EF]], %c
+    // CHECK-DAG: %[[CD:.*]] = synth.aig.and_inv %d, %c
+    // CHECK-DAG: %[[RESULT1:.*]] = synth.aig.and_inv not %[[AB]], not %[[CD]]
+    // CHECK-DAG: %[[RESULT2:.*]] = synth.aig.and_inv not %[[CEF]], %[[RESULT1]]
+    // CHECK-DAG: %[[FINAL:.*]] = synth.aig.and_inv not %[[RESULT2]]
+    // CHECK: hw.output %[[FINAL]]
+    hw.output %5 : i1
+}
+

--- a/test/circt-synth/path-e2e.mlir
+++ b/test/circt-synth/path-e2e.mlir
@@ -1,24 +1,24 @@
-// RUN: circt-synth %s -output-longest-path=- -top counter | FileCheck %s --check-prefixes COMMON,AIG
+// RUN: circt-synth %s -output-longest-path=- -top counter --enable-sop-balancing | FileCheck %s --check-prefixes COMMON,AIG
 // RUN: circt-synth %s -output-longest-path=- -top counter --target-ir mig | FileCheck %s --check-prefixes COMMON,MIG
 // RUN: circt-synth %s -output-longest-path=- -top counter -lower-to-k-lut 6 | FileCheck %s --check-prefixes COMMON,LUT6
-// RUN: circt-synth %s -output-longest-path=- -top counter -output-longest-path-json | FileCheck %s --check-prefix JSON
+// RUN: circt-synth %s -output-longest-path=- -top test -output-longest-path-json | FileCheck %s --check-prefix JSON
 
 // COMMON-LABEL: # Longest Path Analysis result for "counter"
 // COMMON-NEXT: Found 168 paths
 // COMMON-NEXT: Found 32 unique end points
-// AIG-NEXT: Maximum path delay: 32
+// AIG-NEXT: Maximum path delay: 27
 // MIG-NEXT: Maximum path delay: 32
 // LUT6-NEXT: Maximum path delay: 6
 // Don't test detailed reports as they are not stable.
 
-// Make sure json is emitted.
-// JSON: {"module_name":"counter","timing_levels":[
 hw.module @counter(in %a: i16, in %clk: !seq.clock, out result: i16) {
     %reg = seq.compreg %add, %clk : i16
     %add = comb.mul %reg, %a : i16
     hw.output %reg : i16
 }
 
+// Make sure json is emitted.
+// JSON: {"module_name":"test","timing_levels":[
 // COMMON-NOT: "test"
 hw.module @test(in %a: i16, out result: i16) {
     hw.output %a : i16

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -174,6 +174,10 @@ static cl::opt<bool>
                        cl::desc("Disable datapath optimization passes"),
                        cl::init(false), cl::cat(mainCategory));
 
+static cl::opt<bool> enableSOPBalancing("enable-sop-balancing",
+                                        cl::desc("Enable SOP balancing"),
+                                        cl::init(false), cl::cat(mainCategory));
+
 static cl::opt<int> maxCutSizePerRoot("max-cut-size-per-root",
                                       cl::desc("Maximum cut size per root"),
                                       cl::init(6), cl::cat(mainCategory));
@@ -257,6 +261,7 @@ static void populateCIRCTSynthPipeline(PassManager &pm) {
     optimizationOptions.ignoreAbcFailures.setValue(ignoreAbcFailures);
     optimizationOptions.disableWordToBits.setValue(disableWordToBits);
     optimizationOptions.timingAware.setValue(!disableTimingAware);
+    optimizationOptions.disableSOPBalancing.setValue(!enableSOPBalancing);
 
     circt::synth::buildSynthOptimizationPipeline(pm, optimizationOptions);
     if (untilReached(UntilMapping))


### PR DESCRIPTION
This commit introduces a new pass, SOPBalancing, in the Synth dialect to perform delay optimization by restructuring And-Inverter Graphs (AIGs) through sum-of-products (SOP) balancing. The implementation is based on the algorithm described in "Delay Optimization Using SOP Balancing" by Mishchenko et al. (ICCAD 2011), which derives ISOP representations for cuts, balances SOP expressions to minimize critical path delay, and selects optimal cuts based on delay-area trade-offs.

The pass uses cut-based rewriting and is disabled by default for now. There are several improvements necessary for CutRewriter framework to make it practical.  