### PR TITLE
[HW] HWVectorization Part 4: Partial Vectorization (Chunking) 

### DIFF
--- a/lib/Dialect/HW/Transforms/HWVectorization.cpp
+++ b/lib/Dialect/HW/Transforms/HWVectorization.cpp
@@ -177,6 +177,12 @@ public:
         }
       }
 
+      // 3. Fallback to Partial Vectorization
+      if (!transformed && canApplyPartialVectorization(oldOutputVal)) {
+        applyPartialVectorization(rewriter, oldOutputVal, bitWidth);
+        transformed = true;
+      }
+
       if (transformed)
         changed = true;
     }
@@ -516,6 +522,84 @@ private:
         rewriter, loc, rewriter.getIntegerType(bitWidth), chunks);
 
     oldOutputVal.replaceAllUsesWith(newVal);
+  }
+
+  /// Checks if all bits of the output have a valid, traceable source
+  /// to allow partial vectorization.
+  bool canApplyPartialVectorization(Value oldOutputVal) {
+    unsigned bitWidth = cast<IntegerType>(oldOutputVal.getType()).getWidth();
+    if (bitWidth <= 1)
+      return false;
+
+    for (unsigned i = 0; i < bitWidth; ++i) {
+      if (!findBitSource(oldOutputVal, i))
+        return false;
+    }
+    return true;
+  }
+
+  /// Applies partial vectorization by grouping adjacent bits from the same
+  /// source into wider ExtractOps, and combining everything with a ConcatOp.
+  void applyPartialVectorization(IRRewriter &rewriter, Value oldOutputVal,
+                                 unsigned bitWidth) {
+    rewriter.setInsertionPointAfterValue(oldOutputVal);
+    Location loc = oldOutputVal.getLoc();
+
+    SmallVector<Value> chunks;
+
+    for (int i = bitWidth - 1; i >= 0;) {
+      Value bitSource = findBitSource(oldOutputVal, i);
+      if (!bitSource)
+        return;
+
+      Operation *sourceOp = bitSource.getDefiningOp();
+      int len = 1;
+
+      if (auto extractOp = dyn_cast_or_null<comb::ExtractOp>(sourceOp)) {
+        // Try to group adjacent bits that come from the exact same input vector
+        while ((i - len) >= 0) {
+          Value nextBitSource = findBitSource(oldOutputVal, i - len);
+          auto nextExtractOp =
+              dyn_cast_or_null<comb::ExtractOp>(nextBitSource.getDefiningOp());
+
+          // Check if the next bit is consecutive
+          if (nextExtractOp &&
+              nextExtractOp.getInput() == extractOp.getInput() &&
+              nextExtractOp.getLowBit() == extractOp.getLowBit() - len) {
+            len++;
+          } else {
+            break;
+          }
+        }
+
+        // Create a single, wider ExtractOp for the grouped bits
+        Value sourceVec = extractOp.getInput();
+        unsigned extractLowBit = extractOp.getLowBit() - (len - 1);
+
+        Value extractedChunk =
+            comb::ExtractOp::create(rewriter, loc, rewriter.getIntegerType(len),
+                                    sourceVec, extractLowBit);
+        chunks.push_back(extractedChunk);
+      } else {
+        // Not an ExtractOp, just push the individual bit
+        chunks.push_back(bitSource);
+      }
+
+      // Move to the next index after the chunk just processed
+      i -= len;
+    }
+
+    // If everything was grouped into a single chunk matching the output width,
+    // a ConcatOp is unnecessary.
+    if (chunks.size() == 1 &&
+        cast<IntegerType>(chunks[0].getType()).getWidth() == bitWidth) {
+      oldOutputVal.replaceAllUsesWith(chunks[0]);
+      return;
+    }
+
+    Value newOutputVal = comb::ConcatOp::create(
+        rewriter, loc, rewriter.getIntegerType(bitWidth), chunks);
+    oldOutputVal.replaceAllUsesWith(newOutputVal);
   }
 
   /// Single walk that handles ExtractOp and ConcatOp using TypeSwitch.

--- a/test/Dialect/HW/vectorization.mlir
+++ b/test/Dialect/HW/vectorization.mlir
@@ -404,3 +404,64 @@ hw.module @structural_and_i2(in %a : i2, in %b : i2, out out : i2) {
   %out = comb.concat %and1, %and0 : i1, i1
   hw.output %out : i2
 }
+
+// ---------- Partial Vectorization (Chunking) ----------
+// Models the scenario where a subset of bits can be grouped into a single extract,
+// while other bits remain as scalar logic. 
+// Bits [3:1] form a linear sequence, while bit 0 is a structural XOR operation.
+
+// CHECK-LABEL: hw.module @partial_vectorization_chunking(
+// CHECK-DAG:     [[CHUNK_1:%.+]] = comb.extract %in from 1 : (i4) -> i3
+// CHECK-DAG:     [[IN_1:%.+]] = comb.extract %in from 1 : (i4) -> i1
+// CHECK-DAG:     [[IN_0:%.+]] = comb.extract %in from 0 : (i4) -> i1
+// CHECK-DAG:     [[BIT_0:%.+]] = comb.xor [[IN_1]], [[IN_0]] : i1
+// CHECK:         [[RES:%.+]] = comb.concat [[CHUNK_1]], [[BIT_0]] : i3, i1
+// CHECK-NEXT:    hw.output [[RES]] : i4
+hw.module @partial_vectorization_chunking(in %in : i4, out out : i4) {
+  // Bits [3:1] linear
+  %in_3 = comb.extract %in from 3 : (i4) -> i1
+  %in_2 = comb.extract %in from 2 : (i4) -> i1
+  %in_1 = comb.extract %in from 1 : (i4) -> i1
+
+  // Logic for bit 0
+  %in_1_for_0 = comb.extract %in from 1 : (i4) -> i1
+  %in_0 = comb.extract %in from 0 : (i4) -> i1
+  %bit_0 = comb.xor %in_1_for_0, %in_0 : i1
+
+  // Final concatenation
+  %concat = comb.concat %in_3, %in_2, %in_1, %bit_0 : i1, i1, i1, i1
+  hw.output %concat : i4
+}
+
+// ---------- Partial Vectorization: Multiple Chunks ----------
+// Tests if the chunking logic correctly handles multiple separate chunks interspersed
+// with scalar logic. Bits [5:4] are a chunk from %A, bit 3 is an AND gate, 
+// and bits [2:0] are a chunk from %B.
+
+// CHECK-LABEL: hw.module @partial_vectorization_multi_chunk(
+// CHECK-DAG:     [[CHUNK_A:%.+]] = comb.extract %A from 0 : (i2) -> i2
+// CHECK-DAG:     [[EXT_A:%.+]] = comb.extract %A from 1 : (i2) -> i1
+// CHECK-DAG:     [[EXT_B:%.+]] = comb.extract %B from 0 : (i5) -> i1
+// CHECK-DAG:     [[SCALAR:%.+]] = comb.and [[EXT_A]], [[EXT_B]] : i1
+// CHECK-DAG:     [[CHUNK_B:%.+]] = comb.extract %B from 2 : (i5) -> i3
+// CHECK:         [[RES:%.+]] = comb.concat [[CHUNK_A]], [[SCALAR]], [[CHUNK_B]] : i2, i1, i3
+// CHECK-NEXT:    hw.output [[RES]] : i6
+hw.module @partial_vectorization_multi_chunk(in %A : i2, in %B : i5, out out : i6) {
+  // Chunk A (bits 5:4) -> A[1:0]
+  %a1 = comb.extract %A from 1 : (i2) -> i1
+  %a0 = comb.extract %A from 0 : (i2) -> i1
+
+  // Scalar logic (bit 3)
+  %A_1 = comb.extract %A from 1 : (i2) -> i1
+  %B_0 = comb.extract %B from 0 : (i5) -> i1
+  %bit_3 = comb.and %A_1, %B_0 : i1
+
+  // Chunk B (bits 2:0) -> B[4:2]
+  %b4 = comb.extract %B from 4 : (i5) -> i1
+  %b3 = comb.extract %B from 3 : (i5) -> i1
+  %b2 = comb.extract %B from 2 : (i5) -> i1
+
+  // Final concatenation
+  %concat = comb.concat %a1, %a0, %bit_3, %b4, %b3, %b2 : i1, i1, i1, i1, i1, i1
+  hw.output %concat : i6
+}


### PR DESCRIPTION
This is the fourth and last part of a series of patches (#9749, #9704, #9739) for the `hw-vectorization` pass. This patch introduces Partial Vectorization (Chunking). This acts as a fallback when an output vector cannot be entirely vectorized using a single pattern.

The pass iterates over un-vectorizable output buses and identifies contiguous sub-ranges (chunks) of bits that share the same vector provenance. It groups these adjacent 1-bit extracts into wider, multi-bit `comb.extract` operations, reducing the fan-in of the final `comb.concat` and cleaning up redundant scalar logic.

**Example:**

In the example below, a tree of scalar logic (masks, shifts, and logic gates) constructs a vector where the top 3 bits are a direct slice of the input (`in[3:1]`), while the `LSB` is a structural `XOR` (`in[1] ^ in[0]`).

The pass identifies the contiguous 3-bit chunk, collapsing the scalar tree into a single `i3` extract, leaving only the necessary scalar logic for the `LSB`.

```mlir
// Before
hw.module @with_logic_gate(in %in : i4, out out : i4) {
  %c0_i2 = hw.constant 0 : i2
  %false = hw.constant false
  %c7_i4 = hw.constant 7 : i4
  %c-5_i4 = hw.constant -5 : i4
  %c0_i3 = hw.constant 0 : i3
  
  // Scalar masking and shifting tree
  %0 = comb.concat %c0_i3, %13 : i3, i1
  %1 = comb.concat %c0_i2, %11, %false : i2, i1, i1
  %2 = comb.or %1, %0 : i4
  %3 = comb.and %2, %c-5_i4 : i4
  %4 = comb.concat %false, %10, %c0_i2 : i1, i1, i2
  %5 = comb.or %4, %3 : i4
  %6 = comb.and %5, %c7_i4 : i4
  %7 = comb.concat %9, %c0_i3 : i1, i3
  %8 = comb.or %7, %6 : i4
  
  // Individual bit extracts
  %9 = comb.extract %in from 3 : (i4) -> i1
  %10 = comb.extract %in from 2 : (i4) -> i1
  %11 = comb.extract %in from 1 : (i4) -> i1
  %12 = comb.extract %in from 0 : (i4) -> i1
  %13 = comb.xor %11, %12 : i1
  
  hw.output %8 : i4
}
```

```mlir
//After
hw.module @with_logic_gate(in %in : i4, out out : i4) {
  // Scalar logic preserved for bit 0
  %0 = comb.extract %in from 1 : (i4) -> i1
  %1 = comb.extract %in from 0 : (i4) -> i1
  %2 = comb.xor %0, %1 : i1
  
  // Bits [3:1] grouped into a single multi-bit chunk
  %3 = comb.extract %in from 1 : (i4) -> i3
  
  // Final simplified concatenation
  %4 = comb.concat %3, %2 : i3, i1
  hw.output %4 : i4
}
````
