### PR TITLE
[ci] Add z3 to UBTI native builds

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -176,6 +176,7 @@ jobs:
         run: |
           choco install z3
           echo setup=./utils/find-vs.ps1 >> "$GITHUB_OUTPUT"
+          echo cmake="-DZ3_DIR=C:\ProgramData\chocolatey\lib\z3\tools" >> "$GITHUB_OUTPUT"
 # Setup Caching.  Caching has several constraints:
 #
 # 1. RelWithDebInfo and Debug builds require very large caches, roughly ~4.5GiB.
@@ -206,7 +207,7 @@ jobs:
           ${{ steps.setup-windows.outputs.setup }}
           mkdir build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v" -DLLVM_ENABLE_Z3_SOLVER=ON
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v" -DLLVM_ENABLE_Z3_SOLVER=ON ${{ steps.setup-windows.outputs.cmake }}
 # Optionally test
       - name: Test CIRCT
         if: inputs.run_tests

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -191,6 +191,7 @@ jobs:
           # Z3 zips always extract into a folder like 'z3-4.13.0-x64-win'
           Z3_DIR=$(find . -maxdepth 1 -type d -name "z3-*" | head -n 1)
           echo "$(pwd)/$Z3_DIR/bin" >> $GITHUB_PATH
+          z3 --version
           #--------------------------------------- Setup VS Code dev environment
           echo setup=./utils/find-vs.ps1 >> "$GITHUB_OUTPUT"
 # Setup Caching.  Caching has several constraints:

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -164,21 +164,14 @@ jobs:
 #
 # Setup z3 for Linux and macOS.  This hasn't been working on Windows through
 # `choco install z3`, so don't turn on z3 for those runs.
-#
-# Any runner-specific CMAKE configuration can be put into the `cmake` output.
-# These will be used when running `cmake` later.
       - name: Setup (linux)
-        id: setup-linux
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install ninja-build z3
-          echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Setup (macos)
-        id: setup-macos
         if: runner.os == 'macOS'
         run: |
           brew install gnu-tar ninja z3
-          echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Setup (windows)
         id: setup-windows
         if: runner.os == 'Windows'
@@ -215,7 +208,7 @@ jobs:
           ${{ steps.setup-windows.outputs.setup }}
           mkdir build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v" ${{ steps.setup-windows.outputs.cmake }} ${{ steps.setup-linux.outputs.cmake }} ${{ steps.setup-windows.outputs.cmake }}
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v"
 # Optionally test
       - name: Test CIRCT
         if: inputs.run_tests

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -164,16 +164,34 @@ jobs:
       - name: Setup (linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install ninja-build
+          sudo apt-get install ninja-build z3
       - name: Setup (macos)
         if: runner.os == 'macOS'
         run: |
-          brew install ninja gnu-tar
+          brew install gnu-tar ninja z3
       - name: Setup (windows)
         id: setup-windows
         if: runner.os == 'Windows'
         shell: bash
         run: |
+          #--------------------------------------- Install latest z3
+          # 1. Query the GitHub API for the latest release and find the win zip
+          # URL.  This grabs the browser_download_url for the file ending in
+          # -x64-win.zip.
+          Z3_URL=$(curl -s https://api.github.com/repos/Z3Prover/z3/releases/latest | grep "browser_download_url" | grep "x64-win.zip" | cut -d '"' -f 4)
+          echo "Found latest Z3 at: $Z3_URL"
+
+          # 2. Download it.
+          curl -L --retry 3 "$Z3_URL" -o z3.zip
+
+          # 3. Unzip it.
+          unzip -q z3.zip
+
+          # 4. Find the folder name that was just created and add its bin to PATH
+          # Z3 zips always extract into a folder like 'z3-4.13.0-x64-win'
+          Z3_DIR=$(find . -maxdepth 1 -type d -name "z3-*" | head -n 1)
+          echo "$(pwd)/$Z3_DIR/bin" >> $GITHUB_PATH
+          #--------------------------------------- Setup VS Code dev environment
           echo setup=./utils/find-vs.ps1 >> "$GITHUB_OUTPUT"
 # Setup Caching.  Caching has several constraints:
 #
@@ -205,7 +223,7 @@ jobs:
           ${{ steps.setup-windows.outputs.setup }}
           mkdir build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v"
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v" -DLLVM_ENABLE_Z3_SOLVER=ON
 # Optionally test
       - name: Test CIRCT
         if: inputs.run_tests

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -174,25 +174,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          #--------------------------------------- Install latest z3
-          # 1. Query the GitHub API for the latest release and find the win zip
-          # URL.  This grabs the browser_download_url for the file ending in
-          # -x64-win.zip.
-          Z3_URL=$(curl -s https://api.github.com/repos/Z3Prover/z3/releases/latest | grep "browser_download_url" | grep "x64-win.zip" | cut -d '"' -f 4)
-          echo "Found latest Z3 at: $Z3_URL"
-
-          # 2. Download it.
-          curl -L --retry 3 "$Z3_URL" -o z3.zip
-
-          # 3. Unzip it.
-          unzip -q z3.zip
-
-          # 4. Find the folder name that was just created and add its bin to PATH
-          # Z3 zips always extract into a folder like 'z3-4.13.0-x64-win'
-          Z3_DIR=$(find . -maxdepth 1 -type d -name "z3-*" | head -n 1)
-          echo "$(pwd)/$Z3_DIR/bin" >> $GITHUB_PATH
-          z3 --version
-          #--------------------------------------- Setup VS Code dev environment
+          choco install z3
           echo setup=./utils/find-vs.ps1 >> "$GITHUB_OUTPUT"
 # Setup Caching.  Caching has several constraints:
 #

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -164,14 +164,21 @@ jobs:
 #
 # Setup z3 for Linux and macOS.  This hasn't been working on Windows through
 # `choco install z3`, so don't turn on z3 for those runs.
+#
+# Any runner-specific CMAKE configuration can be put into the `cmake` output.
+# These will be used when running `cmake` later.
       - name: Setup (linux)
+        id: setup-linux
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install ninja-build z3
+          echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Setup (macos)
+        id: setup-macos
         if: runner.os == 'macOS'
         run: |
           brew install gnu-tar ninja z3
+          echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Setup (windows)
         id: setup-windows
         if: runner.os == 'Windows'
@@ -208,7 +215,7 @@ jobs:
           ${{ steps.setup-windows.outputs.setup }}
           mkdir build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v"
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v" ${{ steps.setup-linux.outputs.cmake }} ${{ steps.setup-macos.outputs.cmake }} ${{ steps.setup-windows.outputs.cmake }}
 # Optionally test
       - name: Test CIRCT
         if: inputs.run_tests

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -161,22 +161,30 @@ jobs:
         run: |
           git fetch --unshallow --no-recurse-submodules
 # Per-operating system setup
+#
+# Setup z3 for Linux and macOS.  This hasn't been working on Windows through
+# `choco install z3`, so don't turn on z3 for those runs.
+#
+# Any runner-specific CMAKE configuration can be put into the `cmake` output.
+# These will be used when running `cmake` later.
       - name: Setup (linux)
+        id: setup-linux
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install ninja-build z3
+          echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Setup (macos)
+        id: setup-macos
         if: runner.os == 'macOS'
         run: |
           brew install gnu-tar ninja z3
+          echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Setup (windows)
         id: setup-windows
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          choco install z3
           echo setup=./utils/find-vs.ps1 >> "$GITHUB_OUTPUT"
-          echo cmake="-DZ3_DIR=C:\ProgramData\chocolatey\lib\z3\tools" >> "$GITHUB_OUTPUT"
 # Setup Caching.  Caching has several constraints:
 #
 # 1. RelWithDebInfo and Debug builds require very large caches, roughly ~4.5GiB.
@@ -207,7 +215,7 @@ jobs:
           ${{ steps.setup-windows.outputs.setup }}
           mkdir build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v" -DLLVM_ENABLE_Z3_SOLVER=ON ${{ steps.setup-windows.outputs.cmake }}
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v" ${{ steps.setup-windows.outputs.cmake }} ${{ steps.setup-linux.outputs.cmake }} ${{ steps.setup-windows.outputs.cmake }}
 # Optionally test
       - name: Test CIRCT
         if: inputs.run_tests


### PR DESCRIPTION
Add the z3 solver to the Linux and macOS UBTI native builds.  This is
intended to enabled 3 skipped tests to run.

I'm testing macOS here: https://github.com/llvm/circt/actions/runs/24271696594