### PR TITLE
[Verif] Support `verif.formal` in CombineAssertLike

### DIFF
--- a/include/circt/Dialect/Verif/Passes.td
+++ b/include/circt/Dialect/Verif/Passes.td
@@ -15,7 +15,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def CombineAssertLikePass : Pass<"combine-assert-like", "hw::HWModuleOp"> {
+def CombineAssertLikePass : Pass<"combine-assert-like"> {
   let summary = "Combines all assertions and assumptions into single operations";
   let description = [{
     Combines all assertions and assumptions by conjoining their conditions into a

--- a/lib/Dialect/Verif/Transforms/CombineAssertLike.cpp
+++ b/lib/Dialect/Verif/Transforms/CombineAssertLike.cpp
@@ -56,6 +56,12 @@ namespace {
 /// Most of the logic here will be to handle splitting things into blocks
 struct CombineAssertLikePass
     : verif::impl::CombineAssertLikePassBase<CombineAssertLikePass> {
+
+  /// Only allow scheduling on verif::FormalOp and hw::HWModuleOp
+  bool canScheduleOn(RegisteredOperationName opInfo) const override {
+    return opInfo.getStringRef() == hw::HWModuleOp::getOperationName() ||
+           opInfo.getStringRef() == verif::FormalOp::getOperationName();
+  }
   void runOnOperation() override;
 
 private:
@@ -166,13 +172,13 @@ private:
 } // namespace
 
 void CombineAssertLikePass::runOnOperation() {
-  hw::HWModuleOp hwModule = getOperation();
-  OpBuilder builder(hwModule);
+  Operation *module = getOperation();
+  OpBuilder builder(module);
 
   // Walk over all assert-like ops and accumulate their conditions
   // then create a new comb.and op or two for assertions and
   // assumptions to conjoin their respective accumulated conditions.
-  hwModule.walk([&](Operation *op) {
+  module->walk([&](Operation *op) {
     // Only consider assertions and assumptions, not cover ops
     if (auto aop = dyn_cast<verif::AssertOp>(op))
       if (failed(accumulateCondition(aop, assertConditions, assertsToErase,

--- a/test/Dialect/Verif/combine-assert-like.mlir
+++ b/test/Dialect/Verif/combine-assert-like.mlir
@@ -1,4 +1,5 @@
-// RUN: circt-opt --combine-assert-like %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(any(combine-assert-like))' --split-input-file %s | FileCheck %s
+
 
 // CHECK-LABEL: hw.module @ManyAssumes
 // CHECK-NEXT:   [[TMP0:%.+]] = comb.add bin %a, %b : i42
@@ -99,6 +100,51 @@ hw.module @ManyAssertsAndAssumesWithEnable(in %a: i42, in %en: i1, out z: i42) {
   verif.assert %6 if %en : i1
   hw.output %0 : i42
 }
+
+//------
+
+// CHECK-LABEL: verif.formal @formal
+// CHECK-NEXT:   %a = verif.symbolic_value : i42
+// CHECK-NEXT:   %en = verif.symbolic_value : i1
+// CHECK-NEXT:   %c1_i42 = hw.constant 1 : i42
+// CHECK-NEXT:   [[TMP0:%.+]] = comb.shl %a, %c1_i42 : i42
+// CHECK-NEXT:   %c2_i42 = hw.constant 2 : i42
+// CHECK-NEXT:   [[TMP1:%.+]] = comb.icmp ult %a, %c2_i42 : i42
+// CHECK-NEXT:   [[EN0:%.+]] = comb.and [[TMP1]], %en : i1
+// CHECK-NEXT:   %c0_i42 = hw.constant 0 : i42
+// CHECK-NEXT:   [[TMP2:%.+]] = comb.icmp uge %a, %c0_i42 : i42
+// CHECK-NEXT:   [[EN1:%.+]] = comb.and [[TMP2]], %en : i1
+// CHECK-NEXT:   [[REQ:%.+]] = comb.and [[EN0]], [[EN1]] : i1
+// CHECK-NEXT:   verif.assume [[REQ]] : i1
+// CHECK-NEXT:   [[TMP3:%.+]] = comb.mul %a, %c2_i42 : i42
+// CHECK-NEXT:   [[TMP4:%.+]] = comb.icmp eq [[TMP0]], [[TMP3]] : i42
+// CHECK-NEXT:   [[EN2:%.+]] = comb.and [[TMP4]], %en : i1
+// CHECK-NEXT:   [[TMP5:%.+]] = comb.add %a, %a : i42
+// CHECK-NEXT:   [[TMP6:%.+]] = comb.icmp eq [[TMP0]], [[TMP5]] : i42
+// CHECK-NEXT:   [[EN3:%.+]] = comb.and [[TMP6]], %en : i1
+// CHECK-NEXT:   [[ENS:%.+]] = comb.and [[EN2]], [[EN3]] : i1
+// CHECK-NEXT:   verif.assert [[ENS]] : i1
+// CHECK-NEXT: }
+
+verif.formal @formal {} {
+  %a = verif.symbolic_value : i42
+  %en = verif.symbolic_value : i1
+  %c1_i42 = hw.constant 1 : i42
+  %0 = comb.shl %a, %c1_i42 : i42
+  %c2_i42 = hw.constant 2 : i42
+  %1 = comb.icmp ult %a, %c2_i42 : i42
+  verif.assume %1 if %en : i1
+  %c0_i42 = hw.constant 0 : i42
+  %2 = comb.icmp uge %a, %c0_i42 : i42
+  verif.assume %2 if %en: i1
+  %3 = comb.mul %a, %c2_i42 : i42
+  %4 = comb.icmp eq %0, %3 : i42
+  verif.assert %4 if %en : i1
+  %5 = comb.add %a, %a : i42
+  %6 = comb.icmp eq %0, %5 : i42
+  verif.assert %6 if %en : i1
+}
+
 
 //------
 


### PR DESCRIPTION
CombineAssertLike should be able to run on `hw::HWModuleOp` *and* `verif::FormalOp`. This PR adds that support.