### PR TITLE
[RTG][circt-tblgen] Factor out OperandType handling

### DIFF
--- a/test/Tools/circt-tblgen/rtg-instruction-methods-errors.td
+++ b/test/Tools/circt-tblgen/rtg-instruction-methods-errors.td
@@ -27,8 +27,6 @@
 // NOTE: extra space to add run commands without having to change the source locations in each test
 
 
-
-
 include "circt/Dialect/RTG/IR/RTGISAAssemblyInterfaces.td"
 include "circt/Dialect/RTG/IR/RTGTypes.td"
 include "mlir/IR/OpBase.td"
@@ -42,6 +40,8 @@ class TestOp<string mnemonic> : Op<TestDialect, mnemonic, [InstructionOpInterfac
 
 def TestRegType : Type<CPred<"true">, "test register">, RegisterTypeBase {
   let binaryEncodingWidth = 5;
+  let pythonName = "TestReg";
+  let pythonTypeName = "TestRegType";
 }
 
 #ifdef TEST_IMM_NO_WRAPPER

--- a/test/Tools/circt-tblgen/rtg-instruction-methods.td
+++ b/test/Tools/circt-tblgen/rtg-instruction-methods.td
@@ -17,6 +17,8 @@ class TestOp<string mnemonic, list<Trait> traits = []> :
 def TestRegType : TypeDef<RTGDialect, "TestReg">, RegisterTypeBase {
   let mnemonic = "test_reg";
   let binaryEncodingWidth = 5;
+  let pythonName = "TestReg";
+  let pythonTypeName = "TestRegType";
 }
 
 def Test1_BasicRegisterOp : TestOp<"basic_register"> {
@@ -96,7 +98,7 @@ def Test4_ImmSlicingOp : TestOp<"imm_slicing"> {
 // CHECK-NEXT:  void ImmSlicingOp::printInstructionBinary(llvm::raw_ostream &os, FoldAdaptor adaptor) {
 // CHECK-NEXT:    llvm::APInt imm = cast<rtg::ImmediateAttr>(adaptor.getImm()).getValue();
 // CHECK-NEXT:    llvm::APInt rd = llvm::APInt(5, cast<rtg::RegisterAttrInterface>(adaptor.getRd()).getClassIndex());
-// CHECK-EMPTY:  
+// CHECK-EMPTY:
 // CHECK-NEXT:    llvm::APInt binary = llvm::APInt::getZero(0);
 // CHECK-NEXT:    binary = binary.concat(imm.extractBits(8, 12));
 // CHECK-NEXT:    binary = binary.concat(imm.extractBits(1, 11));
@@ -104,7 +106,7 @@ def Test4_ImmSlicingOp : TestOp<"imm_slicing"> {
 // CHECK-NEXT:    binary = binary.concat(imm.extractBits(1, 0));
 // CHECK-NEXT:    binary = binary.concat(rd);
 // CHECK-NEXT:    binary = binary.concat(llvm::APInt(7, 55));
-// CHECK-EMPTY:  
+// CHECK-EMPTY:
 // CHECK-NEXT:    llvm::SmallVector<char> str;
 // CHECK-NEXT:    binary.toStringUnsigned(str, 16);
 // CHECK-NEXT:    os << str;
@@ -170,10 +172,10 @@ def Test7_SignedImmediateOp : TestOp<"signed_immediate"> {
 // CHECK-NEXT:    os << " ";
 // CHECK-NEXT:    os << cast<rtg::RegisterAttrInterface>(adaptor.getRd()).getRegisterAssembly();
 // CHECK-NEXT:    os << ", ";
-// CHECK-NEXT:    { 
-// CHECK-NEXT:      SmallVector<char> strBuf; 
-// CHECK-NEXT:      cast<rtg::ImmediateAttr>(adaptor.getImm()).getValue().toStringSigned(strBuf); 
-// CHECK-NEXT:      os << strBuf; 
+// CHECK-NEXT:    {
+// CHECK-NEXT:      SmallVector<char> strBuf;
+// CHECK-NEXT:      cast<rtg::ImmediateAttr>(adaptor.getImm()).getValue().toStringSigned(strBuf);
+// CHECK-NEXT:      os << strBuf;
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
@@ -212,10 +214,10 @@ def Test9_AnyTypeRegOrImmOp : TestOp<"anytype_reg_or_imm"> {
 // CHECK-NEXT:    if (auto reg = dyn_cast<rtg::RegisterAttrInterface>(adaptor.getSrc())) {
 // CHECK-NEXT:      os << reg.getRegisterAssembly();
 // CHECK-NEXT:    } else if (auto imm = dyn_cast<rtg::ImmediateAttr>(adaptor.getSrc())) {
-// CHECK-NEXT:      { 
-// CHECK-NEXT:        SmallVector<char> strBuf; 
-// CHECK-NEXT:        imm.getValue().toStringUnsigned(strBuf); 
-// CHECK-NEXT:        os << strBuf; 
+// CHECK-NEXT:      {
+// CHECK-NEXT:        SmallVector<char> strBuf;
+// CHECK-NEXT:        imm.getValue().toStringUnsigned(strBuf);
+// CHECK-NEXT:        os << strBuf;
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -243,7 +245,7 @@ def Test10_SingleBitSliceOp : TestOp<"single_bit_slice"> {
 // CHECK-EMPTY:
 // CHECK-NEXT:  void SingleBitSliceOp::printInstructionBinary(llvm::raw_ostream &os, FoldAdaptor adaptor) {
 // CHECK-NEXT:    llvm::APInt imm = cast<rtg::ImmediateAttr>(adaptor.getImm()).getValue();
-// CHECK-EMPTY:  
+// CHECK-EMPTY:
 // CHECK-NEXT:    llvm::APInt binary = llvm::APInt::getZero(0);
 // CHECK-NEXT:    binary = binary.concat(imm.extractBits(1, 7));
 // CHECK-NEXT:    binary = binary.concat(imm.extractBits(1, 0));

--- a/tools/circt-tblgen/CMakeLists.txt
+++ b/tools/circt-tblgen/CMakeLists.txt
@@ -9,6 +9,7 @@ add_tablegen(circt-tblgen CIRCT
   FIRRTLIntrinsicsGen.cpp
   RTGInstructionFormat.cpp
   RTGInstructionMethodsGen.cpp
+  RTGInstructionUtils.cpp
 )
 
 target_link_libraries(circt-tblgen

--- a/tools/circt-tblgen/RTGInstructionFormat.cpp
+++ b/tools/circt-tblgen/RTGInstructionFormat.cpp
@@ -32,18 +32,6 @@ static std::string getGetterName(StringRef operandName) {
   return getterName;
 }
 
-// Find an operand by name in the operation's arguments
-static const NamedTypeConstraint *findOperand(const Operator &op,
-                                              StringRef operandName) {
-  for (auto arg : op.getArgs()) {
-    if (auto *operand = dyn_cast<NamedTypeConstraint *>(arg)) {
-      if (operand->name == operandName)
-        return operand;
-    }
-  }
-  return nullptr;
-}
-
 //===----------------------------------------------------------------------===//
 // FormatParser Implementation
 //===----------------------------------------------------------------------===//
@@ -251,41 +239,11 @@ void FormatParser::parseAndAppendToContext(llvm::SMLoc loc, StringRef format) {
 // Resolve Operands
 //===----------------------------------------------------------------------===//
 
-// Helper to classify a type and add it to the kinds set
-// NOLINTNEXTLINE(misc-no-recursion)
-static void classifyAndAddType(const llvm::Record &typeDef,
-                               DenseSet<OperandType> &kinds) {
-  StringRef typeName = typeDef.getName();
-
-  if (typeName == "LabelType" || typeDef.isSubClassOf("LabelType")) {
-    kinds.insert(OperandType::Label);
-    return;
-  }
-
-  if (typeName == "ImmediateType" || typeName == "ImmediateOfWidth" ||
-      typeDef.isSubClassOf("ImmediateType") ||
-      typeDef.isSubClassOf("ImmediateOfWidth")) {
-    kinds.insert(OperandType::Immediate);
-    return;
-  }
-
-  if (typeDef.isSubClassOf("RegisterTypeBase")) {
-    kinds.insert(OperandType::Register);
-    return;
-  }
-
-  if (typeName == "AnyTypeOf" || typeDef.isSubClassOf("AnyTypeOf")) {
-    auto allowedTypes = typeDef.getValueAsListOfDefs("allowedTypes");
-    for (const llvm::Record *allowedType : allowedTypes)
-      classifyAndAddType(*allowedType, kinds);
-  }
-}
-
 // Resolve the operand types and fill in the 'kinds' field of the
 // OperandNode.
 static void resolveOperand(ASTContext &ctx, OperandNode *operandNode) {
   const NamedTypeConstraint *namedOperand =
-      findOperand(ctx.getOp(), operandNode->getName());
+      findOperandByName(ctx.getOp(), operandNode->getName());
   if (!namedOperand)
     PrintFatalError(operandNode->getLoc(),
                     "unknown operand '$" + operandNode->getName() + "'");
@@ -295,18 +253,13 @@ static void resolveOperand(ASTContext &ctx, OperandNode *operandNode) {
     return;
 
   const llvm::Record &typeDef = namedOperand->constraint.getDef();
-  classifyAndAddType(typeDef, operandNode->kinds);
+  classifyOperandType(typeDef, operandNode->kinds);
 
   if (operandNode->kinds.empty())
     PrintFatalError(operandNode->getLoc(),
                     "failed to classify ISA type for operand '" +
                         operandNode->getName() + "' with type '" +
                         typeDef.getName() + "'");
-
-  if (operandNode->kinds.contains(OperandType::Register) &&
-      typeDef.isSubClassOf("RegisterTypeBase"))
-    operandNode->registerBinaryEncodingWidth =
-        typeDef.getValueAsInt("binaryEncodingWidth");
 }
 
 //===----------------------------------------------------------------------===//
@@ -335,7 +288,7 @@ static void verifyAssemblyFormat(ASTContext &ctx, BinaryLiteralNode *node) {
 static void verifyAssemblyFormat(ASTContext &ctx, OperandNode *node) {
   resolveOperand(ctx, node);
 
-  if (node->kinds.contains(OperandType::Immediate)) {
+  if (node->kinds.contains<Immediate, AnyImmediate>()) {
     if (!isa_and_nonnull<SignednessNode>(node->parent))
       PrintFatalError(node->getLoc(),
                       "immediate operand '$" + node->getName() +
@@ -350,12 +303,12 @@ static void verifyAssemblyFormat(ASTContext &ctx, SignednessNode *node) {
   // Check that wrapped operands are immediates
   if (operandNode->kinds.size() == 1) {
     OperandType kind = *operandNode->kinds.begin();
-    if (kind == OperandType::Label)
+    if (std::holds_alternative<Label>(kind))
       PrintFatalError(operandNode->getLoc(),
                       "label operand '$" + operandNode->getName() +
                           "' cannot be wrapped in signed() or unsigned()");
 
-    if (kind == OperandType::Register)
+    if (std::holds_alternative<Register>(kind))
       PrintFatalError(operandNode->getLoc(),
                       "register operand '$" + operandNode->getName() +
                           "' cannot be wrapped in signed() or unsigned()");
@@ -403,22 +356,23 @@ void BinaryFormatGen::genDecl(OperandNode *node) {
         node->getLoc(),
         "more than 2 operand types per operand not supported in binary format");
 
-  if (node->kinds.size() == 2 && !node->kinds.contains(OperandType::Label))
+  if (node->kinds.size() == 2 && !node->kinds.contains<Label>())
     PrintFatalError(node->getLoc(),
                     "one of the operand types must be a label in binary format "
                     "if there are 2 operand types possible");
 
-  if (node->kinds.contains(OperandType::Label))
+  if (node->kinds.contains<Label>())
     os << "  assert(!isa<rtg::LabelAttr>(adaptor." << getterName
        << "()) && \"labels not supported in binary format\");\n";
 
   if (decls.insert(node->getName()).second) {
     os << "  llvm::APInt " << node->getName();
-    if (node->kinds.contains(OperandType::Register))
-      os << " = llvm::APInt(" << node->registerBinaryEncodingWidth
+    if (node->kinds.contains<Register>())
+      os << " = llvm::APInt("
+         << std::get<Register>(node->kinds[0]).binaryEncodingWidth
          << ", cast<rtg::RegisterAttrInterface>(adaptor." + getterName +
                 "()).getClassIndex());\n";
-    else if (node->kinds.contains(OperandType::Immediate))
+    else if (node->kinds.contains<Immediate, AnyImmediate>())
       os << " = cast<rtg::ImmediateAttr>(adaptor." + getterName +
                 "()).getValue();\n";
     else
@@ -444,7 +398,7 @@ static bool hasOperandThatIsLabelOnly(ASTContext &ctx) {
   return llvm::any_of(ctx.nodes(), [](const FormatNode *node) {
     if (auto *operandNode = dyn_cast<OperandNode>(node)) {
       return operandNode->kinds.size() == 1 &&
-             operandNode->kinds.contains(OperandType::Label);
+             operandNode->kinds.contains<Label>();
     }
     return false;
   });
@@ -560,19 +514,19 @@ void AssemblyFormatGen::gen(OperandNode *node) {
 
   os << "  ";
 
-  if (node->kinds.contains(OperandType::Label)) {
+  if (node->kinds.contains<Label>()) {
     if (needsDynCast && !isFirst)
       os << "  } else ";
     printLabel(os, getterName, needsDynCast);
     isFirst = false;
   }
-  if (node->kinds.contains(OperandType::Register)) {
+  if (node->kinds.contains<Register>()) {
     if (needsDynCast && !isFirst)
       os << "  } else ";
     printRegister(os, getterName, needsDynCast);
     isFirst = false;
   }
-  if (node->kinds.contains(OperandType::Immediate)) {
+  if (node->kinds.contains<Immediate>()) {
     assert(node->parent != nullptr &&
            "verifiers must make sure immediate operands are wrapped in "
            "signedness node");

--- a/tools/circt-tblgen/RTGInstructionFormat.h
+++ b/tools/circt-tblgen/RTGInstructionFormat.h
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "RTGInstructionUtils.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/TableGen/Operator.h"
 #include "llvm/Support/Allocator.h"
@@ -21,15 +22,6 @@
 namespace circt {
 namespace tblgen {
 namespace rtg {
-
-//===----------------------------------------------------------------------===//
-// Operand Type Classification
-//===----------------------------------------------------------------------===//
-
-/// Classification of operand types in RTG instructions.
-/// Used to distinguish between different kinds of operands during code
-/// generation and validation.
-enum class OperandType { Register, Immediate, Label };
 
 //===----------------------------------------------------------------------===//
 // Format AST
@@ -109,14 +101,10 @@ public:
   /// The set of possible operand types for this operand.
   /// Only valid after `resolveOperands()` has been called on the context.
   /// An operand may have multiple possible types, e.g., if `AnyTypeOf` is used.
-  DenseSet<OperandType> kinds;
+  OperandTypeSet kinds;
   /// The parent node of this operand node. 'nullptr' if this is a top-level
   /// operand.
   FormatNode *parent = nullptr;
-  /// The binary encoding width for register operands.
-  /// Only valid after `resolveOperands()` has been called and if this is a
-  /// register operand. Set to -1 if not a register or not yet resolved.
-  int registerBinaryEncodingWidth = -1;
 
 private:
   SmallString<32> name;

--- a/tools/circt-tblgen/RTGInstructionMethodsGen.cpp
+++ b/tools/circt-tblgen/RTGInstructionMethodsGen.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "RTGInstructionFormat.h"
+#include "RTGInstructionUtils.h"
 #include "mlir/TableGen/GenInfo.h"
 #include "mlir/TableGen/Operator.h"
 #include "llvm/ADT/SmallVector.h"
@@ -24,22 +25,7 @@
 using namespace llvm;
 using namespace mlir;
 using namespace mlir::tblgen;
-
-//===----------------------------------------------------------------------===//
-// Decorators
-//===----------------------------------------------------------------------===//
-
-namespace {
-// Helper class to represent a register effect decorator.
-class RegisterEffect : public Operator::VariableDecorator {
-public:
-  StringRef getEffectName() const { return def->getValueAsString("effect"); }
-
-  static bool classof(const Operator::VariableDecorator *var) {
-    return var->getDef().isSubClassOf("RegisterEffect");
-  }
-};
-} // namespace
+using namespace circt::tblgen::rtg;
 
 //===----------------------------------------------------------------------===//
 // Code Generation
@@ -52,19 +38,7 @@ static void genRegisterAllocationMethodsForOp(const Record *opDef,
   Operator op(opDef);
 
   // Check if this op implements RegisterAllocationOpInterface
-  bool hasInterface = false;
-  for (const auto &trait : op.getTraits()) {
-    if (auto *iTrait = dyn_cast<InterfaceTrait>(&trait)) {
-      std::string traitName = iTrait->getFullyQualifiedTraitName();
-      if (traitName.find("circt::rtg::RegisterAllocationOpInterface") !=
-          std::string::npos) {
-        hasInterface = true;
-        break;
-      }
-    }
-  }
-
-  if (!hasInterface)
+  if (!hasRegisterAllocationOpInterface(op))
     return;
 
   // Collect source and destination register indices

--- a/tools/circt-tblgen/RTGInstructionUtils.cpp
+++ b/tools/circt-tblgen/RTGInstructionUtils.cpp
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements helper functions for analyzing and extracting type
+// information from MLIR TableGen operation definitions for RTG.
+//
+//===----------------------------------------------------------------------===//
+
+#include "RTGInstructionUtils.h"
+#include "mlir/TableGen/AttrOrTypeDef.h"
+#include "mlir/TableGen/Trait.h"
+#include "llvm/TableGen/Error.h"
+#include "llvm/TableGen/Record.h"
+
+using namespace llvm;
+using namespace mlir::tblgen;
+using namespace circt;
+using namespace circt::tblgen::rtg;
+
+//===----------------------------------------------------------------------===//
+// Decorator Functions
+//===----------------------------------------------------------------------===//
+
+static bool hasRegisterEffect(const mlir::tblgen::Operator &op,
+                              unsigned argIndex, StringRef effectName) {
+  for (auto decorator : op.getArgDecorators(argIndex)) {
+    if (auto *effect = dyn_cast<RegisterEffect>(&decorator)) {
+      if (effect->getEffectName() == effectName)
+        return true;
+    }
+  }
+  return false;
+}
+
+bool tblgen::rtg::isSourceRegister(const mlir::tblgen::Operator &op,
+                                   unsigned argIndex) {
+  return hasRegisterEffect(op, argIndex, "SourceReg");
+}
+
+bool tblgen::rtg::isDestinationRegister(const mlir::tblgen::Operator &op,
+                                        unsigned argIndex) {
+  return hasRegisterEffect(op, argIndex, "DestReg");
+}
+
+//===----------------------------------------------------------------------===//
+// Type Checking Functions
+//===----------------------------------------------------------------------===//
+
+static bool checkType(const Record &typeRec, StringRef name) {
+  return typeRec.getName() == name || typeRec.isSubClassOf(name);
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+void tblgen::rtg::classifyOperandType(const Record &typeRec,
+                                      OperandTypeSet &kinds) {
+  if (checkType(typeRec, "LabelType"))
+    return kinds.appendAndUnique(Label());
+  if (checkType(typeRec, "ImmediateType"))
+    return kinds.appendAndUnique(AnyImmediate());
+  if (checkType(typeRec, "ImmediateOfWidth"))
+    return kinds.appendAndUnique(Immediate(typeRec.getValueAsInt("immWidth")));
+  if (checkType(typeRec, "MemoryType"))
+    return kinds.appendAndUnique(AnyMemory());
+  if (checkType(typeRec, "MemoryTypeWithAddressWidth"))
+    return kinds.appendAndUnique(Memory(typeRec.getValueAsInt("addressWidth")));
+  if (checkType(typeRec, "RegisterTypeBase"))
+    return kinds.appendAndUnique(
+        Register(typeRec.getValueAsString("pythonName"),
+                 typeRec.getValueAsString("pythonTypeName"),
+                 typeRec.getValueAsInt("binaryEncodingWidth")));
+
+  if (checkType(typeRec, "AnyTypeOf")) {
+    auto allowedTypes = typeRec.getValueAsListOfDefs("allowedTypes");
+    for (const Record *allowedType : allowedTypes)
+      classifyOperandType(*allowedType, kinds);
+  }
+}
+
+const NamedTypeConstraint *tblgen::rtg::findOperandByName(const Operator &op,
+                                                          StringRef name) {
+  for (auto arg : op.getArgs()) {
+    if (auto *operand = dyn_cast<NamedTypeConstraint *>(arg)) {
+      if (operand->name == name)
+        return operand;
+    }
+  }
+  return nullptr;
+}
+
+bool tblgen::rtg::hasOperatorInterface(const Operator &op,
+                                       StringRef interfaceName) {
+  for (const auto &trait : op.getTraits()) {
+    if (auto *iTrait = dyn_cast<InterfaceTrait>(&trait)) {
+      std::string traitName = iTrait->getFullyQualifiedTraitName();
+      if (traitName.find(interfaceName.str()) != std::string::npos)
+        return true;
+    }
+  }
+  return false;
+}

--- a/tools/circt-tblgen/RTGInstructionUtils.h
+++ b/tools/circt-tblgen/RTGInstructionUtils.h
@@ -1,0 +1,179 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares utilities for analyzing RTG instruction operations,
+// including operand type classification, register effect decorators, and
+// helper functions for querying operation properties from TableGen definitions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_TOOLS_CIRCT_TBLGEN_RTGTYPEANALYZER_H
+#define CIRCT_TOOLS_CIRCT_TBLGEN_RTGTYPEANALYZER_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/TableGen/Operator.h"
+#include "llvm/TableGen/Record.h"
+
+namespace circt {
+namespace tblgen {
+namespace rtg {
+
+//===----------------------------------------------------------------------===//
+// Decorators
+//===----------------------------------------------------------------------===//
+
+/// Helper class to represent a register effect decorator.
+class RegisterEffect : public mlir::tblgen::Operator::VariableDecorator {
+public:
+  /// Get the name of the register effect.
+  StringRef getEffectName() const { return def->getValueAsString("effect"); }
+
+  static bool classof(const mlir::tblgen::Operator::VariableDecorator *var) {
+    return var->getDef().isSubClassOf("RegisterEffect");
+  }
+};
+
+/// Check if an operand is a source register.
+bool isSourceRegister(const mlir::tblgen::Operator &op, unsigned argIndex);
+
+/// Check if an operand is a destination register.
+bool isDestinationRegister(const mlir::tblgen::Operator &op, unsigned argIndex);
+
+//===----------------------------------------------------------------------===//
+// Operand Type Classification
+//===----------------------------------------------------------------------===//
+
+/// Represents a register operand type.
+struct Register {
+  Register(StringRef name, StringRef typeName, size_t binaryEncodingWidth)
+      : name(name), typeName(typeName),
+        binaryEncodingWidth(binaryEncodingWidth) {}
+
+  /// The name of a Python class representing this register type.
+  StringRef name;
+  /// The name of a Python class representing the type of this register type.
+  StringRef typeName;
+  /// The number of bits needed to encode this register type in binary format.
+  size_t binaryEncodingWidth;
+
+  bool operator==(const Register &other) const {
+    return name == other.name && typeName == other.typeName &&
+           binaryEncodingWidth == other.binaryEncodingWidth;
+  }
+
+  bool operator<(const Register &other) const {
+    if (name != other.name)
+      return name < other.name;
+    if (typeName != other.typeName)
+      return typeName < other.typeName;
+    return binaryEncodingWidth < other.binaryEncodingWidth;
+  }
+};
+
+/// Represents an immediate operand type with a specific bit width.
+struct Immediate {
+  explicit Immediate(size_t bitWidth) : bitWidth(bitWidth) {}
+
+  size_t bitWidth;
+
+  bool operator==(const Immediate &other) const {
+    return bitWidth == other.bitWidth;
+  }
+
+  bool operator<(const Immediate &other) const {
+    return bitWidth < other.bitWidth;
+  }
+};
+
+/// Represents a memory operand type with a specific address width.
+struct Memory {
+  explicit Memory(size_t addressWidth) : addressWidth(addressWidth) {}
+
+  size_t addressWidth;
+
+  bool operator==(const Memory &other) const {
+    return addressWidth == other.addressWidth;
+  }
+
+  bool operator<(const Memory &other) const {
+    return addressWidth < other.addressWidth;
+  }
+};
+
+/// Represents an immediate operand type with any bit width.
+struct AnyImmediate {
+  bool operator==(const AnyImmediate &) const { return true; }
+  bool operator<(const AnyImmediate &) const { return false; }
+};
+
+/// Represents a memory operand type with any address width.
+struct AnyMemory {
+  bool operator==(const AnyMemory &) const { return true; }
+  bool operator<(const AnyMemory &) const { return false; }
+};
+
+/// Represents a label operand type.
+struct Label {
+  bool operator==(const Label &) const { return true; }
+  bool operator<(const Label &) const { return false; }
+};
+
+/// Classification of operand types in RTG instructions.
+/// Note: don't use an empty struct as first option as it is used by the
+/// variant dense map info for the empty and tombstone key and those empty
+/// structs don't have meaningful keys.
+using OperandType =
+    std::variant<Register, Immediate, Memory, Label, AnyImmediate, AnyMemory>;
+
+/// A set of operand types, supporting queries for specific type alternatives.
+/// After insertion the entries have to be sorted and uniqued manually.
+struct OperandTypeSet : public SmallVector<OperandType> {
+  /// Check if the set contains any of the specified operand type alternatives.
+  template <typename Tp, typename... Ts>
+  bool contains() const {
+    return llvm::any_of(*this, [](const OperandType &el) {
+      return (std::holds_alternative<Tp>(el) || ... ||
+              std::holds_alternative<Ts>(el));
+    });
+  }
+
+  /// Append an operand type to the set and uniquify.
+  void appendAndUnique(const OperandType &kind) {
+    push_back(kind);
+    llvm::sort(*this);
+    erase(llvm::unique(*this), end());
+  }
+};
+
+/// Classify a type Record into one or more type kinds. Multiple kinds meaning
+/// that the type is a union of the kinds.
+void classifyOperandType(const llvm::Record &typeRec, OperandTypeSet &kinds);
+
+/// Find an operand by name in an operation's arguments.
+const mlir::tblgen::NamedTypeConstraint *
+findOperandByName(const mlir::tblgen::Operator &op, llvm::StringRef name);
+
+/// Check if an operation has a specific interface trait.
+bool hasOperatorInterface(const mlir::tblgen::Operator &op,
+                          llvm::StringRef interfaceName);
+
+/// Check if an operation has the InstructionOpInterface.
+inline bool hasInstructionOpInterface(const mlir::tblgen::Operator &op) {
+  return hasOperatorInterface(op, "circt::rtg::InstructionOpInterface");
+}
+
+/// Check if an operation has the RegisterAllocationOpInterface.
+inline bool hasRegisterAllocationOpInterface(const mlir::tblgen::Operator &op) {
+  return hasOperatorInterface(op, "circt::rtg::RegisterAllocationOpInterface");
+}
+
+} // namespace rtg
+} // namespace tblgen
+} // namespace circt
+
+#endif // CIRCT_TOOLS_CIRCT_TBLGEN_RTGTYPEANALYZER_H


### PR DESCRIPTION
Extract and keep track of operand type properties in preparation of another tblgen backend.