### PR TITLE
[Moore][ImportVerilog][MooreToCore][Sim] Add file I/O system tasks support.

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3121,7 +3121,7 @@ def FCloseBIOp : Builtin<"fclose"> {
 // Math Builtins
 //===----------------------------------------------------------------------===//
 
-class RealMathFunc<string mnemonic, list<Trait> traits = []> :
+class RealMathFunc<string mnemonic, list<Trait> traits = []> : 
     Builtin<mnemonic, traits # [SameOperandsAndResultType]> {
   let description = [{
     The system real math functions shall accept real value arguments and return

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3072,18 +3072,36 @@ def SeverityBIOp : Builtin<"severity"> {
 // Files Builtins
 //===----------------------------------------------------------------------===//
 
+// File open modes corresponding to the mode string argument of the `$fopen`
+
+def FOpenModeRead : I32EnumAttrCase<"Read", 0, "r">;
+def FOpenModeWrite : I32EnumAttrCase<"Write", 1, "w">;
+def FOpenModeAppend : I32EnumAttrCase<"Append", 2, "a">;
+def FOpenModeReadUpdate : I32EnumAttrCase<"ReadUpdate", 3, "r_update">;
+def FOpenModeWriteUpdate : I32EnumAttrCase<"WriteUpdate", 4, "w_update">;
+def FOpenModeAppendUpdate : I32EnumAttrCase<"AppendUpdate", 5, "a_update">;
+
+def FOpenModeAttr : I32EnumAttr<"FOpenMode",
+    "File open mode",
+    [FOpenModeRead, FOpenModeWrite, FOpenModeAppend,
+     FOpenModeReadUpdate, FOpenModeWriteUpdate, FOpenModeAppendUpdate]> {
+  let cppNamespace = "circt::moore";
+}
+
 def FOpenBIOp : Builtin<"fopen"> {
   let summary = "Open a file";
   let description = [{
-    If one argument is provided, opens a file and returns a multi-channel
-    descriptor(MCD). If two arguments are provided, returns
-    a file descriptor(fd). This corresponds to the `$fopen` system function.
+    Open a file and returns a file descriptor. If only the filename is provided,
+    opens the file and returns a multi-channel descriptor (MCD).
+    If the optional mode argument is also provided (e.g., "r", "w", "a"),
+    opens the file in the specified mode and returns a file descriptor (fd).
+    This corresponds to the `$fopen` system function.
 
     See IEEE 1800-2017 § 21.3.1 "Opening and closing files".
   }];
-  let arguments = (ins StringType:$filename, Optional<StringType>:$mode);
+  let arguments = (ins StringType:$filename, OptionalAttr<FOpenModeAttr>:$mode);
   let results = (outs TwoValuedI32:$fd);
-  let assemblyFormat = "$filename (`,` $mode^)? attr-dict";
+  let assemblyFormat = "$filename (`mode` `=` $mode^)? attr-dict";
 }
 
 def FCloseBIOp : Builtin<"fclose"> {

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3069,10 +3069,41 @@ def SeverityBIOp : Builtin<"severity"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Files Builtins
+//===----------------------------------------------------------------------===//
+
+def FOpenBIOp : Builtin<"fopen"> {
+  let summary = "Open a file";
+  let description = [{
+    If one argument is provided, opens a file and returns a multi-channel
+    descriptor(MCD). If two arguments are provided, returns
+    a file descriptor(fd). This corresponds to the `$fopen` system function.
+
+    See IEEE 1800-2017 § 21.3.1 "Opening and closing files".
+  }];
+  let arguments = (ins StringType:$filename, Optional<StringType>:$mode);
+  let results = (outs TwoValuedI32:$fd);
+  let assemblyFormat = "$filename (`,` $mode^)? attr-dict";
+}
+
+def FCloseBIOp : Builtin<"fclose"> {
+  let summary = "Close a file";
+  let description = [{
+    Closes a file given its descriptor. This corresponds to the `$fclose`
+    system task.
+
+    See IEEE 1800-2017 § 21.3.1 "Opening and closing files".
+  }];
+  let arguments = (ins TwoValuedI32:$fd);
+  let results = (outs);
+  let assemblyFormat = "$fd attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // Math Builtins
 //===----------------------------------------------------------------------===//
 
-class RealMathFunc<string mnemonic, list<Trait> traits = []> : 
+class RealMathFunc<string mnemonic, list<Trait> traits = []> :
     Builtin<mnemonic, traits # [SameOperandsAndResultType]> {
   let description = [{
     The system real math functions shall accept real value arguments and return

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1200,4 +1200,34 @@ def TriggeredOp : SimOp<"triggered", [
   ];
 }
 
+//===----------------------------------------------------------------------===//
+// File I/O
+//===----------------------------------------------------------------------===//
+
+def FOpenOp : SimOp<"fopen", [ProceduralOp]> {
+  let summary = "Open a file and return a file descriptor";
+  let description = [{
+    Opens a file and return an integer handle.
+    This handle is used in subsequent file operations to identify the file.
+    A return value of 0 indicates failure to open the file, and a non-zero value
+    indicates success.
+  }];
+
+  let arguments = (ins DynamicStringType:$fileName, Optional<DynamicStringType>:$mode);
+  let results = (outs I32:$fd);
+  let assemblyFormat = "$fileName (`,` $mode^)? attr-dict";
+}
+
+def FCloseOp : SimOp<"fclose", [ProceduralOp]> {
+  let summary = "Close a file descriptor";
+  let description = [{
+    Closes a file descriptor obtained from `sim.fopen`. After this operation,
+    the file descriptor is invalid and should not be used in subsequent file
+    operations.
+  }];
+
+  let arguments = (ins I32:$fd);
+  let assemblyFormat = "$fd attr-dict";
+}
+
 #endif // CIRCT_DIALECT_SIM_SIMOPS_TD

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1220,10 +1220,8 @@ def SVFOpenModeAttr : I32EnumAttr<"SVFOpenMode", "SV file open mode",
 def SVFOpenOp : SimOp<"sv.fopen", [ProceduralOp]> {
   let summary = "Open a file and return a file descriptor";
   let description = [{
-    Opens a file and return an integer handle.
-    This handle is used in subsequent file operations to identify the file.
-    A return value of 0 indicates failure to open the file, and a non-zero value
-    indicates success.
+    Implements the SystemVerilog `$fopen` system function.
+    See IEEE 1800-2017 § 21.3.1 "Opening and closing files".
   }];
 
   let arguments = (ins DynamicStringType:$fileName, OptionalAttr<SVFOpenModeAttr>:$mode);
@@ -1234,26 +1232,29 @@ def SVFOpenOp : SimOp<"sv.fopen", [ProceduralOp]> {
 def SVFCloseOp : SimOp<"sv.fclose", [ProceduralOp]> {
   let summary = "Close a file descriptor";
   let description = [{
-    Closes a file descriptor obtained from `sim.sv.fopen`. After this operation,
-    the file descriptor is invalid and should not be used in subsequent file
-    operations.
+    Implements the SystemVerilog `$fclose` system function.
+    See IEEE 1800-2017 § 21.3.1 "Opening and closing files".
   }];
 
   let arguments = (ins I32:$fd);
   let assemblyFormat = "$fd attr-dict";
 }
 
-def SVFdToOutputStreamOp : SimOp<"sv.fd_to_output_stream", [ProceduralOp]> {
-  let summary = "Cast a SV file descriptor to an output stream";
+def SVChannelToOutputStreamOp : SimOp<"sv.channel_to_output_stream", [ProceduralOp]> {
+  let summary = "Cast a SV file descriptor or multichannel descriptor to an output stream";
   let description = [{
-    Casts a SystemVerilog file descriptor (an integer returned by
-    $fopen, or 1 for stdout / 2 for stderr) to an `!sim.output_stream`.
-    The cast semantically asserts that the integer represents a valid,
-    writable file handle or standard output stream
+    Casts a SystemVerilog output channel (an integer returned by `sv.fopen`,
+    or a predefined channel such as stdout (`32'h8000_0001`) or stderr
+    (`32'h8000_0002`)) to an `!sim.output_stream`.
+    The input must represent a valid SystemVerilog file descriptor or
+    multichannel descriptor, which can be used for writing. Otherwise,
+    this operation causes undefined behavior.
+
+    See IEEE 1800-2017 § 21.3.1 "Opening and closing files".
   }];
-  let arguments = (ins I32:$fd);
+  let arguments = (ins I32:$channel);
   let results = (outs OutputStreamType:$stream);
-  let assemblyFormat = "$fd attr-dict";
+  let assemblyFormat = "$channel attr-dict";
 }
 
 #endif // CIRCT_DIALECT_SIM_SIMOPS_TD

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1204,7 +1204,20 @@ def TriggeredOp : SimOp<"triggered", [
 // File I/O
 //===----------------------------------------------------------------------===//
 
-def FOpenOp : SimOp<"fopen", [ProceduralOp]> {
+def SVFOpenModeRead : I32EnumAttrCase<"Read", 0, "r">;
+def SVFOpenModeWrite : I32EnumAttrCase<"Write", 1, "w">;
+def SVFOpenModeAppend : I32EnumAttrCase<"Append", 2, "a">;
+def SVFOpenModeReadUpdate : I32EnumAttrCase<"ReadUpdate", 3, "r_update">;
+def SVFOpenModeWriteUpdate : I32EnumAttrCase<"WriteUpdate", 4, "w_update">;
+def SVFOpenModeAppendUpdate : I32EnumAttrCase<"AppendUpdate", 5, "a_update">;
+
+def SVFOpenModeAttr : I32EnumAttr<"SVFOpenMode", "SV file open mode",
+    [SVFOpenModeRead, SVFOpenModeWrite, SVFOpenModeAppend,
+     SVFOpenModeReadUpdate, SVFOpenModeWriteUpdate, SVFOpenModeAppendUpdate]> {
+  let cppNamespace = "circt::sim";
+}
+
+def SVFOpenOp : SimOp<"sv.fopen", [ProceduralOp]> {
   let summary = "Open a file and return a file descriptor";
   let description = [{
     Opens a file and return an integer handle.
@@ -1213,20 +1226,33 @@ def FOpenOp : SimOp<"fopen", [ProceduralOp]> {
     indicates success.
   }];
 
-  let arguments = (ins DynamicStringType:$fileName, Optional<DynamicStringType>:$mode);
+  let arguments = (ins DynamicStringType:$fileName, OptionalAttr<SVFOpenModeAttr>:$mode);
   let results = (outs I32:$fd);
-  let assemblyFormat = "$fileName (`,` $mode^)? attr-dict";
+  let assemblyFormat = "$fileName (`mode` `=` $mode^)? attr-dict";
 }
 
-def FCloseOp : SimOp<"fclose", [ProceduralOp]> {
+def SVFCloseOp : SimOp<"sv.fclose", [ProceduralOp]> {
   let summary = "Close a file descriptor";
   let description = [{
-    Closes a file descriptor obtained from `sim.fopen`. After this operation,
+    Closes a file descriptor obtained from `sim.sv.fopen`. After this operation,
     the file descriptor is invalid and should not be used in subsequent file
     operations.
   }];
 
   let arguments = (ins I32:$fd);
+  let assemblyFormat = "$fd attr-dict";
+}
+
+def SVFdToOutputStreamOp : SimOp<"sv.fd_to_output_stream", [ProceduralOp]> {
+  let summary = "Cast a SV file descriptor to an output stream";
+  let description = [{
+    Casts a SystemVerilog file descriptor (an integer returned by
+    $fopen, or 1 for stdout / 2 for stderr) to an `!sim.output_stream`.
+    The cast semantically asserts that the integer represents a valid,
+    writable file handle or standard output stream
+  }];
+  let arguments = (ins I32:$fd);
+  let results = (outs OutputStreamType:$stream);
   let assemblyFormat = "$fd attr-dict";
 }
 

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3489,14 +3489,33 @@ Value Context::convertSystemCall(
         convertRvalueExpression(*args[0], moore::StringType::get(getContext()));
     if (!filename)
       return {};
-    Value mode;
+    moore::FOpenModeAttr modeAttr;
     if (numArgs == 2) {
-      mode = convertRvalueExpression(*args[1],
-                                     moore::StringType::get(getContext()));
+      auto *strLit = args[1]
+                         ->unwrapImplicitConversions()
+                         .as_if<slang::ast::StringLiteral>();
+      if (!strLit)
+        return emitError(loc) << "$fopen mode must be a string literal",
+               Value{};
+
+      auto mode =
+          llvm::StringSwitch<std::optional<moore::FOpenMode>>(
+              strLit->getValue())
+              .Cases({"r", "rb"}, moore::FOpenMode::Read)
+              .Cases({"w", "wb"}, moore::FOpenMode::Write)
+              .Cases({"a", "ab"}, moore::FOpenMode::Append)
+              .Cases({"r+", "r+b", "rb+"}, moore::FOpenMode::ReadUpdate)
+              .Cases({"w+", "w+b", "wb+"}, moore::FOpenMode::WriteUpdate)
+              .Cases({"a+", "a+b", "ab+"}, moore::FOpenMode::AppendUpdate)
+              .Default(std::nullopt);
+
       if (!mode)
-        return {};
+        return emitError(loc)
+                   << "invalid $fopen mode '" << strLit->getValue() << "'",
+               Value{};
+      modeAttr = moore::FOpenModeAttr::get(getContext(), *mode);
     }
-    return moore::FOpenBIOp::create(builder, loc, filename, mode);
+    return moore::FOpenBIOp::create(builder, loc, filename, modeAttr);
   }
 
   // Unrecognized system call

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3479,6 +3479,26 @@ Value Context::convertSystemCall(
     return {};
   }
 
+  //===--------------------------------------------------------------------===//
+  // File I/O System Functions
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::FOpen) {
+    assert(numArgs >= 1 && numArgs <= 2 && "`$fopen` takes 1 or 2 arguments");
+    auto filename = convertRvalueExpression(
+      *args[0], moore::StringType::get(getContext()));
+    if (!filename)
+      return {};
+    Value mode;
+    if (numArgs == 2) {
+      mode = convertRvalueExpression(
+        *args[1], moore::StringType::get(getContext()));
+      if (!mode)
+        return {};
+    }
+    return moore::FOpenBIOp::create(builder, loc, filename, mode);
+  }
+
   // Unrecognized system call
   emitError(loc) << "unsupported system call `" << name << "`";
   return {};

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3485,14 +3485,14 @@ Value Context::convertSystemCall(
 
   if (nameId == ksn::FOpen) {
     assert(numArgs >= 1 && numArgs <= 2 && "`$fopen` takes 1 or 2 arguments");
-    auto filename = convertRvalueExpression(
-      *args[0], moore::StringType::get(getContext()));
+    auto filename =
+        convertRvalueExpression(*args[0], moore::StringType::get(getContext()));
     if (!filename)
       return {};
     Value mode;
     if (numArgs == 2) {
-      mode = convertRvalueExpression(
-        *args[1], moore::StringType::get(getContext()));
+      mode = convertRvalueExpression(*args[1],
+                                     moore::StringType::get(getContext()));
       if (!mode)
         return {};
     }

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1105,7 +1105,7 @@ struct StmtVisitor {
     if (nameId == ksn::FClose) {
       assert(args.size() == 1 && "$fclose takes 1 argument");
       auto fd = context.convertRvalueExpression(*args[0]);
-      if(!fd)
+      if (!fd)
         return failure();
       auto i32 = moore::IntType::getInt(builder.getContext(), 32);
       if (fd.getType() != i32)

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1100,6 +1100,20 @@ struct StmtVisitor {
       return true;
     }
 
+    // File I/O Tasks
+
+    if (nameId == ksn::FClose) {
+      assert(args.size() == 1 && "$fclose takes 1 argument");
+      auto fd = context.convertRvalueExpression(*args[0]);
+      if(!fd)
+        return failure();
+      auto i32 = moore::IntType::getInt(builder.getContext(), 32);
+      if (fd.getType() != i32)
+        fd = moore::ConversionOp::create(builder, loc, i32, fd);
+      moore::FCloseBIOp::create(builder, loc, fd);
+      return true;
+    }
+
     // Queue Tasks
 
     if (args.size() >= 1 && args[0]->type->isQueue()) {

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1104,12 +1104,10 @@ struct StmtVisitor {
 
     if (nameId == ksn::FClose) {
       assert(args.size() == 1 && "$fclose takes 1 argument");
-      auto fd = context.convertRvalueExpression(*args[0]);
+      auto fd = context.convertRvalueExpression(
+          *args[0], moore::IntType::getInt(builder.getContext(), 32));
       if (!fd)
         return failure();
-      auto i32Type = moore::IntType::getInt(builder.getContext(), 32);
-      if (fd.getType() != i32Type)
-        fd = moore::ConversionOp::create(builder, loc, i32Type, fd);
       moore::FCloseBIOp::create(builder, loc, fd);
       return true;
     }

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1107,9 +1107,9 @@ struct StmtVisitor {
       auto fd = context.convertRvalueExpression(*args[0]);
       if (!fd)
         return failure();
-      auto i32 = moore::IntType::getInt(builder.getContext(), 32);
-      if (fd.getType() != i32)
-        fd = moore::ConversionOp::create(builder, loc, i32, fd);
+      auto i32Type = moore::IntType::getInt(builder.getContext(), 32);
+      if (fd.getType() != i32Type)
+        fd = moore::ConversionOp::create(builder, loc, i32Type, fd);
       moore::FCloseBIOp::create(builder, loc, fd);
       return true;
     }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2959,7 +2959,8 @@ struct FOpenBIOpConversion : public OpConversionPattern<FOpenBIOp> {
   LogicalResult
   matchAndRewrite(FOpenBIOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<sim::FOpenOp>(op, adaptor.getFilename(), adaptor.getMode());
+    rewriter.replaceOpWithNewOp<sim::FOpenOp>(op, adaptor.getFilename(),
+                                              adaptor.getMode());
     return success();
   }
 };
@@ -2968,7 +2969,7 @@ struct FCloseBIOpConversion : public OpConversionPattern<FCloseBIOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult matchAndRewrite(FCloseBIOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
+                                ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<sim::FCloseOp>(op, adaptor.getFd());
     return success();
   }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2955,12 +2955,33 @@ struct DisplayBIOpConversion : public OpConversionPattern<DisplayBIOp> {
 
 struct FOpenBIOpConversion : public OpConversionPattern<FOpenBIOp> {
   using OpConversionPattern::OpConversionPattern;
-
   LogicalResult
   matchAndRewrite(FOpenBIOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<sim::FOpenOp>(op, adaptor.getFilename(),
-                                              adaptor.getMode());
+    sim::SVFOpenModeAttr simMode;
+    if (auto modeAttr = op.getModeAttr()) {
+      auto mapMode = [](moore::FOpenMode m) -> sim::SVFOpenMode {
+        switch (m) {
+        case moore::FOpenMode::Read:
+          return sim::SVFOpenMode::Read;
+        case moore::FOpenMode::Write:
+          return sim::SVFOpenMode::Write;
+        case moore::FOpenMode::Append:
+          return sim::SVFOpenMode::Append;
+        case moore::FOpenMode::ReadUpdate:
+          return sim::SVFOpenMode::ReadUpdate;
+        case moore::FOpenMode::WriteUpdate:
+          return sim::SVFOpenMode::WriteUpdate;
+        case moore::FOpenMode::AppendUpdate:
+          return sim::SVFOpenMode::AppendUpdate;
+        }
+        llvm_unreachable("unknown FOpenMode");
+      };
+      simMode = sim::SVFOpenModeAttr::get(op.getContext(),
+                                          mapMode(modeAttr.getValue()));
+    }
+    rewriter.replaceOpWithNewOp<sim::SVFOpenOp>(op, adaptor.getFilename(),
+                                                simMode);
     return success();
   }
 };
@@ -2968,9 +2989,10 @@ struct FOpenBIOpConversion : public OpConversionPattern<FOpenBIOp> {
 struct FCloseBIOpConversion : public OpConversionPattern<FCloseBIOp> {
   using OpConversionPattern::OpConversionPattern;
 
-  LogicalResult matchAndRewrite(FCloseBIOp op, OpAdaptor adaptor,
-                                ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<sim::FCloseOp>(op, adaptor.getFd());
+  LogicalResult
+  matchAndRewrite(FCloseBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::SVFCloseOp>(op, adaptor.getFd());
     return success();
   }
 };

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2953,6 +2953,27 @@ struct DisplayBIOpConversion : public OpConversionPattern<DisplayBIOp> {
   }
 };
 
+struct FOpenBIOpConversion : public OpConversionPattern<FOpenBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(FOpenBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::FOpenOp>(op, adaptor.getFilename(), adaptor.getMode());
+    return success();
+  }
+};
+
+struct FCloseBIOpConversion : public OpConversionPattern<FCloseBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(FCloseBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::FCloseOp>(op, adaptor.getFd());
+    return success();
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -3500,6 +3521,10 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FormatIntOpConversion,
     FormatRealOpConversion,
     DisplayBIOpConversion,
+
+    // File I/O operations
+    FOpenBIOpConversion,
+    FCloseBIOpConversion,
 
     // Dynamic string operations
     StringLenOpConversion,

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -602,3 +602,28 @@ function void StringBuiltins(string string_in, int int_in);
   // CHECK: [[CHAR:%.+]] = moore.string.get [[STR]]{{\[}}[[INT]]]
   dummyE(string_in.getc(int_in));
 endfunction
+
+// IEEE 1800-2017 § 21.3 "File I/O system tasks and functions"
+// CHECK-LABEL: func.func private @FileIOBuiltins(
+// CHECK-SAME: [[FD_INT:%.+]]: !moore.i32
+// CHECK-SAME: [[FD_INTEGER:%.+]]: !moore.l32
+function void FileIOBuiltins(int fd_int, integer fd_integer);
+  int fd;
+
+  // CHECK: [[FNAME:%.+]] = moore.constant_string "file.txt" : i64
+  // CHECK-NEXT: [[FNAME_S:%.+]] = moore.int_to_string [[FNAME]] : i64
+  // CHECK-NEXT: [[FD1:%.+]] = moore.builtin.fopen [[FNAME_S]]
+  fd = $fopen("file.txt");
+
+  // CHECK: [[FNAME2:%.+]] = moore.constant_string "file.txt" : i64
+  // CHECK-NEXT: [[FNAME2_S:%.+]] = moore.int_to_string [[FNAME2]] : i64
+  // CHECK-NEXT: [[MODE:%.+]] = moore.constant_string "w" : i8
+  // CHECK-NEXT: [[MODE_S:%.+]] = moore.int_to_string [[MODE]] : i8
+  // CHECK-NEXT: [[FD2:%.+]] = moore.builtin.fopen [[FNAME2_S]], [[MODE_S]]
+  fd = $fopen("file.txt", "w");
+
+  // CHECK: [[FDVAL:%.+]] = moore.read {{%.+}} : <i32>
+  // CHECK-NEXT: moore.builtin.fclose [[FDVAL]]
+  $fclose(fd);
+
+endfunction

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -605,8 +605,8 @@ endfunction
 
 // IEEE 1800-2017 § 21.3 "File I/O system tasks and functions"
 // CHECK-LABEL: func.func private @FileIOBuiltins(
-// CHECK-SAME: [[FD_INT:%.+]]: !moore.i32
-// CHECK-SAME: [[FD_INTEGER:%.+]]: !moore.l32
+// CHECK-SAME: [[FD_INT:%[^ ,]+]]: !moore.i32
+// CHECK-SAME: [[FD_INTEGER:%[^ ,]+]]: !moore.l32
 function void FileIOBuiltins(int fd_int, integer fd_integer);
   int fd;
 
@@ -615,12 +615,80 @@ function void FileIOBuiltins(int fd_int, integer fd_integer);
   // CHECK-NEXT: [[FD1:%.+]] = moore.builtin.fopen [[FNAME_S]]
   fd = $fopen("file.txt");
 
-  // CHECK: [[FNAME2:%.+]] = moore.constant_string "file.txt" : i64
-  // CHECK-NEXT: [[FNAME2_S:%.+]] = moore.int_to_string [[FNAME2]] : i64
-  // CHECK-NEXT: [[MODE:%.+]] = moore.constant_string "w" : i8
-  // CHECK-NEXT: [[MODE_S:%.+]] = moore.int_to_string [[MODE]] : i8
-  // CHECK-NEXT: [[FD2:%.+]] = moore.builtin.fopen [[FNAME2_S]], [[MODE_S]]
-  fd = $fopen("file.txt", "w");
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = r
+  fd = $fopen("f", "r");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = r
+  fd = $fopen("f", "rb");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = w
+  fd = $fopen("f", "w");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = w
+  fd = $fopen("f", "wb");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = a
+  fd = $fopen("f", "a");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = a
+  fd = $fopen("f", "ab");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = r_update
+  fd = $fopen("f", "r+");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = r_update
+  fd = $fopen("f", "r+b");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = r_update
+  fd = $fopen("f", "rb+");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = w_update
+  fd = $fopen("f", "w+");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = w_update
+  fd = $fopen("f", "w+b");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = w_update
+  fd = $fopen("f", "wb+");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = a_update
+  fd = $fopen("f", "a+");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = a_update
+  fd = $fopen("f", "a+b");
+
+  // CHECK: [[F:%.+]] = moore.constant_string "f" : i8
+  // CHECK-NEXT: [[FS:%.+]] = moore.int_to_string [[F]] : i8
+  // CHECK-NEXT: moore.builtin.fopen [[FS]] mode = a_update
+  fd = $fopen("f", "ab+");
 
   // CHECK: [[FDVAL:%.+]] = moore.read {{%.+}} : <i32>
   // CHECK-NEXT: moore.builtin.fclose [[FDVAL]]

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1813,3 +1813,24 @@ moore.module @CoroutineLowering() {
   }
   moore.output
 }
+
+// CHECK-LABEL: func.func @FOpenNoMode
+func.func @FOpenNoMode(%arg0: !moore.string) {
+  // CHECK: [[FD:%.+]] = sim.sv.fopen %arg0
+  %fd = moore.builtin.fopen %arg0
+  return
+}
+
+// CHECK-LABEL: func.func @FOpenWithMode
+func.func @FOpenWithMode(%arg0: !moore.string) {
+  // CHECK: [[FD:%.+]] = sim.sv.fopen %arg0 mode = w
+  %fd = moore.builtin.fopen %arg0 mode = w
+  return
+}
+
+// CHECK-LABEL: func.func @FClose
+func.func @FClose(%arg0: !moore.i32) {
+  // CHECK: sim.sv.fclose %arg0
+  moore.builtin.fclose %arg0
+  return
+}


### PR DESCRIPTION
Implement $fopen, and $fclose system task in the ImportVerilog pipeline.

- Add moore.builtin.fopen/fclose ops in Moore dialect.
- Add sim.fopen/fclose ops in Sim dialect
- Lower Moore file I/O builtins to Sim equivalents in MooreToCore
- Add tests covering that topics in builtin.sv
