### PR TITLE
[ImportVerilog] Add string indexing, sim.string.get

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3067,7 +3067,7 @@ def StringToLowerOp : StringBuiltin<"tolower"> {
   let assemblyFormat = "$str attr-dict";
 }
 
-def StringGetCOp : StringBuiltin<"getc"> {
+def StringGetOp : StringBuiltin<"get"> {
   let summary = "Get a character from a string";
   let description = [{
     Returns the character at the specified index in the given string.

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -620,6 +620,32 @@ def IntToStringOp: SimOp<"string.int_to_string", [Pure]> {
   let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
 }
 
+def StringGetOp : SimOp<"string.get", [Pure]> {
+  let summary = "Get a character from a string at a given index";
+  let description = [{
+    Returns the character (byte) at the specified index within a dynamic string.
+    The index is zero-based, where 0 refers to the first character.
+
+    If the index is negative or greater than or equal to the string length,
+    the behavior follows IEEE 1800-2023 § 6.16, which specifies that accessing
+    an out-of-bounds index returns 0 (null character).
+
+    Example:
+    ```mlir
+    %str = sim.string.literal "Hello"
+    %idx = hw.constant 1 : i32
+    %char = sim.string.get %str[%idx] : i8  // Returns 'e' (0x65)
+    ```
+  }];
+
+  let arguments = (ins DynamicStringType:$str, I32:$index);
+  let results = (outs I8:$result);
+
+  let hasFolder = true;
+
+  let assemblyFormat = "$str `[` $index `]` attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Queues
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -191,7 +191,8 @@ struct ExprVisitor {
       derefType = cast<moore::RefType>(derefType).getNestedType();
 
     if (!isa<moore::IntType, moore::ArrayType, moore::UnpackedArrayType,
-             moore::QueueType, moore::AssocArrayType>(derefType)) {
+             moore::QueueType, moore::AssocArrayType, moore::StringType>(
+            derefType)) {
       mlir::emitError(loc) << "unsupported expression: element select into "
                            << expr.value().type->toString() << "\n";
       return {};
@@ -219,6 +220,23 @@ struct ExprVisitor {
 
       return moore::AssocArrayExtractOp::create(builder, loc, type, value,
                                                 givenIndex);
+    }
+
+    // Handle string indexing.
+    if (isa<moore::StringType>(derefType)) {
+      if (isLvalue) {
+        mlir::emitError(loc) << "string index assignment not supported";
+        return {};
+      }
+
+      // Convert the index to an rvalue with the required type (TwoValuedI32).
+      auto i32Type = moore::IntType::getInt(builder.getContext(), 32);
+      auto index = context.convertRvalueExpression(expr.selector(), i32Type);
+      if (!index)
+        return {};
+
+      // Create the StringGetOp operation.
+      return moore::StringGetOp::create(builder, loc, value, index);
     }
 
     auto resultType =
@@ -3007,8 +3025,8 @@ Context::convertSystemCallArity2(const slang::ast::SystemSubroutine &subroutine,
       llvm::StringSwitch<std::function<FailureOr<Value>()>>(subroutine.name)
           .Case("getc",
                 [&]() -> Value {
-                  return moore::StringGetCOp::create(builder, loc, value1,
-                                                     value2);
+                  return moore::StringGetOp::create(builder, loc, value1,
+                                                    value2);
                 })
           .Case("$urandom_range",
                 [&]() -> Value {

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2251,6 +2251,18 @@ struct StringConcatOpConversion : public OpConversionPattern<StringConcatOp> {
   }
 };
 
+struct StringGetOpConversion : public OpConversionPattern<StringGetOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StringGetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::StringGetOp>(op, adaptor.getStr(),
+                                                  adaptor.getIndex());
+    return success();
+  }
+};
+
 struct QueueSizeBIOpConversion : public OpConversionPattern<QueueSizeBIOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -2972,6 +2984,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     // Dynamic string operations
     StringLenOpConversion,
     StringConcatOpConversion,
+    StringGetOpConversion,
 
     // Queue operations
     QueueSizeBIOpConversion,

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -580,6 +580,32 @@ OpFoldResult IntToStringOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+//===----------------------------------------------------------------------===//
+// StringGetOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult StringGetOp::fold(FoldAdaptor adaptor) {
+  auto strAttr = cast_or_null<StringAttr>(adaptor.getStr());
+  auto indexAttr = cast_or_null<IntegerAttr>(adaptor.getIndex());
+  if (!strAttr || !indexAttr)
+    return {};
+
+  auto str = strAttr.getValue();
+  int64_t index = indexAttr.getValue().getSExtValue();
+
+  // Out-of-bounds access returns 0 (null character) per IEEE 1800-2023 § 6.16
+  if (index < 0 || index >= static_cast<int64_t>(str.size()))
+    return IntegerAttr::get(getType(), 0);
+
+  // Return the character at the specified index
+  uint8_t ch = static_cast<uint8_t>(str[index]);
+  return IntegerAttr::get(getType(), ch);
+}
+
+//===----------------------------------------------------------------------===//
+// QueueResizeOp
+//===----------------------------------------------------------------------===//
+
 LogicalResult QueueResizeOp::verify() {
   if (cast<QueueType>(getInput().getType()).getElementType() !=
       cast<QueueType>(getResult().getType()).getElementType())

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -796,6 +796,15 @@ module Expressions;
     // CHECK: [[TMP2:%.+]] = moore.read %s1
     // CHECK: moore.string.concat ([[TMP1]], [[TMP2]])
     concatstr = {s, s1};
+    // String indexing with i32 index (no conversion needed)
+    // CHECK: moore.string.get {{%.+}}[{{%.+}}]
+    m = s1[c];
+    // String indexing with logic index (conversion to i32 needed)
+    // CHECK: [[M_READ:%.+]] = moore.read %m
+    // CHECK: [[ZEXT:%.+]] = moore.zext [[M_READ]] : l4 -> l32
+    // CHECK: [[CONV:%.+]] = moore.logic_to_int [[ZEXT]]
+    // CHECK: moore.string.get {{%.+}}[[[CONV]]]
+    m = s[m];
     // CHECK: [[TMP1:%.+]] = moore.read %d
     // CHECK: [[TMP2:%.+]] = moore.read %e
     // CHECK: moore.concat [[TMP1]], [[TMP2]] : (!moore.l32, !moore.l32) -> l64

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -533,6 +533,6 @@ function void StringBuiltins(string string_in, int int_in);
   dummyD(string_in.toupper());
   // CHECK: [[LEN:%.+]] = moore.string.tolower [[STR]]
   dummyD(string_in.tolower());
-  // CHECK: [[CHAR:%.+]] = moore.string.getc [[STR]]{{\[}}[[INT]]]
+  // CHECK: [[CHAR:%.+]] = moore.string.get [[STR]]{{\[}}[[INT]]]
   dummyE(string_in.getc(int_in));
 endfunction

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -190,3 +190,13 @@ function Foo;
   // expected-error @below {{unsupported system call `$fwrite`}}
   $fwrite(32'h0, "%x", a);
 endfunction
+
+// -----
+module Foo;
+  string s;
+  byte b;
+  initial begin
+    // expected-error @below {{string index assignment not supported}}
+    s[0] = b;
+  end
+endmodule

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1525,6 +1525,15 @@ func.func @StringOperations(%arg0: !moore.i32, %arg1: !moore.string, %arg2: !moo
   return
 }
 
+// CHECK-LABEL: func.func @StringIndexing
+// CHECK-SAME: %arg0: !sim.dstring
+// CHECK-SAME: %arg1: i32
+func.func @StringIndexing(%arg0: !moore.string, %arg1: !moore.i32) {
+  // CHECK: sim.string.get %arg0[%arg1]
+  %0 = moore.string.get %arg0[%arg1]
+  return
+}
+
 // CHECK-LABEL func.func @QueueOperations
 func.func @QueueOperations(%arg0: !moore.i32, %arg1: !moore.i32) {
   // CHECK: [[EMPTY:%.+]] = sim.queue.empty : <i32, 10>

--- a/test/Dialect/Sim/canonicalization.mlir
+++ b/test/Dialect/Sim/canonicalization.mlir
@@ -1,0 +1,75 @@
+// RUN: circt-opt %s --canonicalize | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// String Operations
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @string_get_constant_fold_valid
+func.func @string_get_constant_fold_valid() -> i8 {
+  %str = sim.string.literal "Hello"
+  %idx = hw.constant 1 : i32
+  // CHECK: [[TMP:%.+]] = hw.constant 101 : i8
+  %char = sim.string.get %str[%idx]
+  // CHECK: return [[TMP]]
+  return %char : i8
+}
+
+// CHECK-LABEL: func.func @string_get_constant_fold_first
+func.func @string_get_constant_fold_first() -> i8 {
+  %str = sim.string.literal "Hello"
+  %idx = hw.constant 0 : i32
+  // CHECK: [[TMP:%.+]] = hw.constant 72 : i8
+  %char = sim.string.get %str[%idx]
+  // CHECK: return [[TMP]]
+  return %char : i8
+}
+
+// CHECK-LABEL: func.func @string_get_constant_fold_last
+func.func @string_get_constant_fold_last() -> i8 {
+  %str = sim.string.literal "Hello"
+  %idx = hw.constant 4 : i32
+  // CHECK: [[TMP:%.+]] = hw.constant 111 : i8
+  %char = sim.string.get %str[%idx]
+  // CHECK: return [[TMP]]
+  return %char : i8
+}
+
+// CHECK-LABEL: func.func @string_get_constant_fold_out_of_bounds_positive
+func.func @string_get_constant_fold_out_of_bounds_positive() -> i8 {
+  %str = sim.string.literal "Hello"
+  %idx = hw.constant 100 : i32
+  // CHECK: [[TMP:%.+]] = hw.constant 0 : i8
+  %char = sim.string.get %str[%idx]
+  // CHECK: return [[TMP]]
+  return %char : i8
+}
+
+// CHECK-LABEL: func.func @string_get_constant_fold_out_of_bounds_negative
+func.func @string_get_constant_fold_out_of_bounds_negative() -> i8 {
+  %str = sim.string.literal "Hello"
+  %idx = hw.constant -1 : i32
+  // CHECK: [[TMP:%.+]] = hw.constant 0 : i8
+  %char = sim.string.get %str[%idx]
+  // CHECK: return [[TMP]]
+  return %char : i8
+}
+
+// CHECK-LABEL: func.func @string_get_constant_fold_empty_string
+func.func @string_get_constant_fold_empty_string() -> i8 {
+  %str = sim.string.literal ""
+  %idx = hw.constant 0 : i32
+  // CHECK: [[TMP:%.+]] = hw.constant 0 : i8
+  %char = sim.string.get %str[%idx]
+  // CHECK: return [[TMP]]
+  return %char : i8
+}
+
+// CHECK-LABEL: func.func @string_get_special_chars
+func.func @string_get_special_chars() -> i8 {
+  %str = sim.string.literal "abc\n"
+  %idx = hw.constant 3 : i32
+  // CHECK: [[TMP:%.+]] = hw.constant 10 : i8
+  %char = sim.string.get %str[%idx]
+  // CHECK: return [[TMP]]
+  return %char : i8
+}

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -67,3 +67,16 @@ func.func @FormatStrings() {
   sim.fmt.hier_path escaped
   return
 }
+
+// CHECK-LABEL: func.func @DynamicStrings
+func.func @DynamicStrings(%idx: i32) {
+  // CHECK: sim.string.literal "Hello"
+  %str = sim.string.literal "Hello"
+  // CHECK: sim.string.length
+  %len = sim.string.length %str
+  // CHECK: sim.string.concat
+  %concat = sim.string.concat (%str, %str)
+  // CHECK: sim.string.get
+  %char = sim.string.get %str[%idx]
+  return
+}


### PR DESCRIPTION
Add support for string indexing expressions like `str[42]`. Lower these to the existing `moore.string.get` operation (renamed from `getc`). Add a new `sim.string.get` operation to target from `moore.string.get`.

Diff on sv-tests errors:
```
-124 error: unsupported expression: element select into string
+118 error: unsupported expression: EmptyArgument
  +2 error: string index assignment not supported
  -1 error: failed to legalize operation 'moore.string.getc'
  +1 error: failed to legalize operation 'moore.fmt.string'
  -4 total change
```