### PR TITLE
[Moore] Drop trivially inferrable assoc_array type annotations

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2078,8 +2078,7 @@ def AssocArrayExtractOp : MooreOp<"assoc_array_extract", [Pure,
   let arguments = (ins AssocArrayType:$input, UnpackedType:$index);
   let results = (outs UnpackedType:$result);
   let assemblyFormat = [{
-    $input `[` $index `]` attr-dict `:`
-    type($input) `,` type($index) `->` type($result)
+    $input `[` $index `]` attr-dict `:` type($input)
   }];
 }
 
@@ -2095,7 +2094,7 @@ def AssocArrayExtractRefOp : MooreOp<"assoc_array_extract_ref",
   let results = (outs RefType:$result);
   let assemblyFormat = [{
     $input `[` $index `]` attr-dict `:`
-    type($input) `,` type($index) `->` type($result)
+    type($input)
   }];
 }
 
@@ -2109,7 +2108,7 @@ def AssocArrayDeleteOp : MooreOp<"assoc_array.delete",
   let arguments = (ins AssocArrayRefType:$assoc_array, UnpackedType:$index);
   let results = (outs);
   let assemblyFormat = [{
-    `index` $index `from` $assoc_array attr-dict `:` type($assoc_array) `[` type($index) `]`
+    `index` $index `from` $assoc_array attr-dict `:` type($assoc_array)
   }];
 }
 
@@ -2151,7 +2150,7 @@ def AssocArrayExistsOp : MooreOp<"assoc_array.exists",
   let arguments = (ins AssocArrayRefType:$assoc_array, UnpackedType:$index);
   let results = (outs TwoValuedI32:$result);
   let assemblyFormat = [{
-    $index `in` $assoc_array attr-dict `:` type($assoc_array) `[` type($index) `]`
+    $index `in` $assoc_array attr-dict `:` type($assoc_array)
   }];
 }
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4418,11 +4418,11 @@ endmodule
 // CHECK:             [[AAR:%.+]] = moore.read [[AA]] : <assoc_array<i32, string>>
 // CHECK:             [[CA1:%.+]] = moore.constant_string "a" : i8
 // CHECK:             [[ITS1:%.+]] = moore.int_to_string [[CA1]] : i8
-// CHECK:             [[E0:%.+]] = moore.assoc_array_extract [[AAR]][[[ITS1]]] : <i32, string>, string -> i32
+// CHECK:             [[E0:%.+]] = moore.assoc_array_extract [[AAR]][[[ITS1]]] : <i32, string>
 // CHECK:             moore.blocking_assign [[AAE]], [[E0]] : i32
 // CHECK:             [[CA2:%.+]] = moore.constant_string "a" : i8
 // CHECK:             [[ITS2:%.+]] = moore.int_to_string [[CA2]] : i8
-// CHECK:             [[R0:%.+]] = moore.assoc_array_extract_ref [[AA]][[[ITS2]]] : <assoc_array<i32, string>>, string -> <i32>
+// CHECK:             [[R0:%.+]] = moore.assoc_array_extract_ref [[AA]][[[ITS2]]] : <assoc_array<i32, string>>
 // CHECK:             [[AAER:%.+]] = moore.read [[AAE]] : <i32>
 // CHECK:             moore.blocking_assign [[R0]], [[AAER]] : i32
 // CHECK:             moore.return
@@ -4443,7 +4443,7 @@ endmodule
 // CHECK:           [[AA:%.+]] = moore.variable : <assoc_array<i32, i32>>
 // CHECK:           moore.procedure initial {
 // CHECK:             [[C0:%.+]] = moore.constant 0 : i32
-// CHECK:             moore.assoc_array.delete index [[C0]] from [[AA]] : <assoc_array<i32, i32>>[i32]
+// CHECK:             moore.assoc_array.delete index [[C0]] from [[AA]] : <assoc_array<i32, i32>>
 // CHECK:             moore.assoc_array.clear [[AA]] : <assoc_array<i32, i32>>
 // CHECK:             moore.return
 // CHECK:           }
@@ -4483,7 +4483,7 @@ endmodule
 // CHECK:           [[AA:%.+]] = moore.variable : <assoc_array<i32, i32>>
 // CHECK:           moore.procedure initial {
 // CHECK:             [[C0:%.+]] = moore.constant 0 : i32
-// CHECK:             [[S1:%.+]] = moore.assoc_array.exists [[C0]] in [[AA]] : <assoc_array<i32, i32>>[i32]
+// CHECK:             [[S1:%.+]] = moore.assoc_array.exists [[C0]] in [[AA]] : <assoc_array<i32, i32>>
 // CHECK:             moore.return
 // CHECK:           }
 // CHECK:           moore.output


### PR DESCRIPTION
Just cleans up a few places where we annotate types that are trivially inferrable (and visually clear) 

CC: @Elijah-Cheesman 