### PR TITLE
ci: declare minimum permissions on dispatchCirctTests workflow

### DIFF
--- a/.github/workflows/dispatchCirctTests.yml
+++ b/.github/workflows/dispatchCirctTests.yml
@@ -12,6 +12,10 @@ on:
     workflows: ["Build and Test"]
     types: [completed]
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   dispatch:
     name: Dispatch circt-tests


### PR DESCRIPTION
Declares an explicit top-level `permissions` block on `.github/workflows/dispatchCirctTests.yml` with the two scopes the job actually uses: `actions: read` (the `actions/download-artifact@v4` step that pulls the `dispatch-metadata` artifact from the upstream `workflow_run` via `run-id` requires this scope on `GITHUB_TOKEN`) and `contents: read`. The cross-repo `gh workflow run` call is authenticated against `CIRCT_TESTS_DISPATCH_TOKEN`, not `GITHUB_TOKEN`, so it does not affect the scope calculation here.

Pinning is worth the small footprint because `workflow_run` events run in the context of the default branch with full repo-level token access by default. CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is the canonical case for why bounding that authority matters - a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs, and the leaked token carried whatever scope was issued. Per-workflow caps bound runtime authority irrespective of repo or org default. OpenSSF Scorecard's Token-Permissions check only credits the explicit declaration.

YAML validated locally with `yaml.safe_load`.
