### PR TITLE
[LTL] Allow PastOp to take integer inputs

### DIFF
--- a/include/circt/Dialect/LTL/LTLOps.h
+++ b/include/circt/Dialect/LTL/LTLOps.h
@@ -11,6 +11,7 @@
 
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 
+#include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/LTL/LTLDialect.h"
 #include "circt/Dialect/LTL/LTLTypes.h"
 

--- a/include/circt/Dialect/LTL/LTLOps.td
+++ b/include/circt/Dialect/LTL/LTLOps.td
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_LTL_LTLOPS_TD
 #define CIRCT_DIALECT_LTL_LTLOPS_TD
 
+include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/LTL/LTLDialect.td"
 include "circt/Dialect/LTL/LTLTypes.td"
 include "mlir/IR/EnumAttr.td"
@@ -104,11 +105,11 @@ def DelayOp : LTLOp<"delay", [Pure]> {
   }];
 }
 
-def PastOp : LTLOp<"past", [Pure]> {
+def PastOp : LTLOp<"past", [SameOperandsAndResultType, Pure]> {
   let arguments = (ins
-    I1:$input,
+    HWIntegerType:$input,
     I64Attr:$delay);
-  let results = (outs I1:$result);
+  let results = (outs HWIntegerType:$result);
   let assemblyFormat = [{
     $input `,` $delay attr-dict `:` type($input)
   }];

--- a/test/Dialect/LTL/basic.mlir
+++ b/test/Dialect/LTL/basic.mlir
@@ -1,6 +1,7 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
 %true = hw.constant true
+%c0_i8 = hw.constant 0 : i8
 
 //===----------------------------------------------------------------------===//
 // Types
@@ -96,6 +97,11 @@ ltl.until %p, %p : !ltl.property, !ltl.property
 ltl.eventually %true : i1
 ltl.eventually %s : !ltl.sequence
 ltl.eventually %p : !ltl.property
+
+// CHECK: ltl.past {{%.+}}, 1 : i1
+// CHECK: ltl.past {{%.+}}, 5 : i8
+ltl.past %true, 1 : i1
+ltl.past %c0_i8, 5 : i8
 
 //===----------------------------------------------------------------------===//
 // Clocking


### PR DESCRIPTION
In line with the SV spec, it seems like restricting this to i1 is overly strict