### PR TITLE
[MooreToCore] Fix crash on class new with unsupported member types

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -890,6 +890,17 @@ struct ClassNewOpConversion : public OpConversionPattern<ClassNewOp> {
 
     auto structTy = cache.getStructInfo(sym)->classBody;
 
+    // Check that all struct members have data layout support. Types like
+    // !sim.dstring or !sim.queue don't have a known size, which would cause
+    // a fatal error in DataLayout::getTypeSize below.
+    for (auto memberTy : structTy.getBody()) {
+      if (!LLVM::isCompatibleType(memberTy) &&
+          !memberTy.hasTrait<DataLayoutTypeInterface::Trait>()) {
+        return op.emitError()
+               << "class struct has member types with no data layout";
+      }
+    }
+
     DataLayout dl(mod);
     // DataLayout::getTypeSize gives a byte count for LLVM types.
     uint64_t byteSize = dl.getTypeSize(structTy);

--- a/test/Conversion/MooreToCore/errors.mlir
+++ b/test/Conversion/MooreToCore/errors.mlir
@@ -68,3 +68,16 @@ moore.module @MixedPortsWithUnsupported(in %valid : !moore.l1, in %data : !moore
 }
 
 // -----
+
+moore.class.classdecl @ClassWithString {
+  moore.class.propertydecl @text : !moore.string
+}
+
+func.func @classNewWithString() {
+  // expected-error @below {{class struct has member types with no data layout}}
+  // expected-error @below {{failed to legalize operation 'moore.class.new'}}
+  %h = moore.class.new : <@ClassWithString>
+  return
+}
+
+// -----


### PR DESCRIPTION
ClassNewOpConversion calls DataLayout::getTypeSize on the class's LLVM struct type, which triggers a fatal error if any struct member lacks data layout support (e.g., !sim.dstring for string properties, or !sim.queue for queue properties).

Check that all struct members are LLVM-compatible or implement DataLayoutTypeInterface before querying the data layout. Emit a proper error diagnostic instead of crashing.