### PR TITLE
[circt-reduce] Add reset disconnect reduction

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -1735,6 +1735,30 @@ struct ObjectInliner : public OpReduction<ObjectOp> {
   std::unique_ptr<hw::InnerSymbolTableCollection> innerSymTables;
 };
 
+/// Reduction that converts `regreset` to `reg` by dropping reset and init
+/// value.
+struct ResetDisconnector : public OpReduction<RegResetOp> {
+  uint64_t match(RegResetOp op) override { return 1; }
+
+  LogicalResult rewrite(RegResetOp regResetOp) override {
+    ImplicitLocOpBuilder builder(regResetOp.getLoc(), regResetOp);
+    auto regOp = RegOp::create(
+        builder, regResetOp.getResult().getType(), regResetOp.getClockVal(),
+        regResetOp.getNameAttr(), regResetOp.getNameKindAttr(),
+        regResetOp.getAnnotationsAttr(), regResetOp.getInnerSymAttr(),
+        regResetOp.getForceableAttr());
+
+    regResetOp.getResult().replaceAllUsesWith(regOp.getResult());
+    if (regResetOp.getForceable())
+      regResetOp.getRef().replaceAllUsesWith(regOp.getRef());
+    regResetOp.erase();
+
+    return success();
+  }
+
+  std::string getName() const override { return "reset-disconnector"; }
+};
+
 /// Psuedo-reduction that sanitizes the names of things inside modules.  This is
 /// not an actual reduction, but often removes extraneous information that has
 /// no bearing on the actual reduction (and would likely be removed before
@@ -2592,6 +2616,7 @@ void firrtl::FIRRTLReducePatternDialectInterface::populateReducePatterns(
   patterns.add<FIRRTLOperandForwarder<1>, 10>();
   patterns.add<FIRRTLOperandForwarder<2>, 9>();
   patterns.add<ListCreateElementRemover, 8>();
+  patterns.add<ResetDisconnector, 8>();
   patterns.add<DetachSubaccesses, 7>();
   patterns.add<ModulePortPruner, 7>();
   patterns.add<ExtmodulePortPruner, 6>();

--- a/test/Dialect/FIRRTL/Reduction/pattern-registration.mlir
+++ b/test/Dialect/FIRRTL/Reduction/pattern-registration.mlir
@@ -47,6 +47,7 @@
 // CHECK-DAG: module-name-sanitizer
 // CHECK-DAG: node-symbol-remover
 // CHECK-DAG: operation-pruner
+// CHECK-DAG: reset-disconnector
 // CHECK-DAG: root-port-pruner
 // CHECK-EMPTY:
 firrtl.circuit "Foo" {

--- a/test/Dialect/FIRRTL/Reduction/reset-disconnector.mlir
+++ b/test/Dialect/FIRRTL/Reduction/reset-disconnector.mlir
@@ -1,0 +1,21 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg true --keep-best=0 --include reset-disconnector | FileCheck %s --check-prefixes=CHECK,ALL
+// RUN: circt-reduce %s --test /usr/bin/grep --test-arg 'reg1.*firrtl\.regreset' --keep-best=0 --include reset-disconnector | FileCheck %s --check-prefixes=CHECK,KEEP_REG1
+
+// Test converting all regreset to reg, and independently keeping one
+// CHECK-LABEL: firrtl.circuit "Test"
+firrtl.circuit "Test" {
+  // CHECK-LABEL: firrtl.module @Test
+  firrtl.module @Test(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
+    // ALL: %reg1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+    // ALL: %reg2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<16>
+    // ALL-NOT: regreset
+    // KEEP_REG1: %reg1 = firrtl.regreset %clock, %reset
+    // KEEP_REG1: %reg2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<16>
+    %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
+    %c0_ui16 = firrtl.constant 0 : !firrtl.uint<16>
+    %reg1 = firrtl.regreset %clock, %reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %reg2 = firrtl.regreset %clock, %reset, %c0_ui16 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<16>, !firrtl.uint<16>
+  }
+}


### PR DESCRIPTION
Add a reduction that converts `firrtl.regreset` to `firrtl.reg` by
dropping the reset signal and initialization value operands.  This likely
has little effect on the actual reduction and is more of an output visual
quality kind of reduction.  I've often found myself doing this reduction
manually to make things easier to read.

AI-assisted-by: Augment (Claude Sonnet 4.5)
