### PR TITLE
[FIRRTL] Add configuration file support for FIRRTL instance choices

### DIFF
--- a/integration_test/Dialect/FIRRTL/instance-choice.fir
+++ b/integration_test/Dialect/FIRRTL/instance-choice.fir
@@ -25,6 +25,11 @@
 ; RUN: %t.default.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=DEFAULT
 ; DEFAULT: result:       0
 
+; -------------------------------------- Test 5: Configuration file
+; RUN: echo '`include "targets-top-Platform-FPGA.svh"' > %t/user-config.svh
+; RUN: verilator %driver %t/top.sv %t/ASICTarget.sv %t/FPGATarget.sv %t/DefaultTarget.sv --cc --sv --exe --build -o %t.config.exe --top-module top -DFIRRTL_CONFIGURATION_FILE=user-config.svh -I%t
+; RUN: %t.config.exe --cycles 1 2>&1 | FileCheck %s --check-prefix=CONFIGFILE
+; CONFIGFILE: result:       20
 
 FIRRTL version 5.1.0
 circuit top:

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -221,6 +221,7 @@ struct CircuitLoweringState {
   std::atomic<bool> usedAssertVerboseCond{false};
   std::atomic<bool> usedStopCond{false};
   std::atomic<bool> usedFileDescriptorLib{false};
+  std::atomic<bool> usedConfiguration{false};
 
   CircuitLoweringState(CircuitOp circuitOp, bool enableAnnotationWarning,
                        firrtl::VerificationFlavor verificationFlavor,
@@ -1019,6 +1020,28 @@ endpackage
              "to stop conditions.");
       emitGuard("STOP_COND_", [&]() {
         emitGuardedDefine("STOP_COND", "STOP_COND_", "(`STOP_COND)", "1");
+      });
+    });
+  }
+
+  // Create a fragment for FIRRTL configuration file include. It enables users
+  // to manage all options through single file.
+  // (e.g. -DFIRRTL_CONFIGURATION_FILE=configuration.svh)
+  if (state.usedConfiguration) {
+    sv::MacroDeclOp::create(b, "FIRRTL_CONFIGURATION_FILE");
+    sv::MacroDeclOp::create(b, "FIRRTL_CONFIGURATION_FILE_");
+    emit::FragmentOp::create(b, "FIRRTL_CONFIGURATION_FRAGMENT", [&] {
+      sv::IfDefOp::create(b, "FIRRTL_CONFIGURATION_FILE", [&]() {
+        sv::IfDefOp::create(
+            b, "FIRRTL_CONFIGURATION_FILE_", [] {},
+            [&]() {
+              StringRef body = R"(`define FIRRTL_CONFIGURATION_INCLUDED
+`define _STRINGIFY(x) `"x`"
+`include `_STRINGIFY(`FIRRTL_CONFIGURATION_FILE)
+`undef _STRINGIFY)";
+              sv::MacroDefOp::create(b, "FIRRTL_CONFIGURATION_FILE_", "");
+              sv::VerbatimOp::create(b, body);
+            });
       });
     });
   }
@@ -4129,6 +4152,11 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceChoiceOp oldInstanceChoice) {
     return oldInstanceChoice->emitOpError(
         "must have instance_macro attribute set before "
         "lowering");
+
+  // Mark that we're using configuration and add the fragment to the module
+  // containing this instance choice.
+  circuitState.usedConfiguration = true;
+  circuitState.addFragment(theModule, "FIRRTL_CONFIGURATION_FRAGMENT");
 
   // Get all the target modules
   auto moduleNames = oldInstanceChoice.getModuleNamesAttr();


### PR DESCRIPTION
This PR proposes a mechanism to configure options based on a single header file instead of tool arguments.

Previously, FIRRTL instance choices required configuration through command-line arguments. This change introduces support for a FIRRTL_CONFIGURATION_FILE macro that allows users to specify all configuration options in a single SystemVerilog header file.

For exmaple an user can create a `user-config.svh` that contains include statements of option header files and compile it with
```
-DFIRRTL_CONFIGURATION_FILE=user-config.svh -I<user-config.svh's parent>
```

This approach centralizes configuration management and simplifies the build process by replacing multiple command-line arguments with a single include file.

AI-assisted-by: Sonnet 4.5