### PR TITLE
[LLHD][SV] Unify the ProceduralRegion trait in CIRCTSupport

### DIFF
--- a/include/circt/Dialect/LLHD/LLHDOps.h
+++ b/include/circt/Dialect/LLHD/LLHDOps.h
@@ -14,6 +14,7 @@
 #include "circt/Dialect/LLHD/LLHDEnums.h.inc"
 #include "circt/Dialect/LLHD/LLHDTypes.h"
 #include "circt/Support/LLVM.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
@@ -31,15 +32,6 @@ namespace llhd {
 
 unsigned getLLHDTypeWidth(Type type);
 Type getLLHDElementType(Type type);
-
-/// Signals that an operations regions are procedural.
-template <typename ConcreteType>
-class ProceduralRegion
-    : public mlir::OpTrait::TraitBase<ConcreteType, ProceduralRegion> {
-  static LogicalResult verifyTrait(Operation *op) {
-    return mlir::OpTrait::impl::verifyNRegions(op, 1);
-  }
-};
 
 void registerDestructableIntegerExternalModel(mlir::DialectRegistry &registry);
 

--- a/include/circt/Dialect/LLHD/LLHDOps.td
+++ b/include/circt/Dialect/LLHD/LLHDOps.td
@@ -11,6 +11,7 @@
 
 include "circt/Dialect/LLHD/LLHDDialect.td"
 include "circt/Dialect/LLHD/LLHDTypes.td"
+include "circt/Support/ProceduralRegionTrait.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
@@ -53,10 +54,6 @@ class SmallerOrEqualResultTypeWidthConstraint<string result, string input>
                 "equal to the " # input # " type",
                 CPred<"llhd::getLLHDTypeWidth($" # result # ".getType()) <= " #
                       "llhd::getLLHDTypeWidth($" # input  # ".getType())">>;
-
-def ProceduralRegion : NativeOpTrait<"ProceduralRegion"> {
-  let cppNamespace = "::circt::llhd";
-}
 
 //===----------------------------------------------------------------------===//
 // Constants

--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_SV_SV
 #define CIRCT_DIALECT_SV_SV
 
+include "circt/Support/ProceduralRegionTrait.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
@@ -24,10 +25,6 @@ include "circt/Dialect/SV/SVDialect.td"
 // Base class for the operation in this dialect.
 class SVOp<string mnemonic, list<Trait> traits = []> :
     Op<SVDialect, mnemonic, traits>;
-
-def ProceduralRegion : NativeOpTrait<"ProceduralRegion"> {
-  let cppNamespace = "::circt::sv";
-}
 
 def ProceduralOp : NativeOpTrait<"ProceduralOp"> {
   let cppNamespace = "::circt::sv";

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -20,6 +20,7 @@
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVTypes.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/CallInterfaces.h"
@@ -169,15 +170,6 @@ struct CaseInfo {
 LogicalResult verifyInProceduralRegion(Operation *op);
 /// Return true if the specified operation is not in a procedural region.
 LogicalResult verifyInNonProceduralRegion(Operation *op);
-
-/// Signals that an operations regions are procedural.
-template <typename ConcreteType>
-class ProceduralRegion
-    : public mlir::OpTrait::TraitBase<ConcreteType, ProceduralRegion> {
-  static LogicalResult verifyTrait(Operation *op) {
-    return mlir::OpTrait::impl::verifyAtLeastNRegions(op, 1);
-  }
-};
 
 /// This class verifies that the specified op is located in a procedural region.
 template <typename ConcreteType>

--- a/include/circt/Support/ProceduralRegionTrait.h
+++ b/include/circt/Support/ProceduralRegionTrait.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines the `ProceduralRegion` trait.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_PROCEDURALREGIONTRAIT_H
+#define CIRCT_SUPPORT_PROCEDURALREGIONTRAIT_H
+
+#include "mlir/IR/OpDefinition.h"
+#include "llvm/Support/LogicalResult.h"
+
+namespace circt {
+
+/// Signals that an operation's regions are procedural.
+template <typename ConcreteType>
+class ProceduralRegion
+    : public mlir::OpTrait::TraitBase<ConcreteType, ProceduralRegion> {
+  static LogicalResult verifyTrait(Operation *op) {
+    return mlir::OpTrait::impl::verifyNRegions(op, 1);
+  }
+};
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_PROCEDURALREGIONTRAIT_H

--- a/include/circt/Support/ProceduralRegionTrait.h
+++ b/include/circt/Support/ProceduralRegionTrait.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_SUPPORT_PROCEDURALREGIONTRAIT_H
 #define CIRCT_SUPPORT_PROCEDURALREGIONTRAIT_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
 #include "llvm/Support/LogicalResult.h"
 

--- a/include/circt/Support/ProceduralRegionTrait.td
+++ b/include/circt/Support/ProceduralRegionTrait.td
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_PROCDURALREGIONTRAIT_TD
+#define CIRCT_SUPPORT_PROCDURALREGIONTRAIT_TD
+
+include "mlir/IR/OpBase.td"
+
+def ProceduralRegion : NativeOpTrait<"ProceduralRegion"> {
+  let cppNamespace = "::circt";
+}
+
+#endif // CIRCT_SUPPORT_PROCDURALREGIONTRAIT_TD

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -37,6 +37,7 @@
 #include "circt/Support/Path.h"
 #include "circt/Support/PrettyPrinter.h"
 #include "circt/Support/PrettyPrinterHelpers.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "circt/Support/Version.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -24,6 +24,7 @@
 #include "circt/Dialect/LTL/LTLDialect.h"
 #include "circt/Dialect/Verif/VerifDialect.h"
 #include "circt/Support/LoweringOptions.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Pass/Pass.h"

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -19,6 +19,7 @@
 #include "circt/Dialect/Sim/SimDialect.h"
 #include "circt/Dialect/Sim/SimOps.h"
 #include "circt/Support/Namespace.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -398,7 +399,7 @@ static bool moveOpsIntoIfdefGuardsAndProcesses(Operation *rootOp) {
       // If there was no pre-existing guard, create one.
       if (!block) {
         OpBuilder builder(op);
-        if (op->getParentOp()->hasTrait<sv::ProceduralRegion>())
+        if (op->getParentOp()->hasTrait<ProceduralRegion>())
           block = sv::IfDefProceduralOp::create(
                       builder, loc, "SYNTHESIS", [] {}, [] {})
                       .getElseBlock();

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -21,6 +21,7 @@
 #include "circt/Dialect/HW/ModuleImplementation.h"
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Support/CustomDirectiveImpl.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
@@ -56,14 +57,14 @@ bool sv::isExpression(Operation *op) {
 }
 
 LogicalResult sv::verifyInProceduralRegion(Operation *op) {
-  if (op->getParentOp()->hasTrait<sv::ProceduralRegion>())
+  if (op->getParentOp()->hasTrait<ProceduralRegion>())
     return success();
   op->emitError() << op->getName() << " should be in a procedural region";
   return failure();
 }
 
 LogicalResult sv::verifyInNonProceduralRegion(Operation *op) {
-  if (!op->getParentOp()->hasTrait<sv::ProceduralRegion>())
+  if (!op->getParentOp()->hasTrait<ProceduralRegion>())
     return success();
   op->emitError() << op->getName() << " should be in a non-procedural region";
   return failure();

--- a/lib/Dialect/SV/Transforms/HWCleanup.cpp
+++ b/lib/Dialect/SV/Transforms/HWCleanup.cpp
@@ -17,6 +17,7 @@
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {
@@ -144,7 +145,7 @@ void HWCleanupPass::runOnOperation() {
 /// Recursively process all of the regions in the specified op, dispatching to
 /// graph or procedural processing as appropriate.
 void HWCleanupPass::runOnRegionsInOp(Operation &op) {
-  if (op.hasTrait<sv::ProceduralRegion>()) {
+  if (op.hasTrait<ProceduralRegion>()) {
     for (auto &region : op.getRegions())
       runOnProceduralRegion(region);
   } else {

--- a/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
@@ -20,6 +20,7 @@
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Support/LoweringOptions.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
 
@@ -288,7 +289,7 @@ Value HWLegalizeModulesPass::lowerLookupToCasez(Operation &op, Value input,
   // A casez is a procedural operation, so if we're in a
   // non-procedural region we need to inject an always_comb
   // block.
-  if (!op.getParentOp()->hasTrait<sv::ProceduralRegion>()) {
+  if (!op.getParentOp()->hasTrait<ProceduralRegion>()) {
     auto alwaysComb = sv::AlwaysCombOp::create(builder, loc);
     builder.setInsertionPointToEnd(alwaysComb.getBodyBlock());
   }

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -15,6 +15,7 @@
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Support/CustomDirectiveImpl.h"
+#include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/PatternMatch.h"
@@ -639,7 +640,7 @@ LogicalResult PrintFormattedProcOp::verify() {
   }
 
   if (isa_and_nonnull<sv::SVDialect>(parentOp->getDialect())) {
-    if (!parentOp->hasTrait<sv::ProceduralRegion>())
+    if (!parentOp->hasTrait<ProceduralRegion>())
       return emitOpError("must be within a procedural region.");
     return success();
   }


### PR DESCRIPTION
Move the `ProceduralRegion` operation traits of the LLHD and SV dialects to a common declaration within the CIRCT support library. This should allow us to (temporarily) include procedural operations of one dialect under procedural regions of another dialect during lowering, without triggering an IR verification error. The behavior of the trait within the dialects remains unchanged.

We will have to further consider how the trait should work transitively.
E.g., while this is now legal:
```MLIR
hw.module @foo() {
  llhd.final {
      sv.write "bye"
      llhd.halt
  }
}
```
This still fails:
```MLIR
hw.module @foo(in %cond: i1) {
  llhd.final {
      scf.if %cond {
        sv.write "bye"
      }
      llhd.halt
  }
}
```