### PR TITLE
[circt-reduce] Add convention attribute remover

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -2542,6 +2542,40 @@ struct ListCreateElementRemover : public OpReduction<ListCreateOp> {
   }
 };
 
+/// Reduction that removes the `convention` attribute from regular modules.
+struct ModuleConventionRemover : public OpReduction<FModuleOp> {
+  uint64_t match(FModuleOp module) override {
+    return module.getConvention() != Convention::Internal;
+  }
+
+  LogicalResult rewrite(FModuleOp module) override {
+    module.setConvention(Convention::Internal);
+    return success();
+  }
+
+  std::string getName() const override { return "module-convention-remover"; }
+  bool acceptSizeIncrease() const override { return true; }
+  bool isOneShot() const override { return true; }
+};
+
+/// Reduction that removes the `convention` attribute from external modules.
+struct ExtmoduleConventionRemover : public OpReduction<FExtModuleOp> {
+  uint64_t match(FExtModuleOp extmodule) override {
+    return extmodule.getConvention() != Convention::Internal;
+  }
+
+  LogicalResult rewrite(FExtModuleOp extmodule) override {
+    extmodule.setConvention(Convention::Internal);
+    return success();
+  }
+
+  std::string getName() const override {
+    return "extmodule-convention-remover";
+  }
+  bool acceptSizeIncrease() const override { return true; }
+  bool isOneShot() const override { return true; }
+};
+
 //===----------------------------------------------------------------------===//
 // Reduction Registration
 //===----------------------------------------------------------------------===//
@@ -2603,6 +2637,8 @@ void firrtl::FIRRTLReducePatternDialectInterface::populateReducePatterns(
   patterns.add<ConnectSourceOperandForwarder<2>, 1>();
   patterns.add<ModuleInternalNameSanitizer, 0>();
   patterns.add<ModuleNameSanitizer, 0>();
+  patterns.add<ModuleConventionRemover, 0>();
+  patterns.add<ExtmoduleConventionRemover, 0>();
 }
 
 void firrtl::registerReducePatternDialectInterface(

--- a/test/Dialect/FIRRTL/Reduction/convention-remover.mlir
+++ b/test/Dialect/FIRRTL/Reduction/convention-remover.mlir
@@ -1,0 +1,22 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include module-convention-remover --include extmodule-convention-remover | FileCheck %s
+
+// Test removing convention attribute from regular module
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: firrtl.module @Foo
+  // CHECK-SAME: () {
+  // CHECK-NOT: attributes
+  // CHECK-NOT: convention
+  firrtl.module @Foo() attributes {convention = #firrtl<convention scalarized>} {
+  }
+}
+
+// Test removing convention attribute from external module
+firrtl.circuit "Bar" {
+  // CHECK-LABEL: firrtl.extmodule @Bar
+  // CHECK-SAME: ()
+  // CHECK-NOT: attributes
+  // CHECK-NOT: convention
+  firrtl.extmodule @Bar() attributes {convention = #firrtl<convention scalarized>}
+}

--- a/test/Dialect/FIRRTL/Reduction/pattern-registration.mlir
+++ b/test/Dialect/FIRRTL/Reduction/pattern-registration.mlir
@@ -16,6 +16,7 @@
 // CHECK-DAG: connect-source-operand-2-forwarder
 // CHECK-DAG: cse
 // CHECK-DAG: detach-subaccesses
+// CHECK-DAG: extmodule-convention-remover
 // CHECK-DAG: firrtl-eager-inliner
 // CHECK-DAG: extmodule-instance-remover
 // CHECK-DAG: firrtl-constantifier
@@ -43,6 +44,7 @@
 // CHECK-DAG: instance-stubber
 // CHECK-DAG: sv-namehint-remover
 // CHECK-DAG: memory-stubber
+// CHECK-DAG: module-convention-remover
 // CHECK-DAG: module-internal-name-sanitizer
 // CHECK-DAG: module-name-sanitizer
 // CHECK-DAG: node-symbol-remover


### PR DESCRIPTION
Add reductions to remove the 'convention' attribute from FModuleOp and
FExtModuleOp. This is a simple cleanup reduction that has little
functional impact but makes the reduced output cleaner for inspection.

The convention attribute controls how module ports are lowered (e.g.,
scalarized vs internal). For reduction purposes, removing this attribute
simplifies the IR without affecting the core issue being reduced.

The reduction sets the convention to 'Internal' (the default), which is
represented as having no explicit convention attribute in the MLIR text
form.

AI-assisted-by: Augment (Claude Sonnet 4.5)
