### PR TITLE
[Moore] Unify random builtins into urandom_range, add lowering

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2919,58 +2919,32 @@ def BitstoshortrealBIOp : Builtin<"bitstoshortreal"> {
 // True-Random and Pseudo-Random Generators
 //===----------------------------------------------------------------------===//
 
-def RandomBIOp : Builtin<"random"> {
-  let summary = "Generate a true random signed integer (optionally seeded)";
+def UrandomRangeBIOp : Builtin<"urandom_range"> {
+  let summary = "Generate a pseudo-random integer within a range";
   let description = [{
-    Corresponds to the `$random` system function. Returns a 32-bit
-    true random integer. The seed is optional; when provided, it initializes
-    the generator. If not provided, treat it as 0 in semantics/lowering.
+    Returns a pseudo-random 32-bit integer in the range [minval, maxval]. This
+    is the unified primitive for all SystemVerilog random number generation:
 
-    `$random` is largely considered to be deprecated since it leads to
-    non-reproducible simulation results. Consider using `$urandom` instead.
+    - `$random` maps to `urandom_range(0, 2^31-1)` (signedness is a
+      reinterpretation of the result, not a property of the random value)
+    - `$urandom` maps to `urandom_range(0, 2^32-1)`
+    - `$urandom_range(max)` maps to `urandom_range(0, max)`
+    - `$urandom_range(max, min)` maps to `urandom_range(min, max)`
 
-    See IEEE 1800-2023 § 20.14 "Probablistic distribution functions".
-  }];
+    The optional `seed` is an inout reference to a 32-bit integer that the
+    random number generator reads and mutates. When not provided, the generator
+    uses an internal seed.
 
-  // Optional positional attribute for the seed
-  let arguments = (ins Optional<TwoValuedI32>:$seed);
-  let results = (outs TwoValuedI32:$result);
-  let assemblyFormat = "($seed^)? attr-dict";
-}
-
-def UrandomBIOp : Builtin<"urandom"> {
-  let summary = "Generate a pseudo-random unsigned integer (optionally seeded)";
-  let description = [{
-    Corresponds to the `$urandom` system function. Returns a 32-bit
-    pseudo-random integer. The seed is optional; when provided, it initializes
-    the generator. If not provided, treat it as 0 in semantics/lowering.
-
-    See IEEE 1800-2023 § 18.13 "Random number system functions and methods".
-  }];
-
-  // Optional positional attribute for the seed
-  let arguments = (ins Optional<TwoValuedI32>:$seed);
-  let results = (outs TwoValuedI32:$result);
-  let assemblyFormat = "($seed^)? attr-dict";
-}
-
-def UrandomrangeBIOp : Builtin<"urandom_range"> {
-  let summary = "Generate a pseudo-random unsigned integer within provided range";
-  let description = [{
-    Corresponds to the `urandom_range()` system function. Returns a 32-bit 
-    pseudo-random integer. The minimum value is optional; when not provided, it 
-    is treated as 0. If the minimum value is provided and larger than the maximum 
-    value, the minimum value is treated as the maximum, aand vice versa.
-
-    See IEEE 1800-2023 $ 18.13.2 "$urandom_range()".
+    See IEEE 1800-2017 § 18.13 "Random number system functions and methods".
   }];
 
   let arguments = (ins
+    TwoValuedI32:$minval,
     TwoValuedI32:$maxval,
-    Optional<TwoValuedI32>:$minval
+    Optional<TwoValuedI32RefType>:$seed
   );
   let results = (outs TwoValuedI32:$result);
-  let assemblyFormat = "$maxval ($minval^)? attr-dict";
+  let assemblyFormat = "$minval `,` $maxval (`,` $seed^)? attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -604,4 +604,10 @@ def QueueRefType : SpecificRefType<QueueType>;
 /// Assoc Array references
 def AssocArrayRefType : SpecificRefType<AssocArrayType>;
 
+/// Integer references
+def TwoValuedI32RefType : SpecificRefType<TwoValuedI32> {
+  let builderCall =
+    "RefType::get(IntType::getInt($_builder.getContext(), 32))";
+}
+
 #endif // CIRCT_DIALECT_MOORE_MOORETYPES

--- a/include/circt/Support/ConversionPatternSet.h
+++ b/include/circt/Support/ConversionPatternSet.h
@@ -31,51 +31,76 @@ public:
   using RewritePatternSet::add;
 
   /// Add a `matchAndRewrite` function as a conversion pattern to the set.
-  template <class Op>
-  ConversionPatternSet &
-  add(LogicalResult (*implFn)(Op, typename Op::Adaptor,
-                              ConversionPatternRewriter &)) {
+  /// Extra arguments beyond the op, adaptor, and rewriter are deduced from the
+  /// function pointer signature, stored in the pattern, and forwarded on each
+  /// invocation.
+  template <class Op, typename... ExtraArgs>
+  ConversionPatternSet &add(LogicalResult (*implFn)(Op, typename Op::Adaptor,
+                                                    ConversionPatternRewriter &,
+                                                    ExtraArgs...),
+                            llvm::type_identity_t<ExtraArgs>... args) {
 
     struct FnPattern final : public OpConversionPattern<Op> {
-      using OpConversionPattern<Op>::OpConversionPattern;
       LogicalResult (*implFn)(Op, typename Op::Adaptor,
-                              ConversionPatternRewriter &);
+                              ConversionPatternRewriter &, ExtraArgs...);
+      std::tuple<ExtraArgs...> extraArgs;
+
+      FnPattern(const TypeConverter &tc, MLIRContext *ctx,
+                LogicalResult (*implFn)(Op, typename Op::Adaptor,
+                                        ConversionPatternRewriter &,
+                                        ExtraArgs...),
+                ExtraArgs... args)
+          : OpConversionPattern<Op>(tc, ctx), implFn(implFn),
+            extraArgs(args...) {}
 
       LogicalResult
       matchAndRewrite(Op op, typename Op::Adaptor adaptor,
                       ConversionPatternRewriter &rewriter) const override {
-        return implFn(op, adaptor, rewriter);
+        return std::apply(
+            implFn, std::tuple_cat(std::tie(op, adaptor, rewriter), extraArgs));
       }
     };
 
-    auto pattern = std::make_unique<FnPattern>(typeConverter, getContext());
-    pattern->implFn = implFn;
-    add(std::move(pattern));
+    add(std::make_unique<FnPattern>(typeConverter, getContext(), implFn,
+                                    args...));
     return *this;
   }
 
-  /// Add a `matchAndRewrite` function as a conversion pattern to the set.
-  template <class Op>
+  /// Add a `matchAndRewrite` function as a conversion pattern to the set. The
+  /// pattern's type converter is automatically forwarded to the function,
+  /// followed by any extra arguments.
+  template <class Op, typename... ExtraArgs>
   ConversionPatternSet &add(LogicalResult (*implFn)(Op, typename Op::Adaptor,
                                                     ConversionPatternRewriter &,
-                                                    const TypeConverter &)) {
+                                                    const TypeConverter &,
+                                                    ExtraArgs...),
+                            llvm::type_identity_t<ExtraArgs>... args) {
 
     struct FnPattern final : public OpConversionPattern<Op> {
-      using OpConversionPattern<Op>::OpConversionPattern;
       LogicalResult (*implFn)(Op, typename Op::Adaptor,
                               ConversionPatternRewriter &,
-                              const TypeConverter &);
+                              const TypeConverter &, ExtraArgs...);
+      std::tuple<ExtraArgs...> extraArgs;
+
+      FnPattern(const TypeConverter &tc, MLIRContext *ctx,
+                LogicalResult (*implFn)(Op, typename Op::Adaptor,
+                                        ConversionPatternRewriter &,
+                                        const TypeConverter &, ExtraArgs...),
+                ExtraArgs... args)
+          : OpConversionPattern<Op>(tc, ctx), implFn(implFn),
+            extraArgs(args...) {}
 
       LogicalResult
       matchAndRewrite(Op op, typename Op::Adaptor adaptor,
                       ConversionPatternRewriter &rewriter) const override {
-        return implFn(op, adaptor, rewriter, *this->typeConverter);
+        return std::apply(
+            implFn, std::tuple_cat(std::tie(op, adaptor, rewriter),
+                                   std::tie(*this->typeConverter), extraArgs));
       }
     };
 
-    auto pattern = std::make_unique<FnPattern>(typeConverter, getContext());
-    pattern->implFn = implFn;
-    add(std::move(pattern));
+    add(std::make_unique<FnPattern>(typeConverter, getContext(), implFn,
+                                    args...));
     return *this;
   }
 };

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2987,48 +2987,37 @@ Value Context::convertSystemCall(
   // Random Number System Functions
   //===--------------------------------------------------------------------===//
 
-  if (nameId == ksn::URandom) {
-    if (numArgs == 0)
-      return moore::UrandomBIOp::create(builder, loc, nullptr);
+  // $urandom, $random, and $urandom_range all map to a single
+  // moore.builtin.urandom_range primitive with (minval, maxval, seed).
+  if (nameId == ksn::URandom || nameId == ksn::Random) {
+    auto i32Ty = moore::IntType::getInt(builder.getContext(), 32);
+    auto minval = moore::ConstantOp::create(builder, loc, i32Ty, 0);
+    auto maxval =
+        moore::ConstantOp::create(builder, loc, i32Ty, APInt::getAllOnes(32));
+    Value seed;
     if (numArgs == 1) {
-      auto seed = convertRvalueExpression(*args[0]);
+      seed = convertLvalueExpression(*args[0]);
       if (!seed)
         return {};
-      return moore::UrandomBIOp::create(builder, loc, seed);
     }
-    // Slang already checks the arity of `$urandom`.
-    assert(false && "`$urandom` takes 0 or 1 arguments");
-    return {};
-  }
-
-  if (nameId == ksn::Random) {
-    if (numArgs == 0)
-      return moore::RandomBIOp::create(builder, loc, nullptr);
-    if (numArgs == 1) {
-      auto seed = convertRvalueExpression(*args[0]);
-      if (!seed)
-        return {};
-      return moore::RandomBIOp::create(builder, loc, seed);
-    }
-    // Slang already checks the arity of `$random`.
-    assert(false && "`$random` takes 0 or 1 arguments");
-    return {};
+    return moore::UrandomRangeBIOp::create(builder, loc, minval, maxval, seed);
   }
 
   if (nameId == ksn::URandomRange) {
-    // Slang already checks the arity of `$urandom_range`.
-    assert(numArgs >= 1 && numArgs <= 2 &&
-           "`$urandom_range` takes 1 or 2 arguments");
+    auto i32Ty = moore::IntType::getInt(builder.getContext(), 32);
     auto maxval = convertRvalueExpression(*args[0]);
     if (!maxval)
       return {};
-    Value minval = nullptr;
-    if (numArgs == 2) {
+    Value minval;
+    if (numArgs >= 2) {
       minval = convertRvalueExpression(*args[1]);
       if (!minval)
         return {};
+    } else {
+      minval = moore::ConstantOp::create(builder, loc, i32Ty, 0);
     }
-    return moore::UrandomrangeBIOp::create(builder, loc, maxval, minval);
+    return moore::UrandomRangeBIOp::create(builder, loc, minval, maxval,
+                                           Value{});
   }
 
   //===--------------------------------------------------------------------===//

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -96,23 +96,47 @@ private:
   DenseMap<Attribute, ClassStructInfo> classToStructMap;
 };
 
-/// Ensure we have `declare i8* @malloc(i64)` (opaque ptr prints as !llvm.ptr).
-static LLVM::LLVMFuncOp getOrCreateMalloc(ModuleOp mod, OpBuilder &b) {
-  if (auto f = mod.lookupSymbol<LLVM::LLVMFuncOp>("malloc"))
-    return f;
+/// Cache for external function declarations. Avoids redundant symbol table
+/// lookups and ensures each function is declared at most once.
+struct FunctionCache {
+  FunctionCache(SymbolTable &symbolTable) : symbolTable(symbolTable) {}
 
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPointToStart(mod.getBody());
+  /// Look up a function by name. If it doesn't exist, invoke the callback to
+  /// create it. The builder is repositioned to the start of the module body
+  /// before the callback is invoked. The result is inserted into the symbol
+  /// table and cache.
+  func::FuncOp getOrCreate(OpBuilder &builder, StringRef name,
+                           function_ref<func::FuncOp()> createFn) {
+    auto &slot = map[name];
+    if (slot)
+      return slot;
+    if (auto fn = symbolTable.lookup<func::FuncOp>(name))
+      return slot = fn;
+    auto mod = cast<ModuleOp>(symbolTable.getOp());
+    OpBuilder::InsertionGuard g(builder);
+    builder.setInsertionPointToStart(mod.getBody());
+    slot = createFn();
+    symbolTable.insert(slot);
+    return slot;
+  }
 
-  auto i64Ty = IntegerType::get(mod.getContext(), 64);
-  auto ptrTy = LLVM::LLVMPointerType::get(mod.getContext()); // opaque pointer
-  auto fnTy = LLVM::LLVMFunctionType::get(ptrTy, {i64Ty}, false);
+  /// Convenience wrapper that creates a private external function declaration
+  /// with the given argument and result types.
+  func::FuncOp getOrCreate(OpBuilder &builder, StringRef name,
+                           TypeRange argTypes, TypeRange resultTypes) {
+    return getOrCreate(builder, name, [&] {
+      auto mod = cast<ModuleOp>(symbolTable.getOp());
+      auto fnTy = builder.getFunctionType(argTypes, resultTypes);
+      auto fn = func::FuncOp::create(builder, mod.getLoc(), name, fnTy);
+      fn.setPrivate();
+      return fn;
+    });
+  }
 
-  auto fn = LLVM::LLVMFuncOp::create(b, mod.getLoc(), "malloc", fnTy);
-  // Link this in from somewhere else.
-  fn.setLinkage(LLVM::Linkage::External);
-  return fn;
-}
+private:
+  SymbolTable &symbolTable;
+  llvm::StringMap<func::FuncOp> map;
+};
 
 /// Helper function to create an opaque LLVM Struct Type which corresponds
 /// to the sym
@@ -931,8 +955,9 @@ struct ClassUpcastOpConversion : public OpConversionPattern<ClassUpcastOp> {
 /// moore.class.new lowering: heap-allocate storage for the class object.
 struct ClassNewOpConversion : public OpConversionPattern<ClassNewOp> {
   ClassNewOpConversion(TypeConverter &tc, MLIRContext *ctx,
-                       ClassTypeCache &cache)
-      : OpConversionPattern<ClassNewOp>(tc, ctx), cache(cache) {}
+                       ClassTypeCache &cache, FunctionCache &funcCache)
+      : OpConversionPattern<ClassNewOp>(tc, ctx), cache(cache),
+        funcCache(funcCache) {}
 
   LogicalResult
   matchAndRewrite(ClassNewOp op, OpAdaptor adaptor,
@@ -969,20 +994,20 @@ struct ClassNewOpConversion : public OpConversionPattern<ClassNewOp> {
                                           rewriter.getI64IntegerAttr(byteSize));
 
     // Get or declare malloc and call it.
-    auto mallocFn = getOrCreateMalloc(mod, rewriter);
     auto ptrTy = LLVM::LLVMPointerType::get(ctx); // opaque pointer result
+    auto mallocFn = funcCache.getOrCreate(rewriter, "malloc", {i64Ty}, {ptrTy});
     auto call =
-        LLVM::CallOp::create(rewriter, loc, TypeRange{ptrTy},
-                             SymbolRefAttr::get(mallocFn), ValueRange{cSize});
+        func::CallOp::create(rewriter, loc, mallocFn, ValueRange{cSize});
 
     // Replace the new op with the malloc pointer (no cast needed with opaque
     // ptrs).
-    rewriter.replaceOp(op, call.getResult());
+    rewriter.replaceOp(op, call.getResult(0));
     return success();
   }
 
 private:
   ClassTypeCache &cache; // shared, owned by the pass
+  FunctionCache &funcCache;
 };
 
 struct ClassDeclOpConversion : public OpConversionPattern<ClassDeclOp> {
@@ -1605,6 +1630,13 @@ struct BoolCastOpConversion : public OpConversionPattern<BoolCastOp> {
           hw::ConstantOp::create(rewriter, op->getLoc(), resultType, 0);
       rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne,
                                                 adaptor.getInput(), zero);
+      return success();
+    }
+    if (isa_and_nonnull<FloatType>(resultType)) {
+      Value zero = arith::ConstantOp::create(
+          rewriter, op->getLoc(), rewriter.getFloatAttr(resultType, 0.0));
+      rewriter.replaceOpWithNewOp<arith::CmpFOp>(op, arith::CmpFPredicate::ONE,
+                                                 adaptor.getInput(), zero);
       return success();
     }
     return failure();
@@ -2768,6 +2800,54 @@ static LogicalResult convert(SeverityBIOp op, SeverityBIOp::Adaptor adaptor,
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// Random Builtin Conversion
+//===----------------------------------------------------------------------===//
+
+/// moore.builtin.urandom_range -> call @__circt_urandom_range(i32, i32, ptr)
+///
+/// The seed pointer is null when no seed is provided. When a seed ref is
+/// present, we probe the current value into an alloca before the call, and
+/// drive the (potentially mutated) value back after.
+static LogicalResult convert(UrandomRangeBIOp op,
+                             UrandomRangeBIOp::Adaptor adaptor,
+                             ConversionPatternRewriter &rewriter,
+                             FunctionCache &funcCache) {
+  auto loc = op.getLoc();
+  auto i32Ty = rewriter.getI32Type();
+  auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext());
+  auto fn = funcCache.getOrCreate(rewriter, "__circt_urandom_range",
+                                  {i32Ty, i32Ty, ptrTy}, {i32Ty});
+
+  Value seedPtr;
+  if (auto seedRef = adaptor.getSeed()) {
+    // Allocate a temporary, probe the current seed value into it.
+    auto one = hw::ConstantOp::create(rewriter, loc, i32Ty, 1);
+    seedPtr = LLVM::AllocaOp::create(rewriter, loc, ptrTy, i32Ty, one);
+    auto seedVal = llhd::ProbeOp::create(rewriter, loc, seedRef);
+    LLVM::StoreOp::create(rewriter, loc, seedVal, seedPtr);
+  } else {
+    seedPtr = LLVM::ZeroOp::create(rewriter, loc, ptrTy);
+  }
+
+  auto call = func::CallOp::create(
+      rewriter, loc, fn,
+      ValueRange{adaptor.getMinval(), adaptor.getMaxval(), seedPtr});
+
+  // Drive the potentially mutated seed back with an epsilon time delta.
+  if (adaptor.getSeed()) {
+    auto newSeed = LLVM::LoadOp::create(rewriter, loc, i32Ty, seedPtr);
+    auto epsilon = llhd::ConstantTimeOp::create(
+        rewriter, loc,
+        llhd::TimeAttr::get(rewriter.getContext(), 0, "ns", 0, 1));
+    llhd::DriveOp::create(rewriter, loc, adaptor.getSeed(), newSeed, epsilon,
+                          Value{});
+  }
+
+  rewriter.replaceOp(op, call.getResult(0));
+  return success();
+}
+
 // moore.builtin.finish_message
 static LogicalResult convert(FinishMessageBIOp op,
                              FinishMessageBIOp::Adaptor adaptor,
@@ -3058,12 +3138,13 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
 
 static void populateOpConversion(ConversionPatternSet &patterns,
                                  TypeConverter &typeConverter,
-                                 ClassTypeCache &classCache) {
+                                 ClassTypeCache &classCache,
+                                 FunctionCache &funcCache) {
 
   patterns.add<ClassDeclOpConversion>(typeConverter, patterns.getContext(),
                                       classCache);
   patterns.add<ClassNewOpConversion>(typeConverter, patterns.getContext(),
-                                     classCache);
+                                     classCache, funcCache);
   patterns.add<ClassPropertyRefOpConversion>(typeConverter,
                                              patterns.getContext(), classCache);
 
@@ -3249,6 +3330,9 @@ static void populateOpConversion(ConversionPatternSet &patterns,
   patterns.add<FinishBIOp>(convert);
   patterns.add<FinishMessageBIOp>(convert);
 
+  // Random builtins
+  patterns.add<UrandomRangeBIOp>(convert, funcCache);
+
   // Timing control
   patterns.add<TimeBIOp>(convert);
   patterns.add<LogicToTimeOp>(convert);
@@ -3283,6 +3367,8 @@ void MooreToCorePass::runOnOperation() {
   MLIRContext &context = getContext();
   ModuleOp module = getOperation();
   ClassTypeCache classCache;
+  auto &symbolTable = getAnalysis<SymbolTable>();
+  FunctionCache funcCache(symbolTable);
 
   IRRewriter rewriter(module);
   (void)mlir::eraseUnreachableBlocks(rewriter, module->getRegions());
@@ -3294,7 +3380,7 @@ void MooreToCorePass::runOnOperation() {
   populateLegality(target, typeConverter);
 
   ConversionPatternSet patterns(&context, typeConverter);
-  populateOpConversion(patterns, typeConverter, classCache);
+  populateOpConversion(patterns, typeConverter, classCache, funcCache);
   mlir::cf::populateCFStructuralTypeConversionsAndLegality(typeConverter,
                                                            patterns, target);
 

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -302,22 +302,43 @@ endfunction
 // CHECK-LABEL: func.func private @RandomBuiltins(
 // CHECK-SAME: [[X:%.+]]: !moore.i32
 function RandomBuiltins(int x);
-  // CHECK: [[URAND0:%.+]] = moore.builtin.urandom
+  // CHECK: [[XVAR:%.+]] = moore.variable [[X]] : <i32>
+  // All random system functions map to moore.builtin.urandom_range with
+  // (minval, maxval, optional seed ref).
+
+  // CHECK: [[ZERO1:%.+]] = moore.constant 0 : i32
+  // CHECK: [[MAX1:%.+]] = moore.constant -1 : i32
+  // CHECK: [[URAND0:%.+]] = moore.builtin.urandom_range [[ZERO1]], [[MAX1]]
   // CHECK-NEXT: call @dummyA([[URAND0]]) : (!moore.i32) -> ()
   dummyA($urandom());
-  // CHECK: [[URAND1:%.+]] = moore.builtin.urandom [[X]]
+
+  // CHECK: [[ZERO2:%.+]] = moore.constant 0 : i32
+  // CHECK: [[MAX2:%.+]] = moore.constant -1 : i32
+  // CHECK: [[URAND1:%.+]] = moore.builtin.urandom_range [[ZERO2]], [[MAX2]], [[XVAR]]
   // CHECK-NEXT: call @dummyA([[URAND1]]) : (!moore.i32) -> ()
   dummyA($urandom(x));
-  // CHECK: [[RAND0:%.+]] = moore.builtin.random
+
+  // CHECK: [[ZERO3:%.+]] = moore.constant 0 : i32
+  // CHECK: [[MAX3:%.+]] = moore.constant -1 : i32
+  // CHECK: [[RAND0:%.+]] = moore.builtin.urandom_range [[ZERO3]], [[MAX3]]
   // CHECK-NEXT: call @dummyA([[RAND0]]) : (!moore.i32) -> ()
   dummyA($random());
-  // CHECK: [[RAND1:%.+]] = moore.builtin.random [[X]]
+
+  // CHECK: [[ZERO4:%.+]] = moore.constant 0 : i32
+  // CHECK: [[MAX4:%.+]] = moore.constant -1 : i32
+  // CHECK: [[RAND1:%.+]] = moore.builtin.urandom_range [[ZERO4]], [[MAX4]], [[XVAR]]
   // CHECK-NEXT: call @dummyA([[RAND1]]) : (!moore.i32) -> ()
   dummyA($random(x));
-  // CHECK: [[URANDRANGE1:%.+]] = moore.builtin.urandom_range [[X]]
+
+  // CHECK: [[XVAL1:%.+]] = moore.read [[XVAR]]
+  // CHECK: [[ZERO5:%.+]] = moore.constant 0 : i32
+  // CHECK: [[URANDRANGE1:%.+]] = moore.builtin.urandom_range [[ZERO5]], [[XVAL1]]
   // CHECK-NEXT: call @dummyA([[URANDRANGE1]]) : (!moore.i32) -> ()
   dummyA($urandom_range(x));
-  // CHECK: [[URANDRANGE2:%.+]] = moore.builtin.urandom_range [[X]] [[X]]
+
+  // CHECK: [[XVAL2:%.+]] = moore.read [[XVAR]]
+  // CHECK: [[XVAL3:%.+]] = moore.read [[XVAR]]
+  // CHECK: [[URANDRANGE2:%.+]] = moore.builtin.urandom_range [[XVAL3]], [[XVAL2]]
   // CHECK-NEXT: call @dummyA([[URANDRANGE2]]) : (!moore.i32) -> ()
   dummyA($urandom_range(x, x));
 endfunction

--- a/test/Conversion/MooreToCore/classes.mlir
+++ b/test/Conversion/MooreToCore/classes.mlir
@@ -20,16 +20,15 @@ func.func @ClassType(%arg0: !moore.class<@PropertyCombo>) {
 
 /// Check that new lowers to malloc
 
-// malloc should be declared in the LLVM dialect.
 // CHECK-LABEL: func.func private @test_new2
 // CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(12 : i64) : i64
-// CHECK:   [[PTR:%.*]] = llvm.call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
 // CHECK:   return
 
 // CHECK-NOT: moore.class.new
 // CHECK-NOT: moore.class.classdecl
 
-// Allocate a new instance; should lower to llvm.call @malloc(i64).
+// Allocate a new instance; should lower to call @malloc(i64).
 func.func private @test_new2() {
   %h = moore.class.new : <@C>
   return
@@ -45,7 +44,7 @@ moore.class.classdecl @C {
 
 // CHECK-LABEL: func.func private @test_new3
 // CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(28 : i64) : i64
-// CHECK:   [[PTR:%.*]] = llvm.call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
 // CHECK:   return
 
 // CHECK-NOT: moore.class.new
@@ -65,7 +64,7 @@ moore.class.classdecl @D extends @C {
 
 // CHECK-LABEL: func.func private @test_new4
 // CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(24 : i64) : i64
-// CHECK:   [[PTR:%.*]] = llvm.call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
 // CHECK:   return
 
 // CHECK-NOT: moore.class.new


### PR DESCRIPTION
Replace the three separate `moore.builtin.random`, `moore.builtin.urandom`, and `moore.builtin.urandom_range` ops with a single `moore.builtin.urandom_range` that takes (minval, maxval, optional seed ref).

The three SystemVerilog random functions are all equivalent to a call to `urandom_range` with different bounds:
- `$random` and `$urandom` → `urandom_range(0, 2^32-1)`
- `$urandom_range(max)` → `urandom_range(0, max)`
- `$urandom_range(max, min)` → `urandom_range(min, max)`

The optional seed is modeled as a `ref<i32>` (an inout parameter per the SV spec) rather than an rvalue.

MooreToCore lowers this to a call to an external
`@__circt_urandom_range(i32, i32, ptr) -> i32` function. When a seed ref is present, the current value is probed into an alloca before the call and driven back with an epsilon time delta after.

Also extend `BoolCastOpConversion` to handle `f64` inputs via `arith.cmpf`.