### PR TITLE
[Moore][ImportVerilog][MooreToCore] Add DPI call semantics to Moore

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.h
+++ b/include/circt/Dialect/Moore/MooreOps.h
@@ -26,6 +26,18 @@
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Moore/MooreEnums.h.inc"
+
+namespace circt {
+namespace moore {
+/// Information about one DPI-imported function argument.
+struct DPIArgInfo {
+  mlir::StringAttr name;
+  mlir::Type type;
+  DPIArgDirection dir;
+};
+} // namespace moore
+} // namespace circt
+
 // Clang format shouldn't reorder these headers.
 #include "circt/Dialect/Moore/Moore.h.inc"
 

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3359,6 +3359,130 @@ def VTableEntryOp : MooreOp<"vtable_entry", [
   }];
 }
 
+// DPI argument direction enum — models the first-class direction keywords
+// used in DPI-imported function declarations (in, out, inout, return).
+def DPIArgDir_In     : I32EnumAttrCase<"In",     0, "in">;
+def DPIArgDir_Out    : I32EnumAttrCase<"Out",    1, "out">;
+def DPIArgDir_InOut  : I32EnumAttrCase<"InOut",  2, "inout">;
+def DPIArgDir_Return : I32EnumAttrCase<"Return", 3, "return">;
+
+def DPIArgDirection : I32EnumAttr<"DPIArgDirection",
+    "DPI argument direction",
+    [DPIArgDir_In, DPIArgDir_Out, DPIArgDir_InOut, DPIArgDir_Return]> {
+  let cppNamespace = "circt::moore";
+}
+
+def DPIFuncOp : MooreOp<"func.dpi",
+  [IsolatedFromAbove, Symbol, OpAsmOpInterface,
+   DeclareOpInterfaceMethods<FunctionOpInterface,
+     ["cloneTypeWith"]>]> {
+  let summary = "A DPI-imported SystemVerilog function declaration";
+  let description = [{
+    `moore.func.dpi` models a DPI-imported function declaration in Moore IR.
+    Each argument has a direction (`in`, `out`, `inout`, `return`), name, and
+    type. MooreToCore reconstructs a `sim::DPIFunctionType` for lowering to
+    `sim.func.dpi`.
+  }];
+
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<FunctionType>:$function_type,
+    ArrayAttr:$dpi_arg_dirs,
+    ArrayAttr:$dpi_arg_names,
+    OptionalAttr<LocationArrayAttr>:$argument_locs,
+    OptionalAttr<StrAttr>:$verilogName,
+    OptionalAttr<StrAttr>:$sym_visibility
+  );
+  let regions = (region AnyRegion:$body);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins
+      "StringAttr":$sym_name,
+      "ArrayRef<DPIArgInfo>":$dpiArgs,
+      "ArrayAttr":$argumentLocs,
+      "StringAttr":$verilogName
+    )>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Whether a direction is a call operand (input-side).
+    static bool isCallOperandDir(DPIArgDirection dir) {
+      return dir == DPIArgDirection::In || dir == DPIArgDirection::InOut;
+    }
+
+    /// Reconstruct the absolute argument types from the FunctionType and
+    /// stored directions.
+    void getDPIArgTypes(SmallVectorImpl<Type> &argTypes);
+
+    ArrayRef<Type> getArgumentTypes() {
+      return cast<mlir::FunctionType>(getFunctionType()).getInputs();
+    }
+    ArrayRef<Type> getResultTypes() {
+      return cast<mlir::FunctionType>(getFunctionType()).getResults();
+    }
+
+    ::mlir::Region *getCallableRegion() { return nullptr; }
+
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// DPI Call
+//===----------------------------------------------------------------------===//
+
+def FuncDPICallOp : MooreOp<"func.dpi.call", [
+  CallOpInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Call a DPI-imported function";
+  let description = [{
+    `moore.func.dpi.call` represents a call to a DPI-C imported function,
+    preserving the DPI intent from ImportVerilog so that downstream
+    MooreToCore lowering emits `sim.func.dpi.call` instead of a plain
+    `func.call`.
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$callee,
+                       Variadic<AnyType>:$inputs);
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = [{
+    $callee `(` $inputs `)` attr-dict `:` functional-type($inputs, results)
+  }];
+
+  let extraClassDeclaration = [{
+    operand_range getArgOperands() {
+      return getInputs();
+    }
+    MutableOperandRange getArgOperandsMutable() {
+      return getInputsMutable();
+    }
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<mlir::SymbolRefAttr>("callee");
+    }
+    void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
+      (*this)->setAttr(getCalleeAttrName(),
+                       llvm::cast<mlir::SymbolRefAttr>(callee));
+    }
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
+  }];
+
+}
+
 
 //===----------------------------------------------------------------------===//
 // String Builtins

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImportVerilogInternals.h"
+#include "circt/Dialect/Moore/MooreOps.h"
 #include "circt/Dialect/Moore/MooreTypes.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
@@ -1741,8 +1742,8 @@ struct RvalueExprVisitor : public ExprVisitor {
         (subroutine->flags & slang::ast::MethodFlags::Virtual) != 0;
 
     if (!isVirtual) {
-      auto calleeSym = lowering->op.getName();
-      if (lowering->isCoroutine())
+      auto calleeSym = lowering->op.getNameAttr().getValue();
+      if (isa<moore::CoroutineOp>(lowering->op.getOperation()))
         return moore::CallCoroutineOp::create(builder, loc, resultTypes,
                                               calleeSym, explicitArguments);
       return mlir::func::CallOp::create(builder, loc, resultTypes, calleeSym,
@@ -1766,6 +1767,97 @@ struct RvalueExprVisitor : public ExprVisitor {
     auto *lowering = context.declareFunction(*subroutine);
     if (!lowering)
       return {};
+
+    if (isa<moore::DPIFuncOp>(lowering->op.getOperation())) {
+      SmallVector<Value> operands;
+      SmallVector<Value> resultTargets;
+
+      for (auto [callArg, declArg] :
+           llvm::zip(expr.arguments(), subroutine->getArguments())) {
+        auto *actual = callArg;
+        if (const auto *assign =
+                actual->as_if<slang::ast::AssignmentExpression>())
+          actual = &assign->left();
+
+        auto argType = context.convertType(declArg->getType());
+        if (!argType)
+          return {};
+
+        switch (declArg->direction) {
+        case slang::ast::ArgumentDirection::In: {
+          auto value = context.convertRvalueExpression(*actual, argType);
+          if (!value)
+            return {};
+          operands.push_back(value);
+          break;
+        }
+        case slang::ast::ArgumentDirection::Out: {
+          auto lvalue = context.convertLvalueExpression(*actual);
+          if (!lvalue)
+            return {};
+          resultTargets.push_back(lvalue);
+          break;
+        }
+        case slang::ast::ArgumentDirection::InOut:
+        case slang::ast::ArgumentDirection::Ref: {
+          auto lvalue = context.convertLvalueExpression(*actual);
+          if (!lvalue)
+            return {};
+          auto value = context.convertRvalueExpression(*actual, argType);
+          if (!value)
+            return {};
+          operands.push_back(value);
+          resultTargets.push_back(lvalue);
+          break;
+        }
+        }
+      }
+
+      SmallVector<Type> resultTypes(
+          cast<FunctionType>(lowering->op.getFunctionType()).getResults());
+      auto callOp = moore::FuncDPICallOp::create(
+          builder, loc, resultTypes,
+          SymbolRefAttr::get(lowering->op.getNameAttr()), operands);
+
+      unsigned resultIndex = 0;
+      unsigned targetIndex = 0;
+      for (const auto *declArg : subroutine->getArguments()) {
+        auto argType = context.convertType(declArg->getType());
+        if (!argType)
+          return {};
+
+        switch (declArg->direction) {
+        case slang::ast::ArgumentDirection::Out:
+        case slang::ast::ArgumentDirection::InOut:
+        case slang::ast::ArgumentDirection::Ref: {
+          auto lvalue = resultTargets[targetIndex++];
+          auto refTy = dyn_cast<moore::RefType>(lvalue.getType());
+          if (!refTy) {
+            lowering->op->emitError(
+                "expected DPI output target to be moore::RefType");
+            return {};
+          }
+          auto converted = context.materializeConversion(
+              refTy.getNestedType(), callOp->getResult(resultIndex++),
+              declArg->getType().isSigned(), loc);
+          if (!converted)
+            return {};
+          moore::BlockingAssignOp::create(builder, loc, lvalue, converted);
+          break;
+        }
+        default:
+          break;
+        }
+      }
+
+      if (!subroutine->getReturnType().isVoid())
+        return callOp->getResult(resultIndex);
+
+      return mlir::UnrealizedConversionCastOp::create(
+                 builder, loc, moore::VoidType::get(context.getContext()),
+                 ValueRange{})
+          .getResult(0);
+    }
 
     // Convert the call arguments. Input arguments are converted to an rvalue.
     // All other arguments are converted to lvalues and passed into the function
@@ -1824,14 +1916,14 @@ struct RvalueExprVisitor : public ExprVisitor {
       auto [thisRef, tyHandle] = getMethodReceiverTypeHandle(expr);
       callOp = buildMethodCall(subroutine, lowering, tyHandle, thisRef,
                                arguments, resultTypes);
-    } else if (lowering->isCoroutine()) {
+    } else if (isa<moore::CoroutineOp>(lowering->op.getOperation())) {
       // Free task -> moore.call_coroutine
-      auto coroutine = cast<moore::CoroutineOp>(lowering->op);
+      auto coroutine = cast<moore::CoroutineOp>(lowering->op.getOperation());
       callOp =
           moore::CallCoroutineOp::create(builder, loc, coroutine, arguments);
     } else {
       // Free function -> func.call
-      auto funcOp = cast<mlir::func::FuncOp>(lowering->op);
+      auto funcOp = cast<mlir::func::FuncOp>(lowering->op.getOperation());
       callOp = mlir::func::CallOp::create(builder, loc, funcOp, arguments);
     }
 

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -94,8 +94,9 @@ struct ModuleLowering {
 };
 
 /// Function lowering information. The `op` field holds either a `func::FuncOp`
-/// (for SystemVerilog functions) or a `moore::CoroutineOp` (for tasks),
-/// accessed through the `FunctionOpInterface`.
+/// (for SystemVerilog functions), a `moore::CoroutineOp` (for tasks), or a
+/// `moore::DPIFuncOp` (for DPI-imported functions), all accessed through the
+/// `FunctionOpInterface`.
 struct FunctionLowering {
   mlir::FunctionOpInterface op;
 
@@ -104,8 +105,7 @@ struct FunctionLowering {
   /// during declaration.
   SmallVector<const slang::ast::ValueSymbol *, 4> capturedSymbols;
 
-  /// Whether this is a coroutine (task) or a regular function.
-  bool isCoroutine() { return isa<moore::CoroutineOp>(op.getOperation()); }
+  explicit FunctionLowering(mlir::FunctionOpInterface op) : op(op) {}
 };
 
 // Class lowering information.

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1433,7 +1433,7 @@ Context::declareFunction(const slang::ast::SubroutineSymbol &subroutine) {
   // Check if there already is a declaration for this function.
   auto &lowering = functions[&subroutine];
   if (lowering) {
-    if (!lowering->op)
+    if (!lowering->op.getOperation())
       return {};
     return lowering.get();
   }
@@ -1517,6 +1517,48 @@ static FunctionType getFunctionSignature(
   return FunctionType::get(context.getContext(), inputTypes, outputTypes);
 }
 
+static FailureOr<SmallVector<moore::DPIArgInfo>>
+getDPISignature(Context &context,
+                const slang::ast::SubroutineSymbol &subroutine) {
+  using slang::ast::ArgumentDirection;
+
+  SmallVector<moore::DPIArgInfo> args;
+  args.reserve(subroutine.getArguments().size() +
+               (!subroutine.getReturnType().isVoid() ? 1 : 0));
+
+  for (const auto *arg : subroutine.getArguments()) {
+    auto type = context.convertType(arg->getType());
+    if (!type)
+      return failure();
+    moore::DPIArgDirection dir;
+    switch (arg->direction) {
+    case ArgumentDirection::In:
+      dir = moore::DPIArgDirection::In;
+      break;
+    case ArgumentDirection::Out:
+      dir = moore::DPIArgDirection::Out;
+      break;
+    case ArgumentDirection::InOut:
+      dir = moore::DPIArgDirection::InOut;
+      break;
+    case ArgumentDirection::Ref:
+      llvm_unreachable("'ref' is not legal for DPI functions");
+    }
+    args.push_back(
+        {StringAttr::get(context.getContext(), arg->name), type, dir});
+  }
+
+  if (!subroutine.getReturnType().isVoid()) {
+    auto type = context.convertType(subroutine.getReturnType());
+    if (!type)
+      return failure();
+    args.push_back({StringAttr::get(context.getContext(), "return"), type,
+                    moore::DPIArgDirection::Return});
+  }
+
+  return args;
+}
+
 /// Convert a function and its arguments to a function declaration in the IR.
 /// This does not convert the function body.
 FunctionLowering *
@@ -1524,9 +1566,6 @@ Context::declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
                              mlir::StringRef qualifiedName,
                              llvm::SmallVectorImpl<Type> &extraParams) {
   auto loc = convertLocation(subroutine.location);
-  std::unique_ptr<FunctionLowering> lowering =
-      std::make_unique<FunctionLowering>();
-
   // Pick an insertion point for this function according to the source file
   // location.
   OpBuilder::InsertionGuard g(builder);
@@ -1557,30 +1596,46 @@ Context::declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
   if (!funcTy)
     return nullptr;
 
-  // Create a coroutine for tasks (which can suspend) or a function for
-  // functions (which cannot).
-  Operation *funcOp;
-  if (subroutine.subroutineKind == slang::ast::SubroutineKind::Task) {
+  std::unique_ptr<FunctionLowering> lowering;
+  Operation *insertedOp = nullptr;
+  if (!subroutine.thisVar &&
+      subroutine.flags.has(slang::ast::MethodFlags::DPIImport)) {
+    // DPI-imported function: create a moore.func.dpi declaration.
+    auto dpiSig = getDPISignature(*this, subroutine);
+    if (failed(dpiSig))
+      return nullptr;
+
+    auto dpiOp = moore::DPIFuncOp::create(
+        builder, loc, StringAttr::get(getContext(), qualifiedName), *dpiSig,
+        /*argumentLocs=*/ArrayAttr(),
+        StringAttr::get(getContext(), subroutine.name));
+    SymbolTable::setSymbolVisibility(dpiOp, SymbolTable::Visibility::Private);
+    lowering = std::make_unique<FunctionLowering>(dpiOp);
+    insertedOp = dpiOp;
+  } else if (subroutine.subroutineKind == slang::ast::SubroutineKind::Task) {
+    // Create a coroutine for tasks (which can suspend).
     auto op = moore::CoroutineOp::create(builder, loc, qualifiedName, funcTy);
     SymbolTable::setSymbolVisibility(op, SymbolTable::Visibility::Private);
-    lowering->op = op;
-    funcOp = op;
+    lowering = std::make_unique<FunctionLowering>(op);
+    insertedOp = op;
   } else {
-    auto op = mlir::func::FuncOp::create(builder, loc, qualifiedName, funcTy);
-    SymbolTable::setSymbolVisibility(op, SymbolTable::Visibility::Private);
-    lowering->op = op;
-    funcOp = op;
+    // Create a function for regular functions (which cannot suspend).
+    auto funcOp =
+        mlir::func::FuncOp::create(builder, loc, qualifiedName, funcTy);
+    SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
+    lowering = std::make_unique<FunctionLowering>(funcOp);
+    insertedOp = funcOp;
   }
-  orderedRootOps.insert(it, {locationKey, funcOp});
+  orderedRootOps.insert(it, {locationKey, insertedOp});
 
   // Store the captured symbols so call sites can look them up.
   if (capturesIt != functionCaptures.end())
     lowering->capturedSymbols.assign(capturesIt->second.begin(),
                                      capturesIt->second.end());
 
-  // Add the function to the symbol table of the MLIR module, which uniquifies
+  // Add the op to the symbol table of the MLIR module, which uniquifies
   // its name.
-  symbolTable.insert(funcOp);
+  symbolTable.insert(insertedOp);
   functions[&subroutine] = std::move(lowering);
 
   // Schedule the body to be defined later.
@@ -1689,7 +1744,7 @@ Context::defineFunction(const slang::ast::SubroutineSymbol &subroutine) {
     if (!type)
       return failure();
     returnVar = moore::VariableOp::create(
-        builder, lowering->op.getLoc(),
+        builder, lowering->op->getLoc(),
         moore::RefType::get(cast<moore::UnpackedType>(type)), StringAttr{},
         Value{});
     valueSymbols.insert(subroutine.returnValVar, returnVar);
@@ -1720,14 +1775,14 @@ Context::defineFunction(const slang::ast::SubroutineSymbol &subroutine) {
   // If there was no explicit return statement provided by the user, insert a
   // default one.
   if (builder.getBlock()) {
-    if (lowering->isCoroutine()) {
-      moore::ReturnOp::create(builder, lowering->op.getLoc());
+    if (isa<moore::CoroutineOp>(lowering->op.getOperation())) {
+      moore::ReturnOp::create(builder, lowering->op->getLoc());
     } else if (returnVar && !subroutine.getReturnType().isVoid()) {
       Value read =
           moore::ReadOp::create(builder, returnVar.getLoc(), returnVar);
-      mlir::func::ReturnOp::create(builder, lowering->op.getLoc(), read);
+      mlir::func::ReturnOp::create(builder, lowering->op->getLoc(), read);
     } else {
-      mlir::func::ReturnOp::create(builder, lowering->op.getLoc(),
+      mlir::func::ReturnOp::create(builder, lowering->op->getLoc(),
                                    ValueRange{});
     }
   }
@@ -2160,8 +2215,9 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
     // Grab the function type from the declaration.
     FunctionType fnTy = cast<FunctionType>(lowering->op.getFunctionType());
     // Emit the method decl into the class body, preserving source order.
-    moore::ClassMethodDeclOp::create(builder, loc, fn.name, fnTy,
-                                     SymbolRefAttr::get(lowering->op));
+    moore::ClassMethodDeclOp::create(
+        builder, loc, fn.name, fnTy,
+        SymbolRefAttr::get(lowering->op.getNameAttr()));
 
     return success();
   }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2135,6 +2135,74 @@ struct CallOpConversion : public OpConversionPattern<func::CallOp> {
   }
 };
 
+struct FuncDPICallOpConversion
+    : public OpConversionPattern<moore::FuncDPICallOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(moore::FuncDPICallOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> convResTypes;
+    if (typeConverter->convertTypes(op.getResultTypes(), convResTypes).failed())
+      return failure();
+    rewriter.replaceOpWithNewOp<sim::DPICallOp>(
+        op, convResTypes, op.getCalleeAttr(), /*clock=*/Value(),
+        /*enable=*/Value(), adaptor.getInputs());
+    return success();
+  }
+};
+
+struct DPIFuncOpConversion : public OpConversionPattern<moore::DPIFuncOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(moore::DPIFuncOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Map Moore DPIArgDirection to sim::DPIDirection.
+    auto toDPIDir = [](moore::DPIArgDirection dir) -> sim::DPIDirection {
+      switch (dir) {
+      case moore::DPIArgDirection::In:
+        return sim::DPIDirection::Input;
+      case moore::DPIArgDirection::Out:
+        return sim::DPIDirection::Output;
+      case moore::DPIArgDirection::InOut:
+        return sim::DPIDirection::InOut;
+      case moore::DPIArgDirection::Return:
+        return sim::DPIDirection::Return;
+      }
+      llvm_unreachable("unknown DPIArgDirection");
+    };
+
+    // Reconstruct sim::DPIFunctionType from Moore's argument arrays.
+    auto dirs = op.getDpiArgDirs();
+    auto names = op.getDpiArgNames();
+    SmallVector<Type> argTypes;
+    op.getDPIArgTypes(argTypes);
+
+    SmallVector<sim::DPIArgument> dpiArguments;
+    for (auto [dirAttr, nameAttr, mooreType] :
+         llvm::zip(dirs, names, argTypes)) {
+      auto dir = toDPIDir(cast<moore::DPIArgDirectionAttr>(dirAttr).getValue());
+      auto name = cast<StringAttr>(nameAttr);
+      Type coreType = typeConverter->convertType(mooreType);
+      if (!coreType)
+        return op.emitOpError("argument '")
+               << name << "' has unsupported type " << mooreType;
+      dpiArguments.push_back({name, coreType, dir});
+    }
+
+    auto coreDPIFuncType =
+        sim::DPIFunctionType::get(rewriter.getContext(), dpiArguments);
+    auto simFunc = sim::DPIFuncOp::create(
+        rewriter, op.getLoc(), op.getSymNameAttr(), coreDPIFuncType,
+        op.getArgumentLocsAttr(), op.getVerilogNameAttr());
+    SymbolTable::setSymbolVisibility(simFunc,
+                                     SymbolTable::getSymbolVisibility(op));
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct UnrealizedConversionCastConversion
     : public OpConversionPattern<UnrealizedConversionCastOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -3390,6 +3458,8 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     HWInstanceOpConversion,
     ReturnOpConversion,
     CallOpConversion,
+    DPIFuncOpConversion,
+    FuncDPICallOpConversion,
     UnrealizedConversionCastConversion,
     InPlaceOpConversion<debug::ArrayOp>,
     InPlaceOpConversion<debug::StructOp>,

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -1879,6 +1879,298 @@ LogicalResult QueueConcatOp::verify() {
   return success();
 }
 
+void DPIFuncOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                      StringAttr symName, ArrayRef<DPIArgInfo> dpiArgs,
+                      ArrayAttr argumentLocs, StringAttr verilogName) {
+  auto *ctx = odsBuilder.getContext();
+  odsState.addAttribute(getSymNameAttrName(odsState.name), symName);
+
+  // Derive FunctionType, direction array, and name array from dpiArgs.
+  SmallVector<Type> inputTypes, resultTypes;
+  SmallVector<Attribute> dirAttrs, nameAttrs;
+  for (auto &arg : dpiArgs) {
+    dirAttrs.push_back(DPIArgDirectionAttr::get(ctx, arg.dir));
+    nameAttrs.push_back(arg.name);
+    if (isCallOperandDir(arg.dir))
+      inputTypes.push_back(arg.type);
+    if (arg.dir == DPIArgDirection::Out || arg.dir == DPIArgDirection::InOut ||
+        arg.dir == DPIArgDirection::Return)
+      resultTypes.push_back(arg.type);
+  }
+
+  odsState.addAttribute(
+      getFunctionTypeAttrName(odsState.name),
+      TypeAttr::get(FunctionType::get(ctx, inputTypes, resultTypes)));
+  odsState.addAttribute(getDpiArgDirsAttrName(odsState.name),
+                        odsBuilder.getArrayAttr(dirAttrs));
+  odsState.addAttribute(getDpiArgNamesAttrName(odsState.name),
+                        odsBuilder.getArrayAttr(nameAttrs));
+
+  if (argumentLocs)
+    odsState.addAttribute(getArgumentLocsAttrName(odsState.name), argumentLocs);
+  if (verilogName)
+    odsState.addAttribute(getVerilogNameAttrName(odsState.name), verilogName);
+  odsState.addRegion();
+}
+
+/// Helper: parse a DPI direction keyword.
+static std::optional<DPIArgDirection> parseDPIArgDirKeyword(StringRef keyword) {
+  return llvm::StringSwitch<std::optional<DPIArgDirection>>(keyword)
+      .Case("in", DPIArgDirection::In)
+      .Case("out", DPIArgDirection::Out)
+      .Case("inout", DPIArgDirection::InOut)
+      .Case("return", DPIArgDirection::Return)
+      .Default(std::nullopt);
+}
+
+/// Helper: stringify a DPI direction.
+static StringRef stringifyDPIArgDir(DPIArgDirection dir) {
+  switch (dir) {
+  case DPIArgDirection::In:
+    return "in";
+  case DPIArgDirection::Out:
+    return "out";
+  case DPIArgDirection::InOut:
+    return "inout";
+  case DPIArgDirection::Return:
+    return "return";
+  }
+  llvm_unreachable("unknown DPIArgDirection");
+}
+
+ParseResult DPIFuncOp::parse(OpAsmParser &parser, OperationState &result) {
+  auto builder = parser.getBuilder();
+  auto ctx = builder.getContext();
+
+  (void)mlir::impl::parseOptionalVisibilityKeyword(parser, result.attributes);
+
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr, SymbolTable::getSymbolAttrName(),
+                             result.attributes))
+    return failure();
+
+  SmallVector<DPIArgDirection> argDirs;
+  SmallVector<StringAttr> argNames;
+  SmallVector<Type> argTypes;
+  SmallVector<Attribute> argLocs;
+  auto unknownLoc = builder.getUnknownLoc();
+  bool hasLocs = false;
+
+  auto parseOneArg = [&]() -> ParseResult {
+    StringRef dirKeyword;
+    auto keyLoc = parser.getCurrentLocation();
+    if (parser.parseKeyword(&dirKeyword))
+      return failure();
+    auto dir = parseDPIArgDirKeyword(dirKeyword);
+    if (!dir)
+      return parser.emitError(keyLoc,
+                              "expected DPI argument direction keyword");
+
+    // For input/inout args, parse SSA name; for output/return, bare name.
+    bool hasSSA = DPIFuncOp::isCallOperandDir(*dir);
+    std::string argName;
+    if (hasSSA) {
+      OpAsmParser::UnresolvedOperand ssaName;
+      if (parser.parseOperand(ssaName, /*allowResultNumber=*/false))
+        return failure();
+      argName = ssaName.name.substr(1).str();
+    } else {
+      if (parser.parseKeywordOrString(&argName))
+        return failure();
+    }
+
+    Type argType;
+    if (parser.parseColonType(argType))
+      return failure();
+
+    argDirs.push_back(*dir);
+    argNames.push_back(StringAttr::get(ctx, argName));
+    argTypes.push_back(argType);
+
+    std::optional<Location> maybeLoc;
+    if (failed(parser.parseOptionalLocationSpecifier(maybeLoc)))
+      return failure();
+    if (maybeLoc) {
+      argLocs.push_back(*maybeLoc);
+      hasLocs = true;
+    } else {
+      argLocs.push_back(unknownLoc);
+    }
+    return success();
+  };
+
+  if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseOneArg,
+                                     " in DPI argument list"))
+    return failure();
+
+  // Derive FunctionType from directions + types.
+  SmallVector<Type> inputTypes, resultTypes;
+  for (auto [dir, type] : llvm::zip(argDirs, argTypes)) {
+    if (DPIFuncOp::isCallOperandDir(dir))
+      inputTypes.push_back(type);
+    if (dir == DPIArgDirection::Out || dir == DPIArgDirection::InOut ||
+        dir == DPIArgDirection::Return)
+      resultTypes.push_back(type);
+  }
+  auto funcType = FunctionType::get(ctx, inputTypes, resultTypes);
+  result.addAttribute(DPIFuncOp::getFunctionTypeAttrName(result.name),
+                      TypeAttr::get(funcType));
+
+  // Store directions.
+  SmallVector<Attribute> dirAttrs;
+  for (auto d : argDirs)
+    dirAttrs.push_back(DPIArgDirectionAttr::get(ctx, d));
+  result.addAttribute(DPIFuncOp::getDpiArgDirsAttrName(result.name),
+                      builder.getArrayAttr(dirAttrs));
+
+  // Store argument names.
+  SmallVector<Attribute> nameAttrs(argNames.begin(), argNames.end());
+  result.addAttribute(DPIFuncOp::getDpiArgNamesAttrName(result.name),
+                      builder.getArrayAttr(nameAttrs));
+
+  if (hasLocs)
+    result.addAttribute(DPIFuncOp::getArgumentLocsAttrName(result.name),
+                        builder.getArrayAttr(argLocs));
+  result.addRegion();
+
+  if (failed(parser.parseOptionalAttrDictWithKeyword(result.attributes)))
+    return failure();
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// DPIFuncOp FunctionOpInterface
+//===----------------------------------------------------------------------===//
+
+::mlir::Type DPIFuncOp::cloneTypeWith(::mlir::TypeRange inputs,
+                                      ::mlir::TypeRange results) {
+  return FunctionType::get(getContext(), inputs, results);
+}
+
+void DPIFuncOp::getDPIArgTypes(SmallVectorImpl<Type> &argTypes) {
+  auto funcType = getFunctionType();
+  auto inputs = funcType.getInputs();
+  auto results = funcType.getResults();
+  auto dirs = getDpiArgDirsAttr();
+  unsigned inputIdx = 0, resultIdx = 0;
+  for (auto dirAttr : dirs) {
+    auto dir = cast<DPIArgDirectionAttr>(dirAttr).getValue();
+    switch (dir) {
+    case DPIArgDirection::In:
+      argTypes.push_back(inputs[inputIdx++]);
+      break;
+    case DPIArgDirection::Out:
+      argTypes.push_back(results[resultIdx++]);
+      break;
+    case DPIArgDirection::InOut:
+      argTypes.push_back(inputs[inputIdx++]);
+      resultIdx++;
+      break;
+    case DPIArgDirection::Return:
+      argTypes.push_back(results[resultIdx++]);
+      break;
+    }
+  }
+}
+
+LogicalResult DPIFuncOp::verify() {
+  auto dirs = getDpiArgDirs();
+  auto names = getDpiArgNames();
+  if (dirs.size() != names.size())
+    return emitOpError("argument directions and names must have the same size");
+
+  // Check return constraints: at most one, must be last.
+  bool seenReturn = false;
+  for (auto [i, dirAttr] : llvm::enumerate(dirs)) {
+    auto dir = cast<DPIArgDirectionAttr>(dirAttr).getValue();
+    if (dir == DPIArgDirection::Return) {
+      if (seenReturn)
+        return emitOpError("'return' argument must be the last argument");
+      if (i != dirs.size() - 1)
+        return emitOpError("'return' argument must be the last argument");
+      seenReturn = true;
+    }
+  }
+  return success();
+}
+
+void DPIFuncOp::print(OpAsmPrinter &p) {
+  p << ' ';
+
+  StringRef visibilityAttrName = SymbolTable::getVisibilityAttrName();
+  if (auto visibility = (*this)->getAttrOfType<StringAttr>(visibilityAttrName))
+    p << visibility.getValue() << ' ';
+  p.printSymbolName(getSymName());
+
+  auto dirs = getDpiArgDirs();
+  auto names = getDpiArgNames();
+  SmallVector<Type> argTypes;
+  getDPIArgTypes(argTypes);
+
+  p << '(';
+  llvm::interleaveComma(llvm::enumerate(dirs), p, [&](auto it) {
+    auto dir = cast<DPIArgDirectionAttr>(it.value()).getValue();
+    auto i = it.index();
+    auto name = cast<StringAttr>(names[i]).getValue();
+    auto type = argTypes[i];
+
+    p << stringifyDPIArgDir(dir) << ' ';
+
+    if (isCallOperandDir(dir))
+      p << '%';
+    p.printKeywordOrString(name);
+    p << " : ";
+    p.printType(type);
+
+    if (getArgumentLocs()) {
+      auto loc = cast<Location>(getArgumentLocsAttr()[i]);
+      if (loc != UnknownLoc::get(getContext()))
+        p.printOptionalLocationSpecifier(loc);
+    }
+  });
+  p << ')';
+
+  mlir::function_interface_impl::printFunctionAttributes(
+      p, *this,
+      {visibilityAttrName, getFunctionTypeAttrName(), getDpiArgDirsAttrName(),
+       getDpiArgNamesAttrName(), getArgumentLocsAttrName()});
+}
+
+LogicalResult
+FuncDPICallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto referencedOp =
+      symbolTable.lookupNearestSymbolFrom(*this, getCalleeAttr());
+  if (!referencedOp)
+    return emitError("cannot find function declaration '")
+           << getCallee() << "'";
+  if (auto dpiFunc = dyn_cast<DPIFuncOp>(referencedOp)) {
+    auto funcType = cast<FunctionType>(dpiFunc.getFunctionType());
+    auto expectedInputs = funcType.getInputs();
+    auto expectedResults = funcType.getResults();
+    if (getInputs().size() != expectedInputs.size())
+      return emitError("expects ")
+             << expectedInputs.size() << " DPI operands, but got "
+             << getInputs().size();
+    if (getResults().size() != expectedResults.size())
+      return emitError("expects ")
+             << expectedResults.size() << " DPI results, but got "
+             << getResults().size();
+    for (auto [operand, expectedType] : llvm::zip(getInputs(), expectedInputs))
+      if (operand.getType() != expectedType)
+        return emitError("operand type mismatch: expected ")
+               << expectedType << ", but got " << operand.getType();
+    for (auto [result, expectedType] : llvm::zip(getResults(), expectedResults))
+      if (result.getType() != expectedType)
+        return emitError("result type mismatch: expected ")
+               << expectedType << ", but got " << result.getType();
+    return success();
+  }
+  if (isa<func::FuncOp>(referencedOp))
+    return success();
+  return emitError("callee must be 'moore.func.dpi' or 'func.func' but got '")
+         << referencedOp->getName() << "'";
+}
+
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4763,31 +4763,41 @@ endmodule
 
 // Test that DPI-C imported functions are emitted as extern declarations
 
-// CHECK:  func.func private @void_dpi(!moore.i32)
+// CHECK:  moore.func.dpi private @void_dpi(in %a : !moore.i32)
 // CHECK-NOT: return
 
-// CHECK:  func.func private @nonvoid_dpi(!moore.i32) -> !moore.i32
+// CHECK:  moore.func.dpi private @nonvoid_dpi(in %a : !moore.i32, return return : !moore.i32)
 // CHECK-NOT: return
 
-// CHECK:  func.func private @dpi_with_output(!moore.i32, !moore.ref<i32>)
+// CHECK:  moore.func.dpi private @dpi_with_output(in %a : !moore.i32, out b : !moore.i32)
+// CHECK-NOT: return
+
+// CHECK:  moore.func.dpi private @dpi_inout(in %a : !moore.i32, inout %b : !moore.i32, return return : !moore.i32)
 // CHECK-NOT: return
 
 import "DPI-C" function void void_dpi(input int a);
 import "DPI-C" function int nonvoid_dpi(input int a);
 import "DPI-C" function void dpi_with_output(input int a, output int b);
+import "DPI-C" function int dpi_inout(input int a, inout int b);
 
 // CHECK-LABEL: moore.module @DpiCallTest
 module DpiCallTest(input int in_val, output int out_val);
   int result;
+  int state;
 
-  // CHECK: func.call @void_dpi
-  // CHECK: func.call @nonvoid_dpi
-  // CHECK: func.call @dpi_with_output
+  // CHECK: moore.func.dpi.call @void_dpi
+  // CHECK: %[[NV:.*]] = moore.func.dpi.call @nonvoid_dpi(%{{.*}}) : (!moore.i32) -> !moore.i32
+  // CHECK: %[[OUT:.*]] = moore.func.dpi.call @dpi_with_output(%{{.*}}) : (!moore.i32) -> !moore.i32
+  // CHECK: moore.blocking_assign %{{.*}}, %[[OUT]] : i32
+  // CHECK: %[[INOUT:.*]]:2 = moore.func.dpi.call @dpi_inout(%{{.*}}, %{{.*}}) : (!moore.i32, !moore.i32) -> (!moore.i32, !moore.i32)
+  // CHECK: moore.blocking_assign %{{.*}}, %[[INOUT]]#0 : i32
+  // CHECK: moore.blocking_assign %{{.*}}, %[[INOUT]]#1 : i32
 
   always_comb begin
     void_dpi(in_val);
     result = nonvoid_dpi(in_val);
     dpi_with_output(in_val, result);
+    state = dpi_inout(in_val, result);
   end
 
   assign out_val = result;
@@ -4798,8 +4808,8 @@ endmodule
 import "DPI-C" function chandle chandle_init(input int size);
 import "DPI-C" function void chandle_tick(input chandle ctx, input int a);
 
-// CHECK: func.func private @chandle_init(!moore.i32) -> !moore.chandle
-// CHECK: func.func private @chandle_tick(!moore.chandle, !moore.i32)
+// CHECK: moore.func.dpi private @chandle_init(in %size : !moore.i32, return return : !moore.chandle)
+// CHECK: moore.func.dpi private @chandle_tick(in %ctx : !moore.chandle, in %a : !moore.i32)
 
 // CHECK-LABEL: moore.module @ChandleTest
 module ChandleTest(input logic clock, input int in_val);
@@ -4817,16 +4827,16 @@ endmodule
 // Test that DPI-C open array types (byte[], int[]) are converted to
 // Moore open array types (!moore.open_uarray<T>).
 
-// CHECK: func.func private @process_data(!moore.open_uarray<i8>)
+// CHECK: moore.func.dpi private @process_data(in %data : !moore.open_uarray<i8>)
 import "DPI-C" function void process_data(input byte data[]);
 
-// CHECK: func.func private @read_write(!moore.open_uarray<i8>, !moore.ref<open_uarray<i8>>)
+// CHECK: moore.func.dpi private @read_write(in %wd : !moore.open_uarray<i8>, out rd : !moore.open_uarray<i8>)
 import "DPI-C" function void read_write(input byte wd[], output byte rd[]);
 
-// CHECK: func.func private @int_array_fn(!moore.open_uarray<i32>)
+// CHECK: moore.func.dpi private @int_array_fn(in %data : !moore.open_uarray<i32>)
 import "DPI-C" function void int_array_fn(input int data[]);
 
-// CHECK: func.func private @packed_bits_fn(!moore.open_array<i1>)
+// CHECK: moore.func.dpi private @packed_bits_fn(in %data : !moore.open_array<i1>)
 import "DPI-C" function void packed_bits_fn(input bit [] data);
 
 // CHECK-LABEL: moore.module @OpenArrayCallTest
@@ -4836,10 +4846,12 @@ module OpenArrayCallTest(input logic clock);
   int idata[];
   bit [7:0] pdata;
 
-  // CHECK: func.call @process_data
-  // CHECK: func.call @read_write
-  // CHECK: func.call @int_array_fn
-  // CHECK: func.call @packed_bits_fn
+  // CHECK: moore.func.dpi.call @process_data
+  // CHECK: %[[RW_RES:.*]] = moore.func.dpi.call @read_write(%{{.*}}) : (!moore.open_uarray<i8>) -> !moore.open_uarray<i8>
+  // CHECK: moore.blocking_assign %result, %[[RW_RES]]
+  // CHECK: moore.func.dpi.call @int_array_fn
+  // CHECK: %[[PD:.*]] = moore.conversion %{{.*}} : !moore.i8 -> !moore.open_array<i1>
+  // CHECK: moore.func.dpi.call @packed_bits_fn(%[[PD]]) : (!moore.open_array<i1>) -> ()
   always @(posedge clock) begin
     process_data(mydata);
     read_write(mydata, result);

--- a/test/Conversion/MooreToCore/moore-dpi-call-lowering.mlir
+++ b/test/Conversion/MooreToCore/moore-dpi-call-lowering.mlir
@@ -1,0 +1,61 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// Verify that moore.func.dpi and moore.func.dpi.call lower to sim.func.dpi and
+// sim.func.dpi.call during MooreToCore conversion, with types converted from
+// Moore to Core.
+
+moore.func.dpi private @dpi_add(in %a : !moore.i32, in %b : !moore.i32, return return : !moore.i32)
+
+// CHECK: sim.func.dpi private @dpi_add(in %a : i32, in %b : i32, return return : i32)
+
+moore.func.dpi private @dpi_out(in %val : !moore.i32, out dst : !moore.i32)
+
+// CHECK: sim.func.dpi private @dpi_out(in %val : i32, out dst : i32)
+
+moore.func.dpi private @dpi_inout_ret(in %val : !moore.i32, inout %state : !moore.i32, return return : !moore.i32)
+
+// CHECK: sim.func.dpi private @dpi_inout_ret(in %val : i32, inout %state : i32, return return : i32)
+
+moore.func.dpi private @dpi_open_array(in %wd : !moore.open_uarray<i8>, out rd : !moore.open_uarray<i8>)
+
+// CHECK: sim.func.dpi private @dpi_open_array(in %wd : !llvm.ptr, out rd : !llvm.ptr)
+
+// CHECK-LABEL: hw.module @DpiConvTest
+moore.module @DpiConvTest(in %in_a : !moore.i32, in %in_b : !moore.i32, out result : !moore.i32) {
+  // CHECK: sim.func.dpi.call @dpi_add(%in_a, %in_b) : (i32, i32) -> i32
+  %0 = moore.func.dpi.call @dpi_add(%in_a, %in_b) : (!moore.i32, !moore.i32) -> !moore.i32
+  moore.output %0 : !moore.i32
+}
+
+// CHECK-LABEL: hw.module @DpiOutTest
+moore.module @DpiOutTest(in %val : !moore.i32, out result : !moore.i32) {
+  // CHECK: sim.func.dpi.call @dpi_out(%val) : (i32) -> i32
+  %0 = moore.func.dpi.call @dpi_out(%val) : (!moore.i32) -> !moore.i32
+  moore.output %0 : !moore.i32
+}
+
+// CHECK-LABEL: hw.module @DpiInoutRetTest
+moore.module @DpiInoutRetTest(in %val : !moore.i32, in %state : !moore.i32, out state_out : !moore.i32, out ret_out : !moore.i32) {
+  // CHECK: sim.func.dpi.call @dpi_inout_ret(%val, %state) : (i32, i32) -> (i32, i32)
+  %0:2 = moore.func.dpi.call @dpi_inout_ret(%val, %state) : (!moore.i32, !moore.i32) -> (!moore.i32, !moore.i32)
+  moore.output %0#0, %0#1 : !moore.i32, !moore.i32
+}
+
+// CHECK-LABEL: func.func @call_dpi_open_array
+func.func @call_dpi_open_array(%wd: !moore.uarray<8 x i8>, %rd: !moore.ref<uarray<8 x i8>>) {
+  %0 = moore.conversion %wd : !moore.uarray<8 x i8> -> !moore.open_uarray<i8>
+  // CHECK: sim.func.dpi.call @dpi_open_array(%{{.*}}) : (!llvm.ptr) -> !llvm.ptr
+  %1 = moore.func.dpi.call @dpi_open_array(%0) : (!moore.open_uarray<i8>) -> !moore.open_uarray<i8>
+  return
+}
+
+moore.func.dpi private @dpi_void(in %val : !moore.i32)
+
+// CHECK: sim.func.dpi private @dpi_void(in %val : i32)
+
+// CHECK-LABEL: hw.module @DpiVoidTest
+moore.module @DpiVoidTest(in %val : !moore.i32) {
+  // CHECK: sim.func.dpi.call @dpi_void(%val) : (i32) -> ()
+  moore.func.dpi.call @dpi_void(%val) : (!moore.i32) -> ()
+  moore.output
+}

--- a/test/Dialect/Moore/errors.mlir
+++ b/test/Dialect/Moore/errors.mlir
@@ -179,6 +179,16 @@ moore.global_variable @Foo : !moore.i42 init {
 
 // -----
 
+// expected-error @below {{'return' argument must be the last argument}}
+moore.func.dpi @dpi_bad_return_pos(return ret : !moore.i32, in %other : !moore.i32)
+
+// -----
+
+// expected-error @below {{'return' argument must be the last argument}}
+moore.func.dpi @dpi_bad_multi_return(return a : !moore.i32, return b : !moore.i32)
+
+// -----
+
 // UnionCreateOp verifier: input type mismatch
 %0 = moore.constant 42 : i16
 // expected-error @below {{op input type '!moore.i16' does not match union field 'x' type '!moore.i32'}}

--- a/test/circt-verilog/dpi-extern-decl.sv
+++ b/test/circt-verilog/dpi-extern-decl.sv
@@ -7,9 +7,9 @@
 
 // --- HW-level checks: declarations survive lowering with correct types ---
 
-// CHECK-DAG: func.func private @void_dpi(i32)
-// CHECK-DAG: func.func private @nonvoid_dpi(i32) -> i32
-// CHECK-DAG: func.func private @dpi_with_output(i32, !llhd.ref<i32>)
+// CHECK-DAG: sim.func.dpi private @void_dpi(in %a : i32)
+// CHECK-DAG: sim.func.dpi private @nonvoid_dpi(in %a : i32, return return : i32)
+// CHECK-DAG: sim.func.dpi private @dpi_with_output(in %a : i32, out b : i32)
 
 import "DPI-C" function void void_dpi(input int a);
 import "DPI-C" function int nonvoid_dpi(input int a);
@@ -19,9 +19,9 @@ import "DPI-C" function void dpi_with_output(input int a, output int b);
 module DpiCallTest(input int in_val, output int out_val);
   int result;
 
-  // CHECK: func.call @void_dpi
-  // CHECK: func.call @nonvoid_dpi
-  // CHECK: func.call @dpi_with_output
+  // CHECK: sim.func.dpi.call @void_dpi
+  // CHECK: sim.func.dpi.call @nonvoid_dpi
+  // CHECK: sim.func.dpi.call @dpi_with_output
 
   always_comb begin
     void_dpi(in_val);
@@ -37,8 +37,8 @@ endmodule
 import "DPI-C" function chandle chandle_init(input int size);
 import "DPI-C" function void chandle_tick(input chandle ctx, input int a);
 
-// CHECK: func.func private @chandle_init(i32) -> !llvm.ptr
-// CHECK: func.func private @chandle_tick(!llvm.ptr, i32)
+// CHECK: sim.func.dpi private @chandle_init(in %size : i32, return return : !llvm.ptr)
+// CHECK: sim.func.dpi private @chandle_tick(in %ctx : !llvm.ptr, in %a : i32)
 
 // CHECK-LABEL: hw.module @ChandleTest
 module ChandleTest(input logic clock, input int in_val);


### PR DESCRIPTION
# Description

Add moore.func.dpi and moore.func.dpi.call ops with a Moore-local
DPIArgDirection enum (in/out/inout/return) and DPIArgInfo struct,
decoupled from the Sim dialect. DPI-C imports are lowered through this
path, preserving DPI semantics (explicit return values, output/inout
arguments) through the Moore→Sim lowering pipeline.

- MooreOps: DPIFuncOp stores FunctionType + dpi_arg_dirs + dpi_arg_names
  with custom parser/printer. Implements FunctionOpInterface.
  FuncDPICallOp models call sites with typed operands/results.
- ImportVerilog: FunctionLowering is a plain data struct holding a
  FunctionOpInterface;
  getDPISignature() builds DPIArgInfo from Slang AST; 'ref' direction
  asserts (illegal for DPI per IEEE 1800).
- MooreToCore: DPIFuncOpConversion reconstructs sim::DPIFunctionType
  from Moore's argument arrays and lowers to sim::DPIFuncOp.
  FuncDPICallOpConversion lowers to sim::DPICallOp.
- Tests: DPI declaration, call-site, open-array, chandle, and
  out/inout result-capture patterns covered in basic.sv.
  Full-pipeline HW-level checks in dpi-extern-decl.sv.
  MooreToCore lowering tested in moore-dpi-call-lowering.mlir.
  Error cases in errors.mlir.

AI-Assisted-by: GitHub Copilot CLI with GPT-5.4 and Claude Opus 4.6

This is the second of a 2 PR series introducing full sematic preserving DPI calls from SystemVerilog through Moore to Sim.
See: #9977 