### PR TITLE
[slang] Add SLANG_ASSERT_ENABLED=1 for assertion build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,6 +577,10 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     set(SLANG_USE_THREADS OFF)  # avoid race condition in BS::thread_pool
     FetchContent_MakeAvailable(slang)
 
+    if(LLVM_ENABLE_ASSERTIONS)
+      target_compile_definitions(slang_slang PUBLIC SLANG_ASSERT_ENABLED=1)
+    endif()
+
     set(CMAKE_CXX_FLAGS ${ORIGINAL_CMAKE_CXX_FLAGS})
     set(BUILD_SHARED_LIBS ${ORIGINAL_BUILD_SHARED_LIBS})
 

--- a/cmake/modules/SlangCompilerOptions.cmake
+++ b/cmake/modules/SlangCompilerOptions.cmake
@@ -14,6 +14,12 @@ set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
 # potentially built or modified by code compiled in the Slang compilation unit.
 add_compile_definitions($<$<CONFIG:Debug>:SLANG_DEBUG>)
 
+# Keep header-defined slang assertion behavior in sync with the linked slang
+# library for LLVM assertions-enabled builds, including non-Debug configs.
+if(LLVM_ENABLE_ASSERTIONS)
+  add_compile_definitions(SLANG_ASSERT_ENABLED=1)
+endif()
+
 # HACK: When the `OBJECT` argument is passed to `llvm_add_library()`,
 # `COMPILE_DEFINITIONS` are not correctly inherited. For that reason, we
 # manually set it here.

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -260,6 +260,8 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
       return failure();
 
   // Populate the driver options.
+  driver.addStandardArgs();
+
   driver.options.excludeExts.insert(options.excludeExts.begin(),
                                     options.excludeExts.end());
   driver.options.ignoreDirectives = options.ignoreDirectives;
@@ -270,17 +272,17 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   driver.options.librariesInheritMacros = options.librariesInheritMacros;
 
   driver.options.timeScale = options.timeScale;
-  driver.options.compilationFlags.emplace(
-      slang::ast::CompilationFlags::AllowUseBeforeDeclare,
-      options.allowUseBeforeDeclare);
-  driver.options.compilationFlags.emplace(
-      slang::ast::CompilationFlags::IgnoreUnknownModules,
-      options.ignoreUnknownModules);
-  driver.options.compilationFlags.emplace(
-      slang::ast::CompilationFlags::LintMode,
-      options.mode == ImportVerilogOptions::Mode::OnlyLint);
-  driver.options.compilationFlags.emplace(
-      slang::ast::CompilationFlags::DisableInstanceCaching, false);
+  driver.options
+      .compilationFlags[slang::ast::CompilationFlags::AllowUseBeforeDeclare] =
+      options.allowUseBeforeDeclare;
+  driver.options
+      .compilationFlags[slang::ast::CompilationFlags::IgnoreUnknownModules] =
+      options.ignoreUnknownModules;
+  driver.options.compilationFlags[slang::ast::CompilationFlags::LintMode] =
+      options.mode == ImportVerilogOptions::Mode::OnlyLint;
+  driver.options
+      .compilationFlags[slang::ast::CompilationFlags::DisableInstanceCaching] =
+      false;
   driver.options.topModules = options.topModules;
   driver.options.paramOverrides = options.paramOverrides;
 
@@ -290,7 +292,6 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   driver.options.singleUnit = options.singleUnit;
 
   // Parse pass through options.
-  driver.addStandardArgs();
   if (!options.slangArgs.empty()) {
     SmallVector<const char *> slangArgs;
     slangArgs.push_back("slang"); // dummy program name

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -260,8 +260,6 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
       return failure();
 
   // Populate the driver options.
-  driver.addStandardArgs();
-
   driver.options.excludeExts.insert(options.excludeExts.begin(),
                                     options.excludeExts.end());
   driver.options.ignoreDirectives = options.ignoreDirectives;
@@ -272,17 +270,17 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   driver.options.librariesInheritMacros = options.librariesInheritMacros;
 
   driver.options.timeScale = options.timeScale;
-  driver.options
-      .compilationFlags[slang::ast::CompilationFlags::AllowUseBeforeDeclare] =
-      options.allowUseBeforeDeclare;
-  driver.options
-      .compilationFlags[slang::ast::CompilationFlags::IgnoreUnknownModules] =
-      options.ignoreUnknownModules;
-  driver.options.compilationFlags[slang::ast::CompilationFlags::LintMode] =
-      options.mode == ImportVerilogOptions::Mode::OnlyLint;
-  driver.options
-      .compilationFlags[slang::ast::CompilationFlags::DisableInstanceCaching] =
-      false;
+  driver.options.compilationFlags.emplace(
+      slang::ast::CompilationFlags::AllowUseBeforeDeclare,
+      options.allowUseBeforeDeclare);
+  driver.options.compilationFlags.emplace(
+      slang::ast::CompilationFlags::IgnoreUnknownModules,
+      options.ignoreUnknownModules);
+  driver.options.compilationFlags.emplace(
+      slang::ast::CompilationFlags::LintMode,
+      options.mode == ImportVerilogOptions::Mode::OnlyLint);
+  driver.options.compilationFlags.emplace(
+      slang::ast::CompilationFlags::DisableInstanceCaching, false);
   driver.options.topModules = options.topModules;
   driver.options.paramOverrides = options.paramOverrides;
 
@@ -292,6 +290,7 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   driver.options.singleUnit = options.singleUnit;
 
   // Parse pass through options.
+  driver.addStandardArgs();
   if (!options.slangArgs.empty()) {
     SmallVector<const char *> slangArgs;
     slangArgs.push_back("slang"); // dummy program name


### PR DESCRIPTION
CI expectedly failed https://github.com/llvm/circt/actions/runs/24583755924/job/71888080182?pr=10261. 

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
