### PR TITLE
[CMake][ArcRuntime] Tweak build of libfst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,10 +632,7 @@ if(CIRCT_LIBFST_ENABLED)
   set(ORIGINAL_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 
   set(BUILD_SHARED_LIBS OFF)
-  FetchContent_GetProperties(libfst)
-  if(NOT libfst_POPULATED)
-    FetchContent_Populate(libfst)
-  endif()
+  FetchContent_MakeAvailable(libfst)
 
   add_library(fst STATIC
     ${libfst_SOURCE_DIR}/src/fastlz.c

--- a/lib/Dialect/Arc/Runtime/CMakeLists.txt
+++ b/lib/Dialect/Arc/Runtime/CMakeLists.txt
@@ -51,4 +51,5 @@ add_circt_library(CIRCTArcJITRuntime
 target_compile_definitions(obj.CIRCTArcJITRuntime PUBLIC ARC_RUNTIME_JIT_BIND)
 if(CIRCT_LIBFST_ENABLED)
   target_compile_definitions(obj.CIRCTArcJITRuntime PUBLIC CIRCT_LIBFST_ENABLED=1)
+  target_link_libraries(CIRCTArcJITRuntime PRIVATE fst)
 endif()

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -42,10 +42,6 @@ set(libs
   MLIRTargetLLVMIRExport
 )
 
-if(CIRCT_LIBFST_ENABLED)
-  list(APPEND ARCILATOR_JIT_DEPS fst)
-endif()
-
 add_circt_tool(arcilator arcilator.cpp DEPENDS ${libs} ${ARCILATOR_JIT_DEPS})
 if(CIRCT_LIBFST_ENABLED)
   target_compile_definitions(arcilator PRIVATE CIRCT_LIBFST_ENABLED=1)


### PR DESCRIPTION
- Add libfst as link dependency to the `CIRCTArcJITRuntime` target to fix the build of the ArcRuntime unit tests when `CIRCT_LIBFST_ENABLED` is set.
- Replace `FetchContent_Populate` with `FetchContent_MakeAvailable` to get rid of a CMake deprecation warning (CMP0169).