### PR TITLE
[LLHD] Skip slots without drive sets in HoistSignals

### DIFF
--- a/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
+++ b/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
@@ -521,6 +521,13 @@ void DriveHoister::finalizeDriveSets() {
 void DriveHoister::hoistDrives() {
   if (driveSets.empty())
     return;
+
+  // Remove slots that have no collected drive set. This can happen when a
+  // signal is driven only in blocks that don't end with a wait/halt terminator.
+  slots.remove_if([&](auto slot) { return !driveSets.count(slot); });
+  if (slots.empty())
+    return;
+
   LLVM_DEBUG(llvm::dbgs() << "Hoisting drives of " << driveSets.size()
                           << " slots\n");
 

--- a/test/Dialect/LLHD/Transforms/hoist-signals.mlir
+++ b/test/Dialect/LLHD/Transforms/hoist-signals.mlir
@@ -343,6 +343,32 @@ hw.module @UnsupportedTypeNotHoisted(in %v : index) {
   }
 }
 
+// A signal driven only in non-halt/wait blocks should not be hoisted, even
+// when other signals in the same process are hoistable. The drive collection
+// only considers blocks with halt/wait terminators, so the first signal ends
+// up without a drive set entry and must be skipped.
+// CHECK-LABEL: @DriveOnlyInNonSuspendBlock
+hw.module @DriveOnlyInNonSuspendBlock(in %v : f64, in %w : i42, in %c : i1) {
+  %0 = llhd.constant_time <0ns, 0d, 1e>
+  %cst = arith.constant 0.0 : f64
+  %c0 = hw.constant 0 : i42
+  %a = llhd.sig %cst : f64
+  %b = llhd.sig %c0 : i42
+  // CHECK: llhd.process
+  llhd.process {
+    // This f64 drive is only in ^bb0 (ends with cond_br, not halt/wait).
+    // CHECK: llhd.drv %a, %v after
+    llhd.drv %a, %v after %0 : f64
+    cf.cond_br %c, ^bb1, ^bb2
+  ^bb1:
+    cf.br ^bb2
+  ^bb2:
+    // This i42 drive IS in the halt block, so it gets hoisted.
+    llhd.drv %b, %w after %0 : i42
+    llhd.halt
+  }
+}
+
 func.func private @use_i42(%arg0: i42)
 func.func private @use_inout_i42(%arg0: !llhd.ref<i42>)
 func.func private @maybe_side_effecting()


### PR DESCRIPTION
findHoistableSlots adds a signal to the slot list when it sees any DriveOp targeting it. But collectDriveSets only records drives from blocks ending with wait/halt terminators. If a signal is only driven in non-suspend blocks (e.g., branching blocks ending with cond_br), it ends up in slots without a corresponding driveSets entry.

hoistDrives then creates an empty DriveSet via operator[], and the subsequent lookup of drive operands returns a default (null) DriveValue whose PointerUnion is not "present", causing a dyn_cast assertion failure.

Filter out slots with no drive set entry at the top of hoistDrives.