### PR TITLE
[CD] Remove scheduled Python wheel uploads.

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -19,8 +19,6 @@ on:
           - cp310-manylinux_x86_64
           - cp313-manylinux_x86_64
           - cp314-manylinux_x86_64
-  schedule:
-    - cron: 0 12 * * 1
 
 jobs:
   select_matrix:


### PR DESCRIPTION
While discussing https://github.com/llvm/circt/pull/10371, we considered removing the weekly dev wheel builds to save space on PyPI. I think that is a great idea, so I'm just removing it here. We can always add it back if needed, but I think they don't really serve much purpose today anyway.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
