### PR TITLE
Add support for loop-generate in SV dialect.

### DIFF
--- a/include/circt/Dialect/SV/SVGenerate.td
+++ b/include/circt/Dialect/SV/SVGenerate.td
@@ -50,3 +50,21 @@ def GenerateCaseOp : SVOp<"generate.case",
 
   let hasVerifier = true;
 }
+
+def GenerateForOp : SVOp<"generate.for",
+                         [SingleBlock, NoTerminator,
+                          HasParent<"GenerateOp">,
+                          AllTypesMatch<["lowerBound", "upperBound", "step"]>]> {
+  let summary = "A 'for' loop inside of a generate block";
+  let description = "See SystemVerilog 2017 27.4.";
+
+  let regions = (region SizedRegion<1>:$body);
+  let arguments = (ins HWIntegerType:$lowerBound,
+                       HWIntegerType:$upperBound,
+                       HWIntegerType:$step,
+                       StrAttr:$genBlockName);
+
+  let assemblyFormat = [{
+    $lowerBound `to` $upperBound `step` $step `name` $genBlockName attr-dict `:` type($lowerBound) $body
+  }];
+}

--- a/include/circt/Dialect/SV/SVGenerate.td
+++ b/include/circt/Dialect/SV/SVGenerate.td
@@ -54,6 +54,7 @@ def GenerateCaseOp : SVOp<"generate.case",
 def GenerateForOp : SVOp<"generate.for",
                          [SingleBlock, NoTerminator,
                           HasParent<"GenerateOp">,
+                          DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
                           AllTypesMatch<["lowerBound", "upperBound", "step"]>]> {
   let summary = "A 'for' loop inside of a generate block";
   let description = "See SystemVerilog 2017 27.4.";
@@ -62,15 +63,18 @@ def GenerateForOp : SVOp<"generate.for",
   let arguments = (ins TypedAttrInterface:$lowerBound,
                        TypedAttrInterface:$upperBound,
                        TypedAttrInterface:$step,
-                       StrAttr:$genBlockName);
+                       StrAttr:$genBlockName,
+                       OptionalAttr<StrAttr>:$inductionVarName);
 
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{
+    custom<ForHeader>($lowerBound, $upperBound, $step, $inductionVarName,
+                      $genBlockName, $body) attr-dict
+  }];
+
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     Block* getBodyBlock() { return &getBody().front(); }
     Value getInductionVar() { return getBodyBlock()->getArgument(0); }
-    void getAsmBlockArgumentNames(mlir::Region &region,
-                                  mlir::OpAsmSetValueNameFn setNameFn);
   }];
 }

--- a/include/circt/Dialect/SV/SVGenerate.td
+++ b/include/circt/Dialect/SV/SVGenerate.td
@@ -59,12 +59,18 @@ def GenerateForOp : SVOp<"generate.for",
   let description = "See SystemVerilog 2017 27.4.";
 
   let regions = (region SizedRegion<1>:$body);
-  let arguments = (ins HWIntegerType:$lowerBound,
-                       HWIntegerType:$upperBound,
-                       HWIntegerType:$step,
+  let arguments = (ins TypedAttrInterface:$lowerBound,
+                       TypedAttrInterface:$upperBound,
+                       TypedAttrInterface:$step,
                        StrAttr:$genBlockName);
 
-  let assemblyFormat = [{
-    $lowerBound `to` $upperBound `step` $step `name` $genBlockName attr-dict `:` type($lowerBound) $body
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    Block* getBodyBlock() { return &getBody().front(); }
+    Value getInductionVar() { return getBodyBlock()->getArgument(0); }
+    void getAsmBlockArgumentNames(mlir::Region &region,
+                                  mlir::OpAsmSetValueNameFn setNameFn);
   }];
 }

--- a/include/circt/Dialect/SV/SVGenerate.td
+++ b/include/circt/Dialect/SV/SVGenerate.td
@@ -67,9 +67,8 @@ def GenerateForOp : SVOp<"generate.for",
                        OptionalAttr<StrAttr>:$inductionVarName);
 
   let assemblyFormat = [{
-    custom<ForInductionVar>($inductionVarName) `=` $lowerBound `to`
-    $upperBound `step` $step `name` $genBlockName
-    custom<ForBody>(ref($inductionVarName), ref($lowerBound), $body) attr-dict
+    custom<GenerateFor>($lowerBound, $upperBound, $step, $inductionVarName,
+                        $genBlockName, $body) attr-dict
   }];
 
   let hasVerifier = 1;

--- a/include/circt/Dialect/SV/SVGenerate.td
+++ b/include/circt/Dialect/SV/SVGenerate.td
@@ -67,8 +67,9 @@ def GenerateForOp : SVOp<"generate.for",
                        OptionalAttr<StrAttr>:$inductionVarName);
 
   let assemblyFormat = [{
-    custom<ForHeader>($lowerBound, $upperBound, $step, $inductionVarName,
-                      $genBlockName, $body) attr-dict
+    custom<ForInductionVar>($inductionVarName) `=` $lowerBound `to`
+    $upperBound `step` $step `name` $genBlockName
+    custom<ForBody>(ref($inductionVarName), ref($lowerBound), $body) attr-dict
   }];
 
   let hasVerifier = 1;

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -62,7 +62,7 @@ public:
             // Memory loading tasks
             ReadMemOp,
             // Generate statements
-            GenerateOp, GenerateCaseOp,
+            GenerateOp, GenerateCaseOp, GenerateForOp,
             // For statements
             ForOp,
             // Sampled value functiions
@@ -197,6 +197,7 @@ public:
   // Generate statements
   HANDLE(GenerateOp, Unhandled);
   HANDLE(GenerateCaseOp, Unhandled);
+  HANDLE(GenerateForOp, Unhandled);
 
   // For loop.
   HANDLE(ForOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4134,6 +4134,7 @@ private:
 
   LogicalResult visitSV(GenerateOp op);
   LogicalResult visitSV(GenerateCaseOp op);
+  LogicalResult visitSV(GenerateForOp op);
 
   LogicalResult visitSV(ForOp op);
 
@@ -4955,6 +4956,50 @@ LogicalResult StmtEmitter::visitSV(GenerateCaseOp op) {
 
   startStatement();
   ps << "endcase";
+  ps.addCallback({op, false});
+  setPendingNewline();
+  return success();
+}
+
+LogicalResult StmtEmitter::visitSV(GenerateForOp op) {
+  emitSVAttributes(op);
+  llvm::SmallPtrSet<Operation *, 8> ops;
+  ps.addCallback({op, true});
+  startStatement();
+
+  StringAttr inductionVarNameAttr =
+      op->getAttrOfType<StringAttr>("hw.verilogName");
+  StringRef inductionVarName =
+      inductionVarNameAttr ? inductionVarNameAttr.getValue() : "i";
+
+  StringRef blockName = op.getGenBlockName();
+
+  ps << "for (";
+  ps.scopedBox(PP::cbox0, [&]() {
+    emitAssignLike(
+        [&]() { ps << "genvar" << PP::nbsp << PPExtString(inductionVarName); },
+        [&]() { emitExpression(op.getLowerBound(), ops); }, PPExtString("="));
+    ps << PP::space;
+
+    emitAssignLike([&]() { ps << PPExtString(inductionVarName); },
+                   [&]() { emitExpression(op.getUpperBound(), ops); },
+                   PPExtString("<"));
+    ps << PP::space;
+
+    ps << PPExtString(inductionVarName) << PP::nbsp << "+=" << PP::nbsp;
+    emitExpression(op.getStep(), ops);
+    ps << ") begin";
+    if (!blockName.empty())
+      ps << " : " << PPExtString(blockName);
+  });
+
+  ps << PP::neverbreak;
+  setPendingNewline();
+  emitStatementBlock(op.getBody().getBlocks().front());
+  startStatement();
+  ps << "end";
+  if (!blockName.empty())
+    ps << " // " << PPExtString(blockName);
   ps.addCallback({op, false});
   setPendingNewline();
   return success();

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -991,6 +991,12 @@ StringRef getVerilogValueName(Value val) {
     // If the value is defined by for op, use its associated verilog name.
     if (auto forOp = dyn_cast<ForOp>(port.getParentBlock()->getParentOp()))
       return forOp->getAttrOfType<StringAttr>("hw.verilogName");
+    if (auto genForOp =
+            dyn_cast<GenerateForOp>(port.getParentBlock()->getParentOp())) {
+      if (auto attr = genForOp->getAttrOfType<StringAttr>("hw.verilogName"))
+        return attr.getValue();
+      return "i";
+    }
     return getInputPortVerilogName(port.getParentBlock()->getParentOp(),
                                    port.getArgNumber());
   }
@@ -4978,16 +4984,34 @@ LogicalResult StmtEmitter::visitSV(GenerateForOp op) {
   ps.scopedBox(PP::cbox0, [&]() {
     emitAssignLike(
         [&]() { ps << "genvar" << PP::nbsp << PPExtString(inductionVarName); },
-        [&]() { emitExpression(op.getLowerBound(), ops); }, PPExtString("="));
+        [&]() {
+          ps.invokeWithStringOS([&](auto &os) {
+            emitter.printParamValue(
+                op.getLowerBound(), os, VerilogPrecedence::LowestPrecedence,
+                [&]() { return op->emitOpError("invalid lower bound"); });
+          });
+        },
+        PPExtString("="));
     ps << PP::space;
 
-    emitAssignLike([&]() { ps << PPExtString(inductionVarName); },
-                   [&]() { emitExpression(op.getUpperBound(), ops); },
-                   PPExtString("<"));
+    emitAssignLike(
+        [&]() { ps << PPExtString(inductionVarName); },
+        [&]() {
+          ps.invokeWithStringOS([&](auto &os) {
+            emitter.printParamValue(
+                op.getUpperBound(), os, VerilogPrecedence::LowestPrecedence,
+                [&]() { return op->emitOpError("invalid upper bound"); });
+          });
+        },
+        PPExtString("<"));
     ps << PP::space;
 
     ps << PPExtString(inductionVarName) << PP::nbsp << "+=" << PP::nbsp;
-    emitExpression(op.getStep(), ops);
+    ps.invokeWithStringOS([&](auto &os) {
+      emitter.printParamValue(
+          op.getStep(), os, VerilogPrecedence::LowestPrecedence,
+          [&]() { return op->emitOpError("invalid step"); });
+    });
     ps << ") begin";
     if (!blockName.empty())
       ps << " : " << PPExtString(blockName);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -989,10 +989,10 @@ StringRef getVerilogValueName(Value val) {
 
   if (auto port = dyn_cast<BlockArgument>(val)) {
     // If the value is defined by for op, use its associated verilog name.
-    if (auto forOp = dyn_cast<ForOp>(port.getParentBlock()->getParentOp()))
+    auto parent = port.getParentBlock()->getParentOp();
+    if (auto forOp = dyn_cast<ForOp>(parent))
       return forOp->getAttrOfType<StringAttr>("hw.verilogName");
-    if (auto genForOp =
-            dyn_cast<GenerateForOp>(port.getParentBlock()->getParentOp())) {
+    if (auto genForOp = dyn_cast<GenerateForOp>(parent)) {
       if (auto attr = genForOp->getAttrOfType<StringAttr>("hw.verilogName"))
         return attr.getValue();
       return "i";
@@ -4973,12 +4973,9 @@ LogicalResult StmtEmitter::visitSV(GenerateForOp op) {
   ps.addCallback({op, true});
   startStatement();
 
-  StringAttr inductionVarNameAttr =
-      op->getAttrOfType<StringAttr>("hw.verilogName");
-  StringRef inductionVarName =
-      inductionVarNameAttr ? inductionVarNameAttr.getValue() : "i";
-
-  StringRef blockName = op.getGenBlockName();
+  StringRef inductionVarName = "i";
+  if (auto nameHint = op->getAttrOfType<StringAttr>("hw.verilogName"))
+    inductionVarName = nameHint.getValue();
 
   ps << "for (";
   ps.scopedBox(PP::cbox0, [&]() {
@@ -5013,6 +5010,7 @@ LogicalResult StmtEmitter::visitSV(GenerateForOp op) {
           [&]() { return op->emitOpError("invalid step"); });
     });
     ps << ") begin";
+    StringRef blockName = op.getGenBlockName();
     if (!blockName.empty())
       ps << " : " << PPExtString(blockName);
   });
@@ -5022,7 +5020,7 @@ LogicalResult StmtEmitter::visitSV(GenerateForOp op) {
   emitStatementBlock(op.getBody().getBlocks().front());
   startStatement();
   ps << "end";
-  if (!blockName.empty())
+  if (StringRef blockName = op.getGenBlockName(); !blockName.empty())
     ps << " // " << PPExtString(blockName);
   ps.addCallback({op, false});
   setPendingNewline();

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -990,13 +990,8 @@ StringRef getVerilogValueName(Value val) {
   if (auto port = dyn_cast<BlockArgument>(val)) {
     // If the value is defined by for op, use its associated verilog name.
     auto parent = port.getParentBlock()->getParentOp();
-    if (auto forOp = dyn_cast<ForOp>(parent))
-      return forOp->getAttrOfType<StringAttr>("hw.verilogName");
-    if (auto genForOp = dyn_cast<GenerateForOp>(parent)) {
-      if (auto attr = genForOp->getAttrOfType<StringAttr>("hw.verilogName"))
-        return attr.getValue();
-      return "i";
-    }
+    if (isa<ForOp, GenerateForOp>(parent))
+      return parent->getAttrOfType<StringAttr>("hw.verilogName");
     return getInputPortVerilogName(port.getParentBlock()->getParentOp(),
                                    port.getArgNumber());
   }
@@ -4973,9 +4968,7 @@ LogicalResult StmtEmitter::visitSV(GenerateForOp op) {
   ps.addCallback({op, true});
   startStatement();
 
-  StringRef inductionVarName = "i";
-  if (auto nameHint = op->getAttrOfType<StringAttr>("hw.verilogName"))
-    inductionVarName = nameHint.getValue();
+  StringRef inductionVarName = op->getAttrOfType<StringAttr>("hw.verilogName");
 
   ps << "for (";
   ps.scopedBox(PP::cbox0, [&]() {

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -206,6 +206,8 @@ static void legalizeModuleLocalNames(HWEmittableModuleLike module,
             op, StringAttr::get(op->getContext(), getSymOpName(op)));
       } else if (auto forOp = dyn_cast<ForOp>(op)) {
         nameEntries.emplace_back(op, forOp.getInductionVarNameAttr());
+      } else if (auto genForOp = dyn_cast<GenerateForOp>(op)) {
+        nameEntries.emplace_back(op, genForOp.getInductionVarNameAttr());
       } else if (isa<AssertOp, AssumeOp, CoverOp, AssertConcurrentOp,
                      AssumeConcurrentOp, CoverConcurrentOp, AssertPropertyOp,
                      AssumePropertyOp, CoverPropertyOp, verif::AssertOp,

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -2541,73 +2541,72 @@ LogicalResult GenerateCaseOp::verify() {
 // GenerateForOp
 //===----------------------------------------------------------------------===//
 
-ParseResult GenerateForOp::parse(OpAsmParser &parser, OperationState &result) {
+/// Parse a generate for header and body:
+///   %i : i32 = 0 to 10 step 1 name "gen_blk" { ... }
+static ParseResult parseForHeader(OpAsmParser &parser, Attribute &lowerBound,
+                                  Attribute &upperBound, Attribute &step,
+                                  StringAttr &inductionVarName,
+                                  StringAttr &genBlockName, Region &body) {
   auto &builder = parser.getBuilder();
   Type type;
 
   OpAsmParser::Argument inductionVariable;
   int64_t lbVal, ubVal, stepVal;
-  StringAttr genBlockNameAttr;
-  SmallVector<OpAsmParser::Argument, 1> regionArgs;
 
   if (parser.parseOperand(inductionVariable.ssaName) || parser.parseColon() ||
       parser.parseType(type) || parser.parseEqual() ||
       parser.parseInteger(lbVal) || parser.parseKeyword("to") ||
       parser.parseInteger(ubVal) || parser.parseKeyword("step") ||
       parser.parseInteger(stepVal) || parser.parseKeyword("name") ||
-      parser.parseAttribute(genBlockNameAttr))
+      parser.parseAttribute(genBlockName))
     return failure();
 
-  regionArgs.push_back(inductionVariable);
-  regionArgs.front().type = type;
+  inductionVariable.type = type;
+  lowerBound = builder.getIntegerAttr(type, lbVal);
+  upperBound = builder.getIntegerAttr(type, ubVal);
+  step = builder.getIntegerAttr(type, stepVal);
 
-  result.addAttribute("lowerBound", builder.getIntegerAttr(type, lbVal));
-  result.addAttribute("upperBound", builder.getIntegerAttr(type, ubVal));
-  result.addAttribute("step", builder.getIntegerAttr(type, stepVal));
-  result.addAttribute("genBlockName", genBlockNameAttr);
+  // Store the induction variable name if it's not a number.
+  if (!inductionVariable.ssaName.name.empty() &&
+      !isdigit(inductionVariable.ssaName.name[1]))
+    inductionVarName =
+        builder.getStringAttr(inductionVariable.ssaName.name.drop_front());
 
-  Region *body = result.addRegion();
-  if (parser.parseRegion(*body, regionArgs))
-    return failure();
-
-  if (parser.parseOptionalAttrDict(result.attributes))
-    return failure();
-
-  if (!inductionVariable.ssaName.name.empty()) {
-    if (!isdigit(inductionVariable.ssaName.name[1]))
-      result.attributes.append(
-          {builder.getStringAttr("inductionVarName"),
-           builder.getStringAttr(inductionVariable.ssaName.name.drop_front())});
-  }
-
-  return success();
+  SmallVector<OpAsmParser::Argument, 1> regionArgs = {inductionVariable};
+  return parser.parseRegion(body, regionArgs);
 }
 
-void GenerateForOp::print(OpAsmPrinter &p) {
-  p << " " << getInductionVar() << " : " << getLowerBound().getType() << " = ";
+/// Print a generate for header and body:
+///   %i : i32 = 0 to 10 step 1 name "gen_blk" { ... }
+static void printForHeader(OpAsmPrinter &p, Operation *op, Attribute lowerBound,
+                           Attribute upperBound, Attribute step,
+                           StringAttr inductionVarName, StringAttr genBlockName,
+                           Region &body) {
+  auto forOp = cast<GenerateForOp>(op);
+  p << forOp.getInductionVar() << " : " << cast<TypedAttr>(lowerBound).getType()
+    << " = ";
 
-  if (auto lowerAttr = dyn_cast<IntegerAttr>(getLowerBound()))
-    p << lowerAttr.getInt();
+  if (auto lb = dyn_cast<IntegerAttr>(lowerBound))
+    p << lb.getInt();
   else
-    p.printAttribute(getLowerBound());
+    p.printAttribute(lowerBound);
 
   p << " to ";
 
-  if (auto upperAttr = dyn_cast<IntegerAttr>(getUpperBound()))
-    p << upperAttr.getInt();
+  if (auto ub = dyn_cast<IntegerAttr>(upperBound))
+    p << ub.getInt();
   else
-    p.printAttribute(getUpperBound());
+    p.printAttribute(upperBound);
 
   p << " step ";
 
-  if (auto stepAttr = dyn_cast<IntegerAttr>(getStep()))
-    p << stepAttr.getInt();
+  if (auto s = dyn_cast<IntegerAttr>(step))
+    p << s.getInt();
   else
-    p.printAttribute(getStep());
+    p.printAttribute(step);
 
-  p << " name " << getGenBlockNameAttr();
-
-  p.printRegion(getBody(), /*printEntryBlockArgs=*/false,
+  p << " name " << genBlockName << " ";
+  p.printRegion(body, /*printEntryBlockArgs=*/false,
                 /*printBlockTerminators=*/true);
 }
 
@@ -2615,6 +2614,8 @@ LogicalResult GenerateForOp::verify() {
   if (getBody().getBlocks().front().getNumArguments() != 1)
     return emitOpError("must have exactly one block argument");
   Type type = getLowerBound().getType();
+  if (!isa<IntegerType>(type))
+    return emitOpError("induction variable, bounds and step must be integral");
   if (getBody().getBlocks().front().getArgument(0).getType() != type)
     return emitOpError("block argument type must match loop bounds type");
 
@@ -2624,8 +2625,7 @@ LogicalResult GenerateForOp::verify() {
 void GenerateForOp::getAsmBlockArgumentNames(
     mlir::Region &region, mlir::OpAsmSetValueNameFn setNameFn) {
   auto *block = &region.front();
-  auto attr = (*this)->getAttrOfType<StringAttr>("inductionVarName");
-  if (attr)
+  if (auto attr = getInductionVarNameAttr())
     setNameFn(block->getArgument(0), attr);
 }
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -2537,6 +2537,105 @@ LogicalResult GenerateCaseOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// GenerateForOp
+//===----------------------------------------------------------------------===//
+
+ParseResult GenerateForOp::parse(OpAsmParser &parser, OperationState &result) {
+  auto &builder = parser.getBuilder();
+  Type type;
+
+  OpAsmParser::Argument inductionVariable;
+  int64_t lbVal, ubVal, stepVal;
+  StringAttr genBlockNameAttr;
+  SmallVector<OpAsmParser::Argument, 1> regionArgs;
+
+  if (parser.parseOperand(inductionVariable.ssaName) || parser.parseColon() ||
+      parser.parseType(type) || parser.parseEqual() ||
+      parser.parseInteger(lbVal) || parser.parseKeyword("to") ||
+      parser.parseInteger(ubVal) || parser.parseKeyword("step") ||
+      parser.parseInteger(stepVal) || parser.parseKeyword("name") ||
+      parser.parseAttribute(genBlockNameAttr))
+    return failure();
+
+  regionArgs.push_back(inductionVariable);
+  regionArgs.front().type = type;
+
+  result.addAttribute("lowerBound", builder.getIntegerAttr(type, lbVal));
+  result.addAttribute("upperBound", builder.getIntegerAttr(type, ubVal));
+  result.addAttribute("step", builder.getIntegerAttr(type, stepVal));
+  result.addAttribute("genBlockName", genBlockNameAttr);
+
+  Region *body = result.addRegion();
+  if (parser.parseRegion(*body, regionArgs))
+    return failure();
+
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  if (!inductionVariable.ssaName.name.empty()) {
+    if (!isdigit(inductionVariable.ssaName.name[1]))
+      result.attributes.append(
+          {builder.getStringAttr("inductionVarName"),
+           builder.getStringAttr(inductionVariable.ssaName.name.drop_front())});
+  }
+
+  return success();
+}
+
+void GenerateForOp::print(OpAsmPrinter &p) {
+  p << " " << getInductionVar() << " : " << getLowerBound().getType() << " = ";
+
+  if (auto lowerAttr = dyn_cast<IntegerAttr>(getLowerBound()))
+    p << lowerAttr.getInt();
+  else
+    p.printAttribute(getLowerBound());
+
+  p << " to ";
+
+  if (auto upperAttr = dyn_cast<IntegerAttr>(getUpperBound()))
+    p << upperAttr.getInt();
+  else
+    p.printAttribute(getUpperBound());
+
+  p << " step ";
+
+  if (auto stepAttr = dyn_cast<IntegerAttr>(getStep()))
+    p << stepAttr.getInt();
+  else
+    p.printAttribute(getStep());
+
+  p << " name " << getGenBlockNameAttr();
+
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/true);
+}
+
+LogicalResult GenerateForOp::verify() {
+  Type type = getLowerBound().getType();
+  if (getUpperBound().getType() != type)
+    return emitOpError("upper bound type must match lower bound type");
+  if (getStep().getType() != type)
+    return emitOpError("step type must match lower bound type");
+
+  if (getBody().getBlocks().size() != 1)
+    return emitOpError("must have exactly one block");
+  if (getBody().getBlocks().front().getNumArguments() != 1)
+    return emitOpError("must have exactly one block argument");
+  if (getBody().getBlocks().front().getArgument(0).getType() != type)
+    return emitOpError("block argument type must match loop bounds type");
+
+  return success();
+}
+
+void GenerateForOp::getAsmBlockArgumentNames(
+    mlir::Region &region, mlir::OpAsmSetValueNameFn setNameFn) {
+  auto *block = &region.front();
+  auto attr = (*this)->getAttrOfType<StringAttr>("inductionVarName");
+  if (attr)
+    setNameFn(block->getArgument(0), attr);
+}
+
 ModportStructAttr ModportStructAttr::get(MLIRContext *context,
                                          ModportDirection direction,
                                          FlatSymbolRefAttr signal) {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -2612,16 +2612,9 @@ void GenerateForOp::print(OpAsmPrinter &p) {
 }
 
 LogicalResult GenerateForOp::verify() {
-  Type type = getLowerBound().getType();
-  if (getUpperBound().getType() != type)
-    return emitOpError("upper bound type must match lower bound type");
-  if (getStep().getType() != type)
-    return emitOpError("step type must match lower bound type");
-
-  if (getBody().getBlocks().size() != 1)
-    return emitOpError("must have exactly one block");
   if (getBody().getBlocks().front().getNumArguments() != 1)
     return emitOpError("must have exactly one block argument");
+  Type type = getLowerBound().getType();
   if (getBody().getBlocks().front().getArgument(0).getType() != type)
     return emitOpError("block argument type must match loop bounds type");
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -2541,56 +2541,104 @@ LogicalResult GenerateCaseOp::verify() {
 // GenerateForOp
 //===----------------------------------------------------------------------===//
 
-// Parse the induction variable name for a generate for loop: `%i`. Captures the
-// SSA name and stores it as the inductionVarName attribute.
-static ParseResult parseForInductionVar(OpAsmParser &parser,
-                                        StringAttr &inductionVarName) {
-  OpAsmParser::UnresolvedOperand ssaName;
-  if (parser.parseOperand(ssaName))
+// Parse attribute and also optional trailing type if there. This is needed
+// primarily for integer types as when given a type, they hapily parse without
+// consuming the colon type.
+static ParseResult parseTypedAttrWithFallback(OpAsmParser &parser,
+                                              TypedAttr &result, Type type) {
+  Attribute attr;
+  // Try parsing with the expected type (no type suffix).
+  if (succeeded(parser.parseCustomAttributeWithFallback(attr, type))) {
+    auto typedAttr = dyn_cast<TypedAttr>(attr);
+    if (!typedAttr || typedAttr.getType() != type) {
+      return parser.emitError(parser.getCurrentLocation(),
+                              "expected typed attribute with type ")
+             << type;
+    }
+
+    // We are being given a type to parse extra.
+    if (succeeded(parser.parseOptionalColon())) {
+      Type localType;
+      if (failed(parser.parseType(localType)) || localType != type)
+        return parser.emitError(parser.getCurrentLocation(),
+                                "expected typed attribute with type ")
+               << type;
+    }
+
+    result = typedAttr;
+    return success();
+  }
+
+  return failure();
+}
+
+// Parse the header and body of a generate for loop.
+static ParseResult parseGenerateFor(OpAsmParser &parser, TypedAttr &lowerBound,
+                                    TypedAttr &upperBound, TypedAttr &step,
+                                    StringAttr &inductionVarName,
+                                    StringAttr &genBlockName, Region &body) {
+  auto &builder = parser.getBuilder();
+
+  OpAsmParser::Argument inductionVariable;
+  if (parser.parseArgument(inductionVariable, /*allowType=*/true))
+    return parser.emitError(parser.getCurrentLocation(),
+                            "expected induction variable argument");
+
+  // Parse induction variable assignment.
+  if (parser.parseEqual())
     return failure();
 
-  // Store the induction variable name if it's not a number. If its a number,
-  // treat it as temporary and so don't store/persist.
-  if (!ssaName.name.empty() && !isdigit(ssaName.name[1]))
+  // Parse lower bound.
+  Type type = inductionVariable.type;
+  if (parseTypedAttrWithFallback(parser, lowerBound, type))
+    return failure();
+
+  if (parser.parseKeyword("to"))
+    return failure();
+
+  // Parse upper bound.
+  if (parseTypedAttrWithFallback(parser, upperBound, type))
+    return failure();
+
+  if (parser.parseKeyword("step"))
+    return failure();
+
+  // Parse step.
+  if (parseTypedAttrWithFallback(parser, step, type))
+    return failure();
+
+  if (parser.parseKeyword("name"))
+    return failure();
+
+  // Parse gen block name.
+  if (parser.parseCustomAttributeWithFallback(
+          genBlockName, parser.getBuilder().getType<NoneType>()))
+    return failure();
+
+  // Store the induction variable name if it's not a number.
+  if (!isdigit(inductionVariable.ssaName.name.front()))
     inductionVarName =
-        parser.getBuilder().getStringAttr(ssaName.name.drop_front());
-
-  return success();
-}
-
-/// Print the induction variable name for a generate for loop: `%i`
-static void printForInductionVar(OpAsmPrinter &p, Operation *op,
-                                 StringAttr inductionVarName) {
-  p << cast<GenerateForOp>(op).getInductionVar();
-}
-
-// Parse the body region of a generate for loop. Reconstructs the block argument
-// from the inductionVarName and the type inferred from lowerBound.
-static ParseResult parseForBody(OpAsmParser &parser,
-                                StringAttr inductionVarName,
-                                Attribute lowerBound, Region &body) {
-  auto typedLB = dyn_cast<TypedAttr>(lowerBound);
-  if (!typedLB)
-    return parser.emitError(parser.getCurrentLocation(),
-                            "lower bound must be a typed attribute");
-
-  // Reconstruct the SSA argument for the region's block argument.
-  OpAsmParser::Argument inductionVariable;
-  std::string ssaName =
-      "%" +
-      (inductionVarName ? inductionVarName.getValue() : Twine("arg0")).str();
-  inductionVariable.ssaName.name = ssaName;
-  inductionVariable.ssaName.location = parser.getCurrentLocation();
-  inductionVariable.type = typedLB.getType();
+        builder.getStringAttr(inductionVariable.ssaName.name.drop_front());
 
   SmallVector<OpAsmParser::Argument, 1> regionArgs = {inductionVariable};
   return parser.parseRegion(body, regionArgs);
 }
 
-/// Print the body region of a generate for loop.
-static void printForBody(OpAsmPrinter &p, Operation *op,
-                         StringAttr inductionVarName, Attribute lowerBound,
-                         Region &body) {
+// Print the header and body of a generate for loop.
+static void printGenerateFor(OpAsmPrinter &p, Operation *op,
+                             TypedAttr lowerBound, TypedAttr upperBound,
+                             TypedAttr step, StringAttr inductionVarName,
+                             StringAttr genBlockName, Region &body) {
+  auto forOp = cast<GenerateForOp>(op);
+  p << forOp.getInductionVar() << " : " << forOp.getInductionVar().getType()
+    << " = ";
+  p.printStrippedAttrOrType(lowerBound);
+  p << " to ";
+  p.printStrippedAttrOrType(upperBound);
+  p << " step ";
+  p.printStrippedAttrOrType(step);
+  p << " name ";
+  p.printAttributeWithoutType(genBlockName);
   p << " ";
   p.printRegion(body, /*printEntryBlockArgs=*/false,
                 /*printBlockTerminators=*/true);

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -2541,71 +2541,57 @@ LogicalResult GenerateCaseOp::verify() {
 // GenerateForOp
 //===----------------------------------------------------------------------===//
 
-/// Parse a generate for header and body:
-///   %i : i32 = 0 to 10 step 1 name "gen_blk" { ... }
-static ParseResult parseForHeader(OpAsmParser &parser, Attribute &lowerBound,
-                                  Attribute &upperBound, Attribute &step,
-                                  StringAttr &inductionVarName,
-                                  StringAttr &genBlockName, Region &body) {
-  auto &builder = parser.getBuilder();
-  Type type;
-
-  OpAsmParser::Argument inductionVariable;
-  int64_t lbVal, ubVal, stepVal;
-
-  if (parser.parseOperand(inductionVariable.ssaName) || parser.parseColon() ||
-      parser.parseType(type) || parser.parseEqual() ||
-      parser.parseInteger(lbVal) || parser.parseKeyword("to") ||
-      parser.parseInteger(ubVal) || parser.parseKeyword("step") ||
-      parser.parseInteger(stepVal) || parser.parseKeyword("name") ||
-      parser.parseAttribute(genBlockName))
+// Parse the induction variable name for a generate for loop: `%i`. Captures the
+// SSA name and stores it as the inductionVarName attribute.
+static ParseResult parseForInductionVar(OpAsmParser &parser,
+                                        StringAttr &inductionVarName) {
+  OpAsmParser::UnresolvedOperand ssaName;
+  if (parser.parseOperand(ssaName))
     return failure();
 
-  inductionVariable.type = type;
-  lowerBound = builder.getIntegerAttr(type, lbVal);
-  upperBound = builder.getIntegerAttr(type, ubVal);
-  step = builder.getIntegerAttr(type, stepVal);
-
-  // Store the induction variable name if it's not a number.
-  if (!inductionVariable.ssaName.name.empty() &&
-      !isdigit(inductionVariable.ssaName.name[1]))
+  // Store the induction variable name if it's not a number. If its a number,
+  // treat it as temporary and so don't store/persist.
+  if (!ssaName.name.empty() && !isdigit(ssaName.name[1]))
     inductionVarName =
-        builder.getStringAttr(inductionVariable.ssaName.name.drop_front());
+        parser.getBuilder().getStringAttr(ssaName.name.drop_front());
+
+  return success();
+}
+
+/// Print the induction variable name for a generate for loop: `%i`
+static void printForInductionVar(OpAsmPrinter &p, Operation *op,
+                                 StringAttr inductionVarName) {
+  p << cast<GenerateForOp>(op).getInductionVar();
+}
+
+// Parse the body region of a generate for loop. Reconstructs the block argument
+// from the inductionVarName and the type inferred from lowerBound.
+static ParseResult parseForBody(OpAsmParser &parser,
+                                StringAttr inductionVarName,
+                                Attribute lowerBound, Region &body) {
+  auto typedLB = dyn_cast<TypedAttr>(lowerBound);
+  if (!typedLB)
+    return parser.emitError(parser.getCurrentLocation(),
+                            "lower bound must be a typed attribute");
+
+  // Reconstruct the SSA argument for the region's block argument.
+  OpAsmParser::Argument inductionVariable;
+  std::string ssaName =
+      "%" +
+      (inductionVarName ? inductionVarName.getValue() : Twine("arg0")).str();
+  inductionVariable.ssaName.name = ssaName;
+  inductionVariable.ssaName.location = parser.getCurrentLocation();
+  inductionVariable.type = typedLB.getType();
 
   SmallVector<OpAsmParser::Argument, 1> regionArgs = {inductionVariable};
   return parser.parseRegion(body, regionArgs);
 }
 
-/// Print a generate for header and body:
-///   %i : i32 = 0 to 10 step 1 name "gen_blk" { ... }
-static void printForHeader(OpAsmPrinter &p, Operation *op, Attribute lowerBound,
-                           Attribute upperBound, Attribute step,
-                           StringAttr inductionVarName, StringAttr genBlockName,
-                           Region &body) {
-  auto forOp = cast<GenerateForOp>(op);
-  p << forOp.getInductionVar() << " : " << cast<TypedAttr>(lowerBound).getType()
-    << " = ";
-
-  if (auto lb = dyn_cast<IntegerAttr>(lowerBound))
-    p << lb.getInt();
-  else
-    p.printAttribute(lowerBound);
-
-  p << " to ";
-
-  if (auto ub = dyn_cast<IntegerAttr>(upperBound))
-    p << ub.getInt();
-  else
-    p.printAttribute(upperBound);
-
-  p << " step ";
-
-  if (auto s = dyn_cast<IntegerAttr>(step))
-    p << s.getInt();
-  else
-    p.printAttribute(step);
-
-  p << " name " << genBlockName << " ";
+/// Print the body region of a generate for loop.
+static void printForBody(OpAsmPrinter &p, Operation *op,
+                         StringAttr inductionVarName, Attribute lowerBound,
+                         Region &body) {
+  p << " ";
   p.printRegion(body, /*printEntryBlockArgs=*/false,
                 /*printBlockTerminators=*/true);
 }
@@ -2614,8 +2600,6 @@ LogicalResult GenerateForOp::verify() {
   if (getBody().getBlocks().front().getNumArguments() != 1)
     return emitOpError("must have exactly one block argument");
   Type type = getLowerBound().getType();
-  if (!isa<IntegerType>(type))
-    return emitOpError("induction variable, bounds and step must be integral");
   if (getBody().getBlocks().front().getArgument(0).getType() != type)
     return emitOpError("block argument type must match loop bounds type");
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -2602,6 +2602,8 @@ LogicalResult GenerateForOp::verify() {
   Type type = getLowerBound().getType();
   if (getBody().getBlocks().front().getArgument(0).getType() != type)
     return emitOpError("block argument type must match loop bounds type");
+  if (!isa<IntegerType>(type))
+    return emitOpError("loop bounds must be integer types");
 
   return success();
 }

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -513,3 +513,17 @@ hw.module @test_write(in %c0 : i32, in %c1 : i8) {
     sv.write "%d %d"(%c0, %c1) : i32, i8
   }
 }
+
+// CHECK-LABEL: hw.module @test_generate_for
+hw.module @test_generate_for() {
+  // CHECK: sv.generate "foo_loop" : {
+  sv.generate "foo_loop" : {
+    // CHECK: sv.generate.for %i = 0 : i32 to 10 : i32 step 1 : i32 name "gen_blk" {
+    sv.generate.for %i = 0 : i32 to 10 : i32 step 1 : i32 name "gen_blk" {
+      sv.initial {
+        sv.write "val = %d"(%i) : i32
+      }
+    }
+  }
+  hw.output
+}

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -518,8 +518,8 @@ hw.module @test_write(in %c0 : i32, in %c1 : i8) {
 hw.module @test_generate_for() {
   // CHECK: sv.generate "foo_loop" : {
   sv.generate "foo_loop" : {
-    // CHECK: sv.generate.for %i = 0 : i32 to 10 : i32 step 1 : i32 name "gen_blk" {
-    sv.generate.for %i = 0 : i32 to 10 : i32 step 1 : i32 name "gen_blk" {
+    // CHECK: sv.generate.for %i : i32 = 0 : i32 to 10 : i32 step 1 : i32 name "gen_blk" {
+    sv.generate.for %i : i32 = 0 to 10 : i32 step 1 name "gen_blk" {
       sv.initial {
         sv.write "val = %d"(%i) : i32
       }

--- a/test/Dialect/SV/generates.mlir
+++ b/test/Dialect/SV/generates.mlir
@@ -3,7 +3,7 @@
 // RUN: circt-opt %s --export-verilog -o %t.mlir | FileCheck %s --check-prefix=SV
 
 // Check the generated SV is lint clean.
-// RUN: %if slang %{ circt-opt %s --export-verilog -o %t.mlir | circt-verilog --lint-only %}
+// RUN: %if slang %{ circt-opt %s --export-verilog -o %t.mlir | circt-verilog --lint-only --format=sv %}
 
 hw.module @PrintPath<> () {
   %fd = hw.constant 0x80000002 : i32

--- a/test/Dialect/SV/generates.mlir
+++ b/test/Dialect/SV/generates.mlir
@@ -1,6 +1,10 @@
 // RUN: circt-opt %s | FileCheck %s
 // RUN: circt-opt %s | circt-opt | FileCheck %s
-// RUN: circt-opt %s --export-verilog -o %t.mlir | FileCheck %s --check-prefix=SV
+// RUN: circt-opt %s --export-verilog -o %t.mlir > %t.sv
+// RUN: FileCheck %s --check-prefix=SV < %t.sv
+
+// Check the generated SV is lint clean.
+// RUN: %if slang %{ circt-verilog --lint-only %t.sv %}
 
 hw.module @PrintPath<> () {
   %fd = hw.constant 0x80000002 : i32
@@ -90,5 +94,34 @@ hw.module @CaseNoDefault<NUM : i8> () {
 // SV:               end: bar0
 // SV:             endcase
 // SV:         end: bar
+// SV:         endgenerate
+// SV:       endmodule
+
+hw.module @Loop1() {
+  %c0 = hw.constant 0 : i32
+  %c10 = hw.constant 10 : i32
+  %c1 = hw.constant 1 : i32
+  sv.generate "foo_loop": {
+    sv.generate.for %c0 to %c10 step %c1 name "gen_blk" : i32 {
+    ^bb0(%i: i32):
+      hw.instance "print" @PrintPath() -> ()
+    }
+  }
+}
+
+// CHECK-LABEL: hw.module @Loop1
+// CHECK:         sv.generate "foo_loop" : {
+// CHECK:           sv.generate.for %{{.*}} to %{{.*}} step %{{.*}} name "gen_blk" : i32 {
+// CHECK:           ^bb0(%{{.*}}: i32):
+// CHECK:             hw.instance "print" @PrintPath() -> ()
+// CHECK:           }
+
+// SV-LABEL: module Loop1
+// SV:         generate
+// SV:         begin: foo_loop
+// SV:           for (genvar i = 32'h0; i < 32'hA; i += 32'h1) begin : gen_blk
+// SV:             PrintPath print ();
+// SV:           end
+// SV:         end: foo_loop
 // SV:         endgenerate
 // SV:       endmodule

--- a/test/Dialect/SV/generates.mlir
+++ b/test/Dialect/SV/generates.mlir
@@ -1,10 +1,9 @@
 // RUN: circt-opt %s | FileCheck %s
 // RUN: circt-opt %s | circt-opt | FileCheck %s
-// RUN: circt-opt %s --export-verilog -o %t.mlir > %t.sv
-// RUN: FileCheck %s --check-prefix=SV < %t.sv
+// RUN: circt-opt %s --export-verilog -o %t.mlir | FileCheck %s --check-prefix=SV
 
 // Check the generated SV is lint clean.
-// RUN: %if slang %{ circt-verilog --lint-only %t.sv %}
+// RUN: %if slang %{ circt-opt %s --export-verilog -o %t.mlir | circt-verilog --lint-only %}
 
 hw.module @PrintPath<> () {
   %fd = hw.constant 0x80000002 : i32
@@ -107,7 +106,7 @@ hw.module @PrintVal(in %val : i32) {
 hw.module @Loop1() {
   sv.generate "foo_loop": {
     sv.generate.for %i : i32 = 0 to 10 step 1 name "gen_blk" {
-      hw.instance "print" @PrintVal(val: %i : i32) -> ()
+      hw.instance "print" @PrintVal(val: %i: i32) -> ()
     }
   }
 }
@@ -115,13 +114,13 @@ hw.module @Loop1() {
 // CHECK-LABEL: hw.module @Loop1
 // CHECK:         sv.generate "foo_loop" : {
 // CHECK:           sv.generate.for %{{.*}} : i32 = 0 to 10 step 1 name "gen_blk" {
-// CHECK:             hw.instance "print" @PrintVal(val: %{{.*}} : i32) -> ()
+// CHECK:             hw.instance "print" @PrintVal(val: %{{.*}}: i32) -> ()
 // CHECK:           }
 
 // SV-LABEL: module Loop1
 // SV:         generate
 // SV:         begin: foo_loop
-// SV:           for (genvar i = 32'h0; i < 32'hA; i += 32'h1) begin : gen_blk
+// SV:           for (genvar i = 0; i < 10; i += 1) begin : gen_blk
 // SV:             PrintVal print (
 // SV:               .val (i)
 // SV:             );

--- a/test/Dialect/SV/generates.mlir
+++ b/test/Dialect/SV/generates.mlir
@@ -97,30 +97,34 @@ hw.module @CaseNoDefault<NUM : i8> () {
 // SV:         endgenerate
 // SV:       endmodule
 
+hw.module @PrintVal(in %val : i32) {
+  %fd = hw.constant 0x80000002 : i32
+  sv.initial {
+    sv.fwrite %fd, "val = %d\n"(%val) : i32
+  }
+}
+
 hw.module @Loop1() {
-  %c0 = hw.constant 0 : i32
-  %c10 = hw.constant 10 : i32
-  %c1 = hw.constant 1 : i32
   sv.generate "foo_loop": {
-    sv.generate.for %c0 to %c10 step %c1 name "gen_blk" : i32 {
-    ^bb0(%i: i32):
-      hw.instance "print" @PrintPath() -> ()
+    sv.generate.for %i : i32 = 0 to 10 step 1 name "gen_blk" {
+      hw.instance "print" @PrintVal(val: %i : i32) -> ()
     }
   }
 }
 
 // CHECK-LABEL: hw.module @Loop1
 // CHECK:         sv.generate "foo_loop" : {
-// CHECK:           sv.generate.for %{{.*}} to %{{.*}} step %{{.*}} name "gen_blk" : i32 {
-// CHECK:           ^bb0(%{{.*}}: i32):
-// CHECK:             hw.instance "print" @PrintPath() -> ()
+// CHECK:           sv.generate.for %{{.*}} : i32 = 0 to 10 step 1 name "gen_blk" {
+// CHECK:             hw.instance "print" @PrintVal(val: %{{.*}} : i32) -> ()
 // CHECK:           }
 
 // SV-LABEL: module Loop1
 // SV:         generate
 // SV:         begin: foo_loop
 // SV:           for (genvar i = 32'h0; i < 32'hA; i += 32'h1) begin : gen_blk
-// SV:             PrintPath print ();
+// SV:             PrintVal print (
+// SV:               .val (i)
+// SV:             );
 // SV:           end
 // SV:         end: foo_loop
 // SV:         endgenerate

--- a/test/Dialect/SV/generates.mlir
+++ b/test/Dialect/SV/generates.mlir
@@ -99,7 +99,7 @@ hw.module @CaseNoDefault<NUM : i8> () {
 hw.module @Loop1<NUM : i32, START: i32> () {
   %fd = hw.constant 0x80000002 : i32
   sv.generate "foo_loop": {
-    sv.generate.for %i = #hw.param.decl.ref<"START"> : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
+    sv.generate.for %i : i32 = #hw.param.decl.ref<"START"> : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
       sv.initial {
         sv.fwrite %fd, "i = %d\n"(%i) : i32
       }
@@ -109,7 +109,7 @@ hw.module @Loop1<NUM : i32, START: i32> () {
 
 // CHECK-LABEL: hw.module @Loop1
 // CHECK:         sv.generate "foo_loop" : {
-// CHECK:           sv.generate.for %i = #hw.param.decl.ref<"START"> : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
+// CHECK:           sv.generate.for %i : i32 = #hw.param.decl.ref<"START"> : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
 // CHECK:             sv.initial {
 // CHECK:               sv.fwrite {{%.+}}, "i = %d\0A"(%i) : i32
 // CHECK:             }

--- a/test/Dialect/SV/generates.mlir
+++ b/test/Dialect/SV/generates.mlir
@@ -96,10 +96,10 @@ hw.module @CaseNoDefault<NUM : i8> () {
 // SV:         endgenerate
 // SV:       endmodule
 
-hw.module @Loop1<NUM : i32> () {
+hw.module @Loop1<NUM : i32, START: i32> () {
   %fd = hw.constant 0x80000002 : i32
   sv.generate "foo_loop": {
-    sv.generate.for %i = 0 : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
+    sv.generate.for %i = #hw.param.decl.ref<"START"> : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
       sv.initial {
         sv.fwrite %fd, "i = %d\n"(%i) : i32
       }
@@ -109,17 +109,18 @@ hw.module @Loop1<NUM : i32> () {
 
 // CHECK-LABEL: hw.module @Loop1
 // CHECK:         sv.generate "foo_loop" : {
-// CHECK:           sv.generate.for %i = 0 : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
+// CHECK:           sv.generate.for %i = #hw.param.decl.ref<"START"> : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
 // CHECK:             sv.initial {
 // CHECK:               sv.fwrite {{%.+}}, "i = %d\0A"(%i) : i32
 // CHECK:             }
 // CHECK:           }
 
 // SV-LABEL: module Loop1
-// SV:         #(parameter /*integer*/ NUM)
+// SV:         #(parameter /*integer*/ NUM,
+// SV:                     /*integer*/ START
 // SV:         generate
 // SV:         begin: foo_loop
-// SV:           for (genvar i = 0; i < NUM; i += 1) begin : gen_blk
+// SV:           for (genvar i = START; i < NUM; i += 1) begin : gen_blk
 // SV:             initial
 // SV:               $fwrite(32'h80000002, "i = %d\n", i);
 // SV:           end

--- a/test/Dialect/SV/generates.mlir
+++ b/test/Dialect/SV/generates.mlir
@@ -96,35 +96,34 @@ hw.module @CaseNoDefault<NUM : i8> () {
 // SV:         endgenerate
 // SV:       endmodule
 
-hw.module @PrintVal(in %val : i32) {
+hw.module @Loop1<NUM : i32> () {
   %fd = hw.constant 0x80000002 : i32
-  sv.initial {
-    sv.fwrite %fd, "val = %d\n"(%val) : i32
-  }
-}
-
-hw.module @Loop1() {
   sv.generate "foo_loop": {
-    sv.generate.for %i : i32 = 0 to 10 step 1 name "gen_blk" {
-      hw.instance "print" @PrintVal(val: %i: i32) -> ()
+    sv.generate.for %i = 0 : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
+      sv.initial {
+        sv.fwrite %fd, "i = %d\n"(%i) : i32
+      }
     }
   }
 }
 
 // CHECK-LABEL: hw.module @Loop1
 // CHECK:         sv.generate "foo_loop" : {
-// CHECK:           sv.generate.for %{{.*}} : i32 = 0 to 10 step 1 name "gen_blk" {
-// CHECK:             hw.instance "print" @PrintVal(val: %{{.*}}: i32) -> ()
+// CHECK:           sv.generate.for %i = 0 : i32 to #hw.param.decl.ref<"NUM"> : i32 step 1 : i32 name "gen_blk" {
+// CHECK:             sv.initial {
+// CHECK:               sv.fwrite {{%.+}}, "i = %d\0A"(%i) : i32
+// CHECK:             }
 // CHECK:           }
 
 // SV-LABEL: module Loop1
+// SV:         #(parameter /*integer*/ NUM)
 // SV:         generate
 // SV:         begin: foo_loop
-// SV:           for (genvar i = 0; i < 10; i += 1) begin : gen_blk
-// SV:             PrintVal print (
-// SV:               .val (i)
-// SV:             );
+// SV:           for (genvar i = 0; i < NUM; i += 1) begin : gen_blk
+// SV:             initial
+// SV:               $fwrite(32'h80000002, "i = %d\n", i);
 // SV:           end
 // SV:         end: foo_loop
 // SV:         endgenerate
 // SV:       endmodule
+


### PR DESCRIPTION
Following the example of the case generate construct, add generate construct for loops.
    
The emissions prefers the newer standard style (e.g., `for (genvar i = 0; ...)`) for loop-generate constructs. Chose to emit the `genvar` declaration automatically in the loop header, making it transparent to the IR which only sees and references the induction variable as a local parameter (block argument).
    
Also added a small lint check for the generated SystemVerilog.
    
Assisted-by: Gemini