### PR TITLE
[Arc] Consider clocked DPI calls as arc-breaking in SplitLoops

### DIFF
--- a/include/circt/Dialect/Sim/SimDialect.td
+++ b/include/circt/Dialect/Sim/SimDialect.td
@@ -24,7 +24,10 @@ def SimDialect : Dialect {
     The `sim` dialect is intented to model simulator-specific operations.
   }];
 
-  let dependentDialects = ["circt::hw::HWDialect"];
+  let dependentDialects = [
+    "circt::hw::HWDialect",
+    "circt::seq::SeqDialect"
+  ];
 
   let useDefaultAttributePrinterParser = 0;
   let useDefaultTypePrinterParser = 1;

--- a/lib/Dialect/Arc/Transforms/SplitLoops.cpp
+++ b/lib/Dialect/Arc/Transforms/SplitLoops.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/Arc/ArcOps.h"
 #include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Sim/SimOps.h"
 #include "circt/Support/Namespace.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -226,8 +227,9 @@ void SplitLoopsPass::runOnOperation() {
     allArcUses.insert(callOp);
 
     auto clockedOp = dyn_cast<ClockedOpInterface>(callOp.getOperation());
+    auto dpiCallOp = dyn_cast<sim::DPICallOp>(callOp.getOperation());
     if ((!clockedOp || clockedOp.getLatency() == 0) &&
-        callOp->getNumResults() > 1)
+        (!dpiCallOp || !dpiCallOp.getClock()) && callOp->getNumResults() > 1)
       arcsToSplit.insert(defOp);
 
     return WalkResult::advance();
@@ -407,6 +409,9 @@ LogicalResult SplitLoopsPass::ensureNoLoops() {
       if (auto clockedOp = dyn_cast<ClockedOpInterface>(def);
           clockedOp && clockedOp.getLatency() > 0)
         continue;
+      if (auto dpiCallOp = dyn_cast<sim::DPICallOp>(def))
+        if (dpiCallOp.getClock())
+          continue;
       if (!seen.insert(def).second) {
         auto d = def->emitError(
             "loop splitting did not eliminate all loops; loop detected");

--- a/lib/Dialect/Sim/SimDialect.cpp
+++ b/lib/Dialect/Sim/SimDialect.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/Sim/SimDialect.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
 #include "circt/Dialect/Sim/SimOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"

--- a/test/Dialect/Arc/split-loops-errors.mlir
+++ b/test/Dialect/Arc/split-loops-errors.mlir
@@ -16,3 +16,24 @@ arc.define @UnbreakableLoopArc(%arg0: i4, %arg1: i4) -> (i4, i4) {
   }
   arc.output %0#0, %0#1 : i4, i4
 }
+
+// -----
+// An unclocked `sim.func.dpi.call` is not arc-breaking and must not be allowed
+// to hide a feedback loop through arcs.
+
+sim.func.dpi @UnclockedDpi(in %arg0: i4, return ret: i4)
+
+hw.module @UnclockedDpiNoBreakLoop(in %a: i4, out x: i4, out y: i4) {
+  // expected-error @below {{loop splitting did not eliminate all loops; loop detected}}
+  // expected-note @below {{through operand 0 here:}}
+  %1 = sim.func.dpi.call @UnclockedDpi(%0#0) : (i4) -> i4
+  // expected-note @below {{through operand 1 here:}}
+  %0:2 = arc.call @UnclockedDpiArc(%a, %1) : (i4, i4) -> (i4, i4)
+  hw.output %0#0, %0#1 : i4, i4
+}
+
+arc.define @UnclockedDpiArc(%arg0: i4, %arg1: i4) -> (i4, i4) {
+  %0 = comb.add %arg0, %arg1 : i4
+  %1 = comb.mul %arg1, %arg0 : i4
+  arc.output %0, %1 : i4, i4
+}

--- a/test/Dialect/Arc/split-loops.mlir
+++ b/test/Dialect/Arc/split-loops.mlir
@@ -210,3 +210,30 @@ func.func @UnrelatedCaller() {
   %res:2 = call @UnrelatedCallee() : () -> (i1, i1)
   return
 }
+
+//===----------------------------------------------------------------------===//
+// A clocked `sim.func.dpi.call` is arc-breaking and should be allowed to sit
+// on a feedback path between split arcs without triggering loop detection.
+
+sim.func.dpi @ClockedDpi(in %arg0: i4, return ret: i4)
+
+// CHECK-LABEL: hw.module @ClockedDpiBreaksLoop(
+hw.module @ClockedDpiBreaksLoop(in %clk: !seq.clock, in %a: i4, out x: i4, out y: i4) {
+  // CHECK-NEXT: [[X:%.+]] = arc.call @ClockedDpiArc_split_0(%a, [[D:%.+]]) :
+  // CHECK-NEXT: [[Y:%.+]] = arc.call @ClockedDpiArc_split_1([[D]], %a) :
+  // CHECK-NEXT: [[D]] = sim.func.dpi.call @ClockedDpi([[X]]) clock %clk
+  // CHECK-NEXT: hw.output [[X]], [[Y]]
+  %0:2 = arc.call @ClockedDpiArc(%a, %1) : (i4, i4) -> (i4, i4)
+  %1 = sim.func.dpi.call @ClockedDpi(%0#0) clock %clk : (i4) -> i4
+  hw.output %0#0, %0#1 : i4, i4
+}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: arc.define @ClockedDpiArc_split_0
+// CHECK-LABEL: arc.define @ClockedDpiArc_split_1
+// CHECK-NOT:   arc.define @ClockedDpiArc(
+arc.define @ClockedDpiArc(%arg0: i4, %arg1: i4) -> (i4, i4) {
+  %0 = comb.add %arg0, %arg1 : i4
+  %1 = comb.mul %arg1, %arg0 : i4
+  arc.output %0, %1 : i4, i4
+}


### PR DESCRIPTION
The Arc dialect currently doesn't have a clean way to reason about whether ops from other dialects are clocked or not. It only has a `ClockedOpInterface` for Arc ops, which we could eventually extend to provide implementations for other dialects. Or we may want to convert some of these ops into an Arc-native flavor of the op.

For now, simply add support for DPICallOp.

Also add Seq as a dependent dialect to Sim, since certain Sim ops create `!seq.clock` types on parsing, which can crash the parser if no Seq op or type has been encountered before.

Assisted-by: Claude Opus 4.7