### PR TITLE
[ESI][Runtime] Add integration tests for ordering issues

### DIFF
--- a/lib/Dialect/ESI/runtime/tests/integration/hw/serialization_probes.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/hw/serialization_probes.py
@@ -1,9 +1,3 @@
-# REQUIRES: esi-cosim, esi-runtime, rtl-sim
-# RUN: rm -rf %t
-# RUN: mkdir %t && cd %t
-
-# Build the system.
-# RUN: %PYTHON% %s %t 2>&1
 """Hardware design for serialization-correctness probes.
 
 This design exercises the on-the-wire layout invariants of the ESI runtime
@@ -55,7 +49,7 @@ class ByteRotate1(Module):
     # In bit-slice terms: the bottom 56 bits of arg become the top 56 bits
     # of the result and the top byte of arg wraps around to the bottom.
     arg_bits = arg.as_bits(64)
-    rotated = BitsSignal.concat([arg_bits[0:56], arg_bits[56:64]]).as_uint(64)
+    rotated = BitsSignal.concat([arg_bits[0:56], arg_bits[56:64]]).as_uint()
 
     out_chan, out_ready = Channel(UInt(64)).wrap(rotated, valid)
     ready.assign(out_ready)
@@ -143,6 +137,12 @@ class SignResult(Struct):
   sign_bit: UInt(1)
 
 
+class SignResult13(Struct):
+  plus_one: SInt(13)
+  neg: SInt(13)
+  sign_bit: UInt(1)
+
+
 class SignProbe(Module):
   """Function ``sign_probe``: si16 -> {plus_one, neg, sign_bit}.
 
@@ -171,6 +171,44 @@ class SignProbe(Module):
     sign_bit = arg.as_bits(16)[15].as_uint(1)
     result = SignResult(plus_one=plus_one, neg=neg, sign_bit=sign_bit)
     out_chan, out_ready = Channel(SignResult).wrap(result, valid)
+    ready.assign(out_ready)
+    result_wire.assign(out_chan)
+
+
+class SignProbe13(Module):
+  """Function ``sign_probe13``: si13 -> {plus_one: si13, neg: si13, sign_bit: ui1}.
+
+  The non-byte-aligned cousin of :class:`SignProbe`. si13 occupies a 2-byte
+  wire slot but only bit 12 carries the sign, with bits 13..15 acting as
+  padding. A host that:
+
+    - uses bit 15 (instead of bit 12) as the sign bit, or
+    - forgets to sign-extend the padding bits on read, or
+    - leaves uninitialised garbage in the padding bits on write,
+
+  will produce wrong ``plus_one`` / ``neg`` values for negative inputs and
+  for inputs near the si13 boundaries (-4096 / 4095). This catches
+  width-bounded sign-extension bugs that si16 would never trip.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    result_wire = Wire(Channel(SignResult13))
+    args = esi.FuncService.get_call_chans(AppID("sign_probe13"),
+                                          arg_type=SInt(13),
+                                          result=result_wire)
+
+    ready = Wire(Bits(1))
+    arg, valid = args.unwrap(ready)
+
+    plus_one = (arg + SInt(13)(1)).as_sint(13)
+    neg = (-arg).as_sint(13)
+    sign_bit = arg.as_bits(13)[12].as_uint(1)
+    result = SignResult13(plus_one=plus_one, neg=neg, sign_bit=sign_bit)
+    out_chan, out_ready = Channel(SignResult13).wrap(result, valid)
     ready.assign(out_ready)
     result_wire.assign(out_chan)
 
@@ -312,9 +350,7 @@ class Top(Module):
 
   @generator
   def construct(ports):
-    ByteRotate1(clk=ports.clk,
-                rst=ports.rst,
-                appid=AppID("byte_rotate1_inst"))
+    ByteRotate1(clk=ports.clk, rst=ports.rst, appid=AppID("byte_rotate1_inst"))
     BytePatternConst(clk=ports.clk,
                      rst=ports.rst,
                      appid=AppID("byte_pattern_const_inst"))
@@ -322,6 +358,7 @@ class Top(Module):
                       rst=ports.rst,
                       appid=AppID("byte_pattern_echo_eq_inst"))
     SignProbe(clk=ports.clk, rst=ports.rst, appid=AppID("sign_probe_inst"))
+    SignProbe13(clk=ports.clk, rst=ports.rst, appid=AppID("sign_probe13_inst"))
     PackProbe(clk=ports.clk, rst=ports.rst, appid=AppID("pack_probe_inst"))
     BitPackProbe(clk=ports.clk,
                  rst=ports.rst,

--- a/lib/Dialect/ESI/runtime/tests/integration/hw/serialization_probes.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/hw/serialization_probes.py
@@ -1,0 +1,336 @@
+# REQUIRES: esi-cosim, esi-runtime, rtl-sim
+# RUN: rm -rf %t
+# RUN: mkdir %t && cd %t
+
+# Build the system.
+# RUN: %PYTHON% %s %t 2>&1
+"""Hardware design for serialization-correctness probes.
+
+This design exercises the on-the-wire layout invariants of the ESI runtime
+serializer/deserializer pair against a hardware implementation that is
+deliberately picky about byte order, sign extension, struct field order,
+sub-byte field packing, and array element order. Each function is small and
+self-checking: the host sends a value with distinguishable bytes/fields/bits,
+the hardware applies a position-revealing transform, and the host asserts
+the exact expected bytes/fields/bits come back. A mismatch in any of those
+five invariants between the host serializer and the hardware wire format
+yields a wrong (rather than coincidentally correct) answer.
+"""
+
+import sys
+
+import pycde.esi as esi
+from pycde import AppID, Clock, Module, Reset, System, generator
+from esiaccel.bsp import get_bsp
+from pycde.constructs import Mux, Wire
+from pycde.signals import BitsSignal, Struct
+from pycde.types import Bits, Channel, SInt, UInt
+
+
+class ByteRotate1(Module):
+  """Function ``byte_rotate1``: ui64 -> ui64.
+
+  Rotates the input left by one byte position. Sending
+  ``0x0102030405060708`` yields ``0x0203040506070801``: the MSB byte wraps
+  around to the LSB. Unlike a byte *swap*, a rotate is **not** its own
+  inverse, so a host that mis-orders bytes symmetrically on the send and
+  receive paths (the classic symmetric-serdes bug that passes loopback)
+  produces a wrong-and-distinguishable answer here.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    result_wire = Wire(Channel(UInt(64)))
+    args = esi.FuncService.get_call_chans(AppID("byte_rotate1"),
+                                          arg_type=UInt(64),
+                                          result=result_wire)
+
+    ready = Wire(Bits(1))
+    arg, valid = args.unwrap(ready)
+
+    # Numerically: result = (arg << 8) | (arg >> 56).
+    # In bit-slice terms: the bottom 56 bits of arg become the top 56 bits
+    # of the result and the top byte of arg wraps around to the bottom.
+    arg_bits = arg.as_bits(64)
+    rotated = BitsSignal.concat([arg_bits[0:56], arg_bits[56:64]]).as_uint(64)
+
+    out_chan, out_ready = Channel(UInt(64)).wrap(rotated, valid)
+    ready.assign(out_ready)
+    result_wire.assign(out_chan)
+
+
+PatternArray = UInt(8) * 8
+
+# A deliberately asymmetric byte sequence: the wire ordering is unambiguous
+# in either direction (no palindrome / no monotone), and every nibble is
+# distinct so a single wrong byte is easy to spot in failure messages.
+_BYTE_PATTERN = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]
+
+
+class BytePatternConst(Module):
+  """Function ``byte_pattern_const``: ui8 -> array<ui8, 8>.
+
+  Ignores the trigger byte and returns the constant pattern
+  ``[0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]`` (in PyCDE / MLIR
+  index order). The driver consumes the result as **raw wire bytes**
+  rather than through the typed deserializer, so any host-side decoding bug
+  (including a symmetric one) is taken out of the loop entirely. A test
+  failure here points at a mismatch between the runtime's wire convention
+  and the spec, not at a SW round-trip.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    result_wire = Wire(Channel(PatternArray))
+    args = esi.FuncService.get_call_chans(AppID("byte_pattern_const"),
+                                          arg_type=UInt(8),
+                                          result=result_wire)
+
+    ready = Wire(Bits(1))
+    _, valid = args.unwrap(ready)
+
+    pattern = PatternArray([UInt(8)(b) for b in _BYTE_PATTERN])
+    out_chan, out_ready = Channel(PatternArray).wrap(pattern, valid)
+    ready.assign(out_ready)
+    result_wire.assign(out_chan)
+
+
+class BytePatternEchoEq(Module):
+  """Function ``byte_pattern_echo_eq``: array<ui8, 8> -> ui8.
+
+  Compares the incoming 8-byte array against the same constant pattern as
+  :class:`BytePatternConst` and returns ``1`` if every element matches,
+  ``0`` otherwise. The driver writes **raw wire bytes** straight into the
+  arg channel, taking the host-side serializer out of the loop. A test
+  failure means the bytes the runtime put on the wire disagree with the
+  spec, not that the host SW ``de``serializer also misread them.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    result_wire = Wire(Channel(UInt(8)))
+    args = esi.FuncService.get_call_chans(AppID("byte_pattern_echo_eq"),
+                                          arg_type=PatternArray,
+                                          result=result_wire)
+
+    ready = Wire(Bits(1))
+    arg, valid = args.unwrap(ready)
+
+    matches = [arg[i] == UInt(8)(b) for i, b in enumerate(_BYTE_PATTERN)]
+    all_match = matches[0]
+    for m in matches[1:]:
+      all_match = all_match & m
+    # ``Mux(sel, false_val, true_val)``: when ``sel`` is 1, pick the last arg.
+    result = Mux(all_match, UInt(8)(0), UInt(8)(1))
+
+    out_chan, out_ready = Channel(UInt(8)).wrap(result, valid)
+    ready.assign(out_ready)
+    result_wire.assign(out_chan)
+
+
+class SignResult(Struct):
+  plus_one: SInt(16)
+  neg: SInt(16)
+  sign_bit: UInt(1)
+
+
+class SignProbe(Module):
+  """Function ``sign_probe``: si16 -> {plus_one, neg, sign_bit}.
+
+  Returns ``arg+1``, ``-arg`` and ``arg<0`` in a single struct. Exercises
+  two's-complement addition, negation and MSB extraction at a sub-32-bit
+  width. A host that confuses signed/unsigned encoding or sign-extends
+  incorrectly will see a wrong ``plus_one`` near the boundaries
+  (``INT16_MIN``/``INT16_MAX``).
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    result_wire = Wire(Channel(SignResult))
+    args = esi.FuncService.get_call_chans(AppID("sign_probe"),
+                                          arg_type=SInt(16),
+                                          result=result_wire)
+
+    ready = Wire(Bits(1))
+    arg, valid = args.unwrap(ready)
+
+    plus_one = (arg + SInt(16)(1)).as_sint(16)
+    neg = (-arg).as_sint(16)
+    sign_bit = arg.as_bits(16)[15].as_uint(1)
+    result = SignResult(plus_one=plus_one, neg=neg, sign_bit=sign_bit)
+    out_chan, out_ready = Channel(SignResult).wrap(result, valid)
+    ready.assign(out_ready)
+    result_wire.assign(out_chan)
+
+
+class PackStruct(Struct):
+  a: UInt(8)
+  b: UInt(16)
+  c: UInt(8)
+  d: UInt(32)
+
+
+class PackProbe(Module):
+  """Function ``pack_probe``: PackStruct -> PackStruct.
+
+  XORs each field with a unique sentinel of the same width. Sentinels
+  (``0xA0``, ``0xB000``, ``0xC0``, ``0xD0000000``) make every byte of the
+  reply unique and per-field-distinguishable, so a host that swaps fields
+  during packing produces a visibly wrong reply rather than a same-bit-width
+  false positive. Catches struct-field order and inter-field padding bugs;
+  CIRCT structs are LSB-first on the wire.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    result_wire = Wire(Channel(PackStruct))
+    args = esi.FuncService.get_call_chans(AppID("pack_probe"),
+                                          arg_type=PackStruct,
+                                          result=result_wire)
+
+    ready = Wire(Bits(1))
+    arg, valid = args.unwrap(ready)
+
+    a = (arg["a"].as_bits(8) ^ Bits(8)(0xA0)).as_uint(8)
+    b = (arg["b"].as_bits(16) ^ Bits(16)(0xB000)).as_uint(16)
+    c = (arg["c"].as_bits(8) ^ Bits(8)(0xC0)).as_uint(8)
+    d = (arg["d"].as_bits(32) ^ Bits(32)(0xD0000000)).as_uint(32)
+    result = PackStruct(a=a, b=b, c=c, d=d)
+    out_chan, out_ready = Channel(PackStruct).wrap(result, valid)
+    ready.assign(out_ready)
+    result_wire.assign(out_chan)
+
+
+class BitPackArg(Struct):
+  x: UInt(3)
+  y: UInt(5)
+  z: UInt(4)
+  w: UInt(4)
+
+
+class BitPackResult(Struct):
+  # Same widths as BitPackArg, but rotated: the original ``x`` lands in the
+  # ``w_field`` slot, etc. Distinct field names so the rotation cannot be
+  # confused for an identity transform by accident.
+  w_field: UInt(3)
+  z_field: UInt(5)
+  y_field: UInt(4)
+  x_field: UInt(4)
+
+
+class BitPackProbe(Module):
+  """Function ``bit_pack_probe``: BitPackArg -> BitPackResult.
+
+  Returns ``{w, z, y, x}`` packed back into a 16-bit-wide struct that uses
+  the same widths as the argument but in reverse field order. Each field has
+  a unique width, and the chosen sentinel values used by the test driver
+  (``x=0b001``, ``y=0b10001``, ``z=0b1001``, ``w=0b1100``) are unique within
+  their own width, so a misaligned shift or wrong field offset produces a
+  wrong number rather than a coincidentally-matching one.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    result_wire = Wire(Channel(BitPackResult))
+    args = esi.FuncService.get_call_chans(AppID("bit_pack_probe"),
+                                          arg_type=BitPackArg,
+                                          result=result_wire)
+
+    ready = Wire(Bits(1))
+    arg, valid = args.unwrap(ready)
+
+    # Move each input field into the output slot whose width matches.
+    result = BitPackResult(
+        w_field=arg["x"],  # 3 bits
+        z_field=arg["y"],  # 5 bits
+        y_field=arg["z"],  # 4 bits
+        x_field=arg["w"],  # 4 bits
+    )
+    out_chan, out_ready = Channel(BitPackResult).wrap(result, valid)
+    ready.assign(out_ready)
+    result_wire.assign(out_chan)
+
+
+ArrayProbeArg = UInt(8) * 4
+ArrayProbeResult = UInt(8) * 4
+
+
+class ArrayProbe(Module):
+  """Function ``array_probe``: array<ui8, 4> -> array<ui8, 4>.
+
+  Returns ``[arg[0]+10, arg[1]+20, arg[2]+30, arg[3]+40]``. CIRCT arrays
+  serialize element-reversed on the wire while lists do not, so this
+  exercises a serializer path distinct from the list-based tests. A host
+  that forgets to reverse on (de)serialize will see, e.g., ``arg=[1,2,3,4]``
+  echoed back as ``[41, 32, 23, 14]`` instead of ``[11, 22, 33, 44]``.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    result_wire = Wire(Channel(ArrayProbeResult))
+    args = esi.FuncService.get_call_chans(AppID("array_probe"),
+                                          arg_type=ArrayProbeArg,
+                                          result=result_wire)
+
+    ready = Wire(Bits(1))
+    arg, valid = args.unwrap(ready)
+
+    # Per-index sentinels (10, 20, 30, 40) make the element order observable.
+    # Build the output in increasing-index order; the C++ host driver
+    # asserts ``out[i] == arg[i] + 10*(i+1)``.
+    plus = [(arg[i] + UInt(8)(10 * (i + 1))).as_uint(8) for i in range(4)]
+    out_array = ArrayProbeResult(plus)
+    out_chan, out_ready = Channel(ArrayProbeResult).wrap(out_array, valid)
+    ready.assign(out_ready)
+    result_wire.assign(out_chan)
+
+
+class Top(Module):
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    ByteRotate1(clk=ports.clk,
+                rst=ports.rst,
+                appid=AppID("byte_rotate1_inst"))
+    BytePatternConst(clk=ports.clk,
+                     rst=ports.rst,
+                     appid=AppID("byte_pattern_const_inst"))
+    BytePatternEchoEq(clk=ports.clk,
+                      rst=ports.rst,
+                      appid=AppID("byte_pattern_echo_eq_inst"))
+    SignProbe(clk=ports.clk, rst=ports.rst, appid=AppID("sign_probe_inst"))
+    PackProbe(clk=ports.clk, rst=ports.rst, appid=AppID("pack_probe_inst"))
+    BitPackProbe(clk=ports.clk,
+                 rst=ports.rst,
+                 appid=AppID("bit_pack_probe_inst"))
+    ArrayProbe(clk=ports.clk, rst=ports.rst, appid=AppID("array_probe_inst"))
+
+
+if __name__ == "__main__":
+  bsp = get_bsp(sys.argv[2] if len(sys.argv) > 2 else None)
+  s = System(bsp(Top), name="SerializationProbes", output_directory=sys.argv[1])
+  s.compile()
+  s.package()

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/CMakeLists.txt
@@ -177,3 +177,31 @@ if (UNIX AND _esi_runtime_lib_dir)
   set_target_properties(loopback_typed_test PROPERTIES
     BUILD_RPATH "${_esi_runtime_lib_dir}")
 endif()
+
+# Hardware-vs-host serialization-correctness probes. The generated headers
+# this target depends on live under <LOOPBACK_GENERATED_DIR>/serialization_probes/
+# rather than <LOOPBACK_GENERATED_DIR>/loopback/, but the CMake variable name
+# is kept generic so callers can use a single include root.
+add_executable(serialization_probes_test
+  "${CMAKE_CURRENT_SOURCE_DIR}/serialization_probes.cpp")
+set_target_properties(serialization_probes_test PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+target_include_directories(serialization_probes_test PRIVATE
+  "${LOOPBACK_GENERATED_DIR}"
+  "${CLI11_INCLUDE_DIR}")
+
+if (ESI_RUNTIME_TARGET)
+  target_link_libraries(serialization_probes_test PRIVATE
+    "${ESI_RUNTIME_TARGET}")
+else()
+  target_include_directories(serialization_probes_test PRIVATE
+    "${ESI_RUNTIME_INCLUDE_DIR}")
+  target_link_libraries(serialization_probes_test PRIVATE
+    "${ESI_RUNTIME_LIB}")
+endif()
+
+if (UNIX AND _esi_runtime_lib_dir)
+  set_target_properties(serialization_probes_test PROPERTIES
+    BUILD_RPATH "${_esi_runtime_lib_dir}")
+endif()

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/serialization_probes.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/serialization_probes.cpp
@@ -10,6 +10,7 @@
 #include "serialization_probes/ByteRotate1.h"
 #include "serialization_probes/PackProbe.h"
 #include "serialization_probes/SignProbe.h"
+#include "serialization_probes/SignProbe13.h"
 
 #include "esi/Accelerator.h"
 #include "esi/CLI.h"
@@ -107,9 +108,9 @@ static void runBytePatternEchoEq(Accelerator *accel) {
   MessageData resMsg =
       func->call(MessageData(kBytePattern.data(), kBytePattern.size())).get();
   if (resMsg.getSize() != 1)
-    throw std::runtime_error(
-        "byte_pattern_echo_eq: wrong response size (got " +
-        std::to_string(resMsg.getSize()) + ", expected 1)");
+    throw std::runtime_error("byte_pattern_echo_eq: wrong response size (got " +
+                             std::to_string(resMsg.getSize()) +
+                             ", expected 1)");
   uint8_t got = *resMsg.getBytes();
   if (got != 1)
     throw std::runtime_error(
@@ -142,12 +143,70 @@ static void runSignProbe(Accelerator *accel) {
   };
   for (const Case &c : cases) {
     esi_system::SignResult r = connected->sign_probe(c.arg).get();
-    if (r.plus_one != c.plus_one || r.neg != c.neg ||
-        r.sign_bit != c.sign_bit)
+    if (r.plus_one != c.plus_one || r.neg != c.neg || r.sign_bit != c.sign_bit)
       throw std::runtime_error("sign_probe mismatch for arg=" +
                                std::to_string(c.arg));
   }
   std::cout << "sign_probe ok\n";
+}
+
+static void runSignProbe13(Accelerator *accel) {
+  esi_system::SignProbe13 mod(findProbe(accel, "sign_probe13_inst"));
+  auto connected = mod.connect();
+
+  // si13 ranges from -4096 (= -2^12) to 4095 (= 2^12 - 1). The boundary
+  // cases are where width-bounded sign extension and saturating-wrap
+  // arithmetic differ from si16 behavior; getting plus_one or neg right
+  // for both -4096 and 4095 forces the host serializer/deserializer to
+  // use the manifest's bit width, not sizeof(int16_t).
+  static constexpr int16_t kMin = -4096;
+  static constexpr int16_t kMax = 4095;
+  struct Case {
+    int16_t arg;
+    int16_t plus_one;
+    int16_t neg;
+    uint8_t sign_bit;
+  };
+  Case cases[] = {
+      {0, 1, 0, 0},
+      {-1, 0, 1, 1},
+      {1, 2, -1, 0},
+      {kMax, kMin, static_cast<int16_t>(-kMax), 0}, // 4095 + 1 wraps to -4096.
+      // -4096 is the si13 minimum: -kMin overflows back to -4096 (just like
+      // -INT16_MIN does for si16), and kMin + 1 = -4095.
+      {kMin, static_cast<int16_t>(kMin + 1), kMin, 1},
+  };
+  for (const Case &c : cases) {
+    esi_system::SignResult13 r = connected->sign_probe13(c.arg).get();
+    if (r.plus_one != c.plus_one || r.neg != c.neg || r.sign_bit != c.sign_bit)
+      throw std::runtime_error(
+          "sign_probe13 mismatch for arg=" + std::to_string(c.arg) +
+          " got plus_one=" + std::to_string(r.plus_one) + " neg=" +
+          std::to_string(r.neg) + " sign_bit=" + std::to_string(r.sign_bit));
+  }
+
+  // TODO: Out-of-range si13 args. The generated facade declares
+  // `sign_probe13Args = int16_t`, and the runtime's `toMessageData` for
+  // int16_t -> si13 just copies the low 2 wire bytes with no truncation.
+  // So a host that does ordinary int16_t arithmetic and passes a value
+  // outside [-4096, 4095] silently sends a wrong si13 to the hardware.
+  // The expected behavior is one of: (a) the codegen emits a wrapper class
+  // (e.g. `sint13_t` with a 13-bit bitfield) that masks/sign-extends on
+  // construction so this round-trip works, or (b) the runtime rejects the
+  // value at write time. Either way the assertion below should hold.
+  // Re-enable once one of those is implemented.
+  //
+  // {
+  //   int16_t out_of_range = 4096; // legal int16_t, illegal si13.
+  //   esi_system::SignResult13 r = connected->sign_probe13(out_of_range).get();
+  //   if (r.plus_one != static_cast<int16_t>(out_of_range + 1))
+  //     throw std::runtime_error(
+  //         "sign_probe13 out-of-range arg mismatch: arg=" +
+  //         std::to_string(out_of_range) +
+  //         " plus_one=" + std::to_string(r.plus_one));
+  // }
+
+  std::cout << "sign_probe13 ok\n";
 }
 
 static void runPackProbe(Accelerator *accel) {
@@ -213,9 +272,8 @@ static void runArrayProbe(Accelerator *accel) {
   std::array<uint8_t, 4> r = array_probe(arg).get();
   if (r[0] != 11 || r[1] != 22 || r[2] != 33 || r[3] != 44)
     throw std::runtime_error("array_probe element-order mismatch: got [" +
-                             std::to_string(r[0]) + "," +
-                             std::to_string(r[1]) + "," +
-                             std::to_string(r[2]) + "," +
+                             std::to_string(r[0]) + "," + std::to_string(r[1]) +
+                             "," + std::to_string(r[2]) + "," +
                              std::to_string(r[3]) + "]");
   std::cout << "array_probe ok: [" << (int)r[0] << "," << (int)r[1] << ","
             << (int)r[2] << "," << (int)r[3] << "]\n";
@@ -223,8 +281,7 @@ static void runArrayProbe(Accelerator *accel) {
 
 int main(int argc, const char *argv[]) {
   CliParser cli("serialization-probes");
-  cli.description(
-      "Hardware-vs-host serialization correctness probes for ESI.");
+  cli.description("Hardware-vs-host serialization correctness probes for ESI.");
   if (int rc = cli.esiParse(argc, argv))
     return rc;
   if (!cli.get_help_ptr()->empty())
@@ -242,6 +299,7 @@ int main(int argc, const char *argv[]) {
     runBytePatternConst(accel);
     runBytePatternEchoEq(accel);
     runSignProbe(accel);
+    runSignProbe13(accel);
     runPackProbe(accel);
     runBitPackProbe(accel);
     runArrayProbe(accel);

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/serialization_probes.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/serialization_probes.cpp
@@ -5,12 +5,14 @@
 // as wrong-but-distinguishable output rather than coincidentally-correct
 // answers; see the corresponding HW module's docstring for the rationale.
 
-#include "serialization_probes/ArrayProbe.h"
 #include "serialization_probes/BitPackProbe.h"
 #include "serialization_probes/ByteRotate1.h"
 #include "serialization_probes/PackProbe.h"
 #include "serialization_probes/SignProbe.h"
 #include "serialization_probes/SignProbe13.h"
+// Note: serialization_probes/ArrayProbe.h is intentionally not included.
+// runArrayProbe drives the raw FuncService port directly to test the wire
+// byte order; see the comment on that function for the rationale.
 
 #include "esi/Accelerator.h"
 #include "esi/CLI.h"
@@ -247,36 +249,54 @@ static void runBitPackProbe(Accelerator *accel) {
   std::cout << "bit_pack_probe ok\n";
 }
 
+// Per-index sentinels (10, 20, 30, 40) make element order observable.
+// The PyCDE source reads the argument as `arg[i]` and returns
+// `arg[i] + 10*(i+1)` packed back into the result array at logical
+// index `i`. With the request bytes [0x01, 0x02, 0x03, 0x04], a wire
+// convention that places logical element `i` at wire byte `i` produces
+// a response of [11, 22, 33, 44]; a reverse-on-wire convention would
+// produce [41, 32, 23, 14]. Either way each byte uniquely identifies
+// its source index so the actual convention is observable from the
+// failure message.
 static void runArrayProbe(Accelerator *accel) {
-  // FIXME: bypass the generated facade for this probe.
-  // verifyTypeCompatibility<std::array<T,N>>() against an ArrayType is not
-  // implemented in the runtime today, so the generated facade's connect()
-  // throws "Cannot verify type compatibility for C++ type 'St5arrayIhLm4EE'".
-  // Once that gap is closed, switch this back to:
-  //   esi_system::ArrayProbe mod(findProbe(accel, "array_probe_inst"));
-  //   auto connected = mod.connect();
-  //   ... connected->array_probe(arg).get();
-  esi::HWModule *probe = findProbe(accel, "array_probe_inst");
-  auto it = probe->getPorts().find(AppID("array_probe"));
-  if (it == probe->getPorts().end())
-    throw std::runtime_error("array_probe port not found on instance");
-  auto *funcPort = it->second.getAs<services::FuncService::Function>();
-  if (!funcPort)
-    throw std::runtime_error("array_probe is not a FuncService::Function");
-  TypedFunction<std::array<uint8_t, 4>, std::array<uint8_t, 4>,
-                /*SkipTypeCheck=*/true>
-      array_probe(funcPort);
-  array_probe.connect();
+  // Driven through the raw FuncService port with explicitly constructed
+  // wire bytes -- not via the generated facade. Two reasons:
+  //
+  //   1. `TypedFunction<std::array<T,N>, ..., SkipTypeCheck=true>` would use
+  //      `TypedPorts`' POD (memcpy) (de)serialization. That path is
+  //      symmetric: it would round-trip a wrong-but-mirrored byte order as
+  //      a false positive without ever exercising what the hardware
+  //      actually puts on (or reads off) the wire.
+  //   2. The runtime's typed `ArrayType` (de)serializer in `types.py`
+  //      reverses element order on the wire. Whether the hardware
+  //      (PyCDE-emitted RTL) also reverses is exactly the convention this
+  //      probe is meant to nail down. By writing/reading raw bytes the
+  //      test pins down the wire format independent of any host-side
+  //      mirror of that convention.
 
-  std::array<uint8_t, 4> arg{1, 2, 3, 4};
-  std::array<uint8_t, 4> r = array_probe(arg).get();
-  if (r[0] != 11 || r[1] != 22 || r[2] != 33 || r[3] != 44)
-    throw std::runtime_error("array_probe element-order mismatch: got [" +
-                             std::to_string(r[0]) + "," + std::to_string(r[1]) +
-                             "," + std::to_string(r[2]) + "," +
-                             std::to_string(r[3]) + "]");
-  std::cout << "array_probe ok: [" << (int)r[0] << "," << (int)r[1] << ","
-            << (int)r[2] << "," << (int)r[3] << "]\n";
+  auto *func = findRawFunc(findProbe(accel, "array_probe_inst"), "array_probe");
+  func->connect();
+
+  static constexpr std::array<uint8_t, 4> kRequest = {0x01, 0x02, 0x03, 0x04};
+  MessageData resMsg =
+      func->call(MessageData(kRequest.data(), kRequest.size())).get();
+  if (resMsg.getSize() != kRequest.size())
+    throw std::runtime_error("array_probe: wrong response size (got " +
+                             std::to_string(resMsg.getSize()) + ", expected " +
+                             std::to_string(kRequest.size()) + ")");
+
+  static constexpr std::array<uint8_t, 4> kExpect = {11, 22, 33, 44};
+  const uint8_t *got = resMsg.getBytes();
+  for (size_t i = 0; i < kExpect.size(); ++i) {
+    if (got[i] != kExpect[i]) {
+      std::stringstream ss;
+      ss << "array_probe: wire byte " << i << " mismatch (got 0x" << std::hex
+         << static_cast<unsigned>(got[i]) << " expected 0x"
+         << static_cast<unsigned>(kExpect[i]) << ")";
+      throw std::runtime_error(ss.str());
+    }
+  }
+  std::cout << "array_probe ok (wire order: natural element-index)\n";
 }
 
 int main(int argc, const char *argv[]) {

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/serialization_probes.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/serialization_probes.cpp
@@ -1,0 +1,256 @@
+// Driver for the SerializationProbes integration test. Each function below
+// targets exactly one of the on-the-wire serialization invariants the host
+// must agree with hardware on (byte order, sign extension, struct-field
+// order, sub-byte field packing, array element order). Mismatches surface
+// as wrong-but-distinguishable output rather than coincidentally-correct
+// answers; see the corresponding HW module's docstring for the rationale.
+
+#include "serialization_probes/ArrayProbe.h"
+#include "serialization_probes/BitPackProbe.h"
+#include "serialization_probes/ByteRotate1.h"
+#include "serialization_probes/PackProbe.h"
+#include "serialization_probes/SignProbe.h"
+
+#include "esi/Accelerator.h"
+#include "esi/CLI.h"
+#include "esi/Manifest.h"
+#include "esi/Services.h"
+
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+using namespace esi;
+
+// Resolve a child instance by AppID name from the top-level accelerator.
+// The probe modules are instantiated under named appids so the runtime
+// hierarchy carries one instance per probe.
+static esi::HWModule *findProbe(Accelerator *accel, const char *appidName) {
+  auto it = accel->getChildren().find(AppID(appidName));
+  if (it == accel->getChildren().end())
+    throw std::runtime_error(std::string("probe instance '") + appidName +
+                             "' not found in accelerator hierarchy");
+  return it->second;
+}
+
+// The constant byte sequence shared by ``byte_pattern_const`` and
+// ``byte_pattern_echo_eq``. Must stay in lock-step with ``_BYTE_PATTERN``
+// in the PyCDE source.
+static constexpr std::array<uint8_t, 8> kBytePattern = {0x12, 0x34, 0x56, 0x78,
+                                                        0x9A, 0xBC, 0xDE, 0xF0};
+
+static void runByteRotate1(Accelerator *accel) {
+  esi_system::ByteRotate1 mod(findProbe(accel, "byte_rotate1_inst"));
+  auto connected = mod.connect();
+
+  uint64_t arg = 0x0102030405060708ULL;
+  uint64_t expect = 0x0203040506070801ULL; // (arg << 8) | (arg >> 56).
+  uint64_t got = connected->byte_rotate1(arg).get();
+  if (got != expect)
+    throw std::runtime_error("byte_rotate1 mismatch: got 0x" + toHex(got) +
+                             " expected 0x" + toHex(expect));
+  std::cout << "byte_rotate1 ok: 0x" << std::hex << got << std::dec << "\n";
+}
+
+// Look up a FuncService::Function port by AppID on a probe instance, skipping
+// the generated facade. Used by the raw-byte probes below so the test depends
+// only on what the runtime actually puts on (or reads off) the wire.
+static services::FuncService::Function *findRawFunc(esi::HWModule *probe,
+                                                    const char *portName) {
+  auto it = probe->getPorts().find(AppID(portName));
+  if (it == probe->getPorts().end())
+    throw std::runtime_error(std::string("port '") + portName +
+                             "' not found on probe instance");
+  auto *func = it->second.getAs<services::FuncService::Function>();
+  if (!func)
+    throw std::runtime_error(std::string("port '") + portName +
+                             "' is not a FuncService::Function");
+  return func;
+}
+
+static void runBytePatternConst(Accelerator *accel) {
+  // Bypasses the generated facade and the typed deserializer so the test
+  // asserts on the *wire* bytes directly.
+  auto *func = findRawFunc(findProbe(accel, "byte_pattern_const_inst"),
+                           "byte_pattern_const");
+  func->connect();
+
+  uint8_t trigger = 0; // value is ignored by the hardware.
+  MessageData resMsg = func->call(MessageData(&trigger, sizeof(trigger))).get();
+
+  if (resMsg.getSize() != kBytePattern.size())
+    throw std::runtime_error("byte_pattern_const: wrong response size (got " +
+                             std::to_string(resMsg.getSize()) + ", expected " +
+                             std::to_string(kBytePattern.size()) + ")");
+  const uint8_t *got = resMsg.getBytes();
+  for (size_t i = 0; i < kBytePattern.size(); ++i) {
+    if (got[i] != kBytePattern[i]) {
+      std::stringstream ss;
+      ss << "byte_pattern_const: wire byte " << i << " mismatch (got 0x"
+         << std::hex << static_cast<unsigned>(got[i]) << " expected 0x"
+         << static_cast<unsigned>(kBytePattern[i]) << ")";
+      throw std::runtime_error(ss.str());
+    }
+  }
+  std::cout << "byte_pattern_const ok\n";
+}
+
+static void runBytePatternEchoEq(Accelerator *accel) {
+  // Bypasses the generated facade and the typed serializer so the bytes the
+  // hardware sees come straight off the wire.
+  auto *func = findRawFunc(findProbe(accel, "byte_pattern_echo_eq_inst"),
+                           "byte_pattern_echo_eq");
+  func->connect();
+
+  MessageData resMsg =
+      func->call(MessageData(kBytePattern.data(), kBytePattern.size())).get();
+  if (resMsg.getSize() != 1)
+    throw std::runtime_error(
+        "byte_pattern_echo_eq: wrong response size (got " +
+        std::to_string(resMsg.getSize()) + ", expected 1)");
+  uint8_t got = *resMsg.getBytes();
+  if (got != 1)
+    throw std::runtime_error(
+        "byte_pattern_echo_eq: hardware reported byte mismatch (got " +
+        std::to_string(got) + ")");
+  std::cout << "byte_pattern_echo_eq ok\n";
+}
+
+static void runSignProbe(Accelerator *accel) {
+  esi_system::SignProbe mod(findProbe(accel, "sign_probe_inst"));
+  auto connected = mod.connect();
+
+  // Probe several signed values, including the boundaries where two's-
+  // complement and sign-extension bugs would show up.
+  struct Case {
+    int16_t arg;
+    int16_t plus_one;
+    int16_t neg;
+    uint8_t sign_bit;
+  };
+  Case cases[] = {
+      {0, 1, 0, 0},
+      {-1, 0, 1, 1},
+      {1, 2, -1, 0},
+      {INT16_MAX, static_cast<int16_t>(INT16_MIN), -INT16_MAX, 0},
+      // INT16_MIN: -INT16_MIN is undefined in two's complement (overflows to
+      // itself), which is the *expected* behavior the hardware reproduces.
+      {INT16_MIN, static_cast<int16_t>(INT16_MIN + 1),
+       static_cast<int16_t>(INT16_MIN), 1},
+  };
+  for (const Case &c : cases) {
+    esi_system::SignResult r = connected->sign_probe(c.arg).get();
+    if (r.plus_one != c.plus_one || r.neg != c.neg ||
+        r.sign_bit != c.sign_bit)
+      throw std::runtime_error("sign_probe mismatch for arg=" +
+                               std::to_string(c.arg));
+  }
+  std::cout << "sign_probe ok\n";
+}
+
+static void runPackProbe(Accelerator *accel) {
+  esi_system::PackProbe mod(findProbe(accel, "pack_probe_inst"));
+  auto connected = mod.connect();
+
+  esi_system::PackStruct arg{};
+  arg.a = 0x01;
+  arg.b = 0x0002;
+  arg.c = 0x03;
+  arg.d = 0x00000004;
+
+  esi_system::PackStruct r = connected->pack_probe(arg).get();
+  if (r.a != 0xA1 || r.b != 0xB002 || r.c != 0xC3 || r.d != 0xD0000004)
+    throw std::runtime_error("pack_probe field mismatch");
+  std::cout << "pack_probe ok: a=0x" << std::hex << (unsigned)r.a << " b=0x"
+            << r.b << " c=0x" << (unsigned)r.c << " d=0x" << r.d << std::dec
+            << "\n";
+}
+
+static void runBitPackProbe(Accelerator *accel) {
+  esi_system::BitPackProbe mod(findProbe(accel, "bit_pack_probe_inst"));
+  auto connected = mod.connect();
+
+  esi_system::BitPackArg arg{};
+  // Distinct values within each width: x=001, y=10001, z=1001, w=1100. A
+  // shift error to a different field width would produce a value outside
+  // these picks.
+  arg.x = 0b001;
+  arg.y = 0b10001;
+  arg.z = 0b1001;
+  arg.w = 0b1100;
+
+  esi_system::BitPackResult r = connected->bit_pack_probe(arg).get();
+  if (r.w_field != arg.x || r.z_field != arg.y || r.y_field != arg.z ||
+      r.x_field != arg.w)
+    throw std::runtime_error("bit_pack_probe field rotation mismatch");
+  std::cout << "bit_pack_probe ok\n";
+}
+
+static void runArrayProbe(Accelerator *accel) {
+  // FIXME: bypass the generated facade for this probe.
+  // verifyTypeCompatibility<std::array<T,N>>() against an ArrayType is not
+  // implemented in the runtime today, so the generated facade's connect()
+  // throws "Cannot verify type compatibility for C++ type 'St5arrayIhLm4EE'".
+  // Once that gap is closed, switch this back to:
+  //   esi_system::ArrayProbe mod(findProbe(accel, "array_probe_inst"));
+  //   auto connected = mod.connect();
+  //   ... connected->array_probe(arg).get();
+  esi::HWModule *probe = findProbe(accel, "array_probe_inst");
+  auto it = probe->getPorts().find(AppID("array_probe"));
+  if (it == probe->getPorts().end())
+    throw std::runtime_error("array_probe port not found on instance");
+  auto *funcPort = it->second.getAs<services::FuncService::Function>();
+  if (!funcPort)
+    throw std::runtime_error("array_probe is not a FuncService::Function");
+  TypedFunction<std::array<uint8_t, 4>, std::array<uint8_t, 4>,
+                /*SkipTypeCheck=*/true>
+      array_probe(funcPort);
+  array_probe.connect();
+
+  std::array<uint8_t, 4> arg{1, 2, 3, 4};
+  std::array<uint8_t, 4> r = array_probe(arg).get();
+  if (r[0] != 11 || r[1] != 22 || r[2] != 33 || r[3] != 44)
+    throw std::runtime_error("array_probe element-order mismatch: got [" +
+                             std::to_string(r[0]) + "," +
+                             std::to_string(r[1]) + "," +
+                             std::to_string(r[2]) + "," +
+                             std::to_string(r[3]) + "]");
+  std::cout << "array_probe ok: [" << (int)r[0] << "," << (int)r[1] << ","
+            << (int)r[2] << "," << (int)r[3] << "]\n";
+}
+
+int main(int argc, const char *argv[]) {
+  CliParser cli("serialization-probes");
+  cli.description(
+      "Hardware-vs-host serialization correctness probes for ESI.");
+  if (int rc = cli.esiParse(argc, argv))
+    return rc;
+  if (!cli.get_help_ptr()->empty())
+    return 0;
+
+  Context &ctxt = cli.getContext();
+  AcceleratorConnection *conn = cli.connect();
+  try {
+    const auto &info = *conn->getService<services::SysInfo>();
+    Manifest manifest(ctxt, info.getJsonManifest());
+    Accelerator *accel = manifest.buildAccelerator(*conn);
+    conn->getServiceThread()->addPoll(*accel);
+
+    runByteRotate1(accel);
+    runBytePatternConst(accel);
+    runBytePatternEchoEq(accel);
+    runSignProbe(accel);
+    runPackProbe(accel);
+    runBitPackProbe(accel);
+    runArrayProbe(accel);
+
+    conn->disconnect();
+  } catch (std::exception &e) {
+    ctxt.getLogger().error("serialization-probes", e.what());
+    conn->disconnect();
+    return 1;
+  }
+  return 0;
+}

--- a/lib/Dialect/ESI/runtime/tests/integration/test_serialization_probes.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_serialization_probes.py
@@ -1,0 +1,102 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Pytest harness for the SerializationProbes integration test.
+
+This builds the C++ driver under ``sw/serialization_probes.cpp`` against
+generated ESI facade headers and runs it against a cosim-driven instance of
+``hw/serialization_probes.py``. Each probe asserts an exact, position-revealing
+result so any drift in the host serializer or deserializer (vs hardware)
+fails loudly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+from esiaccel.cosim.pytest import cosim_test
+
+from .conftest import (HW_DIR, SW_DIR, check_lines, get_runtime_root,
+                       require_tool)
+
+PROBES_EXPECTED = [
+    "byte_rotate1 ok",
+    "byte_pattern_const ok",
+    "byte_pattern_echo_eq ok",
+    "sign_probe ok",
+    "pack_probe ok",
+    "bit_pack_probe ok",
+    "array_probe ok",
+]
+
+
+@cosim_test(HW_DIR / "serialization_probes.py")
+class TestSerializationProbes:
+  """End-to-end serialization-correctness probes."""
+
+  def test_serialization_probes_cpp(self, tmp_path: Path, host: str, port: int,
+                                    sources_dir: Path) -> None:
+    require_tool("cmake")
+
+    runtime_root = get_runtime_root()
+
+    include_dir = tmp_path / "include"
+    generated_dir = include_dir / "serialization_probes"
+    generated_dir.mkdir(parents=True, exist_ok=True)
+
+    # Codegen was already run automatically by cosim_test; copy the generated
+    # headers into the per-test include tree.
+    codegen_src = sources_dir / "generated"
+    if codegen_src.exists():
+      for item in codegen_src.iterdir():
+        if item.is_file():
+          shutil.copy(item, generated_dir)
+
+    build_dir = tmp_path / "serialization_probes-build"
+    result = subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(SW_DIR),
+            "-B",
+            str(build_dir),
+            f"-DLOOPBACK_GENERATED_DIR={include_dir}",
+            f"-DESI_RUNTIME_ROOT={runtime_root}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"cmake configure failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}")
+
+    result = subprocess.run(
+        [
+            "cmake", "--build",
+            str(build_dir), "--target", "serialization_probes_test"
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"cmake build failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}")
+
+    result = subprocess.run(
+        [
+            str(build_dir / "serialization_probes_test"), "cosim",
+            f"{host}:{port}"
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"serialization_probes_test failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}")
+    check_lines(result.stdout, PROBES_EXPECTED)

--- a/lib/Dialect/ESI/runtime/tests/integration/test_serialization_probes.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_serialization_probes.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from pathlib import Path
 import shutil
 import subprocess
-import sys
 
 from esiaccel.cosim.pytest import cosim_test
 

--- a/lib/Dialect/ESI/runtime/tests/integration/test_serialization_probes.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_serialization_probes.py
@@ -27,6 +27,7 @@ PROBES_EXPECTED = [
     "byte_pattern_const ok",
     "byte_pattern_echo_eq ok",
     "sign_probe ok",
+    "sign_probe13 ok",
     "pack_probe ok",
     "bit_pack_probe ok",
     "array_probe ok",


### PR DESCRIPTION
These tests exercises the on-the-wire layout invariants of the ESI runtime
serializer/deserializer pair against a hardware implementation that is
deliberately picky about byte order, sign extension, struct field order,
sub-byte field packing, and array element order. Each function is small and
self-checking: the host sends a value with distinguishable bytes/fields/bits,
the hardware applies a position-revealing transform, and the host asserts
the exact expected bytes/fields/bits come back. A mismatch in any of those
five invariants between the host serializer and the hardware wire format
yields a wrong (rather than coincidentally correct) answer.

Assisted-by: vscode:Claude Opus 4.7
