### PR TITLE
[ci] Switch to Clang 19 for Valgrind Nightly

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -18,6 +18,7 @@ jobs:
         compiler:
           - clang
           - gcc
+          - clang-19
         valgrind: [false, true]
         exclude:
           - build-type: Debug
@@ -31,6 +32,11 @@ jobs:
           # TODO: This corner is failing and has been for some time. #5253.
           - build-type: Release
             compiler: gcc
+            valgrind: true
+          # clang-19 is used for valgrind builds instead of clang.
+          - compiler: clang-19
+            valgrind: false
+          - compiler: clang
             valgrind: true
     permissions:
       contents: write

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -48,8 +48,11 @@ jobs:
       build_shared_libs: ${{ matrix.build-shared }}
       llvm_enable_assertions: ${{ matrix.build-assert }}
       run_tests: true
-      run_integration_tests: true
+      run_integration_tests: ${{ !matrix.valgrind }}
       install_target: ""
       package_name_prefix: ""
       cmake_c_compiler: ${{ matrix.compiler }}
+      # We don't want to run valgrind on integration tests as these do things
+      # like run Verilator to generate C++ and then compile it.  We _don't_ want
+      # to be running valgrind on GCC or Clang themselves.
       valgrind: ${{ matrix.valgrind }}

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -48,11 +48,11 @@ jobs:
       build_shared_libs: ${{ matrix.build-shared }}
       llvm_enable_assertions: ${{ matrix.build-assert }}
       run_tests: true
+      # We don't want to run valgrind on integration tests as these do things
+      # like run Verilator to generate C++ and then compile it.  We _don't_ want
+      # to be running valgrind on GCC or Clang themselves.
       run_integration_tests: ${{ !matrix.valgrind }}
       install_target: ""
       package_name_prefix: ""
       cmake_c_compiler: ${{ matrix.compiler }}
-      # We don't want to run valgrind on integration tests as these do things
-      # like run Verilator to generate C++ and then compile it.  We _don't_ want
-      # to be running valgrind on GCC or Clang themselves.
       valgrind: ${{ matrix.valgrind }}

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -184,8 +184,15 @@ jobs:
         id: setup-linux
         if: runner.os == 'Linux'
         run: |
+          COMPILER="${{ steps.canonicalize.outputs.cmake_c_compiler }}"
+          if [[ "$COMPILER" =~ ^clang-([0-9]+)$ ]]; then
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
+            sudo ./llvm.sh "${BASH_REMATCH[1]}"
+          fi
+
           sudo apt-get update
-          sudo apt-get install ${{ steps.canonicalize.outputs.cmake_c_compiler }} iverilog libsystemc-dev ninja-build valgrind z3
+          sudo apt-get install "$COMPILER" iverilog libsystemc-dev ninja-build valgrind z3
           echo cmake="-DLLVM_ENABLE_Z3_SOLVER=ON" >> "$GITHUB_OUTPUT"
       - name: Restore Verilator Cache (Linux)
         if: inputs.run_integration_tests && runner.os == 'Linux'


### PR DESCRIPTION
Switch from Clang 17 to Clang 19 for the single valgrind nightly job.
This is done because it is suspected that this is a valgrind false
positive.

Fixes #9914.
