### PR TITLE
[FIRRTL][OM] Add Bool/Integer And/Or/Xor

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1492,6 +1492,70 @@ def PropEqOp : FIRRTLOp<"prop.eq", [Pure, AllTypesMatch<["lhs", "rhs"]>]> {
   let hasFolder = 1;
 }
 
+class BoolBinaryPrimOp<string mnemonic, list<Trait> traits = []> :
+    BinaryPrimOp<mnemonic, BoolType, BoolType, BoolType,
+                 [Pure, SameOperandsAndResultType] # traits> {
+  // We use the standard inferReturnTypes from SameOperandsAndResultType.
+  let inferReturnTypesDecl = "";
+
+  // We use a static inferType that always returns BoolType.
+  let inferType = "getBoolType";
+
+  // Define getBoolType inline in ODS.
+  let firrtlExtraClassDeclaration = [{
+    static BoolType getBoolType(FIRRTLType lhs,
+                                FIRRTLType rhs,
+                                std::optional<Location> loc) {
+      return BoolType::get(lhs.getContext());
+    }
+  }];
+
+  // Use a simple `lhs, rhs : type` format (matching the FIRRTL property op
+  // convention) rather than the BinaryPrimOp `(lhstype, rhstype) -> restype`.
+  let assemblyFormat = "$lhs `,` $rhs attr-dict";
+
+  let hasFolder = 1;
+}
+
+def BoolAndOp : BoolBinaryPrimOp<"bool.and", [Commutative]> {
+  let summary = "Bitwise AND of two boolean property values";
+  let description = [{
+    Computes the bitwise AND of two boolean property values, returning a boolean
+    result.
+
+    Example:
+    ```mlir
+    %result = firrtl.bool.and %lhs, %rhs
+    ```
+  }];
+}
+
+def BoolOrOp : BoolBinaryPrimOp<"bool.or", [Commutative]> {
+  let summary = "Bitwise OR of two boolean property values";
+  let description = [{
+    Computes the bitwise OR of two boolean property values, returning a boolean
+    result.
+
+    Example:
+    ```mlir
+    %result = firrtl.bool.or %lhs, %rhs
+    ```
+  }];
+}
+
+def BoolXorOp : BoolBinaryPrimOp<"bool.xor", [Commutative]> {
+  let summary = "Bitwise XOR of two boolean property values";
+  let description = [{
+    Computes the bitwise XOR of two boolean property values, returning a boolean
+    result.  NOT can be lowered as `xor(a, true)`.
+
+    Example:
+    ```mlir
+    %result = firrtl.bool.xor %lhs, %rhs
+    ```
+  }];
+}
+
 def UnknownValueOp : FIRRTLOp<"unknown", [
   Pure,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -69,7 +69,7 @@ public:
             StringConstantOp, FIntegerConstantOp, BoolConstantOp,
             DoubleConstantOp, ListCreateOp, ListConcatOp, UnresolvedPathOp,
             PathOp, IntegerAddOp, IntegerMulOp, IntegerShrOp, StringConcatOp,
-            PropEqOp, UnknownValueOp,
+            PropEqOp, BoolAndOp, BoolOrOp, BoolXorOp, UnknownValueOp,
             // Format String expressions
             TimeOp, HierarchicalModuleNameOp>([&](auto expr) -> ResultType {
           return thisCast->visitExpr(expr, args...);
@@ -235,6 +235,9 @@ public:
   HANDLE(IntegerShrOp, Unhandled);
   HANDLE(StringConcatOp, Unhandled);
   HANDLE(PropEqOp, Unhandled);
+  HANDLE(BoolAndOp, Unhandled);
+  HANDLE(BoolOrOp, Unhandled);
+  HANDLE(BoolXorOp, Unhandled);
   HANDLE(UnknownValueOp, Unhandled);
 
   // Format string expressions

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -568,6 +568,61 @@ def PropEqOp : BinaryEqualityOpBase<"prop.eq"> {
   let hasFolder = 1;
 }
 
+class IntegerBitwiseOpBase<string mnemonic, list<Trait> traits = []> :
+    OMOp<mnemonic, [
+      Pure,
+      SameOperandsAndResultType,
+      DeclareOpInterfaceMethods<IntegerBinaryInterface>
+    ] # traits> {
+  let arguments = (ins AnyInteger:$lhs, AnyInteger:$rhs);
+  let results = (outs AnyInteger:$result);
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
+  let hasFolder = 1;
+}
+
+def IntegerAndOp : IntegerBitwiseOpBase<"integer.and", [Commutative]> {
+  let summary = "Bitwise AND of two integer OM values";
+  let description = [{
+    Compute the bitwise AND of two integer OM values of the same width,
+    returning an integer result of the same width.
+
+    Example:
+    ```mlir
+    %2 = om.integer.and %0, %1 : i1
+    %3 = om.integer.and %4, %5 : i8
+    ```
+  }];
+}
+
+def IntegerOrOp : IntegerBitwiseOpBase<"integer.or", [Commutative]> {
+  let summary = "Bitwise OR of two integer OM values";
+  let description = [{
+    Compute the bitwise OR of two integer OM values of the same width,
+    returning an integer result of the same width.
+
+    Example:
+    ```mlir
+    %2 = om.integer.or %0, %1 : i1
+    %3 = om.integer.or %4, %5 : i8
+    ```
+  }];
+}
+
+def IntegerXorOp : IntegerBitwiseOpBase<"integer.xor", [Commutative]> {
+  let summary = "Bitwise XOR of two integer OM values";
+  let description = [{
+    Compute the bitwise XOR of two integer OM values of the same width,
+    returning an integer result of the same width.  NOT can be expressed
+    as \`xor(a, all-ones)\`.
+
+    Example:
+    ```mlir
+    %2 = om.integer.xor %0, %1 : i1
+    %3 = om.integer.xor %4, %5 : i8
+    ```
+  }];
+}
+
 def PropertyAssertOp : OMOp<"property_assert"> {
   let summary = "Assert that a boolean property holds at evaluation time";
   let description = [{

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -208,6 +208,24 @@ struct Emitter {
     emitPrimExpr("prop_eq", op);
   }
 
+  void emitExpression(BoolAndOp op) {
+    if (failed(requireVersion(missingSpecFIRVersion, op, "boolean and")))
+      return;
+    emitPrimExpr("bool_and", op);
+  }
+
+  void emitExpression(BoolOrOp op) {
+    if (failed(requireVersion(missingSpecFIRVersion, op, "boolean or")))
+      return;
+    emitPrimExpr("bool_or", op);
+  }
+
+  void emitExpression(BoolXorOp op) {
+    if (failed(requireVersion(missingSpecFIRVersion, op, "boolean xor")))
+      return;
+    emitPrimExpr("bool_xor", op);
+  }
+
   // Attributes
   void emitAttribute(MemDirAttr attr);
   void emitAttribute(RUWBehaviorAttr attr);
@@ -1550,7 +1568,8 @@ void Emitter::emitExpression(Value value) {
           ShrPrimOp, UninferredResetCastOp, ConstCastOp, StringConstantOp,
           FIntegerConstantOp, BoolConstantOp, DoubleConstantOp, ListCreateOp,
           UnresolvedPathOp, GenericIntrinsicOp, CatPrimOp, UnsafeDomainCastOp,
-          UnknownValueOp, StringConcatOp, PropEqOp,
+          UnknownValueOp, StringConcatOp, PropEqOp, BoolAndOp, BoolOrOp,
+          BoolXorOp,
           // Reference expressions
           RefSendOp, RefResolveOp, RefSubOp, RWProbeOp, RefCastOp,
           // Format String expressions

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1670,6 +1670,62 @@ OpFoldResult PropEqOp::fold(FoldAdaptor adaptor) {
   return BoolAttr::get(getContext(), lhsAttr == rhsAttr);
 }
 
+//===----------------------------------------------------------------------===//
+// Boolean Property Ops
+//===----------------------------------------------------------------------===//
+
+// Helper to extract the bool value from a BoolAttr.
+static std::optional<bool> getBoolValue(Attribute attr) {
+  if (auto boolAttr = dyn_cast_or_null<BoolAttr>(attr))
+    return boolAttr.getValue();
+  return std::nullopt;
+}
+
+OpFoldResult BoolAndOp::fold(FoldAdaptor adaptor) {
+  auto lhs = getBoolValue(adaptor.getLhs());
+  auto rhs = getBoolValue(adaptor.getRhs());
+  if (lhs && rhs)
+    return BoolAttr::get(getContext(), *lhs && *rhs);
+  // AND with false is always false.
+  if ((lhs && !*lhs) || (rhs && !*rhs))
+    return BoolAttr::get(getContext(), false);
+  // AND with true is identity.
+  if (lhs && *lhs)
+    return getRhs();
+  if (rhs && *rhs)
+    return getLhs();
+  return {};
+}
+
+OpFoldResult BoolOrOp::fold(FoldAdaptor adaptor) {
+  auto lhs = getBoolValue(adaptor.getLhs());
+  auto rhs = getBoolValue(adaptor.getRhs());
+  if (lhs && rhs)
+    return BoolAttr::get(getContext(), *lhs || *rhs);
+  // OR with true is always true.
+  if ((lhs && *lhs) || (rhs && *rhs))
+    return BoolAttr::get(getContext(), true);
+  // OR with false is identity.
+  if (lhs && !*lhs)
+    return getRhs();
+  if (rhs && !*rhs)
+    return getLhs();
+  return {};
+}
+
+OpFoldResult BoolXorOp::fold(FoldAdaptor adaptor) {
+  auto lhs = getBoolValue(adaptor.getLhs());
+  auto rhs = getBoolValue(adaptor.getRhs());
+  if (lhs && rhs)
+    return BoolAttr::get(getContext(), *lhs ^ *rhs);
+  // XOR with false is identity.
+  if (lhs && !*lhs)
+    return getRhs();
+  if (rhs && !*rhs)
+    return getLhs();
+  return {};
+}
+
 OpFoldResult BitCastOp::fold(FoldAdaptor adaptor) {
   auto op = (*this);
   // BitCast is redundant if input and result types are same.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6690,6 +6690,15 @@ void IntegerShrOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 void IntegerShlOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
+void BoolAndOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+void BoolOrOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+void BoolXorOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
 void IsTagOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -267,6 +267,9 @@ TOK_LPKEYWORD_PRIM(integer_shl, IntegerShlOp, 2, 0, FIRVersion(3, 1, 0),
                    "Integers")
 TOK_LPKEYWORD(string_concat)
 TOK_LPKEYWORD(prop_eq)
+TOK_LPKEYWORD_PRIM(bool_and, BoolAndOp, 2, 0, missingSpecFIRVersion, "Boolean and")
+TOK_LPKEYWORD_PRIM(bool_or,  BoolOrOp,  2, 0, missingSpecFIRVersion, "Boolean or")
+TOK_LPKEYWORD_PRIM(bool_xor, BoolXorOp, 2, 0, missingSpecFIRVersion, "Boolean xor")
 
 #undef TOK_MARKER
 #undef TOK_IDENTIFIER

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -20,6 +20,7 @@
 #include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/OM/OMAttributes.h"
 #include "circt/Dialect/OM/OMOps.h"
+#include "circt/Support/ConversionPatternSet.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Threading.h"
@@ -1786,6 +1787,14 @@ struct PropEqOpConversion : public OpConversionPattern<firrtl::PropEqOp> {
   }
 };
 
+template <typename FIRRTLOp, typename OMOp>
+static LogicalResult binaryOpConversion(FIRRTLOp op,
+                                        typename FIRRTLOp::Adaptor adaptor,
+                                        ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<OMOp>(op, adaptor.getLhs(), adaptor.getRhs());
+  return success();
+}
+
 struct PathOpConversion : public OpConversionPattern<firrtl::PathOp> {
 
   PathOpConversion(TypeConverter &typeConverter, MLIRContext *context,
@@ -2238,7 +2247,7 @@ static void populateTypeConverter(TypeConverter &converter) {
 }
 
 static void populateRewritePatterns(
-    RewritePatternSet &patterns, TypeConverter &converter,
+    ConversionPatternSet &patterns, TypeConverter &converter,
     const PathInfoTable &pathInfoTable,
     const DenseMap<StringAttr, firrtl::ClassType> &classTypeTable) {
   patterns.add<FIntegerConstantOpConversion>(converter, patterns.getContext());
@@ -2266,6 +2275,9 @@ static void populateRewritePatterns(
   patterns.add<IntegerShlOpConversion>(converter, patterns.getContext());
   patterns.add<StringConcatOpConversion>(converter, patterns.getContext());
   patterns.add<PropEqOpConversion>(converter, patterns.getContext());
+  patterns.add(binaryOpConversion<firrtl::BoolAndOp, om::IntegerAndOp>);
+  patterns.add(binaryOpConversion<firrtl::BoolOrOp, om::IntegerOrOp>);
+  patterns.add(binaryOpConversion<firrtl::BoolXorOp, om::IntegerXorOp>);
   patterns.add<UnrealizedConversionCastOpConversion>(converter,
                                                      patterns.getContext());
   patterns.add<UnknownValueOpConversion>(converter, patterns.getContext());
@@ -2281,7 +2293,7 @@ LogicalResult LowerClassesPass::dialectConversion(
   TypeConverter typeConverter;
   populateTypeConverter(typeConverter);
 
-  RewritePatternSet patterns(&getContext());
+  ConversionPatternSet patterns(&getContext(), typeConverter);
   populateRewritePatterns(patterns, typeConverter, pathInfoTable,
                           classTypeTable);
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -936,6 +936,96 @@ OpFoldResult PropEqOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// IntegerAndOp / IntegerOrOp / IntegerXorOp
+//===----------------------------------------------------------------------===//
+
+static OpFoldResult foldIntegerBitwise(IntegerBinaryOp op, Attribute lhsAttr,
+                                       Attribute rhsAttr) {
+  auto lhsInt = dyn_cast_or_null<mlir::IntegerAttr>(lhsAttr);
+  auto rhsInt = dyn_cast_or_null<mlir::IntegerAttr>(rhsAttr);
+  if (!lhsInt || !rhsInt)
+    return {};
+  APSInt lhsVal(lhsInt.getValue());
+  APSInt rhsVal(rhsInt.getValue());
+  auto result = op.evaluateIntegerOperation(lhsVal, rhsVal);
+  if (failed(result))
+    return {};
+  return mlir::IntegerAttr::get(
+      lhsInt.getType(), result->extOrTrunc(lhsInt.getValue().getBitWidth()));
+}
+
+// Returns true if attr is an IntegerAttr whose value is all-zeros.
+static bool isZeroInt(Attribute a) {
+  auto i = dyn_cast_or_null<mlir::IntegerAttr>(a);
+  return i && i.getValue().isZero();
+}
+
+// Returns true if attr is an IntegerAttr whose value is all-ones.
+static bool isAllOnesInt(Attribute a) {
+  auto i = dyn_cast_or_null<mlir::IntegerAttr>(a);
+  return i && i.getValue().isAllOnes();
+}
+
+FailureOr<APSInt> IntegerAndOp::evaluateIntegerOperation(const APSInt &lhs,
+                                                         const APSInt &rhs) {
+  return success(APSInt(lhs & rhs, /*isUnsigned=*/false));
+}
+
+OpFoldResult IntegerAndOp::fold(FoldAdaptor adaptor) {
+  if (auto result =
+          foldIntegerBitwise(*this, adaptor.getLhs(), adaptor.getRhs()))
+    return result;
+  // AND with all-zeros is always zero.
+  if (isZeroInt(adaptor.getLhs()) || isZeroInt(adaptor.getRhs()))
+    return mlir::IntegerAttr::get(getResult().getType(),
+                                  APInt::getZero(getType().getWidth()));
+  // AND with all-ones is identity.
+  if (isAllOnesInt(adaptor.getLhs()))
+    return getRhs();
+  if (isAllOnesInt(adaptor.getRhs()))
+    return getLhs();
+  return {};
+}
+
+FailureOr<APSInt> IntegerOrOp::evaluateIntegerOperation(const APSInt &lhs,
+                                                        const APSInt &rhs) {
+  return success(APSInt(lhs | rhs, /*isUnsigned=*/false));
+}
+
+OpFoldResult IntegerOrOp::fold(FoldAdaptor adaptor) {
+  if (auto result =
+          foldIntegerBitwise(*this, adaptor.getLhs(), adaptor.getRhs()))
+    return result;
+  // OR with all-ones is always all-ones.
+  if (isAllOnesInt(adaptor.getLhs()) || isAllOnesInt(adaptor.getRhs()))
+    return mlir::IntegerAttr::get(getResult().getType(),
+                                  APInt::getAllOnes(getType().getWidth()));
+  // OR with all-zeros is identity.
+  if (isZeroInt(adaptor.getLhs()))
+    return getRhs();
+  if (isZeroInt(adaptor.getRhs()))
+    return getLhs();
+  return {};
+}
+
+FailureOr<APSInt> IntegerXorOp::evaluateIntegerOperation(const APSInt &lhs,
+                                                         const APSInt &rhs) {
+  return success(APSInt(lhs ^ rhs, /*isUnsigned=*/false));
+}
+
+OpFoldResult IntegerXorOp::fold(FoldAdaptor adaptor) {
+  if (auto result =
+          foldIntegerBitwise(*this, adaptor.getLhs(), adaptor.getRhs()))
+    return result;
+  // XOR with all-zeros is identity.
+  if (isZeroInt(adaptor.getLhs()))
+    return getRhs();
+  if (isZeroInt(adaptor.getRhs()))
+    return getLhs();
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
 // UnknownValueOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -4093,4 +4093,78 @@ firrtl.module @PropEqFold(in %str: !firrtl.string, in %b: !firrtl.bool,
   firrtl.propassign %out9, %8 : !firrtl.bool
 }
 
+// CHECK-LABEL: firrtl.module @BoolBinaryFold
+firrtl.module @BoolBinaryFold(in %b: !firrtl.bool,
+                               out %out1: !firrtl.bool, out %out2: !firrtl.bool,
+                               out %out3: !firrtl.bool, out %out4: !firrtl.bool,
+                               out %out5: !firrtl.bool, out %out6: !firrtl.bool,
+                               out %out7: !firrtl.bool, out %out8: !firrtl.bool,
+                               out %out9: !firrtl.bool, out %out10: !firrtl.bool,
+                               out %out11: !firrtl.bool) {
+  // CHECK-DAG: [[TRUE:%.+]] = firrtl.bool true
+  // CHECK-DAG: [[FALSE:%.+]] = firrtl.bool false
+  %t = firrtl.bool true
+  %f = firrtl.bool false
+
+  // AND: constant folding.
+  // true AND false = false
+  // CHECK: firrtl.propassign %out1, [[FALSE]]
+  %0 = firrtl.bool.and %t, %f
+  firrtl.propassign %out1, %0 : !firrtl.bool
+
+  // AND with false is always false.
+  // CHECK: firrtl.propassign %out2, [[FALSE]]
+  %1 = firrtl.bool.and %b, %f
+  firrtl.propassign %out2, %1 : !firrtl.bool
+
+  // AND with true is identity.
+  // CHECK: firrtl.propassign %out3, %b
+  %2 = firrtl.bool.and %b, %t
+  firrtl.propassign %out3, %2 : !firrtl.bool
+
+  // OR: constant folding.
+  // true OR false = true
+  // CHECK: firrtl.propassign %out4, [[TRUE]]
+  %3 = firrtl.bool.or %t, %f
+  firrtl.propassign %out4, %3 : !firrtl.bool
+
+  // OR with true is always true.
+  // CHECK: firrtl.propassign %out5, [[TRUE]]
+  %4 = firrtl.bool.or %b, %t
+  firrtl.propassign %out5, %4 : !firrtl.bool
+
+  // OR with false is identity.
+  // CHECK: firrtl.propassign %out6, %b
+  %5 = firrtl.bool.or %b, %f
+  firrtl.propassign %out6, %5 : !firrtl.bool
+
+  // XOR: constant folding.
+  // true XOR false = true
+  // CHECK: firrtl.propassign %out7, [[TRUE]]
+  %6 = firrtl.bool.xor %t, %f
+  firrtl.propassign %out7, %6 : !firrtl.bool
+
+  // XOR: constant folding T xor T = F.
+  // CHECK: firrtl.propassign %out8, [[FALSE]]
+  %7 = firrtl.bool.xor %t, %t
+  firrtl.propassign %out8, %7 : !firrtl.bool
+
+  // XOR with false is identity.
+  // CHECK: firrtl.propassign %out9, %b
+  %8 = firrtl.bool.xor %b, %f
+  firrtl.propassign %out9, %8 : !firrtl.bool
+
+  // Non-constant bool.and operands do not fold.
+  // CHECK: [[AND:%.+]] = firrtl.bool.and %b, %b
+  // CHECK: firrtl.propassign %out10, [[AND]]
+  %9 = firrtl.bool.and %b, %b
+  firrtl.propassign %out10, %9 : !firrtl.bool
+
+  // NOT idiom: bool.xor with true = NOT.
+  // false XOR true = true
+  // CHECK: firrtl.propassign %out11, [[TRUE]]
+  %10 = firrtl.bool.xor %f, %t
+  firrtl.propassign %out11, %10 : !firrtl.bool
+}
+
 }

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -646,7 +646,10 @@ firrtl.circuit "Foo" {
                             out %list : !firrtl.list<list<string>>,
                             out %unknownString : !firrtl.string,
                             out %stringcat : !firrtl.string,
-                            out %stringeq : !firrtl.bool) {
+                            out %stringeq : !firrtl.bool,
+                            out %booland : !firrtl.bool,
+                            out %boolor : !firrtl.bool,
+                            out %boolxor : !firrtl.bool) {
     // CHECK: propassign string, String("hello")
     %0 = firrtl.string "hello"
     firrtl.propassign %string, %0 : !firrtl.string
@@ -688,6 +691,18 @@ firrtl.circuit "Foo" {
     // CHECK: propassign stringeq, prop_eq(String("hello"), String("world"))
     %streq = firrtl.prop.eq %str0, %str1 : !firrtl.string
     firrtl.propassign %stringeq, %streq : !firrtl.bool
+
+    // CHECK: propassign booland, bool_and(Bool(true), Bool(true))
+    %booland_val = firrtl.bool.and %true, %true
+    firrtl.propassign %booland, %booland_val : !firrtl.bool
+
+    // CHECK: propassign boolor, bool_or(Bool(true), Bool(true))
+    %boolor_val = firrtl.bool.or %true, %true
+    firrtl.propassign %boolor, %boolor_val : !firrtl.bool
+
+    // CHECK: propassign boolxor, bool_xor(Bool(true), Bool(true))
+    %boolxor_val = firrtl.bool.xor %true, %true
+    firrtl.propassign %boolxor, %boolxor_val : !firrtl.bool
   }
 
   // Test optional group declaration and definition emission.

--- a/test/Dialect/FIRRTL/emit-version-errors-lt-5.1.0.mlir
+++ b/test/Dialect/FIRRTL/emit-version-errors-lt-5.1.0.mlir
@@ -138,3 +138,39 @@ firrtl.circuit "PropEq" {
     firrtl.propassign %eq, %0 : !firrtl.bool
   }
 }
+
+// -----
+
+// bool.and expression requires >= 5.1.0.
+firrtl.circuit "BoolAnd" {
+  firrtl.module @BoolAnd(in %a : !firrtl.bool, in %b : !firrtl.bool,
+                         out %out : !firrtl.bool) {
+    // expected-error @below {{'firrtl.bool.and' op boolean and requires FIRRTL 5.1.0}}
+    %0 = firrtl.bool.and %a, %b
+    firrtl.propassign %out, %0 : !firrtl.bool
+  }
+}
+
+// -----
+
+// bool.or expression requires >= 5.1.0.
+firrtl.circuit "BoolOr" {
+  firrtl.module @BoolOr(in %a : !firrtl.bool, in %b : !firrtl.bool,
+                        out %out : !firrtl.bool) {
+    // expected-error @below {{'firrtl.bool.or' op boolean or requires FIRRTL 5.1.0}}
+    %0 = firrtl.bool.or %a, %b
+    firrtl.propassign %out, %0 : !firrtl.bool
+  }
+}
+
+// -----
+
+// bool.xor expression requires >= 5.1.0.
+firrtl.circuit "BoolXor" {
+  firrtl.module @BoolXor(in %a : !firrtl.bool, in %b : !firrtl.bool,
+                         out %out : !firrtl.bool) {
+    // expected-error @below {{'firrtl.bool.xor' op boolean xor requires FIRRTL 5.1.0}}
+    %0 = firrtl.bool.xor %a, %b
+    firrtl.propassign %out, %0 : !firrtl.bool
+  }
+}

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -459,6 +459,30 @@ firrtl.circuit "StringCat" {
     // CHECK: om.class.fields %[[EQ]]
     firrtl.propassign %eq, %0 : !firrtl.bool
   }
+
+  // CHECK-LABEL: om.class @BoolAndClass
+  firrtl.class @BoolAndClass(in %a: !firrtl.bool, in %b: !firrtl.bool, out %out: !firrtl.bool) {
+    // CHECK: %[[AND:.+]] = om.integer.and %a, %b : i1
+    %0 = firrtl.bool.and %a, %b
+    // CHECK: om.class.fields %[[AND]]
+    firrtl.propassign %out, %0 : !firrtl.bool
+  }
+
+  // CHECK-LABEL: om.class @BoolOrClass
+  firrtl.class @BoolOrClass(in %a: !firrtl.bool, in %b: !firrtl.bool, out %out: !firrtl.bool) {
+    // CHECK: %[[OR:.+]] = om.integer.or %a, %b : i1
+    %0 = firrtl.bool.or %a, %b
+    // CHECK: om.class.fields %[[OR]]
+    firrtl.propassign %out, %0 : !firrtl.bool
+  }
+
+  // CHECK-LABEL: om.class @BoolXorClass
+  firrtl.class @BoolXorClass(in %a: !firrtl.bool, in %b: !firrtl.bool, out %out: !firrtl.bool) {
+    // CHECK: %[[XOR:.+]] = om.integer.xor %a, %b : i1
+    %0 = firrtl.bool.xor %a, %b
+    // CHECK: om.class.fields %[[XOR]]
+    firrtl.propassign %out, %0 : !firrtl.bool
+  }
 }
 
 // CHECK-LABEL: firrtl.circuit "AltBasePath"

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1712,6 +1712,30 @@ circuit PropEqVersionError :
     propassign c, prop_eq(a, b)
 
 ;// -----
+FIRRTL version 5.1.0
+
+; CHECK-LABEL: firrtl.circuit "BoolBinaryOps"
+circuit BoolBinaryOps :
+  public module BoolBinaryOps :
+    input a : Bool
+    input b : Bool
+    output andOut : Bool
+    output orOut : Bool
+    output xorOut : Bool
+
+    ; CHECK: [[AND:%.+]] = firrtl.bool.and %a, %b
+    ; CHECK: firrtl.propassign %andOut, [[AND]]
+    propassign andOut, bool_and(a, b)
+
+    ; CHECK: [[OR:%.+]] = firrtl.bool.or %a, %b
+    ; CHECK: firrtl.propassign %orOut, [[OR]]
+    propassign orOut, bool_or(a, b)
+
+    ; CHECK: [[XOR:%.+]] = firrtl.bool.xor %a, %b
+    ; CHECK: firrtl.propassign %xorOut, [[XOR]]
+    propassign xorOut, bool_xor(a, b)
+
+;// -----
 FIRRTL version 3.1.0
 
 ; CHECK-LABEL: circuit "BundleOfProps"

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -171,6 +171,15 @@ firrtl.module @PropertyPropEq() {
 
   // CHECK: firrtl.prop.eq %6, %7 : !firrtl.integer
   %8 = firrtl.prop.eq %6, %7 : !firrtl.integer
+
+  // CHECK: firrtl.bool.and %3, %4
+  %9 = firrtl.bool.and %3, %4
+
+  // CHECK: firrtl.bool.or %3, %4
+  %10 = firrtl.bool.or %3, %4
+
+  // CHECK: firrtl.bool.xor %3, %4
+  %11 = firrtl.bool.xor %3, %4
 }
 
 // CHECK-LABEL: firrtl.module @PropertyListOps

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -154,3 +154,43 @@ om.class @PropEqFold(%str: !om.string, %b: i1, %n: !om.integer) -> (out1: i1, ou
   // CHECK: om.class.fields [[TRUE]], [[FALSE]], [[EQ]], [[TRUE]], [[FALSE]], [[BEQ]], [[TRUE]], [[FALSE]], [[IEQ]]
   om.class.fields %0, %1, %2, %3, %4, %5, %6, %7, %8 : i1, i1, i1, i1, i1, i1, i1, i1, i1
 }
+
+// CHECK-LABEL: @IntegerBitwiseFold
+om.class @IntegerBitwiseFold(%b: i8) -> (out1: i8, out2: i8, out3: i8,
+                                          out4: i8, out5: i8, out6: i8,
+                                          out7: i8, out8: i8) {
+  // CHECK-DAG: [[ZERO:%.+]] = om.constant 0 : i8
+  // CHECK-DAG: [[ONES:%.+]] = om.constant -1 : i8
+  %zero = om.constant 0 : i8
+  %ones = om.constant -1 : i8
+
+  // 0xFF AND 0x00 = 0x00.
+  %0 = om.integer.and %ones, %zero : i8
+
+  // 0xFF OR 0x00 = 0xFF.
+  %1 = om.integer.or %ones, %zero : i8
+
+  // 0xFF XOR 0x00 = 0xFF.
+  %2 = om.integer.xor %ones, %zero : i8
+
+  // 0xFF XOR 0xFF = 0x00.
+  %3 = om.integer.xor %ones, %ones : i8
+
+  // Non-constant AND does not fold.
+  // CHECK: [[AND:%.+]] = om.integer.and %b, %b : i8
+  %4 = om.integer.and %b, %b : i8
+
+  // Non-constant OR does not fold.
+  // CHECK: [[OR:%.+]] = om.integer.or %b, %b : i8
+  %5 = om.integer.or %b, %b : i8
+
+  // Non-constant XOR does not fold.
+  // CHECK: [[XOR:%.+]] = om.integer.xor %b, %b : i8
+  %6 = om.integer.xor %b, %b : i8
+
+  // XOR with all-zeros is identity.
+  %7 = om.integer.xor %b, %zero : i8
+
+  // CHECK: om.class.fields [[ZERO]], [[ONES]], [[ONES]], [[ZERO]], [[AND]], [[OR]], [[XOR]], %b
+  om.class.fields %0, %1, %2, %3, %4, %5, %6, %7 : i8, i8, i8, i8, i8, i8, i8, i8
+}

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -317,6 +317,35 @@ om.class @IntegerArithmetic() {
   om.class.fields
 }
 
+// CHECK-LABEL: @IntegerBitwise
+om.class @IntegerBitwise() {
+  %0 = om.constant false
+  %1 = om.constant true
+
+  // CHECK: om.integer.and %0, %1 : i1
+  %2 = om.integer.and %0, %1 : i1
+
+  // CHECK: om.integer.or %0, %1 : i1
+  %3 = om.integer.or %0, %1 : i1
+
+  // CHECK: om.integer.xor %0, %1 : i1
+  %4 = om.integer.xor %0, %1 : i1
+
+  %5 = om.constant 0 : i8
+  %6 = om.constant -1 : i8
+
+  // CHECK: om.integer.and %5, %6 : i8
+  %7 = om.integer.and %5, %6 : i8
+
+  // CHECK: om.integer.or %5, %6 : i8
+  %8 = om.integer.or %5, %6 : i8
+
+  // CHECK: om.integer.xor %5, %6 : i8
+  %9 = om.integer.xor %5, %6 : i8
+
+  om.class.fields
+}
+
 om.class @UnknownValueObject(%a: i8) {
   om.class.fields
 }

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -2026,4 +2026,109 @@ om.class @PropEqInteger(%n: !om.integer) -> (equal: i1, not_equal: i1, unknown: 
   }
 }
 
+TEST(EvaluatorTests, IntegerBitwiseTests) {
+  StringRef mod = R"MLIR(
+om.class @IntegerBitwiseAnd(%a: i8, %b: i8) -> (result: i8) {
+  %and = om.integer.and %a, %b : i8
+  om.class.fields %and : i8
+}
+
+om.class @IntegerBitwiseOr(%a: i8, %b: i8) -> (result: i8) {
+  %or = om.integer.or %a, %b : i8
+  om.class.fields %or : i8
+}
+
+om.class @IntegerBitwiseXor(%a: i8, %b: i8) -> (result: i8) {
+  %xor = om.integer.xor %a, %b : i8
+  om.class.fields %xor : i8
+}
+
+om.class @IntegerBitwiseUnknown(%b: i8) -> (unknown: i8) {
+  %zero = om.constant 0 : i8
+  %unk  = om.integer.and %zero, %b : i8
+  om.class.fields %unk : i8
+}
+)MLIR";
+
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  OwningOpRef<ModuleOp> owning =
+      parseSourceString<ModuleOp>(mod, ParserConfig(&context));
+
+  Evaluator evaluator(owning.release());
+
+  auto unknownLoc = LocationAttr(UnknownLoc::get(&context));
+  auto i8Type = mlir::IntegerType::get(&context, 8);
+
+  // Helper: make an i8 AttributeValue.
+  auto makeI8 = [&](uint8_t val) -> evaluator::EvaluatorValuePtr {
+    auto attr = mlir::IntegerAttr::get(i8Type, val);
+    auto v = evaluator::AttributeValue::get(i8Type, unknownLoc);
+    (void)cast<evaluator::AttributeValue>(v.get())->setAttr(attr);
+    (void)cast<evaluator::AttributeValue>(v.get())->finalize();
+    return v;
+  };
+
+  // Helper: extract the i8 value from the "result" field.
+  auto getResult = [&](evaluator::EvaluatorValuePtr obj) -> uint64_t {
+    auto *o = llvm::cast<evaluator::ObjectValue>(obj.get());
+    return llvm::cast<evaluator::AttributeValue>(
+               o->getField(StringAttr::get(&context, "result")).value().get())
+        ->getAs<mlir::IntegerAttr>()
+        .getValue()
+        .getZExtValue();
+  };
+
+  // Test AND: 0xF0 & 0x0F = 0x00, 0xFF & 0xF0 = 0xF0.
+  struct {
+    uint8_t a, b, expected;
+  } andCases[] = {{0xF0, 0x0F, 0x00}, {0xFF, 0xF0, 0xF0}, {0x00, 0xFF, 0x00}};
+  for (auto [a, b, expected] : andCases) {
+    auto r = evaluator.instantiate(
+        StringAttr::get(&context, "IntegerBitwiseAnd"), {makeI8(a), makeI8(b)});
+    ASSERT_TRUE(succeeded(r));
+    ASSERT_EQ(getResult(r.value()), static_cast<uint64_t>(expected));
+  }
+
+  // Test OR: 0xF0 | 0x0F = 0xFF, 0x00 | 0x0F = 0x0F.
+  struct {
+    uint8_t a, b, expected;
+  } orCases[] = {{0xF0, 0x0F, 0xFF}, {0x00, 0x0F, 0x0F}, {0xFF, 0x00, 0xFF}};
+  for (auto [a, b, expected] : orCases) {
+    auto r = evaluator.instantiate(
+        StringAttr::get(&context, "IntegerBitwiseOr"), {makeI8(a), makeI8(b)});
+    ASSERT_TRUE(succeeded(r));
+    ASSERT_EQ(getResult(r.value()), static_cast<uint64_t>(expected));
+  }
+
+  // Test XOR: 0xF0 ^ 0xFF = 0x0F (NOT idiom: xor(a, 0xFF) = ~a).
+  struct {
+    uint8_t a, b, expected;
+  } xorCases[] = {{0xF0, 0xFF, 0x0F}, {0xAA, 0x55, 0xFF}, {0x00, 0x00, 0x00}};
+  for (auto [a, b, expected] : xorCases) {
+    auto r = evaluator.instantiate(
+        StringAttr::get(&context, "IntegerBitwiseXor"), {makeI8(a), makeI8(b)});
+    ASSERT_TRUE(succeeded(r));
+    ASSERT_EQ(getResult(r.value()), static_cast<uint64_t>(expected));
+  }
+
+  // Test unknown propagation: AND(0x00, unknown) = unknown.
+  // Unknown is treated as poison rather than short-circuiting to zero.
+  {
+    auto unknown = evaluator::AttributeValue::get(i8Type, unknownLoc);
+    unknown->markUnknown();
+    auto r = evaluator.instantiate(
+        StringAttr::get(&context, "IntegerBitwiseUnknown"), {unknown});
+    ASSERT_TRUE(succeeded(r));
+    auto *obj = llvm::cast<evaluator::ObjectValue>(r.value().get());
+    ASSERT_TRUE(obj->getField(StringAttr::get(&context, "unknown"))
+                    .value()
+                    ->isUnknown());
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Add support for minimal boolean property operations to FIRRTL and integer
(bitwise) property operations to OM.  These are added to support more
expressive FIRRTL and OM property assertions.

This includes support for both lowering and for evaluation in the OM
evaluator.  The evaluator treats unknown as a true poison and does not
apply short circuiting optimizations.  This may be a choice that we want
to change.

Note: this uses the usual CIRCT quirk of _not_ providing a logical not
operator and instead just using xor with all ones.

Assisted-by: OpenCode:claude-sonnet-4-6
