### PR TITLE
[OM] Fix object field value is considered fully evaluated even it's not

### DIFF
--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -61,6 +61,14 @@ public:
   void markFullyEvaluated() {
     assert(!fullyEvaluated && "should not mark twice");
     fullyEvaluated = true;
+    // Increment the counter if one is set.
+    if (fullyEvaluatedCounter)
+      (*fullyEvaluatedCounter)++;
+  }
+
+  /// Set a counter to increment when this value becomes fully evaluated.
+  void setFullyEvaluatedCounter(uint64_t *counter) {
+    fullyEvaluatedCounter = counter;
   }
 
   /// Return true if the value is unknown (has unknown in its fan-in).
@@ -104,6 +112,7 @@ private:
   bool fullyEvaluated = false;
   bool finalized = false;
   bool unknown = false;
+  uint64_t *fullyEvaluatedCounter = nullptr;
 };
 
 /// Values which can be used as pointers to different values.
@@ -393,6 +402,9 @@ public:
 
   using ObjectKey = std::pair<Value, ActualParameters>;
 
+  /// Get the number of fully evaluated nodes tracked by this evaluator.
+  uint64_t getFullyEvaluatedCount() const { return fullyEvaluatedCount; }
+
 private:
   bool isFullyEvaluated(Value value, ActualParameters key) {
     return isFullyEvaluated({value, key});
@@ -401,6 +413,12 @@ private:
   bool isFullyEvaluated(ObjectKey key) {
     auto val = objects.lookup(key);
     return val && val->isFullyEvaluated();
+  }
+
+  /// Attach the evaluation counter to a newly created value.
+  void attachCounter(evaluator::EvaluatorValuePtr &value) {
+    if (value && !value->isFullyEvaluated())
+      value->setFullyEvaluatedCounter(&fullyEvaluatedCount);
   }
 
   FailureOr<EvaluatorValuePtr>
@@ -478,8 +496,11 @@ private:
       std::unique_ptr<SmallVector<std::shared_ptr<evaluator::EvaluatorValue>>>>
       actualParametersBuffers;
 
-  /// A worklist that tracks values which needs to be fully evaluated.
-  std::queue<ObjectKey> worklist;
+  /// Worklists that track values which need to be fully evaluated.
+  /// We use two worklists to detect cycles: process all items from one,
+  /// and if any become fully evaluated, swap and continue.
+  std::vector<ObjectKey> worklist;
+  std::vector<ObjectKey> nextWorklist;
 
   /// A queue of pending property assertions to be evaluated after the worklist
   /// is fully drained. Each entry is a (PropertyAssertOp, ActualParameters)
@@ -491,6 +512,9 @@ private:
   /// Evaluator value storage. Return an evaluator value for the given
   /// instantiation context (a pair of Value and parameters).
   DenseMap<ObjectKey, std::shared_ptr<evaluator::EvaluatorValue>> objects;
+
+  /// Counter for fully evaluated nodes.
+  uint64_t fullyEvaluatedCount = 0;
 
 #ifndef NDEBUG
   /// Current nesting depth for debug output indentation.

--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -63,7 +63,7 @@ public:
     fullyEvaluated = true;
     // Increment the counter if one is set.
     if (fullyEvaluatedCounter)
-      (*fullyEvaluatedCounter)++;
+      ++(*fullyEvaluatedCounter);
   }
 
   /// Set a counter to increment when this value becomes fully evaluated.

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -70,32 +70,38 @@ FailureOr<evaluator::EvaluatorValuePtr>
 circt::om::Evaluator::getPartiallyEvaluatedValue(Type type, Location loc) {
   using namespace circt::om::evaluator;
 
-  return TypeSwitch<mlir::Type, FailureOr<evaluator::EvaluatorValuePtr>>(type)
-      .Case([&](circt::om::ListType type) {
-        evaluator::EvaluatorValuePtr result =
-            std::make_shared<evaluator::ListValue>(type, loc);
-        return success(result);
-      })
-      .Case([&](circt::om::ClassType type)
-                -> FailureOr<evaluator::EvaluatorValuePtr> {
-        auto classDef =
-            symbolTable.lookup<ClassLike>(type.getClassName().getValue());
-        if (!classDef)
-          return symbolTable.getOp()->emitError("unknown class name ")
-                 << type.getClassName();
+  auto result =
+      TypeSwitch<mlir::Type, FailureOr<evaluator::EvaluatorValuePtr>>(type)
+          .Case([&](circt::om::ListType type) {
+            evaluator::EvaluatorValuePtr result =
+                std::make_shared<evaluator::ListValue>(type, loc);
+            return success(result);
+          })
+          .Case([&](circt::om::ClassType type)
+                    -> FailureOr<evaluator::EvaluatorValuePtr> {
+            auto classDef =
+                symbolTable.lookup<ClassLike>(type.getClassName().getValue());
+            if (!classDef)
+              return symbolTable.getOp()->emitError("unknown class name ")
+                     << type.getClassName();
 
-        // Create an ObjectValue for both ClassOp and ClassExternOp
-        evaluator::EvaluatorValuePtr result =
-            std::make_shared<evaluator::ObjectValue>(classDef, loc);
+            // Create an ObjectValue for both ClassOp and ClassExternOp
+            evaluator::EvaluatorValuePtr result =
+                std::make_shared<evaluator::ObjectValue>(classDef, loc);
 
-        return success(result);
-      })
-      .Case([&](circt::om::StringType type) {
-        evaluator::EvaluatorValuePtr result =
-            evaluator::AttributeValue::get(type, loc);
-        return success(result);
-      })
-      .Default([&](auto type) { return failure(); });
+            return success(result);
+          })
+          .Case([&](circt::om::StringType type) {
+            evaluator::EvaluatorValuePtr result =
+                evaluator::AttributeValue::get(type, loc);
+            return success(result);
+          })
+          .Default([&](auto type) { return failure(); });
+
+  if (succeeded(result))
+    attachCounter(result.value());
+
+  return result;
 }
 
 FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
@@ -186,6 +192,8 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
   if (failed(result))
     return result;
 
+  // Attach listener to newly created values
+  attachCounter(result.value());
   objects[{value, actualParams}] = result.value();
   return result;
 }
@@ -212,6 +220,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
   if (isa<ClassExternOp>(classDef)) {
     evaluator::EvaluatorValuePtr result =
         std::make_shared<evaluator::ObjectValue>(classDef, loc);
+    attachCounter(result);
     result->markUnknown();
     LLVM_DEBUG(dbgs(1) << "extern: <unknown-value>\n");
     return result;
@@ -283,7 +292,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
                                     UnknownLoc::get(context))))
           return failure();
         // Add to the worklist.
-        worklist.push({result, actualParams});
+        worklist.push_back({result, actualParams});
       }
   }
 
@@ -329,6 +338,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
   // If it's external call, just allocate new ObjectValue.
   evaluator::EvaluatorValuePtr result =
       std::make_shared<evaluator::ObjectValue>(cls, fields, loc);
+  // Note: Object is already fully evaluated when created with fields
   return result;
 }
 
@@ -355,6 +365,7 @@ circt::om::Evaluator::instantiate(
     evaluator::EvaluatorValuePtr result =
         std::make_shared<evaluator::ObjectValue>(
             classDef, UnknownLoc::get(classDef.getContext()));
+    attachCounter(result);
     result->markUnknown();
     LLVM_DEBUG(dbgs(1) << "result: <unknown extern>\n");
     return result;
@@ -380,18 +391,48 @@ circt::om::Evaluator::instantiate(
   // `evaluateObjectInstance` has populated the worklist. Continue evaluations
   // unless there is a partially evaluated value.
   LLVM_DEBUG(dbgs() << "worklist:\n");
+
+  // Use two-worklist approach: process all items from current worklist,
+  // and if at least one becomes fully evaluated, swap and continue.
+  // If a full pass completes with no progress, we have a cycle.
   while (!worklist.empty()) {
-    auto [value, args] = worklist.front();
-    worklist.pop();
+    uint64_t countBeforePass = fullyEvaluatedCount;
+    LLVM_DEBUG(dbgs() << "- processing " << worklist.size()
+                      << " items (fully evaluated count: "
+                      << fullyEvaluatedCount << ")\n");
 
-    auto result = evaluateValue(value, args, loc);
+    // Process all items in the current worklist
+    while (!worklist.empty()) {
+      auto [value, args] = worklist.back();
+      worklist.pop_back();
+      auto result = evaluateValue(value, args, loc);
 
-    if (failed(result))
-      return failure();
+      if (failed(result))
+        return failure();
 
-    // It's possible that the value is not fully evaluated.
-    if (!result.value()->isFullyEvaluated())
-      worklist.push({value, args});
+      // If not fully evaluated, add to next worklist for retry
+      if (!result.value()->isFullyEvaluated()) {
+        nextWorklist.push_back({value, args});
+      }
+    }
+
+    // Check if we made progress
+    uint64_t evaluatedThisPass = fullyEvaluatedCount - countBeforePass;
+    LLVM_DEBUG(dbgs() << "- evaluated " << evaluatedThisPass
+                      << " nodes this pass\n");
+
+    // If nothing became fully evaluated in this pass, we have a cycle
+    if (evaluatedThisPass == 0 && !nextWorklist.empty()) {
+      return cls.emitError()
+             << "cycle detected: " << nextWorklist.size()
+             << " values remain partially evaluated after full pass with no "
+                "progress (total fully evaluated: "
+             << fullyEvaluatedCount << ")";
+    }
+
+    // Swap worklists for next iteration
+    worklist = std::move(nextWorklist);
+    nextWorklist.clear();
   }
 
   // Now that all values are fully resolved, evaluate the deferred property
@@ -732,6 +773,9 @@ circt::om::Evaluator::evaluateObjectField(ObjectFieldOp op,
       currentObject = nextObject;
   }
 
+  if (!finalField->isFullyEvaluated())
+    return objectFieldValue;
+
   // Update the reference.
   llvm::cast<evaluator::ReferenceValue>(objectFieldValue.get())
       ->setValue(finalField);
@@ -1045,8 +1089,10 @@ circt::om::Evaluator::createUnknownValue(Type type, Location loc) {
           });
 
   // Mark the result as unknown if successful
-  if (succeeded(result))
+  if (succeeded(result)) {
+    attachCounter(result.value());
     result->get()->markUnknown();
+  }
 
   return result;
 }

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -338,7 +338,9 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
   // If it's external call, just allocate new ObjectValue.
   evaluator::EvaluatorValuePtr result =
       std::make_shared<evaluator::ObjectValue>(cls, fields, loc);
-  // Note: Object is already fully evaluated when created with fields
+  // Object is already fully evaluated when created with fields.
+  assert(result->isFullyEvaluated() &&
+         "object with fields should be fully evaluated");
   return result;
 }
 
@@ -392,16 +394,16 @@ circt::om::Evaluator::instantiate(
   // unless there is a partially evaluated value.
   LLVM_DEBUG(dbgs() << "worklist:\n");
 
-  // Use two-worklist approach: process all items from current worklist,
-  // and if at least one becomes fully evaluated, swap and continue.
-  // If a full pass completes with no progress, we have a cycle.
+  // Use two-worklist approach: process all items from current worklist, and if
+  // at least one becomes fully evaluated, swap and continue. If a full pass
+  // completes with no progress, we have a cycle.
   while (!worklist.empty()) {
     uint64_t countBeforePass = fullyEvaluatedCount;
     LLVM_DEBUG(dbgs() << "- processing " << worklist.size()
                       << " items (fully evaluated count: "
                       << fullyEvaluatedCount << ")\n");
 
-    // Process all items in the current worklist
+    // Process all items in the current worklist.
     while (!worklist.empty()) {
       auto [value, args] = worklist.back();
       worklist.pop_back();
@@ -410,27 +412,25 @@ circt::om::Evaluator::instantiate(
       if (failed(result))
         return failure();
 
-      // If not fully evaluated, add to next worklist for retry
-      if (!result.value()->isFullyEvaluated()) {
+      // If not fully evaluated, add to next worklist for retry.
+      if (!result.value()->isFullyEvaluated())
         nextWorklist.push_back({value, args});
-      }
     }
 
-    // Check if we made progress
+    // Check if we made progress.
     uint64_t evaluatedThisPass = fullyEvaluatedCount - countBeforePass;
     LLVM_DEBUG(dbgs() << "- evaluated " << evaluatedThisPass
                       << " nodes this pass\n");
 
-    // If nothing became fully evaluated in this pass, we have a cycle
-    if (evaluatedThisPass == 0 && !nextWorklist.empty()) {
+    // If nothing became fully evaluated in this pass, we have a cycle.
+    if (evaluatedThisPass == 0 && !nextWorklist.empty())
       return cls.emitError()
              << "cycle detected: " << nextWorklist.size()
              << " values remain partially evaluated after full pass with no "
                 "progress (total fully evaluated: "
              << fullyEvaluatedCount << ")";
-    }
 
-    // Swap worklists for next iteration
+    // Swap worklists for next iteration.
     worklist = std::move(nextWorklist);
     nextWorklist.clear();
   }
@@ -1088,11 +1088,9 @@ circt::om::Evaluator::createUnknownValue(Type type, Location loc) {
             return success(AttributeValue::get(type, LocationAttr(loc)));
           });
 
-  // Mark the result as unknown if successful
-  if (succeeded(result)) {
-    attachCounter(result.value());
+  // Mark the result as unknown if successful.
+  if (succeeded(result))
     result->get()->markUnknown();
-  }
 
   return result;
 }

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -670,9 +670,8 @@ om.class @ReferenceEachOther() -> (field: !ty){
   ASSERT_TRUE(failed(result));
 }
 
-// Test for issue #10264 - nested object field references that previously
-// caused an assertion failure. This test verifies that the evaluator can
-// properly handle nested field accesses without hitting null pointers.
+// Test nested object field references.
+// https://github.com/llvm/circt/issues/10264
 TEST(EvaluatorTests, Issue10264NestedFieldReferences) {
   StringRef mod = R"MLIR(
 om.class @Domain(%in: !om.string) -> (out: !om.string) {

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -654,8 +654,9 @@ om.class @ReferenceEachOther() -> (field: !ty){
   context.getOrLoadDialect<OMDialect>();
 
   context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
-    ASSERT_EQ(diag.str(), "failed to finalize evaluation. Probably the class "
-                          "contains a dataflow cycle");
+    ASSERT_EQ(diag.str(),
+              "cycle detected: 1 values remain partially evaluated after full "
+              "pass with no progress (total fully evaluated: 1)");
   });
 
   OwningOpRef<ModuleOp> owning =
@@ -667,6 +668,51 @@ om.class @ReferenceEachOther() -> (field: !ty){
       StringAttr::get(&context, "ReferenceEachOther"), {});
 
   ASSERT_TRUE(failed(result));
+}
+
+// Test for issue #10264 - nested object field references that previously
+// caused an assertion failure. This test verifies that the evaluator can
+// properly handle nested field accesses without hitting null pointers.
+TEST(EvaluatorTests, Issue10264NestedFieldReferences) {
+  StringRef mod = R"MLIR(
+om.class @Domain(%in: !om.string) -> (out: !om.string) {
+  om.class.fields %in : !om.string
+}
+
+om.class @Top() -> (test: i1) {
+  %0 = om.constant "A" : !om.string
+  %1 = om.object @Domain(%0) : (!om.string) -> !om.class.type<@Domain>
+  %2 = om.object.field %1, [@out] : (!om.class.type<@Domain>) -> !om.string
+  %3 = om.object @Domain(%2) : (!om.string) -> !om.class.type<@Domain>
+  %4 = om.object.field %3, [@out] : (!om.class.type<@Domain>) -> !om.string
+  %5 = om.constant "B" : !om.string
+  %6 = om.prop.eq %4, %5 : !om.string
+  om.class.fields %6 : i1
+}
+)MLIR";
+
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  OwningOpRef<ModuleOp> owning =
+      parseSourceString<ModuleOp>(mod, ParserConfig(&context));
+
+  Evaluator evaluator(owning.release());
+
+  auto result = evaluator.instantiate(StringAttr::get(&context, "Top"), {});
+
+  ASSERT_TRUE(succeeded(result));
+
+  // Verify the result is correct (false since "A" != "B")
+  auto fieldValue = llvm::cast<evaluator::ObjectValue>(result.value().get())
+                        ->getField("test")
+                        .value();
+  auto boolValue = llvm::cast<evaluator::AttributeValue>(fieldValue.get())
+                       ->getAs<BoolAttr>();
+  ASSERT_FALSE(boolValue.getValue());
 }
 
 TEST(EvaluatorTests, IntegerBinaryArithmeticAdd) {


### PR DESCRIPTION
This fixes an issue that object field is considered as evaluated even when it's still pending. The fix itself was only:
```
if (!finalField->isFullyEvaluated())
    return objectFieldValue;
```

However this change forces a more proper cycle detection mechanism for dataflow cycle, so this PR also added a counter that tracks the number of fully evaluated values. I'm hoping to replace these fixes with more simpler solution that actually mutates the IR as mentioned in https://github.com/llvm/circt/pull/10265

Fixes #10264.

Assisted-by: Augment: claude-sonnet-4.5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
