### PR TITLE
[ImportVerilog] Fix compiler warning, NFC

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -376,11 +376,6 @@ struct ModuleVisitor : public BaseVisitor {
           }
           continue;
         }
-
-        default:
-          return mlir::emitError(loc)
-                 << "unsupported port `" << port->name << "` ("
-                 << slang::ast::toString(port->kind) << ")";
         }
       }
 


### PR DESCRIPTION
Fix a compiler warning to remove a default in a fully-covered switch
statement.
