### PR TITLE
[LLHD] Don't promote signals with non-integer types in Mem2Reg

### DIFF
--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -824,6 +824,14 @@ void Promoter::findPromotableSlots() {
           }))
         continue;
 
+      // Mem2Reg needs to be able to materialize integer constants for promoted
+      // slots, which requires the bit width to fit in an IntegerType. Skip
+      // signals that are too wide.
+      auto bitWidth = hw::getBitWidth(getStoredType(operand));
+      if (bitWidth < 0 ||
+          static_cast<unsigned>(bitWidth) > IntegerType::kMaxWidth)
+        continue;
+
       slots.push_back(operand);
     }
   });

--- a/test/Dialect/LLHD/Transforms/mem2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/mem2reg.mlir
@@ -1156,3 +1156,42 @@ hw.module @CaptureNonProbeValuesAcrossWait(in %a: i42, in %b: i42) {
     llhd.halt
   }
 }
+
+// Don't try to promote signals with types that have no fixed bit width (such as
+// f64) or that exceed MLIR's IntegerType width limit, since Mem2Reg needs to
+// create integer constants for default values of promoted slots.
+// CHECK-LABEL: @RealSignalNotPromoted
+hw.module @RealSignalNotPromoted(in %clk : i1, in %a : f64, in %b : f64) {
+  %0 = llhd.constant_time <0ns, 0d, 1e>
+  // CHECK: %r = llhd.sig %b : f64
+  %r = llhd.sig %b : f64
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    llhd.wait (%clk : i1), ^bb2
+  ^bb2:
+    // CHECK: llhd.drv %r, %a after
+    llhd.drv %r, %a after %0 : f64
+    cf.br ^bb1
+  }
+}
+
+// CHECK-LABEL: @TooWideSignalNotPromoted
+hw.module @TooWideSignalNotPromoted(
+  in %clk : i1,
+  in %a : !hw.array<2097153xi8>,
+  in %b : !hw.array<2097153xi8>
+) {
+  %0 = llhd.constant_time <0ns, 0d, 1e>
+  // CHECK: %r = llhd.sig %b : !hw.array<2097153xi8>
+  %r = llhd.sig %b : !hw.array<2097153xi8>
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    llhd.wait (%clk : i1), ^bb2
+  ^bb2:
+    // CHECK: llhd.drv %r, %a after
+    llhd.drv %r, %a after %0 : !hw.array<2097153xi8>
+    cf.br ^bb1
+  }
+}


### PR DESCRIPTION
Mem2Reg creates integer constants as default values for uninitialized signal slots, using `hw::getBitWidth` to determine the width. For types like `f64` (from Verilog `real`), `getBitWidth` returns -1, which when cast to unsigned becomes ~4 billion, exceeding MLIR's IntegerType width limit of 16M bits and causing an assertion failure. Similarly, very large array signals can exceed the IntegerType width limit directly.

Skip promoting signals whose stored type has no valid bit width or exceeds IntegerType::kMaxWidth. These signals remain as-is in the IR.