### PR TITLE
[ImportVerilog] Add support for $swrite

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -168,13 +168,14 @@ struct StmtVisitor {
       }
 
       // According to IEEE 1800-2023 Section 21.3.3 "Formatting data to a
-      // string" the first argument of $sformat is its output; the other
-      // arguments work like a FormatString.
+      // string" the first argument of $sformat/$swrite is its output; the
+      // other arguments work like a FormatString.
       // In Moore we only support writing to a location if it is a reference;
-      // However, Section 21.3.3 explains that the output of $sformat is
-      // assigned as if it were cast from a string literal (Section 5.9),
+      // However, Section 21.3.3 explains that the output of $sformat/$swrite
+      // is assigned as if it were cast from a string literal (Section 5.9),
       // so this implementation casts the string to the target value.
-      if (!call->getSubroutineName().compare("$sformat")) {
+      if (!call->getSubroutineName().compare("$sformat") ||
+          !call->getSubroutineName().compare("$swrite")) {
 
         // Use the first argument as the output location
         auto *lhsExpr = call->arguments().front();

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3283,6 +3283,35 @@ function automatic void ConcatSformatf(string testStr, string otherString, ref s
    $sformat(logicVector, "%s %s", testStr, otherString);
 endfunction
 
+// CHECK-LABEL: func.func private @Swrite(
+// CHECK-SAME: [[STR1:%[^,]+]]: !moore.string
+// CHECK-SAME: [[STR2:%[^,]+]]: !moore.string
+// CHECK-SAME: [[STR3:%[^,]+]]: !moore.ref<string>
+function automatic void Swrite(string testStr, string otherString, ref string outputString);
+   // CHECK: [[LV:%.+]] = moore.variable : <l64>
+   logic [63:0] logicVector;
+
+   // $swrite to a string output
+   // CHECK: [[FMTSTR1:%.+]] = moore.fmt.string [[STR1]]
+   // CHECK-NEXT: [[SPC:%.+]] = moore.fmt.literal " "
+   // CHECK-NEXT: [[FMTSTR2:%.+]] = moore.fmt.string [[STR2]]
+   // CHECK-NEXT: [[CONCAT:%.+]] = moore.fmt.concat ([[FMTSTR1]], [[SPC]], [[FMTSTR2]])
+   // CHECK-NEXT: [[STROUT:%.+]] = moore.fstring_to_string [[CONCAT]]
+   // CHECK-NEXT: moore.blocking_assign [[STR3]], [[STROUT]] : string
+   $swrite(outputString, "%s %s", testStr, otherString);
+
+   // $swrite to a logic vector (with conversion)
+   // CHECK: [[FMTSTR3:%.+]] = moore.fmt.string [[STR1]]
+   // CHECK-NEXT: [[SPC2:%.+]] = moore.fmt.literal " "
+   // CHECK-NEXT: [[FMTSTR4:%.+]] = moore.fmt.string [[STR2]]
+   // CHECK-NEXT: [[CONCAT2:%.+]] = moore.fmt.concat ([[FMTSTR3]], [[SPC2]], [[FMTSTR4]])
+   // CHECK-NEXT: [[STROUT2:%.+]] = moore.fstring_to_string [[CONCAT2]]
+   // CHECK-NEXT: [[CONV0:%.+]] = moore.string_to_int [[STROUT2]] : i64
+   // CHECK-NEXT: [[CONV:%.+]] = moore.int_to_logic [[CONV0]] : i64
+   // CHECK-NEXT: moore.blocking_assign [[LV]], [[CONV]] : l64
+   $swrite(logicVector, "%s %s", testStr, otherString);
+endfunction
+
 // CHECK-LABEL: moore.module @ContinuousAssignment(
 module ContinuousAssignment;
   // CHECK-NEXT: [[A:%.+]] = moore.variable


### PR DESCRIPTION
Handle the `$swrite` system task in the same way as `$sformat`. The subtle difference between the two is `$sformat` can parse format strings dynamically at run time, whereas `$swrite` requires the format to be a literal. We'll deal with these differences later.

Error diff on sv-tests:

```
-120 error: unsupported expression: EmptyArgument
+119 error: unsupported format specifier `%m`
  -3 error: unsupported system call `$swrite`
  +2 error: failed to legalize operation 'moore.fstring_to_string'
  +1 error: unsupported format specifier `%v`
  +1 error: unsupported system call `$timeformat`
   0 total change
```