### PR TITLE
[CoreToFSM] Require that all registers have the same reset signal

### DIFF
--- a/lib/Conversion/CoreToFSM/CoreToFSM.cpp
+++ b/lib/Conversion/CoreToFSM/CoreToFSM.cpp
@@ -626,9 +626,10 @@ public:
   LogicalResult run() {
     SmallVector<seq::CompRegOp> stateRegs;
     SmallVector<seq::CompRegOp> variableRegs;
-    Value foundClock = nullptr;
+    Value foundClock, foundReset = nullptr;
     WalkResult walkResult = moduleOp.walk([&](seq::CompRegOp reg) {
       auto clk = reg.getClk();
+      auto reset = reg.getReset();
       if (foundClock) {
         if (clk != foundClock) {
           reg.emitError("All clocks must have the same clock signal.");
@@ -637,6 +638,18 @@ public:
       } else {
         foundClock = clk;
       }
+
+      if (reset) {
+        if (foundReset) {
+          if (reset != foundReset) {
+            reg.emitError("All registers must have the same reset signal.");
+            return WalkResult::interrupt();
+          }
+        } else {
+          foundReset = reset;
+        }
+      }
+
       // Check that the register type is an integer.
       if (!isa<IntegerType>(reg.getType())) {
         reg.emitError("FSM extraction only supports integer-typed registers");

--- a/test/Conversion/CoreToFSM/errors.mlir
+++ b/test/Conversion/CoreToFSM/errors.mlir
@@ -131,3 +131,12 @@ hw.module @multiclock(in %clk : !seq.clock, in %clk2 : !seq.clock, in %rst : i1)
     // expected-error @below {{All clocks must have the same clock signal.}}
     %var = seq.compreg name "var" %state, %clk2 reset %rst, %c0_i1 : i1
 }
+
+// -----
+
+hw.module @multireset(in %clk : !seq.clock, in %rst : i1, in %rst2 : i1) {
+    %c0_i1 = hw.constant false
+    %state = seq.compreg name "state" %state, %clk reset %rst, %c0_i1 : i1
+    // expected-error @below {{All registers must have the same reset signal.}}
+    %var = seq.compreg name "var" %state, %clk reset %rst2, %c0_i1 : i1
+}


### PR DESCRIPTION
Pretty much does what #10061 does but for resets (since the `fsm.hw_instance` op has a single reset argument, so we risk mutating reset behaviour in this case).

@luisacicolini @AtticusKuhn a review would be great if either of you have the chance!