### PR TITLE
[circt-verilog] bump Slang to 10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,7 +561,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG v9.1
+      GIT_TAG v10.0
       GIT_SHALLOW ON
     )
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1745,11 +1745,13 @@ module PortsTop;
   // CHECK: [[Y3:%.+]] = moore.read %y3
   // CHECK: [[V2:%.+]] = moore.extract_ref %z3 from 0
   // CHECK: [[V1:%.+]] = moore.extract_ref %z3 from 1
-  // CHECK: [[V0:%.+]] = moore.extract_ref %z3 from 2
-  // CHECK: [[V0_READ:%.+]] = moore.read [[V0]]
+  // CHECK: [[Z3_READ:%.+]] = moore.read %z3
+  // CHECK: [[C2_I32:%.+]] = moore.constant 2 : i32
+  // CHECK: [[V0_READ:%.+]] = moore.dyn_extract [[Z3_READ]] from [[C2_I32]]
   // CHECK: [[C1:%.+]] = moore.extract_ref %w3 from 0
-  // CHECK: [[C0:%.+]] = moore.extract_ref %w3 from 1
-  // CHECK: [[C0_READ:%.+]] = moore.read [[C0]]
+  // CHECK: [[W3_READ:%.+]] = moore.read %w3
+  // CHECK: [[C1_I32:%.+]] = moore.constant 1 : i32
+  // CHECK: [[C0_READ:%.+]] = moore.dyn_extract [[W3_READ]] from [[C1_I32]]
   // CHECK: [[V1_VALUE:%.+]], [[C1_VALUE:%.+]] = moore.instance "p3" @MultiPorts(
   // CHECK-SAME:   a0: [[X3]]: !moore.l1
   // CHECK-SAME:   a1: [[Y3]]: !moore.l1

--- a/test/circt-verilog/commandline.sv
+++ b/test/circt-verilog/commandline.sv
@@ -3,4 +3,4 @@
 // REQUIRES: slang
 
 // CHECK-HELP: OVERVIEW: Verilog and SystemVerilog frontend
-// CHECK-VERSION: slang version 9.
+// CHECK-VERSION: slang version 10.


### PR DESCRIPTION
Bumps to a later version of Slang (primarily so we can make use of https://github.com/MikePopoloski/slang/commit/673c7a70769907f7164b71b4458791d83a291490 to reuse Slang's LRM clock inference on assertions)