### PR TITLE
[FIRRTL] Invalids as constants in InferDomains

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -883,9 +883,11 @@ static LogicalResult processOp(const DomainInfo &info, TermAllocator &allocator,
   for (auto rhs : op->getOperands()) {
     if (!isa<FIRRTLBaseType>(rhs.getType()))
       continue;
-    if (auto *op = rhs.getDefiningOp();
-        op && op->hasTrait<OpTrait::ConstantLike>())
-      continue;
+    if (auto *op = rhs.getDefiningOp()) {
+      // Skip constants and invalid values - they are domain-agnostic.
+      if (op->hasTrait<OpTrait::ConstantLike>() || isa<InvalidValueOp>(op))
+        continue;
+    }
     if (failed(unifyAssociations(info, allocator, table, op, lhs, rhs)))
       return failure();
     lhs = rhs;
@@ -893,9 +895,11 @@ static LogicalResult processOp(const DomainInfo &info, TermAllocator &allocator,
   for (auto rhs : op->getResults()) {
     if (!isa<FIRRTLBaseType>(rhs.getType()))
       continue;
-    if (auto *op = rhs.getDefiningOp();
-        op && op->hasTrait<OpTrait::ConstantLike>())
-      continue;
+    if (auto *op = rhs.getDefiningOp()) {
+      // Skip constants and invalid values - they are domain-agnostic.
+      if (op->hasTrait<OpTrait::ConstantLike>() || isa<InvalidValueOp>(op))
+        continue;
+    }
     if (failed(unifyAssociations(info, allocator, table, op, lhs, rhs)))
       return failure();
     lhs = rhs;

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -281,6 +281,25 @@ firrtl.circuit "ConstantInMultipleDomains" {
   }
 }
 
+// InvalidValue should be domain-agnostic like constants.
+// CHECK-LABEL: InvalidValueInMultipleDomains
+firrtl.circuit "InvalidValueInMultipleDomains" {
+  firrtl.domain @ClockDomain
+
+  firrtl.extmodule @Foo(in A: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<1> domains [A])
+
+  firrtl.module @InvalidValueInMultipleDomains(in %A: !firrtl.domain<@ClockDomain()>, in %B: !firrtl.domain<@ClockDomain()>) {
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    %x_A, %x_i = firrtl.instance x @Foo(in A: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<1> domains [A])
+    firrtl.domain.define %x_A, %A : !firrtl.domain<@ClockDomain()>
+    firrtl.matchingconnect %x_i, %invalid_ui1 : !firrtl.uint<1>
+
+    %y_A, %y_i = firrtl.instance y @Foo(in A: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<1> domains [A])
+    firrtl.domain.define %y_A, %B : !firrtl.domain<@ClockDomain()>
+    firrtl.matchingconnect %y_i, %invalid_ui1 : !firrtl.uint<1>
+  }
+}
+
 firrtl.circuit "Top" {
   firrtl.domain @ClockDomain
   firrtl.extmodule @Foo(


### PR DESCRIPTION
Treat invalid values as constants in the InferDomains pass.

I'm not entirely sure that this is correct given that the FIRRTL spec says
that an invalid value can be any value.  Hence, there exist both legal and
illegal values that could be chosen.  Constants are fine.  However, a
value could be chosen that is on a different domain which would then be
illegal.  It seems wrong to reject a circuit that has a legal, known
solution.  However, this then puts the burden on the downstream assigner
of invalid values to choose a legal value.

AI-assisted-by: Augment (Sonnet 4.5)
