### PR TITLE
[Support] Add parallel instance graph visitors

### DIFF
--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -401,8 +401,9 @@ private:
   ///
   /// Defined out-of-line in InstanceGraph.cpp to keep the header free of
   /// <atomic>, ThreadPool, and Threading includes.
-  LogicalResult walkParallelImpl(
-      llvm::function_ref<LogicalResult(InstanceGraphNode &)> fn, bool forward);
+  LogicalResult
+  walkParallelImpl(llvm::function_ref<LogicalResult(InstanceGraphNode &)> fn,
+                   bool forward);
 
 protected:
   ModuleOpInterface getReferencedModuleImpl(InstanceOpInterface op);

--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -15,15 +15,12 @@
 
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/Threading.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/DOTGraphTraits.h"
-#include "llvm/Support/ThreadPool.h"
-#include <atomic>
 
 /// The InstanceGraph op interface, see InstanceGraphInterface.td for more
 /// details.
@@ -293,13 +290,32 @@ public:
   /// but sibling nodes (those sharing no ancestor/descendant relationship) may
   /// be visited concurrently.
   ///
-  /// **Thread safety:** The callback `fn` must be safe to call from multiple
-  /// threads simultaneously.  The callback must *not* mutate the InstanceGraph
-  /// (add/remove nodes or instances).  Mutations must be performed outside of
-  /// the walk or on a serial walk.
+  /// **Thread safety:** The callback `fn` must be safe to invoke from
+  /// multiple threads concurrently.
+  ///
+  /// The callback must *not* mutate the InstanceGraph's structure.  In
+  /// particular it must not:
+  ///   * add or remove InstanceGraphNodes (`addModule` / `erase`),
+  ///   * add, remove, or replace InstanceRecords (`addInstance` /
+  ///     `InstanceRecord::erase` / `replaceInstance`),
+  ///   * mutate any node's `instances` or `uses` lists by any means.
+  ///
+  /// The callback MAY:
+  ///   * read any field of any InstanceGraphNode or InstanceRecord (target,
+  ///     parent, module, instance),
+  ///   * mutate the underlying MLIR IR of the node's own module, subject to
+  ///     the usual MLIR parallel-walk rules (no cross-thread access to
+  ///     parent regions, symbol tables, or sibling modules' ops),
+  ///   * accumulate results into user-owned data structures using the
+  ///     user's own synchronization.
+  ///
+  /// If the graph must be mutated based on the walk's results, collect the
+  /// required edits into a thread-safe side buffer during the walk, then
+  /// apply them serially after the walk returns.
   ///
   /// **DAG requirement:** The InstanceGraph must be a DAG for the parallel
-  /// walk.  If there are cycles, the walk will assert in debug builds.
+  /// walk.  If there are cycles, nodes belonging to a cycle will be silently
+  /// skipped (their pending counts never reach zero).
   ///
   /// If `fn` returns a `LogicalResult`, the walk returns `failure()` as soon
   /// as any invocation fails.  Remaining ready but unstarted nodes are
@@ -316,13 +332,32 @@ public:
   /// been visited (and their callbacks completed) before the node itself is
   /// visited, but sibling nodes may be visited concurrently.
   ///
-  /// **Thread safety:** The callback `fn` must be safe to call from multiple
-  /// threads simultaneously.  The callback must *not* mutate the InstanceGraph
-  /// (add/remove nodes or instances).  Mutations must be performed outside of
-  /// the walk or on a serial walk.
+  /// **Thread safety:** The callback `fn` must be safe to invoke from
+  /// multiple threads concurrently.
+  ///
+  /// The callback must *not* mutate the InstanceGraph's structure.  In
+  /// particular it must not:
+  ///   * add or remove InstanceGraphNodes (`addModule` / `erase`),
+  ///   * add, remove, or replace InstanceRecords (`addInstance` /
+  ///     `InstanceRecord::erase` / `replaceInstance`),
+  ///   * mutate any node's `instances` or `uses` lists by any means.
+  ///
+  /// The callback MAY:
+  ///   * read any field of any InstanceGraphNode or InstanceRecord (target,
+  ///     parent, module, instance),
+  ///   * mutate the underlying MLIR IR of the node's own module, subject to
+  ///     the usual MLIR parallel-walk rules (no cross-thread access to
+  ///     parent regions, symbol tables, or sibling modules' ops),
+  ///   * accumulate results into user-owned data structures using the
+  ///     user's own synchronization.
+  ///
+  /// If the graph must be mutated based on the walk's results, collect the
+  /// required edits into a thread-safe side buffer during the walk, then
+  /// apply them serially after the walk returns.
   ///
   /// **DAG requirement:** The InstanceGraph must be a DAG for the parallel
-  /// walk.  If there are cycles, the walk will assert in debug builds.
+  /// walk.  If there are cycles, nodes belonging to a cycle will be silently
+  /// skipped (their pending counts never reach zero).
   ///
   /// If `fn` returns a `LogicalResult`, the walk returns `failure()` as soon
   /// as any invocation fails.  Remaining ready but unstarted nodes are
@@ -358,25 +393,16 @@ public:
                                InstanceOpInterface newInst);
 
 private:
-  /// Shared implementation for walkParallelPostOrder and
-  /// walkParallelInversePostOrder.
+  /// Shared non-template implementation for walkParallelPostOrder and
+  /// walkParallelInversePostOrder.  The `forward` flag selects the direction.
+  /// When true, the walk is post-order (children before parents): prereqs
+  /// are a node's children (targets), notifyees are its parents (uses).
+  /// When false, the walk is inverse-post-order.
   ///
-  /// @param fn      The user callback, infallible or returning LogicalResult.
-  /// @param prereqs Populates a vector with the nodes that must finish before
-  ///                a given node is ready.  Used to compute the initial
-  ///                pending count.  May include duplicates or unmanaged
-  ///                sentinel nodes.  walkParallelImpl deduplicates and
-  ///                filters to managed nodes.
-  /// @param notify  Populates a vector with the nodes to notify (i.e., whose
-  ///                pending count to decrement) after a given node finishes.
-  ///                Same filtering applies.
-  /// @param serial  The sequential fallback walk, called when multithreading
-  ///                is disabled.  Accepts no arguments and captures its
-  ///                callback via closure.
-  template <typename Fn, typename PrereqFn, typename NotifyFn,
-            typename SerialFn>
-  decltype(auto) walkParallelImpl(Fn &&fn, PrereqFn &&prereqs,
-                                  NotifyFn &&notify, SerialFn &&serial);
+  /// Defined out-of-line in InstanceGraph.cpp to keep the header free of
+  /// <atomic>, ThreadPool, and Threading includes.
+  LogicalResult walkParallelImpl(
+      llvm::function_ref<LogicalResult(InstanceGraphNode &)> fn, bool forward);
 
 protected:
   ModuleOpInterface getReferencedModuleImpl(InstanceOpInterface op);
@@ -650,227 +676,42 @@ decltype(auto) InstanceGraph::walkInversePostOrder(Fn &&fn) {
 
 template <typename Fn>
 decltype(auto) InstanceGraph::walkParallelPostOrder(Fn &&fn) {
-  return walkParallelImpl(
-      std::forward<Fn>(fn),
-      // Prerequisites: the distinct children (targets) this node instantiates
-      // must all finish before this node is ready.
-      [](InstanceGraphNode &node, SmallVectorImpl<InstanceGraphNode *> &out) {
-        for (auto *record : node)
-          out.push_back(record->getTarget());
-      },
-      // Notify: the parents (uses) of this node become one step closer to
-      // ready when this node finishes.
-      [](InstanceGraphNode &node, SmallVectorImpl<InstanceGraphNode *> &out) {
-        for (auto *use : node.uses())
-          out.push_back(use->getParent());
-      },
-      // Serial fallback.  Capturing fn by reference is safe because
-      // walkParallelImpl calls serial() before returning.
-      [&]() { return walkPostOrder(std::forward<Fn>(fn)); });
+  constexpr bool fallible =
+      std::is_invocable_r_v<LogicalResult, Fn &, InstanceGraphNode &>;
+  // Forward to the non-template core implementation in InstanceGraph.cpp.
+  // The lambda that adapts `fn` to a LogicalResult-returning callback must
+  // be constructed in this scope so that the function_ref bound to it in
+  // walkParallelImpl does not outlive the underlying callable.
+  if constexpr (fallible) {
+    return walkParallelImpl(
+        [&](InstanceGraphNode &node) -> LogicalResult { return fn(node); },
+        /*forward=*/true);
+  } else {
+    (void)walkParallelImpl(
+        [&](InstanceGraphNode &node) -> LogicalResult {
+          fn(node);
+          return success();
+        },
+        /*forward=*/true);
+  }
 }
 
 template <typename Fn>
 decltype(auto) InstanceGraph::walkParallelInversePostOrder(Fn &&fn) {
-  return walkParallelImpl(
-      std::forward<Fn>(fn),
-      // Prerequisites: the distinct parents (uses) of this node must all
-      // finish before this node is ready.
-      [](InstanceGraphNode &node, SmallVectorImpl<InstanceGraphNode *> &out) {
-        for (auto *use : node.uses())
-          out.push_back(use->getParent());
-      },
-      // Notify: the children (targets) of this node become one step closer to
-      // ready when this node finishes.
-      [](InstanceGraphNode &node, SmallVectorImpl<InstanceGraphNode *> &out) {
-        for (auto *record : node)
-          out.push_back(record->getTarget());
-      },
-      // Serial fallback.  Wrap fn to skip nodes not in the managed `nodes`
-      // list.  walkInversePostOrder may visit sentinel nodes reachable via
-      // graph traversal (e.g., the virtual top-level entry in
-      // hw::InstanceGraph).  This wrapper ensures both paths visit exactly
-      // the same set of nodes.
-      [&]() {
-        constexpr bool fallible =
-            std::is_invocable_r_v<LogicalResult, Fn &, InstanceGraphNode &>;
-        DenseSet<InstanceGraphNode *> managed;
-        for (auto &node : nodes)
-          managed.insert(&node);
-        auto filtered = [&](InstanceGraphNode &node) -> decltype(auto) {
-          if (!managed.count(&node)) {
-            if constexpr (fallible)
-              return success();
-            else
-              return;
-          }
-          return fn(node);
-        };
-        return walkInversePostOrder(filtered);
-      });
-}
-
-template <typename Fn, typename PrereqFn, typename NotifyFn, typename SerialFn>
-decltype(auto) InstanceGraph::walkParallelImpl(Fn &&fn, PrereqFn &&prereqs,
-                                               NotifyFn &&notify,
-                                               SerialFn &&serial) {
   constexpr bool fallible =
       std::is_invocable_r_v<LogicalResult, Fn &, InstanceGraphNode &>;
-
-  // If multithreading is disabled fall back to the sequential walk so that
-  // callers don't have to reason about two code paths.
-  MLIRContext *ctx = parent->getContext();
-  if (!ctx->isMultithreadingEnabled()) {
-    return serial();
+  if constexpr (fallible) {
+    return walkParallelImpl(
+        [&](InstanceGraphNode &node) -> LogicalResult { return fn(node); },
+        /*forward=*/false);
+  } else {
+    (void)walkParallelImpl(
+        [&](InstanceGraphNode &node) -> LogicalResult {
+          fn(node);
+          return success();
+        },
+        /*forward=*/false);
   }
-
-  // --- Phase 1: compute per-node pending counts (sequential) ----------------
-  //
-  // `prereqs(node, out)` fills `out` with the nodes that must finish before
-  // `node` becomes ready (post-order: children, inverse post-order: parents).
-  // The pending count of a node is the number of distinct managed prereqs
-  // it has.  A node whose count is zero is a seed for the traversal.
-  //
-  // `notify(node, out)` fills `out` with the nodes to notify when `node`
-  // finishes (post-order: parents, inverse post-order: children).
-  //
-  // Filtering to managed nodes (via nodeIndex) means that sentinel nodes
-  // introduced by subclasses (e.g., the virtual top-level entry in
-  // hw::InstanceGraph) are automatically excluded from both.
-  //
-  // std::atomic is not movable, so we store atomics in a flat vector indexed
-  // by a stable integer assigned to each node.
-
-  // Assign a stable index to every node and compute pending counts in one
-  // pass to avoid a second O(N) scan and extra hash lookups.
-  DenseMap<InstanceGraphNode *, size_t> nodeIndex;
-  size_t numNodes = 0;
-  for (auto &node : nodes) {
-    (void)node;
-    ++numNodes;
-  }
-  nodeIndex.reserve(numNodes);
-
-  // Allocate one atomic<unsigned> per node (value initialised to 0).
-  std::vector<std::atomic<unsigned>> pending(numNodes);
-  // Collect the initial seeds (nodes with zero managed prereqs) while
-  // computing the pending counts.  Seeds must be gathered before submitting
-  // any tasks.  Once a task is running it may decrement another node's
-  // pending count to zero concurrently with this loop.  That node is
-  // submitted by the decrementing thread and must not be resubmitted here.
-  SmallVector<InstanceGraphNode *, 8> seeds;
-  {
-    // First assign indices so nodeIndex is populated for the filtering below.
-    size_t idx = 0;
-    for (auto &node : nodes)
-      nodeIndex[&node] = idx++;
-
-    SmallVector<InstanceGraphNode *, 4> buf;
-    for (auto &node : nodes) {
-      buf.clear();
-      prereqs(node, buf);
-      // Count distinct managed prereqs.
-      SmallPtrSet<InstanceGraphNode *, 4> seen;
-      unsigned count = 0;
-      for (auto *nb : buf)
-        if (nodeIndex.count(nb) && seen.insert(nb).second)
-          ++count;
-      size_t nodeIdx = nodeIndex[&node];
-      pending[nodeIdx].store(count, std::memory_order_relaxed);
-      if (count == 0)
-        seeds.push_back(&node);
-    }
-  }
-
-  // --- Phase 2: parallel traversal via thread pool --------------------------
-
-  // All three accesses to processingFailed use relaxed ordering.  The flag
-  // carries no associated payload.  It is a pure boolean signal.  The
-  // happens-before edge established by taskGroup.wait() provides the
-  // synchronization needed for the final read.
-  std::atomic<bool> processingFailed(false);
-
-  // visitedCount tracks how many nodes were actually executed.  After
-  // taskGroup.wait() it must equal numNodes for a cycle-free DAG.
-  std::atomic<size_t> visitedCount(0);
-
-  llvm::ThreadPoolInterface &threadPool = ctx->getThreadPool();
-  llvm::ThreadPoolTaskGroup taskGroup(threadPool);
-
-  // Submit a single node for execution on the thread pool.  After the
-  // callback completes, decrement the pending count of each unique managed
-  // notifyee.  Those whose count drops to zero are immediately resubmitted.
-  //
-  // `submitNode` calls itself transitively (on different threads) to schedule
-  // newly ready nodes, so we declare it as a std::function to allow the
-  // lambda to capture itself by reference.  taskGroup.async() only enqueues
-  // the task.  It does not execute it on the current stack, so there is no
-  // actual call-stack recursion.
-  //
-  // NOTE: taskGroup.wait() below is load-bearing for the lifetime of
-  // `submitNode`.  Worker threads capture `submitNode` by reference.  The
-  // outer stack frame must not be destroyed until wait() returns.
-  std::function<void(InstanceGraphNode *)> submitNode;
-  submitNode = [&](InstanceGraphNode *node) {
-    taskGroup.async([&, node] {
-      // Skip remaining work after a failure.
-      if (processingFailed.load(std::memory_order_relaxed))
-        return;
-
-      if constexpr (fallible) {
-        if (failed(fn(*node))) {
-          processingFailed.store(true, std::memory_order_relaxed);
-          return;
-        }
-      } else {
-        fn(*node);
-      }
-
-      visitedCount.fetch_add(1, std::memory_order_relaxed);
-
-      // Notify each unique managed notifyee that one of their prereqs is
-      // done.  We use relaxed ordering on the fetch_sub because the user
-      // callback is responsible for its own synchronization and we only need
-      // the counter itself to be atomically decremented.  The overall
-      // happens-before relationship across tasks is guaranteed by the thread
-      // pool.
-      SmallVector<InstanceGraphNode *, 4> toNotify;
-      notify(*node, toNotify);
-      SmallPtrSet<InstanceGraphNode *, 4> notified;
-      for (auto *nb : toNotify) {
-        auto it = nodeIndex.find(nb);
-        if (it == nodeIndex.end())
-          continue;
-        if (!notified.insert(nb).second)
-          continue;
-        // If the notifyee's pending count reaches zero it is now ready.
-        if (pending[it->second].fetch_sub(1, std::memory_order_relaxed) == 1)
-          submitNode(nb);
-      }
-    });
-  };
-
-  // Seed the traversal by submitting all nodes whose initial pending count
-  // was zero.  We use the seeds collected during Phase 1 rather than
-  // re-reading `pending` here because worker threads started by earlier
-  // `submitNode` calls may already be decrementing entries in `pending` to
-  // zero.  Those nodes are submitted by the decrementing thread and must not
-  // be submitted again from this loop.
-  for (auto *node : seeds)
-    submitNode(node);
-
-  taskGroup.wait();
-
-  // If every node was visited the graph is a DAG.  Otherwise there is a
-  // cycle.  Only check this when no failure was reported because a failure
-  // stops scheduling and naturally leaves nodes unvisited.
-  assert((processingFailed.load(std::memory_order_relaxed) ||
-          visitedCount.load(std::memory_order_relaxed) == numNodes) &&
-         "InstanceGraph has a cycle. "
-         "walkParallelPostOrder and walkParallelInversePostOrder require a "
-         "DAG");
-
-  if constexpr (fallible)
-    return failure(processingFailed.load(std::memory_order_relaxed));
 }
 
 } // namespace igraph

--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -15,11 +15,15 @@
 
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Threading.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/DOTGraphTraits.h"
+#include "llvm/Support/ThreadPool.h"
+#include <atomic>
 
 /// The InstanceGraph op interface, see InstanceGraphInterface.td for more
 /// details.
@@ -283,6 +287,55 @@ public:
   template <typename Fn>
   decltype(auto) walkInversePostOrder(Fn &&fn);
 
+  /// Perform a parallel post-order walk across the modules using the MLIR
+  /// context's thread pool. All children of a node are guaranteed to have been
+  /// visited (and their callbacks completed) before the node itself is visited,
+  /// but sibling nodes (those sharing no ancestor/descendant relationship) may
+  /// be visited concurrently.
+  ///
+  /// **Thread safety:** The callback `fn` must be safe to call from multiple
+  /// threads simultaneously.  The callback must *not* mutate the InstanceGraph
+  /// (add/remove nodes or instances).  Mutations must be performed outside of
+  /// the walk or on a serial walk.
+  ///
+  /// **DAG requirement:** The InstanceGraph must be a DAG for the parallel
+  /// walk.  If there are cycles, the walk will assert in debug builds.
+  ///
+  /// If `fn` returns a `LogicalResult`, the walk returns `failure()` as soon
+  /// as any invocation fails.  Remaining ready but unstarted nodes are
+  /// skipped.
+  ///
+  /// Only nodes in the managed node list (`nodes`) are visited.  Sentinel
+  /// nodes introduced by subclasses (e.g., the virtual top-level entry in
+  /// hw::InstanceGraph) are automatically excluded.
+  template <typename Fn>
+  decltype(auto) walkParallelPostOrder(Fn &&fn);
+
+  /// Perform a parallel inverse-post-order walk across the modules using the
+  /// MLIR context's thread pool. All parents of a node are guaranteed to have
+  /// been visited (and their callbacks completed) before the node itself is
+  /// visited, but sibling nodes may be visited concurrently.
+  ///
+  /// **Thread safety:** The callback `fn` must be safe to call from multiple
+  /// threads simultaneously.  The callback must *not* mutate the InstanceGraph
+  /// (add/remove nodes or instances).  Mutations must be performed outside of
+  /// the walk or on a serial walk.
+  ///
+  /// **DAG requirement:** The InstanceGraph must be a DAG for the parallel
+  /// walk.  If there are cycles, the walk will assert in debug builds.
+  ///
+  /// If `fn` returns a `LogicalResult`, the walk returns `failure()` as soon
+  /// as any invocation fails.  Remaining ready but unstarted nodes are
+  /// skipped.
+  ///
+  /// Only nodes in the managed node list (`nodes`) are visited.  Sentinel
+  /// nodes introduced by subclasses (e.g., the virtual top-level entry in
+  /// hw::InstanceGraph) are automatically excluded.  This differs from the
+  /// serial `walkInversePostOrder`, which may also visit nodes reachable via
+  /// graph traversal from sentinels.
+  template <typename Fn>
+  decltype(auto) walkParallelInversePostOrder(Fn &&fn);
+
   //===-------------------------------------------------------------------------
   // Methods to keep an InstanceGraph up to date.
   //
@@ -303,6 +356,27 @@ public:
   /// of both InstanceOps must be the same.
   virtual void replaceInstance(InstanceOpInterface inst,
                                InstanceOpInterface newInst);
+
+private:
+  /// Shared implementation for walkParallelPostOrder and
+  /// walkParallelInversePostOrder.
+  ///
+  /// @param fn      The user callback, infallible or returning LogicalResult.
+  /// @param prereqs Populates a vector with the nodes that must finish before
+  ///                a given node is ready.  Used to compute the initial
+  ///                pending count.  May include duplicates or unmanaged
+  ///                sentinel nodes.  walkParallelImpl deduplicates and
+  ///                filters to managed nodes.
+  /// @param notify  Populates a vector with the nodes to notify (i.e., whose
+  ///                pending count to decrement) after a given node finishes.
+  ///                Same filtering applies.
+  /// @param serial  The sequential fallback walk, called when multithreading
+  ///                is disabled.  Accepts no arguments and captures its
+  ///                callback via closure.
+  template <typename Fn, typename PrereqFn, typename NotifyFn,
+            typename SerialFn>
+  decltype(auto) walkParallelImpl(Fn &&fn, PrereqFn &&prereqs,
+                                  NotifyFn &&notify, SerialFn &&serial);
 
 protected:
   ModuleOpInterface getReferencedModuleImpl(InstanceOpInterface op);
@@ -572,6 +646,231 @@ decltype(auto) InstanceGraph::walkInversePostOrder(Fn &&fn) {
   }
   if constexpr (fallible)
     return success();
+}
+
+template <typename Fn>
+decltype(auto) InstanceGraph::walkParallelPostOrder(Fn &&fn) {
+  return walkParallelImpl(
+      std::forward<Fn>(fn),
+      // Prerequisites: the distinct children (targets) this node instantiates
+      // must all finish before this node is ready.
+      [](InstanceGraphNode &node, SmallVectorImpl<InstanceGraphNode *> &out) {
+        for (auto *record : node)
+          out.push_back(record->getTarget());
+      },
+      // Notify: the parents (uses) of this node become one step closer to
+      // ready when this node finishes.
+      [](InstanceGraphNode &node, SmallVectorImpl<InstanceGraphNode *> &out) {
+        for (auto *use : node.uses())
+          out.push_back(use->getParent());
+      },
+      // Serial fallback.  Capturing fn by reference is safe because
+      // walkParallelImpl calls serial() before returning.
+      [&]() { return walkPostOrder(std::forward<Fn>(fn)); });
+}
+
+template <typename Fn>
+decltype(auto) InstanceGraph::walkParallelInversePostOrder(Fn &&fn) {
+  return walkParallelImpl(
+      std::forward<Fn>(fn),
+      // Prerequisites: the distinct parents (uses) of this node must all
+      // finish before this node is ready.
+      [](InstanceGraphNode &node, SmallVectorImpl<InstanceGraphNode *> &out) {
+        for (auto *use : node.uses())
+          out.push_back(use->getParent());
+      },
+      // Notify: the children (targets) of this node become one step closer to
+      // ready when this node finishes.
+      [](InstanceGraphNode &node, SmallVectorImpl<InstanceGraphNode *> &out) {
+        for (auto *record : node)
+          out.push_back(record->getTarget());
+      },
+      // Serial fallback.  Wrap fn to skip nodes not in the managed `nodes`
+      // list.  walkInversePostOrder may visit sentinel nodes reachable via
+      // graph traversal (e.g., the virtual top-level entry in
+      // hw::InstanceGraph).  This wrapper ensures both paths visit exactly
+      // the same set of nodes.
+      [&]() {
+        constexpr bool fallible =
+            std::is_invocable_r_v<LogicalResult, Fn &, InstanceGraphNode &>;
+        DenseSet<InstanceGraphNode *> managed;
+        for (auto &node : nodes)
+          managed.insert(&node);
+        auto filtered = [&](InstanceGraphNode &node) -> decltype(auto) {
+          if (!managed.count(&node)) {
+            if constexpr (fallible)
+              return success();
+            else
+              return;
+          }
+          return fn(node);
+        };
+        return walkInversePostOrder(filtered);
+      });
+}
+
+template <typename Fn, typename PrereqFn, typename NotifyFn, typename SerialFn>
+decltype(auto) InstanceGraph::walkParallelImpl(Fn &&fn, PrereqFn &&prereqs,
+                                               NotifyFn &&notify,
+                                               SerialFn &&serial) {
+  constexpr bool fallible =
+      std::is_invocable_r_v<LogicalResult, Fn &, InstanceGraphNode &>;
+
+  // If multithreading is disabled fall back to the sequential walk so that
+  // callers don't have to reason about two code paths.
+  MLIRContext *ctx = parent->getContext();
+  if (!ctx->isMultithreadingEnabled()) {
+    return serial();
+  }
+
+  // --- Phase 1: compute per-node pending counts (sequential) ----------------
+  //
+  // `prereqs(node, out)` fills `out` with the nodes that must finish before
+  // `node` becomes ready (post-order: children, inverse post-order: parents).
+  // The pending count of a node is the number of distinct managed prereqs
+  // it has.  A node whose count is zero is a seed for the traversal.
+  //
+  // `notify(node, out)` fills `out` with the nodes to notify when `node`
+  // finishes (post-order: parents, inverse post-order: children).
+  //
+  // Filtering to managed nodes (via nodeIndex) means that sentinel nodes
+  // introduced by subclasses (e.g., the virtual top-level entry in
+  // hw::InstanceGraph) are automatically excluded from both.
+  //
+  // std::atomic is not movable, so we store atomics in a flat vector indexed
+  // by a stable integer assigned to each node.
+
+  // Assign a stable index to every node and compute pending counts in one
+  // pass to avoid a second O(N) scan and extra hash lookups.
+  DenseMap<InstanceGraphNode *, size_t> nodeIndex;
+  size_t numNodes = 0;
+  for (auto &node : nodes) {
+    (void)node;
+    ++numNodes;
+  }
+  nodeIndex.reserve(numNodes);
+
+  // Allocate one atomic<unsigned> per node (value initialised to 0).
+  std::vector<std::atomic<unsigned>> pending(numNodes);
+  // Collect the initial seeds (nodes with zero managed prereqs) while
+  // computing the pending counts.  Seeds must be gathered before submitting
+  // any tasks.  Once a task is running it may decrement another node's
+  // pending count to zero concurrently with this loop.  That node is
+  // submitted by the decrementing thread and must not be resubmitted here.
+  SmallVector<InstanceGraphNode *, 8> seeds;
+  {
+    // First assign indices so nodeIndex is populated for the filtering below.
+    size_t idx = 0;
+    for (auto &node : nodes)
+      nodeIndex[&node] = idx++;
+
+    SmallVector<InstanceGraphNode *, 4> buf;
+    for (auto &node : nodes) {
+      buf.clear();
+      prereqs(node, buf);
+      // Count distinct managed prereqs.
+      SmallPtrSet<InstanceGraphNode *, 4> seen;
+      unsigned count = 0;
+      for (auto *nb : buf)
+        if (nodeIndex.count(nb) && seen.insert(nb).second)
+          ++count;
+      size_t nodeIdx = nodeIndex[&node];
+      pending[nodeIdx].store(count, std::memory_order_relaxed);
+      if (count == 0)
+        seeds.push_back(&node);
+    }
+  }
+
+  // --- Phase 2: parallel traversal via thread pool --------------------------
+
+  // All three accesses to processingFailed use relaxed ordering.  The flag
+  // carries no associated payload.  It is a pure boolean signal.  The
+  // happens-before edge established by taskGroup.wait() provides the
+  // synchronization needed for the final read.
+  std::atomic<bool> processingFailed(false);
+
+  // visitedCount tracks how many nodes were actually executed.  After
+  // taskGroup.wait() it must equal numNodes for a cycle-free DAG.
+  std::atomic<size_t> visitedCount(0);
+
+  llvm::ThreadPoolInterface &threadPool = ctx->getThreadPool();
+  llvm::ThreadPoolTaskGroup taskGroup(threadPool);
+
+  // Submit a single node for execution on the thread pool.  After the
+  // callback completes, decrement the pending count of each unique managed
+  // notifyee.  Those whose count drops to zero are immediately resubmitted.
+  //
+  // `submitNode` calls itself transitively (on different threads) to schedule
+  // newly ready nodes, so we declare it as a std::function to allow the
+  // lambda to capture itself by reference.  taskGroup.async() only enqueues
+  // the task.  It does not execute it on the current stack, so there is no
+  // actual call-stack recursion.
+  //
+  // NOTE: taskGroup.wait() below is load-bearing for the lifetime of
+  // `submitNode`.  Worker threads capture `submitNode` by reference.  The
+  // outer stack frame must not be destroyed until wait() returns.
+  std::function<void(InstanceGraphNode *)> submitNode;
+  submitNode = [&](InstanceGraphNode *node) {
+    taskGroup.async([&, node] {
+      // Skip remaining work after a failure.
+      if (processingFailed.load(std::memory_order_relaxed))
+        return;
+
+      if constexpr (fallible) {
+        if (failed(fn(*node))) {
+          processingFailed.store(true, std::memory_order_relaxed);
+          return;
+        }
+      } else {
+        fn(*node);
+      }
+
+      visitedCount.fetch_add(1, std::memory_order_relaxed);
+
+      // Notify each unique managed notifyee that one of their prereqs is
+      // done.  We use relaxed ordering on the fetch_sub because the user
+      // callback is responsible for its own synchronization and we only need
+      // the counter itself to be atomically decremented.  The overall
+      // happens-before relationship across tasks is guaranteed by the thread
+      // pool.
+      SmallVector<InstanceGraphNode *, 4> toNotify;
+      notify(*node, toNotify);
+      SmallPtrSet<InstanceGraphNode *, 4> notified;
+      for (auto *nb : toNotify) {
+        auto it = nodeIndex.find(nb);
+        if (it == nodeIndex.end())
+          continue;
+        if (!notified.insert(nb).second)
+          continue;
+        // If the notifyee's pending count reaches zero it is now ready.
+        if (pending[it->second].fetch_sub(1, std::memory_order_relaxed) == 1)
+          submitNode(nb);
+      }
+    });
+  };
+
+  // Seed the traversal by submitting all nodes whose initial pending count
+  // was zero.  We use the seeds collected during Phase 1 rather than
+  // re-reading `pending` here because worker threads started by earlier
+  // `submitNode` calls may already be decrementing entries in `pending` to
+  // zero.  Those nodes are submitted by the decrementing thread and must not
+  // be submitted again from this loop.
+  for (auto *node : seeds)
+    submitNode(node);
+
+  taskGroup.wait();
+
+  // If every node was visited the graph is a DAG.  Otherwise there is a
+  // cycle.  Only check this when no failure was reported because a failure
+  // stops scheduling and naturally leaves nodes unvisited.
+  assert((processingFailed.load(std::memory_order_relaxed) ||
+          visitedCount.load(std::memory_order_relaxed) == numNodes) &&
+         "InstanceGraph has a cycle. "
+         "walkParallelPostOrder and walkParallelInversePostOrder require a "
+         "DAG");
+
+  if constexpr (fallible)
+    return failure(processingFailed.load(std::memory_order_relaxed));
 }
 
 } // namespace igraph

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -344,7 +344,7 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
     SmallVector<FModuleOp> publicModules;
 
     // Traverse the modules in post order.
-    auto result = instanceGraph.walkParallelPostOrder([&](auto &node) -> LogicalResult {
+    auto result = instanceGraph.walkPostOrder([&](auto &node) -> LogicalResult {
       auto module = dyn_cast<FModuleOp>(*node.getModule());
       if (!module)
         return success();

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -344,7 +344,7 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
     SmallVector<FModuleOp> publicModules;
 
     // Traverse the modules in post order.
-    auto result = instanceGraph.walkPostOrder([&](auto &node) -> LogicalResult {
+    auto result = instanceGraph.walkParallelPostOrder([&](auto &node) -> LogicalResult {
       auto module = dyn_cast<FModuleOp>(*node.getModule());
       if (!module)
         return success();

--- a/lib/Support/InstanceGraph.cpp
+++ b/lib/Support/InstanceGraph.cpp
@@ -9,6 +9,9 @@
 #include "circt/Support/InstanceGraph.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Threading.h"
+#include "llvm/Support/ThreadPool.h"
+#include <atomic>
+#include <functional>
 
 using namespace circt;
 using namespace igraph;
@@ -393,6 +396,202 @@ void InstancePathCache::replaceInstance(InstanceOpInterface oldOp,
   updateCache(absolutePathsCache);
   for (auto &iter : relativePathsCache)
     updateCache(iter.getSecond());
+}
+
+//===----------------------------------------------------------------------===//
+// Parallel walk implementation
+//===----------------------------------------------------------------------===//
+
+LogicalResult InstanceGraph::walkParallelImpl(
+    llvm::function_ref<LogicalResult(InstanceGraphNode &)> fn, bool forward) {
+  // Direction-dependent neighbor functions.  When `forward` is true the walk
+  // is post-order: children are prereqs, parents are notifyees.  When false
+  // the walk is inverse post-order: parents are prereqs, children are
+  // notifyees.
+  auto appendChildren = [](InstanceGraphNode &node,
+                           SmallVectorImpl<InstanceGraphNode *> &out) {
+    for (auto *record : node)
+      out.push_back(record->getTarget());
+  };
+  auto appendParents = [](InstanceGraphNode &node,
+                          SmallVectorImpl<InstanceGraphNode *> &out) {
+    for (auto *use : node.uses())
+      out.push_back(use->getParent());
+  };
+  auto prereqs = [&](InstanceGraphNode &node,
+                     SmallVectorImpl<InstanceGraphNode *> &out) {
+    if (forward)
+      appendChildren(node, out);
+    else
+      appendParents(node, out);
+  };
+  auto notify = [&](InstanceGraphNode &node,
+                    SmallVectorImpl<InstanceGraphNode *> &out) {
+    if (forward)
+      appendParents(node, out);
+    else
+      appendChildren(node, out);
+  };
+
+  // If multithreading is disabled fall back to the sequential walk so that
+  // callers don't have to reason about two code paths.
+  MLIRContext *ctx = parent->getContext();
+  if (!ctx->isMultithreadingEnabled()) {
+    if (forward)
+      return walkPostOrder(fn);
+    // walkInversePostOrder may visit sentinel nodes reachable via graph
+    // traversal (e.g., the virtual top-level entry in hw::InstanceGraph).
+    // Filter to managed nodes so both paths visit the same set.
+    DenseSet<InstanceGraphNode *> managed;
+    for (auto &node : nodes)
+      managed.insert(&node);
+    return walkInversePostOrder([&](InstanceGraphNode &node) -> LogicalResult {
+      if (!managed.count(&node))
+        return success();
+      return fn(node);
+    });
+  }
+
+  // --- Phase 1: compute per-node pending counts (sequential) --------------
+  //
+  // `prereqs(node, out)` fills `out` with the nodes that must finish before
+  // `node` becomes ready.  The pending count of a node is the number of
+  // distinct managed prereqs it has.  A node whose count is zero is a seed
+  // for the traversal.
+  //
+  // `notify(node, out)` fills `out` with the nodes to notify when `node`
+  // finishes.
+  //
+  // Filtering to managed nodes (via nodeIndex) means that sentinel nodes
+  // introduced by subclasses (e.g., the virtual top-level entry in
+  // hw::InstanceGraph) are automatically excluded from both.
+  //
+  // std::atomic is not movable, so we store atomics in a flat vector indexed
+  // by a stable integer assigned to each node.
+  DenseMap<InstanceGraphNode *, size_t> nodeIndex;
+  size_t numNodes = 0;
+  for (auto &node : nodes) {
+    (void)node;
+    ++numNodes;
+  }
+  nodeIndex.reserve(numNodes);
+
+  // Allocate one atomic<unsigned> per node (value initialised to 0).
+  std::vector<std::atomic<unsigned>> pending(numNodes);
+  // Collect the initial seeds (nodes with zero managed prereqs) while
+  // computing the pending counts.  Seeds must be gathered before submitting
+  // any tasks.  Once a task is running it may decrement another node's
+  // pending count to zero concurrently with this loop.  That node is
+  // submitted by the decrementing thread and must not be resubmitted here.
+  SmallVector<InstanceGraphNode *, 8> seeds;
+  {
+    // First assign indices so nodeIndex is populated for the filtering below.
+    size_t idx = 0;
+    for (auto &node : nodes)
+      nodeIndex[&node] = idx++;
+
+    SmallVector<InstanceGraphNode *, 4> buf;
+    for (auto &node : nodes) {
+      buf.clear();
+      prereqs(node, buf);
+      // Count distinct managed prereqs.
+      SmallPtrSet<InstanceGraphNode *, 4> seen;
+      unsigned count = 0;
+      for (auto *nb : buf)
+        if (nodeIndex.count(nb) && seen.insert(nb).second)
+          ++count;
+      size_t nodeIdx = nodeIndex[&node];
+      pending[nodeIdx].store(count, std::memory_order_relaxed);
+      if (count == 0)
+        seeds.push_back(&node);
+    }
+  }
+
+  // --- Phase 2: parallel traversal via thread pool ------------------------
+
+  // All three accesses to processingFailed use relaxed ordering.  The flag
+  // carries no associated payload.  It is a pure boolean signal.  The
+  // happens-before edge established by taskGroup.wait() provides the
+  // synchronization needed for the final read.
+  std::atomic<bool> processingFailed(false);
+
+  // visitedCount tracks how many nodes were actually executed.  After
+  // taskGroup.wait() it must equal numNodes for a cycle-free DAG.
+  std::atomic<size_t> visitedCount(0);
+
+  llvm::ThreadPoolInterface &threadPool = ctx->getThreadPool();
+  llvm::ThreadPoolTaskGroup taskGroup(threadPool);
+
+  // Submit a single node for execution on the thread pool.  After the
+  // callback completes, decrement the pending count of each unique managed
+  // notifyee.  Those whose count drops to zero are immediately resubmitted.
+  //
+  // `submitNode` calls itself transitively (on different threads) to schedule
+  // newly ready nodes, so we declare it as a std::function to allow the
+  // lambda to capture itself by reference.  taskGroup.async() only enqueues
+  // the task.  It does not execute it on the current stack, so there is no
+  // actual call-stack recursion.
+  //
+  // NOTE: taskGroup.wait() below is load-bearing for the lifetime of
+  // `submitNode`.  Worker threads capture `submitNode` by reference.  The
+  // outer stack frame must not be destroyed until wait() returns.
+  std::function<void(InstanceGraphNode *)> submitNode;
+  submitNode = [&](InstanceGraphNode *node) {
+    taskGroup.async([&, node] {
+      // Skip remaining work after a failure.
+      if (processingFailed.load(std::memory_order_relaxed))
+        return;
+
+      if (failed(fn(*node))) {
+        processingFailed.store(true, std::memory_order_relaxed);
+        return;
+      }
+
+      visitedCount.fetch_add(1, std::memory_order_relaxed);
+
+      // Notify each unique managed notifyee that one of their prereqs is
+      // done.  We use relaxed ordering on the fetch_sub because the user
+      // callback is responsible for its own synchronization and we only need
+      // the counter itself to be atomically decremented.  The overall
+      // happens-before relationship across tasks is guaranteed by the thread
+      // pool.
+      SmallVector<InstanceGraphNode *, 4> toNotify;
+      notify(*node, toNotify);
+      SmallPtrSet<InstanceGraphNode *, 4> notified;
+      for (auto *nb : toNotify) {
+        auto it = nodeIndex.find(nb);
+        if (it == nodeIndex.end())
+          continue;
+        if (!notified.insert(nb).second)
+          continue;
+        // If the notifyee's pending count reaches zero it is now ready.
+        if (pending[it->second].fetch_sub(1, std::memory_order_relaxed) == 1)
+          submitNode(nb);
+      }
+    });
+  };
+
+  // Seed the traversal by submitting all nodes whose initial pending count
+  // was zero.  We use the seeds collected during Phase 1 rather than
+  // re-reading `pending` here because worker threads started by earlier
+  // `submitNode` calls may already be decrementing entries in `pending` to
+  // zero.  Those nodes are submitted by the decrementing thread and must not
+  // be submitted again from this loop.
+  for (auto *node : seeds)
+    submitNode(node);
+
+  taskGroup.wait();
+
+  // If every node was visited the graph is a DAG.  Otherwise there is a
+  // cycle.  Only check this when no failure was reported because a failure
+  // stops scheduling and naturally leaves nodes unvisited.
+  assert((processingFailed.load(std::memory_order_relaxed) ||
+          visitedCount.load(std::memory_order_relaxed) == numNodes) &&
+         "InstanceGraph has a cycle. "
+         "walkParallelPostOrder and walkParallelInversePostOrder require a "
+         "DAG");
+
+  return failure(processingFailed.load(std::memory_order_relaxed));
 }
 
 //===----------------------------------------------------------------------===//

--- a/unittests/Dialect/HW/InstanceGraphTest.cpp
+++ b/unittests/Dialect/HW/InstanceGraphTest.cpp
@@ -12,8 +12,12 @@
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/SmallVector.h"
 #include "gtest/gtest.h"
+#include <atomic>
+#include <mutex>
 
 using namespace mlir;
 using namespace circt;
@@ -90,6 +94,320 @@ TEST(InstanceGraphCAPITest, PostOrderTraversal) {
       &ctx);
 
   ASSERT_EQ(ctx.i, 5UL);
+}
+
+// Verify that walkParallelPostOrder visits every node exactly once.
+TEST(InstanceGraphTest, ParallelPostOrderVisitsAll) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(fixtures::createModule(&context));
+
+  std::mutex mu;
+  llvm::SmallVector<std::string> visited;
+  graph.walkParallelPostOrder([&](igraph::InstanceGraphNode &node) {
+    std::lock_guard<std::mutex> lock(mu);
+    visited.push_back(node.getModule().getModuleName().str());
+  });
+
+  // Every module must appear exactly once.
+  ASSERT_EQ(4u, visited.size());
+  for (const char *name : {"Top", "Alligator", "Bear", "Cat"}) {
+    EXPECT_EQ(1, llvm::count(visited, name)) << name << " not visited once";
+  }
+}
+
+// Verify that walkParallelPostOrder respects the post-order constraint:
+// children are always visited before their parents.
+TEST(InstanceGraphTest, ParallelPostOrderChildBeforeParent) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(fixtures::createModule(&context));
+
+  // Record the visit index of each module.
+  std::mutex mu;
+  llvm::DenseMap<llvm::StringRef, unsigned> visitOrder;
+  unsigned counter = 0;
+  graph.walkParallelPostOrder([&](igraph::InstanceGraphNode &node) {
+    std::lock_guard<std::mutex> lock(mu);
+    visitOrder[node.getModule().getModuleName()] = counter++;
+  });
+
+  // The fixture graph:
+  //   Top  -> Alligator, Cat
+  //   Alligator -> Bear
+  //   Bear -> Cat
+  //   Cat  (leaf)
+  //
+  // We only assert ancestor/descendant pairs here.  Those relationships have
+  // a guaranteed serial ordering regardless of how many threads run.  Sibling
+  // pairs (e.g., Alligator vs Cat as direct children of Top) have no
+  // guaranteed relative order and are intentionally not compared.
+  EXPECT_LT(visitOrder["Cat"], visitOrder["Top"]);
+  EXPECT_LT(visitOrder["Alligator"], visitOrder["Top"]);
+  EXPECT_LT(visitOrder["Bear"], visitOrder["Alligator"]);
+  EXPECT_LT(visitOrder["Cat"], visitOrder["Bear"]);
+}
+
+// Verify that a failing callback propagates the failure return value.
+TEST(InstanceGraphTest, ParallelPostOrderPropagatesFailure) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(fixtures::createModule(&context));
+
+  // Always return failure from the callback.
+  LogicalResult result = graph.walkParallelPostOrder(
+      [&](igraph::InstanceGraphNode &) -> LogicalResult { return failure(); });
+  EXPECT_TRUE(failed(result));
+}
+
+// Verify that walkParallelPostOrder falls back correctly when multithreading is
+// disabled on the context.
+TEST(InstanceGraphTest, ParallelPostOrderFallbackToSerial) {
+  MLIRContext context;
+  context.disableMultithreading();
+  InstanceGraph graph(fixtures::createModule(&context));
+
+  llvm::SmallVector<std::string> visited;
+  graph.walkParallelPostOrder([&](igraph::InstanceGraphNode &node) {
+    visited.push_back(node.getModule().getModuleName().str());
+  });
+
+  ASSERT_EQ(4u, visited.size());
+  for (const char *name : {"Top", "Alligator", "Bear", "Cat"}) {
+    EXPECT_EQ(1, llvm::count(visited, name)) << name << " not visited once";
+  }
+}
+
+// Verify that walkParallelInversePostOrder visits every node exactly once.
+TEST(InstanceGraphTest, ParallelInversePostOrderVisitsAll) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(fixtures::createModule(&context));
+
+  std::mutex mu;
+  llvm::SmallVector<std::string> visited;
+  graph.walkParallelInversePostOrder([&](igraph::InstanceGraphNode &node) {
+    std::lock_guard<std::mutex> lock(mu);
+    visited.push_back(node.getModule().getModuleName().str());
+  });
+
+  ASSERT_EQ(4u, visited.size());
+  for (const char *name : {"Top", "Alligator", "Bear", "Cat"}) {
+    EXPECT_EQ(1, llvm::count(visited, name)) << name << " not visited once";
+  }
+}
+
+// Verify that walkParallelInversePostOrder respects the ordering constraint:
+// parents are always visited before their children.
+TEST(InstanceGraphTest, ParallelInversePostOrderParentBeforeChild) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(fixtures::createModule(&context));
+
+  std::mutex mu;
+  llvm::DenseMap<llvm::StringRef, unsigned> visitOrder;
+  unsigned counter = 0;
+  graph.walkParallelInversePostOrder([&](igraph::InstanceGraphNode &node) {
+    std::lock_guard<std::mutex> lock(mu);
+    visitOrder[node.getModule().getModuleName()] = counter++;
+  });
+
+  // The fixture graph:
+  //   Top  -> Alligator, Cat
+  //   Alligator -> Bear
+  //   Bear -> Cat
+  //   Cat  (leaf)
+  //
+  // We only assert ancestor/descendant pairs here.  Those relationships have
+  // a guaranteed serial ordering regardless of how many threads run.  Sibling
+  // pairs (e.g., Alligator vs Cat as direct children of Top) have no
+  // guaranteed relative order and are intentionally not compared.
+  EXPECT_LT(visitOrder["Top"], visitOrder["Cat"]);
+  EXPECT_LT(visitOrder["Top"], visitOrder["Alligator"]);
+  EXPECT_LT(visitOrder["Alligator"], visitOrder["Bear"]);
+  EXPECT_LT(visitOrder["Bear"], visitOrder["Cat"]);
+}
+
+// Verify that a failing callback propagates the failure return value.
+TEST(InstanceGraphTest, ParallelInversePostOrderPropagatesFailure) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(fixtures::createModule(&context));
+
+  LogicalResult result = graph.walkParallelInversePostOrder(
+      [&](igraph::InstanceGraphNode &) -> LogicalResult { return failure(); });
+  EXPECT_TRUE(failed(result));
+}
+
+// Verify that walkParallelInversePostOrder falls back correctly when
+// multithreading is disabled on the context.  The serial fallback must visit
+// exactly the same set of managed nodes as the parallel path (i.e., only the
+// nodes in the `nodes` list) and must not visit sentinel nodes such as the
+// virtual top-level entry introduced by hw::InstanceGraph.
+TEST(InstanceGraphTest, ParallelInversePostOrderFallbackToSerial) {
+  MLIRContext context;
+  context.disableMultithreading();
+  InstanceGraph graph(fixtures::createModule(&context));
+
+  llvm::SmallVector<std::string> visited;
+  graph.walkParallelInversePostOrder([&](igraph::InstanceGraphNode &node) {
+    visited.push_back(node.getModule().getModuleName().str());
+  });
+
+  ASSERT_EQ(4u, visited.size());
+  for (const char *name : {"Top", "Alligator", "Bear", "Cat"}) {
+    EXPECT_EQ(1, llvm::count(visited, name)) << name << " not visited once";
+  }
+}
+
+// Multi-seed tests.
+// A fixture with two independent chains exercises concurrent starts.  Both
+// chain heads are seeds and can run simultaneously, which is the main scenario
+// the parallel walk is designed for.
+//
+//   hw.module @A { hw.instance "b" @B }   chain 1: A instantiates B
+//   hw.module @B {}
+//   hw.module @C { hw.instance "d" @D }   chain 2: C instantiates D
+//   hw.module @D {}
+//
+// In post-order the only constraints are B before A and D before C.
+// In inverse post-order the constraints are A before B and C before D.
+
+static mlir::ModuleOp createTwoChainModule(mlir::MLIRContext *context) {
+  context->loadDialect<HWDialect>();
+  mlir::LocationAttr loc = mlir::UnknownLoc::get(context);
+  auto circuit = mlir::ModuleOp::create(loc);
+  auto builder = mlir::ImplicitLocOpBuilder::atBlockEnd(loc, circuit.getBody());
+
+  auto modA = HWModuleOp::create(builder, mlir::StringAttr::get(context, "A"),
+                                 llvm::ArrayRef<PortInfo>{});
+  auto modB = HWModuleOp::create(builder, mlir::StringAttr::get(context, "B"),
+                                 llvm::ArrayRef<PortInfo>{});
+  auto modC = HWModuleOp::create(builder, mlir::StringAttr::get(context, "C"),
+                                 llvm::ArrayRef<PortInfo>{});
+  auto modD = HWModuleOp::create(builder, mlir::StringAttr::get(context, "D"),
+                                 llvm::ArrayRef<PortInfo>{});
+
+  modB.setVisibility(mlir::SymbolTable::Visibility::Private);
+  modD.setVisibility(mlir::SymbolTable::Visibility::Private);
+
+  builder.setInsertionPointToStart(modA.getBodyBlock());
+  InstanceOp::create(builder, modB, "b", llvm::ArrayRef<mlir::Value>{});
+  builder.setInsertionPointToStart(modC.getBodyBlock());
+  InstanceOp::create(builder, modD, "d", llvm::ArrayRef<mlir::Value>{});
+
+  return circuit;
+}
+
+TEST(InstanceGraphTest, ParallelPostOrderMultiSeedVisitsAll) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(createTwoChainModule(&context));
+
+  std::mutex mu;
+  llvm::SmallVector<std::string> visited;
+  graph.walkParallelPostOrder([&](igraph::InstanceGraphNode &node) {
+    std::lock_guard<std::mutex> lock(mu);
+    visited.push_back(node.getModule().getModuleName().str());
+  });
+
+  ASSERT_EQ(4u, visited.size());
+  for (const char *name : {"A", "B", "C", "D"}) {
+    EXPECT_EQ(1, llvm::count(visited, name)) << name << " not visited once";
+  }
+}
+
+TEST(InstanceGraphTest, ParallelPostOrderMultiSeedChildBeforeParent) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(createTwoChainModule(&context));
+
+  std::mutex mu;
+  llvm::DenseMap<llvm::StringRef, unsigned> order;
+  unsigned counter = 0;
+  graph.walkParallelPostOrder([&](igraph::InstanceGraphNode &node) {
+    std::lock_guard<std::mutex> lock(mu);
+    order[node.getModule().getModuleName()] = counter++;
+  });
+
+  EXPECT_LT(order["B"], order["A"]);
+  EXPECT_LT(order["D"], order["C"]);
+}
+
+TEST(InstanceGraphTest, ParallelInversePostOrderMultiSeedParentBeforeChild) {
+  MLIRContext context;
+  context.enableMultithreading();
+  InstanceGraph graph(createTwoChainModule(&context));
+
+  std::mutex mu;
+  llvm::DenseMap<llvm::StringRef, unsigned> order;
+  unsigned counter = 0;
+  graph.walkParallelInversePostOrder([&](igraph::InstanceGraphNode &node) {
+    std::lock_guard<std::mutex> lock(mu);
+    order[node.getModule().getModuleName()] = counter++;
+  });
+
+  EXPECT_LT(order["A"], order["B"]);
+  EXPECT_LT(order["C"], order["D"]);
+}
+
+// Wide DAG stress test.
+// Build a two-level DAG: one root module that instantiates N leaves.  All N
+// leaves are seeds and can execute truly concurrently.  Run repeatedly to
+// stress the thread safety of the walk bookkeeping itself.
+
+static mlir::ModuleOp createWideDAGModule(mlir::MLIRContext *context,
+                                          unsigned numLeaves) {
+  context->loadDialect<HWDialect>();
+  mlir::LocationAttr loc = mlir::UnknownLoc::get(context);
+  auto circuit = mlir::ModuleOp::create(loc);
+  auto builder = mlir::ImplicitLocOpBuilder::atBlockEnd(loc, circuit.getBody());
+
+  // Create the root module first so it appears first in the module list.
+  auto root =
+      HWModuleOp::create(builder, mlir::StringAttr::get(context, "Root"),
+                         llvm::ArrayRef<PortInfo>{});
+
+  llvm::SmallVector<HWModuleOp> leaves;
+  for (unsigned i = 0; i < numLeaves; ++i) {
+    auto name = mlir::StringAttr::get(context, "Leaf" + std::to_string(i));
+    auto leaf = HWModuleOp::create(builder, name, llvm::ArrayRef<PortInfo>{});
+    leaf.setVisibility(mlir::SymbolTable::Visibility::Private);
+    leaves.push_back(leaf);
+  }
+
+  builder.setInsertionPointToStart(root.getBodyBlock());
+  for (unsigned i = 0; i < numLeaves; ++i) {
+    auto instName = "leaf" + std::to_string(i);
+    InstanceOp::create(builder, leaves[i], instName,
+                       llvm::ArrayRef<mlir::Value>{});
+  }
+
+  return circuit;
+}
+
+TEST(InstanceGraphTest, ParallelPostOrderWideDAGStress) {
+  constexpr unsigned kNumLeaves = 100;
+  constexpr unsigned kNumRounds = 20;
+
+  MLIRContext context;
+  context.enableMultithreading();
+
+  for (unsigned round = 0; round < kNumRounds; ++round) {
+    InstanceGraph graph(createWideDAGModule(&context, kNumLeaves));
+
+    std::atomic<unsigned> leafCount(0);
+    std::atomic<unsigned> rootCount(0);
+    graph.walkParallelPostOrder([&](igraph::InstanceGraphNode &node) {
+      if (node.getModule().getModuleName() == "Root")
+        rootCount.fetch_add(1, std::memory_order_relaxed);
+      else
+        leafCount.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    ASSERT_EQ(kNumLeaves, leafCount.load());
+    ASSERT_EQ(1u, rootCount.load());
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Add parallel versions of post/inverse post order walkers that exist for
the InstanceGraph.  This is added to hopefully extract more parallelism
from existing passes that need to visit "parents before children" or
"children before parents", but can visit all parents or all children in
parallel, respectively.

Assisted-by: pi.dev:claude-sonnet-4-6
Assisted-by: pi.dev:claude-opus-4-7

**Warning: this is presently marginally-reviewed LLM output. Once I have sufficiently reviewed this I will mark this as non-draft.**
