### PR TITLE
[ConvertSynthToComb] Lower synth.choice

### DIFF
--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -32,6 +32,17 @@ using namespace comb;
 
 namespace {
 
+struct SynthChoiceOpConversion : OpConversionPattern<synth::ChoiceOp> {
+  using OpConversionPattern<synth::ChoiceOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(synth::ChoiceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Use the first input as the output, and ignore the rest.
+    rewriter.replaceOp(op, adaptor.getInputs().front());
+    return success();
+  }
+};
+
 struct SynthAndInverterOpConversion
     : OpConversionPattern<synth::aig::AndInverterOp> {
   using OpConversionPattern<synth::aig::AndInverterOp>::OpConversionPattern;
@@ -120,8 +131,8 @@ struct ConvertSynthToCombPass
 } // namespace
 
 static void populateSynthToCombConversionPatterns(RewritePatternSet &patterns) {
-  patterns.add<SynthAndInverterOpConversion, SynthMajorityInverterOpConversion>(
-      patterns.getContext());
+  patterns.add<SynthChoiceOpConversion, SynthAndInverterOpConversion,
+               SynthMajorityInverterOpConversion>(patterns.getContext());
 }
 
 void ConvertSynthToCombPass::runOnOperation() {

--- a/test/Conversion/SynthToComb/synth-to-comb.mlir
+++ b/test/Conversion/SynthToComb/synth-to-comb.mlir
@@ -22,3 +22,10 @@ hw.module @test_maj(in %a: i32, in %b: i32, in %c: i32, out out0: i32) {
   %0 = synth.mig.maj_inv %a, not %b, %c : i32
   hw.output %0 : i32
 }
+
+// CHECK-LABEL: @test_choice
+hw.module @test_choice(in %a: i32, in %b: i32, in %c: i32, out out0: i32) {
+  // CHECK: hw.output %a : i32
+  %0 = synth.choice %a, %b, %c : i32
+  hw.output %0 : i32
+}


### PR DESCRIPTION
This implements ConvertSynthToComb pattern that lowers synth.choice to its first operand. Since ConvertSynthToComb's main use case now is LEC so it might be worth attaching verif.assume as well but for now this PR implemented the simplest lowering.   