### PR TITLE
ImportVerilog: improve testbench compatibility

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -104,6 +104,28 @@ static uint64_t getTimeScaleInFemtoseconds(Context &context) {
   return scale;
 }
 
+/// Resolve a hierarchical value that refers to a member of an expanded
+/// interface instance.
+static Value lookupExpandedInterfaceMember(
+    Context &context, const slang::ast::HierarchicalValueExpression &expr) {
+  auto nameAttr = context.builder.getStringAttr(expr.symbol.name);
+  for (const auto &element : expr.ref.path) {
+    auto *inst = element.symbol->as_if<slang::ast::InstanceSymbol>();
+    if (!inst)
+      continue;
+    auto *lowering = context.interfaceInstances.lookup(inst);
+    if (!lowering)
+      continue;
+    if (auto it = lowering->expandedMembers.find(&expr.symbol);
+        it != lowering->expandedMembers.end())
+      return it->second;
+    if (auto it = lowering->expandedMembersByName.find(nameAttr);
+        it != lowering->expandedMembersByName.end())
+      return it->second;
+  }
+  return {};
+}
+
 static Value visitClassProperty(Context &context,
                                 const slang::ast::ClassPropertySymbol &expr) {
   auto loc = context.convertLocation(expr.location);
@@ -902,6 +924,16 @@ struct RvalueExprVisitor : public ExprVisitor {
         if (context.rvalueReadCallback)
           context.rvalueReadCallback(readOp);
         value = readOp.getResult();
+      }
+      return value;
+    }
+
+    if (auto value = lookupExpandedInterfaceMember(context, expr)) {
+      if (isa<moore::RefType>(value.getType())) {
+        auto readOp = moore::ReadOp::create(builder, hierLoc, value);
+        if (context.rvalueReadCallback)
+          context.rvalueReadCallback(readOp);
+        return readOp.getResult();
       }
       return value;
     }
@@ -2279,6 +2311,9 @@ struct LvalueExprVisitor : public ExprVisitor {
   Value visit(const slang::ast::HierarchicalValueExpression &expr) {
     // Handle local variables.
     if (auto value = context.valueSymbols.lookup(&expr.symbol))
+      return value;
+
+    if (auto value = lookupExpandedInterfaceMember(context, expr))
       return value;
 
     // Handle global variables.

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -740,6 +740,24 @@ struct StmtVisitor {
 
   // Handle return statements.
   LogicalResult visit(const slang::ast::ReturnStatement &stmt) {
+    Operation *parentOp =
+        builder.getInsertionBlock() ? builder.getInsertionBlock()->getParentOp()
+                                    : nullptr;
+    if (!parentOp)
+      return mlir::emitError(loc) << "return statement is not within an op";
+
+    if (isa<moore::CoroutineOp, moore::ProcedureOp>(parentOp)) {
+      if (stmt.expr)
+        return mlir::emitError(loc)
+               << "unsupported `return <expr>` in a procedure or task";
+      moore::ReturnOp::create(builder, loc);
+      setTerminated();
+      return success();
+    }
+
+    if (!isa<mlir::func::FuncOp>(parentOp))
+      return mlir::emitError(loc) << "unsupported return statement context";
+
     if (stmt.expr) {
       auto expr = context.convertRvalueExpression(*stmt.expr);
       if (!expr)

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -740,9 +740,9 @@ struct StmtVisitor {
 
   // Handle return statements.
   LogicalResult visit(const slang::ast::ReturnStatement &stmt) {
-    Operation *parentOp =
-        builder.getInsertionBlock() ? builder.getInsertionBlock()->getParentOp()
-                                    : nullptr;
+    Operation *parentOp = builder.getInsertionBlock()
+                              ? builder.getInsertionBlock()->getParentOp()
+                              : nullptr;
     if (!parentOp)
       return mlir::emitError(loc) << "return statement is not within an op";
 

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -296,12 +296,15 @@ struct ModuleVisitor : public BaseVisitor {
   expandInterfaceInstance(const slang::ast::InstanceSymbol &instNode) {
     auto prefix = (Twine(blockNamePrefix) + instNode.name + "_").str();
     auto lowering = std::make_unique<InterfaceLowering>();
+    Context::ValueSymbolScope scope(context.valueSymbols);
 
     auto recordMember = [&](const slang::ast::Symbol &sym,
                             Value value) -> void {
       lowering->expandedMembers[&sym] = value;
       auto nameAttr = builder.getStringAttr(sym.name);
       lowering->expandedMembersByName[nameAttr] = value;
+      if (auto *valueSym = sym.as_if<slang::ast::ValueSymbol>())
+        context.valueSymbols.insert(valueSym, value);
     };
 
     for (const auto &member : instNode.body.members()) {
@@ -369,6 +372,24 @@ struct ModuleVisitor : public BaseVisitor {
       if (port->internalSymbol) {
         recordMember(*port->internalSymbol, lvalue);
       }
+    }
+
+    // Lower executable interface body members now that all interface signals
+    // and port bindings are available in the scoped `valueSymbols` table.
+    for (const auto &member : instNode.body.members()) {
+      switch (member.kind) {
+      case slang::ast::SymbolKind::ContinuousAssign:
+      case slang::ast::SymbolKind::ProceduralBlock:
+      case slang::ast::SymbolKind::StatementBlock:
+        break;
+      default:
+        continue;
+      }
+      auto memberLoc = context.convertLocation(member.location);
+      if (failed(member.visit(ModuleVisitor(context, memberLoc, prefix))))
+        return failure();
+      if (failed(context.flushPendingMonitors()))
+        return failure();
     }
 
     context.interfaceInstanceStorage.push_back(std::move(lowering));
@@ -1588,7 +1609,6 @@ Context::defineFunction(const slang::ast::SubroutineSymbol &subroutine) {
 
   ValueSymbolScope scope(valueSymbols);
   VirtualInterfaceMemberScope vifMemberScope(virtualIfaceMembers);
-
   if (isMethod) {
     if (const auto *classTy =
             subroutine.thisVar->getType().as_if<slang::ast::ClassType>()) {

--- a/test/Conversion/ImportVerilog/interface-instance-expansion.sv
+++ b/test/Conversion/ImportVerilog/interface-instance-expansion.sv
@@ -1,0 +1,47 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+// REQUIRES: slang
+//
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+interface input_if(input logic clk);
+  logic seen;
+  assign seen = clk;
+endinterface
+
+// CHECK-LABEL: moore.module @InterfaceContinuousAssign(
+// CHECK-SAME: in %[[CLKA:[^ ,]+]] : !moore.l1, in %[[CLKB:[^ ,]+]] : !moore.l1, out yA : !moore.l1, out yB : !moore.l1
+module InterfaceContinuousAssign(input logic clkA, input logic clkB,
+                                 output logic yA, output logic yB);
+  input_if a(clkA);
+  input_if b(clkB);
+  assign yA = a.seen;
+  assign yB = b.seen;
+
+  // CHECK: %[[A_SEEN:.+]] = moore.assigned_variable %[[CLKA]] : l1
+  // CHECK: %[[B_SEEN:.+]] = moore.assigned_variable %[[CLKB]] : l1
+  // CHECK: moore.output %[[A_SEEN]], %[[B_SEEN]] : !moore.l1, !moore.l1
+endmodule
+
+interface sample_if(input logic clk);
+  logic sampled;
+  always_comb sampled = clk;
+endinterface
+
+// CHECK-LABEL: moore.module @InterfaceProceduralAssign(
+// CHECK-SAME: in %[[CLK:[^ ,]+]] : !moore.l1, out y : !moore.l1
+module InterfaceProceduralAssign(input logic clk, output logic y);
+  sample_if vif(clk);
+  assign y = vif.sampled;
+
+  // CHECK: %[[INNER_CLK:.+]] = moore.variable name "clk" : <l1>
+  // CHECK: %[[SAMPLED:.+]] = moore.variable : <l1>
+  // CHECK: moore.procedure always_comb {
+  // CHECK:   %[[CLK_READ:.+]] = moore.read %[[INNER_CLK]] : <l1>
+  // CHECK:   moore.blocking_assign %[[SAMPLED]], %[[CLK_READ]] : l1
+  // CHECK:   moore.return
+  // CHECK: }
+  // CHECK: %[[SAMPLED_READ:.+]] = moore.read %[[SAMPLED]] : <l1>
+  // CHECK: moore.assign %[[INNER_CLK]], %[[CLK]] : l1
+  // CHECK: moore.output %[[SAMPLED_READ]] : !moore.l1
+endmodule

--- a/test/Conversion/ImportVerilog/testbench-compat.sv
+++ b/test/Conversion/ImportVerilog/testbench-compat.sv
@@ -1,0 +1,21 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+// REQUIRES: slang
+//
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// CHECK-LABEL: moore.module @TaskReturn()
+module TaskReturn;
+  // CHECK: moore.procedure initial {
+  // CHECK-NEXT:   moore.call_coroutine @t() : () -> ()
+  // CHECK-NEXT:   moore.return
+  // CHECK-NEXT: }
+  initial t();
+
+  // CHECK-LABEL: moore.coroutine private @t() {
+  // CHECK-NEXT:   moore.return
+  // CHECK-NEXT: }
+  task automatic t();
+    return;
+  endtask
+endmodule


### PR DESCRIPTION
This is a second PR (building on last week's) for adding UVM-parsing with proper MLIR semantics.