### PR TITLE
[FIRRTL] Remove ReplSeqMem gating of MemToRegOfVec

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -545,8 +545,6 @@ def MemToRegOfVec : Pass<"firrtl-mem-to-reg-of-vec", "firrtl::CircuitOp"> {
     This pass generates the logic to implement a memory using Registers.
   }];
   let options = [
-    Option<"replSeqMem", "repl-seq-mem", "bool",
-                "false", "Prepare seq mems for macro replacement">,
     Option<"ignoreReadEnable", "ignore-read-enable-mem", "bool",
                 "false",
     "ignore the read enable signal, instead of assigning X on read disable">

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -63,9 +63,13 @@ struct MemToRegOfVecPass
       LLVM_DEBUG(llvm::dbgs() << "\n Memory op:" << memOp);
 
       auto firMem = memOp.getSummary();
-      // Ignore if we are running with macro replacement on and the memory is a
-      // candidate for macro replacement.
-      if (replSeqMem && firMem.isSeqMem())
+      // Ignore if the memory is a sequential memory, i.e., something that is
+      // supposed to be an SRAM.  In either possible eventual lowering by later
+      // passes (blackboxing or lowering to a behavioral model) we don't want to
+      // blow this out here as it both breaks expectations about later passes
+      // that may add asynchronous resets (InferResets) or that expect metadata
+      // on SRAMs to not be split up (LowerClasses).
+      if (firMem.isSeqMem())
         return;
 
       generateMemory(memOp, firMem);

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -92,8 +92,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidths());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createMemToRegOfVec(
-      {/*replSeqMem=*/opt.shouldReplaceSequentialMemories(),
-       /*replSeqMemFile=*/opt.shouldIgnoreReadEnableMemories()}));
+      {/*replSeqMemFile=*/opt.shouldIgnoreReadEnableMemories()}));
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResets());
 

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-mem-to-reg-of-vec{repl-seq-mem=true}))' %s | FileCheck  %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-mem-to-reg-of-vec))' %s | FileCheck  %s
 
 firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
   firrtl.module public @Mem(out %d : !firrtl.probe<vector<uint<8>, 8>>, out %d2 : !firrtl.probe<vector<uint<8>, 8>>) attributes {annotations = [

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,8 +1,7 @@
-; RUN: firtool %s --format=fir --ir-sv | FileCheck %s --check-prefixes=CHECK,COMMON --implicit-check-not sv.attributes
-; RUN: firtool %s --format=fir --ir-sv -disable-mem-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM
-; RUN: firtool %s --format=fir --ir-sv -disable-reg-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG
-; RUN: firtool %s --format=fir --ir-sv -disable-mem-randomization --disable-reg-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
-; RUN: firtool %s --format=fir --ir-sv -disable-all-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
+; RUN: firtool %s --format=fir -disable-mem-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM
+; RUN: firtool %s --format=fir -disable-reg-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_REG
+; RUN: firtool %s --format=fir -disable-mem-randomization --disable-reg-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
+; RUN: firtool %s --format=fir -disable-all-randomization | FileCheck %s --check-prefix COMMON --implicit-check-not RANDOMIZE_MEM --implicit-check-not RANDOMIZE_REG
 
 FIRRTL version 4.0.0
 circuit Qux: %[[{
@@ -63,66 +62,4 @@ circuit Qux: %[[{
     connect memory.rw.wdata, rwDataIn
     connect rwDataOut, memory.rw.rdata
 
-
-
-; This test is quite fragile, both as written, and in that it depends on
-; multiple passes.  It should be replaced with a narrower test.
-
-;COMMON-LABEL: hw.module @Qux
-;CHECK:    %[[memory_0:.+]] = sv.reg
-;CHECK:    %[[memory_1:.+]] = sv.reg
-;CHECK:    %[[memory_2:.+]] = sv.reg
-;CHECK:    %[[memory_3:.+]] = sv.reg
-;CHECK:    %[[addr:.+]] = sv.reg
-;CHECK:    %[[v4:.+]] = sv.read_inout %[[addr]]
-;CHECK:    %[[v5:.+]] = hw.array_create
-;CHECK:    %[[v6:.+]] = hw.array_get %[[v5]][%[[v4]]]
-;CHECK:    %[[v7:.+]] = hw.array_get %[[v5]][%rwAddr]
-;CHECK:    %8 = comb.icmp bin eq %rwAddr, %c0_i2 : i2
-;CHECK:    %9 = comb.and bin %rwEn, %rwMode, %rwMask, %8 : i1
-;CHECK:    %10 = comb.icmp bin eq %rwAddr, %c1_i2 : i2
-;CHECK:    %11 = comb.and bin %rwEn, %rwMode, %rwMask, %10 : i1
-;CHECK:    %12 = comb.icmp bin eq %rwAddr, %c-2_i2 : i2
-;CHECK:    %13 = comb.and bin %rwEn, %rwMode, %rwMask, %12 : i1
-;CHECK:    %14 = comb.icmp bin eq %rwAddr, %c-1_i2 : i2
-;CHECK:    %15 = comb.and bin %rwEn, %rwMode, %rwMask, %14 : i1
-;CHECK:    %16 = comb.icmp bin eq %wAddr, %c0_i2 : i2
-;CHECK:    %17 = comb.and bin %wEn, %wMask, %16 : i1
-;CHECK:    %18 = comb.icmp bin eq %wAddr, %c1_i2 : i2
-;CHECK:    %19 = comb.and bin %wEn, %wMask, %18 : i1
-;CHECK:    %20 = comb.icmp bin eq %wAddr, %c-2_i2 : i2
-;CHECK:    %21 = comb.and bin %wEn, %wMask, %20 : i1
-;CHECK:    %22 = comb.icmp bin eq %wAddr, %c-1_i2 : i2
-;CHECK:    %23 = comb.and bin %wEn, %wMask, %22 : i1
-;CHECK:    sv.always posedge %clock {
-;CHECK:      sv.if %17 {
-;CHECK:        sv.passign %memory_0, %wData : i8
-;CHECK:      } else {
-;CHECK:        sv.if %9 {
-;CHECK:          sv.passign %memory_0, %rwDataIn : i8
-;CHECK:        }
-;CHECK:      }
-;CHECK:      sv.if %19 {
-;CHECK:        sv.passign %memory_1, %wData : i8
-;CHECK:      } else {
-;CHECK:        sv.if %11 {
-;CHECK:          sv.passign %memory_1, %rwDataIn : i8
-;CHECK:        }
-;CHECK:      }
-;CHECK:      sv.if %21 {
-;CHECK:        sv.passign %memory_2, %wData : i8
-;CHECK:      } else {
-;CHECK:        sv.if %13 {
-;CHECK:          sv.passign %memory_2, %rwDataIn : i8
-;CHECK:        }
-;CHECK:      }
-;CHECK:      sv.if %23 {
-;CHECK:        sv.passign %memory_3, %wData : i8
-;CHECK:      } else {
-;CHECK:        sv.if %15 {
-;CHECK:          sv.passign %memory_3, %rwDataIn : i8
-;CHECK:        }
-;CHECK:      }
-;CHECK:      sv.passign %addr, %rAddr : i2
-;CHECK:    }
-;CHECK:    hw.output %[[v6]], %[[v7]]
+; COMMON-LABEL: module Qux


### PR DESCRIPTION
Remove the gating of the `MemToRegOfVec` pass on the `-repl-seq-mem`
option.  This doesn't make sense in hindsight as you don't want to blow
out memories just because they are going to be replaced with CIRCT in-tree
behavioral models.

This repurposes the very janky `memory.fir` test to only test the command
line option behavior of the `-disable-*-randomization` options which was
exposed as this refactored that test.

This is currently stacked on both #10284 and #10285.  I will clean this up
once those land.

Assisted-by: OpenCode:claude-sonnet-4-6
