### PR TITLE
[Synth] Remove an unused variable, NFC

### DIFF
--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -138,14 +138,6 @@ LogicalResult MajorityInverterOp::canonicalize(MajorityInverterOp op,
   if (op.getNumOperands() != 3)
     return failure();
 
-  // Return if the idx-th operand is a constant (inverted if necessary),
-  // otherwise return std::nullopt.
-  auto getConstant = [&](unsigned index) -> std::optional<llvm::APInt> {
-    APInt value;
-    if (mlir::matchPattern(op.getInputs()[index], mlir::m_ConstantInt(&value)))
-      return op.isInverted(index) ? ~value : value;
-    return std::nullopt;
-  };
   // Replace the op with the idx-th operand (inverted if necessary).
   auto replaceWithIndex = [&](int index) {
     bool inverted = op.isInverted(index);


### PR DESCRIPTION
Follow-up 09e94c0b27908d83b207959957367064aa536f6e