### PR TITLE
[Arc] Add dialect documentation

### DIFF
--- a/docs/Dialects/Arc.md
+++ b/docs/Dialects/Arc.md
@@ -1,0 +1,28 @@
+# Arc Dialect
+
+This dialect provides operations and types to represent state transfer functions in a circuit, enabling efficient scheduling of operations for simulation.
+
+[TOC]
+
+
+## Rationale
+
+The main goal of the Arc dialect is to provide an intermediate representation of hardware designs that is optimized for simulation.
+It transforms hardware descriptions from the HW, Seq, and Comb dialects into a form where all module hierarchies have been flattened, combinational logic is represented as callable "arcs" (state transfer functions), and sequential elements are modeled explicitly.
+
+The Arc dialect is used by the *arcilator* simulation tool, which compiles Arc IR to a binary object via LLVM for fast simulation.
+
+
+## Types
+
+[include "Dialects/ArcTypes.md"]
+
+
+## Operations
+
+[include "Dialects/ArcOps.md"]
+
+
+## Passes
+
+[include "ArcPasses.md"]

--- a/include/circt/Dialect/Arc/ArcDialect.td
+++ b/include/circt/Dialect/Arc/ArcDialect.td
@@ -9,6 +9,8 @@
 #ifndef CIRCT_DIALECT_ARC_ARCDIALECT_TD
 #define CIRCT_DIALECT_ARC_ARCDIALECT_TD
 
+include "mlir/IR/DialectBase.td"
+
 def ArcDialect : Dialect {
   let name = "arc";
   let summary = "Canonical representation of state transfer in a circuit";

--- a/include/circt/Dialect/Arc/CMakeLists.txt
+++ b/include/circt/Dialect/Arc/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect(Arc arc)
-add_circt_dialect_doc(Arc arc)
+add_circt_doc(Arc Dialects/ArcOps -gen-op-doc)
+add_circt_doc(ArcTypes Dialects/ArcTypes -gen-typedef-doc -dialect arc)
 
 set(LLVM_TARGET_DEFINITIONS ArcPasses.td)
 mlir_tablegen(ArcPasses.h.inc -gen-pass-decls)


### PR DESCRIPTION
Add a handwritten documentation file for the Arc dialect in docs/Dialects/ following the pattern used by Debug and Moore dialects.

Update CMakeLists.txt to generate separate ArcOps.md and ArcTypes.md files that are included by the main documentation. Add the missing DialectBase.td include to ArcDialect.td to allow ArcTypes.td to be processed independently for documentation generation.