### PR TITLE
[ci] More clang versions in UBTI

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -90,6 +90,8 @@ on:
           - clang-15
           - clang-16
           - clang-17
+          - clang-18
+          - clang-19
           - gcc
           - cl
         default: clang
@@ -183,7 +185,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install iverilog libsystemc-dev ninja-build valgrind z3
+          sudo apt-get install ${{ steps.canonicalize.outputs.cmake_c_compiler }} iverilog libsystemc-dev ninja-build valgrind z3
           echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Restore Verilator Cache (Linux)
         if: inputs.run_integration_tests && runner.os == 'Linux'


### PR DESCRIPTION
Update the UBTI workflow_dispatch inputs to support more clang versions.
In the Linux build, have this try to install this version from the package
repositories.

This is done as part of trying to work towards a solution for #9914 and
after discussion on a "fix" with upstream for Clang 17 [[1]].

[1]: https://github.com/llvm/llvm-project/pull/192156
