### PR TITLE
[InstanceGraph] Relax assertion condition

### DIFF
--- a/lib/Support/InstanceGraph.cpp
+++ b/lib/Support/InstanceGraph.cpp
@@ -226,7 +226,7 @@ InstanceGraph::getInferredTopLevelNodes() {
     err << ").";
     return err;
   }
-  assert(!candidateTopLevels.empty() &&
+  assert((visited.empty() || !candidateTopLevels.empty()) &&
          "if non-cyclic, there should be at least 1 candidate top level");
 
   inferredTopLevelNodes = llvm::SmallVector<InstanceGraphNode *>(

--- a/test/Dialect/SV/sv-trace-iverilog-errors.mlir
+++ b/test/Dialect/SV/sv-trace-iverilog-errors.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt --sv-trace-iverilog %s -verify-diagnostics 
+
+// Issue 9375
+// expected-error@+1 {{Expected exactly one top level node}}
+builtin.module {
+  func.func @top () {
+      func.return
+  }
+}


### PR DESCRIPTION
Fix issue #9375. Fix `getInferredTopLevelNodes` not to fail for empty instance graph. 