### PR TITLE
[CMake] Disable precomiled headers in Slang-facing code

### DIFF
--- a/cmake/modules/SlangCompilerOptions.cmake
+++ b/cmake/modules/SlangCompilerOptions.cmake
@@ -2,6 +2,11 @@
 # with Slang must be built accordingly.
 set(CMAKE_CXX_STANDARD 20)
 
+# Fix an issue with CMake's precompiled headers mechanism. Headers would be
+# precompiled for the CIRCT's language setting (C++17), which would then break
+# here where we're locally changing language version.
+set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
+
 # For ABI compatibility, define the SLANG_DEBUG macro in debug builds. Slang
 # sets this internally. If we don't set this here as well, header-defined things
 # like the destructor of `Driver`, which is generated in ImportVerilog's


### PR DESCRIPTION
Since the last LLVM bump, CIRCT builds with Slang enabled may run into problems where CMake precompiles headers for C++17 for CIRCT code, but the local switch to C++20 for any Slang-facing code would still try to use the precompiled header for C++17, leading to compilation failures.

Disable precompiled headers in all Slang-facing parts of CIRCT via a compiler option in `SlangCompilerOptions.cmake`, effectively doing the same as adding the `DISABLE_PCH_REUSE` option to individual targets.