### PR TITLE
[OM] Add ElaborateObject pass

### DIFF
--- a/include/circt/Dialect/OM/OMPasses.td
+++ b/include/circt/Dialect/OM/OMPasses.td
@@ -30,12 +30,16 @@ def ElaborateObject: Pass<"om-elaborate-object", "mlir::ModuleOp"> {
   let description = [{
     Performs evaluation of a specified OM class by inlining all object
     instantiations and folding field accesses.
+
+    The pass requires the `target-class` option to specify which class to
+    elaborate.
   }];
   let options = [
     Option<"targetClass", "target-class", "std::string", /*default=*/"",
            "The class to elaborate">,
     Option<"test", "test", "bool", /*default=*/"false",
-           "Test mode: elaborate all zero-argument classes in the module">
+           "Internal testing mode: elaborate all zero-argument classes",
+           "llvm::cl::Hidden">
   ];
 }
 

--- a/include/circt/Dialect/OM/OMPasses.td
+++ b/include/circt/Dialect/OM/OMPasses.td
@@ -25,6 +25,20 @@ def LinkModules: Pass<"om-link-modules", "mlir::ModuleOp"> {
   }];
 }
 
+def ElaborateObject: Pass<"om-elaborate-object", "mlir::ModuleOp"> {
+  let summary = "Perform elaboration of OM objects";
+  let description = [{
+    Performs evaluation of a specified OM class by inlining all object
+    instantiations and folding field accesses.
+  }];
+  let options = [
+    Option<"targetClass", "target-class", "std::string", /*default=*/"",
+           "The class to elaborate">,
+    Option<"test", "test", "bool", /*default=*/"false",
+           "Test mode: elaborate all zero-argument classes in the module">
+  ];
+}
+
 def StripOMPass : Pass<"strip-om", "mlir::ModuleOp"> {
   let summary = "Remove OM information";
   let description = [{

--- a/lib/Dialect/OM/Transforms/CMakeLists.txt
+++ b/lib/Dialect/OM/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTOMTransforms
+  ElaborateObject.cpp
   FreezePaths.cpp
   LinkModules.cpp
   StripOM.cpp

--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -200,7 +200,7 @@ LogicalResult verifyResult(ClassOp module) {
       if (matchPattern(assertOp.getCondition(), m_ConstantInt(&value)))
         return checkAssert(!value.isZero());
 
-      // Condition is unknown - treat as passing (best-effort verification).
+      // Condition is unknown - treat as passing.
       if (auto unknownOp = dyn_cast_or_null<UnknownValueOp>(defOp))
         return checkAssert(true);
 

--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -1,0 +1,281 @@
+//===- ElaborateObject.cpp - OM compile-time evaluation pass --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass performs evaluation of OM classes by inlining object
+// instantiations and folding field accesses. It replaces the runtime Evaluator
+// framework with static compile-time evaluation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/OM/OMDialect.h"
+#include "circt/Dialect/OM/OMOps.h"
+#include "circt/Dialect/OM/OMPasses.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/WalkResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/LogicalResult.h"
+
+namespace circt {
+namespace om {
+#define GEN_PASS_DEF_ELABORATEOBJECT
+#include "circt/Dialect/OM/OMPasses.h.inc"
+} // namespace om
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace om;
+
+namespace {
+// A map from (class name, field name) to field index.
+using FieldIndex = DenseMap<std::pair<StringAttr, StringAttr>, unsigned>;
+
+/// Pattern to inline ObjectOp instances by cloning the class body and
+/// replacing them with ElaboratedObjectOp.
+struct ObjectOpInliningPattern : public OpRewritePattern<ObjectOp> {
+  ObjectOpInliningPattern(MLIRContext *context, SymbolTable &symTable)
+      : OpRewritePattern<ObjectOp>(context), symTable(symTable) {}
+
+  LogicalResult matchAndRewrite(ObjectOp objOp,
+                                PatternRewriter &rewriter) const override {
+    auto classLike = symTable.lookup<ClassLike>(objOp.getClassNameAttr());
+    assert(classLike);
+
+    // External classes cannot be elaborated; replace with unknown values.
+    if (isa<ClassExternOp>(classLike)) {
+      rewriter.replaceOpWithNewOp<UnknownValueOp>(objOp, objOp.getType());
+      return success();
+    }
+
+    auto classOp = dyn_cast<ClassOp>(classLike.getOperation());
+    if (!classOp)
+      return failure();
+
+    IRMapping mapper;
+    for (auto [formal, actual] : llvm::zip(
+             classOp.getBodyBlock()->getArguments(), objOp.getActualParams()))
+      mapper.map(formal, actual);
+
+    // Clone the class body into a temporary region with argument substitution.
+    Region clonedRegion;
+    classOp.getBody().cloneInto(&clonedRegion, mapper);
+    Block *clonedBlock = &clonedRegion.front();
+
+    auto clonedFields = cast<ClassFieldsOp>(clonedBlock->getTerminator());
+    SmallVector<Value> fieldValues(clonedFields.getFields());
+
+    // Erase the terminator and inline the body at the object instantiation.
+    rewriter.eraseOp(clonedFields);
+    rewriter.inlineBlockBefore(clonedBlock, objOp);
+
+    rewriter.replaceOpWithNewOp<ElaboratedObjectOp>(objOp, classLike,
+                                                    fieldValues);
+
+    return success();
+  }
+
+  SymbolTable &symTable;
+};
+
+/// Pattern to fold ObjectFieldOp on ElaboratedObjectOp by directly accessing
+/// the field value operands.
+struct EvaluateObjectField : OpRewritePattern<ObjectFieldOp> {
+  EvaluateObjectField(MLIRContext *context, const SymbolTable &symTable,
+                      const FieldIndex &fieldIndexes)
+      : OpRewritePattern<ObjectFieldOp>(context), symTable(symTable),
+        fieldIndexes(fieldIndexes) {}
+
+  LogicalResult matchAndRewrite(ObjectFieldOp op,
+                                PatternRewriter &rewriter) const override {
+    // Only fold if the object is an ElaboratedObjectOp.
+    auto elaboratedOp = op.getObject().getDefiningOp<ElaboratedObjectOp>();
+    if (!elaboratedOp)
+      return failure();
+
+    auto classLike =
+        symTable.lookup<ClassLike>(elaboratedOp.getClassNameAttr());
+    assert(classLike);
+
+    // Find the field index and get the corresponding value.
+    auto index =
+        fieldIndexes.at({classLike.getSymNameAttr(), op.getFieldAttr()});
+    auto result = elaboratedOp.getFieldValues()[index];
+
+    // Skip cycles where a field references itself.
+    // This will be raised as an error later.
+    if (op.getResult() == result)
+      return failure();
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+  const SymbolTable &symTable;
+  const FieldIndex &fieldIndexes;
+};
+
+/// Pattern to propagate UnknownValueOp through pure OM operations.
+/// If any operand is unknown, all results become unknown.
+struct UnknownPropagationPattern : RewritePattern {
+  UnknownPropagationPattern(MLIRContext *context)
+      : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    // Only target pure OM operations.
+    // TODO: Consider add a trait for this if we want to have more explict
+    // behavior.
+    if (!isa_and_nonnull<OMDialect>(op->getDialect()) || !isPure(op) ||
+        op->getNumResults() == 0)
+      return failure();
+
+    // Check if any operand is an UnknownValueOp.
+    // TODO: This directly ports the existing Evaluator semantics, but it
+    // causes inconsistent evaluation for operations that can reason about
+    // known values, e.g., "and(0, unknown) -> 0".
+    if (!llvm::any_of(op->getOperands(), [](Value operand) {
+          return operand.getDefiningOp<UnknownValueOp>();
+        }))
+      return failure();
+
+    // Replace all results with UnknownValueOp.
+    SmallVector<Value> unknowns;
+    for (Type resultType : op->getResultTypes())
+      unknowns.push_back(
+          UnknownValueOp::create(rewriter, op->getLoc(), resultType));
+
+    rewriter.replaceOp(op, unknowns);
+    return success();
+  }
+};
+
+bool isSerializable(Operation *op) {
+  return isa<
+      // Structure.
+      ClassOp, ClassFieldsOp, ElaboratedObjectOp, AnyCastOp,
+      // Constant-like.
+      ConstantOp, UnknownValueOp,
+      // Path.
+      FrozenBasePathCreateOp, FrozenPathCreateOp, FrozenEmptyPathOp,
+      // List.
+      ListCreateOp, ListConcatOp>(op);
+}
+
+LogicalResult verifyResult(ClassOp module) {
+  auto isLegal = [](Operation *op) -> LogicalResult {
+    // Check assert satisfied.
+    if (auto assertOp = dyn_cast<PropertyAssertOp>(op)) {
+      // Check if the condition is a constant false, which means the assertion
+      // is violated.
+      auto *defOp = assertOp.getCondition().getDefiningOp();
+      APInt value;
+      auto checkAssert = [&](bool cond) -> LogicalResult {
+        if (cond) {
+          // Erase when success, serialization doesn't need to care about
+          // this.
+          op->erase();
+          return success();
+        }
+
+        return op->emitError("OM property assertion failed: ")
+               << assertOp.getMessage();
+      };
+
+      if (matchPattern(assertOp.getCondition(), m_ConstantInt(&value)))
+        return checkAssert(!value.isZero());
+
+      // Ok.
+      if (auto unknownOp = dyn_cast_or_null<UnknownValueOp>(defOp))
+        return checkAssert(true);
+
+      // This means the condition was not fully evaluated.
+      return emitError(op->getLoc(), "failed to evaluate assertion condition");
+    }
+
+    if (!isSerializable(op))
+      return emitError(op->getLoc()) << "failed to evaluate " << op->getName();
+
+    return success();
+  };
+  bool encounteredError = false;
+  module.walk([&](Operation *op) { encounteredError |= failed(isLegal(op)); });
+
+  return failure(encounteredError);
+}
+
+struct ElaborateObjectPass
+    : public circt::om::impl::ElaborateObjectBase<ElaborateObjectPass> {
+  using Base::Base;
+
+  static LogicalResult elaborateClass(ClassOp classOp, SymbolTable &symTable,
+                                      FieldIndex &fieldIndexes) {
+    // Elaborate objects by inlining all ObjectOps and folding field accesses
+    // using a greedy pattern rewriter. NOTE: The conversion framework is not
+    // suitable here because inlining
+    //       patterns need to be applied recursively to fully evaluate nested
+    //       object instantiations.
+    RewritePatternSet patterns(classOp.getContext());
+    patterns.add<ObjectOpInliningPattern>(classOp.getContext(), symTable);
+    patterns.add<EvaluateObjectField>(classOp.getContext(), symTable,
+                                      fieldIndexes);
+    patterns.add<UnknownPropagationPattern>(classOp.getContext());
+    GreedyRewriteConfig config;
+    // Disable iteration limit to allow full recursive inlining.
+    config.setMaxIterations(GreedyRewriteConfig::kNoLimit);
+    if (failed(applyPatternsGreedily(classOp, std::move(patterns), config)))
+      return failure();
+
+    // Check if elaboration succeeded after saturation.
+    return verifyResult(classOp);
+  }
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    auto &symTable = getAnalysis<SymbolTable>();
+
+    // Build a map from (class name, field name) to field index for all
+    // classes.
+    FieldIndex fieldIndexes;
+    for (auto classOp : module.getOps<ClassLike>()) {
+      auto name = classOp.getSymNameAttr();
+      for (auto [idx, fieldName] :
+           llvm::enumerate(classOp.getFieldNames().getAsRange<StringAttr>()))
+        fieldIndexes[{name, fieldName}] = idx;
+    }
+
+    // Test mode: elaborate all zero-argument classes.
+    if (test) {
+      for (auto classOp : module.getOps<ClassOp>())
+        if (classOp.getBodyBlock()->getNumArguments() == 0)
+          if (failed(elaborateClass(classOp, symTable, fieldIndexes)))
+            return signalPassFailure();
+      return;
+    }
+
+    // Normal mode: elaborate the specified target class.
+    auto classOp = symTable.lookup<ClassOp>(targetClass);
+    if (!classOp) {
+      emitError(module.getLoc())
+          << "target class '" << targetClass << "' was not found";
+      return signalPassFailure();
+    }
+
+    if (failed(elaborateClass(classOp, symTable, fieldIndexes)))
+      return signalPassFailure();
+  }
+};
+
+} // namespace

--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -244,6 +244,13 @@ struct ElaborateObjectPass
     return verifyResult(classOp);
   }
 
+  LogicalResult initialize(MLIRContext *context) override {
+    if (test.getValue() ^ targetClass.getValue().empty())
+      return emitError(UnknownLoc::get(context))
+             << "either 'test' or 'target-class' must be specified";
+    return success();
+  }
+
   void runOnOperation() override {
     auto module = getOperation();
     auto &symTable = getAnalysis<SymbolTable>();

--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -87,7 +87,7 @@ struct ObjectOpInliningPattern : public OpRewritePattern<ObjectOp> {
     return success();
   }
 
-  SymbolTable &symTable;
+  const SymbolTable &symTable;
 };
 
 /// Pattern to fold ObjectFieldOp on ElaboratedObjectOp by directly accessing
@@ -162,7 +162,9 @@ struct UnknownPropagationPattern : RewritePattern {
   }
 };
 
-bool isSerializable(Operation *op) {
+// Check if an operation can be evaluated at compile time and is valid to
+// remain in the IR after elaboration.
+bool isFullyEvaluated(Operation *op) {
   return isa<
       // Structure.
       ClassOp, ClassFieldsOp, ElaboratedObjectOp, AnyCastOp,
@@ -194,10 +196,11 @@ LogicalResult verifyResult(ClassOp module) {
                << assertOp.getMessage();
       };
 
+      // Condition is a constant integer/bool - check if it's true.
       if (matchPattern(assertOp.getCondition(), m_ConstantInt(&value)))
         return checkAssert(!value.isZero());
 
-      // Ok.
+      // Condition is unknown - treat as passing (best-effort verification).
       if (auto unknownOp = dyn_cast_or_null<UnknownValueOp>(defOp))
         return checkAssert(true);
 
@@ -205,7 +208,7 @@ LogicalResult verifyResult(ClassOp module) {
       return emitError(op->getLoc(), "failed to evaluate assertion condition");
     }
 
-    if (!isSerializable(op))
+    if (!isFullyEvaluated(op))
       return emitError(op->getLoc()) << "failed to evaluate " << op->getName();
 
     return success();
@@ -224,9 +227,8 @@ struct ElaborateObjectPass
                                       FieldIndex &fieldIndexes) {
     // Elaborate objects by inlining all ObjectOps and folding field accesses
     // using a greedy pattern rewriter. NOTE: The conversion framework is not
-    // suitable here because inlining
-    //       patterns need to be applied recursively to fully evaluate nested
-    //       object instantiations.
+    // suitable here because inlining patterns need to be applied recursively to
+    // fully evaluate nested object instantiations.
     RewritePatternSet patterns(classOp.getContext());
     patterns.add<ObjectOpInliningPattern>(classOp.getContext(), symTable);
     patterns.add<EvaluateObjectField>(classOp.getContext(), symTable,

--- a/test/Dialect/OM/elaborate-object-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-errors.mlir
@@ -19,7 +19,7 @@ om.class @AssertFalseBool() {
 
 // -----
 
-// Multiple assertions, one fails
+// Multiple assertions
 om.class @MultipleAsserts() {
   %false = om.constant false
   // expected-error @below {{OM property assertion failed: first assertion fails}}

--- a/test/Dialect/OM/elaborate-object-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-errors.mlir
@@ -1,16 +1,6 @@
 // RUN: circt-opt -om-elaborate-object='test=true' %s -verify-diagnostics -split-input-file
 
-om.class @AssertFalseInteger() {
-  %false = om.constant 0 : i1
-  // expected-error @below {{OM property assertion failed: test invariant must hold}}
-  om.property_assert %false, "test invariant must hold" : i1
-  om.class.fields
-}
-
-// -----
-
-// Property assertion with statically false condition (BoolAttr false)
-om.class @AssertFalseBool() {
+om.class @AssertFalse() {
   %false = om.constant false
   // expected-error @below {{OM property assertion failed: condition must be true}}
   om.property_assert %false, "condition must be true" : i1
@@ -26,6 +16,24 @@ om.class @MultipleAsserts() {
   om.property_assert %false, "first assertion fails" : i1
   // expected-error @below {{OM property assertion failed: second assertion fails}}
   om.property_assert %false, "second assertion fails" : i1
+  om.class.fields
+}
+
+// -----
+
+// Multiple assertions in nested classes
+om.class @WrapperWithAssert(%in: i1) -> (out: i1) {
+  // expected-error @below {{OM property assertion failed: wrapper assertion fails}}
+  om.property_assert %in, "wrapper assertion fails" : i1
+  om.class.fields %in : i1
+}
+
+om.class @ParentWithNestedAsserts() {
+  %false = om.constant false
+  %obj = om.object @WrapperWithAssert(%false) : (i1) -> !om.class.type<@WrapperWithAssert>
+  %result = om.object.field %obj["out"] : (!om.class.type<@WrapperWithAssert>) -> i1
+  // expected-error @below {{OM property assertion failed: parent assertion fails}}
+  om.property_assert %result, "parent assertion fails" : i1
   om.class.fields
 }
 

--- a/test/Dialect/OM/elaborate-object-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-errors.mlir
@@ -1,0 +1,60 @@
+// RUN: circt-opt -om-elaborate-object='test=true' %s -verify-diagnostics -split-input-file
+
+om.class @AssertFalseInteger() {
+  %false = om.constant 0 : i1
+  // expected-error @below {{OM property assertion failed: test invariant must hold}}
+  om.property_assert %false, "test invariant must hold" : i1
+  om.class.fields
+}
+
+// -----
+
+// Property assertion with statically false condition (BoolAttr false)
+om.class @AssertFalseBool() {
+  %false = om.constant false
+  // expected-error @below {{OM property assertion failed: condition must be true}}
+  om.property_assert %false, "condition must be true" : i1
+  om.class.fields
+}
+
+// -----
+
+// Multiple assertions, one fails
+om.class @MultipleAsserts() {
+  %false = om.constant false
+  // expected-error @below {{OM property assertion failed: first assertion fails}}
+  om.property_assert %false, "first assertion fails" : i1
+  // expected-error @below {{OM property assertion failed: second assertion fails}}
+  om.property_assert %false, "second assertion fails" : i1
+  om.class.fields
+}
+
+// -----
+
+// Complex expression resulting in false after elaboration
+om.class @ComplexExpressionFalse() {
+  %false = om.constant false
+  %obj = om.object @BoolWrapper(%false) : (i1) -> !om.class.type<@BoolWrapper>
+  %result = om.object.field %obj["out"] : (!om.class.type<@BoolWrapper>) -> i1
+  // expected-error @below {{OM property assertion failed: complex expression is false}}
+  om.property_assert %result, "complex expression is false" : i1
+  om.class.fields
+}
+
+om.class @BoolWrapper(%in: i1) -> (out: i1) {
+  om.class.fields %in : i1
+}
+
+// -----
+
+// Cycle in dataflow (field access creates a cycle that can't be evaluated)
+om.class @WrapperCycle(%val: !om.integer) -> (out: !om.integer) {
+  om.class.fields %val : !om.integer
+}
+
+om.class @DataflowCycle() -> (result: !om.integer) {
+  %obj = om.object @WrapperCycle(%feedback) : (!om.integer) -> !om.class.type<@WrapperCycle>
+  // expected-error @below {{failed to evaluate om.object.field}}
+  %feedback = om.object.field %obj["out"] : (!om.class.type<@WrapperCycle>) -> !om.integer
+  om.class.fields %feedback : !om.integer
+}

--- a/test/Dialect/OM/elaborate-object-option-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-option-errors.mlir
@@ -1,0 +1,7 @@
+// RUN: circt-opt -om-elaborate-object %s -verify-diagnostics
+// expected-error @unknown {{either 'test' or 'target-class' must be specified}}
+module {
+  om.class @SomeClass() {
+    om.class.fields
+  }
+}

--- a/test/Dialect/OM/elaborate-object.mlir
+++ b/test/Dialect/OM/elaborate-object.mlir
@@ -70,9 +70,7 @@ om.class @IntegerArithTop() -> (result: !om.integer) {
   om.class.fields %sum : !om.integer
 }
 
-
 // Test list operations with object fields
-
 om.class @ListBox(%l: !om.list<!om.integer>) -> (value: !om.list<!om.integer>) {
   om.class.fields %l : !om.list<!om.integer>
 }
@@ -114,7 +112,6 @@ om.class @AssertInteger() {
   om.property_assert %one, "one is true" : i1
   om.class.fields
 }
-
 
 // Test property assertion with unknown condition (should pass and be erased)
 // CHECK-LABEL: om.class @AssertUnknown() {

--- a/test/Dialect/OM/elaborate-object.mlir
+++ b/test/Dialect/OM/elaborate-object.mlir
@@ -1,7 +1,6 @@
 // RUN: circt-opt -om-elaborate-object='target-class=Top' %s | FileCheck %s --check-prefix=TOP
 // RUN: circt-opt -om-elaborate-object='test=true' %s | FileCheck %s --check-prefixes=TOP,CHECK
 
-// Test string operations (constant and concat - concat is folded to constant)
 // CHECK-LABEL: om.class @StringOps() -> (str: !om.string, concat: !om.string) {
 // CHECK-DAG:   %[[HELLO:.+]] = om.constant "hello" : !om.string
 // CHECK-DAG:   %[[CONCAT:.+]] = om.constant "hello world" : !om.string
@@ -14,7 +13,10 @@ om.class @StringOps() -> (str: !om.string, concat: !om.string) {
   om.class.fields %hello, %concat : !om.string, !om.string
 }
 
-// Test list creation
+// Test list creation.
+// Note that this is currently not folded because list_create doesn't have a folder.
+// Even when it had a folder we cannot fully evaluate list_concat since objects cannot be
+// representable with attributes.
 // CHECK-LABEL: om.class @SimpleList() -> (result: !om.list<!om.integer>) {
 // CHECK-DAG:   %[[C1:.+]] = om.constant #om.integer<1 : si8> : !om.integer
 // CHECK-DAG:   %[[C2:.+]] = om.constant #om.integer<2 : si8> : !om.integer
@@ -81,24 +83,18 @@ om.class @Top() -> (list: !list, head: !om.integer, tail: !list) {
 }
 
 
-// Test nested field references
-om.class @StringBox(%in: !om.string) -> (out: !om.string) {
-  om.class.fields %in : !om.string
-}
-
-// CHECK-LABEL: om.class @NestedFieldTop() -> (result: !om.string) {
-// CHECK:   %[[STR:.+]] = om.constant "A" : !om.string
-// CHECK:   om.class.fields %[[STR]] : !om.string
+// CHECK-LABEL: om.class @NestedFieldTop() -> (result: !om.integer) {
+// CHECK:   %[[V:.+]] = om.constant #om.integer<1 : i6>
+// CHECK:   om.class.fields %[[V]] : !om.integer
 // CHECK: }
-om.class @NestedFieldTop() -> (result: !om.string) {
-  %0 = om.constant "A" : !om.string
-  %1 = om.object @StringBox(%0) : (!om.string) -> !om.class.type<@StringBox>
-  %2 = om.object.field %1["out"] : (!om.class.type<@StringBox>) -> !om.string
-  %3 = om.object @StringBox(%2) : (!om.string) -> !om.class.type<@StringBox>
-  %4 = om.object.field %3["out"] : (!om.class.type<@StringBox>) -> !om.string
-  om.class.fields %4 : !om.string
+om.class @NestedFieldTop() -> (result: !om.integer) {
+  %0 = om.constant #om.integer<1 : i6> : !om.integer
+  %1 = om.object @InputBox(%0) : (!om.integer) -> !om.class.type<@InputBox>
+  %2 = om.object.field %1["value"] : (!om.class.type<@InputBox>) -> !om.integer
+  %3 = om.object @InputBox(%2) : (!om.integer) -> !om.class.type<@InputBox>
+  %4 = om.object.field %3["value"] : (!om.class.type<@InputBox>) -> !om.integer
+  om.class.fields %4 : !om.integer
 }
-
 
 // CHECK-LABEL: om.class @IntegerArithTop() -> (result: !om.integer) {
 // CHECK:   %[[RESULT:.+]] = om.constant #om.integer<3 : si3> : !om.integer

--- a/test/Dialect/OM/elaborate-object.mlir
+++ b/test/Dialect/OM/elaborate-object.mlir
@@ -1,0 +1,141 @@
+// RUN: circt-opt -om-elaborate-object='target-class=Top' %s | FileCheck %s --check-prefix=TOP
+// RUN: circt-opt -om-elaborate-object='test=true' %s | FileCheck %s --check-prefixes=TOP,CHECK
+
+!list = !om.class.type<@LinkedList>
+
+om.class @InputBox(%input: !om.integer) -> (value: !om.integer) {
+  om.class.fields %input : !om.integer
+}
+
+om.class @LinkedList(%input: !om.integer, %next: !list) -> (value: !om.integer, next: !list) {
+  %box = om.object @InputBox(%input) : (!om.integer) -> !om.class.type<@InputBox>
+  %value = om.object.field %box["value"] : (!om.class.type<@InputBox>) -> !om.integer
+  om.class.fields %value, %next : !om.integer, !list
+}
+
+// TOP-LABEL: om.class @Top() -> (list: !om.class.type<@LinkedList>, head: !om.integer, tail: !om.class.type<@LinkedList>) {
+// TOP-DAG:   %[[TWO:.+]] = om.constant #om.integer<2 : i6> : !om.integer
+// TOP-DAG:   %[[ONE:.+]] = om.constant #om.integer<1 : i6> : !om.integer
+// TOP:   %[[tail:.+]] = om.elaborated_object @LinkedList(%[[TWO]], %[[list:.+]]) : (!om.integer, !om.class.type<@LinkedList>) -> !om.class.type<@LinkedList>
+// TOP:   %[[list]] = om.elaborated_object @LinkedList(%[[ONE]], %[[tail]]) : (!om.integer, !om.class.type<@LinkedList>) -> !om.class.type<@LinkedList>
+// TOP:   om.class.fields %[[list]], %[[ONE]], %[[tail]] : !om.class.type<@LinkedList>, !om.integer, !om.class.type<@LinkedList>
+// TOP: }
+om.class @Top() -> (list: !list, head: !om.integer, tail: !list) {
+  %one = om.constant #om.integer<1 : i6> : !om.integer
+  %two = om.constant #om.integer<2 : i6> : !om.integer
+  %tail = om.object @LinkedList(%two, %list) : (!om.integer, !list) -> !list
+  %list = om.object @LinkedList(%one, %tail) : (!om.integer, !list) -> !list
+  %head = om.object.field %list["value"] : (!list) -> !om.integer
+  om.class.fields %list, %head, %tail : !list, !om.integer, !list
+}
+
+
+// Test nested field references
+om.class @Domain(%in: !om.string) -> (out: !om.string) {
+  om.class.fields %in : !om.string
+}
+
+// CHECK-LABEL: om.class @NestedFieldTop() -> (result: !om.string) {
+// CHECK:   %[[STR:.+]] = om.constant "A" : !om.string
+// CHECK:   om.class.fields %[[STR]] : !om.string
+// CHECK: }
+om.class @NestedFieldTop() -> (result: !om.string) {
+  %0 = om.constant "A" : !om.string
+  %1 = om.object @Domain(%0) : (!om.string) -> !om.class.type<@Domain>
+  %2 = om.object.field %1["out"] : (!om.class.type<@Domain>) -> !om.string
+  %3 = om.object @Domain(%2) : (!om.string) -> !om.class.type<@Domain>
+  %4 = om.object.field %3["out"] : (!om.class.type<@Domain>) -> !om.string
+  om.class.fields %4 : !om.string
+}
+
+
+// Test integer arithmetic with object field access
+om.class @ValueBox(%val: !om.integer) -> (value: !om.integer) {
+  om.class.fields %val : !om.integer
+}
+
+// CHECK-LABEL: om.class @IntegerArithTop() -> (result: !om.integer) {
+// CHECK:   %[[RESULT:.+]] = om.constant #om.integer<3 : si3> : !om.integer
+// CHECK:   om.class.fields %[[RESULT]] : !om.integer
+// CHECK: }
+
+om.class @IntegerArithTop() -> (result: !om.integer) {
+  %1 = om.constant #om.integer<1 : si3> : !om.integer
+  %2 = om.constant #om.integer<2 : si3> : !om.integer
+  %box1 = om.object @ValueBox(%1) : (!om.integer) -> !om.class.type<@ValueBox>
+  %val1 = om.object.field %box1["value"] : (!om.class.type<@ValueBox>) -> !om.integer
+  %box2 = om.object @ValueBox(%2) : (!om.integer) -> !om.class.type<@ValueBox>
+  %val2 = om.object.field %box2["value"] : (!om.class.type<@ValueBox>) -> !om.integer
+  %sum = om.integer.add %val1, %val2 : !om.integer
+  om.class.fields %sum : !om.integer
+}
+
+
+// Test list operations with object fields
+
+om.class @ListBox(%l: !om.list<!om.integer>) -> (value: !om.list<!om.integer>) {
+  om.class.fields %l : !om.list<!om.integer>
+}
+
+// CHECK-LABEL: om.class @ListConcatTop() -> (result: !om.list<!om.integer>) {
+// CHECK-DAG:   %[[ZERO:.+]] = om.constant #om.integer<0 : i8> : !om.integer
+// CHECK-DAG:   %[[ONE:.+]] = om.constant #om.integer<1 : i8> : !om.integer
+// CHECK-DAG:   %[[TWO:.+]] = om.constant #om.integer<2 : i8> : !om.integer
+// CHECK:   %[[L0:.+]] = om.list_create %[[ZERO]], %[[ONE]]
+// CHECK:   %[[L2:.+]] = om.list_create %[[TWO]]
+// CHECK:   %[[CONCAT:.+]] = om.list_concat %[[L0]], %[[L2]]
+// CHECK:   om.class.fields %[[CONCAT]] : !om.list<!om.integer>
+// CHECK: }
+om.class @ListConcatTop() -> (result: !om.list<!om.integer>) {
+  %0 = om.constant #om.integer<0 : i8> : !om.integer
+  %1 = om.constant #om.integer<1 : i8> : !om.integer
+  %2 = om.constant #om.integer<2 : i8> : !om.integer
+  %l0 = om.list_create %0, %1 : !om.integer
+  %box = om.object @ListBox(%l0) : (!om.list<!om.integer>) -> !om.class.type<@ListBox>
+  %l1 = om.object.field %box["value"] : (!om.class.type<@ListBox>) -> !om.list<!om.integer>
+  %l2 = om.list_create %2 : !om.integer
+  %concat = om.list_concat %l1, %l2 : !om.list<!om.integer>
+  om.class.fields %concat : !om.list<!om.integer>
+}
+
+// Test property assertions with true/passing conditions
+// CHECK-LABEL: om.class @AssertTrue() {
+// CHECK-NOT:   om.property_assert
+om.class @AssertTrue() {
+  %true = om.constant true
+  om.property_assert %true, "this should pass" : i1
+  om.class.fields
+}
+
+// CHECK-LABEL: om.class @AssertInteger() {
+// CHECK-NOT:   om.property_assert
+om.class @AssertInteger() {
+  %one = om.constant 1 : i1
+  om.property_assert %one, "one is true" : i1
+  om.class.fields
+}
+
+
+// Test property assertion with unknown condition (should pass and be erased)
+// CHECK-LABEL: om.class @AssertUnknown() {
+// CHECK-NOT:   om.property_assert
+om.class @AssertUnknown() {
+  %unknown = om.unknown : i1
+  om.property_assert %unknown, "unknown condition" : i1
+  om.class.fields
+}
+
+// Test external class instantiation (should be replaced with unknown)
+om.class.extern @ExternalModule(%param: !om.integer) -> (output: !om.integer) {}
+
+// CHECK-LABEL: om.class @UseExtern() -> (result: !om.integer) {
+// CHECK:   %[[UNKNOWN:.+]] = om.unknown : !om.integer
+// CHECK:   om.class.fields %[[UNKNOWN]]
+// CHECK: }
+om.class @UseExtern() -> (result: !om.integer) {
+  %input = om.constant #om.integer<42 : si64> : !om.integer
+  %ext = om.object @ExternalModule(%input) : (!om.integer) -> !om.class.type<@ExternalModule>
+  %result = om.object.field %ext["output"] : (!om.class.type<@ExternalModule>) -> !om.integer
+  om.class.fields %result : !om.integer
+}
+

--- a/test/Dialect/OM/elaborate-object.mlir
+++ b/test/Dialect/OM/elaborate-object.mlir
@@ -96,20 +96,12 @@ om.class @ListConcatTop() -> (result: !om.list<!om.integer>) {
   om.class.fields %concat : !om.list<!om.integer>
 }
 
-// Test property assertions with true/passing conditions
+// Test property assertion with true/passing condition
 // CHECK-LABEL: om.class @AssertTrue() {
 // CHECK-NOT:   om.property_assert
 om.class @AssertTrue() {
   %true = om.constant true
   om.property_assert %true, "this should pass" : i1
-  om.class.fields
-}
-
-// CHECK-LABEL: om.class @AssertInteger() {
-// CHECK-NOT:   om.property_assert
-om.class @AssertInteger() {
-  %one = om.constant 1 : i1
-  om.property_assert %one, "one is true" : i1
   om.class.fields
 }
 

--- a/test/Dialect/OM/elaborate-object.mlir
+++ b/test/Dialect/OM/elaborate-object.mlir
@@ -1,6 +1,57 @@
 // RUN: circt-opt -om-elaborate-object='target-class=Top' %s | FileCheck %s --check-prefix=TOP
 // RUN: circt-opt -om-elaborate-object='test=true' %s | FileCheck %s --check-prefixes=TOP,CHECK
 
+// Test string operations (constant and concat - concat is folded to constant)
+// CHECK-LABEL: om.class @StringOps() -> (str: !om.string, concat: !om.string) {
+// CHECK-DAG:   %[[HELLO:.+]] = om.constant "hello" : !om.string
+// CHECK-DAG:   %[[CONCAT:.+]] = om.constant "hello world" : !om.string
+// CHECK:   om.class.fields %[[HELLO]], %[[CONCAT]] : !om.string, !om.string
+// CHECK: }
+om.class @StringOps() -> (str: !om.string, concat: !om.string) {
+  %hello = om.constant "hello" : !om.string
+  %world = om.constant " world" : !om.string
+  %concat = om.string.concat %hello, %world : !om.string
+  om.class.fields %hello, %concat : !om.string, !om.string
+}
+
+// Test list creation
+// CHECK-LABEL: om.class @SimpleList() -> (result: !om.list<!om.integer>) {
+// CHECK-DAG:   %[[C1:.+]] = om.constant #om.integer<1 : si8> : !om.integer
+// CHECK-DAG:   %[[C2:.+]] = om.constant #om.integer<2 : si8> : !om.integer
+// CHECK:   %[[LIST:.+]] = om.list_create %[[C1]], %[[C2]]
+// CHECK:   om.class.fields %[[LIST]] : !om.list<!om.integer>
+// CHECK: }
+om.class @SimpleList() -> (result: !om.list<!om.integer>) {
+  %c1 = om.constant #om.integer<1 : si8> : !om.integer
+  %c2 = om.constant #om.integer<2 : si8> : !om.integer
+  %list = om.list_create %c1, %c2 : !om.integer
+  om.class.fields %list : !om.list<!om.integer>
+}
+
+// Test integer operations (add, mul, shr, shl)
+// CHECK-LABEL: om.class @IntegerOps() -> (sum: !om.integer, product: !om.integer, shr: !om.integer, shl: !om.integer) {
+// CHECK-DAG:   %[[SUM:.+]] = om.constant #om.integer<7 : si4> : !om.integer
+// CHECK-DAG:   %[[PRODUCT:.+]] = om.constant #om.integer<12 : si8> : !om.integer
+// CHECK-DAG:   %[[SHR:.+]] = om.constant #om.integer<2 : si8> : !om.integer
+// CHECK-DAG:   %[[SHL:.+]] = om.constant #om.integer<16 : si8> : !om.integer
+// CHECK:   om.class.fields %[[SUM]], %[[PRODUCT]], %[[SHR]], %[[SHL]] : !om.integer, !om.integer, !om.integer, !om.integer
+// CHECK: }
+om.class @IntegerOps() -> (sum: !om.integer, product: !om.integer, shr: !om.integer, shl: !om.integer) {
+  %c3 = om.constant #om.integer<3 : si4> : !om.integer
+  %c4 = om.constant #om.integer<4 : si4> : !om.integer
+  %sum = om.integer.add %c3, %c4 : !om.integer
+  %c3_8 = om.constant #om.integer<3 : si8> : !om.integer
+  %c4_8 = om.constant #om.integer<4 : si8> : !om.integer
+  %product = om.integer.mul %c3_8, %c4_8 : !om.integer
+  %c8 = om.constant #om.integer<8 : si8> : !om.integer
+  %c2 = om.constant #om.integer<2 : si8> : !om.integer
+  %shr_result = om.integer.shr %c8, %c2 : !om.integer
+  %shl_result = om.integer.shl %c4_8, %c2 : !om.integer
+  om.class.fields %sum, %product, %shr_result, %shl_result : !om.integer, !om.integer, !om.integer, !om.integer
+}
+
+// More complex tests
+
 !list = !om.class.type<@LinkedList>
 
 om.class @InputBox(%input: !om.integer) -> (value: !om.integer) {
@@ -31,7 +82,7 @@ om.class @Top() -> (list: !list, head: !om.integer, tail: !list) {
 
 
 // Test nested field references
-om.class @Domain(%in: !om.string) -> (out: !om.string) {
+om.class @StringBox(%in: !om.string) -> (out: !om.string) {
   om.class.fields %in : !om.string
 }
 
@@ -41,18 +92,13 @@ om.class @Domain(%in: !om.string) -> (out: !om.string) {
 // CHECK: }
 om.class @NestedFieldTop() -> (result: !om.string) {
   %0 = om.constant "A" : !om.string
-  %1 = om.object @Domain(%0) : (!om.string) -> !om.class.type<@Domain>
-  %2 = om.object.field %1["out"] : (!om.class.type<@Domain>) -> !om.string
-  %3 = om.object @Domain(%2) : (!om.string) -> !om.class.type<@Domain>
-  %4 = om.object.field %3["out"] : (!om.class.type<@Domain>) -> !om.string
+  %1 = om.object @StringBox(%0) : (!om.string) -> !om.class.type<@StringBox>
+  %2 = om.object.field %1["out"] : (!om.class.type<@StringBox>) -> !om.string
+  %3 = om.object @StringBox(%2) : (!om.string) -> !om.class.type<@StringBox>
+  %4 = om.object.field %3["out"] : (!om.class.type<@StringBox>) -> !om.string
   om.class.fields %4 : !om.string
 }
 
-
-// Test integer arithmetic with object field access
-om.class @ValueBox(%val: !om.integer) -> (value: !om.integer) {
-  om.class.fields %val : !om.integer
-}
 
 // CHECK-LABEL: om.class @IntegerArithTop() -> (result: !om.integer) {
 // CHECK:   %[[RESULT:.+]] = om.constant #om.integer<3 : si3> : !om.integer
@@ -62,38 +108,12 @@ om.class @ValueBox(%val: !om.integer) -> (value: !om.integer) {
 om.class @IntegerArithTop() -> (result: !om.integer) {
   %1 = om.constant #om.integer<1 : si3> : !om.integer
   %2 = om.constant #om.integer<2 : si3> : !om.integer
-  %box1 = om.object @ValueBox(%1) : (!om.integer) -> !om.class.type<@ValueBox>
-  %val1 = om.object.field %box1["value"] : (!om.class.type<@ValueBox>) -> !om.integer
-  %box2 = om.object @ValueBox(%2) : (!om.integer) -> !om.class.type<@ValueBox>
-  %val2 = om.object.field %box2["value"] : (!om.class.type<@ValueBox>) -> !om.integer
+  %box1 = om.object @InputBox(%1) : (!om.integer) -> !om.class.type<@InputBox>
+  %val1 = om.object.field %box1["value"] : (!om.class.type<@InputBox>) -> !om.integer
+  %box2 = om.object @InputBox(%2) : (!om.integer) -> !om.class.type<@InputBox>
+  %val2 = om.object.field %box2["value"] : (!om.class.type<@InputBox>) -> !om.integer
   %sum = om.integer.add %val1, %val2 : !om.integer
   om.class.fields %sum : !om.integer
-}
-
-// Test list operations with object fields
-om.class @ListBox(%l: !om.list<!om.integer>) -> (value: !om.list<!om.integer>) {
-  om.class.fields %l : !om.list<!om.integer>
-}
-
-// CHECK-LABEL: om.class @ListConcatTop() -> (result: !om.list<!om.integer>) {
-// CHECK-DAG:   %[[ZERO:.+]] = om.constant #om.integer<0 : i8> : !om.integer
-// CHECK-DAG:   %[[ONE:.+]] = om.constant #om.integer<1 : i8> : !om.integer
-// CHECK-DAG:   %[[TWO:.+]] = om.constant #om.integer<2 : i8> : !om.integer
-// CHECK:   %[[L0:.+]] = om.list_create %[[ZERO]], %[[ONE]]
-// CHECK:   %[[L2:.+]] = om.list_create %[[TWO]]
-// CHECK:   %[[CONCAT:.+]] = om.list_concat %[[L0]], %[[L2]]
-// CHECK:   om.class.fields %[[CONCAT]] : !om.list<!om.integer>
-// CHECK: }
-om.class @ListConcatTop() -> (result: !om.list<!om.integer>) {
-  %0 = om.constant #om.integer<0 : i8> : !om.integer
-  %1 = om.constant #om.integer<1 : i8> : !om.integer
-  %2 = om.constant #om.integer<2 : i8> : !om.integer
-  %l0 = om.list_create %0, %1 : !om.integer
-  %box = om.object @ListBox(%l0) : (!om.list<!om.integer>) -> !om.class.type<@ListBox>
-  %l1 = om.object.field %box["value"] : (!om.class.type<@ListBox>) -> !om.list<!om.integer>
-  %l2 = om.list_create %2 : !om.integer
-  %concat = om.list_concat %l1, %l2 : !om.list<!om.integer>
-  om.class.fields %concat : !om.list<!om.integer>
 }
 
 // Test property assertion with true/passing condition


### PR DESCRIPTION
Implements a new pass that performs elaboration of OM objects by inlining object instantiations and folding field accesses. The goal is to remove complicated graph reductoin in existing Evaluator implementation. In a follow up, this pass will be ran within Evaluator before exporting to shared_ptr data structure. We can remove ReferenceValue/IntegerArithmetic etc after that. 

It uses GreedyPattern rewriter because of necessity of inlining objects recursively (PartialConversion doesn't allow that). 

This PR includes object inlining, field evaluation, unknown value propagation, and assertion verification.

Scalability looks also ok. For one of the largest designs it took 3 sec to elaborate om.class with 0.3M operations. 
```
===-------------------------------------------------------------------------===
                         ... Execution time report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 31.1027 seconds

  ----Wall Time----  ----Name----
   11.2508 ( 36.2%)  Parser
    2.8139 (  9.0%)  ElaborateObject
    0.0251 (  0.1%)    (A) SymbolTable
   15.6469 ( 50.3%)  Output
    1.3911 (  4.5%)  Rest
   31.1027 (100.0%)  Total
```
AI-assisted-by: augment : sonnet-4.5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
