### PR TITLE
[ESI][Runtime] Include "verilated_random.cpp" if available

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/simulator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/simulator.py
@@ -216,16 +216,18 @@ class Simulator:
       if isinstance(ret, int) and ret != 0:
         print("====== Compilation failure")
 
-        # If we have the default file loggers, print the compilation logs to
-        # console. Else, assume that the user has already captured them.
-        if self.UsesStderr:
-          if self._compile_stderr_log is not None:
-            self._compile_stderr_log.seek(0)
-            print(self._compile_stderr_log.read())
-        else:
-          if self._compile_stdout_log is not None:
-            self._compile_stdout_log.seek(0)
-            print(self._compile_stdout_log.read())
+        # Always print both stdout and stderr so that linker errors (which go
+        # to stdout for cmake/ninja) are not silently hidden.
+        if self._compile_stdout_log is not None:
+          self._compile_stdout_log.seek(0)
+          stdout_content = self._compile_stdout_log.read()
+          if stdout_content:
+            print(stdout_content)
+        if self._compile_stderr_log is not None:
+          self._compile_stderr_log.seek(0)
+          stderr_content = self._compile_stderr_log.read()
+          if stderr_content:
+            print(stderr_content)
 
         return ret
     return 0

--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
@@ -168,6 +168,10 @@ class Verilator(Simulator):
       runtime_sources.append(include_dir / "verilated_dpi.cpp")
     if self.debug:
       runtime_sources.append(include_dir / "verilated_fst_c.cpp")
+    # Include constrained-randomization runtime when available (Verilator 5.x+).
+    random_cpp = include_dir / "verilated_random.cpp"
+    if random_cpp.exists():
+      runtime_sources.append(random_cpp)
 
     rt_src = "\n  ".join(str(s) for s in runtime_sources)
     driver = str(Verilator.DefaultDriver)


### PR DESCRIPTION
Some verilator C++ compilations require this file or else linking fails. This linking error was being silently hidden, so change the logging.