### PR TITLE
[Arc] Add time operations for LLHD simulation support

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -611,6 +611,21 @@ def StateWriteOp : ArcOp<"state_write", [
   ];
 }
 
+def CurrentTimeOp : ArcOp<"current_time", [
+  MemoryEffects<[MemRead]>
+]> {
+  let summary = "Read the current simulation time";
+  let description = [{
+    Reads the current simulation time from the model's storage. The time is
+    represented as an `i64` value in femtoseconds.
+  }];
+  let arguments = (ins StorageType:$storage);
+  let results = (outs I64:$time);
+  let assemblyFormat = [{
+    $storage attr-dict `:` qualified(type($storage))
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Procedural Ops
 //===----------------------------------------------------------------------===//
@@ -717,6 +732,37 @@ def SimEmitValueOp : ArcOp<"sim.emit"> {
   }];
   let arguments = (ins StrAttr:$valueName, AnyType:$value);
   let assemblyFormat = [{ $valueName `,` $value attr-dict `:` type($value) }];
+}
+
+def SimGetTimeOp : ArcOp<"sim.get_time", [
+  MemoryEffects<[MemRead]>,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Gets the current simulation time of the model instance";
+  let description = [{
+    Gets the current simulation time of the given model instance. The time is
+    represented as an `i64` value in femtoseconds.
+  }];
+  let arguments = (ins SimModelInstance:$instance);
+  let results = (outs I64:$time);
+  let assemblyFormat = [{
+    $instance attr-dict `:` qualified(type($instance))
+  }];
+}
+
+def SimSetTimeOp : ArcOp<"sim.set_time", [
+  MemoryEffects<[MemWrite]>,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Sets the simulation time of the model instance";
+  let description = [{
+    Sets the simulation time of the given model instance. The time is
+    represented as an `i64` value in femtoseconds.
+  }];
+  let arguments = (ins SimModelInstance:$instance, I64:$time);
+  let assemblyFormat = [{
+    $instance `,` $time attr-dict `:` qualified(type($instance))
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -706,6 +706,40 @@ LogicalResult SimStepOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
+// SimGetTimeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+SimGetTimeOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *moduleOp = getSupportedModuleOp(
+      symbolTable, getOperation(),
+      llvm::cast<SimModelInstanceType>(getInstance().getType())
+          .getModel()
+          .getAttr());
+  if (!moduleOp)
+    return failure();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SimSetTimeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+SimSetTimeOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *moduleOp = getSupportedModuleOp(
+      symbolTable, getOperation(),
+      llvm::cast<SimModelInstanceType>(getInstance().getType())
+          .getModel()
+          .getAttr());
+  if (!moduleOp)
+    return failure();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ExecuteOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -6,12 +6,12 @@
 // TAPS-SAME:   traceTaps [#arc.trace_tap<i16, 0, ["foo", "bar"]>, #arc.trace_tap<i1, 2, ["baz"]>]
 arc.model @test io !hw.modty<input x : i1, output y : i1> {
 ^bb0(%arg0: !arc.storage):
-  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5783>):
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5799>):
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][0] : (!arc.storage<5783>) -> !arc.storage<1159>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][16] : (!arc.storage<5799>) -> !arc.storage<1159>
   // CHECK-NEXT: arc.initial {
   arc.initial {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5783> -> !arc.storage<1159>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][16] : !arc.storage<5799> -> !arc.storage<1159>
     %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i8>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i16>
@@ -31,7 +31,7 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
     // CHECK-NEXT: scf.execute_region {
     scf.execute_region {
       arc.state_read %0 : <i1>
-      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5783> -> !arc.storage<1159>
+      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][16] : !arc.storage<5799> -> !arc.storage<1159>
       // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][0] : !arc.storage<1159> -> !arc.state<i1>
       // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
       arc.state_read %1 : <i1>
@@ -44,10 +44,10 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][1168] : (!arc.storage<5783>) -> !arc.storage<4609>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][1184] : (!arc.storage<5799>) -> !arc.storage<4609>
   // CHECK-NEXT: arc.initial {
   arc.initial {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1168] : !arc.storage<5783> -> !arc.storage<4609>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1184] : !arc.storage<5799> -> !arc.storage<4609>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i1, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i8, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i16, i1>
@@ -71,18 +71,18 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage %arg0[5778] : (!arc.storage<5783>) -> !arc.storage<2>
+  // CHECK-NEXT: arc.alloc_storage %arg0[5794] : (!arc.storage<5799>) -> !arc.storage<2>
   // CHECK-NEXT: arc.initial {
   arc.initial {
     arc.root_input "x", %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.root_output "y", %arg0 : (!arc.storage) -> !arc.state<i1>
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5778] : !arc.storage<5783> -> !arc.storage<2>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5794] : !arc.storage<5799> -> !arc.storage<2>
     // CHECK-NEXT: arc.root_input "x", [[SUBPTR]] {offset = 0 : i32}
     // CHECK-NEXT: arc.root_output "y", [[SUBPTR]] {offset = 1 : i32}
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][5780] : (!arc.storage<5783>) -> !arc.storage<3>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][5796] : (!arc.storage<5799>) -> !arc.storage<3>
   // CHECK-NEXT: arc.initial {
   arc.initial {
     %cstCAFE = hw.constant 0xCAFE: i16
@@ -102,7 +102,7 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
 }
 
 // CHECK-LABEL: arc.model @StructPadding
-// CHECK-NEXT: !arc.storage<4>
+// CHECK-NEXT: !arc.storage<12>
 arc.model @StructPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // This !hw.struct is only 11 bits wide, but mapped to an !llvm.struct, each
@@ -111,7 +111,7 @@ arc.model @StructPadding io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @ArrayPadding
-// CHECK-NEXT: !arc.storage<4>
+// CHECK-NEXT: !arc.storage<12>
 arc.model @ArrayPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // This !hw.array is only 18 bits wide, but mapped to an !llvm.array, each

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -408,3 +408,22 @@ func.func @Execute(%arg0: i42) {
   }
   return
 }
+
+// CHECK-LABEL: func.func @CurrentTime
+func.func @CurrentTime(%arg0: !arc.storage<100>) {
+  // CHECK-NEXT: arc.current_time %arg0 : !arc.storage<100>
+  %0 = arc.current_time %arg0 : !arc.storage<100>
+  return
+}
+
+// CHECK-LABEL: func.func @SimGetSetTime
+func.func @SimGetSetTime() {
+  arc.sim.instantiate @TimeTestModule as %model {
+    // CHECK: arc.sim.get_time %{{.*}} : !arc.sim.instance<@TimeTestModule>
+    %0 = arc.sim.get_time %model : !arc.sim.instance<@TimeTestModule>
+    // CHECK: arc.sim.set_time %{{.*}}, %{{.*}} : !arc.sim.instance<@TimeTestModule>
+    arc.sim.set_time %model, %0 : !arc.sim.instance<@TimeTestModule>
+  }
+  return
+}
+hw.module @TimeTestModule() {}

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -17,21 +17,22 @@ module {
     // CHECK: %[[format_str_ptr:.*]] = llvm.mlir.addressof @[[format_str]] : !llvm.ptr
     // CHECK-DAG: %[[c:.*]] = llvm.mlir.constant(24 : i8)
     // CHECK-DAG: %[[zero:.*]] = llvm.mlir.constant(0 : i8)
-    // CHECK-DAG: %[[size:.*]] = llvm.mlir.constant(3 : i64)
+    // CHECK-DAG: %[[size:.*]] = llvm.mlir.constant(11 : i64)
     // CHECK-DAG: %[[state:.*]] = llvm.call @malloc(%[[size:.*]]) :
     // CHECK: "llvm.intr.memset"(%[[state]], %[[zero]], %[[size]]) <{isVolatile = false}>
     arc.sim.instantiate @id as %model {
-      // CHECK-NEXT: llvm.store %[[c]], %[[state]] : i8
+      // CHECK-NEXT: %[[i_ptr:.*]] = llvm.getelementptr %[[state]][8] : (!llvm.ptr) -> !llvm.ptr, i8
+      // CHECK-NEXT: llvm.store %[[c]], %[[i_ptr]] : i8
       arc.sim.set_input %model, "i" = %c : i8, !arc.sim.instance<@id>
 
-      // CHECK-NEXT: %[[j_ptr:.*]] = llvm.getelementptr %[[state]][1] : (!llvm.ptr) -> !llvm.ptr, i8
+      // CHECK-NEXT: %[[j_ptr:.*]] = llvm.getelementptr %[[state]][9] : (!llvm.ptr) -> !llvm.ptr, i8
       // CHECK-NEXT: llvm.store %[[c]], %[[j_ptr]] : i8
       arc.sim.set_input %model, "j" = %c : i8, !arc.sim.instance<@id>
 
       // CHECK-NEXT: llvm.call @id_eval(%[[state]])
       arc.sim.step %model : !arc.sim.instance<@id>
 
-      // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][2] : (!llvm.ptr) -> !llvm.ptr, i8
+      // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][10] : (!llvm.ptr) -> !llvm.ptr, i8
       // CHECK-NEXT: %[[result:.*]] = llvm.load %[[o_ptr]] : !llvm.ptr -> i8
       %result = arc.sim.get_port %model, "o" : i8, !arc.sim.instance<@id>
 

--- a/test/Dialect/Arc/sim-errors.mlir
+++ b/test/Dialect/Arc/sim-errors.mlir
@@ -123,3 +123,25 @@ func.func @set_port_not_input() {
     }
     return
 }
+
+// -----
+
+func.func @get_time_model_not_found() {
+    // expected-error @+1 {{model not found}}
+    arc.sim.instantiate @unknown as %model {
+        %t = arc.sim.get_time %model : !arc.sim.instance<@unknown>
+        arc.sim.emit "time", %t : i64
+    }
+    return
+}
+
+// -----
+
+func.func @set_time_model_not_found() {
+    // expected-error @+1 {{model not found}}
+    arc.sim.instantiate @unknown as %model {
+        %c0 = arith.constant 0 : i64
+        arc.sim.set_time %model, %c0 : !arc.sim.instance<@unknown>
+    }
+    return
+}


### PR DESCRIPTION
Add three new operations to support simulation time in the Arc dialect:

- `arc.current_time`: Reads the current simulation time from a model's storage. Returns an i64 value representing femtoseconds. This is used inside `arc.model` bodies to access the simulation time.

- `arc.sim.get_time`: Gets the simulation time from an instantiated model. Used with `!arc.sim.instance<@Model>` outside the model body.

- `arc.sim.set_time`: Sets the simulation time on an instantiated model. Used with `!arc.sim.instance<@Model>` outside the model body.

These operations are part of adding basic LLHD time support to Arcilator. The lowering of these operations to LLVM IR will be added in a follow-up commit.