### PR TITLE
[FIRRTL] InferDomains: drive undriven domain wires

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -1472,6 +1472,33 @@ LogicalResult
 ModuleState::updateWire(DenseMap<DomainValue, DomainValue> &domainsInScope,
                         WireOp wireOp) {
   auto result = wireOp.getResult();
+
+  if (auto tgt = dyn_cast<DomainValue>(result)) {
+    if (isDriven(tgt))
+      return success();
+
+    LLVM_DEBUG(llvm::dbgs().indent(4) << "update " << render(wireOp) << "\n");
+    OpBuilder builder(wireOp);
+    builder.setInsertionPointAfter(wireOp);
+    auto *term = getTermForDomain(tgt);
+    if (auto *var = dyn_cast<VariableTerm>(term)) {
+      auto src = solveVarWithAnonDomain(builder, domainsInScope, wireOp,
+                                        tgt.getType(), var);
+      LLVM_DEBUG(llvm::dbgs().indent(6)
+                 << "connect " << render(tgt) << " := " << render(src) << "\n");
+      DomainDefineOp::create(builder, wireOp.getLoc(), tgt, src);
+      return success();
+    }
+    if (auto *val = dyn_cast<ValueTerm>(term)) {
+      auto src = getDomainInScope(builder, domainsInScope, val->value);
+      LLVM_DEBUG(llvm::dbgs().indent(6)
+                 << "connect " << render(tgt) << " := " << render(src) << "\n");
+      DomainDefineOp::create(builder, wireOp.getLoc(), tgt, src);
+      return success();
+    }
+    llvm_unreachable("unhandled domain term type");
+  }
+
   if (!isHardware(result))
     return success();
 

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -736,7 +736,7 @@ firrtl.circuit "DriveWireWithAnonDomain" {
 firrtl.circuit "DriveWireWithInputDomain" {
   firrtl.domain @ClockDomain
 
-  // firrtl.module @DriveWireWithInputDomain(in %ClockDomain: !firrtl.domain<@ClockDomain()>, in %i: !firrtl.uint<1> domains [%ClockDomain])
+  // CHECK-LABEL: firrtl.module @DriveWireWithInputDomain(in %ClockDomain: !firrtl.domain<@ClockDomain()>, in %i: !firrtl.uint<1> domains [%ClockDomain])
   firrtl.module @DriveWireWithInputDomain(in %i: !firrtl.uint<1>) {
     %w = firrtl.wire : !firrtl.domain<@ClockDomain()>
     // CHECK: firrtl.domain.define %w, %ClockDomain : !firrtl.domain<@ClockDomain()>

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -721,3 +721,26 @@ firrtl.circuit "ResolveRWProbeOfInnerSym" {
     firrtl.matchingconnect %o, %data : !firrtl.uint<1>
   }
 }
+
+// CHECK-LABEL: "DriveWireWithAnonDomain"
+firrtl.circuit "DriveWireWithAnonDomain" {
+  firrtl.domain @ClockDomain
+  firrtl.module @DriveWireWithAnonDomain() {
+    %w = firrtl.wire : !firrtl.domain<@ClockDomain()>
+    // CHECK: %ClockDomain = firrtl.domain.anon  : !firrtl.domain<@ClockDomain()>
+    // CHECK: firrtl.domain.define %w, %ClockDomain : !firrtl.domain<@ClockDomain()
+  }
+}
+
+// CHECK-LABEL: "DriveWireWithInputDomain"
+firrtl.circuit "DriveWireWithInputDomain" {
+  firrtl.domain @ClockDomain
+
+  // firrtl.module @DriveWireWithInputDomain(in %ClockDomain: !firrtl.domain<@ClockDomain()>, in %i: !firrtl.uint<1> domains [%ClockDomain])
+  firrtl.module @DriveWireWithInputDomain(in %i: !firrtl.uint<1>) {
+    %w = firrtl.wire : !firrtl.domain<@ClockDomain()>
+    // CHECK: firrtl.domain.define %w, %ClockDomain : !firrtl.domain<@ClockDomain()>
+    %w2 = firrtl.wire domains[%w] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
+    firrtl.matchingconnect %w2, %i : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
When a domain-typed wire is undriven, infer-domains should drive it (initialization checking is disabled for domain-typed values, so it wouldn't be reported as an error).