### PR TITLE
[ImportVerilog][Sim][MooreToCore] Add support for resizing queues

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1766,7 +1766,7 @@ def DynExtractRefOp : MooreOp<"dyn_extract_ref", [Pure]> {
 // Queue Manipulation
 //===----------------------------------------------------------------------===//
 
-def QueueConvertBoundsOp : MooreOp<"queue.conv_bounds", [Pure]> {
+def QueueResizeOp : MooreOp<"queue.resize", [Pure]> {
   let description = [{
     Converts between two queues with different bounds, but the same element
     type.

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -782,7 +782,7 @@ def QueueSliceOp : SimOp<"queue.slice", [Pure,
   let assemblyFormat = "$queue `from` $lowIdx `to` $highIdx attr-dict `:` type($queue)";
 }
 
-def QueueConvertBoundsOp : SimOp<"queue.conv_bounds", [Pure]> {
+def QueueResizeOp : SimOp<"queue.resize", [Pure]> {
   let description = [{
     Converts between two queues with different bounds, but the same element
     type.

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2588,9 +2588,8 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
   // just need to convert the queue bounds.
   if (isa<moore::QueueType>(type) && isa<moore::QueueType>(value.getType()) &&
       cast<moore::QueueType>(type).getElementType() ==
-          cast<moore::QueueType>(value.getType()).getElementType()) {
-    return builder.createOrFold<moore::QueueConvertBoundsOp>(loc, type, value);
-  }
+          cast<moore::QueueType>(value.getType()).getElementType())
+    return builder.createOrFold<moore::QueueResizeOp>(loc, type, value);
 
   // Handle Real To Int conversion
   if (isa<moore::IntType>(type) && isa<moore::RealType>(value.getType())) {

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2431,15 +2431,14 @@ struct QueueDeleteOpConversion : public OpConversionPattern<QueueDeleteOp> {
   };
 };
 
-struct QueueConvertBoundsOpConversion
-    : public OpConversionPattern<QueueConvertBoundsOp> {
+struct QueueResizeOpConversion : public OpConversionPattern<QueueResizeOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(QueueConvertBoundsOp op, OpAdaptor adaptor,
+  matchAndRewrite(QueueResizeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    rewriter.replaceOpWithNewOp<sim::QueueConvertBoundsOp>(
+    rewriter.replaceOpWithNewOp<sim::QueueResizeOp>(
         op, getTypeConverter()->convertType(op.getResult().getType()),
         adaptor.getInput());
     return success();
@@ -2953,7 +2952,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     QueueInsertOpConversion,
     QueueClearOpConversion,
     DynQueueExtractOpConversion,
-    QueueConvertBoundsOpConversion
+    QueueResizeOpConversion
   >(typeConverter, patterns.getContext());
   // clang-format on
 

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -1768,11 +1768,10 @@ LogicalResult DynQueueExtractOp::verify() {
   return success();
 }
 
-LogicalResult QueueConvertBoundsOp::verify() {
+LogicalResult QueueResizeOp::verify() {
   if (cast<QueueType>(getInput().getType()).getElementType() !=
-      cast<QueueType>(getResult().getType()).getElementType()) {
+      cast<QueueType>(getResult().getType()).getElementType())
     return failure();
-  }
   return success();
 }
 

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -580,11 +580,10 @@ OpFoldResult IntToStringOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
-LogicalResult QueueConvertBoundsOp::verify() {
+LogicalResult QueueResizeOp::verify() {
   if (cast<QueueType>(getInput().getType()).getElementType() !=
-      cast<QueueType>(getResult().getType()).getElementType()) {
+      cast<QueueType>(getResult().getType()).getElementType())
     return failure();
-  }
   return success();
 }
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4074,7 +4074,7 @@ endmodule
 // CHECK:           [[Q2:%.+]] = moore.variable : <queue<i32, 10>>
 // CHECK:           moore.procedure initial {
 // CHECK:               [[QR1:%.+]] = moore.read [[Q1]] : <queue<i32, 0>>
-// CHECK:               [[CONV:%.+]] = moore.queue.conv_bounds [[QR1]] : <i32, 0> -> <i32, 10>
+// CHECK:               [[CONV:%.+]] = moore.queue.resize [[QR1]] : <i32, 0> -> <i32, 10>
 // CHECK:               moore.blocking_assign [[Q2]], [[CONV]] : queue<i32, 10>
 // CHECK:               moore.return
 // CHECK:           }

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1569,8 +1569,8 @@ func.func @QueueOperations(%arg0: !moore.i32, %arg1: !moore.i32) {
   // CHECK: [[NEWQ:%.+]] = sim.queue.slice [[QR]] from %arg0 to %arg1 : <i32, 10>
   %newq = moore.dyn_queue_extract %qr from %arg0 to %arg1 : <i32, 10>, i32 -> queue<i32, 10>
 
-  // CHECK: [[DIFFB:%.+]] = sim.queue.conv_bounds [[QR]] : <i32, 10> -> <i32, 0>
-  %diffbounds = moore.queue.conv_bounds %qr : <i32, 10> -> <i32, 0>
+  // CHECK: [[DIFFB:%.+]] = sim.queue.resize [[QR]] : <i32, 10> -> <i32, 0>
+  %diffbounds = moore.queue.resize %qr : <i32, 10> -> <i32, 0>
   return
 }
 


### PR DESCRIPTION
This PR adds a new op in Moore, `moore.queue.conv_bounds`, which allows a conversion between two queue types of differing bounds. Obviously, when converting to a queue type with smaller bounds, excess elements at the end of the queue are discarded. Conversions to expand the bounds are still important, as the bounds will affect the behavior of later calls to `push_back`, for example.

A corresponding op has been added in Sim, (because `conv_bounds` is a pure operation, the Sim op and Moore op are practically identical) alongside lowering in MooreToCore.