### PR TITLE
[ExportVerilog] Update LoweringOptionsParser flags

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -112,10 +112,8 @@ The current set of "style" Lowering Options is:
    (e.g. inner symbols) into comments.
  * `disallowMuxInlining` (default=`false`). If true, every mux expression is spilled to a wire.
    This is used to avoid emitting deeply nested mux expressions to improve readability.
- * `wireSpillingHeuristic` (default=`spillNone`). This controls extra wire spilling performed
-   in PrepareForEmission to improve readability and debuggability. It is possible to combine
-   several heuristics by specifying `wireSpillingHeuristic` multiple times.
-   (e.g. `wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingHeuristic=spillAllMux`).
+ * `wireSpillingHeuristic` (default=`null`). This controls extra wire spilling performed
+   in PrepareForEmission to improve readability and debuggability.
    * `spillLargeTermsWithNamehints`: If spillLargeTermsWithNamehints is specified, expressions
      with meaningful namehints (i.e. names which start with "\_") are spilled to wires.
      For a namehint with "\_" prefix, if the term size is greater than `wireSpillingNamehintTermLimit`

--- a/include/circt/Support/LoweringOptionsParser.h
+++ b/include/circt/Support/LoweringOptionsParser.h
@@ -43,14 +43,20 @@ struct LoweringOptionsOption
             llvm::cl::desc(
                 "Style options.  Valid flags include: "
                 "noAlwaysComb, exprInEventControl, disallowPackedArrays, "
+                "disallowPackedStructAssignments, "
                 "disallowLocalVariables, verifLabels, emittedLineLength=<n>, "
                 "maximumNumberOfTermsPerExpression=<n>, "
                 "explicitBitcast, emitReplicatedOpsToHeader, "
                 "locationInfoStyle={plain,wrapInAtSquareBracket,none}, "
                 "disallowPortDeclSharing, printDebugInfo, "
+                "wireSpillingHeuristic=<spillLargeTermsWithNamehints>, "
+                "wireSpillingNamehintTermLimit=<n>, "
                 "disallowExpressionInliningInPorts, disallowMuxInlining, "
-                "emitWireInPort, emitBindComments, omitVersionComment, "
-                "caseInsensitiveKeywords, disallowClockedAssertions"),
+                "mitigateVivadoArrayIndexConstPropBug, "
+                "emitWireInPorts, emitBindComments, omitVersionComment, "
+                "caseInsensitiveKeywords, emitVerilogLocations, "
+                "fixUpEmptyModules, disallowClockedAssertions, "
+                "disallowDeclAssignments"),
             llvm::cl::cat(cat), llvm::cl::value_desc("option")} {}
 };
 


### PR DESCRIPTION
This PR updates flag descriptions with following `LowerOptions` which was not shipped out before:

- `disallowPackedStructAssignments`
- `wireSpillingHuristic`
- `wireSpillingNamehintTermLimit`
- `mitigateVivadoArrayIndexConstPropBug`
- `emitVerilogLocations`
- `fixUpEmptyModules`
- `disallowDeclAssignments`

And adds 's' behind `emitWireInProp`. This resolves  #10217.