### PR TITLE
[FIRRTL] Fix use-before-def in InferDomains

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -1238,20 +1238,10 @@ static LogicalResult updateModuleDomainInfo(const DomainInfo &info,
   return success();
 }
 
-/// Helper that returns true if a value is defined before an operation in the
-/// same block, or is a block argument.
-static bool valueDefinedBeforeOp(Value value, Operation *op) {
-  Operation *valueOp = value.getDefiningOp();
-  if (!valueOp)
-    return true; // Block argument
-  return valueOp->getBlock() == op->getBlock() && valueOp->isBeforeInBlock(op);
-}
-
 static LogicalResult updateInstance(const DomainInfo &info,
                                     TermAllocator &allocator,
-                                    DomainTable &table, FInstanceLike op) {
-  OpBuilder builder(op.getContext());
-  builder.setInsertionPointAfter(op);
+                                    DomainTable &table, FInstanceLike op,
+                                    OpBuilder &builder) {
   auto numPorts = op->getNumResults();
   for (size_t i = 0; i < numPorts; ++i) {
     auto port = dyn_cast<DomainValue>(op->getResult(i));
@@ -1268,17 +1258,20 @@ static LogicalResult updateInstance(const DomainInfo &info,
         auto domainTypeID = info.getDomainTypeID(domainType);
         auto domainDecl = info.getDomain(domainTypeID);
         auto name = domainDecl.getNameAttr();
-        auto anon = DomainCreateAnonOp::create(builder, loc, domainType, name);
+        DomainValue anon;
+        {
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPointAfter(op);
+          anon = DomainCreateAnonOp::create(builder, loc, domainType, name);
+        }
         solve(var, allocator.allocVal(anon));
+        // Create domain.define at the end of the block to avoid use-before-def.
         DomainDefineOp::create(builder, loc, port, anon);
         continue;
       }
       if (auto *val = dyn_cast<ValueTerm>(term)) {
         auto value = val->value;
-        // Insert the domain.define after the value it references to avoid
-        // use-before-def errors.
-        if (!valueDefinedBeforeOp(value, op.getOperation()))
-          builder.setInsertionPointAfterValue(value);
+        // Create domain.define at the end of the block to avoid use-before-def.
         DomainDefineOp::create(builder, loc, port, value);
         continue;
       }
@@ -1294,9 +1287,14 @@ static LogicalResult updateInstance(const DomainInfo &info,
 static LogicalResult updateModuleBody(const DomainInfo &info,
                                       TermAllocator &allocator,
                                       DomainTable &table, FModuleOp moduleOp) {
+  // Set insertion point to end of block so all domain.define operations are
+  // created there, avoiding use-before-def issues.
+  OpBuilder builder(moduleOp.getContext());
+  builder.setInsertionPointToEnd(moduleOp.getBodyBlock());
+
   auto result =
       moduleOp.getBodyBlock()->walk([&](FInstanceLike op) -> WalkResult {
-        return updateInstance(info, allocator, table, op);
+        return updateInstance(info, allocator, table, op, builder);
       });
   return failure(result.wasInterrupted());
 }

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -230,8 +230,8 @@ firrtl.circuit "InstanceUpdate" {
 
   // CHECK: firrtl.module @InstanceUpdate(in %ClockDomain: !firrtl.domain<@ClockDomain()>, in %i: !firrtl.uint<1> domains [%ClockDomain]) {
   // CHECK:   %foo_ClockDomain, %foo_i = firrtl.instance foo @Foo(in ClockDomain: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<1> domains [ClockDomain])
-  // CHECK:   firrtl.domain.define %foo_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK:   firrtl.connect %foo_i, %i : !firrtl.uint<1>
+  // CHECK:   firrtl.domain.define %foo_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK: }
   firrtl.module @InstanceUpdate(in %i : !firrtl.uint<1>) {
     %foo_i = firrtl.instance foo @Foo(in i: !firrtl.uint<1>)
@@ -254,8 +254,8 @@ firrtl.circuit "InstanceChoiceUpdate" {
 
   // CHECK: firrtl.module @InstanceChoiceUpdate(in %ClockDomain: !firrtl.domain<@ClockDomain()>, in %i: !firrtl.uint<1> domains [%ClockDomain]) {
   // CHECK:   %inst_ClockDomain, %inst_i = firrtl.instance_choice inst @Foo alternatives @Option { @X -> @Bar, @Y -> @Baz } (in ClockDomain: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<1> domains [ClockDomain])
-  // CHECK:   firrtl.domain.define %inst_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK:   firrtl.connect %inst_i, %i : !firrtl.uint<1>
+  // CHECK:   firrtl.domain.define %inst_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK: }
   firrtl.module @InstanceChoiceUpdate(in %i : !firrtl.uint<1>) {
     %inst_i = firrtl.instance_choice inst @Foo alternatives @Option { @X -> @Bar, @Y -> @Baz } (in i : !firrtl.uint<1>)
@@ -356,8 +356,8 @@ firrtl.circuit "UnableToInferDomainOfPortDrivenByConstant" {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK:   %foo_ClockDomain, %foo_i = firrtl.instance foo @Foo(in ClockDomain: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<1> domains [ClockDomain])
   // CHECK:   %ClockDomain = firrtl.domain.anon : !firrtl.domain<@ClockDomain()>
-  // CHECK:   firrtl.domain.define %foo_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK:   firrtl.matchingconnect %foo_i, %c0_ui1 : !firrtl.uint<1>
+  // CHECK:   firrtl.domain.define %foo_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK: }
   firrtl.module @UnableToInferDomainOfPortDrivenByConstant() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -378,8 +378,8 @@ firrtl.circuit "UnableToInferDomainOfPortDrivenByConstantExpr" {
   // CHECK:   %0 = firrtl.add %c0_ui1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
   // CHECK:   %foo_ClockDomain, %foo_i = firrtl.instance foo @Foo(in ClockDomain: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<2> domains [ClockDomain])
   // CHECK:   %ClockDomain = firrtl.domain.anon : !firrtl.domain<@ClockDomain()>
-  // CHECK:   firrtl.domain.define %foo_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK:   firrtl.matchingconnect %foo_i, %0 : !firrtl.uint<2>
+  // CHECK:   firrtl.domain.define %foo_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK: }
   firrtl.module @UnableToInferDomainOfPortDrivenByConstantExpr() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -486,8 +486,8 @@ firrtl.circuit "UnsafeDomainCastMatching" {
   }
 }
 
-// Test that domain.define is inserted after the value it references when that
-// value is defined later in the block (use-before-def fix).
+// Test that domain.define is placed at the end of the block to avoid
+// use-before-def issues.
 // CHECK-LABEL: DomainDefineAfterValue
 firrtl.circuit "DomainDefineAfterValue" {
   firrtl.domain @ClockDomain
@@ -504,12 +504,12 @@ firrtl.circuit "DomainDefineAfterValue" {
       in D: !firrtl.domain<@ClockDomain()>,
       in clk: !firrtl.clock domains [D]
     )
-    // CHECK: %producer_D, %producer_clk = firrtl.instance producer @Producer
     %producer_D, %producer_clk = firrtl.instance producer @Producer(
       out D: !firrtl.domain<@ClockDomain()>,
       out clk: !firrtl.clock domains [D]
     )
-    // CHECK-NEXT: firrtl.domain.define %consumer_D, %producer_D
+    // CHECK: firrtl.matchingconnect %consumer_clk, %producer_clk
     firrtl.matchingconnect %consumer_clk, %producer_clk : !firrtl.clock
+    // CHECK-NEXT: firrtl.domain.define %consumer_D, %producer_D
   }
 }

--- a/test/Dialect/FIRRTL/infer-domains-infer.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer.mlir
@@ -75,8 +75,8 @@ firrtl.circuit "UnableToInferDomainOfPortDrivenByConstant" {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK:   %foo_ClockDomain, %foo_i = firrtl.instance foo @Foo(in ClockDomain: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<1> domains [ClockDomain])
   // CHECK:   %ClockDomain = firrtl.domain.anon : !firrtl.domain<@ClockDomain()>
-  // CHECK:   firrtl.domain.define %foo_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK:   firrtl.matchingconnect %foo_i, %c0_ui1 : !firrtl.uint<1>
+  // CHECK:   firrtl.domain.define %foo_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK: }
   firrtl.module @UnableToInferDomainOfPortDrivenByConstant() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -91,8 +91,8 @@ firrtl.circuit "UnableToInferDomainOfPortDrivenByConstant" {
   // CHECK:   %0 = firrtl.add %c0_ui1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
   // CHECK:   %bar_ClockDomain, %bar_i = firrtl.instance bar @Bar(in ClockDomain: !firrtl.domain<@ClockDomain()>, in i: !firrtl.uint<2> domains [ClockDomain])
   // CHECK:   %ClockDomain = firrtl.domain.anon : !firrtl.domain<@ClockDomain()>
-  // CHECK:   firrtl.domain.define %bar_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK:   firrtl.matchingconnect %bar_i, %0 : !firrtl.uint<2>
+  // CHECK:   firrtl.domain.define %bar_ClockDomain, %ClockDomain : !firrtl.domain<@ClockDomain()>
   // CHECK: }
   firrtl.module @UnableToInferDomainOfPortDrivenByConstantExpr() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>


### PR DESCRIPTION
Fix an issue in FIRRTL's `InferDomains` pass where a `domain.define`
created from inferring an instance that needs to be connected to another
instance would not check that that source has been declared yet.  Do this
check and insert after the source if it is declared later.

Fixes #10028.

AI-assisted-by: Augment (Sonnet 4.5)
