### PR TITLE
[FIRRTL][OM] Property Equality Expression

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1471,6 +1471,27 @@ def StringConcatOp : FIRRTLOp<"string.concat", [Pure, SameOperandsAndResultType]
   let hasCanonicalizer = 1;
 }
 
+def PropEqOp : FIRRTLOp<"prop.eq", [Pure, AllTypesMatch<["lhs", "rhs"]>]> {
+  let summary = "Compare two property values for equality";
+  let description = [{
+    Compares two property values (String, Bool, or Integer) of the same type
+    for equality, producing a boolean result.
+
+    Example:
+    ```mlir
+    %result = firrtl.prop.eq %lhs, %rhs : !firrtl.string
+    ```
+  }];
+
+  let arguments = (ins AnyTypeOf<[StringType, BoolType, FIntegerType]>:$lhs,
+                       AnyTypeOf<[StringType, BoolType, FIntegerType]>:$rhs);
+  let results = (outs BoolType:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs)";
+
+  let hasFolder = 1;
+}
+
 def UnknownValueOp : FIRRTLOp<"unknown", [
   Pure,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -69,7 +69,7 @@ public:
             StringConstantOp, FIntegerConstantOp, BoolConstantOp,
             DoubleConstantOp, ListCreateOp, ListConcatOp, UnresolvedPathOp,
             PathOp, IntegerAddOp, IntegerMulOp, IntegerShrOp, StringConcatOp,
-            UnknownValueOp,
+            PropEqOp, UnknownValueOp,
             // Format String expressions
             TimeOp, HierarchicalModuleNameOp>([&](auto expr) -> ResultType {
           return thisCast->visitExpr(expr, args...);
@@ -234,6 +234,7 @@ public:
   HANDLE(IntegerMulOp, Unhandled);
   HANDLE(IntegerShrOp, Unhandled);
   HANDLE(StringConcatOp, Unhandled);
+  HANDLE(PropEqOp, Unhandled);
   HANDLE(UnknownValueOp, Unhandled);
 
   // Format string expressions

--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -443,6 +443,9 @@ private:
   FailureOr<EvaluatorValuePtr>
   evaluateStringConcat(StringConcatOp op, ActualParameters actualParams,
                        Location loc);
+  FailureOr<EvaluatorValuePtr>
+  evaluateBinaryEquality(BinaryEqualityOp op, ActualParameters actualParams,
+                         Location loc);
   FailureOr<evaluator::EvaluatorValuePtr>
   evaluateBasePathCreate(FrozenBasePathCreateOp op,
                          ActualParameters actualParams, Location loc);

--- a/include/circt/Dialect/OM/OMDialect.td
+++ b/include/circt/Dialect/OM/OMDialect.td
@@ -42,6 +42,12 @@ def OMDialect : Dialect {
 
     /// Register all OM types.
     void registerAttributes();
+
+    /// Materialize a constant value into an om.constant op.
+    ::mlir::Operation *materializeConstant(::mlir::OpBuilder &builder,
+                                           ::mlir::Attribute value,
+                                           ::mlir::Type type,
+                                           ::mlir::Location loc) override;
   }];
 }
 

--- a/include/circt/Dialect/OM/OMOpInterfaces.td
+++ b/include/circt/Dialect/OM/OMOpInterfaces.td
@@ -65,4 +65,20 @@ def IntegerBinaryArithmeticInterface : OpInterface<"IntegerBinaryArithmeticOp"> 
   ];
 }
 
+def BinaryEqualityInterface : OpInterface<"BinaryEqualityOp"> {
+  let cppNamespace = "circt::om";
+  let description = "Common interface for binary property equality ops.";
+  let methods = [
+    InterfaceMethod<"Get the lhs Value",
+      "mlir::Value", "getLhs", (ins)>,
+    InterfaceMethod<"Get the rhs Value",
+      "mlir::Value", "getRhs", (ins)>,
+    InterfaceMethod<"Get the result Value",
+      "mlir::Value", "getResult", (ins)>,
+    InterfaceMethod<"Evaluate the binary equality operation",
+      "mlir::FailureOr<mlir::Attribute>", "evaluateBinaryEquality",
+      (ins "mlir::Attribute":$lhs, "mlir::Attribute":$rhs)>
+  ];
+}
+
 #endif // CIRCT_DIALECT_OM_OMOPINTERFACES_TD

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -536,6 +536,37 @@ def StringConcatOp : OMOp<"string.concat", [Pure, SameOperandsAndResultType]> {
   let hasCanonicalizer = 1;
 }
 
+class BinaryEqualityOpBase<string mnemonic, list<Trait> traits = []> :
+    OMOp<mnemonic, [
+      Pure,
+      AllTypesMatch<["lhs", "rhs"]>,
+      DeclareOpInterfaceMethods<BinaryEqualityInterface>
+    ] # traits> {
+  let arguments = (ins AnyTypeOf<[StringType, OMIntegerType, I1]>:$lhs,
+                       AnyTypeOf<[StringType, OMIntegerType, I1]>:$rhs);
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs)";
+}
+
+def PropEqOp : BinaryEqualityOpBase<"prop.eq"> {
+  let summary = "Compare two OM property values for equality";
+  let description = [{
+    Compare two OM property values (String, Integer, or Bool) for equality,
+    returning a 1-bit integer (i1) result. Returns 1 if the values are equal,
+    0 otherwise. Both operands must have the same type.
+
+    Example:
+    ```mlir
+    %2 = om.prop.eq %0, %1 : !om.string
+    %3 = om.prop.eq %4, %5 : !om.integer
+    %6 = om.prop.eq %7, %8 : i1
+    ```
+  }];
+
+  let results = (outs I1:$result);
+
+  let hasFolder = 1;
+}
+
 def PropertyAssertOp : OMOp<"property_assert"> {
   let summary = "Assert that a boolean property holds at evaluation time";
   let description = [{

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -202,6 +202,12 @@ struct Emitter {
   HANDLE(StringConcatOp, "string_concat");
 #undef HANDLE
 
+  void emitExpression(PropEqOp op) {
+    if (failed(requireVersion(missingSpecFIRVersion, op, "property equality")))
+      return;
+    emitPrimExpr("prop_eq", op);
+  }
+
   // Attributes
   void emitAttribute(MemDirAttr attr);
   void emitAttribute(RUWBehaviorAttr attr);
@@ -1544,7 +1550,7 @@ void Emitter::emitExpression(Value value) {
           ShrPrimOp, UninferredResetCastOp, ConstCastOp, StringConstantOp,
           FIntegerConstantOp, BoolConstantOp, DoubleConstantOp, ListCreateOp,
           UnresolvedPathOp, GenericIntrinsicOp, CatPrimOp, UnsafeDomainCastOp,
-          UnknownValueOp, StringConcatOp,
+          UnknownValueOp, StringConcatOp, PropEqOp,
           // Reference expressions
           RefSendOp, RefResolveOp, RefSubOp, RWProbeOp, RefCastOp,
           // Format String expressions

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1657,6 +1657,19 @@ void StringConcatOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<FlattenStringConcat, MergeAdjacentStringConstants>(context);
 }
 
+//===----------------------------------------------------------------------===//
+// PropEqOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult PropEqOp::fold(FoldAdaptor adaptor) {
+  auto lhsAttr = adaptor.getLhs();
+  auto rhsAttr = adaptor.getRhs();
+  if (!lhsAttr || !rhsAttr)
+    return {};
+
+  return BoolAttr::get(getContext(), lhsAttr == rhsAttr);
+}
+
 OpFoldResult BitCastOp::fold(FoldAdaptor adaptor) {
   auto op = (*this);
   // BitCast is redundant if input and result types are same.

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2000,6 +2000,7 @@ private:
   ParseResult parseListConcatExp(Value &result);
   ParseResult parseCatExp(Value &result);
   ParseResult parseStringConcatExp(Value &result);
+  ParseResult parsePropEqExp(Value &result);
   ParseResult parseUnsafeDomainCast(Value &result);
   ParseResult parseUnknownProperty(Value &result);
 
@@ -2398,6 +2399,12 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
 
   case FIRToken::lp_string_concat:
     if (parseStringConcatExp(result))
+      return failure();
+    break;
+
+  case FIRToken::lp_prop_eq:
+    if (requireFeature(missingSpecFIRVersion, "property equality") ||
+        parsePropEqExp(result))
       return failure();
     break;
 
@@ -2875,6 +2882,37 @@ ParseResult FIRStmtParser::parseStringConcatExp(Value &result) {
   locationProcessor.setLoc(loc);
   auto type = StringType::get(builder.getContext());
   result = builder.create<StringConcatOp>(type, operands);
+  return success();
+}
+
+/// prop_eq-exp ::= 'prop_eq(' expr ',' expr ')'
+ParseResult FIRStmtParser::parsePropEqExp(Value &result) {
+  consumeToken(FIRToken::lp_prop_eq);
+
+  auto loc = getToken().getLoc();
+  Value lhs, rhs;
+  locationProcessor.setLoc(loc);
+  if (parseExp(lhs, "expected lhs expression in prop_eq expression") ||
+      parseToken(FIRToken::comma, "expected ','") ||
+      parseExp(rhs, "expected rhs expression in prop_eq expression") ||
+      parseToken(FIRToken::r_paren, "expected ')'"))
+    return failure();
+
+  auto isValidType = [](Type t) {
+    return type_isa<StringType>(t) || type_isa<BoolType>(t) ||
+           type_isa<FIntegerType>(t);
+  };
+  if (!isValidType(lhs.getType()))
+    return emitError(loc,
+                     "lhs of prop_eq must be String, Bool, or Integer type");
+  if (!isValidType(rhs.getType()))
+    return emitError(loc,
+                     "rhs of prop_eq must be String, Bool, or Integer type");
+  if (lhs.getType() != rhs.getType())
+    return emitError(loc, "prop_eq operands must have the same type");
+
+  locationProcessor.setLoc(loc);
+  result = PropEqOp::create(builder, lhs, rhs);
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -266,6 +266,7 @@ TOK_LPKEYWORD_PRIM(integer_shr, IntegerShrOp, 2, 0, FIRVersion(3, 1, 0),
 TOK_LPKEYWORD_PRIM(integer_shl, IntegerShlOp, 2, 0, FIRVersion(3, 1, 0),
                    "Integers")
 TOK_LPKEYWORD(string_concat)
+TOK_LPKEYWORD(prop_eq)
 
 #undef TOK_MARKER
 #undef TOK_IDENTIFIER

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1774,6 +1774,18 @@ struct StringConcatOpConversion
   }
 };
 
+struct PropEqOpConversion : public OpConversionPattern<firrtl::PropEqOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(firrtl::PropEqOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<om::PropEqOp>(op, adaptor.getLhs(),
+                                              adaptor.getRhs());
+    return success();
+  }
+};
+
 struct PathOpConversion : public OpConversionPattern<firrtl::PathOp> {
 
   PathOpConversion(TypeConverter &typeConverter, MLIRContext *context,
@@ -2253,6 +2265,7 @@ static void populateRewritePatterns(
   patterns.add<IntegerShrOpConversion>(converter, patterns.getContext());
   patterns.add<IntegerShlOpConversion>(converter, patterns.getContext());
   patterns.add<StringConcatOpConversion>(converter, patterns.getContext());
+  patterns.add<PropEqOpConversion>(converter, patterns.getContext());
   patterns.add<UnrealizedConversionCastOpConversion>(converter,
                                                      patterns.getContext());
   patterns.add<UnknownValueOpConversion>(converter, patterns.getContext());

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -160,6 +160,12 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
                           evaluator::PathValue::getEmptyPath(loc));
                   return success(result);
                 })
+                .Case([&](BinaryEqualityOp op) {
+                  evaluator::EvaluatorValuePtr result =
+                      evaluator::AttributeValue::get(op.getResult().getType(),
+                                                     loc);
+                  return success(result);
+                })
                 .Case<ListCreateOp, ListConcatOp, StringConcatOp,
                       ObjectFieldOp>([&](auto op) {
                   return getPartiallyEvaluatedValue(op.getType(), loc);
@@ -391,6 +397,9 @@ circt::om::Evaluator::evaluateValue(Value value, ActualParameters actualParams,
             })
             .Case([&](StringConcatOp op) {
               return evaluateStringConcat(op, actualParams, loc);
+            })
+            .Case([&](BinaryEqualityOp op) {
+              return evaluateBinaryEquality(op, actualParams, loc);
             })
             .Case([&](AnyCastOp op) {
               return evaluateValue(op.getInput(), actualParams, loc);
@@ -796,6 +805,73 @@ circt::om::Evaluator::evaluateStringConcat(StringConcatOp op,
   // Finalize the op result value.
   auto *handleValue = cast<evaluator::AttributeValue>(handle.value().get());
   auto resultStatus = handleValue->setAttr(resultStr);
+  if (failed(resultStatus))
+    return resultStatus;
+
+  auto finalizeStatus = handleValue->finalize();
+  if (failed(finalizeStatus))
+    return finalizeStatus;
+
+  return handle;
+}
+
+// Evaluator dispatch function for binary property equality operations.
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::evaluateBinaryEquality(BinaryEqualityOp op,
+                                             ActualParameters actualParams,
+                                             Location loc) {
+  // Get the op's EvaluatorValue handle, in case it hasn't been evaluated yet.
+  auto handle = getOrCreateValue(op.getResult(), actualParams, loc);
+  if (failed(handle))
+    return handle;
+
+  // If it's fully evaluated, we can return it.
+  if (handle.value()->isFullyEvaluated())
+    return handle;
+
+  // Evaluate both operands, returning the partially evaluated handle if either
+  // isn't ready yet.
+  auto lhsResult = evaluateValue(op.getLhs(), actualParams, loc);
+  if (failed(lhsResult))
+    return lhsResult;
+  if (!lhsResult.value()->isFullyEvaluated())
+    return handle;
+
+  auto rhsResult = evaluateValue(op.getRhs(), actualParams, loc);
+  if (failed(rhsResult))
+    return rhsResult;
+  if (!rhsResult.value()->isFullyEvaluated())
+    return handle;
+
+  // Check if any operand is unknown and propagate the unknown flag.
+  if (lhsResult.value()->isUnknown() || rhsResult.value()->isUnknown()) {
+    handle.value()->markUnknown();
+    return handle;
+  }
+
+  // Extract the underlying attribute, handling both AttributeValue and
+  // ReferenceValue cases.
+  auto extractAttr = [](evaluator::EvaluatorValue *value) -> mlir::Attribute {
+    return llvm::TypeSwitch<evaluator::EvaluatorValue *, mlir::Attribute>(value)
+        .Case([](evaluator::AttributeValue *val) { return val->getAttr(); })
+        .Case([](evaluator::ReferenceValue *val) -> mlir::Attribute {
+          return cast<evaluator::AttributeValue>(val->getStrippedValue()->get())
+              ->getAttr();
+        });
+  };
+
+  mlir::Attribute lhs = extractAttr(lhsResult.value().get());
+  mlir::Attribute rhs = extractAttr(rhsResult.value().get());
+  assert(lhs && rhs && "expected attribute for BinaryEqualityOp operands");
+
+  // Perform the binary equality operation.
+  FailureOr<mlir::Attribute> result = op.evaluateBinaryEquality(lhs, rhs);
+  if (failed(result))
+    return op->emitError("failed to evaluate binary equality operation");
+
+  // Finalize the op result value.
+  auto *handleValue = cast<evaluator::AttributeValue>(handle.value().get());
+  auto resultStatus = handleValue->setAttr(*result);
   if (failed(resultStatus))
     return resultStatus;
 

--- a/lib/Dialect/OM/OMDialect.cpp
+++ b/lib/Dialect/OM/OMDialect.cpp
@@ -13,6 +13,7 @@
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/OM/OMOps.h"
+#include "mlir/IR/Builders.h"
 
 #include "circt/Dialect/OM/OMDialect.cpp.inc"
 
@@ -24,6 +25,16 @@ void circt::om::OMDialect::initialize() {
 
   registerTypes();
   registerAttributes();
+}
+
+mlir::Operation *
+circt::om::OMDialect::materializeConstant(mlir::OpBuilder &builder,
+                                          mlir::Attribute value,
+                                          mlir::Type type, mlir::Location loc) {
+  if (auto typedAttr = mlir::dyn_cast<mlir::TypedAttr>(value))
+    if (typedAttr.getType() == type)
+      return ConstantOp::create(builder, loc, typedAttr);
+  return nullptr;
 }
 
 // Provide implementations for the enums we use.

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -832,6 +832,56 @@ void StringConcatOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 //===----------------------------------------------------------------------===//
+// PropEqOp
+//===----------------------------------------------------------------------===//
+
+FailureOr<mlir::Attribute>
+PropEqOp::evaluateBinaryEquality(mlir::Attribute lhsAttr,
+                                 mlir::Attribute rhsAttr) {
+  auto resultType = mlir::IntegerType::get(getContext(), 1);
+
+  // String equality.
+  if (auto lhs = dyn_cast<mlir::StringAttr>(lhsAttr))
+    if (auto rhs = dyn_cast<mlir::StringAttr>(rhsAttr))
+      return mlir::Attribute(
+          mlir::IntegerAttr::get(resultType, lhs == rhs ? 1 : 0));
+
+  // OM integer equality (arbitrary precision).
+  if (auto lhs = dyn_cast<om::IntegerAttr>(lhsAttr))
+    if (auto rhs = dyn_cast<om::IntegerAttr>(rhsAttr)) {
+      APSInt lhsVal = lhs.getValue().getAPSInt();
+      APSInt rhsVal = rhs.getValue().getAPSInt();
+      if (lhsVal.getBitWidth() > rhsVal.getBitWidth())
+        rhsVal = rhsVal.extend(lhsVal.getBitWidth());
+      else if (rhsVal.getBitWidth() > lhsVal.getBitWidth())
+        lhsVal = lhsVal.extend(rhsVal.getBitWidth());
+      return mlir::Attribute(
+          mlir::IntegerAttr::get(resultType, lhsVal == rhsVal ? 1 : 0));
+    }
+
+  // Boolean (i1) equality.
+  if (auto lhs = dyn_cast<mlir::IntegerAttr>(lhsAttr))
+    if (auto rhs = dyn_cast<mlir::IntegerAttr>(rhsAttr))
+      return mlir::Attribute(
+          mlir::IntegerAttr::get(resultType, lhs == rhs ? 1 : 0));
+
+  return failure();
+}
+
+OpFoldResult PropEqOp::fold(FoldAdaptor adaptor) {
+  auto lhsAttr = adaptor.getLhs();
+  auto rhsAttr = adaptor.getRhs();
+  if (!lhsAttr || !rhsAttr)
+    return {};
+
+  auto result = evaluateBinaryEquality(lhsAttr, rhsAttr);
+  if (failed(result))
+    return {};
+
+  return *result;
+}
+
+//===----------------------------------------------------------------------===//
 // UnknownValueOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -4023,4 +4023,74 @@ firrtl.module @StringConcatCanonicalization(in %str1: !firrtl.string, in %str2: 
   firrtl.propassign %out7, %nested : !firrtl.string
 }
 
+// CHECK-LABEL: firrtl.module @PropEqFold
+firrtl.module @PropEqFold(in %str: !firrtl.string, in %b: !firrtl.bool,
+                          in %i: !firrtl.integer,
+                          out %out1: !firrtl.bool, out %out2: !firrtl.bool,
+                          out %out3: !firrtl.bool, out %out4: !firrtl.bool,
+                          out %out5: !firrtl.bool, out %out6: !firrtl.bool,
+                          out %out7: !firrtl.bool, out %out8: !firrtl.bool,
+                          out %out9: !firrtl.bool) {
+  %s1 = firrtl.string "hello"
+  %s2 = firrtl.string "hello"
+  %s3 = firrtl.string "world"
+
+  // CHECK-DAG: [[TRUE:%.+]] = firrtl.bool true
+  // CHECK-DAG: [[FALSE:%.+]] = firrtl.bool false
+
+  // Equal constant strings fold to true.
+  // CHECK: firrtl.propassign %out1, [[TRUE]]
+  %0 = firrtl.prop.eq %s1, %s2 : !firrtl.string
+  firrtl.propassign %out1, %0 : !firrtl.bool
+
+  // Unequal constant strings fold to false.
+  // CHECK: firrtl.propassign %out2, [[FALSE]]
+  %1 = firrtl.prop.eq %s1, %s3 : !firrtl.string
+  firrtl.propassign %out2, %1 : !firrtl.bool
+
+  // Non-constant string operands do not fold.
+  // CHECK: [[EQ:%.+]] = firrtl.prop.eq %str, %str : !firrtl.string
+  // CHECK: firrtl.propassign %out3, [[EQ]]
+  %2 = firrtl.prop.eq %str, %str : !firrtl.string
+  firrtl.propassign %out3, %2 : !firrtl.bool
+
+  // Equal constant booleans fold to true.
+  %t1 = firrtl.bool true
+  %t2 = firrtl.bool true
+  %f1 = firrtl.bool false
+  // CHECK: firrtl.propassign %out4, [[TRUE]]
+  %3 = firrtl.prop.eq %t1, %t2 : !firrtl.bool
+  firrtl.propassign %out4, %3 : !firrtl.bool
+
+  // Unequal constant booleans fold to false.
+  // CHECK: firrtl.propassign %out5, [[FALSE]]
+  %4 = firrtl.prop.eq %t1, %f1 : !firrtl.bool
+  firrtl.propassign %out5, %4 : !firrtl.bool
+
+  // Non-constant bool operands do not fold.
+  // CHECK: [[BEQB:%.+]] = firrtl.prop.eq %b, %b : !firrtl.bool
+  // CHECK: firrtl.propassign %out6, [[BEQB]]
+  %5 = firrtl.prop.eq %b, %b : !firrtl.bool
+  firrtl.propassign %out6, %5 : !firrtl.bool
+
+  // Equal constant integers fold to true.
+  %i1 = firrtl.integer 42
+  %i2 = firrtl.integer 42
+  %i3 = firrtl.integer 0
+  // CHECK: firrtl.propassign %out7, [[TRUE]]
+  %6 = firrtl.prop.eq %i1, %i2 : !firrtl.integer
+  firrtl.propassign %out7, %6 : !firrtl.bool
+
+  // Unequal constant integers fold to false.
+  // CHECK: firrtl.propassign %out8, [[FALSE]]
+  %7 = firrtl.prop.eq %i1, %i3 : !firrtl.integer
+  firrtl.propassign %out8, %7 : !firrtl.bool
+
+  // Non-constant integer operands do not fold.
+  // CHECK: [[IEQI:%.+]] = firrtl.prop.eq %i, %i : !firrtl.integer
+  // CHECK: firrtl.propassign %out9, [[IEQI]]
+  %8 = firrtl.prop.eq %i, %i : !firrtl.integer
+  firrtl.propassign %out9, %8 : !firrtl.bool
+}
+
 }

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -645,7 +645,8 @@ firrtl.circuit "Foo" {
                             out %path : !firrtl.path,
                             out %list : !firrtl.list<list<string>>,
                             out %unknownString : !firrtl.string,
-                            out %stringcat : !firrtl.string) {
+                            out %stringcat : !firrtl.string,
+                            out %stringeq : !firrtl.bool) {
     // CHECK: propassign string, String("hello")
     %0 = firrtl.string "hello"
     firrtl.propassign %string, %0 : !firrtl.string
@@ -683,6 +684,10 @@ firrtl.circuit "Foo" {
     %str1 = firrtl.string "world"
     %strcat = firrtl.string.concat %str0, %str1 : !firrtl.string
     firrtl.propassign %stringcat, %strcat : !firrtl.string
+
+    // CHECK: propassign stringeq, prop_eq(String("hello"), String("world"))
+    %streq = firrtl.prop.eq %str0, %str1 : !firrtl.string
+    firrtl.propassign %stringeq, %streq : !firrtl.bool
   }
 
   // Test optional group declaration and definition emission.

--- a/test/Dialect/FIRRTL/emit-version-errors-lt-5.1.0.mlir
+++ b/test/Dialect/FIRRTL/emit-version-errors-lt-5.1.0.mlir
@@ -126,3 +126,15 @@ firrtl.circuit "KnownLayers" {
   firrtl.extmodule @ExtWithKnownLayers() attributes {knownLayers = [@GroupA]}
   firrtl.module @KnownLayers() {}
 }
+
+// -----
+
+// prop.eq expression requires >= 5.1.0.
+firrtl.circuit "PropEq" {
+  firrtl.module @PropEq(in %a : !firrtl.string, in %b : !firrtl.string,
+                        out %eq : !firrtl.bool) {
+    // expected-error @below {{'firrtl.prop.eq' op property equality requires FIRRTL 5.1.0}}
+    %0 = firrtl.prop.eq %a, %b : !firrtl.string
+    firrtl.propassign %eq, %0 : !firrtl.bool
+  }
+}

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -435,6 +435,30 @@ firrtl.circuit "StringCat" {
     // CHECK: om.class.fields %[[CONCAT]]
     firrtl.propassign %c, %0 : !firrtl.string
   }
+
+  // CHECK-LABEL: om.class @PropEqStringClass
+  firrtl.class @PropEqStringClass(in %a: !firrtl.string, in %b: !firrtl.string, out %eq: !firrtl.bool) {
+    // CHECK: %[[EQ:.+]] = om.prop.eq %a, %b : !om.string
+    %0 = firrtl.prop.eq %a, %b : !firrtl.string
+    // CHECK: om.class.fields %[[EQ]]
+    firrtl.propassign %eq, %0 : !firrtl.bool
+  }
+
+  // CHECK-LABEL: om.class @PropEqBoolClass
+  firrtl.class @PropEqBoolClass(in %a: !firrtl.bool, in %b: !firrtl.bool, out %eq: !firrtl.bool) {
+    // CHECK: %[[EQ:.+]] = om.prop.eq %a, %b : i1
+    %0 = firrtl.prop.eq %a, %b : !firrtl.bool
+    // CHECK: om.class.fields %[[EQ]]
+    firrtl.propassign %eq, %0 : !firrtl.bool
+  }
+
+  // CHECK-LABEL: om.class @PropEqIntegerClass
+  firrtl.class @PropEqIntegerClass(in %a: !firrtl.integer, in %b: !firrtl.integer, out %eq: !firrtl.bool) {
+    // CHECK: %[[EQ:.+]] = om.prop.eq %a, %b : !om.integer
+    %0 = firrtl.prop.eq %a, %b : !firrtl.integer
+    // CHECK: om.class.fields %[[EQ]]
+    firrtl.propassign %eq, %0 : !firrtl.bool
+  }
 }
 
 // CHECK-LABEL: firrtl.circuit "AltBasePath"

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1686,6 +1686,32 @@ circuit StringOps :
     propassign c, string_concat(a, b)
 
 ;// -----
+FIRRTL version 5.1.0
+
+; CHECK-LABEL: firrtl.circuit "PropEq"
+circuit PropEq :
+  public module PropEq :
+    input a : String
+    input b : String
+    output eq : Bool
+
+    ; CHECK: [[EQ:%.+]] = firrtl.prop.eq %a, %b : !firrtl.string
+    ; CHECK: firrtl.propassign %eq, [[EQ]]
+    propassign eq, prop_eq(a, b)
+
+;// -----
+FIRRTL version 5.0.0
+
+circuit PropEqVersionError :
+  public module PropEqVersionError :
+    input a : String
+    input b : String
+    output c : String
+
+    ; expected-error @+1 {{property equality are a FIRRTL 5.1.0+ feature, but the specified FIRRTL version was 5.0.0}}
+    propassign c, prop_eq(a, b)
+
+;// -----
 FIRRTL version 3.1.0
 
 ; CHECK-LABEL: circuit "BundleOfProps"

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -152,6 +152,27 @@ firrtl.module @PropertyStringOps() {
   %3 = firrtl.string.concat %0, %1, %2 : !firrtl.string
 }
 
+// CHECK-LABEL: firrtl.module @PropertyPropEq
+firrtl.module @PropertyPropEq() {
+  %0 = firrtl.string "hello"
+  %1 = firrtl.string "world"
+
+  // CHECK: firrtl.prop.eq %0, %1 : !firrtl.string
+  %2 = firrtl.prop.eq %0, %1 : !firrtl.string
+
+  %3 = firrtl.bool true
+  %4 = firrtl.bool false
+
+  // CHECK: firrtl.prop.eq %3, %4 : !firrtl.bool
+  %5 = firrtl.prop.eq %3, %4 : !firrtl.bool
+
+  %6 = firrtl.integer 42
+  %7 = firrtl.integer 0
+
+  // CHECK: firrtl.prop.eq %6, %7 : !firrtl.integer
+  %8 = firrtl.prop.eq %6, %7 : !firrtl.integer
+}
+
 // CHECK-LABEL: firrtl.module @PropertyListOps
 firrtl.module @PropertyListOps() {
   %0 = firrtl.integer 0

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -60,3 +60,57 @@ om.class @StringConcatCanonicalization(%str1: !om.string, %str2: !om.string) -> 
   // CHECK: om.class.fields [[HELLOWORLD]], [[HELLO]], [[HELLO]], [[EMPTY]], [[HELLOWORLD]], [[CONCAT1]], [[NESTED]]
   om.class.fields %0, %1, %2, %3, %5, %concat1, %nested : !om.string, !om.string, !om.string, !om.string, !om.string, !om.string, !om.string
 }
+
+// CHECK-LABEL: @PropEqFold
+om.class @PropEqFold(%str: !om.string, %b: i1, %n: !om.integer) -> (out1: i1, out2: i1,
+                                                                     out3: i1, out4: i1,
+                                                                     out5: i1, out6: i1,
+                                                                     out7: i1, out8: i1,
+                                                                     out9: i1) {
+  %hello1 = om.constant "hello" : !om.string
+  %hello2 = om.constant "hello" : !om.string
+  %world  = om.constant "world" : !om.string
+
+  // CHECK-DAG: [[TRUE:%.+]] = om.constant true
+  // CHECK-DAG: [[FALSE:%.+]] = om.constant false
+
+  // Equal constant strings fold to true.
+  %0 = om.prop.eq %hello1, %hello2 : !om.string
+
+  // Unequal constant strings fold to false.
+  %1 = om.prop.eq %hello1, %world : !om.string
+
+  // Non-constant string operands do not fold.
+  // CHECK: [[EQ:%.+]] = om.prop.eq %str, %str : !om.string
+  %2 = om.prop.eq %str, %str : !om.string
+
+  %true  = om.constant true
+  %false = om.constant false
+
+  // Equal constant booleans fold to true.
+  %3 = om.prop.eq %true, %true : i1
+
+  // Unequal constant booleans fold to false.
+  %4 = om.prop.eq %true, %false : i1
+
+  // Non-constant bool operands do not fold.
+  // CHECK: [[BEQ:%.+]] = om.prop.eq %b, %b : i1
+  %5 = om.prop.eq %b, %b : i1
+
+  %i42a = om.constant #om.integer<42 : si64> : !om.integer
+  %i42b = om.constant #om.integer<42 : si64> : !om.integer
+  %i0   = om.constant #om.integer<0 : si64> : !om.integer
+
+  // Equal constant integers fold to true.
+  %6 = om.prop.eq %i42a, %i42b : !om.integer
+
+  // Unequal constant integers fold to false.
+  %7 = om.prop.eq %i42a, %i0 : !om.integer
+
+  // Non-constant integer operands do not fold.
+  // CHECK: [[IEQ:%.+]] = om.prop.eq %n, %n : !om.integer
+  %8 = om.prop.eq %n, %n : !om.integer
+
+  // CHECK: om.class.fields [[TRUE]], [[FALSE]], [[EQ]], [[TRUE]], [[FALSE]], [[BEQ]], [[TRUE]], [[FALSE]], [[IEQ]]
+  om.class.fields %0, %1, %2, %3, %4, %5, %6, %7, %8 : i1, i1, i1, i1, i1, i1, i1, i1, i1
+}

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -196,6 +196,29 @@ om.class @StringConcat() {
   om.class.fields
 }
 
+// CHECK-LABEL: @PropEq
+om.class @PropEq() {
+  %0 = om.constant "hello" : !om.string
+  %1 = om.constant "world" : !om.string
+
+  // CHECK: om.prop.eq %0, %1 : !om.string
+  %2 = om.prop.eq %0, %1 : !om.string
+
+  %3 = om.constant #om.integer<1 : i8> : !om.integer
+  %4 = om.constant #om.integer<2 : i8> : !om.integer
+
+  // CHECK: om.prop.eq %3, %4 : !om.integer
+  %5 = om.prop.eq %3, %4 : !om.integer
+
+  %6 = om.constant true
+  %7 = om.constant false
+
+  // CHECK: om.prop.eq %6, %7 : i1
+  %8 = om.prop.eq %6, %7 : i1
+
+  om.class.fields
+}
+
 // CHECK-LABEL: @LinkedList
 // CHECK-SAME: -> (prev: !om.class.type<@LinkedList>)
 om.class @LinkedList(%prev: !om.class.type<@LinkedList>) -> (prev: !om.class.type<@LinkedList>) {

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -1880,4 +1880,79 @@ om.class @SubfieldFalse() -> () {
       evaluator.instantiate(StringAttr::get(&context, "SubfieldFalse"), {})));
 }
 
+TEST(EvaluatorTests, PropEqTests) {
+  StringRef mod = R"MLIR(
+om.class @PropEqString(%s: !om.string) -> (equal: i1, not_equal: i1, unknown: i1) {
+  %a    = om.constant "hello" : !om.string
+  %b    = om.constant "hello" : !om.string
+  %c    = om.constant "world" : !om.string
+  %eq   = om.prop.eq %a, %b : !om.string
+  %neq  = om.prop.eq %a, %c : !om.string
+  %unk  = om.prop.eq %a, %s : !om.string
+  om.class.fields %eq, %neq, %unk : i1, i1, i1
+}
+
+om.class @PropEqBool(%b: i1) -> (equal: i1, not_equal: i1, unknown: i1) {
+  %t    = om.constant true
+  %f    = om.constant false
+  %eq   = om.prop.eq %t, %t : i1
+  %neq  = om.prop.eq %t, %f : i1
+  %unk  = om.prop.eq %t, %b : i1
+  om.class.fields %eq, %neq, %unk : i1, i1, i1
+}
+
+om.class @PropEqInteger(%n: !om.integer) -> (equal: i1, not_equal: i1, unknown: i1) {
+  %a    = om.constant #om.integer<42 : si64> : !om.integer
+  %b    = om.constant #om.integer<42 : si64> : !om.integer
+  %c    = om.constant #om.integer<0 : si64> : !om.integer
+  %eq   = om.prop.eq %a, %b : !om.integer
+  %neq  = om.prop.eq %a, %c : !om.integer
+  %unk  = om.prop.eq %a, %n : !om.integer
+  om.class.fields %eq, %neq, %unk : i1, i1, i1
+}
+)MLIR";
+
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  OwningOpRef<ModuleOp> owning =
+      parseSourceString<ModuleOp>(mod, ParserConfig(&context));
+
+  Evaluator evaluator(owning.release());
+
+  auto unknownLoc = LocationAttr(UnknownLoc::get(&context));
+
+  // Helper: extract the i1 integer value from a field of an ObjectValue.
+  auto getInt = [](evaluator::ObjectValue *obj, StringRef fieldName,
+                   MLIRContext *ctx) {
+    return llvm::cast<evaluator::AttributeValue>(
+               obj->getField(StringAttr::get(ctx, fieldName)).value().get())
+        ->getAs<mlir::IntegerAttr>()
+        .getValue()
+        .getZExtValue();
+  };
+
+  const std::pair<StringRef, Type> cases[] = {
+      {"PropEqString", StringType::get(&context)},
+      {"PropEqBool", mlir::IntegerType::get(&context, 1)},
+      {"PropEqInteger", OMIntegerType::get(&context)},
+  };
+  for (auto [className, paramType] : cases) {
+    auto unknown = evaluator::AttributeValue::get(paramType, unknownLoc);
+    unknown->markUnknown();
+    auto result =
+        evaluator.instantiate(StringAttr::get(&context, className), {unknown});
+    ASSERT_TRUE(succeeded(result));
+    auto *obj = llvm::cast<evaluator::ObjectValue>(result.value().get());
+    ASSERT_EQ(getInt(obj, "equal", &context), 1ul);
+    ASSERT_EQ(getInt(obj, "not_equal", &context), 0ul);
+    ASSERT_TRUE(obj->getField(StringAttr::get(&context, "unknown"))
+                    .value()
+                    ->isUnknown());
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Add property equality expressions to FIRRTL and OM.  Add a lowering from FIRRTL to
OM in the `LowerClasses` pass.  Add OM evaluator support.

This PR is structured into logical commits that can be reviewed independently.

AI-assisted-by: Claude Code (Claude Sonnet 4.6)
