### PR TITLE
[OM][circt-reduce] Add op to unknown reduction

### DIFF
--- a/lib/Dialect/OM/OMReductions.cpp
+++ b/lib/Dialect/OM/OMReductions.cpp
@@ -350,6 +350,36 @@ struct OMAnyCastOfUnknownSimplifier : public OpReduction<om::AnyCastOp> {
   }
 };
 
+/// Generic Operation-based reduction that replaces any OM operation with
+/// om.unknown of the same result type. This operates at the lowest level by
+/// working directly on Operation* without needing to know concrete op types.
+struct OMOpToUnknown : public Reduction {
+  uint64_t match(Operation *op) override {
+    // Only handle operations from the OM dialect
+    if (!isa<OMDialect>(op->getDialect()))
+      return 0;
+
+    // Must have exactly one result (what we'll replace with unknown)
+    if (op->getNumResults() != 1)
+      return 0;
+
+    // Constant benefit: just eliminate this single operation
+    return 1;
+  }
+
+  LogicalResult rewrite(Operation *op) override {
+    OpBuilder builder(op);
+    Type resultType = op->getResult(0).getType();
+    auto unknownOp =
+        om::UnknownValueOp::create(builder, op->getLoc(), resultType);
+    op->getResult(0).replaceAllUsesWith(unknownOp.getResult());
+    op->erase();
+    return success();
+  }
+
+  std::string getName() const override { return "om-op-to-unknown"; };
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -366,6 +396,7 @@ void om::OMReducePatternDialectInterface::populateReducePatterns(
 
   // Medium priority reductions
   patterns.add<OMUnusedClassRemover, 40>();
+  patterns.add<OMOpToUnknown, 35>();
   patterns.add<OMAnyCastOfUnknownSimplifier, 35>();
 }
 

--- a/test/Dialect/OM/Reduction/op-to-unknown.mlir
+++ b/test/Dialect/OM/Reduction/op-to-unknown.mlir
@@ -1,0 +1,24 @@
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "add" --include om-op-to-unknown --keep-best=0 | FileCheck %s
+
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+
+// This test verifies that the generic OMOpToUnknown pattern replaces ANY
+// single-result OM operation with om.unknown, operating at the lowest level
+// on Operation* without needing concrete op types.
+
+module {
+  // CHECK-LABEL: om.class @TestClass(%input: !om.integer) -> (result: !om.integer) {
+  om.class @TestClass(%input: !om.integer) -> (result: !om.integer) {
+    // CHECK-NEXT: %[[UNKNOWN_0:.+]] = om.unknown : !om.integer
+    // CHECK-NEXT: %[[UNKNOWN_1:.+]] = om.unknown : !om.integer
+    %const_42 = om.constant #om.integer<42 : si64> : !om.integer
+    %const_43 = om.constant #om.integer<43 : si64> : !om.integer
+
+    // Test constant replacement
+    // CHECK: %[[ADD:.+]] = om.integer.add %[[UNKNOWN_0]], %[[UNKNOWN_1]] : !om.integer
+    %add = om.integer.add %const_42, %const_43 : !om.integer
+
+    om.class.fields %add : !om.integer
+  }
+}


### PR DESCRIPTION
Add an aggressive reduction that replaces all OM ops with unknown value
ops.  I was doing this manually in reductions related to #10264 and
realized that this would be a simple, but effective reduction to add.

Assisted-by: OpenCode:Qwen3.5-9B
