### PR TITLE
[ImportVerilog] Fix class conversion crashes

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1767,9 +1767,8 @@ Context::convertClassDeclaration(const slang::ast::ClassType &classdecl) {
   if (classdecl.getBaseClass()) {
     if (const auto *baseClassDecl =
             classdecl.getBaseClass()->as_if<slang::ast::ClassType>()) {
-      if (failed(convertClassDeclaration(*baseClassDecl))) {
+      if (failed(convertClassDeclaration(*baseClassDecl)))
         return failure();
-      }
     }
   }
 


### PR DESCRIPTION
This patch fixes compiler crashes on method conversion if the signature is invalid and enforces that base classes are elaborated before child classes are, avoiding another class of crashes