### PR TITLE
[ImportLiberty] Allow missing "function" attribute

### DIFF
--- a/lib/Conversion/ImportLiberty/ImportLiberty.cpp
+++ b/lib/Conversion/ImportLiberty/ImportLiberty.cpp
@@ -748,7 +748,9 @@ ParseResult LibertyParser::lowerCell(const LibertyGroup &group,
   SmallVector<const LibertyGroup *> pinGroups;
   llvm::DenseSet<StringAttr> seenPins;
 
-  // First pass: gather ports
+  // First pass: gather ports and count output pins without "function"
+  // attribute.
+  size_t numOutputPinMissingFunction = 0;
   for (const auto &sub : group.subGroups) {
     if (sub->name != "pin")
       continue;
@@ -765,6 +767,8 @@ ParseResult LibertyParser::lowerCell(const LibertyGroup &group,
     std::optional<hw::ModulePort::Direction> dir;
     SmallVector<NamedAttribute> pinAttrs;
 
+    // Track if this pin has a "function" attribute (only relevant for outputs).
+    bool functionExist = false;
     for (const auto &attr : sub->attrs) {
       if (attr.name == "direction") {
         if (auto val = dyn_cast<StringAttr>(attr.value)) {
@@ -783,11 +787,18 @@ ParseResult LibertyParser::lowerCell(const LibertyGroup &group,
         }
         continue;
       }
+
+      if (attr.name == "function")
+        functionExist = true;
+
       pinAttrs.push_back(builder.getNamedAttr(attr.name, attr.value));
     }
 
     if (!dir)
       return emitError(sub->loc, "pin direction must be specified");
+
+    if (dir == hw::ModulePort::Direction::Output && !functionExist)
+      ++numOutputPinMissingFunction;
 
     llvm::StringMap<SmallVector<Attribute>> subGroups;
     for (const auto &child : sub->subGroups) {
@@ -821,6 +832,27 @@ ParseResult LibertyParser::lowerCell(const LibertyGroup &group,
   }
 
   auto loc = lexer.translateLocation(group.loc);
+  auto numOutput = ports.size() - inputIdx;
+
+  // Decide whether to create hw.module (with logic) or hw.module.extern (black
+  // box) based on whether output pins have "function" attributes.
+  // All outputs must either have "function" or all must lack it.
+
+  // Mixed case: some outputs have "function", others don't - error.
+  if (numOutputPinMissingFunction != 0 &&
+      numOutputPinMissingFunction != numOutput)
+    return emitError(group.loc, "cell '")
+           << cellNameAttr.getValue()
+           << "' has mixed output pins with and without "
+              "'function' attribute";
+
+  // All outputs lack "function": emit as hw.module.extern (black box).
+  if (numOutputPinMissingFunction == numOutput) {
+    hw::HWModuleExternOp::create(builder, loc, cellNameAttr, ports);
+    return success();
+  }
+
+  // All outputs have "function": emit as hw.module with logic.
   auto moduleOp = hw::HWModuleOp::create(builder, loc, cellNameAttr, ports);
 
   OpBuilder::InsertionGuard guard(builder);
@@ -847,8 +879,7 @@ ParseResult LibertyParser::lowerCell(const LibertyGroup &group,
       continue;
     const LibertyGroup *pg = *it;
     auto attrPair = pg->getAttribute("function");
-    if (!attrPair.first)
-      return emitError(pg->loc, "expected function attribute");
+    assert(attrPair.first && "output pin missing function attribute");
     Value val;
     if (parseExpression(val, cast<StringAttr>(attrPair.first).getValue(),
                         portValues, attrPair.second))

--- a/test/Conversion/ImportLiberty/basic.lib
+++ b/test/Conversion/ImportLiberty/basic.lib
@@ -84,4 +84,16 @@ library(test) {
       function: "A";
     }
   }
+
+  // CHECK-LABEL: hw.module.extern @External(
+  // CHECK-SAME: in %A : i1 {synth.liberty.pin = {}}
+  // CHECK-SAME: out Z : i1 {synth.liberty.pin = {}}
+  cell(External) {
+    pin(A) {
+      direction: input;
+    }
+    pin(Z) {
+      direction: output;
+    }
+  }
 }

--- a/test/Conversion/ImportLiberty/error.lib
+++ b/test/Conversion/ImportLiberty/error.lib
@@ -33,9 +33,13 @@ library(test) {
 // -----
 
 library(test) {
-  cell(C) {
-    pin(Z) { // expected-error {{expected function attribute}}
+  cell(C) { // expected-error {{cell 'C' has mixed output pins with and without 'function' attribute}}
+    pin(Z) {
       direction: output;
+    }
+    pin(Z2) {
+      direction: output;
+      function: "A * B";
     }
   }
 }


### PR DESCRIPTION
This fixes a liberty import error when "function" attribute is missing in output pin https://github.com/llvm/circt/issues/9833