### PR TITLE
[Synth] Clean up boolean logic interface, NFC

### DIFF
--- a/include/circt/Dialect/Synth/SynthOpInterfaces.td
+++ b/include/circt/Dialect/Synth/SynthOpInterfaces.td
@@ -27,6 +27,9 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
   }];
 
   let methods = [
+    //===------------------------------------------------------------------===//
+    // Accessors
+    //===------------------------------------------------------------------===//
     InterfaceMethod<[{
         Get the logical input values.
       }],
@@ -79,24 +82,46 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
         return $_op->getResult(0);
       }]
     >,
-    InterfaceMethod<[{
-        Return whether the operation semantics are invariant under
-        permutation of logical input pairs. Reordering a logical input means
-        moving both the input value and its inversion flag together.
-      }],
-      "bool", "areInputsPermutationInvariant", (ins), "",
-      [{
-        return false;
-      }]
-    >,
+    //===------------------------------------------------------------------===//
+    // Instance Semantics
+    //===------------------------------------------------------------------===//
     InterfaceMethod<[{
         Evaluate the boolean logic operation for the provided raw operand
         inputs. The implementations are responsible for applying any per-input
         inversion described by the operation itself.
       }],
       "::llvm::APInt", "evaluateBooleanLogic",
-      (ins "::llvm::function_ref<const ::llvm::APInt &(unsigned)>":$getInputValue)
+      (ins "::llvm::function_ref<const ::llvm::APInt &(unsigned)>":$getInputValue),
+      "",
+      [{
+        ::llvm::SmallVector<::llvm::APInt, 4> adjustedInputs;
+        auto inverted = $_op.getInverted();
+        adjustedInputs.reserve(inverted.size());
+        for (auto [index, isInverted] : llvm::enumerate(inverted)) {
+          ::llvm::APInt input = getInputValue(index);
+          if (isInverted)
+            input.flipAllBits();
+          adjustedInputs.push_back(std::move(input));
+        }
+        return ConcreteOp::evaluateBooleanLogicWithoutInversion(adjustedInputs);
+      }]
     >,
+    InterfaceMethod<[{
+        Evaluate the boolean logic operation for the provided raw operand
+        inputs.
+      }],
+      "::llvm::APInt", "evaluateBooleanLogic",
+      (ins "::llvm::ArrayRef<::llvm::APInt>":$inputs), "",
+      [{
+        auto getInputValue = [&](unsigned index) -> const ::llvm::APInt & {
+          return inputs[index];
+        };
+        return $_op.evaluateBooleanLogic(getInputValue);
+      }]
+    >,
+    //===------------------------------------------------------------------===//
+    // Analysis Helpers
+    //===------------------------------------------------------------------===//
     InterfaceMethod<[{
         Compute known bits for the result from the logical inputs.
         The implementations are responsible for applying any per-input inversion
@@ -122,17 +147,6 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
       }],
       "std::optional<uint64_t>", "getLogicAreaCost", (ins)
     >,
-    StaticInterfaceMethod<[{
-        Emit CNF clauses encoding `outVar <=> op(inputVars...)` for the
-        non-inverted form of the operation. The provided `inputVars` are SAT
-        literals corresponding to the logical operands in operand order, after
-        any per-input inversion has already been materialized by the caller.
-      }],
-      "void", "emitCNFWithoutInversion",
-      (ins "int":$outVar, "::llvm::ArrayRef<int>":$inputVars,
-           "::llvm::function_ref<void(::llvm::ArrayRef<int>)>":$addClause,
-           "::llvm::function_ref<int()>":$newVar)
-    >,
     InterfaceMethod<[{
         Emit CNF clauses encoding `outVar <=> op(inputVars...)`.
         The provided `inputVars` correspond to this operation's operands in
@@ -157,6 +171,9 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
                                                    newVar);
       }]
     >,
+    //===------------------------------------------------------------------===//
+    // Cloning
+    //===------------------------------------------------------------------===//
     InterfaceMethod<[{
         Clone or fold this operation with the provided inputs while preserving
         the existing inversion flags.
@@ -171,6 +188,54 @@ def BooleanLogicOpInterface : OpInterface<"BooleanLogicOpInterface"> {
                                                 newInputs,
                                                 concreteOp.getInverted());
       }]
+    >,
+    //===------------------------------------------------------------------===//
+    // Static Helpers
+    //===------------------------------------------------------------------===//
+    StaticInterfaceMethod<[{
+        Return whether this op supports the given number of logical inputs.
+      }],
+      "bool", "supportsNumInputs",
+      (ins "unsigned":$numInputs)
+    >,
+    StaticInterfaceMethod<[{
+        Evaluate the boolean logic operation for raw operand inputs after any
+        per-input inversion has already been applied by the caller.
+      }],
+      "::llvm::APInt", "evaluateBooleanLogicWithoutInversion",
+      (ins "::llvm::ArrayRef<::llvm::APInt>":$inputs)
+    >,
+    StaticInterfaceMethod<[{
+        Build this boolean logic operation with the given operands and
+        per-input inversion flags.
+      }],
+      "::mlir::Value", "createBooleanLogicOp",
+      (ins "::mlir::OpBuilder &":$builder, "::mlir::Location":$loc,
+           "::llvm::ArrayRef<::mlir::Value>":$operands,
+           "::llvm::ArrayRef<bool>":$inverted),
+      [{
+        assert(!operands.empty() && "expected at least one operand");
+        return builder.createOrFold<ConcreteOp>(loc, operands.front().getType(),
+                                                operands, inverted);
+      }]
+    >,
+    StaticInterfaceMethod<[{
+        Return whether the operation semantics are invariant under
+        permutation of logical input pairs. Reordering an input means moving
+        both the input value and its inversion flag together.
+      }],
+      "bool", "areInputsPermutationInvariant", (ins)
+    >,
+    StaticInterfaceMethod<[{
+        Emit CNF clauses encoding `outVar <=> op(inputVars...)` for the
+        non-inverted form of the operation. The provided `inputVars` are SAT
+        literals corresponding to the logical operands in operand order, after
+        any per-input inversion has already been materialized by the caller.
+      }],
+      "void", "emitCNFWithoutInversion",
+      (ins "int":$outVar, "::llvm::ArrayRef<int>":$inputVars,
+           "::llvm::function_ref<void(::llvm::ArrayRef<int>)>":$addClause,
+           "::llvm::function_ref<int()>":$newVar)
     >
   ];
 }

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -29,7 +29,8 @@ class InvertibleOperandsOp<string mnemonic, list<Trait> traits = []>
       // syntax across Synth ops such as `synth.aig.and_inv`.
       SameOperandsAndResultType, Pure,
       DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
-        "areInputsPermutationInvariant", "getLogicDepthCost",
+        "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
+        "supportsNumInputs", "createBooleanLogicOp", "getLogicDepthCost",
         "getLogicAreaCost"
       ]> ] # traits> {
   // TODO: Restrict to HWIntegerType.
@@ -137,6 +138,8 @@ def XorInverterOp : InvertibleOperandsOp<"xor_inv"> {
 def DotOp : SynthOp<"dot", [
     SameOperandsAndResultType, Pure,
     DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
+      "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
+      "supportsNumInputs", "createBooleanLogicOp",
       "getLogicAreaCost"
     ]>
   ]> {

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -36,14 +36,6 @@ using namespace matchers;
 
 namespace {
 
-// Keep inversion semantics identical across folding, analysis, and CNF
-// lowering so new invertible Synth ops can reuse the same helpers.
-inline APInt applyInversion(APInt value, bool inverted) {
-  if (inverted)
-    value.flipAllBits();
-  return value;
-}
-
 inline llvm::KnownBits applyInversion(llvm::KnownBits value, bool inverted) {
   if (inverted)
     std::swap(value.Zero, value.One);
@@ -249,16 +241,17 @@ LogicalResult AndInverterOp::canonicalize(AndInverterOp op,
   return success();
 }
 
-APInt AndInverterOp::evaluateBooleanLogic(
-    llvm::function_ref<const APInt &(unsigned)> getInputValue) {
-  assert(getNumOperands() > 0 && "Expected non-empty input list");
-  APInt result = APInt::getAllOnes(getInputValue(0).getBitWidth());
-  for (auto [idx, inverted] : llvm::enumerate(getInverted())) {
-    const APInt &input = getInputValue(idx);
-    // Model each operand inversion before intersecting with the running AND.
-    result &= applyInversion(input, inverted);
-  }
+APInt AndInverterOp::evaluateBooleanLogicWithoutInversion(
+    llvm::ArrayRef<APInt> inputs) {
+  assert(!inputs.empty() && "expected non-empty input list");
+  APInt result = APInt::getAllOnes(inputs.front().getBitWidth());
+  for (const APInt &input : inputs)
+    result &= input;
   return result;
+}
+
+bool AndInverterOp::supportsNumInputs(unsigned numInputs) {
+  return numInputs >= 1;
 }
 
 llvm::KnownBits AndInverterOp::computeKnownBits(
@@ -402,13 +395,17 @@ LogicalResult XorInverterOp::canonicalize(XorInverterOp op,
   return success();
 }
 
-APInt XorInverterOp::evaluateBooleanLogic(
-    llvm::function_ref<const APInt &(unsigned)> getInputValue) {
-  assert(getNumOperands() > 0 && "Expected non-empty input list");
-  APInt result = APInt::getZero(getInputValue(0).getBitWidth());
-  for (auto [idx, inverted] : llvm::enumerate(getInverted()))
-    result ^= applyInversion(getInputValue(idx), inverted);
+APInt XorInverterOp::evaluateBooleanLogicWithoutInversion(
+    llvm::ArrayRef<APInt> inputs) {
+  assert(!inputs.empty() && "expected non-empty input list");
+  APInt result = APInt::getZero(inputs.front().getBitWidth());
+  for (const APInt &input : inputs)
+    result ^= input;
   return result;
+}
+
+bool XorInverterOp::supportsNumInputs(unsigned numInputs) {
+  return numInputs >= 1;
 }
 
 llvm::KnownBits XorInverterOp::computeKnownBits(
@@ -477,13 +474,16 @@ LogicalResult DotOp::verify() {
   return success();
 }
 
-APInt DotOp::evaluateBooleanLogic(
-    llvm::function_ref<const APInt &(unsigned)> getInputValue) {
-  APInt x = applyInversion(getInputValue(0), isInverted(0));
-  APInt y = applyInversion(getInputValue(1), isInverted(1));
-  APInt z = applyInversion(getInputValue(2), isInverted(2));
-  return evaluateDotLogic(x, y, z);
+APInt DotOp::evaluateBooleanLogicWithoutInversion(
+    llvm::ArrayRef<APInt> inputs) {
+  assert(supportsNumInputs(inputs.size()) &&
+         "dot expects exactly three operands");
+  return evaluateDotLogic(inputs[0], inputs[1], inputs[2]);
 }
+
+bool DotOp::areInputsPermutationInvariant() { return false; }
+
+bool DotOp::supportsNumInputs(unsigned numInputs) { return numInputs == 3; }
 
 llvm::KnownBits DotOp::computeKnownBits(
     llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {


### PR DESCRIPTION
Refactor BooleanLogicOpInterface to separate instance behavior from shared static helpers, and update Synth boolean ops to implement the new API for upcoming exact synthesis usage. 

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
