### PR TITLE
[ImportVerilog] Add support for pullup/pulldown primitives

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -281,6 +281,12 @@ struct Context {
   LogicalResult
   convertNOutputPrimitive(const slang::ast::PrimitiveInstanceSymbol &prim);
 
+  LogicalResult
+  convertFixedPrimitive(const slang::ast::PrimitiveInstanceSymbol &prim);
+
+  LogicalResult
+  convertPullGatePrimitive(const slang::ast::PrimitiveInstanceSymbol &prim);
+
   /// Helper function to convert a value to its "truthy" boolean value.
   Value convertToBool(Value value);
 

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1823,6 +1823,9 @@ LogicalResult Context::convertPrimitiveInstance(
   case slang::ast::PrimitiveSymbol::PrimitiveKind::NOutput:
     return this->convertNOutputPrimitive(prim);
     break;
+  case slang::ast::PrimitiveSymbol::PrimitiveKind::Fixed:
+    return this->convertFixedPrimitive(prim);
+    break;
   default:
     return mlir::emitError(convertLocation(prim.location))
            << "unsupported instance of primitive `" << prim.primitiveType.name
@@ -1962,6 +1965,55 @@ LogicalResult Context::convertNOutputPrimitive(
       return failure();
     moore::ContinuousAssignOp::create(builder, loc, outputVal, converted);
   }
+  return success();
+}
+
+LogicalResult Context::convertFixedPrimitive(
+    const slang::ast::PrimitiveInstanceSymbol &prim) {
+  auto primName = prim.primitiveType.name;
+  auto loc = convertLocation(prim.location);
+
+  // Fixed primitives cover a few different cases, so dispatch those separately
+
+  if (primName == "pullup" || primName == "pulldown")
+    return convertPullGatePrimitive(prim);
+
+  // Remaining fixed primitives still need handling
+  mlir::emitError(loc) << "unsupported primitive `" << primName << "`";
+  return failure();
+}
+
+LogicalResult Context::convertPullGatePrimitive(
+    const slang::ast::PrimitiveInstanceSymbol &prim) {
+  assert((prim.primitiveType.name == "pullup" ||
+          prim.primitiveType.name == "pulldown") &&
+         "expected pullup or pulldown primitive");
+  auto loc = convertLocation(prim.location);
+  auto primName = prim.primitiveType.name;
+
+  auto portConns = prim.getPortConnections();
+  // Slang should ensure this for us
+  assert(portConns.size() == 1 &&
+         "pullup/pulldown primitives should have exactly one port");
+
+  Value portVal = this->convertLvalueExpression(
+      portConns.front()->as<slang::ast::AssignmentExpression>().left());
+
+  auto dstType = cast<moore::RefType>(portVal.getType()).getNestedType();
+  auto dstTypeWidth = dstType.getBitSize();
+  // This should be caught elsewhere
+  assert(dstTypeWidth &&
+         "expected fixed-width type for pullup/pulldown primitive");
+  auto constVal = primName == "pullup" ? -1 : 0;
+  auto c = moore::ConstantOp::create(
+      builder, loc,
+      moore::IntType::getInt(this->getContext(), dstTypeWidth.value()),
+      constVal);
+
+  Value converted = materializeConversion(dstType, c, false, loc);
+  if (!converted)
+    return failure();
+  moore::ContinuousAssignOp::create(builder, loc, portVal, converted);
   return success();
 }
 

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -351,8 +351,7 @@ endmodule
 
 // -----
 
-module unsupported_prim;
-    logic A, B, C, D;
-    // expected-error @below {{unsupported instance of primitive `rcmos`}}
-    rcmos u1 (A, B, C, D);
+module unsupported_prim(inout A, inout B);
+    // expected-error @below {{unsupported instance of primitive `tran`}}
+    tran u1 (A, B);
 endmodule

--- a/test/Conversion/ImportVerilog/primitives.sv
+++ b/test/Conversion/ImportVerilog/primitives.sv
@@ -170,3 +170,33 @@ module buf_prim;
     logic A, Q;
     buf n (Q, A);
 endmodule
+
+// CHECK-LABEL: moore.module @pullup_prim()
+// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[ONE:%.+]] = moore.constant 1 : l1
+// CHECK: moore.assign [[A]], [[ONE]] : l1
+
+module pullup_prim;
+    logic A;
+    pullup n (A);
+endmodule
+
+// CHECK-LABEL: moore.module @pulldown_prim()
+// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[ZERO:%.+]] = moore.constant 0 : l1
+// CHECK: moore.assign [[A]], [[ZERO]] : l1
+
+module pulldown_prim;
+    logic A;
+    pulldown n (A);
+endmodule
+
+// CHECK-LABEL: moore.module @wide_pullup_prim()
+// CHECK: [[A:%.+]] = moore.variable : <l4>
+// CHECK: [[ONES:%.+]] = moore.constant -1 : l4
+// CHECK: moore.assign [[A]], [[ONES]] : l4
+
+module wide_pullup_prim;
+    logic [3:0] A;
+    pullup n (A);
+endmodule

--- a/test/Conversion/ImportVerilog/primitives.sv
+++ b/test/Conversion/ImportVerilog/primitives.sv
@@ -182,21 +182,21 @@ module pullup_prim;
 endmodule
 
 // CHECK-LABEL: moore.module @pulldown_prim()
-// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[A:%.+]] = moore.net wire : <l1>
 // CHECK: [[ZERO:%.+]] = moore.constant 0 : l1
 // CHECK: moore.assign [[A]], [[ZERO]] : l1
 
 module pulldown_prim;
-    logic A;
+    wire A;
     pulldown n (A);
 endmodule
 
 // CHECK-LABEL: moore.module @wide_pullup_prim()
-// CHECK: [[A:%.+]] = moore.variable : <l4>
+// CHECK: [[A:%.+]] = moore.net wire : <l4>
 // CHECK: [[ONES:%.+]] = moore.constant -1 : l4
 // CHECK: moore.assign [[A]], [[ONES]] : l4
 
 module wide_pullup_prim;
-    logic [3:0] A;
+    wire [3:0] A;
     pullup n (A);
 endmodule

--- a/test/Conversion/ImportVerilog/primitives.sv
+++ b/test/Conversion/ImportVerilog/primitives.sv
@@ -172,12 +172,12 @@ module buf_prim;
 endmodule
 
 // CHECK-LABEL: moore.module @pullup_prim()
-// CHECK: [[A:%.+]] = moore.variable : <l1>
+// CHECK: [[A:%.+]] = moore.net wire : <l1>
 // CHECK: [[ONE:%.+]] = moore.constant 1 : l1
 // CHECK: moore.assign [[A]], [[ONE]] : l1
 
 module pullup_prim;
-    logic A;
+    wire A;
     pullup n (A);
 endmodule
 


### PR DESCRIPTION
A little fiddlier than the others since the Fixed PrimitiveKind covers a few types of primitive that are separate in IEEE-1800.

n.b. I found the spec a little vague w.r.t. whether signals wider than 1 bit can be connected to pull gates, but it looks like other tools vary in whether they allow this (e.g. Icarus doesn't but Verilator doesn't seem to complain) so I figured it's probably worth handling.