### PR TITLE
[Arc] Fix extraneous semicolons in TraceEncoder; NFC

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/TraceEncoder.h
+++ b/include/circt/Dialect/Arc/Runtime/TraceEncoder.h
@@ -127,13 +127,13 @@ protected:
   virtual bool initialize(const ArcState *state) = 0;
 
   /// Called by the worker thread before entering the encode loop
-  virtual void startUpWorker(){};
+  virtual void startUpWorker() {}
   /// Encode the given trace buffer. Called by the worker thread.
-  virtual void encode(TraceBuffer &work){};
+  virtual void encode(TraceBuffer &work) {}
   /// Called by the worker thread after leaving the encode loop
-  virtual void windDownWorker(){};
+  virtual void windDownWorker() {}
   /// Finish trace encoding. Called by the simulation thread.
-  virtual void finalize(const ArcState *state){};
+  virtual void finalize(const ArcState *state) {}
 
   /// Metadata of the traced model
   const ArcRuntimeModelInfo *const modelInfo;
@@ -175,7 +175,7 @@ private:
 class DummyTraceEncoder final : public TraceEncoder {
 public:
   DummyTraceEncoder(const ArcRuntimeModelInfo *modelInfo, ArcState *state)
-      : TraceEncoder(modelInfo, state, 1, false){};
+      : TraceEncoder(modelInfo, state, 1, false) {}
 
   ~DummyTraceEncoder() override = default;
 


### PR DESCRIPTION
Remove extraneous semicolons after empty function body braces in virtual method default implementations.