### PR TITLE
[ImportVerilog] Handle `$monitor([boh]?|on|off)` statements

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -629,6 +629,7 @@ def ConstantOp : MooreOp<"constant", [Pure, ConstantLike]> {
     OpBuilder<(ins "IntType":$type, "const APInt &":$value)>,
     OpBuilder<(
       ins "IntType":$type, "int64_t":$value, CArg<"bool", "true">:$isSigned)>,
+    OpBuilder<(ins "Domain":$domain, "bool":$value)>,
   ];
 }
 

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -432,6 +432,33 @@ struct Context {
   /// returns the index of the last element of the queue.
   Value currentQueue = {};
 
+  /// Ensure that the global variables for `$monitor` state exist. This creates
+  /// the `__monitor_active_id` and `__monitor_enabled` globals on first call.
+  void ensureMonitorGlobals();
+
+  /// Process any pending `$monitor` calls and generate the monitoring
+  /// procedures at module level.
+  LogicalResult flushPendingMonitors();
+
+  /// Global variable ops for `$monitor` state management. These are created on
+  /// demand by `ensureMonitorGlobals()`.
+  moore::GlobalVariableOp monitorActiveIdGlobal = nullptr;
+  moore::GlobalVariableOp monitorEnabledGlobal = nullptr;
+
+  /// The next monitor ID to allocate. ID 0 is reserved for "no monitor active".
+  unsigned nextMonitorId = 1;
+
+  /// Information about a pending `$monitor` call that needs to be converted
+  /// after the current module's body has been processed.
+  struct PendingMonitor {
+    unsigned id;
+    Location loc;
+    const slang::ast::CallExpression *call;
+  };
+
+  /// Pending `$monitor` calls that need to be converted at module level.
+  SmallVector<PendingMonitor> pendingMonitors;
+
 private:
   /// Helper function to extract the commonalities in lowering of functions and
   /// methods

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1119,6 +1119,40 @@ struct StmtVisitor {
       }
     }
 
+    // Monitor enable/disable tasks (`$monitoron`, `$monitoroff`)
+    if (nameId == ksn::MonitorOn || nameId == ksn::MonitorOff) {
+      context.ensureMonitorGlobals();
+      bool enable = (nameId == ksn::MonitorOn);
+      auto enabledRef = moore::GetGlobalVariableOp::create(
+          context.builder, loc, context.monitorEnabledGlobal);
+      auto value = moore::ConstantOp::create(context.builder, loc,
+                                             moore::Domain::TwoValued, enable);
+      moore::BlockingAssignOp::create(context.builder, loc, enabledRef, value);
+      return true;
+    }
+
+    // Monitor tasks (`$monitor[boh]?`)
+    if (nameId == ksn::Monitor || nameId == ksn::MonitorB ||
+        nameId == ksn::MonitorO || nameId == ksn::MonitorH) {
+      context.ensureMonitorGlobals();
+
+      // Allocate a unique ID for this monitor.
+      unsigned myId = context.nextMonitorId++;
+
+      // Emit code to activate this monitor by setting the active_id global.
+      auto i32Type = moore::IntType::getInt(context.getContext(), 32);
+      auto idConst =
+          moore::ConstantOp::create(context.builder, loc, i32Type, myId);
+      auto activeRef = moore::GetGlobalVariableOp::create(
+          context.builder, loc, context.monitorActiveIdGlobal);
+      moore::BlockingAssignOp::create(context.builder, loc, activeRef, idConst);
+
+      // Queue this monitor for processing at module level.
+      context.pendingMonitors.push_back({myId, loc, &expr});
+
+      return true;
+    }
+
     // Give up on any other system tasks. These will be tried again as an
     // expression later.
     return false;
@@ -1209,3 +1243,124 @@ LogicalResult Context::convertStatement(const slang::ast::Statement &stmt) {
   return stmt.visit(StmtVisitor(*this, loc));
 }
 // NOLINTEND(misc-no-recursion)
+
+//===----------------------------------------------------------------------===//
+// Monitor support
+//===----------------------------------------------------------------------===//
+
+void Context::ensureMonitorGlobals() {
+  // If globals already exist, nothing to do.
+  if (monitorActiveIdGlobal && monitorEnabledGlobal)
+    return;
+
+  // Save current builder position and insert at the start of the module.
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(intoModuleOp.getBody());
+
+  auto loc = intoModuleOp.getLoc();
+  auto i32Type = moore::IntType::getInt(getContext(), 32);
+  auto i1Type = moore::IntType::getInt(getContext(), 1);
+
+  // Create "active_id" global variable. Index 0 indicates no monitor
+  // is active.
+  monitorActiveIdGlobal = moore::GlobalVariableOp::create(
+      builder, loc, "__monitor_active_id", i32Type);
+  {
+    OpBuilder::InsertionGuard initGuard(builder);
+    builder.setInsertionPointToStart(
+        &monitorActiveIdGlobal.getInitRegion().emplaceBlock());
+    auto zero = moore::ConstantOp::create(builder, loc, i32Type, 0);
+    moore::YieldOp::create(builder, loc, zero);
+  }
+  symbolTable.insert(monitorActiveIdGlobal);
+
+  // Create "enabled" global variable.
+  monitorEnabledGlobal = moore::GlobalVariableOp::create(
+      builder, loc, "__monitor_enabled", i1Type);
+  {
+    OpBuilder::InsertionGuard initGuard(builder);
+    builder.setInsertionPointToStart(
+        &monitorEnabledGlobal.getInitRegion().emplaceBlock());
+    auto trueVal =
+        moore::ConstantOp::create(builder, loc, moore::Domain::TwoValued, true);
+    moore::YieldOp::create(builder, loc, trueVal);
+  }
+  symbolTable.insert(monitorEnabledGlobal);
+}
+
+LogicalResult Context::flushPendingMonitors() {
+  using ksn = slang::parsing::KnownSystemName;
+  for (auto &pending : pendingMonitors) {
+    auto &call = *pending.call;
+    auto loc = pending.loc;
+
+    // Extract the SystemCallInfo from the call's subroutine variant.
+    auto &info =
+        std::get<slang::ast::CallExpression::SystemCallInfo>(call.subroutine);
+    auto nameId = info.subroutine->knownNameId;
+
+    // Determine the default format based on the system call name.
+    auto defaultFormat = moore::IntFormat::Decimal;
+    switch (nameId) {
+    case ksn::MonitorB:
+      defaultFormat = moore::IntFormat::Binary;
+      break;
+    case ksn::MonitorO:
+      defaultFormat = moore::IntFormat::Octal;
+      break;
+    case ksn::MonitorH:
+      defaultFormat = moore::IntFormat::HexLower;
+      break;
+    default:
+      break;
+    }
+
+    // Create an always_comb procedure for this monitor. This will implement the
+    // semantics of printing an updated message whenever one of the input
+    // signals changes.
+    auto alwaysProc = moore::ProcedureOp::create(
+        builder, loc, moore::ProcedureKind::AlwaysComb);
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(&alwaysProc.getBody().emplaceBlock());
+
+    // Convert the format string and arguments.
+    auto message = convertFormatString(call.arguments(), loc, defaultFormat,
+                                       /*appendNewline=*/true);
+    if (failed(message))
+      return failure();
+
+    // Check if this monitor is active and enabled.
+    auto i32Type = moore::IntType::getInt(getContext(), 32);
+    auto myId = moore::ConstantOp::create(builder, loc, i32Type, pending.id);
+    Value isActive =
+        moore::GetGlobalVariableOp::create(builder, loc, monitorActiveIdGlobal);
+    isActive = moore::ReadOp::create(builder, loc, isActive);
+    isActive = moore::EqOp::create(builder, loc, isActive, myId);
+
+    Value enabled =
+        moore::GetGlobalVariableOp::create(builder, loc, monitorEnabledGlobal);
+    enabled = moore::ReadOp::create(builder, loc, enabled);
+    enabled = moore::AndOp::create(builder, loc, isActive, enabled);
+    enabled = moore::ToBuiltinIntOp::create(builder, loc, enabled);
+
+    // Branch to a print or skip block based on whether the monitor is enabled
+    // or not.
+    auto &printBlock = alwaysProc.getBody().emplaceBlock();
+    auto &skipBlock = alwaysProc.getBody().emplaceBlock();
+    cf::CondBranchOp::create(builder, loc, enabled, &printBlock, &skipBlock);
+
+    // Display the formatted message if one was created, and the monitor is
+    // enabled.
+    builder.setInsertionPointToStart(&printBlock);
+    if (*message)
+      moore::DisplayBIOp::create(builder, loc, *message);
+    moore::ReturnOp::create(builder, loc);
+
+    // Otherwise just return.
+    builder.setInsertionPointToStart(&skipBlock);
+    moore::ReturnOp::create(builder, loc);
+  }
+
+  pendingMonitors.clear();
+  return success();
+}

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1291,6 +1291,10 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
     auto loc = convertLocation(member.location);
     if (failed(member.visit(ModuleVisitor(*this, loc))))
       return failure();
+    // Flush any pending monitors after each member. This places the monitor
+    // procedures immediately after the code that sets them up.
+    if (failed(flushPendingMonitors()))
+      return failure();
   }
 
   // Create additional ops to drive input port values onto the corresponding

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -679,6 +679,13 @@ void ConstantOp::build(OpBuilder &builder, OperationState &result, IntType type,
         APInt(type.getWidth(), (uint64_t)value, isSigned));
 }
 
+/// This builder constructs a 1-bit boolean constant in the specified domain.
+void ConstantOp::build(OpBuilder &builder, OperationState &result,
+                       Domain domain, bool value) {
+  auto type = IntType::get(builder.getContext(), 1, domain);
+  build(builder, result, type, value ? 1 : 0, /*isSigned=*/false);
+}
+
 OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {
   assert(adaptor.getOperands().empty() && "constant has no operands");
   return getValueAttr();

--- a/test/Conversion/ImportVerilog/monitor.sv
+++ b/test/Conversion/ImportVerilog/monitor.sv
@@ -1,0 +1,171 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// CHECK: moore.global_variable @__monitor_active_id : !moore.i32 init {
+// CHECK:   [[ZERO:%.+]] = moore.constant 0 : i32
+// CHECK:   moore.yield [[ZERO]] : i32
+// CHECK: }
+
+// CHECK: moore.global_variable @__monitor_enabled : !moore.i1 init {
+// CHECK:   [[TRUE:%.+]] = moore.constant 1 : i1
+// CHECK:   moore.yield [[TRUE]] : i1
+// CHECK: }
+
+// CHECK-LABEL: moore.module @MonitorBasic
+module MonitorBasic;
+  // CHECK: [[A:%.+]] = moore.variable
+  int a;
+  // CHECK: moore.procedure initial {
+  // CHECK:   [[ID:%.+]] = moore.constant {{[0-9]+}} : i32
+  // CHECK:   [[ACTIVE_REF:%.+]] = moore.get_global_variable @__monitor_active_id : <i32>
+  // CHECK:   moore.blocking_assign [[ACTIVE_REF]], [[ID]] : i32
+  // CHECK:   moore.return
+  // CHECK: }
+  initial begin
+    $monitor("a=%d", a);
+  end
+  // CHECK: moore.procedure always_comb {
+  // CHECK:   [[LIT:%.+]] = moore.fmt.literal "a="
+  // CHECK:   [[A_VAL:%.+]] = moore.read [[A]] : <i32>
+  // CHECK:   [[FMT:%.+]] = moore.fmt.int decimal [[A_VAL]], align right, pad space signed : i32
+  // CHECK:   [[NEWLINE:%.+]] = moore.fmt.literal "\0A"
+  // CHECK:   [[MSG:%.+]] = moore.fmt.concat ([[LIT]], [[FMT]], [[NEWLINE]])
+  // CHECK:   [[MY_ID:%.+]] = moore.constant {{[0-9]+}} : i32
+  // CHECK:   [[ACTIVE_REF:%.+]] = moore.get_global_variable @__monitor_active_id : <i32>
+  // CHECK:   [[ACTIVE_ID:%.+]] = moore.read [[ACTIVE_REF]] : <i32>
+  // CHECK:   [[IS_ACTIVE:%.+]] = moore.eq [[ACTIVE_ID]], [[MY_ID]] : i32 -> i1
+  // CHECK:   [[ENABLED_REF:%.+]] = moore.get_global_variable @__monitor_enabled : <i1>
+  // CHECK:   [[ENABLED:%.+]] = moore.read [[ENABLED_REF]] : <i1>
+  // CHECK:   [[SHOULD_PRINT_MOORE:%.+]] = moore.and [[IS_ACTIVE]], [[ENABLED]] : i1
+  // CHECK:   [[SHOULD_PRINT:%.+]] = moore.to_builtin_int [[SHOULD_PRINT_MOORE]] : i1
+  // CHECK:   cf.cond_br [[SHOULD_PRINT]], ^[[BB1:.+]], ^[[BB2:.+]]
+  // CHECK: ^[[BB1]]:
+  // CHECK:   moore.builtin.display [[MSG]]
+  // CHECK:   moore.return
+  // CHECK: ^[[BB2]]:
+  // CHECK:   moore.return
+  // CHECK: }
+endmodule
+
+// Test $monitor[boh] variants - TODO: check formatting once implemented
+// CHECK-LABEL: moore.module @MonitorFormats
+module MonitorFormats;
+  // CHECK: [[X:%.+]] = moore.variable
+  int x;
+  // CHECK: moore.procedure initial {
+  // CHECK: }
+  initial begin
+    $monitor(x);
+  end
+  // $monitor(x) should format as decimal (same as $display(x))
+  // CHECK: moore.procedure always_comb {
+  // CHECK:   [[X_VAL_0:%.+]] = moore.read [[X]] : <i32>
+  // CHECK:   [[FMT_0:%.+]] = moore.fmt.int decimal [[X_VAL_0]], align right, pad space signed : i32
+  // CHECK:   [[NEWLINE_0:%.+]] = moore.fmt.literal "\0A"
+  // CHECK:   [[MSG_0:%.+]] = moore.fmt.concat ([[FMT_0]], [[NEWLINE_0]])
+  // CHECK:   moore.builtin.display [[MSG_0]]
+  // CHECK: }
+
+  // CHECK: moore.procedure initial {
+  // CHECK: }
+  initial begin
+    $monitorb(x);
+  end
+  // $monitorb(x) should format as binary (same as $displayb(x))
+  // CHECK: moore.procedure always_comb {
+  // CHECK:   [[X_VAL_1:%.+]] = moore.read [[X]] : <i32>
+  // CHECK:   [[FMT_1:%.+]] = moore.fmt.int binary [[X_VAL_1]], align right, pad zero : i32
+  // CHECK:   [[NEWLINE_1:%.+]] = moore.fmt.literal "\0A"
+  // CHECK:   [[MSG_1:%.+]] = moore.fmt.concat ([[FMT_1]], [[NEWLINE_1]])
+  // CHECK:   moore.builtin.display [[MSG_1]]
+  // CHECK: }
+
+  // CHECK: moore.procedure initial {
+  // CHECK: }
+  initial begin
+    $monitoro(x);
+  end
+  // $monitoro(x) should format as octal (same as $displayo(x))
+  // CHECK: moore.procedure always_comb {
+  // CHECK:   [[X_VAL_2:%.+]] = moore.read [[X]] : <i32>
+  // CHECK:   [[FMT_2:%.+]] = moore.fmt.int octal [[X_VAL_2]], align right, pad zero : i32
+  // CHECK:   [[NEWLINE_2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK:   [[MSG_2:%.+]] = moore.fmt.concat ([[FMT_2]], [[NEWLINE_2]])
+  // CHECK:   moore.builtin.display [[MSG_2]]
+  // CHECK: }
+
+  // CHECK: moore.procedure initial {
+  // CHECK: }
+  initial begin
+    $monitorh(x);
+  end
+  // $monitorh(x) should format as hex (same as $displayh(x))
+  // CHECK: moore.procedure always_comb {
+  // CHECK:   [[X_VAL_3:%.+]] = moore.read [[X]] : <i32>
+  // CHECK:   [[FMT_3:%.+]] = moore.fmt.int hex_lower [[X_VAL_3]], align right, pad zero : i32
+  // CHECK:   [[NEWLINE_3:%.+]] = moore.fmt.literal "\0A"
+  // CHECK:   [[MSG_3:%.+]] = moore.fmt.concat ([[FMT_3]], [[NEWLINE_3]])
+  // CHECK:   moore.builtin.display [[MSG_3]]
+  // CHECK: }
+endmodule
+
+// CHECK-LABEL: moore.module @MonitorControl
+module MonitorControl;
+  int e;
+  // CHECK: moore.procedure initial {
+  // CHECK: [[ENABLED_REF_OFF:%.+]] = moore.get_global_variable @__monitor_enabled : <i1>
+  // CHECK: [[FALSE:%.+]] = moore.constant 0 : i1
+  // CHECK: moore.blocking_assign [[ENABLED_REF_OFF]], [[FALSE]] : i1
+  // CHECK: [[ENABLED_REF_ON:%.+]] = moore.get_global_variable @__monitor_enabled : <i1>
+  // CHECK: [[TRUE:%.+]] = moore.constant 1 : i1
+  // CHECK: moore.blocking_assign [[ENABLED_REF_ON]], [[TRUE]] : i1
+  // CHECK: moore.return
+  // CHECK: }
+  initial begin
+    $monitor("e=%d", e);
+    #10;
+    $monitoroff;
+    #10;
+    $monitoron;
+  end
+  // Verify the monitor procedure is created after the initial block
+  // CHECK: moore.procedure always_comb {
+  // CHECK: moore.return
+  // CHECK: }
+endmodule
+
+// CHECK-LABEL: moore.module @MultipleMonitors
+module MultipleMonitors;
+  // CHECK: [[F:%.+]] = moore.variable
+  // CHECK: [[G:%.+]] = moore.variable
+  int f, g;
+  // CHECK: moore.procedure initial {
+  // CHECK: moore.return
+  // CHECK: }
+  initial begin
+    $monitor("f=%d", f);
+    #10;
+    $monitor("g=%d", g);
+  end
+  // First monitor procedure - monitors variable f
+  // CHECK: moore.procedure always_comb {
+  // CHECK:   [[LIT_F:%.+]] = moore.fmt.literal "f="
+  // CHECK:   [[F_VAL:%.+]] = moore.read [[F]] : <i32>
+  // CHECK:   [[FMT_F:%.+]] = moore.fmt.int decimal [[F_VAL]], align right, pad space signed : i32
+  // CHECK:   [[NEWLINE_F:%.+]] = moore.fmt.literal "\0A"
+  // CHECK:   [[MSG_F:%.+]] = moore.fmt.concat ([[LIT_F]], [[FMT_F]], [[NEWLINE_F]])
+  // CHECK:   moore.builtin.display [[MSG_F]]
+  // CHECK: }
+  // Second monitor procedure - monitors variable g
+  // CHECK: moore.procedure always_comb {
+  // CHECK:   [[LIT_G:%.+]] = moore.fmt.literal "g="
+  // CHECK:   [[G_VAL:%.+]] = moore.read [[G]] : <i32>
+  // CHECK:   [[FMT_G:%.+]] = moore.fmt.int decimal [[G_VAL]], align right, pad space signed : i32
+  // CHECK:   [[NEWLINE_G:%.+]] = moore.fmt.literal "\0A"
+  // CHECK:   [[MSG_G:%.+]] = moore.fmt.concat ([[LIT_G]], [[FMT_G]], [[NEWLINE_G]])
+  // CHECK:   moore.builtin.display [[MSG_G]]
+  // CHECK: }
+endmodule


### PR DESCRIPTION
Implement handling for the `$monitor`, `$monitorb`, `$monitoro`, `$monitorh`, `$monitoron`, and `$monitoroff` system task statements. These are very strange: only the very last monitor task executed is active, across all modules in the design. The monitor will then behave like `$strobe`, printing its message at the end of the simulation time step whenever any of its arguments changes. We don't have proper support for `$strobe` and execution at the end of a time step yet, so we just make `$monitor` behave like a `$display` in an `always_comb` procedure.

As a starting point, create two global variables that track which monitor is active and whether monitoring hsa been enabled or disabled globally by `$monitoron` and `$monitoroff`. Then lower each `$monitor` to an assignment to the variable tracking which monitor is active, and implement the printing as a separate `moore.procedure always_comb`.

This should cover the semantics closely enough for now. The string formatting part is identical to `$display`.