### PR TITLE
[FIRRTL] Don't run MemToRegOfVec on "SeqMem"s

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -63,16 +63,9 @@ struct MemToRegOfVecPass
       LLVM_DEBUG(llvm::dbgs() << "\n Memory op:" << memOp);
 
       auto firMem = memOp.getSummary();
-      // Ignore if the memory is candidate for macro replacement.
-      // The requirements for macro replacement:
-      // 1. read latency and write latency of one.
-      // 2. only one readwrite port or write port.
-      // 3. zero or one read port.
-      // 4. undefined read-under-write behavior.
-      if (replSeqMem &&
-          ((firMem.readLatency == 1 && firMem.writeLatency == 1) &&
-           (firMem.numWritePorts + firMem.numReadWritePorts == 1) &&
-           (firMem.numReadPorts <= 1) && firMem.dataWidth > 0))
+      // Ignore if we are running with macro replacement on and the memory is a
+      // candidate for macro replacement.
+      if (replSeqMem && firMem.isSeqMem())
         return;
 
       generateMemory(memOp, firMem);

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-mem-to-reg-of-vec))' %s | FileCheck  %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-mem-to-reg-of-vec{repl-seq-mem=true}))' %s | FileCheck  %s
 
 firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
   firrtl.module public @Mem(out %d : !firrtl.probe<vector<uint<8>, 8>>, out %d2 : !firrtl.probe<vector<uint<8>, 8>>) attributes {annotations = [
@@ -238,4 +238,49 @@ firrtl.circuit "NLA" attributes {annotations = [
   ]} {
     firrtl.instance foo sym @foo @Foo()
 	}
+}
+
+// Test that certain memories which are intended to be implemented with SRAMs
+// are not lowered.
+//
+// CHECK-LABEL: "SkipMemoryMacros"
+firrtl.circuit "SkipMemoryMacros" attributes {
+  annotations = [
+    {
+      class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"
+    }
+  ]
+} {
+  firrtl.module @SkipMemoryMacros() {
+    // None of the following memories should be replaced.
+    // CHECK-COUNT-4: firrtl.mem
+    %latency_1r1w = firrtl.mem Undefined {
+      depth = 2 : i64,
+      name = "m",
+      portNames = ["rw"],
+      readLatency = 1 : i32,
+      writeLatency = 1 : i32
+    } : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>, wdata: uint<1>, wmask: uint<1>>
+    %latency_1r2w = firrtl.mem Undefined {
+      depth = 2 : i64,
+      name = "m",
+      portNames = ["rw"],
+      readLatency = 1 : i32,
+      writeLatency = 2 : i32
+    } : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>, wdata: uint<1>, wmask: uint<1>>
+    %latency_2r1w = firrtl.mem Undefined {
+      depth = 2 : i64,
+      name = "m",
+      portNames = ["rw"],
+      readLatency = 2 : i32,
+      writeLatency = 1 : i32
+    } : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>, wdata: uint<1>, wmask: uint<1>>
+    %latency_4r4w = firrtl.mem Undefined {
+      depth = 2 : i64,
+      name = "m",
+      portNames = ["rw"],
+      readLatency = 4 : i32,
+      writeLatency = 4 : i32
+    } : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>, wdata: uint<1>, wmask: uint<1>>
+  }
 }


### PR DESCRIPTION
Fix a longstanding bug where "sequential memories" with read and write
latencies greater than one would be targeted by the `MemToRegOfVec`
transform.  Historically, this was never a problem as Chisel provided no
mechanism to access memories that were either read latency 0/1, write
latency 1 memories.  However, now that this is both accessible via the
`chisel3.util.SRAM` API and in use (at least internally), this could
create situations where memories that were intended to be replaced with
SRAMs would get blown out by this pass.  Notably, FIRRTL always supported
these memories, just this was a code path that had never been exercised.

Concretely, this fixes a bug where this transform breaks up memories which
are used by FIRRTL metadata to then error out in `LowerClasses` due to the
duplication of the metadata.  There likely still exists a bug where
memories with any property metadata should not be put through the
`MemToRegOfVec` pass.

Assisted-by: OpenCode:claude-sonnet-4-6
Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>
