### PR TITLE
[ImportVerilog] Add support for static class members

### DIFF
--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -82,9 +82,10 @@ endclass
 
 // CHECK-LABEL: moore.class.classdecl @PropertyCombo {
 // CHECK:   moore.class.propertydecl @pubAutoI32 : !moore.i32
-// CHECK-NEXT:   moore.class.propertydecl @protStatL18 : !moore.l18
 // CHECK-NEXT:   moore.class.propertydecl @localAutoI32 : !moore.i32
 // CHECK: }
+// CHECK-LABEL: moore.global_variable @"PropertyCombo::protStatL18" : !moore.l18
+
 class PropertyCombo;
   // public automatic int
   int pubAutoI32;
@@ -684,3 +685,28 @@ endclass
 function int methodProtoClass::testFunction();
    return mytestvar;
 endfunction
+
+
+// Check static member declarations are emitted as global variables
+// Also check that name resolution properly prefixes them
+
+// CHECK-LABEL: moore.global_variable @member : !moore.i32
+static int member;
+
+// CHECK-LABEL: moore.class.classdecl @staticMemberClass {
+// CHECK-NEXT: }
+class staticMemberClass;
+
+// CHECK-LABEL:   moore.global_variable @"staticMemberClass::member" : !moore.i32
+   static int member;
+
+// CHECK-LABEL:  func.func private @next_member() -> !moore.i32 {
+// CHECK:    [[MEMVAR:%.+]] = moore.get_global_variable @"staticMemberClass::member" : <i32>
+// CHECK:    [[RVAR:%.+]] = moore.read [[MEMVAR]] : <i32>
+// CHECK:    return [[RVAR]] : !moore.i32
+// CHECK:  }
+
+    static function int next_member();
+        return member;
+    endfunction
+endclass


### PR DESCRIPTION
Treat static class members as global variables during lowering:
- Don’t emit class propertydecl for static properties
- Emit fully-qualified global variables for static properties
- Resolve static property access via `GetGlobalVariableOp`

Add SV tests covering static member declaration + name resolution.

EDIT: sv-test diff:
```
-96 error: class property 'inst' referenced without an implicit 'this'
+31 error: expression of type '!moore.class<@"uvm_pkg::uvm_coreservice_t">' cannot be cast to a simple bit vector
 -8 error: top-level module 'dut' has unconnected interface port 'in'
 +4 error: failed to legalize operation 'moore.global_variable'
 +3 error: unknown property `i`
 -2 error: class property 'current' referenced without an implicit 'this'
 -2 error: class property 'id' referenced without an implicit 'this'
 -1 error: unsupported definition: interface
 -1 error: unsupported expression: CopyClass
 +1 error: unknown property `int_incr`
 +1 error: unknown property `s`
 +1 error: unknown property `y`
-69 total change
```