### PR TITLE
[Arc] Add time increment operand to SimStepOp

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -718,10 +718,33 @@ def SimStepOp : ArcOp<"sim.step",
   let description = [{
     Evaluates one step of the simulation for the provided model instance,
     updating ports accordingly.
+
+    If `timePostIncrement` is provided, the instance's simulation time will be
+    incremented by the given number in femtoseconds _after_ the step has been
+    evaluated.
+
+    Example:
+
+    ```mlir
+    %cst5  = arith.constant 5  : i64
+    %cst10 = arith.constant 10 : i64
+    arc.sim.set_time %instance, %cst10 [...]
+    arc.sim.step %instance by %cst5 [...]       // Step at t = 10 fs
+    arc.sim.step %instance [...]                // Step at t = 15 fs
+    arc.sim.step %instance by %cst5 [...]       // Step at t = 15 fs
+    arc.sim.step %instance by %cst5 [...]       // Step at t = 20 fs
+    ```
   }];
-  let arguments = (ins SimModelInstance:$instance);
+  let arguments = (ins SimModelInstance:$instance,
+                       Optional<I64>:$timePostIncrement);
   let assemblyFormat =
-    [{ $instance attr-dict `:` qualified(type($instance)) }];
+    [{ $instance (`by` $timePostIncrement^)? attr-dict
+        `:` qualified(type($instance)) }];
+   let builders = [
+    OpBuilder<(ins "mlir::Value":$instance), [{
+      build($_builder, $_state, instance, /*timePostIncrement=*/ Value{});
+    }]>
+  ];
 }
 
 def SimEmitValueOp : ArcOp<"sim.emit"> {

--- a/integration_test/arcilator/JIT/initial-shift-reg.mlir
+++ b/integration_test/arcilator/JIT/initial-shift-reg.mlir
@@ -25,16 +25,13 @@ module {
     %ff = arith.constant 0xFF : i8
     %false = arith.constant 0 : i1
     %true = arith.constant 1 : i1
+    %tstep = arith.constant 10 : i64
     %t0 = arith.constant 10 : i64
     %t1 = arith.constant 20 : i64
     %t2 = arith.constant 30 : i64
     %t3 = arith.constant 40 : i64
     %t4 = arith.constant 50 : i64
     %t5 = arith.constant 60 : i64
-    %t6 = arith.constant 70 : i64
-    %t7 = arith.constant 80 : i64
-    %t8 = arith.constant 90 : i64
-    %t9 = arith.constant 100 : i64
 
     arc.sim.instantiate @shiftreg as %model {
       arc.sim.set_time %model, %t0 : !arc.sim.instance<@shiftreg>
@@ -69,26 +66,22 @@ module {
 
       arc.sim.set_time %model, %t5 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %true : i1, !arc.sim.instance<@shiftreg>
-      arc.sim.step %model : !arc.sim.instance<@shiftreg>
-      arc.sim.set_time %model, %t6 : !arc.sim.instance<@shiftreg>
+      arc.sim.step %model by %tstep : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %false : i1, !arc.sim.instance<@shiftreg>
-      arc.sim.step %model : !arc.sim.instance<@shiftreg>
+      arc.sim.step %model by %tstep : !arc.sim.instance<@shiftreg>
       %res3 = arc.sim.get_port %model, "dout" : i8, !arc.sim.instance<@shiftreg>
       arc.sim.emit "output", %res3 : i8
 
-      arc.sim.set_time %model, %t7 : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %true : i1, !arc.sim.instance<@shiftreg>
-      arc.sim.step %model : !arc.sim.instance<@shiftreg>
-      arc.sim.set_time %model, %t8 : !arc.sim.instance<@shiftreg>
+      arc.sim.step %model by %tstep : !arc.sim.instance<@shiftreg>
       arc.sim.set_input %model, "clock" = %false : i1, !arc.sim.instance<@shiftreg>
-      arc.sim.step %model : !arc.sim.instance<@shiftreg>
+      arc.sim.step %model by %tstep : !arc.sim.instance<@shiftreg>
       %res4 = arc.sim.get_port %model, "dout" : i8, !arc.sim.instance<@shiftreg>
       arc.sim.emit "output", %res4 : i8
-
-      arc.sim.set_time %model, %t9 : !arc.sim.instance<@shiftreg>
     }
     return
   }
+
 }
 
 // VCD-LABEL: $version

--- a/integration_test/arcilator/JIT/runtime-vcd-nochange.mlir
+++ b/integration_test/arcilator/JIT/runtime-vcd-nochange.mlir
@@ -8,34 +8,16 @@ hw.module @dut(out dout : i136) {
 
 func.func @main() {
   %inc = arith.constant 1 : i64
-  %0 = arith.constant 0 : i64
   arc.sim.instantiate @dut as %model {
-    %1 = arith.addi %0, %inc : i64
-    arc.sim.set_time %model, %1 : !arc.sim.instance<@dut>
-    arc.sim.step %model : !arc.sim.instance<@dut>
-    %2 = arith.addi %1, %inc : i64
-    arc.sim.set_time %model, %2 : !arc.sim.instance<@dut>
-    arc.sim.step %model : !arc.sim.instance<@dut>
-    %3 = arith.addi %2, %inc : i64
-    arc.sim.set_time %model, %3 : !arc.sim.instance<@dut>
-    arc.sim.step %model : !arc.sim.instance<@dut>
-    %4 = arith.addi %3, %inc : i64
-    arc.sim.set_time %model, %4 : !arc.sim.instance<@dut>
-    arc.sim.step %model : !arc.sim.instance<@dut>
-    %5 = arith.addi %4, %inc : i64
-    arc.sim.set_time %model, %5 : !arc.sim.instance<@dut>
-    arc.sim.step %model : !arc.sim.instance<@dut>
-    %6 = arith.addi %5, %inc : i64
-    arc.sim.set_time %model, %6 : !arc.sim.instance<@dut>
-    arc.sim.step %model : !arc.sim.instance<@dut>
-    %7 = arith.addi %6, %inc : i64
-    arc.sim.set_time %model, %7 : !arc.sim.instance<@dut>
-    arc.sim.step %model : !arc.sim.instance<@dut>
-    %8 = arith.addi %7, %inc : i64
-    arc.sim.set_time %model, %8 : !arc.sim.instance<@dut>
-    arc.sim.step %model : !arc.sim.instance<@dut>
-    %9 = arith.addi %8, %inc : i64
-    arc.sim.set_time %model, %9 : !arc.sim.instance<@dut>
+    arc.sim.set_time %model, %inc : !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
   }
   return
 }

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -617,6 +617,18 @@ struct SimStepOpLowering : public ModelAwarePattern<arc::SimStepOp> {
                               .getModel()
                               .getValue();
 
+    if (adaptor.getTimePostIncrement()) {
+      // Increment time after step
+      OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPointAfter(op);
+      auto oldTime =
+          arc::SimGetTimeOp::create(rewriter, op.getLoc(), op.getInstance());
+      auto newTime = LLVM::AddOp::create(rewriter, op.getLoc(), oldTime,
+                                         adaptor.getTimePostIncrement());
+      arc::SimSetTimeOp::create(rewriter, op.getLoc(), op.getInstance(),
+                                newTime);
+    }
+
     StringAttr evalFunc =
         rewriter.getStringAttr(evalSymbolFromModelName(modelName));
     rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, mlir::TypeRange(), evalFunc,

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -423,6 +423,9 @@ func.func @SimGetSetTime() {
     %0 = arc.sim.get_time %model : !arc.sim.instance<@TimeTestModule>
     // CHECK: arc.sim.set_time %{{.*}}, %{{.*}} : !arc.sim.instance<@TimeTestModule>
     arc.sim.set_time %model, %0 : !arc.sim.instance<@TimeTestModule>
+    // CHECK: arc.sim.step %{{.*}} by %{{.*}} : !arc.sim.instance<@TimeTestModule>
+    %tstep = arith.constant 123 : i64
+    arc.sim.step %model by %tstep : !arc.sim.instance<@TimeTestModule>
   }
   return
 }

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -12,12 +12,14 @@ module {
   // CHECK-LABEL: llvm.func @full
   func.func @full() {
     %c = arith.constant 24 : i8
+    %tstep = arith.constant 321 : i64
 
     // CHECK: %[[format_str2_ptr:.*]] = llvm.mlir.addressof @[[format_str2]] : !llvm.ptr
     // CHECK: %[[format_str_ptr:.*]] = llvm.mlir.addressof @[[format_str]] : !llvm.ptr
     // CHECK-DAG: %[[c:.*]] = llvm.mlir.constant(24 : i8)
     // CHECK-DAG: %[[zero:.*]] = llvm.mlir.constant(0 : i8)
     // CHECK-DAG: %[[size:.*]] = llvm.mlir.constant(11 : i64)
+    // CHECK-DAG: %[[tstep:.*]] = llvm.mlir.constant(321 : i64)
     // CHECK-DAG: %[[state:.*]] = llvm.call @malloc(%[[size:.*]]) :
     // CHECK: "llvm.intr.memset"(%[[state]], %[[zero]], %[[size]]) <{isVolatile = false}>
     arc.sim.instantiate @id as %model {
@@ -31,6 +33,12 @@ module {
 
       // CHECK-NEXT: llvm.call @id_eval(%[[state]])
       arc.sim.step %model : !arc.sim.instance<@id>
+
+      // CHECK-NEXT: llvm.call @id_eval(%[[state]])
+      // CHECK-NEXT: %[[told:.*]] = llvm.load %[[state]] : !llvm.ptr -> i64
+      // CHECK-NEXT: %[[tnew:.*]] = llvm.add %[[told]], %[[tstep]] : i64
+      // CHECK-NEXT: llvm.store %[[tnew]], %[[state]] : i64, !llvm.ptr
+      arc.sim.step %model by %tstep : !arc.sim.instance<@id>
 
       // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][10] : (!llvm.ptr) -> !llvm.ptr, i8
       // CHECK-NEXT: %[[result:.*]] = llvm.load %[[o_ptr]] : !llvm.ptr -> i8


### PR DESCRIPTION
Adds an optional operand to `arc.sim.step` that increments the simulation time after the step by the given amount.