### PR TITLE
[ImportVerilog] Fix signal captures in timing controls

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -420,6 +420,12 @@ struct Context {
   /// used to collect all variables assigned in a task scope.
   std::function<void(mlir::Operation *)> variableAssignCallback;
 
+  /// Whether we are currently converting expressions inside a timing control,
+  /// such as `@(posedge clk)`. This is used by the implicit event control
+  /// callback to avoid adding reads from explicit event controls to the
+  /// implicit sensitivity list.
+  bool isInsideTimingControl = false;
+
   /// The time scale currently in effect.
   slang::TimeScale timeScale;
 

--- a/lib/Conversion/ImportVerilog/TimingControls.cpp
+++ b/lib/Conversion/ImportVerilog/TimingControls.cpp
@@ -9,6 +9,7 @@
 #include "ImportVerilogInternals.h"
 #include "slang/ast/TimingControl.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/SaveAndRestore.h"
 
 using namespace circt;
 using namespace ImportVerilog;
@@ -218,15 +219,11 @@ Context::convertTimingControl(const slang::ast::TimingControl &ctrl,
                               const slang::ast::Statement &stmt) {
   // Convert the timing control. Implicit event control will create a new empty
   // `WaitEventOp` and assign it to `implicitWaitOp`. This op will be populated
-  // further down.
+  // further down. Mark that we are inside a timing control so the implicit
+  // event callback can skip reads that are part of the event expression itself.
   moore::WaitEventOp implicitWaitOp;
   {
-    auto previousCallback = rvalueReadCallback;
-    llvm::scope_exit done([&] { rvalueReadCallback = previousCallback; });
-    // Reads happening as part of the event control should not be added to a
-    // surrounding implicit event control's list of implicitly observed
-    // variables.
-    rvalueReadCallback = nullptr;
+    llvm::SaveAndRestore flagGuard(isInsideTimingControl, true);
     if (failed(handleRoot(*this, ctrl, &implicitWaitOp)))
       return failure();
   }
@@ -241,7 +238,8 @@ Context::convertTimingControl(const slang::ast::TimingControl &ctrl,
     llvm::scope_exit done([&] { rvalueReadCallback = previousCallback; });
     if (implicitWaitOp) {
       rvalueReadCallback = [&](moore::ReadOp readOp) {
-        readValues.insert(readOp.getInput());
+        if (!isInsideTimingControl)
+          readValues.insert(readOp.getInput());
         if (previousCallback)
           previousCallback(readOp);
       };

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3736,6 +3736,44 @@ module testRecursiveCaptureFunction();
   endfunction
 endmodule
 
+// Task that reads a module-scope signal in an event control expression. The
+// signal must be captured as an extra argument to the task function.
+// CHECK-LABEL: moore.module @CaptureInEventControl
+module CaptureInEventControl;
+  // CHECK: [[CLK:%.+]] = moore.variable : <l1>
+  logic clk;
+  // CHECK: [[DATA:%.+]] = moore.variable : <i32>
+  int data;
+
+  initial begin
+    // CHECK: call @waitForClk([[CLK]])
+    waitForClk();
+    // CHECK: call @readOnClk([[CLK]], [[DATA]])
+    readOnClk();
+  end
+
+  // CHECK: func.func private @waitForClk(%arg0: !moore.ref<l1>)
+  task automatic waitForClk;
+    // CHECK: moore.wait_event {
+    // CHECK:   [[TMP:%.+]] = moore.read %arg0
+    // CHECK:   moore.detect_event posedge [[TMP]]
+    // CHECK: }
+    @(posedge clk);
+  endtask
+
+  // CHECK: func.func private @readOnClk(%arg0: !moore.ref<l1>, %arg1: !moore.ref<i32>)
+  task automatic readOnClk;
+    int result;
+    // CHECK: moore.wait_event {
+    // CHECK:   [[TMP:%.+]] = moore.read %arg0
+    // CHECK:   moore.detect_event posedge [[TMP]]
+    // CHECK: }
+    @(posedge clk);
+    // CHECK: [[TMP:%.+]] = moore.read %arg1
+    result = data;
+  endtask
+endmodule
+
 // CHECK-LABEL: moore.module @RealLiteral() {
 module RealLiteral();
    // CHECK-NEXT:  [[REALCONSTANT:%.+]] = moore.constant_real 5.000000e-01 : f64


### PR DESCRIPTION
When a task reads a module-scope signal in an event control expression like `@(posedge clk)`, the signal must be captured as an extra argument to the task function. Previously, `convertTimingControl` set the `rvalueReadCallback` to null to prevent event control reads from polluting implicit `@*` sensitivity lists. This also suppressed the function capture callback, causing the signal to be used across region boundaries without being plumbed as an argument.

Replace the callback nulling with an `isInsideTimingControl` flag. The implicit event callback checks this flag before recording reads, while function capture callbacks (which don't check it) continue to work.