### PR TITLE
[ImportVerilog] Adds Exists() op for associative arrays

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2100,6 +2100,23 @@ def AssocArraySizeOp : MooreOp<"assoc_array.size"> {
   let assemblyFormat = "$assoc_array `:` type($assoc_array) attr-dict";
 }
 
+
+def AssocArrayExistsOp : MooreOp<"assoc_array.exists", 
+    [TypesMatchWith<"associative array index and given index must match",
+    "assoc_array", "index", "cast<AssocArrayType>(cast<RefType>($_self).getNestedType()).getIndexType()">]> {
+  let summary = "Check if an element exists at a given index in an associative array";
+  let description = [{
+    See IEEE 1800-2023 § 7.9.3 "Size()". Returns 1 if the element exists at the given index
+    in the given associative array, otherwise return 0.
+    According to spec the returned size fits an `int`.
+  }];
+  let arguments = (ins AssocArrayRefType:$assoc_array, UnpackedType:$index);
+  let results = (outs TwoValuedI32:$result);
+  let assemblyFormat = [{
+    $index `in` $assoc_array attr-dict `:` type($assoc_array) `[` type($index) `]`
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Struct Manipulation
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3064,6 +3064,16 @@ Context::convertSystemCallArity2(const slang::ast::SystemSubroutine &subroutine,
                   return moore::UrandomrangeBIOp::create(builder, loc, value1,
                                                          value2);
                 })
+          .Case(
+              "exists",
+              [&]() -> Value {
+                if (isa<moore::RefType>(value1.getType()) &&
+                    isa<moore::AssocArrayType>(
+                        cast<moore::RefType>(value1.getType()).getNestedType()))
+                  return moore::AssocArrayExistsOp::create(builder, loc, value1,
+                                                           value2);
+                return {};
+              })
           .Default([&]() -> Value { return {}; });
   return systemCallRes();
 }

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4379,6 +4379,22 @@ module AssocArraySizeTest;
     end
 endmodule
 
+// CHECK-LABEL: moore.module @AssocArrayExistsTest() {
+// CHECK:           [[AA:%.+]] = moore.variable : <assoc_array<i32, i32>>
+// CHECK:           moore.procedure initial {
+// CHECK:             [[C0:%.+]] = moore.constant 0 : i32
+// CHECK:             [[S1:%.+]] = moore.assoc_array.exists [[C0]] in [[AA]] : <assoc_array<i32, i32>>[i32]
+// CHECK:             moore.return
+// CHECK:           }
+// CHECK:           moore.output
+// CHECK:         }
+module AssocArrayExistsTest;
+    int aa[int];
+    initial begin
+        aa.exists(0);
+    end
+endmodule
+
 
 // Test that DPI-C imported functions are emitted as extern declarations
 


### PR DESCRIPTION
Implements .Exists() from IEEE Std 1800™-2023 7.9.3. Adds the `MooreOp` `AssocArrayExistsOp` . Exists() takes in an index and returns 1 if the element at the given index exists in the given associative array, .Exists() returns 0 otherwise.