### PR TITLE
[FIRRTL] Add class for module w/ any property

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -78,6 +78,21 @@ static bool shouldCreateClassImpl(igraph::InstanceGraphNode *node) {
           return true;
   }
 
+  // If the module contains _any_ property ops, we need to create a class for
+  // it.  These may be dead or unused.  LowerToHW assumes that all property
+  // operations are gone after this pass.
+  if (auto fmodule = dyn_cast<FModuleOp>(moduleLike.getOperation())) {
+    auto isPropertyType = [](Type t) { return isa<PropertyType>(t); };
+    auto walkResult = fmodule.walk([&](Operation *op) {
+      if (llvm::any_of(op->getOperandTypes(), isPropertyType) ||
+          llvm::any_of(op->getResultTypes(), isPropertyType))
+        return WalkResult::interrupt();
+      return WalkResult::advance();
+    });
+    if (walkResult.wasInterrupted())
+      return true;
+  }
+
   return false;
 }
 

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -764,4 +764,22 @@ firrtl.circuit "UnknownValue" {
     // CHECK: om.property_assert %cond, "module invariant" : i1
     firrtl.property_assert %cond, "module invariant" : !firrtl.bool
   }
+
+  // Test that modules without property ports, but that contain property
+  // operations still get classes created for them.  This is mandatory for
+  // things like property assertions.  It is suboptimal for dead property
+  // operations.  However, LowerToHW assumes that all of these are gone from
+  // module bodies.
+  //
+  // CHECK-LABEL: om.class @UnknownNoPropPorts_Class
+  firrtl.module private @UnknownNoPropPorts(in %clock: !firrtl.clock) {
+    // CHECK: %[[U0:.+]] = om.unknown : !om.string
+    %0 = firrtl.unknown : !firrtl.string
+    // CHECK: %[[U1:.+]] = om.unknown : !om.string
+    %1 = firrtl.unknown : !firrtl.string
+    // CHECK: %[[EQ:.+]] = om.prop.eq %[[U0]], %[[U1]] : !om.string
+    %2 = firrtl.prop.eq %0, %1 : !firrtl.string
+    // CHECK: om.property_assert %[[EQ]], "srcs must match" : i1
+    firrtl.property_assert %2, "srcs must match" : !firrtl.bool
+  }
 }


### PR DESCRIPTION
Fix an issue with FIRRTL's `LowerClasses` pass where it would not create
classes for modules which contained properties, but no property ports or
submodules with property ports.  Instead, create a class for any module
which contains an operation with a property type or operand.

This fixes problems where things like property assertions and any unknown
value residue would _not_ be lowered and would hit the `LowerToHW`
conversion.  That conversion will error on any of these operations.

Assisted-by: pi.dev:claude-sonnet-4-6
