### PR TITLE
[firtool] Fix randomization disable logic

### DIFF
--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -72,6 +72,21 @@ public:
     return disableRandom != RandomKind::All && disableRandom != kind;
   }
 
+  /// Advance the disabled-randomization lattice.  Calling this twice with
+  /// the two individual kinds is equivalent to calling it once with All.
+  static RandomKind mergeRandomKind(RandomKind current, RandomKind incoming) {
+    if (current == RandomKind::None)
+      return incoming;
+    if (current == incoming)
+      return current;
+    return RandomKind::All;
+  }
+
+  FirtoolOptions &setDisableRandom(RandomKind kind) {
+    disableRandom = mergeRandomKind(disableRandom, kind);
+    return *this;
+  }
+
   firrtl::PreserveValues::PreserveMode getPreserveMode() const {
     switch (buildMode) {
     case BuildModeDebug:
@@ -280,11 +295,6 @@ public:
 
   FirtoolOptions &setIgnoreReadEnableMem(bool value) {
     ignoreReadEnableMem = value;
-    return *this;
-  }
-
-  FirtoolOptions &setDisableRandom(RandomKind value) {
-    disableRandom = value;
     return *this;
   }
 

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -82,7 +82,7 @@ public:
     return RandomKind::All;
   }
 
-  FirtoolOptions &setDisableRandom(RandomKind kind) {
+  FirtoolOptions &mergeDisableRandom(RandomKind kind) {
     disableRandom = mergeRandomKind(disableRandom, kind);
     return *this;
   }

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -196,24 +196,20 @@ void circtFirtoolOptionsSetIgnoreReadEnableMem(
 
 void circtFirtoolOptionsSetDisableRandom(CirctFirtoolFirtoolOptions options,
                                          CirctFirtoolRandomKind value) {
-  firtool::FirtoolOptions::RandomKind converted;
-
+  auto *opts = unwrap(options);
   switch (value) {
   case CIRCT_FIRTOOL_RANDOM_KIND_NONE:
-    converted = firtool::FirtoolOptions::RandomKind::None;
     break;
   case CIRCT_FIRTOOL_RANDOM_KIND_MEM:
-    converted = firtool::FirtoolOptions::RandomKind::Mem;
+    opts->setDisableRandom(firtool::FirtoolOptions::RandomKind::Mem);
     break;
   case CIRCT_FIRTOOL_RANDOM_KIND_REG:
-    converted = firtool::FirtoolOptions::RandomKind::Reg;
+    opts->setDisableRandom(firtool::FirtoolOptions::RandomKind::Reg);
     break;
   case CIRCT_FIRTOOL_RANDOM_KIND_ALL:
-    converted = firtool::FirtoolOptions::RandomKind::All;
+    opts->setDisableRandom(firtool::FirtoolOptions::RandomKind::All);
     break;
   }
-
-  unwrap(options)->setDisableRandom(converted);
 }
 
 void circtFirtoolOptionsSetOutputAnnotationFilename(

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -201,13 +201,13 @@ void circtFirtoolOptionsSetDisableRandom(CirctFirtoolFirtoolOptions options,
   case CIRCT_FIRTOOL_RANDOM_KIND_NONE:
     break;
   case CIRCT_FIRTOOL_RANDOM_KIND_MEM:
-    opts->setDisableRandom(firtool::FirtoolOptions::RandomKind::Mem);
+    opts->mergeDisableRandom(firtool::FirtoolOptions::RandomKind::Mem);
     break;
   case CIRCT_FIRTOOL_RANDOM_KIND_REG:
-    opts->setDisableRandom(firtool::FirtoolOptions::RandomKind::Reg);
+    opts->mergeDisableRandom(firtool::FirtoolOptions::RandomKind::Reg);
     break;
   case CIRCT_FIRTOOL_RANDOM_KIND_ALL:
-    opts->setDisableRandom(firtool::FirtoolOptions::RandomKind::All);
+    opts->mergeDisableRandom(firtool::FirtoolOptions::RandomKind::All);
     break;
   }
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -637,20 +637,39 @@ struct FirtoolCmdOptions {
                      "assigning X on read disable"),
       llvm::cl::init(false)};
 
-  llvm::cl::opt<firtool::FirtoolOptions::RandomKind> disableRandom{
-      llvm::cl::desc(
-          "Disable random initialization code (may break semantics!)"),
-      llvm::cl::values(
-          clEnumValN(firtool::FirtoolOptions::RandomKind::Mem,
-                     "disable-mem-randomization",
-                     "Disable emission of memory randomization code"),
-          clEnumValN(firtool::FirtoolOptions::RandomKind::Reg,
-                     "disable-reg-randomization",
-                     "Disable emission of register randomization code"),
-          clEnumValN(firtool::FirtoolOptions::RandomKind::All,
-                     "disable-all-randomization",
-                     "Disable emission of all randomization code")),
-      llvm::cl::init(firtool::FirtoolOptions::RandomKind::None)};
+  firtool::FirtoolOptions::RandomKind disableRandomValue =
+      firtool::FirtoolOptions::RandomKind::None;
+
+  static llvm::cl::OptionCategory randomizationCategory;
+
+  llvm::cl::opt<bool> disableMemRandom{
+      "disable-mem-randomization",
+      llvm::cl::desc("Disable emission of memory randomization code"),
+      llvm::cl::cat(randomizationCategory),
+      llvm::cl::init(false),
+      llvm::cl::callback([&](const bool &) {
+        disableRandomValue = firtool::FirtoolOptions::mergeRandomKind(
+            disableRandomValue, firtool::FirtoolOptions::RandomKind::Mem);
+      })};
+
+  llvm::cl::opt<bool> disableRegRandom{
+      "disable-reg-randomization",
+      llvm::cl::desc("Disable emission of register randomization code"),
+      llvm::cl::cat(randomizationCategory),
+      llvm::cl::init(false),
+      llvm::cl::callback([&](const bool &) {
+        disableRandomValue = firtool::FirtoolOptions::mergeRandomKind(
+            disableRandomValue, firtool::FirtoolOptions::RandomKind::Reg);
+      })};
+
+  llvm::cl::opt<bool> disableAllRandom{
+      "disable-all-randomization",
+      llvm::cl::desc("Disable emission of all randomization code"),
+      llvm::cl::cat(randomizationCategory),
+      llvm::cl::init(false),
+      llvm::cl::callback([&](const bool &) {
+        disableRandomValue = firtool::FirtoolOptions::RandomKind::All;
+      })};
 
   llvm::cl::opt<std::string> outputAnnotationFilename{
       "output-annotation-file",
@@ -803,6 +822,10 @@ struct FirtoolCmdOptions {
       "lint-xmrs-in-design", llvm::cl::desc("Lint XMRs in the design"),
       llvm::cl::init(false)};
 };
+
+llvm::cl::OptionCategory FirtoolCmdOptions::randomizationCategory{
+    "Disable random initialization code (may break semantics!)"};
+
 } // namespace
 
 static llvm::ManagedStatic<FirtoolCmdOptions> clOptions;
@@ -867,7 +890,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   replSeqMem = clOptions->replSeqMem;
   replSeqMemFile = clOptions->replSeqMemFile;
   ignoreReadEnableMem = clOptions->ignoreReadEnableMem;
-  disableRandom = clOptions->disableRandom;
+  disableRandom = clOptions->disableRandomValue;
   outputAnnotationFilename = clOptions->outputAnnotationFilename;
   enableAnnotationWarning = clOptions->enableAnnotationWarning;
   lowerToCore = clOptions->lowerToCore;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -477,10 +477,11 @@ LogicalResult firtool::populateHWToBTOR2(mlir::PassManager &pm,
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// This struct contains command line options that can be used to initialize
-/// various bits of a Firtool pipeline. This uses a struct wrapper to avoid the
+/// This class contains command line options that can be used to initialize
+/// various bits of a Firtool pipeline. This uses a class wrapper to avoid the
 /// need for global command line options.
-struct FirtoolCmdOptions {
+class FirtoolCmdOptions {
+public:
   llvm::cl::opt<std::string> outputFilename{
       "o",
       llvm::cl::desc("Output filename, or directory for split output"),
@@ -640,13 +641,19 @@ struct FirtoolCmdOptions {
   firtool::FirtoolOptions::RandomKind disableRandomValue =
       firtool::FirtoolOptions::RandomKind::None;
 
+// Make these options (and their grouping category) inaccessible as their values
+// are not intended to be used directly.  These change a lattice of
+// randomization disable settings and directly accessing the command line option
+// the user provided is not useful.
+private:
   llvm::cl::OptionCategory randomizationCategory{
       "Disable random initialization code (may break semantics!)"};
 
   llvm::cl::opt<bool> disableMemRandom{
       "disable-mem-randomization",
       llvm::cl::desc("Disable emission of memory randomization code"),
-      llvm::cl::cat(randomizationCategory), llvm::cl::init(false),
+      llvm::cl::cat(randomizationCategory),
+      llvm::cl::ValueDisallowed,
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::mergeRandomKind(
             disableRandomValue, firtool::FirtoolOptions::RandomKind::Mem);
@@ -655,7 +662,8 @@ struct FirtoolCmdOptions {
   llvm::cl::opt<bool> disableRegRandom{
       "disable-reg-randomization",
       llvm::cl::desc("Disable emission of register randomization code"),
-      llvm::cl::cat(randomizationCategory), llvm::cl::init(false),
+      llvm::cl::cat(randomizationCategory),
+      llvm::cl::ValueDisallowed,
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::mergeRandomKind(
             disableRandomValue, firtool::FirtoolOptions::RandomKind::Reg);
@@ -664,11 +672,13 @@ struct FirtoolCmdOptions {
   llvm::cl::opt<bool> disableAllRandom{
       "disable-all-randomization",
       llvm::cl::desc("Disable emission of all randomization code"),
-      llvm::cl::cat(randomizationCategory), llvm::cl::init(false),
+      llvm::cl::cat(randomizationCategory),
+      llvm::cl::ValueDisallowed,
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::RandomKind::All;
       })};
 
+public:
   llvm::cl::opt<std::string> outputAnnotationFilename{
       "output-annotation-file",
       llvm::cl::desc("Optional output annotation file"),

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -645,8 +645,7 @@ struct FirtoolCmdOptions {
   llvm::cl::opt<bool> disableMemRandom{
       "disable-mem-randomization",
       llvm::cl::desc("Disable emission of memory randomization code"),
-      llvm::cl::cat(randomizationCategory),
-      llvm::cl::init(false),
+      llvm::cl::cat(randomizationCategory), llvm::cl::init(false),
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::mergeRandomKind(
             disableRandomValue, firtool::FirtoolOptions::RandomKind::Mem);
@@ -655,8 +654,7 @@ struct FirtoolCmdOptions {
   llvm::cl::opt<bool> disableRegRandom{
       "disable-reg-randomization",
       llvm::cl::desc("Disable emission of register randomization code"),
-      llvm::cl::cat(randomizationCategory),
-      llvm::cl::init(false),
+      llvm::cl::cat(randomizationCategory), llvm::cl::init(false),
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::mergeRandomKind(
             disableRandomValue, firtool::FirtoolOptions::RandomKind::Reg);
@@ -665,8 +663,7 @@ struct FirtoolCmdOptions {
   llvm::cl::opt<bool> disableAllRandom{
       "disable-all-randomization",
       llvm::cl::desc("Disable emission of all randomization code"),
-      llvm::cl::cat(randomizationCategory),
-      llvm::cl::init(false),
+      llvm::cl::cat(randomizationCategory), llvm::cl::init(false),
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::RandomKind::All;
       })};

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -641,10 +641,10 @@ public:
   firtool::FirtoolOptions::RandomKind disableRandomValue =
       firtool::FirtoolOptions::RandomKind::None;
 
-// Make these options (and their grouping category) inaccessible as their values
-// are not intended to be used directly.  These change a lattice of
-// randomization disable settings and directly accessing the command line option
-// the user provided is not useful.
+  // Make these options (and their grouping category) inaccessible as their
+  // values are not intended to be used directly.  These change a lattice of
+  // randomization disable settings and directly accessing the command line
+  // option the user provided is not useful.
 private:
   llvm::cl::OptionCategory randomizationCategory{
       "Disable random initialization code (may break semantics!)"};
@@ -652,8 +652,7 @@ private:
   llvm::cl::opt<bool> disableMemRandom{
       "disable-mem-randomization",
       llvm::cl::desc("Disable emission of memory randomization code"),
-      llvm::cl::cat(randomizationCategory),
-      llvm::cl::ValueDisallowed,
+      llvm::cl::cat(randomizationCategory), llvm::cl::ValueDisallowed,
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::mergeRandomKind(
             disableRandomValue, firtool::FirtoolOptions::RandomKind::Mem);
@@ -662,8 +661,7 @@ private:
   llvm::cl::opt<bool> disableRegRandom{
       "disable-reg-randomization",
       llvm::cl::desc("Disable emission of register randomization code"),
-      llvm::cl::cat(randomizationCategory),
-      llvm::cl::ValueDisallowed,
+      llvm::cl::cat(randomizationCategory), llvm::cl::ValueDisallowed,
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::mergeRandomKind(
             disableRandomValue, firtool::FirtoolOptions::RandomKind::Reg);
@@ -672,8 +670,7 @@ private:
   llvm::cl::opt<bool> disableAllRandom{
       "disable-all-randomization",
       llvm::cl::desc("Disable emission of all randomization code"),
-      llvm::cl::cat(randomizationCategory),
-      llvm::cl::ValueDisallowed,
+      llvm::cl::cat(randomizationCategory), llvm::cl::ValueDisallowed,
       llvm::cl::callback([&](const bool &) {
         disableRandomValue = firtool::FirtoolOptions::RandomKind::All;
       })};

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -640,7 +640,8 @@ struct FirtoolCmdOptions {
   firtool::FirtoolOptions::RandomKind disableRandomValue =
       firtool::FirtoolOptions::RandomKind::None;
 
-  static llvm::cl::OptionCategory randomizationCategory;
+  llvm::cl::OptionCategory randomizationCategory{
+      "Disable random initialization code (may break semantics!)"};
 
   llvm::cl::opt<bool> disableMemRandom{
       "disable-mem-randomization",
@@ -819,10 +820,6 @@ struct FirtoolCmdOptions {
       "lint-xmrs-in-design", llvm::cl::desc("Lint XMRs in the design"),
       llvm::cl::init(false)};
 };
-
-llvm::cl::OptionCategory FirtoolCmdOptions::randomizationCategory{
-    "Disable random initialization code (may break semantics!)"};
-
 } // namespace
 
 static llvm::ManagedStatic<FirtoolCmdOptions> clOptions;


### PR DESCRIPTION
Fix a very old bug in the handling of `-disable-*-randomization` flags
where these were not "additive", but they were supposed to be.  E.g.,
whatever flag was specified last won.

The existing test of this in `test/firtool/memory.fir` intended to test
this, but was broken because that test relied on the `MemToRegOfVec` pass
to remove all memories.

This commit does not add a test.  However, a follow-on commit will
repurpose that test to explicitly check this.

Assisted-by: OpenCode:claude-sonnet-4-6
