### PR TITLE
[LLHD] Handle float types in HoistSignals, skip unsupported types

### DIFF
--- a/include/circt/Dialect/LLHD/LLHDPasses.td
+++ b/include/circt/Dialect/LLHD/LLHDPasses.td
@@ -48,6 +48,7 @@ def Mem2RegPass : Pass<"llhd-mem2reg"> {
 
 def HoistSignalsPass : Pass<"llhd-hoist-signals"> {
   let summary = "Hoist probes and promote drives to process results";
+  let dependentDialects = ["mlir::arith::ArithDialect"];
 }
 
 def LowerProcessesPass : Pass<"llhd-lower-processes", "hw::HWModuleOp"> {

--- a/lib/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_circt_dialect_library(CIRCTLLHDTransforms
   CIRCTLLHD
   CIRCTSeq
   MLIRAnalysis
+  MLIRArithDialect
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRIR

--- a/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
+++ b/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
@@ -9,6 +9,7 @@
 #include "circt/Dialect/LLHD/LLHDOps.h"
 #include "circt/Dialect/LLHD/LLHDPasses.h"
 #include "mlir/Analysis/Liveness.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Matchers.h"
@@ -329,6 +330,13 @@ void DriveHoister::findHoistableSlots() {
         }))
       return;
 
+    // Skip slots with types for which we cannot materialize a default
+    // constant (needed when yielding values across wait boundaries).
+    auto sigType = cast<RefType>(slot.getType()).getNestedType();
+    if (!isa<TimeType>(sigType) && !isa<FloatType>(sigType) &&
+        hw::getBitWidth(sigType) < 0)
+      return;
+
     slots.insert(slot);
   });
   LLVM_DEBUG(llvm::dbgs() << "Found " << slots.size()
@@ -536,13 +544,21 @@ void DriveHoister::hoistDrives() {
             slot = ConstantTimeOp::create(builder, processOp.getLoc(), attr);
           return slot;
         })
-        .Case<Type>([&](auto type) {
+        .Case<Type>([&](auto type) -> Value {
           // TODO: This should probably create something like a `llhd.dontcare`.
           if (isa<TimeType>(type)) {
             auto attr = TimeAttr::get(builder.getContext(), 0, "ns", 0, 0);
             auto &slot = materializedConstants[attr];
             if (!slot)
               slot = ConstantTimeOp::create(builder, processOp.getLoc(), attr);
+            return slot;
+          }
+          if (auto floatTy = dyn_cast<FloatType>(type)) {
+            auto attr = FloatAttr::get(floatTy, 0.0);
+            auto &slot = materializedConstants[attr];
+            if (!slot)
+              slot =
+                  arith::ConstantOp::create(builder, processOp.getLoc(), attr);
             return slot;
           }
           auto numBits = hw::getBitWidth(type);

--- a/test/Dialect/LLHD/Transforms/hoist-signals.mlir
+++ b/test/Dialect/LLHD/Transforms/hoist-signals.mlir
@@ -309,6 +309,40 @@ hw.module @DontHoistAcrossSideEffects(in %v0: i42, in %v1: i42, in %v2: i42) {
   }
 }
 
+// Drive a signal of type f64 (Verilog `real`) across a wait boundary. The
+// hoister must be able to materialize a default f64 constant for the yield.
+// CHECK-LABEL: @RealSignalDriveAcrossWait
+hw.module @RealSignalDriveAcrossWait(in %v : f64) {
+  %0 = llhd.constant_time <1ns, 0d, 0e>
+  %cst = arith.constant 0.0 : f64
+  %a = llhd.sig %cst : f64
+  // CHECK: llhd.process -> f64
+  // CHECK: llhd.drv %a
+  llhd.process {
+    llhd.drv %a, %v after %0 : f64
+    llhd.wait delay %0, ^bb1
+  ^bb1:
+    llhd.halt
+  }
+}
+
+// Signals with types that don't have a materializable default constant (like
+// `index`) should not be hoisted. The drives remain inside the process as-is.
+// CHECK-LABEL: @UnsupportedTypeNotHoisted
+hw.module @UnsupportedTypeNotHoisted(in %v : index) {
+  %0 = llhd.constant_time <1ns, 0d, 0e>
+  %c0 = arith.constant 0 : index
+  %a = llhd.sig %c0 : index
+  // CHECK: llhd.process
+  llhd.process {
+    // CHECK: llhd.drv %a, %v after
+    llhd.drv %a, %v after %0 : index
+    llhd.wait delay %0, ^bb1
+  ^bb1:
+    llhd.halt
+  }
+}
+
 func.func private @use_i42(%arg0: i42)
 func.func private @use_inout_i42(%arg0: !llhd.ref<i42>)
 func.func private @maybe_side_effecting()


### PR DESCRIPTION
HoistSignals needs to materialize default constants when yielding drive values across wait boundaries. For float types like f64 (from Verilog `real`), `hw::getBitWidth` returns -1, causing an assertion failure.

Add support for materializing `arith.constant 0.0` for FloatType signals. For types that have no known bit width and aren't TimeType or FloatType (e.g., `index`), skip hoisting that slot entirely instead of crashing, since this is an optimization pass.