### PR TITLE
[2/4] [MooreToCore] Materialize class RTTI globals

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -52,9 +52,14 @@ namespace {
 
 /// Cache for identified structs and field GEP paths keyed by class symbol.
 struct ClassTypeCache {
+  struct TypeInfoInfo {
+    LLVM::GlobalOp global;
+  };
+
   struct ClassStructInfo {
     LLVM::LLVMStructType classBody;
     LLVM::LLVMStructType headerTy;
+    TypeInfoInfo typeInfo;
 
     unsigned headerFieldIndex = 0;
     unsigned typeInfoFieldIndex = 0;
@@ -94,11 +99,23 @@ struct ClassTypeCache {
     return std::nullopt;
   }
 
+  std::optional<TypeInfoInfo> getTypeInfo(SymbolRefAttr classSym) const {
+    if (auto it = classToTypeInfoMap.find(classSym);
+        it != classToTypeInfoMap.end())
+      return it->second;
+    return std::nullopt;
+  }
+
+  void setTypeInfo(SymbolRefAttr classSym, const TypeInfoInfo &info) {
+    classToTypeInfoMap[classSym] = info;
+  }
+
 private:
   // Keyed by the SymbolRefAttr of the class.
   // Kept private so all accesses are done with helpers which preserve
   // invariants
   DenseMap<Attribute, ClassStructInfo> classToStructMap;
+  DenseMap<Attribute, TypeInfoInfo> classToTypeInfoMap;
 };
 
 /// Cache for external function declarations. Avoids redundant symbol table
@@ -157,6 +174,66 @@ static LLVM::LLVMStructType getClassObjectHeaderType(MLIRContext *ctx) {
                              LLVM::LLVMPointerType::get(ctx)});
 }
 
+static std::string getTypeInfoName(SymbolRefAttr className) {
+  return className.getRootReference().str() + "::typeinfo";
+}
+
+static FailureOr<ClassTypeCache::TypeInfoInfo>
+getOrCreateTypeInfo(ModuleOp mod, SymbolRefAttr classSym,
+                    ClassTypeCache &cache) {
+  if (auto info = cache.getTypeInfo(classSym))
+    return *info;
+
+  MLIRContext *ctx = mod.getContext();
+  auto ptrTy = LLVM::LLVMPointerType::get(ctx);
+  auto typeInfoTy = LLVM::LLVMStructType::getLiteral(ctx, {ptrTy});
+
+  auto globalName = getTypeInfoName(classSym);
+  auto global = mod.lookupSymbol<LLVM::GlobalOp>(globalName);
+  if (!global) {
+    OpBuilder builder = OpBuilder::atBlockBegin(mod.getBody());
+    global = LLVM::GlobalOp::create(
+        builder, mod.getLoc(), typeInfoTy,
+        /*isConstant=*/true, LLVM::Linkage::Internal, globalName, Attribute());
+
+    Block *block = new Block();
+    global.getInitializerRegion().push_back(block);
+    builder.setInsertionPointToStart(block);
+
+    if (auto *classOp = mod.lookupSymbol(classSym)) {
+      auto classDecl = dyn_cast<ClassDeclOp>(classOp);
+      if (classDecl && classDecl.getBaseAttr()) {
+        auto baseInfo =
+            getOrCreateTypeInfo(mod, classDecl.getBaseAttr(), cache);
+        if (failed(baseInfo))
+          return failure();
+        auto baseAddr =
+            LLVM::AddressOfOp::create(builder, mod.getLoc(), baseInfo->global);
+        auto undef = LLVM::UndefOp::create(builder, mod.getLoc(), typeInfoTy)
+                         .getResult();
+        auto init = LLVM::InsertValueOp::create(builder, mod.getLoc(), undef,
+                                                baseAddr.getResult(),
+                                                ArrayRef<int64_t>{0});
+        LLVM::ReturnOp::create(builder, mod.getLoc(), init);
+        ClassTypeCache::TypeInfoInfo info{global};
+        cache.setTypeInfo(classSym, info);
+        return info;
+      }
+    }
+
+    auto undef =
+        LLVM::UndefOp::create(builder, mod.getLoc(), typeInfoTy).getResult();
+    auto nullPtr =
+        LLVM::ZeroOp::create(builder, mod.getLoc(), ptrTy).getResult();
+    auto init = LLVM::InsertValueOp::create(builder, mod.getLoc(), undef,
+                                            nullPtr, ArrayRef<int64_t>{0});
+    LLVM::ReturnOp::create(builder, mod.getLoc(), init);
+  }
+
+  ClassTypeCache::TypeInfoInfo info{global};
+  cache.setTypeInfo(classSym, info);
+  return info;
+}
 static LogicalResult resolveClassStructBody(ClassDeclOp op,
                                             TypeConverter const &typeConverter,
                                             ClassTypeCache &cache) {
@@ -167,10 +244,15 @@ static LogicalResult resolveClassStructBody(ClassDeclOp op,
     // We already have a resolved class struct body.
     return success();
 
+  if (failed(getOrCreateTypeInfo(op->getParentOfType<ModuleOp>(), classSym,
+                                 cache)))
+    return op.emitOpError() << "Failed to create RTTI for class";
+
   // Otherwise we need to resolve.
   ClassTypeCache::ClassStructInfo structBody;
   SmallVector<Type> structBodyMembers;
   structBody.headerTy = getClassObjectHeaderType(op.getContext());
+  structBody.typeInfo = *cache.getTypeInfo(classSym);
   structBodyMembers.push_back(structBody.headerTy);
 
   // Base-first (prefix) layout for single inheritance.
@@ -989,6 +1071,7 @@ struct ClassNewOpConversion : public OpConversionPattern<ClassNewOp> {
       return op.emitError() << "Could not resolve class struct for " << sym;
 
     auto structTy = cache.getStructInfo(sym)->classBody;
+    auto typeInfo = cache.getStructInfo(sym)->typeInfo;
 
     // Check that all struct members have data layout support. Types like
     // !sim.dstring or !sim.queue don't have a known size, which would cause
@@ -1013,6 +1096,21 @@ struct ClassNewOpConversion : public OpConversionPattern<ClassNewOp> {
     auto mallocFn = funcCache.getOrCreate(rewriter, "malloc", {i64Ty}, {ptrTy});
     auto call =
         func::CallOp::create(rewriter, loc, mallocFn, ValueRange{cSize});
+
+    auto typeInfoAddr =
+        LLVM::AddressOfOp::create(rewriter, loc, typeInfo.global);
+    auto i32Ty = IntegerType::get(ctx, 32);
+    auto headerIdx = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty,
+        rewriter.getI32IntegerAttr(cache.getStructInfo(sym)->headerFieldIndex));
+    auto typeInfoIdx = LLVM::ConstantOp::create(
+        rewriter, loc, i32Ty,
+        rewriter.getI32IntegerAttr(
+            cache.getStructInfo(sym)->typeInfoFieldIndex));
+    auto headerPtr =
+        LLVM::GEPOp::create(rewriter, loc, ptrTy, structTy, call.getResult(0),
+                            ValueRange{headerIdx, typeInfoIdx});
+    LLVM::StoreOp::create(rewriter, loc, typeInfoAddr, headerPtr);
 
     // Replace the new op with the malloc pointer (no cast needed with opaque
     // ptrs).

--- a/test/Conversion/MooreToCore/classes.mlir
+++ b/test/Conversion/MooreToCore/classes.mlir
@@ -1,5 +1,15 @@
 // RUN: circt-opt %s --convert-moore-to-core --verify-diagnostics | FileCheck %s
 
+// CHECK-DAG: llvm.mlir.global internal constant @"C::typeinfo"() {addr_space = 0 : i32} : !llvm.struct<(ptr)> {
+// CHECK-DAG: llvm.mlir.zero : !llvm.ptr
+// CHECK-DAG: llvm.insertvalue
+// CHECK-DAG: llvm.mlir.global internal constant @"D::typeinfo"() {addr_space = 0 : i32} : !llvm.struct<(ptr)> {
+// CHECK-DAG: llvm.mlir.addressof @"C::typeinfo" : !llvm.ptr
+// CHECK-DAG: llvm.insertvalue
+// CHECK-DAG: llvm.mlir.global internal constant @"VirtualC::typeinfo"() {addr_space = 0 : i32} : !llvm.struct<(ptr)> {
+// CHECK-DAG: llvm.mlir.zero : !llvm.ptr
+// CHECK-DAG: llvm.insertvalue
+
 /// Check that a classdecl gets noop'd and handles are lowered to !llvm.ptr
 
 // CHECK-LABEL:   func.func @ClassType(%arg0: !llvm.ptr) {
@@ -23,6 +33,10 @@ func.func @ClassType(%arg0: !moore.class<@PropertyCombo>) {
 // CHECK-LABEL: func.func private @test_new2
 // CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(32 : i64) : i64
 // CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   [[TYPEINFO:%.*]] = llvm.mlir.addressof @"C::typeinfo" : !llvm.ptr
+// CHECK:   [[HEADERIDX:%.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:   [[GEP:%.*]] = llvm.getelementptr [[PTR]][[[HEADERIDX]], 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"C", (struct<(ptr, ptr)>, i32, i32, i32)>
+// CHECK:   llvm.store [[TYPEINFO]], [[GEP]] : !llvm.ptr, !llvm.ptr
 // CHECK:   return
 
 // CHECK-NOT: moore.class.new
@@ -45,6 +59,10 @@ moore.class.classdecl @C {
 // CHECK-LABEL: func.func private @test_new3
 // CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(64 : i64) : i64
 // CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   [[TYPEINFO:%.*]] = llvm.mlir.addressof @"D::typeinfo" : !llvm.ptr
+// CHECK:   [[HEADERIDX:%.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:   [[GEP:%.*]] = llvm.getelementptr [[PTR]][[[HEADERIDX]], 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"D", (struct<(ptr, ptr)>, struct<"C", (struct<(ptr, ptr)>, i32, i32, i32)>, i32, i64, i16)>
+// CHECK:   llvm.store [[TYPEINFO]], [[GEP]] : !llvm.ptr, !llvm.ptr
 // CHECK:   return
 
 // CHECK-NOT: moore.class.new
@@ -127,6 +145,10 @@ moore.class.classdecl @G extends @C {
 // CHECK-LABEL: func.func private @test_new7
 // CHECK:   [[SIZE:%.*]] = llvm.mlir.constant(24 : i64) : i64
 // CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   [[TYPEINFO:%.*]] = llvm.mlir.addressof @"VirtualC::typeinfo" : !llvm.ptr
+// CHECK:   [[HEADERIDX:%.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:   [[GEP:%.*]] = llvm.getelementptr [[PTR]][[[HEADERIDX]], 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"VirtualC", (struct<(ptr, ptr)>, i32)>
+// CHECK:   llvm.store [[TYPEINFO]], [[GEP]] : !llvm.ptr, !llvm.ptr
 // CHECK:   return
 
 func.func private @test_new7() {


### PR DESCRIPTION
Add per-class RTTI globals and initialize the object header's type-info
slot during class allocation.

This extends the class type cache with RTTI metadata, synthesizes a
`Class::typeinfo` global for each class, and links derived-class RTTI to
its base class RTTI. `moore.class.new` now stores the address of the
class RTTI global into the canonical object header so later runtime type
checks and casts can use a stable type identity.

Update MooreToCore tests to check RTTI global emission, base-linkage for
derived classes, and type-info header initialization for regular,
derived, and virtual classes.