### PR TITLE
[Synth][CutRewriter] Add timing-preserving area-flow reselection

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -31,6 +31,7 @@
 #include "circt/Dialect/Synth/Synth.h.inc"
 
 #include "llvm/ADT/PriorityQueue.h"
+#include <vector>
 
 namespace circt {
 namespace synth {
@@ -92,18 +93,21 @@ public:
   }
 };
 
-/// Build a balanced binary tree using a priority queue to greedily pair
-/// elements with earliest arrival times. This minimizes the critical path
-/// delay.
+/// Build a balanced binary tree using a priority queue to greedily pair the
+/// cheapest elements first. `T::operator>` defines the heap ordering, which is
+/// typically based on arrival time and a deterministic tie-breaker. `combine`
+/// creates the parent node for each selected pair and computes its new cost.
 ///
 /// Template parameters:
 ///   T - The element type (must have operator> defined)
+///   InlineCapacity - Inline storage capacity for the internal node arena
 ///
-/// The algorithm uses a min-heap to repeatedly combine the two elements with
-/// the earliest arrival times, which is optimal for minimizing maximum delay.
-template <typename T>
-T buildBalancedTreeWithArrivalTimes(llvm::ArrayRef<T> elements,
-                                    llvm::function_ref<T(T, T)> combine) {
+/// The priority queue stores indices into a node arena rather than `T` values
+/// so large plan nodes can be kept stable and only moved when appended.
+template <typename T, unsigned InlineCapacity = 8>
+T buildBalancedTreeWithArrivalTimes(
+    llvm::ArrayRef<T> elements,
+    llvm::function_ref<T(const T &, const T &)> combine) {
   assert(!elements.empty() && "Cannot build tree from empty elements");
 
   if (elements.size() == 1)
@@ -111,23 +115,31 @@ T buildBalancedTreeWithArrivalTimes(llvm::ArrayRef<T> elements,
   if (elements.size() == 2)
     return combine(elements[0], elements[1]);
 
-  // Min-heap priority queue ordered by operator>
-  llvm::PriorityQueue<T, std::vector<T>, std::greater<T>> pq(elements.begin(),
-                                                             elements.end());
+  llvm::SmallVector<T, InlineCapacity> nodes(elements.begin(), elements.end());
+  nodes.reserve(elements.size() * 2 - 1);
 
-  // Greedily pair the two earliest-arriving elements
+  auto compare = [&](unsigned lhs, unsigned rhs) {
+    return nodes[lhs] > nodes[rhs];
+  };
+  // Min-heap priority queue ordered by the referenced node. Store indices
+  // rather than values to avoid repeatedly moving large node payloads.
+  llvm::PriorityQueue<unsigned, std::vector<unsigned>, decltype(compare)> pq(
+      compare);
+  for (unsigned i = 0, e = nodes.size(); i != e; ++i)
+    pq.push(i);
+
+  // Greedily pair the two best-ranked elements.
   while (pq.size() > 1) {
-    T e1 = pq.top();
+    unsigned e1 = pq.top();
     pq.pop();
-    T e2 = pq.top();
+    unsigned e2 = pq.top();
     pq.pop();
 
-    // Combine the two elements
-    T combined = combine(e1, e2);
-    pq.push(combined);
+    nodes.push_back(combine(nodes[e1], nodes[e2]));
+    pq.push(nodes.size() - 1);
   }
 
-  return pq.top();
+  return nodes[pq.top()];
 }
 
 /// Evaluate the Boolean function `x ^ (z | (x & y))`.

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -28,6 +28,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
+#include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -131,6 +132,12 @@ struct LogicNetworkGate {
   /// inversion bit is encoded in each edge.
   Signal edges[3];
 
+  /// Number of uses by logic gates in this network.
+  unsigned logicFanoutCount = 0;
+
+  /// Number of uses outside the logic network.
+  unsigned externalUseCount = 0;
+
   LogicNetworkGate() : opAndKind(nullptr, Constant), edges{} {}
   LogicNetworkGate(Operation *op, Kind kind,
                    llvm::ArrayRef<Signal> operands = {})
@@ -171,11 +178,18 @@ struct LogicNetworkGate {
     return k == And2 || k == Xor2 || k == Maj3 || k == Identity || k == Choice;
   }
 
-  /// Check if this should always be a cut input (PI or constant).
-  bool isAlwaysCutInput() const {
+  /// Check if this gate is a cut leaf (PI or constant).
+  bool isCutLeaf() const {
     Kind k = getKind();
     return k == PrimaryInput || k == Constant;
   }
+
+  unsigned getTotalRefCount() const {
+    unsigned refCount = logicFanoutCount + externalUseCount;
+    return refCount == 0 ? 1 : refCount;
+  }
+
+  bool isPrimaryOutput() const { return externalUseCount != 0; }
 };
 
 /// Flat logic network representation for efficient cut enumeration.
@@ -258,6 +272,16 @@ public:
   /// Get the total number of nodes in the network.
   size_t size() const { return gates.size(); }
 
+  /// Get the total reference count used by area-flow estimation.
+  unsigned getTotalRefCount(uint32_t index) const {
+    return gates[index].getTotalRefCount();
+  }
+
+  /// Check if a node is observed outside the logic network.
+  bool isPrimaryOutput(uint32_t index) const {
+    return gates[index].isPrimaryOutput();
+  }
+
   /// Add a primary input to the network.
   uint32_t addPrimaryInput(Value value);
 
@@ -279,6 +303,9 @@ public:
   void clear();
 
 private:
+  void recordLogicUse(uint32_t index) { ++gates[index].logicFanoutCount; }
+  void recordExternalUse(uint32_t index) { ++gates[index].externalUseCount; }
+
   /// Map from MLIR Value to network index.
   llvm::DenseMap<Value, uint32_t> valueToIndex;
 
@@ -349,8 +376,10 @@ class MatchedPattern {
 private:
   const CutRewritePattern *pattern = nullptr; ///< The matched library pattern
   SmallVector<DelayType, 1>
-      arrivalTimes;  ///< Arrival times of outputs from this pattern
-  double area = 0.0; ///< Area cost of this pattern
+      arrivalTimes; ///< Arrival times of outputs from this pattern
+  /// Saved match data we reuse during area-flow reselection.
+  MatchResult matchResult;
+  SmallVector<unsigned, 6> patternInputToCutInput;
 
 public:
   /// Default constructor creates an invalid matched pattern.
@@ -358,18 +387,38 @@ public:
 
   /// Constructor for a valid matched pattern.
   MatchedPattern(const CutRewritePattern *pattern,
-                 SmallVector<DelayType, 1> arrivalTimes, double area)
-      : pattern(pattern), arrivalTimes(std::move(arrivalTimes)), area(area) {}
+                 SmallVector<DelayType, 1> arrivalTimes,
+                 MatchResult matchResult,
+                 ArrayRef<unsigned> patternInputToCutInput)
+      : pattern(pattern), arrivalTimes(std::move(arrivalTimes)),
+        matchResult(std::move(matchResult)),
+        patternInputToCutInput(patternInputToCutInput.begin(),
+                               patternInputToCutInput.end()) {}
 
   /// Get the arrival time of signals through this pattern.
   DelayType getArrivalTime(unsigned outputIndex) const;
   ArrayRef<DelayType> getArrivalTimes() const;
+  DelayType getWorstOutputArrivalTime() const;
 
   /// Get the library pattern that was matched.
   const CutRewritePattern *getPattern() const;
 
   /// Get the area cost of using this pattern.
   double getArea() const;
+
+  /// Get the per-input delays used when scoring this match.
+  ArrayRef<DelayType> getDelays() const;
+
+  /// Get the cached match payload used to rebuild this match.
+  const MatchResult &getMatchResult() const { return matchResult; }
+
+  /// Get the mapping from pattern input indices to cut input indices.
+  ArrayRef<unsigned> getInputPermutation() const {
+    return patternInputToCutInput;
+  }
+
+  /// Get the delay for a cut input after accounting for input permutation.
+  DelayType getDelayForCutInput(unsigned cutInputIndex) const;
 };
 
 /// Represents a cut in the combinational logic network.
@@ -529,6 +578,15 @@ private:
   bool isFrozen = false; ///< Whether cut set is finalized
 
 public:
+  /// Latest time this node is allowed to arrive.
+  DelayType requiredTime = std::numeric_limits<DelayType>::max();
+
+  /// Arrival time of the currently selected cut.
+  DelayType bestArrivalTime = 0;
+
+  /// Current area-flow score for the selected cut.
+  double areaFlow = 0.0;
+
   /// Check if this cut set has a valid matched pattern.
   bool isMatched() const { return bestCut; }
 
@@ -551,6 +609,9 @@ public:
 
   /// Get read-only access to all cuts in this set.
   ArrayRef<Cut *> getCuts() const;
+
+  /// Replace the currently selected cut during area recovery.
+  void setBestCut(Cut *cut) { bestCut = cut; }
 };
 
 /// Configuration options for the cut-based rewriting algorithm.
@@ -657,6 +718,12 @@ public:
   void noteCutRewritten() { ++stats.numCutsRewritten; }
 
   void dump() const;
+
+  /// Compute required times from the current timing-feasible seed mapping.
+  void computeRequiredTimes();
+
+  /// Re-select cuts using area-flow while preserving required times.
+  void reselectCutsForAreaFlow();
 
   /// Get cut sets (indexed by LogicNetwork index).
   const llvm::DenseMap<uint32_t, CutSet *> &getCutSets() const {

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -132,9 +132,6 @@ struct LogicNetworkGate {
   /// inversion bit is encoded in each edge.
   Signal edges[3];
 
-  /// Number of uses by logic gates in this network.
-  unsigned logicFanoutCount = 0;
-
   /// Number of uses outside the logic network.
   unsigned externalUseCount = 0;
 
@@ -184,12 +181,9 @@ struct LogicNetworkGate {
     return k == PrimaryInput || k == Constant;
   }
 
-  unsigned getTotalRefCount() const {
-    unsigned refCount = logicFanoutCount + externalUseCount;
-    return refCount == 0 ? 1 : refCount;
-  }
-
   bool isPrimaryOutput() const { return externalUseCount != 0; }
+
+  unsigned getExternalUseCount() const { return externalUseCount; }
 };
 
 /// Flat logic network representation for efficient cut enumeration.
@@ -272,14 +266,14 @@ public:
   /// Get the total number of nodes in the network.
   size_t size() const { return gates.size(); }
 
-  /// Get the total reference count used by area-flow estimation.
-  unsigned getTotalRefCount(uint32_t index) const {
-    return gates[index].getTotalRefCount();
-  }
-
   /// Check if a node is observed outside the logic network.
   bool isPrimaryOutput(uint32_t index) const {
     return gates[index].isPrimaryOutput();
+  }
+
+  /// Get the number of uses outside the logic network.
+  unsigned getExternalUseCount(uint32_t index) const {
+    return gates[index].getExternalUseCount();
   }
 
   /// Add a primary input to the network.
@@ -303,7 +297,6 @@ public:
   void clear();
 
 private:
-  void recordLogicUse(uint32_t index) { ++gates[index].logicFanoutCount; }
   void recordExternalUse(uint32_t index) { ++gates[index].externalUseCount; }
 
   /// Map from MLIR Value to network index.

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -718,6 +718,9 @@ public:
   /// Re-select cuts using area-flow while preserving required times.
   void reselectCutsForAreaFlow();
 
+  /// Re-select cuts using exact-area deref/ref while preserving required times.
+  void reselectCutsForExactArea();
+
   /// Get cut sets (indexed by LogicNetwork index).
   const llvm::DenseMap<uint32_t, CutSet *> &getCutSets() const {
     return cutSets;

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -319,88 +319,6 @@ private:
   llvm::SmallVector<LogicNetworkGate> gates;
 };
 
-// Cut matching is split across a few small data objects:
-//
-// - PatternCost: pattern-local cost/timing data, plus optional implementation
-//   data. This is produced by CutRewritePattern::match().
-// - MatchBinding: framework-owned pin binding for NPN/permutation matches.
-// - MatchedPattern: the selected pattern, its arrival times, cost, binding, and
-//   any implementation data needed by CutRewritePattern::rewrite().
-//
-// Keeping these pieces separate lets generic framework reselection recompute
-// timing from cost/binding, while stateful patterns can still replay the exact
-// implementation that was costed during matching.
-
-/// Optional pattern-specific implementation data selected during matching.
-struct PatternImplementation {
-  virtual ~PatternImplementation() = default;
-};
-
-/// Cost of implementing a cut with a pattern.
-///
-/// This structure contains the area and per-input delay information computed
-/// by a pattern matcher. It may also carry implementation data that the pattern
-/// needs to replay exactly the realization chosen during matching.
-///
-/// The delays can be stored in two ways:
-/// 1. As a reference to static/cached data (e.g., tech library delays)
-///    - Use setDelayRef() for zero-cost reference (no allocation)
-/// 2. As owned dynamic data (e.g., computed SOP delays)
-///    - Use setOwnedDelays() to transfer ownership
-///
-struct PatternCost {
-  /// Area cost of implementing this cut with the pattern.
-  double area = 0.0;
-
-  /// Default constructor.
-  PatternCost() = default;
-
-  /// Constructor with area and delays (by reference).
-  PatternCost(double area, ArrayRef<DelayType> delays)
-      : area(area), borrowedDelays(delays) {}
-
-  /// Set delays by reference (zero-cost for static/cached delays).
-  /// The caller must ensure the referenced data remains valid.
-  void setDelayRef(ArrayRef<DelayType> delays) { borrowedDelays = delays; }
-
-  /// Set delays by transferring ownership (for dynamically computed delays).
-  /// This moves the data into internal storage.
-  void setOwnedDelays(SmallVector<DelayType, 6> delays) {
-    ownedDelays.emplace(std::move(delays));
-    borrowedDelays = {};
-  }
-
-  /// Get all delays as an ArrayRef.
-  ArrayRef<DelayType> getDelays() const {
-    return ownedDelays.has_value() ? ArrayRef<DelayType>(*ownedDelays)
-                                   : borrowedDelays;
-  }
-
-  /// Attach pattern-specific implementation data to this match.
-  void setImplementation(std::shared_ptr<const PatternImplementation> impl) {
-    implementation = std::move(impl);
-  }
-
-  /// Get the pattern-specific implementation data, if any.
-  const PatternImplementation *getImplementation() const {
-    return implementation.get();
-  }
-
-private:
-  /// Borrowed delays (used when ownedDelays is empty).
-  /// Points to external data provided via setDelayRef().
-  ArrayRef<DelayType> borrowedDelays;
-
-  /// Owned delays (used when present).
-  /// Only allocated when setOwnedDelays() is called. When empty (std::nullopt),
-  /// moving this PatternCost avoids constructing/moving the SmallVector,
-  /// achieving zero-cost abstraction for the common case (borrowed delays).
-  std::optional<SmallVector<DelayType, 6>> ownedDelays;
-
-  /// Optional implementation data for stateful/dynamic matchers.
-  std::shared_ptr<const PatternImplementation> implementation;
-};
-
 /// Describes how a matched pattern's pins bind to a cut.
 ///
 /// The binding is derived from composing the cut and pattern NPN witnesses. It
@@ -442,6 +360,97 @@ struct MatchBinding {
   bool hasNegation() const { return inputNegation != 0 || outputNegation != 0; }
 };
 
+// Cut matching is split across a few small data objects:
+//
+// - MatchBinding: framework-owned pin binding for NPN/permutation matches.
+// - PatternImplementation: optional pattern-owned rewrite recipe.
+// - PatternMatch: the complete match payload used by selection and rewrite.
+// - MatchedPattern: the selected pattern plus framework-computed arrival times.
+//
+// Keeping binding and cost data in PatternMatch lets generic framework
+// reselection recompute timing, while stateful patterns can still replay the
+// exact implementation that was costed during matching.
+
+/// Optional pattern-specific implementation data selected during matching.
+struct PatternImplementation {
+  virtual ~PatternImplementation() = default;
+};
+
+/// Full payload for implementing a cut with a pattern.
+///
+/// This contains the area and per-input delay information used for selection,
+/// the input/output binding used for NPN/permutation-aware timing and rewrite,
+/// and optional implementation data for patterns whose rewrite cannot be
+/// reconstructed from the cut alone.
+///
+/// The delays can be stored in two ways:
+/// 1. As a reference to static/cached data (e.g., tech library delays)
+///    - Use setDelayRef() for zero-cost reference (no allocation)
+/// 2. As owned dynamic data (e.g., computed SOP delays)
+///    - Use setOwnedDelays() to transfer ownership
+///
+struct PatternMatch {
+  /// Area cost of implementing this cut with the pattern.
+  double area = 0.0;
+
+  /// Default constructor.
+  PatternMatch() = default;
+
+  /// Constructor with area and delays (by reference).
+  PatternMatch(double area, ArrayRef<DelayType> delays)
+      : area(area), borrowedDelays(delays) {}
+
+  /// Set delays by reference (zero-cost for static/cached delays).
+  /// The caller must ensure the referenced data remains valid.
+  void setDelayRef(ArrayRef<DelayType> delays) { borrowedDelays = delays; }
+
+  /// Set delays by transferring ownership (for dynamically computed delays).
+  /// This moves the data into internal storage.
+  void setOwnedDelays(SmallVector<DelayType, 6> delays) {
+    ownedDelays.emplace(std::move(delays));
+    borrowedDelays = {};
+  }
+
+  /// Get all delays as an ArrayRef.
+  ArrayRef<DelayType> getDelays() const {
+    return ownedDelays.has_value() ? ArrayRef<DelayType>(*ownedDelays)
+                                   : borrowedDelays;
+  }
+
+  /// Set the binding between cut inputs and pattern pins.
+  void setBinding(MatchBinding binding) { this->binding = std::move(binding); }
+
+  /// Get the binding between cut inputs and pattern pins.
+  const MatchBinding &getBinding() const { return binding; }
+
+  /// Attach pattern-specific implementation data to this match.
+  void setImplementation(std::shared_ptr<const PatternImplementation> impl) {
+    implementation = std::move(impl);
+  }
+
+  /// Get the pattern-specific implementation data, if any.
+  const PatternImplementation *getImplementation() const {
+    return implementation.get();
+  }
+
+private:
+  /// Borrowed delays (used when ownedDelays is empty).
+  /// Points to external data provided via setDelayRef().
+  ArrayRef<DelayType> borrowedDelays;
+
+  /// Owned delays (used when present).
+  /// Only allocated when setOwnedDelays() is called. When empty (std::nullopt),
+  /// moving this PatternMatch avoids constructing/moving the SmallVector,
+  /// achieving zero-cost abstraction for the common case (borrowed delays).
+  std::optional<SmallVector<DelayType, 6>> ownedDelays;
+
+  /// Binding between the matched pattern pins and cut inputs.
+  MatchBinding binding;
+
+  /// Optional implementation data for stateful/dynamic matchers.
+  std::shared_ptr<const PatternImplementation> implementation;
+};
+
 /// Represents a cut that has been successfully matched to a rewriting pattern.
 ///
 /// This class encapsulates the result of matching a cut against a rewriting
@@ -453,8 +462,7 @@ private:
   SmallVector<DelayType, 1>
       arrivalTimes; ///< Arrival times of outputs from this pattern
   /// Saved match data we reuse during area-flow reselection.
-  PatternCost cost;
-  MatchBinding binding;
+  PatternMatch match;
 
 public:
   /// Default constructor creates an invalid matched pattern.
@@ -462,10 +470,9 @@ public:
 
   /// Constructor for a valid matched pattern.
   MatchedPattern(const CutRewritePattern *pattern,
-                 SmallVector<DelayType, 1> arrivalTimes, PatternCost cost,
-                 MatchBinding binding)
+                 SmallVector<DelayType, 1> arrivalTimes, PatternMatch match)
       : pattern(pattern), arrivalTimes(std::move(arrivalTimes)),
-        cost(std::move(cost)), binding(std::move(binding)) {}
+        match(std::move(match)) {}
 
   /// Get the arrival time of signals through this pattern.
   DelayType getArrivalTime(unsigned outputIndex) const;
@@ -481,16 +488,16 @@ public:
   /// Get the per-input delays used when scoring this match.
   ArrayRef<DelayType> getDelays() const;
 
-  /// Get the cached cost payload used to rebuild this match.
-  const PatternCost &getCost() const { return cost; }
+  /// Get the cached match payload used to rebuild this match.
+  const PatternMatch &getMatch() const { return match; }
 
   /// Get the stored pattern-specific implementation data, if any.
   const PatternImplementation *getImplementation() const {
-    return cost.getImplementation();
+    return match.getImplementation();
   }
 
   /// Get the binding between cut inputs and pattern pins.
-  const MatchBinding &getBinding() const { return binding; }
+  const MatchBinding &getBinding() const { return match.getBinding(); }
 
   /// Get the delay for a cut input after accounting for input permutation.
   DelayType getDelayForCutInput(unsigned cutInputIndex) const;
@@ -871,13 +878,13 @@ struct CutRewritePattern {
   /// Check if a cut matches this pattern and compute area/delay metrics.
   ///
   /// This method is called to determine if a cut can be replaced by this
-  /// pattern. If the cut matches, it should return a PatternCost containing the
-  /// area and per-input delays for this specific cut.
+  /// pattern. If the cut matches, it should return a PatternMatch containing
+  /// the area, delay, and optional rewrite data for this specific cut.
   ///
   /// If useTruthTableMatcher() returns true, this method is only
   /// called for cuts with matching truth tables.
-  virtual std::optional<PatternCost> match(CutEnumerator &enumerator,
-                                           const Cut &cut) const = 0;
+  virtual std::optional<PatternMatch> match(CutEnumerator &enumerator,
+                                            const Cut &cut) const = 0;
 
   /// Specify truth tables that this pattern can match.
   ///

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -881,10 +881,13 @@ struct CutRewritePattern {
   /// pattern. If the cut matches, it should return a PatternMatch containing
   /// the area, delay, and optional rewrite data for this specific cut.
   ///
-  /// If useTruthTableMatcher() returns true, this method is only
-  /// called for cuts with matching truth tables.
-  virtual std::optional<PatternMatch> match(CutEnumerator &enumerator,
-                                            const Cut &cut) const = 0;
+  /// If useTruthTableMatcher() returns true, this method is only called for
+  /// cuts with matching truth tables, and binding describes how the matched
+  /// pattern pins map to the cut. Non-truth-table patterns receive identity
+  /// bindings.
+  virtual std::optional<PatternMatch>
+  match(CutEnumerator &enumerator, const Cut &cut,
+        const MatchBinding &binding) const = 0;
 
   /// Specify truth tables that this pattern can match.
   ///

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -28,6 +28,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
+#include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -135,6 +136,12 @@ struct LogicNetworkGate {
   /// inversion bit is encoded in each edge.
   Signal edges[3];
 
+  /// Number of uses by logic gates in this network.
+  unsigned logicFanoutCount = 0;
+
+  /// Number of uses outside the logic network.
+  unsigned externalUseCount = 0;
+
   LogicNetworkGate() : op(nullptr), kind(Constant), edges{} {}
   LogicNetworkGate(Operation *op, Kind kind,
                    llvm::ArrayRef<Signal> operands = {})
@@ -181,11 +188,18 @@ struct LogicNetworkGate {
            k == Gamble3;
   }
 
-  /// Check if this should always be a cut input (PI or constant).
-  bool isAlwaysCutInput() const {
+  /// Check if this gate is a cut leaf (PI or constant).
+  bool isCutLeaf() const {
     Kind k = getKind();
     return k == PrimaryInput || k == Constant;
   }
+
+  unsigned getTotalRefCount() const {
+    unsigned refCount = logicFanoutCount + externalUseCount;
+    return refCount == 0 ? 1 : refCount;
+  }
+
+  bool isPrimaryOutput() const { return externalUseCount != 0; }
 };
 
 /// Flat logic network representation for efficient cut enumeration.
@@ -268,6 +282,16 @@ public:
   /// Get the total number of nodes in the network.
   size_t size() const { return gates.size(); }
 
+  /// Get the total reference count used by area-flow estimation.
+  unsigned getTotalRefCount(uint32_t index) const {
+    return gates[index].getTotalRefCount();
+  }
+
+  /// Check if a node is observed outside the logic network.
+  bool isPrimaryOutput(uint32_t index) const {
+    return gates[index].isPrimaryOutput();
+  }
+
   /// Add a primary input to the network.
   uint32_t addPrimaryInput(Value value);
 
@@ -289,6 +313,9 @@ public:
   void clear();
 
 private:
+  void recordLogicUse(uint32_t index) { ++gates[index].logicFanoutCount; }
+  void recordExternalUse(uint32_t index) { ++gates[index].externalUseCount; }
+
   /// Map from MLIR Value to network index.
   llvm::DenseMap<Value, uint32_t> valueToIndex;
 
@@ -359,8 +386,10 @@ class MatchedPattern {
 private:
   const CutRewritePattern *pattern = nullptr; ///< The matched library pattern
   SmallVector<DelayType, 1>
-      arrivalTimes;  ///< Arrival times of outputs from this pattern
-  double area = 0.0; ///< Area cost of this pattern
+      arrivalTimes; ///< Arrival times of outputs from this pattern
+  /// Saved match data we reuse during area-flow reselection.
+  MatchResult matchResult;
+  SmallVector<unsigned, 6> patternInputToCutInput;
 
 public:
   /// Default constructor creates an invalid matched pattern.
@@ -368,18 +397,38 @@ public:
 
   /// Constructor for a valid matched pattern.
   MatchedPattern(const CutRewritePattern *pattern,
-                 SmallVector<DelayType, 1> arrivalTimes, double area)
-      : pattern(pattern), arrivalTimes(std::move(arrivalTimes)), area(area) {}
+                 SmallVector<DelayType, 1> arrivalTimes,
+                 MatchResult matchResult,
+                 ArrayRef<unsigned> patternInputToCutInput)
+      : pattern(pattern), arrivalTimes(std::move(arrivalTimes)),
+        matchResult(std::move(matchResult)),
+        patternInputToCutInput(patternInputToCutInput.begin(),
+                               patternInputToCutInput.end()) {}
 
   /// Get the arrival time of signals through this pattern.
   DelayType getArrivalTime(unsigned outputIndex) const;
   ArrayRef<DelayType> getArrivalTimes() const;
+  DelayType getWorstOutputArrivalTime() const;
 
   /// Get the library pattern that was matched.
   const CutRewritePattern *getPattern() const;
 
   /// Get the area cost of using this pattern.
   double getArea() const;
+
+  /// Get the per-input delays used when scoring this match.
+  ArrayRef<DelayType> getDelays() const;
+
+  /// Get the cached match payload used to rebuild this match.
+  const MatchResult &getMatchResult() const { return matchResult; }
+
+  /// Get the mapping from pattern input indices to cut input indices.
+  ArrayRef<unsigned> getInputPermutation() const {
+    return patternInputToCutInput;
+  }
+
+  /// Get the delay for a cut input after accounting for input permutation.
+  DelayType getDelayForCutInput(unsigned cutInputIndex) const;
 };
 
 /// Represents a cut in the combinational logic network.
@@ -539,6 +588,15 @@ private:
   bool isFrozen = false; ///< Whether cut set is finalized
 
 public:
+  /// Latest time this node is allowed to arrive.
+  DelayType requiredTime = std::numeric_limits<DelayType>::max();
+
+  /// Arrival time of the currently selected cut.
+  DelayType bestArrivalTime = 0;
+
+  /// Current area-flow score for the selected cut.
+  double areaFlow = 0.0;
+
   /// Check if this cut set has a valid matched pattern.
   bool isMatched() const { return bestCut; }
 
@@ -561,6 +619,9 @@ public:
 
   /// Get read-only access to all cuts in this set.
   ArrayRef<Cut *> getCuts() const;
+
+  /// Replace the currently selected cut during area recovery.
+  void setBestCut(Cut *cut) { bestCut = cut; }
 };
 
 /// Configuration options for the cut-based rewriting algorithm.
@@ -667,6 +728,12 @@ public:
   void noteCutRewritten() { ++stats.numCutsRewritten; }
 
   void dump() const;
+
+  /// Compute required times from the current timing-feasible seed mapping.
+  void computeRequiredTimes();
+
+  /// Re-select cuts using area-flow while preserving required times.
+  void reselectCutsForAreaFlow();
 
   /// Get cut sets (indexed by LogicNetwork index).
   const llvm::DenseMap<uint32_t, CutSet *> &getCutSets() const {

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -884,11 +884,10 @@ struct CutRewritePattern {
   /// If useTruthTableMatcher() returns true, this method is only called for
   /// cuts with matching truth tables, and binding describes how the matched
   /// pattern pins map to the cut. Non-truth-table patterns receive identity
-  /// bindings. inputArrivalTimes provides the framework-computed arrival time
-  /// for each cut input in cut-input order.
+  /// bindings.
   virtual std::optional<MatchResult>
-  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
-        ArrayRef<DelayType> inputArrivalTimes) const = 0;
+  match(CutEnumerator &enumerator, const Cut &cut,
+        const MatchBinding &binding) const = 0;
 
   /// Specify truth tables that this pattern can match.
   ///

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -364,10 +364,10 @@ struct MatchBinding {
 //
 // - MatchBinding: framework-owned pin binding for NPN/permutation matches.
 // - PatternImplementation: optional pattern-owned rewrite recipe.
-// - PatternMatch: the complete match payload used by selection and rewrite.
+// - MatchResult: the complete match payload used by selection and rewrite.
 // - MatchedPattern: the selected pattern plus framework-computed arrival times.
 //
-// Keeping binding and cost data in PatternMatch lets generic framework
+// Keeping binding and cost data in MatchResult lets generic framework
 // reselection recompute timing, while stateful patterns can still replay the
 // exact implementation that was costed during matching.
 
@@ -389,15 +389,15 @@ struct PatternImplementation {
 /// 2. As owned dynamic data (e.g., computed SOP delays)
 ///    - Use setOwnedDelays() to transfer ownership
 ///
-struct PatternMatch {
+struct MatchResult {
   /// Area cost of implementing this cut with the pattern.
   double area = 0.0;
 
   /// Default constructor.
-  PatternMatch() = default;
+  MatchResult() = default;
 
   /// Constructor with area and delays (by reference).
-  PatternMatch(double area, ArrayRef<DelayType> delays)
+  MatchResult(double area, ArrayRef<DelayType> delays)
       : area(area), borrowedDelays(delays) {}
 
   /// Set delays by reference (zero-cost for static/cached delays).
@@ -440,7 +440,7 @@ private:
 
   /// Owned delays (used when present).
   /// Only allocated when setOwnedDelays() is called. When empty (std::nullopt),
-  /// moving this PatternMatch avoids constructing/moving the SmallVector,
+  /// moving this MatchResult avoids constructing/moving the SmallVector,
   /// achieving zero-cost abstraction for the common case (borrowed delays).
   std::optional<SmallVector<DelayType, 6>> ownedDelays;
 
@@ -462,7 +462,7 @@ private:
   SmallVector<DelayType, 1>
       arrivalTimes; ///< Arrival times of outputs from this pattern
   /// Saved match data we reuse during area-flow reselection.
-  PatternMatch match;
+  MatchResult match;
 
 public:
   /// Default constructor creates an invalid matched pattern.
@@ -470,7 +470,7 @@ public:
 
   /// Constructor for a valid matched pattern.
   MatchedPattern(const CutRewritePattern *pattern,
-                 SmallVector<DelayType, 1> arrivalTimes, PatternMatch match)
+                 SmallVector<DelayType, 1> arrivalTimes, MatchResult match)
       : pattern(pattern), arrivalTimes(std::move(arrivalTimes)),
         match(std::move(match)) {}
 
@@ -489,7 +489,7 @@ public:
   ArrayRef<DelayType> getDelays() const;
 
   /// Get the cached match payload used to rebuild this match.
-  const PatternMatch &getMatch() const { return match; }
+  const MatchResult &getMatch() const { return match; }
 
   /// Get the stored pattern-specific implementation data, if any.
   const PatternImplementation *getImplementation() const {
@@ -878,14 +878,14 @@ struct CutRewritePattern {
   /// Check if a cut matches this pattern and compute area/delay metrics.
   ///
   /// This method is called to determine if a cut can be replaced by this
-  /// pattern. If the cut matches, it should return a PatternMatch containing
+  /// pattern. If the cut matches, it should return a MatchResult containing
   /// the area, delay, and optional rewrite data for this specific cut.
   ///
   /// If useTruthTableMatcher() returns true, this method is only called for
   /// cuts with matching truth tables, and binding describes how the matched
   /// pattern pins map to the cut. Non-truth-table patterns receive identity
   /// bindings.
-  virtual std::optional<PatternMatch>
+  virtual std::optional<MatchResult>
   match(CutEnumerator &enumerator, const Cut &cut,
         const MatchBinding &binding) const = 0;
 

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -884,10 +884,11 @@ struct CutRewritePattern {
   /// If useTruthTableMatcher() returns true, this method is only called for
   /// cuts with matching truth tables, and binding describes how the matched
   /// pattern pins map to the cut. Non-truth-table patterns receive identity
-  /// bindings.
+  /// bindings. inputArrivalTimes provides the framework-computed arrival time
+  /// for each cut input in cut-input order.
   virtual std::optional<MatchResult>
-  match(CutEnumerator &enumerator, const Cut &cut,
-        const MatchBinding &binding) const = 0;
+  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
+        ArrayRef<DelayType> inputArrivalTimes) const = 0;
 
   /// Specify truth tables that this pattern can match.
   ///

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -319,11 +319,28 @@ private:
   llvm::SmallVector<LogicNetworkGate> gates;
 };
 
+// Cut matching is split across a few small data objects:
+//
+// - PatternCost: pattern-local cost/timing data, plus optional implementation
+//   data. This is produced by CutRewritePattern::match().
+// - MatchBinding: framework-owned pin binding for NPN/permutation matches.
+// - MatchedPattern: the selected pattern, its arrival times, cost, binding, and
+//   any implementation data needed by CutRewritePattern::rewrite().
+//
+// Keeping these pieces separate lets generic framework reselection recompute
+// timing from cost/binding, while stateful patterns can still replay the exact
+// implementation that was costed during matching.
+
+/// Optional pattern-specific implementation data selected during matching.
+struct PatternImplementation {
+  virtual ~PatternImplementation() = default;
+};
+
 /// Cost of implementing a cut with a pattern.
 ///
 /// This structure contains the area and per-input delay information computed
-/// by a pattern matcher. It does not describe how the pattern inputs bind to a
-/// cut; that is tracked separately by MatchBinding.
+/// by a pattern matcher. It may also carry implementation data that the pattern
+/// needs to replay exactly the realization chosen during matching.
 ///
 /// The delays can be stored in two ways:
 /// 1. As a reference to static/cached data (e.g., tech library delays)
@@ -359,6 +376,16 @@ struct PatternCost {
                                    : borrowedDelays;
   }
 
+  /// Attach pattern-specific implementation data to this match.
+  void setImplementation(std::shared_ptr<const PatternImplementation> impl) {
+    implementation = std::move(impl);
+  }
+
+  /// Get the pattern-specific implementation data, if any.
+  const PatternImplementation *getImplementation() const {
+    return implementation.get();
+  }
+
 private:
   /// Borrowed delays (used when ownedDelays is empty).
   /// Points to external data provided via setDelayRef().
@@ -369,6 +396,9 @@ private:
   /// moving this PatternCost avoids constructing/moving the SmallVector,
   /// achieving zero-cost abstraction for the common case (borrowed delays).
   std::optional<SmallVector<DelayType, 6>> ownedDelays;
+
+  /// Optional implementation data for stateful/dynamic matchers.
+  std::shared_ptr<const PatternImplementation> implementation;
 };
 
 /// Describes how a matched pattern's pins bind to a cut.
@@ -453,6 +483,11 @@ public:
 
   /// Get the cached cost payload used to rebuild this match.
   const PatternCost &getCost() const { return cost; }
+
+  /// Get the stored pattern-specific implementation data, if any.
+  const PatternImplementation *getImplementation() const {
+    return cost.getImplementation();
+  }
 
   /// Get the binding between cut inputs and pattern pins.
   const MatchBinding &getBinding() const { return binding; }
@@ -863,9 +898,9 @@ struct CutRewritePattern {
   /// because the cut enumerator maintains references to operations throughout
   /// the circuit, making it safe to only replace the root operation of each
   /// cut while preserving all other operations unchanged.
-  virtual FailureOr<Operation *> rewrite(mlir::OpBuilder &builder,
-                                         CutEnumerator &enumerator,
-                                         const Cut &cut) const = 0;
+  virtual FailureOr<Operation *>
+  rewrite(mlir::OpBuilder &builder, CutEnumerator &enumerator, const Cut &cut,
+          const MatchedPattern &matched) const = 0;
 
   /// Get the number of outputs this pattern produces.
   virtual unsigned getNumOutputs() const = 0;

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -728,6 +728,9 @@ public:
   /// Re-select cuts using area-flow while preserving required times.
   void reselectCutsForAreaFlow();
 
+  /// Re-select cuts using exact-area deref/ref while preserving required times.
+  void reselectCutsForExactArea();
+
   /// Get cut sets (indexed by LogicNetwork index).
   const llvm::DenseMap<uint32_t, CutSet *> &getCutSets() const {
     return cutSets;

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -136,9 +136,6 @@ struct LogicNetworkGate {
   /// inversion bit is encoded in each edge.
   Signal edges[3];
 
-  /// Number of uses by logic gates in this network.
-  unsigned logicFanoutCount = 0;
-
   /// Number of uses outside the logic network.
   unsigned externalUseCount = 0;
 
@@ -194,12 +191,9 @@ struct LogicNetworkGate {
     return k == PrimaryInput || k == Constant;
   }
 
-  unsigned getTotalRefCount() const {
-    unsigned refCount = logicFanoutCount + externalUseCount;
-    return refCount == 0 ? 1 : refCount;
-  }
-
   bool isPrimaryOutput() const { return externalUseCount != 0; }
+
+  unsigned getExternalUseCount() const { return externalUseCount; }
 };
 
 /// Flat logic network representation for efficient cut enumeration.
@@ -282,14 +276,14 @@ public:
   /// Get the total number of nodes in the network.
   size_t size() const { return gates.size(); }
 
-  /// Get the total reference count used by area-flow estimation.
-  unsigned getTotalRefCount(uint32_t index) const {
-    return gates[index].getTotalRefCount();
-  }
-
   /// Check if a node is observed outside the logic network.
   bool isPrimaryOutput(uint32_t index) const {
     return gates[index].isPrimaryOutput();
+  }
+
+  /// Get the number of uses outside the logic network.
+  unsigned getExternalUseCount(uint32_t index) const {
+    return gates[index].getExternalUseCount();
   }
 
   /// Add a primary input to the network.
@@ -313,7 +307,6 @@ public:
   void clear();
 
 private:
-  void recordLogicUse(uint32_t index) { ++gates[index].logicFanoutCount; }
   void recordExternalUse(uint32_t index) { ++gates[index].externalUseCount; }
 
   /// Map from MLIR Value to network index.

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -319,10 +319,11 @@ private:
   llvm::SmallVector<LogicNetworkGate> gates;
 };
 
-/// Result of matching a cut against a pattern.
+/// Cost of implementing a cut with a pattern.
 ///
-/// This structure contains the area and per-input delay information
-/// computed during pattern matching.
+/// This structure contains the area and per-input delay information computed
+/// by a pattern matcher. It does not describe how the pattern inputs bind to a
+/// cut; that is tracked separately by MatchBinding.
 ///
 /// The delays can be stored in two ways:
 /// 1. As a reference to static/cached data (e.g., tech library delays)
@@ -330,15 +331,15 @@ private:
 /// 2. As owned dynamic data (e.g., computed SOP delays)
 ///    - Use setOwnedDelays() to transfer ownership
 ///
-struct MatchResult {
+struct PatternCost {
   /// Area cost of implementing this cut with the pattern.
   double area = 0.0;
 
   /// Default constructor.
-  MatchResult() = default;
+  PatternCost() = default;
 
   /// Constructor with area and delays (by reference).
-  MatchResult(double area, ArrayRef<DelayType> delays)
+  PatternCost(double area, ArrayRef<DelayType> delays)
       : area(area), borrowedDelays(delays) {}
 
   /// Set delays by reference (zero-cost for static/cached delays).
@@ -365,9 +366,50 @@ private:
 
   /// Owned delays (used when present).
   /// Only allocated when setOwnedDelays() is called. When empty (std::nullopt),
-  /// moving this MatchResult avoids constructing/moving the SmallVector,
+  /// moving this PatternCost avoids constructing/moving the SmallVector,
   /// achieving zero-cost abstraction for the common case (borrowed delays).
   std::optional<SmallVector<DelayType, 6>> ownedDelays;
+};
+
+/// Describes how a matched pattern's pins bind to a cut.
+///
+/// The binding is derived from composing the cut and pattern NPN witnesses. It
+/// records the permutation and phase changes needed to implement the cut with
+/// the matched pattern.
+struct MatchBinding {
+  /// For each pattern input, the cut input that drives it.
+  SmallVector<unsigned, 6> patternInputToCutInput;
+
+  /// Bit i is set if pattern input i must observe the inverted cut input.
+  unsigned inputNegation = 0;
+
+  /// Bit i is set if pattern output i must be inverted to match the cut.
+  unsigned outputNegation = 0;
+
+  MatchBinding() = default;
+
+  MatchBinding(ArrayRef<unsigned> patternInputToCutInput,
+               unsigned inputNegation, unsigned outputNegation);
+
+  static MatchBinding getIdentity(unsigned numInputs);
+
+  unsigned getNumInputs() const { return patternInputToCutInput.size(); }
+
+  unsigned getPatternInputForCutInput(unsigned cutInputIndex) const;
+
+  unsigned getCutInputForPatternInput(unsigned patternInputIndex) const {
+    return patternInputToCutInput[patternInputIndex];
+  }
+
+  bool isPatternInputNegated(unsigned patternInputIndex) const {
+    return inputNegation & (1u << patternInputIndex);
+  }
+
+  bool isOutputNegated(unsigned outputIndex) const {
+    return outputNegation & (1u << outputIndex);
+  }
+
+  bool hasNegation() const { return inputNegation != 0 || outputNegation != 0; }
 };
 
 /// Represents a cut that has been successfully matched to a rewriting pattern.
@@ -381,8 +423,8 @@ private:
   SmallVector<DelayType, 1>
       arrivalTimes; ///< Arrival times of outputs from this pattern
   /// Saved match data we reuse during area-flow reselection.
-  MatchResult matchResult;
-  SmallVector<unsigned, 6> patternInputToCutInput;
+  PatternCost cost;
+  MatchBinding binding;
 
 public:
   /// Default constructor creates an invalid matched pattern.
@@ -390,13 +432,10 @@ public:
 
   /// Constructor for a valid matched pattern.
   MatchedPattern(const CutRewritePattern *pattern,
-                 SmallVector<DelayType, 1> arrivalTimes,
-                 MatchResult matchResult,
-                 ArrayRef<unsigned> patternInputToCutInput)
+                 SmallVector<DelayType, 1> arrivalTimes, PatternCost cost,
+                 MatchBinding binding)
       : pattern(pattern), arrivalTimes(std::move(arrivalTimes)),
-        matchResult(std::move(matchResult)),
-        patternInputToCutInput(patternInputToCutInput.begin(),
-                               patternInputToCutInput.end()) {}
+        cost(std::move(cost)), binding(std::move(binding)) {}
 
   /// Get the arrival time of signals through this pattern.
   DelayType getArrivalTime(unsigned outputIndex) const;
@@ -412,13 +451,11 @@ public:
   /// Get the per-input delays used when scoring this match.
   ArrayRef<DelayType> getDelays() const;
 
-  /// Get the cached match payload used to rebuild this match.
-  const MatchResult &getMatchResult() const { return matchResult; }
+  /// Get the cached cost payload used to rebuild this match.
+  const PatternCost &getCost() const { return cost; }
 
-  /// Get the mapping from pattern input indices to cut input indices.
-  ArrayRef<unsigned> getInputPermutation() const {
-    return patternInputToCutInput;
-  }
+  /// Get the binding between cut inputs and pattern pins.
+  const MatchBinding &getBinding() const { return binding; }
 
   /// Get the delay for a cut input after accounting for input permutation.
   DelayType getDelayForCutInput(unsigned cutInputIndex) const;
@@ -799,12 +836,12 @@ struct CutRewritePattern {
   /// Check if a cut matches this pattern and compute area/delay metrics.
   ///
   /// This method is called to determine if a cut can be replaced by this
-  /// pattern. If the cut matches, it should return a MatchResult containing
-  /// the area and per-input delays for this specific cut.
+  /// pattern. If the cut matches, it should return a PatternCost containing the
+  /// area and per-input delays for this specific cut.
   ///
   /// If useTruthTableMatcher() returns true, this method is only
   /// called for cuts with matching truth tables.
-  virtual std::optional<MatchResult> match(CutEnumerator &enumerator,
+  virtual std::optional<PatternCost> match(CutEnumerator &enumerator,
                                            const Cut &cut) const = 0;
 
   /// Specify truth tables that this pattern can match.

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -28,6 +28,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
+#include <functional>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -136,6 +137,9 @@ struct LogicNetworkGate {
   /// inversion bit is encoded in each edge.
   Signal edges[3];
 
+  /// Number of uses by logic gates in this network.
+  unsigned logicFanoutCount = 0;
+
   /// Number of uses outside the logic network.
   unsigned externalUseCount = 0;
 
@@ -194,6 +198,11 @@ struct LogicNetworkGate {
   bool isPrimaryOutput() const { return externalUseCount != 0; }
 
   unsigned getExternalUseCount() const { return externalUseCount; }
+
+  unsigned getTotalRefCount() const {
+    unsigned refCount = logicFanoutCount + externalUseCount;
+    return refCount == 0 ? 1 : refCount;
+  }
 };
 
 /// Flat logic network representation for efficient cut enumeration.
@@ -276,6 +285,11 @@ public:
   /// Get the total number of nodes in the network.
   size_t size() const { return gates.size(); }
 
+  /// Get the structural reference count used for initial area-flow estimates.
+  unsigned getTotalRefCount(uint32_t index) const {
+    return gates[index].getTotalRefCount();
+  }
+
   /// Check if a node is observed outside the logic network.
   bool isPrimaryOutput(uint32_t index) const {
     return gates[index].isPrimaryOutput();
@@ -307,6 +321,7 @@ public:
   void clear();
 
 private:
+  void recordLogicUse(uint32_t index) { ++gates[index].logicFanoutCount; }
   void recordExternalUse(uint32_t index) { ++gates[index].externalUseCount; }
 
   /// Map from MLIR Value to network index.
@@ -463,6 +478,8 @@ private:
       arrivalTimes; ///< Arrival times of outputs from this pattern
   /// Saved match data we reuse during area-flow reselection.
   MatchResult match;
+  /// Area-flow estimate used by priority-cut ranking.
+  double areaFlow = 0.0;
 
 public:
   /// Default constructor creates an invalid matched pattern.
@@ -470,9 +487,10 @@ public:
 
   /// Constructor for a valid matched pattern.
   MatchedPattern(const CutRewritePattern *pattern,
-                 SmallVector<DelayType, 1> arrivalTimes, MatchResult match)
+                 SmallVector<DelayType, 1> arrivalTimes, MatchResult match,
+                 double areaFlow = 0.0)
       : pattern(pattern), arrivalTimes(std::move(arrivalTimes)),
-        match(std::move(match)) {}
+        match(std::move(match)), areaFlow(areaFlow) {}
 
   /// Get the arrival time of signals through this pattern.
   DelayType getArrivalTime(unsigned outputIndex) const;
@@ -484,6 +502,9 @@ public:
 
   /// Get the area cost of using this pattern.
   double getArea() const;
+
+  /// Get the area-flow estimate of this implementation.
+  double getAreaFlow() const { return areaFlow; }
 
   /// Get the per-input delays used when scoring this match.
   ArrayRef<DelayType> getDelays() const;
@@ -696,6 +717,23 @@ public:
   void setBestCut(Cut *cut) { bestCut = cut; }
 };
 
+/// Ordering hook for retaining a cut under an additional optimization view.
+/// Return true when the first cut should rank before the second cut.
+using CutComparator = std::function<bool(const Cut &, const Cut &)>;
+
+/// A secondary cut ranking and the number of distinct candidates it may
+/// reserve. The primary ranking always retains at least one candidate.
+struct AdditionalCutRanking {
+  CutComparator comparator;
+  unsigned maxCuts = 1;
+};
+
+/// Compare matched cuts by area flow, then timing and cut size.
+bool compareCutsByAreaFlow(const Cut &lhs, const Cut &rhs);
+
+/// Compare matched cuts by local area, then timing and cut size.
+bool compareCutsByArea(const Cut &lhs, const Cut &rhs);
+
 /// Configuration options for the cut-based rewriting algorithm.
 ///
 /// These options control various aspects of the rewriting process including
@@ -710,9 +748,13 @@ struct CutRewriterOptions {
   unsigned maxCutInputSize;
 
   /// Maximum number of cuts to maintain per logic node.
-  /// The priority cuts algorithm keeps only the most promising cuts
-  /// to prevent exponential explosion.
+  /// This bounds non-trivial cuts; the trivial cut is retained separately.
   unsigned maxCutSizePerRoot;
+
+  /// Additional ranking views that reserve cuts in the bounded set. This
+  /// allows a mapper to preserve candidates that are promising for a later
+  /// optimization phase even when the primary seed ranking differs.
+  SmallVector<AdditionalCutRanking, 1> additionalCutRankings;
 
   /// Fail if there is a root operation that has no matching pattern.
   bool allowNoMatch = false;
@@ -809,6 +851,9 @@ public:
 
   /// Re-select cuts using exact-area deref/ref while preserving required times.
   void reselectCutsForExactArea();
+
+  /// Return the total area of the currently selected cut cover.
+  double getSelectedArea();
 
   /// Get cut sets (indexed by LogicNetwork index).
   const llvm::DenseMap<uint32_t, CutSet *> &getCutSets() const {

--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -20,7 +20,7 @@ def TestPriorityCuts : Pass<"synth-test-priority-cuts", "hw::HWModuleOp"> {
   let summary = "Test priority cuts for synthesis";
   let options = [
     Option<"maxCutsPerRoot", "max-cuts-per-root", "int", "6",
-           "Maximum number of cuts to maintain per node">,
+           "Maximum number of non-trivial cuts to maintain per node">,
     Option<"maxCutInputSize", "max-cut-input-size", "int", "6",
            "Maximum number of cut inputs to consider">,
   ];
@@ -29,7 +29,7 @@ def TestPriorityCuts : Pass<"synth-test-priority-cuts", "hw::HWModuleOp"> {
 class CutRewriterPassBase<string name, string op> : Pass<name, op> {
   list<Option> baseOptions = [
     Option<"maxCutsPerRoot", "max-cuts-per-root", "int", "6",
-           "Maximum number of cuts to maintain per node">,
+           "Maximum number of non-trivial cuts to maintain per node">,
     Option<"strategy", "strategy", "synth::OptimizationStrategy",
            /*default=*/"synth::OptimizationStrategyTiming",
            "Optimization strategy (area vs. timing)",

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -1485,6 +1485,178 @@ void CutEnumerator::reselectCutsForAreaFlow() {
   }
 }
 
+// Pick cuts again using exact-area deref/ref while staying within the timing
+// bound set by the current mapping.
+void CutEnumerator::reselectCutsForExactArea() {
+  SmallVector<unsigned, 0> selectedRefCounts(logicNetwork.size(), 0);
+  for (auto [index, gate] : llvm::enumerate(logicNetwork.getGates()))
+    selectedRefCounts[index] = gate.getExternalUseCount();
+
+  auto referenceNode = [&](auto &&self, uint32_t index) -> double {
+    auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
+    if (!cutSet)
+      return 0.0;
+
+    if (selectedRefCounts[index]++ > 0)
+      return 0.0;
+
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      return 0.0;
+
+    double area = bestCut->getMatchedPattern()->getArea();
+    for (uint32_t inputIndex : bestCut->inputs)
+      area += self(self, inputIndex);
+    return area;
+  };
+
+  auto dereferenceNode = [&](auto &&self, uint32_t index) -> double {
+    auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
+    if (!cutSet)
+      return 0.0;
+
+    assert(selectedRefCounts[index] != 0 &&
+           "selected reference count underflow");
+    if (--selectedRefCounts[index] > 0)
+      return 0.0;
+
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      return 0.0;
+
+    double area = bestCut->getMatchedPattern()->getArea();
+    for (uint32_t inputIndex : bestCut->inputs)
+      area += self(self, inputIndex);
+    return area;
+  };
+
+  auto referenceCut = [&](Cut *cut) -> double {
+    if (!cut)
+      return 0.0;
+    double area = cut->getMatchedPattern()->getArea();
+    for (uint32_t inputIndex : cut->inputs)
+      area += referenceNode(referenceNode, inputIndex);
+    return area;
+  };
+
+  auto dereferenceCut = [&](Cut *cut) -> double {
+    if (!cut)
+      return 0.0;
+    double area = cut->getMatchedPattern()->getArea();
+    for (uint32_t inputIndex : cut->inputs)
+      area += dereferenceNode(dereferenceNode, inputIndex);
+    return area;
+  };
+
+  // Seed counts and arrival times from the current mapping.
+  for (auto index : processingOrder) {
+    auto it = cutSets.find(index);
+    if (it == cutSets.end())
+      continue;
+
+    auto *bestCut = it->second->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    it->second->bestArrivalTime =
+        bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
+    selectedRefCounts[index] = logicNetwork.getExternalUseCount(index);
+  }
+  for (auto index : processingOrder) {
+    if (selectedRefCounts[index] == 0)
+      continue;
+
+    auto cutSetIt = cutSets.find(index);
+    if (cutSetIt == cutSets.end())
+      continue;
+
+    auto *bestCut = cutSetIt->second->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    (void)referenceCut(bestCut);
+  }
+
+  for (auto index : processingOrder) {
+    auto cutSetIt = cutSets.find(index);
+    if (cutSetIt == cutSets.end())
+      continue;
+
+    auto *cutSet = cutSetIt->second;
+    Cut *currentBestCut = cutSet->getBestMatchedCut();
+    if (!currentBestCut)
+      continue;
+
+    bool isActive = selectedRefCounts[index] != 0;
+    if (isActive)
+      (void)dereferenceCut(currentBestCut);
+
+    Cut *bestExactCut = nullptr;
+    std::optional<MatchedPattern> bestExactMatch;
+    double bestExactArea = std::numeric_limits<double>::max();
+    DelayType bestExactArrival = std::numeric_limits<DelayType>::max();
+    double bestLocalArea = std::numeric_limits<double>::max();
+
+    for (Cut *cut : cutSet->getCuts()) {
+      const auto &candidateMatch = cut->getMatchedPattern();
+      if (!candidateMatch)
+        continue;
+
+      SmallVector<DelayType, 4> inputArrivalTimes;
+      inputArrivalTimes.reserve(cut->getInputSize());
+      for (uint32_t inputIndex : cut->inputs) {
+        DelayType inputArrival = 0;
+        if (auto *inputCutSet =
+                getNonLeafCutSet(cutSets, logicNetwork, inputIndex))
+          inputArrival = inputCutSet->bestArrivalTime;
+        inputArrivalTimes.push_back(inputArrival);
+      }
+
+      auto outputArrivalTimes = computeOutputArrivalTimes(
+          cut->getOutputSize(logicNetwork), cut->getInputSize(),
+          candidateMatch->getDelays(), inputArrivalTimes,
+          candidateMatch->getInputPermutation());
+      DelayType arrivalTime = *std::max_element(outputArrivalTimes.begin(),
+                                                outputArrivalTimes.end());
+      if (arrivalTime > cutSet->requiredTime)
+        continue;
+
+      double exactArea = referenceCut(cut);
+      (void)dereferenceCut(cut);
+
+      if (exactArea < bestExactArea ||
+          (areEquivalent(exactArea, bestExactArea) &&
+           arrivalTime < bestExactArrival) ||
+          (areEquivalent(exactArea, bestExactArea) &&
+           arrivalTime == bestExactArrival &&
+           candidateMatch->getArea() < bestLocalArea)) {
+        bestExactArea = exactArea;
+        bestExactArrival = arrivalTime;
+        bestLocalArea = candidateMatch->getArea();
+        bestExactCut = cut;
+        bestExactMatch = MatchedPattern(candidateMatch->getPattern(),
+                                        std::move(outputArrivalTimes),
+                                        candidateMatch->getMatchResult(),
+                                        candidateMatch->getInputPermutation());
+      }
+    }
+
+    if (!bestExactCut || !bestExactMatch) {
+      if (isActive)
+        (void)referenceCut(currentBestCut);
+      continue;
+    }
+
+    bestExactCut->setMatchedPattern(std::move(*bestExactMatch));
+    cutSet->setBestCut(bestExactCut);
+    cutSet->bestArrivalTime =
+        bestExactCut->getMatchedPattern()->getWorstOutputArrivalTime();
+
+    if (isActive)
+      (void)referenceCut(bestExactCut);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // CutRewriter
 //===----------------------------------------------------------------------===//
@@ -1532,6 +1704,7 @@ LogicalResult CutRewriter::run(Operation *topOp) {
   // regardless of the strategy.
   cutEnumerator.computeRequiredTimes();
   cutEnumerator.reselectCutsForAreaFlow();
+  cutEnumerator.reselectCutsForExactArea();
 
   // Select best cuts and perform mapping
   if (failed(runBottomUpRewrite(topOp)))

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -238,11 +238,9 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
     if (index == kConstant0 || index == kConstant1)
       continue;
 
-    // Record both internal fanout and external observation for area-flow.
+    // Record observations that remain visible after cut covering.
     for (OpOperand &use : value.getUses()) {
-      if (isInternalLogicUser(use.getOwner()))
-        recordLogicUse(index);
-      else
+      if (!isInternalLogicUser(use.getOwner()))
         recordExternalUse(index);
     }
   }
@@ -1365,6 +1363,27 @@ void CutEnumerator::computeRequiredTimes() {
 // Pick cuts again using area-flow, while staying within the timing bound set
 // by the current mapping.
 void CutEnumerator::reselectCutsForAreaFlow() {
+  SmallVector<unsigned, 0> selectedRefCounts(logicNetwork.size(), 0);
+  for (auto [index, gate] : llvm::enumerate(logicNetwork.getGates()))
+    selectedRefCounts[index] = gate.getExternalUseCount();
+
+  auto addSelectedCutRefs = [&](const Cut *cut) {
+    if (!cut)
+      return;
+    for (uint32_t inputIndex : cut->inputs)
+      ++selectedRefCounts[inputIndex];
+  };
+
+  auto dropSelectedCutRefs = [&](const Cut *cut) {
+    if (!cut)
+      return;
+    for (uint32_t inputIndex : cut->inputs) {
+      assert(selectedRefCounts[inputIndex] != 0 &&
+             "selected reference count underflow");
+      --selectedRefCounts[inputIndex];
+    }
+  };
+
   // Start from the arrival times of the cuts we already selected.
   for (auto index : processingOrder) {
     auto it = cutSets.find(index);
@@ -1377,6 +1396,7 @@ void CutEnumerator::reselectCutsForAreaFlow() {
 
     it->second->bestArrivalTime =
         bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
+    addSelectedCutRefs(bestCut);
   }
 
   for (auto index : processingOrder) {
@@ -1385,6 +1405,7 @@ void CutEnumerator::reselectCutsForAreaFlow() {
       continue;
 
     auto *cutSet = cutSetIt->second;
+    Cut *currentBestCut = cutSet->getBestMatchedCut();
     Cut *bestAreaFlowCut = nullptr;
     std::optional<MatchedPattern> bestAreaFlowMatch;
     double bestFlow = std::numeric_limits<double>::max();
@@ -1425,8 +1446,12 @@ void CutEnumerator::reselectCutsForAreaFlow() {
         if (!inputCutSet)
           continue;
 
-        flow +=
-            inputCutSet->areaFlow / logicNetwork.getTotalRefCount(inputIndex);
+        unsigned effectiveRefCount = selectedRefCounts[inputIndex];
+        if (!currentBestCut ||
+            !llvm::is_contained(currentBestCut->inputs, inputIndex))
+          ++effectiveRefCount;
+        assert(effectiveRefCount != 0 && "cut inputs must be referenced");
+        flow += inputCutSet->areaFlow / effectiveRefCount;
       }
 
       // Break ties in a stable way: lower flow, then earlier timing, then
@@ -1450,6 +1475,8 @@ void CutEnumerator::reselectCutsForAreaFlow() {
       continue;
 
     // Later nodes should see the timing and flow of the cut we picked here.
+    dropSelectedCutRefs(currentBestCut);
+    addSelectedCutRefs(bestAreaFlowCut);
     bestAreaFlowCut->setMatchedPattern(std::move(*bestAreaFlowMatch));
     cutSet->setBestCut(bestAreaFlowCut);
     cutSet->areaFlow = bestFlow;

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -26,6 +26,7 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/Synth/SynthOpInterfaces.h"
 #include "circt/Dialect/Synth/SynthOps.h"
+#include "circt/Dialect/Synth/Transforms/SynthPasses.h"
 #include "circt/Support/LLVM.h"
 #include "circt/Support/TruthTable.h"
 #include "circt/Support/UnusedOpPruner.h"
@@ -51,6 +52,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
 #include <algorithm>
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -221,6 +223,30 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
       return result;
   }
 
+  auto isInternalLogicUser = [&](Operation *user) {
+    if (user->getNumResults() != 1)
+      return false;
+    Value result = user->getResult(0);
+    if (!hasIndex(result))
+      return false;
+    return getGate(getIndex(result)).isLogicGate();
+  };
+
+  // Note: Iteration over DenseMap is safe here since the order doesn't affect
+  // the results.
+  for (auto &[value, index] : valueToIndex) {
+    if (index == kConstant0 || index == kConstant1)
+      continue;
+
+    // Record both internal fanout and external observation for area-flow.
+    for (OpOperand &use : value.getUses()) {
+      if (isInternalLogicUser(use.getOwner()))
+        recordLogicUse(index);
+      else
+        recordExternalUse(index);
+    }
+  }
+
   return success();
 }
 
@@ -240,10 +266,19 @@ void LogicNetwork::clear() {
 // Helper functions
 //===----------------------------------------------------------------------===//
 
-// Return true if the gate at the given index is always a cut input.
-static bool isAlwaysCutInput(const LogicNetwork &network, uint32_t index) {
+// Return true if the gate at the given index must remain a cut leaf.
+static bool isCutLeaf(const LogicNetwork &network, uint32_t index) {
   const auto &gate = network.getGate(index);
-  return gate.isAlwaysCutInput();
+  return gate.isCutLeaf();
+}
+
+// Return this node's cut set, unless it is a leaf or we never built one.
+static CutSet *getNonLeafCutSet(llvm::DenseMap<uint32_t, CutSet *> &cutSets,
+                                const LogicNetwork &network, uint32_t index) {
+  if (isCutLeaf(network, index))
+    return nullptr;
+  auto it = cutSets.find(index);
+  return it == cutSets.end() ? nullptr : it->second;
 }
 
 // Return true if the new area/delay is better than the old area/delay in the
@@ -256,6 +291,34 @@ static bool compareDelayAndArea(OptimizationStrategy strategy, double newArea,
   if (strategy == OptimizationStrategyTiming)
     return newDelay < oldDelay || (newDelay == oldDelay && newArea < oldArea);
   llvm_unreachable("Unknown mapping strategy");
+}
+
+static constexpr double kAreaComparisonEpsilon = 1e-9;
+
+static bool areEquivalent(double lhs, double rhs) {
+  return std::abs(lhs - rhs) < kAreaComparisonEpsilon;
+}
+
+static SmallVector<DelayType, 1>
+computeOutputArrivalTimes(unsigned numOutputs, unsigned numInputs,
+                          ArrayRef<DelayType> delays,
+                          ArrayRef<DelayType> inputArrivalTimes,
+                          ArrayRef<unsigned> inputPermutation = {}) {
+  assert(inputPermutation.empty() || inputPermutation.size() == numInputs);
+  SmallVector<DelayType, 1> outputArrivalTimes;
+  outputArrivalTimes.reserve(numOutputs);
+  for (unsigned outputIndex = 0; outputIndex < numOutputs; ++outputIndex) {
+    DelayType outputArrivalTime = 0;
+    for (unsigned inputIndex = 0; inputIndex < numInputs; ++inputIndex) {
+      unsigned cutOriginalInput =
+          inputPermutation.empty() ? inputIndex : inputPermutation[inputIndex];
+      outputArrivalTime = std::max(
+          outputArrivalTime, delays[outputIndex * numInputs + inputIndex] +
+                                 inputArrivalTimes[cutOriginalInput]);
+    }
+    outputArrivalTimes.push_back(outputArrivalTime);
+  }
+  return outputArrivalTimes;
 }
 
 LogicalResult circt::synth::topologicallySortLogicNetwork(Operation *topOp) {
@@ -381,7 +444,7 @@ Cut::getInputArrivalTimes(CutEnumerator &enumerator,
 
   // Compute arrival times for each input.
   for (auto inputIndex : inputs) {
-    if (isAlwaysCutInput(network, inputIndex)) {
+    if (isCutLeaf(network, inputIndex)) {
       // If the input is a primary input, it has no delay.
       results.push_back(0);
       continue;
@@ -648,6 +711,13 @@ ArrayRef<DelayType> MatchedPattern::getArrivalTimes() const {
   return arrivalTimes;
 }
 
+DelayType MatchedPattern::getWorstOutputArrivalTime() const {
+  assert(pattern && "Pattern must be set to get arrival time");
+  return arrivalTimes.empty()
+             ? 0
+             : *std::max_element(arrivalTimes.begin(), arrivalTimes.end());
+}
+
 DelayType MatchedPattern::getArrivalTime(unsigned index) const {
   assert(pattern && "Pattern must be set to get arrival time");
   return arrivalTimes[index];
@@ -660,7 +730,22 @@ const CutRewritePattern *MatchedPattern::getPattern() const {
 
 double MatchedPattern::getArea() const {
   assert(pattern && "Pattern must be set to get area");
-  return area;
+  return matchResult.area;
+}
+
+ArrayRef<DelayType> MatchedPattern::getDelays() const {
+  assert(pattern && "Pattern must be set to get delays");
+  return matchResult.getDelays();
+}
+
+DelayType MatchedPattern::getDelayForCutInput(unsigned cutInputIndex) const {
+  assert(pattern && "Pattern must be set to get delays");
+  for (auto [patternInputIndex, mappedCutInput] :
+       llvm::enumerate(patternInputToCutInput)) {
+    if (mappedCutInput == cutInputIndex)
+      return getDelays()[patternInputIndex];
+  }
+  llvm_unreachable("cut input not found in matched permutation");
 }
 
 //===----------------------------------------------------------------------===//
@@ -782,7 +867,8 @@ void CutSet::finalize(
       std::stable_partition(cuts.begin(), cuts.end(),
                             [](const Cut *cut) { return cut->isTrivialCut(); });
 
-  auto isBetterCut = [&options](const Cut *a, const Cut *b) {
+  auto isBetterCut = [seedStrategy = options.strategy](const Cut *a,
+                                                       const Cut *b) {
     assert(!a->isTrivialCut() && !b->isTrivialCut() &&
            "Trivial cuts should have been excluded");
     const auto &aMatched = a->getMatchedPattern();
@@ -790,7 +876,7 @@ void CutSet::finalize(
 
     if (aMatched && bMatched)
       return compareDelayAndArea(
-          options.strategy, aMatched->getArea(), aMatched->getArrivalTimes(),
+          seedStrategy, aMatched->getArea(), aMatched->getArrivalTimes(),
           bMatched->getArea(), bMatched->getArrivalTimes());
 
     if (static_cast<bool>(aMatched) != static_cast<bool>(bMatched))
@@ -811,6 +897,8 @@ void CutSet::finalize(
     if (!currentMatch)
       continue;
     bestCut = cut;
+    bestArrivalTime = currentMatch->getWorstOutputArrivalTime();
+    areaFlow = currentMatch->getArea();
     break;
   }
 
@@ -1224,6 +1312,152 @@ void CutEnumerator::dump() const {
   llvm::outs() << "Cut enumeration completed successfully\n";
 }
 
+void CutEnumerator::computeRequiredTimes() {
+  DelayType globalWorstArrival = 0;
+  SmallVector<CutSet *, 16> outputCutSets;
+  for (auto &[index, cutSet] : cutSets) {
+    if (!logicNetwork.isPrimaryOutput(index))
+      continue;
+
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    globalWorstArrival =
+        std::max(globalWorstArrival,
+                 bestCut->getMatchedPattern()->getWorstOutputArrivalTime());
+    outputCutSets.push_back(cutSet);
+  }
+
+  // There is no output.
+  if (outputCutSets.empty())
+    return;
+
+  // Seed outputs with the worst arrival from the current timing-feasible map.
+  for (auto *cutSet : outputCutSets)
+    cutSet->requiredTime = globalWorstArrival;
+
+  for (auto it = processingOrder.rbegin(); it != processingOrder.rend(); ++it) {
+    auto cutSetIt = cutSets.find(*it);
+    if (cutSetIt == cutSets.end())
+      continue;
+
+    auto *cutSet = cutSetIt->second;
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    for (auto [i, inputNodeIndex] : llvm::enumerate(bestCut->inputs)) {
+      auto *inputCutSet =
+          getNonLeafCutSet(cutSets, logicNetwork, inputNodeIndex);
+      if (!inputCutSet)
+        continue;
+
+      DelayType inputRequired =
+          cutSet->requiredTime -
+          bestCut->getMatchedPattern()->getDelayForCutInput(i);
+      inputCutSet->requiredTime =
+          std::min(inputCutSet->requiredTime, inputRequired);
+    }
+  }
+}
+
+// Pick cuts again using area-flow, while staying within the timing bound set
+// by the current mapping.
+void CutEnumerator::reselectCutsForAreaFlow() {
+  // Start from the arrival times of the cuts we already selected.
+  for (auto index : processingOrder) {
+    auto it = cutSets.find(index);
+    if (it == cutSets.end())
+      continue;
+
+    auto *bestCut = it->second->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    it->second->bestArrivalTime =
+        bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
+  }
+
+  for (auto index : processingOrder) {
+    auto cutSetIt = cutSets.find(index);
+    if (cutSetIt == cutSets.end())
+      continue;
+
+    auto *cutSet = cutSetIt->second;
+    Cut *bestAreaFlowCut = nullptr;
+    std::optional<MatchedPattern> bestAreaFlowMatch;
+    double bestFlow = std::numeric_limits<double>::max();
+    DelayType bestFlowArrival = std::numeric_limits<DelayType>::max();
+    double bestLocalArea = std::numeric_limits<double>::max();
+
+    for (Cut *cut : cutSet->getCuts()) {
+      // Only cuts we already know how to implement can be reconsidered here.
+      const auto &candidateMatch = cut->getMatchedPattern();
+      if (!candidateMatch)
+        continue;
+
+      SmallVector<DelayType, 4> inputArrivalTimes;
+      inputArrivalTimes.reserve(cut->getInputSize());
+      for (uint32_t inputIndex : cut->inputs) {
+        DelayType inputArrival = 0;
+        if (auto *inputCutSet =
+                getNonLeafCutSet(cutSets, logicNetwork, inputIndex))
+          inputArrival = inputCutSet->bestArrivalTime;
+        inputArrivalTimes.push_back(inputArrival);
+      }
+
+      // Recompute this cut's timing from the fanins we currently picked.
+      auto outputArrivalTimes = computeOutputArrivalTimes(
+          cut->getOutputSize(logicNetwork), cut->getInputSize(),
+          candidateMatch->getDelays(), inputArrivalTimes,
+          candidateMatch->getInputPermutation());
+      DelayType arrivalTime = *std::max_element(outputArrivalTimes.begin(),
+                                                outputArrivalTimes.end());
+      // Do not spend area if it would break the current timing bound.
+      if (arrivalTime > cutSet->requiredTime)
+        continue;
+
+      // Count this cut's own area plus its share of the fanins it depends on.
+      double flow = candidateMatch->getArea();
+      for (uint32_t inputIndex : cut->inputs) {
+        auto *inputCutSet = getNonLeafCutSet(cutSets, logicNetwork, inputIndex);
+        if (!inputCutSet)
+          continue;
+
+        flow +=
+            inputCutSet->areaFlow / logicNetwork.getTotalRefCount(inputIndex);
+      }
+
+      // Break ties in a stable way: lower flow, then earlier timing, then
+      // lower local area.
+      if (flow < bestFlow ||
+          (areEquivalent(flow, bestFlow) && arrivalTime < bestFlowArrival) ||
+          (areEquivalent(flow, bestFlow) && arrivalTime == bestFlowArrival &&
+           candidateMatch->getArea() < bestLocalArea)) {
+        bestFlow = flow;
+        bestFlowArrival = arrivalTime;
+        bestLocalArea = candidateMatch->getArea();
+        bestAreaFlowCut = cut;
+        bestAreaFlowMatch = MatchedPattern(
+            candidateMatch->getPattern(), std::move(outputArrivalTimes),
+            candidateMatch->getMatchResult(),
+            candidateMatch->getInputPermutation());
+      }
+    }
+
+    if (!bestAreaFlowCut || !bestAreaFlowMatch)
+      continue;
+
+    // Later nodes should see the timing and flow of the cut we picked here.
+    bestAreaFlowCut->setMatchedPattern(std::move(*bestAreaFlowMatch));
+    cutSet->setBestCut(bestAreaFlowCut);
+    cutSet->areaFlow = bestFlow;
+    cutSet->bestArrivalTime =
+        bestAreaFlowCut->getMatchedPattern()->getWorstOutputArrivalTime();
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // CutRewriter
 //===----------------------------------------------------------------------===//
@@ -1265,6 +1499,13 @@ LogicalResult CutRewriter::run(Operation *topOp) {
     return success();
   }
 
+  // Run area-flow based reselection.
+  // TODO: This selection must be controlled by the strategy option, but
+  // currently it runs area recovery unconditionally since it improves area
+  // regardless of the strategy.
+  cutEnumerator.computeRequiredTimes();
+  cutEnumerator.reselectCutsForAreaFlow();
+
   // Select best cuts and perform mapping
   if (failed(runBottomUpRewrite(topOp)))
     return failure();
@@ -1303,41 +1544,29 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   const CutRewritePattern *bestPattern = nullptr;
   SmallVector<DelayType, 4> inputArrivalTimes;
   SmallVector<DelayType, 1> bestArrivalTimes;
-  double bestArea = 0.0;
+  SmallVector<unsigned, 6> bestInputPermutation;
+  std::optional<MatchResult> bestMatchResult;
   inputArrivalTimes.reserve(cut.getInputSize());
   bestArrivalTimes.reserve(cut.getOutputSize(network));
+  SmallVector<unsigned, 6> identityMapping(cut.getInputSize());
+  for (auto [idx, mapped] : llvm::enumerate(identityMapping))
+    mapped = idx;
 
   // Compute arrival times for each input.
   if (failed(cut.getInputArrivalTimes(cutEnumerator, inputArrivalTimes)))
     return {};
 
   auto computeArrivalTimeAndPickBest =
-      [&](const CutRewritePattern *pattern, const MatchResult &matchResult,
-          llvm::function_ref<unsigned(unsigned)> mapIndex) {
-        SmallVector<DelayType, 1> outputArrivalTimes;
-        // Compute the maximum delay for each output from inputs.
-        for (unsigned outputIndex = 0, outputSize = cut.getOutputSize(network);
-             outputIndex < outputSize; ++outputIndex) {
-          // Compute the arrival time for this output.
-          DelayType outputArrivalTime = 0;
-          auto delays = matchResult.getDelays();
-          for (unsigned inputIndex = 0, inputSize = cut.getInputSize();
-               inputIndex < inputSize; ++inputIndex) {
-            // Map pattern input i to cut input through NPN transformations
-            unsigned cutOriginalInput = mapIndex(inputIndex);
-            outputArrivalTime =
-                std::max(outputArrivalTime,
-                         delays[outputIndex * inputSize + inputIndex] +
-                             inputArrivalTimes[cutOriginalInput]);
-          }
-
-          outputArrivalTimes.push_back(outputArrivalTime);
-        }
+      [&](const CutRewritePattern *pattern, MatchResult matchResult,
+          ArrayRef<unsigned> patternInputToCutInput) {
+        auto outputArrivalTimes = computeOutputArrivalTimes(
+            cut.getOutputSize(network), cut.getInputSize(),
+            matchResult.getDelays(), inputArrivalTimes, patternInputToCutInput);
 
         // Update the arrival time
         if (!bestPattern ||
             compareDelayAndArea(options.strategy, matchResult.area,
-                                outputArrivalTimes, bestArea,
+                                outputArrivalTimes, bestMatchResult->area,
                                 bestArrivalTimes)) {
           LLVM_DEBUG({
             llvm::dbgs() << "== Matched Pattern ==============\n";
@@ -1359,9 +1588,11 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
             llvm::dbgs() << "== Matched Pattern End ==============\n";
           });
 
-          bestArrivalTimes = std::move(outputArrivalTimes);
-          bestArea = matchResult.area;
+          bestArrivalTimes = outputArrivalTimes;
+          bestInputPermutation.assign(patternInputToCutInput.begin(),
+                                      patternInputToCutInput.end());
           bestPattern = pattern;
+          bestMatchResult = std::move(matchResult);
         }
       };
 
@@ -1376,20 +1607,21 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
     // Get the input mapping from pattern's NPN class to cut's NPN class
     SmallVector<unsigned> inputMapping;
     cutNPN.getInputPermutation(patternNPN, inputMapping);
-    computeArrivalTimeAndPickBest(pattern, *matchResult,
-                                  [&](unsigned i) { return inputMapping[i]; });
+    computeArrivalTimeAndPickBest(pattern, std::move(*matchResult),
+                                  inputMapping);
   }
 
   for (const CutRewritePattern *pattern : patterns.nonNPNPatterns) {
     if (auto matchResult = pattern->match(cutEnumerator, cut))
-      computeArrivalTimeAndPickBest(pattern, *matchResult,
-                                    [&](unsigned i) { return i; });
+      computeArrivalTimeAndPickBest(pattern, std::move(*matchResult),
+                                    identityMapping);
   }
 
   if (!bestPattern)
     return {}; // No matching pattern found
 
-  return MatchedPattern(bestPattern, std::move(bestArrivalTimes), bestArea);
+  return MatchedPattern(bestPattern, std::move(bestArrivalTimes),
+                        std::move(*bestMatchResult), bestInputPermutation);
 }
 
 LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {
@@ -1417,7 +1649,7 @@ LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {
       continue;
     }
 
-    if (isAlwaysCutInput(network, index)) {
+    if (isCutLeaf(network, index)) {
       // If the value is a primary input, skip it
       LLVM_DEBUG(llvm::dbgs() << "Skipping inputs: " << value << "\n");
       continue;

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -1533,6 +1533,178 @@ void CutEnumerator::reselectCutsForAreaFlow() {
   }
 }
 
+// Pick cuts again using exact-area deref/ref while staying within the timing
+// bound set by the current mapping.
+void CutEnumerator::reselectCutsForExactArea() {
+  SmallVector<unsigned, 0> selectedRefCounts(logicNetwork.size(), 0);
+  for (auto [index, gate] : llvm::enumerate(logicNetwork.getGates()))
+    selectedRefCounts[index] = gate.getExternalUseCount();
+
+  auto referenceNode = [&](auto &&self, uint32_t index) -> double {
+    auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
+    if (!cutSet)
+      return 0.0;
+
+    if (selectedRefCounts[index]++ > 0)
+      return 0.0;
+
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      return 0.0;
+
+    double area = bestCut->getMatchedPattern()->getArea();
+    for (uint32_t inputIndex : bestCut->inputs)
+      area += self(self, inputIndex);
+    return area;
+  };
+
+  auto dereferenceNode = [&](auto &&self, uint32_t index) -> double {
+    auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
+    if (!cutSet)
+      return 0.0;
+
+    assert(selectedRefCounts[index] != 0 &&
+           "selected reference count underflow");
+    if (--selectedRefCounts[index] > 0)
+      return 0.0;
+
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      return 0.0;
+
+    double area = bestCut->getMatchedPattern()->getArea();
+    for (uint32_t inputIndex : bestCut->inputs)
+      area += self(self, inputIndex);
+    return area;
+  };
+
+  auto referenceCut = [&](Cut *cut) -> double {
+    if (!cut)
+      return 0.0;
+    double area = cut->getMatchedPattern()->getArea();
+    for (uint32_t inputIndex : cut->inputs)
+      area += referenceNode(referenceNode, inputIndex);
+    return area;
+  };
+
+  auto dereferenceCut = [&](Cut *cut) -> double {
+    if (!cut)
+      return 0.0;
+    double area = cut->getMatchedPattern()->getArea();
+    for (uint32_t inputIndex : cut->inputs)
+      area += dereferenceNode(dereferenceNode, inputIndex);
+    return area;
+  };
+
+  // Seed counts and arrival times from the current mapping.
+  for (auto index : processingOrder) {
+    auto it = cutSets.find(index);
+    if (it == cutSets.end())
+      continue;
+
+    auto *bestCut = it->second->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    it->second->bestArrivalTime =
+        bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
+    selectedRefCounts[index] = logicNetwork.getExternalUseCount(index);
+  }
+  for (auto index : processingOrder) {
+    if (selectedRefCounts[index] == 0)
+      continue;
+
+    auto cutSetIt = cutSets.find(index);
+    if (cutSetIt == cutSets.end())
+      continue;
+
+    auto *bestCut = cutSetIt->second->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    (void)referenceCut(bestCut);
+  }
+
+  for (auto index : processingOrder) {
+    auto cutSetIt = cutSets.find(index);
+    if (cutSetIt == cutSets.end())
+      continue;
+
+    auto *cutSet = cutSetIt->second;
+    Cut *currentBestCut = cutSet->getBestMatchedCut();
+    if (!currentBestCut)
+      continue;
+
+    bool isActive = selectedRefCounts[index] != 0;
+    if (isActive)
+      (void)dereferenceCut(currentBestCut);
+
+    Cut *bestExactCut = nullptr;
+    std::optional<MatchedPattern> bestExactMatch;
+    double bestExactArea = std::numeric_limits<double>::max();
+    DelayType bestExactArrival = std::numeric_limits<DelayType>::max();
+    double bestLocalArea = std::numeric_limits<double>::max();
+
+    for (Cut *cut : cutSet->getCuts()) {
+      const auto &candidateMatch = cut->getMatchedPattern();
+      if (!candidateMatch)
+        continue;
+
+      SmallVector<DelayType, 4> inputArrivalTimes;
+      inputArrivalTimes.reserve(cut->getInputSize());
+      for (uint32_t inputIndex : cut->inputs) {
+        DelayType inputArrival = 0;
+        if (auto *inputCutSet =
+                getNonLeafCutSet(cutSets, logicNetwork, inputIndex))
+          inputArrival = inputCutSet->bestArrivalTime;
+        inputArrivalTimes.push_back(inputArrival);
+      }
+
+      auto outputArrivalTimes = computeOutputArrivalTimes(
+          cut->getOutputSize(logicNetwork), cut->getInputSize(),
+          candidateMatch->getDelays(), inputArrivalTimes,
+          candidateMatch->getInputPermutation());
+      DelayType arrivalTime = *std::max_element(outputArrivalTimes.begin(),
+                                                outputArrivalTimes.end());
+      if (arrivalTime > cutSet->requiredTime)
+        continue;
+
+      double exactArea = referenceCut(cut);
+      (void)dereferenceCut(cut);
+
+      if (exactArea < bestExactArea ||
+          (areEquivalent(exactArea, bestExactArea) &&
+           arrivalTime < bestExactArrival) ||
+          (areEquivalent(exactArea, bestExactArea) &&
+           arrivalTime == bestExactArrival &&
+           candidateMatch->getArea() < bestLocalArea)) {
+        bestExactArea = exactArea;
+        bestExactArrival = arrivalTime;
+        bestLocalArea = candidateMatch->getArea();
+        bestExactCut = cut;
+        bestExactMatch = MatchedPattern(candidateMatch->getPattern(),
+                                        std::move(outputArrivalTimes),
+                                        candidateMatch->getMatchResult(),
+                                        candidateMatch->getInputPermutation());
+      }
+    }
+
+    if (!bestExactCut || !bestExactMatch) {
+      if (isActive)
+        (void)referenceCut(currentBestCut);
+      continue;
+    }
+
+    bestExactCut->setMatchedPattern(std::move(*bestExactMatch));
+    cutSet->setBestCut(bestExactCut);
+    cutSet->bestArrivalTime =
+        bestExactCut->getMatchedPattern()->getWorstOutputArrivalTime();
+
+    if (isActive)
+      (void)referenceCut(bestExactCut);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // CutRewriter
 //===----------------------------------------------------------------------===//
@@ -1580,6 +1752,7 @@ LogicalResult CutRewriter::run(Operation *topOp) {
   // regardless of the strategy.
   cutEnumerator.computeRequiredTimes();
   cutEnumerator.reselectCutsForAreaFlow();
+  cutEnumerator.reselectCutsForExactArea();
 
   // Select best cuts and perform mapping
   if (failed(runBottomUpRewrite(topOp)))

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -1408,29 +1408,106 @@ void CutEnumerator::computeRequiredTimes() {
   }
 }
 
+namespace {
+/// Tracks references from the currently selected cut cover. Reference counts are
+/// seeded by values observed outside the logic network, then propagated through
+/// selected cuts on demand.
+class SelectedCoverRefCounts {
+public:
+  SelectedCoverRefCounts(llvm::DenseMap<uint32_t, CutSet *> &cutSets,
+                         const LogicNetwork &logicNetwork)
+      : cutSets(cutSets), logicNetwork(logicNetwork),
+        refCounts(logicNetwork.size(), 0) {
+    for (auto [index, gate] : llvm::enumerate(logicNetwork.getGates()))
+      refCounts[index] = gate.getExternalUseCount();
+  }
+
+  unsigned get(uint32_t index) const { return refCounts[index]; }
+
+  void referenceSelectedCover(ArrayRef<uint32_t> processingOrder) {
+    for (auto index : processingOrder) {
+      if (refCounts[index] == 0)
+        continue;
+
+      auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
+      if (!cutSet)
+        continue;
+
+      referenceCut(cutSet->getBestMatchedCut());
+    }
+  }
+
+  double referenceCut(const Cut *cut) {
+    const auto *match = getMatch(cut);
+    if (!match)
+      return 0.0;
+
+    double area = match->getArea();
+    for (uint32_t inputIndex : cut->inputs)
+      area += referenceNode(inputIndex);
+    return area;
+  }
+
+  double dereferenceCut(const Cut *cut) {
+    const auto *match = getMatch(cut);
+    if (!match)
+      return 0.0;
+
+    double area = match->getArea();
+    for (uint32_t inputIndex : cut->inputs)
+      area += dereferenceNode(inputIndex);
+    return area;
+  }
+
+private:
+  const MatchedPattern *getMatch(const Cut *cut) const {
+    if (!cut)
+      return nullptr;
+    const auto &match = cut->getMatchedPattern();
+    return match ? &*match : nullptr;
+  }
+
+  double referenceNode(uint32_t index) {
+    auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
+    if (!cutSet)
+      return 0.0;
+
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      return 0.0;
+
+    if (refCounts[index]++ > 0)
+      return 0.0;
+
+    return referenceCut(bestCut);
+  }
+
+  double dereferenceNode(uint32_t index) {
+    auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
+    if (!cutSet)
+      return 0.0;
+
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      return 0.0;
+
+    assert(refCounts[index] != 0 && "selected reference count underflow");
+    if (--refCounts[index] > 0)
+      return 0.0;
+
+    return dereferenceCut(bestCut);
+  }
+
+  llvm::DenseMap<uint32_t, CutSet *> &cutSets;
+  const LogicNetwork &logicNetwork;
+  SmallVector<unsigned, 0> refCounts;
+};
+} // namespace
+
 // Pick cuts again using area-flow, while staying within the timing bound set
 // by the current mapping.
 void CutEnumerator::reselectCutsForAreaFlow() {
-  SmallVector<unsigned, 0> selectedRefCounts(logicNetwork.size(), 0);
-  for (auto [index, gate] : llvm::enumerate(logicNetwork.getGates()))
-    selectedRefCounts[index] = gate.getExternalUseCount();
-
-  auto addSelectedCutRefs = [&](const Cut *cut) {
-    if (!cut)
-      return;
-    for (uint32_t inputIndex : cut->inputs)
-      ++selectedRefCounts[inputIndex];
-  };
-
-  auto dropSelectedCutRefs = [&](const Cut *cut) {
-    if (!cut)
-      return;
-    for (uint32_t inputIndex : cut->inputs) {
-      assert(selectedRefCounts[inputIndex] != 0 &&
-             "selected reference count underflow");
-      --selectedRefCounts[inputIndex];
-    }
-  };
+  SelectedCoverRefCounts selectedRefs(cutSets, logicNetwork);
 
   // Start from the arrival times of the cuts we already selected.
   for (auto index : processingOrder) {
@@ -1444,8 +1521,8 @@ void CutEnumerator::reselectCutsForAreaFlow() {
 
     it->second->bestArrivalTime =
         bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
-    addSelectedCutRefs(bestCut);
   }
+  selectedRefs.referenceSelectedCover(processingOrder);
 
   for (auto index : processingOrder) {
     auto cutSetIt = cutSets.find(index);
@@ -1454,6 +1531,7 @@ void CutEnumerator::reselectCutsForAreaFlow() {
 
     auto *cutSet = cutSetIt->second;
     Cut *currentBestCut = cutSet->getBestMatchedCut();
+    bool isActive = selectedRefs.get(index) != 0;
     Cut *bestAreaFlowCut = nullptr;
     std::optional<MatchedPattern> bestAreaFlowMatch;
     double bestFlow = std::numeric_limits<double>::max();
@@ -1494,8 +1572,8 @@ void CutEnumerator::reselectCutsForAreaFlow() {
         if (!inputCutSet)
           continue;
 
-        unsigned effectiveRefCount = selectedRefCounts[inputIndex];
-        if (!currentBestCut ||
+        unsigned effectiveRefCount = selectedRefs.get(inputIndex);
+        if (!isActive || !currentBestCut ||
             !llvm::is_contained(currentBestCut->inputs, inputIndex))
           ++effectiveRefCount;
         assert(effectiveRefCount != 0 && "cut inputs must be referenced");
@@ -1523,78 +1601,24 @@ void CutEnumerator::reselectCutsForAreaFlow() {
       continue;
 
     // Later nodes should see the timing and flow of the cut we picked here.
-    dropSelectedCutRefs(currentBestCut);
-    addSelectedCutRefs(bestAreaFlowCut);
+    if (isActive)
+      selectedRefs.dereferenceCut(currentBestCut);
+
     bestAreaFlowCut->setMatchedPattern(std::move(*bestAreaFlowMatch));
     cutSet->setBestCut(bestAreaFlowCut);
     cutSet->areaFlow = bestFlow;
     cutSet->bestArrivalTime =
         bestAreaFlowCut->getMatchedPattern()->getWorstOutputArrivalTime();
+
+    if (isActive)
+      selectedRefs.referenceCut(bestAreaFlowCut);
   }
 }
 
 // Pick cuts again using exact-area deref/ref while staying within the timing
 // bound set by the current mapping.
 void CutEnumerator::reselectCutsForExactArea() {
-  SmallVector<unsigned, 0> selectedRefCounts(logicNetwork.size(), 0);
-  for (auto [index, gate] : llvm::enumerate(logicNetwork.getGates()))
-    selectedRefCounts[index] = gate.getExternalUseCount();
-
-  auto referenceNode = [&](auto &&self, uint32_t index) -> double {
-    auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
-    if (!cutSet)
-      return 0.0;
-
-    if (selectedRefCounts[index]++ > 0)
-      return 0.0;
-
-    auto *bestCut = cutSet->getBestMatchedCut();
-    if (!bestCut)
-      return 0.0;
-
-    double area = bestCut->getMatchedPattern()->getArea();
-    for (uint32_t inputIndex : bestCut->inputs)
-      area += self(self, inputIndex);
-    return area;
-  };
-
-  auto dereferenceNode = [&](auto &&self, uint32_t index) -> double {
-    auto *cutSet = getNonLeafCutSet(cutSets, logicNetwork, index);
-    if (!cutSet)
-      return 0.0;
-
-    assert(selectedRefCounts[index] != 0 &&
-           "selected reference count underflow");
-    if (--selectedRefCounts[index] > 0)
-      return 0.0;
-
-    auto *bestCut = cutSet->getBestMatchedCut();
-    if (!bestCut)
-      return 0.0;
-
-    double area = bestCut->getMatchedPattern()->getArea();
-    for (uint32_t inputIndex : bestCut->inputs)
-      area += self(self, inputIndex);
-    return area;
-  };
-
-  auto referenceCut = [&](Cut *cut) -> double {
-    if (!cut)
-      return 0.0;
-    double area = cut->getMatchedPattern()->getArea();
-    for (uint32_t inputIndex : cut->inputs)
-      area += referenceNode(referenceNode, inputIndex);
-    return area;
-  };
-
-  auto dereferenceCut = [&](Cut *cut) -> double {
-    if (!cut)
-      return 0.0;
-    double area = cut->getMatchedPattern()->getArea();
-    for (uint32_t inputIndex : cut->inputs)
-      area += dereferenceNode(dereferenceNode, inputIndex);
-    return area;
-  };
+  SelectedCoverRefCounts selectedRefs(cutSets, logicNetwork);
 
   // Seed counts and arrival times from the current mapping.
   for (auto index : processingOrder) {
@@ -1608,22 +1632,8 @@ void CutEnumerator::reselectCutsForExactArea() {
 
     it->second->bestArrivalTime =
         bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
-    selectedRefCounts[index] = logicNetwork.getExternalUseCount(index);
   }
-  for (auto index : processingOrder) {
-    if (selectedRefCounts[index] == 0)
-      continue;
-
-    auto cutSetIt = cutSets.find(index);
-    if (cutSetIt == cutSets.end())
-      continue;
-
-    auto *bestCut = cutSetIt->second->getBestMatchedCut();
-    if (!bestCut)
-      continue;
-
-    (void)referenceCut(bestCut);
-  }
+  selectedRefs.referenceSelectedCover(processingOrder);
 
   for (auto index : processingOrder) {
     auto cutSetIt = cutSets.find(index);
@@ -1635,9 +1645,9 @@ void CutEnumerator::reselectCutsForExactArea() {
     if (!currentBestCut)
       continue;
 
-    bool isActive = selectedRefCounts[index] != 0;
+    bool isActive = selectedRefs.get(index) != 0;
     if (isActive)
-      (void)dereferenceCut(currentBestCut);
+      (void)selectedRefs.dereferenceCut(currentBestCut);
 
     Cut *bestExactCut = nullptr;
     std::optional<MatchedPattern> bestExactMatch;
@@ -1669,8 +1679,8 @@ void CutEnumerator::reselectCutsForExactArea() {
       if (arrivalTime > cutSet->requiredTime)
         continue;
 
-      double exactArea = referenceCut(cut);
-      (void)dereferenceCut(cut);
+      double exactArea = selectedRefs.referenceCut(cut);
+      (void)selectedRefs.dereferenceCut(cut);
 
       if (exactArea < bestExactArea ||
           (areEquivalent(exactArea, bestExactArea) &&
@@ -1691,7 +1701,7 @@ void CutEnumerator::reselectCutsForExactArea() {
 
     if (!bestExactCut || !bestExactMatch) {
       if (isActive)
-        (void)referenceCut(currentBestCut);
+        (void)selectedRefs.referenceCut(currentBestCut);
       continue;
     }
 
@@ -1701,7 +1711,7 @@ void CutEnumerator::reselectCutsForExactArea() {
         bestExactCut->getMatchedPattern()->getWorstOutputArrivalTime();
 
     if (isActive)
-      (void)referenceCut(bestExactCut);
+      (void)selectedRefs.referenceCut(bestExactCut);
   }
 }
 

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -1904,7 +1904,7 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
     auto &cutNPN = cut.getNPNClass(options.npnTable);
     MatchBinding binding = computeMatchBinding(cutNPN, patternNPN);
 
-    auto match = pattern->match(cutEnumerator, cut, binding, inputArrivalTimes);
+    auto match = pattern->match(cutEnumerator, cut, binding);
     if (!match)
       continue;
     computeArrivalTimeAndPickBest(pattern, std::move(*match),
@@ -1912,8 +1912,7 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   }
 
   for (const CutRewritePattern *pattern : patterns.nonNPNPatterns) {
-    if (auto match = pattern->match(cutEnumerator, cut, identityBinding,
-                                    inputArrivalTimes))
+    if (auto match = pattern->match(cutEnumerator, cut, identityBinding))
       computeArrivalTimeAndPickBest(pattern, std::move(*match),
                                     identityBinding);
   }

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -271,11 +271,9 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
     if (index == kConstant0 || index == kConstant1)
       continue;
 
-    // Record both internal fanout and external observation for area-flow.
+    // Record observations that remain visible after cut covering.
     for (OpOperand &use : value.getUses()) {
-      if (isInternalLogicUser(use.getOwner()))
-        recordLogicUse(index);
-      else
+      if (!isInternalLogicUser(use.getOwner()))
         recordExternalUse(index);
     }
   }
@@ -1413,6 +1411,27 @@ void CutEnumerator::computeRequiredTimes() {
 // Pick cuts again using area-flow, while staying within the timing bound set
 // by the current mapping.
 void CutEnumerator::reselectCutsForAreaFlow() {
+  SmallVector<unsigned, 0> selectedRefCounts(logicNetwork.size(), 0);
+  for (auto [index, gate] : llvm::enumerate(logicNetwork.getGates()))
+    selectedRefCounts[index] = gate.getExternalUseCount();
+
+  auto addSelectedCutRefs = [&](const Cut *cut) {
+    if (!cut)
+      return;
+    for (uint32_t inputIndex : cut->inputs)
+      ++selectedRefCounts[inputIndex];
+  };
+
+  auto dropSelectedCutRefs = [&](const Cut *cut) {
+    if (!cut)
+      return;
+    for (uint32_t inputIndex : cut->inputs) {
+      assert(selectedRefCounts[inputIndex] != 0 &&
+             "selected reference count underflow");
+      --selectedRefCounts[inputIndex];
+    }
+  };
+
   // Start from the arrival times of the cuts we already selected.
   for (auto index : processingOrder) {
     auto it = cutSets.find(index);
@@ -1425,6 +1444,7 @@ void CutEnumerator::reselectCutsForAreaFlow() {
 
     it->second->bestArrivalTime =
         bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
+    addSelectedCutRefs(bestCut);
   }
 
   for (auto index : processingOrder) {
@@ -1433,6 +1453,7 @@ void CutEnumerator::reselectCutsForAreaFlow() {
       continue;
 
     auto *cutSet = cutSetIt->second;
+    Cut *currentBestCut = cutSet->getBestMatchedCut();
     Cut *bestAreaFlowCut = nullptr;
     std::optional<MatchedPattern> bestAreaFlowMatch;
     double bestFlow = std::numeric_limits<double>::max();
@@ -1473,8 +1494,12 @@ void CutEnumerator::reselectCutsForAreaFlow() {
         if (!inputCutSet)
           continue;
 
-        flow +=
-            inputCutSet->areaFlow / logicNetwork.getTotalRefCount(inputIndex);
+        unsigned effectiveRefCount = selectedRefCounts[inputIndex];
+        if (!currentBestCut ||
+            !llvm::is_contained(currentBestCut->inputs, inputIndex))
+          ++effectiveRefCount;
+        assert(effectiveRefCount != 0 && "cut inputs must be referenced");
+        flow += inputCutSet->areaFlow / effectiveRefCount;
       }
 
       // Break ties in a stable way: lower flow, then earlier timing, then
@@ -1498,6 +1523,8 @@ void CutEnumerator::reselectCutsForAreaFlow() {
       continue;
 
     // Later nodes should see the timing and flow of the cut we picked here.
+    dropSelectedCutRefs(currentBestCut);
+    addSelectedCutRefs(bestAreaFlowCut);
     bestAreaFlowCut->setMatchedPattern(std::move(*bestAreaFlowMatch));
     cutSet->setBestCut(bestAreaFlowCut);
     cutSet->areaFlow = bestFlow;

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -26,6 +26,7 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/Synth/SynthOpInterfaces.h"
 #include "circt/Dialect/Synth/SynthOps.h"
+#include "circt/Dialect/Synth/Transforms/SynthPasses.h"
 #include "circt/Support/LLVM.h"
 #include "circt/Support/TruthTable.h"
 #include "circt/Support/UnusedOpPruner.h"
@@ -51,6 +52,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
 #include <algorithm>
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -254,6 +256,30 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
       return result;
   }
 
+  auto isInternalLogicUser = [&](Operation *user) {
+    if (user->getNumResults() != 1)
+      return false;
+    Value result = user->getResult(0);
+    if (!hasIndex(result))
+      return false;
+    return getGate(getIndex(result)).isLogicGate();
+  };
+
+  // Note: Iteration over DenseMap is safe here since the order doesn't affect
+  // the results.
+  for (auto &[value, index] : valueToIndex) {
+    if (index == kConstant0 || index == kConstant1)
+      continue;
+
+    // Record both internal fanout and external observation for area-flow.
+    for (OpOperand &use : value.getUses()) {
+      if (isInternalLogicUser(use.getOwner()))
+        recordLogicUse(index);
+      else
+        recordExternalUse(index);
+    }
+  }
+
   return success();
 }
 
@@ -273,10 +299,19 @@ void LogicNetwork::clear() {
 // Helper functions
 //===----------------------------------------------------------------------===//
 
-// Return true if the gate at the given index is always a cut input.
-static bool isAlwaysCutInput(const LogicNetwork &network, uint32_t index) {
+// Return true if the gate at the given index must remain a cut leaf.
+static bool isCutLeaf(const LogicNetwork &network, uint32_t index) {
   const auto &gate = network.getGate(index);
-  return gate.isAlwaysCutInput();
+  return gate.isCutLeaf();
+}
+
+// Return this node's cut set, unless it is a leaf or we never built one.
+static CutSet *getNonLeafCutSet(llvm::DenseMap<uint32_t, CutSet *> &cutSets,
+                                const LogicNetwork &network, uint32_t index) {
+  if (isCutLeaf(network, index))
+    return nullptr;
+  auto it = cutSets.find(index);
+  return it == cutSets.end() ? nullptr : it->second;
 }
 
 // Return true if the new area/delay is better than the old area/delay in the
@@ -289,6 +324,34 @@ static bool compareDelayAndArea(OptimizationStrategy strategy, double newArea,
   if (strategy == OptimizationStrategyTiming)
     return newDelay < oldDelay || (newDelay == oldDelay && newArea < oldArea);
   llvm_unreachable("Unknown mapping strategy");
+}
+
+static constexpr double kAreaComparisonEpsilon = 1e-9;
+
+static bool areEquivalent(double lhs, double rhs) {
+  return std::abs(lhs - rhs) < kAreaComparisonEpsilon;
+}
+
+static SmallVector<DelayType, 1>
+computeOutputArrivalTimes(unsigned numOutputs, unsigned numInputs,
+                          ArrayRef<DelayType> delays,
+                          ArrayRef<DelayType> inputArrivalTimes,
+                          ArrayRef<unsigned> inputPermutation = {}) {
+  assert(inputPermutation.empty() || inputPermutation.size() == numInputs);
+  SmallVector<DelayType, 1> outputArrivalTimes;
+  outputArrivalTimes.reserve(numOutputs);
+  for (unsigned outputIndex = 0; outputIndex < numOutputs; ++outputIndex) {
+    DelayType outputArrivalTime = 0;
+    for (unsigned inputIndex = 0; inputIndex < numInputs; ++inputIndex) {
+      unsigned cutOriginalInput =
+          inputPermutation.empty() ? inputIndex : inputPermutation[inputIndex];
+      outputArrivalTime = std::max(
+          outputArrivalTime, delays[outputIndex * numInputs + inputIndex] +
+                                 inputArrivalTimes[cutOriginalInput]);
+    }
+    outputArrivalTimes.push_back(outputArrivalTime);
+  }
+  return outputArrivalTimes;
 }
 
 LogicalResult circt::synth::topologicallySortLogicNetwork(Operation *topOp) {
@@ -417,7 +480,7 @@ Cut::getInputArrivalTimes(CutEnumerator &enumerator,
 
   // Compute arrival times for each input.
   for (auto inputIndex : inputs) {
-    if (isAlwaysCutInput(network, inputIndex)) {
+    if (isCutLeaf(network, inputIndex)) {
       // If the input is a primary input, it has no delay.
       results.push_back(0);
       continue;
@@ -696,6 +759,13 @@ ArrayRef<DelayType> MatchedPattern::getArrivalTimes() const {
   return arrivalTimes;
 }
 
+DelayType MatchedPattern::getWorstOutputArrivalTime() const {
+  assert(pattern && "Pattern must be set to get arrival time");
+  return arrivalTimes.empty()
+             ? 0
+             : *std::max_element(arrivalTimes.begin(), arrivalTimes.end());
+}
+
 DelayType MatchedPattern::getArrivalTime(unsigned index) const {
   assert(pattern && "Pattern must be set to get arrival time");
   return arrivalTimes[index];
@@ -708,7 +778,22 @@ const CutRewritePattern *MatchedPattern::getPattern() const {
 
 double MatchedPattern::getArea() const {
   assert(pattern && "Pattern must be set to get area");
-  return area;
+  return matchResult.area;
+}
+
+ArrayRef<DelayType> MatchedPattern::getDelays() const {
+  assert(pattern && "Pattern must be set to get delays");
+  return matchResult.getDelays();
+}
+
+DelayType MatchedPattern::getDelayForCutInput(unsigned cutInputIndex) const {
+  assert(pattern && "Pattern must be set to get delays");
+  for (auto [patternInputIndex, mappedCutInput] :
+       llvm::enumerate(patternInputToCutInput)) {
+    if (mappedCutInput == cutInputIndex)
+      return getDelays()[patternInputIndex];
+  }
+  llvm_unreachable("cut input not found in matched permutation");
 }
 
 //===----------------------------------------------------------------------===//
@@ -830,7 +915,8 @@ void CutSet::finalize(
       std::stable_partition(cuts.begin(), cuts.end(),
                             [](const Cut *cut) { return cut->isTrivialCut(); });
 
-  auto isBetterCut = [&options](const Cut *a, const Cut *b) {
+  auto isBetterCut = [seedStrategy = options.strategy](const Cut *a,
+                                                       const Cut *b) {
     assert(!a->isTrivialCut() && !b->isTrivialCut() &&
            "Trivial cuts should have been excluded");
     const auto &aMatched = a->getMatchedPattern();
@@ -838,7 +924,7 @@ void CutSet::finalize(
 
     if (aMatched && bMatched)
       return compareDelayAndArea(
-          options.strategy, aMatched->getArea(), aMatched->getArrivalTimes(),
+          seedStrategy, aMatched->getArea(), aMatched->getArrivalTimes(),
           bMatched->getArea(), bMatched->getArrivalTimes());
 
     if (static_cast<bool>(aMatched) != static_cast<bool>(bMatched))
@@ -859,6 +945,8 @@ void CutSet::finalize(
     if (!currentMatch)
       continue;
     bestCut = cut;
+    bestArrivalTime = currentMatch->getWorstOutputArrivalTime();
+    areaFlow = currentMatch->getArea();
     break;
   }
 
@@ -1272,6 +1360,152 @@ void CutEnumerator::dump() const {
   llvm::outs() << "Cut enumeration completed successfully\n";
 }
 
+void CutEnumerator::computeRequiredTimes() {
+  DelayType globalWorstArrival = 0;
+  SmallVector<CutSet *, 16> outputCutSets;
+  for (auto &[index, cutSet] : cutSets) {
+    if (!logicNetwork.isPrimaryOutput(index))
+      continue;
+
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    globalWorstArrival =
+        std::max(globalWorstArrival,
+                 bestCut->getMatchedPattern()->getWorstOutputArrivalTime());
+    outputCutSets.push_back(cutSet);
+  }
+
+  // There is no output.
+  if (outputCutSets.empty())
+    return;
+
+  // Seed outputs with the worst arrival from the current timing-feasible map.
+  for (auto *cutSet : outputCutSets)
+    cutSet->requiredTime = globalWorstArrival;
+
+  for (auto it = processingOrder.rbegin(); it != processingOrder.rend(); ++it) {
+    auto cutSetIt = cutSets.find(*it);
+    if (cutSetIt == cutSets.end())
+      continue;
+
+    auto *cutSet = cutSetIt->second;
+    auto *bestCut = cutSet->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    for (auto [i, inputNodeIndex] : llvm::enumerate(bestCut->inputs)) {
+      auto *inputCutSet =
+          getNonLeafCutSet(cutSets, logicNetwork, inputNodeIndex);
+      if (!inputCutSet)
+        continue;
+
+      DelayType inputRequired =
+          cutSet->requiredTime -
+          bestCut->getMatchedPattern()->getDelayForCutInput(i);
+      inputCutSet->requiredTime =
+          std::min(inputCutSet->requiredTime, inputRequired);
+    }
+  }
+}
+
+// Pick cuts again using area-flow, while staying within the timing bound set
+// by the current mapping.
+void CutEnumerator::reselectCutsForAreaFlow() {
+  // Start from the arrival times of the cuts we already selected.
+  for (auto index : processingOrder) {
+    auto it = cutSets.find(index);
+    if (it == cutSets.end())
+      continue;
+
+    auto *bestCut = it->second->getBestMatchedCut();
+    if (!bestCut)
+      continue;
+
+    it->second->bestArrivalTime =
+        bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
+  }
+
+  for (auto index : processingOrder) {
+    auto cutSetIt = cutSets.find(index);
+    if (cutSetIt == cutSets.end())
+      continue;
+
+    auto *cutSet = cutSetIt->second;
+    Cut *bestAreaFlowCut = nullptr;
+    std::optional<MatchedPattern> bestAreaFlowMatch;
+    double bestFlow = std::numeric_limits<double>::max();
+    DelayType bestFlowArrival = std::numeric_limits<DelayType>::max();
+    double bestLocalArea = std::numeric_limits<double>::max();
+
+    for (Cut *cut : cutSet->getCuts()) {
+      // Only cuts we already know how to implement can be reconsidered here.
+      const auto &candidateMatch = cut->getMatchedPattern();
+      if (!candidateMatch)
+        continue;
+
+      SmallVector<DelayType, 4> inputArrivalTimes;
+      inputArrivalTimes.reserve(cut->getInputSize());
+      for (uint32_t inputIndex : cut->inputs) {
+        DelayType inputArrival = 0;
+        if (auto *inputCutSet =
+                getNonLeafCutSet(cutSets, logicNetwork, inputIndex))
+          inputArrival = inputCutSet->bestArrivalTime;
+        inputArrivalTimes.push_back(inputArrival);
+      }
+
+      // Recompute this cut's timing from the fanins we currently picked.
+      auto outputArrivalTimes = computeOutputArrivalTimes(
+          cut->getOutputSize(logicNetwork), cut->getInputSize(),
+          candidateMatch->getDelays(), inputArrivalTimes,
+          candidateMatch->getInputPermutation());
+      DelayType arrivalTime = *std::max_element(outputArrivalTimes.begin(),
+                                                outputArrivalTimes.end());
+      // Do not spend area if it would break the current timing bound.
+      if (arrivalTime > cutSet->requiredTime)
+        continue;
+
+      // Count this cut's own area plus its share of the fanins it depends on.
+      double flow = candidateMatch->getArea();
+      for (uint32_t inputIndex : cut->inputs) {
+        auto *inputCutSet = getNonLeafCutSet(cutSets, logicNetwork, inputIndex);
+        if (!inputCutSet)
+          continue;
+
+        flow +=
+            inputCutSet->areaFlow / logicNetwork.getTotalRefCount(inputIndex);
+      }
+
+      // Break ties in a stable way: lower flow, then earlier timing, then
+      // lower local area.
+      if (flow < bestFlow ||
+          (areEquivalent(flow, bestFlow) && arrivalTime < bestFlowArrival) ||
+          (areEquivalent(flow, bestFlow) && arrivalTime == bestFlowArrival &&
+           candidateMatch->getArea() < bestLocalArea)) {
+        bestFlow = flow;
+        bestFlowArrival = arrivalTime;
+        bestLocalArea = candidateMatch->getArea();
+        bestAreaFlowCut = cut;
+        bestAreaFlowMatch = MatchedPattern(
+            candidateMatch->getPattern(), std::move(outputArrivalTimes),
+            candidateMatch->getMatchResult(),
+            candidateMatch->getInputPermutation());
+      }
+    }
+
+    if (!bestAreaFlowCut || !bestAreaFlowMatch)
+      continue;
+
+    // Later nodes should see the timing and flow of the cut we picked here.
+    bestAreaFlowCut->setMatchedPattern(std::move(*bestAreaFlowMatch));
+    cutSet->setBestCut(bestAreaFlowCut);
+    cutSet->areaFlow = bestFlow;
+    cutSet->bestArrivalTime =
+        bestAreaFlowCut->getMatchedPattern()->getWorstOutputArrivalTime();
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // CutRewriter
 //===----------------------------------------------------------------------===//
@@ -1313,6 +1547,13 @@ LogicalResult CutRewriter::run(Operation *topOp) {
     return success();
   }
 
+  // Run area-flow based reselection.
+  // TODO: This selection must be controlled by the strategy option, but
+  // currently it runs area recovery unconditionally since it improves area
+  // regardless of the strategy.
+  cutEnumerator.computeRequiredTimes();
+  cutEnumerator.reselectCutsForAreaFlow();
+
   // Select best cuts and perform mapping
   if (failed(runBottomUpRewrite(topOp)))
     return failure();
@@ -1351,41 +1592,29 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   const CutRewritePattern *bestPattern = nullptr;
   SmallVector<DelayType, 4> inputArrivalTimes;
   SmallVector<DelayType, 1> bestArrivalTimes;
-  double bestArea = 0.0;
+  SmallVector<unsigned, 6> bestInputPermutation;
+  std::optional<MatchResult> bestMatchResult;
   inputArrivalTimes.reserve(cut.getInputSize());
   bestArrivalTimes.reserve(cut.getOutputSize(network));
+  SmallVector<unsigned, 6> identityMapping(cut.getInputSize());
+  for (auto [idx, mapped] : llvm::enumerate(identityMapping))
+    mapped = idx;
 
   // Compute arrival times for each input.
   if (failed(cut.getInputArrivalTimes(cutEnumerator, inputArrivalTimes)))
     return {};
 
   auto computeArrivalTimeAndPickBest =
-      [&](const CutRewritePattern *pattern, const MatchResult &matchResult,
-          llvm::function_ref<unsigned(unsigned)> mapIndex) {
-        SmallVector<DelayType, 1> outputArrivalTimes;
-        // Compute the maximum delay for each output from inputs.
-        for (unsigned outputIndex = 0, outputSize = cut.getOutputSize(network);
-             outputIndex < outputSize; ++outputIndex) {
-          // Compute the arrival time for this output.
-          DelayType outputArrivalTime = 0;
-          auto delays = matchResult.getDelays();
-          for (unsigned inputIndex = 0, inputSize = cut.getInputSize();
-               inputIndex < inputSize; ++inputIndex) {
-            // Map pattern input i to cut input through NPN transformations
-            unsigned cutOriginalInput = mapIndex(inputIndex);
-            outputArrivalTime =
-                std::max(outputArrivalTime,
-                         delays[outputIndex * inputSize + inputIndex] +
-                             inputArrivalTimes[cutOriginalInput]);
-          }
-
-          outputArrivalTimes.push_back(outputArrivalTime);
-        }
+      [&](const CutRewritePattern *pattern, MatchResult matchResult,
+          ArrayRef<unsigned> patternInputToCutInput) {
+        auto outputArrivalTimes = computeOutputArrivalTimes(
+            cut.getOutputSize(network), cut.getInputSize(),
+            matchResult.getDelays(), inputArrivalTimes, patternInputToCutInput);
 
         // Update the arrival time
         if (!bestPattern ||
             compareDelayAndArea(options.strategy, matchResult.area,
-                                outputArrivalTimes, bestArea,
+                                outputArrivalTimes, bestMatchResult->area,
                                 bestArrivalTimes)) {
           LLVM_DEBUG({
             llvm::dbgs() << "== Matched Pattern ==============\n";
@@ -1407,9 +1636,11 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
             llvm::dbgs() << "== Matched Pattern End ==============\n";
           });
 
-          bestArrivalTimes = std::move(outputArrivalTimes);
-          bestArea = matchResult.area;
+          bestArrivalTimes = outputArrivalTimes;
+          bestInputPermutation.assign(patternInputToCutInput.begin(),
+                                      patternInputToCutInput.end());
           bestPattern = pattern;
+          bestMatchResult = std::move(matchResult);
         }
       };
 
@@ -1424,20 +1655,21 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
     // Get the input mapping from pattern's NPN class to cut's NPN class
     SmallVector<unsigned> inputMapping;
     cutNPN.getInputPermutation(patternNPN, inputMapping);
-    computeArrivalTimeAndPickBest(pattern, *matchResult,
-                                  [&](unsigned i) { return inputMapping[i]; });
+    computeArrivalTimeAndPickBest(pattern, std::move(*matchResult),
+                                  inputMapping);
   }
 
   for (const CutRewritePattern *pattern : patterns.nonNPNPatterns) {
     if (auto matchResult = pattern->match(cutEnumerator, cut))
-      computeArrivalTimeAndPickBest(pattern, *matchResult,
-                                    [&](unsigned i) { return i; });
+      computeArrivalTimeAndPickBest(pattern, std::move(*matchResult),
+                                    identityMapping);
   }
 
   if (!bestPattern)
     return {}; // No matching pattern found
 
-  return MatchedPattern(bestPattern, std::move(bestArrivalTimes), bestArea);
+  return MatchedPattern(bestPattern, std::move(bestArrivalTimes),
+                        std::move(*bestMatchResult), bestInputPermutation);
 }
 
 LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {
@@ -1465,7 +1697,7 @@ LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {
       continue;
     }
 
-    if (isAlwaysCutInput(network, index)) {
+    if (isCutLeaf(network, index)) {
       // If the value is a primary input, skip it
       LLVM_DEBUG(llvm::dbgs() << "Skipping inputs: " << value << "\n");
       continue;

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -1972,8 +1972,8 @@ LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {
     auto *rootOp = network.getGate(bestCut->getRootIndex()).getOperation();
     rewriter.setInsertionPoint(rootOp);
     const auto &matchedPattern = bestCut->getMatchedPattern();
-    auto result = matchedPattern->getPattern()->rewrite(rewriter, cutEnumerator,
-                                                        *bestCut);
+    auto result = matchedPattern->getPattern()->rewrite(
+        rewriter, cutEnumerator, *bestCut, *matchedPattern);
     if (failed(result))
       return failure();
 

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -1904,7 +1904,7 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
     auto &cutNPN = cut.getNPNClass(options.npnTable);
     MatchBinding binding = computeMatchBinding(cutNPN, patternNPN);
 
-    auto match = pattern->match(cutEnumerator, cut, binding);
+    auto match = pattern->match(cutEnumerator, cut, binding, inputArrivalTimes);
     if (!match)
       continue;
     computeArrivalTimeAndPickBest(pattern, std::move(*match),
@@ -1912,7 +1912,8 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   }
 
   for (const CutRewritePattern *pattern : patterns.nonNPNPatterns) {
-    if (auto match = pattern->match(cutEnumerator, cut, identityBinding))
+    if (auto match = pattern->match(cutEnumerator, cut, identityBinding,
+                                    inputArrivalTimes))
       computeArrivalTimeAndPickBest(pattern, std::move(*match),
                                     identityBinding);
   }

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -1852,7 +1852,7 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   const CutRewritePattern *bestPattern = nullptr;
   SmallVector<DelayType, 4> inputArrivalTimes;
   SmallVector<DelayType, 1> bestArrivalTimes;
-  std::optional<PatternMatch> bestMatch;
+  std::optional<MatchResult> bestMatch;
   inputArrivalTimes.reserve(cut.getInputSize());
   bestArrivalTimes.reserve(cut.getOutputSize(network));
   MatchBinding identityBinding = MatchBinding::getIdentity(cut.getInputSize());
@@ -1862,7 +1862,7 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
     return {};
 
   auto computeArrivalTimeAndPickBest = [&](const CutRewritePattern *pattern,
-                                           PatternMatch match,
+                                           MatchResult match,
                                            MatchBinding binding) {
     match.setBinding(std::move(binding));
     auto outputArrivalTimes = computeOutputArrivalTimes(

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -831,18 +831,18 @@ const CutRewritePattern *MatchedPattern::getPattern() const {
 
 double MatchedPattern::getArea() const {
   assert(pattern && "Pattern must be set to get area");
-  return cost.area;
+  return match.area;
 }
 
 ArrayRef<DelayType> MatchedPattern::getDelays() const {
   assert(pattern && "Pattern must be set to get delays");
-  return cost.getDelays();
+  return match.getDelays();
 }
 
 DelayType MatchedPattern::getDelayForCutInput(unsigned cutInputIndex) const {
   assert(pattern && "Pattern must be set to get delays");
   unsigned patternInputIndex =
-      binding.getPatternInputForCutInput(cutInputIndex);
+      match.getBinding().getPatternInputForCutInput(cutInputIndex);
   return getDelays()[patternInputIndex];
 }
 
@@ -1642,9 +1642,9 @@ void CutEnumerator::reselectCutsForAreaFlow() {
         bestFlowArrival = arrivalTime;
         bestLocalArea = candidateMatch->getArea();
         bestAreaFlowCut = cut;
-        bestAreaFlowMatch = MatchedPattern(
-            candidateMatch->getPattern(), std::move(outputArrivalTimes),
-            candidateMatch->getCost(), candidateMatch->getBinding());
+        bestAreaFlowMatch = MatchedPattern(candidateMatch->getPattern(),
+                                           std::move(outputArrivalTimes),
+                                           candidateMatch->getMatch());
       }
     }
 
@@ -1743,9 +1743,9 @@ void CutEnumerator::reselectCutsForExactArea() {
         bestExactArrival = arrivalTime;
         bestLocalArea = candidateMatch->getArea();
         bestExactCut = cut;
-        bestExactMatch = MatchedPattern(
-            candidateMatch->getPattern(), std::move(outputArrivalTimes),
-            candidateMatch->getCost(), candidateMatch->getBinding());
+        bestExactMatch = MatchedPattern(candidateMatch->getPattern(),
+                                        std::move(outputArrivalTimes),
+                                        candidateMatch->getMatch());
       }
     }
 
@@ -1852,8 +1852,7 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   const CutRewritePattern *bestPattern = nullptr;
   SmallVector<DelayType, 4> inputArrivalTimes;
   SmallVector<DelayType, 1> bestArrivalTimes;
-  MatchBinding bestBinding;
-  std::optional<PatternCost> bestCost;
+  std::optional<PatternMatch> bestMatch;
   inputArrivalTimes.reserve(cut.getInputSize());
   bestArrivalTimes.reserve(cut.getOutputSize(network));
   MatchBinding identityBinding = MatchBinding::getIdentity(cut.getInputSize());
@@ -1863,22 +1862,23 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
     return {};
 
   auto computeArrivalTimeAndPickBest = [&](const CutRewritePattern *pattern,
-                                           PatternCost cost,
+                                           PatternMatch match,
                                            MatchBinding binding) {
+    match.setBinding(std::move(binding));
     auto outputArrivalTimes = computeOutputArrivalTimes(
-        cut.getOutputSize(network), cut.getInputSize(), cost.getDelays(),
-        inputArrivalTimes, binding);
+        cut.getOutputSize(network), cut.getInputSize(), match.getDelays(),
+        inputArrivalTimes, match.getBinding());
 
     // Update the arrival time
     if (!bestPattern ||
-        compareDelayAndArea(options.strategy, cost.area, outputArrivalTimes,
-                            bestCost->area, bestArrivalTimes)) {
+        compareDelayAndArea(options.strategy, match.area, outputArrivalTimes,
+                            bestMatch->area, bestArrivalTimes)) {
       LLVM_DEBUG({
         llvm::dbgs() << "== Matched Pattern ==============\n";
         llvm::dbgs() << "Matching cut: \n";
         cut.dump(llvm::dbgs(), network);
         llvm::dbgs() << "Found better pattern: " << pattern->getPatternName();
-        llvm::dbgs() << " with area: " << cost.area;
+        llvm::dbgs() << " with area: " << match.area;
         llvm::dbgs() << " and input arrival times: ";
         for (unsigned i = 0; i < inputArrivalTimes.size(); ++i) {
           llvm::dbgs() << " " << inputArrivalTimes[i];
@@ -1893,9 +1893,8 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
       });
 
       bestArrivalTimes = outputArrivalTimes;
-      bestBinding = std::move(binding);
       bestPattern = pattern;
-      bestCost = std::move(cost);
+      bestMatch = std::move(match);
     }
   };
 
@@ -1909,23 +1908,24 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
     if (binding.hasNegation())
       continue;
 
-    auto cost = pattern->match(cutEnumerator, cut);
-    if (!cost)
+    auto match = pattern->match(cutEnumerator, cut);
+    if (!match)
       continue;
-    computeArrivalTimeAndPickBest(pattern, std::move(*cost),
+    computeArrivalTimeAndPickBest(pattern, std::move(*match),
                                   std::move(binding));
   }
 
   for (const CutRewritePattern *pattern : patterns.nonNPNPatterns) {
-    if (auto cost = pattern->match(cutEnumerator, cut))
-      computeArrivalTimeAndPickBest(pattern, std::move(*cost), identityBinding);
+    if (auto match = pattern->match(cutEnumerator, cut))
+      computeArrivalTimeAndPickBest(pattern, std::move(*match),
+                                    identityBinding);
   }
 
   if (!bestPattern)
     return {}; // No matching pattern found
 
   return MatchedPattern(bestPattern, std::move(bestArrivalTimes),
-                        std::move(*bestCost), std::move(bestBinding));
+                        std::move(*bestMatch));
 }
 
 LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -330,22 +330,19 @@ static bool areEquivalent(double lhs, double rhs) {
   return std::abs(lhs - rhs) < kAreaComparisonEpsilon;
 }
 
-static SmallVector<DelayType, 1>
-computeOutputArrivalTimes(unsigned numOutputs, unsigned numInputs,
-                          ArrayRef<DelayType> delays,
-                          ArrayRef<DelayType> inputArrivalTimes,
-                          ArrayRef<unsigned> inputPermutation = {}) {
-  assert(inputPermutation.empty() || inputPermutation.size() == numInputs);
+static SmallVector<DelayType, 1> computeOutputArrivalTimes(
+    unsigned numOutputs, unsigned numInputs, ArrayRef<DelayType> delays,
+    ArrayRef<DelayType> inputArrivalTimes, const MatchBinding &binding) {
+  assert(binding.getNumInputs() == numInputs);
   SmallVector<DelayType, 1> outputArrivalTimes;
   outputArrivalTimes.reserve(numOutputs);
   for (unsigned outputIndex = 0; outputIndex < numOutputs; ++outputIndex) {
     DelayType outputArrivalTime = 0;
-    for (unsigned inputIndex = 0; inputIndex < numInputs; ++inputIndex) {
-      unsigned cutOriginalInput =
-          inputPermutation.empty() ? inputIndex : inputPermutation[inputIndex];
+    for (unsigned patternInput = 0; patternInput < numInputs; ++patternInput) {
+      unsigned cutInput = binding.getCutInputForPatternInput(patternInput);
       outputArrivalTime = std::max(
-          outputArrivalTime, delays[outputIndex * numInputs + inputIndex] +
-                                 inputArrivalTimes[cutOriginalInput]);
+          outputArrivalTime, delays[outputIndex * numInputs + patternInput] +
+                                 inputArrivalTimes[cutInput]);
     }
     outputArrivalTimes.push_back(outputArrivalTime);
   }
@@ -749,6 +746,64 @@ Cut Cut::getTrivialCut(uint32_t index) {
 }
 
 //===----------------------------------------------------------------------===//
+// MatchBinding
+//===----------------------------------------------------------------------===//
+
+MatchBinding::MatchBinding(ArrayRef<unsigned> patternInputToCutInput,
+                           unsigned inputNegation, unsigned outputNegation)
+    : patternInputToCutInput(patternInputToCutInput.begin(),
+                             patternInputToCutInput.end()),
+      inputNegation(inputNegation), outputNegation(outputNegation) {
+  for (auto [patternInput, cutInput] :
+       llvm::enumerate(patternInputToCutInput)) {
+    (void)patternInput;
+    assert(cutInput < patternInputToCutInput.size() &&
+           "cut input index out of range");
+  }
+}
+
+MatchBinding MatchBinding::getIdentity(unsigned numInputs) {
+  SmallVector<unsigned, 6> identity(numInputs);
+  for (auto [idx, mapped] : llvm::enumerate(identity))
+    mapped = idx;
+  return MatchBinding(identity, /*inputNegation=*/0, /*outputNegation=*/0);
+}
+
+unsigned
+MatchBinding::getPatternInputForCutInput(unsigned cutInputIndex) const {
+  auto it = llvm::find(patternInputToCutInput, cutInputIndex);
+  assert(it != patternInputToCutInput.end() && "cut input not bound");
+  return it - patternInputToCutInput.begin();
+}
+
+static MatchBinding computeMatchBinding(const NPNClass &cutNPN,
+                                        const NPNClass &patternNPN) {
+  assert(cutNPN.truthTable == patternNPN.truthTable &&
+         "NPN classes must share a canonical representative");
+  assert(cutNPN.inputPermutation.size() == patternNPN.inputPermutation.size() &&
+         "NPN classes must have the same number of inputs");
+
+  unsigned numInputs = cutNPN.inputPermutation.size();
+  SmallVector<unsigned, 6> patternInputToCutInput(numInputs);
+  unsigned inputNegation = 0;
+  for (unsigned canonicalInput = 0; canonicalInput < numInputs;
+       ++canonicalInput) {
+    unsigned patternInput = patternNPN.inputPermutation[canonicalInput];
+    unsigned cutInput = cutNPN.inputPermutation[canonicalInput];
+    patternInputToCutInput[patternInput] = cutInput;
+
+    bool negateInput =
+        ((cutNPN.inputNegation ^ patternNPN.inputNegation) >> canonicalInput) &
+        1u;
+    if (negateInput)
+      inputNegation |= 1u << patternInput;
+  }
+
+  return MatchBinding(patternInputToCutInput, inputNegation,
+                      cutNPN.outputNegation ^ patternNPN.outputNegation);
+}
+
+//===----------------------------------------------------------------------===//
 // MatchedPattern
 //===----------------------------------------------------------------------===//
 
@@ -776,22 +831,19 @@ const CutRewritePattern *MatchedPattern::getPattern() const {
 
 double MatchedPattern::getArea() const {
   assert(pattern && "Pattern must be set to get area");
-  return matchResult.area;
+  return cost.area;
 }
 
 ArrayRef<DelayType> MatchedPattern::getDelays() const {
   assert(pattern && "Pattern must be set to get delays");
-  return matchResult.getDelays();
+  return cost.getDelays();
 }
 
 DelayType MatchedPattern::getDelayForCutInput(unsigned cutInputIndex) const {
   assert(pattern && "Pattern must be set to get delays");
-  for (auto [patternInputIndex, mappedCutInput] :
-       llvm::enumerate(patternInputToCutInput)) {
-    if (mappedCutInput == cutInputIndex)
-      return getDelays()[patternInputIndex];
-  }
-  llvm_unreachable("cut input not found in matched permutation");
+  unsigned patternInputIndex =
+      binding.getPatternInputForCutInput(cutInputIndex);
+  return getDelays()[patternInputIndex];
 }
 
 //===----------------------------------------------------------------------===//
@@ -1409,9 +1461,9 @@ void CutEnumerator::computeRequiredTimes() {
 }
 
 namespace {
-/// Tracks references from the currently selected cut cover. Reference counts are
-/// seeded by values observed outside the logic network, then propagated through
-/// selected cuts on demand.
+/// Tracks references from the currently selected cut cover. Reference counts
+/// are seeded by values observed outside the logic network, then propagated
+/// through selected cuts on demand.
 class SelectedCoverRefCounts {
 public:
   SelectedCoverRefCounts(llvm::DenseMap<uint32_t, CutSet *> &cutSets,
@@ -1558,7 +1610,7 @@ void CutEnumerator::reselectCutsForAreaFlow() {
       auto outputArrivalTimes = computeOutputArrivalTimes(
           cut->getOutputSize(logicNetwork), cut->getInputSize(),
           candidateMatch->getDelays(), inputArrivalTimes,
-          candidateMatch->getInputPermutation());
+          candidateMatch->getBinding());
       DelayType arrivalTime = *std::max_element(outputArrivalTimes.begin(),
                                                 outputArrivalTimes.end());
       // Do not spend area if it would break the current timing bound.
@@ -1592,8 +1644,7 @@ void CutEnumerator::reselectCutsForAreaFlow() {
         bestAreaFlowCut = cut;
         bestAreaFlowMatch = MatchedPattern(
             candidateMatch->getPattern(), std::move(outputArrivalTimes),
-            candidateMatch->getMatchResult(),
-            candidateMatch->getInputPermutation());
+            candidateMatch->getCost(), candidateMatch->getBinding());
       }
     }
 
@@ -1673,7 +1724,7 @@ void CutEnumerator::reselectCutsForExactArea() {
       auto outputArrivalTimes = computeOutputArrivalTimes(
           cut->getOutputSize(logicNetwork), cut->getInputSize(),
           candidateMatch->getDelays(), inputArrivalTimes,
-          candidateMatch->getInputPermutation());
+          candidateMatch->getBinding());
       DelayType arrivalTime = *std::max_element(outputArrivalTimes.begin(),
                                                 outputArrivalTimes.end());
       if (arrivalTime > cutSet->requiredTime)
@@ -1692,10 +1743,9 @@ void CutEnumerator::reselectCutsForExactArea() {
         bestExactArrival = arrivalTime;
         bestLocalArea = candidateMatch->getArea();
         bestExactCut = cut;
-        bestExactMatch = MatchedPattern(candidateMatch->getPattern(),
-                                        std::move(outputArrivalTimes),
-                                        candidateMatch->getMatchResult(),
-                                        candidateMatch->getInputPermutation());
+        bestExactMatch = MatchedPattern(
+            candidateMatch->getPattern(), std::move(outputArrivalTimes),
+            candidateMatch->getCost(), candidateMatch->getBinding());
       }
     }
 
@@ -1802,84 +1852,80 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   const CutRewritePattern *bestPattern = nullptr;
   SmallVector<DelayType, 4> inputArrivalTimes;
   SmallVector<DelayType, 1> bestArrivalTimes;
-  SmallVector<unsigned, 6> bestInputPermutation;
-  std::optional<MatchResult> bestMatchResult;
+  MatchBinding bestBinding;
+  std::optional<PatternCost> bestCost;
   inputArrivalTimes.reserve(cut.getInputSize());
   bestArrivalTimes.reserve(cut.getOutputSize(network));
-  SmallVector<unsigned, 6> identityMapping(cut.getInputSize());
-  for (auto [idx, mapped] : llvm::enumerate(identityMapping))
-    mapped = idx;
+  MatchBinding identityBinding = MatchBinding::getIdentity(cut.getInputSize());
 
   // Compute arrival times for each input.
   if (failed(cut.getInputArrivalTimes(cutEnumerator, inputArrivalTimes)))
     return {};
 
-  auto computeArrivalTimeAndPickBest =
-      [&](const CutRewritePattern *pattern, MatchResult matchResult,
-          ArrayRef<unsigned> patternInputToCutInput) {
-        auto outputArrivalTimes = computeOutputArrivalTimes(
-            cut.getOutputSize(network), cut.getInputSize(),
-            matchResult.getDelays(), inputArrivalTimes, patternInputToCutInput);
+  auto computeArrivalTimeAndPickBest = [&](const CutRewritePattern *pattern,
+                                           PatternCost cost,
+                                           MatchBinding binding) {
+    auto outputArrivalTimes = computeOutputArrivalTimes(
+        cut.getOutputSize(network), cut.getInputSize(), cost.getDelays(),
+        inputArrivalTimes, binding);
 
-        // Update the arrival time
-        if (!bestPattern ||
-            compareDelayAndArea(options.strategy, matchResult.area,
-                                outputArrivalTimes, bestMatchResult->area,
-                                bestArrivalTimes)) {
-          LLVM_DEBUG({
-            llvm::dbgs() << "== Matched Pattern ==============\n";
-            llvm::dbgs() << "Matching cut: \n";
-            cut.dump(llvm::dbgs(), network);
-            llvm::dbgs() << "Found better pattern: "
-                         << pattern->getPatternName();
-            llvm::dbgs() << " with area: " << matchResult.area;
-            llvm::dbgs() << " and input arrival times: ";
-            for (unsigned i = 0; i < inputArrivalTimes.size(); ++i) {
-              llvm::dbgs() << " " << inputArrivalTimes[i];
-            }
-            llvm::dbgs() << " and arrival times: ";
-
-            for (auto arrivalTime : outputArrivalTimes) {
-              llvm::dbgs() << " " << arrivalTime;
-            }
-            llvm::dbgs() << "\n";
-            llvm::dbgs() << "== Matched Pattern End ==============\n";
-          });
-
-          bestArrivalTimes = outputArrivalTimes;
-          bestInputPermutation.assign(patternInputToCutInput.begin(),
-                                      patternInputToCutInput.end());
-          bestPattern = pattern;
-          bestMatchResult = std::move(matchResult);
+    // Update the arrival time
+    if (!bestPattern ||
+        compareDelayAndArea(options.strategy, cost.area, outputArrivalTimes,
+                            bestCost->area, bestArrivalTimes)) {
+      LLVM_DEBUG({
+        llvm::dbgs() << "== Matched Pattern ==============\n";
+        llvm::dbgs() << "Matching cut: \n";
+        cut.dump(llvm::dbgs(), network);
+        llvm::dbgs() << "Found better pattern: " << pattern->getPatternName();
+        llvm::dbgs() << " with area: " << cost.area;
+        llvm::dbgs() << " and input arrival times: ";
+        for (unsigned i = 0; i < inputArrivalTimes.size(); ++i) {
+          llvm::dbgs() << " " << inputArrivalTimes[i];
         }
-      };
+        llvm::dbgs() << " and arrival times: ";
+
+        for (auto arrivalTime : outputArrivalTimes) {
+          llvm::dbgs() << " " << arrivalTime;
+        }
+        llvm::dbgs() << "\n";
+        llvm::dbgs() << "== Matched Pattern End ==============\n";
+      });
+
+      bestArrivalTimes = outputArrivalTimes;
+      bestBinding = std::move(binding);
+      bestPattern = pattern;
+      bestCost = std::move(cost);
+    }
+  };
 
   for (auto &[patternNPN, pattern] : getMatchingPatternsFromTruthTable(cut)) {
     assert(patternNPN.truthTable.numInputs == cut.getInputSize() &&
            "Pattern input size must match cut input size");
-    auto matchResult = pattern->match(cutEnumerator, cut);
-    if (!matchResult)
-      continue;
     auto &cutNPN = cut.getNPNClass(options.npnTable);
+    MatchBinding binding = computeMatchBinding(cutNPN, patternNPN);
+    // TODO: Support phase-aware mapping by materializing or reusing inverted
+    // input/output values from the binding.
+    if (binding.hasNegation())
+      continue;
 
-    // Get the input mapping from pattern's NPN class to cut's NPN class
-    SmallVector<unsigned> inputMapping;
-    cutNPN.getInputPermutation(patternNPN, inputMapping);
-    computeArrivalTimeAndPickBest(pattern, std::move(*matchResult),
-                                  inputMapping);
+    auto cost = pattern->match(cutEnumerator, cut);
+    if (!cost)
+      continue;
+    computeArrivalTimeAndPickBest(pattern, std::move(*cost),
+                                  std::move(binding));
   }
 
   for (const CutRewritePattern *pattern : patterns.nonNPNPatterns) {
-    if (auto matchResult = pattern->match(cutEnumerator, cut))
-      computeArrivalTimeAndPickBest(pattern, std::move(*matchResult),
-                                    identityMapping);
+    if (auto cost = pattern->match(cutEnumerator, cut))
+      computeArrivalTimeAndPickBest(pattern, std::move(*cost), identityBinding);
   }
 
   if (!bestPattern)
     return {}; // No matching pattern found
 
   return MatchedPattern(bestPattern, std::move(bestArrivalTimes),
-                        std::move(*bestMatchResult), bestInputPermutation);
+                        std::move(*bestCost), std::move(bestBinding));
 }
 
 LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -1903,12 +1903,8 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
            "Pattern input size must match cut input size");
     auto &cutNPN = cut.getNPNClass(options.npnTable);
     MatchBinding binding = computeMatchBinding(cutNPN, patternNPN);
-    // TODO: Support phase-aware mapping by materializing or reusing inverted
-    // input/output values from the binding.
-    if (binding.hasNegation())
-      continue;
 
-    auto match = pattern->match(cutEnumerator, cut);
+    auto match = pattern->match(cutEnumerator, cut, binding);
     if (!match)
       continue;
     computeArrivalTimeAndPickBest(pattern, std::move(*match),
@@ -1916,7 +1912,7 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   }
 
   for (const CutRewritePattern *pattern : patterns.nonNPNPatterns) {
-    if (auto match = pattern->match(cutEnumerator, cut))
+    if (auto match = pattern->match(cutEnumerator, cut, identityBinding))
       computeArrivalTimeAndPickBest(pattern, std::move(*match),
                                     identityBinding);
   }

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -271,9 +271,12 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
     if (index == kConstant0 || index == kConstant1)
       continue;
 
-    // Record observations that remain visible after cut covering.
+    // Record structural fanout for initial area-flow estimates and
+    // observations that remain visible after cut covering.
     for (OpOperand &use : value.getUses()) {
-      if (!isInternalLogicUser(use.getOwner()))
+      if (isInternalLogicUser(use.getOwner()))
+        recordLogicUse(index);
+      else
         recordExternalUse(index);
     }
   }
@@ -861,6 +864,34 @@ void CutSet::addCut(Cut *cut) {
 
 ArrayRef<Cut *> CutSet::getCuts() const { return cuts; }
 
+bool circt::synth::compareCutsByAreaFlow(const Cut &lhs, const Cut &rhs) {
+  const auto &lhsMatch = lhs.getMatchedPattern();
+  const auto &rhsMatch = rhs.getMatchedPattern();
+  if (!lhsMatch || !rhsMatch)
+    return lhsMatch.has_value();
+
+  if (!areEquivalent(lhsMatch->getAreaFlow(), rhsMatch->getAreaFlow()))
+    return lhsMatch->getAreaFlow() < rhsMatch->getAreaFlow();
+  if (lhsMatch->getArrivalTimes() != rhsMatch->getArrivalTimes())
+    return lhsMatch->getArrivalTimes() < rhsMatch->getArrivalTimes();
+  if (lhs.getInputSize() != rhs.getInputSize())
+    return lhs.getInputSize() < rhs.getInputSize();
+  return lhsMatch->getArea() < rhsMatch->getArea();
+}
+
+bool circt::synth::compareCutsByArea(const Cut &lhs, const Cut &rhs) {
+  const auto &lhsMatch = lhs.getMatchedPattern();
+  const auto &rhsMatch = rhs.getMatchedPattern();
+  if (!lhsMatch || !rhsMatch)
+    return lhsMatch.has_value();
+
+  if (!areEquivalent(lhsMatch->getArea(), rhsMatch->getArea()))
+    return lhsMatch->getArea() < rhsMatch->getArea();
+  if (lhsMatch->getArrivalTimes() != rhsMatch->getArrivalTimes())
+    return lhsMatch->getArrivalTimes() < rhsMatch->getArrivalTimes();
+  return lhs.getInputSize() < rhs.getInputSize();
+}
+
 // Remove duplicate cuts and non-minimal cuts. A cut is non-minimal if there
 // exists another cut that is a subset of it.
 static void removeDuplicateAndNonMinimalCuts(SmallVectorImpl<Cut *> &cuts) {
@@ -984,9 +1015,67 @@ void CutSet::finalize(
   };
   std::stable_sort(trivialCutsEnd, cuts.end(), isBetterCut);
 
-  // Keep only the top-K cuts to bound growth.
-  if (cuts.size() > options.maxCutSizePerRoot)
-    cuts.resize(options.maxCutSizePerRoot);
+  // Keep the primary ranking while reserving a bounded top-k set for each
+  // additional optimization view. The trivial cut is carried separately,
+  // matching the usual priority-cut convention that the configured limit
+  // counts non-trivial candidates.
+  SmallVector<Cut *, 12> rankedCuts(trivialCutsEnd, cuts.end());
+  unsigned nonTrivialLimit = options.maxCutSizePerRoot;
+  unsigned requestedReserved = 0;
+  for (const AdditionalCutRanking &ranking : options.additionalCutRankings) {
+    if (requestedReserved == nonTrivialLimit)
+      break;
+    requestedReserved +=
+        std::min(ranking.maxCuts, nonTrivialLimit - requestedReserved);
+  }
+  unsigned maxReserved = nonTrivialLimit == 0 ? 0 : nonTrivialLimit - 1;
+  unsigned numReserved = std::min(requestedReserved, maxReserved);
+  unsigned primaryLimit = nonTrivialLimit - numReserved;
+  unsigned trivialCount = trivialCutsEnd - cuts.begin();
+
+  SmallVector<Cut *, 12> retainedCuts(cuts.begin(), trivialCutsEnd);
+  retainedCuts.append(rankedCuts.begin(),
+                      rankedCuts.begin() +
+                          std::min<unsigned>(primaryLimit, rankedCuts.size()));
+
+  auto isBetterFor = [](const Cut *lhs, const Cut *rhs,
+                        const CutComparator &comparator) {
+    bool lhsMatched = lhs->getMatchedPattern().has_value();
+    bool rhsMatched = rhs->getMatchedPattern().has_value();
+    if (lhsMatched != rhsMatched)
+      return lhsMatched;
+    return comparator(*lhs, *rhs);
+  };
+
+  unsigned remainingReserved = numReserved;
+  for (const AdditionalCutRanking &ranking : options.additionalCutRankings) {
+    SmallVector<Cut *, 12> additionallyRankedCuts(rankedCuts);
+    std::stable_sort(additionallyRankedCuts.begin(),
+                     additionallyRankedCuts.end(), [&](Cut *lhs, Cut *rhs) {
+                       return isBetterFor(lhs, rhs, ranking.comparator);
+                     });
+    unsigned rankingLimit =
+        std::min<unsigned>(ranking.maxCuts, additionallyRankedCuts.size());
+    for (Cut *cut :
+         ArrayRef<Cut *>(additionallyRankedCuts).take_front(rankingLimit)) {
+      if (remainingReserved == 0)
+        break;
+      if (llvm::is_contained(retainedCuts, cut))
+        continue;
+      retainedCuts.push_back(cut);
+      --remainingReserved;
+    }
+  }
+
+  // A reserved view may select a cut already kept by the primary ranking.
+  // Fill any remaining capacity with the next primary candidates.
+  for (Cut *cut : rankedCuts) {
+    if (retainedCuts.size() >= trivialCount + nonTrivialLimit)
+      break;
+    if (!llvm::is_contained(retainedCuts, cut))
+      retainedCuts.push_back(cut);
+  }
+  cuts = std::move(retainedCuts);
 
   // Select the best cut from the remaining candidates.
   bestCut = nullptr;
@@ -996,7 +1085,7 @@ void CutSet::finalize(
       continue;
     bestCut = cut;
     bestArrivalTime = currentMatch->getWorstOutputArrivalTime();
-    areaFlow = currentMatch->getArea();
+    areaFlow = currentMatch->getAreaFlow();
     break;
   }
 
@@ -1396,8 +1485,8 @@ void CutEnumerator::dump() const {
         llvm::outs() << getTestVariableName(inputVal, opCounter);
       });
       auto &pattern = cut->getMatchedPattern();
-      llvm::outs() << "}"
-                   << "@t" << cut->getTruthTable()->table.getZExtValue() << "d";
+      llvm::outs() << "}" << "@t" << cut->getTruthTable()->table.getZExtValue()
+                   << "d";
       if (pattern) {
         llvm::outs() << *std::max_element(pattern->getArrivalTimes().begin(),
                                           pattern->getArrivalTimes().end());
@@ -1411,6 +1500,14 @@ void CutEnumerator::dump() const {
 }
 
 void CutEnumerator::computeRequiredTimes() {
+  // Required times depend on the currently selected cover. Reset the values
+  // before every propagation so this can be called between area-recovery
+  // passes after representative cuts have changed.
+  for (auto &[index, cutSet] : cutSets) {
+    (void)index;
+    cutSet->requiredTime = std::numeric_limits<DelayType>::max();
+  }
+
   DelayType globalWorstArrival = 0;
   SmallVector<CutSet *, 16> outputCutSets;
   for (auto &[index, cutSet] : cutSets) {
@@ -1476,7 +1573,8 @@ public:
 
   unsigned get(uint32_t index) const { return refCounts[index]; }
 
-  void referenceSelectedCover(ArrayRef<uint32_t> processingOrder) {
+  double referenceSelectedCover(ArrayRef<uint32_t> processingOrder) {
+    double area = 0.0;
     for (auto index : processingOrder) {
       if (refCounts[index] == 0)
         continue;
@@ -1485,8 +1583,9 @@ public:
       if (!cutSet)
         continue;
 
-      referenceCut(cutSet->getBestMatchedCut());
+      area += referenceCut(cutSet->getBestMatchedCut());
     }
+    return area;
   }
 
   double referenceCut(const Cut *cut) {
@@ -1556,6 +1655,11 @@ private:
 };
 } // namespace
 
+double CutEnumerator::getSelectedArea() {
+  SelectedCoverRefCounts selectedRefs(cutSets, logicNetwork);
+  return selectedRefs.referenceSelectedCover(processingOrder);
+}
+
 // Pick cuts again using area-flow, while staying within the timing bound set
 // by the current mapping.
 void CutEnumerator::reselectCutsForAreaFlow() {
@@ -1574,7 +1678,7 @@ void CutEnumerator::reselectCutsForAreaFlow() {
     it->second->bestArrivalTime =
         bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
   }
-  selectedRefs.referenceSelectedCover(processingOrder);
+  (void)selectedRefs.referenceSelectedCover(processingOrder);
 
   for (auto index : processingOrder) {
     auto cutSetIt = cutSets.find(index);
@@ -1642,9 +1746,9 @@ void CutEnumerator::reselectCutsForAreaFlow() {
         bestFlowArrival = arrivalTime;
         bestLocalArea = candidateMatch->getArea();
         bestAreaFlowCut = cut;
-        bestAreaFlowMatch = MatchedPattern(candidateMatch->getPattern(),
-                                           std::move(outputArrivalTimes),
-                                           candidateMatch->getMatch());
+        bestAreaFlowMatch = MatchedPattern(
+            candidateMatch->getPattern(), std::move(outputArrivalTimes),
+            candidateMatch->getMatch(), bestFlow);
       }
     }
 
@@ -1684,9 +1788,9 @@ void CutEnumerator::reselectCutsForExactArea() {
     it->second->bestArrivalTime =
         bestCut->getMatchedPattern()->getWorstOutputArrivalTime();
   }
-  selectedRefs.referenceSelectedCover(processingOrder);
+  (void)selectedRefs.referenceSelectedCover(processingOrder);
 
-  for (auto index : processingOrder) {
+  for (uint32_t index : processingOrder) {
     auto cutSetIt = cutSets.find(index);
     if (cutSetIt == cutSets.end())
       continue;
@@ -1743,9 +1847,9 @@ void CutEnumerator::reselectCutsForExactArea() {
         bestExactArrival = arrivalTime;
         bestLocalArea = candidateMatch->getArea();
         bestExactCut = cut;
-        bestExactMatch = MatchedPattern(candidateMatch->getPattern(),
-                                        std::move(outputArrivalTimes),
-                                        candidateMatch->getMatch());
+        bestExactMatch = MatchedPattern(
+            candidateMatch->getPattern(), std::move(outputArrivalTimes),
+            candidateMatch->getMatch(), candidateMatch->getAreaFlow());
       }
     }
 
@@ -1810,9 +1914,66 @@ LogicalResult CutRewriter::run(Operation *topOp) {
   // TODO: This selection must be controlled by the strategy option, but
   // currently it runs area recovery unconditionally since it improves area
   // regardless of the strategy.
-  cutEnumerator.computeRequiredTimes();
-  cutEnumerator.reselectCutsForAreaFlow();
-  cutEnumerator.reselectCutsForExactArea();
+  struct SelectedMapping {
+    struct Selection {
+      CutSet *cutSet;
+      Cut *cut;
+      MatchedPattern match;
+    };
+
+    double area;
+    SmallVector<Selection> selections;
+  };
+
+  auto captureMapping = [&]() {
+    SelectedMapping mapping;
+    mapping.area = cutEnumerator.getSelectedArea();
+    for (auto &[index, cutSet] : cutEnumerator.getCutSets()) {
+      (void)index;
+      Cut *cut = cutSet->getBestMatchedCut();
+      if (!cut)
+        continue;
+      mapping.selections.push_back({cutSet, cut, *cut->getMatchedPattern()});
+    }
+    return mapping;
+  };
+
+  auto restoreMapping = [](const SelectedMapping &mapping) {
+    for (const auto &selection : mapping.selections) {
+      selection.cut->setMatchedPattern(selection.match);
+      selection.cutSet->setBestCut(selection.cut);
+      selection.cutSet->bestArrivalTime =
+          selection.match.getWorstOutputArrivalTime();
+    }
+  };
+
+  // Multiple recovery rounds matter more than their runtime here: area-flow
+  // exposes globally useful sharing opportunities, while exact-area rounds
+  // polish the selected cover. Keep the best cover seen so a later round can
+  // never regress the estimated mapped area.
+  constexpr unsigned areaFlowRecoveryIterations = 2;
+  constexpr unsigned exactAreaPolishingIterations = 3;
+  SelectedMapping bestMapping = captureMapping();
+  for (unsigned iteration = 0; iteration != areaFlowRecoveryIterations;
+       ++iteration) {
+    cutEnumerator.computeRequiredTimes();
+    cutEnumerator.reselectCutsForAreaFlow();
+    cutEnumerator.computeRequiredTimes();
+    cutEnumerator.reselectCutsForExactArea();
+
+    SelectedMapping candidate = captureMapping();
+    if (candidate.area < bestMapping.area)
+      bestMapping = std::move(candidate);
+  }
+  for (unsigned iteration = 0; iteration != exactAreaPolishingIterations;
+       ++iteration) {
+    cutEnumerator.computeRequiredTimes();
+    cutEnumerator.reselectCutsForExactArea();
+    SelectedMapping candidate = captureMapping();
+    if (candidate.area < bestMapping.area)
+      bestMapping = std::move(candidate);
+  }
+  restoreMapping(bestMapping);
 
   // Select best cuts and perform mapping
   if (failed(runBottomUpRewrite(topOp)))
@@ -1920,8 +2081,22 @@ std::optional<MatchedPattern> CutRewriter::patternMatchCut(const Cut &cut) {
   if (!bestPattern)
     return {}; // No matching pattern found
 
+  double areaFlow = bestMatch->area;
+  for (uint32_t inputIndex : cut.inputs) {
+    if (isCutLeaf(network, inputIndex))
+      continue;
+    auto inputIt = cutEnumerator.getCutSets().find(inputIndex);
+    if (inputIt == cutEnumerator.getCutSets().end())
+      continue;
+    Cut *inputCut = inputIt->second->getBestMatchedCut();
+    if (!inputCut)
+      continue;
+    areaFlow += inputCut->getMatchedPattern()->getAreaFlow() /
+                network.getTotalRefCount(inputIndex);
+  }
+
   return MatchedPattern(bestPattern, std::move(bestArrivalTimes),
-                        std::move(*bestMatch));
+                        std::move(*bestMatch), areaFlow);
 }
 
 LogicalResult CutRewriter::runBottomUpRewrite(Operation *top) {

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -61,7 +61,8 @@ struct GenericLUT : public CutRewritePattern {
 
   llvm::FailureOr<Operation *> rewrite(mlir::OpBuilder &rewriter,
                                        CutEnumerator &enumerator,
-                                       const Cut &cut) const override {
+                                       const Cut &cut,
+                                       const MatchedPattern &) const override {
     const auto &network = enumerator.getLogicNetwork();
     // NOTE: Don't use NPN since it's unnecessary.
     const auto &truthTableOpt = cut.getTruthTable();

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -47,9 +47,8 @@ struct GenericLUT : public CutRewritePattern {
   GenericLUT(mlir::MLIRContext *context, unsigned k)
       : CutRewritePattern(context), k(k), cachedDelays(k, 1) {}
 
-  std::optional<PatternMatch>
-  match(CutEnumerator &enumerator, const Cut &cut,
-        const MatchBinding &binding) const override {
+  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
+                                   const MatchBinding &binding) const override {
     const auto &network = enumerator.getLogicNetwork();
     (void)binding;
     // This pattern can implement any cut with at most k inputs
@@ -57,7 +56,7 @@ struct GenericLUT : public CutRewritePattern {
       return std::nullopt;
 
     // Create pattern match with a reference to cached delays.
-    return PatternMatch(
+    return MatchResult(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));
   }
 

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -47,10 +47,12 @@ struct GenericLUT : public CutRewritePattern {
   GenericLUT(mlir::MLIRContext *context, unsigned k)
       : CutRewritePattern(context), k(k), cachedDelays(k, 1) {}
 
-  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
-                                   const MatchBinding &binding) const override {
+  std::optional<MatchResult>
+  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
+        ArrayRef<DelayType> inputArrivalTimes) const override {
     const auto &network = enumerator.getLogicNetwork();
     (void)binding;
+    (void)inputArrivalTimes;
     // This pattern can implement any cut with at most k inputs
     if (cut.getInputSize() > k || cut.getOutputSize(network) != 1)
       return std::nullopt;

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -47,15 +47,15 @@ struct GenericLUT : public CutRewritePattern {
   GenericLUT(mlir::MLIRContext *context, unsigned k)
       : CutRewritePattern(context), k(k), cachedDelays(k, 1) {}
 
-  std::optional<MatchResult> match(CutEnumerator &enumerator,
+  std::optional<PatternCost> match(CutEnumerator &enumerator,
                                    const Cut &cut) const override {
     const auto &network = enumerator.getLogicNetwork();
     // This pattern can implement any cut with at most k inputs
     if (cut.getInputSize() > k || cut.getOutputSize(network) != 1)
       return std::nullopt;
 
-    // Create match result with a reference to cached delays
-    return MatchResult(
+    // Create pattern cost with a reference to cached delays.
+    return PatternCost(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));
   }
 

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -47,15 +47,15 @@ struct GenericLUT : public CutRewritePattern {
   GenericLUT(mlir::MLIRContext *context, unsigned k)
       : CutRewritePattern(context), k(k), cachedDelays(k, 1) {}
 
-  std::optional<PatternCost> match(CutEnumerator &enumerator,
-                                   const Cut &cut) const override {
+  std::optional<PatternMatch> match(CutEnumerator &enumerator,
+                                    const Cut &cut) const override {
     const auto &network = enumerator.getLogicNetwork();
     // This pattern can implement any cut with at most k inputs
     if (cut.getInputSize() > k || cut.getOutputSize(network) != 1)
       return std::nullopt;
 
-    // Create pattern cost with a reference to cached delays.
-    return PatternCost(
+    // Create pattern match with a reference to cached delays.
+    return PatternMatch(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));
   }
 

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -47,9 +47,11 @@ struct GenericLUT : public CutRewritePattern {
   GenericLUT(mlir::MLIRContext *context, unsigned k)
       : CutRewritePattern(context), k(k), cachedDelays(k, 1) {}
 
-  std::optional<PatternMatch> match(CutEnumerator &enumerator,
-                                    const Cut &cut) const override {
+  std::optional<PatternMatch>
+  match(CutEnumerator &enumerator, const Cut &cut,
+        const MatchBinding &binding) const override {
     const auto &network = enumerator.getLogicNetwork();
+    (void)binding;
     // This pattern can implement any cut with at most k inputs
     if (cut.getInputSize() > k || cut.getOutputSize(network) != 1)
       return std::nullopt;

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -47,12 +47,10 @@ struct GenericLUT : public CutRewritePattern {
   GenericLUT(mlir::MLIRContext *context, unsigned k)
       : CutRewritePattern(context), k(k), cachedDelays(k, 1) {}
 
-  std::optional<MatchResult>
-  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
-        ArrayRef<DelayType> inputArrivalTimes) const override {
+  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
+                                   const MatchBinding &binding) const override {
     const auto &network = enumerator.getLogicNetwork();
     (void)binding;
-    (void)inputArrivalTimes;
     // This pattern can implement any cut with at most k inputs
     if (cut.getInputSize() > k || cut.getOutputSize(network) != 1)
       return std::nullopt;

--- a/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/GenericLUTMapper.cpp
@@ -123,6 +123,9 @@ struct GenericLUTMapperPass
     options.maxCutSizePerRoot = maxCutsPerRoot;
     options.allowNoMatch = false;
     options.attachDebugTiming = test;
+    options.additionalCutRankings.push_back({compareCutsByAreaFlow, 1});
+    options.additionalCutRankings.push_back(
+        {compareCutsByArea, static_cast<unsigned>(maxCutsPerRoot)});
 
     // Create the pattern for generic K-LUT
     SmallVector<std::unique_ptr<CutRewritePattern>, 4> patterns;

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -196,8 +196,8 @@ buildSOPImplementation(const SOPForm &sop,
 struct SOPBalancingPattern : public CutRewritePattern {
   SOPBalancingPattern(MLIRContext *context) : CutRewritePattern(context) {}
 
-  std::optional<PatternCost> match(CutEnumerator &enumerator,
-                                   const Cut &cut) const override {
+  std::optional<PatternMatch> match(CutEnumerator &enumerator,
+                                    const Cut &cut) const override {
     const auto &network = enumerator.getLogicNetwork();
     if (cut.isTrivialCut() || cut.getOutputSize(network) != 1)
       return std::nullopt;
@@ -221,11 +221,11 @@ struct SOPBalancingPattern : public CutRewritePattern {
 
     auto implementation = buildSOPImplementation(sop, arrivalTimes);
 
-    PatternCost cost;
-    cost.area = static_cast<double>(totalGates);
-    cost.setDelayRef(implementation->delays);
-    cost.setImplementation(std::move(implementation));
-    return cost;
+    PatternMatch match;
+    match.area = static_cast<double>(totalGates);
+    match.setDelayRef(implementation->delays);
+    match.setImplementation(std::move(implementation));
+    return match;
   }
 
   FailureOr<Operation *> rewrite(OpBuilder &builder, CutEnumerator &enumerator,

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -196,9 +196,8 @@ buildSOPImplementation(const SOPForm &sop,
 struct SOPBalancingPattern : public CutRewritePattern {
   SOPBalancingPattern(MLIRContext *context) : CutRewritePattern(context) {}
 
-  std::optional<PatternMatch>
-  match(CutEnumerator &enumerator, const Cut &cut,
-        const MatchBinding &binding) const override {
+  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
+                                   const MatchBinding &binding) const override {
     const auto &network = enumerator.getLogicNetwork();
     (void)binding;
     if (cut.isTrivialCut() || cut.getOutputSize(network) != 1)
@@ -223,7 +222,7 @@ struct SOPBalancingPattern : public CutRewritePattern {
 
     auto implementation = buildSOPImplementation(sop, arrivalTimes);
 
-    PatternMatch match;
+    MatchResult match;
     match.area = static_cast<double>(totalGates);
     match.setDelayRef(implementation->delays);
     match.setImplementation(std::move(implementation));

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -26,6 +26,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include <array>
 
 #define DEBUG_TYPE "synth-sop-balancing"
 
@@ -85,6 +86,10 @@ struct SOPAndNode {
 
 struct SOPImplementation : PatternImplementation {
   SmallVector<DelayType, expectedISOPInputs> delays;
+  SmallVector<DelayType, expectedISOPInputs> inputArrivalTimes;
+};
+
+struct SOPRewritePlan {
   SmallVector<SOPAndNode, 8> nodes;
   SOPSignal output;
 };
@@ -93,7 +98,7 @@ struct SOPPlanNode {
   DelayType arrivalTime = 0;
   size_t valueNumbering = 0;
   uint64_t usedMask = 0;
-  SmallVector<DelayType, expectedISOPInputs> inputDelays;
+  std::array<DelayType, maxTruthTableInputs> inputDelays = {};
   SOPSignal signal;
 
   SOPPlanNode flipInversion() const {
@@ -108,20 +113,22 @@ struct SOPPlanNode {
   }
 };
 
-static SOPPlanNode combineSOPPlanNodes(const SOPPlanNode &lhs,
-                                       const SOPPlanNode &rhs, unsigned numVars,
-                                       size_t &valueNumbering,
-                                       SOPImplementation &implementation) {
+static SOPPlanNode
+combineSOPPlanNodes(const SOPPlanNode &lhs, const SOPPlanNode &rhs,
+                    unsigned numVars, size_t &valueNumbering,
+                    SmallVectorImpl<SOPAndNode> *implementationNodes) {
   SOPPlanNode result;
   result.arrivalTime = std::max(lhs.arrivalTime, rhs.arrivalTime) + 1;
   result.valueNumbering = valueNumbering++;
   result.usedMask = lhs.usedMask | rhs.usedMask;
-  result.inputDelays.assign(numVars, 0);
+  result.inputDelays.fill(0);
 
-  implementation.nodes.push_back({lhs.signal, rhs.signal});
-  result.signal =
-      SOPSignal{static_cast<unsigned>(implementation.nodes.size() - 1),
-                /*isInput=*/false, /*inverted=*/false};
+  if (implementationNodes) {
+    implementationNodes->push_back({lhs.signal, rhs.signal});
+    result.signal =
+        SOPSignal{static_cast<unsigned>(implementationNodes->size() - 1),
+                  /*isInput=*/false, /*inverted=*/false};
+  }
 
   auto accumulateDelays = [&](const SOPPlanNode &source) {
     for (unsigned i = 0; i < numVars; ++i) {
@@ -136,10 +143,20 @@ static SOPPlanNode combineSOPPlanNodes(const SOPPlanNode &lhs,
   return result;
 }
 
-static std::shared_ptr<SOPImplementation>
-buildSOPImplementation(const SOPForm &sop,
-                       ArrayRef<DelayType> inputArrivalTimes) {
-  auto implementation = std::make_shared<SOPImplementation>();
+static unsigned getSOPArea(const SOPForm &sop) {
+  unsigned totalGates = 0;
+  for (const auto &cube : sop.cubes)
+    if (cube.size() > 1)
+      totalGates += cube.size() - 1;
+  if (sop.cubes.size() > 1)
+    totalGates += sop.cubes.size() - 1;
+  return totalGates;
+}
+
+static SOPPlanNode
+buildSOPTree(const SOPForm &sop, ArrayRef<DelayType> inputArrivalTimes,
+             bool outputInverted,
+             SmallVectorImpl<SOPAndNode> *implementationNodes) {
   SmallVector<SOPPlanNode, expectedISOPInputs> productTerms, literals;
   size_t valueNumbering = 0;
 
@@ -150,7 +167,7 @@ buildSOPImplementation(const SOPForm &sop,
         literal.arrivalTime = inputArrivalTimes[i];
         literal.valueNumbering = valueNumbering++;
         literal.usedMask = uint64_t{1} << i;
-        literal.inputDelays.assign(sop.numVars, 0);
+        literal.inputDelays.fill(0);
         literal.signal =
             SOPSignal{i, /*isInput=*/true, cube.isLiteralInverted(i)};
         literals.push_back(std::move(literal));
@@ -158,11 +175,11 @@ buildSOPImplementation(const SOPForm &sop,
 
     if (!literals.empty()) {
       productTerms.push_back(
-          buildBalancedTreeWithArrivalTimes<SOPPlanNode>(
+          buildBalancedTreeWithArrivalTimes<SOPPlanNode, expectedISOPInputs>(
               literals,
               [&](const SOPPlanNode &lhs, const SOPPlanNode &rhs) {
                 return combineSOPPlanNodes(lhs, rhs, sop.numVars,
-                                           valueNumbering, *implementation);
+                                           valueNumbering, implementationNodes);
               })
               .flipInversion());
       literals.clear();
@@ -171,21 +188,37 @@ buildSOPImplementation(const SOPForm &sop,
 
   assert(!productTerms.empty() && "No product terms");
   auto output =
-      buildBalancedTreeWithArrivalTimes<SOPPlanNode>(
+      buildBalancedTreeWithArrivalTimes<SOPPlanNode, expectedISOPInputs>(
           productTerms,
           [&](const SOPPlanNode &lhs, const SOPPlanNode &rhs) {
             return combineSOPPlanNodes(lhs, rhs, sop.numVars, valueNumbering,
-                                       *implementation);
+                                       implementationNodes);
           })
           .flipInversion();
-  implementation->output = output.signal;
+  if (outputInverted)
+    output = output.flipInversion();
+  return output;
+}
 
-  implementation->delays.assign(sop.numVars, 0);
+static SmallVector<DelayType, expectedISOPInputs>
+computeSOPDelays(const SOPForm &sop, ArrayRef<DelayType> inputArrivalTimes,
+                 bool outputInverted) {
+  auto output = buildSOPTree(sop, inputArrivalTimes, outputInverted, nullptr);
+  SmallVector<DelayType, expectedISOPInputs> delays(sop.numVars, 0);
   for (unsigned i = 0; i < sop.numVars; ++i)
     if (output.usedMask & (uint64_t{1} << i))
-      implementation->delays[i] = output.inputDelays[i];
+      delays[i] = output.inputDelays[i];
+  return delays;
+}
 
-  return implementation;
+static SOPRewritePlan buildSOPRewritePlan(const SOPForm &sop,
+                                          ArrayRef<DelayType> inputArrivalTimes,
+                                          bool outputInverted) {
+  SOPRewritePlan plan;
+  auto output =
+      buildSOPTree(sop, inputArrivalTimes, outputInverted, &plan.nodes);
+  plan.output = output.signal;
+  return plan;
 }
 
 //===----------------------------------------------------------------------===//
@@ -194,36 +227,37 @@ buildSOPImplementation(const SOPForm &sop,
 
 /// Pattern that performs SOP balancing on cuts.
 struct SOPBalancingPattern : public CutRewritePattern {
-  SOPBalancingPattern(MLIRContext *context) : CutRewritePattern(context) {}
+  SOPBalancingPattern(MLIRContext *context, SOPCache &sopCache,
+                      bool outputInverted)
+      : CutRewritePattern(context), sopCache(sopCache),
+        outputInverted(outputInverted) {}
 
-  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
-                                   const MatchBinding &binding) const override {
+  std::optional<MatchResult>
+  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
+        ArrayRef<DelayType> inputArrivalTimes) const override {
     const auto &network = enumerator.getLogicNetwork();
     (void)binding;
     if (cut.isTrivialCut() || cut.getOutputSize(network) != 1)
       return std::nullopt;
 
     const auto &tt = *cut.getTruthTable();
-    const SOPForm &sop = sopCache.getOrCompute(tt.table, tt.numInputs);
+    APInt truthTable = outputInverted ? ~tt.table : tt.table;
+    const SOPForm &sop = sopCache.getOrCompute(truthTable, tt.numInputs);
     if (sop.cubes.empty())
       return std::nullopt;
 
-    SmallVector<DelayType, expectedISOPInputs> arrivalTimes;
-    if (failed(cut.getInputArrivalTimes(enumerator, arrivalTimes)))
+    // Constants should already be handled by cheaper trivial cuts.
+    if (llvm::any_of(sop.cubes,
+                     [](const Cube &cube) { return cube.size() == 0; }))
       return std::nullopt;
 
-    // Compute area estimate
-    unsigned totalGates = 0;
-    for (const auto &cube : sop.cubes)
-      if (cube.size() > 1)
-        totalGates += cube.size() - 1;
-    if (sop.cubes.size() > 1)
-      totalGates += sop.cubes.size() - 1;
-
-    auto implementation = buildSOPImplementation(sop, arrivalTimes);
+    auto implementation = std::make_shared<SOPImplementation>();
+    implementation->delays =
+        computeSOPDelays(sop, inputArrivalTimes, outputInverted);
+    implementation->inputArrivalTimes.assign(inputArrivalTimes);
 
     MatchResult match;
-    match.area = static_cast<double>(totalGates);
+    match.area = static_cast<double>(getSOPArea(sop));
     match.setDelayRef(implementation->delays);
     match.setImplementation(std::move(implementation));
     return match;
@@ -234,7 +268,8 @@ struct SOPBalancingPattern : public CutRewritePattern {
                                  const MatchedPattern &matched) const override {
     const auto &network = enumerator.getLogicNetwork();
     const auto &tt = *cut.getTruthTable();
-    const SOPForm &sop = sopCache.getOrCompute(tt.table, tt.numInputs);
+    APInt truthTable = outputInverted ? ~tt.table : tt.table;
+    const SOPForm &sop = sopCache.getOrCompute(truthTable, tt.numInputs);
     LLVM_DEBUG({
       llvm::dbgs() << "Rewriting SOP:\n";
       sop.dump(llvm::dbgs());
@@ -244,6 +279,8 @@ struct SOPBalancingPattern : public CutRewritePattern {
         static_cast<const SOPImplementation *>(matched.getImplementation());
     if (!implementation)
       return failure();
+    SOPRewritePlan plan = buildSOPRewritePlan(
+        sop, implementation->inputArrivalTimes, outputInverted);
 
     // Construct the fused location.
     SetVector<Location> inputLocs;
@@ -259,21 +296,21 @@ struct SOPBalancingPattern : public CutRewritePattern {
     auto loc = builder.getFusedLoc(inputLocs.getArrayRef());
 
     SmallVector<Value> nodeValues;
-    nodeValues.reserve(implementation->nodes.size());
+    nodeValues.reserve(plan.nodes.size());
     auto resolveSignal = [&](const SOPSignal &signal) -> Value {
       return signal.isInput ? inputValues[signal.index]
                             : nodeValues[signal.index];
     };
 
-    for (const auto &node : implementation->nodes) {
+    for (const auto &node : plan.nodes) {
       Value lhs = resolveSignal(node.lhs);
       Value rhs = resolveSignal(node.rhs);
       nodeValues.push_back(aig::AndInverterOp::create(
           builder, loc, lhs, rhs, node.lhs.inverted, node.rhs.inverted));
     }
 
-    Value result = resolveSignal(implementation->output);
-    if (implementation->output.inverted)
+    Value result = resolveSignal(plan.output);
+    if (plan.output.inverted)
       result = aig::AndInverterOp::create(builder, loc, result, true);
 
     auto *op = result.getDefiningOp();
@@ -283,12 +320,13 @@ struct SOPBalancingPattern : public CutRewritePattern {
   }
 
   unsigned getNumOutputs() const override { return 1; }
-  StringRef getPatternName() const override { return "sop-balancing"; }
+  StringRef getPatternName() const override {
+    return outputInverted ? "sop-balancing-inverted-output" : "sop-balancing";
+  }
 
 private:
-  // Cache for SOP extraction results. Hence the pattern is stateful and must
-  // not be used in parallelly.
-  mutable SOPCache sopCache;
+  SOPCache &sopCache;
+  bool outputInverted = false;
 };
 
 } // namespace
@@ -310,9 +348,12 @@ struct SOPBalancingPass
     options.maxCutSizePerRoot = maxCutsPerRoot;
     options.allowNoMatch = true;
 
-    SmallVector<std::unique_ptr<CutRewritePattern>, 1> patterns;
-    patterns.push_back(
-        std::make_unique<SOPBalancingPattern>(module->getContext()));
+    SOPCache sopCache;
+    SmallVector<std::unique_ptr<CutRewritePattern>, 2> patterns;
+    patterns.push_back(std::make_unique<SOPBalancingPattern>(
+        module->getContext(), sopCache, /*outputInverted=*/false));
+    patterns.push_back(std::make_unique<SOPBalancingPattern>(
+        module->getContext(), sopCache, /*outputInverted=*/true));
 
     CutRewritePatternSet patternSet(std::move(patterns));
     CutRewriter rewriter(options, patternSet);

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -196,9 +196,11 @@ buildSOPImplementation(const SOPForm &sop,
 struct SOPBalancingPattern : public CutRewritePattern {
   SOPBalancingPattern(MLIRContext *context) : CutRewritePattern(context) {}
 
-  std::optional<PatternMatch> match(CutEnumerator &enumerator,
-                                    const Cut &cut) const override {
+  std::optional<PatternMatch>
+  match(CutEnumerator &enumerator, const Cut &cut,
+        const MatchBinding &binding) const override {
     const auto &network = enumerator.getLogicNetwork();
+    (void)binding;
     if (cut.isTrivialCut() || cut.getOutputSize(network) != 1)
       return std::nullopt;
 

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -232,9 +232,8 @@ struct SOPBalancingPattern : public CutRewritePattern {
       : CutRewritePattern(context), sopCache(sopCache),
         outputInverted(outputInverted) {}
 
-  std::optional<MatchResult>
-  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
-        ArrayRef<DelayType> inputArrivalTimes) const override {
+  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
+                                   const MatchBinding &binding) const override {
     const auto &network = enumerator.getLogicNetwork();
     (void)binding;
     if (cut.isTrivialCut() || cut.getOutputSize(network) != 1)
@@ -249,6 +248,10 @@ struct SOPBalancingPattern : public CutRewritePattern {
     // Constants should already be handled by cheaper trivial cuts.
     if (llvm::any_of(sop.cubes,
                      [](const Cube &cube) { return cube.size() == 0; }))
+      return std::nullopt;
+
+    SmallVector<DelayType, expectedISOPInputs> inputArrivalTimes;
+    if (failed(cut.getInputArrivalTimes(enumerator, inputArrivalTimes)))
       return std::nullopt;
 
     auto implementation = std::make_shared<SOPImplementation>();

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -182,7 +182,7 @@ void computeSOPDelays(const SOPForm &sop, ArrayRef<DelayType> inputArrivalTimes,
 struct SOPBalancingPattern : public CutRewritePattern {
   SOPBalancingPattern(MLIRContext *context) : CutRewritePattern(context) {}
 
-  std::optional<MatchResult> match(CutEnumerator &enumerator,
+  std::optional<PatternCost> match(CutEnumerator &enumerator,
                                    const Cut &cut) const override {
     const auto &network = enumerator.getLogicNetwork();
     if (cut.isTrivialCut() || cut.getOutputSize(network) != 1)
@@ -208,10 +208,10 @@ struct SOPBalancingPattern : public CutRewritePattern {
     SmallVector<DelayType, expectedISOPInputs> delays;
     computeSOPDelays(sop, arrivalTimes, delays);
 
-    MatchResult result;
-    result.area = static_cast<double>(totalGates);
-    result.setOwnedDelays(std::move(delays));
-    return result;
+    PatternCost cost;
+    cost.area = static_cast<double>(totalGates);
+    cost.setOwnedDelays(std::move(delays));
+    return cost;
   }
 
   FailureOr<Operation *> rewrite(OpBuilder &builder, CutEnumerator &enumerator,

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -72,106 +72,120 @@ private:
 // Tree Building Helpers
 //===----------------------------------------------------------------------===//
 
-/// Simulate balanced tree and return output arrival time.
-static DelayType simulateBalancedTree(ArrayRef<DelayType> arrivalTimes) {
-  if (arrivalTimes.empty())
-    return 0;
-  return buildBalancedTreeWithArrivalTimes<DelayType>(
-      arrivalTimes, [](auto a, auto b) { return std::max(a, b) + 1; });
-}
+struct SOPSignal {
+  unsigned index = 0;
+  bool isInput = true;
+  bool inverted = false;
+};
 
-/// Build balanced AND tree.
-ValueWithArrivalTime
-buildBalancedAndTree(OpBuilder &builder, Location loc,
-                     SmallVectorImpl<ValueWithArrivalTime> &nodes,
-                     size_t &valueNumbering) {
-  assert(!nodes.empty());
+struct SOPAndNode {
+  SOPSignal lhs;
+  SOPSignal rhs;
+};
 
-  if (nodes.size() == 1)
-    return nodes[0];
+struct SOPImplementation : PatternImplementation {
+  SmallVector<DelayType, expectedISOPInputs> delays;
+  SmallVector<SOPAndNode, 8> nodes;
+  SOPSignal output;
+};
 
-  auto result = buildBalancedTreeWithArrivalTimes<ValueWithArrivalTime>(
-      nodes, [&](const auto &n1, const auto &n2) {
-        Value v = aig::AndInverterOp::create(builder, loc, n1.getValue(),
-                                             n2.getValue(), n1.isInverted(),
-                                             n2.isInverted());
-        return ValueWithArrivalTime(
-            v, std::max(n1.getArrivalTime(), n2.getArrivalTime()) + 1, false,
-            valueNumbering++);
-      });
+struct SOPPlanNode {
+  DelayType arrivalTime = 0;
+  size_t valueNumbering = 0;
+  uint64_t usedMask = 0;
+  SmallVector<DelayType, expectedISOPInputs> inputDelays;
+  SOPSignal signal;
+
+  SOPPlanNode flipInversion() const {
+    SOPPlanNode result = *this;
+    result.signal.inverted = !result.signal.inverted;
+    return result;
+  }
+
+  bool operator>(const SOPPlanNode &other) const {
+    return std::tie(arrivalTime, valueNumbering) >
+           std::tie(other.arrivalTime, other.valueNumbering);
+  }
+};
+
+static SOPPlanNode combineSOPPlanNodes(const SOPPlanNode &lhs,
+                                       const SOPPlanNode &rhs, unsigned numVars,
+                                       size_t &valueNumbering,
+                                       SOPImplementation &implementation) {
+  SOPPlanNode result;
+  result.arrivalTime = std::max(lhs.arrivalTime, rhs.arrivalTime) + 1;
+  result.valueNumbering = valueNumbering++;
+  result.usedMask = lhs.usedMask | rhs.usedMask;
+  result.inputDelays.assign(numVars, 0);
+
+  implementation.nodes.push_back({lhs.signal, rhs.signal});
+  result.signal =
+      SOPSignal{static_cast<unsigned>(implementation.nodes.size() - 1),
+                /*isInput=*/false, /*inverted=*/false};
+
+  auto accumulateDelays = [&](const SOPPlanNode &source) {
+    for (unsigned i = 0; i < numVars; ++i) {
+      if (!(source.usedMask & (uint64_t{1} << i)))
+        continue;
+      result.inputDelays[i] =
+          std::max(result.inputDelays[i], source.inputDelays[i] + 1);
+    }
+  };
+  accumulateDelays(lhs);
+  accumulateDelays(rhs);
   return result;
 }
 
-/// Build balanced SOP structure.
-Value buildBalancedSOP(OpBuilder &builder, Location loc, const SOPForm &sop,
-                       ArrayRef<Value> inputs,
+static std::shared_ptr<SOPImplementation>
+buildSOPImplementation(const SOPForm &sop,
                        ArrayRef<DelayType> inputArrivalTimes) {
-  SmallVector<ValueWithArrivalTime, expectedISOPInputs> productTerms, literals;
+  auto implementation = std::make_shared<SOPImplementation>();
+  SmallVector<SOPPlanNode, expectedISOPInputs> productTerms, literals;
   size_t valueNumbering = 0;
 
   for (const auto &cube : sop.cubes) {
     for (unsigned i = 0; i < sop.numVars; ++i)
-      if (cube.hasLiteral(i))
-        literals.push_back(ValueWithArrivalTime(
-            inputs[i], inputArrivalTimes[i], cube.isLiteralInverted(i),
-            /*valueNumbering=*/valueNumbering++));
+      if (cube.hasLiteral(i)) {
+        SOPPlanNode literal;
+        literal.arrivalTime = inputArrivalTimes[i];
+        literal.valueNumbering = valueNumbering++;
+        literal.usedMask = uint64_t{1} << i;
+        literal.inputDelays.assign(sop.numVars, 0);
+        literal.signal =
+            SOPSignal{i, /*isInput=*/true, cube.isLiteralInverted(i)};
+        literals.push_back(std::move(literal));
+      }
 
-    if (literals.empty())
-      continue;
-
-    // Get product term, and flip the inversion to construct OR afterwards.
-    productTerms.push_back(
-        buildBalancedAndTree(builder, loc, literals, valueNumbering)
-            .flipInversion());
-
-    literals.clear();
-  }
-
-  assert(!productTerms.empty() && "No product terms");
-
-  auto andOfInverted =
-      buildBalancedAndTree(builder, loc, productTerms, valueNumbering)
-          .flipInversion();
-  // Let's invert the output.
-  if (andOfInverted.isInverted())
-    return aig::AndInverterOp::create(builder, loc, andOfInverted.getValue(),
-                                      true);
-  return andOfInverted.getValue();
-}
-
-/// Compute SOP delays for cost estimation.
-void computeSOPDelays(const SOPForm &sop, ArrayRef<DelayType> inputArrivalTimes,
-                      SmallVectorImpl<DelayType> &delays) {
-  SmallVector<DelayType, expectedISOPInputs> productArrivalTimes, literalTimes;
-  for (const auto &cube : sop.cubes) {
-    for (unsigned i = 0; i < sop.numVars; ++i)
-      // No need to consider inverted literals separately for delay.
-      if (cube.hasLiteral(i))
-        literalTimes.push_back(inputArrivalTimes[i]);
-    if (!literalTimes.empty()) {
-      productArrivalTimes.push_back(simulateBalancedTree(literalTimes));
-      literalTimes.clear();
+    if (!literals.empty()) {
+      productTerms.push_back(
+          buildBalancedTreeWithArrivalTimes<SOPPlanNode>(
+              literals,
+              [&](const SOPPlanNode &lhs, const SOPPlanNode &rhs) {
+                return combineSOPPlanNodes(lhs, rhs, sop.numVars,
+                                           valueNumbering, *implementation);
+              })
+              .flipInversion());
+      literals.clear();
     }
   }
 
-  DelayType outputTime = simulateBalancedTree(productArrivalTimes);
+  assert(!productTerms.empty() && "No product terms");
+  auto output =
+      buildBalancedTreeWithArrivalTimes<SOPPlanNode>(
+          productTerms,
+          [&](const SOPPlanNode &lhs, const SOPPlanNode &rhs) {
+            return combineSOPPlanNodes(lhs, rhs, sop.numVars, valueNumbering,
+                                       *implementation);
+          })
+          .flipInversion();
+  implementation->output = output.signal;
 
-  delays.resize(sop.numVars, 0);
-  // Compute the delay contribution of each input to the output for cost
-  // estimation. The CutRewriter framework requires per-input delays, even
-  // though this is somewhat artificial for SOP balancing. This may be
-  // improved in future framework improvements.
-  //
-  // First, determine which variables are actually used in the SOP by
-  // collecting a bitmask from all cubes.
-  uint64_t mask = 0;
-  for (auto &cube : sop.cubes)
-    mask |= cube.mask;
-
-  // Compute delay for each used input variable.
+  implementation->delays.assign(sop.numVars, 0);
   for (unsigned i = 0; i < sop.numVars; ++i)
-    if (mask & (1u << i))
-      delays[i] = outputTime - inputArrivalTimes[i];
+    if (output.usedMask & (uint64_t{1} << i))
+      implementation->delays[i] = output.inputDelays[i];
+
+  return implementation;
 }
 
 //===----------------------------------------------------------------------===//
@@ -205,17 +219,18 @@ struct SOPBalancingPattern : public CutRewritePattern {
     if (sop.cubes.size() > 1)
       totalGates += sop.cubes.size() - 1;
 
-    SmallVector<DelayType, expectedISOPInputs> delays;
-    computeSOPDelays(sop, arrivalTimes, delays);
+    auto implementation = buildSOPImplementation(sop, arrivalTimes);
 
     PatternCost cost;
     cost.area = static_cast<double>(totalGates);
-    cost.setOwnedDelays(std::move(delays));
+    cost.setDelayRef(implementation->delays);
+    cost.setImplementation(std::move(implementation));
     return cost;
   }
 
   FailureOr<Operation *> rewrite(OpBuilder &builder, CutEnumerator &enumerator,
-                                 const Cut &cut) const override {
+                                 const Cut &cut,
+                                 const MatchedPattern &matched) const override {
     const auto &network = enumerator.getLogicNetwork();
     const auto &tt = *cut.getTruthTable();
     const SOPForm &sop = sopCache.getOrCompute(tt.table, tt.numInputs);
@@ -224,8 +239,9 @@ struct SOPBalancingPattern : public CutRewritePattern {
       sop.dump(llvm::dbgs());
     });
 
-    SmallVector<DelayType, expectedISOPInputs> arrivalTimes;
-    if (failed(cut.getInputArrivalTimes(enumerator, arrivalTimes)))
+    auto *implementation =
+        static_cast<const SOPImplementation *>(matched.getImplementation());
+    if (!implementation)
       return failure();
 
     // Construct the fused location.
@@ -241,8 +257,23 @@ struct SOPBalancingPattern : public CutRewritePattern {
 
     auto loc = builder.getFusedLoc(inputLocs.getArrayRef());
 
-    Value result =
-        buildBalancedSOP(builder, loc, sop, inputValues, arrivalTimes);
+    SmallVector<Value> nodeValues;
+    nodeValues.reserve(implementation->nodes.size());
+    auto resolveSignal = [&](const SOPSignal &signal) -> Value {
+      return signal.isInput ? inputValues[signal.index]
+                            : nodeValues[signal.index];
+    };
+
+    for (const auto &node : implementation->nodes) {
+      Value lhs = resolveSignal(node.lhs);
+      Value rhs = resolveSignal(node.rhs);
+      nodeValues.push_back(aig::AndInverterOp::create(
+          builder, loc, lhs, rhs, node.lhs.inverted, node.rhs.inverted));
+    }
+
+    Value result = resolveSignal(implementation->output);
+    if (implementation->output.inverted)
+      result = aig::AndInverterOp::create(builder, loc, result, true);
 
     auto *op = result.getDefiningOp();
     if (!op)

--- a/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
+++ b/lib/Dialect/Synth/Transforms/SOPBalancing.cpp
@@ -350,6 +350,8 @@ struct SOPBalancingPass
     options.maxCutInputSize = maxCutInputSize;
     options.maxCutSizePerRoot = maxCutsPerRoot;
     options.allowNoMatch = true;
+    options.additionalCutRankings.push_back({compareCutsByAreaFlow, 1});
+    options.additionalCutRankings.push_back({compareCutsByArea, 1});
 
     SOPCache sopCache;
     SmallVector<std::unique_ptr<CutRewritePattern>, 2> patterns;

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -112,10 +112,16 @@ struct TechLibraryPattern : public CutRewritePattern {
   }
 
   /// Match the cut set against this library primitive
-  std::optional<PatternMatch> match(CutEnumerator &enumerator,
-                                    const Cut &cut) const override {
+  std::optional<PatternMatch>
+  match(CutEnumerator &enumerator, const Cut &cut,
+        const MatchBinding &binding) const override {
     const auto &cutNPN = cut.getNPNClass(enumerator.getOptions().npnTable);
     if (!(cutNPN.truthTable == npnClass.truthTable))
+      return std::nullopt;
+
+    // TODO: Support phase-aware mapping by materializing or reusing inverted
+    // input/output values from the binding.
+    if (binding.hasNegation())
       return std::nullopt;
 
     return PatternMatch(area, delay);

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -112,8 +112,10 @@ struct TechLibraryPattern : public CutRewritePattern {
   }
 
   /// Match the cut set against this library primitive
-  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
-                                   const MatchBinding &binding) const override {
+  std::optional<MatchResult>
+  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
+        ArrayRef<DelayType> inputArrivalTimes) const override {
+    (void)inputArrivalTimes;
     const auto &cutNPN = cut.getNPNClass(enumerator.getOptions().npnTable);
     if (!(cutNPN.truthTable == npnClass.truthTable))
       return std::nullopt;

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -129,13 +129,11 @@ struct TechLibraryPattern : public CutRewritePattern {
   }
 
   /// Rewrite the cut set using this library primitive
-  llvm::FailureOr<Operation *> rewrite(mlir::OpBuilder &builder,
-                                       CutEnumerator &enumerator,
-                                       const Cut &cut) const override {
+  llvm::FailureOr<Operation *>
+  rewrite(mlir::OpBuilder &builder, CutEnumerator &enumerator, const Cut &cut,
+          const MatchedPattern &matched) const override {
     const auto &network = enumerator.getLogicNetwork();
-    const auto &matchedPattern = cut.getMatchedPattern();
-    assert(matchedPattern && "tech library rewrite requires a matched pattern");
-    const MatchBinding &binding = matchedPattern->getBinding();
+    const MatchBinding &binding = matched.getBinding();
     assert(!binding.hasNegation() &&
            "phase-aware tech mapping is not implemented yet");
 

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -112,10 +112,8 @@ struct TechLibraryPattern : public CutRewritePattern {
   }
 
   /// Match the cut set against this library primitive
-  std::optional<MatchResult>
-  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
-        ArrayRef<DelayType> inputArrivalTimes) const override {
-    (void)inputArrivalTimes;
+  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
+                                   const MatchBinding &binding) const override {
     const auto &cutNPN = cut.getNPNClass(enumerator.getOptions().npnTable);
     if (!(cutNPN.truthTable == npnClass.truthTable))
       return std::nullopt;

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -112,13 +112,13 @@ struct TechLibraryPattern : public CutRewritePattern {
   }
 
   /// Match the cut set against this library primitive
-  std::optional<PatternCost> match(CutEnumerator &enumerator,
-                                   const Cut &cut) const override {
+  std::optional<PatternMatch> match(CutEnumerator &enumerator,
+                                    const Cut &cut) const override {
     const auto &cutNPN = cut.getNPNClass(enumerator.getOptions().npnTable);
     if (!(cutNPN.truthTable == npnClass.truthTable))
       return std::nullopt;
 
-    return PatternCost(area, delay);
+    return PatternMatch(area, delay);
   }
 
   /// Enable truth table matching for this pattern

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -112,9 +112,8 @@ struct TechLibraryPattern : public CutRewritePattern {
   }
 
   /// Match the cut set against this library primitive
-  std::optional<PatternMatch>
-  match(CutEnumerator &enumerator, const Cut &cut,
-        const MatchBinding &binding) const override {
+  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
+                                   const MatchBinding &binding) const override {
     const auto &cutNPN = cut.getNPNClass(enumerator.getOptions().npnTable);
     if (!(cutNPN.truthTable == npnClass.truthTable))
       return std::nullopt;
@@ -124,7 +123,7 @@ struct TechLibraryPattern : public CutRewritePattern {
     if (binding.hasNegation())
       return std::nullopt;
 
-    return PatternMatch(area, delay);
+    return MatchResult(area, delay);
   }
 
   /// Enable truth table matching for this pattern

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -112,13 +112,13 @@ struct TechLibraryPattern : public CutRewritePattern {
   }
 
   /// Match the cut set against this library primitive
-  std::optional<MatchResult> match(CutEnumerator &enumerator,
+  std::optional<PatternCost> match(CutEnumerator &enumerator,
                                    const Cut &cut) const override {
-    if (!cut.getNPNClass(enumerator.getOptions().npnTable)
-             .equivalentOtherThanPermutation(npnClass))
+    const auto &cutNPN = cut.getNPNClass(enumerator.getOptions().npnTable);
+    if (!(cutNPN.truthTable == npnClass.truthTable))
       return std::nullopt;
 
-    return MatchResult(area, delay);
+    return PatternCost(area, delay);
   }
 
   /// Enable truth table matching for this pattern
@@ -133,14 +133,17 @@ struct TechLibraryPattern : public CutRewritePattern {
                                        CutEnumerator &enumerator,
                                        const Cut &cut) const override {
     const auto &network = enumerator.getLogicNetwork();
-    // Create a new instance of the module
-    SmallVector<unsigned> permutedInputIndices;
-    cut.getPermutatedInputIndices(enumerator.getOptions().npnTable, npnClass,
-                                  permutedInputIndices);
+    const auto &matchedPattern = cut.getMatchedPattern();
+    assert(matchedPattern && "tech library rewrite requires a matched pattern");
+    const MatchBinding &binding = matchedPattern->getBinding();
+    assert(!binding.hasNegation() &&
+           "phase-aware tech mapping is not implemented yet");
 
     SmallVector<Value> inputs;
-    inputs.reserve(permutedInputIndices.size());
-    for (unsigned idx : permutedInputIndices) {
+    unsigned numInputs = binding.getNumInputs();
+    inputs.reserve(numInputs);
+    for (unsigned patternInput = 0; patternInput < numInputs; ++patternInput) {
+      unsigned idx = binding.getCutInputForPatternInput(patternInput);
       assert(idx < cut.inputs.size() && "input permutation index out of range");
       inputs.push_back(network.getValue(cut.inputs[idx]));
     }

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -282,6 +282,8 @@ struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
     options.maxCutSizePerRoot = maxCutsPerRoot;
     options.attachDebugTiming = test;
     options.npnTable = npnTable.get();
+    options.additionalCutRankings.push_back({compareCutsByAreaFlow, 1});
+    options.additionalCutRankings.push_back({compareCutsByArea, 1});
     std::atomic<uint64_t> numCutsCreatedCount = 0;
     std::atomic<uint64_t> numCutSetsCreatedCount = 0;
     std::atomic<uint64_t> numCutsRewrittenCount = 0;

--- a/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
+++ b/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
@@ -44,12 +44,11 @@ struct DummyPattern : public CutRewritePattern {
   DummyPattern(mlir::MLIRContext *ctx)
       : CutRewritePattern(ctx), cachedDelays(kMaxInputs, 1) {}
 
-  std::optional<PatternMatch>
-  match(CutEnumerator &enumerator, const Cut &cut,
-        const MatchBinding &binding) const override {
+  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
+                                   const MatchBinding &binding) const override {
     (void)binding;
     assert(cut.getInputSize() <= kMaxInputs && "Too many inputs");
-    return PatternMatch(
+    return MatchResult(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));
   }
 

--- a/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
+++ b/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
@@ -52,8 +52,8 @@ struct DummyPattern : public CutRewritePattern {
   }
 
   FailureOr<Operation *> rewrite(mlir::OpBuilder &builder,
-                                 CutEnumerator &enumerator,
-                                 const Cut &cut) const override {
+                                 CutEnumerator &enumerator, const Cut &cut,
+                                 const MatchedPattern &) const override {
     return failure();
   }
 

--- a/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
+++ b/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
@@ -44,11 +44,9 @@ struct DummyPattern : public CutRewritePattern {
   DummyPattern(mlir::MLIRContext *ctx)
       : CutRewritePattern(ctx), cachedDelays(kMaxInputs, 1) {}
 
-  std::optional<MatchResult>
-  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
-        ArrayRef<DelayType> inputArrivalTimes) const override {
+  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
+                                   const MatchBinding &binding) const override {
     (void)binding;
-    (void)inputArrivalTimes;
     assert(cut.getInputSize() <= kMaxInputs && "Too many inputs");
     return MatchResult(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));

--- a/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
+++ b/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
@@ -44,10 +44,10 @@ struct DummyPattern : public CutRewritePattern {
   DummyPattern(mlir::MLIRContext *ctx)
       : CutRewritePattern(ctx), cachedDelays(kMaxInputs, 1) {}
 
-  std::optional<PatternCost> match(CutEnumerator &enumerator,
-                                   const Cut &cut) const override {
+  std::optional<PatternMatch> match(CutEnumerator &enumerator,
+                                    const Cut &cut) const override {
     assert(cut.getInputSize() <= kMaxInputs && "Too many inputs");
-    return PatternCost(
+    return PatternMatch(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));
   }
 

--- a/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
+++ b/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
@@ -44,10 +44,10 @@ struct DummyPattern : public CutRewritePattern {
   DummyPattern(mlir::MLIRContext *ctx)
       : CutRewritePattern(ctx), cachedDelays(kMaxInputs, 1) {}
 
-  std::optional<MatchResult> match(CutEnumerator &enumerator,
+  std::optional<PatternCost> match(CutEnumerator &enumerator,
                                    const Cut &cut) const override {
     assert(cut.getInputSize() <= kMaxInputs && "Too many inputs");
-    return MatchResult(
+    return PatternCost(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));
   }
 

--- a/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
+++ b/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
@@ -44,8 +44,10 @@ struct DummyPattern : public CutRewritePattern {
   DummyPattern(mlir::MLIRContext *ctx)
       : CutRewritePattern(ctx), cachedDelays(kMaxInputs, 1) {}
 
-  std::optional<PatternMatch> match(CutEnumerator &enumerator,
-                                    const Cut &cut) const override {
+  std::optional<PatternMatch>
+  match(CutEnumerator &enumerator, const Cut &cut,
+        const MatchBinding &binding) const override {
+    (void)binding;
     assert(cut.getInputSize() <= kMaxInputs && "Too many inputs");
     return PatternMatch(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));

--- a/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
+++ b/lib/Dialect/Synth/Transforms/TestPriorityCuts.cpp
@@ -44,9 +44,11 @@ struct DummyPattern : public CutRewritePattern {
   DummyPattern(mlir::MLIRContext *ctx)
       : CutRewritePattern(ctx), cachedDelays(kMaxInputs, 1) {}
 
-  std::optional<MatchResult> match(CutEnumerator &enumerator, const Cut &cut,
-                                   const MatchBinding &binding) const override {
+  std::optional<MatchResult>
+  match(CutEnumerator &enumerator, const Cut &cut, const MatchBinding &binding,
+        ArrayRef<DelayType> inputArrivalTimes) const override {
     (void)binding;
+    (void)inputArrivalTimes;
     assert(cut.getInputSize() <= kMaxInputs && "Too many inputs");
     return MatchResult(
         1.0, ArrayRef<DelayType>(cachedDelays).take_front(cut.getInputSize()));

--- a/test/Dialect/Synth/lut-mapper.mlir
+++ b/test/Dialect/Synth/lut-mapper.mlir
@@ -1,6 +1,7 @@
 // FIXME: max-cuts-per-root=20 is due to a lack of non-minimal cut filtering.
 // RUN: circt-opt --pass-pipeline='builtin.module(hw.module(synth-generic-lut-mapper{test=true max-cuts-per-root=20}))' %s | FileCheck %s --check-prefixes CHECK,LUT
-// RUN: circt-opt --pass-pipeline='builtin.module(hw.module(synth-generic-lut-mapper{test=true max-lut-size=2}))' %s | FileCheck %s --check-prefixes CHECK,LUT2
+// RUN: circt-opt --pass-pipeline='builtin.module(hw.module(synth-generic-lut-mapper{test=true max-lut-size=2 strategy=timing}))' %s | FileCheck %s --check-prefixes CHECK,LUT2
+// RUN: circt-opt --pass-pipeline='builtin.module(hw.module(synth-generic-lut-mapper{test=true max-lut-size=2 strategy=area}))' %s | FileCheck %s --check-prefixes CHECK,LUT2
 
 // CHECK:      %[[B_0:.+]] = comb.extract %b from 0 : (i2) -> i1
 // CHECK-NEXT: %[[B_1:.+]] = comb.extract %b from 1 : (i2) -> i1
@@ -67,4 +68,20 @@ hw.module @choice_slow_branch(in %a : i1, in %b : i1, in %c : i1,
 
   %choice = synth.choice %slow, %fast : i1
   hw.output %choice : i1
+}
+
+// CHECK-LABEL: hw.module @choice_shared_area_flow
+// LUT2-NEXT: %[[AB:.+]] = comb.truth_table %b, %a -> [false, false, false, true]
+// LUT2-SAME: test.arrival_times = [1]
+// LUT2-NEXT: %[[OUT:.+]] = comb.truth_table %[[AB]], %c -> [false, false, false, true]
+// LUT2-SAME: test.arrival_times = [2]
+// LUT2-NEXT: hw.output %[[AB]], %[[OUT]] : i1, i1
+hw.module @choice_shared_area_flow(in %a : i1, in %b : i1, in %c : i1,
+                                   out share : i1, out y : i1) {
+  %ab = synth.aig.and_inv %a, %b : i1
+  %left = synth.aig.and_inv %ab, %c : i1
+  %bc = synth.aig.and_inv %b, %c : i1
+  %right = synth.aig.and_inv %a, %bc : i1
+  %choice = synth.choice %right, %left : i1
+  hw.output %ab, %choice : i1, i1
 }

--- a/test/Dialect/Synth/priority-cuts.mlir
+++ b/test/Dialect/Synth/priority-cuts.mlir
@@ -54,12 +54,12 @@ hw.module @test(in %a : i4, in %b : i2, out result : i3) {
     // ROOT8-NEXT: out0 3 cuts: {out0}@t2d0 {a0, a1, b0}@t128d1 {b0, and0}@t8d2
     // ROOT8-NEXT: out1 5 cuts: {out1}@t2d0 {a0, a1, a2, b0}@t112d1 {and0, and1}@t4d2 {a0, a1, and1}@t112d2 {a2, b0, and0}@t2d2
     // ROOT8-NEXT: out2 3 cuts: {out2}@t2d0 {a3, b1}@t8d1 {b1, and2}@t8d2
-    // Check that the cuts are correctly limited when max-cuts-per-root is set to 2.
-    // Currently (depth, input size) is used as the cut priority.
+    // max-cuts-per-root=2 retains two non-trivial cuts in addition to the
+    // trivial cut. Currently (depth, input size) is used as the cut priority.
     // ROOT2-NEXT: and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
-    // ROOT2-NEXT: out0 2 cuts: {out0}@t2d0 {a0, a1, b0}@t128d1
-    // ROOT2-NEXT: out1 2 cuts: {out1}@t2d0 {a0, a1, a2, b0}@t112d1
-    // ROOT2-NEXT: out2 2 cuts: {out2}@t2d0 {a3, b1}@t8d1
+    // ROOT2-NEXT: out0 3 cuts: {out0}@t2d0 {a0, a1, b0}@t128d1 {b0, and0}@t8d2
+    // ROOT2-NEXT: out1 3 cuts: {out1}@t2d0 {a0, a1, a2, b0}@t112d1 {and0, and1}@t4d2
+    // ROOT2-NEXT: out2 3 cuts: {out2}@t2d0 {a3, b1}@t8d1 {b1, and2}@t8d2
     // INPUT2:    and2 2 cuts: {and2}@t2d0 {a3, b1}@t8d1
     // INPUT2-NEXT: out0 2 cuts: {out0}@t2d0 {b0, and0}@t8d2
     // INPUT2-NEXT: out1 2 cuts: {out1}@t2d0 {and0, and1}@t4d2
@@ -110,9 +110,10 @@ hw.module @hw_constant(in %a : i1, out out0 : i1, out out1 : i1) {
 // ROOT8-SAME: {xor0}
 // ROOT8-SAME: {b_0, a_0}
 // ROOT8-SAME: {and0, and1}
-// ROOT2: xor0 2 cuts:
+// ROOT2: xor0 3 cuts:
 // ROOT2-SAME: {xor0}
 // ROOT2-SAME: {b_0, a_0}
+// ROOT2-SAME: {and0, and1}
 hw.module @Issue8885(in %a : i2, in %b : i2) {
   %0 = comb.extract %b from 0 {sv.namehint = "b_0"} : (i2) -> i1
   %1 = comb.extract %b from 1 {sv.namehint = "b_1"} : (i2) -> i1

--- a/test/Dialect/Synth/tech-mapper-area-flow-fanout.mlir
+++ b/test/Dialect/Synth/tech-mapper-area-flow-fanout.mlir
@@ -1,0 +1,39 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(synth-tech-mapper{strategy=area test=true max-cuts-per-root=8})' %s | FileCheck %s --check-prefixes CHECK,AREA
+
+hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+  %0 = synth.aig.and_inv %a, %b : i1
+  hw.output %0 : i1
+}
+
+hw.module @and_inv_n(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+  %0 = synth.aig.and_inv not %a, %b : i1
+  hw.output %0 : i1
+}
+
+hw.module @and_inv_3_cheap(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {hw.techlib.info = {area = 0.75 : f64, delay = [[1], [1], [1]]}} {
+  %0 = synth.aig.and_inv %a, %b : i1
+  %1 = synth.aig.and_inv not %0, %c : i1
+  hw.output %1 : i1
+}
+
+hw.module @and3_mid(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {hw.techlib.info = {area = 1.75 : f64, delay = [[1], [1], [1]]}} {
+  %0 = synth.aig.and_inv %a, %b : i1
+  %1 = synth.aig.and_inv %0, %c : i1
+  hw.output %1 : i1
+}
+
+// Make sure area-flow uses the current cut cover's fanout, not the original
+// AIG fanout. The first output switches away from %ab immediately, so the
+// second output must see %ab with a single mapped reference.
+// CHECK-LABEL: @mapped_fanout_drives_area_flow
+hw.module @mapped_fanout_drives_area_flow(in %a : i1, in %b : i1, in %c : i1,
+                                          in %d : i1,
+                                          out cheap : i1, out recovered : i1) {
+  // AREA:      %[[CHEAP:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_3_cheap(a: %a: i1, b: %b: i1, c: %c: i1) -> (result: i1) {test.arrival_times = [1]}
+  // AREA-NEXT: %[[RECOVERED:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and3_mid(a: %a: i1, b: %b: i1, c: %d: i1) -> (result: i1) {test.arrival_times = [1]}
+  // AREA-NEXT: hw.output %[[CHEAP]], %[[RECOVERED]] : i1, i1
+  %ab = synth.aig.and_inv %a, %b : i1
+  %cheap = synth.aig.and_inv %c, not %ab : i1
+  %recovered = synth.aig.and_inv %ab, %d : i1
+  hw.output %cheap, %recovered : i1, i1
+}

--- a/test/Dialect/Synth/tech-mapper-area-flow-fanout.mlir
+++ b/test/Dialect/Synth/tech-mapper-area-flow-fanout.mlir
@@ -1,22 +1,22 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(synth-tech-mapper{strategy=area test=true max-cuts-per-root=8})' %s | FileCheck %s --check-prefixes CHECK,AREA
 
-hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
   %0 = synth.aig.and_inv %a, %b : i1
   hw.output %0 : i1
 }
 
-hw.module @and_inv_n(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
+hw.module @and_inv_n(in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
   %0 = synth.aig.and_inv not %a, %b : i1
   hw.output %0 : i1
 }
 
-hw.module @and_inv_3_cheap(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {hw.techlib.info = {area = 0.75 : f64, delay = [[1], [1], [1]]}} {
+hw.module @and_inv_3_cheap(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 0.75 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "c", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
   %0 = synth.aig.and_inv %a, %b : i1
   %1 = synth.aig.and_inv not %0, %c : i1
   hw.output %1 : i1
 }
 
-hw.module @and3_mid(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {hw.techlib.info = {area = 1.75 : f64, delay = [[1], [1], [1]]}} {
+hw.module @and3_mid(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.75 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "c", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
   %0 = synth.aig.and_inv %a, %b : i1
   %1 = synth.aig.and_inv %0, %c : i1
   hw.output %1 : i1

--- a/test/Dialect/Synth/tech-mapper-area-flow-fanout.mlir
+++ b/test/Dialect/Synth/tech-mapper-area-flow-fanout.mlir
@@ -1,22 +1,22 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(synth-tech-mapper{strategy=area test=true max-cuts-per-root=8})' %s | FileCheck %s --check-prefixes CHECK,AREA
 
-hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<1, 0, #synth.polarity<positive>>], input_caps = {}>} {
   %0 = synth.aig.and_inv %a, %b : i1
   hw.output %0 : i1
 }
 
-hw.module @and_inv_n(in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+hw.module @and_inv_n(in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<1, 0, #synth.polarity<positive>>], input_caps = {}>} {
   %0 = synth.aig.and_inv not %a, %b : i1
   hw.output %0 : i1
 }
 
-hw.module @and_inv_3_cheap(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 0.75 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "c", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+hw.module @and_inv_3_cheap(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 0.75 : f64, arcs = [#synth.linear_timing_arc<1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<1, 0, #synth.polarity<positive>>], input_caps = {}>} {
   %0 = synth.aig.and_inv %a, %b : i1
   %1 = synth.aig.and_inv not %0, %c : i1
   hw.output %1 : i1
 }
 
-hw.module @and3_mid(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.75 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "c", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+hw.module @and3_mid(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.75 : f64, arcs = [#synth.linear_timing_arc<1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<1, 0, #synth.polarity<positive>>], input_caps = {}>} {
   %0 = synth.aig.and_inv %a, %b : i1
   %1 = synth.aig.and_inv %0, %c : i1
   hw.output %1 : i1

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -96,6 +96,29 @@ hw.module @area_flow_test(in %a : i1, in %b : i1, in %c: i1, out result : i1) {
     hw.output %1 : i1
 }
 
+// One output arrives later and gives the other output enough slack to switch
+// to a cheaper implementation during recovery.
+// CHECK-LABEL: @shared_slack_allows_area_recovery
+hw.module @shared_slack_allows_area_recovery(in %a : i1, in %b : i1,
+                                             in %c : i1, in %d : i1,
+                                             in %e : i1,
+                                             out slow : i1, out cheap : i1) {
+    // The first output is deep enough to arrive at 3, so recovery should switch the second output to the cheaper 2-stage implementation.
+    // Without recovery @and_inv_3 would be used for the second output.
+    // TIMING:    {test.arrival_times = [3]}
+    // TIMING-NEXT: %[[TCHEAP0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %a: i1, b: %b: i1) -> (result: i1) {test.arrival_times = [1]}
+    // TIMING-NEXT: %[[TCHEAP1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_n(a: %[[TCHEAP0]]: i1, b: %c: i1) -> (result: i1) {test.arrival_times = [2]}
+    // TIMING-NEXT: hw.output %{{.+}}, %[[TCHEAP1]] : i1, i1
+    %slow0 = synth.aig.and_inv %a, %b : i1
+    %slow1 = synth.aig.and_inv %c, not %slow0 : i1
+    %slow2 = synth.aig.and_inv %d, not %slow1 : i1
+    %slow3 = synth.aig.and_inv %e, not %slow2 : i1
+
+    %cheap0 = synth.aig.and_inv %a, %b : i1
+    %cheap1 = synth.aig.and_inv %c, not %cheap0 : i1
+    hw.output %slow3, %cheap1 : i1, i1
+}
+
 // Test primary inputs handling
 // CHECK-LABEL: @primary_inputs_test
 hw.module @primary_inputs_test(in %a : i1, in %b : i1, out result : i1) {

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -98,6 +98,29 @@ hw.module @area_flow_test(in %a : i1, in %b : i1, in %c: i1, out result : i1) {
     hw.output %1 : i1
 }
 
+// One output arrives later and gives the other output enough slack to switch
+// to a cheaper implementation during recovery.
+// CHECK-LABEL: @shared_slack_allows_area_recovery
+hw.module @shared_slack_allows_area_recovery(in %a : i1, in %b : i1,
+                                             in %c : i1, in %d : i1,
+                                             in %e : i1,
+                                             out slow : i1, out cheap : i1) {
+    // The first output is deep enough to arrive at 3, so recovery should switch the second output to the cheaper 2-stage implementation.
+    // Without recovery @and_inv_3 would be used for the second output.
+    // TIMING:    {test.arrival_times = [3]}
+    // TIMING-NEXT: %[[TCHEAP0:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv(a: %a: i1, b: %b: i1) -> (result: i1) {test.arrival_times = [1]}
+    // TIMING-NEXT: %[[TCHEAP1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_n(a: %[[TCHEAP0]]: i1, b: %c: i1) -> (result: i1) {test.arrival_times = [2]}
+    // TIMING-NEXT: hw.output %{{.+}}, %[[TCHEAP1]] : i1, i1
+    %slow0 = synth.aig.and_inv %a, %b : i1
+    %slow1 = synth.aig.and_inv %c, not %slow0 : i1
+    %slow2 = synth.aig.and_inv %d, not %slow1 : i1
+    %slow3 = synth.aig.and_inv %e, not %slow2 : i1
+
+    %cheap0 = synth.aig.and_inv %a, %b : i1
+    %cheap1 = synth.aig.and_inv %c, not %cheap0 : i1
+    hw.output %slow3, %cheap1 : i1, i1
+}
+
 // Test primary inputs handling
 // CHECK-LABEL: @primary_inputs_test
 hw.module @primary_inputs_test(in %a : i1, in %b : i1, out result : i1) {


### PR DESCRIPTION
This implements area recovery using area-flow heuristic. 

The CutRewriter framework is changed to compute required time of the network. Currently it's simply set to worst arrival time of the initial mapping, in future enhancement this should be passed from users through some attributes.

The reselection is based on area-flow mentioned in `3.3.1 Global view heuristic` in https://people.eecs.berkeley.edu/~alanmi/publications/2007/iccad07_map.pdf, which scores cut based on approximation of the shared logic amount. 

Assisted-by: Codex: GPT 5.4

** This is not ready for review **
