### PR TITLE
[SeqToSV] Fix illegal IR in clock-typed register

### DIFF
--- a/lib/Conversion/SeqToSV/FirRegLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirRegLowering.cpp
@@ -757,7 +757,15 @@ void FirRegLowering::lowerReg(FirRegOp reg) {
   if (!conditions.empty())
     regConditionTable.emplace_or_assign(svReg.reg, conditions);
 
-  reg.replaceAllUsesWith(regVal.getResult());
+  // For clock-typed registers the lowered sv.reg holds i1, but any remaining
+  // users of the original !seq.clock result (e.g. seq.from_clock, hw.wire)
+  // still expect that type.  Bridge the gap with a seq.to_clock so that those
+  // users stay type-correct until applyPartialConversion resolves them via
+  // ClockCastLowering<ToClockOp>.
+  Value replacement = regVal.getResult();
+  if (isa<seq::ClockType>(reg.getType()) && !reg.use_empty())
+    replacement = seq::ToClockOp::create(builder, loc, regVal.getResult());
+  reg.replaceAllUsesWith(replacement);
   reg.erase();
 }
 

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -801,6 +801,25 @@ hw.module @reg_of_clock_type(in %clk: !seq.clock, in %rst: i1, in %i: !seq.clock
   hw.output %r2 : !seq.clock
 }
 
+// Registers of clock type need special handling as the clock type is converted
+// to an i1.  However, downstream users, like `seq.from_clock` have hard
+// requirements that types are clocks (not i1).  Keep the IR valid as the
+// folders on `from_clock` may be called.
+//
+// See: https://github.com/llvm/circt/issues/10254
+//
+// CHECK-LABEL: @FirregClockType
+hw.module @FirregClockType(in %a : !seq.clock) {
+  // CHECK: sv.reg : !hw.inout<i1>
+  // CHECK: sv.read_inout
+  // CHECK-NOT: seq.from_clock
+  %false = hw.constant false
+  %next = seq.to_clock %false
+  %reg = seq.firreg %next clock %a : !seq.clock
+  %q = seq.from_clock %reg
+  hw.output
+}
+
 // Check if/else structure for register enable inference is maintained, without
 // pulling unnecessary muxes into if/else structures.
 


### PR DESCRIPTION
Fix an issue related to partial lowering of a clock-typed register in
SeqToSV.  A clock type becomes an i1 after this pass.  However, there
could be users of a clock type which can't handle an i1.  This was
manifesting as a crash in a folder which was using the `getInput` method
which would do a hard cast to the expected type.

Fixes #10254.

Assisted-by: Claude Code:claude-sonnet-4-6
Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>
