### PR TITLE
[Docs] Fixed small error in SVA representation of `$changed` in LTL documentation

### DIFF
--- a/docs/Dialects/LTL.md
+++ b/docs/Dialects/LTL.md
@@ -209,7 +209,7 @@ where the `logic_to_int` conversion is only necessary if `%cond` is 4-valued.
 - **`$stable(a)`**:
 ```mlir
 %1 = seq.compreg %a, %clock : i1
-%rose = comb.icmp bin eq %a, %1 : i1
+%stable = comb.icmp bin eq %a, %1 : i1
 ``` 
 
 - **`$changed(a)`**:


### PR DESCRIPTION
In particular, `%rose` was used for the output of `$changed` instead of `%changed`, probably because the SVA representations of `$rose` and `$changed` were written at the same time in [this PR](https://github.com/llvm/circt/pull/7131).