### PR TITLE
[ESI][Runtime] Support lists in TypedFunction/TypedCallback

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
@@ -675,7 +675,7 @@ private:
 ///
 /// Polling reads return `std::unique_ptr<T>` so complex decoded values can be
 /// delivered without an extra copy.
-template <typename T>
+template <typename T, bool SkipTypeCheck = false>
 class TypedReadPort {
 public:
   explicit TypedReadPort(ReadChannelPort &port) : inner(&port) {}
@@ -825,7 +825,12 @@ private:
   void prepareConnect() {
     if (mode != Mode::Disconnected)
       throw std::runtime_error("Channel already connected");
-    if constexpr (has_esi_id_v<T>) {
+    if constexpr (SkipTypeCheck) {
+      // Skip verification, but still compute wireInfo for the POD path so
+      // small / non-byte-aligned wire widths still encode correctly.
+      if constexpr (!detail::has_type_deserializer_v<T>)
+        wireInfo_ = getWireInfo(inner->getType());
+    } else if constexpr (has_esi_id_v<T>) {
       verifyTypeCompatibility<T>(inner);
     } else if constexpr (!detail::has_type_deserializer_v<T>) {
       verifyTypeCompatibility<T>(inner);
@@ -899,10 +904,53 @@ private:
 //===----------------------------------------------------------------------===//
 // TypedFunction<ArgT, ResultT>
 //
-// Non-owning wrapper around FuncService::Function that provides strongly-typed
-// call() and connect() APIs. Implicitly constructible from Function* (the
-// return type of BundlePort::getAs<FuncService::Function>()).
+// Strongly-typed function-call wrapper built on top of TypedWritePort and
+// TypedReadPort. Implicitly constructible from `FuncService::Function *` (the
+// return type of `BundlePort::getAs<FuncService::Function>()`); construction
+// resolves the underlying raw "arg" / "result" channels but does not connect
+// them until `connect()` is called.
+//
+// We intentionally bypass `FuncService::Function::call`. That helper returns
+// the future from a single `result->readAsync()`, which only sees one raw
+// frame and would race when the response is multi-frame or when calls are
+// pipelined. Driving a `TypedReadPort<ResultT>` instead reuses its persistent
+// per-port deserializer (so partial frames / pending outputs survive between
+// calls) and its FIFO polling buffer (so pipelined `readAsync()` futures
+// hand back per-call decoded values in call order, even when consumers
+// `.get()` them out of order).
 //===----------------------------------------------------------------------===//
+
+namespace detail {
+
+/// Standard ConnectOptions for typed function ports: untranslated frames so
+/// the deserializer can see raw frame boundaries.
+inline ChannelPort::ConnectOptions typedFunctionConnectOptions() {
+  return ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
+                                     /*translateMessage=*/false);
+}
+
+/// Convert a `std::future<std::unique_ptr<T>>` (as returned by
+/// `TypedReadPort::readAsync()`) into a `std::future<T>`. Uses a deferred
+/// async so `.get()` blocks only when the caller actually waits for the
+/// value, preserving the per-call FIFO ordering of the underlying polling
+/// buffer.
+template <typename T>
+std::future<T> awaitDecoded(std::future<std::unique_ptr<T>> inner) {
+  return std::async(std::launch::deferred,
+                    [fut = std::move(inner)]() mutable -> T {
+                      std::unique_ptr<T> v = fut.get();
+                      return std::move(*v);
+                    });
+}
+
+/// Throw the standard "null Function pointer" error used by every
+/// TypedFunction specialization.
+[[noreturn]] inline void throwNullFunction() {
+  throw AcceleratorMismatchError(
+      "TypedFunction: null Function pointer (getAs failed or wrong type)");
+}
+
+} // namespace detail
 
 template <typename ArgT, typename ResultT, bool SkipTypeCheck = false>
 class TypedFunction {
@@ -910,29 +958,47 @@ public:
   /// Implicit conversion from Function* (returned by getAs<>()).
   // NOLINTNEXTLINE(google-explicit-constructor)
   TypedFunction(services::FuncService::Function *func) : inner(func) {}
+  TypedFunction(const TypedFunction &) = delete;
+  TypedFunction &operator=(const TypedFunction &) = delete;
 
   void connect() {
     if (!inner)
-      throw AcceleratorMismatchError(
-          "TypedFunction: null Function pointer (getAs failed or wrong type)");
-    if constexpr (!SkipTypeCheck) {
-      verifyTypeCompatibility<ArgT>(inner->getArgType());
-      verifyTypeCompatibility<ResultT>(inner->getResultType());
-    }
-    argWireInfo_ = getWireInfo(inner->getArgType());
-    resWireInfo_ = getWireInfo(inner->getResultType());
-    inner->connect(ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
-                                               /*translateMessage=*/false));
+      detail::throwNullFunction();
+    argPort.emplace(&inner->getRawWrite("arg"));
+    resultPort.emplace(&inner->getRawRead("result"));
+    auto opts = detail::typedFunctionConnectOptions();
+    argPort->connect(opts);
+    resultPort->connect(opts);
   }
 
   std::future<ResultT> call(const ArgT &arg) {
-    WireInfo rwb = resWireInfo_;
-    auto f = inner->call(toMessageData(arg, argWireInfo_));
-    return std::async(std::launch::deferred,
-                      [fut = std::move(f), rwb]() mutable -> ResultT {
-                        MessageData data = fut.get();
-                        return fromMessageData<ResultT>(data, rwb);
-                      });
+    // Serialize the per-call write+readAsync pair so the polling buffer's
+    // FIFO matches the call FIFO. Pipelined calls are still allowed -- the
+    // shared deserializer drains responses in wire order and the FIFO
+    // ensures call N's future resolves to call N's result, regardless of
+    // the order in which callers `.get()` the futures.
+    std::scoped_lock<std::mutex> lock(callMutex);
+    argPort->write(arg);
+    return detail::awaitDecoded<ResultT>(resultPort->readAsync());
+  }
+
+  /// Emplace-style call: constructs `ArgT` in-place from the forwarded
+  /// arguments and forwards to `call(const ArgT &)`. SFINAE-disabled for the
+  /// single-`ArgT`-argument case so it does not shadow the lvalue overload.
+  template <
+      typename First, typename... Rest,
+      typename = std::enable_if_t<
+          std::is_constructible_v<ArgT, First, Rest...> &&
+          (!std::is_same_v<std::decay_t<First>, ArgT> || sizeof...(Rest) != 0)>>
+  std::future<ResultT> call(First &&first, Rest &&...rest) {
+    return call(ArgT(std::forward<First>(first), std::forward<Rest>(rest)...));
+  }
+
+  /// Function-call operator overloads: forward to `call()`.
+  template <typename... Args>
+  auto operator()(Args &&...args)
+      -> decltype(this->call(std::forward<Args>(args)...)) {
+    return call(std::forward<Args>(args)...);
   }
 
   services::FuncService::Function &raw() { return *inner; }
@@ -940,8 +1006,9 @@ public:
 
 private:
   services::FuncService::Function *inner;
-  WireInfo argWireInfo_;
-  WireInfo resWireInfo_;
+  std::optional<TypedWritePort<ArgT, SkipTypeCheck>> argPort;
+  std::optional<TypedReadPort<ResultT, SkipTypeCheck>> resultPort;
+  std::mutex callMutex;
 };
 
 /// Partial specialization: void argument, typed result.
@@ -950,35 +1017,36 @@ class TypedFunction<void, ResultT, SkipTypeCheck> {
 public:
   // NOLINTNEXTLINE(google-explicit-constructor)
   TypedFunction(services::FuncService::Function *func) : inner(func) {}
+  TypedFunction(const TypedFunction &) = delete;
+  TypedFunction &operator=(const TypedFunction &) = delete;
 
   void connect() {
     if (!inner)
-      throw AcceleratorMismatchError(
-          "TypedFunction: null Function pointer (getAs failed or wrong type)");
-    if constexpr (!SkipTypeCheck) {
-      verifyTypeCompatibility<void>(inner->getArgType());
-      verifyTypeCompatibility<ResultT>(inner->getResultType());
-    }
-    inner->connect(ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
-                                               /*translateMessage=*/false));
+      detail::throwNullFunction();
+    argPort.emplace(&inner->getRawWrite("arg"));
+    resultPort.emplace(&inner->getRawRead("result"));
+    auto opts = detail::typedFunctionConnectOptions();
+    argPort->connect(opts);
+    resultPort->connect(opts);
   }
 
   std::future<ResultT> call() {
-    uint8_t zero = 0;
-    const Type *resType = inner->getResultType();
-    auto f = inner->call(MessageData(&zero, 1));
-    return std::async(std::launch::deferred,
-                      [fut = std::move(f), resType]() mutable -> ResultT {
-                        MessageData data = fut.get();
-                        return fromMessageData<ResultT>(data, resType);
-                      });
+    std::scoped_lock<std::mutex> lock(callMutex);
+    argPort->write();
+    return detail::awaitDecoded<ResultT>(resultPort->readAsync());
   }
+
+  /// Function-call operator overload: forwards to `call()`.
+  std::future<ResultT> operator()() { return call(); }
 
   services::FuncService::Function &raw() { return *inner; }
   const services::FuncService::Function &raw() const { return *inner; }
 
 private:
   services::FuncService::Function *inner;
+  std::optional<TypedWritePort<void>> argPort;
+  std::optional<TypedReadPort<ResultT, SkipTypeCheck>> resultPort;
+  std::mutex callMutex;
 };
 
 /// Partial specialization: typed argument, void result.
@@ -987,24 +1055,42 @@ class TypedFunction<ArgT, void, SkipTypeCheck> {
 public:
   // NOLINTNEXTLINE(google-explicit-constructor)
   TypedFunction(services::FuncService::Function *func) : inner(func) {}
+  TypedFunction(const TypedFunction &) = delete;
+  TypedFunction &operator=(const TypedFunction &) = delete;
 
   void connect() {
     if (!inner)
-      throw AcceleratorMismatchError(
-          "TypedFunction: null Function pointer (getAs failed or wrong type)");
-    if constexpr (!SkipTypeCheck) {
-      verifyTypeCompatibility<ArgT>(inner->getArgType());
-      verifyTypeCompatibility<void>(inner->getResultType());
-    }
-    argWireInfo_ = getWireInfo(inner->getArgType());
-    inner->connect(ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
-                                               /*translateMessage=*/false));
+      detail::throwNullFunction();
+    argPort.emplace(&inner->getRawWrite("arg"));
+    resultPort.emplace(&inner->getRawRead("result"));
+    auto opts = detail::typedFunctionConnectOptions();
+    argPort->connect(opts);
+    resultPort->connect(opts);
   }
 
   std::future<void> call(const ArgT &arg) {
-    auto f = inner->call(toMessageData(arg, argWireInfo_));
-    return std::async(std::launch::deferred,
-                      [fut = std::move(f)]() mutable -> void { fut.get(); });
+    std::scoped_lock<std::mutex> lock(callMutex);
+    argPort->write(arg);
+    return resultPort->readAsync();
+  }
+
+  /// Emplace-style call: constructs `ArgT` in-place from the forwarded
+  /// arguments and forwards to `call(const ArgT &)`. SFINAE-disabled for the
+  /// single-`ArgT`-argument case so it does not shadow the lvalue overload.
+  template <
+      typename First, typename... Rest,
+      typename = std::enable_if_t<
+          std::is_constructible_v<ArgT, First, Rest...> &&
+          (!std::is_same_v<std::decay_t<First>, ArgT> || sizeof...(Rest) != 0)>>
+  std::future<void> call(First &&first, Rest &&...rest) {
+    return call(ArgT(std::forward<First>(first), std::forward<Rest>(rest)...));
+  }
+
+  /// Function-call operator overloads: forward to `call()`.
+  template <typename... Args>
+  auto operator()(Args &&...args)
+      -> decltype(this->call(std::forward<Args>(args)...)) {
+    return call(std::forward<Args>(args)...);
   }
 
   services::FuncService::Function &raw() { return *inner; }
@@ -1012,7 +1098,9 @@ public:
 
 private:
   services::FuncService::Function *inner;
-  WireInfo argWireInfo_;
+  std::optional<TypedWritePort<ArgT, SkipTypeCheck>> argPort;
+  std::optional<TypedReadPort<void>> resultPort;
+  std::mutex callMutex;
 };
 
 /// Full specialization: void argument, void result.
@@ -1021,66 +1109,99 @@ class TypedFunction<void, void, SkipTypeCheck> {
 public:
   // NOLINTNEXTLINE(google-explicit-constructor)
   TypedFunction(services::FuncService::Function *func) : inner(func) {}
+  TypedFunction(const TypedFunction &) = delete;
+  TypedFunction &operator=(const TypedFunction &) = delete;
 
   void connect() {
     if (!inner)
-      throw AcceleratorMismatchError(
-          "TypedFunction: null Function pointer (getAs failed or wrong type)");
-    if constexpr (!SkipTypeCheck) {
-      verifyTypeCompatibility<void>(inner->getArgType());
-      verifyTypeCompatibility<void>(inner->getResultType());
-    }
-    inner->connect(ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
-                                               /*translateMessage=*/false));
+      detail::throwNullFunction();
+    argPort.emplace(&inner->getRawWrite("arg"));
+    resultPort.emplace(&inner->getRawRead("result"));
+    auto opts = detail::typedFunctionConnectOptions();
+    argPort->connect(opts);
+    resultPort->connect(opts);
   }
 
   std::future<void> call() {
-    uint8_t zero = 0;
-    auto f = inner->call(MessageData(&zero, 1));
-    return std::async(std::launch::deferred,
-                      [fut = std::move(f)]() mutable -> void { fut.get(); });
+    std::scoped_lock<std::mutex> lock(callMutex);
+    argPort->write();
+    return resultPort->readAsync();
   }
+
+  /// Function-call operator overload: forwards to `call()`.
+  std::future<void> operator()() { return call(); }
 
   services::FuncService::Function &raw() { return *inner; }
   const services::FuncService::Function &raw() const { return *inner; }
 
 private:
   services::FuncService::Function *inner;
+  std::optional<TypedWritePort<void>> argPort;
+  std::optional<TypedReadPort<void>> resultPort;
+  std::mutex callMutex;
 };
 
 //===----------------------------------------------------------------------===//
 // TypedCallback<ArgT, ResultT>
 //
-// Non-owning wrapper around CallService::Callback that provides strongly-typed
-// connect() and automatic MessageData conversion. Implicitly constructible
-// from Callback* (the return type of BundlePort::getAs<Callback>()).
+// Strongly-typed accelerator-callback wrapper built on top of TypedReadPort
+// and TypedWritePort. Implicitly constructible from `CallService::Callback *`
+// (the return type of `BundlePort::getAs<CallService::Callback>()`);
+// construction resolves the underlying raw "arg" / "result" channels but
+// does not connect them until `connect()` is called.
+//
+// We bypass `CallService::Callback::connect` for the same reason we bypass
+// `FuncService::Function::call`: typed args may span multiple raw frames and
+// we need the persistent stateful deserializer that `TypedReadPort<ArgT>`
+// already provides.
+//
+// Note: the `quick` parameter is kept for API compatibility but has no
+// effect in this design. The typed user callback is always dispatched inline
+// from the read-channel callback thread (matching the previous
+// custom-deserializer behavior). If service-thread dispatch is needed in the
+// future, that can be layered on top by using `TypedReadPort` polling mode
+// plus a worker.
 //===----------------------------------------------------------------------===//
+
+namespace detail {
+
+/// Throw the standard "null Callback pointer" error used by every
+/// TypedCallback specialization.
+[[noreturn]] inline void throwNullCallback() {
+  throw AcceleratorMismatchError(
+      "TypedCallback: null Callback pointer (getAs failed or wrong type)");
+}
+
+} // namespace detail
 
 template <typename ArgT, typename ResultT, bool SkipTypeCheck = false>
 class TypedCallback {
 public:
   // NOLINTNEXTLINE(google-explicit-constructor)
   TypedCallback(services::CallService::Callback *cb) : inner(cb) {}
+  TypedCallback(const TypedCallback &) = delete;
+  TypedCallback &operator=(const TypedCallback &) = delete;
 
   void connect(std::function<ResultT(const ArgT &)> callback,
                bool quick = false) {
+    (void)quick; // See class header.
     if (!inner)
-      throw AcceleratorMismatchError(
-          "TypedCallback: null Callback pointer (getAs failed or wrong type)");
-    if constexpr (!SkipTypeCheck) {
-      verifyTypeCompatibility<ArgT>(inner->getArgType());
-      verifyTypeCompatibility<ResultT>(inner->getResultType());
-    }
-    inner->connect(
-        [cb = std::move(callback), argType = inner->getArgType(),
-         resType = inner->getResultType()](
-            const MessageData &argData) -> MessageData {
-          ResultT result = cb(fromMessageData<ArgT>(argData, argType));
-          return toMessageData(result, resType);
+      detail::throwNullCallback();
+    argPort.emplace(&inner->getRawRead("arg"));
+    resultPort.emplace(&inner->getRawWrite("result"));
+    auto opts = detail::typedFunctionConnectOptions();
+    resultPort->connect(opts);
+    userCallback = std::move(callback);
+    // The TypedReadPort callback runs on the read-channel callback thread
+    // for every decoded ArgT. We forward to the user's callback and then
+    // serialize the result through the TypedWritePort.
+    argPort->connect(
+        [this](const ArgT &arg) -> bool {
+          ResultT result = userCallback(arg);
+          resultPort->write(result);
+          return true;
         },
-        quick,
-        ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
-                                    /*translateMessage=*/false));
+        opts);
   }
 
   services::CallService::Callback &raw() { return *inner; }
@@ -1088,6 +1209,9 @@ public:
 
 private:
   services::CallService::Callback *inner;
+  std::optional<TypedReadPort<ArgT, SkipTypeCheck>> argPort;
+  std::optional<TypedWritePort<ResultT, SkipTypeCheck>> resultPort;
+  std::function<ResultT(const ArgT &)> userCallback;
 };
 
 /// Partial specialization: void argument, typed result.
@@ -1096,24 +1220,25 @@ class TypedCallback<void, ResultT, SkipTypeCheck> {
 public:
   // NOLINTNEXTLINE(google-explicit-constructor)
   TypedCallback(services::CallService::Callback *cb) : inner(cb) {}
+  TypedCallback(const TypedCallback &) = delete;
+  TypedCallback &operator=(const TypedCallback &) = delete;
 
   void connect(std::function<ResultT()> callback, bool quick = false) {
+    (void)quick;
     if (!inner)
-      throw AcceleratorMismatchError(
-          "TypedCallback: null Callback pointer (getAs failed or wrong type)");
-    if constexpr (!SkipTypeCheck) {
-      verifyTypeCompatibility<void>(inner->getArgType());
-      verifyTypeCompatibility<ResultT>(inner->getResultType());
-    }
-    WireInfo rwb = getWireInfo(inner->getResultType());
-    inner->connect(
-        [cb = std::move(callback), rwb](const MessageData &) -> MessageData {
-          ResultT result = cb();
-          return toMessageData(result, rwb);
+      detail::throwNullCallback();
+    argPort.emplace(&inner->getRawRead("arg"));
+    resultPort.emplace(&inner->getRawWrite("result"));
+    auto opts = detail::typedFunctionConnectOptions();
+    resultPort->connect(opts);
+    userCallback = std::move(callback);
+    argPort->connect(
+        [this]() -> bool {
+          ResultT result = userCallback();
+          resultPort->write(result);
+          return true;
         },
-        quick,
-        ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
-                                    /*translateMessage=*/false));
+        opts);
   }
 
   services::CallService::Callback &raw() { return *inner; }
@@ -1121,6 +1246,9 @@ public:
 
 private:
   services::CallService::Callback *inner;
+  std::optional<TypedReadPort<void>> argPort;
+  std::optional<TypedWritePort<ResultT, SkipTypeCheck>> resultPort;
+  std::function<ResultT()> userCallback;
 };
 
 /// Partial specialization: typed argument, void result.
@@ -1129,25 +1257,25 @@ class TypedCallback<ArgT, void, SkipTypeCheck> {
 public:
   // NOLINTNEXTLINE(google-explicit-constructor)
   TypedCallback(services::CallService::Callback *cb) : inner(cb) {}
+  TypedCallback(const TypedCallback &) = delete;
+  TypedCallback &operator=(const TypedCallback &) = delete;
 
   void connect(std::function<void(const ArgT &)> callback, bool quick = false) {
+    (void)quick;
     if (!inner)
-      throw AcceleratorMismatchError(
-          "TypedCallback: null Callback pointer (getAs failed or wrong type)");
-    if constexpr (!SkipTypeCheck) {
-      verifyTypeCompatibility<ArgT>(inner->getArgType());
-      verifyTypeCompatibility<void>(inner->getResultType());
-    }
-    inner->connect(
-        [cb = std::move(callback), argType = inner->getArgType()](
-            const MessageData &argData) -> MessageData {
-          cb(fromMessageData<ArgT>(argData, argType));
-          uint8_t zero = 0;
-          return MessageData(&zero, 1);
+      detail::throwNullCallback();
+    argPort.emplace(&inner->getRawRead("arg"));
+    resultPort.emplace(&inner->getRawWrite("result"));
+    auto opts = detail::typedFunctionConnectOptions();
+    resultPort->connect(opts);
+    userCallback = std::move(callback);
+    argPort->connect(
+        [this](const ArgT &arg) -> bool {
+          userCallback(arg);
+          resultPort->write();
+          return true;
         },
-        quick,
-        ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
-                                    /*translateMessage=*/false));
+        opts);
   }
 
   services::CallService::Callback &raw() { return *inner; }
@@ -1155,6 +1283,9 @@ public:
 
 private:
   services::CallService::Callback *inner;
+  std::optional<TypedReadPort<ArgT, SkipTypeCheck>> argPort;
+  std::optional<TypedWritePort<void>> resultPort;
+  std::function<void(const ArgT &)> userCallback;
 };
 
 /// Full specialization: void argument, void result.
@@ -1163,24 +1294,25 @@ class TypedCallback<void, void, SkipTypeCheck> {
 public:
   // NOLINTNEXTLINE(google-explicit-constructor)
   TypedCallback(services::CallService::Callback *cb) : inner(cb) {}
+  TypedCallback(const TypedCallback &) = delete;
+  TypedCallback &operator=(const TypedCallback &) = delete;
 
   void connect(std::function<void()> callback, bool quick = false) {
+    (void)quick;
     if (!inner)
-      throw AcceleratorMismatchError(
-          "TypedCallback: null Callback pointer (getAs failed or wrong type)");
-    if constexpr (!SkipTypeCheck) {
-      verifyTypeCompatibility<void>(inner->getArgType());
-      verifyTypeCompatibility<void>(inner->getResultType());
-    }
-    inner->connect(
-        [cb = std::move(callback)](const MessageData &) -> MessageData {
-          cb();
-          uint8_t zero = 0;
-          return MessageData(&zero, 1);
+      detail::throwNullCallback();
+    argPort.emplace(&inner->getRawRead("arg"));
+    resultPort.emplace(&inner->getRawWrite("result"));
+    auto opts = detail::typedFunctionConnectOptions();
+    resultPort->connect(opts);
+    userCallback = std::move(callback);
+    argPort->connect(
+        [this]() -> bool {
+          userCallback();
+          resultPort->write();
+          return true;
         },
-        quick,
-        ChannelPort::ConnectOptions(/*bufferSize=*/std::nullopt,
-                                    /*translateMessage=*/false));
+        opts);
   }
 
   services::CallService::Callback &raw() { return *inner; }
@@ -1188,6 +1320,9 @@ public:
 
 private:
   services::CallService::Callback *inner;
+  std::optional<TypedReadPort<void>> argPort;
+  std::optional<TypedWritePort<void>> resultPort;
+  std::function<void()> userCallback;
 };
 
 } // namespace esi

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
@@ -933,12 +933,17 @@ inline ChannelPort::ConnectOptions typedFunctionConnectOptions() {
 /// `TypedReadPort::readAsync()`) into a `std::future<T>`. Uses a deferred
 /// async so `.get()` blocks only when the caller actually waits for the
 /// value, preserving the per-call FIFO ordering of the underlying polling
-/// buffer.
+/// buffer. A null `unique_ptr` from a misbehaving deserializer is reported
+/// as a runtime error rather than dereferenced.
 template <typename T>
 std::future<T> awaitDecoded(std::future<std::unique_ptr<T>> inner) {
   return std::async(std::launch::deferred,
                     [fut = std::move(inner)]() mutable -> T {
                       std::unique_ptr<T> v = fut.get();
+                      if (!v)
+                        throw std::runtime_error(
+                            "TypedFunction: deserializer produced a null "
+                            "value");
                       return std::move(*v);
                     });
 }
@@ -948,6 +953,17 @@ std::future<T> awaitDecoded(std::future<std::unique_ptr<T>> inner) {
 [[noreturn]] inline void throwNullFunction() {
   throw AcceleratorMismatchError(
       "TypedFunction: null Function pointer (getAs failed or wrong type)");
+}
+
+/// Throw a clear "not connected" error from `call()` paths.
+[[noreturn]] inline void throwNotConnected() {
+  throw std::runtime_error("TypedFunction: must be 'connect'ed before "
+                           "calling");
+}
+
+/// Throw a clear "already connected" error from `connect()` paths.
+[[noreturn]] inline void throwAlreadyConnected() {
+  throw std::runtime_error("TypedFunction is already connected");
 }
 
 } // namespace detail
@@ -964,6 +980,8 @@ public:
   void connect() {
     if (!inner)
       detail::throwNullFunction();
+    if (argPort)
+      detail::throwAlreadyConnected();
     argPort.emplace(&inner->getRawWrite("arg"));
     resultPort.emplace(&inner->getRawRead("result"));
     auto opts = detail::typedFunctionConnectOptions();
@@ -972,6 +990,8 @@ public:
   }
 
   std::future<ResultT> call(const ArgT &arg) {
+    if (!argPort)
+      detail::throwNotConnected();
     // Serialize the per-call write+readAsync pair so the polling buffer's
     // FIFO matches the call FIFO. Pipelined calls are still allowed -- the
     // shared deserializer drains responses in wire order and the FIFO
@@ -1023,6 +1043,8 @@ public:
   void connect() {
     if (!inner)
       detail::throwNullFunction();
+    if (argPort)
+      detail::throwAlreadyConnected();
     argPort.emplace(&inner->getRawWrite("arg"));
     resultPort.emplace(&inner->getRawRead("result"));
     auto opts = detail::typedFunctionConnectOptions();
@@ -1031,6 +1053,8 @@ public:
   }
 
   std::future<ResultT> call() {
+    if (!argPort)
+      detail::throwNotConnected();
     std::scoped_lock<std::mutex> lock(callMutex);
     argPort->write();
     return detail::awaitDecoded<ResultT>(resultPort->readAsync());
@@ -1061,6 +1085,8 @@ public:
   void connect() {
     if (!inner)
       detail::throwNullFunction();
+    if (argPort)
+      detail::throwAlreadyConnected();
     argPort.emplace(&inner->getRawWrite("arg"));
     resultPort.emplace(&inner->getRawRead("result"));
     auto opts = detail::typedFunctionConnectOptions();
@@ -1069,6 +1095,8 @@ public:
   }
 
   std::future<void> call(const ArgT &arg) {
+    if (!argPort)
+      detail::throwNotConnected();
     std::scoped_lock<std::mutex> lock(callMutex);
     argPort->write(arg);
     return resultPort->readAsync();
@@ -1115,6 +1143,8 @@ public:
   void connect() {
     if (!inner)
       detail::throwNullFunction();
+    if (argPort)
+      detail::throwAlreadyConnected();
     argPort.emplace(&inner->getRawWrite("arg"));
     resultPort.emplace(&inner->getRawRead("result"));
     auto opts = detail::typedFunctionConnectOptions();
@@ -1123,6 +1153,8 @@ public:
   }
 
   std::future<void> call() {
+    if (!argPort)
+      detail::throwNotConnected();
     std::scoped_lock<std::mutex> lock(callMutex);
     argPort->write();
     return resultPort->readAsync();
@@ -1161,6 +1193,16 @@ private:
 // custom-deserializer behavior). If service-thread dispatch is needed in the
 // future, that can be layered on top by using `TypedReadPort` polling mode
 // plus a worker.
+//
+// Lifetime: the TypedReadPort callback installed on `connect()` captures
+// `this`. The wrapper is non-copyable and non-movable, so its address is
+// stable for its entire lifetime. Destruction of the embedded TypedReadPort
+// synchronously revokes the callback and waits for any in-flight callback
+// dispatch to complete (see ReadChannelPort::disconnect), so the captured
+// `this` cannot dangle. Callers must ensure the TypedCallback outlives any
+// expected callback dispatch -- using a temporary like
+// `TypedCallback<...>(cb).connect(...)` is safe only because the destructor
+// runs at end-of-full-expression and disconnects before returning.
 //===----------------------------------------------------------------------===//
 
 namespace detail {
@@ -1170,6 +1212,12 @@ namespace detail {
 [[noreturn]] inline void throwNullCallback() {
   throw AcceleratorMismatchError(
       "TypedCallback: null Callback pointer (getAs failed or wrong type)");
+}
+
+/// Throw a clear "already connected" error from TypedCallback `connect()`
+/// paths.
+[[noreturn]] inline void throwCallbackAlreadyConnected() {
+  throw std::runtime_error("TypedCallback is already connected");
 }
 
 } // namespace detail
@@ -1187,6 +1235,8 @@ public:
     (void)quick; // See class header.
     if (!inner)
       detail::throwNullCallback();
+    if (argPort)
+      detail::throwCallbackAlreadyConnected();
     argPort.emplace(&inner->getRawRead("arg"));
     resultPort.emplace(&inner->getRawWrite("result"));
     auto opts = detail::typedFunctionConnectOptions();
@@ -1227,6 +1277,8 @@ public:
     (void)quick;
     if (!inner)
       detail::throwNullCallback();
+    if (argPort)
+      detail::throwCallbackAlreadyConnected();
     argPort.emplace(&inner->getRawRead("arg"));
     resultPort.emplace(&inner->getRawWrite("result"));
     auto opts = detail::typedFunctionConnectOptions();
@@ -1264,6 +1316,8 @@ public:
     (void)quick;
     if (!inner)
       detail::throwNullCallback();
+    if (argPort)
+      detail::throwCallbackAlreadyConnected();
     argPort.emplace(&inner->getRawRead("arg"));
     resultPort.emplace(&inner->getRawWrite("result"));
     auto opts = detail::typedFunctionConnectOptions();
@@ -1301,6 +1355,8 @@ public:
     (void)quick;
     if (!inner)
       detail::throwNullCallback();
+    if (argPort)
+      detail::throwCallbackAlreadyConnected();
     argPort.emplace(&inner->getRawRead("arg"));
     resultPort.emplace(&inner->getRawWrite("result"));
     auto opts = detail::typedFunctionConnectOptions();

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
@@ -732,6 +732,38 @@ TEST(TypedPortsTest, TypedFunctionNullThrowsAtConnect) {
   EXPECT_THROW(typed.connect(), AcceleratorMismatchError);
 }
 
+TEST(TypedPortsTest, TypedFunctionCallBeforeConnectThrows) {
+  // call() before connect() must throw, not dereference a null optional.
+  TypedFunction<uint32_t, uint16_t> typed(nullptr);
+  EXPECT_THROW(typed.call(0u).get(), std::runtime_error);
+}
+
+TEST(TypedPortsTest, TypedFunctionDoubleConnectThrows) {
+  // A second connect() on an already-connected wrapper must throw rather
+  // than silently rebuild internal state.
+  SIntType argInner("si24", 24);
+  ChannelType argChanType("channel<si24>", &argInner);
+  UIntType resultInner("ui15", 15);
+  ChannelType resultChanType("channel<ui15>", &resultInner);
+
+  BundleType::ChannelVector channels = {
+      {"arg", BundleType::Direction::To, &argChanType},
+      {"result", BundleType::Direction::From, &resultChanType},
+  };
+  BundleType bundleType("func_bundle", channels);
+
+  MockWritePort mockWrite(&argInner);
+  CallbackDrivenMockReadPort mockRead(&resultInner);
+
+  auto *func = services::FuncService::Function::get(AppID("test"), &bundleType,
+                                                    mockWrite, mockRead);
+
+  TypedFunction<int32_t, uint16_t> typed(func);
+  typed.connect();
+  EXPECT_THROW(typed.connect(), std::runtime_error);
+  delete func;
+}
+
 TEST(TypedPortsTest, TypedFunctionConnectVerifiesTypes) {
   // Create channel types matching si24 arg and ui16 result.
   SIntType argInner("si24", 24);
@@ -1157,6 +1189,12 @@ TEST(TypedPortsTest, VerifyTypeCompatibilityThrowsForUnsupportedType) {
 // Simple TypeDeserializer that decodes a single uint32 from one frame and
 // emits exactly one OneWord value per push. Used to exercise the typical
 // 1-frame-in / 1-typed-value-out custom path.
+//
+// Implements the standard backpressure/retry contract: a decoded `OneWord`
+// is buffered until the output callback accepts it; only then is the raw
+// message consumed. If `output()` returns false, the same raw message will
+// be retried later, and a follow-up `poke()` retries delivery of the
+// already-decoded value without re-decoding.
 struct OneWord {
   uint32_t value;
 
@@ -1168,21 +1206,39 @@ struct OneWord {
         : output(std::move(output)) {}
 
     bool push(std::unique_ptr<SegmentedMessageData> &msg) {
+      // First, try to flush any previously-decoded value blocked on output.
+      if (pending) {
+        if (!output(pending))
+          return false;
+        pending.reset();
+      }
+
       MessageData scratch;
       const MessageData &flat =
           detail::getMessageDataRef<OneWord>(*msg, scratch);
       if (flat.getSize() != sizeof(uint32_t))
         throw std::runtime_error("OneWord: bad size");
-      auto out = std::make_unique<OneWord>();
-      std::memcpy(&out->value, flat.getBytes(), sizeof(uint32_t));
+      pending = std::make_unique<OneWord>();
+      std::memcpy(&pending->value, flat.getBytes(), sizeof(uint32_t));
+      // Raw message is consumed regardless of whether the typed output is
+      // immediately accepted.
       msg.reset();
-      return output(out);
+      if (output(pending))
+        pending.reset();
+      return true;
     }
 
-    bool poke() { return true; }
+    bool poke() {
+      if (pending && output(pending)) {
+        pending.reset();
+        return true;
+      }
+      return false;
+    }
 
   private:
     OutputCallback output;
+    std::unique_ptr<OneWord> pending;
   };
 };
 

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTypedPortsTest.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <chrono>
 #include <cstring>
+#include <deque>
 
 using namespace esi;
 
@@ -794,11 +795,7 @@ TEST(TypedPortsTest, TypedFunctionCallRoundTrip) {
   BundleType bundleType("func_bundle", channels);
 
   MockWritePort mockWrite(&argInner);
-  MockReadPort mockRead(&resultInner);
-
-  // Set up mock read to return a known uint16_t value.
-  uint16_t expected = 42;
-  mockRead.nextResponse = MessageData::from(expected);
+  CallbackDrivenMockReadPort mockRead(&resultInner);
 
   auto *func = services::FuncService::Function::get(AppID("test"), &bundleType,
                                                     mockWrite, mockRead);
@@ -807,7 +804,13 @@ TEST(TypedPortsTest, TypedFunctionCallRoundTrip) {
   typed.connect();
 
   int32_t arg = 100;
-  uint16_t result = typed.call(arg).get();
+  std::future<uint16_t> f = typed.call(arg);
+  // Deliver the response frame to satisfy the future. ui15 wire width is 2
+  // bytes so a 2-byte payload is required.
+  uint16_t expected = 42;
+  EXPECT_TRUE(mockRead.deliver(std::make_unique<MessageData>(MessageData(
+      reinterpret_cast<const uint8_t *>(&expected), sizeof(expected)))));
+  uint16_t result = f.get();
   EXPECT_EQ(result, 42);
 
   // Verify the written arg matches — si24 wire size is 3 bytes.
@@ -1093,11 +1096,7 @@ TEST(TypedPortsTest, TypedFunctionSegmentedArg) {
   BundleType bundleType("func_bundle", channels);
 
   MockWritePort mockWrite(&argInner);
-  MockReadPort mockRead(&resultInner);
-
-  // Set up mock read to return a known uint16_t value.
-  uint16_t expected = 99;
-  mockRead.nextResponse = MessageData::from(expected);
+  CallbackDrivenMockReadPort mockRead(&resultInner);
 
   auto *func = services::FuncService::Function::get(AppID("test"), &bundleType,
                                                     mockWrite, mockRead);
@@ -1110,7 +1109,12 @@ TEST(TypedPortsTest, TypedFunctionSegmentedArg) {
   arg.header.b = 0xBE;
   arg.items = {10, 20};
 
-  uint16_t result = typed.call(arg).get();
+  std::future<uint16_t> f = typed.call(arg);
+  // Deliver the response frame to satisfy the call's future.
+  uint16_t expected = 99;
+  EXPECT_TRUE(mockRead.deliver(std::make_unique<MessageData>(MessageData(
+      reinterpret_cast<const uint8_t *>(&expected), sizeof(expected)))));
+  uint16_t result = f.get();
   EXPECT_EQ(result, 99u);
 
   // Verify the flattened arg: 6 bytes header + 8 bytes items = 14 bytes.
@@ -1144,6 +1148,206 @@ TEST(TypedPortsTest, VerifyTypeCompatibilityThrowsForUnsupportedType) {
   SIntType sint16("si16", 16);
   EXPECT_THROW(verifyTypeCompatibility<UnrecognizedCppType>(&sint16),
                AcceleratorMismatchError);
+}
+
+//===----------------------------------------------------------------------===//
+// TypedFunction custom-deserializer tests
+//===----------------------------------------------------------------------===//
+
+// Simple TypeDeserializer that decodes a single uint32 from one frame and
+// emits exactly one OneWord value per push. Used to exercise the typical
+// 1-frame-in / 1-typed-value-out custom path.
+struct OneWord {
+  uint32_t value;
+
+  class TypeDeserializer {
+  public:
+    using OutputCallback = detail::TypedReadOwnedCallback<OneWord>;
+
+    explicit TypeDeserializer(OutputCallback output)
+        : output(std::move(output)) {}
+
+    bool push(std::unique_ptr<SegmentedMessageData> &msg) {
+      MessageData scratch;
+      const MessageData &flat =
+          detail::getMessageDataRef<OneWord>(*msg, scratch);
+      if (flat.getSize() != sizeof(uint32_t))
+        throw std::runtime_error("OneWord: bad size");
+      auto out = std::make_unique<OneWord>();
+      std::memcpy(&out->value, flat.getBytes(), sizeof(uint32_t));
+      msg.reset();
+      return output(out);
+    }
+
+    bool poke() { return true; }
+
+  private:
+    OutputCallback output;
+  };
+};
+
+TEST(TypedPortsTest, TypedFunctionCustomDeserializerSingleFrame) {
+  UIntType argInner("ui32", 32);
+  ChannelType argChanType("channel<ui32>", &argInner);
+  UIntType resultInner("ui32", 32);
+  ChannelType resultChanType("channel<ui32>", &resultInner);
+
+  BundleType::ChannelVector channels = {
+      {"arg", BundleType::Direction::To, &argChanType},
+      {"result", BundleType::Direction::From, &resultChanType},
+  };
+  BundleType bundleType("func_bundle", channels);
+
+  MockWritePort mockWrite(&argInner);
+  CallbackDrivenMockReadPort mockRead(&resultInner);
+
+  auto *func = services::FuncService::Function::get(AppID("test"), &bundleType,
+                                                    mockWrite, mockRead);
+
+  TypedFunction<uint32_t, OneWord> typed(func);
+  typed.connect();
+
+  std::future<OneWord> f = typed.call(0u);
+  // Deliver one frame containing a single uint32; the deserializer produces
+  // one OneWord which fulfills the call's pending future.
+  uint32_t expected = 0xCAFE;
+  EXPECT_TRUE(mockRead.deliver(std::make_unique<MessageData>(MessageData(
+      reinterpret_cast<const uint8_t *>(&expected), sizeof(expected)))));
+
+  OneWord result = f.get();
+  EXPECT_EQ(result.value, expected);
+
+  delete func;
+}
+
+TEST(TypedPortsTest, TypedFunctionCustomDeserializerReadsMultipleFrames) {
+  // FragmentedCoordBatch's TypeDeserializer emits one batch per 8-byte
+  // FragmentedCoord. By feeding partial frames across multiple raw messages,
+  // we exercise the deserializer's persistent partial-buffer state across
+  // raw callback invocations.
+  UIntType argInner("ui32", 32);
+  ChannelType argChanType("channel<ui32>", &argInner);
+  UIntType resultInner("ui32", 32);
+  ChannelType resultChanType("channel<ui32>", &resultInner);
+
+  BundleType::ChannelVector channels = {
+      {"arg", BundleType::Direction::To, &argChanType},
+      {"result", BundleType::Direction::From, &resultChanType},
+  };
+  BundleType bundleType("func_bundle", channels);
+
+  MockWritePort mockWrite(&argInner);
+  CallbackDrivenMockReadPort mockRead(&resultInner);
+
+  auto *func = services::FuncService::Function::get(AppID("test"), &bundleType,
+                                                    mockWrite, mockRead);
+
+  TypedFunction<uint32_t, FragmentedCoordBatch> typed(func);
+  typed.connect();
+
+  std::future<FragmentedCoordBatch> f = typed.call(0u);
+
+  // Split a single 8-byte FragmentedCoord across two raw frames.
+  std::array<uint8_t, sizeof(FragmentedCoord)> coordBytes =
+      packCoordBytes(/*y=*/55, /*x=*/77);
+  std::vector<uint8_t> firstChunk(coordBytes.begin(), coordBytes.begin() + 6);
+  std::vector<uint8_t> secondChunk(coordBytes.begin() + 6, coordBytes.end());
+  EXPECT_TRUE(
+      mockRead.deliver(std::make_unique<MessageData>(std::move(firstChunk))));
+  EXPECT_TRUE(
+      mockRead.deliver(std::make_unique<MessageData>(std::move(secondChunk))));
+
+  FragmentedCoordBatch batch = f.get();
+  ASSERT_EQ(batch.coords.size(), 1u);
+  EXPECT_EQ(batch.coords[0].y, 55u);
+  EXPECT_EQ(batch.coords[0].x, 77u);
+
+  delete func;
+}
+
+TEST(TypedPortsTest, TypedFunctionCustomDeserializerSkipsResultTypeCheck) {
+  // OneWord has no _ESI_ID, so the result-side type check should be skipped
+  // and we should be able to connect against an arbitrarily-typed result
+  // channel without a thrown AcceleratorMismatchError.
+  UIntType argInner("ui32", 32);
+  ChannelType argChanType("channel<ui32>", &argInner);
+  // Use a wildly mismatched result type to prove the check is skipped.
+  StructType resultInner("Anything", {});
+  ChannelType resultChanType("channel<Anything>", &resultInner);
+
+  BundleType::ChannelVector channels = {
+      {"arg", BundleType::Direction::To, &argChanType},
+      {"result", BundleType::Direction::From, &resultChanType},
+  };
+  BundleType bundleType("func_bundle", channels);
+
+  MockWritePort mockWrite(&argInner);
+  CallbackDrivenMockReadPort mockRead(&resultInner);
+
+  auto *func = services::FuncService::Function::get(AppID("test"), &bundleType,
+                                                    mockWrite, mockRead);
+
+  TypedFunction<uint32_t, OneWord> typed(func);
+  EXPECT_NO_THROW(typed.connect());
+
+  delete func;
+}
+
+TEST(TypedPortsTest, TypedFunctionPipelinedCallsGetOutOfOrder) {
+  // Two pipelined calls, each with a multi-frame response decoded by the
+  // shared deserializer. Even when the second future's get() is called
+  // before the first, each future must yield its own call's result -- not
+  // the other call's frames. This exercises the FIFO contract of the
+  // TypedReadPort polling buffer that backs `call()`.
+  UIntType argInner("ui32", 32);
+  ChannelType argChanType("channel<ui32>", &argInner);
+  UIntType resultInner("ui32", 32);
+  ChannelType resultChanType("channel<ui32>", &resultInner);
+
+  BundleType::ChannelVector channels = {
+      {"arg", BundleType::Direction::To, &argChanType},
+      {"result", BundleType::Direction::From, &resultChanType},
+  };
+  BundleType bundleType("func_bundle", channels);
+
+  MockWritePort mockWrite(&argInner);
+  CallbackDrivenMockReadPort mockRead(&resultInner);
+
+  auto *func = services::FuncService::Function::get(AppID("test"), &bundleType,
+                                                    mockWrite, mockRead);
+
+  TypedFunction<uint32_t, FragmentedCoordBatch> typed(func);
+  typed.connect();
+
+  // Issue two calls before any frames arrive; futures reserve slots in the
+  // polling buffer in call FIFO order.
+  std::future<FragmentedCoordBatch> f1 = typed.call(0u);
+  std::future<FragmentedCoordBatch> f2 = typed.call(0u);
+
+  auto deliverCoord = [&](uint32_t y, uint32_t x) {
+    auto bytes = packCoordBytes(y, x);
+    std::vector<uint8_t> first(bytes.begin(), bytes.begin() + 6);
+    std::vector<uint8_t> second(bytes.begin() + 6, bytes.end());
+    EXPECT_TRUE(
+        mockRead.deliver(std::make_unique<MessageData>(std::move(first))));
+    EXPECT_TRUE(
+        mockRead.deliver(std::make_unique<MessageData>(std::move(second))));
+  };
+  deliverCoord(/*y=*/11, /*x=*/22); // call 1's response
+  deliverCoord(/*y=*/33, /*x=*/44); // call 2's response
+
+  // Intentionally retrieve the second call's result first.
+  FragmentedCoordBatch r2 = f2.get();
+  ASSERT_EQ(r2.coords.size(), 1u);
+  EXPECT_EQ(r2.coords[0].y, 33u);
+  EXPECT_EQ(r2.coords[0].x, 44u);
+
+  FragmentedCoordBatch r1 = f1.get();
+  ASSERT_EQ(r1.coords.size(), 1u);
+  EXPECT_EQ(r1.coords[0].y, 11u);
+  EXPECT_EQ(r1.coords[0].x, 22u);
+
+  delete func;
 }
 
 } // namespace

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/loopback.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/loopback.cpp
@@ -254,11 +254,16 @@ static void serialCoordTranslateTest(Accelerator *accel) {
   // to backpressure on the N+2 reply frames.
   TypedWritePort<SerialCoordInput, /*SkipTypeCheck=*/true> argPort(
       func->getRawWrite("arg"));
-  ChannelPort::ConnectOptions opts(/*bufferSize=*/std::nullopt,
-                                   /*translateMessage=*/false);
-  argPort.connect(opts);
+  ChannelPort::ConnectOptions argOpts(/*bufferSize=*/std::nullopt,
+                                      /*translateMessage=*/false);
+  argPort.connect(argOpts);
   ReadChannelPort &rawResult = func->getRawRead("result");
-  rawResult.connect(opts);
+  // The reply contains numCoords + 2 raw frames (one header + N data + one
+  // footer). Use an unbounded buffer (bufferSize=0) so the polling queue
+  // doesn't backpressure the backend mid-stream.
+  ChannelPort::ConnectOptions resultOpts(/*bufferSize=*/0,
+                                         /*translateMessage=*/false);
+  rawResult.connect(resultOpts);
 
   std::vector<SerialCoordData> coords;
   for (auto &c : inputCoords)

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/loopback.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/loopback.cpp
@@ -242,29 +242,35 @@ static void serialCoordTranslateTest(Accelerator *accel) {
     throw std::runtime_error(
         "Serial coord translate test: no 'translate_coords_serial' port found");
 
-  TypedFunction<SerialCoordInput, SerialCoordOutputFrame,
-                /*SkipTypeCheck=*/true>
-      translateCoords(
-          portIter->second.getAs<services::FuncService::Function>());
+  auto *func = portIter->second.getAs<services::FuncService::Function>();
+  if (!func)
+    throw std::runtime_error(
+        "Serial coord translate test: port is not a FuncService::Function");
 
-  translateCoords.connect();
+  // Drive the raw arg port through TypedWritePort so the segmented batch is
+  // packed correctly; drain the raw result port directly. We bypass
+  // TypedFunction here because `SerialCoordOutputFrame` is a hand-written
+  // union (not a real ESI type) and we don't want the typed result decoder
+  // to backpressure on the N+2 reply frames.
+  TypedWritePort<SerialCoordInput, /*SkipTypeCheck=*/true> argPort(
+      func->getRawWrite("arg"));
+  ChannelPort::ConnectOptions opts(/*bufferSize=*/std::nullopt,
+                                   /*translateMessage=*/false);
+  argPort.connect(opts);
+  ReadChannelPort &rawResult = func->getRawRead("result");
+  rawResult.connect(opts);
 
   std::vector<SerialCoordData> coords;
   for (auto &c : inputCoords)
     coords.emplace_back(c.x, c.y);
   SerialCoordInput batch(xTrans, yTrans, coords);
-  // TODO: List results are currently not supported so we cannot compare the
-  // results.
-  (void)translateCoords.call(batch).get();
+  argPort.write(batch);
 
-  // The bulk-list reply arrives as numCoords data frames plus a footer header,
-  // but `TypedFunction::call()` only waits on the first frame. Drain the rest
-  // off the raw read channel so they don't sit in the polling queue and race
-  // with disconnect/teardown.
-  auto *func = portIter->second.getAs<services::FuncService::Function>();
-  ReadChannelPort &rawResult = func->getRawRead("result");
+  // The bulk-list reply is one header frame + numCoords data frames + one
+  // footer frame. TODO: list results aren't decoded here; we just drain the
+  // frames so the backend doesn't backpressure / hang.
   MessageData drained;
-  for (size_t i = 0; i < numCoords + 1; ++i)
+  for (size_t i = 0; i < numCoords + 2; ++i)
     rawResult.read(drained);
 }
 

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/loopback_typed.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/loopback_typed.cpp
@@ -205,45 +205,29 @@ static void serialCoordTranslateTest(Accelerator *accel) {
     throw std::runtime_error(
         "Serial coord translate test: no 'translate_coords_serial' port found");
 
-  auto *func = portIter->second.getAs<services::FuncService::Function>();
-  if (!func)
-    throw std::runtime_error(
-        "Serial coord translate test: port is not a FuncService::Function");
+  // Drive the serial-list window through TypedFunction. The arg helper
+  // packs the static fields and value list into the header/data/footer
+  // frame protocol; the result helper's nested TypeDeserializer reassembles
+  // the reply frames into a single SerialCoordResult value, which we then
+  // iterate via its accessors.
+  TypedFunction<SerialCoordInput, SerialCoordResult> func =
+      portIter->second.getAs<services::FuncService::Function>();
+  func.connect();
 
-  // Drive the serial-list window through the generated typed helpers. The
-  // arg helper packs the static fields and value list into the
-  // header/data/footer frame protocol; the result helper's nested
-  // TypeDeserializer reassembles the reply frames into a single
-  // SerialCoordResult value, which we then iterate via its accessors.
-  TypedWritePort<SerialCoordInput> argPort(func->getRawWrite("arg"));
-  TypedReadPort<SerialCoordResult> resultPort(func->getRawRead("result"));
+  // Use the emplace-style call() overload to construct SerialCoordInput
+  // in-place from the forwarded constructor arguments.
+  SerialCoordResult result = func(xTrans, yTrans, coords).get();
 
-  // Raw frame transport: the runtime translator does not handle serial-list
-  // windows, so leave message translation off and let the generated
-  // TypeDeserializer walk the burst protocol directly.
-  argPort.connect(ChannelPort::ConnectOptions(std::nullopt, false));
-  resultPort.connect(ChannelPort::ConnectOptions(std::nullopt, false));
-
-  auto batch = std::make_unique<SerialCoordInput>(xTrans, yTrans, coords);
-  argPort.write(batch);
-
-  std::unique_ptr<SerialCoordResult> result = resultPort.read();
-  if (!result)
-    throw std::runtime_error("Serial coord translate test: null result");
-
-  if (result->coords_count() != coords.size())
+  if (result.coords_count() != coords.size())
     throw std::runtime_error("Serial coord translate result size mismatch");
   size_t i = 0;
-  for (const SerialCoordValue &got : result->coords()) {
+  for (const SerialCoordValue &got : result.coords()) {
     uint32_t expX = coords[i].x + xTrans;
     uint32_t expY = coords[i].y + yTrans;
     if (got.x != expX || got.y != expY)
       throw std::runtime_error("Serial coord translate result mismatch");
     ++i;
   }
-
-  argPort.disconnect();
-  resultPort.disconnect();
 }
 
 int main(int argc, const char *argv[]) {


### PR DESCRIPTION
Embed TypedWritePort<ArgT> and TypedReadPort<ResultT> directly in
TypedFunction (and the symmetric pair in TypedCallback) instead of
using FuncService::Function::call / CallService::Callback::connect.
This gives both sides a persistent stateful deserializer plus a FIFO
polling buffer, so multi-frame responses reassemble correctly across
raw callbacks and pipelined calls return per-call futures in call FIFO
order even when callers .get() them out of order.

Has the net effect of supporting lists in TypedFunction/TypedCallback.

Also: add SkipTypeCheck to TypedReadPort, add variadic emplace-style
call(...) and operator()(...) overloads on TypedFunction, update the
loopback cosim tests to match (the typed serial-list result now decodes
end-to-end; the non-typed path drains raw frames manually), and add a
pipelined-out-of-order regression test.

Assisted-by: vscode:Claude Opus 4.7