### PR TITLE
[RTG] Same seed for all tests & random scopes

### DIFF
--- a/frontends/PyRTG/test/basic.py
+++ b/frontends/PyRTG/test/basic.py
@@ -198,26 +198,21 @@ def test1_args(config):
 # ELABORATED-NEXT: rtg.label external [[L1]]
 # ELABORATED-NEXT: [[L2:%.+]] = rtg.label_unique_decl [[L1STR]]
 # ELABORATED-NEXT: rtg.label local [[L2]]
-
 # ELABORATED-NEXT: rtg.label local [[L0]]
 # ELABORATED-NEXT: rtg.label local [[L2]]
-
 # ELABORATED-NEXT: [[LBL5:%.+]] = rtg.constant #rtg.isa.label<"L_5">
 # ELABORATED-NEXT: rtg.label local [[LBL5]]
 # ELABORATED-NEXT: [[LBL3:%.+]] = rtg.constant #rtg.isa.label<"L_3">
 # ELABORATED-NEXT: rtg.label local [[LBL3]]
-
 # ELABORATED-NEXT: rtg.label local [[L2]]
 # ELABORATED-NEXT: rtg.label local [[L0]]
-
-# ELABORATED-NEXT: rtg.label local [[L1]]
 # ELABORATED-NEXT: rtg.label local [[L1]]
 # ELABORATED-NEXT: [[L0_2:%.+]] = rtg.constant #rtg.isa.label<"l0">
 # ELABORATED-NEXT: rtg.label local [[L0_2]]
-
+# ELABORATED-NEXT: [[L0_3:%.+]] = rtg.constant #rtg.isa.label<"l0">
+# ELABORATED-NEXT: rtg.label local [[L0_3]]
 # ELABORATED-NEXT: [[L5:%.+]] = rtg.constant #rtg.isa.label<"s1">
 # ELABORATED-NEXT: rtg.label local [[L5]]
-
 # ELABORATED-NEXT: }
 
 # ASM-LABEL: Begin of test 'test2_labels
@@ -225,22 +220,16 @@ def test1_args(config):
 # ASM-NEXT: l0:
 # ASM-NEXT: .extern l1_0
 # ASM-NEXT: l1_1:
-
 # ASM-NEXT: l0:
 # ASM-NEXT: l1_1:
-
 # ASM-NEXT: L_5:
 # ASM-NEXT: L_3:
-
 # ASM-NEXT: l1_1:
 # ASM-NEXT: l0:
-
-# ASM-NEXT: l1_0:
 # ASM-NEXT: l1_0:
 # ASM-NEXT: l0:
-
+# ASM-NEXT: l0:
 # ASM-NEXT: s1:
-
 # ASM: End of test 'test2_labels
 
 

--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -758,6 +758,32 @@ def ConstraintOp : RTGOp<"constraint", []> {
   let hasCanonicalizeMethod = 1;
 }
 
+def RandomScopeOp : RTGOp<"random_scope", [
+  NoRegionArguments,
+  SingleBlockImplicitTerminator<"rtg::YieldOp">,
+]> {
+  let summary = "introduce a new scope for randomization";
+  let description = [{
+    This operation introduces a new scope for randomization. This is useful to
+    isolate randomization such that the same sequence of operations in the
+    parent scope yields the same RNG results despite operations being added in
+    this scope.
+
+    The optional seed attribute can be used to fix the RNG seed of this scope
+    such that changes in the parent region do not affect the RNG results in this
+    scope. This attribute is intended for internal uses (e.g., regression
+    tests) and not exposed to the frontend user.
+  }];
+
+  let arguments = (ins OptionalAttr<IndexAttr>:$seed);
+  let results = (outs Variadic<AnyType>:$results);
+  let regions = (region SizedRegion<1>:$bodyRegion);
+
+  let assemblyFormat = [{
+    (`seed` $seed^)? attr-dict-with-keyword (`:` type($results)^)? $bodyRegion
+  }];
+}
+
 //===- Test Specification Operations --------------------------------------===//
 
 def TestOp : RTGOp<"test", [

--- a/include/circt/Dialect/RTG/IR/RTGVisitors.h
+++ b/include/circt/Dialect/RTG/IR/RTGVisitors.h
@@ -69,9 +69,10 @@ public:
             // String ops
             StringConcatOp, IntFormatOp, ImmediateFormatOp, RegisterFormatOp,
             // Misc ops
-            CommentOp, ConstraintOp>([&](auto expr) -> ResultType {
-          return thisCast->visitOp(expr, args...);
-        })
+            CommentOp, ConstraintOp, RandomScopeOp>(
+            [&](auto expr) -> ResultType {
+              return thisCast->visitOp(expr, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           if (op->getDialect() ==
               op->getContext()->getLoadedDialect<RTGDialect>())
@@ -157,6 +158,7 @@ public:
   HANDLE(ImmediateFormatOp, Unhandled);
   HANDLE(RegisterFormatOp, Unhandled);
   HANDLE(StringToLabelOp, Unhandled);
+  HANDLE(RandomScopeOp, Unhandled);
 #undef HANDLE
 };
 

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -352,3 +352,19 @@ rtg.test @registerConversion(idx = %arg0: index, reg = %arg1: !rtgtest.ireg) {
   rtg.isa.index_to_register %arg0 : !rtgtest.ireg
   rtg.isa.register_to_index %arg1 : !rtgtest.ireg
 }
+
+// CHECK-LABEL: rtg.test @randomScope
+rtg.test @randomScope() {
+  // CHECK: %{{.*}}:2 = rtg.random_scope attributes {rtg.test = 0 : i64} : index, index {
+  %0:2 = rtg.random_scope attributes {rtg.test = 0 : i64} : index, index {
+    %low = index.constant 0
+    %high = index.constant 100
+    %1 = rtg.random_number_in_range [%low, %high]
+    // CHECK: rtg.yield %{{.*}}, %{{.*}} : index, index
+    rtg.yield %1, %1 : index, index
+  }
+
+  // CHECK: rtg.random_scope {
+  // CHECK-NEXT: }
+  rtg.random_scope {}
+}


### PR DESCRIPTION
Make sure randomness is isolated within tests. Also adds an operation that allows users to define scopes within tests such that adding test-cases to such a nested scope does not affect random choices in the parent or sibling scopes