### PR TITLE
[Sim][MooreToCore] Lowering moore.fmt.string op to the new sim.fmt.string

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.h
+++ b/include/circt/Dialect/Sim/SimOps.h
@@ -40,6 +40,8 @@ namespace sim {
 /// Returns the value operand of a value formatting operation.
 /// Returns a null value for all other operations.
 static inline mlir::Value getFormattedValue(mlir::Operation *fmtOp) {
+  if (auto fmt = llvm::dyn_cast_or_null<circt::sim::FormatStringOp>(fmtOp))
+    return fmt.getValue();
   if (auto fmt = llvm::dyn_cast_or_null<circt::sim::FormatBinOp>(fmtOp))
     return fmt.getValue();
   if (auto fmt = llvm::dyn_cast_or_null<circt::sim::FormatDecOp>(fmtOp))

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -222,6 +222,33 @@ def FormatLiteralOp : SimOp<"fmt.literal", [Pure, ConstantLike]> {
   let hasFolder = true;
 }
 
+def FormatStringOp : SimOp<"fmt.string",
+  [Pure, DeclareOpInterfaceMethods<SimValueFormatter>]
+> {
+  let summary = "Dynamic string format specifier";
+  let description = [{
+    Format the given dynamic string value.
+
+    If `specifierWidth` is present and larger than the string length, the
+    result is padded to that width using `paddingChar`. By default, strings are
+    right-aligned and padded with spaces.
+  }];
+
+  let arguments = (ins DynamicStringType:$value,
+    DefaultValuedAttr<BoolAttr,"false">:$isLeftAligned,
+    DefaultValuedAttr<I8Attr,"32">:$paddingChar,
+    OptionalAttr<I32Attr>:$specifierWidth);
+  let results = (outs FormatStringType:$result);
+
+  let assemblyFormat = [{
+    $value
+    (`isLeftAligned` $isLeftAligned^)?
+    (`paddingChar` $paddingChar^)?
+    (`specifierWidth` $specifierWidth^)?
+    attr-dict `:` qualified(type($value))
+  }];
+}
+
 def FormatHexOp : SimOp<"fmt.hex",
   [Pure, DeclareOpInterfaceMethods<SimValueFormatter>]
 > {

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2502,6 +2502,28 @@ struct FormatLiteralOpConversion : public OpConversionPattern<FormatLiteralOp> {
   }
 };
 
+struct FormatStringOpConversion : public OpConversionPattern<FormatStringOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(FormatStringOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    char padChar =
+        op.getPadding().value_or(IntPadding::Space) == IntPadding::Space ? 32
+                                                                         : 48;
+    IntegerAttr padCharAttr = rewriter.getI8IntegerAttr(padChar);
+    auto widthAttr = adaptor.getWidthAttr();
+
+    bool isLeftAligned =
+        op.getAlignment().value_or(IntAlign::Right) == IntAlign::Left;
+    BoolAttr isLeftAlignedAttr = rewriter.getBoolAttr(isLeftAligned);
+
+    rewriter.replaceOpWithNewOp<sim::FormatStringOp>(
+        op, adaptor.getString(), isLeftAlignedAttr, padCharAttr, widthAttr);
+    return success();
+  }
+};
+
 struct FormatConcatOpConversion : public OpConversionPattern<FormatConcatOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -3472,6 +3494,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
 
     // Format strings.
     FormatLiteralOpConversion,
+    FormatStringOpConversion,
     FormatConcatOpConversion,
     FormatHierPathOpConversion,
     FormatIntOpConversion,

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -326,6 +326,26 @@ OpFoldResult FormatLiteralOp::fold(FoldAdaptor adaptor) {
   return getLiteralAttr();
 }
 
+// --- FormatStringOp ---
+
+StringAttr FormatStringOp::formatConstant(Attribute constVal) {
+  auto strAttr = llvm::dyn_cast<StringAttr>(constVal);
+  if (!strAttr)
+    return {};
+
+  SmallString<128> strBuf(strAttr.getValue());
+  if (getSpecifierWidth().has_value()) {
+    auto padChar = static_cast<char>(getPaddingChar());
+    unsigned padWidth = getSpecifierWidth().value();
+    padWidth = padWidth > strBuf.size() ? padWidth - strBuf.size() : 0;
+    if (getIsLeftAligned())
+      strBuf.append(padWidth, padChar);
+    else
+      strBuf.insert(strBuf.begin(), padWidth, padChar);
+  }
+  return StringAttr::get(getContext(), strBuf);
+}
+
 // --- FormatDecOp ---
 
 StringAttr FormatDecOp::formatConstant(Attribute constVal) {

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -386,7 +386,7 @@ func.func @Statements(%arg0: !moore.i42) {
 }
 
 // CHECK-LABEL: func @FormatStrings
-func.func @FormatStrings(%arg0: !moore.i42, %arg1: !moore.f32, %arg2: !moore.f64) {
+func.func @FormatStrings(%arg0: !moore.i42, %arg1: !moore.f32, %arg2: !moore.f64, %arg3: !moore.string) {
   // CHECK: [[TMP:%.+]] = sim.fmt.literal "hello"
   %0 = moore.fmt.literal "hello"
   // CHECK: sim.fmt.concat ([[TMP]], [[TMP]])
@@ -426,6 +426,11 @@ func.func @FormatStrings(%arg0: !moore.i42, %arg1: !moore.f32, %arg2: !moore.f64
   moore.fmt.real general %arg2, align right : f64
   // CHECK: sim.fmt.flt %arg1 fieldWidth 15 : f32
   moore.fmt.real float %arg1, align right fieldWidth 15 : f32
+
+  // CHECK: sim.fmt.string %arg3 specifierWidth 16 : !sim.dstring
+  moore.fmt.string %arg3, width 16, alignment right, padding space
+  // CHECK: sim.fmt.string %arg3 isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
+  moore.fmt.string %arg3, width 8, alignment left, padding zero
 
   // CHECK: sim.fmt.hier_path
   // CHECK-NOT: escaped

--- a/test/Dialect/Sim/format-strings.mlir
+++ b/test/Dialect/Sim/format-strings.mlir
@@ -323,3 +323,35 @@ hw.module @flatten_concat2(in %val : i8, out res: !sim.fstring) {
 
   hw.output %ccccc : !sim.fstring
 }
+
+// CHECK-LABEL: hw.module @fmt_string_fold_nopad
+// CHECK: sim.fmt.literal "abc"
+hw.module @fmt_string_fold_nopad(out res: !sim.fstring) {
+  %s = sim.string.literal "abc"
+  %f = sim.fmt.string %s : !sim.dstring
+  hw.output %f : !sim.fstring
+}
+
+// CHECK-LABEL: hw.module @fmt_string_fold_pad_nothing
+// CHECK: sim.fmt.literal "abc"
+hw.module @fmt_string_fold_pad_nothing(out res: !sim.fstring) {
+  %s = sim.string.literal "abc"
+  %f = sim.fmt.string %s paddingChar 46  specifierWidth 2 : !sim.dstring
+  hw.output %f : !sim.fstring
+}
+
+// CHECK-LABEL: hw.module @fmt_string_fold_pad_right_aligned
+// CHECK: sim.fmt.literal "  hi"
+hw.module @fmt_string_fold_pad_right_aligned(out res: !sim.fstring) {
+  %s = sim.string.literal "hi"
+  %f = sim.fmt.string %s specifierWidth 4 : !sim.dstring
+  hw.output %f : !sim.fstring
+}
+
+// CHECK-LABEL: hw.module @fmt_string_fold_pad_left_aligned
+// CHECK: sim.fmt.literal "hi.."
+hw.module @fmt_string_fold_pad_left_aligned(out res: !sim.fstring) {
+  %s = sim.string.literal "hi"
+  %f = sim.fmt.string %s isLeftAligned true paddingChar 46 specifierWidth 4 : !sim.dstring
+  hw.output %f : !sim.fstring
+}

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -160,3 +160,11 @@ hw.module @StdoutAndStderr(in %clock: !seq.clock, in %condition: i1) {
   sim.print %stdout_str on %clock if %condition to %stdout
   sim.print %stderr_str on %clock if %condition to %stderr
 }
+
+// CHECK-LABEL: hw.module @FormatString(in %str : !sim.dstring)
+hw.module @FormatString(in %str: !sim.dstring) {
+  // CHECK: sim.fmt.string %str : !sim.dstring
+  %fmt0 = sim.fmt.string %str : !sim.dstring
+  // CHECK: sim.fmt.string %str isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
+  %fmt1 = sim.fmt.string %str isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
+}


### PR DESCRIPTION
Introduce `Sim::FormatStringOp` and add lowering from `Moore::FormatStringOp`.

Assisted-by: Cursor:Composer 2

