### PR TITLE
[SV][ExportVerilog] Add sv.write for no-stream writes

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -513,6 +513,19 @@ def AliasOp : SVOp<"alias"> {
   let hasVerifier = 1;
 }
 
+def WriteOp : SVOp<"write", [ProceduralOp]> {
+  let summary = "'$write' statement";
+
+  let arguments = (ins StrAttr:$format_string,
+                       Variadic<AnyType>:$substitutions);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $format_string attr-dict (`(` $substitutions^ `)` `:`
+    qualified(type($substitutions)))?
+  }];
+}
+
 def FWriteOp : SVOp<"fwrite", [ProceduralOp]> {
   let summary = "'$fwrite' statement";
 

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -40,8 +40,9 @@ public:
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
             // Other Statements.
             AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
-            FWriteOp, FFlushOp, SystemFunctionOp, VerbatimOp, MacroRefOp,
-            FuncCallOp, FuncCallProceduralOp, ReturnOp, IncludeOp, MacroErrorOp,
+            WriteOp, FWriteOp, FFlushOp, SystemFunctionOp, VerbatimOp,
+            MacroRefOp, FuncCallOp, FuncCallProceduralOp, ReturnOp, IncludeOp,
+            MacroErrorOp,
             // Type declarations.
             InterfaceOp, SVVerbatimSourceOp, InterfaceSignalOp,
             InterfaceModportOp, InterfaceInstanceOp, GetModportOp,
@@ -135,6 +136,7 @@ public:
   HANDLE(ForceOp, Unhandled);
   HANDLE(ReleaseOp, Unhandled);
   HANDLE(AliasOp, Unhandled);
+  HANDLE(WriteOp, Unhandled);
   HANDLE(FWriteOp, Unhandled);
   HANDLE(FFlushOp, Unhandled);
   HANDLE(SystemFunctionOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4091,6 +4091,11 @@ private:
   LogicalResult visitSV(AlwaysFFOp op);
   LogicalResult visitSV(InitialOp op);
   LogicalResult visitSV(CaseOp op);
+  template <typename OpTy, typename EmitPrefixFn>
+  LogicalResult
+  emitFormattedWriteLikeOp(OpTy op, StringRef callee, StringRef formatString,
+                           ValueRange substitutions, EmitPrefixFn emitPrefix);
+  LogicalResult visitSV(WriteOp op);
   LogicalResult visitSV(FWriteOp op);
   LogicalResult visitSV(FFlushOp op);
   LogicalResult visitSV(VerbatimOp op);
@@ -4619,7 +4624,11 @@ LogicalResult StmtEmitter::visitSV(FFlushOp op) {
   return success();
 }
 
-LogicalResult StmtEmitter::visitSV(FWriteOp op) {
+template <typename OpTy, typename EmitPrefixFn>
+LogicalResult StmtEmitter::emitFormattedWriteLikeOp(OpTy op, StringRef callee,
+                                                    StringRef formatString,
+                                                    ValueRange substitutions,
+                                                    EmitPrefixFn emitPrefix) {
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 
@@ -4628,20 +4637,17 @@ LogicalResult StmtEmitter::visitSV(FWriteOp op) {
   ops.insert(op);
 
   ps.addCallback({op, true});
-  ps << "$fwrite(";
+  ps << callee;
   ps.scopedBox(PP::ibox0, [&]() {
-    emitExpression(op.getFd(), ops);
-
-    ps << "," << PP::space;
-    ps.writeQuotedEscaped(op.getFormatString());
-
+    emitPrefix(ops);
+    ps.writeQuotedEscaped(formatString);
     // TODO: if any of these breaks, it'd be "nice" to break
     // after the comma, instead of:
     // $fwrite(5, "...", a + b,
     //         longexpr_goes
     //         + here, c);
     // (without forcing breaking between all elements, like braced list)
-    for (auto operand : op.getSubstitutions()) {
+    for (auto operand : substitutions) {
       ps << "," << PP::space;
       emitExpression(operand, ops);
     }
@@ -4650,6 +4656,21 @@ LogicalResult StmtEmitter::visitSV(FWriteOp op) {
   ps.addCallback({op, false});
   emitLocationInfoAndNewLine(ops);
   return success();
+}
+
+LogicalResult StmtEmitter::visitSV(WriteOp op) {
+  return emitFormattedWriteLikeOp(op, "$write(", op.getFormatString(),
+                                  op.getSubstitutions(),
+                                  [&](SmallPtrSetImpl<Operation *> &) {});
+}
+
+LogicalResult StmtEmitter::visitSV(FWriteOp op) {
+  return emitFormattedWriteLikeOp(op, "$fwrite(", op.getFormatString(),
+                                  op.getSubstitutions(),
+                                  [&](SmallPtrSetImpl<Operation *> &ops) {
+                                    emitExpression(op.getFd(), ops);
+                                    ps << "," << PP::space;
+                                  });
 }
 
 LogicalResult StmtEmitter::visitSV(VerbatimOp op) {

--- a/test/Conversion/ExportVerilog/sv-write.mlir
+++ b/test/Conversion/ExportVerilog/sv-write.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+
+hw.module @top(in %clock : i1) {
+  sv.alwaysff(posedge %clock) {
+    %c0 = hw.constant 42 : i32
+    %c1 = hw.constant 0x80000001 : i32
+    %c2 = hw.constant 0x80000002 : i32
+
+    // CHECK:      always_ff @(posedge clock) begin
+    // CHECK-NEXT:   $write("stdout");
+    sv.write "stdout"
+
+    // CHECK-NEXT:   $write("%d", 32'h2A);
+    sv.write "%d"(%c0) : i32
+
+    // CHECK-NEXT:   $write("%d %d", 32'h80000001, 32'h80000002);
+    sv.write "%d %d"(%c1, %c2) : i32, i32
+
+    // CHECK-NEXT: end
+  }
+}

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -501,3 +501,15 @@ sv.verbatim.source @VerbatimTestModule.v<WIDTH: i32 = 8> attributes {
 sv.verbatim.module @VerbatimTestModule<WIDTH: i32 = 8>(in %clk: i1, out out: i1) attributes {
   source = @VerbatimTestModule.v
 }
+
+// CHECK-LABEL: hw.module @test_write(in %c0 : i32, in %c1 : i8) {
+// CHECK: sv.write "stdout"
+// CHECK-NEXT: sv.write "%d"(%c0) : i32
+// CHECK-NEXT: sv.write "%d %d"(%c0, %c1) : i32, i8
+hw.module @test_write(in %c0 : i32, in %c1 : i8) {
+  sv.initial {
+    sv.write "stdout"
+    sv.write "%d"(%c0) : i32
+    sv.write "%d %d"(%c0, %c1) : i32, i8
+  }
+}


### PR DESCRIPTION
As @fzi-hielscher mentioned in #10172, sim.proc.print without an explicitly specified output stream should ideally lower to $write, while prints with an explicit stream should continue to lower to $fwrite.

This PR adds sv.write to preserve that distinction in the SV IR, rather than encoding default stdout printing as a special stream value. 

If maintainers would prefer to keep this modeled via sv.fwrite, I’m happy to adjust accordingly.