### PR TITLE
[FIRRTL] Add ltl.past intrinsic

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1734,6 +1734,17 @@ def LTLImplicationIntrinsicOp : BinaryLTLIntrinsicOp<"implication">;
 def LTLUntilIntrinsicOp : BinaryLTLIntrinsicOp<"until">;
 def LTLEventuallyIntrinsicOp : UnaryLTLIntrinsicOp<"eventually">;
 
+// Past
+def LTLPastIntrinsicOp : LTLIntrinsicOp<"past"> {
+  let arguments = (ins NonConstUInt1Type:$input,
+                       I64Attr:$delay,
+                       Optional<ClockType>:$clock);
+  let assemblyFormat = [{
+    $input `,` $delay (`,` $clock^)? attr-dict `:`
+    functional-type(operands, results)
+  }];
+}
+
 // Clocking
 def LTLClockIntrinsicOp : LTLIntrinsicOp<"clock"> {
   let arguments = (ins NonConstUInt1Type:$input, ClockType:$clock);

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -56,8 +56,8 @@ public:
             LTLRepeatIntrinsicOp, LTLGoToRepeatIntrinsicOp,
             LTLNonConsecutiveRepeatIntrinsicOp, LTLNotIntrinsicOp,
             LTLImplicationIntrinsicOp, LTLUntilIntrinsicOp,
-            LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp, Mux2CellIntrinsicOp,
-            Mux4CellIntrinsicOp, HasBeenResetIntrinsicOp,
+            LTLEventuallyIntrinsicOp, LTLPastIntrinsicOp, LTLClockIntrinsicOp,
+            Mux2CellIntrinsicOp, Mux4CellIntrinsicOp, HasBeenResetIntrinsicOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
@@ -190,6 +190,7 @@ public:
   HANDLE(LTLImplicationIntrinsicOp, Unhandled);
   HANDLE(LTLUntilIntrinsicOp, Unhandled);
   HANDLE(LTLEventuallyIntrinsicOp, Unhandled);
+  HANDLE(LTLPastIntrinsicOp, Unhandled);
   HANDLE(LTLClockIntrinsicOp, Unhandled);
   HANDLE(Mux4CellIntrinsicOp, Unhandled);
   HANDLE(Mux2CellIntrinsicOp, Unhandled);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2024,6 +2024,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(LTLImplicationIntrinsicOp op);
   LogicalResult visitExpr(LTLUntilIntrinsicOp op);
   LogicalResult visitExpr(LTLEventuallyIntrinsicOp op);
+  LogicalResult visitExpr(LTLPastIntrinsicOp op);
   LogicalResult visitExpr(LTLClockIntrinsicOp op);
 
   template <typename TargetOp, typename IntrinsicOp>
@@ -4612,6 +4613,14 @@ LogicalResult FIRRTLLowering::visitExpr(LTLUntilIntrinsicOp op) {
 LogicalResult FIRRTLLowering::visitExpr(LTLEventuallyIntrinsicOp op) {
   return setLoweringToLTL<ltl::EventuallyOp>(op,
                                              getLoweredValue(op.getInput()));
+}
+
+LogicalResult FIRRTLLowering::visitExpr(LTLPastIntrinsicOp op) {
+  Value clk;
+  if (op.getClock())
+    clk = getLoweredNonClockValue(op.getClock());
+  return setLoweringToLTL<ltl::PastOp>(op, getLoweredValue(op.getInput()),
+                                       op.getDelayAttr(), clk);
 }
 
 LogicalResult FIRRTLLowering::visitExpr(LTLClockIntrinsicOp op) {

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -375,6 +375,33 @@ public:
   }
 };
 
+class CirctLTLPastConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check(GenericIntrinsic gi) override {
+    if (gi.hasNInputs(1, 1) || gi.sizedInput<UIntType>(0, 1) ||
+        gi.sizedOutput<UIntType>(1) || gi.namedIntParam("delay") ||
+        gi.hasNParam(1))
+      return true;
+    if (gi.op.getNumOperands() > 1 && gi.typedInput<ClockType>(1))
+      return true;
+    return false;
+  }
+
+  void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor adaptor,
+               PatternRewriter &rewriter) override {
+    auto delay = rewriter.getI64IntegerAttr(
+        gi.getParamValue<IntegerAttr>("delay").getValue().getZExtValue());
+    auto operands = adaptor.getOperands();
+    Value clock;
+    if (operands.size() > 1)
+      clock = operands[1];
+    rewriter.replaceOpWithNewOp<LTLPastIntrinsicOp>(
+        gi.op, gi.op.getResultTypes(), operands[0], delay, clock);
+  }
+};
+
 class CirctLTLClockConverter
     : public IntrinsicOpConverter<LTLClockIntrinsicOp> {
 public:

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -247,6 +247,27 @@ def CirctLTLNonConsecutiveRepeat : FIRRTLIntrinsic {
   }];
 }
 
+def CirctLTLPast : FIRRTLIntrinsic {
+  let mnemonic = "circt.ltl.past";
+  let description = [{
+    Observes a boolean value from a specified number of cycles in the past.
+    Corresponds to the SystemVerilog `$past(a, n)` function.
+
+    | Parameter | Type | Description                      |
+    | --------- | ---- | -------------------------------- |
+    | delay     | int  | number of cycles to look back   |
+
+    | Argument      | Type    | Description                |
+    | ------------- | ------- | -------------------------- |
+    | in            | UInt<1> | input boolean              |
+    | clock (opt.)  | Clock   | optional clock for $past   |
+
+    | Result | Type    | Description              |
+    | ------ | ------- | ------------------------ |
+    | out    | UInt<1> | value from `delay` ago   |
+  }];
+}
+
 def CirctLTLClock : FIRRTLIntrinsic {
   let mnemonic = "circt.ltl.clock";
   let description = [{

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -104,6 +104,11 @@ firrtl.circuit "Intrinsics" {
     // CHECK-NEXT: [[E0:%.+]] = ltl.eventually [[I0]] : !ltl.property
     %e0 = firrtl.int.ltl.eventually %i0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 
+    // CHECK-NEXT: [[P0:%.+]] = ltl.past %a, 1 : i1
+    %p0 = firrtl.int.ltl.past %a, 1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: [[P1:%.+]] = ltl.past %b, 3 clk [[CLK]] : i1
+    %p1 = firrtl.int.ltl.past %b, 3, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+
     // CHECK-NEXT: [[K0:%.+]] = ltl.clock [[I0]], posedge [[CLK]] : !ltl.property
     %k0 = firrtl.int.ltl.clock %i0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
 

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -77,6 +77,11 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: firrtl.int.ltl.eventually %in0 :
     firrtl.int.generic "circt_ltl_eventually"  %in0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 
+    // CHECK-NEXT: firrtl.int.ltl.past %in0, 42 :
+    firrtl.int.generic "circt_ltl_past" <delay: i64 = 42> %in0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.int.ltl.past %in0, 42, %clk :
+    firrtl.int.generic "circt_ltl_past" <delay: i64 = 42> %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+
     // CHECK-NEXT: firrtl.int.ltl.clock %in0, %clk :
     firrtl.int.generic "circt_ltl_clock"  %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
   }


### PR DESCRIPTION
Expose the existing `ltl.past` operation as the FIRRTL `circt.ltl.past` intrinsic, following the same pattern as the other LTL intrinsics. This allows FIRRTL designs to produce `$past(a)`, `$past(a, N)`, and `$past(a, N, clk)` expressions in SVAs.