### PR TITLE
[Arc] Generate time accessors functions in LLVM lowering

### DIFF
--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -349,3 +349,16 @@ func.func @Time(%arg0: !arc.storage<42>) -> (i64, !llhd.time, i64) {
   // CHECK-NEXT: llvm.return [[TMP4]]
   return %0, %1, %2 : i64, !llhd.time, i64
 }
+
+// CHECK-LABEL: func @GetSetTime_eval
+
+// CHECK: func @GetSetTime_getTime(%arg0: !llvm.ptr)
+// CHECK-NEXT: [[TIME:%.+]] = llvm.load %arg0 : !llvm.ptr -> i64
+// CHECK-NEXT: llvm.return [[TIME]] : i64
+
+// CHECK: func @GetSetTime_setTime(%arg0: !llvm.ptr, %arg1: i64)
+// CHECK-NEXT: llvm.store %arg1, %arg0 : i64, !llvm.ptr
+// CHECK-NEXT: llvm.return
+arc.model @GetSetTime io !hw.modty<> {
+^bb0(%arg0: !arc.storage<8>):
+}


### PR DESCRIPTION
Generate `getTime` and `setTime` accessor functions when lowering `arc.model` to LLVM:

- `getTime(ptr state) -> i64`: Loads the simulation time (i64 femtoseconds) from offset 0 in the model's state storage.
- `setTime(ptr state, i64 time)`: Stores the simulation time to offset 0 in the model's state storage.

These functions allow users to get and set the simulation time stored in the model's state.

This is part of adding LLHD time support to Arcilator.