### PR TITLE
[Synth] Add dot gate

### DIFF
--- a/include/circt/Dialect/Synth/SynthOpInterfaces.td
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.td
@@ -32,7 +32,7 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
       }],
       "::mlir::ValueRange", "getInputs", (ins), "",
       [{
-        return $_op.getInputs();
+        return $_op.getOperands();
       }]
     >,
     InterfaceMethod<[{

--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -128,6 +128,12 @@ T buildBalancedTreeWithArrivalTimes(llvm::ArrayRef<T> elements,
   return pq.top();
 }
 
+/// Evaluate the Boolean function `x ^ (z | (x & y))`.
+template <typename T>
+T evaluateDotLogic(const T &x, const T &y, const T &z) {
+  return x ^ (z | (x & y));
+}
+
 } // namespace synth
 } // namespace circt
 

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -120,6 +120,59 @@ def XorInverterOp : InvertibleOperandsOp<"xor_inv"> {
 
 }
 
+def DotOp : SynthOp<"dot", [
+    SameOperandsAndResultType, Pure,
+    DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
+      "getLogicAreaCost"
+    ]>
+  ]> {
+  let summary = "Ordered 3-input DOT gate with invertible inputs";
+  let description = [{
+    The `synth.dot` operation represents the ordered three-input Boolean
+    function `x xor (z or (x and y))`, applied after optional per-input
+    inversion.
+
+    Unlike common AND, OR, XOR, and majority gates, `synth.dot` is not
+    permutation-invariant: its operands play distinct roles in the Boolean
+    expression. Dot gates are known to be a promising intermediate
+    representation for area optimization, as discussed in "Three-Input Gates
+    for Logic Synthesis" (Dewmini Sudara Marakkalage et al., TCAD 2021).
+
+    Example:
+    ```mlir
+      %r0 = synth.dot %x, %y, %z : i1
+      %r1 = synth.dot not %x, %y, not %z : i8
+    ```
+  }];
+
+  let arguments = (ins AnyType:$x, AnyType:$y, AnyType:$z,
+                       DenseBoolArrayAttr:$inverted);
+  let results = (outs AnyType:$result);
+
+  let builders = [
+    OpBuilder<(ins "Value":$x, "Value":$y, "Value":$z,
+                                CArg<"bool", "false">:$invertX,
+                                CArg<"bool", "false">:$invertY,
+                                CArg<"bool", "false">:$invertZ), [{
+      SmallVector<bool> inverted{invertX, invertY, invertZ};
+      return build($_builder, $_state, x.getType(), x, y, z,
+                   $_builder.getDenseBoolArrayAttr(inverted));
+    }]>,
+    OpBuilder<(ins "ValueRange":$inputs, "ArrayRef<bool>":$inverted), [{
+      assert(inputs.size() == 3 && "dot expects exactly three operands");
+      assert(inverted.size() == 3 && "dot expects exactly three inversion flags");
+      return build($_builder, $_state, inputs[0].getType(), inputs[0], inputs[1],
+                   inputs[2], $_builder.getDenseBoolArrayAttr(inverted));
+    }]>,
+    OpBuilder<(ins "Type":$resultType, "ValueRange":$inputs,
+                                "ArrayRef<bool>":$inverted), [{
+      return build($_builder, $_state, inputs, inverted);
+    }]>];
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
 def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
   let summary = "Synth choice operation";
   let description = [{

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -119,7 +119,8 @@ struct LogicNetworkGate {
     Xor2 = 3,         ///< XOR gate (2-input)
     Maj3 = 4,         ///< Reserved 3-input gate kind
     Identity = 5,     ///< Identity gate (used for 1-input inverter)
-    Choice = 6        ///< Choice node (synth.choice)
+    Choice = 6,       ///< Choice node (synth.choice)
+    Dot3 = 7          ///< Ordered DOT gate (3-input, synth.dot)
   };
 
   /// Operation pointer and kind packed together.
@@ -156,6 +157,7 @@ struct LogicNetworkGate {
     case Xor2:
       return 2;
     case Maj3:
+    case Dot3:
       return 3;
     case Identity:
       return 1;
@@ -168,7 +170,8 @@ struct LogicNetworkGate {
   /// Check if this is a logic gate that can be part of a cut.
   bool isLogicGate() const {
     Kind k = getKind();
-    return k == And2 || k == Xor2 || k == Maj3 || k == Identity || k == Choice;
+    return k == And2 || k == Xor2 || k == Maj3 || k == Identity ||
+           k == Choice || k == Dot3;
   }
 
   /// Check if this should always be a cut input (PI or constant).

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -78,3 +78,17 @@ hw.module @functional_reduction_xor_inv_sat(in %a: i1, in %b: i1,
   %4 = synth.aig.and_inv not %3 : i1
   hw.output %0, %4 : i1, i1
 }
+
+// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 test_dot --c2 test_dot | FileCheck %s --check-prefix=DOT
+// DOT: c1 == c2
+// CHECK-LABEL: hw.module @test_dot
+hw.module @test_dot(in %a: i1, in %b: i1, in %c: i1,
+                                    out out0: i1, out out1: i1) {
+  // CHECK: %[[CHOICE:.+]] = synth.choice
+  // CHECK: hw.output %[[CHOICE]], %[[CHOICE]] : i1, i1
+  %0 = synth.aig.and_inv not %a, %b : i1 // !a & b
+  %1 = synth.aig.and_inv %c, not %0 : i1 // !(!a & b) & c
+  %2 = synth.xor_inv not %a, not %1 : i1 // !a ^ !(!(!a & b) & c) = !a ^ ((!a) & b || !c) = dot(!a, b, !c)
+  %3 = synth.dot not %a, %b, not %c : i1
+  hw.output %2, %3 : i1, i1
+}

--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -70,7 +70,7 @@ struct SynthInverterOpConversion : OpConversionPattern<SynthOp> {
     operands.reserve(op.getNumOperands());
     hw::ConstantOp allOnes;
     for (auto [input, inverted] :
-         llvm::zip(adaptor.getInputs(), op.getInverted()))
+         llvm::zip(adaptor.getOperands(), op.getInverted()))
       operands.push_back(materializeInvertedInput(op.getLoc(), input, inverted,
                                                   rewriter, allOnes));
     // `createOp` now only needs to encode the core boolean operator.
@@ -99,6 +99,18 @@ struct SynthXorInverterOpConversion
   }
 };
 
+struct SynthDotOpConversion : SynthInverterOpConversion<synth::DotOp> {
+  using SynthInverterOpConversion<synth::DotOp>::SynthInverterOpConversion;
+  Value createOp(Location loc, ArrayRef<Value> inputs,
+                 ConversionPatternRewriter &rewriter) const override {
+    assert(inputs.size() == 3 && "expected exactly three inputs");
+    auto xy =
+        rewriter.createOrFold<comb::AndOp>(loc, inputs[0], inputs[1], true);
+    auto zOrXy = rewriter.createOrFold<comb::OrOp>(loc, inputs[2], xy, true);
+    return rewriter.createOrFold<comb::XorOp>(loc, inputs[0], zOrXy, true);
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -116,7 +128,8 @@ struct ConvertSynthToCombPass
 
 static void populateSynthToCombConversionPatterns(RewritePatternSet &patterns) {
   patterns.add<SynthChoiceOpConversion, SynthAndInverterOpConversion,
-               SynthXorInverterOpConversion>(patterns.getContext());
+               SynthXorInverterOpConversion, SynthDotOpConversion>(
+      patterns.getContext());
 }
 
 void ConvertSynthToCombPass::runOnOperation() {

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -319,6 +319,82 @@ void XorInverterOp::emitCNFWithoutInversion(
   circt::addParityClauses(outVar, inputVars, addClause, newVar);
 }
 
+//===----------------------------------------------------------------------===//
+// DotOp
+//===----------------------------------------------------------------------===//
+
+ParseResult DotOp::parse(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand> operands;
+  Type resultType;
+  DenseBoolArrayAttr inverted;
+  NamedAttrList attrs;
+
+  if (parseVariadicInvertibleOperands(parser, operands, resultType, inverted,
+                                      attrs))
+    return failure();
+  if (operands.size() != 3)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected exactly three operands";
+  if (parser.resolveOperands(operands, resultType, result.operands))
+    return failure();
+
+  result.addTypes(resultType);
+  result.addAttributes(attrs);
+  result.addAttribute("inverted", inverted);
+  return success();
+}
+
+void DotOp::print(OpAsmPrinter &printer) {
+  printer << ' ';
+  printVariadicInvertibleOperands(printer, getOperation(), getOperands(),
+                                  getType(), getInvertedAttr(),
+                                  (*this)->getAttrDictionary());
+}
+
+LogicalResult DotOp::verify() {
+  if (getInverted().size() != 3)
+    return emitOpError("requires exactly three inversion flags");
+  return success();
+}
+
+APInt DotOp::evaluateBooleanLogic(
+    llvm::function_ref<const APInt &(unsigned)> getInputValue) {
+  APInt x = applyInversion(getInputValue(0), isInverted(0));
+  APInt y = applyInversion(getInputValue(1), isInverted(1));
+  APInt z = applyInversion(getInputValue(2), isInverted(2));
+  return evaluateDotLogic(x, y, z);
+}
+
+llvm::KnownBits DotOp::computeKnownBits(
+    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
+  auto x = applyInversion(getInputKnownBits(0), isInverted(0));
+  auto y = applyInversion(getInputKnownBits(1), isInverted(1));
+  auto z = applyInversion(getInputKnownBits(2), isInverted(2));
+  return evaluateDotLogic(x, y, z);
+}
+
+std::optional<uint64_t> DotOp::getLogicAreaCost() {
+  int64_t bitWidth = hw::getBitWidth(getType());
+  if (bitWidth < 0)
+    return std::nullopt;
+  return static_cast<uint64_t>(bitWidth);
+}
+
+void DotOp::emitCNFWithoutInversion(
+    int outVar, llvm::ArrayRef<int> inputVars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  assert(inputVars.size() == 3 && "expected one SAT variable per operand");
+  int andVar = newVar();
+  int orVar = newVar();
+  // andVar = x and y
+  circt::addAndClauses(andVar, {inputVars[0], inputVars[1]}, addClause);
+  // orVar = z or andVar
+  circt::addOrClauses(orVar, {inputVars[2], andVar}, addClause);
+  // outVar = x xor orVar
+  circt::addXorClauses(outVar, inputVars[0], orVar, addClause);
+}
+
 static Value lowerVariadicInvertibleOp(
     Location loc, ValueRange operands, ArrayRef<bool> inverts,
     PatternRewriter &rewriter,

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -183,6 +183,18 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
             .Case<synth::XorInverterOp>([&](synth::XorInverterOp xorOp) {
               return handleInvertibleBinaryGate(xorOp, LogicNetworkGate::Xor2);
             })
+            .Case<synth::DotOp>([&](synth::DotOp dotOp) {
+              if (!dotOp.getType().isInteger(1)) {
+                handleOtherResults(dotOp);
+                return success();
+              }
+              const Signal xSignal = getInvertibleSignal(dotOp, 0);
+              const Signal ySignal = getInvertibleSignal(dotOp, 1);
+              const Signal zSignal = getInvertibleSignal(dotOp, 2);
+              addGate(dotOp, LogicNetworkGate::Dot3,
+                      {xSignal, ySignal, zSignal});
+              return success();
+            })
             .Case<comb::XorOp>([&](comb::XorOp xorOp) {
               if (xorOp->getNumOperands() != 2) {
                 handleOtherResults(xorOp);
@@ -265,9 +277,10 @@ LogicalResult circt::synth::topologicallySortLogicNetwork(Operation *topOp) {
   const auto isOperationReady = [](Value value, Operation *op) -> bool {
     // Topologically sort AIG ops and dataflow ops. Other operations
     // can be scheduled.
-    return !(isa<aig::AndInverterOp, synth::XorInverterOp, synth::ChoiceOp,
-                 comb::XorOp, comb::AndOp, comb::OrOp, comb::ExtractOp,
-                 comb::ReplicateOp, comb::ConcatOp>(op));
+    return !(
+        isa<BooleanLogicOpInterface, synth::ChoiceOp, comb::XorOp, comb::AndOp,
+            comb::OrOp, comb::ExtractOp, comb::ReplicateOp, comb::ConcatOp>(
+            op));
   };
 
   if (failed(topologicallySortGraphRegionBlocks(topOp, isOperationReady)))
@@ -487,6 +500,8 @@ static inline llvm::APInt applyGateSemantics(LogicNetworkGate::Kind kind,
   switch (kind) {
   case LogicNetworkGate::Maj3:
     return (a & b) | (a & c) | (b & c);
+  case LogicNetworkGate::Dot3:
+    return evaluateDotLogic(a, b, c);
   default:
     llvm_unreachable(
         "Unsupported ternary operation for truth table computation");
@@ -585,6 +600,7 @@ struct MergedTruthTableBuilder {
           numMergedInputs, 1,
           applyGateSemantics(rootGate.getKind(), getEdgeTT(0), getEdgeTT(1)));
     case LogicNetworkGate::Maj3:
+    case LogicNetworkGate::Dot3:
       return BinaryTruthTable(numMergedInputs, 1,
                               applyGateSemantics(rootGate.getKind(),
                                                  getEdgeTT(0), getEdgeTT(1),

--- a/test/Conversion/SynthToComb/synth-to-comb.mlir
+++ b/test/Conversion/SynthToComb/synth-to-comb.mlir
@@ -26,3 +26,14 @@ hw.module @test_xor_inv(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
   %0 = synth.xor_inv %a, not %b, %c : i8
   hw.output %0 : i8
 }
+
+// CHECK-LABEL: @test_dot
+hw.module @test_dot(in %x: i8, in %y: i8, in %z: i8, out out0: i8) {
+  // CHECK: %c-1_i8 = hw.constant -1 : i8
+  // CHECK: %[[NOT_X:.+]] = comb.xor bin %x, %c-1_i8 : i8
+  // CHECK: %[[XY:.+]] = comb.and bin %[[NOT_X]], %y : i8
+  // CHECK: %[[OR:.+]] = comb.or bin %z, %[[XY]] : i8
+  // CHECK: %[[RESULT:.+]] = comb.xor bin %[[NOT_X]], %[[OR]] : i8
+  %0 = synth.dot not %x, %y, %z : i8
+  hw.output %0 : i8
+}

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -110,3 +110,14 @@ func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
   %1 = synth.aig.and_inv not %0, not %0 : i2
   return %1 : i2
 }
+
+// CHECK-LABEL: hw.module @Other
+// Other operation with BooleanLogicOpInterface
+// Only check that they are lowered.
+hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2) {
+  %0 = synth.xor_inv %a, not %b, %c : i2
+  %1 = synth.dot %a, not %b,  %c : i2
+  // CHECK-COUNT-2: synth.xor_inv %{{.+}}, not %{{.+}}, %{{.+}} : i1
+  // CHECK-COUNT-2: synth.dot %{{.+}}, not %{{.+}}, %{{.+}} : i1
+  hw.output %0, %1 : i2, i2
+}

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -24,3 +24,9 @@ hw.module @xor_inv(in %a: i4, in %b: i4, in %c: i4, in %d: i1) {
   %0 = synth.xor_inv %a, not %b, %c : i4
   %1 = synth.xor_inv not %d : i1
 }
+
+// CHECK-LABEL: @dot
+// CHECK-NEXT: %[[R0:.+]] = synth.dot %x, not %y, %z : i1
+hw.module @dot(in %x: i1, in %y: i1, in %z: i1) {
+  %0 = synth.dot %x, not %y, %z : i1
+}

--- a/test/Dialect/Synth/structural_hash.mlir
+++ b/test/Dialect/Synth/structural_hash.mlir
@@ -61,3 +61,16 @@ hw.module @xor_inv_hash(in %a: i1, in %b: i1, in %c: i1, out o0: i1, out o1: i1)
   %1 = synth.xor_inv %c, %a, not %b : i1
   hw.output %0, %1 : i1, i1
 }
+
+// CHECK-LABEL: hw.module @dot_ordered
+hw.module @dot_ordered(in %x: i1, in %y: i1, in %z: i1, out o0: i1, out o1: i1, out o2: i1) {
+  // Make sure that the two dot operations are not CSE'd since they have different operand orders.
+  // CHECK: %[[D0:.+]] = synth.dot not %x, %y, %z : i1
+  // CHECK-NEXT: %[[D1:.+]] = synth.dot %y, not %x, %z : i1
+  // CHECK-NEXT: hw.output %[[D0]], %[[D1]], %[[D0]] : i1, i1, i1
+  %0 = synth.dot not %x, %y, %z : i1
+  %1 = synth.dot %y, not %x, %z : i1
+  %notX = synth.aig.and_inv not %x : i1
+  %2 = synth.dot %notX, %y, %z : i1
+  hw.output %0, %1, %2 : i1, i1, i1
+}

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -160,3 +160,17 @@ hw.module @extract_concat_test(in %data : i4, in %ctrl : i2, out result : i3) {
     
     hw.output %result_concat : i3
 }
+
+hw.module @dot_lib(in %x : i1, in %y : i1, in %z : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1], [1]]}} {
+    %0 = synth.dot %z, not %x, not %y : i1
+    hw.output %0 : i1
+}
+
+// CHECK-LABEL: @dot_test
+hw.module @dot_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
+    // Permute inputs to test the truth table computation and input handling of the dot operation.
+    // CHECK-NEXT: %[[DOT:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @dot_lib(x: %z: i1, y: %y: i1, z: %x: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: hw.output %[[DOT]] : i1
+    %0 = synth.dot %x, not %y, not %z : i1
+    hw.output %0 : i1
+}


### PR DESCRIPTION
Add `synth.dot`, an ordered 3-input Boolean logic op implementing `x xor (z or (x and y))` with per-input inversion support. Dot gates are considered to be a promising intermediate representation for area optimization,
as discussed in "Three-Input Gates for Logic Synthesis" (Dewmini Sudara Marakkalage et al., TCAD 2021).

Add a dot operation with a straightforward implementation of the BooleanLogicOpInterface. This operation won't typically be created by the lowering pipeline; instead, it will be generated through cut rewriting based on a database from exact synthesis. I'm hoping to upstream this exact synthesis pass soon (https://gist.github.com/uenoku/bc99755f2b4ada0d454a088c7257b0e4 is the IR of area optimal exact synthesis result for 4-input boolean function).

Assisted-by: codex: gpt-5.4

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
