### PR TITLE
[Synth] add synth.mux_inv

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -156,6 +156,11 @@ T evaluateOneHotLogic(const T &a, const T &b, const T &c) {
   return (a ^ b ^ c) & invertBooleanLogic(allSet);
 }
 
+template <typename T>
+T evaluateMuxLogic(const T &a, const T &b, const T &c) {
+  return (a & b) | (invertBooleanLogic(a) & c);
+}
+
 } // namespace synth
 } // namespace circt
 

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -300,5 +300,37 @@ def OneHotOp : SynthOp<"onehot", [
   let hasCustomAssemblyFormat = 1;
 }
 
+def MuxInverterOp : InvertibleOperandsOp<"mux_inv"> {
+  let summary = "MUX gate with invertible inputs";
+  let description = [{
+    The `synth.mux_inv` operation represents a 3-input multiplexer node
+    whose operands can be individually inverted before evaluation.
+    The operation chooses between two values based on a condition:
+    given operands (cond, trueValue, falseValue), it calculates `cond ? trueValue : falseValue`,
+    which is equivalent to:
+    
+    `(cond & trueValue) | (~cond & falseValue)`
+
+    Example:
+    ```mlir
+      %r0 = synth.mux_inv %a, %b, %c : i8
+      %r1 = synth.mux_inv not %a, %b, not %c : i8
+    ```
+  }];
+
+  let builders = [
+  OpBuilder<(ins "Value":$cond, "Value":$trueValue, "Value":$falseValue,
+                  CArg<"bool", "false">:$invertCond,
+                  CArg<"bool", "false">:$invertTrue,
+                  CArg<"bool", "false">:$invertFalse),
+                  [{
+    SmallVector<bool> inverted {invertCond, invertTrue, invertFalse};
+    return build($_builder, $_state, {cond, trueValue, falseValue}, inverted);
+  }]>
+];
+let hasVerifier = 1;
+
+}
+
 
 #endif // CIRCT_DIALECT_SYNTH_SYNTHOPS_TD

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -121,7 +121,8 @@ struct LogicNetworkGate {
     Identity = 5,     ///< Identity gate (used for 1-input inverter)
     Choice = 6,       ///< Choice node (synth.choice)
     Dot3 = 7,         ///< Ordered DOT gate (3-input, synth.dot)
-    OneHot3 = 8       ///< OneHot gate (3-input, synth.onehot)
+    OneHot3 = 8,      ///< OneHot gate (3-input, synth.onehot)
+    Mux3 = 9,         ///< Ordered MUX gate (3-input, synth.mux_inv)
   };
 
   /// Operation pointer and gate kind. Constants have a null operation pointer.
@@ -163,6 +164,8 @@ struct LogicNetworkGate {
       return 3;
     case OneHot3:
       return 3;
+    case Mux3:
+      return 3;
     case Identity:
       return 1;
     case Choice:
@@ -175,7 +178,7 @@ struct LogicNetworkGate {
   bool isLogicGate() const {
     Kind k = getKind();
     return k == And2 || k == Xor2 || k == Maj3 || k == Identity ||
-           k == Choice || k == Dot3 || k == OneHot3;
+           k == Choice || k == Dot3 || k == OneHot3 || k == Mux3;
   }
 
   /// Check if this should always be a cut input (PI or constant).

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -124,3 +124,17 @@ hw.module @test_onehot(in %a: i1, in %b: i1, in %c: i1,
   %1 = synth.onehot %a, %b, %c : i1
   hw.output %0, %1 : i1, i1
 }
+
+// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_mux_inv_sat --c2 functional_reduction_mux_inv_sat | FileCheck %s --check-prefix=MUX-INV
+// MUX-INV: c1 == c2
+// CHECK-LABEL: hw.module @functional_reduction_mux_inv_sat
+hw.module @functional_reduction_mux_inv_sat(in %c: i1, in %a: i1, in %b: i1,
+                                            out out0: i1, out out1: i1) {
+  // CHECK: %[[CHOICE:.+]] = synth.choice
+  %0 = synth.mux_inv %c, %a, %b : i1
+  %1 = synth.aig.and_inv %c, %a : i1
+  %2 = synth.aig.and_inv not %c, %b : i1
+  %3 = synth.aig.and_inv not %1, not %2 : i1
+  %4 = synth.aig.and_inv not %3 : i1
+  hw.output %0, %4 : i1, i1
+}

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -351,6 +351,66 @@ struct SynthXorInverterOpConversion
   }
 };
 
+/// Lower a comb::MuxOp operation to synth::MuxInverterOps.
+struct CombMuxOpToSynthConversion : OpConversionPattern<MuxOp> {
+  using OpConversionPattern<MuxOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(MuxOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value cond = adaptor.getCond();
+    Value trueVal = adaptor.getTrueValue();
+    Value falseVal = adaptor.getFalseValue();
+
+    if (!op.getType().isInteger()) {
+      auto widthType = rewriter.getIntegerType(hw::getBitWidth(op.getType()));
+      trueVal =
+          hw::BitcastOp::create(rewriter, op.getLoc(), widthType, trueVal);
+      falseVal =
+          hw::BitcastOp::create(rewriter, op.getLoc(), widthType, falseVal);
+    }
+
+    if (!trueVal.getType().isInteger(1))
+      cond = comb::ReplicateOp::create(rewriter, op.getLoc(), trueVal.getType(),
+                                       cond);
+
+    Value result = synth::MuxInverterOp::create(rewriter, op.getLoc(), cond,
+                                                trueVal, falseVal);
+
+    if (result.getType() != op.getType())
+      result =
+          hw::BitcastOp::create(rewriter, op.getLoc(), op.getType(), result);
+
+    replaceOpAndCopyNamehint(rewriter, op, result);
+    return success();
+  }
+};
+
+/// Lower a synth::MuxInverterOp operation to AIG operations.
+struct SynthMuxInverterOpConversion
+    : OpConversionPattern<synth::MuxInverterOp> {
+  using OpConversionPattern<synth::MuxInverterOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(synth::MuxInverterOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto inputs = adaptor.getInputs();
+    auto inverted = op.getInverted();
+
+    auto lhs = synth::aig::AndInverterOp::create(
+        rewriter, op.getLoc(), inputs[0], inputs[1], inverted[0], inverted[1]);
+
+    auto rhs = synth::aig::AndInverterOp::create(
+        rewriter, op.getLoc(), inputs[0], inputs[2], !inverted[0], inverted[2]);
+
+    auto nand = synth::aig::AndInverterOp::create(rewriter, op.getLoc(), lhs,
+                                                  rhs, true, true);
+    replaceOpWithNewOpAndCopyNamehint<synth::aig::AndInverterOp>(rewriter, op,
+                                                                 nand, true);
+    return success();
+  }
+};
+
 template <typename OpTy>
 struct CombLowerVariadicOp : OpConversionPattern<OpTy> {
   using OpConversionPattern<OpTy>::OpConversionPattern;
@@ -384,47 +444,6 @@ struct CombLowerVariadicOp : OpConversionPattern<OpTy> {
           lowerFullyAssociativeOp(op, operands.drop_front(firstHalf), rewriter);
       return OpTy::create(rewriter, op.getLoc(), ValueRange{lhs, rhs}, true);
     }
-  }
-};
-
-// Lower comb::MuxOp to AIG operations.
-struct CombMuxOpConversion : OpConversionPattern<MuxOp> {
-  using OpConversionPattern<MuxOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(MuxOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    Value cond = op.getCond();
-    auto trueVal = op.getTrueValue();
-    auto falseVal = op.getFalseValue();
-
-    if (!op.getType().isInteger()) {
-      // If the type of the mux is not integer, bitcast the operands first.
-      auto widthType = rewriter.getIntegerType(hw::getBitWidth(op.getType()));
-      trueVal =
-          hw::BitcastOp::create(rewriter, op->getLoc(), widthType, trueVal);
-      falseVal =
-          hw::BitcastOp::create(rewriter, op->getLoc(), widthType, falseVal);
-    }
-
-    // Replicate condition if needed
-    if (!trueVal.getType().isInteger(1))
-      cond = comb::ReplicateOp::create(rewriter, op.getLoc(), trueVal.getType(),
-                                       cond);
-
-    // c ? a : b => (replicate(c) & a) | (~replicate(c) & b)
-    auto lhs =
-        synth::aig::AndInverterOp::create(rewriter, op.getLoc(), cond, trueVal);
-    auto rhs = synth::aig::AndInverterOp::create(rewriter, op.getLoc(), cond,
-                                                 falseVal, true, false);
-
-    Value result = comb::OrOp::create(rewriter, op.getLoc(), lhs, rhs);
-    // Insert the bitcast if the type of the mux is not integer.
-    if (result.getType() != op.getType())
-      result =
-          hw::BitcastOp::create(rewriter, op.getLoc(), op.getType(), result);
-    replaceOpAndCopyNamehint(rewriter, op, result);
-    return success();
   }
 };
 
@@ -1361,8 +1380,8 @@ populateCombToAIGConversionPatterns(RewritePatternSet &patterns,
                                     bool forceAIG) {
   patterns.add<
       // Bitwise Logical Ops
-      CombAndOpConversion, CombMuxOpConversion, CombParityOpConversion,
-      CombXorOpToSynthConversion,
+      CombAndOpConversion, CombParityOpConversion, CombXorOpToSynthConversion,
+      CombMuxOpToSynthConversion,
       // Arithmetic Ops
       CombMulOpConversion, CombICmpOpConversion,
       // Shift Ops
@@ -1371,9 +1390,10 @@ populateCombToAIGConversionPatterns(RewritePatternSet &patterns,
       CombLowerVariadicOp<AddOp>, CombLowerVariadicOp<MulOp>>(
       patterns.getContext());
 
-  if (forceAIG)
-    patterns.add<SynthXorInverterOpConversion>(patterns.getContext());
-
+  if (forceAIG) {
+    patterns.add<SynthXorInverterOpConversion, SynthMuxInverterOpConversion>(
+        patterns.getContext());
+  }
   patterns.add(comb::convertSubToAdd);
 
   patterns.add<CombOrToAIGConversion, CombAddOpConversion>(
@@ -1407,7 +1427,7 @@ void ConvertCombToSynthPass::runOnOperation() {
 
   target.addLegalDialect<synth::SynthDialect>();
   if (forceAIG)
-    target.addIllegalOp<synth::XorInverterOp>();
+    target.addIllegalOp<synth::XorInverterOp, synth::MuxInverterOp>();
 
   // If additional legal ops are specified, add them to the target.
   if (!additionalLegalOps.empty())

--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -156,6 +156,30 @@ struct SynthOneHotOpConversion : SynthInverterOpConversion<synth::OneHotOp> {
   }
 };
 
+struct SynthMuxInverterOpConversion
+    : SynthInverterOpConversion<synth::MuxInverterOp> {
+  using SynthInverterOpConversion<
+      synth::MuxInverterOp>::SynthInverterOpConversion;
+
+  Value createOp(Location loc, ArrayRef<Value> inputs,
+                 ConversionPatternRewriter &rewriter) const override {
+    assert(inputs.size() == 3 && "expected exactly three inputs");
+
+    auto width = inputs[0].getType().getIntOrFloatBitWidth();
+    auto allOnes =
+        hw::ConstantOp::create(rewriter, loc, APInt::getAllOnes(width));
+
+    auto notCond =
+        rewriter.createOrFold<comb::XorOp>(loc, inputs[0], allOnes, true);
+    auto trueValue =
+        rewriter.createOrFold<comb::AndOp>(loc, inputs[0], inputs[1], true);
+    auto falseValue =
+        rewriter.createOrFold<comb::AndOp>(loc, notCond, inputs[2], true);
+
+    return rewriter.createOrFold<comb::OrOp>(loc, trueValue, falseValue, true);
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -173,9 +197,9 @@ struct ConvertSynthToCombPass
 
 static void populateSynthToCombConversionPatterns(RewritePatternSet &patterns) {
   patterns.add<SynthChoiceOpConversion, SynthAndInverterOpConversion,
-               SynthXorInverterOpConversion, SynthDotOpConversion,
-               SynthMajorityOpConversion, SynthOneHotOpConversion>(
-      patterns.getContext());
+               SynthXorInverterOpConversion, SynthMuxInverterOpConversion,
+               SynthDotOpConversion, SynthMajorityOpConversion,
+               SynthOneHotOpConversion>(patterns.getContext());
 }
 
 void ConvertSynthToCombPass::runOnOperation() {

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -763,3 +763,68 @@ void OneHotOp::emitCNFWithoutInversion(
   // out = (a ^ b ^ c) & ~(a & b & c).
   circt::addAndClauses(outVar, {parity, -allSet}, addClause);
 }
+
+//===----------------------------------------------------------------------===//
+// MuxInverterOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult MuxInverterOp::verify() {
+  if (getNumOperands() != 3)
+    return emitOpError("requires exactly three operands");
+  if (getInverted().size() != 3)
+    return emitOpError("requires exactly three inversion flags");
+  return success();
+}
+
+bool MuxInverterOp::areInputsPermutationInvariant() { return false; }
+
+APInt MuxInverterOp::evaluateBooleanLogicWithoutInversion(
+    llvm::ArrayRef<APInt> inputs) {
+  assert(inputs.size() == 3 && "expected exactly three inputs");
+  return evaluateMuxLogic(inputs[0], inputs[1], inputs[2]);
+}
+
+bool MuxInverterOp::supportsNumInputs(unsigned numInputs) {
+  return numInputs == 3;
+}
+
+llvm::KnownBits MuxInverterOp::computeKnownBits(
+    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
+  assert(getNumOperands() == 3 && "expected exactly three inputs");
+
+  auto a = applyInversion(getInputKnownBits(0), isInverted(0));
+  auto b = applyInversion(getInputKnownBits(1), isInverted(1));
+  auto c = applyInversion(getInputKnownBits(2), isInverted(2));
+
+  return evaluateMuxLogic(a, b, c);
+}
+
+int64_t MuxInverterOp::getLogicDepthCost() { return 2; }
+
+std::optional<uint64_t> MuxInverterOp::getLogicAreaCost() {
+  int64_t bitWidth = hw::getBitWidth(getType());
+  if (bitWidth < 0)
+    return std::nullopt;
+  return static_cast<uint64_t>(bitWidth);
+}
+
+void MuxInverterOp::emitCNFWithoutInversion(
+    int outVar, llvm::ArrayRef<int> inputVars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  assert(inputVars.size() == 3 && "expected exactly three inputs");
+
+  int cond = inputVars[0];
+  int trueValue = inputVars[1];
+  int falseValue = inputVars[2];
+
+  int lhs = newVar();
+  int rhs = newVar();
+
+  // lhs = cond & trueValue
+  circt::addAndClauses(lhs, {cond, trueValue}, addClause);
+  // rhs = ~cond & falseValue
+  circt::addAndClauses(rhs, {-cond, falseValue}, addClause);
+  // out = lhs | rhs
+  circt::addOrClauses(outVar, {lhs, rhs}, addClause);
+}

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -196,6 +196,9 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
             .Case<synth::XorInverterOp>([&](synth::XorInverterOp xorOp) {
               return handleInvertibleBinaryGate(xorOp, LogicNetworkGate::Xor2);
             })
+            .Case<synth::MuxInverterOp>([&](synth::MuxInverterOp muxOp) {
+              return handleInvertibleTernaryGate(muxOp, LogicNetworkGate::Mux3);
+            })
             .Case<synth::DotOp>([&](synth::DotOp dotOp) {
               return handleInvertibleTernaryGate(dotOp, LogicNetworkGate::Dot3);
             })
@@ -512,6 +515,8 @@ static inline llvm::APInt applyGateSemantics(LogicNetworkGate::Kind kind,
                                              const llvm::APInt &b,
                                              const llvm::APInt &c) {
   switch (kind) {
+  case LogicNetworkGate::Mux3:
+    return evaluateMuxLogic(a, b, c);
   case LogicNetworkGate::Maj3:
     return evaluateMajorityLogic(a, b, c);
   case LogicNetworkGate::Dot3:
@@ -615,6 +620,11 @@ struct MergedTruthTableBuilder {
       return BinaryTruthTable(
           numMergedInputs, 1,
           applyGateSemantics(rootGate.getKind(), getEdgeTT(0), getEdgeTT(1)));
+    case LogicNetworkGate::Mux3:
+      return BinaryTruthTable(numMergedInputs, 1,
+                              applyGateSemantics(rootGate.getKind(),
+                                                 getEdgeTT(0), getEdgeTT(1),
+                                                 getEdgeTT(2)));
     case LogicNetworkGate::Maj3:
       return BinaryTruthTable(numMergedInputs, 1,
                               applyGateSemantics(rootGate.getKind(),

--- a/test/Conversion/CombToSynth/comb-to-aig.mlir
+++ b/test/Conversion/CombToSynth/comb-to-aig.mlir
@@ -53,6 +53,13 @@ hw.module @mux(in %cond: i1, in %high: !hw.array<2xi4>, in %low: !hw.array<2xi4>
   // CHECK-NEXT: %[[NOT:.+]] = synth.aig.and_inv not %[[NAND]] : i8
   // CHECK-NEXT: %[[RESULT:.+]] = hw.bitcast %[[NOT]] : (i8) -> !hw.array<2xi4>
   // CHECK-NEXT: hw.output %[[RESULT]] : !hw.array<2xi4>
+  // XOR-INV-LABEL: @mux
+  // XOR-INV-NEXT: %[[HIGH:.+]] = hw.bitcast %high : (!hw.array<2xi4>) -> i8
+  // XOR-INV-NEXT: %[[LOW:.+]] = hw.bitcast %low : (!hw.array<2xi4>) -> i8
+  // XOR-INV-NEXT: %[[COND:.+]] = comb.replicate %cond : (i1) -> i8
+  // XOR-INV-NEXT: %[[MUX:.+]] = synth.mux_inv %[[COND]], %[[HIGH]], %[[LOW]] : i8
+  // XOR-INV-NEXT: %[[RESULT:.+]] = hw.bitcast %[[MUX]] : (i8) -> !hw.array<2xi4>
+  // XOR-INV-NEXT: hw.output %[[RESULT]] : !hw.array<2xi4>
   %0 = comb.mux %cond, %high, %low : !hw.array<2xi4>
   hw.output %0 : !hw.array<2xi4>
 }

--- a/test/Conversion/SynthToComb/synth-to-comb.mlir
+++ b/test/Conversion/SynthToComb/synth-to-comb.mlir
@@ -49,6 +49,7 @@ hw.module @test_majority(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
   hw.output %0 : i8
 }
 
+// CHECK-LABEL: @test_onehot
 hw.module @test_onehot(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
   // CHECK: %c-1_i8 = hw.constant -1 : i8
   // CHECK: %[[NOT_A:.+]] = comb.xor bin %a, %c-1_i8 : i8
@@ -59,5 +60,17 @@ hw.module @test_onehot(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
   // CHECK: %[[C_ONLY:.+]] = comb.and bin %[[NOT_A]], %[[NOT_B]], %c : i8
   // CHECK: %[[RESULT:.+]] = comb.or bin %[[A_ONLY]], %[[B_ONLY]], %[[C_ONLY]] : i8
   %0 = synth.onehot %a, %b, %c : i8
+  hw.output %0 : i8
+}
+
+// CHECK-LABEL: @test_mux_inv
+hw.module @test_mux_inv(in %c: i8, in %a: i8, in %b: i8, out out0: i8) {
+  // CHECK: %c-1_i8 = hw.constant -1 : i8
+  // CHECK: %[[NOT_C:.+]] = comb.xor bin %c, %c-1_i8 : i8
+  // CHECK: %[[NOT_B:.+]] = comb.xor bin %b, %c-1_i8 : i8
+  // CHECK: %[[TRUE:.+]] = comb.and bin %[[NOT_C]], %a : i8
+  // CHECK: %[[FALSE:.+]] = comb.and bin %c, %[[NOT_B]] : i8
+  // CHECK: %[[RESULT:.+]] = comb.or bin %[[TRUE]], %[[FALSE]] : i8
+  %0 = synth.mux_inv not %c, %a, not %b : i8
   hw.output %0 : i8
 }

--- a/test/Dialect/Synth/functional-reduction.mlir
+++ b/test/Dialect/Synth/functional-reduction.mlir
@@ -94,3 +94,21 @@ hw.module @test_reachable_erased(in %a: i1, in %b: i1, out out0: i1, out out1: i
   hw.output %ab, %aba : i1, i1
 }
 
+// CHECK-LABEL: hw.module @test_mux_inv_equiv
+hw.module @test_mux_inv_equiv(in %c: i1, in %a: i1, in %b: i1, out out0: i1, out out1: i1) {
+  // CHECK: %[[MUX:.+]] = synth.mux_inv %c, %a, %b
+  // CHECK: %[[CA:.+]] = synth.aig.and_inv %c, %a
+  // CHECK: %[[CB:.+]] = synth.aig.and_inv not %c, %b
+  // CHECK: %[[OR:.+]] = synth.aig.and_inv not %[[CA]], not %[[CB]]
+  // CHECK: %[[RESULT:.+]] = synth.aig.and_inv not %[[OR]]
+  // CHECK: %[[CHOICE:.+]] = synth.choice %[[MUX]], %[[RESULT]] : i1
+  // CHECK: hw.output %[[CHOICE]], %[[CHOICE]] : i1, i1
+  %0 = synth.mux_inv %c, %a, %b {synth.test.fc_equiv_class = 12} : i1
+  %1 = synth.aig.and_inv %c, %a : i1
+  %2 = synth.aig.and_inv not %c, %b : i1
+  %3 = synth.aig.and_inv not %1, not %2 : i1
+  %4 = synth.aig.and_inv not %3 {synth.test.fc_equiv_class = 12} : i1
+  hw.output %0, %4 : i1, i1
+}
+
+

--- a/test/Dialect/Synth/longest-paths.mlir
+++ b/test/Dialect/Synth/longest-paths.mlir
@@ -146,3 +146,12 @@ hw.module private @top(in %clock : !seq.clock) {
   %0 = hw.instance "inst1" @nest(clock: %clock: !seq.clock, a: %a: i1) -> (x: i1)
   %1 = hw.instance "inst2" @nest(clock: %clock: !seq.clock, a: %0: i1) -> (x: i1)
 }
+
+// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.a[0], delay=2, history=[{{.+}}])}}
+// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.b[0], delay=2, history=[{{.+}}])}}
+// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.c[0], delay=2, history=[{{.+}}])}}
+hw.module private @mux_inv_basic(in %a : i1, in %b : i1, in %c : i1, out x : i1) {
+  %m = synth.mux_inv %a, not %b, %c : i1
+  hw.output %m : i1
+}
+

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -114,14 +114,17 @@ func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
 // CHECK-LABEL: hw.module @Other
 // Other operation with BooleanLogicOpInterface
 // Only check that they are lowered.
-hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2, out z: i2, out w: i2) {
+hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2, out z: i2, out w: i2, out v: i2) {
   %0 = synth.xor_inv %a, not %b, %c : i2
   %1 = synth.dot %a, not %b, %c : i2
   %2 = synth.majority %a, not %b, %c : i2
   %3 = synth.onehot %a, not %b, %c : i2
+  %4 = synth.mux_inv %a, not %b, %c : i2
   // CHECK-COUNT-2: synth.xor_inv %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.dot %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.majority %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.onehot %{{.+}}, not %{{.+}}, %{{.+}} : i1
-  hw.output %0, %1, %2, %3 : i2, i2, i2, i2
+  // CHECK-COUNT-2: synth.mux_inv %{{.+}}, not %{{.+}}, %{{.+}} : i1
+  hw.output %0, %1, %2, %3, %4 : i2, i2, i2, i2, i2
 }
+

--- a/test/Dialect/Synth/resource.mlir
+++ b/test/Dialect/Synth/resource.mlir
@@ -58,9 +58,10 @@ hw.module private @unrelated(in %a : i1, in %b : i1, out x : i1) {
 // CHECK-NEXT:   comb.or: 16
 // CHECK-NEXT:   comb.xor: 8
 // CHECK-NEXT:   synth.aig.and_inv: 8
+// CHECK-NEXT:   synth.mux_inv: 8
 // CHECK-NEXT:   synth.xor_inv: 16
 
-hw.module private @multibit(in %a : i8, in %b : i8, in %c : i8, out x : i8) {
+hw.module private @multibit(in %a : i8, in %b : i8, in %c : i8, out x : i8, out y : i8) {
   // 3-input AND on 8-bit: (3-1) * 8 = 16 gates
   %and3 = comb.and %a, %b, %c : i8
   // 2-input AND on 8-bit: (2-1) * 8 = 8 gates
@@ -73,7 +74,9 @@ hw.module private @multibit(in %a : i8, in %b : i8, in %c : i8, out x : i8) {
   %aig = synth.aig.and_inv not %a, %b : i8
   // XOR inverter on 8-bit: (3-1) * 8 = 16 gates
   %xor = synth.xor_inv %aig, not %b, %c : i8
-  hw.output %xor : i8
+  // MUX inverter on 8-bit: (2-1) * 8 = 8 gates
+  %mux = synth.mux_inv %a, not %b, %c : i8
+  hw.output %xor, %mux : i8, i8
 }
 
 

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -42,3 +42,9 @@ hw.module @majority(in %x: i1, in %y: i1, in %z: i1) {
 hw.module @onehot(in %x: i1, in %y: i1, in %z: i1) {
   %0 = synth.onehot %x, not %y, %z : i1
 }
+
+// CHECK-LABEL: @mux_inv
+// CHECK-NEXT: %[[R0:.+]] = synth.mux_inv %c, not %a, %b : i4
+hw.module @mux_inv(in %c: i4, in %a: i4, in %b: i4) {
+  %0 = synth.mux_inv %c, not %a, %b : i4
+}

--- a/test/Dialect/Synth/structural_hash.mlir
+++ b/test/Dialect/Synth/structural_hash.mlir
@@ -94,3 +94,16 @@ hw.module @onehot_commutative(in %x: i1, in %y: i1, in %z: i1, out o0: i1, out o
   %1 = synth.onehot not %y, %x, %z : i1
   hw.output %0, %1 : i1, i1
 }
+
+// CHECK-LABEL: hw.module @mux_inv_ordered
+hw.module @mux_inv_ordered(in %c: i1, in %a: i1, in %b: i1, out o0: i1, out o1: i1, out o2: i1) {
+  // CHECK: %[[M0:.+]] = synth.mux_inv %c, %a, %b : i1
+  // CHECK-NEXT: %[[M1:.+]] = synth.mux_inv %a, %c, %b : i1
+  // CHECK-NEXT: hw.output %[[M0]], %[[M1]], %[[M0]] : i1, i1, i1
+  %0 = synth.mux_inv %c, %a, %b : i1
+  %1 = synth.mux_inv %a, %c, %b : i1
+  %notC = synth.aig.and_inv not %c : i1
+  %2 = synth.mux_inv not %notC, %a, %b : i1
+  hw.output %0, %1, %2 : i1, i1, i1
+}
+

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -204,3 +204,15 @@ hw.module @onehot_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
     %0 = synth.onehot not %z, %x, not %y : i1
     hw.output %0 : i1
 }
+
+hw.module @mux_inv_lib(in %c : i1, in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "c", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+  %0 = synth.mux_inv %c, %a, %b : i1
+  hw.output %0 : i1
+}
+
+// CHECK-LABEL: @mux_inv_test
+hw.module @mux_inv_test(in %c : i1, in %a : i1, in %b : i1, out result : i1) {
+  // CHECK-NEXT: %[[MUX:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @mux_inv_lib(c: %c: i1, a: %a: i1, b: %b: i1) -> (result: i1) {test.arrival_times = [1]}
+  %0 = synth.mux_inv %c, %a, %b : i1
+  hw.output %0 : i1
+}


### PR DESCRIPTION
Concerns #10407 

Add `synth.mux_inv`, an ordered 3-input Boolean logic operation implementing the bitwise mux function (cond & trueValue) | (~cond & falseValue) with per-input inversion support.

This operation is set to three inputs to match mux semantics and the existing cut-rewriter and tech-mapper representation. Multibit operands are supported bitwise, allowing `comb.mux` to lower to `synth.mux_inv` when higher-level synth ops are preserved, while still lowering to AIG when `force-aig` is set.

Assisted-by: <Codex:> <GPT 5.5>


