### PR TITLE
[FIRRTL][circt-reduce] Improve port reductions

### DIFF
--- a/test/Dialect/FIRRTL/Reduction/extmodule-port-pruner.mlir
+++ b/test/Dialect/FIRRTL/Reduction/extmodule-port-pruner.mlir
@@ -1,0 +1,34 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include extmodule-port-pruner | FileCheck %s
+
+// Test removing unused ports from an extmodule with instances
+firrtl.circuit "ExtmoduleWithInstances" {
+  // CHECK-LABEL: firrtl.module @ExtmoduleWithInstances
+  firrtl.module @ExtmoduleWithInstances() {
+    // CHECK: %ext_b = firrtl.instance ext @Ext
+    // CHECK-NOT: %ext_a
+    // CHECK-NOT: %ext_c
+    %ext_a, %ext_b, %ext_c = firrtl.instance ext @Ext(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    %w = firrtl.wire : !firrtl.uint<1>
+    firrtl.connect %w, %ext_b : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: firrtl.extmodule private @Ext
+  // CHECK-NOT: in a
+  // CHECK-SAME: out b
+  // CHECK-NOT: out c
+  firrtl.extmodule private @Ext(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+}
+
+// Uninstantiated extmodules have all ports removed
+firrtl.circuit "UninstantiatedExtmodule" {
+  firrtl.module @UninstantiatedExtmodule() {
+  }
+
+  // CHECK-LABEL: firrtl.extmodule private @UnusedExt
+  // CHECK-NOT: in a
+  // CHECK-NOT: out b
+  firrtl.extmodule private @UnusedExt(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+}
+

--- a/test/Dialect/FIRRTL/Reduction/module-port-pruner.mlir
+++ b/test/Dialect/FIRRTL/Reduction/module-port-pruner.mlir
@@ -1,0 +1,41 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include module-port-pruner | FileCheck %s
+
+// Test removing unused ports from a regular module with instances
+firrtl.circuit "ModuleWithInstances" {
+  // CHECK-LABEL: firrtl.module @ModuleWithInstances
+  firrtl.module @ModuleWithInstances() {
+    // CHECK: %sub_b = firrtl.instance sub @Sub
+    // CHECK-NOT: %sub_a
+    // CHECK-NOT: %sub_c
+    %sub_a, %sub_b, %sub_c = firrtl.instance sub @Sub(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    %w = firrtl.wire : !firrtl.uint<1>
+    firrtl.connect %w, %sub_b : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: firrtl.module private @Sub
+  // CHECK-NOT: in %a
+  // CHECK-SAME: out %b
+  // CHECK-NOT: out %c
+  firrtl.module private @Sub(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+    %invalid = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.connect %b, %invalid : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %c, %invalid : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}
+
+// Test removing unused input ports from an uninstantiated module
+firrtl.circuit "UninstantiatedModule" {
+  firrtl.module @UninstantiatedModule() {
+  }
+
+  // CHECK-LABEL: firrtl.module private @Unused
+  // CHECK-NOT: in %a
+  // CHECK-SAME: out %b
+  firrtl.module private @Unused(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    %invalid = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.connect %b, %invalid : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}
+

--- a/test/Dialect/FIRRTL/Reduction/root-extmodule-port-pruner.mlir
+++ b/test/Dialect/FIRRTL/Reduction/root-extmodule-port-pruner.mlir
@@ -1,0 +1,14 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include root-extmodule-port-pruner | FileCheck %s
+
+// Test removing all ports from the root extmodule
+// CHECK-LABEL: firrtl.circuit "RootExt"
+firrtl.circuit "RootExt" {
+  // CHECK-LABEL: firrtl.extmodule @RootExt()
+  // CHECK-NOT: in a
+  // CHECK-NOT: out b
+  // CHECK-NOT: in c
+  firrtl.extmodule @RootExt(in a: !firrtl.uint<8>, out b: !firrtl.uint<16>, in c: !firrtl.uint<1>)
+}
+


### PR DESCRIPTION
Add reductions to prune unused ports.  This will prune both module and
external module ports, including the main module when it frequently
becomes an external module.

AI-assisted-by: Augment (Claude Sonnet 4.5)
