### PR TITLE
[Synth] Make LowerVariadic run on any operation.

### DIFF
--- a/include/circt/Dialect/Synth/Transforms/SynthPasses.td
+++ b/include/circt/Dialect/Synth/Transforms/SynthPasses.td
@@ -85,7 +85,7 @@ def GenericLutMapper : CutRewriterPassBase<"synth-generic-lut-mapper",
   let dependentDialects = ["comb::CombDialect"];
 }
 
-def LowerVariadic : Pass<"synth-lower-variadic", "hw::HWModuleOp"> {
+def LowerVariadic : Pass<"synth-lower-variadic"> {
   let summary = "Lower variadic operations to binary operations";
   let description = [{
     This pass lowers variadic operations to binary operations using a

--- a/integration_test/circt-synth/lower-variadic.mlir
+++ b/integration_test/circt-synth/lower-variadic.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: libz3
 // REQUIRES: circt-lec-jit
 
-// RUN: circt-opt %s -synth-lower-variadic -o %t.after.mlir
+// RUN: circt-opt %s --pass-pipeline='builtin.module(hw.module(synth-lower-variadic))' -o %t.after.mlir
 // RUN: circt-lec %s %t.after.mlir -c1=AndInverter -c2=AndInverter --shared-libs=%libz3 | FileCheck %s --check-prefix=AND_INVERTER_LEC
 // AND_INVERTER_LEC: c1 == c2
 hw.module @AndInverter(in %a: i2, in %b: i2, in %c: i2, in %d: i2, in %e: i2, in %f: i2, in %g: i2, out o1: i2) {

--- a/lib/Dialect/Synth/Transforms/LowerVariadic.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerVariadic.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 #include <iterator>
 #include <vector>
@@ -207,26 +208,38 @@ static void simplifyWithExistingOperations(
 }
 
 void LowerVariadicPass::runOnOperation() {
+  if (getOperation()->getNumRegions() != 1 ||
+      getOperation()->getRegion(0).getBlocks().size() != 1)
+    return;
   // Topologically sort operations in graph regions to ensure operands are
   // defined before uses.
+  mlir::Block &bodyBlock = getOperation()->getRegion(0).getBlocks().front();
+  auto *moduleOp = getOperation();
+
   if (!mlir::sortTopologically(
-          getOperation().getBodyBlock(), [](Value val, Operation *op) -> bool {
+          &bodyBlock, [](Value val, Operation *op) -> bool {
             if (isa_and_nonnull<hw::HWDialect>(op->getDialect()))
               return isa<hw::InstanceOp>(op);
             return !isa_and_nonnull<comb::CombDialect, synth::SynthDialect>(
                 op->getDialect());
           })) {
-    mlir::emitError(getOperation().getLoc())
+    mlir::emitError(moduleOp->getLoc())
         << "Failed to topologically sort graph region blocks";
     return signalPassFailure();
   }
 
   // Get longest path analysis if timing-aware lowering is enabled.
   synth::IncrementalLongestPathAnalysis *analysis = nullptr;
-  if (timingAware.getValue())
-    analysis = &getAnalysis<synth::IncrementalLongestPathAnalysis>();
-
-  auto moduleOp = getOperation();
+  if (timingAware.getValue()) {
+    if (!dyn_cast<hw::HWModuleOp>(moduleOp)) {
+      moduleOp->emitWarning(
+          "Longest Path Analysis failed: expected 'hw.module', but found '")
+          << moduleOp->getName().getStringRef()
+          << "'. Only HWModuleOps are currently supported.";
+    } else {
+      analysis = &getAnalysis<synth::IncrementalLongestPathAnalysis>();
+    }
+  }
 
   // Build set of operation names to lower if specified.
   SmallVector<OperationName> names;
@@ -248,14 +261,14 @@ void LowerVariadicPass::runOnOperation() {
   if (reuseSubsets) {
     llvm::DenseMap<OperandKey, mlir::Value> seenExpressions;
     // First collect all the andInverterOp operations in the block.
-    for (auto &op : moduleOp.getBodyBlock()->getOperations()) {
+    for (auto &op : bodyBlock.getOperations()) {
       if (auto andInverterOp = llvm::dyn_cast<aig::AndInverterOp>(op)) {
         OperandKey key = getSortedOperandKey(andInverterOp);
         seenExpressions[key] = andInverterOp.getResult();
       }
     }
     // Now try to replace operations with subsets.
-    for (auto &op : moduleOp.getBodyBlock()->getOperations()) {
+    for (auto &op : bodyBlock.getOperations()) {
       if (auto andInverterOp = llvm::dyn_cast<aig::AndInverterOp>(op)) {
         simplifyWithExistingOperations(andInverterOp, rewriter,
                                        seenExpressions);
@@ -265,8 +278,7 @@ void LowerVariadicPass::runOnOperation() {
 
   // FIXME: Currently only top-level operations are lowered due to the lack of
   //        topological sorting in across nested regions.
-  for (auto &opRef :
-       llvm::make_early_inc_range(moduleOp.getBodyBlock()->getOperations())) {
+  for (auto &opRef : llvm::make_early_inc_range(bodyBlock.getOperations())) {
     auto *op = &opRef;
     // Skip operations that don't need lowering or are already binary.
     if (!shouldLower(op) || op->getNumOperands() <= 2)

--- a/test/Dialect/Synth/lower-variadic.mlir
+++ b/test/Dialect/Synth/lower-variadic.mlir
@@ -1,6 +1,6 @@
-// RUN: circt-opt %s --synth-lower-variadic --split-input-file | FileCheck %s --check-prefixes=COMMON,TIMING
-// RUN: circt-opt %s --synth-lower-variadic=timing-aware=false --split-input-file | FileCheck %s --check-prefixes=COMMON,NO-TIMING
-// RUN: circt-opt %s --synth-lower-variadic=reuse-subsets=true | FileCheck %s
+// RUN: circt-opt %s --pass-pipeline='builtin.module(hw.module(synth-lower-variadic))' --split-input-file | FileCheck %s --check-prefixes=COMMON,TIMING
+// RUN: circt-opt %s --pass-pipeline='builtin.module(any(synth-lower-variadic{timing-aware=false}))' --split-input-file | FileCheck %s --check-prefixes=COMMON,NO-TIMING
+// RUN: circt-opt %s --pass-pipeline='builtin.module(hw.module(synth-lower-variadic{reuse-subsets=true}))' | FileCheck %s
 // COMMON-LABEL: hw.module @Basic
 hw.module @Basic(in %a: i2, in %b: i2, in %c: i2, in %d: i2, in %e: i2, out f: i2) {
   // COMMON-NEXT: %[[RES0:.+]] = synth.aig.and_inv not %a, %b : i2
@@ -98,4 +98,14 @@ hw.module @XorInv(in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1, out o: 
   // COMMON-NEXT: %[[X3:.+]] = synth.xor_inv %[[X1]], %[[X2]] : i1
   %0 = synth.xor_inv not %a, %b, %c, not %d, %e : i1
   hw.output %0 : i1
+}
+
+// NO-TIMING-LABEL: func.func @Basic_no_module
+func.func @Basic_no_module(%a: i2, %b: i2, %c: i2, %d: i2, %e: i2, %f: i2) -> i2 {
+  // NO-TIMING-NEXT: %[[RES0:.+]] = synth.aig.and_inv not %arg0, %arg1 : i2
+  // NO-TIMING-NEXT: %[[RES1:.+]] = synth.aig.and_inv %arg2, not %arg3 : i2
+  // NO-TIMING-NEXT: %[[RES2:.+]] = synth.aig.and_inv %arg4, %[[RES0]] : i2
+  // NO-TIMING-NEXT: %[[RES3:.+]] = synth.aig.and_inv %[[RES1]], %[[RES2]] : i2
+  %0 = synth.aig.and_inv not %a, %b, %c, not %d, %e : i2
+  return %0 : i2
 }


### PR DESCRIPTION
Related to #10133
This patch modifies LowerVariadic so it runs on any operation. For now, Longest Path Analysis is only supported for HWModuleOps, so it emits an error if it is enabled for other Ops.