### PR TITLE
[ESI][Runtime] Add a workflow to test just the ESI Runtime

### DIFF
--- a/.github/workflows/testESIRuntime.yml
+++ b/.github/workflows/testESIRuntime.yml
@@ -1,0 +1,83 @@
+# Test the ESI runtime separately from CIRCT and PyCDE. Runs a bunch faster
+# since it pulls down the PyCDE dependency from PyPI instead of building it from
+# source.
+name: Test ESI runtime
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "lib/Dialect/ESI/runtime/**"
+
+# Cancel previous CI builds when a new push occurs to the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # ---------------------------------------------------------------------------
+  #  Build and test Linux wheels. Run the CIRCT tests also.
+  # ---------------------------------------------------------------------------
+
+  build-linux:
+    name: Build and Test
+    # Run on an internal MSFT subscription. Please DO NOT use this for any other
+    # workflows without talking to John Demme (john.demme@microsoft.com, GH
+    # teqdruid) first. We may lose funding for this if it ends up costing too
+    # much.
+    # If individual jobs fail due to timeouts or disconnects, please report to
+    # John and re-run the job.
+    runs-on: Ubuntu-latest
+    container:
+      image: ghcr.io/circt/images/pycde-esi-test:latest
+      volumes:
+        - /mnt:/__w/circt
+
+    steps:
+      # Clone the CIRCT repo. Do not clone the submodule since we won't be
+      # building CIRCT or PyCDE in this workflow.
+      - name: Get CIRCT
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+
+      - name: Setup venv and install dependencies
+        working-directory: /__w/circt/lib/Dialect/ESI/runtime
+        run: |
+          set -o errexit
+          echo "Workspace: $GITHUB_WORKSPACE"
+          echo "Working directory: $PWD"
+          whoami
+          apt update
+          apt install -y python3-venv
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install --upgrade pip
+          pip install -r frontends/PyCDE/python/requirements.txt
+          pip install pycde --pre
+
+      # --------
+      # Build and test CIRCT
+      # --------
+
+      - name: Test ESI runtime (pytest)
+        working-directory: /__w/circt/lib/Dialect/ESI/runtime
+        run: |
+          set -o errexit
+          . venv/bin/activate
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_C_COMPILER=clang
+          ninja -C build -j$(nproc) ESIRuntime ESIRuntimeCppTests
+
+          # Install the ESI C++ runtime into the esiaccel Python package tree
+          # so that cmake-based tests can find headers, libraries, and the
+          # esiaccelConfig.cmake.
+          cmake --install build \
+            --prefix esiaccel_install \
+            --component ESIRuntime
+          export PYTHONPATH="$PWD/esiaccel_install/python"
+          export PATH="$PWD/build/bin:$PATH"
+          export LD_LIBRARY_PATH="$PWD/build/lib:$LD_LIBRARY_PATH"
+          python3 -m pytest lib/Dialect/ESI/runtime/tests/ -v --log-cli-level=INFO


### PR DESCRIPTION
Pulls down PyCDE (a runtime test dependency) from PyPI to avoid building all of CIRCT.