### PR TITLE
[FIRRTL][SpecializeOption] Erase all options with default flag

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
@@ -92,7 +92,11 @@ struct SpecializeOptionPass
 
     bool analysisPreserved = numInstances == 0;
     circuit->walk([&](OptionOp optionOp) {
-      if (!selected.contains(optionOp.getSymNameAttr()))
+      // When selectDefaultInstanceChoice is true, all instance choices are
+      // specialized (either to a selected case or to the default), so we can
+      // erase all options. Otherwise, only erase options that were selected.
+      if (!selectDefaultInstanceChoice &&
+          !selected.contains(optionOp.getSymNameAttr()))
         return;
       optionOp->erase();
       analysisPreserved = false;

--- a/test/Dialect/FIRRTL/specialize-option.mlir
+++ b/test/Dialect/FIRRTL/specialize-option.mlir
@@ -19,6 +19,7 @@ firrtl.option @Performance {
   firrtl.option_case @Small
 }
 
+// DEFAULT-NOT: firrtl.option @NotSelected
 firrtl.option @NotSelected {
   firrtl.option_case @Fast
 }


### PR DESCRIPTION
When select-default-for-unspecified-instance-choice is true, all instance
choices are specialized (either to a selected case or to the default
target). Previously, only explicitly selected options were erased, leaving
unselected options in the IR even though all their uses had been
specialized away.

This commit restores the behavior where all options are erased when the
default flag is set, since all instance choices have been specialized and
no options remain in use. When the flag is false, the pass continues to
preserve unselected options as introduced in commit 5f68ca7b8.

This fixes an observed error where compiling designs with instance choices
that are default-specialized, LowerToHW would error out on the unsupported
firrtl.option operation.

AI-assisted-by: Augment (Claude Sonnet 4.5)
