### PR TITLE
[Support][SATSolver] Add an utility for assume, split decl and def for Z3 backend, NFC

### DIFF
--- a/include/circt/Support/SATSolver.h
+++ b/include/circt/Support/SATSolver.h
@@ -166,6 +166,11 @@ public:
   virtual void assume(int lit) = 0;
   /// Solve under the previously added clauses and current assumptions.
   virtual Result solve() = 0;
+  virtual Result solve(llvm::ArrayRef<int> assumptions) {
+    for (int lit : assumptions)
+      assume(lit);
+    return solve();
+  };
   /// Return the satisfying assignment for variable `v` from the last SAT
   /// result. The sign of the returned literal encodes the Boolean value.
   virtual int val(int v) const = 0;

--- a/lib/Support/SATSolver.cpp
+++ b/lib/Support/SATSolver.cpp
@@ -23,123 +23,147 @@ namespace circt {
 
 namespace {
 
+//===----------------------------------------------------------------------===//
+// Z3 Backend
+//===----------------------------------------------------------------------===//
+
 #if LLVM_WITH_Z3
+
 class Z3SATSolver : public IncrementalSATSolver {
 public:
-  Z3SATSolver() : solver(llvm::CreateZ3Solver()) {}
+  Z3SATSolver();
+  ~Z3SATSolver() override;
 
-  ~Z3SATSolver() override { clearSolveScope(); }
-
-  void add(int lit) override {
-    clearSolveScope();
-    if (lit == 0) {
-      addClauseInternal(clauseBuf);
-      clauseBuf.clear();
-      return;
-    }
-
-    const int absLit = std::abs(lit);
-    if (absLit > maxVariable)
-      reserveVars(absLit);
-
-    clauseBuf.push_back(lit);
-  }
-
-  void assume(int lit) override {
-    clearSolveScope();
-    if (lit == 0)
-      return;
-    assumptions.push_back(lit);
-  }
-
-  Result solve() override {
-    clearSolveScope();
-    solver->push();
-    solveScopeActive = true;
-    for (int lit : assumptions)
-      solver->addConstraint(literalToExpr(lit));
-    assumptions.clear();
-    auto result = solver->check();
-    if (!result)
-      return lastResult = kUNKNOWN;
-    return lastResult = (*result ? kSAT : kUNSAT);
-  }
-
-  int val(int v) const override {
-    if (lastResult != kSAT || v <= 0 || v > maxVariable)
-      return 0;
-    llvm::APSInt value(llvm::APInt(1, 0), true);
-    // Z3 returns an interpretation for all variables, even those not involved
-    // in the problem. If the variable is not involved, return 0 to indicate
-    // "undefined" rather than a potentially misleading true/false value.
-    if (!solver->getInterpretation(variables[v - 1], value))
-      return 0;
-    if (value != 0)
-      return v;
-    return -v;
-  }
-
-  void reserveVars(int maxVar) override {
-    if (maxVar <= maxVariable)
-      return;
-    while (static_cast<int>(variables.size()) < maxVar)
-      newVariable();
-    maxVariable = maxVar;
-  }
+  void add(int lit) override;
+  void assume(int lit) override;
+  Result solve() override;
+  Result solve(llvm::ArrayRef<int> assumptions) override;
+  int val(int v) const override;
+  void reserveVars(int maxVar) override;
 
 private:
-  void clearSolveScope() {
-    if (!solveScopeActive)
-      return;
-    solver->pop();
-    solveScopeActive = false;
-    lastResult = kUNKNOWN;
-  }
-
-  int newVariable() {
-    int varIndex = static_cast<int>(variables.size()) + 1;
-    std::string name = "v" + std::to_string(varIndex);
-    variables.push_back(solver->mkSymbol(name.c_str(), solver->getBoolSort()));
-    return varIndex;
-  }
-
-  llvm::SMTExprRef literalToExpr(int lit) {
-    int absLit = std::abs(lit);
-    // Ensure variable exists for this literal.
-    reserveVars(absLit);
-    auto *variable = variables[absLit - 1];
-    return lit > 0 ? variable : solver->mkNot(variable);
-  }
-
-  void addClauseInternal(llvm::ArrayRef<int> lits) {
-    if (lits.empty()) {
-      solver->addConstraint(solver->mkBoolean(false));
-      return;
-    }
-
-    llvm::SMTExprRef clause = nullptr;
-    for (int lit : lits) {
-      if (lit == 0)
-        continue;
-      auto *expr = literalToExpr(lit);
-      clause = clause ? solver->mkOr(clause, expr) : expr;
-    }
-
-    if (!clause) {
-      solver->addConstraint(solver->mkBoolean(false));
-      return;
-    }
-
-    solver->addConstraint(clause);
-  }
+  void clearSolveScope();
+  int newVariable();
+  llvm::SMTExprRef literalToExpr(int lit);
+  void addClauseInternal(llvm::ArrayRef<int> lits);
 
   llvm::SMTSolverRef solver;
   llvm::SmallVector<llvm::SMTExprRef> variables;
-  llvm::SmallVector<int> assumptions, clauseBuf;
+  llvm::SmallVector<int> assumptions;
+  llvm::SmallVector<int> clauseBuffer;
   int maxVariable = 0;
   Result lastResult = kUNKNOWN;
   bool solveScopeActive = false;
 };
+
+Z3SATSolver::Z3SATSolver() : solver(llvm::CreateZ3Solver()) {}
+
+Z3SATSolver::~Z3SATSolver() { clearSolveScope(); }
+
+void Z3SATSolver::add(int lit) {
+  clearSolveScope();
+  if (lit == 0) {
+    addClauseInternal(clauseBuffer);
+    clauseBuffer.clear();
+    return;
+  }
+
+  reserveVars(std::abs(lit));
+  clauseBuffer.push_back(lit);
+}
+
+void Z3SATSolver::assume(int lit) {
+  clearSolveScope();
+  if (lit == 0)
+    return;
+  assumptions.push_back(lit);
+}
+
+IncrementalSATSolver::Result Z3SATSolver::solve() {
+  auto localAssumptions = assumptions;
+  assumptions.clear();
+  return solve(localAssumptions);
+}
+
+IncrementalSATSolver::Result
+Z3SATSolver::solve(llvm::ArrayRef<int> assumptions) {
+  clearSolveScope();
+  solver->push();
+  solveScopeActive = true;
+  for (int lit : assumptions)
+    solver->addConstraint(literalToExpr(lit));
+  auto result = solver->check();
+  if (!result)
+    return lastResult = kUNKNOWN;
+  if (*result)
+    return lastResult = kSAT;
+  return lastResult = kUNSAT;
+}
+
+int Z3SATSolver::val(int v) const {
+  if (lastResult != kSAT || v <= 0 || v > maxVariable)
+    return 0;
+  llvm::APSInt value(llvm::APInt(1, 0), true);
+  // Z3 returns an interpretation for all variables, even those not involved
+  // in the problem. If the variable is not involved, return 0 to indicate
+  // "undefined" rather than a potentially misleading true/false value.
+  if (!solver->getInterpretation(variables[v - 1], value))
+    return 0;
+  return value != 0 ? v : -v;
+}
+
+void Z3SATSolver::reserveVars(int maxVar) {
+  if (maxVar <= maxVariable)
+    return;
+  while (static_cast<int>(variables.size()) < maxVar)
+    newVariable();
+  maxVariable = maxVar;
+}
+
+void Z3SATSolver::clearSolveScope() {
+  if (!solveScopeActive)
+    return;
+  solver->pop();
+  solveScopeActive = false;
+  lastResult = kUNKNOWN;
+}
+
+int Z3SATSolver::newVariable() {
+  int varIndex = static_cast<int>(variables.size()) + 1;
+  std::string name = "v" + std::to_string(varIndex);
+  variables.push_back(solver->mkSymbol(name.c_str(), solver->getBoolSort()));
+  return varIndex;
+}
+
+llvm::SMTExprRef Z3SATSolver::literalToExpr(int lit) {
+  int absLit = std::abs(lit);
+  // Ensure variable exists for this literal.
+  reserveVars(absLit);
+  auto *variable = variables[absLit - 1];
+  return lit > 0 ? variable : solver->mkNot(variable);
+}
+
+void Z3SATSolver::addClauseInternal(llvm::ArrayRef<int> lits) {
+  if (lits.empty()) {
+    solver->addConstraint(solver->mkBoolean(false));
+    return;
+  }
+
+  llvm::SMTExprRef clause = nullptr;
+  for (int lit : lits) {
+    if (lit == 0)
+      continue;
+    auto *expr = literalToExpr(lit);
+    clause = clause ? solver->mkOr(clause, expr) : expr;
+  }
+
+  if (!clause) {
+    solver->addConstraint(solver->mkBoolean(false));
+    return;
+  }
+  solver->addConstraint(clause);
+}
+
 #endif // LLVM_WITH_Z3
 
 } // namespace


### PR DESCRIPTION
Add a convenient interface for `solve`. It also splits declaration and definition for Z3 backend to reduce the nest. 