### PR TITLE
[ExportVerilog] Drop 'reg' for unpacked arrays too

### DIFF
--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -120,3 +120,7 @@ hw.module @UniformArrayCreate(out arr: !hw.array<5xi8>) {
   %arr = hw.array_create %c0_i8, %c0_i8, %c0_i8, %c0_i8, %c0_i8 : i8
   hw.output %arr : !hw.array<5xi8>
 }
+
+hw.module @RegisterOfUnpackedArrayOfStruct() {
+  %reg6 = sv.reg : !hw.inout<uarray<4xarray<8xstruct<a: i1, b: i1>>>>
+}

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1555,20 +1555,14 @@ static StringRef getVerilogDeclWord(Operation *op,
     // should be left off.
     auto elementType =
         cast<InOutType>(op->getResult(0).getType()).getElementType();
-    if (isa<StructType>(elementType))
-      return "";
-    if (isa<UnionType>(elementType))
-      return "";
-    if (isa<EnumType>(elementType))
-      return "";
-    if (auto innerType = dyn_cast<ArrayType>(elementType)) {
-      while (isa<ArrayType>(innerType.getElementType()))
-        innerType = cast<ArrayType>(innerType.getElementType());
-      if (isa<StructType>(innerType.getElementType()) ||
-          isa<TypeAliasType>(innerType.getElementType()))
-        return "";
-    }
-    if (isa<TypeAliasType>(elementType))
+    // Unwrap arrays. Since packed arrays cannot contain unpacked arrays, we can
+    // unpack unpacked arrays first.
+    while (auto arrayType = hw::type_dyn_cast<UnpackedArrayType>(elementType))
+      elementType = arrayType.getElementType();
+    while (auto arrayType = hw::type_dyn_cast<ArrayType>(elementType))
+      elementType = arrayType.getElementType();
+
+    if (isa<StructType, UnionType, EnumType, TypeAliasType>(elementType))
       return "";
 
     return "reg";

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -63,6 +63,27 @@ hw.module @testRegOp() {
   %r2 = sv.reg : !hw.inout<!hw.array<3xtypealias<@__hw_typedecls::@foo,i1>>>
 }
 
+// Check that sv.reg omits the "reg" keyword for typealias types wrapped in
+// unpacked arrays, matching the behaviour for StructType in the same position.
+// CHECK-LABEL: module testRegOpUnpackedArrayTypealias
+hw.module @testRegOpUnpackedArrayTypealias() {
+  // CHECK-NOT: reg
+  // CHECK: foo{{.*}}[0:7]
+  %r1 = sv.reg : !hw.inout<uarray<8xtypealias<@__hw_typedecls::@foo, i1>>>
+
+  // CHECK-NOT: reg
+  // CHECK: foo{{.*}}[0:3][0:7]
+  %r2 = sv.reg : !hw.inout<uarray<4xuarray<8xtypealias<@__hw_typedecls::@foo, i1>>>>
+
+  // CHECK-NOT: reg
+  // CHECK: bar{{.*}}[0:7]
+  %r3 = sv.reg : !hw.inout<uarray<8xtypealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>>
+
+  // CHECK-NOT: reg
+  // CHECK: bar[7:0]{{.*}}[0:3]
+  %r4 = sv.reg : !hw.inout<uarray<4xarray<8xtypealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>>>
+}
+
 // CHECK-LABEL: module testAggregateCreate
 hw.module @testAggregateCreate(in %i: i1, out out1: i1, out out2: i1) {
   // CHECK: wire bar [[NAME:.+]] = {{.+}};

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1092,6 +1092,21 @@ hw.module @RegisterOfStructOrArrayOfStruct() {
   %reg3 = sv.reg : !hw.inout<array<4xarray<8xstruct<a: i1, b: i1>>>>
 }
 
+// See https://github.com/llvm/circt/issues/7733
+// CHECK-LABEL: module RegisterOfUnpackedArrayOfStruct
+hw.module @RegisterOfUnpackedArrayOfStruct() {
+  // CHECK-NOT: reg
+  // CHECK: struct packed {logic a; logic b; }{{.*}}reg4[0:7]
+  %reg4 = sv.reg : !hw.inout<uarray<8xstruct<a: i1, b: i1>>>
+
+  // CHECK-NOT: reg
+  // CHECK: struct packed {logic a; logic b; }{{.*}}reg5[0:3][0:7]
+  %reg5 = sv.reg : !hw.inout<uarray<4xuarray<8xstruct<a: i1, b: i1>>>>
+
+  // CHECK-NOT: reg
+  // CHECK: struct packed {logic a; logic b; }[7:0]{{.*}}reg6[0:3]
+  %reg6 = sv.reg : !hw.inout<uarray<4xarray<8xstruct<a: i1, b: i1>>>>
+}
 
 // CHECK-LABEL: module MultiUseReadInOut(
 // Issue #1564


### PR DESCRIPTION
See #10357. Replicates the behavior that we have for packed arrays.

