### PR TITLE
[1/4] [MooreToCore] Add stable class object header layout, introduce RTTI slot

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -54,6 +54,11 @@ namespace {
 struct ClassTypeCache {
   struct ClassStructInfo {
     LLVM::LLVMStructType classBody;
+    LLVM::LLVMStructType headerTy;
+
+    unsigned headerFieldIndex = 0;
+    unsigned typeInfoFieldIndex = 0;
+    unsigned vtableFieldIndex = 1;
 
     // field name -> GEP path inside ident (excluding the leading pointer index)
     DenseMap<StringRef, SmallVector<unsigned, 2>> propertyPath;
@@ -145,6 +150,13 @@ static LLVM::LLVMStructType getOrCreateOpaqueStruct(MLIRContext *ctx,
   return LLVM::LLVMStructType::getIdentified(ctx, className.getRootReference());
 }
 
+/// Create the canonical object header for lowered Moore class objects.
+static LLVM::LLVMStructType getClassObjectHeaderType(MLIRContext *ctx) {
+  return LLVM::LLVMStructType::getLiteral(
+      ctx, SmallVector<Type>{LLVM::LLVMPointerType::get(ctx),
+                             LLVM::LLVMPointerType::get(ctx)});
+}
+
 static LogicalResult resolveClassStructBody(ClassDeclOp op,
                                             TypeConverter const &typeConverter,
                                             ClassTypeCache &cache) {
@@ -158,9 +170,11 @@ static LogicalResult resolveClassStructBody(ClassDeclOp op,
   // Otherwise we need to resolve.
   ClassTypeCache::ClassStructInfo structBody;
   SmallVector<Type> structBodyMembers;
+  structBody.headerTy = getClassObjectHeaderType(op.getContext());
+  structBodyMembers.push_back(structBody.headerTy);
 
   // Base-first (prefix) layout for single inheritance.
-  unsigned derivedStartIdx = 0;
+  unsigned derivedStartIdx = 1;
 
   if (auto baseClass = op.getBaseAttr()) {
 
@@ -174,12 +188,13 @@ static LogicalResult resolveClassStructBody(ClassDeclOp op,
     // Process base class' struct layout first
     auto baseClassStruct = cache.getStructInfo(baseClass);
     structBodyMembers.push_back(baseClassStruct->classBody);
-    derivedStartIdx = 1;
+    derivedStartIdx = 2;
 
-    // Inherit base field paths with a leading 0.
+    // Inherit base field paths with a leading 1 to index into the base
+    // subobject after the object header.
     for (auto &kv : baseClassStruct->propertyPath) {
       SmallVector<unsigned, 2> path;
-      path.push_back(0); // into base subobject
+      path.push_back(1); // into base subobject
       path.append(kv.second.begin(), kv.second.end());
       structBody.setFieldPath(kv.first, path);
     }

--- a/test/Conversion/MooreToCore/classes.mlir
+++ b/test/Conversion/MooreToCore/classes.mlir
@@ -21,7 +21,7 @@ func.func @ClassType(%arg0: !moore.class<@PropertyCombo>) {
 /// Check that new lowers to malloc
 
 // CHECK-LABEL: func.func private @test_new2
-// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(12 : i64) : i64
+// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(32 : i64) : i64
 // CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
 // CHECK:   return
 
@@ -43,7 +43,7 @@ moore.class.classdecl @C {
 /// Check that new lowers to malloc with inheritance without shadowing
 
 // CHECK-LABEL: func.func private @test_new3
-// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(28 : i64) : i64
+// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(64 : i64) : i64
 // CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
 // CHECK:   return
 
@@ -63,7 +63,7 @@ moore.class.classdecl @D extends @C {
 /// Check that new lowers to malloc with inheritance & shadowing
 
 // CHECK-LABEL: func.func private @test_new4
-// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(24 : i64) : i64
+// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(64 : i64) : i64
 // CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
 // CHECK:   return
 
@@ -104,8 +104,8 @@ moore.class.classdecl @F extends @C {
 
 // CHECK-LABEL: func.func private @test_new6
 // CHECK-SAME: (%arg0: !llvm.ptr) -> !llhd.ref<i32> {
-// CHECK:   [[CONSTIDX:%.+]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:   [[GEP:%.+]] = llvm.getelementptr %arg0[[[CONSTIDX]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"G", (struct<"C", (i32, i32, i32)>, i32, i32, i32)>
+// CHECK:   [[CONSTIDX:%.+]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:   [[GEP:%.+]] = llvm.getelementptr %arg0[[[CONSTIDX]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"G", (struct<(ptr, ptr)>, struct<"C", (struct<(ptr, ptr)>, i32, i32, i32)>, i32, i32, i32)>
 // CHECK:   [[CONV:%.+]] = builtin.unrealized_conversion_cast [[GEP]] : !llvm.ptr to !llhd.ref<i32>
 // CHECK:   return [[CONV]] : !llhd.ref<i32>
 
@@ -120,4 +120,20 @@ moore.class.classdecl @G extends @C {
   moore.class.propertydecl @d : !moore.i32
   moore.class.propertydecl @e : !moore.l32
   moore.class.propertydecl @f : !moore.l32
+}
+
+/// Check that virtual classes use the same object header layout.
+
+// CHECK-LABEL: func.func private @test_new7
+// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(24 : i64) : i64
+// CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   return
+
+func.func private @test_new7() {
+  %h = moore.class.new : <@VirtualC>
+  return
+}
+moore.class.classdecl @VirtualC {
+  moore.class.propertydecl @a : !moore.i32
+  moore.class.methoddecl @f : (!moore.class<@VirtualC>) -> ()
 }


### PR DESCRIPTION
Introduce a canonical two-pointer header (runtime type info (RTTI) + vtable) for all lowered Moore class objects and make class layout uniformly header-first.

This changes the lowered object ABI to prepend a header struct to every class object, shifts derived property indices accordingly, and keeps base subobjects after the header in single-inheritance layouts. The cache now tracks header type and field indices explicitly so later RTTI / vtable lowering can build on a stable layout.

Update MooreToCore tests to cover the new allocation sizes, adjusted property-ref GEP indices, and a virtual-class allocation case using the same canonical header layout.

Co-authored with the help of the holidays and ample coffee.