### PR TITLE
[ImportVerilog] Allow static member hoisting from outside class

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1559,8 +1559,12 @@ struct ClassDeclVisitor {
     }
 
     // Static variables should be accessed like globals, and not emit any
-    // property declaration.
-    return context.convertGlobalVariable(prop);
+    // property declaration. Static variables might get hoisted elsewhere
+    // so check first whether they have been declared already.
+
+    if (!context.globalVariables.lookup(&prop))
+      return context.convertGlobalVariable(prop);
+    return success();
   }
 
   // Parameters in specialized classes hold no further information; slang

--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -710,3 +710,32 @@ class staticMemberClass;
         return member;
     endfunction
 endclass
+
+// Check that accesses to static members of forward-declared classes without
+// an object instance are valid.
+
+typedef class staticClass;
+
+// CHECK-LABEL:  moore.class.classdecl @otherClass {
+// CHECK:  }
+
+// CHECK-LABEL:  func.func private @"otherClass::otherMemberAccess"
+// CHECK-SAME: (%arg0: !moore.class<@otherClass>) -> !moore.i32 {
+// CHECK:    [[VAR0:%.+]] = moore.get_global_variable @"staticClass::member" : <i32>
+// CHECK:    [[VAR1:%.+]] = moore.read [[VAR0]] : <i32>
+// CHECK:    return [[VAR1]] : !moore.i32
+// CHECK:  }
+
+// CHECK-LABEL:  moore.class.classdecl @staticClass {
+// CHECK:  }
+// CHECK-LABEL: moore.global_variable @"staticClass::member" : !moore.i32
+
+class otherClass;
+    function int otherMemberAccess();
+        return staticClass::member;
+    endfunction
+endclass
+
+class staticClass;
+    static int member;
+endclass


### PR DESCRIPTION
Ensure static class member variables are hoisted to globals when accessed,
even if the class definition appears later or the variable has not yet been
declared.

Static members are now:
- Hoisted on demand during expression conversion if missing
- Guarded against duplicate global emission during class traversal

Add a regression test covering access to static members of forward-declared
classes without an object instance.