### PR TITLE
[ESI][Runtime] Fix runtime test workflow

### DIFF
--- a/.github/workflows/testESIRuntime.yml
+++ b/.github/workflows/testESIRuntime.yml
@@ -21,12 +21,6 @@ jobs:
 
   build-linux:
     name: Build and Test
-    # Run on an internal MSFT subscription. Please DO NOT use this for any other
-    # workflows without talking to John Demme (john.demme@microsoft.com, GH
-    # teqdruid) first. We may lose funding for this if it ends up costing too
-    # much.
-    # If individual jobs fail due to timeouts or disconnects, please report to
-    # John and re-run the job.
     runs-on: Ubuntu-latest
     container:
       image: ghcr.io/circt/images/pycde-esi-test:latest
@@ -37,47 +31,50 @@ jobs:
       # Clone the CIRCT repo. Do not clone the submodule since we won't be
       # building CIRCT or PyCDE in this workflow.
       - name: Get CIRCT
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: false
 
       - name: Setup venv and install dependencies
-        working-directory: /__w/circt/lib/Dialect/ESI/runtime
+        working-directory: lib/Dialect/ESI/runtime
         run: |
           set -o errexit
-          echo "Workspace: $GITHUB_WORKSPACE"
-          echo "Working directory: $PWD"
-          whoami
           apt update
           apt install -y python3-venv
           python3 -m venv venv
           . venv/bin/activate
           pip install --upgrade pip
-          pip install -r frontends/PyCDE/python/requirements.txt
+          pip install pytest nanobind
           pip install pycde --pre
 
       # --------
       # Build and test CIRCT
       # --------
 
-      - name: Test ESI runtime (pytest)
-        working-directory: /__w/circt/lib/Dialect/ESI/runtime
+      - name: Build ESI runtime
+        working-directory: lib/Dialect/ESI/runtime
         run: |
           set -o errexit
           . venv/bin/activate
+
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_C_COMPILER=clang
-          ninja -C build -j$(nproc) ESIRuntime ESIRuntimeCppTests
+          ninja -C build -j$(nproc)
 
           # Install the ESI C++ runtime into the esiaccel Python package tree
           # so that cmake-based tests can find headers, libraries, and the
           # esiaccelConfig.cmake.
           cmake --install build \
-            --prefix esiaccel_install \
-            --component ESIRuntime
-          export PYTHONPATH="$PWD/esiaccel_install/python"
-          export PATH="$PWD/build/bin:$PATH"
-          export LD_LIBRARY_PATH="$PWD/build/lib:$LD_LIBRARY_PATH"
-          python3 -m pytest lib/Dialect/ESI/runtime/tests/ -v --log-cli-level=INFO
+            --prefix esiaccel_install
+
+      - name: Test ESI runtime (pytest)
+        working-directory: lib/Dialect/ESI/runtime
+        run: |
+          set -o errexit
+          . venv/bin/activate
+
+          export PYTHONPATH="$PWD/esiaccel_install/"
+          export PATH="$PWD/esiaccel_install/bin:$PATH"
+          python3 -m pytest tests/ -v --log-cli-level=INFO

--- a/lib/Dialect/ESI/runtime/cosim_dpi_server/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/cosim_dpi_server/CMakeLists.txt
@@ -52,12 +52,19 @@ set(cosim_collateral
   driver.sv
   driver.cpp
 )
-
-install(FILES
-  ${cosim_collateral}
-  DESTINATION cosim
-  COMPONENT ESIRuntime
-)
+if (WHEEL_BUILD)
+  install(FILES
+    ${cosim_collateral}
+    DESTINATION cosim
+    COMPONENT ESIRuntime
+  )
+else()
+  install(FILES
+    ${cosim_collateral}
+    DESTINATION esiaccel/cosim
+    COMPONENT ESIRuntime
+  )
+endif()
 
 add_custom_target(esi-cosim
   COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/lib/Dialect/ESI/runtime/python/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/python/CMakeLists.txt
@@ -99,7 +99,7 @@ if(Python3_FOUND)
         )
       else()
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/esiaccel/esiCppAccel.pyi"
-          DESTINATION python/esiaccel
+          DESTINATION esiaccel
           COMPONENT ESIRuntime
         )
       endif()
@@ -110,7 +110,7 @@ if(Python3_FOUND)
         INSTALL_RPATH "$ORIGIN/lib")
     else()
       set_target_properties(esiCppAccel PROPERTIES
-        INSTALL_RPATH "$ORIGIN/../../lib")
+        INSTALL_RPATH "$ORIGIN/../lib")
     endif()
     set_target_properties(esiCppAccel PROPERTIES
       INSTALL_RPATH_USE_LINK_PATH FALSE)
@@ -122,7 +122,7 @@ if(Python3_FOUND)
       )
     else()
       install(TARGETS esiCppAccel
-        DESTINATION python/esiaccel
+        DESTINATION esiaccel
         COMPONENT ESIRuntime
       )
     endif()

--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/simulator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/simulator.py
@@ -60,14 +60,31 @@ class SourceFiles:
     """Return a list of all the DPI shared object files."""
 
     def find_so(name: str) -> Path:
-      for path in Simulator.get_env().get("LD_LIBRARY_PATH", "").split(":"):
+
+      def check_path(p: Path) -> Optional[Path]:
         if os.name == "nt":
-          so = Path(path) / f"{name}.dll"
+          so = p / f"{name}.dll"
         else:
-          so = Path(path) / f"lib{name}.so"
-        if so.exists():
-          return so
-      raise FileNotFoundError(f"Could not find {name}.so in LD_LIBRARY_PATH")
+          so = p / f"lib{name}.so"
+        return so if so.exists() else None
+
+      for path in Simulator.get_env().get("LD_LIBRARY_PATH", "").split(":"):
+        p = check_path(Path(path))
+        if p is not None:
+          return p
+
+      # If it's not in LD_LIBRARY_PATH, check a couple of parent directories
+      # relative to this file.
+      search_parent = _thisdir.parent
+      p = check_path(search_parent / "lib")
+      if p is not None:
+        return p
+      search_parent = search_parent.parent
+      p = check_path(search_parent / "lib")
+      if p is not None:
+        return p
+
+      raise FileNotFoundError(f"Could not find {name}.so")
 
     return [find_so(name) for name in self.dpi_so]
 
@@ -197,9 +214,9 @@ class Simulator:
 
     env = os.environ.copy()
     env["LIBRARY_PATH"] = env.get("LIBRARY_PATH", "") + ":" + str(
-        _thisdir.parent / "lib")
+        _thisdir.parent / "lib") + ":" + str(_thisdir.parent.parent / "lib")
     env["LD_LIBRARY_PATH"] = env.get("LD_LIBRARY_PATH", "") + ":" + str(
-        _thisdir.parent / "lib")
+        _thisdir.parent / "lib") + ":" + str(_thisdir.parent.parent / "lib")
     return env
 
   def compile_commands(self) -> List[CompileStep]:

--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
@@ -181,8 +181,11 @@ class Verilator(Simulator):
       cflags.append("-DTRACE")
     verilator_cmd += ["-CFLAGS", " ".join(cflags)]
     if self.sources.dpi_so:
+      dpi_so_paths = self.sources.dpi_so_paths()
       verilator_cmd += [
-          "-LDFLAGS", " ".join(["-l" + so for so in self.sources.dpi_so])
+          "-LDFLAGS",
+          " ".join(["-l" + so for so in self.sources.dpi_so]) + " " +
+          " ".join(["-L" + so.parent.as_posix() for so in dpi_so_paths]),
       ]
     verilator_cmd += [str(p) for p in self.sources.rtl_sources]
     top = self.sources.top

--- a/lib/Dialect/ESI/runtime/tests/conftest.py
+++ b/lib/Dialect/ESI/runtime/tests/conftest.py
@@ -11,4 +11,10 @@ collect_ignore_glob = [
 
 def get_runtime_root() -> Path:
   import esiaccel
-  return Path(esiaccel.__file__).resolve().parent.parent.parent
+  p = Path(esiaccel.__file__).resolve().parent.parent
+  if (p / "lib").exists():
+    return p
+  p = Path(esiaccel.__file__).resolve().parent.parent.parent
+  if p.exists():
+    return p
+  raise FileNotFoundError("Could not determine ESI runtime root directory")

--- a/lib/Dialect/ESI/runtime/tests/cpp/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/tests/cpp/CMakeLists.txt
@@ -54,6 +54,10 @@ add_executable(ESIRuntimeCppTests
 # <runtime-build-root>/tests/cpp/ — rather than the global bin/ directory.
 set_target_properties(ESIRuntimeCppTests PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+install(TARGETS ESIRuntimeCppTests
+  DESTINATION bin
+  COMPONENT ESIRuntimeTests
+)
 
 target_link_libraries(ESIRuntimeCppTests PRIVATE
   ESICppRuntime

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/CMakeLists.txt
@@ -10,11 +10,11 @@ if (NOT LOOPBACK_GENERATED_DIR)
   message(FATAL_ERROR "LOOPBACK_GENERATED_DIR must be set")
 endif()
 
-# Optional hint roots to help locate the ESI runtime headers and libraries.
-set(ESI_RUNTIME_ROOT "$ENV{ESI_RUNTIME_ROOT}" CACHE PATH
-  "ESI runtime build/install root")
+option(ESI_RUNTIME_ROOT "Path to ESI runtime installation or build directory" "")
 if (NOT ESI_RUNTIME_ROOT)
   message(FATAL_ERROR "ESI_RUNTIME_ROOT must be set or available in the environment")
+else()
+  message(STATUS "Using ESI runtime root: ${ESI_RUNTIME_ROOT}")
 endif()
 
 set(ESIACCEL_CONFIG "${ESI_RUNTIME_ROOT}/cmake/esiaccelConfig.cmake")
@@ -84,7 +84,9 @@ endif()
 
 find_path(CLI11_INCLUDE_DIR
   NAMES CLI/CLI.hpp
-  PATHS "${ESI_RUNTIME_ROOT}"
+  PATHS
+    "${ESI_RUNTIME_ROOT}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../build/"
   PATH_SUFFIXES _deps/cli11_proj-src/include)
 
 if (NOT CLI11_INCLUDE_DIR)

--- a/lib/Dialect/ESI/runtime/tests/unit/test_cpp_runtime.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_cpp_runtime.py
@@ -48,6 +48,9 @@ def _find_binary() -> Path | None:
     candidate = get_runtime_root() / "tests" / "cpp" / _BIN_NAME
     if candidate.is_file():
       return candidate
+    candidate = get_runtime_root() / "bin" / _BIN_NAME
+    if candidate.is_file():
+      return candidate
   except ImportError:
     pass
 


### PR DESCRIPTION
Fix the broken workflow. This is a new workflow to test ESI runtime changes. The old workflow (PyCDE and ESI Runtime test) built PyCDE, which takes a rather long time. This one installs the latest pre-release from PyPI. As a result, it will break when there is an unpublished change in PyCDE which a change in ESIRuntime tests needs. It's a trade-off.

This change was mostly debugging running pytest on the `cmake --install` version of the ESIRuntime without many environment variables set.