### PR TITLE
ci: declare contents:read on testESIRuntime workflow

### DIFF
--- a/.github/workflows/testESIRuntime.yml
+++ b/.github/workflows/testESIRuntime.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   # ---------------------------------------------------------------------------
   #  Build and test Linux wheels. Run the CIRCT tests also.


### PR DESCRIPTION
Pins `.github/workflows/testESIRuntime.yml` to `permissions: contents: read` at the workflow level. The build job runs inside a container, clones CIRCT without submodules, sets up a Python venv, builds the ESI runtime with `cmake`/`ninja`, and runs `pytest`. None of those steps need anything more than read on contents.

The technical case for declaring this explicitly even when the org default may already be read-only is CVE-2025-30066 (the March 2025 `tj-actions/changed-files` supply-chain attack). A tampered third-party action exfiltrated `GITHUB_TOKEN` from the workflow logs, and the leaked token retained whatever scope it was issued with. Capping each workflow at the minimum bounds the runtime authority of every action in the chain regardless of the repo or org default, and survives a future default-widening change. OpenSSF Scorecard's Token-Permissions check also only credits the explicit per-workflow declaration.

YAML validated locally with `yaml.safe_load`.
