### PR TITLE
[firtool] Add --num-threads/-j option to control parallel compilation

### DIFF
--- a/test/firtool/commandline.mlir
+++ b/test/firtool/commandline.mlir
@@ -4,4 +4,6 @@
 // CHECK: General {{[Oo]}}ptions
 // CHECK: Generic Options
 // CHECK: firtool Options
-// CHECK: --lowering-options=
+// CHECK-DAG: -j{{.*}}Alias for --num-threads
+// CHECK-DAG: --lowering-options=
+// CHECK-DAG: --num-threads=<N>{{.*}}Number of threads to use for parallel compilation


### PR DESCRIPTION
Add command line option to limit thread count during compilation. Default (0) uses all hardware threads, N limits to N threads. Controls both LLVM parallel utilities and MLIR Context threading.

The existing --mlir-disable-threading flag continues to work and takes precedence as a global override, disabling all MLIR threading regardless of --num-threads value.