### PR TITLE
[Synth] Add StaticInterface for CNF construction, NFC

### DIFF
--- a/include/circt/Dialect/Synth/SynthOpInterfaces.td
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.td
@@ -122,16 +122,40 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
       }],
       "std::optional<uint64_t>", "getLogicAreaCost", (ins)
     >,
-    InterfaceMethod<[{
-        Emit CNF clauses encoding `outVar <=> op(inputVars...)`.
-        The provided `inputVars` correspond to this operation's operands in
-        operand order. Implementations are responsible for applying any
-        per-input inversion described by the operation itself.
+    StaticInterfaceMethod<[{
+        Emit CNF clauses encoding `outVar <=> op(inputVars...)` for the
+        non-inverted form of the operation. The provided `inputVars` are SAT
+        literals corresponding to the logical operands in operand order, after
+        any per-input inversion has already been materialized by the caller.
       }],
-      "void", "emitCNF",
+      "void", "emitCNFWithoutInversion",
       (ins "int":$outVar, "::llvm::ArrayRef<int>":$inputVars,
            "::llvm::function_ref<void(::llvm::ArrayRef<int>)>":$addClause,
            "::llvm::function_ref<int()>":$newVar)
+    >,
+    InterfaceMethod<[{
+        Emit CNF clauses encoding `outVar <=> op(inputVars...)`.
+        The provided `inputVars` correspond to this operation's operands in
+        operand order. The default implementation materializes the per-input
+        inversion flags into the SAT literals and then delegates to
+        `emitCNFWithoutInversion`.
+      }],
+      "void", "emitCNF",
+      (ins "int":$outVar, "::llvm::ArrayRef<int>":$inputVars,
+            "::llvm::function_ref<void(::llvm::ArrayRef<int>)>":$addClause,
+            "::llvm::function_ref<int()>":$newVar),
+      "",
+      [{
+        ::llvm::SmallVector<int> inputLits;
+        inputLits.reserve(inputVars.size());
+        auto inverted = $_op.getInverted();
+        assert(inverted.size() == inputVars.size() &&
+              "inputVars should have the same size as the number of inputs");
+        for (auto [inverted, inputVar] : llvm::zip(inverted, inputVars))
+          inputLits.push_back(inverted ? -inputVar : inputVar);
+        return ConcreteOp::emitCNFWithoutInversion(outVar, inputLits, addClause,
+                                                   newVar);
+      }]
     >,
     InterfaceMethod<[{
         Clone or fold this operation with the provided inputs while preserving

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -30,7 +30,7 @@ class InvertibleOperandsOp<string mnemonic, list<Trait> traits = []>
       SameOperandsAndResultType, Pure,
       DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
         "areInputsPermutationInvariant", "getLogicDepthCost",
-        "getLogicAreaCost", "emitCNF"
+        "getLogicAreaCost"
       ]> ] # traits> {
   // TODO: Restrict to HWIntegerType.
   let arguments = (ins Variadic<AnyType>:$inputs,

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -47,11 +47,6 @@ inline llvm::KnownBits applyInversion(llvm::KnownBits value, bool inverted) {
   return value;
 }
 
-inline int applyInversion(int lit, bool inverted) {
-  assert(lit != 0 && "expected non-zero SAT literal");
-  return inverted ? -lit : lit;
-}
-
 } // namespace
 
 LogicalResult ChoiceOp::verify() {
@@ -273,19 +268,12 @@ std::optional<uint64_t> AndInverterOp::getLogicAreaCost() {
   return static_cast<uint64_t>(getNumOperands() - 1) * bitWidth;
 }
 
-void AndInverterOp::emitCNF(
+void AndInverterOp::emitCNFWithoutInversion(
     int outVar, llvm::ArrayRef<int> inputVars,
     llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
     llvm::function_ref<int()> newVar) {
   (void)newVar;
-  assert(inputVars.size() == getInputs().size() &&
-         "expected one SAT variable per operand");
-
-  SmallVector<int> inputLits;
-  inputLits.reserve(inputVars.size());
-  for (auto [inputVar, inverted] : llvm::zip(inputVars, getInverted()))
-    inputLits.push_back(applyInversion(inputVar, inverted));
-  circt::addAndClauses(outVar, inputLits, addClause);
+  circt::addAndClauses(outVar, inputVars, addClause);
 }
 
 //===----------------------------------------------------------------------===//
@@ -324,18 +312,11 @@ std::optional<uint64_t> XorInverterOp::getLogicAreaCost() {
   return static_cast<uint64_t>(getNumOperands() - 1) * bitWidth;
 }
 
-void XorInverterOp::emitCNF(
+void XorInverterOp::emitCNFWithoutInversion(
     int outVar, llvm::ArrayRef<int> inputVars,
     llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
     llvm::function_ref<int()> newVar) {
-  assert(inputVars.size() == getInputs().size() &&
-         "expected one SAT variable per operand");
-
-  SmallVector<int> inputLits;
-  inputLits.reserve(inputVars.size());
-  for (auto [inputVar, inverted] : llvm::zip(inputVars, getInverted()))
-    inputLits.push_back(applyInversion(inputVar, inverted));
-  circt::addParityClauses(outVar, inputLits, addClause, newVar);
+  circt::addParityClauses(outVar, inputVars, addClause, newVar);
 }
 
 static Value lowerVariadicInvertibleOp(


### PR DESCRIPTION
Add a static interface method for CNF construction without inversion to simplify concrete op implementation. NFC
Assisted-by: copilot: gpt-5.4
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
