### PR TITLE
[CI] Dispatch circt-tests via workflow_run, support fork PRs

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -230,35 +230,27 @@ jobs:
 
   # --- end of build-circt job.
 
-  # Dispatch a test run in circt/circt-tests once the entire build matrix has
-  # succeeded.
-  dispatch-circt-tests:
-    name: Dispatch circt-tests
-    needs: build-and-test
+  # Upload metadata about the triggering event so the companion
+  # `dispatchCirctTests.yml` workflow can pick it up. That workflow runs on
+  # `workflow_run`, which executes in the context of this repository and
+  # therefore has access to `CIRCT_TESTS_DISPATCH_TOKEN` even for PRs opened
+  # from forks (regular `pull_request` runs from forks do not).
+  #
+  # We deliberately do not depend on `build-and-test` here: the dispatcher
+  # gates on `workflow_run.conclusion == 'success'`, which already reflects
+  # whether the build matrix passed.
+  upload-dispatch-metadata:
+    name: Upload Dispatch Metadata
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.CIRCT_TESTS_DISPATCH_TOKEN }}
     steps:
-      - name: Dispatch circt-tests
-        if: env.GH_TOKEN != ''
+      - name: Write PR number
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            KIND=main
-            SHA=main
-            REPO="${{ github.repository }}"
-            PR_NUMBER=""
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            KIND=pr
-            SHA="${{ github.event.pull_request.head.ref }}"
-            REPO="${{ github.event.pull_request.head.repo.full_name }}"
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-          else
-            echo "Unhandled event type: ${{ github.event_name }}, skipping."
-            exit 0
-          fi
-          DISPATCH_ARGS="-f kind=$KIND -f sha=$SHA -f repo=$REPO"
-          if [ -n "$PR_NUMBER" ]; then
-            DISPATCH_ARGS="$DISPATCH_ARGS -f pr_number=$PR_NUMBER"
-          fi
-          echo "Dispatching circt-tests with args: $DISPATCH_ARGS"
-          gh workflow run test.yml --repo circt/circt-tests $DISPATCH_ARGS
+          mkdir -p dispatch-metadata
+          echo "${{ github.event.pull_request.number }}" \
+            > dispatch-metadata/pr_number
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dispatch-metadata
+          path: dispatch-metadata/
+          retention-days: 1

--- a/.github/workflows/dispatchCirctTests.yml
+++ b/.github/workflows/dispatchCirctTests.yml
@@ -1,0 +1,63 @@
+name: Dispatch circt-tests
+
+# Trigger a test run in circt/circt-tests once a "Build and Test" run has
+# finished. We use `workflow_run` rather than driving the dispatch directly
+# from `buildAndTest.yml` because `pull_request` events from forks run with a
+# read-only token and no access to repository secrets. `workflow_run`, by
+# contrast, executes in the context of this repository and has the
+# `CIRCT_TESTS_DISPATCH_TOKEN` available regardless of where the PR
+# originated.
+on:
+  workflow_run:
+    workflows: ["Build and Test"]
+    types: [completed]
+
+jobs:
+  dispatch:
+    name: Dispatch circt-tests
+    # Only dispatch when the upstream build matrix actually succeeded.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.CIRCT_TESTS_DISPATCH_TOKEN }}
+    steps:
+      # Pull the small metadata artifact uploaded by buildAndTest.yml. It
+      # contains only the PR number (when applicable); everything else we
+      # need is already on the `workflow_run` event payload.
+      - name: Download dispatch metadata
+        if: env.GH_TOKEN != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: dispatch-metadata
+          path: dispatch-metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Dispatch circt-tests
+        if: env.GH_TOKEN != ''
+        env:
+          EVENT_NAME: ${{ github.event.workflow_run.event }}
+          HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            KIND=main
+            SHA=main
+            REPO="$BASE_REPO"
+            PR_NUMBER=""
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            KIND=pr
+            SHA="$HEAD_REF"
+            REPO="$HEAD_REPO"
+            PR_NUMBER=$(cat dispatch-metadata/pr_number)
+          else
+            echo "Unhandled event type: $EVENT_NAME, skipping."
+            exit 0
+          fi
+          DISPATCH_ARGS="-f kind=$KIND -f sha=$SHA -f repo=$REPO"
+          if [ -n "$PR_NUMBER" ]; then
+            DISPATCH_ARGS="$DISPATCH_ARGS -f pr_number=$PR_NUMBER"
+          fi
+          echo "Dispatching circt-tests with args: $DISPATCH_ARGS"
+          gh workflow run test.yml --repo circt/circt-tests $DISPATCH_ARGS


### PR DESCRIPTION
PRs from forks of CIRCT currently cannot trigger a circt-tests run, since repository secrets are not available in the CI of those PRs.

To fix this, split the dispatch into a separate workflow triggered by `workflow_run`, which always runs in the context of the upstream repository and therefore has access to the secret regardless of where the PR originated. The build workflow only uploads a small metadata artifact with the PR number. The remaining dispatch parameters come straight off the `workflow_run` event payload.

Assisted-by: Claude Opus 4.7