### PR TITLE
[Moore] Add from_builtin_int op

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -828,6 +828,24 @@ def ToBuiltinIntOp : MooreOp<"to_builtin_int", [Pure,
   }];
 }
 
+def FromBuiltinIntOp : MooreOp<"from_builtin_int", [Pure,
+  TypesMatchWith<"result is builtin integer matching input type",
+    "input", "result", [{
+    moore::IntType::get($_self.getContext(),
+      cast<IntegerType>($_self).getIntOrFloatBitWidth(),
+        Domain::TwoValued)
+  }]>
+]> {  let summary = "Convert a builtin `i<n>` to a `!moore.i<n>`";
+  let description = [{
+    Casts from a builtin integer to a two-valued Moore integer.
+  }];
+  let arguments = (ins AnyInteger:$input);
+  let results = (outs TwoValuedIntType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input)
+  }];
+}
+
 def TimeToLogicOp : MooreOp<"time_to_logic", [Pure]> {
   let summary = "Convert a time type to an integer number of femtoseconds";
   let arguments = (ins TimeType:$input);

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -135,6 +135,10 @@ moore.module @Expressions(
   in %d: !moore.l32,
   // CHECK-SAME: in [[X:%[^:]+]] : !moore.i1
   in %x: !moore.i1,
+  // CHECK-SAME: in [[BA:%[^:]+]] : i1
+  in %ba : i1,
+  // CHECK-SAME: in [[BB:%[^:]+]] : i32
+  in %bb : i32,
 
   // CHECK-SAME: in [[ARRAY1:%[^:]+]] : !moore.uarray<4 x i8>
   in %array1: !moore.uarray<4 x i8>,
@@ -199,6 +203,10 @@ moore.module @Expressions(
   moore.to_builtin_int %x : i1
   // CHECK: moore.to_builtin_int [[A]] : i32
   moore.to_builtin_int %a : i32
+  // CHECK: moore.from_builtin_int [[BA]] : i1
+  moore.from_builtin_int %ba : i1
+  // CHECK: moore.from_builtin_int [[BB]] : i32
+  moore.from_builtin_int %bb : i32
 
   // CHECK: moore.neg [[A]] : i32
   moore.neg %a : i32


### PR DESCRIPTION
Allows us to convert from builtin ints to Moore ints (useful when we have bits of IR like LTL ops that operate on builtin ints but still need to interface with wider parts of the Moore dialect)