### PR TITLE
Bump LLVM to a47d3636f953870d96fb6cc68817365fdad2f9fe.

### DIFF
--- a/test/circt-verilog/roundtrip-unions.sv
+++ b/test/circt-verilog/roundtrip-unions.sv
@@ -1,5 +1,6 @@
-// REQUIRES: slang
 // RUN: circt-verilog %s | circt-opt -export-verilog -o /dev/null | FileCheck %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
 
 typedef union packed {
   int x;

--- a/test/circt-verilog/roundtrip-unions.sv
+++ b/test/circt-verilog/roundtrip-unions.sv
@@ -1,3 +1,4 @@
+// REQUIRES: slang
 // RUN: circt-verilog %s | circt-opt -export-verilog -o /dev/null | FileCheck %s
 
 typedef union packed {


### PR DESCRIPTION
This is a routine bump.

The only thing that ended up being needed was a missing REQUIRES line on what must be a relatively new circt-verilog test, which I noticed since my environment doesn't include slang or circt-verilog builds.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
