### PR TITLE
[HWToBTOR2] Add `--assume-init-reset` option

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -638,6 +638,11 @@ def ConvertHWToBTOR2 : Pass<"convert-hw-to-btor2", "mlir::ModuleOp"> {
   let constructor = "circt::createConvertHWToBTOR2Pass()";
   let dependentDialects = ["hw::HWDialect", "sv::SVDialect", "comb::CombDialect",
                            "seq::SeqDialect"];
+  let options =
+    [Option<"assumeInitReset", "assume-init-reset", "bool", "false",
+            "Assume registers have been reset (i.e., initialize them to their"
+            "reset value)">];
+
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
+++ b/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
@@ -1029,21 +1029,38 @@ public:
     // Check for initial values which must be emitted before the state in
     // btor2
     auto init = reg.getInitialValue();
+    auto resetVal = reg.getResetValue();
 
     // If there's an initial value, we need to generate a constant for the
     // initial value, then declare the state, then generate the init statement
     // (BTOR2 parsers are picky about it being in this order)
-    if (init) {
-      if (!init.getDefiningOp<seq::InitialOp>()) {
-        reg->emitError(
-            "Initial value must be emitted directly by a seq.initial op");
-        return;
+    auto shouldInitReset = assumeInitReset && resetVal;
+    // We should create an init statement either if we have an initial value or
+    // if we assume an initial reset
+    if (init || shouldInitReset) {
+      hw::ConstantOp initialConstant;
+      // Assuming an initial reset takes priority over an initial value if
+      // both are present
+      if (shouldInitReset) {
+        initialConstant = resetVal.getDefiningOp<hw::ConstantOp>();
+        if (!initialConstant) {
+          reg->emitError(
+              "Reset value must be emitted directly by a hw.constant "
+              "op when --assume-init-reset is in use.");
+          return;
+        }
+      } else {
+        if (!init.getDefiningOp<seq::InitialOp>()) {
+          reg->emitError(
+              "Initial value must be emitted directly by a seq.initial op");
+          return;
+        }
+        // Check that the initial value is a non-null constant
+        initialConstant = circt::seq::unwrapImmutableValue(init)
+                              .getDefiningOp<hw::ConstantOp>();
+        if (!initialConstant)
+          reg->emitError("initial value must be constant");
       }
-      // Check that the initial value is a non-null constant
-      auto initialConstant = circt::seq::unwrapImmutableValue(init)
-                                 .getDefiningOp<hw::ConstantOp>();
-      if (!initialConstant)
-        reg->emitError("initial value must be constant");
 
       // Visit the initial Value to generate the constant
       dispatchTypeOpVisitor(initialConstant);

--- a/test/Conversion/HWToBTOR2/assume-init-reset.mlir
+++ b/test/Conversion/HWToBTOR2/assume-init-reset.mlir
@@ -1,0 +1,22 @@
+// RUN: circt-opt %s --convert-hw-to-btor2="assume-init-reset" -o %t | FileCheck %s  
+
+// CHECK: [[I32:[0-9]+]] sort bitvec 32
+// CHECK: [[C0_I32:[0-9]+]] constd [[I32]] 0
+// CHECK: [[REG1:[0-9]+]] state [[I32]] reg1
+// CHECK: [[REG1_INIT:[0-9]+]] init [[I32]] [[REG1]] [[C0_I32]]
+// CHECK: [[REG2:[0-9]+]] state [[I32]] reg2
+// CHECK: [[REG2_INIT:[0-9]+]] init [[I32]] [[REG2]] [[C0_I32]]
+
+module {
+  hw.module @inc(in %a : i32, in %clk : !seq.clock, in %reset: i1) {
+    // Basic case
+    %c0_i32 = hw.constant 0 : i32
+    %reg1 = seq.compreg %a, %clk reset %reset, %c0_i32 : i32
+    // Check that reset value is used instead of initial value
+    %initial_const = seq.initial () {
+      %c42_i32 = hw.constant 42 : i32
+      seq.yield %c42_i32 : i32
+    } : () -> !seq.immutable<i32>
+    %reg2 = seq.compreg %a, %clk reset %reset, %c0_i32 initial %initial_const : i32
+  }
+}


### PR DESCRIPTION
Adds a flag to enable assuming for the purposes of BTOR2 emission that a reset has just happened (i.e., that registers initialize to their reset values). This is handy for checking designs that specify reset behaviour but don't have any initial/power-on behaviour (e.g. synthesizable SystemVerilog)