### PR TITLE
[OM] Add a SymbolTable for Evaluator objects in Python.

### DIFF
--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -3,7 +3,7 @@
 
 import circt
 from circt.dialects import om
-from circt.ir import Context, InsertionPoint, Location, Module, IntegerAttr, IntegerType, Type
+from circt.ir import Context, InsertionPoint, Location, Module, IntegerAttr, IntegerType, Type, SymbolTable
 from circt.support import var_to_attribute
 
 from dataclasses import dataclass
@@ -105,6 +105,13 @@ with Context() as ctx, Location.unknown():
   """)
 
   evaluator = om.Evaluator(module)
+
+# Test symbol_table.
+
+assert isinstance(evaluator.symbol_table, SymbolTable)
+
+# CHECK: om.class @Test
+print(evaluator.symbol_table["Test"])
 
 # Test instantiate failure.
 

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from ._om_ops_gen import *
 from .._mlir_libs._circt._om import AnyType, Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, BasePath as BaseBasePath, BasePathType, Path, PathType, ClassType, ReferenceAttr, ListAttr, ListType, OMIntegerAttr, Unknown
 
-from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr, IntegerAttr, IntegerType
+from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr, IntegerAttr, IntegerType, SymbolTable
 from ..support import attribute_to_var, var_to_attribute
 
 import sys
@@ -130,6 +130,9 @@ class Evaluator(BaseEvaluator):
 
     # Attach our Diagnostic handler.
     mod.context.attach_diagnostic_handler(self._handle_diagnostic)
+
+    # Create a SymbolTable for this Evaluator.
+    self.symbol_table = SymbolTable(mod.operation)
 
   def instantiate(self, cls: str, *args: Any) -> Object:
     """Instantiate an Object with a class name and actual parameters."""


### PR DESCRIPTION
The Evaluator internally stores a SymbolTable, and we want to expose one in Python. Unfortunately, the PySymbolTable only wants to be constructed from a SymbolTable operation, rather than supporting a MlirSymbolTable constructor argument. This makes a PySymbolTable in the pure-Python Evaluator constructor, using the ModuleOp that is underlying the SymbolTable owned by the Evaluator.