### PR TITLE
[FIRRTL] InferDomains: add domain-mode=strip

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -71,6 +71,8 @@ enum class CompanionMode {
 
 /// The mode for the InferDomains pass.
 enum class InferDomainsMode {
+  /// Erase domains from the input circuit.
+  Strip,
   /// Check domains without inference.
   Check,
   /// Check domains with inference for private modules.

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -921,6 +921,8 @@ def InferDomains : Pass<"firrtl-infer-domains", "firrtl::CircuitOp"> {
                         "InferDomainsMode::Infer", "infer, check, infer-all.",
                         [{
                  llvm::cl::values(
+                   clEnumValN(InferDomainsMode::Strip, "strip",
+                    "Erase domains from the circuit without checking"),
                    clEnumValN(InferDomainsMode::Infer, "infer",
                      "Check domains with inference for private modules"),
                    clEnumValN(InferDomainsMode::Check, "check",

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -38,6 +38,8 @@ public:
   enum class RandomKind { None, Mem, Reg, All };
 
   enum class DomainMode {
+    /// Erase domains from the input circuit.
+    Strip,
     /// Disable domain checking.
     Disable,
     /// Check domains without inference.
@@ -53,6 +55,8 @@ public:
   static constexpr std::optional<firrtl::InferDomainsMode>
   toInferDomainsPassMode(DomainMode mode) {
     switch (mode) {
+    case DomainMode::Strip:
+      return firrtl::InferDomainsMode::Strip;
     case DomainMode::Disable:
       return std::nullopt;
     case DomainMode::Check:

--- a/test/Dialect/FIRRTL/infer-domains-strip-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-strip-errors.mlir
@@ -1,0 +1,8 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-domains{mode=strip}))' --verify-diagnostics %s
+
+firrtl.circuit "StripDomainErrors" {
+  firrtl.module @StripDomainErrors() {
+    // expected-error @below {{'builtin.unrealized_conversion_cast' op cannot be stripped}}
+    %0 = builtin.unrealized_conversion_cast to !firrtl.domain
+  }
+}

--- a/test/Dialect/FIRRTL/infer-domains-strip.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-strip.mlir
@@ -1,0 +1,56 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-domains{mode=strip}))' %s | FileCheck %s
+
+firrtl.circuit "StripDomains" {
+  firrtl.module @StripDomains() {}
+
+  // CHECK-NOT: firrtl.domain @ClockDomain
+  firrtl.domain @ClockDomain
+
+  // CHECK-LABEL: firrtl.extmodule @Extmodule1(out x: !firrtl.uint<1>)
+  firrtl.extmodule @Extmodule1(out D: !firrtl.domain of @ClockDomain, out x: !firrtl.uint<1> domains [D])
+
+  // CHECK-LABEL: firrtl.extmodule @Extmodule2(out y: !firrtl.uint<1>)
+  firrtl.extmodule @Extmodule2(out y: !firrtl.uint<1> domains [D], out D: !firrtl.domain of @ClockDomain)
+
+  // CHECK-LABEL: firrtl.module @ExtmoduleUser(out %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>) {
+  // CHECK-NEXT:    %inst1_x = firrtl.instance inst1 @Extmodule1(out x: !firrtl.uint<1>)
+  // CHECK-NEXT:    %inst2_y = firrtl.instance inst2 @Extmodule2(out y: !firrtl.uint<1>)
+  // CHECK-NEXT:    firrtl.matchingconnect %x, %inst1_x : !firrtl.uint<1>
+  // CHECK-NEXT:    firrtl.matchingconnect %y, %inst2_y : !firrtl.uint<1>
+  // CHECK-NEXT:  }
+  firrtl.module @ExtmoduleUser(out %x : !firrtl.uint<1>, out %y : !firrtl.uint<1>) {
+    %inst1_D, %inst1_x = firrtl.instance inst1 @Extmodule1(out D: !firrtl.domain of @ClockDomain, out x: !firrtl.uint<1> domains [D])
+    %inst2_y, %inst2_D = firrtl.instance inst2 @Extmodule2(out y: !firrtl.uint<1> domains [D], out D: !firrtl.domain of @ClockDomain)
+    firrtl.matchingconnect %x, %inst1_x : !firrtl.uint<1>
+    firrtl.matchingconnect %y, %inst2_y : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: firrtl.module @StripWire() {
+  // CHECK-NEXT:  }
+  firrtl.module @StripWire(in %DI: !firrtl.domain of @ClockDomain, out %DO: !firrtl.domain of @ClockDomain) {
+    %wire = firrtl.wire : !firrtl.domain
+    firrtl.domain.define %wire, %DI
+    firrtl.domain.define %DO, %wire
+  }
+
+  // CHECK-LABEL: firrtl.module @StripUnsafeDomainCast(
+  // CHECK-SAME:    in  %i:  !firrtl.uint<1>,
+  // CHECK-SAME:    out %o:  !firrtl.uint<1>) {
+  // CHECK-NEXT:    firrtl.matchingconnect %o, %i : !firrtl.uint<1>
+  // CHECK-NEXT:  }
+  firrtl.module @StripUnsafeDomainCast(
+      in  %D1: !firrtl.domain of @ClockDomain,
+      in  %D2: !firrtl.domain of @ClockDomain,
+      in  %i:  !firrtl.uint<1> domains [%D1],
+      out %o:  !firrtl.uint<1> domains [%D2]) {
+    %0 = firrtl.unsafe_domain_cast %i domains %D2 : !firrtl.uint<1>
+    firrtl.matchingconnect %o, %0 : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: firrtl.module @StripAnonDomain() {
+  // CHECK-NEXT:  }
+  firrtl.module @StripAnonDomain(out %D: !firrtl.domain of @ClockDomain) {
+    %0 = firrtl.domain.anon : !firrtl.domain of @ClockDomain
+    firrtl.domain.define %D, %0
+  }
+}


### PR DESCRIPTION
Add a mode to firtool, and to the infer-domains pass, which will strip domains from the IR. When the mode is "strip", we do not perform any domain checking, so domain crossings errors will be permitted. This PR keeps the "disable" mode in firtool, which just disables the infer-domains pass completely. We can remove this flag in a later PR.