### PR TITLE
[CoreToFSM] Error out when clocks are used outside regs

### DIFF
--- a/lib/Conversion/CoreToFSM/CoreToFSM.cpp
+++ b/lib/Conversion/CoreToFSM/CoreToFSM.cpp
@@ -1153,6 +1153,15 @@ public:
     front.eraseArguments([&](BlockArgument arg) {
       return asyncResetBlockArguments.contains(arg);
     });
+
+    if (llvm::any_of(front.getArguments(), [](BlockArgument arg) {
+          return arg.getType() == seq::ClockType::get(arg.getContext()) &&
+                 arg.hasNUsesOrMore(1);
+        })) {
+      moduleOp.emitError("Clock uses outside register clocking are not "
+                         "currently supported.");
+      return failure();
+    }
     machine.getBody().front().eraseArguments([&](BlockArgument arg) {
       return arg.getType() == seq::ClockType::get(arg.getContext());
     });

--- a/test/Conversion/CoreToFSM/errors.mlir
+++ b/test/Conversion/CoreToFSM/errors.mlir
@@ -111,3 +111,14 @@ hw.module @regs_without_reset(in %clk : !seq.clock) {
     // expected-warning @below {{Assuming register with no reset starts with value 0}}
     %var = seq.compreg name "var" %state, %clk : i1
 }
+
+// -----
+
+// expected-warning @+2 {{reset signals detected and removed from FSM}}
+// expected-error @+1 {{Clock uses outside register clocking are not currently supported.}}
+hw.module @clock_use(in %clk : !seq.clock, in %rst : i1) {
+    %c0_i1 = hw.constant 0 : i1
+    %state = seq.compreg name "state" %state, %clk reset %rst, %c0_i1 : i1
+    %clk_as_i1 = seq.from_clock %clk
+    verif.assert %clk_as_i1 : i1
+}


### PR DESCRIPTION
We currently crash when clocks are used for something other than reg clocking, since the pass tries to erase the clock while it still has uses. This just catches that case and errors out.

@AtticusKuhn @luisacicolini I can't request reviews since you're not org members but if you could take a look that would be very appreciated!