### PR TITLE
[ImportVerilog] Support single-delay case for n-input prims

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1812,10 +1812,6 @@ LogicalResult Context::convertPrimitiveInstance(
            << "primitive instances with explicit drive strengths are not "
               "supported.";
 
-  if (prim.getDelay())
-    return mlir::emitError(convertLocation(prim.location))
-           << "primitive instances with delays are not yet supported.";
-
   switch (prim.primitiveType.primitiveKind) {
   case slang::ast::PrimitiveSymbol::PrimitiveKind::NInput:
     return this->convertNInputPrimitive(prim);
@@ -1914,7 +1910,21 @@ LogicalResult Context::convertNInputPrimitive(
   if (!result)
     return failure();
 
-  moore::ContinuousAssignOp::create(builder, loc, outputVal, result);
+  if (prim.getDelay()) {
+    auto &delay3 = prim.getDelay()->as<slang::ast::Delay3Control>();
+    if (delay3.expr2 || delay3.expr3)
+      return mlir::emitError(loc) << "only n-input primitives that specify a "
+                                     "single delay are currently supported.";
+    auto delayVal = this->convertRvalueExpression(
+        delay3.expr1, moore::TimeType::get(getContext()));
+    if (!delayVal)
+      return failure();
+    moore::DelayedContinuousAssignOp::create(builder, loc, outputVal, result,
+                                             delayVal);
+  } else {
+    moore::ContinuousAssignOp::create(builder, loc, outputVal, result);
+  }
+
   return success();
 }
 
@@ -1922,6 +1932,11 @@ LogicalResult Context::convertNOutputPrimitive(
     const slang::ast::PrimitiveInstanceSymbol &prim) {
   auto loc = convertLocation(prim.location);
   auto primName = prim.primitiveType.name;
+
+  if (prim.getDelay())
+    return mlir::emitError(convertLocation(prim.location))
+           << "n-output primitive instances with explicit delays are not "
+              "supported.";
 
   auto portConns = prim.getPortConnections();
   assert(portConns.size() >= 2 &&
@@ -1988,6 +2003,7 @@ LogicalResult Context::convertPullGatePrimitive(
   assert((prim.primitiveType.name == "pullup" ||
           prim.primitiveType.name == "pulldown") &&
          "expected pullup or pulldown primitive");
+  // Slang ensures no delays on pull gates so no need to check here
   auto loc = convertLocation(prim.location);
   auto primName = prim.primitiveType.name;
 

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1911,12 +1911,21 @@ LogicalResult Context::convertNInputPrimitive(
     return failure();
 
   if (prim.getDelay()) {
-    auto &delay3 = prim.getDelay()->as<slang::ast::Delay3Control>();
-    if (delay3.expr2 || delay3.expr3)
-      return mlir::emitError(loc) << "only n-input primitives that specify a "
-                                     "single delay are currently supported.";
+    const slang::ast::Expression *delayExpr;
+    if (const auto *delay3 =
+            prim.getDelay()->as_if<slang::ast::Delay3Control>()) {
+      if (delay3->expr2 || delay3->expr3)
+        return mlir::emitError(loc) << "only n-input primitives that specify a "
+                                       "single delay are currently supported.";
+      delayExpr = &delay3->expr1;
+    } else if (const auto *delay =
+                   prim.getDelay()->as_if<slang::ast::DelayControl>()) {
+      delayExpr = &delay->expr;
+    } else {
+      llvm_unreachable("unexpected delay control type in primitive instance");
+    }
     auto delayVal = this->convertRvalueExpression(
-        delay3.expr1, moore::TimeType::get(getContext()));
+        *delayExpr, moore::TimeType::get(getContext()));
     if (!delayVal)
       return failure();
     moore::DelayedContinuousAssignOp::create(builder, loc, outputVal, result,

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1849,7 +1849,7 @@ LogicalResult Context::convertNInputPrimitive(
   SmallVector<Value> inputVals;
   inputVals.reserve(portConns.size() - 1);
   for (const auto *inputConn : portConns.subspan(1, portConns.size() - 1)) {
-    auto inputVal = this->convertRvalueExpression(*inputConn);
+    auto inputVal = convertRvalueExpression(*inputConn);
     if (!inputVal)
       return failure();
     inputVals.push_back(inputVal);
@@ -2012,7 +2012,9 @@ LogicalResult Context::convertPullGatePrimitive(
   assert((prim.primitiveType.name == "pullup" ||
           prim.primitiveType.name == "pulldown") &&
          "expected pullup or pulldown primitive");
-  // Slang ensures no delays on pull gates so no need to check here
+  // Slang should catch this
+  assert(!prim.getDelay() &&
+         "SystemVerilog does not allow pull gate primitives with delays");
   auto loc = convertLocation(prim.location);
   auto primName = prim.primitiveType.name;
 

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -343,10 +343,19 @@ endmodule
 
 // -----
 
-module delay_prim;
+module multi_delay_input_prim;
     logic A, B, Q;
-    // expected-error @below {{primitive instances with delays are not yet supported.}}
-    and #(5) a (Q, A, B);
+    // expected-error @below {{only n-input primitives that specify a single delay are currently supported.}}
+    and #(5, 5) a (Q, A, B);
+endmodule
+
+
+// -----
+
+module noutput_delay_prim;
+    wire A, Q;
+    // expected-error @below {{n-output primitive instances with explicit delays are not supported.}}
+    not #(5) n (Q, A);
 endmodule
 
 // -----

--- a/test/Conversion/ImportVerilog/primitives.sv
+++ b/test/Conversion/ImportVerilog/primitives.sv
@@ -146,8 +146,25 @@ endmodule
 
 module delayed_nand_prim;
     wire A, B, Q;
+    nand #5 a (Q, A, B);
+endmodule
+
+// CHECK-LABEL: moore.module @delayed3_nand_prim()
+// CHECK: [[A:%.+]] = moore.net wire : <l1>
+// CHECK: [[B:%.+]] = moore.net wire : <l1>
+// CHECK: [[Q:%.+]] = moore.net wire : <l1>
+// CHECK: [[RD_A:%.+]] = moore.read [[A]] : <l1>
+// CHECK: [[RD_B:%.+]] = moore.read [[B]] : <l1>
+// CHECK: [[AND:%.+]] = moore.and [[RD_A]], [[RD_B]] : l1
+// CHECK: [[NOT_AND:%.+]] = moore.not [[AND]] : l1
+// CHECK: [[DELAYCONST:%.+]] = moore.constant_time 5000000 fs
+// CHECK: moore.delayed_assign [[Q]], [[NOT_AND]], [[DELAYCONST]] : l1
+
+module delayed3_nand_prim;
+    wire A, B, Q;
     nand #(5) a (Q, A, B);
 endmodule
+
 
 // CHECK-LABEL: moore.module @not_prim()
 // CHECK: [[A:%.+]] = moore.net wire : <l1>

--- a/test/Conversion/ImportVerilog/primitives.sv
+++ b/test/Conversion/ImportVerilog/primitives.sv
@@ -133,6 +133,22 @@ module multi_nand_prim;
     nand a (Q, A, B, C, D);
 endmodule
 
+// CHECK-LABEL: moore.module @delayed_nand_prim()
+// CHECK: [[A:%.+]] = moore.net wire : <l1>
+// CHECK: [[B:%.+]] = moore.net wire : <l1>
+// CHECK: [[Q:%.+]] = moore.net wire : <l1>
+// CHECK: [[RD_A:%.+]] = moore.read [[A]] : <l1>
+// CHECK: [[RD_B:%.+]] = moore.read [[B]] : <l1>
+// CHECK: [[AND:%.+]] = moore.and [[RD_A]], [[RD_B]] : l1
+// CHECK: [[NOT_AND:%.+]] = moore.not [[AND]] : l1
+// CHECK: [[DELAYCONST:%.+]] = moore.constant_time 5000000 fs
+// CHECK: moore.delayed_assign [[Q]], [[NOT_AND]], [[DELAYCONST]] : l1
+
+module delayed_nand_prim;
+    wire A, B, Q;
+    nand #(5) a (Q, A, B);
+endmodule
+
 // CHECK-LABEL: moore.module @not_prim()
 // CHECK: [[A:%.+]] = moore.net wire : <l1>
 // CHECK: [[Q:%.+]] = moore.net wire : <l1>


### PR DESCRIPTION
Handles the simple delay case where we don't have to worry about rises/falls - n-output prims should be an easy follow-up too, just splitting to keep diff clean!