### PR TITLE
[LowerClasses][OM] Make classes for private modules private

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -24,6 +24,7 @@
 #include "circt/Support/ConversionPatternSet.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Threading.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
@@ -1083,6 +1084,8 @@ om::ClassLike LowerClassesPass::createClass(FModuleLike moduleLike,
     loweredClassOp = convertClass(moduleLike, builder, className + suffix,
                                   formalParamNames, hasContainingModule);
   }
+
+  SymbolTable::setSymbolVisibility(loweredClassOp, moduleLike.getVisibility());
 
   return loweredClassOp;
 }

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/OM/OMUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/STLExtras.h"
 
 using namespace mlir;
@@ -132,6 +133,9 @@ static ParseResult parseClassFieldsList(OpAsmParser &parser,
 }
 
 static ParseResult parseClassLike(OpAsmParser &parser, OperationState &state) {
+  // Parse the optional symbol visibility.
+  (void)mlir::impl::parseOptionalVisibilityKeyword(parser, state.attributes);
+
   // Parse the Class symbol name.
   StringAttr symName;
   if (parser.parseSymbolName(symName, mlir::SymbolTable::getSymbolAttrName(),
@@ -186,9 +190,16 @@ static ParseResult parseClassLike(OpAsmParser &parser, OperationState &state) {
 }
 
 static void printClassLike(ClassLike classLike, OpAsmPrinter &printer) {
+  printer << " ";
+
+  // Print the optional symbol visibility.
+  StringRef visibilityAttrName = SymbolTable::getVisibilityAttrName();
+  if (auto visibility =
+          classLike->getAttrOfType<StringAttr>(visibilityAttrName))
+    printer << visibility.getValue() << ' ';
+
   // Print the Class symbol name.
-  printer << " @";
-  printer << classLike.getSymName();
+  printer.printSymbolName(classLike.getSymName());
 
   // Retrieve the formal parameter names and values.
   auto argNames = SmallVector<StringRef>(
@@ -222,9 +233,9 @@ static void printClassLike(ClassLike classLike, OpAsmPrinter &printer) {
   }
 
   // Print the optional attribute dictionary.
-  SmallVector<StringRef> elidedAttrs{classLike.getSymNameAttrName(),
-                                     classLike.getFormalParamNamesAttrName(),
-                                     "fieldTypes", "fieldNames"};
+  SmallVector<StringRef> elidedAttrs{
+      classLike.getSymNameAttrName(), classLike.getFormalParamNamesAttrName(),
+      visibilityAttrName, "fieldTypes", "fieldNames"};
   printer.printOptionalAttrDictWithKeyword(classLike.getOperation()->getAttrs(),
                                            elidedAttrs);
 

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -firrtl-lower-classes %s | FileCheck %s
 
 firrtl.circuit "Component" {
-  // CHECK-LABEL: om.class @Class_0
+  // CHECK-LABEL: om.class private @Class_0
   // CHECK-SAME: %[[REF1:[^ ]+]]: !om.class.type<@Class_1>
   // CHECK-SAME: -> (someReference: !om.class.type<@Class_1>)
   firrtl.class private @Class_0(in %someReference_in: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>, out %someReference: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>) {
@@ -9,7 +9,7 @@ firrtl.circuit "Component" {
     firrtl.propassign %someReference, %someReference_in : !firrtl.class<@Class_1(out someInt: !firrtl.integer)>
   }
 
-  // CHECK-LABEL: om.class @Class_1
+  // CHECK-LABEL: om.class private @Class_1
   // CHECK-SAME: -> (someInt: !om.integer)
   firrtl.class private @Class_1(out %someInt: !firrtl.integer) {
     // CHECK: %[[C1:.+]] = om.constant #om.integer<1 : si4> : !om.integer
@@ -18,7 +18,7 @@ firrtl.circuit "Component" {
     firrtl.propassign %someInt, %0 : !firrtl.integer
   }
 
-  // CHECK-LABEL: om.class @Class_2
+  // CHECK-LABEL: om.class private @Class_2
   // CHECK-SAME: -> (someString: !om.string)
   firrtl.class private @Class_2(out %someString: !firrtl.string) {
     // CHECK: %[[C2:.+]] = om.constant "fubar" : !om.string
@@ -27,10 +27,10 @@ firrtl.circuit "Component" {
     firrtl.propassign %someString, %0 : !firrtl.string
   }
 
-  // CHECK-LABEL: om.class.extern @ExtClass(%basepath: !om.basepath, %input: !om.string) -> (field: !om.string)
+  // CHECK-LABEL: om.class.extern private @ExtClass(%basepath: !om.basepath, %input: !om.string) -> (field: !om.string)
   firrtl.extclass private @ExtClass(in input: !firrtl.string, out field: !firrtl.string)
 
-  // CHECK-LABEL: om.class @ClassEntrypoint
+  // CHECK-LABEL: om.class private @ClassEntrypoint
   // CHECK-SAME: -> (obj_0_out: !om.class.type<@Class_1>)
   firrtl.class private @ClassEntrypoint(out %obj_0_out: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>) {
     // CHECK: %[[OBJ1:.+]] = om.object @Class_1(%basepath) : (!om.basepath) -> !om.class.type<@Class_1>
@@ -326,11 +326,11 @@ firrtl.circuit "ModuleInstances" {
     firrtl.propassign %outputProp, %mod.outputProp : !firrtl.string
   }
 
-  // CHECK: om.class.extern @ExtModule_Class(%basepath: !om.basepath, %inputProp: !om.string) -> (outputProp: !om.string)
+  // CHECK: om.class.extern private @ExtModule_Class(%basepath: !om.basepath, %inputProp: !om.string) -> (outputProp: !om.string)
 
-  // CHECK: om.class.extern @TheRealName_Class(%basepath: !om.basepath, %inputProp: !om.string) -> (outputProp: !om.string)
+  // CHECK: om.class.extern private @TheRealName_Class(%basepath: !om.basepath, %inputProp: !om.string) -> (outputProp: !om.string)
 
-  // CHECK: om.class @Module_Class(%basepath: !om.basepath, %[[IN_PROP0:.+]]: !om.string) -> (outputProp: !om.string)
+  // CHECK: om.class private @Module_Class(%basepath: !om.basepath, %[[IN_PROP0:.+]]: !om.string) -> (outputProp: !om.string)
   // CHECK:   om.class.fields %[[IN_PROP0]] : !om.string
 
   // CHECK: om.class @ModuleInstances_Class(%basepath: !om.basepath, %[[IN_PROP1:.+]]: !om.string) -> (outputProp: !om.string)
@@ -369,7 +369,7 @@ firrtl.circuit "ModuleWithPropertySubmodule" {
     %inst.prop = firrtl.instance inst @SubmoduleWithProperty(in prop: !firrtl.integer)
     firrtl.propassign %inst.prop, %c0 : !firrtl.integer
   }
-  // CHECK: om.class @SubmoduleWithProperty_Class
+  // CHECK: om.class private @SubmoduleWithProperty_Class
   firrtl.module private @SubmoduleWithProperty(in %prop: !firrtl.integer) {
   }
 }
@@ -381,7 +381,7 @@ firrtl.circuit "ModuleWithObjectNoPorts" {
   // Ensure that a module with no property ports, but contains an object results
   // in a class.
   //
-  // CHECK: om.class @Baz_Class
+  // CHECK: om.class private @Baz_Class
   firrtl.module private @Baz() {
     // CHECK: om.object @Metadata
     %meta = firrtl.object @Metadata()
@@ -495,7 +495,7 @@ firrtl.circuit "AltBasePath" {
   // CHECK: firrtl.module @AltBasePath
   // CHECK: firrtl.instance foo sym [[FOO_SYM]]
 
-  // CHECK: om.class @OMIR(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
+  // CHECK: om.class private @OMIR(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
   firrtl.class private @OMIR() {
     %node = firrtl.object @Node(in path: !firrtl.path)
     %0 = firrtl.object.subfield %node[path] : !firrtl.class<@Node(in path: !firrtl.path)>
@@ -754,7 +754,7 @@ firrtl.circuit "UnknownValue" {
   }
 
   // property_assert in a class body lowers to om.property_assert.
-  // CHECK-LABEL: om.class @PropAssertClass
+  // CHECK-LABEL: om.class private @PropAssertClass
   firrtl.class private @PropAssertClass(in %cond: !firrtl.bool) {
     // CHECK: om.property_assert %cond, "must hold" : i1
     firrtl.property_assert %cond, "must hold" : !firrtl.bool

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt %s -verify-diagnostics --mlir-print-local-scope --mlir-print-debuginfo | circt-opt --mlir-print-local-scope --mlir-print-debuginfo -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL: om.class @Thingy
+// CHECK-LABEL: om.class private @Thingy
 // CHECK-SAME: (%blue_1: i8, %blue_2: i32) -> (widget: !om.class.type<@Widget>, gadget: !om.class.type<@Gadget>, blue_1: i8, blue_2: i8)
-om.class @Thingy(%blue_1: i8, %blue_2: i32) -> (widget: !om.class.type<@Widget>, gadget: !om.class.type<@Gadget>, blue_1: i8, blue_2: i8) {
+om.class private @Thingy(%blue_1: i8, %blue_2: i32) -> (widget: !om.class.type<@Widget>, gadget: !om.class.type<@Gadget>, blue_1: i8, blue_2: i8) {
   // CHECK: %[[c5:.+]] = om.constant 5 : i8
   %0 = om.constant 5 : i8
   // CHECK: %[[c6:.+]] = om.constant 6 : i32
@@ -62,9 +62,9 @@ om.class @DiscardableAttrs() attributes {foo.bar="baz"} {
   om.class.fields
 }
 
-// CHECK-LABEL: om.class.extern @Extern
+// CHECK-LABEL: om.class.extern private @Extern
 // CHECK-SAME: (%param1: i1, %param2: i2) -> (field1: i3, field2: i4)
-om.class.extern @Extern(%param1: i1, %param2: i2) -> (field1 : i3, field2 : i4) {}
+om.class.extern private @Extern(%param1: i1, %param2: i2) -> (field1 : i3, field2 : i4) {}
 
 // CHECK-LABEL: om.class @ExternObject
 // CHECK-SAME: (%[[P0:.+]]: i1, %[[P1:.+]]: i2)

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -66,9 +66,9 @@ om.class @DiscardableAttrs() attributes {foo.bar="baz"} {
 // CHECK-SAME: (%param1: i1, %param2: i2) -> (field1: i3, field2: i4)
 om.class.extern private @Extern(%param1: i1, %param2: i2) -> (field1 : i3, field2 : i4) {}
 
-// CHECK-LABEL: om.class @ExternObject
+// CHECK-LABEL: om.class public @ExternObject
 // CHECK-SAME: (%[[P0:.+]]: i1, %[[P1:.+]]: i2)
-om.class @ExternObject(%param1: i1, %param2: i2) {
+om.class public @ExternObject(%param1: i1, %param2: i2) {
   // CHECK: %[[O0:.+]] = om.object @Extern(%[[P0]], %[[P1]])
   %0 = om.object @Extern(%param1, %param2) : (i1, i2) -> !om.class.type<@Extern>
 

--- a/test/firtool/classes-dedupe.fir
+++ b/test/firtool/classes-dedupe.fir
@@ -89,7 +89,7 @@ circuit Test : %[[
     output out_baz : Integer
     propassign out_baz, Integer(1)
 
-  ; CHECK-LABEL: om.class @OM_1(%basepath: !om.basepath) -> (out_foo_1: !om.class.type<@Foo_1>, out_foo_2: !om.class.type<@Foo_2>, out_foo_3: !om.class.type<@Foo_3>, out_foo_4: !om.class.type<@Foo_3>, out_1: !om.path, out_2: !om.path)
+  ; CHECK-LABEL: om.class private @OM_1(%basepath: !om.basepath) -> (out_foo_1: !om.class.type<@Foo_1>, out_foo_2: !om.class.type<@Foo_2>, out_foo_3: !om.class.type<@Foo_3>, out_foo_4: !om.class.type<@Foo_3>, out_1: !om.path, out_2: !om.path)
   class OM_1 :
     output out_1 : Path
     output out_2 : Path


### PR DESCRIPTION
Propagate symbol visibility from firrtl.module to om.class. Tweak mlir text syntax. 

Extracted from https://github.com/llvm/circt/pull/10480. 
Assisted-by: augment: sonnet 4.5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
