### PR TITLE
[ESI][Runtime] Codegen: window TypeDeserializers

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -214,6 +214,13 @@ public:
   }
   const Type *getType() const { return type; }
 
+  /// If this port carries a windowed type, return the original WindowType
+  /// (whose `intoType` is what `getType()` returns). Returns nullptr for
+  /// non-windowed ports.
+  const WindowType *getWindowType() const {
+    return translationInfo ? translationInfo->windowType : nullptr;
+  }
+
 protected:
   const Type *type;
 

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
@@ -309,6 +309,91 @@ private:
   std::mutex mutex;
 };
 
+/// Reusable serial-list window deserializer.
+///
+/// Walks the serial-list multi-burst protocol used by codegen'd window
+/// helpers -- zero or more `header(N>0) + N data` bursts terminated by a
+/// `header(0)` footer -- and emits a fully-formed `T` instance built from the
+/// accumulated header fields and data frames.
+///
+/// `T` must be a generated window helper that exposes:
+///  - nested `header_frame` / `data_frame` types of identical size,
+///  - `count_type`,
+///  - `static count_type T::_headerCount(const header_frame &)`,
+///  - `static std::unique_ptr<T> T::_fromFrames(const header_frame &,
+///        std::vector<data_frame> &&)`.
+///
+/// `T` typically declares `SerialListTypeDeserializer<T>` as a friend so the
+/// template can reach the (private) `header_frame` definition; the helpers
+/// themselves can stay private as well.
+template <typename T>
+class SerialListTypeDeserializer : public QueuedDecodeTypeDeserializer<T> {
+public:
+  using Base = QueuedDecodeTypeDeserializer<T>;
+  using OutputCallback = typename Base::OutputCallback;
+  using DecodedOutputs = typename Base::DecodedOutputs;
+
+  explicit SerialListTypeDeserializer(OutputCallback output)
+      : Base(std::move(output)) {}
+
+private:
+  using header_frame = typename T::header_frame;
+  using data_frame = typename T::data_frame;
+  using count_type = typename T::count_type;
+
+  static_assert(sizeof(header_frame) == sizeof(data_frame),
+                "header and data frames must be the same width");
+  static constexpr size_t kFrameSize = sizeof(data_frame);
+
+  DecodedOutputs decode(std::unique_ptr<SegmentedMessageData> &msg) override {
+    DecodedOutputs out;
+    MessageData scratch;
+    const MessageData &flat = detail::getMessageDataRef<T>(*msg, scratch);
+    const uint8_t *bytes = flat.getBytes();
+    size_t size = flat.getSize();
+
+    size_t offset = 0;
+    while (offset < size) {
+      size_t needed = kFrameSize - partial_.size();
+      size_t chunk = std::min(needed, size - offset);
+      partial_.insert(partial_.end(), bytes + offset, bytes + offset + chunk);
+      offset += chunk;
+      if (partial_.size() != kFrameSize)
+        break;
+
+      if (remaining_ == 0) {
+        // Header frame: capture static fields and burst count.
+        std::memcpy(&pending_header_, partial_.data(), kFrameSize);
+        partial_.clear();
+        count_type batchCount = T::_headerCount(pending_header_);
+        if (batchCount == 0) {
+          // Footer: emit the accumulated value.
+          out.push_back(
+              T::_fromFrames(pending_header_, std::move(pending_frames_)));
+          pending_frames_.clear();
+          continue;
+        }
+        remaining_ = batchCount;
+        continue;
+      }
+
+      // Data frame.
+      auto &frame = pending_frames_.emplace_back();
+      std::memcpy(&frame, partial_.data(), kFrameSize);
+      partial_.clear();
+      --remaining_;
+    }
+
+    msg.reset();
+    return out;
+  }
+
+  std::vector<uint8_t> partial_;
+  header_frame pending_header_{};
+  std::vector<data_frame> pending_frames_;
+  count_type remaining_ = 0;
+};
+
 //===----------------------------------------------------------------------===//
 // Type-trait: detect T::_ESI_ID (a static constexpr std::string_view).
 //===----------------------------------------------------------------------===//
@@ -322,6 +407,18 @@ struct has_esi_id<T, std::void_t<decltype(T::_ESI_ID)>>
 
 template <typename T>
 inline constexpr bool has_esi_id_v = has_esi_id<T>::value;
+
+// Detect T::_ESI_WINDOW_ID (a static constexpr std::string_view) for
+// generated SegmentedMessageData subclasses bound to a specific WindowType.
+template <typename T, typename = void>
+struct has_esi_window_id : std::false_type {};
+
+template <typename T>
+struct has_esi_window_id<T, std::void_t<decltype(T::_ESI_WINDOW_ID)>>
+    : std::is_convertible<decltype(T::_ESI_WINDOW_ID), std::string_view> {};
+
+template <typename T>
+inline constexpr bool has_esi_window_id_v = has_esi_window_id<T>::value;
 
 //===----------------------------------------------------------------------===//
 // verifyTypeCompatibility<T>(const Type *portType)
@@ -337,6 +434,29 @@ void verifyTypeCompatibility(const Type *portType) {
 
   // Unwrap TypeAliasType to get the inner type for verification.
   portType = unwrapTypeAlias(portType);
+
+  // If the port is a windowed type, verify the window id (if T declares one)
+  // and then continue checking the inner ('into') type.
+  if (auto *windowType = dynamic_cast<const WindowType *>(portType)) {
+    if constexpr (has_esi_window_id_v<T>) {
+      if (std::string_view(windowType->getID()) != T::_ESI_WINDOW_ID)
+        throw AcceleratorMismatchError(
+            "ESI window mismatch: C++ type has _ESI_WINDOW_ID '" +
+            std::string(T::_ESI_WINDOW_ID) + "' but port window type is '" +
+            windowType->toString(/*oneLine=*/true) + "'");
+    } else {
+      throw AcceleratorMismatchError(
+          "ESI type mismatch: port is a window type ('" +
+          windowType->toString(/*oneLine=*/true) +
+          "') but C++ type has no _ESI_WINDOW_ID");
+    }
+    portType = unwrapTypeAlias(windowType->getIntoType());
+  } else if constexpr (has_esi_window_id_v<T>) {
+    throw AcceleratorMismatchError(
+        std::string("ESI type mismatch: C++ type has _ESI_WINDOW_ID '") +
+        std::string(T::_ESI_WINDOW_ID) + "' but port type is not a window: '" +
+        portType->toString(/*oneLine=*/true) + "'");
+  }
 
   if constexpr (has_esi_id_v<T>) {
     // Highest priority: user-defined ESI ID string comparison.
@@ -406,6 +526,37 @@ void verifyTypeCompatibility(const Type *portType) {
   }
 }
 
+// Port-aware overload: when checking against a ChannelPort, also reconcile
+// the windowed wrapper. ChannelPort::getType() returns the unwrapped 'into'
+// type for windowed ports, so we have to consult getWindowType() directly to
+// detect the window and forward the original WindowType into the Type-based
+// overload above.
+template <typename T>
+void verifyTypeCompatibility(const ChannelPort *port) {
+  if (!port)
+    throw AcceleratorMismatchError("Port is null");
+  const WindowType *windowType = port->getWindowType();
+  if constexpr (has_esi_window_id_v<T>) {
+    if (!windowType)
+      throw AcceleratorMismatchError(
+          std::string("ESI type mismatch: C++ type has _ESI_WINDOW_ID '") +
+          std::string(T::_ESI_WINDOW_ID) +
+          "' but port is not a window type ('" +
+          (port->getType() ? port->getType()->toString(/*oneLine=*/true)
+                           : std::string("<null>")) +
+          "')");
+  } else {
+    if (windowType)
+      throw AcceleratorMismatchError(
+          "ESI type mismatch: port is a window type ('" +
+          windowType->toString(/*oneLine=*/true) +
+          "') but C++ type has no _ESI_WINDOW_ID");
+  }
+  const Type *forwardType =
+      windowType ? static_cast<const Type *>(windowType) : port->getType();
+  verifyTypeCompatibility<T>(forwardType);
+}
+
 //===----------------------------------------------------------------------===//
 // TypedWritePort<T, SkipTypeCheck = false>
 //
@@ -425,7 +576,7 @@ public:
     if (!inner)
       throw AcceleratorMismatchError("TypedWritePort: null port pointer");
     if (!SkipTypeCheck)
-      verifyTypeCompatibility<T>(inner->getType());
+      verifyTypeCompatibility<T>(inner);
     wireInfo_ = getWireInfo(inner->getType());
     inner->connect(opts);
   }
@@ -661,9 +812,9 @@ private:
     if (mode != Mode::Disconnected)
       throw std::runtime_error("Channel already connected");
     if constexpr (has_esi_id_v<T>) {
-      verifyTypeCompatibility<T>(inner->getType());
+      verifyTypeCompatibility<T>(inner);
     } else if constexpr (!detail::has_type_deserializer_v<T>) {
-      verifyTypeCompatibility<T>(inner->getType());
+      verifyTypeCompatibility<T>(inner);
       wireInfo_ = getWireInfo(inner->getType());
     }
   }

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
@@ -32,6 +32,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <stdexcept>
 #include <string>
@@ -362,24 +363,30 @@ private:
         break;
 
       if (remaining_ == 0) {
-        // Header or footer frame. Preserve the last non-zero header's static
-        // fields so a footer, which may only set count=0, does not clobber
-        // them before reconstruction.
-        count_type batchCount =
-            T::_headerCount(*reinterpret_cast<const frame_type *>(
-                partial_.data()));
+        // Header or footer frame. Decode into a local frame first so we can
+        // inspect the count without committing. Only the first header of a
+        // transaction is guaranteed to carry valid static fields; the static
+        // slots of continuation and footer headers may be garbage.
+        header_frame frame{};
+        std::memcpy(&frame, partial_.data(), kFrameSize);
+        partial_.clear();
+        count_type batchCount = T::_headerCount(frame);
         if (batchCount == 0) {
-          partial_.clear();
-          // Footer: emit the accumulated value using the previously saved
-          // non-zero header frame.
+          // Footer: emit the accumulated value using the first header's
+          // static fields.
+          if (!pending_header_)
+            throw std::runtime_error(
+                "SerialListTypeDeserializer: footer received before any "
+                "header");
           out.push_back(
-              T::_fromFrames(pending_header_, std::move(pending_frames_)));
+              T::_fromFrames(*pending_header_, std::move(pending_frames_)));
           pending_frames_.clear();
+          pending_header_.reset();
           continue;
         }
 
-        std::memcpy(&pending_header_, partial_.data(), kFrameSize);
-        partial_.clear();
+        if (!pending_header_)
+          pending_header_ = frame;
         remaining_ = batchCount;
         continue;
       }
@@ -396,7 +403,7 @@ private:
   }
 
   std::vector<uint8_t> partial_;
-  header_frame pending_header_{};
+  std::optional<header_frame> pending_header_;
   std::vector<data_frame> pending_frames_;
   count_type remaining_ = 0;
 };

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
@@ -362,17 +362,24 @@ private:
         break;
 
       if (remaining_ == 0) {
-        // Header frame: capture static fields and burst count.
-        std::memcpy(&pending_header_, partial_.data(), kFrameSize);
-        partial_.clear();
-        count_type batchCount = T::_headerCount(pending_header_);
+        // Header or footer frame. Preserve the last non-zero header's static
+        // fields so a footer, which may only set count=0, does not clobber
+        // them before reconstruction.
+        count_type batchCount =
+            T::_headerCount(*reinterpret_cast<const frame_type *>(
+                partial_.data()));
         if (batchCount == 0) {
-          // Footer: emit the accumulated value.
+          partial_.clear();
+          // Footer: emit the accumulated value using the previously saved
+          // non-zero header frame.
           out.push_back(
               T::_fromFrames(pending_header_, std::move(pending_frames_)));
           pending_frames_.clear();
           continue;
         }
+
+        std::memcpy(&pending_header_, partial_.data(), kFrameSize);
+        partial_.clear();
         remaining_ = batchCount;
         continue;
       }

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -164,11 +164,23 @@ class CppTypePlanner:
     return self._reserve_name("_".join(parts), is_alias=False)
 
   def _auto_window_name(self, window_type: types.WindowType) -> str:
-    """Derive a deterministic name for generated window helpers."""
-    if window_type.name:
-      return self._reserve_name(window_type.name, is_alias=False)
-    return self._reserve_name(f"_window_{self._sanitize_name(window_type.id)}",
-                              is_alias=False)
+    """Derive a deterministic name for generated window helpers.
+
+    Two distinct windows can wrap the same `into` struct (e.g. serial and
+    parallel encodings of the same payload), so the helper name must be
+    derived from BOTH the inner type's name and the window's own name/id.
+    """
+    into_type = self._unwrap_aliases(window_type.into_type)
+    into_name = self.type_id_map.get(into_type)
+    window_part = (window_type.name
+                   if window_type.name else self._sanitize_name(window_type.id))
+    if into_name:
+      base = f"{into_name}_{window_part}"
+    elif window_type.name:
+      base = window_part
+    else:
+      base = f"_window_{window_part}"
+    return self._reserve_name(base, is_alias=False)
 
   def _unwrap_aliases(self, wrapped: types.ESIType) -> types.ESIType:
     while isinstance(wrapped, types.TypeAlias):
@@ -817,9 +829,6 @@ class CppTypeEmitter:
     hdr.write(f"    frames.reserve({info['list_field_name']}.size());\n")
     hdr.write(f"    for (const auto &element : {info['list_field_name']}) {{\n")
     hdr.write("      auto &frame = frames.emplace_back();\n")
-    # The data_frame list field is now stored as either a scalar/struct
-    # (assignable) or std::array (also assignable), so a plain assignment
-    # always works regardless of element type.
     hdr.write(f"      frame.{info['list_field_name']} = element;\n")
     hdr.write("    }\n")
     hdr.write(f"    construct({helper_call});\n")
@@ -844,9 +853,16 @@ class CppTypeEmitter:
     )
     hdr.write("  }\n\n")
     hdr.write(
-        f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(window_type.id)};\n"
+        f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(self._unwrap_aliases(window_type.into_type).id)};\n"
+    )
+    # The into-type id alone cannot distinguish two different windows over
+    # the same underlying struct (e.g. serial vs. parallel list encoding).
+    # Emit the window id so the runtime can verify the wire format too.
+    hdr.write(
+        f"  static constexpr std::string_view _ESI_WINDOW_ID = {self._cpp_string_literal(window_type.id)};\n"
     )
     self._emit_window_data_accessors(hdr, info)
+    self._emit_window_deserializer(hdr, info)
     hdr.write("};\n\n")
 
   def _emit_window_data_accessors(self, hdr: TextIO, info) -> None:
@@ -910,6 +926,51 @@ class CppTypeEmitter:
                 f"    return out;\n"
                 f"  }}\n")
 
+  def _emit_window_deserializer(self, hdr: TextIO, info) -> None:
+    """Emit a few bridge helpers + a `TypeDeserializer` alias.
+
+    The actual decoder lives in `esi::SerialListTypeDeserializer<T>`, which
+    walks the header/data/footer burst protocol generically. Each window
+    helper only has to expose:
+
+      - `_headerCount(const header_frame &)` -> `count_type`
+      - `_fromFrames(const header_frame &, std::vector<data_frame> &&)`
+        -> `std::unique_ptr<T>`
+
+    plus a `friend class esi::SerialListTypeDeserializer<T>;` so the template
+    can reach the (private) `header_frame` definition.
+    """
+    window_name = info["window_name"]
+    count_field_name = info["count_field_name"]
+    ctor_args = ", ".join(f"h.{name}" for name, _ in info["ctor_params"])
+    if ctor_args:
+      ctor_args = f"{ctor_args}, std::move(frames)"
+    else:
+      ctor_args = "std::move(frames)"
+
+    hdr.write("\n")
+    hdr.write("private:\n")
+    hdr.write(
+        "  // Bridge helpers used by esi::SerialListTypeDeserializer<T>; the\n")
+    hdr.write(
+        "  // template walks the serial-list burst protocol generically and\n")
+    hdr.write(
+        "  // reaches into `header_frame` via the friend declaration below.\n")
+    hdr.write("  static count_type _headerCount(const header_frame &h) {\n")
+    hdr.write(f"    return h.{count_field_name};\n")
+    hdr.write("  }\n")
+    hdr.write(f"  static std::unique_ptr<{window_name}> _fromFrames(\n")
+    hdr.write(
+        "      const header_frame &h, std::vector<data_frame> &&frames) {\n")
+    hdr.write(f"    return std::make_unique<{window_name}>({ctor_args});\n")
+    hdr.write("  }\n")
+    hdr.write(
+        f"  friend class esi::SerialListTypeDeserializer<{window_name}>;\n\n")
+    hdr.write("public:\n")
+    hdr.write(
+        f"  using TypeDeserializer = esi::SerialListTypeDeserializer<{window_name}>;\n"
+    )
+
   def _emit_alias(self, hdr: TextIO, alias_type: types.TypeAlias) -> None:
     """Emit a using alias when the alias targets a different C++ type."""
     inner_wrapped = alias_type.inner_type
@@ -943,6 +1004,7 @@ class CppTypeEmitter:
         #include <vector>
 
         #include "esi/Common.h"
+        #include "esi/TypedPorts.h"
 
         namespace {system_name} {{
 

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
@@ -206,10 +206,12 @@ TEST(TypedPortsTest, ESIIDTypeCompatibility) {
 }
 
 TEST(TypedPortsTest, NullPortTypeThrows) {
-  EXPECT_THROW(verifyTypeCompatibility<int32_t>(nullptr),
-               AcceleratorMismatchError);
-  EXPECT_THROW(verifyTypeCompatibility<void>(nullptr),
-               AcceleratorMismatchError);
+  EXPECT_THROW(
+      verifyTypeCompatibility<int32_t>(static_cast<const Type *>(nullptr)),
+      AcceleratorMismatchError);
+  EXPECT_THROW(
+      verifyTypeCompatibility<void>(static_cast<const Type *>(nullptr)),
+      AcceleratorMismatchError);
 }
 
 // A type that is not integral and has no _ESI_ID — should hit fallback.

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/loopback.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/loopback.cpp
@@ -256,6 +256,16 @@ static void serialCoordTranslateTest(Accelerator *accel) {
   // TODO: List results are currently not supported so we cannot compare the
   // results.
   (void)translateCoords.call(batch).get();
+
+  // The bulk-list reply arrives as numCoords data frames plus a footer header,
+  // but `TypedFunction::call()` only waits on the first frame. Drain the rest
+  // off the raw read channel so they don't sit in the polling queue and race
+  // with disconnect/teardown.
+  auto *func = portIter->second.getAs<services::FuncService::Function>();
+  ReadChannelPort &rawResult = func->getRawRead("result");
+  MessageData drained;
+  for (size_t i = 0; i < numCoords + 1; ++i)
+    rawResult.read(drained);
 }
 
 int main(int argc, const char *argv[]) {

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/loopback_typed.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/loopback_typed.cpp
@@ -176,24 +176,11 @@ static void runSInt4Loopback(Accelerator *accel) {
 // SerialCoordTranslator test
 //
 
-using SerialCoordInput = esi_system::serial_coord_args;
+using SerialCoordInput = esi_system::
+    _struct_x_translation_i32_y_translation_i32_coords__esi_list__hw_struct_x__i32__y__i32___serial_coord_args;
+using SerialCoordResult = esi_system::
+    _struct_coords__esi_list__hw_struct_x__i32__y__i32___serial_coord_result;
 using SerialCoordValue = SerialCoordInput::value_type;
-
-#pragma pack(push, 1)
-struct SerialCoordOutputHeader {
-  uint8_t _pad[6];
-  uint16_t coordsCount;
-};
-struct SerialCoordOutputData {
-  uint32_t y;
-  uint32_t x;
-};
-union SerialCoordOutputFrame {
-  SerialCoordOutputHeader header;
-  SerialCoordOutputData data;
-};
-#pragma pack(pop)
-static_assert(sizeof(SerialCoordOutputFrame) == 8, "Size mismatch");
 
 static void serialCoordTranslateTest(Accelerator *accel) {
   size_t numCoords = 100;
@@ -223,49 +210,36 @@ static void serialCoordTranslateTest(Accelerator *accel) {
     throw std::runtime_error(
         "Serial coord translate test: port is not a FuncService::Function");
 
-  // Keep the raw result channel here: the serial window reply arrives as
-  // multiple frames, while FuncService::Function / TypedFunction only waits
-  // for a single result message.
-  TypedWritePort<SerialCoordInput, /*SkipTypeCheck=*/true> argPort(
-      func->getRawWrite("arg"));
-  ReadChannelPort &resultPort = func->getRawRead("result");
+  // Drive the serial-list window through the generated typed helpers. The
+  // arg helper packs the static fields and value list into the
+  // header/data/footer frame protocol; the result helper's nested
+  // TypeDeserializer reassembles the reply frames into a single
+  // SerialCoordResult value, which we then iterate via its accessors.
+  TypedWritePort<SerialCoordInput> argPort(func->getRawWrite("arg"));
+  TypedReadPort<SerialCoordResult> resultPort(func->getRawRead("result"));
 
+  // Raw frame transport: the runtime translator does not handle serial-list
+  // windows, so leave message translation off and let the generated
+  // TypeDeserializer walk the burst protocol directly.
   argPort.connect(ChannelPort::ConnectOptions(std::nullopt, false));
   resultPort.connect(ChannelPort::ConnectOptions(std::nullopt, false));
 
   auto batch = std::make_unique<SerialCoordInput>(xTrans, yTrans, coords);
   argPort.write(batch);
 
-  std::vector<SerialCoordValue> results;
-  while (true) {
-    MessageData msg;
-    resultPort.read(msg);
-    if (msg.getSize() != sizeof(SerialCoordOutputFrame))
-      throw std::runtime_error("Unexpected result message size");
+  std::unique_ptr<SerialCoordResult> result = resultPort.read();
+  if (!result)
+    throw std::runtime_error("Serial coord translate test: null result");
 
-    const auto *frame =
-        reinterpret_cast<const SerialCoordOutputFrame *>(msg.getBytes());
-    uint16_t batchCount = frame->header.coordsCount;
-    if (batchCount == 0)
-      break;
-
-    for (uint16_t i = 0; i < batchCount; ++i) {
-      resultPort.read(msg);
-      if (msg.getSize() != sizeof(SerialCoordOutputFrame))
-        throw std::runtime_error("Unexpected result message size");
-      const auto *dFrame =
-          reinterpret_cast<const SerialCoordOutputFrame *>(msg.getBytes());
-      results.push_back({dFrame->data.y, dFrame->data.x});
-    }
-  }
-
-  if (results.size() != coords.size())
+  if (result->coords_count() != coords.size())
     throw std::runtime_error("Serial coord translate result size mismatch");
-  for (size_t i = 0; i < coords.size(); ++i) {
+  size_t i = 0;
+  for (const SerialCoordValue &got : result->coords()) {
     uint32_t expX = coords[i].x + xTrans;
     uint32_t expY = coords[i].y + yTrans;
-    if (results[i].x != expX || results[i].y != expY)
+    if (got.x != expX || got.y != expY)
       throw std::runtime_error("Serial coord translate result mismatch");
+    ++i;
   }
 
   argPort.disconnect();

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -1,5 +1,6 @@
 """Tests for UnionType support in codegen (CppTypePlanner + CppTypeEmitter)."""
 
+import re
 import tempfile
 from pathlib import Path
 
@@ -14,6 +15,19 @@ def _generate_header(type_table, system_name="test_ns"):
   with tempfile.TemporaryDirectory() as tmpdir:
     emitter.write_header(Path(tmpdir), system_name)
     return (Path(tmpdir) / "types.h").read_text()
+
+
+def _window_struct_name(hdr, window_name_suffix):
+  """Find the generated SegmentedMessageData subclass name for a window.
+
+  Auto-names compose `{into_name}_{window_name}`, so locate the helper by its
+  trailing window-name suffix instead of hard-coding the full identifier.
+  """
+  match = re.search(
+      rf"struct (\S*{re.escape(window_name_suffix)}) "
+      r": public esi::SegmentedMessageData", hdr)
+  assert match, f"Window helper for '*{window_name_suffix}' not found in:\n{hdr}"
+  return match.group(1)
 
 
 def test_union_basic():
@@ -228,7 +242,8 @@ def test_windowed_list_bulk_message_wrapper():
 
   hdr = _generate_header([coord, serial_args])
   assert "Unsupported type" not in hdr
-  assert "struct serial_coord_args : public esi::SegmentedMessageData" in hdr
+  win_name = _window_struct_name(hdr, "_serial_coord_args")
+  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
   assert "using value_type = Coord;" in hdr
   assert "using count_type = uint16_t;" in hdr
   assert "count_type coords_count;" in hdr
@@ -245,8 +260,13 @@ def test_windowed_list_bulk_message_wrapper():
   assert "auto &frame = frames.emplace_back();" in hdr
   assert "for (const auto &element : coords) {" in hdr
   assert "frame.coords = element;" in hdr
-  assert '!esi.window<\\"serial_coord_args\\"' in hdr
-  assert 'throw std::out_of_range("serial_coord_args: invalid segment index")' in hdr  # Accessor methods for header fields and data fields.
+  # Inner struct id is _ESI_ID; window id (with escaped quotes) is
+  # _ESI_WINDOW_ID so the runtime can verify the wire format too.
+  assert f'_ESI_ID = "{arg_struct_id}"' in hdr
+  escaped_serial_args_id = serial_args_id.replace('"', '\\"')
+  assert f'_ESI_WINDOW_ID = "{escaped_serial_args_id}"' in hdr
+  assert f'throw std::out_of_range("{win_name}: invalid segment index")' in hdr
+  # Accessor methods for header fields and data fields.
   assert "uint32_t x_translation() const { return header.x_translation; }" in hdr
   assert "uint32_t y_translation() const { return header.y_translation; }" in hdr
   assert "size_t coords_count() const { return data_frames.size(); }" in hdr
@@ -287,7 +307,8 @@ def test_windowed_list_header_padding_matches_frame_width():
   ])
 
   hdr = _generate_header([window])
-  assert "struct coords_only : public esi::SegmentedMessageData" in hdr
+  win_name = _window_struct_name(hdr, "_coords_only")
+  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
   assert "struct header_frame {\n    uint8_t _pad[6];\n    count_type coords_count;\n  };" in hdr
   assert "header_frame footer{};" in hdr
   assert "void construct(std::vector<data_frame> frames)" in hdr
@@ -341,7 +362,8 @@ def test_windowed_list_arrays_in_header_and_value_type():
 
   hdr = _generate_header([window])
   assert "#include <array>" in hdr
-  assert "struct array_payloads : public esi::SegmentedMessageData" in hdr
+  win_name = _window_struct_name(hdr, "_array_payloads")
+  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
   # `value_type` is exposed as `std::array` so it is storable in `std::vector`.
   assert "using value_type = std::array<uint8_t, 4>;" in hdr
   assert "using count_type = uint16_t;" in hdr
@@ -349,12 +371,12 @@ def test_windowed_list_arrays_in_header_and_value_type():
   assert "std::array<uint16_t, 2> header_words;" in hdr
   assert "std::array<uint8_t, 4> payloads;" in hdr
   # Constructor params for arrays are simple const-refs to `std::array`.
-  assert "array_payloads(const std::array<uint16_t, 2> &header_words, const std::vector<value_type> &payloads)" in hdr
+  assert f"{win_name}(const std::array<uint16_t, 2> &header_words, const std::vector<value_type> &payloads)" in hdr
   assert "void construct(const std::array<uint16_t, 2> &header_words, std::vector<data_frame> frames)" in hdr
   # Plain `=` assignment for both header and data array fields.
   assert "header.header_words = header_words;" in hdr
   assert "frame.payloads = element;" in hdr
-  assert 'throw std::out_of_range("array_payloads: invalid segment index")' in hdr
+  assert f'throw std::out_of_range("{win_name}: invalid segment index")' in hdr
   # Array-typed header field: const-ref accessor with std::array return type.
   assert "const std::array<uint16_t, 2> &header_words() const { return header.header_words; }" in hdr
   # Array-typed data field: pointer-to-member projection (zero-copy view) and
@@ -401,7 +423,8 @@ def test_windowed_list_struct_element_data_uses_pointer_to_member():
   ])
 
   hdr = _generate_header([elem_struct, window])
-  assert "struct bitfield_items : public esi::SegmentedMessageData" in hdr
+  win_name = _window_struct_name(hdr, "_bitfield_items")
+  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
   # The data field "items" is a struct type (byte-aligned), so pointer-to-member
   # IS valid.  The generated accessor must use &data_frame::items, not a lambda.
   assert "return std::views::transform(data_frames, &data_frame::items);" in hdr
@@ -438,7 +461,8 @@ def test_windowed_list_bitfield_scalar_data_uses_lambda():
   ])
 
   hdr = _generate_header([window])
-  assert "struct bitval_window : public esi::SegmentedMessageData" in hdr
+  win_name = _window_struct_name(hdr, "_bitval_window")
+  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
   # The data field "vals" stores a 3-bit uint, which becomes a bit-field.
   # The range accessor must use a lambda, not &data_frame::vals.
   assert "[](const data_frame &f) { return f.vals; }" in hdr


### PR DESCRIPTION
Each window helper now emits a nested `TypeDeserializer` based on `QueuedDecodeTypeDeserializer`, walking the bulk header/data/footer burst protocol and emitting a fully-formed `SegmentedMessageData` subclass via the same frame constructor used on the write side.

Updated the typed loopback integration test to use the generated `SerialCoordResult` and its `coords()` accessor instead of a hand-rolled frame walk.

Also adds type verification by both underlying type and window type.

Assisted-by: vscode:Claude Opus 4.7

