### PR TITLE
[docs] Clarifications on AI Tool Use

### DIFF
--- a/docs/AIToolPolicy.md
+++ b/docs/AIToolPolicy.md
@@ -8,7 +8,7 @@ Contributors may use AI tools to assist with their work, but must:
 
 - **Keep a human in the loop** - All AI-generated content must be reviewed and understood by the contributor before submission
 - **Take full accountability** - The contributor is the author and is responsible for their contributions
-- **Be transparent** - Label contributions containing substantial AI-generated content (e.g., using `AI-assisted-by:` in commit messages)
+- **Be transparent** - Label contributions containing substantial AI-generated content with a commit message trailer: `Assited-by: <tool>:<model>`, e.g., `Assisted-by: Claude:claude-sonnet-4-6`.
 - **Ensure quality** - Contributions should be worth more to the project than the time required to review them
 
 ## What This Means

--- a/docs/AIToolPolicy.md
+++ b/docs/AIToolPolicy.md
@@ -8,7 +8,7 @@ Contributors may use AI tools to assist with their work, but must:
 
 - **Keep a human in the loop** - All AI-generated content must be reviewed and understood by the contributor before submission
 - **Take full accountability** - The contributor is the author and is responsible for their contributions
-- **Be transparent** - Label contributions containing substantial AI-generated content with a commit message trailer: `Assited-by: <tool>:<model>`, e.g., `Assisted-by: Claude:claude-sonnet-4-6`.
+- **Be transparent** - Label contributions containing AI-generated content with a message trailer: `Assisted-by: <tool>:<model>`, e.g., `Assisted-by: Claude:claude-sonnet-4-6`.  Include this trailer in commit messages, Pull Requests, or wherever authorship is normally indicated.
 - **Ensure quality** - Contributions should be worth more to the project than the time required to review them
 
 ## What This Means

--- a/docs/AIToolPolicy.md
+++ b/docs/AIToolPolicy.md
@@ -8,7 +8,7 @@ Contributors may use AI tools to assist with their work, but must:
 
 - **Keep a human in the loop** - All AI-generated content must be reviewed and understood by the contributor before submission
 - **Take full accountability** - The contributor is the author and is responsible for their contributions
-- **Be transparent** - Label contributions containing AI-generated content with a message trailer: `Assisted-by: <tool>:<model>`, e.g., `Assisted-by: Claude:claude-sonnet-4-6`.  Include this trailer in commit messages, Pull Requests, or wherever authorship is normally indicated.
+- **Be transparent** - Label contributions containing AI-generated content with a message trailer: `Assisted-by: <tool>:<model>`, e.g., `Assisted-by: Claude Code:claude-sonnet-4-6`.  Include this trailer in commit messages, Pull Requests, or wherever authorship is normally indicated.  CIRCT is more restrictive than the upstream LLVM policy and requires the use of AI transparency even when contributions are less than "substantial".
 - **Ensure quality** - Contributions should be worth more to the project than the time required to review them
 
 ## What This Means


### PR DESCRIPTION
Minor clarifications on AI tool use.  This is not intended to be a change, just
more clarification:

1. Provide more guidance on the message trailer and switch to something closer
   to what the Linux kernel has adopted.
2. Clarify that AI tool use should be transparent for not just "substantial"
   contributions.
3. Clarify that AI tool use should be indicated, like with upstream language,
   anywhere authorship is normally indicated/assumed.
