### PR TITLE
[HW] HWVectorization Part 3: Structural Patterns

### DIFF
--- a/lib/Dialect/HW/Transforms/HWVectorization.cpp
+++ b/lib/Dialect/HW/Transforms/HWVectorization.cpp
@@ -115,10 +115,10 @@ public:
 
     // Phase 2: for each integer output, attempt vectorization strategies in
     // order of increasing complexity:
-    //   (a) Linear   – direct wire-through  → drop the concat entirely
-    //   (b) Reverse  – mirror permutation   → comb.reverse
-    //   (c) Mix      – arbitrary bijection  → extract + concat chunks
-    //   (d) Structural – isomorphic scalar cones → wide AND/OR/XOR/MUX
+    //   (a) Linear   – direct wire-through  -> drop the concat entirely
+    //   (b) Reverse  – mirror permutation   -> comb.reverse
+    //   (c) Mix      – arbitrary bijection  -> extract + concat chunks
+    //   (d) Structural – isomorphic scalar cones -> wide AND/OR/XOR/MUX
     for (Value oldOutputVal : outputOp->getOperands()) {
       auto type = dyn_cast<IntegerType>(oldOutputVal.getType());
       if (!type)
@@ -161,7 +161,8 @@ public:
 
       // 2. If it wasn't vectorized (or if it has multiple sources), try
       // Structural.
-      if (!transformed && canVectorizeStructurally(oldOutputVal)) {
+      if (!transformed && !hasCrossBitDependencies(oldOutputVal) &&
+          canVectorizeStructurally(oldOutputVal)) {
         rewriter.setInsertionPointAfterValue(oldOutputVal);
 
         unsigned width = cast<IntegerType>(oldOutputVal.getType()).getWidth();
@@ -189,126 +190,211 @@ private:
   llvm::DenseMap<Value, BitArray> bitArrays;
   hw::HWModuleOp module;
 
-  // Returns true if `output` can be replaced by a single wide operation.
+  /// Analyzes the logic cones of all bit lanes to detect illegal cross-bit
+  /// dependencies in O(bitWidth + N) time.
+  bool hasCrossBitDependencies(mlir::Value outputVal) {
+    unsigned bitWidth = cast<IntegerType>(outputVal.getType()).getWidth();
+
+    llvm::DenseSet<mlir::Value> visitedUnsafe; // Accumulate unsafe values.
+    llvm::SmallVector<mlir::Value> worklist;
+
+    for (unsigned i = 0; i < bitWidth; ++i) {
+      llvm::DenseSet<mlir::Value> visitedLocal;
+      mlir::Value bitSource = findBitSource(outputVal, i);
+      if (!bitSource)
+        continue;
+
+      worklist.push_back(bitSource);
+      while (!worklist.empty()) {
+        auto top = worklist.pop_back_val();
+        if (isSafeSharedValue(top))
+          continue; // don't add to the set.
+        if (!visitedLocal.insert(top).second)
+          continue; // Arriving multiple time in the same iteration is fine.
+        // If it's already visited, there is a depencency
+        if (!visitedUnsafe.insert(top).second)
+          return true;
+        if (auto *op = top.getDefiningOp()) {
+          for (auto operand : op->getOperands())
+            worklist.push_back(operand);
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Determines if a shared value is safe for vectorization. Only constants
+  /// and block arguments are safe to share between bit lanes. Any intermediate
+  /// operation is considered unsafe as it may introduce cross-lane
+  /// dependencies.
+  bool isSafeSharedValue(mlir::Value val) {
+    return val &&
+           (isa<BlockArgument>(val) || val.getDefiningOp<hw::ConstantOp>());
+  }
+
+  /// Checks if a logic cone is composed of structurally equivalent slices
+  /// that can be merged into a vector operation.
   ///
-  /// The check succeeds when every bit slice i of `output` is produced by a
-  /// subgraph that is isomorphic to the bit-0 subgraph up to a uniform
-  /// bit-index offset of i (see areSubgraphsEquivalent).
+  /// The check succeeds when every bit slice i of the output is produced by a
+  /// subgraph that is isomorphic to the bit-0 subgraph (slice0).
   bool canVectorizeStructurally(Value output) {
-    unsigned width = cast<IntegerType>(output.getType()).getWidth();
-
-    // A 1-bit value is already scalar; nothing to vectorize.
-    if (width <= 1)
+    unsigned bitWidth = cast<IntegerType>(output.getType()).getWidth();
+    if (bitWidth <= 1)
       return false;
 
-    Value slice0 = findBitSource(output, 0);
-    if (!slice0)
+    Value slice0Val = findBitSource(output, 0);
+    if (!slice0Val)
       return false;
 
-    // Compare each bit slice N against the base slice 0 to ensure isomorphism.
-    for (unsigned i = 1; i < width; ++i) {
-      Value sliceN = findBitSource(output, i);
-      if (!sliceN)
+    Value slice1Val = findBitSource(output, 1);
+    if (!slice1Val)
+      return false;
+
+    auto extract0 = slice0Val.getDefiningOp<comb::ExtractOp>();
+    auto extract1 = slice1Val.getDefiningOp<comb::ExtractOp>();
+
+    if (!extract0 || !extract1 || extract0.getInput() != extract1.getInput()) {
+      for (unsigned i = 1; i < bitWidth; ++i) {
+        Value sliceNVal = findBitSource(output, i);
+        if (!sliceNVal || !sliceNVal.getDefiningOp())
+          return false;
+        llvm::DenseMap<mlir::Value, mlir::Value> map;
+        if (!areSubgraphsEquivalent(slice0Val, sliceNVal, i, 1, map)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    int stride = (int)extract1.getLowBit() - (int)extract0.getLowBit();
+
+    for (unsigned i = 1; i < bitWidth; ++i) {
+      Value sliceNVal = findBitSource(output, i);
+      if (!sliceNVal || !sliceNVal.getDefiningOp())
         return false;
 
-      DenseMap<Value, Value> map;
-      if (!areSubgraphsEquivalent(slice0, sliceN, i, map))
+      llvm::DenseMap<mlir::Value, mlir::Value> map;
+      if (!areSubgraphsEquivalent(slice0Val, sliceNVal, i, stride, map)) {
         return false;
+      }
     }
     return true;
   }
 
-  /// Recursively checks whether subgraph `b` is isomorphic to subgraph `a`
-  /// under the assumption that all ExtractOp low-bit indices in `b` are
-  /// exactly `index` greater than those in `a`.
+  /// Recursively compares two subgraphs to determine if they are isomorphic
+  /// with respect to a constant bit-stride.
   ///
-  /// Shared control values (block arguments, constants) are treated as
-  /// identical across all bit lanes.
-  ///
-  /// `map` caches already-verified pairs (a → b) to avoid redundant traversal
-  /// and to handle DAGs (values with multiple uses) correctly.
-  bool areSubgraphsEquivalent(Value a, Value b, unsigned index,
-                              DenseMap<Value, Value> &map) {
+  /// It assumes that all ExtractOp low-bit indices in the second subgraph
+  /// are exactly (sliceIndex * stride) greater than those in the first.
+  /// Caches results in slice0ToNMap to handle DAGs efficiently.
+  bool areSubgraphsEquivalent(Value slice0Val, Value sliceNVal,
+                              unsigned sliceIndex, int stride,
+                              DenseMap<Value, Value> &slice0ToNMap) {
 
-    // If `a` was already mapped, verify it points to the same `b`.
-    if (map.count(a))
-      return map[a] == b;
+    if (slice0ToNMap.count(slice0Val))
+      return slice0ToNMap[slice0Val] == sliceNVal;
 
-    Operation *opA = a.getDefiningOp();
-    Operation *opB = b.getDefiningOp();
+    Operation *op0 = slice0Val.getDefiningOp();
+    Operation *opN = sliceNVal.getDefiningOp();
 
-    // Leaf case: ExtractOp – same source, low-bit shifted by `index`.
-    if (auto exA = dyn_cast_or_null<comb::ExtractOp>(opA)) {
-      auto exB = dyn_cast_or_null<comb::ExtractOp>(opB);
-      if (!exB || exA.getInput() != exB.getInput())
-        return false;
+    if (auto extract0 = dyn_cast_or_null<comb::ExtractOp>(op0)) {
+      auto extractN = dyn_cast_or_null<comb::ExtractOp>(opN);
 
-      // The bit index in slice N must be exactly `index` ahead of slice 0.
-      if (exB.getLowBit() != exA.getLowBit() + (int)index)
-        return false;
+      if (extractN && extract0.getInput() == extractN.getInput() &&
+          extractN.getLowBit() ==
+              static_cast<unsigned>(static_cast<int>(extract0.getLowBit()) +
+                                    static_cast<int>(sliceIndex) * stride)) {
+        slice0ToNMap[slice0Val] = sliceNVal;
+        return true;
+      }
+      return false;
+    }
 
-      map[a] = b;
+    if (slice0Val == sliceNVal && (mlir::isa<BlockArgument>(slice0Val) ||
+                                   mlir::isa<hw::ConstantOp>(op0))) {
+      slice0ToNMap[slice0Val] = sliceNVal;
       return true;
     }
 
-    // Leaf case: block arguments and constants are considered equivalent when
-    // they are the *exact same* SSA value (shared across all bit lanes, e.g.,
-    // a mux select signal).
-    if (!opA && !opB) {
-      map[a] = b;
-      return true;
-    }
-
-    // Interior node: both must be the same operation kind with the same arity.
-    if (!opA || !opB || opA->getName() != opB->getName() ||
-        opA->getNumOperands() != opB->getNumOperands())
+    if (!op0 || !opN || op0->getName() != opN->getName() ||
+        op0->getNumOperands() != opN->getNumOperands())
       return false;
 
-    // Recurse into all operand pairs.
-    for (unsigned i = 0; i < opA->getNumOperands(); ++i)
-      if (!areSubgraphsEquivalent(opA->getOperand(i), opB->getOperand(i), index,
-                                  map))
+    for (unsigned i = 0; i < op0->getNumOperands(); ++i) {
+      if (!areSubgraphsEquivalent(op0->getOperand(i), opN->getOperand(i),
+                                  sliceIndex, stride, slice0ToNMap))
         return false;
+    }
 
-    map[a] = b;
+    slice0ToNMap[slice0Val] = sliceNVal;
     return true;
   }
 
-  /// Traverses ConcatOps to locate the defining 1-bit Value for `bitIndex`
-  /// within `vectorVal`.
+  /// Traverses through ConcatOps and basic logic gates to locate the
+  /// original 1-bit source for a specific bit index.
   ///
-  /// Returns nullptr if the bit cannot be traced to a concrete 1-bit source
-  /// (e.g., the concat is not fully decomposed into 1-bit pieces).
+  /// Returns the 1-bit Value or nullptr if the bit cannot be traced back
+  /// to a concrete scalar source
   Value findBitSource(Value vectorVal, unsigned bitIndex) {
 
-    // A 1-bit block argument is its own source at index 0.
-    if (auto arg = dyn_cast<BlockArgument>(vectorVal))
-      return arg.getType().isInteger(1) && bitIndex == 0 ? arg : nullptr;
-
-    Operation *op = vectorVal.getDefiningOp();
-    if (!op)
-      return nullptr;
-
-    // Decompose ConcatOp: comb.concat lists operands MSB→LSB, so we walk
-    // them and track the cumulative bit offset from LSB upward.
-    if (auto concat = dyn_cast<comb::ConcatOp>(op)) {
-      // `cur` starts at the total width and decreases as we peel off operands.
-      unsigned cur = cast<IntegerType>(vectorVal.getType()).getWidth();
-      for (Value operand : concat.getInputs()) {
-        unsigned w = cast<IntegerType>(operand.getType()).getWidth();
-        cur -= w;
-        // `bitIndex` falls inside this operand's range [cur, cur+w].
-        if (bitIndex >= cur && bitIndex < cur + w)
-          return findBitSource(operand, bitIndex - cur);
-      }
+    if (auto blockArg = dyn_cast<BlockArgument>(vectorVal)) {
+      if (blockArg.getType().isInteger(1))
+        return blockArg;
       return nullptr;
     }
 
-    // Any other 1-bit result (AND, OR, XOR, MUX, …) is its own source at
-    // bit position 0.
-    if (op->getNumResults() == 1 && op->getResult(0).getType().isInteger(1) &&
-        bitIndex == 0)
+    Operation *op = vectorVal.getDefiningOp();
+
+    if (op->getNumResults() == 1 && op->getResult(0).getType().isInteger(1)) {
       return op->getResult(0);
+    }
+
+    if (auto concat = dyn_cast<comb::ConcatOp>(op)) {
+      unsigned currentBit = cast<IntegerType>(vectorVal.getType()).getWidth();
+      for (Value operand : concat.getInputs()) {
+        unsigned operandWidth = cast<IntegerType>(operand.getType()).getWidth();
+        currentBit -= operandWidth;
+        if (bitIndex >= currentBit && bitIndex < currentBit + operandWidth) {
+          return findBitSource(operand, bitIndex - currentBit);
+        }
+      }
+    } else if (auto orOp = dyn_cast<comb::OrOp>(op)) {
+      if (orOp.getNumOperands() != 2)
+        return nullptr;
+
+      Value lhs = orOp.getInputs()[0];
+      Value rhs = orOp.getInputs()[1];
+
+      if (auto constRhs =
+              dyn_cast_or_null<hw::ConstantOp>(rhs.getDefiningOp())) {
+        if (!constRhs.getValue()[bitIndex])
+          return findBitSource(lhs, bitIndex);
+      }
+
+      if (auto constLhs =
+              dyn_cast_or_null<hw::ConstantOp>(lhs.getDefiningOp())) {
+        if (!constLhs.getValue()[bitIndex])
+          return findBitSource(rhs, bitIndex);
+      }
+    } else if (auto andOp = dyn_cast<comb::AndOp>(op)) {
+      if (andOp.getNumOperands() != 2)
+        return nullptr;
+
+      Value lhs = andOp.getInputs()[0];
+      Value rhs = andOp.getInputs()[1];
+
+      if (auto constRhs =
+              dyn_cast_or_null<hw::ConstantOp>(rhs.getDefiningOp())) {
+        if (constRhs.getValue()[bitIndex])
+          return findBitSource(lhs, bitIndex);
+      }
+
+      if (auto constLhs =
+              dyn_cast_or_null<hw::ConstantOp>(lhs.getDefiningOp())) {
+        if (constLhs.getValue()[bitIndex])
+          return findBitSource(rhs, bitIndex);
+      }
+    }
 
     return nullptr;
   }
@@ -337,8 +423,7 @@ private:
 
     // Base case: a 1-bit constant or block argument (e.g., a shared selector)
     // must be broadcast to all `width` lanes via comb.replicate.
-    if (isa<BlockArgument>(scalarRoot) ||
-        isa<hw::ConstantOp>(scalarRoot.getDefiningOp())) {
+    if (isSafeSharedValue(scalarRoot)) {
       if (cast<IntegerType>(scalarRoot.getType()).getWidth() == 1)
         return comb::ReplicateOp::create(b, scalarRoot.getLoc(),
                                          b.getIntegerType(width), scalarRoot);
@@ -355,7 +440,7 @@ private:
     for (Value operand : op->getOperands()) {
       Value v = vectorizeSubgraph(b, operand, width, map);
       if (!v)
-        return nullptr;
+        return map[scalarRoot] = nullptr;
       ops.push_back(v);
     }
 
@@ -369,13 +454,9 @@ private:
       result = comb::OrOp::create(b, op->getLoc(), vecTy, ops);
     else if (isa<comb::XorOp>(op))
       result = comb::XorOp::create(b, op->getLoc(), vecTy, ops);
-    else if (isa<comb::MuxOp>(op)) {
-      Value sel = op->getOperand(0);
-      Value trueVal = vectorizeSubgraph(b, op->getOperand(1), width, map);
-      Value falseVal = vectorizeSubgraph(b, op->getOperand(2), width, map);
-      if (!trueVal || !falseVal)
-        return nullptr;
-      result = comb::MuxOp::create(b, op->getLoc(), sel, trueVal, falseVal);
+    else if (auto muxOp = dyn_cast<comb::MuxOp>(op)) {
+      Value sel = muxOp.getCond();
+      result = comb::MuxOp::create(b, muxOp.getLoc(), sel, ops[1], ops[2]);
     } else
       // Unsupported op kind; signal failure to the caller.
       return nullptr;

--- a/test/Dialect/HW/vectorization.mlir
+++ b/test/Dialect/HW/vectorization.mlir
@@ -2,9 +2,9 @@
 
 // ---------- Identity permutation ----------
 
-// CHECK-LABEL: hw.module @simple_vectorization(
+// CHECK-LABEL: hw.module @identity_permutation_vectorization(
 // CHECK: hw.output %in : i4
-hw.module @simple_vectorization(in %in : i4, out out : i4) {
+hw.module @identity_permutation_vectorization(in %in : i4, out out : i4) {
   %in_0 = comb.extract %in from 0 : (i4) -> i1
   %in_1 = comb.extract %in from 1 : (i4) -> i1
   %in_2 = comb.extract %in from 2 : (i4) -> i1
@@ -79,4 +79,328 @@ hw.module @duplicate_bits_no_vectorization(in %in : i4, out out : i4) {
   // It uses bit 0 and bit 1 twice. It is not a 1:1 permutation.
   %dupe = comb.concat %in_1, %in_1, %in_0, %in_0 : i1, i1, i1, i1
   hw.output %dupe : i4
+}
+
+// ---------- Structural XOR Vectorization ----------
+// Patterns: 4 independent XOR gates with bits from %a and %b.
+// Transformation: Should collapse into a single 4-bit XOR.
+
+// CHECK-LABEL: hw.module @structural_xor(
+// CHECK-NEXT:    [[RES:%.+]] = comb.xor %a, %b : i4
+// CHECK-NEXT:    hw.output [[RES]] : i4
+hw.module @structural_xor(in %a : i4, in %b : i4, out out : i4) {
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %b0 = comb.extract %b from 0 : (i4) -> i1
+  %b1 = comb.extract %b from 1 : (i4) -> i1
+  %b2 = comb.extract %b from 2 : (i4) -> i1
+  %b3 = comb.extract %b from 3 : (i4) -> i1
+
+  %xor0 = comb.xor %a0, %b0 : i1
+  %xor1 = comb.xor %a1, %b1 : i1
+  %xor2 = comb.xor %a2, %b2 : i1
+  %xor3 = comb.xor %a3, %b3 : i1
+
+  %out = comb.concat %xor3, %xor2, %xor1, %xor0 : i1, i1, i1, i1
+  hw.output %out : i4
+}
+
+// ---------- Structural Mux Vectorization (Shared Control) ----------
+// `sel` is a shared i1 BlockArgument; areSubgraphsEquivalent treats it as a
+// shared control signal (the !opA && !opB leaf case), so it is passed directly
+// to the wide comb.mux without replication.
+// CHECK-LABEL: hw.module @structural_mux(
+// CHECK-NEXT:    %[[RES:.+]] = comb.mux %sel, %a, %b : i4
+// CHECK-NEXT:    hw.output %[[RES]] : i4
+hw.module @structural_mux(in %a : i4, in %b : i4, in %sel : i1, out out : i4) {
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %b0 = comb.extract %b from 0 : (i4) -> i1
+  %b1 = comb.extract %b from 1 : (i4) -> i1
+  %b2 = comb.extract %b from 2 : (i4) -> i1
+  %b3 = comb.extract %b from 3 : (i4) -> i1
+
+  %m0 = comb.mux %sel, %a0, %b0 : i1
+  %m1 = comb.mux %sel, %a1, %b1 : i1
+  %m2 = comb.mux %sel, %a2, %b2 : i1
+  %m3 = comb.mux %sel, %a3, %b3 : i1
+
+  %out = comb.concat %m3, %m2, %m1, %m0 : i1, i1, i1, i1
+  hw.output %out : i4
+}
+
+// ---------- Structural AND with scalar enable ----------
+// Models: assign o[i] = a[i] & enable; for all i.
+// `enable` is a shared i1 BlockArgument used as a *data* operand (not a
+// selector), so vectorizeSubgraph broadcasts it via comb.replicate to match
+// the vector width before emitting the wide AND.
+//
+// CHECK-LABEL: hw.module @structural_and_enable(
+// CHECK-NEXT:    %[[REP:.+]] = comb.replicate %enable : (i1) -> i4
+// CHECK-NEXT:    %[[RES:.+]] = comb.and %a, %[[REP]] : i4
+// CHECK-NEXT:    hw.output %[[RES]] : i4
+hw.module @structural_and_enable(in %a : i4, in %enable : i1, out out : i4) {
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %and0 = comb.and %a0, %enable : i1
+  %and1 = comb.and %a1, %enable : i1
+  %and2 = comb.and %a2, %enable : i1
+  %and3 = comb.and %a3, %enable : i1
+
+  %out = comb.concat %and3, %and2, %and1, %and0 : i1, i1, i1, i1
+  hw.output %out : i4
+}
+
+// ---------- Structural AND with vector enable ----------
+// Models: assign o[i] = a[i] & enable[i]; for all i.
+// Both operands advance by 1 bit per lane, so the pattern is recognized
+// as a standard 2-operand structural AND between two i4 vectors.
+//
+// CHECK-LABEL: hw.module @structural_and_vector_enable(
+// CHECK-NEXT:    [[RES:%.+]] = comb.and %a, %enable : i4
+// CHECK-NEXT:    hw.output [[RES]] : i4
+hw.module @structural_and_vector_enable(in %a : i4, in %enable : i4, out out : i4) {
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %e0 = comb.extract %enable from 0 : (i4) -> i1
+  %e1 = comb.extract %enable from 1 : (i4) -> i1
+  %e2 = comb.extract %enable from 2 : (i4) -> i1
+  %e3 = comb.extract %enable from 3 : (i4) -> i1
+
+  %and0 = comb.and %a0, %e0 : i1
+  %and1 = comb.and %a1, %e1 : i1
+  %and2 = comb.and %a2, %e2 : i1
+  %and3 = comb.and %a3, %e3 : i1
+
+  %out = comb.concat %and3, %and2, %and1, %and0 : i1, i1, i1, i1
+  hw.output %out : i4
+}
+
+// ---------- Structural XOR with constant ----------
+// Models: assign out[i] = a[i] ^ 1'b1; for all i (bitwise NOT via XOR).
+// The constant %c1 is a shared hw.constant with no operands; the recursive
+// comparison in areSubgraphsEquivalent returns true for operand-less ops
+// with the same name, so all lanes are recognized as isomorphic.
+//
+// CHECK-LABEL: hw.module @structural_xor_constant(
+// CHECK:         [[RES:%.+]] = comb.xor %a
+// CHECK-NEXT:    hw.output [[RES]] : i4
+hw.module @structural_xor_constant(in %a : i4, out out : i4) {
+  %c1 = hw.constant 1 : i1
+
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %xor0 = comb.xor %a0, %c1 : i1
+  %xor1 = comb.xor %a1, %c1 : i1
+  %xor2 = comb.xor %a2, %c1 : i1
+  %xor3 = comb.xor %a3, %c1 : i1
+
+  %out = comb.concat %xor3, %xor2, %xor1, %xor0 : i1, i1, i1, i1
+  hw.output %out : i4
+}
+
+// ---------- Multiple output ports (XOR and AND) ----------
+// Models test_multiple_patterns from Verilog: two independent output vectors
+// sharing the same input, each vectorized independently.
+//
+// CHECK-LABEL: hw.module @structural_multiple_outputs(
+// CHECK-DAG:     [[XOR:%.+]] = comb.xor %a, %b : i4
+// CHECK-DAG:     [[AND:%.+]] = comb.and %a, %c : i4
+// CHECK:         hw.output [[XOR]], [[AND]] : i4, i4
+hw.module @structural_multiple_outputs(
+    in %a : i4, in %b : i4, in %c : i4,
+    out out_xor : i4, out out_and : i4) {
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %b0 = comb.extract %b from 0 : (i4) -> i1
+  %b1 = comb.extract %b from 1 : (i4) -> i1
+  %b2 = comb.extract %b from 2 : (i4) -> i1
+  %b3 = comb.extract %b from 3 : (i4) -> i1
+
+  %c0 = comb.extract %c from 0 : (i4) -> i1
+  %c1 = comb.extract %c from 1 : (i4) -> i1
+  %c2 = comb.extract %c from 2 : (i4) -> i1
+  %c3 = comb.extract %c from 3 : (i4) -> i1
+
+  %xor0 = comb.xor %a0, %b0 : i1
+  %xor1 = comb.xor %a1, %b1 : i1
+  %xor2 = comb.xor %a2, %b2 : i1
+  %xor3 = comb.xor %a3, %b3 : i1
+
+  %and0 = comb.and %a0, %c0 : i1
+  %and1 = comb.and %a1, %c1 : i1
+  %and2 = comb.and %a2, %c2 : i1
+  %and3 = comb.and %a3, %c3 : i1
+
+  %out_xor = comb.concat %xor3, %xor2, %xor1, %xor0 : i1, i1, i1, i1
+  %out_and = comb.concat %and3, %and2, %and1, %and0 : i1, i1, i1, i1
+  hw.output %out_xor, %out_and : i4, i4
+}
+
+// ---------- Structural OR Vectorization ----------
+// Mirrors the XOR test but for OR, ensuring the OrOp lifting path is covered.
+//
+// CHECK-LABEL: hw.module @structural_or(
+// CHECK-NEXT:    [[RES:%.+]] = comb.or %a, %b : i4
+// CHECK-NEXT:    hw.output [[RES]] : i4
+hw.module @structural_or(in %a : i4, in %b : i4, out out : i4) {
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %b0 = comb.extract %b from 0 : (i4) -> i1
+  %b1 = comb.extract %b from 1 : (i4) -> i1
+  %b2 = comb.extract %b from 2 : (i4) -> i1
+  %b3 = comb.extract %b from 3 : (i4) -> i1
+
+  %or0 = comb.or %a0, %b0 : i1
+  %or1 = comb.or %a1, %b1 : i1
+  %or2 = comb.or %a2, %b2 : i1
+  %or3 = comb.or %a3, %b3 : i1
+
+  %out = comb.concat %or3, %or2, %or1, %or0 : i1, i1, i1, i1
+  hw.output %out : i4
+}
+
+// ---------- Structural nested operations: (a & b) ^ c ----------
+// Each bit lane computes (a[i] & b[i]) ^ c[i]. The recursion in
+// areSubgraphsEquivalent must handle depth-2 subgraphs correctly.
+//
+// CHECK-LABEL: hw.module @structural_nested(
+// CHECK:         [[AND:%.+]] = comb.and %a, %b : i4
+// CHECK-NEXT:    [[RES:%.+]] = comb.xor [[AND]], %c : i4
+// CHECK-NEXT:    hw.output [[RES]] : i4
+hw.module @structural_nested(in %a : i4, in %b : i4, in %c : i4, out out : i4) {
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %b0 = comb.extract %b from 0 : (i4) -> i1
+  %b1 = comb.extract %b from 1 : (i4) -> i1
+  %b2 = comb.extract %b from 2 : (i4) -> i1
+  %b3 = comb.extract %b from 3 : (i4) -> i1
+
+  %c0 = comb.extract %c from 0 : (i4) -> i1
+  %c1 = comb.extract %c from 1 : (i4) -> i1
+  %c2 = comb.extract %c from 2 : (i4) -> i1
+  %c3 = comb.extract %c from 3 : (i4) -> i1
+
+  %and0 = comb.and %a0, %b0 : i1
+  %and1 = comb.and %a1, %b1 : i1
+  %and2 = comb.and %a2, %b2 : i1
+  %and3 = comb.and %a3, %b3 : i1
+
+  %xor0 = comb.xor %and0, %c0 : i1
+  %xor1 = comb.xor %and1, %c1 : i1
+  %xor2 = comb.xor %and2, %c2 : i1
+  %xor3 = comb.xor %and3, %c3 : i1
+
+  %out = comb.concat %xor3, %xor2, %xor1, %xor0 : i1, i1, i1, i1
+  hw.output %out : i4
+}
+
+// ---------- Negative Case: Non-uniform structural pattern ----------
+// Bit 0 uses XOR but bits 1-3 use AND — the cones are not isomorphic.
+// canVectorizeStructurally must reject this and leave the concat intact.
+//
+// CHECK-LABEL: hw.module @structural_non_uniform_no_vectorization(
+// CHECK:         comb.concat
+hw.module @structural_non_uniform_no_vectorization(
+    in %a : i4, in %b : i4, out out : i4) {
+  %a0 = comb.extract %a from 0 : (i4) -> i1
+  %a1 = comb.extract %a from 1 : (i4) -> i1
+  %a2 = comb.extract %a from 2 : (i4) -> i1
+  %a3 = comb.extract %a from 3 : (i4) -> i1
+
+  %b0 = comb.extract %b from 0 : (i4) -> i1
+  %b1 = comb.extract %b from 1 : (i4) -> i1
+  %b2 = comb.extract %b from 2 : (i4) -> i1
+  %b3 = comb.extract %b from 3 : (i4) -> i1
+
+  // Bit 0 uses XOR, bits 1-3 use AND: not isomorphic, must not vectorize.
+  %op0 = comb.xor %a0, %b0 : i1
+  %op1 = comb.and %a1, %b1 : i1
+  %op2 = comb.and %a2, %b2 : i1
+  %op3 = comb.and %a3, %b3 : i1
+
+  %out = comb.concat %op3, %op2, %op1, %op0 : i1, i1, i1, i1
+  hw.output %out : i4
+}
+
+// ---------- Wider vector (i8) ----------
+// Ensures no width is hardcoded anywhere in the pass.
+//
+// CHECK-LABEL: hw.module @structural_xor_i8(
+// CHECK-NEXT:    [[RES:%.+]] = comb.xor %a, %b : i8
+// CHECK-NEXT:    hw.output [[RES]] : i8
+hw.module @structural_xor_i8(in %a : i8, in %b : i8, out out : i8) {
+  %a0 = comb.extract %a from 0 : (i8) -> i1
+  %a1 = comb.extract %a from 1 : (i8) -> i1
+  %a2 = comb.extract %a from 2 : (i8) -> i1
+  %a3 = comb.extract %a from 3 : (i8) -> i1
+  %a4 = comb.extract %a from 4 : (i8) -> i1
+  %a5 = comb.extract %a from 5 : (i8) -> i1
+  %a6 = comb.extract %a from 6 : (i8) -> i1
+  %a7 = comb.extract %a from 7 : (i8) -> i1
+
+  %b0 = comb.extract %b from 0 : (i8) -> i1
+  %b1 = comb.extract %b from 1 : (i8) -> i1
+  %b2 = comb.extract %b from 2 : (i8) -> i1
+  %b3 = comb.extract %b from 3 : (i8) -> i1
+  %b4 = comb.extract %b from 4 : (i8) -> i1
+  %b5 = comb.extract %b from 5 : (i8) -> i1
+  %b6 = comb.extract %b from 6 : (i8) -> i1
+  %b7 = comb.extract %b from 7 : (i8) -> i1
+
+  %xor0 = comb.xor %a0, %b0 : i1
+  %xor1 = comb.xor %a1, %b1 : i1
+  %xor2 = comb.xor %a2, %b2 : i1
+  %xor3 = comb.xor %a3, %b3 : i1
+  %xor4 = comb.xor %a4, %b4 : i1
+  %xor5 = comb.xor %a5, %b5 : i1
+  %xor6 = comb.xor %a6, %b6 : i1
+  %xor7 = comb.xor %a7, %b7 : i1
+
+  %out = comb.concat %xor7, %xor6, %xor5, %xor4, %xor3, %xor2, %xor1, %xor0 : i1, i1, i1, i1, i1, i1, i1, i1
+  hw.output %out : i8
+}
+
+// ---------- Narrower vector (i2) ----------
+// Ensures the pass works correctly at minimal width.
+//
+// CHECK-LABEL: hw.module @structural_and_i2(
+// CHECK-NEXT:    [[RES:%.+]] = comb.and %a, %b : i2
+// CHECK-NEXT:    hw.output [[RES]] : i2
+hw.module @structural_and_i2(in %a : i2, in %b : i2, out out : i2) {
+  %a0 = comb.extract %a from 0 : (i2) -> i1
+  %a1 = comb.extract %a from 1 : (i2) -> i1
+
+  %b0 = comb.extract %b from 0 : (i2) -> i1
+  %b1 = comb.extract %b from 1 : (i2) -> i1
+
+  %and0 = comb.and %a0, %b0 : i1
+  %and1 = comb.and %a1, %b1 : i1
+
+  %out = comb.concat %and1, %and0 : i1, i1
+  hw.output %out : i2
 }


### PR DESCRIPTION
**Context:** This PR is the third part of a series of incremental patches for the  `HWVectorization` pass. Building upon the bit-tracking infrastructure from Parts 1 and 2 (#9704 and #9739), this patch introduces Structural Vectorization: the ability to collapse N isomorphic scalar logic cones into a single wide operation.

**Key Enhancements:**

- **Structural Isomorphism Check:** The pass analyzes the scalar subgraph feeding each output bit and verifies that all N bit-slices are structurally equivalent up to a uniform bit-index offset. This enables collapsing patterns like N independent `AND/OR/XOR/MUX` gates into a single N-bit operation.
```MLIR
// Before: 4 independent XOR gates
%xor0 = comb.xor %a0, %b0 : i1
%xor1 = comb.xor %a1, %b1 : i1
%xor2 = comb.xor %a2, %b2 : i1
%xor3 = comb.xor %a3, %b3 : i1
%out  = comb.concat %xor3, %xor2, %xor1, %xor0 : i1, i1, i1, i1

// After: single 4-bit XOR
%out = comb.xor %a, %b : i4
```
- **Shared Control Signal Handling:** Scalar signals shared across all bit lanes (e.g., a `MUX select` or an `AND enable`) are identified by `areSubgraphsEquivalent` as common leaves and passed directly to the wide operation, or broadcast via `comb.replicate` when used as data operands.
```MLIR
// Before: 4 muxes controlled by the same scalar %sel
%m0 = comb.mux %sel, %a0, %b0 : i1
%m1 = comb.mux %sel, %a1, %b1 : i1
%m2 = comb.mux %sel, %a2, %b2 : i1
%m3 = comb.mux %sel, %a3, %b3 : i1
%out = comb.concat %m3, %m2, %m1, %m0 : i1, i1, i1, i1

// After: single wide mux with shared scalar selector
%out = comb.mux %sel, %a, %b : i4
```

- **Recursive Subgraph Reconstruction:** `vectorizeSubgraph` recursively rebuilds the scalar logic tree into its vectorized equivalent, supporting arbitrary depth (e.g., `(a[i] & b[i]) ^ c[i]` across all bits becomes `comb.and` followed by `comb.xor`).
```MLIR
// Before: 2-level cone, (a[i] & b[i]) ^ c[i] for each bit
%and0 = comb.and %a0, %b0 : i1
%and1 = comb.and %a1, %b1 : i1
%xor0 = comb.xor %and0, %c0 : i1
%xor1 = comb.xor %and1, %c1 : i1
%out  = comb.concat %xor1, %xor0 : i1, i1

// After: two wide ops preserving the original structure
%and = comb.and %a, %b : i2
%out = comb.xor %and, %c : i2
```

- **Multiple Output Support:** Each output port is analyzed and transformed independently, so modules with multiple vectorizable outputs (e.g.,  `out_xor` and `out_and`) are fully vectorized in a single pass.
```MLIR
// Before: two independent scalar cones feeding two outputs
%out_xor = comb.concat %xor3, %xor2, %xor1, %xor0 : i1, i1, i1, i1
%out_and = comb.concat %and3, %and2, %and1, %and0 : i1, i1, i1, i1

// After: each output vectorized independently
%out_xor = comb.xor %a, %b : i4
%out_and = comb.and %a, %c : i4
```
