### PR TITLE
[LLHD] Make Mem2Reg fixpoint iteration deterministic

### DIFF
--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -233,6 +233,7 @@ struct LatticeValue {
 struct LatticeNode {
   enum class Kind { BlockEntry, BlockExit, Probe, Drive, Signal };
   const Kind kind;
+  /// Dirty flag to prevent duplicate pushes to worklist.
   bool dirty = false;
   LatticeNode(Kind kind) : kind(kind) {}
 };

--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -233,6 +233,7 @@ struct LatticeValue {
 struct LatticeNode {
   enum class Kind { BlockEntry, BlockExit, Probe, Drive, Signal };
   const Kind kind;
+  bool dirty = false;
   LatticeNode(Kind kind) : kind(kind) {}
 };
 
@@ -715,7 +716,7 @@ struct Promoter {
   /// definitions forwards.
   Lattice lattice;
   /// A worklist of lattice nodes used within calls to `propagate*`.
-  SmallPtrSet<LatticeNode *, 4> dirtyNodes;
+  SmallVector<LatticeNode *> dirtyNodes;
 
   /// Helper to clean up unused ops.
   UnusedOpPruner pruner;
@@ -1091,10 +1092,14 @@ void Promoter::constructLattice() {
 void Promoter::propagateBackward() {
   for (auto *node : lattice.nodes)
     propagateBackward(node);
+  SmallVector<LatticeNode *> nodes;
   while (!dirtyNodes.empty()) {
-    auto *node = *dirtyNodes.begin();
-    dirtyNodes.erase(node);
-    propagateBackward(node);
+    std::swap(dirtyNodes, nodes);
+    for (auto *node : nodes) {
+      node->dirty = false;
+      propagateBackward(node);
+    }
+    nodes.clear();
   }
 }
 
@@ -1182,10 +1187,14 @@ void Promoter::propagateForward(bool optimisticMerges,
                                 DominanceInfo &dominance) {
   for (auto *node : lattice.nodes)
     propagateForward(node, optimisticMerges, dominance);
+  SmallVector<LatticeNode *> nodes;
   while (!dirtyNodes.empty()) {
-    auto *node = *dirtyNodes.begin();
-    dirtyNodes.erase(node);
-    propagateForward(node, optimisticMerges, dominance);
+    std::swap(dirtyNodes, nodes);
+    for (auto *node : nodes) {
+      node->dirty = false;
+      propagateForward(node, optimisticMerges, dominance);
+    }
+    nodes.clear();
   }
 }
 
@@ -1347,7 +1356,10 @@ void Promoter::propagateForward(LatticeNode *node, bool optimisticMerges,
 /// Mark a lattice node to be updated during propagation.
 void Promoter::markDirty(LatticeNode *node) {
   assert(node);
-  dirtyNodes.insert(node);
+  if (node->dirty)
+    return;
+  node->dirty = true;
+  dirtyNodes.push_back(node);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The Mem2Reg pass currently uses a `SmallPtrSet` as worklist to drive the lattice of definitions and uses to a fixpoint. This makes the performance of the pass non-deterministic, since certain iteration orders will cause a pathologically slow convergence of the lattice.

To fix this, switch to a plain `SmallVector` and add a `dirty` flag to the lattice nodes. This allows us to make multiple passes across the lattice, collecting dirty nodes for the next round, and avoiding the pathological case of pushing a node onto the worklist to then immediately pop it back off and process it.

We'll need to revisit the lattice at some point in the near future, since even a moderate llhd.process of around 900 lattice nodes takes around 1.5s to converge on my machine. If the lattice contains N probe nodes, it would propagate N value uses to N nodes, which ends up being N².