### PR TITLE
[ImportVerilog] Refactor HierarchicalNames to use ASTVisitor

### DIFF
--- a/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
+++ b/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
@@ -12,7 +12,10 @@ using namespace circt;
 using namespace ImportVerilog;
 
 namespace {
-struct HierPathValueExprVisitor {
+struct HierPathValueExprVisitor
+    : public slang::ast::ASTVisitor<HierPathValueExprVisitor,
+                                    /*VisitStatements=*/false,
+                                    /*VisitExpressions=*/true> {
   Context &context;
   Location loc;
   OpBuilder &builder;
@@ -27,7 +30,7 @@ struct HierPathValueExprVisitor {
         outermostModule(outermostModule) {}
 
   // Handle hierarchical values
-  LogicalResult visit(const slang::ast::HierarchicalValueExpression &expr) {
+  void handle(const slang::ast::HierarchicalValueExpression &expr) {
     auto *currentInstBody =
         expr.symbol.getParentScope()->getContainingInstance();
     auto *outermostInstBody =
@@ -36,7 +39,7 @@ struct HierPathValueExprVisitor {
     // Like module Foo; int a; Foo.a; endmodule.
     // Ignore "Foo.a" invoked by this module itself.
     if (currentInstBody == outermostInstBody)
-      return success();
+      return;
 
     auto hierName = builder.getStringAttr(expr.symbol.name);
     const slang::ast::InstanceBodySymbol *parentInstBody = nullptr;
@@ -85,107 +88,54 @@ struct HierPathValueExprVisitor {
                          ->getContainingInstance();
       if (tempInstBody == outermostInstBody) {
         collectHierarchicalPaths(currentInstBody, true);
-        return success();
+        return;
       }
     }
 
     hierName = builder.getStringAttr(currentInstBody->parentInstance->name +
                                      llvm::Twine(".") + hierName.getValue());
     collectHierarchicalPaths(outermostInstBody, false);
-    return success();
-  }
-
-  /// TODO:Skip all others.
-  /// But we should output a warning to display which symbol had been skipped.
-  /// However, to ensure we can test smoothly, we didn't do that.
-  template <typename T>
-  LogicalResult visit(T &&node) {
-    return success();
-  }
-
-  LogicalResult visitInvalid(const slang::ast::Expression &expr) {
-    mlir::emitError(loc, "invalid expression");
-    return failure();
   }
 };
 } // namespace
 
-LogicalResult
-Context::collectHierarchicalValues(const slang::ast::Expression &expr,
-                                   const slang::ast::Symbol &outermostModule) {
+void Context::collectHierarchicalValues(
+    const slang::ast::Expression &expr,
+    const slang::ast::Symbol &outermostModule) {
   auto loc = convertLocation(expr.sourceRange);
-  return expr.visit(HierPathValueExprVisitor(*this, loc, outermostModule));
+  HierPathValueExprVisitor visitor(*this, loc, outermostModule);
+  expr.visit(visitor);
 }
 
 /// Traverse the instance body.
 namespace {
-struct InstBodyVisitor {
+struct InstBodyVisitor
+    : public slang::ast::ASTVisitor<InstBodyVisitor,
+                                    /*VisitStatements=*/true,
+                                    /*VisitExpressions=*/true> {
+
+  InstBodyVisitor(Context &context, const slang::ast::Symbol &outermostModule)
+      : context(context), outermostModule(outermostModule) {}
+
+  void handle(const slang::ast::InstanceSymbol &instNode) {
+    context.traverseInstanceBody(instNode.body);
+  }
+
+  void handle(const slang::ast::Expression &expr) {
+    context.collectHierarchicalValues(expr, outermostModule);
+  }
+
   Context &context;
-  Location loc;
-
-  InstBodyVisitor(Context &context, Location loc)
-      : context(context), loc(loc) {}
-
-  // Handle instances.
-  LogicalResult visit(const slang::ast::InstanceSymbol &instNode) {
-    return context.traverseInstanceBody(instNode.body);
-  }
-
-  // Handle variables.
-  LogicalResult visit(const slang::ast::VariableSymbol &varNode) {
-    auto &outermostModule = varNode.getParentScope()->asSymbol();
-    if (const auto *init = varNode.getInitializer())
-      if (failed(context.collectHierarchicalValues(*init, outermostModule)))
-        return failure();
-    return success();
-  }
-
-  // Handle nets.
-  LogicalResult visit(const slang::ast::NetSymbol &netNode) {
-    auto &outermostModule = netNode.getParentScope()->asSymbol();
-    if (const auto *init = netNode.getInitializer())
-      if (failed(context.collectHierarchicalValues(*init, outermostModule)))
-        return failure();
-    return success();
-  }
-
-  // Handle continuous assignments.
-  LogicalResult visit(const slang::ast::ContinuousAssignSymbol &assignNode) {
-    const auto &expr =
-        assignNode.getAssignment().as<slang::ast::AssignmentExpression>();
-
-    // Such as `sub.a`, the `sub` is the outermost module for the hierarchical
-    // variable `a`.
-    auto &outermostModule = assignNode.getParentScope()->asSymbol();
-    if (expr.left().hasHierarchicalReference())
-      if (failed(
-              context.collectHierarchicalValues(expr.left(), outermostModule)))
-        return failure();
-
-    if (expr.right().hasHierarchicalReference())
-      if (failed(
-              context.collectHierarchicalValues(expr.right(), outermostModule)))
-        return failure();
-
-    return success();
-  }
-
-  /// TODO:Skip all others.
-  /// But we should output a warning to display which symbol had been skipped.
-  /// However, to ensure we can test smoothly, we didn't do that.
-  template <typename T>
-  LogicalResult visit(T &&node) {
-    return success();
-  }
+  const slang::ast::Symbol &outermostModule;
 };
+
 } // namespace
 
-LogicalResult Context::traverseInstanceBody(const slang::ast::Symbol &symbol) {
+void Context::traverseInstanceBody(const slang::ast::Symbol &symbol) {
   if (auto *instBodySymbol = symbol.as_if<slang::ast::InstanceBodySymbol>())
     for (auto &member : instBodySymbol->members()) {
-      auto loc = convertLocation(member.location);
-      if (failed(member.visit(InstBodyVisitor(*this, loc))))
-        return failure();
+      auto &outermostModule = member.getParentScope()->asSymbol();
+      InstBodyVisitor visitor(*this, outermostModule);
+      member.visit(visitor);
     }
-  return success();
 }

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -233,10 +233,9 @@ struct Context {
       const slang::ast::CallExpression::SystemCallInfo &info, Location loc);
 
   // Traverse the whole AST to collect hierarchical names.
-  LogicalResult
-  collectHierarchicalValues(const slang::ast::Expression &expr,
-                            const slang::ast::Symbol &outermostModule);
-  LogicalResult traverseInstanceBody(const slang::ast::Symbol &symbol);
+  void collectHierarchicalValues(const slang::ast::Expression &expr,
+                                 const slang::ast::Symbol &outermostModule);
+  void traverseInstanceBody(const slang::ast::Symbol &symbol);
 
   // Convert timing controls into a corresponding set of ops that delay
   // execution of the current block. Produces an error if the implicit event

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -877,8 +877,7 @@ LogicalResult Context::convertCompilation() {
   // First only to visit the whole AST to collect the hierarchical names without
   // any operation creating.
   for (auto *inst : root.topInstances)
-    if (failed(traverseInstanceBody(inst->body)))
-      return failure();
+    traverseInstanceBody(inst->body);
 
   // Visit all top-level declarations in all compilation units. This does not
   // include instantiable constructs like modules, interfaces, and programs,

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -228,8 +228,8 @@ endmodule
 // reference resolution code that actually needs fixing. This test guards
 // against a regression to this being a crash.
 module HierRefTop(input i, output o);
-  HierRefA A();
   // expected-error @below {{unsupported port}}
+  HierRefA A();
   HierRefB B();
   assign A.i = i;
   assign o = B.o;

--- a/test/Conversion/ImportVerilog/hierarchical-names.sv
+++ b/test/Conversion/ImportVerilog/hierarchical-names.sv
@@ -69,3 +69,50 @@ module SubD;
   // CHECK: moore.assign %w, [[RD_Z]] : i32
   assign SubD.w = SubD.z;
 endmodule
+
+// -----
+
+// Check we descend into procedural blocks
+// CHECK-LABEL: moore.module @HasInitial()
+// CHECK: [[INSTRES:%.+]] = moore.instance "subE1" @SubE() -> (a: !moore.ref<l1>)
+// CHECK: moore.procedure initial {
+// CHECK: [[C1:%.+]] = moore.constant 1 : l1
+// CHECK: moore.nonblocking_assign [[INSTRES]], [[C1]] : l1
+// CHECK: moore.return
+module HasInitial;
+   SubE subE1();
+   initial
+      begin
+        subE1.a  <= 1'b1;
+      end
+endmodule
+
+// CHECK-LABEL: moore.module private @SubE(out a : !moore.ref<l1>)
+// CHECK: [[VAR:%.+]] = moore.variable : <l1>
+// CHECK: moore.output [[VAR]] : !moore.ref<l1>
+module SubE;
+   reg    a;
+endmodule
+
+// -----
+
+// Make sure we recurse through expressions
+// CHECK-LABEL: moore.module @SubExpr()
+// CHECK: [[INSTRES:%.+]] = moore.instance "subF" @SubF() -> (x: !moore.ref<l8>)
+// CHECK: [[READ:%.+]] = moore.read [[INSTRES]] : <l8>
+// CHECK: [[C1:%.+]] = moore.constant 1 : l8
+// CHECK: [[ADD:%.+]] = moore.add [[READ]], [[C1]] : l8
+// CHECK: moore.assign %a, [[ADD]] : l8
+
+module SubExpr;
+  SubF subF();
+  logic [7:0] a;
+  assign a = subF.x + 8'd1;
+endmodule
+
+// CHECK-LABEL: moore.module private @SubF(out x : !moore.ref<l8>)
+// CHECK: [[VAR:%.+]] = moore.variable : <l8>
+// CHECK: moore.output [[VAR]] : !moore.ref<l8>
+module SubF;
+  logic [7:0] x;
+endmodule


### PR DESCRIPTION
This refactors the pre-pass that gathers hierarchical reference names to use Slang's ASTVisitor, which is much more generic and allows us to a) prune out a load of boilerplate to cover specific cases and b) support cases that we didn't have existing code to support.

AI-assisted-by: GPT-5.1-Codex-Max