### PR TITLE
[Calyx] Fix SeqMemoryOp reset port attributes

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2236,7 +2236,7 @@ SmallVector<DictionaryAttr> SeqMemoryOp::portAttributes() {
   NamedAttrList done, clk, reset, contentEn;
   done.append(donePort, isSet);
   clk.append(clkPort, isSet);
-  clk.append(resetPort, isSet);
+  reset.append(resetPort, isSet);
   contentEn.append(goPort, isTwo);
   portAttributes.append({clk.getDictionary(context),       // Clk
                          reset.getDictionary(context),     // Reset


### PR DESCRIPTION
Fix a typo in SeqMemoryOp::portAttributes() in lib/Dialect/Calyx/CalyxOps.cpp.

The clock port was being tagged with both clk and reset, while the reset port was left untagged. That causes clk/reset insertion to wire %mem.clk twice and fail with a duplicate continuous assignment.