### PR TITLE
[Synth] Add synth.choice

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -134,4 +134,26 @@ def AndInverterOp : SynthOp<"aig.and_inv", [SameOperandsAndResultType, Pure]> {
   let cppNamespace = "::circt::synth::aig";
 }
 
+def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
+  let summary = "Synth choice operation";
+  let description = [{
+    The `synth.choice` operation represents a set of structurally equivalent
+    choices, corresponding to the choice nodes introduced in "Reducing
+    Structural Bias in Technology Mapping" (ICCAD 2005, S. Chatterjee et al.).
+
+    A compiler may assume all operands are equivalent and replace the operation
+    with any one of them at any point in the pipeline.
+
+    Example:
+    ```mlir
+      %r1 = synth.choice %a, %b : i1
+      %r2 = synth.choice %a, %b, %c : i16
+    ```
+  }];
+  let arguments = (ins Variadic<AnyType>:$inputs);
+  let results = (outs AnyType:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = "$inputs attr-dict `:` type($result)";
+}
+
 #endif // CIRCT_DIALECT_SYNTH_SYNTHOPS_TD

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -21,11 +21,18 @@
 
 using namespace mlir;
 using namespace circt;
+using namespace circt::synth;
 using namespace circt::synth::mig;
 using namespace circt::synth::aig;
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Synth/Synth.cpp.inc"
+
+LogicalResult ChoiceOp::verify() {
+  if (getNumOperands() < 1)
+    return emitOpError("requires at least one operand");
+  return success();
+}
 
 LogicalResult MajorityInverterOp::verify() {
   if (getNumOperands() % 2 != 1)

--- a/test/Dialect/Synth/errors.mlir
+++ b/test/Dialect/Synth/errors.mlir
@@ -1,7 +1,15 @@
-// RUN: circt-opt %s --verify-diagnostics
+// RUN: circt-opt %s --verify-diagnostics --split-input-file
 
 hw.module @test(in %a : i1, in %b : i1, out result : i1) {
     // expected-error @+1 {{'synth.mig.maj_inv' op requires an odd number of operands}}
     %0 = synth.mig.maj_inv %a, %b : i1
+    hw.output %0 : i1
+}
+
+// -----
+
+hw.module @test(out result : i1) {
+    // expected-error @+1 {{'synth.choice' op expected 1 or more operands, but found 0}}
+    %0 = synth.choice : i1
     hw.output %0 : i1
 }

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -16,3 +16,10 @@ hw.module @And(in %a: i1, in %b: i4) {
   %2 = synth.aig.and_inv not %a, not %a : i1
 }
 
+// CHECK-LABEL: @choice
+// CHECK-NEXT: %[[R0:.+]] = synth.choice %a : i4
+// CHECK-NEXT: %[[R1:.+]] = synth.choice %a, %b, %a : i4
+hw.module @choice(in %a: i4, in %b: i4) {
+  %0 = synth.choice %a : i4
+  %1 = synth.choice %a, %b, %a : i4
+}


### PR DESCRIPTION
The `synth.choice` operation represents a set of structurally equivalent choices, corresponding to the choice nodes introduced in "Reducing Structural Bias in Technology Mapping" (ICCAD 2005, S. Chatterjee et al.).

A compiler may assume all operands are equivalent and replace the operation with any one of them at any point in the pipeline.

This is a preparation commit for introducing Functional Reduction pass (e.g. [FRAIG](https://people.eecs.berkeley.edu/~alanmi/publications/2005/tech05_fraigs.pdf)). 

Semantically this is equivalent to dataflow-ish `verif.assume` or chains of `verif.contract`. 