### PR TITLE
[Synth] Add synth.xor_inv 

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -864,6 +864,9 @@ def ConvertCombToSynth : Pass<"convert-comb-to-synth"> {
   let options =
       [ListOption<"additionalLegalOps", "additional-legal-ops", "std::string",
                   "Specify additional legal ops to partially legalize Comb">,
+       Option<"forceAIG", "force-aig", "bool", "true",
+              "Force lowering to AIG-only synth ops instead of preserving "
+              "higher-level synth ops such as synth.xor_inv">,
        Option<"maxEmulationUnknownBits", "max-emulation-unknown-bits",
               "uint32_t", "10",
               "Maximum number of unknown bits to emulate in a table lookup">];

--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -33,13 +33,10 @@
 
 namespace circt {
 namespace synth {
-struct AndInverterVariadicOpConversion
-    : mlir::OpRewritePattern<aig::AndInverterOp> {
-  using OpRewritePattern<aig::AndInverterOp>::OpRewritePattern;
-  mlir::LogicalResult
-  matchAndRewrite(aig::AndInverterOp op,
-                  mlir::PatternRewriter &rewriter) const override;
-};
+void populateVariadicAndInverterLoweringPatterns(
+    mlir::RewritePatternSet &patterns);
+void populateVariadicXorInverterLoweringPatterns(
+    mlir::RewritePatternSet &patterns);
 
 /// This function performs a topological sort on the operations within each
 /// block of graph regions in the given operation. It uses MLIR's topological

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -90,6 +90,36 @@ def AndInverterOp : InvertibleOperandsOp<"aig.and_inv"> {
   let cppNamespace = "::circt::synth::aig";
 }
 
+def XorInverterOp : InvertibleOperandsOp<"xor_inv"> {
+  let summary = "XOR gate with invertible variadic inputs";
+  let description = [{
+    The `synth.xor_inv` operation represents a parity node whose operands may be
+    individually inverted before the XOR is evaluated.
+
+    Example:
+    ```mlir
+      %r0 = synth.xor_inv %a, %b : i1
+      %r1 = synth.xor_inv not %a, %b, %c : i8
+      %r2 = synth.xor_inv not %a : i1
+    ```
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$input, CArg<"bool", "false">:$invert),
+                            [{
+      SmallVector<bool> inverted {invert};
+      return build($_builder, $_state, {input}, inverted);
+    }]>,
+    OpBuilder<(ins "Value":$lhs, "Value":$rhs,
+                                CArg<"bool", "false">:$invertLhs,
+                                CArg<"bool", "false">:$invertRhs),
+                            [{
+      SmallVector<bool> inverted {invertLhs, invertRhs};
+      return build($_builder, $_state, {lhs, rhs}, inverted);
+    }]>];
+
+}
+
 def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
   let summary = "Synth choice operation";
   let description = [{

--- a/integration_test/circt-synth/functional-reduction-cadical.mlir
+++ b/integration_test/circt-synth/functional-reduction-cadical.mlir
@@ -20,3 +20,12 @@ hw.module @functional_reduction_sat(in %a: i1, in %b: i1, in %c: i1, in %d: i1,
   %4 = synth.aig.and_inv %a, not %b, not %c, not %d : i1
   hw.output %2, %3, %4 : i1, i1, i1
 }
+
+// CHECK-LABEL: hw.module @functional_reduction_xor_inv_sat
+hw.module @functional_reduction_xor_inv_sat(in %a: i1, in %b: i1,
+                                            out out0: i1, out out1: i1) {
+  // CHECK: hw.output %[[CHOICE:.+]], %[[CHOICE]] : i1, i1
+  %0 = synth.xor_inv %a, %b : i1
+  %1 = comb.xor %b, %a : i1
+  hw.output %0, %1 : i1, i1
+}

--- a/integration_test/circt-synth/functional-reduction-cadical.mlir
+++ b/integration_test/circt-synth/functional-reduction-cadical.mlir
@@ -20,12 +20,3 @@ hw.module @functional_reduction_sat(in %a: i1, in %b: i1, in %c: i1, in %d: i1,
   %4 = synth.aig.and_inv %a, not %b, not %c, not %d : i1
   hw.output %2, %3, %4 : i1, i1, i1
 }
-
-// CHECK-LABEL: hw.module @functional_reduction_xor_inv_sat
-hw.module @functional_reduction_xor_inv_sat(in %a: i1, in %b: i1,
-                                            out out0: i1, out out1: i1) {
-  // CHECK: hw.output %[[CHOICE:.+]], %[[CHOICE]] : i1, i1
-  %0 = synth.xor_inv %a, %b : i1
-  %1 = comb.xor %b, %a : i1
-  hw.output %0, %1 : i1, i1
-}

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -68,10 +68,13 @@ hw.module @functional_reduction_inversion_equiv_sat(in %a: i1, in %b: i1,
 // RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_xor_inv_sat --c2 functional_reduction_xor_inv_sat | FileCheck %s --check-prefix=XOR-INV
 // XOR-INV: c1 == c2
 // CHECK-LABEL: hw.module @functional_reduction_xor_inv_sat
-hw.module @functional_reduction_xor_inv_sat(in %a: i1, in %b: i1, in %c: i1,
+hw.module @functional_reduction_xor_inv_sat(in %a: i1, in %b: i1,
                                             out out0: i1, out out1: i1) {
   // CHECK: hw.output %[[CHOICE:.+]], %[[CHOICE]] : i1, i1
-  %0 = synth.xor_inv not %a, %b, %b, not %b, not %c, %c : i1
-  %1 = synth.xor_inv not %a, %b : i1
-  hw.output %0, %1 : i1, i1
+  %0 = synth.xor_inv %a, %b : i1
+  %1 = synth.aig.and_inv not %a, %b : i1
+  %2 = synth.aig.and_inv %a, not %b : i1
+  %3 = synth.aig.and_inv not %1, not %2 : i1
+  %4 = synth.aig.and_inv not %3 : i1
+  hw.output %0, %4 : i1, i1
 }

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -62,3 +62,16 @@ hw.module @functional_reduction_inversion_equiv_sat(in %a: i1, in %b: i1,
   %1 = comb.or %a, %b : i1
   hw.output %0, %1 : i1, i1
 }
+
+// SAT should also prove equivalence between synth.xor_inv and an AND/OR
+// implementation of XOR.
+// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_xor_inv_sat --c2 functional_reduction_xor_inv_sat | FileCheck %s --check-prefix=XOR-INV
+// XOR-INV: c1 == c2
+// CHECK-LABEL: hw.module @functional_reduction_xor_inv_sat
+hw.module @functional_reduction_xor_inv_sat(in %a: i1, in %b: i1, in %c: i1,
+                                            out out0: i1, out out1: i1) {
+  // CHECK: hw.output %[[CHOICE:.+]], %[[CHOICE]] : i1, i1
+  %0 = synth.xor_inv not %a, %b, %b, not %b, not %c, %c : i1
+  %1 = synth.xor_inv not %a, %b : i1
+  hw.output %0, %1 : i1, i1
+}

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -307,12 +307,26 @@ struct CombOrToAIGConversion : OpConversionPattern<OrOp> {
   }
 };
 
-/// Lower a comb::XorOp operation to AIG operations
-struct CombXorOpConversion : OpConversionPattern<XorOp> {
+struct CombXorOpToSynthConversion : OpConversionPattern<XorOp> {
   using OpConversionPattern<XorOp>::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(XorOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<bool> inverted(adaptor.getInputs().size(), false);
+    replaceOpWithNewOpAndCopyNamehint<synth::XorInverterOp>(
+        rewriter, op, adaptor.getInputs(), inverted);
+    return success();
+  }
+};
+
+/// Lower a synth::XorOp operation to AIG operations
+struct SynthXorInverterOpConversion
+    : OpConversionPattern<synth::XorInverterOp> {
+  using OpConversionPattern<synth::XorInverterOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(synth::XorInverterOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (op.getNumOperands() != 2)
       return failure();
@@ -321,8 +335,8 @@ struct CombXorOpConversion : OpConversionPattern<XorOp> {
     // (a | b) = ~(~a & ~b)
     // (~a | ~b) = ~(a & b)
     auto inputs = adaptor.getInputs();
-    SmallVector<bool> allInverts(inputs.size(), true);
-    SmallVector<bool> allNotInverts(inputs.size(), false);
+    auto allNotInverts = op.getInverted();
+    std::array<bool, 2> allInverts = {!allNotInverts[0], !allNotInverts[1]};
 
     auto notAAndNotB = synth::aig::AndInverterOp::create(rewriter, op.getLoc(),
                                                          inputs, allInverts);
@@ -1343,24 +1357,31 @@ struct ConvertCombToSynthPass
 
 static void
 populateCombToAIGConversionPatterns(RewritePatternSet &patterns,
-                                    uint32_t maxEmulationUnknownBits) {
+                                    uint32_t maxEmulationUnknownBits,
+                                    bool forceAIG) {
   patterns.add<
       // Bitwise Logical Ops
-      CombAndOpConversion, CombXorOpConversion, CombMuxOpConversion,
-      CombParityOpConversion,
+      CombAndOpConversion, CombMuxOpConversion, CombParityOpConversion,
+      CombXorOpToSynthConversion,
       // Arithmetic Ops
       CombMulOpConversion, CombICmpOpConversion,
       // Shift Ops
       CombShlOpConversion, CombShrUOpConversion, CombShrSOpConversion,
       // Variadic ops that must be lowered to binary operations
-      CombLowerVariadicOp<XorOp>, CombLowerVariadicOp<AddOp>,
-      CombLowerVariadicOp<MulOp>>(patterns.getContext());
+      CombLowerVariadicOp<AddOp>, CombLowerVariadicOp<MulOp>>(
+      patterns.getContext());
+
+  if (forceAIG)
+    patterns.add<SynthXorInverterOpConversion>(patterns.getContext());
 
   patterns.add(comb::convertSubToAdd);
 
-  patterns
-      .add<CombOrToAIGConversion, circt::synth::AndInverterVariadicOpConversion,
-           CombAddOpConversion>(patterns.getContext());
+  patterns.add<CombOrToAIGConversion, CombAddOpConversion>(
+      patterns.getContext());
+  synth::populateVariadicAndInverterLoweringPatterns(patterns);
+
+  if (forceAIG)
+    synth::populateVariadicXorInverterLoweringPatterns(patterns);
 
   // Add div/mod patterns with a threshold given by the pass option.
   patterns.add<CombDivUOpConversion, CombModUOpConversion, CombDivSOpConversion,
@@ -1385,6 +1406,8 @@ void ConvertCombToSynthPass::runOnOperation() {
                       hw::AggregateConstantOp>();
 
   target.addLegalDialect<synth::SynthDialect>();
+  if (forceAIG)
+    target.addIllegalOp<synth::XorInverterOp>();
 
   // If additional legal ops are specified, add them to the target.
   if (!additionalLegalOps.empty())
@@ -1392,7 +1415,8 @@ void ConvertCombToSynthPass::runOnOperation() {
       target.addLegalOp(OperationName(opName, &getContext()));
 
   RewritePatternSet patterns(&getContext());
-  populateCombToAIGConversionPatterns(patterns, maxEmulationUnknownBits);
+  populateCombToAIGConversionPatterns(patterns, maxEmulationUnknownBits,
+                                      forceAIG);
 
   if (failed(mlir::applyPartialConversion(getOperation(), target,
                                           std::move(patterns))))

--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -89,6 +89,16 @@ struct SynthAndInverterOpConversion
   }
 };
 
+struct SynthXorInverterOpConversion
+    : SynthInverterOpConversion<synth::XorInverterOp> {
+  using SynthInverterOpConversion<
+      synth::XorInverterOp>::SynthInverterOpConversion;
+  Value createOp(Location loc, ArrayRef<Value> inputs,
+                 ConversionPatternRewriter &rewriter) const override {
+    return rewriter.createOrFold<comb::XorOp>(loc, inputs, true);
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -105,8 +115,8 @@ struct ConvertSynthToCombPass
 } // namespace
 
 static void populateSynthToCombConversionPatterns(RewritePatternSet &patterns) {
-  patterns.add<SynthChoiceOpConversion, SynthAndInverterOpConversion>(
-      patterns.getContext());
+  patterns.add<SynthChoiceOpConversion, SynthAndInverterOpConversion,
+               SynthXorInverterOpConversion>(patterns.getContext());
 }
 
 void ConvertSynthToCombPass::runOnOperation() {

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -283,51 +283,113 @@ void AndInverterOp::emitCNF(
 
   SmallVector<int> inputLits;
   inputLits.reserve(inputVars.size());
-  for (auto [inputVar, inverted] : llvm::zip(inputVars, getInverted())) {
-    assert(inputVar > 0 && "input SAT variables must be positive");
+  for (auto [inputVar, inverted] : llvm::zip(inputVars, getInverted()))
     inputLits.push_back(applyInversion(inputVar, inverted));
-  }
   circt::addAndClauses(outVar, inputLits, addClause);
 }
 
-static Value lowerVariadicAndInverterOp(AndInverterOp op, OperandRange operands,
-                                        ArrayRef<bool> inverts,
-                                        PatternRewriter &rewriter) {
+//===----------------------------------------------------------------------===//
+// XorInverterOp
+//===----------------------------------------------------------------------===//
+
+bool XorInverterOp::areInputsPermutationInvariant() { return true; }
+
+APInt XorInverterOp::evaluateBooleanLogic(
+    llvm::function_ref<const APInt &(unsigned)> getInputValue) {
+  assert(getNumOperands() > 0 && "Expected non-empty input list");
+  APInt result = APInt::getZero(getInputValue(0).getBitWidth());
+  for (auto [idx, inverted] : llvm::enumerate(getInverted()))
+    result ^= applyInversion(getInputValue(idx), inverted);
+  return result;
+}
+
+llvm::KnownBits XorInverterOp::computeKnownBits(
+    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
+  assert(getNumOperands() > 0 && "Expected non-empty input list");
+
+  llvm::KnownBits result(getInputKnownBits(0).getBitWidth());
+  for (auto [i, inverted] : llvm::enumerate(getInverted()))
+    result ^= applyInversion(getInputKnownBits(i), inverted);
+  return result;
+}
+
+int64_t XorInverterOp::getLogicDepthCost() {
+  return llvm::Log2_64_Ceil(getNumOperands());
+}
+
+std::optional<uint64_t> XorInverterOp::getLogicAreaCost() {
+  int64_t bitWidth = hw::getBitWidth(getType());
+  if (bitWidth < 0)
+    return std::nullopt;
+  return static_cast<uint64_t>(getNumOperands() - 1) * bitWidth;
+}
+
+void XorInverterOp::emitCNF(
+    int outVar, llvm::ArrayRef<int> inputVars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  assert(inputVars.size() == getInputs().size() &&
+         "expected one SAT variable per operand");
+
+  SmallVector<int> inputLits;
+  inputLits.reserve(inputVars.size());
+  for (auto [inputVar, inverted] : llvm::zip(inputVars, getInverted()))
+    inputLits.push_back(applyInversion(inputVar, inverted));
+  circt::addParityClauses(outVar, inputLits, addClause, newVar);
+}
+
+static Value lowerVariadicInvertibleOp(
+    Location loc, ValueRange operands, ArrayRef<bool> inverts,
+    PatternRewriter &rewriter,
+    llvm::function_ref<Value(Value, bool)> createUnary,
+    llvm::function_ref<Value(Value, Value, bool, bool)> createBinary) {
   switch (operands.size()) {
   case 0:
     assert(0 && "cannot be called with empty operand range");
     break;
   case 1:
-    if (inverts[0])
-      return AndInverterOp::create(rewriter, op.getLoc(), operands[0], true);
-    else
-      return operands[0];
+    return inverts[0] ? createUnary(operands[0], true) : operands[0];
   case 2:
-    return AndInverterOp::create(rewriter, op.getLoc(), operands[0],
-                                 operands[1], inverts[0], inverts[1]);
+    return createBinary(operands[0], operands[1], inverts[0], inverts[1]);
   default:
     auto firstHalf = operands.size() / 2;
-    auto lhs =
-        lowerVariadicAndInverterOp(op, operands.take_front(firstHalf),
-                                   inverts.take_front(firstHalf), rewriter);
-    auto rhs =
-        lowerVariadicAndInverterOp(op, operands.drop_front(firstHalf),
-                                   inverts.drop_front(firstHalf), rewriter);
-    return AndInverterOp::create(rewriter, op.getLoc(), lhs, rhs);
+    auto lhs = lowerVariadicInvertibleOp(loc, operands.take_front(firstHalf),
+                                         inverts.take_front(firstHalf),
+                                         rewriter, createUnary, createBinary);
+    auto rhs = lowerVariadicInvertibleOp(loc, operands.drop_front(firstHalf),
+                                         inverts.drop_front(firstHalf),
+                                         rewriter, createUnary, createBinary);
+    return createBinary(lhs, rhs, false, false);
   }
   return Value();
 }
 
-LogicalResult circt::synth::AndInverterVariadicOpConversion::matchAndRewrite(
-    AndInverterOp op, PatternRewriter &rewriter) const {
+template <typename OpTy>
+LogicalResult lowerVariadicAndInverterOpConversion(OpTy op,
+                                                   PatternRewriter &rewriter) {
   if (op.getInputs().size() <= 2)
     return failure();
-  // TODO: This is a naive implementation that creates a balanced binary tree.
-  //       We can improve by analyzing the dataflow and creating a tree that
-  //       improves the critical path or area.
-  rewriter.replaceOp(op, lowerVariadicAndInverterOp(
-                             op, op.getOperands(), op.getInverted(), rewriter));
+  auto result = lowerVariadicInvertibleOp(
+      op.getLoc(), op.getOperands(), op.getInverted(), rewriter,
+      [&](Value input, bool invert) {
+        return OpTy::create(rewriter, op.getLoc(), input, invert);
+      },
+      [&](Value lhs, Value rhs, bool invertLhs, bool invertRhs) {
+        return OpTy::create(rewriter, op.getLoc(), lhs, rhs, invertLhs,
+                            invertRhs);
+      });
+  replaceOpAndCopyNamehint(rewriter, op, result);
   return success();
+}
+
+void circt::synth::populateVariadicAndInverterLoweringPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add(lowerVariadicAndInverterOpConversion<aig::AndInverterOp>);
+}
+
+void circt::synth::populateVariadicXorInverterLoweringPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add(lowerVariadicAndInverterOpConversion<XorInverterOp>);
 }
 
 LogicalResult circt::synth::topologicallySortGraphRegionBlocks(

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -180,6 +180,9 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
             .Case<aig::AndInverterOp>([&](aig::AndInverterOp andOp) {
               return handleInvertibleBinaryGate(andOp, LogicNetworkGate::And2);
             })
+            .Case<synth::XorInverterOp>([&](synth::XorInverterOp xorOp) {
+              return handleInvertibleBinaryGate(xorOp, LogicNetworkGate::Xor2);
+            })
             .Case<comb::XorOp>([&](comb::XorOp xorOp) {
               if (xorOp->getNumOperands() != 2) {
                 handleOtherResults(xorOp);
@@ -262,10 +265,9 @@ LogicalResult circt::synth::topologicallySortLogicNetwork(Operation *topOp) {
   const auto isOperationReady = [](Value value, Operation *op) -> bool {
     // Topologically sort AIG ops and dataflow ops. Other operations
     // can be scheduled.
-    return !(
-        isa<aig::AndInverterOp, synth::ChoiceOp, comb::XorOp, comb::AndOp,
-            comb::OrOp, comb::ExtractOp, comb::ReplicateOp, comb::ConcatOp>(
-            op));
+    return !(isa<aig::AndInverterOp, synth::XorInverterOp, synth::ChoiceOp,
+                 comb::XorOp, comb::AndOp, comb::OrOp, comb::ExtractOp,
+                 comb::ReplicateOp, comb::ConcatOp>(op));
   };
 
   if (failed(topologicallySortGraphRegionBlocks(topOp, isOperationReady)))

--- a/lib/Dialect/Synth/Transforms/LowerVariadic.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerVariadic.cpp
@@ -274,10 +274,10 @@ void LowerVariadicPass::runOnOperation() {
 
     rewriter.setInsertionPoint(op);
 
-    // Handle AndInverterOp specially to preserve inversion flags.
+    // Handle invertible Synth ops specially to preserve inversion flags.
     auto result =
         mlir::TypeSwitch<Operation *, LogicalResult>(op)
-            .Case<aig::AndInverterOp>([&](auto op) {
+            .Case<aig::AndInverterOp, XorInverterOp>([&](auto op) {
               return replaceWithBalancedTree(
                   analysis, rewriter, op,
                   // Check if each operand is inverted.

--- a/test/Conversion/CombToSynth/comb-to-aig.mlir
+++ b/test/Conversion/CombToSynth/comb-to-aig.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-opt %s --convert-comb-to-synth | FileCheck %s
+// RUN: circt-opt %s --convert-comb-to-synth='force-aig=false' | FileCheck %s --check-prefix=XOR-INV
 
 // CHECK-LABEL: @test
 hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, out out0: i32, out out1: i32) {
@@ -20,6 +21,9 @@ hw.module @xor(in %arg0: i32, in %arg1: i32, in %arg2: i32, out out0: i32) {
   // CHECK-NEXT: %[[AND:.+]] = synth.aig.and_inv %arg0, %[[RHS_XOR]] : i32
   // CHECK-NEXT: %[[RESULT:.+]] = synth.aig.and_inv not %[[NOT_AND]], not %[[AND]] : i32
   // CHECK-NEXT: hw.output %[[RESULT]]
+  // XOR-INV-LABEL: @xor
+  // XOR-INV-NEXT: %[[RESULT:.+]] = synth.xor_inv %arg0, %arg1, %arg2 : i32
+  // XOR-INV-NEXT: hw.output %[[RESULT]]
   %0 = comb.xor %arg0, %arg1, %arg2 : i32
   hw.output %0 : i32
 }

--- a/test/Conversion/SynthToComb/synth-to-comb.mlir
+++ b/test/Conversion/SynthToComb/synth-to-comb.mlir
@@ -17,3 +17,12 @@ hw.module @test_choice(in %a: i32, in %b: i32, in %c: i32, out out0: i32) {
   %0 = synth.choice %a, %b, %c : i32
   hw.output %0 : i32
 }
+
+// CHECK-LABEL: @test_xor_inv
+hw.module @test_xor_inv(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
+  // CHECK: %c-1_i8 = hw.constant -1 : i8
+  // CHECK: %[[NOT_B:.+]] = comb.xor bin %b, %c-1_i8 : i8
+  // CHECK: %[[RESULT:.+]] = comb.xor bin %a, %[[NOT_B]], %c : i8
+  %0 = synth.xor_inv %a, not %b, %c : i8
+  hw.output %0 : i8
+}

--- a/test/Dialect/Synth/functional-reduction.mlir
+++ b/test/Dialect/Synth/functional-reduction.mlir
@@ -68,3 +68,14 @@ hw.module @test_no_ssa_cycle(in %a: i1, in %b: i1,
   %2 = synth.aig.and_inv %b, %a {synth.test.fc_equiv_class = 7} : i1
   hw.output %0, %1, %2 : i1, i1, i1
 }
+
+// CHECK-LABEL: hw.module @test_xor_inv_equiv
+hw.module @test_xor_inv_equiv(in %a: i1, in %b: i1, out out0: i1, out out1: i1) {
+  // CHECK: %[[XOR_INV:.+]] = synth.xor_inv %a, %b
+  // CHECK: %[[XOR:.+]] = comb.xor %b, %a
+  // CHECK: %[[CHOICE:.+]] = synth.choice %[[XOR_INV]], %[[XOR]] : i1
+  // CHECK: hw.output %[[CHOICE]], %[[CHOICE]] : i1, i1
+  %0 = synth.xor_inv %a, %b {synth.test.fc_equiv_class = 11} : i1
+  %1 = comb.xor %b, %a {synth.test.fc_equiv_class = 11} : i1
+  hw.output %0, %1 : i1, i1
+}

--- a/test/Dialect/Synth/longest-paths.mlir
+++ b/test/Dialect/Synth/longest-paths.mlir
@@ -1,14 +1,15 @@
 // RUN: circt-opt %s --split-input-file --pass-pipeline='builtin.module(synth-print-longest-path-analysis{test=true})' --verify-diagnostics
 
-// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.a[0], delay=4, history=[{{.+}}])}}
-// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.b[0], delay=4, history=[{{.+}}])}}
+// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.a[0], delay=6, history=[{{.+}}])}}
+// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.b[0], delay=6, history=[{{.+}}])}}
 hw.module private @basic(in %a : i1, in %b : i1, out x : i1) {
   // These operations are considered to have a delay of 1.
   %p = synth.aig.and_inv not %a, %b : i1 // p[0] := max(a[0], b[0]) + 1 = 1
   %q = comb.and %p, %a : i1  // q[0] := max(p[0], a[0]) + 1 = 2
   %r = comb.or %q, %a : i1  // r[0] := max(q[0], a[0]) + 1 = 3
   %s = comb.xor %r, %a : i1 // s[0] := max(r[0], a[0]) + 1 = 4
-  hw.output %s : i1
+  %t = synth.xor_inv %s, not %b, %a : i1 // t[0] := max(s[0], b[0], a[0]) + 2 = 6
+  hw.output %t : i1
 }
 
 // expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.a[0], delay=1, history=[{{.+}}])}}

--- a/test/Dialect/Synth/lower-variadic.mlir
+++ b/test/Dialect/Synth/lower-variadic.mlir
@@ -86,7 +86,16 @@ hw.module @SharingHeuristic(in %in0 : i1, in %in1 : i1, in %in2 : i1, in %in3 : 
   // CHECK: %[[OUT1_ROOT:.+]] = synth.aig.and_inv %in0, %[[SUBSET_RES]]
   %out1 = synth.aig.and_inv %in0, %in1, %in2, %in3, %in4 : i1
 
-  // CHECK: hw.output %[[OUT1_ROOT]], %[[SUBSET_RES]]
+  // CHECK: hw.output %[[OUT1_ROOT]], %[[SUBSET_RES]] : i1, i1
   hw.output %out1, %out2 : i1, i1
 }
 
+// COMMON-LABEL: hw.module @XorInv
+hw.module @XorInv(in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1, out o: i1) {
+  // COMMON-NEXT: %[[X0:.+]] = synth.xor_inv not %a, %b : i1
+  // COMMON-NEXT: %[[X1:.+]] = synth.xor_inv %c, not %d : i1
+  // COMMON-NEXT: %[[X2:.+]] = synth.xor_inv %e, %[[X0]] : i1
+  // COMMON-NEXT: %[[X3:.+]] = synth.xor_inv %[[X1]], %[[X2]] : i1
+  %0 = synth.xor_inv not %a, %b, %c, not %d, %e : i1
+  hw.output %0 : i1
+}

--- a/test/Dialect/Synth/resource.mlir
+++ b/test/Dialect/Synth/resource.mlir
@@ -58,6 +58,7 @@ hw.module private @unrelated(in %a : i1, in %b : i1, out x : i1) {
 // CHECK-NEXT:   comb.or: 16
 // CHECK-NEXT:   comb.xor: 8
 // CHECK-NEXT:   synth.aig.and_inv: 8
+// CHECK-NEXT:   synth.xor_inv: 16
 
 hw.module private @multibit(in %a : i8, in %b : i8, in %c : i8, out x : i8) {
   // 3-input AND on 8-bit: (3-1) * 8 = 16 gates
@@ -70,8 +71,11 @@ hw.module private @multibit(in %a : i8, in %b : i8, in %c : i8, out x : i8) {
   %xor2 = comb.xor %a, %b : i8
   // AIG on 8-bit: (2-1) * 8 = 8 gates
   %aig = synth.aig.and_inv not %a, %b : i8
-  hw.output %aig : i8
+  // XOR inverter on 8-bit: (3-1) * 8 = 16 gates
+  %xor = synth.xor_inv %aig, not %b, %c : i8
+  hw.output %xor : i8
 }
+
 
 // Test sequential elements (registers)
 // CHECK:      Resource Usage Analysis for module: sequential

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -16,3 +16,11 @@ hw.module @choice(in %a: i4, in %b: i4) {
   %0 = synth.choice %a : i4
   %1 = synth.choice %a, %b, %a : i4
 }
+
+// CHECK-LABEL: @xor_inv
+// CHECK-NEXT: %[[R0:.+]] = synth.xor_inv %a, not %b, %c : i4
+// CHECK-NEXT: %[[R1:.+]] = synth.xor_inv not %d : i1
+hw.module @xor_inv(in %a: i4, in %b: i4, in %c: i4, in %d: i1) {
+  %0 = synth.xor_inv %a, not %b, %c : i4
+  %1 = synth.xor_inv not %d : i1
+}

--- a/test/Dialect/Synth/structural_hash.mlir
+++ b/test/Dialect/Synth/structural_hash.mlir
@@ -52,3 +52,12 @@ func.func @test_func(%a: i2, %b: i2) -> (i2, i2) {
   %1 = synth.aig.and_inv %b, %a : i2
   return %0, %1 : i2, i2
 }
+
+// CHECK-LABEL: hw.module @xor_inv_hash
+hw.module @xor_inv_hash(in %a: i1, in %b: i1, in %c: i1, out o0: i1, out o1: i1) {
+  // CHECK: %[[X:.+]] = synth.xor_inv %a, not %b, %c : i1
+  // CHECK-NEXT: hw.output %[[X]], %[[X]] : i1, i1
+  %0 = synth.xor_inv %a, not %b, %c : i1
+  %1 = synth.xor_inv %c, %a, not %b : i1
+  hw.output %0, %1 : i1, i1
+}


### PR DESCRIPTION
Add synth.xor_inv and relevant pass changes. Since these passes already utilize the BooleanLogicOpInterface, the implementation primarily involves adding the interface to the new op.

This allows the Synth dialect to represent XOR natively rather than forcing it into AIG form (called XAG) , with the flexibility to lower back to AIG nodes if necessary. Native XOR representation is critical for arithmetic circuits, where AIG-based decomposition is often inefficient and requires multiple nodes.

This PR doesn't change the default behavior but preserving XOR would be generally always beneficial so XOR will be preserved in the pipeline in a follow-up. 

AI-assisted-by: Codex GPT-5.4
