### PR TITLE
[Arc] Lower time operations to LLVM IR

### DIFF
--- a/lib/Conversion/ArcToLLVM/CMakeLists.txt
+++ b/lib/Conversion/ArcToLLVM/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_conversion_library(CIRCTArcToLLVM
   LINK_LIBS PUBLIC
   CIRCTArc
   CIRCTComb
+  CIRCTLLHD
   CIRCTSeq
   CIRCTSim
   CIRCTCombToArith

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -17,6 +17,8 @@
 #include "circt/Dialect/Arc/Runtime/JITBind.h"
 #include "circt/Dialect/Arc/Runtime/TraceTaps.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/LLHD/LLHDOps.h"
+#include "circt/Dialect/LLHD/LLHDTypes.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Dialect/Sim/SimOps.h"
 #include "circt/Support/ConversionPatternSet.h"
@@ -156,6 +158,48 @@ struct StateWriteOpLowering : public OpConversionPattern<arc::StateWriteOp> {
     return success();
   }
 };
+
+//===----------------------------------------------------------------------===//
+// Time Operations Lowering
+//===----------------------------------------------------------------------===//
+
+struct CurrentTimeOpLowering : public OpConversionPattern<arc::CurrentTimeOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(arc::CurrentTimeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    // Time is stored at offset 0 in storage (no offset needed).
+    Value ptr = adaptor.getStorage();
+    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, rewriter.getI64Type(), ptr);
+    return success();
+  }
+};
+
+// `llhd.int_to_time` is a no-op
+struct IntToTimeOpLowering : public OpConversionPattern<llhd::IntToTimeOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(llhd::IntToTimeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
+// `llhd.time_to_int` is a no-op
+struct TimeToIntOpLowering : public OpConversionPattern<llhd::TimeToIntOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(llhd::TimeToIntOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Memory and Storage Lowering
+//===----------------------------------------------------------------------===//
 
 struct AllocMemoryOpLowering : public OpConversionPattern<arc::AllocMemoryOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -578,6 +622,36 @@ struct SimStepOpLowering : public ModelAwarePattern<arc::SimStepOp> {
     rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, mlir::TypeRange(), evalFunc,
                                               adaptor.getInstance());
 
+    return success();
+  }
+};
+
+// Loads the simulation time (i64 femtoseconds) from byte offset 0 in the
+// model instance's state storage.
+struct SimGetTimeOpLowering : public OpConversionPattern<arc::SimGetTimeOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arc::SimGetTimeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    // Time is stored at offset 0 in the instance storage.
+    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, rewriter.getI64Type(),
+                                              adaptor.getInstance());
+    return success();
+  }
+};
+
+// Stores the simulation time (i64 femtoseconds) to byte offset 0 in the
+// model instance's state storage.
+struct SimSetTimeOpLowering : public OpConversionPattern<arc::SimSetTimeOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arc::SimSetTimeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    // Time is stored at offset 0 in the instance storage.
+    rewriter.replaceOpWithNewOp<LLVM::StoreOp>(op, adaptor.getTime(),
+                                               adaptor.getInstance());
     return success();
   }
 };
@@ -1262,6 +1336,10 @@ void LowerArcToLLVMPass::runOnOperation() {
   converter.addConversion([&](sim::FormatStringType type) {
     return LLVM::LLVMPointerType::get(type.getContext());
   });
+  converter.addConversion([&](llhd::TimeType type) {
+    // LLHD time is represented as i64 femtoseconds.
+    return IntegerType::get(type.getContext(), 64);
+  });
 
   // Setup the conversion patterns.
   ConversionPatternSet patterns(&getContext(), converter);
@@ -1299,6 +1377,8 @@ void LowerArcToLLVMPass::runOnOperation() {
     AllocStorageOpLowering,
     ClockGateOpLowering,
     ClockInvOpLowering,
+    CurrentTimeOpLowering,
+    IntToTimeOpLowering,
     MemoryReadOpLowering,
     MemoryWriteOpLowering,
     ModelOpLowering,
@@ -1306,9 +1386,12 @@ void LowerArcToLLVMPass::runOnOperation() {
     ReplaceOpWithInputPattern<seq::FromClockOp>,
     RuntimeModelOpLowering,
     SeqConstClockLowering,
+    SimGetTimeOpLowering,
+    SimSetTimeOpLowering,
     StateReadOpLowering,
     StateWriteOpLowering,
     StorageGetOpLowering,
+    TimeToIntOpLowering,
     ZeroCountOpLowering
   >(converter, &getContext());
   // clang-format on

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -4,22 +4,27 @@
 // CHECK-SAME:    %arg0: !llvm.ptr
 // CHECK-SAME:    %arg1: !llvm.ptr
 // CHECK-SAME:    %arg2: !llvm.ptr
+// CHECK-SAME:    %arg3: i64
 // CHECK-SAME:  ) -> !llvm.struct<(
 // CHECK-SAME:    ptr
 // CHECK-SAME:    ptr
+// CHECK-SAME:    ptr
+// CHECK-SAME:    i64
 // CHECK-SAME:  )> {
 func.func @Types(
   %arg0: !arc.storage,
   %arg1: !arc.state<i1>,
-  %arg2: !arc.memory<4 x i7, i2>
+  %arg2: !arc.memory<4 x i7, i2>,
+  %arg3: !llhd.time
 ) -> (
   !arc.storage,
   !arc.state<i1>,
-  !arc.memory<4 x i7, i2>
+  !arc.memory<4 x i7, i2>,
+  !llhd.time
 ) {
-  return %arg0, %arg1, %arg2 : !arc.storage, !arc.state<i1>, !arc.memory<4 x i7, i2>
+  return %arg0, %arg1, %arg2, %arg3 : !arc.storage, !arc.state<i1>, !arc.memory<4 x i7, i2>, !llhd.time
   // CHECK: llvm.return
-  // CHECK-SAME: !llvm.struct<(ptr, ptr, ptr)>
+  // CHECK-SAME: !llvm.struct<(ptr, ptr, ptr, i64)>
 }
 // CHECK-NEXT: }
 
@@ -325,3 +330,22 @@ func.func @issue9171(%arg0: !arc.state<!hw.array<4xi1>>, %idx: i2) -> (i1) {
 arc.runtime.model @arcRuntimeModel_fooModelSym "fooModelName" numStateBytes 1234567
 
 func.func private @Dummy(%arg0: i42, %arg1: !hw.array<4xi19>, %arg2: !arc.storage)
+
+
+// CHECK-LABEL: llvm.func @Time
+// CHECK-SAME: (%arg0: !llvm.ptr)
+// CHECK-SAME: -> !llvm.struct<(i64, i64, i64)>
+func.func @Time(%arg0: !arc.storage<42>) -> (i64, !llhd.time, i64) {
+  // CHECK-NEXT: [[TIME:%.+]] = llvm.load %arg0 : !llvm.ptr -> i64
+  // CHECK-NOT: int_to_time
+  // CHECK-NOT: time_to_int
+  %0 = arc.current_time %arg0 : !arc.storage<42>
+  %1 = llhd.int_to_time %0
+  %2 = llhd.time_to_int %1
+  // CHECK-NEXT: [[TMP1:%.+]] = llvm.mlir.poison : !llvm.struct<(i64, i64, i64)>
+  // CHECK-NEXT: [[TMP2:%.+]] = llvm.insertvalue [[TIME]], [[TMP1]][0]
+  // CHECK-NEXT: [[TMP3:%.+]] = llvm.insertvalue [[TIME]], [[TMP2]][1]
+  // CHECK-NEXT: [[TMP4:%.+]] = llvm.insertvalue [[TIME]], [[TMP3]][2]
+  // CHECK-NEXT: llvm.return [[TMP4]]
+  return %0, %1, %2 : i64, !llhd.time, i64
+}


### PR DESCRIPTION
Lower the new Arc time operations to LLVM IR:

- `arc.current_time` loads an i64 from offset 0 in the model storage.
- `arc.sim.get_time` and `arc.sim.set_time` load/store the time value at the beginning of the instantiated model's state.
- `llhd.int_to_time` and `llhd.time_to_int` are no-ops.

This is part of adding LLHD time support to Arcilator.