### PR TITLE
[ImportVerilog] Remove unnecessary field `ModuleLowering::canonicalBody`

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -105,11 +105,6 @@ struct ModuleLowering {
   SmallVector<FlattenedIfacePort> ifacePorts;
   DenseMap<const slang::syntax::SyntaxNode *, const slang::ast::PortSymbol *>
       portsBySyntaxNode;
-
-  /// The canonical InstanceBodySymbol used as the key in `hierPaths` after
-  /// module deduplication. When multiple instance bodies share the same
-  /// definition and parameters, they are deduplicated to a single module.
-  const slang::ast::InstanceBodySymbol *canonicalBody = nullptr;
 };
 
 /// Function lowering information. The `op` field holds either a `func::FuncOp`
@@ -509,6 +504,8 @@ struct Context {
   CaptureMap functionCaptures;
 
   /// Collect all hierarchical names used for the per module/instance.
+  /// The keys are the slang canonical instance bodies (or the real instance
+  /// if slang's getCanonicalBody() returned null).
   DenseMap<const slang::ast::InstanceBodySymbol *, SmallVector<HierPathInfo>>
       hierPaths;
 

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -649,11 +649,9 @@ struct ModuleVisitor : public BaseVisitor {
 
     // Here we use the hierarchical value recorded in `Context::valueSymbols`.
     // Then we pass it as the input port with the ref<T> type of the instance.
-    // Use the canonical body from moduleLowering, not &instNode.body, because
-    // module deduplication may have remapped the body pointer and only the
-    // canonical body's hierPaths entries have valid port indices.
-    const auto *canonBody = moduleLowering->canonicalBody;
-    for (const auto &hierPath : context.hierPaths[canonBody]) {
+    // Note that `body` is always the canonical instance body here and in the
+    // `hierPaths` keys.
+    for (const auto &hierPath : context.hierPaths[body]) {
       assert(!hierPath.valueSyms.empty() && "hierPath must have valueSyms");
       if (auto hierValue =
               context.valueSymbols.lookup(hierPath.valueSyms.front());
@@ -680,7 +678,7 @@ struct ModuleVisitor : public BaseVisitor {
     // hierValueSymbols map (for cross-scope lookups from other modules).
     // The hierValueSymbols key is {&instNode, hierName} to ensure
     // instance-specific resolution (e.g., p1 vs p2 get separate entries).
-    for (const auto &hierPath : context.hierPaths[canonBody])
+    for (const auto &hierPath : context.hierPaths[body])
       if (hierPath.idx && hierPath.direction == ArgumentDirection::Out) {
         auto result = inst->getResult(*hierPath.idx);
         // Register the result for ALL aliased symbol pointers so that
@@ -1035,7 +1033,6 @@ Context::convertModuleHeader(const slang::ast::InstanceBodySymbol *module) {
     return slot.get();
   slot = std::make_unique<ModuleLowering>();
   auto &lowering = *slot;
-  lowering.canonicalBody = module;
 
   auto loc = convertLocation(module->location);
   OpBuilder::InsertionGuard g(builder);


### PR DESCRIPTION
This field is no longer needed, and is slightly confusing since it raises the possibility it might not match the slang canonical body.