### PR TITLE
[ImportVerilog] Fix moore.conversion legalization failure on interface ports

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -568,8 +568,8 @@ struct ModuleVisitor : public BaseVisitor {
         outputValues.push_back(val);
       } else {
         // For input ports, if the value is a ref (from VariableOp/NetOp),
-        // read it to get the rvalue.
-        if (isa<moore::RefType>(val.getType()))
+        // read it to get the rvalue, unless the port itself expects a ref.
+        if (isa<moore::RefType>(val.getType()) && !isa<moore::RefType>(fp.type))
           val = moore::ReadOp::create(builder, loc, val);
         inputValues.push_back(val);
       }

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4852,6 +4852,27 @@ module TopTwoPorts;
   TwoPortsSameType dut(.a(i1), .b(i2));
 endmodule
 
+// The test from sv-test
+interface test_bus;
+  logic test_pad;
+endinterface: test_bus
+
+// CHECK-LABEL: moore.module private @sub(in %iface_test_pad : !moore.ref<l1>) {
+// CHECK:         moore.output
+// CHECK:       }
+module sub(test_bus iface);
+endmodule
+
+// CHECK-LABEL: moore.module @top() {
+// CHECK:         %iface_test_pad = moore.variable : <l1>
+// CHECK:         moore.instance "sub" @sub(iface_test_pad: %iface_test_pad: !moore.ref<l1>) -> ()
+// CHECK:         moore.output
+// CHECK:       }
+module top;
+   test_bus iface();
+   sub sub (.iface);
+endmodule
+
 // CHECK-LABEL: moore.module @DynamicArrayInitializeTest() {
 // CHECK: [[ARR:%.+]] = moore.variable : <open_uarray<i8>>
 // CHECK: moore.procedure initial {
@@ -4920,3 +4941,4 @@ module DynamicArrayDeleteTest;
   end
 
 endmodule
+


### PR DESCRIPTION
`moore.read `was being applied to all input interface signals during port flattening, which caused legalization failures when connecting to interface ports that actually expect the raw `!moore.ref` type, so I added a check to skip the `moore.read` operation if the target port's type is already a reference.