### PR TITLE
[MooreToCore] Emit error for unsupported module port types

### DIFF
--- a/test/Conversion/MooreToCore/errors.mlir
+++ b/test/Conversion/MooreToCore/errors.mlir
@@ -8,3 +8,19 @@ func.func @invalidType() {
 }
 
 // -----
+
+// expected-error @below {{port '"queue_port"' has unsupported type '!moore.queue<i32, 10>' that cannot be converted to hardware type}}
+// expected-error @below {{failed to legalize}}
+moore.module @UnsupportedInputPortType(in %queue_port : !moore.queue<i32, 10>) {
+  moore.output
+}
+
+// -----
+
+// expected-error @below {{port '"data"' has unsupported type '!moore.queue<i32, 10>' that cannot be converted to hardware type}}
+// expected-error @below {{failed to legalize}}
+moore.module @MixedPortsWithUnsupported(in %valid : !moore.l1, in %data : !moore.queue<i32, 10>, out out : !moore.l1) {
+  moore.output %valid : !moore.l1
+}
+
+// -----


### PR DESCRIPTION
## Summary

Fix assertion failure and emit precise diagnostic when `moore.module` has unsupported port types. Previously, `typeConverter.convertType()` could return `nullptr` for unsupported types (e.g., `!moore.queue<i32, 10>`, `!moore.string`), causing either a crash or an unhelpful "failed to legalize" error.

Fixes #9572

## Root Cause

**File**: `lib/Conversion/MooreToCore/MooreToCore.cpp`  
**Function**: `getModulePortInfo()`

The function did not validate the result of `typeConverter.convertType()`:

```cpp
Type portTy = typeConverter.convertType(port.type);  // May return nullptr
ports.push_back(hw::PortInfo({{port.name, portTy, port.dir}, ...}));  // Stores invalid type
return hw::ModulePortInfo(ports);  // Constructor calls sanitizeInOut() → dyn_cast assertion
```

When conversion fails, the invalid `Type` is passed to `ModulePortInfo` constructor, triggering an assertion in `sanitizeInOut()`.

## Fix

### Code Changes

**lib/Conversion/MooreToCore/MooreToCore.cpp:231-285**

1. Changed return type to `FailureOr<hw::ModulePortInfo>`:

```cpp
-static hw::ModulePortInfo getModulePortInfo(const TypeConverter &typeConverter,
-                                            SVModuleOp op) {
+static FailureOr<hw::ModulePortInfo>
+getModulePortInfo(const TypeConverter &typeConverter, SVModuleOp op) {
```

2. Added validation after type conversion:

```cpp
Type portTy = typeConverter.convertType(port.type);
+if (!portTy) {
+  return op.emitOpError("port '")
+         << port.name << "' has unsupported type " << port.type
+         << " that cannot be converted to hardware type";
+}
```

3. Updated caller to handle failure:

```cpp
+auto portInfo = getModulePortInfo(*typeConverter, op);
+if (failed(portInfo))
+  return failure();
 auto hwModuleOp = hw::HWModuleOp::create(rewriter, op.getLoc(), op.getSymNameAttr(),
-                                           getModulePortInfo(*typeConverter, op));
+                                           *portInfo);
```

### Test Coverage

**test/Conversion/MooreToCore/errors.mlir**

Added two test cases:

```mlir
// Test 1: Single unsupported port
moore.module @UnsupportedInputPortType(in %queue_port : !moore.queue<i32, 10>) {
  moore.output
}
// expected-error: port 'queue_port' has unsupported type '!moore.queue<i32, 10>'

// Test 2: Mixed supported and unsupported ports
moore.module @MixedPortsWithUnsupported(in %valid : !moore.l1,
                                        in %data : !moore.queue<i32, 10>,
                                        out out : !moore.l1) {
  moore.output %valid : !moore.l1
}
// expected-error: port 'data' has unsupported type '!moore.queue<i32, 10>'
```

## Behavior Changes

| Aspect | Before | After |
|--------|--------|-------|
| Error message | `failed to legalize operation 'moore.module'` | `port '<name>' has unsupported type '<type>' that cannot be converted to hardware type` |
| Crash on empty type | Possible assertion failure | Graceful failure with diagnostic |
| Debugging effort | High (inspect IR manually) | Low (error identifies problem) |

Fixes #9572
