### PR TITLE
[Comb] Add two canonicalization patterns

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1106,6 +1106,26 @@ LogicalResult AndOp::canonicalize(AndOp op, PatternRewriter &rewriter) {
     return success();
   }
 
+  // and(x, replicate(p : i1)) -> mux(p, x, zero)
+  if (op.getTwoState() && op.getNumOperands() == 2) {
+    auto isReplicateOfI1 = [](Value v) {
+      auto rep = v.getDefiningOp<ReplicateOp>();
+      if (!rep) return false;
+      return rep.getOperand().getType().isInteger(1);
+    };
+    Value x = op.getOperand(0);
+    Value y = op.getOperand(1);
+    if (isReplicateOfI1(x)) std::swap(x, y);
+    if (isReplicateOfI1(y)) {
+      Value p = y.getDefiningOp<ReplicateOp>().getInput();
+      Value zero = hw::ConstantOp::create(
+          rewriter, op.getLoc(), rewriter.getIntegerAttr(op.getType(), 0));
+      replaceOpWithNewOpAndCopyNamehint<MuxOp>(rewriter, op, p, x, zero,
+                                               /*isTwoState=*/true);
+      return success();
+    }
+  }
+
   /// TODO: and(..., x, not(x)) -> and(..., 0) -- complement
   return failure();
 }
@@ -1246,6 +1266,35 @@ LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
         replaceOpWithNewOpAndCopyNamehint<comb::MuxOp>(
             rewriter, op, cond, firstMux.getTrueValue(),
             firstMux.getFalseValue(), true);
+        return success();
+      }
+    }
+  }
+
+  // or(mux(c_0, a_0, 0), mux(c_1, a_1, 0), ..., mux(c_n, a_n, 0)) ->
+  //   mux(c_0, a_0, mux(c_1, a_1, ...))
+  //
+  // The mux tree should then be balanced by MuxOp patterns.
+  if (auto firstMux = op.getOperand(0).getDefiningOp<comb::MuxOp>();
+      op.getTwoState() && firstMux && firstMux.getTwoState()) {
+    APInt value;
+    if (matchPattern(firstMux.getFalseValue(), m_ConstantInt(&value)) &&
+        value.isZero()) {
+      auto check = [&](Value v) {
+        auto mux = v.getDefiningOp<comb::MuxOp>();
+        if (!mux) return false;
+        return mux.getTwoState() &&
+               mux.getFalseValue() == firstMux.getFalseValue();
+      };
+      if (llvm::all_of(op.getOperands(), check)) {
+        SmallVector<Value> values(op.getOperands().drop_back());
+        Value v = op.getOperands().back();
+        while (!values.empty()) {
+          auto mux = values.pop_back_val().getDefiningOp<comb::MuxOp>();
+          v = comb::MuxOp::create(rewriter, op.getLoc(), mux.getCond(),
+                                  mux.getTrueValue(), v, /*twoState=*/true);
+        }
+        replaceOpAndCopyNamehint(rewriter, op, v);
         return success();
       }
     }

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1110,12 +1110,14 @@ LogicalResult AndOp::canonicalize(AndOp op, PatternRewriter &rewriter) {
   if (op.getTwoState() && op.getNumOperands() == 2) {
     auto isReplicateOfI1 = [](Value v) {
       auto rep = v.getDefiningOp<ReplicateOp>();
-      if (!rep) return false;
+      if (!rep)
+        return false;
       return rep.getOperand().getType().isInteger(1);
     };
     Value x = op.getOperand(0);
     Value y = op.getOperand(1);
-    if (isReplicateOfI1(x)) std::swap(x, y);
+    if (isReplicateOfI1(x))
+      std::swap(x, y);
     if (isReplicateOfI1(y)) {
       Value p = y.getDefiningOp<ReplicateOp>().getInput();
       Value zero = hw::ConstantOp::create(
@@ -1282,7 +1284,8 @@ LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
         value.isZero()) {
       auto check = [&](Value v) {
         auto mux = v.getDefiningOp<comb::MuxOp>();
-        if (!mux) return false;
+        if (!mux)
+          return false;
         return mux.getTwoState() &&
                mux.getFalseValue() == firstMux.getFalseValue();
       };

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1273,36 +1273,6 @@ LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
     }
   }
 
-  // or(mux(c_0, a_0, 0), mux(c_1, a_1, 0), ..., mux(c_n, a_n, 0)) ->
-  //   mux(c_0, a_0, mux(c_1, a_1, ...))
-  //
-  // The mux tree should then be balanced by MuxOp patterns.
-  if (auto firstMux = op.getOperand(0).getDefiningOp<comb::MuxOp>();
-      op.getTwoState() && firstMux && firstMux.getTwoState()) {
-    APInt value;
-    if (matchPattern(firstMux.getFalseValue(), m_ConstantInt(&value)) &&
-        value.isZero()) {
-      auto check = [&](Value v) {
-        auto mux = v.getDefiningOp<comb::MuxOp>();
-        if (!mux)
-          return false;
-        return mux.getTwoState() &&
-               mux.getFalseValue() == firstMux.getFalseValue();
-      };
-      if (llvm::all_of(op.getOperands(), check)) {
-        SmallVector<Value> values(op.getOperands().drop_back());
-        Value v = op.getOperands().back();
-        while (!values.empty()) {
-          auto mux = values.pop_back_val().getDefiningOp<comb::MuxOp>();
-          v = comb::MuxOp::create(rewriter, op.getLoc(), mux.getCond(),
-                                  mux.getTrueValue(), v, /*twoState=*/true);
-        }
-        replaceOpAndCopyNamehint(rewriter, op, v);
-        return success();
-      }
-    }
-  }
-
   /// TODO: or(..., x, not(x)) -> or(..., '1) -- complement
   return failure();
 }

--- a/lib/Dialect/Comb/Transforms/BalanceMux.cpp
+++ b/lib/Dialect/Comb/Transforms/BalanceMux.cpp
@@ -237,6 +237,74 @@ Value PriorityMuxReshape::buildBalancedPriorityMux(
   return MuxOp::create(rewriter, loc, combinedCond, leftTree, rightTree);
 }
 
+// or(mux(c_0, a_0, 0), mux(c_1, a_1, 0), ..., mux(c_n, a_n, 0)) ->
+//   mux(c_0, a_0, mux(c_1, a_1, ...)) iff all conditions are independent.
+//
+// The mux tree should then be balanced by other MuxOp patterns.
+struct OrOfMuxToMuxChain : public OpRewritePattern<OrOp> {
+  using OpRewritePattern<OrOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OrOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op.getTwoState()) {
+      return failure();
+    }
+
+    SmallVector<MuxOp> muxes = llvm::map_to_vector(
+        op.getOperands(), [](Value v) { return v.getDefiningOp<MuxOp>(); });
+    if (llvm::find(muxes, nullptr) != muxes.end()) {
+      return failure();
+    }
+
+    SmallVector<Value> conditions;
+    for (MuxOp mux : muxes) {
+      if (!mux.getTwoState() ||
+          !matchPattern(mux.getFalseValue(), mlir::m_Zero())) {
+        return failure();
+      }
+      conditions.push_back(mux.getCond());
+    }
+
+    if (!areConditionsIndependent(conditions)) {
+      return failure();
+    }
+
+    // Construct the mux chain from back to front.
+    SmallVector<Value> values(op.getOperands().drop_back());
+    Value v = op.getOperands().back();
+    while (!values.empty()) {
+      auto mux = values.pop_back_val().getDefiningOp<comb::MuxOp>();
+      v = comb::MuxOp::create(rewriter, op.getLoc(), mux.getCond(),
+                              mux.getTrueValue(), v, /*twoState=*/true);
+    }
+    replaceOpAndCopyNamehint(rewriter, op, v);
+    return success();
+  }
+
+  // Returns true if the given i1 conditions are independent. That is, at most
+  // one condition can be true at a time.
+  //
+  // Currently we take a shortcut and check if the conditions are defined by
+  // ICmpEqs for different values. This is a common pattern in priority
+  // encoders.
+  bool areConditionsIndependent(ArrayRef<Value> conditions) const {
+    DenseSet<APInt> seenConstants;
+    for (Value v : conditions) {
+      auto icmp = v.getDefiningOp<ICmpOp>();
+      APInt value;
+      if (!icmp || icmp.getPredicate() != ICmpPredicate::eq ||
+          !matchPattern(icmp.getRhs(), mlir::m_ConstantInt(&value))) {
+        return false;
+      }
+
+      if (!seenConstants.insert(value).second) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
 /// Pass that performs enhanced mux chain optimizations
 struct BalanceMuxPass : public impl::BalanceMuxBase<BalanceMuxPass> {
   using BalanceMuxBase::BalanceMuxBase;
@@ -248,6 +316,7 @@ struct BalanceMuxPass : public impl::BalanceMuxBase<BalanceMuxPass> {
     RewritePatternSet patterns(context);
     patterns.add<MuxChainWithComparison, PriorityMuxReshape>(context,
                                                              muxChainThreshold);
+    patterns.add<OrOfMuxToMuxChain>(context);
 
     if (failed(applyPatternsGreedily(op, std::move(patterns))))
       return signalPassFailure();

--- a/lib/Dialect/Comb/Transforms/BalanceMux.cpp
+++ b/lib/Dialect/Comb/Transforms/BalanceMux.cpp
@@ -246,28 +246,21 @@ struct OrOfMuxToMuxChain : public OpRewritePattern<OrOp> {
 
   LogicalResult matchAndRewrite(OrOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!op.getTwoState()) {
+    if (!op.getTwoState())
       return failure();
-    }
-
-    SmallVector<MuxOp> muxes = llvm::map_to_vector(
-        op.getOperands(), [](Value v) { return v.getDefiningOp<MuxOp>(); });
-    if (llvm::find(muxes, nullptr) != muxes.end()) {
-      return failure();
-    }
 
     SmallVector<Value> conditions;
-    for (MuxOp mux : muxes) {
-      if (!mux.getTwoState() ||
-          !matchPattern(mux.getFalseValue(), mlir::m_Zero())) {
+    for (Value operand : op.getOperands()) {
+      MuxOp mux = operand.getDefiningOp<MuxOp>();
+      if (!mux || !mux.getTwoState() ||
+          !matchPattern(mux.getFalseValue(), mlir::m_Zero()))
         return failure();
-      }
+
       conditions.push_back(mux.getCond());
     }
 
-    if (!areConditionsIndependent(conditions)) {
+    if (!areConditionsIndependent(conditions))
       return failure();
-    }
 
     // Construct the mux chain from back to front.
     SmallVector<Value> values(op.getOperands().drop_back());
@@ -288,18 +281,16 @@ struct OrOfMuxToMuxChain : public OpRewritePattern<OrOp> {
   // ICmpEqs for different values. This is a common pattern in priority
   // encoders.
   bool areConditionsIndependent(ArrayRef<Value> conditions) const {
-    DenseSet<APInt> seenConstants;
+    DenseSet<IntegerAttr> seenConstants;
     for (Value v : conditions) {
       auto icmp = v.getDefiningOp<ICmpOp>();
-      APInt value;
+      IntegerAttr value;
       if (!icmp || icmp.getPredicate() != ICmpPredicate::eq ||
-          !matchPattern(icmp.getRhs(), mlir::m_ConstantInt(&value))) {
+          !matchPattern(icmp.getRhs(), mlir::m_Constant(&value)))
         return false;
-      }
 
-      if (!seenConstants.insert(value).second) {
+      if (!seenConstants.insert(value).second)
         return false;
-      }
     }
     return true;
   }

--- a/test/Dialect/Comb/balance-mux-or.mlir
+++ b/test/Dialect/Comb/balance-mux-or.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-opt %s -comb-balance-mux | FileCheck %s
+
+// CHECK-LABEL: hw.module @OrOfMuxes
+// CHECK: %[[C0:.*]] = comb.icmp eq %c, %c0_i4
+// CHECK: %[[C1:.*]] = comb.icmp eq %c, %c1_i4
+// CHECK: %[[X:.*]] = comb.mux bin %[[C1]], %a1, %c0_i4
+// CHECK: %[[Y:.*]] = comb.mux bin %[[C0]], %a0, %[[X]]
+// CHECK: hw.output %[[Y]]
+hw.module @OrOfMuxes(in %c: i4, in %a0: i4, in %a1: i4, out y: i4) {
+  %cst0_i4 = hw.constant 0 : i4
+  %cst1_i4 = hw.constant 1 : i4
+  %c0 = comb.icmp eq %c, %cst0_i4 : i4
+  %c1 = comb.icmp eq %c, %cst1_i4 : i4
+  %m0 = comb.mux bin %c0, %a0, %cst0_i4 : i4
+  %m1 = comb.mux bin %c1, %a1, %cst0_i4 : i4
+  %or = comb.or bin %m0, %m1 : i4
+  hw.output %or : i4
+}
+
+// CHECK-LABEL: hw.module @OrOfMuxesNot2State
+// CHECK: comb.or
+hw.module @OrOfMuxesNot2State(in %c0: i1, in %c1: i1, in %a0: i4, in %a1: i4, out y: i4) {
+  %c0_i4 = hw.constant 0 : i4
+  %m0 = comb.mux %c0, %a0, %c0_i4 : i4
+  %m1 = comb.mux %c1, %a1, %c0_i4 : i4
+  %or = comb.or %m0, %m1 : i4
+  hw.output %or : i4
+}
+
+// CHECK-LABEL: hw.module @OrOfMuxesNotGuaranteedIndependent
+// CHECK: comb.or
+hw.module @OrOfMuxesNotGuaranteedIndependent(in %c0: i1, in %c1: i1, in %a0: i4, in %a1: i4, out y: i4) {
+  %c0_i4 = hw.constant 0 : i4
+  %m0 = comb.mux bin %c0, %a0, %c0_i4 : i4
+  %m1 = comb.mux bin %c1, %a1, %c0_i4 : i4
+  %or = comb.or %m0, %m1 : i4
+  hw.output %or : i4
+}

--- a/test/Dialect/Comb/balance-mux.mlir
+++ b/test/Dialect/Comb/balance-mux.mlir
@@ -144,30 +144,3 @@ hw.module @test_min_conditions_2(in %cond0: i1, in %cond1: i1, in %cond2: i1, ou
 
   hw.output %mux1 : i32
 }
-
-// CHECK-LABEL: hw.module @OrOfMuxes
-// CHECK: %[[C0:.*]] = comb.icmp eq %c, %c0_i4
-// CHECK: %[[C1:.*]] = comb.icmp eq %c, %c1_i4
-// CHECK: %[[X:.*]] = comb.mux bin %[[C1]], %a1, %c0_i4
-// CHECK: %[[Y:.*]] = comb.mux bin %[[C0]], %a0, %[[X]]
-// CHECK: hw.output %[[Y]]
-hw.module @OrOfMuxes(in %c: i4, in %a0: i4, in %a1: i4, out y: i4) {
-  %cst0_i4 = hw.constant 0 : i4
-  %cst1_i4 = hw.constant 1 : i4
-  %c0 = comb.icmp eq %c, %cst0_i4 : i4
-  %c1 = comb.icmp eq %c, %cst1_i4 : i4
-  %m0 = comb.mux bin %c0, %a0, %cst0_i4 : i4
-  %m1 = comb.mux bin %c1, %a1, %cst0_i4 : i4
-  %or = comb.or bin %m0, %m1 : i4
-  hw.output %or : i4
-}
-
-// CHECK-LABEL: hw.module @OrOfMuxesNot2State
-// CHECK: comb.or
-hw.module @OrOfMuxesNot2State(in %c0: i1, in %c1: i1, in %a0: i4, in %a1: i4, out y: i4) {
-  %c0_i4 = hw.constant 0 : i4
-  %m0 = comb.mux %c0, %a0, %c0_i4 : i4
-  %m1 = comb.mux %c1, %a1, %c0_i4 : i4
-  %or = comb.or %m0, %m1 : i4
-  hw.output %or : i4
-}

--- a/test/Dialect/Comb/balance-mux.mlir
+++ b/test/Dialect/Comb/balance-mux.mlir
@@ -144,3 +144,30 @@ hw.module @test_min_conditions_2(in %cond0: i1, in %cond1: i1, in %cond2: i1, ou
 
   hw.output %mux1 : i32
 }
+
+// CHECK-LABEL: hw.module @OrOfMuxes
+// CHECK: %[[C0:.*]] = comb.icmp eq %c, %c0_i4
+// CHECK: %[[C1:.*]] = comb.icmp eq %c, %c1_i4
+// CHECK: %[[X:.*]] = comb.mux bin %[[C1]], %a1, %c0_i4
+// CHECK: %[[Y:.*]] = comb.mux bin %[[C0]], %a0, %[[X]]
+// CHECK: hw.output %[[Y]]
+hw.module @OrOfMuxes(in %c: i4, in %a0: i4, in %a1: i4, out y: i4) {
+  %cst0_i4 = hw.constant 0 : i4
+  %cst1_i4 = hw.constant 1 : i4
+  %c0 = comb.icmp eq %c, %cst0_i4 : i4
+  %c1 = comb.icmp eq %c, %cst1_i4 : i4
+  %m0 = comb.mux bin %c0, %a0, %cst0_i4 : i4
+  %m1 = comb.mux bin %c1, %a1, %cst0_i4 : i4
+  %or = comb.or bin %m0, %m1 : i4
+  hw.output %or : i4
+}
+
+// CHECK-LABEL: hw.module @OrOfMuxesNot2State
+// CHECK: comb.or
+hw.module @OrOfMuxesNot2State(in %c0: i1, in %c1: i1, in %a0: i4, in %a1: i4, out y: i4) {
+  %c0_i4 = hw.constant 0 : i4
+  %m0 = comb.mux %c0, %a0, %c0_i4 : i4
+  %m1 = comb.mux %c1, %a1, %c0_i4 : i4
+  %or = comb.or %m0, %m1 : i4
+  hw.output %or : i4
+}

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -2128,3 +2128,44 @@ hw.module private @SextMatcherBlockArguments(in %a : i6, in %b : i2, in %c : i27
   %3 = comb.extract %1 from 26 : (i35) -> i1
   hw.output
 }
+
+// CHECK-LABEL: hw.module @AndOfReplicate
+// CHECK: %c0_i4 = hw.constant 0 : i4
+// CHECK: %[[X:.*]] = comb.mux bin %p, %x, %c0_i4
+// CHECK: hw.output %[[X]]
+hw.module @AndOfReplicate(in %p: i1, in %x: i4, out y: i4) {
+  %r = comb.replicate %p : (i1) -> i4
+  %and = comb.and bin %x, %r : i4
+  hw.output %and : i4
+}
+
+// CHECK-LABEL: hw.module @AndOfReplicateNot2State
+// CHECK: comb.replicate
+// CHECK: comb.and
+hw.module @AndOfReplicateNot2State(in %p: i1, in %x: i4, out y: i4) {
+  %r = comb.replicate %p : (i1) -> i4
+  %and = comb.and %x, %r : i4
+  hw.output %and : i4
+}
+
+// CHECK-LABEL: hw.module @OrOfMuxes
+// CHECK: %[[X:.*]] = comb.mux bin %c1, %a1, %c0_i4
+// CHECK: %[[Y:.*]] = comb.mux bin %c0, %a0, %[[X]]
+// CHECK: hw.output %[[Y]]
+hw.module @OrOfMuxes(in %c0: i1, in %c1: i1, in %a0: i4, in %a1: i4, out y: i4) {
+  %c0_i4 = hw.constant 0 : i4
+  %m0 = comb.mux bin %c0, %a0, %c0_i4 : i4
+  %m1 = comb.mux bin %c1, %a1, %c0_i4 : i4
+  %or = comb.or bin %m0, %m1 : i4
+  hw.output %or : i4
+}
+
+// CHECK-LABEL: hw.module @OrOfMuxesNot2State
+// CHECK: comb.or
+hw.module @OrOfMuxesNot2State(in %c0: i1, in %c1: i1, in %a0: i4, in %a1: i4, out y: i4) {
+  %c0_i4 = hw.constant 0 : i4
+  %m0 = comb.mux %c0, %a0, %c0_i4 : i4
+  %m1 = comb.mux %c1, %a1, %c0_i4 : i4
+  %or = comb.or %m0, %m1 : i4
+  hw.output %or : i4
+}

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -420,7 +420,7 @@ hw.module @compareExtractFold(in %arg0 : i8, out o1: i1, out o2: i1, out o3: i1)
   %c3_i8 = hw.constant 3 : i8
   %0 = comb.icmp ugt %arg0, %c3_i8 : i8
   // CHECK: %0 = comb.extract %arg0 from 2 : (i8) -> i6
-  // CHECK: %1 = comb.icmp ne %0, %c0_i6 : i6 
+  // CHECK: %1 = comb.icmp ne %0, %c0_i6 : i6
 
   // x < 0b11000000 -> extract(x, 6..8) != 0b11
   %c192_i8 = hw.constant 192 : i8
@@ -723,7 +723,7 @@ hw.module @extract_from_replicate(in %x: i8, out r0: i16, out r1: i4, out r2: i8
   // CHECK-NEXT: %3 = comb.extract %0 from 2 : (i24) -> i8
   %r3 = comb.extract %0 from 2 : (i24) -> i8
 
-  // CHECK-NEXT: hw.output %1, %2, %3 : 
+  // CHECK-NEXT: hw.output %1, %2, %3 :
   hw.output %r1, %r2, %r3 : i16, i4, i8
 }
 
@@ -742,7 +742,7 @@ hw.module @narrow_extract_from_and(in %arg0 : i32, out o1: i8, out o2: i14, out 
 
   %c42_i32 = hw.constant 42 : i32  // 0b101010
   %3 = comb.and %arg0, %c42_i32 : i32
-  %4 = comb.extract %3 from 1 : (i32) -> i8  
+  %4 = comb.extract %3 from 1 : (i32) -> i8
   // CHECK: %3 = comb.extract %arg0 from 1 : (i32) -> i5
   // CHECK: %4 = comb.and %3, %c-11_i5 : i5
   // CHECK: %5 = comb.concat %c0_i3, %4 : i3, i5
@@ -752,7 +752,7 @@ hw.module @narrow_extract_from_and(in %arg0 : i32, out o1: i8, out o2: i14, out 
   %6 = comb.and %5, %c12_i8 : i8
   // CHECK: %6 = comb.extract %arg0 from 25 : (i32) -> i2
   // CHECK: %7 = comb.concat %c0_i4, %6, %c0_i2 : i4, i2, i2
- 
+
   hw.output %1, %2, %4, %6 : i8, i14, i8, i8
   // CHECK: hw.output %1, %2, %5, %7 : i8, i14, i8, i8
 }
@@ -1407,7 +1407,7 @@ hw.module @muxCommon(in %cond: i1, in %cond2: i1, in %cond3: i1,
   // CHECK: [[O6:%.*]] = comb.mux [[CONDS]], %arg0, %arg1 : i32
   %0 = comb.mux %cond, %arg0, %arg1 : i32
   %o6 = comb.mux %cond2, %arg0, %0 : i32
-  
+
   // CHECK: [[CONDS:%.*]] = comb.and %cond2, %cond : i1
   // CHECK: [[O7:%.*]] = comb.mux [[CONDS]], %arg1, %arg0 : i32
   %1 = comb.mux %cond, %arg1, %arg0 : i32
@@ -1475,22 +1475,22 @@ hw.module @muxCommonOp(in %cond: i1,
   %0 = comb.concat %allones, %arg1, %arg2, %arg3 : i32, i32, i32, i32
   %1 = comb.concat %arg0, %arg2, %arg2, %arg3 : i32, i32, i32, i32
   %o1 = comb.mux %cond, %0, %1 : i128
-  // CHECK: %0 = comb.concat %c-1_i32, %arg1 : i32, i32 
-  // CHECK: %1 = comb.concat %arg0, %arg2 : i32, i32 
-  // CHECK: %2 = comb.mux %cond, %0, %1 : i64 
-  // CHECK: [[O1:%.*]] = comb.concat %2, %arg2, %arg3 : i64, i32, i32 
+  // CHECK: %0 = comb.concat %c-1_i32, %arg1 : i32, i32
+  // CHECK: %1 = comb.concat %arg0, %arg2 : i32, i32
+  // CHECK: %2 = comb.mux %cond, %0, %1 : i64
+  // CHECK: [[O1:%.*]] = comb.concat %2, %arg2, %arg3 : i64, i32, i32
 
   %2 = comb.concat %allones, %arg1, %arg2, %arg3 : i32, i32, i32, i32
   %3 = comb.concat %allones, %arg1, %arg2, %arg3 : i32, i32, i32, i32
   %o2 = comb.mux %cond, %2, %3 : i128
-  // CHECK: [[O2:%.*]] = comb.concat %c-1_i32, %arg1, %arg2, %arg3 : i32, i32, i32, i32 
+  // CHECK: [[O2:%.*]] = comb.concat %c-1_i32, %arg1, %arg2, %arg3 : i32, i32, i32, i32
 
   %4 = comb.concat %allones, %arg1, %arg2, %arg3 : i32, i32, i32, i32
   %5 = comb.concat %allones, %arg2, %arg2, %arg3 : i32, i32, i32, i32
   %o3 = comb.mux %cond, %4, %5 : i128
-  // CHECK: [[M3:%.*]] = comb.mux %cond, %arg1, %arg2 : i32 
-  // CHECK: [[O3:%.*]] = comb.concat %c-1_i32, [[M3]], %arg2, %arg3 : i32, i32, i32, i32 
- 
+  // CHECK: [[M3:%.*]] = comb.mux %cond, %arg1, %arg2 : i32
+  // CHECK: [[O3:%.*]] = comb.concat %c-1_i32, [[M3]], %arg2, %arg3 : i32, i32, i32, i32
+
   // CHECK: hw.output [[O1]], [[O2]], [[O3]]
   hw.output %o1, %o2, %o3 : i128, i128, i128
 }
@@ -1575,12 +1575,12 @@ hw.module @MuxSimplify(in %index: i1, in %a: i1, in %foo_0: i2, in %foo_1: i2, o
   %4 = comb.mux bin %a, %1, %3 : i2
   %5 = comb.mux bin %index, %c-2_i2, %foo_1 : i2
   %6 = comb.mux bin %a, %2, %5 : i2
-  
+
   %7 = comb.mux bin %a, %foo_0, %foo_1 : i2
   %8 = comb.mux bin %index, %foo_0, %foo_1 : i2
   %9 = comb.xor %a, %index : i1
   %10 = comb.mux bin %9, %7, %8 : i2
-  
+
   %11 = comb.mux bin %index, %foo_0, %foo_1 : i2
   %12 = comb.mux bin %a, %foo_0, %11 : i2
 
@@ -1599,9 +1599,9 @@ hw.module @MuxSimplify(in %index: i1, in %a: i1, in %foo_0: i2, in %foo_1: i2, o
 // CHECK-NEXT:  %1 = comb.mux bin %index, %foo_0, %0 : i2
 // CHECK-NEXT:  %2 = comb.mux %a, %c1_i2, %c-2_i2 : i2
 // CHECK-NEXT:  %3 = comb.mux bin %index, %2, %foo_1 : i2
-// CHECK-NEXT:  %4 = comb.xor %a, %index : i1 
-// CHECK-NEXT:  %5 = comb.mux %4, %a, %index : i1 
-// CHECK-NEXT:  %6 = comb.mux bin %5, %foo_0, %foo_1 : i2 
+// CHECK-NEXT:  %4 = comb.xor %a, %index : i1
+// CHECK-NEXT:  %5 = comb.mux %4, %a, %index : i1
+// CHECK-NEXT:  %6 = comb.mux bin %5, %foo_0, %foo_1 : i2
 // CHECK-NEXT:  %7 = comb.or %a, %index : i1
 // CHECK-NEXT:  %8 = comb.mux bin %7, %foo_0, %foo_1 : i2
 // CHECK-NEXT:  %9 = comb.or %a, %index : i1
@@ -2146,26 +2146,4 @@ hw.module @AndOfReplicateNot2State(in %p: i1, in %x: i4, out y: i4) {
   %r = comb.replicate %p : (i1) -> i4
   %and = comb.and %x, %r : i4
   hw.output %and : i4
-}
-
-// CHECK-LABEL: hw.module @OrOfMuxes
-// CHECK: %[[X:.*]] = comb.mux bin %c1, %a1, %c0_i4
-// CHECK: %[[Y:.*]] = comb.mux bin %c0, %a0, %[[X]]
-// CHECK: hw.output %[[Y]]
-hw.module @OrOfMuxes(in %c0: i1, in %c1: i1, in %a0: i4, in %a1: i4, out y: i4) {
-  %c0_i4 = hw.constant 0 : i4
-  %m0 = comb.mux bin %c0, %a0, %c0_i4 : i4
-  %m1 = comb.mux bin %c1, %a1, %c0_i4 : i4
-  %or = comb.or bin %m0, %m1 : i4
-  hw.output %or : i4
-}
-
-// CHECK-LABEL: hw.module @OrOfMuxesNot2State
-// CHECK: comb.or
-hw.module @OrOfMuxesNot2State(in %c0: i1, in %c1: i1, in %a0: i4, in %a1: i4, out y: i4) {
-  %c0_i4 = hw.constant 0 : i4
-  %m0 = comb.mux %c0, %a0, %c0_i4 : i4
-  %m1 = comb.mux %c1, %a1, %c0_i4 : i4
-  %or = comb.or %m0, %m1 : i4
-  hw.output %or : i4
 }

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -420,7 +420,7 @@ hw.module @compareExtractFold(in %arg0 : i8, out o1: i1, out o2: i1, out o3: i1)
   %c3_i8 = hw.constant 3 : i8
   %0 = comb.icmp ugt %arg0, %c3_i8 : i8
   // CHECK: %0 = comb.extract %arg0 from 2 : (i8) -> i6
-  // CHECK: %1 = comb.icmp ne %0, %c0_i6 : i6
+  // CHECK: %1 = comb.icmp ne %0, %c0_i6 : i6 
 
   // x < 0b11000000 -> extract(x, 6..8) != 0b11
   %c192_i8 = hw.constant 192 : i8
@@ -723,7 +723,7 @@ hw.module @extract_from_replicate(in %x: i8, out r0: i16, out r1: i4, out r2: i8
   // CHECK-NEXT: %3 = comb.extract %0 from 2 : (i24) -> i8
   %r3 = comb.extract %0 from 2 : (i24) -> i8
 
-  // CHECK-NEXT: hw.output %1, %2, %3 :
+  // CHECK-NEXT: hw.output %1, %2, %3 : 
   hw.output %r1, %r2, %r3 : i16, i4, i8
 }
 
@@ -742,7 +742,7 @@ hw.module @narrow_extract_from_and(in %arg0 : i32, out o1: i8, out o2: i14, out 
 
   %c42_i32 = hw.constant 42 : i32  // 0b101010
   %3 = comb.and %arg0, %c42_i32 : i32
-  %4 = comb.extract %3 from 1 : (i32) -> i8
+  %4 = comb.extract %3 from 1 : (i32) -> i8  
   // CHECK: %3 = comb.extract %arg0 from 1 : (i32) -> i5
   // CHECK: %4 = comb.and %3, %c-11_i5 : i5
   // CHECK: %5 = comb.concat %c0_i3, %4 : i3, i5
@@ -752,7 +752,7 @@ hw.module @narrow_extract_from_and(in %arg0 : i32, out o1: i8, out o2: i14, out 
   %6 = comb.and %5, %c12_i8 : i8
   // CHECK: %6 = comb.extract %arg0 from 25 : (i32) -> i2
   // CHECK: %7 = comb.concat %c0_i4, %6, %c0_i2 : i4, i2, i2
-
+ 
   hw.output %1, %2, %4, %6 : i8, i14, i8, i8
   // CHECK: hw.output %1, %2, %5, %7 : i8, i14, i8, i8
 }
@@ -1407,7 +1407,7 @@ hw.module @muxCommon(in %cond: i1, in %cond2: i1, in %cond3: i1,
   // CHECK: [[O6:%.*]] = comb.mux [[CONDS]], %arg0, %arg1 : i32
   %0 = comb.mux %cond, %arg0, %arg1 : i32
   %o6 = comb.mux %cond2, %arg0, %0 : i32
-
+  
   // CHECK: [[CONDS:%.*]] = comb.and %cond2, %cond : i1
   // CHECK: [[O7:%.*]] = comb.mux [[CONDS]], %arg1, %arg0 : i32
   %1 = comb.mux %cond, %arg1, %arg0 : i32
@@ -1475,22 +1475,22 @@ hw.module @muxCommonOp(in %cond: i1,
   %0 = comb.concat %allones, %arg1, %arg2, %arg3 : i32, i32, i32, i32
   %1 = comb.concat %arg0, %arg2, %arg2, %arg3 : i32, i32, i32, i32
   %o1 = comb.mux %cond, %0, %1 : i128
-  // CHECK: %0 = comb.concat %c-1_i32, %arg1 : i32, i32
-  // CHECK: %1 = comb.concat %arg0, %arg2 : i32, i32
-  // CHECK: %2 = comb.mux %cond, %0, %1 : i64
-  // CHECK: [[O1:%.*]] = comb.concat %2, %arg2, %arg3 : i64, i32, i32
+  // CHECK: %0 = comb.concat %c-1_i32, %arg1 : i32, i32 
+  // CHECK: %1 = comb.concat %arg0, %arg2 : i32, i32 
+  // CHECK: %2 = comb.mux %cond, %0, %1 : i64 
+  // CHECK: [[O1:%.*]] = comb.concat %2, %arg2, %arg3 : i64, i32, i32 
 
   %2 = comb.concat %allones, %arg1, %arg2, %arg3 : i32, i32, i32, i32
   %3 = comb.concat %allones, %arg1, %arg2, %arg3 : i32, i32, i32, i32
   %o2 = comb.mux %cond, %2, %3 : i128
-  // CHECK: [[O2:%.*]] = comb.concat %c-1_i32, %arg1, %arg2, %arg3 : i32, i32, i32, i32
+  // CHECK: [[O2:%.*]] = comb.concat %c-1_i32, %arg1, %arg2, %arg3 : i32, i32, i32, i32 
 
   %4 = comb.concat %allones, %arg1, %arg2, %arg3 : i32, i32, i32, i32
   %5 = comb.concat %allones, %arg2, %arg2, %arg3 : i32, i32, i32, i32
   %o3 = comb.mux %cond, %4, %5 : i128
-  // CHECK: [[M3:%.*]] = comb.mux %cond, %arg1, %arg2 : i32
-  // CHECK: [[O3:%.*]] = comb.concat %c-1_i32, [[M3]], %arg2, %arg3 : i32, i32, i32, i32
-
+  // CHECK: [[M3:%.*]] = comb.mux %cond, %arg1, %arg2 : i32 
+  // CHECK: [[O3:%.*]] = comb.concat %c-1_i32, [[M3]], %arg2, %arg3 : i32, i32, i32, i32 
+ 
   // CHECK: hw.output [[O1]], [[O2]], [[O3]]
   hw.output %o1, %o2, %o3 : i128, i128, i128
 }
@@ -1575,12 +1575,12 @@ hw.module @MuxSimplify(in %index: i1, in %a: i1, in %foo_0: i2, in %foo_1: i2, o
   %4 = comb.mux bin %a, %1, %3 : i2
   %5 = comb.mux bin %index, %c-2_i2, %foo_1 : i2
   %6 = comb.mux bin %a, %2, %5 : i2
-
+  
   %7 = comb.mux bin %a, %foo_0, %foo_1 : i2
   %8 = comb.mux bin %index, %foo_0, %foo_1 : i2
   %9 = comb.xor %a, %index : i1
   %10 = comb.mux bin %9, %7, %8 : i2
-
+  
   %11 = comb.mux bin %index, %foo_0, %foo_1 : i2
   %12 = comb.mux bin %a, %foo_0, %11 : i2
 
@@ -1599,9 +1599,9 @@ hw.module @MuxSimplify(in %index: i1, in %a: i1, in %foo_0: i2, in %foo_1: i2, o
 // CHECK-NEXT:  %1 = comb.mux bin %index, %foo_0, %0 : i2
 // CHECK-NEXT:  %2 = comb.mux %a, %c1_i2, %c-2_i2 : i2
 // CHECK-NEXT:  %3 = comb.mux bin %index, %2, %foo_1 : i2
-// CHECK-NEXT:  %4 = comb.xor %a, %index : i1
-// CHECK-NEXT:  %5 = comb.mux %4, %a, %index : i1
-// CHECK-NEXT:  %6 = comb.mux bin %5, %foo_0, %foo_1 : i2
+// CHECK-NEXT:  %4 = comb.xor %a, %index : i1 
+// CHECK-NEXT:  %5 = comb.mux %4, %a, %index : i1 
+// CHECK-NEXT:  %6 = comb.mux bin %5, %foo_0, %foo_1 : i2 
 // CHECK-NEXT:  %7 = comb.or %a, %index : i1
 // CHECK-NEXT:  %8 = comb.mux bin %7, %foo_0, %foo_1 : i2
 // CHECK-NEXT:  %9 = comb.or %a, %index : i1


### PR DESCRIPTION
  1) and(x, replicate(p : i1)) -> mux(p, x, zero)
  2) or(mux(c_0, a_0, zero), mux(c_1, a_1, zero), ...) ->
       mux(c_0, a_0, mux(c_1, a_1, ...))

Generally, forming muxes is good because mux chains can be analyzed,
balanced, and folded further.

In (2) I create a simple right-leaning linear tree and expect the MuxOp
canonicalizers to clean it up and balance it.

Both of these canonicalizations are only valid in two state mode.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
