### PR TITLE
[ImportVerilog] Fix silent failure on unsupported system calls

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1603,7 +1603,7 @@ struct RvalueExprVisitor : public ExprVisitor {
 
     auto args = expr.arguments();
 
-    FailureOr<Value> result;
+    FailureOr<Value> result = Value{};
     Value value;
     Value value2;
 

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -204,3 +204,10 @@ module Foo;
   // expected-error @below {{expected integer argument for system call `$past`}}
   assert property ($past(b));
 endmodule
+
+// -----
+function Foo;
+  logic [1:0] a;
+  // expected-error @below {{unsupported system call `$fwrite`}}
+  $fwrite(32'h0, "%x", a);
+endfunction


### PR DESCRIPTION
Fix ImportVerilog failing silently when an unsupported system call with more than two arguments is encountered.

Instead of initializing the result with the default constructed failed state (indicating a conversion has been attempted and failed), use a null `Value` (indicating that no conversion has been attempted).