### PR TITLE
[ESI][Runtime] Use `std::array` and limit packing

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -442,22 +442,30 @@ class CppTypeEmitter:
       raise ValueError(f"Unsupported unbounded type width for '{wrapped}'")
     return (wrapped.bit_width + 7) // 8
 
-  def _array_base_and_suffix(self,
-                             array_type: types.ArrayType) -> Tuple[str, str]:
-    """Return the base C++ type and bracket suffix for a nested array."""
+  def _array_base_and_dims(
+      self, array_type: types.ArrayType) -> Tuple[str, List[int]]:
+    """Return the base C++ type and outer-to-inner dimensions of a nested array."""
     dims: List[int] = []
     inner: types.ESIType = array_type
     while isinstance(inner, types.ArrayType):
       dims.append(inner.size)
       inner = inner.element_type
     base_cpp = self._cpp_type(inner)
-    suffix = "".join([f"[{d}]" for d in dims])
-    return base_cpp, suffix
+    return base_cpp, dims
 
-  def _format_array_type(self, array_type: types.ArrayType) -> str:
-    """Return the C++ type string for a nested array alias."""
-    base_cpp, suffix = self._array_base_and_suffix(array_type)
-    return f"{base_cpp}{suffix}"
+  def _std_array_type(self, array_type: types.ArrayType) -> str:
+    """Return the equivalent nested `std::array<...>` type for an array.
+
+    `std::array<T, N>` is layout-compatible in practice with `T[N]` on every
+    major implementation (and identical under `#pragma pack(1)`), so the
+    generator uses it everywhere a fixed-size array would appear.  This keeps
+    field/value/ctor types storable in `std::vector` and assignable with `=`.
+    """
+    base_cpp, dims = self._array_base_and_dims(array_type)
+    result = base_cpp
+    for size in reversed(dims):
+      result = f"std::array<{result}, {size}>"
+    return result
 
   def _cpp_type(self, wrapped: types.ESIType) -> str:
     """Resolve an ESI type to its C++ identifier."""
@@ -479,7 +487,7 @@ class CppTypeEmitter:
     if isinstance(wrapped, (types.BitsType, types.IntType)):
       return self._get_bitvector_str(wrapped)
     if isinstance(wrapped, types.ArrayType):
-      return self._format_array_type(wrapped)
+      return self._std_array_type(wrapped)
     if type(wrapped) is types.ESIType:
       return "std::any"
     raise NotImplementedError(
@@ -491,19 +499,13 @@ class CppTypeEmitter:
       wrapped = wrapped.inner_type
     return wrapped
 
-  def _format_array_decl(self, array_type: types.ArrayType, name: str) -> str:
-    """Emit a field declaration for a multi-dimensional array member.
-
-    The declaration flattens nested arrays into repeated bracketed sizes for C++.
-    """
-    base_cpp, suffix = self._array_base_and_suffix(array_type)
-    return f"{base_cpp} {name}{suffix};"
-
   def _format_window_field_decl(self, field_name: str,
                                 field_type: types.ESIType) -> str:
-    """Emit a packed field declaration for generated window helpers."""
-    if isinstance(field_type, types.ArrayType):
-      return self._format_array_decl(field_type, field_name)
+    """Emit a packed field declaration for generated window helpers.
+
+    Arrays use `std::array` (handled by `_cpp_type`), so no bracket syntax is
+    needed and a single uniform declaration form covers every type.
+    """
     field_cpp = self._cpp_type(field_type)
     wrapped = self._unwrap_aliases(field_type)
     if isinstance(wrapped, (types.BitsType, types.IntType)) and \
@@ -518,9 +520,6 @@ class CppTypeEmitter:
     Small scalar header fields are cheaper to pass by value than by reference.
     Larger aggregates stay as const references.
     """
-    if isinstance(field_type, types.ArrayType):
-      base_cpp, suffix = self._array_base_and_suffix(field_type)
-      return f"const {base_cpp} (&{field_name}){suffix}"
     field_cpp = self._cpp_type(field_type)
     wrapped = self._unwrap_aliases(field_type)
     if isinstance(wrapped, (types.BitsType, types.IntType)):
@@ -529,11 +528,7 @@ class CppTypeEmitter:
 
   def _emit_window_field_copy(self, hdr: TextIO, dest_expr: str, src_expr: str,
                               field_type: types.ESIType) -> None:
-    """Copy a generated window field, preserving array semantics."""
-    if isinstance(field_type, types.ArrayType):
-      hdr.write(
-          f"    std::memcpy(&{dest_expr}, &{src_expr}, sizeof({dest_expr}));\n")
-      return
+    """Copy a generated window field."""
     hdr.write(f"    {dest_expr} = {src_expr};\n")
 
   def _field_byte_width(self, field_type: types.ESIType) -> int:
@@ -633,21 +628,19 @@ class CppTypeEmitter:
       fields = list(reversed(fields))
     field_decls: List[str] = []
     for field_name, field_type in fields:
-      if isinstance(field_type, types.ArrayType):
-        field_decls.append(self._format_array_decl(field_type, field_name))
-      else:
-        field_cpp = self._cpp_type(field_type)
-        wrapped = self._unwrap_aliases(field_type)
-        if isinstance(wrapped, (types.BitsType, types.IntType)):
-          # TODO: Bitfield layout is implementation-defined; consider
-          # byte-aligned storage with explicit pack/unpack helpers.
-          bitfield_width = wrapped.bit_width
-          if bitfield_width >= 0:
-            field_decls.append(f"{field_cpp} {field_name} : {bitfield_width};")
-          else:
-            field_decls.append(f"{field_cpp} {field_name};")
+      field_cpp = self._cpp_type(field_type)
+      wrapped = self._unwrap_aliases(field_type)
+      if isinstance(wrapped, (types.BitsType, types.IntType)):
+        # TODO: Bitfield layout is implementation-defined; consider
+        # byte-aligned storage with explicit pack/unpack helpers.
+        bitfield_width = wrapped.bit_width
+        if bitfield_width >= 0:
+          field_decls.append(f"{field_cpp} {field_name} : {bitfield_width};")
         else:
           field_decls.append(f"{field_cpp} {field_name};")
+      else:
+        field_decls.append(f"{field_cpp} {field_name};")
+    hdr.write("#pragma pack(push, 1)\n")
     hdr.write(f"struct {self.type_id_map[struct_type]} {{\n")
     for decl in field_decls:
       hdr.write(f"  {decl}\n")
@@ -655,7 +648,8 @@ class CppTypeEmitter:
     hdr.write(
         f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(struct_type.id)};\n"
     )
-    hdr.write("};\n\n")
+    hdr.write("};\n")
+    hdr.write("#pragma pack(pop)\n\n")
 
   def _emit_union(self, hdr: TextIO, union_type: types.UnionType) -> None:
     """Emit a packed union declaration plus its type id string.
@@ -668,6 +662,7 @@ class CppTypeEmitter:
     union_bytes = self._field_byte_width(union_type)
     fields = list(union_type.fields)
 
+    hdr.write("#pragma pack(push, 1)\n")
     # First pass: emit wrapper structs for fields that need padding.
     wrapper_names: Dict[str, str] = {}
     for field_name, field_type in fields:
@@ -697,7 +692,8 @@ class CppTypeEmitter:
     hdr.write(
         f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(union_type.id)};\n"
     )
-    hdr.write("};\n\n")
+    hdr.write("};\n")
+    hdr.write("#pragma pack(pop)\n\n")
 
   def _emit_window(self, hdr: TextIO, window_type: types.WindowType) -> None:
     """Emit a SegmentedMessageData helper for a serial list window."""
@@ -721,14 +717,17 @@ class CppTypeEmitter:
     hdr.write("public:\n")
     hdr.write(f"  using value_type = {info['element_cpp']};\n")
     hdr.write(f"  using count_type = {info['count_cpp']};\n\n")
+    hdr.write("#pragma pack(push, 1)\n")
     hdr.write("  struct data_frame {\n")
     if info["data_pad_bytes"] > 0:
       hdr.write(f"    uint8_t _pad[{info['data_pad_bytes']}];\n")
     for field_name, field_type in info["data_fields"]:
       decl = self._format_window_field_decl(field_name, field_type)
       hdr.write(f"    {decl}\n")
-    hdr.write("  };\n\n")
+    hdr.write("  };\n")
+    hdr.write("#pragma pack(pop)\n\n")
     hdr.write("private:\n")
+    hdr.write("#pragma pack(push, 1)\n")
     hdr.write("  struct header_frame {\n")
     if info["header_pad_bytes"] > 0:
       hdr.write(f"    uint8_t _pad[{info['header_pad_bytes']}];\n")
@@ -741,7 +740,8 @@ class CppTypeEmitter:
       else:
         decl = self._format_window_field_decl(field_name, field_type)
       hdr.write(f"    {decl}\n")
-    hdr.write("  };\n\n")
+    hdr.write("  };\n")
+    hdr.write("#pragma pack(pop)\n\n")
     hdr.write("  header_frame header{};\n")
     hdr.write("  std::vector<data_frame> data_frames;\n")
     hdr.write("  header_frame footer{};\n\n")
@@ -775,15 +775,10 @@ class CppTypeEmitter:
     hdr.write(f"    frames.reserve({info['list_field_name']}.size());\n")
     hdr.write(f"    for (const auto &element : {info['list_field_name']}) {{\n")
     hdr.write("      auto &frame = frames.emplace_back();\n")
-    list_field_type = next(
-        field_type for field_name, field_type in info["data_fields"]
-        if field_name == info["list_field_name"])
-    if isinstance(list_field_type, types.ArrayType):
-      hdr.write(
-          f"      std::memcpy(&frame.{info['list_field_name']}, &element, sizeof(frame.{info['list_field_name']}));\n"
-      )
-    else:
-      hdr.write(f"      frame.{info['list_field_name']} = element;\n")
+    # The data_frame list field is now stored as either a scalar/struct
+    # (assignable) or std::array (also assignable), so a plain assignment
+    # always works regardless of element type.
+    hdr.write(f"      frame.{info['list_field_name']} = element;\n")
     hdr.write("    }\n")
     hdr.write(f"    construct({helper_call});\n")
     hdr.write("  }\n\n")
@@ -826,28 +821,26 @@ class CppTypeEmitter:
       # `<list>_count()` below.
       if field_type is None:
         continue
-      # Unwrap any alias before checking for array so that alias-to-array
-      # types (e.g. `using Alias = T[N]`) get the const-ref accessor form.
+      cpp = self._cpp_type(field_type)
       unwrapped_header = self._unwrap_aliases(field_type)
-      if isinstance(unwrapped_header, types.ArrayType):
-        base_cpp, suffix = self._array_base_and_suffix(unwrapped_header)
-        hdr.write(
-            f"  const {base_cpp} (&{field_name}() const){suffix} {{ return header.{field_name}; }}\n"
-        )
-      else:
-        cpp = self._cpp_type(field_type)
+      # Aggregate types (structs/unions/std::array) get a const-ref accessor;
+      # bit-vector scalars are returned by value.
+      if isinstance(unwrapped_header,
+                    (types.BitsType, types.IntType, types.VoidType)):
         hdr.write(
             f"  {cpp} {field_name}() const {{ return header.{field_name}; }}\n")
+      else:
+        hdr.write(
+            f"  const {cpp} &{field_name}() const {{ return header.{field_name}; }}\n"
+        )
     hdr.write(
         f"  size_t {list_field_name}_count() const {{ return data_frames.size(); }}\n"
     )
     for field_name, field_type in info["data_fields"]:
-      # std::vector cannot hold C-style arrays, so skip array-typed data
-      # fields here (including alias-to-array types); callers can still reach
-      # them via the underlying frames.
+      # All field types — scalars, structs, and arrays-as-`std::array` — are
+      # uniformly addressable via pointer-to-member, except bit-fields which
+      # have no pointer-to-member representation.
       unwrapped_data = self._unwrap_aliases(field_type)
-      if isinstance(unwrapped_data, types.ArrayType):
-        continue
       if field_name == list_field_name:
         elem_cpp = "value_type"
       else:
@@ -899,7 +892,7 @@ class CppTypeEmitter:
         #include <cstdint>
         #include <cstddef>
         #include <any>
-        #include <cstring>
+        #include <array>
         #include <limits>
         #include <ranges>
         #include <stdexcept>
@@ -910,7 +903,6 @@ class CppTypeEmitter:
         #include "esi/Common.h"
 
         namespace {system_name} {{
-        #pragma pack(push, 1)
 
       """))
       if self.has_cycle:
@@ -933,9 +925,7 @@ class CppTypeEmitter:
           sys.stderr.write(f"Error emitting type '{emit_type}': {e}\n")
           hdr.write(f"// Unsupported type '{emit_type}': {e}\n\n")
 
-      hdr.write(
-          textwrap.dedent(f"""
-    #pragma pack(pop)
+      hdr.write(textwrap.dedent(f"""
     }} // namespace {system_name}
     """))
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -535,6 +535,38 @@ class CppTypeEmitter:
     """Compute the byte width of a field type, rounding up to full bytes."""
     return (field_type.bit_width + 7) // 8
 
+  def _safe_byte_width(self, esi_type: types.ESIType) -> Optional[int]:
+    """Return the bounded byte width of `esi_type`, or `None` if it has no
+    well-defined static size (e.g. unbounded `!esi.any` or recursive types).
+    """
+    try:
+      bit_width = esi_type.bit_width
+    except Exception:
+      return None
+    if bit_width is None or bit_width < 0:
+      return None
+    return (bit_width + 7) // 8
+
+  def _emit_size_assert(self,
+                        hdr: TextIO,
+                        type_name: str,
+                        expected_bytes: Optional[int],
+                        indent: str = "") -> None:
+    """Emit a `static_assert` that pins the C++ `sizeof` of a packed type to
+    the byte width derived from the manifest.
+
+    `std::array` and bit-field layout are technically implementation-defined,
+    so this assertion is the safety net that catches a toolchain that lays
+    them out differently from the wire format.  Skipped silently for types
+    without a bounded static size.
+    """
+    if expected_bytes is None:
+      return
+    hdr.write(
+        f"{indent}static_assert(sizeof({type_name}) == {expected_bytes},\n"
+        f"{indent}              \"{type_name}: packed layout does not match "
+        f"manifest size\");\n")
+
   def _analyze_window(self, window_type: types.WindowType):
     """Extract the metadata needed to emit a bulk list window wrapper."""
     into_type = self._unwrap_aliases(window_type.into_type)
@@ -615,6 +647,7 @@ class CppTypeEmitter:
         "data_fields": data_fields,
         "data_pad_bytes": frame_bytes - data_bytes,
         "element_cpp": self._cpp_type(list_type.element_type),
+        "frame_bytes": frame_bytes,
         "header_fields": header_fields,
         "header_pad_bytes": frame_bytes - header_bytes,
         "list_field_name": list_field_name,
@@ -649,6 +682,8 @@ class CppTypeEmitter:
         f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(struct_type.id)};\n"
     )
     hdr.write("};\n")
+    self._emit_size_assert(hdr, self.type_id_map[struct_type],
+                           self._safe_byte_width(struct_type))
     hdr.write("#pragma pack(pop)\n\n")
 
   def _emit_union(self, hdr: TextIO, union_type: types.UnionType) -> None:
@@ -676,6 +711,7 @@ class CppTypeEmitter:
         field_cpp = self._cpp_type(field_type)
         hdr.write(f"  {field_cpp} {field_name};\n")
         hdr.write("};\n")
+        self._emit_size_assert(hdr, wrapper, union_bytes)
 
     # Second pass: emit the union itself.
     union_field_decls: List[str] = []
@@ -693,6 +729,7 @@ class CppTypeEmitter:
         f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(union_type.id)};\n"
     )
     hdr.write("};\n")
+    self._emit_size_assert(hdr, union_name, union_bytes)
     hdr.write("#pragma pack(pop)\n\n")
 
   def _emit_window(self, hdr: TextIO, window_type: types.WindowType) -> None:
@@ -725,6 +762,7 @@ class CppTypeEmitter:
       decl = self._format_window_field_decl(field_name, field_type)
       hdr.write(f"    {decl}\n")
     hdr.write("  };\n")
+    self._emit_size_assert(hdr, "data_frame", info["frame_bytes"], indent="  ")
     hdr.write("#pragma pack(pop)\n\n")
     hdr.write("private:\n")
     hdr.write("#pragma pack(push, 1)\n")
@@ -741,6 +779,10 @@ class CppTypeEmitter:
         decl = self._format_window_field_decl(field_name, field_type)
       hdr.write(f"    {decl}\n")
     hdr.write("  };\n")
+    self._emit_size_assert(hdr,
+                           "header_frame",
+                           info["frame_bytes"],
+                           indent="  ")
     hdr.write("#pragma pack(pop)\n\n")
     hdr.write("  header_frame header{};\n")
     hdr.write("  std::vector<data_frame> data_frames;\n")

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -235,7 +235,7 @@ def test_windowed_list_bulk_message_wrapper():
   assert "uint8_t _pad[2];" in hdr
   assert "Coord coords;" in hdr
   assert hdr.index("struct data_frame {") < hdr.index(
-      "private:\n  struct header_frame {")
+      "private:\n#pragma pack(push, 1)\n  struct header_frame {")
   assert "std::vector<data_frame> data_frames;" in hdr
   assert "esi::Segment segment(size_t idx) const override" in hdr
   assert "footer.coords_count = 0;" in hdr
@@ -340,22 +340,29 @@ def test_windowed_list_arrays_in_header_and_value_type():
   ])
 
   hdr = _generate_header([window])
-  assert "#include <cstring>" in hdr
+  assert "#include <array>" in hdr
   assert "struct array_payloads : public esi::SegmentedMessageData" in hdr
-  assert "using value_type = uint8_t[4];" in hdr
+  # `value_type` is exposed as `std::array` so it is storable in `std::vector`.
+  assert "using value_type = std::array<uint8_t, 4>;" in hdr
   assert "using count_type = uint16_t;" in hdr
-  assert "uint16_t header_words[2];" in hdr
-  assert "uint8_t payloads[4];" in hdr
-  assert "array_payloads(const uint16_t (&header_words)[2], const std::vector<value_type> &payloads)" in hdr
-  assert "void construct(const uint16_t (&header_words)[2], std::vector<data_frame> frames)" in hdr
-  assert "std::memcpy(&header.header_words, &header_words, sizeof(header.header_words));" in hdr
-  assert "std::memcpy(&frame.payloads, &element, sizeof(frame.payloads));" in hdr
+  # All array-typed fields (header and data) are emitted as `std::array`.
+  assert "std::array<uint16_t, 2> header_words;" in hdr
+  assert "std::array<uint8_t, 4> payloads;" in hdr
+  # Constructor params for arrays are simple const-refs to `std::array`.
+  assert "array_payloads(const std::array<uint16_t, 2> &header_words, const std::vector<value_type> &payloads)" in hdr
+  assert "void construct(const std::array<uint16_t, 2> &header_words, std::vector<data_frame> frames)" in hdr
+  # Plain `=` assignment for both header and data array fields.
+  assert "header.header_words = header_words;" in hdr
+  assert "frame.payloads = element;" in hdr
   assert 'throw std::out_of_range("array_payloads: invalid segment index")' in hdr
-  # Array-typed header field: const-ref accessor emitted.
-  assert "const uint16_t (&header_words() const)[2] { return header.header_words; }" in hdr
-  # Array-typed data field: range/vector accessors are skipped.
-  assert "return std::views::transform" not in hdr
-  assert "payloads_vector" not in hdr
+  # Array-typed header field: const-ref accessor with std::array return type.
+  assert "const std::array<uint16_t, 2> &header_words() const { return header.header_words; }" in hdr
+  # Array-typed data field: pointer-to-member projection (zero-copy view) and
+  # std::array-valued vector helper. The list field uses the `value_type`
+  # alias (which equals `std::array<uint8_t, 4>`).
+  assert "return std::views::transform(data_frames, &data_frame::payloads);" in hdr
+  assert "std::vector<value_type> payloads_vector() const" in hdr
+  assert "out.push_back(frame.payloads);" in hdr
 
 
 def test_windowed_list_struct_element_data_uses_pointer_to_member():

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -444,3 +444,79 @@ def test_windowed_list_bitfield_scalar_data_uses_lambda():
   assert "[](const data_frame &f) { return f.vals; }" in hdr
   assert "&data_frame::vals" not in hdr
   assert "std::vector<value_type> vals_vector() const" in hdr
+
+
+def test_size_assert_emitted_for_struct():
+  """Each packed struct gets a `static_assert` pinning its `sizeof`."""
+  uint16 = types.UIntType("ui16", 16)
+  sint8 = types.SIntType("si8", 8)
+  s = types.StructType("!hw.struct<a: ui16, b: si8>", [("a", uint16),
+                                                       ("b", sint8)])
+
+  hdr = _generate_header([s])
+  # Total: 16 + 8 = 24 bits = 3 bytes.
+  assert "static_assert(sizeof(_struct_a_ui16_b_si8) == 3," in hdr
+  assert "packed layout does not match manifest size" in hdr
+
+
+def test_size_assert_emitted_for_union_and_wrappers():
+  """Unions and their padding wrapper structs each get a size assert."""
+  uint8 = types.UIntType("ui8", 8)
+  uint16 = types.UIntType("ui16", 16)
+  union_t = types.UnionType("!hw.union<a: ui8, b: ui16>", [("a", uint8),
+                                                           ("b", uint16)])
+
+  hdr = _generate_header([union_t])
+  # The union itself is 2 bytes (max(8, 16) = 16 bits).
+  assert "static_assert(sizeof(_union_a_ui8_b_ui16) == 2," in hdr
+  # The wrapper around the narrow `a` field is also 2 bytes.
+  assert "static_assert(sizeof(_union_a_ui8_b_ui16_a) == 2," in hdr
+
+
+def test_size_assert_emitted_for_window_frames():
+  """Both `data_frame` and `header_frame` get size asserts inside the window."""
+  uint16 = types.UIntType("ui16", 16)
+  uint32 = types.UIntType("ui32", 32)
+  element_id = "!hw.struct<x: ui32, y: ui32>"
+  list_id = f"!esi.list<{element_id}>"
+  arg_struct_id = f"!hw.struct<coords: {list_id}>"
+  header_struct_id = "!hw.struct<coords_count: ui16>"
+  data_struct_id = f"!hw.struct<coords: !hw.array<1x{element_id}>>"
+  lowered_id = f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>"
+  window_id = (f'!esi.window<"coords_only", {arg_struct_id}, '
+               '[<"header", [<"coords" countWidth 16>]>, '
+               '<"data", [<"coords", 1>]>]>')
+
+  element = types.StructType(element_id, [("x", uint32), ("y", uint32)])
+  coord_list = types.ListType(list_id, element)
+  arg_struct = types.StructType(arg_struct_id, [("coords", coord_list)])
+  header_struct = types.StructType(header_struct_id, [("coords_count", uint16)])
+  data_struct = types.StructType(
+      data_struct_id,
+      [("coords", types.ArrayType(f"!hw.array<1x{element_id}>", element, 1))],
+  )
+  lowered = types.UnionType(lowered_id, [("header", header_struct),
+                                         ("data", data_struct)])
+  window = types.WindowType(window_id, "coords_only", arg_struct, lowered, [
+      types.WindowType.Frame("header",
+                             [types.WindowType.Field("coords", 0, 16)]),
+      types.WindowType.Frame("data", [types.WindowType.Field("coords", 1, 0)]),
+  ])
+
+  hdr = _generate_header([window])
+  # Both inner frames are sized to the wider data frame: 8 bytes per coord.
+  assert "static_assert(sizeof(data_frame) == 8," in hdr
+  assert "static_assert(sizeof(header_frame) == 8," in hdr
+
+
+def test_size_assert_skipped_for_unbounded_struct():
+  """Structs containing an `!esi.any` field have no static size, so no assert."""
+  uint8 = types.UIntType("ui8", 8)
+  any_t = types.AnyType("!esi.any")
+  s = types.StructType("!hw.struct<tag: ui8, data: !esi.any>",
+                       [("tag", uint8), ("data", any_t)])
+
+  hdr = _generate_header([s])
+  # The struct is still emitted, but no size assert (its size is unbounded).
+  assert "struct _struct_tag_ui8_data__esi_any" in hdr
+  assert "static_assert(sizeof(_struct_tag_ui8_data__esi_any)" not in hdr


### PR DESCRIPTION
- Move from C arrays (`T[N]`) to C++ `std:array`s.
- Surround only structs which need to be packed with that pragma.

Assisted-by: vscode:Claude Opus 4.7
