### PR TITLE
[NFC] Missing requires line in circt-verilog test

### DIFF
--- a/test/circt-verilog/xslang.sv
+++ b/test/circt-verilog/xslang.sv
@@ -1,4 +1,4 @@
 // RUN: not circt-verilog %s -Xslang=--std=foo 2>&1 | FileCheck %s
 // RUN: circt-verilog %s -Xslang=--std=latest
-
+// REQUIRES: slang
 // CHECK: invalid value for --std option: 'foo'


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
