### PR TITLE
[FIRRTL] Dedup: fix non-deduplicatable public module handling

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1859,6 +1859,8 @@ class DedupPass : public circt::firrtl::impl::DedupBase<DedupPass> {
         // If the current module is public, and the original is private, we
         // want to dedup the private module into the public one.
         if (!canRemoveModule(module)) {
+          // Record that this module's name is staying the same.
+          dedupMap[moduleName] = moduleName;
           // If both modules are public, then we can't dedup anything.
           if (!canRemoveModule(original))
             continue;


### PR DESCRIPTION
When two equivalent public modules cannot be deduplicated into each other, the pass was failing to record the module in the deduplication map. When a parent module looks up such a module when renaming its children, it would see a null attribute, and think that child was equal to any other unmapped child, which could cause parent modules to dedup when their children did not.  This change fixes the issue by making sure we record the self-mapping of non-deduplicatable modules before continuing to the next module.