### PR TITLE
[RTG] Sanity check implicit constraints during emission

### DIFF
--- a/lib/Dialect/RTG/Transforms/EmitRTGISAAssemblyPass.cpp
+++ b/lib/Dialect/RTG/Transforms/EmitRTGISAAssemblyPass.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/Emit/EmitOps.h"
 #include "circt/Dialect/RTG/IR/RTGISAAssemblyOpInterfaces.h"
+#include "circt/Dialect/RTG/IR/RTGOpInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGOps.h"
 #include "circt/Dialect/RTG/Transforms/RTGPasses.h"
 #include "circt/Support/Path.h"
@@ -57,6 +58,12 @@ public:
         }
 
         continue;
+      }
+
+      if (auto implicitConstrOp =
+              dyn_cast<ImplicitConstraintOpInterface>(&op)) {
+        if (!implicitConstrOp.isConstraintMaterialized())
+          return op.emitError("implicit constraint not materialized");
       }
 
       auto res =

--- a/test/Dialect/RTG/Transform/emit-rtg-isa-assembly-errors.mlir
+++ b/test/Dialect/RTG/Transform/emit-rtg-isa-assembly-errors.mlir
@@ -16,3 +16,10 @@ emit.file "-" {
   // expected-error @below {{label arguments must be elaborated before emission}}
   %label = rtg.label_decl "label_name_{{0}}", %0
 }
+
+// -----
+
+emit.file "-" {
+  // expected-error @below {{implicit constraint not materialized}}
+  rtgtest.implicit_constraint_op implicit_constraint
+}


### PR DESCRIPTION
Make sure no implicit constraints were forgotten to be materialized and thus incorrect assembly emitted