### PR TITLE
[FIRRTL][CAPI] Update RefType creation to support layers

### DIFF
--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -210,6 +210,11 @@ MLIR_CAPI_EXPORTED bool firrtlTypeIsARef(MlirType type);
 /// Creates a ref type.
 MLIR_CAPI_EXPORTED MlirType firrtlTypeGetRef(MlirType target, bool forceable);
 
+/// Creates a ref type.
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetColoredRef(MlirType target,
+                                                    bool forceable,
+                                                    MlirAttribute layer);
+
 /// Checks if this type is an anyref type.
 MLIR_CAPI_EXPORTED bool firrtlTypeIsAAnyRef(MlirType type);
 

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -192,6 +192,16 @@ MlirType firrtlTypeGetRef(MlirType target, bool forceable) {
   return wrap(RefType::get(baseType, forceable));
 }
 
+MlirType firrtlTypeGetColoredRef(MlirType target, bool forceable,
+                                 MlirAttribute layer) {
+  auto baseType = dyn_cast<FIRRTLBaseType>(unwrap(target));
+  assert(baseType && "target must be base type");
+  auto layerAttr = dyn_cast<SymbolRefAttr>(unwrap(layer));
+  assert(layerAttr && "layer must be symbol ref attribute");
+
+  return wrap(RefType::get(baseType, forceable, layerAttr));
+}
+
 bool firrtlTypeIsAAnyRef(MlirType type) {
   return isa<AnyRefType>(unwrap(type));
 }

--- a/test/CAPI/firrtl.c
+++ b/test/CAPI/firrtl.c
@@ -241,6 +241,8 @@ void testTypeDiscriminantsAndQueries(MlirContext ctx) {
   MlirType cls = firrtlTypeGetClass(
       ctx, mlirFlatSymbolRefAttrGet(ctx, mlirStringRefCreateFromCString("cls")),
       ARRAY_SIZE(classElements), classElements);
+  MlirAttribute layer =
+      mlirFlatSymbolRefAttrGet(ctx, mlirStringRefCreateFromCString("layer"));
 
   assert(firrtlTypeIsConst(
       firrtlTypeGetConstType(firrtlTypeGetUInt(ctx, 32), true)));
@@ -257,6 +259,8 @@ void testTypeDiscriminantsAndQueries(MlirContext ctx) {
   assert(firrtlTypeIsABundle(bundle));
   assert(firrtlTypeIsAOpenBundle(openBundle));
   assert(firrtlTypeIsARef(firrtlTypeGetRef(firrtlTypeGetClock(ctx), false)));
+  assert(firrtlTypeIsARef(
+      firrtlTypeGetColoredRef(firrtlTypeGetClock(ctx), false, layer)));
   assert(firrtlTypeIsAAnyRef(firrtlTypeGetAnyRef(ctx)));
   assert(firrtlTypeIsAInteger(firrtlTypeGetInteger(ctx)));
   assert(firrtlTypeIsADouble(firrtlTypeGetDouble(ctx)));
@@ -281,6 +285,8 @@ void testTypeDiscriminantsAndQueries(MlirContext ctx) {
   assert(!firrtlTypeIsARef(firrtlTypeGetAnyRef(ctx)));
   assert(
       !firrtlTypeIsAAnyRef(firrtlTypeGetRef(firrtlTypeGetClock(ctx), false)));
+  assert(!firrtlTypeIsAAnyRef(
+      firrtlTypeGetColoredRef(firrtlTypeGetClock(ctx), false, layer)));
   assert(!firrtlTypeIsAInteger(firrtlTypeGetDouble(ctx)));
   assert(!firrtlTypeIsADouble(firrtlTypeGetString(ctx)));
   assert(!firrtlTypeIsAString(firrtlTypeGetBoolean(ctx)));


### PR DESCRIPTION
Update `firrtlTypeGetRef` to accept a `layer` attribute. This takes over #8093.