### PR TITLE
[circt-bmc] Add verif.contract support

### DIFF
--- a/lib/Tools/circt-bmc/LowerToBMC.cpp
+++ b/lib/Tools/circt-bmc/LowerToBMC.cpp
@@ -190,6 +190,12 @@ void LowerToBMCPass::runOnOperation() {
   bmcOp.getCircuit().takeBody(hwModule.getBody());
   hwModule->erase();
 
+  // Erase leftover hw.module/hw.module.extern ops (e.g., apply-mode modules
+  // from contract lowering) that would cause ConvertHWToSMT to fail.
+  for (auto &op : llvm::make_early_inc_range(moduleOp.getOps()))
+    if (isa<hw::HWModuleOp, hw::HWModuleExternOp>(op))
+      op.erase();
+
   // Define global string constants to print on success/failure
   auto createUniqueStringGlobal = [&](StringRef str) -> FailureOr<Value> {
     Location loc = moduleOp.getLoc();

--- a/test/Tools/circt-bmc/circt-bmc-contract-wrong.mlir
+++ b/test/Tools/circt-bmc/circt-bmc-contract-wrong.mlir
@@ -1,0 +1,24 @@
+// Test that circt-bmc produces well-formed SMT output for a wrong contract
+// (one the solver would find a counterexample for at runtime).
+
+// RUN: circt-bmc %s --module WrongMul_CheckContract_0 -b 1 --emit-mlir | FileCheck %s
+
+// The pipeline should still succeed — it produces valid SMT IR regardless of
+// whether the property holds.  The solver (at JIT runtime) determines pass/fail.
+// CHECK:       func.func @WrongMul_CheckContract_0()
+// CHECK:         smt.solver
+// CHECK:       func.func @bmc_circuit(%{{.+}}: !smt.bv<42>)
+// CHECK:         smt.assert
+
+// A wrong contract: claims a * 9 but implements a * 8 (missing + a).
+hw.module @WrongMul(in %a: i42, out z: i42) {
+  %c3_i42 = hw.constant 3 : i42
+  %c9_i42 = hw.constant 9 : i42
+  %0 = comb.shl %a, %c3_i42 : i42
+  %1 = verif.contract %0 : i42 {
+    %2 = comb.mul %a, %c9_i42 : i42
+    %3 = comb.icmp eq %1, %2 : i42
+    verif.ensure %3 : i1
+  }
+  hw.output %1 : i42
+}

--- a/test/Tools/circt-bmc/circt-bmc-contract.mlir
+++ b/test/Tools/circt-bmc/circt-bmc-contract.mlir
@@ -1,0 +1,29 @@
+// Test that circt-bmc can verify verif.contract ops end-to-end.
+
+// RUN: circt-bmc %s --module Mul9_CheckContract_0 -b 1 --emit-mlir | FileCheck %s
+
+// The full pipeline (lower-contracts -> lower-tests -> flatten-modules ->
+// externalize-registers -> lower-to-bmc -> convert-hw-to-smt -> ...) should
+// produce a solver invocation with the contract property encoded in SMT.
+// CHECK:       func.func @Mul9_CheckContract_0()
+// CHECK:         smt.solver
+// CHECK:       func.func @bmc_circuit(%{{.+}}: !smt.bv<42>)
+// CHECK:         smt.bv.shl
+// CHECK:         smt.bv.add
+// CHECK:         smt.bv.mul
+// CHECK:         smt.eq
+// CHECK:         smt.assert
+
+// A correct contract: a * 9 == (a << 3) + a
+hw.module @Mul9(in %a: i42, out z: i42) {
+  %c3_i42 = hw.constant 3 : i42
+  %c9_i42 = hw.constant 9 : i42
+  %0 = comb.shl %a, %c3_i42 : i42
+  %1 = comb.add %a, %0 : i42
+  %2 = verif.contract %1 : i42 {
+    %3 = comb.mul %a, %c9_i42 : i42
+    %4 = comb.icmp eq %2, %3 : i42
+    verif.ensure %4 : i1
+  }
+  hw.output %2 : i42
+}

--- a/test/Tools/circt-bmc/lower-to-bmc-contract.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-contract.mlir
@@ -1,0 +1,115 @@
+// Test that lower-to-bmc erases leftover hw.module ops after absorbing the
+// target module (e.g., apply-mode modules from contract lowering).
+
+// RUN: circt-opt --lower-to-bmc="top-module=Mul9_CheckContract_0 bound=10" %s | FileCheck %s
+// RUN: circt-opt --lower-to-bmc="top-module=ShiftLeft_CheckContract_0 bound=10" %s | FileCheck %s --check-prefix=SHIFT
+
+// All hw.module ops should be erased after lower-to-bmc absorbs the target.
+// CHECK-NOT: hw.module
+
+// The check module should be absorbed into a verif.bmc op and replaced by a
+// func.func of the same name.
+// CHECK:  func.func @Mul9_CheckContract_0() {
+// CHECK:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 0 initial_values [] init {
+// CHECK:    } loop {
+// CHECK:    } circuit {
+// CHECK:    ^bb0([[A:%.+]]: i42):
+// CHECK:      [[C9:%.+]] = hw.constant 9 : i42
+// CHECK:      [[C3:%.+]] = hw.constant 3 : i42
+// CHECK:      [[SHL:%.+]] = comb.shl [[A]], [[C3]]
+// CHECK:      [[ADD:%.+]] = comb.add [[A]], [[SHL]]
+// CHECK:      [[MUL:%.+]] = comb.mul [[A]], [[C9]]
+// CHECK:      [[EQ:%.+]] = comb.icmp eq [[ADD]], [[MUL]]
+// CHECK:      verif.assert [[EQ]]
+// CHECK:    }
+
+// All hw.module ops should be erased.
+// SHIFT-NOT: hw.module
+
+// Test with require (precondition) + ensure (postcondition).
+// SHIFT:  func.func @ShiftLeft_CheckContract_0() {
+// SHIFT:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 0 initial_values [] init {
+// SHIFT:    } loop {
+// SHIFT:    } circuit {
+// SHIFT:    ^bb0([[B:%.+]]: i8, [[A:%.+]]: i8):
+// SHIFT:      verif.assume
+// SHIFT:      verif.assert
+// SHIFT:    }
+
+// Input: pre-lowered contract IR (after lower-contracts, lower-tests,
+// flatten-modules, and externalize-registers).
+//
+// hw.module @Mul9 is the apply-mode module — it has verif.assume and
+// verif.symbolic_value but no assertions.  lower-to-bmc targets
+// @Mul9_CheckContract_0 and should erase @Mul9 afterward.
+
+hw.module @Mul9(in %a : i42, out z : i42) attributes {initial_values = [], num_regs = 0 : i32} {
+  %c3_i42 = hw.constant 3 : i42
+  %c9_i42 = hw.constant 9 : i42
+  %0 = comb.shl %a, %c3_i42 : i42
+  %1 = comb.add %a, %0 : i42
+  %2 = verif.symbolic_value : i42
+  %3 = comb.mul %a, %c9_i42 : i42
+  %4 = comb.icmp eq %2, %3 : i42
+  verif.assume %4 : i1
+  hw.output %2 : i42
+}
+
+hw.module @Mul9_CheckContract_0(in %symbolic_value_0 : i42) attributes {initial_values = [], num_regs = 0 : i32} {
+  %c9_i42 = hw.constant 9 : i42
+  %c3_i42 = hw.constant 3 : i42
+  %0 = comb.shl %symbolic_value_0, %c3_i42 : i42
+  %1 = comb.add %symbolic_value_0, %0 : i42
+  %2 = comb.mul %symbolic_value_0, %c9_i42 : i42
+  %3 = comb.icmp eq %1, %2 : i42
+  verif.assert %3 : i1
+  hw.output
+}
+
+// hw.module @ShiftLeft is the apply-mode module for a contract with both
+// require (precondition) and ensure (postcondition).
+
+hw.module @ShiftLeft(in %a : i8, in %b : i8, out z : i8) attributes {initial_values = [], num_regs = 0 : i32} {
+  %c4_i8 = hw.constant 4 : i8
+  %c2_i8 = hw.constant 2 : i8
+  %c1_i8 = hw.constant 1 : i8
+  %0 = comb.extract %b from 2 : (i8) -> i1
+  %1 = comb.extract %b from 1 : (i8) -> i1
+  %2 = comb.extract %b from 0 : (i8) -> i1
+  %3 = comb.shl %a, %c4_i8 : i8
+  %4 = comb.mux %0, %3, %a : i8
+  %5 = comb.shl %4, %c2_i8 : i8
+  %6 = comb.mux %1, %5, %4 : i8
+  %7 = comb.shl %6, %c1_i8 : i8
+  %8 = comb.mux %2, %7, %6 : i8
+  %9 = verif.symbolic_value : i8
+  %c8_i8 = hw.constant 8 : i8
+  %10 = comb.icmp ult %b, %c8_i8 : i8
+  verif.assert %10 : i1
+  %11 = comb.shl %a, %b : i8
+  %12 = comb.icmp eq %9, %11 : i8
+  verif.assume %12 : i1
+  hw.output %9 : i8
+}
+
+hw.module @ShiftLeft_CheckContract_0(in %symbolic_value_0 : i8, in %symbolic_value_1 : i8) attributes {initial_values = [], num_regs = 0 : i32} {
+  %0 = comb.extract %symbolic_value_0 from 0 : (i8) -> i1
+  %c1_i8 = hw.constant 1 : i8
+  %1 = comb.extract %symbolic_value_0 from 1 : (i8) -> i1
+  %c2_i8 = hw.constant 2 : i8
+  %2 = comb.extract %symbolic_value_0 from 2 : (i8) -> i1
+  %c4_i8 = hw.constant 4 : i8
+  %3 = comb.shl %symbolic_value_1, %c4_i8 : i8
+  %4 = comb.mux %2, %3, %symbolic_value_1 : i8
+  %5 = comb.shl %4, %c2_i8 : i8
+  %6 = comb.mux %1, %5, %4 : i8
+  %7 = comb.shl %6, %c1_i8 : i8
+  %8 = comb.mux %0, %7, %6 : i8
+  %c8_i8 = hw.constant 8 : i8
+  %9 = comb.icmp ult %symbolic_value_0, %c8_i8 : i8
+  verif.assume %9 : i1
+  %10 = comb.shl %symbolic_value_1, %symbolic_value_0 : i8
+  %11 = comb.icmp eq %8, %10 : i8
+  verif.assert %11 : i1
+  hw.output
+}

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -200,6 +200,12 @@ static LogicalResult executeBMC(MLIRContext &context) {
         std::make_unique<VerbosePassInstrumentation<mlir::ModuleOp>>(
             "circt-bmc"));
 
+  // Lower verif.contract ops into verif.formal check blocks + apply-mode
+  // hw.modules.  LowerTests then converts verif.formal into hw.module,
+  // turning verif.symbolic_value ops into regular input ports that BMC
+  // treats as unconstrained solver variables.
+  pm.addPass(verif::createLowerContractsPass());
+
   pm.addPass(om::createStripOMPass());
   pm.addPass(emit::createStripEmitPass());
   pm.addPass(verif::createLowerTestsPass());


### PR DESCRIPTION
circt-bmc currently handles verif.formal ops (added in #9145) but not verif.contract ops. Running circt-bmc on a module containing a verif.contract fails at ConvertHWToSMT because the apply-mode hw.module produced by LowerContracts is still present when the HW dialect is marked illegal.

This patch adds contract support with two small changes:

1. circt-bmc.cpp: Add LowerContractsPass to the pipeline before LowerTests. LowerContracts splits each contract into a verif.formal check block and an apply-mode hw.module; the existing LowerTests then converts the verif.formal into an hw.module that BMC can target.
2. LowerToBMC.cpp: After absorbing the target hw.module into a verif.bmc op, erase any remaining hw.module/hw.module.extern ops. Without this, the leftover apply-mode modules cause ConvertHWToSMT to fail.

Usage: circt-bmc input.mlir --module <Name>_CheckContract_0 -b <bound> --run

The check module name is generated by LowerContracts (pattern: <OriginalModule>_CheckContract_<N>).