### PR TITLE
[ImportVerilog] Split class lowering into property + method passes

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -58,6 +58,7 @@ struct FunctionLowering {
 // Class lowering information.
 struct ClassLowering {
   circt::moore::ClassDeclOp op;
+  bool methodsFinalized = false;
 };
 
 /// Information about a loops continuation and exit blocks relevant while
@@ -120,8 +121,9 @@ struct Context {
   declareFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult convertFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult finalizeFunctionBodyCaptures(FunctionLowering &lowering);
-  LogicalResult convertClassDeclaration(const slang::ast::ClassType &classdecl);
   ClassLowering *declareClass(const slang::ast::ClassType &cls);
+  LogicalResult buildClassProperties(const slang::ast::ClassType &classdecl);
+  LogicalResult materializeClassMethods(const slang::ast::ClassType &classdecl);
   LogicalResult convertGlobalVariable(const slang::ast::VariableSymbol &var);
 
   /// Checks whether one class (actualTy) is derived from another class

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -167,7 +167,7 @@ struct TypeVisitor {
   }
 
   Type visit(const slang::ast::ClassType &type) {
-    if (failed(context.convertClassDeclaration(type)))
+    if (failed(context.buildClassProperties(type)))
       return {};
     auto *lowering = context.declareClass(type);
     if (!lowering) {

--- a/test/Conversion/ImportVerilog/classes.sv
+++ b/test/Conversion/ImportVerilog/classes.sv
@@ -819,3 +819,28 @@ class methodDeclTestClass;
    endfunction
 
 endclass
+
+// CHECK:      moore.class.classdecl @c {
+// CHECK:      }
+
+// CHECK:      moore.global_variable @"c::m_inst" : !moore.class<@c>
+// CHECK:      moore.global_variable @c_handle : !moore.class<@c>
+
+// CHECK:      func.func private @get_inst() -> !moore.class<@c> {
+// CHECK:        [[V0:%.+]] = moore.variable : <class<@c>>
+// CHECK:        [[V1:%.+]] = moore.get_global_variable @c_handle : <class<@c>>
+// CHECK:        [[V2:%.+]] = moore.get_global_variable @"c::m_inst" : <class<@c>>
+// CHECK:        [[V3:%.+]] = moore.read [[V2]] : <class<@c>>
+// CHECK:        moore.blocking_assign [[V1]], [[V3]] : class<@c>
+// CHECK:        [[V4:%.+]] = moore.read [[V0]] : <class<@c>>
+// CHECK:        return [[V4]] : !moore.class<@c>
+// CHECK:      }
+
+typedef class c;
+c c_handle;
+class c;
+   static local c m_inst;
+   static function c get_inst();
+      c_handle = m_inst;
+   endfunction
+endclass


### PR DESCRIPTION
- Build class properties/body first, materialize methods later (with methodsFinalized guard)
- Add post-module worklist to materialize unused class methods
- Update Types.cpp to trigger property build for class types
- Add regression test for static local singleton + get_inst lowering