### PR TITLE
[HW] Guard bitcast canonicalization against cyclic input (Fixes #9648)

### DIFF
--- a/test/circt-verilog/issue9648-ir-hw-timeout.sv
+++ b/test/circt-verilog/issue9648-ir-hw-timeout.sv
@@ -1,0 +1,14 @@
+// RUN: circt-verilog --ir-hw %s | FileCheck %s
+// REQUIRES: slang
+
+module M(output logic O);
+  typedef struct packed { logic a; logic b; } S;
+  S s;
+
+  always_comb s.b = 0;
+  assign O = s.a;
+
+  // CHECK-LABEL: hw.module @M(
+  // CHECK: hw.struct_inject
+  // CHECK: hw.output
+endmodule


### PR DESCRIPTION
## Summary
- prevent `hw.bitcast` canonicalization from composing through inputs that transitively depend on the current result, which avoids non-terminating rewrite behavior on cyclic aggregate-update IR
- add a `circt-verilog --ir-hw` regression test reproducing issue #9648 (packed struct partial update in `always_comb`)
- verify the original `circt-b8/bug.sv` reproducer now terminates with the built `circt-verilog`

## Testing
- `ninja -C build bin/circt-verilog`
- `./build/bin/llvm-lit test/circt-verilog/issue9648-ir-hw-timeout.sv -v`
- `/usr/bin/timeout 20s ./build/bin/circt-verilog --ir-hw circt-b8/bug.sv`