### PR TITLE
Prioritize in-tree MLIR headers in unified builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,10 @@ else()
   set(MLIR_INCLUDE_DIR ${MLIR_MAIN_SRC_DIR}/include ) # --includedir
   set(MLIR_TABLEGEN_OUTPUT_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
   set(MLIR_TABLEGEN_EXE $<TARGET_FILE:mlir-tblgen>)
-  include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
-  include_directories(SYSTEM ${MLIR_TABLEGEN_OUTPUT_DIR})
+  # Keep the in-tree MLIR headers ahead of dependency prefixes that might also
+  # contain an installed MLIR checkout.
+  include_directories(BEFORE ${MLIR_INCLUDE_DIR})
+  include_directories(BEFORE ${MLIR_TABLEGEN_OUTPUT_DIR})
 
   # If building as part of a unified build, whether or not MLIR's execution engine
   # is enabled must be fetched from its subdirectory scope.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,8 +127,8 @@ else()
   set(MLIR_TABLEGEN_EXE $<TARGET_FILE:mlir-tblgen>)
   # Keep the in-tree MLIR headers ahead of dependency prefixes that might also
   # contain an installed MLIR checkout.
-  include_directories(BEFORE ${MLIR_INCLUDE_DIR})
-  include_directories(BEFORE ${MLIR_TABLEGEN_OUTPUT_DIR})
+  include_directories(BEFORE "${MLIR_INCLUDE_DIR}")
+  include_directories(BEFORE "${MLIR_TABLEGEN_OUTPUT_DIR}")
 
   # If building as part of a unified build, whether or not MLIR's execution engine
   # is enabled must be fetched from its subdirectory scope.


### PR DESCRIPTION
This change updates the unified build configuration so the in-tree MLIR include directories are added with `BEFORE` and are no longer marked as `SYSTEM`.

The previous ordering allowed external dependency prefixes, such as `/home/linuxbrew/.linuxbrew/include`, to appear before the checked-out MLIR headers. If that prefix contained an older installed MLIR, generated CIRCT headers could be compiled against mismatched MLIR APIs. In the observed failure, the generated Debug dialect declarations referenced `mlir::PropertyRef`, while the compiler picked up older MLIR headers that did not define that type.

## AI Tool Use

AI tools were used to help prepare this change. I reviewed the generated content,
understand the change, and take responsibility for the submitted work.

Assisted-by: Codex:gpt-5
