### PR TITLE
[Sim] Implement the lowering logic from sim.proc.print to the SV dialect

### DIFF
--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -468,14 +468,13 @@ static bool moveOpsIntoIfdefGuardsAndProcesses(Operation *rootOp) {
 
 namespace {
 
-static LogicalResult emitLoweringError(Location loc, const Twine &reason) {
-  mlir::emitError(loc) << "cannot lower 'sim.proc.print' to sv.write: "
-                       << reason;
-  return failure();
+LogicalResult emitLoweringError(Location loc, const Twine &reason) {
+  return mlir::emitError(loc)
+         << "cannot lower 'sim.proc.print' to sv.write: " << reason;
 }
 
-static void appendLiteralToFWriteFormat(SmallString<128> &formatString,
-                                        StringRef literal) {
+void appendLiteralToFWriteFormat(SmallString<128> &formatString,
+                                 StringRef literal) {
   for (char ch : literal) {
     if (ch == '%')
       formatString += "%%";
@@ -484,11 +483,9 @@ static void appendLiteralToFWriteFormat(SmallString<128> &formatString,
   }
 }
 
-static LogicalResult appendIntegerSpecifier(SmallString<128> &formatString,
-                                            bool isLeftAligned,
-                                            uint8_t paddingChar,
-                                            std::optional<int32_t> width,
-                                            char spec) {
+LogicalResult appendIntegerSpecifier(SmallString<128> &formatString,
+                                     bool isLeftAligned, uint8_t paddingChar,
+                                     std::optional<int32_t> width, char spec) {
   formatString.push_back('%');
   if (isLeftAligned)
     formatString.push_back('-');
@@ -507,10 +504,9 @@ static LogicalResult appendIntegerSpecifier(SmallString<128> &formatString,
   return success();
 }
 
-static void appendFloatSpecifier(SmallString<128> &formatString,
-                                 bool isLeftAligned,
-                                 std::optional<int32_t> fieldWidth,
-                                 int32_t fracDigits, char spec) {
+void appendFloatSpecifier(SmallString<128> &formatString, bool isLeftAligned,
+                          std::optional<int32_t> fieldWidth, int32_t fracDigits,
+                          char spec) {
   formatString.push_back('%');
   if (isLeftAligned)
     formatString.push_back('-');
@@ -521,8 +517,8 @@ static void appendFloatSpecifier(SmallString<128> &formatString,
   formatString.push_back(spec);
 }
 
-static LogicalResult
-getFlattenedFormatFragments(Value input, SmallVectorImpl<Value> &fragments) {
+LogicalResult getFlattenedFormatFragments(Value input,
+                                          SmallVectorImpl<Value> &fragments) {
   if (auto concat = input.getDefiningOp<FormatStringConcatOp>()) {
     if (failed(concat.getFlattenedInputs(fragments)))
       return emitLoweringError(input.getLoc(),
@@ -534,9 +530,10 @@ getFlattenedFormatFragments(Value input, SmallVectorImpl<Value> &fragments) {
   return success();
 }
 
-static LogicalResult
-appendFormatFragmentToFWrite(Value fragment, SmallString<128> &formatString,
-                             SmallVectorImpl<Value> &args, OpBuilder &builder) {
+LogicalResult appendFormatFragmentToFWrite(Value fragment,
+                                           SmallString<128> &formatString,
+                                           SmallVectorImpl<Value> &args,
+                                           OpBuilder &builder) {
   Operation *fragmentOp = fragment.getDefiningOp();
   if (!fragmentOp)
     return emitLoweringError(fragment.getLoc(),
@@ -639,10 +636,10 @@ appendFormatFragmentToFWrite(Value fragment, SmallString<128> &formatString,
       });
 }
 
-static LogicalResult foldFormatStringToFWrite(Value input,
-                                              SmallString<128> &formatString,
-                                              SmallVectorImpl<Value> &args,
-                                              OpBuilder &builder) {
+LogicalResult foldFormatStringToFWrite(Value input,
+                                       SmallString<128> &formatString,
+                                       SmallVectorImpl<Value> &args,
+                                       OpBuilder &builder) {
   SmallVector<Value, 8> fragments;
   if (failed(getFlattenedFormatFragments(input, fragments)))
     return failure();

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/RegionUtils.h"
+#include "llvm/ADT/Twine.h"
 
 #define DEBUG_TYPE "lower-sim-to-sv"
 
@@ -500,7 +501,7 @@ static LogicalResult appendIntegerSpecifier(SmallString<128> &formatString,
     return failure();
 
   if (width.has_value())
-    formatString += std::to_string(width.value());
+    llvm::Twine(width.value()).toVector(formatString);
 
   formatString.push_back(spec);
   return success();
@@ -514,9 +515,9 @@ static void appendFloatSpecifier(SmallString<128> &formatString,
   if (isLeftAligned)
     formatString.push_back('-');
   if (fieldWidth.has_value())
-    formatString += std::to_string(fieldWidth.value());
+    llvm::Twine(fieldWidth.value()).toVector(formatString);
   formatString.push_back('.');
-  formatString += std::to_string(fracDigits);
+  llvm::Twine(fracDigits).toVector(formatString);
   formatString.push_back(spec);
 }
 
@@ -702,9 +703,8 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
 
     std::atomic<bool> usedSynthesisMacro = false;
     auto lowerModule = [&](hw::HWModuleOp module) {
-      if (failed(lowerPrintFormattedProcToSV(module))) {
+      if (failed(lowerPrintFormattedProcToSV(module)))
         return failure();
-      }
 
       if (moveOpsIntoIfdefGuardsAndProcesses(module))
         usedSynthesisMacro = true;

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -26,6 +26,7 @@
 #include "mlir/IR/Threading.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/RegionUtils.h"
 
 #define DEBUG_TYPE "lower-sim-to-sv"
 
@@ -465,6 +466,229 @@ static bool moveOpsIntoIfdefGuardsAndProcesses(Operation *rootOp) {
 }
 
 namespace {
+
+static LogicalResult emitLoweringError(Location loc, const Twine &reason) {
+  mlir::emitError(loc) << "cannot lower 'sim.proc.print' to sv.write: "
+                       << reason;
+  return failure();
+}
+
+static void appendLiteralToFWriteFormat(SmallString<128> &formatString,
+                                        StringRef literal) {
+  for (char ch : literal) {
+    if (ch == '%')
+      formatString += "%%";
+    else
+      formatString.push_back(ch);
+  }
+}
+
+static LogicalResult appendIntegerSpecifier(SmallString<128> &formatString,
+                                            bool isLeftAligned,
+                                            uint8_t paddingChar,
+                                            std::optional<int32_t> width,
+                                            char spec) {
+  formatString.push_back('%');
+  if (isLeftAligned)
+    formatString.push_back('-');
+
+  // SystemVerilog formatting only has built-in support for '0' and ' '. Keep
+  // this lowering strict to avoid silently changing formatting semantics.
+  if (paddingChar == '0')
+    formatString.push_back('0');
+  else if (paddingChar != ' ')
+    return failure();
+
+  if (width.has_value())
+    formatString += std::to_string(width.value());
+
+  formatString.push_back(spec);
+  return success();
+}
+
+static void appendFloatSpecifier(SmallString<128> &formatString,
+                                 bool isLeftAligned,
+                                 std::optional<int32_t> fieldWidth,
+                                 int32_t fracDigits, char spec) {
+  formatString.push_back('%');
+  if (isLeftAligned)
+    formatString.push_back('-');
+  if (fieldWidth.has_value())
+    formatString += std::to_string(fieldWidth.value());
+  formatString.push_back('.');
+  formatString += std::to_string(fracDigits);
+  formatString.push_back(spec);
+}
+
+static LogicalResult
+getFlattenedFormatFragments(Value input, SmallVectorImpl<Value> &fragments) {
+  if (auto concat = input.getDefiningOp<FormatStringConcatOp>()) {
+    if (failed(concat.getFlattenedInputs(fragments)))
+      return emitLoweringError(input.getLoc(),
+                               "cyclic sim.fmt.concat is unsupported");
+    return success();
+  }
+
+  fragments.push_back(input);
+  return success();
+}
+
+static LogicalResult
+appendFormatFragmentToFWrite(Value fragment, SmallString<128> &formatString,
+                             SmallVectorImpl<Value> &args, OpBuilder &builder) {
+  Operation *fragmentOp = fragment.getDefiningOp();
+  if (!fragmentOp)
+    return emitLoweringError(fragment.getLoc(),
+                             "block argument format strings are unsupported as "
+                             "sim.proc.print input");
+
+  return TypeSwitch<Operation *, LogicalResult>(fragmentOp)
+      .Case<FormatLiteralOp>([&](auto literal) -> LogicalResult {
+        appendLiteralToFWriteFormat(formatString, literal.getLiteral());
+        return success();
+      })
+      .Case<FormatHierPathOp>([&](auto hierPath) -> LogicalResult {
+        formatString += hierPath.getUseEscapes() ? "%M" : "%m";
+        return success();
+      })
+      .Case<FormatCharOp>([&](auto fmt) -> LogicalResult {
+        formatString += "%c";
+        args.push_back(fmt.getValue());
+        return success();
+      })
+      .Case<FormatDecOp>([&](auto fmt) -> LogicalResult {
+        if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
+                                          fmt.getPaddingChar(),
+                                          fmt.getSpecifierWidth(), 'd'))) {
+          return emitLoweringError(
+              fmt.getLoc(), "sim.fmt.dec only supports paddingChar 32 (' ') "
+                            "or 48 ('0') for SystemVerilog lowering");
+        }
+        // Match sim.fmt.dec signedness semantics explicitly in SV.
+        if (fmt.getIsSigned()) {
+          auto signedValue = sv::SystemFunctionOp::create(
+              builder, fmt.getLoc(), fmt.getValue().getType(), "signed",
+              ValueRange{fmt.getValue()});
+          args.push_back(signedValue);
+        } else {
+          auto unsignedValue = sv::SystemFunctionOp::create(
+              builder, fmt.getLoc(), fmt.getValue().getType(), "unsigned",
+              ValueRange{fmt.getValue()});
+          args.push_back(unsignedValue);
+        }
+        return success();
+      })
+      .Case<FormatHexOp>([&](auto fmt) -> LogicalResult {
+        if (failed(appendIntegerSpecifier(
+                formatString, fmt.getIsLeftAligned(), fmt.getPaddingChar(),
+                fmt.getSpecifierWidth(),
+                fmt.getIsHexUppercase() ? 'X' : 'x'))) {
+          return emitLoweringError(
+              fmt.getLoc(), "sim.fmt.hex only supports paddingChar 32 (' ') "
+                            "or 48 ('0') for SystemVerilog lowering");
+        }
+        args.push_back(fmt.getValue());
+        return success();
+      })
+      .Case<FormatOctOp>([&](auto fmt) -> LogicalResult {
+        if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
+                                          fmt.getPaddingChar(),
+                                          fmt.getSpecifierWidth(), 'o'))) {
+          return emitLoweringError(
+              fmt.getLoc(), "sim.fmt.oct only supports paddingChar 32 (' ') "
+                            "or 48 ('0') for SystemVerilog lowering");
+        }
+        args.push_back(fmt.getValue());
+        return success();
+      })
+      .Case<FormatBinOp>([&](auto fmt) -> LogicalResult {
+        if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
+                                          fmt.getPaddingChar(),
+                                          fmt.getSpecifierWidth(), 'b'))) {
+          return emitLoweringError(
+              fmt.getLoc(), "sim.fmt.bin only supports paddingChar 32 (' ') "
+                            "or 48 ('0') for SystemVerilog lowering");
+        }
+        args.push_back(fmt.getValue());
+        return success();
+      })
+      .Case<FormatScientificOp>([&](auto fmt) -> LogicalResult {
+        appendFloatSpecifier(formatString, fmt.getIsLeftAligned(),
+                             fmt.getFieldWidth(), fmt.getFracDigits(), 'e');
+        args.push_back(fmt.getValue());
+        return success();
+      })
+      .Case<FormatFloatOp>([&](auto fmt) -> LogicalResult {
+        appendFloatSpecifier(formatString, fmt.getIsLeftAligned(),
+                             fmt.getFieldWidth(), fmt.getFracDigits(), 'f');
+        args.push_back(fmt.getValue());
+        return success();
+      })
+      .Case<FormatGeneralOp>([&](auto fmt) -> LogicalResult {
+        appendFloatSpecifier(formatString, fmt.getIsLeftAligned(),
+                             fmt.getFieldWidth(), fmt.getFracDigits(), 'g');
+        args.push_back(fmt.getValue());
+        return success();
+      })
+      .Default([&](auto unsupportedOp) {
+        return emitLoweringError(unsupportedOp->getLoc(),
+                                 Twine("unsupported format fragment '") +
+                                     unsupportedOp->getName().getStringRef() +
+                                     "'");
+      });
+}
+
+static LogicalResult foldFormatStringToFWrite(Value input,
+                                              SmallString<128> &formatString,
+                                              SmallVectorImpl<Value> &args,
+                                              OpBuilder &builder) {
+  SmallVector<Value, 8> fragments;
+  if (failed(getFlattenedFormatFragments(input, fragments)))
+    return failure();
+  for (auto fragment : fragments)
+    if (failed(appendFormatFragmentToFWrite(fragment, formatString, args,
+                                            builder)))
+      return failure();
+  return success();
+}
+
+LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module) {
+  SmallVector<PrintFormattedProcOp> printOps;
+  module.walk([&](PrintFormattedProcOp op) { printOps.push_back(op); });
+
+  llvm::SmallPtrSet<Operation *, 8> dceRoots;
+
+  for (auto printOp : printOps) {
+    OpBuilder builder(printOp);
+    SmallString<128> formatString;
+    SmallVector<Value> args;
+    if (failed(foldFormatStringToFWrite(printOp.getInput(), formatString, args,
+                                        builder))) {
+      return failure();
+    }
+    auto stream = printOp.getStream();
+    if (!stream) {
+      // no stream is specified, emit sv.write.
+      sv::WriteOp::create(builder, printOp.getLoc(), formatString, args);
+    } else {
+      // Stream-based printing is not supported yet.
+      return printOp->emitError(
+          "lowering 'sim.proc.print' with a stream is not supported yet");
+    }
+    auto *procRoot =
+        printOp->getParentWithTrait<mlir::OpTrait::IsIsolatedFromAbove>();
+    if (procRoot)
+      dceRoots.insert(procRoot);
+    printOp.erase();
+  }
+
+  mlir::IRRewriter rewriter(module);
+  for (Operation *dceRoot : dceRoots)
+    (void)mlir::runRegionDCE(rewriter, dceRoot->getRegions());
+
+  return success();
+}
+
 struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
   void runOnOperation() override {
     auto circuit = getOperation();
@@ -478,6 +702,10 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
 
     std::atomic<bool> usedSynthesisMacro = false;
     auto lowerModule = [&](hw::HWModuleOp module) {
+      if (failed(lowerPrintFormattedProcToSV(module))) {
+        return failure();
+      }
+
       if (moveOpsIntoIfdefGuardsAndProcesses(module))
         usedSynthesisMacro = true;
 

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv-errors.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv-errors.mlir
@@ -1,0 +1,42 @@
+// RUN: circt-opt --lower-sim-to-sv --split-input-file --verify-diagnostics %s
+
+hw.module @unsupported_padding_char(in %clk : i1, in %arg : i8) {
+  hw.triggered posedge %clk (%arg) : i8 {
+    ^bb0(%arg_in : i8):
+    %lit = sim.fmt.literal "bad="
+    // expected-error @below {{cannot lower 'sim.proc.print' to sv.write: sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0') for SystemVerilog lowering}}
+    %bad = sim.fmt.dec %arg_in paddingChar 42 specifierWidth 2 : i8
+    %msg = sim.fmt.concat (%lit, %bad)
+    sim.proc.print %msg
+  }
+}
+
+// -----
+
+hw.module @unsupported_input_block_argument(in %clk : i1, in %arg : !sim.fstring) {
+  hw.triggered posedge %clk (%arg) : !sim.fstring {
+    // expected-error @below {{cannot lower 'sim.proc.print' to sv.write: block argument format strings are unsupported as sim.proc.print input}}
+    ^bb0(%arg_in : !sim.fstring):
+    sim.proc.print %arg_in
+  }
+}
+
+// -----
+
+hw.module @unsupported_stream_block_argument(
+    in %clk : i1, in %stream : !sim.output_stream) {
+  hw.triggered posedge %clk (%stream) : !sim.output_stream {
+    ^bb0(%stream_in : !sim.output_stream):
+    %fmt = sim.fmt.literal "x"
+    // expected-error @below {{lowering 'sim.proc.print' with a stream is not supported yet}}
+    sim.proc.print %fmt to %stream_in
+  }
+}
+
+// -----
+
+hw.module @unsupported_stream_from_get_file() {
+    %literal = sim.fmt.literal "stream.log"
+    // expected-error @below {{'sim.proc.print' op must not be in a non-procedural region}}
+    sim.proc.print %literal 
+}

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv-errors.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv-errors.mlir
@@ -32,11 +32,3 @@ hw.module @unsupported_stream_block_argument(
     sim.proc.print %fmt to %stream_in
   }
 }
-
-// -----
-
-hw.module @unsupported_stream_from_get_file() {
-    %literal = sim.fmt.literal "stream.log"
-    // expected-error @below {{'sim.proc.print' op must not be in a non-procedural region}}
-    sim.proc.print %literal 
-}

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
@@ -1,0 +1,103 @@
+// RUN: circt-opt --lower-sim-to-sv %s | FileCheck %s
+
+// This pass assumes sim.proc.print is already in some procedural region.
+// It lowers both SV and non-SV procedural containers (e.g. hw.triggered).
+
+// CHECK-LABEL: hw.module @proc_print
+hw.module @proc_print(in %clk : i1, in %arg: i8) {
+  // CHECK: hw.triggered posedge %clk
+  hw.triggered posedge %clk (%arg) : i8 {
+    ^bb0(%arg_in : i8):
+    %l0 = sim.fmt.literal "err: "
+    %f0 = sim.fmt.hex %arg_in, isUpper true specifierWidth 2 : i8
+    %l1 = sim.fmt.literal " 100%"
+    %msg = sim.fmt.concat (%l0, %f0, %l1)
+
+    // CHECK: sv.write "err: %02X 100%%"
+    sim.proc.print %msg
+  }
+}
+
+
+// CHECK-LABEL: hw.module @all_format_fragments
+hw.module @all_format_fragments(
+    in %clk : i1, in %ival : i16, in %ch : i8, in %fval : f64) {
+  hw.triggered posedge %clk (%ival, %ch, %fval) : i16, i8, f64 {
+    ^bb0(%ival_in : i16, %ch_in : i8, %fval_in : f64):
+    %i0 = sim.fmt.literal "dec="
+    %f0 = sim.fmt.dec %ival_in specifierWidth 6 signed : i16
+    %i1 = sim.fmt.literal " hex="
+    %f1 = sim.fmt.hex %ival_in, isUpper true paddingChar 48 specifierWidth 4 : i16
+    %i2 = sim.fmt.literal " oct="
+    %f2 = sim.fmt.oct %ival_in isLeftAligned true specifierWidth 6 : i16
+    %i3 = sim.fmt.literal " bin="
+    %f3 = sim.fmt.bin %ival_in paddingChar 32 specifierWidth 8 : i16
+    %i4 = sim.fmt.literal " char="
+    %f4 = sim.fmt.char %ch_in : i8
+    %i5 = sim.fmt.literal " exp="
+    %f5 = sim.fmt.exp %fval_in fieldWidth 10 fracDigits 3 : f64
+    %i6 = sim.fmt.literal " flt="
+    %f6 = sim.fmt.flt %fval_in isLeftAligned true fieldWidth 8 fracDigits 2 : f64
+    %i7 = sim.fmt.literal " gen="
+    %f7 = sim.fmt.gen %fval_in fracDigits 4 : f64
+    %i8 = sim.fmt.literal " path="
+    %f8 = sim.fmt.hier_path
+    %i9 = sim.fmt.literal " esc="
+    %f9 = sim.fmt.hier_path escaped
+    %i10 = sim.fmt.literal " pct=%"
+    %msg = sim.fmt.concat (%i0, %f0, %i1, %f1, %i2, %f2, %i3, %f3, %i4, %f4, %i5, %f5, %i6, %f6, %i7, %f7, %i8, %f8, %i9, %f9, %i10)
+
+    // CHECK: ^bb0(%[[IVAL:.+]]: i16, %[[CH:.+]]: i8, %[[FVAL:.+]]: f64):
+    // CHECK-NEXT: %[[SIGNED:.+]] = sv.system "signed"(%[[IVAL]]) : (i16) -> i16
+    // CHECK-NEXT: sv.write "dec=%6d hex=%04X oct=%-06o bin=%8b char=%c exp=%10.3e flt=%-8.2f gen=%.4g path=%m esc=%M pct=%%"(%[[SIGNED]], %[[IVAL]], %[[IVAL]], %[[IVAL]], %[[CH]], %[[FVAL]], %[[FVAL]], %[[FVAL]]) : i16, i16, i16, i16, i8, f64, f64, f64
+    sim.proc.print %msg
+  }
+}
+
+// CHECK-LABEL: hw.module @nested_concat_order
+hw.module @nested_concat_order(in %clk : i1, in %lhs : i8, in %rhs : i8) {
+  hw.triggered posedge %clk (%lhs, %rhs) : i8, i8 {
+    ^bb0(%lhs_in : i8, %rhs_in : i8):
+    %l0 = sim.fmt.literal "L="
+    %l1 = sim.fmt.literal ", R="
+    %d0 = sim.fmt.dec %lhs_in specifierWidth 3 : i8
+    %h0 = sim.fmt.hex %rhs_in, isUpper false specifierWidth 2 : i8
+
+    %c0 = sim.fmt.concat (%l0, %d0)
+    %c1 = sim.fmt.concat (%c0, %l1)
+    %c2 = sim.fmt.concat (%c1, %h0)
+
+    // CHECK: ^bb0(%[[LHS:.+]]: i8, %[[RHS:.+]]: i8):
+    // CHECK-NEXT: %[[UNSIGNED:.+]] = sv.system "unsigned"(%[[LHS]]) : (i8) -> i8
+    // CHECK-NEXT: sv.write "L=%3d, R=%02x"(%[[UNSIGNED]], %[[RHS]]) : i8, i8
+    sim.proc.print %c2
+  }
+}
+
+// CHECK-LABEL: hw.module @dce_uses_outer_procedural_root
+hw.module @dce_uses_outer_procedural_root(
+    in %clk : i1, in %cond : i1, in %val : i8) {
+  // CHECK: hw.triggered posedge %clk
+  hw.triggered posedge %clk (%cond, %val) : i1, i8 {
+    ^bb0(%cond_in : i1, %val_in : i8):
+    %lit = sim.fmt.literal "v="
+    %fmt = sim.fmt.dec %val_in : i8
+    %msg = sim.fmt.concat (%lit, %fmt)
+    // CHECK: ^bb0(%[[COND:.+]]: i1, %[[VAL:.+]]: i8):
+    // CHECK: scf.if %[[COND]] {
+    // CHECK: %[[UNSIGNED:.+]] = sv.system "unsigned"(%[[VAL]]) : (i8) -> i8
+    // CHECK-NEXT: sv.write "v=%d"(%[[UNSIGNED]]) : i8
+    scf.if %cond_in {
+      sim.proc.print %msg
+    }
+  }
+}
+
+hw.module @triggered_print(in %clk : i1) {
+  // CHECK-LABEL: hw.module @triggered_print
+  hw.triggered posedge %clk {
+    %lit = sim.fmt.literal "hello"
+    // CHECK: sv.write "hello"
+    sim.proc.print %lit
+  }
+}


### PR DESCRIPTION
This PR lowers `sim.proc.print` to SystemVerilog `sv.fwrite`.

It only handles the procedural form of print operations. Non-procedural `sim.print` is expected to be converted first, for example by `--sim-proceduralize`.

Split from #10146 .

AI-assisted-by: OpenAI ChatGPT