### PR TITLE
[FIRRTL][InferResets] Only create reset ports for modules that need them

### DIFF
--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -1248,19 +1248,22 @@ firrtl.circuit "top" {
 
 // -----
 // Issue 9396
+// Modules without reset-less registers should not get reset ports added, even
+// when instantiated in multiple reset domains.
 firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Baz
   firrtl.module @Baz(in %reset: !firrtl.asyncreset [{class = "circt.FullResetAnnotation", resetType = "async"}]) {
     firrtl.instance bar @Bar()
-    // CHECK: firrtl.matchingconnect %bar_reset, %reset : !firrtl.asyncreset
+    // CHECK-NOT: firrtl.matchingconnect %bar_reset
   }
-  // CHECK-LABEL: firrtl.module private @Bar(in %reset: !firrtl.asyncreset)
+  // CHECK-LABEL: firrtl.module private @Bar()
+  // CHECK-NOT: in %reset
   firrtl.module private @Bar() {
   }
   // CHECK-LABEL: firrtl.module @Foo(in %reset: !firrtl.asyncreset
   firrtl.module @Foo(in %reset: !firrtl.asyncreset [{class = "circt.FullResetAnnotation", resetType = "async"}]) {
     firrtl.instance bar @Bar()
-    // CHECK: firrtl.matchingconnect %bar_reset, %reset : !firrtl.asyncreset
+    // CHECK-NOT: firrtl.matchingconnect %bar_reset
   }
 }
 


### PR DESCRIPTION
The InferResets pass was unconditionally creating reset ports on all
modules in a reset domain, even if they didn't contain any reset-less
registers. This caused issues in multi-top scenarios where a module is
instantiated in multiple places - the pass would create a port on the
module but fail to update all instances, leading to verification errors.

This patch modifies the pass to only create reset ports for modules that
actually need them. A module needs a reset port if it:
1. Contains reset-less registers (RegOp), OR
2. Instantiates a module that needs a reset port

The implementation adds a bottom-up analysis phase that determines which
modules need reset ports before creating them. This ensures that:
- Modules without reset-less registers don't get unnecessary ports
- All instances are correctly updated when ports are added
- Multi-top scenarios work correctly

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>
