### PR TITLE
[Sim] Add sim.fmt.current_time for printing simulation time

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -485,6 +485,17 @@ def FormatCharOp : SimOp<"fmt.char",
   let assemblyFormat = "$value attr-dict `:` qualified(type($value))";
 }
 
+def FormatTimeOp : SimOp<"fmt.time", [Pure]> {
+  let summary = "Simulation time format specifier";
+  let description = [{
+    Format string fragment that resolves to the current simulation time when
+    printed. This corresponds to the `%0t` format specifier paired with the
+    current simulation time in SystemVerilog.
+  }];
+  let results = (outs FormatStringType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
 def FormatHierPathOp : SimOp<"fmt.hier_path", [Pure]> {
   let summary = "Hierarchical path format specifier";
   let description = [{

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -485,12 +485,11 @@ def FormatCharOp : SimOp<"fmt.char",
   let assemblyFormat = "$value attr-dict `:` qualified(type($value))";
 }
 
-def FormatTimeOp : SimOp<"fmt.time", [Pure]> {
+def FormatCurrentTimeOp : SimOp<"fmt.current_time", [Pure]> {
   let summary = "Simulation time format specifier";
   let description = [{
     Format string fragment that resolves to the current simulation time when
-    printed. This corresponds to the `%0t` format specifier paired with the
-    current simulation time in SystemVerilog.
+    printed. The textual representation is implementation defined.
   }];
   let results = (outs FormatStringType:$result);
   let assemblyFormat = "attr-dict";

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -594,6 +594,11 @@ LogicalResult appendFormatFragmentToSVFormat(Value fragment,
         appendLiteralToSVFormat(formatString, literal.getLiteral());
         return success();
       })
+      .Case<FormatTimeOp>([&](auto fmt) -> LogicalResult {
+        formatString += "%0t";
+        args.push_back(sv::TimeOp::create(builder, fmt.getLoc()));
+        return success();
+      })
       .Case<FormatHierPathOp>([&](auto hierPath) -> LogicalResult {
         formatString += hierPath.getUseEscapes() ? "%M" : "%m";
         return success();

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -594,7 +594,7 @@ LogicalResult appendFormatFragmentToSVFormat(Value fragment,
         appendLiteralToSVFormat(formatString, literal.getLiteral());
         return success();
       })
-      .Case<FormatTimeOp>([&](auto fmt) -> LogicalResult {
+      .Case<FormatCurrentTimeOp>([&](auto fmt) -> LogicalResult {
         formatString += "%0t";
         args.push_back(sv::TimeOp::create(builder, fmt.getLoc()));
         return success();

--- a/lib/Dialect/Sim/Transforms/ProceduralizeSim.cpp
+++ b/lib/Dialect/Sim/Transforms/ProceduralizeSim.cpp
@@ -64,11 +64,10 @@ static LogicalResult collectFormatStringFragments(
     fragmentList.push_back(fmtOp);
     allFStringFragments.insert(fmtOp);
 
-    // For non-literal fragments, the value to be formatted has to become a
-    // triggered region argument.
-    if (!llvm::isa<FormatLiteralOp>(fmtOp)) {
-      auto fmtVal = getFormattedValue(fmtOp);
-      assert(!!fmtVal && "Unexpected formatting fragment op.");
+    // Value formatter fragments have to carry their formatted value into the
+    // triggered region. Contextual fragments such as sim.fmt.time or
+    // sim.fmt.hier_path do not require an extra argument.
+    if (auto fmtVal = getFormattedValue(fmtOp)) {
       arguments.insert(fmtVal);
     }
   }

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
@@ -45,7 +45,7 @@ hw.module @all_format_fragments(
     %i7 = sim.fmt.literal " gen="
     %f7 = sim.fmt.gen %fval_in fracDigits 4 : f64
     %i8 = sim.fmt.literal " time="
-    %f8 = sim.fmt.time
+    %f8 = sim.fmt.current_time
     %i9 = sim.fmt.literal " path="
     %f9 = sim.fmt.hier_path
     %i10 = sim.fmt.literal " esc="

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
@@ -44,16 +44,19 @@ hw.module @all_format_fragments(
     %f6 = sim.fmt.flt %fval_in isLeftAligned true fieldWidth 8 fracDigits 2 : f64
     %i7 = sim.fmt.literal " gen="
     %f7 = sim.fmt.gen %fval_in fracDigits 4 : f64
-    %i8 = sim.fmt.literal " path="
-    %f8 = sim.fmt.hier_path
-    %i9 = sim.fmt.literal " esc="
-    %f9 = sim.fmt.hier_path escaped
-    %i10 = sim.fmt.literal " pct=%"
-    %msg = sim.fmt.concat (%i0, %f0, %i1, %f1, %i2, %f2, %i3, %f3, %i4, %f4, %i5, %f5, %i6, %f6, %i7, %f7, %i8, %f8, %i9, %f9, %i10)
+    %i8 = sim.fmt.literal " time="
+    %f8 = sim.fmt.time
+    %i9 = sim.fmt.literal " path="
+    %f9 = sim.fmt.hier_path
+    %i10 = sim.fmt.literal " esc="
+    %f10 = sim.fmt.hier_path escaped
+    %i11 = sim.fmt.literal " pct=%"
+    %msg = sim.fmt.concat (%i0, %f0, %i1, %f1, %i2, %f2, %i3, %f3, %i4, %f4, %i5, %f5, %i6, %f6, %i7, %f7, %i8, %f8, %i9, %f9, %i10, %f10, %i11)
 
     // CHECK: ^bb0(%[[IVAL:.+]]: i16, %[[CH:.+]]: i8, %[[FVAL:.+]]: f64):
     // CHECK-NEXT: %[[SIGNED:.+]] = sv.system "signed"(%[[IVAL]]) : (i16) -> i16
-    // CHECK-NEXT: sv.write "dec=%6d hex=%04X oct=%-06o bin=%8b char=%c exp=%10.3e flt=%-8.2f gen=%.4g path=%m esc=%M pct=%%"(%[[SIGNED]], %[[IVAL]], %[[IVAL]], %[[IVAL]], %[[CH]], %[[FVAL]], %[[FVAL]], %[[FVAL]]) : i16, i16, i16, i16, i8, f64, f64, f64
+    // CHECK-NEXT: %[[TIME:.+]] = sv.system.time : i64
+    // CHECK-NEXT: sv.write "dec=%6d hex=%04X oct=%-06o bin=%8b char=%c exp=%10.3e flt=%-8.2f gen=%.4g time=%0t path=%m esc=%M pct=%%"(%[[SIGNED]], %[[IVAL]], %[[IVAL]], %[[IVAL]], %[[CH]], %[[FVAL]], %[[FVAL]], %[[FVAL]], %[[TIME]]) : i16, i16, i16, i16, i8, f64, f64, f64, i64
     sim.proc.print %msg
   }
 }

--- a/test/Dialect/Sim/proceduralize-sim.mlir
+++ b/test/Dialect/Sim/proceduralize-sim.mlir
@@ -111,7 +111,7 @@ hw.module @basic_real_print(in %clk : !seq.clock, in %val : f64) {
 // CHECK-NEXT:  %[[TRG:.*]] = seq.from_clock %clk
 // CHECK-NEXT:  hw.triggered posedge %[[TRG]] {
 // CHECK-DAG:      %[[L0:.*]] = sim.fmt.literal "t="
-// CHECK-DAG:      %[[T:.*]] = sim.fmt.time
+// CHECK-DAG:      %[[T:.*]] = sim.fmt.current_time
 // CHECK-DAG:      %[[L1:.*]] = sim.fmt.literal " p="
 // CHECK-DAG:      %[[P:.*]] = sim.fmt.hier_path
 // CHECK-DAG:      %[[CAT:.*]] = sim.fmt.concat (%[[L0]], %[[T]], %[[L1]], %[[P]])
@@ -120,7 +120,7 @@ hw.module @basic_real_print(in %clk : !seq.clock, in %val : f64) {
 hw.module @contextual_fragments(in %clk : !seq.clock) {
   %true = hw.constant true
   %l0 = sim.fmt.literal "t="
-  %t = sim.fmt.time
+  %t = sim.fmt.current_time
   %l1 = sim.fmt.literal " p="
   %p = sim.fmt.hier_path
   %cat = sim.fmt.concat (%l0, %t, %l1, %p)

--- a/test/Dialect/Sim/proceduralize-sim.mlir
+++ b/test/Dialect/Sim/proceduralize-sim.mlir
@@ -107,6 +107,26 @@ hw.module @basic_real_print(in %clk : !seq.clock, in %val : f64) {
   sim.print %cat on %clk if %true
 }
 
+// CHECK-LABEL: @contextual_fragments
+// CHECK-NEXT:  %[[TRG:.*]] = seq.from_clock %clk
+// CHECK-NEXT:  hw.triggered posedge %[[TRG]] {
+// CHECK-DAG:      %[[L0:.*]] = sim.fmt.literal "t="
+// CHECK-DAG:      %[[T:.*]] = sim.fmt.time
+// CHECK-DAG:      %[[L1:.*]] = sim.fmt.literal " p="
+// CHECK-DAG:      %[[P:.*]] = sim.fmt.hier_path
+// CHECK-DAG:      %[[CAT:.*]] = sim.fmt.concat (%[[L0]], %[[T]], %[[L1]], %[[P]])
+// CHECK:          sim.proc.print %[[CAT]]
+// CHECK-NEXT:   }
+hw.module @contextual_fragments(in %clk : !seq.clock) {
+  %true = hw.constant true
+  %l0 = sim.fmt.literal "t="
+  %t = sim.fmt.time
+  %l1 = sim.fmt.literal " p="
+  %p = sim.fmt.hier_path
+  %cat = sim.fmt.concat (%l0, %t, %l1, %p)
+  sim.print %cat on %clk if %true
+}
+
 // CHECK-LABEL: @multi_args
 // CHECK-NEXT:  %[[TRG:.*]] = seq.from_clock %clk
 // CHECK-NEXT:  hw.triggered posedge %0(%a, %b, %c) : i8, i8, i8 {

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -80,6 +80,8 @@ func.func @SimulationControl() {
 
 // CHECK-LABEL: func.func @FormatStrings
 func.func @FormatStrings() {
+  // CHECK: sim.fmt.time
+  sim.fmt.time
   // CHECK: sim.fmt.hier_path
   sim.fmt.hier_path
   // CHECK: sim.fmt.hier_path escaped

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -80,8 +80,8 @@ func.func @SimulationControl() {
 
 // CHECK-LABEL: func.func @FormatStrings
 func.func @FormatStrings() {
-  // CHECK: sim.fmt.time
-  sim.fmt.time
+  // CHECK: sim.fmt.current_time
+  sim.fmt.current_time
   // CHECK: sim.fmt.hier_path
   sim.fmt.hier_path
   // CHECK: sim.fmt.hier_path escaped


### PR DESCRIPTION
Assisted-by: Codex: GPT-5.4

Add sim.fmt.time for printing simulation time
