### PR TITLE
[Arc] Stabilize order in ModelInfoAnalysis, NFC

### DIFF
--- a/include/circt/Dialect/Arc/ModelInfo.h
+++ b/include/circt/Dialect/Arc/ModelInfo.h
@@ -51,7 +51,7 @@ struct ModelInfo {
 
 struct ModelInfoAnalysis {
   explicit ModelInfoAnalysis(Operation *container);
-  llvm::DenseMap<ModelOp, ModelInfo> infoMap;
+  llvm::MapVector<ModelOp, ModelInfo> infoMap;
 };
 
 /// Collects information about states within the provided Arc model storage

--- a/lib/Dialect/Arc/ModelInfo.cpp
+++ b/lib/Dialect/Arc/ModelInfo.cpp
@@ -129,7 +129,8 @@ LogicalResult circt::arc::collectModels(mlir::ModuleOp module,
     SmallVector<StateInfo> states;
     if (failed(collectStates(storageArg, 0, states)))
       return failure();
-    llvm::sort(states, [](auto &a, auto &b) { return a.offset < b.offset; });
+    llvm::stable_sort(states,
+                      [](auto &a, auto &b) { return a.offset < b.offset; });
 
     models.emplace_back(std::string(modelOp.getName()), storageType.getSize(),
                         std::move(states), modelOp.getInitialFnAttr(),
@@ -202,7 +203,8 @@ circt::arc::ModelInfoAnalysis::ModelInfoAnalysis(Operation *container) {
       assert(false && "Failed to collect model states");
       continue;
     }
-    llvm::sort(states, [](auto &a, auto &b) { return a.offset < b.offset; });
+    llvm::stable_sort(states,
+                      [](auto &a, auto &b) { return a.offset < b.offset; });
     infoMap.try_emplace(modelOp, std::string(modelOp.getName()),
                         storageType.getSize(), std::move(states),
                         modelOp.getInitialFnAttr(), modelOp.getFinalFnAttr());


### PR DESCRIPTION
Use `MapVector` and `llvm::stable_sort` for reproducible results. State offsets are not unique, since a signal can have multiple aliases.