### PR TITLE
[CI] Enable Reverse iteration

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -164,7 +164,7 @@ jobs:
               "cmake_c_compiler": "gcc"
             },
             {
-              "name": "Linux (Clang) Test",
+              "name": "Linux (Clang) Test w/ Reverse Iteration",
               "install_target": "",
               "package_name_prefix": "",
               "cmake_build_type": "release",
@@ -173,7 +173,8 @@ jobs:
               "run_tests": true,
               "run_integration_tests": false,
               "runner": "ubuntu-24.04",
-              "cmake_c_compiler": "clang"
+              "cmake_c_compiler": "clang",
+              "extra_cmake_args": "-DLLVM_ENABLE_REVERSE_ITERATION=ON"
             },
             {
               "name": "Windows Test",


### PR DESCRIPTION
Split from https://github.com/llvm/circt/pull/10300. Enable  LLVM_ENABLE_REVERSE_ITERATION=On in pre-merge. 

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
