### PR TITLE
[Synth][ResourceUsage] Fix misuse of InstanceGraphNode::getModule, report truth table total count

### DIFF
--- a/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
@@ -41,53 +41,54 @@ using namespace synth;
 // ResourceUsageAnalysis Implementation
 //===----------------------------------------------------------------------===//
 
-/// Get resource count for an operation if it's a tracked resource type.
-/// Returns (operation name, count) pair, or std::nullopt if not tracked.
-/// The operation name may include additional information (e.g., LUT input
-/// count).
-static std::optional<std::pair<std::string, uint64_t>>
-getResourceCount(Operation *op) {
+/// Accumulate resource counts for an operation if it's a tracked resource type.
+/// Returns true if the operation was tracked, false otherwise.
+static bool accumulateResourceCounts(Operation *op,
+                                     llvm::StringMap<uint64_t> &counts) {
   if (op->getNumResults() != 1 || !op->getResult(0).getType().isInteger())
-    return std::nullopt;
-  return TypeSwitch<Operation *,
-                    std::optional<std::pair<std::string, uint64_t>>>(op)
+    return false;
+  return TypeSwitch<Operation *, bool>(op)
       // Variadic logic operations (AND, OR, XOR, AIG).
       // Gate count = (num_inputs - 1) * bitwidth
       .Case<synth::aig::AndInverterOp, comb::AndOp, comb::OrOp, comb::XorOp>(
-          [](auto logicOp) {
-            return std::make_pair(
-                logicOp->getName().getStringRef(),
+          [&](auto logicOp) {
+            counts[logicOp->getName().getStringRef()] +=
                 (logicOp.getNumOperands() - 1) *
-                    logicOp.getType().getIntOrFloatBitWidth());
+                logicOp.getType().getIntOrFloatBitWidth();
+            return true;
           })
       // Majority-inverter graph (MIG) - include input count in the name.
       // Gate count = (num_inputs / 2) * bitwidth
       // Each MIG gate consumes 3 inputs and produces 1 output, so a variadic
       // MIG operation with N inputs requires N/2 gates (rounded down).
-      .Case<synth::mig::MajorityInverterOp>([](auto logicOp) {
+      .Case<synth::mig::MajorityInverterOp>([&](auto logicOp) {
         uint64_t count = logicOp.getType().getIntOrFloatBitWidth();
         // Concatenate input count to the operation name.
         std::string name = (Twine(logicOp->getName().getStringRef()) + "_" +
                             Twine(logicOp.getNumOperands()))
                                .str();
-        return std::make_pair(std::move(name), count);
+        counts[name] += count;
+        return true;
       })
-      // Truth tables (LUTs) - include input count in the name.
-      .Case<comb::TruthTableOp>([](auto op) {
+      // Truth tables (LUTs) - count both the total number of truth tables and
+      // the per-input breakdown.
+      .Case<comb::TruthTableOp>([&](auto op) {
         uint64_t count = op.getType().getIntOrFloatBitWidth();
-        // Concatenate LUT input number to the operation name.
-        std::string name = (Twine(op->getName().getStringRef()) + "_" +
-                            Twine(op.getNumOperands()))
-                               .str();
-        return std::make_pair(std::move(name), count);
+        counts[op->getName().getStringRef()] += count;
+        std::string bucket = (Twine(op->getName().getStringRef()) + "_" +
+                              Twine(op.getNumOperands()))
+                                 .str();
+        counts[bucket] += count;
+        return true;
       })
       // Sequential elements.
       // Count = bitwidth
-      .Case<seq::CompRegOp, seq::FirRegOp>([](auto op) {
+      .Case<seq::CompRegOp, seq::FirRegOp>([&](auto op) {
         uint64_t count = op.getType().getIntOrFloatBitWidth();
-        return std::make_pair(op->getName().getStringRef().str(), count);
+        counts[op->getName().getStringRef()] += count;
+        return true;
       })
-      .Default([](Operation *) { return std::nullopt; });
+      .Default([](Operation *) { return false; });
 }
 
 ResourceUsageAnalysis::ResourceUsageAnalysis(Operation *moduleOp,
@@ -122,10 +123,10 @@ ResourceUsageAnalysis::getResourceUsage(igraph::ModuleOpInterface module) {
   llvm::StringMap<uint64_t> counts;
   uint64_t unknownOpCount = 0;
   module->walk([&](Operation *op) {
-    if (auto resource = getResourceCount(op))
-      counts[resource->first] += resource->second;
-    else if (op->getNumResults() > 0 && !isa<hw::HWInstanceLike>(op) &&
-             !op->hasTrait<mlir::OpTrait::ConstantLike>()) {
+    if (accumulateResourceCounts(op, counts))
+      return;
+    if (op->getNumResults() > 0 && !isa<hw::HWInstanceLike>(op) &&
+        !op->hasTrait<mlir::OpTrait::ConstantLike>()) {
       // Track operations that has one result and is not a constant.
       unknownOpCount++;
     }

--- a/test/Dialect/Synth/resource.mlir
+++ b/test/Dialect/Synth/resource.mlir
@@ -143,6 +143,7 @@ hw.module private @mig_test(in %a : i4, in %b : i4, in %c : i4, out x : i4) {
 // CHECK:      Resource Usage Analysis for module: lut_test
 // CHECK-NEXT: ========================================
 // CHECK-NEXT: Total:
+// CHECK-NEXT:   comb.truth_table:   2
 // CHECK-NEXT:   comb.truth_table_2: 1
 // CHECK-NEXT:   comb.truth_table_3: 1
 


### PR DESCRIPTION
This PR makes small changes to ResourceUsageAnalysis. 
* Fix warnings due to patterns from `dyn_cast_or_null<igraph::ModuleOpInterface>(targetNode->getModule());`. We can simply use `targetNode->getModule()`. This removes warnnings.
* It changes to dump total count of LUT op as well in addition to per-size LUT. 