### PR TITLE
[FIRRTL] Fix domain info updates in cloneWithInsertedPorts

### DIFF
--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -340,3 +340,36 @@ firrtl.circuit "DomainInfo" {
   ) {
   }
 }
+
+// -----
+
+// Test that domain info is correctly updated when port indices change due to
+// bundle expansion.
+// CHECK-LABEL: circuit "DomainInfoIndexUpdate"
+firrtl.circuit "DomainInfoIndexUpdate" {
+  firrtl.domain @D
+  // CHECK:      firrtl.extmodule @Ext(
+  // CHECK-SAME:   out bundle_a: !firrtl.probe<uint<1>>,
+  // CHECK-SAME:   out bundle_b: !firrtl.probe<uint<1>>,
+  // CHECK-SAME:   in reset: !firrtl.asyncreset domains [domain],
+  // CHECK-SAME:   in domain: !firrtl.domain of @D)
+  firrtl.extmodule @Ext(
+    out bundle: !firrtl.openbundle<a: probe<uint<1>>, b: probe<uint<1>>>,
+    in reset: !firrtl.asyncreset domains [domain],
+    in domain: !firrtl.domain of @D
+  )
+
+  // CHECK:      firrtl.module @DomainInfoIndexUpdate
+  firrtl.module @DomainInfoIndexUpdate() {
+    // CHECK: %ext_bundle_a, %ext_bundle_b, %ext_reset, %ext_domain = firrtl.instance ext @Ext(
+    // CHECK-SAME: out bundle_a: !firrtl.probe<uint<1>>,
+    // CHECK-SAME: out bundle_b: !firrtl.probe<uint<1>>,
+    // CHECK-SAME: in reset: !firrtl.asyncreset domains [domain],
+    // CHECK-SAME: in domain: !firrtl.domain of @D)
+    %bundle, %reset, %domain = firrtl.instance ext @Ext(
+      out bundle: !firrtl.openbundle<a: probe<uint<1>>, b: probe<uint<1>>>,
+      in reset: !firrtl.asyncreset domains [domain],
+      in domain: !firrtl.domain of @D
+    )
+  }
+}


### PR DESCRIPTION
When cloneWithInsertedPorts expands ports (e.g., LowerOpenAggs
expanding bundles), domain info for existing ports must be updated
because port indices change. Previously, the indexMap was built
incrementally and existing ports' domain info was copied without
updating indices.

This fixes two issues:
1. Build complete indexMap before processing ports
2. Call fixDomainInfoInsertions on both new and existing ports

Applied to both InstanceOp and InstanceChoiceOp.

AI-assisted-by: Augment (Claude Sonnet 4.5)
Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>
