### PR TITLE
[Release] Add macOS AARCH64 (macos-15) runner to release artifacts

### DIFF
--- a/.github/bin/uploadReleaseArtifacts.sh
+++ b/.github/bin/uploadReleaseArtifacts.sh
@@ -180,6 +180,11 @@ configMacOsRunner=$(cat <<EOF
     "runner": "macos-15-intel",
     "cmake_c_compiler": "clang",
     "cmake_cxx_compiler": "clang++"
+  },
+  {
+    "runner": "macos-15",
+    "cmake_c_compiler": "clang",
+    "cmake_cxx_compiler": "clang++"
   }
 ]
 EOF


### PR DESCRIPTION
Add `macos-15` (Apple Silicon) alongside `macos-15-intel` in the macOS
runner configuration so that release artifacts are built for both
architectures.  Artifact names are automatically differentiated by the
`unifiedBuildTestAndInstall` workflow using `runner.arch` (e.g.,
`firrtl-bin-macos-arm64.tar.gz` vs `firrtl-bin-macos-x64.tar.gz`).

Fixes #8135.

AI-assisted-by: Claude Code (Claude Sonnet 4.6)
