### PR TITLE
[FlattenMemRefs] Remove global static variables

### DIFF
--- a/lib/Transforms/FlattenMemRefs.cpp
+++ b/lib/Transforms/FlattenMemRefs.cpp
@@ -217,8 +217,8 @@ struct GlobalOpConversion : public OpConversionPattern<memref::GlobalOp> {
       flattenedVals.push_back(attr);
 
     auto newTypeAttr = TypeAttr::get(newType);
-    auto newNameStr = getFlattenedMemRefName(state, op.getConstantAttrName(),
-                                             type);
+    auto newNameStr =
+        getFlattenedMemRefName(state, op.getConstantAttrName(), type);
     auto newName = rewriter.getStringAttr(newNameStr);
     state.nameMap[op.getSymNameAttr()] = newName;
 


### PR DESCRIPTION
This patch addresses #9633 by removing the global static state used by `FlattenMemRefs.cpp`.

The pass previously used file-level globals to:
  - generate unique flattened global names
  - track the mapping from original global symbols to rewritten symbols

This changes that state to be pass-local instead. A small `FlattenMemRefsState` object is created in `FlattenMemRefPass` and passed only to the conversion patterns that need it (`GlobalOpConversion` and `GetGlobalOpConversion`).

This keeps the change narrowly scoped to the reported issue and preserves the existing behavior while removing process-global mutable state.