### PR TITLE
[Synth][CutRewriter] Include constant in truth table computation

### DIFF
--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -314,9 +314,10 @@ FailureOr<BinaryTruthTable> circt::synth::getTruthTable(ValueRange values,
     eval[inputArgs[i]] = circt::createVarMask(numInputs, i, true);
 
   // Simulate the operations in the block
-  for (Operation &op : *block) {
-    if (op.getNumResults() == 0)
-      continue;
+  for (Operation &op : block->without_terminator()) {
+    if (op.getNumResults() != 1 ||
+        hw::getBitWidth(op.getResult(0).getType()) != 1)
+      return op.emitError("Unsupported operation for truth table simulation");
 
     if (auto choiceOp = dyn_cast<synth::ChoiceOp>(&op)) {
       auto it = eval.find(choiceOp.getInputs().front());
@@ -345,7 +346,12 @@ FailureOr<BinaryTruthTable> circt::synth::getTruthTable(ValueRange values,
         result ^= it->second;
       }
       eval[xorOp.getResult()] = result;
-    } else if (!isa<hw::OutputOp>(&op)) {
+    } else if (auto constantOp = dyn_cast<hw::ConstantOp>(&op)) {
+      auto tableSize = 1ULL << numInputs;
+      eval[constantOp.getResult()] = constantOp.getValue().isZero()
+                                         ? llvm::APInt::getZero(tableSize)
+                                         : llvm::APInt::getAllOnes(tableSize);
+    } else {
       return op.emitError("Unsupported operation for truth table simulation");
     }
   }

--- a/test/Dialect/Synth/tech-mapper-error.mlir
+++ b/test/Dialect/Synth/tech-mapper-error.mlir
@@ -43,6 +43,16 @@ hw.module @multibit(in %a : i1, in %b: i1, out result : i2) attributes {hw.techl
 
 hw.module @multibit(in %a : i1, in %b: i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2]]}} {
   // expected-error@+1 {{Unsupported operation for truth table simulation}}
+  %0 = hw.constant 1 : i2
+  %1 = comb.extract %0 from 1 : (i2) -> i1
+  hw.output %1: i1
+}
+
+// -----
+
+
+hw.module @multibit(in %a : i1, in %b: i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [2]]}} {
+  // expected-error@+1 {{Unsupported operation for truth table simulation}}
   %0 = comb.add %a, %b : i1
   hw.output %0: i1
 }

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -2,7 +2,9 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(synth-tech-mapper{strategy=timing test=true max-cuts-per-root=8})' %s | FileCheck %s --check-prefixes CHECK,TIMING
 
 hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {hw.techlib.info = {area = 1.0 : f64, delay = [[1], [1]]}} {
-    %0 = synth.aig.and_inv %a, %b : i1
+    %false = hw.constant false
+    %true = hw.constant true
+    %0 = synth.aig.and_inv %a, %b, not %false, %true : i1
     hw.output %0 : i1
 }
 


### PR DESCRIPTION
Handle hw.constant operations during truth table simulation in CutRewriter so constant values are computed when it's used in hw.module that represents tech lib. 

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
