### PR TITLE
[circt-reduce] Add IMDCE as a FIRRTL reduction

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -2587,7 +2587,8 @@ void firrtl::FIRRTLReducePatternDialectInterface::populateReducePatterns(
   patterns.add<PassReduction, 17>(
       getContext(),
       firrtl::createRemoveUnusedPorts({/*ignoreDontTouch=*/true}));
-  patterns.add<NodeSymbolRemover, 15>();
+  patterns.add<NodeSymbolRemover, 16>();
+  patterns.add<PassReduction, 15>(getContext(), firrtl::createIMDeadCodeElim());
   patterns.add<ConnectForwarder, 14>();
   patterns.add<ConnectInvalidator, 13>();
   patterns.add<Constantifier, 12>();


### PR DESCRIPTION
Add FIRRTL's `IMDeadCodeElim` pass as a reduction strategy.  This should
help replace a hodge-podge of other strategies like
`RemoveUnusedPorts` (which should be the same as `AnnotationRemover` +
IMDCE) and `ModulePortPruner` (which should be strictly weaker than
IMDCE).  I'm waiting to remove the other strategies until I've had some
time to test this, though.

AI-assisted-by: Augment (Claude Sonnet 4.5)
