### PR TITLE
[FIRRTL] Allow Unknown as an identifier

### DIFF
--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1704,8 +1704,9 @@ void Emitter::emitExpression(UnsafeDomainCastOp op) {
 }
 
 void Emitter::emitExpression(UnknownValueOp op) {
-  ps << "Unknown";
-  emitTypeWithColon(op.getType());
+  ps << "Unknown(";
+  emitType(op.getType());
+  ps << ")";
 }
 
 void Emitter::emitAttribute(MemDirAttr attr) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2391,7 +2391,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
         parseUnsafeDomainCast(result))
       return failure();
     break;
-  case FIRToken::kw_Unknown:
+  case FIRToken::lp_Unknown:
     if (requireFeature(nextFIRVersion, "unknown property expressions") ||
         parseUnknownProperty(result))
       return failure();
@@ -2858,12 +2858,13 @@ ParseResult FIRStmtParser::parseUnsafeDomainCast(Value &result) {
 }
 
 ParseResult FIRStmtParser::parseUnknownProperty(Value &result) {
-  consumeToken(FIRToken::kw_Unknown);
-
   auto loc = getToken().getLoc();
+  consumeToken(FIRToken::lp_Unknown);
+  // The '(' has already been consumed by the lexer.
+
   PropertyType type;
-  if (parseToken(FIRToken::colon, "expected ':' in unknown property") ||
-      parsePropertyType(type, "expected property type"))
+  if (parsePropertyType(type, "expected property type") ||
+      parseToken(FIRToken::r_paren, "expected ')' in unknown property"))
     return failure();
 
   locationProcessor.setLoc(loc);

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -107,7 +107,6 @@ TOK_KEYWORD(Reset)
 TOK_KEYWORD(SInt)
 TOK_KEYWORD(String)
 TOK_KEYWORD(UInt)
-TOK_KEYWORD(Unknown)
 TOK_KEYWORD(attach)
 TOK_KEYWORD(case)
 TOK_KEYWORD(circuit)
@@ -209,6 +208,7 @@ TOK_LPKEYWORD(Integer)
 TOK_LPKEYWORD(Bool)
 TOK_LPKEYWORD(Double)
 TOK_LPKEYWORD(List)
+TOK_LPKEYWORD(Unknown)
 
 // Keywords when followed by a '<'. These turn "foo" into
 // FIRToken::langle_foo enums.

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -673,7 +673,7 @@ firrtl.circuit "Foo" {
     %strings_and_empty = firrtl.list.create %strings, %empty : !firrtl.list<list<string>>
     firrtl.propassign %list, %strings_and_empty : !firrtl.list<list<string>>
 
-    // CHECK: propassign unknownString, Unknown : String
+    // CHECK: propassign unknownString, Unknown(String)
     %2 = firrtl.unknown : !firrtl.string
     firrtl.propassign %unknownString, %2 : !firrtl.string
   }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2291,13 +2291,13 @@ circuit UnknownProperties:
 
     ; CHECK:      %[[#INTEGER:]] = firrtl.unknown : !firrtl.integer
     ; CHECK-NEXT: firrtl.propassign %a, %[[#INTEGER]] : !firrtl.integer
-    propassign a, Unknown: Integer
+    propassign a, Unknown(Integer)
     ; CHECK:      %[[#STRING:]] = firrtl.unknown : !firrtl.string
     ; CHECK-NEXT: firrtl.propassign %b, %[[#STRING]] : !firrtl.string
-    propassign b, Unknown: String
+    propassign b, Unknown(String)
     ; CHECK:      %[[#INSTANCE:]] = firrtl.unknown : !firrtl.class<@Foo()>
     ; CHECK-NEXT: firrtl.propassign %c, %[[#INSTANCE]] : !firrtl.class<@Foo()>
-    propassign c, Unknown: Inst<Foo>
+    propassign c, Unknown(Inst<Foo>)
 
 ; // -----
 
@@ -2320,3 +2320,9 @@ circuit KeywordIdentifiers :
     ; CHECK: firrtl.constant -10
     connect UInt, UInt<8>(42)
     connect SInt, SInt<8>(-10)
+
+    ; Test Unknown as identifier
+    ; CHECK: %Unknown = firrtl.wire
+    wire Unknown : UInt<1>
+    ; CHECK: firrtl.constant 0
+    connect Unknown, UInt<1>(0)

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1936,7 +1936,7 @@ circuit Foo:
   public module Foo:
     output a: Integer
     ; expected-error @below {{unknown property expressions are a FIRRTL 5.1.0+ feature}}
-    propassign a, Unknown: Integer
+    propassign a, Unknown(Integer)
 
 ;// -----
 
@@ -1945,7 +1945,7 @@ circuit Foo:
   public module Foo:
     output a: Integer
     ; expected-error @below {{expected property type}}
-    propassign a, Unknown: UInt<1>
+    propassign a, Unknown(UInt<1>)
 
 ;// -----
 


### PR DESCRIPTION
This change allows the FIRRTL keyword 'Unknown' to be used as an identifier
when it is not followed by '('.

The lexer now creates a special token (lp_Unknown) when 'Unknown' is
immediately followed by '(', allowing the parser to distinguish between:
- 'Unknown' as an identifier (e.g., output Unknown : UInt<1>)
- 'Unknown(String)' as an unknown property expression

This follows the same pattern as lp_ tokens for other keywords.

The syntax for unknown property expressions has been changed from
'Unknown: <type>' to 'Unknown(<type>)' to be more consistent with other
expression syntax like 'UInt<8>(42)'.

AI-assisted-by: Augment (Claude Sonnet 4.5)
