### PR TITLE
[ESI][codegen] Comment out invalid C++ void fields

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -1272,6 +1272,11 @@ class CppTypeEmitter:
     field_decls: List[str] = []
     for field_name, field_type in fields:
       field_cpp = self._cpp_type(field_type)
+      if field_cpp == "void":
+        # `void` is not a valid C++ field type; emit a comment so the field
+        # remains visible in the generated header without breaking compilation.
+        field_decls.append(f"// void {field_name};")
+        continue
       wrapped = self._unwrap_aliases(field_type)
       if isinstance(wrapped, (types.BitsType, types.IntType)):
         # TODO: Bitfield layout is implementation-defined; consider
@@ -1292,7 +1297,9 @@ class CppTypeEmitter:
     # Logical-order constructor: parameters follow `struct_type.fields` order
     # (the user-facing order from the manifest), independent of any wire-layout
     # reversal applied to the member declarations above.
-    logical_fields = list(struct_type.fields)
+    logical_fields = [(name, ftype)
+                      for name, ftype in struct_type.fields
+                      if self._cpp_type(ftype) != "void"]
     if logical_fields:
       hdr.write(f"  {struct_name}() = default;\n")
       ctor_params = ", ".join(
@@ -1322,6 +1329,8 @@ class CppTypeEmitter:
     # First pass: emit wrapper structs for fields that need padding.
     wrapper_names: Dict[str, str] = {}
     for field_name, field_type in fields:
+      if self._cpp_type(field_type) == "void":
+        continue
       field_bytes = self._field_byte_width(field_type)
       pad_bytes = union_bytes - field_bytes
       if pad_bytes > 0:
@@ -1337,10 +1346,13 @@ class CppTypeEmitter:
     # Second pass: emit the union itself.
     union_field_decls: List[str] = []
     for field_name, field_type in fields:
-      if field_name in wrapper_names:
+      field_cpp = self._cpp_type(field_type)
+      if field_cpp == "void":
+        # `void` is not a valid C++ union member; emit a comment placeholder.
+        union_field_decls.append(f"// void {field_name};")
+      elif field_name in wrapper_names:
         union_field_decls.append(f"{wrapper_names[field_name]} {field_name};")
       else:
-        field_cpp = self._cpp_type(field_type)
         union_field_decls.append(f"{field_cpp} {field_name};")
     hdr.write(f"union {union_name} {{\n")
     for decl in union_field_decls:

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -544,3 +544,53 @@ def test_size_assert_skipped_for_unbounded_struct():
   # The struct is still emitted, but no size assert (its size is unbounded).
   assert "struct _struct_tag_ui8_data__esi_any" in hdr
   assert "static_assert(sizeof(_struct_tag_ui8_data__esi_any)" not in hdr
+
+
+def test_struct_with_void_field_commented_out():
+  """Void-typed struct fields are commented out so the header stays valid C++.
+
+  `void x;` is not a valid C++ field declaration. The codegen must instead
+  emit `// void x;` and exclude the field from the generated constructor.
+  """
+  uint8 = types.UIntType("ui8", 8)
+  void_t = types.VoidType("!esi.void")
+  s = types.StructType(
+      "!hw.struct<valid: ui8, client_data: void>",
+      [("valid", uint8), ("client_data", void_t)],
+  )
+
+  hdr = _generate_header([s])
+  # No uncommented `void <name>;` declaration may appear in the header.
+  assert re.search(r"^\s*void\s+\w+;", hdr, re.M) is None, hdr
+  # The void field must instead show up as a commented-out placeholder.
+  assert "// void client_data;" in hdr
+  # The non-void field is still emitted normally.
+  assert "uint8_t valid" in hdr
+  # The constructor must not take a `void` parameter (which would be
+  # invalid C++); only the non-void field is in the parameter list.
+  ctor_match = re.search(r"_struct_[^\s(]*\(([^)]*)\) :", hdr)
+  assert ctor_match, f"Constructor not found in:\n{hdr}"
+  ctor_params = ctor_match.group(1)
+  assert "client_data" not in ctor_params
+  assert "valid" in ctor_params
+
+
+def test_union_with_void_field_commented_out():
+  """Void-typed union members are commented out and skip wrapper generation."""
+  uint16 = types.UIntType("ui16", 16)
+  void_t = types.VoidType("!esi.void")
+  u = types.UnionType(
+      "!hw.union<a: ui16, b: void>",
+      [("a", uint16), ("b", void_t)],
+  )
+
+  hdr = _generate_header([u])
+  # No uncommented `void <name>;` declaration may appear in the header;
+  # the void member must show up as a commented-out placeholder instead.
+  assert re.search(r"^\s*void\s+\w+;", hdr, re.M) is None, hdr
+  assert "// void b;" in hdr
+  # No padding wrapper struct is generated for the void field.
+  assert "_union_a_ui16_b__esi_void_b" not in hdr
+  # The non-void member is still present in the union body.
+  union_body = hdr[hdr.index("union "):]
+  assert "uint16_t a;" in union_body


### PR DESCRIPTION
void is not a valid C++ field/member type. When an ESI struct or union has a void-typed field, emit '// void <name>;' instead and skip it from the generated constructor parameter list.

Assisted-by: GitHub Copilot:claude-opus-4-7

