### PR TITLE
[circt-verilog] Add bytecode emission

### DIFF
--- a/tools/circt-verilog/CMakeLists.txt
+++ b/tools/circt-verilog/CMakeLists.txt
@@ -16,6 +16,7 @@ set(libs
   CIRCTVerif
   MLIRArithDialect
   MLIRBytecodeReader
+  MLIRBytecodeWriter
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRFuncInlinerExtension

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -26,6 +26,7 @@
 #include "circt/Dialect/Verif/VerifDialect.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
+#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
@@ -85,6 +86,13 @@ struct CLOptions {
   cl::opt<std::string> outputFilename{
       "o", cl::desc("Output filename (`-` for stdout)"),
       cl::value_desc("filename"), cl::init("-"), cl::cat(cat)};
+
+  cl::opt<bool> emitBytecode{
+      "emit-bytecode", cl::desc("Emit bytecode when generating MLIR output"),
+      cl::init(false), cl::cat(cat)};
+
+  cl::opt<bool> force{"f", cl::desc("Enable binary output on terminals"),
+                      cl::init(false), cl::cat(cat)};
 
   cl::opt<bool> verifyDiagnostics{
       "verify-diagnostics",
@@ -287,6 +295,19 @@ struct CLOptions {
 
 static CLOptions opts;
 
+/// Check output stream before writing bytecode to it.
+/// Warn and return true if output is known to be displayed.
+static bool checkBytecodeOutputToConsole(raw_ostream &os) {
+  if (os.is_displayed()) {
+    llvm::errs() << "WARNING: You're attempting to print out a bytecode file.\n"
+                    "This is inadvisable as it may cause display problems. If\n"
+                    "you REALLY want to taste MLIR bytecode first-hand, you\n"
+                    "can force output with the `-f' option.\n\n";
+    return true;
+  }
+  return false;
+}
+
 /// Populate the given pass manager with transformations as configured by the
 /// command line options.
 static void populatePasses(PassManager &pm) {
@@ -412,7 +433,15 @@ static LogicalResult executeWithSources(MLIRContext *context,
 
   // Print the final MLIR.
   auto outputTimer = ts.nest("MLIR Printer");
-  module->print(outputFile->os());
+  if (opts.emitBytecode &&
+      (opts.force || !checkBytecodeOutputToConsole(outputFile->os()))) {
+    if (failed(
+            writeBytecodeToFile(module.get(), outputFile->os(),
+                                mlir::BytecodeWriterConfig(getCirctVersion()))))
+      return failure();
+  } else {
+    module->print(outputFile->os());
+  }
   outputFile->keep();
   return success();
 }


### PR DESCRIPTION
Add the usual `--emit-bytecode` and `-f` flags to circt-verilog to emit MLIR bytecode instead of textual IR.

Assisted-by: Claude Sonnet 4.5