### PR TITLE
[ImportVerilog] Add capture analysis pre-pass for functions

### DIFF
--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -72,17 +72,26 @@ using mlir::TypeSwitch;       // NOLINT(misc-unused-using-decls)
 // Forward declarations of LLVM classes to be imported in to the circt
 // namespace.
 namespace llvm {
+template <typename KeyT, typename ValueT, typename MapType, typename VectorType>
+class MapVector;
 template <typename KeyT, typename ValueT, unsigned InlineBuckets,
           typename KeyInfoT, typename BucketT>
 class SmallDenseMap;
+template <typename KeyT, typename ValueT, unsigned N>
+struct SmallMapVector;
 template <typename T, unsigned N, typename C>
 class SmallSet;
+template <typename T, unsigned N>
+class SmallSetVector;
 } // namespace llvm
 
 // Import things we want into our namespace.
 namespace circt {
-using llvm::SmallDenseMap; // NOLINT(misc-unused-using-decls)
-using llvm::SmallSet;      // NOLINT(misc-unused-using-decls)
+using llvm::MapVector;      // NOLINT(misc-unused-using-decls)
+using llvm::SmallDenseMap;  // NOLINT(misc-unused-using-decls)
+using llvm::SmallMapVector; // NOLINT(misc-unused-using-decls)
+using llvm::SmallSet;       // NOLINT(misc-unused-using-decls)
+using llvm::SmallSetVector; // NOLINT(misc-unused-using-decls)
 } // namespace circt
 
 // Forward declarations of classes to be imported in to the circt namespace.

--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -2,6 +2,7 @@ include(SlangCompilerOptions)
 
 add_circt_translation_library(CIRCTImportVerilog
   AssertionExpr.cpp
+  CaptureAnalysis.cpp
   Expressions.cpp
   FormatStrings.cpp
   HierarchicalNames.cpp

--- a/lib/Conversion/ImportVerilog/CaptureAnalysis.cpp
+++ b/lib/Conversion/ImportVerilog/CaptureAnalysis.cpp
@@ -1,0 +1,194 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CaptureAnalysis.h"
+#include "slang/ast/ASTVisitor.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/Support/SaveAndRestore.h"
+
+using namespace slang::ast;
+using namespace circt;
+using namespace circt::ImportVerilog;
+
+/// Check whether `var` is local to `func`. Walk up from the variable's parent
+/// scope; if we reach `func` before hitting another function boundary, the
+/// variable is local.
+static bool isLocalToFunction(const ValueSymbol &var,
+                              const SubroutineSymbol &func) {
+  for (const Scope *scope = var.getParentScope(); scope;
+       scope = scope->asSymbol().getParentScope()) {
+    if (&scope->asSymbol() == &func)
+      return true;
+    if (scope->asSymbol().kind == SymbolKind::Subroutine)
+      return false;
+  }
+  return false;
+}
+
+/// Workaround for a slang deficiency: when accessing a member of a virtual
+/// interface (e.g., `vif.data`), slang resolves the entire dotted path during
+/// name lookup and produces a `NamedValueExpression` that directly references
+/// the signal symbol inside the interface's `InstanceBody`. Unlike struct
+/// fields and class properties, which produce a `MemberAccessExpression`, there
+/// is no syntactic indication on the expression that this was a member
+/// projection.
+///
+/// This check matches variables that live inside an interface instance body.
+/// A `NamedValueExpression` referencing such a symbol is the result of slang's
+/// virtual interface member resolution, not a genuine variable capture. This is
+/// expected to be fixed upstream in slang.
+///
+/// See https://github.com/MikePopoloski/slang/discussions/1770
+static bool isVirtualInterfaceMemberAccess(const ValueSymbol &var) {
+  // Walk up from the variable to find the nearest enclosing InstanceBody.
+  for (const Scope *scope = var.getParentScope(); scope;
+       scope = scope->asSymbol().getParentScope()) {
+    auto *body = scope->asSymbol().as_if<InstanceBodySymbol>();
+    if (!body)
+      continue;
+    return body->getDefinition().definitionKind == DefinitionKind::Interface;
+  }
+  return false;
+}
+
+/// Check whether `var` is a global variable. Walk up from the variable's parent
+/// scope; if we hit a function or instance body, it's not global. Otherwise
+/// (package, compilation unit, root) it is.
+static bool isGlobalVariable(const ValueSymbol &var) {
+  for (const Scope *scope = var.getParentScope(); scope;
+       scope = scope->asSymbol().getParentScope()) {
+    switch (scope->asSymbol().kind) {
+    case SymbolKind::Subroutine:
+    case SymbolKind::InstanceBody:
+      return false;
+    default:
+      break;
+    }
+  }
+  return true;
+}
+
+namespace {
+
+/// Walk the entire AST to collect captured variables and the call graph for
+/// each function. Uses slang's `ASTVisitor` with both statement and expression
+/// visiting enabled so that we recurse into all function bodies.
+struct CaptureWalker
+    : public ASTVisitor<CaptureWalker, /*VisitStatements=*/true,
+                        /*VisitExpressions=*/true> {
+
+  /// The function whose body we are currently inside, or nullptr if we are at
+  /// a scope outside any function.
+  const SubroutineSymbol *currentFunc = nullptr;
+
+  /// Captured variables per function.
+  CaptureMap capturedVars;
+
+  /// Inverse call graph: maps each callee to the set of callers that call it.
+  /// Used to propagate captures from callees to their callers. Uses MapVector
+  /// for deterministic iteration order during propagation.
+  MapVector<const SubroutineSymbol *,
+            SmallSetVector<const SubroutineSymbol *, 4>>
+      callers;
+
+  /// When we enter a function body, record it as the current function and
+  /// recurse into its members and body statements.
+  void handle(const SubroutineSymbol &func) {
+    llvm::SaveAndRestore guard(currentFunc, &func);
+    visitDefault(func);
+  }
+
+  /// When we see a named value reference inside a function, check if it needs
+  /// to be captured.
+  void handle(const NamedValueExpression &expr) {
+    if (!currentFunc)
+      return;
+
+    auto &var = expr.symbol;
+
+    // Class properties are accessed through `this`, not captured.
+    if (var.kind == SymbolKind::ClassProperty)
+      return;
+
+    // Function arguments are local by definition.
+    if (var.kind == SymbolKind::FormalArgument)
+      return;
+
+    // Compile-time constants are materialized inline and don't need capturing.
+    // Slang monomorphizes modules and classes per parameterization, so within
+    // any given elaborated scope these are fixed values.
+    if (var.kind == SymbolKind::Parameter ||
+        var.kind == SymbolKind::EnumValue || var.kind == SymbolKind::Genvar ||
+        var.kind == SymbolKind::Specparam)
+      return;
+
+    // Only capture variables that are non-local and non-global.
+    if (isLocalToFunction(var, *currentFunc) || isGlobalVariable(var))
+      return;
+
+    // Work around a slang deficiency where virtual interface member accesses
+    // are resolved to NamedValueExpressions referencing symbols inside the
+    // interface's instance body, indistinguishable from direct variable
+    // references. See isVirtualInterfaceMemberAccess for details.
+    if (isVirtualInterfaceMemberAccess(var))
+      return;
+
+    capturedVars[currentFunc].insert(&var);
+  }
+
+  /// Record call graph edges when we see a function call.
+  void handle(const CallExpression &expr) {
+    if (currentFunc)
+      if (auto *const *callee =
+              std::get_if<const SubroutineSymbol *>(&expr.subroutine))
+        callers[*callee].insert(currentFunc);
+    visitDefault(expr);
+  }
+
+  /// Propagate captures transitively through the call graph. For each callee
+  /// that has captures, push each captured variable upward through all
+  /// transitive callers using a worklist. A captured variable is only
+  /// propagated to a caller if it is not local to that caller.
+  void propagateCaptures() {
+    using WorkItem = std::pair<const SubroutineSymbol *, const ValueSymbol *>;
+    SmallSetVector<WorkItem, 16> worklist;
+
+    for (auto &[func, _] : callers) {
+      // Check if this function captures any variables. Nothing to do if it
+      // doesn't.
+      auto it = capturedVars.find(func);
+      if (it == capturedVars.end())
+        continue;
+
+      // Prime the worklist with the captured variables.
+      for (auto *var : it->second)
+        worklist.insert({func, var});
+
+      // Push each captured variables to the func's callers transitively.
+      while (!worklist.empty()) {
+        auto [func, cap] = worklist.pop_back_val();
+        auto callersIt = callers.find(func);
+        if (callersIt == callers.end())
+          continue;
+        for (auto *caller : callersIt->second)
+          if (!isLocalToFunction(*cap, *caller))
+            if (capturedVars[caller].insert(cap))
+              worklist.insert({caller, cap});
+      }
+    }
+  }
+};
+
+} // namespace
+
+CaptureMap ImportVerilog::analyzeFunctionCaptures(const RootSymbol &root) {
+  CaptureWalker walker;
+  root.visit(walker);
+  walker.propagateCaptures();
+  return std::move(walker.capturedVars);
+}

--- a/lib/Conversion/ImportVerilog/CaptureAnalysis.h
+++ b/lib/Conversion/ImportVerilog/CaptureAnalysis.h
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Pre-pass over the slang AST to determine which non-local, non-global
+// variables each function captures, either directly or transitively through
+// calls to other functions.
+//
+// This information is needed before any MLIR conversion happens so that
+// function declarations can be created with the correct signature (including
+// extra capture parameters) upfront, enabling a clean two-phase
+// declare-then-define approach for functions.
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef CONVERSION_IMPORTVERILOG_CAPTUREANALYSIS_H
+#define CONVERSION_IMPORTVERILOG_CAPTUREANALYSIS_H
+
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/SetVector.h"
+
+namespace slang {
+namespace ast {
+class RootSymbol;
+class SubroutineSymbol;
+class ValueSymbol;
+} // namespace ast
+} // namespace slang
+
+namespace circt {
+namespace ImportVerilog {
+
+/// The result of capture analysis: for each function, the set of non-local,
+/// non-global variable symbols that the function captures directly or
+/// transitively through calls.
+using CaptureMap = DenseMap<const slang::ast::SubroutineSymbol *,
+                            SmallSetVector<const slang::ast::ValueSymbol *, 4>>;
+
+/// Analyze the AST rooted at `root` to determine which variables each function
+/// captures. A variable is considered captured by a function if it is
+/// referenced inside the function's body (or transitively through called
+/// functions) and is neither local to the function nor a global variable
+/// (package-scope or compilation-unit-scope variables that are lowered via
+/// `get_global_signal`).
+CaptureMap analyzeFunctionCaptures(const slang::ast::RootSymbol &root);
+
+} // namespace ImportVerilog
+} // namespace circt
+
+#endif // CONVERSION_IMPORTVERILOG_CAPTUREANALYSIS_H

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -9,6 +9,7 @@ function(add_circt_unittest test_dirname)
   add_unittest(CIRCTUnitTests ${test_dirname} ${ARGN})
 endfunction()
 
+add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(Support)
 add_subdirectory(Tools)

--- a/unittests/Conversion/CMakeLists.txt
+++ b/unittests/Conversion/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(CIRCT_SLANG_FRONTEND_ENABLED)
+  add_subdirectory(ImportVerilog)
+endif()

--- a/unittests/Conversion/ImportVerilog/CMakeLists.txt
+++ b/unittests/Conversion/ImportVerilog/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(SlangCompilerOptions)
+
+add_circt_unittest(CIRCTImportVerilogTests
+  CaptureAnalysisTest.cpp
+)
+
+target_include_directories(CIRCTImportVerilogTests
+  PRIVATE
+  ${CIRCT_MAIN_SRC_DIR}
+)
+
+target_link_libraries(CIRCTImportVerilogTests
+  PRIVATE
+  CIRCTImportVerilog
+  LLVMSupport
+  slang_slang
+)

--- a/unittests/Conversion/ImportVerilog/CaptureAnalysisTest.cpp
+++ b/unittests/Conversion/ImportVerilog/CaptureAnalysisTest.cpp
@@ -1,0 +1,297 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lib/Conversion/ImportVerilog/CaptureAnalysis.h"
+#include "slang/ast/ASTVisitor.h"
+#include "slang/ast/Compilation.h"
+#include "slang/syntax/SyntaxTree.h"
+#include "llvm/Support/Valgrind.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+using namespace circt::ImportVerilog;
+using testing::ElementsAre;
+using testing::IsEmpty;
+
+namespace {
+
+/// Maps function names to sorted, unique lists of captured variable names.
+using NamedCaptures = std::map<std::string, std::vector<std::string>>;
+
+/// Test fixture that skips all tests when running under Valgrind, since slang
+/// triggers Valgrind's uninitialized value detection.
+class CaptureAnalysisTest : public testing::Test {
+protected:
+  void SetUp() override {
+    if (llvm::sys::RunningOnValgrind())
+      GTEST_SKIP() << "Slang triggers Valgrind false positives";
+  }
+
+  /// Parse Verilog, run capture analysis, and return a map from function name
+  /// to sorted capture variable names. All AST pointers are resolved to strings
+  /// before the compilation is destroyed.
+  NamedCaptures analyze(std::string_view code) {
+    auto tree = SyntaxTree::fromText(code);
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    auto captures = analyzeFunctionCaptures(compilation.getRoot());
+
+    NamedCaptures result;
+    for (auto &[func, caps] : captures) {
+      auto &names = result[std::string(func->name)];
+      for (auto *var : caps)
+        names.emplace_back(var->name);
+      std::sort(names.begin(), names.end());
+      names.erase(std::unique(names.begin(), names.end()), names.end());
+    }
+    return result;
+  }
+};
+
+// Virtual interface member accesses should not be treated as captures.
+// Slang resolves `vif.data` directly to a NamedValueExpression for the
+// interface signal, but this is lowered through the virtual interface
+// mechanism, not through capture parameters.
+TEST_F(CaptureAnalysisTest, VirtualInterfaceMemberNotCaptured) {
+  auto captures = analyze(R"(
+    interface MyIf;
+      logic data;
+    endinterface
+
+    class consumer;
+      virtual MyIf vif;
+      function void drive(logic val);
+        vif.data = val;
+      endfunction
+    endclass
+
+    module top;
+      MyIf intf();
+      initial begin
+        consumer c = new;
+        c.vif = intf;
+        c.drive(1'b1);
+      end
+    endmodule
+  )");
+  EXPECT_THAT(captures["drive"], IsEmpty());
+}
+
+// Parameters are compile-time constants and should not be captured.
+TEST_F(CaptureAnalysisTest, ParameterNotCaptured) {
+  auto captures = analyze(R"(
+    module top;
+      parameter MAX = 256;
+      function automatic int scale();
+        return $random % MAX;
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["scale"], IsEmpty());
+}
+
+// Localparams are compile-time constants and should not be captured.
+TEST_F(CaptureAnalysisTest, LocalparamNotCaptured) {
+  auto captures = analyze(R"(
+    module top;
+      localparam OFFSET = 42;
+      function automatic int get();
+        return $random + OFFSET;
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["get"], IsEmpty());
+}
+
+// Enum values are compile-time constants and should not be captured.
+TEST_F(CaptureAnalysisTest, EnumValueNotCaptured) {
+  auto captures = analyze(R"(
+    module top;
+      typedef enum logic [1:0] { A, B, C } state_t;
+      task automatic check(state_t s);
+        if (s === B)
+          $display("ok");
+      endtask
+    endmodule
+  )");
+  EXPECT_THAT(captures["check"], IsEmpty());
+}
+
+// Class type parameters are compile-time constants and should not be captured.
+TEST_F(CaptureAnalysisTest, ClassTypeParamNotCaptured) {
+  auto captures = analyze(R"(
+    module top;
+      class C #(int N = 10);
+        function automatic int get();
+          return $random % N;
+        endfunction
+      endclass
+    endmodule
+  )");
+  EXPECT_THAT(captures["get"], IsEmpty());
+}
+
+} // namespace
+
+// A function referencing a module-level variable should capture it.
+TEST_F(CaptureAnalysisTest, DirectCapture) {
+  auto captures = analyze(R"(
+    module top;
+      int x;
+      function void foo();
+        x = 42;
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["foo"], ElementsAre("x"));
+}
+
+// A function referencing only local variables should have no captures.
+TEST_F(CaptureAnalysisTest, NoCapture) {
+  auto captures = analyze(R"(
+    module top;
+      function int foo();
+        int y;
+        y = 42;
+        return y;
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["foo"], IsEmpty());
+}
+
+// Package-scope variables are global and should not be captured.
+TEST_F(CaptureAnalysisTest, GlobalVariableNotCaptured) {
+  auto captures = analyze(R"(
+    package pkg;
+      int g;
+      function int foo();
+        return g;
+      endfunction
+    endpackage
+    module top;
+      import pkg::*;
+    endmodule
+  )");
+  EXPECT_THAT(captures["foo"], IsEmpty());
+}
+
+// Transitive capture: foo calls bar, bar captures x, so foo should too.
+TEST_F(CaptureAnalysisTest, TransitiveCapture) {
+  auto captures = analyze(R"(
+    module top;
+      int x;
+      function void bar();
+        x = 1;
+      endfunction
+      function void foo();
+        bar();
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["bar"], ElementsAre("x"));
+  EXPECT_THAT(captures["foo"], ElementsAre("x"));
+}
+
+// A variable defined by the caller should not propagate as a capture of the
+// caller, even though the callee captures it.
+TEST_F(CaptureAnalysisTest, TransitiveCaptureStopsAtDefiner) {
+  auto captures = analyze(R"(
+    module top;
+      function void inner(int x);
+      endfunction
+      function void outer();
+        int x;
+        inner(x);
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["inner"], IsEmpty());
+  EXPECT_THAT(captures["outer"], IsEmpty());
+}
+
+// A shadowing local in the caller does not prevent transitive propagation,
+// because the callee captures a different symbol (the module-level one).
+TEST_F(CaptureAnalysisTest, ShadowingDoesNotPreventCapture) {
+  auto captures = analyze(R"(
+    module top;
+      int x;
+      function void inner();
+        x = 1;
+      endfunction
+      function void outer();
+        int x;
+        inner();
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["inner"], ElementsAre("x"));
+  EXPECT_THAT(captures["outer"], ElementsAre("x"));
+}
+
+// Multiple variables captured by the same function.
+TEST_F(CaptureAnalysisTest, MultipleCaptures) {
+  auto captures = analyze(R"(
+    module top;
+      int a, b, c;
+      function void foo();
+        a = b + c;
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["foo"], ElementsAre("a", "b", "c"));
+}
+
+// Function arguments should not be captured.
+TEST_F(CaptureAnalysisTest, ArgumentsNotCaptured) {
+  auto captures = analyze(R"(
+    module top;
+      function int foo(int a, int b);
+        return a + b;
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["foo"], IsEmpty());
+}
+
+// Recursive functions should not cause infinite loops.
+TEST_F(CaptureAnalysisTest, RecursiveFunction) {
+  auto captures = analyze(R"(
+    module top;
+      int x;
+      function void foo();
+        x = 1;
+        foo();
+      endfunction
+    endmodule
+  )");
+  EXPECT_THAT(captures["foo"], ElementsAre("x"));
+}
+
+// Deep transitive capture chain: a -> b -> c, c captures x.
+TEST_F(CaptureAnalysisTest, DeepTransitiveCapture) {
+  auto captures = analyze(R"(
+    module top;
+      int x;
+      function void c();
+        x = 1;
+      endfunction
+      function void b();
+        c();
+      endfunction
+      function void a();
+        b();
+      endfunction
+    endmodule
+  )");
+  for (auto *name : {"a", "b", "c"})
+    EXPECT_THAT(captures[name], ElementsAre("x")) << "function " << name;
+}


### PR DESCRIPTION
Add a pre-pass over the slang AST that determines which non-local, non-global variables each function captures, either directly or transitively through calls. This walks the entire AST, collecting variable references and call graph edges, then propagates captures through the inverse call graph using a worklist until stable.

This analysis is a prerequisite for switching ImportVerilog to a two-phase declare-then-define approach for functions. Currently, function bodies are converted eagerly during package/module member iteration, which can fail when a function transitively references a variable that hasn't been declared yet (e.g., UVM's `m_uvm_core_state`). With the capture sets known upfront, function declarations can include the correct capture parameters from the start, and body conversion can be deferred.

Also add `MapVector`, `SmallMapVector`, and `SmallSetVector` re-exports.

The analysis is not yet directly used in ImportVerilog. This will be done in a follow-up commit.