### PR TITLE
[FIRRTL] Replace Wires w/ Objects in LowerDomains

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerDomains.cpp
@@ -635,70 +635,39 @@ LogicalResult LowerModule::lowerModule() {
         return WalkResult::advance();
       }
 
-      // If we see a WireOp of a domain type, then we want to erase it.  To do
-      // this, find what is driving it and what it is driving and then replace
-      // that triplet of operations with a single domain define inserted before
-      // the latest define.  If the wire is undriven or if the wire drives
-      // nothing, then everything will be deleted.
+      // Handle WireOp.
       //
-      // Before:
+      // For domain-typed wires, create a placeholder ObjectOp and replace all
+      // uses of the wire with a conversion cast wrapping the new object.  A
+      // placeholder is always used (even when the wire is driven) because the
+      // source of the define may not have been lowered to a conversion cast yet
+      // (it may appear later in the IR).  Any DomainDefineOps that drive the
+      // wire are handled when they are visited: per-field PropAssignOps connect
+      // the source object's output ports to the placeholder's input ports.  For
+      // cleaner output, this should rely on optimizations to remove these
+      // wires.
       //
-      //     %a = firrtl.wire : !firrtl.domain // <- operation being visited
-      //     firrtl.domain.define %a, %src
-      //     firrtl.domain.define %dst, %a
-      //
-      // After:
-      //     %a = firrtl.wire : !firrtl.domain // <- to-be-deleted after walk
-      //     firrtl.domain.define %a, %src     // <- to-be-deleted when visited
-      //     firrtl.domain.define %dst, %src   // <- added
-      //     firrtl.domain.define %dst, %a     // <- to-be-deleted when visited
-      //
-      // If the wire is not of domain type, then we just erase its associations.
+      // For non-domain-typed wires, erase any domain associations.
       if (auto wireOp = dyn_cast<WireOp>(walkOp)) {
-        if (type_isa<DomainType>(wireOp.getResult().getType())) {
-          Value src;
-          SmallVector<Value> dsts;
-          DomainDefineOp lastDefineOp;
-          for (auto *user : llvm::make_early_inc_range(wireOp->getUsers())) {
-            // This domain is associated with another wire.  Nothing to do.
-            if (isa<WireOp>(user))
-              continue;
-
-            auto domainDefineOp = dyn_cast<DomainDefineOp>(user);
-            if (operationsToErase.contains(domainDefineOp))
-              continue;
-            if (!domainDefineOp) {
-              auto diag =
-                  wireOp.emitOpError()
-                  << "cannot be lowered by `LowerDomains` because it "
-                     "has a user that is not a domain define op or wire";
-              diag.attachNote(user->getLoc()) << "is one such user";
-              return WalkResult::interrupt();
-            }
-            if (!lastDefineOp || lastDefineOp->isBeforeInBlock(domainDefineOp))
-              lastDefineOp = domainDefineOp;
-            if (wireOp == domainDefineOp.getSrc().getDefiningOp())
-              dsts.push_back(domainDefineOp.getDest());
-            else
-              src = domainDefineOp.getSrc();
-            operationsToErase.insert(domainDefineOp);
-          }
+        // Handle domain-typed wires.
+        if (auto domainType =
+                type_dyn_cast<DomainType>(wireOp.getResult().getType())) {
+          OpBuilder builder(wireOp);
+          auto classIn =
+              domainToClasses.at(domainType.getName().getAttr()).input;
+          auto object = ObjectOp::create(builder, wireOp.getLoc(), classIn,
+                                         wireOp.getNameAttr());
+          instanceGraph.lookup(op)->addInstance(object,
+                                                instanceGraph.lookup(classIn));
+          auto cast = UnrealizedConversionCastOp::create(
+              builder, wireOp.getLoc(), {wireOp.getResult().getType()},
+              {object.getResult()});
+          wireOp.getResult().replaceAllUsesWith(cast.getResult(0));
+          conversionsToErase.insert(cast);
           conversionsToErase.insert(wireOp);
-
-          // If this wire is dead or undriven, then there's nothing to do.
-          if (!src || dsts.empty())
-            return WalkResult::advance();
-          // Insert a domain define that removes the need for the wire.  This is
-          // inserted just before the latest domain define involving the wire.
-          // This is done to prevent unnecessary permutations of the IR.
-          OpBuilder builder(lastDefineOp);
-          for (auto dst : llvm::reverse(dsts))
-            DomainDefineOp::create(builder, builder.getUnknownLoc(), dst, src);
         }
 
-        // Erase the domain association from non-domain type wires.  Track the
-        // defining ops of domain operands so that any conversion casts that
-        // were only serving as domain associations are also cleaned up.
+        // Handle non-domain-typed wires.
         if (!wireOp.getDomains().empty()) {
           for (auto domain : wireOp.getDomains())
             if (auto *defOp = domain.getDefiningOp())
@@ -714,12 +683,14 @@ LogicalResult LowerModule::lowerModule() {
       if (!defineOp)
         return WalkResult::advance();
 
-      // There are only two possibilities for kinds of `DomainDefineOp`s that we
-      // can see a this point: the destination is always a conversion cast and
-      // the source is _either_ (1) a conversion cast if the source is a module
-      // or instance port or (2) an anonymous domain op or a domain create op.
-      // This relies on the earlier "canonicalization" that erased `WireOp`s to
-      // leave only `DomainDefineOp`s.
+      // The destination of a DomainDefineOp is always a conversion cast.  The
+      // source is _either_ (1) a conversion cast if the source is a module or
+      // instance port or (2) an anonymous domain op or a domain create op.
+      //
+      // When the destination wraps an ObjectOp (a wire placeholder), per-field
+      // connections are created from the source object's output ports to the
+      // destination object's input ports.  Otherwise, a single prop.assign
+      // connects the source to the destination.
       auto *src = defineOp.getSrc().getDefiningOp();
       auto dest = dyn_cast<UnrealizedConversionCastOp>(
           defineOp.getDest().getDefiningOp());
@@ -732,8 +703,24 @@ LogicalResult LowerModule::lowerModule() {
       if (auto srcCast = dyn_cast<UnrealizedConversionCastOp>(src)) {
         assert(srcCast.getNumOperands() == 1 && srcCast.getNumResults() == 1);
         OpBuilder builder(defineOp);
-        PropAssignOp::create(builder, defineOp.getLoc(), dest.getOperand(0),
-                             srcCast.getOperand(0));
+        // If the destination wraps an ObjectOp (wire placeholder), create
+        // per-field connections.  A single prop.assign would fail because
+        // ObjectOp results have source flow, not sink flow.
+        if (dest.getOperand(0).getDefiningOp<ObjectOp>()) {
+          auto domainType =
+              firrtl::type_cast<DomainType>(defineOp.getDest().getType());
+          auto numFields = domainType.getNumFields();
+          for (size_t i = 0; i < numFields; ++i) {
+            auto destIn = ObjectSubfieldOp::create(builder, defineOp.getLoc(),
+                                                   dest.getOperand(0), i * 2);
+            auto srcOut = ObjectSubfieldOp::create(
+                builder, defineOp.getLoc(), srcCast.getOperand(0), i * 2 + 1);
+            PropAssignOp::create(builder, defineOp.getLoc(), destIn, srcOut);
+          }
+        } else {
+          PropAssignOp::create(builder, defineOp.getLoc(), dest.getOperand(0),
+                               srcCast.getOperand(0));
+        }
       } else if (!isa<DomainCreateAnonOp, DomainCreateOp>(src)) {
         auto diag = defineOp.emitOpError()
                     << "has a source which cannot be lowered by 'LowerDomains'";

--- a/test/Dialect/FIRRTL/lower-domains.mlir
+++ b/test/Dialect/FIRRTL/lower-domains.mlir
@@ -720,8 +720,8 @@ firrtl.circuit "DrivenWireSubfield" {
   // CHECK-NEXT:    firrtl.propassign %[[src_in]], %[[name]]
   // CHECK-NEXT:    %wire = firrtl.object @ClockDomain(
   // CHECK-NEXT:    %[[wire_in:.+]] = firrtl.object.subfield %wire[source_in]
-  // CHECK-NEXT:    %[[src_out2:.+]] = firrtl.object.subfield %src[source_out]
-  // CHECK-NEXT:    firrtl.propassign %[[wire_in]], %[[src_out2]]
+  // CHECK-NEXT:    %[[src_out:.+]] = firrtl.object.subfield %src[source_out]
+  // CHECK-NEXT:    firrtl.propassign %[[wire_in]], %[[src_out]]
   // CHECK-NEXT:    %[[wire_out:.+]] = firrtl.object.subfield %wire[source_out]
   // CHECK-NEXT:    firrtl.propassign %out, %[[wire_out]]
   firrtl.module @DrivenWireSubfield(out %out : !firrtl.string) {

--- a/test/Dialect/FIRRTL/lower-domains.mlir
+++ b/test/Dialect/FIRRTL/lower-domains.mlir
@@ -222,7 +222,12 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: firrtl.propassign %[[associations_in]], %[[list]]
     // CHECK-NEXT: firrtl.propassign %B_out, %B_object :
     //
-    // CHECK-NEXT: firrtl.propassign %[[domainInfo_in]], %A :
+    // CHECK-NEXT: %w0 = firrtl.object @ClockDomain()
+    // CHECK-NEXT: %w1 = firrtl.object @ClockDomain()
+    // CHECK-NEXT: %w2 = firrtl.object @ClockDomain()
+    // CHECK-NEXT: firrtl.propassign %[[domainInfo_in]], %w2
+    // CHECK-NEXT: firrtl.matchingconnect %b, %a
+    // CHECK-NOT:  firrtl.wire
     %w0 = firrtl.wire : !firrtl.domain<@ClockDomain()>
     %w1 = firrtl.wire : !firrtl.domain<@ClockDomain()>
     %w2 = firrtl.wire : !firrtl.domain<@ClockDomain()>
@@ -230,10 +235,8 @@ firrtl.circuit "Foo" {
     firrtl.domain.define %w1, %w0 : !firrtl.domain<@ClockDomain()>
     firrtl.domain.define %w2, %w1 : !firrtl.domain<@ClockDomain()>
     firrtl.domain.define %B, %w2 : !firrtl.domain<@ClockDomain()>
-    // CHECK-NEXT: firrtl.matchingconnect %b, %a
     %0 = firrtl.unsafe_domain_cast %a domains[%B] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
     firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
-    // CHECK-NOT: firrtl.wire
   }
 }
 
@@ -248,6 +251,7 @@ firrtl.circuit "Foo" {
     in b: !firrtl.domain<@ClockDomain()>
   )
   // CHECK-LABEL: firrtl.module @Foo
+  // CHECK:         %wire = firrtl.object @ClockDomain()
   firrtl.module @Foo(
     in %a: !firrtl.domain<@ClockDomain()>
   ) {
@@ -257,8 +261,6 @@ firrtl.circuit "Foo" {
     )
     %wire = firrtl.wire : !firrtl.domain<@ClockDomain()>
     firrtl.domain.define %wire, %a : !firrtl.domain<@ClockDomain()>
-    // CHECK:      firrtl.propassign %bar_a, %a
-    // CHECK-NEXT: firrtl.propassign %bar_b, %a
     firrtl.domain.define %bar_a, %wire : !firrtl.domain<@ClockDomain()>
     firrtl.domain.define %bar_b, %wire : !firrtl.domain<@ClockDomain()>
   }
@@ -508,7 +510,6 @@ firrtl.circuit "DeadDomainOps" {
   // CHECK-NOT: firrtl.wire
   // CHECK-NOT: firrtl.domain.define
   // CHECK-NOT: firrtl.domain.anon : !firrtl.domain<@ClockDomain()>
-  // CHECK-NOT: firrtl.unknown
   firrtl.module @DeadDomainOps(
   ) {
     // A lone, undriven wire.
@@ -694,12 +695,57 @@ firrtl.circuit "WireWithCreateDomain" {
 firrtl.circuit "DomainWireUsedByWire" {
   firrtl.domain @ClockDomain
   // CHECK-LABEL: firrtl.module @DomainWireUsedByWire()
+  // CHECK-NEXT:    %domain_wire = firrtl.object @ClockDomain()
   // CHECK-NEXT:    %w = firrtl.wire : !firrtl.uint<1>
+  // CHECK-NEXT:    %actual_domain = firrtl.object @ClockDomain()
   // CHECK-NEXT:  }
   firrtl.module @DomainWireUsedByWire() {
     %domain_wire = firrtl.wire : !firrtl.domain<@ClockDomain()>
     %w = firrtl.wire domains[%domain_wire] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
     %actual_domain = firrtl.domain.create : !firrtl.domain<@ClockDomain()>
     firrtl.domain.define %domain_wire, %actual_domain : !firrtl.domain<@ClockDomain()>
+  }
+}
+
+// -----
+
+// Test that domain.subfield on a driven domain wire is properly lowered.
+// The subfield should read from the source that drives the wire.
+firrtl.circuit "DrivenWireSubfield" {
+  firrtl.domain @ClockDomain [#firrtl.domain.field<"source", !firrtl.string>]
+  // CHECK-LABEL: firrtl.module @DrivenWireSubfield(
+  // CHECK-NEXT:    %[[name:.+]] = firrtl.string "clk"
+  // CHECK-NEXT:    %src = firrtl.object @ClockDomain(
+  // CHECK-NEXT:    %[[src_in:.+]] = firrtl.object.subfield %src[source_in]
+  // CHECK-NEXT:    firrtl.propassign %[[src_in]], %[[name]]
+  // CHECK-NEXT:    %wire = firrtl.object @ClockDomain(
+  // CHECK-NEXT:    %[[wire_in:.+]] = firrtl.object.subfield %wire[source_in]
+  // CHECK-NEXT:    %[[src_out2:.+]] = firrtl.object.subfield %src[source_out]
+  // CHECK-NEXT:    firrtl.propassign %[[wire_in]], %[[src_out2]]
+  // CHECK-NEXT:    %[[wire_out:.+]] = firrtl.object.subfield %wire[source_out]
+  // CHECK-NEXT:    firrtl.propassign %out, %[[wire_out]]
+  firrtl.module @DrivenWireSubfield(out %out : !firrtl.string) {
+    %name = firrtl.string "clk"
+    %src = firrtl.domain.create(%name) : !firrtl.domain<@ClockDomain(source: !firrtl.string)>
+    %wire = firrtl.wire : !firrtl.domain<@ClockDomain(source: !firrtl.string)>
+    firrtl.domain.define %wire, %src : !firrtl.domain<@ClockDomain(source: !firrtl.string)>
+    %1 = firrtl.domain.subfield %wire[source] : !firrtl.domain<@ClockDomain(source: !firrtl.string)>
+    firrtl.propassign %out, %1 : !firrtl.string
+  }
+}
+
+// -----
+
+// Test that an unsafe_domain_cast using a domain wire as an association is
+// properly lowered.  The wire should be replaced with a conversion cast and the
+// unsafe_domain_cast should be removed.
+firrtl.circuit "UnsafeDomainCastWithWire" {
+  firrtl.domain @ClockDomain [#firrtl.domain.field<"source", !firrtl.string>]
+  // CHECK-LABEL: firrtl.module @UnsafeDomainCastWithWire(in %a: !firrtl.uint<1>)
+  // CHECK-NEXT:    %wire = firrtl.object @ClockDomain(
+  // CHECK-NEXT:  }
+  firrtl.module @UnsafeDomainCastWithWire(in %a: !firrtl.uint<1>) {
+    %wire = firrtl.wire : !firrtl.domain<@ClockDomain(source: !firrtl.string)>
+    %0 = firrtl.unsafe_domain_cast %a domains[%wire] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain(source: !firrtl.string)>]
   }
 }


### PR DESCRIPTION
Fix general with how `LowerDomains` handles wires.  Change this to do the
absolute simplest lowering: replace a domain-typed wire with an object of
the underlying domain-lowered class.

This is not always necessary, and the previous code was trying to be
overly cute by splicing wire destinations to wire sources.  However, this
had bugs where it did not handle the case of a wire having non-association
users, specifically domain subfield ops.  Instead of maintaining the cute
optimization, instead just do the simplest lowering and rely on
to-be-written optimizations to simplify connections through wires in the
future.

Fixes #10245.

Assisted-by: Claude Code:claude-opus-4-6
