### PR TITLE
[FIRRTL] Support probe ports in instance_choice operations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -74,6 +74,22 @@ private:
   SmallDenseMap<Type, Value, 8> cache;
 };
 
+// Instance choice option case macro name utilities.
+class InstanceChoiceMacroTable {
+public:
+  InstanceChoiceMacroTable(Operation *op);
+
+  // Get the macro for an option case. Return null if it doesn't exist.
+  FlatSymbolRefAttr getMacro(StringAttr optionName, StringAttr caseName) const;
+
+  // Get all option/case pairs in the IR occurrence order.
+  auto getKeys() const { return cache.keys(); }
+
+private:
+  // Option/Case -> Macro Symbol
+  llvm::MapVector<std::pair<StringAttr, StringAttr>, FlatSymbolRefAttr> cache;
+};
+
 //===----------------------------------------------------------------------===//
 // Template utilities
 //===----------------------------------------------------------------------===//

--- a/integration_test/Dialect/FIRRTL/instance-choice.fir
+++ b/integration_test/Dialect/FIRRTL/instance-choice.fir
@@ -1,0 +1,50 @@
+; REQUIRES: verilator
+; This test verifies that the instance choice header inclusion mechanism works correctly:
+
+; RUN: rm -rf %t && mkdir -p %t
+; RUN: firtool %s --split-verilog -o=%t
+; Check it errors when including both headers.
+; RUN: not verilator %t/targets_top_Platform_ASIC.svh %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --lint-only --top-module top 2>&1 | FileCheck %s --check-prefix=ERROR
+; RUN: verilator %driver %t/targets_top_Platform_ASIC.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.asic.exe --top-module top
+; RUN: %t.asic.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=ASIC
+; RUN: verilator %driver %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.fpga.exe --top-module top
+; RUN: %t.fpga.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=FPGA
+; RUN: verilator %driver %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.default.exe --top-module top
+; RUN: %t.default.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=DEFAULT
+;
+; ERROR: must__not__be__set
+;
+; ASIC: result:         10
+; FPGA: result:         20
+; DEFAULT: result:       0
+
+FIRRTL version 5.1.0
+circuit top:
+  option Platform:
+    FPGA
+    ASIC
+
+  module DefaultTarget:
+    output result: UInt<32>
+
+    connect result, UInt<32>(0)
+
+  module ASICTarget:
+    output result: UInt<32>
+
+    connect result, UInt<32>(10)
+
+  module FPGATarget:
+    output result: UInt<32>
+
+    connect result, UInt<32>(20)
+
+  public module top:
+    input clk: Clock
+    input rst: UInt<1>
+
+    instchoice proc of DefaultTarget, Platform:
+      ASIC => ASICTarget
+      FPGA => FPGATarget
+
+    printf(clk, UInt<1>(1), "result: %d\n", proc.result)

--- a/integration_test/Dialect/FIRRTL/instance-choice.fir
+++ b/integration_test/Dialect/FIRRTL/instance-choice.fir
@@ -5,12 +5,12 @@
 ; RUN: rm -rf %t && mkdir -p %t
 ; RUN: firtool %s --split-verilog -o=%t
 ; Check it errors when including both headers.
-; RUN: not verilator %t/targets_top_Platform_ASIC.svh %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --lint-only --top-module top 2>&1 | FileCheck %s --check-prefix=ERROR
-; RUN: verilator %driver %t/targets_top_Platform_ASIC.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv %t/ref_top.sv --cc --sv --exe --build -o %t.asic.exe --top-module top
+; RUN: not verilator %t/targets_top_Platform_ASIC.svh %t/targets_top_Platform_FPGA.svh %t/ref_top.sv %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --lint-only --top-module top 2>&1 | FileCheck %s --check-prefix=ERROR
+; RUN: verilator %driver %t/targets_top_Platform_ASIC.svh %t/ref_top.sv %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.asic.exe --top-module top
 ; RUN: %t.asic.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=ASIC
-; RUN: verilator %driver %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv %t/ref_top.sv --cc --sv --exe --build -o %t.fpga.exe --top-module top
+; RUN: verilator %driver %t/targets_top_Platform_FPGA.svh %t/ref_top.sv %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.fpga.exe --top-module top
 ; RUN: %t.fpga.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=FPGA
-; RUN: verilator %driver %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv %t/ref_top.sv --cc --sv --exe --build -o %t.default.exe --top-module top
+; RUN: verilator %driver %t/ref_top.sv %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.default.exe --top-module top
 ; RUN: %t.default.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=DEFAULT
 ;
 ; ERROR: must__not__be__set

--- a/integration_test/Dialect/FIRRTL/instance-choice.fir
+++ b/integration_test/Dialect/FIRRTL/instance-choice.fir
@@ -1,22 +1,26 @@
 ; REQUIRES: verilator
-; This test verifies that the instance choice header inclusion mechanism works correctly:
+; This test verifies that the instance choice header inclusion mechanism works correctly
+; with probes to access internal signals:
 
 ; RUN: rm -rf %t && mkdir -p %t
 ; RUN: firtool %s --split-verilog -o=%t
 ; Check it errors when including both headers.
 ; RUN: not verilator %t/targets_top_Platform_ASIC.svh %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --lint-only --top-module top 2>&1 | FileCheck %s --check-prefix=ERROR
-; RUN: verilator %driver %t/targets_top_Platform_ASIC.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.asic.exe --top-module top
+; RUN: verilator %driver %t/targets_top_Platform_ASIC.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv %t/ref_top.sv --cc --sv --exe --build -o %t.asic.exe --top-module top
 ; RUN: %t.asic.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=ASIC
-; RUN: verilator %driver %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.fpga.exe --top-module top
+; RUN: verilator %driver %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv %t/ref_top.sv --cc --sv --exe --build -o %t.fpga.exe --top-module top
 ; RUN: %t.fpga.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=FPGA
-; RUN: verilator %driver %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.default.exe --top-module top
+; RUN: verilator %driver %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv %t/ref_top.sv --cc --sv --exe --build -o %t.default.exe --top-module top
 ; RUN: %t.default.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=DEFAULT
 ;
 ; ERROR: must__not__be__set
 ;
 ; ASIC: result:         10
+; ASIC: internal:       15
 ; FPGA: result:         20
+; FPGA: internal:       25
 ; DEFAULT: result:       0
+; DEFAULT: internal:      5
 
 FIRRTL version 5.1.0
 circuit top:
@@ -26,18 +30,30 @@ circuit top:
 
   module DefaultTarget:
     output result: UInt<32>
+    output internal_probe: Probe<UInt<32>>
 
+    wire internal: UInt<32>
+    connect internal, UInt<32>(5)
     connect result, UInt<32>(0)
+    define internal_probe = probe(internal)
 
   module ASICTarget:
     output result: UInt<32>
+    output internal_probe: Probe<UInt<32>>
 
+    wire internal: UInt<32>
+    connect internal, UInt<32>(15)
     connect result, UInt<32>(10)
+    define internal_probe = probe(internal)
 
   module FPGATarget:
     output result: UInt<32>
+    output internal_probe: Probe<UInt<32>>
 
+    wire internal: UInt<32>
+    connect internal, UInt<32>(25)
     connect result, UInt<32>(20)
+    define internal_probe = probe(internal)
 
   public module top:
     input clk: Clock
@@ -47,4 +63,8 @@ circuit top:
       ASIC => ASICTarget
       FPGA => FPGATarget
 
+    wire probed_value: UInt<32>
+    connect probed_value, read(proc.internal_probe)
+
     printf(clk, UInt<1>(1), "result: %d\n", proc.result)
+    printf(clk, UInt<1>(1), "internal: %d\n", probed_value)

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -251,10 +251,12 @@ struct CircuitLoweringState {
 
   CircuitLoweringState(CircuitOp circuitOp, bool enableAnnotationWarning,
                        firrtl::VerificationFlavor verificationFlavor,
-                       InstanceGraph &instanceGraph, NLATable *nlaTable)
+                       InstanceGraph &instanceGraph, NLATable *nlaTable,
+                       const InstanceChoiceMacroTable &macroTable)
       : circuitOp(circuitOp), instanceGraph(instanceGraph),
         enableAnnotationWarning(enableAnnotationWarning),
-        verificationFlavor(verificationFlavor), nlaTable(nlaTable) {
+        verificationFlavor(verificationFlavor), nlaTable(nlaTable),
+        macroTable(macroTable) {
     auto *context = circuitOp.getContext();
 
     // Get the testbench output directory.
@@ -465,6 +467,32 @@ private:
     macroDeclNames.insert(name);
   }
 
+  /// Information about an instance choice for a specific option case.
+  struct LoweredInstanceChoice {
+    StringAttr parentModule;
+    // The instance macro (macro name) for this instance choice
+    FlatSymbolRefAttr instanceMacro;
+    hw::InstanceOp hwInstance;
+  };
+
+  using OptionAndCase = std::pair<StringAttr, StringAttr>;
+
+  // Map from moduleName to (optionName, caseName) to list of instance choices.
+  DenseMap<StringAttr,
+           DenseMap<OptionAndCase, SmallVector<LoweredInstanceChoice>>>
+      instanceChoicesByModuleAndCase;
+  std::mutex instanceChoicesMutex;
+
+  void addInstanceChoiceForCase(StringAttr optionName, StringAttr caseName,
+                                StringAttr parentModule,
+                                FlatSymbolRefAttr instanceMacro,
+                                hw::InstanceOp hwInstance) {
+    OptionAndCase innerKey{optionName, caseName};
+    std::unique_lock<std::mutex> lock(instanceChoicesMutex);
+    instanceChoicesByModuleAndCase[parentModule][innerKey].push_back(
+        {parentModule, instanceMacro, hwInstance});
+  }
+
   /// The list of fragments on which the modules rely. Must be set outside the
   /// parallelized module lowering since module type reads access it.
   DenseMap<hw::HWModuleOp, SetVector<Attribute>> fragments;
@@ -559,6 +587,9 @@ private:
   // emit.files for additional sources for verbatim extmodules
   llvm::StringMap<emit::FileOp> emitFilesByFileName;
   llvm::sys::SmartMutex<true> emitFilesMutex;
+
+  // Instance choice macro table for looking up option case macros
+  const InstanceChoiceMacroTable &macroTable;
 };
 
 void CircuitLoweringState::processRemainingAnnotations(
@@ -624,6 +655,14 @@ struct FIRRTLModuleLowering
 
 private:
   void lowerFileHeader(CircuitOp op, CircuitLoweringState &loweringState);
+  void emitInstanceChoiceIncludes(mlir::ModuleOp circuit,
+                                  CircuitLoweringState &loweringState);
+  static void emitInstanceChoiceIncludeFile(
+      OpBuilder &builder, ModuleOp circuit, StringAttr publicModuleName,
+      StringAttr optionName, StringAttr caseName,
+      ArrayRef<CircuitLoweringState::LoweredInstanceChoice> instances,
+      Namespace &circuitNamespace, const InstanceChoiceMacroTable &macroTable);
+
   LogicalResult lowerPorts(ArrayRef<PortInfo> firrtlPorts,
                            SmallVectorImpl<hw::PortInfo> &ports,
                            Operation *moduleOp, StringRef moduleName,
@@ -694,7 +733,8 @@ void FIRRTLModuleLowering::runOnOperation() {
   // if lowering failed.
   CircuitLoweringState state(circuit, enableAnnotationWarning,
                              verificationFlavor, getAnalysis<InstanceGraph>(),
-                             &getAnalysis<NLATable>());
+                             &getAnalysis<NLATable>(),
+                             getAnalysis<InstanceChoiceMacroTable>());
 
   SmallVector<Operation *, 32> opsToProcess;
 
@@ -866,6 +906,11 @@ void FIRRTLModuleLowering::runOnOperation() {
   // Emit all the macros and preprocessor gunk at the start of the file.
   lowerFileHeader(circuit, state);
 
+  // Emit global include files for instance choice options.
+  // Make sure to call after `lowerFileHeader` so that symbols generated for
+  // instance choices don't conflict with the macros defined in the header.
+  emitInstanceChoiceIncludes(getOperation(), state);
+
   // Now that the modules are moved over, remove the Circuit.
   circuit.erase();
 }
@@ -1012,6 +1057,144 @@ endpackage
         emitGuardedDefine("STOP_COND", "STOP_COND_", "(`STOP_COND)", "1");
       });
     });
+  }
+}
+
+/// Helper function to emit a single instance choice include file for a given
+/// (option, case) combination.
+void FIRRTLModuleLowering::emitInstanceChoiceIncludeFile(
+    OpBuilder &builder, mlir::ModuleOp circuit, StringAttr publicModuleName,
+    StringAttr optionName, StringAttr caseName,
+    ArrayRef<CircuitLoweringState::LoweredInstanceChoice> instances,
+    Namespace &circuitNamespace, const InstanceChoiceMacroTable &macroTable) {
+  // If no instances, don't emit anything.
+  if (instances.empty())
+    return;
+
+  // Filename format: targets_<PublicModule>_<Option>_<Case>.svh
+  SmallString<128> includeFileName;
+  {
+    llvm::raw_svector_ostream os(includeFileName);
+    os << "targets_" << publicModuleName.getValue() << "_"
+       << optionName.getValue() << "_" << caseName.getValue() << ".svh";
+  }
+
+  // Create the emit.file operation at the top level
+  auto fileSymbolName = circuitNamespace.newName(includeFileName);
+
+  auto emitFile = emit::FileOp::create(builder, circuit.getLoc(),
+                                       includeFileName, fileSymbolName);
+  OpBuilder::InsertionGuard g(builder);
+  builder.setInsertionPointToStart(&emitFile.getBodyRegion().front());
+
+  // Add header comment
+  {
+    SmallString<256> headerComment;
+    llvm::raw_svector_ostream os(headerComment);
+    os << "// Specialization file for public module: "
+       << publicModuleName.getValue() << "\n";
+    os << "// Option: " << optionName.getValue()
+       << ", Case: " << caseName.getValue() << "\n";
+    emit::VerbatimOp::create(builder, circuit.getLoc(),
+                             builder.getStringAttr(headerComment));
+  }
+
+  // Define the global option case macro to avoid conflicts
+  // `ifndef <optionCaseMacro>
+  //  `define <optionCaseMacro>
+  // `endif
+  auto optionCaseMacroRef = macroTable.getMacro(optionName, caseName);
+  sv::IfDefOp::create(
+      builder, circuit.getLoc(), optionCaseMacroRef, [&]() {},
+      [&]() {
+        sv::MacroDefOp::create(builder, circuit.getLoc(), optionCaseMacroRef);
+      });
+
+  // Emit instance name macros for all instances in this module
+  for (auto info : instances) {
+    auto innerSym = info.hwInstance.getInnerSymAttr();
+    assert(innerSym && "expected instance to have inner symbol");
+    // Error checking: macro must not already be set
+    // `ifdef <instanceMacroName>
+    //  `ERROR<instanceMacroName>__must__not__be__set
+    // `else
+    //  `define <instanceMacroName> <InnerRef to instance>
+    // `endif
+    SmallString<256> errorMessage;
+    {
+      llvm::raw_svector_ostream os(errorMessage);
+      os << info.instanceMacro.getAttr().getValue() << "__must__not__be__set";
+    }
+
+    sv::IfDefOp::create(
+        builder, circuit.getLoc(), info.instanceMacro,
+        [&]() {
+          sv::MacroErrorOp::create(builder, circuit.getLoc(),
+                                   builder.getStringAttr(errorMessage));
+        },
+        [&]() {
+          SmallVector<Attribute> attrs;
+          attrs.push_back(
+              hw::InnerRefAttr::get(info.parentModule, innerSym.getSymName()));
+          auto attr = ArrayAttr::get(builder.getContext(), attrs);
+          sv::MacroDefOp::create(builder, circuit.getLoc(), info.instanceMacro,
+                                 builder.getStringAttr("{{0}}"), attr);
+        });
+  }
+
+  // Set output file attribute .svh files should be excluded from file list
+  auto outputFileAttr = hw::OutputFileAttr::getFromFilename(
+      builder.getContext(), includeFileName, /*excludeFromFileList=*/true);
+  emitFile->setAttr("output_file", outputFileAttr);
+}
+
+/// Creates one include file per public module and option case following the
+/// FIRRTL ABI spec.
+void FIRRTLModuleLowering::emitInstanceChoiceIncludes(
+    mlir::ModuleOp topLevelModule, CircuitLoweringState &loweringState) {
+  if (loweringState.instanceChoicesByModuleAndCase.empty())
+    return;
+
+  OpBuilder builder(&getContext());
+  builder.setInsertionPointToEnd(topLevelModule.getBody());
+  Namespace circuitNamespace;
+  circuitNamespace.add(topLevelModule);
+
+  // Find all public modules
+  for (auto module : topLevelModule.getOps<hw::HWModuleOp>()) {
+    if (!module.isPublic())
+      continue;
+
+    auto *rootNode = loweringState.getInstanceGraph().lookup(module);
+    assert(rootNode && "Public module not found in instance graph");
+
+    auto publicModuleName = module.getModuleNameAttr();
+
+    // Collect all instance choices reachable from this public module
+    // Grouped by (optionName, caseName)
+    DenseMap<CircuitLoweringState::OptionAndCase,
+             SmallVector<CircuitLoweringState::LoweredInstanceChoice>>
+        choicesInHierarchy;
+
+    // Walk all modules reachable from this public module
+    for (auto *node : llvm::post_order(rootNode)) {
+      auto it = loweringState.instanceChoicesByModuleAndCase.find(
+          node->getModule().getModuleNameAttr());
+      if (it == loweringState.instanceChoicesByModuleAndCase.end())
+        continue;
+
+      // Accumulate all instance choices from this module
+      for (auto &[key, instances] : it->second)
+        choicesInHierarchy[key].append(instances.begin(), instances.end());
+    }
+
+    // Emit one include file for each (option, case) combination
+    for (auto key : loweringState.macroTable.getKeys())
+      emitInstanceChoiceIncludeFile(builder, topLevelModule, publicModuleName,
+                                    /*optionName=*/key.first,
+                                    /*caseName=*/key.second,
+                                    choicesInHierarchy.lookup(key),
+                                    circuitNamespace, loweringState.macroTable);
   }
 }
 
@@ -4029,12 +4212,12 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceChoiceOp oldInstanceChoice) {
       return failure();
   }
 
+  auto optionName = oldInstanceChoice.getOptionNameAttr();
+
   // Lambda to create an instance for a given module and assign outputs to wires
   auto createInstanceAndAssign = [&](Operation *oldMod,
-                                     StringRef suffix) -> LogicalResult {
+                                     StringRef suffix) -> hw::InstanceOp {
     auto *newMod = circuitState.getNewModule(oldMod);
-    if (!newMod)
-      return oldInstanceChoice->emitOpError("could not find lowered module");
 
     ArrayAttr parameters;
     if (auto oldExtModule = dyn_cast<FExtModuleOp>(oldMod))
@@ -4049,39 +4232,71 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceChoiceOp oldInstanceChoice) {
     }
     auto instNameAttr = builder.getStringAttr(instName);
 
-    // Create the instance
+    auto [innerSym, innerSymName] = getOrAddInnerSym(
+        oldInstanceChoice.getContext(), /*attr=*/nullptr, 0,
+        [&]() -> hw::InnerSymbolNamespace & { return moduleNamespace; });
+
     auto inst = hw::InstanceOp::create(builder, newMod, instNameAttr,
-                                       inputOperands, parameters,
-                                       /*innerSym=*/nullptr);
+                                       inputOperands, parameters, innerSym);
 
     // Assign instance outputs to the wires
     for (unsigned i = 0; i < inst.getNumResults(); ++i)
       sv::AssignOp::create(builder, outputWires[i], inst.getResult(i));
-    return success();
+
+    return inst;
   };
 
-  // Create instance for the default module
-  if (failed(createInstanceAndAssign(defaultModule, "default")))
-    return failure();
+  // Build macro names and module list for nested ifdefs
+  SmallVector<StringAttr> macroNames;
+  SmallVector<Operation *> altModules;
 
-  // Create instances for all alternative modules
-  for (size_t i = 0; i < caseNames.size(); ++i) {
-    auto caseSymRef = cast<SymbolRefAttr>(caseNames[i]);
-    auto caseName = caseSymRef.getLeafReference();
+  for (size_t i = 0, e = caseNames.size(); i < e; ++i) {
+    auto caseName = cast<SymbolRefAttr>(caseNames[i]).getLeafReference();
     auto targetModuleRef = cast<FlatSymbolRefAttr>(moduleNames[i + 1]);
 
-    Operation *altModule = circuitState.getInstanceGraph()
-                               .lookup(targetModuleRef.getAttr())
-                               ->getModule();
-    if (!altModule)
-      return oldInstanceChoice->emitOpError(
-                 "could not find alternative module [")
-             << targetModuleRef << "] referenced by instance choice";
+    altModules.push_back(circuitState.getInstanceGraph()
+                             .lookup(targetModuleRef.getAttr())
+                             ->getModule());
 
-    // Create instance with case name as suffix
-    if (failed(createInstanceAndAssign(altModule, caseName.getValue())))
-      return failure();
+    // Get the macro name for this option case using InstanceChoiceMacroTable
+    auto optionCaseMacroRef =
+        circuitState.macroTable.getMacro(optionName, caseName);
+    if (!optionCaseMacroRef)
+      return oldInstanceChoice->emitOpError(
+          "failed to get macro for option case");
+    macroNames.push_back(optionCaseMacroRef.getAttr());
   }
+
+  // Use the helper function to create nested ifdefs and register instances
+  sv::createNestedIfDefs(
+      macroNames,
+      /*ifdefCtor=*/
+      [&](StringRef macro, std::function<void()> thenCtor,
+          std::function<void()> elseCtor) {
+        addToIfDefBlock(macro, std::move(thenCtor), std::move(elseCtor));
+      },
+      [&](size_t index) {
+        auto caseSymRef =
+            cast<SymbolRefAttr>(caseNames[index]).getLeafReference();
+        auto inst =
+            createInstanceAndAssign(altModules[index], caseSymRef.getValue());
+        circuitState.addInstanceChoiceForCase(optionName, caseSymRef,
+                                              theModule.getNameAttr(),
+                                              instanceMacro, inst);
+      },
+      [&]() {
+        auto inst = createInstanceAndAssign(defaultModule, "default");
+        // Define the instance macro for the default case.
+        sv::IfDefOp::create(
+            builder, inst.getLoc(), instanceMacro, [&]() {},
+            [&]() {
+              auto array = builder.getArrayAttr(
+                  {hw::InnerRefAttr::get(theModule.getNameAttr(),
+                                         inst.getInnerSymAttr().getSymName())});
+              sv::MacroDefOp::create(builder, inst.getLoc(), instanceMacro,
+                                     builder.getStringAttr("{{0}}"), array);
+            });
+      });
 
   return success();
 }

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -1213,3 +1213,33 @@ circt::firrtl::parseFormatString(mlir::OpBuilder &builder, mlir::Location loc,
   formatStringResult = builder.getStringAttr(validatedFormatString);
   return mlir::success();
 }
+
+//===----------------------------------------------------------------------===//
+// Instance choice option case macro name utilities.
+//===----------------------------------------------------------------------===//
+
+circt::firrtl::InstanceChoiceMacroTable::InstanceChoiceMacroTable(
+    Operation *operation) {
+  if (auto mod = dyn_cast<mlir::ModuleOp>(operation))
+    for (auto &op : *mod.getBody())
+      if ((operation = dyn_cast<CircuitOp>(&op)))
+        break;
+
+  auto circuit = cast<CircuitOp>(operation);
+  for (auto option : circuit.getOps<OptionOp>()) {
+    for (auto optionCase : option.getOps<OptionCaseOp>()) {
+      auto optionName = option.getSymNameAttr();
+      auto caseName = optionCase.getSymNameAttr();
+      cache[{optionName, caseName}] = optionCase.getCaseMacroAttr();
+    }
+  }
+}
+
+FlatSymbolRefAttr
+circt::firrtl::InstanceChoiceMacroTable::getMacro(StringAttr optionName,
+                                                  StringAttr caseName) const {
+  auto it = cache.find({optionName, caseName});
+  if (it == cache.end())
+    return {};
+  return it->second;
+}

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -121,6 +121,33 @@ private:
   /// The saved insertion point for XMRRefOps.
   OpBuilder::InsertPoint xmrRefPoint;
 };
+
+/// Information about an instance choice ref port for header generation.
+/// This stores metadata needed to generate ifdef-guarded macro definitions
+/// in the ref_<module>.sv header file for each instance choice ref port.
+struct InstanceChoiceRefPortInfo {
+  // Internal macro name (e.g., __targetref_Top_inst_probe)
+  StringAttr macroName;
+
+  // Port index in the target module
+  size_t portNum;
+
+  // Instance macro (e.g., __target_Platform_Top_inst)
+  FlatSymbolRefAttr instanceMacro;
+
+  // Option name (e.g., Platform)
+  StringAttr optionName;
+
+  // Case -> Module mappings
+  SmallVector<std::pair<SymbolRefAttr, FlatSymbolRefAttr>, 1> targetChoices;
+
+  // Default target module
+  FlatSymbolRefAttr defaultTarget;
+
+  // The instance choice operation
+  InstanceChoiceOp inst;
+};
+
 } // end anonymous namespace
 
 class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
@@ -138,6 +165,10 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
 
     llvm::EquivalenceClasses<Value> eq;
     dataFlowClasses = &eq;
+
+    // Initialize the macro table for looking up option case macros.
+    InstanceChoiceMacroTable &mt = getAnalysis<InstanceChoiceMacroTable>();
+    macroTable = &mt;
 
     InstanceGraph &instanceGraph = getAnalysis<InstanceGraph>();
     SmallVector<RefResolveOp> resolveOps;
@@ -254,6 +285,9 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
           })
           .Case<InstanceOp>(
               [&](auto inst) { return handleInstanceOp(inst, instanceGraph); })
+          .Case<InstanceChoiceOp>([&](auto inst) {
+            return handleInstanceChoiceOp(inst, instanceGraph);
+          })
           .Case<FConnectLike>([&](FConnectLike connect) {
             // Ignore BaseType.
             if (!isa<RefType>(connect.getSrc().getType()))
@@ -461,10 +495,11 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
   LogicalResult resolveReferencePath(mlir::TypedValue<RefType> refVal,
                                      ImplicitLocOpBuilder builder,
                                      mlir::FlatSymbolRefAttr &ref,
-                                     SmallString<128> &stringLeaf) {
+                                     SmallString<128> &stringLeaf,
+                                     bool errorIfNotFound = true) {
     assert(stringLeaf.empty());
 
-    auto remoteOpPath = getRemoteRefSend(refVal);
+    auto remoteOpPath = getRemoteRefSend(refVal, errorIfNotFound);
     if (!remoteOpPath)
       return failure();
     SmallVector<Attribute> refSendPath;
@@ -494,9 +529,6 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
         stringLeaf.append(".");
       stringLeaf.append(iter->getSecond());
     }
-
-    assert(!(refSendPath.empty() && stringLeaf.empty()) &&
-           "nothing to index through");
 
     // All indexing done as the ref is plumbed around indexes through
     // the target/referent, not the current point of the path which
@@ -565,6 +597,15 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
               if (failed(resolveReference(op.getDest(), builder, ref, str)))
                 return failure();
 
+              if (!ref) {
+                // No hierpath (e.g., InstanceChoiceOp): force/release not
+                // supported yet.
+                op.emitError(
+                    "force/release operations on instance choice ref ports are "
+                    "not yet supported");
+                return failure();
+              }
+
               Value xmr =
                   moduleStates.find(op->template getParentOfType<FModuleOp>())
                       ->getSecond()
@@ -597,7 +638,51 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
     if (failed(resolveReference(resolve.getRef(), builder, ref, str)))
       return failure();
 
-    Value result = XMRDerefOp::create(builder, resolve.getType(), ref, str);
+    Value result;
+    if (ref) {
+      // Standard case: hierpath with optional suffix
+      result = XMRDerefOp::create(builder, resolve.getType(), ref, str);
+    } else {
+      // No hierpath (e.g., InstanceChoiceOp): the suffix contains the complete
+      // XMR as a macro reference in the form `macroname.suffix.
+      // Parse to extract macro and suffix, then construct {{0}}.suffix format.
+      // FIXME: Avoid parsing here and also VerbatimExprOp entirely.
+      StringRef xmrPath = str ? str.getValue() : "";
+      SmallVector<Attribute> symbols;
+      SmallString<128> formatString;
+
+      // Assume format is always `macroname or `macroname.suffix
+      assert(xmrPath.starts_with("`") &&
+             "Expected macro reference to start with backtick");
+
+      // Find the dot that separates macro from suffix
+      size_t dotPos = xmrPath.find('.', 1);
+      StringRef macroName;
+      StringRef suffix;
+
+      if (dotPos == StringRef::npos) {
+        // No suffix: `macroname
+        macroName = xmrPath.drop_front(1);
+        suffix = "";
+      } else {
+        // Has suffix: `macroname.suffix
+        macroName = xmrPath.slice(1, dotPos);
+        suffix = xmrPath.substr(dotPos); // includes the leading dot
+      }
+
+      // Add macro as symbol reference
+      symbols.push_back(
+          FlatSymbolRefAttr::get(builder.getStringAttr(macroName)));
+
+      // Build format string: "{{0}}" or "{{0}}.suffix"
+      formatString.append("{{0}}");
+      if (!suffix.empty())
+        formatString.append(suffix);
+
+      result = VerbatimExprOp::create(builder, resolve.getType(), formatString,
+                                      /*substitutions=*/{},
+                                      /*symbols=*/symbols);
+    }
     resolve.getResult().replaceAllUsesWith(result);
     return success();
   }
@@ -684,6 +769,225 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
     return success();
   }
 
+  /// Resolve the XMR path for a target module's ref port.
+  /// Returns the HierPath symbol and suffix string for the path.
+  LogicalResult resolveModuleRefPortPath(FModuleOp targetMod, size_t portNum,
+                                         ImplicitLocOpBuilder &builder,
+                                         FlatSymbolRefAttr &hierPathRef,
+                                         SmallString<128> &suffix) {
+    auto refModuleArg =
+        cast<mlir::TypedValue<RefType>>(targetMod.getArgument(portNum));
+    return resolveReferencePath(refModuleArg, builder, hierPathRef, suffix,
+                                /*errorIfNotFound=*/false);
+  }
+
+  /// Handle XMR lowering for InstanceChoiceOp.
+  ///
+  /// For each ref port in an instance choice:
+  /// 1. Creates an internal macro declaration (e.g.,
+  /// __targetref_Module_inst_port)
+  /// 2. Registers the macro as the XMR path for the port (with backtick prefix)
+  /// 3. Stores metadata for later header generation in ref_<module>.sv
+  ///
+  /// The internal macro will be defined in the ref_<module>.sv header file with
+  /// ifdef guards that select the appropriate XMR path based on the option
+  /// value.
+  ///
+  /// Example output in ref_Top.sv:
+  ///   `ifdef __option__Platform_FPGA
+  ///     `define __targetref_Top_inst_probe `__target_Platform_Top_inst.inner.r
+  ///   `elsif __option__Platform_ASIC
+  ///     `define __targetref_Top_inst_probe
+  ///     `__target_Platform_Top_inst.middle.deep.r
+  ///   `else
+  ///     `define __targetref_Top_inst_probe `__target_Platform_Top_inst.r
+  ///   `endif
+  LogicalResult handleInstanceChoiceOp(InstanceChoiceOp inst,
+                                       InstanceGraph &instanceGraph) {
+    auto parentModule = inst->getParentOfType<FModuleOp>();
+
+    // This should have been set by the PopulateInstanceChoiceSymbols pass.
+    auto instanceMacro = inst.getInstanceMacroAttr();
+    if (!instanceMacro)
+      return inst.emitOpError("missing instanceMacro attribute - ensure "
+                              "PopulateInstanceChoiceSymbols pass has run");
+
+    auto optionName = inst.getOptionNameAttr();
+    auto numPorts = inst.getNumResults();
+    auto *body = getOperation().getBodyBlock();
+    auto declBuilder = ImplicitLocOpBuilder::atBlockBegin(inst.getLoc(), body);
+
+    // Get all target choices (case -> module mappings).
+    auto targetChoices = inst.getTargetChoices();
+    auto defaultTarget = inst.getDefaultTargetAttr();
+
+    // Process ref ports and create macro declarations.
+    for (size_t portNum = 0; portNum < numPorts; ++portNum) {
+      auto instanceResult = inst.getResult(portNum);
+      if (!isa<RefType>(instanceResult.getType()))
+        continue;
+
+      setPortToRemove(inst, portNum, numPorts);
+
+      // Skip dead or zero-width ports.
+      if (instanceResult.use_empty() ||
+          isZeroWidth(type_cast<RefType>(instanceResult.getType()).getType()))
+        continue;
+
+      // Generate internal macro name: __targetref_<parent>_<instance>_<port>
+      // This macro will be used in the generated Verilog to reference the
+      // probe.
+      SmallString<128> internalMacroName;
+      llvm::raw_svector_ostream(internalMacroName)
+          << "__targetref_" << parentModule.getName() << "_"
+          << inst.getInstanceName() << "_" << inst.getPortName(portNum);
+
+      auto internalMacroNameAttr =
+          StringAttr::get(&getContext(), internalMacroName);
+
+      // Declare the internal macro
+      sv::MacroDeclOp::create(declBuilder, internalMacroNameAttr, ArrayAttr(),
+                              StringAttr());
+
+      // Register the internal macro as the XMR path for this port.
+      SmallString<128> macroPath("`");
+      macroPath.append(internalMacroName);
+      auto ind = addReachingSendsEntry(instanceResult, InnerRefAttr());
+      xmrPathSuffix[ind] = macroPath;
+
+      // Store information for header generation.
+      // We'll collect these later when processing public modules.
+      instanceChoiceInfo[parentModule].push_back(
+          {internalMacroNameAttr, portNum, instanceMacro, optionName,
+           targetChoices, defaultTarget, inst});
+    }
+
+    return success();
+  }
+
+  /// Generate ifdef-guarded macro definition for an instance choice ref port.
+  LogicalResult
+  generateInstanceChoiceRefPortMacro(ImplicitLocOpBuilder &fileBuilder,
+                                     InstanceChoiceRefPortInfo &info,
+                                     InstanceGraph &instanceGraph) {
+    struct PathInfo {
+      FlatSymbolRefAttr hierPath;
+      std::string suffix;
+    };
+    DenseMap<std::pair<StringAttr, size_t>, PathInfo> pathCache;
+    auto *body = getOperation().getBodyBlock();
+    auto declBuilder =
+        ImplicitLocOpBuilder::atBlockBegin(info.inst.getLoc(), body);
+
+    // Get or compute XMR path for a module's ref port.
+    auto getModuleXMRPath = [&](FlatSymbolRefAttr moduleRef,
+                                size_t portNum) -> std::optional<PathInfo> {
+      auto key = std::make_pair(moduleRef.getAttr(), portNum);
+      if (auto it = pathCache.find(key); it != pathCache.end())
+        return it->second;
+
+      auto *node = instanceGraph.lookup(moduleRef.getAttr());
+      if (!node)
+        return std::nullopt;
+      auto targetMod = dyn_cast<FModuleOp>(*node->getModule());
+      if (!targetMod)
+        return std::nullopt;
+
+      FlatSymbolRefAttr hierPathRef;
+      SmallString<128> suffix;
+      if (failed(resolveModuleRefPortPath(targetMod, portNum, declBuilder,
+                                          hierPathRef, suffix)))
+        return std::nullopt;
+
+      PathInfo pathInfo{hierPathRef, suffix.str().str()};
+      pathCache[key] = pathInfo;
+      return pathInfo;
+    };
+
+    SmallVector<Attribute> symbols;
+    DenseMap<Attribute, size_t> symbolIndices;
+    symbols.push_back(info.instanceMacro);
+
+    // Build macro value with symbol substitution.
+    auto buildMacroValue = [&](const PathInfo &pathInfo) -> std::string {
+      SmallString<128> value("`{{0}}");
+      if (pathInfo.hierPath) {
+        auto [it, inserted] =
+            symbolIndices.try_emplace(pathInfo.hierPath, symbols.size());
+        if (inserted)
+          symbols.push_back(pathInfo.hierPath);
+        value.append(".{{");
+        value.append(std::to_string(it->second));
+        value.append("}}");
+      }
+      if (!pathInfo.suffix.empty()) {
+        if (!pathInfo.hierPath)
+          value.append(".");
+        value.append(pathInfo.suffix);
+      }
+      return value.str().str();
+    };
+
+    // Build option macro names for ifdef chain using InstanceChoiceMacroTable.
+    SmallVector<StringAttr> macroNames;
+    for (auto [caseRef, moduleRef] : info.targetChoices) {
+      auto caseName = caseRef.getLeafReference();
+      auto optionCaseMacro = macroTable->getMacro(info.optionName, caseName);
+      if (!optionCaseMacro)
+        return info.inst.emitOpError("failed to get macro for option case");
+      macroNames.push_back(optionCaseMacro.getAttr());
+    }
+
+    // Create nested ifdef structure for each target choice.
+    auto createMacroDef = [&](std::optional<PathInfo> pathInfo) {
+      std::string macroValue = pathInfo ? buildMacroValue(*pathInfo) : "{{0}}";
+      sv::MacroDefOp::create(fileBuilder, info.macroName,
+                             fileBuilder.getStringAttr(macroValue),
+                             fileBuilder.getArrayAttr(symbols));
+    };
+
+    sv::createNestedIfDefs(
+        macroNames,
+        [&](StringRef macro, std::function<void()> thenCtor,
+            std::function<void()> elseCtor) {
+          sv::IfDefOp::create(fileBuilder, macro, std::move(thenCtor),
+                              std::move(elseCtor));
+        },
+        [&](size_t index) {
+          createMacroDef(
+              getModuleXMRPath(info.targetChoices[index].second, info.portNum));
+        },
+        [&]() {
+          createMacroDef(getModuleXMRPath(info.defaultTarget, info.portNum));
+        });
+
+    return success();
+  }
+
+  /// Collect all instance choice ref ports from a module and its hierarchy
+  /// in post-order.
+  void collectInstanceChoiceRefPorts(
+      FModuleOp module, InstanceGraph &instanceGraph,
+      SmallVectorImpl<InstanceChoiceRefPortInfo> &collected) {
+    auto *node = instanceGraph.lookup(module);
+    if (!node)
+      return;
+
+    // Walk in post-order to collect from children first
+    for (auto *instRecord : *node) {
+      auto *targetNode = instRecord->getTarget();
+      if (auto targetModule = dyn_cast<FModuleOp>(*targetNode->getModule())) {
+        collectInstanceChoiceRefPorts(targetModule, instanceGraph, collected);
+      }
+    }
+
+    // Add instance choice ref ports from this module
+    auto it = instanceChoiceInfo.find(module);
+    if (it != instanceChoiceInfo.end()) {
+      collected.append(it->second.begin(), it->second.end());
+    }
+  }
+
   LogicalResult handlePublicModuleRefPorts(FModuleOp module) {
     auto *body = getOperation().getBodyBlock();
 
@@ -722,21 +1026,45 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
                          ref ? declBuilder.getArrayAttr({ref}) : ArrayAttr{});
     }
 
+    // Collect all instance choice ref ports from this module's hierarchy
+    InstanceGraph &instanceGraph = getAnalysis<InstanceGraph>();
+    SmallVector<InstanceChoiceRefPortInfo> instanceChoiceRefPorts;
+    collectInstanceChoiceRefPorts(module, instanceGraph,
+                                  instanceChoiceRefPorts);
+
     // Create a file only if the module has at least one ref port.
-    if (ports.empty())
+    if (ports.empty() && instanceChoiceRefPorts.empty())
       return success();
 
     // The macros will be exported to a `ref_<module-name>.sv` file.
     // In the IR, the file is inserted before the module.
     auto fileBuilder = ImplicitLocOpBuilder(module.getLoc(), module);
-    emit::FileOp::create(fileBuilder, circuitRefPrefix + ".sv", [&] {
+    // Insert a macro with the format:
+    // ref_<module-name>_<ref-name> <path>
+    if (circuitRefPrefix.empty())
+      getRefABIPrefix(module, circuitRefPrefix);
+    SmallString<128> fileName = circuitRefPrefix;
+    fileName.append(".sv");
+    bool encounteredError = false;
+
+    emit::FileOp::create(fileBuilder, fileName, [&] {
+      // Generate macro definitions for module ref ports.
       for (auto [macroName, formatString, symbols] : ports) {
         sv::MacroDefOp::create(fileBuilder, FlatSymbolRefAttr::get(macroName),
                                formatString, symbols);
       }
+
+      // Generate ifdef-guarded macro definitions for instance choice ref ports.
+      for (auto &info : instanceChoiceRefPorts) {
+        if (failed(generateInstanceChoiceRefPortMacro(fileBuilder, info,
+                                                      instanceGraph))) {
+          encounteredError = true;
+          return;
+        }
+      }
     });
 
-    return success();
+    return success(!encounteredError);
   }
 
   /// Get the cached namespace for a module.
@@ -811,6 +1139,10 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
       else if (auto inst = dyn_cast<InstanceOp>(iter.getFirst())) {
         inst.cloneWithErasedPortsAndReplaceUses(iter.getSecond());
         inst.erase();
+      } else if (auto instChoice =
+                     dyn_cast<InstanceChoiceOp>(iter.getFirst())) {
+        instChoice.cloneWithErasedPortsAndReplaceUses(iter.getSecond());
+        instChoice.erase();
       } else if (auto mem = dyn_cast<MemOp>(iter.getFirst())) {
         // Remove all debug ports of the memory.
         ImplicitLocOpBuilder builder(mem.getLoc(), mem);
@@ -884,4 +1216,11 @@ private:
 
   /// Per-module helpers for creating operations within modules.
   DenseMap<FModuleOp, ModuleState> moduleStates;
+
+  /// A map from parent module to child instance choice instances.
+  DenseMap<FModuleOp, SmallVector<InstanceChoiceRefPortInfo>>
+      instanceChoiceInfo;
+
+  /// Table for looking up option case macros.
+  InstanceChoiceMacroTable *macroTable = nullptr;
 };

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -644,44 +644,13 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
       result = XMRDerefOp::create(builder, resolve.getType(), ref, str);
     } else {
       // No hierpath (e.g., InstanceChoiceOp): the suffix contains the complete
-      // XMR as a macro reference in the form `macroname.suffix.
-      // Parse to extract macro and suffix, then construct {{0}}.suffix format.
-      // FIXME: Avoid parsing here and also VerbatimExprOp entirely.
-      StringRef xmrPath = str ? str.getValue() : "";
-      SmallVector<Attribute> symbols;
-      SmallString<128> formatString;
-
-      // Assume format is always `macroname or `macroname.suffix
-      assert(xmrPath.starts_with("`") &&
-             "Expected macro reference to start with backtick");
-
-      // Find the dot that separates macro from suffix
-      size_t dotPos = xmrPath.find('.', 1);
-      StringRef macroName;
-      StringRef suffix;
-
-      if (dotPos == StringRef::npos) {
-        // No suffix: `macroname
-        macroName = xmrPath.drop_front(1);
-        suffix = "";
-      } else {
-        // Has suffix: `macroname.suffix
-        macroName = xmrPath.slice(1, dotPos);
-        suffix = xmrPath.substr(dotPos); // includes the leading dot
-      }
-
-      // Add macro as symbol reference
-      symbols.push_back(
-          FlatSymbolRefAttr::get(builder.getStringAttr(macroName)));
-
-      // Build format string: "{{0}}" or "{{0}}.suffix"
-      formatString.append("{{0}}");
-      if (!suffix.empty())
-        formatString.append(suffix);
-
-      result = VerbatimExprOp::create(builder, resolve.getType(), formatString,
-                                      /*substitutions=*/{},
-                                      /*symbols=*/symbols);
+      // XMR as a macro reference. Just use it directly in a verbatim
+      // expression.
+      assert(str && "Expected non-null string for instance choice ref");
+      result =
+          VerbatimExprOp::create(builder, resolve.getType(), str.getValue(),
+                                 /*substitutions=*/{},
+                                 /*symbols=*/{});
     }
     resolve.getResult().replaceAllUsesWith(result);
     return success();

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1952,11 +1952,18 @@ firrtl.circuit "ExternalRequirements" {
 firrtl.circuit "InstanceChoiceTest" {
   // CHECK-NOT: firrtl.option
   // CHECK-NOT: firrtl.option_case
+  sv.macro.decl @__option__Opt_FPGA
+  sv.macro.decl @__option__Power_Low
   firrtl.option @Opt {
-    firrtl.option_case @FPGA
+    firrtl.option_case @FPGA { case_macro = @__option__Opt_FPGA }
   }
 
-  sv.macro.decl @InstanceChoiceTest_inst
+  firrtl.option @Power {
+    firrtl.option_case @Low { case_macro = @__option__Power_Low }
+  }
+
+  sv.macro.decl @InstanceChoiceUnit_inst
+  sv.macro.decl @InstanceChoiceTop_inst
 
   firrtl.module private @ModuleDefault(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
     firrtl.matchingconnect %out, %in : !firrtl.uint<8>
@@ -1966,17 +1973,56 @@ firrtl.circuit "InstanceChoiceTest" {
     firrtl.matchingconnect %out, %in : !firrtl.uint<8>
   }
 
-  // CHECK-LABEL: hw.module @InstanceChoiceTest
-  firrtl.module @InstanceChoiceTest(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
-    // CHECK: %[[WIRE:.+]] = sv.wire
-    // CHECK: %[[READ:.+]] = sv.read_inout %[[WIRE]]
-    // CHECK: %[[INST_DEFAULT:.+]] = hw.instance "inst_default" @ModuleDefault
-    // CHECK: sv.assign %[[WIRE]], %[[INST_DEFAULT]]
-    // CHECK: %[[INST_FPGA:.+]] = hw.instance "inst_FPGA" @ModuleFPGA
-    // CHECK: sv.assign %[[WIRE]], %[[INST_FPGA]]
+  firrtl.module private @Bar() {}
+  firrtl.module private @Baz() {}
+
+  // CHECK-LABEL: hw.module @InstanceChoiceUnit
+  firrtl.module @InstanceChoiceUnit(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+    // CHECK:      %[[WIRE:.+]] = sv.wire
+    // CHECK:      %[[READ:.+]] = sv.read_inout %[[WIRE]]
+    // CHECK:      sv.ifdef @__option__Opt_FPGA {
+    // CHECK-NEXT:   %{{.+}} = hw.instance "inst_FPGA" sym @{{.+}} @ModuleFPGA
+    // CHECK-NEXT:   sv.assign %[[WIRE]]
+    // CHECK-NEXT: } else {
+    // CHECK-NEXT:   {{.+}} = hw.instance "inst_default" sym @{{.+}} @ModuleDefault
+    // CHECK-NEXT:   sv.assign %[[WIRE]]
+    // CHECK-NEXT:   sv.ifdef @InstanceChoiceUnit_inst
+    // CHECK-NEXT:   } else {
+    // CHECK-NEXT:     sv.macro.def @InstanceChoiceUnit_inst
+    // CHECK-SAME:     ([#hw.innerNameRef<@InstanceChoiceUnit::@{{.+}}>])
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
     // CHECK: hw.output %[[READ]]
-    %inst_in, %inst_out = firrtl.instance_choice inst {instance_macro = @InstanceChoiceTest_inst} @ModuleDefault alternatives @Opt { @FPGA -> @ModuleFPGA } (in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
+    %inst_in, %inst_out = firrtl.instance_choice inst {instance_macro = @InstanceChoiceUnit_inst} @ModuleDefault alternatives @Opt { @FPGA -> @ModuleFPGA } (in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     firrtl.matchingconnect %inst_in, %in : !firrtl.uint<8>
     firrtl.matchingconnect %out, %inst_out : !firrtl.uint<8>
   }
+
+  // CHECK-LABEL: hw.module @InstanceChoiceTest
+  firrtl.module @InstanceChoiceTest(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+    %inst_in, %inst_out = firrtl.instance inst @InstanceChoiceUnit (in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
+
+    firrtl.matchingconnect %inst_in, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %out, %inst_out : !firrtl.uint<8>
+    firrtl.instance_choice inst {instance_macro = @InstanceChoiceTop_inst} @Bar alternatives @Power { @Low -> @Baz } ()
+  }
+
+  // CHECK-LABEL: emit.file "targets_InstanceChoiceUnit_Opt_FPGA.svh"
+  // CHECK-NEXT:    emit.verbatim "// Specialization file for public module: InstanceChoiceUnit\0A// Option: Opt, Case: FPGA\0A"
+  // CHECK-NEXT:       sv.ifdef @__option__Opt_FPGA {
+  // CHECK-NEXT:    } else {
+  // CHECK-NEXT:       sv.macro.def @__option__Opt_FPGA ""
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    sv.ifdef @InstanceChoiceUnit_inst {
+  // CHECK-NEXT:      sv.macro.error
+  // CHECK-NEXT:    } else {
+  // CHECK-NEXT:      sv.macro.def @InstanceChoiceUnit_inst "{{[{][{]}}0{{[}][}]}}"([#hw.innerNameRef<@InstanceChoiceUnit::@{{.+}}>])
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  } {output_file = #hw.output_file<"targets_InstanceChoiceUnit_Opt_FPGA.svh", excludeFromFileList>}
+
+  // CHECK-LABEL: emit.file "targets_InstanceChoiceTest_Opt_FPGA.svh"
+  // CHECK:         sv.macro.def @InstanceChoiceUnit_inst
+
+  // CHECK-LABEL: emit.file "targets_InstanceChoiceTest_Power_Low.svh"
+  // CHECK:         sv.macro.def @InstanceChoiceTop_inst
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -828,7 +828,7 @@ firrtl.circuit "InstanceChoiceProbe" {
     } (out probe: !firrtl.probe<uint<8>>)
 
     %0 = firrtl.ref.resolve %inst_probe : !firrtl.probe<uint<8>>
-    // CHECK: %[[VERBATIM:.+]] = firrtl.verbatim.expr "{{[{][{]}}0}}" : () -> !firrtl.uint<8> {symbols = [@__targetref_InstanceChoiceProbe_inst_probe]}
+    // CHECK: %[[VERBATIM:.+]] = firrtl.verbatim.expr "`__targetref_InstanceChoiceProbe_inst_probe" : () -> !firrtl.uint<8>
     firrtl.matchingconnect %out, %0 : !firrtl.uint<8>
     // CHECK: firrtl.matchingconnect %out, %[[VERBATIM]]
   }
@@ -873,7 +873,7 @@ firrtl.circuit "InstanceChoiceRefSub" {
 
     %sub = firrtl.ref.sub %inst_probe[1] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
     %0 = firrtl.ref.resolve %sub : !firrtl.probe<uint<2>>
-    // CHECK: %{{.+}} = firrtl.verbatim.expr "{{[{][{]}}0}}.b" : () -> !firrtl.uint<2> {symbols = [@__targetref_InstanceChoiceRefSub_inst_probe]}
+    // CHECK: %{{.+}} = firrtl.verbatim.expr "`__targetref_InstanceChoiceRefSub_inst_probe.b" : () -> !firrtl.uint<2>
     firrtl.matchingconnect %out, %0 : !firrtl.uint<2>
     // CHECK: firrtl.matchingconnect %out, %{{.+}}
   }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -766,6 +766,168 @@ firrtl.circuit "Foo" {
 }
 
 // -----
+// Test XMR lowering through instance_choice with probe ports
+// CHECK-LABEL: firrtl.circuit "InstanceChoiceProbe"
+firrtl.circuit "InstanceChoiceProbe" {
+  sv.macro.decl @__option_Platform_FPGA
+  sv.macro.decl @__option_Platform_ASIC
+  sv.macro.decl @__target_Platform_InstanceChoiceProbe_inst
+
+  // CHECK-DAG: sv.macro.decl @__targetref_InstanceChoiceProbe_inst_probe
+  // CHECK-DAG: hw.hierpath private @[[PATH_DEFAULT:[a-zA-Z0-9_]+]] [@DefaultTarget::@[[DEFAULT_SYM:[a-zA-Z0-9_]+]]]
+  // CHECK-DAG: hw.hierpath private @[[PATH_FPGA:[a-zA-Z0-9_]+]] [@FPGATarget::@[[FPGA_SYM:[a-zA-Z0-9_]+]]]
+  // CHECK-DAG: hw.hierpath private @[[PATH_ASIC:[a-zA-Z0-9_]+]] [@ASICTarget::@[[ASIC_SYM:[a-zA-Z0-9_]+]]]
+
+  firrtl.option @Platform {
+    firrtl.option_case @FPGA {case_macro = @__option_Platform_FPGA}
+    firrtl.option_case @ASIC {case_macro = @__option_Platform_ASIC}
+  }
+
+  // CHECK: firrtl.module @DefaultTarget() {
+  firrtl.module @DefaultTarget(out %probe: !firrtl.probe<uint<8>>) {
+    %r = firrtl.wire : !firrtl.uint<8>
+    // CHECK: %r = firrtl.wire sym @[[DEFAULT_SYM]]
+    %0 = firrtl.ref.send %r : !firrtl.uint<8>
+    firrtl.ref.define %probe, %0 : !firrtl.probe<uint<8>>
+  }
+
+  // CHECK: firrtl.module @FPGATarget() {
+  firrtl.module @FPGATarget(out %probe: !firrtl.probe<uint<8>>) {
+    %r = firrtl.wire : !firrtl.uint<8>
+    // CHECK: %r = firrtl.wire sym @[[FPGA_SYM]]
+    %0 = firrtl.ref.send %r : !firrtl.uint<8>
+    firrtl.ref.define %probe, %0 : !firrtl.probe<uint<8>>
+  }
+
+  // CHECK: firrtl.module @ASICTarget() {
+  firrtl.module @ASICTarget(out %probe: !firrtl.probe<uint<8>>) {
+    %r = firrtl.wire : !firrtl.uint<8>
+    // CHECK: %r = firrtl.wire sym @[[ASIC_SYM]]
+    %0 = firrtl.ref.send %r : !firrtl.uint<8>
+    firrtl.ref.define %probe, %0 : !firrtl.probe<uint<8>>
+  }
+
+  // CHECK: emit.file "ref_InstanceChoiceProbe.sv" {
+  // CHECK:   sv.ifdef @__option_Platform_FPGA {
+  // CHECK:     sv.macro.def @__targetref_InstanceChoiceProbe_inst_probe
+  // CHECK:   } else {
+  // CHECK:     sv.ifdef @__option_Platform_ASIC {
+  // CHECK:       sv.macro.def @__targetref_InstanceChoiceProbe_inst_probe
+  // CHECK:     } else {
+  // CHECK:       sv.macro.def @__targetref_InstanceChoiceProbe_inst_probe
+  // CHECK:     }
+  // CHECK:   }
+  // CHECK: }
+
+  // CHECK-LABEL: firrtl.module @InstanceChoiceProbe
+  firrtl.module @InstanceChoiceProbe(out %out: !firrtl.uint<8>) {
+    // CHECK: firrtl.instance_choice inst {instance_macro = @__target_Platform_InstanceChoiceProbe_inst}
+    %inst_probe = firrtl.instance_choice inst {instance_macro = @__target_Platform_InstanceChoiceProbe_inst} @DefaultTarget alternatives @Platform {
+      @FPGA -> @FPGATarget,
+      @ASIC -> @ASICTarget
+    } (out probe: !firrtl.probe<uint<8>>)
+
+    %0 = firrtl.ref.resolve %inst_probe : !firrtl.probe<uint<8>>
+    // CHECK: %[[VERBATIM:.+]] = firrtl.verbatim.expr "{{[{][{]}}0}}" : () -> !firrtl.uint<8> {symbols = [@__targetref_InstanceChoiceProbe_inst_probe]}
+    firrtl.matchingconnect %out, %0 : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %out, %[[VERBATIM]]
+  }
+}
+
+// -----
+// Test instance_choice with ref.sub
+// CHECK-LABEL: firrtl.circuit "InstanceChoiceRefSub"
+firrtl.circuit "InstanceChoiceRefSub" {
+  sv.macro.decl @__option_Platform_FPGA
+  sv.macro.decl @__target_Platform_InstanceChoiceRefSub_inst
+
+  // CHECK: sv.macro.decl @__targetref_InstanceChoiceRefSub_inst_probe
+  // CHECK: hw.hierpath private @[[PATH:[a-zA-Z0-9_]+]] [@Target::@{{.+}}]
+
+  firrtl.option @Platform {
+    firrtl.option_case @FPGA {case_macro = @__option_Platform_FPGA}
+  }
+
+  // CHECK: firrtl.module @Target() {
+  firrtl.module @Target(out %probe: !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>) {
+    %w = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    // CHECK: %w = firrtl.wire sym
+    %0 = firrtl.ref.send %w : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    firrtl.ref.define %probe, %0 : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+  }
+
+  // CHECK: emit.file "ref_InstanceChoiceRefSub.sv" {
+  // CHECK:   sv.ifdef @__option_Platform_FPGA {
+  // CHECK:     sv.macro.def @__targetref_InstanceChoiceRefSub_inst_probe
+  // CHECK:   } else {
+  // CHECK:     sv.macro.def @__targetref_InstanceChoiceRefSub_inst_probe
+  // CHECK:   }
+  // CHECK: }
+
+  // CHECK-LABEL: firrtl.module @InstanceChoiceRefSub
+  firrtl.module @InstanceChoiceRefSub(out %out: !firrtl.uint<2>) {
+    // CHECK: firrtl.instance_choice inst {instance_macro = @__target_Platform_InstanceChoiceRefSub_inst}
+    %inst_probe = firrtl.instance_choice inst {instance_macro = @__target_Platform_InstanceChoiceRefSub_inst} @Target alternatives @Platform {
+      @FPGA -> @Target
+    } (out probe: !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>)
+
+    %sub = firrtl.ref.sub %inst_probe[1] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
+    %0 = firrtl.ref.resolve %sub : !firrtl.probe<uint<2>>
+    // CHECK: %{{.+}} = firrtl.verbatim.expr "{{[{][{]}}0}}.b" : () -> !firrtl.uint<2> {symbols = [@__targetref_InstanceChoiceRefSub_inst_probe]}
+    firrtl.matchingconnect %out, %0 : !firrtl.uint<2>
+    // CHECK: firrtl.matchingconnect %out, %{{.+}}
+  }
+}
+
+// -----
+// Test instance_choice with public module output probe ports
+// CHECK-LABEL: firrtl.circuit "InstanceChoicePublicProbe"
+firrtl.circuit "InstanceChoicePublicProbe" {
+  sv.macro.decl @__option_Platform_FPGA
+  sv.macro.decl @__option_Platform_ASIC
+  sv.macro.decl @__target_Platform_InstanceChoicePublicProbe_inst
+
+  // CHECK: sv.macro.decl @ref_InstanceChoicePublicProbe_out
+  // CHECK-DAG: hw.hierpath private @{{.+}} [@DefaultTarget::@{{.+}}]
+  // CHECK-DAG: hw.hierpath private @{{.+}} [@FPGATarget::@{{.+}}]
+  // CHECK-DAG: hw.hierpath private @{{.+}} [@ASICTarget::@{{.+}}]
+
+  firrtl.option @Platform {
+    firrtl.option_case @FPGA {case_macro = @__option_Platform_FPGA}
+    firrtl.option_case @ASIC {case_macro = @__option_Platform_ASIC}
+  }
+
+  firrtl.module @DefaultTarget(out %probe: !firrtl.probe<uint<3>>) {
+    %w = firrtl.wire : !firrtl.uint<3>
+    %0 = firrtl.ref.send %w : !firrtl.uint<3>
+    firrtl.ref.define %probe, %0 : !firrtl.probe<uint<3>>
+  }
+
+  firrtl.module @FPGATarget(out %probe: !firrtl.probe<uint<3>>) {
+    %w = firrtl.wire : !firrtl.uint<3>
+    %0 = firrtl.ref.send %w : !firrtl.uint<3>
+    firrtl.ref.define %probe, %0 : !firrtl.probe<uint<3>>
+  }
+
+  firrtl.module @ASICTarget(out %probe: !firrtl.probe<uint<3>>) {
+    %w = firrtl.wire : !firrtl.uint<3>
+    %0 = firrtl.ref.send %w : !firrtl.uint<3>
+    firrtl.ref.define %probe, %0 : !firrtl.probe<uint<3>>
+  }
+
+  // CHECK: emit.file "ref_InstanceChoicePublicProbe.sv"
+  // CHECK-LABEL: firrtl.module @InstanceChoicePublicProbe
+  firrtl.module @InstanceChoicePublicProbe(out %out: !firrtl.probe<uint<3>>) {
+    %inst_probe = firrtl.instance_choice inst {instance_macro = @__target_Platform_InstanceChoicePublicProbe_inst} @DefaultTarget alternatives @Platform {
+      @FPGA -> @FPGATarget,
+      @ASIC -> @ASICTarget
+    } (out probe: !firrtl.probe<uint<3>>)
+
+    firrtl.ref.define %out, %inst_probe : !firrtl.probe<uint<3>>
+  }
+}
+
+// -----
 // Test that all modules are reached and updated.
 
 // CHECK-LABEL: firrtl.circuit "PF"
@@ -787,7 +949,6 @@ firrtl.circuit "PF" {
     firrtl.ref.define %p, %c_p : !firrtl.probe<uint<1>>
   }
 }
-
 
 // -----
 // Test that instance results used in both connects and ref.send preserve


### PR DESCRIPTION
This commit adds support for read probe ports on instance_choice operations, enabling XMR lowering through instance choices where different target modules may have different internal probe paths.

For each ref port in an instance choice, the LowerXMR pass creates an internal macro (e.g., `__targetref_Module_inst_port`) and generates ifdef-guarded macro definitions in ref_<module>.sv header files that select the appropriate XMR path based on the option value:
```
  `ifdef __option__Platform_FPGA
    `define __targetref_Top_inst_probe `__target_Platform_Top_inst.inner.r
  `elsif __option__Platform_ASIC
    `define __targetref_Top_inst_probe `__target_Platform_Top_inst.deep.r
  `else
    `define __targetref_Top_inst_probe `__target_Platform_Top_inst.r
  `endif
```
The implementation extends resolveReferencePath() to handle macro-based XMR paths without hierpaths, and adds VerbatimExprOp creation for these references.

RWProbe on instance choice ref ports are not yet supported.

AI-assited-by: Sonnet 4.5