### PR TITLE
[FIRRTLToHW] Fix crash when lowering instance_choice with clock outputs

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -4163,10 +4163,26 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceChoiceOp oldInstanceChoice) {
     auto portType = lowerType(port.type);
     if (!portType || portType.isInteger(0))
       continue;
+
+    // Clock types cannot be used as inout element types. Use i1 instead and
+    // convert to/from clock when reading/writing.
+    Type wireType = portType;
+    if (isa<seq::ClockType>(portType))
+      wireType = builder.getIntegerType(1);
+
     auto wire = sv::WireOp::create(
-        builder, portType, wirePrefix.str() + "." + port.getName().str());
+        builder, wireType, wirePrefix.str() + "." + port.getName().str());
     outputWires.push_back(wire);
-    if (failed(setLowering(oldInstanceChoice.getResult(portIndex), wire)))
+
+    // If this is a clock type, we need to read the i1 wire and convert it to
+    // a clock.
+    Value wireValue = wire;
+    if (isa<seq::ClockType>(portType)) {
+      auto readWire = getReadValue(wire);
+      wireValue = seq::ToClockOp::create(builder, readWire);
+    }
+
+    if (failed(setLowering(oldInstanceChoice.getResult(portIndex), wireValue)))
       return failure();
   }
 
@@ -4197,8 +4213,14 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceChoiceOp oldInstanceChoice) {
         [&]() -> hw::InnerSymbolNamespace & { return moduleNamespace; });
 
     // Assign instance outputs to the wires
-    for (unsigned i = 0; i < inst.getNumResults(); ++i)
-      sv::AssignOp::create(builder, outputWires[i], inst.getResult(i));
+    for (unsigned i = 0; i < inst.getNumResults(); ++i) {
+      Value result = inst.getResult(i);
+      // If the result is a clock type, convert it to i1 before assigning to the
+      // wire.
+      if (isa<seq::ClockType>(result.getType()))
+        result = getNonClockValue(result);
+      sv::AssignOp::create(builder, outputWires[i], result);
+    }
 
     return inst;
   };

--- a/test/Conversion/FIRRTLToHW/lower-instance-choice-clock.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-instance-choice-clock.mlir
@@ -1,0 +1,48 @@
+// RUN: circt-opt -lower-firrtl-to-hw %s | FileCheck %s
+
+// Test that instance_choice with clock-typed output ports is lowered correctly.
+// Clock types cannot be used as inout element types, so we use i1 wires and
+// convert to/from clock when reading/writing.
+
+module {
+  firrtl.circuit "Top" {
+    sv.macro.decl @__option_Opt_A {sym_visibility = "private"}
+    sv.macro.decl @__option_Opt_B {sym_visibility = "private"}
+    sv.macro.decl @__target_Opt_inst {sym_visibility = "private"}
+    
+    firrtl.option @Opt attributes {sym_visibility = "private"} {
+      firrtl.option_case @A {case_macro = @__option_Opt_A}
+      firrtl.option_case @B {case_macro = @__option_Opt_B}
+    }
+    
+    firrtl.extmodule private @ModA(in clk_in: !firrtl.clock, out clk_out: !firrtl.clock) attributes {convention = #firrtl<convention scalarized>, defname = "ModA"}
+    firrtl.extmodule private @ModB(in clk_in: !firrtl.clock, out clk_out: !firrtl.clock) attributes {convention = #firrtl<convention scalarized>, defname = "ModB"}
+    
+    // CHECK-LABEL: hw.module @Top
+    firrtl.module @Top(in %clk: !firrtl.clock, out %out_clk: !firrtl.clock) {
+      // CHECK: %inst.clk_out = sv.wire : !hw.inout<i1>
+      // CHECK-NEXT: %[[READ:.+]] = sv.read_inout %inst.clk_out : !hw.inout<i1>
+      // CHECK-NEXT: %[[TO_CLOCK:.+]] = seq.to_clock %[[READ]]
+      %inst_clk_in, %inst_clk_out = firrtl.instance_choice inst {instance_macro = @__target_Opt_inst} @ModA alternatives @Opt { @A -> @ModA, @B -> @ModB } (in clk_in: !firrtl.clock, out clk_out: !firrtl.clock)
+      firrtl.matchingconnect %inst_clk_in, %clk : !firrtl.clock
+      firrtl.matchingconnect %out_clk, %inst_clk_out : !firrtl.clock
+      
+      // CHECK: sv.ifdef @__option_Opt_A {
+      // CHECK:   %inst_A.clk_out = hw.instance "inst_A"
+      // CHECK:   %[[FROM_CLOCK_A:.+]] = seq.from_clock %inst_A.clk_out
+      // CHECK:   sv.assign %inst.clk_out, %[[FROM_CLOCK_A]] : i1
+      // CHECK: } else {
+      // CHECK:   sv.ifdef @__option_Opt_B {
+      // CHECK:     %inst_B.clk_out = hw.instance "inst_B"
+      // CHECK:     %[[FROM_CLOCK_B:.+]] = seq.from_clock %inst_B.clk_out
+      // CHECK:     sv.assign %inst.clk_out, %[[FROM_CLOCK_B]] : i1
+      // CHECK:   } else {
+      // CHECK:     %inst_default.clk_out = hw.instance "inst_default"
+      // CHECK:     %[[FROM_CLOCK_DEFAULT:.+]] = seq.from_clock %inst_default.clk_out
+      // CHECK:     sv.assign %inst.clk_out, %[[FROM_CLOCK_DEFAULT]] : i1
+      
+      // CHECK: hw.output %[[TO_CLOCK]] : !seq.clock
+    }
+  }
+}
+


### PR DESCRIPTION
When lowering instance_choice operations with clock-typed output ports,
the code was attempting to create sv.wire operations with !seq.clock as
the element type. However, !seq.clock is not a valid element type for
hw.inout, causing an assertion failure.

The fix follows the same pattern used for XMR operations: use i1 wires
instead of !seq.clock wires, and convert to/from clock when reading/
writing:
- When creating wires for clock outputs, use i1 type
- When reading from the wire (for the result value), convert i1 to clock
  using seq.to_clock
- When writing to the wire (from instance outputs), convert clock to i1
  using seq.from_clock

This allows instance_choice to work correctly with clock-typed ports
while respecting the type constraints of hw.inout.

Fixes a crash with the error:
  error: invalid element for hw.inout type '!seq.clock'
  Assertion failed: (succeeded(ConcreteT::verifyInvariants(...)))

AI-assisted-by: Augment (Claude Sonnet 4.5)
Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

**This is DRAFT as I have not reviewed it yet!**
