### PR TITLE
[FIRRTL]  parser: support rwprobe of open-agg instance results.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3920,15 +3920,8 @@ ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
         // Otherwise, replace with bounce wire.
         auto type = instResult.getType();
 
-        // Either entire instance result is forceable + bounce wire, or reject.
-        // (even if rwprobe is of a portion of the port)
-        bool forceable = static_cast<bool>(
-            firrtl::detail::getForceableResultType(true, type));
-        if (!forceable)
-          return emitError(loc, "unable to force instance result of type ")
-                 << type;
-
         // Create bounce wire for the instance result.
+        // This may be an open aggregate, or other non-base type.
         auto annotations = getConstants().emptyArrayAttr;
         StringAttr sym = {};
         SmallString<64> name;
@@ -3939,7 +3932,7 @@ ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
         auto bounce =
             WireOp::create(builder, type, name, NameKindEnum::InterestingName,
                            annotations, sym);
-        auto bounceVal = bounce.getData();
+        auto bounceVal = bounce.getDataRaw();
 
         // Replace instance result with reads from bounce wire.
         instResult.replaceAllUsesWith(bounceVal);

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1092,6 +1092,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule"
    ; CHECK-NEXT: firrtl.ref.define %inst_rw2, %[[RWPROBE_RC2_IN_BOUNCE_2]]
     define inst_rw2 = rwprobe(rc2.in)
 
+   ; CHECK-NEXT: firrtl.wire sym [<@[[RCOA_RWPROBE_SYM:.+]],1,public>] interesting_name : !firrtl.openbundle<a: uint<1>, rw flip: rwprobe<uint<1>>>
+   ; CHECK: firrtl.instance rcoa
+   inst rcoa of RefsChildOpenAgg
+   ; CHECK: firrtl.ref.rwprobe <@Refs::@[[RCOA_RWPROBE_SYM]]>
+   wire inst_rcoa_a : RWProbe<UInt<1>>
+   define inst_rcoa_a = rwprobe(rcoa.in.a)
+
   ; CHECK-LABEL: module private @ForceRelease(
   module ForceRelease :
     input in : UInt<1>


### PR DESCRIPTION
Don't require the entire instance result is forceable.

Add test that fails before this change.

Builds on #10017 .