### PR TITLE
[HW] Use size_t max as HWSymbolCache invalid port sentinel, NFC

### DIFF
--- a/include/circt/Dialect/HW/HWSymCache.h
+++ b/include/circt/Dialect/HW/HWSymCache.h
@@ -27,8 +27,6 @@ namespace hw {
 /// between the two states.
 class HWSymbolCache : public SymbolCacheBase {
 public:
-  static constexpr size_t invalidPort = std::numeric_limits<size_t>::max();
-
   class Item {
   public:
     Item(mlir::Operation *op) : op(op), port(invalidPort) {}
@@ -78,6 +76,7 @@ public:
   void freeze() { isFrozen = true; }
 
 private:
+  static constexpr size_t invalidPort = std::numeric_limits<size_t>::max();
   Item lookupInner(InnerRefAttr attr) const {
     assert(isFrozen && "cannot read from this cache until it is frozen");
     auto it = symbolCache.find(attr);


### PR DESCRIPTION
Replace `~0ULL` with `std::numeric_limits<size_t>::max()` for the invalid port value in `HWSymbolCache`. This avoids width mismatches on 32-bit builds (e.g. wasm) and keeps the sentinel type-correct for `size_t`.