### PR TITLE
[FIRRTL] Allow full reset module instances outside of reset domain

### DIFF
--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -257,7 +257,6 @@ firrtl.circuit "Top" {
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   }
   firrtl.module @Other(in %clock: !firrtl.clock) attributes {annotations = [{class = "circt.ExcludeFromFullResetAnnotation"}]} {
-    // expected-note @+1 {{instance 'other/inst' is in no reset domain}}
     %inst_clock = firrtl.instance inst @Foo(in clock: !firrtl.clock)
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   }
@@ -297,20 +296,3 @@ firrtl.circuit "Top" {
   firrtl.module @Top(in %reset: !firrtl.asyncreset) attributes {portAnnotations = [[{class = "circt.FullResetAnnotation", resetType = "potato"}]]} {}
 }
 
-// -----
-// Issue 9396
-firrtl.circuit "Foo" {
-  firrtl.module @Baz(in %reset: !firrtl.asyncreset) {
-    // expected-note @+1 {{instance 'bar' is in no reset domain}}
-    firrtl.instance bar @Bar()
-  }
-  // expected-error @+1 {{module 'Bar' instantiated in different reset domains}}
-  firrtl.module private @Bar() {
-  }
-
-  // expected-note @+1 {{reset domain 'reset' of module 'Foo' declared here:}}
-  firrtl.module @Foo(in %reset: !firrtl.asyncreset [{class = "circt.FullResetAnnotation", resetType = "async"}]) {
-    // expected-note @+1 {{instance 'bar' is in reset domain rooted at 'reset' of module 'Foo'}}
-    firrtl.instance bar @Bar()
-  }
-}


### PR DESCRIPTION
When a module is part of a full reset domain, we create an additional reset port on it to connect to reset-less registers. At the moment it is an error to instantiate a module which has such an added reset inside a context that has no full reset domain:

```firrtl
firrtl.circuit "Foo" {
  firrtl.module @Foo(
    in %reset: !firrtl.asyncreset
      [{class = "circt.FullResetAnnotation", resetType = "async"}]
  ) {
    firrtl.instance foo @Baz()  // instance within full reset domain
  }
  firrtl.module @Bar() {
    firrtl.instance foo @Baz()  // instance outside any domain; error
  }
  firrtl.module private @Baz() {
    // ...
  }
}
```

This commit explicitly allows instances of such modules inside a context that has no full reset. The added reset port is tied-off to a constant zero value, which effectively turns the reset-less registers that were transformed to be fully reset, back into reset-less registers.

Fixes #9396.