### PR TITLE
[OM] Fix an unused variable warning

### DIFF
--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -360,7 +360,7 @@ LogicalResult circt::om::ClassOp::verifyRegions() {
       return this->emitOpError("field name is not a StringAttr");
 
     if (auto fieldType = types.get(fieldNameAttr))
-      if (auto typeAttr = dyn_cast_or_null<TypeAttr>(fieldType))
+      if (auto typeAttr = dyn_cast<TypeAttr>(fieldType))
         if (typeAttr.getValue() == terminatorOperandType)
           continue;
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -359,9 +359,10 @@ LogicalResult circt::om::ClassOp::verifyRegions() {
     if (!fieldNameAttr)
       return this->emitOpError("field name is not a StringAttr");
 
-    if (auto fieldType = getClassLikeFieldType(*this, fieldNameAttr))
-      if (*fieldType == terminatorOperandType)
-        continue;
+    if (auto fieldType = types.get(fieldNameAttr))
+      if (auto typeAttr = dyn_cast_or_null<TypeAttr>(fieldType))
+        if (typeAttr.getValue() == terminatorOperandType)
+          continue;
 
     auto diag = this->emitOpError()
                 << "returns different field types than its terminator";


### PR DESCRIPTION
This partially reverts a change in ed0d9cc5534e which replaced `types` with `getClassLikeFieldType`. It's better to keep using `types` since it avoids a dictionary attr lookup. 
   
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
