### PR TITLE
[FIRRTL] Improve error messages for domain symbol verification

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -7249,10 +7249,13 @@ LogicalResult BindOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
 LogicalResult
 DomainCreateAnonOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto circuitOp = getOperation()->getParentOfType<CircuitOp>();
-  auto domain = getDomainAttr();
-  if (!symbolTable.lookupSymbolIn<DomainOp>(circuitOp, domain))
-    return emitOpError() << "references undefined domain '" << domain << "'";
-
+  auto domainAttr = getDomainAttr();
+  auto *symbol = symbolTable.lookupSymbolIn(circuitOp, domainAttr);
+  if (!symbol)
+    return emitOpError() << "references undefined symbol '" << domainAttr << "'";
+  if (!isa<DomainOp>(symbol))
+    return emitOpError() << "references symbol '" << domainAttr
+                         << "' which is not a domain";
   return success();
 }
 
@@ -7263,10 +7266,13 @@ void DomainCreateOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 LogicalResult
 DomainCreateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto circuitOp = getOperation()->getParentOfType<CircuitOp>();
-  auto domain = getDomainAttr();
-  if (!symbolTable.lookupSymbolIn<DomainOp>(circuitOp, domain))
-    return emitOpError() << "references undefined domain '" << domain << "'";
-
+  auto domainAttr = getDomainAttr();
+  auto *symbol = symbolTable.lookupSymbolIn(circuitOp, domainAttr);
+  if (!symbol)
+    return emitOpError() << "references undefined symbol '" << domainAttr << "'";
+  if (!isa<DomainOp>(symbol))
+    return emitOpError() << "references symbol '" << domainAttr
+                         << "' which is not a domain";
   return success();
 }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -3277,19 +3277,19 @@ firrtl.circuit "WrongInstanceChoiceDomainInfo" {
 
 // -----
 
-firrtl.circuit "AnonDomainPointingAtNonDomain" {
-  firrtl.extmodule @Foo()
+firrtl.circuit "UndefinedDomainInAnonDomain" {
   firrtl.module @UndefinedDomainInAnonDomain() {
-    // expected-error @below {{references undefined domain '@Foo'}}
+    // expected-error @below {{references undefined symbol '@Foo'}}
     %0 = firrtl.domain.anon : !firrtl.domain of @Foo
   }
 }
 
 // -----
 
-firrtl.circuit "UndefinedDomainInAnonDomain" {
-  firrtl.module @UndefinedDomainInAnonDomain() {
-    // expected-error @below {{references undefined domain '@Foo'}}
+firrtl.circuit "AnonDomainPointingAtNonDomain" {
+  firrtl.extmodule @Foo()
+  firrtl.module @AnonDomainPointingAtNonDomain() {
+    // expected-error @below {{references symbol '@Foo' which is not a domain}}
     %0 = firrtl.domain.anon : !firrtl.domain of @Foo
   }
 }
@@ -3298,7 +3298,7 @@ firrtl.circuit "UndefinedDomainInAnonDomain" {
 
 firrtl.circuit "UndefinedDomainInCreateDomain" {
   firrtl.module @UndefinedDomainInCreateDomain() {
-    // expected-error @below {{references undefined domain '@Foo'}}
+    // expected-error @below {{references undefined symbol '@Foo'}}
     %my_domain = firrtl.domain.create : !firrtl.domain of @Foo
   }
 }
@@ -3308,7 +3308,7 @@ firrtl.circuit "UndefinedDomainInCreateDomain" {
 firrtl.circuit "CreateDomainPointingAtNonDomain" {
   firrtl.extmodule @Foo()
   firrtl.module @CreateDomainPointingAtNonDomain() {
-    // expected-error @below {{references undefined domain '@Foo'}}
+    // expected-error @below {{references symbol '@Foo' which is not a domain}}
     %my_domain = firrtl.domain.create : !firrtl.domain of @Foo
   }
 }


### PR DESCRIPTION
Separate error messages for domain operations to distinguish between:
  1. the symbol doesn't exist at all,
  2. and the symbol exists but is not a domain.

This applies to both DomainCreateOp and DomainCreateAnonOp, providing
clearer diagnostics when domain references are incorrect.

AI-assisted-by: Augment (Claude Sonnet 4.5)
