### PR TITLE
[ImportVerilog] Fix a segmentation fault

### DIFF
--- a/lib/Dialect/Moore/Transforms/CreateVTables.cpp
+++ b/lib/Dialect/Moore/Transforms/CreateVTables.cpp
@@ -64,6 +64,14 @@ void CreateVTablesPass::collectClassDependencies(ModuleOp mod,
   auto dependencyDecl =
       symTab.lookupNearestSymbolFrom<ClassDeclOp>(mod, dependencyName);
 
+  // Due to skipping GenericClassDefSymbol now, the parameterized interface
+  // class(@Bar) will not be collected in the symbol table, such as:
+  // `interface class Bar #(parameter N); endclass` extracted from Chipsalliance
+  // class_test_26.
+  if (!dependencyDecl) {
+    return;
+  }
+
   auto &clsMap = classToMethodMap[clsDecl];
   for (auto methodDecl : dependencyDecl.getBody().getOps<ClassMethodDeclOp>()) {
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3908,6 +3908,14 @@ module Events;
   initial @(e) dummyA();
 endmodule
 
+
+// CHECK-LABEL: moore.class.classdecl @Foo implements [@Bar]
+interface class Bar #(parameter int N); endclass
+
+parameter N = 1;
+class Foo implements Bar#(N); endclass
+
+
 // CHECK-LABEL:   moore.class.classdecl @nullableClass {
 // CHECK:  }
 


### PR DESCRIPTION
Due to skipping GenericClassDefSymbol now, it cannot generate IR for the parameterized interface class, and then it cannot collect this symbol into the symbol table, such as:`interface class Bar #(parameter N); endclass` extracted from Chipsalliance class_test_26. Therefore, when executing the `CreateVtables` pass, the `lookupNearestSymbolFrom<ClassDeclOp>` will return null, and then it will cause a segmentation fault.