### PR TITLE
[FIRRTL] Include "public" in hasProperties logic

### DIFF
--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -106,7 +106,8 @@ public:
   };
 
   /// Information about a module
-  struct ModuleAttributes {
+  class ModuleAttributes {
+  public:
     /// Indicates if this module is instantiated under the design-under-test.
     InstanceInfo::LatticeValue underDut;
 
@@ -131,8 +132,23 @@ public:
     InstanceInfo::LatticeValue inInstanceChoice;
 
     /// Indicates if this module has any property operations within (or
-    /// transitively within) it.
+    /// transitively within) it, or if it is public or contains (transitively)
+    /// any public modules.
     bool hasProperties = false;
+
+    /// Return true if the product of post-order information is saturated
+    /// (cannot ever change).  This corresponds to all attributes populated
+    /// during the post-order walk are true.  This is an optimization that is
+    /// used to short circuit the walk when no more information can change.
+    bool postOrderSaturated() {
+      if (!saturated)
+        saturated = hasProperties;
+
+      return saturated;
+    }
+
+  private:
+    bool saturated = false;
   };
 
   //===--------------------------------------------------------------------===//
@@ -215,8 +231,9 @@ public:
 
   /// Return true if this module contains (or its children transitively contain)
   /// any property operations, i.e., operations whose operands or results have
-  /// a PropertyType, if any port of the module has a PropertyType, or if the
-  /// module is a class.
+  /// a PropertyType, if any port of the module has a PropertyType, if the
+  /// module is a class, or if the module is public or contains any public
+  /// modules.
   bool moduleContainsProperties(igraph::ModuleOpInterface op);
 
 private:

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -190,27 +190,36 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
     auto moduleOp = modIt.getModule();
     ModuleAttributes &attributes = moduleAttributes[moduleOp];
 
-    // Merge in attributes from children.
-    attributes
-        .hasProperties |= llvm::any_of(modIt, [&](InstanceRecord *record) {
-      return moduleAttributes[record->getTarget()->getModule()].hasProperties;
-    });
+    // Merge in attributes of instances within the module.
+    for (auto *instIt : modIt) {
+      attributes.hasProperties |=
+          moduleAttributes[instIt->getTarget()->getModule()].hasProperties;
+      if (attributes.postOrderSaturated())
+        break;
+    }
 
-    if (attributes.hasProperties)
-      return;
-
-    // Compute attributes of the module itself.
+    // Early exit if there is no body to examine or if the module cannot be
+    // public.
     auto moduleLike = modIt.getModule<FModuleLike>();
     if (!moduleLike)
       return;
 
-    // If the module is classlike consider this a "property" or if any of the
-    // ports have property type.
-    attributes.hasProperties |=
-        isa<ClassLike>(moduleLike.getOperation()) ||
-        llvm::any_of(moduleLike.getPorts(), [](PortInfo port) {
-          return isa<PropertyType>(port.type);
-        });
+    // Merge in attributes of the module.
+    attributes.hasProperties |= moduleLike.isPublic();
+
+    // If the module is classlike, it is a property.  Walk the ports and update
+    // attributes for each.
+    attributes.hasProperties |= isa<ClassLike>(moduleLike.getOperation());
+    for (auto port : moduleLike.getPorts()) {
+      attributes.hasProperties |= isa<PropertyType>(port.type);
+      if (attributes.postOrderSaturated())
+        break;
+    }
+
+    // Early exit if the attributes can no longer change.  This avoids needing
+    // to do a walk of the module body.
+    if (attributes.postOrderSaturated())
+      return;
 
     // Walk the ops to populate information, short circuiting as soon as
     // we've gathered enough information to stop the walk.  Only FModuleOp has

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -84,7 +84,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
   // CHECK:        anyInstanceInInstanceChoice: false
-  // CHECK-NEXT:   moduleContainsProperties: false
+  // CHECK-NEXT:   moduleContainsProperties: true
   firrtl.module @Foo() {
     firrtl.instance bar @Bar()
     firrtl.instance_choice qux @Qux alternatives @Platform {
@@ -118,7 +118,7 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   anyInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
   // CHECK:        anyInstanceInInstanceChoice: false
-  // CHECK-NEXT:   moduleContainsProperties: false
+  // CHECK-NEXT:   moduleContainsProperties: true
   firrtl.module @Foo() {}
 }
 
@@ -591,11 +591,11 @@ firrtl.circuit "Top" {
   // CHECK:        moduleContainsProperties: true
   firrtl.class private @EmptyClass() {}
 
-  // MemMod is a firrtl.memmodule. It has no body and its ports are not
-  // property types, so moduleContainsProperties is false.
+  // MemMod is a firrtl.memmodule.  It has no body and its ports are not
+  // property types, but it is public, so moduleContainsProperties is true.
   //
   // CHECK:      @MemMod
-  // CHECK:        moduleContainsProperties: false
+  // CHECK:        moduleContainsProperties: true
   firrtl.memmodule @MemMod(
     in W0_addr: !firrtl.uint<1>,
     in W0_en: !firrtl.uint<1>,
@@ -613,8 +613,7 @@ firrtl.circuit "Top" {
     writeLatency = 1 : ui32
   }
 
-  // Top instantiates children with properties, so moduleContainsProperties is
-  // true transitively.
+  // Top is public and instantiates children with properties.
   //
   // CHECK:      @Top
   // CHECK:        moduleContainsProperties: true
@@ -631,3 +630,4 @@ firrtl.circuit "Top" {
     )
   }
 }
+


### PR DESCRIPTION
Change the logic when computing `hasProperties` in FIRRTL's instance info
analysis to include if the module or its children are public.  A public
module always gets a class and needs to be instantiated.  This is building
towards a fix in `LowerClasses` to use this and `LowerClasses` already
uses the publicness of modules or its children.  This will avoid needing
to special case this in `LowerClasses`.

Assisted-by: pi.dev:claude-opus-4-7
