### PR TITLE
[github] Add a PR template for AI policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@ including the requirements for human review, transparency, and accountability.
 
 Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.
 
-AI-assisted-by: <fill this in for substantial AI-generated content, e.g., "Claude Code: Opus 4.6">
+Include the following message trailer in commits and Pull Requests when AI tools were used:
+Assisted-by: <tool>:<model>
 
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!--
+
+If AI tools were used, ensure this pull request complies with the
+[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
+including the requirements for human review, transparency, and accountability.
+
+Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.
+
+AI-assisted-by: <fill this in for substantial AI-generated content, e.g., "Claude Code: Opus 4.6">
+
+-->


### PR DESCRIPTION
This adds a PR template that displays a link to AI policy. 
This is currently shown as a comment, so it won't show up in the actual PR description so that it doesn't cause annoyance for regular contributors. 

<img width="1429" height="691" alt="test" src="https://github.com/user-attachments/assets/92eeed1a-d028-4bcc-b1c8-e039b261f1c0" />

AI-assisted-by: Codex GPT-5.4