### PR TITLE
[ImportVerilog] Convert arity-based system task to named-based matching

### DIFF
--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -299,113 +299,61 @@ struct AssertionExprVisitor {
 FailureOr<Value> Context::convertAssertionSystemCallArity1(
     const slang::ast::SystemSubroutine &subroutine, Location loc, Value value,
     Type originalType) {
+  using ksn = slang::parsing::KnownSystemName;
+  auto nameId = subroutine.knownNameId;
 
-  auto systemCallRes =
-      llvm::StringSwitch<std::function<FailureOr<Value>()>>(subroutine.name)
-          .Case("$sampled",
-                [&]() -> Value {
-                  Value sampled = ltl::SampledOp::create(builder, loc, value);
-                  // Cast back to Moore integers so Moore ops can use the result
-                  // if needed
-                  if (auto ty = dyn_cast<moore::IntType>(originalType)) {
-                    sampled =
-                        moore::FromBuiltinIntOp::create(builder, loc, sampled);
-                    if (ty.getDomain() == Domain::FourValued)
-                      sampled =
-                          moore::IntToLogicOp::create(builder, loc, sampled);
-                  }
-                  return sampled;
-                })
-          // Translate $fell to ¬x[0] ∧ x[-1]
-          .Case("$fell",
-                [&]() -> Value {
-                  auto current = value;
-                  auto past =
-                      ltl::PastOp::create(builder, loc, value, 1, Value{})
-                          .getResult();
-                  Value fell = comb::ICmpOp::create(builder, loc,
-                                                    comb::ICmpPredicate::ugt,
-                                                    past, current, false);
-                  if (auto ty = dyn_cast<moore::IntType>(originalType)) {
-                    fell = moore::FromBuiltinIntOp::create(builder, loc, fell);
-                    if (ty.getDomain() == Domain::FourValued) {
-                      fell = moore::IntToLogicOp::create(builder, loc, fell);
-                    }
-                  }
-                  return fell;
-                })
-          // Translate $rose to x[0] ∧ ¬x[-1]
-          .Case("$rose",
-                [&]() -> Value {
-                  auto past =
-                      ltl::PastOp::create(builder, loc, value, 1, Value{})
-                          .getResult();
-                  auto current = value;
-                  Value rose = comb::ICmpOp::create(builder, loc,
-                                                    comb::ICmpPredicate::ult,
-                                                    past, current, false);
-                  if (auto ty = dyn_cast<moore::IntType>(originalType)) {
-                    rose = moore::FromBuiltinIntOp::create(builder, loc, rose);
-                    if (ty.getDomain() == Domain::FourValued) {
-                      rose = moore::IntToLogicOp::create(builder, loc, rose);
-                    }
-                  }
-                  return rose;
-                })
-          // Translate $changed to ( ¬x[0] ∧ x[-1] ) ⋁ ( x[0] ∧ ¬x[-1] )
-          .Case("$changed",
-                [&]() -> Value {
-                  auto past =
-                      ltl::PastOp::create(builder, loc, value, 1, Value{})
-                          .getResult();
-                  auto current = value;
-                  Value changed = comb::ICmpOp::create(builder, loc,
-                                                       comb::ICmpPredicate::ne,
-                                                       past, current, false);
-                  if (auto ty = dyn_cast<moore::IntType>(originalType)) {
-                    changed =
-                        moore::FromBuiltinIntOp::create(builder, loc, changed);
-                    if (ty.getDomain() == Domain::FourValued) {
-                      changed =
-                          moore::IntToLogicOp::create(builder, loc, changed);
-                    }
-                  }
-                  return changed;
-                })
-          // Translate $stable to ( x[0] ∧ x[-1] ) ⋁ ( ¬x[0] ∧ ¬x[-1] )
-          .Case(
-              "$stable",
-              [&]() -> Value {
-                auto past = ltl::PastOp::create(builder, loc, value, 1, Value{})
-                                .getResult();
-                auto current = value;
-                Value stable =
-                    comb::ICmpOp::create(builder, loc, comb::ICmpPredicate::eq,
-                                         past, current, false);
-                if (auto ty = dyn_cast<moore::IntType>(originalType)) {
-                  stable =
-                      moore::FromBuiltinIntOp::create(builder, loc, stable);
-                  if (ty.getDomain() == Domain::FourValued) {
-                    stable = moore::IntToLogicOp::create(builder, loc, stable);
-                  }
-                }
-                return stable;
-              })
-          .Case("$past",
-                [&]() -> Value {
-                  Value past =
-                      ltl::PastOp::create(builder, loc, value, 1, Value{});
-                  // Cast back to Moore integers so Moore ops can use the result
-                  // if needed
-                  if (auto ty = dyn_cast<moore::IntType>(originalType)) {
-                    past = moore::FromBuiltinIntOp::create(builder, loc, past);
-                    if (ty.getDomain() == Domain::FourValued)
-                      past = moore::IntToLogicOp::create(builder, loc, past);
-                  }
-                  return past;
-                })
-          .Default([&]() -> Value { return {}; });
-  return systemCallRes();
+  // Helper to cast a builtin integer result back to Moore integer types.
+  auto castToMoore = [&](Value v) -> Value {
+    if (auto ty = dyn_cast<moore::IntType>(originalType)) {
+      v = moore::FromBuiltinIntOp::create(builder, loc, v);
+      if (ty.getDomain() == Domain::FourValued)
+        v = moore::IntToLogicOp::create(builder, loc, v);
+    }
+    return v;
+  };
+
+  switch (nameId) {
+  case ksn::Sampled:
+    return castToMoore(ltl::SampledOp::create(builder, loc, value));
+
+  // Translate $fell to ¬x[0] ∧ x[-1]
+  case ksn::Fell: {
+    auto past =
+        ltl::PastOp::create(builder, loc, value, 1, Value{}).getResult();
+    return castToMoore(comb::ICmpOp::create(
+        builder, loc, comb::ICmpPredicate::ugt, past, value, false));
+  }
+
+  // Translate $rose to x[0] ∧ ¬x[-1]
+  case ksn::Rose: {
+    auto past =
+        ltl::PastOp::create(builder, loc, value, 1, Value{}).getResult();
+    return castToMoore(comb::ICmpOp::create(
+        builder, loc, comb::ICmpPredicate::ult, past, value, false));
+  }
+
+  // Translate $changed to x[0] ≠ x[-1]
+  case ksn::Changed: {
+    auto past =
+        ltl::PastOp::create(builder, loc, value, 1, Value{}).getResult();
+    return castToMoore(comb::ICmpOp::create(
+        builder, loc, comb::ICmpPredicate::ne, past, value, false));
+  }
+
+  // Translate $stable to x[0] = x[-1]
+  case ksn::Stable: {
+    auto past =
+        ltl::PastOp::create(builder, loc, value, 1, Value{}).getResult();
+    return castToMoore(comb::ICmpOp::create(
+        builder, loc, comb::ICmpPredicate::eq, past, value, false));
+  }
+
+  case ksn::Past:
+    return castToMoore(ltl::PastOp::create(builder, loc, value, 1, Value{}));
+
+  default:
+    return Value{};
+  }
 }
 
 Value Context::convertAssertionCallExpression(
@@ -427,7 +375,7 @@ Value Context::convertAssertionCallExpression(
     originalType = value.getType();
     valTy = dyn_cast<moore::IntType>(value.getType());
     if (!valTy) {
-      mlir::emitError(loc) << "expected integer argument for system call `"
+      mlir::emitError(loc) << "expected integer argument for `"
                            << subroutine.name << "`";
       return {};
     }

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1778,25 +1778,26 @@ struct RvalueExprVisitor : public ExprVisitor {
   /// Handle system calls.
   Value visitCall(const slang::ast::CallExpression &expr,
                   const slang::ast::CallExpression::SystemCallInfo &info) {
+    using ksn = slang::parsing::KnownSystemName;
     const auto &subroutine = *info.subroutine;
+    auto nameId = subroutine.knownNameId;
 
     // $rose, $fell, $stable, $changed, and $past are only valid in
     // the context of properties and assertions. Those are treated in the
     // LTLDialect; treat them there instead.
-    bool isAssertionCall = llvm::StringSwitch<bool>(subroutine.name)
-                               .Cases({"$rose", "$fell", "$stable", "$changed",
-                                       "$past", "$sampled"},
-                                      true)
-                               .Default(false);
-
-    if (isAssertionCall)
+    switch (nameId) {
+    case ksn::Rose:
+    case ksn::Fell:
+    case ksn::Stable:
+    case ksn::Changed:
+    case ksn::Past:
+    case ksn::Sampled:
       return context.convertAssertionCallExpression(expr, info, loc);
+    default:
+      break;
+    }
 
     auto args = expr.arguments();
-
-    FailureOr<Value> result = Value{};
-    Value value;
-    Value value2;
 
     // $sformatf() and $sformat look like system tasks, but we handle string
     // formatting differently from expression evaluation, so handle them
@@ -1804,7 +1805,7 @@ struct RvalueExprVisitor : public ExprVisitor {
     // According to IEEE 1800-2023 Section 21.3.3 "Formatting data to a
     // string" $sformatf works just like the string formatting but returns
     // a StringType.
-    if (!subroutine.name.compare("$sformatf")) {
+    if (nameId == ksn::SFormatF) {
       // Create the FormatString
       auto fmtValue = context.convertFormatString(
           expr.arguments(), loc, moore::IntFormat::Decimal, false);
@@ -1813,68 +1814,14 @@ struct RvalueExprVisitor : public ExprVisitor {
       return fmtValue.value();
     }
 
-    // Queue ops take their parameter as a reference
-    // So do AssocArray ops
-    bool isByRefOp = args.size() >= 1 &&
-                     ((args[0]->type->isQueue() && subroutine.name != "size") ||
-                      args[0]->type->isAssociativeArray());
-
-    // Associative Array Traversal Ops require value2 to be refs
-    bool secondArgIsByRef =
-        args.size() >= 1 &&
-        (args[0]->type->isAssociativeArray() && subroutine.name != "exists");
-
-    // Call the conversion function with the appropriate arity. These return one
-    // of the following:
-    //
-    // - `failure()` if the system call was recognized but some error occurred
-    // - `Value{}` if the system call was not recognized
-    // - non-null `Value` result otherwise
-    switch (args.size()) {
-    case (0):
-      result = context.convertSystemCallArity0(subroutine, loc);
-      break;
-
-    case (1):
-      value = isByRefOp ? context.convertLvalueExpression(*args[0])
-                        : context.convertRvalueExpression(*args[0]);
-      if (!value)
-        return {};
-      result = context.convertSystemCallArity1(subroutine, loc, value);
-      break;
-
-    case (2):
-      value = isByRefOp ? context.convertLvalueExpression(*args[0])
-                        : context.convertRvalueExpression(*args[0]);
-      value2 = secondArgIsByRef ? context.convertLvalueExpression(*args[1])
-                                : context.convertRvalueExpression(*args[1]);
-      if (!value || !value2)
-        return {};
-      result = context.convertSystemCallArity2(subroutine, loc, value, value2);
-      break;
-
-    default:
-      break;
-    }
-
-    // If we have recognized the system call but the conversion has encountered
-    // and already reported an error, simply return the usual null `Value` to
-    // indicate failure.
-    if (failed(result))
+    // Convert the system call using unified dispatch
+    auto result = context.convertSystemCall(subroutine, loc, args);
+    if (!result)
       return {};
 
-    // If we have recognized the system call and got a non-null `Value` result,
-    // return that.
-    if (*result) {
-      auto ty = context.convertType(*expr.type);
-      return context.materializeConversion(ty, *result, expr.type->isSigned(),
-                                           loc);
-    }
-
-    // Otherwise we didn't recognize the system call.
-    mlir::emitError(loc) << "unsupported system call `" << subroutine.name
-                         << "`";
-    return {};
+    auto ty = context.convertType(*expr.type);
+    return context.materializeConversion(ty, result, expr.type->isSigned(),
+                                         loc);
   }
 
   /// Handle string literals.
@@ -2865,291 +2812,328 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
   return value;
 }
 
-FailureOr<Value>
-Context::convertSystemCallArity0(const slang::ast::SystemSubroutine &subroutine,
-                                 Location loc) {
-
-  auto systemCallRes =
-      llvm::StringSwitch<std::function<FailureOr<Value>()>>(subroutine.name)
-          .Case("$urandom",
-                [&]() -> Value {
-                  return moore::UrandomBIOp::create(builder, loc, nullptr);
-                })
-          .Case("$random",
-                [&]() -> Value {
-                  return moore::RandomBIOp::create(builder, loc, nullptr);
-                })
-          .Case(
-              "$time",
-              [&]() -> Value { return moore::TimeBIOp::create(builder, loc); })
-          .Case(
-              "$stime",
-              [&]() -> Value { return moore::TimeBIOp::create(builder, loc); })
-          .Case(
-              "$realtime",
-              [&]() -> Value { return moore::TimeBIOp::create(builder, loc); })
-          .Default([&]() -> Value { return {}; });
-  return systemCallRes();
+/// Helper function to convert real math builtin functions that take exactly
+/// one argument.
+template <typename OpTy>
+static Value
+convertRealMathBI(Context &context, Location loc, StringRef name,
+                  std::span<const slang::ast::Expression *const> args) {
+  // Slang already checks the arity of real math builtins.
+  assert(args.size() == 1 && "real math builtin expects 1 argument");
+  auto value = context.convertRvalueExpression(*args[0]);
+  if (!value)
+    return {};
+  return OpTy::create(context.builder, loc, value);
 }
 
-FailureOr<Value>
-Context::convertSystemCallArity1(const slang::ast::SystemSubroutine &subroutine,
-                                 Location loc, Value value) {
-  auto systemCallRes =
-      llvm::StringSwitch<std::function<FailureOr<Value>()>>(subroutine.name)
-          // Signed and unsigned system functions.
-          .Case("$signed", [&]() { return value; })
-          .Case("$unsigned", [&]() { return value; })
+Value Context::convertSystemCall(
+    const slang::ast::SystemSubroutine &subroutine, Location loc,
+    std::span<const slang::ast::Expression *const> args) {
+  using ksn = slang::parsing::KnownSystemName;
+  StringRef name = subroutine.name;
+  auto nameId = subroutine.knownNameId;
+  size_t numArgs = args.size();
 
-          // Math functions in SystemVerilog.
-          .Case("$clog2",
-                [&]() -> FailureOr<Value> {
-                  value = convertToSimpleBitVector(value);
-                  if (!value)
-                    return failure();
-                  return (Value)moore::Clog2BIOp::create(builder, loc, value);
-                })
-          .Case("$ln",
-                [&]() -> Value {
-                  return moore::LnBIOp::create(builder, loc, value);
-                })
-          .Case("$log10",
-                [&]() -> Value {
-                  return moore::Log10BIOp::create(builder, loc, value);
-                })
-          .Case("$sin",
-                [&]() -> Value {
-                  return moore::SinBIOp::create(builder, loc, value);
-                })
-          .Case("$cos",
-                [&]() -> Value {
-                  return moore::CosBIOp::create(builder, loc, value);
-                })
-          .Case("$tan",
-                [&]() -> Value {
-                  return moore::TanBIOp::create(builder, loc, value);
-                })
-          .Case("$exp",
-                [&]() -> Value {
-                  return moore::ExpBIOp::create(builder, loc, value);
-                })
-          .Case("$sqrt",
-                [&]() -> Value {
-                  return moore::SqrtBIOp::create(builder, loc, value);
-                })
-          .Case("$floor",
-                [&]() -> Value {
-                  return moore::FloorBIOp::create(builder, loc, value);
-                })
-          .Case("$ceil",
-                [&]() -> Value {
-                  return moore::CeilBIOp::create(builder, loc, value);
-                })
-          .Case("$asin",
-                [&]() -> Value {
-                  return moore::AsinBIOp::create(builder, loc, value);
-                })
-          .Case("$acos",
-                [&]() -> Value {
-                  return moore::AcosBIOp::create(builder, loc, value);
-                })
-          .Case("$atan",
-                [&]() -> Value {
-                  return moore::AtanBIOp::create(builder, loc, value);
-                })
-          .Case("$sinh",
-                [&]() -> Value {
-                  return moore::SinhBIOp::create(builder, loc, value);
-                })
-          .Case("$cosh",
-                [&]() -> Value {
-                  return moore::CoshBIOp::create(builder, loc, value);
-                })
-          .Case("$tanh",
-                [&]() -> Value {
-                  return moore::TanhBIOp::create(builder, loc, value);
-                })
-          .Case("$asinh",
-                [&]() -> Value {
-                  return moore::AsinhBIOp::create(builder, loc, value);
-                })
-          .Case("$acosh",
-                [&]() -> Value {
-                  return moore::AcoshBIOp::create(builder, loc, value);
-                })
-          .Case("$atanh",
-                [&]() -> Value {
-                  return moore::AtanhBIOp::create(builder, loc, value);
-                })
-          .Case("$urandom",
-                [&]() -> Value {
-                  return moore::UrandomBIOp::create(builder, loc, value);
-                })
-          .Case("$random",
-                [&]() -> Value {
-                  return moore::RandomBIOp::create(builder, loc, value);
-                })
-          .Case("$urandom_range",
-                [&]() -> Value {
-                  return moore::UrandomrangeBIOp::create(builder, loc, value,
-                                                         nullptr);
-                })
-          .Case("$realtobits",
-                [&]() -> Value {
-                  return moore::RealtobitsBIOp::create(builder, loc, value);
-                })
-          .Case("$bitstoreal",
-                [&]() -> Value {
-                  return moore::BitstorealBIOp::create(builder, loc, value);
-                })
-          .Case("$shortrealtobits",
-                [&]() -> Value {
-                  return moore::ShortrealtobitsBIOp::create(builder, loc,
-                                                            value);
-                })
-          .Case("$bitstoshortreal",
-                [&]() -> Value {
-                  return moore::BitstoshortrealBIOp::create(builder, loc,
-                                                            value);
-                })
-          .Case("len",
-                [&]() -> Value {
-                  if (isa<moore::StringType>(value.getType()))
-                    return moore::StringLenOp::create(builder, loc, value);
-                  return {};
-                })
-          .Case("toupper",
-                [&]() -> Value {
-                  return moore::StringToUpperOp::create(builder, loc, value);
-                })
-          .Case("size",
-                [&]() -> Value {
-                  if (isa<moore::QueueType>(value.getType())) {
-                    return moore::QueueSizeBIOp::create(builder, loc, value);
-                  }
-                  if (isa<moore::OpenUnpackedArrayType>(value.getType())) {
-                    return moore::OpenUArraySizeOp::create(builder, loc, value);
-                  }
-                  if (isa<moore::RefType>(value.getType()) &&
-                      isa<moore::AssocArrayType>(
-                          cast<moore::RefType>(value.getType())
-                              .getNestedType())) {
-                    return moore::AssocArraySizeOp::create(builder, loc, value);
-                  }
-                  return {};
-                })
-          .Case("delete",
-                [&]() -> Value {
-                  if (isa<moore::OpenUnpackedArrayType>(value.getType())) {
-                    return moore::OpenUArrayDeleteOp::create(builder, loc,
-                                                             value);
-                  }
-                  return {};
-                })
-          .Case("num",
-                [&]() -> Value {
-                  if (isa<moore::RefType>(value.getType()) &&
-                      isa<moore::AssocArrayType>(
-                          cast<moore::RefType>(value.getType())
-                              .getNestedType())) {
-                    return moore::AssocArraySizeOp::create(builder, loc, value);
-                  }
-                  return {};
-                })
-          .Case("tolower",
-                [&]() -> Value {
-                  return moore::StringToLowerOp::create(builder, loc, value);
-                })
-          .Case(
-              "pop_back",
-              [&]() -> Value {
-                if (isa<moore::RefType>(value.getType()) &&
-                    isa<moore::QueueType>(
-                        cast<moore::RefType>(value.getType()).getNestedType()))
-                  return moore::QueuePopBackOp::create(builder, loc, value);
+  //===--------------------------------------------------------------------===//
+  // Random Number System Functions
+  //===--------------------------------------------------------------------===//
 
-                return {};
-              })
-          .Case(
-              "pop_front",
-              [&]() -> Value {
-                if (isa<moore::RefType>(value.getType()) &&
-                    isa<moore::QueueType>(
-                        cast<moore::RefType>(value.getType()).getNestedType()))
-                  return moore::QueuePopFrontOp::create(builder, loc, value);
-                return {};
-              })
-          .Default([&]() -> Value { return {}; });
-  return systemCallRes();
-}
+  if (nameId == ksn::URandom) {
+    if (numArgs == 0)
+      return moore::UrandomBIOp::create(builder, loc, nullptr);
+    if (numArgs == 1) {
+      auto seed = convertRvalueExpression(*args[0]);
+      if (!seed)
+        return {};
+      return moore::UrandomBIOp::create(builder, loc, seed);
+    }
+    // Slang already checks the arity of `$urandom`.
+    assert(false && "`$urandom` takes 0 or 1 arguments");
+    return {};
+  }
 
-FailureOr<Value>
-Context::convertSystemCallArity2(const slang::ast::SystemSubroutine &subroutine,
-                                 Location loc, Value value1, Value value2) {
-  auto systemCallRes =
-      llvm::StringSwitch<std::function<FailureOr<Value>()>>(subroutine.name)
-          .Case("getc",
-                [&]() -> Value {
-                  return moore::StringGetOp::create(builder, loc, value1,
-                                                    value2);
-                })
-          .Case("$urandom_range",
-                [&]() -> Value {
-                  return moore::UrandomrangeBIOp::create(builder, loc, value1,
-                                                         value2);
-                })
-          .Case(
-              "exists",
-              [&]() -> Value {
-                if (isa<moore::RefType>(value1.getType()) &&
-                    isa<moore::AssocArrayType>(
-                        cast<moore::RefType>(value1.getType()).getNestedType()))
-                  return moore::AssocArrayExistsOp::create(builder, loc, value1,
-                                                           value2);
-                return {};
-              })
-          .Case(
-              "first",
-              [&]() -> Value {
-                if (isa<moore::RefType>(value1.getType()) &&
-                    isa<moore::AssocArrayType>(
-                        cast<moore::RefType>(value1.getType()).getNestedType()))
-                  return moore::AssocArrayFirstOp::create(builder, loc, value1,
-                                                          value2);
-                return {};
-              })
-          .Case(
-              "last",
-              [&]() -> Value {
-                if (isa<moore::RefType>(value1.getType()) &&
-                    isa<moore::AssocArrayType>(
-                        cast<moore::RefType>(value1.getType()).getNestedType()))
-                  return moore::AssocArrayLastOp::create(builder, loc, value1,
-                                                         value2);
-                return {};
-              })
-          .Case(
-              "next",
-              [&]() -> Value {
-                if (isa<moore::RefType>(value1.getType()) &&
-                    isa<moore::AssocArrayType>(
-                        cast<moore::RefType>(value1.getType()).getNestedType()))
-                  return moore::AssocArrayNextOp::create(builder, loc, value1,
-                                                         value2);
-                return {};
-              })
-          .Case(
-              "prev",
-              [&]() -> Value {
-                if (isa<moore::RefType>(value1.getType()) &&
-                    isa<moore::AssocArrayType>(
-                        cast<moore::RefType>(value1.getType()).getNestedType()))
-                  return moore::AssocArrayPrevOp::create(builder, loc, value1,
-                                                         value2);
-                return {};
-              })
-          .Default([&]() -> Value { return {}; });
-  return systemCallRes();
+  if (nameId == ksn::Random) {
+    if (numArgs == 0)
+      return moore::RandomBIOp::create(builder, loc, nullptr);
+    if (numArgs == 1) {
+      auto seed = convertRvalueExpression(*args[0]);
+      if (!seed)
+        return {};
+      return moore::RandomBIOp::create(builder, loc, seed);
+    }
+    // Slang already checks the arity of `$random`.
+    assert(false && "`$random` takes 0 or 1 arguments");
+    return {};
+  }
+
+  if (nameId == ksn::URandomRange) {
+    // Slang already checks the arity of `$urandom_range`.
+    assert(numArgs >= 1 && numArgs <= 2 &&
+           "`$urandom_range` takes 1 or 2 arguments");
+    auto maxval = convertRvalueExpression(*args[0]);
+    if (!maxval)
+      return {};
+    Value minval = nullptr;
+    if (numArgs == 2) {
+      minval = convertRvalueExpression(*args[1]);
+      if (!minval)
+        return {};
+    }
+    return moore::UrandomrangeBIOp::create(builder, loc, maxval, minval);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Time System Functions
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::Time || nameId == ksn::STime || nameId == ksn::RealTime) {
+    // Slang already checks the arity of time functions.
+    assert(numArgs == 0 && "time functions take no arguments");
+    return moore::TimeBIOp::create(builder, loc);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Math System Functions
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::Clog2) {
+    // Slang already checks the arity of `$clog2`.
+    assert(numArgs == 1 && "`$clog2` takes 1 argument");
+    auto value = convertRvalueExpression(*args[0]);
+    if (!value)
+      return {};
+    value = convertToSimpleBitVector(value);
+    if (!value)
+      return {};
+    return moore::Clog2BIOp::create(builder, loc, value);
+  }
+
+  // Real math functions (all take 1 real argument)
+  if (nameId == ksn::Ln)
+    return convertRealMathBI<moore::LnBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Log10)
+    return convertRealMathBI<moore::Log10BIOp>(*this, loc, name, args);
+  if (nameId == ksn::Exp)
+    return convertRealMathBI<moore::ExpBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Sqrt)
+    return convertRealMathBI<moore::SqrtBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Floor)
+    return convertRealMathBI<moore::FloorBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Ceil)
+    return convertRealMathBI<moore::CeilBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Sin)
+    return convertRealMathBI<moore::SinBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Cos)
+    return convertRealMathBI<moore::CosBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Tan)
+    return convertRealMathBI<moore::TanBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Asin)
+    return convertRealMathBI<moore::AsinBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Acos)
+    return convertRealMathBI<moore::AcosBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Atan)
+    return convertRealMathBI<moore::AtanBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Sinh)
+    return convertRealMathBI<moore::SinhBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Cosh)
+    return convertRealMathBI<moore::CoshBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Tanh)
+    return convertRealMathBI<moore::TanhBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Asinh)
+    return convertRealMathBI<moore::AsinhBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Acosh)
+    return convertRealMathBI<moore::AcoshBIOp>(*this, loc, name, args);
+  if (nameId == ksn::Atanh)
+    return convertRealMathBI<moore::AtanhBIOp>(*this, loc, name, args);
+
+  //===--------------------------------------------------------------------===//
+  // Type Conversion System Functions
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::Signed || nameId == ksn::Unsigned) {
+    // Slang already checks the arity of `$signed`/`$unsigned`.
+    assert(numArgs == 1 && "`$signed`/`$unsigned` take 1 argument");
+    // These are just passthroughs in the IR; signedness is carried on the Slang
+    // AST type which we use to convert the IR.
+    return convertRvalueExpression(*args[0]);
+  }
+
+  if (nameId == ksn::RealToBits)
+    return convertRealMathBI<moore::RealtobitsBIOp>(*this, loc, name, args);
+  if (nameId == ksn::BitsToReal)
+    return convertRealMathBI<moore::BitstorealBIOp>(*this, loc, name, args);
+  if (nameId == ksn::ShortrealToBits)
+    return convertRealMathBI<moore::ShortrealtobitsBIOp>(*this, loc, name,
+                                                         args);
+  if (nameId == ksn::BitsToShortreal)
+    return convertRealMathBI<moore::BitstoshortrealBIOp>(*this, loc, name,
+                                                         args);
+
+  //===--------------------------------------------------------------------===//
+  // String Methods
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::Len) {
+    // Slang already checks the arity of string methods.
+    assert(numArgs == 1 && "`len` takes 1 argument");
+    auto stringType = moore::StringType::get(getContext());
+    auto value = convertRvalueExpression(*args[0], stringType);
+    if (!value)
+      return {};
+    return moore::StringLenOp::create(builder, loc, value);
+  }
+
+  if (nameId == ksn::ToUpper) {
+    // Slang already checks the arity of string methods.
+    assert(numArgs == 1 && "`toupper` takes 1 argument");
+    auto stringType = moore::StringType::get(getContext());
+    auto value = convertRvalueExpression(*args[0], stringType);
+    if (!value)
+      return {};
+    return moore::StringToUpperOp::create(builder, loc, value);
+  }
+
+  if (nameId == ksn::ToLower) {
+    // Slang already checks the arity of string methods.
+    assert(numArgs == 1 && "`tolower` takes 1 argument");
+    auto stringType = moore::StringType::get(getContext());
+    auto value = convertRvalueExpression(*args[0], stringType);
+    if (!value)
+      return {};
+    return moore::StringToLowerOp::create(builder, loc, value);
+  }
+
+  if (nameId == ksn::Getc) {
+    // Slang already checks the arity of string methods.
+    assert(numArgs == 2 && "`getc` takes 2 arguments");
+    auto stringType = moore::StringType::get(getContext());
+    auto str = convertRvalueExpression(*args[0], stringType);
+    auto index = convertRvalueExpression(*args[1]);
+    if (!str || !index)
+      return {};
+    return moore::StringGetOp::create(builder, loc, str, index);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Queue Methods
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::ArraySize) {
+    // Slang already checks the arity of `size`.
+    assert(numArgs == 1 && "`size` takes 1 argument");
+    if (args[0]->type->isQueue()) {
+      auto value = convertRvalueExpression(*args[0]);
+      if (!value)
+        return {};
+      return moore::QueueSizeBIOp::create(builder, loc, value);
+    }
+    if (args[0]->type->getCanonicalType().kind ==
+        slang::ast::SymbolKind::DynamicArrayType) {
+      auto value = convertRvalueExpression(*args[0]);
+      if (!value)
+        return {};
+      return moore::OpenUArraySizeOp::create(builder, loc, value);
+    }
+    if (args[0]->type->isAssociativeArray()) {
+      auto value = convertLvalueExpression(*args[0]);
+      if (!value)
+        return {};
+      return moore::AssocArraySizeOp::create(builder, loc, value);
+    }
+    emitError(loc) << "unsupported member function `size` on type `"
+                   << args[0]->type->toString() << "`";
+    return {};
+  }
+
+  if (nameId == ksn::Delete) {
+    // Slang already checks the arity of `delete`.
+    assert(numArgs == 1 && "`delete` takes 1 argument");
+    if (args[0]->type->getCanonicalType().kind ==
+        slang::ast::SymbolKind::DynamicArrayType) {
+      auto value = convertRvalueExpression(*args[0]);
+      if (!value)
+        return {};
+      return moore::OpenUArrayDeleteOp::create(builder, loc, value);
+    }
+    emitError(loc) << "unsupported member function `delete` on type `"
+                   << args[0]->type->toString() << "`";
+    return {};
+  }
+
+  if (nameId == ksn::PopBack) {
+    // Slang already checks the arity and applicability of `pop_back`.
+    assert(numArgs == 1 && "`pop_back` takes 1 argument");
+    assert(args[0]->type->isQueue() && "`pop_back` is only valid on queues");
+    auto value = convertLvalueExpression(*args[0]);
+    if (!value)
+      return {};
+    return moore::QueuePopBackOp::create(builder, loc, value);
+  }
+
+  if (nameId == ksn::PopFront) {
+    // Slang already checks the arity and applicability of `pop_front`.
+    assert(numArgs == 1 && "`pop_front` takes 1 argument");
+    assert(args[0]->type->isQueue() && "`pop_front` is only valid on queues");
+    auto value = convertLvalueExpression(*args[0]);
+    if (!value)
+      return {};
+    return moore::QueuePopFrontOp::create(builder, loc, value);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Associative Array Methods
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::Num) {
+    // Slang already checks the arity and applicability of `num`.
+    assert(numArgs == 1 && "`num` takes 1 argument");
+    assert(args[0]->type->isAssociativeArray() &&
+           "`num` is only valid on associative arrays");
+    auto value = convertLvalueExpression(*args[0]);
+    if (!value)
+      return {};
+    return moore::AssocArraySizeOp::create(builder, loc, value);
+  }
+
+  if (nameId == ksn::Exists) {
+    // Slang already checks the arity and applicability of `exists`.
+    assert(numArgs == 2 && "`exists` takes 2 arguments");
+    assert(args[0]->type->isAssociativeArray() &&
+           "`exists` is only valid on associative arrays");
+    auto array = convertLvalueExpression(*args[0]);
+    auto key = convertRvalueExpression(*args[1]);
+    if (!array || !key)
+      return {};
+    return moore::AssocArrayExistsOp::create(builder, loc, array, key);
+  }
+
+  // Associative array traversal methods (all take 2 arguments: array ref, key
+  // ref)
+  if (nameId == ksn::First || nameId == ksn::Last || nameId == ksn::Next ||
+      nameId == ksn::Prev) {
+    // Slang already checks the arity and applicability of traversal methods.
+    assert(numArgs == 2 && "traversal methods take 2 arguments");
+    assert(args[0]->type->isAssociativeArray() &&
+           "traversal methods are only valid on associative arrays");
+    auto array = convertLvalueExpression(*args[0]);
+    auto key = convertLvalueExpression(*args[1]);
+    if (!array || !key)
+      return {};
+    if (nameId == ksn::First)
+      return moore::AssocArrayFirstOp::create(builder, loc, array, key);
+    if (nameId == ksn::Last)
+      return moore::AssocArrayLastOp::create(builder, loc, array, key);
+    if (nameId == ksn::Next)
+      return moore::AssocArrayNextOp::create(builder, loc, array, key);
+    if (nameId == ksn::Prev)
+      return moore::AssocArrayPrevOp::create(builder, loc, array, key);
+    assert(false && "all traversal cases handled above");
+    return {};
+  }
+
+  // Unrecognized system call
+  emitError(loc) << "unsupported system call `" << name << "`";
+  return {};
 }
 
 // Resolve any (possibly nested) SymbolRefAttr to an op from the root.

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -253,20 +253,11 @@ struct Context {
       moore::IntFormat defaultFormat = moore::IntFormat::Decimal,
       bool appendNewline = false);
 
-  /// Convert system function calls only have arity-0.
-  FailureOr<Value>
-  convertSystemCallArity0(const slang::ast::SystemSubroutine &subroutine,
-                          Location loc);
-
-  /// Convert system function calls only have arity-1.
-  FailureOr<Value>
-  convertSystemCallArity1(const slang::ast::SystemSubroutine &subroutine,
-                          Location loc, Value value);
-
-  /// Convert system function calls with arity-2.
-  FailureOr<Value>
-  convertSystemCallArity2(const slang::ast::SystemSubroutine &subroutine,
-                          Location loc, Value value1, Value value2);
+  /// Convert system function calls. Returns a null `Value` on failure after
+  /// emitting an error.
+  Value convertSystemCall(const slang::ast::SystemSubroutine &subroutine,
+                          Location loc,
+                          std::span<const slang::ast::Expression *const> args);
 
   /// Convert system function calls within properties and assertion with a
   /// single argument.

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -935,18 +935,20 @@ struct StmtVisitor {
   visitSystemCall(const slang::ast::ExpressionStatement &stmt,
                   const slang::ast::CallExpression &expr,
                   const slang::ast::CallExpression::SystemCallInfo &info) {
+    using ksn = slang::parsing::KnownSystemName;
     const auto &subroutine = *info.subroutine;
+    auto nameId = subroutine.knownNameId;
     auto args = expr.arguments();
 
     // Simulation Control Tasks
 
-    if (subroutine.name == "$stop") {
+    if (nameId == ksn::Stop) {
       createFinishMessage(args.size() >= 1 ? args[0] : nullptr);
       moore::StopBIOp::create(builder, loc);
       return true;
     }
 
-    if (subroutine.name == "$finish") {
+    if (nameId == ksn::Finish) {
       createFinishMessage(args.size() >= 1 ? args[0] : nullptr);
       moore::FinishBIOp::create(builder, loc, 0);
       moore::UnreachableOp::create(builder, loc);
@@ -954,7 +956,7 @@ struct StmtVisitor {
       return true;
     }
 
-    if (subroutine.name == "$exit") {
+    if (nameId == ksn::Exit) {
       // Calls to `$exit` from outside a `program` are ignored. Since we don't
       // yet support programs, there is nothing to do here.
       // TODO: Fix this once we support programs.
@@ -963,29 +965,47 @@ struct StmtVisitor {
 
     // Display and Write Tasks (`$display[boh]?` or `$write[boh]?`)
 
-    // Check for a `$display` or `$write` prefix.
-    bool isDisplay = false;     // display or write
-    bool appendNewline = false; // display
-    StringRef remainingName = subroutine.name;
-    if (remainingName.consume_front("$display")) {
+    using moore::IntFormat;
+    bool isDisplay = false;
+    bool appendNewline = false;
+    IntFormat defaultFormat = IntFormat::Decimal;
+    switch (nameId) {
+    case ksn::Display:
       isDisplay = true;
       appendNewline = true;
-    } else if (remainingName.consume_front("$write")) {
+      break;
+    case ksn::DisplayB:
       isDisplay = true;
-    }
-
-    // Check for optional `b`, `o`, or `h` suffix indicating default format.
-    using moore::IntFormat;
-    IntFormat defaultFormat = IntFormat::Decimal;
-    if (isDisplay && !remainingName.empty()) {
-      if (remainingName == "b")
-        defaultFormat = IntFormat::Binary;
-      else if (remainingName == "o")
-        defaultFormat = IntFormat::Octal;
-      else if (remainingName == "h")
-        defaultFormat = IntFormat::HexLower;
-      else
-        isDisplay = false;
+      appendNewline = true;
+      defaultFormat = IntFormat::Binary;
+      break;
+    case ksn::DisplayO:
+      isDisplay = true;
+      appendNewline = true;
+      defaultFormat = IntFormat::Octal;
+      break;
+    case ksn::DisplayH:
+      isDisplay = true;
+      appendNewline = true;
+      defaultFormat = IntFormat::HexLower;
+      break;
+    case ksn::Write:
+      isDisplay = true;
+      break;
+    case ksn::WriteB:
+      isDisplay = true;
+      defaultFormat = IntFormat::Binary;
+      break;
+    case ksn::WriteO:
+      isDisplay = true;
+      defaultFormat = IntFormat::Octal;
+      break;
+    case ksn::WriteH:
+      isDisplay = true;
+      defaultFormat = IntFormat::HexLower;
+      break;
+    default:
+      break;
     }
 
     if (isDisplay) {
@@ -1002,13 +1022,13 @@ struct StmtVisitor {
     // Severity Tasks
     using moore::Severity;
     std::optional<Severity> severity;
-    if (subroutine.name == "$info")
+    if (nameId == ksn::Info)
       severity = Severity::Info;
-    else if (subroutine.name == "$warning")
+    else if (nameId == ksn::Warning)
       severity = Severity::Warning;
-    else if (subroutine.name == "$error")
+    else if (nameId == ksn::Error)
       severity = Severity::Error;
-    else if (subroutine.name == "$fatal")
+    else if (nameId == ksn::Fatal)
       severity = Severity::Fatal;
 
     if (severity) {
@@ -1045,7 +1065,7 @@ struct StmtVisitor {
 
       // `delete` has two functions: If there is an index passed, then it
       // deletes that specific element, otherwise, it clears the entire queue.
-      if (subroutine.name == "delete") {
+      if (nameId == ksn::Delete) {
         if (args.size() == 1) {
           moore::QueueClearOp::create(builder, loc, queue);
           return true;
@@ -1055,17 +1075,17 @@ struct StmtVisitor {
           moore::QueueDeleteOp::create(builder, loc, queue, index);
           return true;
         }
-      } else if (subroutine.name == "insert" && args.size() == 3) {
+      } else if (nameId == ksn::Insert && args.size() == 3) {
         auto index = context.convertRvalueExpression(*args[1]);
         auto item = context.convertRvalueExpression(*args[2]);
 
         moore::QueueInsertOp::create(builder, loc, queue, index, item);
         return true;
-      } else if (subroutine.name == "push_back" && args.size() == 2) {
+      } else if (nameId == ksn::PushBack && args.size() == 2) {
         auto item = context.convertRvalueExpression(*args[1]);
         moore::QueuePushBackOp::create(builder, loc, queue, item);
         return true;
-      } else if (subroutine.name == "push_front" && args.size() == 2) {
+      } else if (nameId == ksn::PushFront && args.size() == 2) {
         auto item = context.convertRvalueExpression(*args[1]);
         moore::QueuePushFrontOp::create(builder, loc, queue, item);
         return true;
@@ -1081,7 +1101,7 @@ struct StmtVisitor {
       // `delete` has two functions: If there is an index passed, then it
       // deletes that specific element, otherwise, it clears the entire
       // associative array.
-      if (subroutine.name == "delete") {
+      if (nameId == ksn::Delete) {
         if (args.size() == 1) {
           moore::AssocArrayClearOp::create(builder, loc, assocArray);
           return true;

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -181,7 +181,7 @@ endfunction
 module Foo;
   logic a;
   string b;
-  // expected-error @below {{expected integer argument for system call `$past`}}
+  // expected-error @below {{expected integer argument for `$past`}}
   assert property (@(posedge a) $past(b));
 endmodule
 


### PR DESCRIPTION
Instead of first checking the number of arguments of a system task or function, and only then checking the name, create one big name-based dispatch before going into details about the number of arguments. This allows us to produce better error messages about the actual system tasks that aren't supported yet, instead of failing on things like `EmptyArgument` expression conversions. It also allows us to better handle system tasks that can have a variable number of arguments.

Sorry for the churn everyone!