### PR TITLE
[HWFlattenModules] Add support for `verif.formal` parent ops. 

### DIFF
--- a/lib/Dialect/HW/Transforms/FlattenModules.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenModules.cpp
@@ -11,6 +11,7 @@
 #include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Verif/VerifOps.h"
 #include "circt/Support/BackedgeBuilder.h"
 #include "mlir/IR/AttrTypeSubElements.h"
 #include "mlir/IR/Builders.h"
@@ -60,7 +61,7 @@ private:
 struct PrefixingInliner : public InlinerInterface {
   StringRef prefix;
   InnerSymbolNamespace *ns;
-  HWModuleOp parentModule;
+  Operation *parentModule;
   HWModuleOp sourceModule;
   DenseMap<StringAttr, StringAttr> *symMapping;
   mlir::AttrTypeReplacer *replacer;
@@ -68,7 +69,7 @@ struct PrefixingInliner : public InlinerInterface {
   hw::InnerRefAttr instanceRef;
 
   PrefixingInliner(MLIRContext *context, StringRef prefix,
-                   InnerSymbolNamespace *ns, HWModuleOp parentModule,
+                   InnerSymbolNamespace *ns, Operation *parentModule,
                    HWModuleOp sourceModule,
                    DenseMap<StringAttr, StringAttr> *symMapping,
                    mlir::AttrTypeReplacer *replacer, HierPathTable *pathsTable,
@@ -225,7 +226,7 @@ void FlattenModulesPass::runOnOperation() {
 
   // Cache InnerSymbolNamespace objects per parent module to avoid
   // recreating them for each instance in the same parent.
-  DenseMap<HWModuleOp, std::unique_ptr<InnerSymbolNamespace>> nsCache;
+  DenseMap<Operation *, std::unique_ptr<InnerSymbolNamespace>> nsCache;
 
   // Iterate over all instances in the instance graph. This ensures we visit
   // every module, even private top modules (private and never instantiated).
@@ -281,8 +282,9 @@ void FlattenModulesPass::runOnOperation() {
 
         bool isLastModuleUse = --numUsesLeft == 0;
 
-        // Get the parent module
-        HWModuleOp parentModule = inst->getParentOfType<HWModuleOp>();
+        // Get the parent module, only accept hw::HWModuleOp or verif::FormalOp
+        Operation *parentModule =
+            inst->getParentOfType<hw::HWModuleOp, verif::FormalOp>();
 
         // Get or create the InnerSymbolNamespace for the parent module
         auto &nsPtr = nsCache[parentModule];
@@ -307,8 +309,16 @@ void FlattenModulesPass::runOnOperation() {
               if (it == oldToNewInnerSyms.end())
                 return {attr, WalkResult::skip()};
 
-              auto newAttr = InnerRefAttr::get(parentModule.getModuleNameAttr(),
-                                               it->second);
+              InnerRefAttr newAttr;
+              // Extract module name if hw.module
+              if (auto hwmodule = dyn_cast<hw::HWModuleOp>(parentModule))
+                newAttr =
+                    InnerRefAttr::get(hwmodule.getModuleNameAttr(), it->second);
+              // Use symbol name if it's a verif.formal
+              else if (auto formal = dyn_cast<verif::FormalOp>(parentModule))
+                newAttr =
+                    InnerRefAttr::get(formal.getSymNameAttr(), it->second);
+
               return {newAttr, WalkResult::skip()};
             });
 

--- a/test/Dialect/HW/hw-inliner.mlir
+++ b/test/Dialect/HW/hw-inliner.mlir
@@ -262,3 +262,31 @@ hw.module private @DontInlineModuleNLA(in %a: i4, out b: i4) {
   hw.output %0 : i4
 }
 
+// Test inlining where parent is verif.formal
+// CHECK-LABEL: verif.formal @InlineToFormal
+verif.formal @InlineToFormal {} {
+  // CHECK: %x = verif.symbolic_value : i4
+  // CHECK-NOT: hw.instance
+  // CHECK-NEXT: %[[V0:.+]] = comb.add %x, %x : i4
+  // CHECK-NEXT: %[[V1:.+]] = comb.mul %[[V0]], %[[V0]]
+  // CHECK-NEXT: %[[COND:.+]] = comb.icmp bin eq %[[V1]], %x : i4
+  // CHECK-NEXT: verif.assert %[[COND]] : i1
+  %x = verif.symbolic_value: i4
+  %0 = hw.instance "outer" @OuterModule0(a: %x: i4) -> (b: i4)
+  %cond = comb.icmp bin eq %0, %x : i4
+  verif.assert %cond : i1
+}
+
+// CHECK-NOT: hw.module private @OuterModule
+hw.module private @OuterModule0(in %a: i4, out b: i4) {
+  %0 = hw.instance "inner" @InnerModule0(x: %a: i4) -> (y: i4)
+  hw.output %0 : i4
+}
+// CHECK-NOT: hw.module private @InnerModule
+hw.module private @InnerModule0(in %x: i4, out y: i4) {
+  %0 = comb.add %x, %x : i4
+  %1 = comb.mul %0, %0 : i4
+  hw.output %1 : i4
+}
+
+

--- a/unittests/Dialect/HW/CMakeLists.txt
+++ b/unittests/Dialect/HW/CMakeLists.txt
@@ -9,5 +9,6 @@ add_circt_unittest(CIRCTHWTests
 target_link_libraries(CIRCTHWTests
   PRIVATE
   CIRCTHW
+  CIRCTVerif #Instance graphs can contain verif::FormalOp
   CIRCTCAPIHW
 )


### PR DESCRIPTION
This is my attempt at adding support for having `verif.formal` be the parent of an instance to inline. 
This currently still doesn't do anything for some reason (but doesn't break the pass).
Any help or ideas are appreciated, particularly if @fabianschuiki has an idea, since I think this is originally your code.