### PR TITLE
[Arc][StripSV] Replace i1 macro references with true constants

### DIFF
--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -98,6 +98,22 @@ void StripSVPass::runOnOperation() {
   for (auto verb : mlirModule.getOps<sv::MacroDeclOp>())
     opsToDelete.push_back(verb);
 
+  mlirModule.walk([&](sv::MacroRefExprOp macroRef) {
+    StringRef macroName = macroRef.getMacroName();
+    bool isConditionMacro = macroName == "STOP_COND_" ||
+                            macroName == "PRINTF_COND_" ||
+                            macroName == "ASSERT_VERBOSE_COND_";
+
+    if (macroRef.getType().isInteger(1) && isConditionMacro) {
+      OpBuilder builder(macroRef);
+      auto trueConst = hw::ConstantOp::create(builder, macroRef.getLoc(),
+                                              builder.getI1Type(), 1);
+
+      macroRef.replaceAllUsesWith(trueConst->getResult(0));
+      opsToDelete.push_back(macroRef);
+    }
+  });
+
   for (auto module : mlirModule.getOps<hw::HWModuleOp>()) {
     for (Operation &op : *module.getBodyBlock()) {
       // Remove ifdefs and verbatim.

--- a/test/arcilator/macro-strip.mlir
+++ b/test/arcilator/macro-strip.mlir
@@ -1,0 +1,13 @@
+// RUN: arcilator %s
+
+// CHECK: %[[VAL:.+]] = hw.constant 1 : i1
+// CHECK: comb.and %[[VAL]]
+
+module {
+  sv.macro.decl @STOP_COND_
+  hw.module @SimTop(in %cond : i1, out out : i1) {
+    %STOP_COND_ = sv.macro.ref.expr @STOP_COND_() : () -> i1
+    %0 = comb.and %STOP_COND_, %cond : i1
+    hw.output %0 : i1
+  }
+}


### PR DESCRIPTION
### Description
This PR fixes a symbol verification failure in `arc-strip-sv`. 

### Background
During the lowering flow from Chisel/FIRRTL, `firtool` generates macro references (e.g., `@STOP_COND_`) to gate simulation-only logic. Currently, the `StripSV` pass removes the global `sv.macro.decl` but does not handle `sv.macro.ref.expr`. 

In modern FIRRTL lowering, these references can appear outside of `sv.always` blocks (such as in `sim.clocked_terminate` operands). When `StripSV` runs, it deletes the declaration but leaves the reference, leading to an `undefined symbol` error.

### Changes
- Implemented a walker in `StripSV` to identify and replace `i1` macro references.
- Replaces `@STOP_COND_`, `@PRINTF_COND_`, and `@ASSERT_VERBOSE_COND_` with `hw.constant 1 : i1`.
- This approach ensures the simulation logic is preserved and the IR remains valid for downstream passes like `arcilator`.

### Testing
- Added `test/arcilator/macro-strip.mlir` to verify the transformation.
- Passed `ninja check-circt`.