### PR TITLE
circt-bmc: materialize debug anchors 

### DIFF
--- a/include/circt/Tools/circt-bmc/Passes.h
+++ b/include/circt/Tools/circt-bmc/Passes.h
@@ -24,6 +24,7 @@ namespace circt {
 /// Generate the code for registering passes.
 #define GEN_PASS_DECL_LOWERTOBMC
 #define GEN_PASS_DECL_EXTERNALIZEREGISTERS
+#define GEN_PASS_DECL_MATERIALIZEDEBUGVARIABLES
 #define GEN_PASS_REGISTRATION
 #include "circt/Tools/circt-bmc/Passes.h.inc"
 

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -50,5 +50,18 @@ def ExternalizeRegisters : Pass<"externalize-registers", "::mlir::ModuleOp"> {
   ];
 }
 
-#endif // CIRCT_TOOLS_CIRCT_BMC_PASSES_TD
+def MaterializeDebugVariables : Pass<"materialize-debug-variables", "::mlir::ModuleOp"> {
+  let summary = "Materializes debug anchors for module inputs";
+  let description = [{
+    Creates `dbg.variable` anchors for module input arguments that do not yet have
+    one. When an input `<name>_state` has a matching output `<name>_next`, the
+    anchor name is normalized to `<name>`.
+  }];
 
+  let dependentDialects = [
+    "circt::debug::DebugDialect", "circt::seq::SeqDialect",
+    "circt::hw::HWDialect"
+  ];
+}
+
+#endif // CIRCT_TOOLS_CIRCT_BMC_PASSES_TD

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -53,7 +53,7 @@ def ExternalizeRegisters : Pass<"externalize-registers", "::mlir::ModuleOp"> {
 def MaterializeDebugVariables : Pass<"materialize-debug-variables", "::mlir::ModuleOp"> {
   let summary = "Materializes debug anchors for module inputs and registers";
   let description = [{
-    Creates `dbg.variable` anchors for module input arguments and register
+    Creates `dbg.variable` anchors for module inputs and register
     results that do not yet have one.
   }];
 

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -51,11 +51,10 @@ def ExternalizeRegisters : Pass<"externalize-registers", "::mlir::ModuleOp"> {
 }
 
 def MaterializeDebugVariables : Pass<"materialize-debug-variables", "::mlir::ModuleOp"> {
-  let summary = "Materializes debug anchors for module inputs";
+  let summary = "Materializes debug anchors for module inputs and registers";
   let description = [{
-    Creates `dbg.variable` anchors for module input arguments that do not yet have
-    one. When an input `<name>_state` has a matching output `<name>_next`, the
-    anchor name is normalized to `<name>`.
+    Creates `dbg.variable` anchors for module input arguments and register
+    results that do not yet have one.
   }];
 
   let dependentDialects = [

--- a/lib/Tools/circt-bmc/CMakeLists.txt
+++ b/lib/Tools/circt-bmc/CMakeLists.txt
@@ -1,11 +1,13 @@
 add_circt_library(CIRCTBMCTransforms
   ExternalizeRegisters.cpp
   LowerToBMC.cpp
+  MaterializeDebugVariables.cpp
 
   DEPENDS
   CIRCTBMCTransformsIncGen
 
   LINK_LIBS PUBLIC
+  CIRCTDebug
   CIRCTHW
   CIRCTSeq
   CIRCTComb

--- a/lib/Tools/circt-bmc/MaterializeDebugVariables.cpp
+++ b/lib/Tools/circt-bmc/MaterializeDebugVariables.cpp
@@ -1,0 +1,78 @@
+//===- MaterializeDebugVariables.cpp --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Debug/DebugOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
+#include "circt/Support/LLVM.h"
+#include "circt/Tools/circt-bmc/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/Twine.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+
+namespace circt {
+#define GEN_PASS_DEF_MATERIALIZEDEBUGVARIABLES
+#include "circt/Tools/circt-bmc/Passes.h.inc"
+} // namespace circt
+
+namespace {
+struct MaterializeDebugVariablesPass
+    : public circt::impl::MaterializeDebugVariablesBase<
+          MaterializeDebugVariablesPass> {
+  using MaterializeDebugVariablesBase::MaterializeDebugVariablesBase;
+
+  void runOnOperation() override {
+    for (auto module : getOperation().getOps<HWModuleOp>())
+      materializeDebugVariables(module);
+  }
+
+private:
+  static void materializeDebugVariables(HWModuleOp module) {
+    auto *body = module.getBodyBlock();
+    DenseSet<Value> trackedValues;
+    for (auto varOp : body->getOps<debug::VariableOp>())
+      trackedValues.insert(varOp.getValue());
+
+    DenseSet<StringAttr> outputPortNames;
+    for (auto &port : module.getPortList())
+      if (port.isOutput())
+        outputPortNames.insert(port.name);
+
+    OpBuilder builder = OpBuilder::atBlockBegin(body);
+    StringRef stateSuffix = "_state";
+    for (auto &port : module.getPortList()) {
+      if (port.isOutput())
+        continue;
+      if (isa<seq::ClockType>(port.type))
+        continue;
+      if (!port.name || port.name.getValue().empty())
+        continue;
+
+      auto value = body->getArgument(port.argNum);
+      if (!trackedValues.insert(value).second)
+        continue;
+
+      StringAttr debugName = port.name;
+      auto portName = port.name.getValue();
+      if (portName.ends_with(stateSuffix)) {
+        auto baseName = portName.drop_back(stateSuffix.size());
+        auto nextNameAttr =
+            builder.getStringAttr((Twine(baseName) + "_next").str());
+        if (outputPortNames.contains(nextNameAttr))
+          debugName = builder.getStringAttr(baseName);
+      }
+
+      debug::VariableOp::create(builder, value.getLoc(), debugName, value,
+                                /*scope=*/Value{});
+    }
+  }
+};
+} // namespace

--- a/lib/Tools/circt-bmc/MaterializeDebugVariables.cpp
+++ b/lib/Tools/circt-bmc/MaterializeDebugVariables.cpp
@@ -38,7 +38,8 @@ private:
   static void materializeDebugVariables(HWModuleOp module) {
     auto *body = module.getBodyBlock();
     DenseSet<Value> trackedValues;
-    for (auto varOp : body->getOps<debug::VariableOp>())
+    for (auto varOp :
+         llvm::make_early_inc_range(body->getOps<debug::VariableOp>()))
       trackedValues.insert(varOp.getValue());
 
     DenseSet<StringAttr> outputPortNames;

--- a/lib/Tools/circt-bmc/MaterializeDebugVariables.cpp
+++ b/lib/Tools/circt-bmc/MaterializeDebugVariables.cpp
@@ -58,7 +58,7 @@ private:
                                 /*scope=*/Value{});
     }
 
-    auto materializeReg = [&](auto regOp, StringRef regName) {
+    auto materializeRegAnchor = [&](auto regOp, StringRef regName) {
       auto regResult = regOp.getResult();
       if (!trackedValues.insert(regResult).second)
         return;
@@ -70,21 +70,19 @@ private:
     };
 
     unsigned regIndex = 0;
-    for (auto regOp :
-         llvm::make_early_inc_range(body->getOps<seq::CompRegOp>())) {
+    for (auto regOp : body->getOps<seq::CompRegOp>()) {
       if (regOp.getName() && !regOp.getName()->empty())
-        materializeReg(regOp, regOp.getName().value());
+        materializeRegAnchor(regOp, regOp.getName().value());
       else
-        materializeReg(regOp, ("reg_" + Twine(regIndex)).str());
+        materializeRegAnchor(regOp, ("reg_" + Twine(regIndex)).str());
       ++regIndex;
     }
 
-    for (auto regOp :
-         llvm::make_early_inc_range(body->getOps<seq::FirRegOp>())) {
+    for (auto regOp : body->getOps<seq::FirRegOp>()) {
       if (!regOp.getName().empty())
-        materializeReg(regOp, regOp.getName());
+        materializeRegAnchor(regOp, regOp.getName());
       else
-        materializeReg(regOp, ("reg_" + Twine(regIndex)).str());
+        materializeRegAnchor(regOp, ("reg_" + Twine(regIndex)).str());
       ++regIndex;
     }
   }

--- a/lib/Tools/circt-bmc/MaterializeDebugVariables.cpp
+++ b/lib/Tools/circt-bmc/MaterializeDebugVariables.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/Debug/DebugOps.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Dialect/Seq/SeqTypes.h"
 #include "circt/Support/LLVM.h"
 #include "circt/Tools/circt-bmc/Passes.h"
@@ -38,17 +39,10 @@ private:
   static void materializeDebugVariables(HWModuleOp module) {
     auto *body = module.getBodyBlock();
     DenseSet<Value> trackedValues;
-    for (auto varOp :
-         llvm::make_early_inc_range(body->getOps<debug::VariableOp>()))
+    for (auto varOp : body->getOps<debug::VariableOp>())
       trackedValues.insert(varOp.getValue());
 
-    DenseSet<StringAttr> outputPortNames;
-    for (auto &port : module.getPortList())
-      if (port.isOutput())
-        outputPortNames.insert(port.name);
-
     OpBuilder builder = OpBuilder::atBlockBegin(body);
-    StringRef stateSuffix = "_state";
     for (auto &port : module.getPortList()) {
       if (port.isOutput())
         continue;
@@ -60,19 +54,38 @@ private:
       auto value = body->getArgument(port.argNum);
       if (!trackedValues.insert(value).second)
         continue;
-
-      StringAttr debugName = port.name;
-      auto portName = port.name.getValue();
-      if (portName.ends_with(stateSuffix)) {
-        auto baseName = portName.drop_back(stateSuffix.size());
-        auto nextNameAttr =
-            builder.getStringAttr((Twine(baseName) + "_next").str());
-        if (outputPortNames.contains(nextNameAttr))
-          debugName = builder.getStringAttr(baseName);
-      }
-
-      debug::VariableOp::create(builder, value.getLoc(), debugName, value,
+      debug::VariableOp::create(builder, value.getLoc(), port.name, value,
                                 /*scope=*/Value{});
+    }
+
+    auto materializeReg = [&](auto regOp, StringRef regName) {
+      auto regResult = regOp.getResult();
+      if (!trackedValues.insert(regResult).second)
+        return;
+      auto regNameAttr = builder.getStringAttr(regName);
+      OpBuilder regBuilder(regOp);
+      regBuilder.setInsertionPointAfter(regOp);
+      debug::VariableOp::create(regBuilder, regResult.getLoc(), regNameAttr,
+                                regResult, /*scope=*/Value{});
+    };
+
+    unsigned regIndex = 0;
+    for (auto regOp :
+         llvm::make_early_inc_range(body->getOps<seq::CompRegOp>())) {
+      if (regOp.getName() && !regOp.getName()->empty())
+        materializeReg(regOp, regOp.getName().value());
+      else
+        materializeReg(regOp, ("reg_" + Twine(regIndex)).str());
+      ++regIndex;
+    }
+
+    for (auto regOp :
+         llvm::make_early_inc_range(body->getOps<seq::FirRegOp>())) {
+      if (!regOp.getName().empty())
+        materializeReg(regOp, regOp.getName());
+      else
+        materializeReg(regOp, ("reg_" + Twine(regIndex)).str());
+      ++regIndex;
     }
   }
 };

--- a/test/Tools/circt-bmc/materialize-debug-variables.mlir
+++ b/test/Tools/circt-bmc/materialize-debug-variables.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --externalize-registers --materialize-debug-variables %s | FileCheck %s
+// RUN: circt-opt --materialize-debug-variables --externalize-registers %s | FileCheck %s
 
 // CHECK-LABEL: hw.module @named_regs(
 // CHECK:         dbg.variable "in0", [[IN0:%.+]] : i32
@@ -24,4 +24,13 @@ hw.module @preserve_existing_and_non_normalized(in %clk: !seq.clock, in %x: i8, 
   dbg.variable "x_alias", %x : i8
   %0 = comb.add %x, %y : i8
   hw.output %0 : i8
+}
+
+// -----
+
+// CHECK-LABEL: hw.module @do_not_guess_from_suffix(
+// CHECK:         dbg.variable "foo_state", [[STATE:%.+]] : i1
+// CHECK-NOT:     dbg.variable "foo", [[STATE]]
+hw.module @do_not_guess_from_suffix(in %foo_state: i1, out foo_next: i1) {
+  hw.output %foo_state : i1
 }

--- a/test/Tools/circt-bmc/materialize-debug-variables.mlir
+++ b/test/Tools/circt-bmc/materialize-debug-variables.mlir
@@ -1,0 +1,27 @@
+// RUN: circt-opt --externalize-registers --materialize-debug-variables %s | FileCheck %s
+
+// CHECK-LABEL: hw.module @named_regs(
+// CHECK:         dbg.variable "in0", [[IN0:%.+]] : i32
+// CHECK:         dbg.variable "in1", [[IN1:%.+]] : i32
+// CHECK:         dbg.variable "firstreg", %firstreg_state : i32
+// CHECK:         dbg.variable "secondreg", %secondreg_state : i32
+// CHECK-NOT:     dbg.variable "clk"
+hw.module @named_regs(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = comb.add %in0, %in1 : i32
+  %firstreg = seq.compreg %0, %clk : i32
+  %secondreg = seq.compreg %firstreg, %clk : i32
+  hw.output %secondreg : i32
+}
+
+// -----
+
+// CHECK-LABEL: hw.module @preserve_existing_and_non_normalized(
+// CHECK:         dbg.variable "y", [[Y:%.+]] : i8
+// CHECK:         dbg.variable "data_state", [[STATE:%.+]] : i8
+// CHECK:         dbg.variable "x_alias", [[X:%.+]] : i8
+// CHECK-NOT:     dbg.variable "x", [[X]]
+hw.module @preserve_existing_and_non_normalized(in %clk: !seq.clock, in %x: i8, in %y: i8, in %data_state: i8, out out: i8) {
+  dbg.variable "x_alias", %x : i8
+  %0 = comb.add %x, %y : i8
+  hw.output %0 : i8
+}

--- a/test/Tools/circt-bmc/materialize-debug-variables.mlir
+++ b/test/Tools/circt-bmc/materialize-debug-variables.mlir
@@ -1,11 +1,16 @@
-// RUN: circt-opt --materialize-debug-variables --externalize-registers %s | FileCheck %s
+// RUN: circt-opt --materialize-debug-variables %s | FileCheck %s
 
 // CHECK-LABEL: hw.module @named_regs(
-// CHECK:         dbg.variable "in0", [[IN0:%.+]] : i32
-// CHECK:         dbg.variable "in1", [[IN1:%.+]] : i32
-// CHECK:         dbg.variable "firstreg", %firstreg_state : i32
-// CHECK:         dbg.variable "secondreg", %secondreg_state : i32
-// CHECK-NOT:     dbg.variable "clk"
+// CHECK-SAME:   in [[CLK:%[^:]+]] : !seq.clock
+// CHECK-SAME:   in [[IN0:%[^:]+]] : i32
+// CHECK-SAME:   in [[IN1:%[^:]+]] : i32
+// CHECK:         dbg.variable "in0", [[IN0]] : i32
+// CHECK:         dbg.variable "in1", [[IN1]] : i32
+// CHECK:         [[FIRSTREG:%.+]] = seq.compreg
+// CHECK-NEXT:    dbg.variable "firstreg", [[FIRSTREG]] : i32
+// CHECK:         [[SECONDREG:%.+]] = seq.compreg
+// CHECK-NEXT:    dbg.variable "secondreg", [[SECONDREG]] : i32
+// CHECK-NOT:     dbg.variable "clk", [[CLK]]
 hw.module @named_regs(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
   %0 = comb.add %in0, %in1 : i32
   %firstreg = seq.compreg %0, %clk : i32
@@ -16,10 +21,13 @@ hw.module @named_regs(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: 
 // -----
 
 // CHECK-LABEL: hw.module @preserve_existing_and_non_normalized(
-// CHECK:         dbg.variable "y", [[Y:%.+]] : i8
-// CHECK:         dbg.variable "data_state", [[STATE:%.+]] : i8
-// CHECK:         dbg.variable "x_alias", [[X:%.+]] : i8
-// CHECK-NOT:     dbg.variable "x", [[X]]
+// CHECK-SAME:   in [[X_IN:%[^:]+]] : i8
+// CHECK-SAME:   in [[Y_IN:%[^:]+]] : i8
+// CHECK-SAME:   in [[DATA_STATE_IN:%[^:]+]] : i8
+// CHECK:         dbg.variable "y", [[Y_IN]] : i8
+// CHECK:         dbg.variable "data_state", [[DATA_STATE_IN]] : i8
+// CHECK:         dbg.variable "x_alias", [[X_IN]] : i8
+// CHECK-NOT:     dbg.variable "x", [[X_IN]]
 hw.module @preserve_existing_and_non_normalized(in %clk: !seq.clock, in %x: i8, in %y: i8, in %data_state: i8, out out: i8) {
   dbg.variable "x_alias", %x : i8
   %0 = comb.add %x, %y : i8
@@ -29,8 +37,9 @@ hw.module @preserve_existing_and_non_normalized(in %clk: !seq.clock, in %x: i8, 
 // -----
 
 // CHECK-LABEL: hw.module @do_not_guess_from_suffix(
-// CHECK:         dbg.variable "foo_state", [[STATE:%.+]] : i1
-// CHECK-NOT:     dbg.variable "foo", [[STATE]]
+// CHECK-SAME:   in [[FOO_STATE_IN:%[^:]+]] : i1
+// CHECK:         dbg.variable "foo_state", [[FOO_STATE_IN]] : i1
+// CHECK-NOT:     dbg.variable "foo", [[FOO_STATE_IN]]
 hw.module @do_not_guess_from_suffix(in %foo_state: i1, out foo_next: i1) {
   hw.output %foo_state : i1
 }

--- a/test/Tools/circt-bmc/materialize-debug-variables.mlir
+++ b/test/Tools/circt-bmc/materialize-debug-variables.mlir
@@ -43,3 +43,25 @@ hw.module @preserve_existing_and_non_normalized(in %clk: !seq.clock, in %x: i8, 
 hw.module @do_not_guess_from_suffix(in %foo_state: i1, out foo_next: i1) {
   hw.output %foo_state : i1
 }
+
+// -----
+
+// CHECK-LABEL: hw.module @mixed_named_and_unnamed_regs(
+// CHECK-SAME:   in [[CLK_MIXED:%[^:]+]] : !seq.clock
+// CHECK-SAME:   in [[IN_MIXED:%[^:]+]] : i32
+// CHECK:         dbg.variable "in", [[IN_MIXED]] : i32
+// CHECK:         [[NAMED_COMP:%.+]] = seq.compreg
+// CHECK-NEXT:    dbg.variable "named_comp", [[NAMED_COMP]] : i32
+// CHECK:         [[UNNAMED_COMP:%.+]] = seq.compreg
+// CHECK-NEXT:    dbg.variable "reg_1", [[UNNAMED_COMP]] : i32
+// CHECK:         [[NAMED_FIR:%.+]] = seq.firreg
+// CHECK-NEXT:    dbg.variable "named_fir", [[NAMED_FIR]] : i32
+// CHECK:         [[UNNAMED_FIR:%.+]] = seq.firreg
+// CHECK-NEXT:    dbg.variable "reg_3", [[UNNAMED_FIR]] : i32
+hw.module @mixed_named_and_unnamed_regs(in %clk: !seq.clock, in %in: i32, out out: i32) {
+  %named_comp = seq.compreg %in, %clk : i32
+  %0 = seq.compreg %named_comp, %clk : i32
+  %named_fir = seq.firreg %0 clock %clk : i32
+  %1 = seq.firreg %named_fir clock %clk : i32
+  hw.output %1 : i32
+}

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(circt-bmc
   CIRCTBMCTransforms
   CIRCTComb
   CIRCTCombToSMT
+  CIRCTDebug
   CIRCTEmitTransforms
   CIRCTHW
   CIRCTHWToSMT

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -213,8 +213,8 @@ static LogicalResult executeBMC(MLIRContext &context) {
   }
   pm.addNestedPass<hw::HWModuleOp>(createLowerLTLToCorePass());
   pm.addNestedPass<hw::HWModuleOp>(verif::createCombineAssertLikePass());
-  pm.addPass(createExternalizeRegisters());
   pm.addPass(createMaterializeDebugVariables());
+  pm.addPass(createExternalizeRegisters());
   LowerToBMCOptions lowerToBMCOptions;
   lowerToBMCOptions.bound = clockBound;
   lowerToBMCOptions.ignoreAssertionsUntil = ignoreAssertionsUntil;

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -16,6 +16,7 @@
 #include "circt/Conversion/SMTToZ3LLVM.h"
 #include "circt/Conversion/VerifToSMT.h"
 #include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/Debug/DebugDialect.h"
 #include "circt/Dialect/Emit/EmitDialect.h"
 #include "circt/Dialect/Emit/EmitPasses.h"
 #include "circt/Dialect/HW/HWDialect.h"
@@ -213,6 +214,7 @@ static LogicalResult executeBMC(MLIRContext &context) {
   pm.addNestedPass<hw::HWModuleOp>(createLowerLTLToCorePass());
   pm.addNestedPass<hw::HWModuleOp>(verif::createCombineAssertLikePass());
   pm.addPass(createExternalizeRegisters());
+  pm.addPass(createMaterializeDebugVariables());
   LowerToBMCOptions lowerToBMCOptions;
   lowerToBMCOptions.bound = clockBound;
   lowerToBMCOptions.ignoreAssertionsUntil = ignoreAssertionsUntil;
@@ -360,6 +362,7 @@ int main(int argc, char **argv) {
   // clang-format off
   registry.insert<
     circt::comb::CombDialect,
+    circt::debug::DebugDialect,
     circt::emit::EmitDialect,
     circt::hw::HWDialect,
     circt::om::OMDialect,


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->


This PR adds another pass before ExternalizeRegisters, to create dbg.variable anchors for input arguments that do not already have one.

The pass is registered and wired into the pipeline after `externalize-registers`.


Assisted-by: codex:gpt-5.3