### PR TITLE
[FIRRTL] Make UnknownValueOp CSE-able

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1451,6 +1451,7 @@ def IntegerShlOp : IntegerBinaryPrimOp<"integer.shl"> {
 }
 
 def UnknownValueOp : FIRRTLOp<"unknown", [
+  Pure,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
 ]> {
   let summary = "A property with an unknown value used to tie-off connections";
@@ -1461,7 +1462,7 @@ def UnknownValueOp : FIRRTLOp<"unknown", [
     This lowers to an `om::UnknownOp`.
   }];
   let arguments = (ins);
-  let results = (outs Res<PropertyType, "", [MemAlloc]>:$result);
+  let results = (outs PropertyType:$result);
   let assemblyFormat = "attr-dict `:` type($result)";
 }
 

--- a/test/Dialect/FIRRTL/cse.mlir
+++ b/test/Dialect/FIRRTL/cse.mlir
@@ -68,5 +68,16 @@ firrtl.module @Domains_Foo() {
   %2 = firrtl.domain.anon : !firrtl.domain of @ClockDomain
 }
 
+// UnknownValueOp should CSE
+// CHECK-LABEL: firrtl.module @UnknownValue(
+firrtl.module @UnknownValue(out %a: !firrtl.integer, out %b: !firrtl.integer) {
+  // CHECK: %0 = firrtl.unknown : !firrtl.integer
+  %0 = firrtl.unknown : !firrtl.integer
+  // CHECK-NEXT: firrtl.propassign %a, %0
+  firrtl.propassign %a, %0 : !firrtl.integer
+  // CHECK-NEXT: firrtl.propassign %b, %0
+  %1 = firrtl.unknown : !firrtl.integer
+  firrtl.propassign %b, %1 : !firrtl.integer
+}
 
 }


### PR DESCRIPTION
Add the Pure trait to UnknownValueOp to allow common subexpression
elimination. This operation has no side effects and produces the same
result for the same type, making it safe to CSE.

Add a test case to verify that duplicate UnknownValueOp instances are
correctly eliminated by the CSE pass.

h/t @dtzSiFive

AI-assisted-by: Augment (Claude Sonnet 4.5)
