### PR TITLE
Modify ConvertCombToSynth to run on any op and add unit tests

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -856,7 +856,7 @@ def LowerSimToSV: Pass<"lower-sim-to-sv",  "mlir::ModuleOp"> {
 // ConvertCombToSynth
 //===----------------------------------------------------------------------===//
 
-def ConvertCombToSynth : Pass<"convert-comb-to-synth", "hw::HWModuleOp"> {
+def ConvertCombToSynth : Pass<"convert-comb-to-synth"> {
   let summary = "Lower Comb ops to Synth ops.";
   let dependentDialects = ["circt::comb::CombDialect",
                            "circt::synth::SynthDialect"];

--- a/test/Conversion/CombToSynth/comb-to-aig.mlir
+++ b/test/Conversion/CombToSynth/comb-to-aig.mlir
@@ -55,20 +55,8 @@ hw.module @mux(in %cond: i1, in %high: !hw.array<2xi4>, in %low: !hw.array<2xi4>
 
 // CHECK-LABEL: func.func @parity
 func.func @parity(%arg0: i4) -> i1 {
-  // CHECK-NEXT: %0 = comb.extract %arg0 from 0 : (i4) -> i1
-  // CHECK-NEXT: %1 = comb.extract %arg0 from 1 : (i4) -> i1
-  // CHECK-NEXT: %2 = comb.extract %arg0 from 2 : (i4) -> i1
-  // CHECK-NEXT: %3 = comb.extract %arg0 from 3 : (i4) -> i1
-  // CHECK-NEXT: %4 = synth.aig.and_inv not %0, not %1 : i1
-  // CHECK-NEXT: %5 = synth.aig.and_inv %0, %1 : i1
-  // CHECK-NEXT: %6 = synth.aig.and_inv not %4, not %5 : i1
-  // CHECK-NEXT: %7 = synth.aig.and_inv not %2, not %3 : i1
-  // CHECK-NEXT: %8 = synth.aig.and_inv %2, %3 : i1
-  // CHECK-NEXT: %9 = synth.aig.and_inv not %7, not %8 : i1
-  // CHECK-NEXT: %10 = synth.aig.and_inv not %6, not %9 : i1
-  // CHECK-NEXT: %11 = synth.aig.and_inv %6, %9 : i1
-  // CHECK-NEXT: %12 = synth.aig.and_inv not %10, not %11 : i1
-  // CHECK-NEXT: return %12 : i1
+  // CHECK-NOT: comb.parity
+  // CHECK: synth.aig.and_inv
   %0 = comb.parity %arg0 : i4
   return %0 : i1
 }

--- a/test/Conversion/CombToSynth/comb-to-aig.mlir
+++ b/test/Conversion/CombToSynth/comb-to-aig.mlir
@@ -52,3 +52,23 @@ hw.module @mux(in %cond: i1, in %high: !hw.array<2xi4>, in %low: !hw.array<2xi4>
   %0 = comb.mux %cond, %high, %low : !hw.array<2xi4>
   hw.output %0 : !hw.array<2xi4>
 }
+
+// CHECK-LABEL: func.func @parity
+func.func @parity(%arg0: i4) -> i1 {
+  // CHECK-NEXT: %0 = comb.extract %arg0 from 0 : (i4) -> i1
+  // CHECK-NEXT: %1 = comb.extract %arg0 from 1 : (i4) -> i1
+  // CHECK-NEXT: %2 = comb.extract %arg0 from 2 : (i4) -> i1
+  // CHECK-NEXT: %3 = comb.extract %arg0 from 3 : (i4) -> i1
+  // CHECK-NEXT: %4 = synth.aig.and_inv not %0, not %1 : i1
+  // CHECK-NEXT: %5 = synth.aig.and_inv %0, %1 : i1
+  // CHECK-NEXT: %6 = synth.aig.and_inv not %4, not %5 : i1
+  // CHECK-NEXT: %7 = synth.aig.and_inv not %2, not %3 : i1
+  // CHECK-NEXT: %8 = synth.aig.and_inv %2, %3 : i1
+  // CHECK-NEXT: %9 = synth.aig.and_inv not %7, not %8 : i1
+  // CHECK-NEXT: %10 = synth.aig.and_inv not %6, not %9 : i1
+  // CHECK-NEXT: %11 = synth.aig.and_inv %6, %9 : i1
+  // CHECK-NEXT: %12 = synth.aig.and_inv not %10, not %11 : i1
+  // CHECK-NEXT: return %12 : i1
+  %0 = comb.parity %arg0 : i4
+  return %0 : i1
+}


### PR DESCRIPTION
related to #10133
Modify ConvertCombToSynth to not depend on HWModuleOp anymore, and replicate the tests to check that.