### PR TITLE
[PyCDE][ESI] Fix ListWindowTo* for zero width list types

### DIFF
--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -1269,16 +1269,23 @@ def ListWindowToParallel(serial_window_type: Window):
   # be exactly one list field.
   static_field_names: List[str] = []
   list_field_name: Optional[str] = None
+  list_element_type: Optional[Type] = None
   for name, ftype in into_type.fields:
     if isinstance(ftype, ListType):
       if list_field_name is not None:
         raise ValueError("ListWindowToParallel requires exactly one list field")
       list_field_name = name
+      list_element_type = ftype.element_type
     else:
       static_field_names.append(name)
   if list_field_name is None:
     raise ValueError("ListWindowToParallel requires exactly one list field")
   count_field_name = f"{list_field_name}_count"
+  # Per the ESI spec, list types of zero bitwidth are supported (so callers
+  # need not special-case). With zero-width data, the per-item buffer
+  # register and forward/buffer mux are skipped: there is nothing to
+  # store or select between, and seq.CompReg disallows zero-width types.
+  data_is_zero = list_element_type.bitwidth == 0
 
   # The serial window must have exactly two frames: a header frame followed
   # by a data frame. The frame names are captured here (rather than hardcoded)
@@ -1469,19 +1476,24 @@ def ListWindowToParallel(serial_window_type: Window):
       # ----- Buffered item -----
       # Latch the last data item of a burst into a register before peeking
       # the next header. Gated by serial_xact so a back-pressured beat is
-      # only latched once.
+      # only latched once. With zero-width data there is nothing to
+      # buffer (and seq.CompReg rejects zero-width types), so out_item
+      # just forwards the (zero-width) data_item in every state.
       data_item = data_struct[list_field_name][0]
       consume_burst_last = in_emit & is_last_of_burst & serial_valid
-      buf_item = data_item.reg(ports.clk,
-                               ports.rst,
-                               ce=consume_burst_last,
-                               name="buf_item")
+      if data_is_zero:
+        out_item = data_item
+      else:
+        buf_item = data_item.reg(ports.clk,
+                                 ports.rst,
+                                 ce=consume_burst_last,
+                                 name="buf_item")
 
-      # ----- Parallel output construction -----
-      # In S_EMIT we forward the live data_item; in S_EMIT_BUF we emit the
-      # buffered item. `last` is only ever set in S_EMIT_BUF, and only when
-      # the header just consumed by S_PEEK had count==0.
-      out_item = Mux(in_emit_buf, data_item, buf_item)
+        # ----- Parallel output construction -----
+        # In S_EMIT we forward the live data_item; in S_EMIT_BUF we emit the
+        # buffered item. `last` is only ever set in S_EMIT_BUF, and only when
+        # the header just consumed by S_PEEK had count==0.
+        out_item = Mux(in_emit_buf, data_item, buf_item)
       out_last = in_emit_buf & (cur_count == zero)
 
       parallel_fields = {name: static_regs[name] for name in static_field_names}
@@ -1655,8 +1667,13 @@ def ListWindowToSerial(parallel_window_type: Window,
   header_struct_type = serial_variants["header"]
   data_struct_type = serial_variants["data"]
 
-  # The data FIFO carries one list element per slot.
+  # The data FIFO carries one list element per slot. When the element type
+  # has zero bitwidth (per the ESI spec, supported to avoid special-casing
+  # callers), the FIFO is omitted entirely: SeqFIFO disallows zero-bitwidth
+  # types, and there is nothing to actually store -- only the per-burst
+  # item count carried in the metadata FIFO matters.
   data_elem_type = list_element_type
+  data_is_zero = data_elem_type.bitwidth == 0
 
   # Burst-count counter width: must hold values 0..fifo_depth.
   bc_bitwidth = max(1, (fifo_depth + 1).bit_length())
@@ -1699,7 +1716,8 @@ def ListWindowToSerial(parallel_window_type: Window,
       par_last = par_struct["last"]
       par_item = par_struct[list_field_name]
 
-      data_fifo = SeqFIFO(data_elem_type, fifo_depth, ports.clk, ports.rst)
+      data_fifo = (None if data_is_zero else SeqFIFO(data_elem_type, fifo_depth,
+                                                     ports.clk, ports.rst))
       meta_fifo = SeqFIFO(meta_entry_type, meta_fifo_depth, ports.clk,
                           ports.rst)
 
@@ -1707,12 +1725,17 @@ def ListWindowToSerial(parallel_window_type: Window,
       # may happen on any par_xact, and computing whether one is needed
       # this cycle would require par_xact -> par_ready -> par_xact comb
       # loop). The slight throughput penalty is acceptable since meta_fifo
-      # drains at the bulk-transfer rate.
-      par_ready_wire.assign(~data_fifo.full & ~meta_fifo.full)
+      # drains at the bulk-transfer rate. With no data FIFO (zero-width
+      # elements), only meta_fifo backpressures.
+      if data_is_zero:
+        par_ready_wire.assign(~meta_fifo.full)
+      else:
+        par_ready_wire.assign(~data_fifo.full & ~meta_fifo.full)
       par_xact = par_valid & par_ready_wire
       par_xact_last = par_xact & par_last
 
-      data_fifo.push(par_item, par_xact)
+      if not data_is_zero:
+        data_fifo.push(par_item, par_xact)
 
       # Track whether we're currently mid-list (i.e. have seen at least one
       # item of the current list but not yet its `last`). `at_list_start`
@@ -1853,15 +1876,22 @@ def ListWindowToSerial(parallel_window_type: Window,
                       UInt(count_bitwidth)(1)).as_uint(count_bitwidth)
       last_item_in_burst = next_emitted == cur_count
 
-      # Data FIFO pop.
-      data_pop_rden = Wire(Bits(1))
-      data_value = data_fifo.pop(data_pop_rden)
-      data_valid = ~data_fifo.empty
+      # Data FIFO pop. With no data FIFO (zero-width elements), there is
+      # nothing to pop or wait on: data_value is a constant zero-width
+      # struct, and data_valid is unconditionally true.
+      if data_is_zero:
+        data_pop_rden = None
+        data_struct_value = Bits(0)(0).bitcast(data_struct_type)
+        data_valid = Bits(1)(1)
+      else:
+        data_pop_rden = Wire(Bits(1))
+        data_value = data_fifo.pop(data_pop_rden)
+        data_struct_value = data_struct_type({list_field_name: [data_value]})
+        data_valid = ~data_fifo.empty
 
       # Output union variants.
       header_union = serial_lowered(("header", cur_hdr))
       footer_union = serial_lowered(("header", footer_value))
-      data_struct_value = data_struct_type({list_field_name: [data_value]})
       data_union = serial_lowered(("data", data_struct_value))
 
       # Mux the union by current state. The S_IDLE slot is don't-care
@@ -1884,7 +1914,8 @@ def ListWindowToSerial(parallel_window_type: Window,
       data_xact = in_data & data_valid & out_ready
       burst_done = data_xact & last_item_in_burst
       footer_xact = in_footer & out_ready
-      data_pop_rden.assign(data_xact)
+      if not data_is_zero:
+        data_pop_rden.assign(data_xact)
 
       # Emitted-counter: clear at burst_done, increment on every other
       # data xact. Counter.clear takes precedence over .increment.

--- a/frontends/PyCDE/src/pycde/seq.py
+++ b/frontends/PyCDE/src/pycde/seq.py
@@ -19,6 +19,10 @@ class FIFO:
                clk: ClockSignal,
                rst: BitsSignal,
                rd_latency: int = 0):
+    if type.bitwidth is None:
+      raise ValueError("FIFO type must have a defined bitwidth")
+    if type.bitwidth == 0:
+      raise ValueError("FIFO type must have a non-zero bitwidth")
     self.type = type
     self.input = Wire(type)
     self.wr_en = Wire(Bits(1))

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -533,12 +533,11 @@ class TestListWindowToParallel(Module):
   @generator
   def build(self):
     to_parallel = ListWindowToParallel(
-        Window.serial_of(TestListWindowToParallel.into_type,
-                         TestListWindowToParallel.data_count_width,
-                         TestListWindowToParallel.items_per_frame))(
-                             clk=self.clk,
-                             rst=self.rst,
-                             serial_in=self.serial_lst_in)
+        TestListWindowToParallel.into_type,
+        TestListWindowToParallel.data_count_width,
+        TestListWindowToParallel.items_per_frame)(clk=self.clk,
+                                                  rst=self.rst,
+                                                  serial_in=self.serial_lst_in)
     self.parallel_lst_out = to_parallel.parallel_out
 
 
@@ -560,11 +559,11 @@ class TestListWindowToSerial(Module):
 
   @generator
   def build(self):
-    to_serial = ListWindowToSerial(
-        Window.default_of(TestListWindowToSerial.into_type),
-        TestListWindowToSerial.data_count_width,
-        TestListWindowToSerial.items_per_frame,
-        TestListWindowToSerial.fifo_depth)(clk=self.clk,
-                                           rst=self.rst,
-                                           parallel_in=self.parallel_lst_in)
+    to_serial = ListWindowToSerial(TestListWindowToSerial.into_type,
+                                   TestListWindowToSerial.data_count_width,
+                                   TestListWindowToSerial.items_per_frame,
+                                   TestListWindowToSerial.fifo_depth)(
+                                       clk=self.clk,
+                                       rst=self.rst,
+                                       parallel_in=self.parallel_lst_in)
     self.serial_lst_out = to_serial.serial_out

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -515,6 +515,13 @@ class TestBundleTransformBasic(Module):
     self.bundle_out = transformed_bundle
 
 
+# CHECK-LABEL: hw.module @ListWindowToParallel_{{.*}}esi_list_i8{{.*}}(in %clk : !seq.clock, in %rst : i1, in %serial_in :
+# Non-zero-width data: the per-item buffer register and forward/buffer mux
+# are present.
+# CHECK:         %buf_item = seq.compreg.ce sym @buf_item %{{.+}}, %clk, %{{.+}} reset %rst, %{{.+}} : i8
+# CHECK:         comb.mux bin %{{.+}}, %buf_item, %{{.+}} {{.+}} : i8
+# CHECK:         hw.instance "Counter" sym @Counter @Counter_width8
+# CHECK:         %state = seq.compreg sym @state %{{.+}}, %clk reset %rst, %{{.+}} : i2
 @unittestmodule()
 class TestListWindowToParallel(Module):
   """Test transforming a list window to parallel channels."""
@@ -533,14 +540,22 @@ class TestListWindowToParallel(Module):
   @generator
   def build(self):
     to_parallel = ListWindowToParallel(
-        TestListWindowToParallel.into_type,
-        TestListWindowToParallel.data_count_width,
-        TestListWindowToParallel.items_per_frame)(clk=self.clk,
-                                                  rst=self.rst,
-                                                  serial_in=self.serial_lst_in)
+        Window.serial_of(TestListWindowToParallel.into_type,
+                         TestListWindowToParallel.data_count_width,
+                         TestListWindowToParallel.items_per_frame))(
+                             clk=self.clk,
+                             rst=self.rst,
+                             serial_in=self.serial_lst_in)
     self.parallel_lst_out = to_parallel.parallel_out
 
 
+# CHECK-LABEL: hw.module @ListWindowToSerial_{{.*}}esi_list_i8{{.*}}(in %clk : !seq.clock, in %rst : i1, in %parallel_in :
+# Non-zero-width data: a data FIFO of element type i8 is instantiated in
+# addition to the metadata FIFO.
+# CHECK:         seq.fifo depth 8 {{.+}} : i8
+# CHECK:         seq.fifo depth 2 {{.+}} : !hw.struct<hdr:
+# CHECK:         hw.instance "in_list" sym @in_list @ControlReg_num_asserts1_num_resets1
+# CHECK:         %state = seq.compreg sym @state %{{.+}}, %clk reset %rst, %{{.+}} : i2
 @unittestmodule()
 class TestListWindowToSerial(Module):
   """Test transforming parallel channels into a serial list window."""
@@ -559,11 +574,86 @@ class TestListWindowToSerial(Module):
 
   @generator
   def build(self):
-    to_serial = ListWindowToSerial(TestListWindowToSerial.into_type,
-                                   TestListWindowToSerial.data_count_width,
-                                   TestListWindowToSerial.items_per_frame,
-                                   TestListWindowToSerial.fifo_depth)(
-                                       clk=self.clk,
-                                       rst=self.rst,
-                                       parallel_in=self.parallel_lst_in)
+    to_serial = ListWindowToSerial(
+        Window.default_of(TestListWindowToSerial.into_type),
+        TestListWindowToSerial.data_count_width,
+        TestListWindowToSerial.items_per_frame,
+        TestListWindowToSerial.fifo_depth)(clk=self.clk,
+                                           rst=self.rst,
+                                           parallel_in=self.parallel_lst_in)
+    self.serial_lst_out = to_serial.serial_out
+
+
+# Verify ListWindowToParallel/Serial accept list element types of zero
+# bitwidth. With zero-width data the per-item buffer register and data FIFO
+# are skipped (seq.CompReg / SeqFIFO disallow zero-width types), but the
+# modules still elaborate with the same external signatures.
+# CHECK-LABEL: hw.module @ListWindowToParallel_{{.*}}esi_list_i0{{.*}}(in %clk : !seq.clock, in %rst : i1, in %serial_in :
+# Zero-width data: the per-item buffer register is omitted and the data
+# item is forwarded directly into the output struct.
+# CHECK-NOT:     @buf_item
+# CHECK:         hw.struct_create (%{{.+}}, %{{.+}}, %{{.+}}) : !hw.struct<header: i4, data: i0, last: i1>
+# CHECK:         hw.instance "Counter" sym @Counter @Counter_width8
+# CHECK-NOT:     @buf_item
+# CHECK:         %state = seq.compreg sym @state %{{.+}}, %clk reset %rst, %{{.+}} : i2
+@unittestmodule()
+class TestListWindowToParallelZeroWidth(Module):
+  """Test transforming a zero-bitwidth list window to parallel channels."""
+
+  clk = Clock()
+  rst = Reset()
+
+  into_type = StructType({'header': Bits(4), 'data': List(Bits(0))})
+  data_count_width = 8
+  items_per_frame = 1
+
+  serial_lst_in = InputChannel(
+      Window.serial_of(into_type, data_count_width, items_per_frame))
+  parallel_lst_out = OutputChannel(Window.default_of(into_type))
+
+  @generator
+  def build(self):
+    to_parallel = ListWindowToParallel(
+        Window.serial_of(TestListWindowToParallelZeroWidth.into_type,
+                         TestListWindowToParallelZeroWidth.data_count_width,
+                         TestListWindowToParallelZeroWidth.items_per_frame))(
+                             clk=self.clk,
+                             rst=self.rst,
+                             serial_in=self.serial_lst_in)
+    self.parallel_lst_out = to_parallel.parallel_out
+
+
+# CHECK-LABEL: hw.module @ListWindowToSerial_{{.*}}esi_list_i0{{.*}}(in %clk : !seq.clock, in %rst : i1, in %parallel_in :
+# Zero-width data: only the metadata FIFO is instantiated; no data FIFO.
+# CHECK-NOT:     seq.fifo {{.+}} : i0
+# CHECK:         seq.fifo depth 2 {{.+}} : !hw.struct<hdr:
+# CHECK-NOT:     seq.fifo {{.+}} : i0
+# CHECK:         hw.instance "in_list" sym @in_list @ControlReg_num_asserts1_num_resets1
+# CHECK-NOT:     seq.fifo {{.+}} : i0
+# CHECK:         %state = seq.compreg sym @state %{{.+}}, %clk reset %rst, %{{.+}} : i2
+@unittestmodule()
+class TestListWindowToSerialZeroWidth(Module):
+  """Test transforming zero-bitwidth parallel channels into a serial list
+  window."""
+
+  clk = Clock()
+  rst = Reset()
+
+  into_type = StructType({'header': Bits(4), 'data': List(Bits(0))})
+  data_count_width = 8
+  items_per_frame = 1
+  fifo_depth = 8
+
+  parallel_lst_in = InputChannel(Window.default_of(into_type))
+  serial_lst_out = OutputChannel(
+      Window.serial_of(into_type, data_count_width, items_per_frame))
+
+  @generator
+  def build(self):
+    to_serial = ListWindowToSerial(
+        Window.default_of(TestListWindowToSerialZeroWidth.into_type),
+        TestListWindowToSerialZeroWidth.data_count_width,
+        TestListWindowToSerialZeroWidth.items_per_frame,
+        TestListWindowToSerialZeroWidth.fifo_depth)(
+            clk=self.clk, rst=self.rst, parallel_in=self.parallel_lst_in)
     self.serial_lst_out = to_serial.serial_out

--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -540,6 +540,11 @@ def WindowFieldType : ESI_Type<"WindowField"> {
       the last transfer, the header should set the count to zero. This method
       allows for efficient transfers over serial links (no 'last' or '_size'
       fields) without requiring knowledge of the total list size up front.
+
+    Note: list types with zero bitwidth are supported merely so one does not
+    have to special case elsewhere. It is not recommended to actually use them
+    as there is no special casing here either: in the serial encoding, N data
+    frames will still be transmitted!
   }];
   let mnemonic = "window.field";
 


### PR DESCRIPTION
Add support for zero bitwidth list element types. Avoids clients having to special case this. Also adds checks on SeqFIFO.

Assisted-by: vscode:Claude Opus 4.7

