### PR TITLE
[LTL] Add fold and canonicalization patterns for ClockedDelayOp

### DIFF
--- a/docs/Dialects/LTL.md
+++ b/docs/Dialects/LTL.md
@@ -160,6 +160,32 @@ Sequence and property expressions in SVAs can specify a clock with respect to wh
 - `@(negedge clk) seqOrProp`. **Trigger on high-to-low clock edge.** Equivalent to `ltl.clock %seqOrProp, negedge %clk`.
 - `@(edge clk) seqOrProp`. **Trigger on any clock edge.** Equivalent to `ltl.clock %seqOrProp, edge %clk`.
 
+#### Delay clocking
+
+`ltl.delay` takes the delayed input first, followed by the delay window:
+
+```
+ltl.delay %input, <delay>[, <length>]
+```
+
+For explicitly clocked delays, use `ltl.clocked_delay`:
+
+```
+ltl.clocked_delay %input, <edge> %clock, <delay>[, <length>]
+```
+
+`%clock` is an `i1` value (e.g. a module clock); `<edge>` is `posedge`, `negedge`, or `edge`. For example, `ltl.clocked_delay %s, posedge %clk, 3` means `%s` must hold 3 cycles later on `%clk` rising edges.
+
+`ltl.delay` is unclocked and may be resolved by an enclosing `ltl.clock` or by the `InferLTLClocks` pass. `ltl.clock` globally associates a sequence/property with a clock/edge; `ltl.clocked_delay` carries an explicit per-delay clock.
+
+Examples:
+
+```mlir
+ltl.delay %s, 3
+ltl.delay %s, 3, 0
+ltl.clocked_delay %s, posedge %clk, 3, 0
+```
+
 
 ### Disable Iff
 

--- a/include/circt/Dialect/LTL/LTLFolds.td
+++ b/include/circt/Dialect/LTL/LTLFolds.td
@@ -21,6 +21,10 @@ def valueTail : NativeCodeCall<"$0.drop_front()">;
 def concatValues : NativeCodeCall<
   "concatValues(ValueRange{$0}, ValueRange{$1})">;
 
+// Ensure that outer and inner clocked delays use the same clock and edge
+// before merging. Accepts (outerClock, innerClock, outerEdge, innerEdge).
+def SameClockAndEdge : Constraint<CPred<"$0 == $1 && $2 == $3">>;
+
 //===----------------------------------------------------------------------===//
 // DelayOp
 //===----------------------------------------------------------------------===//
@@ -44,6 +48,27 @@ def NestedDelays : Pat<
 def MoveDelayIntoConcat : Pat<
   (DelayOp (ConcatOp $inputs), $delay, $length),
   (ConcatOp (concatValues (DelayOp (valueHead $inputs), $delay, $length),
+                          (valueTail $inputs)))>;
+
+//===----------------------------------------------------------------------===//
+// ClockedDelayOp
+//===----------------------------------------------------------------------===//
+
+// clocked_delay(clocked_delay(s, edge clk, I, N), edge clk, J, M)
+//   -> clocked_delay(s, edge clk, I+J, N+M)
+def NestedClockedDelays : Pat<
+  (ClockedDelayOp (ClockedDelayOp $input, $edge0, $clock0, $delay0, $length0),
+                  $edge1, $clock1, $delay1, $length1),
+  (ClockedDelayOp $input, $edge0, $clock0, (mergedDelays $delay0, $delay1),
+                  (mergedLengths $length0, $length1)),
+  [(SameClockAndEdge $clock0, $clock1, $edge0, $edge1)]>;
+
+// clocked_delay(concat(s, ...), edge clk, N, M)
+//   -> concat(clocked_delay(s, edge clk, N, M), ...)
+def MoveClockedDelayIntoConcat : Pat<
+  (ClockedDelayOp (ConcatOp $inputs), $edge, $clock, $delay, $length),
+  (ConcatOp (concatValues (ClockedDelayOp (valueHead $inputs), $edge, $clock,
+                                         $delay, $length),
                           (valueTail $inputs)))>;
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/LTL/LTLOps.td
+++ b/include/circt/Dialect/LTL/LTLOps.td
@@ -158,6 +158,8 @@ def ClockedDelayOp : LTLOp<"clocked_delay", [Pure]> {
   let assemblyFormat = [{
     $input `,` $edge $clock `,` $delay (`,` $length^)? attr-dict `:` type($input)
   }];
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 
   let summary = "Delay a sequence by a number of cycles on an explicit clock.";
   let description = [{

--- a/lib/Dialect/LTL/LTLFolds.cpp
+++ b/lib/Dialect/LTL/LTLFolds.cpp
@@ -95,6 +95,25 @@ void DelayOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 //===----------------------------------------------------------------------===//
+// ClockedDelayOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ClockedDelayOp::fold(FoldAdaptor adaptor) {
+  // clocked_delay(s, edge clk, 0, 0) -> s
+  if (adaptor.getDelay() == 0 && adaptor.getLength() == 0 &&
+      isa<SequenceType>(getInput().getType()))
+    return getInput();
+
+  return {};
+}
+
+void ClockedDelayOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                                 MLIRContext *context) {
+  results.add<patterns::NestedClockedDelays>(results.getContext());
+  results.add<patterns::MoveClockedDelayIntoConcat>(results.getContext());
+}
+
+//===----------------------------------------------------------------------===//
 // ConcatOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/LTL/basic.mlir
+++ b/test/Dialect/LTL/basic.mlir
@@ -2,6 +2,7 @@
 
 %true = hw.constant true
 %c0_i8 = hw.constant 0 : i8
+%clk = hw.constant true
 
 //===----------------------------------------------------------------------===//
 // Types
@@ -53,8 +54,12 @@ unrealized_conversion_cast %p3 : !ltl.property to index
 
 // CHECK: ltl.delay {{%.+}}, 0 : !ltl.sequence
 // CHECK: ltl.delay {{%.+}}, 42, 1337 : !ltl.sequence
+// CHECK: ltl.clocked_delay {{%.+}}, posedge {{%.+}}, 0 : !ltl.sequence
+// CHECK: ltl.clocked_delay {{%.+}}, posedge {{%.+}}, 42, 1337 : !ltl.sequence
 ltl.delay %s, 0 : !ltl.sequence
 ltl.delay %s, 42, 1337 : !ltl.sequence
+ltl.clocked_delay %s, posedge %clk, 0 : !ltl.sequence
+ltl.clocked_delay %s, posedge %clk, 42, 1337 : !ltl.sequence
 
 // CHECK: ltl.concat {{%.+}} : !ltl.sequence
 // CHECK: ltl.concat {{%.+}}, {{%.+}} : !ltl.sequence, !ltl.sequence

--- a/test/Dialect/LTL/canonicalization.mlir
+++ b/test/Dialect/LTL/canonicalization.mlir
@@ -64,6 +64,97 @@ func.func @DelayFolds(%arg0: !ltl.sequence, %arg1: i1) {
   return
 }
 
+// CHECK-LABEL: @ClockedDelayFolds
+// CHECK-SAME: (%[[S:.+]]: !ltl.sequence, %[[I:.+]]: i1, %[[CLK:.+]]: i1)
+func.func @ClockedDelayFolds(%arg0: !ltl.sequence, %arg1: i1, %clk: i1) {
+  // clocked_delay(seq, posedge clk, 0, 0) -> seq
+  // clocked_delay(i1, posedge clk, 0, 0) stays because it converts i1 to sequence.
+  // CHECK-NEXT: %[[D:.+]] = ltl.clocked_delay %[[I]], posedge %[[CLK]], 0, 0 : i1
+  // CHECK-NEXT: call @Seq(%[[S]])
+  // CHECK-NEXT: call @Seq(%[[D]])
+  %0 = ltl.clocked_delay %arg0, posedge %clk, 0, 0 : !ltl.sequence
+  %n0 = ltl.clocked_delay %arg1, posedge %clk, 0, 0 : i1
+  call @Seq(%0) : (!ltl.sequence) -> ()
+  call @Seq(%n0) : (!ltl.sequence) -> ()
+
+  // Nested clocked delays with same clock/edge: merge delays
+  // clocked_delay(clocked_delay(s, posedge clk, 1), posedge clk, 2)
+  //   -> clocked_delay(s, posedge clk, 3)
+  // CHECK-NEXT: %[[D:.+]] = ltl.clocked_delay %[[S]], posedge %[[CLK]], 3 :
+  // CHECK-NEXT: call @Seq(%[[D]])
+  %1 = ltl.clocked_delay %arg0, posedge %clk, 1 : !ltl.sequence
+  %2 = ltl.clocked_delay %1, posedge %clk, 2 : !ltl.sequence
+  call @Seq(%2) : (!ltl.sequence) -> ()
+
+  // Inner has length, outer does not: length dropped
+  // clocked_delay(clocked_delay(s, posedge clk, 1, 42), posedge clk, 2)
+  //   -> clocked_delay(s, posedge clk, 3)
+  // CHECK-NEXT: %[[D:.+]] = ltl.clocked_delay %[[S]], posedge %[[CLK]], 3 :
+  // CHECK-NEXT: call @Seq(%[[D]])
+  %3 = ltl.clocked_delay %arg0, posedge %clk, 1, 42 : !ltl.sequence
+  %4 = ltl.clocked_delay %3, posedge %clk, 2 : !ltl.sequence
+  call @Seq(%4) : (!ltl.sequence) -> ()
+
+  // Outer has length, inner does not: length dropped
+  // clocked_delay(clocked_delay(s, posedge clk, 1), posedge clk, 2, 5)
+  //   -> clocked_delay(s, posedge clk, 3)
+  // CHECK-NEXT: %[[D:.+]] = ltl.clocked_delay %[[S]], posedge %[[CLK]], 3 :
+  // CHECK-NEXT: call @Seq(%[[D]])
+  %5 = ltl.clocked_delay %arg0, posedge %clk, 1 : !ltl.sequence
+  %6 = ltl.clocked_delay %5, posedge %clk, 2, 5 : !ltl.sequence
+  call @Seq(%6) : (!ltl.sequence) -> ()
+
+  // Both have length: lengths merged
+  // clocked_delay(clocked_delay(s, posedge clk, 1, 2), posedge clk, 3, 5)
+  //   -> clocked_delay(s, posedge clk, 4, 7)
+  // CHECK-NEXT: %[[D:.+]] = ltl.clocked_delay %[[S]], posedge %[[CLK]], 4, 7 :
+  // CHECK-NEXT: call @Seq(%[[D]])
+  %7 = ltl.clocked_delay %arg0, posedge %clk, 1, 2 : !ltl.sequence
+  %8 = ltl.clocked_delay %7, posedge %clk, 3, 5 : !ltl.sequence
+  call @Seq(%8) : (!ltl.sequence) -> ()
+
+  // Both have length, outer length is 0: no drop
+  // clocked_delay(clocked_delay(s, posedge clk, 1, 2), posedge clk, 3, 0)
+  //   -> clocked_delay(s, posedge clk, 4, 2)
+  // CHECK-NEXT: %[[D:.+]] = ltl.clocked_delay %[[S]], posedge %[[CLK]], 4, 2 :
+  // CHECK-NEXT: call @Seq(%[[D]])
+  %9 = ltl.clocked_delay %arg0, posedge %clk, 1, 2 : !ltl.sequence
+  %10 = ltl.clocked_delay %9, posedge %clk, 3, 0 : !ltl.sequence
+  call @Seq(%10) : (!ltl.sequence) -> ()
+
+  // Different edge: should NOT merge
+  // CHECK-NEXT: %[[D1:.+]] = ltl.clocked_delay %[[S]], posedge %[[CLK]], 1 :
+  // CHECK-NEXT: %[[D2:.+]] = ltl.clocked_delay %[[D1]], negedge %[[CLK]], 2 :
+  // CHECK-NEXT: call @Seq(%[[D2]])
+  %11 = ltl.clocked_delay %arg0, posedge %clk, 1 : !ltl.sequence
+  %12 = ltl.clocked_delay %11, negedge %clk, 2 : !ltl.sequence
+  call @Seq(%12) : (!ltl.sequence) -> ()
+
+  // Different clock: should NOT merge
+  // CHECK-NEXT: %[[D1:.+]] = ltl.clocked_delay %[[S]], posedge %[[CLK]], 1 :
+  // CHECK-NEXT: %[[D2:.+]] = ltl.clocked_delay %[[D1]], posedge %[[I]], 2 :
+  // CHECK-NEXT: call @Seq(%[[D2]])
+  %13 = ltl.clocked_delay %arg0, posedge %clk, 1 : !ltl.sequence
+  %14 = ltl.clocked_delay %13, posedge %arg1, 2 : !ltl.sequence
+  call @Seq(%14) : (!ltl.sequence) -> ()
+
+  return
+}
+
+// CHECK-LABEL: @ClockedDelayIntoConcatFolds
+// CHECK-SAME: (%[[S0:.+]]: !ltl.sequence, %[[S1:.+]]: !ltl.sequence, %[[CLK:.+]]: i1)
+func.func @ClockedDelayIntoConcatFolds(%arg0: !ltl.sequence, %arg1: !ltl.sequence, %clk: i1) {
+  // clocked_delay(concat(s0, s1), posedge clk, N, M)
+  //   -> concat(clocked_delay(s0, posedge clk, N, M), s1)
+  // CHECK-NEXT: %[[DELAYED:.+]] = ltl.clocked_delay %[[S0]], posedge %[[CLK]], 2, 3 :
+  // CHECK-NEXT: %[[CONCAT:.+]] = ltl.concat %[[DELAYED]], %[[S1]] :
+  // CHECK-NEXT: call @Seq(%[[CONCAT]])
+  %0 = ltl.concat %arg0, %arg1 : !ltl.sequence, !ltl.sequence
+  %1 = ltl.clocked_delay %0, posedge %clk, 2, 3 : !ltl.sequence
+  call @Seq(%1) : (!ltl.sequence) -> ()
+  return
+}
+
 // CHECK-LABEL: @ConcatFolds
 func.func @ConcatFolds(%arg0: !ltl.sequence, %arg1: !ltl.sequence, %arg2: !ltl.sequence) {
   // concat(s) -> s


### PR DESCRIPTION
This PR is a follow-up to #10415 and add fold and canonicalization patterns for ClockedDelayOp.

Assisted-by: Claude Code:claude-opus-4.6