### PR TITLE
[circt-reduce] Fix extmodule-instance-remover crash with strings

### DIFF
--- a/test/Dialect/FIRRTL/Reduction/extmodule-instance-remover.mlir
+++ b/test/Dialect/FIRRTL/Reduction/extmodule-instance-remover.mlir
@@ -1,0 +1,29 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include extmodule-instance-remover | FileCheck %s
+
+firrtl.circuit "StringTypes" {
+  firrtl.extmodule @Bar(out a: !firrtl.string)
+  // CHECK-LABEL: firrtl.module @StringTypes
+  firrtl.module @StringTypes() {
+    // CHECK-NOT: firrtl.instance Bar @Bar
+    %a = firrtl.instance Bar @Bar(out a: !firrtl.string)
+    %wire = firrtl.wire : !firrtl.string
+    // This should not crash when extmodule-instance-remover handles string types
+    firrtl.propassign %wire, %a : !firrtl.string
+  }
+}
+
+firrtl.circuit "RegularTypes" {
+  firrtl.extmodule @Ext(out a: !firrtl.uint<8>)
+  // CHECK-LABEL: firrtl.module @RegularTypes
+  firrtl.module @RegularTypes() {
+    // CHECK-NOT: firrtl.instance Ext @Ext
+    // CHECK: %Ext_a = firrtl.wire
+    // CHECK: %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
+    // CHECK: firrtl.connect %Ext_a, %invalid_ui8
+    %a = firrtl.instance Ext @Ext(out a: !firrtl.uint<8>)
+    %wire = firrtl.wire : !firrtl.uint<8>
+    firrtl.connect %wire, %a : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}


### PR DESCRIPTION
The extmodule-instance-remover reduction was crashing with a cast
assertion failure when trying to create InvalidValueOp for !firrtl.string
types. The issue was that InvalidValueOp only accepts FIRRTLBaseType,
but !firrtl.string is a PropertyType (which inherits from FIRRTLType
but not FIRRTLBaseType).

This commit adds a check to only create InvalidValueOp for FIRRTLBaseType
ports. Property types like !firrtl.string cannot be invalidated and are
left unconnected.

Fixes #9563.

AI-assisted-by: Augment (Claude Sonnet 4)
