### PR TITLE
[MooreToCore] Add NoOpConversion

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1607,11 +1607,7 @@ struct NoOpConversion : public OpConversionPattern<SourceOp> {
   LogicalResult
   matchAndRewrite(SourceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto type = typeConverter->convertType(op.getResult().getType());
-    if (type == adaptor.getInput().getType())
-      rewriter.replaceOp(op, adaptor.getInput());
-    else
-      return failure();
+    rewriter.replaceOp(op, adaptor.getInput());
     return success();
   }
 };


### PR DESCRIPTION
As suggested by @fabianschuiki on #9591, this adds a NoOpConversion for ops whose type verifiers ensure that they will always become a no-op (i.e. both input and output will be cast to equivalent builtin integer types)