### PR TITLE
[OM] Fix unsafe cast in OM class op verifier, fix up unverified unit tests, NFC

### DIFF
--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -355,11 +355,11 @@ LogicalResult circt::om::ClassOp::verifyRegions() {
   for (auto [fieldName, terminatorOperandType] :
        llvm::zip(this->getFieldNames(), fieldsOp.getOperandTypes())) {
 
-    if (!llvm::isa_and_nonnull<StringAttr>(fieldName))
+    auto fieldNameAttr = dyn_cast_or_null<StringAttr>(fieldName);
+    if (!fieldNameAttr)
       return this->emitOpError("field name is not a StringAttr");
 
-    if (auto fieldType =
-            getClassLikeFieldType(*this, cast<StringAttr>(fieldName)))
+    if (auto fieldType = getClassLikeFieldType(*this, fieldNameAttr))
       if (*fieldType == terminatorOperandType)
         continue;
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -277,9 +277,9 @@ std::optional<Type> getClassLikeFieldType(ClassLike classLike,
   DictionaryAttr fieldTypes = mlir::cast<DictionaryAttr>(
       classLike.getOperation()->getAttr("fieldTypes"));
   Attribute type = fieldTypes.get(name);
-  if (!type)
-    return std::nullopt;
-  return cast<TypeAttr>(type).getValue();
+  if (auto field = dyn_cast_or_null<TypeAttr>(type))
+    return field.getValue();
+  return std::nullopt;
 }
 
 void replaceClassLikeFieldTypes(ClassLike classLike,
@@ -336,7 +336,10 @@ void circt::om::ClassOp::print(OpAsmPrinter &printer) {
 LogicalResult circt::om::ClassOp::verify() { return verifyClassLike(*this); }
 
 LogicalResult circt::om::ClassOp::verifyRegions() {
-  auto fieldsOp = cast<ClassFieldsOp>(this->getBodyBlock()->getTerminator());
+  auto fieldsOp =
+      dyn_cast_or_null<ClassFieldsOp>(this->getBodyBlock()->getTerminator());
+  if (!fieldsOp)
+    return this->emitOpError("expected terminator to be ClassFieldsOp");
 
   // The number of results matches the number of terminator operands.
   if (fieldsOp.getNumOperands() != this->getFieldNames().size()) {
@@ -352,9 +355,13 @@ LogicalResult circt::om::ClassOp::verifyRegions() {
   for (auto [fieldName, terminatorOperandType] :
        llvm::zip(this->getFieldNames(), fieldsOp.getOperandTypes())) {
 
-    if (terminatorOperandType ==
-        cast<TypeAttr>(types.get(cast<StringAttr>(fieldName))).getValue())
-      continue;
+    if (!llvm::isa_and_nonnull<StringAttr>(fieldName))
+      return this->emitOpError("field name is not a StringAttr");
+
+    if (auto fieldType =
+            getClassLikeFieldType(*this, cast<StringAttr>(fieldName)))
+      if (*fieldType == terminatorOperandType)
+        continue;
 
     auto diag = this->emitOpError()
                 << "returns different field types than its terminator";

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -70,8 +70,10 @@ TEST(EvaluatorTests, InstantiateInvalidParamSize) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   auto cls = ClassOp::create(builder, "MyClass", params);
-  cls.getBody().emplaceBlock().addArgument(
-      circt::om::OMIntegerType::get(&context), cls.getLoc());
+  auto &body = cls.getBody().emplaceBlock();
+  body.addArgument(circt::om::OMIntegerType::get(&context), cls.getLoc());
+  builder.setInsertionPointToStart(&body);
+  ClassFieldsOp::create(builder, loc, ValueRange{}, ArrayAttr{});
 
   Evaluator evaluator(mod);
 
@@ -103,8 +105,10 @@ TEST(EvaluatorTests, InstantiateNullParam) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   auto cls = ClassOp::create(builder, "MyClass", params);
-  cls.getBody().emplaceBlock().addArgument(
-      circt::om::OMIntegerType::get(&context), cls.getLoc());
+  auto &body = cls.getBody().emplaceBlock();
+  body.addArgument(circt::om::OMIntegerType::get(&context), cls.getLoc());
+  builder.setInsertionPointToStart(&body);
+  ClassFieldsOp::create(builder, loc, ValueRange{}, ArrayAttr{});
 
   Evaluator evaluator(mod);
 
@@ -134,8 +138,10 @@ TEST(EvaluatorTests, InstantiateInvalidParamType) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   auto cls = ClassOp::create(builder, "MyClass", params);
-  cls.getBody().emplaceBlock().addArgument(
-      circt::om::OMIntegerType::get(&context), cls.getLoc());
+  auto &body = cls.getBody().emplaceBlock();
+  body.addArgument(circt::om::OMIntegerType::get(&context), cls.getLoc());
+  builder.setInsertionPointToStart(&body);
+  ClassFieldsOp::create(builder, loc, ValueRange{}, ArrayAttr{});
 
   Evaluator evaluator(mod);
 
@@ -247,7 +253,9 @@ TEST(EvaluatorTests, InstantiateObjectWithConstantField) {
   auto cls = ClassOp::create(
       builder, "MyClass", builder.getStrArrayAttr({"field"}),
       builder.getDictionaryAttr({
-          NamedAttribute(builder.getStringAttr("field"), constantType),
+          NamedAttribute(builder.getStringAttr("field"),
+                         TypeAttr::get(circt::om::OMIntegerType::get(
+                             builder.getContext()))),
 
       }));
   auto &body = cls.getBody().emplaceBlock();
@@ -355,20 +363,21 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
                                               params, fields, types);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
-  auto innerType = TypeAttr::get(ClassType::get(
-      builder.getContext(), mlir::FlatSymbolRefAttr::get(innerCls)));
   auto cls = ClassOp::create(
       builder, "MyClass", params, builder.getStrArrayAttr({"field"}),
       builder.getDictionaryAttr({
-          NamedAttribute(builder.getStringAttr("field"), innerType),
+          NamedAttribute(builder.getStringAttr("field"),
+                         TypeAttr::get(circt::om::OMIntegerType::get(
+                             builder.getContext()))),
 
       }));
   auto &body = cls.getBody().emplaceBlock();
   body.addArgument(circt::om::OMIntegerType::get(&context), cls.getLoc());
   builder.setInsertionPointToStart(&body);
   auto object = ObjectOp::create(builder, innerCls, body.getArguments());
-  auto field = ObjectFieldOp::create(builder, builder.getI32Type(), object,
-                                     builder.getStringAttr("field"));
+  auto field =
+      ObjectFieldOp::create(builder, circt::om::OMIntegerType::get(&context),
+                            object, builder.getStringAttr("field"));
   ClassFieldsOp::create(builder, loc, ValueRange{field}, ArrayAttr{});
 
   Evaluator evaluator(mod);
@@ -483,14 +492,13 @@ TEST(EvaluatorTests, AnyCastObject) {
                         ArrayAttr{});
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
-  auto innerType = TypeAttr::get(ClassType::get(
-      builder.getContext(), mlir::FlatSymbolRefAttr::get(innerCls)));
-  auto cls = ClassOp::create(
-      builder, "MyClass", builder.getStrArrayAttr({"field"}),
-      builder.getDictionaryAttr({
-          NamedAttribute(builder.getStringAttr("field"), innerType),
+  auto cls =
+      ClassOp::create(builder, "MyClass", builder.getStrArrayAttr({"field"}),
+                      builder.getDictionaryAttr({
+                          NamedAttribute(builder.getStringAttr("field"),
+                                         TypeAttr::get(AnyType::get(&context))),
 
-      }));
+                      }));
   auto &body = cls.getBody().emplaceBlock();
   builder.setInsertionPointToStart(&body);
   auto object = ObjectOp::create(builder, innerCls, body.getArguments());


### PR DESCRIPTION
This update improves the OM class operation verifier so that it no longer crashes during verification (at least for ill-formed IR we had in unittests). It also corrects several test cases in unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp that previously failed the verifier.


<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
