### PR TITLE
[SimToSV] lower sim.get_file to i32 fd

### DIFF
--- a/lib/Conversion/SimToSV/CMakeLists.txt
+++ b/lib/Conversion/SimToSV/CMakeLists.txt
@@ -11,4 +11,5 @@ add_circt_conversion_library(CIRCTSimToSV
   CIRCTEmit
   CIRCTSim
   CIRCTSeq
+  CIRCTSVLoweringUtils
 )

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -523,12 +523,6 @@ static bool moveOpsIntoIfdefGuardsAndProcesses(Operation *rootOp) {
 
 namespace {
 
-LogicalResult emitFormatLoweringError(Location loc, StringRef context,
-                                      const Twine &reason) {
-  return mlir::emitError(loc)
-         << "cannot lower " << context << " to SystemVerilog: " << reason;
-}
-
 void appendLiteralToSVFormat(SmallString<128> &formatString,
                              StringRef literal) {
   for (char ch : literal) {
@@ -573,12 +567,12 @@ void appendFloatSpecifier(SmallString<128> &formatString, bool isLeftAligned,
   formatString.push_back(spec);
 }
 
-LogicalResult getFlattenedFormatFragments(Value input, StringRef context,
+LogicalResult getFlattenedFormatFragments(Value input,
                                           SmallVectorImpl<Value> &fragments) {
   if (auto concat = input.getDefiningOp<FormatStringConcatOp>()) {
     if (failed(concat.getFlattenedInputs(fragments)))
-      return emitFormatLoweringError(input.getLoc(), context,
-                                     "cyclic sim.fmt.concat is unsupported");
+      return mlir::emitError(input.getLoc(),
+                             "cyclic sim.fmt.concat is unsupported");
     return success();
   }
 
@@ -586,15 +580,14 @@ LogicalResult getFlattenedFormatFragments(Value input, StringRef context,
   return success();
 }
 
-LogicalResult appendFormatFragmentToSVFormat(Value fragment, StringRef context,
+LogicalResult appendFormatFragmentToSVFormat(Value fragment,
                                              SmallString<128> &formatString,
                                              SmallVectorImpl<Value> &args,
                                              OpBuilder &builder) {
   Operation *fragmentOp = fragment.getDefiningOp();
   if (!fragmentOp)
-    return emitFormatLoweringError(
-        fragment.getLoc(), context,
-        "block argument format strings are unsupported");
+    return mlir::emitError(fragment.getLoc(),
+                           "block argument format strings are unsupported");
 
   return TypeSwitch<Operation *, LogicalResult>(fragmentOp)
       .Case<FormatLiteralOp>([&](auto literal) -> LogicalResult {
@@ -614,9 +607,9 @@ LogicalResult appendFormatFragmentToSVFormat(Value fragment, StringRef context,
         if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
                                           fmt.getPaddingChar(),
                                           fmt.getSpecifierWidth(), 'd'))) {
-          return emitFormatLoweringError(
-              fmt.getLoc(), context,
-              "sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0')");
+          return mlir::emitError(fmt.getLoc())
+                 << "sim.fmt.dec only supports paddingChar 32 (' ') or 48 "
+                    "('0')";
         }
         // Match sim.fmt.dec signedness semantics explicitly in SV.
         if (fmt.getIsSigned()) {
@@ -637,9 +630,9 @@ LogicalResult appendFormatFragmentToSVFormat(Value fragment, StringRef context,
                 formatString, fmt.getIsLeftAligned(), fmt.getPaddingChar(),
                 fmt.getSpecifierWidth(),
                 fmt.getIsHexUppercase() ? 'X' : 'x'))) {
-          return emitFormatLoweringError(
-              fmt.getLoc(), context,
-              "sim.fmt.hex only supports paddingChar 32 (' ') or 48 ('0')");
+          return mlir::emitError(fmt.getLoc())
+                 << "sim.fmt.hex only supports paddingChar 32 (' ') or 48 "
+                    "('0')";
         }
         args.push_back(fmt.getValue());
         return success();
@@ -648,9 +641,9 @@ LogicalResult appendFormatFragmentToSVFormat(Value fragment, StringRef context,
         if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
                                           fmt.getPaddingChar(),
                                           fmt.getSpecifierWidth(), 'o'))) {
-          return emitFormatLoweringError(
-              fmt.getLoc(), context,
-              "sim.fmt.oct only supports paddingChar 32 (' ') or 48 ('0')");
+          return mlir::emitError(fmt.getLoc())
+                 << "sim.fmt.oct only supports paddingChar 32 (' ') or 48 "
+                    "('0')";
         }
         args.push_back(fmt.getValue());
         return success();
@@ -659,9 +652,9 @@ LogicalResult appendFormatFragmentToSVFormat(Value fragment, StringRef context,
         if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
                                           fmt.getPaddingChar(),
                                           fmt.getSpecifierWidth(), 'b'))) {
-          return emitFormatLoweringError(
-              fmt.getLoc(), context,
-              "sim.fmt.bin only supports paddingChar 32 (' ') or 48 ('0')");
+          return mlir::emitError(fmt.getLoc())
+                 << "sim.fmt.bin only supports paddingChar 32 (' ') or 48 "
+                    "('0')";
         }
         args.push_back(fmt.getValue());
         return success();
@@ -685,35 +678,37 @@ LogicalResult appendFormatFragmentToSVFormat(Value fragment, StringRef context,
         return success();
       })
       .Default([&](auto unsupportedOp) {
-        return emitFormatLoweringError(
-            unsupportedOp->getLoc(), context,
-            Twine("unsupported format fragment '") +
-                unsupportedOp->getName().getStringRef() + "'");
+        return mlir::emitError(unsupportedOp->getLoc())
+               << "unsupported format fragment '"
+               << unsupportedOp->getName().getStringRef() << "'";
       });
 }
 
-LogicalResult lowerFormatStringToSVFormat(Value input, StringRef context,
+LogicalResult lowerFormatStringToSVFormat(Value input,
                                           SmallString<128> &formatString,
                                           SmallVectorImpl<Value> &args,
                                           OpBuilder &builder) {
   SmallVector<Value, 8> fragments;
-  if (failed(getFlattenedFormatFragments(input, context, fragments)))
+  if (failed(getFlattenedFormatFragments(input, fragments)))
     return failure();
   for (auto fragment : fragments)
-    if (failed(appendFormatFragmentToSVFormat(fragment, context, formatString,
-                                              args, builder)))
+    if (failed(appendFormatFragmentToSVFormat(fragment, formatString, args,
+                                              builder)))
       return failure();
   return success();
 }
 
-FailureOr<Value> lowerGetFileToSVAtUse(GetFileOp getFileOp,
-                                       OpBuilder &builder) {
+FailureOr<Value> createFileDescriptorGetterForGetFile(GetFileOp getFileOp,
+                                                      OpBuilder &builder) {
   SmallString<128> formatString;
   SmallVector<Value> args;
-  if (failed(lowerFormatStringToSVFormat(getFileOp.getFileName(),
-                                         "file name for 'sim.get_file'",
-                                         formatString, args, builder)))
+  if (failed(lowerFormatStringToSVFormat(getFileOp.getFileName(), formatString,
+                                         args, builder))) {
+    getFileOp.emitError("cannot lower 'sim.get_file' to SystemVerilog")
+            .attachNote(getFileOp.getFileName().getLoc())
+        << "while lowering file name";
     return failure();
+  }
 
   Value fileName =
       args.empty()
@@ -740,9 +735,11 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
     OpBuilder builder(printOp);
     SmallString<128> formatString;
     SmallVector<Value> args;
-    if (failed(lowerFormatStringToSVFormat(printOp.getInput(),
-                                           "format string for 'sim.proc.print'",
-                                           formatString, args, builder))) {
+    if (failed(lowerFormatStringToSVFormat(printOp.getInput(), formatString,
+                                           args, builder))) {
+      printOp.emitError("cannot lower 'sim.proc.print' to SystemVerilog")
+              .attachNote(printOp.getInput().getLoc())
+          << "while lowering format string";
       return failure();
     }
     auto stream = printOp.getStream();
@@ -752,7 +749,8 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
     } else {
       Value fd;
       if (auto getFileOp = stream.getDefiningOp<GetFileOp>()) {
-        auto fdOrFailure = lowerGetFileToSVAtUse(getFileOp, builder);
+        auto fdOrFailure =
+            createFileDescriptorGetterForGetFile(getFileOp, builder);
         if (failed(fdOrFailure))
           return failure();
         fd = *fdOrFailure;

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Conversion/SimToSV.h"
+#include "circt/Conversion/SVLoweringUtils.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/Emit/EmitOps.h"
 #include "circt/Dialect/HW/HWOps.h"
@@ -62,6 +63,7 @@ namespace {
 struct SimConversionState {
   hw::HWModuleOp module;
   bool usedSynthesisMacro = false;
+  bool usedFileDescriptorRuntime = false;
   SetVector<StringAttr> dpiCallees;
 };
 
@@ -341,8 +343,6 @@ struct LowerDPIFunc {
   circt::Namespace nameSpace;
   LowerDPIFunc(mlir::ModuleOp module) { nameSpace.add(module); }
   void lower(sim::DPIFuncOp func);
-  void addFragments(hw::HWModuleOp module,
-                    ArrayRef<StringAttr> dpiCallees) const;
 };
 
 static ArrayAttr buildSVPerArgumentAttrs(MLIRContext *context,
@@ -409,18 +409,22 @@ void LowerDPIFunc::lower(sim::DPIFuncOp func) {
   func.erase();
 }
 
-void LowerDPIFunc::addFragments(hw::HWModuleOp module,
-                                ArrayRef<StringAttr> dpiCallees) const {
+static void
+addFragments(hw::HWModuleOp module,
+             const llvm::DenseMap<StringAttr, StringAttr> &symbolToFragment,
+             const SimConversionState &state) {
   llvm::SetVector<Attribute> fragments;
   // Add existing emit fragments.
   if (auto exstingFragments =
           module->getAttrOfType<ArrayAttr>(emit::getFragmentsAttrName()))
     for (auto fragment : exstingFragments.getAsRange<FlatSymbolRefAttr>())
       fragments.insert(fragment);
-  for (auto callee : dpiCallees) {
+  for (auto callee : state.dpiCallees) {
     auto attr = symbolToFragment.at(callee);
     fragments.insert(FlatSymbolRefAttr::get(attr));
   }
+  if (state.usedFileDescriptorRuntime)
+    fragments.insert(sv::getFileDescriptorFragmentRef(module.getContext()));
   if (!fragments.empty())
     module->setAttr(
         emit::getFragmentsAttrName(),
@@ -519,13 +523,14 @@ static bool moveOpsIntoIfdefGuardsAndProcesses(Operation *rootOp) {
 
 namespace {
 
-LogicalResult emitLoweringError(Location loc, const Twine &reason) {
+LogicalResult emitFormatLoweringError(Location loc, StringRef context,
+                                      const Twine &reason) {
   return mlir::emitError(loc)
-         << "cannot lower 'sim.proc.print' to sv.write: " << reason;
+         << "cannot lower " << context << " to SystemVerilog: " << reason;
 }
 
-void appendLiteralToFWriteFormat(SmallString<128> &formatString,
-                                 StringRef literal) {
+void appendLiteralToSVFormat(SmallString<128> &formatString,
+                             StringRef literal) {
   for (char ch : literal) {
     if (ch == '%')
       formatString += "%%";
@@ -568,12 +573,12 @@ void appendFloatSpecifier(SmallString<128> &formatString, bool isLeftAligned,
   formatString.push_back(spec);
 }
 
-LogicalResult getFlattenedFormatFragments(Value input,
+LogicalResult getFlattenedFormatFragments(Value input, StringRef context,
                                           SmallVectorImpl<Value> &fragments) {
   if (auto concat = input.getDefiningOp<FormatStringConcatOp>()) {
     if (failed(concat.getFlattenedInputs(fragments)))
-      return emitLoweringError(input.getLoc(),
-                               "cyclic sim.fmt.concat is unsupported");
+      return emitFormatLoweringError(input.getLoc(), context,
+                                     "cyclic sim.fmt.concat is unsupported");
     return success();
   }
 
@@ -581,19 +586,19 @@ LogicalResult getFlattenedFormatFragments(Value input,
   return success();
 }
 
-LogicalResult appendFormatFragmentToFWrite(Value fragment,
-                                           SmallString<128> &formatString,
-                                           SmallVectorImpl<Value> &args,
-                                           OpBuilder &builder) {
+LogicalResult appendFormatFragmentToSVFormat(Value fragment, StringRef context,
+                                             SmallString<128> &formatString,
+                                             SmallVectorImpl<Value> &args,
+                                             OpBuilder &builder) {
   Operation *fragmentOp = fragment.getDefiningOp();
   if (!fragmentOp)
-    return emitLoweringError(fragment.getLoc(),
-                             "block argument format strings are unsupported as "
-                             "sim.proc.print input");
+    return emitFormatLoweringError(
+        fragment.getLoc(), context,
+        "block argument format strings are unsupported");
 
   return TypeSwitch<Operation *, LogicalResult>(fragmentOp)
       .Case<FormatLiteralOp>([&](auto literal) -> LogicalResult {
-        appendLiteralToFWriteFormat(formatString, literal.getLiteral());
+        appendLiteralToSVFormat(formatString, literal.getLiteral());
         return success();
       })
       .Case<FormatHierPathOp>([&](auto hierPath) -> LogicalResult {
@@ -609,9 +614,9 @@ LogicalResult appendFormatFragmentToFWrite(Value fragment,
         if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
                                           fmt.getPaddingChar(),
                                           fmt.getSpecifierWidth(), 'd'))) {
-          return emitLoweringError(
-              fmt.getLoc(), "sim.fmt.dec only supports paddingChar 32 (' ') "
-                            "or 48 ('0') for SystemVerilog lowering");
+          return emitFormatLoweringError(
+              fmt.getLoc(), context,
+              "sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0')");
         }
         // Match sim.fmt.dec signedness semantics explicitly in SV.
         if (fmt.getIsSigned()) {
@@ -632,9 +637,9 @@ LogicalResult appendFormatFragmentToFWrite(Value fragment,
                 formatString, fmt.getIsLeftAligned(), fmt.getPaddingChar(),
                 fmt.getSpecifierWidth(),
                 fmt.getIsHexUppercase() ? 'X' : 'x'))) {
-          return emitLoweringError(
-              fmt.getLoc(), "sim.fmt.hex only supports paddingChar 32 (' ') "
-                            "or 48 ('0') for SystemVerilog lowering");
+          return emitFormatLoweringError(
+              fmt.getLoc(), context,
+              "sim.fmt.hex only supports paddingChar 32 (' ') or 48 ('0')");
         }
         args.push_back(fmt.getValue());
         return success();
@@ -643,9 +648,9 @@ LogicalResult appendFormatFragmentToFWrite(Value fragment,
         if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
                                           fmt.getPaddingChar(),
                                           fmt.getSpecifierWidth(), 'o'))) {
-          return emitLoweringError(
-              fmt.getLoc(), "sim.fmt.oct only supports paddingChar 32 (' ') "
-                            "or 48 ('0') for SystemVerilog lowering");
+          return emitFormatLoweringError(
+              fmt.getLoc(), context,
+              "sim.fmt.oct only supports paddingChar 32 (' ') or 48 ('0')");
         }
         args.push_back(fmt.getValue());
         return success();
@@ -654,9 +659,9 @@ LogicalResult appendFormatFragmentToFWrite(Value fragment,
         if (failed(appendIntegerSpecifier(formatString, fmt.getIsLeftAligned(),
                                           fmt.getPaddingChar(),
                                           fmt.getSpecifierWidth(), 'b'))) {
-          return emitLoweringError(
-              fmt.getLoc(), "sim.fmt.bin only supports paddingChar 32 (' ') "
-                            "or 48 ('0') for SystemVerilog lowering");
+          return emitFormatLoweringError(
+              fmt.getLoc(), context,
+              "sim.fmt.bin only supports paddingChar 32 (' ') or 48 ('0')");
         }
         args.push_back(fmt.getValue());
         return success();
@@ -680,29 +685,52 @@ LogicalResult appendFormatFragmentToFWrite(Value fragment,
         return success();
       })
       .Default([&](auto unsupportedOp) {
-        return emitLoweringError(unsupportedOp->getLoc(),
-                                 Twine("unsupported format fragment '") +
-                                     unsupportedOp->getName().getStringRef() +
-                                     "'");
+        return emitFormatLoweringError(
+            unsupportedOp->getLoc(), context,
+            Twine("unsupported format fragment '") +
+                unsupportedOp->getName().getStringRef() + "'");
       });
 }
 
-LogicalResult foldFormatStringToFWrite(Value input,
-                                       SmallString<128> &formatString,
-                                       SmallVectorImpl<Value> &args,
-                                       OpBuilder &builder) {
+LogicalResult lowerFormatStringToSVFormat(Value input, StringRef context,
+                                          SmallString<128> &formatString,
+                                          SmallVectorImpl<Value> &args,
+                                          OpBuilder &builder) {
   SmallVector<Value, 8> fragments;
-  if (failed(getFlattenedFormatFragments(input, fragments)))
+  if (failed(getFlattenedFormatFragments(input, context, fragments)))
     return failure();
   for (auto fragment : fragments)
-    if (failed(appendFormatFragmentToFWrite(fragment, formatString, args,
-                                            builder)))
+    if (failed(appendFormatFragmentToSVFormat(fragment, context, formatString,
+                                              args, builder)))
       return failure();
   return success();
 }
 
+FailureOr<Value> lowerGetFileToSVAtUse(GetFileOp getFileOp,
+                                       OpBuilder &builder) {
+  SmallString<128> formatString;
+  SmallVector<Value> args;
+  if (failed(lowerFormatStringToSVFormat(getFileOp.getFileName(),
+                                         "file name for 'sim.get_file'",
+                                         formatString, args, builder)))
+    return failure();
+
+  Value fileName =
+      args.empty()
+          ? sv::ConstantStrOp::create(builder, getFileOp.getLoc(),
+                                      builder.getStringAttr(formatString))
+                .getResult()
+          : sv::SFormatFOp::create(builder, getFileOp.getLoc(),
+                                   builder.getStringAttr(formatString), args)
+                .getResult();
+
+  return sv::createProceduralFileDescriptorGetterCall(
+      builder, getFileOp.getLoc(), fileName);
+}
+
 LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
-                                          const TypeConverter &typeConverter) {
+                                          const TypeConverter &typeConverter,
+                                          SimConversionState &state) {
   SmallVector<PrintFormattedProcOp> printOps;
   module.walk([&](PrintFormattedProcOp op) { printOps.push_back(op); });
 
@@ -712,8 +740,9 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
     OpBuilder builder(printOp);
     SmallString<128> formatString;
     SmallVector<Value> args;
-    if (failed(foldFormatStringToFWrite(printOp.getInput(), formatString, args,
-                                        builder))) {
+    if (failed(lowerFormatStringToSVFormat(printOp.getInput(),
+                                           "format string for 'sim.proc.print'",
+                                           formatString, args, builder))) {
       return failure();
     }
     auto stream = printOp.getStream();
@@ -721,11 +750,20 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
       // no stream is specified, emit sv.write.
       sv::WriteOp::create(builder, printOp.getLoc(), formatString, args);
     } else {
-      auto fdType = typeConverter.convertType(stream.getType());
-      assert(fdType && "expected output stream type conversion");
-      auto fd = mlir::UnrealizedConversionCastOp::create(
-                    builder, printOp.getLoc(), fdType, stream)
-                    ->getResult(0);
+      Value fd;
+      if (auto getFileOp = stream.getDefiningOp<GetFileOp>()) {
+        auto fdOrFailure = lowerGetFileToSVAtUse(getFileOp, builder);
+        if (failed(fdOrFailure))
+          return failure();
+        fd = *fdOrFailure;
+        state.usedFileDescriptorRuntime = true;
+      } else {
+        auto fdType = typeConverter.convertType(stream.getType());
+        assert(fdType && "expected output stream type conversion");
+        fd = mlir::UnrealizedConversionCastOp::create(builder, printOp.getLoc(),
+                                                      fdType, stream)
+                 ->getResult(0);
+      }
       sv::FWriteOp::create(builder, printOp.getLoc(), fd, formatString, args);
     }
     auto *procRoot =
@@ -754,16 +792,17 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
       lowerDPIFunc.lower(func);
 
     std::atomic<bool> usedSynthesisMacro = false;
+    std::atomic<bool> usedFileDescriptorRuntime = false;
     auto lowerModule = [&](hw::HWModuleOp module) {
       SimTypeConverter typeConverter(context);
+      SimConversionState state;
 
-      if (failed(lowerPrintFormattedProcToSV(module, typeConverter)))
+      if (failed(lowerPrintFormattedProcToSV(module, typeConverter, state)))
         return failure();
 
       if (moveOpsIntoIfdefGuardsAndProcesses(module))
         usedSynthesisMacro = true;
 
-      SimConversionState state;
       ConversionTarget target(*context);
       target.addIllegalDialect<SimDialect>();
       target.addLegalDialect<sv::SVDialect>();
@@ -791,11 +830,13 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
       if (failed(result))
         return result;
 
-      // Set the emit fragment.
-      lowerDPIFunc.addFragments(module, state.dpiCallees.takeVector());
+      // Set the emit fragments required by this module.
+      addFragments(module, lowerDPIFunc.symbolToFragment, state);
 
       if (state.usedSynthesisMacro)
         usedSynthesisMacro = true;
+      if (state.usedFileDescriptorRuntime)
+        usedFileDescriptorRuntime = true;
       return result;
     };
 
@@ -803,7 +844,7 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
             context, circuit.getOps<hw::HWModuleOp>(), lowerModule)))
       return signalPassFailure();
 
-    if (usedSynthesisMacro) {
+    if (usedSynthesisMacro || usedFileDescriptorRuntime) {
       Operation *op = circuit.lookupSymbol("SYNTHESIS");
       if (op) {
         if (!isa<sv::MacroDeclOp>(op)) {
@@ -815,6 +856,12 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
             UnknownLoc::get(context), circuit.getBody());
         sv::MacroDeclOp::create(builder, "SYNTHESIS");
       }
+    }
+
+    if (usedFileDescriptorRuntime) {
+      auto builder = ImplicitLocOpBuilder::atBlockBegin(
+          UnknownLoc::get(context), circuit.getBody());
+      sv::emitFileDescriptorRuntime(circuit, builder);
     }
   }
 };

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -755,6 +755,7 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
           return failure();
         fd = *fdOrFailure;
         state.usedFileDescriptorRuntime = true;
+        state.usedSynthesisMacro = true;
       } else {
         auto fdType = typeConverter.convertType(stream.getType());
         assert(fdType && "expected output stream type conversion");
@@ -842,7 +843,7 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
             context, circuit.getOps<hw::HWModuleOp>(), lowerModule)))
       return signalPassFailure();
 
-    if (usedSynthesisMacro || usedFileDescriptorRuntime) {
+    if (usedSynthesisMacro) {
       Operation *op = circuit.lookupSymbol("SYNTHESIS");
       if (op) {
         if (!isa<sv::MacroDeclOp>(op)) {

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv-errors.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv-errors.mlir
@@ -4,9 +4,11 @@ hw.module @unsupported_padding_char(in %clk : i1, in %arg : i8) {
   hw.triggered posedge %clk (%arg) : i8 {
     ^bb0(%arg_in : i8):
     %lit = sim.fmt.literal "bad="
-    // expected-error @below {{cannot lower format string for 'sim.proc.print' to SystemVerilog: sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0')}}
+    // expected-error @below {{sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0')}}
     %bad = sim.fmt.dec %arg_in paddingChar 42 specifierWidth 2 : i8
+    // expected-note @below {{while lowering format string}}
     %msg = sim.fmt.concat (%lit, %bad)
+    // expected-error @below {{cannot lower 'sim.proc.print' to SystemVerilog}}
     sim.proc.print %msg
   }
 }
@@ -15,8 +17,10 @@ hw.module @unsupported_padding_char(in %clk : i1, in %arg : i8) {
 
 hw.module @unsupported_input_block_argument(in %clk : i1, in %arg : !sim.fstring) {
   hw.triggered posedge %clk (%arg) : !sim.fstring {
-    // expected-error @below {{cannot lower format string for 'sim.proc.print' to SystemVerilog: block argument format strings are unsupported}}
+    // expected-error @below {{block argument format strings are unsupported}}
+    // expected-note @below {{while lowering format string}}
     ^bb0(%arg_in : !sim.fstring):
+    // expected-error @below {{cannot lower 'sim.proc.print' to SystemVerilog}}
     sim.proc.print %arg_in
   }
 }
@@ -27,9 +31,11 @@ hw.module @unsupported_get_file_padding_char(in %clk : i1, in %arg : i8) {
   hw.triggered posedge %clk (%arg) : i8 {
     ^bb0(%arg_in : i8):
     %filePrefix = sim.fmt.literal "bad="
-    // expected-error @below {{cannot lower file name for 'sim.get_file' to SystemVerilog: sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0')}}
+    // expected-error @below {{sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0')}}
     %fileValue = sim.fmt.dec %arg_in paddingChar 42 specifierWidth 2 : i8
+    // expected-note @below {{while lowering file name}}
     %fileName = sim.fmt.concat (%filePrefix, %fileValue)
+    // expected-error @below {{cannot lower 'sim.get_file' to SystemVerilog}}
     %file = sim.get_file %fileName
     %msg = sim.fmt.literal "message"
     sim.proc.print %msg to %file

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv-errors.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv-errors.mlir
@@ -4,7 +4,7 @@ hw.module @unsupported_padding_char(in %clk : i1, in %arg : i8) {
   hw.triggered posedge %clk (%arg) : i8 {
     ^bb0(%arg_in : i8):
     %lit = sim.fmt.literal "bad="
-    // expected-error @below {{cannot lower 'sim.proc.print' to sv.write: sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0') for SystemVerilog lowering}}
+    // expected-error @below {{cannot lower format string for 'sim.proc.print' to SystemVerilog: sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0')}}
     %bad = sim.fmt.dec %arg_in paddingChar 42 specifierWidth 2 : i8
     %msg = sim.fmt.concat (%lit, %bad)
     sim.proc.print %msg
@@ -15,8 +15,23 @@ hw.module @unsupported_padding_char(in %clk : i1, in %arg : i8) {
 
 hw.module @unsupported_input_block_argument(in %clk : i1, in %arg : !sim.fstring) {
   hw.triggered posedge %clk (%arg) : !sim.fstring {
-    // expected-error @below {{cannot lower 'sim.proc.print' to sv.write: block argument format strings are unsupported as sim.proc.print input}}
+    // expected-error @below {{cannot lower format string for 'sim.proc.print' to SystemVerilog: block argument format strings are unsupported}}
     ^bb0(%arg_in : !sim.fstring):
     sim.proc.print %arg_in
+  }
+}
+
+// -----
+
+hw.module @unsupported_get_file_padding_char(in %clk : i1, in %arg : i8) {
+  hw.triggered posedge %clk (%arg) : i8 {
+    ^bb0(%arg_in : i8):
+    %filePrefix = sim.fmt.literal "bad="
+    // expected-error @below {{cannot lower file name for 'sim.get_file' to SystemVerilog: sim.fmt.dec only supports paddingChar 32 (' ') or 48 ('0')}}
+    %fileValue = sim.fmt.dec %arg_in paddingChar 42 specifierWidth 2 : i8
+    %fileName = sim.fmt.concat (%filePrefix, %fileValue)
+    %file = sim.get_file %fileName
+    %msg = sim.fmt.literal "message"
+    sim.proc.print %msg to %file
   }
 }

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
@@ -1,5 +1,9 @@
 // RUN: circt-opt --lower-sim-to-sv %s | FileCheck %s
 
+// CHECK: sv.func private @"__circt_lib_logging::FileDescriptor::get"
+// CHECK: sv.macro.decl @__CIRCT_LIB_LOGGING
+// CHECK: emit.fragment @CIRCT_LIB_LOGGING_FRAGMENT
+
 // This pass assumes sim.proc.print is already in some procedural region.
 // It lowers both SV and non-SV procedural containers (e.g. hw.triggered).
 
@@ -114,5 +118,50 @@ hw.module @print_to_stdout_and_stderr(in %clk : i1) {
     sim.proc.print %lit to %stdout
     // CHECK-NEXT: sv.fwrite %[[STDERR]], "literal"
     sim.proc.print %lit to %stderr
+  }
+}
+
+hw.module @print_to_file(in %clk : i1, in %idx : i8) {
+  // CHECK-LABEL: hw.module @print_to_file
+  // CHECK-SAME: emit.fragments = [@CIRCT_LIB_LOGGING_FRAGMENT]
+  hw.triggered posedge %clk (%idx) : i8 {
+    ^bb0(%idx_in : i8):
+    %filePrefix = sim.fmt.literal "trace_"
+    %fileIndex = sim.fmt.dec %idx_in paddingChar 48 specifierWidth 2 : i8
+    %fileSuffix = sim.fmt.literal ".log"
+    %fileName = sim.fmt.concat (%filePrefix, %fileIndex, %fileSuffix)
+    %file = sim.get_file %fileName
+    %msgPrefix = sim.fmt.literal "value="
+    %msgValue = sim.fmt.hex %idx_in, isUpper false specifierWidth 2 : i8
+    %msg = sim.fmt.concat (%msgPrefix, %msgValue)
+    // CHECK: ^bb0(%[[IDX:.+]]: i8):
+    // CHECK-NEXT: %[[UNSIGNED:.+]] = sv.system "unsigned"(%[[IDX]]) : (i8) -> i8
+    // CHECK-NEXT: %[[FILENAME:.+]] = sv.sformatf "trace_%02d.log"(%[[UNSIGNED]]) : i8
+    // CHECK-NEXT: %[[FD:.+]] = sv.func.call.procedural @"__circt_lib_logging::FileDescriptor::get"(%[[FILENAME]]) : (!hw.string) -> i32
+    // CHECK-NEXT: sv.fwrite %[[FD]], "value=%02x"(%[[IDX]]) : i8
+    sim.proc.print %msg to %file
+  }
+}
+
+hw.module @print_to_file_under_condition(in %clk : i1, in %idx : i8, in %en : i1) {
+  // CHECK-LABEL: hw.module @print_to_file_under_condition
+  // CHECK-SAME: emit.fragments = [@CIRCT_LIB_LOGGING_FRAGMENT]
+  hw.triggered posedge %clk (%idx, %en) : i8, i1 {
+    ^bb0(%idx_in : i8, %en_in : i1):
+    %filePrefix = sim.fmt.literal "trace_"
+    %fileIndex = sim.fmt.dec %idx_in paddingChar 48 specifierWidth 2 : i8
+    %fileSuffix = sim.fmt.literal ".log"
+    %fileName = sim.fmt.concat (%filePrefix, %fileIndex, %fileSuffix)
+    %file = sim.get_file %fileName
+    scf.if %en_in {
+      %msg = sim.fmt.literal "enabled"
+      // CHECK: ^bb0(%[[IDX:.+]]: i8, %[[EN:.+]]: i1):
+      // CHECK-NEXT: scf.if %[[EN]] {
+      // CHECK-NEXT:   %[[UNSIGNED:.+]] = sv.system "unsigned"(%[[IDX]]) : (i8) -> i8
+      // CHECK-NEXT:   %[[FILENAME:.+]] = sv.sformatf "trace_%02d.log"(%[[UNSIGNED]]) : i8
+      // CHECK-NEXT:   %[[FD:.+]] = sv.func.call.procedural @"__circt_lib_logging::FileDescriptor::get"(%[[FILENAME]]) : (!hw.string) -> i32
+      // CHECK-NEXT:   sv.fwrite %[[FD]], "enabled"
+      sim.proc.print %msg to %file
+    }
   }
 }

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
@@ -143,6 +143,20 @@ hw.module @print_to_file(in %clk : i1, in %idx : i8) {
   }
 }
 
+hw.module @print_to_literal_file(in %clk : i1) {
+  // CHECK-LABEL: hw.module @print_to_literal_file
+  // CHECK-SAME: emit.fragments = [@CIRCT_LIB_LOGGING_FRAGMENT]
+  hw.triggered posedge %clk {
+    %fileName = sim.fmt.literal "static.log"
+    %file = sim.get_file %fileName
+    %msg = sim.fmt.literal "value"
+    // CHECK: %[[FILENAME:.+]] = sv.constantStr "static.log"
+    // CHECK-NEXT: %[[FD:.+]] = sv.func.call.procedural @"__circt_lib_logging::FileDescriptor::get"(%[[FILENAME]]) : (!hw.string) -> i32
+    // CHECK-NEXT: sv.fwrite %[[FD]], "value"
+    sim.proc.print %msg to %file
+  }
+}
+
 hw.module @print_to_file_under_condition(in %clk : i1, in %idx : i8, in %en : i1) {
   // CHECK-LABEL: hw.module @print_to_file_under_condition
   // CHECK-SAME: emit.fragments = [@CIRCT_LIB_LOGGING_FRAGMENT]


### PR DESCRIPTION
Add support for lowering sim.get_file to sv dialect.

Assisted-by: Codex: GPT-5.5

