### PR TITLE
[Arc] Lower ConstantTimeOp to i64 constant

### DIFF
--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -177,6 +177,46 @@ struct CurrentTimeOpLowering : public OpConversionPattern<arc::CurrentTimeOp> {
   }
 };
 
+// Lower `llhd.constant_time` to an `i64` LLVM constant holding the time in
+// femtoseconds. Time attributes with non-zero delta or epsilon, units smaller
+// than `fs`, or values that overflow `i64` femtoseconds are rejected.
+struct ConstantTimeOpLowering
+    : public OpConversionPattern<llhd::ConstantTimeOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(llhd::ConstantTimeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto attr = op.getValue();
+    if (attr.getDelta() != 0 || attr.getEpsilon() != 0)
+      return rewriter.notifyMatchFailure(
+          op, "non-zero delta or epsilon time components are not supported");
+    uint64_t value = attr.getTime();
+    StringRef unit = attr.getTimeUnit();
+    uint64_t scale;
+    if (unit == "fs")
+      scale = 1;
+    else if (unit == "ps")
+      scale = 1'000ULL;
+    else if (unit == "ns")
+      scale = 1'000'000ULL;
+    else if (unit == "us")
+      scale = 1'000'000'000ULL;
+    else if (unit == "ms")
+      scale = 1'000'000'000'000ULL;
+    else if (unit == "s")
+      scale = 1'000'000'000'000'000ULL;
+    else
+      return rewriter.notifyMatchFailure(
+          op, "time units smaller than `fs` are not supported");
+    if (value > std::numeric_limits<uint64_t>::max() / scale)
+      return rewriter.notifyMatchFailure(
+          op, "time value does not fit into `i64` femtoseconds");
+    rewriter.replaceOpWithNewOp<LLVM::ConstantOp>(op, rewriter.getI64Type(),
+                                                  value * scale);
+    return success();
+  }
+};
+
 // `llhd.int_to_time` is a no-op
 struct IntToTimeOpLowering : public OpConversionPattern<llhd::IntToTimeOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -1417,6 +1457,7 @@ void LowerArcToLLVMPass::runOnOperation() {
     AllocStorageOpLowering,
     ClockGateOpLowering,
     ClockInvOpLowering,
+    ConstantTimeOpLowering,
     CurrentTimeOpLowering,
     IntToTimeOpLowering,
     MemoryReadOpLowering,

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -565,26 +565,21 @@ struct ConvertToArcsPass
 } // namespace
 
 void ConvertToArcsPass::runOnOperation() {
-  // Setup the type conversion.
+  // Pass-through type converter; this pass does not change any types.
   TypeConverter converter;
-
-  // Define legal types.
-  converter.addConversion([](Type type) -> std::optional<Type> {
-    if (isa<llhd::LLHDDialect>(type.getDialect()))
-      return std::nullopt;
-    return type;
-  });
+  converter.addConversion([](Type type) { return type; });
 
   // Gather the conversion patterns.
   ConversionPatternSet patterns(&getContext(), converter);
   patterns.add<llhd::CombinationalOp>(convert);
   patterns.add<llhd::YieldOp>(convert);
 
-  // Setup the legal ops. (Sort alphabetically.)
+  // `llhd.combinational` and `llhd.yield` are the only LLHD ops rewritten by
+  // this pass; all other ops are left untouched for subsequent lowering
+  // passes to handle.
   ConversionTarget target(getContext());
-  target.addIllegalDialect<llhd::LLHDDialect>();
-  target.markUnknownOpDynamicallyLegal(
-      [](Operation *op) { return !isa<llhd::LLHDDialect>(op->getDialect()); });
+  target.addIllegalOp<llhd::CombinationalOp, llhd::YieldOp>();
+  target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 
   // Disable pattern rollback to use the faster one-shot dialect conversion.
   ConversionConfig config;

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -351,6 +351,19 @@ func.func @Time(%arg0: !arc.storage<42>) -> (i64, !llhd.time, i64) {
 }
 
 
+// CHECK-LABEL: llvm.func @ConstantTime
+// CHECK-SAME: -> !llvm.struct<(i64, i64, i64)>
+func.func @ConstantTime() -> (!llhd.time, !llhd.time, !llhd.time) {
+  // CHECK-DAG: llvm.mlir.constant(42 : i64) : i64
+  // CHECK-DAG: llvm.mlir.constant(7000 : i64) : i64
+  // CHECK-DAG: llvm.mlir.constant(10000000 : i64) : i64
+  %0 = llhd.constant_time <42fs, 0d, 0e>
+  %1 = llhd.constant_time <7ps, 0d, 0e>
+  %2 = llhd.constant_time <10ns, 0d, 0e>
+  return %0, %1, %2 : !llhd.time, !llhd.time, !llhd.time
+}
+
+
 // CHECK-LABEL: llvm.func @test_success_eval
 // CHECK-SAME: (%[[STATE:.*]]: !llvm.ptr, %[[COND:.*]]: i1)
 func.func @test_success_eval(%state: !arc.storage, %cond: i1) {

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -315,3 +315,19 @@ hw.module @OpsWithRegions(in %a: i42, in %b: i42, in %c: i42, in %d: i42, out z:
   // CHECK: hw.output [[SUB]]
   hw.output %2 : i42
 }
+
+// LLHD time ops survive `convert-to-arcs` unchanged. The arc outliner may
+// pull purely combinational time ops into separate arcs.
+// CHECK-LABEL: arc.define @TimeOpsPassthrough_arc
+//       CHECK:   llhd.time_to_int
+// CHECK-LABEL: hw.module @TimeOpsPassthrough
+//   CHECK-DAG:   llhd.constant_time <42fs, 0d, 0e>
+//   CHECK-DAG:   llhd.int_to_time
+//   CHECK-DAG:   llhd.current_time
+hw.module @TimeOpsPassthrough(in %a : i64, out t : i64) {
+  %0 = llhd.constant_time <42fs, 0d, 0e>
+  %1 = llhd.int_to_time %a
+  %2 = llhd.current_time
+  %3 = llhd.time_to_int %0
+  hw.output %3 : i64
+}


### PR DESCRIPTION
Add support for `llhd.constant_time` to the LowerArcToLLVM pass, mapping time constants to `i64` constants holding the time value in femtoseconds. Time attributes with non-zero delta or epsilon, units smaller than `fs`, or values that overflow `i64` femtoseconds are rejected.

Restrict ConvertToArcs's conversion target to the LLHD ops it actually rewrites, namely `llhd.combinational` and `llhd.yield`. Other LLHD ops and types should just pass through unchanged and are since they are handled by later passes.

Assisted-by: Claude Opus 4.7