### PR TITLE
[HWToSystemC] Fix illegal Op creation

### DIFF
--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -86,7 +86,7 @@ def SCModuleOp : SystemCOp<"module", [
 
     // Return the Ctor operation in this module's body or create one if none
     // exists yet.
-    systemc::CtorOp getOrCreateCtor();
+    systemc::CtorOp getOrCreateCtor(OpBuilder &builder);
 
     // Return the Destructor operation in this module's body or create one if
     // none exists yet.

--- a/lib/Conversion/HWToSystemC/HWToSystemC.cpp
+++ b/lib/Conversion/HWToSystemC/HWToSystemC.cpp
@@ -83,7 +83,7 @@ struct ConvertHWModule : public OpConversionPattern<HWModuleOp> {
 
     // Register the systemc.func inside the systemc.ctor
     rewriter.setInsertionPointToStart(
-        scModule.getOrCreateCtor().getBodyBlock());
+        scModule.getOrCreateCtor(rewriter).getBodyBlock());
     MethodOp::create(rewriter, scModule.getLoc(), scFunc.getHandle());
 
     // Register the sensitivities of above SC_METHOD registration.
@@ -172,10 +172,13 @@ public:
       return rewriter.notifyMatchFailure(instanceOp,
                                          "parent was not an SCModuleOp");
 
-    // Get the builders for the different places to insert operations.
-    auto ctor = scModule.getOrCreateCtor();
-    OpBuilder stateBuilder(ctor);
-    OpBuilder initBuilder = OpBuilder::atBlockEnd(ctor.getBodyBlock());
+    // Track the insertion points for the different places we need to insert
+    // operations while continuing to use the active pattern rewriter.
+    auto ctor = scModule.getOrCreateCtor(rewriter);
+    OpBuilder::InsertPoint stateInsertPt(ctor->getBlock(),
+                                         Block::iterator(ctor.getOperation()));
+    OpBuilder::InsertPoint initInsertPt(ctor.getBodyBlock(),
+                                        ctor.getBodyBlock()->end());
 
     // Collect the port types and names of the instantiated module and convert
     // them to appropriate systemc types.
@@ -191,7 +194,8 @@ public:
     auto instModuleName = instanceOp.getModuleNameAttr();
 
     // Declare the instance.
-    auto instDecl = InstanceDeclOp::create(stateBuilder, loc, instanceName,
+    rewriter.restoreInsertionPoint(stateInsertPt);
+    auto instDecl = InstanceDeclOp::create(rewriter, loc, instanceName,
                                            instModuleName, portInfo);
 
     // Bind the input ports.
@@ -205,15 +209,18 @@ public:
       if (auto readOp = input.getDefiningOp<SignalReadOp>()) {
         // Use the read channel directly without adding an
         // intermediate signal.
-        BindPortOp::create(initBuilder, loc, instDecl, portId,
-                           readOp.getInput());
+        rewriter.restoreInsertionPoint(initInsertPt);
+        BindPortOp::create(rewriter, loc, instDecl, portId, readOp.getInput());
         continue;
       }
 
       // Otherwise, create an intermediate signal to bind the instance port to.
       Type sigType = SignalType::get(getSignalBaseType(portInfo[i].type));
-      Value channel = SignalOp::create(stateBuilder, loc, sigType, signalName);
-      BindPortOp::create(initBuilder, loc, instDecl, portId, channel);
+      rewriter.restoreInsertionPoint(stateInsertPt);
+      Value channel = SignalOp::create(rewriter, loc, sigType, signalName);
+      rewriter.restoreInsertionPoint(initInsertPt);
+      BindPortOp::create(rewriter, loc, instDecl, portId, channel);
+      rewriter.setInsertionPoint(instanceOp);
       SignalWriteOp::create(rewriter, loc, channel, input);
     }
 
@@ -235,7 +242,8 @@ public:
           // we cannot insert multiple bind statements for one submodule port.
           // It is also necessary to bind it to an intermediate signal when it
           // has no uses as every port has to be bound to a channel.
-          BindPortOp::create(initBuilder, loc, instDecl, portId,
+          rewriter.restoreInsertionPoint(initInsertPt);
+          BindPortOp::create(rewriter, loc, instDecl, portId,
                              writeOp.getDest());
           writeOp->erase();
           continue;
@@ -245,8 +253,11 @@ public:
       // Otherwise, create an intermediate signal.
       Type sigType =
           SignalType::get(getSignalBaseType(portInfo[i + numInputs].type));
-      Value channel = SignalOp::create(stateBuilder, loc, sigType, signalName);
-      BindPortOp::create(initBuilder, loc, instDecl, portId, channel);
+      rewriter.restoreInsertionPoint(stateInsertPt);
+      Value channel = SignalOp::create(rewriter, loc, sigType, signalName);
+      rewriter.restoreInsertionPoint(initInsertPt);
+      BindPortOp::create(rewriter, loc, instDecl, portId, channel);
+      rewriter.setInsertionPoint(instanceOp);
       auto instOut = SignalReadOp::create(rewriter, loc, channel);
       output.replaceAllUsesWith(instOut);
     }

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -320,7 +320,7 @@ LogicalResult SCModuleOp::verifyRegions() {
   return verifyUniqueNamesInRegion(getOperation(), getPortNames(), attachNote);
 }
 
-CtorOp SCModuleOp::getOrCreateCtor() {
+CtorOp SCModuleOp::getOrCreateCtor(OpBuilder &builder) {
   CtorOp ctor;
   getBody().walk([&](Operation *op) {
     if ((ctor = dyn_cast<CtorOp>(op)))
@@ -332,7 +332,8 @@ CtorOp SCModuleOp::getOrCreateCtor() {
   if (ctor)
     return ctor;
 
-  auto builder = OpBuilder(getBody());
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPoint(getBodyBlock(), getBodyBlock()->begin());
   return CtorOp::create(builder, getLoc());
 }
 


### PR DESCRIPTION
There are a few operation creations that don't use rewriter which is illegal (https://mlir.llvm.org/docs/PatternRewriter/#restrictions). 

This fixes the issue by using rewriter (though it was necessary to manually manage 3 different insertion points in `ConvertInstance` so there may be a better fix).

This should fix https://github.com/llvm/circt/issues/9376 
