### PR TITLE
[Synth] Canonicalize transitive choice operands

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -154,6 +154,7 @@ def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
   let results = (outs AnyType:$result);
   let hasVerifier = 1;
   let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
   let assemblyFormat = "$inputs attr-dict `:` type($result)";
 }
 

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -16,6 +16,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallDenseSet.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/LogicalResult.h"
 
@@ -38,6 +39,49 @@ OpFoldResult ChoiceOp::fold(FoldAdaptor adaptor) {
   if (adaptor.getInputs().size() == 1)
     return getOperand(0);
   return {};
+}
+
+LogicalResult ChoiceOp::canonicalize(ChoiceOp op, PatternRewriter &rewriter) {
+  SmallDenseSet<Value> seen;
+  SmallVector<Value> inputs;
+  bool changed = false;
+
+  auto appendInput = [&](Value value, auto &appendInputRef) -> LogicalResult {
+    if (auto constOp = value.getDefiningOp<hw::ConstantOp>()) {
+      rewriter.replaceOp(op, constOp.getResult());
+      return success();
+    }
+
+    if (auto nestedChoice = value.getDefiningOp<ChoiceOp>()) {
+      changed = true;
+      for (auto nestedInput : nestedChoice.getInputs())
+        if (succeeded(appendInputRef(nestedInput, appendInputRef)))
+          return success();
+      return failure();
+    }
+
+    if (seen.insert(value).second) {
+      inputs.push_back(value);
+    } else {
+      changed = true;
+    }
+    return failure();
+  };
+
+  for (auto input : op.getInputs())
+    if (succeeded(appendInput(input, appendInput)))
+      return success();
+
+  if (inputs.size() == 1) {
+    rewriter.replaceOp(op, inputs.front());
+    return success();
+  }
+
+  if (!changed && inputs.size() == op.getNumOperands())
+    return failure();
+
+  replaceOpWithNewOpAndCopyNamehint<ChoiceOp>(rewriter, op, inputs);
+  return success();
 }
 
 LogicalResult MajorityInverterOp::verify() {

--- a/test/Dialect/Synth/canonicalizer.mlir
+++ b/test/Dialect/Synth/canonicalizer.mlir
@@ -140,3 +140,33 @@ hw.module @choice_single_operand(in %a: i4, out o: i4) {
   %0 = synth.choice %a : i4
   hw.output %0 : i4
 }
+
+// CHECK-LABEL: hw.module @choice_constant
+hw.module @choice_constant(in %a: i4, in %b: i4, out o: i4) {
+  %c7_i4 = hw.constant 7 : i4
+  // CHECK-NEXT: %c7_i4 = hw.constant 7 : i4
+  // CHECK-NEXT: hw.output %c7_i4 : i4
+  %0 = synth.choice %a, %b, %c7_i4 : i4
+  hw.output %0 : i4
+}
+
+// CHECK-LABEL: hw.module @choice_transitive_merge
+hw.module @choice_transitive_merge(in %x: i4, in %y: i4, in %z: i4, in %u: i4,
+                                   in %v: i4, out o: i4) {
+  %0 = synth.choice %x, %y, %z : i4
+  %1 = synth.choice %0, %u : i4
+  %2 = synth.choice %z, %v : i4
+  // CHECK-NEXT: %[[CHOICE:.+]] = synth.choice %x, %y, %z, %u, %v : i4
+  // CHECK-NEXT: hw.output %[[CHOICE]] : i4
+  %3 = synth.choice %1, %2 : i4
+  hw.output %3 : i4
+}
+
+// CHECK-LABEL: hw.module @choice_nested_dedup
+hw.module @choice_nested_dedup(in %a: i4, in %b: i4, in %c: i4, out o: i4) {
+  %0 = synth.choice %a, %b : i4
+  // CHECK-NEXT: %[[CHOICE:.+]] = synth.choice %a, %b, %c : i4
+  // CHECK-NEXT: hw.output %[[CHOICE]] : i4
+  %1 = synth.choice %0, %b, %c, %a : i4
+  hw.output %1 : i4
+}


### PR DESCRIPTION
## Summary

  Fixes `synth.choice` canonicalization for transitive operand merging.

  This addresses the issue described in #9932: nested `synth.choice` operands were not being flattened/merged transitively, and constant operands were not short-circuiting the choice during canonicalization.

  ## Problem

  Before this change, `ChoiceOp` only had:
  - verification that at least one operand exists
  - a fold for the trivial single-operand case

  It did **not** canonicalize nested choices like:

  ```mlir
  %0 = synth.choice %x, %y, %z : i4
  %1 = synth.choice %0, %u : i4
  %2 = synth.choice %z, %v : i4
  %3 = synth.choice %1, %2 : i4
```
  into:
```mlir
  %0 = synth.choice %x, %y, %z, %u, %v : i4
```
  It also did not canonicalize cases like:
```mlir
  %0 = synth.choice %x, %y, %constant : i4
```
  to:
```mlir
  %constant
```
  ## What this PR changes

  This PR adds ChoiceOp canonicalization that:

  - flattens nested synth.choice operands transitively
  - deduplicates merged operands while preserving first-seen order
  - replaces the choice with a constant if any reachable operand is an hw.constant
  - replaces the choice with the single remaining operand if canonicalization collapses it to one input

  ## Scope
  It only adds local canonicalization for synth.choice and does not:

  - introduce broader structural equivalence reasoning
  - change the semantics of synth.choice
  - add new synthesis transformations beyond the issue described in #9932

  ## Tests

  Added focused canonicalizer coverage for:

  - single-operand choice folding
  - constant short-circuiting
  - transitive flattening of nested choices
  - deduplication across nested choices