### PR TITLE
[circt-verilog] Fix failing CI check, NFC

### DIFF
--- a/test/circt-verilog/xslang.sv
+++ b/test/circt-verilog/xslang.sv
@@ -1,4 +1,5 @@
 // RUN: not circt-verilog %s -Xslang=--std=foo 2>&1 | FileCheck %s
 // RUN: circt-verilog %s -Xslang=--std=latest
 // REQUIRES: slang
+// UNSUPPORTED: valgrind
 // CHECK: invalid value for --std option: 'foo'


### PR DESCRIPTION
Fix CI failure introduced in: https://github.com/llvm/circt/pull/10290.
