### PR TITLE
[Sim] Fix null dereference in StringConcatOp::fold

### DIFF
--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -538,10 +538,10 @@ OpFoldResult StringConcatOp::fold(FoldAdaptor adaptor) {
 
   SmallString<128> result;
   for (auto &operand : operands) {
-    if (auto strAttr = cast<StringAttr>(operand))
-      result += strAttr.getValue();
-    else
+    auto strAttr = cast_if_present<StringAttr>(operand);
+    if (!strAttr)
       return {};
+    result += strAttr.getValue();
   }
 
   return StringAttr::get(getContext(), result);

--- a/test/Dialect/Sim/dynamic-strings.mlir
+++ b/test/Dialect/Sim/dynamic-strings.mlir
@@ -55,6 +55,15 @@ hw.module @string_concat_multiple_literals(out res: !sim.dstring) {
   hw.output %concat : !sim.dstring
 }
 
+// Concat with a non-constant operand should not crash during folding.
+// CHECK-LABEL: hw.module @string_concat_non_constant
+// CHECK: sim.string.concat
+hw.module @string_concat_non_constant(in %s: !sim.dstring, out res: !sim.dstring) {
+  %str = sim.string.literal "Hello"
+  %concat = sim.string.concat (%str, %s)
+  hw.output %concat : !sim.dstring
+}
+
 // CHECK-LABEL: hw.module @convert_int_to_string_0
 // CHECK: sim.string.literal "Test"
 hw.module @convert_int_to_string_0(out res: !sim.dstring) {


### PR DESCRIPTION
The fold method used `cast<StringAttr>(operand)` which crashes when the operand attribute is null (i.e., the operand is not a constant). Use `cast_if_present` to handle null gracefully while still asserting the type is correct for non-null attributes.