### PR TITLE
[LowerToHW] Use "-" for instance choice header file delimiter

### DIFF
--- a/integration_test/Dialect/FIRRTL/instance-choice.fir
+++ b/integration_test/Dialect/FIRRTL/instance-choice.fir
@@ -6,17 +6,17 @@
 ; RUN: firtool %s --split-verilog -o=%t
 
 ; -------------------------------------- Test 1: Invalid includes
-; RUN: not verilator %t/targets_top_Platform_ASIC.svh %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --lint-only --top-module top 2>&1 | FileCheck %s --check-prefix=ERROR
-; RUN: not verilator %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv %t/targets_top_Platform_ASIC.svh --cc --sv --exe --build -o %t.default.exe --top-module top 2>&1 | FileCheck %s --check-prefix=ERROR
+; RUN: not verilator %t/targets-top-Platform-ASIC.svh %t/targets-top-Platform-FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --lint-only --top-module top 2>&1 | FileCheck %s --check-prefix=ERROR
+; RUN: not verilator %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv %t/targets-top-Platform-ASIC.svh --cc --sv --exe --build -o %t.default.exe --top-module top 2>&1 | FileCheck %s --check-prefix=ERROR
 ; ERROR: must_not_be_set
 
 ; -------------------------------------- Test 2: ASIC target
-; RUN: verilator %driver %t/targets_top_Platform_ASIC.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.asic.exe --top-module top
+; RUN: verilator %driver %t/targets-top-Platform-ASIC.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.asic.exe --top-module top
 ; RUN: %t.asic.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=ASIC
 ; ASIC: result:         10
 
 ; -------------------------------------- Test 3: FPGA target
-; RUN: verilator %driver %t/targets_top_Platform_FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.fpga.exe --top-module top
+; RUN: verilator %driver %t/targets-top-Platform-FPGA.svh %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.fpga.exe --top-module top
 ; RUN: %t.fpga.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=FPGA
 ; FPGA: result:         20
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1076,8 +1076,8 @@ void FIRRTLModuleLowering::emitInstanceChoiceIncludeFile(
   SmallString<128> includeFileName;
   {
     llvm::raw_svector_ostream os(includeFileName);
-    os << "targets_" << publicModuleName.getValue() << "_"
-       << optionName.getValue() << "_" << caseName.getValue() << ".svh";
+    os << "targets-" << publicModuleName.getValue() << "-"
+       << optionName.getValue() << "-" << caseName.getValue() << ".svh";
   }
 
   // Create the emit.file operation at the top level

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -2007,7 +2007,7 @@ firrtl.circuit "InstanceChoiceTest" {
     firrtl.instance_choice inst {instance_macro = @InstanceChoiceTop_inst} @Bar alternatives @Power { @Low -> @Baz } ()
   }
 
-  // CHECK-LABEL: emit.file "targets_InstanceChoiceUnit_Opt_FPGA.svh"
+  // CHECK-LABEL: emit.file "targets-InstanceChoiceUnit-Opt-FPGA.svh"
   // CHECK-NEXT:    emit.verbatim "// Specialization file for public module: InstanceChoiceUnit\0A// Option: Opt, Case: FPGA\0A"
   // CHECK-NEXT:       sv.ifdef @__option__Opt_FPGA {
   // CHECK-NEXT:    } else {
@@ -2018,11 +2018,11 @@ firrtl.circuit "InstanceChoiceTest" {
   // CHECK-NEXT:    } else {
   // CHECK-NEXT:      sv.macro.def @InstanceChoiceUnit_inst "{{[{][{]}}0{{[}][}]}}"([#hw.innerNameRef<@InstanceChoiceUnit::@{{.+}}>])
   // CHECK-NEXT:    }
-  // CHECK-NEXT:  } {output_file = #hw.output_file<"targets_InstanceChoiceUnit_Opt_FPGA.svh", excludeFromFileList>}
+  // CHECK-NEXT:  } {output_file = #hw.output_file<"targets-InstanceChoiceUnit-Opt-FPGA.svh", excludeFromFileList>}
 
-  // CHECK-LABEL: emit.file "targets_InstanceChoiceTest_Opt_FPGA.svh"
+  // CHECK-LABEL: emit.file "targets-InstanceChoiceTest-Opt-FPGA.svh"
   // CHECK:         sv.macro.def @InstanceChoiceUnit_inst
 
-  // CHECK-LABEL: emit.file "targets_InstanceChoiceTest_Power_Low.svh"
+  // CHECK-LABEL: emit.file "targets-InstanceChoiceTest-Power-Low.svh"
   // CHECK:         sv.macro.def @InstanceChoiceTop_inst
 }

--- a/test/firtool/instance-choice.fir
+++ b/test/firtool/instance-choice.fir
@@ -35,7 +35,7 @@ circuit top:
       FPGA => FPGATarget
 
     printf(clk, UInt<1>(1), "result: %d\n", proc.result)
-; CHECK-LABEL: // ----- 8< ----- FILE "targets_top_Platform_FPGA.svh" ----- 8< -----
+; CHECK-LABEL: // ----- 8< ----- FILE "targets-top-Platform-FPGA.svh" ----- 8< -----
 ; CHECK:       `ifndef [[OPTION_NAME]]
 ; CHECK-NEXT:    `define [[OPTION_NAME]]
 ; CHECK-NEXT:  `endif


### PR DESCRIPTION
Fix https://github.com/llvm/circt/issues/9831 for instance choice header (even though instance choice header has `.svh` so it would not conflict, but consistency with layers would be good).