### PR TITLE
[PyCDE] Don't call 'echo' in setup.py

### DIFF
--- a/frontends/PyCDE/setup.py
+++ b/frontends/PyCDE/setup.py
@@ -102,8 +102,7 @@ class CMakeBuild(build_py):
     cmake_cache_file = os.path.join(cmake_build_dir, "CMakeCache.txt")
     if os.path.exists(cmake_cache_file):
       os.remove(cmake_cache_file)
-    print(f"Running cmake with args: {cmake_args}", file=sys.stderr)
-    subprocess.check_call(["echo", "Running: cmake", src_dir] + cmake_args)
+    print(f"Running: cmake {src_dir} {' '.join(cmake_args)}", file=sys.stderr)
     subprocess.check_call(["cmake", src_dir] + cmake_args, cwd=cmake_build_dir)
     targets = ["check-pycde"]
     if "RUN_TESTS" in os.environ and os.environ["RUN_TESTS"] != "false":


### PR DESCRIPTION
On Windows, echo is built in so setup fails.


