### PR TITLE
[FIRRTL] Add asReset cast support to InferWidths and InferResets

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1552,8 +1552,8 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       // Handle operations with a single result type that always has a
       // well-known width.
       .Case<LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp, EQPrimOp, NEQPrimOp,
-            AsClockPrimOp, AsAsyncResetPrimOp, AndRPrimOp, OrRPrimOp,
-            XorRPrimOp>([&](auto op) {
+            AsClockPrimOp, AsAsyncResetPrimOp, AsResetPrimOp, AndRPrimOp,
+            OrRPrimOp, XorRPrimOp>([&](auto op) {
         auto width = op.getType().getBitWidthOrSentinel();
         assert(width > 0 && "width should have been checked by verifier");
         setExpr(op.getResult(), solver.known(width));

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -219,6 +219,7 @@ firrtl.circuit "Foo" {
     %7 = firrtl.asUInt %3 : (!firrtl.asyncreset) -> !firrtl.uint<1>
     %8 = firrtl.asClock %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
     %9 = firrtl.asAsyncReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+    %10 = firrtl.asReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.reset
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_si3 = firrtl.constant 2 : !firrtl.sint<3>
     firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>


### PR DESCRIPTION
This is a mostly mechanical change to make sure the `asReset` cast op is handled properly during width and reset inference. Once resets have been inferred, we can replace `asReset` either with nothing if the reset turned out to be sync, or with an `asAsyncReset` cast if it turned out to be async.