### PR TITLE
[circt-test] Print empty JSON array when listing tests on empty input

### DIFF
--- a/test/circt-test/json-empty-filtered.mlir
+++ b/test/circt-test/json-empty-filtered.mlir
@@ -1,0 +1,5 @@
+// RUN: circt-test -l --json -x 'MyTest' %s 2>/dev/null | FileCheck %s
+
+// CHECK: []
+
+verif.formal @MyTest {} {}

--- a/test/circt-test/json-empty.mlir
+++ b/test/circt-test/json-empty.mlir
@@ -1,0 +1,7 @@
+// RUN: circt-test -l %s 2>&1 | FileCheck %s --check-prefix=NO-JSON
+// RUN: circt-test -l --json %s | FileCheck %s --check-prefix=EMPTY-JSON
+
+// NO-JSON: no tests discovered
+// EMPTY-JSON: []
+
+builtin.module {}

--- a/tools/circt-test/circt-test.cpp
+++ b/tools/circt-test/circt-test.cpp
@@ -1260,21 +1260,21 @@ static LogicalResult executeWithHandler(MLIRContext *context,
   TestSuite suite(context, opts.listIgnored);
   if (failed(suite.discoverInModule(*module)))
     return failure();
-  if (suite.tests.empty()) {
+  if (suite.tests.empty())
     llvm::errs() << "no tests discovered\n";
-    return success();
-  }
 
-  // Apply filters.
-  applyFilters(suite, includeFilters, excludeFilters);
-  if (suite.tests.empty()) {
-    llvm::errs() << "all tests excluded by filters\n";
-    return success();
+  if (!suite.tests.empty()) {
+    // Apply filters.
+    applyFilters(suite, includeFilters, excludeFilters);
+    if (suite.tests.empty())
+      llvm::errs() << "all tests excluded by filters\n";
   }
 
   // List all tests in the input and exit if requested.
   if (opts.listTests)
     return listTests(suite);
+  if (suite.tests.empty())
+    return success();
   llvm::errs() << "running " << suite.tests.size() << " tests\n";
 
   // Create the output directory where we keep all the run data.


### PR DESCRIPTION
While passing `--json -l` to circt-test with an empty input file, print an empty array [ ] instead of the "no tests discovered"
This fixes #10262 .

also added a test which covers both the fix and existing behavior, `--json -l` on an empty file now prints [ ], and  `-l` without `--json` still prints "no tests discovered" as before.