### PR TITLE
[ImportVerilog] Two-phase function conversion: declare then define

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -15,6 +15,7 @@
 #include "slang/ast/types/AllTypes.h"
 #include "slang/syntax/AllSyntax.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/SaveAndRestore.h"
 
 using namespace circt;
 using namespace ImportVerilog;
@@ -1733,9 +1734,6 @@ struct RvalueExprVisitor : public ExprVisitor {
     auto *lowering = context.declareFunction(*subroutine);
     if (!lowering)
       return {};
-    auto convertedFunction = context.convertFunction(*subroutine);
-    if (failed(convertedFunction))
-      return {};
 
     // Convert the call arguments. Input arguments are converted to an rvalue.
     // All other arguments are converted to lvalues and passed into the function
@@ -2188,24 +2186,15 @@ struct RvalueExprVisitor : public ExprVisitor {
       if (const auto *subroutine =
               std::get_if<const slang::ast::SubroutineSymbol *>(
                   &callConstructor->subroutine)) {
-        // Bit paranoid, but virtually free checks that new is a class method
-        // and the subroutine has already been converted.
         if (!(*subroutine)->thisVar) {
-          mlir::emitError(loc) << "Expected subroutine called by new to use an "
-                                  "implicit this reference";
+          mlir::emitError(loc)
+              << "unsupported constructor call without `this` argument";
           return {};
         }
-        if (failed(context.convertFunction(**subroutine)))
-          return {};
         // Pass the newObj as the implicit this argument of the ctor.
-        auto savedThis = context.currentThisRef;
-        context.currentThisRef = newObj;
-        llvm::scope_exit restoreThis(
-            [&] { context.currentThisRef = savedThis; });
-        // Emit a call to ctor
+        llvm::SaveAndRestore saveThis(context.currentThisRef, newObj);
         if (!visitCall(*callConstructor, *subroutine))
           return {};
-        // Return new handle
         return newObj;
       }
     return {};

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -103,13 +103,6 @@ struct FunctionLowering {
   /// during declaration.
   SmallVector<const slang::ast::ValueSymbol *, 4> capturedSymbols;
 
-  /// Whether the function body has been fully converted.
-  bool bodyConverted = false;
-
-  /// Whether we are currently converting this function's body. Used to prevent
-  /// infinite recursion for recursive functions.
-  bool isConverting = false;
-
   /// Whether this is a coroutine (task) or a regular function.
   bool isCoroutine() { return isa<moore::CoroutineOp>(op.getOperation()); }
 };
@@ -178,7 +171,7 @@ struct Context {
   LogicalResult convertPackage(const slang::ast::PackageSymbol &package);
   FunctionLowering *
   declareFunction(const slang::ast::SubroutineSymbol &subroutine);
-  LogicalResult convertFunction(const slang::ast::SubroutineSymbol &subroutine);
+  LogicalResult defineFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult
   convertPrimitiveInstance(const slang::ast::PrimitiveInstanceSymbol &prim);
   ClassLowering *declareClass(const slang::ast::ClassType &cls);
@@ -373,6 +366,10 @@ struct Context {
   /// A list of modules for which the header has been created, but the body has
   /// not been converted yet.
   std::queue<const slang::ast::InstanceBodySymbol *> moduleWorklist;
+
+  /// A list of functions for which the declaration has been created, but the
+  /// body has not been defined yet.
+  std::queue<const slang::ast::SubroutineSymbol *> functionWorklist;
 
   /// Functions that have already been converted.
   DenseMap<const slang::ast::SubroutineSymbol *,

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -147,7 +147,9 @@ struct RootVisitor : public BaseVisitor {
 
   // Handle functions and tasks.
   LogicalResult visit(const slang::ast::SubroutineSymbol &subroutine) {
-    return context.convertFunction(subroutine);
+    if (!context.declareFunction(subroutine))
+      return failure();
+    return success();
   }
 
   // Handle global variables.
@@ -176,7 +178,9 @@ struct PackageVisitor : public BaseVisitor {
 
   // Handle functions and tasks.
   LogicalResult visit(const slang::ast::SubroutineSymbol &subroutine) {
-    return context.convertFunction(subroutine);
+    if (!context.declareFunction(subroutine))
+      return failure();
+    return success();
   }
 
   // Handle global variables.
@@ -846,7 +850,9 @@ struct ModuleVisitor : public BaseVisitor {
 
   // Handle functions and tasks.
   LogicalResult visit(const slang::ast::SubroutineSymbol &subroutine) {
-    return context.convertFunction(subroutine);
+    if (!context.declareFunction(subroutine))
+      return failure();
+    return success();
   }
 
   // Handle primitive instances.
@@ -926,6 +932,17 @@ LogicalResult Context::convertCompilation() {
 
   for (auto *inst : classMethodWorklist) {
     if (failed(materializeClassMethods(*inst)))
+      return failure();
+  }
+
+  // Define all function bodies. Functions are declared (and pushed onto the
+  // worklist) during module body conversion and class method materialization.
+  // Defining a function body may discover additional functions through call
+  // expressions, which are declared and added to the worklist on the fly.
+  while (!functionWorklist.empty()) {
+    auto *fn = functionWorklist.front();
+    functionWorklist.pop();
+    if (failed(defineFunction(*fn)))
       return failure();
   }
 
@@ -1541,35 +1558,31 @@ Context::declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
   symbolTable.insert(funcOp);
   functions[&subroutine] = std::move(lowering);
 
+  // Schedule the body to be defined later.
+  functionWorklist.push(&subroutine);
+
   return functions[&subroutine].get();
 }
 
-/// Convert a function.
+/// Define a function’s body. The function must already have been declared via
+/// `declareFunction`. This is called from the function worklist after all
+/// declarations have been created, ensuring that all function prototypes are
+/// available for calls within the body.
 LogicalResult
-Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
+Context::defineFunction(const slang::ast::SubroutineSymbol &subroutine) {
+  auto *lowering = functions.at(&subroutine).get();
+
   // Keep track of the local time scale. `getTimeScale` automatically looks
   // through parent scopes to find the time scale effective locally.
   auto prevTimeScale = timeScale;
   timeScale = subroutine.getTimeScale().value_or(slang::TimeScale());
   llvm::scope_exit timeScaleGuard([&] { timeScale = prevTimeScale; });
 
-  // First get or create the function declaration.
-  auto *lowering = declareFunction(subroutine);
-  if (!lowering)
-    return failure();
-
-  // If function already has been converted, or is already being converted
-  // (recursive/re-entrant calls) stop here.
-  if (lowering->bodyConverted || lowering->isConverting)
-    return success();
-
   // DPI-C imported functions are extern declarations with no Verilog body.
   // Leave the func.func without a body region so it survives as an external
   // symbol and calls to it are not eliminated.
-  if (subroutine.flags.has(slang::ast::MethodFlags::DPIImport)) {
-    lowering->bodyConverted = true;
+  if (subroutine.flags.has(slang::ast::MethodFlags::DPIImport))
     return success();
-  }
 
   const bool isMethod = (subroutine.thisVar != nullptr);
 
@@ -1677,9 +1690,6 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
   currentThisRef = valueSymbols.lookup(subroutine.thisVar);
   llvm::scope_exit restoreThis([&] { currentThisRef = savedThis; });
 
-  lowering->isConverting = true;
-  llvm::scope_exit convertingGuard([&] { lowering->isConverting = false; });
-
   if (failed(convertStatement(subroutine.getBody())))
     return failure();
 
@@ -1711,7 +1721,6 @@ Context::convertFunction(const slang::ast::SubroutineSymbol &subroutine) {
     }
   }
 
-  lowering->bodyConverted = true;
   return success();
 }
 
@@ -2060,17 +2069,11 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
     if (!lowering)
       return failure();
 
-    if (failed(context.convertFunction(fn)))
-      return failure();
-
-    if (!lowering->bodyConverted)
-      return failure();
-
     // We only emit methoddecls for virtual methods.
     if (!isVirtual)
       return success();
 
-    // Grab the finalized function type from the lowered func.op.
+    // Grab the function type from the declaration.
     FunctionType fnTy = cast<FunctionType>(lowering->op.getFunctionType());
     // Emit the method decl into the class body, preserving source order.
     moore::ClassMethodDeclOp::create(builder, loc, fn.name, fnTy,
@@ -2192,11 +2195,13 @@ Context::materializeClassMethods(const slang::ast::ClassType &classdecl) {
   llvm::scope_exit timeScaleGuard([&] { timeScale = prevTimeScale; });
 
   // The class must have been declared already via buildClassProperties.
-  auto it = classes.find(&classdecl);
-  if (it == classes.end() || !it->second)
+  auto *lowering = classes[&classdecl].get();
+  if (!lowering)
     return failure();
 
-  // Materialize base class methods first.
+  // Materialize base class methods first. This may insert new entries into the
+  // `classes` map (e.g. for nested classes), so we must not hold an iterator
+  // or reference into the map across this call.
   if (classdecl.getBaseClass()) {
     if (const auto *baseClassDecl =
             classdecl.getBaseClass()->as_if<slang::ast::ClassType>()) {
@@ -2205,7 +2210,7 @@ Context::materializeClassMethods(const slang::ast::ClassType &classdecl) {
     }
   }
 
-  return ClassMethodVisitor(*this, *it->second).run(classdecl);
+  return ClassMethodVisitor(*this, *lowering).run(classdecl);
 }
 
 /// Convert a variable to a `moore.global_variable` operation.


### PR DESCRIPTION
Refactor function conversion from eager depth-first body conversion into a two-phase declare-then-define approach, matching the existing module conversion pattern. Previously, encountering a function at any call site or visitor would immediately convert its body, which could fail when referenced names weren't yet registered in the symbol table.

Now, `declareFunction` creates the function op with the correct signature (including capture parameters) and pushes it onto a `functionWorklist`. Function bodies are defined later by draining the worklist via `defineFunction`, after all modules and class methods have been processed. This ensures all prototypes are available before any body is converted.

Also fix a DenseMap iterator invalidation bug in
`materializeClassMethods` where recursive base class processing could insert new entries into the `classes` map, invalidating the iterator held by the outer call.