### PR TITLE
[FIRRTL] Name sanitizer collions, idempotency

### DIFF
--- a/include/circt/Reduce/ReductionUtils.h
+++ b/include/circt/Reduce/ReductionUtils.h
@@ -11,6 +11,7 @@
 
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Support/LLVM.h"
+#include "circt/Support/Namespace.h"
 
 namespace circt {
 // Forward declarations.
@@ -38,6 +39,21 @@ public:
 
   /// Get the next metasyntactic name in the sequence.
   const char *getNextName();
+
+  /// Get the next metasyntactic name that is not already reserved in \p ns,
+  /// and reserve it.  If the candidate name is already taken, \p ns appends a
+  /// numeric suffix (e.g. "Foo_0") to make it unique.
+  StringRef getNextName(Namespace &ns);
+
+  /// Return true if \p name already has a metasyntactic prefix, i.e. the
+  /// substring before the first '_' (or the whole string if there is no '_')
+  /// is one of the names in the generator sequence.  Examples:
+  ///   isMetasyntacticName("Foo")       → true
+  ///   isMetasyntacticName("Foo_0")     → true
+  ///   isMetasyntacticName("Foo_0_0_0") → true
+  ///   isMetasyntacticName("FooBar")    → false
+  ///   isMetasyntacticName("MyModule")  → false
+  static bool isMetasyntacticName(StringRef name);
 
   /// Reset the generator to start from the beginning of the sequence.
   void reset() { index = 0; }

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/LayerSet.h"
 #include "circt/Dialect/FIRRTL/NLATable.h"
+#include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/HW/InnerSymbolTable.h"
@@ -1832,6 +1833,7 @@ struct ModuleNameSanitizer : OpReduction<firrtl::CircuitOp> {
     firrtl::InstanceGraph iGraph(circuitOp);
     NLATable nlaTable(circuitOp);
     SymbolTable symTable(circuitOp);
+    CircuitNamespace ns(circuitOp);
 
     // Rename symbols and NLAs.
     auto renameModule = [&](firrtl::FModuleLike mod,
@@ -1843,18 +1845,10 @@ struct ModuleNameSanitizer : OpReduction<firrtl::CircuitOp> {
       return success();
     };
 
-    // Build a namespace seeded with every symbol currently in the circuit so
-    // that generated names are guaranteed to be collision-free.
-    auto *ctx = circuitOp.getContext();
-    circt::Namespace ns;
-    for (auto &op : *circuitOp.getBodyBlock())
-      if (auto sym =
-              op.getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
-        ns.add(sym.getValue());
-
     // Set the top-modulefirst so that the circuit gets the first metasyntactic
     // name, i.e., "Foo".
     auto topModule = iGraph.getTopLevelModule();
+    auto *ctx = circuitOp.getContext();
     if (!reduce::MetasyntacticNameGenerator::isMetasyntacticName(
             topModule.getModuleName())) {
       auto newTopName = StringAttr::get(ctx, nameGenerator.getNextName(ns));

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -1843,14 +1843,25 @@ struct ModuleNameSanitizer : OpReduction<firrtl::CircuitOp> {
       return success();
     };
 
-    // Set the circuit name.  This is the top-level module and the name on the
-    // circuit.  The circuit name is a string so it requires an extra step.
+    // Build a namespace seeded with every symbol currently in the circuit so
+    // that generated names are guaranteed to be collision-free.
     auto *ctx = circuitOp.getContext();
-    auto *circuitName = nameGenerator.getNextName();
-    auto newTopName = StringAttr::get(ctx, circuitName);
-    if (failed(renameModule(iGraph.getTopLevelModule(), newTopName)))
-      return failure();
-    circuitOp.setName(circuitName);
+    circt::Namespace ns;
+    for (auto &op : *circuitOp.getBodyBlock())
+      if (auto sym =
+              op.getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
+        ns.add(sym.getValue());
+
+    // Set the top-modulefirst so that the circuit gets the first metasyntactic
+    // name, i.e., "Foo".
+    auto topModule = iGraph.getTopLevelModule();
+    if (!reduce::MetasyntacticNameGenerator::isMetasyntacticName(
+            topModule.getModuleName())) {
+      auto newTopName = StringAttr::get(ctx, nameGenerator.getNextName(ns));
+      if (failed(renameModule(topModule, newTopName)))
+        return failure();
+      circuitOp.setName(newTopName.getValue());
+    }
 
     for (auto *node : iGraph) {
       auto module = node->getModule<firrtl::FModuleLike>();
@@ -1884,7 +1895,11 @@ struct ModuleNameSanitizer : OpReduction<firrtl::CircuitOp> {
 
       if (module == iGraph.getTopLevelModule())
         continue;
-      auto newName = StringAttr::get(ctx, nameGenerator.getNextName());
+      // Skip renaming if the module already has a metasyntactic name.
+      if (reduce::MetasyntacticNameGenerator::isMetasyntacticName(
+              module.getModuleName()))
+        continue;
+      auto newName = StringAttr::get(ctx, nameGenerator.getNextName(ns));
       if (failed(renameModule(module, newName)))
         return failure();
       for (auto *use : node->uses()) {

--- a/lib/Reduce/ReductionUtils.cpp
+++ b/lib/Reduce/ReductionUtils.cpp
@@ -25,6 +25,22 @@ const char *MetasyntacticNameGenerator::getNextName() {
   return names[index++];
 }
 
+StringRef MetasyntacticNameGenerator::getNextName(Namespace &ns) {
+  return ns.newName(getNextName());
+}
+
+bool MetasyntacticNameGenerator::isMetasyntacticName(StringRef name) {
+  // Build a set of all metasyntactic names on first use.
+  static const llvm::StringSet<> nameSet = [] {
+    llvm::StringSet<> s;
+    for (auto *n : names)
+      s.insert(n);
+    return s;
+  }();
+  // The prefix is everything before the first '_', or the whole name.
+  return nameSet.contains(name.split('_').first);
+}
+
 //===----------------------------------------------------------------------===//
 // Utilities
 //===----------------------------------------------------------------------===//

--- a/test/circt-reduce/name-sanitizer-collision.mlir
+++ b/test/circt-reduce/name-sanitizer-collision.mlir
@@ -1,0 +1,17 @@
+// UNSUPPORTED: system-windows
+// RUN: circt-reduce %s --include=module-name-sanitizer --test /usr/bin/env --test-arg true --keep-best=0 | FileCheck %s
+
+// Test that a metasyntactic name collision doesn't result in a symbol collision
+// error.  Run this test separately to avoid collisions with other circuits as
+// we don't have a `-split-input-file` option to `circt-reduce`.
+
+// CHECK-LABEL: firrtl.circuit "Foo_0"
+// CHECK:       firrtl.module @Foo_0()
+// CHECK:       firrtl.extmodule @Qux()
+// CHECK:       firrtl.extmodule @Foo()
+firrtl.circuit "A" {
+  firrtl.module @A() {
+  }
+  firrtl.extmodule @Qux()
+  firrtl.extmodule @Foo()
+}

--- a/test/circt-reduce/name-sanitizer.mlir
+++ b/test/circt-reduce/name-sanitizer.mlir
@@ -102,16 +102,3 @@ firrtl.circuit "Foo" {
   firrtl.module private @Bar() {}
   firrtl.module private @Baz() {}
 }
-
-
-// Test that symbol collisions are properly handled as opposed to causing a
-// crash.
-//
-// CHECK-LABEL: firrtl.circuit "Foo"
-firrtl.circuit "Foo" {
-  // CHECK-NEXT: firrtl.module @Qux_0
-  firrtl.module @A() {
-  }
-  firrtl.extmodule @Qux()
-  firrtl.extmodule @Foo()
-}

--- a/test/circt-reduce/name-sanitizer.mlir
+++ b/test/circt-reduce/name-sanitizer.mlir
@@ -4,6 +4,8 @@
 // Test that module-name-sanitizer correctly renames modules, updates all
 // SymbolRefAttr users (including sv.verbatim $symbols), and updates
 // hw.hierpath namepath entries (which use InnerRefAttr, not SymbolRefAttr).
+// Also tests that modules already carrying a metasyntactic name prefix are
+// left unchanged (idempotency).
 
 // CHECK-LABEL: firrtl.circuit "Foo"
 firrtl.circuit "A" {
@@ -81,4 +83,35 @@ firrtl.circuit "A" {
   // CHECK: firrtl.class @Baz() {
   firrtl.class @MyClass() {
   }
+}
+
+// Test reduction idempotency.  Modules that have already been renamed, should
+// not be renamed again.  The reduction is one-shot, so it should not run more
+// than once.  However, if a user runs it manually more than once, this should
+// do something sane.
+//
+// CHECK-LABEL: firrtl.circuit "Foo"
+// CHECK:       firrtl.module @Foo()
+// CHECK:       firrtl.module private @Bar()
+// CHECK:       firrtl.module private @Baz()
+firrtl.circuit "Foo" {
+  firrtl.module @Foo() {
+    firrtl.instance bar @Bar()
+    firrtl.instance baz @Baz()
+  }
+  firrtl.module private @Bar() {}
+  firrtl.module private @Baz() {}
+}
+
+
+// Test that symbol collisions are properly handled as opposed to causing a
+// crash.
+//
+// CHECK-LABEL: firrtl.circuit "Foo"
+firrtl.circuit "Foo" {
+  // CHECK-NEXT: firrtl.module @Qux_0
+  firrtl.module @A() {
+  }
+  firrtl.extmodule @Qux()
+  firrtl.extmodule @Foo()
 }


### PR DESCRIPTION
Fix two bugs in the module name sanitizer that could arise if you run this
more than once on a circuit:

1. Symbol names were being blindly set.  Run these through a namespace to
   avoid collisions.
2. Fixes to (1) could make the pass non-idempotent.  Change this so that
   names which already have metasyntactic prefixes are not renamed again.

These bugs were generally unreachable as this sanitizer runs very late and
is one-shot.  I.e., users would have only hit this if they were manually
running a reduction after running another reduction.

Assisted-by: OpenCode:claude-sonnet-4-6
