### PR TITLE
[LTLToCore] Add `assume-first-clock` flag for SV ingestion

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -660,6 +660,11 @@ def LowerLTLToCore : Pass<"lower-ltl-to-core", "hw::HWModuleOp"> {
     "hw::HWDialect", "sv::SVDialect", "comb::CombDialect",
     "seq::SeqDialect"
   ];
+  let options =
+    [Option<"assumeFirstClock", "assume-first-clock", "bool", "false",
+            "Assume that implicitly clocked LTL operations are clocked by the"
+            "first clock argument, or failing that, the first seq.to_clock"
+            "operation in their parent hw.module.">];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -167,16 +167,39 @@ struct LTLOrOpConversion : public OpConversionPattern<ltl::OrOp> {
 };
 
 struct LTLPastOpConversion : public OpConversionPattern<ltl::PastOp> {
-  using OpConversionPattern<ltl::PastOp>::OpConversionPattern;
+  LTLPastOpConversion(MLIRContext *context, bool assumeFirstClock)
+      : OpConversionPattern<ltl::PastOp>(context),
+        assumeFirstClock(assumeFirstClock) {}
 
   LogicalResult
   matchAndRewrite(ltl::PastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!adaptor.getClk())
-      return failure();
+    Value clock;
+    if (!adaptor.getClk()) {
+      if (!assumeFirstClock)
+        return failure();
+      // Find the first clock, looking at inputs then at to_clock operations
+      auto module = op->getParentOfType<HWModuleOp>();
+      hw::PortInfo *clockPort = nullptr;
+      for (auto &port : module.getPortList())
+        if (port.isInput() && isa<seq::ClockType>(port.type)) {
+          clockPort = &port;
+          break;
+        }
+      if (clockPort) {
+        clock = module.getArgumentForInput(clockPort->argNum);
+      } else {
+        // If there are no clock ports, we try to_clock operations
+        auto toClockOps = module.getOps<seq::ToClockOp>();
+        if (toClockOps.empty())
+          return failure();
+        clock = (*toClockOps.begin()).getResult();
+      }
+    } else {
+      clock = seq::ToClockOp::create(rewriter, op.getLoc(), adaptor.getClk());
+    }
+
     Value cur = adaptor.getInput();
-    auto clock =
-        seq::ToClockOp::create(rewriter, op.getLoc(), adaptor.getClk());
     Value ce =
         hw::ConstantOp::create(rewriter, op.getLoc(), rewriter.getI1Type(), 1);
     auto shiftreg =
@@ -185,6 +208,8 @@ struct LTLPastOpConversion : public OpConversionPattern<ltl::PastOp> {
     rewriter.replaceOp(op, shiftreg);
     return success();
   }
+
+  bool assumeFirstClock;
 };
 
 } // namespace
@@ -205,16 +230,18 @@ struct LowerLTLToCorePass
 void LowerLTLToCorePass::runOnOperation() {
   // Emit an explicit error for unsupported past ops, rather than a confusing
   // 'failed to legalize' error
-  auto res = getOperation().walk([&](ltl::PastOp op) {
-    if (!op.getClk()) {
-      op.emitError(
-          "ltl.past operations without a clock operand are not supported.");
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  if (res.wasInterrupted())
-    return signalPassFailure();
+  if (!assumeFirstClock) {
+    auto res = getOperation().walk([&](ltl::PastOp op) {
+      if (!op.getClk()) {
+        op.emitError(
+            "ltl.past operations without a clock operand are not supported.");
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (res.wasInterrupted())
+      return signalPassFailure();
+  }
 
   // Set target dialects: We don't want to see any ltl or verif that might
   // come from an AssertProperty left in the result
@@ -286,10 +313,10 @@ void LowerLTLToCorePass::runOnOperation() {
 
   // Create the operation rewrite patters
   RewritePatternSet patterns(&getContext());
-  patterns
-      .add<HasBeenResetOpConversion, LTLImplicationConversion, LTLNotConversion,
-           LTLAndOpConversion, LTLOrOpConversion, LTLPastOpConversion>(
-          converter, patterns.getContext());
+  patterns.add<HasBeenResetOpConversion, LTLImplicationConversion,
+               LTLNotConversion, LTLAndOpConversion, LTLOrOpConversion>(
+      converter, patterns.getContext());
+  patterns.add<LTLPastOpConversion>(patterns.getContext(), assumeFirstClock);
   // Apply the conversions
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))
@@ -301,8 +328,8 @@ void LowerLTLToCorePass::runOnOperation() {
       return;
     Value prop = op->getOperand(0);
     if (auto cast = prop.getDefiningOp<UnrealizedConversionCastOp>()) {
-      // Make sure that the cast is from an i1, not something random that was in
-      // the input
+      // Make sure that the cast is from an i1, not something random that was
+      // in the input
       if (auto intType = dyn_cast<IntegerType>(cast.getOperandTypes()[0]);
           intType && intType.getWidth() == 1)
         op->setOperand(0, cast.getInputs()[0]);

--- a/test/Conversion/LTLToCore/assume-first-clock-errors.mlir
+++ b/test/Conversion/LTLToCore/assume-first-clock-errors.mlir
@@ -1,0 +1,7 @@
+// RUN: circt-opt --lower-ltl-to-core='assume-first-clock' --verify-diagnostics --split-input-file %s
+
+// Make sure we don't hallucinate some clock argument where there isn't one
+hw.module @past_impl_clk(in %a: i32) {
+  // expected-error @below {{failed to legalize operation 'ltl.past' that was explicitly marked illegal}}
+  %past = ltl.past %a, 2 : i32
+}

--- a/test/Conversion/LTLToCore/assume-first-clock.mlir
+++ b/test/Conversion/LTLToCore/assume-first-clock.mlir
@@ -1,0 +1,30 @@
+// RUN: circt-opt %s --lower-ltl-to-core='assume-first-clock' | FileCheck %s
+
+// CHECK: hw.module @clock_arg(in [[A:%.+]] : i32, in [[CLK:%.+]] : !seq.clock)
+// CHECK: [[TRUE:%.+]] = hw.constant true
+// CHECK: [[SHIFTREG:%.+]] = seq.shiftreg[2] [[A]], [[CLK]], [[TRUE]] : i32
+
+hw.module @clock_arg(in %a: i32, in %clk: !seq.clock) {
+  ltl.past %a, 2 : i32
+}
+
+// CHECK: hw.module @to_clock(in [[A:%.+]] : i32, in [[CLK:%.+]] : i1)
+// CHECK: [[TO_CLK:%.+]] = seq.to_clock [[CLK]]
+// CHECK: [[TRUE:%.+]] = hw.constant true
+// CHECK: [[SHIFTREG:%.+]] = seq.shiftreg[2] [[A]], [[TO_CLK]], [[TRUE]] : i32
+
+hw.module @to_clock(in %a: i32, in %clk: i1) {
+  %0 = seq.to_clock %clk
+  ltl.past %a, 2 : i32
+}
+
+// Ensure !seq.clock arguments are considered over to_clocks
+// CHECK: hw.module @both(in [[A:%.+]] : i32, in [[B:%.+]] : i1, in [[CLK:%.+]] : !seq.clock)
+// CHECK: [[TO_CLK:%.+]] = seq.to_clock [[B]]
+// CHECK: [[TRUE:%.+]] = hw.constant true
+// CHECK: [[SHIFTREG:%.+]] = seq.shiftreg[2] [[A]], [[CLK]], [[TRUE]] : i32
+
+hw.module @both(in %a: i32, in %b: i1, in %clk: !seq.clock) {
+  %0 = seq.to_clock %b
+  ltl.past %a, 2 : i32
+}


### PR DESCRIPTION
Adds a flag to assume all LTL clocked operations (i.e., currently, past operations) are clocked by the first clock found in a module. Adding this for some simple cases where I need to lower PastOps - this provides a flow for simple, single clock cases before we have full integration with the Slang LRM clock inference infra.