### PR TITLE
[LTLToCore] Drop assume-first-clock option

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -650,11 +650,6 @@ def LowerLTLToCore : Pass<"lower-ltl-to-core", "hw::HWModuleOp"> {
     "hw::HWDialect", "sv::SVDialect", "comb::CombDialect",
     "seq::SeqDialect"
   ];
-  let options =
-    [Option<"assumeFirstClock", "assume-first-clock", "bool", "false",
-            "Assume that implicitly clocked LTL operations are clocked by the"
-            "first clock argument, or failing that, the first seq.to_clock"
-            "operation in their parent hw.module.">];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -167,39 +167,13 @@ struct LTLOrOpConversion : public OpConversionPattern<ltl::OrOp> {
 };
 
 struct LTLPastOpConversion : public OpConversionPattern<ltl::PastOp> {
-  LTLPastOpConversion(MLIRContext *context, bool assumeFirstClock)
-      : OpConversionPattern<ltl::PastOp>(context),
-        assumeFirstClock(assumeFirstClock) {}
+  using OpConversionPattern<ltl::PastOp>::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(ltl::PastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value clock;
-    if (!adaptor.getClk()) {
-      if (!assumeFirstClock)
-        return failure();
-      // Find the first clock, looking at inputs then at to_clock operations
-      auto module = op->getParentOfType<HWModuleOp>();
-      std::optional<size_t> clockArgNum;
-      for (auto &port : module.getPortList()) {
-        if (port.isInput() && isa<seq::ClockType>(port.type)) {
-          clockArgNum = port.argNum;
-          break;
-        }
-      }
-      if (clockArgNum) {
-        clock = module.getArgumentForInput(*clockArgNum);
-      } else {
-        // If there are no clock ports, we try to_clock operations
-        auto toClockOps = module.getOps<seq::ToClockOp>();
-        if (toClockOps.empty())
-          return failure();
-        clock = (*toClockOps.begin()).getResult();
-      }
-    } else {
-      clock = seq::ToClockOp::create(rewriter, op.getLoc(), adaptor.getClk());
-    }
-
+    Value clock =
+        seq::ToClockOp::create(rewriter, op.getLoc(), adaptor.getClk());
     Value cur = adaptor.getInput();
     Value ce =
         hw::ConstantOp::create(rewriter, op.getLoc(), rewriter.getI1Type(), 1);
@@ -209,8 +183,6 @@ struct LTLPastOpConversion : public OpConversionPattern<ltl::PastOp> {
     rewriter.replaceOp(op, shiftreg);
     return success();
   }
-
-  bool assumeFirstClock;
 };
 
 } // namespace
@@ -229,21 +201,6 @@ struct LowerLTLToCorePass
 
 // Simply applies the conversion patterns defined above
 void LowerLTLToCorePass::runOnOperation() {
-  // Emit an explicit error for unsupported past ops, rather than a confusing
-  // 'failed to legalize' error
-  if (!assumeFirstClock) {
-    auto res = getOperation().walk([&](ltl::PastOp op) {
-      if (!op.getClk()) {
-        op.emitError(
-            "ltl.past operations without a clock operand are not supported.");
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    });
-    if (res.wasInterrupted())
-      return signalPassFailure();
-  }
-
   // Set target dialects: We don't want to see any ltl or verif that might
   // come from an AssertProperty left in the result
   ConversionTarget target(getContext());
@@ -314,10 +271,10 @@ void LowerLTLToCorePass::runOnOperation() {
 
   // Create the operation rewrite patters
   RewritePatternSet patterns(&getContext());
-  patterns.add<HasBeenResetOpConversion, LTLImplicationConversion,
-               LTLNotConversion, LTLAndOpConversion, LTLOrOpConversion>(
-      converter, patterns.getContext());
-  patterns.add<LTLPastOpConversion>(patterns.getContext(), assumeFirstClock);
+  patterns
+      .add<HasBeenResetOpConversion, LTLImplicationConversion, LTLNotConversion,
+           LTLAndOpConversion, LTLOrOpConversion, LTLPastOpConversion>(
+          converter, patterns.getContext());
   // Apply the conversions
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))


### PR DESCRIPTION
This option only existed to provide a lowering flow for past ops with implicit clocks, and as of #10392 past op clocks are all explicit, so this flag is redundant (and as we're shifting towards explicit clocking elsewhere it doesn't look like we're going to need it for lowering anything else).