### PR TITLE
[Synth] Make MaximumAndCover and FunctionalReduction runnable on any op

### DIFF
--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -264,7 +264,7 @@ def StructuralHash : Pass<"synth-structural-hash", "hw::HWModuleOp"> {
   }];
 }
 
-def MaximumAndCover : Pass<"synth-maximum-and-cover", "hw::HWModuleOp"> {
+def MaximumAndCover : Pass<"synth-maximum-and-cover"> {
   let summary = "Maximum And Cover for And-Inverter";
   let description = [{
     This pass performs maximum AND-cover optimization by collapsing single-fanout

--- a/test/Dialect/Synth/maximum-and-cover.mlir
+++ b/test/Dialect/Synth/maximum-and-cover.mlir
@@ -29,6 +29,15 @@ hw.module @InvertedNoCollapse(in %a: i1, in %b: i1, in %c: i1, out o1: i1) {
   hw.output %1 : i1
 }
 
+// CHECK-LABEL: @func
+func.func @func(%a: i1, %b: i1, %c: i1, %d: i1) -> (i1) {
+  // CHECK-NEXT: %[[AND:.+]] = synth.aig.and_inv %arg0, %arg1, not %arg2, %arg3 : i1
+  // CHECK-NEXT: return %[[AND]] : i1
+  %0 = synth.aig.and_inv %a, %b : i1
+  %1 = synth.aig.and_inv %0, not %c, %d : i1
+  func.return %1 : i1
+}
+
 // CHECK-LABEL: @ComplexTree
 hw.module @ComplexTree(in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1, in %f: i1, in %g: i1, out o1: i1) {
   // CHECK-NEXT: %[[AND0:.+]] = synth.aig.and_inv %d, not %e : i1


### PR DESCRIPTION
## Summary

  - Removes the `hw::HWModuleOp` anchor from `MaximumAndCover` and `FunctionalReduction` passes so they can be inserted
  into pipelines operating at any level (e.g. `mlir::ModuleOp`)
  - `MaximumAndCover` requires no code change — `applyPatternsGreedily` already traverses nested ops generically
  - `FunctionalReduction` is updated to walk the anchor op for `hw::HWModuleLike` ops and invoke the solver once per
  module

  Part of #10133. This covers the two "no dependency" passes.

  ## Test plan

  - [x] `PASS: CIRCT :: Dialect/Synth/maximum-and-cover.mlir`
  - [x] `PASS: CIRCT :: Dialect/Synth/functional-reduction.mlir`
  - [x] All 19 tests in `test/Dialect/Synth/` pass