### PR TITLE
[debug][firrtl] Carry Chisel source-level types through the pipeline

### DIFF
--- a/include/circt/Analysis/DebugInfo.h
+++ b/include/circt/Analysis/DebugInfo.h
@@ -12,6 +12,7 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Operation.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 
 namespace circt {
@@ -22,6 +23,23 @@ struct DIVariable;
 namespace detail {
 struct DebugInfoBuilder;
 } // namespace detail
+
+/// Per-module integer identifier for a `dbg.enumdef` op
+using DIEnumDefId = uint32_t;
+
+/// Map from an enum's raw integer value to its variant name
+using DIEnumValMap = llvm::MapVector<int64_t, StringAttr>;
+
+/// Module-scoped table of all enum definitions: id -> variant map
+using DIEnumDefMap = llvm::MapVector<DIEnumDefId, DIEnumValMap>;
+
+/// Source-language type information lifted off
+/// `dbg.moduleinfo` and `dbg.variable` ops
+struct DISourceLang {
+  // Fields are null when absent; check before use.
+  StringAttr typeName;
+  ArrayAttr params;
+};
 
 struct DIModule {
   /// The operation that generated this level of hierarchy.
@@ -36,6 +54,16 @@ struct DIModule {
   bool isExtern = false;
   /// If this is an inline scope created by a `dbg.scope` operation.
   bool isInline = false;
+
+  /// Source-language type, from `dbg.moduleinfo`.
+  DISourceLang sourceLangType;
+
+  /// Enum defs declared inside this module (not inherited from parent scopes)
+  DIEnumDefMap enumDefinitions;
+
+  /// Maps each `dbg.enumdef` op to its id in `enumDefinitions`. Duplicates
+  /// (same enumTypeName + fqn + variants) share the first-seen id.
+  llvm::DenseMap<mlir::Operation *, DIEnumDefId> enumDefIds;
 };
 
 struct DIInstance {
@@ -54,6 +82,16 @@ struct DIVariable {
   LocationAttr loc;
   /// The SSA value representing the value of this variable.
   Value value = nullptr;
+  /// Enum definition for scalar-typed variables; null for aggregate
+  mlir::Value enumDef = nullptr;
+
+  /// Source-language type, from `dbg.variable` attributes.
+  DISourceLang sourceLangType;
+
+  /// Per-module integer id for `enumDef`. nullopt when `enumDef` is null, when
+  /// its defining op is not a `dbg.enumdef`, or when that op was not registered
+  /// in the enclosing module's `enumDefIds` (e.g. it lives in another module).
+  std::optional<DIEnumDefId> enumDefRef = std::nullopt;
 };
 
 /// Debug information attached to an operation and the operations nested within.

--- a/include/circt/Dialect/Debug/DebugOps.h
+++ b/include/circt/Dialect/Debug/DebugOps.h
@@ -17,8 +17,24 @@
 #include "circt/Dialect/Debug/DebugDialect.h"
 #include "circt/Dialect/Debug/DebugTypes.h"
 
+#include <tuple>
+
 // Operation definitions generated from `Debug.td`
 #define GET_OP_CLASSES
 #include "circt/Dialect/Debug/Debug.h.inc"
+
+namespace circt {
+namespace debug {
+
+/// Content-identity key for a `dbg.enumdef`: (enumTypeName, fqn, variantsMap)
+using EnumDefContentKey =
+    std::tuple<mlir::StringAttr, mlir::StringAttr, mlir::DictionaryAttr>;
+
+inline EnumDefContentKey getEnumDefContentKey(EnumDefOp op) {
+  return {op.getEnumTypeNameAttr(), op.getFqnAttr(), op.getVariantsMapAttr()};
+}
+
+} // namespace debug
+} // namespace circt
 
 #endif // CIRCT_DIALECT_DEBUG_DEBUGOPS_H

--- a/include/circt/Dialect/Debug/DebugOps.td
+++ b/include/circt/Dialect/Debug/DebugOps.td
@@ -50,7 +50,7 @@ def ScopeOp : DebugOp<"scope"> {
 }
 
 
-def VariableOp : DebugOp<"variable"> {
+def VariableOp : DebugOp<"variable", [AttrSizedOperandSegments]> {
   let summary = "A named value to be captured in debug info";
   let description = [{
     Marks a value to be tracked in DI under the given name. The `dbg.variable`
@@ -65,19 +65,122 @@ def VariableOp : DebugOp<"variable"> {
     these source language values can be reconstituted from the actual IR values
     present at the end of compilation.
 
+    The optional `typeName` attribute and `params` array attribute carry
+    source-language type information (the type name and constructor parameters),
+    letting consumers reconstruct the source language type more precisely. The
+    optional `enumDef` operand links the variable to a `dbg.enumdef` that
+    describes the named variants of an enumeration type.
+
     See the rationale for examples and details. See the `dbg.scope` operation
     for additional details on how to use the `scope` operand.
   }];
   let arguments = (ins
     StrAttr:$name,
     AnyType:$value,
+    OptionalAttr<StrAttr>:$typeName,
+    OptionalAttr<ArrayAttr>:$params,
+    Optional<EnumDefType>:$enumDef,
     Optional<ScopeType>:$scope
   );
   let assemblyFormat = [{
-    $name `,` $value (`scope` $scope^)? attr-dict `:` type($value)
+    $name `,` $value (`typeName` $typeName^)? (`params` $params^)?
+        (`enumDef` $enumDef^)? (`scope` $scope^)? attr-dict `:` type($value)
   }];
+
+  let builders = [
+    OpBuilder<(ins "::mlir::StringAttr":$name, "::mlir::Value":$value,
+                   "::mlir::Value":$scope), [{
+      build($_builder, $_state, name, value, /*typeName=*/nullptr,
+            /*params=*/nullptr, /*enumDef=*/nullptr, scope);
+    }]>
+  ];
 }
 
+
+def SubFieldOp : DebugOp<"subfield"> {
+  let summary = "A named aggregate-leaf value to be captured in debug info";
+  let description = [{
+    Tags a single leaf of an aggregate for debug info, carrying the same
+    optional source-language type / enum metadata as `dbg.variable`. Unlike
+    `dbg.variable`, a `dbg.subfield` is intended to appear only as an operand
+    of a `dbg.struct` or `dbg.array`. Freshly-created ops with no users are
+    tolerated by the verifier to accommodate construction patterns; any
+    surviving user must be `dbg.struct` or `dbg.array`.
+  }];
+  let arguments = (ins
+    StrAttr:$name,
+    AnyType:$value,
+    OptionalAttr<StrAttr>:$typeName,
+    OptionalAttr<ArrayAttr>:$params,
+    Optional<EnumDefType>:$enumDef
+  );
+  let results = (outs SubFieldType:$result);
+  let assemblyFormat = [{
+    $name `,` $value (`typeName` $typeName^)? (`params` $params^)?
+        (`enumDef` $enumDef^)? attr-dict `:` type($value)
+  }];
+  let hasVerifier = 1;
+}
+
+def ModuleInfoOp : DebugOp<"moduleinfo"> {
+  let summary = "Define extra debug information for a module";
+  let description = [{
+    Creates debug information for a module. If present, this operation provides
+    extra information about the module type in the source language, such as its
+    type name and constructor parameters.
+
+    At most one `dbg.moduleinfo` may appear in a given region.
+  }];
+
+  let arguments = (ins
+    StrAttr:$typeName,
+    OptionalAttr<ArrayAttr>:$params
+  );
+
+  let assemblyFormat = [{
+    `typeName` $typeName (`params` $params^)? attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+def EnumDefOp : DebugOp<"enumdef"> {
+  let summary = "Define the value variants of an enumeration";
+  let description = [{
+    Defines an enumeration type so consumers can reconstruct the named
+    variants from a raw integer value. Logically the mapping is
+    `int -> name`, but in IR it is stored as a `DictionaryAttr` keyed by
+    variant name with `IntegerAttr` values (the integer is not a valid
+    dictionary key); consumers reading variants programmatically must
+    invert the map. `DictionaryAttr` sorts keys lexicographically, so
+    declaration order is not preserved and consumers must not rely on it.
+
+    Declared once per enum per scope. The result is consumed by
+    `dbg.variable` and `dbg.subfield` ops whose value has this enum type.
+
+    Intentionally not marked `Pure` (or similar): even an `enumdef` with no
+    `dbg.variable` / `dbg.subfield` users must survive DCE because
+    `DebugInfoBuilder` assigns sequential IDs to every enumdef in walk
+    order, and downstream consumers may reference those IDs via metadata
+    that the analysis cannot see.
+  }];
+
+  let arguments = (ins
+    StrAttr:$enumTypeName,
+    StrAttr:$fqn,
+    DictionaryAttr:$variantsMap,
+    Optional<ScopeType>:$scope
+  );
+
+  let results = (outs EnumDefType:$result);
+
+  let assemblyFormat = [{
+    $enumTypeName `,` `fqn` $fqn `,` $variantsMap (`scope` $scope^)? attr-dict
+  }];
+
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+}
 
 def StructOp : DebugOp<"struct", [
   Pure,

--- a/include/circt/Dialect/Debug/DebugTypes.td
+++ b/include/circt/Dialect/Debug/DebugTypes.td
@@ -32,4 +32,16 @@ def ArrayType : DebugTypeDef<"Array"> {
   let description = "The result of a `dbg.array` operation.";
 }
 
+def SubFieldType : DebugTypeDef<"SubField"> {
+  let mnemonic = "subfield";
+  let summary = "debug variable subfield of an aggregate";
+  let description = "The result of a `dbg.subfield` operation.";
+}
+
+def EnumDefType : DebugTypeDef<"EnumDef"> {
+  let mnemonic = "enumdef";
+  let summary = "debug enum definition";
+  let description = "The result of a `dbg.enumdef` operation.";
+}
+
 #endif // CIRCT_DIALECT_DEBUG_DEBUGTYPES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
@@ -184,6 +184,20 @@ struct GenericIntrinsic {
   }
 };
 
+/// Side-channel list of `circt_debug_subfield` leaves staged by
+/// `liftDebugIntrinsics`. See its doc for the dictionary schema.
+using DebugLeafList = llvm::SmallVector<mlir::DictionaryAttr>;
+
+/// Per-invocation context for `IntrinsicLowerings::lower`. Non-owning;
+/// pointers may be null when no debug staging is needed.
+struct IntrinsicConvertContext {
+  const DebugLeafList *debugLeaves = nullptr;
+  const llvm::StringMap<mlir::Value> *enumDefByFqn = nullptr;
+  /// Accumulator for emitted `dbg.variable` names; a failed insert means a
+  /// duplicate was seen and triggers a warning. Null disables the check.
+  llvm::StringSet<> *existingVariableNames = nullptr;
+};
+
 /// Base class for Intrinsic Converters.
 ///
 /// Intrinsic converters contain validation logic, along with a converter
@@ -207,10 +221,24 @@ public:
   }
 
   /// Transform the intrinsic to its implementation.
+  /// Override this for context-free conversions. Converters that need
+  /// per-invocation state (e.g. debug leaf metadata) should override
+  /// `convertWithContext` instead.
   virtual void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor adaptor,
                        PatternRewriter &rewriter) {
-    llvm::report_fatal_error(
-        "convert() or checkAndConvert() must be implemented");
+    llvm::report_fatal_error("convert(), convertWithContext(), or "
+                             "checkAndConvert() must be implemented");
+  }
+
+  /// Transform the intrinsic to its implementation, with access to the
+  /// per-invocation lowering context. Default delegates to the context-free
+  /// `convert`. Only override this when the converter needs to read
+  /// per-module staging data (e.g. `CirctDebugVarConverter`).
+  virtual void convertWithContext(GenericIntrinsic gi,
+                                  GenericIntrinsicOpAdaptor adaptor,
+                                  PatternRewriter &rewriter,
+                                  IntrinsicConvertContext ctx) {
+    convert(gi, adaptor, rewriter);
   }
 
   /// Perform both check and convert, defaults to using check() and convert().
@@ -220,10 +248,11 @@ public:
   /// recomputing work done during check needed for the conversion.
   virtual LogicalResult checkAndConvert(GenericIntrinsic gi,
                                         GenericIntrinsicOpAdaptor adaptor,
-                                        PatternRewriter &rewriter) {
+                                        PatternRewriter &rewriter,
+                                        IntrinsicConvertContext ctx) {
     if (check(gi))
       return failure();
-    convert(gi, adaptor, rewriter);
+    convertWithContext(gi, adaptor, rewriter, ctx);
     return success();
   };
 };
@@ -263,8 +292,23 @@ public:
     (addConverter<T>(args), ...);
   }
 
+  /// Registers a converter with constructor arguments.
+  template <typename T, typename... Args>
+  void addConverter(StringRef name, Args &&...args) {
+    auto nameAttr = StringAttr::get(context, name);
+    assert(!conversions.contains(nameAttr) &&
+           "duplicate conversion for intrinsic");
+    conversions.try_emplace(nameAttr,
+                            std::make_unique<T>(std::forward<Args>(args)...));
+  }
+
   /// Lowers all intrinsics in a module.  Returns number converted or failure.
-  FailureOr<size_t> lower(FModuleOp mod, bool allowUnknownIntrinsics = false);
+  /// The optional `ctx` provides per-invocation staging data (e.g. debug
+  /// leaf metadata produced by `liftDebugIntrinsics`). It MUST live on the
+  /// caller's stack for the duration of this call; storing it on the shared
+  /// `IntrinsicLowerings` object would race across parallel pass invocations.
+  FailureOr<size_t> lower(FModuleOp mod, bool allowUnknownIntrinsics = false,
+                          IntrinsicConvertContext ctx = {});
 
 private:
   template <typename T>
@@ -300,6 +344,30 @@ struct FIRRTLIntrinsicLoweringDialectInterface
   using IntrinsicLoweringDialectInterface::IntrinsicLoweringDialectInterface;
   void populateIntrinsicLowerings(IntrinsicLowerings &lowerings) const override;
 };
+
+/// Pre-pass: in a single module walk, lift `circt_debug_enumdef` intrinsics
+/// into module-level `dbg.enumdef` ops (deduplicated by fqn; on fqn collision
+/// with mismatched variants the first wins with a warning) and collect
+/// `circt_debug_subfield` intrinsics into `outLeaves`. Both kinds of
+/// intrinsic are erased. Must run before `IntrinsicLowerings::lower`; the
+/// caller passes `outLeaves` and `outEnumDefByFqn` through
+/// `IntrinsicConvertContext`. Returns failure on malformed intrinsics.
+///
+/// Frontend contract for `circt_debug_subfield`:
+///   - `parent` (mandatory) is the enclosing var's `name` and is the sole
+///     var<->leaf linkage key. Do not derive it from `name`.
+///   - `name` is the full dotted/indexed display path (e.g. `"io.state"`,
+///     `"v[0].x"`); used for display and path-matching, NOT for linkage.
+///
+/// Each entry in `outLeaves` is a `DictionaryAttr` with keys:
+///   - `parent`   : StringAttr -- enclosing var's `name`, the linkage key.
+///   - `name`     : StringAttr -- dotted/indexed path under `parent`.
+///   - `typeName` : StringAttr (optional) -- source-language type name.
+///   - `params`   : ArrayAttr  (optional) -- parsed JSON parameter list.
+///   - `enumFqn`  : StringAttr (optional) -- FQN of an enumdef to bind.
+LogicalResult
+liftDebugIntrinsics(FModuleOp mod, OpBuilder &builder, DebugLeafList &outLeaves,
+                    llvm::StringMap<mlir::Value> &outEnumDefByFqn);
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -641,6 +641,7 @@ def LowerIntrinsics : Pass<"firrtl-lower-intrinsics", "firrtl::FModuleOp"> {
   let description = [{
     This pass lowers generic intrinsic ops to their implementation or op.
   }];
+  let dependentDialects = ["debug::DebugDialect"];
   let statistics = [
     Statistic<"numConverted", "num-converted", "Number of intrinsic operations lowered">,
   ];

--- a/lib/Analysis/DebugInfo.cpp
+++ b/lib/Analysis/DebugInfo.cpp
@@ -10,6 +10,7 @@
 #include "circt/Dialect/Debug/DebugOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "di"
@@ -97,6 +98,10 @@ void DebugInfoBuilder::visitModule(hw::HWModuleOp moduleOp, DIModule &module) {
     if (isa<debug::VariableOp>(op))
       hasVariables = true;
     if (auto scopeOp = dyn_cast<debug::ScopeOp>(op)) {
+      // A `dbg.scope` op declares an explicit instance in the DI hierarchy.
+      // Mark `hasInstances` so the `hw::InstanceOp` fallback below does not
+      // also add this module's `hw.instance` ops as duplicate children.
+      hasInstances = true;
       auto *node = createModule();
       node->isInline = true;
       node->name = scopeOp.getModuleNameAttr();
@@ -132,53 +137,104 @@ void DebugInfoBuilder::visitModule(hw::HWModuleOp moduleOp, DIModule &module) {
     }
   }
 
-  // Fill in any missing DI as a fallback.
-  moduleOp->walk([&](Operation *op) {
-    if (auto varOp = dyn_cast<debug::VariableOp>(op)) {
-      auto *var = createVariable();
-      var->name = varOp.getNameAttr();
-      var->loc = varOp.getLoc();
-      var->value = varOp.getValue();
-      getScope(varOp.getScope()).variables.push_back(var);
-      return;
-    }
+  // Local dedup keyed on uniqued attributes; pointer equality suffices.
+  llvm::DenseMap<debug::EnumDefContentKey, DIEnumDefId> dedupIndex;
 
-    if (auto scopeOp = dyn_cast<debug::ScopeOp>(op)) {
-      auto *instance = createInstance();
-      instance->name = scopeOp.getInstanceNameAttr();
-      instance->op = scopeOp;
-      instance->module = scopes.lookup(scopeOp);
-      getScope(scopeOp.getScope()).instances.push_back(instance);
-    }
+  // Collection walk plus fallback synthesis from `hw.instance` / `hw.wire`.
+  // PreOrder: a `dbg.variable` may live in a nested region while its
+  // `dbg.enumdef` sits at module level. PostOrder would descend into that
+  // region before visiting the outer enumdef, leaving `enumDefIds` empty at
+  // lookup. PreOrder visits each op before its regions, so every enumdef
+  // dominating a variable is registered first.
+  moduleOp->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    return llvm::TypeSwitch<Operation *, WalkResult>(op)
+        .Case<debug::ModuleInfoOp>([&](auto miOp) {
+          module.sourceLangType.typeName = miOp.getTypeNameAttr();
+          module.sourceLangType.params = miOp.getParamsAttr();
+          return WalkResult::advance();
+        })
+        .Case<debug::EnumDefOp>([&](auto edOp) {
+          assert(module.enumDefIds.size() <
+                     std::numeric_limits<DIEnumDefId>::max() &&
+                 "too many enumdefs");
 
-    // Fallback if the module has no DI for its instances.
-    if (!hasInstances) {
-      if (auto instOp = dyn_cast<hw::InstanceOp>(op)) {
-        auto &childModule =
-            getOrCreateModule(instOp.getModuleNameAttr().getAttr());
-        auto *instance = createInstance();
-        instance->name = instOp.getInstanceNameAttr();
-        instance->op = instOp;
-        instance->module = &childModule;
-        module.instances.push_back(instance);
+          auto [deduIt, inserted] = dedupIndex.try_emplace(
+              debug::getEnumDefContentKey(edOp), DIEnumDefId{});
+          if (!inserted) {
+            module.enumDefIds.try_emplace(edOp, deduIt->second);
+            return WalkResult::advance();
+          }
 
-        // TODO: What do we do with the port assignments? These should be
-        // tracked somewhere.
-        return;
-      }
-    }
+          auto id = static_cast<DIEnumDefId>(module.enumDefinitions.size());
+          deduIt->second = id;
+          module.enumDefIds.try_emplace(edOp, id);
+          DIEnumValMap variants;
+          for (auto na : edOp.getVariantsMapAttr()) {
+            auto key = cast<IntegerAttr>(na.getValue()).getInt();
+            auto val = cast<StringAttr>(na.getName());
+            variants.insert({key, val});
+          }
+          module.enumDefinitions.try_emplace(id, std::move(variants));
+          return WalkResult::advance();
+        })
+        .Case<debug::VariableOp>([&](auto varOp) {
+          auto *var = createVariable();
+          var->name = varOp.getNameAttr();
+          var->loc = varOp.getLoc();
+          var->value = varOp.getValue();
+          var->sourceLangType.typeName = varOp.getTypeNameAttr();
+          var->sourceLangType.params = varOp.getParamsAttr();
+          if (auto enumDefVal = varOp.getEnumDef()) {
+            var->enumDef = enumDefVal;
+            if (auto edOp =
+                    enumDefVal.template getDefiningOp<debug::EnumDefOp>()) {
+              auto it = module.enumDefIds.find(edOp);
+              if (it != module.enumDefIds.end())
+                var->enumDefRef = it->second;
+            }
+          }
+          getScope(varOp.getScope()).variables.push_back(var);
+          return WalkResult::advance();
+        })
+        .Case<debug::ScopeOp>([&](auto scopeOp) {
+          auto *instance = createInstance();
+          instance->name = scopeOp.getInstanceNameAttr();
+          instance->op = scopeOp;
+          instance->module = scopes.lookup(scopeOp);
+          getScope(scopeOp.getScope()).instances.push_back(instance);
+          return WalkResult::advance();
+        })
+        .Default([&](Operation *op) {
+          // Fallback if the module has no DI for its instances.
+          if (!hasInstances) {
+            if (auto instOp = dyn_cast<hw::InstanceOp>(op)) {
+              auto &childModule =
+                  getOrCreateModule(instOp.getModuleNameAttr().getAttr());
+              auto *instance = createInstance();
+              instance->name = instOp.getInstanceNameAttr();
+              instance->op = instOp;
+              instance->module = &childModule;
+              module.instances.push_back(instance);
 
-    // Fallback if the module has no DI for its variables.
-    if (!hasVariables) {
-      if (auto wireOp = dyn_cast<hw::WireOp>(op)) {
-        auto *var = createVariable();
-        var->name = wireOp.getNameAttr();
-        var->loc = wireOp.getLoc();
-        var->value = wireOp;
-        module.variables.push_back(var);
-        return;
-      }
-    }
+              // TODO: What do we do with the port assignments? These should be
+              // tracked somewhere.
+              return WalkResult::advance();
+            }
+          }
+
+          // Fallback if the module has no DI for its variables.
+          if (!hasVariables) {
+            if (auto wireOp = dyn_cast<hw::WireOp>(op)) {
+              auto *var = createVariable();
+              var->name = wireOp.getNameAttr();
+              var->loc = wireOp.getLoc();
+              var->value = wireOp;
+              module.variables.push_back(var);
+            }
+          }
+
+          return WalkResult::advance();
+        });
   });
 }
 

--- a/lib/Dialect/Debug/DebugOps.cpp
+++ b/lib/Dialect/Debug/DebugOps.cpp
@@ -8,6 +8,8 @@
 
 #include "circt/Dialect/Debug/DebugOps.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/DenseSet.h"
 
 using namespace circt;
 using namespace debug;
@@ -115,7 +117,9 @@ void ArrayOp::print(OpAsmPrinter &printer) {
   }
 }
 
-// Operation implementations generated from `Debug.td`
+//===----------------------------------------------------------------------===//
+// Generated operation code
+//===----------------------------------------------------------------------===//
 #define GET_OP_CLASSES
 #include "circt/Dialect/Debug/Debug.cpp.inc"
 
@@ -124,4 +128,102 @@ void DebugDialect::registerOps() {
 #define GET_OP_LIST
 #include "circt/Dialect/Debug/Debug.cpp.inc"
       >();
+}
+
+//===----------------------------------------------------------------------===//
+// SubFieldOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SubFieldOp::verify() {
+  // Final IR is expected to have >=1 user (dbg.struct/dbg.array).
+  if (getResult().use_empty())
+    return success();
+
+  if (!llvm::all_of(getResult().getUsers(), [](Operation *user) {
+        return isa<StructOp, ArrayOp>(user);
+      }))
+    return emitOpError(
+        "must only be used as an operand of dbg.struct or dbg.array");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// EnumDefOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult EnumDefOp::verify() {
+  if (getVariantsMap().empty())
+    return emitOpError("variantsMap must not be empty");
+
+  llvm::DenseSet<int64_t> seenValues{};
+  for (auto namedAttr : getVariantsMap()) {
+    auto intAttr = dyn_cast<IntegerAttr>(namedAttr.getValue());
+    if (!intAttr)
+      return emitOpError("variantsMap entry '")
+             << namedAttr.getName().getValue()
+             << "' must be an IntegerAttr, got " << namedAttr.getValue();
+    if (!intAttr.getType().isSignlessInteger())
+      return emitOpError() << "variant '" << namedAttr.getName().getValue()
+                           << "' must have a signless integer value";
+    auto value = intAttr.getInt();
+    if (!seenValues.insert(value).second)
+      return emitOpError("duplicate enum value ") << value;
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ModuleInfoOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ModuleInfoOp::verify() {
+  auto *region = getOperation()->getParentRegion();
+  if (!region)
+    return success();
+
+  for (auto &block : *region) {
+    for (auto mi : block.getOps<ModuleInfoOp>()) {
+      if (mi == *this)
+        return success();
+      return emitOpError("only one dbg.moduleinfo may appear in a region");
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// EnumDefOp canonicalization
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct EnumDefDeduplication : public OpRewritePattern<EnumDefOp> {
+  using OpRewritePattern<EnumDefOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(EnumDefOp op,
+                                PatternRewriter &rewriter) const override {
+    // TODO(perf): O(N^2) per-op scan
+    auto opKey = getEnumDefContentKey(op);
+    auto opScope = op.getScope();
+
+    // Backward scan: every candidate dominates `op` without a DominanceInfo.
+    for (auto *prev = op->getPrevNode(); prev; prev = prev->getPrevNode()) {
+      auto otherEnumDef = dyn_cast<EnumDefOp>(prev);
+      if (!otherEnumDef)
+        continue;
+
+      if (getEnumDefContentKey(otherEnumDef) == opKey &&
+          otherEnumDef.getScope() == opScope) {
+        rewriter.replaceOp(op, otherEnumDef.getResult());
+        return success();
+      }
+    }
+    return failure();
+  }
+};
+} // namespace
+
+void EnumDefOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.add<EnumDefDeduplication>(context);
 }

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -45,6 +45,7 @@ add_circt_dialect_library(CIRCTFIRRTL
 
   LINK_LIBS PUBLIC
   CIRCTSupport
+  CIRCTDebug
   CIRCTHW
   CIRCTOM
   CIRCTSeq

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/FIRRTL/FIRRTLIntrinsics.h"
+#include "circt/Dialect/Debug/DebugOps.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/CHIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
@@ -115,10 +117,10 @@ public:
 
   IntrinsicOpConversion(TypeConverter &typeConverter, MLIRContext *context,
                         const ConversionMapTy &conversions,
-                        size_t &numConversions,
+                        size_t &numConversions, IntrinsicConvertContext convCtx,
                         bool allowUnknownIntrinsics = false)
       : OpConversionPattern(typeConverter, context), conversions(conversions),
-        numConversions(numConversions),
+        numConversions(numConversions), convCtx(convCtx),
         allowUnknownIntrinsics(allowUnknownIntrinsics) {}
 
   LogicalResult
@@ -133,7 +135,8 @@ public:
     }
 
     auto &conv = *it->second;
-    auto result = conv.checkAndConvert(GenericIntrinsic(op), adaptor, rewriter);
+    auto result =
+        conv.checkAndConvert(GenericIntrinsic(op), adaptor, rewriter, convCtx);
     if (succeeded(result))
       ++numConversions;
     return result;
@@ -142,6 +145,7 @@ public:
 private:
   const ConversionMapTy &conversions;
   size_t &numConversions;
+  IntrinsicConvertContext convCtx;
   const bool allowUnknownIntrinsics;
 };
 } // namespace
@@ -151,7 +155,8 @@ private:
 //===----------------------------------------------------------------------===//
 
 FailureOr<size_t> IntrinsicLowerings::lower(FModuleOp mod,
-                                            bool allowUnknownIntrinsics) {
+                                            bool allowUnknownIntrinsics,
+                                            IntrinsicConvertContext ctx) {
 
   ConversionTarget target(*context);
 
@@ -168,6 +173,7 @@ FailureOr<size_t> IntrinsicLowerings::lower(FModuleOp mod,
   // For now, this is not customizable/extendable.
   TypeConverter typeConverter;
   typeConverter.addConversion([](Type type) { return type; });
+
   auto firrtlBaseTypeMaterialization =
       [](OpBuilder &builder, FIRRTLBaseType resultType, ValueRange inputs,
          Location loc) -> Value {
@@ -193,7 +199,7 @@ FailureOr<size_t> IntrinsicLowerings::lower(FModuleOp mod,
   RewritePatternSet patterns(context);
   size_t count = 0;
   patterns.add<IntrinsicOpConversion>(typeConverter, context, conversions,
-                                      count, allowUnknownIntrinsics);
+                                      count, ctx, allowUnknownIntrinsics);
 
   if (failed(mlir::applyPartialConversion(mod, target, std::move(patterns))))
     return failure();
@@ -570,7 +576,8 @@ public:
 
   LogicalResult checkAndConvert(GenericIntrinsic gi,
                                 GenericIntrinsicOpAdaptor adaptor,
-                                PatternRewriter &rewriter) override {
+                                PatternRewriter &rewriter,
+                                IntrinsicConvertContext) override {
     // Check structure of the intrinsic.
     if (gi.typedInput<ClockType>(0) || gi.sizedInput<UIntType>(1, 1) ||
         gi.sizedInput<UIntType>(2, 1) ||
@@ -756,6 +763,416 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// Debug intrinsic converters
+//===----------------------------------------------------------------------===//
+
+static ArrayAttr parseParamsJSON(MLIRContext *ctx, StringAttr paramsStr,
+                                 Operation *warnAt);
+
+class CirctDebugModuleInfoConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check(GenericIntrinsic gi) override {
+    return gi.hasNInputs(0) || gi.namedParam("typeName") ||
+           gi.namedParam("params", /*optional=*/true) || gi.hasNParam(1, 1) ||
+           gi.hasNoOutput();
+  }
+
+  void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor adaptor,
+               PatternRewriter &rewriter) override {
+    auto typeName = gi.getParamValue<StringAttr>("typeName");
+    auto paramsStr = gi.getParamValue<StringAttr>("params");
+
+    ArrayAttr params;
+    if (paramsStr) {
+      params = parseParamsJSON(rewriter.getContext(), paramsStr, gi.op);
+    }
+
+    rewriter.replaceOpWithNewOp<debug::ModuleInfoOp>(gi.op, typeName, params);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Debug intrinsic helpers
+//===----------------------------------------------------------------------===//
+
+static std::optional<Attribute>
+jsonValueToAttr(MLIRContext *ctx, const llvm::json::Value &v, bool &skipped) {
+  if (auto b = v.getAsBoolean())
+    return BoolAttr::get(ctx, *b);
+  if (auto s = v.getAsString())
+    return StringAttr::get(ctx, *s);
+  if (auto i = v.getAsInteger())
+    return IntegerAttr::get(IntegerType::get(ctx, 64), *i);
+  if (v.getAsNumber() || v.getAsObject() || v.getAsArray())
+    skipped = true;
+  return std::nullopt;
+}
+
+static ArrayAttr parseParamsJSON(MLIRContext *ctx, StringAttr paramsStr,
+                                 Operation *warnAt) {
+  if (!paramsStr || paramsStr.getValue().empty())
+    return {};
+
+  auto parsed = llvm::json::parse(paramsStr.strref());
+  if (auto err = parsed.takeError()) {
+    auto msg = llvm::toString(std::move(err));
+    if (warnAt)
+      warnAt->emitWarning()
+          << "debug params JSON failed to parse (type-parameter info "
+             "dropped): "
+          << msg;
+    return {};
+  }
+
+  auto *arr = parsed->getAsArray();
+  if (!arr) {
+    if (warnAt)
+      warnAt->emitWarning()
+          << "debug params JSON is not a JSON array (type-parameter info "
+             "dropped)";
+    return {};
+  }
+
+  bool skippedUnsupported = false;
+  SmallVector<Attribute> entries{};
+  for (const auto &item : *arr) {
+    auto *obj = item.getAsObject();
+    if (!obj)
+      continue;
+
+    SmallVector<NamedAttribute> fields;
+    for (auto &[k, v] : *obj) {
+      if (auto attr = jsonValueToAttr(ctx, v, skippedUnsupported))
+        fields.push_back({StringAttr::get(ctx, StringRef(k)), *attr});
+    }
+
+    entries.push_back(DictionaryAttr::get(ctx, fields));
+  }
+
+  if (skippedUnsupported && warnAt)
+    warnAt->emitWarning() << "debug params JSON contains unsupported value "
+                             "types (float/object/array); those fields are "
+                             "dropped";
+  return ArrayAttr::get(ctx, entries);
+}
+
+/// Per-leaf metadata flattened from `IntrinsicConvertContext::debugLeaves`,
+/// keyed by the subfield's full dotted path (e.g. "io.in.a").
+namespace {
+struct LeafMeta {
+  Value enumDefVal;
+  StringAttr typeName;
+  ArrayAttr params;
+};
+} // namespace
+using LeafMetaMap = llvm::StringMap<LeafMeta>;
+
+namespace {
+class DebugAggregateBuilder {
+public:
+  DebugAggregateBuilder(PatternRewriter &rewriter, Location loc,
+                        const LeafMetaMap &leafMetaMap, Operation *warnAt)
+      : rewriter(rewriter), loc(loc), leafMetaMap(leafMetaMap), warnAt(warnAt) {
+  }
+
+  Value build(Value value, StringRef parentPath, bool isRoot = true) {
+    return FIRRTLTypeSwitch<Type, Value>(value.getType())
+        .Case<BundleType>([&](BundleType t) {
+          return buildBundle(value, t, parentPath, isRoot);
+        })
+        .Case<FVectorType>([&](FVectorType t) {
+          return buildVector(value, t, parentPath, isRoot);
+        })
+        .Case<FIRRTLBaseType>([&](FIRRTLBaseType t) -> Value {
+          if (!t.isGround())
+            return {};
+          return wrap(value, parentPath, isRoot);
+        })
+        .Default([](auto) -> Value { return {}; });
+  }
+
+private:
+  Value wrap(Value inner, StringRef parentPath, bool isRoot) {
+    if (isRoot)
+      return inner;
+
+    Value enumDef{};
+    ArrayAttr params{};
+    StringAttr typeName{};
+    if (auto it = leafMetaMap.find(parentPath); it != leafMetaMap.end()) {
+      typeName = it->second.typeName;
+      params = it->second.params;
+      enumDef = it->second.enumDefVal;
+    }
+
+    auto nameAttr = StringAttr::get(rewriter.getContext(), parentPath);
+    return debug::SubFieldOp::create(rewriter, loc, nameAttr, inner, typeName,
+                                     params, enumDef)
+        .getResult();
+  }
+
+  void eraseUnused(ArrayRef<Operation *> ops) {
+    for (auto *op : ops)
+      if (op->use_empty())
+        rewriter.eraseOp(op);
+  }
+
+  Value buildBundle(Value value, BundleType type, StringRef parentPath,
+                    bool isRoot) {
+    SmallVector<Value> fields{};
+    SmallVector<Attribute> names{};
+    SmallVector<Operation *> subOps{};
+    for (auto [index, element] : llvm::enumerate(type.getElements())) {
+      auto subOp = SubfieldOp::create(rewriter, loc, value, index);
+      subOps.push_back(subOp.getOperation());
+
+      std::string fieldPath =
+          (Twine(parentPath) + "." + element.name.getValue()).str();
+      if (auto dbgVal = build(subOp.getResult(), fieldPath, /*isRoot=*/false)) {
+        fields.push_back(dbgVal);
+        names.push_back(element.name);
+      } else if (warnAt) {
+        warnAt->emitWarning() << "dbg.struct field '" << element.name.getValue()
+                              << "' has unsupported type; skipping";
+      }
+    }
+
+    if (fields.empty())
+      return {};
+
+    Value result = debug::StructOp::create(rewriter, loc, fields,
+                                           rewriter.getArrayAttr(names));
+    eraseUnused(subOps);
+    return wrap(result, parentPath, isRoot);
+  }
+
+  Value buildVector(Value value, FVectorType type, StringRef parentPath,
+                    bool isRoot) {
+    SmallVector<Value> elements{};
+    SmallVector<Operation *> subOps{};
+    for (std::size_t i = 0; i < type.getNumElements(); ++i) {
+      auto subOp = SubindexOp::create(rewriter, loc, value, i);
+      subOps.push_back(subOp.getOperation());
+
+      std::string elemPath = (Twine(parentPath) + "[" + Twine(i) + "]").str();
+      if (auto dbgVal = build(subOp.getResult(), elemPath, /*isRoot=*/false))
+        elements.push_back(dbgVal);
+    }
+
+    if (elements.size() != type.getNumElements()) {
+      if (warnAt)
+        warnAt->emitWarning()
+            << "dbg.array for '" << parentPath << "' has " << elements.size()
+            << "/" << type.getNumElements()
+            << " elements due to unsupported element types; skipping";
+      eraseUnused(subOps);
+      return {};
+    }
+
+    Value result = debug::ArrayOp::create(rewriter, loc, elements);
+    eraseUnused(subOps);
+    return wrap(result, parentPath, isRoot);
+  }
+
+  PatternRewriter &rewriter;
+  const LeafMetaMap &leafMetaMap;
+
+  Location loc;
+  Operation *warnAt;
+};
+} // namespace
+
+static Value buildDebugAggregateWithMeta(PatternRewriter &rewriter,
+                                         Location loc, Value value,
+                                         StringRef parentPath,
+                                         const LeafMetaMap &leafMetaMap,
+                                         bool isRoot = true,
+                                         Operation *warnAt = nullptr) {
+  return DebugAggregateBuilder(rewriter, loc, leafMetaMap, warnAt)
+      .build(value, parentPath, isRoot);
+}
+
+/// Converts `circt_debug_var` to `dbg.variable`, reading the per-module
+/// `dbg.enumdef` table and side-channel leaf list staged by
+/// `liftDebugIntrinsics` and threaded through `IntrinsicConvertContext`.
+class CirctDebugVarConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check(GenericIntrinsic gi) override {
+    // 0 operands for memories (no SSA), 1 operand for normal values.
+    unsigned n = gi.op.getNumOperands();
+    if (n != 0 && n != 1)
+      return true;
+    return gi.namedParam("name") || gi.namedParam("typeName") ||
+           gi.namedParam("params", /*optional=*/true) ||
+           gi.namedParam("enumFqn", /*optional=*/true) || gi.hasNParam(2, 2) ||
+           gi.hasNoOutput();
+  }
+
+  void convertWithContext(GenericIntrinsic gi,
+                          GenericIntrinsicOpAdaptor adaptor,
+                          PatternRewriter &rewriter,
+                          IntrinsicConvertContext ctx) override {
+    auto varName = gi.getParamValue<StringAttr>("name");
+    auto typeName = gi.getParamValue<StringAttr>("typeName");
+    auto location = gi.op.getLoc();
+    auto modOp = gi.op->getParentOfType<FModuleOp>();
+
+    // Warn on duplicate variable name within the same module.
+    // `ctx.existingVariableNames` is an accumulator: insert the name now and
+    // warn if it was already inserted by an earlier circt_debug_var in this
+    // invocation. This is O(1) per call -- no IR walk -- and emits the warning
+    // exactly once for each duplicate (on the second occurrence).
+    if (varName && ctx.existingVariableNames) {
+      if (!ctx.existingVariableNames->insert(varName.getValue()).second)
+        gi.op->emitWarning("duplicate circt_debug_var with name '")
+            << varName.getValue() << "'";
+    }
+
+    ArrayAttr params;
+    if (auto paramAttr = gi.getParamValue<StringAttr>("params"))
+      params = parseParamsJSON(rewriter.getContext(), paramAttr, gi.op);
+
+    // Module-level `dbg.enumdef` ops are collected once by
+    // `liftDebugIntrinsics` and exposed via the per-invocation `ctx`.
+    assert(ctx.enumDefByFqn &&
+           "CirctDebugVarConverter requires liftDebugIntrinsics to publish "
+           "enumDefByFqn via IntrinsicConvertContext");
+    const auto &enumDefByFqn = *ctx.enumDefByFqn;
+    // Look up a dbg.enumdef by FQN. If the FQN is non-empty but no matching
+    // enumdef was found, emit a warning on `warnAt` (UHDI is still emitted,
+    // just without the enum binding).
+    auto lookupEnumDef = [&](StringAttr fqnAttr,
+                             Operation *warnAt = nullptr) -> Value {
+      if (!fqnAttr || fqnAttr.getValue().empty())
+        return {};
+      auto it = enumDefByFqn.find(fqnAttr.getValue());
+      if (it == enumDefByFqn.end()) {
+        if (warnAt)
+          warnAt->emitWarning()
+              << "no circt_debug_enumdef found for '" << fqnAttr.getValue()
+              << "'; leaf will be emitted without enum binding";
+        return {};
+      }
+      return it->second;
+    };
+
+    Value enumDef =
+        lookupEnumDef(gi.getParamValue<StringAttr>("enumFqn"), gi.op);
+
+    // Pick leaves belonging to this var from the side-channel list staged
+    // by `liftDebugIntrinsics`, keyed by their display path (matches what
+    // `buildDebugAggregateWithMeta` reconstructs).
+    LeafMetaMap leafMap;
+    StringRef varPath = varName ? varName.getValue() : StringRef{};
+    if (!varPath.empty() && ctx.debugLeaves) {
+      for (auto entry : *ctx.debugLeaves) {
+        auto parentAttr = entry.getAs<StringAttr>("parent");
+        if (!parentAttr || parentAttr.getValue() != varPath)
+          continue;
+        auto pathAttr = entry.getAs<StringAttr>("name");
+        if (!pathAttr)
+          continue;
+        LeafMeta meta;
+        meta.typeName = entry.getAs<StringAttr>("typeName");
+        meta.params = entry.getAs<ArrayAttr>("params");
+        meta.enumDefVal =
+            lookupEnumDef(entry.getAs<StringAttr>("enumFqn"), gi.op);
+        leafMap[pathAttr.getValue()] = meta;
+      }
+    }
+
+    // Locate the SSA to walk: direct operand, or (for non-passive roots
+    // emitted with 0 operands) a port/wire/reg named `varName`.
+    //
+    // Name-based lookup assumes this pass runs BEFORE LowerTypes and
+    // PrettifyVerilogNames, which rewrite port/wire names. Re-ordering passes
+    // breaks this resolution silently.
+    Value rawSignal;
+    if (!adaptor.getOperands().empty()) {
+      rawSignal = adaptor.getOperands()[0];
+    } else if (modOp && varName) {
+      StringRef wanted = varName.getValue();
+      SmallVector<Value, 2> candidates;
+      for (auto [port, arg] :
+           llvm::zip(modOp.getPorts(), modOp.getArguments())) {
+        if (port.name.getValue() == wanted)
+          candidates.push_back(arg);
+      }
+      if (candidates.empty()) {
+        // Single walk: collect wire/node/reg/regreset candidates and flag
+        // memories; both cases only matter when no port matched.
+        bool isMemory = false;
+        modOp.walk([&](Operation *op) {
+          TypeSwitch<Operation *>(op)
+              .Case<WireOp, NodeOp, RegOp, RegResetOp>([&](auto o) {
+                if (o.getNameAttr().getValue() == wanted)
+                  candidates.push_back(o->getResult(0));
+              })
+              .Case<chirrtl::CombMemOp, chirrtl::SeqMemOp, MemOp>(
+                  [&](Operation *memOp) {
+                    // Use generic getAttrOfType because the three op types
+                    // (CombMemOp, SeqMemOp, MemOp) have different native getter
+                    // signatures; a polymorphic attribute lookup is simpler.
+                    if (auto nameAttr =
+                            memOp->getAttrOfType<StringAttr>("name"))
+                      if (nameAttr.getValue() == wanted)
+                        isMemory = true;
+                  });
+        });
+        if (candidates.empty() && isMemory) {
+          // Memory 0-operand debug_var: erase silently (no SSA result to bind).
+          rewriter.eraseOp(gi.op);
+          return;
+        }
+      }
+      if (candidates.size() > 1) {
+        gi.op->emitError("circt_debug_var: name '")
+            << wanted << "' is ambiguous (matches " << candidates.size()
+            << " signals)";
+        return;
+      }
+      if (candidates.size() == 1)
+        rawSignal = candidates[0];
+    }
+
+    if (!rawSignal) {
+      if (varName)
+        gi.op->emitWarning(
+            "circt_debug_var: no wire, port, or register named '")
+            << varName.getValue() << "' found";
+      rewriter.eraseOp(gi.op);
+      return;
+    }
+
+    Value dbgValue = buildDebugAggregateWithMeta(rewriter, location, rawSignal,
+                                                 varPath, leafMap,
+                                                 /*isRoot=*/true, gi.op);
+    if (!dbgValue)
+      dbgValue = rawSignal;
+
+    rewriter.replaceOpWithNewOp<debug::VariableOp>(gi.op, varName, dbgValue,
+                                                   typeName, params, enumDef,
+                                                   /*scope=*/Value{});
+  }
+};
+
+/// TODO: silently drops `circt_debug_typedef` (no `dbg.typedef` op yet).
+/// Replace with a real lowering once the dialect grows one.
+class CirctDebugTypeDefConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+  bool check(GenericIntrinsic gi) override { return false; }
+  void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor,
+               PatternRewriter &rewriter) override {
+    rewriter.eraseOp(gi.op);
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // View intrinsic converter and helpers
 //===----------------------------------------------------------------------===//
 
@@ -910,7 +1327,8 @@ class ViewConverter : public IntrinsicConverter {
 public:
   LogicalResult checkAndConvert(GenericIntrinsic gi,
                                 GenericIntrinsicOpAdaptor adaptor,
-                                PatternRewriter &rewriter) override {
+                                PatternRewriter &rewriter,
+                                IntrinsicConvertContext) override {
     // Check structure of the intrinsic.
     if (gi.hasNoOutput() || gi.namedParam("info") || gi.namedParam("name") ||
         gi.namedParam("yaml", true))
@@ -1006,4 +1424,188 @@ public:
 void FIRRTLIntrinsicLoweringDialectInterface::populateIntrinsicLowerings(
     IntrinsicLowerings &lowering) const {
   populateLowerings(lowering);
+  lowering.add<CirctDebugTypeDefConverter>("circt_debug_typedef");
+  lowering.add<CirctDebugVarConverter>("circt_debug_var");
+  lowering.add<CirctDebugModuleInfoConverter>("circt_debug_moduleinfo");
 }
+
+namespace {
+
+/// Process one `circt_debug_enumdef` intrinsic: validate, parse variants,
+/// and (re)use a module-level `dbg.enumdef` op deduplicated by fqn
+LogicalResult processEnumDefIntrinsic(GenericIntrinsicOp op, FModuleOp mod,
+                                      OpBuilder &builder,
+                                      llvm::StringMap<Value> &seen) {
+  GenericIntrinsic gi{op};
+
+  auto fqn = gi.getParamValue<StringAttr>("fqn");
+  auto typeName = gi.getParamValue<StringAttr>("typeName");
+  auto variantsStr = gi.getParamValue<StringAttr>("variants");
+  if (!fqn || !typeName || !variantsStr)
+    return op.emitError("circt_debug_enumdef: missing required parameter(s) "
+                        "'fqn', 'typeName', or 'variants'");
+
+  auto parsed = llvm::json::parse(variantsStr.strref());
+  if (auto err = parsed.takeError())
+    return op.emitError("circt_debug_enumdef: failed to parse 'variants': ")
+           << llvm::toString(std::move(err));
+
+  auto *arr = parsed->getAsArray();
+  if (!arr)
+    return op.emitError("circt_debug_enumdef: 'variants' is not a JSON array");
+
+  auto *ctx = mod.getContext();
+  SmallVector<NamedAttribute> variants;
+  for (const auto &item : *arr) {
+    auto *obj = item.getAsObject();
+    if (!obj)
+      return op.emitError(
+          "circt_debug_enumdef: variant entry is not a JSON object");
+
+    auto varNameOpt = obj->getString("name");
+    if (!varNameOpt)
+      return op.emitError("circt_debug_enumdef: variant is missing 'name'");
+
+    // Frontend emits value as a string; tolerate integers for tests.
+    int64_t val = 0;
+    if (auto s = obj->getString("value")) {
+      auto sv = *s;
+      if (sv.getAsInteger(10, val))
+        return op.emitError("circt_debug_enumdef: variant '")
+               << *varNameOpt << "' has non-integer value '" << sv << "'";
+    } else if (auto i = obj->getInteger("value")) {
+      val = *i;
+    } else {
+      return op.emitError("circt_debug_enumdef: variant '")
+             << *varNameOpt << "' is missing 'value'";
+    }
+
+    variants.push_back({StringAttr::get(ctx, *varNameOpt),
+                        IntegerAttr::get(IntegerType::get(ctx, 64), val)});
+  }
+
+  auto variantsMap = DictionaryAttr::get(ctx, variants);
+
+  auto [it, inserted] = seen.try_emplace(fqn.getValue(), Value{});
+  if (inserted) {
+    auto enumOp = debug::EnumDefOp::create(builder, op.getLoc(), typeName, fqn,
+                                           variantsMap, /*scope=*/Value{});
+    it->second = enumOp.getResult();
+    // Advance insertion point so the next enumdef is created after this one,
+    // preserving walk order (block-start insertion would reverse the sequence)
+    builder.setInsertionPointAfter(enumOp);
+  } else if (auto existing = it->second.getDefiningOp<debug::EnumDefOp>()) {
+    if (existing.getVariantsMap() != variantsMap ||
+        existing.getEnumTypeNameAttr() != typeName)
+      op.emitWarning("duplicate circt_debug_enumdef for fqn '")
+          << fqn.getValue()
+          << "' with differing variants or typeName; first definition wins";
+  }
+  return success();
+}
+
+/// Process one `circt_debug_subfield` intrinsic: validate parent/name
+/// invariant and append a leaf descriptor to the side-channel list.
+LogicalResult processSubfieldIntrinsic(GenericIntrinsicOp op,
+                                       DebugLeafList &entries) {
+  GenericIntrinsic gi{op};
+  auto nameAttr = gi.getParamValue<StringAttr>("name");
+  if (!nameAttr)
+    return op.emitError(
+        "circt_debug_subfield: missing required parameter 'name'");
+
+  auto parentAttr = gi.getParamValue<StringAttr>("parent");
+  if (!parentAttr)
+    return op.emitError(
+        "circt_debug_subfield: missing required parameter 'parent' "
+        "(must equal the 'name' of the enclosing circt_debug_var)");
+
+  // `name` must be a path rooted at `parent` -- catches frontend regressions
+  // that drop or mangle the root prefix.
+  auto name = nameAttr.getValue();
+  auto parent = parentAttr.getValue();
+  if (name.empty())
+    return op.emitError("circt_debug_subfield: 'name' must not be empty");
+  if (parent.empty())
+    return op.emitError("circt_debug_subfield: 'parent' must not be empty");
+  if (!name.starts_with(parent))
+    return op.emitError("circt_debug_subfield: 'name' (")
+           << name << ") is not rooted at 'parent' (" << parent
+           << "); expected '" << parent << ".<field>' or '" << parent
+           << "[<idx>]...'";
+
+  auto rest = name.drop_front(parent.size());
+  if (rest.empty() || (rest[0] != '.' && rest[0] != '['))
+    return op.emitError("circt_debug_subfield: 'name' (")
+           << name << ") is not rooted at 'parent' (" << parent
+           << "); expected '" << parent << ".<field>' or '" << parent
+           << "[<idx>]...'";
+
+  auto *ctx = op.getContext();
+  SmallVector<NamedAttribute> fields{};
+  fields.push_back({StringAttr::get(ctx, "name"), nameAttr});
+  fields.push_back({StringAttr::get(ctx, "parent"), parentAttr});
+  if (auto tn = gi.getParamValue<StringAttr>("typeName"))
+    fields.push_back({StringAttr::get(ctx, "typeName"), tn});
+  if (auto fqn = gi.getParamValue<StringAttr>("enumFqn");
+      fqn && !fqn.getValue().empty())
+    fields.push_back({StringAttr::get(ctx, "enumFqn"), fqn});
+  if (auto paramsStr = gi.getParamValue<StringAttr>("params"))
+    if (auto params = parseParamsJSON(ctx, paramsStr, op))
+      fields.push_back({StringAttr::get(ctx, "params"), params});
+  // TODO(enumTypeName): accepted but not forwarded -- no consumer reads it
+  // yet. Distinct from `typeName` (struct-level) and `enumFqn` (enumdef ref).
+
+  entries.push_back(DictionaryAttr::get(ctx, fields));
+  return success();
+}
+
+} // namespace
+
+namespace circt::firrtl {
+
+LogicalResult
+liftDebugIntrinsics(FModuleOp mod, OpBuilder &builder, DebugLeafList &outLeaves,
+                    llvm::StringMap<mlir::Value> &outEnumDefByFqn) {
+  // Set insertion point once at the start of the module body.
+  // Guard restores the caller's insertion point
+  // when liftDebugIntrinsics returns
+  OpBuilder::InsertionGuard guard{builder};
+  builder.setInsertionPointToStart(mod.getBodyBlock());
+
+  // Collect first, then process
+  SmallVector<GenericIntrinsicOp> intrinsics{};
+  mod.walk([&](GenericIntrinsicOp op) {
+    auto kind = op.getIntrinsic();
+    if (kind == "circt_debug_enumdef" || kind == "circt_debug_subfield")
+      intrinsics.push_back(op);
+  });
+
+  bool hadError = false;
+  SmallVector<GenericIntrinsicOp> toErase{};
+  for (auto op : intrinsics) {
+    auto kind = op.getIntrinsic();
+    if (kind == "circt_debug_enumdef") {
+      toErase.push_back(op);
+      if (failed(processEnumDefIntrinsic(op, mod, builder, outEnumDefByFqn)))
+        hadError = true;
+    } else if (kind == "circt_debug_subfield") {
+      toErase.push_back(op);
+      if (failed(processSubfieldIntrinsic(op, outLeaves)))
+        hadError = true;
+    }
+  }
+
+  for (auto op : toErase)
+    op.erase();
+
+  if (hadError) {
+    outLeaves.clear();
+    outEnumDefByFqn.clear();
+    return failure();
+  }
+
+  return success();
+}
+
+} // namespace circt::firrtl

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/Debug/DebugOps.h"
 #include "circt/Dialect/FIRRTL/CHIRRTLVisitors.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
@@ -58,6 +59,12 @@ struct LowerCHIRRTLPass
   // Chain the CHIRRTL visitor to the FIRRTL visitor.
   void visitInvalidCHIRRTL(Operation *op) { dispatchVisitor(op); }
   void visitUnhandledCHIRRTL(Operation *op) { visitUnhandledOp(op); }
+  // Route Debug-dialect ops through the rdata remapper; all other non-FIRRTL
+  // ops are left untouched.
+  void visitInvalidOp(Operation *op) {
+    if (isa_and_nonnull<debug::DebugDialect>(op->getDialect()))
+      visitUnhandledOp(op);
+  }
 
   /// Get a the constant 0.  This constant is inserted at the beginning of the
   /// module.

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/Debug/DebugDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLIntrinsics.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/Pass/Pass.h"
@@ -39,20 +40,44 @@ struct LowerIntrinsicsPass
 };
 } // namespace
 
-/// Initialize the conversions for use during execution.
+/// Build the immutable converter set once, shared across module invocations.
 LogicalResult LowerIntrinsicsPass::initialize(MLIRContext *context) {
-  IntrinsicLowerings lowering(context);
-
-  IntrinsicLoweringInterfaceCollection loweringCollection(context);
-  loweringCollection.populateIntrinsicLowerings(lowering);
-
-  this->lowering = std::make_shared<IntrinsicLowerings>(std::move(lowering));
+  // `IntrinsicLowerings` holds only the converter registry -- no mutable
+  // per-invocation state. Per-module staging data is passed through
+  // `lower(mod, allowUnknown, ctx)` on each `runOnOperation` invocation,
+  // making this safe to share across parallel module passes.
+  this->lowering = std::make_shared<IntrinsicLowerings>(context);
+  IntrinsicLoweringInterfaceCollection collection(context);
+  collection.populateIntrinsicLowerings(*this->lowering);
   return success();
 }
 
 // This is the main entrypoint for the lowering pass.
 void LowerIntrinsicsPass::runOnOperation() {
-  auto result = lowering->lower(getOperation());
+  auto mod = getOperation();
+
+  // Phase 1: stage debug-intrinsic data. `dbg.enumdef` ops are written into
+  // the IR (they have semantics downstream); `circt_debug_subfield` leaves
+  // are gathered into a stack-local side-channel list that is passed to
+  // `lower()` via `IntrinsicConvertContext`. Keeping the staging data on
+  // this function's stack -- never on the shared `lowering` object -- is what
+  // makes the pass safe to run concurrently across modules.
+  // (firrtl.module is a Graph region; block-start insertion is cosmetic.)
+  OpBuilder builder = OpBuilder::atBlockBegin(mod.getBodyBlock());
+  firrtl::DebugLeafList debugLeaves;
+  llvm::StringMap<mlir::Value> enumDefByFqn;
+  if (mlir::failed(
+          firrtl::liftDebugIntrinsics(mod, builder, debugLeaves, enumDefByFqn)))
+    return signalPassFailure();
+
+  // Phase 2: run intrinsic lowerings with a stack-local context.
+  // `seenVarNames` accumulates names of dbg.variable ops as they are emitted;
+  // CirctDebugVarConverter uses it for O(1) duplicate detection instead of
+  // walking the growing IR on every invocation.
+  llvm::StringSet<> seenVarNames;
+  firrtl::IntrinsicConvertContext convCtx{&debugLeaves, &enumDefByFqn,
+                                          &seenVarNames};
+  auto result = lowering->lower(mod, /*allowUnknownIntrinsics=*/false, convCtx);
   if (failed(result))
     return signalPassFailure();
 

--- a/lib/Dialect/FIRRTL/Transforms/MaterializeDebugInfo.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MaterializeDebugInfo.cpp
@@ -5,8 +5,16 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// This pass must run BEFORE `firrtl-lower-intrinsics`. The skip-set built
+// from `circt_debug_var`-intrinsics keeps us from duplicating debug variables
+// that the intrinsic lowering will materialize. If the intrinsics have already
+// been lowered, this pass detects the presence of `dbg.variable` ops and
+// bails out per-module to avoid creating duplicates.
+//
 
 #include "circt/Dialect/Debug/DebugOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLIntrinsics.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
@@ -14,6 +22,7 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace circt {
 namespace firrtl {
@@ -38,20 +47,58 @@ struct MaterializeDebugInfoPass
 
 void MaterializeDebugInfoPass::runOnOperation() {
   auto module = getOperation();
-  auto builder = OpBuilder::atBlockBegin(module.getBodyBlock());
 
-  // Create DI variables for each port.
-  for (const auto &[port, value] :
-       llvm::zip(module.getPorts(), module.getArguments())) {
-    materializeVariable(builder, port.name, value);
+  // 1-operand vars are keyed by SSA Value (no cross-scope name collisions);
+  // 0-operand (memory) vars are keyed by name. `seenNames` spans both arities
+  // for duplicate-name warnings.
+  bool hasExistingVariables = false;
+  DenseSet<Value> coveredByIntrinsic;
+  DenseSet<StringAttr> coveredNameByIntrinsic;
+  DenseSet<StringAttr> seenNames;
+  module.walk([&](Operation *op) -> WalkResult {
+    if (isa<debug::VariableOp>(op)) {
+      hasExistingVariables = true;
+      return WalkResult::interrupt();
+    }
+    auto gi = dyn_cast<firrtl::GenericIntrinsicOp>(op);
+    if (!gi || gi.getIntrinsic() != "circt_debug_var")
+      return WalkResult::advance();
+    auto varName = GenericIntrinsic(gi).getParamValue<StringAttr>("name");
+    if (!varName || varName.getValue().empty())
+      return WalkResult::advance();
+    if (!seenNames.insert(varName).second)
+      gi.emitWarning() << "duplicate circt_debug_var '" << varName.getValue()
+                       << "' ignored by MaterializeDebugInfo";
+    if (gi.getNumOperands() == 1)
+      coveredByIntrinsic.insert(gi.getOperand(0));
+    else if (gi.getNumOperands() == 0)
+      coveredNameByIntrinsic.insert(varName);
+    return WalkResult::advance();
+  });
+  if (hasExistingVariables) {
+    module.emitWarning()
+        << "MaterializeDebugInfo: dbg.variable ops already present "
+           "(LowerIntrinsics likely ran first); skipping to avoid duplicates";
+    return;
   }
 
-  // Create DI variables for each declaration in the module body.
+  auto builder = OpBuilder::atBlockBegin(module.getBodyBlock());
+
+  for (const auto &[port, value] :
+       llvm::zip(module.getPorts(), module.getArguments())) {
+    if (!coveredByIntrinsic.contains(value) &&
+        !coveredNameByIntrinsic.contains(port.name))
+      materializeVariable(builder, port.name, value);
+  }
+
   module.walk([&](Operation *op) {
     TypeSwitch<Operation *>(op).Case<WireOp, NodeOp, RegOp, RegResetOp>(
         [&](auto op) {
-          builder.setInsertionPointAfter(op);
-          materializeVariable(builder, op.getNameAttr(), op.getResult());
+          if (!coveredByIntrinsic.contains(op.getResult()) &&
+              !coveredNameByIntrinsic.contains(op.getNameAttr())) {
+            builder.setInsertionPointAfter(op);
+            materializeVariable(builder, op.getNameAttr(), op.getResult());
+          }
         });
   });
 }

--- a/lib/Target/DebugInfo/DumpDebugInfo.cpp
+++ b/lib/Target/DebugInfo/DumpDebugInfo.cpp
@@ -32,6 +32,13 @@ static void dump(DIVariable &variable, raw_indented_ostream &os) {
     os << " of type " << variable.value.getType() << " at "
        << variable.value.getLoc() << "\n";
   }
+  if (variable.enumDefRef.has_value())
+    os << "enumDefRef = " << *variable.enumDefRef << "\n";
+  if (variable.sourceLangType.typeName)
+    os << "sourceLangType.typeName = " << variable.sourceLangType.typeName
+       << "\n";
+  if (variable.sourceLangType.params)
+    os << "sourceLangType.params = " << variable.sourceLangType.params << "\n";
   os.unindent();
 }
 
@@ -53,6 +60,18 @@ static void dump(DIModule &module, raw_indented_ostream &os) {
     os << " for " << module.op->getName() << " at " << module.op->getLoc();
   os << "\n";
   os.indent();
+  if (module.sourceLangType.typeName)
+    os << "sourceLangType.typeName = " << module.sourceLangType.typeName
+       << "\n";
+  if (module.sourceLangType.params)
+    os << "sourceLangType.params = " << module.sourceLangType.params << "\n";
+  for (auto &[id, variants] : module.enumDefinitions) {
+    os << "EnumDef #" << id << " (";
+    llvm::interleaveComma(variants, os, [&](const auto &kv) {
+      os << kv.second << "=" << kv.first;
+    });
+    os << ")\n";
+  }
   for (auto *variable : module.variables)
     dump(*variable, os);
   for (auto *instance : module.instances)

--- a/test/Analysis/debug-info-aggregate-enum.mlir
+++ b/test/Analysis/debug-info-aggregate-enum.mlir
@@ -1,0 +1,57 @@
+// RUN: circt-translate --dump-di --verify-diagnostics %s | FileCheck %s
+
+// For aggregates, per-leaf enum info lives on the inner `dbg.subfield` ops;
+// the DI analysis must not collapse them into the root `DIVariable::enumDef`
+// slot (that would be lossy). Consumers that need the full mapping walk
+// `DIVariable::value` themselves. `--verify-diagnostics` flags any stray
+// warning from the analysis.
+
+// CHECK-LABEL: Module "MixedLeafEnums" for hw.module
+// CHECK:         EnumDef #0 ("Idle"=0, "Run"=1)
+// CHECK:         EnumDef #1 ("Read"=0, "Write"=1)
+// CHECK:         Variable "io"
+// CHECK-NOT:     enumDefRef
+hw.module @MixedLeafEnums(in %state: i2, in %mode: i3, in %data: i8) {
+  %stateEnum = dbg.enumdef "State", fqn "pkg.State$", {Idle = 0 : i64, Run = 1 : i64}
+  %modeEnum  = dbg.enumdef "Mode",  fqn "pkg.Mode$",  {Read = 0 : i64, Write = 1 : i64}
+
+  // Two leaves with *different* enumDefs and one plain leaf.
+  %s = dbg.subfield "io.state", %state enumDef %stateEnum : i2
+  %m = dbg.subfield "io.mode",  %mode  enumDef %modeEnum  : i3
+  %d = dbg.subfield "io.data",  %data                     : i8
+
+  %agg = dbg.struct {"state": %s, "mode": %m, "data": %d} : !dbg.subfield, !dbg.subfield, !dbg.subfield
+
+  // Root dbg.variable has no enumDef; previously this path triggered a
+  // graph walk that warned "enum info for non-first leaves will be lost".
+  // Now it's silent; --verify-diagnostics would catch any stray warning.
+  // enumDefRef must be absent for an aggregate variable.
+  dbg.variable "io", %agg : !dbg.struct<!dbg.subfield, !dbg.subfield, !dbg.subfield>
+}
+
+// Scalar variable with an enumDef: DIVariable::enumDefRef must be set.
+// CHECK-LABEL: Module "ScalarEnum" for hw.module
+// CHECK:         EnumDef #0 ("Idle"=0, "Run"=1)
+// CHECK:         Variable "state"
+// CHECK:           enumDefRef = 0
+hw.module @ScalarEnum(in %state: i2) {
+  %e = dbg.enumdef "State", fqn "pkg.State$", {Idle = 0 : i64, Run = 1 : i64}
+  dbg.variable "state", %state enumDef %e : i2
+}
+
+// Two distinct dbg.enumdef ops with identical (name, fqn, variants) must
+// share one id after deduplication: only one EnumDef entry, both variables
+// reference id 0.
+// CHECK-LABEL: Module "DedupEnum" for hw.module
+// CHECK:         EnumDef #0
+// CHECK-NOT:     EnumDef #1
+// CHECK:         Variable "va"
+// CHECK:           enumDefRef = 0
+// CHECK:         Variable "vb"
+// CHECK:           enumDefRef = 0
+hw.module @DedupEnum(in %a: i2, in %b: i2) {
+  %e1 = dbg.enumdef "State", fqn "pkg.State$", {Idle = 0 : i64, Run = 1 : i64}
+  %e2 = dbg.enumdef "State", fqn "pkg.State$", {Idle = 0 : i64, Run = 1 : i64}
+  dbg.variable "va", %a enumDef %e1 : i2
+  dbg.variable "vb", %b enumDef %e2 : i2
+}

--- a/test/Dialect/Debug/enumdef-canonicalize.mlir
+++ b/test/Dialect/Debug/enumdef-canonicalize.mlir
@@ -1,0 +1,100 @@
+// RUN: circt-opt --canonicalize %s | FileCheck %s
+
+module {
+  func.func @Test() {
+    // CHECK: %[[E:.+]] = dbg.enumdef "S", fqn "p.S", {A = 0 : i64}
+    // CHECK-NOT: = dbg.enumdef "S", fqn "p.S", {A = 0 : i64}
+    %e0 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64}
+    %e1 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64}
+
+    %0 = arith.constant 0 : i2
+    // CHECK: dbg.variable "x", {{.*}} enumDef %[[E]]
+    // CHECK: dbg.variable "y", {{.*}} enumDef %[[E]]
+    dbg.variable "x", %0 enumDef %e0 : i2
+    dbg.variable "y", %0 enumDef %e1 : i2
+    return
+  }
+
+  // CHECK-LABEL: func @TestDivergingVariants
+  // Test that enumdefs with same fqn but different variants are NOT deduplicated
+  // Both should remain since they have different semantics
+  func.func @TestDivergingVariants() {
+    // CHECK: %[[E0:.+]] = dbg.enumdef "S", fqn "p.S", {A = 0 : i64}
+    // CHECK: %[[E1:.+]] = dbg.enumdef "S", fqn "p.S", {A = 0 : i64, B = 1 : i64}
+    // both enumdefs should remain (different variants)
+    %e0 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64}
+    %e1 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64, B = 1 : i64}
+
+    %0 = arith.constant 0 : i2
+    // CHECK: dbg.variable "x", {{.*}} enumDef %[[E0]]
+    // CHECK: dbg.variable "y", {{.*}} enumDef %[[E1]]
+    dbg.variable "x", %0 enumDef %e0 : i2
+    dbg.variable "y", %0 enumDef %e1 : i2
+    return
+  }
+
+  // Scope-sensitive dedup: two enumdefs describing the same source-level enum
+  // type but living in different inline scopes must NOT be merged, because
+  // their SSA tokens are consumed by variables that belong to those distinct
+  // scopes. See the EnumDefDeduplication rationale.
+  //
+  // CHECK-LABEL: func @TestScopeDistinct
+  func.func @TestScopeDistinct() {
+    // CHECK: %[[S1:.+]] = dbg.scope "a", "A"
+    // CHECK: %[[S2:.+]] = dbg.scope "b", "B"
+    %s1 = dbg.scope "a", "A"
+    %s2 = dbg.scope "b", "B"
+    // CHECK: %[[E0:.+]] = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %[[S1]]
+    // CHECK: %[[E1:.+]] = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %[[S2]]
+    %e0 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %s1
+    %e1 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %s2
+
+    %0 = arith.constant 0 : i2
+    // CHECK: dbg.variable "x", {{.*}} enumDef %[[E0]]
+    // CHECK: dbg.variable "y", {{.*}} enumDef %[[E1]]
+    dbg.variable "x", %0 enumDef %e0 : i2
+    dbg.variable "y", %0 enumDef %e1 : i2
+    return
+  }
+
+  // Within a single shared scope, two enumdefs with identical (fqn, variants)
+  // SHOULD still deduplicate.
+  //
+  // CHECK-LABEL: func @TestScopeSameDedups
+  func.func @TestScopeSameDedups() {
+    // CHECK: %[[S:.+]] = dbg.scope "a", "A"
+    %s = dbg.scope "a", "A"
+    // CHECK: %[[E:.+]] = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %[[S]]
+    // CHECK-NOT: = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope
+    %e0 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %s
+    %e1 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %s
+
+    %0 = arith.constant 0 : i2
+    // CHECK: dbg.variable "x", {{.*}} enumDef %[[E]]
+    // CHECK: dbg.variable "y", {{.*}} enumDef %[[E]]
+    dbg.variable "x", %0 enumDef %e0 : i2
+    dbg.variable "y", %0 enumDef %e1 : i2
+    return
+  }
+
+  // Mixed: one enumdef at module-scope (scope=null), one under a dbg.scope;
+  // both must remain because a null scope is distinct from any non-null scope.
+  //
+  // CHECK-LABEL: func @TestScopeNullVsNonNull
+  func.func @TestScopeNullVsNonNull() {
+    // CHECK: %[[S:.+]] = dbg.scope "a", "A"
+    %s = dbg.scope "a", "A"
+    // CHECK: %[[E0:.+]] = dbg.enumdef "S", fqn "p.S", {A = 0 : i64}
+    // CHECK-NOT: scope %{{.*}}
+    // CHECK: %[[E1:.+]] = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %[[S]]
+    %e0 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64}
+    %e1 = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %s
+
+    %0 = arith.constant 0 : i2
+    // CHECK: dbg.variable "x", {{.*}} enumDef %[[E0]]
+    // CHECK: dbg.variable "y", {{.*}} enumDef %[[E1]]
+    dbg.variable "x", %0 enumDef %e0 : i2
+    dbg.variable "y", %0 enumDef %e1 : i2
+    return
+  }
+}

--- a/test/Dialect/Debug/enumdef-ssa-roundtrip.mlir
+++ b/test/Dialect/Debug/enumdef-ssa-roundtrip.mlir
@@ -1,0 +1,13 @@
+// RUN: circt-opt --verify-roundtrip %s | FileCheck %s
+
+module {
+  func.func @Test() {
+    // CHECK: %[[E:.+]] = dbg.enumdef "MyState", fqn "pkg.MyState", {A = 0 : i64, B = 1 : i64}
+    %e = dbg.enumdef "MyState", fqn "pkg.MyState", {A = 0 : i64, B = 1 : i64}
+
+    %0 = arith.constant 0 : i2
+    // CHECK: dbg.variable "state", {{.+}} enumDef %[[E]] : i2
+    dbg.variable "state", %0 enumDef %e : i2
+    return
+  }
+}

--- a/test/Dialect/Debug/enumdef-verify-errors.mlir
+++ b/test/Dialect/Debug/enumdef-verify-errors.mlir
@@ -1,0 +1,62 @@
+// RUN: circt-opt %s --verify-diagnostics --split-input-file
+
+// -----
+// dbg.enumdef with a non-IntegerAttr variant value.
+
+func.func @EnumDefNonIntegerAttr() {
+  // expected-error @+1 {{variantsMap entry 'A' must be an IntegerAttr}}
+  %e = dbg.enumdef "MyState", fqn "pkg.MyState$", {A = "not-an-int"}
+  return
+}
+
+// -----
+// dbg.enumdef with duplicate variant values.
+
+func.func @EnumDefDuplicateValues() {
+  // expected-error @+1 {{duplicate enum value 0}}
+  %e = dbg.enumdef "MyState", fqn "pkg.MyState$", {A = 0 : i64, B = 0 : i64}
+  return
+}
+
+// -----
+// dbg.subfield used by a non-struct/array op triggers verifier error.
+
+func.func @SubFieldBadUser() {
+  %c = arith.constant 0 : i32
+  // expected-error @+1 {{must only be used as an operand of dbg.struct or dbg.array}}
+  %sf = dbg.subfield "x", %c : i32
+  dbg.variable "y", %sf : !dbg.subfield
+  return
+}
+
+// -----
+// dbg.moduleinfo uniqueness: two in the same region must be rejected.
+
+func.func @ModuleInfoDuplicate() {
+  dbg.moduleinfo typeName "MyMod"
+  // expected-error @+1 {{only one dbg.moduleinfo may appear in a region}}
+  dbg.moduleinfo typeName "MyMod"
+  return
+}
+
+// -----
+// dbg.moduleinfo uniqueness must hold across blocks of the same region, not
+// just within a single block.
+
+func.func @ModuleInfoDuplicateAcrossBlocks() {
+  dbg.moduleinfo typeName "MyMod"
+  cf.br ^bb1
+^bb1:
+  // expected-error @+1 {{only one dbg.moduleinfo may appear in a region}}
+  dbg.moduleinfo typeName "MyMod"
+  return
+}
+
+// -----
+// dbg.enumdef with an empty variantsMap is semantically useless and rejected.
+
+func.func @EnumDefEmptyVariants() {
+  // expected-error @+1 {{variantsMap must not be empty}}
+  %e = dbg.enumdef "Empty", fqn "pkg.Empty", {}
+  return
+}

--- a/test/Dialect/Debug/ops.mlir
+++ b/test/Dialect/Debug/ops.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-opt %s --verify-roundtrip | FileCheck %s
+//
+// Parser/printer round-trip for ops introduced alongside source-language
+// type tracking: dbg.moduleinfo, dbg.enumdef, and dbg.variable's enumDef
+// operand. Aggregate/scope shapes are covered in basic.mlir.
+
+// CHECK-LABEL: func.func @ModuleInfoPlain
+func.func @ModuleInfoPlain() {
+  // CHECK: dbg.moduleinfo typeName "MyMod"
+  dbg.moduleinfo typeName "MyMod"
+  return
+}
+
+// CHECK-LABEL: func.func @ModuleInfoWithParams
+func.func @ModuleInfoWithParams() {
+  // CHECK: dbg.moduleinfo typeName "MyClass" params [{name = "arg0", value = "42"}]
+  dbg.moduleinfo typeName "MyClass" params [{name = "arg0", value = "42"}]
+  return
+}
+
+// CHECK-LABEL: func.func @EnumDefAndVariable
+func.func @EnumDefAndVariable() {
+  // CHECK: %[[E:.+]] = dbg.enumdef "MyState", fqn "pkg.MyState$", {Idle = 0 : i64, Run = 1 : i64}
+  %e = dbg.enumdef "MyState", fqn "pkg.MyState$", {Idle = 0 : i64, Run = 1 : i64}
+  %c = arith.constant 0 : i2
+  // CHECK: dbg.variable "state", %{{.*}} typeName "MyState" enumDef %[[E]] : i2
+  dbg.variable "state", %c typeName "MyState" enumDef %e : i2
+  return
+}
+
+// CHECK-LABEL: func.func @EnumDefWithScope
+func.func @EnumDefWithScope() {
+  // CHECK: %[[S:.+]] = dbg.scope "inner", "InnerMod"
+  %scope = dbg.scope "inner", "InnerMod"
+  // CHECK: dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %[[S]]
+  %e = dbg.enumdef "S", fqn "p.S", {A = 0 : i64} scope %scope
+  return
+}

--- a/test/Dialect/Debug/subfield-enumdef-ssa.mlir
+++ b/test/Dialect/Debug/subfield-enumdef-ssa.mlir
@@ -1,0 +1,15 @@
+// RUN: circt-opt --verify-roundtrip %s | FileCheck %s
+
+module {
+  func.func @Test() {
+    %e = dbg.enumdef "FieldEnum", fqn "pkg.FieldEnum", {VALUE = 42 : i64}
+    %0 = arith.constant 0 : i32
+
+    // CHECK: %[[SF:.+]] = dbg.subfield "field", %{{.*}} enumDef %{{.*}} : i32
+    %f = dbg.subfield "field", %0 enumDef %e : i32
+
+    // Use in a struct so SubFieldOp is not treated as dead code.
+    %s = dbg.struct {"field": %f} : !dbg.subfield
+    return
+  }
+}

--- a/test/Dialect/FIRRTL/debug-pipeline.mlir
+++ b/test/Dialect/FIRRTL/debug-pipeline.mlir
@@ -1,0 +1,158 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-materialize-debug-info,firrtl-lower-intrinsics)))' %s | FileCheck %s
+
+// Integration check: when MaterializeDebugInfo runs BEFORE LowerIntrinsics
+// (the order firtool pins in lib/Firtool/Firtool.cpp), names covered by a
+// `circt_debug_var` intrinsic must end up with a single rich `dbg.variable`
+// from LowerIntrinsics -- not a duplicate basic one from MaterializeDebugInfo.
+
+// CHECK-LABEL: firrtl.module @PipelineDedup
+firrtl.circuit "PipelineDedup" {
+  firrtl.module @PipelineDedup() {
+    %w = firrtl.wire : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "w", typeName: none = "UInt">
+      %w : (!firrtl.uint<8>) -> ()
+
+    %u = firrtl.wire : !firrtl.uint<4>
+
+    // The rich variable for `w` (with typeName) is the only `dbg.variable "w"`.
+    // CHECK:     dbg.variable "w", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK-NOT: dbg.variable "w"
+    //
+    // The wire `u` has no intrinsic, so MaterializeDebugInfo emits a basic
+    // `dbg.variable "u"` (no typeName, ground type passes through).
+    // CHECK:     dbg.variable "u", %{{.*}} : !firrtl.uint<4>
+    // CHECK-NOT: dbg.variable "u"
+  }
+}
+
+// Port covered by circt_debug_var: MaterializeDebugInfo must NOT emit a basic
+// dbg.variable for the port; only LowerIntrinsics emits the rich one.
+//
+// CHECK-LABEL: firrtl.module @PipelinePortCovered
+firrtl.circuit "PipelinePortCovered" {
+  firrtl.module @PipelinePortCovered(in %clk: !firrtl.clock,
+                                     in %data: !firrtl.uint<16>) {
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "data", typeName: none = "UInt">
+      %data : (!firrtl.uint<16>) -> ()
+
+    // MaterializeDebugInfo runs first and emits ports in declaration order,
+    // skipping `data` (covered by the intrinsic). LowerIntrinsics then emits
+    // the rich `dbg.variable "data"` at the intrinsic site.
+    // CHECK:     dbg.variable "clk", %{{.*}} : !firrtl.clock
+    // CHECK-NOT: dbg.variable "clk"
+    // CHECK:     dbg.variable "data", %{{.*}} typeName "UInt" : !firrtl.uint<16>
+    // CHECK-NOT: dbg.variable "data"
+  }
+}
+
+// Two distinct SSA values with the same name in different scopes: the
+// Value-based skip-set must not conflate them. Here only `w1` is covered by
+// an intrinsic; `w2` (a different SSA value, same name conceptually but a
+// separate wire) must still get a materialized dbg.variable.
+//
+// Note: firrtl.when with nested wire declarations is not supported in this IR
+// form -- both arms share the same basic-block scope so a wire declared in one
+// arm is visible in the other, making true name-shadowing impossible at this
+// IR level. Instead we use two separate wires with distinct SSA values to
+// verify that the DenseSet<Value> key (not a name key) correctly discriminates
+// them. True shadowed-name coverage would require a when-aware IR pass that
+// is out of scope here.
+//
+// CHECK-LABEL: firrtl.module @PipelineScopeDistinct
+firrtl.circuit "PipelineScopeDistinct" {
+  firrtl.module @PipelineScopeDistinct() {
+    %w1 = firrtl.wire : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "w1", typeName: none = "UInt">
+      %w1 : (!firrtl.uint<8>) -> ()
+
+    // w2 is a *different* SSA value from w1 (even if logically same-named).
+    // The Value-based skip-set only covers w1; w2 must be materialized.
+    %w2 = firrtl.wire : !firrtl.uint<8>
+
+    // LowerIntrinsics emits the rich `dbg.variable "w1"` at the intrinsic site
+    // (between the two wires). MaterializeDebugInfo emits the basic `w2` after
+    // its wire. The Value-keyed skip-set must not conflate the two SSA values.
+    // CHECK:     dbg.variable "w1", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK-NOT: dbg.variable "w1"
+    // CHECK:     dbg.variable "w2", %{{.*}} : !firrtl.uint<8>
+    // CHECK-NOT: dbg.variable "w2"
+  }
+}
+
+// 0-operand circt_debug_var (memory / name-only form): MaterializeDebugInfo
+// must skip the wire/port/reg matched by name, deferring to LowerIntrinsics.
+//
+// CHECK-LABEL: firrtl.module @PipelineZeroOperand
+firrtl.circuit "PipelineZeroOperand" {
+  firrtl.module @PipelineZeroOperand(in %clk: !firrtl.clock,
+                                     in %data: !firrtl.uint<16>) {
+    // 0-operand intrinsic covering a wire by name.
+    %mem = firrtl.wire : !firrtl.uint<32>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "mem", typeName: none = "UInt"> : () -> ()
+
+    // 0-operand intrinsic covering a port by name.
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "data", typeName: none = "UInt"> : () -> ()
+
+    // `clk` has no intrinsic -> MaterializeDebugInfo emits it at block start.
+    // `mem` is name-covered by a 0-operand intrinsic -> MaterializeDebugInfo
+    //   skips it; LowerIntrinsics emits the rich dbg.variable (with typeName)
+    //   at the intrinsic site (after the wire declaration).
+    // `data` is name-covered by a 0-operand intrinsic -> same.
+    // Emission order: clk (materialized at block start), then mem (intrinsic
+    // site after wire), then data (intrinsic site after mem's intrinsic).
+    // CHECK:     dbg.variable "clk", %{{.*}} : !firrtl.clock
+    // CHECK-NOT: dbg.variable "clk"
+    // CHECK:     dbg.variable "mem", %{{.*}} typeName "UInt" : !firrtl.uint<32>
+    // CHECK-NOT: dbg.variable "mem"
+    // CHECK:     dbg.variable "data", %{{.*}} typeName "UInt" : !firrtl.uint<16>
+    // CHECK-NOT: dbg.variable "data"
+  }
+}
+
+// firrtl.reg covered by 1-operand intrinsic: MaterializeDebugInfo must not
+// emit a basic dbg.variable for the reg; only LowerIntrinsics emits the rich
+// one. An uncovered reg must still be materialized.
+//
+// CHECK-LABEL: firrtl.module @PipelineRegCovered
+firrtl.circuit "PipelineRegCovered" {
+  firrtl.module @PipelineRegCovered(in %clk: !firrtl.clock) {
+    %r_covered = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "r_covered", typeName: none = "UInt">
+      %r_covered : (!firrtl.uint<8>) -> ()
+
+    %r_plain = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<4>
+
+    // CHECK:     dbg.variable "clk", %{{.*}} : !firrtl.clock
+    // CHECK:     dbg.variable "r_covered", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK-NOT: dbg.variable "r_covered"
+    // CHECK:     dbg.variable "r_plain", %{{.*}} : !firrtl.uint<4>
+    // CHECK-NOT: dbg.variable "r_plain"
+  }
+}
+
+// firrtl.node covered by 1-operand intrinsic: same dedup logic applies.
+// An uncovered node must still be materialized.
+//
+// CHECK-LABEL: firrtl.module @PipelineNodeCovered
+firrtl.circuit "PipelineNodeCovered" {
+  firrtl.module @PipelineNodeCovered(in %in: !firrtl.uint<8>) {
+    %n_covered = firrtl.node %in : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "n_covered", typeName: none = "UInt">
+      %n_covered : (!firrtl.uint<8>) -> ()
+
+    %n_plain = firrtl.node %in : !firrtl.uint<8>
+
+    // CHECK:     dbg.variable "in", %{{.*}} : !firrtl.uint<8>
+    // CHECK:     dbg.variable "n_covered", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK-NOT: dbg.variable "n_covered"
+    // CHECK:     dbg.variable "n_plain", %{{.*}} : !firrtl.uint<8>
+    // CHECK-NOT: dbg.variable "n_plain"
+  }
+}

--- a/test/Dialect/FIRRTL/lower-chirrtl-debug.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl-debug.mlir
@@ -1,0 +1,76 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-chirrtl)))'  %s | FileCheck %s
+
+// Verify that dbg.* ops whose operands reference chirrtl.memoryport data
+// results survive lower-chirrtl with those operands remapped to the
+// corresponding firrtl.mem subfield results.
+
+// ---- Test 1: dbg.variable referencing a CHIRRTL memoryport data result ----
+
+// CHECK-LABEL: firrtl.module @DebugMemPort
+firrtl.circuit "DebugMemPort" {
+  firrtl.module @DebugMemPort(in %clock: !firrtl.clock,
+                               in %addr: !firrtl.uint<8>,
+                               in %en: !firrtl.uint<1>) {
+    %ram = chirrtl.combmem : !chirrtl.cmemory<uint<8>, 256>
+
+    %rdata, %rport = chirrtl.memoryport Infer %ram {name = "rport"}
+        : (!chirrtl.cmemory<uint<8>, 256>) -> (!firrtl.uint<8>, !chirrtl.cmemoryport)
+    chirrtl.memoryport.access %rport[%addr], %clock
+        : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+
+    // dbg.variable references the chirrtl memoryport data result (%rdata).
+    // After the pass, the operand must be remapped to the firrtl.mem data
+    // subfield -- the variable must still be present.
+    // CHECK: dbg.variable "rdata", %{{.*}} : !firrtl.uint<8>
+    dbg.variable "rdata", %rdata : !firrtl.uint<8>
+  }
+}
+
+// ---- Test 2: dbg.subfield referencing a CHIRRTL memoryport data result ----
+// dbg.subfield (like dbg.variable) consumes an SSA value; its operand must
+// also be remapped when it references a CHIRRTL port data result.
+
+// CHECK-LABEL: firrtl.module @DebugSubfieldMemPort
+firrtl.circuit "DebugSubfieldMemPort" {
+  firrtl.module @DebugSubfieldMemPort(in %clock: !firrtl.clock,
+                                       in %addr: !firrtl.uint<8>) {
+    %ram = chirrtl.combmem : !chirrtl.cmemory<uint<8>, 256>
+
+    %rdata, %rport = chirrtl.memoryport Infer %ram {name = "rport"}
+        : (!chirrtl.cmemory<uint<8>, 256>) -> (!firrtl.uint<8>, !chirrtl.cmemoryport)
+    chirrtl.memoryport.access %rport[%addr], %clock
+        : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+
+    // dbg.subfield references the chirrtl memoryport data result (%rdata).
+    // After the pass, the operand must be remapped; the subfield op must
+    // survive with a valid (non-CHIRRTL) operand.
+    // CHECK: %[[SF:.+]] = dbg.subfield "rdata", %{{.*}} : !firrtl.uint<8>
+    // CHECK: dbg.struct {"rdata": %[[SF]]}
+    %sf = dbg.subfield "rdata", %rdata : !firrtl.uint<8>
+    %st = dbg.struct {"rdata": %sf} : !dbg.subfield
+    dbg.variable "mem", %st : !dbg.struct
+  }
+}
+
+// ---- Test 3: non-Debug dialect op alongside a CHIRRTL memory ----
+// visitInvalidOp must not touch ops from dialects other than Debug.
+// The hw.constant below is from the HW dialect; even though a CHIRRTL memory
+// exists in the same module, visitInvalidOp must leave it completely alone.
+
+// CHECK-LABEL: firrtl.module @NonDebugHwOp
+firrtl.circuit "NonDebugHwOp" {
+  firrtl.module @NonDebugHwOp(in %clock: !firrtl.clock,
+                               in %addr: !firrtl.uint<8>) {
+    %ram = chirrtl.combmem : !chirrtl.cmemory<uint<8>, 256>
+
+    %rdata, %rport = chirrtl.memoryport Infer %ram {name = "rport"}
+        : (!chirrtl.cmemory<uint<8>, 256>) -> (!firrtl.uint<8>, !chirrtl.cmemoryport)
+    chirrtl.memoryport.access %rport[%addr], %clock
+        : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+
+    // hw.constant is dispatched through visitInvalidOp (not FIRRTL, not Debug).
+    // The new branch must skip it; the constant must survive unchanged.
+    // CHECK: hw.constant 42 : i8
+    %c = hw.constant 42 : i8
+  }
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics-debug-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-debug-errors.mlir
@@ -1,0 +1,230 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-intrinsics)))' %s --split-input-file --verify-diagnostics
+
+// Malformed / missing-parameter cases for the Chisel debug intrinsics. The
+// pre-passes must diagnose these explicitly rather than silently dropping the
+// intrinsic and producing incomplete debug metadata.
+
+// -----
+
+// Missing 'fqn' param on circt_debug_enumdef.
+firrtl.circuit "EnumDefMissingFqn" {
+  firrtl.module @EnumDefMissingFqn() {
+    // expected-error @below {{circt_debug_enumdef: missing required parameter}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState",
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Missing 'typeName' param on circt_debug_enumdef.
+firrtl.circuit "EnumDefMissingTypeName" {
+  firrtl.module @EnumDefMissingTypeName() {
+    // expected-error @below {{circt_debug_enumdef: missing required parameter}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Missing 'variants' param on circt_debug_enumdef.
+firrtl.circuit "EnumDefMissingVariants" {
+  firrtl.module @EnumDefMissingVariants() {
+    // expected-error @below {{circt_debug_enumdef: missing required parameter}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$"> : () -> ()
+  }
+}
+
+// -----
+
+// Unparseable JSON in 'variants'.
+firrtl.circuit "EnumDefBadJSON" {
+  firrtl.module @EnumDefBadJSON() {
+    // expected-error @below {{circt_debug_enumdef: failed to parse 'variants'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{not valid json"> : () -> ()
+  }
+}
+
+// -----
+
+// Valid JSON that is not an array in 'variants'. Previously this silently
+// produced a dbg.enumdef with an empty variant map.
+firrtl.circuit "EnumDefVariantsNotArray" {
+  firrtl.module @EnumDefVariantsNotArray() {
+    // expected-error @below {{circt_debug_enumdef: 'variants' is not a JSON array}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "{}"> : () -> ()
+  }
+}
+
+// -----
+
+// Variant with a non-integer string value. Previously this silently produced a
+// variant with value 0.
+firrtl.circuit "EnumDefBadVariantValue" {
+  firrtl.module @EnumDefBadVariantValue() {
+    // expected-error @below {{circt_debug_enumdef: variant 'A' has non-integer value 'notanint'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"notanint\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Variant missing 'name'.
+firrtl.circuit "EnumDefVariantMissingName" {
+  firrtl.module @EnumDefVariantMissingName() {
+    // expected-error @below {{circt_debug_enumdef: variant is missing 'name'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"value\":\"0\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Variant missing 'value'.
+firrtl.circuit "EnumDefVariantMissingValue" {
+  firrtl.module @EnumDefVariantMissingValue() {
+    // expected-error @below {{circt_debug_enumdef: variant 'A' is missing 'value'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Two enumdefs with the same fqn but differing variants; the second must
+// not create a new dbg.enumdef, but the mismatch must be warned about.
+firrtl.circuit "EnumDefConflict" {
+  firrtl.module @EnumDefConflict() {
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"}]"> : () -> ()
+    // expected-warning @below {{duplicate circt_debug_enumdef for fqn 'pkg.MyState$' with differing variants}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"},{\"name\":\"B\",\"value\":\"1\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Missing 'name' on circt_debug_subfield.
+firrtl.circuit "SubfieldMissingName" {
+  firrtl.module @SubfieldMissingName() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: missing required parameter 'name'}}
+    firrtl.int.generic "circt_debug_subfield"
+      <typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Missing 'parent' on circt_debug_subfield; without it the pre-pass cannot
+// link the leaf to its circt_debug_var.
+firrtl.circuit "SubfieldMissingParent" {
+  firrtl.module @SubfieldMissingParent() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: missing required parameter 'parent'}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var whose 'name' matches no wire/port/reg: converter
+// emits a warning and erases the op (see FIRRTLIntrinsics.cpp,
+// CirctDebugVarConverter::convert, the `!rawSignal` branch).
+firrtl.circuit "DebugVarUnresolved" {
+  firrtl.module @DebugVarUnresolved() {
+    // expected-warning @below {{circt_debug_var: no wire, port, or register named 'missing' found}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "missing", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// Two circt_debug_var with the same name="x" in one module; the second must
+// be diagnosed so metadata consumers (hgdb/tywaves) are not silently given a
+// duplicate variable entry. Implementation: walk of existing `dbg.variable`
+// ops at convert time (FIRRTLIntrinsics.cpp CirctDebugVarConverter::convert).
+firrtl.circuit "DebugVarDuplicateName" {
+  firrtl.module @DebugVarDuplicateName(in %x: !firrtl.uint<8>,
+                                       in %y: !firrtl.uint<8>) {
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt">
+      %x : (!firrtl.uint<8>) -> ()
+    // expected-warning @below {{duplicate circt_debug_var with name 'x'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt">
+      %y : (!firrtl.uint<8>) -> ()
+  }
+}
+
+// -----
+
+// 'name' is not rooted at 'parent'; frontend regression check.
+firrtl.circuit "SubfieldNameNotRooted" {
+  firrtl.module @SubfieldNameNotRooted() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'name' (state) is not rooted at 'parent' (io)}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "state", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Empty 'name' on circt_debug_subfield (finding #5).
+firrtl.circuit "SubfieldEmptyName" {
+  firrtl.module @SubfieldEmptyName() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'name' must not be empty}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Empty 'parent' on circt_debug_subfield (finding #5).
+firrtl.circuit "SubfieldEmptyParent" {
+  firrtl.module @SubfieldEmptyParent() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'parent' must not be empty}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt", parent: none = "">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Dangling enumFqn: circt_debug_var references an enumFqn for which no
+// circt_debug_enumdef exists. A warning must be emitted but UHDI lowering
+// continues (finding #4).
+firrtl.circuit "DanglingEnumFqn" {
+  firrtl.module @DanglingEnumFqn(in %s: !firrtl.uint<2>) {
+    // expected-warning @below {{no circt_debug_enumdef found for 'pkg.Missing$'; leaf will be emitted without enum binding}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "UInt", enumFqn: none = "pkg.Missing$">
+      %s : (!firrtl.uint<2>) -> ()
+  }
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics-debug.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-debug.mlir
@@ -1,0 +1,545 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-intrinsics)))' %s --split-input-file | FileCheck %s
+
+// Scalar, bundle, and vec cases for the three Chisel debug intrinsics
+// (circt_debug_moduleinfo, circt_debug_var, circt_debug_subfield) and
+// circt_debug_enumdef.
+
+// CHECK-LABEL: firrtl.module @DebugTest
+firrtl.circuit "DebugTest" {
+  firrtl.module @DebugTest(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+
+    // 1. moduleinfo (empty params array is forwarded as [])
+    // CHECK-DAG: dbg.moduleinfo typeName "MyModule" params []
+    firrtl.int.generic "circt_debug_moduleinfo"
+      <typeName: none = "MyModule", params: none = "[]"> : () -> ()
+
+    // 2. enumdef with JSON array (value serialized as string by frontend)
+    // CHECK-DAG: dbg.enumdef "MyState", fqn "pkg.MyState$", {Idle = 0 : i64, Run = 1 : i64}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"Idle\",\"value\":\"0\"},{\"name\":\"Run\",\"value\":\"1\"}]">
+      : () -> ()
+
+    // 3. circt_debug_var on scalar wire -> dbg.variable with the wire value
+    // CHECK: dbg.variable "w", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    %w = firrtl.wire : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "w", typeName: none = "UInt">
+      %w : (!firrtl.uint<8>) -> ()
+
+    // 4. circt_debug_var on a passive bundle -> dbg.struct + dbg.variable
+    //    The converter builds:
+    //      %a = firrtl.subfield %io[in]
+    //      %b = firrtl.subfield %io[out]
+    //      %s = dbg.struct {"in": %a, "out": %b}
+    //      dbg.variable "io", %s
+    // CHECK:      firrtl.subfield %io[in]
+    // CHECK:      firrtl.subfield %io[out]
+    // CHECK:      dbg.struct
+    // CHECK: dbg.variable "io", %{{.*}} typeName "MyBundle"
+    %io = firrtl.wire : !firrtl.bundle<in: uint<8>, out: uint<8>>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<in: uint<8>, out: uint<8>>) -> ()
+
+    // 5. circt_debug_var on a Vec -> dbg.array + dbg.variable
+    // CHECK:      firrtl.subindex %v[0]
+    // CHECK:      firrtl.subindex %v[1]
+    // CHECK:      dbg.array
+    // CHECK-NEXT: dbg.variable "v", %{{.*}} typeName "Vec"
+    %v = firrtl.wire : !firrtl.vector<uint<4>, 2>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "Vec">
+      %v : (!firrtl.vector<uint<4>, 2>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Bundle with an enum-typed field -- the field must get a dbg.subfield
+// wrapping it with an enumDef reference.
+//
+// Chisel emits:
+//   circt_debug_enumdef for MyState
+//   circt_debug_subfield(parent="io", name="state") for io.state with enumFqn
+//   circt_debug_subfield(parent="io", name="data")  for io.data
+//   circt_debug_var(name="io")                      for io
+
+// CHECK-LABEL: firrtl.module @BundleEnumFieldTest
+firrtl.circuit "BundleEnumFieldTest" {
+  firrtl.module @BundleEnumFieldTest(
+      in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+
+    // enumdef must appear in the output
+    // CHECK: %[[E:.+]] = dbg.enumdef "MyState", fqn "pkg.MyState$", {Idle = 0 : i64, Run = 1 : i64}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"Idle\",\"value\":\"0\"},{\"name\":\"Run\",\"value\":\"1\"}]">
+      : () -> ()
+
+    %io = firrtl.wire : !firrtl.bundle<state: uint<2>, data: uint<8>>
+
+    // Leaf io.state with enumFqn -- captured into leafMetaMap, erased
+    // CHECK-NOT: circt_debug_subfield
+    // CHECK-NOT: dbg.variable "state"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.state", typeName: none = "UInt", parent: none = "io",
+       enumTypeName: none = "MyState", enumFqn: none = "pkg.MyState$">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    // Leaf io.data without enum
+    // CHECK-NOT: dbg.variable "data"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.data", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    // Root circt_debug_var -- produces dbg.struct + dbg.variable
+    // CHECK:      firrtl.subfield %{{.*}}[state]
+    // CHECK:      dbg.subfield "io.state", %{{.*}} typeName "UInt" enumDef %[[E]] : !firrtl.uint<2>
+    // CHECK:      firrtl.subfield %{{.*}}[data]
+    // CHECK:      dbg.subfield "io.data", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io", %{{.*}} typeName "MyBundle"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Bundle with a FixedPoint field carrying type parameters.
+// Verifies that the "params" JSON string is parsed and forwarded to
+// dbg.subfield as an ArrayAttr of DictionaryAttrs.
+
+// CHECK-LABEL: firrtl.module @BundleParamsFieldTest
+firrtl.circuit "BundleParamsFieldTest" {
+  firrtl.module @BundleParamsFieldTest(
+      in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+
+    %io = firrtl.wire : !firrtl.bundle<fp: uint<8>, data: uint<8>>
+
+    // Leaf io.fp with params
+    // CHECK-NOT: dbg.variable "fp"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.fp", typeName: none = "FixedPoint", parent: none = "io",
+       params: none = "[{\"name\":\"width\",\"value\":\"8\"},{\"name\":\"binaryPoint\",\"value\":\"4\"}]">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    // Leaf io.data without params
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.data", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    // Root circt_debug_var -- produces dbg.struct + dbg.variable
+    // CHECK:      firrtl.subfield %{{.*}}[fp]
+    // CHECK:      dbg.subfield "io.fp", %{{.*}} typeName "FixedPoint" params [{name = "width", value = "8"}, {name = "binaryPoint", value = "4"}] : !firrtl.uint<8>
+    // CHECK:      firrtl.subfield %{{.*}}[data]
+    // CHECK:      dbg.subfield "io.data", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io", %{{.*}} typeName "MyBundle"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// moduleinfo with constructor params
+
+// CHECK-LABEL: firrtl.module @ModuleInfoWithParams
+firrtl.circuit "ModuleInfoWithParams" {
+  firrtl.module @ModuleInfoWithParams() {
+    // CHECK: dbg.moduleinfo typeName "Counter" params [{name = "width", value = "8"}]
+    firrtl.int.generic "circt_debug_moduleinfo"
+      <typeName: none = "Counter",
+       params: none = "[{\"name\":\"width\",\"value\":\"8\"}]">
+      : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var: the frontend emits no SSA operand when the
+// referenced value is a non-passive aggregate (e.g. a bidirectional bundle
+// port) whose SSA form is not directly assignable to a dbg.variable. The
+// converter must locate the matching port / wire / node / reg by name.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarPort
+firrtl.circuit "ZeroOperandVarPort" {
+  firrtl.module @ZeroOperandVarPort(
+      in %a: !firrtl.uint<8>,
+      out %b: !firrtl.uint<8>) {
+    // Match by port name; resolves to the block argument %a.
+    // CHECK: dbg.variable "a", %a typeName "UInt" : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "a", typeName: none = "UInt"> : () -> ()
+
+    firrtl.connect %b, %a : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a wire.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarWire
+firrtl.circuit "ZeroOperandVarWire" {
+  firrtl.module @ZeroOperandVarWire() {
+    // CHECK: %mywire = firrtl.wire
+    %mywire = firrtl.wire : !firrtl.uint<8>
+    // CHECK: dbg.variable "mywire", %mywire typeName "UInt" : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "mywire", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var with no matching port/wire/reg is silently erased
+// (a warning is emitted by the converter; the warning case is asserted by
+// `DebugVarUnresolved` in lower-intrinsics-debug-errors.mlir). Here we just
+// confirm no `dbg.variable` is produced.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarNoMatch
+firrtl.circuit "ZeroOperandVarNoMatch" {
+  firrtl.module @ZeroOperandVarNoMatch() {
+    // CHECK-NOT: dbg.variable
+    // CHECK-NOT: circt_debug_var
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "nonexistent", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.reg.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarReg
+firrtl.circuit "ZeroOperandVarReg" {
+  firrtl.module @ZeroOperandVarReg(in %clk: !firrtl.clock) {
+    // CHECK: %myreg = firrtl.reg
+    %myreg = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: dbg.variable "myreg", %myreg typeName "UInt" : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "myreg", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.regreset (async reset)
+// with a bundle type.  The fallback name-walk must handle RegResetOp the same
+// way it handles RegOp.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarRegReset
+firrtl.circuit "ZeroOperandVarRegReset" {
+  firrtl.module @ZeroOperandVarRegReset(
+      in %clk: !firrtl.clock,
+      in %rst: !firrtl.asyncreset) {
+    // CHECK: %r = firrtl.regreset
+    %c0 = firrtl.aggregateconstant [0 : ui8, 0 : ui8] : !firrtl.bundle<x: uint<8>, y: uint<8>>
+    %r = firrtl.regreset %clk, %rst, %c0 :
+        !firrtl.clock, !firrtl.asyncreset,
+        !firrtl.bundle<x: uint<8>, y: uint<8>>,
+        !firrtl.bundle<x: uint<8>, y: uint<8>>
+    // CHECK:      firrtl.subfield %r[x]
+    // CHECK:      firrtl.subfield %r[y]
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "r", %{{.*}} typeName "MyBundle" : !dbg.struct
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "r", typeName: none = "MyBundle"> : () -> ()
+  }
+}
+
+// -----
+
+// Nested aggregate: bundle whose field is itself a bundle. Exercises
+// recursion in buildDebugAggregateWithMeta -- the outer struct contains
+// an inner struct, with a leaf-meta entry on the deepest field.
+
+// CHECK-LABEL: firrtl.module @NestedBundleTest
+firrtl.circuit "NestedBundleTest" {
+  firrtl.module @NestedBundleTest() {
+    %io = firrtl.wire : !firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>
+
+    // Subfield meta on a deeply nested leaf: io.inner.a
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.inner.a", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[inner]
+    // CHECK:      firrtl.subfield %{{.*}}[a]
+    // CHECK:      dbg.subfield "io.inner.a", %{{.*}} typeName "UInt" : !firrtl.uint<4>
+    // CHECK:      firrtl.subfield %{{.*}}[b]
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "Outer">
+      %io : (!firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>) -> ()
+  }
+}
+
+// -----
+
+// circt_debug_typedef is silently consumed: no representation in the IR yet,
+// and no error.
+
+// CHECK-LABEL: firrtl.module @TypeDefDropped
+firrtl.circuit "TypeDefDropped" {
+  firrtl.module @TypeDefDropped() {
+    // CHECK-NOT: circt_debug_typedef
+    firrtl.int.generic "circt_debug_typedef"
+      <typeName: none = "MyAlias"> : () -> ()
+  }
+}
+
+// -----
+
+// Nested bundle: bundle<a: bundle<b: uint<8>>>.
+// A single circt_debug_subfield for the leaf "io.a.b" (parent="io") and a
+// circt_debug_var for the root "io".  The converter must recurse two levels:
+//   outer struct {"a": inner_struct}
+//   inner struct {"b": dbg.subfield "io.a.b"}
+//
+// Expected lowering:
+//   firrtl.subfield %io[a]            -- descend into outer field
+//   firrtl.subfield %<a_val>[b]       -- descend into inner field
+//   dbg.subfield "io.a.b", ...        -- leaf with meta
+//   dbg.struct {"b": ...}             -- inner struct
+//   dbg.struct {"a": ...}             -- outer struct
+//   dbg.variable "io", ...            -- root variable
+
+// CHECK-LABEL: firrtl.module @NestedBundleSingleLeafTest
+firrtl.circuit "NestedBundleSingleLeafTest" {
+  firrtl.module @NestedBundleSingleLeafTest() {
+    %io = firrtl.wire : !firrtl.bundle<a: bundle<b: uint<8>>>
+
+    // Leaf at depth-2: io.a.b
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.a.b", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<a: bundle<b: uint<8>>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[a]
+    // CHECK:      firrtl.subfield %{{.*}}[b]
+    // CHECK:      dbg.subfield "io.a.b", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io", %{{.*}} typeName "MyBundle"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<a: bundle<b: uint<8>>>) -> ()
+  }
+}
+
+// -----
+
+// Nested vector: vector<vector<uint<8>,2>,2> with a circt_debug_subfield leaf
+// for path v[0][1]. Exercises two levels of firrtl.subindex in
+// buildDebugAggregateWithMeta, producing nested dbg.array ops with the leaf
+// wrapped in dbg.subfield at position [0][1].
+//
+// FIXME: if this test fails, the converter does not yet recurse into
+// vector-of-vector with subindex-based leaf lookup (nested dbg.array path
+// resolution unimplemented).
+
+// CHECK-LABEL: firrtl.module @NestedVecTest
+firrtl.circuit "NestedVecTest" {
+  firrtl.module @NestedVecTest() {
+    %v = firrtl.wire : !firrtl.vector<vector<uint<8>, 2>, 2>
+
+    // Leaf for v[0][1]: parent="v", name="v[0][1]"
+    // CHECK-NOT: circt_debug_subfield
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "v[0][1]", typeName: none = "UInt", parent: none = "v">
+      %v : (!firrtl.vector<vector<uint<8>, 2>, 2>) -> ()
+
+    // Root circt_debug_var -- must produce nested dbg.array ops:
+    //   outer dbg.array contains two inner dbg.array values;
+    //   inner dbg.array at index 0 has its element at index 1 wrapped in
+    //   dbg.subfield "v[0][1]".
+    // CHECK:      firrtl.subindex %v[0]
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      firrtl.subindex %{{.*}}[1]
+    // CHECK:      dbg.subfield "v[0][1]", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.array
+    // CHECK:      firrtl.subindex %v[1]
+    // CHECK:      dbg.array
+    // CHECK:      dbg.array
+    // CHECK:      dbg.variable "v"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "Vec">
+      %v : (!firrtl.vector<vector<uint<8>, 2>, 2>) -> ()
+  }
+}
+
+// -----
+
+// circt_debug_var inside a firrtl.layerblock must lower to dbg.variable
+// that remains nested inside the same layerblock (walk is recursive).
+
+// CHECK-LABEL: firrtl.module @LayerBlockDebugVar
+firrtl.circuit "LayerBlockDebugVar" {
+  firrtl.layer @MyLayer bind {}
+  firrtl.module @LayerBlockDebugVar(in %in: !firrtl.uint<8>) {
+    firrtl.layerblock @MyLayer {
+      // CHECK: firrtl.layerblock @MyLayer {
+      %w = firrtl.wire : !firrtl.uint<8>
+      firrtl.connect %w, %in : !firrtl.uint<8>, !firrtl.uint<8>
+      // CHECK: dbg.variable "w", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+      firrtl.int.generic "circt_debug_var"
+        <name: none = "w", typeName: none = "UInt">
+        %w : (!firrtl.uint<8>) -> ()
+    }
+  }
+}
+
+// -----
+
+// Prefix-collision guard: two variables "io" and "iox" exist in the same
+// module. A circt_debug_subfield with parent="io" and name="io.x" must only
+// match the variable named exactly "io", not "iox". The boundary check in
+// processSubfieldIntrinsic uses `starts_with(parent + ".")` and
+// `starts_with(parent + "[")` -- bare `starts_with(parent)` would let "io.x"
+// match "iox" (since "io.x".starts_with("io") is true for both "io" and "iox"
+// after stripping the dot). This test pins that "iox" never gets the leaf.
+
+// CHECK-LABEL: firrtl.module @PrefixCollisionGuard
+firrtl.circuit "PrefixCollisionGuard" {
+  firrtl.module @PrefixCollisionGuard() {
+    %io  = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    %iox = firrtl.wire : !firrtl.uint<8>
+
+    // Leaf belongs to "io", NOT to "iox".
+    // CHECK-NOT: circt_debug_subfield
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+
+    // "io" variable: must receive the leaf and produce dbg.subfield.
+    // CHECK:      firrtl.subfield %{{.*}}[x]
+    // CHECK:      dbg.subfield "io.x", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+
+    // "iox" variable: no leaf should be associated; must NOT produce dbg.struct.
+    // CHECK:      dbg.variable "iox", %iox
+    // CHECK-NOT:  dbg.struct
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "iox", typeName: none = "UInt">
+      %iox : (!firrtl.uint<8>) -> ()
+  }
+}
+
+// -----
+
+// Mixed-path regression guard (PASSING): verify that `starts_with` in
+// processSubfieldIntrinsic (FIRRTLIntrinsics.cpp ~1412) correctly accepts
+// both `parent + "["` (vec-rooted leaf) and `parent + "."` (bundle-rooted leaf).
+//
+// (a) vector<bundle<x: uint<8>>, 2>  with leaf "v[0].x"
+//     parent="v", name starts with "v[" -> starts_with(parent+"[") fires. PASSING.
+// (b) bundle<v: vector<uint<8>, 1>>  with leaf "b.v[0]"
+//     parent="b", name starts with "b." -> starts_with(parent+".") fires. PASSING.
+//     (size-1 vector keeps dbg.array operands homogeneous to avoid type mismatch)
+//
+// If either check regresses, processSubfieldIntrinsic emits a diagnostic and
+// firrtl-lower-intrinsics fails, making this FileCheck run fail.
+// FIXME(a): regression if starts_with(parent+"[") stops matching vec-rooted paths
+// FIXME(b): regression if starts_with(parent+".") stops matching bundle-rooted vec paths
+
+// CHECK-LABEL: firrtl.module @MixedPathSubfieldTest
+firrtl.circuit "MixedPathSubfieldTest" {
+  firrtl.module @MixedPathSubfieldTest() {
+
+    // (a) vector<bundle<x: uint<8>>, 2>, leaf "v[0].x"
+    // CHECK-NOT: circt_debug_subfield
+    %v = firrtl.wire : !firrtl.vector<bundle<x: uint<8>>, 2>
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "v[0].x", typeName: none = "UInt", parent: none = "v">
+      %v : (!firrtl.vector<bundle<x: uint<8>>, 2>) -> ()
+
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      firrtl.subfield %{{.*}}[x]
+    // CHECK:      dbg.subfield "v[0].x", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.variable "v"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "VecBundle">
+      %v : (!firrtl.vector<bundle<x: uint<8>>, 2>) -> ()
+
+    // (b) bundle<v: vector<uint<8>, 1>>, leaf "b.v[0]"
+    // Use size-1 vector so all dbg.array operands share one type (dbg.subfield),
+    // avoiding the mixed-type dbg.array constraint that would fire with size>1
+    // when only one element carries a dbg.subfield leaf.
+    %b = firrtl.wire : !firrtl.bundle<v: vector<uint<8>, 1>>
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "b.v[0]", typeName: none = "UInt", parent: none = "b">
+      %b : (!firrtl.bundle<v: vector<uint<8>, 1>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[v]
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      dbg.subfield "b.v[0]", %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.variable "b"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "b", typeName: none = "BundleVec">
+      %b : (!firrtl.bundle<v: vector<uint<8>, 1>>) -> ()
+  }
+}
+
+// -----
+
+// sint<8> operand: the signedness path must lower to dbg.variable just like
+// uint<8>. (FIRRTLBaseType::isGround() returns true for sint, so the scalar
+// branch in buildDebugAggregateWithMeta fires.)
+
+// CHECK-LABEL: firrtl.module @SIntVar
+firrtl.circuit "SIntVar" {
+  firrtl.module @SIntVar(in %s: !firrtl.sint<8>) {
+    // CHECK: dbg.variable "s", %s typeName "SInt" : !firrtl.sint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "SInt">
+      %s : (!firrtl.sint<8>) -> ()
+  }
+}
+
+// -----
+
+// uint<0> (zero-width): still a ground type -> dbg.variable is emitted.
+
+// CHECK-LABEL: firrtl.module @ZeroWidthVar
+firrtl.circuit "ZeroWidthVar" {
+  firrtl.module @ZeroWidthVar(in %z: !firrtl.uint<0>) {
+    // CHECK: dbg.variable "z", %z typeName "UInt" : !firrtl.uint<0>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "z", typeName: none = "UInt">
+      %z : (!firrtl.uint<0>) -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.node.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarNode
+firrtl.circuit "ZeroOperandVarNode" {
+  firrtl.module @ZeroOperandVarNode(in %in: !firrtl.uint<8>) {
+    // CHECK: %mynode = firrtl.node
+    %mynode = firrtl.node %in : !firrtl.uint<8>
+    // CHECK: dbg.variable "mynode", %mynode typeName "UInt" : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "mynode", typeName: none = "UInt"> : () -> ()
+  }
+}


### PR DESCRIPTION
Hi! This commit carry Chisel source-level type information (type names, enum definitions, constructor parameters) through the FIRRTL -> MLIR pipeline so downstream consumers (Tywaves, HGDB) can recover the original Chisel types

Based on [@rameloni](https://github.com/rameloni)'s prior Tywaves/CIRCT debug-info work (https://github.com/llvm/circt/issues/6983, https://github.com/llvm/circt/pull/7246, https://github.com/chipsalliance/chisel/pull/4224, https://github.com/chipsalliance/chisel/issues/4015), but uses intrinsics instead of annotations. This PR pairs with the frontend intrinsics from [chipsalliance/chisel#5276](https://github.com/chipsalliance/chisel/pull/5276)

The dbg dialect extensions (dbg.enumdef, dbg.subfield, dbg.moduleinfo) are language-agnostic and reusable by any frontend; the FIRRTL side adds handlers in firrtl-lower-intrinsics for the new circt_debug_{var,subfield,enumdef,moduleinfo} intrinsics that feed them

I am also working on a new debug output format (UHDI) -- it is intended to avoid changes to the current HGLDD format and to let existing HGL debug tools (Tywaves, HGDB, ChiselTrace, etc.) work without maintaining outdated forks. Work is still in progress (demo repo: https://github.com/fkhaidari/uhdi, CIRCT UHDI PR: https://github.com/fkhaidari/circt/pull/2).