### PR TITLE
[ImportVerilog] Add ops for extracting queue elements

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1760,6 +1760,33 @@ def DynExtractRefOp : MooreOp<"dyn_extract_ref", [Pure]> {
 // Queue Manipulation
 //===----------------------------------------------------------------------===//
 
+def DynQueueExtractOp : MooreOp<"dyn_queue_extract", [Pure,
+    TypesMatchWith<"input and result types must match",
+    "input", "result", "cast<QueueType>($_self).getElementType()">]> {
+  let description = [{
+    It's similar to extract, but it's used to select from a value
+    with a dynamic lower index.
+  }];
+  let arguments = (ins QueueType:$input, UnpackedType:$lowerIdx);
+  let results = (outs UnpackedType:$result);
+  let assemblyFormat = [{
+    $input `from` $lowerIdx attr-dict `:`
+    type($input) `,` type($lowerIdx) `->` type($result)
+  }];
+}
+
+def DynQueueExtractRefOp : MooreOp<"dyn_queue_extract_ref", [Pure]> {
+  let description = [{
+  The copy of dyn_extract that explicitly works on the ref type.
+  }];
+  let arguments = (ins RefType:$input, UnpackedType:$lowerIdx);
+  let results = (outs RefType:$result);
+  let assemblyFormat = [{
+    $input `from` $lowerIdx attr-dict `:`
+    type($input) `,` type($lowerIdx) `->` type($result)
+  }];
+}
+
 def QueuePushBackOp : MooreOp<"push_back", [
     TypesMatchWith<"queue and element types must match",
     "queue", "element", "cast<QueueType>($_self).getElementType()">]> {

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3927,3 +3927,29 @@ module QueueManipulationTest;
        q.pop_front();
     end
 endmodule
+
+// CHECK-LABEL: moore.module @QueueExtractTest() {
+// CHECK:           [[Q:%.+]] = moore.variable : <queue<l32, 0>>
+// CHECK:           [[QE:%.+]] = moore.variable : <l32>
+// CHECK:           moore.procedure initial {
+// CHECK:             [[QR:%.+]] = moore.read [[Q]] : <queue<l32, 0>>
+// CHECK:             [[C0A:%.+]] = moore.constant 0 : i32
+// CHECK:             [[E0:%.+]] = moore.dyn_queue_extract [[QR]] from [[C0A]] : <l32, 0>, i32 -> l32
+// CHECK:             moore.blocking_assign [[QE]], [[E0]] : l32
+// CHECK:             [[C0B:%.+]] = moore.constant 0 : i32
+// CHECK:             [[R0:%.+]] = moore.dyn_queue_extract_ref [[Q]] from [[C0B]] : <queue<l32, 0>>, i32 -> <l32>
+// CHECK:             [[QER:%.+]] = moore.read [[QE]] : <l32>
+// CHECK:             moore.blocking_assign [[R0]], [[QER]] : l32
+// CHECK:             moore.return
+// CHECK:           }
+// CHECK:           moore.output
+// CHECK:         }
+
+module QueueExtractTest;
+    logic [31:0] q[$];
+    logic [31:0]  qe;
+    initial begin
+        qe = q[0];
+        q[0] = qe;
+    end
+endmodule


### PR DESCRIPTION
Introduce moore.dyn_queue_extract and moore.dyn_queue_extract_ref to model dynamic element selection from queues.

Update ImportVerilog lowering to route element selects on queue-typed values through the new queue extract ops, while preserving existing extract behavior for arrays and packed types.

The main reason for adding dedicated ref extraction operations for queues rather than reusing existing versions is that references to queue members have some very subtle semantics (compare `outdated references` in IEEE 1800-2023 § 13.5.2)

Add FileCheck coverage for queue element reads and writes.