### PR TITLE
[Arc] Add a next wakeup time slot to the model header

### DIFF
--- a/include/circt/Dialect/Arc/ArcConstants.h
+++ b/include/circt/Dialect/Arc/ArcConstants.h
@@ -12,13 +12,11 @@
 namespace circt {
 namespace arc {
 
-// Offset for model state allocations. The first 16 bytes of model storage are
-// reserved for the model header. The first 8 bytes contain the current
-// simulation time. The next 8 bytes are reserved for the termination flag used
-// by `SimTerminateOp`. The actual model state starts at offset 16.
+// Offsets for model state allocations.
 inline constexpr unsigned kTimeOffset = 0;
 inline constexpr unsigned kTerminateFlagOffset = 8;
-inline constexpr unsigned kStateOffset = 16;
+inline constexpr unsigned kNextWakeupOffset = 16;
+inline constexpr unsigned kStateOffset = 24;
 
 } // namespace arc
 

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -633,17 +633,51 @@ def TerminateOp : ArcOp<"terminate", [
   let description = [{
     Sets a termination flag in the model's storage.
     It unconditionally writes 1 for success or 2 for failure.
-    This allows the simulation to exit gracefully after the current 
+    This allows the simulation to exit gracefully after the current
     evaluation cycle.
   }];
 
-  let arguments = (ins 
-    StorageType:$storage, 
+  let arguments = (ins
+    StorageType:$storage,
     BoolAttr:$success
   );
 
   let assemblyFormat = [{
     $storage `,` $success attr-dict `:` qualified(type($storage))
+  }];
+}
+
+def GetNextWakeupOp : ArcOp<"get_next_wakeup", [
+  MemoryEffects<[MemRead]>
+]> {
+  let summary = "Read the model's next wakeup time";
+  let description = [{
+    Reads the next wakeup time from the model's storage. The time is
+    represented as an `i64` value in femtoseconds. A value of `0` indicates
+    "wake up immediately"; a value of `UINT64_MAX` indicates that no wakeup
+    is pending.
+  }];
+  let arguments = (ins StorageType:$storage);
+  let results = (outs I64:$time);
+  let assemblyFormat = [{
+    $storage attr-dict `:` qualified(type($storage))
+  }];
+}
+
+def SetNextWakeupOp : ArcOp<"set_next_wakeup", [
+  MemoryEffects<[MemWrite]>
+]> {
+  let summary = "Set the model's next wakeup time";
+  let description = [{
+    Writes the next wakeup time into the model's storage. The time is
+    represented as an `i64` value in femtoseconds. The model's eval body
+    establishes the slot at `UINT64_MAX` ("no wakeup pending") on entry, and
+    process suspension code lowers the value to the earliest scheduled
+    wakeup over the course of an evaluation.
+  }];
+  let arguments = (ins StorageType:$storage, I64:$time);
+  let assemblyFormat = [{
+    $storage `,` $time attr-dict `:` qualified(type($storage))
   }];
 }
 
@@ -806,6 +840,26 @@ def SimSetTimeOp : ArcOp<"sim.set_time", [
   let arguments = (ins SimModelInstance:$instance, I64:$time);
   let assemblyFormat = [{
     $instance `,` $time attr-dict `:` qualified(type($instance))
+  }];
+}
+
+def SimGetNextWakeupOp : ArcOp<"sim.get_next_wakeup", [
+  MemoryEffects<[MemRead]>,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Gets the next wakeup time of the model instance";
+  let description = [{
+    Gets the next wakeup time of the given model instance. The time is
+    represented as an `i64` value in femtoseconds. A value of `0` indicates
+    "wake up immediately"; a value of `UINT64_MAX` indicates that no wakeup
+    is pending. The slot is recomputed on every evaluation, so a driver
+    typically reads it after each `arc.sim.step` to decide how far to
+    advance simulation time before the next step.
+  }];
+  let arguments = (ins SimModelInstance:$instance);
+  let results = (outs I64:$time);
+  let assemblyFormat = [{
+    $instance attr-dict `:` qualified(type($instance))
   }];
 }
 

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -710,6 +710,26 @@ struct SimSetTimeOpLowering : public OpConversionPattern<arc::SimSetTimeOp> {
   }
 };
 
+// Loads the next wakeup time (i64 femtoseconds) from `kNextWakeupOffset` of
+// the model instance's state storage.
+struct SimGetNextWakeupOpLowering
+    : public OpConversionPattern<arc::SimGetNextWakeupOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arc::SimGetNextWakeupOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto loc = op.getLoc();
+    auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
+    Value slotPtr = LLVM::GEPOp::create(
+        rewriter, loc, ptrType, rewriter.getI8Type(), adaptor.getInstance(),
+        ArrayRef<LLVM::GEPArg>{arc::kNextWakeupOffset});
+    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, rewriter.getI64Type(),
+                                              slotPtr);
+    return success();
+  }
+};
+
 // Global string constants in the module.
 class StringCache {
 public:
@@ -1051,6 +1071,45 @@ struct TerminateOpLowering : public OpConversionPattern<arc::TerminateOp> {
     LLVM::StoreOp::create(rewriter, loc, codeVal, flagPtr);
 
     rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// Loads the next wakeup time (i64 femtoseconds) from the model's storage at
+// `kNextWakeupOffset`.
+struct GetNextWakeupOpLowering
+    : public OpConversionPattern<arc::GetNextWakeupOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arc::GetNextWakeupOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
+    Value slotPtr = LLVM::GEPOp::create(
+        rewriter, loc, ptrType, rewriter.getI8Type(), adaptor.getStorage(),
+        ArrayRef<LLVM::GEPArg>{arc::kNextWakeupOffset});
+    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, rewriter.getI64Type(),
+                                              slotPtr);
+    return success();
+  }
+};
+
+// Stores the next wakeup time (i64 femtoseconds) to the model's storage at
+// `kNextWakeupOffset`.
+struct SetNextWakeupOpLowering
+    : public OpConversionPattern<arc::SetNextWakeupOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arc::SetNextWakeupOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
+    Value slotPtr = LLVM::GEPOp::create(
+        rewriter, loc, ptrType, rewriter.getI8Type(), adaptor.getStorage(),
+        ArrayRef<LLVM::GEPArg>{arc::kNextWakeupOffset});
+    rewriter.replaceOpWithNewOp<LLVM::StoreOp>(op, adaptor.getTime(), slotPtr);
     return success();
   }
 };
@@ -1459,6 +1518,7 @@ void LowerArcToLLVMPass::runOnOperation() {
     ClockInvOpLowering,
     ConstantTimeOpLowering,
     CurrentTimeOpLowering,
+    GetNextWakeupOpLowering,
     IntToTimeOpLowering,
     MemoryReadOpLowering,
     MemoryWriteOpLowering,
@@ -1467,6 +1527,8 @@ void LowerArcToLLVMPass::runOnOperation() {
     ReplaceOpWithInputPattern<seq::FromClockOp>,
     RuntimeModelOpLowering,
     SeqConstClockLowering,
+    SetNextWakeupOpLowering,
+    SimGetNextWakeupOpLowering,
     SimGetTimeOpLowering,
     SimSetTimeOpLowering,
     StateReadOpLowering,

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -740,6 +740,23 @@ SimSetTimeOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
+// SimGetNextWakeupOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+SimGetNextWakeupOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *moduleOp = getSupportedModuleOp(
+      symbolTable, getOperation(),
+      llvm::cast<SimModelInstanceType>(getInstance().getType())
+          .getModel()
+          .getAttr());
+  if (!moduleOp)
+    return failure();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ExecuteOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -200,6 +200,13 @@ LogicalResult ModuleLowering::run() {
       StorageType::get(builder.getContext(), {}), modelOp.getLoc());
   builder.setInsertionPointToStart(&modelBlock);
 
+  // Reset the next wakeup slot to `UINT64_MAX` ("no wakeup pending") at the
+  // start of every eval. Process suspension code lowers the value to the
+  // earliest scheduled wakeup over the course of the evaluation.
+  auto noWakeup = hw::ConstantOp::create(builder, moduleOp.getLoc(),
+                                         builder.getI64Type(), -1);
+  SetNextWakeupOp::create(builder, moduleOp.getLoc(), storageArg, noWakeup);
+
   // Create the `arc.initial` op to contain the ops for the initialization
   // phase.
   auto initialOp = InitialOp::create(builder, moduleOp.getLoc());

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -364,6 +364,20 @@ func.func @ConstantTime() -> (!llhd.time, !llhd.time, !llhd.time) {
 }
 
 
+// CHECK-LABEL: llvm.func @NextWakeup
+// CHECK-SAME: (%[[STATE:.*]]: !llvm.ptr, %[[T:.*]]: i64)
+func.func @NextWakeup(%state: !arc.storage<42>, %t: i64) -> i64 {
+  // CHECK-NEXT: %[[WGEP:.*]] = llvm.getelementptr %[[STATE]][16] : (!llvm.ptr) -> !llvm.ptr, i8
+  // CHECK-NEXT: llvm.store %[[T]], %[[WGEP]] : i64, !llvm.ptr
+  arc.set_next_wakeup %state, %t : !arc.storage<42>
+  // CHECK-NEXT: %[[RGEP:.*]] = llvm.getelementptr %[[STATE]][16] : (!llvm.ptr) -> !llvm.ptr, i8
+  // CHECK-NEXT: %[[OUT:.*]] = llvm.load %[[RGEP]] : !llvm.ptr -> i64
+  %0 = arc.get_next_wakeup %state : !arc.storage<42>
+  // CHECK-NEXT: llvm.return %[[OUT]]
+  return %0 : i64
+}
+
+
 // CHECK-LABEL: llvm.func @test_success_eval
 // CHECK-SAME: (%[[STATE:.*]]: !llvm.ptr, %[[COND:.*]]: i1)
 func.func @test_success_eval(%state: !arc.storage, %cond: i1) {

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -6,12 +6,12 @@
 // TAPS-SAME:   traceTaps [#arc.trace_tap<i16, 0, ["foo", "bar"]>, #arc.trace_tap<i1, 2, ["baz"]>]
 arc.model @test io !hw.modty<input x : i1, output y : i1> {
 ^bb0(%arg0: !arc.storage):
-  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5799>):
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5815>):
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][16] : (!arc.storage<5799>) -> !arc.storage<1159>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][32] : (!arc.storage<5815>) -> !arc.storage<1159>
   // CHECK-NEXT: arc.initial {
   arc.initial {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][16] : !arc.storage<5799> -> !arc.storage<1159>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][32] : !arc.storage<5815> -> !arc.storage<1159>
     %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i8>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i16>
@@ -31,7 +31,7 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
     // CHECK-NEXT: scf.execute_region {
     scf.execute_region {
       arc.state_read %0 : <i1>
-      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][16] : !arc.storage<5799> -> !arc.storage<1159>
+      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][32] : !arc.storage<5815> -> !arc.storage<1159>
       // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][0] : !arc.storage<1159> -> !arc.state<i1>
       // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
       arc.state_read %1 : <i1>
@@ -44,10 +44,10 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][1184] : (!arc.storage<5799>) -> !arc.storage<4609>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][1200] : (!arc.storage<5815>) -> !arc.storage<4609>
   // CHECK-NEXT: arc.initial {
   arc.initial {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1184] : !arc.storage<5799> -> !arc.storage<4609>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1200] : !arc.storage<5815> -> !arc.storage<4609>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i1, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i8, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i16, i1>
@@ -71,18 +71,18 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage %arg0[5794] : (!arc.storage<5799>) -> !arc.storage<2>
+  // CHECK-NEXT: arc.alloc_storage %arg0[5810] : (!arc.storage<5815>) -> !arc.storage<2>
   // CHECK-NEXT: arc.initial {
   arc.initial {
     arc.root_input "x", %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.root_output "y", %arg0 : (!arc.storage) -> !arc.state<i1>
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5794] : !arc.storage<5799> -> !arc.storage<2>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5810] : !arc.storage<5815> -> !arc.storage<2>
     // CHECK-NEXT: arc.root_input "x", [[SUBPTR]] {offset = 0 : i32}
     // CHECK-NEXT: arc.root_output "y", [[SUBPTR]] {offset = 1 : i32}
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][5796] : (!arc.storage<5799>) -> !arc.storage<3>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][5812] : (!arc.storage<5815>) -> !arc.storage<3>
   // CHECK-NEXT: arc.initial {
   arc.initial {
     %cstCAFE = hw.constant 0xCAFE: i16
@@ -102,7 +102,7 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
 }
 
 // CHECK-LABEL: arc.model @StructPadding
-// CHECK-NEXT: !arc.storage<20>
+// CHECK-NEXT: !arc.storage<28>
 arc.model @StructPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // This !hw.struct is only 19 bits wide, but mapped to an !llvm.struct, each
@@ -111,7 +111,7 @@ arc.model @StructPadding io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @ArrayPadding
-// CHECK-NEXT: !arc.storage<20>
+// CHECK-NEXT: !arc.storage<28>
 arc.model @ArrayPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // This !hw.array is only 18 bits wide, but mapped to an !llvm.array, each

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -416,6 +416,15 @@ func.func @CurrentTime(%arg0: !arc.storage<100>) {
   return
 }
 
+// CHECK-LABEL: func.func @NextWakeup
+func.func @NextWakeup(%arg0: !arc.storage<100>, %arg1: i64) {
+  // CHECK-NEXT: arc.get_next_wakeup %arg0 : !arc.storage<100>
+  %0 = arc.get_next_wakeup %arg0 : !arc.storage<100>
+  // CHECK-NEXT: arc.set_next_wakeup %arg0, %arg1 : !arc.storage<100>
+  arc.set_next_wakeup %arg0, %arg1 : !arc.storage<100>
+  return
+}
+
 // CHECK-LABEL: func.func @SimGetSetTime
 func.func @SimGetSetTime() {
   arc.sim.instantiate @TimeTestModule as %model {
@@ -423,6 +432,8 @@ func.func @SimGetSetTime() {
     %0 = arc.sim.get_time %model : !arc.sim.instance<@TimeTestModule>
     // CHECK: arc.sim.set_time %{{.*}}, %{{.*}} : !arc.sim.instance<@TimeTestModule>
     arc.sim.set_time %model, %0 : !arc.sim.instance<@TimeTestModule>
+    // CHECK: arc.sim.get_next_wakeup %{{.*}} : !arc.sim.instance<@TimeTestModule>
+    %1 = arc.sim.get_next_wakeup %model : !arc.sim.instance<@TimeTestModule>
     // CHECK: arc.sim.step %{{.*}} by %{{.*}} : !arc.sim.instance<@TimeTestModule>
     %tstep = arith.constant 123 : i64
     arc.sim.step %model by %tstep : !arc.sim.instance<@TimeTestModule>

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -18,16 +18,16 @@ module {
     // CHECK: %[[format_str_ptr:.*]] = llvm.mlir.addressof @[[format_str]] : !llvm.ptr
     // CHECK-DAG: %[[c:.*]] = llvm.mlir.constant(24 : i8)
     // CHECK-DAG: %[[zero:.*]] = llvm.mlir.constant(0 : i8)
-    // CHECK-DAG: %[[size:.*]] = llvm.mlir.constant(19 : i64)
+    // CHECK-DAG: %[[size:.*]] = llvm.mlir.constant(27 : i64)
     // CHECK-DAG: %[[tstep:.*]] = llvm.mlir.constant(321 : i64)
     // CHECK-DAG: %[[state:.*]] = llvm.call @malloc(%[[size:.*]]) :
     // CHECK: "llvm.intr.memset"(%[[state]], %[[zero]], %[[size]]) <{isVolatile = false}>
     arc.sim.instantiate @id as %model {
-      // CHECK-NEXT: %[[i_ptr:.*]] = llvm.getelementptr %[[state]][16] : (!llvm.ptr) -> !llvm.ptr, i8
+      // CHECK-NEXT: %[[i_ptr:.*]] = llvm.getelementptr %[[state]][24] : (!llvm.ptr) -> !llvm.ptr, i8
       // CHECK-NEXT: llvm.store %[[c]], %[[i_ptr]] : i8
       arc.sim.set_input %model, "i" = %c : i8, !arc.sim.instance<@id>
 
-      // CHECK-NEXT: %[[j_ptr:.*]] = llvm.getelementptr %[[state]][17] : (!llvm.ptr) -> !llvm.ptr, i8
+      // CHECK-NEXT: %[[j_ptr:.*]] = llvm.getelementptr %[[state]][25] : (!llvm.ptr) -> !llvm.ptr, i8
       // CHECK-NEXT: llvm.store %[[c]], %[[j_ptr]] : i8
       arc.sim.set_input %model, "j" = %c : i8, !arc.sim.instance<@id>
 
@@ -40,9 +40,14 @@ module {
       // CHECK-NEXT: llvm.store %[[tnew]], %[[state]] : i64, !llvm.ptr
       arc.sim.step %model by %tstep : !arc.sim.instance<@id>
 
-      // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][18] : (!llvm.ptr) -> !llvm.ptr, i8
+      // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][26] : (!llvm.ptr) -> !llvm.ptr, i8
       // CHECK-NEXT: %[[result:.*]] = llvm.load %[[o_ptr]] : !llvm.ptr -> i8
       %result = arc.sim.get_port %model, "o" : i8, !arc.sim.instance<@id>
+
+      // CHECK-NEXT: %[[wkup_ptr:.*]] = llvm.getelementptr %[[state]][16] : (!llvm.ptr) -> !llvm.ptr, i8
+      // CHECK-NEXT: %[[wkup:.*]] = llvm.load %[[wkup_ptr]] : !llvm.ptr -> i64
+      %wkup = arc.sim.get_next_wakeup %model : !arc.sim.instance<@id>
+      arc.sim.emit "next_wakeup", %wkup : i64
 
       // CHECK-DAG: %[[to_print:.*]] = llvm.zext %[[result]] : i8 to i64
       // CHECK: llvm.call @printf(%[[format_str_ptr]], %[[to_print]])

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -44,6 +44,8 @@ arc.define @RandomI42AndI19Arc() -> (i42, i19) {
 
 // CHECK-LABEL: arc.model @Empty
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage):
+// CHECK-NEXT:    [[NWK:%.+]] = hw.constant -1 : i64
+// CHECK-NEXT:    arc.set_next_wakeup %arg0, [[NWK]] : !arc.storage
 // CHECK-NEXT:  }
 hw.module @Empty() {}
 

--- a/test/Dialect/Arc/sim-errors.mlir
+++ b/test/Dialect/Arc/sim-errors.mlir
@@ -145,3 +145,14 @@ func.func @set_time_model_not_found() {
     }
     return
 }
+
+// -----
+
+func.func @get_next_wakeup_model_not_found() {
+    // expected-error @+1 {{model not found}}
+    arc.sim.instantiate @unknown as %model {
+        %t = arc.sim.get_next_wakeup %model : !arc.sim.instance<@unknown>
+        arc.sim.emit "next_wakeup", %t : i64
+    }
+    return
+}


### PR DESCRIPTION
Reserve the third 8-byte word of the model state header for an i64 femtosecond "next wakeup time" slot, with `0` meaning "wake up immediately" and `UINT64_MAX` meaning "no wakeup pending". Bump the header size from 16 to 24 bytes and shift the dynamic state start.

Add `arc.get_next_wakeup` and `arc.set_next_wakeup` for use inside an `arc.model` body, an `arc.sim.get_next_wakeup` for drivers operating on a `SimModelInstance` handle, and LLVM lowerings for all three.

Inject an `arc.set_next_wakeup` of `UINT64_MAX` at the start of every `arc.model` body so the eval-start contract holds: process suspension code in a follow-up will lower the value to the earliest scheduled wakeup over the course of an evaluation.

Assisted-by: Claude Opus 4.7