### PR TITLE
Add LLVM subprojects to .gitignore to speed up LLM context indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ lit.site.cfg.py
 
 # LLVM subprojects not needed for CIRCT
 # NOTE: This is not necessary as they are in a submodule, but this helps
-#       optimize LLM context indexing
+#       optimize LLM context indexing.
 /llvm/bolt
 /llvm/clang-tools-extra
 /llvm/compiler-rt


### PR DESCRIPTION
Add exclusions for LLVM subprojects unrelated to CIRCT to improve LLM context indexing performance (for Augment, this provides 40% reduction 162 sec -> 96 sec). While these files are already in a submodule, explicitly ignoring them helps optimize the context engine's file scanning.

Currently, all LLVM subprojects except llvm/clang, llvm/mlir, llvm/llvm, and llvm/cmake are excluded. (clang may not be necessary but thought maybe LLM becomes better at C++ if clang is in context)

Unfortunately, there is no standard way to specify exclusions for LLM tools (e.g., .geminiignore, .augmentignore, .cursorignore), and .gitignore is generally respected by most tools. This may be considered an unconventional or abusive usage of .gitignore, as it's being used for tooling optimization rather than version control purposes. However, since there is no functional impact on Git's behavior, I think the practical benefits outweigh this concern.