### PR TITLE
Revert "[CI] Cancel in-progress PR builds on new push"

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -8,11 +8,6 @@ on:
     types: [assigned, opened, synchronize, reopened]
   workflow_dispatch:
 
-# Cancel previous CI builds when a new push occurs to the same PR.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   # Do sanity check (clang-format and python-format) first.
   sanity-check:

--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -8,11 +8,6 @@ on:
     types: [assigned, opened, synchronize, reopened]
   workflow_dispatch:
 
-# Cancel previous CI builds when a new push occurs to the same PR.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   # Build CIRCT and run its tests.
   build-circt:

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -16,11 +16,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# Cancel previous CI builds when a new push occurs to the same PR.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   # Build CIRCT and run its tests using a Docker container with all the
   # integration testing prerequisite installed.

--- a/.github/workflows/testPycdeESI.yml
+++ b/.github/workflows/testPycdeESI.yml
@@ -9,11 +9,6 @@ on:
       - "frontends/PyCDE/**"
       - "lib/Dialect/ESI/runtime/**"
 
-# Cancel previous CI builds when a new push occurs to the same PR.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   # ---------------------------------------------------------------------------
   #  Build and test Linux wheels. Run the CIRCT tests also.


### PR DESCRIPTION
Reverts llvm/circt#9751

This tries to fix random CI failures we are getting for a week. I suspect concurrency group is conflicting somehow across different PRs/commits for some reason. 

I'll reapply if this doesn't fix the failures. 