### PR TITLE
[FIRRTL][Inliner] Fix NLA updates during flattening

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -155,8 +155,8 @@ public:
   /// (This is done to save unnecessary state cleanup of a pass-private
   /// utility.)
   hw::HierPathOp applyUpdates() {
-    // Delete an NLA which is either dead or has been made local.
-    if (isLocal() || isDead()) {
+    // Delete an NLA which is dead.
+    if (isDead()) {
       nla.erase();
       return nullptr;
     }
@@ -174,30 +174,36 @@ public:
       SmallVector<Attribute> namepath;
       StringAttr lastMod;
 
-      // Root of the namepath.
-      if (!inlinedSymbols.test(1))
+      // Root of the namepath. If we're flattening at the root (flattenPoint ==
+      // 0) or the next module has been inlined, set lastMod to root and skip
+      // adding to the namepath. Otherwise, add the root with its inner ref.
+      if (flattenPoint == 0 || !inlinedSymbols.test(1)) {
         lastMod = root;
-      else
+      } else {
         namepath.push_back(InnerRefAttr::get(root, lookupRename(root)));
+      }
 
       // Everything in the middle of the namepath (excluding the root and leaf).
-      for (signed i = 1, e = inlinedSymbols.size() - 1; i != e; ++i) {
-        if (i == flattenPoint) {
-          lastMod = nla.modPart(i);
-          break;
-        }
-
-        if (!inlinedSymbols.test(i + 1)) {
-          if (!lastMod)
+      // Skip this loop if we're flattening at the root.
+      if (flattenPoint != 0) {
+        for (signed i = 1, e = inlinedSymbols.size() - 1; i != e; ++i) {
+          if (i == flattenPoint) {
             lastMod = nla.modPart(i);
-          continue;
-        }
+            break;
+          }
 
-        // Update the inner symbol if it has been renamed.
-        auto modPart = lastMod ? lastMod : nla.modPart(i);
-        auto refPart = lookupRename(modPart, i);
-        namepath.push_back(InnerRefAttr::get(modPart, refPart));
-        lastMod = {};
+          if (!inlinedSymbols.test(i + 1)) {
+            if (!lastMod)
+              lastMod = nla.modPart(i);
+            continue;
+          }
+
+          // Update the inner symbol if it has been renamed.
+          auto modPart = lastMod ? lastMod : nla.modPart(i);
+          auto refPart = lookupRename(modPart, i);
+          namepath.push_back(InnerRefAttr::get(modPart, refPart));
+          lastMod = {};
+        }
       }
 
       // Leaf of the namepath.
@@ -261,39 +267,48 @@ public:
       os << "firrtl.nla @" << sym.getValue() << " [";
 
       StringAttr lastMod;
-      // Root of the namepath.
-      if (!x.inlinedSymbols.test(1))
+      bool needsComma = false;
+
+      // Root of the namepath. If we're flattening at the root (flattenPoint ==
+      // 0) or the next module has been inlined, set lastMod to root and skip
+      // adding to the output. Otherwise, write the root with its inner ref.
+      if (x.flattenPoint == 0 || !x.inlinedSymbols.test(1)) {
         lastMod = root;
-      else
+      } else {
         writePathSegment(root, x.lookupRename(root));
+        needsComma = true;
+      }
 
       // Everything in the middle of the namepath (excluding the root and leaf).
-      bool needsComma = false;
-      for (signed i = 1, e = x.inlinedSymbols.size() - 1; i != e; ++i) {
-        if (i == x.flattenPoint) {
-          lastMod = x.nla.modPart(i);
-          break;
-        }
-
-        if (!x.inlinedSymbols.test(i + 1)) {
-          if (!lastMod)
+      // Skip this loop if we're flattening at the root.
+      if (x.flattenPoint != 0) {
+        for (signed i = 1, e = x.inlinedSymbols.size() - 1; i != e; ++i) {
+          if (i == x.flattenPoint) {
             lastMod = x.nla.modPart(i);
-          continue;
-        }
+            break;
+          }
 
-        if (needsComma)
-          os << ", ";
-        auto modPart = lastMod ? lastMod : x.nla.modPart(i);
-        auto refPart = x.nla.refPart(i);
-        if (x.renames.count(modPart))
-          refPart = x.renames[modPart];
-        writePathSegment(modPart, refPart);
-        needsComma = true;
-        lastMod = {};
+          if (!x.inlinedSymbols.test(i + 1)) {
+            if (!lastMod)
+              lastMod = x.nla.modPart(i);
+            continue;
+          }
+
+          if (needsComma)
+            os << ", ";
+          auto modPart = lastMod ? lastMod : x.nla.modPart(i);
+          auto refPart = x.nla.refPart(i);
+          if (x.renames.count(modPart))
+            refPart = x.renames[modPart];
+          writePathSegment(modPart, refPart);
+          needsComma = true;
+          lastMod = {};
+        }
       }
 
       // Leaf of the namepath.
-      os << ", ";
+      if (needsComma)
+        os << ", ";
       auto modPart = lastMod ? lastMod : x.nla.modPart(x.size - 1);
       auto refPart = x.nla.refPart(x.size - 1);
       if (x.renames.count(modPart))

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -303,8 +303,9 @@ firrtl.circuit "NLAInlining" {
   // CHECK-NEXT: hw.hierpath private @nla1 [@NLAInlining::@bar, @Bar]
   // CHECK-NEXT: hw.hierpath private @nla2 [@NLAInlining::@bar, @Bar::@a]
   // CHECK-NEXT: hw.hierpath private @nla3 [@NLAInlining::@bar, @Bar::@port]
+  // CHECK-NEXT: hw.hierpath private @nla5 [@NLAInlining::@b]
+  // CHECK-NEXT: hw.hierpath private @nla6 [@NLAInlining::@port]
   // CHECK-NOT:  hw.hierpath private @nla4
-  // CHECK-NOT:  hw.hierpath private @nla5
   hw.hierpath private @nla1 [@NLAInlining::@foo, @Foo::@bar, @Bar]
   hw.hierpath private @nla2 [@NLAInlining::@foo, @Foo::@bar, @Bar::@a]
   hw.hierpath private @nla3 [@NLAInlining::@foo, @Foo::@bar, @Bar::@port]
@@ -383,8 +384,8 @@ firrtl.circuit "NLAInliningNotMainRoot" {
 firrtl.circuit "NLAFlattening" {
   // CHECK-NEXT: hw.hierpath private @nla1 [@NLAFlattening::@foo, @Foo::@a]
   // CHECK-NEXT: hw.hierpath private @nla2 [@NLAFlattening::@foo, @Foo::@port]
+  // CHECK-NEXT: hw.hierpath private @nla4 [@Foo::@b]
   // CHECK-NOT:  hw.hierpath private @nla3
-  // CHECK-NOT:  hw.hierpath private @nla4
   hw.hierpath private @nla1 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz::@a]
   hw.hierpath private @nla2 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz::@port]
   hw.hierpath private @nla3 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz]
@@ -1431,7 +1432,7 @@ firrtl.circuit "FormalMarkerIsUse" {
 // -----
 
 firrtl.circuit "RemoveNonLocalFromLocal" {
-  // CHECK-NOT: @dutNLA
+  // CHECK: hw.hierpath private @dutNLA [@RemoveNonLocalFromLocal::@sym]
   hw.hierpath private @dutNLA [@RemoveNonLocalFromLocal::@sym]
   firrtl.module @Bar() {}
   // CHECK-LABEL: firrtl.module @RemoveNonLocalFromLocal
@@ -1571,5 +1572,55 @@ firrtl.circuit "InstanceChoiceWithFlattening" {
     // After flattening, instance_choice should be inlined but still reference @ImplA
     // CHECK: firrtl.instance_choice level1_level2_inst @ImplA
     firrtl.instance level1 @Level1()
+  }
+}
+
+// -----
+
+// Test that NLAs are correctly updated when flattening.
+//
+// CHECK-LABEL: firrtl.circuit "FlattenAtRoot"
+firrtl.circuit "FlattenAtRoot" {
+  // CHECK: hw.hierpath private @nla [@Foo::@b]
+  hw.hierpath private @nla [@Foo::@bar, @Bar::@b]
+  // CHECK: firrtl.module @Bar
+  firrtl.module @Bar() {
+    // CHECK: %b = firrtl.wire sym @b {annotations = [{class = "nla"}]}
+    %b = firrtl.wire sym @b {annotations = [{circt.nonlocal = @nla, class = "nla"}]} : !firrtl.uint<1>
+  }
+  // CHECK: firrtl.module @Foo
+  firrtl.module @Foo() attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]} {
+    // CHECK: %bar_b = firrtl.wire sym @b {annotations = [{class = "nla"}]}
+    firrtl.instance bar sym @bar @Bar()
+  }
+  // CHECK: firrtl.module @FlattenAtRoot
+  firrtl.module @FlattenAtRoot() {
+    firrtl.instance foo sym @foo @Foo()
+    // CHECK: sv.xmr.ref @nla : !hw.inout<i1>
+    %xmr = sv.xmr.ref @nla : !hw.inout<i1>
+  }
+}
+
+// -----
+
+// Test that hierarchical paths are correctly update when inlining.  This is the
+// same, conceptually, as the previous `FlattenAtRoot` test.
+//
+// CHECK-LABEL: firrtl.circuit "InlineBothModules"
+firrtl.circuit "InlineBothModules" {
+  // CHECK: hw.hierpath @path [@InlineBothModules::@sym_0]
+  hw.hierpath @path [@Foo::@bar, @Bar::@sym]
+  firrtl.module private @Bar() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    %w = firrtl.wire sym @sym {annotations = [{circt.nonlocal = @path, class = "test"}]} : !firrtl.uint<5>
+  }
+  firrtl.module private @Foo() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    firrtl.instance b sym @bar @Bar()
+  }
+  // CHECK: firrtl.module @InlineBothModules
+  firrtl.module @InlineBothModules() {
+    // CHECK: %foo_b_w = firrtl.wire sym @sym_0 {annotations = [{class = "test"}]}
+    firrtl.instance foo @Foo()
+    // CHECK: sv.xmr.ref @path : !hw.inout<i5>
+    %xmr = sv.xmr.ref @path : !hw.inout<i5>
   }
 }


### PR DESCRIPTION
Fix two bugs in `hw.hierpath` handling for the FIRRTL's Module Inliner
pass:

1. a `hw.hierpath` made local by inlining, but used by an `sv.verbatim`
could be deleted
2. and flattening/inlining could result in `hw.hierpath`s not being
updated.

Note: this diff is best viewed with the `Hide Whitespace` option on.

AI-assisted-by: Augment (Claude Sonnet 4.5)
