### PR TITLE
[ESI][Runtime] Switch ReadChannelPort to segmented

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
@@ -107,10 +107,52 @@ struct HWClientDetail {
 using HWClientDetails = std::vector<HWClientDetail>;
 using ServiceImplDetails = std::map<std::string, std::any>;
 
-/// A logical chunk of data representing serialized data. Currently, just a
-/// wrapper for a vector of bytes, which is not efficient in terms of memory
-/// copying. This will change in the future as will the API.
-class MessageData {
+class MessageData;
+
+//===----------------------------------------------------------------------===//
+// SegmentedMessageData -- multi-segment message support.
+//===----------------------------------------------------------------------===//
+
+/// A contiguous, non-owning view of bytes within a SegmentedMessageData.
+/// Valid only while the owning SegmentedMessageData is alive.
+struct Segment {
+  const uint8_t *data;
+  size_t size;
+  std::span<const uint8_t> span() const { return {data, size}; }
+  bool empty() const { return size == 0; }
+};
+
+/// Abstract multi-segment message. Generated types subclass this to expose
+/// header + list segments without flattening into a contiguous buffer.
+///
+/// MessageData is the canonical flat, one-segment implementation of this
+/// interface. Other subclasses represent naturally segmented layouts.
+///
+/// Subclasses MUST own all data that their segments point to. Read and write
+/// APIs can hold the message across async boundaries / retries.
+class SegmentedMessageData {
+public:
+  virtual ~SegmentedMessageData() = default;
+
+  /// Number of segments in the message.
+  virtual size_t numSegments() const = 0;
+  /// Get a segment by index.
+  virtual Segment segment(size_t idx) const = 0;
+
+  /// Total size across all segments.
+  size_t totalSize() const;
+  /// True if totalSize() == 0.
+  bool empty() const;
+
+  /// Flatten all segments into a standard MessageData.
+  virtual MessageData toMessageData() const;
+};
+
+/// A concrete flat message backed by a single vector of bytes.
+///
+/// This is also a one-segment SegmentedMessageData so flat and segmented
+/// messages can flow through the same internal APIs.
+class MessageData : public SegmentedMessageData {
 public:
   /// Adopts the data vector buffer.
   MessageData() = default;
@@ -162,47 +204,16 @@ public:
   /// Convert the data to a hex string.
   std::string toHex() const;
 
+  size_t numSegments() const override { return 1; }
+  Segment segment(size_t idx) const override {
+    if (idx != 0)
+      throw std::out_of_range("MessageData only has one segment");
+    return {data.data(), data.size()};
+  }
+  MessageData toMessageData() const override { return *this; }
+
 private:
   std::vector<uint8_t> data;
-};
-
-//===----------------------------------------------------------------------===//
-// SegmentedMessageData — multi-segment message for generated types.
-//===----------------------------------------------------------------------===//
-
-/// A contiguous, non-owning view of bytes within a SegmentedMessageData.
-/// Valid only while the owning SegmentedMessageData is alive.
-struct Segment {
-  const uint8_t *data;
-  size_t size;
-  std::span<const uint8_t> span() const { return {data, size}; }
-  bool empty() const { return size == 0; }
-};
-
-/// Abstract multi-segment message. Generated types subclass this to expose
-/// header + list segments without flattening into a contiguous buffer.
-///
-/// This class does NOT replace MessageData. It lives alongside it.
-///
-/// Subclasses MUST own all data that their segments point to. The write API
-/// takes ownership (unique_ptr<SegmentedMessageData>) and a backend may hold
-/// the message across async boundaries / partial writes.
-class SegmentedMessageData {
-public:
-  virtual ~SegmentedMessageData() = default;
-
-  /// Number of segments in the message.
-  virtual size_t numSegments() const = 0;
-  /// Get a segment by index.
-  virtual Segment segment(size_t idx) const = 0;
-
-  /// Total size across all segments.
-  size_t totalSize() const;
-  /// True if totalSize() == 0.
-  bool empty() const;
-
-  /// Flatten all segments into a standard MessageData.
-  MessageData toMessageData() const;
 };
 
 /// Cursor for incremental consumption of a SegmentedMessageData.

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -341,6 +341,10 @@ protected:
 class ReadChannelPort : public ChannelPort {
 
 public:
+  using ReadCallback =
+      std::function<bool(std::unique_ptr<SegmentedMessageData> &)>;
+  using FlatReadCallback = std::function<bool(MessageData)>;
+
   ReadChannelPort(const Type *type)
       : ChannelPort(type), mode(Mode::Disconnected) {}
   virtual void disconnect() override { mode = Mode::Disconnected; }
@@ -359,7 +363,10 @@ public:
   // wait, and be notified.
   //===--------------------------------------------------------------------===//
 
-  virtual void connect(std::function<bool(MessageData)> callback,
+  virtual void connect(ReadCallback callback,
+                       const ConnectOptions &options = {});
+
+  virtual void connect(FlatReadCallback callback,
                        const ConnectOptions &options = {});
 
   //===--------------------------------------------------------------------===//
@@ -398,7 +405,11 @@ protected:
   volatile Mode mode;
 
   /// Backends call this callback when new data is available.
-  std::function<bool(MessageData)> callback;
+  ReadCallback callback;
+
+  /// If a translated message has been assembled but not yet consumed, retain
+  /// ownership here so retries present the same message object.
+  std::unique_ptr<SegmentedMessageData> translatedMessage;
 
   /// Window translation support.
   std::vector<uint8_t> translationBuffer;
@@ -435,7 +446,11 @@ public:
   UnknownReadChannelPort(const Type *type, std::string errmsg)
       : ReadChannelPort(type), errmsg(errmsg) {}
 
-  void connect(std::function<bool(MessageData)> callback,
+  void connect(ReadCallback callback,
+               const ConnectOptions &options = ConnectOptions()) override {
+    throw std::runtime_error(errmsg);
+  }
+  void connect(FlatReadCallback callback,
                const ConnectOptions &options = ConnectOptions()) override {
     throw std::runtime_error(errmsg);
   }

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/RpcClient.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/RpcClient.h
@@ -69,8 +69,10 @@ public:
   void writeToServer(const std::string &channelName, const MessageData &data);
 
   /// Callback type for receiving messages from a client-bound channel.
-  /// Return true if the message was consumed, false to retry.
-  using ReadCallback = std::function<bool(const MessageData &)>;
+  /// Return true if the message was consumed, false to retry the same owning
+  /// message object.
+  using ReadCallback =
+      std::function<bool(std::unique_ptr<SegmentedMessageData> &)>;
 
   /// Abstract handle for a read channel connection.
   /// Destructor disconnects from the channel.

--- a/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
@@ -96,6 +96,8 @@ protected:
   OneItemBuffersToHost *engine;
   // Single buffer.
   std::unique_ptr<services::HostMem::HostMemRegion> buffer;
+  // Retain the current message across callback retries.
+  std::unique_ptr<SegmentedMessageData> pendingMessage;
   // Number of times the poll function has been called.
   uint64_t pollCount = 0;
 
@@ -198,27 +200,34 @@ void OneItemBuffersToHostReadPort::connectImpl(
 }
 
 bool OneItemBuffersToHostReadPort::pollImpl() {
-  // Check to see if the buffer has been filled.
-  uint8_t *bufferData = reinterpret_cast<uint8_t *>(buffer->getPtr());
-  if (bufferData[bufferSize - 1] == 0)
-    return false;
-
   Logger &logger = engine->conn.getLogger();
 
-  // If it has, copy the data out. If the consumer (callback) reports that it
-  // has accepted the data, re-use the buffer.
-  MessageData data(bufferData, bufferSize - 1);
-  logger.trace(
-      [this, data](std::string &subsystem, std::string &msg,
-                   std::unique_ptr<std::map<std::string, std::any>> &details) {
-        subsystem = "OneItemBuffersToHost";
-        msg = "recieved message";
-        details = std::make_unique<std::map<std::string, std::any>>();
-        (*details)["channel"] = identifier();
-        (*details)["data_size"] = data.getSize();
-        (*details)["message_data"] = data.toHex();
-      });
-  if (callback(std::move(data))) {
+  auto tryDeliverPending = [&]() {
+    logger.trace(
+        [&](std::string &subsystem, std::string &msg,
+            std::unique_ptr<std::map<std::string, std::any>> &details) {
+          subsystem = "OneItemBuffersToHost";
+          msg = "recieved message";
+          details = std::make_unique<std::map<std::string, std::any>>();
+          MessageData flat = pendingMessage->toMessageData();
+          (*details)["channel"] = identifier();
+          (*details)["data_size"] = flat.getSize();
+          (*details)["message_data"] = flat.toHex();
+        });
+
+    if (!callback(pendingMessage)) {
+      logger.trace(
+          [&](std::string &subsystem, std::string &msg,
+              std::unique_ptr<std::map<std::string, std::any>> &details) {
+            subsystem = "OneItemBuffersToHost";
+            msg = "callback rejected data";
+            details = std::make_unique<std::map<std::string, std::any>>();
+            (*details)["channel"] = identifier();
+          });
+      return false;
+    }
+
+    pendingMessage.reset();
     writeBufferPtr();
     logger.trace(
         [this](std::string &subsystem, std::string &msg,
@@ -229,16 +238,19 @@ bool OneItemBuffersToHostReadPort::pollImpl() {
           (*details)["channel"] = identifier();
         });
     return true;
-  }
-  logger.trace(
-      [this](std::string &subsystem, std::string &msg,
-             std::unique_ptr<std::map<std::string, std::any>> &details) {
-        subsystem = "OneItemBuffersToHost";
-        msg = "callback rejected data";
-        details = std::make_unique<std::map<std::string, std::any>>();
-        (*details)["channel"] = identifier();
-      });
-  return false;
+  };
+
+  if (pendingMessage)
+    return tryDeliverPending();
+
+  // Check to see if the buffer has been filled.
+  uint8_t *bufferData = reinterpret_cast<uint8_t *>(buffer->getPtr());
+  if (bufferData[bufferSize - 1] == 0)
+    return false;
+
+  // If it has, copy the data out and retain it until the consumer accepts it.
+  pendingMessage = std::make_unique<MessageData>(bufferData, bufferSize - 1);
+  return tryDeliverPending();
 }
 
 REGISTER_ENGINE("OneItemBuffersToHost", OneItemBuffersToHost);

--- a/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
@@ -207,7 +207,7 @@ bool OneItemBuffersToHostReadPort::pollImpl() {
         [&](std::string &subsystem, std::string &msg,
             std::unique_ptr<std::map<std::string, std::any>> &details) {
           subsystem = "OneItemBuffersToHost";
-          msg = "recieved message";
+          msg = "received message";
           details = std::make_unique<std::map<std::string, std::any>>();
           MessageData flat = pendingMessage->toMessageData();
           (*details)["channel"] = identifier();

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -64,9 +64,10 @@ void ReadChannelPort::resetTranslationState() {
   accumulatingListData = false;
   translationBuffer.clear();
   listDataBuffer.clear();
+  translatedMessage.reset();
 }
 
-void ReadChannelPort::connect(std::function<bool(MessageData)> callback,
+void ReadChannelPort::connect(ReadCallback callback,
                               const ConnectOptions &options) {
   if (mode != Mode::Disconnected)
     throw std::runtime_error("Channel already connected");
@@ -75,9 +76,20 @@ void ReadChannelPort::connect(std::function<bool(MessageData)> callback,
 
   if (options.translateMessage && translationInfo) {
     translationInfo->precomputeFrameInfo();
-    this->callback = [this, cb = std::move(callback)](MessageData data) {
-      if (translateIncoming(data))
-        return cb(MessageData(std::move(translationBuffer)));
+    this->callback = [this, cb = std::move(callback)](
+                         std::unique_ptr<SegmentedMessageData> &data) {
+      if (!translatedMessage) {
+        MessageData flat = data->toMessageData();
+        if (!translateIncoming(flat))
+          return true;
+        translatedMessage =
+            std::make_unique<MessageData>(std::move(translationBuffer));
+      }
+
+      if (!cb(translatedMessage))
+        return false;
+
+      translatedMessage.reset();
       return true;
     };
   } else {
@@ -85,6 +97,14 @@ void ReadChannelPort::connect(std::function<bool(MessageData)> callback,
   }
   connectImpl(options);
   mode = Mode::Callback;
+}
+
+void ReadChannelPort::connect(FlatReadCallback callback,
+                              const ConnectOptions &options) {
+  connect(
+      [cb = std::move(callback)](std::unique_ptr<SegmentedMessageData> &data)
+          -> bool { return cb(data->toMessageData()); },
+      options);
 }
 
 void ReadChannelPort::connect(const ConnectOptions &options) {
@@ -95,11 +115,20 @@ void ReadChannelPort::connect(const ConnectOptions &options) {
   bool translate = options.translateMessage && translationInfo;
   if (translate)
     translationInfo->precomputeFrameInfo();
-  this->callback = [this, translate](MessageData data) {
+  this->callback = [this,
+                    translate](std::unique_ptr<SegmentedMessageData> &msg) {
+    MessageData data;
     if (translate) {
-      if (!translateIncoming(data))
-        return true;
-      data = MessageData(std::move(translationBuffer));
+      if (!translatedMessage) {
+        MessageData flat = msg->toMessageData();
+        if (!translateIncoming(flat))
+          return true;
+        translatedMessage =
+            std::make_unique<MessageData>(std::move(translationBuffer));
+      }
+      data = translatedMessage->toMessageData();
+    } else {
+      data = msg->toMessageData();
     }
 
     std::scoped_lock<std::mutex> lock(pollingM);
@@ -117,6 +146,8 @@ void ReadChannelPort::connect(const ConnectOptions &options) {
         return false;
       dataQueue.push(std::move(data));
     }
+
+    translatedMessage.reset();
     return true;
   };
   connectImpl(options);

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -107,8 +107,8 @@ public:
                                "' is not a to client channel");
 
     // Connect to the channel and set up callback.
-    connection =
-        client.connectClientReceiver(name, [this](const MessageData &data) {
+    connection = client.connectClientReceiver(
+        name, [this](std::unique_ptr<SegmentedMessageData> &data) {
           // Add trace logging for the received message.
           conn.getLogger().trace(
               [this, &data](
@@ -117,9 +117,10 @@ public:
                 subsystem = "cosim_read";
                 msg = "Received message from channel '" + name + "'";
                 details = std::make_unique<std::map<std::string, std::any>>();
+                MessageData flat = data->toMessageData();
                 (*details)["channel"] = name;
-                (*details)["data_size"] = data.getSize();
-                (*details)["message_data"] = data.toHex();
+                (*details)["data_size"] = flat.getSize();
+                (*details)["message_data"] = flat.toHex();
               });
 
           bool consumed = callback(data);

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/RpcClient.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/RpcClient.cpp
@@ -87,8 +87,9 @@ public:
 
     // Read the delivered message and push it onto the queue.
     const std::string &messageString = incomingMessage.data();
-    MessageData data(reinterpret_cast<const uint8_t *>(messageString.data()),
-                     messageString.size());
+    std::unique_ptr<SegmentedMessageData> data = std::make_unique<MessageData>(
+        reinterpret_cast<const uint8_t *>(messageString.data()),
+        messageString.size());
 
     // Process the callback. Check disconnecting to avoid blocking forever.
     while (!callback(data)) {

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/RpcServer.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/RpcServer.cpp
@@ -117,7 +117,9 @@ public:
 
   /// Internal call. Push a message FROM the RPC client to the read port.
   void push(MessageData &data) {
-    while (!callback(data))
+    std::unique_ptr<SegmentedMessageData> msg =
+        std::make_unique<MessageData>(data);
+    while (!callback(msg))
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 };

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -247,7 +247,16 @@ private:
     return MessageData(bytes);
   }
 
-  bool pollImpl() override { return callback(genMessage()); }
+  bool pollImpl() override {
+    if (!pendingMessage)
+      pendingMessage = std::make_unique<MessageData>(genMessage());
+    if (!callback(pendingMessage))
+      return false;
+    pendingMessage.reset();
+    return true;
+  }
+
+  std::unique_ptr<SegmentedMessageData> pendingMessage;
 };
 } // namespace
 

--- a/lib/Dialect/ESI/runtime/docs/MessageData.md
+++ b/lib/Dialect/ESI/runtime/docs/MessageData.md
@@ -3,42 +3,49 @@
 Goals:
 - Support generated types with variable-length lists (header + list data)
   without flattening into a single contiguous buffer before sending.
-- Keep the existing `MessageData` class and all port APIs unchanged.
-- Provide an opt-in conversion path so backends can choose to handle
-  multi-segment messages efficiently (scatter-gather, chunked DMA) or fall
-  back to flattening.
+- Keep existing flat `MessageData` entry points available for compatibility.
+- Unify backend/client internals on an owning `SegmentedMessageData` path so
+  read retries can preserve message ownership and identity.
+- Let backends handle multi-segment messages efficiently (scatter-gather,
+  chunked DMA) or fall back to flattening.
 
 ## Background
 
 The existing `MessageData` is a concrete, value-type class wrapping a
-`std::vector<uint8_t>`. It is used by value throughout the port APIs
-(`write(const MessageData &)`, `read(MessageData &)`, callbacks, futures).
-Changing it to an abstract class would require rewriting every port, backend,
-and user-facing API — far too invasive.
+`std::vector<uint8_t>`. It is used by value throughout the public flat APIs
+(`write(const MessageData &)`, `read(MessageData &)`, flat callbacks,
+futures). Replacing it outright with an abstract segmented type would require
+rewriting every port, backend, and user-facing API.
 
-Instead, we introduce `SegmentedMessageData` as a parallel class. Generated
-types that need multiple segments (e.g. a fixed-size header followed by a
-variable-length list) produce a `SegmentedMessageData` and flatten it into a
-`MessageData` for transport through the existing port APIs. Backends that want
-to avoid that copy can optionally accept `SegmentedMessageData` directly via a
-new overridable method.
+Instead, `SegmentedMessageData` becomes the common abstract base and
+`MessageData` becomes its concrete one-segment implementation. Generated types
+that need multiple segments (e.g. a fixed-size header followed by a
+variable-length list) also subclass `SegmentedMessageData`. This keeps the
+public flat APIs available while letting the backend/client internals move a
+single owning message type through retry-capable paths.
 
 ## Design
 
 `SegmentedMessageData` is a pure abstract class representing an ordered
-sequence of contiguous byte spans ("segments"). Generated types subclass it to
-expose their header and list-body segments without copying them into a single
-buffer.
+sequence of contiguous byte spans ("segments"). `MessageData` is the flat,
+single-segment implementation. Generated types subclass it to expose their
+header and list-body segments without copying them into a single buffer.
 
-A non-virtual `toMessageData()` method flattens all segments into a standard
-`MessageData` for use with the existing port APIs. This is the default path
-and requires no backend changes.
+A virtual `toMessageData()` method flattens segmented subclasses into a
+standard flat `MessageData`. `MessageData` overrides it trivially by returning
+itself.
 
 For backends that support scatter-gather, chunked DMA, or avoid a memcpy to
 write directly into its buffer, `WriteChannelPort` gains an optional virtual
 `write()` method overload that accepts a `SegmentedMessageData` directly. The
 default implementation calls `toMessageData()` and forwards to the existing
 `writeImpl()`, so all existing backends keep working without modification.
+
+`ReadChannelPort` likewise unifies its callback-mode internals around an owning
+`std::unique_ptr<SegmentedMessageData> &` callback. This lets a backend keep
+the exact same message object alive across `false` retries. Legacy flat
+callbacks and polling reads remain available as adapters layered on top of that
+segmented callback path.
 
 A separate `Cursor` class tracks consumption position across segments. Backends
 that need to resume partial writes store both a `unique_ptr<SegmentedMessageData>`
@@ -61,8 +68,6 @@ layout matches the hardware wire format exactly.
   /// Abstract multi-segment message. Generated types subclass this to
   /// expose header + list segments without flattening.
   ///
-  /// This class does NOT replace MessageData. It lives alongside it.
-  ///
   /// Subclasses MUST own all data that their segments point to. This is
   /// required because the write API takes ownership
   /// (unique_ptr<SegmentedMessageData>) and a backend may hold the
@@ -80,10 +85,17 @@ layout matches the hardware wire format exactly.
     bool empty() const;
 
     /// Flatten all segments into a standard MessageData.
-    /// This is the primary integration point: generated types produce a
-    /// SegmentedMessageData, then call toMessageData() to go through the
-    /// existing port APIs.
-    MessageData toMessageData() const;
+    virtual MessageData toMessageData() const;
+  };
+
+  /// A concrete flat message backed by a single vector of bytes.
+  class MessageData : public SegmentedMessageData {
+  public:
+    // Existing vector-backed API unchanged.
+
+    size_t numSegments() const override { return 1; }
+    Segment segment(size_t idx) const override;
+    MessageData toMessageData() const override { return *this; }
   };
 
   /// Cursor for incremental consumption of a SegmentedMessageData.
@@ -117,7 +129,7 @@ layout matches the hardware wire format exactly.
   };
 ```
 
-## Port API additions (optional, backward-compatible)
+## Port API additions
 
 ```c++
   class WriteChannelPort : public ChannelPort {
@@ -131,16 +143,31 @@ layout matches the hardware wire format exactly.
       write(msg->toMessageData());
     }
   };
+
+  class ReadChannelPort : public ChannelPort {
+  public:
+    using ReadCallback =
+        std::function<bool(std::unique_ptr<SegmentedMessageData> &)>;
+    using FlatReadCallback = std::function<bool(MessageData)>;
+
+    virtual void connect(ReadCallback callback,
+                         const ConnectOptions &options = {});
+    virtual void connect(FlatReadCallback callback,
+                         const ConnectOptions &options = {});
+
+    // Polling `connect()`, `readAsync()`, and `read(MessageData &)` remain.
+  };
 ```
 
-Backends that do not override this method get correct behavior automatically.
-Backends that *do* override it receive sole ownership of the message and
-can store the `unique_ptr` to resume partial writes later, alongside a
-`SegmentedMessageDataCursor` to track progress.
+Backends that do not override segmented write handling get correct behavior
+automatically via flattening. Backends that *do* override it receive sole
+ownership of the message and can store the `unique_ptr` to resume partial
+writes later, alongside a `SegmentedMessageDataCursor` to track progress.
 
-No changes to ReadChannelPort. On the read side, generated types deserialize
-from a flat `MessageData` as they do today (the data coming back from the
-accelerator is already in a contiguous buffer from the backend's DMA read).
+On the read side, the owning segmented callback is now the canonical internal
+path. A backend can retain and retry the same `SegmentedMessageData` object
+until the callback accepts it. Existing flat callbacks and polling reads still
+work, but they are adapters layered on top of the segmented ownership path.
 
 ## Type serialization (write side)
 
@@ -311,11 +338,11 @@ The generated specialization casts the owned `Packet` up to
 
 ## What does NOT change
 
-- `MessageData` class: unchanged, remains a concrete value type wrapping
-  `std::vector<uint8_t>`.
-- `ReadChannelPort` / `WriteChannelPort::writeImpl()`: unchanged.
-- All existing backends: unchanged (the default
-  `write(unique_ptr<SegmentedMessageData>)` flattens automatically).
+- `MessageData` remains a concrete value type wrapping `std::vector<uint8_t>`.
+- The public flat APIs remain: `write(const MessageData &)`,
+  `connect(std::function<bool(MessageData)>)`, `readAsync()`, and
+  `read(MessageData &)`. They now sit on top of the segmented path.
+- `WriteChannelPort::writeImpl()` remains flat.
 - All existing user code that constructs `MessageData` directly: unchanged.
 - `TypedWritePort` / `TypedReadPort`: unchanged for scalar types.
   Generated specializations for list-containing types opt in.

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
@@ -335,6 +335,31 @@ public:
   MessageData nextResponse;
 };
 
+class CallbackDrivenMockReadPort : public ReadChannelPort {
+public:
+  CallbackDrivenMockReadPort(const Type *type) : ReadChannelPort(type) {}
+
+  bool deliver(std::unique_ptr<SegmentedMessageData> msg) {
+    pending = std::move(msg);
+    return retryPending();
+  }
+
+  bool retryPending() {
+    if (!pending)
+      throw std::runtime_error(
+          "CallbackDrivenMockReadPort::retryPending with no message");
+    if (!callback(pending))
+      return false;
+    pending.reset();
+    return true;
+  }
+
+  bool hasPending() const { return static_cast<bool>(pending); }
+
+private:
+  std::unique_ptr<SegmentedMessageData> pending;
+};
+
 //===----------------------------------------------------------------------===//
 // TypedFunction tests
 //===----------------------------------------------------------------------===//
@@ -453,6 +478,98 @@ struct TestSegmented : public SegmentedMessageData {
             items.size() * sizeof(uint32_t)};
   }
 };
+
+TEST(TypedPortsTest, ReadChannelPortSegmentedCallbackRetriesSameMessageObject) {
+  UIntType uint32("ui32", 32);
+  CallbackDrivenMockReadPort mock(&uint32);
+
+  uint32_t expected = 0x12345678;
+  const uint8_t *firstBytes = nullptr;
+  size_t callbackCalls = 0;
+
+  mock.connect([&](std::unique_ptr<SegmentedMessageData> &msg) -> bool {
+    ++callbackCalls;
+    EXPECT_EQ(msg->numSegments(), 1u);
+
+    auto *flat = dynamic_cast<MessageData *>(msg.get());
+    EXPECT_NE(flat, nullptr);
+    if (!flat)
+      return false;
+    EXPECT_EQ(*flat->as<uint32_t>(), expected);
+
+    if (callbackCalls == 1)
+      firstBytes = flat->getBytes();
+    else
+      EXPECT_EQ(flat->getBytes(), firstBytes);
+
+    return callbackCalls == 2;
+  });
+
+  EXPECT_FALSE(
+      mock.deliver(std::make_unique<MessageData>(MessageData::from(expected))));
+  EXPECT_TRUE(mock.hasPending());
+  EXPECT_TRUE(mock.retryPending());
+  EXPECT_FALSE(mock.hasPending());
+  EXPECT_EQ(callbackCalls, 2u);
+}
+
+TEST(TypedPortsTest, ReadChannelPortFlatCallbackFlattensSegmentedMessageRetry) {
+  UIntType uint32("ui32", 32);
+  CallbackDrivenMockReadPort mock(&uint32);
+
+  TestSegmented input;
+  input.header.a = 0x12345678;
+  input.header.b = 0xABCD;
+  input.items = {1, 2, 3};
+  MessageData expected = input.toMessageData();
+
+  size_t callbackCalls = 0;
+  mock.connect([&](MessageData data) {
+    ++callbackCalls;
+    EXPECT_EQ(data.getData(), expected.getData());
+    return callbackCalls == 2;
+  });
+
+  EXPECT_FALSE(mock.deliver(std::make_unique<TestSegmented>(input)));
+  EXPECT_TRUE(mock.hasPending());
+  EXPECT_TRUE(mock.retryPending());
+  EXPECT_FALSE(mock.hasPending());
+  EXPECT_EQ(callbackCalls, 2u);
+}
+
+TEST(TypedPortsTest, ReadChannelPortPollingRetriesFlattenedSegmentedMessage) {
+  UIntType uint32("ui32", 32);
+  CallbackDrivenMockReadPort mock(&uint32);
+  mock.connect();
+  mock.setMaxDataQueueMsgs(1);
+
+  TestSegmented firstInput;
+  firstInput.header.a = 0xAAAA5555;
+  firstInput.header.b = 0x1357;
+  firstInput.items = {10};
+  MessageData firstExpected = firstInput.toMessageData();
+
+  TestSegmented secondInput;
+  secondInput.header.a = 0xDEADBEEF;
+  secondInput.header.b = 0x2468;
+  secondInput.items = {20, 30};
+  MessageData secondExpected = secondInput.toMessageData();
+
+  EXPECT_TRUE(mock.deliver(std::make_unique<TestSegmented>(firstInput)));
+  EXPECT_FALSE(mock.deliver(std::make_unique<TestSegmented>(secondInput)));
+  EXPECT_TRUE(mock.hasPending());
+
+  MessageData firstOut;
+  mock.read(firstOut);
+  EXPECT_EQ(firstOut.getData(), firstExpected.getData());
+
+  EXPECT_TRUE(mock.retryPending());
+  EXPECT_FALSE(mock.hasPending());
+
+  MessageData secondOut;
+  mock.read(secondOut);
+  EXPECT_EQ(secondOut.getData(), secondExpected.getData());
+}
 
 TEST(TypedPortsTest, TypedWritePortSegmentedMessageData) {
   // Use any type — SegmentedMessageData skips type checks.


### PR DESCRIPTION
The segmented message path is more efficient since it avoids data copies. This switches to it entirely while maintaining client compatibility. Anyone implementing another ReadChannelPort will have to update their code, though it should be a straightforward change.

Assisted-by: vscode:GPT-5.4