### PR TITLE
[Arc] Use simulation time for VCD timestamps

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/TraceEncoder.h
+++ b/include/circt/Dialect/Arc/Runtime/TraceEncoder.h
@@ -34,9 +34,12 @@ namespace circt::arc::runtime::impl {
 /// Helper for marking time steps within a trace buffer
 struct TraceBufferMarker {
   TraceBufferMarker() = delete;
-  explicit TraceBufferMarker(uint32_t offset) : offset(offset), numSteps(1) {}
+  explicit TraceBufferMarker(uint32_t offset, uint64_t simTime)
+      : offset(offset), simTime(simTime), numSteps(1) {}
   /// Offset within the buffer in number of elements
   uint32_t offset;
+  /// Simulation time in femtoseconds at this marker
+  uint64_t simTime;
   /// Number of time steps to advance at the given offset
   uint32_t numSteps;
 };
@@ -65,6 +68,8 @@ public:
   uint32_t size = 0;
   /// Time step of the buffer's first entry
   int64_t firstStep = -1;
+  /// Simulation time in femtoseconds at the buffer's first entry
+  uint64_t firstSimTime = 0;
   /// Time step markers
   std::vector<TraceBufferMarker> stepMarkers;
 
@@ -75,6 +80,7 @@ public:
   void clear() {
     size = 0;
     firstStep = -1;
+    firstSimTime = 0;
     stepMarkers.clear();
   }
 
@@ -149,6 +155,8 @@ private:
 
   /// Current simulation time step
   int64_t timeStep;
+  /// Current simulation time in femtoseconds
+  uint64_t simTime;
 
   /// Trace encoder worker thread. If empty, tracing is disabled.
   std::optional<std::thread> worker;

--- a/integration_test/arcilator/JIT/initial-shift-reg.mlir
+++ b/integration_test/arcilator/JIT/initial-shift-reg.mlir
@@ -25,8 +25,19 @@ module {
     %ff = arith.constant 0xFF : i8
     %false = arith.constant 0 : i1
     %true = arith.constant 1 : i1
+    %t0 = arith.constant 10 : i64
+    %t1 = arith.constant 20 : i64
+    %t2 = arith.constant 30 : i64
+    %t3 = arith.constant 40 : i64
+    %t4 = arith.constant 50 : i64
+    %t5 = arith.constant 60 : i64
+    %t6 = arith.constant 70 : i64
+    %t7 = arith.constant 80 : i64
+    %t8 = arith.constant 90 : i64
+    %t9 = arith.constant 100 : i64
 
     arc.sim.instantiate @shiftreg as %model {
+      arc.sim.set_time %model, %t0 : !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "en" = %false : i1, !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "reset" = %false : i1, !arc.sim.instance<@shiftreg>
@@ -35,8 +46,10 @@ module {
       %res0 = arc.sim.get_port %model, "dout" : i8, !arc.sim.instance<@shiftreg>
       arc.sim.emit "output", %res0 : i8
 
+      arc.sim.set_time %model, %t1 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %true : i1, !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
+      arc.sim.set_time %model, %t2 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %false : i1, !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
 
@@ -45,26 +58,34 @@ module {
 
       arc.sim.set_input %model, "en" = %true : i1, !arc.sim.instance<@shiftreg>
 
+      arc.sim.set_time %model, %t3 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %true : i1, !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
+      arc.sim.set_time %model, %t4 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %false : i1, !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
       %res2 = arc.sim.get_port %model, "dout" : i8, !arc.sim.instance<@shiftreg>
       arc.sim.emit "output", %res2 : i8
 
+      arc.sim.set_time %model, %t5 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %true : i1, !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
+      arc.sim.set_time %model, %t6 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %false : i1, !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
       %res3 = arc.sim.get_port %model, "dout" : i8, !arc.sim.instance<@shiftreg>
       arc.sim.emit "output", %res3 : i8
 
+      arc.sim.set_time %model, %t7 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %true : i1, !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
+      arc.sim.set_time %model, %t8 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %false : i1, !arc.sim.instance<@shiftreg>
       arc.sim.step %model : !arc.sim.instance<@shiftreg>
       %res4 = arc.sim.get_port %model, "dout" : i8, !arc.sim.instance<@shiftreg>
       arc.sim.emit "output", %res4 : i8
+
+      arc.sim.set_time %model, %t9 : !arc.sim.instance<@shiftreg>
     }
     return
   }
@@ -73,7 +94,7 @@ module {
 // VCD-LABEL: $version
 // VCD-NEXT:     Some cryptic ArcRuntime magic
 // VCD-NEXT: $end
-// VCD-NEXT: $timescale 1ns $end
+// VCD-NEXT: $timescale 1fs $end
 // VCD-NEXT: $scope module shiftreg $end
 // VCD-NEXT:  $var wire 1 ! clock $end
 // VCD-NEXT:  $var wire 8 $ din $end
@@ -94,33 +115,33 @@ module {
 // VCD-NEXT: b00000000 &
 // VCD-NEXT: b00000000 '
 // VCD-NEXT: b11111110 (
-// VCD-NEXT: #1
+// VCD-NEXT: #10
 // VCD-NEXT: b11001010 '
-// VCD-NEXT: #2
+// VCD-NEXT: #20
 // VCD-NEXT: 1!
 // VCD-NEXT: b11111111 $
-// VCD-NEXT: #3
+// VCD-NEXT: #30
 // VCD-NEXT: 0!
-// VCD-NEXT: #4
+// VCD-NEXT: #40
 // VCD-NEXT: 1!
 // VCD-NEXT: 1#
 // VCD-NEXT: b00000000 %
 // VCD-NEXT: b00000000 '
 // VCD-NEXT: b11111111 (
 // VCD-NEXT: b11111110 &
-// VCD-NEXT: #5
+// VCD-NEXT: #50
 // VCD-NEXT: 0!
-// VCD-NEXT: #6
+// VCD-NEXT: #60
 // VCD-NEXT: 1!
 // VCD-NEXT: b11111110 %
 // VCD-NEXT: b11111110 '
 // VCD-NEXT: b11111111 &
-// VCD-NEXT: #7
+// VCD-NEXT: #70
 // VCD-NEXT: 0!
-// VCD-NEXT: #8
+// VCD-NEXT: #80
 // VCD-NEXT: 1!
 // VCD-NEXT: b11111111 %
 // VCD-NEXT: b11111111 '
-// VCD-NEXT: #9
+// VCD-NEXT: #90
 // VCD-NEXT: 0!
-// VCD-NEXT: #10
+// VCD-NEXT: #100

--- a/integration_test/arcilator/JIT/runtime-vcd-nochange.mlir
+++ b/integration_test/arcilator/JIT/runtime-vcd-nochange.mlir
@@ -1,4 +1,5 @@
 // RUN: arcilator %s --run --jit-entry=main --jit-vcd-file=%t && cat %t | FileCheck %s --match-full-lines --check-prefix VCD
+// REQUIRES: arcilator-jit
 
 hw.module @dut(out dout : i136) {
   %cst = hw.constant 0 : i136
@@ -6,15 +7,35 @@ hw.module @dut(out dout : i136) {
 }
 
 func.func @main() {
+  %inc = arith.constant 1 : i64
+  %0 = arith.constant 0 : i64
   arc.sim.instantiate @dut as %model {
+    %1 = arith.addi %0, %inc : i64
+    arc.sim.set_time %model, %1 : !arc.sim.instance<@dut>
     arc.sim.step %model : !arc.sim.instance<@dut>
+    %2 = arith.addi %1, %inc : i64
+    arc.sim.set_time %model, %2 : !arc.sim.instance<@dut>
     arc.sim.step %model : !arc.sim.instance<@dut>
+    %3 = arith.addi %2, %inc : i64
+    arc.sim.set_time %model, %3 : !arc.sim.instance<@dut>
     arc.sim.step %model : !arc.sim.instance<@dut>
+    %4 = arith.addi %3, %inc : i64
+    arc.sim.set_time %model, %4 : !arc.sim.instance<@dut>
     arc.sim.step %model : !arc.sim.instance<@dut>
+    %5 = arith.addi %4, %inc : i64
+    arc.sim.set_time %model, %5 : !arc.sim.instance<@dut>
     arc.sim.step %model : !arc.sim.instance<@dut>
+    %6 = arith.addi %5, %inc : i64
+    arc.sim.set_time %model, %6 : !arc.sim.instance<@dut>
     arc.sim.step %model : !arc.sim.instance<@dut>
+    %7 = arith.addi %6, %inc : i64
+    arc.sim.set_time %model, %7 : !arc.sim.instance<@dut>
     arc.sim.step %model : !arc.sim.instance<@dut>
+    %8 = arith.addi %7, %inc : i64
+    arc.sim.set_time %model, %8 : !arc.sim.instance<@dut>
     arc.sim.step %model : !arc.sim.instance<@dut>
+    %9 = arith.addi %8, %inc : i64
+    arc.sim.set_time %model, %9 : !arc.sim.instance<@dut>
   }
   return
 }
@@ -22,7 +43,7 @@ func.func @main() {
 // VCD-LABEL: $version
 // VCD-NEXT:      Some cryptic ArcRuntime magic
 // VCD-NEXT:  $end
-// VCD-NEXT:  $timescale 1ns $end
+// VCD-NEXT:  $timescale 1fs $end
 // VCD-NEXT:  $scope module dut $end
 // VCD-NEXT:   $var wire 136 ! dout $end
 // VCD-NEXT:  $upscope $end


### PR DESCRIPTION
Change VCD tracing to use the actual simulation time stored in the model memory instead of an internal step counter. Also adjust VCD timescale to 1fs to match what we do in Moore, LLHD, and Arc.

This is part of adding LLHD time support to Arcilator.