### PR TITLE
[CI] Try workaround concurrency bug

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -8,6 +8,12 @@ on:
     types: [assigned, opened, synchronize, reopened]
   workflow_dispatch:
 
+# FIXME: `concurrency` causes random cancellation (See https://github.com/orgs/community/discussions/188508)
+# # Cancel previous CI builds when a new push occurs to the same PR.
+# concurrency:
+#  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+#  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Do sanity check (clang-format and python-format) first.
   sanity-check:
@@ -160,11 +166,6 @@ jobs:
             mode: Release
             assert: OFF
             shared: OFF
-
-    # Cancel previous CI builds when a new push occurs to the same PR.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ matrix.compiler.cc }}-${{ matrix.compiler.cxx }}-${{ matrix.compiler.mode }}-${{ matrix.compiler.assert }}-${{ matrix.compiler.shared }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - name: Configure Environment


### PR DESCRIPTION
There seems to be a bug that causes `concurrency` setting causes unexpected random shutdown 
https://github.com/orgs/community/discussions/188508 https://github.com/orgs/community/discussions/188446. 

We've seen the same bug quite a few times this week and I suspect one root cause is mishandling of
matrix and concurrency group (so clang cancels gcc in buildAndTest). 

This tries to add workaround to put detailed build configuration to the group to avoid conflict. 