### PR TITLE
[FIRRTL] Name Sanitizer: hierpath, symbol users

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -1828,17 +1828,35 @@ struct ModuleNameSanitizer : OpReduction<firrtl::CircuitOp> {
 
   LogicalResult rewrite(firrtl::CircuitOp circuitOp) override {
 
+    // Analyses used to aid the rewrite.
     firrtl::InstanceGraph iGraph(circuitOp);
+    NLATable nlaTable(circuitOp);
+    SymbolTable symTable(circuitOp);
 
+    // Rename symbols and NLAs.
+    auto renameModule = [&](firrtl::FModuleLike mod,
+                            StringAttr newName) -> LogicalResult {
+      StringAttr oldName = mod.getModuleNameAttr();
+      if (failed(symTable.rename(mod, newName)))
+        return failure();
+      nlaTable.renameModule(oldName, newName);
+      return success();
+    };
+
+    // Set the circuit name.  This is the top-level module and the name on the
+    // circuit.  The circuit name is a string so it requires an extra step.
+    auto *ctx = circuitOp.getContext();
     auto *circuitName = nameGenerator.getNextName();
-    iGraph.getTopLevelModule().setName(circuitName);
+    auto newTopName = StringAttr::get(ctx, circuitName);
+    if (failed(renameModule(iGraph.getTopLevelModule(), newTopName)))
+      return failure();
     circuitOp.setName(circuitName);
 
     for (auto *node : iGraph) {
       auto module = node->getModule<firrtl::FModuleLike>();
 
       bool shouldReplacePorts = false;
-      SmallVector<Attribute> newNames;
+      SmallVector<Attribute> newPortNames;
       if (auto fmodule = dyn_cast<firrtl::FModuleOp>(*module)) {
         portNameIndex = 0;
         // TODO: The namespace should be unnecessary. However, some FIRRTL
@@ -1858,32 +1876,33 @@ struct ModuleNameSanitizer : OpReduction<firrtl::CircuitOp> {
                              .Default([&](auto a) {
                                return ns.newName(Twine(getPortName()));
                              });
-          newNames.push_back(StringAttr::get(circuitOp.getContext(), newName));
+          newPortNames.push_back(StringAttr::get(ctx, newName));
         }
         fmodule->setAttr("portNames",
-                         ArrayAttr::get(fmodule.getContext(), newNames));
+                         ArrayAttr::get(fmodule.getContext(), newPortNames));
       }
 
       if (module == iGraph.getTopLevelModule())
         continue;
-      auto newName =
-          StringAttr::get(circuitOp.getContext(), nameGenerator.getNextName());
-      module.setName(newName);
+      auto newName = StringAttr::get(ctx, nameGenerator.getNextName());
+      if (failed(renameModule(module, newName)))
+        return failure();
       for (auto *use : node->uses()) {
         auto useOp = use->getInstance();
         if (auto instanceOp = dyn_cast<firrtl::InstanceOp>(*useOp)) {
-          instanceOp.setModuleName(newName);
+          // SymbolTable::rename already updated the moduleName
+          // FlatSymbolRefAttr on all InstanceOps.  Only the debug instance name
+          // and port names need manual fixup here.
           instanceOp.setName(newName);
           if (shouldReplacePorts)
-            instanceOp.setPortNamesAttr(
-                ArrayAttr::get(circuitOp.getContext(), newNames));
+            instanceOp.setPortNamesAttr(ArrayAttr::get(ctx, newPortNames));
         } else if (auto objectOp = dyn_cast<firrtl::ObjectOp>(*useOp)) {
-          // ObjectOp stores the class name in its result type, so we need to
-          // create a new ClassType with the new name and set it on the result.
+          // ObjectOp stores the class name in its result type.  Result types
+          // are not updated by SymbolTable::rename (AttrTypeReplacer is called
+          // with replaceTypes=false), so we must patch the ClassType manually.
           auto oldClassType = objectOp.getType();
           auto newClassType = firrtl::ClassType::get(
-              circuitOp.getContext(), FlatSymbolRefAttr::get(newName),
-              oldClassType.getElements());
+              ctx, FlatSymbolRefAttr::get(newName), oldClassType.getElements());
           objectOp.getResult().setType(newClassType);
           objectOp.setName(newName);
         }

--- a/test/circt-reduce/name-sanitizer.mlir
+++ b/test/circt-reduce/name-sanitizer.mlir
@@ -1,12 +1,20 @@
 // UNSUPPORTED: system-windows
 // RUN: circt-reduce %s --include=module-internal-name-sanitizer --include=module-name-sanitizer --test /usr/bin/env --test-arg true --keep-best=0 | FileCheck %s
 
-// Test that module-name-sanitizer reduction works with both InstanceOp and ObjectOp.
-// This should not crash when the ModuleNameSanitizer tries to rename modules
-// that are instantiated via firrtl.object operations.
+// Test that module-name-sanitizer correctly renames modules, updates all
+// SymbolRefAttr users (including sv.verbatim $symbols), and updates
+// hw.hierpath namepath entries (which use InnerRefAttr, not SymbolRefAttr).
 
 // CHECK-LABEL: firrtl.circuit "Foo"
 firrtl.circuit "A" {
+  // hw.hierpath namepath entries use InnerRefAttr, not SymbolRefAttr, so they
+  // require the NLATable rename step rather than SymbolTable::rename.
+  // CHECK: hw.hierpath private @nla [@Foo::@sym_b, @Bar]
+  hw.hierpath private @nla [@A::@sym_b, @B]
+  // sv.verbatim $symbols entries use FlatSymbolRefAttr, so they are updated
+  // by SymbolTable::rename.
+  // CHECK: sv.verbatim "// ref: {{[{][{]0[}][}]}}" {symbols = [@Bar]}
+  sv.verbatim "// ref: {{0}}" {symbols = [@B]}
   // CHECK-NEXT: firrtl.module private @Bar
   // CHECK-SAME:   in %clk: !firrtl.clock
   // CHECK-SAME:   in %clk_0: !firrtl.clock
@@ -57,7 +65,7 @@ firrtl.circuit "A" {
     %baz = firrtl.node %bar : !firrtl.uint<1>
     %qux = firrtl.node %baz : !firrtl.uint<1>
     %b_clock, %b_clock2, %b_reset, %b_reset2,  %b_someProbe, %b_someOtherProbe,
-      %b_x, %b_y = firrtl.instance b @B(
+      %b_x, %b_y = firrtl.instance b sym @sym_b @B(
         in clock: !firrtl.clock,
         in clock2: !firrtl.clock,
         in reset: !firrtl.reset,


### PR DESCRIPTION
Fix a bug where FIRRTL's `ModuleNameSanitizer` reduction would rename
modules and instances, but not other symbol users: hierarchical path ops
and generic other symbol users.  Fix this by doing NLA renames and generic
symbol table renames.  Unfortunately, both of these are needed due to how
inner ref attrs work.

This greatly improves the effectiveness of this pass as it will error out
less frequently than before.  Specifically, it will now work on circuits
which have `hw.hierpath` ops which show up frequently in Chisel-generated
FIRRTL.

Assisted-by: OpenCode:claude-sonnet-4-6
