### PR TITLE
[FIRRTL] InferDomains: Fix wire updating

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -1441,31 +1441,39 @@ static LogicalResult updateInstance(PassGlobals &globals,
 
 /// Update a wire operation with inferred domain associations.
 static LogicalResult updateWire(PassGlobals &globals, TermAllocator &allocator,
-                                DomainTable &table, WireOp wireOp) {
+                                DomainTable &table, WireOp wireOp,
+                                OpBuilder &builder) {
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPoint(wireOp);
+
   auto result = wireOp.getResult();
   if (!isa<FIRRTLBaseType>(result.getType()))
     return success();
 
-  // Get the inferred domain associations for this wire.
-  auto *term = table.getOptDomainAssociation(result);
-  if (!term)
-    return success();
+  auto *row =
+      getDomainAssociationAsRow(globals, allocator, table, wireOp.getResult());
 
-  auto *row = dyn_cast<RowTerm>(find(term));
-  if (!row)
-    return success();
-
-  // Collect the domain values to add as operands.
   SmallVector<Value> domainOperands;
-  for (auto *element : llvm::map_range(row->elements, find))
-    if (auto *val = dyn_cast_or_null<ValueTerm>(element))
+  for (auto [i, element] :
+       llvm::enumerate(llvm::map_range(row->elements, find))) {
+    if (auto *val = dyn_cast<ValueTerm>(element)) {
       domainOperands.push_back(val->value);
-
-  // Update the wire's domain operands in place. $domains is the only operand
-  // group on WireOp, so setOperands replaces exactly the domain list.
-  if (!domainOperands.empty() && wireOp.getDomains().empty())
-    wireOp->setOperands(domainOperands);
-
+      continue;
+    }
+    if (auto *var = dyn_cast<VariableTerm>(element)) {
+      auto domainDecl = globals.domainInfo.getDomain(DomainTypeID{i});
+      auto domainType = DomainType::getFromDomainOp(domainDecl);
+      auto domainName = domainDecl.getNameAttr();
+      auto anonDomain = DomainCreateAnonOp::create(builder, wireOp.getLoc(),
+                                                   domainType, domainName);
+      domainOperands.push_back(anonDomain);
+      auto *val = allocator.allocVal(anonDomain);
+      solve(globals, var, val);
+      continue;
+    }
+    assert(0 && "unhandled domain type");
+  }
+  wireOp.getDomainsMutable().assign(domainOperands);
   return success();
 }
 
@@ -1478,20 +1486,14 @@ static LogicalResult updateModuleBody(PassGlobals &globals,
   // created there, avoiding use-before-def issues.
   OpBuilder builder(moduleOp.getContext());
   builder.setInsertionPointToEnd(moduleOp.getBodyBlock());
-
-  // Update instances
-  auto instanceResult =
-      moduleOp.getBodyBlock()->walk([&](FInstanceLike op) -> WalkResult {
-        return updateInstance(globals, allocator, table, op, builder);
-      });
-  if (instanceResult.wasInterrupted())
-    return failure();
-
-  // Update wires with inferred domain associations
-  auto wireResult = moduleOp.getBodyBlock()->walk([&](WireOp op) -> WalkResult {
-    return updateWire(globals, allocator, table, op);
+  auto result = moduleOp.getBodyBlock()->walk([&](Operation *op) -> WalkResult {
+    if (auto wire = dyn_cast<WireOp>(op))
+      return updateWire(globals, allocator, table, wire, builder);
+    if (auto instance = dyn_cast<FInstanceLike>(op))
+      return updateInstance(globals, allocator, table, instance, builder);
+    return success();
   });
-  return failure(wireResult.wasInterrupted());
+  return failure(result.wasInterrupted());
 }
 
 /// Write the domain associations recorded in the domain table back to the IR.

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -591,3 +591,53 @@ firrtl.circuit "WireInferFromConnect" {
     firrtl.matchingconnect %b, %w : !firrtl.uint<1>
   }
 }
+
+// CHECK-LABEL: firrtl.circuit "WireInferSecondDomain"
+firrtl.circuit "WireInferSecondDomain" {
+  firrtl.domain @ClockDomain
+  firrtl.domain @PowerDomain
+  firrtl.module @WireInferSecondDomain(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    in %a: !firrtl.uint<1> domains [%A]
+  ) {
+    // CHECK: %w = firrtl.wire domains[%A, %PowerDomain]
+    %w = firrtl.wire domains [%A] : !firrtl.uint<1> domains [!firrtl.domain<@ClockDomain()>]
+    firrtl.matchingconnect %w, %a : !firrtl.uint<1>
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "DoNotReUseAnonDomain"
+firrtl.circuit "DoNotReUseAnonDomain" {
+  firrtl.domain @ClockDomain
+  firrtl.domain @PowerDomain
+  firrtl.module @DoNotReUseAnonDomain() {
+    // CHECK: %ClockDomain = firrtl.domain.anon
+    // CHECK: %PowerDomain = firrtl.domain.anon
+    // CHECK: %w1 = firrtl.wire domains[%ClockDomain, %PowerDomain]
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %w1 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %ClockDomain_0 = firrtl.domain.anon
+    // CHECK: %PowerDomain_1 = firrtl.domain.anon
+    // CHECK: %w2 = firrtl.wire domains[%ClockDomain_0, %PowerDomain_1]
+    %w2 = firrtl.wire : !firrtl.uint<1>
+    firrtl.matchingconnect %w1, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %w2, %c0_ui1 : !firrtl.uint<1>
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "ReUseAnonDomain"
+firrtl.circuit "ReUseAnonDomain" {
+  firrtl.domain @ClockDomain
+  firrtl.domain @PowerDomain
+  firrtl.module @ReUseAnonDomain() {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK: %ClockDomain = firrtl.domain.anon
+    // CHECK: %PowerDomain = firrtl.domain.anon
+    // CHECK: %w1 = firrtl.wire domains[%ClockDomain, %PowerDomain] 
+    %w1 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %w2 = firrtl.wire domains[%ClockDomain, %PowerDomain]
+    %w2 = firrtl.wire : !firrtl.uint<1>
+    firrtl.matchingconnect %w1, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %w2, %w1 : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
When updating the domain associations of a wire, we need to sets the domain arguments every time, even if they are already set. This fixes a bug where, if the user provided some (but not all) domain annotations, the wire would not be updated with the full list of domains.

As well...

When a wire is associated with an unknown domain (a metavariable), we create an anonymous domain. When we do this, we also need to solve the metavariable with the newly created unknown domain. Otherwise later ops, associated with the same domain variable, will be associated with a fresh anonymous domain instead.