### PR TITLE
[ESI][Runtime] Fix data race in PODTypeDeserializer::poke()

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/TypedPorts.h
@@ -184,7 +184,7 @@ public:
       throw std::runtime_error("PODTypeDeserializer::push: null message");
 
     // Flush the buffer, bail if still full.
-    poke();
+    pokeLocked();
     if (pendingOutput)
       return false;
 
@@ -194,11 +194,17 @@ public:
     const MessageData &flat = getMessageDataRef<T>(*msg, scratch);
     pendingOutput = std::make_unique<T>(fromMessageData<T>(flat, wireInfo));
     msg.reset();
-    poke();
+    pokeLocked();
     return true;
   }
 
   bool poke() {
+    std::scoped_lock<std::mutex> lock(mutex);
+    return pokeLocked();
+  }
+
+private:
+  bool pokeLocked() {
     if (pendingOutput && output(pendingOutput)) {
       pendingOutput.reset();
       return true;
@@ -206,7 +212,6 @@ public:
     return false;
   }
 
-private:
   OutputCallback output;
   WireInfo wireInfo;
   std::mutex mutex;


### PR DESCRIPTION
PODTypeDeserializer::push() ran under a mutex, but poke() did not. TypedReadPort::readAsync() calls deserializer->poke() from the consumer thread while the cosim background thread can be in push() (which also calls poke()). Two concurrent poke()s could both pass the 'if (pendingOutput)' check and both invoke output(pendingOutput), each std::move'ing from the same unique_ptr. Result: a null unique_ptr gets enqueued into the PollingBuffer (or handed to a waiting promise), manifesting as either:

  - 'TypedFunction: deserializer produced a null value' thrown by awaitDecoded (e.g. sign_probe in serialization_probes_test), or
  - SIGSEGV in tight typed read loops (e.g. typed_read_channel_struct in test_codegen_test) from UB on the moved-from unique_ptr.

Both showed up as occasional CI failures and were hard to repro locally. Fix mirrors the QueuedDecodeTypeDeserializer pattern: split into a private pokeLocked() helper used from push(), and a public poke() that takes the mutex before delegating.

Assisted-by: vscode:Claude Opus 4.7
