### PR TITLE
[Synth] Refactor invertible logic op handling, NFC

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -23,14 +23,23 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class SynthOp<string mnemonic, list<Trait> traits = []> :
     Op<Synth_Dialect, mnemonic, traits>;
 
-def AndInverterOp :
-  SynthOp<"aig.and_inv",
-          [SameOperandsAndResultType, Pure,
-           DeclareOpInterfaceMethods<BooleanLogicOpInterface,
-                                     ["areInputsPermutationInvariant",
-                                      "getLogicDepthCost",
-                                      "getLogicAreaCost",
-                                      "emitCNF"]>]> {
+class InvertibleOperandsOp<string mnemonic, list<Trait> traits = []>
+  : SynthOp<mnemonic,[
+      SameOperandsAndResultType, Pure,
+      DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
+        "areInputsPermutationInvariant", "getLogicDepthCost",
+        "getLogicAreaCost", "emitCNF"
+      ]> ] # traits> {
+  // TODO: Restrict to HWIntegerType.
+  let arguments = (ins Variadic<AnyType>:$inputs,
+                       DenseBoolArrayAttr:$inverted);
+  let results = (outs AnyType:$result);
+  let assemblyFormat = [{
+    custom<VariadicInvertibleOperands>($inputs, type($result), $inverted, attr-dict)
+  }];
+}
+
+def AndInverterOp : InvertibleOperandsOp<"aig.and_inv"> {
   let summary = "AIG dialect AND operation";
   let description = [{
     The `synth.aig.and_inv` operation represents an And-Inverter in the AIG dialect.
@@ -59,13 +68,6 @@ def AndInverterOp :
     scalability. This approach enables a form of vectorization, allowing for
     batch processing of logic synthesis when multibit operations are constructed
     in a similar manner.
-  }];
-  // TODO: Restrict to HWIntegerType.
-  let arguments = (ins Variadic<AnyType>:$inputs, DenseBoolArrayAttr:$inverted);
-  let results = (outs AnyType:$result);
-
-  let assemblyFormat = [{
-    custom<VariadicInvertibleOperands>($inputs, type($result), $inverted, attr-dict)
   }];
 
   let builders = [OpBuilder<(ins "Value":$input, CArg<"bool", "false">:$invert),

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -25,6 +25,8 @@ class SynthOp<string mnemonic, list<Trait> traits = []> :
 
 class InvertibleOperandsOp<string mnemonic, list<Trait> traits = []>
   : SynthOp<mnemonic,[
+      // Share the BooleanLogicOpInterface contract and invertible operand
+      // syntax across Synth ops such as `synth.aig.and_inv`.
       SameOperandsAndResultType, Pure,
       DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
         "areInputsPermutationInvariant", "getLogicDepthCost",

--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -32,13 +32,15 @@ using namespace comb;
 
 namespace {
 
+// Return a value that represents the inverted input if `inverted` is true,
 static Value materializeInvertedInput(Location loc, Value input, bool inverted,
-                                      ConversionPatternRewriter &rewriter) {
+                                      ConversionPatternRewriter &rewriter,
+                                      hw::ConstantOp &allOnes) {
   if (!inverted)
     return input;
   auto width = input.getType().getIntOrFloatBitWidth();
-  auto allOnes =
-      hw::ConstantOp::create(rewriter, loc, APInt::getAllOnes(width));
+  if (!allOnes)
+    allOnes = hw::ConstantOp::create(rewriter, loc, APInt::getAllOnes(width));
   return rewriter.createOrFold<comb::XorOp>(loc, input, allOnes, true);
 }
 
@@ -56,6 +58,8 @@ struct SynthChoiceOpConversion : OpConversionPattern<synth::ChoiceOp> {
 template <typename SynthOp>
 struct SynthInverterOpConversion : OpConversionPattern<SynthOp> {
   using OpConversionPattern<SynthOp>::OpConversionPattern;
+  // Subclasses provide the target comb op after generic input inversion has
+  // been materialized.
   virtual Value createOp(Location loc, ArrayRef<Value> inputs,
                          ConversionPatternRewriter &rewriter) const = 0;
 
@@ -64,10 +68,12 @@ struct SynthInverterOpConversion : OpConversionPattern<SynthOp> {
                   ConversionPatternRewriter &rewriter) const override {
     SmallVector<Value> operands;
     operands.reserve(op.getNumOperands());
+    hw::ConstantOp allOnes;
     for (auto [input, inverted] :
          llvm::zip(adaptor.getInputs(), op.getInverted()))
-      operands.push_back(
-          materializeInvertedInput(op.getLoc(), input, inverted, rewriter));
+      operands.push_back(materializeInvertedInput(op.getLoc(), input, inverted,
+                                                  rewriter, allOnes));
+    // `createOp` now only needs to encode the core boolean operator.
     rewriter.replaceOp(op, createOp(op.getLoc(), operands, rewriter));
     return success();
   }
@@ -82,7 +88,6 @@ struct SynthAndInverterOpConversion
     return rewriter.createOrFold<comb::AndOp>(loc, inputs, true);
   }
 };
-
 
 } // namespace
 

--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -32,6 +32,16 @@ using namespace comb;
 
 namespace {
 
+static Value materializeInvertedInput(Location loc, Value input, bool inverted,
+                                      ConversionPatternRewriter &rewriter) {
+  if (!inverted)
+    return input;
+  auto width = input.getType().getIntOrFloatBitWidth();
+  auto allOnes =
+      hw::ConstantOp::create(rewriter, loc, APInt::getAllOnes(width));
+  return rewriter.createOrFold<comb::XorOp>(loc, input, allOnes, true);
+}
+
 struct SynthChoiceOpConversion : OpConversionPattern<synth::ChoiceOp> {
   using OpConversionPattern<synth::ChoiceOp>::OpConversionPattern;
   LogicalResult
@@ -43,28 +53,36 @@ struct SynthChoiceOpConversion : OpConversionPattern<synth::ChoiceOp> {
   }
 };
 
-struct SynthAndInverterOpConversion
-    : OpConversionPattern<synth::aig::AndInverterOp> {
-  using OpConversionPattern<synth::aig::AndInverterOp>::OpConversionPattern;
-  LogicalResult
-  matchAndRewrite(synth::aig::AndInverterOp op, OpAdaptor adaptor,
+template <typename SynthOp>
+struct SynthInverterOpConversion : OpConversionPattern<SynthOp> {
+  using OpConversionPattern<SynthOp>::OpConversionPattern;
+  virtual Value createOp(Location loc, ArrayRef<Value> inputs,
+                         ConversionPatternRewriter &rewriter) const = 0;
+
+  virtual LogicalResult
+  matchAndRewrite(SynthOp op, typename SynthOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Convert to comb.and + comb.xor + hw.constant
-    auto width = op.getResult().getType().getIntOrFloatBitWidth();
-    auto allOnes =
-        hw::ConstantOp::create(rewriter, op.getLoc(), APInt::getAllOnes(width));
     SmallVector<Value> operands;
     operands.reserve(op.getNumOperands());
-    for (auto [input, inverted] : llvm::zip(op.getOperands(), op.getInverted()))
-      operands.push_back(inverted ? rewriter.createOrFold<comb::XorOp>(
-                                        op.getLoc(), input, allOnes, true)
-                                  : input);
-    // NOTE: Use createOrFold to avoid creating a new operation if possible.
-    rewriter.replaceOp(
-        op, rewriter.createOrFold<comb::AndOp>(op.getLoc(), operands, true));
+    for (auto [input, inverted] :
+         llvm::zip(adaptor.getInputs(), op.getInverted()))
+      operands.push_back(
+          materializeInvertedInput(op.getLoc(), input, inverted, rewriter));
+    rewriter.replaceOp(op, createOp(op.getLoc(), operands, rewriter));
     return success();
   }
 };
+
+struct SynthAndInverterOpConversion
+    : SynthInverterOpConversion<synth::aig::AndInverterOp> {
+  using SynthInverterOpConversion<
+      synth::aig::AndInverterOp>::SynthInverterOpConversion;
+  Value createOp(Location loc, ArrayRef<Value> inputs,
+                 ConversionPatternRewriter &rewriter) const override {
+    return rewriter.createOrFold<comb::AndOp>(loc, inputs, true);
+  }
+};
+
 
 } // namespace
 

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -33,6 +33,8 @@ using namespace circt::synth::aig;
 
 namespace {
 
+// Keep inversion semantics identical across folding, analysis, and CNF
+// lowering so new invertible Synth ops can reuse the same helpers.
 inline APInt applyInversion(APInt value, bool inverted) {
   if (inverted)
     value.flipAllBits();
@@ -239,6 +241,7 @@ APInt AndInverterOp::evaluateBooleanLogic(
   APInt result = APInt::getAllOnes(getInputValue(0).getBitWidth());
   for (auto [idx, inverted] : llvm::enumerate(getInverted())) {
     const APInt &input = getInputValue(idx);
+    // Model each operand inversion before intersecting with the running AND.
     result &= applyInversion(input, inverted);
   }
   return result;

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -31,6 +31,27 @@ using namespace circt::synth::aig;
 #define GET_OP_CLASSES
 #include "circt/Dialect/Synth/Synth.cpp.inc"
 
+namespace {
+
+inline APInt applyInversion(APInt value, bool inverted) {
+  if (inverted)
+    value.flipAllBits();
+  return value;
+}
+
+inline llvm::KnownBits applyInversion(llvm::KnownBits value, bool inverted) {
+  if (inverted)
+    std::swap(value.Zero, value.One);
+  return value;
+}
+
+inline int applyInversion(int lit, bool inverted) {
+  assert(lit != 0 && "expected non-zero SAT literal");
+  return inverted ? -lit : lit;
+}
+
+} // namespace
+
 LogicalResult ChoiceOp::verify() {
   if (getNumOperands() < 1)
     return emitOpError("requires at least one operand");
@@ -108,7 +129,7 @@ LogicalResult ChoiceOp::canonicalize(ChoiceOp op, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
-// AIG Operations
+// AndInverterOp
 //===----------------------------------------------------------------------===//
 
 bool AndInverterOp::areInputsPermutationInvariant() { return true; }
@@ -218,10 +239,7 @@ APInt AndInverterOp::evaluateBooleanLogic(
   APInt result = APInt::getAllOnes(getInputValue(0).getBitWidth());
   for (auto [idx, inverted] : llvm::enumerate(getInverted())) {
     const APInt &input = getInputValue(idx);
-    if (inverted)
-      result &= ~input;
-    else
-      result &= input;
+    result &= applyInversion(input, inverted);
   }
   return result;
 }
@@ -235,12 +253,8 @@ llvm::KnownBits AndInverterOp::computeKnownBits(
   result.One = APInt::getAllOnes(width);
   result.Zero = APInt::getZero(width);
 
-  for (auto [i, inverted] : llvm::enumerate(getInverted())) {
-    auto operandKnownBits = getInputKnownBits(i);
-    if (inverted)
-      std::swap(operandKnownBits.Zero, operandKnownBits.One);
-    result &= operandKnownBits;
-  }
+  for (auto [i, inverted] : llvm::enumerate(getInverted()))
+    result &= applyInversion(getInputKnownBits(i), inverted);
 
   return result;
 }
@@ -268,7 +282,7 @@ void AndInverterOp::emitCNF(
   inputLits.reserve(inputVars.size());
   for (auto [inputVar, inverted] : llvm::zip(inputVars, getInverted())) {
     assert(inputVar > 0 && "input SAT variables must be positive");
-    inputLits.push_back(inverted ? -inputVar : inputVar);
+    inputLits.push_back(applyInversion(inputVar, inverted));
   }
   circt::addAndClauses(outVar, inputLits, addClause);
 }

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -154,22 +154,22 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
 
   auto handleInvertibleBinaryGate = [&](auto logicOp,
                                         LogicNetworkGate::Kind kind) {
-    if (!logicOp.getType().isInteger(1)) {
-      handleOtherResults(logicOp);
-      return success();
-    }
-    if (logicOp->getNumOperands() == 1) {
+    // The cut rewriter only has dedicated nodes for single-bit unary/binary
+    // gates. Wider or variadic forms stay as opaque cut inputs for now.
+    const auto inputs = logicOp.getInputs();
+    if (inputs.size() == 1) {
       const Signal inputSignal = getInvertibleSignal(logicOp, 0);
       handleSingleInputGate(logicOp, logicOp.getResult(), inputSignal);
       return success();
     }
-    if (logicOp->getNumOperands() != 2) {
-      handleOtherResults(logicOp);
-      return success();
+    if (inputs.size() == 2) {
+      const Signal lhsSignal = getInvertibleSignal(logicOp, 0);
+      const Signal rhsSignal = getInvertibleSignal(logicOp, 1);
+      addGate(logicOp, kind, {lhsSignal, rhsSignal});
     }
-    const Signal lhsSignal = getInvertibleSignal(logicOp, 0);
-    const Signal rhsSignal = getInvertibleSignal(logicOp, 1);
-    addGate(logicOp, kind, {lhsSignal, rhsSignal});
+    // Variadic gates with >2 inputs are treated as primary
+    // inputs for now.
+    handleOtherResults(logicOp);
     return success();
   };
 

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -148,29 +148,37 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
     }
   };
 
+  auto getInvertibleSignal = [&](auto op, unsigned index) {
+    return getOrCreateSignal(op.getOperand(index), op.isInverted(index));
+  };
+
+  auto handleInvertibleBinaryGate = [&](auto logicOp,
+                                        LogicNetworkGate::Kind kind) {
+    if (!logicOp.getType().isInteger(1)) {
+      handleOtherResults(logicOp);
+      return success();
+    }
+    if (logicOp->getNumOperands() == 1) {
+      const Signal inputSignal = getInvertibleSignal(logicOp, 0);
+      handleSingleInputGate(logicOp, logicOp.getResult(), inputSignal);
+      return success();
+    }
+    if (logicOp->getNumOperands() != 2) {
+      handleOtherResults(logicOp);
+      return success();
+    }
+    const Signal lhsSignal = getInvertibleSignal(logicOp, 0);
+    const Signal rhsSignal = getInvertibleSignal(logicOp, 1);
+    addGate(logicOp, kind, {lhsSignal, rhsSignal});
+    return success();
+  };
+
   // Process operations in topological order
   for (Operation &op : block->getOperations()) {
     LogicalResult result =
         llvm::TypeSwitch<Operation *, LogicalResult>(&op)
             .Case<aig::AndInverterOp>([&](aig::AndInverterOp andOp) {
-              const auto inputs = andOp.getInputs();
-              if (inputs.size() == 1) {
-                // Single-input AND is a buffer or NOT gate
-                const Signal inputSignal =
-                    getOrCreateSignal(inputs[0], andOp.isInverted(0));
-                handleSingleInputGate(andOp, andOp.getResult(), inputSignal);
-              } else if (inputs.size() == 2) {
-                const Signal lhsSignal =
-                    getOrCreateSignal(inputs[0], andOp.isInverted(0));
-                const Signal rhsSignal =
-                    getOrCreateSignal(inputs[1], andOp.isInverted(1));
-                addGate(andOp, LogicNetworkGate::And2, {lhsSignal, rhsSignal});
-              } else {
-                // Variadic AND gates with >2 inputs are treated as primary
-                // inputs.
-                handleOtherResults(andOp);
-              }
-              return success();
+              return handleInvertibleBinaryGate(andOp, LogicNetworkGate::And2);
             })
             .Case<comb::XorOp>([&](comb::XorOp xorOp) {
               if (xorOp->getNumOperands() != 2) {

--- a/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
@@ -46,8 +46,8 @@ using namespace synth;
 
 /// Check if an operation should be lowered to bit-level operations.
 static bool shouldLowerOperation(Operation *op) {
-  return isa<ChoiceOp, aig::AndInverterOp, comb::AndOp, comb::OrOp, comb::XorOp,
-             comb::MuxOp>(op);
+  return isa<ChoiceOp, BooleanLogicOpInterface, comb::AndOp, comb::OrOp,
+             comb::XorOp, comb::MuxOp>(op);
 }
 
 namespace {

--- a/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerWordToBits.cpp
@@ -46,6 +46,8 @@ using namespace synth;
 
 /// Check if an operation should be lowered to bit-level operations.
 static bool shouldLowerOperation(Operation *op) {
+  // Lower all Synth boolean ops through the interface instead of maintaining a
+  // per-op allowlist here.
   return isa<ChoiceOp, BooleanLogicOpInterface, comb::AndOp, comb::OrOp,
              comb::XorOp, comb::MuxOp>(op);
 }


### PR DESCRIPTION
Extract common invertible operand behavior into a shared Synth op base and
reuse inversion helpers across evaluation, known-bits, and CNF emission for
aig.and_inv. Generalize the SynthToComb lowering and cut rewriter logic for
invertible gates, and lower all BooleanLogicOpInterface ops in word-to-bits.

This reduces duplicated inversion handling and prepares the Synth dialect for
additional invertible boolean ops.

