### PR TITLE
[OM] Support evaluated object evaluator flow

### DIFF
--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -421,6 +421,10 @@ private:
       value->setFullyEvaluatedCounter(&fullyEvaluatedCount);
   }
 
+  FailureOr<evaluator::EvaluatorValuePtr>
+  instantiateImpl(StringAttr className,
+                  ArrayRef<EvaluatorValuePtr> actualParams);
+
   FailureOr<EvaluatorValuePtr>
   getOrCreateValue(Value value, ActualParameters actualParams, Location loc);
   FailureOr<EvaluatorValuePtr>
@@ -446,6 +450,9 @@ private:
                          Location loc, ObjectKey instanceKey = {});
   FailureOr<EvaluatorValuePtr>
   evaluateObjectInstance(ObjectOp op, ActualParameters actualParams);
+  FailureOr<EvaluatorValuePtr>
+  evaluateElaboratedObject(ElaboratedObjectOp op, ActualParameters actualParams,
+                           Location loc);
   FailureOr<EvaluatorValuePtr>
   evaluateObjectField(ObjectFieldOp op, ActualParameters actualParams,
                       Location loc);

--- a/lib/Dialect/OM/Evaluator/CMakeLists.txt
+++ b/lib/Dialect/OM/Evaluator/CMakeLists.txt
@@ -8,5 +8,6 @@ add_circt_library(CIRCTOMEvaluator
 
   LINK_LIBS
   CIRCTOM
+  CIRCTOMTransforms
   MLIRIR
 )

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -92,29 +92,35 @@ public:
     SmallVector<EvaluatorValuePtr> actualParams;
   };
 
-  ScratchIRBuilder(ModuleOp sourceModule, SymbolTable &sourceSymbols);
+  ScratchIRBuilder(ModuleOp module, SymbolTable &symbolTable,
+                   StringAttr rootClassName, Location loc)
+      : module(module), symbolTable(symbolTable), rootClassName(rootClassName),
+        wrapperClass(createWrapperClass(rootClassName, loc)) {}
 
-  FailureOr<InstantiationInfo> run(StringAttr rootClassName,
+  FailureOr<InstantiationInfo> run(ClassLike rootClass,
                                    ArrayRef<EvaluatorValuePtr> actualParams);
 
 private:
   /// Create the temporary class that owns all scratch IR.
-  StringAttr createWrapperClass(StringAttr rootClassName, Location loc);
+  ClassOp createWrapperClass(StringAttr rootClassName, Location loc);
 
   /// Convert an API input value into scratch IR, preserving opaque any-typed
   /// inputs and rejecting runtime references/cycles.
   FailureOr<Value> materializeInput(const EvaluatorValuePtr &value,
                                     Location loc, Type expectedType);
+  /// Convert a fully evaluated list value into scratch IR.
   FailureOr<Value> materializeListInput(evaluator::ListValue *listValue,
                                         Location loc);
+  /// Convert a fully evaluated object value into scratch IR.
   FailureOr<Value> materializeObjectInput(evaluator::ObjectValue *objectValue,
                                           Location loc);
+  /// Add a wrapper class parameter for an input that must stay opaque.
   FailureOr<Value> createWrapperArgument(EvaluatorValuePtr value, Location loc,
                                          Type argType);
 
   ModuleOp module;
   SymbolTable &symbolTable;
-  OpBuilder builder;
+  StringAttr rootClassName;
   ClassOp wrapperClass;
   // A mapping from evaluator input values to their corresponding imported IR
   // values.
@@ -128,25 +134,15 @@ private:
   SmallVector<EvaluatorValuePtr> wrapperActualParams;
 };
 
-ScratchIRBuilder::ScratchIRBuilder(ModuleOp sourceModule,
-                                   SymbolTable &sourceSymbols)
-    : module(sourceModule), symbolTable(sourceSymbols),
-      builder(sourceModule.getContext()) {}
-
 FailureOr<ScratchIRBuilder::InstantiationInfo>
-ScratchIRBuilder::run(StringAttr rootClassName,
+ScratchIRBuilder::run(ClassLike rootClass,
                       ArrayRef<EvaluatorValuePtr> actualParams) {
   auto *ctx = module.getContext();
-
-  auto rootClass = symbolTable.lookup<ClassLike>(rootClassName);
-  if (!rootClass)
-    return module.emitError("unknown class name ") << rootClassName;
-  if (failed(verifyActualParameters(rootClass, actualParams)))
-    return failure();
-
+  assert(rootClass.getSymNameAttr() == rootClassName &&
+         "root class must match the wrapper class target");
   auto rootLoc = rootClass.getLoc();
-  auto wrapperName = createWrapperClass(rootClassName, rootLoc);
 
+  OpBuilder builder(wrapperClass.getFieldsOp());
   builder.setInsertionPoint(wrapperClass.getFieldsOp());
   SmallVector<Value> importedActualValues;
   importedActualValues.reserve(actualParams.size());
@@ -162,17 +158,21 @@ ScratchIRBuilder::run(StringAttr rootClassName,
   wrapperClass->setAttr(wrapperClass.getFormalParamNamesAttrName(),
                         builder.getArrayAttr(wrapperArgNames));
 
-  auto rootType = ClassType::get(ctx, FlatSymbolRefAttr::get(rootClassName));
-  auto rootObject = ObjectOp::create(builder, rootLoc, rootType, rootClassName,
-                                     importedActualValues);
-  wrapperClass.updateFields({rootLoc}, {rootObject.getResult()},
-                            {builder.getStringAttr("root")});
+  wrapperClass.updateFields(
+      {rootLoc},
+      {ObjectOp::create(
+           builder, rootLoc,
+           ClassType::get(ctx, FlatSymbolRefAttr::get(rootClassName)),
+           rootClassName, importedActualValues)
+           .getResult()},
+      {builder.getStringAttr("root")});
 
   if (failed(verify(module)))
     return failure();
 
   PassManager pm(ctx);
   ElaborateObjectOptions options;
+  auto wrapperName = wrapperClass.getSymNameAttr();
   options.targetClass = wrapperName.getValue().str();
   pm.addPass(createElaborateObject(std::move(options)));
   if (failed(pm.run(module)))
@@ -181,19 +181,19 @@ ScratchIRBuilder::run(StringAttr rootClassName,
   return InstantiationInfo{wrapperName, std::move(wrapperActualParams)};
 }
 
-StringAttr ScratchIRBuilder::createWrapperClass(StringAttr rootClassName,
-                                                Location loc) {
+ClassOp ScratchIRBuilder::createWrapperClass(StringAttr rootClassName,
+                                             Location loc) {
+  OpBuilder builder(module.getBody(), module.getBody()->end());
   builder.setInsertionPointToEnd(module.getBody());
 
-  std::string wrapperName =
-      ("__om_evaluator_wrapper_" + rootClassName.getValue()).str();
-  wrapperClass = ClassOp::create(builder, loc, wrapperName);
-  auto uniqueWrapperName = symbolTable.insert(wrapperClass);
-
+  wrapperClass = ClassOp::create(builder, loc,
+                                 Twine("__om_evaluator_wrapper_") +
+                                     rootClassName.getValue());
+  (void)symbolTable.insert(wrapperClass);
   Block *body = &wrapperClass.getBody().emplaceBlock();
   builder.setInsertionPointToEnd(body);
   ClassFieldsOp::create(builder, loc, ValueRange(), ArrayAttr{});
-  return uniqueWrapperName;
+  return wrapperClass;
 }
 
 FailureOr<Value>
@@ -217,32 +217,37 @@ ScratchIRBuilder::materializeInput(const EvaluatorValuePtr &value, Location loc,
     return it->second;
 
   if (value->isUnknown()) {
+    OpBuilder builder(wrapperClass.getFieldsOp());
     auto result = UnknownValueOp::create(builder, loc, expectedType);
     importedValues[value.get()] = result.getResult();
     return result.getResult();
   }
 
-  if (auto *attrValue = dyn_cast<evaluator::AttributeValue>(value.get())) {
-    auto attr = attrValue->getAttr();
-    if (!attr)
-      return emitError(loc, "cannot import OM attribute value without an "
-                            "attribute");
+  return llvm::TypeSwitch<evaluator::EvaluatorValue *, FailureOr<Value>>(
+             value.get())
+      .Case([&](evaluator::AttributeValue *attrValue) -> FailureOr<Value> {
+        auto attr = attrValue->getAttr();
+        if (!attr)
+          return emitError(loc, "cannot import OM attribute value without an "
+                                "attribute");
 
-    auto result = ConstantOp::create(builder, loc, cast<TypedAttr>(attr));
-    importedValues[value.get()] = result.getResult();
-    return result.getResult();
-  }
-
-  if (auto *listValue = dyn_cast<evaluator::ListValue>(value.get()))
-    return materializeListInput(listValue, loc);
-
-  if (auto *objectValue = dyn_cast<evaluator::ObjectValue>(value.get()))
-    return materializeObjectInput(objectValue, loc);
-
-  auto result = createWrapperArgument(value, loc, expectedType);
-  if (succeeded(result))
-    importedValues[value.get()] = *result;
-  return result;
+        OpBuilder builder(wrapperClass.getFieldsOp());
+        auto result = ConstantOp::create(builder, loc, cast<TypedAttr>(attr));
+        importedValues[value.get()] = result.getResult();
+        return result.getResult();
+      })
+      .Case([&](evaluator::ListValue *listValue) {
+        return materializeListInput(listValue, loc);
+      })
+      .Case([&](evaluator::ObjectValue *objectValue) {
+        return materializeObjectInput(objectValue, loc);
+      })
+      .Default([&](evaluator::EvaluatorValue *) -> FailureOr<Value> {
+        auto result = createWrapperArgument(value, loc, expectedType);
+        if (succeeded(result))
+          importedValues[value.get()] = *result;
+        return result;
+      });
 }
 
 FailureOr<Value>
@@ -262,6 +267,7 @@ ScratchIRBuilder::materializeListInput(evaluator::ListValue *listValue,
     elementValues.push_back(*materializedElement);
   }
 
+  OpBuilder builder(wrapperClass.getFieldsOp());
   auto result = ListCreateOp::create(builder, loc, listType, elementValues);
   importedValues[listValue] = result.getResult();
   return result.getResult();
@@ -272,11 +278,10 @@ ScratchIRBuilder::materializeObjectInput(evaluator::ObjectValue *objectValue,
                                          Location loc) {
   // TODO: Currently we only support importing object values that don't have
   // mutual references with other object values in the inputs for the
-  // simplicity. We could consturct mutually referencing object values with a
+  // simplicity. We could construct mutually referencing object values with a
   // backedge builder but currently we don't have a use case for that.
   if (!activeObjectImports.insert(objectValue).second)
-    return emitError(loc,
-                     "cannot import mutually referencing OM object values");
+    return emitError(loc, "cannot import mutually referential OM objects");
 
   llvm::scope_exit popActiveObjectImport(
       [&] { activeObjectImports.erase(objectValue); });
@@ -297,6 +302,7 @@ ScratchIRBuilder::materializeObjectInput(evaluator::ObjectValue *objectValue,
     fieldValues.push_back(*materializedField);
   }
 
+  OpBuilder builder(wrapperClass.getFieldsOp());
   auto result =
       ElaboratedObjectOp::create(builder, loc, classLike, fieldValues);
   importedValues[objectValue] = result.getResult();
@@ -306,16 +312,11 @@ ScratchIRBuilder::materializeObjectInput(evaluator::ObjectValue *objectValue,
 FailureOr<Value>
 ScratchIRBuilder::createWrapperArgument(EvaluatorValuePtr value, Location loc,
                                         Type argType) {
-  auto argName = ("arg" + Twine(wrapperArgNames.size())).str();
-  wrapperArgNames.push_back(builder.getStringAttr(argName));
-
-  auto arg = wrapperClass.getBodyBlock()->addArgument(argType, loc);
+  Builder builder(module.getContext());
+  wrapperArgNames.push_back(
+      builder.getStringAttr(Twine("arg") + Twine(wrapperArgNames.size())));
   wrapperActualParams.push_back(value);
-  return arg;
-}
-
-bool shouldRunElaborationTransform(ModuleOp module) {
-  return !module->hasAttr(skipElaborationTransformAttr);
+  return wrapperClass.getBodyBlock()->addArgument(argType, loc);
 }
 
 } // namespace
@@ -615,11 +616,22 @@ circt::om::Evaluator::instantiate(
       dbgs() << "- " << param << "\n";
   });
 
-  if (!shouldRunElaborationTransform(getModule()))
+  // Skip the elaboration transform and directly instantiate the class if the
+  // caller explicitly requests so.
+  // TODO: Remove this after fully migrating to the new evaluator-based
+  // implementation.
+  if (getModule()->hasAttr(skipElaborationTransformAttr))
     return instantiateImpl(className, actualParams);
 
-  ScratchIRBuilder scratchBuilder(getModule(), symbolTable);
-  auto transformedInstantiation = scratchBuilder.run(className, actualParams);
+  auto rootClass = symbolTable.lookup<ClassLike>(className);
+  if (!rootClass)
+    return symbolTable.getOp()->emitError("unknown class name ") << className;
+  if (failed(verifyActualParameters(rootClass, actualParams)))
+    return failure();
+
+  ScratchIRBuilder scratchBuilder(getModule(), symbolTable, className,
+                                  rootClass.getLoc());
+  auto transformedInstantiation = scratchBuilder.run(rootClass, actualParams);
   if (failed(transformedInstantiation))
     return failure();
 

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -93,16 +93,15 @@ public:
   };
 
   ScratchIRBuilder(ModuleOp module, SymbolTable &symbolTable,
-                   StringAttr rootClassName, Location loc)
-      : module(module), symbolTable(symbolTable), rootClassName(rootClassName),
-        wrapperClass(createWrapperClass(rootClassName, loc)) {}
+                   ClassLike rootClass)
+      : module(module), symbolTable(symbolTable), rootClass(rootClass),
+        wrapperClass(createWrapperClass(rootClass)) {}
 
-  FailureOr<InstantiationInfo> run(ClassLike rootClass,
-                                   ArrayRef<EvaluatorValuePtr> actualParams);
+  FailureOr<InstantiationInfo> run(ArrayRef<EvaluatorValuePtr> actualParams);
 
 private:
   /// Create the temporary class that owns all scratch IR.
-  ClassOp createWrapperClass(StringAttr rootClassName, Location loc);
+  ClassOp createWrapperClass(ClassLike rootClass);
 
   /// Convert an API input value into scratch IR, preserving opaque any-typed
   /// inputs and rejecting runtime references/cycles.
@@ -120,7 +119,7 @@ private:
 
   ModuleOp module;
   SymbolTable &symbolTable;
-  StringAttr rootClassName;
+  ClassLike rootClass;
   ClassOp wrapperClass;
   // A mapping from evaluator input values to their corresponding imported IR
   // values.
@@ -135,12 +134,11 @@ private:
 };
 
 FailureOr<ScratchIRBuilder::InstantiationInfo>
-ScratchIRBuilder::run(ClassLike rootClass,
-                      ArrayRef<EvaluatorValuePtr> actualParams) {
+ScratchIRBuilder::run(ArrayRef<EvaluatorValuePtr> actualParams) {
   auto *ctx = module.getContext();
-  assert(rootClass.getSymNameAttr() == rootClassName &&
-         "root class must match the wrapper class target");
+  assert(rootClass && "root class must be resolved before building scratch IR");
   auto rootLoc = rootClass.getLoc();
+  auto rootClassName = rootClass.getSymNameAttr();
 
   OpBuilder builder(wrapperClass.getFieldsOp());
   builder.setInsertionPoint(wrapperClass.getFieldsOp());
@@ -181,19 +179,18 @@ ScratchIRBuilder::run(ClassLike rootClass,
   return InstantiationInfo{wrapperName, std::move(wrapperActualParams)};
 }
 
-ClassOp ScratchIRBuilder::createWrapperClass(StringAttr rootClassName,
-                                             Location loc) {
+ClassOp ScratchIRBuilder::createWrapperClass(ClassLike rootClass) {
   OpBuilder builder(module.getBody(), module.getBody()->end());
   builder.setInsertionPointToEnd(module.getBody());
 
-  wrapperClass = ClassOp::create(builder, loc,
+  auto wrapper = ClassOp::create(builder, rootClass.getLoc(),
                                  Twine("__om_evaluator_wrapper_") +
-                                     rootClassName.getValue());
-  (void)symbolTable.insert(wrapperClass);
-  Block *body = &wrapperClass.getBody().emplaceBlock();
+                                     rootClass.getSymName());
+  (void)symbolTable.insert(wrapper);
+  Block *body = &wrapper.getBody().emplaceBlock();
   builder.setInsertionPointToEnd(body);
-  ClassFieldsOp::create(builder, loc, ValueRange(), ArrayAttr{});
-  return wrapperClass;
+  ClassFieldsOp::create(builder, rootClass.getLoc(), ValueRange(), ArrayAttr{});
+  return wrapper;
 }
 
 FailureOr<Value>
@@ -629,9 +626,8 @@ circt::om::Evaluator::instantiate(
   if (failed(verifyActualParameters(rootClass, actualParams)))
     return failure();
 
-  ScratchIRBuilder scratchBuilder(getModule(), symbolTable, className,
-                                  rootClass.getLoc());
-  auto transformedInstantiation = scratchBuilder.run(rootClass, actualParams);
+  ScratchIRBuilder scratchBuilder(getModule(), symbolTable, rootClass);
+  auto transformedInstantiation = scratchBuilder.run(actualParams);
   if (failed(transformedInstantiation))
     return failure();
 

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -11,9 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/OM/Evaluator/Evaluator.h"
+#include "circt/Dialect/OM/OMPasses.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Pass/PassManager.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Debug.h"
@@ -22,6 +28,297 @@
 
 using namespace mlir;
 using namespace circt::om;
+
+namespace {
+
+constexpr StringLiteral skipElaborationTransformAttr =
+    "om.skip_elaboration_transform";
+
+LogicalResult verifyActualParameters(ClassLike classLike,
+                                     ArrayRef<EvaluatorValuePtr> actualParams) {
+  auto formalParamNames =
+      classLike.getFormalParamNames().getAsRange<StringAttr>();
+  auto formalParamTypes = classLike.getBodyBlock()->getArgumentTypes();
+
+  if (actualParams.size() != formalParamTypes.size()) {
+    auto error = classLike.emitError("actual parameter list length (")
+                 << actualParams.size() << ") does not match formal "
+                 << "parameter list length (" << formalParamTypes.size() << ")";
+    auto &diag = error.attachNote() << "actual parameters: ";
+    bool isFirst = true;
+    for (const auto &param : actualParams) {
+      if (isFirst)
+        isFirst = false;
+      else
+        diag << ", ";
+      diag << param;
+    }
+    error.attachNote(classLike.getLoc())
+        << "formal parameters: " << formalParamTypes;
+    return failure();
+  }
+
+  for (auto [actualParam, formalParamName, formalParamType] :
+       llvm::zip(actualParams, formalParamNames, formalParamTypes)) {
+    if (!actualParam || !actualParam.get())
+      return classLike.emitError("actual parameter for ")
+             << formalParamName << " is null";
+
+    // Subtyping: if formal param is any type, any actual param may be passed.
+    if (isa<AnyType>(formalParamType))
+      continue;
+
+    Type actualParamType = actualParam->getType();
+    assert(actualParamType && "actualParamType must be non-null!");
+
+    if (actualParamType != formalParamType) {
+      auto error = classLike.emitError("actual parameter for ")
+                   << formalParamName << " has invalid type";
+      error.attachNote() << "actual parameter: " << *actualParam;
+      error.attachNote() << "format parameter type: " << formalParamType;
+      return failure();
+    }
+  }
+  return success();
+}
+
+/// A helper class that builds the scratch IR for evaluating an object. This is
+/// used to convert from the evaluator's API (which uses opaque pointers to
+/// evaluator values) into actual MLIR IR.
+class ScratchIRBuilder {
+public:
+  struct InstantiationInfo {
+    StringAttr className;
+    SmallVector<EvaluatorValuePtr> actualParams;
+  };
+
+  ScratchIRBuilder(ModuleOp sourceModule, SymbolTable &sourceSymbols);
+
+  FailureOr<InstantiationInfo> run(StringAttr rootClassName,
+                                   ArrayRef<EvaluatorValuePtr> actualParams);
+
+private:
+  /// Create the temporary class that owns all scratch IR.
+  StringAttr createWrapperClass(StringAttr rootClassName, Location loc);
+
+  /// Convert an API input value into scratch IR, preserving opaque any-typed
+  /// inputs and rejecting runtime references/cycles.
+  FailureOr<Value> materializeInput(const EvaluatorValuePtr &value,
+                                    Location loc, Type expectedType);
+  FailureOr<Value> materializeListInput(evaluator::ListValue *listValue,
+                                        Location loc);
+  FailureOr<Value> materializeObjectInput(evaluator::ObjectValue *objectValue,
+                                          Location loc);
+  FailureOr<Value> createWrapperArgument(EvaluatorValuePtr value, Location loc,
+                                         Type argType);
+
+  ModuleOp module;
+  SymbolTable &symbolTable;
+  OpBuilder builder;
+  ClassOp wrapperClass;
+  // A mapping from evaluator input values to their corresponding imported IR
+  // values.
+  DenseMap<evaluator::EvaluatorValue *, Value> importedValues;
+
+  // A set of object values that have been imported into the scratch IR, used to
+  // detect mutual references in the inputs.
+  SmallPtrSet<evaluator::ObjectValue *, 8> activeObjectImports;
+
+  SmallVector<Attribute> wrapperArgNames;
+  SmallVector<EvaluatorValuePtr> wrapperActualParams;
+};
+
+ScratchIRBuilder::ScratchIRBuilder(ModuleOp sourceModule,
+                                   SymbolTable &sourceSymbols)
+    : module(sourceModule), symbolTable(sourceSymbols),
+      builder(sourceModule.getContext()) {}
+
+FailureOr<ScratchIRBuilder::InstantiationInfo>
+ScratchIRBuilder::run(StringAttr rootClassName,
+                      ArrayRef<EvaluatorValuePtr> actualParams) {
+  auto *ctx = module.getContext();
+
+  auto rootClass = symbolTable.lookup<ClassLike>(rootClassName);
+  if (!rootClass)
+    return module.emitError("unknown class name ") << rootClassName;
+  if (failed(verifyActualParameters(rootClass, actualParams)))
+    return failure();
+
+  auto rootLoc = rootClass.getLoc();
+  auto wrapperName = createWrapperClass(rootClassName, rootLoc);
+
+  builder.setInsertionPoint(wrapperClass.getFieldsOp());
+  SmallVector<Value> importedActualValues;
+  importedActualValues.reserve(actualParams.size());
+  auto formalTypes = rootClass.getBodyBlock()->getArgumentTypes();
+  for (auto [actual, expectedType] : llvm::zip(actualParams, formalTypes)) {
+    auto imported = materializeInput(actual, rootLoc, expectedType);
+    if (failed(imported))
+      return failure();
+    importedActualValues.push_back(*imported);
+  }
+
+  // Update wrapper class after materializing actual parameters.
+  wrapperClass->setAttr(wrapperClass.getFormalParamNamesAttrName(),
+                        builder.getArrayAttr(wrapperArgNames));
+
+  auto rootType = ClassType::get(ctx, FlatSymbolRefAttr::get(rootClassName));
+  auto rootObject = ObjectOp::create(builder, rootLoc, rootType, rootClassName,
+                                     importedActualValues);
+  wrapperClass.updateFields({rootLoc}, {rootObject.getResult()},
+                            {builder.getStringAttr("root")});
+
+  if (failed(verify(module)))
+    return failure();
+
+  PassManager pm(ctx);
+  ElaborateObjectOptions options;
+  options.targetClass = wrapperName.getValue().str();
+  pm.addPass(createElaborateObject(std::move(options)));
+  if (failed(pm.run(module)))
+    return failure();
+
+  return InstantiationInfo{wrapperName, std::move(wrapperActualParams)};
+}
+
+StringAttr ScratchIRBuilder::createWrapperClass(StringAttr rootClassName,
+                                                Location loc) {
+  builder.setInsertionPointToEnd(module.getBody());
+
+  std::string wrapperName =
+      ("__om_evaluator_wrapper_" + rootClassName.getValue()).str();
+  wrapperClass = ClassOp::create(builder, loc, wrapperName);
+  auto uniqueWrapperName = symbolTable.insert(wrapperClass);
+
+  Block *body = &wrapperClass.getBody().emplaceBlock();
+  builder.setInsertionPointToEnd(body);
+  ClassFieldsOp::create(builder, loc, ValueRange(), ArrayAttr{});
+  return uniqueWrapperName;
+}
+
+FailureOr<Value>
+ScratchIRBuilder::materializeInput(const EvaluatorValuePtr &value, Location loc,
+                                   Type expectedType) {
+  if (!value)
+    return emitError(loc, "cannot materialize null OM evaluator value");
+
+  loc = value->getLoc();
+  if (isa<evaluator::ReferenceValue>(value.get()))
+    return emitError(loc, "cannot import OM reference value");
+  if (!expectedType)
+    return emitError(loc, "cannot import OM evaluator value without an "
+                          "expected type");
+
+  // Keep any-typed values opaque at the wrapper boundary.
+  if (isa<AnyType>(expectedType))
+    return createWrapperArgument(value, loc, expectedType);
+
+  if (auto it = importedValues.find(value.get()); it != importedValues.end())
+    return it->second;
+
+  if (value->isUnknown()) {
+    auto result = UnknownValueOp::create(builder, loc, expectedType);
+    importedValues[value.get()] = result.getResult();
+    return result.getResult();
+  }
+
+  if (auto *attrValue = dyn_cast<evaluator::AttributeValue>(value.get())) {
+    auto attr = attrValue->getAttr();
+    if (!attr)
+      return emitError(loc, "cannot import OM attribute value without an "
+                            "attribute");
+
+    auto result = ConstantOp::create(builder, loc, cast<TypedAttr>(attr));
+    importedValues[value.get()] = result.getResult();
+    return result.getResult();
+  }
+
+  if (auto *listValue = dyn_cast<evaluator::ListValue>(value.get()))
+    return materializeListInput(listValue, loc);
+
+  if (auto *objectValue = dyn_cast<evaluator::ObjectValue>(value.get()))
+    return materializeObjectInput(objectValue, loc);
+
+  auto result = createWrapperArgument(value, loc, expectedType);
+  if (succeeded(result))
+    importedValues[value.get()] = *result;
+  return result;
+}
+
+FailureOr<Value>
+ScratchIRBuilder::materializeListInput(evaluator::ListValue *listValue,
+                                       Location loc) {
+  if (!listValue->isFullyEvaluated())
+    return emitError(loc, "cannot import partially evaluated OM list value");
+
+  auto listType = listValue->getListType();
+  SmallVector<Value> elementValues;
+  elementValues.reserve(listValue->getElements().size());
+  for (const auto &elementValue : listValue->getElements()) {
+    auto materializedElement =
+        materializeInput(elementValue, loc, listType.getElementType());
+    if (failed(materializedElement))
+      return failure();
+    elementValues.push_back(*materializedElement);
+  }
+
+  auto result = ListCreateOp::create(builder, loc, listType, elementValues);
+  importedValues[listValue] = result.getResult();
+  return result.getResult();
+}
+
+FailureOr<Value>
+ScratchIRBuilder::materializeObjectInput(evaluator::ObjectValue *objectValue,
+                                         Location loc) {
+  // TODO: Currently we only support importing object values that don't have
+  // mutual references with other object values in the inputs for the
+  // simplicity. We could consturct mutually referencing object values with a
+  // backedge builder but currently we don't have a use case for that.
+  if (!activeObjectImports.insert(objectValue).second)
+    return emitError(loc,
+                     "cannot import mutually referencing OM object values");
+
+  llvm::scope_exit popActiveObjectImport(
+      [&] { activeObjectImports.erase(objectValue); });
+
+  auto classLike = objectValue->getClassOp();
+  SmallVector<Value> fieldValues;
+  auto fieldNames = classLike.getFieldNames();
+  fieldValues.reserve(fieldNames.size());
+  for (auto fieldName : fieldNames) {
+    auto fieldNameAttr = cast<StringAttr>(fieldName);
+    auto field = objectValue->getField(fieldNameAttr);
+    if (failed(field))
+      return failure();
+    auto materializedField = materializeInput(
+        field.value(), loc, classLike.getFieldType(fieldNameAttr).value());
+    if (failed(materializedField))
+      return failure();
+    fieldValues.push_back(*materializedField);
+  }
+
+  auto result =
+      ElaboratedObjectOp::create(builder, loc, classLike, fieldValues);
+  importedValues[objectValue] = result.getResult();
+  return result.getResult();
+}
+
+FailureOr<Value>
+ScratchIRBuilder::createWrapperArgument(EvaluatorValuePtr value, Location loc,
+                                        Type argType) {
+  auto argName = ("arg" + Twine(wrapperArgNames.size())).str();
+  wrapperArgNames.push_back(builder.getStringAttr(argName));
+
+  auto arg = wrapperClass.getBodyBlock()->addArgument(argType, loc);
+  wrapperActualParams.push_back(value);
+  return arg;
+}
+
+bool shouldRunElaborationTransform(ModuleOp module) {
+  return !module->hasAttr(skipElaborationTransformAttr);
+}
+
+} // namespace
 
 /// Construct an Evaluator with an IR module.
 circt::om::Evaluator::Evaluator(ModuleOp mod) : symbolTable(mod) {}
@@ -181,6 +478,9 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
                 .Case<ObjectOp>([&](auto op) {
                   return getPartiallyEvaluatedValue(op.getType(), op.getLoc());
                 })
+                .Case<ElaboratedObjectOp>([&](auto op) {
+                  return getPartiallyEvaluatedValue(op.getType(), op.getLoc());
+                })
                 .Case<UnknownValueOp>(
                     [&](auto op) { return evaluateUnknownValue(op, loc); })
                 .Default([&](Operation *op) {
@@ -229,51 +529,8 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
   // Otherwise, it's a regular class, proceed normally
   ClassOp cls = cast<ClassOp>(classDef);
 
-  auto formalParamNames = cls.getFormalParamNames().getAsRange<StringAttr>();
-  auto formalParamTypes = cls.getBodyBlock()->getArgumentTypes();
-
-  // Verify the actual parameters are the right size and types for this class.
-  if (actualParams->size() != formalParamTypes.size()) {
-    auto error = cls.emitError("actual parameter list length (")
-                 << actualParams->size() << ") does not match formal "
-                 << "parameter list length (" << formalParamTypes.size() << ")";
-    auto &diag = error.attachNote() << "actual parameters: ";
-    // FIXME: `diag << actualParams` doesn't work for some reason.
-    bool isFirst = true;
-    for (const auto &param : *actualParams) {
-      if (isFirst)
-        isFirst = false;
-      else
-        diag << ", ";
-      diag << param;
-    }
-    error.attachNote(cls.getLoc()) << "formal parameters: " << formalParamTypes;
-    return error;
-  }
-
-  // Verify the actual parameter types match.
-  for (auto [actualParam, formalParamName, formalParamType] :
-       llvm::zip(*actualParams, formalParamNames, formalParamTypes)) {
-    if (!actualParam || !actualParam.get())
-      return cls.emitError("actual parameter for ")
-             << formalParamName << " is null";
-
-    // Subtyping: if formal param is any type, any actual param may be passed.
-    if (isa<AnyType>(formalParamType))
-      continue;
-
-    Type actualParamType = actualParam->getType();
-
-    assert(actualParamType && "actualParamType must be non-null!");
-
-    if (actualParamType != formalParamType) {
-      auto error = cls.emitError("actual parameter for ")
-                   << formalParamName << " has invalid type";
-      error.attachNote() << "actual parameter: " << *actualParam;
-      error.attachNote() << "format parameter type: " << formalParamType;
-      return error;
-    }
-  }
+  if (failed(verifyActualParameters(cls, *actualParams)))
+    return failure();
 
   // Instantiate the fields.
   evaluator::ObjectFields fields;
@@ -358,6 +615,29 @@ circt::om::Evaluator::instantiate(
       dbgs() << "- " << param << "\n";
   });
 
+  if (!shouldRunElaborationTransform(getModule()))
+    return instantiateImpl(className, actualParams);
+
+  ScratchIRBuilder scratchBuilder(getModule(), symbolTable);
+  auto transformedInstantiation = scratchBuilder.run(className, actualParams);
+  if (failed(transformedInstantiation))
+    return failure();
+
+  auto wrapper = instantiateImpl(transformedInstantiation->className,
+                                 transformedInstantiation->actualParams);
+  if (failed(wrapper))
+    return failure();
+
+  auto root =
+      cast<evaluator::ObjectValue>(wrapper.value().get())->getField("root");
+  if (failed(root))
+    return failure();
+  return root.value();
+}
+
+FailureOr<std::shared_ptr<evaluator::EvaluatorValue>>
+circt::om::Evaluator::instantiateImpl(
+    StringAttr className, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
   auto classDef = symbolTable.lookup<ClassLike>(className);
   if (!classDef)
     return symbolTable.getOp()->emitError("unknown class name ") << className;
@@ -486,6 +766,9 @@ circt::om::Evaluator::evaluateValue(Value value, ActualParameters actualParams,
             })
             .Case([&](ObjectOp op) {
               return evaluateObjectInstance(op, actualParams);
+            })
+            .Case([&](ElaboratedObjectOp op) {
+              return evaluateElaboratedObject(op, actualParams, loc);
             })
             .Case([&](ObjectFieldOp op) {
               return evaluateObjectField(op, actualParams, loc);
@@ -707,6 +990,49 @@ circt::om::Evaluator::evaluateObjectInstance(ObjectOp op,
     return failure();
   return evaluateObjectInstance(op.getClassNameAttr(), params.value(), loc,
                                 {op, actualParams});
+}
+
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::evaluateElaboratedObject(ElaboratedObjectOp op,
+                                               ActualParameters actualParams,
+                                               Location loc) {
+  auto objectValue = getOrCreateValue(op, actualParams, loc);
+  if (failed(objectValue))
+    return failure();
+  auto object = cast<evaluator::ObjectValue>(objectValue.value().get());
+  if (object->isFullyEvaluated())
+    return objectValue;
+
+  auto classLike = symbolTable.lookup<ClassLike>(op.getClassNameAttr());
+  if (!classLike)
+    return symbolTable.getOp()->emitError("unknown class name ")
+           << op.getClassNameAttr();
+
+  auto fieldNames = classLike.getFieldNames();
+  auto fieldValues = op.getFieldValues();
+  if (fieldNames.size() != fieldValues.size())
+    return op.emitError("field value list doesn't match class field list, "
+                        "expected ")
+           << fieldNames.size() << " values but got " << fieldValues.size();
+
+  evaluator::ObjectFields fields;
+  auto classOp = dyn_cast<ClassOp>(classLike.getOperation());
+  for (auto [index, fieldNameAndValue] :
+       llvm::enumerate(llvm::zip(fieldNames, fieldValues))) {
+    auto [fieldName, fieldValue] = fieldNameAndValue;
+    auto fieldLoc = classOp ? classOp.getFieldLocByIndex(index) : loc;
+    auto fieldResult = getOrCreateValue(fieldValue, actualParams, fieldLoc);
+    if (failed(fieldResult))
+      return failure();
+
+    if (!fieldResult.value()->isFullyEvaluated())
+      worklist.push_back({fieldValue, actualParams});
+
+    fields[cast<StringAttr>(fieldName)] = fieldResult.value();
+  }
+
+  object->setFields(std::move(fields));
+  return objectValue;
 }
 
 /// Evaluator dispatch function for Object fields.

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -38,8 +38,14 @@ struct EvaluatorTestContext {
     context.getOrLoadDialect<OMDialect>();
   }
 
-  OwningOpRef<ModuleOp> parseModule(StringRef moduleText) {
-    return parseSourceString<ModuleOp>(moduleText, ParserConfig(&context));
+  OwningOpRef<ModuleOp> parseModule(StringRef moduleText,
+                                    bool skipElaborationTransform = false) {
+    OwningOpRef<ModuleOp> owning =
+        parseSourceString<ModuleOp>(moduleText, ParserConfig(&context));
+    if (owning && skipElaborationTransform)
+      owning.get()->setAttr("om.skip_elaboration_transform",
+                            UnitAttr::get(&context));
+    return owning;
   }
 
   DialectRegistry registry;
@@ -98,19 +104,29 @@ getListElements(const evaluator::EvaluatorValuePtr &value) {
   return llvm::cast<evaluator::ListValue>(value.get())->getElements();
 }
 
-class EvaluatorTests : public ::testing::Test {
+class EvaluatorTests : public ::testing::TestWithParam<bool> {
 protected:
   OwningOpRef<ModuleOp> parseModule(StringRef moduleText) {
-    return test.parseModule(moduleText);
+    return test.parseModule(moduleText, GetParam());
+  }
+
+  OwningOpRef<ModuleOp> parseModule(StringRef moduleText,
+                                    bool skipElaborationTransform) {
+    return test.parseModule(moduleText, skipElaborationTransform);
   }
 
   EvaluatorTestContext test;
   MLIRContext &context = test.context;
 };
 
+std::string getEvaluatorFlowName(const ::testing::TestParamInfo<bool> &info) {
+  return info.param ? "WithoutElaborationTransform"
+                    : "WithElaborationTransform";
+}
+
 /// Failure scenarios.
 
-TEST_F(EvaluatorTests, InstantiateInvalidClassName) {
+TEST_P(EvaluatorTests, InstantiateInvalidClassName) {
   StringRef mod = R"MLIR(
 module {
 }
@@ -129,7 +145,7 @@ module {
   ASSERT_FALSE(succeeded(result));
 }
 
-TEST_F(EvaluatorTests, InstantiateInvalidParamSize) {
+TEST_P(EvaluatorTests, InstantiateInvalidParamSize) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyClass(%param: !om.integer) {
@@ -154,7 +170,7 @@ module {
   ASSERT_FALSE(succeeded(result));
 }
 
-TEST_F(EvaluatorTests, InstantiateNullParam) {
+TEST_P(EvaluatorTests, InstantiateNullParam) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyClass(%param: !om.integer) {
@@ -177,7 +193,7 @@ module {
   ASSERT_FALSE(succeeded(result));
 }
 
-TEST_F(EvaluatorTests, InstantiateInvalidParamType) {
+TEST_P(EvaluatorTests, InstantiateInvalidParamType) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyClass(%param: !om.integer) {
@@ -202,7 +218,7 @@ module {
   ASSERT_FALSE(succeeded(result));
 }
 
-TEST_F(EvaluatorTests, GetFieldInvalidName) {
+TEST_P(EvaluatorTests, GetFieldInvalidName) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyClass() {
@@ -231,7 +247,7 @@ module {
 
 /// Success scenarios.
 
-TEST_F(EvaluatorTests, InstantiateObjectWithParamField) {
+TEST_P(EvaluatorTests, InstantiateObjectWithParamField) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyClass(%param: !om.integer) -> (field: !om.integer) {
@@ -251,7 +267,118 @@ module {
   ASSERT_EQ(42, getInteger(getField(result.value(), "field")));
 }
 
-TEST_F(EvaluatorTests, InstantiateObjectWithConstantField) {
+TEST_P(EvaluatorTests, InstantiateWithStructuredInputs) {
+  StringRef mod = R"MLIR(
+module {
+  om.class @Leaf(%value: !om.integer) -> (value: !om.integer) {
+    om.class.fields %value : !om.integer
+  }
+
+  om.class @Input() -> (leaf: !om.class.type<@Leaf>, leaves: !om.list<!om.class.type<@Leaf>>, any_leaf: !om.any) {
+    %value = om.constant #om.integer<11 : si8> : !om.integer
+    %leaf = om.object @Leaf(%value) : (!om.integer) -> !om.class.type<@Leaf>
+    %leaves = om.list_create %leaf : !om.class.type<@Leaf>
+    %any_leaf = om.any_cast %leaf : (!om.class.type<@Leaf>) -> !om.any
+    om.class.fields %leaf, %leaves, %any_leaf : !om.class.type<@Leaf>, !om.list<!om.class.type<@Leaf>>, !om.any
+  }
+
+  om.class @UseObject(%leaf: !om.class.type<@Leaf>) -> (value: !om.integer) {
+    %value = om.object.field %leaf["value"] : (!om.class.type<@Leaf>) -> !om.integer
+    om.class.fields %value : !om.integer
+  }
+
+  om.class @UseList(%leaves: !om.list<!om.class.type<@Leaf>>) -> (leaves: !om.list<!om.class.type<@Leaf>>) {
+    om.class.fields %leaves : !om.list<!om.class.type<@Leaf>>
+  }
+
+  om.class @UseAny(%value: !om.any) -> (value: !om.any) {
+    om.class.fields %value : !om.any
+  }
+}
+)MLIR";
+
+  OwningOpRef<ModuleOp> owning = parseModule(mod);
+  ASSERT_TRUE(owning);
+  Evaluator evaluator(owning.get());
+
+  auto inputResult =
+      evaluator.instantiate(StringAttr::get(&context, "Input"), {});
+  ASSERT_TRUE(succeeded(inputResult));
+
+  auto objectResult =
+      evaluator.instantiate(StringAttr::get(&context, "UseObject"),
+                            {getField(inputResult.value(), "leaf")});
+  ASSERT_TRUE(succeeded(objectResult));
+  ASSERT_EQ(getInteger(getField(objectResult.value(), "value")), 11);
+
+  auto listResult =
+      evaluator.instantiate(StringAttr::get(&context, "UseList"),
+                            {getField(inputResult.value(), "leaves")});
+  ASSERT_TRUE(succeeded(listResult));
+  auto leaves = getListElements(getField(listResult.value(), "leaves"));
+  ASSERT_EQ(leaves.size(), 1u);
+
+  ASSERT_EQ(getInteger(getField(leaves.front(), "value")), 11);
+
+  auto anyResult =
+      evaluator.instantiate(StringAttr::get(&context, "UseAny"),
+                            {getField(inputResult.value(), "any_leaf")});
+  ASSERT_TRUE(succeeded(anyResult));
+  auto *anyFieldValue = getObject(getField(anyResult.value(), "value"));
+  ASSERT_EQ(anyFieldValue->getClassOp().getSymNameAttr().getValue(), "Leaf");
+}
+
+TEST_P(EvaluatorTests, InstantiateWithPartiallyEvaluatedInputs) {
+  if (GetParam())
+    return;
+
+  auto runFailure = [&](StringRef mod, StringRef className,
+                        evaluator::EvaluatorValuePtr value,
+                        StringRef expectedError) {
+    OwningOpRef<ModuleOp> owning = parseModule(mod);
+    ASSERT_TRUE(owning);
+    Evaluator evaluator(owning.get());
+
+    SmallVector<std::string> diagnostics;
+    ScopedDiagnosticHandler handler(
+        &context, [&](Diagnostic &diag) { diagnostics.push_back(diag.str()); });
+
+    auto result =
+        evaluator.instantiate(StringAttr::get(&context, className), {value});
+    ASSERT_TRUE(failed(result));
+    ASSERT_EQ(diagnostics.size(), 1u);
+    ASSERT_EQ(diagnostics[0], expectedError);
+  };
+
+  runFailure(
+      R"MLIR(
+module {
+  om.class @Top(%value: !om.integer) -> (value: !om.integer) {
+    om.class.fields %value : !om.integer
+  }
+}
+)MLIR",
+      "Top",
+      evaluator::AttributeValue::get(circt::om::OMIntegerType::get(&context),
+                                     UnknownLoc::get(&context)),
+      "cannot import OM attribute value without an attribute");
+
+  auto listType =
+      circt::om::ListType::get(circt::om::OMIntegerType::get(&context));
+  runFailure(R"MLIR(
+module {
+  om.class @Top(%values: !om.list<!om.integer>) -> (values: !om.list<!om.integer>) {
+    om.class.fields %values : !om.list<!om.integer>
+  }
+}
+)MLIR",
+             "Top",
+             std::make_shared<evaluator::ListValue>(listType,
+                                                    UnknownLoc::get(&context)),
+             "cannot import partially evaluated OM list value");
+}
+
+TEST_P(EvaluatorTests, InstantiateObjectWithConstantField) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyClass() -> (field: !om.integer) {
@@ -271,7 +398,7 @@ module {
   ASSERT_EQ(42, getInteger(getField(result.value(), "field")));
 }
 
-TEST_F(EvaluatorTests, InstantiateObjectWithChildObject) {
+TEST_P(EvaluatorTests, InstantiateObjectWithChildObject) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyInnerClass(%param: !om.integer) -> (field: !om.integer) {
@@ -297,7 +424,7 @@ module {
   ASSERT_EQ(42, getInteger(getField(fieldValue, "field")));
 }
 
-TEST_F(EvaluatorTests, InstantiateObjectWithFieldAccess) {
+TEST_P(EvaluatorTests, InstantiateObjectWithFieldAccess) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyInnerClass(%param: !om.integer) -> (field: !om.integer) {
@@ -323,7 +450,7 @@ module {
   ASSERT_EQ(42, getInteger(getField(result.value(), "field")));
 }
 
-TEST_F(EvaluatorTests, InstantiateObjectWithChildObjectMemoized) {
+TEST_P(EvaluatorTests, InstantiateObjectWithChildObjectMemoized) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyInnerClass() {
@@ -362,7 +489,7 @@ module {
   ASSERT_EQ(field1Value, field2Value);
 }
 
-TEST_F(EvaluatorTests, AnyCastObject) {
+TEST_P(EvaluatorTests, AnyCastObject) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyInnerClass() {
@@ -388,7 +515,7 @@ module {
   ASSERT_EQ(fieldValue->getClassOp().getSymName(), "MyInnerClass");
 }
 
-TEST_F(EvaluatorTests, AnyCastParam) {
+TEST_P(EvaluatorTests, AnyCastParam) {
   StringRef mod = R"MLIR(
 module {
   om.class @MyInnerClass(%param: !om.any) -> (field: !om.any) {
@@ -418,7 +545,7 @@ module {
   ASSERT_EQ(42u, getBuiltinInteger(getField(fieldValue, "field")));
 }
 
-TEST_F(EvaluatorTests, InstantiateGraphRegion) {
+TEST_P(EvaluatorTests, InstantiateGraphRegion) {
   StringRef mod = R"MLIR(
 !ty = !om.class.type<@LinkedList>
 om.class @LinkedList(%n: !ty, %val: !om.string) -> (n: !ty, val:
@@ -433,6 +560,9 @@ om.class @ReferenceEachOther() -> (field1: !ty, field2: !ty) {
   %0 = om.object @LinkedList(%1, %val) : (!ty, !om.string) -> !ty
   %1 = om.object @LinkedList(%0, %str) : (!ty, !om.string) -> !ty
   om.class.fields %0, %1 : !ty, !ty
+}
+om.class @UseNode(%node: !ty) -> (node: !ty) {
+  om.class.fields %node : !ty
 }
 )MLIR";
 
@@ -453,9 +583,28 @@ om.class @ReferenceEachOther() -> (field1: !ty, field2: !ty) {
   ASSERT_EQ(field2.get(), getField(field1, "n").get());
 
   ASSERT_EQ("foo", getString(getField(field1, "val")));
+
+  auto node = getField(result.value(), "field1");
+
+  if (!GetParam()) {
+    context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+      ASSERT_EQ(diag.str(),
+                "cannot import mutually referencing OM object values");
+    });
+    auto useNodeResult =
+        evaluator.instantiate(StringAttr::get(&context, "UseNode"), {node});
+    ASSERT_TRUE(failed(useNodeResult));
+    return;
+  }
+
+  auto useNodeResult =
+      evaluator.instantiate(StringAttr::get(&context, "UseNode"), {node});
+  ASSERT_TRUE(succeeded(useNodeResult));
+  auto resultNode = getField(useNodeResult.value(), "node");
+  ASSERT_EQ(resultNode.get(), node.get());
 }
 
-TEST_F(EvaluatorTests, InstantiateCycle) {
+TEST_P(EvaluatorTests, InstantiateCycle) {
   StringRef mod = R"MLIR(
 !ty = !om.class.type<@LinkedList>
 om.class @LinkedList(%n: !ty) -> (n: !ty){
@@ -470,8 +619,10 @@ om.class @ReferenceEachOther() -> (field: !ty){
 
   context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
     ASSERT_EQ(diag.str(),
-              "cycle detected: 1 values remain partially evaluated after full "
-              "pass with no progress (total fully evaluated: 1)");
+              GetParam()
+                  ? "cycle detected: 1 values remain partially evaluated after "
+                    "full pass with no progress (total fully evaluated: 1)"
+                  : "failed to evaluate om.object.field");
   });
 
   OwningOpRef<ModuleOp> owning = parseModule(mod);
@@ -487,7 +638,7 @@ om.class @ReferenceEachOther() -> (field: !ty){
 
 // Test nested object field references.
 // https://github.com/llvm/circt/issues/10264
-TEST_F(EvaluatorTests, Issue10264NestedFieldReferences) {
+TEST_P(EvaluatorTests, Issue10264NestedFieldReferences) {
   StringRef mod = R"MLIR(
 om.class @Domain(%in: !om.string) -> (out: !om.string) {
   om.class.fields %in : !om.string
@@ -516,7 +667,7 @@ om.class @Top() -> (test: i1) {
   ASSERT_FALSE(getBool(getField(result.value(), "test")));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticAdd) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticAdd) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticAdd() -> (result: !om.integer) {
   %0 = om.constant #om.integer<1 : si3> : !om.integer
@@ -535,10 +686,10 @@ om.class @IntegerBinaryArithmeticAdd() -> (result: !om.integer) {
       StringAttr::get(&context, "IntegerBinaryArithmeticAdd"), {});
 
   ASSERT_TRUE(succeeded(result));
-  ASSERT_EQ(3, getInteger(getField(result.value(), "result")));
+  ASSERT_EQ(getInteger(getField(result.value(), "result")), 3);
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticMul) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticMul) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticMul() -> (result: !om.integer) {
   %0 = om.constant #om.integer<2 : si3> : !om.integer
@@ -560,7 +711,7 @@ om.class @IntegerBinaryArithmeticMul() -> (result: !om.integer) {
   ASSERT_EQ(6, getInteger(getField(result.value(), "result")));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticShr) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticShr) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticShr() -> (result: !om.integer){
   %0 = om.constant #om.integer<8 : si5> : !om.integer
@@ -582,7 +733,7 @@ om.class @IntegerBinaryArithmeticShr() -> (result: !om.integer){
   ASSERT_EQ(2, getInteger(getField(result.value(), "result")));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticShrNegative) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticShrNegative) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticShrNegative() -> (result: !om.integer){
   %0 = om.constant #om.integer<8 : si5> : !om.integer
@@ -597,7 +748,8 @@ om.class @IntegerBinaryArithmeticShrNegative() -> (result: !om.integer){
       ASSERT_EQ(diag.str(),
                 "'om.integer.shr' op shift amount must be non-negative");
     if (StringRef(diag.str()).starts_with("failed"))
-      ASSERT_EQ(diag.str(), "failed to evaluate integer operation");
+      ASSERT_EQ(diag.str(), GetParam() ? "failed to evaluate integer operation"
+                                       : "failed to evaluate om.integer.shr");
   });
 
   OwningOpRef<ModuleOp> owning = parseModule(mod);
@@ -611,7 +763,7 @@ om.class @IntegerBinaryArithmeticShrNegative() -> (result: !om.integer){
   ASSERT_TRUE(failed(result));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticShrTooLarge) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticShrTooLarge) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticShrTooLarge() -> (result: !om.integer){
   %0 = om.constant #om.integer<8 : si5> : !om.integer
@@ -627,7 +779,8 @@ om.class @IntegerBinaryArithmeticShrTooLarge() -> (result: !om.integer){
           diag.str(),
           "'om.integer.shr' op shift amount must be representable in 64 bits");
     if (StringRef(diag.str()).starts_with("failed"))
-      ASSERT_EQ(diag.str(), "failed to evaluate integer operation");
+      ASSERT_EQ(diag.str(), GetParam() ? "failed to evaluate integer operation"
+                                       : "failed to evaluate om.integer.shr");
   });
 
   OwningOpRef<ModuleOp> owning = parseModule(mod);
@@ -641,7 +794,7 @@ om.class @IntegerBinaryArithmeticShrTooLarge() -> (result: !om.integer){
   ASSERT_TRUE(failed(result));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticShl) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticShl) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticShl() -> (result: !om.integer){
   %0 = om.constant #om.integer<8 : si7> : !om.integer
@@ -663,7 +816,7 @@ om.class @IntegerBinaryArithmeticShl() -> (result: !om.integer){
   ASSERT_EQ(32, getInteger(getField(result.value(), "result")));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticShlNegative) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticShlNegative) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticShlNegative() -> (result: !om.integer) {
   %0 = om.constant #om.integer<8 : si5> : !om.integer
@@ -678,7 +831,8 @@ om.class @IntegerBinaryArithmeticShlNegative() -> (result: !om.integer) {
       ASSERT_EQ(diag.str(),
                 "'om.integer.shl' op shift amount must be non-negative");
     if (StringRef(diag.str()).starts_with("failed"))
-      ASSERT_EQ(diag.str(), "failed to evaluate integer operation");
+      ASSERT_EQ(diag.str(), GetParam() ? "failed to evaluate integer operation"
+                                       : "failed to evaluate om.integer.shl");
   });
 
   OwningOpRef<ModuleOp> owning = parseModule(mod);
@@ -692,7 +846,7 @@ om.class @IntegerBinaryArithmeticShlNegative() -> (result: !om.integer) {
   ASSERT_TRUE(failed(result));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticShlTooLarge) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticShlTooLarge) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticShlTooLarge() -> (result: !om.integer) {
   %0 = om.constant #om.integer<8 : si5> : !om.integer
@@ -708,7 +862,8 @@ om.class @IntegerBinaryArithmeticShlTooLarge() -> (result: !om.integer) {
           diag.str(),
           "'om.integer.shl' op shift amount must be representable in 64 bits");
     if (StringRef(diag.str()).starts_with("failed"))
-      ASSERT_EQ(diag.str(), "failed to evaluate integer operation");
+      ASSERT_EQ(diag.str(), GetParam() ? "failed to evaluate integer operation"
+                                       : "failed to evaluate om.integer.shl");
   });
 
   OwningOpRef<ModuleOp> owning = parseModule(mod);
@@ -722,7 +877,7 @@ om.class @IntegerBinaryArithmeticShlTooLarge() -> (result: !om.integer) {
   ASSERT_TRUE(failed(result));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticObjects) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticObjects) {
   StringRef mod = R"MLIR(
 om.class @Class1() -> (value: !om.integer){
   %0 = om.constant #om.integer<1 : si3> : !om.integer
@@ -758,7 +913,7 @@ om.class @IntegerBinaryArithmeticObjects() -> (result: !om.integer) {
   ASSERT_EQ(3, getInteger(getField(result.value(), "result")));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticObjectsDelayed) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticObjectsDelayed) {
   StringRef mod = R"MLIR(
 om.class @Class1(%input: !om.integer) -> (value: !om.integer, input: !om.integer) {
   %0 = om.constant #om.integer<1 : si3> : !om.integer
@@ -794,7 +949,7 @@ om.class @IntegerBinaryArithmeticObjectsDelayed() -> (result: !om.integer){
   ASSERT_EQ(3, getInteger(getField(result.value(), "result")));
 }
 
-TEST_F(EvaluatorTests, IntegerBinaryArithmeticWidthMismatch) {
+TEST_P(EvaluatorTests, IntegerBinaryArithmeticWidthMismatch) {
   StringRef mod = R"MLIR(
 om.class @IntegerBinaryArithmeticWidthMismatch() -> (result: !om.integer) {
   %0 = om.constant #om.integer<1 : si3> : !om.integer
@@ -816,7 +971,7 @@ om.class @IntegerBinaryArithmeticWidthMismatch() -> (result: !om.integer) {
   ASSERT_EQ(3, getInteger(getField(result.value(), "result")));
 }
 
-TEST_F(EvaluatorTests, ListConcat) {
+TEST_P(EvaluatorTests, ListConcat) {
   StringRef mod = R"MLIR(
 om.class @ListConcat() -> (result: !om.list<!om.integer>) {
   %0 = om.constant #om.integer<0 : i8> : !om.integer
@@ -846,7 +1001,7 @@ om.class @ListConcat() -> (result: !om.list<!om.integer>) {
   ASSERT_EQ(2, getInteger(finalList[2]));
 }
 
-TEST_F(EvaluatorTests, ListConcatField) {
+TEST_P(EvaluatorTests, ListConcatField) {
   StringRef mod = R"MLIR(
 om.class @ListField() -> (value: !om.list<!om.integer>) {
   %0 = om.constant #om.integer<2 : i8> : !om.integer
@@ -881,7 +1036,7 @@ om.class @ListConcatField() -> (result: !om.list<!om.integer>){
   ASSERT_EQ(2, getInteger(finalList[2]));
 }
 
-TEST_F(EvaluatorTests, ListOfListConcat) {
+TEST_P(EvaluatorTests, ListOfListConcat) {
   StringRef mod = R"MLIR(
 om.class @ListOfListConcat()  -> (result: !om.list<!om.list<!om.string>>) {
   %0 = om.constant "foo" : !om.string
@@ -919,7 +1074,7 @@ om.class @ListOfListConcat()  -> (result: !om.list<!om.list<!om.string>>) {
   ASSERT_EQ("qux", getString(sublist1[1]));
 }
 
-TEST_F(EvaluatorTests, ListConcatPartialCycle) {
+TEST_P(EvaluatorTests, ListConcatPartialCycle) {
   StringRef mod = R"MLIR(
 om.class @Child(%field_in: !om.any) -> (field: !om.list<!om.any>) {
   %1 = om.list_create %field_in : !om.any
@@ -961,7 +1116,7 @@ om.class @ListConcatPartialCycle() -> (result: !om.list<!om.any>){
   ASSERT_EQ(2, getInteger(getField(finalList[1], "id")));
 }
 
-TEST_F(EvaluatorTests, NestedReferenceValue) {
+TEST_P(EvaluatorTests, NestedReferenceValue) {
   StringRef mod = R"MLIR(
 om.class @Empty() {
   om.class.fields
@@ -1018,7 +1173,7 @@ om.class @OuterClass1()  -> (om: !om.any) {
   ASSERT_TRUE(isa<evaluator::ObjectValue>(anyList2[0].get()));
 }
 
-TEST_F(EvaluatorTests, ListAttrConcat) {
+TEST_P(EvaluatorTests, ListAttrConcat) {
   StringRef mod = R"MLIR(
 om.class @ConcatListAttribute() -> (result: !om.list<!om.string>) {
   %0 = om.constant #om.list<!om.string, ["X" : !om.string, "Y" : !om.string]> : !om.list<!om.string>
@@ -1049,7 +1204,7 @@ om.class @ConcatListAttribute() -> (result: !om.list<!om.string>) {
   checkEq(listVal[3], "Y");
 }
 
-TEST_F(EvaluatorTests, UnknownValuesBasic) {
+TEST_P(EvaluatorTests, UnknownValuesBasic) {
   StringRef mod = R"MLIR(
 om.class.extern @Baz() -> (a: !om.integer) {}
 
@@ -1184,7 +1339,7 @@ om.class @Foo(
   checkFieldValueType("q", Kind::Object);   // external class -> ObjectValue
 }
 
-TEST_F(EvaluatorTests, UnknownValuesNested) {
+TEST_P(EvaluatorTests, UnknownValuesNested) {
   StringRef mod = R"MLIR(
 om.class @Bar(
   %known_in: !om.integer,
@@ -1232,7 +1387,7 @@ om.class @Foo(
   ASSERT_TRUE(getField(result.value(), "b")->isUnknown());
 }
 
-TEST_F(EvaluatorTests, StringConcat) {
+TEST_P(EvaluatorTests, StringConcat) {
   const char *mod = R"MLIR(
 module {
   om.class @Test() -> (result: !om.string) {
@@ -1259,7 +1414,7 @@ module {
   ASSERT_EQ("Hello, World!", getString(getField(result.value(), "result")));
 }
 
-TEST_F(EvaluatorTests, UnknownObjectFieldTest) {
+TEST_P(EvaluatorTests, UnknownObjectFieldTest) {
   StringRef mod = R"MLIR(
 om.class.extern @Dut_Class(%basepath: !om.frozenbasepath) -> (omirOut: !om.list<!om.any>) {
 }
@@ -1288,7 +1443,7 @@ om.class @TestHarness_Class(%basepath: !om.frozenbasepath) -> (result: !om.list<
   EXPECT_TRUE(getField(result.value(), "result")->isUnknown());
 }
 
-TEST_F(EvaluatorTests, PropertyAssertTests) {
+TEST_P(EvaluatorTests, PropertyAssertTests) {
   StringRef mod = R"MLIR(
 // Test 1: A true assert passes.
 om.class @True() -> () {
@@ -1408,6 +1563,11 @@ om.class @ChainedDomainAssert(%basepath: !om.frozenbasepath) -> () {
 
   Evaluator evaluator(owning.release());
 
+  SmallVector<std::string> assertMessages;
+  ScopedDiagnosticHandler diagnosticHandler(&context, [&](Diagnostic &diag) {
+    assertMessages.push_back(diag.str());
+  });
+
   ASSERT_TRUE(
       succeeded(evaluator.instantiate(StringAttr::get(&context, "True"), {})));
 
@@ -1444,9 +1604,20 @@ om.class @ChainedDomainAssert(%basepath: !om.frozenbasepath) -> () {
   auto basepath = std::make_shared<evaluator::BasePathValue>(&context);
   ASSERT_TRUE(failed(evaluator.instantiate(
       StringAttr::get(&context, "ChainedDomainAssert"), {basepath})));
+
+  SmallVector<StringRef> expectedMessages = {
+      "OM property assertion failed: fail!",
+      "OM property assertion failed: input must be true true",
+      "OM property assertion failed: input must be true true",
+      "OM property assertion failed: input must be true true",
+      "OM property assertion failed: input must be true true",
+      "OM property assertion failed: hello"};
+  ASSERT_EQ(assertMessages.size(), expectedMessages.size());
+  for (auto [actual, expected] : llvm::zip(assertMessages, expectedMessages))
+    EXPECT_EQ(actual, expected);
 }
 
-TEST_F(EvaluatorTests, PropEqTests) {
+TEST_P(EvaluatorTests, PropEqTests) {
   StringRef mod = R"MLIR(
 om.class @PropEqString(%s: !om.string) -> (equal: i1, not_equal: i1, unknown: i1) {
   %a    = om.constant "hello" : !om.string
@@ -1506,7 +1677,7 @@ om.class @PropEqInteger(%n: !om.integer) -> (equal: i1, not_equal: i1, unknown: 
   }
 }
 
-TEST_F(EvaluatorTests, IntegerBitwiseTests) {
+TEST_P(EvaluatorTests, IntegerBitwiseTests) {
   StringRef mod = R"MLIR(
 om.class @IntegerBitwiseAnd(%a: i8, %b: i8) -> (result: i8) {
   %and = om.integer.and %a, %b : i8
@@ -1592,8 +1763,11 @@ om.class @IntegerBitwiseUnknown(%b: i8) -> (unknown: i8) {
     auto r = evaluator.instantiate(
         StringAttr::get(&context, "IntegerBitwiseUnknown"), {unknown});
     ASSERT_TRUE(succeeded(r));
-    ASSERT_TRUE(getField(r.value(), "unknown")->isUnknown());
+    ASSERT_EQ(getField(r.value(), "unknown")->isUnknown(), GetParam());
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(EvaluatorFlows, EvaluatorTests,
+                         ::testing::Values(false, true), getEvaluatorFlowName);
 
 } // namespace

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -588,8 +588,7 @@ om.class @UseNode(%node: !ty) -> (node: !ty) {
 
   if (!GetParam()) {
     context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
-      ASSERT_EQ(diag.str(),
-                "cannot import mutually referencing OM object values");
+      ASSERT_EQ(diag.str(), "cannot import mutually referential OM objects");
     });
     auto useNodeResult =
         evaluator.instantiate(StringAttr::get(&context, "UseNode"), {node});


### PR DESCRIPTION
Run object elaboration as an internal evaluator pre-pass and evaluate the
resulting `om.elaborated_object` values through the existing evaluator path.

This switches default flow to use a new pre-pass and om.elaborated_objects.
In order to reduce the migration risk I kept the previous implementation as a fallback 
under hidden discardable attribute (`om.skip_elaboration_transform`). The old implementation
will be fully removed once it's confirmed safe. 

Assisted-by: codex: gpt 5.5

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
