### PR TITLE
[circt-synth] Register datapath dialect

### DIFF
--- a/test/circt-synth/datapath.mlir
+++ b/test/circt-synth/datapath.mlir
@@ -7,3 +7,10 @@ hw.module @arith(in %a: i4, in %b: i4, in %c: i4, out add: i4, out mul: i4) {
   %1 = comb.mul %a, %b : i4
   hw.output %0, %1 : i4, i4
 }
+
+// CHECK-LABEL: @datapath_passthrough
+hw.module @datapath_passthrough(in %a: i4, in %b: i4, in %c: i4,
+                                out out0: i4, out out1: i4) {
+  %0:2 = datapath.compress %a, %b, %c : i4 [3 -> 2]
+  hw.output %0#0, %0#1 : i4, i4
+}

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/Comb/CombPasses.h"
+#include "circt/Dialect/Datapath/DatapathDialect.h"
 #include "circt/Dialect/Debug/DebugDialect.h"
 #include "circt/Dialect/Emit/EmitDialect.h"
 #include "circt/Dialect/HW/HWDialect.h"
@@ -496,10 +497,11 @@ int main(int argc, char **argv) {
 
   // Register the supported CIRCT dialects and create a context to work with.
   DialectRegistry registry;
-  registry.insert<comb::CombDialect, debug::DebugDialect, emit::EmitDialect,
-                  hw::HWDialect, ltl::LTLDialect, om::OMDialect,
-                  seq::SeqDialect, sim::SimDialect, synth::SynthDialect,
-                  sv::SVDialect, verif::VerifDialect>();
+  registry
+      .insert<comb::CombDialect, datapath::DatapathDialect, debug::DebugDialect,
+              emit::EmitDialect, hw::HWDialect, ltl::LTLDialect, om::OMDialect,
+              seq::SeqDialect, sim::SimDialect, synth::SynthDialect,
+              sv::SVDialect, verif::VerifDialect>();
   MLIRContext context(registry);
   if (allowUnregisteredDialects)
     context.allowUnregisteredDialects();


### PR DESCRIPTION
Explicitly register the Datapath dialect in circt-synth to enable parsing of datapath operations. This is NFC beyond input parsing, as the pipeline already depends on the dialect.
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
