### PR TITLE
[Synth] Add majority gate

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -135,6 +135,11 @@ T evaluateDotLogic(const T &x, const T &y, const T &z) {
   return x ^ (z | (x & y));
 }
 
+template <typename T>
+T evaluateMajorityLogic(const T &a, const T &b, const T &c) {
+  return (a & b) | (a & c) | (b & c);
+}
+
 } // namespace synth
 } // namespace circt
 

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -214,4 +214,48 @@ def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
   let assemblyFormat = "$inputs attr-dict `:` type($result)";
 }
 
+def MajorityOp : SynthOp<"majority", [
+    SameOperandsAndResultType, Pure,
+    DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
+      "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
+      "supportsNumInputs", "createBooleanLogicOp",
+      "getLogicAreaCost"
+    ]>
+  ]>{
+  let summary = "Majority gate with invertible inputs";
+  let description = [{
+    The `synth.majority` operation computes the majority function of its
+    inputs, where each operand can be optionally inverted. 
+
+    The majority function returns 1 when more than half of the inputs are 1,
+    and 0 otherwise. For three inputs, it's equivalent to:
+    (a & b) | (a & c) | (b & c).
+
+    The number of inputs must be odd to avoid ties.
+
+     Example:
+  ```mlir
+      %r0 = synth.majority %a, %b, %c : i1
+      %r1 = synth.majority not %a, %b, not %c : i1
+  ```
+  }];
+   let arguments = (ins Variadic<AnyType>:$inputs,
+                       DenseBoolArrayAttr:$inverted);
+  let results = (outs AnyType:$result);
+
+  let builders = [
+  OpBuilder<(ins "Value":$a, "Value":$b, "Value":$c,
+                              CArg<"bool", "false">:$invertA,
+                              CArg<"bool", "false">:$invertB,
+                              CArg<"bool", "false">:$invertC), [{
+    SmallVector<bool> inverted{invertA, invertB, invertC};
+    return build($_builder, $_state, ValueRange{a, b, c},
+                 $_builder.getDenseBoolArrayAttr(inverted));
+  }]>
+];
+
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
 #endif // CIRCT_DIALECT_SYNTH_SYNTHOPS_TD

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -157,6 +157,7 @@ struct LogicNetworkGate {
     case Xor2:
       return 2;
     case Maj3:
+      return 3;
     case Dot3:
       return 3;
     case Identity:

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -94,3 +94,18 @@ hw.module @test_dot(in %a: i1, in %b: i1, in %c: i1,
   %3 = synth.dot not %a, %b, not %c : i1
   hw.output %2, %3 : i1, i1
 }
+
+// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 test_majority --c2 test_majority | FileCheck %s --check-prefix=MAJORITY
+// MAJORITY: c1 == c2
+// CHECK-LABEL: hw.module @test_majority
+hw.module @test_majority(in %a: i1, in %b: i1, in %c: i1,
+                         out out0: i1, out out1: i1) {
+  // CHECK: %[[CHOICE:.+]] = synth.choice
+  // CHECK: hw.output %[[CHOICE]], %[[CHOICE]] : i1, i1
+  %ab = synth.aig.and_inv %a, %b : i1
+  %ac = synth.aig.and_inv %a, %c : i1
+  %bc = synth.aig.and_inv %b, %c : i1
+  %0 = comb.or %ab, %ac, %bc : i1
+  %1 = synth.majority %a, %b, %c : i1
+  hw.output %0, %1 : i1, i1
+}

--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -111,6 +111,22 @@ struct SynthDotOpConversion : SynthInverterOpConversion<synth::DotOp> {
   }
 };
 
+struct SynthMajorityOpConversion
+    : SynthInverterOpConversion<synth::MajorityOp> {
+  using SynthInverterOpConversion<synth::MajorityOp>::SynthInverterOpConversion;
+  Value createOp(Location loc, ArrayRef<Value> inputs,
+                 ConversionPatternRewriter &rewriter) const override {
+    assert(inputs.size() == 3 && "expected exactly three inputs");
+    auto ab =
+        rewriter.createOrFold<comb::AndOp>(loc, inputs[0], inputs[1], true);
+    auto ac =
+        rewriter.createOrFold<comb::AndOp>(loc, inputs[0], inputs[2], true);
+    auto bc =
+        rewriter.createOrFold<comb::AndOp>(loc, inputs[1], inputs[2], true);
+    auto abOrAc = rewriter.createOrFold<comb::OrOp>(loc, ab, ac, true);
+    return rewriter.createOrFold<comb::OrOp>(loc, abOrAc, bc, true);
+  }
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -128,8 +144,8 @@ struct ConvertSynthToCombPass
 
 static void populateSynthToCombConversionPatterns(RewritePatternSet &patterns) {
   patterns.add<SynthChoiceOpConversion, SynthAndInverterOpConversion,
-               SynthXorInverterOpConversion, SynthDotOpConversion>(
-      patterns.getContext());
+               SynthXorInverterOpConversion, SynthDotOpConversion,
+               SynthMajorityOpConversion>(patterns.getContext());
 }
 
 void ConvertSynthToCombPass::runOnOperation() {

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -515,6 +515,91 @@ void DotOp::emitCNFWithoutInversion(
   circt::addXorClauses(outVar, inputVars[0], orVar, addClause);
 }
 
+//===----------------------------------------------------------------------===//
+// MajorityOp
+//===----------------------------------------------------------------------===//
+
+ParseResult MajorityOp::parse(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand> operands;
+  Type resultType;
+  DenseBoolArrayAttr inverted;
+  NamedAttrList attrs;
+
+  if (parseVariadicInvertibleOperands(parser, operands, resultType, inverted,
+                                      attrs))
+    return failure();
+  if (operands.size() != 3)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected exactly three operands";
+  if (parser.resolveOperands(operands, resultType, result.operands))
+    return failure();
+
+  result.addTypes(resultType);
+  result.addAttributes(attrs);
+  result.addAttribute("inverted", inverted);
+  return success();
+}
+
+void MajorityOp::print(OpAsmPrinter &printer) {
+  printer << ' ';
+  printVariadicInvertibleOperands(printer, getOperation(), getOperands(),
+                                  getType(), getInvertedAttr(),
+                                  (*this)->getAttrDictionary());
+}
+
+LogicalResult MajorityOp::verify() {
+  if (getNumOperands() != 3)
+    return emitOpError("requires exactly three operands");
+  if (getInverted().size() != 3)
+    return emitOpError("requires exactly three inversion flags");
+  return success();
+}
+
+bool MajorityOp::areInputsPermutationInvariant() { return true; }
+
+bool MajorityOp::supportsNumInputs(unsigned numInputs) {
+  return numInputs == 3;
+}
+
+std::optional<uint64_t> MajorityOp::getLogicAreaCost() {
+  int64_t bitWidth = hw::getBitWidth(getType());
+  if (bitWidth < 0)
+    return std::nullopt;
+  return static_cast<uint64_t>(bitWidth);
+}
+
+llvm::KnownBits MajorityOp::computeKnownBits(
+    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
+  auto a = applyInversion(getInputKnownBits(0), isInverted(0));
+  auto b = applyInversion(getInputKnownBits(1), isInverted(1));
+  auto c = applyInversion(getInputKnownBits(2), isInverted(2));
+  return evaluateMajorityLogic(a, b, c);
+}
+
+APInt MajorityOp::evaluateBooleanLogicWithoutInversion(
+    llvm::ArrayRef<APInt> inputs) {
+  assert(inputs.size() == 3 && "majority requires exactly three inputs");
+  return evaluateMajorityLogic(inputs[0], inputs[1], inputs[2]);
+}
+
+void MajorityOp::emitCNFWithoutInversion(
+    int outVar, llvm::ArrayRef<int> inputVars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  assert(inputVars.size() == 3 && "expected exactly three inputs");
+  int ab = newVar();
+  int ac = newVar();
+  int bc = newVar();
+  // ab = a & b
+  circt::addAndClauses(ab, {inputVars[0], inputVars[1]}, addClause);
+  // ac = a & c
+  circt::addAndClauses(ac, {inputVars[0], inputVars[2]}, addClause);
+  // bc = b & c
+  circt::addAndClauses(bc, {inputVars[1], inputVars[2]}, addClause);
+  // out = ab | ac | bc
+  circt::addOrClauses(outVar, {ab, ac, bc}, addClause);
+}
+
 static Value lowerVariadicInvertibleOp(
     Location loc, ValueRange operands, ArrayRef<bool> inverts,
     PatternRewriter &rewriter,

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -195,6 +195,18 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
                       {xSignal, ySignal, zSignal});
               return success();
             })
+            .Case<synth::MajorityOp>([&](synth::MajorityOp majOp) {
+              if (!majOp.getType().isInteger(1)) {
+                handleOtherResults(majOp);
+                return success();
+              }
+              const Signal aSignal = getInvertibleSignal(majOp, 0);
+              const Signal bSignal = getInvertibleSignal(majOp, 1);
+              const Signal cSignal = getInvertibleSignal(majOp, 2);
+              addGate(majOp, LogicNetworkGate::Maj3,
+                      {aSignal, bSignal, cSignal});
+              return success();
+            })
             .Case<comb::XorOp>([&](comb::XorOp xorOp) {
               if (xorOp->getNumOperands() != 2) {
                 handleOtherResults(xorOp);
@@ -502,7 +514,7 @@ static inline llvm::APInt applyGateSemantics(LogicNetworkGate::Kind kind,
                                              const llvm::APInt &c) {
   switch (kind) {
   case LogicNetworkGate::Maj3:
-    return (a & b) | (a & c) | (b & c);
+    return evaluateMajorityLogic(a, b, c);
   case LogicNetworkGate::Dot3:
     return evaluateDotLogic(a, b, c);
   default:
@@ -603,6 +615,10 @@ struct MergedTruthTableBuilder {
           numMergedInputs, 1,
           applyGateSemantics(rootGate.getKind(), getEdgeTT(0), getEdgeTT(1)));
     case LogicNetworkGate::Maj3:
+      return BinaryTruthTable(numMergedInputs, 1,
+                              applyGateSemantics(rootGate.getKind(),
+                                                 getEdgeTT(0), getEdgeTT(1),
+                                                 getEdgeTT(2)));
     case LogicNetworkGate::Dot3:
       return BinaryTruthTable(numMergedInputs, 1,
                               applyGateSemantics(rootGate.getKind(),

--- a/test/Conversion/SynthToComb/synth-to-comb.mlir
+++ b/test/Conversion/SynthToComb/synth-to-comb.mlir
@@ -37,3 +37,14 @@ hw.module @test_dot(in %x: i8, in %y: i8, in %z: i8, out out0: i8) {
   %0 = synth.dot not %x, %y, %z : i8
   hw.output %0 : i8
 }
+
+// CHECK-LABEL: @test_majority
+hw.module @test_majority(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
+  // CHECK: %[[AB:.+]] = comb.and bin %a, %b : i8
+  // CHECK: %[[AC:.+]] = comb.and bin %a, %c : i8
+  // CHECK: %[[BC:.+]] = comb.and bin %b, %c : i8
+  // CHECK: %[[OR:.+]] = comb.or bin %[[AB]], %[[AC]] : i8
+  // CHECK: %[[RESULT:.+]] = comb.or bin %[[OR]], %[[BC]] : i8
+  %0 = synth.majority %a, %b, %c : i8
+  hw.output %0 : i8
+}

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -114,10 +114,12 @@ func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
 // CHECK-LABEL: hw.module @Other
 // Other operation with BooleanLogicOpInterface
 // Only check that they are lowered.
-hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2) {
+hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2, out z: i2) {
   %0 = synth.xor_inv %a, not %b, %c : i2
-  %1 = synth.dot %a, not %b,  %c : i2
+  %1 = synth.dot %a, not %b, %c : i2
+  %2 = synth.majority %a, not %b, %c : i2
   // CHECK-COUNT-2: synth.xor_inv %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.dot %{{.+}}, not %{{.+}}, %{{.+}} : i1
-  hw.output %0, %1 : i2, i2
+  // CHECK-COUNT-2: synth.majority %{{.+}}, not %{{.+}}, %{{.+}} : i1
+  hw.output %0, %1, %2 : i2, i2, i2
 }

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -30,3 +30,9 @@ hw.module @xor_inv(in %a: i4, in %b: i4, in %c: i4, in %d: i1) {
 hw.module @dot(in %x: i1, in %y: i1, in %z: i1) {
   %0 = synth.dot %x, not %y, %z : i1
 }
+
+// CHECK-LABEL: @majority
+// CHECK-NEXT: %[[R0:.+]] = synth.majority %x, not %y, %z : i1
+hw.module @majority(in %x: i1, in %y: i1, in %z: i1) {
+  %0 = synth.majority %x, not %y, %z : i1
+}

--- a/test/Dialect/Synth/structural_hash.mlir
+++ b/test/Dialect/Synth/structural_hash.mlir
@@ -74,3 +74,13 @@ hw.module @dot_ordered(in %x: i1, in %y: i1, in %z: i1, out o0: i1, out o1: i1, 
   %2 = synth.dot %notX, %y, %z : i1
   hw.output %0, %1, %2 : i1, i1, i1
 }
+
+// CHECK-LABEL: hw.module @majority_commutative
+hw.module @majority_commutative(in %x: i1, in %y: i1, in %z: i1, out o0: i1, out o1: i1) {
+  // majority is permutation invariant so these should be CSE'd to the same op
+  // CHECK: %[[M0:.+]] = synth.majority %x, not %y, %z : i1
+  // CHECK-NEXT: hw.output %[[M0]], %[[M0]] : i1, i1
+  %0 = synth.majority %x, not %y, %z : i1
+  %1 = synth.majority not %y, %x, %z : i1
+  hw.output %0, %1 : i1, i1
+}

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -177,3 +177,15 @@ hw.module @dot_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
     hw.output %0 : i1
 }
 
+hw.module @majority_lib(in %x : i1, in %y : i1, in %z : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "x", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "y", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "z", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+    %0 = synth.majority %x, not %y, not %z : i1
+    hw.output %0 : i1
+}
+
+// CHECK-LABEL: @majority_test
+hw.module @majority_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
+    // CHECK-NEXT: %[[MAJ:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @majority_lib(x: %{{.+}}: i1, y: %{{.+}}: i1, z: %{{.+}}: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: hw.output %[[MAJ]] : i1
+    %0 = synth.majority %x, not %y, not %z : i1
+    hw.output %0 : i1
+}


### PR DESCRIPTION
Concerns #10407 

We add `synth.majority`,  a permutation invariant 3-input boolean logic operation implementing the majority function  `(a & b) | (a & c) | (b & c)` with per-input inversion support.  

Similar to `synth.dot`, this operation will be useful as an IR for logic synthesis than rather than as a primary homogeneous logic representation.  Currently, we choose to fix the operation to three inputs to match the existing cut-rewriter and techmapper representation, where possible we may expand to the general odd-arity majority representation `(2n+1 inputs)` .If and when needed this may require altering the cut-rewriter and techmapping architecture.