### PR TITLE
[ImportVerilog] Add support for $isunknown.

### DIFF
--- a/docs/Dialects/LTL.md
+++ b/docs/Dialects/LTL.md
@@ -225,10 +225,21 @@ where the `logic_to_int` conversion is only necessary if `%cond` is 4-valued.
 %1 = seq.shiftreg n, %a, %clk, %true, powerOn %zero : i1
 ``` 
 
+- **`$isunknown(a)`**:
+```mlir
+// For 1-bit 'a'
+%x = moore.constant 1'bx : <l1>
+%isunknown = moore.case_eq %a, %x : i1
+
+// For multi-bit 'a'
+%reduced = moore.reduce_xor %a : <l1>
+%x = moore.constant 1'bx : <l1>
+%isunknown = moore.case_eq %reduced, %x : i1
+```
+
 > The following functions are not yet supported by CIRCT:  
 > - **`$onehot(a)`**  
 > - **`$onehot0(a)`**  
-> - **`$isunknown(a)`**  
 > - **`$countones(a)`**     
   
   

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -8,9 +8,6 @@
 
 #include "slang/ast/expressions/AssertionExpr.h"
 
-#include <optional>
-#include <utility>
-
 #include "ImportVerilogInternals.h"
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/Comb/CombOps.h"
@@ -22,6 +19,9 @@
 #include "mlir/Support/LLVM.h"
 #include "slang/ast/SystemSubroutine.h"
 #include "slang/parsing/KnownSystemName.h"
+
+#include <optional>
+#include <utility>
 
 using namespace circt;
 using namespace ImportVerilog;

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -7,18 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 #include "slang/ast/expressions/AssertionExpr.h"
+
+#include <optional>
+#include <utility>
+
 #include "ImportVerilogInternals.h"
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/LTL/LTLOps.h"
 #include "circt/Dialect/Moore/MooreOps.h"
+#include "circt/Support/FVInt.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Support/LLVM.h"
 #include "slang/ast/SystemSubroutine.h"
-
-#include <optional>
-#include <utility>
+#include "slang/parsing/KnownSystemName.h"
 
 using namespace circt;
 using namespace ImportVerilog;
@@ -378,6 +381,25 @@ Value Context::convertAssertionCallExpression(
       mlir::emitError(loc) << "expected integer argument for `"
                            << subroutine.name << "`";
       return {};
+    }
+
+    // IsUnknown is handled here rather than below with the others as below it
+    // would have already been converted to an integer type rather than bool
+    // type as here.
+    if (subroutine.knownNameId == slang::parsing::KnownSystemName::IsUnknown) {
+      Value bitVal = value;
+      if (valTy.getWidth() > 1) {
+        auto mooreI1Type =
+            moore::IntType::get(getContext(), 1, valTy.getDomain());
+        bitVal = moore::ReduceXorOp::create(builder, loc, mooreI1Type, value);
+      }
+
+      auto xType =
+          moore::IntType::get(getContext(), 1, moore::Domain::FourValued);
+      auto xValue = FVInt::getAllX(1);
+      auto xConst = moore::ConstantOp::create(builder, loc, xType, xValue);
+
+      return moore::CaseEqOp::create(builder, loc, bitVal, xConst).getResult();
     }
 
     // If the value is four-valued, we need to map it to two-valued before we

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2010,6 +2010,7 @@ struct RvalueExprVisitor : public ExprVisitor {
     case ksn::Changed:
     case ksn::Past:
     case ksn::Sampled:
+    case ksn::IsUnknown:
       return context.convertAssertionCallExpression(expr, info, loc);
     default:
       break;

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -542,6 +542,15 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[D1]], [[PAST_LOGIC]] : l8 -> l1
   past_data: assert property (@(posedge clk_i) data_i == $past(data_i));
 
+  // CHECK: moore.procedure always {
+  // CHECK: [[D:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK: [[RED:%.+]] = moore.reduce_xor [[D]] : l8 -> l1
+  // CHECK: [[X:%.+]] = moore.constant bX : l1
+  // CHECK: [[CEQ:%.+]] = moore.case_eq [[RED]], [[X]] : l1
+  // CHECK: [[CEQ_I1:%.+]] = moore.to_builtin_int [[CEQ]] : i1
+  // CHECK: ltl.clock [[CEQ_I1]]
+  isunknown_data: assert property (@(posedge clk_i) $isunknown(data_i));
+
 endmodule
 
 // CHECK-LABEL: func.func private @StringBuiltins(


### PR DESCRIPTION
Mostly following #9634. But we can't handle it the same as the others, as we need it with Moore types rather than integer ones. So add the logic higher/before conversion to int types.

Assisted-by: Antigravity:Gemini
