### PR TITLE
Add support for comb.reverse in comb to SMT.

### DIFF
--- a/integration_test/circt-lec/comb.mlir
+++ b/integration_test/circt-lec/comb.mlir
@@ -238,6 +238,28 @@ hw.module @decomposedParity(in %in: i8, out out: i1) {
   hw.output %res : i1
 }
 
+// comb.reverse
+//  RUN: circt-lec %s -c1=reverse -c2=decomposedReverse --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_REVERSE
+//  COMB_REVERSE: c1 == c2
+
+hw.module @reverse(in %a : i8, out out : i8) {
+  %0 = comb.reverse %a : i8
+  hw.output %0 : i8
+}
+
+hw.module @decomposedReverse(in %a : i8, out out : i8) {
+  %b0 = comb.extract %a from 0 : (i8) -> i1
+  %b1 = comb.extract %a from 1 : (i8) -> i1
+  %b2 = comb.extract %a from 2 : (i8) -> i1
+  %b3 = comb.extract %a from 3 : (i8) -> i1
+  %b4 = comb.extract %a from 4 : (i8) -> i1
+  %b5 = comb.extract %a from 5 : (i8) -> i1
+  %b6 = comb.extract %a from 6 : (i8) -> i1
+  %b7 = comb.extract %a from 7 : (i8) -> i1
+  %0 = comb.concat %b0, %b1, %b2, %b3, %b4, %b5, %b6, %b7 : i1, i1, i1, i1, i1, i1, i1, i1
+  hw.output %0 : i8
+}
+
 // comb.replicate
 //  RUN: circt-lec %s -c1=replicate -c2=decomposedReplicate --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_REPLICATE
 //  COMB_REPLICATE: c1 == c2

--- a/lib/Conversion/CombToSMT/CombToSMT.cpp
+++ b/lib/Conversion/CombToSMT/CombToSMT.cpp
@@ -182,6 +182,34 @@ struct ParityOpConversion : OpConversionPattern<ParityOp> {
   }
 };
 
+/// Lower a comb::ReverseOp operation to a chain of smt::Extract + Concat ops
+struct ReverseOpConversion : OpConversionPattern<ReverseOp> {
+  using OpConversionPattern<ReverseOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ReverseOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    unsigned bitwidth =
+        cast<smt::BitVectorType>(adaptor.getInput().getType()).getWidth();
+
+    Type oneBitTy = smt::BitVectorType::get(getContext(), 1);
+    // Extract bit 0 (LSB), which becomes the MSB of the reversed result.
+    Value result =
+        smt::ExtractOp::create(rewriter, loc, oneBitTy, 0, adaptor.getInput());
+    // Concatenate remaining bits in ascending order (LSB-to-MSB of input
+    // becomes MSB-to-LSB of output).
+    for (unsigned i = 1; i < bitwidth; ++i) {
+      Value ext = smt::ExtractOp::create(rewriter, loc, oneBitTy, i,
+                                         adaptor.getInput());
+      result = smt::ConcatOp::create(rewriter, loc, result, ext);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 /// Lower the SourceOp to the TargetOp one-to-one.
 template <typename SourceOp, typename TargetOp>
 struct OneToOneOpConversion : OpConversionPattern<SourceOp> {
@@ -270,7 +298,7 @@ void circt::populateCombToSMTConversionPatterns(TypeConverter &converter,
                                                 RewritePatternSet &patterns) {
   patterns.add<CombReplicateOpConversion, IcmpOpConversion, ExtractOpConversion,
                SubOpConversion, MuxOpConversion, ParityOpConversion,
-               OneToOneOpConversion<ShlOp, smt::BVShlOp>,
+               ReverseOpConversion, OneToOneOpConversion<ShlOp, smt::BVShlOp>,
                OneToOneOpConversion<ShrUOp, smt::BVLShrOp>,
                OneToOneOpConversion<ShrSOp, smt::BVAShrOp>,
                DivisionOpConversion<DivSOp, smt::BVSDivOp>,
@@ -285,8 +313,8 @@ void circt::populateCombToSMTConversionPatterns(TypeConverter &converter,
                VariadicToBinaryOpConversion<XorOp, smt::BVXOrOp>>(
       converter, patterns.getContext());
 
-  // TODO: there are two unsupported operations in the comb dialect: 'parity'
-  // and 'truth_table'.
+  // TODO: there is one unsupported operation in the comb dialect:
+  // 'truth_table'.
 }
 
 void ConvertCombToSMTPass::runOnOperation() {

--- a/test/Conversion/CombToSMT/comb-to-smt.mlir
+++ b/test/Conversion/CombToSMT/comb-to-smt.mlir
@@ -124,6 +124,15 @@ func.func @test(%a0: !smt.bv<32>, %a1: !smt.bv<32>, %a2: !smt.bv<32>, %a3: !smt.
   // CHECK-NEXT: smt.bv.xor [[V4]], [[V5]] : !smt.bv<1>
   %36 = comb.parity %arg5 : i4
 
+  // CHECK-NEXT: [[V0:%.+]] = smt.bv.extract [[ARG5]] from 0 : (!smt.bv<4>) -> !smt.bv<1>
+  // CHECK-NEXT: [[V1:%.+]] = smt.bv.extract [[ARG5]] from 1 : (!smt.bv<4>) -> !smt.bv<1>
+  // CHECK-NEXT: [[V2:%.+]] = smt.bv.concat [[V0]], [[V1]] : !smt.bv<1>, !smt.bv<1>
+  // CHECK-NEXT: [[V3:%.+]] = smt.bv.extract [[ARG5]] from 2 : (!smt.bv<4>) -> !smt.bv<1>
+  // CHECK-NEXT: [[V4:%.+]] = smt.bv.concat [[V2]], [[V3]] : !smt.bv<2>, !smt.bv<1>
+  // CHECK-NEXT: [[V5:%.+]] = smt.bv.extract [[ARG5]] from 3 : (!smt.bv<4>) -> !smt.bv<1>
+  // CHECK-NEXT: smt.bv.concat [[V4]], [[V5]] : !smt.bv<3>, !smt.bv<1>
+  %37 = comb.reverse %arg5 : i4
+
   return
 }
 


### PR DESCRIPTION
Following comb.parity pattern. Not sure if there was a reason it wasn't supported, seems to directly map to parity with a different combinator.