### PR TITLE
[Python] Don't eager-load LLVM dialect in CIRCT bindings

### DIFF
--- a/integration_test/Bindings/Python/dialects/hw_flatten.py
+++ b/integration_test/Bindings/Python/dialects/hw_flatten.py
@@ -1,0 +1,74 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+# Build a simple two-module HW design (Top instantiates Inner) and run the
+# `hw-flatten-modules` pass on it. After flattening, the instantiation of
+# `Inner` should be inlined into `Top`. This also exercises the registration
+# of the LLVM dialect's inliner interface, which the FlattenModules pass
+# requires when it builds an `mlir::InlinerInterface`.
+
+import circt
+from circt.dialects import comb, hw
+from circt.ir import (ArrayAttr, Context, InsertionPoint, IntegerType, Location,
+                      Module, StringAttr)
+from circt.passmanager import PassManager
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+
+  i8 = IntegerType.get_signless(8)
+
+  m = Module.create()
+  with InsertionPoint(m.body):
+
+    def build_inner(module):
+      a, b = module.entry_block.arguments
+      hw.OutputOp([comb.add([a, b])])
+
+    inner = hw.HWModuleOp(
+        name="Inner",
+        input_ports=[("a", i8), ("b", i8)],
+        output_ports=[("y", i8)],
+        body_builder=build_inner,
+        attributes={"sym_visibility": StringAttr.get("private")},
+    )
+    del inner
+
+    def build_top(module):
+      x, = module.entry_block.arguments
+      y = hw.instance(
+          [i8],
+          "inner",
+          "Inner",
+          [x, x],
+          ["a", "b"],
+          ["y"],
+          parameters=ArrayAttr.get([]),
+      )
+      hw.OutputOp([y])
+
+    hw.HWModuleOp(name="Top",
+                  input_ports=[("x", i8)],
+                  output_ports=[("y", i8)],
+                  body_builder=build_top)
+
+  # Pre-flatten IR: both modules are still present and `Top` instantiates
+  # `Inner`.
+  # CHECK-LABEL: === Before hw-flatten-modules ===
+  # CHECK: hw.module private @Inner
+  # CHECK: hw.module @Top
+  # CHECK: hw.instance "inner" @Inner
+  print("=== Before hw-flatten-modules ===")
+  print(m)
+
+  pm = PassManager.parse("builtin.module(hw-flatten-modules)")
+  pm.run(m.operation)
+
+  # After flattening: the `Inner` module is gone and its body is inlined into
+  # `Top`, so there should be no `hw.instance` left.
+  # CHECK-LABEL: === After hw-flatten-modules ===
+  # CHECK:     hw.module @Top
+  # CHECK-NOT: hw.instance
+  # CHECK-NOT: hw.module private @Inner
+  print("=== After hw-flatten-modules ===")
+  print(m)

--- a/integration_test/Bindings/Python/dialects/hw_flatten.py
+++ b/integration_test/Bindings/Python/dialects/hw_flatten.py
@@ -3,9 +3,7 @@
 
 # Build a simple two-module HW design (Top instantiates Inner) and run the
 # `hw-flatten-modules` pass on it. After flattening, the instantiation of
-# `Inner` should be inlined into `Top`. This also exercises the registration
-# of the LLVM dialect's inliner interface, which the FlattenModules pass
-# requires when it builds an `mlir::InlinerInterface`.
+# `Inner` should be inlined into `Top`.
 
 import circt
 from circt.dialects import comb, hw

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -124,9 +124,16 @@ NB_MODULE(_circt, m) {
         mlirDialectHandleRegisterDialect(index, context);
         mlirDialectHandleLoadDialect(index, context);
 
+        // Register (but do not eagerly load) the LLVM dialect. Loading it
+        // would force every `DialectInterfaceCollection` (e.g. the one built
+        // by the inliner used by `hw-flatten-modules`) to query the LLVM
+        // dialect for its promised interfaces, fatally aborting in asserts
+        // builds when those interface extensions have not also been
+        // registered. Users that actually need the LLVM dialect can load it
+        // explicitly (e.g. by importing it from MLIR's own bindings) or it
+        // will be loaded on demand by translation/lowering helpers.
         MlirDialectHandle llvm = mlirGetDialectHandle__llvm__();
         mlirDialectHandleRegisterDialect(llvm, context);
-        mlirDialectHandleLoadDialect(llvm, context);
 
         MlirDialectHandle scf = mlirGetDialectHandle__scf__();
         mlirDialectHandleRegisterDialect(scf, context);

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -124,16 +124,11 @@ NB_MODULE(_circt, m) {
         mlirDialectHandleRegisterDialect(index, context);
         mlirDialectHandleLoadDialect(index, context);
 
-        // Register (but do not eagerly load) the LLVM dialect. Loading it
-        // would force every `DialectInterfaceCollection` (e.g. the one built
-        // by the inliner used by `hw-flatten-modules`) to query the LLVM
-        // dialect for its promised interfaces, fatally aborting in asserts
-        // builds when those interface extensions have not also been
-        // registered. Users that actually need the LLVM dialect can load it
-        // explicitly (e.g. by importing it from MLIR's own bindings) or it
-        // will be loaded on demand by translation/lowering helpers.
         MlirDialectHandle llvm = mlirGetDialectHandle__llvm__();
         mlirDialectHandleRegisterDialect(llvm, context);
+        // We don't load the LLVM dialect here since it doesn't load all of its
+        // promised interfaces. If you need to load it, you can do so by calling
+        // `Context().load_all_available_dialects()` in Python.
 
         MlirDialectHandle scf = mlirGetDialectHandle__scf__();
         mlirDialectHandleRegisterDialect(scf, context);


### PR DESCRIPTION
Loading the LLVM dialect in the CIRCT Python bindings forces every `DialectInterfaceCollection` (e.g. the inliner used by `hw-flatten-modules`) to query the LLVM dialect for its promised `DialectInlinerInterface`, fatally aborting in asserts builds because that interface is provided as an opt-in dialect extension that lives in `MLIRLLVMIRTransforms` and is not registered here.

Just register the dialect (so it is available on demand) without loading it. Add an integration test that builds a two-module HW design and runs `hw-flatten-modules` to inline one into the other, which previously aborted with the promised-interface error.

Assisted-by: GitHub Copilot:claude-opus-4-7

