### PR TITLE
Revert "[Verif] Add `ifdef SYNTHESIS guards in SV lowering (#10387)"

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -471,7 +471,7 @@ class System:
       "builtin.module(lower-seq-to-sv)",
       "builtin.module(hw.module(lower-hw-to-sv))",
       "builtin.module(lower-comb)",
-      "builtin.module(lower-verif-to-sv)",
+      "builtin.module(hw.module(lower-verif-to-sv))",
       "builtin.module(cse, canonicalize, cse)",
       "builtin.module(hw.module(prettify-verilog), hw.module(hw-cleanup))",
       "builtin.module(msft-export-tcl{{tops={tops} tcl-file={tcl_file}}})"

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -661,17 +661,10 @@ def LowerLTLToCore : Pass<"lower-ltl-to-core", "hw::HWModuleOp"> {
 // VerifToSV
 //===----------------------------------------------------------------------===//
 
-def LowerVerifToSV : Pass<"lower-verif-to-sv", "mlir::ModuleOp"> {
+def LowerVerifToSV : Pass<"lower-verif-to-sv", "hw::HWModuleOp"> {
   let summary = "Convert Verif to SV";
   let description = [{
-    This pass converts various Verif constructs to SV.
-
-    Operations that are not generally supported by synthesis (e.g.
-    `sv.fwrite`, `sv.assert_property`, `sv.assume_property`,
-    `sv.cover_property`) are emitted inside an `` `ifndef SYNTHESIS `` guard,
-    so the resulting Verilog can be consumed by synthesis tools such as Quartus
-    or Vivado without producing errors. The `SYNTHESIS` macro is declared at
-    the top of the module if it is not already present.
+    This pass converts various Verif contructs to SV.
   }];
   let constructor = "circt::createLowerVerifToSVPass()";
   let dependentDialects = [

--- a/include/circt/Conversion/VerifToSV.h
+++ b/include/circt/Conversion/VerifToSV.h
@@ -27,7 +27,7 @@ class HWModuleOp;
 } // namespace hw
 
 /// Create the Verif to SV conversion pass.
-std::unique_ptr<OperationPass<mlir::ModuleOp>> createLowerVerifToSVPass();
+std::unique_ptr<OperationPass<hw::HWModuleOp>> createLowerVerifToSVPass();
 
 } // namespace circt
 

--- a/include/circt/Support/ProceduralRegionTrait.h
+++ b/include/circt/Support/ProceduralRegionTrait.h
@@ -33,12 +33,6 @@ LogicalResult verifyNotInProceduralRegion(Operation *op);
 /// non-procedural region.
 LogicalResult verifyNotInNonProceduralRegion(Operation *op);
 
-/// Returns true if `op` is itself marked as a procedural region, or has such
-/// a parent that is closer than any parent marked as a non-procedural region.
-/// Returns false if neither condition holds. Useful for deciding whether ops
-/// inserted as children of `op` would live in a procedural region.
-bool isProceduralRegionOp(Operation *op);
-
 /// Signals that an operation's regions are procedural.
 template <typename ConcreteType>
 class ProceduralRegion

--- a/lib/Conversion/VerifToSV/VerifToSV.cpp
+++ b/lib/Conversion/VerifToSV/VerifToSV.cpp
@@ -17,13 +17,9 @@
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Verif/VerifOps.h"
-#include "circt/Support/Namespace.h"
-#include "circt/Support/ProceduralRegionTrait.h"
-#include "mlir/IR/Threading.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include <atomic>
 
 namespace circt {
 #define GEN_PASS_DEF_LOWERVERIFTOSV
@@ -40,41 +36,16 @@ using namespace verif;
 //===----------------------------------------------------------------------===//
 
 namespace {
-
-/// Shared context for the synthesis guard: the symbol name of the
-/// `sv.macro.decl` that guards reference, and a flag tracking whether any
-/// guard was actually emitted (so the pass can skip creating the macro decl
-/// if no pattern fired).
-struct SynthesisGuardContext {
-  FlatSymbolRefAttr macroSym;
-  mutable std::atomic<bool> macroUsed{false};
-};
-
-/// Build an `` `ifndef SYNTHESIS `` guard around `bodyCtor`. Picks between
-/// `sv.ifdef` and `sv.ifdef.procedural` based on the current insertion point.
-static void buildSynthesisGuard(ConversionPatternRewriter &rewriter,
-                                Location loc, const SynthesisGuardContext &ctx,
-                                std::function<void()> bodyCtor) {
-  ctx.macroUsed.store(true, std::memory_order_relaxed);
-  if (isProceduralRegionOp(rewriter.getBlock()->getParentOp())) {
-    sv::IfDefProceduralOp::create(
-        rewriter, loc, ctx.macroSym,
-        /*thenCtor=*/[]() {}, std::move(bodyCtor));
-  } else {
-    sv::IfDefOp::create(
-        rewriter, loc, ctx.macroSym,
-        /*thenCtor=*/[]() {}, std::move(bodyCtor));
-  }
-}
-
 struct PrintOpConversionPattern : public OpConversionPattern<PrintOp> {
-  PrintOpConversionPattern(MLIRContext *context,
-                           const SynthesisGuardContext &guardCtx)
-      : OpConversionPattern<PrintOp>(context), guardCtx(guardCtx) {}
+  using OpConversionPattern<PrintOp>::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(PrintOp op, OpAdaptor operands,
                   ConversionPatternRewriter &rewriter) const override {
+
+    // Printf's will be emitted to stdout (32'h8000_0001 in IEEE Std 1800-2012).
+    Value fdStdout =
+        hw::ConstantOp::create(rewriter, op.getLoc(), APInt(32, 0x80000001));
 
     auto fstrOp =
         dyn_cast_or_null<FormatVerilogStringOp>(op.getString().getDefiningOp());
@@ -82,20 +53,10 @@ struct PrintOpConversionPattern : public OpConversionPattern<PrintOp> {
       return op->emitOpError() << "expected FormatVerilogStringOp as the "
                                   "source of the formatted string";
 
-    auto loc = op.getLoc();
-    buildSynthesisGuard(rewriter, loc, guardCtx, [&]() {
-      // Printf's will be emitted to stdout (32'h8000_0001 in IEEE Std
-      // 1800-2012).
-      Value fdStdout =
-          hw::ConstantOp::create(rewriter, loc, APInt(32, 0x80000001));
-      sv::FWriteOp::create(rewriter, loc, fdStdout, fstrOp.getFormatString(),
-                           fstrOp.getSubstitutions());
-    });
-    rewriter.eraseOp(op);
+    rewriter.replaceOpWithNewOp<sv::FWriteOp>(
+        op, fdStdout, fstrOp.getFormatString(), fstrOp.getSubstitutions());
     return success();
   }
-
-  const SynthesisGuardContext &guardCtx;
 };
 
 struct HasBeenResetConversion : public OpConversionPattern<HasBeenResetOp> {
@@ -180,14 +141,11 @@ static sv::EventControl verifToSVEventControl(verif::ClockEdge ce) {
   llvm_unreachable("Unknown event control kind");
 }
 
-// Generic conversion for verif.assert, verif.assume and verif.cover.
+// Generic conversion for verif.assert, verif.assume and verif.cover
 template <typename Op, typename TargetOp>
 struct VerifAssertLikeConversion : public OpConversionPattern<Op> {
+  using OpConversionPattern<Op>::OpConversionPattern;
   using OpAdaptor = typename OpConversionPattern<Op>::OpAdaptor;
-
-  VerifAssertLikeConversion(MLIRContext *context,
-                            const SynthesisGuardContext &guardCtx)
-      : OpConversionPattern<Op>(context), guardCtx(guardCtx) {}
 
   // Convert the verif.assert like op that uses an enable, into an equivalent
   // sv.assert_property op that has the negated enable as its disable.
@@ -203,26 +161,19 @@ struct VerifAssertLikeConversion : public OpConversionPattern<Op> {
           rewriter.createOrFold<comb::XorOp>(op.getLoc(), enable, constOne);
     }
 
-    buildSynthesisGuard(rewriter, op.getLoc(), guardCtx, [&]() {
-      TargetOp::create(rewriter, op.getLoc(), operands.getProperty(), disable,
-                       operands.getLabelAttr());
-    });
-    rewriter.eraseOp(op);
+    rewriter.replaceOpWithNewOp<TargetOp>(op, operands.getProperty(), disable,
+                                          operands.getLabelAttr());
+
     return success();
   }
-
-  const SynthesisGuardContext &guardCtx;
 };
 
 // Generic conversion for verif.clocked_assert, verif.clocked_assume and
-// verif.clocked_cover.
+// verif.clocked_cover
 template <typename Op, typename TargetOp>
 struct VerifClockedAssertLikeConversion : public OpConversionPattern<Op> {
+  using OpConversionPattern<Op>::OpConversionPattern;
   using OpAdaptor = typename OpConversionPattern<Op>::OpAdaptor;
-
-  VerifClockedAssertLikeConversion(MLIRContext *context,
-                                   const SynthesisGuardContext &guardCtx)
-      : OpConversionPattern<Op>(context), guardCtx(guardCtx) {}
 
   // Convert the verif.assert like op that uses an enable, into an equivalent
   // sv.assert_property op that has the negated enable as its disable.
@@ -241,15 +192,12 @@ struct VerifClockedAssertLikeConversion : public OpConversionPattern<Op> {
     auto eventattr = sv::EventControlAttr::get(
         op.getContext(), verifToSVEventControl(operands.getEdge()));
 
-    buildSynthesisGuard(rewriter, op.getLoc(), guardCtx, [&]() {
-      TargetOp::create(rewriter, op.getLoc(), operands.getProperty(), eventattr,
-                       operands.getClock(), disable, operands.getLabelAttr());
-    });
-    rewriter.eraseOp(op);
+    rewriter.replaceOpWithNewOp<TargetOp>(op, operands.getProperty(), eventattr,
+                                          operands.getClock(), disable,
+                                          operands.getLabelAttr());
+
     return success();
   }
-
-  const SynthesisGuardContext &guardCtx;
 };
 
 } // namespace
@@ -264,20 +212,19 @@ struct VerifToSVPass : public circt::impl::LowerVerifToSVBase<VerifToSVPass> {
 };
 } // namespace
 
-/// Run the verif-to-sv conversion patterns on a single hw.module.
-static LogicalResult lowerModule(hw::HWModuleOp module,
-                                 const SynthesisGuardContext &guardCtx) {
-  MLIRContext *context = module.getContext();
-  ConversionTarget target(*context);
-  RewritePatternSet patterns(context);
+void VerifToSVPass::runOnOperation() {
+  MLIRContext &context = getContext();
+  hw::HWModuleOp module = getOperation();
+
+  ConversionTarget target(context);
+  RewritePatternSet patterns(&context);
 
   target.addIllegalOp<PrintOp, HasBeenResetOp, verif::AssertOp, verif::AssumeOp,
                       verif::CoverOp, ClockedAssertOp, ClockedAssumeOp,
                       ClockedCoverOp>();
   target.addLegalDialect<sv::SVDialect, hw::HWDialect, comb::CombDialect>();
-  patterns.add<HasBeenResetConversion>(context);
   patterns.add<
-      PrintOpConversionPattern,
+      PrintOpConversionPattern, HasBeenResetConversion,
       VerifAssertLikeConversion<verif::AssertOp, AssertPropertyOp>,
       VerifAssertLikeConversion<verif::AssumeOp, AssumePropertyOp>,
       VerifAssertLikeConversion<verif::CoverOp, CoverPropertyOp>,
@@ -286,51 +233,13 @@ static LogicalResult lowerModule(hw::HWModuleOp module,
       VerifClockedAssertLikeConversion<verif::ClockedAssumeOp,
                                        AssumePropertyOp>,
       VerifClockedAssertLikeConversion<verif::ClockedCoverOp, CoverPropertyOp>>(
-      context, guardCtx);
+      &context);
 
-  return applyPartialConversion(module, target, std::move(patterns));
+  if (failed(applyPartialConversion(module, target, std::move(patterns))))
+    signalPassFailure();
 }
 
-void VerifToSVPass::runOnOperation() {
-  ModuleOp moduleOp = getOperation();
-  MLIRContext &context = getContext();
-
-  // Determine the symbol name of the `sv.macro.decl` that the synthesis
-  // guards will reference.
-  StringRef macroSymName = "SYNTHESIS";
-  bool macroDeclAlreadyExists = false;
-  Namespace names;
-
-  if (auto *existing = SymbolTable::lookupSymbolIn(moduleOp, macroSymName)) {
-    if (isa<sv::MacroDeclOp>(existing)) {
-      macroDeclAlreadyExists = true;
-    } else {
-      // Fall back to a unique symbol name.
-      names.add(moduleOp);
-      macroSymName = names.newName(macroSymName);
-    }
-  }
-  SynthesisGuardContext guardCtx{FlatSymbolRefAttr::get(&context, macroSymName),
-                                 /*macroUsed=*/{false}};
-
-  if (failed(mlir::failableParallelForEach(
-          &context, moduleOp.getOps<hw::HWModuleOp>(),
-          [&](hw::HWModuleOp module) {
-            return lowerModule(module, guardCtx);
-          })))
-    return signalPassFailure();
-
-  // Only materialize the `sv.macro.decl` if a guard pattern actually fired and
-  // the symbol isn't already provided by the input.
-  if (guardCtx.macroUsed.load(std::memory_order_relaxed) &&
-      !macroDeclAlreadyExists) {
-    auto builder = OpBuilder::atBlockBegin(moduleOp.getBody());
-    sv::MacroDeclOp::create(builder, moduleOp.getLoc(), macroSymName,
-                            /*args=*/ArrayAttr{},
-                            builder.getStringAttr("SYNTHESIS"));
-  }
-}
-
-std::unique_ptr<OperationPass<ModuleOp>> circt::createLowerVerifToSVPass() {
+std::unique_ptr<OperationPass<hw::HWModuleOp>>
+circt::createLowerVerifToSVPass() {
   return std::make_unique<VerifToSVPass>();
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -338,7 +338,7 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
        !opt.isRandomEnabled(FirtoolOptions::RandomKind::Mem),
        /*emitSeparateAlwaysBlocks=*/
        opt.shouldEmitSeparateAlwaysBlocks()}));
-  pm.addPass(createLowerVerifToSVPass());
+  pm.addNestedPass<hw::HWModuleOp>(createLowerVerifToSVPass());
   pm.addPass(seq::createHWMemSimImpl(
       {/*disableMemRandomization=*/!opt.isRandomEnabled(
            FirtoolOptions::RandomKind::Mem),

--- a/lib/Support/ProceduralRegionTrait.cpp
+++ b/lib/Support/ProceduralRegionTrait.cpp
@@ -35,14 +35,4 @@ LogicalResult verifyNotInNonProceduralRegion(Operation *op) {
   return success();
 }
 
-bool isProceduralRegionOp(Operation *op) {
-  for (; op; op = op->getParentOp()) {
-    if (op->hasTrait<NonProceduralRegion>())
-      return false;
-    if (op->hasTrait<ProceduralRegion>())
-      return true;
-  }
-  return false;
-}
-
 } // namespace circt

--- a/test/Conversion/VerifToSV/test_print.mlir
+++ b/test/Conversion/VerifToSV/test_print.mlir
@@ -4,11 +4,8 @@
 // CHECK:           sv.always posedge %[[VAL_0]] {
 // CHECK:             %[[VAL_1:.*]] = hw.constant true
 // CHECK:             %[[VAL_2:.*]] = verif.format_verilog_string "Hi %[[VAL_3:.*]]\0A"(%[[VAL_1]]) : i1
-// CHECK:             sv.ifdef.procedural @SYNTHESIS {
-// CHECK:             } else {
-// CHECK:               %[[VAL_4:.*]] = hw.constant -2147483647 : i32
-// CHECK:               sv.fwrite %[[VAL_4]], "Hi %x\0A"(%[[VAL_1]]) : i1
-// CHECK:             }
+// CHECK:             %[[VAL_4:.*]] = hw.constant -2147483647 : i32
+// CHECK:             sv.fwrite %[[VAL_4]], "Hi %x\0A"(%[[VAL_1]]) : i1
 // CHECK:           }
 // CHECK:           hw.output
 // CHECK:         }

--- a/test/Conversion/VerifToSV/verif-to-sv.mlir
+++ b/test/Conversion/VerifToSV/verif-to-sv.mlir
@@ -1,6 +1,4 @@
-// RUN: circt-opt --lower-verif-to-sv --split-input-file %s | FileCheck %s
-
-// CHECK: sv.macro.decl @SYNTHESIS
+// RUN: circt-opt --lower-verif-to-sv %s | FileCheck %s
 
 // CHECK-LABEL: hw.module @HasBeenResetAsync
 hw.module @HasBeenResetAsync(in %clock: i1, in %reset: i1, out out: i1) {
@@ -56,62 +54,4 @@ hw.module @HasBeenResetSync(in %clock: i1, in %reset: i1, out out: i1) {
   // CHECK-NEXT: %hasBeenReset = hw.wire [[DONE]]
 
   // CHECK-NEXT: hw.output %hasBeenReset
-}
-
-// CHECK-LABEL: hw.module @AssertLike
-hw.module @AssertLike(in %clock: i1, in %p: i1, in %en: i1) {
-  // CHECK: [[T:%.+]] = hw.constant true
-  // CHECK: [[D:%.+]] = comb.xor %en, [[T]]
-  // CHECK: sv.ifdef @SYNTHESIS {
-  // CHECK: } else {
-  // CHECK:   sv.assert_property %p disable_iff [[D]] label "a" : i1
-  // CHECK: }
-  verif.assert %p if %en label "a" : i1
-  // CHECK: sv.ifdef @SYNTHESIS {
-  // CHECK: } else {
-  // CHECK:   sv.assume_property %p label "u" : i1
-  // CHECK: }
-  verif.assume %p label "u" : i1
-  // CHECK: sv.ifdef @SYNTHESIS {
-  // CHECK: } else {
-  // CHECK:   sv.cover_property %p label "c" : i1
-  // CHECK: }
-  verif.cover %p label "c" : i1
-}
-
-// CHECK-LABEL: hw.module @ClockedAssertLike
-hw.module @ClockedAssertLike(in %clock: i1, in %p: i1) {
-  // CHECK: sv.ifdef @SYNTHESIS {
-  // CHECK: } else {
-  // CHECK:   sv.assert_property %p on posedge %clock label "a" : i1
-  // CHECK: }
-  verif.clocked_assert %p, posedge %clock label "a" : i1
-  // CHECK: sv.ifdef @SYNTHESIS {
-  // CHECK: } else {
-  // CHECK:   sv.assume_property %p on negedge %clock label "u" : i1
-  // CHECK: }
-  verif.clocked_assume %p, negedge %clock label "u" : i1
-  // CHECK: sv.ifdef @SYNTHESIS {
-  // CHECK: } else {
-  // CHECK:   sv.cover_property %p on edge %clock label "c" : i1
-  // CHECK: }
-  verif.clocked_cover %p, edge %clock label "c" : i1
-}
-
-// -----
-
-// Verify that when a non-`sv.macro.decl` symbol named `SYNTHESIS` already
-// exists in the module, the pass falls back to a unique symbol name.
-
-// CHECK: sv.macro.decl @[[SYM:SYNTHESIS_[0-9]+]]["SYNTHESIS"]
-// CHECK: hw.module.extern @SYNTHESIS()
-hw.module.extern @SYNTHESIS()
-
-// CHECK-LABEL: hw.module @Top
-hw.module @Top(in %clock: i1, in %p: i1) {
-  // CHECK: sv.ifdef @[[SYM]] {
-  // CHECK: } else {
-  // CHECK:   sv.assert_property %p on posedge %clock label "a" : i1
-  // CHECK: }
-  verif.clocked_assert %p, posedge %clock label "a" : i1
 }

--- a/test/firtool/lower-layers-with-1dvec-preservation.fir
+++ b/test/firtool/lower-layers-with-1dvec-preservation.fir
@@ -13,10 +13,8 @@ FIRRTL version 5.1.0
 ; CHECK:     if (Foo.reset)
 ; CHECK:       hasBeenResetReg <= 1'h1;
 ; CHECK:   end // always @(posedge)
-; CHECK:   `ifndef SYNTHESIS
-; CHECK:     wire _GEN = ~(hasBeenResetReg === 1'h1 & Foo.reset === 1'h0);
-; CHECK:     assert property (@(posedge Foo.clock) disable iff (_GEN) Foo.in[Foo.addr] == 4'h0);
-; CHECK:   `endif // not def SYNTHESIS
+; CHECK:   wire _GEN = ~(hasBeenResetReg === 1'h1 & Foo.reset === 1'h0);
+; CHECK:   assert property (@(posedge Foo.clock) disable iff (_GEN) Foo.in[Foo.addr] == 4'h0);
 ; CHECK: endmodule
 
 circuit Foo :


### PR DESCRIPTION
This reverts commit 0bf4ff634d6eb8bc6134d09a6e3409606181b5a2.

This created problems because assertions are not generally "not
synthesizable" from the perspective of all tools.  E.g., VC Formal defines
the `SYNTHESIS` macro while also expects that assertions are available.

The proposed alternative solution is to either:

1. rely fully on the "front end" (language, early pass, etc.)
2. or implement this functionality with a pass that is configurable, close
   to an existing lowering option.
