### PR TITLE
[FIRRTL] LowerDomains Domain-type Associated Wire

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerDomains.cpp
@@ -660,13 +660,18 @@ LogicalResult LowerModule::lowerModule() {
           SmallVector<Value> dsts;
           DomainDefineOp lastDefineOp;
           for (auto *user : llvm::make_early_inc_range(wireOp->getUsers())) {
+            // This domain is associated with another wire.  Nothing to do.
+            if (isa<WireOp>(user))
+              continue;
+
             auto domainDefineOp = dyn_cast<DomainDefineOp>(user);
             if (operationsToErase.contains(domainDefineOp))
               continue;
             if (!domainDefineOp) {
-              auto diag = wireOp.emitOpError()
-                          << "cannot be lowered by `LowerDomains` because it "
-                             "has a user that is not a domain define op";
+              auto diag =
+                  wireOp.emitOpError()
+                  << "cannot be lowered by `LowerDomains` because it "
+                     "has a user that is not a domain define op or wire";
               diag.attachNote(user->getLoc()) << "is one such user";
               return WalkResult::interrupt();
             }

--- a/test/Dialect/FIRRTL/lower-domains.mlir
+++ b/test/Dialect/FIRRTL/lower-domains.mlir
@@ -685,3 +685,21 @@ firrtl.circuit "WireWithCreateDomain" {
     %w = firrtl.wire domains[%my_domain] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
   }
 }
+
+// -----
+
+// Test that a domain wire used by another wire (via domain association) and by
+// a domain.define op is properly lowered.  All domain-related ops should be
+// removed, leaving just the wire.
+firrtl.circuit "DomainWireUsedByWire" {
+  firrtl.domain @ClockDomain
+  // CHECK-LABEL: firrtl.module @DomainWireUsedByWire()
+  // CHECK-NEXT:    %w = firrtl.wire : !firrtl.uint<1>
+  // CHECK-NEXT:  }
+  firrtl.module @DomainWireUsedByWire() {
+    %domain_wire = firrtl.wire : !firrtl.domain<@ClockDomain()>
+    %w = firrtl.wire domains[%domain_wire] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
+    %actual_domain = firrtl.domain.create : !firrtl.domain<@ClockDomain()>
+    firrtl.domain.define %domain_wire, %actual_domain : !firrtl.domain<@ClockDomain()>
+  }
+}


### PR DESCRIPTION
Fix a bug in FIRRTL's `LowerDomains` pass where it incorrectly assumed
that all users of domain-type wires were domain define operations.  This
was not the case after wires gained the ability to record domain
associations as operands.  (Wires can be users of domain-typed wires.)

This is related to #10116 as any fix for this will likely trigger this.
However, this was always reachable in FIRRTL text.

AI-assisted-by: Augment (Claude Sonnet 4.5)
