### PR TITLE
[MooreToCore] Add DPI open-array lowering support

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -259,8 +259,66 @@ getModulePortInfo(const TypeConverter &typeConverter, SVModuleOp op) {
           hw::PortInfo({{port.name, portTy, port.dir}, inputNum++, {}}));
     }
   }
-
   return hw::ModulePortInfo(ports);
+}
+
+struct DpiArrayCastInfo {
+  bool isRef = false;
+  bool isOpen = false;
+  bool isPacked = false;
+  Type elementType;
+};
+
+static std::optional<DpiArrayCastInfo> getDpiArrayCastInfo(Type type) {
+  DpiArrayCastInfo info;
+  if (auto refType = dyn_cast<RefType>(type)) {
+    info.isRef = true;
+    type = refType.getNestedType();
+  }
+
+  if (auto arrayType = dyn_cast<ArrayType>(type)) {
+    info.isPacked = true;
+    info.elementType = arrayType.getElementType();
+    return info;
+  }
+  if (auto arrayType = dyn_cast<OpenArrayType>(type)) {
+    info.isOpen = true;
+    info.isPacked = true;
+    info.elementType = arrayType.getElementType();
+    return info;
+  }
+  if (auto arrayType = dyn_cast<UnpackedArrayType>(type)) {
+    info.elementType = arrayType.getElementType();
+    return info;
+  }
+  if (auto arrayType = dyn_cast<OpenUnpackedArrayType>(type)) {
+    info.isOpen = true;
+    info.elementType = arrayType.getElementType();
+    return info;
+  }
+  return std::nullopt;
+}
+
+static bool hasOpenArrayBoundaryType(Type type) {
+  if (isa<OpenArrayType, OpenUnpackedArrayType>(type))
+    return true;
+  if (auto refType = dyn_cast<RefType>(type))
+    return isa<OpenArrayType, OpenUnpackedArrayType>(refType.getNestedType());
+  return false;
+}
+
+static bool isSupportedDpiOpenArrayCast(Type source, Type target) {
+  auto sourceInfo = getDpiArrayCastInfo(source);
+  auto targetInfo = getDpiArrayCastInfo(target);
+  if (!sourceInfo || !targetInfo)
+    return false;
+  // note: We currently don't support converting from open array to non-open
+  // array, even if the element types match, because there is no size
+  // information for the open array.
+  return sourceInfo->isRef == targetInfo->isRef &&
+         sourceInfo->isPacked == targetInfo->isPacked &&
+         sourceInfo->elementType == targetInfo->elementType &&
+         (targetInfo->isOpen && !sourceInfo->isOpen);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1641,8 +1699,21 @@ struct ConversionOpConversion : public OpConversionPattern<ConversionOp> {
     }
     int64_t inputBw = hw::getBitWidth(adaptor.getInput().getType());
     int64_t resultBw = hw::getBitWidth(resultType);
-    if (inputBw == -1 || resultBw == -1)
+    if (inputBw == -1 || resultBw == -1) {
+      if (isSupportedDpiOpenArrayCast(op.getInput().getType(),
+                                      op.getResult().getType())) {
+        rewriter.replaceOpWithNewOp<UnrealizedConversionCastOp>(
+            op, resultType, adaptor.getInput());
+        return success();
+      }
+      if (hasOpenArrayBoundaryType(op.getInput().getType()) ||
+          hasOpenArrayBoundaryType(op.getResult().getType())) {
+        op.emitError("unsupported DPI open-array conversion from ")
+            << op.getInput().getType() << " to " << op.getResult().getType();
+        return failure();
+      }
       return failure();
+    }
 
     Value input = rewriter.createOrFold<hw::BitcastOp>(
         loc, rewriter.getIntegerType(inputBw), adaptor.getInput());
@@ -2661,6 +2732,15 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
         return {};
       });
 
+  typeConverter.addConversion([&](OpenArrayType type) -> std::optional<Type> {
+    return LLVM::LLVMPointerType::get(type.getContext());
+  });
+
+  typeConverter.addConversion(
+      [&](OpenUnpackedArrayType type) -> std::optional<Type> {
+        return LLVM::LLVMPointerType::get(type.getContext());
+      });
+
   typeConverter.addConversion([&](StructType type) -> std::optional<Type> {
     SmallVector<hw::StructType::FieldInfo> fields;
     for (auto field : type.getMembers()) {
@@ -2740,6 +2820,8 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
   });
 
   typeConverter.addConversion([&](RefType type) -> std::optional<Type> {
+    if (isa<OpenArrayType, OpenUnpackedArrayType>(type.getNestedType()))
+      return LLVM::LLVMPointerType::get(type.getContext());
     if (auto innerType = typeConverter.convertType(type.getNestedType()))
       return llhd::RefType::get(innerType);
     return {};

--- a/test/Conversion/MooreToCore/dpi-open-array.mlir
+++ b/test/Conversion/MooreToCore/dpi-open-array.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func private @memory_tick(
+// CHECK-SAME: !llvm.ptr
+// CHECK-SAME: !llvm.ptr
+// CHECK-SAME: !llvm.ptr
+// CHECK-SAME: !llhd.ref<i1>
+func.func private @memory_tick(!moore.chandle, !moore.open_uarray<i8>, !moore.ref<open_uarray<i8>>, !moore.ref<i1>)
+
+// CHECK-LABEL: func.func @call_memory_tick(
+// CHECK-SAME: %[[CHANNEL:.*]]: !llvm.ptr, %[[RDATA:.*]]: !llhd.ref<!hw.array<8xi8>>, %[[WDATA:.*]]: !hw.array<8xi8>, %[[READY:.*]]: !llhd.ref<i1>
+func.func @call_memory_tick(%channel: !moore.chandle, %r_data: !moore.ref<uarray<8 x i8>>, %w_data: !moore.uarray<8 x i8>, %ready: !moore.ref<i1>) {
+  %0 = moore.conversion %w_data : !moore.uarray<8 x i8> -> !moore.open_uarray<i8>
+  %1 = moore.conversion %r_data : !moore.ref<uarray<8 x i8>> -> !moore.ref<open_uarray<i8>>
+  // CHECK: %[[WCAST:.*]] = builtin.unrealized_conversion_cast %[[WDATA]] : !hw.array<8xi8> to !llvm.ptr
+  // CHECK: %[[RCAST:.*]] = builtin.unrealized_conversion_cast %[[RDATA]] : !llhd.ref<!hw.array<8xi8>> to !llvm.ptr
+  // CHECK: call @memory_tick(%[[CHANNEL]], %[[WCAST]], %[[RCAST]], %[[READY]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llhd.ref<i1>) -> ()
+  call @memory_tick(%channel, %0, %1, %ready) : (!moore.chandle, !moore.open_uarray<i8>, !moore.ref<open_uarray<i8>>, !moore.ref<i1>) -> ()
+  return
+}

--- a/test/Conversion/MooreToCore/errors.mlir
+++ b/test/Conversion/MooreToCore/errors.mlir
@@ -9,6 +9,42 @@ func.func @invalidType() {
 
 // -----
 
+func.func @unsupportedOpenArrayCastReftoOpen(%arg0: !moore.ref<i1>) {
+  // expected-error @below {{unsupported DPI open-array conversion from '!moore.ref<i1>' to '!moore.open_uarray<i8>'}}
+  // expected-error @below {{failed to legalize operation 'moore.conversion'}}
+  %0 = moore.conversion %arg0 : !moore.ref<i1> -> !moore.open_uarray<i8>
+  return
+}
+
+// -----
+
+func.func @unsupportedOpenArrayCastOpenToFixed(%arg0: !moore.open_uarray<i8>) {
+  // expected-error @below {{unsupported DPI open-array conversion from '!moore.open_uarray<i8>' to '!moore.uarray<8 x i8>'}}
+  // expected-error @below {{failed to legalize operation 'moore.conversion'}}
+  %1 = moore.conversion %arg0 : !moore.open_uarray<i8> -> !moore.uarray<8 x i8>
+  return
+}
+
+// -----
+
+func.func @unsupportedOpenArrayCastPackedToUnpacked(%arg0: !moore.array<8 x i8>) {
+  // expected-error @below {{unsupported DPI open-array conversion from '!moore.array<8 x i8>' to '!moore.open_uarray<i8>'}}
+  // expected-error @below {{failed to legalize operation 'moore.conversion'}}
+  %2 = moore.conversion %arg0 : !moore.array<8 x i8> -> !moore.open_uarray<i8>
+  return
+}
+
+// -----
+
+func.func @unsupportedOpenArrayCastUnpackedToPacked(%arg0: !moore.uarray<8 x i8>) {
+  // expected-error @below {{unsupported DPI open-array conversion from '!moore.uarray<8 x i8>' to '!moore.open_array<i8>'}}
+  // expected-error @below {{failed to legalize operation 'moore.conversion'}}
+  %3 = moore.conversion %arg0 : !moore.uarray<8 x i8> -> !moore.open_array<i8>
+  return
+}
+
+// -----
+
 // expected-error @below {{port '"queue_port"' has unsupported type '!moore.assoc_array<i32, string>' that cannot be converted to hardware type}}
 // expected-error @below {{failed to legalize}}
 moore.module @UnsupportedInputPortType(in %queue_port : !moore.assoc_array<i32, string>) {


### PR DESCRIPTION
Add MooreToCore support for DPI open-array lowering by mapping open_array/open_uarray (and refs to them) to !llvm.ptr.

Current implementation prevents the following conversions:
- open to fixed
- ref to non-ref (and vice-versa)
- packed to unpacked (and vice versa)


Disclaimer: PR was authored with the help of AI