### PR TITLE
[FIRRTL][LayerSink] Support InstanceChoice

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LayerSink.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LayerSink.cpp
@@ -347,8 +347,7 @@ void DemandInfo::updateConnects(WorkStack &work, Operation *op, Demand demand) {
           updateConnects(work, result, demand);
       })
       .Case<InstanceOp, InstanceChoiceOp>([&](auto op) {
-        auto dirs = op.getPortDirections();
-        for (auto [i, dir] : llvm::enumerate(dirs))
+        for (auto [i, dir] : llvm::enumerate(op.getPortDirections()))
           if (direction::get(dir) == Direction::In)
             updateConnects(work, op->getResult(i), demand);
       });

--- a/test/Dialect/FIRRTL/layer-sink.mlir
+++ b/test/Dialect/FIRRTL/layer-sink.mlir
@@ -861,11 +861,11 @@ firrtl.circuit "InstanceChoice" {
   // CHECK: firrtl.module public @InstanceChoice() {
   firrtl.module public @InstanceChoice() {
     // Effectful instance_choice cannot be moved.
-    // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK-NEXT:   %effectful_i, %effectful_o = firrtl.instance_choice effectful @Pure alternatives @Platform {
-    // CHECK-SAME:     @FPGA -> @Effectful
-    // CHECK-SAME:   } (in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
-    // CHECK-NEXT:   firrtl.matchingconnect %effectful_i, %c0_ui1 : !firrtl.uint<1>
+    // CHECK:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK-NEXT: %effectful_i, %effectful_o = firrtl.instance_choice effectful @Pure alternatives @Platform {
+    // CHECK-SAME:   @FPGA -> @Effectful
+    // CHECK-SAME: } (in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
+    // CHECK-NEXT: firrtl.matchingconnect %effectful_i, %c0_ui1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %effectful_i, %effectful_o = firrtl.instance_choice effectful @Pure alternatives @Platform {
       @FPGA -> @Effectful
@@ -873,14 +873,14 @@ firrtl.circuit "InstanceChoice" {
     firrtl.matchingconnect %effectful_i, %c0_ui1 : !firrtl.uint<1>
 
     // Pure instance_choice can be sunk into layerblock.
-    // CHECK:   firrtl.layerblock @A {
-    // CHECK-NEXT:     %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK-NEXT:     %pure_i, %pure_o = firrtl.instance_choice pure @Pure alternatives @Platform {
-    // CHECK-SAME:       @FPGA -> @PureFPGA
-    // CHECK-SAME:     } (in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
-    // CHECK-NEXT:     firrtl.matchingconnect %pure_i, %c0_ui1_0 : !firrtl.uint<1>
-    // CHECK-NEXT:     "unknown"(%pure_o) : (!firrtl.uint<1>) -> ()
-    // CHECK-NEXT:   }
+    // CHECK:      firrtl.layerblock @A {
+    // CHECK-NEXT:   %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK-NEXT:   %pure_i, %pure_o = firrtl.instance_choice pure @Pure alternatives @Platform {
+    // CHECK-SAME:     @FPGA -> @PureFPGA
+    // CHECK-SAME:   } (in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
+    // CHECK-NEXT:   firrtl.matchingconnect %pure_i, %c0_ui1_0 : !firrtl.uint<1>
+    // CHECK-NEXT:   "unknown"(%pure_o) : (!firrtl.uint<1>) -> ()
+    // CHECK-NEXT: }
     %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
     %pure_i, %pure_o = firrtl.instance_choice pure @Pure alternatives @Platform {
       @FPGA -> @PureFPGA
@@ -890,7 +890,7 @@ firrtl.circuit "InstanceChoice" {
       "unknown"(%pure_o) : (!firrtl.uint<1>) -> ()
     }
 
-    // CHECK:   firrtl.layerblock @A {
+    // CHECK:      firrtl.layerblock @A {
     // CHECK-NEXT:     "unknown"(%effectful_o) : (!firrtl.uint<1>) -> ()
     // CHECK-NEXT:   }
     // CHECK-NEXT: }


### PR DESCRIPTION
InstanceChoice support is mostly same to InstanceOp (instance choice is effectful if any of the target module is effectful).

It was necessary to update LayerSink as otherwise `DemandInfo::updateConnects` optimistically removes connections. 