### PR TITLE
[PyCDE] Disable cocotb tests by default

### DIFF
--- a/.github/workflows/pycdePublish.yml
+++ b/.github/workflows/pycdePublish.yml
@@ -1,4 +1,4 @@
-name: PyCDE Test and Publish
+name: PyCDE Publish
 
 on:
   push:

--- a/frontends/PyCDE/pyproject.toml
+++ b/frontends/PyCDE/pyproject.toml
@@ -10,10 +10,6 @@ requires = [
   "numpy",
   "nanobind>=2.2",
   "PyYAML",
-
-  # PyCDE depends
-  "cocotb>=1.6.2",
-  "cocotb-test>=0.2.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -47,7 +43,7 @@ dynamic = ["version"]
 description = "Python CIRCT Design Entry"
 authors = [{ name = "John Demme", email = "John.Demme@microsoft.com" }]
 dependencies = ['numpy']
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [project.urls]
 "Homepage" = "https://circt.llvm.org/docs/PyCDE/"

--- a/frontends/PyCDE/setup.py
+++ b/frontends/PyCDE/setup.py
@@ -107,9 +107,6 @@ class CMakeBuild(build_py):
     subprocess.check_call(["cmake", src_dir] + cmake_args, cwd=cmake_build_dir)
     targets = ["check-pycde"]
     if "RUN_TESTS" in os.environ and os.environ["RUN_TESTS"] != "false":
-      # The pycde integration tests test both PyCDE and the ESIRuntime so
-      # failure shouldn't gate publishing PyCDE.
-      # targets.append("check-pycde-integration")
       targets.append("check-circt")
     subprocess.check_call([
         "cmake",


### PR DESCRIPTION
PyCDE supports python 3.14 but cocotb does not (yet). So drop it from the build requirements.