### PR TITLE
[LLHD] Add global signal ops; use in MooreToCore

### DIFF
--- a/include/circt/Dialect/LLHD/LLHDOps.td
+++ b/include/circt/Dialect/LLHD/LLHDOps.td
@@ -13,6 +13,7 @@ include "circt/Dialect/LLHD/LLHDDialect.td"
 include "circt/Dialect/LLHD/LLHDTypes.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/MemorySlotInterfaces.td"
@@ -287,6 +288,50 @@ def DelayOp : LLHDOp<"delay", [Pure, SameOperandsAndResultType]> {
   let results = (outs HWNonInOutType:$result);
 
   let assemblyFormat = "$input `by` $delay attr-dict `:` type($result)";
+}
+
+def GlobalSignalOp : LLHDOp<"global_signal", [
+  IsolatedFromAbove,
+  NoRegionArguments,
+  SingleBlock,
+  Symbol,
+]> {
+  let summary = "A global signal declaration";
+  let description = [{
+    Define a global signal identified by a symbol name. The corresponding
+    `llhd.get_global_signal` operation can be used to get a `!llhd.ref` to it.
+    Global signals behave just like normal signals.
+  }];
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<AnyType>:$type
+  );
+  let regions = (region MaxSizedRegion<1>:$initRegion);
+  let assemblyFormat = [{
+    $sym_name attr-dict `:` $type (`init` $initRegion^)?
+  }];
+  let hasRegionVerifier = 1;
+  let extraClassDeclaration = [{
+    Block *getInitBlock();
+  }];
+}
+
+def GetGlobalSignalOp : LLHDOp<"get_global_signal", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  Pure,
+]> {
+  let summary = "Get a reference to a global signal";
+  let arguments = (ins FlatSymbolRefAttr:$global_name);
+  let results = (outs RefType:$result);
+  let assemblyFormat = [{
+    $global_name attr-dict `:` type($result)
+  }];
+  let builders = [
+    OpBuilder<(ins "llhd::GlobalSignalOp":$global), [{
+      build($_builder, $_state,
+        RefType::get(global.getType()), global.getSymName());
+    }]>,
+  ];
 }
 
 //===----------------------------------------------------------------------===//
@@ -645,7 +690,7 @@ def HaltOp : LLHDOp<"halt", [
 }
 
 def YieldOp : LLHDOp<"yield", [
-  HasParent<"CombinationalOp">,
+  ParentOneOf<["CombinationalOp", "GlobalSignalOp"]>,
   Pure,
   ReturnLike,
   Terminator,

--- a/test/Dialect/LLHD/IR/basic.mlir
+++ b/test/Dialect/LLHD/IR/basic.mlir
@@ -213,3 +213,20 @@ func.func @TimeConversion(%arg0: i64, %arg1: !llhd.time) -> (!llhd.time, i64) {
   %1 = llhd.time_to_int %arg1
   return %0, %1 : !llhd.time, i64
 }
+
+// CHECK-LABEL: llhd.global_signal @GlobalSig1 : i42
+llhd.global_signal @GlobalSig1 : i42
+
+// CHECK: llhd.get_global_signal @GlobalSig1 : <i42>
+llhd.get_global_signal @GlobalSig1 : <i42>
+
+// CHECK-LABEL: llhd.global_signal @GlobalSig2 : i42
+llhd.global_signal @GlobalSig2 : i42 init {
+  // CHECK-NEXT: hw.constant
+  %c9001_i42 = hw.constant 9001 : i42
+  // CHECK-NEXT: llhd.yield
+  llhd.yield %c9001_i42 : i42
+}
+
+// CHECK: llhd.get_global_signal @GlobalSig2 : <i42>
+llhd.get_global_signal @GlobalSig2 : <i42>

--- a/test/Dialect/LLHD/IR/errors.mlir
+++ b/test/Dialect/LLHD/IR/errors.mlir
@@ -92,3 +92,27 @@ hw.module @HaltYieldTypes(in %arg0: i42) {
     llhd.yield %arg0, %arg0 : i42, i42
   }
 }
+
+// -----
+
+// expected-error @below {{references unknown symbol @doesNotExist}}
+llhd.get_global_signal @doesNotExist : <i42>
+
+// -----
+
+// expected-error @below {{must reference a 'llhd.global_signal', but @Foo is a 'func.func'}}
+llhd.get_global_signal @Foo : <i42>
+func.func @Foo() { return }
+
+// -----
+
+// expected-error @below {{returns a 'i42' reference, but @Foo is of type 'i9001'}}
+llhd.get_global_signal @Foo : <i42>
+llhd.global_signal @Foo : i9001
+
+// -----
+
+// expected-error @below {{must have a 'llhd.yield' terminator}}
+llhd.global_signal @Foo : i42 init {
+  llvm.unreachable
+}


### PR DESCRIPTION
Add an `llhd.global_signal` and `llhd.get_global_signal` op, similar to how the `moore.global_variable` and `moore.get_global_variable` ops work. These ops allow us to define global LLHD signals, and to resolve them to an `!llhd.ref` that can be used for probes and drives.

Extend the MooreToCore conversion to map Moore global variables to global signals in LLHD.

Currently, nothing in CIRCT knows how to deal with these global signals. But having the ops available will allow us to allocate storage for these signals in the Arc pipeline and eventually add simulation support.

Error delta on `circt-tests/results/sv-tests/errors.txt`:
```
-49 error: failed to legalize operation 'moore.global_variable'
 +2 error: failed to legalize operation 'moore.fneg'
-47 total change
```