### PR TITLE
[Verif] Preserve labeled assert/assume ops during canonicalization

### DIFF
--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -14,6 +14,7 @@
 #include "circt/Support/CustomDirectiveImpl.h"
 #include "circt/Support/FoldUtils.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
@@ -76,12 +77,13 @@ struct RemoveEnableTrue : public OpRewritePattern<Op> {
     if (!enableConst || !enableConst.getValue().isOne())
       return failure();
 
-    rewriter.modifyOpInPlace(op, [&]() { op.getEnableMutable().clear(); });
+    rewriter.modifyOpInPlace(op, [&] { op.getEnableMutable().clear(); });
     return success();
   }
 };
 
-/// Delete operation if enable is `false`.
+/// Delete operation if enable is `false`. If the operation has a label,
+/// preserve it as a trivially-true assertion instead of erasing it.
 template <typename Op>
 struct EraseIfEnableFalse : public OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
@@ -91,43 +93,95 @@ struct EraseIfEnableFalse : public OpRewritePattern<Op> {
     Value enable = op.getEnable();
     if (!enable)
       return failure();
-    auto enableConst = enable.getDefiningOp<hw::ConstantOp>();
-    if (!enableConst || !enableConst.getValue().isZero())
+    APInt enableValue;
+    if (!matchPattern(enable, m_ConstantInt(&enableValue)) ||
+        !enableValue.isZero())
       return failure();
 
-    rewriter.eraseOp(op);
-    return success();
+    // If the op has no label, erase it. Otherwise preserve it as a
+    // trivially-satisfied assertion instead of erasing it.
+    if (!op.getLabel()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // Replace the property with a constant true if it isn't already.
+    bool changed = false;
+    IntegerAttr propAttr;
+    if (!matchPattern(op.getProperty(), m_Constant(&propAttr)) ||
+        !propAttr.getValue().isOne()) {
+      auto trueVal = hw::ConstantOp::create(rewriter, op.getLoc(), APInt(1, 1));
+      rewriter.modifyOpInPlace(
+          op, [&] { op.getPropertyMutable().assign(trueVal); });
+      changed = true;
+    }
+
+    // Clear the enable.
+    if (op.getEnable()) {
+      rewriter.modifyOpInPlace(op, [&] { op.getEnableMutable().clear(); });
+      changed = true;
+    }
+
+    // For clocked ops, replace the clock with a constant if it isn't one.
+    if constexpr (std::is_same_v<Op, ClockedAssertOp> ||
+                  std::is_same_v<Op, ClockedAssumeOp>) {
+      Attribute attr;
+      if (!matchPattern(op.getClock(), m_Constant(&attr))) {
+        auto falseVal =
+            hw::ConstantOp::create(rewriter, op.getLoc(), APInt(1, 0));
+        rewriter.modifyOpInPlace(
+            op, [&] { op.getClockMutable().assign(falseVal); });
+        changed = true;
+      }
+    }
+
+    return success(changed);
   }
 };
 
-/// Delete operation if property is `ltl.boolean_constant true` or
-/// `hw.constant true`.
+/// Delete operation if property is a constant true. If the operation has a
+/// label, preserve it instead of erasing it, since the label is expected to be
+/// visible in the output.
 template <typename Op>
 struct EraseIfPropertyTrue : public OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(Op op,
                                 PatternRewriter &rewriter) const override {
-    Value property = op.getProperty();
+    // Check if the property is a constant true.
+    IntegerAttr propAttr;
+    if (!matchPattern(op.getProperty(), m_Constant(&propAttr)) ||
+        !propAttr.getValue().isOne())
+      return failure();
 
-    // Check for ltl.boolean_constant true
-    if (auto boolConst =
-            property.template getDefiningOp<ltl::BooleanConstantOp>()) {
-      if (boolConst.getValueAttr().getValue()) {
-        rewriter.eraseOp(op);
-        return success();
+    // If the op has no label, erase it. Otherwise preserve it instead of
+    // erasing it. The property is already trivially true.
+    if (!op.getLabel()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // Clear the enable if present.
+    bool changed = false;
+    if (op.getEnable()) {
+      rewriter.modifyOpInPlace(op, [&] { op.getEnableMutable().clear(); });
+      changed = true;
+    }
+
+    // For clocked ops, replace the clock with a constant if it isn't one.
+    if constexpr (std::is_same_v<Op, ClockedAssertOp> ||
+                  std::is_same_v<Op, ClockedAssumeOp>) {
+      Attribute attr;
+      if (!matchPattern(op.getClock(), m_Constant(&attr))) {
+        auto falseVal =
+            hw::ConstantOp::create(rewriter, op.getLoc(), APInt(1, 0));
+        rewriter.modifyOpInPlace(
+            op, [&] { op.getClockMutable().assign(falseVal); });
+        changed = true;
       }
     }
 
-    // Check for hw.constant true (for i1 properties)
-    if (auto hwConst = property.template getDefiningOp<hw::ConstantOp>()) {
-      if (hwConst.getValue().isOne()) {
-        rewriter.eraseOp(op);
-        return success();
-      }
-    }
-
-    return failure();
+    return success(changed);
   }
 };
 

--- a/test/Dialect/Verif/canonicalization.mlir
+++ b/test/Dialect/Verif/canonicalization.mlir
@@ -48,6 +48,23 @@ hw.module @AssertEnableFalse(in %a : i1) {
   verif.assert %a if %false : i1
 }
 
+// CHECK-LABEL: @AssertEnableFalseLabeled
+hw.module @AssertEnableFalseLabeled(in %a : i1) {
+  %false = hw.constant false
+  // CHECK: verif.assert %true label "foo" : i1
+  // CHECK-NOT: if
+  verif.assert %a if %false label "foo" : i1
+}
+
+// CHECK-LABEL: @AssertEnableFalseBooleanConstantTrueLabeled
+hw.module @AssertEnableFalseBooleanConstantTrueLabeled() {
+  %false = hw.constant false
+  %prop = ltl.boolean_constant true
+  // CHECK: [[PROP:%.+]] = ltl.boolean_constant true
+  // CHECK: verif.assert [[PROP]] label "foo" : !ltl.property
+  verif.assert %prop if %false label "foo" : !ltl.property
+}
+
 // CHECK-LABEL: @AssertBooleanConstantTrue
 hw.module @AssertBooleanConstantTrue() {
   %prop = ltl.boolean_constant true
@@ -56,12 +73,27 @@ hw.module @AssertBooleanConstantTrue() {
   // CHECK: hw.output
 }
 
+// CHECK-LABEL: @AssertBooleanConstantTrueLabeled
+hw.module @AssertBooleanConstantTrueLabeled() {
+  %prop = ltl.boolean_constant true
+  // CHECK: [[PROP:%.+]] = ltl.boolean_constant true
+  // CHECK: verif.assert [[PROP]] label "foo" : !ltl.property
+  verif.assert %prop label "foo" : !ltl.property
+}
+
 // CHECK-LABEL: @AssertHWConstantTrue
 hw.module @AssertHWConstantTrue() {
   %true = hw.constant true
   // CHECK-NOT: verif.assert
   verif.assert %true : i1
   // CHECK: hw.output
+}
+
+// CHECK-LABEL: @AssertHWConstantTrueLabeled
+hw.module @AssertHWConstantTrueLabeled() {
+  %true = hw.constant true
+  // CHECK: verif.assert %true label "foo" : i1
+  verif.assert %true label "foo" : i1
 }
 
 // CHECK-LABEL: @AssertEnableTrue
@@ -92,6 +124,14 @@ hw.module @AssumeEnableFalse(in %a : i1) {
   verif.assume %a if %false : i1
 }
 
+// CHECK-LABEL: @AssumeEnableFalseLabeled
+hw.module @AssumeEnableFalseLabeled(in %a : i1) {
+  %false = hw.constant false
+  // CHECK: verif.assume %true label "foo" : i1
+  // CHECK-NOT: if
+  verif.assume %a if %false label "foo" : i1
+}
+
 // CHECK-LABEL: @AssumeBooleanConstantTrue
 hw.module @AssumeBooleanConstantTrue() {
   %prop = ltl.boolean_constant true
@@ -100,12 +140,27 @@ hw.module @AssumeBooleanConstantTrue() {
   // CHECK: hw.output
 }
 
+// CHECK-LABEL: @AssumeBooleanConstantTrueLabeled
+hw.module @AssumeBooleanConstantTrueLabeled() {
+  %prop = ltl.boolean_constant true
+  // CHECK: [[PROP:%.+]] = ltl.boolean_constant true
+  // CHECK: verif.assume [[PROP]] label "foo" : !ltl.property
+  verif.assume %prop label "foo" : !ltl.property
+}
+
 // CHECK-LABEL: @AssumeHWConstantTrue
 hw.module @AssumeHWConstantTrue() {
   %true = hw.constant true
   // CHECK-NOT: verif.assume
   verif.assume %true : i1
   // CHECK: hw.output
+}
+
+// CHECK-LABEL: @AssumeHWConstantTrueLabeled
+hw.module @AssumeHWConstantTrueLabeled() {
+  %true = hw.constant true
+  // CHECK: verif.assume %true label "foo" : i1
+  verif.assume %true label "foo" : i1
 }
 
 // CHECK-LABEL: @AssumeEnableTrue
@@ -192,6 +247,13 @@ hw.module @ClockedAssertEnableFalse(in %clock : i1, in %a : i1) {
   verif.clocked_assert %a if %false, posedge %clock : i1
 }
 
+// CHECK-LABEL: @ClockedAssertEnableFalseLabeled
+hw.module @ClockedAssertEnableFalseLabeled(in %clock : i1, in %a : i1) {
+  %false = hw.constant false
+  // CHECK: verif.clocked_assert %true, posedge %false label "foo" : i1
+  verif.clocked_assert %a if %false, posedge %clock label "foo" : i1
+}
+
 // CHECK-LABEL: @ClockedAssertBooleanConstantTrue
 hw.module @ClockedAssertBooleanConstantTrue(in %clock : i1) {
   %prop = ltl.boolean_constant true
@@ -200,12 +262,27 @@ hw.module @ClockedAssertBooleanConstantTrue(in %clock : i1) {
   // CHECK: hw.output
 }
 
+// CHECK-LABEL: @ClockedAssertBooleanConstantTrueLabeled
+hw.module @ClockedAssertBooleanConstantTrueLabeled(in %clock : i1) {
+  %prop = ltl.boolean_constant true
+  // CHECK: [[PROP:%.+]] = ltl.boolean_constant true
+  // CHECK: verif.clocked_assert [[PROP]], posedge %false label "foo" : !ltl.property
+  verif.clocked_assert %prop, posedge %clock label "foo" : !ltl.property
+}
+
 // CHECK-LABEL: @ClockedAssertHWConstantTrue
 hw.module @ClockedAssertHWConstantTrue(in %clock : i1) {
   %true = hw.constant true
   // CHECK-NOT: verif.clocked_assert
   verif.clocked_assert %true, posedge %clock : i1
   // CHECK: hw.output
+}
+
+// CHECK-LABEL: @ClockedAssertHWConstantTrueLabeled
+hw.module @ClockedAssertHWConstantTrueLabeled(in %clock : i1) {
+  %true = hw.constant true
+  // CHECK: verif.clocked_assert %true, posedge %false label "foo" : i1
+  verif.clocked_assert %true, posedge %clock label "foo" : i1
 }
 
 //===----------------------------------------------------------------------===//
@@ -229,6 +306,13 @@ hw.module @ClockedAssumeEnableFalse(in %clock : i1, in %a : i1) {
   verif.clocked_assume %a if %false, posedge %clock : i1
 }
 
+// CHECK-LABEL: @ClockedAssumeEnableFalseLabeled
+hw.module @ClockedAssumeEnableFalseLabeled(in %clock : i1, in %a : i1) {
+  %false = hw.constant false
+  // CHECK: verif.clocked_assume %true, posedge %false label "foo" : i1
+  verif.clocked_assume %a if %false, posedge %clock label "foo" : i1
+}
+
 // CHECK-LABEL: @ClockedAssumeBooleanConstantTrue
 hw.module @ClockedAssumeBooleanConstantTrue(in %clock : i1) {
   %prop = ltl.boolean_constant true
@@ -237,12 +321,27 @@ hw.module @ClockedAssumeBooleanConstantTrue(in %clock : i1) {
   // CHECK: hw.output
 }
 
+// CHECK-LABEL: @ClockedAssumeBooleanConstantTrueLabeled
+hw.module @ClockedAssumeBooleanConstantTrueLabeled(in %clock : i1) {
+  %prop = ltl.boolean_constant true
+  // CHECK: [[PROP:%.+]] = ltl.boolean_constant true
+  // CHECK: verif.clocked_assume [[PROP]], posedge %false label "foo" : !ltl.property
+  verif.clocked_assume %prop, posedge %clock label "foo" : !ltl.property
+}
+
 // CHECK-LABEL: @ClockedAssumeHWConstantTrue
 hw.module @ClockedAssumeHWConstantTrue(in %clock : i1) {
   %true = hw.constant true
   // CHECK-NOT: verif.clocked_assume
   verif.clocked_assume %true, posedge %clock : i1
   // CHECK: hw.output
+}
+
+// CHECK-LABEL: @ClockedAssumeHWConstantTrueLabeled
+hw.module @ClockedAssumeHWConstantTrueLabeled(in %clock : i1) {
+  %true = hw.constant true
+  // CHECK: verif.clocked_assume %true, posedge %false label "foo" : i1
+  verif.clocked_assume %true, posedge %clock label "foo" : i1
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The EraseIfEnableFalse and EraseIfPropertyTrue canonicalization patterns unconditionally erased verif.assert and verif.assume ops (and their clocked variants) when they were trivially true or disabled. This silently dropped user-visible labels that users expect to see in the output regardless of optimizations.

Instead of erasing labeled ops, replace them with trivially-satisfied versions that preserve the label: set the property to constant true, clear the enable, and for clocked ops replace a non-constant clock with constant false.