### PR TITLE
[ImportVerilog] Add support for buf primitive

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1888,6 +1888,9 @@ LogicalResult Context::convertNOutputPrimitive(
       llvm::StringSwitch<std::function<Value()>>(prim.primitiveType.name)
           .Case("not",
                 ([&] { return moore::NotOp::create(builder, loc, inputVal); }))
+          .Case("buf", ([&] {
+                  return moore::BoolCastOp::create(builder, loc, inputVal);
+                }))
           .Default([&] {
             mlir::emitError(loc)
                 << "unsupported primitive `" << primName << "`";

--- a/test/Conversion/ImportVerilog/primitives.sv
+++ b/test/Conversion/ImportVerilog/primitives.sv
@@ -158,3 +158,15 @@ module multi_not_prim;
     logic A, Q0, Q1;
     not n (Q0, Q1, A);
 endmodule
+
+// CHECK-LABEL: moore.module @buf_prim()
+// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[Q:%.+]] = moore.variable : <l1>
+// CHECK: [[RD_A:%.+]] = moore.read [[A]] : <l1>
+// CHECK: [[NOT:%.+]] = moore.bool_cast [[RD_A]] : l1
+// CHECK: moore.assign [[Q]], [[NOT]] : l1
+
+module buf_prim;
+    logic A, Q;
+    buf n (Q, A);
+endmodule


### PR DESCRIPTION
buf's truth table is:

<img width="311" height="393" alt="image" src="https://github.com/user-attachments/assets/a4557db9-bca3-4e33-bfa3-6189c6ab8d51" />

and bool_cast will 'Convert a nonzero or true value into 1, a zero or false value into 0, and any value containing Z or X bits into a X', so this felt like a sensible mapping, but conscious that bool_cast is probably intended for use with wider bitvecs so alternative suggestions on a potential mapping I missed very welcome!