### PR TITLE
[CoreToFSM] Error out on multiple reg clocks

### DIFF
--- a/lib/Conversion/CoreToFSM/CoreToFSM.cpp
+++ b/lib/Conversion/CoreToFSM/CoreToFSM.cpp
@@ -626,7 +626,17 @@ public:
   LogicalResult run() {
     SmallVector<seq::CompRegOp> stateRegs;
     SmallVector<seq::CompRegOp> variableRegs;
+    Value foundClock = nullptr;
     WalkResult walkResult = moduleOp.walk([&](seq::CompRegOp reg) {
+      auto clk = reg.getClk();
+      if (foundClock) {
+        if (clk != foundClock) {
+          reg.emitError("All clocks must have the same clock signal.");
+          return WalkResult::interrupt();
+        }
+      } else {
+        foundClock = clk;
+      }
       // Check that the register type is an integer.
       if (!isa<IntegerType>(reg.getType())) {
         reg.emitError("FSM extraction only supports integer-typed registers");

--- a/test/Conversion/CoreToFSM/errors.mlir
+++ b/test/Conversion/CoreToFSM/errors.mlir
@@ -122,3 +122,12 @@ hw.module @clock_use(in %clk : !seq.clock, in %rst : i1) {
     %clk_as_i1 = seq.from_clock %clk
     verif.assert %clk_as_i1 : i1
 }
+
+// -----
+
+hw.module @multiclock(in %clk : !seq.clock, in %clk2 : !seq.clock, in %rst : i1) {
+    %c0_i1 = hw.constant false
+    %state = seq.compreg name "state" %state, %clk reset %rst, %c0_i1 : i1
+    // expected-error @below {{All clocks must have the same clock signal.}}
+    %var = seq.compreg name "var" %state, %clk2 reset %rst, %c0_i1 : i1
+}


### PR DESCRIPTION
Currently we assume all registers have the same clocks - if that isn't the case, we ignore it and produce an FSM with mismatched semantics. This just ensures we error out if we hit this case.

@luisacicolini @AtticusKuhn as before if one of you has time to review this that would be very helpful!