### PR TITLE
[FIRRTL][Reduce] Fix module-port-pruner crash with probe ports

### DIFF
--- a/test/Dialect/FIRRTL/Reduction/module-port-pruner-probe.mlir
+++ b/test/Dialect/FIRRTL/Reduction/module-port-pruner-probe.mlir
@@ -1,0 +1,31 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include module-port-pruner | FileCheck %s
+
+// Test removing probe ports that are used by ref.send and ref.define operations.
+// This tests the fix for a crash where operations using port arguments were not
+// properly erased before removing the ports.
+firrtl.circuit "ProbePortRemoval" {
+  // CHECK-LABEL: firrtl.module private @Bar
+  // CHECK-NOT: in %a
+  // CHECK-NOT: out %b
+  // CHECK-NOT: out %c
+  // CHECK-SAME: {
+  firrtl.module private @Bar(
+    in %a: !firrtl.uint<65>,
+    out %b: !firrtl.probe<uint<65>>,
+    out %c: !firrtl.rwprobe<uint<65>>
+  ) {
+    // CHECK: %wire = firrtl.wire sym @sym
+    // CHECK-NOT: firrtl.ref.send
+    // CHECK-NOT: firrtl.ref.define
+    // CHECK-NOT: firrtl.ref.rwprobe
+    %wire = firrtl.wire sym @sym : !firrtl.uint<65>
+    %0 = firrtl.ref.send %a : !firrtl.uint<65>
+    firrtl.ref.define %b, %0 : !firrtl.probe<uint<65>>
+    %1 = firrtl.ref.rwprobe <@Bar::@sym> : !firrtl.rwprobe<uint<65>>
+    firrtl.ref.define %c, %1 : !firrtl.rwprobe<uint<65>>
+  }
+  firrtl.extmodule @ProbePortRemoval()
+}
+


### PR DESCRIPTION
The module-port-pruner reduction pattern was crashing when trying to
remove ports that were used by operations like firrtl.ref.send, which
were themselves used by other operations like firrtl.ref.define.

The issue was that the code was directly erasing operations that used
the port arguments without first recursively erasing their users. This
caused the 'operation destroyed but still has uses' error.

The fix uses the reduce::pruneUnusedOps utility function which properly
handles recursive erasure of operations and their use-def chains.

Added a test case that reproduces the crash scenario with probe ports
and verifies the fix works correctly.

Fixes #9689.

AI-assisted-by: Augment (Claude Sonnet 4.5)
