### PR TITLE
[circt-verilog] Add -Xslang passthrough flag for Slang frontend.

### DIFF
--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -144,6 +144,12 @@ struct ImportVerilogOptions {
 
   /// A list of command files to process for compilation.
   std::vector<std::string> commandFiles;
+
+  //===--------------------------------------------------------------------===//
+  // Misc slang options
+  //===--------------------------------------------------------------------===//
+  /// A list of arbitrary arguments to pass to the Slang CLI.
+  std::vector<std::string> slangArgs;
 };
 
 /// Parse files in a source manager as Verilog source code and populate the

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -290,8 +290,8 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   driver.options.singleUnit = options.singleUnit;
 
   // Parse pass through options.
+  driver.addStandardArgs();
   if (!options.slangArgs.empty()) {
-    driver.addStandardArgs();
     SmallVector<const char *> slangArgs;
     slangArgs.push_back("slang"); // dummy program name
     for (const auto &arg : options.slangArgs)

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -292,9 +292,10 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   // Parse pass through options.
   if (!options.slangArgs.empty()) {
     driver.addStandardArgs();
-    SmallVector<const char*> slangArgs;
-    slangArgs.push_back("slang");  // dummy program name
-    for (const auto& arg : options.slangArgs) slangArgs.push_back(arg.c_str());
+    SmallVector<const char *> slangArgs;
+    slangArgs.push_back("slang"); // dummy program name
+    for (const auto &arg : options.slangArgs)
+      slangArgs.push_back(arg.c_str());
     if (!driver.parseCommandLine(slangArgs.size(), slangArgs.data()))
       return failure();
   }

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -289,6 +289,16 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
 
   driver.options.singleUnit = options.singleUnit;
 
+  // Parse pass through options.
+  if (!options.slangArgs.empty()) {
+    driver.addStandardArgs();
+    SmallVector<const char*> slangArgs;
+    slangArgs.push_back("slang");  // dummy program name
+    for (const auto& arg : options.slangArgs) slangArgs.push_back(arg.c_str());
+    if (!driver.parseCommandLine(slangArgs.size(), slangArgs.data()))
+      return failure();
+  }
+
   return success(driver.processOptions());
 }
 

--- a/test/circt-verilog/xslang.sv
+++ b/test/circt-verilog/xslang.sv
@@ -1,0 +1,4 @@
+// RUN: not circt-verilog %s -Xslang=--std=foo 2>&1 | FileCheck %s
+// RUN: circt-verilog %s -Xslang=--std=latest
+
+// CHECK: invalid value for --std option: 'foo'

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -278,6 +278,10 @@ struct CLOptions {
           "One or more command files, which are independent compilation units "
           "where modules are automatically instantiated."),
       cl::value_desc("filename"), cl::Prefix, cl::cat(cat)};
+
+  cl::list<std::string> slangArgs{"Xslang",
+                                  cl::desc("Pass <arg> to the Slang CLI"),
+                                  cl::value_desc("arg"), cl::cat(cat)};
 };
 } // namespace
 
@@ -346,6 +350,7 @@ static LogicalResult executeWithSources(MLIRContext *context,
   options.singleUnit = opts.singleUnit;
   options.libraryFiles = opts.libraryFiles;
   options.commandFiles = opts.commandFiles;
+  options.slangArgs = opts.slangArgs;
 
   // Open the output file.
   std::string errorMessage;


### PR DESCRIPTION
This takes some inspiration from the Xclang flag of clang and allows passing in arbitrary slang flags to it. I was looking at adding support for `allow-self-determined-stream-concat`, but it felt too low level a flag for circ-verilog/I wasn't sure if it made sense to add as a supported feature. Felt better to enable generic passthrough behavior such that one could evaluate impact and need.

Propagating the flags in a rather direct manner. Take this as an RFC, I could see how this could be seen as too unstructured.