### PR TITLE
[CI] Try a newer docker image

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Sanity Check
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/circt/images/circt-ci-build:20260107030736
+      image: ghcr.io/circt/images/circt-ci-build:20260404025445
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.


### PR DESCRIPTION
It’s unlikely, but there’s a chance some recent Docker images have issues that are causing CI failures. 
~It might be worth a shot to just use the newer Docker image~. It didn't work well :) 