### PR TITLE
[ExportVerilog] Emit LTL clocked delays

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3598,6 +3598,7 @@ private:
   EmittedProperty visitLTL(ltl::OrOp op);
   EmittedProperty visitLTL(ltl::IntersectOp op);
   EmittedProperty visitLTL(ltl::DelayOp op);
+  EmittedProperty visitLTL(ltl::ClockedDelayOp op);
   EmittedProperty visitLTL(ltl::ConcatOp op);
   EmittedProperty visitLTL(ltl::RepeatOp op);
   EmittedProperty visitLTL(ltl::GoToRepeatOp op);
@@ -3608,6 +3609,8 @@ private:
   EmittedProperty visitLTL(ltl::EventuallyOp op);
   EmittedProperty visitLTL(ltl::ClockOp op);
 
+  void emitLTLDelay(int64_t delay, std::optional<int64_t> length);
+  void emitLTLClockingEvent(ltl::ClockEdge edge, Value clock);
   void emitLTLConcat(ValueRange inputs);
 
 public:
@@ -3766,32 +3769,55 @@ EmittedProperty PropertyEmitter::visitLTL(ltl::IntersectOp op) {
   return {PropertyPrecedence::Intersect};
 }
 
-EmittedProperty PropertyEmitter::visitLTL(ltl::DelayOp op) {
+void PropertyEmitter::emitLTLDelay(int64_t delay,
+                                   std::optional<int64_t> length) {
   ps << "##";
-  if (auto length = op.getLength()) {
+  if (length) {
     if (*length == 0) {
-      ps.addAsString(op.getDelay());
+      ps.addAsString(delay);
     } else {
       ps << "[";
-      ps.addAsString(op.getDelay());
+      ps.addAsString(delay);
       ps << ":";
-      ps.addAsString(op.getDelay() + *length);
+      ps.addAsString(delay + *length);
       ps << "]";
     }
   } else {
-    if (op.getDelay() == 0) {
+    if (delay == 0) {
       ps << "[*]";
-    } else if (op.getDelay() == 1) {
+    } else if (delay == 1) {
       ps << "[+]";
     } else {
       ps << "[";
-      ps.addAsString(op.getDelay());
+      ps.addAsString(delay);
       ps << ":$]";
     }
   }
+}
+
+void PropertyEmitter::emitLTLClockingEvent(ltl::ClockEdge edge, Value clock) {
+  ps << "@(";
+  ps.scopedBox(PP::ibox2, [&] {
+    ps << PPExtString(stringifyClockEdge(edge)) << PP::space;
+    emitNestedProperty(clock, PropertyPrecedence::Lowest);
+    ps << ")";
+  });
+}
+
+EmittedProperty PropertyEmitter::visitLTL(ltl::DelayOp op) {
+  emitLTLDelay(op.getDelay(), op.getLength());
   ps << PP::space;
   emitNestedProperty(op.getInput(), PropertyPrecedence::Concat);
   return {PropertyPrecedence::Concat};
+}
+
+EmittedProperty PropertyEmitter::visitLTL(ltl::ClockedDelayOp op) {
+  emitLTLClockingEvent(op.getEdge(), op.getClock());
+  ps << PP::space;
+  emitLTLDelay(op.getDelay(), op.getLength());
+  ps << PP::space;
+  emitNestedProperty(op.getInput(), PropertyPrecedence::Concat);
+  return {PropertyPrecedence::Clocking};
 }
 
 void PropertyEmitter::emitLTLConcat(ValueRange inputs) {
@@ -3915,12 +3941,7 @@ EmittedProperty PropertyEmitter::visitLTL(ltl::EventuallyOp op) {
 }
 
 EmittedProperty PropertyEmitter::visitLTL(ltl::ClockOp op) {
-  ps << "@(";
-  ps.scopedBox(PP::ibox2, [&] {
-    ps << PPExtString(stringifyClockEdge(op.getEdge())) << PP::space;
-    emitNestedProperty(op.getClock(), PropertyPrecedence::Lowest);
-    ps << ")";
-  });
+  emitLTLClockingEvent(op.getEdge(), op.getClock());
   ps << PP::space;
   emitNestedProperty(op.getInput(), PropertyPrecedence::Clocking);
   return {PropertyPrecedence::Clocking};

--- a/test/Conversion/ExportVerilog/verif.mlir
+++ b/test/Conversion/ExportVerilog/verif.mlir
@@ -85,6 +85,16 @@ hw.module @Sequences(in %clk: i1, in %a: i1, in %b: i1) {
   %d5 = ltl.delay %a, 1 : i1
   sv.assert_property %d5 : !ltl.sequence
 
+  // CHECK: assert property (@(posedge clk) ##4 a);
+  %cd0 = ltl.clocked_delay %a, posedge %clk, 4, 0 : i1
+  sv.assert_property %cd0 : !ltl.sequence
+  // CHECK: assert property (@(negedge clk) ##[5:6] a);
+  %cd1 = ltl.clocked_delay %a, negedge %clk, 5, 1 : i1
+  sv.assert_property %cd1 : !ltl.sequence
+  // CHECK: assert property (@(edge clk) ##[7:$] a);
+  %cd2 = ltl.clocked_delay %a, edge %clk, 7 : i1
+  sv.assert_property %cd2 : !ltl.sequence
+
   // CHECK: assert property (a ##0 a);
   %c0 = ltl.concat %a, %a : i1, i1
   sv.assert_property %c0 : !ltl.sequence
@@ -97,6 +107,10 @@ hw.module @Sequences(in %clk: i1, in %a: i1, in %b: i1) {
   // CHECK: assert property (##4 a ##[5:6] a ##[7:$] a);
   %c3 = ltl.concat %d1, %d2, %d3 : !ltl.sequence, !ltl.sequence, !ltl.sequence
   sv.assert_property %c3 : !ltl.sequence
+  // CHECK: assert property (a ##0 (@(posedge clk) ##4 b));
+  %cd3 = ltl.clocked_delay %b, posedge %clk, 4, 0 : i1
+  %c4 = ltl.concat %a, %cd3 : i1, !ltl.sequence
+  sv.assert_property %c4 : !ltl.sequence
 
   // CHECK: assert property (a and ##0 a);
   %g0 = ltl.and %a, %d0 : i1, !ltl.sequence
@@ -165,6 +179,9 @@ hw.module @Sequences(in %clk: i1, in %a: i1, in %b: i1) {
   // CHECK: assert property (b ##0 (@(posedge clk) a));
   %k4 = ltl.concat %b, %k0 : i1, !ltl.sequence
   sv.assert_property %k4 : !ltl.sequence
+  // CHECK: assert property (@(edge clk) @(posedge clk) ##4 b);
+  %k5 = ltl.clock %cd3, edge %clk : !ltl.sequence
+  sv.assert_property %k5 : !ltl.sequence
 }
 
 // CHECK-LABEL: module Properties


### PR DESCRIPTION
This PR is a follow-up to #10423, emit LTL clocked delays to verilog. Completed `Stage3` of the POC #9859. 

As for the `InferLTLClocks pass` for `Stage2`, I found it a bit complicated after implementing part of it, I think it would be better to continue working on it after merging #10392, and then analyze `ltl.clocked_delay` and `ltl.past` together in the pass.

Assisted-by: codex:gpt-5.5