### PR TITLE
[FIRRTL] Add "hasProperties" to InstanceInfo

### DIFF
--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -129,6 +129,10 @@ public:
     /// Indicates if this module is instantiated within (or transitively within)
     /// an instance choice operation.
     InstanceInfo::LatticeValue inInstanceChoice;
+
+    /// Indicates if this module has any property operations within (or
+    /// transitively within) it.
+    bool hasProperties = false;
   };
 
   //===--------------------------------------------------------------------===//
@@ -208,6 +212,11 @@ public:
   /// Note: allInstancesInInstanceChoice is intentionally not provided because
   /// that property is relative to the public module.
   bool anyInstanceInInstanceChoice(igraph::ModuleOpInterface op);
+
+  /// Return true if this module contains (or its children transitively contain)
+  /// any property operations, i.e., operations whose operands or results have
+  /// a PropertyType, or if any port of the module has a PropertyType.
+  bool moduleContainsProperties(igraph::ModuleOpInterface op);
 
 private:
   /// Stores circuit-level attributes.

--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -196,7 +196,7 @@ public:
   bool anyInstanceInDesign(igraph::ModuleOpInterface op);
 
   /// Return true if all instances of this module are within (or transitively
-  /// withiin) the design.
+  /// within) the design.
   bool allInstancesInDesign(igraph::ModuleOpInterface op);
 
   /// Return true if any instance of this module is within (or transitively
@@ -204,7 +204,7 @@ public:
   bool anyInstanceInEffectiveDesign(igraph::ModuleOpInterface op);
 
   /// Return true if all instances of this module are within (or transitively
-  /// withiin) the effective design.
+  /// within) the effective design.
   bool allInstancesInEffectiveDesign(igraph::ModuleOpInterface op);
 
   /// Return true if any instance of this module is within (or transitively
@@ -215,7 +215,8 @@ public:
 
   /// Return true if this module contains (or its children transitively contain)
   /// any property operations, i.e., operations whose operands or results have
-  /// a PropertyType, or if any port of the module has a PropertyType.
+  /// a PropertyType, if any port of the module has a PropertyType, or if the
+  /// module is a class.
   bool moduleContainsProperties(igraph::ModuleOpInterface op);
 
 private:

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -210,7 +210,9 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
         });
 
     // Walk the ops to populate information, short circuiting as soon as
-    // we've gathered enough information to stop the walk.
+    // we've gathered enough information to stop the walk.  Only FModuleOp has
+    // a body to walk; external/intrinsic modules are fully characterized by
+    // their ports, already checked above.
     if (auto fmodule = dyn_cast<FModuleOp>(moduleLike.getOperation())) {
       auto isPropertyType = [](Type t) { return isa<PropertyType>(t); };
       fmodule.walk([&](Operation *op) {
@@ -248,7 +250,7 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
           << llvm::indent(6)
           << "isDut: " << (isDut(moduleOp) ? "true" : "false") << "\n"
           << llvm::indent(6)
-          << "isEffectiveDue: " << (isEffectiveDut(moduleOp) ? "true" : "false")
+          << "isEffectiveDut: " << (isEffectiveDut(moduleOp) ? "true" : "false")
           << "\n"
           << llvm::indent(6) << "underDut: " << attributes.underDut << "\n"
           << llvm::indent(6) << "underLayer: " << attributes.underLayer << "\n"

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -180,6 +180,50 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
     }
   });
 
+  // Visit modules in post-order (visit children before parents) to aggregate
+  // information into parents about themselves and their children.
+  //
+  // This walk is _more expensive_ than the earlier walk as this, at worst,
+  // needs to do a full IR walk.  Mitigate this via short circuiting when we
+  // have enough information to interrupt the walk or to skip it entirely.
+  iGraph.walkPostOrder([&](igraph::InstanceGraphNode &modIt) {
+    auto moduleOp = modIt.getModule();
+    ModuleAttributes &attributes = moduleAttributes[moduleOp];
+
+    // Merge in attributes from children.
+    attributes
+        .hasProperties |= llvm::any_of(modIt, [&](InstanceRecord *record) {
+      return moduleAttributes[record->getTarget()->getModule()].hasProperties;
+    });
+
+    // Compute attributes of the module itself.
+    auto moduleLike = modIt.getModule<FModuleLike>();
+    if (!moduleLike)
+      return;
+
+    // If the module is classlike consider this a "property" or if any of the
+    // ports have property type.
+    attributes.hasProperties |=
+        isa<ClassLike>(moduleLike.getOperation()) ||
+        llvm::any_of(moduleLike.getPorts(), [](PortInfo port) {
+          return isa<PropertyType>(port.type);
+        });
+
+    // Walk the ops to populate information, short circuiting as soon as
+    // we've gathered enough information to stop the walk.
+    if (auto fmodule = dyn_cast<FModuleOp>(moduleLike.getOperation())) {
+      auto isPropertyType = [](Type t) { return isa<PropertyType>(t); };
+      fmodule.walk([&](Operation *op) {
+        if (attributes.hasProperties)
+          return WalkResult::interrupt();
+        attributes.hasProperties |=
+            llvm::any_of(op->getOperandTypes(), isPropertyType) ||
+            llvm::any_of(op->getResultTypes(), isPropertyType);
+        return WalkResult::advance();
+      });
+    }
+  });
+
   LLVM_DEBUG({
     mlir::OpPrintingFlags flags;
     flags.skipRegions();
@@ -212,7 +256,10 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
           << llvm::indent(6)
           << "inEffectiveDesign: " << attributes.inEffectiveDesign << "\n"
           << llvm::indent(6)
-          << "inInstanceChoice: " << attributes.inInstanceChoice << "\n";
+          << "inInstanceChoice: " << attributes.inInstanceChoice << "\n"
+          << llvm::indent(6)
+          << "hasProperties: " << (attributes.hasProperties ? "true" : "false")
+          << "\n";
     });
   });
 }
@@ -296,4 +343,8 @@ bool InstanceInfo::anyInstanceInInstanceChoice(igraph::ModuleOpInterface op) {
   auto inInstanceChoice = getModuleAttributes(op).inInstanceChoice;
   return inInstanceChoice.isMixed() ||
          (inInstanceChoice.isConstant() && inInstanceChoice.getConstant());
+}
+
+bool InstanceInfo::moduleContainsProperties(igraph::ModuleOpInterface op) {
+  return getModuleAttributes(op).hasProperties;
 }

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -196,6 +196,9 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
       return moduleAttributes[record->getTarget()->getModule()].hasProperties;
     });
 
+    if (attributes.hasProperties)
+      return;
+
     // Compute attributes of the module itself.
     auto moduleLike = modIt.getModule<FModuleLike>();
     if (!moduleLike)

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -233,30 +233,29 @@ static void printModuleInfo(igraph::ModuleOpInterface op,
   flags.skipRegions();
   llvm::errs() << "  - operation: ";
   op->print(llvm::errs(), flags);
-  llvm::errs() << "\n"
-               << "    isDut: " << iInfo.isDut(op) << "\n"
-               << "    anyInstanceUnderDut: " << iInfo.anyInstanceUnderDut(op)
-               << "\n"
-               << "    allInstancesUnderDut: " << iInfo.allInstancesUnderDut(op)
-               << "\n"
-               << "    anyInstanceUnderEffectiveDut: "
-               << iInfo.anyInstanceUnderEffectiveDut(op) << "\n"
-               << "    allInstancesUnderEffectiveDut: "
-               << iInfo.allInstancesUnderEffectiveDut(op) << "\n"
-               << "    anyInstanceUnderLayer: "
-               << iInfo.anyInstanceUnderLayer(op) << "\n"
-               << "    allInstancesUnderLayer: "
-               << iInfo.allInstancesUnderLayer(op) << "\n"
-               << "    anyInstanceInDesign: " << iInfo.anyInstanceInDesign(op)
-               << "\n"
-               << "    allInstancesInDesign: " << iInfo.allInstancesInDesign(op)
-               << "\n"
-               << "    anyInstanceInEffectiveDesign: "
-               << iInfo.anyInstanceInEffectiveDesign(op) << "\n"
-               << "    allInstancesInEffectiveDesign: "
-               << iInfo.allInstancesInEffectiveDesign(op) << "\n"
-               << "    anyInstanceInInstanceChoice: "
-               << iInfo.anyInstanceInInstanceChoice(op) << "\n";
+  llvm::errs()
+      << "\n"
+      << "    isDut: " << iInfo.isDut(op) << "\n"
+      << "    anyInstanceUnderDut: " << iInfo.anyInstanceUnderDut(op) << "\n"
+      << "    allInstancesUnderDut: " << iInfo.allInstancesUnderDut(op) << "\n"
+      << "    anyInstanceUnderEffectiveDut: "
+      << iInfo.anyInstanceUnderEffectiveDut(op) << "\n"
+      << "    allInstancesUnderEffectiveDut: "
+      << iInfo.allInstancesUnderEffectiveDut(op) << "\n"
+      << "    anyInstanceUnderLayer: " << iInfo.anyInstanceUnderLayer(op)
+      << "\n"
+      << "    allInstancesUnderLayer: " << iInfo.allInstancesUnderLayer(op)
+      << "\n"
+      << "    anyInstanceInDesign: " << iInfo.anyInstanceInDesign(op) << "\n"
+      << "    allInstancesInDesign: " << iInfo.allInstancesInDesign(op) << "\n"
+      << "    anyInstanceInEffectiveDesign: "
+      << iInfo.anyInstanceInEffectiveDesign(op) << "\n"
+      << "    allInstancesInEffectiveDesign: "
+      << iInfo.allInstancesInEffectiveDesign(op) << "\n"
+      << "    anyInstanceInInstanceChoice: "
+      << iInfo.anyInstanceInInstanceChoice(op) << "\n"
+      << "    moduleContainsProperties: " << iInfo.moduleContainsProperties(op)
+      << "\n";
 }
 
 void FIRRTLInstanceInfoPass::runOnOperation() {

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -613,6 +613,11 @@ firrtl.circuit "Top" {
     writeLatency = 1 : ui32
   }
 
+  // Top instantiates children with properties, so moduleContainsProperties is
+  // true transitively.
+  //
+  // CHECK:      @Top
+  // CHECK:        moduleContainsProperties: true
   firrtl.module @Top() {
     firrtl.instance has_prop_port @HasPropPort(in p: !firrtl.string)
     firrtl.instance has_prop_op @HasPropOp()

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -22,6 +22,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: true
   // CHECK-NEXT:   allInstancesUnderLayer: false
   // CHECK:        anyInstanceInInstanceChoice: true
+  // CHECK-NEXT:   moduleContainsProperties: false
   firrtl.module private @Corge() {}
   // CHECK:      @Quz
   // CHECK-NEXT:   isDut: false
@@ -32,6 +33,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: true
   // CHECK-NEXT:   allInstancesUnderLayer: true
   // CHECK:        anyInstanceInInstanceChoice: false
+  // CHECK-NEXT:   moduleContainsProperties: false
   firrtl.module private @Quz() {}
   // CHECK:      @Qux
   // CHECK-NEXT:   isDut: false
@@ -42,6 +44,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
   // CHECK:        anyInstanceInInstanceChoice: true
+  // CHECK-NEXT:   moduleContainsProperties: false
   firrtl.module private @Qux() {}
   // CHECK:      @Baz
   // CHECK-NEXT:   isDut: false
@@ -52,6 +55,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
   // CHECK:        anyInstanceInInstanceChoice: false
+  // CHECK-NEXT:   moduleContainsProperties: false
   firrtl.module private @Baz() {}
   // CHECK:      @Bar
   // CHECK-NEXT:   isDut: true
@@ -62,6 +66,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
   // CHECK:        anyInstanceInInstanceChoice: false
+  // CHECK-NEXT:   moduleContainsProperties: false
   firrtl.module private @Bar() attributes {
     annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
@@ -79,6 +84,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
   // CHECK:        anyInstanceInInstanceChoice: false
+  // CHECK-NEXT:   moduleContainsProperties: false
   firrtl.module @Foo() {
     firrtl.instance bar @Bar()
     firrtl.instance_choice qux @Qux alternatives @Platform {
@@ -112,6 +118,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
   // CHECK:        anyInstanceInInstanceChoice: false
+  // CHECK-NEXT:   moduleContainsProperties: false
   firrtl.module @Foo() {}
 }
 
@@ -536,5 +543,86 @@ firrtl.circuit "Testharness" {
   // CHECK-NEXT:   anyInstanceUnderDut: false
   // CHECK-NEXT:   allInstancesUnderDut: false
   firrtl.module private @Foo() {
+  }
+}
+
+// -----
+
+// Test moduleContainsProperties.
+firrtl.circuit "Top" {
+  // HasPropPort has a !firrtl.string port, so the flag is set from the port
+  // check alone.
+  //
+  // CHECK:      @HasPropPort
+  // CHECK:        moduleContainsProperties: true
+  firrtl.module private @HasPropPort(in %p: !firrtl.string) {}
+
+  // HasPropOp has no property port but contains a firrtl.integer op whose
+  // result has a property type, so the flag is set from the body walk.
+  //
+  // CHECK:      @HasPropOp
+  // CHECK:        moduleContainsProperties: true
+  firrtl.module private @HasPropOp() {
+    %0 = firrtl.integer 42
+  }
+
+  // NoProp has no property ports and no property ops.
+  //
+  // CHECK:      @NoProp
+  // CHECK:        moduleContainsProperties: false
+  firrtl.module private @NoProp() {
+    %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
+  }
+
+  // TransitiveProp has no properties itself, but instantiates HasPropPort, so
+  // the flag is propagated upward from the child.
+  //
+  // CHECK:      @TransitiveProp
+  // CHECK:        moduleContainsProperties: true
+  firrtl.module private @TransitiveProp() {
+    firrtl.instance child @HasPropPort(in p: !firrtl.string)
+  }
+
+  // EmptyClass has no ports and no body ops, but a ClassLike op is itself a
+  // property, so the flag is unconditionally true for all classes.  This covers
+  // checking of classes with properties or any transitive checking.
+  //
+  // CHECK:      @EmptyClass
+  // CHECK:        moduleContainsProperties: true
+  firrtl.class private @EmptyClass() {}
+
+  // MemMod is a firrtl.memmodule. It has no body and its ports are not
+  // property types, so moduleContainsProperties is false.
+  //
+  // CHECK:      @MemMod
+  // CHECK:        moduleContainsProperties: false
+  firrtl.memmodule @MemMod(
+    in W0_addr: !firrtl.uint<1>,
+    in W0_en: !firrtl.uint<1>,
+    in W0_clk: !firrtl.clock,
+    in W0_data: !firrtl.uint<8>
+  ) attributes {
+    dataWidth = 8 : ui32,
+    depth = 2 : ui64,
+    extraPorts = [],
+    maskBits = 1 : ui32,
+    numReadPorts = 0 : ui32,
+    numReadWritePorts = 0 : ui32,
+    numWritePorts = 1 : ui32,
+    readLatency = 1 : ui32,
+    writeLatency = 1 : ui32
+  }
+
+  firrtl.module @Top() {
+    firrtl.instance has_prop_port @HasPropPort(in p: !firrtl.string)
+    firrtl.instance has_prop_op @HasPropOp()
+    firrtl.instance no_prop @NoProp()
+    firrtl.instance transitive @TransitiveProp()
+    %0:4 = firrtl.instance mem @MemMod(
+      in W0_addr: !firrtl.uint<1>,
+      in W0_en: !firrtl.uint<1>,
+      in W0_clk: !firrtl.clock,
+      in W0_data: !firrtl.uint<8>
+    )
   }
 }


### PR DESCRIPTION
Add a post-order walk to FIRRTL's IntsnaceInfo analysis that is used to
determine if modules contain any properties.

This is planned to have two uses which will be added in a follow-on.:

  1. The LowerClasses pass needs to know if modules contain properties in
  order to know if it needs to create classes for these modules.
  Currently, this only looks at ports which is insufficient.

  2. @rwy7 has a need for computing "contains a layerblock" which can
  be added to this same walk.

Due to the type of information that needs to be computed, this has
annoying asymptotic behavior of, at worst, walking the whole IR.  This has
short circuiting logic to hopefully get the average case better.  As an
alternative mitigation, this could be broken out into a separate analysis
where the user can pick from either the existing "top-down"
InstanceInfo (which is faster as it only visits nodes and IR parents of
instances) and the "bottom-up" InstanceInfo (this one, which may be
slower).  Additionally, the new "bottom-up" is a great candidate for work

Assisted-by: pi.dev:claude-sonnet-4-6
