### PR TITLE
[ImportVerilog] Add basic (and/or/xor) primitive support

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -179,6 +179,8 @@ struct Context {
   FunctionLowering *
   declareFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult convertFunction(const slang::ast::SubroutineSymbol &subroutine);
+  LogicalResult
+  convertPrimitiveInstance(const slang::ast::PrimitiveInstanceSymbol &prim);
   ClassLowering *declareClass(const slang::ast::ClassType &cls);
   LogicalResult buildClassProperties(const slang::ast::ClassType &classdecl);
   LogicalResult materializeClassMethods(const slang::ast::ClassType &classdecl);
@@ -260,6 +262,9 @@ struct Context {
   // Convert a slang timing control for LTL
   Value convertLTLTimingControl(const slang::ast::TimingControl &ctrl,
                                 const Value &seqOrPro);
+
+  LogicalResult
+  convertNInputPrimitive(const slang::ast::PrimitiveInstanceSymbol &prim);
 
   /// Helper function to convert a value to its "truthy" boolean value.
   Value convertToBool(Value value);

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -849,6 +849,11 @@ struct ModuleVisitor : public BaseVisitor {
     return context.convertFunction(subroutine);
   }
 
+  // Handle primitive instances.
+  LogicalResult visit(const slang::ast::PrimitiveInstanceSymbol &prim) {
+    return context.convertPrimitiveInstance(prim);
+  }
+
   /// Emit an error for all other members.
   template <typename T>
   LogicalResult visit(T &&node) {
@@ -1707,6 +1712,105 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
   }
 
   lowering->bodyConverted = true;
+  return success();
+}
+
+/// Convert a primitive instance.
+LogicalResult Context::convertPrimitiveInstance(
+    const slang::ast::PrimitiveInstanceSymbol &prim) {
+  if (prim.getDriveStrength().first.has_value() ||
+      prim.getDriveStrength().second.has_value())
+    return mlir::emitError(convertLocation(prim.location))
+           << "primitive instances with explicit drive strengths are not "
+              "supported.";
+
+  if (prim.getDelay())
+    return mlir::emitError(convertLocation(prim.location))
+           << "primitive instances with delays are not yet supported.";
+
+  switch (prim.primitiveType.primitiveKind) {
+  case slang::ast::PrimitiveSymbol::PrimitiveKind::NInput:
+    return this->convertNInputPrimitive(prim);
+    break;
+  default:
+    return mlir::emitError(convertLocation(prim.location))
+           << "unsupported instance of primitive `" << prim.primitiveType.name
+           << "`";
+  }
+}
+
+LogicalResult Context::convertNInputPrimitive(
+    const slang::ast::PrimitiveInstanceSymbol &prim) {
+  auto loc = convertLocation(prim.location);
+  auto primName = prim.primitiveType.name;
+
+  auto portConns = prim.getPortConnections();
+  if (portConns.size() < 2)
+    return mlir::emitError(loc) << "n-input primitive `" << primName
+                                << "` requires at least 2 ports";
+
+  // Get SSA values corresponding to operands (and unwrap where necessary)
+  const slang::ast::Expression *outputConn = portConns[0];
+  if (const auto *assign =
+          outputConn->as_if<slang::ast::AssignmentExpression>())
+    outputConn = &assign->left();
+
+  auto outputVal = this->convertLvalueExpression(*outputConn);
+  if (!outputVal)
+    return failure();
+
+  SmallVector<Value> inputVals;
+  inputVals.reserve(portConns.size() - 1);
+  for (const auto *inputConn : portConns.subspan(1, portConns.size() - 1)) {
+    const slang::ast::Expression *inputExpr = inputConn;
+    if (const auto *assign =
+            inputExpr->as_if<slang::ast::AssignmentExpression>()) {
+      inputExpr = &assign->left();
+    }
+    auto inputVal = this->convertRvalueExpression(*inputExpr);
+    if (!inputVal)
+      return failure();
+    inputVals.push_back(inputVal);
+  }
+
+  Value nextInput = inputVals.front();
+  auto result =
+      llvm::StringSwitch<std::function<Value()>>(prim.primitiveType.name)
+          .Case("and", ([&] {
+                  for (Value inputVal : llvm::drop_begin(inputVals))
+                    nextInput =
+                        moore::AndOp::create(builder, loc, nextInput, inputVal);
+                  return nextInput;
+                }))
+          .Case("or", ([&] {
+                  for (Value inputVal : llvm::drop_begin(inputVals))
+                    nextInput =
+                        moore::OrOp::create(builder, loc, nextInput, inputVal);
+                  return nextInput;
+                }))
+          .Case("xor", ([&] {
+                  for (Value inputVal : llvm::drop_begin(inputVals))
+                    nextInput =
+                        moore::XorOp::create(builder, loc, nextInput, inputVal);
+                  return nextInput;
+                }))
+          .Default([&] {
+            mlir::emitError(loc)
+                << "unsupported primitive `" << primName << "`";
+            return Value();
+          })();
+
+  if (!result)
+    return failure();
+
+  // TODO: annotate with debug ops to preserve primitive name
+
+  auto dstType = cast<moore::RefType>(outputVal.getType()).getNestedType();
+  auto resultRef = materializeConversion(dstType, result, false, loc);
+  if (!resultRef)
+    return failure();
+
+  moore::ContinuousAssignOp::create(builder, loc, outputVal, resultRef);
   return success();
 }
 

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -332,3 +332,27 @@ module Foo;
   // expected-error @below {{'always' procedure does not advance time and so will create a simulation deadlock}}
   always a = ~a;
 endmodule
+
+// -----
+
+module drive_strength_prim;
+    logic A, B, Q;
+    // expected-error @below {{primitive instances with explicit drive strengths are not supported.}}
+    and (pull0, strong1) a (Q, A, B);
+endmodule
+
+// -----
+
+module delay_prim;
+    logic A, B, Q;
+    // expected-error @below {{primitive instances with delays are not yet supported.}}
+    and #(5) a (Q, A, B);
+endmodule
+
+// -----
+
+module not_prim;
+    logic A, Q;
+    // expected-error @below {{unsupported instance of primitive `not`}}
+    not u1 (Q, A);
+endmodule

--- a/test/Conversion/ImportVerilog/primitives.sv
+++ b/test/Conversion/ImportVerilog/primitives.sv
@@ -1,0 +1,68 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// CHECK-LABEL: moore.module @and_prim()
+// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[B:%.+]] = moore.variable : <l1>
+// CHECK: [[Q:%.+]] = moore.variable : <l1>
+// CHECK: [[RD_A:%.+]] = moore.read [[A]] : <l1>
+// CHECK: [[RD_B:%.+]] = moore.read [[B]] : <l1>
+// CHECK: [[AND:%.+]] = moore.and [[RD_A]], [[RD_B]] : l1
+// CHECK: moore.assign [[Q]], [[AND]] : l1
+
+module and_prim;
+    logic A, B, Q;
+    and a (Q, A, B);
+endmodule
+
+// CHECK-LABEL: moore.module @or_prim()
+// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[B:%.+]] = moore.variable : <l1>
+// CHECK: [[Q:%.+]] = moore.variable : <l1>
+// CHECK: [[RD_A:%.+]] = moore.read [[A]] : <l1>
+// CHECK: [[RD_B:%.+]] = moore.read [[B]] : <l1>
+// CHECK: [[OR:%.+]] = moore.or [[RD_A]], [[RD_B]] : l1
+// CHECK: moore.assign [[Q]], [[OR]] : l1
+
+module or_prim;
+    logic A, B, Q;
+    or a (Q, A, B);
+endmodule
+
+// CHECK-LABEL: moore.module @xor_prim()
+// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[B:%.+]] = moore.variable : <l1>
+// CHECK: [[Q:%.+]] = moore.variable : <l1>
+// CHECK: [[RD_A:%.+]] = moore.read [[A]] : <l1>
+// CHECK: [[RD_B:%.+]] = moore.read [[B]] : <l1>
+// CHECK: [[XOR:%.+]] = moore.xor [[RD_A]], [[RD_B]] : l1
+// CHECK: moore.assign [[Q]], [[XOR]] : l1
+
+module xor_prim;
+    logic A, B, Q;
+    xor c (Q, A, B);
+endmodule
+
+// CHECK-LABEL: moore.module @multi_and_prim()
+// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[B:%.+]] = moore.variable : <l1>
+// CHECK: [[C:%.+]] = moore.variable : <l1>
+// CHECK: [[D:%.+]] = moore.variable : <l1>
+// CHECK: [[Q:%.+]] = moore.variable : <l1>
+// CHECK: [[RD_A:%.+]] = moore.read [[A]] : <l1>
+// CHECK: [[RD_B:%.+]] = moore.read [[B]] : <l1>
+// CHECK: [[RD_C:%.+]] = moore.read [[C]] : <l1>
+// CHECK: [[RD_D:%.+]] = moore.read [[D]] : <l1>
+// CHECK: [[AND0:%.+]] = moore.and [[RD_A]], [[RD_B]] : l1
+// CHECK: [[AND1:%.+]] = moore.and [[AND0]], [[RD_C]] : l1
+// CHECK: [[AND2:%.+]] = moore.and [[AND1]], [[RD_D]] : l1
+// CHECK: moore.assign [[Q]], [[AND2]] : l1
+
+module multi_and_prim;
+    logic A, B, C, D, Q;
+    and a (Q, A, B, C, D);
+endmodule


### PR DESCRIPTION
This adds support for those primitives that have a single corresponding Moore op - follow-ups will add remaining builtin n-input primitives and debug ops to track primitive ports. Not all errors can be hit currently hence they are not all tested, just keeping them in so we don't hit crashes as we support more primitive situations.