### PR TITLE
[Sim] Add builtin stdout/stderr stream ops

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -618,6 +618,28 @@ def GetFileOp : SimOp<"get_file", [Pure]> {
   let assemblyFormat = "$fileName attr-dict";
 }
 
+def StdoutStreamOp : SimOp<"stdout_stream", [Pure]> {
+  let summary = "The standard output stream";
+  let description = [{
+    Returns a reference to the standard output stream, which can be consumed
+    by `sim.print` or `sim.proc.print`.
+  }];
+
+  let results = (outs OutputStreamType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def StderrStreamOp : SimOp<"stderr_stream", [Pure]> {
+  let summary = "The standard error stream";
+  let description = [{
+    Returns a reference to the standard error stream, which can be consumed
+    by `sim.print` or `sim.proc.print`.
+  }];
+
+  let results = (outs OutputStreamType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Dynamic Strings
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -142,3 +142,19 @@ hw.module @ProceduralPrint(in %trigger: i1, in %condition: i1) {
     }
   }
 }
+
+// CHECK-LABEL: hw.module @StdoutAndStderr
+hw.module @StdoutAndStderr(in %clock: !seq.clock, in %condition: i1) {
+  // CHECK: %[[STDOUT_STR:.*]] = sim.fmt.literal "Hello, stdout!"
+  // CHECK: %[[STDERR_STR:.*]] = sim.fmt.literal "Hello, stderr!"
+  %stdout_str = sim.fmt.literal "Hello, stdout!"
+  %stderr_str = sim.fmt.literal "Hello, stderr!"
+  // CHECK: %[[STDOUT:.*]] = sim.stdout_stream
+  // CHECK: %[[STDERR:.*]] = sim.stderr_stream
+  %stdout = sim.stdout_stream
+  %stderr = sim.stderr_stream
+  // CHECK: sim.print %[[STDOUT_STR]] on %clock if %condition to %[[STDOUT]]
+  // CHECK: sim.print %[[STDERR_STR]] on %clock if %condition to %[[STDERR]]
+  sim.print %stdout_str on %clock if %condition to %stdout
+  sim.print %stderr_str on %clock if %condition to %stderr
+}


### PR DESCRIPTION
This introduces sim.stream.stdout and sim.stream.stderr as built-in producers of !sim.output_stream. This is intended as preparatory infrastructure for follow-up lowering work.

Follow up #10163 .