### PR TITLE
[FIRRTL] Fix C++20 incomplete type error in FIRRTLAnnotationsGen

### DIFF
--- a/tools/circt-tblgen/FIRRTLAnnotationsGen.cpp
+++ b/tools/circt-tblgen/FIRRTLAnnotationsGen.cpp
@@ -74,7 +74,7 @@ struct ObjectType {
 
   static StringRef getJSONTypeName() { return "object"; }
   StringRef getDescription() const { return description; }
-  ArrayRef<Parameter> getFields() const { return fields; }
+  ArrayRef<Parameter> getFields() const;
 };
 
 /// Annotation type - references another annotation definition as a member type.
@@ -124,6 +124,8 @@ struct Parameter {
         type);
   }
 };
+
+inline ArrayRef<Parameter> ObjectType::getFields() const { return fields; }
 
 //===----------------------------------------------------------------------===//
 // TargetTypeDef


### PR DESCRIPTION
Apple Clang with C++20 strictly enforces incomplete type rules on `std::vector`. This fixes the build failure by moving the definition of `ObjectType::getFields()` after `Parameter` is fully defined.