### PR TITLE
[circt-lec] Lower truth tables before SMT conversion

### DIFF
--- a/test/Tools/circt-lec/truth-table.mlir
+++ b/test/Tools/circt-lec/truth-table.mlir
@@ -1,0 +1,14 @@
+// RUN: circt-lec %s --c1 table --c2 xor --emit-mlir | FileCheck %s
+
+// CHECK-LABEL: smt.solver()
+// CHECK-NOT: comb.truth_table
+// CHECK: smt.ite
+hw.module @table(in %a : i1, in %b : i1, out result : i1) {
+  %0 = comb.truth_table %a, %b -> [false, true, true, false]
+  hw.output %0 : i1
+}
+
+hw.module @xor(in %a : i1, in %b : i1, out result : i1) {
+  %0 = comb.xor %a, %b : i1
+  hw.output %0 : i1
+}

--- a/tools/circt-lec/CMakeLists.txt
+++ b/tools/circt-lec/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(circt-lec
   PRIVATE
   CIRCTComb
   CIRCTCombToSMT
+  CIRCTCombTransforms
   CIRCTDatapath
   CIRCTDatapathToSMT
   CIRCTEmitTransforms

--- a/tools/circt-lec/circt-lec.cpp
+++ b/tools/circt-lec/circt-lec.cpp
@@ -19,6 +19,7 @@
 #include "circt/Conversion/SynthToComb.h"
 #include "circt/Conversion/VerifToSMT.h"
 #include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/Comb/CombPasses.h"
 #include "circt/Dialect/Datapath/DatapathDialect.h"
 #include "circt/Dialect/Emit/EmitDialect.h"
 #include "circt/Dialect/Emit/EmitPasses.h"
@@ -238,6 +239,7 @@ static LogicalResult executeLEC(MLIRContext &context) {
     pm.addPass(createConstructLEC(opts));
   }
   pm.addPass(createConvertSynthToComb());
+  pm.addPass(comb::createLowerComb());
   pm.addPass(createConvertHWToSMT());
   pm.addPass(createConvertDatapathToSMT());
   pm.addPass(createConvertCombToSMT());


### PR DESCRIPTION
This commit adds `lower-comb` pass as a prepass of circt-lec to support comb truth table op. 

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
