### PR TITLE
[Support] Add SparseOpSCC utility

### DIFF
--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -13,8 +13,8 @@
 // -----------
 // Each operation is a node.  A directed edge runs from op A to op B if B uses
 // one of A's results.  The traversal direction is configurable:
-//   - OpSCCDirection::Reachable -- follow edges forward (defining op -> users).
-//   - OpSCCDirection::Reaching  -- follow edges backward (user -> defining op).
+//   - OpSCCDirection::Forward   -- follow edges from defining ops to uses.
+//   - OpSCCDirection::Backward  -- follow edges from uses to defining op.
 //
 // SCC classification
 // ------------------
@@ -29,10 +29,10 @@
 // An optional OpSCCFilter predicate can be supplied to the constructor to
 // prevent the traversal over certain edges of the graph. The first argument
 // contains the operation into which the traversal would lead. The second
-// argument contains the edge's destination operand.
-// For "reachable" (forward) traversal the operand's owner is identical to the
-// first argument. For "reaching" (reverse) traversal the first argument is
-// identical to the operand's defining operation.
+// argument contains the edge's destination operand. For forward traversal
+// the operand's owner is identical to the first argument. For reverse
+// traversal the first argument is identical to the operand's defining
+// operation.
 //
 // Output ordering
 // ---------------
@@ -54,9 +54,11 @@
 // Collect all ops reachable from seedOp, excluding register ops, and process
 // them in topological order:
 //
-//   auto regFilter = [](Operation *op, OpOperand&) { return
-//   !isa<seq::FirRegOp>(op); }; SparseOpSCC<OpSCCDirection::Reachable>
-//   sccs(regFilter); sccs.visit(seedOp);
+//   auto regFilter = [](Operation *op, OpOperand&) {
+//     return !isa<seq::FirRegOp>(op);
+//   };
+//   SparseOpSCC<OpSCCDirection::Forward> sccs(regFilter);
+//   sccs.visit(seedOp);
 //
 //   for (OpSCC entry : sccs.topological()) {
 //     if (Operation *op = llvm::dyn_cast<mlir::Operation *>(entry)) {
@@ -160,9 +162,9 @@ namespace circt {
 using OpSCC = llvm::PointerUnion<mlir::Operation *, CyclicOpSCC>;
 
 /// Traversal direction for SparseOpSCC.
-///   - Reachable: follow def-use edges forward (defining op -> users).
-///   - Reaching:  follow def-use edges backward (user -> defining op).
-enum class OpSCCDirection { Reachable, Reaching };
+///   - Forward: follow def-use edges forward (defining op -> users).
+///   - Backward:  follow def-use edges backward (user -> defining op).
+enum class OpSCCDirection { Forward, Backward };
 
 template <OpSCCDirection, unsigned>
 class SparseOpSCC;
@@ -262,7 +264,7 @@ public:
 
   // NOLINTNEXTLINE(readability-identifier-naming)
   auto topological_begin() const {
-    if constexpr (Direction == OpSCCDirection::Reaching)
+    if constexpr (Direction == OpSCCDirection::Backward)
       return detail::OpSCCIterator<typename decltype(sccs)::const_iterator>(
           sccs.begin(), cyclicSccs);
     else
@@ -273,7 +275,7 @@ public:
 
   // NOLINTNEXTLINE(readability-identifier-naming)
   auto topological_end() const {
-    if constexpr (Direction == OpSCCDirection::Reaching)
+    if constexpr (Direction == OpSCCDirection::Backward)
       return detail::OpSCCIterator<typename decltype(sccs)::const_iterator>(
           sccs.end(), cyclicSccs);
     else
@@ -290,7 +292,7 @@ public:
 
   // NOLINTNEXTLINE(readability-identifier-naming)
   auto reverseTopological_begin() const {
-    if constexpr (Direction == OpSCCDirection::Reachable)
+    if constexpr (Direction == OpSCCDirection::Forward)
       return detail::OpSCCIterator<typename decltype(sccs)::const_iterator>(
           sccs.begin(), cyclicSccs);
     else
@@ -301,7 +303,7 @@ public:
 
   // NOLINTNEXTLINE(readability-identifier-naming)
   auto reverseTopological_end() const {
-    if constexpr (Direction == OpSCCDirection::Reachable)
+    if constexpr (Direction == OpSCCDirection::Forward)
       return detail::OpSCCIterator<typename decltype(sccs)::const_iterator>(
           sccs.end(), cyclicSccs);
     else
@@ -357,7 +359,7 @@ private:
     }
   };
 
-  using FrameT = std::conditional_t<Direction == OpSCCDirection::Reachable,
+  using FrameT = std::conditional_t<Direction == OpSCCDirection::Forward,
                                     ForwardFrame, InverseFrame>;
 
   static bool hasSelfLoop(mlir::Operation *op) {

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -115,15 +115,6 @@ namespace circt {
 /// first argument; for backward traversal its defining op equals the first
 /// argument.
 using OpSCCFilter = std::function<bool(mlir::Operation *, mlir::OpOperand &)>;
-
-/// Sentinel type representing "no SCC" in an OpSCC PointerUnion.
-struct NullOpSCC {
-  void *getAsVoidPointer() const { return nullptr; }
-  static NullOpSCC getFromVoidPointer(void *) { return NullOpSCC{}; }
-  static constexpr int NumLowBitsAvailable =
-      llvm::PointerLikeTypeTraits<mlir::Operation *>::NumLowBitsAvailable;
-};
-
 namespace detail {
 /// Backing storage for a cyclic SCC (implementation detail).
 using CyclicOpSCCStorage = llvm::SmallVector<mlir::Operation *, 4>;
@@ -170,18 +161,6 @@ private:
 
 namespace llvm {
 template <>
-struct PointerLikeTypeTraits<circt::NullOpSCC> {
-  static void *getAsVoidPointer(circt::NullOpSCC) { return nullptr; }
-  static circt::NullOpSCC getFromVoidPointer(void *ptr) {
-    (void)ptr;
-    assert(ptr == nullptr);
-    return circt::NullOpSCC{};
-  }
-  static constexpr int NumLowBitsAvailable =
-      circt::NullOpSCC::NumLowBitsAvailable;
-};
-
-template <>
 struct PointerLikeTypeTraits<circt::CyclicOpSCC> {
   static void *getAsVoidPointer(circt::CyclicOpSCC scc) {
     return scc.getAsVoidPointer();
@@ -198,12 +177,11 @@ namespace circt {
 
 /// One entry in the SCC output: a null sentinel, a trivial (non-cyclic)
 /// operation, or a cyclic group.  Use llvm::isa / llvm::cast / llvm::dyn_cast
-/// to distinguish.  The null state (isa<NullOpSCC>) is returned by getSCC()
-/// when the queried operation has not been discovered.
-/// Note: NullOpSCC must be placed first in the union so that the all-zero
-/// (default-constructed) state identifies unambiguously as NullOpSCC, not as a
+/// to distinguish.
+/// Note: void * must be placed first in the union so that the all-zero
+/// (default-constructed) state identifies unambiguously as invalid, not as a
 /// null Operation*.
-using OpSCC = llvm::PointerUnion<NullOpSCC, mlir::Operation *, CyclicOpSCC>;
+using OpSCC = llvm::PointerUnion<void *, mlir::Operation *, CyclicOpSCC>;
 
 /// Traversal direction for SparseOpSCC.
 ///   - Forward: follow def-use edges forward (defining op -> users).
@@ -292,12 +270,12 @@ public:
     return opToSccIndex.contains(op);
   }
 
-  /// Return the SCC that `op` belongs to, or an OpSCC holding NullOpSCC if it
-  /// has not been discovered.
+  /// Return the SCC that `op` belongs to. If the operation has not been
+  /// discovered, it returns a `nullptr` sentinel.
   OpSCC getSCC(mlir::Operation *op) const {
     auto it = opToSccIndex.find(op);
     if (it == opToSccIndex.end())
-      return OpSCC(NullOpSCC{});
+      return OpSCC(nullptr);
     detail::OpOrIndex entry = sccs[it->second];
     if (llvm::isa<mlir::Operation *>(entry))
       return OpSCC(llvm::cast<mlir::Operation *>(entry));

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -40,6 +40,15 @@
 // sources first, leaves last) via topological(), and in the reverse via
 // reverseTopological().
 //
+// Operation Graph Mutation
+// ------------------------
+// The SparseOpSCC class internally stores the result of the SCC analysis
+// and is only updated when visit(...) is called. It is not recommended
+// to mutate the IR between visit calls. Calling visit invalidates all
+// iterators. It is safe to mutate the IR while iterating. To reflect the
+// changes in the analysis, reset() must be called and the graph must be
+// re-visited.
+//
 // Usage example
 // -------------
 // Collect all ops reachable from seedOp, excluding register ops, and process
@@ -204,7 +213,8 @@ private:
 /// treated as if it did not exist in the graph.
 ///
 /// Iterators obtained from topological() and reverseTopological() hold a
-/// reference into this object and invalidated by calling visit() or reset().
+/// reference into this object and are invalidated by calling visit() or
+//  reset().
 template <OpSCCDirection Direction, unsigned NumInlineElts = 32>
 class SparseOpSCC {
 public:

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -171,7 +171,9 @@ namespace llvm {
 template <>
 struct PointerLikeTypeTraits<circt::NullOpSCC> {
   static void *getAsVoidPointer(circt::NullOpSCC) { return nullptr; }
-  static circt::NullOpSCC getFromVoidPointer(void *) {
+  static circt::NullOpSCC getFromVoidPointer(void *ptr) {
+    (void)ptr;
+    assert(ptr == nullptr);
     return circt::NullOpSCC{};
   }
   static constexpr int NumLowBitsAvailable =
@@ -248,8 +250,8 @@ private:
 /// accumulate across multiple visit() calls, so the visited subgraph can be
 /// expanded incrementally.
 ///
-/// The optional filter passed to the constructor is applied to every candidate
-/// operation before it is visited.  An operation that fails the filter is
+/// The optional filter passed to the constructor is applied to every
+/// discovered edge before it is traversed. An edge that fails the filter is
 /// treated as if it did not exist in the graph.
 ///
 /// Iterators obtained from topological() and reverseTopological() hold a
@@ -420,7 +422,6 @@ private:
   }
 
   void tarjanImpl(mlir::Operation *startOp) {
-    // All state below is local to this DFS and discarded when the call returns.
     unsigned nextIdx = 0;
     llvm::SmallDenseMap<mlir::Operation *, std::pair<unsigned, unsigned>>
         idxAndLowLinkMap;
@@ -468,10 +469,15 @@ private:
           sccOps.push_back(sccStack.pop_back_val());
         } while (sccOps.back() != op);
 
+        // Store the SCC index of the discovered ops
         unsigned sccIdx = sccs.size();
-        for (auto *sccOp : sccOps)
-          opToSccIndex[sccOp] = sccIdx;
+        for (auto *sccOp : sccOps) {
+          bool inserted = opToSccIndex.insert({sccOp, sccIdx}).second;
+          (void)inserted;
+          assert(inserted && "Unexpectedly revisited node");
+        }
 
+        // Insert the pointers into the persistent storage
         if (sccOps.size() == 1 && !hasSelfLoop(sccOps.front())) {
           sccs.push_back(detail::OpOrIndex(sccOps.front()));
         } else {
@@ -483,11 +489,10 @@ private:
       }
 
       // Not an SCC root — back-propagate lowlink to the parent frame.
-      if (!dfsStack.empty()) {
-        auto &parentLowLink = idxAndLowLinkMap.at(dfsStack.back().op).second;
-        parentLowLink = std::min(parentLowLink, opLowLink);
-      }
+      auto &parentLowLink = idxAndLowLinkMap.at(dfsStack.back().op).second;
+      parentLowLink = std::min(parentLowLink, opLowLink);
     }
+    assert(sccStack.empty());
   }
 
   /// Optional edge filter supplied at construction time.

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -26,9 +26,13 @@
 //
 // Filtering
 // ---------
-// An optional OpSCCFilter predicate can be supplied to the constructor.  Any
-// operation for which the predicate returns false is excluded from the graph:
-// It is neither visited nor followed as a neighbour.
+// An optional OpSCCFilter predicate can be supplied to the constructor to
+// prevent the traversal over certain edges of the graph. The first argument
+// contains the operation into which the traversal would lead. The second
+// argument contains the edge's destination operand.
+// For "reachable" (forward) traversal the operand's owner is identical to the
+// first argument. For "reaching" (reverse) traversal the first argument is
+// identical to the operand's defining operation.
 //
 // Output ordering
 // ---------------
@@ -41,9 +45,9 @@
 // Collect all ops reachable from seedOp, excluding register ops, and process
 // them in topological order:
 //
-//   auto filter = [](Operation *op) { return !isa<seq::FirRegOp>(op); };
-//   SparseOpSCC<OpSCCDirection::Reachable> sccs(filter);
-//   sccs.visit(seedOp);
+//   auto regFilter = [](Operation *op, OpOperand&) { return
+//   !isa<seq::FirRegOp>(op); }; SparseOpSCC<OpSCCDirection::Reachable>
+//   sccs(regFilter); sccs.visit(seedOp);
 //
 //   for (OpSCC entry : sccs.topological()) {
 //     if (Operation *op = llvm::dyn_cast<mlir::Operation *>(entry)) {
@@ -55,6 +59,15 @@
 //         processInCycle(op);
 //     }
 //   }
+//
+// Alternative filter that traverses registers through their clock and reset
+// values but not the "next" data values:
+//
+//   auto regEdgeFilter = [](Operation*, OpOperand& operand) {
+//     if (auto regOp = dyn_cast<seq::FirRegOp>(operand.getOwner()))
+//       return operand != regOp.getNextMutable();
+//     return true;
+//   };
 //
 //===----------------------------------------------------------------------===//
 
@@ -74,8 +87,9 @@
 namespace circt {
 
 /// Filter predicate passed to the SCC collection functions.  Return `true` to
-/// include an operation in the traversal, `false` to skip it.
-using OpSCCFilter = llvm::function_ref<bool(mlir::Operation *)>;
+/// include an edge in the traversal, `false` to skip it.
+using OpSCCFilter =
+    llvm::function_ref<bool(mlir::Operation *, mlir::OpOperand &)>;
 
 namespace detail {
 /// Backing storage for a cyclic SCC (implementation detail).
@@ -194,7 +208,8 @@ private:
 template <OpSCCDirection Direction, unsigned NumInlineElts = 32>
 class SparseOpSCC {
 public:
-  explicit SparseOpSCC(OpSCCFilter filter = {}) : filter(filter) {}
+  explicit SparseOpSCC(OpSCCFilter shouldTraverseFn = {})
+      : shouldTraverseFn(shouldTraverseFn) {}
 
   /// Clear all accumulated state.
   void reset() {
@@ -206,11 +221,10 @@ public:
     nextIdx = 0;
   }
 
-  /// Visit `op` if it passes the filter and has not been visited yet.
+  /// Visit `op` if it passes the shouldTraverseFn and has not been visited yet.
   void visit(mlir::Operation *op) {
-    if (shouldVisit(op))
-      if (!indexAndLowLinkMap.contains(op))
-        tarjanImpl(op);
+    if (!indexAndLowLinkMap.contains(op))
+      tarjanImpl(op);
   }
 
   /// Visit each operation in `ops`, skipping already-visited or filtered ones.
@@ -291,21 +305,25 @@ private:
   struct ForwardFrame {
     mlir::Operation *op;
     unsigned resultIdx;
-    std::optional<mlir::Value::user_iterator> userIt;
+    std::optional<mlir::Value::use_iterator> useIt;
 
     explicit ForwardFrame(mlir::Operation *op) : op(op), resultIdx(0) {
       if (op->getNumResults() > 0)
-        userIt = op->getResult(0).user_begin();
+        useIt = op->getResult(0).use_begin();
     }
 
-    mlir::Operation *nextChild() {
+    mlir::Operation *nextChild(OpSCCFilter shouldTraverseFn) {
       while (resultIdx < op->getNumResults()) {
-        auto result = op->getResult(resultIdx);
-        if (*userIt != result.user_end())
-          return *(*userIt)++;
+        auto useEnd = op->getResult(resultIdx).use_end();
+        while (*useIt != useEnd) {
+          mlir::OpOperand &use = **useIt;
+          ++(*useIt);
+          if (!shouldTraverseFn || shouldTraverseFn(use.getOwner(), use))
+            return use.getOwner();
+        }
         ++resultIdx;
         if (resultIdx < op->getNumResults())
-          userIt = op->getResult(resultIdx).user_begin();
+          useIt = op->getResult(resultIdx).use_begin();
       }
       return nullptr;
     }
@@ -318,11 +336,11 @@ private:
 
     explicit InverseFrame(mlir::Operation *op) : op(op), operandIdx(0) {}
 
-    mlir::Operation *nextChild() {
+    mlir::Operation *nextChild(OpSCCFilter shouldTraverseFn) {
       while (operandIdx < op->getNumOperands()) {
-        auto *defOp = op->getOperand(operandIdx).getDefiningOp();
-        ++operandIdx;
-        if (defOp)
+        mlir::OpOperand &operand = op->getOpOperand(operandIdx++);
+        auto *defOp = operand.get().getDefiningOp();
+        if (defOp && (!shouldTraverseFn || shouldTraverseFn(defOp, operand)))
           return defOp;
       }
       return nullptr;
@@ -331,8 +349,6 @@ private:
 
   using FrameT = std::conditional_t<Direction == OpSCCDirection::Reachable,
                                     ForwardFrame, InverseFrame>;
-
-  bool shouldVisit(mlir::Operation *op) const { return !filter || filter(op); }
 
   static bool hasSelfLoop(mlir::Operation *op) {
     for (const auto &operand : op->getOperands())
@@ -351,9 +367,7 @@ private:
       FrameT &frame = dfsStack.back();
       mlir::Operation *op = frame.op;
 
-      if (auto *child = frame.nextChild()) {
-        if (!shouldVisit(child))
-          continue;
+      if (auto *child = frame.nextChild(shouldTraverseFn)) {
         // Visit successor node
         auto it = indexAndLowLinkMap.find(child);
         if (it == indexAndLowLinkMap.end()) {
@@ -404,7 +418,7 @@ private:
     }
   }
 
-  OpSCCFilter filter;
+  OpSCCFilter shouldTraverseFn;
 
   llvm::SmallSetVector<mlir::Operation *, NumInlineElts> sccStack;
   llvm::SmallVector<FrameT, NumInlineElts> dfsStack;

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -40,6 +40,13 @@
 // sources first, leaves last) via topological(), and in the reverse via
 // reverseTopological().
 //
+// Blocks and Regions
+// ------------------
+// The traversal does not follow through block arguments. It does not consider
+// control flow. It will descend into / ascend from regions without considering
+// the parent operation. The filter predicate can be used to restrict the
+// traversal to certain blocks or regions.
+//
 // Operation Graph Mutation
 // ------------------------
 // The SparseOpSCC class internally stores the result of the SCC analysis

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -36,9 +36,12 @@
 //
 // Output ordering
 // ---------------
-// SCCs are available in topological order of the condensation DAG (seeds /
-// sources first, leaves last) via topological(), and in the reverse via
-// reverseTopological().
+// SCCs are available in a topological order of the condensation DAG via
+// the iterator returned by topological(), and in the reverse via
+// reverseTopological(). The returned order is deterministic (identical graphs
+// will result in an identical order). However, if more than one topological
+// order exists, there is no guarantee on the specific order. Equally, the
+// order of operations within an SCC is deterministic but unspecified.
 //
 // Blocks and Regions
 // ------------------
@@ -50,12 +53,12 @@
 // Operation Graph Mutation
 // ------------------------
 // The SparseOpSCC class internally stores the result of the SCC analysis
-// and is only updated when visit(...) is called. It is not recommended
-// to mutate the IR between visit calls. Calling visit invalidates all
-// iterators. It is safe to mutate the IR while iterating. However, the
-// iteration sequence may contain invalid operation pointers, if the underlying
-// operation is erased after visiting the graph. To reflect the changes in the
-// analysis, reset() must be called and the graph must be re-visited.
+// and is only updated when visit(...) is called. The IR should not be mutated
+// between visit calls. Calling visit invalidates all iterators.
+// It is safe to mutate the IR while iterating. However, the iteration sequence
+// may contain invalid operation pointers, if the underlying operation is erased
+// after visiting the graph. To reflect changes to the graph in the analysis,
+// reset() must be called and the graph must be re-visited.
 //
 // Usage example
 // -------------
@@ -114,8 +117,6 @@ namespace circt {
 using OpSCCFilter = std::function<bool(mlir::Operation *, mlir::OpOperand &)>;
 
 /// Sentinel type representing "no SCC" in an OpSCC PointerUnion.
-/// It is placed first in the union so that the all-zero (default-constructed)
-/// state identifies unambiguously as NullOpSCC, not as a null Operation*.
 struct NullOpSCC {
   void *getAsVoidPointer() const { return nullptr; }
   static NullOpSCC getFromVoidPointer(void *) { return NullOpSCC{}; }
@@ -198,7 +199,10 @@ namespace circt {
 /// One entry in the SCC output: a null sentinel, a trivial (non-cyclic)
 /// operation, or a cyclic group.  Use llvm::isa / llvm::cast / llvm::dyn_cast
 /// to distinguish.  The null state (isa<NullOpSCC>) is returned by getSCC()
-/// when the queried operation has not been visited.
+/// when the queried operation has not been discovered.
+/// Note: NullOpSCC must be placed first in the union so that the all-zero
+/// (default-constructed) state identifies unambiguously as NullOpSCC, not as a
+/// null Operation*.
 using OpSCC = llvm::PointerUnion<NullOpSCC, mlir::Operation *, CyclicOpSCC>;
 
 /// Traversal direction for SparseOpSCC.
@@ -502,6 +506,8 @@ private:
   /// visit() calls and is the authoritative "already visited" guard.
   llvm::SmallDenseMap<mlir::Operation *, unsigned, NumInlineElts> opToSccIndex;
   /// Flat list of SCC entries emitted by Tarjan, in emission order.
+  /// Trivial SCCs are stored directly. Cyclic SCCs are stored as index into
+  /// the `cyclicSccs` vector.
   llvm::SmallVector<detail::OpOrIndex, NumInlineElts> sccs;
   /// Backing storage for cyclic SCCs; CyclicOpSCC holds a pointer into here.
   llvm::SmallVector<detail::CyclicOpSCCStorage, 0> cyclicSccs;

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -98,10 +98,13 @@
 
 namespace circt {
 
-/// Filter predicate passed to the SCC collection functions.  Return `true` to
-/// include an edge in the traversal, `false` to skip it.
-using OpSCCFilter =
-    llvm::function_ref<bool(mlir::Operation *, mlir::OpOperand &)>;
+/// Filter predicate passed to the SparseOpSCC constructor.  Return `true` to
+/// include an edge in the traversal, `false` to skip it. The first argument is
+/// the operation the traversal would enter. The second argument is the
+/// `OpOperand` being followed: for forward traversal its owner equals the
+/// first argument; for backward traversal its defining op equals the first
+/// argument.
+using OpSCCFilter = std::function<bool(mlir::Operation *, mlir::OpOperand &)>;
 
 namespace detail {
 /// Backing storage for a cyclic SCC (implementation detail).

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -349,10 +349,12 @@ private:
   // DFS stack frame for forward traversal. Skips over unused results.
   struct ForwardFrame {
     mlir::Operation *op;
-    unsigned resultIdx;
     std::optional<mlir::Value::use_iterator> useIt;
+    unsigned resultIdx;
+    bool hasSelfLoop = false;
 
-    explicit ForwardFrame(mlir::Operation *op) : op(op), resultIdx(0) {
+    explicit ForwardFrame(mlir::Operation *op)
+        : op(op), useIt(std::nullopt), resultIdx(0) {
       if (op->getNumResults() > 0)
         useIt = op->getResult(0).use_begin();
     }
@@ -378,6 +380,7 @@ private:
   struct InverseFrame {
     mlir::Operation *op;
     unsigned operandIdx;
+    bool hasSelfLoop = false;
 
     explicit InverseFrame(mlir::Operation *op) : op(op), operandIdx(0) {}
 
@@ -394,14 +397,6 @@ private:
 
   using FrameT = std::conditional_t<Direction == OpSCCDirection::Forward,
                                     ForwardFrame, InverseFrame>;
-
-  bool hasSelfLoop(mlir::Operation *op) const {
-    for (mlir::OpOperand &operand : op->getOpOperands())
-      if (operand.get().getDefiningOp() == op &&
-          (!shouldTraverseFn || shouldTraverseFn(op, operand)))
-        return true;
-    return false;
-  }
 
   void tarjanImpl(mlir::Operation *startOp) {
     unsigned nextIdx = 0;
@@ -424,23 +419,29 @@ private:
       mlir::Operation *op = frame.op;
 
       if (auto *child = frame.nextChild(shouldTraverseFn)) {
-        auto it = idxAndLowLinkMap.find(child);
-        if (it != idxAndLowLinkMap.end()) {
-          // Already seen in this DFS.
-          if (sccStack.contains(child))
-            // Back edge — update lowlink.
-            idxAndLowLinkMap[op].second =
-                std::min(idxAndLowLinkMap[op].second, it->second.first);
-          // else: forward/cross edge within this DFS — ignore.
-        } else if (!opToSccIndex.contains(child)) {
-          // Not yet seen in any DFS — recurse.
-          pushFrame(child);
+        if (child == op) {
+          // Self-loop — record it in the frame; no lowlink update needed.
+          frame.hasSelfLoop = true;
+        } else {
+          auto it = idxAndLowLinkMap.find(child);
+          if (it != idxAndLowLinkMap.end()) {
+            // Already seen in this DFS.
+            if (sccStack.contains(child))
+              // Back edge — update lowlink.
+              idxAndLowLinkMap[op].second =
+                  std::min(idxAndLowLinkMap[op].second, it->second.first);
+            // else: forward/cross edge within this DFS — ignore.
+          } else if (!opToSccIndex.contains(child)) {
+            // Not yet seen in any DFS — recurse.
+            pushFrame(child);
+          }
+          // else: completed in a previous visit() call — cross edge, ignore.
         }
-        // else: completed in a previous visit() call — cross edge, ignore.
         continue;
       }
 
       // All children processed — backtrack.
+      bool selfLoop = frame.hasSelfLoop;
       auto [opIndex, opLowLink] = idxAndLowLinkMap.at(op);
       dfsStack.pop_back();
 
@@ -460,7 +461,7 @@ private:
         }
 
         // Insert the pointers into the persistent storage
-        if (sccOps.size() == 1 && !hasSelfLoop(sccOps.front())) {
+        if (sccOps.size() == 1 && !selfLoop) {
           sccs.push_back(detail::OpOrIndex(sccOps.front()));
         } else {
           unsigned cyclicIdx = cyclicSccs.size();

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -60,8 +60,35 @@
 // after visiting the graph. To reflect changes to the graph in the analysis,
 // reset() must be called and the graph must be re-visited.
 //
-// Usage example
+// Usage examples
 // -------------
+//
+// Check if seedOp can be reached from someOp:
+//
+//   SparseOpSCC<OpSCCDirection::Backward> sccs(regFilter);
+//   sccs.visit(seedOp);
+//   if (OpSCC someScc = sccs.getSCC(someOp)) {
+//     if (someScc == sccs.getSCC(seedOp)) {
+//       if (auto cycScc = llvm::dyn_cast<CyclicOpSCC>(someScc)) {
+//         // seedOp and someOp are on at least one common cycle
+//         if (cycScc.size() == 1) {
+//           // seedOp and someOp are equal and there is a self-loop (i.e., at
+//           // least one operand of seedOp is a result of itself)
+//         }
+//       } else {
+//         // seedOp and someOp are equal and there is no self-loop
+//         // (trivial SCC)
+//       }
+//     } else {
+//       // seedOp is reachable from someOp but not the other way around
+//       // (someOp discovered during backwards traversal, but different SCCs)
+//     }
+//   } else {
+//     // seedOp is not reachable from someOp (someOp not discovered during
+//     // backwards traversal)
+//   }
+//
+//
 // Collect all ops reachable from seedOp, excluding register ops, and process
 // them in topological order:
 //
@@ -377,12 +404,12 @@ private:
   };
 
   // DFS stack frame for backward traversal. Skips over block arguments.
-  struct InverseFrame {
+  struct BackwardFrame {
     mlir::Operation *op;
     unsigned operandIdx;
     bool hasSelfLoop = false;
 
-    explicit InverseFrame(mlir::Operation *op) : op(op), operandIdx(0) {}
+    explicit BackwardFrame(mlir::Operation *op) : op(op), operandIdx(0) {}
 
     mlir::Operation *nextChild(OpSCCFilter shouldTraverseFn) {
       while (operandIdx < op->getNumOperands()) {
@@ -396,7 +423,7 @@ private:
   };
 
   using FrameT = std::conditional_t<Direction == OpSCCDirection::Forward,
-                                    ForwardFrame, InverseFrame>;
+                                    ForwardFrame, BackwardFrame>;
 
   void tarjanImpl(mlir::Operation *startOp) {
     unsigned nextIdx = 0;

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -1,0 +1,421 @@
+//===- SparseOpSCCs.h - SCC analysis on sparse op subgraphs ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Collect strongly connected components (SCCs) in the (filtered) def-use graph
+// of MLIR operations, starting from a sparse set of seed operations.
+//
+// Graph model
+// -----------
+// Each operation is a node.  A directed edge runs from op A to op B if B uses
+// one of A's results.  The traversal direction is configurable:
+//   - OpSCCDirection::Reachable -- follow edges forward (defining op -> users).
+//   - OpSCCDirection::Reaching  -- follow edges backward (user -> defining op).
+//
+// SCC classification
+// ------------------
+// An SCC is either:
+//   - Trivial: a single op with no self-loop.  Represented as
+//     mlir::Operation * inside an OpSCC value.
+//   - Cyclic: a group of mutually-reachable ops, or a single op with a
+//     self-loop.  Represented as a CyclicOpSCC inside an OpSCC value.
+//
+// Filtering
+// ---------
+// An optional OpSCCFilter predicate can be supplied to the constructor.  Any
+// operation for which the predicate returns false is excluded from the graph:
+// It is neither visited nor followed as a neighbour.
+//
+// Output ordering
+// ---------------
+// SCCs are available in topological order of the condensation DAG (seeds /
+// sources first, leaves last) via topological(), and in the reverse via
+// reverseTopological().
+//
+// Usage example
+// -------------
+// Collect all ops reachable from seedOp, excluding register ops, and process
+// them in topological order:
+//
+//   auto filter = [](Operation *op) { return !isa<seq::FirRegOp>(op); };
+//   SparseOpSCC<OpSCCDirection::Reachable> sccs(filter);
+//   sccs.visit(seedOp);
+//
+//   for (OpSCC entry : sccs.topological()) {
+//     if (Operation *op = llvm::dyn_cast<mlir::Operation *>(entry)) {
+//       // Trivial SCC: a single op with no cycle.
+//       processSingle(op);
+//     } else {
+//       // Cyclic SCC: a group of mutually-reachable ops (or a self-loop).
+//       for (Operation *op : llvm::cast<CyclicOpSCC>(entry))
+//         processInCycle(op);
+//     }
+//   }
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_SPARSEOPSCC_H
+#define CIRCT_SUPPORT_SPARSEOPSCC_H
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/PointerEmbeddedInt.h"
+#include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include <type_traits>
+
+namespace circt {
+
+/// Filter predicate passed to the SCC collection functions.  Return `true` to
+/// include an operation in the traversal, `false` to skip it.
+using OpSCCFilter = llvm::function_ref<bool(mlir::Operation *)>;
+
+namespace detail {
+/// Backing storage for a cyclic SCC (implementation detail).
+using CyclicOpSCCStorage = llvm::SmallVector<mlir::Operation *, 4>;
+} // namespace detail
+
+/// A cyclic SCC: a pointer-sized, directly-iterable reference to a group of
+/// mutually-reachable operations (or a single op with a self-loop).
+///
+/// Instances are obtained via llvm::cast<CyclicOpSCC> on an OpSCC entry.
+/// The referenced storage is owned by the SparseOpSCC that produced the entry.
+class CyclicOpSCC {
+public:
+  using iterator = detail::CyclicOpSCCStorage::const_iterator;
+
+  explicit CyclicOpSCC(const detail::CyclicOpSCCStorage *storage)
+      : storage(storage) {}
+
+  iterator begin() const { return storage->begin(); }
+  iterator end() const { return storage->end(); }
+  size_t size() const { return storage->size(); }
+  mlir::Operation *const *data() const { return storage->data(); }
+  mlir::Operation *operator[](size_t i) const { return (*storage)[i]; }
+
+  // Interface for PointerLikeTypeTraits.
+  void *getAsVoidPointer() const {
+    return const_cast<detail::CyclicOpSCCStorage *>(storage);
+  }
+  static CyclicOpSCC getFromVoidPointer(void *p) {
+    return CyclicOpSCC(static_cast<const detail::CyclicOpSCCStorage *>(p));
+  }
+  static constexpr int NumLowBitsAvailable = llvm::PointerLikeTypeTraits<
+      const detail::CyclicOpSCCStorage *>::NumLowBitsAvailable;
+
+private:
+  const detail::CyclicOpSCCStorage *storage;
+};
+
+} // namespace circt
+
+namespace llvm {
+template <>
+struct PointerLikeTypeTraits<circt::CyclicOpSCC> {
+  static void *getAsVoidPointer(circt::CyclicOpSCC scc) {
+    return scc.getAsVoidPointer();
+  }
+  static circt::CyclicOpSCC getFromVoidPointer(void *p) {
+    return circt::CyclicOpSCC::getFromVoidPointer(p);
+  }
+  static constexpr int NumLowBitsAvailable =
+      circt::CyclicOpSCC::NumLowBitsAvailable;
+};
+} // namespace llvm
+
+namespace circt {
+
+/// One entry in the SCC output: either a trivial (non-cyclic) operation or a
+/// cyclic group.  Use llvm::isa / llvm::cast / llvm::dyn_cast to distinguish.
+using OpSCC = llvm::PointerUnion<mlir::Operation *, CyclicOpSCC>;
+
+/// Traversal direction for SparseOpSCC.
+///   - Reachable: follow def-use edges forward (defining op -> users).
+///   - Reaching:  follow def-use edges backward (user -> defining op).
+enum class OpSCCDirection { Reachable, Reaching };
+
+template <OpSCCDirection, unsigned>
+class SparseOpSCC;
+
+namespace detail {
+using OpSccEmbeddedIndex = llvm::PointerEmbeddedInt<unsigned, 31>;
+using OpOrIndex = llvm::PointerUnion<mlir::Operation *, OpSccEmbeddedIndex>;
+
+// Iterator template resolving indices to CyclicOpSCC
+template <typename BaseIteratorT>
+class OpSCCIterator final
+    : public llvm::mapped_iterator_base<OpSCCIterator<BaseIteratorT>,
+                                        BaseIteratorT, OpSCC> {
+public:
+  using llvm::mapped_iterator_base<OpSCCIterator<BaseIteratorT>, BaseIteratorT,
+                                   OpSCC>::mapped_iterator_base;
+
+  OpSCC mapElement(OpOrIndex opOrIndex) const {
+    if (llvm::isa<mlir::Operation *>(opOrIndex))
+      return llvm::cast<mlir::Operation *>(opOrIndex);
+    unsigned index = llvm::cast<OpSccEmbeddedIndex>(opOrIndex);
+    return CyclicOpSCC(&cyclicSccs[index]);
+  }
+
+private:
+  template <OpSCCDirection, unsigned>
+  friend class circt::SparseOpSCC;
+
+  OpSCCIterator(BaseIteratorT it,
+                const llvm::SmallVectorImpl<CyclicOpSCCStorage> &cyclicSccs)
+      : llvm::mapped_iterator_base<OpSCCIterator<BaseIteratorT>, BaseIteratorT,
+                                   OpSCC>(it),
+        cyclicSccs(cyclicSccs) {}
+
+  const llvm::SmallVectorImpl<CyclicOpSCCStorage> &cyclicSccs;
+};
+
+} // namespace detail
+
+/// Iterative Tarjan SCC analysis on a sparse subgraph of MLIR operations.
+///
+/// Call visit() with one or more seed operations to trigger the DFS.  Results
+/// accumulate across multiple visit() calls, so the visited subgraph can be
+/// expanded incrementally.
+///
+/// The optional filter passed to the constructor is applied to every candidate
+/// operation before it is visited.  An operation that fails the filter is
+/// treated as if it did not exist in the graph.
+///
+/// Iterators obtained from topological() and reverseTopological() hold a
+/// reference into this object and invalidated by calling visit() or reset().
+template <OpSCCDirection Direction, unsigned NumInlineElts = 32>
+class SparseOpSCC {
+public:
+  explicit SparseOpSCC(OpSCCFilter filter = {}) : filter(filter) {}
+
+  /// Clear all accumulated state.
+  void reset() {
+    sccStack.clear();
+    dfsStack.clear();
+    indexAndLowLinkMap.clear();
+    sccs.clear();
+    cyclicSccs.clear();
+    nextIdx = 0;
+  }
+
+  /// Visit `op` if it passes the filter and has not been visited yet.
+  void visit(mlir::Operation *op) {
+    if (shouldVisit(op))
+      if (!indexAndLowLinkMap.contains(op))
+        tarjanImpl(op);
+  }
+
+  /// Visit each operation in `ops`, skipping already-visited or filtered ones.
+  void visit(llvm::ArrayRef<mlir::Operation *> ops) {
+    for (auto *op : ops)
+      visit(op);
+  }
+
+  /// Return true if `op` was reached by any previous visit() call.
+  bool hasVisited(mlir::Operation *op) const {
+    return indexAndLowLinkMap.contains(op);
+  }
+
+  /// Number of operations visited so far.
+  unsigned getNumVisited() const { return indexAndLowLinkMap.size(); }
+  /// Total number of SCC entries emitted (trivial ops + cyclic groups).
+  unsigned getNumSCCs() const { return sccs.size(); }
+  /// Number of cyclic SCC groups (excludes trivial ops).
+  unsigned getNumCyclicSCCs() const { return cyclicSccs.size(); }
+
+  /// Iterate over SCCs in topological order (sources/seeds first, leaves last).
+  auto topological() const {
+    return llvm::iterator_range(topological_begin(), topological_end());
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  auto topological_begin() const {
+    if constexpr (Direction == OpSCCDirection::Reaching)
+      return detail::OpSCCIterator<typename decltype(sccs)::const_iterator>(
+          sccs.begin(), cyclicSccs);
+    else
+      return detail::OpSCCIterator<
+          typename decltype(sccs)::const_reverse_iterator>(sccs.rbegin(),
+                                                           cyclicSccs);
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  auto topological_end() const {
+    if constexpr (Direction == OpSCCDirection::Reaching)
+      return detail::OpSCCIterator<typename decltype(sccs)::const_iterator>(
+          sccs.end(), cyclicSccs);
+    else
+      return detail::OpSCCIterator<
+          typename decltype(sccs)::const_reverse_iterator>(sccs.rend(),
+                                                           cyclicSccs);
+  }
+
+  /// Iterate over SCCs in reverse topological order (leaves first).
+  auto reverseTopological() const {
+    return llvm::iterator_range(reverseTopological_begin(),
+                                reverseTopological_end());
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  auto reverseTopological_begin() const {
+    if constexpr (Direction == OpSCCDirection::Reachable)
+      return detail::OpSCCIterator<typename decltype(sccs)::const_iterator>(
+          sccs.begin(), cyclicSccs);
+    else
+      return detail::OpSCCIterator<
+          typename decltype(sccs)::const_reverse_iterator>(sccs.rbegin(),
+                                                           cyclicSccs);
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  auto reverseTopological_end() const {
+    if constexpr (Direction == OpSCCDirection::Reachable)
+      return detail::OpSCCIterator<typename decltype(sccs)::const_iterator>(
+          sccs.end(), cyclicSccs);
+    else
+      return detail::OpSCCIterator<
+          typename decltype(sccs)::const_reverse_iterator>(sccs.rend(),
+                                                           cyclicSccs);
+  }
+
+private:
+  // DFS stack frame for forward traversal. Skips over unused results.
+  struct ForwardFrame {
+    mlir::Operation *op;
+    unsigned resultIdx;
+    std::optional<mlir::Value::user_iterator> userIt;
+
+    explicit ForwardFrame(mlir::Operation *op) : op(op), resultIdx(0) {
+      if (op->getNumResults() > 0)
+        userIt = op->getResult(0).user_begin();
+    }
+
+    mlir::Operation *nextChild() {
+      while (resultIdx < op->getNumResults()) {
+        auto result = op->getResult(resultIdx);
+        if (*userIt != result.user_end())
+          return *(*userIt)++;
+        ++resultIdx;
+        if (resultIdx < op->getNumResults())
+          userIt = op->getResult(resultIdx).user_begin();
+      }
+      return nullptr;
+    }
+  };
+
+  // DFS stack frame for backward traversal. Skips over block arguments.
+  struct InverseFrame {
+    mlir::Operation *op;
+    unsigned operandIdx;
+
+    explicit InverseFrame(mlir::Operation *op) : op(op), operandIdx(0) {}
+
+    mlir::Operation *nextChild() {
+      while (operandIdx < op->getNumOperands()) {
+        auto *defOp = op->getOperand(operandIdx).getDefiningOp();
+        ++operandIdx;
+        if (defOp)
+          return defOp;
+      }
+      return nullptr;
+    }
+  };
+
+  using FrameT = std::conditional_t<Direction == OpSCCDirection::Reachable,
+                                    ForwardFrame, InverseFrame>;
+
+  bool shouldVisit(mlir::Operation *op) const { return !filter || filter(op); }
+
+  static bool hasSelfLoop(mlir::Operation *op) {
+    for (const auto &operand : op->getOperands())
+      if (operand.getDefiningOp() == op)
+        return true;
+    return false;
+  }
+
+  void tarjanImpl(mlir::Operation *startOp) {
+    indexAndLowLinkMap[startOp] = {nextIdx, nextIdx};
+    nextIdx++;
+    sccStack.insert(startOp);
+    dfsStack.push_back(FrameT(startOp));
+
+    while (!dfsStack.empty()) {
+      FrameT &frame = dfsStack.back();
+      mlir::Operation *op = frame.op;
+
+      if (auto *child = frame.nextChild()) {
+        if (!shouldVisit(child))
+          continue;
+        // Visit successor node
+        auto it = indexAndLowLinkMap.find(child);
+        if (it == indexAndLowLinkMap.end()) {
+          // Unvisited — push a new frame and recurse.
+          indexAndLowLinkMap[child] = {nextIdx, nextIdx};
+          nextIdx++;
+          sccStack.insert(child);
+          dfsStack.push_back(FrameT(child));
+        } else if (sccStack.contains(child)) {
+          // Back edge — update lowlink.
+          auto &opLowLink = indexAndLowLinkMap.at(op).second;
+          auto childIndex = it->second.first;
+          opLowLink = std::min(opLowLink, childIndex);
+        }
+        // Forward/cross edge: ignore.
+        continue;
+      }
+
+      // Backtrack
+      auto [opIndex, opLowLink] = indexAndLowLinkMap.at(op);
+      // All children processed — pop this frame.
+      dfsStack.pop_back();
+
+      // If op is the root of an SCC, pop and emit it.
+      if (opLowLink == opIndex) {
+        detail::CyclicOpSCCStorage sccOps;
+        do {
+          sccOps.push_back(sccStack.pop_back_val());
+        } while (sccOps.back() != op);
+
+        if (sccOps.size() == 1 && !hasSelfLoop(sccOps.front())) {
+          // Non-cyclic SCC
+          sccs.push_back(detail::OpOrIndex(sccOps.front()));
+        } else {
+          // Cyclic SCC
+          unsigned idx = cyclicSccs.size();
+          cyclicSccs.emplace_back(std::move(sccOps));
+          sccs.push_back(detail::OpOrIndex(idx));
+        }
+        continue;
+      }
+
+      // Not a root. Back-propagate lowlink to the parent frame.
+      if (!dfsStack.empty()) {
+        auto &backLowLink = indexAndLowLinkMap.at(dfsStack.back().op).second;
+        backLowLink = std::min(backLowLink, opLowLink);
+      }
+    }
+  }
+
+  OpSCCFilter filter;
+
+  llvm::SmallSetVector<mlir::Operation *, NumInlineElts> sccStack;
+  llvm::SmallVector<FrameT, NumInlineElts> dfsStack;
+  llvm::SmallDenseMap<mlir::Operation *, std::pair<unsigned, unsigned>,
+                      NumInlineElts>
+      indexAndLowLinkMap;
+  llvm::SmallVector<detail::OpOrIndex, NumInlineElts> sccs;
+  llvm::SmallVector<detail::CyclicOpSCCStorage, 0> cyclicSccs;
+  unsigned nextIdx = 0;
+};
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_SPARSEOPSCC_H

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -113,6 +113,16 @@ namespace circt {
 /// argument.
 using OpSCCFilter = std::function<bool(mlir::Operation *, mlir::OpOperand &)>;
 
+/// Sentinel type representing "no SCC" in an OpSCC PointerUnion.
+/// It is placed first in the union so that the all-zero (default-constructed)
+/// state identifies unambiguously as NullOpSCC, not as a null Operation*.
+struct NullOpSCC {
+  void *getAsVoidPointer() const { return nullptr; }
+  static NullOpSCC getFromVoidPointer(void *) { return NullOpSCC{}; }
+  static constexpr int NumLowBitsAvailable =
+      llvm::PointerLikeTypeTraits<mlir::Operation *>::NumLowBitsAvailable;
+};
+
 namespace detail {
 /// Backing storage for a cyclic SCC (implementation detail).
 using CyclicOpSCCStorage = llvm::SmallVector<mlir::Operation *, 4>;
@@ -127,14 +137,19 @@ class CyclicOpSCC {
 public:
   using iterator = detail::CyclicOpSCCStorage::const_iterator;
 
-  explicit CyclicOpSCC(const detail::CyclicOpSCCStorage *storage)
-      : storage(storage) {}
+  CyclicOpSCC() : storage(nullptr) {}
+  CyclicOpSCC(const detail::CyclicOpSCCStorage *storage) : storage(storage) {}
 
   iterator begin() const { return storage->begin(); }
   iterator end() const { return storage->end(); }
   size_t size() const { return storage->size(); }
   mlir::Operation *const *data() const { return storage->data(); }
   mlir::Operation *operator[](size_t i) const { return (*storage)[i]; }
+
+  operator bool() const { return storage != nullptr; }
+
+  bool operator==(CyclicOpSCC other) const { return storage == other.storage; }
+  bool operator!=(CyclicOpSCC other) const { return storage != other.storage; }
 
   // Interface for PointerLikeTypeTraits.
   void *getAsVoidPointer() const {
@@ -154,6 +169,16 @@ private:
 
 namespace llvm {
 template <>
+struct PointerLikeTypeTraits<circt::NullOpSCC> {
+  static void *getAsVoidPointer(circt::NullOpSCC) { return nullptr; }
+  static circt::NullOpSCC getFromVoidPointer(void *) {
+    return circt::NullOpSCC{};
+  }
+  static constexpr int NumLowBitsAvailable =
+      circt::NullOpSCC::NumLowBitsAvailable;
+};
+
+template <>
 struct PointerLikeTypeTraits<circt::CyclicOpSCC> {
   static void *getAsVoidPointer(circt::CyclicOpSCC scc) {
     return scc.getAsVoidPointer();
@@ -168,9 +193,11 @@ struct PointerLikeTypeTraits<circt::CyclicOpSCC> {
 
 namespace circt {
 
-/// One entry in the SCC output: either a trivial (non-cyclic) operation or a
-/// cyclic group.  Use llvm::isa / llvm::cast / llvm::dyn_cast to distinguish.
-using OpSCC = llvm::PointerUnion<mlir::Operation *, CyclicOpSCC>;
+/// One entry in the SCC output: a null sentinel, a trivial (non-cyclic)
+/// operation, or a cyclic group.  Use llvm::isa / llvm::cast / llvm::dyn_cast
+/// to distinguish.  The null state (isa<NullOpSCC>) is returned by getSCC()
+/// when the queried operation has not been visited.
+using OpSCC = llvm::PointerUnion<NullOpSCC, mlir::Operation *, CyclicOpSCC>;
 
 /// Traversal direction for SparseOpSCC.
 ///   - Forward: follow def-use edges forward (defining op -> users).
@@ -238,15 +265,14 @@ public:
   void reset() {
     sccStack.clear();
     dfsStack.clear();
-    indexAndLowLinkMap.clear();
+    opToSccIndex.clear();
     sccs.clear();
     cyclicSccs.clear();
-    nextIdx = 0;
   }
 
   /// Visit `op` if it passes the shouldTraverseFn and has not been visited yet.
   void visit(mlir::Operation *op) {
-    if (!indexAndLowLinkMap.contains(op))
+    if (!opToSccIndex.contains(op))
       tarjanImpl(op);
   }
 
@@ -258,11 +284,25 @@ public:
 
   /// Return true if `op` was reached by any previous visit() call.
   bool hasVisited(mlir::Operation *op) const {
-    return indexAndLowLinkMap.contains(op);
+    return opToSccIndex.contains(op);
+  }
+
+  /// Return the SCC that `op` belongs to, or an OpSCC holding NullOpSCC if it
+  /// has not been visited.  Check with isa<NullOpSCC> or the bool conversion
+  /// before dispatching with isa/cast.
+  OpSCC getSCC(mlir::Operation *op) const {
+    auto it = opToSccIndex.find(op);
+    if (it == opToSccIndex.end())
+      return OpSCC(NullOpSCC{});
+    detail::OpOrIndex entry = sccs[it->second];
+    if (llvm::isa<mlir::Operation *>(entry))
+      return OpSCC(llvm::cast<mlir::Operation *>(entry));
+    unsigned cyclicIdx = llvm::cast<detail::OpSccEmbeddedIndex>(entry);
+    return OpSCC(CyclicOpSCC(&cyclicSccs[cyclicIdx]));
   }
 
   /// Number of operations visited so far.
-  unsigned getNumVisited() const { return indexAndLowLinkMap.size(); }
+  unsigned getNumVisited() const { return opToSccIndex.size(); }
   /// Total number of SCC entries emitted (trivial ops + cyclic groups).
   unsigned getNumSCCs() const { return sccs.size(); }
   /// Number of cyclic SCC groups (excludes trivial ops).
@@ -382,62 +422,70 @@ private:
   }
 
   void tarjanImpl(mlir::Operation *startOp) {
-    indexAndLowLinkMap[startOp] = {nextIdx, nextIdx};
-    nextIdx++;
-    sccStack.insert(startOp);
-    dfsStack.push_back(FrameT(startOp));
+    // Per-call Tarjan state: {index, lowlink} for each op discovered in this
+    // DFS. Discarded when the call returns.
+    llvm::DenseMap<mlir::Operation *, std::pair<unsigned, unsigned>> tarjanData;
+    unsigned nextIdx = 0;
+
+    auto pushFrame = [&](mlir::Operation *op) {
+      tarjanData[op] = {nextIdx, nextIdx};
+      ++nextIdx;
+      sccStack.insert(op);
+      dfsStack.push_back(FrameT(op));
+    };
+
+    pushFrame(startOp);
 
     while (!dfsStack.empty()) {
       FrameT &frame = dfsStack.back();
       mlir::Operation *op = frame.op;
 
       if (auto *child = frame.nextChild(shouldTraverseFn)) {
-        // Visit successor node
-        auto it = indexAndLowLinkMap.find(child);
-        if (it == indexAndLowLinkMap.end()) {
-          // Unvisited — push a new frame and recurse.
-          indexAndLowLinkMap[child] = {nextIdx, nextIdx};
-          nextIdx++;
-          sccStack.insert(child);
-          dfsStack.push_back(FrameT(child));
-        } else if (sccStack.contains(child)) {
-          // Back edge — update lowlink.
-          auto &opLowLink = indexAndLowLinkMap.at(op).second;
-          auto childIndex = it->second.first;
-          opLowLink = std::min(opLowLink, childIndex);
+        auto it = tarjanData.find(child);
+        if (it != tarjanData.end()) {
+          // Already seen in this DFS.
+          if (sccStack.contains(child))
+            // Back edge — update lowlink.
+            tarjanData[op].second =
+                std::min(tarjanData[op].second, it->second.first);
+          // else: forward/cross edge within this DFS — ignore.
+        } else if (!opToSccIndex.contains(child)) {
+          // Not yet seen in any DFS — recurse.
+          pushFrame(child);
         }
-        // Forward/cross edge: ignore.
+        // else: completed in a previous visit() call — cross edge, ignore.
         continue;
       }
 
-      // Backtrack
-      auto [opIndex, opLowLink] = indexAndLowLinkMap.at(op);
-      // All children processed — pop this frame.
+      // All children processed — backtrack.
+      auto [opIndex, opLowLink] = tarjanData.at(op);
       dfsStack.pop_back();
 
-      // If op is the root of an SCC, pop and emit it.
+      // If op is the root of its SCC, pop and emit it.
       if (opLowLink == opIndex) {
         detail::CyclicOpSCCStorage sccOps;
         do {
           sccOps.push_back(sccStack.pop_back_val());
         } while (sccOps.back() != op);
 
+        unsigned sccIdx = sccs.size();
+        for (auto *sccOp : sccOps)
+          opToSccIndex[sccOp] = sccIdx;
+
         if (sccOps.size() == 1 && !hasSelfLoop(sccOps.front())) {
-          // Non-cyclic SCC
           sccs.push_back(detail::OpOrIndex(sccOps.front()));
         } else {
-          // Cyclic SCC
-          unsigned idx = cyclicSccs.size();
+          unsigned cyclicIdx = cyclicSccs.size();
           cyclicSccs.emplace_back(std::move(sccOps));
-          sccs.push_back(detail::OpOrIndex(idx));
+          sccs.push_back(detail::OpOrIndex(cyclicIdx));
         }
         continue;
       }
 
-      // Not a root. Back-propagate lowlink to the parent frame.
+      // Not an SCC root — back-propagate lowlink to the parent frame.
       if (!dfsStack.empty()) {
-        auto &backLowLink = indexAndLowLinkMap.at(dfsStack.back().op).second;
-        backLowLink = std::min(backLowLink, opLowLink);
+        auto &parentLowLink = tarjanData.at(dfsStack.back().op).second;
+        parentLowLink = std::min(parentLowLink, opLowLink);
       }
     }
   }
@@ -446,12 +494,9 @@ private:
 
   llvm::SmallSetVector<mlir::Operation *, NumInlineElts> sccStack;
   llvm::SmallVector<FrameT, NumInlineElts> dfsStack;
-  llvm::SmallDenseMap<mlir::Operation *, std::pair<unsigned, unsigned>,
-                      NumInlineElts>
-      indexAndLowLinkMap;
+  llvm::SmallDenseMap<mlir::Operation *, unsigned, NumInlineElts> opToSccIndex;
   llvm::SmallVector<detail::OpOrIndex, NumInlineElts> sccs;
   llvm::SmallVector<detail::CyclicOpSCCStorage, 0> cyclicSccs;
-  unsigned nextIdx = 0;
 };
 
 } // namespace circt

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -263,8 +263,6 @@ public:
 
   /// Clear all accumulated state.
   void reset() {
-    sccStack.clear();
-    dfsStack.clear();
     opToSccIndex.clear();
     sccs.clear();
     cyclicSccs.clear();
@@ -422,13 +420,15 @@ private:
   }
 
   void tarjanImpl(mlir::Operation *startOp) {
-    // Per-call Tarjan state: {index, lowlink} for each op discovered in this
-    // DFS. Discarded when the call returns.
-    llvm::DenseMap<mlir::Operation *, std::pair<unsigned, unsigned>> tarjanData;
+    // All state below is local to this DFS and discarded when the call returns.
     unsigned nextIdx = 0;
+    llvm::SmallDenseMap<mlir::Operation *, std::pair<unsigned, unsigned>>
+        idxAndLowLinkMap;
+    llvm::SetVector<mlir::Operation *> sccStack;
+    llvm::SmallVector<FrameT> dfsStack;
 
     auto pushFrame = [&](mlir::Operation *op) {
-      tarjanData[op] = {nextIdx, nextIdx};
+      idxAndLowLinkMap[op] = {nextIdx, nextIdx};
       ++nextIdx;
       sccStack.insert(op);
       dfsStack.push_back(FrameT(op));
@@ -441,13 +441,13 @@ private:
       mlir::Operation *op = frame.op;
 
       if (auto *child = frame.nextChild(shouldTraverseFn)) {
-        auto it = tarjanData.find(child);
-        if (it != tarjanData.end()) {
+        auto it = idxAndLowLinkMap.find(child);
+        if (it != idxAndLowLinkMap.end()) {
           // Already seen in this DFS.
           if (sccStack.contains(child))
             // Back edge — update lowlink.
-            tarjanData[op].second =
-                std::min(tarjanData[op].second, it->second.first);
+            idxAndLowLinkMap[op].second =
+                std::min(idxAndLowLinkMap[op].second, it->second.first);
           // else: forward/cross edge within this DFS — ignore.
         } else if (!opToSccIndex.contains(child)) {
           // Not yet seen in any DFS — recurse.
@@ -458,7 +458,7 @@ private:
       }
 
       // All children processed — backtrack.
-      auto [opIndex, opLowLink] = tarjanData.at(op);
+      auto [opIndex, opLowLink] = idxAndLowLinkMap.at(op);
       dfsStack.pop_back();
 
       // If op is the root of its SCC, pop and emit it.
@@ -484,18 +484,21 @@ private:
 
       // Not an SCC root — back-propagate lowlink to the parent frame.
       if (!dfsStack.empty()) {
-        auto &parentLowLink = tarjanData.at(dfsStack.back().op).second;
+        auto &parentLowLink = idxAndLowLinkMap.at(dfsStack.back().op).second;
         parentLowLink = std::min(parentLowLink, opLowLink);
       }
     }
   }
 
+  /// Optional edge filter supplied at construction time.
   OpSCCFilter shouldTraverseFn;
 
-  llvm::SmallSetVector<mlir::Operation *, NumInlineElts> sccStack;
-  llvm::SmallVector<FrameT, NumInlineElts> dfsStack;
+  /// Maps each visited op to the index of its SCC in `sccs`. Persists across
+  /// visit() calls and is the authoritative "already visited" guard.
   llvm::SmallDenseMap<mlir::Operation *, unsigned, NumInlineElts> opToSccIndex;
+  /// Flat list of SCC entries emitted by Tarjan, in emission order.
   llvm::SmallVector<detail::OpOrIndex, NumInlineElts> sccs;
+  /// Backing storage for cyclic SCCs; CyclicOpSCC holds a pointer into here.
   llvm::SmallVector<detail::CyclicOpSCCStorage, 0> cyclicSccs;
 };
 

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -247,7 +247,7 @@ private:
 /// Iterative Tarjan SCC analysis on a sparse subgraph of MLIR operations.
 ///
 /// Call visit() with one or more seed operations to trigger the DFS.  Results
-/// accumulate across multiple visit() calls, so the visited subgraph can be
+/// accumulate across multiple visit() calls, so the discovered subgraph can be
 /// expanded incrementally.
 ///
 /// The optional filter passed to the constructor is applied to every
@@ -270,26 +270,26 @@ public:
     cyclicSccs.clear();
   }
 
-  /// Visit `op` if it passes the shouldTraverseFn and has not been visited yet.
+  /// Seed `op` into the DFS if it has not already been discovered.
   void visit(mlir::Operation *op) {
     if (!opToSccIndex.contains(op))
       tarjanImpl(op);
   }
 
-  /// Visit each operation in `ops`, skipping already-visited or filtered ones.
+  /// Visit each operation in `ops`, skipping already-discovered ones.
   void visit(llvm::ArrayRef<mlir::Operation *> ops) {
     for (auto *op : ops)
       visit(op);
   }
 
-  /// Return true if `op` was reached by any previous visit() call.
-  bool hasVisited(mlir::Operation *op) const {
+  /// Return true if `op` was discovered (as a seed or transitively) by any
+  /// previous visit() call.
+  bool hasDiscovered(mlir::Operation *op) const {
     return opToSccIndex.contains(op);
   }
 
   /// Return the SCC that `op` belongs to, or an OpSCC holding NullOpSCC if it
-  /// has not been visited.  Check with isa<NullOpSCC> or the bool conversion
-  /// before dispatching with isa/cast.
+  /// has not been discovered.
   OpSCC getSCC(mlir::Operation *op) const {
     auto it = opToSccIndex.find(op);
     if (it == opToSccIndex.end())
@@ -301,8 +301,8 @@ public:
     return OpSCC(CyclicOpSCC(&cyclicSccs[cyclicIdx]));
   }
 
-  /// Number of operations visited so far.
-  unsigned getNumVisited() const { return opToSccIndex.size(); }
+  /// Number of operations discovered so far across all visit() calls.
+  unsigned getNumDiscovered() const { return opToSccIndex.size(); }
   /// Total number of SCC entries emitted (trivial ops + cyclic groups).
   unsigned getNumSCCs() const { return sccs.size(); }
   /// Number of cyclic SCC groups (excludes trivial ops).

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -45,9 +45,10 @@
 // The SparseOpSCC class internally stores the result of the SCC analysis
 // and is only updated when visit(...) is called. It is not recommended
 // to mutate the IR between visit calls. Calling visit invalidates all
-// iterators. It is safe to mutate the IR while iterating. To reflect the
-// changes in the analysis, reset() must be called and the graph must be
-// re-visited.
+// iterators. It is safe to mutate the IR while iterating. However, the
+// iteration sequence may contain invalid operation pointers, if the underlying
+// operation is erased after visiting the graph. To reflect the changes in the
+// analysis, reset() must be called and the graph must be re-visited.
 //
 // Usage example
 // -------------

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -362,9 +362,10 @@ private:
   using FrameT = std::conditional_t<Direction == OpSCCDirection::Forward,
                                     ForwardFrame, InverseFrame>;
 
-  static bool hasSelfLoop(mlir::Operation *op) {
-    for (const auto &operand : op->getOperands())
-      if (operand.getDefiningOp() == op)
+  bool hasSelfLoop(mlir::Operation *op) const {
+    for (mlir::OpOperand &operand : op->getOpOperands())
+      if (operand.get().getDefiningOp() == op &&
+          (!shouldTraverseFn || shouldTraverseFn(op, operand)))
         return true;
     return false;
   }

--- a/include/circt/Support/SparseOpSCC.h
+++ b/include/circt/Support/SparseOpSCC.h
@@ -243,12 +243,12 @@ private:
   friend class circt::SparseOpSCC;
 
   OpSCCIterator(BaseIteratorT it,
-                const llvm::SmallVectorImpl<CyclicOpSCCStorage> &cyclicSccs)
+                const llvm::ArrayRef<CyclicOpSCCStorage> cyclicSccs)
       : llvm::mapped_iterator_base<OpSCCIterator<BaseIteratorT>, BaseIteratorT,
                                    OpSCC>(it),
         cyclicSccs(cyclicSccs) {}
 
-  const llvm::SmallVectorImpl<CyclicOpSCCStorage> &cyclicSccs;
+  const llvm::ArrayRef<CyclicOpSCCStorage> cyclicSccs;
 };
 
 } // namespace detail

--- a/unittests/Support/CMakeLists.txt
+++ b/unittests/Support/CMakeLists.txt
@@ -3,10 +3,16 @@ add_circt_unittest(CIRCTSupportTests
   JSONTest.cpp
   PrettyPrinterTest.cpp
   SATSolverTest.cpp
+  SparseOpSCCTest.cpp
   TruthTableTest.cpp
 )
 
 target_link_libraries(CIRCTSupportTests
   PRIVATE
   CIRCTSupport
+  CIRCTHW
+  CIRCTComb
+  CIRCTSeq
+  MLIRIR
+  MLIRParser
 )

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -67,6 +67,11 @@ TEST(SparseOpSCCsTest, SimpleChain) {
     EXPECT_EQ(orOp, cast<Operation *>(*(revTopoIt++)));
     EXPECT_EQ(andOp, cast<Operation *>(*(revTopoIt++)));
     EXPECT_EQ(revTopoIt, opScc.reverseTopological_end());
+
+    // getSCC maps each visited op to its own trivial SCC entry.
+    EXPECT_EQ(cast<Operation *>(opScc.getSCC(andOp)), andOp);
+    EXPECT_EQ(cast<Operation *>(opScc.getSCC(orOp)), orOp);
+    EXPECT_EQ(cast<Operation *>(opScc.getSCC(outputOp)), outputOp);
   }
 
   // Inverse reachability from outputOp.
@@ -141,6 +146,12 @@ TEST(SparseOpSCCsTest, BoundarySeed) {
     auto topoIt = opScc.topological_begin();
     EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
     EXPECT_EQ(topoIt, opScc.topological_end());
+
+    // getSCC returns a valid entry for the visited op and NullOpSCC for
+    // unvisited.
+    EXPECT_EQ(cast<Operation *>(opScc.getSCC(outputOp)), outputOp);
+    EXPECT_TRUE(isa<NullOpSCC>(opScc.getSCC(andOp)));
+    EXPECT_FALSE(opScc.getSCC(andOp));
   }
 
   {
@@ -343,6 +354,11 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
     EXPECT_TRUE(llvm::is_contained(scc, regOp));
     EXPECT_TRUE(llvm::is_contained(scc, andOp));
     EXPECT_EQ(revIt, opScc.reverseTopological_end());
+
+    // getSCC: both cycle members map to the same CyclicOpSCC entry.
+    EXPECT_EQ(cast<CyclicOpSCC>(opScc.getSCC(regOp)), scc);
+    EXPECT_EQ(cast<CyclicOpSCC>(opScc.getSCC(andOp)), scc);
+    EXPECT_EQ(cast<Operation *>(opScc.getSCC(outputOp)), outputOp);
   }
 
   // With filter that excludes regOp: no cycle, both ops are trivial.
@@ -696,6 +712,81 @@ TEST(SparseOpSCCsTest, SelfLoopRegWithEdgeFilter) {
     EXPECT_EQ(cast<Operation *>(*(revIt++)), regOp);
     EXPECT_EQ(revIt, opScc.reverseTopological_end());
   }
+}
+
+// IR for casting test: a reg<->and cycle, a leaf output, and a disconnected
+// or-op that is never reached by a forward DFS from andOp.
+const char *castingIr = R"MLIR(
+  hw.module private @casting(in %clock: !seq.clock, in %reset: i1, in %a: i1, out x: i1) {
+    %reg     = seq.firreg %and clock %clock reset sync %reset, %and : i1
+    %and     = comb.and %reg, %a : i1
+    %unused  = comb.or  %a, %a : i1
+    hw.output %and : i1
+  }
+)MLIR";
+
+// Verify isa / dyn_cast behaviour across all three OpSCC variants.
+TEST(SparseOpSCCsTest, OpSCCCasting) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+  context.loadDialect<seq::SeqDialect>();
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(castingIr, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("casting");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *regOp = &*it++;
+  Operation *andOp = &*it++;
+  Operation *unusedOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  SparseOpSCC<OpSCCDirection::Forward> opScc;
+  opScc.visit(andOp);
+
+  // Obtain one entry of each kind via getSCC.
+  OpSCC trivialEntry = opScc.getSCC(outputOp); // trivial: no cycle
+  OpSCC cyclicEntry = opScc.getSCC(andOp);     // cyclic: reg <-> and
+  OpSCC nullEntry = opScc.getSCC(unusedOp);    // not reachable from andOp
+
+  // isa<> correctly identifies each variant.
+  EXPECT_TRUE(isa<Operation *>(trivialEntry));
+  EXPECT_FALSE(isa<CyclicOpSCC>(trivialEntry));
+  EXPECT_FALSE(isa<NullOpSCC>(trivialEntry));
+
+  EXPECT_FALSE(isa<Operation *>(cyclicEntry));
+  EXPECT_TRUE(isa<CyclicOpSCC>(cyclicEntry));
+  EXPECT_FALSE(isa<NullOpSCC>(cyclicEntry));
+
+  EXPECT_FALSE(isa<Operation *>(nullEntry));
+  EXPECT_FALSE(isa<CyclicOpSCC>(nullEntry));
+  EXPECT_TRUE(isa<NullOpSCC>(nullEntry));
+
+  // A NullOpSCC entry is bool-false; present entries are bool-true.
+  EXPECT_FALSE(nullEntry);
+  EXPECT_TRUE(trivialEntry);
+  EXPECT_TRUE(cyclicEntry);
+
+  // dyn_cast on known-present values.
+  EXPECT_EQ(dyn_cast<Operation *>(trivialEntry), outputOp);
+  EXPECT_EQ(dyn_cast<Operation *>(cyclicEntry), nullptr);
+  EXPECT_FALSE(dyn_cast<CyclicOpSCC>(trivialEntry));
+  if (auto scc = dyn_cast<CyclicOpSCC>(cyclicEntry)) {
+    EXPECT_EQ(scc.size(), 2u);
+    EXPECT_TRUE(llvm::is_contained(scc, regOp));
+    EXPECT_TRUE(llvm::is_contained(scc, andOp));
+  } else {
+    FAIL() << "expected CyclicOpSCC for cyclicEntry";
+  }
+
+  // dyn_cast_if_present additionally handles null entries gracefully.
+  EXPECT_EQ(dyn_cast_if_present<Operation *>(nullEntry), nullptr);
+  EXPECT_FALSE(dyn_cast_if_present<CyclicOpSCC>(nullEntry));
 }
 
 } // namespace

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -1,0 +1,540 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/SparseOpSCC.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Parser/Parser.h"
+#include "llvm/ADT/SmallVector.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+using namespace circt;
+
+namespace {
+
+// Graph region with a simple chain:  and -> or -> output
+// (each op's result is consumed by the next)
+const char *ir = R"MLIR(
+  hw.module private @test(in %a: i1, in %b: i1, out x: i1) {
+    %and = comb.and %a, %b : i1
+    %or  = comb.or  %and, %a : i1
+    hw.output %or : i1
+  }
+)MLIR";
+
+TEST(SparseOpSCCsTest, SimpleChain) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(ir, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("test");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *andOp = &*it++;
+  Operation *orOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  // Forward reachability from andOp.
+  // Reverse topological order: leaves-first -> [outputOp, orOp, andOp].
+  {
+    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    opScc.visit(andOp);
+
+    EXPECT_EQ(opScc.getNumVisited(), 3u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto topoIt = opScc.topological_begin();
+    EXPECT_EQ(andOp, cast<Operation *>(*(topoIt++)));
+    EXPECT_EQ(orOp, cast<Operation *>(*(topoIt++)));
+    EXPECT_EQ(outputOp, cast<Operation *>(*(topoIt++)));
+    EXPECT_EQ(topoIt, opScc.topological_end());
+
+    auto revTopoIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(outputOp, cast<Operation *>(*(revTopoIt++)));
+    EXPECT_EQ(orOp, cast<Operation *>(*(revTopoIt++)));
+    EXPECT_EQ(andOp, cast<Operation *>(*(revTopoIt++)));
+    EXPECT_EQ(revTopoIt, opScc.reverseTopological_end());
+  }
+
+  // Inverse reachability from outputOp.
+  // Follows operands backward; reverse topo of inverse = forward topo:
+  // [andOp, orOp, outputOp].
+  {
+    SparseOpSCC<OpSCCDirection::Reaching> opScc;
+    opScc.visit(outputOp);
+
+    EXPECT_EQ(opScc.getNumVisited(), 3u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto topoIt = opScc.topological_begin();
+    EXPECT_EQ(andOp, cast<Operation *>(*(topoIt++)));
+    EXPECT_EQ(orOp, cast<Operation *>(*(topoIt++)));
+    EXPECT_EQ(outputOp, cast<Operation *>(*(topoIt++)));
+    EXPECT_EQ(topoIt, opScc.topological_end());
+
+    auto revTopoIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(outputOp, cast<Operation *>(*(revTopoIt++)));
+    EXPECT_EQ(orOp, cast<Operation *>(*(revTopoIt++)));
+    EXPECT_EQ(andOp, cast<Operation *>(*(revTopoIt++)));
+    EXPECT_EQ(revTopoIt, opScc.reverseTopological_end());
+  }
+}
+
+// Passing an empty seed list leaves all counts at zero.
+TEST(SparseOpSCCsTest, EmptySeeds) {
+  SparseOpSCC<OpSCCDirection::Reachable> fwd;
+  fwd.visit(ArrayRef<Operation *>{});
+  EXPECT_EQ(fwd.getNumVisited(), 0u);
+  EXPECT_EQ(fwd.getNumSCCs(), 0u);
+  EXPECT_EQ(fwd.getNumCyclicSCCs(), 0u);
+
+  SparseOpSCC<OpSCCDirection::Reaching> inv;
+  inv.visit(ArrayRef<Operation *>{});
+  EXPECT_EQ(inv.getNumVisited(), 0u);
+  EXPECT_EQ(inv.getNumSCCs(), 0u);
+  EXPECT_EQ(inv.getNumCyclicSCCs(), 0u);
+}
+
+// A seed that is a boundary node in the traversal direction is returned as a
+// single trivial SCC with no further expansion.
+//   - Forward from outputOp: hw.output produces no results, so it has no
+//     forward edges; only outputOp is emitted.
+//   - Inverse from andOp: both operands are block arguments (no defining op),
+//     so there are no inverse edges; only andOp is emitted.
+TEST(SparseOpSCCsTest, BoundarySeed) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(ir, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("test");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *andOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  {
+    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    opScc.visit(outputOp);
+
+    EXPECT_EQ(opScc.getNumVisited(), 1u);
+    EXPECT_EQ(opScc.getNumSCCs(), 1u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto topoIt = opScc.topological_begin();
+    EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
+    EXPECT_EQ(topoIt, opScc.topological_end());
+  }
+
+  {
+    SparseOpSCC<OpSCCDirection::Reaching> opScc;
+    opScc.visit(andOp);
+
+    EXPECT_EQ(opScc.getNumVisited(), 1u);
+    EXPECT_EQ(opScc.getNumSCCs(), 1u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto topoIt = opScc.topological_begin();
+    EXPECT_EQ(cast<Operation *>(*(topoIt++)), andOp);
+    EXPECT_EQ(topoIt, opScc.topological_end());
+  }
+}
+
+// When one seed is already reachable from another, it is visited during the
+// first seed's DFS and silently skipped when the loop encounters it as a seed.
+// The result is identical to seeding with just the upstream op.
+TEST(SparseOpSCCsTest, OverlappingSeeds) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(ir, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("test");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *andOp = &*it++;
+  Operation *orOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  SparseOpSCC<OpSCCDirection::Reachable> opScc;
+  opScc.visit(andOp);
+  opScc.visit(orOp); // already visited via andOp — skipped
+
+  EXPECT_EQ(opScc.getNumSCCs(), 3u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+  auto topoIt = opScc.topological_begin();
+  EXPECT_EQ(cast<Operation *>(*(topoIt++)), andOp);
+  EXPECT_EQ(cast<Operation *>(*(topoIt++)), orOp);
+  EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
+  EXPECT_EQ(topoIt, opScc.topological_end());
+}
+
+// A filter that excludes the seed op prevents it from being visited at all.
+TEST(SparseOpSCCsTest, FilterExcludesSeed) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(ir, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("test");
+  ASSERT_TRUE(hwModule);
+
+  Operation *andOp = &*hwModule.getBodyBlock()->begin();
+
+  auto filter = [&](Operation *op) { return op != andOp; };
+  SparseOpSCC<OpSCCDirection::Reachable> opScc(filter);
+  opScc.visit(andOp);
+
+  EXPECT_EQ(opScc.getNumVisited(), 0u);
+  EXPECT_EQ(opScc.getNumSCCs(), 0u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+}
+
+// Diamond: %and splits into two branches that join at %merge; no cycle.
+//
+//   %and   = comb.and %a, %b : i1     split node
+//   %or    = comb.or  %and, %a : i1   left branch
+//   %xor   = comb.xor %and, %b : i1   right branch
+//   %merge = comb.or  %or, %xor : i1  join node
+//   hw.output %merge : i1
+//
+// Forward edges: and->{or,xor}, or->merge, xor->merge, merge->output.
+// Reverse-topo order: outputOp, mergeOp, {orOp,xorOp} (order unspecified),
+// andOp.
+const char *diamondIr = R"MLIR(
+  hw.module private @diamond(in %a: i1, in %b: i1, out x: i1) {
+    %and   = comb.and %a, %b : i1
+    %or    = comb.or  %and, %a : i1
+    %xor   = comb.xor %and, %b : i1
+    %merge = comb.or  %or, %xor : i1
+    hw.output %merge : i1
+  }
+)MLIR";
+
+TEST(SparseOpSCCsTest, DiamondNoCycle) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(diamondIr, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("diamond");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *andOp = &*it++;
+  Operation *orOp = &*it++;
+  Operation *xorOp = &*it++;
+  Operation *mergeOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  SparseOpSCC<OpSCCDirection::Reachable> opScc;
+  opScc.visit(andOp);
+
+  EXPECT_EQ(opScc.getNumSCCs(), 5u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+  // outputOp first, mergeOp second, andOp last; orOp/xorOp order is
+  // DFS-dependent.
+  auto revIt = opScc.reverseTopological_begin();
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), mergeOp);
+  std::array<Operation *, 2> middle = {cast<Operation *>(*(revIt++)),
+                                       cast<Operation *>(*(revIt++))};
+  EXPECT_TRUE(llvm::is_contained(middle, orOp));
+  EXPECT_TRUE(llvm::is_contained(middle, xorOp));
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), andOp);
+  EXPECT_EQ(revIt, opScc.reverseTopological_end());
+}
+
+// Graph with a cycle: and uses reg's result, reg uses and's result.
+//
+//   %reg = seq.firreg %and clock %clock : i1
+//   %and = comb.and %reg, %a : i1
+//   hw.output %and : i1
+//
+// Block order: regOp, andOp, outputOp (terminator).
+// Forward edges: reg->and, and->{reg, output}.
+const char *cycleIr = R"MLIR(
+  hw.module private @cycle(in %clock: !seq.clock, in %a: i1, out x: i1) {
+    %reg = seq.firreg %and clock %clock : i1
+    %and = comb.and %reg, %a : i1
+    hw.output %and : i1
+  }
+)MLIR";
+
+TEST(SparseOpSCCsTest, CycleWithRegister) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+  context.loadDialect<seq::SeqDialect>();
+
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(cycleIr, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("cycle");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *regOp = &*it++;
+  Operation *andOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  // Without filter: reg and and form a cycle -> one CyclicOpSCC.
+  {
+    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    opScc.visit(andOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+
+    CyclicOpSCC scc = cast<CyclicOpSCC>(*revIt++);
+    EXPECT_EQ(scc.size(), 2u);
+    EXPECT_TRUE(llvm::is_contained(scc, regOp));
+    EXPECT_TRUE(llvm::is_contained(scc, andOp));
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
+
+  // With filter that excludes regOp: no cycle, both ops are trivial.
+  {
+    auto filter = [&](Operation *op) { return op != regOp; };
+    SparseOpSCC<OpSCCDirection::Reachable> opScc(filter);
+    opScc.visit(andOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto topoIt = opScc.topological_begin();
+    EXPECT_EQ(cast<Operation *>(*(topoIt++)), andOp);
+    EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
+    EXPECT_EQ(topoIt, opScc.topological_end());
+  }
+}
+
+// Two disjoint register cycles sharing a common downstream merge node.
+//
+//   %reg1 = seq.firreg %and1 clock %clock : i1   -. cycle 1
+//   %and1 = comb.and %reg1, %a : i1              -'
+//   %reg2 = seq.firreg %or1  clock %clock : i1   -. cycle 2
+//   %or1  = comb.or  %reg2, %a : i1              -'
+//   %xor  = comb.xor %and1, %or1 : i1              merge node
+//   hw.output %xor : i1
+//
+// Seeds: {and1Op, or1Op}.
+// Expected reverse-topo: [outputOp, xorOp, SCC{reg1,and1}, SCC{reg2,or1}]
+const char *twoCyclesIr = R"MLIR(
+  hw.module private @twocycles(in %clock: !seq.clock, in %a: i1, out x: i1) {
+    %reg1 = seq.firreg %and1 clock %clock : i1
+    %and1 = comb.and %reg1, %a : i1
+    %reg2 = seq.firreg %or1  clock %clock : i1
+    %or1  = comb.or  %reg2, %a : i1
+    %xor  = comb.xor %and1, %or1 : i1
+    hw.output %xor : i1
+  }
+)MLIR";
+
+TEST(SparseOpSCCsTest, TwoCycles) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+  context.loadDialect<seq::SeqDialect>();
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(twoCyclesIr, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("twocycles");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *reg1Op = &*it++;
+  Operation *and1Op = &*it++;
+  Operation *reg2Op = &*it++;
+  Operation *or1Op = &*it++;
+  Operation *xorOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  SparseOpSCC<OpSCCDirection::Reachable> opScc;
+  opScc.visit(and1Op);
+  opScc.visit(or1Op);
+
+  EXPECT_EQ(opScc.getNumSCCs(), 4u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 2u);
+
+  auto revIt = opScc.reverseTopological_begin();
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), xorOp);
+
+  // First cyclic SCC: reg1 <-> and1.
+  CyclicOpSCC scc0 = cast<CyclicOpSCC>(*revIt++);
+  EXPECT_EQ(scc0.size(), 2u);
+  EXPECT_TRUE(llvm::is_contained(scc0, reg1Op));
+  EXPECT_TRUE(llvm::is_contained(scc0, and1Op));
+
+  // Second cyclic SCC: reg2 <-> or1.
+  CyclicOpSCC scc1 = cast<CyclicOpSCC>(*revIt++);
+  EXPECT_EQ(scc1.size(), 2u);
+  EXPECT_TRUE(llvm::is_contained(scc1, reg2Op));
+  EXPECT_TRUE(llvm::is_contained(scc1, or1Op));
+
+  EXPECT_EQ(revIt, opScc.reverseTopological_end());
+}
+
+// One large SCC containing two internal cycles and five operations.
+//
+//   %r0   = seq.firreg %and1 ...  -. cycle A: r0 <-> and1
+//   %and1 = comb.and %r0, %r2     -'   (and1 also drives xor4 and output)
+//   %r2   = seq.firreg %or3  ...  -. cycle B: r2 <-> or3
+//   %or3  = comb.or  %r2, %xor4   -'
+//   %xor4 = comb.xor %and1, %a      bridge: and1 -> xor4 -> or3 -> r2 -> and1
+//
+// All five are mutually reachable -> single CyclicOpSCC of size 5.
+const char *twoInternalCyclesIr = R"MLIR(
+  hw.module private @largeSCC(in %clock: !seq.clock, in %a: i1, out x: i1) {
+    %r0   = seq.firreg %and1 clock %clock : i1
+    %and1 = comb.and %r0, %r2 : i1
+    %r2   = seq.firreg %or3  clock %clock : i1
+    %or3  = comb.or  %r2, %xor4 : i1
+    %xor4 = comb.xor %and1, %a : i1
+    hw.output %and1 : i1
+  }
+)MLIR";
+
+TEST(SparseOpSCCsTest, TwoInternalCycles) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+  context.loadDialect<seq::SeqDialect>();
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(twoInternalCyclesIr, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("largeSCC");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *r0Op = &*it++;
+  Operation *and1Op = &*it++;
+  Operation *r2Op = &*it++;
+  Operation *or3Op = &*it++;
+  Operation *xor4Op = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  auto checkFiveOpSCC = [&](CyclicOpSCC scc) {
+    EXPECT_EQ(scc.size(), 5u);
+    EXPECT_TRUE(llvm::is_contained(scc, r0Op));
+    EXPECT_TRUE(llvm::is_contained(scc, and1Op));
+    EXPECT_TRUE(llvm::is_contained(scc, r2Op));
+    EXPECT_TRUE(llvm::is_contained(scc, or3Op));
+    EXPECT_TRUE(llvm::is_contained(scc, xor4Op));
+  };
+
+  // Forward direction from and1Op: outputOp is the only leaf; the five-op SCC
+  // follows.
+  {
+    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    opScc.visit(and1Op);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    checkFiveOpSCC(cast<CyclicOpSCC>(*revIt++));
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
+
+  // Inverse direction from outputOp: the five-op SCC precedes outputOp
+  // (topological order: predecessors before successors).
+  {
+    SparseOpSCC<OpSCCDirection::Reaching> opScc;
+    opScc.visit(outputOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+
+    auto topoIt = opScc.topological_begin();
+    checkFiveOpSCC(cast<CyclicOpSCC>(*topoIt++));
+    EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
+    EXPECT_EQ(topoIt, opScc.topological_end());
+  }
+}
+
+// Self-loop: comb.and that uses its own result as one operand.
+const char *selfLoopIr = R"MLIR(
+  hw.module private @selfloop(in %a: i1, out x: i1) {
+    %and = comb.and %and, %a : i1
+    hw.output %and : i1
+  }
+)MLIR";
+
+TEST(SparseOpSCCsTest, SelfLoop) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(selfLoopIr, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("selfloop");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *andOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  SparseOpSCC<OpSCCDirection::Reachable> opScc;
+  opScc.visit(andOp);
+
+  // outputOp is a trivial leaf; andOp is a size-1 CyclicOpSCC due to self-loop.
+  EXPECT_EQ(opScc.getNumSCCs(), 2u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+
+  auto revIt = opScc.reverseTopological_begin();
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+  // Second entry is a CyclicOpSCC, not a plain Operation *.
+  EXPECT_EQ(dyn_cast<Operation *>(*revIt), nullptr);
+  CyclicOpSCC scc = cast<CyclicOpSCC>(*revIt++);
+  EXPECT_EQ(scc.size(), 1u);
+  EXPECT_EQ(scc[0], andOp);
+  EXPECT_EQ(revIt, opScc.reverseTopological_end());
+}
+
+} // namespace

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -30,6 +30,17 @@ const char *ir = R"MLIR(
   }
 )MLIR";
 
+// Graph with a register-and cycle: reg uses and's result as next/resetValue,
+// and uses reg's result as an operand.
+//   Forward edges: reg->and, and->{reg(next), reg(resetValue), output}
+const char *cycleIr = R"MLIR(
+  hw.module private @cycle(in %clock: !seq.clock, in %reset: i1, in %a: i1, out x: i1) {
+    %reg = seq.firreg %and clock %clock reset sync %reset, %and : i1
+    %and = comb.and %reg, %a : i1
+    hw.output %and : i1
+  }
+)MLIR";
+
 TEST(SparseOpSCCsTest, SimpleChain) {
   MLIRContext context;
   context.loadDialect<hw::HWDialect>();
@@ -48,7 +59,6 @@ TEST(SparseOpSCCsTest, SimpleChain) {
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
   // Forward reachability from andOp.
-  // Reverse topological order: leaves-first -> [outputOp, orOp, andOp].
   {
     SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(andOp);
@@ -98,42 +108,49 @@ TEST(SparseOpSCCsTest, SimpleChain) {
   }
 }
 
-// reset() clears all accumulated state; re-visiting produces fresh results.
+// reset() clears all accumulated state including cyclic SCC storage;
+// re-visiting produces fresh results.
 TEST(SparseOpSCCsTest, Reset) {
   MLIRContext context;
   context.loadDialect<hw::HWDialect>();
   context.loadDialect<comb::CombDialect>();
+  context.loadDialect<seq::SeqDialect>();
 
-  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(ir, &context);
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(cycleIr, &context);
   ASSERT_TRUE(module);
 
   SymbolTable symbolTable(module.get());
-  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("test");
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("cycle");
   ASSERT_TRUE(hwModule);
 
   auto it = hwModule.getBodyBlock()->begin();
+  Operation *regOp = &*it++;
   Operation *andOp = &*it++;
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
   SparseOpSCC<OpSCCDirection::Forward> opScc;
-  opScc.visit(andOp); // discovers andOp, orOp, outputOp
+  opScc.visit(andOp); // discovers CyclicOpSCC{reg,and} + trivial outputOp
   EXPECT_EQ(opScc.getNumDiscovered(), 3u);
-  EXPECT_EQ(opScc.getNumSCCs(), 3u);
+  EXPECT_EQ(opScc.getNumSCCs(), 2u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
 
   opScc.reset();
 
-  // All state cleared.
+  // All state cleared, including cyclic SCC storage.
   EXPECT_EQ(opScc.getNumDiscovered(), 0u);
   EXPECT_EQ(opScc.getNumSCCs(), 0u);
   EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+  EXPECT_FALSE(opScc.hasDiscovered(regOp));
   EXPECT_FALSE(opScc.hasDiscovered(andOp));
   EXPECT_FALSE(opScc.hasDiscovered(outputOp));
   EXPECT_EQ(opScc.topological_begin(), opScc.topological_end());
+  EXPECT_EQ(opScc.reverseTopological_begin(), opScc.reverseTopological_end());
 
-  // Re-visiting with a different seed produces the correct fresh result.
-  opScc.visit(outputOp); // boundary seed: no results, only outputOp discovered
+  // Re-visiting with a boundary seed produces the correct fresh result.
+  opScc.visit(outputOp); // hw.output has no results: only outputOp discovered.
   EXPECT_EQ(opScc.getNumDiscovered(), 1u);
   EXPECT_EQ(opScc.getNumSCCs(), 1u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
   EXPECT_TRUE(opScc.hasDiscovered(outputOp));
   EXPECT_FALSE(opScc.hasDiscovered(andOp));
 }
@@ -411,7 +428,7 @@ TEST(SparseOpSCCsTest, DiamondNoCycle) {
   }
 }
 
-// Graph with a cycle: and uses reg's result, reg uses and's result.
+// Graph with a cycle: "and" uses "reg"'s result, "reg" uses "and"'s result.
 //
 //   %reg = seq.firreg %and clock %clock reset sync %reset, %and : i1
 //   %and = comb.and %reg, %a : i1
@@ -420,13 +437,6 @@ TEST(SparseOpSCCsTest, DiamondNoCycle) {
 // %and feeds reg.next (the cycle edge) and reg.resetValue.
 // Block order: regOp, andOp, outputOp (terminator).
 // Forward edges: reg->and, and->{reg(next), reg(resetValue), output}.
-const char *cycleIr = R"MLIR(
-  hw.module private @cycle(in %clock: !seq.clock, in %reset: i1, in %a: i1, out x: i1) {
-    %reg = seq.firreg %and clock %clock reset sync %reset, %and : i1
-    %and = comb.and %reg, %a : i1
-    hw.output %and : i1
-  }
-)MLIR";
 
 TEST(SparseOpSCCsTest, CycleWithRegister) {
   MLIRContext context;
@@ -446,7 +456,7 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
   Operation *andOp = &*it++;
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
-  // Without filter: reg and and form a cycle -> one CyclicOpSCC.
+  // Without filter: "reg" and "and" form a cycle -> one CyclicOpSCC.
   {
     SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(andOp);
@@ -612,6 +622,36 @@ TEST(SparseOpSCCsTest, TwoCycles) {
   EXPECT_NE(opScc.getSCC(or1Op), opScc.getSCC(hwModule));
 
   EXPECT_EQ(revIt, opScc.reverseTopological_end());
+
+  // Backward from xorOp: discovers both cycles plus xorOp itself.
+  // outputOp is downstream of xorOp in the forward graph and is not reached.
+  // reverseTopological: xorOp first (forward-graph leaf), then the two cyclic
+  // SCCs in unspecified order.
+  {
+    SparseOpSCC<OpSCCDirection::Backward> opScc;
+    opScc.visit(xorOp);
+
+    EXPECT_EQ(opScc.getNumDiscovered(), 5u); // reg1, and1, reg2, or1, xor
+    EXPECT_EQ(opScc.getNumSCCs(), 3u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 2u);
+    EXPECT_FALSE(opScc.hasDiscovered(outputOp));
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), xorOp);
+
+    std::array<CyclicOpSCC, 2> cycles = {cast<CyclicOpSCC>(*revIt++),
+                                         cast<CyclicOpSCC>(*revIt++)};
+    EXPECT_TRUE(llvm::any_of(cycles, [&](CyclicOpSCC scc) {
+      return scc.size() == 2 && llvm::is_contained(scc, reg1Op) &&
+             llvm::is_contained(scc, and1Op);
+    }));
+    EXPECT_TRUE(llvm::any_of(cycles, [&](CyclicOpSCC scc) {
+      return scc.size() == 2 && llvm::is_contained(scc, reg2Op) &&
+             llvm::is_contained(scc, or1Op);
+    }));
+
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
 }
 
 // One large SCC containing two internal cycles and five operations.

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -98,6 +98,46 @@ TEST(SparseOpSCCsTest, SimpleChain) {
   }
 }
 
+// reset() clears all accumulated state; re-visiting produces fresh results.
+TEST(SparseOpSCCsTest, Reset) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(ir, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("test");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *andOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  SparseOpSCC<OpSCCDirection::Forward> opScc;
+  opScc.visit(andOp); // discovers andOp, orOp, outputOp
+  EXPECT_EQ(opScc.getNumDiscovered(), 3u);
+  EXPECT_EQ(opScc.getNumSCCs(), 3u);
+
+  opScc.reset();
+
+  // All state cleared.
+  EXPECT_EQ(opScc.getNumDiscovered(), 0u);
+  EXPECT_EQ(opScc.getNumSCCs(), 0u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+  EXPECT_FALSE(opScc.hasDiscovered(andOp));
+  EXPECT_FALSE(opScc.hasDiscovered(outputOp));
+  EXPECT_EQ(opScc.topological_begin(), opScc.topological_end());
+
+  // Re-visiting with a different seed produces the correct fresh result.
+  opScc.visit(outputOp); // boundary seed: no results, only outputOp discovered
+  EXPECT_EQ(opScc.getNumDiscovered(), 1u);
+  EXPECT_EQ(opScc.getNumSCCs(), 1u);
+  EXPECT_TRUE(opScc.hasDiscovered(outputOp));
+  EXPECT_FALSE(opScc.hasDiscovered(andOp));
+}
+
 // Passing an empty seed list leaves all counts at zero.
 TEST(SparseOpSCCsTest, EmptySeeds) {
   SparseOpSCC<OpSCCDirection::Forward> fwd;
@@ -199,6 +239,75 @@ TEST(SparseOpSCCsTest, OverlappingSeeds) {
   EXPECT_EQ(cast<Operation *>(*(topoIt++)), orOp);
   EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
   EXPECT_EQ(topoIt, opScc.topological_end());
+}
+
+// Incremental visit: two independent roots feeding a shared merge node.
+//
+//   %av    = comb.and %a, %a : i1   seed 1 (independent)
+//   %bv    = comb.or  %b, %b : i1   seed 2 (independent)
+//   %merge = comb.xor %av, %bv : i1 shared successor
+//   hw.output %merge : i1
+//
+// visit(avOp) discovers {avOp, mergeOp, outputOp}.
+// visit(bvOp) discovers only bvOp: mergeOp is already discovered and is
+// treated as a cross-edge, not re-entered.
+const char *incrementalIr = R"MLIR(
+  hw.module private @incremental(in %a: i1, in %b: i1, out x: i1) {
+    %av    = comb.and %a, %a : i1
+    %bv    = comb.or  %b, %b : i1
+    %merge = comb.xor %av, %bv : i1
+    hw.output %merge : i1
+  }
+)MLIR";
+
+TEST(SparseOpSCCsTest, IncrementalVisit) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<comb::CombDialect>();
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(incrementalIr, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("incremental");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *avOp = &*it++;
+  Operation *bvOp = &*it++;
+  Operation *mergeOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  SparseOpSCC<OpSCCDirection::Forward> opScc;
+
+  // First visit: avOp → mergeOp → outputOp.
+  opScc.visit(avOp);
+  EXPECT_EQ(opScc.getNumDiscovered(), 3u);
+  EXPECT_TRUE(opScc.hasDiscovered(avOp));
+  EXPECT_TRUE(opScc.hasDiscovered(mergeOp));
+  EXPECT_TRUE(opScc.hasDiscovered(outputOp));
+  EXPECT_FALSE(opScc.hasDiscovered(bvOp));
+
+  // Second visit: bvOp is new; mergeOp/outputOp are cross-edges — not
+  // re-entered, so only bvOp is added.
+  opScc.visit(bvOp);
+  EXPECT_EQ(opScc.getNumDiscovered(), 4u);
+  EXPECT_TRUE(opScc.hasDiscovered(bvOp));
+  EXPECT_EQ(opScc.getNumSCCs(), 4u);
+  EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+  // mergeOp's SCC was assigned by the first visit and is unchanged.
+  EXPECT_EQ(cast<Operation *>(opScc.getSCC(mergeOp)), mergeOp);
+
+  // Reverse-topological (leaves first): outputOp, mergeOp, avOp, bvOp.
+  // bvOp trails because it was emitted by the second DFS.
+  auto revIt = opScc.reverseTopological_begin();
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), mergeOp);
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), avOp);
+  EXPECT_EQ(cast<Operation *>(*(revIt++)), bvOp);
+  EXPECT_EQ(revIt, opScc.reverseTopological_end());
 }
 
 // Diamond: %and splits into two branches that join at %merge; no cycle.
@@ -786,7 +895,12 @@ TEST(SparseOpSCCsTest, OpSCCCasting) {
 
   // dyn_cast on known-present values.
   EXPECT_EQ(dyn_cast<Operation *>(trivialEntry), outputOp);
+  EXPECT_TRUE(static_cast<bool>(dyn_cast<Operation *>(trivialEntry)));
+  EXPECT_FALSE(static_cast<bool>(dyn_cast<CyclicOpSCC>(trivialEntry)));
+
   EXPECT_EQ(dyn_cast<Operation *>(cyclicEntry), nullptr);
+  EXPECT_FALSE(static_cast<bool>(dyn_cast<Operation *>(cyclicEntry)));
+  EXPECT_TRUE(static_cast<bool>(dyn_cast<CyclicOpSCC>(cyclicEntry)));
 
   EXPECT_EQ(dyn_cast<CyclicOpSCC>(cyclicEntry), opScc.getSCC(regOp));
   EXPECT_NE(dyn_cast<CyclicOpSCC>(cyclicEntry), opScc.getSCC(outputOp));
@@ -803,6 +917,7 @@ TEST(SparseOpSCCsTest, OpSCCCasting) {
 
   // dyn_cast_if_present additionally handles null entries gracefully.
   EXPECT_EQ(dyn_cast_if_present<Operation *>(nullEntry), nullptr);
+  EXPECT_FALSE(static_cast<bool>(dyn_cast_if_present<Operation *>(nullEntry)));
   EXPECT_FALSE(static_cast<bool>(dyn_cast_if_present<CyclicOpSCC>(nullEntry)));
 }
 

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -9,7 +9,7 @@
 #include "circt/Support/SparseOpSCC.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
-#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Parser/Parser.h"
 #include "llvm/ADT/SmallVector.h"
@@ -191,30 +191,6 @@ TEST(SparseOpSCCsTest, OverlappingSeeds) {
   EXPECT_EQ(topoIt, opScc.topological_end());
 }
 
-// A filter that excludes the seed op prevents it from being visited at all.
-TEST(SparseOpSCCsTest, FilterExcludesSeed) {
-  MLIRContext context;
-  context.loadDialect<hw::HWDialect>();
-  context.loadDialect<comb::CombDialect>();
-
-  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(ir, &context);
-  ASSERT_TRUE(module);
-
-  SymbolTable symbolTable(module.get());
-  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("test");
-  ASSERT_TRUE(hwModule);
-
-  Operation *andOp = &*hwModule.getBodyBlock()->begin();
-
-  auto filter = [&](Operation *op) { return op != andOp; };
-  SparseOpSCC<OpSCCDirection::Reachable> opScc(filter);
-  opScc.visit(andOp);
-
-  EXPECT_EQ(opScc.getNumVisited(), 0u);
-  EXPECT_EQ(opScc.getNumSCCs(), 0u);
-  EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
-}
-
 // Diamond: %and splits into two branches that join at %merge; no cycle.
 //
 //   %and   = comb.and %a, %b : i1     split node
@@ -256,36 +232,78 @@ TEST(SparseOpSCCsTest, DiamondNoCycle) {
   Operation *mergeOp = &*it++;
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
-  SparseOpSCC<OpSCCDirection::Reachable> opScc;
-  opScc.visit(andOp);
+  // Without filter: all five ops, orOp/xorOp order is DFS-dependent.
+  {
+    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    opScc.visit(andOp);
 
-  EXPECT_EQ(opScc.getNumSCCs(), 5u);
-  EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+    EXPECT_EQ(opScc.getNumSCCs(), 5u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
 
-  // outputOp first, mergeOp second, andOp last; orOp/xorOp order is
-  // DFS-dependent.
-  auto revIt = opScc.reverseTopological_begin();
-  EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
-  EXPECT_EQ(cast<Operation *>(*(revIt++)), mergeOp);
-  std::array<Operation *, 2> middle = {cast<Operation *>(*(revIt++)),
-                                       cast<Operation *>(*(revIt++))};
-  EXPECT_TRUE(llvm::is_contained(middle, orOp));
-  EXPECT_TRUE(llvm::is_contained(middle, xorOp));
-  EXPECT_EQ(cast<Operation *>(*(revIt++)), andOp);
-  EXPECT_EQ(revIt, opScc.reverseTopological_end());
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), mergeOp);
+    std::array<Operation *, 2> middle = {cast<Operation *>(*(revIt++)),
+                                         cast<Operation *>(*(revIt++))};
+    EXPECT_TRUE(llvm::is_contained(middle, orOp));
+    EXPECT_TRUE(llvm::is_contained(middle, xorOp));
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), andOp);
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
+
+  // Reachable direction with edge filter blocking xorOp as destination: only
+  // the left branch (andOp->orOp->mergeOp->outputOp) is visited. xorOp is
+  // never reachable, so 4 trivial SCCs in deterministic reverseTopological
+  // order: outputOp, mergeOp, orOp, andOp.
+  {
+    auto filter = [&](Operation *op, OpOperand &) { return op != xorOp; };
+    SparseOpSCC<OpSCCDirection::Reachable> opScc(filter);
+    opScc.visit(andOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 4u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), mergeOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), orOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), andOp);
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
+
+  // Reaching direction from outputOp with edge filter blocking xorOp as
+  // source: the backward path through xorOp is cut, so only the left branch
+  // (orOp) is visited (outputOp<-mergeOp<-orOp<-andOp). 4 trivial SCCs in
+  // reverseTopological order (sinks-first): outputOp, mergeOp, orOp, andOp.
+  {
+    auto filter = [&](Operation *src, OpOperand &) { return src != xorOp; };
+    SparseOpSCC<OpSCCDirection::Reaching> opScc(filter);
+    opScc.visit(outputOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 4u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), mergeOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), orOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), andOp);
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
 }
 
 // Graph with a cycle: and uses reg's result, reg uses and's result.
 //
-//   %reg = seq.firreg %and clock %clock : i1
+//   %reg = seq.firreg %and clock %clock reset sync %reset, %and : i1
 //   %and = comb.and %reg, %a : i1
 //   hw.output %and : i1
 //
+// %and feeds reg.next (the cycle edge) and reg.resetValue.
 // Block order: regOp, andOp, outputOp (terminator).
-// Forward edges: reg->and, and->{reg, output}.
+// Forward edges: reg->and, and->{reg(next), reg(resetValue), output}.
 const char *cycleIr = R"MLIR(
-  hw.module private @cycle(in %clock: !seq.clock, in %a: i1, out x: i1) {
-    %reg = seq.firreg %and clock %clock : i1
+  hw.module private @cycle(in %clock: !seq.clock, in %reset: i1, in %a: i1, out x: i1) {
+    %reg = seq.firreg %and clock %clock reset sync %reset, %and : i1
     %and = comb.and %reg, %a : i1
     hw.output %and : i1
   }
@@ -329,7 +347,7 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
 
   // With filter that excludes regOp: no cycle, both ops are trivial.
   {
-    auto filter = [&](Operation *op) { return op != regOp; };
+    auto filter = [&](Operation *op, OpOperand &) { return op != regOp; };
     SparseOpSCC<OpSCCDirection::Reachable> opScc(filter);
     opScc.visit(andOp);
 
@@ -340,6 +358,55 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
     EXPECT_EQ(cast<Operation *>(*(topoIt++)), andOp);
     EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
     EXPECT_EQ(topoIt, opScc.topological_end());
+  }
+
+  // With edge filter blocking only reg's 'next' operand: %and also drives
+  // reg.resetValue, so the cycle persists through the reset edge.
+  {
+    auto regEdgeFilter = [](Operation *, OpOperand &operand) -> bool {
+      if (auto firReg = dyn_cast<seq::FirRegOp>(operand.getOwner()))
+        return operand != firReg.getNextMutable();
+      return true;
+    };
+    SparseOpSCC<OpSCCDirection::Reachable> opScc(regEdgeFilter);
+    opScc.visit(andOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+
+    CyclicOpSCC scc = cast<CyclicOpSCC>(*revIt++);
+    ASSERT_EQ(scc.size(), 2u);
+    EXPECT_TRUE(llvm::is_contained(scc, regOp));
+    EXPECT_TRUE(llvm::is_contained(scc, andOp));
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
+
+  // Reaching direction from outputOp with regEdgeFilter: the backward path
+  // through reg.resetValue keeps the cycle alive even though reg.next is
+  // blocked. reverseTopological order (sinks-first): outputOp, then
+  // CyclicOpSCC{regOp,andOp}.
+  {
+    auto regEdgeFilter = [](Operation *, OpOperand &operand) -> bool {
+      if (auto firReg = dyn_cast<seq::FirRegOp>(operand.getOwner()))
+        return operand != firReg.getNextMutable();
+      return true;
+    };
+    SparseOpSCC<OpSCCDirection::Reaching> opScc(regEdgeFilter);
+    opScc.visit(outputOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    CyclicOpSCC scc = cast<CyclicOpSCC>(*revIt++);
+    ASSERT_EQ(scc.size(), 2u);
+    EXPECT_TRUE(llvm::is_contained(scc, regOp));
+    EXPECT_TRUE(llvm::is_contained(scc, andOp));
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
   }
 }
 

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -50,7 +50,7 @@ TEST(SparseOpSCCsTest, SimpleChain) {
   // Forward reachability from andOp.
   // Reverse topological order: leaves-first -> [outputOp, orOp, andOp].
   {
-    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(andOp);
 
     EXPECT_EQ(opScc.getNumVisited(), 3u);
@@ -73,7 +73,7 @@ TEST(SparseOpSCCsTest, SimpleChain) {
   // Follows operands backward; reverse topo of inverse = forward topo:
   // [andOp, orOp, outputOp].
   {
-    SparseOpSCC<OpSCCDirection::Reaching> opScc;
+    SparseOpSCC<OpSCCDirection::Backward> opScc;
     opScc.visit(outputOp);
 
     EXPECT_EQ(opScc.getNumVisited(), 3u);
@@ -95,13 +95,13 @@ TEST(SparseOpSCCsTest, SimpleChain) {
 
 // Passing an empty seed list leaves all counts at zero.
 TEST(SparseOpSCCsTest, EmptySeeds) {
-  SparseOpSCC<OpSCCDirection::Reachable> fwd;
+  SparseOpSCC<OpSCCDirection::Forward> fwd;
   fwd.visit(ArrayRef<Operation *>{});
   EXPECT_EQ(fwd.getNumVisited(), 0u);
   EXPECT_EQ(fwd.getNumSCCs(), 0u);
   EXPECT_EQ(fwd.getNumCyclicSCCs(), 0u);
 
-  SparseOpSCC<OpSCCDirection::Reaching> inv;
+  SparseOpSCC<OpSCCDirection::Backward> inv;
   inv.visit(ArrayRef<Operation *>{});
   EXPECT_EQ(inv.getNumVisited(), 0u);
   EXPECT_EQ(inv.getNumSCCs(), 0u);
@@ -131,7 +131,7 @@ TEST(SparseOpSCCsTest, BoundarySeed) {
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
   {
-    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(outputOp);
 
     EXPECT_EQ(opScc.getNumVisited(), 1u);
@@ -144,7 +144,7 @@ TEST(SparseOpSCCsTest, BoundarySeed) {
   }
 
   {
-    SparseOpSCC<OpSCCDirection::Reaching> opScc;
+    SparseOpSCC<OpSCCDirection::Backward> opScc;
     opScc.visit(andOp);
 
     EXPECT_EQ(opScc.getNumVisited(), 1u);
@@ -177,7 +177,7 @@ TEST(SparseOpSCCsTest, OverlappingSeeds) {
   Operation *orOp = &*it++;
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
-  SparseOpSCC<OpSCCDirection::Reachable> opScc;
+  SparseOpSCC<OpSCCDirection::Forward> opScc;
   opScc.visit(andOp);
   opScc.visit(orOp); // already visited via andOp — skipped
 
@@ -234,7 +234,7 @@ TEST(SparseOpSCCsTest, DiamondNoCycle) {
 
   // Without filter: all five ops, orOp/xorOp order is DFS-dependent.
   {
-    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(andOp);
 
     EXPECT_EQ(opScc.getNumSCCs(), 5u);
@@ -251,13 +251,13 @@ TEST(SparseOpSCCsTest, DiamondNoCycle) {
     EXPECT_EQ(revIt, opScc.reverseTopological_end());
   }
 
-  // Reachable direction with edge filter blocking xorOp as destination: only
+  // Forward direction with edge filter blocking xorOp as destination: only
   // the left branch (andOp->orOp->mergeOp->outputOp) is visited. xorOp is
   // never reachable, so 4 trivial SCCs in deterministic reverseTopological
   // order: outputOp, mergeOp, orOp, andOp.
   {
     auto filter = [&](Operation *op, OpOperand &) { return op != xorOp; };
-    SparseOpSCC<OpSCCDirection::Reachable> opScc(filter);
+    SparseOpSCC<OpSCCDirection::Forward> opScc(filter);
     opScc.visit(andOp);
 
     EXPECT_EQ(opScc.getNumSCCs(), 4u);
@@ -271,13 +271,13 @@ TEST(SparseOpSCCsTest, DiamondNoCycle) {
     EXPECT_EQ(revIt, opScc.reverseTopological_end());
   }
 
-  // Reaching direction from outputOp with edge filter blocking xorOp as
+  // Backward direction from outputOp with edge filter blocking xorOp as
   // source: the backward path through xorOp is cut, so only the left branch
   // (orOp) is visited (outputOp<-mergeOp<-orOp<-andOp). 4 trivial SCCs in
   // reverseTopological order (sinks-first): outputOp, mergeOp, orOp, andOp.
   {
     auto filter = [&](Operation *src, OpOperand &) { return src != xorOp; };
-    SparseOpSCC<OpSCCDirection::Reaching> opScc(filter);
+    SparseOpSCC<OpSCCDirection::Backward> opScc(filter);
     opScc.visit(outputOp);
 
     EXPECT_EQ(opScc.getNumSCCs(), 4u);
@@ -329,7 +329,7 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
 
   // Without filter: reg and and form a cycle -> one CyclicOpSCC.
   {
-    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(andOp);
 
     EXPECT_EQ(opScc.getNumSCCs(), 2u);
@@ -348,7 +348,7 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
   // With filter that excludes regOp: no cycle, both ops are trivial.
   {
     auto filter = [&](Operation *op, OpOperand &) { return op != regOp; };
-    SparseOpSCC<OpSCCDirection::Reachable> opScc(filter);
+    SparseOpSCC<OpSCCDirection::Forward> opScc(filter);
     opScc.visit(andOp);
 
     EXPECT_EQ(opScc.getNumSCCs(), 2u);
@@ -368,7 +368,7 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
         return operand != firReg.getNextMutable();
       return true;
     };
-    SparseOpSCC<OpSCCDirection::Reachable> opScc(regEdgeFilter);
+    SparseOpSCC<OpSCCDirection::Forward> opScc(regEdgeFilter);
     opScc.visit(andOp);
 
     EXPECT_EQ(opScc.getNumSCCs(), 2u);
@@ -384,7 +384,7 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
     EXPECT_EQ(revIt, opScc.reverseTopological_end());
   }
 
-  // Reaching direction from outputOp with regEdgeFilter: the backward path
+  // Backward direction from outputOp with regEdgeFilter: the backward path
   // through reg.resetValue keeps the cycle alive even though reg.next is
   // blocked. reverseTopological order (sinks-first): outputOp, then
   // CyclicOpSCC{regOp,andOp}.
@@ -394,7 +394,7 @@ TEST(SparseOpSCCsTest, CycleWithRegister) {
         return operand != firReg.getNextMutable();
       return true;
     };
-    SparseOpSCC<OpSCCDirection::Reaching> opScc(regEdgeFilter);
+    SparseOpSCC<OpSCCDirection::Backward> opScc(regEdgeFilter);
     opScc.visit(outputOp);
 
     EXPECT_EQ(opScc.getNumSCCs(), 2u);
@@ -454,7 +454,7 @@ TEST(SparseOpSCCsTest, TwoCycles) {
   Operation *xorOp = &*it++;
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
-  SparseOpSCC<OpSCCDirection::Reachable> opScc;
+  SparseOpSCC<OpSCCDirection::Forward> opScc;
   opScc.visit(and1Op);
   opScc.visit(or1Op);
 
@@ -534,7 +534,7 @@ TEST(SparseOpSCCsTest, TwoInternalCycles) {
   // Forward direction from and1Op: outputOp is the only leaf; the five-op SCC
   // follows.
   {
-    SparseOpSCC<OpSCCDirection::Reachable> opScc;
+    SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(and1Op);
 
     EXPECT_EQ(opScc.getNumSCCs(), 2u);
@@ -549,7 +549,7 @@ TEST(SparseOpSCCsTest, TwoInternalCycles) {
   // Inverse direction from outputOp: the five-op SCC precedes outputOp
   // (topological order: predecessors before successors).
   {
-    SparseOpSCC<OpSCCDirection::Reaching> opScc;
+    SparseOpSCC<OpSCCDirection::Backward> opScc;
     opScc.visit(outputOp);
 
     EXPECT_EQ(opScc.getNumSCCs(), 2u);
@@ -587,7 +587,7 @@ TEST(SparseOpSCCsTest, SelfLoop) {
   Operation *andOp = &*it++;
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
-  SparseOpSCC<OpSCCDirection::Reachable> opScc;
+  SparseOpSCC<OpSCCDirection::Forward> opScc;
   opScc.visit(andOp);
 
   // outputOp is a trivial leaf; andOp is a size-1 CyclicOpSCC due to self-loop.

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -147,11 +147,10 @@ TEST(SparseOpSCCsTest, BoundarySeed) {
     EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
     EXPECT_EQ(topoIt, opScc.topological_end());
 
-    // getSCC returns a valid entry for the visited op and NullOpSCC for
+    // getSCC returns a valid entry for the visited op and null for
     // unvisited.
     EXPECT_EQ(cast<Operation *>(opScc.getSCC(outputOp)), outputOp);
-    EXPECT_TRUE(isa<NullOpSCC>(opScc.getSCC(andOp)));
-    EXPECT_FALSE(opScc.getSCC(andOp));
+    EXPECT_FALSE(static_cast<bool>(opScc.getSCC(andOp)));
   }
 
   {
@@ -487,11 +486,21 @@ TEST(SparseOpSCCsTest, TwoCycles) {
   EXPECT_TRUE(llvm::is_contained(scc0, reg1Op));
   EXPECT_TRUE(llvm::is_contained(scc0, and1Op));
 
+  EXPECT_EQ(opScc.getSCC(reg1Op), opScc.getSCC(and1Op));
+  EXPECT_NE(opScc.getSCC(reg1Op), opScc.getSCC(or1Op));
+  EXPECT_NE(opScc.getSCC(reg1Op), opScc.getSCC(xorOp));
+  EXPECT_NE(opScc.getSCC(reg1Op), opScc.getSCC(hwModule));
+
   // Second cyclic SCC: reg2 <-> or1.
   CyclicOpSCC scc1 = cast<CyclicOpSCC>(*revIt++);
   EXPECT_EQ(scc1.size(), 2u);
   EXPECT_TRUE(llvm::is_contained(scc1, reg2Op));
   EXPECT_TRUE(llvm::is_contained(scc1, or1Op));
+
+  EXPECT_EQ(opScc.getSCC(reg2Op), opScc.getSCC(or1Op));
+  EXPECT_NE(opScc.getSCC(or1Op), opScc.getSCC(and1Op));
+  EXPECT_NE(opScc.getSCC(or1Op), opScc.getSCC(xorOp));
+  EXPECT_NE(opScc.getSCC(or1Op), opScc.getSCC(hwModule));
 
   EXPECT_EQ(revIt, opScc.reverseTopological_end());
 }
@@ -558,7 +567,10 @@ TEST(SparseOpSCCsTest, TwoInternalCycles) {
 
     auto revIt = opScc.reverseTopological_begin();
     EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
-    checkFiveOpSCC(cast<CyclicOpSCC>(*revIt++));
+    auto cyclicSCC = cast<CyclicOpSCC>(*revIt++);
+    checkFiveOpSCC(cyclicSCC);
+    EXPECT_TRUE(llvm::all_equal(llvm::map_range(
+        cyclicSCC, [&](Operation *op) -> OpSCC { return opScc.getSCC(op); })));
     EXPECT_EQ(revIt, opScc.reverseTopological_end());
   }
 
@@ -572,7 +584,10 @@ TEST(SparseOpSCCsTest, TwoInternalCycles) {
     EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
 
     auto topoIt = opScc.topological_begin();
-    checkFiveOpSCC(cast<CyclicOpSCC>(*topoIt++));
+    auto cyclicSCC = cast<CyclicOpSCC>(*topoIt++);
+    checkFiveOpSCC(cyclicSCC);
+    EXPECT_TRUE(llvm::all_equal(llvm::map_range(
+        cyclicSCC, [&](Operation *op) -> OpSCC { return opScc.getSCC(op); })));
     EXPECT_EQ(cast<Operation *>(*(topoIt++)), outputOp);
     EXPECT_EQ(topoIt, opScc.topological_end());
   }
@@ -757,25 +772,27 @@ TEST(SparseOpSCCsTest, OpSCCCasting) {
   // isa<> correctly identifies each variant.
   EXPECT_TRUE(isa<Operation *>(trivialEntry));
   EXPECT_FALSE(isa<CyclicOpSCC>(trivialEntry));
-  EXPECT_FALSE(isa<NullOpSCC>(trivialEntry));
 
   EXPECT_FALSE(isa<Operation *>(cyclicEntry));
   EXPECT_TRUE(isa<CyclicOpSCC>(cyclicEntry));
-  EXPECT_FALSE(isa<NullOpSCC>(cyclicEntry));
 
   EXPECT_FALSE(isa<Operation *>(nullEntry));
   EXPECT_FALSE(isa<CyclicOpSCC>(nullEntry));
-  EXPECT_TRUE(isa<NullOpSCC>(nullEntry));
 
-  // A NullOpSCC entry is bool-false; present entries are bool-true.
-  EXPECT_FALSE(nullEntry);
-  EXPECT_TRUE(trivialEntry);
-  EXPECT_TRUE(cyclicEntry);
+  // An undiscovered entry is bool-false; present entries are bool-true.
+  EXPECT_FALSE(static_cast<bool>(nullEntry));
+  EXPECT_TRUE(static_cast<bool>(trivialEntry));
+  EXPECT_TRUE(static_cast<bool>(cyclicEntry));
 
   // dyn_cast on known-present values.
   EXPECT_EQ(dyn_cast<Operation *>(trivialEntry), outputOp);
   EXPECT_EQ(dyn_cast<Operation *>(cyclicEntry), nullptr);
-  EXPECT_FALSE(dyn_cast<CyclicOpSCC>(trivialEntry));
+
+  EXPECT_EQ(dyn_cast<CyclicOpSCC>(cyclicEntry), opScc.getSCC(regOp));
+  EXPECT_NE(dyn_cast<CyclicOpSCC>(cyclicEntry), opScc.getSCC(outputOp));
+  EXPECT_NE(dyn_cast<CyclicOpSCC>(cyclicEntry), opScc.getSCC(unusedOp));
+
+  EXPECT_FALSE(static_cast<bool>(dyn_cast<CyclicOpSCC>(trivialEntry)));
   if (auto scc = dyn_cast<CyclicOpSCC>(cyclicEntry)) {
     EXPECT_EQ(scc.size(), 2u);
     EXPECT_TRUE(llvm::is_contained(scc, regOp));
@@ -786,7 +803,7 @@ TEST(SparseOpSCCsTest, OpSCCCasting) {
 
   // dyn_cast_if_present additionally handles null entries gracefully.
   EXPECT_EQ(dyn_cast_if_present<Operation *>(nullEntry), nullptr);
-  EXPECT_FALSE(dyn_cast_if_present<CyclicOpSCC>(nullEntry));
+  EXPECT_FALSE(static_cast<bool>(dyn_cast_if_present<CyclicOpSCC>(nullEntry)));
 }
 
 } // namespace

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -53,7 +53,7 @@ TEST(SparseOpSCCsTest, SimpleChain) {
     SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(andOp);
 
-    EXPECT_EQ(opScc.getNumVisited(), 3u);
+    EXPECT_EQ(opScc.getNumDiscovered(), 3u);
     EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
 
     auto topoIt = opScc.topological_begin();
@@ -81,7 +81,7 @@ TEST(SparseOpSCCsTest, SimpleChain) {
     SparseOpSCC<OpSCCDirection::Backward> opScc;
     opScc.visit(outputOp);
 
-    EXPECT_EQ(opScc.getNumVisited(), 3u);
+    EXPECT_EQ(opScc.getNumDiscovered(), 3u);
     EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
 
     auto topoIt = opScc.topological_begin();
@@ -102,13 +102,13 @@ TEST(SparseOpSCCsTest, SimpleChain) {
 TEST(SparseOpSCCsTest, EmptySeeds) {
   SparseOpSCC<OpSCCDirection::Forward> fwd;
   fwd.visit(ArrayRef<Operation *>{});
-  EXPECT_EQ(fwd.getNumVisited(), 0u);
+  EXPECT_EQ(fwd.getNumDiscovered(), 0u);
   EXPECT_EQ(fwd.getNumSCCs(), 0u);
   EXPECT_EQ(fwd.getNumCyclicSCCs(), 0u);
 
   SparseOpSCC<OpSCCDirection::Backward> inv;
   inv.visit(ArrayRef<Operation *>{});
-  EXPECT_EQ(inv.getNumVisited(), 0u);
+  EXPECT_EQ(inv.getNumDiscovered(), 0u);
   EXPECT_EQ(inv.getNumSCCs(), 0u);
   EXPECT_EQ(inv.getNumCyclicSCCs(), 0u);
 }
@@ -139,7 +139,7 @@ TEST(SparseOpSCCsTest, BoundarySeed) {
     SparseOpSCC<OpSCCDirection::Forward> opScc;
     opScc.visit(outputOp);
 
-    EXPECT_EQ(opScc.getNumVisited(), 1u);
+    EXPECT_EQ(opScc.getNumDiscovered(), 1u);
     EXPECT_EQ(opScc.getNumSCCs(), 1u);
     EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
 
@@ -158,7 +158,7 @@ TEST(SparseOpSCCsTest, BoundarySeed) {
     SparseOpSCC<OpSCCDirection::Backward> opScc;
     opScc.visit(andOp);
 
-    EXPECT_EQ(opScc.getNumVisited(), 1u);
+    EXPECT_EQ(opScc.getNumDiscovered(), 1u);
     EXPECT_EQ(opScc.getNumSCCs(), 1u);
     EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
 

--- a/unittests/Support/SparseOpSCCTest.cpp
+++ b/unittests/Support/SparseOpSCCTest.cpp
@@ -587,21 +587,115 @@ TEST(SparseOpSCCsTest, SelfLoop) {
   Operation *andOp = &*it++;
   Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
 
-  SparseOpSCC<OpSCCDirection::Forward> opScc;
-  opScc.visit(andOp);
+  // Without filter: andOp is a size-1 CyclicOpSCC due to self-loop.
+  {
+    SparseOpSCC<OpSCCDirection::Forward> opScc;
+    opScc.visit(andOp);
 
-  // outputOp is a trivial leaf; andOp is a size-1 CyclicOpSCC due to self-loop.
-  EXPECT_EQ(opScc.getNumSCCs(), 2u);
-  EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
 
-  auto revIt = opScc.reverseTopological_begin();
-  EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
-  // Second entry is a CyclicOpSCC, not a plain Operation *.
-  EXPECT_EQ(dyn_cast<Operation *>(*revIt), nullptr);
-  CyclicOpSCC scc = cast<CyclicOpSCC>(*revIt++);
-  EXPECT_EQ(scc.size(), 1u);
-  EXPECT_EQ(scc[0], andOp);
-  EXPECT_EQ(revIt, opScc.reverseTopological_end());
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    EXPECT_EQ(dyn_cast<Operation *>(*revIt), nullptr);
+    CyclicOpSCC scc = cast<CyclicOpSCC>(*revIt++);
+    EXPECT_EQ(scc.size(), 1u);
+    EXPECT_EQ(scc[0], andOp);
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
+
+  // With edge filter blocking the self-loop edge: andOp becomes trivial.
+  {
+    auto filter = [&](Operation *dest, OpOperand &) { return dest != andOp; };
+    SparseOpSCC<OpSCCDirection::Forward> opScc(filter);
+    opScc.visit(andOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), andOp);
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
+}
+
+// Self-loop via register: both 'next' and 'resetValue' feed back into the
+// register itself, creating two independent self-loop edges.
+//
+//   %reg = seq.firreg %reg clock %clock reset sync %reset, %reg : i1
+//
+// Operand 0 (next) and operand 3 (resetValue) are both self-loop edges.
+const char *selfLoopRegIr = R"MLIR(
+  hw.module private @selfloopReg(in %clock: !seq.clock, in %reset: i1, out x: i1) {
+    %reg = seq.firreg %reg clock %clock reset sync %reset, %reg : i1
+    hw.output %reg : i1
+  }
+)MLIR";
+
+TEST(SparseOpSCCsTest, SelfLoopRegWithEdgeFilter) {
+  MLIRContext context;
+  context.loadDialect<hw::HWDialect>();
+  context.loadDialect<seq::SeqDialect>();
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(selfLoopRegIr, &context);
+  ASSERT_TRUE(module);
+
+  SymbolTable symbolTable(module.get());
+  auto hwModule = symbolTable.lookup<hw::HWModuleOp>("selfloopReg");
+  ASSERT_TRUE(hwModule);
+
+  auto it = hwModule.getBodyBlock()->begin();
+  Operation *regOp = &*it++;
+  Operation *outputOp = hwModule.getBodyBlock()->getTerminator();
+
+  // Without filter: both self-loop edges are visible -> CyclicOpSCC of size 1.
+  {
+    SparseOpSCC<OpSCCDirection::Forward> opScc;
+    opScc.visit(regOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    CyclicOpSCC scc = cast<CyclicOpSCC>(*revIt++);
+    ASSERT_EQ(scc.size(), 1u);
+    EXPECT_EQ(scc[0], regOp);
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
+
+  // Filter blocking only 'next': resetValue self-loop edge is still
+  // traversable -> still classified as CyclicOpSCC.
+  {
+    auto regEdgeFilter = [](Operation *, OpOperand &operand) -> bool {
+      if (auto firReg = dyn_cast<seq::FirRegOp>(operand.getOwner()))
+        return operand != firReg.getNextMutable();
+      return true;
+    };
+    SparseOpSCC<OpSCCDirection::Forward> opScc(regEdgeFilter);
+    opScc.visit(regOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 1u);
+  }
+
+  // Filter blocking all edges into regOp: both self-loop edges blocked ->
+  // regOp becomes trivial.
+  {
+    auto filter = [&](Operation *dest, OpOperand &) { return dest != regOp; };
+    SparseOpSCC<OpSCCDirection::Forward> opScc(filter);
+    opScc.visit(regOp);
+
+    EXPECT_EQ(opScc.getNumSCCs(), 2u);
+    EXPECT_EQ(opScc.getNumCyclicSCCs(), 0u);
+
+    auto revIt = opScc.reverseTopological_begin();
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), outputOp);
+    EXPECT_EQ(cast<Operation *>(*(revIt++)), regOp);
+    EXPECT_EQ(revIt, opScc.reverseTopological_end());
+  }
 }
 
 } // namespace


### PR DESCRIPTION
This PR adds a helper class that collects strongly connected components (SCCs) on a subset of the MLIR operation graph, and allows iterating over them in (reverse) topological order.

I frequently find myself needing to collect a (filtered) graph of operations feeding into one or several given operations to clone or erase them. My ad-hoc implementations are often tedious, error-prone, may have quadratic scaling and/or fail to handle cycles in the graph. So I'm hoping to get this right with a reusable implementation. 

The `SparseOpSCC` class contains a simple implementation of [Tarjan's SCC algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm) that can iteratively construct a list of SCCs which are reaching or are reachable by a set of given operations. Its constructor takes an optional filter function as argument, that allows us to exclude certain ~~operations~~  (Update:) edges from the graph. E.g., this can be used to ignore register operations, which in many practical cases will make the remaining graph acyclic. If, and only if, the graph is acyclic, every found SCC will simply be represented by an `Operation *`. Cyclic SCCs are stored separately  as a vector of `Operation *` wrapped by the `CyclicOpSCC` helper class.

I initially tried building this around the existing `llvm::scc_iterator`, but couldn't figure out a  "nice" way to get the desired API without having to allocate a wrapper around each `Operation *`. Let me know if you can think of a way of doing this better, or if I'm missing existing infra that already solves this problem.

AI Disclosure: The code was written with AI assistance. The unit tests are entirely AI generated.

Assisted-by: Claude Code:Sonnet 4.6