### PR TITLE
[SCFToCalyx] Fix incorrect assert in setResultRegs for scf::IfOp

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -188,7 +188,7 @@ public:
   void setResultRegs(scf::IfOp op, calyx::RegisterOp reg, unsigned idx) {
     assert(resultRegs[op.getOperation()].count(idx) == 0 &&
            "A register was already registered for the given yield result.\n");
-    assert(idx < op->getNumOperands());
+    assert(idx < op->getNumResults());
     resultRegs[op.getOperation()][idx] = reg;
   }
 


### PR DESCRIPTION
Fixes #9720 

`setResultRegs` asserts `idx < op->getNumOperands()`, but `idx` is a result index from `ifOpRes.getResultNumber()`. `scf::IfOp` has one operand (the condition) and a variadic number of results, so the assert fires for any `scf::IfOp` with 2+ results.

Changed to `op->getNumResults()` to match the caller and the map it guards.
