### PR TITLE
[ArcRuntime] Error on invalid trace buffer size

### DIFF
--- a/lib/Dialect/Arc/Runtime/TraceEncoder.cpp
+++ b/lib/Dialect/Arc/Runtime/TraceEncoder.cpp
@@ -101,6 +101,7 @@ void TraceEncoder::workLoop() {
 
     // Process the taken buffer
     assert(work->size > 0);
+    assert(work->size <= work->capacity);
     encode(*work);
     work->clear();
 
@@ -165,6 +166,8 @@ uint64_t *TraceEncoder::dispatch(uint32_t oldBufferSize) {
   activeBuffer.assertSentinel();
   if (oldBufferSize == 0)
     impl::fatalError("Trace dispatch called on an empty buffer");
+  if (oldBufferSize > activeBuffer.capacity)
+    impl::fatalError("Trace buffer size exceeds capacity");
   if (worker.has_value()) {
     activeBuffer.size = oldBufferSize;
     enqueueBuffer(std::move(activeBuffer));

--- a/unittests/Dialect/Arc/Runtime/ArcRuntimeTest.cpp
+++ b/unittests/Dialect/Arc/Runtime/ArcRuntimeTest.cpp
@@ -3,6 +3,7 @@
 #define ARC_RUNTIME_JITBIND_FNDECL
 #include "circt/Dialect/Arc/Runtime/ArcRuntime.h"
 #include "circt/Dialect/Arc/Runtime/JITBind.h"
+#include "circt/Dialect/Arc/Runtime/TraceTaps.h"
 
 struct TestImpl {
   uint64_t foo = 0x123456;
@@ -95,4 +96,105 @@ TEST(ArcRuntimeTest, InstanceLifecycleIR) {
   for (auto i = 0; i < 128; ++i)
     api.fnOnEval(modelState);
   api.fnDeleteInstance(modelState);
+}
+
+// Runtime should accept a valid trace buffer
+TEST(ArcRuntimeTest, SwapTraceBuffer) {
+  auto &api = circt::arc::runtime::getArcRuntimeAPICallbacks();
+
+  ArcRuntimeModelInfo bogusModel;
+  ArcModelTraceInfo traceInfo;
+  ArcTraceTap traceTap;
+
+  bogusModel.apiVersion = ARC_RUNTIME_API_VERSION;
+  bogusModel.modelName = "bogus";
+  bogusModel.numStateBytes = 2048;
+  bogusModel.traceInfo = &traceInfo;
+
+  traceInfo.numTraceTaps = 1;
+  traceInfo.traceTaps = &traceTap;
+  traceInfo.traceTapNames = "fooTap";
+  traceTap.stateOffset = 16;
+  traceInfo.traceBufferCapacity = 8;
+
+  traceTap.nameOffset = 0;
+  traceTap.typeBits = 32;
+
+  uint8_t *modelState = api.fnAllocInstance(&bogusModel, nullptr);
+  ASSERT_NE(modelState, nullptr);
+  ArcState *state = arcRuntimeGetStateFromModelState(modelState, 0);
+  EXPECT_NE(state->traceBuffer, nullptr);
+
+  memset(state->traceBuffer, 0, traceInfo.traceBufferCapacity * 8);
+  state->traceBufferSize = 2;
+  state->traceBuffer = api.fnSwapTraceBuffer(state->modelState);
+  EXPECT_NE(state->traceBuffer, nullptr);
+
+  api.fnDeleteInstance(modelState);
+}
+
+// Runtime should error on overwritten trace buffer sentinel
+TEST(ArcRuntimeTest, TraceBufferOverflow) {
+  auto &api = circt::arc::runtime::getArcRuntimeAPICallbacks();
+
+  ArcRuntimeModelInfo bogusModel;
+  ArcModelTraceInfo traceInfo;
+  ArcTraceTap traceTap;
+
+  bogusModel.apiVersion = ARC_RUNTIME_API_VERSION;
+  bogusModel.modelName = "bogus";
+  bogusModel.numStateBytes = 2048;
+  bogusModel.traceInfo = &traceInfo;
+
+  traceInfo.numTraceTaps = 1;
+  traceInfo.traceTaps = &traceTap;
+  traceInfo.traceTapNames = "fooTap";
+  traceTap.stateOffset = 16;
+  traceInfo.traceBufferCapacity = 8;
+
+  traceTap.nameOffset = 0;
+  traceTap.typeBits = 32;
+
+  uint8_t *modelState = api.fnAllocInstance(&bogusModel, nullptr);
+  ASSERT_NE(modelState, nullptr);
+  ArcState *state = arcRuntimeGetStateFromModelState(modelState, 0);
+  ASSERT_NE(state->traceBuffer, nullptr);
+
+  // Write one byte over limit
+  memset(state->traceBuffer, 0, traceInfo.traceBufferCapacity * 8 + 1);
+  state->traceBufferSize = 2;
+  EXPECT_DEATH(api.fnSwapTraceBuffer(state->modelState), "");
+}
+
+// Runtime should error on trace buffer size beyond capacity
+TEST(ArcRuntimeTest, TraceBufferExceededCapacity) {
+  auto &api = circt::arc::runtime::getArcRuntimeAPICallbacks();
+
+  ArcRuntimeModelInfo bogusModel;
+  ArcModelTraceInfo traceInfo;
+  ArcTraceTap traceTap;
+
+  bogusModel.apiVersion = ARC_RUNTIME_API_VERSION;
+  bogusModel.modelName = "bogus";
+  bogusModel.numStateBytes = 2048;
+  bogusModel.traceInfo = &traceInfo;
+
+  traceInfo.numTraceTaps = 1;
+  traceInfo.traceTaps = &traceTap;
+  traceInfo.traceTapNames = "fooTap";
+  traceTap.stateOffset = 16;
+  traceInfo.traceBufferCapacity = 8;
+
+  traceTap.nameOffset = 0;
+  traceTap.typeBits = 32;
+
+  uint8_t *modelState = api.fnAllocInstance(&bogusModel, nullptr);
+  ASSERT_NE(modelState, nullptr);
+  ArcState *state = arcRuntimeGetStateFromModelState(modelState, 0);
+  ASSERT_NE(state->traceBuffer, nullptr);
+
+  memset(state->traceBuffer, 0, traceInfo.traceBufferCapacity * 8);
+  // Invalid size
+  state->traceBufferSize = traceInfo.traceBufferCapacity + 1;
+  EXPECT_DEATH(api.fnSwapTraceBuffer(state->modelState), "");
 }


### PR DESCRIPTION
Raise a fatal error when the hardware model reports a trace buffer size that exceeds the requested capacity. This should never happen, but if it does we better catch it early.