### PR TITLE
[LLHD] Handle union types in Mem2Reg signal promotion

### DIFF
--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -534,9 +534,12 @@ DeletionKind
 SigStructExtractOp::rewire(const DestructurableMemorySlot &slot,
                            DenseMap<Attribute, MemorySlot> &subslots,
                            OpBuilder &builder, const DataLayout &dataLayout) {
-  auto index =
-      cast<hw::StructType>(cast<RefType>(getInput().getType()).getNestedType())
-          .getFieldIndex(getFieldAttr());
+  auto nestedType = cast<RefType>(getInput().getType()).getNestedType();
+  std::optional<unsigned> index;
+  if (auto structTy = dyn_cast<hw::StructType>(nestedType))
+    index = structTy.getFieldIndex(getFieldAttr());
+  else if (auto unionTy = dyn_cast<hw::UnionType>(nestedType))
+    index = unionTy.getFieldIndex(getFieldAttr());
   assert(index.has_value());
   auto indexAttr = IntegerAttr::get(IndexType::get(getContext()), *index);
   auto it = subslots.find(indexAttr);

--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -593,6 +593,11 @@ static Value unpackProjections(OpBuilder &builder, Value value,
                       op.getLoc(), value, op.getIndex());
                 })
                 .Case<SigStructExtractOp>([&](auto op) {
+                  // SigStructExtractOp is used for both struct and union
+                  // member access; use the appropriate HW extract op.
+                  if (isa<hw::UnionType>(value.getType()))
+                    return builder.createOrFold<hw::UnionExtractOp>(
+                        op.getLoc(), value, op.getFieldAttr());
                   return builder.createOrFold<hw::StructExtractOp>(
                       op.getLoc(), value, op.getFieldAttr());
                 })
@@ -627,6 +632,12 @@ static Value packProjections(OpBuilder &builder, Value value,
                       op.getLoc(), projection.into, op.getIndex(), value);
                 })
                 .Case<SigStructExtractOp>([&](auto op) {
+                  // For unions, creating a new value from a single field
+                  // replaces the entire union (all fields share storage).
+                  if (auto unionTy =
+                          dyn_cast<hw::UnionType>(projection.into.getType()))
+                    return builder.createOrFold<hw::UnionCreateOp>(
+                        op.getLoc(), unionTy, op.getFieldAttr(), value);
                   return builder.createOrFold<hw::StructInjectOp>(
                       op.getLoc(), projection.into, op.getFieldAttr(), value);
                 })

--- a/test/Dialect/LLHD/Transforms/mem2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/mem2reg.mlir
@@ -1015,9 +1015,11 @@ hw.module @CombCreateDynamicInject(in %u: i42, in %v: i10, in %q: i1) {
   }
 }
 
+func.func private @use_i8(%arg0: i8)
 func.func private @use_i42(%arg0: i42)
 func.func private @use_ref_i42(%arg0: !llhd.ref<i42>)
 func.func private @use_array_i42(%arg0: !hw.array<4xi42>)
+func.func private @use_union(%arg0: !hw.union<a: i8, b: i8>)
 
 // Regression test that verifies probe is inserted post use.
 // CHECK-LABEL: ProbePostDef
@@ -1193,5 +1195,45 @@ hw.module @TooWideSignalNotPromoted(
     // CHECK: llhd.drv %r, %a after
     llhd.drv %r, %a after %0 : !hw.array<2097153xi8>
     cf.br ^bb1
+  }
+}
+
+// Promote a signal of union type. The SigStructExtractOp is used for both
+// struct and union member access; Mem2Reg must use the appropriate HW ops
+// for unpacking (union_extract) and packing (union_create).
+// CHECK-LABEL: @UnionSignalPromoted
+hw.module @UnionSignalPromoted(in %u : !hw.union<a: i8, b: i8>, in %v : i8, in %q : i1) {
+  %0 = llhd.constant_time <0ns, 0d, 1e>
+  %c0 = hw.constant 0 : i8
+  %init = hw.bitcast %c0 : (i8) -> !hw.union<a: i8, b: i8>
+  %a = llhd.sig %init : !hw.union<a: i8, b: i8>
+  // CHECK: llhd.process
+  llhd.process {
+    // Drive the whole union, then project a field.
+    // CHECK-NOT: llhd.drv
+    llhd.drv %a, %u after %0 : !hw.union<a: i8, b: i8>
+    // CHECK-NOT: llhd.sig.struct_extract
+    %1 = llhd.sig.struct_extract %a["a"] : <!hw.union<a: i8, b: i8>>
+    // Conditionally drive the field (tests unpack and pack with unions).
+    // CHECK-NOT: llhd.drv
+    // CHECK-NEXT: [[EXT:%.+]] = hw.union_extract %u["a"]
+    // CHECK-NEXT: [[MUX:%.+]] = comb.mux %q, %v, [[EXT]]
+    // CHECK-NEXT: [[INJ:%.+]] = hw.union_create "a", [[MUX]]
+    llhd.drv %1, %v after %0 if %q : i8
+    // Probe the field (the value should be forwarded through the union).
+    // CHECK-NOT: llhd.prb
+    // CHECK-NEXT: [[READFIELD:%.+]] = hw.union_extract [[INJ]]["a"]
+    %2 = llhd.prb %1 : i8
+    // CHECK-NEXT: call @use_i8([[READFIELD]])
+    func.call @use_i8(%2) : (i8) -> ()
+    // Probe the whole union (should see the union_create result).
+    // CHECK-NOT: llhd.prb
+    %3 = llhd.prb %a : !hw.union<a: i8, b: i8>
+    // CHECK-NEXT: call @use_union([[INJ]])
+    func.call @use_union(%3) : (!hw.union<a: i8, b: i8>) -> ()
+    // CHECK-NEXT: llhd.constant_time
+    // CHECK-NEXT: llhd.drv %a, [[INJ]]
+    // CHECK-NEXT: llhd.halt
+    llhd.halt
   }
 }


### PR DESCRIPTION
SigStructExtractOp is used for both struct and union member access. The Mem2Reg pass's unpackProjections and packProjections functions assumed the underlying type was always hw::StructType, creating hw::StructExtractOp and hw::StructInjectOp which assert on union types.

Use hw::UnionExtractOp for unpacking and hw::UnionCreateOp for packing when the underlying type is hw::UnionType. The union "inject" semantic differs from struct: since all union fields share storage, writing a field creates a new union value rather than injecting into an existing one.

Also fix SigStructExtractOp::rewire in LLHDOps.cpp to look up the field index from either StructType or UnionType.