### PR TITLE
[ImportVerilog] Waive another valgrind test, NFC

### DIFF
--- a/test/circt-verilog/dpi-extern-decl.sv
+++ b/test/circt-verilog/dpi-extern-decl.sv
@@ -1,5 +1,7 @@
 // RUN: circt-verilog %s | FileCheck %s
 // REQUIRES: slang
+// Internal issue in Slang about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
 
 // Test that DPI-C imported functions are emitted as extern declarations
 


### PR DESCRIPTION
Fix nightly failures by waiving a test that is flagging valgrind errors
originating inside Slang.
