### PR TITLE
[circt-verilog] Bump slang version requirement to 10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,7 +607,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang)
     install(TARGETS slang_slang EXPORT CIRCTTargets)
   else()
-    find_package(slang 9.1 REQUIRED)
+    find_package(slang 10.0 REQUIRED)
   endif()
 endif()
 


### PR DESCRIPTION
This fixes a mismatch in CMakeLists.txt introduced by #9667.