### PR TITLE
[Handshake] Fix argument index tracking with multiple ext memref args

### DIFF
--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -392,7 +392,7 @@ LogicalResult
 HandshakeLowerExtmemToHWPass::lowerExtmemToHW(handshake::FuncOp func) {
   // Gather memref ports to be converted. This is an ordered map, and will be
   // iterated from lo to hi indices.
-  std::map<unsigned, Value> memrefArgs;
+  std::map<unsigned, BlockArgument> memrefArgs;
   for (auto [i, arg] : llvm::enumerate(func.getArguments()))
     if (isa<MemRefType>(arg.getType()))
       memrefArgs[i] = arg;
@@ -411,8 +411,10 @@ HandshakeLowerExtmemToHWPass::lowerExtmemToHW(handshake::FuncOp func) {
   OpBuilder b(func);
   for (auto it : memrefArgs) {
     // Do not use structured bindings for 'it' - cannot reference inside lambda.
-    unsigned i = it.first;
     auto arg = it.second;
+    // arg.getArgNumber() reflects the current position after any insertions/
+    // erasures from processing earlier memref arguments.
+    unsigned i = arg.getArgNumber();
     auto loc = arg.getLoc();
     // Get the attached extmemory external module.
     auto extmemOp = cast<handshake::ExternalMemoryOp>(*arg.getUsers().begin());
@@ -489,7 +491,8 @@ HandshakeLowerExtmemToHWPass::lowerExtmemToHW(handshake::FuncOp func) {
       return failure();
     eraseFromArrayAttr(func, "argNames", i + addedInPorts);
 
-    argReplacements[i] = memIOTypes;
+    // it.first is the original (pre-lowering) argument index
+    argReplacements[it.first] = memIOTypes;
   }
 
   if (createESIWrapper)

--- a/test/Dialect/Handshake/lower-extmem.mlir
+++ b/test/Dialect/Handshake/lower-extmem.mlir
@@ -36,3 +36,33 @@ handshake.func @i0(%c : memref<1xi32>) {
   return
 }
 
+// CHECK-LABEL:   handshake.func @two_extmems(
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: none, %[[VAL_2:.*]]: none, %[[VAL_3:.*]]: none, ...) -> (none, i4, !hw.struct<address: i4, data: i32>, !hw.struct<address: i4, data: i32>)
+// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_3]] {value = 0 : index} : index
+// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_3]] {value = 0 : index} : index
+// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_3]] {value = 0 : index} : index
+// CHECK:           %[[VAL_7:.*]] = constant %[[VAL_3]] {value = 0 : i32} : i32
+// CHECK:           %[[VAL_8:.*]] = constant %[[VAL_3]] {value = 0 : i32} : i32
+// CHECK:           %[[VAL_9:.*]]:2 = fork [2] %[[VAL_0]] : i32
+// CHECK:           %[[VAL_10:.*]] = join %[[VAL_9]]#1 : i32
+// CHECK:           %[[VAL_11:.*]] = arith.index_cast %[[VAL_4]] : index to i4
+// CHECK:           %[[VAL_12:.*]] = arith.index_cast %[[VAL_5]] : index to i4
+// CHECK:           %[[VAL_13:.*]] = hw.struct_create (%[[VAL_12]], %[[VAL_7]]) : !hw.struct<address: i4, data: i32>
+// CHECK:           %[[VAL_14:.*]] = arith.index_cast %[[VAL_6]] : index to i4
+// CHECK:           %[[VAL_15:.*]] = hw.struct_create (%[[VAL_14]], %[[VAL_8]]) : !hw.struct<address: i4, data: i32>
+// CHECK:           sink %[[VAL_9]]#0 : i32
+// CHECK:           %[[VAL_16:.*]] = join %[[VAL_1]], %[[VAL_10]], %[[VAL_2]] : none, none, none
+// CHECK:           return %[[VAL_16]], %[[VAL_11]], %[[VAL_13]], %[[VAL_15]] : none, i4, !hw.struct<address: i4, data: i32>, !hw.struct<address: i4, data: i32>
+// CHECK:         }
+handshake.func @two_extmems(%mem0: memref<10xi32>, %mem1: memref<10xi32>, %argCtrl: none) -> none {
+  %ldAddr = constant %argCtrl {value = 0 : index} : index
+  %stAddr0 = constant %argCtrl {value = 0 : index} : index
+  %stAddr1 = constant %argCtrl {value = 0 : index} : index
+  %stData0 = constant %argCtrl {value = 0 : i32} : i32
+  %stData1 = constant %argCtrl {value = 0 : i32} : i32
+  %ldData, %stCtrl0, %ldCtrl = handshake.extmemory[ld=1, st=1](%mem0 : memref<10xi32>)(%stData0, %stAddr0, %ldAddr) {id = 0 : i32} : (i32, index, index) -> (i32, none, none)
+  %stCtrl1 = handshake.extmemory[ld=0, st=1](%mem1 : memref<10xi32>)(%stData1, %stAddr1) {id = 1 : i32} : (i32, index) -> none
+  sink %ldData : i32
+  %finCtrl = join %stCtrl0, %ldCtrl, %stCtrl1 : none, none, none
+  return %finCtrl : none
+}


### PR DESCRIPTION
Hi, I bumped into the issue #9807, and managed to fix it.

When `lowerExtmemToHW` processes a function with more than one external memref argument, each iteration inserts `addedInPorts` new block arguments and erases the original memref argument. Subsequent iterations weren't taking this into account.