### PR TITLE
[FIRRTL] Fix canonicalizer infinite loop with const types

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -77,6 +77,13 @@ def UIntTypes : Constraint<CPred<"type_isa<UIntType>($0.getType())">>;
 // Constraint that enforces types mismatches
 def mismatchTypes : Constraint<CPred<"!areAnonymousTypesEquivalent($0.getType(), $1.getType())">>;
 
+// Constraint that enforces types mismatches, ignoring const qualifiers
+def mismatchTypesIgnoringConst : Constraint<CPred<[{
+  !areAnonymousTypesEquivalent(
+    type_cast<FIRRTLBaseType>($0.getType()).getAllConstDroppedType(),
+    type_cast<FIRRTLBaseType>($1.getType()).getAllConstDroppedType())
+  }]>>;
+
 // Constraint that enforces types of known width
 def KnownWidth : Constraint<CPred<[{
   type_isa<FIRRTLBaseType>($0.getType()) &&
@@ -237,19 +244,19 @@ def extendAnd : Pat <
   (AndPrimOp:$old $lhs, $rhs),
   (MoveNameHint $old, (AndPrimOp (PadPrimOp $lhs, (TypeWidth32 $old)),
                                  (PadPrimOp $rhs, (TypeWidth32 $old)))),
-  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypes $lhs, $rhs)]>;
+  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypesIgnoringConst $lhs, $rhs)]>;
 
 def extendOr : Pat <
   (OrPrimOp:$old $lhs, $rhs),
   (MoveNameHint $old, (OrPrimOp (PadPrimOp $lhs, (TypeWidth32 $old)),
                                 (PadPrimOp $rhs, (TypeWidth32 $old)))),
-  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypes $lhs, $rhs)]>;
+  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypesIgnoringConst $lhs, $rhs)]>;
 
 def extendXor : Pat <
   (XorPrimOp:$old $lhs, $rhs),
   (MoveNameHint $old, (XorPrimOp (PadPrimOp $lhs, (TypeWidth32 $old)),
                                  (PadPrimOp $rhs, (TypeWidth32 $old)))),
-  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypes $lhs, $rhs)]>;
+  [(KnownWidth $lhs), (KnownWidth $rhs), (mismatchTypesIgnoringConst $lhs, $rhs)]>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Move constants to the right

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -119,6 +119,7 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
                    in %sin: !firrtl.sint<4>,
                    in %zin1: !firrtl.uint<0>,
                    in %zin2: !firrtl.uint<0>,
+                   in %cin: !firrtl.const.uint<4>,
                    out %out: !firrtl.uint<4>,
                    out %out6: !firrtl.uint<6>,
                    out %out5: !firrtl.uint<5>,
@@ -196,6 +197,10 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   %10 = firrtl.cvt %in : (!firrtl.uint<4>) -> !firrtl.sint<5>
   %11 = firrtl.and %10, %c3_si5 : (!firrtl.sint<5>, !firrtl.sint<5>) -> !firrtl.uint<5>
   firrtl.matchingconnect %out5, %11 : !firrtl.uint<5>
+
+  // Test that this doesn't loop infinitely.
+  %12 = firrtl.and %in, %cin : (!firrtl.uint<4>, !firrtl.const.uint<4>) -> !firrtl.uint<4>
+  firrtl.matchingconnect %out, %12 : !firrtl.uint<4>
 }
 
 // AndOfAsSInt patterns should not crash on non-IntType inputs
@@ -237,6 +242,7 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
                   in %sin: !firrtl.sint<4>,
                   in %zin1: !firrtl.uint<0>,
                   in %zin2: !firrtl.uint<0>,
+                  in %cin: !firrtl.const.uint<4>,
                   out %out: !firrtl.uint<4>,
                   out %out6: !firrtl.uint<6>,
                   out %outz: !firrtl.uint<0>) {
@@ -296,6 +302,9 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
   %9 = firrtl.or %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
   firrtl.connect %out6, %9 : !firrtl.uint<6>, !firrtl.uint<6>
 
+  // Test that this doesn't loop infinitely.
+  %10 = firrtl.or %in, %cin : (!firrtl.uint<4>, !firrtl.const.uint<4>) -> !firrtl.uint<4>
+  firrtl.matchingconnect %out, %10 : !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Xor
@@ -304,6 +313,7 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
                    in %sin: !firrtl.sint<4>,
                    in %zin1: !firrtl.uint<0>,
                    in %zin2: !firrtl.uint<0>,
+                   in %cin: !firrtl.const.uint<4>,
                    out %out: !firrtl.uint<4>,
                    out %out6: !firrtl.uint<6>,
                    out %outz: !firrtl.uint<0>) {
@@ -349,6 +359,9 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
   %9 = firrtl.xor %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
   firrtl.connect %out6, %9 : !firrtl.uint<6>, !firrtl.uint<6>
 
+  // Test that this doesn't loop infinitely.
+  %10 = firrtl.xor %in, %cin : (!firrtl.uint<4>, !firrtl.const.uint<4>) -> !firrtl.uint<4>
+  firrtl.matchingconnect %out, %10 : !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Not


### PR DESCRIPTION
The extendAnd, extendOr, and extendXor canonicalization patterns use the
mismatchTypes constraint to check if operand types differ.  However, this
considers const and non-const as different.  This creates an infinite
canonicalization loop which has been frequently encountered when running
`circt-reduce` on un-adulterated Chisel-generated FIRRTL.

Fixes #9560.

AI-assisted-by: Augment (Claude Sonnet 4.5)
