### PR TITLE
[ci] Use UBTI for nightly

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -7,108 +7,43 @@ on:
     - cron: 0 12 * * *
 
 jobs:
-  # Build CIRCT and run its tests using a Docker container with all the
-  # integration testing prerequisite installed.
   build-circt:
-    name: Build and Test
-    # Run on an internal MSFT subscription. Please DO NOT use this for any other
-    # workflows without talking to John Demme (john.demme@microsoft.com, GH
-    # teqdruid) first. We may lose funding for this if it ends up costing too
-    # much.
-    # If individual jobs fail due to timeouts or disconnects, please report to
-    # John and re-run the job.
-    runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
-    container:
-      image: ghcr.io/circt/images/circt-integration-test:v20
-      volumes:
-        - /mnt:/__w/circt
+    name: "${{ matrix.compiler }}/${{ matrix.build-type }}/${{ matrix.build-shared == 'ON' && 'shared' || 'static' }}-libs/asserts-${{ matrix.build-assert == 'ON' && 'on' || 'off' }}${{ matrix.valgrind && '/valgrind' || '' }}"
     strategy:
       fail-fast: false
       matrix:
-        # Please clear all new builds with John first. Any changes to this
-        # matrix could result in a drastically increased number of builds, which
-        # in turn costs more. Changes which don't result in new builds are OK.
         build-assert: [ON, OFF]
         build-shared: [ON, OFF]
         build-type: [Debug, Release]
         compiler:
-          - cc: clang
-            cxx: clang++
-          - cc: gcc
-            cxx: g++
-        lit-flags: ['', '--vg']
+          - clang
+          - gcc
+        valgrind: [false, true]
         exclude:
           - build-type: Debug
-            lit-flags: --vg
+            valgrind: true
           - build-type: Release
-            lit-flags: --vg
+            valgrind: true
             build-assert: OFF
           - build-type: Release
-            lit-flags: --vg
+            valgrind: true
             build-shared: ON
           # TODO: This corner is failing and has been for some time. #5253.
           - build-type: Release
-            compiler: {cc: gcc, cxx: g++}
-            lit-flags: --vg
-
-    steps:
-      # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
-      # time.
-      - name: Get CIRCT
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-          submodules: true
-
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        # Cache only when build type is release
-        if: matrix.build-type == 'Release'
-        with:
-          max-size: 300M
-          key: nightly-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
-
-      # --------
-      # Build and test CIRCT
-      # --------
-
-      - name: Configure CIRCT
-        env:
-          CC: ${{ matrix.compiler.cc }}
-          CXX: ${{ matrix.compiler.cxx }}
-          BUILD_ASSERT: ${{ matrix.build-assert }}
-          BUILD_SHARED: ${{ matrix.build-shared }}
-          BUILD_TYPE: ${{ matrix.build-type }}
-        run: |
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-          mkdir build && cd build
-          cmake -GNinja ../llvm/llvm \
-            -DBUILD_SHARED_LIBS=$BUILD_SHARED \
-            -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-            -DCMAKE_C_COMPILER=$CC \
-            -DCMAKE_CXX_COMPILER=$CXX \
-            -DLLVM_CCACHE_BUILD=ON \
-            -DLLVM_ENABLE_ASSERTIONS=$BUILD_ASSERT \
-            -DLLVM_ENABLE_PROJECTS=mlir \
-            -DLLVM_EXTERNAL_PROJECTS=circt \
-            -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=.. \
-            -DLLVM_TARGETS_TO_BUILD="host" \
-            -DLLVM_USE_LINKER=lld \
-            -DLLVM_USE_SPLIT_DWARF=ON \
-            -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-            -DCIRCT_BINDINGS_PYTHON_ENABLED=ON \
-            -DLLVM_LIT_ARGS="-v --show-unsupported ${{ matrix.lit-flags }}" \
-            -DCIRCT_SLANG_FRONTEND_ENABLED=ON
-
-            # Temporarily disable ESI runtime builds until we work out the Abseil conflict (#7236).
-            # -DESI_RUNTIME=ON
-      - name: Test CIRCT
-        run: |
-          ninja -C build check-circt -j$(nproc)
-      - name: Unit Test CIRCT
-        run: |
-          ninja -C build check-circt-unit -j$(nproc)
-      - name: Integration Test CIRCT
-        if: ${{ matrix.lit-flags == '' }}
-        run: |
-          ninja -C build check-circt-integration -j$(nproc)
+            compiler: gcc
+            valgrind: true
+    permissions:
+      contents: write
+      actions: write
+    uses: ./.github/workflows/unifiedBuildTestAndInstall.yml
+    with:
+      runner: ubuntu-24.04
+      cmake_build_type: ${{ matrix.build-type }}
+      build_shared_libs: ${{ matrix.build-shared }}
+      llvm_enable_assertions: ${{ matrix.build-assert }}
+      run_tests: true
+      run_integration_tests: true
+      install_target: ""
+      package_name_prefix: ""
+      cmake_c_compiler: ${{ matrix.compiler }}
+      valgrind: ${{ matrix.valgrind }}

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -166,7 +166,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install iverilog libsystemc-dev ninja-build z3
+          sudo apt-get install iverilog libsystemc-dev ninja-build valgrind z3
           echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Restore Verilator Cache (Linux)
         if: inputs.run_integration_tests && runner.os == 'Linux'

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -146,6 +146,23 @@ jobs:
     permissions:
       contents: write # Upload assets to release.
     steps:
+# Canonicalize inputs (which could come from workflow_dispatch or workflow_call)
+# which may be slightly different.  E.g., change `true` to `ON` or `Release` to
+# `release`.  This guarantees that we get cache hits regardless of input casing.
+      - name: Canonicalize inputs
+        id: canonicalize
+        shell: bash
+        run: |
+          on_off() { case "${1,,}" in on|true) echo "ON" ;; *) echo "OFF" ;; esac; }
+          echo "cmake_build_type=${INPUT_BUILD_TYPE,,}" >> $GITHUB_OUTPUT
+          echo "cmake_c_compiler=${INPUT_COMPILER,,}" >> $GITHUB_OUTPUT
+          echo "build_shared_libs=$(on_off "${INPUT_SHARED}")" >> $GITHUB_OUTPUT
+          echo "llvm_enable_assertions=$(on_off "${INPUT_ASSERTIONS}")" >> $GITHUB_OUTPUT
+        env:
+          INPUT_BUILD_TYPE: ${{ inputs.cmake_build_type }}
+          INPUT_COMPILER: ${{ inputs.cmake_c_compiler }}
+          INPUT_SHARED: ${{ inputs.build_shared_libs }}
+          INPUT_ASSERTIONS: ${{ inputs.llvm_enable_assertions }}
       - name: Clone llvm/circt
         uses: actions/checkout@v3
         with:
@@ -263,9 +280,7 @@ jobs:
           pip install pycapnp psutil pybind11==2.11.2 nanobind==2.9.2 numpy jinja2 cocotb~=1.9 cocotb_test~=0.2 click
 
           echo cmake="-DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCIRCT_BINDINGS_PYTHON_ENABLED=ON" >> "$GITHUB_OUTPUT"
-# Setup Caching.  Canonicalize inputs (which could come from workflow_dispatch
-# or workflow_call) and may be slightly different.  E.g., change `true` to `ON`.
-# This will guarantee that we get cache hits.
+# Setup Caching.
 #
 # Caching has several constraints:
 #
@@ -276,24 +291,17 @@ jobs:
 # Taken together, disable caching on non-release builds.
 #
 # [1]: https://gitlab.kitware.com/cmake/cmake/-/issues/22529
-      - name: Canonicalize inputs
-        id: canonicalize
-        shell: bash
-        run: |
-          on_off() { case "${1,,}" in on|true) echo "ON" ;; *) echo "OFF" ;; esac; }
-          echo "build_shared_libs=$(on_off '${{ inputs.build_shared_libs }}')" >> $GITHUB_OUTPUT
-          echo "llvm_enable_assertions=$(on_off '${{ inputs.llvm_enable_assertions }}')" >> $GITHUB_OUTPUT
       - name: sccache
-        if: inputs.cmake_build_type == 'release'
+        if: steps.canonicalize.outputs.cmake_build_type == 'release'
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ inputs.runner }}-${{ inputs.cmake_c_compiler }}-${{ inputs.cmake_build_type }}-${{ steps.canonicalize.outputs.build_shared_libs }}-${{ steps.canonicalize.outputs.llvm_enable_assertions }}
+          key: ${{ inputs.runner }}-${{ steps.canonicalize.outputs.cmake_c_compiler }}-${{ steps.canonicalize.outputs.cmake_build_type }}-${{ steps.canonicalize.outputs.build_shared_libs }}-${{ steps.canonicalize.outputs.llvm_enable_assertions }}
           max-size: 500M
           variant: sccache
           save: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       - name: Configure sccache
         id: configure-sccache
-        if: inputs.cmake_build_type == 'release'
+        if: steps.canonicalize.outputs.cmake_build_type == 'release'
         shell: bash
         run:
           echo enable_sccache="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_OUTPUT

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -317,7 +317,7 @@ jobs:
           # Add Valgrind arg
           LLVM_LIT_ARGS="--show-skipped --show-unsupported --show-xfail -v"
           if [[ "${{ inputs.valgrind }}" == "true" ]]; then
-            LLVM_LIT_ARGS="$LLVM_LIT_ARGS --vg"
+            LLVM_LIT_ARGS="$LLVM_LIT_ARGS --vg --vg-arg=--track-origins=yes"
           fi
 
           # Set CMAKE_CXX_COMPILER based on CMAKE_C_COMPILER


### PR DESCRIPTION
Switch the nightly regression from using a `circt/images` Docker container
and a custom build/test to using the UBTI build.  This is intended to be a
one-to-one change where all jobs running previously will run the same as
before (just on different infrastructure).

This is done for three reasons: (1) the combination of docker images
running on hosted runners has empirically been broken for some time (both
on the external MSFT-hosted runners as well as in at least one internal
hosted GitHub Enterprise instance), (2) moving onto a single build flow
for everything greatly simplifies how things are built and tested (there
is exactly one build/test flow), and (3) the UBTI flow is more easily
modifiable as it is self-documenting as opposed to being split over the
`circt/images` and `llvm/circt` repositories.

Assisted-by: Claude:claude-sonnet-4-6

This is stacked on #10188.

~I'm not going to try a full nightly until #10188 lands (to get the Verilator and Yosys caching). However, I've started and cancelled a workflow dispatch of this here: https://github.com/llvm/circt/actions/runs/24372135856 This is showing all 17 jobs being launched. A benefit about this is that we now have more flexibility in launching nightlies over different runners. (The integration tests won't run fully for anything other than Linux right now, but this can be made to work.)~

Full nightly is running here: https://github.com/llvm/circt/actions/runs/24407900984
