### PR TITLE
[arc][LowerToLLVM] Handle i0 types more rigorously

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -366,6 +366,15 @@ def StripSV : Pass<"arc-strip-sv", "mlir::ModuleOp"> {
   ];
 }
 
+def RemoveI0Types : Pass<"arc-remove-i0-types", "mlir::ModuleOp"> {
+  let summary = "Remove i0 types completely";
+  let description = [{
+    i0 types are tautologous and usually exist due to array<1xT> types. i0 is
+    not valid in LLVM-IR, so we transform array<1xT> -> T and ban i0 types.
+  }];
+  let dependentDialects = ["arc::ArcDialect", "hw::HWDialect"];
+}
+
 def ResolveXMRRef : Pass<"arc-resolve-xmr", "mlir::ModuleOp"> {
   let summary = "Resolve sv.xmr.ref into direct signal references";
   let description = [{

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1381,6 +1381,21 @@ void LowerArcToLLVMPass::runOnOperation() {
     return IntegerType::get(type.getContext(), 64);
   });
 
+  // i0 is not legal in LLVM-IR. Most i0 should have been removed already,
+  // but if any manage to slip through (e.g. in function signatures), we'll turn
+  // them into i1 for now.
+  converter.addConversion([&](IntegerType type) -> Type {
+    if (type.getWidth() == 0)
+      return IntegerType::get(type.getContext(), 1);
+    return type;
+  });
+  converter.addSourceMaterialization(
+      [](OpBuilder &b, IntegerType type, ValueRange, Location loc) -> Value {
+        if (type.getWidth() != 0)
+          return nullptr;
+        return hw::ConstantOp::create(b, loc, APInt::getZero(0));
+      });
+
   // Setup the conversion patterns.
   ConversionPatternSet patterns(&getContext(), converter);
 

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1311,29 +1311,6 @@ struct LowerArcToLLVMPass
 } // namespace
 
 void LowerArcToLLVMPass::runOnOperation() {
-  // Replace any `i0` values with an `hw.constant 0 : i0` to avoid later issues
-  // in LLVM conversion.
-  {
-    DenseMap<Region *, hw::ConstantOp> zeros;
-    getOperation().walk([&](Operation *op) {
-      if (op->hasTrait<OpTrait::ConstantLike>())
-        return;
-      for (auto result : op->getResults()) {
-        auto type = dyn_cast<IntegerType>(result.getType());
-        if (!type || type.getWidth() != 0)
-          continue;
-        auto *region = op->getParentRegion();
-        auto &zero = zeros[region];
-        if (!zero) {
-          auto builder = OpBuilder::atBlockBegin(&region->front());
-          zero = hw::ConstantOp::create(builder, result.getLoc(),
-                                        APInt::getZero(0));
-        }
-        result.replaceAllUsesWith(zero);
-      }
-    });
-  }
-
   // Collect the symbols in the root op such that the HW-to-LLVM lowering can
   // create LLVM globals with non-colliding names.
   Namespace globals;

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1381,21 +1381,6 @@ void LowerArcToLLVMPass::runOnOperation() {
     return IntegerType::get(type.getContext(), 64);
   });
 
-  // i0 is not legal in LLVM-IR. Most i0 should have been removed already,
-  // but if any manage to slip through (e.g. in function signatures), we'll turn
-  // them into i1 for now.
-  converter.addConversion([&](IntegerType type) -> Type {
-    if (type.getWidth() == 0)
-      return IntegerType::get(type.getContext(), 1);
-    return type;
-  });
-  converter.addSourceMaterialization(
-      [](OpBuilder &b, IntegerType type, ValueRange, Location loc) -> Value {
-        if (type.getWidth() != 0)
-          return nullptr;
-        return hw::ConstantOp::create(b, loc, APInt::getZero(0));
-      });
-
   // Setup the conversion patterns.
   ConversionPatternSet patterns(&getContext(), converter);
 

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -294,7 +294,7 @@ struct ArrayInjectOpConversion
     auto oneC =
         LLVM::ConstantOp::create(rewriter, op->getLoc(), rewriter.getI32Type(),
                                  rewriter.getI32IntegerAttr(1));
-    auto zextIndex = zextByOne(op->getLoc(), rewriter, op.getIndex());
+    auto zextIndex = zextByOne(op->getLoc(), rewriter, adaptor.getIndex());
 
     if (arrElems == 1 || !llvm::isPowerOf2_64(arrElems)) {
       // Clamp index to prevent OOB access. We add an extra element to the
@@ -353,7 +353,7 @@ struct ArrayGetOpConversion : public HWArrayOpToLLVMPattern<hw::ArrayGetOp> {
 
     auto arrTy = typeConverter->convertType(op.getInput().getType());
     auto elemTy = typeConverter->convertType(op.getResult().getType());
-    auto zextIndex = zextByOne(op->getLoc(), rewriter, op.getIndex());
+    auto zextIndex = zextByOne(op->getLoc(), rewriter, adaptor.getIndex());
 
     // During the ongoing migration to opaque types, use the constructor that
     // accepts an element type when the array pointer type is opaque, and
@@ -389,7 +389,7 @@ struct ArraySliceOpConversion
     if (!arrPtr)
       arrPtr = spillValueOnStack(rewriter, op.getLoc(), adaptor.getInput());
 
-    auto zextIndex = zextByOne(op->getLoc(), rewriter, op.getLowIndex());
+    auto zextIndex = zextByOne(op->getLoc(), rewriter, adaptor.getLowIndex());
 
     // During the ongoing migration to opaque types, use the constructor that
     // accepts an element type when the array pointer type is opaque, and
@@ -503,9 +503,15 @@ struct HWConstantOpConversion : public ConvertToLLVMPattern {
     auto constOp = cast<hw::ConstantOp>(op);
     // Get the converted llvm type.
     auto intType = typeConverter->convertType(constOp.getValueAttr().getType());
+
+    Attribute attr = constOp.getValueAttr();
+    if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
+      // Ensure the attribute's type is converted if needed.
+      attr = IntegerAttr::get(intType, intAttr.getValue());
+    }
+
     // Replace the operation with an llvm constant op.
-    rewriter.replaceOpWithNewOp<LLVM::ConstantOp>(op, intType,
-                                                  constOp.getValueAttr());
+    rewriter.replaceOpWithNewOp<LLVM::ConstantOp>(op, intType, attr);
 
     return success();
   }

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -294,7 +294,7 @@ struct ArrayInjectOpConversion
     auto oneC =
         LLVM::ConstantOp::create(rewriter, op->getLoc(), rewriter.getI32Type(),
                                  rewriter.getI32IntegerAttr(1));
-    auto zextIndex = zextByOne(op->getLoc(), rewriter, adaptor.getIndex());
+    auto zextIndex = zextByOne(op->getLoc(), rewriter, op.getIndex());
 
     if (arrElems == 1 || !llvm::isPowerOf2_64(arrElems)) {
       // Clamp index to prevent OOB access. We add an extra element to the
@@ -353,7 +353,7 @@ struct ArrayGetOpConversion : public HWArrayOpToLLVMPattern<hw::ArrayGetOp> {
 
     auto arrTy = typeConverter->convertType(op.getInput().getType());
     auto elemTy = typeConverter->convertType(op.getResult().getType());
-    auto zextIndex = zextByOne(op->getLoc(), rewriter, adaptor.getIndex());
+    auto zextIndex = zextByOne(op->getLoc(), rewriter, op.getIndex());
 
     // During the ongoing migration to opaque types, use the constructor that
     // accepts an element type when the array pointer type is opaque, and
@@ -389,7 +389,7 @@ struct ArraySliceOpConversion
     if (!arrPtr)
       arrPtr = spillValueOnStack(rewriter, op.getLoc(), adaptor.getInput());
 
-    auto zextIndex = zextByOne(op->getLoc(), rewriter, adaptor.getLowIndex());
+    auto zextIndex = zextByOne(op->getLoc(), rewriter, op.getLowIndex());
 
     // During the ongoing migration to opaque types, use the constructor that
     // accepts an element type when the array pointer type is opaque, and
@@ -503,15 +503,9 @@ struct HWConstantOpConversion : public ConvertToLLVMPattern {
     auto constOp = cast<hw::ConstantOp>(op);
     // Get the converted llvm type.
     auto intType = typeConverter->convertType(constOp.getValueAttr().getType());
-
-    Attribute attr = constOp.getValueAttr();
-    if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
-      // Ensure the attribute's type is converted if needed.
-      attr = IntegerAttr::get(intType, intAttr.getValue());
-    }
-
     // Replace the operation with an llvm constant op.
-    rewriter.replaceOpWithNewOp<LLVM::ConstantOp>(op, intType, attr);
+    rewriter.replaceOpWithNewOp<LLVM::ConstantOp>(op, intType,
+                                                  constOp.getValueAttr());
 
     return success();
   }

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -21,6 +21,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   MergeTaps.cpp
   MuxToControlFlow.cpp
   PrintCostModel.cpp
+  RemoveI0Types.cpp
   ResolveXMRRef.cpp
   SimplifyVariadicOps.cpp
   SplitFuncs.cpp

--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -200,6 +200,54 @@ struct HandleGenericOp : public ConversionPattern {
     return success();
   }
 };
+
+struct ConvertAggregateConstant : public OpConversionPattern<hw::AggregateConstantOp> {
+  using OpConversionPattern<hw::AggregateConstantOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(hw::AggregateConstantOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const override {
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+
+    // Recursively rewrite the attribute.
+    Attribute newFields = rewriteArrayAttr(op.getFields(), op.getResult().getType());
+
+    if (!isa<ArrayAttr>(newFields)) {
+      // Scalar result -> becomes hw.constant.
+      IntegerAttr attr = cast<IntegerAttr>(newFields);
+      auto result = hw::ConstantOp::create(rewriter, op.getLoc(), resultType,
+                                           attr);
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    // Composite result -> new aggregate_constant op.
+    auto newOp = hw::AggregateConstantOp::create(rewriter, op.getLoc(), resultType, cast<ArrayAttr>(newFields));
+    rewriter.replaceOp(op, newOp);
+    return success();
+  }
+
+  Attribute rewriteArrayAttr(ArrayAttr array, Type type) const {
+    if (getTypeConverter()->convertType(type) == type)
+      return array;
+    if (auto arrayType = dyn_cast<hw::ArrayType>(type); arrayType && arrayType.getNumElements() == 1) {
+      return *array.begin();
+    }
+
+    // Collect the immediate subtypes. FieldIDTypeInterface is supported by
+    // ArrayType, UnpackedArrayType, StructType, UnionType.
+    auto fieldIdInterface = cast<hw::FieldIDTypeInterface>(type);
+    SmallVector<Attribute> attrs;
+    for (auto [index, attr] : llvm::enumerate(array)) {
+      uint64_t fieldId = fieldIdInterface.getFieldID(index);
+      Type subType = fieldIdInterface.getSubTypeByFieldID(fieldId).first;
+      if (auto subArrayAttr = dyn_cast<ArrayAttr>(attr)) {
+        attrs.push_back(rewriteArrayAttr(subArrayAttr, subType));
+      } else {
+        attrs.push_back(attr);
+      }
+    }
+    return ArrayAttr::get(array.getContext(), attrs);
+  }
+};
 } // namespace
 
 void RemoveI0TypesPass::runOnOperation() {
@@ -254,7 +302,8 @@ void RemoveI0TypesPass::runOnOperation() {
   });
 
   patterns.add<ConvertFunc, ConvertReturn, ConvertCall, ConvertArrayGet,
-               ConvertArrayCreate, ConvertArrayInject, HandleGenericOp>(
+               ConvertArrayCreate, ConvertArrayInject, HandleGenericOp,
+               ConvertAggregateConstant>(
       converter, &getContext());
   if (failed(
           applyFullConversion(getOperation(), target, std::move(patterns)))) {

--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -237,10 +237,8 @@ void RemoveI0TypesPass::runOnOperation() {
 
   // The conversions for types are 1:N, where N may be 1 or 0.
   converter.addConversion([](Type type, SmallVectorImpl<Type> &types) {
-    if (isI0(type))
-      // Do not add any types to `types`.
-      return success();
-    types.push_back(type);
+    if (!isI0(type))
+      types.push_back(type);
     return success();
   });
 
@@ -249,10 +247,8 @@ void RemoveI0TypesPass::runOnOperation() {
                                        SmallVectorImpl<Type> &types) {
     // If the array has only one element, we replace the array with the element.
     if (type.getNumElements() == 1) {
-      Type converted = converter.convertType(type.getElementType());
-      if (converted)
+      if (Type converted = converter.convertType(type.getElementType()))
         types.push_back(converted);
-      // The element was i0; no type is added to `types`.
       return success();
     }
     // Recursively apply type conversion to inner types.

--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -215,7 +215,7 @@ void RemoveI0TypesPass::runOnOperation() {
   });
   converter.addConversion([&converter](hw::ArrayType type) -> Type {
     if (type.getNumElements() == 1)
-      return type.getElementType();
+      return converter.convertType(type.getElementType());
     // Recursively apply type conversion to inner types.
     return hw::ArrayType::get(converter.convertType(type.getElementType()),
                               type.getNumElements());
@@ -240,6 +240,9 @@ void RemoveI0TypesPass::runOnOperation() {
   });
   converter.addConversion([&converter](hw::TypeAliasType type) {
     return converter.convertType(type.getCanonicalType());
+  });
+  converter.addConversion([&converter](arc::StateType type) {
+    return arc::StateType::get(converter.convertType(type.getType()));
   });
 
   target.markUnknownOpDynamicallyLegal(

--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -201,26 +201,30 @@ struct HandleGenericOp : public ConversionPattern {
   }
 };
 
-struct ConvertAggregateConstant : public OpConversionPattern<hw::AggregateConstantOp> {
+struct ConvertAggregateConstant
+    : public OpConversionPattern<hw::AggregateConstantOp> {
   using OpConversionPattern<hw::AggregateConstantOp>::OpConversionPattern;
   LogicalResult
-  matchAndRewrite(hw::AggregateConstantOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const override {
+  matchAndRewrite(hw::AggregateConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
     Type resultType = getTypeConverter()->convertType(op.getResult().getType());
 
     // Recursively rewrite the attribute.
-    Attribute newFields = rewriteArrayAttr(op.getFields(), op.getResult().getType());
+    Attribute newFields =
+        rewriteArrayAttr(op.getFields(), op.getResult().getType());
 
     if (!isa<ArrayAttr>(newFields)) {
       // Scalar result -> becomes hw.constant.
       IntegerAttr attr = cast<IntegerAttr>(newFields);
-      auto result = hw::ConstantOp::create(rewriter, op.getLoc(), resultType,
-                                           attr);
+      auto result =
+          hw::ConstantOp::create(rewriter, op.getLoc(), resultType, attr);
       rewriter.replaceOp(op, result);
       return success();
     }
 
     // Composite result -> new aggregate_constant op.
-    auto newOp = hw::AggregateConstantOp::create(rewriter, op.getLoc(), resultType, cast<ArrayAttr>(newFields));
+    auto newOp = hw::AggregateConstantOp::create(
+        rewriter, op.getLoc(), resultType, cast<ArrayAttr>(newFields));
     rewriter.replaceOp(op, newOp);
     return success();
   }
@@ -228,7 +232,8 @@ struct ConvertAggregateConstant : public OpConversionPattern<hw::AggregateConsta
   Attribute rewriteArrayAttr(ArrayAttr array, Type type) const {
     if (getTypeConverter()->convertType(type) == type)
       return array;
-    if (auto arrayType = dyn_cast<hw::ArrayType>(type); arrayType && arrayType.getNumElements() == 1) {
+    if (auto arrayType = dyn_cast<hw::ArrayType>(type);
+        arrayType && arrayType.getNumElements() == 1) {
       return *array.begin();
     }
 
@@ -303,8 +308,7 @@ void RemoveI0TypesPass::runOnOperation() {
 
   patterns.add<ConvertFunc, ConvertReturn, ConvertCall, ConvertArrayGet,
                ConvertArrayCreate, ConvertArrayInject, HandleGenericOp,
-               ConvertAggregateConstant>(
-      converter, &getContext());
+               ConvertAggregateConstant>(converter, &getContext());
   if (failed(
           applyFullConversion(getOperation(), target, std::move(patterns)))) {
     return signalPassFailure();

--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -1,0 +1,267 @@
+//===- RemoveI0Types.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_REMOVEI0TYPES
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+namespace {
+struct RemoveI0TypesPass
+    : public arc::impl::RemoveI0TypesBase<RemoveI0TypesPass> {
+  using RemoveI0TypesBase::RemoveI0TypesBase;
+  void runOnOperation() override;
+};
+
+bool isI0(Type type) {
+  auto intType = dyn_cast<IntegerType>(type);
+  return intType && intType.getWidth() == 0;
+}
+
+bool isPoison(Type type) { return isa<OpaqueType>(type); }
+
+SmallVector<Type> filterOutPoison(TypeRange range) {
+  return llvm::filter_to_vector(range, [](Type t) { return !isPoison(t); });
+}
+
+SmallVector<Value> filterOutPoison(ValueRange range) {
+  return llvm::filter_to_vector(range,
+                                [](Value v) { return !isPoison(v.getType()); });
+}
+
+struct ConvertFunc : public OpConversionPattern<func::FuncOp> {
+  using OpConversionPattern<func::FuncOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(func::FuncOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const TypeConverter &converter = *getTypeConverter();
+    FunctionType fty = op.getFunctionType();
+
+    rewriter.setInsertionPointToStart(&op.getBody().front());
+    TypeConverter::SignatureConversion sig(op.getNumArguments());
+    for (auto [origIdx, type] : enumerate(fty.getInputs())) {
+      Type newType = converter.convertType(type);
+      if (!newType)
+        return failure();
+      if (isPoison(newType)) {
+        Value cast = UnrealizedConversionCastOp::create(rewriter, op.getLoc(),
+                                                        newType, ValueRange{})
+                         .getResult(0);
+        sig.remapInput(origIdx, cast);
+        continue;
+      }
+      sig.addInputs(origIdx, newType);
+    }
+
+    if (failed(rewriter.convertRegionTypes(&op.getBody(), converter, &sig))) {
+      return failure();
+    }
+
+    SmallVector<Type> filteredResultTypes;
+    if (failed(converter.convertTypes(fty.getResults(), filteredResultTypes)))
+      return failure();
+    filteredResultTypes = filterOutPoison(filteredResultTypes);
+
+    rewriter.modifyOpInPlace(op, [&]() {
+      op.setFunctionType(FunctionType::get(
+          getContext(), sig.getConvertedTypes(), filteredResultTypes));
+    });
+
+    return success();
+  }
+};
+
+struct ConvertReturn : public OpConversionPattern<func::ReturnOp> {
+  using OpConversionPattern<func::ReturnOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value> filteredOperands =
+        filterOutPoison(adaptor.getOperands());
+    rewriter.modifyOpInPlace(op, [&]() { op->setOperands(filteredOperands); });
+
+    return success();
+  }
+};
+
+struct ConvertCall : public OpConversionPattern<func::CallOp> {
+  using OpConversionPattern<func::CallOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(func::CallOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const TypeConverter &converter = *getTypeConverter();
+    SmallVector<Value> filteredOperands =
+        filterOutPoison(adaptor.getOperands());
+    SmallVector<Type> resultTypes;
+    if (failed(converter.convertTypes(op.getResultTypes(), resultTypes)))
+      return failure();
+    SmallVector<Type> filteredResultTypes = filterOutPoison(resultTypes);
+
+    auto newOp =
+        func::CallOp::create(rewriter, op.getLoc(), filteredResultTypes,
+                             filteredOperands, op->getAttrs());
+
+    auto newOpResultIt = newOp.result_begin();
+    SmallVector<Value> results;
+    for (auto type : resultTypes) {
+      if (isPoison(type)) {
+        results.push_back(UnrealizedConversionCastOp::create(
+                              rewriter, op.getLoc(), type, ValueRange{})
+                              .getResult(0));
+      } else {
+        results.push_back(*newOpResultIt++);
+      }
+    }
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
+
+struct ConvertArrayGet : public OpConversionPattern<hw::ArrayGetOp> {
+  using OpConversionPattern<hw::ArrayGetOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(hw::ArrayGetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
+struct ConvertArrayCreate : public OpConversionPattern<hw::ArrayCreateOp> {
+  using OpConversionPattern<hw::ArrayCreateOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(hw::ArrayCreateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(op, adaptor.getInputs().front());
+    return success();
+  }
+};
+
+struct ConvertArrayInject : public OpConversionPattern<hw::ArrayInjectOp> {
+  using OpConversionPattern<hw::ArrayInjectOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(hw::ArrayInjectOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(op, adaptor.getElement());
+    return success();
+  }
+};
+
+struct HandleGenericOp : public ConversionPattern {
+  HandleGenericOp(TypeConverter &converter, MLIRContext *context)
+      : ConversionPattern(converter, MatchAnyOpTypeTag{},
+                          /*benefit=*/0, context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Any op returning i0 must be dead.
+    if (llvm::any_of(op->getResults(),
+                     [](Value v) { return isI0(v.getType()); })) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // Otherwise just perform type replacement.
+    auto result =
+        convertOpResultTypes(op, operands, *getTypeConverter(), rewriter);
+    if (failed(result))
+      return failure();
+
+    rewriter.replaceOp(op, *result);
+    return success();
+  }
+};
+} // namespace
+
+void RemoveI0TypesPass::runOnOperation() {
+  TypeConverter converter;
+  ConversionTarget target(getContext());
+  RewritePatternSet patterns(&getContext());
+
+  converter.addConversion([](Type type) -> Type {
+    if (isI0(type))
+      return OpaqueType::get(StringAttr::get(type.getContext(), "arc"),
+                             StringAttr::get(type.getContext(), "poison"));
+    return type;
+  });
+  converter.addConversion([&converter](hw::ArrayType type) -> Type {
+    if (type.getNumElements() == 1)
+      return type.getElementType();
+    // Recursively apply type conversion to inner types.
+    return hw::ArrayType::get(converter.convertType(type.getElementType()),
+                              type.getNumElements());
+  });
+
+  // Composite types - recursively apply type conversion to inner types.
+  converter.addConversion([&converter](hw::StructType type) {
+    auto newMembers =
+        map_to_vector(type.getElements(), [&](hw::StructType::FieldInfo field) {
+          field.type = converter.convertType(field.type);
+          return field;
+        });
+    return hw::StructType::get(type.getContext(), newMembers);
+  });
+  converter.addConversion([&converter](hw::UnionType type) {
+    auto newMembers =
+        map_to_vector(type.getElements(), [&](hw::UnionType::FieldInfo field) {
+          field.type = converter.convertType(field.type);
+          return field;
+        });
+    return hw::UnionType::get(type.getContext(), newMembers);
+  });
+  converter.addConversion([&converter](hw::TypeAliasType type) {
+    return converter.convertType(type.getCanonicalType());
+  });
+
+  target.markUnknownOpDynamicallyLegal(
+      [&](Operation *op) { return converter.isLegal(op); });
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp func) {
+    FunctionType fty = func.getFunctionType();
+    return converter.isLegal(fty.getInputs()) &&
+           converter.isLegal(fty.getResults());
+  });
+
+  patterns.add<ConvertFunc, ConvertReturn, ConvertCall, ConvertArrayGet,
+               ConvertArrayCreate, ConvertArrayInject, HandleGenericOp>(
+      converter, &getContext());
+  if (failed(
+          applyFullConversion(getOperation(), target, std::move(patterns)))) {
+    return signalPassFailure();
+  }
+
+  // Run an empty set of patterns through applyPatternsGreedily to perform
+  // a poor-man's DCE.
+  if (failed(applyPatternsGreedily(getOperation(),
+                                   RewritePatternSet(&getContext())))) {
+    return signalPassFailure();
+  }
+}

--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -6,19 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcDialect.h"
 #include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Arc/ArcTypes.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Location.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace circt {
 namespace arc {
@@ -43,164 +44,137 @@ bool isI0(Type type) {
   return intType && intType.getWidth() == 0;
 }
 
-bool isPoison(Type type) { return isa<OpaqueType>(type); }
-
-SmallVector<Type> filterOutPoison(TypeRange range) {
-  return llvm::filter_to_vector(range, [](Type t) { return !isPoison(t); });
+// Flattens a list of list of values into a list of values.
+SmallVector<Value> flatten(ArrayRef<ValueRange> ranges) {
+  SmallVector<Value> flat;
+  for (auto range : ranges) {
+    flat.insert(flat.end(), range.begin(), range.end());
+  }
+  return flat;
 }
 
-SmallVector<Value> filterOutPoison(ValueRange range) {
-  return llvm::filter_to_vector(range,
-                                [](Value v) { return !isPoison(v.getType()); });
-}
-
-struct ConvertFunc : public OpConversionPattern<func::FuncOp> {
-  using OpConversionPattern<func::FuncOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(func::FuncOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    const TypeConverter &converter = *getTypeConverter();
-    FunctionType fty = op.getFunctionType();
-
-    rewriter.setInsertionPointToStart(&op.getBody().front());
-    TypeConverter::SignatureConversion sig(op.getNumArguments());
-    for (auto [origIdx, type] : enumerate(fty.getInputs())) {
-      Type newType = converter.convertType(type);
-      if (!newType)
-        return failure();
-      if (isPoison(newType)) {
-        Value cast = UnrealizedConversionCastOp::create(rewriter, op.getLoc(),
-                                                        newType, ValueRange{})
-                         .getResult(0);
-        sig.remapInput(origIdx, cast);
-        continue;
-      }
-      sig.addInputs(origIdx, newType);
-    }
-
-    if (failed(rewriter.convertRegionTypes(&op.getBody(), converter, &sig))) {
-      return failure();
-    }
-
-    SmallVector<Type> filteredResultTypes;
-    if (failed(converter.convertTypes(fty.getResults(), filteredResultTypes)))
-      return failure();
-    filteredResultTypes = filterOutPoison(filteredResultTypes);
-
-    rewriter.modifyOpInPlace(op, [&]() {
-      op.setFunctionType(FunctionType::get(
-          getContext(), sig.getConvertedTypes(), filteredResultTypes));
-    });
-
-    return success();
-  }
-};
-
-struct ConvertReturn : public OpConversionPattern<func::ReturnOp> {
-  using OpConversionPattern<func::ReturnOp>::OpConversionPattern;
+// Generic pattern for ops that are legalizable by flattening their remaining
+// operands after type conversion.
+template <typename T>
+struct LegalizeGeneric : public OpConversionPattern<T> {
+  using OpConversionPattern<T>::OpConversionPattern;
+  using OneToNOpAdaptor = typename OpConversionPattern<T>::OneToNOpAdaptor;
 
   LogicalResult
-  matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
+  matchAndRewrite(T op, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    SmallVector<Value> filteredOperands =
-        filterOutPoison(adaptor.getOperands());
-    rewriter.modifyOpInPlace(op, [&]() { op->setOperands(filteredOperands); });
-
-    return success();
-  }
-};
-
-struct ConvertCall : public OpConversionPattern<func::CallOp> {
-  using OpConversionPattern<func::CallOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(func::CallOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    const TypeConverter &converter = *getTypeConverter();
-    SmallVector<Value> filteredOperands =
-        filterOutPoison(adaptor.getOperands());
-    SmallVector<Type> resultTypes;
-    if (failed(converter.convertTypes(op.getResultTypes(), resultTypes)))
+    const TypeConverter &converter = *this->getTypeConverter();
+    auto result = convertOpResultTypes(op, flatten(adaptor.getOperands()),
+                                       converter, rewriter);
+    if (failed(result))
       return failure();
-    SmallVector<Type> filteredResultTypes = filterOutPoison(resultTypes);
 
-    auto newOp =
-        func::CallOp::create(rewriter, op.getLoc(), filteredResultTypes,
-                             filteredOperands, op->getAttrs());
-
-    auto newOpResultIt = newOp.result_begin();
+    // Map from old results to new results, assuming the results size may have
+    // changed.
+    Operation *newOp = *result;
+    auto newOpResultIt = newOp->result_begin();
     SmallVector<Value> results;
-    for (auto type : resultTypes) {
-      if (isPoison(type)) {
-        results.push_back(UnrealizedConversionCastOp::create(
-                              rewriter, op.getLoc(), type, ValueRange{})
-                              .getResult(0));
+    for (auto oldType : op->getResultTypes()) {
+      if (!converter.convertType(oldType)) {
+        results.push_back(nullptr);
       } else {
         results.push_back(*newOpResultIt++);
       }
     }
+    assert(newOpResultIt == newOp->result_end() && "Didn't map all results!");
     rewriter.replaceOp(op, results);
     return success();
   }
 };
 
-struct ConvertArrayGet : public OpConversionPattern<hw::ArrayGetOp> {
-  using OpConversionPattern<hw::ArrayGetOp>::OpConversionPattern;
-  LogicalResult
-  matchAndRewrite(hw::ArrayGetOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOp(op, adaptor.getInput());
-    return success();
-  }
-};
-
-struct ConvertArrayCreate : public OpConversionPattern<hw::ArrayCreateOp> {
-  using OpConversionPattern<hw::ArrayCreateOp>::OpConversionPattern;
-  LogicalResult
-  matchAndRewrite(hw::ArrayCreateOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOp(op, adaptor.getInputs().front());
-    return success();
-  }
-};
-
-struct ConvertArrayInject : public OpConversionPattern<hw::ArrayInjectOp> {
-  using OpConversionPattern<hw::ArrayInjectOp>::OpConversionPattern;
-  LogicalResult
-  matchAndRewrite(hw::ArrayInjectOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOp(op, adaptor.getElement());
-    return success();
-  }
-};
-
-struct HandleGenericOp : public ConversionPattern {
-  HandleGenericOp(TypeConverter &converter, MLIRContext *context)
+// As above, but if any converted operand is empty (i.e. the operand was i0
+// initially) or the number of results after conversion changes, then the op is
+// erased. This is used for all ops where we don't explicitly know the legality
+// of removing operands from its operand list.
+struct ConvertGeneric : public ConversionPattern {
+  ConvertGeneric(TypeConverter &converter, MLIRContext *context)
       : ConversionPattern(converter, MatchAnyOpTypeTag{},
                           /*benefit=*/0, context) {}
 
   LogicalResult
-  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  matchAndRewrite(Operation *op, ArrayRef<ValueRange> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    // Any op returning i0 must be dead.
-    if (llvm::any_of(op->getResults(),
-                     [](Value v) { return isI0(v.getType()); })) {
+    const TypeConverter &converter = *getTypeConverter();
+
+    // If any operand wasn't converted (empty range), the op must be dead.
+    for (ValueRange range : operands) {
+      if (range.empty()) {
+        rewriter.eraseOp(op);
+        return success();
+      }
+    }
+
+    // If any result wasn't converted, the op must be dead.
+    SmallVector<Type> resultTypes;
+    if (failed(converter.convertTypes(op->getResultTypes(), resultTypes)))
+      return failure();
+    if (resultTypes.size() != op->getNumResults()) {
       rewriter.eraseOp(op);
       return success();
     }
 
-    // Otherwise just perform type replacement.
     auto result =
-        convertOpResultTypes(op, operands, *getTypeConverter(), rewriter);
+        convertOpResultTypes(op, flatten(operands), converter, rewriter);
     if (failed(result))
       return failure();
-
     rewriter.replaceOp(op, *result);
     return success();
   }
 };
 
+// An array_get with i0 index just returns the array input, which will have been
+// scalarized.
+struct ConvertArrayGet : public OpConversionPattern<hw::ArrayGetOp> {
+  using OpConversionPattern<hw::ArrayGetOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(hw::ArrayGetOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (adaptor.getIndex().empty()) {
+      assert(adaptor.getInput().size() == 1);
+      rewriter.replaceOp(op, adaptor.getInput().front());
+      return success();
+    }
+    // Handled by ConvertGeneric.
+    return failure();
+  }
+};
+
+// Replaces array_create of a single element with the element.
+struct ConvertArrayCreate : public OpConversionPattern<hw::ArrayCreateOp> {
+  using OpConversionPattern<hw::ArrayCreateOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(hw::ArrayCreateOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (adaptor.getInputs().size() == 1) {
+      rewriter.replaceOp(op, adaptor.getInputs().front());
+      return success();
+    }
+    // Handled by ConvertGeneric.
+    return failure();
+  }
+};
+
+// Converts array_inject with i0 index to just return the element.
+struct ConvertArrayInject : public OpConversionPattern<hw::ArrayInjectOp> {
+  using OpConversionPattern<hw::ArrayInjectOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(hw::ArrayInjectOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (adaptor.getIndex().empty()) {
+      rewriter.replaceOp(op, adaptor.getElement());
+      return success();
+    }
+    // Handled by ConvertGeneric.
+    return failure();
+  }
+};
+
+// Converts an aggregate_constant by recursively rewriting its attribute.
 struct ConvertAggregateConstant
     : public OpConversionPattern<hw::AggregateConstantOp> {
   using OpConversionPattern<hw::AggregateConstantOp>::OpConversionPattern;
@@ -214,7 +188,7 @@ struct ConvertAggregateConstant
         rewriteArrayAttr(op.getFields(), op.getResult().getType());
 
     if (!isa<ArrayAttr>(newFields)) {
-      // Scalar result -> becomes hw.constant.
+      // Scalar result becomes hw.constant.
       IntegerAttr attr = cast<IntegerAttr>(newFields);
       auto result =
           hw::ConstantOp::create(rewriter, op.getLoc(), resultType, attr);
@@ -222,13 +196,14 @@ struct ConvertAggregateConstant
       return success();
     }
 
-    // Composite result -> new aggregate_constant op.
+    // Composite result becomes a new aggregate_constant op.
     auto newOp = hw::AggregateConstantOp::create(
         rewriter, op.getLoc(), resultType, cast<ArrayAttr>(newFields));
     rewriter.replaceOp(op, newOp);
     return success();
   }
 
+  // NOLINTNEXTLINE(misc-no-recursion): Bounded recursion.
   Attribute rewriteArrayAttr(ArrayAttr array, Type type) const {
     if (getTypeConverter()->convertType(type) == type)
       return array;
@@ -244,15 +219,15 @@ struct ConvertAggregateConstant
     for (auto [index, attr] : llvm::enumerate(array)) {
       uint64_t fieldId = fieldIdInterface.getFieldID(index);
       Type subType = fieldIdInterface.getSubTypeByFieldID(fieldId).first;
-      if (auto subArrayAttr = dyn_cast<ArrayAttr>(attr)) {
+      if (auto subArrayAttr = dyn_cast<ArrayAttr>(attr))
         attrs.push_back(rewriteArrayAttr(subArrayAttr, subType));
-      } else {
+      else
         attrs.push_back(attr);
-      }
     }
     return ArrayAttr::get(array.getContext(), attrs);
   }
 };
+
 } // namespace
 
 void RemoveI0TypesPass::runOnOperation() {
@@ -260,43 +235,71 @@ void RemoveI0TypesPass::runOnOperation() {
   ConversionTarget target(getContext());
   RewritePatternSet patterns(&getContext());
 
-  converter.addConversion([](Type type) -> Type {
+  // The conversions for types are 1:N, where N may be 1 or 0.
+  converter.addConversion([](Type type, SmallVectorImpl<Type> &types) {
     if (isI0(type))
-      return OpaqueType::get(StringAttr::get(type.getContext(), "arc"),
-                             StringAttr::get(type.getContext(), "poison"));
-    return type;
-  });
-  converter.addConversion([&converter](hw::ArrayType type) -> Type {
-    if (type.getNumElements() == 1)
-      return converter.convertType(type.getElementType());
-    // Recursively apply type conversion to inner types.
-    return hw::ArrayType::get(converter.convertType(type.getElementType()),
-                              type.getNumElements());
+      // Do not add any types to `types`.
+      return success();
+    types.push_back(type);
+    return success();
   });
 
   // Composite types - recursively apply type conversion to inner types.
-  converter.addConversion([&converter](hw::StructType type) {
-    auto newMembers =
-        map_to_vector(type.getElements(), [&](hw::StructType::FieldInfo field) {
-          field.type = converter.convertType(field.type);
-          return field;
-        });
+  converter.addConversion([&converter](hw::ArrayType type,
+                                       SmallVectorImpl<Type> &types) {
+    // If the array has only one element, we replace the array with the element.
+    if (type.getNumElements() == 1) {
+      Type converted = converter.convertType(type.getElementType());
+      if (converted)
+        types.push_back(converted);
+      // The element was i0; no type is added to `types`.
+      return success();
+    }
+    // Recursively apply type conversion to inner types.
+    types.push_back(hw::ArrayType::get(
+        converter.convertType(type.getElementType()), type.getNumElements()));
+    return success();
+  });
+  converter.addConversion([&converter](hw::StructType type) -> Type {
+    SmallVector<hw::StructType::FieldInfo> newMembers;
+    // Convert and filter out any i0 fields.
+    for (auto &field : type.getElements()) {
+      SmallVector<Type> convertedTypes;
+      if (failed(converter.convertType(field.type, convertedTypes)))
+        return Type();
+      if (!convertedTypes.empty()) {
+        assert(convertedTypes.size() == 1);
+        newMembers.push_back({field.name, convertedTypes[0]});
+      }
+    }
     return hw::StructType::get(type.getContext(), newMembers);
   });
-  converter.addConversion([&converter](hw::UnionType type) {
-    auto newMembers =
-        map_to_vector(type.getElements(), [&](hw::UnionType::FieldInfo field) {
-          field.type = converter.convertType(field.type);
-          return field;
-        });
+  converter.addConversion([&converter](hw::UnionType type) -> Type {
+    SmallVector<hw::UnionType::FieldInfo> newMembers;
+    // Convert and filter out any i0 fields.
+    for (auto &field : type.getElements()) {
+      SmallVector<Type> convertedTypes;
+      if (failed(converter.convertType(field.type, convertedTypes)))
+        return Type();
+      if (!convertedTypes.empty()) {
+        assert(convertedTypes.size() == 1);
+        newMembers.push_back({field.name, convertedTypes[0], field.offset});
+      }
+    }
     return hw::UnionType::get(type.getContext(), newMembers);
   });
-  converter.addConversion([&converter](hw::TypeAliasType type) {
-    return converter.convertType(type.getCanonicalType());
-  });
-  converter.addConversion([&converter](arc::StateType type) {
-    return arc::StateType::get(converter.convertType(type.getType()));
-  });
+  converter.addConversion(
+      [&converter](hw::TypeAliasType type, SmallVectorImpl<Type> &types) {
+        return converter.convertType(type.getCanonicalType(), types);
+      });
+  converter.addConversion(
+      [&converter](arc::StateType type, SmallVectorImpl<Type> &types) {
+        if (failed(converter.convertType(type.getType(), types)))
+          return failure();
+        assert(types.size() == 1);
+        types[0] = arc::StateType::get(types[0]);
+        return success();
+      });
 
   target.markUnknownOpDynamicallyLegal(
       [&](Operation *op) { return converter.isLegal(op); });
@@ -306,18 +309,16 @@ void RemoveI0TypesPass::runOnOperation() {
            converter.isLegal(fty.getResults());
   });
 
-  patterns.add<ConvertFunc, ConvertReturn, ConvertCall, ConvertArrayGet,
-               ConvertArrayCreate, ConvertArrayInject, HandleGenericOp,
-               ConvertAggregateConstant>(converter, &getContext());
-  if (failed(
-          applyFullConversion(getOperation(), target, std::move(patterns)))) {
-    return signalPassFailure();
-  }
+  populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
+                                                                 converter);
 
-  // Run an empty set of patterns through applyPatternsGreedily to perform
-  // a poor-man's DCE.
-  if (failed(applyPatternsGreedily(getOperation(),
-                                   RewritePatternSet(&getContext())))) {
+  patterns.add<LegalizeGeneric<func::ReturnOp>, LegalizeGeneric<func::CallOp>,
+               LegalizeGeneric<hw::StructCreateOp>, ConvertArrayGet,
+               ConvertArrayCreate, ConvertArrayInject, ConvertGeneric,
+               ConvertAggregateConstant>(converter, &getContext());
+  ConversionConfig config;
+  config.allowPatternRollback = false;
+  if (failed(applyFullConversion(getOperation(), target, std::move(patterns),
+                                 config)))
     return signalPassFailure();
-  }
 }

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -118,7 +118,6 @@ void circt::populateArcStateLoweringPipeline(
   if (options.shouldInline)
     pm.addPass(arc::createInlineArcs());
 
-  pm.addPass(arc::createRemoveI0Types());
   pm.addPass(arc::createMergeIfsPass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizer());
@@ -127,6 +126,7 @@ void circt::populateArcStateLoweringPipeline(
 void circt::populateArcStateAllocationPipeline(
     OpPassManager &pm, const ArcStateAllocationOptions &options) {
   pm.addPass(arc::createLowerArcsToFuncs());
+  pm.addPass(arc::createRemoveI0Types());
   {
     AllocateStateOptions allocStateOpts;
     allocStateOpts.insertTraceTaps = options.insertTraceTaps;

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -118,6 +118,7 @@ void circt::populateArcStateLoweringPipeline(
   if (options.shouldInline)
     pm.addPass(arc::createInlineArcs());
 
+  pm.addPass(arc::createRemoveI0Types());
   pm.addPass(arc::createMergeIfsPass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizer());

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -239,14 +239,28 @@ func.func @WriteArray(%arg0: !arc.state<!hw.array<4xi1>>, %arg1: !hw.array<4xi1>
 // CHECK-LABEL: llvm.func @DontCrashOnI0(
 func.func @DontCrashOnI0(%arg0: i1, %arg1: !hw.array<1xi42>) -> i42 {
   // CHECK: [[STACK:%.+]] = llvm.alloca {{%.+}} x !llvm.array<1 x i42>
-  // CHECK: [[ZERO:%.+]] = llvm.mlir.constant(0 : i0) : i0
-  // CHECK: [[ZEXT:%.+]] = llvm.zext [[ZERO]] : i0 to i1
+  // CHECK: [[ZERO:%.+]] = llvm.mlir.constant(false) : i1
+  // CHECK: [[ZEXT:%.+]] = llvm.zext [[ZERO]] : i1 to i2
   // CHECK: [[GEP:%.+]] = llvm.getelementptr [[STACK]][0, [[ZEXT]]] :
   // CHECK: [[RESULT:%.+]] = llvm.load [[GEP]] : !llvm.ptr -> i42
   // CHECK: llvm.return [[RESULT]]
   %0 = comb.extract %arg0 from 0 : (i1) -> i0
   %1 = hw.array_get %arg1[%0] : !hw.array<1xi42>, i0
   return %1 : i42
+}
+
+// CHECK-LABEL: llvm.func @DontCrashOnI0_2
+// CHECK-NOT: i0
+func.func @DontCrashOnI0_2(%arg0: i0, %arg1: !hw.array<1xi42>) -> i42 {
+  %0 = hw.array_get %arg1[%arg0] : !hw.array<1xi42>, i0
+  return %0 : i42
+}
+
+// CHECK-LABEL: llvm.func @DontCrashOnI0_3
+// CHECK-NOT: i0
+func.func @DontCrashOnI0_3() -> i0 {
+  %0 = hw.constant 0 : i0
+  return %0 : i0
 }
 
 // CHECK-LABEL: llvm.func @ExecuteEmpty

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -233,22 +233,6 @@ func.func @WriteArray(%arg0: !arc.state<!hw.array<4xi1>>, %arg1: !hw.array<4xi1>
   return
 }
 
-// The LLVM IR does not like `i0` types. The lowering replaces all `i0` values
-// with constants to allow canonicalizers to elide i0 values as needed.
-// See https://github.com/llvm/circt/pull/8871.
-// CHECK-LABEL: llvm.func @DontCrashOnI0(
-func.func @DontCrashOnI0(%arg0: i1, %arg1: !hw.array<1xi42>) -> i42 {
-  // CHECK: [[STACK:%.+]] = llvm.alloca {{%.+}} x !llvm.array<1 x i42>
-  // CHECK: [[ZERO:%.+]] = llvm.mlir.constant(0 : i0) : i0
-  // CHECK: [[ZEXT:%.+]] = llvm.zext [[ZERO]] : i0 to i1
-  // CHECK: [[GEP:%.+]] = llvm.getelementptr [[STACK]][0, [[ZEXT]]] :
-  // CHECK: [[RESULT:%.+]] = llvm.load [[GEP]] : !llvm.ptr -> i42
-  // CHECK: llvm.return [[RESULT]]
-  %0 = comb.extract %arg0 from 0 : (i1) -> i0
-  %1 = hw.array_get %arg1[%0] : !hw.array<1xi42>, i0
-  return %1 : i42
-}
-
 // CHECK-LABEL: llvm.func @ExecuteEmpty
 func.func @ExecuteEmpty() {
   // CHECK-NEXT: llvm.br [[BB:\^.+]]

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -239,28 +239,14 @@ func.func @WriteArray(%arg0: !arc.state<!hw.array<4xi1>>, %arg1: !hw.array<4xi1>
 // CHECK-LABEL: llvm.func @DontCrashOnI0(
 func.func @DontCrashOnI0(%arg0: i1, %arg1: !hw.array<1xi42>) -> i42 {
   // CHECK: [[STACK:%.+]] = llvm.alloca {{%.+}} x !llvm.array<1 x i42>
-  // CHECK: [[ZERO:%.+]] = llvm.mlir.constant(false) : i1
-  // CHECK: [[ZEXT:%.+]] = llvm.zext [[ZERO]] : i1 to i2
+  // CHECK: [[ZERO:%.+]] = llvm.mlir.constant(0 : i0) : i0
+  // CHECK: [[ZEXT:%.+]] = llvm.zext [[ZERO]] : i0 to i1
   // CHECK: [[GEP:%.+]] = llvm.getelementptr [[STACK]][0, [[ZEXT]]] :
   // CHECK: [[RESULT:%.+]] = llvm.load [[GEP]] : !llvm.ptr -> i42
   // CHECK: llvm.return [[RESULT]]
   %0 = comb.extract %arg0 from 0 : (i1) -> i0
   %1 = hw.array_get %arg1[%0] : !hw.array<1xi42>, i0
   return %1 : i42
-}
-
-// CHECK-LABEL: llvm.func @DontCrashOnI0_2
-// CHECK-NOT: i0
-func.func @DontCrashOnI0_2(%arg0: i0, %arg1: !hw.array<1xi42>) -> i42 {
-  %0 = hw.array_get %arg1[%arg0] : !hw.array<1xi42>, i0
-  return %0 : i42
-}
-
-// CHECK-LABEL: llvm.func @DontCrashOnI0_3
-// CHECK-NOT: i0
-func.func @DontCrashOnI0_3() -> i0 {
-  %0 = hw.constant 0 : i0
-  return %0 : i0
 }
 
 // CHECK-LABEL: llvm.func @ExecuteEmpty

--- a/test/Dialect/Arc/remove-i0-types.mlir
+++ b/test/Dialect/Arc/remove-i0-types.mlir
@@ -132,12 +132,10 @@ func.func @CallMixed(%a: i32) -> i32 {
   return %0#0 : i32
 }
 
-// A struct with an i0 field: the i0 field type is replaced with !arc.poison
-// by the type converter. Struct fields are not removed, only type-converted.
-// CHECK-LABEL: func.func @StructWithI0Field(%arg0: i32) -> !hw.struct<x: i32, y: !arc.poison>
-// CHECK-NEXT:    %0 = builtin.unrealized_conversion_cast to !arc.poison
-// CHECK-NEXT:    %1 = hw.struct_create (%arg0, %0) : !hw.struct<x: i32, y: !arc.poison>
-// CHECK-NEXT:    return %1 : !hw.struct<x: i32, y: !arc.poison>
+// A struct with an i0 field: the i0 field type is removed.
+// CHECK-LABEL: func.func @StructWithI0Field(%arg0: i32) -> !hw.struct<x: i32>
+// CHECK-NEXT:    %0 = hw.struct_create (%arg0) : !hw.struct<x: i32>
+// CHECK-NEXT:    return %0 : !hw.struct<x: i32>
 // CHECK-NEXT:  }
 func.func @StructWithI0Field(%a: i32, %b: i0) -> !hw.struct<x: i32, y: i0> {
   %0 = hw.struct_create (%a, %b) : !hw.struct<x: i32, y: i0>
@@ -145,13 +143,22 @@ func.func @StructWithI0Field(%a: i32, %b: i0) -> !hw.struct<x: i32, y: i0> {
 }
 
 // Extracting a non-i0 field from a struct that also contains an i0 field.
-// CHECK-LABEL: func.func @StructExtractNonI0(%arg0: !hw.struct<x: i32, y: !arc.poison>) -> i32
-// CHECK-NEXT:    %x = hw.struct_extract %arg0["x"] : !hw.struct<x: i32, y: !arc.poison>
+// CHECK-LABEL: func.func @StructExtractNonI0(%arg0: !hw.struct<x: i32>) -> i32
+// CHECK-NEXT:    %x = hw.struct_extract %arg0["x"] : !hw.struct<x: i32>
 // CHECK-NEXT:    return %x : i32
 // CHECK-NEXT:  }
 func.func @StructExtractNonI0(%a: !hw.struct<x: i32, y: i0>) -> i32 {
   %0 = hw.struct_extract %a["x"] : !hw.struct<x: i32, y: i0>
   return %0 : i32
+}
+
+// Extracting an i0 field from a struct that also contains a non-i0 field.
+// CHECK-LABEL: func.func @StructExtractI0(%arg0: !hw.struct<x: i32>)
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @StructExtractI0(%a: !hw.struct<x: i32, y: i0>) -> i0 {
+  %0 = hw.struct_extract %a["y"] : !hw.struct<x: i32, y: i0>
+  return %0 : i0
 }
 
 // A function that has all i0 arguments: all are removed, leaving an empty

--- a/test/Dialect/Arc/remove-i0-types.mlir
+++ b/test/Dialect/Arc/remove-i0-types.mlir
@@ -192,3 +192,18 @@ func.func @ArrayOfArrayOf1(%arg0: !hw.array<2x!hw.array<1xi32>>) ->
 func.func @StateType(%arg0: !arc.state<!hw.array<1xi32>>) {
   return
 }
+
+// CHECK-LABEL: func.func @AggregateConstantBecomesScalar
+// CHECK-SAME: -> i32
+// CHECK-NEXT: hw.constant 0 : i32
+func.func @AggregateConstantBecomesScalar() -> !hw.array<1xi32> {
+  %0 = hw.aggregate_constant [0 : i32] : !hw.array<1xi32>
+  return %0 : !hw.array<1xi32>
+}
+
+// CHECK-LABEL: func.func @AggregateConstantStaysAggregate
+// CHECK-NEXT: hw.aggregate_constant [0 : i32, 1 : i32] : !hw.array<2xi32>
+func.func @AggregateConstantStaysAggregate() -> !hw.array<2x!hw.array<1xi32>> {
+  %0 = hw.aggregate_constant [[0 : i32], [1 : i32]] : !hw.array<2x!hw.array<1xi32>>
+  return %0 : !hw.array<2x!hw.array<1xi32>>
+}

--- a/test/Dialect/Arc/remove-i0-types.mlir
+++ b/test/Dialect/Arc/remove-i0-types.mlir
@@ -179,3 +179,16 @@ func.func @MultiElementArray(%a: !hw.array<4xi32>) -> !hw.array<4xi32> {
 func.func @NoI0(%a: i32, %b: i64) -> i32 {
   return %a : i32
 }
+
+// CHECK-LABEL: func.func @ArrayOfArrayOf1
+// CHECK-SAME: !hw.array<2xi32>
+func.func @ArrayOfArrayOf1(%arg0: !hw.array<2x!hw.array<1xi32>>) ->
+  !hw.array<2x!hw.array<1xi32>> {
+  return %arg0 : !hw.array<2x!hw.array<1xi32>>
+}
+
+// CHECK-LABEL: func.func @StateType
+// CHECK-SAME: !arc.state<i32>
+func.func @StateType(%arg0: !arc.state<!hw.array<1xi32>>) {
+  return
+}

--- a/test/Dialect/Arc/remove-i0-types.mlir
+++ b/test/Dialect/Arc/remove-i0-types.mlir
@@ -1,0 +1,181 @@
+// RUN: circt-opt --arc-remove-i0-types %s | FileCheck %s
+
+// The i0 argument is removed entirely from the function signature.
+// CHECK-LABEL: func.func @TakesI0()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @TakesI0(%a: i0) {
+  return
+}
+
+// All i0 operations are dead code and are erased.
+// CHECK-LABEL: func.func @DeadCode()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @DeadCode(%a: i0) {
+  %0 = comb.and %a, %a : i0
+  %1 = comb.or %0, %a : i0
+  return
+}
+
+// Both the i0 argument and the i0 result are removed.
+// CHECK-LABEL: func.func @ReturnsI0()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @ReturnsI0(%a: i0) -> i0 {
+  return %a : i0
+}
+
+// The i0 constant and return value are removed.
+// CHECK-LABEL: func.func @ConstantI0()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @ConstantI0() -> i0 {
+  %cst = hw.constant 0 : i0
+  return %cst : i0
+}
+
+// The i0 index argument is removed, and the single-element array is unwrapped
+// to its element type. The array_get is replaced by the element directly.
+// CHECK-LABEL: func.func @ArrayGet(%arg0: i32) -> i32
+// CHECK-NEXT:    return %arg0 : i32
+// CHECK-NEXT:  }
+func.func @ArrayGet(%a: !hw.array<1xi32>, %b: i0) -> i32 {
+  %0 = hw.array_get %a[%b] : !hw.array<1xi32>, i0
+  return %0 : i32
+}
+
+// The single-element array create is replaced by its element directly.
+// CHECK-LABEL: func.func @ArrayCreate(%arg0: i32) -> i32
+// CHECK-NEXT:    return %arg0 : i32
+// CHECK-NEXT:  }
+func.func @ArrayCreate(%a: i32) -> !hw.array<1xi32> {
+  %0 = hw.array_create %a : i32
+  return %0 : !hw.array<1xi32>
+}
+
+// The single-element array inject is replaced by the injected element; the i0
+// index argument is removed.
+// CHECK-LABEL: func.func @ArrayInject(%arg0: i32, %arg1: i32) -> i32
+// CHECK-NEXT:    return %arg1 : i32
+// CHECK-NEXT:  }
+func.func @ArrayInject(%a: !hw.array<1xi32>, %b: i0, %c: i32) -> !hw.array<1xi32> {
+  %0 = hw.array_inject %a[%b], %c : !hw.array<1xi32>, i0
+  return %0 : !hw.array<1xi32>
+}
+
+// The i0 argument is removed from both the caller and the callee signature.
+// CHECK-LABEL: func.func @Call()
+// CHECK-NEXT:    call @TakesI0() : () -> ()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @Call(%a: i0) {
+  func.call @TakesI0(%a) : (i0) -> ()
+  return
+}
+
+// The i0 return value is removed from both the caller and the callee signature.
+// CHECK-LABEL: func.func @Call2()
+// CHECK-NEXT:    call @ReturnsI0() : () -> ()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @Call2(%a: i0) -> i0 {
+  %0 = func.call @ReturnsI0(%a) : (i0) -> (i0)
+  return %0 : i0
+}
+
+// The single-element array inside the struct is unwrapped to its element type.
+// CHECK-LABEL: func.func @StructCreate(%arg0: i32) -> !hw.struct<x: i32>
+// CHECK-NEXT:    %0 = hw.struct_create (%arg0) : !hw.struct<x: i32>
+// CHECK-NEXT:    return %0 : !hw.struct<x: i32>
+// CHECK-NEXT:  }
+func.func @StructCreate(%a: !hw.array<1xi32>) -> !hw.struct<x: !hw.array<1xi32>> {
+  %0 = hw.struct_create (%a) : !hw.struct<x: !hw.array<1xi32>>
+  return %0 : !hw.struct<x: !hw.array<1xi32>>
+}
+
+// CHECK-LABEL: func.func @StructExtract(%arg0: !hw.struct<x: i32>) -> i32
+// CHECK-NEXT:    %x = hw.struct_extract %arg0["x"] : !hw.struct<x: i32>
+// CHECK-NEXT:    return %x : i32
+// CHECK-NEXT:  }
+func.func @StructExtract(%a: !hw.struct<x: i32>) -> i32 {
+  %0 = hw.struct_extract %a["x"] : !hw.struct<x: i32>
+  return %0 : i32
+}
+
+// Mixed i0 and non-i0 arguments: the i0 arguments are removed while the
+// non-i0 arguments are preserved.
+// CHECK-LABEL: func.func @MixedArgs(%arg0: i32, %arg1: i8) -> i32
+// CHECK-NEXT:    return %arg0 : i32
+// CHECK-NEXT:  }
+func.func @MixedArgs(%a: i0, %b: i32, %c: i0, %d: i8) -> i32 {
+  return %b : i32
+}
+
+// Mixed i0 and non-i0 return values: the i0 results are removed.
+// CHECK-LABEL: func.func @MixedResults(%arg0: i32) -> i32
+// CHECK-NEXT:    return %arg0 : i32
+// CHECK-NEXT:  }
+func.func @MixedResults(%a: i32) -> (i32, i0) {
+  %cst = hw.constant 0 : i0
+  return %a, %cst : i32, i0
+}
+
+// Calling a function with mixed i0 and non-i0 arguments and results.
+// CHECK-LABEL: func.func @CallMixed(%arg0: i32) -> i32
+// CHECK-NEXT:    %0 = call @MixedResults(%arg0) : (i32) -> i32
+// CHECK-NEXT:    return %0 : i32
+// CHECK-NEXT:  }
+func.func @CallMixed(%a: i32) -> i32 {
+  %cst = hw.constant 0 : i0
+  %0:2 = func.call @MixedResults(%a) : (i32) -> (i32, i0)
+  return %0#0 : i32
+}
+
+// A struct with an i0 field: the i0 field type is replaced with !arc.poison
+// by the type converter. Struct fields are not removed, only type-converted.
+// CHECK-LABEL: func.func @StructWithI0Field(%arg0: i32) -> !hw.struct<x: i32, y: !arc.poison>
+// CHECK-NEXT:    %0 = builtin.unrealized_conversion_cast to !arc.poison
+// CHECK-NEXT:    %1 = hw.struct_create (%arg0, %0) : !hw.struct<x: i32, y: !arc.poison>
+// CHECK-NEXT:    return %1 : !hw.struct<x: i32, y: !arc.poison>
+// CHECK-NEXT:  }
+func.func @StructWithI0Field(%a: i32, %b: i0) -> !hw.struct<x: i32, y: i0> {
+  %0 = hw.struct_create (%a, %b) : !hw.struct<x: i32, y: i0>
+  return %0 : !hw.struct<x: i32, y: i0>
+}
+
+// Extracting a non-i0 field from a struct that also contains an i0 field.
+// CHECK-LABEL: func.func @StructExtractNonI0(%arg0: !hw.struct<x: i32, y: !arc.poison>) -> i32
+// CHECK-NEXT:    %x = hw.struct_extract %arg0["x"] : !hw.struct<x: i32, y: !arc.poison>
+// CHECK-NEXT:    return %x : i32
+// CHECK-NEXT:  }
+func.func @StructExtractNonI0(%a: !hw.struct<x: i32, y: i0>) -> i32 {
+  %0 = hw.struct_extract %a["x"] : !hw.struct<x: i32, y: i0>
+  return %0 : i32
+}
+
+// A function that has all i0 arguments: all are removed, leaving an empty
+// argument list.
+// CHECK-LABEL: func.func @AllI0Args()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @AllI0Args(%a: i0, %b: i0, %c: i0) {
+  return
+}
+
+// Multi-element array should remain an array type (only single-element arrays
+// are unwrapped).
+// CHECK-LABEL: func.func @MultiElementArray(%arg0: !hw.array<4xi32>) -> !hw.array<4xi32>
+// CHECK-NEXT:    return %arg0 : !hw.array<4xi32>
+// CHECK-NEXT:  }
+func.func @MultiElementArray(%a: !hw.array<4xi32>) -> !hw.array<4xi32> {
+  return %a : !hw.array<4xi32>
+}
+
+// Non-i0 types should pass through unchanged.
+// CHECK-LABEL: func.func @NoI0(%arg0: i32, %arg1: i64) -> i32
+// CHECK-NEXT:    return %arg0 : i32
+// CHECK-NEXT:  }
+func.func @NoI0(%a: i32, %b: i64) -> i32 {
+  return %a : i32
+}


### PR DESCRIPTION
i0 is legal in MLIR but illegal in LLVM-IR. https://github.com/llvm/circt/pull/8871
added support for eliding most i0 uses in generated LLVM-IR.

However there are ways i0s can sneak through the cracks - for example in function
signatures. This occurs when ArcInline chooses not to inline functions that take
i0 operands (which typically come with / degenerate from !hw.array<1xT> types).

Mark i0 as illegal. Transform it to i1 for expediency. Driveby fix incorrect LLVM
lowering in HWToLLVM (using op.getIndex() rather than adaptor.getIndex()).

Marking i0 as illegal does also make the `llvm.mlir.constant(0 : i0) : i0` that were
inserted earlier illegal too, so we do have to ensure that the hw::ConstantOp lowering
correctly changes its attribute type as well as its result type. This is a bit grim,
and perhaps points to a better fix being a dedicated "remove i0 and array<1xT>" pass.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
