### PR TITLE
[FIRRTL] Eliminate Implicit Truncation

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -163,21 +163,10 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     return;
   }
 
-  // The source must be extended or truncated.
-  if (dstWidth < srcWidth) {
-    // firrtl.tail always returns uint even for sint operands.
-    IntType tmpType =
-        type_cast<IntType>(dstType).getConstType(srcType.isConst());
-    bool isSignedDest = tmpType.isSigned();
-    if (isSignedDest)
-      tmpType =
-          UIntType::get(dstType.getContext(), dstWidth, srcType.isConst());
-    src = TailPrimOp::create(builder, tmpType, src, srcWidth - dstWidth);
-    // Insert the cast back to signed if needed.
-    if (isSignedDest)
-      src = AsSIntPrimOp::create(builder,
-                                 dstType.getConstType(tmpType.isConst()), src);
-  } else if (srcWidth < dstWidth) {
+  // The source can be extended if needed, but truncation is not allowed.
+  assert(dstWidth >= srcWidth &&
+         "implicit truncation is not allowed in connect operations");
+  if (srcWidth < dstWidth) {
     // Need to extend arg.
     src = PadPrimOp::create(builder, src, dstWidth);
   }
@@ -193,8 +182,10 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   if (dstType == src.getType() && dstType.isPassive() &&
       !dstType.hasUninferredWidth()) {
     MatchingConnectOp::create(builder, dst, src);
-  } else
+  } else {
+    assert(0 && "Shouldn't have to emit connect");
     ConnectOp::create(builder, dst, src);
+  }
 }
 
 IntegerAttr circt::firrtl::getIntAttr(Type type, const APInt &value) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4565,6 +4565,12 @@ ParseResult FIRStmtParser::parseConnect() {
     return emitError(loc, "cannot connect non-equivalent type ")
            << rhsType << " to " << lhsType;
 
+  // Check that the destination is at least as wide as the source. This rejects
+  // implicit truncation.
+  if (!isTypeLarger(lhsType, rhsType))
+    return emitError(loc, "destination ")
+           << lhsType << " is not as wide as the source " << rhsType;
+
   locationProcessor.setLoc(loc);
   emitConnect(builder, lhs, rhs);
   return success();
@@ -4763,6 +4769,13 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
   if (!areTypesEquivalent(lhsType, rhsType))
     return emitError(loc, "cannot connect non-equivalent type ")
            << rhsType << " to " << lhsType;
+
+  // Check that the destination is at least as wide as the source. This rejects
+  // implicit truncation.
+  if (!isTypeLarger(lhsType, rhsType))
+    return emitError(loc, "destination ")
+           << lhsType << " is not as wide as the source " << rhsType;
+
   emitConnect(builder, lhs, rhs);
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -2097,7 +2097,8 @@ FailureOr<bool> InferenceTypeUpdate::updateOperation(Operation *op) {
     auto lhsWidth = lhsType.getBitWidthOrSentinel();
     auto rhsWidth = rhsType.getBitWidthOrSentinel();
     if (lhsWidth >= 0 && rhsWidth >= 0 && lhsWidth < rhsWidth) {
-      con.emitOpError("destination ") << lhsType << " is not as wide as the source " << rhsType;
+      con.emitOpError("destination ")
+          << lhsType << " is not as wide as the source " << rhsType;
       return failure();
     }
     return anyChanged;

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1404,7 +1404,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         // dialect enforces the reset signal to be an async reset or a
         // `uint<1>`.
         declareVars(op.getResult());
-        // Contrain the register to be greater than or equal to the reset
+        // Constrain the register to be greater than or equal to the reset
         // signal.
         constrainTypes(op.getResult(), op.getResetValue());
       })

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -2082,8 +2082,8 @@ FailureOr<bool> InferenceTypeUpdate::updateOperation(Operation *op) {
   }
 
   // If this is a connect operation, width inference might have inferred a RHS
-  // that is wider than the LHS, in which case an additional BitsPrimOp is
-  // necessary to truncate the value.
+  // that is wider than the LHS. This is an error - implicit truncation is not
+  // allowed.
   if (auto con = dyn_cast<ConnectOp>(op)) {
     auto lhs = con.getDest();
     auto rhs = con.getSrc();
@@ -2097,16 +2097,8 @@ FailureOr<bool> InferenceTypeUpdate::updateOperation(Operation *op) {
     auto lhsWidth = lhsType.getBitWidthOrSentinel();
     auto rhsWidth = rhsType.getBitWidthOrSentinel();
     if (lhsWidth >= 0 && rhsWidth >= 0 && lhsWidth < rhsWidth) {
-      OpBuilder builder(op);
-      auto trunc = builder.createOrFold<TailPrimOp>(con.getLoc(), con.getSrc(),
-                                                    rhsWidth - lhsWidth);
-      if (type_isa<SIntType>(rhsType))
-        trunc =
-            builder.createOrFold<AsSIntPrimOp>(con.getLoc(), lhsType, trunc);
-
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Truncating RHS to " << lhsType << " in " << con << "\n");
-      con->replaceUsesOfWith(con.getSrc(), trunc);
+      con.emitOpError("destination ") << lhsType << " is not as wide as the source " << rhsType;
+      return failure();
     }
     return anyChanged;
   }

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -407,8 +407,9 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
 
     // If both widths are known and index is wider, insert explicit truncation
     if (addrWidth >= 0 && indexWidth >= 0 && indexWidth > addrWidth) {
-      indexValue = TailPrimOp::create(portBuilder, indexValue,
-                                       indexWidth - addrWidth).getResult();
+      indexValue =
+          TailPrimOp::create(portBuilder, indexValue, indexWidth - addrWidth)
+              .getResult();
     }
     emitConnect(portBuilder, address, indexValue);
     // Sequential+Read ports have a more complicated "enable inference".

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -378,6 +378,11 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
     auto cmemoryPort = cast<MemoryPortOp>(ports[i].cmemPort);
     auto cmemoryPortAccess = cmemoryPort.getAccess();
 
+    // If there's no access operation, skip this port
+    if (!cmemoryPortAccess) {
+      continue;
+    }
+
     // Most fields on the newly created memory will be assigned an initial value
     // immediately following the memory decl, and then will be assigned a second
     // value at the location of the CHIRRTL memory port.
@@ -393,7 +398,19 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
     emitInvalid(memBuilder, clock);
 
     // Initialization at the MemoryPortOp.
-    emitConnect(portBuilder, address, cmemoryPortAccess.getIndex());
+    // If the index is wider than the address port, we need to truncate it.
+    Value indexValue = cmemoryPortAccess.getIndex();
+    auto addrType = type_cast<FIRRTLBaseType>(address.getType());
+    auto indexType = type_cast<FIRRTLBaseType>(indexValue.getType());
+    auto addrWidth = addrType.getBitWidthOrSentinel();
+    auto indexWidth = indexType.getBitWidthOrSentinel();
+
+    // If both widths are known and index is wider, insert explicit truncation
+    if (addrWidth >= 0 && indexWidth >= 0 && indexWidth > addrWidth) {
+      indexValue = TailPrimOp::create(portBuilder, indexValue,
+                                       indexWidth - addrWidth).getResult();
+    }
+    emitConnect(portBuilder, address, indexValue);
     // Sequential+Read ports have a more complicated "enable inference".
     auto useEnableInference = isSequential && portKind == MemOp::PortKind::Read;
     auto *addressOp = cmemoryPortAccess.getIndex().getDefiningOp();

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -422,13 +422,13 @@ circuit Top11 : %[[
   ; CHECK: firrtl.module private @A(
   module A :
     input x: UInt<1>
-    output y: UInt<1>
+    output y: UInt<3>
     ; CHECK: firrtl.node {{.+}} {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "circt.test", data = "hello"}, {circt.nonlocal = @[[nlaSym2]], class = "circt.test", data = "hello"}]}
     node a = add(x, UInt(1))
     connect y, add(a, a)
   module A_ :
     input x: UInt<1>
-    output y: UInt<1>
+    output y: UInt<3>
     node b = add(x, UInt(1))
     connect y, add(b, b)
 

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -182,3 +182,30 @@ firrtl.circuit "MuxSelTooWide" {
     firrtl.connect %0, %c2_ui2 : !firrtl.uint, !firrtl.uint<2>
   }
 }
+
+// -----
+
+// Implicit truncation is not allowed in connect operations.
+firrtl.circuit "TruncateConnect" {
+  firrtl.module @TruncateConnect() {
+    %w = firrtl.wire  : !firrtl.uint
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    firrtl.connect %w, %c1_ui1 : !firrtl.uint, !firrtl.uint<1>
+    %w1 = firrtl.wire  : !firrtl.uint<0>
+    // expected-error @+1 {{destination '!firrtl.uint<0>' is not as wide as the source '!firrtl.uint<1>'}}
+    firrtl.connect %w1, %w : !firrtl.uint<0>, !firrtl.uint
+  }
+}
+
+// -----
+
+// Issue #1088 - Implicit truncation is not allowed.
+firrtl.circuit "Issue1088" {
+  firrtl.module @Issue1088(out %y: !firrtl.sint<4>) {
+    %x = firrtl.wire : !firrtl.sint
+    %c200_si = firrtl.constant 200 : !firrtl.sint
+    // expected-error @+1 {{destination '!firrtl.sint<4>' is not as wide as the source '!firrtl.sint<9>'}}
+    firrtl.connect %y, %x : !firrtl.sint<4>, !firrtl.sint
+    firrtl.connect %x, %c200_si : !firrtl.sint, !firrtl.sint
+  }
+}

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -468,33 +468,6 @@ firrtl.circuit "Foo" {
     firrtl.domain.define %B, %A : !firrtl.domain<@ClockDomain()>
   }
 
-  // Issue #1088
-  // CHECK-LABEL: @Issue1088
-  firrtl.module @Issue1088(out %y: !firrtl.sint<4>) {
-    // CHECK: %x = firrtl.wire : !firrtl.sint<9>
-    // CHECK: %c200_si9 = firrtl.constant 200 : !firrtl.sint<9>
-    // CHECK: %0 = firrtl.tail %x, 5 : (!firrtl.sint<9>) -> !firrtl.uint<4>
-    // CHECK: %1 = firrtl.asSInt %0 : (!firrtl.uint<4>) -> !firrtl.sint<4>
-    // CHECK: firrtl.connect %y, %1 : !firrtl.sint<4>
-    // CHECK: firrtl.connect %x, %c200_si9 : !firrtl.sint<9>
-    %x = firrtl.wire : !firrtl.sint
-    %c200_si = firrtl.constant 200 : !firrtl.sint
-    firrtl.connect %y, %x : !firrtl.sint<4>, !firrtl.sint
-    firrtl.connect %x, %c200_si : !firrtl.sint, !firrtl.sint
-  }
-
-  // Should truncate all the way to 0 bits if its has to.
-  // CHECK-LABEL: @TruncateConnect
-  firrtl.module @TruncateConnect() {
-    %w = firrtl.wire  : !firrtl.uint
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    firrtl.connect %w, %c1_ui1 : !firrtl.uint, !firrtl.uint<1>
-    %w1 = firrtl.wire  : !firrtl.uint<0>
-    // CHECK: %0 = firrtl.tail %w, 1 : (!firrtl.uint<1>) -> !firrtl.uint<0>
-    // CHECK: firrtl.connect %w1, %0 : !firrtl.uint<0>
-    firrtl.connect %w1, %w : !firrtl.uint<0>, !firrtl.uint
-  }
-
   // Issue #1110: Width inference should infer 0 width when appropriate
   // CHECK-LABEL: @Issue1110
   // CHECK-SAME: out %y: !firrtl.uint<0>

--- a/test/firtool/connect-errors.fir
+++ b/test/firtool/connect-errors.fir
@@ -1,4 +1,26 @@
-; RUN: firtool %s --format=fir --parse-only -verify-diagnostics
+; RUN: firtool %s --format=fir --parse-only --split-input-file -verify-diagnostics
+
+
+; Truncation is an error.
+FIRRTL version 4.0.0
+circuit truncatingIntegerConnect :
+ public module truncatingIntegerConnect :
+   output a: UInt<3>
+   input b: UInt<5>
+   ; expected-error @+1 {{destination '!firrtl.uint<3>' is not as wide as the source '!firrtl.uint<5>'}}
+   connect a, b
+
+; // -----
+
+FIRRTL version 4.0.0
+circuit truncatingBundleConnect :
+ public module truncatingBundleConnect :
+   output a: { a: UInt<5>, b: UInt<3> }
+   input b: { a: UInt<6>, b: UInt<1> }
+   ; expected-error @+1 {{destination '!firrtl.bundle<a: uint<5>, b: uint<3>>' is not as wide as the source '!firrtl.bundle<a: uint<6>, b: uint<1>>'}}
+   connect a, b
+
+; // -----
 
 ; CHECK-LABEL: outOfOrderFields
 FIRRTL version 4.0.0
@@ -6,5 +28,6 @@ circuit outOfOrderFields :
   public module outOfOrderFields :
     output a: { a: UInt<5>, b: UInt<3> }
     input b: { b: UInt<1>, a: UInt<6> }
-    ; expected-error@+1 {{cannot connect non-equivalent type '!firrtl.bundle<b: uint<1>, a: uint<6>>' to '!firrtl.bundle<a: uint<5>, b: uint<3>>'}}
+    ; expected-error @+1 {{cannot connect non-equivalent type '!firrtl.bundle<b: uint<1>, a: uint<6>>' to '!firrtl.bundle<a: uint<5>, b: uint<3>>'}}
     connect a, b
+

--- a/test/firtool/connect.fir
+++ b/test/firtool/connect.fir
@@ -1,27 +1,13 @@
 ; RUN: firtool %s --format=fir --parse-only --split-input-file | FileCheck %s
 
-; Ensure connect is demoted to partial connect in the presence of implicit truncation.
-
 ; CHECK-LABEL: @regularConnect
 ; CHECK: %0 = firrtl.pad %b, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
 ; CHECK: firrtl.matchingconnect %a, %0 : !firrtl.uint<5>
-FIRRTL version 4.0.0
+ FIRRTL version 4.0.0
 circuit regularConnect :
  public module regularConnect :
    output a: UInt<5>
    input b: UInt<3>
-   connect a, b
-
-; // -----
-
-; CHECK-LABEL: @truncatingIntegerConnect
-; CHECK: %0 = firrtl.tail %b, 2 : (!firrtl.uint<5>) -> !firrtl.uint<3>
-; CHECK: firrtl.matchingconnect %a, %0 : !firrtl.uint<3>
-FIRRTL version 4.0.0
-circuit truncatingIntegerConnect :
- public module truncatingIntegerConnect :
-   output a: UInt<3>
-   input b: UInt<5>
    connect a, b
 
 ; // -----
@@ -40,22 +26,4 @@ circuit regularBundleConnect :
  public module regularBundleConnect :
    output a: { a: UInt<5>, b: UInt<3> }
    input b: { a: UInt<3>, b: UInt<2> }
-   connect a, b
-
-; // -----
-
-; CHECK-LABEL: @truncatingBundleConnect
-; CHECK: %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<5>, b: uint<3>>
-; CHECK: %1 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<6>, b: uint<1>>
-; CHECK: %2 = firrtl.tail %1, 1 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; CHECK: firrtl.matchingconnect %0, %2 : !firrtl.uint<5>
-; CHECK: %3 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<5>, b: uint<3>>
-; CHECK: %4 = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<6>, b: uint<1>>
-; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<1>) -> !firrtl.uint<3>
-; CHECK: firrtl.matchingconnect %3, %5 : !firrtl.uint<3>
-FIRRTL version 4.0.0
-circuit truncatingBundleConnect :
- public module truncatingBundleConnect :
-   output a: { a: UInt<5>, b: UInt<3> }
-   input b: { a: UInt<6>, b: UInt<1> }
    connect a, b

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -34,7 +34,6 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
     input b: UInt<2>
     output c: UInt<1>
     input vec: V3
-    output out_implicitTrunc: UInt<1>
     output out_prettifyExample: UInt<1>
     output out_multibitMux: UInt<1>
     output out_mux2cell: V2
@@ -43,10 +42,6 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
     connect cat.a, b
     connect cat.b, b
     connect cat.c, b
-
-    inst implicitTrunc of ImplicitTrunc
-    connect implicitTrunc.inp_1, a
-    connect implicitTrunc.inp_2, asSInt(cat.d)
 
     inst prettifyExample of PrettifyExample
     connect prettifyExample.inp_1, cat.d
@@ -76,27 +71,19 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
     ;
     ; TODO: This test should be rewritten to not be so brittle around module
     ; port removal.
-    connect out_implicitTrunc, or(orr(implicitTrunc.out1), orr(implicitTrunc.out2))
     connect out_prettifyExample, or(orr(prettifyExample.out1), orr(prettifyExample.out2))
     connect out_multibitMux, multibitMux.b
 
 
-; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>, in %vec_0: !firrtl.uint<1>, in %vec_1: !firrtl.uint<1>, in %vec_2: !firrtl.uint<1>, out %out_implicitTrunc: !firrtl.uint<1>, out %out_prettifyExample: !firrtl.uint<1>, out %out_multibitMux: !firrtl.uint<1>, out %out_mux2cell_0: !firrtl.uint<1>, out %out_mux2cell_1: !firrtl.uint<1>) {{.*}}{
+; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>, in %vec_0: !firrtl.uint<1>, in %vec_1: !firrtl.uint<1>, in %vec_2: !firrtl.uint<1>, out %out_prettifyExample: !firrtl.uint<1>, out %out_multibitMux: !firrtl.uint<1>, out %out_mux2cell_0: !firrtl.uint<1>, out %out_mux2cell_1: !firrtl.uint<1>) {{.*}}{
 ; MLIR:         %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
 ; MLIR-NEXT:    firrtl.matchingconnect %cat_a, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.matchingconnect %cat_b, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.matchingconnect %cat_c, %b : !firrtl.uint<2>
-; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
-; MLIR-NEXT:    firrtl.matchingconnect %implicitTrunc_inp_1, %a : !firrtl.uint<1>
-; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : (!firrtl.uint<6>) -> !firrtl.sint<6>
-; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : (!firrtl.sint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    %2 = firrtl.asSInt %1 : (!firrtl.uint<5>) -> !firrtl.sint<5>
-; MLIR-NEXT:    firrtl.matchingconnect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>
-; MLIR:         %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
-; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_1, %3 : !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_2, %3 : !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_3, %3 : !firrtl.uint<5>
+; MLIR:         %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<6>, in inp_2: !firrtl.uint<6>, in inp_3: !firrtl.uint<6>, out out1: !firrtl.uint<12>, out out2: !firrtl.uint<12>)
+; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_1, %cat_d : !firrtl.uint<6>
+; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_2, %cat_d : !firrtl.uint<6>
+; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_3, %cat_d : !firrtl.uint<6>
 ; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
 ; MLIR-NEXT:    firrtl.matchingconnect %flipFlop_clock, %clock : !firrtl.clock
 ; MLIR-NEXT:    firrtl.matchingconnect %flipFlop_a_d, %a : !firrtl.uint<1>
@@ -121,17 +108,14 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 ; VERILOG-NEXT:    input vec_0,
 ; VERILOG-NEXT:          vec_1,
 ; VERILOG-NEXT:          vec_2,
-; VERILOG-NEXT:    output       out_implicitTrunc,
-; VERILOG-NEXT:                 out_prettifyExample,
+; VERILOG-NEXT:    output       out_prettifyExample,
 ; VERILOG-NEXT:                 out_multibitMux,
 ; VERILOG-NEXT:                 out_mux2cell_0,
 ; VERILOG-NEXT:                 out_mux2cell_1
 ; VERILOG-NEXT:    );
 ; VERILOG-EMPTY:
-; VERILOG-NEXT:    wire [9:0] _prettifyExample_out1;
-; VERILOG-NEXT:    wire [9:0] _prettifyExample_out2;
-; VERILOG-NEXT:    wire [2:0] _implicitTrunc_out1;
-; VERILOG-NEXT:    wire [2:0] _implicitTrunc_out2;
+; VERILOG-NEXT:    wire [11:0] _prettifyExample_out1;
+; VERILOG-NEXT:    wire [11:0] _prettifyExample_out2;
 ; VERILOG-NEXT:    wire [5:0] _cat_d;
 ; VERILOG-NEXT:    Cat cat (
 ; VERILOG-NEXT:      .a (b),
@@ -139,16 +123,10 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 ; VERILOG-NEXT:      .c (b),
 ; VERILOG-NEXT:      .d (_cat_d)
 ; VERILOG-NEXT:    );
-; VERILOG-NEXT:    ImplicitTrunc implicitTrunc (
-; VERILOG-NEXT:      .inp_1 (a),
-; VERILOG-NEXT:      .inp_2 (_cat_d[4:0]),
-; VERILOG-NEXT:      .out1  (_implicitTrunc_out1),
-; VERILOG-NEXT:      .out2  (_implicitTrunc_out2)
-; VERILOG-NEXT:    );
 ; VERILOG-NEXT:    PrettifyExample prettifyExample (
-; VERILOG-NEXT:      .inp_1 (_cat_d[4:0]),
-; VERILOG-NEXT:      .inp_2 (_cat_d[4:0]),
-; VERILOG-NEXT:      .inp_3 (_cat_d[4:0]),
+; VERILOG-NEXT:      .inp_1 (_cat_d),
+; VERILOG-NEXT:      .inp_2 (_cat_d),
+; VERILOG-NEXT:      .inp_3 (_cat_d),
 ; VERILOG-NEXT:      .out1  (_prettifyExample_out1),
 ; VERILOG-NEXT:      .out2  (_prettifyExample_out2)
 ; VERILOG-NEXT:    );
@@ -181,48 +159,14 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 ; MLIRLOWER-NEXT:  }
 
 
-; Check that implicit truncation is working.
-
-  module ImplicitTrunc :
-    input inp_1: UInt<1>
-    input inp_2: SInt<5>
-    output out1: SInt<3>
-    output out2: SInt<3>
-    connect out1, dshl(inp_2, inp_1)
-    connect out2, inp_2
-
-; MLIRLOWER-LABEL: hw.module private @ImplicitTrunc(in %inp_1 : i1, in %inp_2 : i5, out out1 : i3, out out2 : i3) {
-; MLIRLOWER-NEXT:    %c0_i5 = hw.constant 0 : i5
-; MLIRLOWER-NEXT:    %0 = comb.extract %inp_2 from 4 : (i5) -> i1
-; MLIRLOWER-NEXT:    %1 = comb.concat %0, %inp_2 : i1, i5
-; MLIRLOWER-NEXT:    %2 = comb.concat %c0_i5, %inp_1 : i5, i1
-; MLIRLOWER-NEXT:    %3 = comb.shl bin %1, %2 : i6
-; MLIRLOWER-NEXT:    %4 = comb.extract %3 from 0 : (i6) -> i3
-; MLIRLOWER-NEXT:    %5 = comb.extract %inp_2 from 0 : (i5) -> i3
-; MLIRLOWER-NEXT:    hw.output %4, %5 : i3, i3
-; MLIRLOWER-NEXT:  }
-
-; VERILOG-LABEL: module ImplicitTrunc(
-; VERILOG-NEXT:   input        inp_1,
-; VERILOG-NEXT:   input  [4:0] inp_2,
-; VERILOG-NEXT:   output [2:0] out1,
-; VERILOG-NEXT:                out2
-; VERILOG-NEXT:   );
-; VERILOG-EMPTY:
-; VERILOG-NEXT:   wire [5:0] _GEN = {inp_2[4], inp_2} << inp_1;
-; VERILOG-NEXT:   assign out1 = _GEN[2:0];
-; VERILOG-NEXT:   assign out2 = inp_2[2:0];
-; VERILOG-NEXT: endmodule
-
-
 ; Check that we prettify the IR before Verilog emission.
 
   module PrettifyExample :
-    input inp_1: UInt<5>
-    input inp_2: UInt<5>
-    input inp_3: UInt<5>
-    output out1: UInt<10>
-    output out2: UInt<10>
+    input inp_1: UInt<6>
+    input inp_2: UInt<6>
+    input inp_3: UInt<6>
+    output out1: UInt<12>
+    output out2: UInt<12>
     connect out1, cat(not(inp_1), inp_2)
     connect out2, cat(not(inp_1), inp_3)
 

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -9,7 +9,7 @@ circuit test:
     input rEn: UInt<1>
     output rData: UInt<8>
     input wMask: UInt<1>
-    input wData: UInt<8>
+    input wData: UInt<1>
 
     mem tbMemoryKind1:
       data-type => UInt<1>
@@ -40,7 +40,7 @@ circuit test:
     input rEn: UInt<1>
     output rData: UInt<8>
     input wMask: UInt<1>
-    input wData: UInt<8>
+    input wData: UInt<2>
 
     mem dutMemory:
       data-type => UInt<2>
@@ -70,7 +70,7 @@ circuit test:
     input rEn: UInt<1>
     output rData: UInt<8>
     input wMask: UInt<1>
-    input wData: UInt<8>
+    input wData: UInt<3>
 
     mem tbMemoryKind1:
       data-type => UInt<3>
@@ -101,7 +101,7 @@ circuit test:
     input rEn: UInt<1>
     output rData: UInt<8>
     input wMask: UInt<1>
-    input wData: UInt<8>
+    input wData: UInt<1>
 
 
     inst m of tbMemModule1
@@ -118,7 +118,7 @@ circuit test:
     input rEn: UInt<1>
     output rData: UInt<8>[3]
     input wMask: UInt<1>
-    input wData: UInt<8>
+    input wData: UInt<1>
 
 
     inst h1 of hier1
@@ -156,7 +156,7 @@ circuit test:
     input rEn: UInt<1>
     output rData: UInt<8>
     input wMask: UInt<1>
-    input wData: UInt<8>
+    input wData: UInt<2>
 
 
     inst m of dutModule2

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -37,7 +37,7 @@ circuit Foo : %[[
     output readData : UInt<32>
     input writeEn : UInt<1>
     input writeAddr : UInt<3>
-    input writeData : UInt<32>
+    input writeData : UInt<1>
 
     ; REPL-FIR:     firrtl.instance mem sym @{{[^ ]+}} {annotations = [{circt.nonlocal = @memHier, class = "circt.tracker", id = distinct[0]<>}]} @prefix1_mem
     ; REPL-HW:      hw.instance "mem" sym @{{[^ ]+}} @prefix1_mem
@@ -82,7 +82,7 @@ circuit Foo : %[[
     output readData : UInt<32>
     input writeEn : UInt<1>
     input writeAddr : UInt<3>
-    input writeData : UInt<32>
+    input writeData : UInt<2>
 
     ; REPL-FIR:     firrtl.module private @Baz
     ; REPL-FIR-NEXT:     firrtl.instance mem sym @sym {annotations = [{circt.nonlocal = @memHier_0, class = "circt.tracker", id = distinct[1]<>}]} @prefix2_mem
@@ -124,7 +124,7 @@ circuit Foo : %[[
     output readData : UInt<32>
     input writeEn : UInt<1>
     input writeAddr : UInt<3>
-    input writeData : UInt<32>
+    input writeData : UInt<1>
 
     inst bar of Bar
     connect bar.clock, clock

--- a/test/firtool/spec/refs/force_and_release.fir
+++ b/test/firtool/spec/refs/force_and_release.fir
@@ -7,7 +7,7 @@ circuit ForceAndRelease:
     input a: UInt<2>
     input clock : Clock
     input cond : UInt<1>
-    output o : UInt<3>
+    output o : UInt<4>
 
     inst r of AddRefs
     connect o, r.sum
@@ -21,7 +21,7 @@ circuit ForceAndRelease:
     output a : RWProbe<UInt<2>>
     output b : RWProbe<UInt<2>>
     output c : RWProbe<UInt<2>>
-    output sum : UInt<3>
+    output sum : UInt<4>
 
     ; XXX: modified, workaround inability create non-const node w/literal initializer.
     wire w : UInt<2>

--- a/test/firtool/spec/refs/force_initial.fir
+++ b/test/firtool/spec/refs/force_initial.fir
@@ -5,7 +5,7 @@ FIRRTL version 3.0.0
 circuit ForceAndRelease:
   ; SPEC EXAMPLE BEGIN
   module ForceAndRelease:
-    output o : UInt<3>
+    output o : UInt<4>
 
     inst r of AddRefs
     connect o, r.sum
@@ -22,7 +22,7 @@ circuit ForceAndRelease:
     output a : RWProbe<UInt<2>>
     output b : RWProbe<UInt<2>>
     output c : RWProbe<UInt<2>>
-    output sum : UInt<3>
+    output sum : UInt<4>
 
     ; XXX: modified, workaround inability create non-const node w/literal initializer.
     wire w : UInt<2>


### PR DESCRIPTION
Eliminate implicit truncations from FIRRTL.  This changes connects, InferWidths, and parsing.

Assisted-by: Augment:Sonet-4.5
