### PR TITLE
[ImportVerilog] Fix slang compilation flag precedence

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -260,6 +260,8 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
       return failure();
 
   // Populate the driver options.
+  driver.addStandardArgs();
+
   driver.options.excludeExts.insert(options.excludeExts.begin(),
                                     options.excludeExts.end());
   driver.options.ignoreDirectives = options.ignoreDirectives;
@@ -270,17 +272,17 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   driver.options.librariesInheritMacros = options.librariesInheritMacros;
 
   driver.options.timeScale = options.timeScale;
-  driver.options.compilationFlags.emplace(
-      slang::ast::CompilationFlags::AllowUseBeforeDeclare,
-      options.allowUseBeforeDeclare);
-  driver.options.compilationFlags.emplace(
-      slang::ast::CompilationFlags::IgnoreUnknownModules,
-      options.ignoreUnknownModules);
-  driver.options.compilationFlags.emplace(
-      slang::ast::CompilationFlags::LintMode,
-      options.mode == ImportVerilogOptions::Mode::OnlyLint);
-  driver.options.compilationFlags.emplace(
-      slang::ast::CompilationFlags::DisableInstanceCaching, false);
+  driver.options
+      .compilationFlags[slang::ast::CompilationFlags::AllowUseBeforeDeclare] =
+      options.allowUseBeforeDeclare;
+  driver.options
+      .compilationFlags[slang::ast::CompilationFlags::IgnoreUnknownModules] =
+      options.ignoreUnknownModules;
+  driver.options.compilationFlags[slang::ast::CompilationFlags::LintMode] =
+      options.mode == ImportVerilogOptions::Mode::OnlyLint;
+  driver.options
+      .compilationFlags[slang::ast::CompilationFlags::DisableInstanceCaching] =
+      false;
   driver.options.topModules = options.topModules;
   driver.options.paramOverrides = options.paramOverrides;
 
@@ -290,7 +292,6 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   driver.options.singleUnit = options.singleUnit;
 
   // Parse pass through options.
-  driver.addStandardArgs();
   if (!options.slangArgs.empty()) {
     SmallVector<const char *> slangArgs;
     slangArgs.push_back("slang"); // dummy program name


### PR DESCRIPTION
Insert the explicitly set slang compilation flags _after_ the call to `addStandardArgs` instead of before. This should prevent our arguments from being overridden by the defaults* and avoids an assertion in slang.

After #10238 `circt-verilog` is crashing in slang with an assertion locally for me:
https://github.com/MikePopoloski/slang/blob/v10.0/source/driver/Driver.cpp#L214
Not sure why it isn't showing up in the CI. **
The problem appears to be `addStandardArgs` attempting to set a flag to a default value, which we have already explicitly set in ImportVerilog. Instead of silently ignoring it, it asserts.

\* On second thought: Without the assert triggering, the default would not actually override our value but be ignored instead.

** Well - it _did_ show up in the nightlies 😅 
https://github.com/llvm/circt/actions/runs/24564472782