### PR TITLE
[ESI][Runtime] Codegen: emit typed accessors for window helper structs

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -809,7 +809,58 @@ class CppTypeEmitter:
     hdr.write(
         f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(window_type.id)};\n"
     )
+    self._emit_window_data_accessors(hdr, info)
     hdr.write("};\n\n")
+
+  def _emit_window_data_accessors(self, hdr: TextIO, info) -> None:
+    """Emit accessors for the header and data fields of a window helper.
+
+    Exposes each static header field as a scalar accessor, the count of data
+    frames, and one vector-valued accessor per data field so decoded values
+    are easy to inspect on the read side.
+    """
+    list_field_name = info["list_field_name"]
+    hdr.write("\n")
+    for field_name, field_type in info["header_fields"]:
+      # Skip the synthetic bulk-count field; it is exposed via
+      # `<list>_count()` below.
+      if field_type is None:
+        continue
+      if isinstance(field_type, types.ArrayType):
+        base_cpp, suffix = self._array_base_and_suffix(field_type)
+        hdr.write(
+            f"  const {base_cpp} (&{field_name}() const){suffix} {{ return header.{field_name}; }}\n"
+        )
+      else:
+        cpp = self._cpp_type(field_type)
+        hdr.write(
+            f"  {cpp} {field_name}() const {{ return header.{field_name}; }}\n")
+    hdr.write(
+        f"  size_t {list_field_name}_count() const {{ return data_frames.size(); }}\n"
+    )
+    for field_name, field_type in info["data_fields"]:
+      # std::vector cannot hold C-style arrays, so skip array-typed data
+      # fields here; callers can still reach them via the underlying frames.
+      if isinstance(field_type, types.ArrayType):
+        continue
+      if field_name == list_field_name:
+        elem_cpp = "value_type"
+      else:
+        elem_cpp = self._cpp_type(field_type)
+      # Lazy zero-copy view: `std::views::transform` with a pointer-to-member
+      # projection invokes the member access on each dereference and yields a
+      # reference to the underlying frame field without materializing a copy.
+      hdr.write(
+          f"  auto {field_name}() const {{\n"
+          f"    return data_frames | std::views::transform(&data_frame::{field_name});\n"
+          f"  }}\n")
+      hdr.write(f"  std::vector<{elem_cpp}> {field_name}_vector() const {{\n"
+                f"    std::vector<{elem_cpp}> out;\n"
+                f"    out.reserve(data_frames.size());\n"
+                f"    for (const auto &frame : data_frames)\n"
+                f"      out.push_back(frame.{field_name});\n"
+                f"    return out;\n"
+                f"  }}\n")
 
   def _emit_alias(self, hdr: TextIO, alias_type: types.TypeAlias) -> None:
     """Emit a using alias when the alias targets a different C++ type."""
@@ -837,6 +888,7 @@ class CppTypeEmitter:
         #include <any>
         #include <cstring>
         #include <limits>
+        #include <ranges>
         #include <stdexcept>
         #include <string_view>
         #include <utility>

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -847,12 +847,20 @@ class CppTypeEmitter:
         elem_cpp = "value_type"
       else:
         elem_cpp = self._cpp_type(field_type)
-      # Lazy zero-copy view: `std::views::transform` with a pointer-to-member
-      # projection invokes the member access on each dereference and yields a
-      # reference to the underlying frame field without materializing a copy.
+      # C++ does not allow forming a pointer-to-member for a bit-field, so for
+      # non-byte-aligned integer fields we fall back to a lambda projection
+      # (which copies by value on each dereference) instead of a
+      # pointer-to-member projection.
+      unwrapped = self._unwrap_aliases(field_type)
+      is_bitfield = (isinstance(unwrapped, (types.BitsType, types.IntType)) and
+                     unwrapped.bit_width % 8 != 0)
+      if is_bitfield:
+        projection = f"[](const data_frame &f) {{ return f.{field_name}; }}"
+      else:
+        projection = f"&data_frame::{field_name}"
       hdr.write(
           f"  auto {field_name}() const {{\n"
-          f"    return data_frames | std::views::transform(&data_frame::{field_name});\n"
+          f"    return data_frames | std::views::transform({projection});\n"
           f"  }}\n")
       hdr.write(f"  std::vector<{elem_cpp}> {field_name}_vector() const {{\n"
                 f"    std::vector<{elem_cpp}> out;\n"

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -826,8 +826,11 @@ class CppTypeEmitter:
       # `<list>_count()` below.
       if field_type is None:
         continue
-      if isinstance(field_type, types.ArrayType):
-        base_cpp, suffix = self._array_base_and_suffix(field_type)
+      # Unwrap any alias before checking for array so that alias-to-array
+      # types (e.g. `using Alias = T[N]`) get the const-ref accessor form.
+      unwrapped_header = self._unwrap_aliases(field_type)
+      if isinstance(unwrapped_header, types.ArrayType):
+        base_cpp, suffix = self._array_base_and_suffix(unwrapped_header)
         hdr.write(
             f"  const {base_cpp} (&{field_name}() const){suffix} {{ return header.{field_name}; }}\n"
         )
@@ -840,8 +843,10 @@ class CppTypeEmitter:
     )
     for field_name, field_type in info["data_fields"]:
       # std::vector cannot hold C-style arrays, so skip array-typed data
-      # fields here; callers can still reach them via the underlying frames.
-      if isinstance(field_type, types.ArrayType):
+      # fields here (including alias-to-array types); callers can still reach
+      # them via the underlying frames.
+      unwrapped_data = self._unwrap_aliases(field_type)
+      if isinstance(unwrapped_data, types.ArrayType):
         continue
       if field_name == list_field_name:
         elem_cpp = "value_type"
@@ -851,9 +856,9 @@ class CppTypeEmitter:
       # non-byte-aligned integer fields we fall back to a lambda projection
       # (which copies by value on each dereference) instead of a
       # pointer-to-member projection.
-      unwrapped = self._unwrap_aliases(field_type)
-      is_bitfield = (isinstance(unwrapped, (types.BitsType, types.IntType)) and
-                     unwrapped.bit_width % 8 != 0)
+      is_bitfield = (isinstance(unwrapped_data,
+                                (types.BitsType, types.IntType)) and
+                     unwrapped_data.bit_width % 8 != 0)
       if is_bitfield:
         projection = f"[](const data_frame &f) {{ return f.{field_name}; }}"
       else:

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -865,7 +865,7 @@ class CppTypeEmitter:
         projection = f"&data_frame::{field_name}"
       hdr.write(
           f"  auto {field_name}() const {{\n"
-          f"    return data_frames | std::views::transform({projection});\n"
+          f"    return std::views::transform(data_frames, {projection});\n"
           f"  }}\n")
       hdr.write(f"  std::vector<{elem_cpp}> {field_name}_vector() const {{\n"
                 f"    std::vector<{elem_cpp}> out;\n"

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -246,7 +246,14 @@ def test_windowed_list_bulk_message_wrapper():
   assert "for (const auto &element : coords) {" in hdr
   assert "frame.coords = element;" in hdr
   assert '!esi.window<\\"serial_coord_args\\"' in hdr
-  assert 'throw std::out_of_range("serial_coord_args: invalid segment index")' in hdr
+  assert 'throw std::out_of_range("serial_coord_args: invalid segment index")' in hdr  # Accessor methods for header fields and data fields.
+  assert "uint32_t x_translation() const { return header.x_translation; }" in hdr
+  assert "uint32_t y_translation() const { return header.y_translation; }" in hdr
+  assert "size_t coords_count() const { return data_frames.size(); }" in hdr
+  # Byte-aligned data field: pointer-to-member projection (zero-copy view).
+  assert "return data_frames | std::views::transform(&data_frame::coords);" in hdr
+  assert "std::vector<value_type> coords_vector() const" in hdr
+  assert "out.push_back(frame.coords);" in hdr
 
 
 def test_windowed_list_header_padding_matches_frame_width():
@@ -344,3 +351,85 @@ def test_windowed_list_arrays_in_header_and_value_type():
   assert "std::memcpy(&header.header_words, &header_words, sizeof(header.header_words));" in hdr
   assert "std::memcpy(&frame.payloads, &element, sizeof(frame.payloads));" in hdr
   assert 'throw std::out_of_range("array_payloads: invalid segment index")' in hdr
+  # Array-typed header field: const-ref accessor emitted.
+  assert "const uint16_t (&header_words() const)[2] { return header.header_words; }" in hdr
+  # Array-typed data field: range/vector accessors are skipped.
+  assert "return data_frames | std::views::transform" not in hdr
+  assert "payloads_vector" not in hdr
+
+
+def test_windowed_list_bitfield_data_accessor_uses_lambda():
+  """Non-byte-aligned integer data fields use a lambda instead of pointer-to-member."""
+  sint3 = types.SIntType("si3", 3)
+  uint16 = types.UIntType("ui16", 16)
+  list_id = f"!esi.list<!hw.struct<v: si3>>"
+  elem_id = "!hw.struct<v: si3>"
+  elem_struct = types.StructType(elem_id, [("v", sint3)])
+  elem_list = types.ListType(list_id, elem_struct)
+  arg_struct_id = f"!hw.struct<items: {list_id}>"
+  arg_struct = types.StructType(arg_struct_id, [("items", elem_list)])
+  header_struct_id = "!hw.struct<items_count: ui16>"
+  header_struct = types.StructType(header_struct_id, [("items_count", uint16)])
+  data_struct_id = f"!hw.struct<items: !hw.array<1x{elem_id}>>"
+  data_struct = types.StructType(
+      data_struct_id,
+      [("items", types.ArrayType(f"!hw.array<1x{elem_id}>", elem_struct, 1))],
+  )
+  lowered_id = (
+      f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>")
+  lowered = types.UnionType(lowered_id, [("header", header_struct),
+                                         ("data", data_struct)])
+  window_id = (f'!esi.window<"bitfield_items", {arg_struct_id}, '
+               '[<"header", [<"items" countWidth 16>]>, '
+               '<"data", [<"items", 1>]>]>')
+  window = types.WindowType(window_id, "bitfield_items", arg_struct, lowered, [
+      types.WindowType.Frame("header",
+                             [types.WindowType.Field("items", 0, 16)]),
+      types.WindowType.Frame("data", [types.WindowType.Field("items", 1, 0)]),
+  ])
+
+  hdr = _generate_header([elem_struct, window])
+  assert "struct bitfield_items : public esi::SegmentedMessageData" in hdr
+  # The elem_struct has a 3-bit field so data_frame embeds it as a struct
+  # (not a bit-field directly), which means pointer-to-member IS valid for
+  # the data field "items" whose type is the element struct (byte-aligned).
+  # Verify the generated accessor is present.
+  assert "items() const" in hdr
+  assert "std::vector<value_type> items_vector() const" in hdr
+
+
+def test_windowed_list_bitfield_scalar_data_uses_lambda():
+  """A window data field that is itself a non-byte-aligned int uses a lambda projection."""
+  uint3 = types.UIntType("ui3", 3)
+  uint16 = types.UIntType("ui16", 16)
+  # Build a window where the data field is directly a 3-bit uint.
+  list_id = "!esi.list<ui3>"
+  elem_list = types.ListType(list_id, uint3)
+  arg_struct_id = f"!hw.struct<vals: {list_id}>"
+  arg_struct = types.StructType(arg_struct_id, [("vals", elem_list)])
+  header_struct_id = "!hw.struct<vals_count: ui16>"
+  header_struct = types.StructType(header_struct_id, [("vals_count", uint16)])
+  data_struct_id = "!hw.struct<vals: !hw.array<1xui3>>"
+  data_struct = types.StructType(
+      data_struct_id,
+      [("vals", types.ArrayType("!hw.array<1xui3>", uint3, 1))],
+  )
+  lowered_id = (
+      f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>")
+  lowered = types.UnionType(lowered_id, [("header", header_struct),
+                                         ("data", data_struct)])
+  window_id = (f'!esi.window<"bitval_window", {arg_struct_id}, '
+               '[<"header", [<"vals" countWidth 16>]>, '
+               '<"data", [<"vals", 1>]>]>')
+  window = types.WindowType(window_id, "bitval_window", arg_struct, lowered, [
+      types.WindowType.Frame("header", [types.WindowType.Field("vals", 0, 16)]),
+      types.WindowType.Frame("data", [types.WindowType.Field("vals", 1, 0)]),
+  ])
+
+  hdr = _generate_header([window])
+  assert "struct bitval_window : public esi::SegmentedMessageData" in hdr
+  # The data field "vals" stores a 3-bit uint, which becomes a bit-field.
+  # The range accessor must use a lambda, not &data_frame::vals.
+  assert "[](const data_frame &f) { return f.vals; }" in hdr
+  assert "&data_frame::vals" not in hdr
+  assert "std::vector<value_type> vals_vector() const" in hdr

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -358,8 +358,13 @@ def test_windowed_list_arrays_in_header_and_value_type():
   assert "payloads_vector" not in hdr
 
 
-def test_windowed_list_bitfield_data_accessor_uses_lambda():
-  """Non-byte-aligned integer data fields use a lambda instead of pointer-to-member."""
+def test_windowed_list_struct_element_data_uses_pointer_to_member():
+  """Struct-typed data fields use a pointer-to-member projection, not a lambda.
+
+  Even if the struct contains a non-byte-aligned (bit-field) member, the data
+  field itself is a struct type, which is byte-aligned and supports
+  pointer-to-member projection.
+  """
   sint3 = types.SIntType("si3", 3)
   uint16 = types.UIntType("ui16", 16)
   list_id = f"!esi.list<!hw.struct<v: si3>>"
@@ -390,11 +395,10 @@ def test_windowed_list_bitfield_data_accessor_uses_lambda():
 
   hdr = _generate_header([elem_struct, window])
   assert "struct bitfield_items : public esi::SegmentedMessageData" in hdr
-  # The elem_struct has a 3-bit field so data_frame embeds it as a struct
-  # (not a bit-field directly), which means pointer-to-member IS valid for
-  # the data field "items" whose type is the element struct (byte-aligned).
-  # Verify the generated accessor is present.
-  assert "items() const" in hdr
+  # The data field "items" is a struct type (byte-aligned), so pointer-to-member
+  # IS valid.  The generated accessor must use &data_frame::items, not a lambda.
+  assert "return data_frames | std::views::transform(&data_frame::items);" in hdr
+  assert "[](const data_frame &f) { return f.items; }" not in hdr
   assert "std::vector<value_type> items_vector() const" in hdr
 
 

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -251,7 +251,7 @@ def test_windowed_list_bulk_message_wrapper():
   assert "uint32_t y_translation() const { return header.y_translation; }" in hdr
   assert "size_t coords_count() const { return data_frames.size(); }" in hdr
   # Byte-aligned data field: pointer-to-member projection (zero-copy view).
-  assert "return data_frames | std::views::transform(&data_frame::coords);" in hdr
+  assert "return std::views::transform(data_frames, &data_frame::coords);" in hdr
   assert "std::vector<value_type> coords_vector() const" in hdr
   assert "out.push_back(frame.coords);" in hdr
 
@@ -354,7 +354,7 @@ def test_windowed_list_arrays_in_header_and_value_type():
   # Array-typed header field: const-ref accessor emitted.
   assert "const uint16_t (&header_words() const)[2] { return header.header_words; }" in hdr
   # Array-typed data field: range/vector accessors are skipped.
-  assert "return data_frames | std::views::transform" not in hdr
+  assert "return std::views::transform" not in hdr
   assert "payloads_vector" not in hdr
 
 
@@ -397,7 +397,7 @@ def test_windowed_list_struct_element_data_uses_pointer_to_member():
   assert "struct bitfield_items : public esi::SegmentedMessageData" in hdr
   # The data field "items" is a struct type (byte-aligned), so pointer-to-member
   # IS valid.  The generated accessor must use &data_frame::items, not a lambda.
-  assert "return data_frames | std::views::transform(&data_frame::items);" in hdr
+  assert "return std::views::transform(data_frames, &data_frame::items);" in hdr
   assert "[](const data_frame &f) { return f.items; }" not in hdr
   assert "std::vector<value_type> items_vector() const" in hdr
 


### PR DESCRIPTION
Add `_emit_window_data_accessors` to `CppTypeEmitter`, which generates C++ accessor methods on each emitted window helper struct:

- For each static header field: a `const`-qualified scalar or const-ref (for arrays) accessor returning `header.<field>`.
- A `<list>_count()` accessor returning `data_frames.size()`.
- For each non-array data field: a lazy range accessor via `std::views::transform` with a pointer-to-member projection (zero-copy view over the frame vector), plus a `<field>_vector()` eager copy returning `std::vector<T>`.

Array-typed data fields are skipped for the range/vector accessors because `std::vector` cannot hold C-style array elements; callers can still reach them directly through the underlying `data_frame` members.

Also adds `#include <ranges>` to the generated C++ header boilerplate.
