### PR TITLE
[FIRRTL] LowerLayers: Do not include dummy bindfiles

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -194,6 +194,8 @@ struct BindFileInfo {
   StringAttr filename;
   /// Where to insert bind statements into the bind file.
   Block *body;
+  /// True if including the bindfile has an effect on the design.
+  bool effectful;
 };
 } // namespace
 
@@ -264,7 +266,8 @@ class LowerLayersPass
 
   /// Build a bindfile skeleton for a particular module and layer.
   void buildBindFile(CircuitNamespace &ns, InstanceGraphNode *node,
-                     OpBuilder &b, SymbolRefAttr layerName, LayerOp layer);
+                     OpBuilder &b, SymbolRefAttr layerName, LayerOp layer,
+                     bool effectful);
 
   /// Entry point for the function.
   void runOnOperation() override;
@@ -1143,7 +1146,8 @@ void LowerLayersPass::preprocessLayers(CircuitNamespace &ns) {
 
 void LowerLayersPass::buildBindFile(CircuitNamespace &ns,
                                     InstanceGraphNode *node, OpBuilder &b,
-                                    SymbolRefAttr layerName, LayerOp layer) {
+                                    SymbolRefAttr layerName, LayerOp layer,
+                                    bool effectful) {
   assert(layer.getConvention() == LayerConvention::Bind);
   auto module = node->getModule<FModuleOp>();
   auto loc = module.getLoc();
@@ -1222,15 +1226,16 @@ void LowerLayersPass::buildBindFile(CircuitNamespace &ns,
       continue;
     auto files = bindFiles[child];
     auto lookup = files.find(layer);
-    if (lookup != files.end())
-      sv::IncludeOp::create(b, loc, IncludeStyle::Local,
-                            lookup->second.filename);
+    if (lookup == files.end() || !lookup->second.effectful)
+      continue;
+    sv::IncludeOp::create(b, loc, IncludeStyle::Local, lookup->second.filename);
   }
 
   // Save the bind file information for later.
   auto &info = bindFiles[module][layer];
   info.filename = filename;
   info.body = includeGuard.getElseBlock();
+  info.effectful = effectful;
 }
 
 void LowerLayersPass::preprocessModule(CircuitNamespace &ns,
@@ -1240,13 +1245,13 @@ void LowerLayersPass::preprocessModule(CircuitNamespace &ns,
   b.setInsertionPointAfter(module);
 
   // Create a bind file only if the layer is used under the module.
-  llvm::SmallDenseSet<LayerOp> layersRequiringBindFiles;
+  llvm::SmallDenseMap<LayerOp, bool> layersRequiringBindFiles;
 
   // If the module is public, create a bind file for all layers.
   if (module.isPublic() || emitAllBindFiles)
     for (auto [_, layer] : symbolToLayer)
       if (layer.getConvention() == LayerConvention::Bind)
-        layersRequiringBindFiles.insert(layer);
+        layersRequiringBindFiles[layer] = false;
 
   // Handle layers used directly in this module.
   module->walk([&](LayerBlockOp layerBlock) {
@@ -1255,7 +1260,7 @@ void LowerLayersPass::preprocessModule(CircuitNamespace &ns,
       return;
 
     // Create a bindfile for any layer directly used in the module.
-    layersRequiringBindFiles.insert(layer);
+    layersRequiringBindFiles[layer] = true;
 
     // Determine names for all modules that will be created.
     auto moduleName = module.getModuleName();
@@ -1277,15 +1282,18 @@ void LowerLayersPass::preprocessModule(CircuitNamespace &ns,
   // Create a bindfile for layers used indirectly under this module.
   for (auto *record : *node) {
     auto *child = record->getTarget()->getModule().getOperation();
-    for (auto [layer, _] : bindFiles[child])
-      layersRequiringBindFiles.insert(layer);
+    for (auto [layer, info] : bindFiles[child])
+      layersRequiringBindFiles[layer] |= info.effectful;
   }
 
   // Build the bindfiles for any layer seen under this module. The bindfiles
   // are emitted in the order which they are declared, for readability.
-  for (auto [sym, layer] : symbolToLayer)
-    if (layersRequiringBindFiles.contains(layer))
-      buildBindFile(ns, node, b, sym, layer);
+  for (auto [sym, layer] : symbolToLayer) {
+    auto it = layersRequiringBindFiles.find(layer);
+    if (it == layersRequiringBindFiles.end())
+      continue;
+    buildBindFile(ns, node, b, sym, layer, it->second);
+  }
 }
 
 void LowerLayersPass::preprocessExtModule(CircuitNamespace &ns,
@@ -1315,6 +1323,7 @@ void LowerLayersPass::preprocessExtModule(CircuitNamespace &ns,
             fileNameForLayer(moduleName, rootLayerName, nestedLayerNames);
         info.filename = StringAttr::get(&getContext(), filename);
         info.body = nullptr;
+        info.effectful = true;
         files.insert({layer, info});
       }
       layer = layer->getParentOfType<LayerOp>();

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -1122,3 +1122,24 @@ firrtl.circuit "EmptyLayerBlocks" {
     }
   }
 }
+
+// -----
+
+firrtl.circuit "DoNotIncludeDummyBindfiles" {
+  firrtl.layer @A bind {}
+
+  firrtl.module public @Child1() {}
+  firrtl.module public @Child2() {
+    firrtl.layerblock @A {
+      %c = firrtl.wire : !firrtl.uint<1>
+    }
+  }
+
+  firrtl.module public @DoNotIncludeDummyBindfiles() {
+    firrtl.instance child1 @Child1()
+    firrtl.instance child2 @Child2()
+  }
+
+  // CHECK-NOT: sv.include local "layers-Child1-A.sv"
+  // CHECK: sv.include local "layers-Child2-A.sv"
+}

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -1142,4 +1142,5 @@ firrtl.circuit "DoNotIncludeDummyBindfiles" {
 
   // CHECK-NOT: sv.include local "layers-Child1-A.sv"
   // CHECK: sv.include local "layers-Child2-A.sv"
+  // CHECK-NOT: sv.include local "layers-Child1-A.sv"  
 }

--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -300,7 +300,7 @@ circuit Foo:
   layer A, bind, "A":
   layer B, bind, "B":
 
-  extmodule Baz:
+  extmodule Baz knownlayer A knownlayer B:
 
   public module Bar:
     ; This instance of an extmodule prevents Foo/bar from being DCE'd.


### PR DESCRIPTION
Track when a bind file has no associated layer block ops, and when that is the case, do not include it. These sorts of bind files are created for public modules, or when "emit-all-bind-files" is enabled, which both cause us to emit a bind file for each module*layer, even if there is no associated layer block.
