### PR TITLE
[FIRRTL] Fix LowerClasses Objects not InstanceLike

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -65,6 +65,12 @@ static bool shouldCreateClassImpl(igraph::InstanceGraphNode *node) {
   // Create a class for modules that instantiate classes or modules with
   // property ports.
   for (auto *instance : *node) {
+    // ObjectOp instantiates a class directly and always requires a class.
+    // Note: if combined with the check below, this has the same result (as
+    // objects always have one result, even if they have no ports).
+    if (instance->getInstance<firrtl::ObjectOp>())
+      return true;
+    // There is an instance with property ports.
     if (auto op = instance->getInstance<FInstanceLike>())
       for (auto result : op->getResults())
         if (type_isa<PropertyType>(result.getType()))

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -374,6 +374,21 @@ firrtl.circuit "ModuleWithPropertySubmodule" {
   }
 }
 
+// CHECK-LABEL: firrtl.circuit "ModuleWithObjectNoPorts"
+firrtl.circuit "ModuleWithObjectNoPorts" {
+  firrtl.class private @Metadata() {
+  }
+  // Ensure that a module with no property ports, but contains an object results
+  // in a class.
+  //
+  // CHECK: om.class @Baz_Class
+  firrtl.module private @Baz() {
+    // CHECK: om.object @Metadata
+    %meta = firrtl.object @Metadata()
+  }
+  firrtl.extmodule @ModuleWithObjectNoPorts()
+}
+
 // CHECK-LABEL: firrtl.circuit "DownwardReferences"
 firrtl.circuit "DownwardReferences" {
   firrtl.class @MyClass() {


### PR DESCRIPTION
Fix a regression introduced when `ObjectOp`s were made not
`FInstanceLike` [[1]].  The `LowerClasses` pass was relying on this to
know if a module had objects instantiated inside it.  Without this, a
module had to have property ports which may not be the case.

Fixes #10080.

[1]: 4b0b5bf22

AI-assisted-by: Claude Code (Claude Sonnet 4.6)
