### PR TITLE
fix: update flattenIndices to generate correct indices for a flattened memref

### DIFF
--- a/lib/Transforms/FlattenMemRefs.cpp
+++ b/lib/Transforms/FlattenMemRefs.cpp
@@ -83,7 +83,8 @@ static Value flattenIndices(ConversionPatternRewriter &rewriter, Operation *op,
   Value finalIdx = indices.front();
 
   for (auto [i, partialIdx] : llvm::enumerate(indices.drop_front())) {
-    // + 1 because enumerate starts from 0, and we are ommiting the zeroth index.
+    // + 1 because enumerate starts from 0, and we are ommiting the zeroth
+    // index.
     int64_t dimSize = memrefType.getShape()[i + 1];
 
     if (llvm::isPowerOf2_64(dimSize)) {

--- a/lib/Transforms/FlattenMemRefs.cpp
+++ b/lib/Transforms/FlattenMemRefs.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/MathExtras.h"
@@ -66,8 +67,8 @@ static std::string getFlattenedMemRefName(StringAttr baseName,
                        type.getElementType(), uniqueID);
 }
 
-// For a arr[i, j, k] : memref<3x10x10>
-// calculates: (i * 10 + j) * 10 + k
+// For a arr[i, j, k] : memref<3x4x5>
+// calculates: (i * 4 + j) * 5 + k
 static Value flattenIndices(ConversionPatternRewriter &rewriter, Operation *op,
                             ValueRange indices, MemRefType memrefType) {
   assert(memrefType.hasStaticShape() && "expected statically shaped memref");
@@ -81,9 +82,9 @@ static Value flattenIndices(ConversionPatternRewriter &rewriter, Operation *op,
 
   Value finalIdx = indices.front();
 
-  for (size_t i = 1; i < indices.size(); ++i) {
-    Value partialIdx = indices[i];
-    int64_t dimSize = memrefType.getShape()[i];
+  for (auto [i, partialIdx] : llvm::enumerate(indices.drop_front())) {
+    // + 1 because enumerate starts from 0, and we are ommiting the zeroth index.
+    int64_t dimSize = memrefType.getShape()[i + 1];
 
     if (llvm::isPowerOf2_64(dimSize)) {
       auto constant =

--- a/lib/Transforms/FlattenMemRefs.cpp
+++ b/lib/Transforms/FlattenMemRefs.cpp
@@ -66,8 +66,8 @@ static std::string getFlattenedMemRefName(StringAttr baseName,
                        type.getElementType(), uniqueID);
 }
 
-// Flatten indices by generating the product of the i'th index and the [0:i-1]
-// shapes, for each index, and then summing these.
+// For a arr[i, j, k] : memref<3x10x10>
+// calculates: (i * 10 + j) * 10 + k
 static Value flattenIndices(ConversionPatternRewriter &rewriter, Operation *op,
                             ValueRange indices, MemRefType memrefType) {
   assert(memrefType.hasStaticShape() && "expected statically shaped memref");
@@ -80,36 +80,28 @@ static Value flattenIndices(ConversionPatternRewriter &rewriter, Operation *op,
   }
 
   Value finalIdx = indices.front();
-  for (auto memIdx : llvm::enumerate(indices.drop_front())) {
-    Value partialIdx = memIdx.value();
-    int64_t indexMulFactor = 1;
 
-    // Calculate the product of the i'th index and the [0:i-1] shape dims.
-    for (unsigned i = memIdx.index() + 1; i < memrefType.getShape().size();
-         ++i) {
-      int64_t dimSize = memrefType.getShape()[i];
-      indexMulFactor *= dimSize;
-    }
+  for (size_t i = 1; i < indices.size(); ++i) {
+    Value partialIdx = indices[i];
+    int64_t dimSize = memrefType.getShape()[i];
 
-    // Multiply product by the current index operand.
-    if (llvm::isPowerOf2_64(indexMulFactor)) {
-      auto constant = arith::ConstantOp::create(
-                          rewriter, loc,
-                          rewriter.getIndexAttr(llvm::Log2_64(indexMulFactor)))
-                          .getResult();
+    if (llvm::isPowerOf2_64(dimSize)) {
+      auto constant =
+          arith::ConstantOp::create(
+              rewriter, loc, rewriter.getIndexAttr(llvm::Log2_64(dimSize)))
+              .getResult();
       finalIdx =
           arith::ShLIOp::create(rewriter, loc, finalIdx, constant).getResult();
     } else {
-      auto constant = arith::ConstantOp::create(
-                          rewriter, loc, rewriter.getIndexAttr(indexMulFactor))
+      auto constant = arith::ConstantOp::create(rewriter, loc,
+                                                rewriter.getIndexAttr(dimSize))
                           .getResult();
       finalIdx =
           arith::MulIOp::create(rewriter, loc, finalIdx, constant).getResult();
     }
 
-    // Sum up with the prior lower dimension accessors.
-    auto sumOp = arith::AddIOp::create(rewriter, loc, finalIdx, partialIdx);
-    finalIdx = sumOp.getResult();
+    finalIdx =
+        arith::AddIOp::create(rewriter, loc, finalIdx, partialIdx).getResult();
   }
   return finalIdx;
 }

--- a/test/Transforms/flatten_memref.mlir
+++ b/test/Transforms/flatten_memref.mlir
@@ -23,7 +23,7 @@ func.func @as_func_arg(%a : memref<4x4xi32>, %i : index) -> i32 {
 
 // CHECK-LABEL:   func @multidim3(
 // CHECK:                    %[[VAL_0:.*]]: memref<210xi32>, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index, %[[VAL_3:.*]]: index) -> i32 {
-// CHECK:           %[[VAL_4:.*]] = arith.constant 42 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 6 : index
 // CHECK:           %[[VAL_5:.*]] = arith.muli %[[VAL_1]], %[[VAL_4]] : index
 // CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_2]] : index
 // CHECK:           %[[VAL_7:.*]] = arith.constant 7 : index
@@ -41,13 +41,13 @@ func.func @multidim3(%a : memref<5x6x7xi32>, %i1 : index, %i2 : index, %i3 : ind
 
 // CHECK-LABEL:   func @multidim5(
 // CHECK:                    %[[VAL_0:.*]]: memref<18900xi32>, %[[VAL_1:.*]]: index) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 3780 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 6 : index
 // CHECK:           %[[VAL_3:.*]] = arith.muli %[[VAL_1]], %[[VAL_2]] : index
 // CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : index
-// CHECK:           %[[VAL_5:.*]] = arith.constant 630 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 7 : index
 // CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_4]], %[[VAL_5]] : index
 // CHECK:           %[[VAL_7:.*]] = arith.addi %[[VAL_6]], %[[VAL_1]] : index
-// CHECK:           %[[VAL_8:.*]] = arith.constant 90 : index
+// CHECK:           %[[VAL_8:.*]] = arith.constant 9 : index
 // CHECK:           %[[VAL_9:.*]] = arith.muli %[[VAL_7]], %[[VAL_8]] : index
 // CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_9]], %[[VAL_1]] : index
 // CHECK:           %[[VAL_11:.*]] = arith.constant 10 : index
@@ -65,13 +65,13 @@ func.func @multidim5(%a : memref<5x6x7x9x10xi32>, %i : index) -> i32 {
 
 // CHECK-LABEL:   func @multidim5_p2(
 // CHECK:                    %[[VAL_0:.*]]: memref<512xi32>, %[[VAL_1:.*]]: index) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 8 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
 // CHECK:           %[[VAL_3:.*]] = arith.shli %[[VAL_1]], %[[VAL_2]] : index
 // CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : index
-// CHECK:           %[[VAL_5:.*]] = arith.constant 6 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 3 : index
 // CHECK:           %[[VAL_6:.*]] = arith.shli %[[VAL_4]], %[[VAL_5]] : index
 // CHECK:           %[[VAL_7:.*]] = arith.addi %[[VAL_6]], %[[VAL_1]] : index
-// CHECK:           %[[VAL_8:.*]] = arith.constant 3 : index
+// CHECK:           %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_9:.*]] = arith.shli %[[VAL_7]], %[[VAL_8]] : index
 // CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_9]], %[[VAL_1]] : index
 // CHECK:           %[[VAL_11:.*]] = arith.constant 2 : index


### PR DESCRIPTION
Fixes #10326 
