### PR TITLE
[Synth] Add BooleanLogicOpInterface for and_inv

### DIFF
--- a/include/circt/Dialect/Synth/CMakeLists.txt
+++ b/include/circt/Dialect/Synth/CMakeLists.txt
@@ -8,5 +8,6 @@
 
 add_circt_dialect(Synth synth)
 add_circt_dialect_doc(Synth synth)
+add_circt_interface(SynthOpInterfaces)
 
 add_subdirectory(Transforms)

--- a/include/circt/Dialect/Synth/Synth.td
+++ b/include/circt/Dialect/Synth/Synth.td
@@ -10,6 +10,7 @@
 #define CIRCT_SYNTH_DIALECT_TD
 
 include "mlir/IR/DialectBase.td"
+include "circt/Dialect/Synth/SynthOpInterfaces.td"
 
 def Synth_Dialect : Dialect {
   let name = "synth";

--- a/include/circt/Dialect/Synth/SynthOpInterfaces.h
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.h
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SYNTH_SYNTHOPINTERFACES_H
+#define CIRCT_DIALECT_SYNTH_SYNTHOPINTERFACES_H
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpDefinition.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/KnownBits.h"
+
+namespace circt {
+namespace synth {
+class BooleanLogicOpInterface;
+} // namespace synth
+} // namespace circt
+
+#include "circt/Dialect/Synth/SynthOpInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_SYNTH_SYNTHOPINTERFACES_H

--- a/include/circt/Dialect/Synth/SynthOpInterfaces.h
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.h
@@ -17,12 +17,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/KnownBits.h"
 
-namespace circt {
-namespace synth {
-class BooleanLogicOpInterface;
-} // namespace synth
-} // namespace circt
-
 #include "circt/Dialect/Synth/SynthOpInterfaces.h.inc"
 
 #endif // CIRCT_DIALECT_SYNTH_SYNTHOPINTERFACES_H

--- a/include/circt/Dialect/Synth/SynthOpInterfaces.td
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.td
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SYNTH_SYNTHOPINTERFACES_TD
+#define CIRCT_DIALECT_SYNTH_SYNTHOPINTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+
+def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
+  let cppNamespace = "::circt::synth";
+
+  let description = [{
+    Common interface for boolean-logic DAG nodes whose semantics are defined by
+    a list of input values together with per-input inversion flags.
+
+    Modern logic-network representations often use the same "value plus
+    complemented edge" model across several node kinds, for example AIG-style
+    nodes as well as closely related 3-input or otherwise non-binary DAG
+    nodes. Passes such as structural hashing, bit lowering, and simulation
+    should be able to operate on those common semantics without hardcoding a
+    specific concrete op.
+  }];
+
+  let methods = [
+    InterfaceMethod<[{
+        Get the logical input values.
+      }],
+      "::mlir::ValueRange", "getInputs", (ins), "",
+      [{
+        return $_op.getInputs();
+      }]
+    >,
+    InterfaceMethod<[{
+        Get the logical input at the specified index and whether it is
+        inverted before the operation is evaluated.
+      }],
+      "::std::pair<::mlir::Value, bool>", "getInputPair", (ins "unsigned":$index), "",
+      [{
+        auto concreteOp = mlir::cast<ConcreteOp>($_op);
+        return {concreteOp->getOperand(index), concreteOp.isInverted(index)};
+      }]
+    >,
+
+    InterfaceMethod<[{
+        Get the logical input value at the specified index.
+      }],
+      "::mlir::Value", "getInput", (ins "unsigned":$index), "",
+      [{
+        return $_op.getInputs()[index];
+      }]
+    >,
+    InterfaceMethod<[{
+        Return whether the specified logical input is inverted before the
+        operation is evaluated.
+      }],
+      "bool", "isInverted", (ins "unsigned":$index), "",
+      [{
+        return $_op.getInverted()[index];
+      }]
+    >,
+    InterfaceMethod<[{
+        Get the inversion flags for all logical inputs.
+      }],
+      "::llvm::ArrayRef<bool>", "getInverted", (ins)>,
+    InterfaceMethod<[{
+        Set the inversion flags for all logical inputs.
+      }],
+      "void", "setInverted", (ins "::llvm::ArrayRef<bool>":$inverted)
+    >,
+    InterfaceMethod<[{
+        Get the primary logical result of this operation.
+      }],
+      "::mlir::Value", "getResult", (ins), "",
+      [{
+        return $_op->getResult(0);
+      }]
+    >,
+    InterfaceMethod<[{
+        Return whether the operation semantics are invariant under
+        permutation of logical input pairs. Reordering a logical input means
+        moving both the input value and its inversion flag together.
+      }],
+      "bool", "areInputsPermutationInvariant", (ins), "",
+      [{
+        return false;
+      }]
+    >,
+    InterfaceMethod<[{
+        Evaluate the boolean logic operation for the provided raw operand
+        inputs. The implementations are responsible for applying any per-input
+        inversion described by the operation itself.
+      }],
+      "::llvm::APInt", "evaluateBooleanLogic",
+      (ins "::llvm::function_ref<const ::llvm::APInt &(unsigned)>":$getInputValue)
+    >,
+    InterfaceMethod<[{
+        Compute known bits for the result from the logical inputs.
+        The implementations are responsible for applying any per-input inversion
+        described by the operation itself.
+      }],
+      "::llvm::KnownBits", "computeKnownBits",
+      (ins "::llvm::function_ref<const ::llvm::KnownBits &(unsigned)>":$getInputKnownBits)
+    >,
+    InterfaceMethod<[{
+        Clone or fold this operation with the provided inputs while preserving
+        the existing inversion flags.
+      }],
+      "::mlir::Value", "cloneWithSameInversion",
+      (ins "::mlir::OpBuilder &":$builder, "::mlir::ValueRange":$newInputs), "",
+      [{
+        auto concreteOp = mlir::cast<ConcreteOp>($_op);
+        assert(!newInputs.empty());
+        auto resultType = newInputs.front().getType();
+        return builder.createOrFold<ConcreteOp>(concreteOp.getLoc(), resultType,
+                                                newInputs,
+                                                concreteOp.getInverted());
+      }]
+    >
+  ];
+}
+
+#endif // CIRCT_DIALECT_SYNTH_SYNTHOPINTERFACES_TD

--- a/include/circt/Dialect/Synth/SynthOpInterfaces.td
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.td
@@ -107,6 +107,30 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
       (ins "::llvm::function_ref<const ::llvm::KnownBits &(unsigned)>":$getInputKnownBits)
     >,
     InterfaceMethod<[{
+        Return the abstract logic depth cost contributed by this operation.
+        This is the per-node delay used by analyses such as longest path.
+      }],
+      "int64_t", "getLogicDepthCost", (ins)
+    >,
+    InterfaceMethod<[{
+        Return the abstract logic area cost contributed by this operation.
+        This is the local resource cost used by analyses such as resource
+        usage.
+      }],
+      "uint64_t", "getLogicAreaCost", (ins)
+    >,
+    InterfaceMethod<[{
+        Emit CNF clauses encoding `outVar <=> op(inputVars...)`.
+        The provided `inputVars` correspond to this operation's operands in
+        operand order. Implementations are responsible for applying any
+        per-input inversion described by the operation itself.
+      }],
+      "void", "emitCNF",
+      (ins "int":$outVar, "::llvm::ArrayRef<int>":$inputVars,
+           "::llvm::function_ref<void(::llvm::ArrayRef<int>)>":$addClause,
+           "::llvm::function_ref<int()>":$newVar)
+    >,
+    InterfaceMethod<[{
         Clone or fold this operation with the provided inputs while preserving
         the existing inversion flags.
       }],

--- a/include/circt/Dialect/Synth/SynthOpInterfaces.td
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.td
@@ -41,8 +41,7 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
       }],
       "::std::pair<::mlir::Value, bool>", "getInputPair", (ins "unsigned":$index), "",
       [{
-        auto concreteOp = mlir::cast<ConcreteOp>($_op);
-        return {concreteOp->getOperand(index), concreteOp.isInverted(index)};
+        return {$_op.getInput(index), $_op.isInverted(index)};
       }]
     >,
     InterfaceMethod<[{

--- a/include/circt/Dialect/Synth/SynthOpInterfaces.td
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.td
@@ -45,7 +45,6 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
         return {concreteOp->getOperand(index), concreteOp.isInverted(index)};
       }]
     >,
-
     InterfaceMethod<[{
         Get the logical input value at the specified index.
       }],
@@ -66,7 +65,8 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
     InterfaceMethod<[{
         Get the inversion flags for all logical inputs.
       }],
-      "::llvm::ArrayRef<bool>", "getInverted", (ins)>,
+      "::llvm::ArrayRef<bool>", "getInverted", (ins)
+    >,
     InterfaceMethod<[{
         Set the inversion flags for all logical inputs.
       }],
@@ -110,14 +110,18 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
         Return the abstract logic depth cost contributed by this operation.
         This is the per-node delay used by analyses such as longest path.
       }],
-      "int64_t", "getLogicDepthCost", (ins)
+      "int64_t", "getLogicDepthCost", (ins), "",
+      [{
+        return 1;
+      }]
     >,
     InterfaceMethod<[{
         Return the abstract logic area cost contributed by this operation.
         This is the local resource cost used by analyses such as resource
-        usage.
+        usage. Implementations may return `std::nullopt` to indicate that
+        the area cost is unknown.
       }],
-      "uint64_t", "getLogicAreaCost", (ins)
+      "std::optional<uint64_t>", "getLogicAreaCost", (ins)
     >,
     InterfaceMethod<[{
         Emit CNF clauses encoding `outVar <=> op(inputVars...)`.

--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_SYNTH_SYNTHOPS_H
 
 #include "circt/Dialect/Synth/SynthDialect.h"
+#include "circt/Dialect/Synth/SynthOpInterfaces.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -27,7 +27,10 @@ def AndInverterOp :
   SynthOp<"aig.and_inv",
           [SameOperandsAndResultType, Pure,
            DeclareOpInterfaceMethods<BooleanLogicOpInterface,
-                                     ["areInputsPermutationInvariant"]>]> {
+                                     ["areInputsPermutationInvariant",
+                                      "getLogicDepthCost",
+                                      "getLogicAreaCost",
+                                      "emitCNF"]>]> {
   let summary = "AIG dialect AND operation";
   let description = [{
     The `synth.aig.and_inv` operation represents an And-Inverter in the AIG dialect.

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -23,7 +23,11 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class SynthOp<string mnemonic, list<Trait> traits = []> :
     Op<Synth_Dialect, mnemonic, traits>;
 
-def AndInverterOp : SynthOp<"aig.and_inv", [SameOperandsAndResultType, Pure]> {
+def AndInverterOp :
+  SynthOp<"aig.and_inv",
+          [SameOperandsAndResultType, Pure,
+           DeclareOpInterfaceMethods<BooleanLogicOpInterface,
+                                     ["areInputsPermutationInvariant"]>]> {
   let summary = "AIG dialect AND operation";
   let description = [{
     The `synth.aig.and_inv` operation represents an And-Inverter in the AIG dialect.
@@ -74,15 +78,6 @@ def AndInverterOp : SynthOp<"aig.and_inv", [SameOperandsAndResultType, Pure]> {
       return build($_builder, $_state, {lhs, rhs}, inverted);
     }]>];
 
-  let extraClassDeclaration = [{
-    // Evaluate the operation with the given input values.
-    APInt evaluate(ArrayRef<APInt> inputs);
-
-    // Check if the input is inverted.
-    bool isInverted(size_t idx) {
-      return getInverted()[idx];
-    }
-  }];
   let hasFolder = 1;
   let hasCanonicalizeMethod = 1;
   let cppNamespace = "::circt::synth::aig";

--- a/include/circt/Support/SATSolver.h
+++ b/include/circt/Support/SATSolver.h
@@ -14,6 +14,8 @@
 #define CIRCT_SUPPORT_SATSOLVER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include <memory>
 
 namespace circt {
@@ -189,6 +191,23 @@ public:
     add(0);
   }
 };
+
+/// Emit clauses encoding `outVar <=> and(inputLits)`.
+void addAndClauses(int outVar, llvm::ArrayRef<int> inputLits,
+                   llvm::function_ref<void(llvm::ArrayRef<int>)> addClause);
+
+/// Emit clauses encoding `outVar <=> or(inputLits)`.
+void addOrClauses(int outVar, llvm::ArrayRef<int> inputLits,
+                  llvm::function_ref<void(llvm::ArrayRef<int>)> addClause);
+
+/// Emit clauses encoding `outVar <=> (lhsLit xor rhsLit)`.
+void addXorClauses(int outVar, int lhsLit, int rhsLit,
+                   llvm::function_ref<void(llvm::ArrayRef<int>)> addClause);
+
+/// Emit clauses encoding `outVar <=> parity(inputLits)`.
+void addParityClauses(int outVar, llvm::ArrayRef<int> inputLits,
+                      llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+                      llvm::function_ref<int()> newVar);
 
 /// Construct a Z3-backed incremental IPASIR-style SAT solver.
 std::unique_ptr<IncrementalSATSolver> createZ3SATSolver();

--- a/lib/Dialect/Synth/Analysis/LongestPathAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/LongestPathAnalysis.cpp
@@ -1035,8 +1035,9 @@ LogicalResult LocalVisitor::visit(comb::ConcatOp op, size_t bitPos,
 
 LogicalResult LocalVisitor::addLogicOp(Operation *op, size_t bitPos,
                                        SmallVectorImpl<OpenPath> &results) {
-  auto size = op->getNumOperands();
-  auto cost = llvm::Log2_64_Ceil(size);
+  auto cost = isa<BooleanLogicOpInterface>(op)
+                  ? cast<BooleanLogicOpInterface>(op).getLogicDepthCost()
+                  : llvm::Log2_64_Ceil(op->getNumOperands());
   // Create edges each operand with cost ceil(log(size)).
   for (auto operand : op->getOperands())
     if (failed(addEdge(operand, bitPos, cost, results)))

--- a/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
@@ -47,16 +47,19 @@ static bool accumulateResourceCounts(Operation *op,
                                      llvm::StringMap<uint64_t> &counts) {
   if (op->getNumResults() != 1 || !op->getResult(0).getType().isInteger())
     return false;
+  if (auto logicOp = dyn_cast<BooleanLogicOpInterface>(op)) {
+    counts[op->getName().getStringRef()] += logicOp.getLogicAreaCost();
+    return true;
+  }
   return TypeSwitch<Operation *, bool>(op)
-      // Variadic logic operations (AND, OR, XOR, AIG).
+      // Variadic comb logic operations.
       // Gate count = (num_inputs - 1) * bitwidth
-      .Case<synth::aig::AndInverterOp, comb::AndOp, comb::OrOp, comb::XorOp>(
-          [&](auto logicOp) {
-            counts[logicOp->getName().getStringRef()] +=
-                (logicOp.getNumOperands() - 1) *
-                logicOp.getType().getIntOrFloatBitWidth();
-            return true;
-          })
+      .Case<comb::AndOp, comb::OrOp, comb::XorOp>([&](auto logicOp) {
+        counts[logicOp->getName().getStringRef()] +=
+            static_cast<uint64_t>(logicOp.getNumOperands() - 1) *
+            logicOp.getType().getIntOrFloatBitWidth();
+        return true;
+      })
       // Truth tables (LUTs) - count both the total number of truth tables and
       // the per-input breakdown.
       .Case<comb::TruthTableOp>([&](auto op) {

--- a/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
@@ -54,6 +54,7 @@ static bool accumulateResourceCounts(Operation *op,
           counts[op->getName().getStringRef()] += *areaCost;
           return true;
         }
+        return false;
       })
       // Variadic comb logic operations.
       // Gate count = (num_inputs - 1) * bitwidth

--- a/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
@@ -50,8 +50,10 @@ static bool accumulateResourceCounts(Operation *op,
     return false;
   return TypeSwitch<Operation *, bool>(op)
       .Case<BooleanLogicOpInterface>([&](auto logicOp) {
-        counts[op->getName().getStringRef()] += logicOp.getLogicAreaCost();
-        return true;
+        if (auto areaCost = logicOp.getLogicAreaCost()) {
+          counts[op->getName().getStringRef()] += *areaCost;
+          return true;
+        }
       })
       // Variadic comb logic operations.
       // Gate count = (num_inputs - 1) * bitwidth

--- a/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Synth/SynthOpInterfaces.h"
 #include "circt/Dialect/Synth/SynthOps.h"
 #include "circt/Dialect/Synth/Transforms/SynthPasses.h"
 #include "circt/Support/InstanceGraph.h"
@@ -47,11 +48,11 @@ static bool accumulateResourceCounts(Operation *op,
                                      llvm::StringMap<uint64_t> &counts) {
   if (op->getNumResults() != 1 || !op->getResult(0).getType().isInteger())
     return false;
-  if (auto logicOp = dyn_cast<BooleanLogicOpInterface>(op)) {
-    counts[op->getName().getStringRef()] += logicOp.getLogicAreaCost();
-    return true;
-  }
   return TypeSwitch<Operation *, bool>(op)
+      .Case<BooleanLogicOpInterface>([&](auto logicOp) {
+        counts[op->getName().getStringRef()] += logicOp.getLogicAreaCost();
+        return true;
+      })
       // Variadic comb logic operations.
       // Gate count = (num_inputs - 1) * bitwidth
       .Case<comb::AndOp, comb::OrOp, comb::XorOp>([&](auto logicOp) {

--- a/lib/Dialect/Synth/CMakeLists.txt
+++ b/lib/Dialect/Synth/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 add_circt_dialect_library(CIRCTSynth
   SynthDialect.cpp
+  SynthOpInterfaces.cpp
   SynthOps.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -13,6 +14,7 @@ add_circt_dialect_library(CIRCTSynth
 
   DEPENDS
   MLIRSynthIncGen
+  MLIRSynthOpInterfacesIncGen
 
   LINK_COMPONENTS
   Support

--- a/lib/Dialect/Synth/SynthOpInterfaces.cpp
+++ b/lib/Dialect/Synth/SynthOpInterfaces.cpp
@@ -1,0 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Synth/SynthOpInterfaces.h"
+
+#include "circt/Dialect/Synth/SynthOpInterfaces.cpp.inc"

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -10,6 +10,7 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Support/CustomDirectiveImpl.h"
 #include "circt/Support/Naming.h"
+#include "circt/Support/SATSolver.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Matchers.h"
@@ -241,6 +242,32 @@ llvm::KnownBits AndInverterOp::computeKnownBits(
   }
 
   return result;
+}
+
+int64_t AndInverterOp::getLogicDepthCost() {
+  return llvm::Log2_64_Ceil(getNumOperands());
+}
+
+uint64_t AndInverterOp::getLogicAreaCost() {
+  return static_cast<uint64_t>(getNumOperands() - 1) *
+         getType().getIntOrFloatBitWidth();
+}
+
+void AndInverterOp::emitCNF(
+    int outVar, llvm::ArrayRef<int> inputVars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  (void)newVar;
+  assert(inputVars.size() == getInputs().size() &&
+         "expected one SAT variable per operand");
+
+  SmallVector<int> inputLits;
+  inputLits.reserve(inputVars.size());
+  for (auto [inputVar, inverted] : llvm::zip(inputVars, getInverted())) {
+    assert(inputVar > 0 && "input SAT variables must be positive");
+    inputLits.push_back(inverted ? -inputVar : inputVar);
+  }
+  circt::addAndClauses(outVar, inputLits, addClause);
 }
 
 static Value lowerVariadicAndInverterOp(AndInverterOp op, OperandRange operands,

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -109,6 +109,8 @@ LogicalResult ChoiceOp::canonicalize(ChoiceOp op, PatternRewriter &rewriter) {
 // AIG Operations
 //===----------------------------------------------------------------------===//
 
+bool AndInverterOp::areInputsPermutationInvariant() { return true; }
+
 OpFoldResult AndInverterOp::fold(FoldAdaptor adaptor) {
   if (getNumOperands() == 1 && !isInverted(0))
     return getOperand(0);
@@ -208,17 +210,36 @@ LogicalResult AndInverterOp::canonicalize(AndInverterOp op,
   return success();
 }
 
-APInt AndInverterOp::evaluate(ArrayRef<APInt> inputs) {
-  assert(inputs.size() == getNumOperands() &&
-         "Expected as many inputs as operands");
-  assert(!inputs.empty() && "Expected non-empty input list");
-  APInt result = APInt::getAllOnes(inputs.front().getBitWidth());
-  for (auto [idx, input] : llvm::enumerate(inputs)) {
-    if (isInverted(idx))
+APInt AndInverterOp::evaluateBooleanLogic(
+    llvm::function_ref<const APInt &(unsigned)> getInputValue) {
+  assert(getNumOperands() > 0 && "Expected non-empty input list");
+  APInt result = APInt::getAllOnes(getInputValue(0).getBitWidth());
+  for (auto [idx, inverted] : llvm::enumerate(getInverted())) {
+    const APInt &input = getInputValue(idx);
+    if (inverted)
       result &= ~input;
     else
       result &= input;
   }
+  return result;
+}
+
+llvm::KnownBits AndInverterOp::computeKnownBits(
+    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
+  assert(getNumOperands() > 0 && "Expected non-empty input list");
+
+  auto width = getInputKnownBits(0).getBitWidth();
+  llvm::KnownBits result(width);
+  result.One = APInt::getAllOnes(width);
+  result.Zero = APInt::getZero(width);
+
+  for (auto [i, inverted] : llvm::enumerate(getInverted())) {
+    auto operandKnownBits = getInputKnownBits(i);
+    if (inverted)
+      std::swap(operandKnownBits.Zero, operandKnownBits.One);
+    result &= operandKnownBits;
+  }
+
   return result;
 }
 

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/Synth/SynthOps.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Support/CustomDirectiveImpl.h"
 #include "circt/Support/Naming.h"
 #include "circt/Support/SATSolver.h"
@@ -248,9 +249,11 @@ int64_t AndInverterOp::getLogicDepthCost() {
   return llvm::Log2_64_Ceil(getNumOperands());
 }
 
-uint64_t AndInverterOp::getLogicAreaCost() {
-  return static_cast<uint64_t>(getNumOperands() - 1) *
-         getType().getIntOrFloatBitWidth();
+std::optional<uint64_t> AndInverterOp::getLogicAreaCost() {
+  int64_t bitWidth = hw::getBitWidth(getType());
+  if (bitWidth < 0)
+    return std::nullopt;
+  return static_cast<uint64_t>(getNumOperands() - 1) * bitWidth;
 }
 
 void AndInverterOp::emitCNF(

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -24,6 +24,7 @@
 
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Synth/SynthOpInterfaces.h"
 #include "circt/Dialect/Synth/SynthOps.h"
 #include "circt/Support/LLVM.h"
 #include "circt/Support/TruthTable.h"
@@ -302,17 +303,16 @@ FailureOr<BinaryTruthTable> circt::synth::getTruthTable(ValueRange values,
       if (it == eval.end())
         return choiceOp.emitError("Input value not found in evaluation map");
       eval[choiceOp.getResult()] = it->second;
-    } else if (auto andOp = dyn_cast<aig::AndInverterOp>(&op)) {
+    } else if (auto logicOp = dyn_cast<BooleanLogicOpInterface>(&op)) {
       // Support AIG and XOR operations
-      SmallVector<llvm::APInt, 2> inputs;
-      inputs.reserve(andOp.getInputs().size());
-      for (auto input : andOp.getInputs()) {
-        auto it = eval.find(input);
-        if (it == eval.end())
-          return andOp.emitError("Input value not found in evaluation map");
-        inputs.push_back(it->second);
-      }
-      eval[andOp.getResult()] = andOp.evaluate(inputs);
+      for (auto value : logicOp.getInputs())
+        if (!eval.contains(value))
+          return logicOp->emitError("Input value not found in evaluation map");
+
+      eval[logicOp.getResult()] =
+          logicOp.evaluateBooleanLogic([&](unsigned i) -> const APInt & {
+            return eval.find(logicOp.getInput(i))->second;
+          });
     } else if (auto xorOp = dyn_cast<comb::XorOp>(&op)) {
       auto it = eval.find(xorOp.getOperand(0));
       if (it == eval.end())

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -304,7 +304,6 @@ FailureOr<BinaryTruthTable> circt::synth::getTruthTable(ValueRange values,
         return choiceOp.emitError("Input value not found in evaluation map");
       eval[choiceOp.getResult()] = it->second;
     } else if (auto logicOp = dyn_cast<BooleanLogicOpInterface>(&op)) {
-      // Support AIG and XOR operations
       for (auto value : logicOp.getInputs())
         if (!eval.contains(value))
           return logicOp->emitError("Input value not found in evaluation map");
@@ -314,6 +313,7 @@ FailureOr<BinaryTruthTable> circt::synth::getTruthTable(ValueRange values,
             return eval.find(logicOp.getInput(i))->second;
           });
     } else if (auto xorOp = dyn_cast<comb::XorOp>(&op)) {
+      // TODO: Define Xor as Synth op.
       auto it = eval.find(xorOp.getOperand(0));
       if (it == eval.end())
         return xorOp.emitError("Input value not found in evaluation map");

--- a/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
+++ b/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
@@ -494,10 +494,9 @@ llvm::APInt FunctionalReductionSolver::simulateValue(Value v) {
     return simSignatures.at(v);
   return llvm::TypeSwitch<Operation *, llvm::APInt>(op)
       .Case<aig::AndInverterOp>([&](auto op) {
-        SmallVector<llvm::APInt> inputSigs;
-        for (auto input : op.getInputs())
-          inputSigs.push_back(simSignatures.at(input));
-        return op.evaluate(inputSigs);
+        return op.evaluateBooleanLogic([&](unsigned i) -> const APInt & {
+          return simSignatures.at(op.getInput(i));
+        });
       })
       .Case<comb::AndOp>([&](auto op) {
         APInt result = APInt::getAllOnes(numPatterns);

--- a/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
+++ b/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Synth/SynthOpInterfaces.h"
 #include "circt/Dialect/Synth/SynthOps.h"
 #include "circt/Dialect/Synth/Transforms/CutRewriter.h"
 #include "circt/Dialect/Synth/Transforms/SynthPasses.h"
@@ -84,11 +85,7 @@ private:
   // Create a fresh SAT variable for an intermediate Boolean subexpression that
   // does not correspond to an MLIR value.
   int createAuxVar();
-  int getLiteral(Value value, bool inverted = false);
-  void addAndClauses(int outVar, llvm::ArrayRef<int> inputLits);
-  void addOrClauses(int outVar, llvm::ArrayRef<int> inputLits);
-  void addXorClauses(int outVar, int lhsLit, int rhsLit);
-  void addParityClauses(int outVar, llvm::ArrayRef<int> inputLits);
+  SmallVector<int> getOperandVars(ValueRange operands);
   void encodeValue(Value value);
 
   IncrementalSATSolver &solver;
@@ -98,7 +95,7 @@ private:
 };
 
 static bool isFunctionalReductionSimulatableOp(Operation *op) {
-  return isa<aig::AndInverterOp, comb::AndOp, comb::OrOp, comb::XorOp>(op);
+  return isa<BooleanLogicOpInterface, comb::AndOp, comb::OrOp, comb::XorOp>(op);
 }
 
 EquivResult FunctionalReductionSATBuilder::verify(Value lhs, Value rhs,
@@ -144,74 +141,13 @@ int FunctionalReductionSATBuilder::createAuxVar() {
   return freshVar;
 }
 
-int FunctionalReductionSATBuilder::getLiteral(Value value, bool inverted) {
-  int lit = getOrCreateVar(value);
-  return inverted ? -lit : lit;
-}
-
-void FunctionalReductionSATBuilder::addAndClauses(
-    int outVar, llvm::ArrayRef<int> inputLits) {
-  // Tseitin encoding (https://en.wikipedia.org/wiki/Tseytin_transformation)
-  // for `outVar <=> and(inputLits)`. This keeps the CNF linear in the gate size
-  // while preserving satisfiability.
-  for (int lit : inputLits)
-    solver.addClause({-outVar, lit});
-
-  SmallVector<int> clause;
-  for (int lit : inputLits)
-    clause.push_back(-lit);
-  clause.push_back(outVar);
-  solver.addClause(clause);
-}
-
-void FunctionalReductionSATBuilder::addOrClauses(
-    int outVar, llvm::ArrayRef<int> inputLits) {
-  // Encode `outVar <=> or(inputLits)`.
-  //
-  // `(-lit v outVar)` for each input enforces `lit -> outVar`, i.e. any true
-  // input forces the OR result high.
-  for (int lit : inputLits)
-    solver.addClause({-lit, outVar});
-
-  SmallVector<int> clause;
-  clause.reserve(inputLits.size() + 1);
-  // `(-outVar v lit0 v lit1 ...)` enforces `outVar -> (lit0 v lit1 ...)`.
-  // Together these clauses make `outVar` exactly the OR of the inputs.
-  clause.push_back(-outVar);
-  clause.append(inputLits.begin(), inputLits.end());
-  solver.addClause(clause);
-}
-
-void FunctionalReductionSATBuilder::addXorClauses(int outVar, int lhsLit,
-                                                  int rhsLit) {
-  // Encode `outVar <=> (lhsLit xor rhsLit)` with the four satisfying rows of
-  // the 2-input XOR truth table. This is the standard definitional CNF for a
-  // binary XOR.
-  solver.addClause({-lhsLit, -rhsLit, -outVar});
-  solver.addClause({lhsLit, rhsLit, -outVar});
-  solver.addClause({lhsLit, -rhsLit, outVar});
-  solver.addClause({-lhsLit, rhsLit, outVar});
-}
-
-void FunctionalReductionSATBuilder::addParityClauses(
-    int outVar, llvm::ArrayRef<int> inputLits) {
-  assert(!inputLits.empty() && "parity requires at least one input");
-  if (inputLits.size() == 1) {
-    solver.addClause({-outVar, inputLits.front()});
-    solver.addClause({outVar, -inputLits.front()});
-    return;
-  }
-
-  int accumulatedLit = inputLits.front();
-  // Variadic XOR does not have a compact direct CNF encoding like AND/OR, so
-  // encode it as a chain of binary XORs and give each intermediate result its
-  // own auxiliary SAT variable.
-  for (auto [index, lit] : llvm::enumerate(inputLits.drop_front())) {
-    bool isLast = index + 2 == inputLits.size();
-    int outLit = isLast ? outVar : createAuxVar();
-    addXorClauses(outLit, accumulatedLit, lit);
-    accumulatedLit = outLit;
-  }
+SmallVector<int>
+FunctionalReductionSATBuilder::getOperandVars(ValueRange operands) {
+  SmallVector<int> vars;
+  vars.reserve(operands.size());
+  for (auto operand : operands)
+    vars.push_back(getOrCreateVar(operand));
+  return vars;
 }
 
 void FunctionalReductionSATBuilder::encodeValue(Value value) {
@@ -258,30 +194,28 @@ void FunctionalReductionSATBuilder::encodeValue(Value value) {
 
     encodedValues.insert(current);
     int outVar = getOrCreateVar(current);
+    auto addClause = [&](llvm::ArrayRef<int> clause) {
+      solver.addClause(clause);
+    };
 
-    SmallVector<int> inputLits;
-    inputLits.reserve(op->getNumOperands());
     TypeSwitch<Operation *>(op)
-        .Case<aig::AndInverterOp>([&](auto andOp) {
-          for (auto [input, inverted] :
-               llvm::zip(andOp.getInputs(), andOp.getInverted()))
-            inputLits.push_back(getLiteral(input, inverted));
-          addAndClauses(outVar, inputLits);
+        .Case<BooleanLogicOpInterface>([&](auto logicOp) {
+          auto inputVars = getOperandVars(logicOp.getInputs());
+          logicOp.emitCNF(outVar, inputVars, addClause,
+                          [&]() { return createAuxVar(); });
         })
         .Case<comb::AndOp>([&](auto andOp) {
-          for (auto input : andOp.getInputs())
-            inputLits.push_back(getLiteral(input));
-          addAndClauses(outVar, inputLits);
+          auto inputLits = getOperandVars(andOp.getInputs());
+          circt::addAndClauses(outVar, inputLits, addClause);
         })
         .Case<comb::OrOp>([&](auto orOp) {
-          for (auto input : orOp.getInputs())
-            inputLits.push_back(getLiteral(input));
-          addOrClauses(outVar, inputLits);
+          auto inputLits = getOperandVars(orOp.getInputs());
+          circt::addOrClauses(outVar, inputLits, addClause);
         })
         .Case<comb::XorOp>([&](auto xorOp) {
-          for (auto input : xorOp.getInputs())
-            inputLits.push_back(getLiteral(input));
-          addParityClauses(outVar, inputLits);
+          auto inputLits = getOperandVars(xorOp.getInputs());
+          circt::addParityClauses(outVar, getOperandVars(xorOp.getInputs()),
+                                  addClause, [&]() { return createAuxVar(); });
         })
         .Default(
             [](Operation *) { llvm_unreachable("unexpected supported op"); });
@@ -493,7 +427,7 @@ llvm::APInt FunctionalReductionSolver::simulateValue(Value v) {
   if (!op)
     return simSignatures.at(v);
   return llvm::TypeSwitch<Operation *, llvm::APInt>(op)
-      .Case<aig::AndInverterOp>([&](auto op) {
+      .Case<BooleanLogicOpInterface>([&](auto op) {
         return op.evaluateBooleanLogic([&](unsigned i) -> const APInt & {
           return simSignatures.at(op.getInput(i));
         });

--- a/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
+++ b/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
@@ -214,8 +214,8 @@ void FunctionalReductionSATBuilder::encodeValue(Value value) {
         })
         .Case<comb::XorOp>([&](auto xorOp) {
           auto inputLits = getOperandVars(xorOp.getInputs());
-          circt::addParityClauses(outVar, getOperandVars(xorOp.getInputs()),
-                                  addClause, [&]() { return createAuxVar(); });
+          circt::addParityClauses(outVar, inputLits, addClause,
+                                  [&]() { return createAuxVar(); });
         })
         .Default(
             [](Operation *) { llvm_unreachable("unexpected supported op"); });

--- a/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
@@ -84,8 +84,7 @@ private:
   /// Lower a multi-bit value to individual bits.
   /// This is the main entry point for bit-blasting a value.
   ArrayRef<Value> lowerValueToBits(Value value);
-  template <typename OpTy>
-  ArrayRef<Value> lowerInvertibleOperations(OpTy op);
+  ArrayRef<Value> lowerBooleanLogicOperation(BooleanLogicOpInterface op);
   template <typename OpTy>
   ArrayRef<Value> lowerCombLogicOperations(OpTy op);
   ArrayRef<Value> lowerCombMux(comb::MuxOp op);
@@ -155,20 +154,12 @@ const llvm::KnownBits &BitBlaster::computeKnownBits(Value value) {
     return insertKnownBits(value, llvm::KnownBits(width));
 
   llvm::KnownBits result(width);
-  if (auto aig = dyn_cast<aig::AndInverterOp>(op)) {
-    // Initialize to all ones for AND operation
-    result.One = APInt::getAllOnes(width);
-    result.Zero = APInt::getZero(width);
-
-    for (auto [operand, inverted] :
-         llvm::zip(aig.getInputs(), aig.getInverted())) {
-      auto operandKnownBits = computeKnownBits(operand);
-      if (inverted)
-        // Complement the known bits by swapping Zero and One
-        std::swap(operandKnownBits.Zero, operandKnownBits.One);
-      result &= operandKnownBits;
-    }
-  } else if (auto choice = dyn_cast<ChoiceOp>(op)) {
+  if (auto logicOp = dyn_cast<BooleanLogicOpInterface>(op))
+    result =
+        logicOp.computeKnownBits([&](unsigned i) -> const llvm::KnownBits & {
+          return computeKnownBits(logicOp.getInput(i));
+        });
+  else if (auto choice = dyn_cast<ChoiceOp>(op)) {
     result = computeKnownBits(choice.getInputs().front());
     for (auto input : choice.getInputs().drop_front()) {
       auto known = computeKnownBits(input);
@@ -248,8 +239,8 @@ ArrayRef<Value> BitBlaster::lowerValueToBits(Value value) {
         };
         return lowerOp(op, createOp);
       })
-      .Case<aig::AndInverterOp>(
-          [&](auto op) { return lowerInvertibleOperations(op); })
+      .Case<BooleanLogicOpInterface>(
+          [&](auto op) { return lowerBooleanLogicOperation(op); })
       .Case<comb::AndOp, comb::OrOp, comb::XorOp>(
           [&](auto op) { return lowerCombLogicOperations(op); })
       .Case<comb::MuxOp>([&](comb::MuxOp op) { return lowerCombMux(op); })
@@ -323,12 +314,12 @@ Value BitBlaster::getBoolConstant(bool value) {
   return constants[value];
 }
 
-template <typename OpTy>
-ArrayRef<Value> BitBlaster::lowerInvertibleOperations(OpTy op) {
+ArrayRef<Value>
+BitBlaster::lowerBooleanLogicOperation(BooleanLogicOpInterface op) {
   auto createOp = [&](OpBuilder &builder, ValueRange operands) {
-    return builder.createOrFold<OpTy>(op.getLoc(), operands, op.getInverted());
+    return op.cloneWithSameInversion(builder, operands);
   };
-  return lowerOp(op, createOp);
+  return lowerOp(op.getOperation(), createOp);
 }
 
 template <typename OpTy>

--- a/lib/Dialect/Synth/Transforms/StructuralHash.cpp
+++ b/lib/Dialect/Synth/Transforms/StructuralHash.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Synth/SynthOpInterfaces.h"
 #include "circt/Dialect/Synth/SynthOps.h"
 #include "circt/Dialect/Synth/Transforms/SynthPasses.h"
 #include "circt/Support/Naming.h"
@@ -100,9 +101,9 @@ namespace {
 class StructuralHashDriver {
 public:
   StructuralHashDriver() = default;
-  void visitOp(Operation *op, ArrayRef<bool> inverted);
-  void visitUnaryOp(Operation *op, bool inverted);
-  void visitVariadicOp(Operation *op, ArrayRef<bool> inverted);
+  void visitOp(BooleanLogicOpInterface op);
+  void visitUnaryOp(BooleanLogicOpInterface op);
+  void visitVariadicOp(BooleanLogicOpInterface op);
   uint64_t getNumber(Value v);
 
   /// Runs the structural hashing pass on the given module.
@@ -116,7 +117,7 @@ private:
   uint64_t constantCounter = 0;
 
   /// Hash table mapping structural keys to canonical operations for CSE.
-  DenseMap<StructuralHashKey, Operation *> hashTable;
+  DenseMap<StructuralHashKey, BooleanLogicOpInterface> hashTable;
 
   /// Maps inverted values to their non-inverted equivalents for propagation.
   /// For example, if we have:
@@ -130,48 +131,49 @@ private:
 };
 } // namespace
 
-void StructuralHashDriver::visitOp(Operation *op, ArrayRef<bool> inverted) {
+void StructuralHashDriver::visitOp(BooleanLogicOpInterface op) {
   /// Dispatches to the appropriate visitor based on the number of operands.
   /// For unary operations, calls visitUnaryOp; for variadic operations,
   /// calls visitVariadicOp.
-  if (op->getNumOperands() == 1) {
-    visitUnaryOp(op, inverted[0]);
+  if (op.getInputs().size() == 1) {
+    visitUnaryOp(op);
     return;
   }
-  visitVariadicOp(op, inverted);
+  visitVariadicOp(op);
 }
 
 /// Handles unary operations (single operand).
 /// If not inverted, replaces the operation with its operand.
 /// If inverted, attempts to propagate inversion through the inversion map
 /// or records the inversion for later propagation.
-void StructuralHashDriver::visitUnaryOp(Operation *op, bool inverted) {
+void StructuralHashDriver::visitUnaryOp(BooleanLogicOpInterface logicOp) {
+  Operation *op = logicOp.getOperation();
+  auto [input, inverted] = logicOp.getInputPair(0);
   if (!inverted) {
-    op->replaceAllUsesWith(ArrayRef<Value>{op->getOperand(0)});
+    op->replaceAllUsesWith(ArrayRef<Value>{input});
     op->erase();
     return;
   }
-  // Check if we can propagate inversion through the inversion map.
-  auto operand = op->getOperand(0);
-  auto it = inversion.find(operand);
+  auto it = inversion.find(input);
   if (it != inversion.end()) {
     // Found, replace the operand with the mapped value
     op->replaceAllUsesWith(ArrayRef<Value>{it->second});
     op->erase();
   } else {
     // Not found, insert into the map
-    inversion[op->getResult(0)] = operand;
+    inversion[logicOp.getResult()] = input;
   }
 }
 
 /// Computes a structural hash key, sorts operands for canonicalization,
 /// and performs CSE by checking the hash table for equivalent operations.
-void StructuralHashDriver::visitVariadicOp(Operation *op,
-                                           ArrayRef<bool> inverted) {
+void StructuralHashDriver::visitVariadicOp(BooleanLogicOpInterface logicOp) {
+  Operation *op = logicOp.getOperation();
+  auto inversions = logicOp.getInverted();
 
   // Compute the structural hash key for the operation.
   StructuralHashKey key(op->getName(), {});
-  for (auto [input, inverted] : llvm::zip(op->getOperands(), inverted)) {
+  for (auto [input, inverted] : llvm::zip(op->getOperands(), inversions)) {
     bool isInverted = inverted;
     // Check if we can propagate inversion through the inversion map
     auto it = inversion.find(input);
@@ -188,27 +190,29 @@ void StructuralHashDriver::visitVariadicOp(Operation *op,
     (void)getNumber(input);
   }
 
-  // Sort operands based on their assigned numbers.
-  llvm::sort(key.operandPairs, [&](auto a, auto b) {
-    size_t aNum = getNumber(a.getPointer());
-    size_t bNum = getNumber(b.getPointer());
-    if (aNum != bNum)
-      return aNum < bNum;
-    return a.getInt() < b.getInt();
-  });
+  // Canonicalize operand order only when the operation semantics permit
+  // reordering full (input, inverted) pairs.
+  if (logicOp.areInputsPermutationInvariant()) {
+    llvm::sort(key.operandPairs, [&](auto a, auto b) {
+      size_t aNum = getNumber(a.getPointer());
+      size_t bNum = getNumber(b.getPointer());
+      if (aNum != bNum)
+        return aNum < bNum;
+      return a.getInt() < b.getInt();
+    });
+  }
 
   // Insert the key into the hash table.
-  auto [it, inserted] = hashTable.try_emplace(key, op);
+  auto [it, inserted] = hashTable.try_emplace(key, logicOp);
   if (inserted) {
     // New entry, keep the operation and sort its operands.
     op->setOperands(llvm::to_vector<3>(llvm::map_range(
         key.operandPairs, [](auto p) { return p.getPointer(); })));
     SmallVector<bool, 3> newInversion(
         llvm::map_range(key.operandPairs, [](auto p) { return p.getInt(); }));
-    op->setAttr("inverted",
-                mlir::DenseBoolArrayAttr::get(op->getContext(), newInversion));
+    logicOp.setInverted(newInversion);
     // Assign a number to the result for future sorting.
-    (void)getNumber(op->getResult(0));
+    (void)getNumber(logicOp.getResult());
   } else {
     LDBG() << "Structural Hash: Replacing " << *op << " with " << *(it->second)
            << "\n";
@@ -245,7 +249,7 @@ uint64_t StructuralHashDriver::getNumber(Value v) {
 llvm::LogicalResult StructuralHashDriver::run(hw::HWModuleOp moduleOp) {
   auto isOperationReady = [&](Value value, Operation *op) -> bool {
     // Other than target ops, all other ops are always ready.
-    return !isa<circt::synth::aig::AndInverterOp>(op);
+    return !isa<BooleanLogicOpInterface>(op);
   };
 
   if (!mlir::sortTopologically(moduleOp.getBodyBlock(), isOperationReady))
@@ -257,13 +261,9 @@ llvm::LogicalResult StructuralHashDriver::run(hw::HWModuleOp moduleOp) {
   // Process target ops.
   // NOTE: Don't use walk here since the pass currently doesn't handle nested
   // regions.
-  for (auto &op :
-       llvm::make_early_inc_range(moduleOp.getBodyBlock()->getOperations())) {
-    mlir::TypeSwitch<Operation *>(&op)
-        .Case<circt::synth::aig::AndInverterOp>([&](auto invertibleOp) {
-          visitOp(invertibleOp, invertibleOp.getInverted());
-        })
-        .Default([&](Operation *op) {});
+  for (auto op :
+       llvm::make_early_inc_range(moduleOp.getOps<BooleanLogicOpInterface>())) {
+    visitOp(op);
   }
 
   // Run DCE to remove dangling ops.

--- a/lib/Support/SATSolver.cpp
+++ b/lib/Support/SATSolver.cpp
@@ -249,6 +249,58 @@ void Z3SATSolver::addClauseInternal(llvm::ArrayRef<int> lits) {
 
 } // namespace
 
+void addAndClauses(int outVar, llvm::ArrayRef<int> inputLits,
+                   llvm::function_ref<void(llvm::ArrayRef<int>)> addClause) {
+  for (int lit : inputLits)
+    addClause({-outVar, lit});
+
+  llvm::SmallVector<int> clause;
+  clause.reserve(inputLits.size() + 1);
+  for (int lit : inputLits)
+    clause.push_back(-lit);
+  clause.push_back(outVar);
+  addClause(clause);
+}
+
+void addOrClauses(int outVar, llvm::ArrayRef<int> inputLits,
+                  llvm::function_ref<void(llvm::ArrayRef<int>)> addClause) {
+  for (int lit : inputLits)
+    addClause({-lit, outVar});
+
+  llvm::SmallVector<int> clause;
+  clause.reserve(inputLits.size() + 1);
+  clause.push_back(-outVar);
+  clause.append(inputLits.begin(), inputLits.end());
+  addClause(clause);
+}
+
+void addXorClauses(int outVar, int lhsLit, int rhsLit,
+                   llvm::function_ref<void(llvm::ArrayRef<int>)> addClause) {
+  addClause({-lhsLit, -rhsLit, -outVar});
+  addClause({lhsLit, rhsLit, -outVar});
+  addClause({lhsLit, -rhsLit, outVar});
+  addClause({-lhsLit, rhsLit, outVar});
+}
+
+void addParityClauses(int outVar, llvm::ArrayRef<int> inputLits,
+                      llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+                      llvm::function_ref<int()> newVar) {
+  assert(!inputLits.empty() && "parity requires at least one input");
+  if (inputLits.size() == 1) {
+    addClause({-outVar, inputLits.front()});
+    addClause({outVar, -inputLits.front()});
+    return;
+  }
+
+  int accumulatedLit = inputLits.front();
+  for (auto [index, lit] : llvm::enumerate(inputLits.drop_front())) {
+    bool isLast = index + 2 == inputLits.size();
+    int outLit = isLast ? outVar : newVar();
+    addXorClauses(outLit, accumulatedLit, lit, addClause);
+    accumulatedLit = outLit;
+  }
+}
+
 std::unique_ptr<IncrementalSATSolver> createZ3SATSolver() {
 #if LLVM_WITH_Z3
   return std::make_unique<Z3SATSolver>();


### PR DESCRIPTION
 Add a common interface for boolean-logic DAG nodes whose semantics are defined by
 a list of input values together with per-input inversion flags.

The interface is implemented by only AIG op and this is a preparation for introducing other different operations (e.g. onehot, dot, majority). 

No functional change in the existing flow. 

AI-assisted-by: GPT-5.4