### PR TITLE
[CI] Enable macos wheel building

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -50,11 +50,11 @@ jobs:
             else
               os="ubuntu-22.04"
             fi
-            matrix='{
-              "config": [
-                {"os":"${{ os }}","cibw_build":"${{ cibw_build }}"}
-             ]
-            }'
+            matrix="{
+              \"config\": [
+                {\"os\":\"$os\",\"cibw_build\":\"$cibw_build\"}
+              ]
+            }"
           fi
           {
             echo "matrix<<EOF"

--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -127,16 +127,6 @@ jobs:
         run: ls -laR
         working-directory: ./wheelhouse/
 
-      - name: Remove macOS wheels before PyPI upload
-        # macOS wheels are still kept as GitHub artifacts (uploaded above), but
-        # are intentionally not published to PyPI.
-        run: |
-          shopt -s nullglob
-          for f in wheelhouse/*macosx*.whl; do
-            echo "Skipping macOS wheel for PyPI: $f"
-            rm -f "$f"
-          done
-
       - name: Upload wheels to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -19,6 +19,8 @@ on:
           - cp310-manylinux_x86_64
           - cp313-manylinux_x86_64
           - cp314-manylinux_x86_64
+          - cp313-macosx_arm64
+          - cp314-macosx_arm64
 
 jobs:
   select_matrix:
@@ -36,15 +38,23 @@ jobs:
               "config": [
                 {"os":"ubuntu-22.04","cibw_build":"cp310-manylinux_x86_64"},
                 {"os":"ubuntu-22.04","cibw_build":"cp313-manylinux_x86_64"},
-                {"os":"ubuntu-22.04","cibw_build":"cp314-manylinux_x86_64"}
+                {"os":"ubuntu-22.04","cibw_build":"cp314-manylinux_x86_64"},
+                {"os":"macos-14","cibw_build":"cp313-macosx_arm64"},
+                {"os":"macos-14","cibw_build":"cp314-macosx_arm64"}
               ]
             }'
           else
-            matrix='{
-              "config": [
-                {"os":"ubuntu-22.04","cibw_build":"${{ inputs.cibw-build }}"}
+            cibw_build="${{ inputs.cibw-build }}"
+            if [[ "$cibw_build" == *"macosx_arm64" ]]; then
+              os="macos-14"
+            else
+              os="ubuntu-22.04"
+            fi
+            matrix="{
+              \"config\": [
+                {\"os\":\"$os\",\"cibw_build\":\"$cibw_build\"}
               ]
-            }'
+            }"
           fi
           {
             echo "matrix<<EOF"
@@ -83,6 +93,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.config.cibw_build }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD_FRONTEND: build
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14.0
           SETUPTOOLS_SCM_DEBUG: True
 
       - name: Upload (stage) wheels as artifacts
@@ -115,6 +126,16 @@ jobs:
       - name: List downloaded wheels
         run: ls -laR
         working-directory: ./wheelhouse/
+
+      - name: Remove macOS wheels before PyPI upload
+        # macOS wheels are still kept as GitHub artifacts (uploaded above), but
+        # are intentionally not published to PyPI.
+        run: |
+          shopt -s nullglob
+          for f in wheelhouse/*macosx*.whl; do
+            echo "Skipping macOS wheel for PyPI: $f"
+            rm -f "$f"
+          done
 
       - name: Upload wheels to pypi
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -50,11 +50,11 @@ jobs:
             else
               os="ubuntu-22.04"
             fi
-            matrix="{
-              \"config\": [
-                {\"os\":\"$os\",\"cibw_build\":\"$cibw_build\"}
-              ]
-            }"
+            matrix='{
+              "config": [
+                {"os":"${{ os }}","cibw_build":"${{ cibw_build }}"}
+             ]
+            }'
           fi
           {
             echo "matrix<<EOF"


### PR DESCRIPTION
@mikeurbach told me on discord that macos wheels were disabled because PyPI storage ran out, and there's little interest from others. This pr re-enables generation of wheels for macos, but shouldn't push them to PyPI.
I tested things a little on my fork: https://github.com/jumerckx/circt/pull/2 (there are also some changes to esiruntime before I realized I only want the circt wheels.)
For now the wheels for macos are only built for arm macs with relatively recent python versions (>= 3.13).  

Assisted-by: AMP
