### PR TITLE
[Tools] Set bug report messages to CIRCT

### DIFF
--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -734,6 +734,10 @@ static LogicalResult executeArcilator(MLIRContext &context) {
 int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
 
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  llvm::setBugReportMsg(circt::circtBugReportMsg);
+
   // Hide default LLVM options, other than for this tool.
   // MLIR options are added below.
   llvm::cl::HideUnrelatedOptions(mainCategory);

--- a/tools/circt-tblgen/circt-tblgen.cpp
+++ b/tools/circt-tblgen/circt-tblgen.cpp
@@ -6,12 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Support/Version.h"
 #include "mlir/TableGen/GenInfo.h"
 #include "mlir/Tools/mlir-tblgen/MlirTblgenMain.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/TableGen/Record.h"
 
 using namespace llvm;
 using namespace mlir;
+using namespace circt;
 
 // Generator that prints records.
 static GenRegistration
@@ -21,4 +24,10 @@ static GenRegistration
                    return false;
                  });
 
-int main(int argc, char **argv) { return MlirTblgenMain(argc, argv); }
+int main(int argc, char **argv) {
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  setBugReportMsg(circtBugReportMsg);
+
+  return MlirTblgenMain(argc, argv);
+}

--- a/tools/circt-verilog-lsp-server/circt-verilog-lsp-server.cpp
+++ b/tools/circt-verilog-lsp-server/circt-verilog-lsp-server.cpp
@@ -12,15 +12,21 @@
 
 #include "circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h"
 
+#include "circt/Support/Version.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/LSP/Logging.h"
 #include "llvm/Support/LSP/Transport.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Program.h"
 
 using namespace llvm::lsp;
 
 int main(int argc, char **argv) {
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  llvm::setBugReportMsg(circt::circtBugReportMsg);
+
   //===--------------------------------------------------------------------===//
   // LSP options
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Usually bug report messages are set to CIRCT but some tools were missing.  