### PR TITLE
[FIRRTL][NotForCommit] Add ReadDesignConfigInt intrinsic for post-Verilog configuration

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -243,4 +243,39 @@ def ViewIntrinsicOp : FIRRTLOp<"view", []> {
   let assemblyFormat = "$name `,` (`yaml` $yamlFile^ `,`)? $augmentedType (`,` $inputs^)? attr-dict (`:` type($inputs)^)?";
 }
 
+def ReadDesignConfigIntIntrinsicOp : FIRRTLOp<"int.read_design_config_int",
+    [HasCustomSSAName, Pure]> {
+  let summary = "Read an integer design configuration value";
+  let description = [{
+    The `int.read_design_config_int` intrinsic reads an integer design
+    configuration value that will be defined in a generated configuration package
+    (DesignConfigPackage). This enables post-Verilog configuration where
+    configuration values can be set after Verilog generation.
+
+    The intrinsic takes a parameter name, default value, comment, and
+    a result type. It returns the default value, but the actual value can be
+    changed via the generated configuration package.
+
+    Example usage in FIRRTL:
+    ```
+    %value = firrtl.int.read_design_config_int "mode", 3, "Mode selection" : !firrtl.uint<8>
+    ```
+
+    This generates Verilog like:
+    ```verilog
+    localparam mode = DesignConfigPackage::mode;
+    ```
+  }];
+
+  let arguments = (ins
+    StrAttr:$paramName,
+    I64Attr:$defaultValue,
+    StrAttr:$comment
+  );
+  let results = (outs IntType:$result);
+  let assemblyFormat = [{
+    $paramName `,` $defaultValue `,` $comment attr-dict `:` type($result)
+  }];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -57,6 +57,7 @@ public:
             LTLImplicationIntrinsicOp, LTLUntilIntrinsicOp,
             LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp, Mux2CellIntrinsicOp,
             Mux4CellIntrinsicOp, HasBeenResetIntrinsicOp,
+            ReadDesignConfigIntIntrinsicOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
@@ -190,6 +191,7 @@ public:
   HANDLE(Mux4CellIntrinsicOp, Unhandled);
   HANDLE(Mux2CellIntrinsicOp, Unhandled);
   HANDLE(HasBeenResetIntrinsicOp, Unhandled);
+  HANDLE(ReadDesignConfigIntIntrinsicOp, Unhandled);
 
   // Miscellaneous.
   HANDLE(BitsPrimOp, Unhandled);

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -961,5 +961,31 @@ def AnnotateInputOnlyModules : Pass<"firrtl-annotate-input-only-modules",
   ];
 }
 
+def CreateDesignConfigPackage : Pass<"firrtl-create-design-config-package",
+                                     "firrtl::CircuitOp"> {
+  let summary = "Create design configuration package for post-Verilog configuration";
+  let description = [{
+    This pass accumulates all ReadDesignConfigInt intrinsics in the design
+    and generates a SystemVerilog package (DesignConfigPackage) containing
+    all the configuration values. It also creates an OM class with metadata
+    about the configurations.
+
+    The pass only generates the package for the effective DUT (Design Under Test).
+    Configuration values are collected from all modules instantiated under the DUT.
+
+    The generated package can be used for post-Verilog configuration by
+    modifying the configuration values without regenerating the Verilog.
+  }];
+  let dependentDialects = [
+    "emit::EmitDialect",
+    "hw::HWDialect",
+    "sv::SVDialect",
+    "om::OMDialect"
+  ];
+  let statistics = [
+    Statistic<"numConfigs", "num-configs", "Number of configurations collected">
+  ];
+}
+
 
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -65,3 +65,28 @@ def CirctIsX : FIRRTLIntrinsic {
     | found  | UInt<1> | i is `x`    |
   }];
 }
+
+def CirctReadDesignConfigInt : FIRRTLIntrinsic {
+  let mnemonic = "circt.read_design_config_int";
+  let converter = "CirctReadDesignConfigIntConverter";
+  let description = [{
+    Reads an integer design configuration value that will be defined in a
+    generated configuration package. This intrinsic is used for post-Verilog
+    configuration, where configuration values can be set after Verilog generation.
+
+    The generated Verilog will reference the configuration from DesignConfigPackage:
+    ```verilog
+    localparam mode = DesignConfigPackage.mode;
+    ```
+
+    | Parameter    | Type   | Description                                  |
+    | ------------ | ------ | -------------------------------------------- |
+    | name         | String | Name of the configuration                    |
+    | defaultValue | Int    | Default value of the configuration           |
+    | comment      | String | Description of the configuration (can be empty) |
+
+    | Result | Type | Description                                |
+    | ------ | ---- | ------------------------------------------ |
+    | value  | Int  | The configuration value                    |
+  }];
+}

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6462,6 +6462,10 @@ void AndRPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 void SizeOfIntrinsicOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
+void ReadDesignConfigIntIntrinsicOp::getAsmResultNames(
+    OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getResult(), getParamName());
+}
 void AsAsyncResetPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   CheckLayers.cpp
   CheckRecursiveInstantiation.cpp
   CreateSiFiveMetadata.cpp
+  CreateDesignConfigPackage.cpp
   Dedup.cpp
   DropConst.cpp
   DropName.cpp

--- a/lib/Dialect/FIRRTL/Transforms/CreateDesignConfigPackage.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateDesignConfigPackage.cpp
@@ -1,0 +1,235 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the CreateDesignConfigPackage pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Analysis/FIRRTLInstanceInfo.h"
+#include "circt/Dialect/Emit/EmitOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/OM/OMOps.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/JSON.h"
+
+namespace circt {
+namespace firrtl {
+#define GEN_PASS_DEF_CREATEDESIGNCONFIGPACKAGE
+#include "circt/Dialect/FIRRTL/Passes.h.inc"
+} // namespace firrtl
+} // namespace circt
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+
+/// Structure to hold information about a design configuration
+struct ConfigInfo {
+  StringAttr name;
+  int64_t defaultValue;
+  StringAttr comment;
+  Type resultType;
+  Location loc;
+};
+
+class CreateDesignConfigPackagePass
+    : public circt::firrtl::impl::CreateDesignConfigPackageBase<
+          CreateDesignConfigPackagePass> {
+public:
+  void runOnOperation() override;
+
+private:
+  /// Generate the SystemVerilog package containing all configurations
+  void generateConfigPackage(CircuitOp circuit, ArrayRef<ConfigInfo> configs);
+
+  /// Generate OM class metadata for the configurations
+  void generateOMMetadata(CircuitOp circuit, ArrayRef<ConfigInfo> configs);
+
+  /// Schema class for individual configuration parameters
+  ClassOp configSchemaClass;
+
+  /// Metadata class containing list of all configurations
+  ClassOp configMetadataClass;
+};
+
+} // namespace
+
+void CreateDesignConfigPackagePass::generateConfigPackage(
+    CircuitOp circuit, ArrayRef<ConfigInfo> configs) {
+  if (configs.empty())
+    return;
+
+  auto builder = mlir::ImplicitLocOpBuilder::atBlockEnd(circuit.getLoc(),
+                                                        circuit.getBodyBlock());
+
+  // Build the package content
+  std::string packageContent = "package DesignConfigPackage;\n";
+
+  for (const auto &config : configs) {
+    // Add comment if present and non-empty
+    if (config.comment && !config.comment.getValue().empty()) {
+      // FIXME: Properly indent if a comment contains a new lines.
+      packageContent += "  // " + config.comment.getValue().str() + "\n";
+    }
+
+    // Generate parameter declaration with default value
+    packageContent += "  parameter " + config.name.getValue().str() + " = " +
+                      std::to_string(config.defaultValue) + ";\n";
+  }
+
+  packageContent += "endpackage\n";
+
+  // Create a verbatim op with the package content
+  auto verbatimOp = sv::VerbatimOp::create(builder, packageContent);
+  verbatimOp->setAttr("output_file",
+                      hw::OutputFileAttr::getFromFilename(
+                          &getContext(), "DesignConfigPackage.sv",
+                          /*excludeFromFileList=*/false,
+                          /*includeReplicatedOps=*/false));
+}
+
+void CreateDesignConfigPackagePass::generateOMMetadata(
+    CircuitOp circuit, ArrayRef<ConfigInfo> configs) {
+  if (configs.empty())
+    return;
+
+  auto unknownLoc = mlir::UnknownLoc::get(&getContext());
+  auto builder = mlir::ImplicitLocOpBuilder::atBlockEnd(unknownLoc,
+                                                        circuit.getBodyBlock());
+
+  // Create the schema class for individual configuration parameters
+  // Fields: name, defaultValue, comment, width
+  StringRef schemaFieldNames[] = {"name", "defaultValue", "comment", "width"};
+  Type schemaFieldTypes[] = {
+      StringType::get(&getContext()), FIntegerType::get(&getContext()),
+      StringType::get(&getContext()), FIntegerType::get(&getContext())};
+
+  configSchemaClass = ClassOp::create(builder, "DesignConfigSchema",
+                                      schemaFieldNames, schemaFieldTypes);
+
+  // Create the metadata class that will hold all configuration objects
+  SmallVector<PortInfo> metadataPorts;
+  configMetadataClass = ClassOp::create(
+      builder, builder.getStringAttr("DesignConfigMetadata"), metadataPorts);
+
+  builder.setInsertionPointToStart(configMetadataClass.getBodyBlock());
+
+  // Create an object for each configuration and assign its fields
+  SmallVector<Value> configObjects;
+  for (const auto &config : configs) {
+    // Create an object instance of the schema class
+    auto configObj = ObjectOp::create(builder, configSchemaClass, config.name);
+
+    // Assign field values using ObjectSubfieldOp to access input ports
+    // Port indices: 0=name_in, 1=name_out, 2=defaultValue_in,
+    // 3=defaultValue_out, etc.
+
+    // Field 0: name (input port index 0)
+    auto nameInPort = ObjectSubfieldOp::create(builder, configObj, 0);
+    auto nameConst = StringConstantOp::create(builder, config.name);
+    PropAssignOp::create(builder, nameInPort, nameConst);
+
+    // Field 1: defaultValue (input port index 2)
+    auto defaultValueInPort = ObjectSubfieldOp::create(builder, configObj, 2);
+    auto defaultValueAttr = builder.getIntegerAttr(
+        builder.getIntegerType(64, /*isSigned=*/true), config.defaultValue);
+    auto defaultValueConst =
+        FIntegerConstantOp::create(builder, defaultValueAttr);
+    PropAssignOp::create(builder, defaultValueInPort, defaultValueConst);
+
+    // Field 2: comment (input port index 4)
+    auto commentInPort = ObjectSubfieldOp::create(builder, configObj, 4);
+    auto commentConst = StringConstantOp::create(
+        builder, config.comment ? config.comment : builder.getStringAttr(""));
+    PropAssignOp::create(builder, commentInPort, commentConst);
+
+    // Field 3: width (input port index 6)
+    auto widthInPort = ObjectSubfieldOp::create(builder, configObj, 6);
+    int32_t width = cast<IntType>(config.resultType).getWidth().value_or(0);
+    auto widthAttr = builder.getIntegerAttr(
+        builder.getIntegerType(64, /*isSigned=*/true), width);
+    auto widthConst = FIntegerConstantOp::create(builder, widthAttr);
+    PropAssignOp::create(builder, widthInPort, widthConst);
+
+    configObjects.push_back(configObj);
+  }
+
+  // Create a list of all configuration objects
+  auto listType = ListType::get(
+      &getContext(), cast<PropertyType>(detail::getInstanceTypeForClassLike(
+                         configSchemaClass)));
+  auto configList = ListCreateOp::create(builder, listType, configObjects);
+
+  // Add the list as an output port of the metadata class
+  auto portIndex = configMetadataClass.getNumPorts();
+  SmallVector<std::pair<unsigned, PortInfo>> newPorts = {
+      {portIndex, PortInfo(builder.getStringAttr("configs"),
+                           configList.getType(), Direction::Out)}};
+  configMetadataClass.insertPorts(newPorts);
+  auto blockarg = configMetadataClass.getBodyBlock()->addArgument(
+      configList.getType(), unknownLoc);
+  PropAssignOp::create(builder, blockarg, configList);
+}
+
+void CreateDesignConfigPackagePass::runOnOperation() {
+  auto circuit = getOperation();
+  auto &instanceInfo = getAnalysis<InstanceInfo>();
+
+  auto dut = instanceInfo.getEffectiveDut();
+
+  // Walk all modules in the circuit
+  SmallVector<ConfigInfo> configs;
+  bool hasErrors = false;
+
+  for (auto module : circuit.getOps<FModuleOp>()) {
+    // Check if this module is under the DUT
+    bool isUnderDUT = dut && instanceInfo.anyInstanceInEffectiveDesign(module);
+
+    module.walk([&](ReadDesignConfigIntIntrinsicOp op) {
+      if (!isUnderDUT) {
+        // Emit error if config is used outside of DUT
+        // PR NOTE: The requirement here is not to generate a package when
+        // compiling testbench (since otherwise there are two configuration
+        // packages). How SiFiveMetadata pass avoids this problem?
+        op.emitError() << "design configuration '" << op.getParamName()
+                       << "' can only be used within the effective DUT";
+        hasErrors = true;
+      } else {
+        // Collect configuration info
+        ConfigInfo info{
+            op.getParamNameAttr(), static_cast<int64_t>(op.getDefaultValue()),
+            op.getCommentAttr(), op.getResult().getType(), op.getLoc()};
+        configs.push_back(info);
+        ++numConfigs;
+      }
+    });
+  }
+
+  if (hasErrors) {
+    signalPassFailure();
+    return;
+  }
+
+  // TODO: Check the uniqueness of parameters.
+  //       We want to allow modules to refer to the same parameters across
+  //       the design hierarchy, but we need to ensure they are referring to
+  //       the same parameters. In addition to the parameter name, the type,
+  //       default value, and comment must all be the same.
+
+  // Generate the configuration package
+  generateConfigPackage(circuit, configs);
+
+  // Generate OM metadata
+  generateOMMetadata(circuit, configs);
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -238,6 +238,10 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   if (!opt.shouldDisableLayerSink() && !opt.shouldDisableOptimization())
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLayerSink());
 
+  // Generate design configuration package for post-Verilog configuration
+  pm.nest<firrtl::CircuitOp>().addPass(
+      firrtl::createCreateDesignConfigPackage());
+
   // Lower the ref.resolve and ref.send ops and remove the RefType ports.
   // LowerToHW cannot handle RefType so, this pass must be run to remove all
   // RefType ports and ops.

--- a/test/Conversion/FIRRTLToHW/read-design-config-int.mlir
+++ b/test/Conversion/FIRRTLToHW/read-design-config-int.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt --lower-firrtl-to-hw %s | FileCheck %s
+
+firrtl.circuit "ReadDesignConfigIntTest" {
+  // CHECK-LABEL: hw.module @ReadDesignConfigIntTest
+  firrtl.module @ReadDesignConfigIntTest(
+    out %param1: !firrtl.uint<4>,
+    out %param2: !firrtl.uint<16>
+  ) {
+    // CHECK: %mode = sv.localparam {value = #hw.param.verbatim<"DesignConfigPackage::mode"> : i4} : i4
+    %mode = firrtl.int.read_design_config_int "mode", 0, "Mode" : !firrtl.uint<4>
+
+    // CHECK: %depth = sv.localparam {value = #hw.param.verbatim<"DesignConfigPackage::depth"> : i16} : i16
+    %depth = firrtl.int.read_design_config_int "depth", 1024, "" : !firrtl.uint<16>
+
+    // CHECK: hw.output %mode, %depth : i4, i16
+    firrtl.connect %param1, %mode : !firrtl.uint<4>, !firrtl.uint<4>
+    firrtl.connect %param2, %depth : !firrtl.uint<16>, !firrtl.uint<16>
+  }
+
+}
+

--- a/test/Dialect/FIRRTL/create-design-config-package-error.mlir
+++ b/test/Dialect/FIRRTL/create-design-config-package-error.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt --firrtl-create-design-config-package %s -verify-diagnostics
+
+firrtl.circuit "TestHarness" {
+  firrtl.module @TestHarness(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %harness_param: !firrtl.uint<8>) attributes {convention = #firrtl<convention scalarized>} {
+    firrtl.instance dut sym @sym @DUT()
+    // expected-error @below {{design configuration 'harness_config' can only be used within the effective DUT}}
+    %harness_config = firrtl.int.read_design_config_int "harness_config", 99, "" : !firrtl.uint<8>
+    firrtl.matchingconnect %harness_param, %harness_config : !firrtl.uint<8>
+  }
+  firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}], convention = #firrtl<convention scalarized>} {
+  }
+}

--- a/test/Dialect/FIRRTL/create-design-config-package.mlir
+++ b/test/Dialect/FIRRTL/create-design-config-package.mlir
@@ -1,0 +1,32 @@
+// RUN: circt-opt --firrtl-create-design-config-package %s | FileCheck %s
+firrtl.circuit "ReadDesignConfigIntTest" {
+// CHECK:       sv.verbatim "package DesignConfigPackage
+// CHECK-SAME: {output_file = #hw.output_file<"DesignConfigPackage.sv">}
+
+// CHECK-LABEL:  firrtl.class @DesignConfigSchema(in %name_in: !firrtl.string, out %name: !firrtl.string, in %defaultValue_in: !firrtl.integer, out %defaultValue: !firrtl.integer, in %comment_in: !firrtl.string, out %comment: !firrtl.string, in %width_in: !firrtl.integer, out %width: !firrtl.integer) {
+// CHECK-NEXT:    firrtl.propassign %name, %name_in : !firrtl.string
+// CHECK-NEXT:    firrtl.propassign %defaultValue, %defaultValue_in : !firrtl.integer
+// CHECK-NEXT:    firrtl.propassign %comment, %comment_in : !firrtl.string
+// CHECK-NEXT:    firrtl.propassign %width, %width_in : !firrtl.integer
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: firrtl.class @DesignConfigMetadata(out %configs: !firrtl.list<class<@DesignConfigSchema
+// CHECK:          %mode = firrtl.object @DesignConfigSchema
+// CHECK:          %depth = firrtl.object @DesignConfigSchema
+// CHECK:          %[[list:.+]] = firrtl.list.create %mode, %depth
+// CHECK:          firrtl.propassign %configs, %[[list]]
+// CHECK:       }
+  firrtl.module @ReadDesignConfigIntTest(
+    out %param1: !firrtl.uint<4>,
+    out %param2: !firrtl.uint<16>
+  ) {
+    %mode = firrtl.int.read_design_config_int "mode", 0, "Mode" : !firrtl.uint<4>
+
+    %depth = firrtl.int.read_design_config_int "depth", 1024, "" : !firrtl.uint<16>
+
+    firrtl.connect %param1, %mode : !firrtl.uint<4>, !firrtl.uint<4>
+    firrtl.connect %param2, %depth : !firrtl.uint<16>, !firrtl.uint<16>
+  }
+
+}
+

--- a/test/firtool/read-design-config-int.fir
+++ b/test/firtool/read-design-config-int.fir
@@ -1,0 +1,59 @@
+; RUN: firtool %s --verilog | FileCheck %s --check-prefix=VERILOG
+; RUN: firtool %s --ir-hw | FileCheck %s --check-prefix=HW
+
+FIRRTL version 4.0.0
+
+; Test the ReadDesignConfigInt intrinsic end-to-end
+; This intrinsic allows creating configurable parameters that can be
+; overridden after Verilog generation
+
+circuit Top:
+  extmodule Buffer:
+    input data_in : UInt<8>
+    input mode : UInt<2>
+    output data_out : UInt<8>
+    defname = Buffer
+  public module Top:
+    input clock: Clock
+    input reset: UInt<1>
+    input data_in: UInt<8>
+    output data_out: UInt<8>
+    output buffer_out: UInt<8>
+
+    ; Create parameters with different default values
+    wire mode : UInt<2>
+    wire enable_feature : UInt<1>
+
+    connect mode, intrinsic(circt_read_design_config_int<name = "mode", defaultValue = 3, comment = "Mode selection"> : UInt<2>)
+    connect enable_feature, intrinsic(circt_read_design_config_int<name = "enable_feature", defaultValue = 1, comment = "Enable feature flag"> : UInt<1>)
+
+    ; Use the parameters in logic
+    inst buffer of Buffer
+    connect buffer.data_in, data_in
+    connect buffer.mode, mode
+    connect data_out, buffer.data_out
+    node selected_data = mux(enable_feature, data_in, UInt<8>(0))
+    connect data_out, selected_data
+    connect buffer_out, buffer.data_out
+
+; VERILOG-LABEL: module Top(
+; VERILOG:   localparam [1:0] mode = DesignConfigPackage::mode;
+; VERILOG:   localparam [0:0] enable_feature = DesignConfigPackage::enable_feature;
+; VERILOG:   Buffer buffer (
+; VERILOG:     .data_in     (data_in),
+; VERILOG:     .mode (mode),
+; VERILOG:     .data_out    (buffer_out)
+; VERILOG:   );
+; VERILOG:   assign data_out = enable_feature ? data_in : 8'h0;
+
+; VERILOG-LABEL: package DesignConfigPackage;
+; VERILOG-NEXT:    // Mode selection
+; VERILOG-NEXT:    parameter mode = 3;
+; VERILOG-NEXT:    // Enable feature flag
+; VERILOG-NEXT:    parameter enable_feature = 1;
+; VERILOG-NEXT:  endpackage
+
+; HW-LABEL: hw.module @Top
+; HW:         %mode = sv.localparam {value = #hw.param.verbatim<"DesignConfigPackage::mode"> : i2} : i2
+; HW:         %enable_feature = sv.localparam {value = #hw.param.verbatim<"DesignConfigPackage::enable_feature"> : i1} : i1
+


### PR DESCRIPTION
This is PoC for one of proposals to achieve verilog level configuration. Not for commit. 

This patch introduces a new FIRRTL intrinsic `circt.read_design_config_int` that enables post-Verilog configuration by generating a SystemVerilog package (DesignConfigPackage) containing configurable parameters. The intrinsic allows hardware designs to reference configuration values that can be modified after Verilog generation without requiring recompilation.

The naming is intentionally "config" instead of "parameter" to reserve keyword/feature for FIRRTL parameters. 

The implementation follows standard lowering flow for the intrinsic: 
* LowerToHW pass converts these intrinsics to sv.localparam operations that reference the generated package using the syntax `DesignConfigPackage::param_name`. 
* CreateDesignConfigPackage pass collects all configuration parameters from modules under the effective DUT, generates a SystemVerilog package with parameter declarations, and creates OM metadata for tooling integration.

Configuration parameters are only generated for the effective DUT to avoid conflicts when compiling testbenches separately. The generated package uses standard SystemVerilog parameter syntax, allowing values to be overridden via either modifying configuration flag or maybe via macro (it's not implemented here, but we can add `ifdef CIRCT_DESIGNCONFIG_<PARAMETER_NAME>` to the package). 


Example:
```scala
FIRRTL version 10.0.0
circuit Top:
  extmodule Buffer:
    input data_in : UInt<8>
    input mode : UInt<2>
    output data_out : UInt<8>
    defname = Buffer
  public module Top:
    input clock: Clock
    input reset: UInt<1>
    input data_in: UInt<8>
    output data_out: UInt<8>
    output buffer_out: UInt<8>

    wire mode : UInt<2>
    wire enable_feature : UInt<1>

    connect mode, intrinsic(circt_read_design_config_int<name = "mode", defaultValue = 3, comment = "Mode selection"> : UInt<2>)
    connect enable_feature, intrinsic(circt_read_design_config_int<name = "enable_feature", defaultValue = 1, comment = "Enable feature flag"> : UInt<1>)

    inst buffer of Buffer
    connect buffer.data_in, data_in
    connect buffer.mode, mode
    connect data_out, buffer.data_out
    node selected_data = mux(enable_feature, data_in, UInt<8>(0))
    connect data_out, selected_data
    connect buffer_out, buffer.data_out
```

Output:
```verilog
// Generated by CIRCT firtool-1.139.0-139-g13f1f1710
module Top(
  input        clock,
               reset,
  input  [7:0] data_in,
  output [7:0] data_out,
               buffer_out
);

  localparam [1:0] mode = DesignConfigPackage::mode;
  localparam [0:0] enable_feature = DesignConfigPackage::enable_feature;
  Buffer buffer (
    .data_in  (data_in),
    .mode     (mode),
    .data_out (buffer_out)
  );
  assign data_out = enable_feature ? data_in : 8'h0;
endmodule


// ----- 8< ----- FILE "DesignConfigPackage.sv" ----- 8< -----

// Generated by CIRCT firtool-1.139.0-139-g13f1f1710
package DesignConfigPackage;
  // Mode selection
  parameter mode = 3;
  // Enable feature flag
  parameter enable_feature = 1;
endpackage
```