### PR TITLE
[MooreToCore] Add support for `$info`

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2365,6 +2365,9 @@ static LogicalResult convert(SeverityBIOp op, SeverityBIOp::Adaptor adaptor,
   case (Severity::Warning):
     severityString = "Warning: ";
     break;
+  case (Severity::Info):
+    severityString = "Info: ";
+    break;
   default:
     return failure();
   }

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1391,6 +1391,13 @@ func.func @SeverityToPrint() {
   %2 = moore.fmt.literal "Warning condition met!"
   moore.builtin.severity warning %2
 
+  // CHECK: [[MSG:%.*]] = sim.fmt.literal "Info condition met!"
+  // CHECK-NEXT: [[PFX:%.*]] = sim.fmt.literal "Info: "
+  // CHECK-NEXT: [[CONCAT:%.*]] = sim.fmt.concat ([[PFX]], [[MSG]])
+  // CHECK-NEXT: sim.proc.print [[CONCAT]]
+  %3 = moore.fmt.literal "Info condition met!"
+  moore.builtin.severity info %3
+
   return
 }
 


### PR DESCRIPTION
Implemented support in MooreToCore for the `$info` severity system task (IEEE 1800–2023 $20.10 "Severity system tasks"). All the infrastructure for this was already laid out by @Scheremo in [this PR](https://github.com/llvm/circt/pull/8936). I can't tell if there is a specific reason why `$info` was left out originally, but I couldn't find anything special about it in the specification 😅  

I've also added a test for this in `basic.mlir`.

I don't have commit access, so I'd appreciate help merging this! @Scheremo @fabianschuiki 