### PR TITLE
[Synth] Fold single-operand synth.choice

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -153,6 +153,7 @@ def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
   let arguments = (ins Variadic<AnyType>:$inputs);
   let results = (outs AnyType:$result);
   let hasVerifier = 1;
+  let hasFolder = 1;
   let assemblyFormat = "$inputs attr-dict `:` type($result)";
 }
 

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -34,6 +34,12 @@ LogicalResult ChoiceOp::verify() {
   return success();
 }
 
+OpFoldResult ChoiceOp::fold(FoldAdaptor adaptor) {
+  if (adaptor.getInputs().size() == 1)
+    return getOperand(0);
+  return {};
+}
+
 LogicalResult MajorityInverterOp::verify() {
   if (getNumOperands() % 2 != 1)
     return emitOpError("requires an odd number of operands");

--- a/test/Dialect/Synth/canonicalizer.mlir
+++ b/test/Dialect/Synth/canonicalizer.mlir
@@ -133,3 +133,10 @@ hw.module @parameter<in: i8> (in %a: i8, out o1: i8) {
   %1 = synth.mig.maj_inv %0, %a, %param : i8
   hw.output %1 : i8
 }
+
+// CHECK-LABEL: hw.module @choice_single_operand
+hw.module @choice_single_operand(in %a: i4, out o: i4) {
+  // CHECK-NEXT: hw.output %a : i4
+  %0 = synth.choice %a : i4
+  hw.output %0 : i4
+}


### PR DESCRIPTION
There is no point to keep choice operations with a single operand. 