### PR TITLE
[ImportVerilog] Add queue push back method

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1741,6 +1741,68 @@ def DynExtractRefOp : MooreOp<"dyn_extract_ref", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Queue Manipulation
+//===----------------------------------------------------------------------===//
+
+def QueuePushBackOp : MooreOp<"push_back", [
+    TypesMatchWith<"queue and element types must match",
+    "queue", "element", "cast<QueueType>($_self).getElementType()">]> {
+  let summary = "Push an element to the back of a queue";
+  let description = [{
+    See IEEE 1800-2023 § 7.10.2.7 "Push_back()"
+  }];
+  let arguments = (ins QueueType:$queue, UnpackedType:$element);
+  let results = (outs VoidType:$out);
+  let assemblyFormat = [{
+    $element `into` $queue attr-dict `:` type($queue)
+  }];
+}
+
+def QueuePushFrontOp : MooreOp<"push_front", [
+    TypesMatchWith<"queue and element types must match",
+    "queue", "element", "cast<QueueType>($_self).getElementType()">]> {
+  let summary = "Push an element to the front of a queue";
+  let description = [{
+    See IEEE 1800-2023 § 7.10.2.6 "Push_front()"
+  }];
+  let arguments = (ins QueueType:$queue, UnpackedType:$element);
+  let results = (outs VoidType:$out);
+  let assemblyFormat = [{
+    $element `into` $queue attr-dict `:` type($queue)
+  }];
+}
+
+
+def QueuePopBackOp : MooreOp<"pop_back", [
+    TypesMatchWith<"queue and element types must match",
+    "queue", "result", "cast<QueueType>($_self).getElementType()">]> {
+  let summary = "Return and remove an element from the back of a queue";
+  let description = [{
+    See IEEE 1800-2023 § 7.10.2.4 "Pop_back()"
+  }];
+  let arguments = (ins QueueType:$queue);
+  let results = (outs UnpackedType:$result);
+  let assemblyFormat = [{
+    `from` $queue attr-dict `:` type($queue)
+  }];
+}
+
+def QueuePopFrontOp : MooreOp<"pop_front", [
+    TypesMatchWith<"queue and element types must match",
+    "queue", "result", "cast<QueueType>($_self).getElementType()">]> {
+  let summary = "Return and remove an element from the front of a queue";
+  let description = [{
+    See IEEE 1800-2023 § 7.10.2.5 "Pop_front()"
+  }];
+  let arguments = (ins QueueType:$queue);
+  let results = (outs UnpackedType:$result);
+  let assemblyFormat = [{
+    `from` $queue attr-dict `:` type($queue)
+  }];
+}
+
+
+//===----------------------------------------------------------------------===//
 // Array Manipulation
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2755,6 +2755,18 @@ Context::convertSystemCallArity1(const slang::ast::SystemSubroutine &subroutine,
                 [&]() -> Value {
                   return moore::StringToLowerOp::create(builder, loc, value);
                 })
+          .Case("pop_back",
+                [&]() -> Value {
+                  if (isa<moore::QueueType>(value.getType()))
+                    return moore::QueuePopBackOp::create(builder, loc, value);
+                  return {};
+                })
+          .Case("pop_front",
+                [&]() -> Value {
+                  if (isa<moore::QueueType>(value.getType()))
+                    return moore::QueuePopFrontOp::create(builder, loc, value);
+                  return {};
+                })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();
 }
@@ -2768,6 +2780,20 @@ Context::convertSystemCallArity2(const slang::ast::SystemSubroutine &subroutine,
                 [&]() -> Value {
                   return moore::StringGetCOp::create(builder, loc, value1,
                                                      value2);
+                })
+          .Case("push_back",
+                [&]() -> Value {
+                  if (isa<moore::QueueType>(value1.getType()))
+                    return moore::QueuePushBackOp::create(builder, loc, value1,
+                                                          value2);
+                  return {};
+                })
+          .Case("push_front",
+                [&]() -> Value {
+                  if (isa<moore::QueueType>(value1.getType()))
+                    return moore::QueuePushFrontOp::create(builder, loc, value1,
+                                                           value2);
+                  return {};
                 })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3897,3 +3897,33 @@ module testHandleComparison #()();
    assign d = (b == null) | (b != null) | (b === null) | (b !== null);
 
 endmodule
+
+// CHECK-LABEL: moore.module @QueueManipulationTest() {
+// CHECK:    [[Q:%.+]] = moore.variable : <queue<i32, 0>>
+// CHECK:    [[QSIZE:%.+]] = moore.variable : <i32>
+// CHECK:    moore.procedure initial {
+// CHECK:      [[QR:%.+]] = moore.read [[Q]] : <queue<i32, 0>>
+// CHECK:      [[QSIZER:%.+]] = moore.read [[QSIZE]] : <i32>
+// CHECK:      [[PB:%.+]] = moore.push_back [[QSIZER]] into [[QR]] : <i32, 0>
+// CHECK:      [[QR:%.+]] = moore.read [[Q]] : <queue<i32, 0>>
+// CHECK:      [[QSIZER:%.+]] = moore.read [[QSIZE]] : <i32>
+// CHECK:      [[PF:%.+]] = moore.push_front [[QSIZER]] into [[QR]] : <i32, 0>
+// CHECK:      [[QR:%.+]] = moore.read [[Q]] : <queue<i32, 0>>
+// CHECK:      [[POPB:%.+]] = moore.pop_back from [[QR]] : <i32, 0>
+// CHECK:      [[QR:%.+]] = moore.read [[Q]] : <queue<i32, 0>>
+// CHECK:      [[POPF:%.+]] = moore.pop_front from [[QR]] : <i32, 0>
+// CHECK:      moore.return
+// CHECK:    }
+// CHECK:    moore.output
+// CHECK:  }
+
+module QueueManipulationTest;
+    int q[$];
+    int qsize;
+    initial begin
+       q.push_back(qsize);
+       q.push_front(qsize);
+       q.pop_back();
+       q.pop_front();
+    end
+endmodule


### PR DESCRIPTION
Introduce Moore dialect operations for queue manipulation:
- moore.push_back / moore.push_front
- moore.pop_back / moore.pop_front

Lower the corresponding SystemVerilog queue methods in ImportVerilog and enforce element type matching via ODS constraints.

Add FileCheck coverage for queue push/pop lowering.