### PR TITLE
[FIRRTL][Inliner] Remove flattenPoint, use inlinedSymbols

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -69,12 +69,10 @@ class MutableNLA {
   /// A mapping of symbol to index in the NLA.
   DenseMap<Attribute, unsigned> symIdx;
 
-  /// Records which elements of the path are inlined.
+  /// Records which elements of the path are inlined.  A bit set to true
+  /// indicates the module is still in the path.  A bit set to false indicates
+  /// the module has been inlined/flattened and removed from the path.
   BitVector inlinedSymbols;
-
-  /// The point after which the NLA is flattened.  A value of "-1" indicates
-  /// that this was never set.
-  signed flattenPoint = -1;
 
   /// Indicates if the _original_ NLA is dead and should be deleted.  Updates
   /// may still need to be written if the newTops vector below is non-empty.
@@ -163,8 +161,7 @@ public:
 
     // The NLA was never updated, just return the NLA and do not writeback
     // anything.
-    if (inlinedSymbols.all() && newTops.empty() && flattenPoint == -1 &&
-        renames.empty())
+    if (inlinedSymbols.all() && newTops.empty() && renames.empty())
       return nla;
 
     // The NLA has updates.  Generate a new NLA with the same symbol and delete
@@ -174,36 +171,28 @@ public:
       SmallVector<Attribute> namepath;
       StringAttr lastMod;
 
-      // Root of the namepath. If we're flattening at the root (flattenPoint ==
-      // 0) or the next module has been inlined, set lastMod to root and skip
-      // adding to the namepath. Otherwise, add the root with its inner ref.
-      if (flattenPoint == 0 || !inlinedSymbols.test(1)) {
+      // Root of the namepath. If the next module has been inlined, set lastMod
+      // to root and skip adding to the namepath. Otherwise, add the root with
+      // its inner ref.
+      if (!inlinedSymbols.test(1)) {
         lastMod = root;
       } else {
         namepath.push_back(InnerRefAttr::get(root, lookupRename(root)));
       }
 
       // Everything in the middle of the namepath (excluding the root and leaf).
-      // Skip this loop if we're flattening at the root.
-      if (flattenPoint != 0) {
-        for (signed i = 1, e = inlinedSymbols.size() - 1; i != e; ++i) {
-          if (i == flattenPoint) {
+      for (signed i = 1, e = inlinedSymbols.size() - 1; i != e; ++i) {
+        if (!inlinedSymbols.test(i + 1)) {
+          if (!lastMod)
             lastMod = nla.modPart(i);
-            break;
-          }
-
-          if (!inlinedSymbols.test(i + 1)) {
-            if (!lastMod)
-              lastMod = nla.modPart(i);
-            continue;
-          }
-
-          // Update the inner symbol if it has been renamed.
-          auto modPart = lastMod ? lastMod : nla.modPart(i);
-          auto refPart = lookupRename(modPart, i);
-          namepath.push_back(InnerRefAttr::get(modPart, refPart));
-          lastMod = {};
+          continue;
         }
+
+        // Update the inner symbol if it has been renamed.
+        auto modPart = lastMod ? lastMod : nla.modPart(i);
+        auto refPart = lookupRename(modPart, i);
+        namepath.push_back(InnerRefAttr::get(modPart, refPart));
+        lastMod = {};
       }
 
       // Leaf of the namepath.
@@ -244,7 +233,6 @@ public:
       llvm::errs() << llvm::formatv("{0:x-}", a);
     });
     llvm::errs() << "]\n"
-                 << "    flattenPoint:   " << flattenPoint << "\n"
                  << "    renames:\n";
     for (auto rename : renames)
       llvm::errs() << "      - " << rename.first << " -> " << rename.second
@@ -269,10 +257,10 @@ public:
       StringAttr lastMod;
       bool needsComma = false;
 
-      // Root of the namepath. If we're flattening at the root (flattenPoint ==
-      // 0) or the next module has been inlined, set lastMod to root and skip
-      // adding to the output. Otherwise, write the root with its inner ref.
-      if (x.flattenPoint == 0 || !x.inlinedSymbols.test(1)) {
+      // Root of the namepath. If the next module has been inlined, set lastMod
+      // to root and skip adding to the output. Otherwise, write the root with
+      // its inner ref.
+      if (!x.inlinedSymbols.test(1)) {
         lastMod = root;
       } else {
         writePathSegment(root, x.lookupRename(root));
@@ -280,30 +268,22 @@ public:
       }
 
       // Everything in the middle of the namepath (excluding the root and leaf).
-      // Skip this loop if we're flattening at the root.
-      if (x.flattenPoint != 0) {
-        for (signed i = 1, e = x.inlinedSymbols.size() - 1; i != e; ++i) {
-          if (i == x.flattenPoint) {
+      for (signed i = 1, e = x.inlinedSymbols.size() - 1; i != e; ++i) {
+        if (!x.inlinedSymbols.test(i + 1)) {
+          if (!lastMod)
             lastMod = x.nla.modPart(i);
-            break;
-          }
-
-          if (!x.inlinedSymbols.test(i + 1)) {
-            if (!lastMod)
-              lastMod = x.nla.modPart(i);
-            continue;
-          }
-
-          if (needsComma)
-            os << ", ";
-          auto modPart = lastMod ? lastMod : x.nla.modPart(i);
-          auto refPart = x.nla.refPart(i);
-          if (x.renames.count(modPart))
-            refPart = x.renames[modPart];
-          writePathSegment(modPart, refPart);
-          needsComma = true;
-          lastMod = {};
+          continue;
         }
+
+        if (needsComma)
+          os << ", ";
+        auto modPart = lastMod ? lastMod : x.nla.modPart(i);
+        auto refPart = x.nla.refPart(i);
+        if (x.renames.count(modPart))
+          refPart = x.renames[modPart];
+        writePathSegment(modPart, refPart);
+        needsComma = true;
+        lastMod = {};
       }
 
       // Leaf of the namepath.
@@ -344,11 +324,10 @@ public:
   bool isModuleOnly() { return moduleOnly; }
 
   /// Returns true if this NLA is local.  For this to be local, every module
-  /// after the root (up to the flatten point or the end) must be inlined.  The
-  /// root is never truly inlined as inlining the root just sets a new root.
+  /// after the root must be inlined.  The root is never truly inlined as
+  /// inlining the root just sets a new root.
   bool isLocal() {
-    unsigned end = flattenPoint > -1 ? flattenPoint + 1 : inlinedSymbols.size();
-    return inlinedSymbols.find_first_in(1, end) == -1;
+    return inlinedSymbols.find_first_in(1, inlinedSymbols.size()) == -1;
   }
 
   /// Return true if this NLA has a root that originates from a specific module.
@@ -381,8 +360,10 @@ public:
   void flattenModule(FModuleOp module) {
     auto sym = module.getNameAttr();
     assert(symIdx.count(sym) && "module is not in the symIdx map");
-    auto idx = symIdx[sym] - 1;
-    flattenPoint = idx;
+    // When flattening a module, all modules from this point onwards in the path
+    // are effectively inlined. Reset all bits from the module's index onwards.
+    auto moduleIdx = symIdx[sym];
+    inlinedSymbols.reset(moduleIdx, size);
     // If the NLA only targets a module and we're flattening the NLA,
     // then the NLA must be dead.  Mark it as such.
     if (moduleOnly)


### PR DESCRIPTION
The MutableNLA class tracked path modifications using two separate
mechanisms: a BitVector (inlinedSymbols) for inlining and a separate
integer (flattenPoint) for flattening. This dual representation required
special-case logic throughout the code to handle flattening differently
from inlining.

Since flattening is semantically equivalent to inlining all modules from
a given point onwards in the path, we can represent both operations
uniformly using only the inlinedSymbols BitVector. This eliminates the
need for flattenPoint checks and simplifies the path reconstruction logic.

AI-assisted-by: Augment (Claude Sonnet 4.5)
