### PR TITLE
[OM] Drop memory effects from Class, Object

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -193,7 +193,7 @@ def ObjectOp : OMOp<"object", [
   );
 
   let results = (outs
-    Res<ClassType, "", [MemAlloc]>:$result
+    ClassType:$result
   );
 
   let builders = [

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -14,13 +14,31 @@ func.func @ObjectsMustNotCSE() -> (!om.class.type<@Foo>, !om.class.type<@Foo>) {
   return %obj1, %obj2 : !om.class.type<@Foo>, !om.class.type<@Foo>
 }
 
-// Objects must DCE.
-// CHECK-LABEL: @ObjectsMustDCE
-func.func @ObjectsMustDCE() {
-  // CHECK-NOT: om.object
+// Objects must not DCE: om.object always has a write effect, so unused
+// instantiations are conservatively preserved, even if there are no "effects"
+// (e.g., asserts) in the corresponding class.
+//
+// CHECK-LABEL: @ObjectsMustNotDCE
+func.func @ObjectsMustNotDCE() {
+  // CHECK: om.object @Foo
   // CHECK-NEXT: return
   om.object @Foo() : () -> !om.class.type<@Foo>
   return
+}
+
+om.class @FooWithAssert() {
+  %0 = om.constant false
+  om.property_assert %0, "foo" : i1
+  om.class.fields
+}
+
+// An object instantiation of a class containing a property_assert must not be
+// canonicalized away, because the assert has observable side effects.
+// CHECK-LABEL: @ObjectWithAssertMustNotDCE
+om.class @ObjectWithAssertMustNotDCE() {
+  // CHECK: om.object @FooWithAssert
+  %0 = om.object @FooWithAssert() : () -> !om.class.type<@FooWithAssert>
+  om.class.fields
 }
 
 om.class @StringConcatCanonicalization(%str1: !om.string, %str2: !om.string) -> (out1: !om.string, out2: !om.string,

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -14,18 +14,6 @@ func.func @ObjectsMustNotCSE() -> (!om.class.type<@Foo>, !om.class.type<@Foo>) {
   return %obj1, %obj2 : !om.class.type<@Foo>, !om.class.type<@Foo>
 }
 
-// Objects must not DCE: om.object always has a write effect, so unused
-// instantiations are conservatively preserved, even if there are no "effects"
-// (e.g., asserts) in the corresponding class.
-//
-// CHECK-LABEL: @ObjectsMustNotDCE
-func.func @ObjectsMustNotDCE() {
-  // CHECK: om.object @Foo
-  // CHECK-NEXT: return
-  om.object @Foo() : () -> !om.class.type<@Foo>
-  return
-}
-
 om.class @FooWithAssert() {
   %0 = om.constant false
   om.property_assert %0, "foo" : i1


### PR DESCRIPTION
Drop all memory effects from OM's class and object operations.  This will
block all CSE and DCE of these as MLIR infra will conservatively assume
that these could have effects.  This is done so that these will not cause
actually effectfull classes and their instantiation via objects (e.g.,
those that contain asserts) from being deleted.

This can be improved in the future with a dedicated DCE pass that will
prune unused, effectless objects.

Fixes #10332.

Assisted-by: pi.dev:claude-sonnet-4-6
