### PR TITLE
[ESI][Runtime] Packaging: don't include debug DLLs

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -310,8 +310,12 @@ if(WIN32 AND MSVC)
 endif()
 
 
-# Add the Python bindings.
-add_subdirectory(python)
+# Add the Python bindings. The `python` subdirectory is not shipped with the
+# source tree distributed inside the wheel (which is only used for on-demand
+# Debug builds on Windows), so guard against its absence.
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python/CMakeLists.txt)
+  add_subdirectory(python)
+endif()
 
 ##===----------------------------------------------------------------------===//
 ## Backends are loaded dynamically as plugins.

--- a/lib/Dialect/ESI/runtime/cpp/cmake/esiaccelConfig.cmake.in
+++ b/lib/Dialect/ESI/runtime/cpp/cmake/esiaccelConfig.cmake.in
@@ -1,21 +1,35 @@
+# On Windows, the wheel ships only Release binaries to keep its size
+# manageable. If a consumer is configuring a Debug build on Windows, build the
+# runtime from the C++ sources shipped alongside the wheel under
+# `<wheel>/esiaccel/source` instead of pointing at non-existent debug DLLs.
+# CMAKE_BUILD_TYPE is empty for multi-config generators (Visual Studio, etc.),
+# so the source-build path is only taken for single-config generators; with
+# multi-config generators the consumer must select the Release configuration.
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(_esiaccel_source_dir "${CMAKE_CURRENT_LIST_DIR}/../source")
+  if(NOT EXISTS "${_esiaccel_source_dir}/CMakeLists.txt")
+    message(FATAL_ERROR
+      "esiaccel: Debug build requested on Windows but C++ sources were "
+      "not found at ${_esiaccel_source_dir}. The wheel may be incomplete.")
+  endif()
+  message(STATUS
+    "esiaccel: building runtime from source for Debug build on Windows")
+  set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+  add_subdirectory("${_esiaccel_source_dir}"
+                   "${CMAKE_BINARY_DIR}/esiaccel-source-build"
+                   EXCLUDE_FROM_ALL)
+  return()
+endif()
+
 add_library(esiaccel::ESICppRuntime SHARED IMPORTED)
 set_target_properties(esiaccel::ESICppRuntime PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../include"
 )
 
 if(WIN32)
-  # Default to Release variant for single-config generators and as fallback.
-  # Multi-config generators (Visual Studio, Xcode) use the per-config
-  # IMPORTED_LOCATION_<CONFIG> properties set below.
   set_target_properties(esiaccel::ESICppRuntime PROPERTIES
     IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/../ESICppRuntime.dll"
     IMPORTED_IMPLIB "${CMAKE_CURRENT_LIST_DIR}/../ESICppRuntime.lib"
-  )
-  set_target_properties(esiaccel::ESICppRuntime PROPERTIES
-    IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_LIST_DIR}/../ESICppRuntime.dll"
-    IMPORTED_IMPLIB_RELEASE "${CMAKE_CURRENT_LIST_DIR}/../ESICppRuntime.lib"
-    IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_LIST_DIR}/../ESICppRuntime_d.dll"
-    IMPORTED_IMPLIB_DEBUG "${CMAKE_CURRENT_LIST_DIR}/../ESICppRuntime_d.lib"
   )
 else()
   set_target_properties(esiaccel::ESICppRuntime PROPERTIES
@@ -34,12 +48,6 @@ if(WIN32)
     IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/../CosimRpc.dll"
     IMPORTED_IMPLIB "${CMAKE_CURRENT_LIST_DIR}/../CosimRpc.lib"
   )
-  set_target_properties(esiaccel::CosimRpc PROPERTIES
-    IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_LIST_DIR}/../CosimRpc.dll"
-    IMPORTED_IMPLIB_RELEASE "${CMAKE_CURRENT_LIST_DIR}/../CosimRpc.lib"
-    IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_LIST_DIR}/../CosimRpc_d.dll"
-    IMPORTED_IMPLIB_DEBUG "${CMAKE_CURRENT_LIST_DIR}/../CosimRpc_d.lib"
-  )
 else()
   set_target_properties(esiaccel::CosimRpc PROPERTIES
     IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/../@ESIRT_INSTALL_LIBDIR@/libCosimRpc.so"
@@ -56,12 +64,6 @@ if(WIN32)
   set_target_properties(esiaccel::CosimBackend PROPERTIES
     IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/../CosimBackend.dll"
     IMPORTED_IMPLIB "${CMAKE_CURRENT_LIST_DIR}/../CosimBackend.lib"
-  )
-  set_target_properties(esiaccel::CosimBackend PROPERTIES
-    IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_LIST_DIR}/../CosimBackend.dll"
-    IMPORTED_IMPLIB_RELEASE "${CMAKE_CURRENT_LIST_DIR}/../CosimBackend.lib"
-    IMPORTED_LOCATION_DEBUG "${CMAKE_CURRENT_LIST_DIR}/../CosimBackend_d.dll"
-    IMPORTED_IMPLIB_DEBUG "${CMAKE_CURRENT_LIST_DIR}/../CosimBackend_d.lib"
   )
 else()
   set_target_properties(esiaccel::CosimBackend PROPERTIES

--- a/lib/Dialect/ESI/runtime/setup.py
+++ b/lib/Dialect/ESI/runtime/setup.py
@@ -58,17 +58,14 @@ class CMakeBuild(build_py):
           os.path.join(target_dir, "..", "cmake_build"))
     src_dir = _thisdir
 
-    # On Windows, we build both Release and Debug configurations
-    # to support applications in both modes.
+    # We build a single Release configuration. On Windows, Debug builds for
+    # consumers are supported by shipping the C++ sources alongside the wheel
+    # and having the distributed esiaccelConfig.cmake compile them on demand
+    # (see the copy step below and cpp/cmake/esiaccelConfig.cmake.in).
     configs_to_build = ["Release"]
-    if platform.system() == "Windows":
-      configs_to_build.append("Debug")
 
     for cfg in configs_to_build:
-      # Use separate build directories for each configuration
       current_build_dir = cmake_build_dir
-      if len(configs_to_build) > 1:
-        current_build_dir = os.path.join(cmake_build_dir, cfg)
 
       os.makedirs(current_build_dir, exist_ok=True)
       cmake_cache_file = os.path.join(current_build_dir, "CMakeCache.txt")
@@ -163,47 +160,42 @@ class CMakeBuild(build_py):
       )
 
       # Install the runtime directly into the target directory.
-      # For the first config (Release), clear the target directory.
-      # For subsequent configs (Debug on Windows), keep existing files.
       if cfg == "Release" and os.path.exists(target_dir):
         shutil.rmtree(target_dir)
 
       print(f"Installing {cfg} configuration...")
-      if cfg == "Debug":
-        # For Debug builds, we only built the C++ runtime (not the Python
-        # extension), so we can't use cmake --install with the ESIRuntime
-        # component (it would fail trying to install the unbuilt Python
-        # extension). Instead, manually copy the debug DLLs, PDBs, import
-        # libraries, and executables for the specific ESIRuntime binaries.
-        import glob
-        install_dir = os.path.join(target_dir, "esiaccel")
-        os.makedirs(install_dir, exist_ok=True)
-        debug_patterns = [
-            "ESICppRuntime*.dll",
-            "ESICppRuntime*.lib",
-            "CosimRpc*.dll",
-            "CosimRpc*.lib",
-            "CosimBackend*.dll",
-            "CosimBackend*.lib",
-            "esiquery*.exe",
-        ]
-        for pattern in debug_patterns:
-          for f in glob.glob(os.path.join(current_build_dir, pattern)):
-            print(f"  Installing {os.path.basename(f)}")
-            shutil.copy2(f, install_dir)
-      else:
-        subprocess.check_call(
-            [
-                "cmake",
-                "--install",
-                ".",
-                "--prefix",
-                os.path.join(target_dir, "esiaccel"),
-                "--component",
-                "ESIRuntime",
-            ],
-            cwd=current_build_dir,
-        )
+      subprocess.check_call(
+          [
+              "cmake",
+              "--install",
+              ".",
+              "--prefix",
+              os.path.join(target_dir, "esiaccel"),
+              "--component",
+              "ESIRuntime",
+          ],
+          cwd=current_build_dir,
+      )
+
+    # Ship the C++ sources alongside the wheel so that consumers on Windows
+    # can build a Debug variant on demand. The distributed
+    # esiaccelConfig.cmake adds this source tree as a subdirectory when the
+    # consumer is configuring a Debug build on Windows.
+    source_dst = os.path.join(target_dir, "esiaccel", "source")
+    if os.path.exists(source_dst):
+      shutil.rmtree(source_dst)
+    os.makedirs(source_dst, exist_ok=True)
+    print(f"Copying C++ sources into wheel at {source_dst}")
+    shutil.copy2(os.path.join(src_dir, "CMakeLists.txt"), source_dst)
+    shutil.copy2(os.path.join(src_dir, "cosim.proto"), source_dst)
+    # Copy the cpp/ tree but skip the cmake/ subdirectory: the
+    # esiaccelConfig.cmake.in template is only relevant when (re)building the
+    # full wheel, not when consumers compile the runtime from these sources.
+    shutil.copytree(os.path.join(src_dir, "cpp"),
+                    os.path.join(source_dst, "cpp"),
+                    ignore=shutil.ignore_patterns("cmake"))
+    shutil.copytree(os.path.join(src_dir, "cosim_dpi_server"),
+                    os.path.join(source_dst, "cosim_dpi_server"))
 
 
 class NoopBuildExtension(build_ext):


### PR DESCRIPTION
This was likely a good idea but it doubled the size of python wheels on Windows. We're now bumping up against the total project size on pypi.org.

Assisted-by: vscode:Claude Opus 4.7

