### PR TITLE
[docs] Clarify contribution, AI tool use

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ of LLVM discord server.
 for more information.
 
 3) Contribute code.  CIRCT follows all of the LLVM Policies: you can create pull
-requests for the CIRCT repository, and gain commit access using the [standard LLVM policies](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access).
+requests for the CIRCT repository, and gain commit access using the [standard LLVM policies](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access). See our [Developer Policy](docs/DeveloperPolicy.md) and [AI Tool Use Policy](docs/AIToolPolicy.md) for more details.
 
 ## Motivation
 

--- a/docs/AIToolPolicy.md
+++ b/docs/AIToolPolicy.md
@@ -1,0 +1,33 @@
+# CIRCT AI Tool Use Policy
+
+The CIRCT project follows the upstream [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).
+
+## Summary
+
+Contributors may use AI tools to assist with their work, but must:
+
+- **Keep a human in the loop** - All AI-generated content must be reviewed and understood by the contributor before submission
+- **Take full accountability** - The contributor is the author and is responsible for their contributions
+- **Be transparent** - Label contributions containing substantial AI-generated content (e.g., using `AI-assisted-by:` in commit messages)
+- **Ensure quality** - Contributions should be worth more to the project than the time required to review them
+
+## What This Means
+
+**Allowed:**
+- Using AI tools to generate code that you review, understand, and can explain
+- Using AI for documentation that you verify for correctness
+- Using AI to help debug or optimize code you understand
+
+**Not Allowed:**
+- Submitting AI-generated code without thorough human review
+- Using automated agents that take action without human approval (e.g., GitHub `@claude` agent)
+- Using AI tools to fix "good first issue" labeled issues (these are learning opportunities for newcomers)
+- Passing maintainer feedback to an LLM without understanding and addressing it yourself
+
+## Legal Requirements
+
+Contributors using AI tools must still ensure they have the legal right to contribute code under the Apache-2.0 WITH LLVM-exception license. Using AI to regenerate copyrighted material does not remove the copyright.
+
+## Full Policy
+
+For complete details, see the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).

--- a/docs/DeveloperPolicy.md
+++ b/docs/DeveloperPolicy.md
@@ -1,0 +1,26 @@
+# CIRCT Developer Policy
+
+The CIRCT project is an [LLVM Incubator Project](https://llvm.org/docs/DeveloperPolicy.html#incubating-new-projects) and follows the upstream [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html).
+
+## Key Requirements
+
+All contributors to CIRCT must:
+
+- Have the legal right to contribute code under the [Apache-2.0 WITH LLVM-exception license](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework)
+- Follow the [LLVM Code of Conduct](https://llvm.org/docs/CodeOfConduct.html)
+- Adhere to the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html)
+- Follow the [LLVM Code Review Policy](https://llvm.org/docs/CodeReview.html)
+
+## Obtaining Commit Access
+
+CIRCT follows the standard LLVM process for obtaining commit access. See the [LLVM Developer Policy on Obtaining Commit Access](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access) for details.
+
+## AI Tool Use
+
+CIRCT follows the [LLVM AI Tool Use Policy](AIToolPolicy.md). Contributors using AI tools must ensure human review and accountability for all contributions.
+
+## Additional Resources
+
+- [LLVM Developer Policy (full)](https://llvm.org/docs/DeveloperPolicy.html)
+- [CIRCT Getting Started Guide](GettingStarted.md)
+- [CIRCT Charter](Charter.md)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -8,6 +8,8 @@ Welcome to the CIRCT project!
 (experimental!) effort looking to apply MLIR and the LLVM development
 methodology to the domain of hardware design tools.
 
+CIRCT is an [LLVM Incubator Project](https://llvm.org/docs/DeveloperPolicy.html#incubating-new-projects) and follows all LLVM policies. Before contributing, please review our [Developer Policy](DeveloperPolicy.md) and [AI Tool Use Policy](AIToolPolicy.md).
+
 Take a look at the following diagram, which gives a brief overview of the
 current [dialects and how they interact](https://circt.llvm.org/includes/img/dialects.svg):
 


### PR DESCRIPTION
Add new documentation that states that CIRCT is an LLVM Incubator Project
and follows upstream guidance on both contributions and AI tool use.  Add
explicit documentation on both of these latter points, summarizing the
upstream policies.
