### PR TITLE
[ImportVerilog] Allow $past with non-boolean bitvecs

### DIFF
--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -387,16 +387,6 @@ Value Context::convertAssertionCallExpression(
                            << subroutine.name << "`";
       return {};
     }
-    if (subroutine.name == "$past") {
-      // For now, catch unsupported non-i1 $past case before we try and cast to
-      // a bool and get an unhelpful error
-      if (auto ty = dyn_cast<moore::IntType>(value.getType());
-          !ty || ty.getBitSize() != 1) {
-        mlir::emitError(loc, "$past is currently only supported for 1-wide "
-                             "bitvectors");
-        return {};
-      }
-    }
     // If the value is four-valued, we need to map it to two-valued before we
     // cast it to a builtin int
     if (valTy.getDomain() == Domain::FourValued) {

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -366,9 +366,11 @@ endfunction
 // CHECK-LABEL: moore.module @SampleValueBuiltins(
 // CHECK-SAME: in [[CLK:%.+]] : !moore.l1
 module SampleValueBuiltins #() (
-    input clk_i
+    input clk_i,
+    input [7:0] data_i
 );
   // CHECK: [[CLKWIRE:%.+]] = moore.net name "clk_i" wire : <l1>
+  // CHECK: [[DATAWIRE:%.+]] = moore.net name "data_i" wire : <l8>
   // CHECK: moore.procedure always {
   // CHECK-NEXT: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[C_INT:%.+]] = moore.logic_to_int [[C]] : l1
@@ -426,6 +428,17 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i1
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[C1]], [[PAST_LOGIC]] : l1 -> l1
   past_eq: assert property (@(posedge clk_i) clk_i == $past(clk_i));
+  // Test $past on wider bitvectors
+  // CHECK: moore.procedure always {
+  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D2:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D2_INT:%.+]] = moore.logic_to_int [[D2]] : l8
+  // CHECK-NEXT: [[DB:%.+]] = moore.to_builtin_int [[D2_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 1 : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[D1]], [[PAST_LOGIC]] : l8 -> l1
+  past_data: assert property (@(posedge clk_i) data_i == $past(data_i));
 
 endmodule
 

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -193,13 +193,6 @@ endfunction
 
 // -----
 module Foo;
-  logic [1:0] a;
-  // expected-error @below {{$past is currently only supported for 1-wide bitvectors}}
-  assert property ($past(a) == 2'b10);
-endmodule
-
-// -----
-module Foo;
   string b;
   // expected-error @below {{expected integer argument for system call `$past`}}
   assert property ($past(b));


### PR DESCRIPTION
Necessary infra has all been patched already so just a case of dropping the error check