### PR TITLE
[FIRRTL] Move InferDomains pass after ExpandWhens

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the ExpandWhens pass.
+// This file defines the ExpandWhens pass.  This pass resolves last-connect
+// semantics and ensures that all values (except domain types) are connected
+// to exactly once.  Domain types are exempt from initialization checking and
+// are handled by the InferDomains pass.
 //
 //===----------------------------------------------------------------------===//
 
@@ -204,6 +207,11 @@ public:
     // Recurse through a bundle and declare each leaf sink node.
     std::function<void(Type, Flow, bool)> declare = [&](Type type, Flow flow,
                                                         bool local) {
+      // Domain types are exempt from initialization checking and will be
+      // handled by the InferDomains pass.
+      if (type_isa<DomainType>(type))
+        return;
+
       // If this is a class type, recurse to each of the fields.
       if (auto classType = type_dyn_cast<ClassType>(type)) {
         if (local) {

--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// InferDomains implements FIRRTL domain inference and checking. This pass is a
-// bottom-up transform acting on modules. For each moduleOp, we ensure there are
-// no domain crossings, and we make explicit the domain associations of ports.
+// InferDomains implements FIRRTL domain inference and checking.  This pass is
+// a bottom-up transform acting on modules.  For each moduleOp, we ensure there
+// are no domain crossings, and we make explicit the domain associations of
+// ports.
+//
+// This pass does not require that ExpandWhens has run, but it should have run.
+// If ExpandWhens has not been run, then duplicate connections will influence
+// domain inference and this can result in errors.
 //
 //===----------------------------------------------------------------------===//
 

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -48,9 +48,6 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createLowerIntrinsics());
 
-  if (auto mode = FirtoolOptions::toInferDomainsPassMode(opt.getDomainMode()))
-    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferDomains({*mode}));
-
   return success();
 }
 
@@ -131,6 +128,14 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
     modulePM.addPass(firrtl::createExpandWhens());
     modulePM.addPass(firrtl::createSFCCompat());
   }
+
+  // InferDomains runs after ExpandWhens because FIRRTL allows for last-connect
+  // semantics and users have historically relied on this behavior to set
+  // default connections that are then overridden later.  If this pass is run
+  // before ExpandWhens, then users can get errors if they rely on last-connect
+  // semantics.
+  if (auto mode = FirtoolOptions::toInferDomainsPassMode(opt.getDomainMode()))
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferDomains({*mode}));
 
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createCheckCombLoops());
 

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -253,15 +253,6 @@ firrtl.module @Test() {
 
 // -----
 
-firrtl.circuit "DomainTypeUndriven" {
-  firrtl.domain @ClockDomain
-  // expected-error @below {{port "A" not fully initialized in "DomainTypeUndriven"}}
-  firrtl.module @DomainTypeUndriven(out %A: !firrtl.domain<@ClockDomain()>) {}
-}
-
-
-// -----
-
 firrtl.circuit "instance_choice_test" {
 firrtl.option @Platform {
   firrtl.option_case @FPGA


### PR DESCRIPTION
Domain inference now runs after when expansion to prevent spurious domain
unification from connections that are later overridden.  This fixes issues
where an earlier connection causes domains to unify before a later
connection overrides it with a different domain.

For example, with clock gating:

    connect baz.clock, clock
    connect baz.clock, gated_clock  // override

Previously, both domains would unify during inference.  Now, ExpandWhens
eliminates the first connection first, leaving only the final connection
for domain inference.

Domain types are now exempt from ExpandWhens initialization checking and
will be validated by InferDomains.

AI-assisted-by: Augment (Claude Sonnet 4.5)
