### PR TITLE
[OM] Add a folder for IntegerBinaryArithmeticOp and use it in Evaluator, extend StringConcat folder

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -460,6 +460,7 @@ class IntegerBinaryArithmeticOp<string mnemonic, list<Trait> traits = []> :
   let results = (outs OMIntegerType:$result);
 
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
+  let hasFolder = 1;
 }
 
 def IntegerAddOp : IntegerBinaryArithmeticOp<"integer.add", [Commutative]> {

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -491,27 +491,14 @@ circt::om::Evaluator::evaluateIntegerBinaryArithmetic(
   assert(lhs && rhs &&
          "expected om::IntegerAttr for IntegerBinaryArithmeticOp operands");
 
-  // Extend values if necessary to match bitwidth. Most interesting arithmetic
-  // on APSInt asserts that both operands are the same bitwidth, but the
-  // IntegerAttrs we are working with may have used the smallest necessary
-  // bitwidth to represent the number they hold, and won't necessarily match.
-  APSInt lhsVal = lhs.getValue().getAPSInt();
-  APSInt rhsVal = rhs.getValue().getAPSInt();
-  if (lhsVal.getBitWidth() > rhsVal.getBitWidth())
-    rhsVal = rhsVal.extend(lhsVal.getBitWidth());
-  else if (rhsVal.getBitWidth() > lhsVal.getBitWidth())
-    lhsVal = lhsVal.extend(rhsVal.getBitWidth());
-
-  // Perform arbitrary precision signed integer binary arithmetic.
-  FailureOr<APSInt> result = op.evaluateIntegerOperation(lhsVal, rhsVal);
-
-  if (failed(result))
+  std::array<Attribute, 2> operandAttrs = {lhs, rhs};
+  SmallVector<mlir::OpFoldResult, 1> results;
+  om::IntegerAttr resultAttr;
+  auto foldResult = op->fold(operandAttrs, results);
+  if (failed(foldResult) || results.size() != 1 ||
+      !(resultAttr = llvm::dyn_cast_or_null<om::IntegerAttr>(
+            results[0].dyn_cast<Attribute>())))
     return op->emitError("failed to evaluate integer operation");
-
-  // Package the result as a new om::IntegerAttr.
-  MLIRContext *ctx = op->getContext();
-  auto resultAttr =
-      om::IntegerAttr::get(ctx, mlir::IntegerAttr::get(ctx, result.value()));
 
   // Finalize the op result value.
   auto *handleValue = cast<evaluator::AttributeValue>(handle.value().get());

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -493,11 +493,15 @@ circt::om::Evaluator::evaluateIntegerBinaryArithmetic(
 
   std::array<Attribute, 2> operandAttrs = {lhs, rhs};
   SmallVector<mlir::OpFoldResult, 1> results;
-  om::IntegerAttr resultAttr;
-  auto foldResult = op->fold(operandAttrs, results);
-  if (failed(foldResult) || results.size() != 1 ||
-      !(resultAttr = llvm::dyn_cast_or_null<om::IntegerAttr>(
-            results[0].dyn_cast<Attribute>())))
+  if (failed(op->fold(operandAttrs, results)) || results.size() != 1)
+    return op->emitError("failed to fold integer operation");
+
+  // Even with fully constant operands, folders may decline to fold or may
+  // produce a non-attribute result. Keep the evaluator-side type check so this
+  // fails cleanly instead of tripping an assertion below.
+  auto resultAttr =
+      llvm::dyn_cast_or_null<om::IntegerAttr>(results[0].dyn_cast<Attribute>());
+  if (!resultAttr)
     return op->emitError("failed to evaluate integer operation");
 
   // Finalize the op result value.

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -493,15 +493,12 @@ circt::om::Evaluator::evaluateIntegerBinaryArithmetic(
 
   std::array<Attribute, 2> operandAttrs = {lhs, rhs};
   SmallVector<mlir::OpFoldResult, 1> results;
-  if (failed(op->fold(operandAttrs, results)) || results.size() != 1)
-    return op->emitError("failed to fold integer operation");
-
+  IntegerAttr resultAttr;
   // Even with fully constant operands, folders may decline to fold or may
-  // produce a non-attribute result. Keep the evaluator-side type check so this
-  // fails cleanly instead of tripping an assertion below.
-  auto resultAttr =
-      llvm::dyn_cast_or_null<om::IntegerAttr>(results[0].dyn_cast<Attribute>());
-  if (!resultAttr)
+  // produce a non-attribute result.
+  if (failed(op->fold(operandAttrs, results)) || results.size() != 1 ||
+      !(resultAttr = llvm::dyn_cast_or_null<om::IntegerAttr>(
+            results[0].dyn_cast<Attribute>())))
     return op->emitError("failed to evaluate integer operation");
 
   // Finalize the op result value.

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/OM/OMOps.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/OM/OMOpInterfaces.h"
 #include "circt/Dialect/OM/OMUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -640,6 +641,39 @@ PathCreateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
+// IntegerBinaryArithmeticOp
+//===----------------------------------------------------------------------===//
+
+static OpFoldResult foldIntegerBinaryArithmetic(IntegerBinaryArithmeticOp op,
+                                                Attribute lhsAttr,
+                                                Attribute rhsAttr) {
+  auto lhs = dyn_cast_or_null<circt::om::IntegerAttr>(lhsAttr);
+  auto rhs = dyn_cast_or_null<circt::om::IntegerAttr>(rhsAttr);
+  if (!lhs || !rhs)
+    return {};
+  // Extend values if necessary to match bitwidth. Most interesting arithmetic
+  // on APSInt asserts that both operands are the same bitwidth, but the
+  // IntegerAttrs we are working with may have used the smallest necessary
+  // bitwidth to represent the number they hold, and won't necessarily match.
+  APSInt lhsVal = lhs.getValue().getAPSInt();
+  APSInt rhsVal = rhs.getValue().getAPSInt();
+  if (lhsVal.getBitWidth() > rhsVal.getBitWidth())
+    rhsVal = rhsVal.extend(lhsVal.getBitWidth());
+  else if (rhsVal.getBitWidth() > lhsVal.getBitWidth())
+    lhsVal = lhsVal.extend(rhsVal.getBitWidth());
+
+  // Perform arbitrary precision signed integer binary arithmetic.
+  auto result = op.evaluateIntegerOperation(lhsVal, rhsVal);
+  if (failed(result))
+    return {};
+
+  auto *ctx = op.getContext();
+  // Return the result as a new om::IntegerAttr.
+  return circt::om::IntegerAttr::get(
+      ctx, mlir::IntegerAttr::get(ctx, result.value()));
+}
+
+//===----------------------------------------------------------------------===//
 // IntegerAddOp
 //===----------------------------------------------------------------------===//
 
@@ -647,6 +681,10 @@ FailureOr<llvm::APSInt>
 IntegerAddOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
                                        const llvm::APSInt &rhs) {
   return success(lhs + rhs);
+}
+
+OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
+  return foldIntegerBinaryArithmetic(*this, adaptor.getLhs(), adaptor.getRhs());
 }
 
 //===----------------------------------------------------------------------===//
@@ -657,6 +695,10 @@ FailureOr<llvm::APSInt>
 IntegerMulOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
                                        const llvm::APSInt &rhs) {
   return success(lhs * rhs);
+}
+
+OpFoldResult IntegerMulOp::fold(FoldAdaptor adaptor) {
+  return foldIntegerBinaryArithmetic(*this, adaptor.getLhs(), adaptor.getRhs());
 }
 
 //===----------------------------------------------------------------------===//
@@ -675,6 +717,10 @@ IntegerShrOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
   return success(lhs >> rhs.getExtValue());
 }
 
+OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
+  return foldIntegerBinaryArithmetic(*this, adaptor.getLhs(), adaptor.getRhs());
+}
+
 //===----------------------------------------------------------------------===//
 // IntegerShlOp
 //===----------------------------------------------------------------------===//
@@ -691,14 +737,22 @@ IntegerShlOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
   return success(lhs << rhs.getExtValue());
 }
 
+OpFoldResult IntegerShlOp::fold(FoldAdaptor adaptor) {
+  return foldIntegerBinaryArithmetic(*this, adaptor.getLhs(), adaptor.getRhs());
+}
+
 //===----------------------------------------------------------------------===//
 // StringConcatOp
 //===----------------------------------------------------------------------===//
 
 OpFoldResult StringConcatOp::fold(FoldAdaptor adaptor) {
   // Fold single-operand concat to just the operand.
-  if (getStrings().size() == 1)
+  if (getStrings().size() == 1) {
+    if (auto strAttr = adaptor.getStrings()[0])
+      return strAttr;
+
     return getStrings()[0];
+  }
 
   // Check if all operands are constant strings before accumulating.
   if (!llvm::all_of(adaptor.getStrings(), [](Attribute operand) {

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -23,7 +23,10 @@ func.func @ObjectsMustDCE() {
   return
 }
 
-om.class @StringConcatCanonicalization(%str1: !om.string, %str2: !om.string) -> (out1: !om.string, out2: !om.string, out3: !om.string, out4: !om.string, out5: !om.string, out6: !om.string, out7: !om.string, out8: !om.string) {
+om.class @StringConcatCanonicalization(%str1: !om.string, %str2: !om.string) -> (out1: !om.string, out2: !om.string,
+                                                                                  out3: !om.string, out4: !om.string,
+                                                                                  out5: !om.string, out6: !om.string,
+                                                                                  out7: !om.string, out8: !om.string) {
   %s1 = om.constant "Hello" : !om.string
   %s2 = om.constant "World" : !om.string
   %s3 = om.constant "!" : !om.string
@@ -76,6 +79,8 @@ om.class @IntegerBinaryArithmeticFold(%x: !om.integer) -> (out1: !om.integer, ou
   %wide = om.constant #om.integer<7 : si6> : !om.integer
 
   // CHECK-DAG: [[ADD:%.+]] = om.constant #om.integer<7 : si4> : !om.integer
+  // Arithmetic uses APSInt semantics at the operands' folded bit width, so
+  // 3 * 4 folds to si4 -4 here.
   // CHECK-DAG: [[MUL:%.+]] = om.constant #om.integer<-4 : si4> : !om.integer
   // CHECK-DAG: [[SHR:%.+]] = om.constant #om.integer<1 : si4> : !om.integer
   // CHECK-DAG: [[SHL:%.+]] = om.constant #om.integer<-2 : si4> : !om.integer

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -23,7 +23,7 @@ func.func @ObjectsMustDCE() {
   return
 }
 
-om.class @StringConcatCanonicalization(%str1: !om.string, %str2: !om.string) -> (out1: !om.string, out2: !om.string, out3: !om.string, out4: !om.string, out5: !om.string, out6: !om.string, out7: !om.string) {
+om.class @StringConcatCanonicalization(%str1: !om.string, %str2: !om.string) -> (out1: !om.string, out2: !om.string, out3: !om.string, out4: !om.string, out5: !om.string, out6: !om.string, out7: !om.string, out8: !om.string) {
   %s1 = om.constant "Hello" : !om.string
   %s2 = om.constant "World" : !om.string
   %s3 = om.constant "!" : !om.string
@@ -43,6 +43,9 @@ om.class @StringConcatCanonicalization(%str1: !om.string, %str2: !om.string) -> 
   // Single operand replaced with operand
   %2 = om.string.concat %s1 : !om.string
 
+  // Single constant operand folds to the attribute.
+  %singleConst = om.string.concat %s3 : !om.string
+
   // Empty concat
   %3 = om.string.concat %empty, %empty : !om.string
 
@@ -57,8 +60,40 @@ om.class @StringConcatCanonicalization(%str1: !om.string, %str2: !om.string) -> 
   %nested = om.string.concat %str1, %str2 : !om.string
   %concat1 = om.string.concat %nested, %s3 : !om.string
 
-  // CHECK: om.class.fields [[HELLOWORLD]], [[HELLO]], [[HELLO]], [[EMPTY]], [[HELLOWORLD]], [[CONCAT1]], [[NESTED]]
-  om.class.fields %0, %1, %2, %3, %5, %concat1, %nested : !om.string, !om.string, !om.string, !om.string, !om.string, !om.string, !om.string
+  // CHECK: om.class.fields [[HELLOWORLD]], [[HELLO]], [[HELLO]], [[CONST]], [[EMPTY]], [[HELLOWORLD]], [[CONCAT1]], [[NESTED]]
+  om.class.fields %0, %1, %2, %singleConst, %3, %5, %concat1, %nested : !om.string, !om.string, !om.string, !om.string, !om.string, !om.string, !om.string, !om.string
+}
+
+// CHECK-LABEL: @IntegerBinaryArithmeticFold
+om.class @IntegerBinaryArithmeticFold(%x: !om.integer) -> (out1: !om.integer, out2: !om.integer,
+                                                           out3: !om.integer, out4: !om.integer,
+                                                           out5: !om.integer, out6: !om.integer) {
+  %i3 = om.constant #om.integer<3 : si4> : !om.integer
+  %i4 = om.constant #om.integer<4 : si4> : !om.integer
+  %i2 = om.constant #om.integer<2 : si4> : !om.integer
+  %neg1 = om.constant #om.integer<-1 : si4> : !om.integer
+  %i1 = om.constant #om.integer<1 : si4> : !om.integer
+  %wide = om.constant #om.integer<7 : si6> : !om.integer
+
+  // CHECK-DAG: [[ADD:%.+]] = om.constant #om.integer<7 : si4> : !om.integer
+  // CHECK-DAG: [[MUL:%.+]] = om.constant #om.integer<-4 : si4> : !om.integer
+  // CHECK-DAG: [[SHR:%.+]] = om.constant #om.integer<1 : si4> : !om.integer
+  // CHECK-DAG: [[SHL:%.+]] = om.constant #om.integer<-2 : si4> : !om.integer
+  // CHECK-DAG: [[WIDEADD:%.+]] = om.constant #om.integer<9 : si6> : !om.integer
+  // CHECK: [[DYN:%.+]] = om.integer.add %x, %{{.+}} : !om.integer
+  %0 = om.integer.add %i3, %i4 : !om.integer
+  %1 = om.integer.mul %i3, %i4 : !om.integer
+  %2 = om.integer.shr %i4, %i2 : !om.integer
+  %3 = om.integer.shl %neg1, %i1 : !om.integer
+
+  // Mixed bit widths should still fold after extending operands.
+  %4 = om.integer.add %i2, %wide : !om.integer
+
+  // Non-constant operands should remain.
+  %5 = om.integer.add %x, %i1 : !om.integer
+
+  // CHECK: om.class.fields [[ADD]], [[MUL]], [[SHR]], [[SHL]], [[WIDEADD]], [[DYN]]
+  om.class.fields %0, %1, %2, %3, %4, %5 : !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer
 }
 
 // CHECK-LABEL: @PropEqFold


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

This extends IntegerBinaryArithmeticOp folder using evaluation rule in Evaluator. Also changes Evaluator to use folder to avoid code duplication. Also extends a folder of StringConcat.  

Separated from https://github.com/llvm/circt/pull/10265, which proposes to a pattern to use Op folder not only IntegerArithmeticOp. 


Assisted-by: Codex: GPT 5.4