### PR TITLE
[ci] Restore original buildAndTest job names, NFC

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -200,7 +200,7 @@ jobs:
 
   # Build CIRCT and run its tests.
   build-and-test:
-    name: "UBTI Native: ${{ matrix.generated.name }}"
+    name: ${{ matrix.generated.name }}
     needs:
       - sanity-check
       - choose-matrix


### PR DESCRIPTION
Restore the original job names for pre-merge CI.  These looked better
before.
