### PR TITLE
[Support][SATSolver] Add at-most-one / exactly-one clause helpers

### DIFF
--- a/include/circt/Support/SATSolver.h
+++ b/include/circt/Support/SATSolver.h
@@ -211,6 +211,18 @@ void addParityClauses(int outVar, llvm::ArrayRef<int> inputLits,
                       llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
                       llvm::function_ref<int()> newVar);
 
+/// Emit clauses encoding that at most one literal in `vars` can be true.
+void addAtMostOneClauses(
+    llvm::ArrayRef<int> vars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar);
+
+/// Emit clauses encoding that exactly one literal in `vars` is true.
+void addExactlyOneClauses(
+    llvm::ArrayRef<int> vars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar);
+
 /// Construct a Z3-backed incremental IPASIR-style SAT solver.
 std::unique_ptr<IncrementalSATSolver> createZ3SATSolver();
 struct CadicalSATSolverOptions {

--- a/include/circt/Support/SATSolver.h
+++ b/include/circt/Support/SATSolver.h
@@ -211,15 +211,17 @@ void addParityClauses(int outVar, llvm::ArrayRef<int> inputLits,
                       llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
                       llvm::function_ref<int()> newVar);
 
-/// Emit clauses encoding that at most one literal in `vars` can be true.
+/// Emit clauses encoding that at most one literal in `inputLits` can be true.
+/// Unlike the Tseitin-style gate helpers above, this helper does not
+/// take an `outVar`; it only emits the cardinality constraint itself.
 void addAtMostOneClauses(
-    llvm::ArrayRef<int> vars,
+    llvm::ArrayRef<int> inputLits,
     llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
     llvm::function_ref<int()> newVar);
 
-/// Emit clauses encoding that exactly one literal in `vars` is true.
+/// Emit clauses encoding that exactly one literal in `inputLits` is true.
 void addExactlyOneClauses(
-    llvm::ArrayRef<int> vars,
+    llvm::ArrayRef<int> inputLits,
     llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
     llvm::function_ref<int()> newVar);
 

--- a/lib/Support/SATSolver.cpp
+++ b/lib/Support/SATSolver.cpp
@@ -316,10 +316,10 @@ void addParityClauses(int outVar, llvm::ArrayRef<int> inputLits,
 }
 
 void addAtMostOneClauses(
-    llvm::ArrayRef<int> vars,
+    llvm::ArrayRef<int> inputLits,
     llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
     llvm::function_ref<int()> newVar) {
-  if (vars.size() < 2)
+  if (inputLits.size() < 2)
     return;
 
   // Emit the clause encoding `lhs => rhs`.
@@ -329,35 +329,37 @@ void addAtMostOneClauses(
   // Carsten Sinz, "Towards an Optimal CNF Encoding of Boolean Cardinality
   // Constraints", CP 2005.
   //
-  // `ladder[i]` means "at least one of `vars[0]` through `vars[i]` is true".
+  // `ladder[i]` means "at least one of `inputLits[0]` through `inputLits[i]`
+  // is true".
   // We use these helper variables to remember when an earlier choice was made.
-  llvm::SmallVector<int, 8> ladder(vars.size() - 1);
+  llvm::SmallVector<int, 8> ladder(inputLits.size() - 1);
   for (int &var : ladder)
     var = newVar();
 
-  imply(vars.front(), ladder.front());
-  for (unsigned i = 1, e = vars.size() - 1; i < e; ++i) {
-    // If `vars[i]` is true, remember that one of `vars[0..i]` is true.
-    imply(vars[i], ladder[i]);
+  imply(inputLits.front(), ladder.front());
+  for (unsigned i = 1, e = inputLits.size() - 1; i < e; ++i) {
+    // If `inputLits[i]` is true, remember that one of `inputLits[0..i]` is
+    // true.
+    imply(inputLits[i], ladder[i]);
     // If an earlier variable was already true, keep that fact true for the
-    // larger range `vars[0..i]`.
+    // larger range `inputLits[0..i]`.
     imply(ladder[i - 1], ladder[i]);
     // If `ladder[i - 1]` is true, then some earlier variable was true, so
-    // `vars[i]` must be false since at most one variable can be true.
-    imply(ladder[i - 1], -vars[i]);
+    // `inputLits[i]` must be false since at most one variable can be true.
+    imply(ladder[i - 1], -inputLits[i]);
   }
 
   // If `ladder.back()` is true, then some earlier variable was true, so the
   // last variable must be false.
-  imply(ladder.back(), -vars.back());
+  imply(ladder.back(), -inputLits.back());
 }
 
 void addExactlyOneClauses(
-    llvm::ArrayRef<int> vars,
+    llvm::ArrayRef<int> inputLits,
     llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
     llvm::function_ref<int()> newVar) {
-  addClause(vars);
-  addAtMostOneClauses(vars, addClause, newVar);
+  addClause(inputLits);
+  addAtMostOneClauses(inputLits, addClause, newVar);
 }
 
 std::unique_ptr<IncrementalSATSolver> createZ3SATSolver() {

--- a/lib/Support/SATSolver.cpp
+++ b/lib/Support/SATSolver.cpp
@@ -315,6 +315,51 @@ void addParityClauses(int outVar, llvm::ArrayRef<int> inputLits,
   }
 }
 
+void addAtMostOneClauses(
+    llvm::ArrayRef<int> vars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  if (vars.size() < 2)
+    return;
+
+  // Emit the clause encoding `lhs => rhs`.
+  auto imply = [&](int lhs, int rhs) { addClause({-lhs, rhs}); };
+
+  // Use a sequential-ladder encoding for the at-most-one constraint; see
+  // Carsten Sinz, "Towards an Optimal CNF Encoding of Boolean Cardinality
+  // Constraints", CP 2005.
+  //
+  // `ladder[i]` means "at least one of `vars[0]` through `vars[i]` is true".
+  // We use these helper variables to remember when an earlier choice was made.
+  llvm::SmallVector<int, 8> ladder(vars.size() - 1);
+  for (int &var : ladder)
+    var = newVar();
+
+  imply(vars.front(), ladder.front());
+  for (unsigned i = 1, e = vars.size() - 1; i < e; ++i) {
+    // If `vars[i]` is true, remember that one of `vars[0..i]` is true.
+    imply(vars[i], ladder[i]);
+    // If an earlier variable was already true, keep that fact true for the
+    // larger range `vars[0..i]`.
+    imply(ladder[i - 1], ladder[i]);
+    // If `ladder[i - 1]` is true, then some earlier variable was true, so
+    // `vars[i]` must be false since at most one variable can be true.
+    imply(ladder[i - 1], -vars[i]);
+  }
+
+  // If `ladder.back()` is true, then some earlier variable was true, so the
+  // last variable must be false.
+  imply(ladder.back(), -vars.back());
+}
+
+void addExactlyOneClauses(
+    llvm::ArrayRef<int> vars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  addClause(vars);
+  addAtMostOneClauses(vars, addClause, newVar);
+}
+
 std::unique_ptr<IncrementalSATSolver> createZ3SATSolver() {
 #if LLVM_WITH_Z3
   return std::make_unique<Z3SATSolver>();

--- a/unittests/Support/SATSolverTest.cpp
+++ b/unittests/Support/SATSolverTest.cpp
@@ -126,6 +126,44 @@ TEST(SatSolverTest, AssumptionsAreScopedToSolve) {
   EXPECT_EQ(2, solver->val(2));
 }
 
+TEST(SatSolverTest, AddAtMostOneClausesRejectsTwoTrueInputs) {
+  auto solver = createZ3SATSolver();
+  if (!solver)
+    GTEST_SKIP() << "Z3 is not available in this build.";
+  solver->reserveVars(3);
+  addAtMostOneClauses(
+      {1, 2, 3}, [&](llvm::ArrayRef<int> clause) { solver->addClause(clause); },
+      [&] { return solver->newVar(); });
+
+  // Any single selected literal should remain satisfiable.
+  EXPECT_EQ(IncrementalSATSolver::kSAT, solver->solve({1}));
+  EXPECT_EQ(IncrementalSATSolver::kSAT, solver->solve({2}));
+  EXPECT_EQ(IncrementalSATSolver::kSAT, solver->solve({3}));
+  // Any pair of selected literals must violate the at-most-one constraint.
+  EXPECT_EQ(IncrementalSATSolver::kUNSAT, solver->solve({1, 2}));
+  EXPECT_EQ(IncrementalSATSolver::kUNSAT, solver->solve({1, 3}));
+  EXPECT_EQ(IncrementalSATSolver::kUNSAT, solver->solve({2, 3}));
+}
+
+TEST(SatSolverTest, AddExactlyOneClausesRequiresOneSelection) {
+  auto solver = createZ3SATSolver();
+  if (!solver)
+    GTEST_SKIP() << "Z3 is not available in this build.";
+
+  solver->reserveVars(3);
+  addExactlyOneClauses(
+      {1, 2, 3}, [&](llvm::ArrayRef<int> clause) { solver->addClause(clause); },
+      [&] { return solver->newVar(); });
+
+  // Exactly one literal set true is a valid model.
+  EXPECT_EQ(IncrementalSATSolver::kSAT, solver->solve({1, -2, -3}));
+  EXPECT_EQ(IncrementalSATSolver::kSAT, solver->solve({-1, 2, -3}));
+  EXPECT_EQ(IncrementalSATSolver::kSAT, solver->solve({-1, -2, 3}));
+  // Zero or multiple selected literals must be rejected.
+  EXPECT_EQ(IncrementalSATSolver::kUNSAT, solver->solve({-1, -2, -3}));
+  EXPECT_EQ(IncrementalSATSolver::kUNSAT, solver->solve({1, 2}));
+}
+
 TEST(SatSolverTest, CadicalConflictLimitCanBeConfigured) {
   CadicalSATSolverOptions options;
   options.config = CadicalSATSolverOptions::CadicalSolverConfig::Plain;


### PR DESCRIPTION
Add reusable SAT clause builders and unit tests for at-most-one and exactly-one using encoding
referred in Carsten Sinz, “Towards an Optimal CNF Encoding of Boolean Cardinality Constraints” (CP 2005).

This is preparation commit for exact synthesis. Exactly one will be used in constraint on the enumerated graph. 

Assisted-by: codex: gpt 5.4

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
