### PR TITLE
[ImportVerilog] Fix crash on repeat loop with real count

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -580,7 +580,8 @@ struct StmtVisitor {
 
   // Handle `repeat` loops.
   LogicalResult visit(const slang::ast::RepeatLoopStatement &stmt) {
-    auto count = context.convertRvalueExpression(stmt.count);
+    auto intType = moore::IntType::getInt(context.getContext(), 32);
+    auto count = context.convertRvalueExpression(stmt.count, intType);
     if (!count)
       return failure();
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -618,6 +618,17 @@ function void RepeatLoopStatements(int x, bit y);
   // CHECK: ^[[BB_EXIT]]:
 endfunction
 
+// CHECK-LABEL: func.func private @RepeatLoopWithReal(
+// CHECK-SAME: %arg0: !moore.f64
+function void RepeatLoopWithReal(real x);
+  // CHECK: [[CONV:%.+]] = moore.real_to_int %arg0 : f64 -> i32
+  // CHECK: cf.br ^[[BB_CHECK:.+]]([[CONV]] : !moore.i32)
+  repeat (x) begin
+    // CHECK: ^[[BB_CHECK]]
+    dummyA();
+  end
+endfunction
+
 // CHECK-LABEL: moore.module @Statements
 module Statements(
   // CHECK-SAME: out out0 : !moore.l256


### PR DESCRIPTION
The `repeat` loop handler used `cast<moore::IntType>(count.getType())` to create a decrement constant, which crashes when the count expression is a real type (e.g., `repeat (10.4)`). In SystemVerilog, the repeat count is treated as a non-negative integer, so convert the count expression to `i32` using the `requiredType` parameter of `convertRvalueExpression`, which handles the real-to-int conversion.