### PR TITLE
[ImportVerilog] Use capture analysis for function declarations

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1810,53 +1810,18 @@ struct RvalueExprVisitor : public ExprVisitor {
       arguments.push_back(value);
     }
 
-    if (!lowering->isConverting && !lowering->captures.empty()) {
-      auto materializeCaptureAtCall = [&](Value cap) -> Value {
-        // Captures are expected to be moore::RefType.
-        auto refTy = dyn_cast<moore::RefType>(cap.getType());
-        if (!refTy) {
-          lowering->op.emitError(
-              "expected captured value to be moore::RefType");
-          return {};
-        }
-
-        // Expected case: the capture stems from a variable of any parent
-        // scope. We need to walk up, since definition might be a couple regions
-        // up.
-        Region *capRegion = [&]() -> Region * {
-          if (auto ba = dyn_cast<BlockArgument>(cap))
-            return ba.getOwner()->getParent();
-          if (auto *def = cap.getDefiningOp())
-            return def->getParentRegion();
-          return nullptr;
-        }();
-
-        Region *callRegion =
-            builder.getBlock() ? builder.getBlock()->getParent() : nullptr;
-
-        for (Region *r = callRegion; r; r = r->getParentRegion()) {
-          if (r == capRegion) {
-            // Safe to use the SSA value directly here.
-            return cap;
-          }
-        }
-
-        // Otherwise we can’t legally rematerialize this capture here.
-        lowering->op.emitError()
-            << "cannot materialize captured ref at call site; non-symbol "
-            << "source: "
-            << (cap.getDefiningOp()
-                    ? cap.getDefiningOp()->getName().getStringRef()
-                    : "<block-arg>");
+    // Pass captured variables as extra arguments. Each captured AST symbol is
+    // resolved to an MLIR value through the scoped symbol table, which
+    // naturally handles transitive captures (the caller’s own capture block
+    // argument will be found for variables captured from an outer scope).
+    for (auto *sym : lowering->capturedSymbols) {
+      Value val = context.valueSymbols.lookup(sym);
+      if (!val) {
+        mlir::emitError(loc) << "failed to resolve captured variable `"
+                             << sym->name << "` at call site";
         return {};
-      };
-
-      for (Value cap : lowering->captures) {
-        Value mat = materializeCaptureAtCall(cap);
-        if (!mat)
-          return {};
-        arguments.push_back(mat);
       }
+      arguments.push_back(val);
     }
 
     // Determine result types from the declared/converted func op.

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -10,6 +10,7 @@
 #ifndef CONVERSION_IMPORTVERILOG_IMPORTVERILOGINTERNALS_H
 #define CONVERSION_IMPORTVERILOG_IMPORTVERILOGINTERNALS_H
 
+#include "CaptureAnalysis.h"
 #include "circt/Conversion/ImportVerilog.h"
 #include "circt/Dialect/Debug/DebugOps.h"
 #include "circt/Dialect/HW/HWOps.h"
@@ -96,9 +97,17 @@ struct ModuleLowering {
 /// accessed through the `FunctionOpInterface`.
 struct FunctionLowering {
   mlir::FunctionOpInterface op;
-  llvm::SmallVector<Value, 4> captures;
-  llvm::DenseMap<Value, unsigned> captureIndex;
-  bool capturesFinalized = false;
+
+  /// The AST symbols captured by this function, determined by the capture
+  /// analysis pre-pass. These are added as extra parameters to the function
+  /// during declaration.
+  SmallVector<const slang::ast::ValueSymbol *, 4> capturedSymbols;
+
+  /// Whether the function body has been fully converted.
+  bool bodyConverted = false;
+
+  /// Whether we are currently converting this function's body. Used to prevent
+  /// infinite recursion for recursive functions.
   bool isConverting = false;
 
   /// Whether this is a coroutine (task) or a regular function.
@@ -170,7 +179,6 @@ struct Context {
   FunctionLowering *
   declareFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult convertFunction(const slang::ast::SubroutineSymbol &subroutine);
-  LogicalResult finalizeFunctionBodyCaptures(FunctionLowering &lowering);
   ClassLowering *declareClass(const slang::ast::ClassType &cls);
   LogicalResult buildClassProperties(const slang::ast::ClassType &classdecl);
   LogicalResult materializeClassMethods(const slang::ast::ClassType &classdecl);
@@ -389,6 +397,10 @@ struct Context {
   /// A list of global variables that still need their initializers to be
   /// converted.
   SmallVector<const slang::ast::ValueSymbol *> globalVariableWorklist;
+
+  /// Pre-computed capture analysis: maps each function to the set of non-local,
+  /// non-global variables it captures (directly or transitively).
+  CaptureMap functionCaptures;
 
   /// Collect all hierarchical names used for the per module/instance.
   DenseMap<const slang::ast::InstanceBodySymbol *, SmallVector<HierPathInfo>>

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -874,8 +874,12 @@ LogicalResult Context::convertCompilation() {
   timeScale = root.getTimeScale().value_or(slang::TimeScale());
   llvm::scope_exit timeScaleGuard([&] { timeScale = prevTimeScale; });
 
-  // First only to visit the whole AST to collect the hierarchical names without
-  // any operation creating.
+  // Analyze function captures upfront so that function declarations can be
+  // created with the correct signature including capture parameters.
+  functionCaptures = analyzeFunctionCaptures(root);
+
+  // Visit the whole AST to collect the hierarchical names without any operation
+  // creating.
   for (auto *inst : root.topInstances)
     traverseInstanceBody(inst->body);
 
@@ -1433,14 +1437,13 @@ Context::declareFunction(const slang::ast::SubroutineSymbol &subroutine) {
 
 /// Helper function to generate the function signature from a SubroutineSymbol
 /// and optional extra arguments (used for %this argument)
-static FunctionType
-getFunctionSignature(Context &context,
-                     const slang::ast::SubroutineSymbol &subroutine,
-                     llvm::SmallVectorImpl<Type> &extraParams) {
+static FunctionType getFunctionSignature(
+    Context &context, const slang::ast::SubroutineSymbol &subroutine,
+    ArrayRef<Type> prefixParams, ArrayRef<Type> suffixParams = {}) {
   using slang::ast::ArgumentDirection;
 
   SmallVector<Type> inputTypes;
-  inputTypes.append(extraParams.begin(), extraParams.end());
+  inputTypes.append(prefixParams.begin(), prefixParams.end());
   SmallVector<Type, 1> outputTypes;
 
   for (const auto *arg : subroutine.getArguments()) {
@@ -1455,6 +1458,8 @@ getFunctionSignature(Context &context,
     }
   }
 
+  inputTypes.append(suffixParams.begin(), suffixParams.end());
+
   const auto &returnType = subroutine.getReturnType();
   if (!returnType.isVoid()) {
     auto type = context.convertType(returnType);
@@ -1463,11 +1468,7 @@ getFunctionSignature(Context &context,
     outputTypes.push_back(type);
   }
 
-  auto funcType =
-      FunctionType::get(context.getContext(), inputTypes, outputTypes);
-
-  // Create a function declaration.
-  return funcType;
+  return FunctionType::get(context.getContext(), inputTypes, outputTypes);
 }
 
 /// Convert a function and its arguments to a function declaration in the IR.
@@ -1489,7 +1490,23 @@ Context::declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
   else
     builder.setInsertionPoint(it->second);
 
-  auto funcTy = getFunctionSignature(*this, subroutine, extraParams);
+  // Build the capture parameter types. These are appended after the user-
+  // defined arguments, not in the extraParams prefix, so the function type has
+  // the layout [this?] [user args] [captures].
+  SmallVector<Type> captureTypes;
+  auto capturesIt = functionCaptures.find(&subroutine);
+  if (capturesIt != functionCaptures.end()) {
+    for (auto *sym : capturesIt->second) {
+      auto type = convertType(sym->getType());
+      if (!type)
+        return nullptr;
+      captureTypes.push_back(
+          moore::RefType::get(cast<moore::UnpackedType>(type)));
+    }
+  }
+
+  auto funcTy =
+      getFunctionSignature(*this, subroutine, extraParams, captureTypes);
   if (!funcTy)
     return nullptr;
 
@@ -1509,80 +1526,17 @@ Context::declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
   }
   orderedRootOps.insert(it, {subroutine.location, funcOp});
 
+  // Store the captured symbols so call sites can look them up.
+  if (capturesIt != functionCaptures.end())
+    lowering->capturedSymbols.assign(capturesIt->second.begin(),
+                                     capturesIt->second.end());
+
   // Add the function to the symbol table of the MLIR module, which uniquifies
   // its name.
   symbolTable.insert(funcOp);
   functions[&subroutine] = std::move(lowering);
 
   return functions[&subroutine].get();
-}
-
-/// Special case handling for recursive functions with captures;
-/// this function fixes the in-body call of the recursive function with
-/// the captured arguments.
-static LogicalResult
-rewriteCallSitesToPassCaptures(FunctionLowering &lowering) {
-  auto &captures = lowering.captures;
-  if (captures.empty())
-    return success();
-
-  auto *callee = lowering.op.getOperation();
-  mlir::ModuleOp module = callee->getParentOfType<mlir::ModuleOp>();
-  if (!module)
-    return lowering.op.emitError("expected callee to be nested under ModuleOp");
-
-  auto usesOpt = mlir::SymbolTable::getSymbolUses(callee, module);
-  if (!usesOpt)
-    return lowering.op.emitError("failed to compute symbol uses");
-
-  // Snapshot the relevant call users before we mutate IR.
-  SmallVector<Operation *, 8> callSites;
-  for (const mlir::SymbolTable::SymbolUse &use : *usesOpt) {
-    auto *user = use.getUser();
-    if (isa<mlir::func::CallOp>(user) || isa<moore::CallCoroutineOp>(user))
-      callSites.push_back(user);
-  }
-  if (callSites.empty())
-    return success();
-
-  Block &entry = lowering.op.getFunctionBody().front();
-  const unsigned numCaps = captures.size();
-  const unsigned numEntryArgs = entry.getNumArguments();
-  if (numEntryArgs < numCaps)
-    return lowering.op.emitError("entry block has fewer args than captures");
-  const unsigned capArgStart = numEntryArgs - numCaps;
-
-  auto fTy = cast<FunctionType>(lowering.op.getFunctionType());
-
-  for (auto *callOp : callSites) {
-    // Get the existing operands from the call.
-    auto argOperands = callOp->getOperands();
-    SmallVector<Value> newOperands(argOperands.begin(), argOperands.end());
-
-    const bool inSameFunc = callee->isProperAncestor(callOp);
-    if (inSameFunc) {
-      for (unsigned i = 0; i < numCaps; ++i)
-        newOperands.push_back(entry.getArgument(capArgStart + i));
-    } else {
-      newOperands.append(captures.begin(), captures.end());
-    }
-
-    OpBuilder b(callOp);
-    auto flatRef = mlir::FlatSymbolRefAttr::get(callee->getContext(),
-                                                lowering.op.getName());
-    Operation *newCall;
-    if (lowering.isCoroutine()) {
-      newCall = moore::CallCoroutineOp::create(
-          b, callOp->getLoc(), fTy.getResults(), flatRef, newOperands);
-    } else {
-      newCall = mlir::func::CallOp::create(
-          b, callOp->getLoc(), fTy.getResults(), flatRef, newOperands);
-    }
-    callOp->replaceAllUsesWith(newCall);
-    callOp->erase();
-  }
-
-  return success();
 }
 
 /// Convert a function.
@@ -1599,16 +1553,16 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
   if (!lowering)
     return failure();
 
-  // If function already has been finalized, or is already being converted
+  // If function already has been converted, or is already being converted
   // (recursive/re-entrant calls) stop here.
-  if (lowering->capturesFinalized || lowering->isConverting)
+  if (lowering->bodyConverted || lowering->isConverting)
     return success();
 
   // DPI-C imported functions are extern declarations with no Verilog body.
   // Leave the func.func without a body region so it survives as an external
   // symbol and calls to it are not eliminated.
   if (subroutine.flags.has(slang::ast::MethodFlags::DPIImport)) {
-    lowering->capturesFinalized = true;
+    lowering->bodyConverted = true;
     return success();
   }
 
@@ -1651,10 +1605,14 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
     valueSymbols.insert(subroutine.thisVar, thisArg);
   }
 
-  // Add user-defined block arguments
+  // Add user-defined block arguments. The function type has the shape
+  // [this?] [user args] [capture args], so we skip the prefix and suffix.
   auto inputs = cast<FunctionType>(lowering->op.getFunctionType()).getInputs();
   auto astArgs = subroutine.getArguments();
-  auto valInputs = llvm::ArrayRef<Type>(inputs).drop_front(isMethod ? 1 : 0);
+  unsigned prefixCount = isMethod ? 1 : 0;
+  auto valInputs = llvm::ArrayRef<Type>(inputs)
+                       .drop_front(prefixCount)
+                       .take_front(astArgs.size());
 
   for (auto [astArg, type] : llvm::zip(astArgs, valInputs)) {
     auto loc = convertLocation(astArg->location);
@@ -1695,75 +1653,20 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
     valueSymbols.insert(subroutine.returnValVar, returnVar);
   }
 
-  // Save previous callbacks
-  auto prevRCb = rvalueReadCallback;
-  auto prevWCb = variableAssignCallback;
-  llvm::scope_exit prevRCbGuard([&] {
-    rvalueReadCallback = prevRCb;
-    variableAssignCallback = prevWCb;
-  });
-
-  // Capture this function's captured context directly
-  rvalueReadCallback = [lowering, prevRCb](moore::ReadOp rop) {
-    mlir::Value ref = rop.getInput();
-
-    // Don't capture anything that's not a reference
-    mlir::Type ty = ref.getType();
-    if (!ty || !(isa<moore::RefType>(ty)))
-      return;
-
-    // Don't capture anything that's a local reference
-    mlir::Region *defReg = ref.getParentRegion();
-    if (defReg && lowering->op.getFunctionBody().isAncestor(defReg))
-      return;
-
-    // If we've already recorded this capture, skip.
-    if (lowering->captureIndex.count(ref))
-      return;
-
-    // Only capture refs defined outside this function’s region
-    auto [it, inserted] =
-        lowering->captureIndex.try_emplace(ref, lowering->captures.size());
-    if (inserted) {
-      lowering->captures.push_back(ref);
-      // Propagate over outer scope
-      if (prevRCb)
-        prevRCb(rop); // chain previous callback
-    }
-  };
-  // Capture this function's captured context directly
-  variableAssignCallback = [lowering, prevWCb](mlir::Operation *op) {
-    mlir::Value dstRef =
-        llvm::TypeSwitch<mlir::Operation *, mlir::Value>(op)
-            .Case<moore::BlockingAssignOp, moore::NonBlockingAssignOp,
-                  moore::DelayedNonBlockingAssignOp>(
-                [](auto op) { return op.getDst(); })
-            .Default([](auto) -> mlir::Value { return {}; });
-
-    // Don't capture anything that's not a reference
-    mlir::Type ty = dstRef.getType();
-    if (!ty || !(isa<moore::RefType>(ty)))
-      return;
-
-    // Don't capture anything that's a local reference
-    mlir::Region *defReg = dstRef.getParentRegion();
-    if (defReg && lowering->op.getFunctionBody().isAncestor(defReg))
-      return;
-
-    // If we've already recorded this capture, skip.
-    if (lowering->captureIndex.count(dstRef))
-      return;
-
-    // Only capture refs defined outside this function’s region
-    auto [it, inserted] =
-        lowering->captureIndex.try_emplace(dstRef, lowering->captures.size());
-    if (inserted) {
-      lowering->captures.push_back(dstRef);
-      // Propagate over outer scope
-      if (prevWCb)
-        prevWCb(op); // chain previous callback
-    }
-  };
+  // Add block arguments for captured variables and bind them in the symbol
+  // table. The captures were already added to the function type during
+  // declaration; here we create the corresponding block arguments and map each
+  // captured AST symbol to its block argument so that references in the body
+  // resolve to the capture parameter instead of the enclosing scope’s value.
+  for (auto *sym : lowering->capturedSymbols) {
+    auto type = convertType(sym->getType());
+    if (!type)
+      return failure();
+    auto refType = moore::RefType::get(cast<moore::UnpackedType>(type));
+    auto loc = convertLocation(sym->location);
+    auto blockArg = block.addArgument(refType, loc);
+    valueSymbols.insert(sym, blockArg);
+  }
 
   auto savedThis = currentThisRef;
   currentThisRef = valueSymbols.lookup(subroutine.thisVar);
@@ -1773,15 +1676,6 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
   llvm::scope_exit convertingGuard([&] { lowering->isConverting = false; });
 
   if (failed(convertStatement(subroutine.getBody())))
-    return failure();
-
-  // Plumb captures into the function as extra block arguments
-  if (failed(finalizeFunctionBodyCaptures(*lowering)))
-    return failure();
-
-  // For the special case of recursive functions, fix the call sites within the
-  // body
-  if (failed(rewriteCallSitesToPassCaptures(*lowering)))
     return failure();
 
   // If there was no explicit return statement provided by the user, insert a
@@ -1812,56 +1706,7 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
     }
   }
 
-  lowering->capturesFinalized = true;
-  return success();
-}
-
-LogicalResult
-Context::finalizeFunctionBodyCaptures(FunctionLowering &lowering) {
-  if (lowering.captures.empty())
-    return success();
-
-  MLIRContext *ctx = getContext();
-
-  // Build new input type list: existing inputs + capture ref types.
-  SmallVector<Type> newInputs(
-      cast<FunctionType>(lowering.op.getFunctionType()).getInputs().begin(),
-      cast<FunctionType>(lowering.op.getFunctionType()).getInputs().end());
-
-  for (Value cap : lowering.captures) {
-    // Expect captures to be refs.
-    Type capTy = cap.getType();
-    if (!isa<moore::RefType>(capTy)) {
-      return lowering.op.emitError(
-          "expected captured value to be a ref-like type");
-    }
-    newInputs.push_back(capTy);
-  }
-
-  // Results unchanged.
-  auto newFuncTy = FunctionType::get(
-      ctx, newInputs,
-      cast<FunctionType>(lowering.op.getFunctionType()).getResults());
-  lowering.op.setType(newFuncTy);
-
-  // Add the new block arguments to the entry block.
-  Block &entry = lowering.op.getFunctionBody().front();
-  SmallVector<Value> capArgs;
-  capArgs.reserve(lowering.captures.size());
-  for (Type t :
-       llvm::ArrayRef<Type>(newInputs).take_back(lowering.captures.size())) {
-    capArgs.push_back(entry.addArgument(t, lowering.op.getLoc()));
-  }
-
-  // Replace uses of each captured Value *inside the function body* with the new
-  // arg. Keep uses outside untouched (e.g., in callers).
-  for (auto [cap, idx] : lowering.captureIndex) {
-    Value arg = capArgs[idx];
-    cap.replaceUsesWithIf(arg, [&](OpOperand &use) {
-      return lowering.op->isProperAncestor(use.getOwner());
-    });
-  }
-
+  lowering->bodyConverted = true;
   return success();
 }
 
@@ -2114,7 +1959,7 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
     if (failed(context.convertFunction(fn)))
       return failure();
 
-    if (!lowering->capturesFinalized)
+    if (!lowering->bodyConverted)
       return failure();
 
     // We only emit methoddecls for virtual methods.

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3716,63 +3716,6 @@ function int testRecursive(input int n);
     return n * testRecursive(n - 1);
 endfunction
 
-// CHECK-LABEL: moore.module @testRecursiveCaptureFunction() {
-module testRecursiveCaptureFunction();
-  // CHECK: [[CAPTUREME:%.+]] = moore.variable : <i32>
-  int captureMe;
-  int r;
-  initial begin
-    // CHECK: func.call @fact({{.*}}, [[CAPTUREME]]) : (!moore.i32, !moore.ref<i32>) -> !moore.i32
-    r = fact(5);
-  end
-
-  // CHECK: func.func private @fact(%arg0: !moore.i32, %arg1: !moore.ref<i32>) -> !moore.i32 {
-  function int fact(input int n);
-    // CHECK: [[CAPTUREDVALUE:%.*]] = moore.read %arg1 : <i32>
-    // CHECK: return [[CAPTUREDVALUE]] : !moore.i32
-    if (n <= 1) return captureMe;
-    // CHECK: [[REC_CALL:%.*]] = call @fact({{.*}}, %arg1) : (!moore.i32, !moore.ref<i32>) -> !moore.i32
-    return n * fact(n - 1);
-  endfunction
-endmodule
-
-// Task that reads a module-scope signal in an event control expression. The
-// signal must be captured as an extra argument to the task function.
-// CHECK-LABEL: moore.module @CaptureInEventControl
-module CaptureInEventControl;
-  // CHECK: [[CLK:%.+]] = moore.variable : <l1>
-  logic clk;
-  // CHECK: [[DATA:%.+]] = moore.variable : <i32>
-  int data;
-
-  initial begin
-    // CHECK: moore.call_coroutine @waitForClk([[CLK]])
-    waitForClk();
-    // CHECK: moore.call_coroutine @readOnClk([[CLK]], [[DATA]])
-    readOnClk();
-  end
-
-  // CHECK: moore.coroutine private @waitForClk(%arg0: !moore.ref<l1>)
-  task automatic waitForClk;
-    // CHECK: moore.wait_event {
-    // CHECK:   [[TMP:%.+]] = moore.read %arg0
-    // CHECK:   moore.detect_event posedge [[TMP]]
-    // CHECK: }
-    @(posedge clk);
-  endtask
-
-  // CHECK: moore.coroutine private @readOnClk(%arg0: !moore.ref<l1>, %arg1: !moore.ref<i32>)
-  task automatic readOnClk;
-    int result;
-    // CHECK: moore.wait_event {
-    // CHECK:   [[TMP:%.+]] = moore.read %arg0
-    // CHECK:   moore.detect_event posedge [[TMP]]
-    // CHECK: }
-    @(posedge clk);
-    // CHECK: [[TMP:%.+]] = moore.read %arg1
-    result = data;
-  endtask
-endmodule
 
 // CHECK-LABEL: moore.module @RealLiteral() {
 module RealLiteral();

--- a/test/Conversion/ImportVerilog/captures.sv
+++ b/test/Conversion/ImportVerilog/captures.sv
@@ -1,0 +1,139 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+//===----------------------------------------------------------------------===//
+// Recursive function with a capture
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: moore.module @RecursiveCaptureFunction() {
+module RecursiveCaptureFunction;
+  // CHECK: %captureMe = moore.variable : <i32>
+  int captureMe;
+  int r;
+  initial begin
+    // CHECK: func.call @fact({{.*}}, %captureMe) : (!moore.i32, !moore.ref<i32>) -> !moore.i32
+    r = fact(5);
+  end
+
+  // CHECK: func.func private @fact(%arg0: !moore.i32, %arg1: !moore.ref<i32>) -> !moore.i32 {
+  function int fact(input int n);
+    // CHECK: moore.read %arg1 : <i32>
+    if (n <= 1) return captureMe;
+    // CHECK: call @fact({{.*}}, %arg1) : (!moore.i32, !moore.ref<i32>) -> !moore.i32
+    return n * fact(n - 1);
+  endfunction
+endmodule
+
+//===----------------------------------------------------------------------===//
+// Task capturing a signal used in an event control expression
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: moore.module @CaptureInEventControl
+module CaptureInEventControl;
+  // CHECK: %clk = moore.variable : <l1>
+  logic clk;
+  // CHECK: %data = moore.variable : <i32>
+  int data;
+
+  initial begin
+    // CHECK: moore.call_coroutine @waitForClk(%clk)
+    waitForClk();
+    // CHECK: moore.call_coroutine @readOnClk(%clk, %data)
+    readOnClk();
+  end
+
+  // CHECK: moore.coroutine private @waitForClk(%arg0: !moore.ref<l1>)
+  task automatic waitForClk;
+    // CHECK: moore.read %arg0 : <l1>
+    // CHECK: moore.detect_event posedge
+    @(posedge clk);
+  endtask
+
+  // CHECK: moore.coroutine private @readOnClk(%arg0: !moore.ref<l1>, %arg1: !moore.ref<i32>)
+  task automatic readOnClk;
+    int result;
+    // CHECK: moore.detect_event posedge
+    @(posedge clk);
+    result = data;
+  endtask
+endmodule
+
+//===----------------------------------------------------------------------===//
+// Transitive capture: wrapper -> inner, inner captures x
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: moore.module @TransitiveCapture
+module TransitiveCapture;
+  // CHECK: %x = moore.variable : <i32>
+  int x;
+
+  initial begin
+    // CHECK: moore.call_coroutine @wrapper({{.*}}, %x)
+    wrapper(42);
+  end
+
+  // CHECK: moore.coroutine private @inner(%arg0: !moore.i32, %arg1: !moore.ref<i32>)
+  task automatic inner(int val);
+    x = val;
+  endtask
+
+  // CHECK: moore.coroutine private @wrapper(%arg0: !moore.i32, %arg1: !moore.ref<i32>)
+  task automatic wrapper(int val);
+    // CHECK: moore.call_coroutine @inner(%arg0, %arg1)
+    inner(val);
+  endtask
+endmodule
+
+//===----------------------------------------------------------------------===//
+// Compile-time constants should not be captured
+//===----------------------------------------------------------------------===//
+
+// Parameter referenced in a function that can't be constant-folded.
+// CHECK-LABEL: func.func private @scale() -> !moore.i32
+module ParamNotCaptured;
+  parameter MAX = 256;
+  function automatic int scale();
+    return $random % MAX;
+  endfunction
+  initial $display("%0d", scale());
+endmodule
+
+// Enum value referenced in a task.
+// CHECK-LABEL: moore.coroutine private @check(%arg0: !moore.l2)
+module EnumNotCaptured;
+  typedef enum logic [1:0] { A, B, C } state_t;
+  task automatic check(state_t s);
+    if (s === B)
+      $display("PASSED");
+  endtask
+  initial check(B);
+endmodule
+
+// Localparam referenced in a function via non-constant expression.
+// CHECK-LABEL: func.func private @get_rand() -> !moore.i32
+module LocalparamNotCaptured;
+  localparam OFFSET = 42;
+  function automatic int get_rand();
+    return $random + OFFSET;
+  endfunction
+  initial $display("%0d", get_rand());
+endmodule
+
+// Class parameter referenced in a method.
+// CHECK: func.func private @"ClassParamNotCaptured::C::get"(%arg0: !moore.class<@"ClassParamNotCaptured::C">) -> !moore.i32
+module ClassParamNotCaptured;
+  class C #(int N = 10);
+    function automatic int get();
+      return $random % N;
+    endfunction
+  endclass
+
+  initial begin
+    C #(5) c = new;
+    $display("%0d", c.get());
+  end
+endmodule


### PR DESCRIPTION
Replace the ad-hoc MLIR-based capture discovery (rvalueReadCallback, variableAssignCallback, finalizeFunctionBodyCaptures, and rewriteCallSitesToPassCaptures) with the AST-level capture analysis pre-pass.

Function declarations now include capture parameters from the start, and function body conversion binds captured AST symbols to their block arguments in the scoped symbol table. Call sites resolve captures through the symbol table, which naturally handles transitive captures.

This fixes a transitive capture bug where a wrapper function calling a function that captures a module variable would fail with "cannot materialize captured ref at call site".

Outline capture-related lit tests from basic.sv into captures.sv.