### PR TITLE
[circt-synth] Transform Dialect support PR 1

### DIFF
--- a/test/circt-synth/transform-dialect.mlir
+++ b/test/circt-synth/transform-dialect.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-synth %s --use-transformDialect | FileCheck %s
+
+// ---- PAYLOAD: a tiny HW module with a duplicated comb.and that CSE should fold. ----
+hw.module @dup(in %a: i1, in %b: i1, out o: i1) {
+  %0 = comb.and %a, %b : i1
+  %1 = comb.and %b, %a : i1
+  %2 = comb.xor %0, %1 : i1
+  hw.output %2 : i1
+}
+
+// ---- TRANSFORM SCRIPT: tells the interpreter to run the registered "cse" pass on the root. ----
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @match_hw_module(%op: !transform.any_op {transform.readonly})
+      -> !transform.any_op {
+    transform.match.operation_name %op ["hw.module"] : !transform.any_op
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %target = transform.collect_matching @match_hw_module in %root
+      : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "cse" to %target
+      : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// ---- ASSERTIONS ----
+// After CSE, the two identical comb.and ops collapse into one, and the comb.xor
+// uses that single value twice.
+//
+// CHECK-LABEL: hw.module @dup
+// CHECK:         %[[AND:.+]] = comb.and %a, %b : i1
+// CHECK-NOT:     comb.and
+// CHECK:         %{{.+}} = comb.xor %[[AND]], %[[AND]] : i1
+// CHECK:         hw.output
+

--- a/tools/circt-synth/CMakeLists.txt
+++ b/tools/circt-synth/CMakeLists.txt
@@ -22,8 +22,10 @@ target_link_libraries(circt-synth
   CIRCTTransforms
   CIRCTVerif
   MLIRBytecodeWriter
-  MLIRIR
   MLIRParser
+  MLIRIR
+  MLIRTransformDialect
+  MLIRTransformDialectTransforms
   LLVMSupport
 )
 

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -513,12 +513,12 @@ int main(int argc, char **argv) {
   // Register the supported CIRCT dialects and create a context to work with.
   DialectRegistry registry;
   mlir::transform::registerInterpreterPass();
-  mlir::registerCSEPass();
-  registry
-      .insert<comb::CombDialect, debug::DebugDialect, emit::EmitDialect,
-              hw::HWDialect, ltl::LTLDialect, om::OMDialect, seq::SeqDialect,
-              sim::SimDialect, synth::SynthDialect, sv::SVDialect,
-              verif::VerifDialect, mlir::transform::TransformDialect>();
+
+  registry.insert<comb::CombDialect, datapath::DatapathDialect,
+                  debug::DebugDialect, emit::EmitDialect, hw::HWDialect,
+                  ltl::LTLDialect, om::OMDialect, seq::SeqDialect,
+                  sim::SimDialect, synth::SynthDialect, sv::SVDialect,
+                  verif::VerifDialect, mlir::transform::TransformDialect>();
 
   // Register the standard passes we want.
   MLIRContext context(registry);

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -33,9 +33,15 @@
 #include "circt/Dialect/Synth/Transforms/SynthPasses.h"
 #include "circt/Dialect/Synth/Transforms/SynthesisPipeline.h"
 #include "circt/Dialect/Verif/VerifDialect.h"
+#include "circt/InitAllDialects.h"
+#include "circt/InitAllPasses.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
 #include "circt/Transforms/Passes.h"
+
+#include "mlir/Dialect/Transform/Transforms/Passes.h"
+#include "mlir/Transforms/Passes.h"
+
 #include "mlir/Bytecode/BytecodeReader.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/IR/Diagnostics.h"
@@ -93,6 +99,11 @@ static cl::opt<bool>
     emitBytecode("emit-bytecode",
                  cl::desc("Emit bytecode when generating MLIR output"),
                  cl::init(false), cl::cat(mainCategory));
+
+static cl::opt<bool>
+    useTransformInterpreter("use-transformDialect",
+                            cl::desc("transform dialect interpreter"),
+                            cl::init(false), cl::cat(mainCategory));
 
 static cl::opt<bool> force("f", cl::desc("Enable binary output on terminals"),
                            cl::init(false), cl::cat(mainCategory));
@@ -455,7 +466,11 @@ static LogicalResult executeSynthesis(MLIRContext &context) {
     pm.addInstrumentation(
         std::make_unique<VerbosePassInstrumentation<mlir::ModuleOp>>(
             "circt-synth"));
-  populateCIRCTSynthPipeline(pm);
+  if (useTransformInterpreter) {
+    pm.addPass(mlir::transform::createInterpreterPass());
+  } else {
+    populateCIRCTSynthPipeline(pm);
+  }
 
   if (failed(pm.run(module.get())))
     return failure();
@@ -497,11 +512,15 @@ int main(int argc, char **argv) {
 
   // Register the supported CIRCT dialects and create a context to work with.
   DialectRegistry registry;
+  mlir::transform::registerInterpreterPass();
+  mlir::registerCSEPass();
   registry
-      .insert<comb::CombDialect, datapath::DatapathDialect, debug::DebugDialect,
-              emit::EmitDialect, hw::HWDialect, ltl::LTLDialect, om::OMDialect,
-              seq::SeqDialect, sim::SimDialect, synth::SynthDialect,
-              sv::SVDialect, verif::VerifDialect>();
+      .insert<comb::CombDialect, debug::DebugDialect, emit::EmitDialect,
+              hw::HWDialect, ltl::LTLDialect, om::OMDialect, seq::SeqDialect,
+              sim::SimDialect, synth::SynthDialect, sv::SVDialect,
+              verif::VerifDialect, mlir::transform::TransformDialect>();
+
+  // Register the standard passes we want.
   MLIRContext context(registry);
   if (allowUnregisteredDialects)
     context.allowUnregisteredDialects();

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -33,17 +33,12 @@
 #include "circt/Dialect/Synth/Transforms/SynthPasses.h"
 #include "circt/Dialect/Synth/Transforms/SynthesisPipeline.h"
 #include "circt/Dialect/Verif/VerifDialect.h"
-#include "circt/InitAllDialects.h"
-#include "circt/InitAllPasses.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
 #include "circt/Transforms/Passes.h"
-
-#include "mlir/Dialect/Transform/Transforms/Passes.h"
-#include "mlir/Transforms/Passes.h"
-
 #include "mlir/Bytecode/BytecodeReader.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
+#include "mlir/Dialect/Transform/Transforms/Passes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Parser/Parser.h"


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

Resolve  partial #10315 
- Adds  Support for Transform Dialect 
- I wasn't not able to add transform-interpreter option in circt-synth whereas when i tried for circt-opt it is working fine 
- Did a hackaround using createInterpreterPass 
- When transform-dialect is enabled skips populateCIRCTSynthPipeline in this pr 