### PR TITLE
[Synth] [LowerWordToBits] Constant defined outside of IsolatedAbove region

### DIFF
--- a/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
@@ -18,12 +18,15 @@
 #include "circt/Dialect/Synth/Transforms/SynthPasses.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/LogicalResult.h"
+#include <array>
 
 #define DEBUG_TYPE "synth-lower-word-to-bits"
 
@@ -101,8 +104,8 @@ private:
   const llvm::KnownBits &computeKnownBits(Value value);
 
   /// Get or create a boolean constant (0 or 1).
-  /// Constants are cached to avoid duplication.
-  Value getBoolConstant(bool value);
+  /// Constants are cached by block to avoid duplication.
+  Value getBoolConstant(bool value, Block *block);
 
   //===--------------------------------------------------------------------===//
   // Helper Methods
@@ -127,8 +130,8 @@ private:
   /// Cache for computed known bits information
   llvm::MapVector<Value, llvm::KnownBits> knownBits;
 
-  /// Cached boolean constants (false at index 0, true at index 1)
-  std::array<Value, 2> constants;
+  /// Cached boolean constants by block (false at index 0, true at index 1)
+  llvm::DenseMap<Block *, std::array<Value, 2>> constantsByBlock;
 
   /// Reference to the top-level operation being processed
   Operation *topOp;
@@ -208,7 +211,7 @@ Value BitBlaster::extractBit(Value value, size_t index) {
       })
       .Case<hw::ConstantOp>([&](hw::ConstantOp op) {
         auto value = op.getValue();
-        return getBoolConstant(value[index]);
+        return getBoolConstant(value[index], op->getBlock());
       })
       .Default([&](auto op) { return lowerValueToBits(value)[index]; });
 }
@@ -304,14 +307,14 @@ LogicalResult BitBlaster::run() {
   return success();
 }
 
-Value BitBlaster::getBoolConstant(bool value) {
-  if (!constants[value]) {
-    auto &entryBlock = topOp->getRegion(0).front();
-    auto builder = OpBuilder::atBlockBegin(&entryBlock);
-    constants[value] = hw::ConstantOp::create(builder, builder.getUnknownLoc(),
-                                              builder.getI1Type(), value);
+Value BitBlaster::getBoolConstant(bool value, Block *block) {
+  auto &blockConstants = constantsByBlock[block];
+  if (!blockConstants[value]) {
+    auto builder = OpBuilder::atBlockBegin(block);
+    blockConstants[value] = hw::ConstantOp::create(
+        builder, builder.getUnknownLoc(), builder.getI1Type(), value);
   }
-  return constants[value];
+  return blockConstants[value];
 }
 
 ArrayRef<Value>
@@ -364,7 +367,7 @@ ArrayRef<Value> BitBlaster::lowerOp(
     operands.reserve(op->getNumOperands());
     if (knownMask[i]) {
       // Use known constant value
-      results.push_back(getBoolConstant(known.One[i]));
+      results.push_back(getBoolConstant(known.One[i], op->getBlock()));
       continue;
     }
 

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s  --pass-pipeline='builtin.module(any(synth-lower-word-to-bits))'| FileCheck %s
+// RUN: circt-opt %s --synth-lower-word-to-bits | FileCheck %s
 // CHECK: hw.module @Basic
 hw.module @Basic(in %a: i2, in %b: i2, out f: i2) {
   %0 = synth.aig.and_inv not %a, %b : i2


### PR DESCRIPTION
Resolves #10201

Replace 
` std::array<Value, 2> constants; ` \
with 
`llvm::DenseMap<Block *, std::array<Value, 2>> constantsByBlock;`
to fix a bug where constants are defined outside of IsolatedAbove regions. it is related to the changes introduced in #10198

### Testcase output
``` mlir
$ cat bar.mlir 
module {
func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
  %zero = hw.constant 0 : i2
  %0 = synth.aig.and_inv not %arg0, %zero : i2
  %1 = synth.aig.and_inv not %0, not %0 : i2
  return %1 : i2
}
}

$ circt-opt -synth-lower-word-to-bits bar.mlir -mlir-print-ir-after-failure
module {
  func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
    %true = hw.constant true
    %false = hw.constant false
    %c0_i2 = hw.constant 0 : i2
    %0 = comb.concat %true, %true : i1, i1
    return %0 : i2
  }
}
```