### PR TITLE
[ImportVerilog] Fix a fork-join stmt bug

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -178,14 +178,25 @@ struct StmtVisitor {
     // Slang stores all threads of a fork-join block inside a `StatementList`.
     // This cannot be visited normally due to the need to make each statement a
     // separate thread so must be converted here.
-    auto &threadList = stmt.body.as<slang::ast::StatementList>();
-    unsigned int threadCount = threadList.list.size();
+    auto *threadList = stmt.body.as_if<slang::ast::StatementList>();
+    unsigned int threadCount = threadList ? threadList->list.size() : 1;
 
     auto forkOp = moore::ForkJoinOp::create(builder, loc, kind, threadCount);
     OpBuilder::InsertionGuard guard(builder);
 
+    // When only a single statement is present, Slang does not create a
+    // `StatementList`.
+    if (!threadList) {
+      auto &tBlock = forkOp->getRegion(0).emplaceBlock();
+      builder.setInsertionPointToStart(&tBlock);
+      if (failed(context.convertStatement(stmt.body)))
+        return failure();
+      moore::CompleteOp::create(builder, loc);
+      return success();
+    }
+
     int i = 0;
-    for (auto *thread : threadList.list) {
+    for (auto *thread : threadList->list) {
       auto &tBlock = forkOp->getRegion(i).emplaceBlock();
       builder.setInsertionPointToStart(&tBlock);
       // Populate thread operator with thread body and finish with a thread

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4416,7 +4416,30 @@ module WaitForkTest();
   end
 endmodule
 
+// CHECK-LABEL: moore.module @ForkJoinWithSingleStmt
+// CHECK:         [[VAR_A:%.+]] = moore.variable : <i32>
+// CHECK:         moore.procedure initial {
+// CHECK:           moore.fork join_all {
+// CHECK:         [[CONST_1:%.+]] = moore.constant 1 : i32
+// CHECK:             moore.blocking_assign [[VAR_A]], [[CONST_1]] : i32
+// CHECK:             moore.complete
+// CHECK:           }
+// CHECK:           moore.fork join_all
+// CHECK:           moore.return
+// CHECK:         }
+// CHECK:         moore.output
+// CHECK:       }
+module ForkJoinWithSingleStmt;
+  int a;
+  initial begin
+    fork 
+      a = 1;
+    join
 
+    fork
+    join
+  end
+endmodule
 
 
 // CHECK-LABEL: moore.module @AssocArrayExtractTest() {


### PR DESCRIPTION
When only a single statement is in the fork-join, Slang does not create a `slang::ast::StatementList` to contain this single statement. So at this moment, `as<slang::ast::StatementList>` will cause a segmentation fault.