### PR TITLE
[ESI][Runtime] Fix race condition in port disconnects

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -21,7 +21,10 @@
 #include "esi/Utils.h"
 
 #include <cassert>
+#include <condition_variable>
 #include <future>
+#include <mutex>
+#include <queue>
 
 namespace esi {
 
@@ -337,17 +340,29 @@ protected:
 /// A ChannelPort which reads data from the accelerator. It has two modes:
 /// Callback and Polling which cannot be used at the same time. The mode is set
 /// at connect() time. To change the mode, disconnect() and then connect()
-/// again.
+/// again. When the port is disconnected, it will backpressure hardware.
 class ReadChannelPort : public ChannelPort {
 
 public:
+  /// Primary callback API for raw reads.
+  ///
+  /// The message is passed by owning reference so the callee can consume it,
+  /// move storage out of it, or leave it intact when returning `false` to
+  /// request a retry with the same message object.
   using ReadCallback =
       std::function<bool(std::unique_ptr<SegmentedMessageData> &)>;
+
+  /// Compatibility callback API for callers which want flattened message
+  /// bytes instead of the owning segmented message object.
   using FlatReadCallback = std::function<bool(MessageData)>;
 
   ReadChannelPort(const Type *type)
       : ChannelPort(type), mode(Mode::Disconnected) {}
-  virtual void disconnect() override { mode = Mode::Disconnected; }
+
+  /// Disconnect the channel. Warning: this method may block until all callbacks
+  /// have returned. Do not call it anywhere which could be in a callback
+  /// control path otherwise deadlock will occur.
+  virtual void disconnect() override;
   virtual bool isConnected() const override {
     return mode != Mode::Disconnected;
   }
@@ -366,6 +381,8 @@ public:
   virtual void connect(ReadCallback callback,
                        const ConnectOptions &options = {});
 
+  /// Connect a compatibility callback which receives flattened `MessageData`
+  /// objects. This adapts the primary segmented callback path.
   virtual void connect(FlatReadCallback callback,
                        const ConnectOptions &options = {});
 
@@ -380,7 +397,10 @@ public:
   /// Connect to the channel in polling mode.
   virtual void connect(const ConnectOptions &options = {}) override;
 
-  /// Asynchronous read.
+  /// Asynchronous polling read.
+  ///
+  /// Throws if the port is disconnected or currently connected in callback
+  /// mode.
   virtual std::future<MessageData> readAsync();
 
   /// Specify a buffer to read into. Blocking. Basic API, will likely change
@@ -400,12 +420,21 @@ public:
   void setMaxDataQueueMsgs(uint64_t maxMsgs) { maxDataQueueMsgs = maxMsgs; }
 
 protected:
+  /// Invoke the currently registered callback.
+  ///
+  /// Handles synchronization race conditions with disconnects. Backends should
+  /// use this helper instead of calling `callback` directly.
+  bool invokeCallback(std::unique_ptr<SegmentedMessageData> &msg);
+
+private:
+  /// Backends should not call this directly. Use `invokeCallback()` instead,
+  /// which handles synchronization with disconnects.
+  ReadCallback callback;
+
+protected:
   /// Indicates the current mode of the channel.
   enum Mode { Disconnected, Callback, Polling };
   volatile Mode mode;
-
-  /// Backends call this callback when new data is available.
-  ReadCallback callback;
 
   /// If a translated message has been assembled but not yet consumed, retain
   /// ownership here so retries present the same message object.
@@ -438,6 +467,14 @@ protected:
   uint64_t maxDataQueueMsgs;
   /// Promises to be fulfilled when data is available.
   std::queue<std::promise<MessageData>> promiseQueue;
+
+  //===--------------------------------------------------------------------===//
+  // Synchronizes callback revocation during disconnect.
+  //===--------------------------------------------------------------------===//
+
+  std::mutex callbackMutex;
+  std::condition_variable callbackCv;
+  size_t activeCallbacks = 0;
 };
 
 /// Instantiated when a backend does not know how to create a read channel.

--- a/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
@@ -215,7 +215,7 @@ bool OneItemBuffersToHostReadPort::pollImpl() {
           (*details)["message_data"] = flat.toHex();
         });
 
-    if (!callback(pendingMessage)) {
+    if (!invokeCallback(pendingMessage)) {
       logger.trace(
           [&](std::string &subsystem, std::string &msg,
               std::unique_ptr<std::map<std::string, std::any>> &details) {

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -67,6 +67,61 @@ void ReadChannelPort::resetTranslationState() {
   translatedMessage.reset();
 }
 
+void ReadChannelPort::disconnect() {
+  {
+    std::unique_lock<std::mutex> lock(callbackMutex);
+    // Revoke the callback under the same mutex used by invokeCallback(). New
+    // deliveries need to observe the disconnected state and the callback
+    // nullification at the same time.
+    callback = nullptr;
+    mode = Mode::Disconnected;
+    // Wait for any callback which already snapped the old function to finish
+    // before clearing per-connection state below.
+    callbackCv.wait(lock, [this]() { return activeCallbacks == 0; });
+  }
+
+  resetTranslationState();
+}
+
+bool ReadChannelPort::invokeCallback(
+    std::unique_ptr<SegmentedMessageData> &msg) {
+  ReadCallback activeCallback;
+  {
+    std::lock_guard<std::mutex> lock(callbackMutex);
+    // Check the disconnected state and snapshot the callback while holding the
+    // same mutex as disconnect(). That prevents disconnect() from clearing the
+    // callback after we decide to invoke it but before we've retained our own
+    // safe local copy.
+    if (mode == Mode::Disconnected)
+      return false;
+    assert(callback && "Callback should be set in non-disconnected mode");
+    activeCallback = callback;
+    // Count only callbacks which successfully captured a callable target.
+    // disconnect() waits on this count so it can safely tear down state which
+    // the callback path may still reference.
+    ++activeCallbacks;
+  }
+
+  // Release the in-flight slot on every exit path, including exceptions from
+  // the callback itself.
+  auto finish = [this]() {
+    std::lock_guard<std::mutex> lock(callbackMutex);
+    assert(activeCallbacks > 0 && "Callback count underflow");
+    --activeCallbacks;
+    if (activeCallbacks == 0)
+      callbackCv.notify_all();
+  };
+
+  try {
+    bool consumed = activeCallback(msg);
+    finish();
+    return consumed;
+  } catch (...) {
+    finish();
+    throw;
+  }
+}
+
 void ReadChannelPort::connect(ReadCallback callback,
                               const ConnectOptions &options) {
   if (mode != Mode::Disconnected)
@@ -108,7 +163,10 @@ void ReadChannelPort::connect(FlatReadCallback callback,
 }
 
 void ReadChannelPort::connect(const ConnectOptions &options) {
-  maxDataQueueMsgs = DefaultMaxDataQueueMsgs;
+  if (mode != Mode::Disconnected)
+    throw std::runtime_error("Channel already connected");
+
+  maxDataQueueMsgs = options.bufferSize.value_or(DefaultMaxDataQueueMsgs);
 
   resetTranslationState();
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -123,7 +123,7 @@ public:
                 (*details)["message_data"] = flat.toHex();
               });
 
-          bool consumed = callback(data);
+          bool consumed = invokeCallback(data);
 
           if (consumed) {
             // Log the message consumption.

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/RpcServer.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/RpcServer.cpp
@@ -119,7 +119,7 @@ public:
   void push(MessageData &data) {
     std::unique_ptr<SegmentedMessageData> msg =
         std::make_unique<MessageData>(data);
-    while (!callback(msg))
+    while (!isConnected() || !invokeCallback(msg))
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 };

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -250,7 +250,7 @@ private:
   bool pollImpl() override {
     if (!pendingMessage)
       pendingMessage = std::make_unique<MessageData>(genMessage());
-    if (!callback(pendingMessage))
+    if (!invokeCallback(pendingMessage))
       return false;
     pendingMessage.reset();
     return true;

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
@@ -348,7 +348,7 @@ public:
     if (!pending)
       throw std::runtime_error(
           "CallbackDrivenMockReadPort::retryPending with no message");
-    if (!callback(pending))
+    if (!invokeCallback(pending))
       return false;
     pending.reset();
     return true;


### PR DESCRIPTION
When a connection is being disconnected incoming messages could still be delivered to the callback _after_ disconnect returned. This change prevents that.

Also updates some documentation.

Assisted-by: vscode:GPT-5.4