### PR TITLE
[domaintool] Use "define_period" in CSJ handler

### DIFF
--- a/test/Tools/domaintool/clock-spec-json.mlir
+++ b/test/Tools/domaintool/clock-spec-json.mlir
@@ -1,16 +1,14 @@
-// RUN: domaintool --module Foo --domain ClockDomain,A,10 --domain ClockDomain,B,20 --assign 0 --assign 1 %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
-// RUN: domaintool --module Foo --domain ClockDomain,A,10 --domain ClockDomain,B,20 --assign 0 --assign 1 --sifive-clock-domain-async=A %s | FileCheck %s --check-prefixes=CHECK,ASYNC
-// RUN: domaintool --module Foo --domain ClockDomain,A,10 --domain ClockDomain,B,20 --assign 0 --assign 1 --sifive-clock-domain-static=A %s | FileCheck %s --check-prefixes=CHECK,STATIC
+// RUN: domaintool --module Foo --domain ClockDomain,A --domain ClockDomain,B --assign 0 --assign 1 %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
+// RUN: domaintool --module Foo --domain ClockDomain,A --domain ClockDomain,B --assign 0 --assign 1 --sifive-clock-domain-async=A %s | FileCheck %s --check-prefixes=CHECK,ASYNC
+// RUN: domaintool --module Foo --domain ClockDomain,A --domain ClockDomain,B --assign 0 --assign 1 --sifive-clock-domain-static=A %s | FileCheck %s --check-prefixes=CHECK,STATIC
 
 om.class @ClockDomain(
   %basepath: !om.frozenbasepath,
-  %name_in: !om.string,
-  %period_in: !om.integer
+  %name_in: !om.string
 )  -> (
-  name_out: !om.string,
-  period_out: !om.integer
+  name_out: !om.string
 ) {
-  om.class.fields %name_in, %period_in : !om.string, !om.integer
+  om.class.fields %name_in : !om.string
 }
 
 om.class @ClockDomain_out(
@@ -58,26 +56,26 @@ om.class @Foo_Class(
 // DEFAULT-NEXT:   "clocks": [
 // DEFAULT-NEXT:     {
 // DEFAULT-NEXT:       "name_pattern": "A",
-// DEFAULT-NEXT:       "define_period": 10,
+// DEFAULT-NEXT:       "define_period": "A_PERIOD",
 // DEFAULT-NEXT:       "clock_relationships": []
 // DEFAULT-NEXT:     },
 // DEFAULT-NEXT:     {
 // DEFAULT-NEXT:       "name_pattern": "B",
-// DEFAULT-NEXT:       "define_period": 20,
+// DEFAULT-NEXT:       "define_period": "B_PERIOD",
 // DEFAULT-NEXT:       "clock_relationships": []
 // DEFAULT-NEXT:     }
 // DEFAULT-NEXT:   ],
 // ASYNC-NEXT:     "clocks": [
 // ASYNC-NEXT:       {
 // ASYNC-NEXT:         "name_pattern": "B",
-// ASYNC-NEXT:         "define_period": 20,
+// ASYNC-NEXT:         "define_period": "B_PERIOD",
 // ASYNC-NEXT:         "clock_relationships": []
 // ASYNC-NEXT:       }
 // ASYNC-NEXT:     ],
 // STATIC-NEXT:    "clocks": [
 // STATIC-NEXT:      {
 // STATIC-NEXT:        "name_pattern": "B",
-// STATIC-NEXT:        "define_period": 20,
+// STATIC-NEXT:        "define_period": "B_PERIOD",
 // STATIC-NEXT:        "clock_relationships": []
 // STATIC-NEXT:      }
 // STATIC-NEXT:    ],

--- a/tools/domaintool/ClockSpecJSONHandler.cpp
+++ b/tools/domaintool/ClockSpecJSONHandler.cpp
@@ -51,7 +51,6 @@ struct Relationship {
 
 struct Clock {
   StringRef namePattern;
-  uint64_t definePeriod;
   SmallVector<Relationship> relationships;
 };
 
@@ -124,16 +123,8 @@ public:
 
       // Otherwise, this is a normal clock association.  Add the clock and
       // populate the associations.
-      clocks.push_back(
-          {/*namePattern=*/name,
-           /*define_period=*/
-           cast<om::IntegerAttr>(cast<om::evaluator::AttributeValue>(
-                                     objectValue->getField("period_out")->get())
-                                     ->getAttr())
-               .getValue()
-               .getValue()
-               .getZExtValue(),
-           /*relationships=*/{}});
+      clocks.push_back({/*namePattern=*/name,
+                        /*relationships=*/{}});
 
       for (auto &association : associations) {
         if (auto *p = dyn_cast<om::evaluator::PathValue>(association.get())) {
@@ -161,8 +152,10 @@ public:
       json.attributeArray("clocks", [&] {
         for (auto clock : clocks) {
           json.object([&] {
-            json.attribute("name_pattern", clock.namePattern);
-            json.attribute("define_period", clock.definePeriod);
+            auto &name = clock.namePattern;
+            json.attribute("name_pattern", name);
+            json.attribute("define_period",
+                           (Twine(name.upper()) + "_PERIOD").str());
             json.attributeArray("clock_relationships", [&] {
               // TODO: Implement this.
             });


### PR DESCRIPTION
Change the Clock Spec JSON `domaintool` handler to derive the
"define_period" JSON field for each clock from the clock name.
Previously, this was encoded as an integer property of a clock domain.
However, this doesn't match the reality of how this works.
