### PR TITLE
[FIRRTL] Add asReset cast op

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -761,6 +761,7 @@ let hasCanonicalizer=1 in {
 }
 def AsAsyncResetPrimOp
   : UnaryPrimOp<"asAsyncReset", OneBitCastableType, AsyncResetType>;
+def AsResetPrimOp : UnaryPrimOp<"asReset", UInt1Type, ResetType>;
 def AsClockPrimOp : UnaryPrimOp<"asClock", OneBitCastableType, ClockType>;
 def NegPrimOp : UnaryPrimOp<"neg", IntType, SIntType>;
 let hasCanonicalizer = true in

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -45,8 +45,9 @@ public:
             // Misc Binary Primitives.
             CatPrimOp, DShlPrimOp, DShlwPrimOp, DShrPrimOp,
             // Unary operators.
-            AsSIntPrimOp, AsUIntPrimOp, AsAsyncResetPrimOp, AsClockPrimOp,
-            CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
+            AsSIntPrimOp, AsUIntPrimOp, AsAsyncResetPrimOp, AsResetPrimOp,
+            AsClockPrimOp, CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp,
+            OrRPrimOp, XorRPrimOp,
             // Intrinsic Expressions.
             IsXIntrinsicOp, PlusArgsValueIntrinsicOp, PlusArgsTestIntrinsicOp,
             SizeOfIntrinsicOp, ClockGateIntrinsicOp, ClockInverterIntrinsicOp,
@@ -154,6 +155,7 @@ public:
   HANDLE(AsSIntPrimOp, Unary);
   HANDLE(AsUIntPrimOp, Unary);
   HANDLE(AsAsyncResetPrimOp, Unary);
+  HANDLE(AsResetPrimOp, Unary);
   HANDLE(AsClockPrimOp, Unary);
   HANDLE(CvtPrimOp, Unary);
   HANDLE(NegPrimOp, Unary);

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -188,6 +188,7 @@ struct Emitter {
   HANDLE(AsSIntPrimOp, "asSInt");
   HANDLE(AsUIntPrimOp, "asUInt");
   HANDLE(AsAsyncResetPrimOp, "asAsyncReset");
+  HANDLE(AsResetPrimOp, "asReset");
   HANDLE(AsClockPrimOp, "asClock");
   HANDLE(CvtPrimOp, "cvt");
   HANDLE(NegPrimOp, "neg");
@@ -1436,8 +1437,9 @@ void Emitter::emitExpression(Value value) {
           OrPrimOp, XorPrimOp, LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp,
           EQPrimOp, NEQPrimOp, DShlPrimOp, DShlwPrimOp, DShrPrimOp,
           // Unary
-          AsSIntPrimOp, AsUIntPrimOp, AsAsyncResetPrimOp, AsClockPrimOp,
-          CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
+          AsSIntPrimOp, AsUIntPrimOp, AsAsyncResetPrimOp, AsResetPrimOp,
+          AsClockPrimOp, CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp,
+          XorRPrimOp,
           // Miscellaneous
           BitsPrimOp, HeadPrimOp, TailPrimOp, PadPrimOp, MuxPrimOp, ShlPrimOp,
           ShrPrimOp, UninferredResetCastOp, ConstCastOp, StringConstantOp,

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1062,6 +1062,12 @@ OpFoldResult AsAsyncResetPrimOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+OpFoldResult AsResetPrimOp::fold(FoldAdaptor adaptor) {
+  if (auto cst = getConstant(adaptor.getInput()))
+    return BoolAttr::get(getContext(), cst->getBoolValue());
+  return {};
+}
+
 OpFoldResult AsClockPrimOp::fold(FoldAdaptor adaptor) {
   // No effect.
   if (getInput().getType() == getType())

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5734,6 +5734,14 @@ FIRRTLType AsAsyncResetPrimOp::inferReturnType(FIRRTLType input,
   return AsyncResetType::get(input.getContext(), base.isConst());
 }
 
+FIRRTLType AsResetPrimOp::inferReturnType(FIRRTLType input,
+                                          std::optional<Location> loc) {
+  auto base = type_dyn_cast<FIRRTLBaseType>(input);
+  if (!base)
+    return emitInferRetTypeError(loc, "operand must be a scalar base type");
+  return ResetType::get(input.getContext(), base.isConst());
+}
+
 FIRRTLType AsClockPrimOp::inferReturnType(FIRRTLType input,
                                           std::optional<Location> loc) {
   return ClockType::get(input.getContext(), isConst(input));
@@ -6463,6 +6471,9 @@ void SizeOfIntrinsicOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 void AsAsyncResetPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+void AsResetPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 void AsClockPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -205,6 +205,8 @@ TOK_LPKEYWORD_PRIM(and, AndPrimOp, 2, 0, FIRVersion(0, 0, 0), "Base")
 TOK_LPKEYWORD_PRIM(andr, AndRPrimOp, 1, 0, FIRVersion(0, 0, 0), "Base")
 TOK_LPKEYWORD_PRIM(asAsyncReset, AsAsyncResetPrimOp, 1, 0, FIRVersion(0, 0, 0),
                    "Base")
+TOK_LPKEYWORD_PRIM(asReset, AsResetPrimOp, 1, 0, missingSpecFIRVersion,
+                   "reset casts")
 TOK_LPKEYWORD_PRIM(asClock, AsClockPrimOp, 1, 0, FIRVersion(0, 0, 0), "Base")
 TOK_LPKEYWORD_PRIM(asSInt, AsSIntPrimOp, 1, 0, FIRVersion(0, 0, 0), "Base")
 TOK_LPKEYWORD_PRIM(asUInt, AsUIntPrimOp, 1, 0, FIRVersion(0, 0, 0), "Base")

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3943,4 +3943,21 @@ firrtl.module @Domains(
   firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
 
 }
+
+// CHECK-LABEL: firrtl.module @ResetCast
+firrtl.module @ResetCast(out %a0: !firrtl.reset, out %a1: !firrtl.reset) {
+  // CHECK-DAG: [[R0:%.+]] = firrtl.specialconstant 0 : !firrtl.reset
+  // CHECK-DAG: [[R1:%.+]] = firrtl.specialconstant 1 : !firrtl.reset
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+
+  // CHECK: firrtl.matchingconnect %a0, [[R0]]
+  %0 = firrtl.asReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.reset
+  firrtl.matchingconnect %a0, %0 : !firrtl.reset
+
+  // CHECK: firrtl.matchingconnect %a1, [[R1]]
+  %1 = firrtl.asReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.reset
+  firrtl.matchingconnect %a1, %1 : !firrtl.reset
+}
+
 }

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -251,6 +251,7 @@ firrtl.circuit "Foo" {
     // CHECK: node asSIntPrimOp = asSInt(x)
     // CHECK: node asUIntPrimOp = asUInt(x)
     // CHECK: node asAsyncResetPrimOp = asAsyncReset(x)
+    // CHECK: node asResetPrimOp = asReset(ui1)
     // CHECK: node asClockPrimOp = asClock(x)
     // CHECK: node cvtPrimOp = cvt(x)
     // CHECK: node negPrimOp = neg(x)
@@ -261,6 +262,7 @@ firrtl.circuit "Foo" {
     %asSIntPrimOp_tmp = firrtl.asSInt %x : (!firrtl.uint) -> !firrtl.sint
     %asUIntPrimOp_tmp = firrtl.asUInt %x : (!firrtl.uint) -> !firrtl.uint
     %asAsyncResetPrimOp_tmp = firrtl.asAsyncReset %x : (!firrtl.uint) -> !firrtl.asyncreset
+    %asResetPrimOp_tmp = firrtl.asReset %ui1 : (!firrtl.uint<1>) -> !firrtl.reset
     %asClockPrimOp_tmp = firrtl.asClock %x : (!firrtl.uint) -> !firrtl.clock
     %cvtPrimOp_tmp = firrtl.cvt %x : (!firrtl.uint) -> !firrtl.sint
     %negPrimOp_tmp = firrtl.neg %x : (!firrtl.uint) -> !firrtl.sint
@@ -271,6 +273,7 @@ firrtl.circuit "Foo" {
     %asSIntPrimOp = firrtl.node %asSIntPrimOp_tmp : !firrtl.sint
     %asUIntPrimOp = firrtl.node %asUIntPrimOp_tmp : !firrtl.uint
     %asAsyncResetPrimOp = firrtl.node %asAsyncResetPrimOp_tmp : !firrtl.asyncreset
+    %asResetPrimOp = firrtl.node %asResetPrimOp_tmp : !firrtl.reset
     %asClockPrimOp = firrtl.node %asClockPrimOp_tmp : !firrtl.clock
     %cvtPrimOp = firrtl.node %cvtPrimOp_tmp : !firrtl.sint
     %negPrimOp = firrtl.node %negPrimOp_tmp : !firrtl.sint

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -178,6 +178,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule"
     ; CHECK: firrtl.asAsyncReset %reset_async : (!firrtl.asyncreset) -> !firrtl.asyncreset
     node check_ar5 = asAsyncReset(reset_async)
 
+    ; CHECK: firrtl.asReset %reset : (!firrtl.uint<1>) -> !firrtl.reset
+    node check_r0 = asReset(reset)
+
     ; CHECK: firrtl.asClock %clock : (!firrtl.clock) -> !firrtl.clock
     node check_c0 = asClock(clock)
     ; CHECK: firrtl.asClock %reset : (!firrtl.uint<1>) -> !firrtl.clock

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1946,3 +1946,12 @@ circuit Foo:
     output a: Integer
     ; expected-error @below {{expected property type}}
     propassign a, Unknown: UInt<1>
+
+;// -----
+
+FIRRTL version 5.0.0
+circuit AsResetVersion:
+  public module AsResetVersion:
+    input in: UInt<1>
+    ; expected-error @below {{reset casts are a FIRRTL 5.1.0+ feature}}
+    node x = asReset(in)

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -20,6 +20,9 @@ firrtl.module @Intrinsics(in %ui : !firrtl.uint, in %clock: !firrtl.clock, in %u
   // CHECK-NEXT: firrtl.int.isX %ui : !firrtl.uint
   %isx = firrtl.int.isX %ui : !firrtl.uint
 
+  // CHECK-NEXT: firrtl.asReset %ui1 : (!firrtl.uint<1>) -> !firrtl.reset
+  %reset = firrtl.asReset %ui1 : (!firrtl.uint<1>) -> !firrtl.reset
+
   // CHECK-NEXT: firrtl.int.plusargs.test "foo"
   // CHECK-NEXT: firrtl.int.plusargs.value "bar" : !firrtl.uint<5>
   %foo_found = firrtl.int.plusargs.test "foo"


### PR DESCRIPTION
Add a cast operation to the FIRRTL dialect that goes from `UInt<1>` to an uninferred `Reset` type. This cast is always safe to do: if the reset is inferred to be a sync `UInt<1>`, the cast is a no-op; if it is inferred to be an `AsyncReset`, using a sync `UInt<1>` as async reset is always safe.

Also add corresponding parser and emitter support.

This does not yet cover width inference and reset inference, which will come in follow-up commits.