### PR TITLE
[ArcRuntime][VCDTrace] Fix final time step on empty trace buffer

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/TraceEncoder.h
+++ b/include/circt/Dialect/Arc/Runtime/TraceEncoder.h
@@ -112,6 +112,9 @@ public:
   /// Stop tracing
   void finish(const ArcState *state);
 
+  /// Return the value of the internal step counter
+  int64_t getTimeStep() const { return timeStep; }
+
   /// Number of trace buffers in rotation
   const unsigned numBuffers;
 

--- a/integration_test/arcilator/JIT/runtime-vcd-nochange.mlir
+++ b/integration_test/arcilator/JIT/runtime-vcd-nochange.mlir
@@ -1,0 +1,32 @@
+// RUN: arcilator %s --run --jit-entry=main --jit-vcd-file=%t && cat %t | FileCheck %s --match-full-lines --check-prefix VCD
+
+hw.module @dut(out dout : i136) {
+  %cst = hw.constant 0 : i136
+  hw.output %cst : i136
+}
+
+func.func @main() {
+  arc.sim.instantiate @dut as %model {
+    arc.sim.step %model : !arc.sim.instance<@dut>
+    arc.sim.step %model : !arc.sim.instance<@dut>
+    arc.sim.step %model : !arc.sim.instance<@dut>
+    arc.sim.step %model : !arc.sim.instance<@dut>
+    arc.sim.step %model : !arc.sim.instance<@dut>
+    arc.sim.step %model : !arc.sim.instance<@dut>
+    arc.sim.step %model : !arc.sim.instance<@dut>
+    arc.sim.step %model : !arc.sim.instance<@dut>
+  }
+  return
+}
+
+// VCD-LABEL: $version
+// VCD-NEXT:      Some cryptic ArcRuntime magic
+// VCD-NEXT:  $end
+// VCD-NEXT:  $timescale 1ns $end
+// VCD-NEXT:  $scope module dut $end
+// VCD-NEXT:   $var wire 136 ! dout $end
+// VCD-NEXT:  $upscope $end
+// VCD-NEXT:  $enddefinitions $end
+// VCD-NEXT:  #0
+// VCD-NEXT:  b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 !
+// VCD-NEXT:  #9

--- a/lib/Dialect/Arc/Runtime/VCDTraceEncoder.cpp
+++ b/lib/Dialect/Arc/Runtime/VCDTraceEncoder.cpp
@@ -287,17 +287,16 @@ void VCDTraceEncoder::encode(TraceBuffer &work) {
 
 void VCDTraceEncoder::windDownWorker() {
   assert(workerOutBuffer.empty());
-  // Terminate and flush the file
-  workerStep++;
-  writeTimestepToBuffer(workerStep, workerOutBuffer);
-  outFile.write(workerOutBuffer.data(), workerOutBuffer.size());
   outFile.flush();
-  workerOutBuffer.clear();
 }
 
 void VCDTraceEncoder::finalize(const ArcState *state) {
-  if (outFile.is_open())
+  if (outFile.is_open()) {
+    // Finalize the trace file
+    assert(workerStep <= getTimeStep());
+    outFile << '#' << getTimeStep() + 1 << '\n';
     outFile.close();
+  }
 }
 
 } // namespace circt::arc::runtime::impl


### PR DESCRIPTION
This fixes a bug in the ArcRuntime's VCD encoder which would cause an incorrect final time to be emitted to the VCD file when the simulation ends with an empty trace buffer.

The encoder's time step variable is only updated when data is received. Without any data this will never progress and incorrectly write `0` as final step during the thread's wind down routine. This commit moves the final time step emission to the simulation thread, after the enocder thread has finished, and uses the correct final step value.