### PR TITLE
[FIRRTL][OM] Use signed integer attributes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1271,6 +1271,7 @@ def FIntegerConstantOp : FIRRTLOp<"integer", [Pure, ConstantLike]> {
   let results = (outs FIntegerType:$result);
   let hasFolder = 1;
   let hasCustomAssemblyFormat = true;
+  let hasVerifier = true;
 }
 
 def UnresolvedPathOp : FIRRTLOp<"unresolved_path", [Pure]> {

--- a/include/circt/Dialect/OM/OMAttributes.td
+++ b/include/circt/Dialect/OM/OMAttributes.td
@@ -110,6 +110,8 @@ def OMIntegerAttr : AttrDef<OMDialect, "Integer", [TypedAttrInterface]> {
   let extraClassDeclaration = [{
     mlir::Type getType();
   }];
+
+  let genVerifyDecl = true;
 }
 
 #endif // CIRCT_DIALECT_OM_OMATTRIBUTES_TD

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -36,13 +36,13 @@ with Context() as ctx, Location.unknown():
     om.class @Test(%param: !om.integer) -> (field: !om.integer, child: !om.class.type<@Child>, reference: !om.ref, list: !om.list<!om.string>, nest: !om.class.type<@Nest>, true: i1, false: i1) {
       %sym = om.constant #om.ref<<@Root::@x>> : !om.ref
 
-      %c_14 = om.constant #om.integer<14> : !om.integer
+      %c_14 = om.constant #om.integer<14 : si32> : !om.integer
       %0 = om.object @Child(%c_14) : (!om.integer) -> !om.class.type<@Child>
 
 
       %list = om.constant #om.list<!om.string, ["X" : !om.string, "Y" : !om.string]> : !om.list<!om.string>
 
-      %c_15 = om.constant #om.integer<15> : !om.integer
+      %c_15 = om.constant #om.integer<15 : si32> : !om.integer
       %1 = om.object @Child(%c_15) : (!om.integer) -> !om.class.type<@Child>
       %list_child = om.list_create %0, %1: !om.class.type<@Child>
       %2 = om.object @Nest(%list_child) : (!om.list<!om.class.type<@Child>>) -> !om.class.type<@Nest>
@@ -232,17 +232,6 @@ except TypeError as e:
 with Context() as ctx:
   circt.register_dialects(ctx)
 
-  # Signless
-  int_attr1 = om.OMIntegerAttr.get(
-      IntegerAttr.get(IntegerType.get_signless(64), 42))
-  # CHECK: 42
-  print(str(int_attr1))
-
-  int_attr2 = om.OMIntegerAttr.get(
-      IntegerAttr.get(IntegerType.get_signless(64), -42))
-  # CHECK: 18446744073709551574
-  print(str(int_attr2))
-
   # Signed
   int_attr3 = om.OMIntegerAttr.get(
       IntegerAttr.get(IntegerType.get_signed(64), 42))
@@ -253,17 +242,6 @@ with Context() as ctx:
       IntegerAttr.get(IntegerType.get_signed(64), -42))
   # CHECK: -42
   print(str(int_attr4))
-
-  # Unsigned
-  int_attr5 = om.OMIntegerAttr.get(
-      IntegerAttr.get(IntegerType.get_unsigned(64), 42))
-  # CHECK: 42
-  print(str(int_attr5))
-
-  int_attr6 = om.OMIntegerAttr.get(
-      IntegerAttr.get(IntegerType.get_unsigned(64), -42))
-  # CHECK: 18446744073709551574
-  print(str(int_attr6))
 
   # Test AnyType
   any_type = Type.parse("!om.any")

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -293,7 +293,7 @@ static PythonPrimitive omPrimitiveToPythonValue(MlirAttribute attr) {
 static MlirAttribute omPythonValueToPrimitive(PythonPrimitive value,
                                               MlirContext ctx) {
   if (auto *intValue = std::get_if<nb::int_>(&value)) {
-    auto intType = mlirIntegerTypeGet(ctx, 64);
+    auto intType = mlirIntegerTypeSignedGet(ctx, 64);
     auto intAttr = mlirIntegerAttrGet(intType, nb::cast<int64_t>(*intValue));
     return omIntegerAttrGet(intAttr);
   }

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -41,7 +41,7 @@ def wrap_mlir_object(value):
 
 def om_var_to_attribute(obj, none_on_fail: bool = False) -> ir.Attrbute:
   if isinstance(obj, int):
-    return OMIntegerAttr.get(IntegerAttr.get(IntegerType.get_signless(64), obj))
+    return OMIntegerAttr.get(IntegerAttr.get(IntegerType.get_signed(64), obj))
   return var_to_attribute(obj, none_on_fail)
 
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -962,9 +962,10 @@ OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
   if (auto rhsCst = getConstant(adaptor.getRhs())) {
     if (auto lhsCst = getConstant(adaptor.getLhs())) {
 
-      return IntegerAttr::get(
-          IntegerType::get(getContext(), lhsCst->getBitWidth()),
-          lhsCst->ashr(*rhsCst));
+      return IntegerAttr::get(IntegerType::get(getContext(),
+                                               lhsCst->getBitWidth(),
+                                               IntegerType::Signed),
+                              lhsCst->ashr(*rhsCst));
     }
 
     if (rhsCst->isZero())
@@ -979,9 +980,10 @@ OpFoldResult IntegerShlOp::fold(FoldAdaptor adaptor) {
     // Constant folding
     if (auto lhsCst = getConstant(adaptor.getLhs()))
 
-      return IntegerAttr::get(
-          IntegerType::get(getContext(), lhsCst->getBitWidth()),
-          lhsCst->shl(*rhsCst));
+      return IntegerAttr::get(IntegerType::get(getContext(),
+                                               lhsCst->getBitWidth(),
+                                               IntegerType::Signed),
+                              lhsCst->shl(*rhsCst));
 
     // integer.shl(x, 0) -> x
     if (rhsCst->isZero())

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4807,6 +4807,13 @@ Attribute AggregateConstantOp::getAttributeFromFieldID(uint64_t fieldID) {
   return value;
 }
 
+LogicalResult FIntegerConstantOp::verify() {
+  auto i = getValueAttr();
+  if (!i.getType().isSignedInteger())
+    return emitOpError("value must be signed");
+  return success();
+}
+
 void FIntegerConstantOp::print(OpAsmPrinter &p) {
   p << " ";
   p.printAttributeWithoutType(getValueAttr());

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -717,7 +717,7 @@ struct Constantifier : public Reduction {
 
     // Handle property integer types.
     if (isa<FIntegerType>(type)) {
-      auto attr = builder.getIntegerAttr(builder.getI64Type(), 0);
+      auto attr = builder.getIntegerAttr(builder.getIntegerType(64, true), 0);
       auto newOp = FIntegerConstantOp::create(builder, op->getLoc(), attr);
       op->replaceAllUsesWith(newOp);
       reduce::pruneUnusedOps(op, *this);

--- a/lib/Dialect/OM/OMAttributes.cpp
+++ b/lib/Dialect/OM/OMAttributes.cpp
@@ -105,6 +105,15 @@ Type circt::om::IntegerAttr::getType() {
   return OMIntegerType::get(getContext());
 }
 
+LogicalResult circt::om::IntegerAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+    mlir::IntegerAttr value) {
+  if (value.getType().isUnsignedInteger())
+    return emitError() << "integers must be signed";
+
+  return success();
+}
+
 void circt::om::OMDialect::registerAttributes() {
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/test/CAPI/om.c
+++ b/test/CAPI/om.c
@@ -131,8 +131,8 @@ void testEvaluator(MlirContext ctx) {
 
   // Test instantiation success.
 
-  OMEvaluatorValue actualParam = omEvaluatorValueFromPrimitive(
-      omIntegerAttrGet(mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 8), 42)));
+  OMEvaluatorValue actualParam = omEvaluatorValueFromPrimitive(omIntegerAttrGet(
+      mlirIntegerAttrGet(mlirIntegerTypeSignedGet(ctx, 8), 42)));
 
   OMEvaluatorValue object =
       omEvaluatorInstantiate(evaluator, className, 1, &actualParam);
@@ -176,7 +176,7 @@ void testEvaluator(MlirContext ctx) {
 
   MlirAttribute fieldValue = omEvaluatorValueGetPrimitive(field);
 
-  // CHECK: #om.integer<42 : i8> : !om.integer
+  // CHECK: #om.integer<42 : si8> : !om.integer
   mlirAttributeDump(fieldValue);
 
   // Test get field success for child object.

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -161,21 +161,21 @@ circuit TestHarness:
 ; MLIR_OUT-DAG: om.list_create
 ; MLIR_OUT-DAG: [[OBJ1:%.+]] = om.object @MemorySchema
 ; MLIR_OUT-DAG: om.constant "foo_m_ext" : !om.string
-; MLIR_OUT-DAG: om.constant #om.integer<1 : ui64> : !om.integer
-; MLIR_OUT-DAG: om.constant #om.integer<8 : ui32> : !om.integer
-; MLIR_OUT-DAG: om.constant #om.integer<1 : ui32> : !om.integer
-; MLIR_OUT-DAG: om.constant #om.integer<0 : ui32> : !om.integer
+; MLIR_OUT-DAG: om.constant #om.integer<1 : si64> : !om.integer
+; MLIR_OUT-DAG: om.constant #om.integer<8 : si32> : !om.integer
+; MLIR_OUT-DAG: om.constant #om.integer<1 : si32> : !om.integer
+; MLIR_OUT-DAG: om.constant #om.integer<0 : si32> : !om.integer
 ; MLIR_OUT-DAG: om.path_create instance %basepath @memNLA_0
 ; MLIR_OUT-DAG: om.list_create
 ; MLIR_OUT-DAG: [[OBJ2:%.+]] = om.object @MemorySchema
 ; MLIR_OUT-DAG: om.constant "bar_m_ext" : !om.string
-; MLIR_OUT-DAG: om.constant #om.integer<2 : ui64> : !om.integer
+; MLIR_OUT-DAG: om.constant #om.integer<2 : si64> : !om.integer
 ; MLIR_OUT-DAG: om.path_create instance %basepath @memNLA_1
 ; MLIR_OUT-DAG: om.path_create instance %basepath @memNLA_2
 ; MLIR_OUT-DAG: om.list_create
 ; MLIR_OUT-DAG: [[OBJ3:%.+]] = om.object @MemorySchema
 ; MLIR_OUT-DAG: om.constant "baz_m_ext" : !om.string
-; MLIR_OUT-DAG: om.constant #om.integer<3 : ui64> : !om.integer
+; MLIR_OUT-DAG: om.constant #om.integer<3 : si64> : !om.integer
 ; MLIR_OUT:     om.class.fields [[OBJ1]], [[OBJ2]], [[OBJ3]] : !om.class.type<@MemorySchema>, !om.class.type<@MemorySchema>, !om.class.type<@MemorySchema>
 
 ; SITEST_NODUT:     FILE "design.sitest.json"


### PR DESCRIPTION
- In the FIRRTL IntegerConstantOp, use a verifier to ensure that the underlying value (encoded as an attribute) has a signed type.
- Similarly, in the OM IntegerAttr, use an attribute verifier to ensure the underlying value is signed, too.
- Fix the OM shl/shr folders so they return OM IntegerAttrs with signed integers, and
- Fix the python API so that, when converting from a python integer to an OM integer attribute, the OM IntegerAttr is signed.