### PR TITLE
[ImportVerilog] `HierarchicalNames` should skip reprocessing identical module instances

### DIFF
--- a/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
+++ b/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
@@ -19,10 +19,9 @@ struct InstBodyVisitor
                                     /*VisitExpressions=*/true> {
   InstBodyVisitor(
       Context &context, const slang::ast::Symbol &outermostModule,
-      DenseSet<StringAttr> &sameHierPaths,
       DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies)
       : context(context), outermostModule(outermostModule),
-        visitedBodies(visitedBodies), sameHierPaths(sameHierPaths) {}
+        visitedBodies(visitedBodies) {}
 
   void handle(const slang::ast::InstanceSymbol &instNode) {
     traverseInstanceBody(context, instNode, visitedBodies);
@@ -59,28 +58,29 @@ struct InstBodyVisitor
     // Collect hierarchical names that are added to the port list.
     std::function<void(const slang::ast::InstanceBodySymbol *, bool)>
         collectHierarchicalPaths = [&](auto sym, bool isUpward) {
-          // Here we use "sameHierPaths" to avoid collecting the repeat
-          // hierarchical names on the same path.
-          if (!sameHierPaths.contains(hierName) ||
-              !context.hierPaths.contains(sym)) {
+          // Check if this path already exists globally for this module
+          HierPathInfo *existing = nullptr;
+          if (context.hierPaths.contains(sym)) {
+            for (auto &path : context.hierPaths[sym]) {
+              if (path.hierName == hierName) {
+                existing = &path;
+                break;
+              }
+            }
+          }
+
+          if (!existing) {
             context.hierPaths[sym].push_back(
                 HierPathInfo{hierName,
                              {},
                              isUpward ? slang::ast::ArgumentDirection::Out
                                       : slang::ast::ArgumentDirection::In,
                              {&expr.symbol}});
-            sameHierPaths.insert(hierName);
           } else {
-            // The path already exists (dedup hit), but this may be a
-            // different instance resolving to a different symbol object
-            // for the same logical variable. Add it as an alias.
-            for (auto &existing : context.hierPaths[sym]) {
-              if (existing.hierName == hierName) {
-                if (!llvm::is_contained(existing.valueSyms, &expr.symbol))
-                  existing.valueSyms.push_back(&expr.symbol);
-                break;
-              }
-            }
+            // The path already exists, but this may be a different instance
+            // resolving to a different symbol object. Add as an alias.
+            if (!llvm::is_contained(existing->valueSyms, &expr.symbol))
+              existing->valueSyms.push_back(&expr.symbol);
           }
 
           // Iterate up from the current instance body symbol until meeting the
@@ -124,20 +124,14 @@ struct InstBodyVisitor
   const slang::ast::Symbol &outermostModule;
   DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies;
 
-  // Deduplication set shared across the entire traversal tree rooted at
-  // the top-level traverseInstanceBody call.
-  DenseSet<StringAttr> &sameHierPaths;
-
   static void traverseInstanceBody(
       Context &context, const slang::ast::InstanceSymbol &symbol,
       DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies) {
     const slang::ast::InstanceBodySymbol *body = getCanonicalBody(symbol);
     if (visitedBodies.insert(body).second) {
-      DenseSet<StringAttr> sameHierPaths;
       for (auto &member : body->members()) {
         auto &outermostModule = member.getParentScope()->asSymbol();
-        InstBodyVisitor visitor(context, outermostModule, sameHierPaths,
-                                visitedBodies);
+        InstBodyVisitor visitor(context, outermostModule, visitedBodies);
         member.visit(visitor);
       }
     }

--- a/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
+++ b/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
@@ -17,13 +17,15 @@ struct InstBodyVisitor
     : public slang::ast::ASTVisitor<InstBodyVisitor,
                                     /*VisitStatements=*/true,
                                     /*VisitExpressions=*/true> {
-  InstBodyVisitor(Context &context, const slang::ast::Symbol &outermostModule,
-                  DenseSet<StringAttr> &sameHierPaths)
+  InstBodyVisitor(
+      Context &context, const slang::ast::Symbol &outermostModule,
+      DenseSet<StringAttr> &sameHierPaths,
+      DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies)
       : context(context), outermostModule(outermostModule),
-        sameHierPaths(sameHierPaths) {}
+        visitedBodies(visitedBodies), sameHierPaths(sameHierPaths) {}
 
   void handle(const slang::ast::InstanceSymbol &instNode) {
-    context.traverseInstanceBody(instNode.body, sameHierPaths);
+    traverseInstanceBody(context, instNode, sameHierPaths, visitedBodies);
     // Also visit port connection expressions to find hier refs used as
     // port arguments (e.g., .in_val(b_inst.local_val)).
     for (auto *conn : instNode.getPortConnections())
@@ -120,28 +122,36 @@ struct InstBodyVisitor
 
   Context &context;
   const slang::ast::Symbol &outermostModule;
+  DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies;
 
   // Deduplication set shared across the entire traversal tree rooted at
   // the top-level traverseInstanceBody call.
   DenseSet<StringAttr> &sameHierPaths;
+
+  static void traverseInstanceBody(
+      Context& context,
+      const slang::ast::InstanceSymbol &symbol,
+      DenseSet<StringAttr> &sameHierPaths,
+      DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies) {
+    const slang::ast::InstanceBodySymbol *body = getCanonicalBody(symbol);
+    if (visitedBodies.insert(body).second)
+      for (auto &member : body->members()) {
+        auto &outermostModule = member.getParentScope()->asSymbol();
+        InstBodyVisitor visitor(context, outermostModule, sameHierPaths,
+                                visitedBodies);
+        member.visit(visitor);
+      }
+  }
 };
 
 } // namespace
 
-void Context::traverseInstanceBody(const slang::ast::Symbol &symbol) {
+void Context::traverseInstanceBody(const slang::ast::InstanceSymbol &symbol) {
   // Top-level entry point: create a fresh deduplication set that is shared
   // across all recursive traversals of this instance tree. This prevents
   // cross-hierarchy contamination between independent top-level instances.
   DenseSet<StringAttr> sameHierPaths;
-  traverseInstanceBody(symbol, sameHierPaths);
-}
-
-void Context::traverseInstanceBody(const slang::ast::Symbol &symbol,
-                                   DenseSet<StringAttr> &sameHierPaths) {
-  if (auto *instBodySymbol = symbol.as_if<slang::ast::InstanceBodySymbol>())
-    for (auto &member : instBodySymbol->members()) {
-      auto &outermostModule = member.getParentScope()->asSymbol();
-      InstBodyVisitor visitor(*this, outermostModule, sameHierPaths);
-      member.visit(visitor);
-    }
+  DenseSet<const slang::ast::InstanceBodySymbol *> visitedBodies;
+  InstBodyVisitor::traverseInstanceBody(*this, symbol, sameHierPaths,
+                                        visitedBodies);
 }

--- a/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
+++ b/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
@@ -129,8 +129,7 @@ struct InstBodyVisitor
   DenseSet<StringAttr> &sameHierPaths;
 
   static void traverseInstanceBody(
-      Context& context,
-      const slang::ast::InstanceSymbol &symbol,
+      Context &context, const slang::ast::InstanceSymbol &symbol,
       DenseSet<StringAttr> &sameHierPaths,
       DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies) {
     const slang::ast::InstanceBodySymbol *body = getCanonicalBody(symbol);

--- a/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
+++ b/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
@@ -25,7 +25,7 @@ struct InstBodyVisitor
         visitedBodies(visitedBodies), sameHierPaths(sameHierPaths) {}
 
   void handle(const slang::ast::InstanceSymbol &instNode) {
-    traverseInstanceBody(context, instNode, sameHierPaths, visitedBodies);
+    traverseInstanceBody(context, instNode, visitedBodies);
     // Also visit port connection expressions to find hier refs used as
     // port arguments (e.g., .in_val(b_inst.local_val)).
     for (auto *conn : instNode.getPortConnections())
@@ -130,27 +130,25 @@ struct InstBodyVisitor
 
   static void traverseInstanceBody(
       Context &context, const slang::ast::InstanceSymbol &symbol,
-      DenseSet<StringAttr> &sameHierPaths,
       DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies) {
     const slang::ast::InstanceBodySymbol *body = getCanonicalBody(symbol);
-    if (visitedBodies.insert(body).second)
+    if (visitedBodies.insert(body).second) {
+      DenseSet<StringAttr> sameHierPaths;
       for (auto &member : body->members()) {
         auto &outermostModule = member.getParentScope()->asSymbol();
         InstBodyVisitor visitor(context, outermostModule, sameHierPaths,
                                 visitedBodies);
         member.visit(visitor);
       }
+    }
   }
 };
 
 } // namespace
 
 void Context::traverseInstanceBody(const slang::ast::InstanceSymbol &symbol) {
-  // Top-level entry point: create a fresh deduplication set that is shared
-  // across all recursive traversals of this instance tree. This prevents
-  // cross-hierarchy contamination between independent top-level instances.
-  DenseSet<StringAttr> sameHierPaths;
+  // Top-level entry point: create a fresh visitedBodies set to prevent
+  // infinite recursion and to skip identical module bodies.
   DenseSet<const slang::ast::InstanceBodySymbol *> visitedBodies;
-  InstBodyVisitor::traverseInstanceBody(*this, symbol, sameHierPaths,
-                                        visitedBodies);
+  InstBodyVisitor::traverseInstanceBody(*this, symbol, visitedBodies);
 }

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -312,9 +312,7 @@ struct Context {
       const slang::ast::CallExpression::SystemCallInfo &info, Location loc);
 
   // Traverse the whole AST to collect hierarchical names.
-  void traverseInstanceBody(const slang::ast::Symbol &symbol);
-  void traverseInstanceBody(const slang::ast::Symbol &symbol,
-                            DenseSet<StringAttr> &sameHierPaths);
+  void traverseInstanceBody(const slang::ast::InstanceSymbol &symbol);
 
   /// Build a composite key for hierValueSymbols from a hierarchical value
   /// expression. Returns {firstInstanceSymbol, dottedHierName} or std::nullopt

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -935,7 +935,7 @@ LogicalResult Context::convertCompilation() {
   // Visit the whole AST to collect the hierarchical names without any operation
   // creating.
   for (auto *inst : root.topInstances)
-    traverseInstanceBody(inst->body);
+    traverseInstanceBody(*inst);
 
   // Analyze the compilation to infer clocks for assertion system calls
   // using Slang's LRM clock inference.

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -237,28 +237,6 @@ module Foo;
 endmodule
 
 // -----
-// Cross-module hierarchical references can produce null port values that must
-// not crash during instance creation. This is an error in the hierarchical
-// reference resolution code that actually needs fixing. This test guards
-// against a regression to this being a crash.
-module HierRefTop(input i, output o);
-  // expected-error @below {{unsupported port}}
-  HierRefA A();
-  HierRefB B();
-  assign A.i = i;
-  assign o = B.o;
-endmodule
-module HierRefA;
-  wire i, y;
-  assign B.x = !i;
-  assign y = !B.y;
-endmodule
-module HierRefB;
-  wire x, y, o;
-  assign y = x, o = A.y;
-endmodule
-
-// -----
 module Foo;
   reg i;
   wire o;

--- a/test/circt-verilog/hierarchical-names.sv
+++ b/test/circt-verilog/hierarchical-names.sv
@@ -125,9 +125,9 @@ module Top2();
 endmodule
 
 // CHECK: hw.module private @Child()
-// CHECK:   hw.instance "gc" @GrandChild(c1.i: {{.+}}, c1.i: {{.+}})
+// CHECK:   hw.instance "gc" @GrandChild(c1.i: {{.+}})
 
-// CHECK: hw.module private @GrandChild(in %c1.i : !llhd.ref<i1>, in %c1.i_0 {{.+}} : !llhd.ref<i1>)
+// CHECK: hw.module private @GrandChild(in %c1.i : !llhd.ref<i1>)
 
 // CHECK: hw.module @Top1() {
 // CHECK:   hw.instance "c1" @Child() -> ()

--- a/test/circt-verilog/hierarchical-names.sv
+++ b/test/circt-verilog/hierarchical-names.sv
@@ -101,3 +101,37 @@ endmodule
 
 // CHECK: hw.module private @LeafInst(in %TopRoot.root_val : !llhd.ref<i1>) {
 // CHECK: }
+
+// Regression test for cross-module hierarchical name deduplication bug.
+// Child is instantiated multiple times, GrandChild has upward reference, Top2 has cross-hierarchy.
+module Child();
+  logic i;
+  GrandChild gc();
+endmodule
+
+module GrandChild();
+  logic i;
+  assign Child.i = 1'b1;
+endmodule
+
+module Top1();
+  Child c1();
+endmodule
+
+module Top2();
+  Child c2();
+  logic x;
+  assign x = Top1.c1.i;
+endmodule
+
+// CHECK: hw.module private @Child()
+// CHECK:   hw.instance "gc" @GrandChild(c1.i: {{.+}}, c1.i: {{.+}})
+
+// CHECK: hw.module private @GrandChild(in %c1.i : !llhd.ref<i1>, in %c1.i_0 {{.+}} : !llhd.ref<i1>)
+
+// CHECK: hw.module @Top1() {
+// CHECK:   hw.instance "c1" @Child() -> ()
+
+// CHECK: hw.module @Top2(in %c1.i : !llhd.ref<i1>) {
+// CHECK:   hw.instance "c2" @Child() -> ()
+


### PR DESCRIPTION
Currently `HierarchicalNames` unconditionally descends into all module instance bodies. This forces slang to instantiate complete ASTs for all module instances, transitively. For large designs this does not scale. For example with one 7M LOC Verilog example, ImportVerilog consumes more than 200GB of memory before crashing with OOM.

So, use slang's canonical module bodies to avoid re-traversing identical modules.

With this fixed on top of PR #10338, the aforementioned example is imported quite quickly, consuming no more than 30GB of memory.

NOTE: do not merge yet. I'm not super confident that the logic is correct.