### PR TITLE
[ImportVerilog] Add support for queue size() builtin

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2437,6 +2437,25 @@ def AtanhBIOp : RealMathFunc<"atanh"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Size
+//===----------------------------------------------------------------------===//
+
+def QueueSizeBIOp : Builtin<"size"> {
+  let summary = "Return the number of elements in a queue";
+  let description = [{
+    Corresponds to the `size` system function. Returns the number of items in a queue.
+    According to spec the returned size fits an `int`.
+
+    See IEEE 1800-2023 § 7.10.2.1 "Size()".
+  }];
+
+  // Optional positional attribute for the seed
+  let arguments = (ins QueueType:$queue);
+  let results = (outs TwoValuedI32:$result);
+  let assemblyFormat = "$queue `:` type($queue) attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // Classes
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2695,6 +2695,12 @@ Context::convertSystemCallArity1(const slang::ast::SystemSubroutine &subroutine,
                 [&]() -> Value {
                   return moore::StringToUpperOp::create(builder, loc, value);
                 })
+          .Case("size",
+                [&]() -> Value {
+                  if (isa<moore::QueueType>(value.getType()))
+                    return moore::QueueSizeBIOp::create(builder, loc, value);
+                  return {};
+                })
           .Case("tolower",
                 [&]() -> Value {
                   return moore::StringToLowerOp::create(builder, loc, value);

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3823,3 +3823,23 @@ module NullableTest;
    nullableClass c = null;
    event e = null;
 endmodule
+
+// CHECK-LABEL: moore.module @QueueSizeTest() {
+// CHECK:    [[Q:%.+]] = moore.variable : <queue<i32, 0>>
+// CHECK:    [[QSIZE:%.+]] = moore.variable : <i32>
+// CHECK:    moore.procedure initial {
+// CHECK:      [[QVAR:%.+]] = moore.read [[Q]] : <queue<i32, 0>>
+// CHECK:      [[SIZE:%.+]] = moore.builtin.size [[QVAR]] : <i32, 0>
+// CHECK:      moore.blocking_assign [[QSIZE]], [[SIZE]] : i32
+// CHECK:      moore.return
+// CHECK:    }
+// CHECK:    moore.output
+// CHECK:  }
+
+module QueueSizeTest;
+    int q[$];
+    int qsize;
+    initial begin
+        qsize = q.size();
+    end
+endmodule


### PR DESCRIPTION
Introduce a Moore SizeBIOp modeling the SystemVerilog `size()` system function on queues. Lower calls to `size()` during ImportVerilog expression conversion when applied to queue-typed operands.

Add a regression test verifying correct lowering of queue size accesses.