### PR TITLE
[ImportVerilog] Fix several bugs in the handling of arrays

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -181,6 +181,25 @@ static Value visitClassProperty(Context &context,
   return fieldRef;
 }
 
+/// Ensures that the given range is in "descending" order.
+///
+/// `type` must have a fixed range. If the range is defined such that
+/// left < right, the range is reversed.
+///
+/// For example:
+///   [3:0] => do not reverse
+///   [0:3] => reverse
+///
+/// The resulting range is suitable for passing to an ArrayCreateOp which expects
+/// operands to be in descending order of significance.
+template <typename RangeT>
+static void ensureDescendingOrder(RangeT& range, const slang::ast::Type& type) {
+  assert(type.hasFixedRange());
+  const slang::ConstantRange& cstRange = type.getFixedRange();
+  if (cstRange.left < cstRange.right)
+    std::reverse(std::begin(range), std::end(range));
+}
+
 namespace {
 /// A visitor handling expressions that can be lowered as lvalue and rvalue.
 struct ExprVisitor {
@@ -2141,6 +2160,7 @@ struct RvalueExprVisitor : public ExprVisitor {
         return {};
 
       assert(intType.getWidth() == elements->size());
+      ensureDescendingOrder(*elements, *expr.type);
       std::reverse(elements->begin(), elements->end());
       return moore::ConcatOp::create(builder, loc, intType, *elements);
     }
@@ -2194,6 +2214,7 @@ struct RvalueExprVisitor : public ExprVisitor {
       if (failed(elements))
         return {};
 
+      ensureDescendingOrder(*elements, *expr.type);
       assert(arrayType.getSize() == elements->size());
       return moore::ArrayCreateOp::create(builder, loc, arrayType, *elements);
     }
@@ -2206,6 +2227,7 @@ struct RvalueExprVisitor : public ExprVisitor {
       if (failed(elements))
         return {};
 
+      ensureDescendingOrder(*elements, *expr.type);
       assert(arrayType.getSize() == elements->size());
       return moore::ArrayCreateOp::create(builder, loc, arrayType, *elements);
     }
@@ -2756,6 +2778,7 @@ Value Context::materializeFixedSizeUnpackedArrayType(
 
   // Take the result of each ConstantOp and concatenate them into an array (of
   // constant values).
+  ensureDescendingOrder(elemVals, astType);
   auto arrayOp = moore::ArrayCreateOp::create(builder, loc, arrType, elemVals);
 
   return arrayOp.getResult();

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -190,12 +190,12 @@ static Value visitClassProperty(Context &context,
 ///   [3:0] => do not reverse
 ///   [0:3] => reverse
 ///
-/// The resulting range is suitable for passing to an ArrayCreateOp which expects
-/// operands to be in descending order of significance.
+/// The resulting range is suitable for passing to an ArrayCreateOp which
+/// expects operands to be in descending order of significance.
 template <typename RangeT>
-static void ensureDescendingOrder(RangeT& range, const slang::ast::Type& type) {
+static void ensureDescendingOrder(RangeT &range, const slang::ast::Type &type) {
   assert(type.hasFixedRange());
-  const slang::ConstantRange& cstRange = type.getFixedRange();
+  const slang::ConstantRange &cstRange = type.getFixedRange();
   if (cstRange.left < cstRange.right)
     std::reverse(std::begin(range), std::end(range));
 }

--- a/test/Conversion/ImportVerilog/array.sv
+++ b/test/Conversion/ImportVerilog/array.sv
@@ -7,13 +7,11 @@
 //===---------------------------------------------------------------------===//
 // Array element indexing
 //===---------------------------------------------------------------------===//
-// Array element indexing should return the same value regardless of whether
-// the array is packed or unpacked, or reverse-ordered. array[X] should return
-// the X'th value.
-//
 // hw.array's indices are always ordered such that index 0 means the least
-// significant element. Therefore regardless of the SV type ([3:0] vs [0:3] vs
-// $[4]) we should always plant an array_get of the same index.
+// significant element.
+//
+// SV types provide a mapping onto those elements, with [3:0 being the identity
+// mapping and [0:3] being the reversed mapping.
 
 // CHECK-LABEL: @array_get_dyn_packed
 // CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %idx

--- a/test/Conversion/ImportVerilog/array.sv
+++ b/test/Conversion/ImportVerilog/array.sv
@@ -18,12 +18,11 @@
 // CHECK-LABEL: @array_get_dyn_packed
 // CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %idx
 // CHECK-NEXT: moore.output %[[X]]
-module array_get_dyn_packed(
-  input wire [3:0][15:0] arg0,
-  input wire [1:0]       idx,
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[idx];
+module array_get_dyn_packed
+    (input wire [3 : 0][15 : 0] arg0,
+     input wire [1 : 0] idx,
+     output wire [15 : 0] elem);
+  assign elem = arg0[idx];
 endmodule
 
 // CHECK-LABEL: @array_get_dyn_packed_rev
@@ -31,12 +30,11 @@ endmodule
 // CHECK: %[[S:.*]] = moore.sub %[[C]], %idx
 // CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %[[S]]
 // CHECK-NEXT: moore.output %[[X]]
-module array_get_dyn_packed_rev(
-  input wire [0:3][15:0] arg0,
-  input wire [1:0]       idx,
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[idx];
+module array_get_dyn_packed_rev
+    (input wire [0 : 3][15 : 0] arg0,
+     input wire [1 : 0] idx,
+     output wire [15 : 0] elem);
+  assign elem = arg0[idx];
 endmodule
 
 // CHECK-LABEL: @array_get_dyn_unpacked
@@ -44,127 +42,115 @@ endmodule
 // CHECK: %[[S:.*]] = moore.sub %[[C]], %idx
 // CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %[[S]]
 // CHECK-NEXT: moore.output %[[X]]
-module array_get_dyn_unpacked(
-  input wire [15:0] arg0 [4],
-  input wire [1:0]       idx,
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[idx];
+module array_get_dyn_unpacked
+    (input wire [15 : 0] arg0[4],
+     input wire [1 : 0] idx,
+     output wire [15 : 0] elem);
+  assign elem = arg0[idx];
 endmodule
 
 // CHECK-LABEL: @array_get_dyn_unpacked_rev
 // CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %idx
 // CHECK-NEXT: moore.output %[[X]]
-module array_get_dyn_unpacked_rev(
-  input wire [15:0] arg0 [3:0],
-  input wire [1:0]       idx,
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[idx];
+module array_get_dyn_unpacked_rev
+    (input wire [15 : 0] arg0[3 : 0],
+     input wire [1 : 0] idx,
+     output wire [15 : 0] elem);
+  assign elem = arg0[idx];
 endmodule
 
 // CHECK-LABEL: @array_get_static_packed
 // CHECK: %[[X:.*]] = moore.extract %arg0 from 1
 // CHECK-NEXT: moore.output %[[X]]
-module array_get_static_packed(
-  input wire [3:0][15:0] arg0,
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[1];
+module array_get_static_packed
+    (input wire [3 : 0][15 : 0] arg0,
+     output wire [15 : 0] elem);
+  assign elem = arg0[1];
 endmodule
 
 // CHECK-LABEL: @array_get_static_packed_rev
 // CHECK: %[[X:.*]] = moore.extract %arg0 from 2
 // CHECK-NEXT: moore.output %[[X]]
-module array_get_static_packed_rev(
-  input wire [0:3][15:0] arg0,
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[1];
+module array_get_static_packed_rev
+    (input wire [0 : 3][15 : 0] arg0,
+     output wire [15 : 0] elem);
+  assign elem = arg0[1];
 endmodule
 
 // CHECK-LABEL: @array_get_static_unpacked
 // CHECK: %[[X:.*]] = moore.extract %arg0 from 2
 // CHECK-NEXT: moore.output %[[X]]
-module array_get_static_unpacked(
-  input wire [15:0] arg0 [4],
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[1];
+module array_get_static_unpacked
+    (input wire [15 : 0] arg0[4],
+     output wire [15 : 0] elem);
+  assign elem = arg0[1];
 endmodule
 
 // CHECK-LABEL: @array_get_static_unpacked_rev
 // CHECK: %[[X:.*]] = moore.extract %arg0 from 1
 // CHECK-NEXT: moore.output %[[X]]
-module array_get_static_unpacked_rev(
-  input wire [15:0] arg0 [3:0],
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[1];
+module array_get_static_unpacked_rev
+    (input wire [15 : 0] arg0[3 : 0],
+     output wire [15 : 0] elem);
+  assign elem = arg0[1];
 endmodule
 
 // CHECK-LABEL: @array_get_static_unpacked_rev
 // CHECK: %[[X:.*]] = moore.extract %arg0 from 2
-module array_get_static_unpacked_rev_rev(
-  input wire [15:0] arg0 [0:3],
-  output wire [15:0]	 elem
-);
-   assign elem = arg0[1];
+module array_get_static_unpacked_rev_rev
+    (input wire [15 : 0] arg0[0 : 3],
+     output wire [15 : 0] elem);
+  assign elem = arg0[1];
 endmodule
 
 // CHECK-LABEL: @array_slice_dyn_packed
 // CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %idx
 // CHECK-NEXT: moore.output %[[X]]
-module array_slice_dyn_packed(
-  input wire [7:0][15:0] arg0,
-  input wire [2:0]       idx,
-  output wire [3:0][15:0] slice
-);
-  assign slice = arg0[idx+:4];
+module array_slice_dyn_packed
+    (input wire [7 : 0][15 : 0] arg0,
+     input wire [2 : 0] idx,
+     output wire [3 : 0][15 : 0] slice);
+  assign slice = arg0[idx +: 4];
 endmodule
 
 // CHECK-LABEL: @array_slice_dyn_packed_rev
 // CHECK: %[[S:.*]] = moore.sub
 // CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %[[S]]
 // CHECK-NEXT: moore.output %[[X]]
-module array_slice_dyn_packed_rev(
-  input wire [0:7][15:0] arg0,
-  input wire [2:0]       idx,
-  output wire [3:0][15:0] slice
-);
-  assign slice = arg0[idx+:4];
+module array_slice_dyn_packed_rev
+    (input wire [0 : 7][15 : 0] arg0,
+     input wire [2 : 0] idx,
+     output wire [3 : 0][15 : 0] slice);
+  assign slice = arg0[idx +: 4];
 endmodule
 
 // CHECK-LABEL: @array_slice_dyn_unpacked
 // CHECK: %[[S:.*]] = moore.sub
 // CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %[[S]]
 // CHECK-NEXT: moore.output %[[X]]
-module array_slice_dyn_unpacked(
-  input wire [15:0] arg0 [8],
-  input wire [2:0]       idx,
-  output wire [15:0] slice [4]
-);
-  assign slice = arg0[idx+:4];
+module array_slice_dyn_unpacked
+    (input wire [15 : 0] arg0[8],
+     input wire [2 : 0] idx,
+     output wire [15 : 0] slice[4]);
+  assign slice = arg0[idx +: 4];
 endmodule
 
 // CHECK-LABEL: @array_slice_static_packed
 // CHECK: %[[X:.*]] = moore.extract %arg0 from 1
 // CHECK-NEXT: moore.output %[[X]]
-module array_slice_static_packed(
-  input wire [7:0][15:0] arg0,
-  output wire [3:0][15:0] slice
-);
-  assign slice = arg0[1+:4];
+module array_slice_static_packed
+    (input wire [7 : 0][15 : 0] arg0,
+     output wire [3 : 0][15 : 0] slice);
+  assign slice = arg0[1 +: 4];
 endmodule
 
 // CHECK-LABEL: @array_slice_static_unpacked
 // CHECK: %[[X:.*]] = moore.extract %arg0 from 3
 // CHECK-NEXT: moore.output %[[X]]
-module array_slice_static_unpacked(
-  input wire [15:0] arg0 [8],
-  output wire [15:0] slice [4]
-);
-  assign slice = arg0[1+:4];
+module array_slice_static_unpacked
+    (input wire [15 : 0] arg0[8],
+     output wire [15 : 0] slice[4]);
+  assign slice = arg0[1 +: 4];
 endmodule
 
 //===----------------------------------------------------------------------===//
@@ -181,37 +167,33 @@ endmodule
 
 // CHECK-LABEL: @array_assign_packed
 // CHECK: moore.array_create %d, %c, %b, %a
-module array_assign_packed(
-  input wire [15:0] a, b, c, d,
-  output wire [3:0][15:0] out
-);
+module array_assign_packed
+    (input wire [15 : 0] a, b, c, d,
+     output wire [3 : 0][15 : 0] out);
   assign out = '{d, c, b, a};
 endmodule
 
 // CHECK-LABEL: @array_assign_unpacked
 // CHECK: moore.array_create %a, %b, %c, %d
-module array_assign_unpacked(
-  input wire [15:0] a, b, c, d,
-  output wire [15:0] out [4]
-);
+module array_assign_unpacked
+    (input wire [15 : 0] a, b, c, d,
+     output wire [15 : 0] out[4]);
   assign out = '{d, c, b, a};
 endmodule
 
 // CHECK-LABEL: @array_assign_rev_packed
 // CHECK: moore.array_create %a, %b, %c, %d
-module array_assign_rev_packed(
-  input wire [15:0] a, b, c, d,
-  output wire [0:3][15:0] out
-);
+module array_assign_rev_packed
+    (input wire [15 : 0] a, b, c, d,
+     output wire [0 : 3][15 : 0] out);
   assign out = '{d, c, b, a};
 endmodule
 
 // CHECK-LABEL: @array_assign_rev_unpacked
 // CHECK: moore.array_create %d, %c, %b, %a
-module array_assign_rev_unpacked(
-  input wire [15:0] a, b, c, d,
-  output wire [15:0] out [3:0]
-);
+module array_assign_rev_unpacked
+    (input wire [15 : 0] a, b, c, d,
+     output wire [15 : 0] out[3 : 0]);
   assign out = '{d, c, b, a};
 endmodule
 
@@ -224,11 +206,10 @@ endmodule
 // CHECK-DAG: %[[X2:.*]] = moore.constant 12
 // CHECK-DAG: %[[X3:.*]] = moore.constant 13
 // CHECK: moore.array_create %[[X0]], %[[X1]], %[[X2]], %[[X3]]
-module array_assign_constant(
-  input wire [1:0] addr,
-  output wire [15:0] out
-);
-  localparam bit [15:0] kArr[4] = '{16'hD, 16'hC, 16'hB, 16'hA};
+module array_assign_constant
+    (input wire [1 : 0] addr,
+     output wire [15 : 0] out);
+  localparam bit [15 : 0] kArr[4] = '{16'hD, 16'hC, 16'hB, 16'hA};
 
   assign out = kArr[addr];
 endmodule
@@ -240,11 +221,10 @@ endmodule
 // CHECK-DAG: %[[X2:.*]] = moore.constant 12
 // CHECK-DAG: %[[X3:.*]] = moore.constant 13
 // CHECK: moore.array_create %[[X0]], %[[X1]], %[[X2]], %[[X3]]
-module array_assign_constant_explicit(
-  input wire [1:0] addr,
-  output wire [15:0] out
-);
-  localparam bit [15:0] kArr[0:3] = '{16'hD, 16'hC, 16'hB, 16'hA};
+module array_assign_constant_explicit
+    (input wire [1 : 0] addr,
+     output wire [15 : 0] out);
+  localparam bit [15 : 0] kArr[0 : 3] = '{16'hD, 16'hC, 16'hB, 16'hA};
 
   assign out = kArr[addr];
 endmodule
@@ -257,11 +237,10 @@ endmodule
 // CHECK-DAG: %[[X2:.*]] = moore.constant 12
 // CHECK-DAG: %[[X3:.*]] = moore.constant 13
 // CHECK: moore.array_create %[[X3]], %[[X2]], %[[X1]], %[[X0]]
-module array_assign_constant_explicit_rev(
-  input wire [1:0] addr,
-  output wire [15:0] out
-);
-  localparam bit [15:0] kArr[3:0] = '{16'hD, 16'hC, 16'hB, 16'hA};
+module array_assign_constant_explicit_rev
+    (input wire [1 : 0] addr,
+     output wire [15 : 0] out);
+  localparam bit [15 : 0] kArr[3 : 0] = '{16'hD, 16'hC, 16'hB, 16'hA};
 
   assign out = kArr[addr];
 endmodule
@@ -272,9 +251,8 @@ endmodule
 // CHECK-DAG: %[[X0:.*]] = moore.constant 0 :
 // CHECK-DAG: %[[X1:.*]] = moore.constant 1 :
 // CHECK: moore.concat %[[X1]], %[[X0]]
-module int_assign_constant(
-  output wire [1:0] out
-);
+module int_assign_constant
+    (output wire [1 : 0] out);
   assign out = '{0, 1};
 endmodule
 
@@ -282,9 +260,8 @@ endmodule
 // CHECK-DAG: %[[X0:.*]] = moore.constant 0 :
 // CHECK-DAG: %[[X1:.*]] = moore.constant 1 :
 // CHECK: moore.concat %[[X0]], %[[X1]]
-module int_assign_constant_rev(
-  output wire [0:1] out
-);
+module int_assign_constant_rev
+    (output wire [0 : 1] out);
   assign out = '{0, 1};
 endmodule
 
@@ -297,22 +274,18 @@ endmodule
 //  wire [2:0] a = {1, 2, 3}  // a[0] == 3
 //  wire [0:2] b = {1, 2, 3}  // b[0] == 3
 
-module array_concat_constant_packed(
-  output wire [2:0][3:0] out
-);
+module array_concat_constant_packed
+    (output wire [2 : 0][3 : 0] out);
   assign out = {4'd1, 4'd2, 4'd3};
 endmodule
 
-module array_concat_constant_packed_rev(
-  output wire [0:2][3:0] out
-);
+module array_concat_constant_packed_rev
+    (output wire [0 : 2][3 : 0] out);
   assign out = {4'd1, 4'd2, 4'd3};
 endmodule
-
 
 // Note that the standard says that this should not compile!
-module array_concat_constant_unpacked(
-  output wire [3:0] out [3]
-);
+module array_concat_constant_unpacked
+    (output wire [3 : 0] out[3]);
   assign out = {4'd1, 4'd2, 4'd3};
 endmodule

--- a/test/Conversion/ImportVerilog/array.sv
+++ b/test/Conversion/ImportVerilog/array.sv
@@ -1,0 +1,318 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+//===---------------------------------------------------------------------===//
+// Array element indexing
+//===---------------------------------------------------------------------===//
+// Array element indexing should return the same value regardless of whether
+// the array is packed or unpacked, or reverse-ordered. array[X] should return
+// the X'th value.
+//
+// hw.array's indices are always ordered such that index 0 means the least
+// significant element. Therefore regardless of the SV type ([3:0] vs [0:3] vs
+// $[4]) we should always plant an array_get of the same index.
+
+// CHECK-LABEL: @array_get_dyn_packed
+// CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %idx
+// CHECK-NEXT: moore.output %[[X]]
+module array_get_dyn_packed(
+  input wire [3:0][15:0] arg0,
+  input wire [1:0]       idx,
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[idx];
+endmodule
+
+// CHECK-LABEL: @array_get_dyn_packed_rev
+// CHECK: %[[C:.*]] = moore.constant -1
+// CHECK: %[[S:.*]] = moore.sub %[[C]], %idx
+// CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %[[S]]
+// CHECK-NEXT: moore.output %[[X]]
+module array_get_dyn_packed_rev(
+  input wire [0:3][15:0] arg0,
+  input wire [1:0]       idx,
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[idx];
+endmodule
+
+// CHECK-LABEL: @array_get_dyn_unpacked
+// CHECK: %[[C:.*]] = moore.constant -1
+// CHECK: %[[S:.*]] = moore.sub %[[C]], %idx
+// CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %[[S]]
+// CHECK-NEXT: moore.output %[[X]]
+module array_get_dyn_unpacked(
+  input wire [15:0] arg0 [4],
+  input wire [1:0]       idx,
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[idx];
+endmodule
+
+// CHECK-LABEL: @array_get_dyn_unpacked_rev
+// CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %idx
+// CHECK-NEXT: moore.output %[[X]]
+module array_get_dyn_unpacked_rev(
+  input wire [15:0] arg0 [3:0],
+  input wire [1:0]       idx,
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[idx];
+endmodule
+
+// CHECK-LABEL: @array_get_static_packed
+// CHECK: %[[X:.*]] = moore.extract %arg0 from 1
+// CHECK-NEXT: moore.output %[[X]]
+module array_get_static_packed(
+  input wire [3:0][15:0] arg0,
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[1];
+endmodule
+
+// CHECK-LABEL: @array_get_static_packed_rev
+// CHECK: %[[X:.*]] = moore.extract %arg0 from 2
+// CHECK-NEXT: moore.output %[[X]]
+module array_get_static_packed_rev(
+  input wire [0:3][15:0] arg0,
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[1];
+endmodule
+
+// CHECK-LABEL: @array_get_static_unpacked
+// CHECK: %[[X:.*]] = moore.extract %arg0 from 2
+// CHECK-NEXT: moore.output %[[X]]
+module array_get_static_unpacked(
+  input wire [15:0] arg0 [4],
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[1];
+endmodule
+
+// CHECK-LABEL: @array_get_static_unpacked_rev
+// CHECK: %[[X:.*]] = moore.extract %arg0 from 1
+// CHECK-NEXT: moore.output %[[X]]
+module array_get_static_unpacked_rev(
+  input wire [15:0] arg0 [3:0],
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[1];
+endmodule
+
+// CHECK-LABEL: @array_get_static_unpacked_rev
+// CHECK: %[[X:.*]] = moore.extract %arg0 from 2
+module array_get_static_unpacked_rev_rev(
+  input wire [15:0] arg0 [0:3],
+  output wire [15:0]	 elem
+);
+   assign elem = arg0[1];
+endmodule
+
+// CHECK-LABEL: @array_slice_dyn_packed
+// CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %idx
+// CHECK-NEXT: moore.output %[[X]]
+module array_slice_dyn_packed(
+  input wire [7:0][15:0] arg0,
+  input wire [2:0]       idx,
+  output wire [3:0][15:0] slice
+);
+  assign slice = arg0[idx+:4];
+endmodule
+
+// CHECK-LABEL: @array_slice_dyn_packed_rev
+// CHECK: %[[S:.*]] = moore.sub
+// CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %[[S]]
+// CHECK-NEXT: moore.output %[[X]]
+module array_slice_dyn_packed_rev(
+  input wire [0:7][15:0] arg0,
+  input wire [2:0]       idx,
+  output wire [3:0][15:0] slice
+);
+  assign slice = arg0[idx+:4];
+endmodule
+
+// CHECK-LABEL: @array_slice_dyn_unpacked
+// CHECK: %[[S:.*]] = moore.sub
+// CHECK: %[[X:.*]] = moore.dyn_extract %arg0 from %[[S]]
+// CHECK-NEXT: moore.output %[[X]]
+module array_slice_dyn_unpacked(
+  input wire [15:0] arg0 [8],
+  input wire [2:0]       idx,
+  output wire [15:0] slice [4]
+);
+  assign slice = arg0[idx+:4];
+endmodule
+
+// CHECK-LABEL: @array_slice_static_packed
+// CHECK: %[[X:.*]] = moore.extract %arg0 from 1
+// CHECK-NEXT: moore.output %[[X]]
+module array_slice_static_packed(
+  input wire [7:0][15:0] arg0,
+  output wire [3:0][15:0] slice
+);
+  assign slice = arg0[1+:4];
+endmodule
+
+// CHECK-LABEL: @array_slice_static_unpacked
+// CHECK: %[[X:.*]] = moore.extract %arg0 from 3
+// CHECK-NEXT: moore.output %[[X]]
+module array_slice_static_unpacked(
+  input wire [15:0] arg0 [8],
+  output wire [15:0] slice [4]
+);
+  assign slice = arg0[1+:4];
+endmodule
+
+//===----------------------------------------------------------------------===//
+// Array assignment
+//===----------------------------------------------------------------------===//
+//
+// The assignment pattern '{...} populates an array starting from its leftmost
+// bound, which is inferred from the type; `3` for `[3:0]`, `0` for `[0:3]`.
+//
+// The natural ordering for unpacked array assignment is little endian [0:N]:
+//
+//  7.4.2: "A declaration like `logic [7:0] b [3]` is equivalent to
+//         `logic [7:0] b [0:2]`.
+
+// CHECK-LABEL: @array_assign_packed
+// CHECK: moore.array_create %d, %c, %b, %a
+module array_assign_packed(
+  input wire [15:0] a, b, c, d,
+  output wire [3:0][15:0] out
+);
+  assign out = '{d, c, b, a};
+endmodule
+
+// CHECK-LABEL: @array_assign_unpacked
+// CHECK: moore.array_create %a, %b, %c, %d
+module array_assign_unpacked(
+  input wire [15:0] a, b, c, d,
+  output wire [15:0] out [4]
+);
+  assign out = '{d, c, b, a};
+endmodule
+
+// CHECK-LABEL: @array_assign_rev_packed
+// CHECK: moore.array_create %a, %b, %c, %d
+module array_assign_rev_packed(
+  input wire [15:0] a, b, c, d,
+  output wire [0:3][15:0] out
+);
+  assign out = '{d, c, b, a};
+endmodule
+
+// CHECK-LABEL: @array_assign_rev_unpacked
+// CHECK: moore.array_create %d, %c, %b, %a
+module array_assign_rev_unpacked(
+  input wire [15:0] a, b, c, d,
+  output wire [15:0] out [3:0]
+);
+  assign out = '{d, c, b, a};
+endmodule
+
+// Arrays are assigned left-to-right according to their type.
+// bit [15:0]$[4] implicitly has type [15:0]$[0:3], so
+//   out[0] = D, out[1] = C, out[2] = B, out[3] = A
+// CHECK-LABEL: @array_assign_constant
+// CHECK-DAG: %[[X0:.*]] = moore.constant 10
+// CHECK-DAG: %[[X1:.*]] = moore.constant 11
+// CHECK-DAG: %[[X2:.*]] = moore.constant 12
+// CHECK-DAG: %[[X3:.*]] = moore.constant 13
+// CHECK: moore.array_create %[[X0]], %[[X1]], %[[X2]], %[[X3]]
+module array_assign_constant(
+  input wire [1:0] addr,
+  output wire [15:0] out
+);
+  localparam bit [15:0] kArr[4] = '{16'hD, 16'hC, 16'hB, 16'hA};
+
+  assign out = kArr[addr];
+endmodule
+
+// As above, but using the explicit [0:3] syntax.
+// CHECK-LABEL: @array_assign_constant_explicit
+// CHECK-DAG: %[[X0:.*]] = moore.constant 10
+// CHECK-DAG: %[[X1:.*]] = moore.constant 11
+// CHECK-DAG: %[[X2:.*]] = moore.constant 12
+// CHECK-DAG: %[[X3:.*]] = moore.constant 13
+// CHECK: moore.array_create %[[X0]], %[[X1]], %[[X2]], %[[X3]]
+module array_assign_constant_explicit(
+  input wire [1:0] addr,
+  output wire [15:0] out
+);
+  localparam bit [15:0] kArr[0:3] = '{16'hD, 16'hC, 16'hB, 16'hA};
+
+  assign out = kArr[addr];
+endmodule
+
+// Explicitly using the reversed syntax [3:0]. Again, assign left-to-right,
+// so out[3] = D, out[2] = C, out[1] = B, out[0] = A.
+// CHECK-LABEL: @array_assign_constant_explicit_rev
+// CHECK-DAG: %[[X0:.*]] = moore.constant 10
+// CHECK-DAG: %[[X1:.*]] = moore.constant 11
+// CHECK-DAG: %[[X2:.*]] = moore.constant 12
+// CHECK-DAG: %[[X3:.*]] = moore.constant 13
+// CHECK: moore.array_create %[[X3]], %[[X2]], %[[X1]], %[[X0]]
+module array_assign_constant_explicit_rev(
+  input wire [1:0] addr,
+  output wire [15:0] out
+);
+  localparam bit [15:0] kArr[3:0] = '{16'hD, 16'hC, 16'hB, 16'hA};
+
+  assign out = kArr[addr];
+endmodule
+
+// The same rules apply for integers; assignment proceeds from left-to-right,
+// so out[1] = 0, out[0] = 1.
+// CHECK-LABEL: @int_assign_constant
+// CHECK-DAG: %[[X0:.*]] = moore.constant 0 :
+// CHECK-DAG: %[[X1:.*]] = moore.constant 1 :
+// CHECK: moore.concat %[[X1]], %[[X0]]
+module int_assign_constant(
+  output wire [1:0] out
+);
+  assign out = '{0, 1};
+endmodule
+
+// CHECK-LABEL: @int_assign_constant_rev
+// CHECK-DAG: %[[X0:.*]] = moore.constant 0 :
+// CHECK-DAG: %[[X1:.*]] = moore.constant 1 :
+// CHECK: moore.concat %[[X0]], %[[X1]]
+module int_assign_constant_rev(
+  output wire [0:1] out
+);
+  assign out = '{0, 1};
+endmodule
+
+//===----------------------------------------------------------------------===//
+// Array concatenation
+//===----------------------------------------------------------------------===//
+//
+// The concatenation operator's operands are always ordered from most to least
+// significant:
+//  wire [2:0] a = {1, 2, 3}  // a[0] == 3
+//  wire [0:2] b = {1, 2, 3}  // b[0] == 3
+
+module array_concat_constant_packed(
+  output wire [2:0][3:0] out
+);
+  assign out = {4'd1, 4'd2, 4'd3};
+endmodule
+
+module array_concat_constant_packed_rev(
+  output wire [0:2][3:0] out
+);
+  assign out = {4'd1, 4'd2, 4'd3};
+endmodule
+
+
+// Note that the standard says that this should not compile!
+module array_concat_constant_unpacked(
+  output wire [3:0] out [3]
+);
+  assign out = {4'd1, 4'd2, 4'd3};
+endmodule

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -958,25 +958,25 @@ module Expressions;
     // CHECK: [[TMP1:%.+]] = moore.read %vec_1 : <l32>
     // CHECK: moore.extract [[TMP1]] from 15 : l32 -> l1
     y = vec_1[15];
-    // CHECK: [[TMP1:%.+]] = moore.read %vec_2 : <l32> 
-    // CHECK: [[TMP2:%.+]] = moore.read %vec_1 : <l32> 
-    // CHECK: [[TMP3:%.+]] = moore.constant 31 : l32 
-    // CHECK: [[TMP4:%.+]] = moore.sub [[TMP3]], [[TMP2]] : l32 
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_2 : <l32>
+    // CHECK: [[TMP2:%.+]] = moore.read %vec_1 : <l32>
+    // CHECK: [[TMP3:%.+]] = moore.constant 31 : l32
+    // CHECK: [[TMP4:%.+]] = moore.sub [[TMP3]], [[TMP2]] : l32
     // CHECK: moore.dyn_extract [[TMP1]] from [[TMP4]] : l32, l32 -> l1
     y = vec_2[vec_1];
-    // CHECK: [[TMP1:%.+]] = moore.read %vec_1a : <l17> 
-    // CHECK: [[TMP2:%.+]] = moore.read %vec_1 : <l32> 
-    // CHECK: [[TMP3:%.+]] = moore.constant 15 : l32 
-    // CHECK: [[TMP4:%.+]] = moore.sub [[TMP2]], [[TMP3]] : l32 
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_1a : <l17>
+    // CHECK: [[TMP2:%.+]] = moore.read %vec_1 : <l32>
+    // CHECK: [[TMP3:%.+]] = moore.constant 15 : l32
+    // CHECK: [[TMP4:%.+]] = moore.sub [[TMP2]], [[TMP3]] : l32
     // CHECK: moore.dyn_extract [[TMP1]] from [[TMP4]] : l17, l32 -> l1
     y = vec_1a[vec_1];
-    // CHECK: [[TMP1:%.+]] = moore.read %vec_1b : <l32> 
-    // CHECK: [[TMP2:%.+]] = moore.read %vec_1 : <l32> 
-    // CHECK: [[TMP3:%.+]] = moore.neg [[TMP2]] : l32 
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_1b : <l32>
+    // CHECK: [[TMP2:%.+]] = moore.read %vec_1 : <l32>
+    // CHECK: [[TMP3:%.+]] = moore.neg [[TMP2]] : l32
     // CHECK: moore.dyn_extract [[TMP1]] from [[TMP3]] : l32, l32 -> l1
     y = vec_1b[vec_1];
-    // CHECK: [[TMP1:%.+]] = moore.read %vec_1a : <l17> 
-    // CHECK: [[TMP2:%.+]] = moore.read %x : <i1> 
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_1a : <l17>
+    // CHECK: [[TMP2:%.+]] = moore.read %x : <i1>
     // CHECK: [[TMP3:%.+]] = moore.zext [[TMP2]] : i1 -> i5
     // CHECK: [[TMP4:%.+]] = moore.constant 15 : i5
     // CHECK: [[TMP5:%.+]] = moore.sub [[TMP3]], [[TMP4]] : i5
@@ -1003,7 +1003,7 @@ module Expressions;
     // CHECK: [[X_ZEXT:%.+]] = moore.zext [[X_READ]] : i1 -> i5
     // CHECK: moore.dyn_extract_ref %vec_1 from [[X_ZEXT]] : <l32>, i5 -> <l1>
     vec_1[x] = y;
-    
+
     // CHECK: moore.extract_ref %vec_1 from 13 : <l32> -> <l3>
     vec_1[15-:3] = y;
 
@@ -1167,11 +1167,11 @@ module Expressions;
 
     // CHECK: [[TMP0:%.+]] = moore.constant 43
     // CHECK: [[TMP1:%.+]] = moore.constant 9002
-    // CHECK: moore.array_create [[TMP0]], [[TMP1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+    // CHECK: moore.array_create [[TMP1]], [[TMP0]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
     arr1 = '{43, 9002};
     // CHECK: [[TMP0:%.+]] = moore.constant 43
     // CHECK: [[TMP1:%.+]] = moore.constant 9002
-    // CHECK: moore.array_create [[TMP0]], [[TMP1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+    // CHECK: moore.array_create [[TMP1]], [[TMP0]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
     arr2 = '{43, 9002};
     // CHECK: [[TMP1:%.+]] = moore.read %arr1
     // CHECK: [[TMP2:%.+]] = moore.read %arr2
@@ -1639,13 +1639,13 @@ module Expressions;
 
     // CHECK: [[TMP0:%.+]] = moore.constant 43
     // CHECK: [[TMP1:%.+]] = moore.constant 9002
-    // CHECK: moore.array_create [[TMP0]], [[TMP1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+    // CHECK: moore.array_create [[TMP1]], [[TMP0]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
     uarrayInt = '{43, 9002};
 
     // CHECK: [[TMP0:%.+]] = moore.constant 1
     // CHECK: [[TMP1:%.+]] = moore.constant 2
     // CHECK: [[TMP2:%.+]] = moore.constant 3
-    // CHECK: [[TMP3:%.+]] = moore.array_create [[TMP0]], [[TMP1]], [[TMP2]], [[TMP0]], [[TMP1]], [[TMP2]] : !moore.i4, !moore.i4, !moore.i4, !moore.i4, !moore.i4, !moore.i4 -> uarray<6 x i4>
+    // CHECK: [[TMP3:%.+]] = moore.array_create [[TMP2]], [[TMP1]], [[TMP0]], [[TMP2]], [[TMP1]], [[TMP0]] : !moore.i4, !moore.i4, !moore.i4, !moore.i4, !moore.i4, !moore.i4 -> uarray<6 x i4>
     // CHECK: moore.array_create [[TMP3]], [[TMP3]], [[TMP3]] : !moore.uarray<6 x i4>, !moore.uarray<6 x i4>, !moore.uarray<6 x i4> -> uarray<3 x uarray<6 x i4>>
     arr = '{3{'{2{4'd1, 4'd2, 4'd3}}}};
 
@@ -1655,7 +1655,7 @@ module Expressions;
     // CHECK: [[TMP3:%.+]] = moore.constant 0 :
     // CHECK: moore.concat [[TMP3]], [[TMP2]], [[TMP1]], [[TMP0]] : (!moore.l1, !moore.l1, !moore.l1, !moore.l1) -> l4
     m = '{default: '0, 2: '1};
- 
+
     //===------------------------------------------------------------------===//
     // Builtin Functions
 
@@ -1728,13 +1728,13 @@ endmodule
 // CHECK-LABEL: moore.module @realToTimeConversion
 module realToTimeConversion;
   // CHECK: procedure initial
-  // CHECK: [[TIME:%.+]] = moore.builtin.time 
+  // CHECK: [[TIME:%.+]] = moore.builtin.time
   // CHECK: [[TIME_TO_LOGIC:%.+]] = moore.time_to_logic [[TIME]]
-  // CHECK: [[INT:%.+]] = moore.logic_to_int [[TIME_TO_LOGIC]] : l64 
-  // CHECK: [[REAL:%.+]] = moore.uint_to_real [[INT]] : i64 -> f64 
-  // CHECK: [[SCALE:%.+]] = moore.constant_real 1.000000e+05 : f64 
-  // CHECK: [[DIV:%.+]] = moore.fdiv [[REAL]], [[SCALE]] : f64 
-  // CHECK: [[FMT:%.+]] = moore.fmt.real float [[DIV]], align right fracDigits 3 : f64 
+  // CHECK: [[INT:%.+]] = moore.logic_to_int [[TIME_TO_LOGIC]] : l64
+  // CHECK: [[REAL:%.+]] = moore.uint_to_real [[INT]] : i64 -> f64
+  // CHECK: [[SCALE:%.+]] = moore.constant_real 1.000000e+05 : f64
+  // CHECK: [[DIV:%.+]] = moore.fdiv [[REAL]], [[SCALE]] : f64
+  // CHECK: [[FMT:%.+]] = moore.fmt.real float [[DIV]], align right fracDigits 3 : f64
   initial
     $display("%0.3f", $time);
 endmodule
@@ -1983,7 +1983,7 @@ module PortsUnconnected(
   // CHECK: [[C_INT:%.+]] = moore.variable name "c" : <l1>
   // CHECK: [[D_INT:%.+]] = moore.net wire : <l1>
   // CHECK: [[E_INT:%.+]] = moore.net wire : <l1>
-  
+
   // Mapping ports to local declarations.
   // CHECK: moore.assign [[A_INT]], %a : l1
   // CHECK: moore.assign [[B_INT]], %b : l1
@@ -1998,7 +1998,7 @@ module GenerateConstructs;
   // CHECK: [[TMP:%.+]] = moore.constant 2
   // CHECK: dbg.variable "p", [[TMP]]
   parameter p = 2;
-  
+
   generate
     // CHECK: [[TMP:%.+]] = moore.constant 0
     // CHECK: dbg.variable "i", [[TMP]]
@@ -2019,7 +2019,7 @@ module GenerateConstructs;
     end else begin
       int g2 = 3;
     end
-    
+
     // CHECK: [[TMP:%.+]] = moore.constant 2 : i32
     // CHECK: %genblk3.g3 = moore.variable [[TMP]] : <i32>
     case (p)
@@ -2467,14 +2467,14 @@ module WaitStatementTest();
 	initial begin
 		wait (enable) a = b;
 	end
-	
+
 	initial begin
 		wait (a);
 		enable = 0;
 	end
 endmodule
 
-// CHECK-LABEL: moore.module @ImmediateAssert(in %clk : !moore.l1) 
+// CHECK-LABEL: moore.module @ImmediateAssert(in %clk : !moore.l1)
 module ImmediateAssert(input clk);
   // CHECK: [[CLK:%.+]] = moore.net name "clk" wire : <l1>
   // CHECK: [[A:%.+]] = moore.variable : <i1>
@@ -2499,7 +2499,7 @@ module ImmediateAssert(input clk);
   cover final (a);
 endmodule
 
-// CHECK-LABEL: moore.module @ImmediateAssertiWithActionBlock() 
+// CHECK-LABEL: moore.module @ImmediateAssertiWithActionBlock()
 module ImmediateAssertiWithActionBlock;
   logic x;
   int a;
@@ -3181,7 +3181,7 @@ function int AssignFuncArgs2(int x, int y);
   // CHECK: [[C1:%.+]] = moore.constant 1 : i32
   // CHECK: moore.blocking_assign [[X]], [[C1]] : i32
   x = 1;
-  
+
   // CHECK: [[C2:%.+]] = moore.constant 2 : i32
   // CHECK: moore.blocking_assign [[Y]], [[C2]] : i32
   y = 2;
@@ -3520,7 +3520,7 @@ function automatic int unsigned returnParameterArrayElement (int idx);
   localparam int unsigned ParameterArray [2] = '{42, 9001};
   // CHECK: [[CONST0:%.+]] = moore.constant 42 : i32
   // CHECK-NEXT: [[CONST1:%.+]] = moore.constant 9001 : i32
-  // CHECK-NEXT: [[ARR:%.+]] = moore.array_create [[CONST0]], [[CONST1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+  // CHECK-NEXT: [[ARR:%.+]] = moore.array_create [[CONST1]], [[CONST0]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
   // CHECK: [[RETURN:%.+]] = moore.dyn_extract [[ARR]] from {{%.+}} : uarray<2 x i32>, i32 -> i32
   return ParameterArray[idx];
 endfunction
@@ -3848,9 +3848,9 @@ endfunction // testStrLiteralReturn
 // CHECK-LABEL: func.func private @testStrLiteralAsIntReturn()
 // CHECK-SAME: -> !moore.i1 {
 function bit testStrLiteralAsIntReturn;
-    // CHECK-NEXT: [[CONST:%.+]] = moore.constant_string "\22A string literal\22" : i127 
-    // CHECK-NEXT: [[STR:%.+]] = moore.int_to_string [[CONST]] : i127 
-    // CHECK-NEXT: [[INT:%.+]] = moore.string_to_int [[STR]] : i1 
+    // CHECK-NEXT: [[CONST:%.+]] = moore.constant_string "\22A string literal\22" : i127
+    // CHECK-NEXT: [[STR:%.+]] = moore.int_to_string [[CONST]] : i127
+    // CHECK-NEXT: [[INT:%.+]] = moore.string_to_int [[STR]] : i1
     // CHECK-NEXT: return [[INT]] : !moore.i1
     parameter string testStrLiteral = "A string literal";
     return bit'(testStrLiteral);
@@ -4117,7 +4117,7 @@ module realtimeOperations;
     if (x > 1.1001) begin
       $finish;
     end
-  end 
+  end
   // CHECK: procedure initial
   // CHECK: moore.constant_real
   // CHECK: [[ONE:%.+]] = moore.constant_real 1.000000e+05 : f64
@@ -4474,7 +4474,7 @@ module QueueConcatTest;
     int arr [0:10];
     int qres[$];
     initial begin
-      // Should create one temporary queue with 1 as an element, then convert 
+      // Should create one temporary queue with 1 as an element, then convert
       // `arr` to a queue, then create a temporary queue with 1,2,
       // then finally append them all
       qres = { 1, q1, arr, 1, 2};
@@ -4598,7 +4598,7 @@ module ForkJoinTest ();
 				d = 6;
 				e = 7;
 			end
-		join_none	
+		join_none
 		a = 8;
 	end
 endmodule
@@ -4653,7 +4653,7 @@ endmodule
 module ForkJoinWithSingleStmt;
   int a;
   initial begin
-    fork 
+    fork
       a = 1;
     join
 
@@ -5223,7 +5223,7 @@ endmodule
 function int BuiltinCastTrue(inout integer a);
   struct packed { shortint a; shortint b; } x;
   logic [3:0][7:0] y;
-  
+
   $cast(x, 2.3);
   $cast(y, 2.3);
   return $cast(a, 2.3);


### PR DESCRIPTION
Arrays can take several forms: packed vs unpacked, and low-to-high or
high-to-low element ordering.

moore::ArrayType is always ordered such that index zero is the least
significant element. moore::ArrayCreateOp and moore::ConcatOp are
set up so that the operands are ordered from most to least significant.

Slang provides us functionality to query the type ordering: [3:0] vs [0:3]
for example. This is particularly important for unpacked arrays, where
`wire [31:0] x [4]` actually means `wire [31:0] x [0:3]` (NOT [3:0] which
would be the "standard" ordering).

Add a bunch of tests to check correctness. Array get/assign and slice were
correct already (yay!) but constants for unpacked array types were reversed
(when the array bounds were a single integer, e.g. [4]).

Assignment patterns `x = '{1, 2, 3}` were broken for both integers and
arrays.

Note: a language lawyer would be useful... I've done my best but I'm not
a Verilog expert by any stretch of the imagination.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
