### PR TITLE
[CI] Add extra_cmake_args option to UBTI and enable LLVM_ENABLE_REVERSE_ITERATION

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -225,6 +225,7 @@ jobs:
       install_target: ${{ matrix.generated.install_target }}
       package_name_prefix: ${{ matrix.generated.package_name_prefix }}
       cmake_c_compiler: ${{ matrix.generated.cmake_c_compiler }}
+      extra_cmake_args: ${{ matrix.generated.extra_cmake_args }}
 
   # --- end of build-circt job.
 

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -56,3 +56,4 @@ jobs:
       package_name_prefix: ""
       cmake_c_compiler: ${{ matrix.compiler }}
       valgrind: ${{ matrix.valgrind }}
+      extra_cmake_args: ""

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -100,6 +100,11 @@ on:
         required: false
         type: boolean
         default: false
+      extra_cmake_args:
+        description: "Extra CMake arguments to pass to the configuration step"
+        required: false
+        type: string
+        default: ""
   workflow_call:
     inputs:
       runner:
@@ -141,6 +146,11 @@ on:
         required: false
         type: boolean
         default: false
+      extra_cmake_args:
+        description: "Extra CMake arguments to pass to the configuration step"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-test-and-install:
@@ -160,11 +170,15 @@ jobs:
           echo "cmake_c_compiler=${INPUT_COMPILER,,}" >> $GITHUB_OUTPUT
           echo "build_shared_libs=$(on_off "${INPUT_SHARED}")" >> $GITHUB_OUTPUT
           echo "llvm_enable_assertions=$(on_off "${INPUT_ASSERTIONS}")" >> $GITHUB_OUTPUT
+          # Hash extra cmake args for cache key (use first 8 chars of sha256)
+          EXTRA_CMAKE_HASH=$(echo -n "${INPUT_EXTRA_CMAKE}" | sha256sum | cut -c1-8)
+          echo "extra_cmake_hash=$EXTRA_CMAKE_HASH" >> $GITHUB_OUTPUT
         env:
           INPUT_BUILD_TYPE: ${{ inputs.cmake_build_type }}
           INPUT_COMPILER: ${{ inputs.cmake_c_compiler }}
           INPUT_SHARED: ${{ inputs.build_shared_libs }}
           INPUT_ASSERTIONS: ${{ inputs.llvm_enable_assertions }}
+          INPUT_EXTRA_CMAKE: ${{ inputs.extra_cmake_args }}
       - name: Clone llvm/circt
         uses: actions/checkout@v3
         with:
@@ -304,7 +318,7 @@ jobs:
         if: steps.canonicalize.outputs.cmake_build_type == 'release'
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ inputs.runner }}-${{ steps.canonicalize.outputs.cmake_c_compiler }}-${{ steps.canonicalize.outputs.cmake_build_type }}-${{ steps.canonicalize.outputs.build_shared_libs }}-${{ steps.canonicalize.outputs.llvm_enable_assertions }}
+          key: ${{ inputs.runner }}-${{ steps.canonicalize.outputs.cmake_c_compiler }}-${{ steps.canonicalize.outputs.cmake_build_type }}-${{ steps.canonicalize.outputs.build_shared_libs }}-${{ steps.canonicalize.outputs.llvm_enable_assertions }}-${{ steps.canonicalize.outputs.extra_cmake_hash }}
           max-size: 500M
           variant: sccache
           save: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
@@ -350,7 +364,7 @@ jobs:
 
           # Run cmake.  Use one long line for `cmake` so that this works on
           # Linux/macOS AND Windows.
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=ON -DLLVM_ENABLE_ZSTD=OFF -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ steps.set-cmake-options.outputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ steps.set-cmake-options.outputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="${{ steps.set-cmake-options.outputs.llvm_lit_args }}" ${{ steps.setup-linux.outputs.cmake }} ${{ steps.setup-macos.outputs.cmake }} ${{ steps.setup-windows.outputs.cmake }} ${{ steps.integration-test-setup-generic.outputs.cmake }}
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=ON -DLLVM_ENABLE_ZSTD=OFF -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ steps.set-cmake-options.outputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ steps.set-cmake-options.outputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DLLVM_LIT_ARGS="${{ steps.set-cmake-options.outputs.llvm_lit_args }}" ${{ steps.setup-linux.outputs.cmake }} ${{ steps.setup-macos.outputs.cmake }} ${{ steps.setup-windows.outputs.cmake }} ${{ steps.integration-test-setup-generic.outputs.cmake }} ${{ inputs.extra_cmake_args }}
 # Optionally test
       - name: Test CIRCT
         if: inputs.run_tests


### PR DESCRIPTION
Adds the extra_cmake_args input to unifiedBuildTestAndInstall.yml and enables 
`LLVM_ENABLE_REVERSE_ITERATION=ON` for Linux (Clang) Test builds.  
Integration test is clean yet https://github.com/llvm/circt/issues/10299 so it's tested on clang matrix that doesn't integration test. 

This allows injecting arbitrary CMake arguments without adding dedicated fields for every flag (h/t @seldridge for this approach). 

I think it's acceptable to check in pre-merge CI as it doesn't affect build times. The first 8 bits of the extra_cmake_args hash are used as the ccache key.

Close https://github.com/llvm/circt/issues/5660. 

Assisted-by: Augment: Sonnet 4.5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
