### PR TITLE
[PyCDE] Remove python 3.8, 3.9 and add 3.14 builds

### DIFF
--- a/.github/workflows/pycdePublish.yml
+++ b/.github/workflows/pycdePublish.yml
@@ -26,12 +26,11 @@ jobs:
     strategy:
       matrix:
         python-env:
-          - cp38-manylinux_x86_64
-          - cp39-manylinux_x86_64
           - cp310-manylinux_x86_64
           - cp311-manylinux_x86_64
           - cp312-manylinux_x86_64
           - cp313-manylinux_x86_64
+          - cp314-manylinux_x86_64
     steps:
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -105,12 +104,11 @@ jobs:
     strategy:
       matrix:
         python-env:
-          - cp38-win_amd64
-          - cp39-win_amd64
           - cp310-win_amd64
           - cp311-win_amd64
           - cp312-win_amd64
           - cp313-win_amd64
+          - cp314-win_amd64
     steps:
       # Since we don't use docker on Windows, we need to install the dependencies.
       - name: Build additional c++ deps


### PR DESCRIPTION
It appears that MLIR has dropped support for 3.8 and 3.9.
