### PR TITLE
[MooreToCore] Lowering convert_real to extf or truncf of arith

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1851,6 +1851,21 @@ struct RealToIntOpConversion : public OpConversionPattern<RealToIntOp> {
   }
 };
 
+struct ConvertRealOpConversion : public OpConversionPattern<ConvertRealOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ConvertRealOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    op.getInput().getType().getWidth() < op.getResult().getType().getWidth()
+        ? rewriter.replaceOpWithNewOp<arith::ExtFOp>(
+              op, typeConverter->convertType(op.getType()), adaptor.getInput())
+        : rewriter.replaceOpWithNewOp<arith::TruncFOp>(
+              op, typeConverter->convertType(op.getType()), adaptor.getInput());
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Statement Conversion
 //===----------------------------------------------------------------------===//
@@ -3003,6 +3018,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     UIntToRealOpConversion,
     IntToStringOpConversion,
     RealToIntOpConversion,
+    ConvertRealOpConversion,
 
     // Patterns of miscellaneous operations.
     ConstantOpConv,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1507,6 +1507,17 @@ func.func @IntToStringConversion(%arg0: !moore.i45) {
   return
 }
 
+// CHECK-LABEL: func.func @ConvertRealOperations
+func.func @ConvertRealOperations(%arg0: !moore.f32, %arg1: !moore.f64) {
+  // CHECK: arith.extf %arg0 : f32 to f64
+  moore.convert_real %arg0 : f32 -> f64
+
+  // CHECK: arith.truncf %arg1 : f64 to f32
+  moore.convert_real %arg1 : f64 -> f32
+  
+  return
+}
+
 // CHECK-LABEL: func.func @StringOperations
 // CHECK-SAME: %arg0: i32
 // CHECK-SAME: %arg1: !sim.dstring


### PR DESCRIPTION
Support lowering the `moore.convert_real` op to the `arith.extf` or `arith.truncf` op based on the type width.