### PR TITLE
[SV] Add pass to hide non-synthesizable ops

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -473,8 +473,8 @@ class System:
       "builtin.module(lower-comb)",
       "builtin.module(hw.module(lower-verif-to-sv))",
       "builtin.module(cse, canonicalize, cse)",
+      "builtin.module(sv-mask-non-synthesizable)",
       "builtin.module(hw.module(prettify-verilog), hw.module(hw-cleanup))",
-      "builtin.module(sv-mask-non-synthesizable{{mode=pragma}})",
       "builtin.module(msft-export-tcl{{tops={tops} tcl-file={tcl_file}}})"
   ]
 

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -474,6 +474,7 @@ class System:
       "builtin.module(hw.module(lower-verif-to-sv))",
       "builtin.module(cse, canonicalize, cse)",
       "builtin.module(hw.module(prettify-verilog), hw.module(hw-cleanup))",
+      "builtin.module(sv-mask-non-synthesizable{{mode=pragma}})",
       "builtin.module(msft-export-tcl{{tops={tops} tcl-file={tcl_file}}})"
   ]
 

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -25,9 +25,6 @@ enum class MaskNonSynthesizableMode {
   Delete,
   /// Wrap the matched ops in `` `ifndef SYNTHESIS `` ... `` `endif ``.
   Ifdef,
-  /// Surround the matched ops with `// synthesis translate_off` /
-  /// `// synthesis translate_on` comment pragmas.
-  Pragma,
 };
 
 #define GEN_PASS_DECL

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -18,6 +18,18 @@
 namespace circt {
 namespace sv {
 
+/// Selects how `sv-mask-non-synthesizable` hides matched ops from
+/// synthesis-bound SystemVerilog output.
+enum class MaskNonSynthesizableMode {
+  /// Erase the matched ops.
+  Delete,
+  /// Wrap the matched ops in `` `ifndef SYNTHESIS `` ... `` `endif ``.
+  Ifdef,
+  /// Surround the matched ops with `// synthesis translate_off` /
+  /// `// synthesis translate_on` comment pragmas.
+  Pragma,
+};
+
 #define GEN_PASS_DECL
 #include "circt/Dialect/SV/SVPasses.h.inc"
 

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -130,4 +130,49 @@ def HWEliminateInOutPorts : Pass<"hw-eliminate-inout-ports",
   ];
 }
 
+def SVMaskNonSynthesizable : Pass<"sv-mask-non-synthesizable",
+                                  "mlir::ModuleOp"> {
+  let summary = "Hide non-synthesizable SV ops from synthesis tools";
+  let description = [{
+    This pass hides a fixed set of `sv` ops that are not generally
+    synthesizable (concurrent and property assertions) from the
+    SystemVerilog output. Three masking modes are supported:
+
+    * `delete` — erase the matched ops entirely.
+    * `ifdef`  — wrap ops in a single
+      `` `ifndef <macro> `` ... `` `endif `` block (using `sv.ifdef` or
+      `sv.ifdef.procedural` as appropriate). A matching `sv.macro.decl` is
+      created at the top of the module if one is not already present. The
+      macro name is configurable via the `macro` option (default
+      `SYNTHESIS`).
+    * `pragma` — surround ops with
+      `// synthesis translate_off` / `// synthesis translate_on` comment
+      pragmas (emitted as `sv.verbatim` ops).
+
+    The pass is intended to run as one of the last passes before `ExportVerilog`
+    so we only have to know about a smaller number of ops. The set of masked op
+    names is hard-coded in the pass implementation. All three modes are
+    idempotent.
+  }];
+
+  let dependentDialects = ["circt::sv::SVDialect"];
+  let options = [
+    Option<"mode", "mode", "::circt::sv::MaskNonSynthesizableMode",
+           "::circt::sv::MaskNonSynthesizableMode::Ifdef",
+           "How to mask the matched ops",
+           [{::llvm::cl::values(
+             clEnumValN(::circt::sv::MaskNonSynthesizableMode::Delete,
+                        "delete", "Erase the matched ops"),
+             clEnumValN(::circt::sv::MaskNonSynthesizableMode::Ifdef,
+                        "ifdef",
+                        "Wrap matched ops in `ifndef SYNTHESIS"),
+             clEnumValN(::circt::sv::MaskNonSynthesizableMode::Pragma,
+                        "pragma",
+                        "Bracket matched ops with synthesis translate_off/_on")
+           )}]>,
+    Option<"macro", "macro", "std::string", "\"SYNTHESIS\"",
+           "Macro name used by `ifdef` mode">
+  ];
+}
+
 #endif // CIRCT_DIALECT_SV_SVPASSES

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -136,23 +136,20 @@ def SVMaskNonSynthesizable : Pass<"sv-mask-non-synthesizable",
   let description = [{
     This pass hides a fixed set of `sv` ops that are not generally
     synthesizable (concurrent and property assertions) from the
-    SystemVerilog output. Three masking modes are supported:
+    SystemVerilog output. Two masking modes are supported:
 
     * `delete` — erase the matched ops entirely.
-    * `ifdef`  — wrap ops in a single
-      `` `ifndef <macro> `` ... `` `endif `` block (using `sv.ifdef` or
+    * `ifdef`  — wrap each matched op individually in
+      `` `ifndef <macro> `` ... `` `endif `` (using `sv.ifdef` or
       `sv.ifdef.procedural` as appropriate). A matching `sv.macro.decl` is
       created at the top of the module if one is not already present. The
       macro name is configurable via the `macro` option (default
-      `SYNTHESIS`).
-    * `pragma` — surround ops with
-      `// synthesis translate_off` / `// synthesis translate_on` comment
-      pragmas (emitted as `sv.verbatim` ops).
+      `SYNTHESIS`). Adjacent wrappers are not coalesced here; run
+      `hw-cleanup` afterwards to merge them where possible.
 
     The pass is intended to run as one of the last passes before `ExportVerilog`
     so we only have to know about a smaller number of ops. The set of masked op
-    names is hard-coded in the pass implementation. All three modes are
-    idempotent.
+    names is hard-coded in the pass implementation. Both modes are idempotent.
   }];
 
   let dependentDialects = ["circt::sv::SVDialect"];
@@ -165,10 +162,7 @@ def SVMaskNonSynthesizable : Pass<"sv-mask-non-synthesizable",
                         "delete", "Erase the matched ops"),
              clEnumValN(::circt::sv::MaskNonSynthesizableMode::Ifdef,
                         "ifdef",
-                        "Wrap matched ops in `ifndef SYNTHESIS"),
-             clEnumValN(::circt::sv::MaskNonSynthesizableMode::Pragma,
-                        "pragma",
-                        "Bracket matched ops with synthesis translate_off/_on")
+                        "Wrap matched ops in `ifndef SYNTHESIS")
            )}]>,
     Option<"macro", "macro", "std::string", "\"SYNTHESIS\"",
            "Macro name used by `ifdef` mode">

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -144,12 +144,13 @@ def SVMaskNonSynthesizable : Pass<"sv-mask-non-synthesizable",
       `sv.ifdef.procedural` as appropriate). A matching `sv.macro.decl` is
       created at the top of the module if one is not already present. The
       macro name is configurable via the `macro` option (default
-      `SYNTHESIS`). Adjacent wrappers are not coalesced here; run
-      `hw-cleanup` afterwards to merge them where possible.
+      `SYNTHESIS`).
 
     The pass is intended to run as one of the last passes before `ExportVerilog`
-    so we only have to know about a smaller number of ops. The set of masked op
-    names is hard-coded in the pass implementation. Both modes are idempotent.
+    so we only have to know about a smaller number of ops but before the
+    HWCleanup pass (which will merge the sv.ifdef ops where it can). The set of
+    masked op names is hard-coded in the pass implementation. Both modes are
+    idempotent.
   }];
 
   let dependentDialects = ["circt::sv::SVDialect"];

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -138,8 +138,8 @@ def SVMaskNonSynthesizable : Pass<"sv-mask-non-synthesizable",
     synthesizable (concurrent and property assertions) from the
     SystemVerilog output. Two masking modes are supported:
 
-    * `delete` — erase the matched ops entirely.
-    * `ifdef`  — wrap each matched op individually in
+    * `delete`: erase the matched ops entirely.
+    * `ifdef`: wrap each matched op individually in
       `` `ifndef <macro> `` ... `` `endif `` (using `sv.ifdef` or
       `sv.ifdef.procedural` as appropriate). A matching `sv.macro.decl` is
       created at the top of the module if one is not already present. The

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_dialect_library(CIRCTSVTransforms
   HWLegalizeModules.cpp
   PrettifyVerilog.cpp
   HWExportModuleHierarchy.cpp
+  SVMaskNonSynthesizable.cpp
   SVTraceIVerilog.cpp
   HWEliminateInOutPorts.cpp
 

--- a/lib/Dialect/SV/Transforms/SVMaskNonSynthesizable.cpp
+++ b/lib/Dialect/SV/Transforms/SVMaskNonSynthesizable.cpp
@@ -24,10 +24,10 @@
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Support/Namespace.h"
 #include "circt/Support/ProceduralRegionTrait.h"
+#include "circt/Support/Utils.h"
 #include "mlir/IR/Builders.h"
-#include "mlir/IR/Threading.h"
 #include "mlir/Pass/Pass.h"
-#include <atomic>
+#include "llvm/ADT/TypeSwitch.h"
 
 namespace circt {
 namespace sv {
@@ -55,18 +55,13 @@ static bool isMaskedOp(Operation *op) {
 /// to identify the region that need not be re-wrapped in `ifdef` mode.
 static Region *getMatchingIfDefElseRegion(Operation *op,
                                           StringRef expectedMacro) {
-  StringRef macro;
-  Region *elseRegion = nullptr;
-  if (auto ifdef = dyn_cast<sv::IfDefOp>(op)) {
-    macro = ifdef.getCond().getName();
-    elseRegion = &ifdef.getElseRegion();
-  } else if (auto ifdef = dyn_cast<sv::IfDefProceduralOp>(op)) {
-    macro = ifdef.getCond().getName();
-    elseRegion = &ifdef.getElseRegion();
-  } else {
-    return nullptr;
-  }
-  return macro == expectedMacro ? elseRegion : nullptr;
+  return llvm::TypeSwitch<Operation *, Region *>(op)
+      .Case<sv::IfDefOp, sv::IfDefProceduralOp>([&](auto ifdef) -> Region * {
+        if (ifdef.getCond().getName() != expectedMacro)
+          return nullptr;
+        return &ifdef.getElseRegion();
+      })
+      .Default(static_cast<Region *>(nullptr));
 }
 
 /// Resolve the symbol name to use for the `sv.macro.decl` referenced by
@@ -103,14 +98,13 @@ static void processBlockDelete(Block &block) {
 /// Wrap a single masked op in its own `sv.ifdef`/`sv.ifdef.procedural`. Picks
 /// the procedural variant based on the enclosing region.
 static void maskOpByIfdef(Operation *op, StringRef macro) {
-  bool procedural = isInProceduralRegion(op);
   OpBuilder builder(op);
   Location loc = op->getLoc();
 
   // Passing a non-null `elseCtor` is what triggers the builder to create an
   // else block.
   Block *elseBlock;
-  if (procedural)
+  if (isInProceduralRegion(op))
     elseBlock =
         sv::IfDefProceduralOp::create(builder, loc, macro,
                                       /*thenCtor=*/{}, /*elseCtor=*/[]() {})
@@ -177,22 +171,22 @@ void SVMaskNonSynthesizablePass::runOnOperation() {
   // Each `hw.module`'s body is independent: `processBlock*` only mutates ops
   // inside the module it's called on.
   SmallVector<hw::HWModuleOp> hwModules(moduleOp.getOps<hw::HWModuleOp>());
-  std::atomic<bool> anyChanged{false};
-  mlir::parallelForEach(&getContext(), hwModules, [&](hw::HWModuleOp hwModule) {
-    Block &body = *hwModule.getBodyBlock();
-    switch (mode) {
-    case MaskNonSynthesizableMode::Delete:
-      processBlockDelete(body);
-      break;
-    case MaskNonSynthesizableMode::Ifdef:
-      if (processBlockIfdef(body, passDownMacro))
-        anyChanged.store(true, std::memory_order_relaxed);
-      break;
-    }
-  });
+  unsigned numChanged =
+      transformReduce(&getContext(), hwModules, /*init=*/0u, std::plus<>(),
+                      [&](hw::HWModuleOp hwModule) -> unsigned {
+                        Block &body = *hwModule.getBodyBlock();
+                        switch (mode) {
+                        case MaskNonSynthesizableMode::Delete:
+                          processBlockDelete(body);
+                          return 0;
+                        case MaskNonSynthesizableMode::Ifdef:
+                          return processBlockIfdef(body, passDownMacro) ? 1 : 0;
+                        }
+                        llvm_unreachable("all modes handled");
+                      });
 
-  if (mode == MaskNonSynthesizableMode::Ifdef &&
-      anyChanged.load(std::memory_order_relaxed) && macroDeclNeedsCreation) {
+  if (mode == MaskNonSynthesizableMode::Ifdef && numChanged > 0 &&
+      macroDeclNeedsCreation) {
     auto builder = OpBuilder::atBlockBegin(moduleOp.getBody());
     sv::MacroDeclOp::create(builder, moduleOp.getLoc(), macroSymName,
                             /*args=*/ArrayAttr{}, builder.getStringAttr(macro));

--- a/lib/Dialect/SV/Transforms/SVMaskNonSynthesizable.cpp
+++ b/lib/Dialect/SV/Transforms/SVMaskNonSynthesizable.cpp
@@ -14,8 +14,7 @@
 //   * `ifdef` : wrap each matched op individually in an
 //               `sv.ifdef`/`sv.ifdef.procedural` whose else region holds the
 //               moved op, plus a single `sv.macro.decl @SYNTHESIS` at the top
-//               of the module if absent. Adjacent wrappers are not coalesced
-//               here; the `hw-cleanup` pass can merge them afterwards.
+//               of the module if absent.
 //
 //===----------------------------------------------------------------------===//
 
@@ -94,15 +93,11 @@ static StringAttr resolveMacroSymName(mlir::ModuleOp moduleOp,
 }
 
 /// `delete` mode: walk the block and erase every masked op.
-static bool processBlockDelete(Block &block) {
-  SmallVector<Operation *> toErase;
+static void processBlockDelete(Block &block) {
   block.walk([&](Operation *op) {
     if (isMaskedOp(op))
-      toErase.push_back(op);
+      op->erase();
   });
-  for (Operation *op : toErase)
-    op->erase();
-  return !toErase.empty();
 }
 
 /// Wrap a single masked op in its own `sv.ifdef`/`sv.ifdef.procedural`. Picks
@@ -129,17 +124,18 @@ static void maskOpByIfdef(Operation *op, StringRef macro) {
   op->moveBefore(elseBlock, elseBlock->end());
 }
 
-/// `ifdef` mode: wrap each masked sibling op in its own
+/// `ifdef` mode: wrap each masked op in its own
 /// `sv.ifdef`/`sv.ifdef.procedural`. Recurse into nested regions of non-masked
 /// ops, but skip recursion into the else region of a matching
 /// `sv.ifdef @<macro>` -- those ops are already guarded.
 static bool processBlockIfdef(Block &block, StringRef macro) {
   bool changed = false;
-  SmallVector<Operation *> toWrap;
-
-  for (Operation &op : block) {
+  // `make_early_inc_range` lets us move the current op out of `block` inside
+  // the loop body without invalidating the iterator.
+  for (Operation &op : llvm::make_early_inc_range(block)) {
     if (isMaskedOp(&op)) {
-      toWrap.push_back(&op);
+      maskOpByIfdef(&op, macro);
+      changed = true;
       continue;
     }
     Region *guardedElseRegion = getMatchingIfDefElseRegion(&op, macro);
@@ -150,10 +146,7 @@ static bool processBlockIfdef(Block &block, StringRef macro) {
         changed |= processBlockIfdef(nested, macro);
     }
   }
-
-  for (Operation *op : toWrap)
-    maskOpByIfdef(op, macro);
-  return changed || !toWrap.empty();
+  return changed;
 }
 
 //===----------------------------------------------------------------------===//
@@ -187,22 +180,19 @@ void SVMaskNonSynthesizablePass::runOnOperation() {
   std::atomic<bool> anyChanged{false};
   mlir::parallelForEach(&getContext(), hwModules, [&](hw::HWModuleOp hwModule) {
     Block &body = *hwModule.getBodyBlock();
-    bool localChanged = false;
     switch (mode) {
     case MaskNonSynthesizableMode::Delete:
-      localChanged = processBlockDelete(body);
+      processBlockDelete(body);
       break;
     case MaskNonSynthesizableMode::Ifdef:
-      localChanged = processBlockIfdef(body, passDownMacro);
+      if (processBlockIfdef(body, passDownMacro))
+        anyChanged.store(true, std::memory_order_relaxed);
       break;
     }
-    if (localChanged)
-      anyChanged.store(true, std::memory_order_relaxed);
   });
-  bool changed = anyChanged.load(std::memory_order_relaxed);
 
-  if (mode == MaskNonSynthesizableMode::Ifdef && changed &&
-      macroDeclNeedsCreation) {
+  if (mode == MaskNonSynthesizableMode::Ifdef &&
+      anyChanged.load(std::memory_order_relaxed) && macroDeclNeedsCreation) {
     auto builder = OpBuilder::atBlockBegin(moduleOp.getBody());
     sv::MacroDeclOp::create(builder, moduleOp.getLoc(), macroSymName,
                             /*args=*/ArrayAttr{}, builder.getStringAttr(macro));

--- a/lib/Dialect/SV/Transforms/SVMaskNonSynthesizable.cpp
+++ b/lib/Dialect/SV/Transforms/SVMaskNonSynthesizable.cpp
@@ -1,0 +1,317 @@
+//===- SVMaskNonSynthesizable.cpp - Mask non-synthesizable SV ops ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass hides a fixed set of `sv` operations that are not generally
+// synthesizable (concurrent and property assertions) from the SystemVerilog
+// output. It supports three masking modes:
+//
+//   * `delete`: erase the matched ops.
+//   * `ifdef` : wrap ops in a single `sv.ifdef`/`sv.ifdef.procedural` whose
+//               else region holds the moved ops, plus a single `sv.macro.decl
+//               @SYNTHESIS` at the top of the module if absent.
+//   * `pragma`: bracket ops with `// synthesis translate_off` /
+//               `// synthesis translate_on` `sv.verbatim` ops.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/SV/SVAttributes.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Support/Namespace.h"
+#include "circt/Support/ProceduralRegionTrait.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Threading.h"
+#include "mlir/Pass/Pass.h"
+#include <atomic>
+
+namespace circt {
+namespace sv {
+#define GEN_PASS_DEF_SVMASKNONSYNTHESIZABLE
+#include "circt/Dialect/SV/SVPasses.h.inc"
+} // namespace sv
+} // namespace circt
+
+using namespace circt;
+using namespace circt::sv;
+
+//===----------------------------------------------------------------------===//
+// Constants
+//===----------------------------------------------------------------------===//
+
+/// Comment text emitted by the `pragma` masking mode.
+static constexpr llvm::StringLiteral kPragmaTranslateOff =
+    "// synthesis translate_off";
+static constexpr llvm::StringLiteral kPragmaTranslateOn =
+    "// synthesis translate_on";
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// A maximal sequence of consecutive sibling ops within a single block that are
+/// all in the masked set.
+struct Run {
+  Operation *first = nullptr;
+  Operation *last = nullptr; // Inclusive.
+
+  /// If this run holds any ops, append a copy onto `runs` and clear ourselves
+  /// so we can start accumulating the next one.
+  void endRun(SmallVectorImpl<Run> &runs) {
+    if (!first)
+      return;
+    runs.push_back(*this);
+    first = nullptr;
+    last = nullptr;
+  }
+};
+
+} // namespace
+
+/// Returns true if `op` is one of the SV ops we mask.
+static bool isMaskedOp(Operation *op) {
+  return isa<sv::AssertConcurrentOp, sv::AssumeConcurrentOp,
+             sv::CoverConcurrentOp, sv::AssertPropertyOp, sv::AssumePropertyOp,
+             sv::CoverPropertyOp>(op);
+}
+
+/// If `op` is an `sv.ifdef`/`sv.ifdef.procedural` whose macro matches
+/// `expectedMacro`, returns its else region; otherwise returns nullptr. Used
+/// to identify the region that need not be re-wrapped in `ifdef` mode.
+static Region *getMatchingIfDefElseRegion(Operation *op,
+                                          StringRef expectedMacro) {
+  StringRef macro;
+  Region *elseRegion = nullptr;
+  if (auto ifdef = dyn_cast<sv::IfDefOp>(op)) {
+    macro = ifdef.getCond().getName();
+    elseRegion = &ifdef.getElseRegion();
+  } else if (auto ifdef = dyn_cast<sv::IfDefProceduralOp>(op)) {
+    macro = ifdef.getCond().getName();
+    elseRegion = &ifdef.getElseRegion();
+  } else {
+    return nullptr;
+  }
+  return macro == expectedMacro ? elseRegion : nullptr;
+}
+
+/// Returns true if `op` is an `sv.verbatim` whose format string equals
+/// `expected`.
+static bool isPragmaVerbatim(Operation *op, StringRef expected) {
+  auto verbatim = dyn_cast<sv::VerbatimOp>(op);
+  if (!verbatim)
+    return false;
+  return verbatim.getFormatString() == expected;
+}
+
+/// Resolve the symbol name to use for the `sv.macro.decl` referenced by
+/// `ifdef` mode's `sv.ifdef` ops. Returns the existing decl's sym_name if a
+/// `sv.macro.decl` whose Verilog identifier matches `verilogName` already
+/// exists at top level; otherwise returns a fresh sym_name that does not
+/// collide with any existing top-level symbol (which may differ from
+/// `verilogName` if a non-`sv.macro.decl` symbol of that name is present).
+/// `created` is set to true iff the returned name belongs to a decl that
+/// the caller still needs to materialize.
+static StringAttr resolveMacroSymName(mlir::ModuleOp moduleOp,
+                                      StringRef verilogName, bool &created) {
+  for (auto decl : moduleOp.getOps<sv::MacroDeclOp>()) {
+    if (decl.getMacroIdentifier() == verilogName) {
+      created = false;
+      return decl.getSymNameAttr();
+    }
+  }
+  Namespace ns;
+  ns.add(moduleOp);
+  StringRef name = ns.newName(verilogName);
+  created = true;
+  return StringAttr::get(moduleOp.getContext(), name);
+}
+
+/// `delete` mode: walk the block and erase every masked op.
+static bool processBlockDelete(Block &block) {
+  SmallVector<Operation *> toErase;
+  block.walk([&](Operation *op) {
+    if (isMaskedOp(op))
+      toErase.push_back(op);
+  });
+  for (Operation *op : toErase)
+    op->erase();
+  return !toErase.empty();
+}
+
+/// Apply the `ifdef` mode to a run. Picks `sv.ifdef.procedural` vs `sv.ifdef`
+/// based on the enclosing region.
+static void maskRunByIfdef(Run run, StringRef macro) {
+  bool procedural = isInProceduralRegion(run.first);
+  OpBuilder builder(run.first);
+  Block *parentBlock = run.first->getBlock();
+  Location loc = run.first->getLoc();
+
+  // Passing a non-null `elseCtor` is what triggers the builder to create an
+  // else block.
+  Block *elseBlock;
+  if (procedural)
+    elseBlock =
+        sv::IfDefProceduralOp::create(builder, loc, macro,
+                                      /*thenCtor=*/{}, /*elseCtor=*/[]() {})
+            .getElseBlock();
+  else
+    elseBlock = sv::IfDefOp::create(builder, loc, macro, /*thenCtor=*/{},
+                                    /*elseCtor=*/[]() {})
+                    .getElseBlock();
+
+  // Move the run's ops into the else block, preserving order.
+  auto firstIt = run.first->getIterator();
+  auto endIt = std::next(run.last->getIterator());
+  elseBlock->getOperations().splice(
+      elseBlock->end(), parentBlock->getOperations(), firstIt, endIt);
+}
+
+/// `ifdef` mode: collect runs of consecutive masked sibling ops and wrap
+/// each in `sv.ifdef`/`sv.ifdef.procedural`. Recurse into nested regions of
+/// non-masked ops, but skip recursion into the else region of a matching
+/// `sv.ifdef @<macro>` -- those ops are already guarded.
+static bool processBlockIfdef(Block &block, StringRef macro) {
+  bool changed = false;
+  Run currentRun;
+  SmallVector<Run> runs;
+
+  for (Operation &op : block) {
+    if (isMaskedOp(&op)) {
+      if (currentRun.first)
+        currentRun.last = &op;
+      else
+        currentRun = Run{&op, &op};
+      continue;
+    }
+
+    currentRun.endRun(runs);
+    Region *guardedElseRegion = getMatchingIfDefElseRegion(&op, macro);
+    for (Region &region : op.getRegions()) {
+      if (&region == guardedElseRegion)
+        continue;
+      for (Block &nested : region)
+        changed |= processBlockIfdef(nested, macro);
+    }
+  }
+  currentRun.endRun(runs);
+
+  for (const Run &run : runs)
+    maskRunByIfdef(run, macro);
+  return changed || !runs.empty();
+}
+
+/// Apply the `pragma` mode to a run.
+static void maskRunByPragma(Run run) {
+  OpBuilder builder(run.first);
+  sv::VerbatimOp::create(builder, run.first->getLoc(),
+                         builder.getStringAttr(kPragmaTranslateOff));
+  builder.setInsertionPointAfter(run.last);
+  sv::VerbatimOp::create(builder, run.last->getLoc(),
+                         builder.getStringAttr(kPragmaTranslateOn));
+}
+
+/// `pragma` mode: collect runs of consecutive masked sibling ops and bracket
+/// each with `// synthesis translate_off` / `_on` `sv.verbatim` ops. Track
+/// the bracket state across siblings so ops already sandwiched between
+/// matching brackets are skipped. `inheritedGuard` carries the bracket state
+/// from the enclosing block so nested blocks wholly contained in an outer
+/// pragma bracket are also skipped.
+static bool processBlockPragma(Block &block, bool inheritedGuard) {
+  bool changed = false;
+  bool inGuard = inheritedGuard;
+  Run currentRun;
+  SmallVector<Run> runs;
+
+  for (Operation &op : block) {
+    if (isPragmaVerbatim(&op, kPragmaTranslateOff))
+      inGuard = true;
+    else if (isPragmaVerbatim(&op, kPragmaTranslateOn))
+      inGuard = false;
+
+    if (isMaskedOp(&op)) {
+      if (inGuard)
+        currentRun.endRun(runs);
+      else if (currentRun.first)
+        currentRun.last = &op;
+      else
+        currentRun = Run{&op, &op};
+      continue;
+    }
+
+    currentRun.endRun(runs);
+    for (Region &region : op.getRegions())
+      for (Block &nested : region)
+        changed |= processBlockPragma(nested, inGuard);
+  }
+  currentRun.endRun(runs);
+
+  if (runs.empty())
+    return changed;
+  for (const Run &run : runs)
+    maskRunByPragma(run);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct SVMaskNonSynthesizablePass
+    : public circt::sv::impl::SVMaskNonSynthesizableBase<
+          SVMaskNonSynthesizablePass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+void SVMaskNonSynthesizablePass::runOnOperation() {
+  mlir::ModuleOp moduleOp = getOperation();
+
+  // For `ifdef` mode, resolve the symbol name to use for the macro decl
+  // up front.
+  StringAttr macroSymName;
+  bool macroDeclNeedsCreation = false;
+  if (mode == MaskNonSynthesizableMode::Ifdef)
+    macroSymName = resolveMacroSymName(moduleOp, macro, macroDeclNeedsCreation);
+
+  bool changed = false;
+  StringRef passDownMacro =
+      macroSymName ? macroSymName.getValue() : StringRef();
+  // Each `hw.module`'s body is independent: `processBlock` only mutates ops
+  // inside the module it's called on.
+  SmallVector<hw::HWModuleOp> hwModules(moduleOp.getOps<hw::HWModuleOp>());
+  std::atomic<bool> anyChanged{false};
+  mlir::parallelForEach(&getContext(), hwModules, [&](hw::HWModuleOp hwModule) {
+    Block &body = *hwModule.getBodyBlock();
+    bool localChanged = false;
+    switch (mode) {
+    case MaskNonSynthesizableMode::Delete:
+      localChanged = processBlockDelete(body);
+      break;
+    case MaskNonSynthesizableMode::Ifdef:
+      localChanged = processBlockIfdef(body, passDownMacro);
+      break;
+    case MaskNonSynthesizableMode::Pragma:
+      localChanged = processBlockPragma(body, /*inheritedGuard=*/false);
+      break;
+    }
+    if (localChanged)
+      anyChanged.store(true, std::memory_order_relaxed);
+  });
+  changed = anyChanged.load(std::memory_order_relaxed);
+
+  if (mode == MaskNonSynthesizableMode::Ifdef && changed &&
+      macroDeclNeedsCreation) {
+    auto builder = OpBuilder::atBlockBegin(moduleOp.getBody());
+    sv::MacroDeclOp::create(builder, moduleOp.getLoc(), macroSymName,
+                            /*args=*/ArrayAttr{}, builder.getStringAttr(macro));
+  }
+}

--- a/lib/Dialect/SV/Transforms/SVMaskNonSynthesizable.cpp
+++ b/lib/Dialect/SV/Transforms/SVMaskNonSynthesizable.cpp
@@ -8,14 +8,14 @@
 //
 // This pass hides a fixed set of `sv` operations that are not generally
 // synthesizable (concurrent and property assertions) from the SystemVerilog
-// output. It supports three masking modes:
+// output. It supports two masking modes:
 //
 //   * `delete`: erase the matched ops.
-//   * `ifdef` : wrap ops in a single `sv.ifdef`/`sv.ifdef.procedural` whose
-//               else region holds the moved ops, plus a single `sv.macro.decl
-//               @SYNTHESIS` at the top of the module if absent.
-//   * `pragma`: bracket ops with `// synthesis translate_off` /
-//               `// synthesis translate_on` `sv.verbatim` ops.
+//   * `ifdef` : wrap each matched op individually in an
+//               `sv.ifdef`/`sv.ifdef.procedural` whose else region holds the
+//               moved op, plus a single `sv.macro.decl @SYNTHESIS` at the top
+//               of the module if absent. Adjacent wrappers are not coalesced
+//               here; the `hw-cleanup` pass can merge them afterwards.
 //
 //===----------------------------------------------------------------------===//
 
@@ -41,39 +41,8 @@ using namespace circt;
 using namespace circt::sv;
 
 //===----------------------------------------------------------------------===//
-// Constants
-//===----------------------------------------------------------------------===//
-
-/// Comment text emitted by the `pragma` masking mode.
-static constexpr llvm::StringLiteral kPragmaTranslateOff =
-    "// synthesis translate_off";
-static constexpr llvm::StringLiteral kPragmaTranslateOn =
-    "// synthesis translate_on";
-
-//===----------------------------------------------------------------------===//
 // Helpers
 //===----------------------------------------------------------------------===//
-
-namespace {
-
-/// A maximal sequence of consecutive sibling ops within a single block that are
-/// all in the masked set.
-struct Run {
-  Operation *first = nullptr;
-  Operation *last = nullptr; // Inclusive.
-
-  /// If this run holds any ops, append a copy onto `runs` and clear ourselves
-  /// so we can start accumulating the next one.
-  void endRun(SmallVectorImpl<Run> &runs) {
-    if (!first)
-      return;
-    runs.push_back(*this);
-    first = nullptr;
-    last = nullptr;
-  }
-};
-
-} // namespace
 
 /// Returns true if `op` is one of the SV ops we mask.
 static bool isMaskedOp(Operation *op) {
@@ -99,15 +68,6 @@ static Region *getMatchingIfDefElseRegion(Operation *op,
     return nullptr;
   }
   return macro == expectedMacro ? elseRegion : nullptr;
-}
-
-/// Returns true if `op` is an `sv.verbatim` whose format string equals
-/// `expected`.
-static bool isPragmaVerbatim(Operation *op, StringRef expected) {
-  auto verbatim = dyn_cast<sv::VerbatimOp>(op);
-  if (!verbatim)
-    return false;
-  return verbatim.getFormatString() == expected;
 }
 
 /// Resolve the symbol name to use for the `sv.macro.decl` referenced by
@@ -145,13 +105,12 @@ static bool processBlockDelete(Block &block) {
   return !toErase.empty();
 }
 
-/// Apply the `ifdef` mode to a run. Picks `sv.ifdef.procedural` vs `sv.ifdef`
-/// based on the enclosing region.
-static void maskRunByIfdef(Run run, StringRef macro) {
-  bool procedural = isInProceduralRegion(run.first);
-  OpBuilder builder(run.first);
-  Block *parentBlock = run.first->getBlock();
-  Location loc = run.first->getLoc();
+/// Wrap a single masked op in its own `sv.ifdef`/`sv.ifdef.procedural`. Picks
+/// the procedural variant based on the enclosing region.
+static void maskOpByIfdef(Operation *op, StringRef macro) {
+  bool procedural = isInProceduralRegion(op);
+  OpBuilder builder(op);
+  Location loc = op->getLoc();
 
   // Passing a non-null `elseCtor` is what triggers the builder to create an
   // else block.
@@ -166,32 +125,23 @@ static void maskRunByIfdef(Run run, StringRef macro) {
                                     /*elseCtor=*/[]() {})
                     .getElseBlock();
 
-  // Move the run's ops into the else block, preserving order.
-  auto firstIt = run.first->getIterator();
-  auto endIt = std::next(run.last->getIterator());
-  elseBlock->getOperations().splice(
-      elseBlock->end(), parentBlock->getOperations(), firstIt, endIt);
+  // Move the op into the else block.
+  op->moveBefore(elseBlock, elseBlock->end());
 }
 
-/// `ifdef` mode: collect runs of consecutive masked sibling ops and wrap
-/// each in `sv.ifdef`/`sv.ifdef.procedural`. Recurse into nested regions of
-/// non-masked ops, but skip recursion into the else region of a matching
+/// `ifdef` mode: wrap each masked sibling op in its own
+/// `sv.ifdef`/`sv.ifdef.procedural`. Recurse into nested regions of non-masked
+/// ops, but skip recursion into the else region of a matching
 /// `sv.ifdef @<macro>` -- those ops are already guarded.
 static bool processBlockIfdef(Block &block, StringRef macro) {
   bool changed = false;
-  Run currentRun;
-  SmallVector<Run> runs;
+  SmallVector<Operation *> toWrap;
 
   for (Operation &op : block) {
     if (isMaskedOp(&op)) {
-      if (currentRun.first)
-        currentRun.last = &op;
-      else
-        currentRun = Run{&op, &op};
+      toWrap.push_back(&op);
       continue;
     }
-
-    currentRun.endRun(runs);
     Region *guardedElseRegion = getMatchingIfDefElseRegion(&op, macro);
     for (Region &region : op.getRegions()) {
       if (&region == guardedElseRegion)
@@ -200,63 +150,10 @@ static bool processBlockIfdef(Block &block, StringRef macro) {
         changed |= processBlockIfdef(nested, macro);
     }
   }
-  currentRun.endRun(runs);
 
-  for (const Run &run : runs)
-    maskRunByIfdef(run, macro);
-  return changed || !runs.empty();
-}
-
-/// Apply the `pragma` mode to a run.
-static void maskRunByPragma(Run run) {
-  OpBuilder builder(run.first);
-  sv::VerbatimOp::create(builder, run.first->getLoc(),
-                         builder.getStringAttr(kPragmaTranslateOff));
-  builder.setInsertionPointAfter(run.last);
-  sv::VerbatimOp::create(builder, run.last->getLoc(),
-                         builder.getStringAttr(kPragmaTranslateOn));
-}
-
-/// `pragma` mode: collect runs of consecutive masked sibling ops and bracket
-/// each with `// synthesis translate_off` / `_on` `sv.verbatim` ops. Track
-/// the bracket state across siblings so ops already sandwiched between
-/// matching brackets are skipped. `inheritedGuard` carries the bracket state
-/// from the enclosing block so nested blocks wholly contained in an outer
-/// pragma bracket are also skipped.
-static bool processBlockPragma(Block &block, bool inheritedGuard) {
-  bool changed = false;
-  bool inGuard = inheritedGuard;
-  Run currentRun;
-  SmallVector<Run> runs;
-
-  for (Operation &op : block) {
-    if (isPragmaVerbatim(&op, kPragmaTranslateOff))
-      inGuard = true;
-    else if (isPragmaVerbatim(&op, kPragmaTranslateOn))
-      inGuard = false;
-
-    if (isMaskedOp(&op)) {
-      if (inGuard)
-        currentRun.endRun(runs);
-      else if (currentRun.first)
-        currentRun.last = &op;
-      else
-        currentRun = Run{&op, &op};
-      continue;
-    }
-
-    currentRun.endRun(runs);
-    for (Region &region : op.getRegions())
-      for (Block &nested : region)
-        changed |= processBlockPragma(nested, inGuard);
-  }
-  currentRun.endRun(runs);
-
-  if (runs.empty())
-    return changed;
-  for (const Run &run : runs)
-    maskRunByPragma(run);
-  return true;
+  for (Operation *op : toWrap)
+    maskOpByIfdef(op, macro);
+  return changed || !toWrap.empty();
 }
 
 //===----------------------------------------------------------------------===//
@@ -282,10 +179,9 @@ void SVMaskNonSynthesizablePass::runOnOperation() {
   if (mode == MaskNonSynthesizableMode::Ifdef)
     macroSymName = resolveMacroSymName(moduleOp, macro, macroDeclNeedsCreation);
 
-  bool changed = false;
   StringRef passDownMacro =
       macroSymName ? macroSymName.getValue() : StringRef();
-  // Each `hw.module`'s body is independent: `processBlock` only mutates ops
+  // Each `hw.module`'s body is independent: `processBlock*` only mutates ops
   // inside the module it's called on.
   SmallVector<hw::HWModuleOp> hwModules(moduleOp.getOps<hw::HWModuleOp>());
   std::atomic<bool> anyChanged{false};
@@ -299,14 +195,11 @@ void SVMaskNonSynthesizablePass::runOnOperation() {
     case MaskNonSynthesizableMode::Ifdef:
       localChanged = processBlockIfdef(body, passDownMacro);
       break;
-    case MaskNonSynthesizableMode::Pragma:
-      localChanged = processBlockPragma(body, /*inheritedGuard=*/false);
-      break;
     }
     if (localChanged)
       anyChanged.store(true, std::memory_order_relaxed);
   });
-  changed = anyChanged.load(std::memory_order_relaxed);
+  bool changed = anyChanged.load(std::memory_order_relaxed);
 
   if (mode == MaskNonSynthesizableMode::Ifdef && changed &&
       macroDeclNeedsCreation) {

--- a/test/Dialect/SV/sv-mask-non-synthesizable.mlir
+++ b/test/Dialect/SV/sv-mask-non-synthesizable.mlir
@@ -1,18 +1,17 @@
 // RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete %s | FileCheck %s --check-prefix=DELETE
 // RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef %s | FileCheck %s --check-prefix=IFDEF
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=pragma %s | FileCheck %s --check-prefix=PRAGMA
 // Default mode is `ifdef`.
 // RUN: circt-opt -split-input-file -sv-mask-non-synthesizable %s | FileCheck %s --check-prefix=IFDEF
-// All modes are idempotent across re-runs.
+// Both modes are idempotent across re-runs.
 // RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete | FileCheck %s --check-prefix=DELETE
 // RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef | FileCheck %s --check-prefix=IFDEF
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=pragma %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=pragma | FileCheck %s --check-prefix=PRAGMA
 // `ifdef` mode honors a custom macro name and is idempotent under it.
 // RUN: circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' %s | FileCheck %s --check-prefix=CUSTOM
 // RUN: circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' %s | circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' | FileCheck %s --check-prefix=CUSTOM
 
 //===----------------------------------------------------------------------===//
-// Coalesced runs and isolated matches in non-procedural regions.
+// Each masked op is wrapped in its own `sv.ifdef`; adjacent wrappers are not
+// coalesced (we rely on `hw-cleanup` to merge them downstream).
 //===----------------------------------------------------------------------===//
 
 // IFDEF: sv.macro.decl @SYNTHESIS
@@ -20,17 +19,15 @@
 
 // DELETE-LABEL: hw.module @basic
 // IFDEF-LABEL:  hw.module @basic
-// PRAGMA-LABEL: hw.module @basic
 // CUSTOM-LABEL: hw.module @basic
 hw.module @basic(in %clock : i1, in %prop : i1) {
   // Untouched ops outside the masked set always pass through.
   // DELETE: hw.constant true
   // IFDEF:  hw.constant true
-  // PRAGMA: hw.constant true
   // CUSTOM: hw.constant true
   %true = hw.constant true
 
-  // A coalesced run of three masked ops becomes a single wrapper.
+  // Each masked op gets its own wrapper, even when they are adjacent.
   //
   // DELETE-NOT: sv.assert.concurrent
   // DELETE-NOT: sv.assume.concurrent
@@ -39,42 +36,47 @@ hw.module @basic(in %clock : i1, in %prop : i1) {
   // IFDEF:      sv.ifdef @SYNTHESIS {
   // IFDEF-NEXT: } else {
   // IFDEF-NEXT:   sv.assert.concurrent posedge %clock, %prop
+  // IFDEF-NEXT: }
+  // IFDEF-NEXT: sv.ifdef @SYNTHESIS {
+  // IFDEF-NEXT: } else {
   // IFDEF-NEXT:   sv.assume.concurrent posedge %clock, %prop
+  // IFDEF-NEXT: }
+  // IFDEF-NEXT: sv.ifdef @SYNTHESIS {
+  // IFDEF-NEXT: } else {
   // IFDEF-NEXT:   sv.cover.concurrent posedge %clock, %prop
   // IFDEF-NEXT: }
   //
   // CUSTOM:      sv.ifdef @MY_GUARD {
   // CUSTOM-NEXT: } else {
   // CUSTOM-NEXT:   sv.assert.concurrent posedge %clock, %prop
+  // CUSTOM-NEXT: }
+  // CUSTOM-NEXT: sv.ifdef @MY_GUARD {
+  // CUSTOM-NEXT: } else {
   // CUSTOM-NEXT:   sv.assume.concurrent posedge %clock, %prop
+  // CUSTOM-NEXT: }
+  // CUSTOM-NEXT: sv.ifdef @MY_GUARD {
+  // CUSTOM-NEXT: } else {
   // CUSTOM-NEXT:   sv.cover.concurrent posedge %clock, %prop
   // CUSTOM-NEXT: }
-  //
-  // PRAGMA:      sv.verbatim "// synthesis translate_off"
-  // PRAGMA-NEXT: sv.assert.concurrent posedge %clock, %prop
-  // PRAGMA-NEXT: sv.assume.concurrent posedge %clock, %prop
-  // PRAGMA-NEXT: sv.cover.concurrent posedge %clock, %prop
-  // PRAGMA-NEXT: sv.verbatim "// synthesis translate_on"
   sv.assert.concurrent posedge %clock, %prop
   sv.assume.concurrent posedge %clock, %prop
   sv.cover.concurrent posedge %clock, %prop
 
-  // A non-masked op separates two independent runs, each gets its own wrapper.
+  // A non-masked op separating masked ops doesn't change the per-op wrapping.
   //
   // IFDEF:      hw.constant false
   // IFDEF-NEXT: sv.ifdef @SYNTHESIS {
   // IFDEF-NEXT: } else {
   // IFDEF-NEXT:   sv.assert_property %prop : i1
+  // IFDEF-NEXT: }
+  // IFDEF-NEXT: sv.ifdef @SYNTHESIS {
+  // IFDEF-NEXT: } else {
   // IFDEF-NEXT:   sv.assume_property %prop : i1
+  // IFDEF-NEXT: }
+  // IFDEF-NEXT: sv.ifdef @SYNTHESIS {
+  // IFDEF-NEXT: } else {
   // IFDEF-NEXT:   sv.cover_property %prop : i1
   // IFDEF-NEXT: }
-  //
-  // PRAGMA:      hw.constant false
-  // PRAGMA-NEXT: sv.verbatim "// synthesis translate_off"
-  // PRAGMA-NEXT: sv.assert_property %prop : i1
-  // PRAGMA-NEXT: sv.assume_property %prop : i1
-  // PRAGMA-NEXT: sv.cover_property %prop : i1
-  // PRAGMA-NEXT: sv.verbatim "// synthesis translate_on"
   %false = hw.constant false
   sv.assert_property %prop : i1
   sv.assume_property %prop : i1
@@ -84,14 +86,13 @@ hw.module @basic(in %clock : i1, in %prop : i1) {
 // -----
 
 //===----------------------------------------------------------------------===//
-// Procedural regions: use `sv.ifdef.procedural` and place verbatim ops inside.
+// Procedural regions: use `sv.ifdef.procedural` to wrap each masked op.
 //===----------------------------------------------------------------------===//
 
 // IFDEF: sv.macro.decl @SYNTHESIS
 
 // DELETE-LABEL: hw.module @procedural
 // IFDEF-LABEL:  hw.module @procedural
-// PRAGMA-LABEL: hw.module @procedural
 hw.module @procedural(in %clock : i1, in %prop : i1) {
   // DELETE:      sv.always posedge %clock {
   // DELETE-NEXT: }
@@ -100,16 +101,12 @@ hw.module @procedural(in %clock : i1, in %prop : i1) {
   // IFDEF-NEXT:   sv.ifdef.procedural @SYNTHESIS {
   // IFDEF-NEXT:   } else {
   // IFDEF-NEXT:     sv.assert_property %prop : i1
+  // IFDEF-NEXT:   }
+  // IFDEF-NEXT:   sv.ifdef.procedural @SYNTHESIS {
+  // IFDEF-NEXT:   } else {
   // IFDEF-NEXT:     sv.assume_property %prop : i1
   // IFDEF-NEXT:   }
   // IFDEF-NEXT: }
-  //
-  // PRAGMA:      sv.always posedge %clock {
-  // PRAGMA-NEXT:   sv.verbatim "// synthesis translate_off"
-  // PRAGMA-NEXT:   sv.assert_property %prop : i1
-  // PRAGMA-NEXT:   sv.assume_property %prop : i1
-  // PRAGMA-NEXT:   sv.verbatim "// synthesis translate_on"
-  // PRAGMA-NEXT: }
   sv.always posedge %clock {
     sv.assert_property %prop : i1
     sv.assume_property %prop : i1
@@ -140,13 +137,9 @@ hw.module @preexisting_macro(in %clock : i1, in %prop : i1) {
 
 //===----------------------------------------------------------------------===//
 // `ifdef` mode skips ops already wrapped by an enclosing
-// `sv.ifdef @SYNTHESIS` ancestor (recursive idempotence): a nested
-// `sv.ifdef.procedural @SYNTHESIS` is not added inside an `sv.always` that
+// `sv.ifdef @SYNTHESIS` ancestor (recursive idempotence): no nested
+// `sv.ifdef.procedural @SYNTHESIS` is added inside an `sv.always` that
 // is itself inside the else region of an outer `sv.ifdef @SYNTHESIS`.
-//
-// `pragma` mode similarly skips ops inside an `sv.always` that is wholly
-// contained between matching `// synthesis translate_off` /
-// `// synthesis translate_on` `sv.verbatim` siblings.
 //===----------------------------------------------------------------------===//
 
 sv.macro.decl @SYNTHESIS
@@ -166,23 +159,6 @@ hw.module @nested_in_existing_ifdef(in %clock : i1, in %prop : i1) {
       sv.assert_property %prop : i1
     }
   }
-}
-
-// -----
-
-// PRAGMA-LABEL: hw.module @nested_in_existing_pragma
-// IFDEF-LABEL: hw.module @nested_in_existing_pragma
-hw.module @nested_in_existing_pragma(in %clock : i1, in %prop : i1) {
-  // PRAGMA:      sv.verbatim "// synthesis translate_off"
-  // PRAGMA-NEXT: sv.always posedge %clock {
-  // PRAGMA-NEXT:   sv.assert_property %prop : i1
-  // PRAGMA-NEXT: }
-  // PRAGMA-NEXT: sv.verbatim "// synthesis translate_on"
-  sv.verbatim "// synthesis translate_off"
-  sv.always posedge %clock {
-    sv.assert_property %prop : i1
-  }
-  sv.verbatim "// synthesis translate_on"
 }
 
 // -----
@@ -231,16 +207,14 @@ hw.module @reuses_existing_decl(in %clock : i1, in %prop : i1) {
 
 //===----------------------------------------------------------------------===//
 // Modules with no masked ops are untouched (no `sv.macro.decl` is added in
-// `ifdef` mode when nothing was wrapped, no verbatim added in `pragma` mode).
+// `ifdef` mode when nothing was wrapped).
 //===----------------------------------------------------------------------===//
 
 // IFDEF-NOT:    sv.macro.decl @SYNTHESIS
 // IFDEF-LABEL:  hw.module @nothing_to_mask
 // DELETE-LABEL: hw.module @nothing_to_mask
-// PRAGMA-LABEL: hw.module @nothing_to_mask
 hw.module @nothing_to_mask(in %clock : i1) {
   // IFDEF-NOT:  sv.ifdef
-  // PRAGMA-NOT: sv.verbatim
   %true = hw.constant true
   sv.always posedge %clock {
     sv.if %true {}

--- a/test/Dialect/SV/sv-mask-non-synthesizable.mlir
+++ b/test/Dialect/SV/sv-mask-non-synthesizable.mlir
@@ -1,13 +1,15 @@
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete %s | FileCheck %s --check-prefix=DELETE
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef %s | FileCheck %s --check-prefix=IFDEF
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete %s | FileCheck %s --check-prefixes=COMMON,DELETE
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef %s | FileCheck %s --check-prefixes=COMMON,IFDEF
+//
 // Default mode is `ifdef`.
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable %s | FileCheck %s --check-prefix=IFDEF
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable %s | FileCheck %s --check-prefixes=COMMON,IFDEF
+//
 // Both modes are idempotent across re-runs.
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete | FileCheck %s --check-prefix=DELETE
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef | FileCheck %s --check-prefix=IFDEF
-// `ifdef` mode honors a custom macro name and is idempotent under it.
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' %s | FileCheck %s --check-prefix=CUSTOM
-// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' %s | circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' | FileCheck %s --check-prefix=CUSTOM
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete | FileCheck %s --check-prefixes=COMMON,DELETE
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef | FileCheck %s --check-prefixes=COMMON,IFDEF
+//
+// `ifdef` mode honors a custom macro name.
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' %s | FileCheck %s --check-prefix=COMMON,CUSTOM
 
 //===----------------------------------------------------------------------===//
 // Each masked op is wrapped in its own `sv.ifdef`; adjacent wrappers are not
@@ -17,14 +19,10 @@
 // IFDEF: sv.macro.decl @SYNTHESIS
 // CUSTOM: sv.macro.decl @MY_GUARD
 
-// DELETE-LABEL: hw.module @basic
-// IFDEF-LABEL:  hw.module @basic
-// CUSTOM-LABEL: hw.module @basic
+// COMMON-LABEL: hw.module @basic
 hw.module @basic(in %clock : i1, in %prop : i1) {
   // Untouched ops outside the masked set always pass through.
-  // DELETE: hw.constant true
-  // IFDEF:  hw.constant true
-  // CUSTOM: hw.constant true
+  // COMMON: hw.constant true
   %true = hw.constant true
 
   // Each masked op gets its own wrapper, even when they are adjacent.
@@ -90,9 +88,7 @@ hw.module @basic(in %clock : i1, in %prop : i1) {
 //===----------------------------------------------------------------------===//
 
 // IFDEF: sv.macro.decl @SYNTHESIS
-
-// DELETE-LABEL: hw.module @procedural
-// IFDEF-LABEL:  hw.module @procedural
+// COMMON-LABEL: hw.module @procedural
 hw.module @procedural(in %clock : i1, in %prop : i1) {
   // DELETE:      sv.always posedge %clock {
   // DELETE-NEXT: }
@@ -211,8 +207,7 @@ hw.module @reuses_existing_decl(in %clock : i1, in %prop : i1) {
 //===----------------------------------------------------------------------===//
 
 // IFDEF-NOT:    sv.macro.decl @SYNTHESIS
-// IFDEF-LABEL:  hw.module @nothing_to_mask
-// DELETE-LABEL: hw.module @nothing_to_mask
+// COMMON-LABEL: hw.module @nothing_to_mask
 hw.module @nothing_to_mask(in %clock : i1) {
   // IFDEF-NOT:  sv.ifdef
   %true = hw.constant true

--- a/test/Dialect/SV/sv-mask-non-synthesizable.mlir
+++ b/test/Dialect/SV/sv-mask-non-synthesizable.mlir
@@ -1,0 +1,248 @@
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete %s | FileCheck %s --check-prefix=DELETE
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef %s | FileCheck %s --check-prefix=IFDEF
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=pragma %s | FileCheck %s --check-prefix=PRAGMA
+// Default mode is `ifdef`.
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable %s | FileCheck %s --check-prefix=IFDEF
+// All modes are idempotent across re-runs.
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=delete | FileCheck %s --check-prefix=DELETE
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=ifdef | FileCheck %s --check-prefix=IFDEF
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable=mode=pragma %s | circt-opt -split-input-file -sv-mask-non-synthesizable=mode=pragma | FileCheck %s --check-prefix=PRAGMA
+// `ifdef` mode honors a custom macro name and is idempotent under it.
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' %s | FileCheck %s --check-prefix=CUSTOM
+// RUN: circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' %s | circt-opt -split-input-file -sv-mask-non-synthesizable='mode=ifdef macro=MY_GUARD' | FileCheck %s --check-prefix=CUSTOM
+
+//===----------------------------------------------------------------------===//
+// Coalesced runs and isolated matches in non-procedural regions.
+//===----------------------------------------------------------------------===//
+
+// IFDEF: sv.macro.decl @SYNTHESIS
+// CUSTOM: sv.macro.decl @MY_GUARD
+
+// DELETE-LABEL: hw.module @basic
+// IFDEF-LABEL:  hw.module @basic
+// PRAGMA-LABEL: hw.module @basic
+// CUSTOM-LABEL: hw.module @basic
+hw.module @basic(in %clock : i1, in %prop : i1) {
+  // Untouched ops outside the masked set always pass through.
+  // DELETE: hw.constant true
+  // IFDEF:  hw.constant true
+  // PRAGMA: hw.constant true
+  // CUSTOM: hw.constant true
+  %true = hw.constant true
+
+  // A coalesced run of three masked ops becomes a single wrapper.
+  //
+  // DELETE-NOT: sv.assert.concurrent
+  // DELETE-NOT: sv.assume.concurrent
+  // DELETE-NOT: sv.cover.concurrent
+  //
+  // IFDEF:      sv.ifdef @SYNTHESIS {
+  // IFDEF-NEXT: } else {
+  // IFDEF-NEXT:   sv.assert.concurrent posedge %clock, %prop
+  // IFDEF-NEXT:   sv.assume.concurrent posedge %clock, %prop
+  // IFDEF-NEXT:   sv.cover.concurrent posedge %clock, %prop
+  // IFDEF-NEXT: }
+  //
+  // CUSTOM:      sv.ifdef @MY_GUARD {
+  // CUSTOM-NEXT: } else {
+  // CUSTOM-NEXT:   sv.assert.concurrent posedge %clock, %prop
+  // CUSTOM-NEXT:   sv.assume.concurrent posedge %clock, %prop
+  // CUSTOM-NEXT:   sv.cover.concurrent posedge %clock, %prop
+  // CUSTOM-NEXT: }
+  //
+  // PRAGMA:      sv.verbatim "// synthesis translate_off"
+  // PRAGMA-NEXT: sv.assert.concurrent posedge %clock, %prop
+  // PRAGMA-NEXT: sv.assume.concurrent posedge %clock, %prop
+  // PRAGMA-NEXT: sv.cover.concurrent posedge %clock, %prop
+  // PRAGMA-NEXT: sv.verbatim "// synthesis translate_on"
+  sv.assert.concurrent posedge %clock, %prop
+  sv.assume.concurrent posedge %clock, %prop
+  sv.cover.concurrent posedge %clock, %prop
+
+  // A non-masked op separates two independent runs, each gets its own wrapper.
+  //
+  // IFDEF:      hw.constant false
+  // IFDEF-NEXT: sv.ifdef @SYNTHESIS {
+  // IFDEF-NEXT: } else {
+  // IFDEF-NEXT:   sv.assert_property %prop : i1
+  // IFDEF-NEXT:   sv.assume_property %prop : i1
+  // IFDEF-NEXT:   sv.cover_property %prop : i1
+  // IFDEF-NEXT: }
+  //
+  // PRAGMA:      hw.constant false
+  // PRAGMA-NEXT: sv.verbatim "// synthesis translate_off"
+  // PRAGMA-NEXT: sv.assert_property %prop : i1
+  // PRAGMA-NEXT: sv.assume_property %prop : i1
+  // PRAGMA-NEXT: sv.cover_property %prop : i1
+  // PRAGMA-NEXT: sv.verbatim "// synthesis translate_on"
+  %false = hw.constant false
+  sv.assert_property %prop : i1
+  sv.assume_property %prop : i1
+  sv.cover_property %prop : i1
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Procedural regions: use `sv.ifdef.procedural` and place verbatim ops inside.
+//===----------------------------------------------------------------------===//
+
+// IFDEF: sv.macro.decl @SYNTHESIS
+
+// DELETE-LABEL: hw.module @procedural
+// IFDEF-LABEL:  hw.module @procedural
+// PRAGMA-LABEL: hw.module @procedural
+hw.module @procedural(in %clock : i1, in %prop : i1) {
+  // DELETE:      sv.always posedge %clock {
+  // DELETE-NEXT: }
+  //
+  // IFDEF:      sv.always posedge %clock {
+  // IFDEF-NEXT:   sv.ifdef.procedural @SYNTHESIS {
+  // IFDEF-NEXT:   } else {
+  // IFDEF-NEXT:     sv.assert_property %prop : i1
+  // IFDEF-NEXT:     sv.assume_property %prop : i1
+  // IFDEF-NEXT:   }
+  // IFDEF-NEXT: }
+  //
+  // PRAGMA:      sv.always posedge %clock {
+  // PRAGMA-NEXT:   sv.verbatim "// synthesis translate_off"
+  // PRAGMA-NEXT:   sv.assert_property %prop : i1
+  // PRAGMA-NEXT:   sv.assume_property %prop : i1
+  // PRAGMA-NEXT:   sv.verbatim "// synthesis translate_on"
+  // PRAGMA-NEXT: }
+  sv.always posedge %clock {
+    sv.assert_property %prop : i1
+    sv.assume_property %prop : i1
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// `ifdef` mode reuses an existing `sv.macro.decl @SYNTHESIS` and does not
+// emit a duplicate.
+//===----------------------------------------------------------------------===//
+
+// IFDEF:     sv.macro.decl @SYNTHESIS
+// IFDEF-NOT: sv.macro.decl @SYNTHESIS
+sv.macro.decl @SYNTHESIS
+
+// IFDEF-LABEL: hw.module @preexisting_macro
+hw.module @preexisting_macro(in %clock : i1, in %prop : i1) {
+  // IFDEF:      sv.ifdef @SYNTHESIS {
+  // IFDEF-NEXT: } else {
+  // IFDEF-NEXT:   sv.assert.concurrent posedge %clock, %prop
+  // IFDEF-NEXT: }
+  sv.assert.concurrent posedge %clock, %prop
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// `ifdef` mode skips ops already wrapped by an enclosing
+// `sv.ifdef @SYNTHESIS` ancestor (recursive idempotence): a nested
+// `sv.ifdef.procedural @SYNTHESIS` is not added inside an `sv.always` that
+// is itself inside the else region of an outer `sv.ifdef @SYNTHESIS`.
+//
+// `pragma` mode similarly skips ops inside an `sv.always` that is wholly
+// contained between matching `// synthesis translate_off` /
+// `// synthesis translate_on` `sv.verbatim` siblings.
+//===----------------------------------------------------------------------===//
+
+sv.macro.decl @SYNTHESIS
+
+// IFDEF-LABEL: hw.module @nested_in_existing_ifdef
+hw.module @nested_in_existing_ifdef(in %clock : i1, in %prop : i1) {
+  // IFDEF:      sv.ifdef @SYNTHESIS {
+  // IFDEF-NEXT: } else {
+  // IFDEF-NEXT:   sv.always posedge %clock {
+  // IFDEF-NEXT:     sv.assert_property %prop : i1
+  // IFDEF-NEXT:   }
+  // IFDEF-NEXT: }
+  // IFDEF-NOT:  sv.ifdef.procedural
+  sv.ifdef @SYNTHESIS {
+  } else {
+    sv.always posedge %clock {
+      sv.assert_property %prop : i1
+    }
+  }
+}
+
+// -----
+
+// PRAGMA-LABEL: hw.module @nested_in_existing_pragma
+// IFDEF-LABEL: hw.module @nested_in_existing_pragma
+hw.module @nested_in_existing_pragma(in %clock : i1, in %prop : i1) {
+  // PRAGMA:      sv.verbatim "// synthesis translate_off"
+  // PRAGMA-NEXT: sv.always posedge %clock {
+  // PRAGMA-NEXT:   sv.assert_property %prop : i1
+  // PRAGMA-NEXT: }
+  // PRAGMA-NEXT: sv.verbatim "// synthesis translate_on"
+  sv.verbatim "// synthesis translate_off"
+  sv.always posedge %clock {
+    sv.assert_property %prop : i1
+  }
+  sv.verbatim "// synthesis translate_on"
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// `ifdef` mode picks a unique symbol name when a non-`sv.macro.decl` symbol
+// of the requested name already exists at top level. The `verilogName`
+// attribute keeps the emitted ``ifdef`` macro spelled as the user requested.
+//===----------------------------------------------------------------------===//
+
+// IFDEF: sv.macro.decl @SYNTHESIS_0["SYNTHESIS"]
+
+// IFDEF-LABEL: hw.module @SYNTHESIS
+hw.module @SYNTHESIS() {}
+
+// IFDEF-LABEL: hw.module @collides_with_module
+hw.module @collides_with_module(in %clock : i1, in %prop : i1) {
+  // IFDEF:      sv.ifdef @SYNTHESIS_0 {
+  // IFDEF-NEXT: } else {
+  // IFDEF-NEXT:   sv.assert.concurrent posedge %clock, %prop
+  // IFDEF-NEXT: }
+  sv.assert.concurrent posedge %clock, %prop
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// `ifdef` mode reuses an existing `sv.macro.decl` whose Verilog identifier
+// matches the requested macro name, even when its sym_name differs.
+//===----------------------------------------------------------------------===//
+
+// IFDEF:     sv.macro.decl @MY_SYM["SYNTHESIS"]
+// IFDEF-NOT: sv.macro.decl
+sv.macro.decl @MY_SYM["SYNTHESIS"]
+
+// IFDEF-LABEL: hw.module @reuses_existing_decl
+hw.module @reuses_existing_decl(in %clock : i1, in %prop : i1) {
+  // IFDEF:      sv.ifdef @MY_SYM {
+  // IFDEF-NEXT: } else {
+  // IFDEF-NEXT:   sv.assert.concurrent posedge %clock, %prop
+  // IFDEF-NEXT: }
+  sv.assert.concurrent posedge %clock, %prop
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Modules with no masked ops are untouched (no `sv.macro.decl` is added in
+// `ifdef` mode when nothing was wrapped, no verbatim added in `pragma` mode).
+//===----------------------------------------------------------------------===//
+
+// IFDEF-NOT:    sv.macro.decl @SYNTHESIS
+// IFDEF-LABEL:  hw.module @nothing_to_mask
+// DELETE-LABEL: hw.module @nothing_to_mask
+// PRAGMA-LABEL: hw.module @nothing_to_mask
+hw.module @nothing_to_mask(in %clock : i1) {
+  // IFDEF-NOT:  sv.ifdef
+  // PRAGMA-NOT: sv.verbatim
+  %true = hw.constant true
+  sv.always posedge %clock {
+    sv.if %true {}
+  }
+}


### PR DESCRIPTION
Add `--sv-mask-non-synthesizable`, a late SV pass that hides concurrent and property assert/assume/cover ops from synthesis. Three modes (`delete`, `ifdef`) and a configurable macro name. All modes are idempotent across re-runs. Operates on `mlir::ModuleOp` and processes each `hw.module` in parallel. Wired into the PyCDE final lowering pipeline so its output is acceptable to Quartus and other tools that reject SVA constructs. This is the configurable-pass alternative to the always-on `ifdef SYNTHESIS` guards in `LowerVerifToSV` that were tried in #10387 and reverted.

Closes #10378.

Assisted-by: vscode:Claude Opus 4.7
