### PR TITLE
[circt-reduce] Fix module-name-sanitizer crash with objects

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -1542,12 +1542,23 @@ struct ModuleNameSanitizer : OpReduction<firrtl::CircuitOp> {
       auto newName = StringAttr::get(circuitOp.getContext(), getName());
       module.setName(newName);
       for (auto *use : node->uses()) {
-        auto instanceOp = dyn_cast<firrtl::InstanceOp>(*use->getInstance());
-        instanceOp.setModuleName(newName);
-        instanceOp.setName(newName);
-        if (shouldReplacePorts)
-          instanceOp.setPortNamesAttr(
-              ArrayAttr::get(circuitOp.getContext(), newNames));
+        auto useOp = use->getInstance();
+        if (auto instanceOp = dyn_cast<firrtl::InstanceOp>(*useOp)) {
+          instanceOp.setModuleName(newName);
+          instanceOp.setName(newName);
+          if (shouldReplacePorts)
+            instanceOp.setPortNamesAttr(
+                ArrayAttr::get(circuitOp.getContext(), newNames));
+        } else if (auto objectOp = dyn_cast<firrtl::ObjectOp>(*useOp)) {
+          // ObjectOp stores the class name in its result type, so we need to
+          // create a new ClassType with the new name and set it on the result.
+          auto oldClassType = objectOp.getType();
+          auto newClassType = firrtl::ClassType::get(
+              circuitOp.getContext(), FlatSymbolRefAttr::get(newName),
+              oldClassType.getElements());
+          objectOp.getResult().setType(newClassType);
+          objectOp.setName(newName);
+        }
       }
     }
 

--- a/test/circt-reduce/name-sanitizer.mlir
+++ b/test/circt-reduce/name-sanitizer.mlir
@@ -1,6 +1,10 @@
 // UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --include=module-internal-name-sanitizer --include=module-name-sanitizer --test /usr/bin/env --test-arg true --keep-best=0 | FileCheck %s
 
+// Test that module-name-sanitizer reduction works with both InstanceOp and ObjectOp.
+// This should not crash when the ModuleNameSanitizer tries to rename modules
+// that are instantiated via firrtl.object operations.
+
 // CHECK-LABEL: firrtl.circuit "Foo"
 firrtl.circuit "A" {
   // CHECK-NEXT: firrtl.module private @Bar
@@ -63,5 +67,10 @@ firrtl.circuit "A" {
         in x: !firrtl.uint<1>,
         out y: !firrtl.uint<1>
       )
+    // CHECK: %Baz = firrtl.object @Baz()
+    %obj = firrtl.object @MyClass()
+  }
+  // CHECK: firrtl.class @Baz() {
+  firrtl.class @MyClass() {
   }
 }


### PR DESCRIPTION
The ModuleNameSanitizer reduction was crashing with a segmentation fault
when encountering firrtl.object operations. The issue was that the code
assumed all uses in the instance graph were InstanceOp, but ObjectOp is
also tracked in the instance graph.

When dyn_cast<firrtl::InstanceOp> failed for an ObjectOp, it returned
nullptr, and calling setModuleName on a null pointer caused a
segmentation fault.

This fix checks if the use is an ObjectOp and handles it differently.
For ObjectOp, we create a new ClassType with the new name and set it on
the result, since ObjectOp stores the class name in its result type
rather than having a setModuleName() method.

Fixes #9565.

AI-assisted-by: Augment (Claude Sonnet 4)
AI-assisted-by: Augment (Claude Sonnet 4.5)
