### PR TITLE
[RTG] Add StringType and basic string ops

### DIFF
--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -183,6 +183,35 @@ def InterleaveSequencesOp : RTGOp<"interleave_sequences", [Pure]> {
   let hasFolder = 1;
 }
 
+//===- String Operations --------------------------------------------------===//
+
+def StringConcatOp : RTGOp<"string_concat", [Pure]> {
+  let summary = "concatenate strings";
+  let description = [{
+    This operation concatenates a variadic number of strings into a single
+    string. The operands are concatenated in order, with the first operand
+    becoming the most significant bits of the result.
+  }];
+
+  let arguments = (ins Variadic<StringType>:$strings);
+  let results = (outs StringType:$result);
+
+  let assemblyFormat = "$strings attr-dict";
+
+  let hasFolder = 1;
+}
+
+def IntFormatOp : RTGOp<"int_format", [Pure]> {
+  let summary = "format an integer as a string";
+
+  let arguments = (ins Index:$value);
+  let results = (outs StringType:$result);
+
+  let assemblyFormat = "$value attr-dict";
+  
+  let hasFolder = 1;
+}
+
 //===- Label Operations ---------------------------------------------------===//
 
 class LabelDeclBase<string mnemonic,

--- a/include/circt/Dialect/RTG/IR/RTGTypes.td
+++ b/include/circt/Dialect/RTG/IR/RTGTypes.td
@@ -163,6 +163,13 @@ def TupleType : RTGTypeDef<"Tuple"> {
   let assemblyFormat = "(`<` $fieldTypes^ `>`)?";
 }
 
+def StringType : RTGTypeDef<"String"> {
+  let summary = "a string type";
+
+  let mnemonic = "string";
+  let assemblyFormat = "";
+}
+
 //===----------------------------------------------------------------------===//
 // Types for ISA targets
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/RTG/IR/RTGVisitors.h
+++ b/include/circt/Dialect/RTG/IR/RTGVisitors.h
@@ -65,6 +65,8 @@ public:
             MemoryBlockDeclareOp,
             // Data segment ops
             SpaceOp, StringDataOp, SegmentOp,
+            // String ops
+            StringConcatOp, IntFormatOp,
             // Misc ops
             CommentOp, ConstraintOp>([&](auto expr) -> ResultType {
           return thisCast->visitOp(expr, args...);
@@ -149,6 +151,8 @@ public:
   HANDLE(SpaceOp, Unhandled);
   HANDLE(StringDataOp, Unhandled);
   HANDLE(SegmentOp, Unhandled);
+  HANDLE(StringConcatOp, Unhandled);
+  HANDLE(IntFormatOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Dialect/RTG/IR/RTGOps.cpp
+++ b/lib/Dialect/RTG/IR/RTGOps.cpp
@@ -965,6 +965,37 @@ OpFoldResult LabelDeclOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// StringConcatOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult StringConcatOp::fold(FoldAdaptor adaptor) {
+  SmallString<32> result;
+  for (auto attr : adaptor.getStrings()) {
+    auto stringAttr = dyn_cast_or_null<StringAttr>(attr);
+    if (!stringAttr)
+      return {};
+
+    result += stringAttr.getValue();
+  }
+
+  return StringAttr::get(result, StringType::get(getContext()));
+}
+
+//===----------------------------------------------------------------------===//
+// IntFormatOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult IntFormatOp::fold(FoldAdaptor adaptor) {
+  auto intAttr = dyn_cast_or_null<IntegerAttr>(adaptor.getValue());
+  if (!intAttr)
+    return {};
+  if (!intAttr.getType().isIndex())
+    return {};
+  return StringAttr::get(Twine(intAttr.getValue().getZExtValue()),
+                         StringType::get(getContext()));
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -294,3 +294,18 @@ rtg.test @testConstraints() {
   %0 = index.bool.constant 1
   rtg.constraint %0
 }
+
+// CHECK-LABEL: rtg.test @strings
+rtg.test @strings() {
+  %1 = rtg.constant 23 : index
+  // CHECK: [[V3:%.+]] = rtg.int_format {{%.+}}
+  rtg.int_format %1
+
+  // CHECK-NEXT: [[V0:%.+]] = rtg.constant "hello" : !rtg.string
+  %0 = rtg.constant "hello" : !rtg.string
+  // CHECK-NEXT: rtg.string_concat [[V0]], [[V0]]
+  %5 = rtg.string_concat %0, %0
+
+  // CHECK-NEXT: rtg.string_concat
+  rtg.string_concat
+}

--- a/test/Dialect/RTG/IR/canonicalization.mlir
+++ b/test/Dialect/RTG/IR/canonicalization.mlir
@@ -1,6 +1,7 @@
 // RUN: circt-opt --canonicalize %s | FileCheck %s
 
 func.func @dummy(%arg0: !rtg.isa.label) -> () {return}
+func.func @dummy1(%arg0: !rtg.string) -> () {return}
 
 // CHECK-LABEL: @interleaveSequences
 rtg.test @interleaveSequences(seq0 = %seq0: !rtg.randomized_sequence) {
@@ -43,4 +44,25 @@ rtg.test @constraints() {
   // CHECK-NOT: rtg.constraint
   %true = rtg.constant true
   rtg.constraint %true
+}
+
+// CHECK-LABEL: rtg.test @strings
+rtg.test @strings() {
+  // CHECK-NEXT: [[V2:%.+]] = rtg.constant "" : !rtg.string
+  // CHECK-NEXT: [[V1:%.+]] = rtg.constant "23" : !rtg.string
+  // CHECK-NEXT: [[V0:%.+]] = rtg.constant "hellohello" : !rtg.string
+
+  %0 = rtg.constant "hello" : !rtg.string
+  %1 = rtg.string_concat %0, %0
+  // CHECK-NEXT: func.call @dummy1([[V0]])
+  func.call @dummy1(%1) : (!rtg.string) -> ()
+
+  %2 = rtg.constant 23 : index
+  %3 = rtg.int_format %2
+  // CHECK-NEXT: func.call @dummy1([[V1]])
+  func.call @dummy1(%3) : (!rtg.string) -> ()
+  
+  %4 = rtg.string_concat
+  // CHECK-NEXT: func.call @dummy1([[V2]])
+  func.call @dummy1(%4) : (!rtg.string) -> ()
 }


### PR DESCRIPTION
Currently comments and error messages embedded into the final assembly can only be constant strings, i.e., no integers or other values represented in the RTG meta-programming dialect can be embedded. The goal is to allow this by having string typed values and formatting ops.