### PR TITLE
Handle alternate form of empty action block.

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -909,7 +909,7 @@ struct StmtVisitor {
       return failure();
 
     // Handle assertion statements that don't have an action block.
-    if (stmt.ifTrue && stmt.ifTrue->as_if<slang::ast::EmptyStatement>()) {
+    if (!stmt.ifTrue || stmt.ifTrue->as_if<slang::ast::EmptyStatement>()) {
       switch (stmt.assertionKind) {
       case slang::ast::AssertionKind::Assert:
         verif::AssertOp::create(builder, loc, property, enable, StringAttr{});

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -2552,6 +2552,22 @@ module ImmediateAssertiWithActionBlock;
   assert (x) a = 1; else a = 0;
 endmodule
 
+// CHECK-LABEL: moore.module @AssertNoActionBlock
+module AssertNoActionBlock(input clk_i, input rst_ni, input eret_o);
+  typedef struct packed {
+    logic valid;
+  } ex_t;
+  ex_t ex_i;
+
+  // CHECK: %[[ENABLE:[0-9]+]] = moore.to_builtin_int %{{[0-9]+}} : i1
+  // CHECK: %[[PROP:[0-9]+]] = moore.to_builtin_int %{{[0-9]+}} : i1
+  // CHECK: %[[CLK_READ:[0-9]+]] = moore.read %clk_i_0 : <l1>
+  // CHECK: %[[CLK_I1:[0-9]+]] = moore.to_builtin_int %{{[0-9]+}} : i1
+  // CHECK: %[[CLOCK_OP:[0-9]+]] = ltl.clock %[[PROP]], posedge %[[CLK_I1]] : i1
+  // CHECK: verif.assert %[[CLOCK_OP]] if %[[ENABLE]] : !ltl.sequence
+  assert property (@(posedge clk_i) disable iff (!rst_ni !== '0) !(eret_o && ex_i.valid));
+endmodule
+
 // CHECK-LABEL: moore.module @ConcurrentAssert(in %clk : !moore.l1)
 module ConcurrentAssert(input clk);
   // CHECK: [[CLK:%.+]] = moore.net name "clk" wire : <l1>


### PR DESCRIPTION
If the action block is elided entirely, slang can also return a null statement. Treat a null same as an EmptyStatement here.

Unit test extracted from instance in sv_test.
