### PR TITLE
[HWToBTOR2] Only allow integer-typed registers

### DIFF
--- a/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
+++ b/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
@@ -1009,7 +1009,12 @@ public:
   void visit(seq::FirRegOp reg) {
     // Start by retrieving the register's name and width
     StringRef regName = reg.getName();
-    int64_t w = requireSort(reg.getType());
+    auto type = reg.getType();
+    if (!isa<mlir::IntegerType>(type)) {
+      reg.emitError("Only integer typed seq.firregs are supported in BTOR2.");
+      return signalPassFailure();
+    }
+    int64_t w = requireSort(type);
 
     // Generate state instruction (represents the register declaration)
     genState(reg, w, regName);
@@ -1024,7 +1029,12 @@ public:
   void visit(seq::CompRegOp reg) {
     // Start by retrieving the register's name and width
     StringRef regName = reg.getName().value();
-    int64_t w = requireSort(reg.getType());
+    auto type = reg.getType();
+    if (!isa<mlir::IntegerType>(type)) {
+      reg.emitError("Only integer typed seq.compregs are supported in BTOR2.");
+      return signalPassFailure();
+    }
+    int64_t w = requireSort(type);
 
     // Check for initial values which must be emitted before the state in
     // btor2

--- a/test/Conversion/HWToBTOR2/errors.mlir
+++ b/test/Conversion/HWToBTOR2/errors.mlir
@@ -34,6 +34,20 @@ hw.module @dual_clock_error(in %in : i32, in %clk : !seq.clock, in %clk1 : !seq.
 
 // -----
 
+hw.module @non_int_reg(in %clk : !seq.clock) {
+  // expected-error @below {{Only integer typed seq.compregs are supported in BTOR2.}}
+  %0 = seq.compreg %clk, %clk : !seq.clock
+}
+
+// -----
+
+hw.module @non_int_reg(in %clk : !seq.clock) {
+  // expected-error @below {{Only integer typed seq.firregs are supported in BTOR2.}}
+  %0 = seq.firreg %clk clock %clk : !seq.clock
+}
+
+// -----
+
 hw.module @nullary_variadic() {
   // expected-error @below {{variadic operations with no operands are not supported}}
   "comb.concat"() : () -> (i0)


### PR DESCRIPTION
The added error tests currently result in a nasty crash (and this helps avoid some weird cases in clocking logic e.g., a clock being an operand's input instead of its clock). We should probably also do this for ports, but I'll do that in a follow up once #9837 lands to avoid conflicts.