### PR TITLE
[SV] Add sv.macro.module operation

### DIFF
--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -19,6 +19,7 @@ include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
+include "circt/Dialect/HW/HWAttributes.td"
 include "circt/Dialect/SV/SVDialect.td"
 
 // Base class for the operation in this dialect.

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -1202,6 +1202,155 @@ def ReturnOp : SVOp<"return",
 }
 
 //===----------------------------------------------------------------------===//
+// Macro module operation
+//===----------------------------------------------------------------------===//
+
+def MacroModuleOp : SVOp<"macro.module", [
+    Symbol,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+    DeclareOpInterfaceMethods<HWModuleLike>,
+    OpAsmOpInterface,
+    SingleBlock,
+    NoTerminator,
+    NoRegionArguments,
+    HasParent<"mlir::ModuleOp">
+]> {
+  let summary = "External module configurable via macro";
+  let description = [{
+    This represents an external module declaration where the actual module
+    to instantiate is determined by a macro at elaboration time.
+
+    The macro must be defined and point to a module with compatible ports.
+
+    Example:
+    ```mlir
+    sv.macro.decl @WHICH_MODULE
+    sv.macro.module @MyModule macro @WHICH_MODULE(in %a: i1, out c: i1)
+
+    %inst = hw.instance "foo" @MyModule(a: %a: i1)
+    ```
+    ```verilog
+    `WHICH_MODULE foo (.a(a), .c(c));
+    ```
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       FlatSymbolRefAttr:$macroName,
+                       TypeAttrOf<ModuleType>:$module_type,
+                       OptionalAttr<DictArrayAttr>:$per_port_attrs,
+                       OptionalAttr<LocationArrayAttr>:$port_locs,
+                       ParamDeclArrayAttr:$parameters);
+  let results = (outs);
+  let regions = (region AnyRegion:$body);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "StringAttr":$name, "FlatSymbolRefAttr":$macroName,
+                   "ArrayRef<hw::PortInfo>":$ports,
+                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    StringAttr getNameAttr() {
+      return (*this)->getAttrOfType<StringAttr>(
+          ::mlir::SymbolTable::getSymbolAttrName());
+    }
+
+    StringRef getName() {
+      return getNameAttr().getValue();
+    }
+
+    void getAsmBlockArgumentNames(mlir::Region &region,
+                                  mlir::OpAsmSetValueNameFn setNameFn) {}
+
+    size_t getNumPorts() { return getModuleType().getNumPorts(); }
+    size_t getNumInputPorts() { return getModuleType().getNumInputs(); }
+    size_t getNumOutputPorts() { return getModuleType().getNumOutputs(); }
+    size_t getPortIdForInputId(size_t idx) {
+      return getModuleType().getPortIdForInputId(idx);
+    }
+    size_t getPortIdForOutputId(size_t idx) {
+      return getModuleType().getPortIdForOutputId(idx);
+    }
+
+    ::circt::hw::PortInfo getPort(size_t idx);
+    SmallVector<::circt::hw::PortInfo> getPortList();
+  }];
+  let extraClassDefinition = [{
+    SmallVector<::circt::hw::PortInfo> $cppClass::getPortList() {
+      SmallVector<::circt::hw::PortInfo> results;
+      auto locs = getPortLocs();
+      auto attrs = getPerPortAttrs();
+      for (auto [index, port] : llvm::enumerate(getModuleType().getPorts())) {
+        ::circt::hw::PortInfo portInfo;
+        portInfo.name = port.name;
+        portInfo.dir = port.dir;
+        portInfo.type = port.type;
+        if (locs && index < locs->size())
+          portInfo.loc = cast<LocationAttr>((*locs)[index]);
+        if (attrs && index < attrs->size())
+          portInfo.attrs = cast<DictionaryAttr>((*attrs)[index]);
+        results.push_back(portInfo);
+      }
+      return results;
+    }
+
+    ::circt::hw::PortInfo $cppClass::getPort(size_t idx) {
+      return getPortList()[idx];
+    }
+
+    hw::ModuleType $cppClass::getHWModuleType() {
+      return getModuleType();
+    }
+
+    ArrayRef<Attribute> $cppClass::getAllPortAttrs() {
+      if (auto attrs = getPerPortAttrs())
+        return attrs->getValue();
+      return {};
+    }
+
+    void $cppClass::setAllPortAttrs(ArrayRef<Attribute> attrs) {
+      setPerPortAttrsAttr(ArrayAttr::get(getContext(), attrs));
+    }
+
+    void $cppClass::removeAllPortAttrs() {
+      removePerPortAttrsAttr();
+    }
+
+    SmallVector<Location> $cppClass::getAllPortLocs() {
+      SmallVector<Location> locs;
+      if (auto portLocs = getPortLocs()) {
+        for (auto loc : *portLocs)
+          locs.push_back(cast<Location>(loc));
+      } else {
+        locs.resize(getModuleType().getNumPorts(),
+                    UnknownLoc::get(getContext()));
+      }
+      return locs;
+    }
+
+    void $cppClass::setAllPortLocsAttrs(ArrayRef<Attribute> locs) {
+      setPortLocsAttr(ArrayAttr::get(getContext(), locs));
+    }
+
+    void $cppClass::setHWModuleType(hw::ModuleType type) {
+      setModuleTypeAttr(TypeAttr::get(type));
+    }
+
+    void $cppClass::setAllPortNames(ArrayRef<Attribute> names) {
+      auto type = getModuleType();
+      SmallVector<hw::ModulePort> ports;
+      for (auto [idx, port] : llvm::enumerate(type.getPorts()))
+        ports.push_back({cast<StringAttr>(names[idx]), port.type, port.dir});
+      setHWModuleType(hw::ModuleType::get(getContext(), ports));
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // SV output control.
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -46,7 +46,7 @@ public:
             InterfaceOp, SVVerbatimSourceOp, InterfaceSignalOp,
             InterfaceModportOp, InterfaceInstanceOp, GetModportOp,
             AssignInterfaceSignalOp, ReadInterfaceSignalOp, MacroDeclOp,
-            MacroDefOp, FuncOp, FuncDPIImportOp,
+            MacroDefOp, MacroModuleOp, FuncOp, FuncDPIImportOp,
             // Verification statements.
             AssertOp, AssumeOp, CoverOp, AssertConcurrentOp, AssumeConcurrentOp,
             CoverConcurrentOp, AssertPropertyOp, AssumePropertyOp,
@@ -157,6 +157,7 @@ public:
   HANDLE(ReadInterfaceSignalOp, Unhandled);
   HANDLE(MacroDefOp, Unhandled);
   HANDLE(MacroDeclOp, Unhandled);
+  HANDLE(MacroModuleOp, Unhandled);
   HANDLE(FuncDPIImportOp, Unhandled);
   HANDLE(FuncOp, Unhandled);
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -2879,6 +2879,117 @@ LogicalResult CoverPropertyOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// MacroModuleOp
+//===----------------------------------------------------------------------===//
+
+void MacroModuleOp::build(OpBuilder &builder, OperationState &result,
+                          StringAttr name, FlatSymbolRefAttr macroName,
+                          ArrayRef<hw::PortInfo> ports,
+                          ArrayRef<NamedAttribute> attributes) {
+  result.addAttribute(SymbolTable::getSymbolAttrName(), name);
+  result.addAttribute("macroName", macroName);
+
+  SmallVector<hw::ModulePort> modulePorts;
+  SmallVector<Attribute> portLocs;
+  SmallVector<Attribute> portAttrs;
+  for (auto port : ports) {
+    modulePorts.push_back({port.name, port.type, port.dir});
+    portLocs.push_back(port.loc ? LocationAttr(port.loc)
+                                : LocationAttr(builder.getUnknownLoc()));
+    portAttrs.push_back(port.attrs ? port.attrs
+                                   : builder.getDictionaryAttr({}));
+  }
+  auto type = hw::ModuleType::get(builder.getContext(), modulePorts);
+  result.addAttribute("module_type", TypeAttr::get(type));
+  result.addAttribute("port_locs", builder.getArrayAttr(portLocs));
+  result.addAttribute("per_port_attrs", builder.getArrayAttr(portAttrs));
+  result.addAttribute("parameters", builder.getArrayAttr({}));
+  result.addAttributes(attributes);
+  result.addRegion();
+}
+
+LogicalResult
+MacroModuleOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto macro = symbolTable.lookupNearestSymbolFrom<MacroDeclOp>(
+      *this, getMacroNameAttr());
+  if (!macro)
+    return emitError("cannot find macro declaration '")
+           << getMacroName() << "'";
+  return success();
+}
+
+ParseResult MacroModuleOp::parse(OpAsmParser &parser, OperationState &result) {
+  auto &builder = parser.getBuilder();
+
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr, SymbolTable::getSymbolAttrName(),
+                             result.attributes))
+    return failure();
+
+  FlatSymbolRefAttr macroNameAttr;
+  if (parser.parseKeyword("macro") ||
+      parser.parseAttribute(macroNameAttr, builder.getNoneType(), "macroName",
+                            result.attributes))
+    return failure();
+
+  SmallVector<hw::module_like_impl::PortParse> ports;
+  TypeAttr modType;
+  if (hw::module_like_impl::parseModuleSignature(parser, ports, modType))
+    return failure();
+  result.addAttribute("module_type", modType);
+
+  SmallVector<Attribute> portAttrs, portLocs;
+  for (auto &port : ports) {
+    portLocs.push_back(builder.getUnknownLoc());
+    portAttrs.push_back(port.attrs ? port.attrs
+                                   : builder.getDictionaryAttr({}));
+  }
+  result.addAttribute("per_port_attrs", builder.getArrayAttr(portAttrs));
+  result.addAttribute("port_locs", builder.getArrayAttr(portLocs));
+  result.addAttribute("parameters", builder.getArrayAttr({}));
+
+  if (parser.parseOptionalAttrDictWithKeyword(result.attributes))
+    return failure();
+
+  result.addRegion();
+  return success();
+}
+
+void MacroModuleOp::print(OpAsmPrinter &p) {
+  p << ' ';
+  p.printSymbolName(getSymName());
+  p << " macro ";
+  p.printAttributeWithoutType(getMacroNameAttr());
+
+  auto modType = getModuleType();
+  p << "(";
+  llvm::interleaveComma(modType.getPorts(), p, [&](auto port) {
+    p << (port.dir == hw::ModulePort::Direction::Input ? "in %" : "out ");
+    p.printKeywordOrString(port.name.getValue());
+    p << " : ";
+    p.printType(port.type);
+  });
+  p << ")";
+
+  SmallVector<StringRef> omittedAttrs = {
+      SymbolTable::getSymbolAttrName(), "module_type", "per_port_attrs",
+      "port_locs", "macroName", "parameters"};
+  p.printOptionalAttrDictWithKeyword((*this)->getAttrs(), omittedAttrs);
+}
+
+LogicalResult MacroModuleOp::verify() {
+  auto modType = getModuleType();
+  auto portLocs = getPortLocs();
+  auto portAttrs = getPerPortAttrs();
+
+  if (portLocs && portLocs->size() != modType.getNumPorts())
+    return emitError("port_locs size doesn't match module type");
+  if (portAttrs && portAttrs->size() != modType.getNumPorts())
+    return emitError("per_port_attrs size doesn't match module type");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -501,3 +501,17 @@ sv.verbatim.source @VerbatimTestModule.v<WIDTH: i32 = 8> attributes {
 sv.verbatim.module @VerbatimTestModule<WIDTH: i32 = 8>(in %clk: i1, out out: i1) attributes {
   source = @VerbatimTestModule.v
 }
+
+sv.macro.decl @WHICH_MODULE
+
+// CHECK-LABEL: sv.macro.module @MyModule macro @WHICH_MODULE(in %a : i1, out c : i1)
+sv.macro.module @MyModule macro @WHICH_MODULE(in %a: i1, out c: i1)
+
+// CHECK-LABEL: sv.macro.module @MyModule2 macro @WHICH_MODULE(in %x : i4, in %y : i4, out z : i8)
+sv.macro.module @MyModule2 macro @WHICH_MODULE(in %x: i4, in %y: i4, out z: i8)
+
+hw.module @Top(in %a: i1, out c: i1) {
+  // CHECK: %inst.c = hw.instance "inst" @MyModule(a: %a: i1) -> (c: i1)
+  %0 = hw.instance "inst" @MyModule(a: %a: i1) -> (c: i1)
+  hw.output %0 : i1
+}


### PR DESCRIPTION
This is alternative implementation for https://github.com/llvm/circt/pull/9900 which we discussed 
in the last ODM.
 
 It introduces sv.macro.module, which represents an external module
  declaration whose concrete implementation is selected by a macro during
  elaboration.

  sv.macro.module is intentionally modeled to behave like an external module.
  It does not carry a set of concrete candidate modules, so instances of it
  do not create caller-to-callee edges in the instance graph. As a result,
  FIRRTL instance-choice use cases still need to preserve the referenced
  modules explicitly, for example by marking them public or by placing inner
  symbols on ports to block optimizations that would otherwise remove them.

 ```mlir
sv.macro.decl @WHICH_MODULE
sv.macro.module @MyModule macro @WHICH_MODULE(in %a: i1, out c: i1)

%inst = hw.instance "foo" @MyModule(a: %a: i1)
```
```verilog
`WHICH_MODULE foo (.a(a), .c(c));
```