### PR TITLE
[Synth] Extend functional reduction SAT support to OR/XOR/MIG

### DIFF
--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -1,6 +1,9 @@
-// REQUIRES: z3-integration
-// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(synth-functional-reduction{num-random-patterns=64}))' | FileCheck %s
+// REQUIRES: z3-integration, libz3
+// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(synth-functional-reduction{num-random-patterns=64}))' -o %t.mlir
+// RUN: cat %t.mlir | FileCheck %s
 
+// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_sat --c2 functional_reduction_sat | FileCheck %s --check-prefix=BASIC
+// BASIC: c1 == c2
 // SAT should prove that AND(AND(a, not b), AND(c, not d)) is equivalent to
 // AND(a, not b, c, not d), and the pass should materialize that with a choice.
 // CHECK-LABEL: hw.module @functional_reduction_sat
@@ -19,4 +22,38 @@ hw.module @functional_reduction_sat(in %a: i1, in %b: i1, in %c: i1, in %d: i1,
   %3 = synth.aig.and_inv %a, not %b, %c, not %d : i1
   %4 = synth.aig.and_inv %a, not %b, not %c, not %d : i1
   hw.output %2, %3, %4 : i1, i1, i1
+}
+
+// SAT should also prove equivalence across the newly supported comb and MIG
+// nodes.
+// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_supported_ops_sat --c2 functional_reduction_supported_ops_sat | FileCheck %s --check-prefix=MIXED
+// MIXED: c1 == c2
+// CHECK-LABEL: hw.module @functional_reduction_supported_ops_sat
+hw.module @functional_reduction_supported_ops_sat(
+    in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1,
+    out out0: i1, out out1: i1, out out2: i1, out out3: i1,
+    out out4: i1, out out5: i1, out out6: i1, out out7: i1,
+    out out8: i1, out out9: i1) {
+  // CHECK: hw.output %[[ORCHOICE:.+]], %[[ORCHOICE]],
+  // CHECK-SAME:      %[[ANDCHOICE:.+]], %[[ANDCHOICE]],
+  // CHECK-SAME:      %[[XORCHOICE:.+]], %[[XORCHOICE]],
+  // CHECK-SAME:      %[[MAJCHOICE:.+]], %[[MAJCHOICE]],
+  // CHECK-SAME:      %[[MIG5_CHOICE:.+]], %[[MIG5_CHOICE]]
+  %false = hw.constant false
+  %0 = comb.or %a, %b, %c : i1
+  %1 = comb.or %c, %b, %a : i1
+  %2 = comb.and %a, %b : i1
+  %3 = synth.mig.maj_inv %a, %b, %false : i1
+  %4 = comb.xor %a, %b : i1
+  %5 = comb.xor %b, %a : i1
+  %6 = synth.mig.maj_inv %a, %b, %c : i1
+  %7 = comb.and %c, %4 : i1
+  %8 = comb.or %2, %7 : i1
+  %9 = synth.mig.maj_inv %a, %b, %c, %d, %e : i1
+  %10 = synth.mig.maj_inv %b, %c, %d : i1
+  %11 = synth.mig.maj_inv %b, %d, %e : i1
+  %12 = synth.mig.maj_inv %b, %c, %e : i1
+  %13 = synth.mig.maj_inv %a, %12, %11 : i1
+  %14 = synth.mig.maj_inv %a, %10, %13 : i1
+  hw.output %0, %1, %2, %3, %4, %5, %6, %8, %9, %14 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
 }

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -268,8 +268,8 @@ LogicalResult circt::synth::topologicallySortLogicNetwork(Operation *topOp) {
     // Topologically sort AIG ops, MIG ops, and dataflow ops. Other operations
     // can be scheduled.
     return !(isa<aig::AndInverterOp, mig::MajorityInverterOp>(op) ||
-             isa<comb::XorOp, comb::AndOp, comb::ExtractOp, comb::ReplicateOp,
-                 comb::ConcatOp>(op));
+             isa<comb::XorOp, comb::AndOp, comb::OrOp, comb::ExtractOp,
+                 comb::ReplicateOp, comb::ConcatOp>(op));
   };
 
   if (failed(topologicallySortGraphRegionBlocks(topOp, isOperationReady)))

--- a/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
+++ b/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
@@ -30,6 +30,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -58,19 +59,34 @@ class FunctionalReductionSATBuilder {
 public:
   FunctionalReductionSATBuilder(IncrementalSATSolver &solver,
                                 llvm::DenseMap<Value, int> &satVars,
-                                llvm::DenseSet<Value> &encodedValues);
+                                llvm::DenseSet<Value> &encodedValues,
+                                int &nextFreshVar);
 
   EquivResult verify(Value lhs, Value rhs);
 
 private:
   int getOrCreateVar(Value value);
+  // Create a fresh SAT variable for an intermediate Boolean subexpression that
+  // does not correspond to an MLIR value.
+  int createAuxVar();
+  int getLiteral(Value value, bool inverted = false);
   void addAndClauses(int outVar, llvm::ArrayRef<int> inputLits);
+  void addOrClauses(int outVar, llvm::ArrayRef<int> inputLits);
+  void addXorClauses(int outVar, int lhsLit, int rhsLit);
+  void addParityClauses(int outVar, llvm::ArrayRef<int> inputLits);
+  void addMajorityClauses(int outVar, llvm::ArrayRef<int> inputLits);
   void encodeValue(Value value);
 
   IncrementalSATSolver &solver;
   llvm::DenseMap<Value, int> &satVars;
   llvm::DenseSet<Value> &encodedValues;
+  int &nextFreshVar;
 };
+
+static bool isFunctionalReductionSimulatableOp(Operation *op) {
+  return isa<aig::AndInverterOp, mig::MajorityInverterOp, comb::AndOp,
+             comb::OrOp, comb::XorOp>(op);
+}
 
 EquivResult FunctionalReductionSATBuilder::verify(Value lhs, Value rhs) {
   encodeValue(lhs);
@@ -106,6 +122,17 @@ int FunctionalReductionSATBuilder::getOrCreateVar(Value value) {
   return it->second;
 }
 
+int FunctionalReductionSATBuilder::createAuxVar() {
+  int freshVar = ++nextFreshVar;
+  solver.reserveVars(freshVar);
+  return freshVar;
+}
+
+int FunctionalReductionSATBuilder::getLiteral(Value value, bool inverted) {
+  int lit = getOrCreateVar(value);
+  return inverted ? -lit : lit;
+}
+
 void FunctionalReductionSATBuilder::addAndClauses(
     int outVar, llvm::ArrayRef<int> inputLits) {
   // Tseitin encoding (https://en.wikipedia.org/wiki/Tseytin_transformation)
@@ -119,6 +146,109 @@ void FunctionalReductionSATBuilder::addAndClauses(
     clause.push_back(-lit);
   clause.push_back(outVar);
   solver.addClause(clause);
+}
+
+void FunctionalReductionSATBuilder::addOrClauses(
+    int outVar, llvm::ArrayRef<int> inputLits) {
+  // Encode `outVar <=> or(inputLits)`.
+  //
+  // `(-lit v outVar)` for each input enforces `lit -> outVar`, i.e. any true
+  // input forces the OR result high.
+  for (int lit : inputLits)
+    solver.addClause({-lit, outVar});
+
+  SmallVector<int> clause;
+  clause.reserve(inputLits.size() + 1);
+  // `(-outVar v lit0 v lit1 ...)` enforces `outVar -> (lit0 v lit1 ...)`.
+  // Together these clauses make `outVar` exactly the OR of the inputs.
+  clause.push_back(-outVar);
+  clause.append(inputLits.begin(), inputLits.end());
+  solver.addClause(clause);
+}
+
+void FunctionalReductionSATBuilder::addXorClauses(int outVar, int lhsLit,
+                                                  int rhsLit) {
+  // Encode `outVar <=> (lhsLit xor rhsLit)` with the four satisfying rows of
+  // the 2-input XOR truth table. This is the standard definitional CNF for a
+  // binary XOR.
+  solver.addClause({-lhsLit, -rhsLit, -outVar});
+  solver.addClause({lhsLit, rhsLit, -outVar});
+  solver.addClause({lhsLit, -rhsLit, outVar});
+  solver.addClause({-lhsLit, rhsLit, outVar});
+}
+
+void FunctionalReductionSATBuilder::addParityClauses(
+    int outVar, llvm::ArrayRef<int> inputLits) {
+  assert(!inputLits.empty() && "parity requires at least one input");
+  if (inputLits.size() == 1) {
+    solver.addClause({-outVar, inputLits.front()});
+    solver.addClause({outVar, -inputLits.front()});
+    return;
+  }
+
+  int accumulatedLit = inputLits.front();
+  // Variadic XOR does not have a compact direct CNF encoding like AND/OR, so
+  // encode it as a chain of binary XORs and give each intermediate result its
+  // own auxiliary SAT variable.
+  for (auto [index, lit] : llvm::enumerate(inputLits.drop_front())) {
+    bool isLast = index + 2 == inputLits.size();
+    int outLit = isLast ? outVar : createAuxVar();
+    addXorClauses(outLit, accumulatedLit, lit);
+    accumulatedLit = outLit;
+  }
+}
+
+static void enumerateLiteralSubsets(
+    llvm::ArrayRef<int> inputLits, size_t subsetSize,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> callback) {
+  SmallVector<int> subset;
+  subset.reserve(subsetSize);
+  std::function<void(size_t, size_t)> visit = [&](size_t start,
+                                                  size_t remaining) {
+    if (remaining == 0) {
+      callback(subset);
+      return;
+    }
+    for (size_t i = start; i + remaining <= inputLits.size(); ++i) {
+      subset.push_back(inputLits[i]);
+      visit(i + 1, remaining - 1);
+      subset.pop_back();
+    }
+  };
+  visit(0, subsetSize);
+}
+
+void FunctionalReductionSATBuilder::addMajorityClauses(
+    int outVar, llvm::ArrayRef<int> inputLits) {
+  assert(inputLits.size() % 2 == 1 &&
+         "majority requires an odd number of inputs");
+  size_t threshold = inputLits.size() / 2 + 1;
+
+  // If any threshold-sized subset is all true, the majority output must be
+  // true as well. For 5 inputs, these are all 3-input subsets.
+  enumerateLiteralSubsets(inputLits, threshold,
+                          [&](llvm::ArrayRef<int> subset) {
+                            SmallVector<int> clause;
+                            clause.reserve(subset.size() + 1);
+                            for (int lit : subset)
+                              clause.push_back(-lit);
+                            clause.push_back(outVar);
+                            solver.addClause(clause);
+                          });
+
+  // Conversely, if any threshold-sized subset is all false, the majority
+  // output must be false. Writing that implication in positive-literal form is
+  // equivalent to `outVar ->` not(all literals in the subset are false).
+  // For example with 3-input majority, `(-outVar v a v b)` prevents
+  // `outVar = 1` when both `a` and `b` are 0.
+  enumerateLiteralSubsets(inputLits, threshold,
+                          [&](llvm::ArrayRef<int> subset) {
+                            SmallVector<int> clause;
+                            clause.reserve(subset.size() + 1);
+                            clause.push_back(-outVar);
+                            clause.append(subset.begin(), subset.end());
+                            solver.addClause(clause);
+                          });
 }
 
 void FunctionalReductionSATBuilder::encodeValue(Value value) {
@@ -136,8 +266,15 @@ void FunctionalReductionSATBuilder::encodeValue(Value value) {
       continue;
     }
 
-    auto andOp = dyn_cast<aig::AndInverterOp>(op);
-    if (!andOp) {
+    APInt constantValue;
+    if (matchPattern(current, mlir::m_ConstantInt(&constantValue))) {
+      encodedValues.insert(current);
+      solver.addClause({constantValue.isZero() ? -getOrCreateVar(current)
+                                               : getOrCreateVar(current)});
+      continue;
+    }
+
+    if (!isFunctionalReductionSimulatableOp(op)) {
       // Unsupported operations remain unconstrained, just like block
       // arguments. Since we only prove equivalence from UNSAT, omitting these
       // clauses may miss a proof but cannot create a false proof.
@@ -147,22 +284,50 @@ void FunctionalReductionSATBuilder::encodeValue(Value value) {
 
     if (!readyToEncode) {
       worklist.push_back({current, true});
-      for (auto input : andOp.getInputs())
+      for (auto input : op->getOperands()) {
+        assert(input.getType().isInteger(1) &&
+               "only i1 inputs should be simulated or encoded");
         if (!encodedValues.contains(input))
           worklist.push_back({input, false});
+      }
       continue;
     }
 
     encodedValues.insert(current);
     int outVar = getOrCreateVar(current);
+
     SmallVector<int> inputLits;
-    inputLits.reserve(andOp.getInputs().size());
-    for (auto [input, inverted] :
-         llvm::zip(andOp.getInputs(), andOp.getInverted())) {
-      int lit = getOrCreateVar(input);
-      inputLits.push_back(inverted ? -lit : lit);
-    }
-    addAndClauses(outVar, inputLits);
+    inputLits.reserve(op->getNumOperands());
+    TypeSwitch<Operation *>(op)
+        .Case<aig::AndInverterOp>([&](auto andOp) {
+          for (auto [input, inverted] :
+               llvm::zip(andOp.getInputs(), andOp.getInverted()))
+            inputLits.push_back(getLiteral(input, inverted));
+          addAndClauses(outVar, inputLits);
+        })
+        .Case<mig::MajorityInverterOp>([&](auto majOp) {
+          for (auto [input, inverted] :
+               llvm::zip(majOp.getInputs(), majOp.getInverted()))
+            inputLits.push_back(getLiteral(input, inverted));
+          addMajorityClauses(outVar, inputLits);
+        })
+        .Case<comb::AndOp>([&](auto andOp) {
+          for (auto input : andOp.getInputs())
+            inputLits.push_back(getLiteral(input));
+          addAndClauses(outVar, inputLits);
+        })
+        .Case<comb::OrOp>([&](auto orOp) {
+          for (auto input : orOp.getInputs())
+            inputLits.push_back(getLiteral(input));
+          addOrClauses(outVar, inputLits);
+        })
+        .Case<comb::XorOp>([&](auto xorOp) {
+          for (auto input : xorOp.getInputs())
+            inputLits.push_back(getLiteral(input));
+          addParityClauses(outVar, inputLits);
+        })
+        .Default(
+            [](Operation *) { llvm_unreachable("unexpected supported op"); });
   }
 }
 
@@ -241,13 +406,17 @@ private:
   std::unique_ptr<FunctionalReductionSATBuilder> satBuilder;
   llvm::DenseMap<Value, int> satVars;
   llvm::DenseSet<Value> encodedValues;
+  // Monotonic counter for auxiliary SAT variables introduced by definitional
+  // CNF encodings, currently used for variadic XOR.
+  int nextFreshVar = 0;
   Stats stats;
 };
 
 FunctionalReductionSATBuilder::FunctionalReductionSATBuilder(
     IncrementalSATSolver &solver, llvm::DenseMap<Value, int> &satVars,
-    llvm::DenseSet<Value> &encodedValues)
-    : solver(solver), satVars(satVars), encodedValues(encodedValues) {}
+    llvm::DenseSet<Value> &encodedValues, int &nextFreshVar)
+    : solver(solver), satVars(satVars), encodedValues(encodedValues),
+      nextFreshVar(nextFreshVar) {}
 
 Attribute FunctionalReductionSolver::getTestEquivClass(Value value) {
   Operation *op = value.getDefiningOp();
@@ -282,10 +451,11 @@ void FunctionalReductionSolver::initializeSATState() {
   satVars.reserve(allValues.size());
   for (auto [index, value] : llvm::enumerate(allValues))
     satVars[value] = index + 1;
+  nextFreshVar = allValues.size();
   satSolver->reserveVars(allValues.size());
 
   satBuilder = std::make_unique<FunctionalReductionSATBuilder>(
-      *satSolver, satVars, encodedValues);
+      *satSolver, satVars, encodedValues, nextFreshVar);
 }
 
 //===----------------------------------------------------------------------===//
@@ -310,7 +480,8 @@ void FunctionalReductionSolver::collectValues() {
         continue;
 
       allValues.push_back(result);
-      if (!isa<aig::AndInverterOp>(op)) {
+      if (!op->hasTrait<OpTrait::ConstantLike>() &&
+          !isFunctionalReductionSimulatableOp(op)) {
         // Unknown operations - treat as primary inputs
         primaryInputs.push_back(result);
       }
@@ -360,11 +531,33 @@ llvm::APInt FunctionalReductionSolver::simulateValue(Value v) {
   if (!op)
     return simSignatures.at(v);
   return llvm::TypeSwitch<Operation *, llvm::APInt>(op)
-      .Case<aig::AndInverterOp>([&](auto op) {
+      .Case<mig::MajorityInverterOp, aig::AndInverterOp>([&](auto op) {
         SmallVector<llvm::APInt> inputSigs;
         for (auto input : op.getInputs())
           inputSigs.push_back(simSignatures.at(input));
         return op.evaluate(inputSigs);
+      })
+      .Case<comb::AndOp>([&](auto op) {
+        APInt result = APInt::getAllOnes(numPatterns);
+        for (auto input : op.getInputs())
+          result &= simSignatures.at(input);
+        return result;
+      })
+      .Case<comb::OrOp>([&](auto op) {
+        APInt result = APInt::getZero(numPatterns);
+        for (auto input : op.getInputs())
+          result |= simSignatures.at(input);
+        return result;
+      })
+      .Case<comb::XorOp>([&](auto op) {
+        APInt result = APInt::getZero(numPatterns);
+        for (auto input : op.getInputs())
+          result ^= simSignatures.at(input);
+        return result;
+      })
+      .Case([&](hw::ConstantOp op) {
+        return op.getValue().isZero() ? APInt::getZero(numPatterns)
+                                      : APInt::getAllOnes(numPatterns);
       })
       .Default([&](Operation *) {
         // Unknown operation - treat as input (already assigned a random

--- a/test/Dialect/Synth/functional-reduction.mlir
+++ b/test/Dialect/Synth/functional-reduction.mlir
@@ -17,3 +17,49 @@ hw.module @test_mixed(in %a: i1, in %b: i1, in %c: i1, in %d: i1, out out1: i1, 
   %4 = synth.aig.and_inv %a, not %b, not %c, not %d {synth.test.fc_equiv_class = 1} : i1
   hw.output %2, %3, %4 : i1, i1, i1
 }
+
+// CHECK-LABEL: hw.module @test_supported_ops
+hw.module @test_supported_ops(in %a: i1, in %b: i1, in %c: i1,
+                              out out0: i1, out out1: i1,
+                              out out2: i1, out out3: i1,
+                              out out4: i1, out out5: i1,
+                              out out6: i1, out out7: i1) {
+  // CHECK: %[[FALSE:.+]] = hw.constant false
+  // CHECK: %[[OR0:.+]] = comb.or %a, %b, %c
+  // CHECK: %[[OR1:.+]] = comb.or %c, %b, %a
+  // CHECK-NEXT: %[[ORCHOICE:.+]] = synth.choice %[[OR0]], %[[OR1]] : i1
+  // CHECK: %[[AND0:.+]] = comb.and %a, %b
+  // CHECK: %[[AND1:.+]] = synth.mig.maj_inv %a, %b, %[[FALSE]]
+  // CHECK-NEXT: %[[ANDCHOICE:.+]] = synth.choice %[[AND0]], %[[AND1]] : i1
+  // CHECK: %[[XOR0:.+]] = comb.xor %a, %b
+  // CHECK: %[[XOR1:.+]] = comb.xor %b, %a
+  // CHECK-NEXT: %[[XORCHOICE:.+]] = synth.choice %[[XOR0]], %[[XOR1]] : i1
+  // CHECK: %[[MAJ0:.+]] = synth.mig.maj_inv %a, %b, %c
+  // CHECK: %[[CXOR:.+]] = comb.and %c, %[[XORCHOICE]]
+  // CHECK: %[[MAJ1:.+]] = comb.or %[[ANDCHOICE]], %[[CXOR]]
+  // CHECK-NEXT: %[[MAJCHOICE:.+]] = synth.choice %[[MAJ0]], %[[MAJ1]] : i1
+  // CHECK: hw.output %[[ORCHOICE]], %[[ORCHOICE]], %[[ANDCHOICE]], %[[ANDCHOICE]], %[[XORCHOICE]], %[[XORCHOICE]], %[[MAJCHOICE]], %[[MAJCHOICE]] : i1, i1, i1, i1, i1, i1, i1, i1
+  %false = hw.constant false
+  %0 = comb.or %a, %b, %c {synth.test.fc_equiv_class = 2} : i1
+  %1 = comb.or %c, %b, %a {synth.test.fc_equiv_class = 2} : i1
+  %2 = comb.and %a, %b {synth.test.fc_equiv_class = 3} : i1
+  %3 = synth.mig.maj_inv %a, %b, %false {synth.test.fc_equiv_class = 3} : i1
+  %4 = comb.xor %a, %b {synth.test.fc_equiv_class = 4} : i1
+  %5 = comb.xor %b, %a {synth.test.fc_equiv_class = 4} : i1
+  %6 = synth.mig.maj_inv %a, %b, %c {synth.test.fc_equiv_class = 5} : i1
+  %7 = comb.and %c, %4 : i1
+  %8 = comb.or %2, %7 {synth.test.fc_equiv_class = 5} : i1
+  hw.output %0, %1, %2, %3, %4, %5, %6, %8 : i1, i1, i1, i1, i1, i1, i1, i1
+}
+
+// CHECK-LABEL: hw.module @test_five_input_mig
+hw.module @test_five_input_mig(in %a: i1, in %b: i1, in %c: i1, in %d: i1,
+                               in %e: i1, out out0: i1, out out1: i1) {
+  // CHECK: %[[M0:.+]] = synth.mig.maj_inv %a, %b, %c, %d, %e
+  // CHECK: %[[M1:.+]] = synth.mig.maj_inv %e, %d, %c, %b, %a
+  // CHECK-NEXT: %[[CHOICE:.+]] = synth.choice %[[M0]], %[[M1]] : i1
+  // CHECK: hw.output %[[CHOICE]], %[[CHOICE]] : i1, i1
+  %0 = synth.mig.maj_inv %a, %b, %c, %d, %e {synth.test.fc_equiv_class = 6} : i1
+  %1 = synth.mig.maj_inv %e, %d, %c, %b, %a {synth.test.fc_equiv_class = 6} : i1
+  hw.output %0, %1 : i1, i1
+}


### PR DESCRIPTION
Extend FunctionalReduction to encode additional supported logic in SAT, including comb.or, comb.xor, and variadic MIG majority nodes. This adds CNF construction helpers for OR, XOR/parity, and majority functions, plus auxiliary SAT variables for intermediate expressions.

As for MIG, eventually we might want to directly pass Majority function to SAT engine like techniques mentioned in MajorSAT, https://www.aspdac.com/aspdac2016/technical_program/pdf/5C-3.pdf. 

AI-assisted-by: Codex 5.3