### PR TITLE
[LLHD][Deseq] Lower reset-only async reset processes as register holds

### DIFF
--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -1126,9 +1126,10 @@ bool Deseq::matchDriveClock(
 /// `drive.clock`.
 bool Deseq::matchDriveClockAndReset(
     DriveInfo &drive, ArrayRef<std::pair<DNFTerm, ValueEntry>> valueTable) {
-  // We need exactly three entries in the value table to represent a register
-  // with reset.
-  if (valueTable.size() != 3) {
+  // We need two or three entries in the value table to represent a register
+  // with reset. A table with two entries means that the clock edge while reset
+  // is inactive has no drive, which is a hold.
+  if (valueTable.size() != 2 && valueTable.size() != 3) {
     LLVM_DEBUG(llvm::dbgs() << "- Aborting: two trigger value table has "
                             << valueTable.size() << " entries\n");
     return false;
@@ -1175,7 +1176,8 @@ bool Deseq::matchDriveClockAndReset(
     auto clockIt = llvm::find_if(valueTable, [&](auto &pair) {
       return pair.first == clockWithoutEnable || pair.first == clockWithEnable;
     });
-    if (clockIt == valueTable.end())
+    bool clockHolds = clockIt == valueTable.end();
+    if (clockHolds && valueTable.size() != 2)
       continue;
 
     // Ensure that `/rst` and `/clk&rst` set the register to the same reset
@@ -1194,17 +1196,24 @@ bool Deseq::matchDriveClockAndReset(
 
     drive.clock.clock = triggers[clockIdx].getProjected();
     drive.clock.risingEdge = !negClock;
-    if (clockIt->first == clockWithEnable)
-      drive.clock.enable = drive.op.getEnable();
     drive.clock.value = drive.op.getValue();
-    if (!clockIt->second.isUnknown())
-      drive.clock.value = clockIt->second.value;
+    if (clockHolds) {
+      drive.clock.enable = drive.op.getEnable();
+    } else {
+      if (clockIt->first == clockWithEnable)
+        drive.clock.enable = drive.op.getEnable();
+      if (!clockIt->second.isUnknown())
+        drive.clock.value = clockIt->second.value;
+    }
 
     LLVM_DEBUG({
       llvm::dbgs() << "  - Matched " << (negClock ? "neg" : "pos")
                    << "edge clock ";
       drive.clock.clock.printAsOperand(llvm::dbgs(), OpPrintingFlags());
-      llvm::dbgs() << " -> " << clockIt->second;
+      if (clockHolds)
+        llvm::dbgs() << " -> hold";
+      else
+        llvm::dbgs() << " -> " << clockIt->second;
       if (drive.clock.enable)
         llvm::dbgs() << " (with enable)";
       llvm::dbgs() << "\n";

--- a/test/circt-verilog/registers.sv
+++ b/test/circt-verilog/registers.sv
@@ -49,6 +49,15 @@ module ActiveLowReset(input logic clock, input logic reset, input int d1, input 
   always @(posedge clock, negedge reset) q2 <= !reset ? 42 : d2;
 endmodule
 
+// CHECK-LABEL: hw.module @ActiveLowResetOnlyHold(
+module ActiveLowResetOnlyHold(input logic clock, input logic reset, input int rstval, output int q);
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[RST_INV:%.+]] = comb.xor %reset, %true
+  // CHECK: [[REG:%.+]] = seq.firreg [[REG]] clock [[CLK]] reset async [[RST_INV]], %rstval : i32
+  // CHECK: hw.output [[REG]]
+  always @(posedge clock, negedge reset) if (!reset) q <= rstval; else begin end
+endmodule
+
 // CHECK-LABEL: hw.module @Enable(
 module Enable(input logic clock, input logic enable, input int d, output int q);
   // CHECK: [[CLK:%.+]] = seq.to_clock %clock


### PR DESCRIPTION
# PR Description

## Summary

Fixes https://github.com/llvm/circt/issues/10340.

Teach `llhd-deseq` to recognize async-reset processes where the reset branch drives a register value, but the clocked branch has no assignment and therefore represents hold behavior.

Previously, `matchDriveClockAndReset` required exactly three value-table entries for resettable registers:

- reset edge
- clock edge while reset is active
- clock edge while reset is inactive

For reset-only update patterns, the last entry is absent because the normal clocked branch does not drive the signal. This caused `llhd-deseq` to leave behind `llhd.process`/`llhd.drv` instead of lowering through the normal `seq.firreg` path.

## Changes

- Allow resettable register matching with either two or three value-table entries.
- Treat a missing `clock edge && reset inactive` entry as an implicit hold.
- Reuse the existing enable/self-feedback lowering path to represent that hold behavior.
- Keep the existing reset consistency check requiring the reset edge and clock-while-reset-active entries to drive the same reset value.

## Test

Added a `circt-verilog` regression test for an active-low async reset where the non-reset branch is empty:

```systemverilog
always @(posedge clock, negedge reset)
  if (!reset) q <= rstval;
  else begin end
```

The test checks that the full Verilog frontend pipeline lowers this to a `seq.firreg` with async reset and self-feedback hold behavior.

For the original issue reproducer, where the reset value is constant zero, the full `circt-verilog` pipeline now lowers the design completely and subsequent canonicalization folds the result to:

```mlir
module {
  hw.module @arbiter(in %clk : i1, in %rst_n : i1, in %req : i4, out grant : i4) {
    %c0_i4 = hw.constant 0 : i4
    hw.output %c0_i4 : i4
  }
}
```

## Verification

```sh
ninja -C build bin/circt-verilog
./build/bin/llvm-lit -v test/circt-verilog/registers.sv
```
Assisted-by: Codex:gpt-5.5
