### PR TITLE
[FIRRTL] Remove getPortNames from FInstanceLike 

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -345,12 +345,6 @@ def FInstanceLike : OpInterface<"FInstanceLike", [
     InterfaceMethod<"Get the port names attribute",
       "ArrayAttr", "getPortNamesAttr">,
 
-    InterfaceMethod<"Get the port names",
-    "ArrayRef<Attribute>", "getPortNames", (ins), [{}],
-    /*defaultImplementation=*/[{
-      return $_op.getPortNamesAttr().getValue();
-    }]>,
-
     //===------------------------------------------------------------------===//
     // Inner Symbol
     //===------------------------------------------------------------------===//


### PR DESCRIPTION
This commit removes `getPortNames` from FInstanceLike as there is no user and prevent warnings due to 
ArrayAttr -> ArrayRef conversion in Interface function. 


