### PR TITLE
[Synth][CutRewriter] Migrate CutRewriter to use Flat IR

### DIFF
--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -182,10 +182,11 @@ struct SOPBalancingPattern : public CutRewritePattern {
 
   std::optional<MatchResult> match(CutEnumerator &enumerator,
                                    const Cut &cut) const override {
-    if (cut.isTrivialCut() || cut.getOutputSize() != 1)
+    const auto &network = enumerator.getLogicNetwork();
+    if (cut.isTrivialCut() || cut.getOutputSize(network) != 1)
       return std::nullopt;
 
-    const auto &tt = cut.getTruthTable();
+    const auto &tt = *cut.getTruthTable();
     const SOPForm &sop = sopCache.getOrCompute(tt.table, tt.numInputs);
     if (sop.cubes.empty())
       return std::nullopt;
@@ -213,7 +214,8 @@ struct SOPBalancingPattern : public CutRewritePattern {
 
   FailureOr<Operation *> rewrite(OpBuilder &builder, CutEnumerator &enumerator,
                                  const Cut &cut) const override {
-    const auto &tt = cut.getTruthTable();
+    const auto &network = enumerator.getLogicNetwork();
+    const auto &tt = *cut.getTruthTable();
     const SOPForm &sop = sopCache.getOrCompute(tt.table, tt.numInputs);
     LLVM_DEBUG({
       llvm::dbgs() << "Rewriting SOP:\n";
@@ -223,16 +225,22 @@ struct SOPBalancingPattern : public CutRewritePattern {
     SmallVector<DelayType, expectedISOPInputs> arrivalTimes;
     if (failed(cut.getInputArrivalTimes(enumerator, arrivalTimes)))
       return failure();
+
     // Construct the fused location.
     SetVector<Location> inputLocs;
-    inputLocs.insert(cut.getRoot()->getLoc());
-    for (auto input : cut.inputs)
+    auto *rootOp = network.getGate(cut.getRootIndex()).getOperation();
+    assert(rootOp && "cut root must be a valid operation");
+    inputLocs.insert(rootOp->getLoc());
+
+    SmallVector<Value> inputValues;
+    network.getValues(cut.inputs, inputValues);
+    for (auto input : inputValues)
       inputLocs.insert(input.getLoc());
 
     auto loc = builder.getFusedLoc(inputLocs.getArrayRef());
 
-    Value result = buildBalancedSOP(builder, loc, sop, cut.inputs.getArrayRef(),
-                                    arrivalTimes);
+    Value result =
+        buildBalancedSOP(builder, loc, sop, inputValues, arrivalTimes);
 
     auto *op = result.getDefiningOp();
     if (!op)

--- a/lib/Support/TruthTable.cpp
+++ b/lib/Support/TruthTable.cpp
@@ -165,11 +165,9 @@ llvm::SmallVector<unsigned> identityPermutation(unsigned size) {
 unsigned permuteNegationMask(unsigned negationMask,
                              ArrayRef<unsigned> permutation) {
   unsigned result = 0;
-  for (unsigned i = 0; i < permutation.size(); ++i) {
-    if (negationMask & (1u << i)) {
-      result |= (1u << permutation[i]);
-    }
-  }
+  for (unsigned i = 0; i < permutation.size(); ++i)
+    if (negationMask & (1u << permutation[i]))
+      result |= (1u << i);
   return result;
 }
 

--- a/test/Dialect/Synth/lut-mapper.mlir
+++ b/test/Dialect/Synth/lut-mapper.mlir
@@ -9,7 +9,7 @@
 
 // LUT-NEXT:   %[[C_0:.+]] = comb.truth_table %[[A_0]], %[[B_0]] -> [false, true, true, false]
 // LUT-SAME:   test.arrival_times = [1]
-// LUT-NEXT:   %[[C_1:.+]] = comb.truth_table %[[B_1]], %[[A_1]], %[[A_0]], %[[B_0]] ->  [false, false, false, true, true, true, true, false, true, true, true, false, false, false, false, true]
+// LUT-NEXT:   %[[C_1:.+]] = comb.truth_table %[[A_1]], %[[A_0]], %[[B_1]], %[[B_0]] -> [false, false, true, true, false, true, true, false, true, true, false, false, true, false, false, true]
 // LUT-SAME:   test.arrival_times = [1]
 // LUT-NEXT:   %[[C_2:.+]] = comb.concat %[[C_1]], %[[C_0]] : i1, i1
 // LUT-NEXT:   hw.output %[[C_2]] : i2

--- a/test/Dialect/Synth/priority-cuts-error.mlir
+++ b/test/Dialect/Synth/priority-cuts-error.mlir
@@ -1,11 +1,5 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(hw.module(synth-test-priority-cuts))' %s --split-input-file --verify-diagnostics
 
-hw.module @test_too_many_operands(in %a : i1, in %b : i1, in %c : i1, out result : i1) {
-    // expected-error @+1 {{Cut enumeration supports at most 2 operands, found: 3}}
-    %and_three = synth.aig.and_inv %a, %b, %c : i1
-    hw.output %and_three : i1
-}
-
 // -----
 
 hw.module @test_multi_bit_result(in %a : i2, in %b : i2, out result : i2) {

--- a/test/Dialect/Synth/priority-cuts.mlir
+++ b/test/Dialect/Synth/priority-cuts.mlir
@@ -30,8 +30,7 @@
 
 // CHECK-LABEL: Enumerating cuts for module: trivial
 hw.module @trivial(in %a : i1, out result : i1) {
-    // CHECK: a 1 cuts: {a}@t2d0
-    // CHECK-NEXT: out0 2 cuts: {out0}@t2d0 {a}@t2d1
+    // CHECK: out0 2 cuts: {out0}@t2d0 {a}@t2d1
     // CHECK-NEXT: Cut enumeration completed successfully
     %out0 = synth.aig.and_inv %a, %a {sv.namehint = "out0"} : i1
     hw.output %out0 : i1
@@ -39,9 +38,7 @@ hw.module @trivial(in %a : i1, out result : i1) {
 
 // CHECK-LABEL: Enumerating cuts for module: extract
 hw.module @extract(in %a : i2, out result : i1) {
-    // CHECK:      a0 1 cuts: {a0}@t2d0
-    // CHECK-NEXT: a1 1 cuts: {a1}@t2d0
-    // CHECK-NEXT: out0 2 cuts: {out0}@t2d0 {a0, a1}@t8d1
+    // CHECK: out0 2 cuts: {out0}@t2d0 {a0, a1}@t8d1
     // CHECK-NEXT: Cut enumeration completed successfully
     %a0 = comb.extract %a from 0 {sv.namehint = "a0"}: (i2) -> i1
     %a1 = comb.extract %a from 1 {sv.namehint = "a1"}: (i2) -> i1
@@ -51,28 +48,22 @@ hw.module @extract(in %a : i2, out result : i1) {
 
 // CHECK-LABEL: Enumerating cuts for module: test
 hw.module @test(in %a : i4, in %b : i2, out result : i3) {
-    // CHECK:     a0 1 cuts: {a0}@t2d0
-    // CHECK-NEXT: a1 1 cuts: {a1}@t2d0
     // CHECK-NEXT: and0 2 cuts: {and0}@t2d0 {a0, a1}@t8d1
-    // CHECK-NEXT: a2 1 cuts: {a2}@t2d0
-    // CHECK-NEXT: b0 1 cuts: {b0}@t2d0
     // CHECK-NEXT: and1 2 cuts: {and1}@t2d0 {a2, b0}@t2d1
-    // CHECK-NEXT: a3 1 cuts: {a3}@t2d0
-    // CHECK-NEXT: b1 1 cuts: {b1}@t2d0
     // ROOT8-NEXT: and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
-    // ROOT8-NEXT: out0 3 cuts: {out0}@t2d0 {a0, a1, b0}@t128d1 {and0, b0}@t8d2
-    // ROOT8-NEXT: out1 5 cuts: {out1}@t2d0 {a2, b0, a0, a1}@t546d1 {and1, and0}@t2d2 {a0, a1, and1}@t112d2 {a2, b0, and0}@t2d2
-    // ROOT8-NEXT: out2 3 cuts: {out2}@t2d0 {a3, b1}@t8d1 {and2, b1}@t8d2
+    // ROOT8-NEXT: out0 3 cuts: {out0}@t2d0 {a0, a1, b0}@t128d1 {b0, and0}@t8d2
+    // ROOT8-NEXT: out1 5 cuts: {out1}@t2d0 {a0, a1, a2, b0}@t112d1 {and0, and1}@t4d2 {a0, a1, and1}@t112d2 {a2, b0, and0}@t2d2
+    // ROOT8-NEXT: out2 3 cuts: {out2}@t2d0 {a3, b1}@t8d1 {b1, and2}@t8d2
     // Check that the cuts are correctly limited when max-cuts-per-root is set to 2.
     // Currently (depth, input size) is used as the cut priority.
     // ROOT2-NEXT: and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
     // ROOT2-NEXT: out0 2 cuts: {out0}@t2d0 {a0, a1, b0}@t128d1
-    // ROOT2-NEXT: out1 2 cuts: {out1}@t2d0 {a2, b0, a0, a1}@t546d1
+    // ROOT2-NEXT: out1 2 cuts: {out1}@t2d0 {a0, a1, a2, b0}@t112d1
     // ROOT2-NEXT: out2 2 cuts: {out2}@t2d0 {a3, b1}@t8d1
     // INPUT2:    and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
-    // INPUT2-NEXT: out0 2 cuts: {out0}@t2d0 {and0, b0}@t8d2
-    // INPUT2-NEXT: out1 2 cuts: {out1}@t2d0 {and1, and0}@t2d2
-    // INPUT2-NEXT: out2 3 cuts: {out2}@t2d0 {a3, b1}@t8d1 {and2, b1}@t8d2
+    // INPUT2-NEXT: out0 2 cuts: {out0}@t2d0 {b0, and0}@t8d2
+    // INPUT2-NEXT: out1 2 cuts: {out1}@t2d0 {and0, and1}@t4d2
+    // INPUT2-NEXT: out2 3 cuts: {out2}@t2d0 {a3, b1}@t8d1 {b1, and2}@t8d2
     // CHECK-NEXT: Cut enumeration completed successfully
 
     // Extract individual bits from multi-bit inputs
@@ -96,6 +87,22 @@ hw.module @test(in %a : i4, in %b : i2, out result : i3) {
     %result_concat = comb.concat %out2, %out1, %out0 {sv.namehint = "result_concat"} : i1, i1, i1
 
     hw.output %result_concat : i3
+}
+
+// CHECK-LABEL: Enumerating cuts for module: hw_constant
+// Verify that hw.constant 0/1 are correctly treated as constants (not as
+// primary inputs). AND(a, 0) should produce truth table 0 (always false) and
+// AND(a, 1) should produce truth table 2 (identity), both with only 'a' as
+// the cut input.
+hw.module @hw_constant(in %a : i1, out out0 : i1, out out1 : i1) {
+    %c0 = hw.constant 0 : i1
+    %c1 = hw.constant 1 : i1
+    // CHECK: out0 2 cuts: {out0}@t2d0 {a}@t0d1
+    %out0 = synth.aig.and_inv %a, %c0 {sv.namehint = "out0"} : i1
+    // CHECK-NEXT: out1 2 cuts: {out1}@t2d0 {a}@t2d1
+    %out1 = synth.aig.and_inv %a, %c1 {sv.namehint = "out1"} : i1
+    // CHECK-NEXT: Cut enumeration completed successfully
+    hw.output %out0, %out1 : i1, i1
 }
 
 // CHECK-LABEL: Enumerating cuts for module: Issue8885

--- a/test/Dialect/Synth/sop-balancing.mlir
+++ b/test/Dialect/Synth/sop-balancing.mlir
@@ -32,9 +32,9 @@ hw.module @balance(in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1, in %f:
     %5 = synth.aig.and_inv not %4 : i1
     // CHECK-DAG: %[[AB:.*]] = synth.aig.and_inv %a, %b
     // CHECK-DAG: %[[EF:.*]] = synth.aig.and_inv %e, %f
-    // CHECK-DAG: %[[CEF:.*]] = synth.aig.and_inv %[[EF]], %c
-    // CHECK-DAG: %[[CD:.*]] = synth.aig.and_inv %d, %c
-    // CHECK-DAG: %[[RESULT1:.*]] = synth.aig.and_inv not %[[AB]], not %[[CD]]
+    // CHECK-DAG: %[[CEF:.*]] = synth.aig.and_inv  %c, %[[EF]]
+    // CHECK-DAG: %[[CD:.*]] = synth.aig.and_inv %c, %d
+    // CHECK-DAG: %[[RESULT1:.*]] = synth.aig.and_inv not %[[CD]], not %[[AB]]
     // CHECK-DAG: %[[RESULT2:.*]] = synth.aig.and_inv not %[[CEF]], %[[RESULT1]]
     // CHECK-DAG: %[[FINAL:.*]] = synth.aig.and_inv not %[[RESULT2]]
     // CHECK: hw.output %[[FINAL]]

--- a/test/Dialect/Synth/tech-mapper-error.mlir
+++ b/test/Dialect/Synth/tech-mapper-error.mlir
@@ -12,20 +12,6 @@ hw.module @test(in %a : i1, in %b : i1, out result : i1) {
 
 // -----
 
-hw.module @do_nothing(in %a : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1]]}} {
-    hw.output %a : i1
-}
-
-// Test for too many operands in AIG operation
-hw.module @test(in %a : i1, in %b : i1, out result : i1) {
-    // expected-error-re@+1 {{Cut enumeration supports at most 2 operands, found: 3}}
-    %0 = synth.aig.and_inv %a, %b, %a : i1
-    hw.output %0 : i1
-}
-
-
-// -----
-
 // expected-error@+1 {{Modules with multiple outputs are not supported yet}}
 hw.module @multi_output(in %a : i1, out result1 : i1, out result2 : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
     hw.output %a, %a : i1, i1
@@ -57,7 +43,7 @@ hw.module @multibit(in %a : i1, in %b: i1, out result : i2) attributes {hw.techl
 
 hw.module @multibit(in %a : i1, in %b: i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2]]}} {
   // expected-error@+1 {{Unsupported operation for truth table simulation}}
-  %0 = comb.xor %a, %b : i1
+  %0 = comb.add %a, %b : i1
   hw.output %0: i1
 }
 

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -45,8 +45,7 @@ hw.module @permutation(in %a: i1, in %b: i1, in %c: i1, in %d: i1, out result: i
 
 // CHECK-LABEL: hw.module @permutation_test(in %p : i1, in %q : i1, in %r : i1, in %s : i1, out result : i1) {
 hw.module @permutation_test(in %p: i1, in %q: i1, in %r: i1, in %s: i1, out result: i1) {
-    // {a -> s, b -> p, c -> q, d -> r}
-    // CHECK-NEXT: hw.instance "{{.+}}" @permutation(a: %s: i1, b: %p: i1, c: %q: i1, d: %r: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: %[[r0:.+]] = hw.instance "{{.+}}" @permutation(a: %r: i1, b: %p: i1, c: %s: i1, d: %q: i1) -> (result: i1) {test.arrival_times = [1]}
     %0 = synth.aig.and_inv %s, not %p : i1
     %1 = synth.aig.and_inv %q, not %r : i1
     %2 = synth.aig.and_inv %0, not %1 : i1
@@ -70,7 +69,7 @@ hw.module @and_inv_5_test(in %a : i1, in %b : i1, in %c : i1, in %d : i1, in %e:
     %5 = synth.aig.and_inv not %b, %e : i1
     %6 = synth.aig.and_inv %5, %c : i1
     %7 = synth.aig.and_inv %6, %4 : i1
-    // CHECK-NEXT: %[[result_1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_5(a: %b: i1, b: %e: i1, c: %a: i1, d: %c: i1, e: %d: i1)
+    // CHECK-NEXT: %[[result_1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_5(a: %d: i1, b: %e: i1, c: %c: i1, d: %a: i1, e: %b: i1)
     
     hw.output %3, %7 : i1, i1
     // CHECK-NEXT: hw.output %[[result_0]], %[[result_1]] : i1, i1
@@ -153,7 +152,7 @@ hw.module @extract_concat_test(in %data : i4, in %ctrl : i2, out result : i3) {
     // CHECK-NEXT: %[[ctrl1:.+]] = comb.extract %ctrl from 1
     // CHECK-NEXT: %[[and0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %[[bit0]]: i1, b: %[[bit1]]: i1) -> (result: i1) {test.arrival_times = [1]}
     // CHECK-NEXT: %[[and1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_n(a: %[[ctrl0]]: i1, b: %[[bit2]]: i1) -> (result: i1) {test.arrival_times = [1]}
-    // CHECK-NEXT: %[[out0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %[[and0]]: i1, b: %[[ctrl0]]: i1) -> (result: i1) {test.arrival_times = [2]}
+    // CHECK-NEXT: %[[out0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %[[ctrl0]]: i1, b: %[[and0]]: i1) -> (result: i1) {test.arrival_times = [2]}
     // CHECK-NEXT: %[[out1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_n(a: %[[and0]]: i1, b: %[[and1]]: i1) -> (result: i1) {test.arrival_times = [2]}
     // CHECK-NEXT: %[[out2:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %[[bit3]]: i1, b: %[[ctrl1]]: i1) -> (result: i1) {test.arrival_times = [1]}
     // CHECK-NEXT: %[[result:.+]] = comb.concat %[[out2]], %[[out1]], %[[out0]] : i1, i1, i1


### PR DESCRIPTION
Switch cut enumeration and truth table handling to LogicNetwork indices, update downstream mappers to the new cut API, and refresh Synth tests for the updated ordering and operations. PR staked on https://github.com/llvm/circt/pull/9804. 

This is NFCI except for a small bug fix in NPNClass utils; only operand orders are reordered.

The following is a runtime comparison of LUT mapping for `hyp` test case (0.2M AIG nodes, largest test case of non MtM category) in [EPFL Combinational Benchmark Suite](https://github.com/lsils/benchmarks/). LUT mapping is a good benchmark to check cut enumeration performance since only cut enumeration is generally performed. Note that this is not a perfectly fair comparison to ABC because ABC performs more optimizations like area recovery or applying several strategies for cut selection. When k=6 is generally same, for k > 6 we are missing fast computation for truth table (since we cannot represent in single 64 bit integer) so it's reasonable. At least it got 8~10 times faster from the previous implementation. 


before:
| max_lut_size(K) | max_cuts_per_root(C) | ABC ("if -K -C") time (sec) | CIRCT GenericLutMapper (sec) | LUT depth  ABC | LUT depth CIRCT |
|---:|---:|---:|---:|---:|---:|
| 6 | 8  | 2.72 | 16.3945 | 4194 | 4195 |
| 6 | 15 | 5.52 | 54.3470 | 4196 | 4197 |

after:
| max_lut_size(K) | max_cuts_per_root(C) | ABC  ("if -K -C")  time (sec) | CIRCT GenericLutMapper (sec) | LUT depth ABC | LUT depth CIRCT |
|---:|---:|---:|---:|---:|---:|
| 6 | 8  | 2.73 | 2.5538 | 4194 | 4195 |
| 6 | 15 | 5.49 | 5.3534 | 4196 | 4196 |
| 6 | 25 | 9.70 | 9.2742 | 4194 | 4194 |
| 8 | 8  | 3.76 | 6.2786 | 2818 | 2818 |
| 8 | 15 | 8.40 | 15.4164 | 2818 | 2818 |
| 8 | 25 | 17.00 | 28.0075 | 2818 | 2818 |
| 10 | 8  | 4.83 | 10.0969 | 2119 | 2120 |
| 10 | 15 | 12.02 | 29.8168 | 2118 | 2120 |
| 10 | 25 | 25.59 | 69.3343 | 2119 | 2119 |

AI-assisted-by: Claude Sonnet 4.6, Opus 4.6