### PR TITLE
[Seq][RegOfVecToMem] Fix invalid address type for single element memories

### DIFF
--- a/lib/Dialect/Seq/Transforms/RegOfVecToMem.cpp
+++ b/lib/Dialect/Seq/Transforms/RegOfVecToMem.cpp
@@ -207,8 +207,9 @@ bool RegOfVecToMemPass::createFirMemory(MemoryPattern &pattern) {
   };
 
   // Create read port
+  auto readAddr = fixZeroWidthAddr(pattern.readAddr);
   Value readData = FirMemReadOp::create(
-      builder, firMem, fixZeroWidthAddr(pattern.readAddr), pattern.clock,
+      builder, firMem, readAddr, pattern.clock,
       /*enable=*/hw::ConstantOp::create(builder, builder.getI1Type(), 1));
 
   LLVM_DEBUG(llvm::dbgs() << "  Created read port\n"
@@ -216,9 +217,9 @@ bool RegOfVecToMemPass::createFirMemory(MemoryPattern &pattern) {
 
   Value mask;
   // Create write port
-  FirMemWriteOp::create(builder, firMem, fixZeroWidthAddr(pattern.writeAddr),
-                        pattern.clock, pattern.writeEnable, pattern.writeData,
-                        mask);
+  auto writeAddr = fixZeroWidthAddr(pattern.writeAddr);
+  FirMemWriteOp::create(builder, firMem, writeAddr, pattern.clock,
+                        pattern.writeEnable, pattern.writeData, mask);
 
   LLVM_DEBUG(llvm::dbgs() << "  Created write port\n");
 

--- a/test/Dialect/Seq/reg-of-vec-to-mem.mlir
+++ b/test/Dialect/Seq/reg-of-vec-to-mem.mlir
@@ -61,8 +61,8 @@ hw.module @single_el_mem(in %clk : i1, in %addr : i0, in %data : i8, in %we : i1
 
 // CHECK: %[[clock:.+]] = seq.to_clock %clk
 // CHECK: %mem = seq.firmem 0, 1, undefined, undefined : <1 x 8, mask 1>
-// CHECK: %[[TRUE:.+]] = hw.constant true
 // CHECK: %[[FALSE:.+]] = hw.constant false
+// CHECK: %[[TRUE:.+]] = hw.constant true
 // CHECK: %[[READ:.+]] = seq.firmem.read_port %mem[%[[FALSE]]], clock %[[clock]] enable %[[TRUE]]
 // CHECK: %[[FALSE:.+]] = hw.constant false
 // CHECK: seq.firmem.write_port %mem[%[[FALSE]]] = %data, clock %[[clock]] enable %we


### PR DESCRIPTION
This PR fixes a bug where the `RegOfVecToMem` pass will attempt to use a 0-bit address in a `seq::FirMemOp` when converting from a `hw::ArrayGetOp`. (`FirMemOp` expects a 1-bit address for a single element memory.)

As a reasonable solution, the PR simply creates a constant op which gives an address of 0, and passes it to `FirMemOp`. 

Seemingly, `FIRRTL` is quite reliant on its 1-bit addresses at the moment. I feel as though a maintainer of this dialect might be better suited to switch to 0-bit addresses, but I don't want to make such a sweeping change myself.