### PR TITLE
[Datapath][Synth] Make comb-to-datapath and lower-word-to-bits work on generic ops

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -887,7 +887,7 @@ def ConvertSynthToComb: Pass<"convert-synth-to-comb"> {
 // ConvertCombToDatapath
 //===----------------------------------------------------------------------===//
 
-def ConvertCombToDatapath: Pass<"convert-comb-to-datapath",  "hw::HWModuleOp"> {
+def ConvertCombToDatapath: Pass<"convert-comb-to-datapath"> {
   let summary = "Lower Comb ops to Datapath ops";
   let description = [{
     This pass converts arithmetic Comb operations into Datapath operations that

--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -107,7 +107,7 @@ def LowerVariadic : Pass<"synth-lower-variadic", "hw::HWModuleOp"> {
   ];
 }
 
-def LowerWordToBits : Pass<"synth-lower-word-to-bits", "hw::HWModuleOp"> {
+def LowerWordToBits : Pass<"synth-lower-word-to-bits"> {
   let summary = "Lower multi-bit AndInverter to single-bit ones";
   let dependentDialects = ["comb::CombDialect"];
   let statistics = [

--- a/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
@@ -410,41 +410,12 @@ struct LowerWordToBitsPass
 } // namespace
 
 void LowerWordToBitsPass::runOnOperation() {
-  auto *op = getOperation();
-  // Check if the op contains target operations.
-  bool hasDirectTargets = false;
-  op->walk([&](Operation *inner) -> WalkResult {
-    if (inner->getParentOp() == op && shouldLowerOperation(inner)) {
-      hasDirectTargets = true;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
+  BitBlaster driver(getOperation());
+  if (failed(driver.run()))
+    return signalPassFailure();
 
-  // If so we run BitBlaster directly on it.
-  if (hasDirectTargets) {
-    BitBlaster driver(op);
-    if (failed(driver.run()))
-      return signalPassFailure();
-    numLoweredBits += driver.numLoweredBits;
-    numLoweredConstants += driver.numLoweredConstants;
-    numLoweredOps += driver.numLoweredOps;
-    return;
-  }
-
-  // Otherwise we iterate over the children.
-  for (auto &region : op->getRegions()) {
-    for (auto &block : region) {
-      for (auto &childOp : block) {
-        if (childOp.getNumRegions() == 0)
-          continue;
-        BitBlaster driver(&childOp);
-        if (failed(driver.run()))
-          return signalPassFailure();
-        numLoweredBits += driver.numLoweredBits;
-        numLoweredConstants += driver.numLoweredConstants;
-        numLoweredOps += driver.numLoweredOps;
-      }
-    }
-  }
+  // Update statistics
+  numLoweredBits += driver.numLoweredBits;
+  numLoweredConstants += driver.numLoweredConstants;
+  numLoweredOps += driver.numLoweredOps;
 }

--- a/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
@@ -424,7 +424,8 @@ void LowerWordToBitsPass::runOnOperation() {
   // If so we run BitBlaster directly on it.
   if (hasDirectTargets) {
     BitBlaster driver(op);
-    if (failed(driver.run())) return signalPassFailure();
+    if (failed(driver.run()))
+      return signalPassFailure();
     numLoweredBits += driver.numLoweredBits;
     numLoweredConstants += driver.numLoweredConstants;
     numLoweredOps += driver.numLoweredOps;
@@ -435,9 +436,11 @@ void LowerWordToBitsPass::runOnOperation() {
   for (auto &region : op->getRegions()) {
     for (auto &block : region) {
       for (auto &childOp : block) {
-        if (childOp.getNumRegions() == 0) continue;
+        if (childOp.getNumRegions() == 0)
+          continue;
         BitBlaster driver(&childOp);
-        if (failed(driver.run())) return signalPassFailure();
+        if (failed(driver.run()))
+          return signalPassFailure();
         numLoweredBits += driver.numLoweredBits;
         numLoweredConstants += driver.numLoweredConstants;
         numLoweredOps += driver.numLoweredOps;

--- a/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
@@ -58,7 +58,7 @@ namespace {
 /// while maintaining correctness and optimizing for constant propagation.
 class BitBlaster {
 public:
-  explicit BitBlaster(hw::HWModuleOp moduleOp) : moduleOp(moduleOp) {}
+  explicit BitBlaster(Operation *topOp) : topOp(topOp) {}
 
   /// Run the bit-blasting algorithm on the module.
   LogicalResult run();
@@ -131,8 +131,8 @@ private:
   /// Cached boolean constants (false at index 0, true at index 1)
   std::array<Value, 2> constants;
 
-  /// Reference to the module being processed
-  hw::HWModuleOp moduleOp;
+  /// Reference to the top-level operation being processed
+  Operation *topOp;
 };
 
 } // namespace
@@ -267,18 +267,18 @@ LogicalResult BitBlaster::run() {
   // Topologically sort operations in graph regions so that walk visits them in
   // the topological order.
   if (failed(topologicallySortGraphRegionBlocks(
-          moduleOp, [](Value value, Operation *op) -> bool {
+          topOp, [](Value value, Operation *op) -> bool {
             // Otherthan target ops, all other ops are always ready.
             return !(shouldLowerOperation(op) ||
                      isa<comb::ExtractOp, comb::ReplicateOp, comb::ConcatOp,
                          comb::ReplicateOp>(op));
           }))) {
     // If we failed to topologically sort operations we cannot proceed.
-    return mlir::emitError(moduleOp.getLoc(), "there is a combinational cycle");
+    return mlir::emitError(topOp->getLoc(), "there is a combinational cycle");
   }
 
   // Lower target operations
-  moduleOp.walk([&](Operation *op) {
+  topOp->walk([&](Operation *op) {
     // If the block is in a graph region, topologically sort it first.
     if (shouldLowerOperation(op))
       (void)lowerValueToBits(op->getResult(0));
@@ -315,7 +315,8 @@ LogicalResult BitBlaster::run() {
 
 Value BitBlaster::getBoolConstant(bool value) {
   if (!constants[value]) {
-    auto builder = OpBuilder::atBlockBegin(moduleOp.getBodyBlock());
+    auto &entryBlock = topOp->getRegion(0).front();
+    auto builder = OpBuilder::atBlockBegin(&entryBlock);
     constants[value] = hw::ConstantOp::create(builder, builder.getUnknownLoc(),
                                               builder.getI1Type(), value);
   }
@@ -409,12 +410,38 @@ struct LowerWordToBitsPass
 } // namespace
 
 void LowerWordToBitsPass::runOnOperation() {
-  BitBlaster driver(getOperation());
-  if (failed(driver.run()))
-    return signalPassFailure();
+  auto *op = getOperation();
+  // Check if the op contains target operations.
+  bool hasDirectTargets = false;
+  op->walk([&](Operation *inner) -> WalkResult {
+    if (inner->getParentOp() == op && shouldLowerOperation(inner)) {
+      hasDirectTargets = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
 
-  // Update statistics
-  numLoweredBits += driver.numLoweredBits;
-  numLoweredConstants += driver.numLoweredConstants;
-  numLoweredOps += driver.numLoweredOps;
+  // If so we run BitBlaster directly on it.
+  if (hasDirectTargets) {
+    BitBlaster driver(op);
+    if (failed(driver.run())) return signalPassFailure();
+    numLoweredBits += driver.numLoweredBits;
+    numLoweredConstants += driver.numLoweredConstants;
+    numLoweredOps += driver.numLoweredOps;
+    return;
+  }
+
+  // Otherwise we iterate over the children.
+  for (auto &region : op->getRegions()) {
+    for (auto &block : region) {
+      for (auto &childOp : block) {
+        if (childOp.getNumRegions() == 0) continue;
+        BitBlaster driver(&childOp);
+        if (failed(driver.run())) return signalPassFailure();
+        numLoweredBits += driver.numLoweredBits;
+        numLoweredConstants += driver.numLoweredConstants;
+        numLoweredOps += driver.numLoweredOps;
+      }
+    }
+  }
 }

--- a/test/Conversion/CombToDatapath/comb-to-datapath.mlir
+++ b/test/Conversion/CombToDatapath/comb-to-datapath.mlir
@@ -38,3 +38,11 @@ hw.module @sub(in %arg0: i4, in %arg1: i4, out out: i4) {
   hw.output %0 : i4
 }
 
+// CHECK-LABEL: func.func @test_no_module
+func.func @test_no_module(%arg0: i4, %arg1: i4) -> i4 {
+  // CHECK: datapath.partial_product
+  // CHECK: datapath.compress
+  %0 = comb.mul %arg0, %arg1 : i4
+  return %0 :i4
+}
+

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -99,3 +99,13 @@ hw.module @Choice(in %a: i2, in %b: i2, in %c: i2, out f: i2, out g: i2) {
   // CHECK-NEXT: hw.output %[[CONCAT1]], %[[CONCAT2]]
   hw.output %0, %1 : i2, i2
 }
+
+// CHECK-LABEL: func.func @Basic_No_Module
+func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
+  // CHECK: comb.extract
+  // CHECK: synth.aig.and_inv
+  // CHECK: comb.concat
+  %0 = synth.aig.and_inv not %arg0, %arg1 : i2
+  %1 = synth.aig.and_inv not %0, not %0 : i2
+  return %1 : i2
+}

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s  --pass-pipeline='builtin.module(any(synth-lower-word-to-bits ))'| FileCheck %s
+// RUN: circt-opt %s  --pass-pipeline='builtin.module(any(synth-lower-word-to-bits))'| FileCheck %s
 // CHECK: hw.module @Basic
 hw.module @Basic(in %a: i2, in %b: i2, out f: i2) {
   %0 = synth.aig.and_inv not %a, %b : i2
@@ -104,6 +104,7 @@ hw.module @Choice(in %a: i2, in %b: i2, in %c: i2, out f: i2, out g: i2) {
 func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
   // CHECK: comb.extract
   // CHECK: synth.aig.and_inv
+  // CHECK-SAME: i1
   // CHECK: comb.concat
   %0 = synth.aig.and_inv not %arg0, %arg1 : i2
   %1 = synth.aig.and_inv not %0, not %0 : i2

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --synth-lower-word-to-bits | FileCheck %s
+// RUN: circt-opt %s  --pass-pipeline='builtin.module(any(synth-lower-word-to-bits ))'| FileCheck %s
 // CHECK: hw.module @Basic
 hw.module @Basic(in %a: i2, in %b: i2, out f: i2) {
   %0 = synth.aig.and_inv not %a, %b : i2


### PR DESCRIPTION
Related to #10133.
Modify both comb-to-datapath and lower-word-to-bits to work on generic operations. Since the changes for both weren't complex, I'm submitting a unified PR. Added one unit test for each pass.