### PR TITLE
[ImportVerilog] Support case inside statements

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1574,58 +1574,16 @@ struct RvalueExprVisitor : public ExprVisitor {
         context.convertRvalueExpression(expr.left()));
     if (!lhs)
       return {};
+
     // All conditions for determining whether it is inside.
     SmallVector<Value> conditions;
 
     // Traverse open range list.
     for (const auto *listExpr : expr.rangeList()) {
-      Value cond;
-      // The open range list on the right-hand side of the inside operator is a
-      // comma-separated list of expressions or ranges.
-      if (const auto *openRange =
-              listExpr->as_if<slang::ast::ValueRangeExpression>()) {
-        // Handle ranges.
-        auto lowBound = context.convertToSimpleBitVector(
-            context.convertRvalueExpression(openRange->left()));
-        auto highBound = context.convertToSimpleBitVector(
-            context.convertRvalueExpression(openRange->right()));
-        if (!lowBound || !highBound)
-          return {};
-        Value leftValue, rightValue;
-        // Determine if the expression on the left-hand side is inclusively
-        // within the range.
-        if (openRange->left().type->isSigned() ||
-            expr.left().type->isSigned()) {
-          leftValue = moore::SgeOp::create(builder, loc, lhs, lowBound);
-        } else {
-          leftValue = moore::UgeOp::create(builder, loc, lhs, lowBound);
-        }
-        if (openRange->right().type->isSigned() ||
-            expr.left().type->isSigned()) {
-          rightValue = moore::SleOp::create(builder, loc, lhs, highBound);
-        } else {
-          rightValue = moore::UleOp::create(builder, loc, lhs, highBound);
-        }
-        cond = moore::AndOp::create(builder, loc, leftValue, rightValue);
-      } else {
-        // Handle expressions.
-        if (!listExpr->type->isIntegral()) {
-          if (listExpr->type->isUnpackedArray()) {
-            mlir::emitError(
-                loc, "unpacked arrays in 'inside' expressions not supported");
-            return {};
-          }
-          mlir::emitError(
-              loc, "only simple bit vectors supported in 'inside' expressions");
-          return {};
-        }
+      auto cond = context.convertInsideCheck(lhs, loc, *listExpr);
+      if (!cond)
+        return {};
 
-        auto value = context.convertToSimpleBitVector(
-            context.convertRvalueExpression(*listExpr));
-        if (!value)
-          return {};
-        cond = moore::WildcardEqOp::create(builder, loc, lhs, value);
-      }
       conditions.push_back(cond);
     }
 
@@ -3340,4 +3298,58 @@ Context::getAncestorClassWithProperty(const moore::ClassHandleType &actualTy,
   // No ancestor declares that property.
   mlir::emitError(loc) << "unknown property `" << fieldName << "`";
   return {};
+}
+
+//===--------------------------------------------------------------------===//
+// Value Range Expression Methods
+//===--------------------------------------------------------------------===//
+
+Value Context::convertInsideCheck(Value insideLhs, Location loc,
+                                  const slang::ast::Expression &expr) {
+  // The value range list on the right-hand side of the inside operator is a
+  // comma-separated list of expressions or ranges.
+  if (const auto *valueRange = expr.as_if<slang::ast::ValueRangeExpression>()) {
+    auto lowBound =
+        convertToSimpleBitVector(convertRvalueExpression(valueRange->left()));
+    auto highBound =
+        convertToSimpleBitVector(convertRvalueExpression(valueRange->right()));
+    if (!insideLhs || !lowBound || !highBound)
+      return {};
+
+    Value rangeLhs, rangeRhs;
+    // Determine if the insideLhs on the left-hand side is inclusively
+    // within the range.
+    if (valueRange->left().type->isSigned() ||
+        insideLhs.getType().isSignedInteger()) {
+      rangeLhs = moore::SgeOp::create(builder, loc, insideLhs, lowBound);
+    } else {
+      rangeLhs = moore::UgeOp::create(builder, loc, insideLhs, lowBound);
+    }
+
+    if (valueRange->right().type->isSigned() ||
+        insideLhs.getType().isSignedInteger()) {
+      rangeRhs = moore::SleOp::create(builder, loc, insideLhs, highBound);
+    } else {
+      rangeRhs = moore::UleOp::create(builder, loc, insideLhs, highBound);
+    }
+
+    return moore::AndOp::create(builder, loc, rangeLhs, rangeRhs);
+  }
+
+  // Handle expressions.
+  if (!expr.type->isIntegral()) {
+    if (expr.type->isUnpackedArray()) {
+      mlir::emitError(loc,
+                      "unpacked arrays in 'inside' expressions not supported");
+      return {};
+    }
+    mlir::emitError(
+        loc, "only simple bit vectors supported in 'inside' expressions");
+    return {};
+  }
+
+  auto value = convertToSimpleBitVector(convertRvalueExpression(expr));
+  if (!value)
+    return {};
+  return moore::WildcardEqOp::create(builder, loc, insideLhs, value);
 }

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -317,6 +317,10 @@ struct Context {
   /// Evaluate the constant value of an expression.
   slang::ConstantValue evaluateConstant(const slang::ast::Expression &expr);
 
+  /// Convert the inside/set-membership expression.
+  Value convertInsideCheck(Value insideLhs, Location loc,
+                           const slang::ast::Expression &expr);
+
   const ImportVerilogOptions &options;
   slang::ast::Compilation &compilation;
   mlir::ModuleOp intoModuleOp;

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -389,35 +389,47 @@ struct StmtVisitor {
       // specified by the user, and for the evaluation to stop as soon as the
       // first matching expression is encountered.
       for (const auto *expr : item.expressions) {
-        auto value = context.convertRvalueExpression(*expr);
-        if (!value)
-          return failure();
-        auto itemLoc = value.getLoc();
-
-        // Take note if the expression is a constant.
-        auto maybeConst = value;
-        while (isa_and_nonnull<moore::ConversionOp, moore::IntToLogicOp,
-                               moore::LogicToIntOp>(maybeConst.getDefiningOp()))
-          maybeConst = maybeConst.getDefiningOp()->getOperand(0);
-        if (auto defOp = maybeConst.getDefiningOp<moore::ConstantOp>())
-          itemConsts.push_back(defOp.getValueAttr());
-
-        // Generate the appropriate equality operator.
         Value cond;
-        switch (caseStmt.condition) {
-        case CaseStatementCondition::Normal:
-          cond = moore::CaseEqOp::create(builder, itemLoc, caseExpr, value);
-          break;
-        case CaseStatementCondition::WildcardXOrZ:
-          cond = moore::CaseXZEqOp::create(builder, itemLoc, caseExpr, value);
-          break;
-        case CaseStatementCondition::WildcardJustZ:
-          cond = moore::CaseZEqOp::create(builder, itemLoc, caseExpr, value);
-          break;
-        case CaseStatementCondition::Inside:
-          mlir::emitError(loc, "unsupported set membership case statement");
-          return failure();
+        auto itemLoc = loc;
+
+        if (caseStmt.condition == CaseStatementCondition::Inside) {
+          // ConvertInsideCheck will check insideLhs whether it is empty or not.
+          cond = context.convertInsideCheck(
+              context.convertToSimpleBitVector(caseExpr), itemLoc, *expr);
+          if (!cond)
+            return failure();
+        } else {
+          auto value = context.convertRvalueExpression(*expr);
+          if (!value)
+            return failure();
+          itemLoc = value.getLoc();
+
+          // Take note if the expression is a constant.
+          auto maybeConst = value;
+          while (
+              isa_and_nonnull<moore::ConversionOp, moore::IntToLogicOp,
+                              moore::LogicToIntOp>(maybeConst.getDefiningOp()))
+            maybeConst = maybeConst.getDefiningOp()->getOperand(0);
+          if (auto defOp = maybeConst.getDefiningOp<moore::ConstantOp>())
+            itemConsts.push_back(defOp.getValueAttr());
+
+          // Generate the appropriate equality operator.
+          switch (caseStmt.condition) {
+          case CaseStatementCondition::Normal:
+            cond = moore::CaseEqOp::create(builder, itemLoc, caseExpr, value);
+            break;
+          case CaseStatementCondition::WildcardXOrZ:
+            cond = moore::CaseXZEqOp::create(builder, itemLoc, caseExpr, value);
+            break;
+          case CaseStatementCondition::WildcardJustZ:
+            cond = moore::CaseZEqOp::create(builder, itemLoc, caseExpr, value);
+            break;
+          case CaseStatementCondition::Inside:
+            llvm_unreachable("Inside condition has been handled already");
+            break;
+          }
         }
+
         if (auto ty = dyn_cast<moore::IntType>(cond.getType());
             ty && ty.getDomain() == Domain::FourValued) {
           cond = moore::LogicToIntOp::create(builder, loc, cond);

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1377,6 +1377,65 @@ module Expressions;
     // CHECK: moore.or [[TMP3]], [[TMP11]] : i1
     c = a inside { a, b, [a:b] };
 
+    // CHECK: [[READ_M:%.+]] = moore.read %m : <l4>
+    // CHECK: [[ZEXT_M:%.+]] = moore.zext [[READ_M]] : l4 -> l32
+    // CHECK: [[CONST_0_I32:%.+]] = moore.constant 0 : i32
+    // CHECK: [[CONST_0_L32:%.+]] = moore.constant 0 : l32
+    // CHECK: [[EQ_0:%.+]] = moore.wildcard_eq [[ZEXT_M]], [[CONST_0_L32]] : l32 -> l1
+    // CHECK: [[EQ_0_I1:%.+]] = moore.logic_to_int [[EQ_0]] : l1
+    // CHECK: [[EQ_0_BUILTIN:%.+]] = moore.to_builtin_int [[EQ_0_I1]] : i1
+    // CHECK: cf.cond_br [[EQ_0_BUILTIN]], ^bb2, ^bb1
+    // CHECK: ^bb1:  // pred: ^bb0
+    // CHECK: [[CONST_1_I32:%.+]] = moore.constant 1 : i32
+    // CHECK: [[CONST_1_L32:%.+]] = moore.constant 1 : l32
+    // CHECK: [[EQ_1:%.+]] = moore.wildcard_eq [[ZEXT_M]], [[CONST_1_L32]] : l32 -> l1
+    // CHECK: [[EQ_1_I1:%.+]] = moore.logic_to_int [[EQ_1]] : l1
+    // CHECK: [[EQ_1_BUILTIN:%.+]] = moore.to_builtin_int [[EQ_1_I1]] : i1
+    // CHECK: cf.cond_br [[EQ_1_BUILTIN]], ^bb2, ^bb3
+    // CHECK: ^bb2:  // 2 preds: ^bb0, ^bb1
+    // CHECK: [[ASSIGN_1:%.+]] = moore.constant 1 : i32
+    // CHECK: moore.blocking_assign %b, [[ASSIGN_1]] : i32
+    // CHECK: cf.br ^bb8
+    // CHECK: ^bb3:  // pred: ^bb1
+    // CHECK: [[RANGE_LO_I4:%.+]] = moore.constant 0 : i4
+    // CHECK: [[RANGE_LO_I32:%.+]] = moore.constant 0 : i32
+    // CHECK: [[RANGE_LO_L32:%.+]] = moore.constant 0 : l32
+    // CHECK: [[RANGE_HI_I4:%.+]] = moore.constant -1 : i4
+    // CHECK: [[RANGE_HI_I32:%.+]] = moore.constant 15 : i32
+    // CHECK: [[RANGE_HI_L32:%.+]] = moore.constant 15 : l32
+    // CHECK: [[GE_LO:%.+]] = moore.uge [[ZEXT_M]], [[RANGE_LO_L32]] : l32 -> l1
+    // CHECK: [[LE_HI:%.+]] = moore.ule [[ZEXT_M]], [[RANGE_HI_L32]] : l32 -> l1
+    // CHECK: [[IN_RANGE:%.+]] = moore.and [[GE_LO]], [[LE_HI]] : l1
+    // CHECK: [[IN_RANGE_I1:%.+]] = moore.logic_to_int [[IN_RANGE]] : l1
+    // CHECK: [[IN_RANGE_BUILTIN:%.+]] = moore.to_builtin_int [[IN_RANGE_I1]] : i1
+    // CHECK: cf.cond_br [[IN_RANGE_BUILTIN]], ^bb4, ^bb5
+    // CHECK: ^bb4:  // pred: ^bb3
+    // CHECK: [[ASSIGN_2:%.+]] = moore.constant 2 : i32
+    // CHECK: moore.blocking_assign %b, [[ASSIGN_2]] : i32
+    // CHECK: cf.br ^bb8
+    // CHECK: ^bb5:  // pred: ^bb3
+    // CHECK: [[CONST_1ZXZ_L4:%.+]] = moore.constant b1ZXZ : l4
+    // CHECK: [[CONST_1ZXZ_L32:%.+]] = moore.constant b1ZXZ : l32
+    // CHECK: [[EQ_1ZXZ:%.+]] = moore.wildcard_eq [[ZEXT_M]], [[CONST_1ZXZ_L32]] : l32 -> l1
+    // CHECK: [[EQ_1ZXZ_I1:%.+]] = moore.logic_to_int [[EQ_1ZXZ]] : l1
+    // CHECK: [[EQ_1ZXZ_BUILTIN:%.+]] = moore.to_builtin_int [[EQ_1ZXZ_I1]] : i1
+    // CHECK: cf.cond_br [[EQ_1ZXZ_BUILTIN]], ^bb6, ^bb7
+    // CHECK: ^bb6:  // pred: ^bb5
+    // CHECK: [[ASSIGN_3:%.+]] = moore.constant 3 : i32
+    // CHECK: moore.blocking_assign %b, [[ASSIGN_3]] : i32
+    // CHECK: cf.br ^bb8
+    // CHECK: ^bb7:  // pred: ^bb5
+    // CHECK: [[ASSIGN_4:%.+]] = moore.constant 4 : i32
+    // CHECK: moore.blocking_assign %b, [[ASSIGN_4]] : i32
+    // CHECK: cf.br ^bb8
+    // CHECK: ^bb8:  // 4 preds: ^bb2, ^bb4, ^bb6, ^bb7
+    case(m) inside
+        0, 1 : b = 1;
+        [4'h0:4'hF] : b = 2;
+        4'b1?xz : b = 3;
+        default : b = 4;
+    endcase
+
     //===------------------------------------------------------------------===//
     // Conditional operator
 


### PR DESCRIPTION
Support translating  `case (...) inside` statements. As part of this change, refactor existing `slang::ast::InsideExpression` handling by moving `ValueRangeExpression` translation into a dedicated visit.