### PR TITLE
[Comb] [NFC] Reorder arguments for the consistency in CombOps create* helpers

### DIFF
--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -54,14 +54,14 @@ Value createZExt(OpBuilder &builder, Location loc, Value value,
 
 /// Create a sign extension operation from a value of integer type to an equal
 /// or larger integer type.
-Value createOrFoldSExt(Location loc, Value value, Type destTy,
-                       OpBuilder &builder);
-Value createOrFoldSExt(Value value, Type destTy, ImplicitLocOpBuilder &builder);
+Value createOrFoldSExt(OpBuilder &builder, Location loc, Value value,
+                       Type destTy);
+Value createOrFoldSExt(ImplicitLocOpBuilder &builder, Value value, Type destTy);
 
 /// Create a ``Not'' gate on a value.
-Value createOrFoldNot(Location loc, Value value, OpBuilder &builder,
+Value createOrFoldNot(OpBuilder &builder, Location loc, Value value,
                       bool twoState = false);
-Value createOrFoldNot(Value value, ImplicitLocOpBuilder &builder,
+Value createOrFoldNot(ImplicitLocOpBuilder &builder, Value value,
                       bool twoState = false);
 
 /// Extract bits from a value.

--- a/lib/Conversion/CalyxToFSM/CalyxToFSM.cpp
+++ b/lib/Conversion/CalyxToFSM/CalyxToFSM.cpp
@@ -141,7 +141,7 @@ LogicalResult CompileFSMVisitor::visit(StateOp currentState, IfOp ifOp,
     Value branchTaken = cond;
     if (invert) {
       OpBuilder::InsertionGuard g(builder);
-      branchTaken = comb::createOrFoldNot(loc, branchTaken, builder);
+      branchTaken = comb::createOrFoldNot(builder, loc, branchTaken);
     }
 
     returnOp.setOperand(branchTaken);
@@ -242,7 +242,7 @@ LogicalResult CompileFSMVisitor::visit(StateOp currentState, WhileOp whileOp,
   nextStateTransition.ensureGuard(builder);
   builder.setInsertionPoint(nextStateTransition.getGuardReturn());
   nextStateTransition.getGuardReturn().setOperand(
-      comb::createOrFoldNot(loc, whileOp.getCond(), builder));
+      comb::createOrFoldNot(builder, loc, whileOp.getCond()));
   return success();
 }
 

--- a/lib/Conversion/CalyxToHW/CalyxToHW.cpp
+++ b/lib/Conversion/CalyxToHW/CalyxToHW.cpp
@@ -287,7 +287,7 @@ private:
               reg(writeEn, seqClk, reset, op.instanceName() + "_done_reg", b);
           auto done =
               wireOut(doneReg, op.instanceName(), op.portName(op.getDone()), b);
-          auto clockEn = AndOp::create(b, writeEn, createOrFoldNot(done, b));
+          auto clockEn = AndOp::create(b, writeEn, createOrFoldNot(b, done));
           auto outReg =
               regCe(in, seqClk, clockEn, reset, op.instanceName() + "_reg", b);
           auto out = wireOut(outReg, op.instanceName(), "", b);
@@ -310,7 +310,7 @@ private:
           auto in =
               wireIn(op.getIn(), op.instanceName(), op.portName(op.getIn()), b);
 
-          auto notOp = comb::createOrFoldNot(in, b);
+          auto notOp = comb::createOrFoldNot(b, in);
 
           auto out =
               wireOut(notOp, op.instanceName(), op.portName(op.getOut()), b);
@@ -338,9 +338,8 @@ private:
         .Case([&](ExtSILibOp op) {
           auto in =
               wireIn(op.getIn(), op.instanceName(), op.portName(op.getIn()), b);
-          auto extsi = wireOut(
-              createOrFoldSExt(op.getLoc(), in, op.getOut().getType(), b),
-              op.instanceName(), op.portName(op.getOut()), b);
+          auto extsi = wireOut(createOrFoldSExt(b, in, op.getOut().getType()),
+                               op.instanceName(), op.portName(op.getOut()), b);
           wires.append({in.getInput(), extsi});
         })
         .Default([](Operation *) { return SmallVector<Value>(); });
@@ -401,7 +400,7 @@ private:
     for (auto &&[targetRes, sourceRes] :
          llvm::zip(targetOp->getResults(), op.getOutputPorts())) {
       auto portName = op.portName(sourceRes);
-      auto clockEn = AndOp::create(b, go, createOrFoldNot(done, b));
+      auto clockEn = AndOp::create(b, go, createOrFoldNot(b, done));
       auto resReg = regCe(targetRes, seqClk, clockEn, reset,
                           createName(op.instanceName(), portName), b);
       wires.push_back(wireOut(resReg, op.instanceName(), portName, b));

--- a/lib/Conversion/DCToHW/DCToHW.cpp
+++ b/lib/Conversion/DCToHW/DCToHW.cpp
@@ -355,7 +355,7 @@ struct RTLBuilder {
   }
 
   Value sext(Value value, unsigned outWidth, StringRef name = {}) {
-    return comb::createOrFoldSExt(loc, value, b.getIntegerType(outWidth), b);
+    return comb::createOrFoldSExt(b, loc, value, b.getIntegerType(outWidth));
   }
 
   ///  Extracts a single bit v[bit].

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -622,7 +622,7 @@ struct RTLBuilder {
 
   Value sext(Value value, unsigned outWidth,
              std::optional<StringRef> name = {}) {
-    return comb::createOrFoldSExt(loc, value, b.getIntegerType(outWidth), b);
+    return comb::createOrFoldSExt(b, loc, value, b.getIntegerType(outWidth));
   }
 
   // Extracts a single bit v[bit].

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -105,7 +105,7 @@ struct LTLImplicationConversion
       return failure();
     /// A -> B = !A || B
     auto loc = op.getLoc();
-    auto notA = comb::createOrFoldNot(loc, adaptor.getAntecedent(), rewriter);
+    auto notA = comb::createOrFoldNot(rewriter, loc, adaptor.getAntecedent());
     auto orOp =
         comb::OrOp::create(rewriter, loc, notA, adaptor.getConsequent());
     rewriter.replaceOp(op, orOp);
@@ -123,7 +123,7 @@ struct LTLNotConversion : public OpConversionPattern<ltl::NotOp> {
     if (!isa<IntegerType>(op.getInput().getType()))
       return failure();
     auto loc = op.getLoc();
-    auto inverted = comb::createOrFoldNot(loc, adaptor.getInput(), rewriter);
+    auto inverted = comb::createOrFoldNot(rewriter, loc, adaptor.getInput());
     rewriter.replaceOp(op, inverted);
     return success();
   }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1727,7 +1727,7 @@ struct SExtOpConversion : public OpConversionPattern<SExtOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto type = typeConverter->convertType(op.getType());
     auto value =
-        comb::createOrFoldSExt(op.getLoc(), adaptor.getInput(), type, rewriter);
+        comb::createOrFoldSExt(rewriter, op.getLoc(), adaptor.getInput(), type);
     rewriter.replaceOp(op, value);
     return success();
   }

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -106,7 +106,7 @@ public:
     Value notStalled;
     auto getOrSetNotStalled = [&]() {
       if (!notStalled) {
-        notStalled = comb::createOrFoldNot(loc, args.stall, builder);
+        notStalled = comb::createOrFoldNot(builder, loc, args.stall);
       }
       return notStalled;
     };
@@ -396,7 +396,7 @@ public:
       case StageKind::Stallable:
         stageEnabled = seq::CompRegClockEnabledOp::create(
             builder, loc, args.enable, args.clock,
-            comb::createOrFoldNot(loc, args.stall, builder), args.reset,
+            comb::createOrFoldNot(builder, loc, args.stall), args.reset,
             enableRegResetVal, enableRegName);
         break;
       case StageKind::Runoff:
@@ -405,7 +405,7 @@ public:
         stageEnabled = seq::CompRegClockEnabledOp::create(
             builder, loc, args.enable, args.clock,
             comb::OrOp::create(builder, loc, args.lnsEn,
-                               comb::createOrFoldNot(loc, args.stall, builder)),
+                               comb::createOrFoldNot(builder, loc, args.stall)),
             args.reset, enableRegResetVal, enableRegName);
         break;
       }

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -638,7 +638,7 @@ private:
     hw::ConstantOp c1 = createConstant(loc, rewriter, getComponent(), 1, 1);
     calyx::AssignOp::create(
         rewriter, loc, opPipe.getGo(), c1,
-        comb::createOrFoldNot(group.getLoc(), opPipe.getDone(), builder));
+        comb::createOrFoldNot(builder, group.getLoc(), opPipe.getDone()));
     // The group is done when the register write is complete.
     calyx::GroupDoneOp::create(rewriter, loc, reg.getDone());
 
@@ -718,7 +718,7 @@ private:
 
     calyx::AssignOp::create(
         rewriter, loc, calyxOp.getGo(), c1,
-        comb::createOrFoldNot(loc, calyxOp.getDone(), builder));
+        comb::createOrFoldNot(builder, loc, calyxOp.getDone()));
     calyx::GroupDoneOp::create(rewriter, loc, reg.getDone());
 
     return success();
@@ -1183,7 +1183,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   // Set the go and done signal
   calyx::AssignOp::create(
       rewriter, loc, calyxCmpFOp.getGo(), c1,
-      comb::createOrFoldNot(loc, calyxCmpFOp.getDone(), builder));
+      comb::createOrFoldNot(builder, loc, calyxCmpFOp.getDone()));
   calyx::GroupDoneOp::create(rewriter, loc, reg.getDone());
 
   cmpf.getResult().replaceAllUsesWith(reg.getOut());

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -319,7 +319,7 @@ public:
         rewriter, loc, llvm::SmallVector<sv::EventControl>{},
         llvm::SmallVector<Value>{}, [&]() {
           sv::IfOp::create(
-              rewriter, loc, comb::createOrFoldNot(loc, clk, rewriter), [&]() {
+              rewriter, loc, comb::createOrFoldNot(rewriter, loc, clk), [&]() {
                 sv::PAssignOp::create(rewriter, loc, enableLatch, enable);
               });
         });

--- a/lib/Dialect/Calyx/Transforms/CompileControl.cpp
+++ b/lib/Dialect/Calyx/Transforms/CompileControl.cpp
@@ -128,7 +128,7 @@ void CompileControlVisitor::visit(SeqOp seq, ComponentOp &component) {
     auto eqCmp =
         comb::ICmpOp::create(builder, wires->getLoc(), comb::ICmpPredicate::eq,
                              fsmOut, fsmCurrentState, false);
-    auto notDone = comb::createOrFoldNot(wires->getLoc(), doneOpValue, builder);
+    auto notDone = comb::createOrFoldNot(builder, wires->getLoc(), doneOpValue);
     auto groupGoGuard =
         comb::AndOp::create(builder, wires->getLoc(), eqCmp, notDone, false);
 

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -274,7 +274,7 @@ struct SextCompress : public OpRewritePattern<CompressOp> {
       auto signBit = comb::ExtractOp::create(rewriter, op.getLoc(), sextInput,
                                              baseWidth - 1, 1);
       auto invSign =
-          comb::createOrFoldNot(op.getLoc(), signBit, rewriter, true);
+          comb::createOrFoldNot(rewriter, op.getLoc(), signBit, true);
       // {~x[p-1], x[p-2:0]}
       auto newOp = comb::ConcatOp::create(rewriter, op.getLoc(),
                                           ValueRange{invSign, base});
@@ -522,7 +522,7 @@ struct SignedPartialProducts : public OpRewritePattern<PartialProductOp> {
     auto lhsSignAndRhs =
         comb::AndOp::create(rewriter, op.getLoc(), lhsSignReplicate, rhsBase);
     auto lhsSignCorrection =
-        comb::createOrFoldNot(op.getLoc(), lhsSignAndRhs, rewriter, true);
+        comb::createOrFoldNot(rewriter, op.getLoc(), lhsSignAndRhs, true);
 
     // zext({lhsSignCorrection, lhsBaseWidth{1'b0}})
     auto alignLhsSignCorrection = zeroPad(
@@ -534,7 +534,7 @@ struct SignedPartialProducts : public OpRewritePattern<PartialProductOp> {
     auto rhsSignAndLhs =
         comb::AndOp::create(rewriter, op.getLoc(), rhsSignReplicate, lhsBase);
     auto rhsSignCorrection =
-        comb::createOrFoldNot(op.getLoc(), rhsSignAndLhs, rewriter, true);
+        comb::createOrFoldNot(rewriter, op.getLoc(), rhsSignAndLhs, true);
 
     // zext({rhsSignCorrection, rhsBaseWidth{1'b0}})
     auto alignRhsSignCorrection = zeroPad(

--- a/lib/Dialect/Datapath/Transforms/ReduceDelay.cpp
+++ b/lib/Dialect/Datapath/Transforms/ReduceDelay.cpp
@@ -204,7 +204,7 @@ struct ConvertCmpToAdd : public OpRewritePattern<comb::ICmpOp> {
     SmallVector<Value> rhsExtend;
     for (auto addend : rhsAddends) {
       auto ext = comb::createZExt(rewriter, op.getLoc(), addend, width + 1);
-      auto negatedAddend = comb::createOrFoldNot(op.getLoc(), ext, rewriter);
+      auto negatedAddend = comb::createOrFoldNot(rewriter, op.getLoc(), ext);
       rhsExtend.push_back(negatedAddend);
     }
 
@@ -222,7 +222,7 @@ struct ConvertCmpToAdd : public OpRewritePattern<comb::ICmpOp> {
       return success();
     }
 
-    auto notOp = comb::createOrFoldNot(op.getLoc(), msb, rewriter);
+    auto notOp = comb::createOrFoldNot(rewriter, op.getLoc(), msb);
     rewriter.replaceOp(op, notOp);
     return success();
   }

--- a/lib/Dialect/ESI/Passes/ESILowerPhysical.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerPhysical.cpp
@@ -157,8 +157,9 @@ FIFOLowering::matchAndRewrite(FIFOOp op, OpAdaptor adaptor,
     auto unwrapValidReady =
         UnwrapValidReadyOp::create(rewriter, loc, chanInput, inputEn);
     rawData = unwrapValidReady.getRawOutput();
-    dataNotAvailable = comb::createOrFoldNot(loc, unwrapValidReady.getValid(),
-                                             rewriter, /*twoState=*/true);
+    dataNotAvailable =
+        comb::createOrFoldNot(rewriter, loc, unwrapValidReady.getValid(),
+                              /*twoState=*/true);
     dataNotAvailable.getDefiningOp()->setAttr(
         "sv.namehint", rewriter.getStringAttr("dataNotAvailable"));
   } else if (chanInput.getType().getSignaling() == ChannelSignaling::FIFO) {
@@ -192,7 +193,7 @@ FIFOLowering::matchAndRewrite(FIFOOp op, OpAdaptor adaptor,
   if (outputType.getSignaling() == ChannelSignaling::ValidReady) {
     auto wrap = WrapValidReadyOp::create(
         rewriter, loc, mlir::TypeRange{outputType, i1}, seqFifo.getOutput(),
-        comb::createOrFoldNot(loc, seqFifo.getEmpty(), rewriter,
+        comb::createOrFoldNot(rewriter, loc, seqFifo.getEmpty(),
                               /*twoState=*/true));
     output = wrap.getChanOutput();
     outputRdEn.setValue(

--- a/lib/Dialect/LLHD/Transforms/RemoveControlFlow.cpp
+++ b/lib/Dialect/LLHD/Transforms/RemoveControlFlow.cpp
@@ -94,7 +94,7 @@ struct Condition {
       return false;
     if (isFalse())
       return true;
-    return comb::createOrFoldNot(getValue().getLoc(), getValue(), builder);
+    return comb::createOrFoldNot(builder, getValue().getLoc(), getValue());
   }
 
 private:

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -615,7 +615,7 @@ LogicalResult IfOp::canonicalize(IfOp op, PatternRewriter &rewriter) {
   // region if the condition is a 2-state operation.  This changes x prop
   // behavior so it needs to be guarded.
   if (is2StateExpression(op.getCond())) {
-    auto cond = comb::createOrFoldNot(op.getLoc(), op.getCond(), rewriter);
+    auto cond = comb::createOrFoldNot(rewriter, op.getLoc(), op.getCond());
     op.setOperand(cond);
 
     auto *thenBlock = op.getThenBlock(), *elseBlock = op.getElseBlock();

--- a/lib/Dialect/Seq/Transforms/LowerSeqFIFO.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqFIFO.cpp
@@ -86,8 +86,8 @@ public:
     fifoEmpty->setAttr("sv.namehint", rewriter.getStringAttr("fifo_empty"));
 
     // ====== Next-state count ======
-    auto notRdEn = comb::createOrFoldNot(loc, adaptor.getRdEn(), rewriter);
-    auto notWrEn = comb::createOrFoldNot(loc, adaptor.getWrEn(), rewriter);
+    auto notRdEn = comb::createOrFoldNot(rewriter, loc, adaptor.getRdEn());
+    auto notWrEn = comb::createOrFoldNot(rewriter, loc, adaptor.getWrEn());
     Value rdEnNandWrEn = comb::AndOp::create(rewriter, loc, notRdEn, notWrEn);
     Value rdEnAndNotWrEn =
         comb::AndOp::create(rewriter, loc, adaptor.getRdEn(), notWrEn);
@@ -124,7 +124,7 @@ public:
     // ====== Read/write pointers ======
     Value wrAndNotFull =
         comb::AndOp::create(rewriter, loc, adaptor.getWrEn(),
-                            comb::createOrFoldNot(loc, fifoFull, rewriter));
+                            comb::createOrFoldNot(rewriter, loc, fifoFull));
     auto addWrAddrPtrTc1 = comb::AddOp::create(rewriter, loc, wrAddr, ptrTc1);
 
     auto wrAddrNextNoRollover = comb::MuxOp::create(rewriter, loc, wrAndNotFull,
@@ -138,7 +138,7 @@ public:
         .getDefiningOp()
         ->setAttr("sv.namehint", rewriter.getStringAttr("fifo_wr_addr_next"));
 
-    auto notFifoEmpty = comb::createOrFoldNot(loc, fifoEmpty, rewriter);
+    auto notFifoEmpty = comb::createOrFoldNot(rewriter, loc, fifoEmpty);
     Value rdAndNotEmpty =
         comb::AndOp::create(rewriter, loc, adaptor.getRdEn(), notFifoEmpty);
     auto addRdAddrPtrTc1 = comb::AddOp::create(rewriter, loc, rdAddr, ptrTc1);
@@ -186,15 +186,15 @@ public:
     // ====== Protocol checks =====
     Value clkI1 = seq::FromClockOp::create(rewriter, loc, clk);
     Value notEmptyAndRden = comb::createOrFoldNot(
-        loc, comb::AndOp::create(rewriter, loc, adaptor.getRdEn(), fifoEmpty),
-        rewriter);
+        rewriter, loc,
+        comb::AndOp::create(rewriter, loc, adaptor.getRdEn(), fifoEmpty));
     verif::ClockedAssertOp::create(
         rewriter, loc, notEmptyAndRden, verif::ClockEdge::Pos, clkI1,
         /*enable=*/Value(),
         rewriter.getStringAttr("FIFO empty when read enabled"));
     Value notFullAndWren = comb::createOrFoldNot(
-        loc, comb::AndOp::create(rewriter, loc, adaptor.getWrEn(), fifoFull),
-        rewriter);
+        rewriter, loc,
+        comb::AndOp::create(rewriter, loc, adaptor.getWrEn(), fifoFull));
     verif::ClockedAssertOp::create(
         rewriter, loc, notFullAndWren, verif::ClockEdge::Pos, clkI1,
         /*enable=*/Value(),

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -67,9 +67,9 @@ public:
   matchAndRewrite(arith::ExtSIOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     size_t outWidth = op.getType().getIntOrFloatBitWidth();
-    rewriter.replaceOp(op, comb::createOrFoldSExt(
-                               op.getLoc(), op.getOperand(),
-                               rewriter.getIntegerType(outWidth), rewriter));
+    rewriter.replaceOp(
+        op, comb::createOrFoldSExt(rewriter, op.getLoc(), op.getOperand(),
+                                   rewriter.getIntegerType(outWidth)));
     return success();
   }
 };


### PR DESCRIPTION
Reorder parameters in createOrFoldSExt and createOrFoldNot to match MLIR convention for builder method: (OpBuilder &builder, Location loc, ...) instead of (Location loc, ..., OpBuilder &builder).