### PR TITLE
[ci] Add workflow_dispatch cibw-build selector for uploadWheels

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -12,7 +12,6 @@ on:
         type: boolean
       cibw-build:
         description: 'Which wheel target to build (workflow_dispatch only)'
-        required: true
         default: all
         type: choice
         options:
@@ -33,31 +32,27 @@ jobs:
     steps:
       - name: Set matrix
         id: set-matrix
-        uses: actions/github-script@v7
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          CIBW_BUILD: ${{ inputs.cibw-build }}
-        with:
-          script: |
-            const allTargets = [
-              "cp310-manylinux_x86_64",
-              "cp313-manylinux_x86_64",
-              "cp314-manylinux_x86_64",
-            ];
-
-            const selectedTargets =
-              process.env.EVENT_NAME !== "workflow_dispatch" || process.env.CIBW_BUILD === "all"
-                ? allTargets
-                : [process.env.CIBW_BUILD];
-
-            const matrix = {
-              config: selectedTargets.map((target) => ({
-                os: "ubuntu-22.04",
-                cibw_build: target,
-              })),
-            };
-
-            core.setOutput("matrix", JSON.stringify(matrix));
+        run: |
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ inputs.cibw-build }}" == "all" ]]; then
+            matrix='{
+              "config": [
+                {"os":"ubuntu-22.04","cibw_build":"cp310-manylinux_x86_64"},
+                {"os":"ubuntu-22.04","cibw_build":"cp313-manylinux_x86_64"},
+                {"os":"ubuntu-22.04","cibw_build":"cp314-manylinux_x86_64"}
+              ]
+            }'
+          else
+            matrix='{
+              "config": [
+                {"os":"ubuntu-22.04","cibw_build":"${{ inputs.cibw-build }}"}
+              ]
+            }'
+          fi
+          {
+            echo "matrix<<EOF"
+            echo "$matrix"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
   build_wheels:
     name: Build wheels with ${{ matrix.config.cibw_build }}


### PR DESCRIPTION
Allow manual Upload Wheels runs to select a single wheel target via workflow_dispatch input (all/cp310/cp313/cp314) to save computing/pypi resource. Keep release/schedule behavior unchanged. 

Unfortunately it was a bit tricky to dynamically generate matrix, and it currently uses JS script. 

Tested in https://github.com/llvm/circt/actions/runs/23074576448 and https://github.com/llvm/circt/actions/runs/23074598662 (both jobs were cancelled after matrix generation). 