### PR TITLE
[Synth] add onehot gate

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -140,6 +140,22 @@ T evaluateMajorityLogic(const T &a, const T &b, const T &c) {
   return (a & b) | (a & c) | (b & c);
 }
 
+inline llvm::APInt invertBooleanLogic(llvm::APInt value) {
+  value.flipAllBits();
+  return value;
+}
+
+inline llvm::KnownBits invertBooleanLogic(llvm::KnownBits value) {
+  std::swap(value.Zero, value.One);
+  return value;
+}
+
+template <typename T>
+T evaluateOneHotLogic(const T &a, const T &b, const T &c) {
+  auto allSet = a & b & c;
+  return (a ^ b ^ c) & invertBooleanLogic(allSet);
+}
+
 } // namespace synth
 } // namespace circt
 

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -258,4 +258,47 @@ def MajorityOp : SynthOp<"majority", [
   let hasCustomAssemblyFormat = 1;
 }
 
+def OneHotOp : SynthOp<"onehot", [
+    SameOperandsAndResultType, Pure,
+    DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
+      "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
+      "supportsNumInputs", "createBooleanLogicOp",
+      "getLogicAreaCost"
+    ]>
+  ]>{
+   let summary = "3-input Onehot gate with invertible inputs";
+  let description = [{
+    The `synth.onehot` operation computes the one-hot function of its three
+    inputs, where each operand can be optionally inverted. The one-hot function
+    returns 1 when exactly one of the inputs is 1, and 0 otherwise. For three
+    inputs, it is equivalent to:
+
+    `(a & ~b & ~c) | (~a & b & ~c) | (~a & ~b & c)`
+
+    Example:
+```mlir
+      %r0 = synth.onehot %a, %b, %c : i1
+      %r1 = synth.onehot not %a, %b, not %c : i1
+```
+  }];
+  
+  let arguments = (ins Variadic<AnyType>:$inputs,
+                       DenseBoolArrayAttr:$inverted);
+  let results = (outs AnyType:$result);
+  let builders = [
+  OpBuilder<(ins "Value":$a, "Value":$b, "Value":$c,
+                              CArg<"bool", "false">:$invertA,
+                              CArg<"bool", "false">:$invertB,
+                              CArg<"bool", "false">:$invertC), [{
+    SmallVector<bool> inverted{invertA, invertB, invertC};
+    return build($_builder, $_state, ValueRange{a, b, c},
+                 $_builder.getDenseBoolArrayAttr(inverted));
+  }]>
+];
+
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+
 #endif // CIRCT_DIALECT_SYNTH_SYNTHOPS_TD

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -120,32 +120,33 @@ struct LogicNetworkGate {
     Maj3 = 4,         ///< Reserved 3-input gate kind
     Identity = 5,     ///< Identity gate (used for 1-input inverter)
     Choice = 6,       ///< Choice node (synth.choice)
-    Dot3 = 7          ///< Ordered DOT gate (3-input, synth.dot)
+    Dot3 = 7,         ///< Ordered DOT gate (3-input, synth.dot)
+    OneHot3 = 8       ///< OneHot gate (3-input, synth.onehot)
   };
 
-  /// Operation pointer and kind packed together.
-  /// The kind is stored in the low bits of the pointer.
-  llvm::PointerIntPair<Operation *, 3, Kind> opAndKind;
+  /// Operation pointer and gate kind. Constants have a null operation pointer.
+  Operation *op = nullptr;
+  Kind kind = Constant;
 
   /// Fanin edges (up to 3 inputs). For AND gates, only edges[0] and edges[1]
   /// are used. For PrimaryInput/Constant and Choice, none are used. The
   /// inversion bit is encoded in each edge.
   Signal edges[3];
 
-  LogicNetworkGate() : opAndKind(nullptr, Constant), edges{} {}
+  LogicNetworkGate() : op(nullptr), kind(Constant), edges{} {}
   LogicNetworkGate(Operation *op, Kind kind,
                    llvm::ArrayRef<Signal> operands = {})
-      : opAndKind(op, kind), edges{} {
+      : op(op), kind(kind), edges{} {
     assert(operands.size() <= 3 && "Too many operands for LogicNetworkGate");
     for (size_t i = 0; i < operands.size(); ++i)
       edges[i] = operands[i];
   }
 
   /// Get the kind of this gate.
-  Kind getKind() const { return opAndKind.getInt(); }
+  Kind getKind() const { return kind; }
 
   /// Get the operation pointer (nullptr for constants).
-  Operation *getOperation() const { return opAndKind.getPointer(); }
+  Operation *getOperation() const { return op; }
 
   /// Get the number of fanin edges based on kind.
   unsigned getNumFanins() const {
@@ -160,6 +161,8 @@ struct LogicNetworkGate {
       return 3;
     case Dot3:
       return 3;
+    case OneHot3:
+      return 3;
     case Identity:
       return 1;
     case Choice:
@@ -172,7 +175,7 @@ struct LogicNetworkGate {
   bool isLogicGate() const {
     Kind k = getKind();
     return k == And2 || k == Xor2 || k == Maj3 || k == Identity ||
-           k == Choice || k == Dot3;
+           k == Choice || k == Dot3 || k == OneHot3;
   }
 
   /// Check if this should always be a cut input (PI or constant).

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -109,3 +109,18 @@ hw.module @test_majority(in %a: i1, in %b: i1, in %c: i1,
   %1 = synth.majority %a, %b, %c : i1
   hw.output %0, %1 : i1, i1
 }
+
+// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 test_onehot --c2 test_onehot | FileCheck %s --check-prefix=ONEHOT
+// ONEHOT: c1 == c2
+// CHECK-LABEL: hw.module @test_onehot
+hw.module @test_onehot(in %a: i1, in %b: i1, in %c: i1,
+                       out out0: i1, out out1: i1) {
+  // CHECK: %[[CHOICE:.+]] = synth.choice
+  // CHECK: hw.output %[[CHOICE]], %[[CHOICE]] : i1, i1
+  %aOnly = synth.aig.and_inv %a, not %b, not %c : i1
+  %bOnly = synth.aig.and_inv not %a, %b, not %c : i1
+  %cOnly = synth.aig.and_inv not %a, not %b, %c : i1
+  %0 = comb.xor %aOnly, %bOnly, %cOnly : i1
+  %1 = synth.onehot %a, %b, %c : i1
+  hw.output %0, %1 : i1, i1
+}

--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -127,6 +127,35 @@ struct SynthMajorityOpConversion
     return rewriter.createOrFold<comb::OrOp>(loc, abOrAc, bc, true);
   }
 };
+
+struct SynthOneHotOpConversion : SynthInverterOpConversion<synth::OneHotOp> {
+  using SynthInverterOpConversion<synth::OneHotOp>::SynthInverterOpConversion;
+  Value createOp(Location loc, ArrayRef<Value> inputs,
+                 ConversionPatternRewriter &rewriter) const override {
+    assert(inputs.size() == 3 && "expected exactly three inputs");
+    auto width = inputs[0].getType().getIntOrFloatBitWidth();
+    auto allOnes =
+        hw::ConstantOp::create(rewriter, loc, APInt::getAllOnes(width));
+
+    // NOT each input
+    auto notA = rewriter.createOrFold<comb::XorOp>(loc, inputs[0],
+                                                   allOnes.getResult(), true);
+    auto notB = rewriter.createOrFold<comb::XorOp>(loc, inputs[1],
+                                                   allOnes.getResult(), true);
+    auto notC = rewriter.createOrFold<comb::XorOp>(loc, inputs[2],
+                                                   allOnes.getResult(), true);
+
+    auto aOnly = rewriter.createOrFold<comb::AndOp>(
+        loc, ValueRange{inputs[0], notB, notC}, true);
+    auto bOnly = rewriter.createOrFold<comb::AndOp>(
+        loc, ValueRange{notA, inputs[1], notC}, true);
+    auto cOnly = rewriter.createOrFold<comb::AndOp>(
+        loc, ValueRange{notA, notB, inputs[2]}, true);
+    return rewriter.createOrFold<comb::OrOp>(
+        loc, ValueRange{aOnly, bOnly, cOnly}, true);
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -145,7 +174,8 @@ struct ConvertSynthToCombPass
 static void populateSynthToCombConversionPatterns(RewritePatternSet &patterns) {
   patterns.add<SynthChoiceOpConversion, SynthAndInverterOpConversion,
                SynthXorInverterOpConversion, SynthDotOpConversion,
-               SynthMajorityOpConversion>(patterns.getContext());
+               SynthMajorityOpConversion, SynthOneHotOpConversion>(
+      patterns.getContext());
 }
 
 void ConvertSynthToCombPass::runOnOperation() {

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -680,3 +680,86 @@ LogicalResult circt::synth::topologicallySortGraphRegionBlocks(
 
   return success(!walkResult.wasInterrupted());
 }
+
+//===----------------------------------------------------------------------===//
+// OneHotOp
+//===----------------------------------------------------------------------===//
+
+ParseResult OneHotOp::parse(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand> operands;
+  Type resultType;
+  DenseBoolArrayAttr inverted;
+  NamedAttrList attrs;
+
+  if (parseVariadicInvertibleOperands(parser, operands, resultType, inverted,
+                                      attrs))
+    return failure();
+  if (operands.size() != 3)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected exactly three operands";
+  if (parser.resolveOperands(operands, resultType, result.operands))
+    return failure();
+
+  result.addTypes(resultType);
+  result.addAttributes(attrs);
+  result.addAttribute("inverted", inverted);
+  return success();
+}
+
+void OneHotOp::print(OpAsmPrinter &printer) {
+  printer << ' ';
+  printVariadicInvertibleOperands(printer, getOperation(), getOperands(),
+                                  getType(), getInvertedAttr(),
+                                  (*this)->getAttrDictionary());
+}
+
+LogicalResult OneHotOp::verify() {
+  if (getNumOperands() != 3)
+    return emitOpError("requires exactly three operands");
+  if (getInverted().size() != 3)
+    return emitOpError("requires exactly three inversion flags");
+  return success();
+}
+
+bool OneHotOp::areInputsPermutationInvariant() { return true; }
+
+bool OneHotOp::supportsNumInputs(unsigned numInputs) { return numInputs == 3; }
+
+std::optional<uint64_t> OneHotOp::getLogicAreaCost() {
+  int64_t bitWidth = hw::getBitWidth(getType());
+  if (bitWidth < 0)
+    return std::nullopt;
+  return static_cast<uint64_t>(bitWidth);
+}
+
+llvm::KnownBits OneHotOp::computeKnownBits(
+    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
+  auto a = applyInversion(getInputKnownBits(0), isInverted(0));
+  auto b = applyInversion(getInputKnownBits(1), isInverted(1));
+  auto c = applyInversion(getInputKnownBits(2), isInverted(2));
+  return evaluateOneHotLogic(a, b, c);
+}
+
+APInt OneHotOp::evaluateBooleanLogicWithoutInversion(
+    llvm::ArrayRef<APInt> inputs) {
+  assert(inputs.size() == 3 && "onehot requires exactly three inputs");
+  return evaluateOneHotLogic(inputs[0], inputs[1], inputs[2]);
+}
+
+void OneHotOp::emitCNFWithoutInversion(
+    int outVar, llvm::ArrayRef<int> inputVars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  assert(inputVars.size() == 3 && "expected exactly three inputs");
+
+  // parity = a ^ b ^ c.
+  int parity = newVar();
+  circt::addParityClauses(parity, inputVars, addClause, newVar);
+
+  // allSet = a & b & c.
+  int allSet = newVar();
+  circt::addAndClauses(allSet, inputVars, addClause);
+
+  // out = (a ^ b ^ c) & ~(a & b & c).
+  circt::addAndClauses(outVar, {parity, -allSet}, addClause);
+}

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -173,6 +173,19 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
     return success();
   };
 
+  auto handleInvertibleTernaryGate = [&](auto logicOp,
+                                         LogicNetworkGate::Kind kind) {
+    if (!logicOp.getType().isInteger(1)) {
+      handleOtherResults(logicOp);
+      return success();
+    }
+    const Signal aSignal = getInvertibleSignal(logicOp, 0);
+    const Signal bSignal = getInvertibleSignal(logicOp, 1);
+    const Signal cSignal = getInvertibleSignal(logicOp, 2);
+    addGate(logicOp, kind, {aSignal, bSignal, cSignal});
+    return success();
+  };
+
   // Process operations in topological order
   for (Operation &op : block->getOperations()) {
     LogicalResult result =
@@ -184,28 +197,14 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
               return handleInvertibleBinaryGate(xorOp, LogicNetworkGate::Xor2);
             })
             .Case<synth::DotOp>([&](synth::DotOp dotOp) {
-              if (!dotOp.getType().isInteger(1)) {
-                handleOtherResults(dotOp);
-                return success();
-              }
-              const Signal xSignal = getInvertibleSignal(dotOp, 0);
-              const Signal ySignal = getInvertibleSignal(dotOp, 1);
-              const Signal zSignal = getInvertibleSignal(dotOp, 2);
-              addGate(dotOp, LogicNetworkGate::Dot3,
-                      {xSignal, ySignal, zSignal});
-              return success();
+              return handleInvertibleTernaryGate(dotOp, LogicNetworkGate::Dot3);
             })
             .Case<synth::MajorityOp>([&](synth::MajorityOp majOp) {
-              if (!majOp.getType().isInteger(1)) {
-                handleOtherResults(majOp);
-                return success();
-              }
-              const Signal aSignal = getInvertibleSignal(majOp, 0);
-              const Signal bSignal = getInvertibleSignal(majOp, 1);
-              const Signal cSignal = getInvertibleSignal(majOp, 2);
-              addGate(majOp, LogicNetworkGate::Maj3,
-                      {aSignal, bSignal, cSignal});
-              return success();
+              return handleInvertibleTernaryGate(majOp, LogicNetworkGate::Maj3);
+            })
+            .Case<synth::OneHotOp>([&](synth::OneHotOp oneHotOp) {
+              return handleInvertibleTernaryGate(oneHotOp,
+                                                 LogicNetworkGate::OneHot3);
             })
             .Case<comb::XorOp>([&](comb::XorOp xorOp) {
               if (xorOp->getNumOperands() != 2) {
@@ -517,6 +516,8 @@ static inline llvm::APInt applyGateSemantics(LogicNetworkGate::Kind kind,
     return evaluateMajorityLogic(a, b, c);
   case LogicNetworkGate::Dot3:
     return evaluateDotLogic(a, b, c);
+  case LogicNetworkGate::OneHot3:
+    return evaluateOneHotLogic(a, b, c);
   default:
     llvm_unreachable(
         "Unsupported ternary operation for truth table computation");
@@ -620,6 +621,11 @@ struct MergedTruthTableBuilder {
                                                  getEdgeTT(0), getEdgeTT(1),
                                                  getEdgeTT(2)));
     case LogicNetworkGate::Dot3:
+      return BinaryTruthTable(numMergedInputs, 1,
+                              applyGateSemantics(rootGate.getKind(),
+                                                 getEdgeTT(0), getEdgeTT(1),
+                                                 getEdgeTT(2)));
+    case LogicNetworkGate::OneHot3:
       return BinaryTruthTable(numMergedInputs, 1,
                               applyGateSemantics(rootGate.getKind(),
                                                  getEdgeTT(0), getEdgeTT(1),

--- a/test/Conversion/SynthToComb/synth-to-comb.mlir
+++ b/test/Conversion/SynthToComb/synth-to-comb.mlir
@@ -48,3 +48,16 @@ hw.module @test_majority(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
   %0 = synth.majority %a, %b, %c : i8
   hw.output %0 : i8
 }
+
+hw.module @test_onehot(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
+  // CHECK: %c-1_i8 = hw.constant -1 : i8
+  // CHECK: %[[NOT_A:.+]] = comb.xor bin %a, %c-1_i8 : i8
+  // CHECK: %[[NOT_B:.+]] = comb.xor bin %b, %c-1_i8 : i8
+  // CHECK: %[[NOT_C:.+]] = comb.xor bin %c, %c-1_i8 : i8
+  // CHECK: %[[A_ONLY:.+]] = comb.and bin %a, %[[NOT_B]], %[[NOT_C]] : i8
+  // CHECK: %[[B_ONLY:.+]] = comb.and bin %[[NOT_A]], %b, %[[NOT_C]] : i8
+  // CHECK: %[[C_ONLY:.+]] = comb.and bin %[[NOT_A]], %[[NOT_B]], %c : i8
+  // CHECK: %[[RESULT:.+]] = comb.or bin %[[A_ONLY]], %[[B_ONLY]], %[[C_ONLY]] : i8
+  %0 = synth.onehot %a, %b, %c : i8
+  hw.output %0 : i8
+}

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -114,12 +114,14 @@ func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
 // CHECK-LABEL: hw.module @Other
 // Other operation with BooleanLogicOpInterface
 // Only check that they are lowered.
-hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2, out z: i2) {
+hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2, out z: i2, out w: i2) {
   %0 = synth.xor_inv %a, not %b, %c : i2
   %1 = synth.dot %a, not %b, %c : i2
   %2 = synth.majority %a, not %b, %c : i2
+  %3 = synth.onehot %a, not %b, %c : i2
   // CHECK-COUNT-2: synth.xor_inv %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.dot %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.majority %{{.+}}, not %{{.+}}, %{{.+}} : i1
-  hw.output %0, %1, %2 : i2, i2, i2
+  // CHECK-COUNT-2: synth.onehot %{{.+}}, not %{{.+}}, %{{.+}} : i1
+  hw.output %0, %1, %2, %3 : i2, i2, i2, i2
 }

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -36,3 +36,9 @@ hw.module @dot(in %x: i1, in %y: i1, in %z: i1) {
 hw.module @majority(in %x: i1, in %y: i1, in %z: i1) {
   %0 = synth.majority %x, not %y, %z : i1
 }
+
+// CHECK-LABEL: @onehot
+// CHECK-NEXT: %[[R0:.+]] = synth.onehot %x, not %y, %z : i1
+hw.module @onehot(in %x: i1, in %y: i1, in %z: i1) {
+  %0 = synth.onehot %x, not %y, %z : i1
+}

--- a/test/Dialect/Synth/structural_hash.mlir
+++ b/test/Dialect/Synth/structural_hash.mlir
@@ -84,3 +84,13 @@ hw.module @majority_commutative(in %x: i1, in %y: i1, in %z: i1, out o0: i1, out
   %1 = synth.majority not %y, %x, %z : i1
   hw.output %0, %1 : i1, i1
 }
+
+// CHECK-LABEL: hw.module @onehot_commutative
+hw.module @onehot_commutative(in %x: i1, in %y: i1, in %z: i1, out o0: i1, out o1: i1) {
+  // onehot is permutation invariant so these should be CSE'd to the same op
+  // CHECK: %[[O0:.+]] = synth.onehot %x, not %y, %z : i1
+  // CHECK-NEXT: hw.output %[[O0]], %[[O0]] : i1, i1
+  %0 = synth.onehot %x, not %y, %z : i1
+  %1 = synth.onehot not %y, %x, %z : i1
+  hw.output %0, %1 : i1, i1
+}

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -184,8 +184,23 @@ hw.module @majority_lib(in %x : i1, in %y : i1, in %z : i1, out result : i1) att
 
 // CHECK-LABEL: @majority_test
 hw.module @majority_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
+    // Permute inputs to test the truth table computation and input handling of the majority operation.
     // CHECK-NEXT: %[[MAJ:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @majority_lib(x: %{{.+}}: i1, y: %{{.+}}: i1, z: %{{.+}}: i1) -> (result: i1) {test.arrival_times = [1]}
     // CHECK-NEXT: hw.output %[[MAJ]] : i1
     %0 = synth.majority %x, not %y, not %z : i1
+    hw.output %0 : i1
+}
+
+hw.module @onehot_lib(in %x : i1, in %y : i1, in %z : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "x", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "y", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "z", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+    %0 = synth.onehot %x, not %y, not %z : i1
+    hw.output %0 : i1
+}
+
+// CHECK-LABEL: @onehot_test
+hw.module @onehot_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
+    // Permute inputs to test the truth table computation and input handling of the onehot operation.
+    // CHECK-NEXT: %[[ONEHOT:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @onehot_lib(x: %{{.+}}: i1, y: %{{.+}}: i1, z: %{{.+}}: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: hw.output %[[ONEHOT]] : i1
+    %0 = synth.onehot not %z, %x, not %y : i1
     hw.output %0 : i1
 }

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -187,7 +187,7 @@ hw.module @majority_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
     // Permute inputs to test the truth table computation and input handling of the majority operation.
     // CHECK-NEXT: %[[MAJ:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @majority_lib(x: %{{.+}}: i1, y: %{{.+}}: i1, z: %{{.+}}: i1) -> (result: i1) {test.arrival_times = [1]}
     // CHECK-NEXT: hw.output %[[MAJ]] : i1
-    %0 = synth.majority %x, not %y, not %z : i1
+    %0 = synth.majority not %y, %x, not %z : i1
     hw.output %0 : i1
 }
 


### PR DESCRIPTION
Concerns #10407 

Add `synth.onehot`, a permutation-invariant 3-input Boolean logic operation
implementing the onehot function `(a & !b & !c) | (!a & b & !c) |
(!a & !b & c)` with per-input inversion support.

This operation is currently fixed to three inputs to match the existing
cut-rewriter and tech-mapper representation. A general n-input onehot operation,
which returns true when exactly one input is true, can be added later if needed.