### PR TITLE
[MooreToCore] Add pattern for conversion of NegRealOp

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1491,6 +1491,16 @@ struct NegOpConversion : public OpConversionPattern<NegOp> {
   }
 };
 
+struct NegRealOpConversion : public OpConversionPattern<NegRealOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(NegRealOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<arith::NegFOp>(op, adaptor.getInput());
+    return success();
+  }
+};
+
 template <typename SourceOp, typename TargetOp>
 struct BinaryOpConversion : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
@@ -2803,6 +2813,9 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     BinaryOpConversion<AndOp, comb::AndOp>,
     BinaryOpConversion<OrOp, comb::OrOp>,
     BinaryOpConversion<XorOp, comb::XorOp>,
+
+    // Patterns for unary real operations.
+    NegRealOpConversion,
 
     // Patterns for binary real operations.
     BinaryRealOpConversion<AddRealOp, arith::AddFOp>,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -759,6 +759,14 @@ func.func @CmpReal(%arg0: !moore.f32, %arg1: !moore.f32) {
   return
 }
 
+// CHECK-LABEL: func.func @UnaryRealOps
+func.func @UnaryRealOps(%arg0: !moore.f32) {
+  // CHECK: arith.negf %arg0 : f32
+  moore.fneg %arg0 : f32
+
+  return
+}
+
 // CHECK-LABEL: func.func @BinaryRealOps
 func.func @BinaryRealOps(%arg0: !moore.f32, %arg1: !moore.f32) {
   // CHECK: arith.addf %arg0, %arg1 : f32


### PR DESCRIPTION
Adds a pattern to MooreToCore converting `moore.fneg` directly to `arith.negf`.