### PR TITLE
[circt-reduce] Fix connect-forwarder crash

### DIFF
--- a/include/circt/Reduce/ReductionUtils.h
+++ b/include/circt/Reduce/ReductionUtils.h
@@ -18,6 +18,13 @@ struct Reduction;
 
 namespace reduce {
 
+/// Starting from an initial worklist of operations, traverse through it and its
+/// operands and erase operations that have no more uses.  This is useful when
+/// there are repeated calls to `pruneUnusedOp` that want to delete the same
+/// operations.
+void pruneUnusedOps(SmallVectorImpl<Operation *> &worklist,
+                    Reduction &reduction);
+
 /// Starting at the given `op`, traverse through it and its operands and erase
 /// operations that have no more uses.
 void pruneUnusedOps(Operation *initialOp, Reduction &reduction);

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -1327,12 +1327,11 @@ struct ConnectForwarder : public Reduction {
   LogicalResult rewrite(Operation *op) override {
     auto dst = op->getOperand(0);
     auto src = op->getOperand(1);
-    dst.replaceAllUsesWith(src);
+    dst.replaceAllUsesExcept(src, op);
     op->erase();
-    if (auto *dstOp = dst.getDefiningOp())
-      reduce::pruneUnusedOps(dstOp, *this);
-    if (auto *srcOp = src.getDefiningOp())
-      reduce::pruneUnusedOps(srcOp, *this);
+    SmallVector<Operation *> worklist(
+        {dst.getDefiningOp(), src.getDefiningOp()});
+    reduce::pruneUnusedOps(worklist, *this);
     return success();
   }
 

--- a/lib/Reduce/ReductionUtils.cpp
+++ b/lib/Reduce/ReductionUtils.cpp
@@ -29,21 +29,26 @@ const char *MetasyntacticNameGenerator::getNextName() {
 // Utilities
 //===----------------------------------------------------------------------===//
 
-void reduce::pruneUnusedOps(Operation *initialOp, Reduction &reduction) {
-  SmallVector<Operation *> worklist;
+void reduce::pruneUnusedOps(SmallVectorImpl<Operation *> &worklist,
+                            Reduction &reduction) {
   SmallSet<Operation *, 4> handled;
-  worklist.push_back(initialOp);
   while (!worklist.empty()) {
     auto *op = worklist.pop_back_val();
-    if (!op->use_empty() || op->hasAttr("inner_sym"))
+    if (!op || handled.contains(op) || !op->use_empty() ||
+        op->hasAttr("inner_sym"))
       continue;
+    handled.insert(op);
     for (auto arg : op->getOperands())
       if (auto *argOp = arg.getDefiningOp())
-        if (handled.insert(argOp).second)
-          worklist.push_back(argOp);
+        worklist.push_back(argOp);
     reduction.notifyOpErased(op);
     op->erase();
   }
+}
+
+void reduce::pruneUnusedOps(Operation *initialOp, Reduction &reduction) {
+  SmallVector<Operation *> worklist({initialOp});
+  pruneUnusedOps(worklist, reduction);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/Reduction/connect-forwarder.mlir
+++ b/test/Dialect/FIRRTL/Reduction/connect-forwarder.mlir
@@ -55,3 +55,17 @@ firrtl.circuit "LayerblockCrossBlock" {
     }
   }
 }
+
+// Test that when forwarding through connects and using the "pruneUnusedOps"
+// APIs, that this doesn't break if both the source and the destination are
+// pruned twice (once by visiting the source and once by the destination).
+// See: https://github.com/llvm/circt/issues/10049
+firrtl.circuit "PruneUnusedSourceAndDest" {
+  // CHECK-LABEL: firrtl.module @PruneUnusedSourceAndDest
+  firrtl.module @PruneUnusedSourceAndDest(in %clk: !firrtl.clock, in %rst: !firrtl.asyncreset) {
+    // CHECK-NEXT: }
+    %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
+    %reg = firrtl.regreset %clk, %rst, %c0_ui4 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<4>, !firrtl.uint<4>
+    firrtl.matchingconnect %reg, %c0_ui4 : !firrtl.uint<4>
+  }
+}


### PR DESCRIPTION
Fix a crash in the connect-forwarder stemming from serial use of
`pruneUnusedOp`.  Add a new `pruneUnusedOps` which allows the user to
specify a worklist which avoids the need to deal with serial calls where
the first call deletes operations that the second also wants to
visit/delete.

Fixes #10049.

AI-assisted-by: Augment (Claude Sonnet 4.5)
