### PR TITLE
[FSMToSMT] Allow fsm.machines with no outputs/vars

### DIFF
--- a/lib/Conversion/FSMToSMT/FSMToSMT.cpp
+++ b/lib/Conversion/FSMToSMT/FSMToSMT.cpp
@@ -266,10 +266,6 @@ LogicalResult MachineOpConverter::dispatch() {
   for (auto i = numArgs; i < quantifiedTypes.size(); i++)
     stateFunDomain.push_back(quantifiedTypes[i]);
 
-  // The domain should not be empty
-  if (stateFunDomain.empty())
-    return solver.emitError("At least one variable or output is required.");
-
   // For each state, declare one SMT function: `F_state(outs, vars, [time]) ->
   // Bool`, returning `true`  when `state` is activated.
   for (auto stateOp : machineOp.front().getOps<fsm::StateOp>()) {

--- a/test/Conversion/FSMToSMT/empty_domain.mlir
+++ b/test/Conversion/FSMToSMT/empty_domain.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-opt -convert-fsm-to-smt %s | FileCheck %s
+
+// A machine with no outputs or variables should produce state functions with
+// an empty domain
+
+// CHECK: smt.declare_fun "F_A" : !smt.func<() !smt.bool>
+
+fsm.machine @action() -> () attributes {initialState = "A"} {
+  fsm.state @A output  {
+  }
+}

--- a/test/Conversion/FSMToSMT/errors.mlir
+++ b/test/Conversion/FSMToSMT/errors.mlir
@@ -100,16 +100,3 @@ fsm.machine @action() -> () attributes {initialState = "A"} {
     }
   }
 }
-
-
-// -----
-
-// expected-error @below {{At least one variable or output is required.}}
-fsm.machine @action() -> () attributes {initialState = "A"} {
-  fsm.state @A output  {
-  } transitions {
-    fsm.transition @A guard {
-    } action {
-    }
-  }
-}


### PR DESCRIPTION
As of [this change](https://github.com/llvm/llvm-project/pull/193732), the SMT dialect supports functions with empty domains, so we can now support fsm.machines with no vars or outputs (since their state functions will have an empty domain).

CC: @luisacicolini 
