### PR TITLE
[Moore][ImportVerilog] Preserve class virtual and override attributes

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3224,11 +3224,25 @@ def ClassMethodDeclOp
   let summary = "Declare a class method";
   let arguments = (ins SymbolNameAttr:$sym_name,
       TypeAttrOf<FunctionType>:$function_type,
-      OptionalAttr<SymbolRefAttr>:$impl);
+      OptionalAttr<SymbolRefAttr>:$impl,
+      OptionalAttr<UnitAttr>:$is_virtual);
   let results = (outs);
   let assemblyFormat = [{
       $sym_name (`->` $impl^)? `:` $function_type attr-dict
   }];
+  // Legacy builder: (sym_name, function_type, impl).
+  // ImportVerilog call sites use this 3-arg form.
+  let builders = [
+    OpBuilder<(ins "::llvm::StringRef":$sym_name,
+                   "::mlir::FunctionType":$function_type,
+                   "::mlir::SymbolRefAttr":$impl), [{
+      build($_builder, $_state,
+            $_builder.getStringAttr(sym_name),
+            ::mlir::TypeAttr::get(function_type),
+            impl,
+            /*is_virtual=*/::mlir::UnitAttr());
+    }]>
+  ];
 }
 
 def ClassDeclOp

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3225,7 +3225,8 @@ def ClassMethodDeclOp
   let arguments = (ins SymbolNameAttr:$sym_name,
       TypeAttrOf<FunctionType>:$function_type,
       OptionalAttr<SymbolRefAttr>:$impl,
-      OptionalAttr<UnitAttr>:$is_virtual);
+      OptionalAttr<UnitAttr>:$is_virtual,
+      OptionalAttr<UnitAttr>:$is_override);
   let results = (outs);
   let assemblyFormat = [{
       $sym_name (`->` $impl^)? `:` $function_type attr-dict
@@ -3240,7 +3241,8 @@ def ClassMethodDeclOp
             $_builder.getStringAttr(sym_name),
             ::mlir::TypeAttr::get(function_type),
             impl,
-            /*is_virtual=*/::mlir::UnitAttr());
+            /*is_virtual=*/::mlir::UnitAttr(),
+            /*is_override=*/::mlir::UnitAttr());
     }]>
   ];
 }
@@ -3251,7 +3253,8 @@ def ClassDeclOp
   let summary = "Class declaration";
   let arguments = (ins SymbolNameAttr:$sym_name,
       OptionalAttr<SymbolRefAttr>:$base,
-      OptionalAttr<SymbolRefArrayAttr>:$implementedInterfaces);
+      OptionalAttr<SymbolRefArrayAttr>:$implementedInterfaces,
+      OptionalAttr<UnitAttr>:$is_virtual);
   let results = (outs);
   let regions = (region AnyRegion:$body);
   let assemblyFormat = [{
@@ -3261,6 +3264,15 @@ def ClassDeclOp
     attr-dict-with-keyword $body
   }];
   let hasVerifier = 1;
+  // Legacy builder: (builder, loc, sym_name, base, implementedInterfaces).
+  let builders = [
+    OpBuilder<(ins "::mlir::StringAttr":$sym_name,
+                   "::mlir::SymbolRefAttr":$base,
+                   "::mlir::ArrayAttr":$implementedInterfaces), [{
+      build($_builder, $_state, sym_name, base, implementedInterfaces,
+            /*is_virtual=*/::mlir::UnitAttr());
+    }]>
+  ];
 }
 
 def ClassNewOp

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -2325,7 +2325,10 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
         return failure();
       }
 
-      moore::ClassMethodDeclOp::create(builder, loc, fn.name, funcTy, nullptr);
+      auto pureMethodOp = moore::ClassMethodDeclOp::create(
+          builder, loc, fn.name, funcTy, nullptr);
+      if (isVirtual)
+        pureMethodOp.setIsVirtualAttr(isVirtual);
       return success();
     }
 
@@ -2340,9 +2343,10 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
     // Grab the function type from the declaration.
     FunctionType fnTy = cast<FunctionType>(lowering->op.getFunctionType());
     // Emit the method decl into the class body, preserving source order.
-    moore::ClassMethodDeclOp::create(
+    auto methodDeclOp = moore::ClassMethodDeclOp::create(
         builder, loc, fn.name, fnTy,
         SymbolRefAttr::get(lowering->op.getNameAttr()));
+    methodDeclOp.setIsVirtualAttr(isVirtual);
 
     return success();
   }

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -2305,6 +2305,7 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
         (fn.flags & slang::ast::MethodFlags::Virtual)
             ? UnitAttr::get(context.getContext())
             : nullptr;
+    const bool isOverride = fn.getOverride() != nullptr;
 
     auto loc = convertLocation(fn.location);
     // Pure virtual functions regulate inheritance rules during parsing.
@@ -2329,6 +2330,8 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
           builder, loc, fn.name, funcTy, nullptr);
       if (isVirtual)
         pureMethodOp.setIsVirtualAttr(isVirtual);
+      if (isOverride)
+        pureMethodOp.setIsOverrideAttr(builder.getUnitAttr());
       return success();
     }
 
@@ -2336,8 +2339,8 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
     if (!lowering)
       return failure();
 
-    // We only emit methoddecls for virtual methods.
-    if (!isVirtual)
+    // We only emit methoddecls for virtual methods or overrides.
+    if (!isVirtual && !isOverride)
       return success();
 
     // Grab the function type from the declaration.
@@ -2346,7 +2349,10 @@ struct ClassMethodVisitor : ClassDeclVisitorBase {
     auto methodDeclOp = moore::ClassMethodDeclOp::create(
         builder, loc, fn.name, fnTy,
         SymbolRefAttr::get(lowering->op.getNameAttr()));
-    methodDeclOp.setIsVirtualAttr(isVirtual);
+    if (isVirtual)
+      methodDeclOp.setIsVirtualAttr(isVirtual);
+    if (isOverride)
+      methodDeclOp.setIsOverrideAttr(builder.getUnitAttr());
 
     return success();
   }
@@ -2419,6 +2425,8 @@ ClassLowering *Context::declareClass(const slang::ast::ClassType &cls) {
   auto [base, impls] = buildBaseAndImplementsAttrs(*this, cls);
   auto classDeclOp =
       moore::ClassDeclOp::create(builder, loc, symName, base, impls);
+  if (cls.isAbstract)
+    classDeclOp.setIsVirtualAttr(builder.getUnitAttr());
 
   SymbolTable::setSymbolVisibility(classDeclOp,
                                    SymbolTable::Visibility::Public);

--- a/test/Conversion/ImportVerilog/classes-attributes.sv
+++ b/test/Conversion/ImportVerilog/classes-attributes.sv
@@ -1,0 +1,35 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+
+// Verifies Moore class attributes populated from slang:
+//   * ClassMethodDeclOp.is_virtual from MethodFlags::Virtual
+//   * ClassMethodDeclOp.is_override from SubroutineSymbol::getOverride()
+//   * ClassDeclOp.is_virtual from ClassType::isAbstract
+
+class BaseComponent;
+  virtual function void build_phase();
+  endfunction
+endclass
+
+class DerivedComponent extends BaseComponent;
+  function void build_phase();
+  endfunction
+endclass
+
+virtual class AbstractComponent;
+  pure virtual function void abstract_method();
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @BaseComponent
+// CHECK: moore.class.methoddecl @build_phase
+// CHECK-SAME: is_virtual
+
+// CHECK-LABEL: moore.class.classdecl @DerivedComponent
+// CHECK: moore.class.methoddecl @build_phase
+// CHECK-SAME: is_override
+
+// CHECK-LABEL: moore.class.classdecl @AbstractComponent
+// CHECK-SAME: is_virtual
+// CHECK: moore.class.methoddecl @abstract_method
+// CHECK-SAME: is_virtual


### PR DESCRIPTION
## Summary

Add Moore attributes that preserve SystemVerilog class polymorphism information
from the slang frontend:

- `moore.class.methoddecl` now has optional `is_virtual` and `is_override`
  unit attributes.
- `moore.class.classdecl` now has an optional `is_virtual` unit attribute for
  virtual classes.
- ImportVerilog sets these attributes from slang's class and subroutine
  metadata.

The new `test/Conversion/ImportVerilog/classes-attributes.sv` lit test covers
virtual methods, override methods, and virtual classes.

## Details

`ClassMethodDeclOp.is_virtual` is set when slang reports
`MethodFlags::Virtual`. `ClassMethodDeclOp.is_override` is set when slang
resolves an override through `SubroutineSymbol::getOverride()`. Override method
declarations are emitted even when the derived method source does not repeat
the `virtual` keyword, since the override relationship is resolved through the
base method.

`ClassDeclOp.is_virtual` is set when slang marks the class type abstract, which
corresponds to a SystemVerilog virtual class.

Legacy builders keep source compatibility by forwarding empty unit attributes
for the new optional arguments.

## Testing

Built locally with the slang frontend enabled against a local slang source
checkout:

```sh
cmake -G Ninja <llvm-project>/llvm \
  -B <build-dir> \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DLLVM_ENABLE_ASSERTIONS=ON \
  -DLLVM_TARGETS_TO_BUILD=host \
  -DLLVM_ENABLE_PROJECTS=mlir \
  -DLLVM_EXTERNAL_PROJECTS=circt \
  -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=<circt-source-dir> \
  -DLLVM_ENABLE_LLD=OFF \
  -DCIRCT_SLANG_FRONTEND_ENABLED=ON \
  -DCIRCT_SLANG_BUILD_FROM_SOURCE=ON \
  -DFETCHCONTENT_SOURCE_DIR_SLANG=<slang-source-dir>
```

```sh
ninja -C <build-dir> \
  MLIRMooreIncGen CIRCTImportVerilog circt-translate circt-verilog
```

```sh
ninja -C <build-dir> FileCheck count not llvm-config
```

```sh
env PYTHONPATH=<llvm-project>/llvm/utils/lit \
  PATH=<build-dir>/bin:$PATH \
  python3 <llvm-project>/llvm/utils/lit/lit.py -sv \
  --filter='Conversion/ImportVerilog/classes-attributes.sv' \
  <build-dir>/tools/circt/test
```

Result: `Passed: 1`.
