### PR TITLE
[FSM] Canonicalize away no-op updates

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -352,6 +352,8 @@ def UpdateOp : FSMOp<"update", [HasParent<"TransitionOp">, SameTypeOperands]> {
 
   let arguments = (ins AnyType:$variable, AnyType:$value);
 
+  let hasCanonicalizeMethod = true;
+
   let assemblyFormat = [{ attr-dict $variable `,` $value `:` qualified(type($value)) }];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -559,6 +559,15 @@ VariableOp UpdateOp::getVariableOp() {
   return getVariable().getDefiningOp<VariableOp>();
 }
 
+LogicalResult UpdateOp::canonicalize(UpdateOp op, PatternRewriter &rewriter) {
+  // Remove no-op updates that update a variable to itself
+  if (op.getVariable() == op.getValue()) {
+    rewriter.eraseOp(op);
+    return success();
+  }
+  return failure();
+}
+
 LogicalResult UpdateOp::verify() {
   if (!getVariable())
     return emitOpError("destination is not a variable operation");

--- a/test/Dialect/FSM/canonicalize.mlir
+++ b/test/Dialect/FSM/canonicalize.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt --canonicalize %s | FileCheck %s
+
+// CHECK-NOT: fsm.update
+
+fsm.machine @foo(%arg0: i1) attributes {initialState = "A"} {
+  %var = fsm.variable "var" {initValue = 0 : i16} : i16
+  fsm.state @A transitions {
+    fsm.transition @A action {
+        fsm.update %var, %var : i16
+    }
+  }
+}


### PR DESCRIPTION
`fsm.update` ops with the same value as both operands make no change to variable values, so this canonicalizes them away

CC: @luisacicolini 