### PR TITLE
[ci] Better release artifact matrix job names, NFC

### DIFF
--- a/.github/bin/uploadReleaseArtifacts.sh
+++ b/.github/bin/uploadReleaseArtifacts.sh
@@ -310,8 +310,8 @@ config=$(echo "$config" | jq '
     elif .install_target == "install" then "/install-full"
     else "/install-\(.install_target | split(" ") | map(select(. != "")) | length)"
     end;
-  .native |= map(. + {name: "\(.runner)/\(.cmake_c_compiler)/\(.cmake_build_type)/\(libs)-libs/asserts-\(asserts)\(tests)\(install)"}) |
-  .static |= map(. + {name: "\(.cmake_build_type)/asserts-\(asserts)\(tests)\(install)"})
+  .native |= map(. + {name: "native/\(.runner)/\(.cmake_c_compiler)/\(.cmake_build_type)/\(libs)-libs/asserts-\(asserts)\(tests)\(install)"}) |
+  .static |= map(. + {name: "static/\(.cmake_build_type)/asserts-\(asserts)\(tests)\(install)"})
 ')
 
 # Return the final `config` JSON.

--- a/.github/bin/uploadReleaseArtifacts.sh
+++ b/.github/bin/uploadReleaseArtifacts.sh
@@ -199,7 +199,6 @@ EOF
 configNativeFullShared=$(cat <<EOF
 [
   {
-    "name":"CIRCT-full shared",
     "install_target":"install",
     "package_name_prefix":"circt-full-shared",
     "cmake_build_type":"$OPT_CMAKE_BUILD_TYPE",
@@ -213,7 +212,6 @@ EOF
 configNativeFullStatic=$(cat <<EOF
 [
   {
-    "name":"CIRCT-full static",
     "install_target":"install",
     "package_name_prefix":"circt-full-static",
     "cmake_build_type":"$OPT_CMAKE_BUILD_TYPE",
@@ -227,7 +225,6 @@ EOF
 configNativeFirtool=$(cat <<EOF
 [
   {
-    "name": "firtool",
     "install_target": "$binaryTargets",
     "package_name_prefix": "firrtl-bin",
     "cmake_build_type":"$OPT_CMAKE_BUILD_TYPE",
@@ -292,6 +289,30 @@ for os in "${OPT_OS[@]}"; do
       ;;
   esac
 done
+
+# Set a human-readable name for the native and static configurations.  This
+# produces the following for the native UBTI build:
+#
+#   <runner>/<compiler>/<build-type>/<shared-vs-static>/<asserts>(/test)?(/install-(full|<n>))?
+#
+# and the following for the static UBTI build:
+#
+#   <build-type>/<asserts>(/test)?(/install-(full|<n>))?
+#
+# This is intended to be used to set the matrix job name in order to make this
+# readable on GitHub when trying to see what is running or what failed.
+config=$(echo "$config" | jq '
+  def libs: if .build_shared_libs == "ON" then "shared" else "static" end;
+  def asserts: if .llvm_enable_assertions == "ON" then "on" else "off" end;
+  def tests: if .run_tests then "/test" else "" end;
+  def install:
+    if (.install_target // "") == "" then ""
+    elif .install_target == "install" then "/install-full"
+    else "/install-\(.install_target | split(" ") | map(select(. != "")) | length)"
+    end;
+  .native |= map(. + {name: "\(.runner)/\(.cmake_c_compiler)/\(.cmake_build_type)/\(libs)-libs/asserts-\(asserts)\(tests)\(install)"}) |
+  .static |= map(. + {name: "\(.cmake_build_type)/asserts-\(asserts)\(tests)\(install)"})
+')
 
 # Return the final `config` JSON.
 echo "$config"

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -200,7 +200,7 @@ jobs:
 
   # Build CIRCT and run its tests.
   build-and-test:
-    name: "Test: ${{ matrix.generated.name }}"
+    name: "UBTI Native: ${{ matrix.generated.name }}"
     needs:
       - sanity-check
       - choose-matrix

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -125,6 +125,7 @@ jobs:
       native: ${{ steps.get-config.outputs.native }}
 
   publish-static:
+    name: "UBTI Static: ${{ matrix.generated.name }}"
     needs:
       - choose-matrix
     if: ${{ needs.choose-matrix.outputs.static != '[]' }}
@@ -143,6 +144,7 @@ jobs:
       package_name_prefix: ${{ matrix.generated.package_name_prefix }}
 
   publish-native:
+    name: "UBTI Native: ${{ matrix.generated.name }}"
     needs:
       - choose-matrix
     if: ${{ needs.choose-matrix.outputs.native != '[]' }}

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -125,7 +125,7 @@ jobs:
       native: ${{ steps.get-config.outputs.native }}
 
   publish-static:
-    name: "UBTI Static: ${{ matrix.generated.name }}"
+    name: ${{ matrix.generated.name }}
     needs:
       - choose-matrix
     if: ${{ needs.choose-matrix.outputs.static != '[]' }}
@@ -144,7 +144,7 @@ jobs:
       package_name_prefix: ${{ matrix.generated.package_name_prefix }}
 
   publish-native:
-    name: "UBTI Native: ${{ matrix.generated.name }}"
+    name: ${{ matrix.generated.name }}
     needs:
       - choose-matrix
     if: ${{ needs.choose-matrix.outputs.native != '[]' }}


### PR DESCRIPTION
Improve the names of the matrix jobs when doing a release.  There are a
lot of these jobs and it can be very confusing to see what is going on or
to see what happens when something goes wrong.

This is moving towards a standard format for when the UBTI jobs are used
in nightly integration testing.

Assisted-by: Claude:claude-sonnet-4-6

---

The improve names can be seen here: https://github.com/llvm/circt/actions/runs/24299290918 A truncated view of this is shown below:

<img width="300" height="809" alt="image" src="https://github.com/user-attachments/assets/27970672-6574-4b17-94da-993f2a8a0c56" />
