### PR TITLE
[LLHD] Don't promote signals with projections and mixed drive delays

### DIFF
--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -805,6 +805,9 @@ void Promoter::findPromotableSlots() {
         continue;
 
       // Ensure the slot is not used in any way we cannot reason about.
+      bool hasProjection = false;
+      bool hasBlockingDrive = false;
+      bool hasDeltaDrive = false;
       auto checkUser = [&](Operation *user) -> bool {
         // We don't support nested probes and drives.
         if (region.isProperAncestor(user->getParentRegion()))
@@ -817,17 +820,22 @@ void Promoter::findPromotableSlots() {
         // during promotion because the projection chain gets severed when
         // Mem2Reg rewrites signal references into SSA block arguments.
         if (isa<SigArrayGetOp, SigExtractOp, SigStructExtractOp>(user)) {
+          hasProjection = true;
           for (auto *projectionUser : user->getUsers()) {
             if (isa<SigArrayGetOp, SigExtractOp, SigStructExtractOp>(
                     projectionUser) &&
                 projectionUser->getBlock() != user->getBlock())
               return false;
+            hasBlockingDrive |= isBlockingDrive(projectionUser);
+            hasDeltaDrive |= isDeltaDrive(projectionUser);
             if (checkedUsers.insert(projectionUser).second)
               userWorklist.push_back(projectionUser);
           }
           projections.insert({user->getResult(0), operand});
           return true;
         }
+        hasBlockingDrive |= isBlockingDrive(user);
+        hasDeltaDrive |= isDeltaDrive(user);
         return isa<ProbeOp>(user) || isBlockingDrive(user) ||
                isDeltaDrive(user);
       };
@@ -841,6 +849,12 @@ void Promoter::findPromotableSlots() {
             userWorklist.clear();
             return allOk;
           }))
+        continue;
+
+      // Don't promote slots that have projections and a mix of blocking and
+      // delta drives. A blocking drive erases the delayed reaching definition,
+      // which leaves delta projection drives without a reaching definition.
+      if (hasProjection && hasBlockingDrive && hasDeltaDrive)
         continue;
 
       // Mem2Reg needs to be able to materialize integer constants for promoted

--- a/test/Dialect/LLHD/Transforms/mem2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/mem2reg.mlir
@@ -1264,3 +1264,26 @@ hw.module @NestedProjectionAcrossBlocks(in %v : i4) {
     llhd.halt
   }
 }
+
+// Don't promote a signal if a projection has multiple drives with different
+// delays. Mem2Reg splits blocking and delta drives into separate slot tracking,
+// but the reaching definition analysis doesn't handle this correctly for
+// projections, causing a "no definition reaches drive" assertion.
+// CHECK-LABEL: @MultiDelayProjectionDrive
+hw.module @MultiDelayProjectionDrive() {
+  %t_eps = llhd.constant_time <0ns, 0d, 1e>
+  %t_delta = llhd.constant_time <0ns, 1d, 0e>
+  %c0 = hw.constant 0 : i8
+  %true = hw.constant true
+  %init = hw.aggregate_constant [0 : i8, 0 : i8] : !hw.array<2xi8>
+  // CHECK: %sig = llhd.sig
+  %sig = llhd.sig %init : !hw.array<2xi8>
+  llhd.process {
+    %e = llhd.sig.array_get %sig[%true] : <!hw.array<2xi8>>
+    // CHECK: llhd.drv
+    llhd.drv %e, %c0 after %t_eps : i8
+    // CHECK: llhd.drv
+    llhd.drv %e, %c0 after %t_delta : i8
+    llhd.halt
+  }
+}


### PR DESCRIPTION
When a signal has projections (sig.array_get, sig.extract, sig.struct_extract) and is driven with both blocking (epsilon) and delta delays, the Mem2Reg reaching definition analysis fails. A blocking drive erases the delayed reaching definition for the slot, but subsequent delta drives to projections need that definition to inject their value into the aggregate. This leaves the delta projection drives without a reaching definition, triggering an assertion.

Skip promoting such slots entirely. This is a conservative check that avoids the crash while deferring a more precise fix to the reaching definition framework.