### PR TITLE
[circt][arc] Add bufferized array handling

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -21,6 +21,7 @@ include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
+
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -551,7 +552,7 @@ def RootOutputOp : ArcOp<"root_output", [
 // Storage Access
 //===----------------------------------------------------------------------===//
 
-def AllocatableType : AnyTypeOf<[StateType, MemoryType, StorageType]>;
+def AllocatableType : AnyTypeOf<[StateType, MemoryType, StorageType, ArrayRefType]>;
 
 def StorageGetOp : ArcOp<"storage.get", [Pure]> {
   let summary = "Access an allocated state, memory, or storage slice";
@@ -1077,6 +1078,96 @@ def RuntimeModelOp : ArcOp<"runtime.model", [
   let assemblyFormat = [{
     $sym_name $name `numStateBytes` $numStateBytes
     (`traceTaps` $traceTaps^)? attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// ArrayRef ops
+//===----------------------------------------------------------------------===//
+//
+// Ops that deal with bufferized arrays. The !hw.array type has value semantics;
+// the !arc.arrayref type is the equivalent but with reference semantics.
+def ArrayRefAllocOp : ArcOp<"arrayref.alloc", []> {
+  let summary = "array allocation";
+  let description = [{
+    Allocates an array on the stack. If `init` is set, the array is initialized
+    to this value. Otherwise the array's contents are undefined.
+  }];
+  let arguments = (ins OptionalAttr<AnyAttr>:$init);
+  let results = (outs ArrayRefType:$dest);
+  let assemblyFormat = "attr-dict (`init` $init^)? type($dest)";
+}
+
+def ArrayRefGetOp : ArcOp<"arrayref.get", [
+  MemoryEffects<[MemRead]>
+]> {
+  let summary = "array get";
+  let description = [{
+    Loads a single value from an arrayref.
+  }];
+  let arguments = (ins ArrayRefType:$array, Index:$index);
+  let results = (outs AnyType:$value);
+  let assemblyFormat = [{
+    $array `[` $index `]` attr-dict `:` type($array) `->` type($value)
+  }];
+}
+
+def ArrayRefInjectOp : ArcOp<"arrayref.inject", [
+  MemoryEffects<[MemRead, MemWrite]>
+]> {
+  let summary = "array inject";
+  let description = [{
+    Stores a single value into an arrayref.
+  }];
+  let arguments = (ins ArrayRefType:$input, Index:$index, AnyType:$element);
+  let results = (outs ArrayRefType:$result);
+  let assemblyFormat = [{
+    $input `[` $index `]` `,` $element attr-dict `:` type($input) `,` type($element) `->` type($result)
+  }];
+}
+
+def ArrayRefSliceOp : ArcOp<"arrayref.slice", [Pure]> {
+  let summary = "array slice";
+  let description = [{
+    Slices an array into a sub-array, returning a view into the original array.
+  }];
+  let arguments = (ins ArrayRefType:$input, Index:$lowIndex);
+  let results = (outs ArrayRefType:$dst);
+  let assemblyFormat = [{
+    $input`[`$lowIndex`]` attr-dict `:` functional-type($input, $dst)
+  }];
+}
+
+def ArrayRefCopyOp : ArcOp<"arrayref.copy", [
+  MemoryEffects<[MemRead, MemWrite]>,
+  SameOperandsAndResultType,
+]> {
+  let summary = "array copy";
+  let description = [{
+    Copies the content of one array into another array. Returns the input array.
+  }];
+  let arguments = (ins ArrayRefType:$destInput, ArrayRefType:$source);
+  let results = (outs ArrayRefType:$destResult);
+  let assemblyFormat = [{
+    $destInput `=` $source attr-dict `:` type($destInput)
+  }];
+}
+
+def ArrayRefCreateOp : ArcOp<"arrayref.create", [
+  MemoryEffects<[MemWrite]>
+]> {
+  let summary = "array create";
+  let description = [{
+    Creates an array from a list of values. The values are ordered from
+    most significant to least significant (the same as `hw.array_create`).
+
+    The `input` array is populated with `elements` and is returned.
+  }];
+  let arguments = (ins ArrayRefType:$input, Variadic<AnyType>:$elements);
+  let results = (outs ArrayRefType:$dest);
+  let assemblyFormat = [{
+    $input `=` $elements attr-dict `:` type($dest)
+    custom<ARCreate>(ref(type($dest)), type($input), type($elements))
   }];
 }
 

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -21,7 +21,6 @@ include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
-
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -552,7 +551,8 @@ def RootOutputOp : ArcOp<"root_output", [
 // Storage Access
 //===----------------------------------------------------------------------===//
 
-def AllocatableType : AnyTypeOf<[StateType, MemoryType, StorageType, ArrayRefType]>;
+def AllocatableType : AnyTypeOf<[StateType, MemoryType, StorageType,
+                                 ArrayRefType]>;
 
 def StorageGetOp : ArcOp<"storage.get", [Pure]> {
   let summary = "Access an allocated state, memory, or storage slice";
@@ -634,12 +634,12 @@ def TerminateOp : ArcOp<"terminate", [
   let description = [{
     Sets a termination flag in the model's storage.
     It unconditionally writes 1 for success or 2 for failure.
-    This allows the simulation to exit gracefully after the current 
+    This allows the simulation to exit gracefully after the current
     evaluation cycle.
   }];
 
-  let arguments = (ins 
-    StorageType:$storage, 
+  let arguments = (ins
+    StorageType:$storage,
     BoolAttr:$success
   );
 
@@ -1087,6 +1087,7 @@ def RuntimeModelOp : ArcOp<"runtime.model", [
 //
 // Ops that deal with bufferized arrays. The !hw.array type has value semantics;
 // the !arc.arrayref type is the equivalent but with reference semantics.
+
 def ArrayRefAllocOp : ArcOp<"arrayref.alloc", []> {
   let summary = "array allocation";
   let description = [{

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -1185,4 +1185,42 @@ def ArrayRefCreateOp : ArcOp<"arrayref.create", [
   }];
 }
 
+def ArrayRefFromArrayOp : ArcOp<"arrayref.from_array", [
+  MemoryEffects<[MemWrite]>,
+  AllTypesMatch<["input", "output"]>,
+  TypesMatchWith<"array type matches output type",
+                 "array", "output",
+                 "ArrayRefType::get("
+                   "cast<hw::ArrayType>($_self).getElementType(), "
+                   "cast<hw::ArrayType>($_self).getNumElements())">
+]> {
+  let summary = "arrayref from array";
+  let description = [{
+    Populates an arrayref with the elements of an array.
+  }];
+  let arguments = (ins ArrayRefType:$input, ArrayType:$array);
+  let results = (outs ArrayRefType:$output);
+  let assemblyFormat = [{
+    $input `=` $array attr-dict `:` type($output) `,` type($array)
+  }];
+}
+
+def ArrayRefToArrayOp : ArcOp<"arrayref.to_array", [
+  TypesMatchWith<"array type matches result type",
+                 "input", "result",
+                 "hw::ArrayType::get("
+                   "cast<ArrayRefType>($_self).getElementType(), "
+                   "cast<ArrayRefType>($_self).getNumElements())">
+]> {
+  let summary = "arrayref to array";
+  let description = [{
+    Creates an array from an arrayref.
+  }];
+  let arguments = (ins ArrayRefType:$input);
+  let results = (outs ArrayType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` functional-type($input, $result)
+  }];
+}
+
 #endif // CIRCT_DIALECT_ARC_ARCOPS_TD

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -1094,7 +1094,7 @@ def ArrayRefAllocOp : ArcOp<"arrayref.alloc", []> {
     Allocates an array on the stack. If `init` is set, the array is initialized
     to this value. Otherwise the array's contents are undefined.
   }];
-  let arguments = (ins OptionalAttr<DenseI64ArrayAttr>:$init);
+  let arguments = (ins OptionalAttr<ArrayAttr>:$init);
   let results = (outs ArrayRefType:$output);
   let assemblyFormat = "attr-dict (`init` `(` $init^ `)`)? `:` type($output)";
   let hasVerifier = 1;

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -1094,48 +1094,57 @@ def ArrayRefAllocOp : ArcOp<"arrayref.alloc", []> {
     Allocates an array on the stack. If `init` is set, the array is initialized
     to this value. Otherwise the array's contents are undefined.
   }];
-  let arguments = (ins OptionalAttr<AnyAttr>:$init);
-  let results = (outs ArrayRefType:$dest);
-  let assemblyFormat = "attr-dict (`init` $init^)? type($dest)";
+  let arguments = (ins OptionalAttr<DenseI64ArrayAttr>:$init);
+  let results = (outs ArrayRefType:$output);
+  let assemblyFormat = "attr-dict (`init` `(` $init^ `)`)? `:` type($output)";
+  let hasVerifier = 1;
 }
 
 def ArrayRefGetOp : ArcOp<"arrayref.get", [
-  MemoryEffects<[MemRead]>
+  MemoryEffects<[MemRead]>,
+  TypesMatchWith<"array element type matches the result type", "input", "value",
+                 "cast<ArrayRefType>($_self).getElementType()">
 ]> {
   let summary = "array get";
   let description = [{
     Loads a single value from an arrayref.
   }];
-  let arguments = (ins ArrayRefType:$array, Index:$index);
+  let arguments = (ins ArrayRefType:$input, Index:$index);
   let results = (outs AnyType:$value);
   let assemblyFormat = [{
-    $array `[` $index `]` attr-dict `:` type($array) `->` type($value)
+    $input `[` $index `]` attr-dict `:` type($input) `->` type($value)
   }];
 }
 
 def ArrayRefInjectOp : ArcOp<"arrayref.inject", [
-  MemoryEffects<[MemRead, MemWrite]>
+  MemoryEffects<[MemRead, MemWrite]>,
+  AllTypesMatch<["input", "output"]>,
+  TypesMatchWith<"element type matches input element type", "input", "element",
+                 "cast<ArrayRefType>($_self).getElementType()">
 ]> {
   let summary = "array inject";
   let description = [{
     Stores a single value into an arrayref.
   }];
   let arguments = (ins ArrayRefType:$input, Index:$index, AnyType:$element);
-  let results = (outs ArrayRefType:$result);
+  let results = (outs ArrayRefType:$output);
   let assemblyFormat = [{
-    $input `[` $index `]` `,` $element attr-dict `:` type($input) `,` type($element) `->` type($result)
+    $input `[` $index `]` `,` $element attr-dict `:` type($input) `,` type($element) `->` type($output)
   }];
 }
 
-def ArrayRefSliceOp : ArcOp<"arrayref.slice", [Pure]> {
+def ArrayRefSliceOp : ArcOp<"arrayref.slice", [
+  Pure,
+  AllElementTypesMatch<["input", "output"]>
+]> {
   let summary = "array slice";
   let description = [{
     Slices an array into a sub-array, returning a view into the original array.
   }];
   let arguments = (ins ArrayRefType:$input, Index:$lowIndex);
-  let results = (outs ArrayRefType:$dst);
+  let results = (outs ArrayRefType:$output);
   let assemblyFormat = [{
-    $input`[`$lowIndex`]` attr-dict `:` functional-type($input, $dst)
+    $input`[`$lowIndex`]` attr-dict `:` functional-type($input, $output)
   }];
 }
 
@@ -1147,15 +1156,20 @@ def ArrayRefCopyOp : ArcOp<"arrayref.copy", [
   let description = [{
     Copies the content of one array into another array. Returns the input array.
   }];
-  let arguments = (ins ArrayRefType:$destInput, ArrayRefType:$source);
-  let results = (outs ArrayRefType:$destResult);
+  let arguments = (ins ArrayRefType:$input, ArrayRefType:$source);
+  let results = (outs ArrayRefType:$output);
   let assemblyFormat = [{
-    $destInput `=` $source attr-dict `:` type($destInput)
+    $input `=` $source attr-dict `:` type($input)
   }];
 }
 
 def ArrayRefCreateOp : ArcOp<"arrayref.create", [
-  MemoryEffects<[MemWrite]>
+  MemoryEffects<[MemWrite]>,
+  AllTypesMatch<["input", "output"]>,
+  TypesMatchWith<"operand types match element type",
+                 "output", "elements", "SmallVector<Type, 2>("
+                 "cast<ArrayRefType>($_self).getNumElements(), "
+                 "cast<ArrayRefType>($_self).getElementType())">
 ]> {
   let summary = "array create";
   let description = [{
@@ -1165,10 +1179,9 @@ def ArrayRefCreateOp : ArcOp<"arrayref.create", [
     The `input` array is populated with `elements` and is returned.
   }];
   let arguments = (ins ArrayRefType:$input, Variadic<AnyType>:$elements);
-  let results = (outs ArrayRefType:$dest);
+  let results = (outs ArrayRefType:$output);
   let assemblyFormat = [{
-    $input `=` $elements attr-dict `:` type($dest)
-    custom<ARCreate>(ref(type($dest)), type($input), type($elements))
+    $input `=` $elements attr-dict `:` type($output)
   }];
 }
 

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -177,6 +177,11 @@ def LowerClocksToFuncs : Pass<"arc-lower-clocks-to-funcs", "mlir::ModuleOp"> {
   let dependentDialects = ["mlir::func::FuncDialect", "mlir::scf::SCFDialect"];
 }
 
+def LowerArrays : Pass<"arc-lower-arrays", "mlir::ModuleOp"> {
+  let summary = "Lower arrays in Arc dialect";
+  let dependentDialects = ["arc::ArcDialect"];
+}
+
 def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {
   let summary = "Lowers arc.lut into a comb and hw only representation.";
   let dependentDialects = ["hw::HWDialect", "comb::CombDialect"];

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -178,7 +178,7 @@ def LowerClocksToFuncs : Pass<"arc-lower-clocks-to-funcs", "mlir::ModuleOp"> {
 }
 
 def LowerArrays : Pass<"arc-lower-arrays", "mlir::ModuleOp"> {
-  let summary = "Lower arrays in Arc dialect";
+  let summary = "Lower arrays to use bufferized arrayrefs";
   let dependentDialects = ["arc::ArcDialect"];
 }
 

--- a/include/circt/Dialect/Arc/ArcTypes.h
+++ b/include/circt/Dialect/Arc/ArcTypes.h
@@ -17,11 +17,17 @@
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/Arc/ArcTypes.h.inc"
 
+namespace circt {
+namespace arc {
+
 /// Compute the bit width a type will have when allocated as part of the
 /// simulator's storage. This includes any padding and alignment that may be
 /// necessary once the type has been mapped to LLVM. The idea is for this
 /// function to be conservative, such that we provide sufficient storage bytes
 /// for any type.
 std::optional<uint64_t> computeLLVMBitWidth(mlir::Type type);
+
+} // namespace arc
+} // namespace circt
 
 #endif // CIRCT_DIALECT_ARC_ARCTYPES_H

--- a/include/circt/Dialect/Arc/ArcTypes.h
+++ b/include/circt/Dialect/Arc/ArcTypes.h
@@ -9,11 +9,19 @@
 #ifndef CIRCT_DIALECT_ARC_ARCTYPES_H
 #define CIRCT_DIALECT_ARC_ARCTYPES_H
 
+#include "circt/Dialect/HW/HWTypeInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/Arc/ArcTypes.h.inc"
+
+/// Compute the bit width a type will have when allocated as part of the
+/// simulator's storage. This includes any padding and alignment that may be
+/// necessary once the type has been mapped to LLVM. The idea is for this
+/// function to be conservative, such that we provide sufficient storage bytes
+/// for any type.
+std::optional<uint64_t> computeLLVMBitWidth(mlir::Type type);
 
 #endif // CIRCT_DIALECT_ARC_ARCTYPES_H

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -14,7 +14,8 @@ include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 include "circt/Dialect/HW/HWTypeInterfaces.td"
 
-class ArcTypeDef<string name, list<Trait> traits = []> : TypeDef<ArcDialect, name, traits> { }
+class ArcTypeDef<string name, list<Trait> traits = []> :
+  TypeDef<ArcDialect, name, traits> { }
 
 def StateType : ArcTypeDef<"State"> {
   let mnemonic = "state";
@@ -65,7 +66,10 @@ def ArrayRefType : ArcTypeDef<"ArrayRef", [
     An array reference is a reference (pointer) to an array of values.
   }];
   let mnemonic = "arrayref";
-  let parameters = (ins "::mlir::Type":$elementType, "::mlir::IntegerAttr":$sizeAttr);
+  let parameters = (ins
+    "::mlir::Type":$elementType,
+    "::mlir::IntegerAttr":$sizeAttr
+  );
 
   let builders = [
     TypeBuilderWithInferredContext<(ins "Type":$elementType, "size_t":$size), [{

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -12,8 +12,9 @@
 include "circt/Dialect/Arc/ArcDialect.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
+include "circt/Dialect/HW/HWTypeInterfaces.td"
 
-class ArcTypeDef<string name> : TypeDef<ArcDialect, name> { }
+class ArcTypeDef<string name, list<Trait> traits = []> : TypeDef<ArcDialect, name, traits> { }
 
 def StateType : ArcTypeDef<"State"> {
   let mnemonic = "state";
@@ -54,6 +55,40 @@ def SimModelInstance : ArcTypeDef<"SimModelInstance"> {
   let mnemonic = "sim.instance";
   let parameters = (ins "mlir::FlatSymbolRefAttr":$model);
   let assemblyFormat = "`<` $model `>`";
+}
+
+def ArrayRefType : ArcTypeDef<"ArrayRef", [
+  DeclareTypeInterfaceMethods<BitWidthTypeInterface>
+]> {
+  let summary = "array reference";
+  let description = [{
+    An array reference is a reference (pointer) to an array of values.
+  }];
+  let mnemonic = "arrayref";
+  let parameters = (ins "::mlir::Type":$elementType, "::mlir::IntegerAttr":$sizeAttr);
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "Type":$elementType, "size_t":$size), [{
+      auto *ctx = elementType.getContext();
+      auto intType = mlir::IntegerType::get(ctx, 64);
+      auto sizeAttr = mlir::IntegerAttr::get(intType, size);
+      return $_get(ctx, elementType, sizeAttr);
+    }]>
+  ];
+
+  let assemblyFormat = "`<` custom<ArcArrayRef>($sizeAttr, $elementType) `>`";
+
+  let extraClassDeclaration = [{
+    size_t getNumElements() const;
+
+    std::optional<size_t> getByteWidth() const {
+      std::optional<size_t> bitWidth = getBitWidth();
+      if (!bitWidth.has_value()) {
+        return std::nullopt;
+      }
+      return (*bitWidth + 7) / 8;
+    }
+  }];
 }
 
 #endif // CIRCT_DIALECT_ARC_ARCTYPES_TD

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -11,6 +11,7 @@
 
 include "circt/Dialect/Arc/ArcDialect.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
 include "mlir/IR/OpBase.td"
 include "circt/Dialect/HW/HWTypeInterfaces.td"
 
@@ -59,7 +60,8 @@ def SimModelInstance : ArcTypeDef<"SimModelInstance"> {
 }
 
 def ArrayRefType : ArcTypeDef<"ArrayRef", [
-  DeclareTypeInterfaceMethods<BitWidthTypeInterface>
+  DeclareTypeInterfaceMethods<BitWidthTypeInterface>,
+  DeclareTypeInterfaceMethods<ShapedTypeInterface>
 ]> {
   let summary = "array reference";
   let description = [{
@@ -68,19 +70,17 @@ def ArrayRefType : ArcTypeDef<"ArrayRef", [
   let mnemonic = "arrayref";
   let parameters = (ins
     "::mlir::Type":$elementType,
-    "::mlir::IntegerAttr":$sizeAttr
+    "uint64_t":$size
   );
 
   let builders = [
-    TypeBuilderWithInferredContext<(ins "Type":$elementType, "size_t":$size), [{
+    TypeBuilderWithInferredContext<(ins "Type":$elementType, "uint64_t":$size), [{
       auto *ctx = elementType.getContext();
-      auto intType = mlir::IntegerType::get(ctx, 64);
-      auto sizeAttr = mlir::IntegerAttr::get(intType, size);
-      return $_get(ctx, elementType, sizeAttr);
+      return $_get(ctx, elementType, size);
     }]>
   ];
 
-  let assemblyFormat = "`<` custom<ArcArrayRef>($sizeAttr, $elementType) `>`";
+  let assemblyFormat = "`<` $size `` custom<XInDimList>($elementType) `>`";
 
   let extraClassDeclaration = [{
     size_t getNumElements() const;

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -82,6 +82,8 @@ def ArrayRefType : ArcTypeDef<"ArrayRef", [
 
   let assemblyFormat = "`<` $size `` custom<XInDimList>($elementType) `>`";
 
+  let genVerifyDecl = 1;
+
   let extraClassDeclaration = [{
     size_t getNumElements() const;
 

--- a/include/circt/Tools/arcilator/pipelines.h
+++ b/include/circt/Tools/arcilator/pipelines.h
@@ -126,6 +126,10 @@ struct ArcToLLVMOptions : mlir::PassPipelineOptions<ArcToLLVMOptions> {
   Option<std::string> traceFileName{
       *this, "trace-file", llvm::cl::desc("Output file for signal traces"),
       llvm::cl::init("")};
+  Option<bool> bufferizeArrays{
+      *this, "bufferize-arrays",
+      llvm::cl::desc("Bufferize arrays before lowering to LLVM"),
+      llvm::cl::init(false)};
 };
 void populateArcToLLVMPipeline(mlir::OpPassManager &pm,
                                const ArcToLLVMOptions &options = {});

--- a/include/circt/Tools/arcilator/pipelines.h
+++ b/include/circt/Tools/arcilator/pipelines.h
@@ -129,7 +129,7 @@ struct ArcToLLVMOptions : mlir::PassPipelineOptions<ArcToLLVMOptions> {
   Option<bool> bufferizeArrays{
       *this, "bufferize-arrays",
       llvm::cl::desc("Bufferize arrays before lowering to LLVM"),
-      llvm::cl::init(false)};
+      llvm::cl::init(true)};
 };
 void populateArcToLLVMPipeline(mlir::OpPassManager &pm,
                                const ArcToLLVMOptions &options = {});

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -135,6 +135,12 @@ struct StateReadOpLowering : public OpConversionPattern<arc::StateReadOp> {
   LogicalResult
   matchAndRewrite(arc::StateReadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    // Loading an ArrayRef is a no-op as ArrayRefs are accessed by reference.
+    if (isa<ArrayRefType>(op.getType())) {
+      rewriter.replaceOp(op, adaptor.getState());
+      return success();
+    }
+
     auto type = typeConverter->convertType(op.getType());
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, type, adaptor.getState());
     return success();
@@ -146,16 +152,29 @@ struct StateWriteOpLowering : public OpConversionPattern<arc::StateWriteOp> {
   LogicalResult
   matchAndRewrite(arc::StateWriteOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    auto doStore = [&](OpBuilder &builder, Location loc) {
+      if (!isa<ArrayRefType>(op.getValue().getType())) {
+        LLVM::StoreOp::create(builder, loc, adaptor.getValue(),
+                              adaptor.getState());
+        return;
+      }
+
+      int numBytes = op.getState().getType().getByteWidth();
+      Value size = LLVM::ConstantOp::create(builder, loc, rewriter.getI64Type(),
+                                            numBytes);
+      LLVM::MemcpyOp::create(builder, loc, adaptor.getState(),
+                             adaptor.getValue(), size, /*volatile=*/false);
+    };
+
     if (adaptor.getCondition()) {
       rewriter.replaceOpWithNewOp<scf::IfOp>(
           op, adaptor.getCondition(), [&](auto &builder, auto loc) {
-            LLVM::StoreOp::create(builder, loc, adaptor.getValue(),
-                                  adaptor.getState());
+            doStore(builder, loc);
             scf::YieldOp::create(builder, loc);
           });
     } else {
-      rewriter.replaceOpWithNewOp<LLVM::StoreOp>(op, adaptor.getValue(),
-                                                 adaptor.getState());
+      doStore(rewriter, op.getLoc());
+      rewriter.eraseOp(op);
     }
     return success();
   }
@@ -1300,6 +1319,231 @@ struct RuntimeModelOpLowering
 };
 
 //===----------------------------------------------------------------------===//
+// ArrayRef patterns
+//===----------------------------------------------------------------------===//
+
+size_t computeElementByteWidth(ArrayRefType arrayRefType,
+                               ConversionPatternRewriter &rewriter) {
+  auto arrayBitWidth = computeLLVMBitWidth(arrayRefType);
+  assert(arrayBitWidth.has_value());
+  size_t elementBitWidth = *arrayBitWidth / arrayRefType.getNumElements();
+  return llvm::divideCeil(elementBitWidth, 8);
+}
+
+size_t computeByteWidth(Type type, ConversionPatternRewriter &rewriter) {
+  auto bitWidth = computeLLVMBitWidth(type);
+  assert(bitWidth.has_value());
+  return llvm::divideCeil(*bitWidth, 8);
+}
+
+struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayRefAllocOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto ptrTy = LLVM::LLVMPointerType::get(getContext());
+    auto i8Ty = rewriter.getI8Type();
+    ArrayRefType arrayRefType = op.getType();
+    size_t byteWidth = computeByteWidth(arrayRefType, rewriter);
+    auto size = LLVM::ConstantOp::create(rewriter, op.getLoc(),
+                                         rewriter.getI64Type(), byteWidth);
+    auto alloc =
+        LLVM::AllocaOp::create(rewriter, op.getLoc(), ptrTy, i8Ty, size);
+
+    if (op.getInitAttr()) {
+      ArrayAttr initAttr = cast<ArrayAttr>(op.getInitAttr());
+      if (isZero(initAttr)) {
+        auto i8Ty = rewriter.getI8Type();
+        auto zero = LLVM::ConstantOp::create(rewriter, op.getLoc(), i8Ty, 0);
+        LLVM::MemsetOp::create(rewriter, op.getLoc(), alloc, zero, size,
+                               /*isVolatile=*/false);
+      } else {
+        initializeArray(rewriter, op.getLoc(), alloc, initAttr, arrayRefType);
+      }
+    }
+
+    rewriter.replaceOp(op, alloc);
+    return success();
+  }
+
+  bool isZero(ArrayAttr arrayAttr) const {
+    for (const Attribute &elem : arrayAttr.getValue()) {
+      if (auto intAttr = dyn_cast<IntegerAttr>(elem);
+          !intAttr || !intAttr.getValue().isZero())
+        return false;
+    }
+    return true;
+  }
+
+  void initializeArray(ConversionPatternRewriter &rewriter, Location loc,
+                       Value alloc, ArrayAttr initAttr,
+                       ArrayRefType arrayRefType) const {
+    size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
+    Type ptrTy = LLVM::LLVMPointerType::get(getContext());
+    Type i8Ty = rewriter.getI8Type();
+    for (unsigned i = 0; i < arrayRefType.getNumElements(); ++i) {
+      unsigned elemIndex = arrayRefType.getNumElements() - i - 1;
+      Value elemOffset = LLVM::ConstantOp::create(
+          rewriter, loc, rewriter.getI64Type(), elemIndex * elemByteWidth);
+      auto elemAddr =
+          LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty, alloc, elemOffset);
+      auto elem = LLVM::ConstantOp::create(
+          rewriter, loc, arrayRefType.getElementType(), initAttr.getValue()[i]);
+      LLVM::StoreOp::create(rewriter, loc, elem, elemAddr);
+    }
+  }
+};
+
+struct ArrayRefCreateOpLowering : public OpConversionPattern<ArrayRefCreateOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayRefCreateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ArrayRefType arrayRefType = cast<ArrayRefType>(op.getType());
+    Value alloc = adaptor.getInput();
+    auto ptrTy = LLVM::LLVMPointerType::get(getContext());
+    auto i8Ty = rewriter.getI8Type();
+    size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
+    auto elements = adaptor.getElements();
+    for (unsigned i = 0; i < elements.size(); ++i) {
+      unsigned elemIndex = arrayRefType.getNumElements() - i - 1;
+      Value elemOffset =
+          LLVM::ConstantOp::create(rewriter, op.getLoc(), rewriter.getI64Type(),
+                                   elemIndex * elemByteWidth);
+      auto elemAddr = LLVM::GEPOp::create(rewriter, op.getLoc(), ptrTy, i8Ty,
+                                          alloc, elemOffset);
+      LLVM::StoreOp::create(rewriter, op.getLoc(), elements[i], elemAddr);
+    }
+    rewriter.replaceOp(op, alloc);
+    return success();
+  }
+};
+
+struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayRefGetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    ArrayRefType arrayRefType = cast<ArrayRefType>(op.getArray().getType());
+    auto ptrTy = LLVM::LLVMPointerType::get(getContext());
+    auto i8Ty = rewriter.getI8Type();
+    auto i64Ty = rewriter.getI64Type();
+    size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
+    assert(!isa<ArrayRefType>(arrayRefType.getElementType()));
+    // Compute byte offset = index * elemByteWidth. The index comes from the
+    // index dialect and is lowered to i64 by index-to-llvm conversion.
+    Value stride =
+        LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
+    Value byteOffset =
+        LLVM::MulOp::create(rewriter, loc, adaptor.getIndex(), stride);
+    auto elemAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
+                                        adaptor.getArray(), byteOffset);
+    Value loaded = LLVM::LoadOp::create(
+        rewriter, loc, typeConverter->convertType(op.getValue().getType()),
+        elemAddr);
+    rewriter.replaceOp(op, loaded);
+    return success();
+  }
+};
+
+struct ArrayRefInjectOpLowering : public OpConversionPattern<ArrayRefInjectOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayRefInjectOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    ArrayRefType arrayRefType = cast<ArrayRefType>(op.getInput().getType());
+    assert(!isa<ArrayRefType>(arrayRefType.getElementType()));
+    auto ptrTy = LLVM::LLVMPointerType::get(getContext());
+    auto i8Ty = rewriter.getI8Type();
+    auto i64Ty = rewriter.getI64Type();
+    size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
+
+    Value stride =
+        LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
+    Value byteOffset =
+        LLVM::MulOp::create(rewriter, loc, adaptor.getIndex(), stride);
+    auto elemAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
+                                        adaptor.getInput(), byteOffset);
+    LLVM::StoreOp::create(rewriter, loc, adaptor.getElement(), elemAddr);
+    // Inject is pure; returns the same pointer (input buffer is modified
+    // in-place and the pointer is forwarded as the result).
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
+struct ArrayRefSliceOpLowering : public OpConversionPattern<ArrayRefSliceOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayRefSliceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    // The result type is the sub-array type; use its element size.
+    ArrayRefType resultType = cast<ArrayRefType>(op.getDst().getType());
+    auto ptrTy = LLVM::LLVMPointerType::get(getContext());
+    auto i8Ty = rewriter.getI8Type();
+    auto i64Ty = rewriter.getI64Type();
+    size_t elemByteWidth = computeElementByteWidth(resultType, rewriter);
+
+    // Byte offset = lowIndex * elemByteWidth.
+    Value stride =
+        LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
+    Value byteOffset =
+        LLVM::MulOp::create(rewriter, loc, adaptor.getLowIndex(), stride);
+    auto sliceAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
+                                         adaptor.getInput(), byteOffset);
+    rewriter.replaceOp(op, sliceAddr);
+    return success();
+  }
+};
+
+struct ArrayRefCopyOpLowering : public OpConversionPattern<ArrayRefCopyOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayRefCopyOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    ArrayRefType arrayRefType = cast<ArrayRefType>(op.getDestInput().getType());
+    auto i64Ty = rewriter.getI64Type();
+    size_t byteWidth = computeByteWidth(arrayRefType, rewriter);
+    Value size = LLVM::ConstantOp::create(rewriter, loc, i64Ty, byteWidth);
+    LLVM::MemcpyOp::create(rewriter, loc, adaptor.getDestInput(),
+                           adaptor.getSource(), size,
+                           /*isVolatile=*/false);
+    rewriter.replaceOp(op, adaptor.getDestInput());
+    return success();
+  }
+};
+
+struct ArrayRefToLLVMArrayOpLowering
+    : public OpConversionPattern<UnrealizedConversionCastOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(UnrealizedConversionCastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!isa<ArrayRefType>(op.getOperand(0).getType()) ||
+        !isa<LLVM::LLVMArrayType>(op.getResult(0).getType())) {
+      return failure();
+    }
+
+    Value loaded =
+        LLVM::LoadOp::create(rewriter, op.getLoc(), op.getResult(0).getType(),
+                             adaptor.getInputs().front());
+    rewriter.replaceOp(op, loaded);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Pass Implementation
 //===----------------------------------------------------------------------===//
 
@@ -1380,6 +1624,18 @@ void LowerArcToLLVMPass::runOnOperation() {
     // LLHD time is represented as i64 femtoseconds.
     return IntegerType::get(type.getContext(), 64);
   });
+  converter.addConversion([&](ArrayRefType type) {
+    return LLVM::LLVMPointerType::get(type.getContext());
+  });
+
+  // Convert an UnrealizedConversionCastOp from !arc.arrayref<T> to
+  // !llvm.array<T>. These are inserted by the InsertRuntime pass.
+  target.addDynamicallyLegalOp<UnrealizedConversionCastOp>([&](Operation *op) {
+    Type src = op->getOperand(0).getType();
+    Type dst = op->getResult(0).getType();
+    bool needsConvert = isa<ArrayRefType>(src) && isa<LLVM::LLVMArrayType>(dst);
+    return !needsConvert;
+  });
 
   // Setup the conversion patterns.
   ConversionPatternSet patterns(&getContext(), converter);
@@ -1433,7 +1689,14 @@ void LowerArcToLLVMPass::runOnOperation() {
     StorageGetOpLowering,
     TerminateOpLowering,
     TimeToIntOpLowering,
-    ZeroCountOpLowering
+    ZeroCountOpLowering,
+    ArrayRefCreateOpLowering,
+    ArrayRefAllocOpLowering,
+    ArrayRefGetOpLowering,
+    ArrayRefInjectOpLowering,
+    ArrayRefSliceOpLowering,
+    ArrayRefCopyOpLowering,
+    ArrayRefToLLVMArrayOpLowering
   >(converter, &getContext());
   // clang-format on
   patterns.add<ExecuteOp>(convert);

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1322,16 +1322,14 @@ struct RuntimeModelOpLowering
 // ArrayRef patterns
 //===----------------------------------------------------------------------===//
 
-size_t computeByteWidth(ArrayRefType type,
-                        ConversionPatternRewriter &rewriter) {
+size_t computeByteWidth(ArrayRefType type) {
   auto bitWidth = computeLLVMBitWidth(type);
   assert(bitWidth.has_value());
   return llvm::divideCeil(*bitWidth, 8);
 }
 
 // Computes the padded bytewidth (stride) of each element.
-size_t computeElementByteWidth(ArrayRefType arrayRefType,
-                               ConversionPatternRewriter &rewriter) {
+size_t computeElementByteWidth(ArrayRefType arrayRefType) {
   auto arrayBitWidth = computeLLVMBitWidth(arrayRefType);
   assert(arrayBitWidth.has_value());
   size_t elementBitWidth = *arrayBitWidth / arrayRefType.getNumElements();
@@ -1347,7 +1345,7 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     ArrayRefType arrayRefType = op.getType();
-    size_t byteWidth = computeByteWidth(arrayRefType, rewriter);
+    size_t byteWidth = computeByteWidth(arrayRefType);
     auto size = LLVM::ConstantOp::create(rewriter, op.getLoc(),
                                          rewriter.getI64Type(), byteWidth);
     auto alloc =
@@ -1381,7 +1379,7 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
   void initializeArray(ConversionPatternRewriter &rewriter, Location loc,
                        Value alloc, ArrayAttr initAttr,
                        ArrayRefType arrayRefType) const {
-    size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
+    size_t elemByteWidth = computeElementByteWidth(arrayRefType);
     Type ptrTy = LLVM::LLVMPointerType::get(getContext());
     Type i8Ty = rewriter.getI8Type();
     for (unsigned i = 0; i < arrayRefType.getNumElements(); ++i) {
@@ -1407,7 +1405,7 @@ struct ArrayRefCreateOpLowering : public OpConversionPattern<ArrayRefCreateOp> {
     Value alloc = adaptor.getInput();
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
-    size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
+    size_t elemByteWidth = computeElementByteWidth(arrayRefType);
     auto elements = adaptor.getElements();
     for (unsigned i = 0; i < elements.size(); ++i) {
       // Note: hardcoded for little endian targets.
@@ -1435,7 +1433,7 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
-    size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
+    size_t elemByteWidth = computeElementByteWidth(arrayRefType);
     assert(!isa<ArrayRefType>(arrayRefType.getElementType()));
 
     Value stride =
@@ -1464,7 +1462,7 @@ struct ArrayRefInjectOpLowering : public OpConversionPattern<ArrayRefInjectOp> {
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
-    size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
+    size_t elemByteWidth = computeElementByteWidth(arrayRefType);
 
     Value stride =
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
@@ -1492,7 +1490,7 @@ struct ArrayRefSliceOpLowering : public OpConversionPattern<ArrayRefSliceOp> {
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
-    size_t elemByteWidth = computeElementByteWidth(resultType, rewriter);
+    size_t elemByteWidth = computeElementByteWidth(resultType);
 
     // Byte offset = lowIndex * elemByteWidth.
     Value stride =
@@ -1515,7 +1513,7 @@ struct ArrayRefCopyOpLowering : public OpConversionPattern<ArrayRefCopyOp> {
     auto loc = op.getLoc();
     ArrayRefType arrayRefType = cast<ArrayRefType>(op.getDestInput().getType());
     auto i64Ty = rewriter.getI64Type();
-    size_t byteWidth = computeByteWidth(arrayRefType, rewriter);
+    size_t byteWidth = computeByteWidth(arrayRefType);
     Value size = LLVM::ConstantOp::create(rewriter, loc, i64Ty, byteWidth);
     LLVM::MemcpyOp::create(rewriter, loc, adaptor.getDestInput(),
                            adaptor.getSource(), size,
@@ -1578,6 +1576,20 @@ void LowerArcToLLVMPass::runOnOperation() {
         result.replaceAllUsesWith(zero);
       }
     });
+  }
+
+  // Add `dereferenceable(<N>)` attributes to all function arguments that take
+  // ArrayRefTypes.
+  for (func::FuncOp func : getOperation().getOps<func::FuncOp>()) {
+    for (int i = 0, e = func.getNumArguments(); i != e; ++i) {
+      if (auto arrayRefType =
+              dyn_cast<ArrayRefType>(func.getArgumentTypes()[i])) {
+        size_t byteWidth = computeByteWidth(arrayRefType);
+        Builder builder(&getContext());
+        func.setArgAttr(i, LLVM::LLVMDialect::getDereferenceableAttrName(),
+                        builder.getI64IntegerAttr(byteWidth));
+      }
+    }
   }
 
   // Collect the symbols in the root op such that the HW-to-LLVM lowering can

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1322,18 +1322,20 @@ struct RuntimeModelOpLowering
 // ArrayRef patterns
 //===----------------------------------------------------------------------===//
 
+size_t computeByteWidth(ArrayRefType type,
+                        ConversionPatternRewriter &rewriter) {
+  auto bitWidth = computeLLVMBitWidth(type);
+  assert(bitWidth.has_value());
+  return llvm::divideCeil(*bitWidth, 8);
+}
+
+// Computes the padded bytewidth (stride) of each element.
 size_t computeElementByteWidth(ArrayRefType arrayRefType,
                                ConversionPatternRewriter &rewriter) {
   auto arrayBitWidth = computeLLVMBitWidth(arrayRefType);
   assert(arrayBitWidth.has_value());
   size_t elementBitWidth = *arrayBitWidth / arrayRefType.getNumElements();
   return llvm::divideCeil(elementBitWidth, 8);
-}
-
-size_t computeByteWidth(Type type, ConversionPatternRewriter &rewriter) {
-  auto bitWidth = computeLLVMBitWidth(type);
-  assert(bitWidth.has_value());
-  return llvm::divideCeil(*bitWidth, 8);
 }
 
 struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
@@ -1408,6 +1410,7 @@ struct ArrayRefCreateOpLowering : public OpConversionPattern<ArrayRefCreateOp> {
     size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
     auto elements = adaptor.getElements();
     for (unsigned i = 0; i < elements.size(); ++i) {
+      // Note: hardcoded for little endian targets.
       unsigned elemIndex = arrayRefType.getNumElements() - i - 1;
       Value elemOffset =
           LLVM::ConstantOp::create(rewriter, op.getLoc(), rewriter.getI64Type(),
@@ -1434,8 +1437,7 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
     auto i64Ty = rewriter.getI64Type();
     size_t elemByteWidth = computeElementByteWidth(arrayRefType, rewriter);
     assert(!isa<ArrayRefType>(arrayRefType.getElementType()));
-    // Compute byte offset = index * elemByteWidth. The index comes from the
-    // index dialect and is lowered to i64 by index-to-llvm conversion.
+
     Value stride =
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
     Value byteOffset =

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1348,11 +1348,14 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
     size_t byteWidth = computeByteWidth(arrayRefType);
     auto size = LLVM::ConstantOp::create(rewriter, op.getLoc(),
                                          rewriter.getI64Type(), byteWidth);
+
+
+    size_t alignment = computeAllocaAlignment(arrayRefType, op);
     auto alloc =
-        LLVM::AllocaOp::create(rewriter, op.getLoc(), ptrTy, i8Ty, size);
+        LLVM::AllocaOp::create(rewriter, op.getLoc(), ptrTy, i8Ty, size, alignment);
 
     if (op.getInitAttr()) {
-      DenseI64ArrayAttr initAttr = op.getInitAttr();
+      ArrayAttr initAttr = op.getInitAttr();
       if (isZero(initAttr)) {
         auto i8Ty = rewriter.getI8Type();
         auto zero = LLVM::ConstantOp::create(rewriter, op.getLoc(), i8Ty, 0);
@@ -1367,13 +1370,28 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
     return success();
   }
 
-  bool isZero(DenseI64ArrayAttr arrayAttr) const {
-    return llvm::all_of(arrayAttr.asArrayRef(),
-                        [](int64_t i) { return i == 0; });
+  // Computes the required alignment for an AllocaOp of the given type.
+  // c.f. HWToLLVM.cpp.
+  size_t computeAllocaAlignment(ArrayRefType type, Operation* op) const {
+    if (alignmentCache.count(type)) {
+      return alignmentCache[type];
+    }
+    auto dl = DataLayout::closest(op);
+    auto hwType = hw::ArrayType::get(type.getElementType(), type.getNumElements());
+    auto llvmType = getTypeConverter()->convertType(hwType);
+    auto alignment = static_cast<unsigned>(dl.getTypePreferredAlignment(llvmType));
+    alignment = std::max(4u, alignment);
+    alignmentCache[type] = alignment;
+    return alignment;
+  }
+
+  bool isZero(ArrayAttr arrayAttr) const {
+    return llvm::all_of(arrayAttr.getAsValueRange<IntegerAttr>(),
+                        [](APInt i) { return i.isZero(); });
   }
 
   void initializeArray(ConversionPatternRewriter &rewriter, Location loc,
-                       Value alloc, DenseI64ArrayAttr initAttr,
+                       Value alloc, ArrayAttr initAttr,
                        ArrayRefType arrayRefType) const {
     size_t elemByteWidth = computeElementByteWidth(arrayRefType);
     Type ptrTy = LLVM::LLVMPointerType::get(getContext());
@@ -1389,6 +1407,9 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
       LLVM::StoreOp::create(rewriter, loc, elem, elemAddr);
     }
   }
+
+ private:
+  mutable DenseMap<ArrayRefType, size_t> alignmentCache;
 };
 
 struct ArrayRefCreateOpLowering : public OpConversionPattern<ArrayRefCreateOp> {
@@ -1429,6 +1450,7 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
+    size_t byteWidth = computeByteWidth(arrayRefType);
     size_t elemByteWidth = computeElementByteWidth(arrayRefType);
     assert(!isa<ArrayRefType>(arrayRefType.getElementType()));
 
@@ -1436,8 +1458,14 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
     Value byteOffset =
         LLVM::MulOp::create(rewriter, loc, adaptor.getIndex(), stride);
+    Value totalSize = LLVM::ConstantOp::create(rewriter, loc, i64Ty,
+                                               byteWidth);
+    // Defend against out-of-bounds accesses. What we return is undefined in the
+    // case of OOB.
+    Value clampedOffset =
+        LLVM::UMinOp::create(rewriter, loc, i64Ty, byteOffset, totalSize);
     auto elemAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
-                                        adaptor.getInput(), byteOffset);
+                                        adaptor.getInput(), clampedOffset);
     Value loaded = LLVM::LoadOp::create(
         rewriter, loc, typeConverter->convertType(op.getValue().getType()),
         elemAddr);
@@ -1458,15 +1486,26 @@ struct ArrayRefInjectOpLowering : public OpConversionPattern<ArrayRefInjectOp> {
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
+    size_t byteWidth = computeByteWidth(arrayRefType);
     size_t elemByteWidth = computeElementByteWidth(arrayRefType);
 
     Value stride =
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
     Value byteOffset =
         LLVM::MulOp::create(rewriter, loc, adaptor.getIndex(), stride);
-    auto elemAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
-                                        adaptor.getInput(), byteOffset);
-    LLVM::StoreOp::create(rewriter, loc, adaptor.getElement(), elemAddr);
+    Value totalSize = LLVM::ConstantOp::create(rewriter, loc, i64Ty,
+                                               byteWidth);
+    // Defend against out-of-bounds accesses. We must avoid corrupting the
+    // array.
+    Value isInbounds = LLVM::ICmpOp::create(
+        rewriter, loc, LLVM::ICmpPredicate::ult, byteOffset, totalSize);
+    scf::IfOp::create(rewriter, loc, isInbounds, [&](OpBuilder &b, Location) {
+      auto elemAddr = LLVM::GEPOp::create(b, loc, ptrTy, i8Ty,
+                                          adaptor.getInput(), byteOffset);
+      LLVM::StoreOp::create(b, loc, adaptor.getElement(), elemAddr);
+      scf::YieldOp::create(b, loc);
+    });
+
     // Inject is pure; returns the same pointer (input buffer is modified
     // in-place and the pointer is forwarded as the result).
     rewriter.replaceOp(op, adaptor.getInput());
@@ -1482,17 +1521,26 @@ struct ArrayRefSliceOpLowering : public OpConversionPattern<ArrayRefSliceOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     // The result type is the sub-array type; use its element size.
+    ArrayRefType inputType = cast<ArrayRefType>(op.getInput().getType());
     ArrayRefType resultType = cast<ArrayRefType>(op.getOutput().getType());
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
     size_t elemByteWidth = computeElementByteWidth(resultType);
 
+    // Ensure the slice doesn't go out of bounds.
+    size_t maxLowIndex = inputType.getNumElements() - resultType.getNumElements();
+    Value maxLowIndexVal =
+        LLVM::ConstantOp::create(rewriter, loc, i64Ty, maxLowIndex);
+    Value clampedLowIndex =
+        LLVM::UMinOp::create(rewriter, loc, i64Ty, adaptor.getLowIndex(),
+                             maxLowIndexVal);
+
     // Byte offset = lowIndex * elemByteWidth.
     Value stride =
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
     Value byteOffset =
-        LLVM::MulOp::create(rewriter, loc, adaptor.getLowIndex(), stride);
+        LLVM::MulOp::create(rewriter, loc, clampedLowIndex, stride);
     auto sliceAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
                                          adaptor.getInput(), byteOffset);
     rewriter.replaceOp(op, sliceAddr);

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1352,7 +1352,7 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
         LLVM::AllocaOp::create(rewriter, op.getLoc(), ptrTy, i8Ty, size);
 
     if (op.getInitAttr()) {
-      ArrayAttr initAttr = cast<ArrayAttr>(op.getInitAttr());
+      DenseI64ArrayAttr initAttr = op.getInitAttr();
       if (isZero(initAttr)) {
         auto i8Ty = rewriter.getI8Type();
         auto zero = LLVM::ConstantOp::create(rewriter, op.getLoc(), i8Ty, 0);
@@ -1367,17 +1367,13 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
     return success();
   }
 
-  bool isZero(ArrayAttr arrayAttr) const {
-    for (const Attribute &elem : arrayAttr.getValue()) {
-      if (auto intAttr = dyn_cast<IntegerAttr>(elem);
-          !intAttr || !intAttr.getValue().isZero())
-        return false;
-    }
-    return true;
+  bool isZero(DenseI64ArrayAttr arrayAttr) const {
+    return llvm::all_of(arrayAttr.asArrayRef(),
+                        [](int64_t i) { return i == 0; });
   }
 
   void initializeArray(ConversionPatternRewriter &rewriter, Location loc,
-                       Value alloc, ArrayAttr initAttr,
+                       Value alloc, DenseI64ArrayAttr initAttr,
                        ArrayRefType arrayRefType) const {
     size_t elemByteWidth = computeElementByteWidth(arrayRefType);
     Type ptrTy = LLVM::LLVMPointerType::get(getContext());
@@ -1389,7 +1385,7 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
       auto elemAddr =
           LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty, alloc, elemOffset);
       auto elem = LLVM::ConstantOp::create(
-          rewriter, loc, arrayRefType.getElementType(), initAttr.getValue()[i]);
+          rewriter, loc, arrayRefType.getElementType(), initAttr[i]);
       LLVM::StoreOp::create(rewriter, loc, elem, elemAddr);
     }
   }
@@ -1429,7 +1425,7 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
   matchAndRewrite(ArrayRefGetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    ArrayRefType arrayRefType = cast<ArrayRefType>(op.getArray().getType());
+    ArrayRefType arrayRefType = cast<ArrayRefType>(op.getInput().getType());
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
@@ -1441,7 +1437,7 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
     Value byteOffset =
         LLVM::MulOp::create(rewriter, loc, adaptor.getIndex(), stride);
     auto elemAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
-                                        adaptor.getArray(), byteOffset);
+                                        adaptor.getInput(), byteOffset);
     Value loaded = LLVM::LoadOp::create(
         rewriter, loc, typeConverter->convertType(op.getValue().getType()),
         elemAddr);
@@ -1486,7 +1482,7 @@ struct ArrayRefSliceOpLowering : public OpConversionPattern<ArrayRefSliceOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     // The result type is the sub-array type; use its element size.
-    ArrayRefType resultType = cast<ArrayRefType>(op.getDst().getType());
+    ArrayRefType resultType = cast<ArrayRefType>(op.getOutput().getType());
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
@@ -1511,14 +1507,14 @@ struct ArrayRefCopyOpLowering : public OpConversionPattern<ArrayRefCopyOp> {
   matchAndRewrite(ArrayRefCopyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    ArrayRefType arrayRefType = cast<ArrayRefType>(op.getDestInput().getType());
+    ArrayRefType arrayRefType = cast<ArrayRefType>(op.getInput().getType());
     auto i64Ty = rewriter.getI64Type();
     size_t byteWidth = computeByteWidth(arrayRefType);
     Value size = LLVM::ConstantOp::create(rewriter, loc, i64Ty, byteWidth);
-    LLVM::MemcpyOp::create(rewriter, loc, adaptor.getDestInput(),
+    LLVM::MemcpyOp::create(rewriter, loc, adaptor.getInput(),
                            adaptor.getSource(), size,
                            /*isVolatile=*/false);
-    rewriter.replaceOp(op, adaptor.getDestInput());
+    rewriter.replaceOp(op, adaptor.getInput());
     return success();
   }
 };

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1566,6 +1566,39 @@ struct ArrayRefCopyOpLowering : public OpConversionPattern<ArrayRefCopyOp> {
   }
 };
 
+static Value loadArrayRefAsArray(ImplicitLocOpBuilder &builder, Value arrayRef,
+                                 ArrayRefType arrayRefType,
+                                 LLVM::LLVMArrayType llvmType) {
+  auto i8Ty = builder.getI8Type();
+  auto ptrTy = LLVM::LLVMPointerType::get(builder.getContext());
+  size_t elemByteWidth = computeElementByteWidth(arrayRefType);
+  Value v = LLVM::UndefOp::create(builder, llvmType);
+  int32_t size = arrayRefType.getNumElements();
+  for (int32_t i = 0; i < size; i++) {
+    int32_t byteOffset = i * elemByteWidth;
+    Value gep = LLVM::GEPOp::create(builder, ptrTy, i8Ty, arrayRef,
+                                    LLVM::GEPArg{byteOffset});
+    Value load = LLVM::LoadOp::create(builder, llvmType.getElementType(), gep);
+    v = LLVM::InsertValueOp::create(builder, v, load, i);
+  }
+  return v;
+}
+
+static void storeArrayAsArrayRef(ImplicitLocOpBuilder &builder, Value array,
+                                 Value arrayRef, ArrayRefType arrayRefType) {
+  auto i8Ty = builder.getI8Type();
+  auto ptrTy = LLVM::LLVMPointerType::get(builder.getContext());
+  size_t elemByteWidth = computeElementByteWidth(arrayRefType);
+  int32_t size = arrayRefType.getNumElements();
+  for (int32_t i = 0; i < size; i++) {
+    int32_t byteOffset = i * elemByteWidth;
+    Value gep = LLVM::GEPOp::create(builder, ptrTy, i8Ty, arrayRef,
+                                    LLVM::GEPArg{byteOffset});
+    Value val = LLVM::ExtractValueOp::create(builder, array, i);
+    LLVM::StoreOp::create(builder, val, gep);
+  }
+}
+
 struct ArrayRefToLLVMArrayOpLowering
     : public OpConversionPattern<UnrealizedConversionCastOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -1578,9 +1611,11 @@ struct ArrayRefToLLVMArrayOpLowering
       return failure();
     }
 
-    Value loaded =
-        LLVM::LoadOp::create(rewriter, op.getLoc(), op.getResult(0).getType(),
-                             adaptor.getInputs().front());
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    Value loaded = loadArrayRefAsArray(
+        b, adaptor.getInputs().front(),
+        cast<ArrayRefType>(op.getOperand(0).getType()),
+        cast<LLVM::LLVMArrayType>(op.getResult(0).getType()));
     rewriter.replaceOp(op, loaded);
     return success();
   }
@@ -1594,8 +1629,10 @@ struct ArrayRefToArrayOpLowering
   matchAndRewrite(ArrayRefToArrayOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = getTypeConverter()->convertType(op.getResult().getType());
-    Value loaded = LLVM::LoadOp::create(rewriter, op.getLoc(), resultType,
-                                        adaptor.getInput());
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    Value loaded = loadArrayRefAsArray(
+        b, adaptor.getInput(), cast<ArrayRefType>(op.getInput().getType()),
+        cast<LLVM::LLVMArrayType>(resultType));
     rewriter.replaceOp(op, loaded);
     return success();
   }
@@ -1608,8 +1645,9 @@ struct ArrayRefFromArrayOpLowering
   LogicalResult
   matchAndRewrite(ArrayRefFromArrayOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    LLVM::StoreOp::create(rewriter, op.getLoc(), adaptor.getArray(),
-                          adaptor.getInput());
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    storeArrayAsArrayRef(b, adaptor.getArray(), adaptor.getInput(),
+                         cast<ArrayRefType>(op.getInput().getType()));
     rewriter.replaceOp(op, adaptor.getInput());
     return success();
   }

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1332,6 +1332,7 @@ size_t computeByteWidth(ArrayRefType type) {
 size_t computeElementByteWidth(ArrayRefType arrayRefType) {
   auto arrayBitWidth = computeLLVMBitWidth(arrayRefType);
   assert(arrayBitWidth.has_value());
+  assert(arrayRefType.getNumElements() > 0 && "Cannot compute stride for zero sized array");
   size_t elementBitWidth = *arrayBitWidth / arrayRefType.getNumElements();
   return llvm::divideCeil(elementBitWidth, 8);
 }
@@ -1451,7 +1452,6 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
     auto ptrTy = LLVM::LLVMPointerType::get(getContext());
     auto i8Ty = rewriter.getI8Type();
     auto i64Ty = rewriter.getI64Type();
-    size_t byteWidth = computeByteWidth(arrayRefType);
     size_t elemByteWidth = computeElementByteWidth(arrayRefType);
     assert(!isa<ArrayRefType>(arrayRefType.getElementType()));
 
@@ -1459,11 +1459,14 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
     Value byteOffset =
         LLVM::MulOp::create(rewriter, loc, adaptor.getIndex(), stride);
-    Value totalSize = LLVM::ConstantOp::create(rewriter, loc, i64Ty, byteWidth);
     // Defend against out-of-bounds accesses. What we return is undefined in the
     // case of OOB.
+    size_t lastElementByteOffset =
+        elemByteWidth * (arrayRefType.getNumElements() - 1);
+    Value lastElementByteOffsetVal =
+        LLVM::ConstantOp::create(rewriter, loc, i64Ty, lastElementByteOffset);
     Value clampedOffset =
-        LLVM::UMinOp::create(rewriter, loc, i64Ty, byteOffset, totalSize);
+        LLVM::UMinOp::create(rewriter, loc, i64Ty, byteOffset, lastElementByteOffsetVal);
     auto elemAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
                                         adaptor.getInput(), clampedOffset);
     Value loaded = LLVM::LoadOp::create(
@@ -1558,7 +1561,8 @@ struct ArrayRefCopyOpLowering : public OpConversionPattern<ArrayRefCopyOp> {
     auto i64Ty = rewriter.getI64Type();
     size_t byteWidth = computeByteWidth(arrayRefType);
     Value size = LLVM::ConstantOp::create(rewriter, loc, i64Ty, byteWidth);
-    LLVM::MemcpyOp::create(rewriter, loc, adaptor.getInput(),
+    // Use a memmove rather than a memcpy just in case the arrays alias.
+    LLVM::MemmoveOp::create(rewriter, loc, adaptor.getInput(),
                            adaptor.getSource(), size,
                            /*isVolatile=*/false);
     rewriter.replaceOp(op, adaptor.getInput());
@@ -1572,7 +1576,7 @@ static Value loadArrayRefAsArray(ImplicitLocOpBuilder &builder, Value arrayRef,
   auto i8Ty = builder.getI8Type();
   auto ptrTy = LLVM::LLVMPointerType::get(builder.getContext());
   size_t elemByteWidth = computeElementByteWidth(arrayRefType);
-  Value v = LLVM::UndefOp::create(builder, llvmType);
+  Value v = LLVM::PoisonOp::create(builder, llvmType);
   int32_t size = arrayRefType.getNumElements();
   for (int32_t i = 0; i < size; i++) {
     int32_t byteOffset = i * elemByteWidth;

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1332,7 +1332,8 @@ size_t computeByteWidth(ArrayRefType type) {
 size_t computeElementByteWidth(ArrayRefType arrayRefType) {
   auto arrayBitWidth = computeLLVMBitWidth(arrayRefType);
   assert(arrayBitWidth.has_value());
-  assert(arrayRefType.getNumElements() > 0 && "Cannot compute stride for zero sized array");
+  assert(arrayRefType.getNumElements() > 0 &&
+         "Cannot compute stride for zero sized array");
   size_t elementBitWidth = *arrayBitWidth / arrayRefType.getNumElements();
   return llvm::divideCeil(elementBitWidth, 8);
 }
@@ -1465,8 +1466,8 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
         elemByteWidth * (arrayRefType.getNumElements() - 1);
     Value lastElementByteOffsetVal =
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, lastElementByteOffset);
-    Value clampedOffset =
-        LLVM::UMinOp::create(rewriter, loc, i64Ty, byteOffset, lastElementByteOffsetVal);
+    Value clampedOffset = LLVM::UMinOp::create(rewriter, loc, i64Ty, byteOffset,
+                                               lastElementByteOffsetVal);
     auto elemAddr = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8Ty,
                                         adaptor.getInput(), clampedOffset);
     Value loaded = LLVM::LoadOp::create(
@@ -1563,8 +1564,8 @@ struct ArrayRefCopyOpLowering : public OpConversionPattern<ArrayRefCopyOp> {
     Value size = LLVM::ConstantOp::create(rewriter, loc, i64Ty, byteWidth);
     // Use a memmove rather than a memcpy just in case the arrays alias.
     LLVM::MemmoveOp::create(rewriter, loc, adaptor.getInput(),
-                           adaptor.getSource(), size,
-                           /*isVolatile=*/false);
+                            adaptor.getSource(), size,
+                            /*isVolatile=*/false);
     rewriter.replaceOp(op, adaptor.getInput());
     return success();
   }

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1349,10 +1349,9 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
     auto size = LLVM::ConstantOp::create(rewriter, op.getLoc(),
                                          rewriter.getI64Type(), byteWidth);
 
-
     size_t alignment = computeAllocaAlignment(arrayRefType, op);
-    auto alloc =
-        LLVM::AllocaOp::create(rewriter, op.getLoc(), ptrTy, i8Ty, size, alignment);
+    auto alloc = LLVM::AllocaOp::create(rewriter, op.getLoc(), ptrTy, i8Ty,
+                                        size, alignment);
 
     if (op.getInitAttr()) {
       ArrayAttr initAttr = op.getInitAttr();
@@ -1372,14 +1371,16 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
 
   // Computes the required alignment for an AllocaOp of the given type.
   // c.f. HWToLLVM.cpp.
-  size_t computeAllocaAlignment(ArrayRefType type, Operation* op) const {
+  size_t computeAllocaAlignment(ArrayRefType type, Operation *op) const {
     if (alignmentCache.count(type)) {
       return alignmentCache[type];
     }
     auto dl = DataLayout::closest(op);
-    auto hwType = hw::ArrayType::get(type.getElementType(), type.getNumElements());
+    auto hwType =
+        hw::ArrayType::get(type.getElementType(), type.getNumElements());
     auto llvmType = getTypeConverter()->convertType(hwType);
-    auto alignment = static_cast<unsigned>(dl.getTypePreferredAlignment(llvmType));
+    auto alignment =
+        static_cast<unsigned>(dl.getTypePreferredAlignment(llvmType));
     alignment = std::max(4u, alignment);
     alignmentCache[type] = alignment;
     return alignment;
@@ -1408,7 +1409,7 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
     }
   }
 
- private:
+private:
   mutable DenseMap<ArrayRefType, size_t> alignmentCache;
 };
 
@@ -1458,8 +1459,7 @@ struct ArrayRefGetOpLowering : public OpConversionPattern<ArrayRefGetOp> {
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
     Value byteOffset =
         LLVM::MulOp::create(rewriter, loc, adaptor.getIndex(), stride);
-    Value totalSize = LLVM::ConstantOp::create(rewriter, loc, i64Ty,
-                                               byteWidth);
+    Value totalSize = LLVM::ConstantOp::create(rewriter, loc, i64Ty, byteWidth);
     // Defend against out-of-bounds accesses. What we return is undefined in the
     // case of OOB.
     Value clampedOffset =
@@ -1493,8 +1493,7 @@ struct ArrayRefInjectOpLowering : public OpConversionPattern<ArrayRefInjectOp> {
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, elemByteWidth);
     Value byteOffset =
         LLVM::MulOp::create(rewriter, loc, adaptor.getIndex(), stride);
-    Value totalSize = LLVM::ConstantOp::create(rewriter, loc, i64Ty,
-                                               byteWidth);
+    Value totalSize = LLVM::ConstantOp::create(rewriter, loc, i64Ty, byteWidth);
     // Defend against out-of-bounds accesses. We must avoid corrupting the
     // array.
     Value isInbounds = LLVM::ICmpOp::create(
@@ -1529,12 +1528,12 @@ struct ArrayRefSliceOpLowering : public OpConversionPattern<ArrayRefSliceOp> {
     size_t elemByteWidth = computeElementByteWidth(resultType);
 
     // Ensure the slice doesn't go out of bounds.
-    size_t maxLowIndex = inputType.getNumElements() - resultType.getNumElements();
+    size_t maxLowIndex =
+        inputType.getNumElements() - resultType.getNumElements();
     Value maxLowIndexVal =
         LLVM::ConstantOp::create(rewriter, loc, i64Ty, maxLowIndex);
-    Value clampedLowIndex =
-        LLVM::UMinOp::create(rewriter, loc, i64Ty, adaptor.getLowIndex(),
-                             maxLowIndexVal);
+    Value clampedLowIndex = LLVM::UMinOp::create(
+        rewriter, loc, i64Ty, adaptor.getLowIndex(), maxLowIndexVal);
 
     // Byte offset = lowIndex * elemByteWidth.
     Value stride =

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1539,6 +1539,35 @@ struct ArrayRefToLLVMArrayOpLowering
   }
 };
 
+struct ArrayRefToArrayOpLowering
+    : public OpConversionPattern<ArrayRefToArrayOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayRefToArrayOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+    Value loaded = LLVM::LoadOp::create(rewriter, op.getLoc(), resultType,
+                                        adaptor.getInput());
+    rewriter.replaceOp(op, loaded);
+    return success();
+  }
+};
+
+struct ArrayRefFromArrayOpLowering
+    : public OpConversionPattern<ArrayRefFromArrayOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayRefFromArrayOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    LLVM::StoreOp::create(rewriter, op.getLoc(), adaptor.getArray(),
+                          adaptor.getInput());
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Pass Implementation
 //===----------------------------------------------------------------------===//
@@ -1706,7 +1735,9 @@ void LowerArcToLLVMPass::runOnOperation() {
     ArrayRefInjectOpLowering,
     ArrayRefSliceOpLowering,
     ArrayRefCopyOpLowering,
-    ArrayRefToLLVMArrayOpLowering
+    ArrayRefToLLVMArrayOpLowering,
+    ArrayRefToArrayOpLowering,
+    ArrayRefFromArrayOpLowering
   >(converter, &getContext());
   // clang-format on
   patterns.add<ExecuteOp>(convert);

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -748,6 +748,24 @@ LogicalResult ExecuteOp::verifyRegions() {
                                    getBody().getArgumentTypes(), "input");
 }
 
+//===----------------------------------------------------------------------===//
+// ArrayRefCreateOp
+//===----------------------------------------------------------------------===//
+
+ParseResult parseARCreate(OpAsmParser &parser, Type destType, Type &inputType,
+                          SmallVectorImpl<Type> &elementsTypes) {
+  inputType = destType;
+  ArrayRefType arrayType = dyn_cast<ArrayRefType>(destType);
+  if (!arrayType)
+    return parser.emitError(parser.getCurrentLocation(),
+                            "expected arrayref type");
+  elementsTypes.append(arrayType.getNumElements(), arrayType.getElementType());
+  return success();
+}
+
+void printARCreate(OpAsmPrinter &printer, Operation *op, Type destType,
+                   Type inputType, TypeRange elementsTypes) {}
+
 #include "circt/Dialect/Arc/ArcInterfaces.cpp.inc"
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -760,12 +760,10 @@ LogicalResult ArrayRefAllocOp::verify() {
              << getType().getNumElements();
     }
 
-    int elemBitwidth = getType().getElementType().getIntOrFloatBitWidth();
-    for (int64_t value : *init) {
-      APInt apint(elemBitwidth, value);
-      if (apint.getSExtValue() != value) {
-        return emitOpError("value ") << value << " cannot be represented as `"
-                                     << getType().getElementType() << "`";
+    unsigned elemBitwidth = getType().getElementType().getIntOrFloatBitWidth();
+    for (APInt value : init->getAsValueRange<IntegerAttr>()) {
+      if (value.getBitWidth() != elemBitwidth) {
+        return emitOpError("expected element to be of type ") << getType().getElementType();
       }
     }
   }

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -753,7 +753,7 @@ LogicalResult ExecuteOp::verifyRegions() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ArrayRefAllocOp::verify() {
-  if (auto init = getInit(); init.has_value()) {
+  if (auto init = getInit()) {
     if (init->size() != getType().getNumElements()) {
       return emitOpError("init size does not match array size; init had size ")
              << init->size() << " but array has size "

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -749,22 +749,28 @@ LogicalResult ExecuteOp::verifyRegions() {
 }
 
 //===----------------------------------------------------------------------===//
-// ArrayRefCreateOp
+// ArrayRefAllocOp
 //===----------------------------------------------------------------------===//
 
-ParseResult parseARCreate(OpAsmParser &parser, Type destType, Type &inputType,
-                          SmallVectorImpl<Type> &elementsTypes) {
-  inputType = destType;
-  ArrayRefType arrayType = dyn_cast<ArrayRefType>(destType);
-  if (!arrayType)
-    return parser.emitError(parser.getCurrentLocation(),
-                            "expected arrayref type");
-  elementsTypes.append(arrayType.getNumElements(), arrayType.getElementType());
+LogicalResult ArrayRefAllocOp::verify() {
+  if (auto init = getInit(); init.has_value()) {
+    if (init->size() != getType().getNumElements()) {
+      return emitOpError("init size does not match array size; init had size ")
+             << init->size() << " but array has size "
+             << getType().getNumElements();
+    }
+
+    int elemBitwidth = getType().getElementType().getIntOrFloatBitWidth();
+    for (int64_t value : *init) {
+      APInt apint(elemBitwidth, value);
+      if (apint.getSExtValue() != value) {
+        return emitOpError("value ") << value << " cannot be represented as `"
+                                     << getType().getElementType() << "`";
+      }
+    }
+  }
   return success();
 }
-
-void printARCreate(OpAsmPrinter &printer, Operation *op, Type destType,
-                   Type inputType, TypeRange elementsTypes) {}
 
 #include "circt/Dialect/Arc/ArcInterfaces.cpp.inc"
 

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -763,7 +763,8 @@ LogicalResult ArrayRefAllocOp::verify() {
     unsigned elemBitwidth = getType().getElementType().getIntOrFloatBitWidth();
     for (APInt value : init->getAsValueRange<IntegerAttr>()) {
       if (value.getBitWidth() != elemBitwidth) {
-        return emitOpError("expected element to be of type ") << getType().getElementType();
+        return emitOpError("expected element to be of type ")
+               << getType().getElementType();
       }
     }
   }

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -18,6 +18,11 @@ using namespace circt;
 using namespace arc;
 using namespace mlir;
 
+static ParseResult parseArcArrayRef(AsmParser &parser, Attribute &dim,
+                                    Type &elementType);
+static void printArcArrayRef(AsmPrinter &printer, Attribute dim,
+                             Type elementType);
+
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/Arc/ArcTypes.cpp.inc"
 
@@ -26,14 +31,14 @@ using namespace mlir;
 /// necessary once the type has been mapped to LLVM. The idea is for this
 /// function to be conservative, such that we provide sufficient storage bytes
 /// for any type.
-static std::optional<uint64_t> computeLLVMBitWidth(Type type) {
+std::optional<uint64_t> computeLLVMBitWidth(Type type) {
   if (isa<seq::ClockType>(type))
     return 1;
 
   if (auto intType = dyn_cast<IntegerType>(type))
     return intType.getWidth();
 
-  if (auto arrayType = dyn_cast<hw::ArrayType>(type)) {
+  auto computeForArrayType = [&](auto arrayType) -> std::optional<uint64_t> {
     // Compute element width.
     auto maybeWidth = computeLLVMBitWidth(arrayType.getElementType());
     if (!maybeWidth)
@@ -45,7 +50,13 @@ static std::optional<uint64_t> computeLLVMBitWidth(Type type) {
     auto alignedWidth = llvm::alignToPowerOf2(width, alignment);
     // Multiply by the number of elements in the array.
     return arrayType.getNumElements() * alignedWidth;
-  }
+  };
+
+  if (auto arrayType = dyn_cast<hw::ArrayType>(type))
+    return computeForArrayType(arrayType);
+
+  if (auto arrayRefType = dyn_cast<ArrayRefType>(type))
+    return computeForArrayType(arrayRefType);
 
   if (auto structType = dyn_cast<hw::StructType>(type)) {
     uint64_t structWidth = 0;
@@ -89,6 +100,52 @@ StateType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
 unsigned MemoryType::getStride() {
   unsigned stride = (getWordType().getWidth() + 7) / 8;
   return llvm::alignToPowerOf2(stride, llvm::bit_ceil(std::min(stride, 16U)));
+}
+size_t ArrayRefType::getNumElements() const {
+  if (auto intAttr = llvm::dyn_cast<IntegerAttr>(getSizeAttr()))
+    return intAttr.getInt();
+  return 0;
+}
+
+std::optional<int64_t> ArrayRefType::getBitWidth() const {
+  auto elementBitWidth = hw::getBitWidth(getElementType());
+  if (elementBitWidth < 0)
+    return std::nullopt;
+  int64_t numElements = getNumElements();
+  if (numElements < 0)
+    return std::nullopt;
+  return numElements * elementBitWidth;
+}
+
+static ParseResult parseArcArrayRef(AsmParser &p, Attribute &dim, Type &inner) {
+  uint64_t dimLiteral;
+  auto int64Type = p.getBuilder().getIntegerType(64);
+
+  if (auto res = p.parseOptionalInteger(dimLiteral); res.has_value()) {
+    if (failed(*res))
+      return failure();
+    dim = p.getBuilder().getI64IntegerAttr(dimLiteral);
+  } else if (auto res64 = p.parseOptionalAttribute(dim, int64Type);
+             res64.has_value()) {
+    if (failed(*res64))
+      return failure();
+  } else
+    return p.emitError(p.getNameLoc(), "expected integer");
+
+  if (!isa<IntegerAttr>(dim)) {
+    p.emitError(p.getNameLoc(), "unsupported dimension kind in arc.arrayref");
+    return failure();
+  }
+
+  if (p.parseXInDimensionList() || p.parseType(inner))
+    return failure();
+
+  return success();
+}
+
+static void printArcArrayRef(AsmPrinter &p, Attribute dim, Type elementType) {
+  p.printAttributeWithoutType(dim);
+  p << "x" << elementType;
 }
 
 void ArcDialect::registerTypes() {

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -31,7 +31,7 @@ static void printArcArrayRef(AsmPrinter &printer, Attribute dim,
 /// necessary once the type has been mapped to LLVM. The idea is for this
 /// function to be conservative, such that we provide sufficient storage bytes
 /// for any type.
-std::optional<uint64_t> computeLLVMBitWidth(Type type) {
+std::optional<uint64_t> circt::arc::computeLLVMBitWidth(Type type) {
   if (isa<seq::ClockType>(type))
     return 1;
 

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -132,8 +132,9 @@ static void printXInDimList(AsmPrinter &p, Type elementType) {
   p << "x" << elementType;
 }
 
-LogicalResult ArrayRefType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
-                          Type elementType, uint64_t size) {
+LogicalResult
+ArrayRefType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
+                     Type elementType, uint64_t size) {
   if (size == 0) {
     return emitError() << "must have nonzero element count";
   }

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -132,6 +132,14 @@ static void printXInDimList(AsmPrinter &p, Type elementType) {
   p << "x" << elementType;
 }
 
+LogicalResult ArrayRefType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
+                          Type elementType, uint64_t size) {
+  if (size == 0) {
+    return emitError() << "must have nonzero element count";
+  }
+  return success();
+}
+
 void ArcDialect::registerTypes() {
   addTypes<
 #define GET_TYPEDEF_LIST

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -18,10 +18,8 @@ using namespace circt;
 using namespace arc;
 using namespace mlir;
 
-static ParseResult parseArcArrayRef(AsmParser &parser, Attribute &dim,
-                                    Type &elementType);
-static void printArcArrayRef(AsmPrinter &printer, Attribute dim,
-                             Type elementType);
+static ParseResult parseXInDimList(AsmParser &p, Type &elementType);
+static void printXInDimList(AsmPrinter &p, Type elementType);
 
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/Arc/ArcTypes.cpp.inc"
@@ -101,11 +99,8 @@ unsigned MemoryType::getStride() {
   unsigned stride = (getWordType().getWidth() + 7) / 8;
   return llvm::alignToPowerOf2(stride, llvm::bit_ceil(std::min(stride, 16U)));
 }
-size_t ArrayRefType::getNumElements() const {
-  if (auto intAttr = llvm::dyn_cast<IntegerAttr>(getSizeAttr()))
-    return intAttr.getInt();
-  return 0;
-}
+
+size_t ArrayRefType::getNumElements() const { return getSize(); }
 
 std::optional<int64_t> ArrayRefType::getBitWidth() const {
   auto elementBitWidth = hw::getBitWidth(getElementType());
@@ -117,34 +112,23 @@ std::optional<int64_t> ArrayRefType::getBitWidth() const {
   return numElements * elementBitWidth;
 }
 
-static ParseResult parseArcArrayRef(AsmParser &p, Attribute &dim, Type &inner) {
-  uint64_t dimLiteral;
-  auto int64Type = p.getBuilder().getIntegerType(64);
-
-  if (auto res = p.parseOptionalInteger(dimLiteral); res.has_value()) {
-    if (failed(*res))
-      return failure();
-    dim = p.getBuilder().getI64IntegerAttr(dimLiteral);
-  } else if (auto res64 = p.parseOptionalAttribute(dim, int64Type);
-             res64.has_value()) {
-    if (failed(*res64))
-      return failure();
-  } else
-    return p.emitError(p.getNameLoc(), "expected integer");
-
-  if (!isa<IntegerAttr>(dim)) {
-    p.emitError(p.getNameLoc(), "unsupported dimension kind in arc.arrayref");
-    return failure();
-  }
-
-  if (p.parseXInDimensionList() || p.parseType(inner))
-    return failure();
-
-  return success();
+ShapedType ArrayRefType::cloneWith(std::optional<ArrayRef<int64_t>> shape,
+                                   Type elementType) const {
+  llvm_unreachable("ArrayRefType::cloneWith not implemented!");
 }
 
-static void printArcArrayRef(AsmPrinter &p, Attribute dim, Type elementType) {
-  p.printAttributeWithoutType(dim);
+bool ArrayRefType::hasRank() const { return true; }
+
+ArrayRef<int64_t> ArrayRefType::getShape() const {
+  const uint64_t &size = getImpl()->size;
+  return ArrayRef<int64_t>(reinterpret_cast<const int64_t *>(&size), 1);
+}
+
+static ParseResult parseXInDimList(AsmParser &p, Type &elementType) {
+  return failure(p.parseXInDimensionList() || p.parseType(elementType));
+}
+
+static void printXInDimList(AsmPrinter &p, Type elementType) {
   p << "x" << elementType;
 }
 

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   IsolateClocks.cpp
   LatencyRetiming.cpp
   LowerArcsToFuncs.cpp
+  LowerArrays.cpp
   LowerClocksToFuncs.cpp
   LowerLUT.cpp
   LowerState.cpp

--- a/lib/Dialect/Arc/Transforms/LowerArrays.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArrays.cpp
@@ -1,0 +1,441 @@
+//===- LowerArrays.cpp ----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include <utility>
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Arc/ArcTypes.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "arc-lower-arrays"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_LOWERARRAYS
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+using namespace hw;
+using ::llvm::enumerate;
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerArraysPass : public arc::impl::LowerArraysBase<LowerArraysPass> {
+  LowerArraysPass() = default;
+  LowerArraysPass(const LowerArraysPass &pass) : LowerArraysPass() {}
+
+  void runOnOperation() override;
+};
+
+Value AsIndex(Value value, OpBuilder &builder) {
+  Location loc = builder.getUnknownLoc();
+  if (Operation *parent = value.getDefiningOp()) {
+    loc = parent->getLoc();
+  }
+  return arith::IndexCastUIOp::create(builder, loc, builder.getIndexType(),
+                                      value);
+}
+
+Value CloneArrayRef(Value value, OpBuilder &builder, Location loc) {
+  Value newAlloc = ArrayRefAllocOp::create(builder, loc, value.getType(), {});
+  return ArrayRefCopyOp::create(builder, loc, newAlloc, value);
+}
+
+struct ConvertFunc : public OpConversionPattern<func::FuncOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(func::FuncOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const TypeConverter &converter = *getTypeConverter();
+    TypeConverter::SignatureConversion conversion(op.getNumArguments());
+
+    SmallVector<Type> newArgTypes;
+    SmallVector<Type> newResultTypes;
+    assert(op.getBody().getBlocks().size() == 1);
+
+    // Any array-typed results become parameters.
+    Operation *ret = op.getBody().front().getTerminator();
+    for (Value result : ret->getOperands()) {
+      if (isa<ArrayType>(result.getType())) {
+        Type newType = converter.convertType(result.getType());
+        conversion.addInputs(newType);
+        newArgTypes.push_back(newType);
+      }
+    }
+
+    if (failed(converter.convertTypes(op.getArgumentTypes(), newArgTypes)) ||
+        failed(converter.convertTypes(op.getResultTypes(), newResultTypes))) {
+      return failure();
+    }
+
+    if (failed(converter.convertSignatureArgs(op.getArgumentTypes(),
+                                              conversion)) ||
+        failed(rewriter.convertRegionTypes(&op.getBody(), converter,
+                                           &conversion))) {
+      return failure();
+    }
+
+    rewriter.modifyOpInPlace(op, [&] {
+      op.setType(FunctionType::get(getContext(), newArgTypes, newResultTypes));
+    });
+
+    return success();
+  }
+};
+
+struct ConvertReturn : public OpConversionPattern<func::ReturnOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    func::FuncOp func = op->getParentOfType<func::FuncOp>();
+    int sretIndex = 0;
+    SmallVector<Value> newOperands;
+    for (Value operand : adaptor.getOperands()) {
+      if (isa<ArrayRefType>(operand.getType())) {
+        Value arg = func.getArgument(sretIndex++);
+        Value copy =
+            ArrayRefCopyOp::create(rewriter, op.getLoc(), arg, operand);
+        newOperands.push_back(copy);
+      } else {
+        newOperands.push_back(operand);
+      }
+    }
+    rewriter.modifyOpInPlace(op, [&] { op->setOperands(newOperands); });
+    return success();
+  }
+};
+
+struct ConvertCall : public OpConversionPattern<func::CallOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(func::CallOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value> newOperands;
+    for (Type resultType : op.getResultTypes()) {
+      auto arrayType = dyn_cast<ArrayType>(resultType);
+      if (!arrayType)
+        continue;
+      auto arrayRefType = ArrayRefType::get(arrayType.getElementType(),
+                                            arrayType.getNumElements());
+      Value alloc =
+          ArrayRefAllocOp::create(rewriter, op.getLoc(), arrayRefType, {});
+      newOperands.push_back(alloc);
+    }
+    for (Value operand : adaptor.getOperands()) {
+      newOperands.push_back(operand);
+    }
+
+    SmallVector<Type> resultTypes;
+    if (failed(getTypeConverter()->convertTypes(op.getResultTypes(),
+                                                resultTypes))) {
+      return failure();
+    }
+
+    auto newCall = func::CallOp::create(rewriter, op.getLoc(), op.getCallee(),
+                                        resultTypes, newOperands);
+    newCall->setDiscardableAttrs(op->getDiscardableAttrDictionary());
+
+    rewriter.replaceOp(op, newCall);
+    return success();
+  }
+};
+
+struct ConvertAggregateConstant
+    : public OpConversionPattern<AggregateConstantOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(AggregateConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type newType = getTypeConverter()->convertType(op.getType());
+    Value newOp = ArrayRefAllocOp::create(rewriter, op.getLoc(), newType,
+                                          op.getFieldsAttr());
+    rewriter.replaceOp(op, newOp);
+    return success();
+  }
+};
+
+struct ConvertArrayGet : public OpConversionPattern<ArrayGetOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(hw::ArrayGetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value index = AsIndex(op.getIndex(), rewriter);
+    Type resultType = getTypeConverter()->convertType(op.getType());
+    Value newOp = ArrayRefGetOp::create(rewriter, op.getLoc(), resultType,
+                                        adaptor.getInput(), index);
+    rewriter.replaceOp(op, newOp);
+    return success();
+  }
+};
+
+struct ConvertArrayInject : public OpConversionPattern<ArrayInjectOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayInjectOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value index = AsIndex(op.getIndex(), rewriter);
+    Value dest = CloneArrayRef(adaptor.getInput(), rewriter, op.getLoc());
+    Value newOp =
+        ArrayRefInjectOp::create(rewriter, op.getLoc(), dest.getType(), dest,
+                                 index, adaptor.getElement());
+    rewriter.replaceOp(op, newOp);
+    return success();
+  }
+};
+
+struct ConvertArraySlice : public OpConversionPattern<ArraySliceOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArraySliceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Because we're converting from value semantics and ArrayRefSliceOp is
+    // a subview-like operator, we must clone the input array first.
+    Value newInput = CloneArrayRef(adaptor.getInput(), rewriter, op.getLoc());
+    Value index = AsIndex(op.getLowIndex(), rewriter);
+    Type destType = getTypeConverter()->convertType(op.getType());
+    Value newOp = ArrayRefSliceOp::create(rewriter, op.getLoc(), destType,
+                                          newInput, index);
+    rewriter.replaceOp(op, newOp);
+    return success();
+  }
+};
+
+struct ConvertArrayConcat : public OpConversionPattern<ArrayConcatOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayConcatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type destType = getTypeConverter()->convertType(op.getType());
+    Value dest = ArrayRefAllocOp::create(rewriter, op.getLoc(), destType, {});
+
+    // ArrayConcatOp's operands are ordered from most significant to least
+    // significant.
+    int offset = cast<ArrayRefType>(destType).getNumElements();
+    for (Value operand : adaptor.getOperands()) {
+      offset -= cast<ArrayRefType>(operand.getType()).getNumElements();
+      Value index =
+          arith::ConstantIndexOp::create(rewriter, op.getLoc(), offset);
+      Value destSlice = ArrayRefSliceOp::create(rewriter, op.getLoc(),
+                                                operand.getType(), dest, index);
+      ArrayRefCopyOp::create(rewriter, op.getLoc(), destSlice, operand);
+    }
+    assert(offset == 0);
+    rewriter.replaceOp(op, dest);
+    return success();
+  }
+};
+
+struct ConvertArrayCreate : public OpConversionPattern<ArrayCreateOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArrayCreateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type newType = getTypeConverter()->convertType(op.getType());
+    Value alloc = ArrayRefAllocOp::create(rewriter, op.getLoc(), newType, {});
+    Value create = ArrayRefCreateOp::create(rewriter, op.getLoc(), newType,
+                                            alloc, adaptor.getInputs());
+    rewriter.replaceOp(op, create);
+    return success();
+  }
+};
+
+struct ConvertStorageGet : public OpConversionPattern<StorageGetOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StorageGetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto result = convertOpResultTypes(op, adaptor.getOperands(),
+                                       *getTypeConverter(), rewriter);
+    if (failed(result))
+      return failure();
+
+    rewriter.replaceOp(op, *result);
+    return success();
+  }
+};
+
+struct ConvertMux : public OpConversionPattern<comb::MuxOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(comb::MuxOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type newType = getTypeConverter()->convertType(op.getType());
+    Value newOp = arith::SelectOp::create(
+        rewriter, op.getLoc(), newType, adaptor.getCond(),
+        adaptor.getTrueValue(), adaptor.getFalseValue());
+    rewriter.replaceOp(op, newOp);
+    return success();
+  }
+};
+
+// Identifies a return of an ArrayRef that is defined by an ArrayRefAllocOp,
+// and replaces the alloc with the sret buffer. Also removes the copy.
+struct OptimizeReturnOfAlloc : public OpRewritePattern<func::ReturnOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(func::ReturnOp op,
+                                PatternRewriter &rewriter) const override {
+    auto funcOp = op->getParentOfType<func::FuncOp>();
+    bool changed = false;
+
+    // Iterate over all pairs of (result, sret-buffer). The sret buffers are
+    // always the initial function arguments, and every !arc.arrayref<T>
+    // result has one sret buffer associated with it.
+    auto args = funcOp.getArguments();
+    auto results =
+        llvm::make_filter_range(op->getOpOperands(), [](OpOperand &operand) {
+          return isa<ArrayRefType>(operand.get().getType());
+        });
+
+    for (auto [arg, result] : llvm::zip(args, results)) {
+      Value resultValue = result.get();
+      auto copy = resultValue.getDefiningOp<ArrayRefCopyOp>();
+      if (!copy || copy.getDestInput() != arg)
+        continue;
+      ArrayRefAllocOp alloc = getUltimatelyDefiningAlloc(copy.getSource());
+      if (!alloc || alloc.getInit())
+        continue;
+      result.set(copy.getSource());
+      rewriter.replaceAllUsesWith(alloc, arg);
+      rewriter.eraseOp(alloc);
+      rewriter.eraseOp(copy);
+      changed = true;
+    }
+    return success(changed);
+  }
+
+  ArrayRefAllocOp getUltimatelyDefiningAlloc(Value value) const {
+    if (!isa<ArrayRefType>(value.getType()))
+      return nullptr;
+    while (value) {
+      Operation *op = value.getDefiningOp();
+      if (!op)
+        return nullptr;
+      if (auto alloc = dyn_cast<ArrayRefAllocOp>(op))
+        return alloc;
+
+      value = TypeSwitch<Operation *, Value>(op)
+                  .Case<ArrayRefCopyOp>(
+                      [&](auto copy) { return copy.getDestInput(); })
+                  .Case<ArrayRefInjectOp>(
+                      [&](auto inject) { return inject.getInput(); })
+                  .Case<func::CallOp>([&](auto call) {
+                    OpResult result = cast<OpResult>(value);
+                    return call.getOperand(result.getResultNumber());
+                  })
+                  .Default([&](Operation *) { return nullptr; });
+    }
+    return nullptr;
+  }
+};
+
+template <typename Op>
+struct ConvertTrivially : public OpConversionPattern<Op> {
+  using OpConversionPattern<Op>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(Op op, typename Op::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto result = convertOpResultTypes(op, adaptor.getOperands(),
+                                       *this->getTypeConverter(), rewriter);
+    if (failed(result))
+      return failure();
+    rewriter.replaceOp(op, *result);
+    return success();
+  }
+};
+
+using ConvertAllocState = ConvertTrivially<arc::AllocStateOp>;
+using ConvertStateRead = ConvertTrivially<arc::StateReadOp>;
+using ConvertStateWrite = ConvertTrivially<arc::StateWriteOp>;
+using ConvertRootInput = ConvertTrivially<arc::RootInputOp>;
+using ConvertRootOutput = ConvertTrivially<arc::RootOutputOp>;
+using ConvertUnrealizedConversionCast =
+    ConvertTrivially<UnrealizedConversionCastOp>;
+
+} // namespace
+
+void LowerArraysPass::runOnOperation() {
+  TypeConverter converter;
+  ConversionTarget target(getContext());
+  RewritePatternSet patterns(&getContext());
+
+  converter.addConversion([](Type type) { return type; });
+  converter.addConversion([](ArrayType type) {
+    return ArrayRefType::get(type.getElementType(), type.getNumElements());
+  });
+  converter.addConversion([&converter](StateType type) {
+    return StateType::get(converter.convertType(type.getType()));
+  });
+
+  target.addIllegalOp<ArrayCreateOp, ArrayConcatOp, ArrayGetOp, ArrayInjectOp,
+                      ArraySliceOp>();
+  target.markUnknownOpDynamicallyLegal(
+      [&](Operation *op) { return converter.isLegal(op); });
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp func) {
+    FunctionType fty = func.getFunctionType();
+    return converter.isLegal(fty.getInputs()) &&
+           converter.isLegal(fty.getResults());
+  });
+
+  patterns.add<ConvertFunc, ConvertReturn, ConvertCall,
+               ConvertAggregateConstant, ConvertArrayGet, ConvertArrayInject,
+               ConvertArraySlice, ConvertArrayConcat, ConvertArrayCreate,
+               ConvertStorageGet, ConvertMux, ConvertAllocState,
+               ConvertStateRead, ConvertStateWrite, ConvertRootInput,
+               ConvertRootOutput, ConvertUnrealizedConversionCast>(
+      converter, &getContext());
+
+  if (failed(applyPartialConversion(getOperation(), target,
+                                    std::move(patterns)))) {
+    return signalPassFailure();
+  }
+
+  // Apply some cleanup patterns to optimize away ArrayRefAllocOps.
+  RewritePatternSet cleanupPatterns(&getContext());
+  cleanupPatterns.add<OptimizeReturnOfAlloc>(&getContext());
+  if (failed(
+          applyPatternsGreedily(getOperation(), std::move(cleanupPatterns)))) {
+    return signalPassFailure();
+  }
+}

--- a/lib/Dialect/Arc/Transforms/LowerArrays.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArrays.cpp
@@ -198,8 +198,8 @@ struct ConvertArrayGet : public OpConversionPattern<ArrayGetOp> {
   LogicalResult
   matchAndRewrite(hw::ArrayGetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value index = asIndex(op.getIndex(), rewriter);
     Type resultType = getTypeConverter()->convertType(op.getType());
+    Value index = asIndex(op.getIndex(), rewriter);
     Value newOp = ArrayRefGetOp::create(rewriter, op.getLoc(), resultType,
                                         adaptor.getInput(), index);
     rewriter.replaceOp(op, newOp);
@@ -367,6 +367,8 @@ struct OptimizeReturnOfAlloc : public OpRewritePattern<func::ReturnOp> {
               .Case<ArrayRefCopyOp>([&](auto copy) { return copy.getInput(); })
               .Case<ArrayRefInjectOp>(
                   [&](auto inject) { return inject.getInput(); })
+              .Case<ArrayRefFromArrayOp>(
+                  [&](auto fromArray) { return fromArray.getInput(); })
               .Case<func::CallOp>([&](auto call) {
                 OpResult result = cast<OpResult>(value);
                 return call.getOperand(result.getResultNumber());
@@ -409,21 +411,50 @@ void LowerArraysPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
 
   converter.addConversion([](Type type) { return type; });
-  converter.addConversion([](ArrayType type) {
-    return ArrayRefType::get(type.getElementType(), type.getNumElements());
+  converter.addConversion([&converter](ArrayType type) -> Type {
+    Type newElem = converter.convertType(type.getElementType());
+    // Don't convert nested array types.
+    if (newElem != type.getElementType())
+      return type;
+    return ArrayRefType::get(newElem, type.getNumElements());
   });
   converter.addConversion([&converter](StateType type) {
     return StateType::get(converter.convertType(type.getType()));
   });
 
-  target.addIllegalOp<ArrayCreateOp, ArrayConcatOp, ArrayGetOp, ArrayInjectOp,
-                      ArraySliceOp>();
+  target.addLegalOp<ArrayRefFromArrayOp, ArrayRefToArrayOp>();
   target.markUnknownOpDynamicallyLegal(
       [&](Operation *op) { return converter.isLegal(op); });
   target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp func) {
     FunctionType fty = func.getFunctionType();
     return converter.isLegal(fty.getInputs()) &&
            converter.isLegal(fty.getResults());
+  });
+  // An ArrayGetOp may legally return an array if the input type was a nested
+  // array. Similarly for ArrayCreateOp and ArrayInjectOp.
+  target.addDynamicallyLegalOp<ArrayGetOp>([&](ArrayGetOp op) {
+    return converter.isLegal(op.getInput().getType());
+  });
+  target.addDynamicallyLegalOp<ArrayCreateOp, ArrayInjectOp>(
+      [&](Operation *op) {
+        return converter.isLegal(op->getResult(0).getType());
+      });
+
+  // Produces an ArrayRefType from an ArrayType.
+  converter.addTargetMaterialization([&](OpBuilder &b, ArrayRefType type,
+                                         ValueRange values, Location loc,
+                                         Type fromType) -> Value {
+    assert(isa<ArrayType>(fromType));
+    Value alloc = ArrayRefAllocOp::create(b, loc, type, {});
+    return ArrayRefFromArrayOp::create(b, loc, type, alloc, values.front());
+  });
+
+  // Produces an ArrayType from an ArrayRefType.
+  converter.addSourceMaterialization([&](OpBuilder &b, ArrayType type,
+                                         ValueRange values,
+                                         Location loc) -> Value {
+    assert(isa<ArrayRefType>(values.front().getType()));
+    return ArrayRefToArrayOp::create(b, loc, type, values.front());
   });
 
   patterns.add<ConvertFunc, ConvertReturn, ConvertCall,

--- a/lib/Dialect/Arc/Transforms/LowerArrays.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArrays.cpp
@@ -379,6 +379,24 @@ struct OptimizeReturnOfAlloc : public OpRewritePattern<func::ReturnOp> {
   }
 };
 
+struct ConvertStateRead : public OpConversionPattern<StateReadOp> {
+  using OpConversionPattern<StateReadOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StateReadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto result = convertOpResultTypes(op, adaptor.getOperands(),
+                                       *this->getTypeConverter(), rewriter);
+    if (failed(result))
+      return failure();
+
+    // For correctness we need to copy the read state into a local array.
+    Value resultValue = result.value()->getResult(0);
+    rewriter.replaceOp(op, cloneArrayRef(resultValue, rewriter, op.getLoc()));
+    return success();
+  }
+};
+
 template <typename Op>
 struct ConvertTrivially : public OpConversionPattern<Op> {
   using OpConversionPattern<Op>::OpConversionPattern;
@@ -396,7 +414,6 @@ struct ConvertTrivially : public OpConversionPattern<Op> {
 };
 
 using ConvertAllocState = ConvertTrivially<arc::AllocStateOp>;
-using ConvertStateRead = ConvertTrivially<arc::StateReadOp>;
 using ConvertStateWrite = ConvertTrivially<arc::StateWriteOp>;
 using ConvertRootInput = ConvertTrivially<arc::RootInputOp>;
 using ConvertRootOutput = ConvertTrivially<arc::RootOutputOp>;
@@ -423,6 +440,9 @@ void LowerArraysPass::runOnOperation() {
   });
 
   target.addLegalOp<ArrayRefFromArrayOp, ArrayRefToArrayOp>();
+  // Arrays within structs or unions always use !hw.array.
+  target.addLegalOp<StructCreateOp, StructInjectOp, StructExtractOp,
+                    StructExplodeOp, UnionCreateOp, UnionExtractOp>();
   target.markUnknownOpDynamicallyLegal(
       [&](Operation *op) { return converter.isLegal(op); });
   target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp func) {

--- a/lib/Dialect/Arc/Transforms/LowerArrays.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArrays.cpp
@@ -490,8 +490,8 @@ void LowerArraysPass::runOnOperation() {
 
   ConversionConfig config;
   config.allowPatternRollback = false;
-  if (failed(applyPartialConversion(getOperation(), target,
-                                    std::move(patterns), config))) {
+  if (failed(applyPartialConversion(getOperation(), target, std::move(patterns),
+                                    config))) {
     return signalPassFailure();
   }
 

--- a/lib/Dialect/Arc/Transforms/LowerArrays.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArrays.cpp
@@ -55,7 +55,7 @@ struct LowerArraysPass : public arc::impl::LowerArraysBase<LowerArraysPass> {
   void runOnOperation() override;
 };
 
-Value AsIndex(Value value, OpBuilder &builder) {
+Value asIndex(Value value, OpBuilder &builder) {
   Location loc = builder.getUnknownLoc();
   if (Operation *parent = value.getDefiningOp()) {
     loc = parent->getLoc();
@@ -64,7 +64,7 @@ Value AsIndex(Value value, OpBuilder &builder) {
                                       value);
 }
 
-Value CloneArrayRef(Value value, OpBuilder &builder, Location loc) {
+Value cloneArrayRef(Value value, OpBuilder &builder, Location loc) {
   Value newAlloc = ArrayRefAllocOp::create(builder, loc, value.getType(), {});
   return ArrayRefCopyOp::create(builder, loc, newAlloc, value);
 }
@@ -179,9 +179,14 @@ struct ConvertAggregateConstant
   LogicalResult
   matchAndRewrite(AggregateConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Type newType = getTypeConverter()->convertType(op.getType());
+    auto newType =
+        cast<ArrayRefType>(getTypeConverter()->convertType(op.getType()));
+    SmallVector<int64_t> ints;
+    for (APInt apint : op.getFieldsAttr().getAsValueRange<IntegerAttr>()) {
+      ints.push_back(apint.getSExtValue());
+    }
     Value newOp = ArrayRefAllocOp::create(rewriter, op.getLoc(), newType,
-                                          op.getFieldsAttr());
+                                          rewriter.getDenseI64ArrayAttr(ints));
     rewriter.replaceOp(op, newOp);
     return success();
   }
@@ -193,7 +198,7 @@ struct ConvertArrayGet : public OpConversionPattern<ArrayGetOp> {
   LogicalResult
   matchAndRewrite(hw::ArrayGetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value index = AsIndex(op.getIndex(), rewriter);
+    Value index = asIndex(op.getIndex(), rewriter);
     Type resultType = getTypeConverter()->convertType(op.getType());
     Value newOp = ArrayRefGetOp::create(rewriter, op.getLoc(), resultType,
                                         adaptor.getInput(), index);
@@ -208,8 +213,8 @@ struct ConvertArrayInject : public OpConversionPattern<ArrayInjectOp> {
   LogicalResult
   matchAndRewrite(ArrayInjectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value index = AsIndex(op.getIndex(), rewriter);
-    Value dest = CloneArrayRef(adaptor.getInput(), rewriter, op.getLoc());
+    Value index = asIndex(op.getIndex(), rewriter);
+    Value dest = cloneArrayRef(adaptor.getInput(), rewriter, op.getLoc());
     Value newOp =
         ArrayRefInjectOp::create(rewriter, op.getLoc(), dest.getType(), dest,
                                  index, adaptor.getElement());
@@ -226,8 +231,8 @@ struct ConvertArraySlice : public OpConversionPattern<ArraySliceOp> {
                   ConversionPatternRewriter &rewriter) const override {
     // Because we're converting from value semantics and ArrayRefSliceOp is
     // a subview-like operator, we must clone the input array first.
-    Value newInput = CloneArrayRef(adaptor.getInput(), rewriter, op.getLoc());
-    Value index = AsIndex(op.getLowIndex(), rewriter);
+    Value newInput = cloneArrayRef(adaptor.getInput(), rewriter, op.getLoc());
+    Value index = asIndex(op.getLowIndex(), rewriter);
     Type destType = getTypeConverter()->convertType(op.getType());
     Value newOp = ArrayRefSliceOp::create(rewriter, op.getLoc(), destType,
                                           newInput, index);
@@ -330,12 +335,15 @@ struct OptimizeReturnOfAlloc : public OpRewritePattern<func::ReturnOp> {
     for (auto [arg, result] : llvm::zip(args, results)) {
       Value resultValue = result.get();
       auto copy = resultValue.getDefiningOp<ArrayRefCopyOp>();
-      if (!copy || copy.getDestInput() != arg)
+      if (!copy || copy.getInput() != arg)
         continue;
       ArrayRefAllocOp alloc = getUltimatelyDefiningAlloc(copy.getSource());
       if (!alloc || alloc.getInit())
         continue;
-      result.set(copy.getSource());
+      // Note that `result` is a structured binding, which cannot be implicitly
+      // captured until C++20.
+      rewriter.modifyOpInPlace(
+          op, [&, &result = result] { result.set(copy.getSource()); });
       rewriter.replaceAllUsesWith(alloc, arg);
       rewriter.eraseOp(alloc);
       rewriter.eraseOp(copy);
@@ -354,16 +362,16 @@ struct OptimizeReturnOfAlloc : public OpRewritePattern<func::ReturnOp> {
       if (auto alloc = dyn_cast<ArrayRefAllocOp>(op))
         return alloc;
 
-      value = TypeSwitch<Operation *, Value>(op)
-                  .Case<ArrayRefCopyOp>(
-                      [&](auto copy) { return copy.getDestInput(); })
-                  .Case<ArrayRefInjectOp>(
-                      [&](auto inject) { return inject.getInput(); })
-                  .Case<func::CallOp>([&](auto call) {
-                    OpResult result = cast<OpResult>(value);
-                    return call.getOperand(result.getResultNumber());
-                  })
-                  .Default([&](Operation *) { return nullptr; });
+      value =
+          TypeSwitch<Operation *, Value>(op)
+              .Case<ArrayRefCopyOp>([&](auto copy) { return copy.getInput(); })
+              .Case<ArrayRefInjectOp>(
+                  [&](auto inject) { return inject.getInput(); })
+              .Case<func::CallOp>([&](auto call) {
+                OpResult result = cast<OpResult>(value);
+                return call.getOperand(result.getResultNumber());
+              })
+              .Default([&](Operation *) { return nullptr; });
     }
     return nullptr;
   }

--- a/lib/Dialect/Arc/Transforms/LowerArrays.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArrays.cpp
@@ -355,13 +355,6 @@ struct OptimizeReturnOfAlloc : public OpRewritePattern<func::ReturnOp> {
       if (!op)
         return nullptr;
 
-      // If any op on the chain is used by a slice, it is not safe to replace
-      // the array with the sret buffer.
-      for (Operation *user : op->getUsers()) {
-        if (isa<ArraySliceOp>(user))
-          return nullptr;
-      }
-
       if (auto alloc = dyn_cast<ArrayRefAllocOp>(op))
         return alloc;
 

--- a/lib/Dialect/Arc/Transforms/LowerArrays.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArrays.cpp
@@ -181,12 +181,8 @@ struct ConvertAggregateConstant
                   ConversionPatternRewriter &rewriter) const override {
     auto newType =
         cast<ArrayRefType>(getTypeConverter()->convertType(op.getType()));
-    SmallVector<int64_t> ints;
-    for (APInt apint : op.getFieldsAttr().getAsValueRange<IntegerAttr>()) {
-      ints.push_back(apint.getSExtValue());
-    }
     Value newOp = ArrayRefAllocOp::create(rewriter, op.getLoc(), newType,
-                                          rewriter.getDenseI64ArrayAttr(ints));
+                                          op.getFieldsAttr());
     rewriter.replaceOp(op, newOp);
     return success();
   }
@@ -229,13 +225,12 @@ struct ConvertArraySlice : public OpConversionPattern<ArraySliceOp> {
   LogicalResult
   matchAndRewrite(ArraySliceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Because we're converting from value semantics and ArrayRefSliceOp is
-    // a subview-like operator, we must clone the input array first.
-    Value newInput = cloneArrayRef(adaptor.getInput(), rewriter, op.getLoc());
+    // Because we're converting from value semantics we can assume that the
+    // input buffer is immutable, so we don't need to copy it.
     Value index = asIndex(op.getLowIndex(), rewriter);
     Type destType = getTypeConverter()->convertType(op.getType());
     Value newOp = ArrayRefSliceOp::create(rewriter, op.getLoc(), destType,
-                                          newInput, index);
+                                          adaptor.getInput(), index);
     rewriter.replaceOp(op, newOp);
     return success();
   }
@@ -359,6 +354,14 @@ struct OptimizeReturnOfAlloc : public OpRewritePattern<func::ReturnOp> {
       Operation *op = value.getDefiningOp();
       if (!op)
         return nullptr;
+
+      // If any op on the chain is used by a slice, it is not safe to replace
+      // the array with the sret buffer.
+      for (Operation *user : op->getUsers()) {
+        if (isa<ArraySliceOp>(user))
+          return nullptr;
+      }
+
       if (auto alloc = dyn_cast<ArrayRefAllocOp>(op))
         return alloc;
 
@@ -485,8 +488,10 @@ void LowerArraysPass::runOnOperation() {
                ConvertRootOutput, ConvertUnrealizedConversionCast>(
       converter, &getContext());
 
+  ConversionConfig config;
+  config.allowPatternRollback = false;
   if (failed(applyPartialConversion(getOperation(), target,
-                                    std::move(patterns)))) {
+                                    std::move(patterns), config))) {
     return signalPassFailure();
   }
 

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -154,6 +154,9 @@ void circt::populateArcToLLVMPipeline(OpPassManager &pm,
     opts.traceFileName = options.traceFileName;
     pm.addPass(createInsertRuntime(opts));
   }
+  if (options.bufferizeArrays) {
+    pm.addPass(createLowerArrays());
+  }
   pm.addPass(createLowerArcToLLVMPass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizer());

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
 
 // CHECK-LABEL: @Types
-// CHECK-SAME: %arg0: !llvm.ptr
+// CHECK-SAME: %arg0: !llvm.ptr {llvm.dereferenceable = 8 : i64}
 // CHECK-SAME: -> !llvm.ptr
 func.func @Types(%arg0: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32> {
   return %arg0 : !arc.arrayref<2xi32>

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -1,0 +1,128 @@
+// RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @Types
+// CHECK-SAME: %arg0: !llvm.ptr
+// CHECK-SAME: -> !llvm.ptr
+func.func @Types(%arg0: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32> {
+  return %arg0 : !arc.arrayref<2xi32>
+}
+
+// CHECK-LABEL: @StorageGet
+func.func @StorageGet(%arg0: !arc.storage<12>) -> !arc.state<!arc.arrayref<2xi32>> {
+  %0 = arc.storage.get %arg0[4] : !arc.storage<12> -> !arc.state<!arc.arrayref<2xi32>>
+  return %0 : !arc.state<!arc.arrayref<2xi32>>
+}
+
+// CHECK-LABEL: @StateRead
+// CHECK-NEXT: return %arg0
+func.func @StateRead(%arg0: !arc.state<!arc.arrayref<2xi32>>) -> !arc.arrayref<2xi32> {
+  %0 = arc.state_read %arg0 : <!arc.arrayref<2xi32>>
+  return %0 : !arc.arrayref<2xi32>
+}
+
+// CHECK-LABEL: @StateWrite
+// CHECK-NEXT: %[[C:.*]] = llvm.mlir.constant(8 : i64)
+// CHECK-NEXT: "llvm.intr.memcpy"(%arg0, %arg1, %[[C]])
+func.func @StateWrite(%arg0: !arc.state<!arc.arrayref<2xi32>>, %arg1: !arc.arrayref<2xi32>) {
+  arc.state_write %arg0 = %arg1 : <!arc.arrayref<2xi32>>
+  return
+}
+
+// CHECK-LABEL: @Mux
+// CHECK-NEXT: %[[R:.*]] = llvm.select %arg2, %arg0, %arg1 : i1, !llvm.ptr
+// CHECK-NEXT: return %[[R]]
+func.func @Mux(%arg0: !arc.arrayref<2xi32>, %arg1: !arc.arrayref<2xi32>, %arg2: i1) -> !arc.arrayref<2xi32> {
+  %0 = arith.select %arg2, %arg0, %arg1 : !arc.arrayref<2xi32>
+  return %0 : !arc.arrayref<2xi32>
+}
+
+// CHECK-LABEL: @ArrayRefCreate
+// CHECK: %[[C4:.*]] = llvm.mlir.constant(4 : i64)
+// CHECK: %[[GEP0:.*]] = llvm.getelementptr %arg0[%[[C4]]]
+// CHECK: llvm.store %arg1, %[[GEP0]]
+// CHECK: %[[C0:.*]] = llvm.mlir.constant(0 : i64)
+// CHECK: %[[GEP1:.*]] = llvm.getelementptr %arg0[%[[C0]]]
+// CHECK: llvm.store %arg2, %[[GEP1]]
+// CHECK: return %arg0
+func.func @ArrayRefCreate(%arg0: !arc.arrayref<2xi32>, %arg1: i32, %arg2: i32) -> !arc.arrayref<2xi32> {
+  %1 = arc.arrayref.create %arg0 = %arg1, %arg2 : !arc.arrayref<2xi32>
+  return %1 : !arc.arrayref<2xi32>
+}
+
+// CHECK-LABEL: @ArrayRefAlloc
+// CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
+// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8
+// CHECK-NEXT: return %[[A]]
+func.func @ArrayRefAlloc() -> !arc.arrayref<2xi32> {
+  %0 = arc.arrayref.alloc  !arc.arrayref<2xi32>
+  return %0 : !arc.arrayref<2xi32>
+}
+
+// CHECK-LABEL: @ArrayRefInit
+// CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
+// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8
+// CHECK-NEXT: %[[C4:.*]] = llvm.mlir.constant(4 : i64)
+// CHECK-NEXT: %[[GEP0:.*]] = llvm.getelementptr %[[A]][%[[C4]]]
+// CHECK-NEXT: %[[V123:.*]] = llvm.mlir.constant(123 : i32)
+// CHECK-NEXT: llvm.store %[[V123]], %[[GEP0]]
+// CHECK-NEXT: %[[C0:.*]] = llvm.mlir.constant(0 : i64)
+// CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[A]][%[[C0]]]
+// CHECK-NEXT: %[[V456:.*]] = llvm.mlir.constant(456 : i32)
+// CHECK-NEXT: llvm.store %[[V456]], %[[GEP1]]
+// CHECK-NEXT: return %[[A]]
+func.func @ArrayRefInit() -> !arc.arrayref<2xi32> {
+  %0 = arc.arrayref.alloc init [123 : i32, 456 : i32] !arc.arrayref<2xi32>
+  return %0 : !arc.arrayref<2xi32>
+}
+
+// CHECK-LABEL: @ArrayRefInitZero
+// CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
+// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8
+// CHECK-NEXT: %[[ZERO:.*]] = llvm.mlir.constant(0 : i8)
+// CHECK-NEXT: "llvm.intr.memset"(%[[A]], %[[ZERO]], %[[C8]])
+// CHECK-NEXT: return %[[A]]
+func.func @ArrayRefInitZero() -> !arc.arrayref<2xi32> {
+  %0 = arc.arrayref.alloc init [0 : i32, 0 : i32] !arc.arrayref<2xi32>
+  return %0 : !arc.arrayref<2xi32>
+}
+
+// CHECK-LABEL: @ArrayRefGet
+// CHECK-NEXT: %[[STRIDE:.*]] = llvm.mlir.constant(4 : i64)
+// CHECK-NEXT: %[[OFF:.*]] = llvm.mul %arg1, %[[STRIDE]]
+// CHECK-NEXT: %[[ADDR:.*]] = llvm.getelementptr %arg0[%[[OFF]]]
+// CHECK-NEXT: %[[VAL:.*]] = llvm.load %[[ADDR]]
+// CHECK-NEXT: return %[[VAL]]
+func.func @ArrayRefGet(%arg0: !arc.arrayref<4xi32>, %idx: index) -> i32 {
+  %0 = arc.arrayref.get %arg0[%idx] : !arc.arrayref<4xi32> -> i32
+  return %0 : i32
+}
+
+// CHECK-LABEL: @ArrayRefInject
+// CHECK-NEXT: %[[STRIDE:.*]] = llvm.mlir.constant(4 : i64)
+// CHECK-NEXT: %[[OFF:.*]] = llvm.mul %arg1, %[[STRIDE]]
+// CHECK-NEXT: %[[ADDR:.*]] = llvm.getelementptr %arg0[%[[OFF]]]
+// CHECK-NEXT: llvm.store %arg2, %[[ADDR]]
+// CHECK-NEXT: return %arg0
+func.func @ArrayRefInject(%arg0: !arc.arrayref<4xi32>, %idx: index, %val: i32) -> !arc.arrayref<4xi32> {
+  %0 = arc.arrayref.inject %arg0[%idx], %val : !arc.arrayref<4xi32>, i32 -> !arc.arrayref<4xi32>
+  return %0 : !arc.arrayref<4xi32>
+}
+
+// CHECK-LABEL: @ArrayRefSlice
+// CHECK-NEXT: %[[STRIDE:.*]] = llvm.mlir.constant(4 : i64)
+// CHECK-NEXT: %[[OFF:.*]] = llvm.mul %arg1, %[[STRIDE]]
+// CHECK-NEXT: %[[ADDR:.*]] = llvm.getelementptr %arg0[%[[OFF]]]
+// CHECK-NEXT: return %[[ADDR]]
+func.func @ArrayRefSlice(%arg0: !arc.arrayref<4xi32>, %lowIdx: index) -> !arc.arrayref<2xi32> {
+  %0 = arc.arrayref.slice %arg0[%lowIdx] : (!arc.arrayref<4xi32>) -> !arc.arrayref<2xi32>
+  return %0 : !arc.arrayref<2xi32>
+}
+
+// CHECK-LABEL: @ArrayRefCopy
+// CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
+// CHECK-NEXT: "llvm.intr.memcpy"(%arg0, %arg1, %[[C8]])
+// CHECK-NEXT: return %arg0
+func.func @ArrayRefCopy(%arg0: !arc.arrayref<2xi32>, %arg1: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32> {
+  %0 = arc.arrayref.copy %arg0 = %arg1 : !arc.arrayref<2xi32>
+  return %0 : !arc.arrayref<2xi32>
+}

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -138,15 +138,26 @@ func.func @ArrayRefCopy(%arg0: !arc.arrayref<2xi32>, %arg1: !arc.arrayref<2xi32>
 }
 
 // CHECK-LABEL: @ArrayRefToArray
-// CHECK-NEXT: %[[LOAD:.*]] = llvm.load %arg0 : !llvm.ptr -> !llvm.array<2 x i32>
-// CHECK-NEXT: return %[[LOAD]]
+// CHECK-NEXT: %[[UNDEF:.*]] = llvm.mlir.undef : !llvm.array<2 x i32>
+// CHECK-NEXT: %[[GEP0:.*]] = llvm.getelementptr %arg0[0] : (!llvm.ptr) -> !llvm.ptr, i8
+// CHECK-NEXT: %[[LOAD0:.*]] = llvm.load %[[GEP0]] : !llvm.ptr -> i32
+// CHECK-NEXT: %[[INS0:.*]] = llvm.insertvalue %[[LOAD0]], %[[UNDEF]][0] : !llvm.array<2 x i32>
+// CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %arg0[4] : (!llvm.ptr) -> !llvm.ptr, i8
+// CHECK-NEXT: %[[LOAD1:.*]] = llvm.load %[[GEP1]] : !llvm.ptr -> i32
+// CHECK-NEXT: %[[INS1:.*]] = llvm.insertvalue %[[LOAD1]], %[[INS0]][1] : !llvm.array<2 x i32>
+// CHECK-NEXT: return %[[INS1]]
 func.func @ArrayRefToArray(%arg0: !arc.arrayref<2xi32>) -> !hw.array<2xi32> {
   %0 = arc.arrayref.to_array %arg0 : (!arc.arrayref<2xi32>) -> !hw.array<2xi32>
   return %0 : !hw.array<2xi32>
 }
 
 // CHECK-LABEL: @ArrayRefFromArray
-// CHECK-NEXT: llvm.store %arg1, %arg0 : !llvm.array<2 x i32>, !llvm.ptr
+// CHECK-NEXT: %[[GEP0:.*]] = llvm.getelementptr %arg0[0] : (!llvm.ptr) -> !llvm.ptr, i8
+// CHECK-NEXT: %[[VAL0:.*]] = llvm.extractvalue %arg1[0] : !llvm.array<2 x i32>
+// CHECK-NEXT: llvm.store %[[VAL0]], %[[GEP0]] : i32, !llvm.ptr
+// CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %arg0[4] : (!llvm.ptr) -> !llvm.ptr, i8
+// CHECK-NEXT: %[[VAL1:.*]] = llvm.extractvalue %arg1[1] : !llvm.array<2 x i32>
+// CHECK-NEXT: llvm.store %[[VAL1]], %[[GEP1]] : i32, !llvm.ptr
 // CHECK-NEXT: return %arg0
 func.func @ArrayRefFromArray(%arg0: !arc.arrayref<2xi32>, %arg1: !hw.array<2xi32>) -> !arc.arrayref<2xi32> {
   %0 = arc.arrayref.from_array %arg0 = %arg1 : <2xi32>, !hw.array<2xi32>

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -54,7 +54,7 @@ func.func @ArrayRefCreate(%arg0: !arc.arrayref<2xi32>, %arg1: i32, %arg2: i32) -
 // CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8
 // CHECK-NEXT: return %[[A]]
 func.func @ArrayRefAlloc() -> !arc.arrayref<2xi32> {
-  %0 = arc.arrayref.alloc  !arc.arrayref<2xi32>
+  %0 = arc.arrayref.alloc : !arc.arrayref<2xi32>
   return %0 : !arc.arrayref<2xi32>
 }
 
@@ -71,7 +71,7 @@ func.func @ArrayRefAlloc() -> !arc.arrayref<2xi32> {
 // CHECK-NEXT: llvm.store %[[V456]], %[[GEP1]]
 // CHECK-NEXT: return %[[A]]
 func.func @ArrayRefInit() -> !arc.arrayref<2xi32> {
-  %0 = arc.arrayref.alloc init [123 : i32, 456 : i32] !arc.arrayref<2xi32>
+  %0 = arc.arrayref.alloc init([123, 456]) : !arc.arrayref<2xi32>
   return %0 : !arc.arrayref<2xi32>
 }
 
@@ -82,7 +82,7 @@ func.func @ArrayRefInit() -> !arc.arrayref<2xi32> {
 // CHECK-NEXT: "llvm.intr.memset"(%[[A]], %[[ZERO]], %[[C8]])
 // CHECK-NEXT: return %[[A]]
 func.func @ArrayRefInitZero() -> !arc.arrayref<2xi32> {
-  %0 = arc.arrayref.alloc init [0 : i32, 0 : i32] !arc.arrayref<2xi32>
+  %0 = arc.arrayref.alloc init([0, 0]) : !arc.arrayref<2xi32>
   return %0 : !arc.arrayref<2xi32>
 }
 

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -89,7 +89,7 @@ func.func @ArrayRefInitZero() -> !arc.arrayref<2xi32> {
 // CHECK-LABEL: @ArrayRefGet
 // CHECK-NEXT: %[[STRIDE:.*]] = llvm.mlir.constant(4 : i64)
 // CHECK-NEXT: %[[OFF:.*]] = llvm.mul %arg1, %[[STRIDE]]
-// CHECK-NEXT: %[[TOTAL:.*]] = llvm.mlir.constant(16 : i64)
+// CHECK-NEXT: %[[TOTAL:.*]] = llvm.mlir.constant(12 : i64)
 // CHECK-NEXT: %[[CLAMPED:.*]] = llvm.intr.umin(%[[OFF]], %[[TOTAL]])
 // CHECK-NEXT: %[[ADDR:.*]] = llvm.getelementptr %arg0[%[[CLAMPED]]]
 // CHECK-NEXT: %[[VAL:.*]] = llvm.load %[[ADDR]]
@@ -130,7 +130,7 @@ func.func @ArrayRefSlice(%arg0: !arc.arrayref<4xi32>, %lowIdx: index) -> !arc.ar
 
 // CHECK-LABEL: @ArrayRefCopy
 // CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
-// CHECK-NEXT: "llvm.intr.memcpy"(%arg0, %arg1, %[[C8]])
+// CHECK-NEXT: "llvm.intr.memmove"(%arg0, %arg1, %[[C8]])
 // CHECK-NEXT: return %arg0
 func.func @ArrayRefCopy(%arg0: !arc.arrayref<2xi32>, %arg1: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32> {
   %0 = arc.arrayref.copy %arg0 = %arg1 : !arc.arrayref<2xi32>
@@ -138,7 +138,7 @@ func.func @ArrayRefCopy(%arg0: !arc.arrayref<2xi32>, %arg1: !arc.arrayref<2xi32>
 }
 
 // CHECK-LABEL: @ArrayRefToArray
-// CHECK-NEXT: %[[UNDEF:.*]] = llvm.mlir.undef : !llvm.array<2 x i32>
+// CHECK-NEXT: %[[UNDEF:.*]] = llvm.mlir.poison : !llvm.array<2 x i32>
 // CHECK-NEXT: %[[GEP0:.*]] = llvm.getelementptr %arg0[0] : (!llvm.ptr) -> !llvm.ptr, i8
 // CHECK-NEXT: %[[LOAD0:.*]] = llvm.load %[[GEP0]] : !llvm.ptr -> i32
 // CHECK-NEXT: %[[INS0:.*]] = llvm.insertvalue %[[LOAD0]], %[[UNDEF]][0] : !llvm.array<2 x i32>

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -51,7 +51,7 @@ func.func @ArrayRefCreate(%arg0: !arc.arrayref<2xi32>, %arg1: i32, %arg2: i32) -
 
 // CHECK-LABEL: @ArrayRefAlloc
 // CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
-// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8
+// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8 {alignment = 4 : i64}
 // CHECK-NEXT: return %[[A]]
 func.func @ArrayRefAlloc() -> !arc.arrayref<2xi32> {
   %0 = arc.arrayref.alloc : !arc.arrayref<2xi32>
@@ -60,7 +60,7 @@ func.func @ArrayRefAlloc() -> !arc.arrayref<2xi32> {
 
 // CHECK-LABEL: @ArrayRefInit
 // CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
-// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8
+// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8 {alignment = 4 : i64}
 // CHECK-NEXT: %[[C4:.*]] = llvm.mlir.constant(4 : i64)
 // CHECK-NEXT: %[[GEP0:.*]] = llvm.getelementptr %[[A]][%[[C4]]]
 // CHECK-NEXT: %[[V123:.*]] = llvm.mlir.constant(123 : i32)
@@ -71,25 +71,27 @@ func.func @ArrayRefAlloc() -> !arc.arrayref<2xi32> {
 // CHECK-NEXT: llvm.store %[[V456]], %[[GEP1]]
 // CHECK-NEXT: return %[[A]]
 func.func @ArrayRefInit() -> !arc.arrayref<2xi32> {
-  %0 = arc.arrayref.alloc init([123, 456]) : !arc.arrayref<2xi32>
+  %0 = arc.arrayref.alloc init([123 : i32, 456 : i32]) : !arc.arrayref<2xi32>
   return %0 : !arc.arrayref<2xi32>
 }
 
 // CHECK-LABEL: @ArrayRefInitZero
 // CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
-// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8
+// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8 {alignment = 4 : i64}
 // CHECK-NEXT: %[[ZERO:.*]] = llvm.mlir.constant(0 : i8)
 // CHECK-NEXT: "llvm.intr.memset"(%[[A]], %[[ZERO]], %[[C8]])
 // CHECK-NEXT: return %[[A]]
 func.func @ArrayRefInitZero() -> !arc.arrayref<2xi32> {
-  %0 = arc.arrayref.alloc init([0, 0]) : !arc.arrayref<2xi32>
+  %0 = arc.arrayref.alloc init([0 : i32, 0 : i32]) : !arc.arrayref<2xi32>
   return %0 : !arc.arrayref<2xi32>
 }
 
 // CHECK-LABEL: @ArrayRefGet
 // CHECK-NEXT: %[[STRIDE:.*]] = llvm.mlir.constant(4 : i64)
 // CHECK-NEXT: %[[OFF:.*]] = llvm.mul %arg1, %[[STRIDE]]
-// CHECK-NEXT: %[[ADDR:.*]] = llvm.getelementptr %arg0[%[[OFF]]]
+// CHECK-NEXT: %[[TOTAL:.*]] = llvm.mlir.constant(16 : i64)
+// CHECK-NEXT: %[[CLAMPED:.*]] = llvm.intr.umin(%[[OFF]], %[[TOTAL]])
+// CHECK-NEXT: %[[ADDR:.*]] = llvm.getelementptr %arg0[%[[CLAMPED]]]
 // CHECK-NEXT: %[[VAL:.*]] = llvm.load %[[ADDR]]
 // CHECK-NEXT: return %[[VAL]]
 func.func @ArrayRefGet(%arg0: !arc.arrayref<4xi32>, %idx: index) -> i32 {
@@ -100,8 +102,14 @@ func.func @ArrayRefGet(%arg0: !arc.arrayref<4xi32>, %idx: index) -> i32 {
 // CHECK-LABEL: @ArrayRefInject
 // CHECK-NEXT: %[[STRIDE:.*]] = llvm.mlir.constant(4 : i64)
 // CHECK-NEXT: %[[OFF:.*]] = llvm.mul %arg1, %[[STRIDE]]
+// CHECK-NEXT: %[[TOTAL:.*]] = llvm.mlir.constant(16 : i64)
+// CHECK-NEXT: %[[INBOUNDS:.*]] = llvm.icmp "ult" %[[OFF]], %[[TOTAL]]
+// CHECK-NEXT: llvm.cond_br %[[INBOUNDS]], ^[[BB1:.*]], ^[[BB2:.*]]
+// CHECK-NEXT: ^[[BB1]]:
 // CHECK-NEXT: %[[ADDR:.*]] = llvm.getelementptr %arg0[%[[OFF]]]
 // CHECK-NEXT: llvm.store %arg2, %[[ADDR]]
+// CHECK-NEXT: llvm.br ^[[BB2]]
+// CHECK-NEXT: ^[[BB2]]:
 // CHECK-NEXT: return %arg0
 func.func @ArrayRefInject(%arg0: !arc.arrayref<4xi32>, %idx: index, %val: i32) -> !arc.arrayref<4xi32> {
   %0 = arc.arrayref.inject %arg0[%idx], %val : !arc.arrayref<4xi32>, i32 -> !arc.arrayref<4xi32>
@@ -109,8 +117,10 @@ func.func @ArrayRefInject(%arg0: !arc.arrayref<4xi32>, %idx: index, %val: i32) -
 }
 
 // CHECK-LABEL: @ArrayRefSlice
+// CHECK-NEXT: %[[MAX:.*]] = llvm.mlir.constant(2 : i64)
+// CHECK-NEXT: %[[CLAMPED:.*]] = llvm.intr.umin(%arg1, %[[MAX]])
 // CHECK-NEXT: %[[STRIDE:.*]] = llvm.mlir.constant(4 : i64)
-// CHECK-NEXT: %[[OFF:.*]] = llvm.mul %arg1, %[[STRIDE]]
+// CHECK-NEXT: %[[OFF:.*]] = llvm.mul %[[CLAMPED]], %[[STRIDE]]
 // CHECK-NEXT: %[[ADDR:.*]] = llvm.getelementptr %arg0[%[[OFF]]]
 // CHECK-NEXT: return %[[ADDR]]
 func.func @ArrayRefSlice(%arg0: !arc.arrayref<4xi32>, %lowIdx: index) -> !arc.arrayref<2xi32> {

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -126,3 +126,20 @@ func.func @ArrayRefCopy(%arg0: !arc.arrayref<2xi32>, %arg1: !arc.arrayref<2xi32>
   %0 = arc.arrayref.copy %arg0 = %arg1 : !arc.arrayref<2xi32>
   return %0 : !arc.arrayref<2xi32>
 }
+
+// CHECK-LABEL: @ArrayRefToArray
+// CHECK-NEXT: %[[LOAD:.*]] = llvm.load %arg0 : !llvm.ptr -> !llvm.array<2 x i32>
+// CHECK-NEXT: return %[[LOAD]]
+func.func @ArrayRefToArray(%arg0: !arc.arrayref<2xi32>) -> !hw.array<2xi32> {
+  %0 = arc.arrayref.to_array %arg0 : (!arc.arrayref<2xi32>) -> !hw.array<2xi32>
+  return %0 : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: @ArrayRefFromArray
+// CHECK-NEXT: llvm.store %arg1, %arg0 : !llvm.array<2 x i32>, !llvm.ptr
+// CHECK-NEXT: return %arg0
+func.func @ArrayRefFromArray(%arg0: !arc.arrayref<2xi32>, %arg1: !hw.array<2xi32>) -> !arc.arrayref<2xi32> {
+  %0 = arc.arrayref.from_array %arg0 = %arg1 : <2xi32>, !hw.array<2xi32>
+  return %0 : !arc.arrayref<2xi32>
+}
+

--- a/test/Dialect/Arc/lower-arrays.mlir
+++ b/test/Dialect/Arc/lower-arrays.mlir
@@ -1,0 +1,134 @@
+// RUN: circt-opt %s -arc-lower-arrays -o - | FileCheck %s
+
+// CHECK-LABEL: @test_func_arg
+// CHECK-SAME: %arg0: !arc.arrayref<2xi32>
+func.func @test_func_arg(%a: !hw.array<2xi32>, %b: i32) -> i32 {
+  return %b : i32
+}
+
+// CHECK-LABEL: @test_func_result
+// CHECK-SAME: %arg0: !arc.arrayref<2xi32>, %arg1: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32>
+// CHECK: %[[R:.*]] = arc.arrayref.copy %arg0 = %arg1
+// CHECK-NEXT: return %[[R]]
+func.func @test_func_result(%a: !hw.array<2xi32>) -> !hw.array<2xi32> {
+  return %a : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_func_call
+// CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[CALL:.*]] = call @test_func_result(%[[ARG0]], %[[ARG1]]) : (!arc.arrayref<2xi32>, !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: return %[[CALL]] : !arc.arrayref<2xi32>
+func.func @test_func_call(%a: !hw.array<2xi32>) -> !hw.array<2xi32> {
+  %0 = func.call @test_func_result(%a) : (!hw.array<2xi32>) -> !hw.array<2xi32>
+  return %0 : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_aggregate_constant
+// CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc init [0 : i32, 1 : i32] <2xi32>
+// CHECK-NEXT: %[[COPY:.*]] = arc.arrayref.copy %[[ARG0]] = %[[ALLOC]] : <2xi32>
+// CHECK-NEXT: return %[[COPY]] : !arc.arrayref<2xi32>
+func.func @test_aggregate_constant() -> !hw.array<2xi32> {
+  %0 = hw.aggregate_constant [0 : i32, 1 : i32] : !hw.array<2xi32>
+  return %0 : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_array_get
+// CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: i1) -> i32
+// CHECK-NEXT: %[[IDX:.*]] = arith.index_castui %[[ARG1]] : i1 to index
+// CHECK-NEXT: %[[GET:.*]] = arc.arrayref.get %[[ARG0]][%[[IDX]]] : <2xi32> -> i32
+// CHECK-NEXT: return %[[GET]] : i32
+func.func @test_array_get(%a: !hw.array<2xi32>, %b: i1) -> i32 {
+  %0 = hw.array_get %a[%b] : !hw.array<2xi32>, i1
+  return %0 : i32
+}
+
+// CHECK-LABEL: func.func @test_array_inject
+// CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: !arc.arrayref<2xi32>, %[[ARG2:.*]]: i1, %[[ARG3:.*]]: i32) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[IDX:.*]] = arith.index_castui %[[ARG2]] : i1 to index
+// CHECK-NEXT: %[[COPY:.*]] = arc.arrayref.copy %[[ARG0]] = %[[ARG1]] : <2xi32>
+// CHECK-NEXT: %[[INJ:.*]] = arc.arrayref.inject %[[COPY]][%[[IDX]]], %[[ARG3]] : <2xi32>, i32 -> <2xi32>
+// CHECK-NEXT: return %[[INJ]] : !arc.arrayref<2xi32>
+func.func @test_array_inject(%a: !hw.array<2xi32>, %b: i1, %c: i32) -> !hw.array<2xi32> {
+  %0 = hw.array_inject %a[%b], %c : !hw.array<2xi32>, i1
+  return %0 : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_array_slice
+// CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: !arc.arrayref<4xi32>, %[[ARG2:.*]]: i2) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc <4xi32>
+// CHECK-NEXT: %[[COPY1:.*]] = arc.arrayref.copy %[[ALLOC]] = %[[ARG1]] : <4xi32>
+// CHECK-NEXT: %[[IDX:.*]] = arith.index_castui %[[ARG2]] : i2 to index
+// CHECK-NEXT: %[[SLICE:.*]] = arc.arrayref.slice %[[COPY1]][%[[IDX]]] : (!arc.arrayref<4xi32>) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[COPY2:.*]] = arc.arrayref.copy %[[ARG0]] = %[[SLICE]] : <2xi32>
+// CHECK-NEXT: return %[[COPY2]] : !arc.arrayref<2xi32>
+func.func @test_array_slice(%a: !hw.array<4xi32>, %b: i2) -> !hw.array<2xi32> {
+  %0 = hw.array_slice %a[%b] : (!hw.array<4xi32>) -> !hw.array<2xi32>
+  return %0 : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_array_concat
+// CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<4xi32>, %[[ARG1:.*]]: !arc.arrayref<2xi32>, %[[ARG2:.*]]: !arc.arrayref<2xi32>) -> !arc.arrayref<4xi32>
+// CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C2:.*]] = arith.constant 2 : index
+// CHECK-NEXT: %[[S2:.*]] = arc.arrayref.slice %[[ARG0]][%[[C2]]] : (!arc.arrayref<4xi32>) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: arc.arrayref.copy %[[S2]] = %[[ARG1]] : <2xi32>
+// CHECK-NEXT: %[[S0:.*]] = arc.arrayref.slice %[[ARG0]][%[[C0]]] : (!arc.arrayref<4xi32>) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: arc.arrayref.copy %[[S0]] = %[[ARG2]] : <2xi32>
+// CHECK-NEXT: return %[[ARG0]] : !arc.arrayref<4xi32>
+func.func @test_array_concat(%a: !hw.array<2xi32>, %b: !hw.array<2xi32>) -> !hw.array<4xi32> {
+  %0 = hw.array_concat %a, %b : !hw.array<2xi32>, !hw.array<2xi32>
+  return %0 : !hw.array<4xi32>
+}
+
+// CHECK-LABEL: func.func @test_array_create
+// CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: i32, %[[ARG2:.*]]: i32) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc <2xi32>
+// CHECK-NEXT: %[[CREATE:.*]] = arc.arrayref.create %[[ALLOC]] = %[[ARG1]], %[[ARG2]] : <2xi32>
+// CHECK-NEXT: %[[COPY:.*]] = arc.arrayref.copy %[[ARG0]] = %[[CREATE]] : <2xi32>
+// CHECK-NEXT: return %[[COPY]] : !arc.arrayref<2xi32>
+func.func @test_array_create(%a: i32, %b: i32) -> !hw.array<2xi32> {
+  %0 = hw.array_create %a, %b : i32
+  return %0 : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_storage_get
+// CHECK-SAME: -> !arc.state<!arc.arrayref<2xi32>>
+// CHECK-NEXT: %0 = arc.storage.get %arg0[0] : !arc.storage<8> -> !arc.state<!arc.arrayref<2xi32>>
+// CHECK-NEXT: return %0 : !arc.state<!arc.arrayref<2xi32>>
+func.func @test_storage_get(%a: !arc.storage<8>) -> !arc.state<!hw.array<2xi32>> {
+  %0 = arc.storage.get %a[0] : !arc.storage<8> -> !arc.state<!hw.array<2xi32>>
+  return %0 : !arc.state<!hw.array<2xi32>>
+}
+
+// CHECK-LABEL: func.func @test_mux
+// CHECK-NEXT: %[[S:.*]] = arith.select %arg3, %arg1, %arg2 : !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[R:.*]] = arc.arrayref.copy %arg0 = %[[S]]
+// CHECK-NEXT: return %[[R]]
+func.func @test_mux(%a: !hw.array<2xi32>, %b: !hw.array<2xi32>, %c: i1) -> !hw.array<2xi32> {
+  %r = comb.mux %c, %a, %b : !hw.array<2xi32>
+  return %r : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_alloc_state
+// CHECK: arc.alloc_state %arg0 : (!arc.storage<8>) -> !arc.state<!arc.arrayref<2xi32>>
+func.func @test_alloc_state(%arg0: !arc.storage<8>) -> !arc.state<!hw.array<2xi32>> {
+  %0 = arc.alloc_state %arg0 : (!arc.storage<8>) -> !arc.state<!hw.array<2xi32>>
+  return %0 : !arc.state<!hw.array<2xi32>>
+}
+
+// CHECK-LABEL: func.func @test_state_read
+// CHECK: %[[X:.*]] = arc.state_read %arg1 : <!arc.arrayref<2xi32>>
+// CHECK: %[[R:.*]] = arc.arrayref.copy %arg0 = %[[X]] : <2xi32>
+// CHECK: return %[[R]]
+func.func @test_state_read(%arg0: !arc.state<!hw.array<2xi32>>) -> !hw.array<2xi32> {
+  %0 = arc.state_read %arg0 : <!hw.array<2xi32>>
+  return %0 : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_state_write
+// CHECK: arc.state_write %arg0 = %arg1 : <!arc.arrayref<2xi32>>
+func.func @test_state_write(%arg0: !arc.state<!hw.array<2xi32>>, %arg1: !hw.array<2xi32>) {
+  arc.state_write %arg0 = %arg1 : <!hw.array<2xi32>>
+  return
+}

--- a/test/Dialect/Arc/lower-arrays.mlir
+++ b/test/Dialect/Arc/lower-arrays.mlir
@@ -25,7 +25,7 @@ func.func @test_func_call(%a: !hw.array<2xi32>) -> !hw.array<2xi32> {
 
 // CHECK-LABEL: func.func @test_aggregate_constant
 // CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32>
-// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc init [0 : i32, 1 : i32] <2xi32>
+// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc init([0, 1]) : <2xi32>
 // CHECK-NEXT: %[[COPY:.*]] = arc.arrayref.copy %[[ARG0]] = %[[ALLOC]] : <2xi32>
 // CHECK-NEXT: return %[[COPY]] : !arc.arrayref<2xi32>
 func.func @test_aggregate_constant() -> !hw.array<2xi32> {
@@ -56,7 +56,7 @@ func.func @test_array_inject(%a: !hw.array<2xi32>, %b: i1, %c: i32) -> !hw.array
 
 // CHECK-LABEL: func.func @test_array_slice
 // CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: !arc.arrayref<4xi32>, %[[ARG2:.*]]: i2) -> !arc.arrayref<2xi32>
-// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc <4xi32>
+// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc : <4xi32>
 // CHECK-NEXT: %[[COPY1:.*]] = arc.arrayref.copy %[[ALLOC]] = %[[ARG1]] : <4xi32>
 // CHECK-NEXT: %[[IDX:.*]] = arith.index_castui %[[ARG2]] : i2 to index
 // CHECK-NEXT: %[[SLICE:.*]] = arc.arrayref.slice %[[COPY1]][%[[IDX]]] : (!arc.arrayref<4xi32>) -> !arc.arrayref<2xi32>
@@ -83,7 +83,7 @@ func.func @test_array_concat(%a: !hw.array<2xi32>, %b: !hw.array<2xi32>) -> !hw.
 
 // CHECK-LABEL: func.func @test_array_create
 // CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: i32, %[[ARG2:.*]]: i32) -> !arc.arrayref<2xi32>
-// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc <2xi32>
+// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc : <2xi32>
 // CHECK-NEXT: %[[CREATE:.*]] = arc.arrayref.create %[[ALLOC]] = %[[ARG1]], %[[ARG2]] : <2xi32>
 // CHECK-NEXT: %[[COPY:.*]] = arc.arrayref.copy %[[ARG0]] = %[[CREATE]] : <2xi32>
 // CHECK-NEXT: return %[[COPY]] : !arc.arrayref<2xi32>

--- a/test/Dialect/Arc/lower-arrays.mlir
+++ b/test/Dialect/Arc/lower-arrays.mlir
@@ -132,3 +132,43 @@ func.func @test_state_write(%arg0: !arc.state<!hw.array<2xi32>>, %arg1: !hw.arra
   arc.state_write %arg0 = %arg1 : <!hw.array<2xi32>>
   return
 }
+
+// CHECK-LABEL: func.func @test_nested_array_arg
+// CHECK-SAME: (%arg0: !hw.array<3xarray<2xi32>>)
+// CHECK-SAME: -> !hw.array<3xarray<2xi32>>
+// CHECK-NEXT: return
+func.func @test_nested_array_arg(%a: !hw.array<3x!hw.array<2xi32>>) -> !hw.array<3x!hw.array<2xi32>> {
+  return %a : !hw.array<3x!hw.array<2xi32>>
+}
+
+// CHECK-LABEL: func.func @test_nested_array_get
+// CHECK-SAME: (%[[SRET:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: !hw.array<3xarray<2xi32>>, %[[ARG2:.*]]: i2) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[GET:.*]] = hw.array_get %[[ARG1]][%[[ARG2]]] : !hw.array<3xarray<2xi32>>, i2
+// CHECK-NEXT: %[[FROM:.*]] = arc.arrayref.from_array %[[SRET]] = %[[GET]] : <2xi32>, !hw.array<2xi32>
+// CHECK-NEXT: return %[[FROM]] : !arc.arrayref<2xi32>
+func.func @test_nested_array_get(%a: !hw.array<3x!hw.array<2xi32>>, %b: i2) -> !hw.array<2xi32> {
+  %0 = hw.array_get %a[%b] : !hw.array<3x!hw.array<2xi32>>, i2
+  return %0 : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: func.func @test_nested_array_create
+// CHECK-SAME: (%[[ARG0:.*]]: !hw.array<3xarray<2xi32>>, %[[ARG1:.*]]: !arc.arrayref<2xi32>, %[[ARG2:.*]]: !arc.arrayref<2xi32>, %[[ARG3:.*]]: !arc.arrayref<2xi32>) -> !hw.array<3xarray<2xi32>>
+// CHECK-NEXT: %[[TO0:.*]] = arc.arrayref.to_array %[[ARG3]] : (!arc.arrayref<2xi32>) -> !hw.array<2xi32>
+// CHECK-NEXT: %[[TO1:.*]] = arc.arrayref.to_array %[[ARG2]] : (!arc.arrayref<2xi32>) -> !hw.array<2xi32>
+// CHECK-NEXT: %[[TO2:.*]] = arc.arrayref.to_array %[[ARG1]] : (!arc.arrayref<2xi32>) -> !hw.array<2xi32>
+// CHECK-NEXT: %[[CREATE:.*]] = hw.array_create %[[TO2]], %[[TO1]], %[[TO0]] : !hw.array<2xi32>
+// CHECK-NEXT: return %[[CREATE]] : !hw.array<3xarray<2xi32>>
+func.func @test_nested_array_create(%a: !hw.array<2xi32>, %b: !hw.array<2xi32>, %c: !hw.array<2xi32>) -> !hw.array<3x!hw.array<2xi32>> {
+  %0 = hw.array_create %a, %b, %c : !hw.array<2xi32>
+  return %0 : !hw.array<3x!hw.array<2xi32>>
+}
+
+// CHECK-LABEL: func.func @test_nested_array_inject
+// CHECK-SAME: (%[[ARG0:.*]]: !hw.array<3xarray<2xi32>>, %[[ARG1:.*]]: !hw.array<3xarray<2xi32>>, %[[ARG2:.*]]: i2, %[[ARG3:.*]]: !arc.arrayref<2xi32>) -> !hw.array<3xarray<2xi32>>
+// CHECK-NEXT: %[[TO:.*]] = arc.arrayref.to_array %[[ARG3]] : (!arc.arrayref<2xi32>) -> !hw.array<2xi32>
+// CHECK-NEXT: %[[INJ:.*]] = hw.array_inject %[[ARG1]][%[[ARG2]]], %[[TO]] : !hw.array<3xarray<2xi32>>, i2
+// CHECK-NEXT: return %[[INJ]] : !hw.array<3xarray<2xi32>>
+func.func @test_nested_array_inject(%a: !hw.array<3x!hw.array<2xi32>>, %b: i2, %c: !hw.array<2xi32>) -> !hw.array<3x!hw.array<2xi32>> {
+  %0 = hw.array_inject %a[%b], %c : !hw.array<3x!hw.array<2xi32>>, i2
+  return %0 : !hw.array<3x!hw.array<2xi32>>
+}

--- a/test/Dialect/Arc/lower-arrays.mlir
+++ b/test/Dialect/Arc/lower-arrays.mlir
@@ -25,7 +25,7 @@ func.func @test_func_call(%a: !hw.array<2xi32>) -> !hw.array<2xi32> {
 
 // CHECK-LABEL: func.func @test_aggregate_constant
 // CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32>
-// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc init([0, 1]) : <2xi32>
+// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc init([0 : i32, 1 : i32]) : <2xi32>
 // CHECK-NEXT: %[[COPY:.*]] = arc.arrayref.copy %[[ARG0]] = %[[ALLOC]] : <2xi32>
 // CHECK-NEXT: return %[[COPY]] : !arc.arrayref<2xi32>
 func.func @test_aggregate_constant() -> !hw.array<2xi32> {
@@ -56,12 +56,10 @@ func.func @test_array_inject(%a: !hw.array<2xi32>, %b: i1, %c: i32) -> !hw.array
 
 // CHECK-LABEL: func.func @test_array_slice
 // CHECK-SAME: (%[[ARG0:.*]]: !arc.arrayref<2xi32>, %[[ARG1:.*]]: !arc.arrayref<4xi32>, %[[ARG2:.*]]: i2) -> !arc.arrayref<2xi32>
-// CHECK-NEXT: %[[ALLOC:.*]] = arc.arrayref.alloc : <4xi32>
-// CHECK-NEXT: %[[COPY1:.*]] = arc.arrayref.copy %[[ALLOC]] = %[[ARG1]] : <4xi32>
 // CHECK-NEXT: %[[IDX:.*]] = arith.index_castui %[[ARG2]] : i2 to index
-// CHECK-NEXT: %[[SLICE:.*]] = arc.arrayref.slice %[[COPY1]][%[[IDX]]] : (!arc.arrayref<4xi32>) -> !arc.arrayref<2xi32>
-// CHECK-NEXT: %[[COPY2:.*]] = arc.arrayref.copy %[[ARG0]] = %[[SLICE]] : <2xi32>
-// CHECK-NEXT: return %[[COPY2]] : !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[SLICE:.*]] = arc.arrayref.slice %[[ARG1]][%[[IDX]]] : (!arc.arrayref<4xi32>) -> !arc.arrayref<2xi32>
+// CHECK-NEXT: %[[COPY:.*]] = arc.arrayref.copy %[[ARG0]] = %[[SLICE]] : <2xi32>
+// CHECK-NEXT: return %[[COPY]] : !arc.arrayref<2xi32>
 func.func @test_array_slice(%a: !hw.array<4xi32>, %b: i2) -> !hw.array<2xi32> {
   %0 = hw.array_slice %a[%b] : (!hw.array<4xi32>) -> !hw.array<2xi32>
   return %0 : !hw.array<2xi32>


### PR DESCRIPTION
Previously, !hw.array types were lowered directly to !llvm.array types. This
is the obvious lowering, but unfortunately it produces very poor code and can
in some cases bog down LLVM quadratically.

LLVM's ArrayType is aggressively SROA'd - it is really assumed to be more like
a tuple-type - so no matter how we try to avoid it (e.g. HWSpillCache), LLVM
will expand each array into individual scalars. This creates a large number of
instructions, but worse - it creates very difficult scheduling problems with
high connectivity. LLVM's pre-regalloc scheduler has been seen to take hours
on a problem that should be fairly simple.

This PR fixes this issue by introducing an !arc.arrayref<T> type. This mirrors
!hw.array<T>, except that it has buffer semantics rather than value semantics.
That is, !arc.arrayref is to memref as !hw.array is to tensor.

I did heavily look into using the exising bufferization passes in MLIR, but
these are (a) quite hard to use, and (b) heavily tailored to the "tensor" and
"memref" types.

In the end it felt like much less complexity to implement our own barebones
bufferizer.

Each !hw.array op is translatable to an !arrayref op, except that the arrayref
versions take a destination buffer to modify as an operand. They are mostly in
destination passing style.

The translation to LLVMIR dialect is trivial (!arrayref -> !llvm.ptr).

There are other optimizations we can do to reduce the compile time (and runtime)
of array-heavy code but they are left for further PRs:

  * Aggressive reduction of arc.arrayref.alloc ops (better bufferization).
  * Optimization of hw.array_creates where array permutations/shuffles have been
    expanded.
  * Proper handling of nested arrays.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
