### PR TITLE
[HW] HWVectorization Part 2: Mixed Permutations

### DIFF
--- a/test/Dialect/HW/vectorization.mlir
+++ b/test/Dialect/HW/vectorization.mlir
@@ -27,15 +27,56 @@ hw.module @reverse_endianess_vectorization(in %in : i4, out out : i4) {
   hw.output %rev : i4
 }
 
-// ---------- Mixed permutation: should NOT be vectorized ----------
-// CHECK-LABEL: hw.module @mixed_no_vectorization
-// CHECK:         comb.concat
-hw.module @mixed_no_vectorization(in %in : i4, out out : i4) {
+// ---------- Mixed permutation: bits [3,1:2,0] -> extract+concat chunks ----------
+//
+// Input concat (MSB->LSB): %in_0, %in_2, %in_1, %in_3
+//   out[3]=in[0], out[2]=in[2], out[1]=in[1], out[0]=in[3]
+//
+// Mix grouping (LSB->MSB):
+//   i=0: startBit=3, len=1  -> extract %in from 3 : i1
+//   i=1: startBit=1, len=2  -> extract %in from 1 : i2  (in[1] and in[2] are consecutive)
+//   i=3: startBit=0, len=1  -> extract %in from 0 : i1
+//
+// After reversing chunks for concat (MSB->LSB order):
+//   concat(extract[0:i1], extract[1:i2], extract[3:i1])
+
+// CHECK-LABEL: hw.module @mixed_vectorization(
+// CHECK-DAG: [[C0:%[0-9]+]] = comb.extract %in from 0 : (i4) -> i1
+// CHECK-DAG: [[C1:%[0-9]+]] = comb.extract %in from 1 : (i4) -> i2
+// CHECK-DAG: [[C3:%[0-9]+]] = comb.extract %in from 3 : (i4) -> i1
+// CHECK: comb.concat [[C0]], [[C1]], [[C3]] : i1, i2, i1
+hw.module @mixed_vectorization(in %in : i4, out out : i4) {
   %in_0 = comb.extract %in from 0 : (i4) -> i1
   %in_1 = comb.extract %in from 1 : (i4) -> i1
   %in_2 = comb.extract %in from 2 : (i4) -> i1
   %in_3 = comb.extract %in from 3 : (i4) -> i1
-  // Random permutation (0, 2, 1, 3)
+  // Permutation (MSB->LSB): out[3]=in[0], out[2]=in[2], out[1]=in[1], out[0]=in[3]
   %mix = comb.concat %in_0, %in_2, %in_1, %in_3 : i1, i1, i1, i1
   hw.output %mix : i4
+}
+
+// ---------- Negative Case: Bits from different sources ----------
+// CHECK-LABEL: hw.module @multi_source_no_vectorization
+// CHECK:         comb.concat
+hw.module @multi_source_no_vectorization(in %a : i2, in %b : i2, out out : i4) {
+  %a0 = comb.extract %a from 0 : (i2) -> i1
+  %a1 = comb.extract %a from 1 : (i2) -> i1
+  %b0 = comb.extract %b from 0 : (i2) -> i1
+  %b1 = comb.extract %b from 1 : (i2) -> i1
+  
+  // Mixing pieces of %a and %b. Should not be vectorized to a single source.
+  %mix = comb.concat %a1, %b1, %a0, %b0 : i1, i1, i1, i1
+  hw.output %mix : i4
+}
+
+// ---------- Negative Case: Duplicate bits ----------
+// CHECK-LABEL: hw.module @duplicate_bits_no_vectorization
+// CHECK:         comb.concat
+hw.module @duplicate_bits_no_vectorization(in %in : i4, out out : i4) {
+  %in_0 = comb.extract %in from 0 : (i4) -> i1
+  %in_1 = comb.extract %in from 1 : (i4) -> i1
+  
+  // It uses bit 0 and bit 1 twice. It is not a 1:1 permutation.
+  %dupe = comb.concat %in_1, %in_1, %in_0, %in_0 : i1, i1, i1, i1
+  hw.output %dupe : i4
 }


### PR DESCRIPTION
**Context:** This PR is the second part of a series of incremental patches for the HWVectorization pass, previously proposed in PR #9222. Following reviewer feedback, this patch builds upon the infrastructure established in Part 1 (already merged #9704).

This Part 2 introduces support for arbitrary bit-level permutations from a single source and implements a greedy chunking algorithm to minimize the number of generated hardware operations.

Supported transformations include:

### **Mixed Permutations:**

- **Pattern**: Bits are extracted from a single source in any order. The pass identifies contiguous sub-ranges (chunks) of source bits that remain consecutive in the output, even if the overall bus is shuffled.

- **Transformation**: Instead of creating a `comb.extract` for every single bit, the pass groups consecutive bits into wider `comb.extract` operations and then concatenates these "chunks" in the required order.

```MLIR
// Before: swap upper and lower nibbles
// out[7:4] = in[3:0], out[3:0] = in[7:4]
%in_0 = comb.extract %in from 0 : (i8) -> i1
%in_1 = comb.extract %in from 1 : (i8) -> i1
%in_2 = comb.extract %in from 2 : (i8) -> i1
%in_3 = comb.extract %in from 3 : (i8) -> i1
%in_4 = comb.extract %in from 4 : (i8) -> i1
%in_5 = comb.extract %in from 5 : (i8) -> i1
%in_6 = comb.extract %in from 6 : (i8) -> i1
%in_7 = comb.extract %in from 7 : (i8) -> i1
%mix = comb.concat %in_3, %in_2, %in_1, %in_0,
                   %in_7, %in_6, %in_5, %in_4 : i1, i1, i1, i1, i1, i1, i1, i1
hw.output %mix : i8

// After: 8 single-bit ops → 2 wide extracts + 1 concat
%lo = comb.extract %in from 0 : (i8) -> i4  // in[3:0] as a block
%hi = comb.extract %in from 4 : (i8) -> i4  // in[7:4] as a block
%out = comb.concat %lo, %hi : i4, i4
hw.output %out : i8
```