### PR TITLE
[Synth][CutRewriter] Fix potential non-determinism

### DIFF
--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -591,11 +591,6 @@ public:
   /// In that case return a trivial cut set.
   const CutSet *getCutSet(uint32_t index);
 
-  /// Clear all cut sets and return them as a vector.
-  /// Note: CutSets remain owned by the allocator and are invalidated on
-  /// clear().
-  llvm::SmallVector<std::pair<uint32_t, CutSet *>> takeCutSets();
-
   /// Clear all cut sets and reset the enumerator.
   void clear();
 

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -655,7 +655,7 @@ static void removeDuplicateAndNonMinimalCuts(SmallVectorImpl<Cut *> &cuts) {
   };
   // Sort by size, then lexicographically by inputs. This enables cheap exact
   // duplicate elimination and tighter candidate filtering for subset checks.
-  std::sort(cuts.begin(), cuts.end(), [](const Cut *a, const Cut *b) {
+  std::stable_sort(cuts.begin(), cuts.end(), [](const Cut *a, const Cut *b) {
     if (a->getInputSize() != b->getInputSize())
       return a->getInputSize() < b->getInputSize();
     return std::lexicographical_compare(a->inputs.begin(), a->inputs.end(),
@@ -840,15 +840,6 @@ CutSet *CutEnumerator::createNewCutSet(uint32_t index) {
   auto [cutSetPtr, inserted] = cutSets.try_emplace(index, cutSet);
   assert(inserted && "Cut set already exists for this index");
   return cutSetPtr->second;
-}
-
-llvm::SmallVector<std::pair<uint32_t, CutSet *>> CutEnumerator::takeCutSets() {
-  llvm::SmallVector<std::pair<uint32_t, CutSet *>> result;
-  result.reserve(cutSets.size());
-  for (auto &[idx, cutSet] : cutSets)
-    result.emplace_back(idx, cutSet);
-  cutSets.clear();
-  return result;
 }
 
 void CutEnumerator::clear() {


### PR DESCRIPTION
Remove unused takeCutSets (which returns non-deterministic order of vector) and also use stable_sort when sorting cuts. 