### PR TITLE
[circt-test] Add waveform tracing option

### DIFF
--- a/integration_test/circt-test/verilator-no-trace.mlir
+++ b/integration_test/circt-test/verilator-no-trace.mlir
@@ -1,0 +1,13 @@
+// RUN: circt-test %s -d %t -r \verilator 2>&1 | FileCheck %s
+// RUN: ! test -f %t/NoTraceTest/NoTraceTest.vcd
+// RUN: ! test -f %t/NoTraceTest/NoTraceTest.fst
+// REQUIRES: verilator
+
+// CHECK: 1 tests passed
+
+verif.simulation @NoTraceTest {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %true = hw.constant true
+  verif.yield %true, %true : i1, i1
+}
+

--- a/integration_test/circt-test/verilator-trace-fallback.mlir
+++ b/integration_test/circt-test/verilator-trace-fallback.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-test %s -d %t -r \verilator --trace=fsdb,fst 2>&1 | FileCheck %s
+// RUN: test -f %t/FallbackTest/FallbackTest.fst
+// REQUIRES: verilator
+
+// CHECK: 1 tests passed
+
+verif.simulation @FallbackTest {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %true = hw.constant true
+  verif.yield %true, %true : i1, i1
+}
+

--- a/integration_test/circt-test/verilator-trace-fst.mlir
+++ b/integration_test/circt-test/verilator-trace-fst.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-test %s -d %t -r \verilator --trace=fst 2>&1 | FileCheck %s
+// RUN: test -f %t/FSTTest/FSTTest.fst
+// REQUIRES: verilator
+
+// CHECK: 1 tests passed
+
+verif.simulation @FSTTest {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %true = hw.constant true
+  verif.yield %true, %true : i1, i1
+}
+

--- a/integration_test/circt-test/verilator-trace-vcd.mlir
+++ b/integration_test/circt-test/verilator-trace-vcd.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-test %s -d %t -r \verilator --trace=vcd 2>&1 | FileCheck %s
+// RUN: test -f %t/VCDTest/VCDTest.vcd
+// REQUIRES: verilator
+
+// CHECK: 1 tests passed
+
+verif.simulation @VCDTest {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %true = hw.constant true
+  verif.yield %true, %true : i1, i1
+}
+

--- a/tools/circt-test/circt-test-runner-verilator.py
+++ b/tools/circt-test/circt-test-runner-verilator.py
@@ -10,12 +10,41 @@ parser = argparse.ArgumentParser()
 parser.add_argument("verilog")
 parser.add_argument("-t", "--test", required=True)
 parser.add_argument("-d", "--directory", required=True)
+parser.add_argument(
+    "--trace",
+    type=str,
+    default="",
+    help="Enable waveform tracing with format preferences (e.g., 'fst,vcd')")
 args = parser.parse_args()
+
+
+def select_trace_format(preferences):
+  if not preferences:
+    return None, None, None
+  supported = {
+      "vcd": ("vcd", ".vcd", "--trace-vcd"),
+      "fst": ("fst", ".fst", "--trace-fst"),
+  }
+  prefs = [p.strip().lower() for p in preferences.split(",")]
+  for pref in prefs:
+    if pref in supported:
+      return supported[pref]
+  return supported["vcd"]
+
 
 directory = Path(args.directory)
 source_path = Path(args.verilog)
 build_path = directory / "build"
 testbench_path = directory / "testbench.sv"
+
+# Select trace format (returns Nones if args.trace is empty)
+trace_format, trace_ext, trace_option = select_trace_format(args.trace)
+
+# Only set trace_file if tracing is enabled
+if trace_format:
+  trace_file = directory / f"{args.test}{trace_ext}"
+else:
+  trace_file = ""
 
 # Generate the Verilog top-level that interacts with the test module.
 testbench = f"""
@@ -23,6 +52,13 @@ module circt_test;
   bit clock = 0, init = 1, done, success;
   {args.test} dut(.clock, .init, .done, .success);
   initial begin
+"""
+if trace_format:
+  testbench += f"""
+    $dumpfile("{trace_file}");
+    $dumpvars(0, circt_test);
+  """
+testbench += f"""
     #1 clock = 1;
     #1 clock = 0; init = 0;
     #1 clock = 1;
@@ -50,6 +86,11 @@ cmd = [
     "--top-module",
     "circt_test",
 ]
+
+# Add trace support if tracing is enabled
+if trace_format:
+  cmd += [trace_option]
+
 if source_path.is_dir():
   cmd += ["-F", source_path / "filelist.f"]
 else:

--- a/tools/circt-test/circt-test.cpp
+++ b/tools/circt-test/circt-test.cpp
@@ -96,6 +96,18 @@ struct Options {
       cl::desc("Print command for each test to stdout instead of executing it"),
       cl::init(false), cl::cat(testCat)};
 
+  cl::opt<std::string> trace{
+      "trace",
+      cl::desc(
+          "Emit waveforms in the given comma-separated formats.\n"
+          "Not all formats are available for all simulators.\n"
+          "First supported format in the list or simulator's default is used.\n"
+          "Available formats:\n"
+          "- auto: Use simulator's default format\n"
+          "- vcd: Value Change Dump (Verilator)\n"
+          "- fst: Fast Simulation Trace (Verilator)"),
+      cl::value_desc("formats"), cl::init(""), cl::cat(testCat)};
+
   cl::opt<unsigned> numThreads{
       "j", cl::value_desc("N"),
       cl::desc("Number of tests to run in parallel\n"
@@ -1145,6 +1157,12 @@ static TestStatus executeTest(Test &test, RunnerSuite &runnerSuite,
     SmallString<8> str;
     depthInt.getValue().toStringUnsigned(str);
     args.push_back(argsSaver.save(str.str()));
+  }
+
+  // Pass trace preferences to simulation runners.
+  if (!opts.trace.empty() && runner->kind == TestKind::Simulation) {
+    args.push_back("--trace");
+    args.push_back(opts.trace);
   }
 
   // If we are doing a dry run, store the command we would run in the test's


### PR DESCRIPTION
Add the `--trace` option to circt-test, which accepts a list of waveform formats that should be tried in order for each backend. Backends use the first format that they support, or they fall back to the default format, e.g. VCD.

Currently only Verilator is available as a runner, so this is pretty straightforward. Later, we'll add other simulation runners into the mix which will want to add other formats.