### PR TITLE
[circt-test] Add test filtering by name and attribute

### DIFF
--- a/test/circt-test/filter.mlir
+++ b/test/circt-test/filter.mlir
@@ -1,0 +1,98 @@
+// RUN: circt-test -l -f 'Alpha*' %s | FileCheck %s --check-prefix=INC-NAME
+// RUN: circt-test -l -x '*Gamma' %s | FileCheck %s --check-prefix=EXC-NAME
+// RUN: circt-test -l -f 'engine=*' %s | FileCheck %s --check-prefix=INC-EXIST
+// RUN: circt-test -l -f 'engine=bmc' %s | FileCheck %s --check-prefix=INC-VAL
+// RUN: circt-test -l -f '*Alpha*' -x '*Gamma*' %s | FileCheck %s --check-prefix=COMBINED
+// RUN: circt-test -l -f '*Alpha*' -f '*Delta*' %s | FileCheck %s --check-prefix=MULTI-INC
+// RUN: circt-test -l -x 'depth=*' %s | FileCheck %s --check-prefix=EXC-EXIST
+// RUN: circt-test -l -f 'depth=5' %s | FileCheck %s --check-prefix=INC-INT
+// RUN: circt-test -l --include '*Alpha*' --exclude '*Gamma*' %s | FileCheck %s --check-prefix=COMBINED
+// RUN: circt-test -l -f 'config.backend=vltr' %s | FileCheck %s --check-prefix=NESTED-VAL
+// RUN: circt-test -l -f 'config.backend=*' %s | FileCheck %s --check-prefix=NESTED-EXIST
+// RUN: circt-test -l -x 'config.backend=*' %s | FileCheck %s --check-prefix=NESTED-EXC
+// RUN: circt-test -l -f 'Alph?' %s | FileCheck %s --check-prefix=GLOB-QMARK
+// RUN: circt-test -l -f '[AZ]*' %s | FileCheck %s --check-prefix=GLOB-CLASS
+
+// INC-NAME: Alpha formal
+// INC-NAME: AlphaGamma formal
+// INC-NAME-NOT: Beta
+// INC-NAME-NOT: Delta
+
+// EXC-NAME: Alpha formal {
+// EXC-NAME: Beta formal
+// EXC-NAME-NOT: AlphaGamma
+// EXC-NAME: Delta simulation
+
+// INC-EXIST: Alpha formal {
+// INC-EXIST: Beta formal
+// INC-EXIST-NOT: AlphaGamma
+// INC-EXIST: Delta simulation
+
+// INC-VAL: Alpha formal {
+// INC-VAL-NOT: Beta
+// INC-VAL-NOT: AlphaGamma
+// INC-VAL: Delta simulation
+
+// COMBINED: Alpha formal {
+// COMBINED-NOT: AlphaGamma
+// COMBINED-NOT: Beta
+// COMBINED-NOT: Delta
+
+// MULTI-INC: Alpha formal {
+// MULTI-INC: AlphaGamma formal
+// MULTI-INC-NOT: Beta
+// MULTI-INC: Delta simulation
+
+// EXC-EXIST-NOT: depth =
+// EXC-EXIST: Beta formal
+// EXC-EXIST: AlphaGamma formal
+// EXC-EXIST: Delta simulation
+
+// INC-INT: Alpha formal {
+// INC-INT-NOT: Beta
+// INC-INT-NOT: AlphaGamma
+// INC-INT-NOT: Delta
+
+// NESTED-VAL-NOT: Alpha
+// NESTED-VAL-NOT: Beta
+// NESTED-VAL-NOT: AlphaGamma
+// NESTED-VAL-NOT: Delta
+// NESTED-VAL: Epsilon formal
+// NESTED-VAL-NOT: Zeta
+
+// NESTED-EXIST-NOT: Alpha
+// NESTED-EXIST-NOT: Beta
+// NESTED-EXIST-NOT: AlphaGamma
+// NESTED-EXIST-NOT: Delta
+// NESTED-EXIST: Epsilon formal
+// NESTED-EXIST: Zeta formal
+
+// NESTED-EXC: Alpha formal
+// NESTED-EXC: Beta formal
+// NESTED-EXC: AlphaGamma formal
+// NESTED-EXC: Delta simulation
+// NESTED-EXC-NOT: Epsilon
+// NESTED-EXC-NOT: Zeta
+
+// GLOB-QMARK: Alpha formal
+// GLOB-QMARK-NOT: AlphaGamma
+// GLOB-QMARK-NOT: Beta
+// GLOB-QMARK-NOT: Delta
+
+// GLOB-CLASS: Alpha formal
+// GLOB-CLASS: AlphaGamma formal
+// GLOB-CLASS-NOT: Beta
+// GLOB-CLASS-NOT: Delta
+// GLOB-CLASS-NOT: Epsilon
+// GLOB-CLASS: Zeta formal
+
+verif.formal @Alpha {engine = "bmc", depth = 5 : i64} {}
+verif.formal @Beta {engine = "induction"} {}
+verif.formal @AlphaGamma {} {}
+verif.simulation @Delta {engine = "bmc"} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %0 = hw.constant true
+  verif.yield %0, %0 : i1, i1
+}
+verif.formal @Epsilon {config = {backend = "vltr", depth = 7 : i64}} {}
+verif.formal @Zeta {config = {backend = "icrs", depth = 3 : i64}} {}

--- a/tools/circt-test/circt-test.cpp
+++ b/tools/circt-test/circt-test.cpp
@@ -38,6 +38,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
@@ -109,6 +110,20 @@ struct Options {
   cl::list<std::string> runners{"r", cl::desc("Use a specific set of runners"),
                                 cl::value_desc("name"),
                                 cl::MiscFlags::CommaSeparated, cl::cat(cat)};
+
+  cl::list<std::string> includeFilters{
+      "f", cl::desc("Include filter (<glob> or <path>=<glob>)"),
+      cl::value_desc("filter"), cl::cat(testCat)};
+
+  cl::alias includeFiltersAlias{"include", cl::aliasopt(includeFilters),
+                                cl::desc("Alias for -f")};
+
+  cl::list<std::string> excludeFilters{
+      "x", cl::desc("Exclude filter (<glob> or <path>=<glob>)"),
+      cl::value_desc("filter"), cl::cat(testCat)};
+
+  cl::alias excludeFiltersAlias{"exclude", cl::aliasopt(excludeFilters),
+                                cl::desc("Alias for -x")};
 
   cl::opt<bool> ignoreContracts{
       "ignore-contracts",
@@ -471,6 +486,124 @@ LogicalResult TestSuite::discoverTest(Test &&test, Operation *op) {
 
   tests.push_back(std::move(test));
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Test Filtering
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// A parsed test filter, used for the `-f` (include) and `-x` (exclude) CLI
+/// options. Filters can match by test name or attribute value.
+struct TestFilter {
+  enum Kind { Name, AttrValue };
+  Kind kind;
+  std::string attrPath;
+  llvm::GlobPattern pattern;
+};
+} // namespace
+
+/// Parse a filter string into a `TestFilter`. The string is one of:
+/// - `<glob>` — match test name
+/// - `<path>=<glob>` — attribute value matches glob
+static FailureOr<TestFilter> parseFilter(StringRef filter) {
+  auto eqPos = filter.find('=');
+  if (eqPos == StringRef::npos) {
+    TestFilter f;
+    f.kind = TestFilter::Name;
+    auto pat = llvm::GlobPattern::create(filter);
+    if (!pat) {
+      WithColor::error() << "invalid filter glob '" << filter
+                         << "': " << toString(pat.takeError()) << "\n";
+      return failure();
+    }
+    f.pattern = std::move(*pat);
+    return f;
+  }
+
+  auto path = filter.take_front(eqPos);
+  auto value = filter.drop_front(eqPos + 1);
+  TestFilter f;
+  f.kind = TestFilter::AttrValue;
+  f.attrPath = path.str();
+  auto pat = llvm::GlobPattern::create(value);
+  if (!pat) {
+    WithColor::error() << "invalid filter glob '" << value
+                       << "': " << toString(pat.takeError()) << "\n";
+    return failure();
+  }
+  f.pattern = std::move(*pat);
+  return f;
+}
+
+/// Walk a dotted attribute path (e.g., `config.backend`) through nested
+/// `DictionaryAttr`s, returning the leaf attribute or `nullptr`.
+static Attribute walkAttrPath(DictionaryAttr dict, StringRef path) {
+  while (!path.empty()) {
+    auto [segment, rest] = path.split('.');
+    auto attr = dict.get(segment);
+    if (!attr)
+      return nullptr;
+    if (rest.empty())
+      return attr;
+    dict = dyn_cast<DictionaryAttr>(attr);
+    if (!dict)
+      return nullptr;
+    path = rest;
+  }
+  return nullptr;
+}
+
+/// Convert an attribute to a string for glob matching.
+static std::string stringifyAttrValue(Attribute attr) {
+  if (auto s = dyn_cast<StringAttr>(attr))
+    return s.getValue().str();
+  if (auto b = dyn_cast<BoolAttr>(attr))
+    return b.getValue() ? "true" : "false";
+  if (auto i = dyn_cast<IntegerAttr>(attr)) {
+    SmallString<16> str;
+    i.getValue().toString(str, 10, /*Signed=*/true);
+    return std::string(str);
+  }
+  if (auto f = dyn_cast<FloatAttr>(attr)) {
+    SmallString<16> str;
+    f.getValue().toString(str);
+    return std::string(str);
+  }
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  attr.print(os);
+  return str;
+}
+
+/// Check whether a test matches a given filter.
+static bool matchFilter(const Test &test, TestFilter &filter) {
+  switch (filter.kind) {
+  case TestFilter::Name:
+    return filter.pattern.match(test.name.getValue());
+  case TestFilter::AttrValue:
+    if (auto leaf = walkAttrPath(test.attrs, filter.attrPath))
+      return filter.pattern.match(stringifyAttrValue(leaf));
+    return false;
+  }
+  return false;
+}
+
+/// Apply include and exclude filters to the tests in the suite. A test is kept
+/// if it matches any include filter (or none are specified) and matches no
+/// exclude filter.
+static void applyFilters(TestSuite &suite,
+                         MutableArrayRef<TestFilter> includeFilters,
+                         MutableArrayRef<TestFilter> excludeFilters) {
+  for (auto &test : suite.tests) {
+    if (!includeFilters.empty() && !llvm::any_of(includeFilters, [&](auto &f) {
+          return matchFilter(test, f);
+        }))
+      test.ignore = true;
+    if (llvm::any_of(excludeFilters,
+                     [&](auto &f) { return matchFilter(test, f); }))
+      test.ignore = true;
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -963,12 +1096,34 @@ static LogicalResult executeWithHandler(MLIRContext *context,
     return success();
   }
 
+  // Parse include and exclude filters.
+  SmallVector<TestFilter> includeFilters, excludeFilters;
+  for (auto &filter : opts.includeFilters) {
+    auto parsed = parseFilter(filter);
+    if (failed(parsed))
+      return failure();
+    includeFilters.push_back(std::move(*parsed));
+  }
+  for (auto &filter : opts.excludeFilters) {
+    auto parsed = parseFilter(filter);
+    if (failed(parsed))
+      return failure();
+    excludeFilters.push_back(std::move(*parsed));
+  }
+
   // Discover all tests in the input.
   TestSuite suite(context, opts.listIgnored);
   if (failed(suite.discoverInModule(*module)))
     return failure();
   if (suite.tests.empty()) {
     llvm::errs() << "no tests discovered\n";
+    return success();
+  }
+
+  // Apply filters.
+  applyFilters(suite, includeFilters, excludeFilters);
+  if (suite.tests.empty()) {
+    llvm::errs() << "all tests excluded by filters\n";
     return success();
   }
 


### PR DESCRIPTION
Add `-f`/`--include` and `-x`/`--exclude` CLI options for fine-grained test filtering. Each filter string takes one of three forms:

- `<regex>` to match test name
- `<path>=` to check if an attribute at the dotted path exists
- `<path>=<regex>` to match an attribute value at the dotted path

A test is kept if it matches any include filter (or none are specified) and matches no exclude filter. Attribute paths support `.`-separated nesting for `DictionaryAttr`s.