### PR TITLE
[ImportVerilog] Fix crash on continuous assign with rise/fall delay

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -682,14 +682,16 @@ struct ModuleVisitor : public BaseVisitor {
 
     // Handle delayed assignments.
     if (auto *timingCtrl = assignNode.getDelay()) {
-      auto *ctrl = timingCtrl->as_if<slang::ast::DelayControl>();
-      assert(ctrl && "slang guarantees this to be a simple delay");
-      auto delay = context.convertRvalueExpression(
-          ctrl->expr, moore::TimeType::get(builder.getContext()));
-      if (!delay)
-        return failure();
-      moore::DelayedContinuousAssignOp::create(builder, loc, lhs, rhs, delay);
-      return success();
+      if (auto *ctrl = timingCtrl->as_if<slang::ast::DelayControl>()) {
+        auto delay = context.convertRvalueExpression(
+            ctrl->expr, moore::TimeType::get(builder.getContext()));
+        if (!delay)
+          return failure();
+        moore::DelayedContinuousAssignOp::create(builder, loc, lhs, rhs, delay);
+        return success();
+      }
+      mlir::emitError(loc) << "unsupported delay with rise/fall/turn-off";
+      return failure();
     }
 
     // Otherwise this is a regular assignment.

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -213,6 +213,14 @@ module Foo;
 endmodule
 
 // -----
+module Foo;
+  reg i;
+  wire o;
+  // expected-error @below {{unsupported delay with rise/fall/turn-off}}
+  assign #(1, 2) o = i;
+endmodule
+
+// -----
 function Foo;
   logic [1:0] a;
   // expected-error @below {{unsupported system call `$fwrite`}}


### PR DESCRIPTION
The continuous assignment handler asserted that the timing control is always a simple `DelayControl`, but slang produces a `Delay3Control` for rise/fall/turn-off delay specifications like `assign #(1, 2) o = i`. The `as_if<DelayControl>` returned null, triggering the assertion.

Replace the assertion with a conditional check and emit a proper diagnostic for unsupported Delay3 timing controls.