### PR TITLE
[firtool] Move SpecializeOption after InferResets

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -53,11 +53,6 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
 
 LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
                                                   const FirtoolOptions &opt) {
-  // TODO: Ensure instance graph and other passes can handle instance choice
-  // then run this pass after all diagnostic passes have run.
-  pm.addNestedPass<firrtl::CircuitOp>(firrtl::createSpecializeOption(
-      {/*selectDefaultInstanceChoice*/ opt
-           .shouldSelectDefaultInstanceChoice()}));
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerSignatures());
 
   // This pass is _not_ idempotent.  It preserves its controlling annotation for
@@ -95,6 +90,11 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       {/*replSeqMemFile=*/opt.shouldIgnoreReadEnableMemories()}));
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResets());
+
+  // TODO: Move this to the same location as SpecializeLayers.
+  pm.addNestedPass<firrtl::CircuitOp>(firrtl::createSpecializeOption(
+      {/*selectDefaultInstanceChoice*/ opt
+           .shouldSelectDefaultInstanceChoice()}));
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDropConst());
 

--- a/test/firtool/instance-choice.fir
+++ b/test/firtool/instance-choice.fir
@@ -1,4 +1,5 @@
 ; RUN: firtool %s | FileCheck %s
+; RUN: firtool %s --select-default-for-unspecified-instance-choice | FileCheck %s --check-prefix=SPECIALIZE
 
 FIRRTL version 5.1.0
 circuit top:
@@ -6,11 +7,13 @@ circuit top:
     FPGA
 
   module DefaultTarget:
+    input rst: Reset
     output result: UInt<32>[1]
 
     connect result[0], UInt<32>(0)
 
   module FPGATarget:
+    input rst: Reset
     output result: UInt<32>[1]
 
     connect result[0], UInt<32>(20)
@@ -21,13 +24,16 @@ circuit top:
     ; CHECK:       wire [31:0] [[RESULT:.+]];
     ; CHECK-NEXT:  `ifdef targets$Platform$FPGA
     ; CHECK-NEXT:    FPGATarget proc_FPGA (
+    ; CHECK-NEXT:      .rst (rst),
     ; CHECK-NEXT:      .result_0 ([[RESULT]])
     ; CHECK-NEXT:    );
     ; CHECK-NEXT:    `define targets$Platform$top$proc proc_FPGA
     ; CHECK-NEXT:  `else  // targets$Platform$FPGA
     ; CHECK-NEXT:   $error("Required instance choice option 'Platform' not selected, must define one of: 'targets$Platform$FPGA'");
     ; CHECK-NEXT:  `endif // targets$Platform$FPGA
+    ; SPECIALIZE-NOT: FPGATarget
     instchoice proc of DefaultTarget, Platform:
       FPGA => FPGATarget
+    connect proc.rst, rst
 
     printf(clk, UInt<1>(1), "result: %d\n", proc.result[0])


### PR DESCRIPTION
Move the SpecializeOption pass from the beginning of the CHIRRTL to LowFIRRTL pipeline to after InferResets.

Close https://github.com/llvm/circt/issues/10380
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
