### PR TITLE
[ImportVerilog] Add basic interface definition and instantiation support

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -843,12 +843,11 @@ Context::convertModuleHeader(const slang::ast::InstanceBodySymbol *module) {
   auto loc = convertLocation(module->location);
   OpBuilder::InsertionGuard g(builder);
 
-  // We only support modules and programs for now. Extension to interfaces
-  // should be trivial though, since they are essentially the same thing with
-  // only minor differences in semantics.
+  // We currently support modules, programs and an Extention to interfaces.
   auto kind = module->getDefinition().definitionKind;
   if (kind != slang::ast::DefinitionKind::Module &&
-      kind != slang::ast::DefinitionKind::Program) {
+      kind != slang::ast::DefinitionKind::Program &&
+      kind != slang::ast::DefinitionKind::Interface) {
     mlir::emitError(loc) << "unsupported definition: "
                          << module->getDefinition().getKindString();
     return {};

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4203,3 +4203,57 @@ module UnconnectedPortsTop;
     .d()  // Unconnected ref
   );
 endmodule
+
+//===----------------------------------------------------------------------===//
+// Interfaces
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: moore.module private @EmptyIface() {
+// CHECK:         moore.output
+// CHECK:       }
+interface EmptyIface;
+endinterface
+
+// CHECK-LABEL: moore.module @EmptyIfaceTop() {
+// CHECK:         moore.instance "ei" @EmptyIface() -> ()
+// CHECK:       }
+module EmptyIfaceTop;
+  EmptyIface ei();
+endmodule
+
+// CHECK-LABEL: moore.module private @SimpleIface() {
+// CHECK:         %data = moore.variable : <l8>
+// CHECK:         %valid = moore.variable : <l1>
+// CHECK:         %ready = moore.variable : <l1>
+// CHECK:         moore.output
+// CHECK:       }
+interface SimpleIface;
+  logic [7:0] data;
+  logic valid;
+  logic ready;
+endinterface
+
+// CHECK-LABEL: moore.module @SimpleIfaceTop() {
+// CHECK:         moore.instance "si" @SimpleIface() -> ()
+// CHECK:       }
+module SimpleIfaceTop;
+  SimpleIface si();
+endmodule
+
+// CHECK-LABEL: moore.module private @BusIface() {
+// CHECK:         %req = moore.variable : <l1>
+// CHECK:         %addr = moore.variable : <l8>
+// CHECK:         moore.output
+// CHECK:       }
+interface BusIface;
+  logic req;
+  logic [7:0] addr;
+endinterface
+
+// CHECK-LABEL: moore.module @UsesIface() {
+// CHECK:         moore.instance "bus" @BusIface() -> ()
+// CHECK:       }
+module UsesIface;
+  BusIface bus();
+endmodule
+


### PR DESCRIPTION
Slang uses the same `InstanceBodySymbol` for both `modules` and `interfaces`. So rather than anything clever, this PR just adds DefinitionKind::Interface to the guard in convertModuleHeader that was previously rejecting interfaces with "unsupported definition".

now interface definitions lower to `moore.module `ops and interface instantiation produces `moore.instance `ops through
the exact same paths that modules already use

