### PR TITLE
[NFC][ImportVerilog] Drop outdated TODO

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1907,8 +1907,6 @@ LogicalResult Context::convertNInputPrimitive(
   if (!result)
     return failure();
 
-  // TODO: annotate with debug ops to preserve primitive name
-
   auto dstType = cast<moore::RefType>(outputVal.getType()).getNestedType();
   result = materializeConversion(dstType, result, false, loc);
   if (!result)


### PR DESCRIPTION
Looking at other tools, they don't seem to track builtin primitive ports so dropping this