### PR TITLE
[ImportVerilog] Use type predicates for handle comparisons

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1064,16 +1064,13 @@ struct RvalueExprVisitor : public ExprVisitor {
     if (rhsFloatType || lhsFloatType)
       return visitRealBOp(expr);
 
-    // Check whether we are comparing against a Class Handle
-    const auto *rhsClassType =
-        expr.right().type->as_if<slang::ast::ClassType>();
-    const auto *lhsClassType = expr.left().type->as_if<slang::ast::ClassType>();
-    const auto *rhsChandleType =
-        expr.right().type->as_if<slang::ast::CHandleType>();
-    const auto *lhsChandleType =
-        expr.left().type->as_if<slang::ast::CHandleType>();
+    // Check whether we are comparing against a Class Handle or CHandle
+    const auto rhsIsClass = expr.right().type->isClass();
+    const auto lhsIsClass = expr.left().type->isClass();
+    const auto rhsIsChandle = expr.right().type->isCHandle();
+    const auto lhsIsChandle = expr.left().type->isCHandle();
     // If either arg is class handle-typed, treat as class handle BOp.
-    if (rhsClassType || lhsClassType || rhsChandleType || lhsChandleType)
+    if (rhsIsClass || lhsIsClass || rhsIsChandle || lhsIsChandle)
       return visitHandleBOp(expr);
 
     auto lhs = context.convertRvalueExpression(expr.left());


### PR DESCRIPTION
Detect class/chandle equality operators via slang type predicates (isClass / isCHandle) instead of as_if casts, ensuring handle comparisons are lowered through the class-handle binary-op path.

In parts of the Slang AST comparison operators can refer to non-monomorphized classes, so an `as_if<ClassHandleType>()` cast breaks, whereas `isClass` succeeds.

Add a regression test covering non-monomorphized/forward-declared class handle comparisons (static method + static instance pattern).