### PR TITLE
[FIRRTL] Refactor LowerTypes to use linear-time port removal, NFC

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -858,7 +858,8 @@ static void eraseElementsAtIndices(SmallVectorImpl<T> &vec,
   // Copy any remaining elements after the last removal point.
   size_t remainingSize = vec.size() - readIndex;
   if (remainingSize > 0) {
-    std::move(vec.begin() + readIndex, vec.end(), vec.begin() + writeIndex);
+    if (writeIndex != readIndex)
+      std::move(vec.begin() + readIndex, vec.end(), vec.begin() + writeIndex);
     writeIndex += remainingSize;
   }
 


### PR DESCRIPTION
This commit fixes a performance issue in the LowerTypes pass where removing lowered ports had O(N^2) complexity due to repeated erasures from the middle of a vector during iteration.

There is similar function in FIRRTLOps.cpp that returns a copy of SmallVector so would be nice to clean up that usage as well using in-place version. 