### PR TITLE
[Arc] Convert HasBeenResetOp to register in StripSV

### DIFF
--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -11,6 +11,7 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Verif/VerifOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/Support/Debug.h"
@@ -189,6 +190,34 @@ void StripSVPass::runOnOperation() {
           instOp.replaceAllUsesWith(gated);
           opsToDelete.push_back(instOp);
         }
+        continue;
+      }
+
+      // Canonicalize has-been-reset indicators.
+      if (auto hbr = dyn_cast<verif::HasBeenResetOp>(&op)) {
+        OpBuilder builder(hbr);
+
+        if (hbr.getAsync() && !asyncResetsAsSync) {
+          hbr.emitOpError("has async reset, but only sync resets supported");
+          return signalPassFailure();
+        }
+
+        auto clock =
+            seq::ToClockOp::create(builder, hbr.getLoc(), hbr.getClock());
+        auto initial = circt::seq::createConstantInitialValue(
+            builder, hbr.getLoc(), builder.getBoolAttr(false));
+        auto one =
+            hw::ConstantOp::create(builder, hbr.getLoc(), hbr.getType(), 1);
+        auto reg = seq::CompRegOp::create(builder, hbr.getLoc(), one, clock,
+                                          StringAttr{}, hbr.getReset(), one,
+                                          initial, hw::InnerSymAttr{});
+        reg.getInputMutable().assign(reg);
+        auto notReset =
+            comb::createOrFoldNot(builder, hbr.getLoc(), hbr.getReset());
+        auto masked =
+            comb::AndOp::create(builder, hbr.getLoc(), reg, notReset, true);
+        hbr.getResult().replaceAllUsesWith(masked);
+        opsToDelete.push_back(hbr);
         continue;
       }
     }

--- a/test/Dialect/Arc/strip-sv-errors.mlir
+++ b/test/Dialect/Arc/strip-sv-errors.mlir
@@ -5,3 +5,11 @@ hw.module @AsyncReg(in %clk : !seq.clock, in %rst : i1, in %arg0: i8) {
   // expected-error @below {{only synchronous resets are currently supported}}
   %int_rtc_tick_value = seq.firreg %arg0 clock %clk reset async %rst, %c0_i8 : i8
 }
+
+// -----
+
+hw.module @AsyncHasBeenReset(in %clock: i1, in %reset: i1, out z: i1) {
+  // expected-error @below {{has async reset, but only sync resets supported}}
+  %0 = verif.has_been_reset %clock, async %reset
+  hw.output %0 : i1
+}

--- a/test/Dialect/Arc/strip-sv-ignore-async.mlir
+++ b/test/Dialect/Arc/strip-sv-ignore-async.mlir
@@ -8,3 +8,19 @@ hw.module @AsyncReg(in %clk : !seq.clock, in %rst : i1, in %arg0: i8) {
   %c0_i8 = hw.constant 0 : i8
   %int_rtc_tick_value = seq.firreg %arg0 clock %clk reset async %rst, %c0_i8 : i8
 }
+
+// CHECK-LABEL: hw.module @HasBeenResetAsync(
+hw.module @HasBeenResetAsync(in %clock: i1, in %reset: i1, out z: i1) {
+  // CHECK-DAG: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK-DAG: [[INIT:%.+]] = seq.initial() {
+  // CHECK-DAG:   [[FALSE:%.+]] = hw.constant false
+  // CHECK-DAG:   seq.yield [[FALSE]]
+  // CHECK-DAG: }
+  // CHECK-DAG: [[TRUE:%.+]] = hw.constant true
+  // CHECK-DAG: [[REG:%.+]] = seq.compreg [[REG]], [[CLK]] reset %reset, [[TRUE]] initial [[INIT]] : i1
+  // CHECK-DAG: [[NOT_RESET:%.+]] = comb.xor %reset, %{{.+}} : i1
+  // CHECK-DAG: [[OUT:%.+]] = comb.and bin [[REG]], [[NOT_RESET]] : i1
+  %0 = verif.has_been_reset %clock, async %reset
+  // CHECK: hw.output [[OUT]]
+  hw.output %0 : i1
+}

--- a/test/Dialect/Arc/strip-sv.mlir
+++ b/test/Dialect/Arc/strip-sv.mlir
@@ -34,3 +34,19 @@ hw.module @Top() {
 
 // CHECK-NOT: sv.macro.decl
 sv.macro.decl @RANDOM
+
+// CHECK-LABEL: hw.module @HasBeenReset(
+hw.module @HasBeenReset(in %clock: i1, in %reset: i1, out z: i1) {
+  // CHECK-DAG: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK-DAG: [[INIT:%.+]] = seq.initial() {
+  // CHECK-DAG:   [[FALSE:%.+]] = hw.constant false
+  // CHECK-DAG:   seq.yield [[FALSE]]
+  // CHECK-DAG: }
+  // CHECK-DAG: [[TRUE:%.+]] = hw.constant true
+  // CHECK-DAG: [[REG:%.+]] = seq.compreg [[REG]], [[CLK]] reset %reset, [[TRUE]] initial [[INIT]] : i1
+  // CHECK-DAG: [[NOT_RESET:%.+]] = comb.xor %reset, %{{.+}} : i1
+  // CHECK-DAG: [[OUT:%.+]] = comb.and bin [[REG]], [[NOT_RESET]] : i1
+  %0 = verif.has_been_reset %clock, sync %reset
+  // CHECK: hw.output [[OUT]]
+  hw.output %0 : i1
+}


### PR DESCRIPTION
The StripSV pass is currently a grab-bag of canonicalizations and conversions that prepare input IR for conversion to the Arc dialect. Add support for the `verif.has_been_reset` op there, which is a simple register with a fixed initial value during simulation. In the future, we'll want to merge most of this into the ConvertToArcs pass.