### PR TITLE
[MooreToCore] Fix crash on dynamic array variable conversion

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -948,8 +948,11 @@ struct VariableOpConversion : public OpConversionPattern<VariableOp> {
     // Determine the initial value of the signal.
     Value init = adaptor.getInitial();
     if (!init) {
-      auto elementType = cast<llhd::RefType>(resultType).getNestedType();
-      init = createZeroValue(elementType, loc, rewriter);
+      auto refType = dyn_cast<llhd::RefType>(resultType);
+      if (!refType)
+        return rewriter.notifyMatchFailure(
+            op.getLoc(), "variable type did not convert to llhd::RefType");
+      init = createZeroValue(refType.getNestedType(), loc, rewriter);
       if (!init)
         return failure();
     }

--- a/test/Conversion/MooreToCore/errors.mlir
+++ b/test/Conversion/MooreToCore/errors.mlir
@@ -9,6 +9,14 @@ func.func @invalidType() {
 
 // -----
 
+func.func @dynamicArrayVariable() {
+  // expected-error @below {{failed to legalize operation 'moore.variable'}}
+  %var = moore.variable : <!moore.open_uarray<i32>>
+  return
+}
+
+// -----
+
 func.func @unsupportedOpenArrayCastReftoOpen(%arg0: !moore.ref<i1>) {
   // expected-error @below {{unsupported DPI open-array conversion from '!moore.ref<i1>' to '!moore.open_uarray<i8>'}}
   // expected-error @below {{failed to legalize operation 'moore.conversion'}}


### PR DESCRIPTION
VariableOpConversion unconditionally cast the converted result type to llhd::RefType, but dynamic array variables (open_uarray) convert to LLVM::LLVMPointerType instead. The cast fails with an assertion.

Use dyn_cast and return a match failure when the converted type is not an llhd::RefType, turning the crash into a clean legalization failure.