### PR TITLE
[FIRRTL][LOA] Fix bug dropping inner symbol within mapped type.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -703,6 +703,13 @@ FailureOr<MappingInfo> Visitor::mapType(Type type, Location errorLoc,
   }
 
   SmallVector<hw::InnerSymPropertiesAttr> newProps;
+  SmallVector<hw::InnerSymPropertiesAttr> oldProps;
+  if (sym) {
+    llvm::append_range(oldProps, sym.getProps());
+    llvm::sort(oldProps, [](const auto &p, const auto &q) {
+      return p.getFieldID() < q.getFieldID();
+    });
+  }
 
   // NOLINTBEGIN(misc-no-recursion)
   auto recurse = [&](auto &&f, FIRRTLType type, const Twine &suffix = "",
@@ -785,15 +792,32 @@ FailureOr<MappingInfo> Visitor::mapType(Type type, Location errorLoc,
       return failure();
 
     // If there's a symbol on this, add it with adjusted fieldID.
-    if (sym)
-      if (auto symOnThis = sym.getSymIfExists(fieldID)) {
+    if (sym) {
+      // If types changed, copy symbol over for specifically this fieldID.
+      // If they did not, copy over range of symbols for the type.
+      // The logic here is if they didn't change we didn't recurse into it,
+      // and so need to grab all symbols on and within this type.
+      auto maxFieldID = (type != *newType)
+                            ? fieldID
+                            : fieldID + hw::FieldIdImpl::getMaxFieldID(type);
+      assert((isa<FIRRTLBaseType>(type) || maxFieldID == fieldID) &&
+             "unexpected non-base type with fields");
+      auto propFind = [](auto &prop, auto fID) {
+        return prop.getFieldID() < fID;
+      };
+      for (auto symIt = llvm::lower_bound(oldProps, fieldID, propFind);
+           symIt != oldProps.end() && symIt->getFieldID() <= maxFieldID;
+           ++symIt) {
+        auto symToMap = symIt->getName();
         if (!*newType)
           return mlir::emitError(errorLoc, "inner symbol ")
-                 << symOnThis << " mapped to non-HW type";
+                 << symToMap << " mapped to non-HW type";
+        auto relFieldID = symIt->getFieldID() - fieldID;
         newProps.push_back(hw::InnerSymPropertiesAttr::get(
-            context, symOnThis, newFieldID,
+            context, symToMap, newFieldID + relFieldID,
             StringAttr::get(context, "public")));
       }
+    }
     return newType;
   };
 

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -373,3 +373,14 @@ firrtl.circuit "DomainInfoIndexUpdate" {
     )
   }
 }
+
+// -----
+
+// Test that inner symbols within nested base aggregates are propagated.
+// CHECK-LABEL: circuit "NestedBaseInnerSym"
+firrtl.circuit "NestedBaseInnerSym" {
+  firrtl.module @NestedBaseInnerSym() {
+    // CHECK: [<@sym,0,public>, <@sym_b,1,public>, <@sym_c,2,public>]
+    %w = firrtl.wire sym [<@sym, 0, public>, <@sym_b, 2, public>, <@sym_c, 3, public>] : !firrtl.openbundle<a: probe<uint<1>>, b: bundle<c: uint<1>>, d: probe<uint<1>>>
+  }
+}


### PR DESCRIPTION
LOA maps types to their new HW type, recurisng through the original type generally.  However, FIRRTLBaseType's encountered within are mapped through directly without recursing.

Adjust the inner symbol propagation logic to copy over range of inner symbols for portions we map but do not change, while only copying inner symbol for the specific point of recursion as we will have already copied the rest during the recursion.