### PR TITLE
[OM] Switch to IntegerBinaryInterface

### DIFF
--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -440,10 +440,6 @@ private:
   FailureOr<EvaluatorValuePtr>
   evaluateConstant(ConstantOp op, ActualParameters actualParams, Location loc);
 
-  FailureOr<EvaluatorValuePtr>
-  evaluateIntegerBinaryArithmetic(IntegerBinaryArithmeticOp op,
-                                  ActualParameters actualParams, Location loc);
-
   /// Instantiate an Object with its class name and actual parameters.
   FailureOr<EvaluatorValuePtr>
   evaluateObjectInstance(StringAttr className, ActualParameters actualParams,
@@ -459,6 +455,9 @@ private:
   FailureOr<EvaluatorValuePtr> evaluateListConcat(ListConcatOp op,
                                                   ActualParameters actualParams,
                                                   Location loc);
+  FailureOr<EvaluatorValuePtr>
+  evaluateIntegerBinary(IntegerBinaryOp op, ActualParameters actualParams,
+                        Location loc);
   FailureOr<EvaluatorValuePtr>
   evaluateStringConcat(StringConcatOp op, ActualParameters actualParams,
                        Location loc);

--- a/include/circt/Dialect/OM/OMOpInterfaces.td
+++ b/include/circt/Dialect/OM/OMOpInterfaces.td
@@ -49,9 +49,9 @@ def ClassLike : OpInterface<"ClassLike"> {
   ];
 }
 
-def IntegerBinaryArithmeticInterface : OpInterface<"IntegerBinaryArithmeticOp"> {
+def IntegerBinaryInterface : OpInterface<"IntegerBinaryOp"> {
   let cppNamespace = "circt::om";
-  let description = "Common interface for integer binary arithmetic ops.";
+  let description = "Common interface for integer binary ops (arithmetic and bitwise).";
   let methods = [
     InterfaceMethod<"Get the lhs Value",
       "mlir::Value", "getLhs", (ins)>,
@@ -59,7 +59,7 @@ def IntegerBinaryArithmeticInterface : OpInterface<"IntegerBinaryArithmeticOp"> 
       "mlir::Value", "getRhs", (ins)>,
     InterfaceMethod<"Get the result Value",
       "mlir::Value", "getResult", (ins)>,
-    InterfaceMethod<"Evaluate the integer binary arithmetic operation",
+    InterfaceMethod<"Evaluate the integer binary operation",
       "mlir::FailureOr<llvm::APSInt>", "evaluateIntegerOperation",
       (ins "const llvm::APSInt &":$lhs, "const llvm::APSInt &":$rhs)>
   ];

--- a/include/circt/Dialect/OM/OMOpInterfaces.td
+++ b/include/circt/Dialect/OM/OMOpInterfaces.td
@@ -51,7 +51,7 @@ def ClassLike : OpInterface<"ClassLike"> {
 
 def IntegerBinaryInterface : OpInterface<"IntegerBinaryOp"> {
   let cppNamespace = "circt::om";
-  let description = "Common interface for integer binary ops (arithmetic and bitwise).";
+  let description = "Common interface for integer binary ops.";
   let methods = [
     InterfaceMethod<"Get the lhs Value",
       "mlir::Value", "getLhs", (ins)>,

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -450,10 +450,10 @@ def AnyCastOp : OMOp<"any_cast", [Pure]> {
      "$input attr-dict `:` functional-type($input, $result)";
 }
 
-class IntegerBinaryArithmeticOp<string mnemonic, list<Trait> traits = []> :
+class IntegerBinaryOp<string mnemonic, list<Trait> traits = []> :
     OMOp<mnemonic, [
       Pure,
-      DeclareOpInterfaceMethods<IntegerBinaryArithmeticInterface>
+      DeclareOpInterfaceMethods<IntegerBinaryInterface>
     ] # traits> {
   let arguments = (ins OMIntegerType:$lhs, OMIntegerType:$rhs);
 
@@ -463,7 +463,7 @@ class IntegerBinaryArithmeticOp<string mnemonic, list<Trait> traits = []> :
   let hasFolder = 1;
 }
 
-def IntegerAddOp : IntegerBinaryArithmeticOp<"integer.add", [Commutative]> {
+def IntegerAddOp : IntegerBinaryOp<"integer.add", [Commutative]> {
   let summary = "Add two OMIntegerType values";
   let description = [{
     Perform arbitrary precision signed integer addition of two OMIntegerType
@@ -476,7 +476,7 @@ def IntegerAddOp : IntegerBinaryArithmeticOp<"integer.add", [Commutative]> {
   }];
 }
 
-def IntegerMulOp : IntegerBinaryArithmeticOp<"integer.mul", [Commutative]> {
+def IntegerMulOp : IntegerBinaryOp<"integer.mul", [Commutative]> {
   let summary = "Multiply two OMIntegerType values";
   let description = [{
     Perform arbitrary prevision signed integer multiplication of two
@@ -489,7 +489,7 @@ def IntegerMulOp : IntegerBinaryArithmeticOp<"integer.mul", [Commutative]> {
   }];
 }
 
-def IntegerShrOp : IntegerBinaryArithmeticOp<"integer.shr"> {
+def IntegerShrOp : IntegerBinaryOp<"integer.shr"> {
   let summary = "Shift an OMIntegerType value right by an OMIntegerType value";
   let description = [{
     Perform arbitrary precision signed integer arithmetic shift right of the lhs
@@ -503,7 +503,7 @@ def IntegerShrOp : IntegerBinaryArithmeticOp<"integer.shr"> {
   }];
 }
 
-def IntegerShlOp : IntegerBinaryArithmeticOp<"integer.shl"> {
+def IntegerShlOp : IntegerBinaryOp<"integer.shl"> {
   let summary = "Shift an OMIntegerType value left by an OMIntegerType value";
   let description = [{
     Perform arbitrary precision signed integer arithmetic shift left of the lhs

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -129,9 +129,9 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
                 .Case([&](ConstantOp op) {
                   return evaluateConstant(op, actualParams, loc);
                 })
-                .Case([&](IntegerBinaryArithmeticOp op) {
-                  // Create a partially evaluated AttributeValue of
-                  // om::IntegerType in case we need to delay evaluation.
+                .Case([&](IntegerBinaryOp op) {
+                  // Create a partially evaluated AttributeValue in case we need
+                  // to delay evaluation.
                   evaluator::EvaluatorValuePtr result =
                       evaluator::AttributeValue::get(op.getResult().getType(),
                                                      loc);
@@ -481,8 +481,8 @@ circt::om::Evaluator::evaluateValue(Value value, ActualParameters actualParams,
             .Case([&](ConstantOp op) {
               return evaluateConstant(op, actualParams, loc);
             })
-            .Case([&](IntegerBinaryArithmeticOp op) {
-              return evaluateIntegerBinaryArithmetic(op, actualParams, loc);
+            .Case([&](IntegerBinaryOp op) {
+              return evaluateIntegerBinary(op, actualParams, loc);
             })
             .Case([&](ObjectOp op) {
               return evaluateObjectInstance(op, actualParams);
@@ -542,10 +542,9 @@ circt::om::Evaluator::evaluateConstant(ConstantOp op,
   return success(om::evaluator::AttributeValue::get(op.getValue(), loc));
 }
 
-// Evaluator dispatch function for integer binary arithmetic.
-FailureOr<EvaluatorValuePtr>
-circt::om::Evaluator::evaluateIntegerBinaryArithmetic(
-    IntegerBinaryArithmeticOp op, ActualParameters actualParams, Location loc) {
+// Evaluator dispatch function for integer binary operations.
+FailureOr<EvaluatorValuePtr> circt::om::Evaluator::evaluateIntegerBinary(
+    IntegerBinaryOp op, ActualParameters actualParams, Location loc) {
   // Get the op's EvaluatorValue handle, in case it hasn't been evaluated yet.
   auto handle = getOrCreateValue(op.getResult(), actualParams, loc);
 
@@ -573,33 +572,36 @@ circt::om::Evaluator::evaluateIntegerBinaryArithmetic(
     return handle;
   }
 
-  // Extract the integer attributes.
-  auto extractAttr = [](evaluator::EvaluatorValue *value) {
-    return std::move(
-        llvm::TypeSwitch<evaluator::EvaluatorValue *, om::IntegerAttr>(value)
-            .Case([](evaluator::AttributeValue *val) {
-              return val->getAs<om::IntegerAttr>();
-            })
+  // Extract the attribute from an EvaluatorValue (handles both om::IntegerAttr
+  // and mlir::IntegerAttr).
+  auto extractAttr = [](evaluator::EvaluatorValue *value) -> mlir::Attribute {
+    auto *attrVal =
+        llvm::TypeSwitch<evaluator::EvaluatorValue *,
+                         evaluator::AttributeValue *>(value)
+            .Case([](evaluator::AttributeValue *val) { return val; })
             .Case([](evaluator::ReferenceValue *val) {
               return cast<evaluator::AttributeValue>(
-                         val->getStrippedValue()->get())
-                  ->getAs<om::IntegerAttr>();
-            }));
+                  val->getStrippedValue()->get());
+            })
+            .Default(
+                [](auto) -> evaluator::AttributeValue * { return nullptr; });
+    if (!attrVal)
+      return {};
+    return attrVal->getAttr();
   };
 
-  om::IntegerAttr lhs = extractAttr(lhsResult.value().get());
-  om::IntegerAttr rhs = extractAttr(rhsResult.value().get());
-  assert(lhs && rhs &&
-         "expected om::IntegerAttr for IntegerBinaryArithmeticOp operands");
+  mlir::Attribute lhsAttr = extractAttr(lhsResult.value().get());
+  mlir::Attribute rhsAttr = extractAttr(rhsResult.value().get());
+  assert(lhsAttr && rhsAttr &&
+         "expected attribute for IntegerBinaryOp operands");
 
-  std::array<Attribute, 2> operandAttrs = {lhs, rhs};
+  std::array<Attribute, 2> operandAttrs = {lhsAttr, rhsAttr};
   SmallVector<mlir::OpFoldResult, 1> results;
-  IntegerAttr resultAttr;
+  mlir::Attribute resultAttr;
   // Even with fully constant operands, folders may decline to fold or may
   // produce a non-attribute result.
   if (failed(op->fold(operandAttrs, results)) || results.size() != 1 ||
-      !(resultAttr = llvm::dyn_cast_or_null<om::IntegerAttr>(
-            results[0].dyn_cast<Attribute>())))
+      !(resultAttr = results[0].dyn_cast<Attribute>()))
     return op->emitError("failed to evaluate integer operation");
 
   // Finalize the op result value.

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -574,20 +574,13 @@ FailureOr<EvaluatorValuePtr> circt::om::Evaluator::evaluateIntegerBinary(
 
   // Extract the attribute from an EvaluatorValue (handles both om::IntegerAttr
   // and mlir::IntegerAttr).
-  auto extractAttr = [](evaluator::EvaluatorValue *value) -> mlir::Attribute {
-    auto *attrVal =
-        llvm::TypeSwitch<evaluator::EvaluatorValue *,
-                         evaluator::AttributeValue *>(value)
-            .Case([](evaluator::AttributeValue *val) { return val; })
-            .Case([](evaluator::ReferenceValue *val) {
-              return cast<evaluator::AttributeValue>(
-                  val->getStrippedValue()->get());
-            })
-            .Default(
-                [](auto) -> evaluator::AttributeValue * { return nullptr; });
-    if (!attrVal)
-      return {};
-    return attrVal->getAttr();
+  auto extractAttr = [](evaluator::EvaluatorValue *value) -> Attribute {
+    return llvm::TypeSwitch<evaluator::EvaluatorValue *, Attribute>(value)
+        .Case([](evaluator::AttributeValue *val) { return val->getAttr(); })
+        .Case([](evaluator::ReferenceValue *val) {
+          return cast<evaluator::AttributeValue>(val->getStrippedValue()->get())
+              ->getAttr();
+        });
   };
 
   mlir::Attribute lhsAttr = extractAttr(lhsResult.value().get());

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -641,10 +641,10 @@ PathCreateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
-// IntegerBinaryArithmeticOp
+// IntegerBinaryOp (arithmetic)
 //===----------------------------------------------------------------------===//
 
-static OpFoldResult foldIntegerBinaryArithmetic(IntegerBinaryArithmeticOp op,
+static OpFoldResult foldIntegerBinaryArithmetic(IntegerBinaryOp op,
                                                 Attribute lhsAttr,
                                                 Attribute rhsAttr) {
   auto lhs = dyn_cast_or_null<circt::om::IntegerAttr>(lhsAttr);


### PR DESCRIPTION
Change the `IntegerBinaryArithmeticInterface` to `IntegerBinaryInterface`.
There is nothing about this that is specific to arithmetic, just binary
operations involving integers.

In a follow-on, new bitwise operations will be added and implement this
appropriately renamed interface.

Assisted-by: OpenCode:claude-sonnet-4-6
