### PR TITLE
[Datapath] Bug Fix for Sign-Extension Logic when Lowering Partial Products to Booth Arrays (#9726)

### DIFF
--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -391,17 +391,13 @@ private:
         break;
     }
 
-    // Sign-extension Optimisation:
-    // Section 7.2.2 of "Application Specific Arithmetic" by Dinechin &
-    // Kumm Handle sign-extension and padding to full width s = encNeg
-    // (sign-bit) {s, s, s, s, s, pp} = {1, 1, 1, 1, 1, pp}
-    //                                + {0, 0, 0, 0,!s, '0}
-    // Applying this to every row we create an upper-triangle of 1s that
-    // can be optimised away since they will not affect the final sum.
-    // {!s3,  0,!s2,  0,!s1,  0}
-    // {  1,  1,  1,  1,  1, p1}
-    // {  1,  1,  1,   p2      }
-    // {  1,       p3          }
+    // Sign-extension:
+    // { s1, s1, s1, s1, s1, p1}
+    // { s2, s2, s2,   p2      }
+    // { s3,       p3          }
+    // TODO: optimize by only replicating the sign bit once using
+    // typical sign-extension trick - can be handled by separate
+    // canonicalization patterns
     for (unsigned i = 0; i < partialProducts.size(); ++i) {
       auto ppRow = partialProducts[i];
       auto encNeg = encNegs[i];

--- a/test/Conversion/DatapathToComb/datapath-to-comb.mlir
+++ b/test/Conversion/DatapathToComb/datapath-to-comb.mlir
@@ -179,8 +179,6 @@ hw.module @partial_product_booth_zext(in %a : i3, in %b : i3, out pp0 : i6, out 
   // FORCE-BOOTH-NEXT: %[[ROW0A:.*]] = comb.and %[[RB0]], %[[A]] : i4
   // FORCE-BOOTH-NEXT: %[[ROW0:.*]] = comb.or bin %[[ROW02A]], %[[ROW0A]] : i4
   // FORCE-BOOTH-NEXT: %[[NROW0:.*]] = comb.xor bin %[[ROW0]], %[[RB1]] : i4
-  // FORCE-BOOTH-NEXT: %[[SEXTB1:.*]] = comb.replicate %[[B1]] : (i1) -> i2
-  // FORCE-BOOTH-NEXT: %[[PP0:.*]] = comb.concat %[[SEXTB1]], %[[NROW0]] : i2, i4
   // FORCE-BOOTH-NEXT: %[[B2XORB1:.*]] = comb.xor bin %[[B2]], %[[B1]] : i1
   // FORCE-BOOTH-NEXT: %[[B2B1:.*]] = comb.and %[[B2]], %[[B1]] : i1
   // FORCE-BOOTH-NEXT: %[[RB2XORB1:.*]] = comb.replicate %[[B2XORB1]] : (i1) -> i4
@@ -189,6 +187,8 @@ hw.module @partial_product_booth_zext(in %a : i3, in %b : i3, out pp0 : i6, out 
   // FORCE-BOOTH-NEXT: %[[ROW1A:.*]] = comb.and %[[RB2XORB1]], %[[A]] : i4
   // FORCE-BOOTH-NEXT: %[[ROW1:.*]] = comb.or bin %[[ROW12A]], %[[ROW1A]] : i4
   // FORCE-BOOTH-NEXT: %[[PP1:.*]] = comb.concat %[[ROW1]], %false, %[[B1]] : i4, i1, i1
+  // FORCE-BOOTH-NEXT: %[[SEXTB1:.*]] = comb.replicate %[[B1]] : (i1) -> i2
+  // FORCE-BOOTH-NEXT: %[[PP0:.*]] = comb.concat %[[SEXTB1]], %[[NROW0]] : i2, i4
   // FORCE-BOOTH-NEXT: hw.output %[[PP0]], %[[PP1]], %c0_i6 : i6, i6, i6
   %c0_i3 = hw.constant 0 : i3
   %0 = comb.concat %c0_i3, %a : i3, i3


### PR DESCRIPTION
Bug fix for datapath-to-comb pass: #9726

## Problem: 
Sign-extension optimization, where we avoid replicating bits and replace them by ones, was incorrect when the result is to be extended beyond the sum of the input widths (e.g. sext(a*b)).

## Fix: 
revert to a simple sign-extension lowering.

## Consequences: 
Will cause a degradation in circt-synth performance.

## Planned Future Changes:
Insert a canonicalization pass in-between partial product and compressor logic that handles replicated sign-bits. Then we only implement this once reducing the risks of getting it wrong.
