### PR TITLE
[Synth][CutRewriter] Support choice cuts in mapping

### DIFF
--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -118,7 +118,8 @@ struct LogicNetworkGate {
     And2 = 2,         ///< AND gate (2-input, aig::AndInverterOp)
     Xor2 = 3,         ///< XOR gate (2-input)
     Maj3 = 4,         ///< Reserved 3-input gate kind
-    Identity = 5      ///< Identity gate (used for 1-input inverter)
+    Identity = 5,     ///< Identity gate (used for 1-input inverter)
+    Choice = 6        ///< Choice node (synth.choice)
   };
 
   /// Operation pointer and kind packed together.
@@ -126,8 +127,8 @@ struct LogicNetworkGate {
   llvm::PointerIntPair<Operation *, 3, Kind> opAndKind;
 
   /// Fanin edges (up to 3 inputs). For AND gates, only edges[0] and edges[1]
-  /// are used. For MAJ gates, all three are used. For PrimaryInput/Constant,
-  /// none are used. The inversion bit is encoded in each edge.
+  /// are used. For PrimaryInput/Constant and Choice, none are used. The
+  /// inversion bit is encoded in each edge.
   Signal edges[3];
 
   LogicNetworkGate() : opAndKind(nullptr, Constant), edges{} {}
@@ -158,6 +159,8 @@ struct LogicNetworkGate {
       return 3;
     case Identity:
       return 1;
+    case Choice:
+      return 0;
     }
     llvm_unreachable("Unknown gate kind");
   }
@@ -165,7 +168,7 @@ struct LogicNetworkGate {
   /// Check if this is a logic gate that can be part of a cut.
   bool isLogicGate() const {
     Kind k = getKind();
-    return k == And2 || k == Xor2 || k == Maj3 || k == Identity;
+    return k == And2 || k == Xor2 || k == Maj3 || k == Identity || k == Choice;
   }
 
   /// Check if this should always be a cut input (PI or constant).
@@ -409,6 +412,15 @@ class Cut {
   llvm::SmallVector<const Cut *, 3> operandCuts;
 
 public:
+  Cut() = default;
+  Cut(uint32_t rootIndex, ArrayRef<uint32_t> inputs, uint64_t signature,
+      ArrayRef<const Cut *> operandCuts = {},
+      std::optional<BinaryTruthTable> truthTable = std::nullopt)
+      : truthTable(std::move(truthTable)), rootIndex(rootIndex),
+        signature(signature),
+        operandCuts(operandCuts.begin(), operandCuts.end()),
+        inputs(inputs.begin(), inputs.end()) {}
+
   /// Create a trivial cut for a value.
   static Cut getTrivialCut(uint32_t index);
 

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -194,6 +194,15 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
               valueToIndex[result] = constIdx;
               return success();
             })
+            .Case<synth::ChoiceOp>([&](synth::ChoiceOp choiceOp) {
+              if (!choiceOp.getType().isInteger(1)) {
+                handleOtherResults(choiceOp);
+                return success();
+              }
+              addGate(choiceOp, LogicNetworkGate::Choice, choiceOp.getResult(),
+                      {});
+              return success();
+            })
             .Default([&](Operation *defaultOp) {
               handleOtherResults(defaultOp);
               return success();
@@ -242,11 +251,12 @@ static bool compareDelayAndArea(OptimizationStrategy strategy, double newArea,
 
 LogicalResult circt::synth::topologicallySortLogicNetwork(Operation *topOp) {
   const auto isOperationReady = [](Value value, Operation *op) -> bool {
-    // Topologically sort AIG ops and dataflow ops. Other operations can be
-    // scheduled.
-    return !(isa<aig::AndInverterOp>(op) ||
-             isa<comb::XorOp, comb::AndOp, comb::OrOp, comb::ExtractOp,
-                 comb::ReplicateOp, comb::ConcatOp>(op));
+    // Topologically sort AIG ops and dataflow ops. Other operations
+    // can be scheduled.
+    return !(
+        isa<aig::AndInverterOp, synth::ChoiceOp, comb::XorOp, comb::AndOp,
+            comb::OrOp, comb::ExtractOp, comb::ReplicateOp, comb::ConcatOp>(
+            op));
   };
 
   if (failed(topologicallySortGraphRegionBlocks(topOp, isOperationReady)))
@@ -287,8 +297,13 @@ FailureOr<BinaryTruthTable> circt::synth::getTruthTable(ValueRange values,
     if (op.getNumResults() == 0)
       continue;
 
-    // Support AIG and XOR operations
-    if (auto andOp = dyn_cast<aig::AndInverterOp>(&op)) {
+    if (auto choiceOp = dyn_cast<synth::ChoiceOp>(&op)) {
+      auto it = eval.find(choiceOp.getInputs().front());
+      if (it == eval.end())
+        return choiceOp.emitError("Input value not found in evaluation map");
+      eval[choiceOp.getResult()] = it->second;
+    } else if (auto andOp = dyn_cast<aig::AndInverterOp>(&op)) {
+      // Support AIG and XOR operations
       SmallVector<llvm::APInt, 2> inputs;
       inputs.reserve(andOp.getInputs().size());
       for (auto input : andOp.getInputs()) {
@@ -868,6 +883,35 @@ LogicalResult CutEnumerator::visitLogicOp(uint32_t nodeIndex) {
   assert(logicOp && logicOp->getNumResults() == 1 &&
          "Logic operation must have a single result");
 
+  if (gate.getKind() == LogicNetworkGate::Choice) {
+    auto choiceOp = cast<synth::ChoiceOp>(logicOp);
+    auto *resultCutSet = createNewCutSet(nodeIndex);
+    Cut *primaryInputCut = cutAllocator.create(Cut::getTrivialCut(nodeIndex));
+    processingOrder.push_back(nodeIndex);
+    resultCutSet->addCut(primaryInputCut);
+
+    for (Value operand : choiceOp.getInputs()) {
+      auto *operandCutSet = getCutSet(logicNetwork.getIndex(operand));
+      if (!operandCutSet)
+        return logicOp->emitError("Failed to get cut set for choice operand");
+
+      // Choice nodes do not introduce new logic. They forward each non-trivial
+      // operand cut as an equivalent alternative for the same root.
+      for (const Cut *operandCut : operandCutSet->getCuts()) {
+        if (operandCut->isTrivialCut())
+          continue;
+
+        resultCutSet->addCut(cutAllocator.create(
+            nodeIndex, operandCut->inputs, operandCut->getSignature(),
+            ArrayRef<const Cut *>{operandCut}, *operandCut->getTruthTable()));
+      }
+    }
+
+    // Finalize cut set: remove duplicates, limit size, and match patterns
+    resultCutSet->finalize(options, matchCut, logicNetwork);
+    return success();
+  }
+
   unsigned numFanins = gate.getNumFanins();
 
   // Validate operation constraints
@@ -909,12 +953,6 @@ LogicalResult CutEnumerator::visitLogicOp(uint32_t nodeIndex) {
   auto *resultCutSet = createNewCutSet(nodeIndex);
   processingOrder.push_back(nodeIndex);
   resultCutSet->addCut(primaryInputCut);
-
-  // Schedule cut set finalization when exiting this scope
-  llvm::scope_exit prune([&]() {
-    // Finalize cut set: remove duplicates, limit size, and match patterns
-    resultCutSet->finalize(options, matchCut, logicNetwork);
-  });
 
   // Sort operand cut sets by their largest cut size in descending order. This
   // heuristic improves efficiency of the k-way merge when generating cuts for
@@ -1011,14 +1049,8 @@ LogicalResult CutEnumerator::visitLogicOp(uint32_t nodeIndex) {
       }
 
       // Create the merged cut.
-      Cut *mergedCut = cutAllocator.create();
-      mergedCut->setRootIndex(nodeIndex);
-      mergedCut->inputs = std::move(mergedInputs);
-
-      // Store operand cuts for lazy truth table computation using fast
-      // incremental method (after duplicate removal in finalize)
-      mergedCut->setOperandCuts(cutPtrs);
-      mergedCut->setSignature(currentSig);
+      Cut *mergedCut = cutAllocator.create(nodeIndex, mergedInputs, currentSig,
+                                           ArrayRef<const Cut *>(cutPtrs));
       resultCutSet->addCut(mergedCut);
 
       LLVM_DEBUG({
@@ -1055,6 +1087,9 @@ LogicalResult CutEnumerator::visitLogicOp(uint32_t nodeIndex) {
   SmallVector<const Cut *, 3> cutPtrs;
   cutPtrs.reserve(numFanins);
   enumerateCutCombinations(enumerateCutCombinations, 0, cutPtrs, 0ULL);
+
+  // Finalize cut set: remove duplicates, limit size, and match patterns
+  resultCutSet->finalize(options, matchCut, logicNetwork);
 
   return success();
 }

--- a/test/Dialect/Synth/lut-mapper.mlir
+++ b/test/Dialect/Synth/lut-mapper.mlir
@@ -41,3 +41,30 @@ hw.module @add(in %a : i2, in %b : i2, out result : i2) {
   %13 = comb.concat %12, %6 : i1, i1
   hw.output %13 : i2
 }
+
+// CHECK-LABEL: hw.module @choice_slow_branch
+// LUT-NEXT:   %[[OUT:.+]] = comb.truth_table %c, %b, %a -> [false, false, false, false, false, false, false, true]
+// LUT-SAME:   test.arrival_times = [1]
+// LUT-NEXT:   hw.output %[[OUT]] : i1
+// LUT2-NEXT:  %[[AB:.+]] = comb.truth_table %b, %a -> [false, false, false, true]
+// LUT2-SAME:  test.arrival_times = [1]
+// LUT2-NEXT:  %[[OUT:.+]] = comb.truth_table %[[AB]], %c -> [false, false, false, true]
+// LUT2-SAME:  test.arrival_times = [2]
+// LUT2-NEXT:  hw.output %[[OUT]] : i1
+hw.module @choice_slow_branch(in %a : i1, in %b : i1, in %c : i1,
+                              out y : i1) {
+  %fast0 = synth.aig.and_inv %a, %b : i1
+  %fast = synth.aig.and_inv %fast0, %c : i1
+
+  %na = synth.aig.and_inv not %a : i1
+  %a2 = synth.aig.and_inv not %na : i1
+  %nb = synth.aig.and_inv not %b : i1
+  %b2 = synth.aig.and_inv not %nb : i1
+  %nc = synth.aig.and_inv not %c : i1
+  %c2 = synth.aig.and_inv not %nc : i1
+  %slow0 = synth.aig.and_inv %a2, %b2 : i1
+  %slow = synth.aig.and_inv %slow0, %c2 : i1
+
+  %choice = synth.choice %slow, %fast : i1
+  hw.output %choice : i1
+}

--- a/test/Dialect/Synth/priority-cuts.mlir
+++ b/test/Dialect/Synth/priority-cuts.mlir
@@ -122,3 +122,17 @@ hw.module @Issue8885(in %a : i2, in %b : i2) {
   %5 = synth.aig.and_inv %0, %2 {sv.namehint = "and1"} : i1
   %6 = synth.aig.and_inv not %4, not %5 {sv.namehint = "xor0"} : i1
 }
+
+// ROOT8-LABEL: Enumerating cuts for module: choice_expanded_truth_table
+// ROOT8: choice 4 cuts: {choice}@t2d0 {a, b, c}@t128d1 {a, bc}@t8d2 {c, ab}@t8d2
+// ROOT8: out 5 cuts: {out}@t2d0 {a, b, c, d}@t32768d1 {d, choice}@t8d2 {a, d, bc}@t128d2 {c, d, ab}@t128d2
+hw.module @choice_expanded_truth_table(in %a : i1, in %b : i1, in %c : i1,
+                                       in %d : i1, out y : i1) {
+  %ab = synth.aig.and_inv %a, %b {sv.namehint = "ab"} : i1
+  %abc_left = synth.aig.and_inv %ab, %c {sv.namehint = "abc_left"} : i1
+  %bc = synth.aig.and_inv %b, %c {sv.namehint = "bc"} : i1
+  %abc_right = synth.aig.and_inv %a, %bc {sv.namehint = "abc_right"} : i1
+  %choice = synth.choice %abc_left, %abc_right {sv.namehint = "choice"} : i1
+  %out = synth.aig.and_inv %choice, %d {sv.namehint = "out"} : i1
+  hw.output %out : i1
+}


### PR DESCRIPTION
Teach the cut rewriter to model `synth.choice` as alternative cuts for the same root so equivalent implementations can participate in cut selection and rewriting.

AI-assisted-by: codex 5.3
