### PR TITLE
[domaintool] Switch to relationship ClockDomains

### DIFF
--- a/test/Tools/domaintool/clock-spec-json.mlir
+++ b/test/Tools/domaintool/clock-spec-json.mlir
@@ -1,17 +1,20 @@
-// RUN: domaintool --module Foo --domain ClockDomain,A,"" --domain ClockDomain,B,"" --assign 0 --assign 1 %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
-// RUN: domaintool --module Foo --domain ClockDomain,A,"" --domain ClockDomain,B,"" --assign 0 --assign 1 --sifive-clock-domain-async=A %s | FileCheck %s --check-prefixes=CHECK,ASYNC
-// RUN: domaintool --module Foo --domain ClockDomain,A,"" --domain ClockDomain,B,"" --assign 0 --assign 1 --sifive-clock-domain-static=A %s | FileCheck %s --check-prefixes=CHECK,STATIC
-// RUN: domaintool --module Foo --domain ClockDomain,A,"" --domain ClockDomain,B,A --assign 0 --assign 1 %s | FileCheck %s --check-prefixes=CHECK,SYNC
+// RUN: domaintool --module Foo --domain ClockDomain,A,A,synchronous --domain ClockDomain,B,B,synchronous --assign 0 --assign 1 %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
+// RUN: domaintool --module Foo --domain ClockDomain,A,A,synchronous --domain ClockDomain,B,B,synchronous --assign 0 --assign 1 --sifive-clock-domain-async=A %s | FileCheck %s --check-prefixes=CHECK,ASYNC
+// RUN: domaintool --module Foo --domain ClockDomain,A,A,synchronous --domain ClockDomain,B,B,synchronous --assign 0 --assign 1 --sifive-clock-domain-static=A %s | FileCheck %s --check-prefixes=CHECK,STATIC
+// RUN: domaintool --module Foo --domain ClockDomain,A,A,synchronous --domain ClockDomain,B,A,synchronous --assign 0 --assign 1 %s | FileCheck %s --check-prefixes=CHECK,SYNC
+// RUN: domaintool --module Foo --domain ClockDomain,A,A,synchronous --domain ClockDomain,B,A,rational --assign 0 --assign 1 %s | FileCheck %s --check-prefixes=CHECK,RATIONAL
 
 om.class @ClockDomain(
   %basepath: !om.frozenbasepath,
   %name_in: !om.string,
-  %synchronousTo_in: !om.string
+  %source_in: !om.string,
+  %relationship_in: !om.string
 )  -> (
   name_out: !om.string,
-  synchronousTo_out: !om.string
+  source_out: !om.string,
+  relationship_out: !om.string
 ) {
-  om.class.fields %name_in, %synchronousTo_in : !om.string, !om.string
+  om.class.fields %name_in, %source_in, %relationship_in : !om.string, !om.string, !om.string
 }
 
 om.class @ClockDomain_out(
@@ -99,6 +102,23 @@ om.class @Foo_Class(
 // SYNC-NEXT:          ]
 // SYNC-NEXT:        }
 // SYNC-NEXT:      ],
+// RATIONAL-NEXT:  "clocks": [
+// RATIONAL-NEXT:    {
+// RATIONAL-NEXT:      "name_pattern": "A",
+// RATIONAL-NEXT:      "define_period": "A_PERIOD",
+// RATIONAL-NEXT:      "clock_relationships": []
+// RATIONAL-NEXT:    },
+// RATIONAL-NEXT:    {
+// RATIONAL-NEXT:      "name_pattern": "B",
+// RATIONAL-NEXT:      "define_period": "B_PERIOD",
+// RATIONAL-NEXT:      "clock_relationships": [
+// RATIONAL-NEXT:        {
+// RATIONAL-NEXT:          "name_pattern": "A",
+// RATIONAL-NEXT:          "relationship": "sync"
+// RATIONAL-NEXT:        }
+// RATIONAL-NEXT:      ]
+// RATIONAL-NEXT:    }
+// RATIONAL-NEXT:  ],
 //
 // DEFAULT-NEXT:   "static_ports": [],
 // ASYNC-NEXT:     "static_ports": [],
@@ -107,6 +127,7 @@ om.class @Foo_Class(
 // STATIC-NEXT:      "b"
 // STATIC-NEXT:    ],
 // SYNC-NEXT:      "static_ports": [],
+// RATIONAL-NEXT:  "static_ports": [],
 //
 // DEFAULT-NEXT:   "asynchronous_ports": [],
 // ASYNC-NEXT:     "asynchronous_ports": [
@@ -115,6 +136,7 @@ om.class @Foo_Class(
 // ASYNC-NEXT:     ],
 // STATIC-NEXT:    "asynchronous_ports": [],
 // SYNC-NEXT:      "asynchronous_ports": [],
+// RATIONAL-NEXT:  "asynchronous_ports": [],
 //
 // DEFAULT-NEXT:   "synchronous_ports": [
 // DEFAULT-NEXT:     {
@@ -172,5 +194,23 @@ om.class @Foo_Class(
 // SYNC-NEXT:          "comment": null
 // SYNC-NEXT:        }
 // SYNC-NEXT:      ]
+// RATIONAL-NEXT:  "synchronous_ports": [
+// RATIONAL-NEXT:    {
+// RATIONAL-NEXT:      "name_pattern": "A",
+// RATIONAL-NEXT:      "port_patterns": [
+// RATIONAL-NEXT:        "a",
+// RATIONAL-NEXT:        "b"
+// RATIONAL-NEXT:      ],
+// RATIONAL-NEXT:      "comment": null
+// RATIONAL-NEXT:    },
+// RATIONAL-NEXT:    {
+// RATIONAL-NEXT:      "name_pattern": "B",
+// RATIONAL-NEXT:      "port_patterns": [
+// RATIONAL-NEXT:        "a",
+// RATIONAL-NEXT:        "b"
+// RATIONAL-NEXT:      ],
+// RATIONAL-NEXT:      "comment": null
+// RATIONAL-NEXT:    }
+// RATIONAL-NEXT:  ]
 //
 // CHECK-NEXT:   }

--- a/tools/domaintool/ClockSpecJSONHandler.cpp
+++ b/tools/domaintool/ClockSpecJSONHandler.cpp
@@ -43,7 +43,18 @@ cl::list<std::string> sifiveClockDomainStatic{
 namespace circt {
 namespace handlers {
 
-enum class RelationshipKind { Sync, Async, Inferred };
+/// The kind of relationship between two clock domains.
+enum class RelationshipKind {
+  /// A synchronous relationship (integer frequency ratio, same source).
+  Synchronous,
+  /// A rational relationship (non-integer rational frequency ratio, same
+  /// source).
+  Rational,
+  /// An asynchronous relationship (no deterministic phase relationship).
+  Async,
+  /// Relationship is not yet determined.
+  Inferred
+};
 
 struct Relationship {
   StringAttr namePattern;
@@ -84,17 +95,33 @@ public:
                                        objectValue->getField("name_out")->get())
                                        ->getAttr());
 
-      // Insert this domain into its own equivalence class.  Then, if this has a
-      // specified "synchronousTo" relationship to a different domain, merge
-      // this domain into that different domain.
+      // Insert this domain into its own equivalence class.  Then, if this
+      // domain specifies a "source" relationship (either synchronous or
+      // rational), merge it into the same equivalence class as its source.
       syncEquivalenceClasses.insert(name);
-      auto synchronousTo = cast<StringAttr>(
-          cast<om::evaluator::AttributeValue>(
-              objectValue->getField("synchronousTo_out")->get())
-              ->getAttr());
-      if (!synchronousTo.getValue().empty()) {
-        syncEquivalenceClasses.insert(synchronousTo);
-        syncEquivalenceClasses.unionSets(synchronousTo, name);
+
+      auto source =
+          cast<StringAttr>(cast<om::evaluator::AttributeValue>(
+                               objectValue->getField("source_out")->get())
+                               ->getAttr());
+      auto relationship =
+          cast<StringAttr>(cast<om::evaluator::AttributeValue>(
+                               objectValue->getField("relationship_out")->get())
+                               ->getAttr());
+
+      // Track the relationship kind for this domain.
+      RelationshipKind kind = RelationshipKind::Inferred;
+      if (relationship.getValue() == "synchronous")
+        kind = RelationshipKind::Synchronous;
+      else if (relationship.getValue() == "rational")
+        kind = RelationshipKind::Rational;
+
+      // If this domain specifies a source, merge it into that source's
+      // equivalence class and record the relationship.
+      if (!source.getValue().empty()) {
+        syncEquivalenceClasses.insert(source);
+        syncEquivalenceClasses.unionSets(source, name);
+        domainRelationships[name] = {source, kind};
       }
 
       // Add to async ports if the name matches a provided option.
@@ -179,6 +206,9 @@ public:
               for (auto &rel : clock.relationships) {
                 json.object([&] {
                   json.attribute("name_pattern", rel.namePattern.getValue());
+                  // Both synchronous and rational are treated as "sync" in the
+                  // output JSON.  They both imply a deterministic, bounded
+                  // frequency relationship derived from a common source.
                   json.attribute("relationship", "sync");
                 });
               }
@@ -219,12 +249,14 @@ public:
     asyncPorts.clear();
     staticPorts.clear();
     syncPorts.clear();
+    domainRelationships.clear();
     syncEquivalenceClasses = EquivalenceClasses<StringAttr>();
   };
 
 private:
   /// Populate clock relationships based on equivalence class leaders.  If a
-  /// domain's leader is not itself, it has a sync relationship to the leader.
+  /// domain's leader is not itself, it has a sync (or rational, treated the
+  /// same in output) relationship to the leader.
   void populateClockRelationships() {
     for (auto &clock : clocks) {
       auto &name = clock.namePattern;
@@ -236,9 +268,16 @@ private:
 
       StringAttr leader = *leaderIter;
 
-      // If this domain is not the leader, add a sync relationship to the leader
-      if (name != leader)
-        clock.relationships.push_back({leader, RelationshipKind::Sync});
+      // If this domain is not the leader, add a relationship to the leader.
+      // Look up the recorded relationship kind for this domain and fall back to
+      // Synchronous if no explicit entry exists.
+      if (name != leader) {
+        RelationshipKind kind = RelationshipKind::Synchronous;
+        auto it = domainRelationships.find(name);
+        if (it != domainRelationships.end())
+          kind = it->second.relationship;
+        clock.relationships.push_back({leader, kind});
+      }
     }
   }
 
@@ -247,9 +286,15 @@ private:
   SmallVector<StringAttr> staticPorts;
   MapVector<StringAttr, SynchronousData> syncPorts;
 
-  // Equivalence classes tracking all domains that are synchronous to each other
-  // through the transitive closure of synchronousTo relationships.  The leader
-  // of each equivalence class represents the root synchronous domain.
+  /// Map from a domain name to its recorded source relationship (source name +
+  /// kind).  Populated during handle() when a domain declares a non-empty
+  /// source.
+  DenseMap<StringAttr, Relationship> domainRelationships;
+
+  // Equivalence classes tracking all domains that are related to each other
+  // (synchronous or rational) through the transitive closure of source
+  // relationships.  The leader of each equivalence class represents the root
+  // domain.
   EquivalenceClasses<StringAttr> syncEquivalenceClasses;
 };
 


### PR DESCRIPTION
Update `domaintool` to handle the new schema for Clock Domains [[1]].
This removes the "synchronousTo" field and replaces it with two fields:
(1): a "source" field tracking the root, source clock and (2) a
"relationship" field which can take on a value of "synchronous" or
"rational".

The clock spec JSON handler presently treats rational the same as
synchronous.

[1]: https://github.com/chipsalliance/chisel/pull/5270

Assisted-by: OpenCode:claude-sonnet-4-6
