### PR TITLE
[CI] Run integration tests in Clang as well

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -164,14 +164,14 @@ jobs:
               "cmake_c_compiler": "gcc"
             },
             {
-              "name": "Linux (Clang) Test w/ Reverse Iteration",
+              "name": "Linux (Clang) Integration w/ Reverse Iteration",
               "install_target": "",
               "package_name_prefix": "",
               "cmake_build_type": "release",
               "llvm_enable_assertions": "OFF",
               "build_shared_libs": "OFF",
               "run_tests": true,
-              "run_integration_tests": false,
+              "run_integration_tests": true,
               "runner": "ubuntu-24.04",
               "cmake_c_compiler": "clang",
               "extra_cmake_args": "-DLLVM_ENABLE_REVERSE_ITERATION=ON"


### PR DESCRIPTION
This enables integration tests for Clang in pre-merge builds as well. My primary motivation was to test LLVM_ENABLE_REVERSE_ITERATION during pre-merge, which requires both integration tests to run. I don't see any significant downside to enabling these for Clang.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
