### PR TITLE
[ESI][Runtime] Refactor pytest for loopback C++

### DIFF
--- a/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
@@ -115,6 +115,45 @@ class TestCosimEsitester:
         "writemem[32].addrCmdResponses: 0",
     ])
 
+  def test_channel_python(self, conn: AcceleratorConnection) -> None:
+    """Test ChannelService ToHost and FromHost ports from Python."""
+    acc = conn.build_accelerator()
+    channel_test = acc.children[esiaccel.AppID("channel_test")]
+    ports = channel_test.ports
+
+    # Get the MMIO port and trigger the producer to send 5 values.
+    mmio = ports[esiaccel.AppID("cmd")]
+    assert isinstance(mmio, types.MMIORegion), \
+        f"Expected MMIORegion, got {type(mmio)}"
+
+    producer = ports[esiaccel.AppID("producer")]
+    assert isinstance(producer, types.ToHostPort), \
+        f"Expected ToHostPort, got {type(producer)}"
+    producer.connect()
+
+    num_values = 5
+    mmio.write(0x0, num_values)
+    for i in range(num_values):
+      result = producer.read().result()
+      assert result == i, f"Producer: expected {i}, got {result}"
+
+    # Test from_host -> to_host loopback.
+    loopback_in = ports[esiaccel.AppID("loopback_in")]
+    assert isinstance(loopback_in, types.FromHostPort), \
+        f"Expected FromHostPort, got {type(loopback_in)}"
+    loopback_in.connect()
+
+    loopback_out = ports[esiaccel.AppID("loopback_out")]
+    assert isinstance(loopback_out, types.ToHostPort), \
+        f"Expected ToHostPort, got {type(loopback_out)}"
+    loopback_out.connect()
+
+    for i in range(5):
+      loopback_in.write(42 + i)
+      result = loopback_out.read().result()
+      assert result == 42 + i, \
+          f"Loopback: expected {42 + i}, got {result}"
+
 
 @cosim_test(HW_DIR / "esitester.py", args=("{tmp_dir}", "cosim_dma"))
 class TestCosimEsitesterDma:
@@ -162,44 +201,3 @@ class TestCosimEsitesterDma:
         "coord[0]=",
         "Serial coord translate test passed",
     ])
-
-
-@cosim_test(HW_DIR / "esitester.py", args=("{tmp_dir}", "cosim"))
-def test_channel_python(conn: AcceleratorConnection) -> None:
-  """Test ChannelService ToHost and FromHost ports from Python."""
-  acc = conn.build_accelerator()
-  channel_test = acc.children[esiaccel.AppID("channel_test")]
-  ports = channel_test.ports
-
-  # Get the MMIO port and trigger the producer to send 5 values.
-  mmio = ports[esiaccel.AppID("cmd")]
-  assert isinstance(mmio, types.MMIORegion), \
-      f"Expected MMIORegion, got {type(mmio)}"
-
-  producer = ports[esiaccel.AppID("producer")]
-  assert isinstance(producer, types.ToHostPort), \
-      f"Expected ToHostPort, got {type(producer)}"
-  producer.connect()
-
-  num_values = 5
-  mmio.write(0x0, num_values)
-  for i in range(num_values):
-    result = producer.read().result()
-    assert result == i, f"Producer: expected {i}, got {result}"
-
-  # Test from_host -> to_host loopback.
-  loopback_in = ports[esiaccel.AppID("loopback_in")]
-  assert isinstance(loopback_in, types.FromHostPort), \
-      f"Expected FromHostPort, got {type(loopback_in)}"
-  loopback_in.connect()
-
-  loopback_out = ports[esiaccel.AppID("loopback_out")]
-  assert isinstance(loopback_out, types.ToHostPort), \
-      f"Expected ToHostPort, got {type(loopback_out)}"
-  loopback_out.connect()
-
-  for i in range(5):
-    loopback_in.write(42 + i)
-    result = loopback_out.read().result()
-    assert result == 42 + i, \
-        f"Loopback: expected {42 + i}, got {result}"

--- a/lib/Dialect/ESI/runtime/tests/integration/test_loopback_cpp.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_loopback_cpp.py
@@ -16,27 +16,37 @@ from esiaccel.cosim.pytest import cosim_test
 from .conftest import (HW_DIR, SW_DIR, check_lines, get_runtime_root,
                        require_tool)
 
+LOOPBACK_EXPECTED = [
+    "depth: 0x5",
+    "loopback i8 ok: 0x5a",
+    "struct func ok: b=-7 x=-6 y=-7",
+    "odd struct func ok: a=2749 b=-20 p=10 q=-5 r0=4 r1=6",
+    "array func ok: -3 -2",
+]
+
+LOOPBACK_TYPED_EXPECTED = LOOPBACK_EXPECTED[:1] + [
+    "loopback i8 ok: 0x5a",
+    "sint4 loopback ok: pos=5 neg=-3",
+    "struct func ok: b=-7 x=-6 y=-7",
+    "odd struct func ok: a=2749 b=-20 p=10 q=-5 r0=4 r1=6",
+    "array func ok: -3 -2",
+]
+
 
 @cosim_test(HW_DIR / "loopback.py")
-@pytest.mark.parametrize("mode", ["from_manifest", "from_accel"])
-def test_loopback_cpp_codegen(mode: str, tmp_path: Path, host: str, port: int,
-                              sources_dir: Path) -> None:
-  require_tool("cmake")
+class TestLoopback:
+  """Tests for esiquery against the loopback design."""
 
-  runtime_root = get_runtime_root()
+  def test_loopback_cpp_codegen(self, tmp_path: Path, host: str,
+                                port: int) -> None:
+    require_tool("cmake")
 
-  include_dir = tmp_path / "include"
-  generated_dir = include_dir / "loopback"
-  generated_dir.mkdir(parents=True, exist_ok=True)
-  if mode == "from_manifest":
-    # Codegen was already run automatically; copy the generated code.
-    codegen_src = sources_dir / "generated"
-    if codegen_src.exists():
-      for item in codegen_src.iterdir():
-        if item.is_file():
-          shutil.copy(item, generated_dir)
-  else:
-    # Generate from live cosim connection instead.
+    runtime_root = get_runtime_root()
+
+    include_dir = tmp_path / "include"
+    generated_dir = include_dir / "loopback"
+    generated_dir.mkdir(parents=True, exist_ok=True)
+
     subprocess.run(
         [
             sys.executable,
@@ -52,79 +62,95 @@ def test_loopback_cpp_codegen(mode: str, tmp_path: Path, host: str, port: int,
         check=True,
     )
 
-  # Verify generated header content (LOOPBACK-H checks).
-  header_path = generated_dir / "LoopbackIP.h"
-  assert header_path.exists(), "Generated header LoopbackIP.h not found"
-  header_content = header_path.read_text()
-  check_lines(header_content, [
-      "/// Generated header for esi_system module LoopbackIP.",
-      "#pragma once",
-      '#include "types.h"',
-      "namespace esi_system {",
-      "class LoopbackIP {",
-      "static constexpr uint32_t depth = 0x5;",
-      "} // namespace esi_system",
-  ])
+    # Verify generated header content (LOOPBACK-H checks).
+    header_path = generated_dir / "LoopbackIP.h"
+    assert header_path.exists(), "Generated header LoopbackIP.h not found"
+    header_content = header_path.read_text()
+    check_lines(header_content, [
+        "/// Generated header for esi_system module LoopbackIP.",
+        "#pragma once",
+        '#include "types.h"',
+        "namespace esi_system {",
+        "class LoopbackIP {",
+        "static constexpr uint32_t depth = 0x5;",
+        "} // namespace esi_system",
+    ])
 
-  build_dir = tmp_path / f"loopback-build-{mode}"
-  result = subprocess.run(
-      [
-          "cmake",
-          "-S",
-          str(SW_DIR),
-          "-B",
-          str(build_dir),
-          f"-DLOOPBACK_GENERATED_DIR={include_dir}",
-          f"-DESI_RUNTIME_ROOT={runtime_root}",
-      ],
-      capture_output=True,
-      text=True,
-  )
-  assert result.returncode == 0, (
-      f"cmake configure failed (rc={result.returncode}):\n"
-      f"--- stdout ---\n{result.stdout}\n"
-      f"--- stderr ---\n{result.stderr}")
+    build_dir = tmp_path / "loopback-build"
+    result = subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(SW_DIR),
+            "-B",
+            str(build_dir),
+            f"-DLOOPBACK_GENERATED_DIR={include_dir}",
+            f"-DESI_RUNTIME_ROOT={runtime_root}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"cmake configure failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}")
 
-  result = subprocess.run(
-      ["cmake", "--build",
-       str(build_dir), "--target", "loopback_test"],
-      capture_output=True,
-      text=True,
-  )
-  assert result.returncode == 0, (
-      f"cmake build failed (rc={result.returncode}):\n"
-      f"--- stdout ---\n{result.stdout}\n"
-      f"--- stderr ---\n{result.stderr}")
+    result = subprocess.run(
+        ["cmake", "--build",
+         str(build_dir), "--target", "loopback_test"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"cmake build failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}")
 
-  LOOPBACK_EXPECTED = [
-      "depth: 0x5",
-      "loopback i8 ok: 0x5a",
-      "struct func ok: b=-7 x=-6 y=-7",
-      "odd struct func ok: a=2749 b=-20 p=10 q=-5 r0=4 r1=6",
-      "array func ok: -3 -2",
-  ]
+    # Run the C++ test binary and verify output (CPP-TEST checks).
+    result = subprocess.run(
+        [str(build_dir / "loopback_test"), "cosim", f"{host}:{port}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    check_lines(result.stdout, LOOPBACK_EXPECTED)
 
-  LOOPBACK_TYPED_EXPECTED = LOOPBACK_EXPECTED[:1] + [
-      "loopback i8 ok: 0x5a",
-      "sint4 loopback ok: pos=5 neg=-3",
-      "struct func ok: b=-7 x=-6 y=-7",
-      "odd struct func ok: a=2749 b=-20 p=10 q=-5 r0=4 r1=6",
-      "array func ok: -3 -2",
-  ]
+  def test_loopback_typed_cpp_codegen(self, tmp_path: Path, host: str,
+                                      port: int, sources_dir: Path) -> None:
+    require_tool("cmake")
 
-  # Run the C++ test binary and verify output (CPP-TEST checks).
-  result = subprocess.run(
-      [str(build_dir / "loopback_test"), "cosim", f"{host}:{port}"],
-      check=True,
-      capture_output=True,
-      text=True,
-  )
-  check_lines(result.stdout, LOOPBACK_EXPECTED)
+    runtime_root = get_runtime_root()
 
-  # Also build and run the typed-port variant (loopback_typed_test) which
-  # exercises TypedWritePort, TypedReadPort, and TypedFunction wrappers.
-  # Only done for a single codegen mode to avoid redundant work.
-  if mode == "from_manifest":
+    include_dir = tmp_path / "include"
+    generated_dir = include_dir / "loopback"
+    generated_dir.mkdir(parents=True, exist_ok=True)
+
+    # Codegen was already run automatically; copy the generated code.
+    codegen_src = sources_dir / "generated"
+    if codegen_src.exists():
+      for item in codegen_src.iterdir():
+        if item.is_file():
+          shutil.copy(item, generated_dir)
+
+    build_dir = tmp_path / "loopback_typed-build"
+    result = subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(SW_DIR),
+            "-B",
+            str(build_dir),
+            f"-DLOOPBACK_GENERATED_DIR={include_dir}",
+            f"-DESI_RUNTIME_ROOT={runtime_root}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"cmake configure failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}")
+
     result = subprocess.run(
         ["cmake", "--build",
          str(build_dir), "--target", "loopback_typed_test"],
@@ -138,16 +164,14 @@ def test_loopback_cpp_codegen(mode: str, tmp_path: Path, host: str, port: int,
 
     result = subprocess.run(
         [str(build_dir / "loopback_typed_test"), "cosim", f"{host}:{port}"],
-        check=True,
         capture_output=True,
         text=True,
     )
+    assert result.returncode == 0, (
+        f"loopback_typed_test failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}")
     check_lines(result.stdout, LOOPBACK_TYPED_EXPECTED)
-
-
-@cosim_test(HW_DIR / "loopback.py")
-class TestLoopbackQuery:
-  """Tests for esiquery against the loopback design."""
 
   def test_loopback_query_info(self, sources_dir: Path) -> None:
     """Verify esiquery info output against the generated manifest


### PR DESCRIPTION
Do one thing in each test -- run the loopback app then in another test the loopback_typed app. Increases clarity when the tests fail.
