### PR TITLE
[FIRRTL] Add missing #include

### DIFF
--- a/include/circt/Dialect/FIRRTL/LayerSet.h
+++ b/include/circt/Dialect/FIRRTL/LayerSet.h
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_FIRRTL_LAYERSET_H
 #define CIRCT_DIALECT_FIRRTL_LAYERSET_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinAttributes.h"
 
 namespace circt {


### PR DESCRIPTION
Fails to compile in strict headers mode because SmallSet/SymbolRefAttr
are not defined.

No functional change.
