### PR TITLE
[Moore] Add builtin for $urandom_range

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2377,6 +2377,25 @@ def UrandomBIOp : Builtin<"urandom"> {
   let assemblyFormat = "($seed^)? attr-dict";
 }
 
+def UrandomrangeBIOp : Builtin<"urandom_range"> {
+  let summary = "Generate a pseudo-random unsigned integer within provided range";
+  let description = [{
+    Corresponds to the `urandom_range()` system function. Returns a 32-bit 
+    pseudo-random integer. The minimum value is optional; when not provided, it 
+    is treated as 0. If the minimum value is provided and larger than the maximum 
+    value, the minimum value is treated as the maximum, aand vice versa.
+
+    See IEEE 1800-2023 $ 18.13.2 "$urandom_range()".
+  }];
+
+  let arguments = (ins
+    TwoValuedI32:$maxval,
+    Optional<TwoValuedI32>:$minval
+  );
+  let results = (outs TwoValuedI32:$result);
+  let assemblyFormat = "$maxval ($minval^)? attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Simulation Time Measurement Builtins
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2751,6 +2751,11 @@ Context::convertSystemCallArity1(const slang::ast::SystemSubroutine &subroutine,
                 [&]() -> Value {
                   return moore::RandomBIOp::create(builder, loc, value);
                 })
+          .Case("$urandom_range",
+                [&]() -> Value {
+                  return moore::UrandomrangeBIOp::create(builder, loc, value,
+                                                         nullptr);
+                })
           .Case("$realtobits",
                 [&]() -> Value {
                   return moore::RealtobitsBIOp::create(builder, loc, value);
@@ -2828,6 +2833,11 @@ Context::convertSystemCallArity2(const slang::ast::SystemSubroutine &subroutine,
                     return moore::QueuePushFrontOp::create(builder, loc, value1,
                                                            value2);
                   return {};
+                })
+          .Case("$urandom_range",
+                [&]() -> Value {
+                  return moore::UrandomrangeBIOp::create(builder, loc, value1,
+                                                         value2);
                 })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -285,6 +285,7 @@ function void MathBuiltins(int x, logic [41:0] y, real r);
 
 endfunction
 
+// IEEE 1800-2023 $ 18.3 "Random number system functions and methods"
 // CHECK-LABEL: func.func private @RandomBuiltins(
 // CHECK-SAME: [[X:%.+]]: !moore.i32
 function RandomBuiltins(int x);
@@ -300,6 +301,12 @@ function RandomBuiltins(int x);
   // CHECK: [[RAND1:%.+]] = moore.builtin.random [[X]]
   // CHECK-NEXT: call @dummyA([[RAND1]]) : (!moore.i32) -> ()
   dummyA($random(x));
+  // CHECK: [[URANDRANGE1:%.+]] = moore.builtin.urandom_range [[X]]
+  // CHECK-NEXT: call @dummyA([[URANDRANGE1]]) : (!moore.i32) -> ()
+  dummyA($urandom_range(x));
+  // CHECK: [[URANDRANGE2:%.+]] = moore.builtin.urandom_range [[X]] [[X]]
+  // CHECK-NEXT: call @dummyA([[URANDRANGE2]]) : (!moore.i32) -> ()
+  dummyA($urandom_range(x, x));
 endfunction
 
 // CHECK-LABEL: func.func private @TimeBuiltins(


### PR DESCRIPTION
Hi! It's my first time contributing to CIRCT, so please let me know if I've done something wrong.

I've added a Moore built-in operation for $urandom_range, inspired by https://github.com/llvm/circt/pull/8968.

I had some trouble in `builtins.sv`; I couldn't get the checking constructs to match with two arguments of the same type on the same line, and so I've called `$urandom_range(x, x)` rather than `$urandom_range(x, y)`.

I hope it's okay that I'm tagging you: @fabianschuiki @Scheremo 