### PR TITLE
[LLHD] Don't promote signals with cross-block nested projections

### DIFF
--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -812,11 +812,19 @@ void Promoter::findPromotableSlots() {
         // Ignore uses outside of the region.
         if (user->getParentRegion() != &region)
           return true;
-        // Projection operations are okay.
+        // Projection operations are okay, as long as nested projections
+        // stay in the same block. Cross-block nested projections would break
+        // during promotion because the projection chain gets severed when
+        // Mem2Reg rewrites signal references into SSA block arguments.
         if (isa<SigArrayGetOp, SigExtractOp, SigStructExtractOp>(user)) {
-          for (auto *projectionUser : user->getUsers())
+          for (auto *projectionUser : user->getUsers()) {
+            if (isa<SigArrayGetOp, SigExtractOp, SigStructExtractOp>(
+                    projectionUser) &&
+                projectionUser->getBlock() != user->getBlock())
+              return false;
             if (checkedUsers.insert(projectionUser).second)
               userWorklist.push_back(projectionUser);
+          }
           projections.insert({user->getResult(0), operand});
           return true;
         }

--- a/test/Dialect/LLHD/Transforms/mem2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/mem2reg.mlir
@@ -1237,3 +1237,30 @@ hw.module @UnionSignalPromoted(in %u : !hw.union<a: i8, b: i8>, in %v : i8, in %
     llhd.halt
   }
 }
+
+// Don't promote a signal if a projection op (like sig.array_get) has a nested
+// projection user (like sig.extract) in a different block. Mem2Reg rewrites
+// signal references across block boundaries and would break the projection
+// chain, causing getProjections to encounter a BlockArgument.
+// CHECK-LABEL: @NestedProjectionAcrossBlocks
+hw.module @NestedProjectionAcrossBlocks(in %v : i4) {
+  %t = llhd.constant_time <0ns, 0d, 1e>
+  %d = llhd.constant_time <1ns, 0d, 0e>
+  %true = hw.constant true
+  %c0 = hw.constant 0 : i8
+  %c4 = hw.constant -4 : i3
+  %init = hw.aggregate_constant [0 : i8, 0 : i8] : !hw.array<2xi8>
+  // CHECK: %mem = llhd.sig
+  %mem = llhd.sig %init : !hw.array<2xi8>
+  llhd.process {
+    %e = llhd.sig.array_get %mem[%true] : <!hw.array<2xi8>>
+    llhd.drv %e, %c0 after %t : i8
+    llhd.wait delay %d, ^bb1
+  ^bb1:
+    // This sig.extract is a nested projection of %e, but in a different block.
+    // CHECK: llhd.sig.extract
+    %sub = llhd.sig.extract %e from %c4 : <i8> -> <i4>
+    llhd.drv %sub, %v after %t : i4
+    llhd.halt
+  }
+}


### PR DESCRIPTION
When a projection op like sig.array_get is in one block and a nested projection op like sig.extract on its result is in a different block, Mem2Reg's promotion breaks the projection chain. The promotion rewrites signal references into SSA block arguments, but getProjections expects to trace back from the nested projection to the slot through OpResults only. After promotion, the intermediate projection's input becomes a block argument, causing a cast<OpResult> assertion failure.

Reject such slots during findPromotableSlots by checking that nested projection users are in the same block as their parent projection.