### PR TITLE
[Moore][ImportVerilog] Implement static $cast via materializeConversion

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2711,7 +2711,7 @@ Value Context::convertToSimpleBitVector(Value value) {
 /// corresponding simple bit vector `IntType`. This will apply special handling
 /// to time values, which requires scaling by the local timescale.
 static Value materializePackedToSBVConversion(Context &context, Value value,
-                                              Location loc) {
+                                              Location loc, bool fallible) {
   if (isa<moore::IntType>(value.getType()))
     return value;
 
@@ -2734,9 +2734,10 @@ static Value materializePackedToSBVConversion(Context &context, Value value,
   // `TimeType` fields. These require special conversion to ensure that the
   // local timescale is in effect.
   if (packedType.containsTimeType()) {
-    mlir::emitError(loc) << "unsupported conversion: " << packedType
-                         << " cannot be converted to " << intType
-                         << "; contains a time type";
+    if (!fallible)
+      mlir::emitError(loc) << "unsupported conversion: " << packedType
+                           << " cannot be converted to " << intType
+                           << "; contains a time type";
     return {};
   }
 
@@ -2749,7 +2750,8 @@ static Value materializePackedToSBVConversion(Context &context, Value value,
 /// time values, which requires scaling by the local timescale.
 static Value materializeSBVToPackedConversion(Context &context,
                                               moore::PackedType packedType,
-                                              Value value, Location loc) {
+                                              Value value, Location loc,
+                                              bool fallible) {
   if (value.getType() == packedType)
     return value;
 
@@ -2771,9 +2773,10 @@ static Value materializeSBVToPackedConversion(Context &context,
   // `TimeType` fields. These require special conversion to ensure that the
   // local timescale is in effect.
   if (packedType.containsTimeType()) {
-    mlir::emitError(loc) << "unsupported conversion: " << intType
-                         << " cannot be converted to " << packedType
-                         << "; contains a time type";
+    if (!fallible)
+      mlir::emitError(loc) << "unsupported conversion: " << intType
+                           << " cannot be converted to " << packedType
+                           << "; contains a time type";
     return {};
   }
 
@@ -2815,7 +2818,7 @@ static mlir::Value maybeUpcastHandle(Context &context, mlir::Value actualHandle,
 }
 
 Value Context::materializeConversion(Type type, Value value, bool isSigned,
-                                     Location loc) {
+                                     Location loc, bool fallible) {
   // Nothing to do if the types are already equal.
   if (type == value.getType())
     return value;
@@ -2829,7 +2832,7 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
 
   if (dstInt && srcInt) {
     // Convert the value to a simple bit vector if it isn't one already.
-    value = materializePackedToSBVConversion(*this, value, loc);
+    value = materializePackedToSBVConversion(*this, value, loc, fallible);
     if (!value)
       return {};
 
@@ -2855,7 +2858,8 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
     }
 
     // Convert the value from a simple bit vector back to the packed type.
-    value = materializeSBVToPackedConversion(*this, dstPacked, value, loc);
+    value = materializeSBVToPackedConversion(*this, dstPacked, value, loc,
+                                             fallible);
     if (!value)
       return {};
 
@@ -2896,13 +2900,10 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
   }
 
   // Handle Real To Int conversion
-  if (isa<moore::IntType>(type) && isa<moore::RealType>(value.getType())) {
+  if (dstInt && isa<moore::RealType>(value.getType())) {
     auto twoValInt = builder.createOrFold<moore::RealToIntOp>(
-        loc, dyn_cast<moore::IntType>(type).getTwoValued(), value);
-
-    if (dyn_cast<moore::IntType>(type).getDomain() == moore::Domain::FourValued)
-      return materializePackedToSBVConversion(*this, twoValInt, loc);
-    return twoValInt;
+        loc, dstInt.getTwoValued(), value);
+    return materializeConversion(type, twoValInt, true, loc, fallible);
   }
 
   // Handle Int to Real conversion
@@ -2995,6 +2996,8 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
     return maybeUpcastHandle(*this, value, cast<moore::ClassHandleType>(type));
 
   // TODO: Handle other conversions with dedicated ops.
+  if (fallible && value.getType() != type)
+    return {};
   if (value.getType() != type)
     value = moore::ConversionOp::create(builder, loc, type, value);
   return value;
@@ -3145,6 +3148,40 @@ Value Context::convertSystemCall(
   if (nameId == ksn::BitsToShortreal)
     return convertRealMathBI<moore::BitstoshortrealBIOp>(*this, loc, name,
                                                          args);
+
+  if (nameId == ksn::Cast) {
+    assert(numArgs == 2 && "`cast` takes 2 arguments");
+    auto *dstExpr = args[0];
+    auto dstType = convertType(*dstExpr->type);
+    if (!dstType)
+      return {};
+
+    if (auto *assign = dstExpr->as_if<slang::ast::AssignmentExpression>())
+      dstExpr = &assign->left();
+    auto dst = convertLvalueExpression(*dstExpr);
+    if (!dst)
+      return {};
+
+    auto src = convertRvalueExpression(*args[1]);
+    if (!src)
+      return {};
+    // Class-typed $cast (upcast/downcast) is intentionally left for follow-up.
+    if (isa<moore::ClassHandleType>(dstType) ||
+        isa<moore::ClassHandleType>(src.getType())) {
+      auto i1Ty = moore::IntType::getInt(builder.getContext(), 1);
+      return moore::ConstantOp::create(builder, loc, i1Ty, 0,
+                                       /*isSigned=*/false);
+    }
+    auto converted = materializeConversion(
+        dstType, src, args[1]->type->isSigned(), loc, /*fallible=*/true);
+    auto i1Ty = moore::IntType::getInt(builder.getContext(), 1);
+    if (!converted)
+      return moore::ConstantOp::create(builder, loc, i1Ty, 0,
+                                       /*isSigned=*/false);
+    moore::BlockingAssignOp::create(builder, loc, dst, converted);
+    return moore::ConstantOp::create(builder, loc, i1Ty, 1,
+                                     /*isSigned=*/false);
+  }
 
   //===--------------------------------------------------------------------===//
   // String Methods

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -294,9 +294,10 @@ struct Context {
   Value convertToSimpleBitVector(Value value);
 
   /// Helper function to insert the necessary operations to cast a value from
-  /// one type to another.
+  /// one type to another. If `fallible` is true, conversion failures are
+  /// reported by returning a null value without emitting diagnostics.
   Value materializeConversion(Type type, Value value, bool isSigned,
-                              Location loc);
+                              Location loc, bool fallible = false);
 
   /// Helper function to materialize an `SVInt` as an SSA value.
   Value materializeSVInt(const slang::SVInt &svint,

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -975,6 +975,13 @@ struct StmtVisitor {
     auto nameId = subroutine.knownNameId;
     auto args = expr.arguments();
 
+    // The `$cast` system call is handled by `Context::convertSystemCall` in the
+    // `Expressions.cpp` file. Skip it is order to avoid visiting the
+    // `EmptyArgument` node.
+    if (nameId == ksn::Cast) {
+      return false;
+    }
+
     // Simulation Control Tasks
 
     if (nameId == ksn::Stop) {

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -5179,3 +5179,54 @@ module DisplayWithStringArg;
   initial $display(i, s);
 endmodule
 
+// CHECK-LABEL: func.func private @BuiltinCastTrue(
+// CHECK-SAME:    %arg0: !moore.ref<l32>
+// CHECK-SAME:  ) -> !moore.i32 {
+// CHECK: [[X:%.+]] = moore.variable : <struct<{a: i16, b: i16}>>
+// CHECK: [[Y:%.+]] = moore.variable : <array<4 x l8>>
+// CHECK: [[CR1:%.+]] = moore.constant_real 2.300000e+00 : f64
+// CHECK: [[REAL_TO_INT1:%.+]] = moore.real_to_int [[CR1]] : f64 -> i32
+// CHECK: [[SBV_TO_PACK1:%.+]] = moore.sbv_to_packed [[REAL_TO_INT1]] : struct<{a: i16, b: i16}>
+// CHECK: moore.blocking_assign [[X]], [[SBV_TO_PACK1]] : struct<{a: i16, b: i16}>
+// CHECK: [[SUCC1:%.+]] = moore.constant 1 : i1
+// CHECK: [[CR2:%.+]] = moore.constant_real 2.300000e+00 : f64
+// CHECK: [[REAL_TO_INT2:%.+]] = moore.real_to_int [[CR2]] : f64 -> i32
+// CHECK: [[INT_TO_LOGIC2:%.+]] = moore.int_to_logic [[REAL_TO_INT2]] : i32
+// CHECK: [[SBV_TO_PACK2:%.+]] = moore.sbv_to_packed [[INT_TO_LOGIC2]] : array<4 x l8>
+// CHECK: moore.blocking_assign [[Y]], [[SBV_TO_PACK2]] : array<4 x l8>
+// CHECK: [[SUCC2:%.+]] = moore.constant 1 : i1
+// CHECK: [[CR3:%.+]] = moore.constant_real 2.300000e+00 : f64
+// CHECK: [[REAL_TO_INT3:%.+]] = moore.real_to_int [[CR3]] : f64 -> i32
+// CHECK: [[INT_TO_LOGIC3:%.+]] = moore.int_to_logic [[REAL_TO_INT3]] : i32
+// CHECK: moore.blocking_assign %arg0, [[INT_TO_LOGIC3]] : l32
+// CHECK: [[SUCC3:%.+]] = moore.constant 1 : i1
+// CHECK: [[MAX:%.+]] = moore.constant -1 : i32
+// CHECK: return [[MAX]] : !moore.i32
+// CHECK: }
+
+function int BuiltinCastTrue(inout integer a);
+  struct packed { shortint a; shortint b; } x;
+  logic [3:0][7:0] y;
+  
+  $cast(x, 2.3);
+  $cast(y, 2.3);
+  return $cast(a, 2.3);
+endfunction
+
+// CHECK-LABEL: moore.coroutine private @BuiltinCastFalse() {
+// CHECK: [[S:%.+]] = moore.variable : <string>
+// CHECK: [[Q:%.+]] = moore.variable : <queue<l1, 0>>
+// CHECK: [[CR1:%.+]] = moore.constant_real 2.300000e+00 : f64
+// CHECK: [[FAIL1:%.+]] = moore.constant 0 : i1
+// CHECK: [[CR2:%.+]] = moore.constant_real 2.300000e+00 : f64
+// CHECK: [[FAIL2:%.+]] = moore.constant 0 : i1
+// CHECK: moore.return
+// CHECK: }
+
+task BuiltinCastFalse;
+  string s;
+  logic q [$];
+
+  $cast(s, 2.3);
+  $cast(q, 2.3);
+endtask


### PR DESCRIPTION
Implement statically inferable $cast lowering through materializeConversion. Use fallible conversion to produce the $cast success flag: emit blocking assignment only on success, and return i1 true/false accordingly.