### PR TITLE
[FIRRTL] Update InstanceInfo to handle instance choice

### DIFF
--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -118,6 +118,10 @@ public:
     /// is deemed to be in the design except those which are explicitly
     /// verification code.
     InstanceInfo::LatticeValue inEffectiveDesign;
+
+    /// Indicates if this module is instantiated within (or transitively within)
+    /// an instance choice operation.
+    InstanceInfo::LatticeValue inInstanceChoice;
   };
 
   //===--------------------------------------------------------------------===//
@@ -191,6 +195,12 @@ public:
   /// Return true if all instances of this module are within (or transitively
   /// withiin) the effective design.
   bool allInstancesInEffectiveDesign(igraph::ModuleOpInterface op);
+
+  /// Return true if any instance of this module is within (or transitively
+  /// within) an instance choice.
+  /// Note: allInstancesInInstanceChoice is intentionally not provided because
+  /// that property is relative to the public module.
+  bool anyInstanceInInstanceChoice(igraph::ModuleOpInterface op);
 
 private:
   /// Stores circuit-level attributes.

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -110,6 +110,7 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
     attributes.inDesign.mergeIn(isDut(moduleOp));
     attributes.inEffectiveDesign.mergeIn(isEffectiveDut(moduleOp) || !hasDut());
     attributes.underLayer.mergeIn(false);
+    attributes.inInstanceChoice.mergeIn(false);
   }
 
   // Visit modules in reverse post-order (visit parents before children) to
@@ -147,6 +148,16 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
       bool underLayer = false;
       if (auto instanceOp = useIt->template getInstance<InstanceOp>())
         underLayer = InstanceInfo::isInstanceUnderLayer(instanceOp);
+
+      // Update inInstanceChoice.
+      if (auto instanceChoiceOp =
+              useIt->template getInstance<InstanceChoiceOp>()) {
+        attributes.inInstanceChoice.mergeIn(true);
+        if (instanceChoiceOp->template getParentOfType<LayerBlockOp>() ||
+            instanceChoiceOp->template getParentOfType<sv::IfDefOp>())
+          underLayer = true;
+      } else
+        attributes.inInstanceChoice.mergeIn(parentAttrs.inInstanceChoice);
 
       if (!isGCCompanion) {
         if (underLayer)
@@ -196,7 +207,9 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
           << llvm::indent(6) << "underLayer: " << attributes.underLayer << "\n"
           << llvm::indent(6) << "inDesign: " << attributes.inDesign << "\n"
           << llvm::indent(6)
-          << "inEffectiveDesign: " << attributes.inEffectiveDesign << "\n";
+          << "inEffectiveDesign: " << attributes.inEffectiveDesign << "\n"
+          << llvm::indent(6)
+          << "inInstanceChoice: " << attributes.inInstanceChoice << "\n";
     });
   });
 }
@@ -274,4 +287,10 @@ bool InstanceInfo::anyInstanceInEffectiveDesign(igraph::ModuleOpInterface op) {
 bool InstanceInfo::allInstancesInEffectiveDesign(igraph::ModuleOpInterface op) {
   auto inEffectiveDesign = getModuleAttributes(op).inEffectiveDesign;
   return inEffectiveDesign.isConstant() && inEffectiveDesign.getConstant();
+}
+
+bool InstanceInfo::anyInstanceInInstanceChoice(igraph::ModuleOpInterface op) {
+  auto inInstanceChoice = getModuleAttributes(op).inInstanceChoice;
+  return inInstanceChoice.isMixed() ||
+         (inInstanceChoice.isConstant() && inInstanceChoice.getConstant());
 }

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -254,7 +254,9 @@ static void printModuleInfo(igraph::ModuleOpInterface op,
                << "    anyInstanceInEffectiveDesign: "
                << iInfo.anyInstanceInEffectiveDesign(op) << "\n"
                << "    allInstancesInEffectiveDesign: "
-               << iInfo.allInstancesInEffectiveDesign(op) << "\n";
+               << iInfo.allInstancesInEffectiveDesign(op) << "\n"
+               << "    anyInstanceInInstanceChoice: "
+               << iInfo.anyInstanceInInstanceChoice(op) << "\n";
 }
 
 void FIRRTLInstanceInfoPass::runOnOperation() {

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -10,6 +10,9 @@
 firrtl.circuit "Foo" {
   firrtl.layer @A bind {
   }
+  firrtl.option @Platform {
+    firrtl.option_case @FPGA
+  }
   // CHECK:      @Corge
   // CHECK-NEXT:   isDut: false
   // CHECK-NEXT:   anyInstanceUnderDut: false
@@ -18,6 +21,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   allInstancesUnderEffectiveDut: false
   // CHECK-NEXT:   anyInstanceUnderLayer: true
   // CHECK-NEXT:   allInstancesUnderLayer: false
+  // CHECK:        anyInstanceInInstanceChoice: true
   firrtl.module private @Corge() {}
   // CHECK:      @Quz
   // CHECK-NEXT:   isDut: false
@@ -27,6 +31,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   allInstancesUnderEffectiveDut: false
   // CHECK-NEXT:   anyInstanceUnderLayer: true
   // CHECK-NEXT:   allInstancesUnderLayer: true
+  // CHECK:        anyInstanceInInstanceChoice: false
   firrtl.module private @Quz() {}
   // CHECK:      @Qux
   // CHECK-NEXT:   isDut: false
@@ -36,6 +41,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   allInstancesUnderEffectiveDut: false
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
+  // CHECK:        anyInstanceInInstanceChoice: true
   firrtl.module private @Qux() {}
   // CHECK:      @Baz
   // CHECK-NEXT:   isDut: false
@@ -45,6 +51,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   allInstancesUnderEffectiveDut: true
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
+  // CHECK:        anyInstanceInInstanceChoice: false
   firrtl.module private @Baz() {}
   // CHECK:      @Bar
   // CHECK-NEXT:   isDut: true
@@ -54,6 +61,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   allInstancesUnderEffectiveDut: true
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
+  // CHECK:        anyInstanceInInstanceChoice: false
   firrtl.module private @Bar() attributes {
     annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
@@ -70,12 +78,17 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   allInstancesUnderEffectiveDut: false
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
+  // CHECK:        anyInstanceInInstanceChoice: false
   firrtl.module @Foo() {
     firrtl.instance bar @Bar()
-    firrtl.instance qux @Qux()
+    firrtl.instance_choice qux @Qux alternatives @Platform {
+      @FPGA -> @Corge
+    } ()
     firrtl.layerblock @A {
       firrtl.instance quz @Quz()
-      firrtl.instance corge @Corge()
+      firrtl.instance_choice corge @Corge alternatives @Platform {
+        @FPGA -> @Corge
+      } ()
     }
     firrtl.instance corge2 @Corge()
   }
@@ -98,6 +111,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   allInstancesUnderEffectiveDut: true
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
+  // CHECK:        anyInstanceInInstanceChoice: false
   firrtl.module @Foo() {}
 }
 


### PR DESCRIPTION
Implement tracking of modules that are instantiated within instance choice operations (i.e., modules that are alternatives in an InstanceChoiceOp). This follows the same pattern as other module attributes like `inDesign` and `inEffectiveDesign`.

isUnderLayer is updated as well

AI-assisted-by: Sonnet 4.5