### PR TITLE
[VerifToSMT] Use dbg.variable names for BMC declarations

### DIFF
--- a/lib/Conversion/VerifToSMT/CMakeLists.txt
+++ b/lib/Conversion/VerifToSMT/CMakeLists.txt
@@ -8,6 +8,7 @@ add_circt_conversion_library(CIRCTVerifToSMT
   Core
 
   LINK_LIBS PUBLIC
+  CIRCTDebug
   CIRCTHW
   CIRCTHWToSMT
   CIRCTVerif

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -507,7 +507,8 @@ struct VerifBoundedModelCheckingOpConversion
         }
       }
       inputDecls.push_back(smt::DeclareFunOp::create(
-          rewriter, loc, newTy, getNameAttr(curIndex, curIndex >= regStartIdx)));
+          rewriter, loc, newTy,
+          getNameAttr(curIndex, curIndex >= regStartIdx)));
     }
 
     auto numStateArgs = initVals.size() - initIndex;

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Conversion/VerifToSMT.h"
 #include "circt/Conversion/HWToSMT.h"
+#include "circt/Dialect/Debug/DebugOps.h"
 #include "circt/Dialect/Seq/SeqTypes.h"
 #include "circt/Dialect/Verif/VerifOps.h"
 #include "circt/Support/Namespace.h"
@@ -20,6 +21,7 @@
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace circt {
@@ -36,6 +38,21 @@ using namespace hw;
 //===----------------------------------------------------------------------===//
 
 namespace {
+static llvm::SmallDenseMap<unsigned, StringAttr>
+collectDebugNames(Block &block) {
+  llvm::SmallDenseMap<unsigned, StringAttr> debugNames;
+  for (auto varOp : block.getOps<debug::VariableOp>()) {
+    auto name = varOp.getNameAttr();
+    if (name.getValue().empty())
+      continue;
+    auto arg = dyn_cast<BlockArgument>(varOp.getValue());
+    if (!arg || arg.getOwner() != &block)
+      continue;
+    debugNames.try_emplace(arg.getArgNumber(), name);
+  }
+  return debugNames;
+}
+
 /// Lower a verif::AssertOp operation with an i1 operand to a smt::AssertOp,
 /// negated to check for unsatisfiability.
 struct VerifAssertOpConversion : OpConversionPattern<verif::AssertOp> {
@@ -393,6 +410,7 @@ struct VerifBoundedModelCheckingOpConversion
     if (failed(typeConverter->convertTypes(
             op.getCircuit().front().back().getOperandTypes(), circuitOutputTy)))
       return failure();
+    auto debugNames = collectDebugNames(op.getCircuit().front());
     if (failed(rewriter.convertRegionTypes(&op.getInit(), *typeConverter)))
       return failure();
     if (failed(rewriter.convertRegionTypes(&op.getLoop(), *typeConverter)))
@@ -462,6 +480,13 @@ struct VerifBoundedModelCheckingOpConversion
     size_t regStartIdx = oldCircuitInputTy.size() - numRegs;
     SmallVector<Value> inputDecls;
     SmallVector<int> clockIndexes;
+    auto getNameAttr = [&](unsigned argIndex, bool isReg) {
+      if (auto it = debugNames.find(argIndex); it != debugNames.end())
+        return it->second;
+      auto fallback = isReg ? ("reg_" + Twine(argIndex - regStartIdx)).str()
+                            : ("input_" + Twine(argIndex)).str();
+      return rewriter.getStringAttr(fallback);
+    };
     for (auto [curIndex, oldTy, newTy] :
          llvm::enumerate(oldCircuitInputTy, circuitInputTy)) {
       if (isa<seq::ClockType>(oldTy)) {
@@ -481,14 +506,8 @@ struct VerifBoundedModelCheckingOpConversion
           continue;
         }
       }
-      // Give a meaningful name prefix based on the argument's role.
-      std::string name;
-      if (curIndex >= regStartIdx)
-        name = ("reg_" + Twine(curIndex - regStartIdx)).str();
-      else
-        name = ("input_" + Twine(curIndex)).str();
       inputDecls.push_back(smt::DeclareFunOp::create(
-          rewriter, loc, newTy, rewriter.getStringAttr(name)));
+          rewriter, loc, newTy, getNameAttr(curIndex, curIndex >= regStartIdx)));
     }
 
     auto numStateArgs = initVals.size() - initIndex;
@@ -601,9 +620,8 @@ struct VerifBoundedModelCheckingOpConversion
             if (isa<seq::ClockType>(oldTy)) {
               newDecls.push_back(loopVals[loopIndex++]);
             } else {
-              auto name = ("input_" + Twine(inputIdx)).str();
               newDecls.push_back(smt::DeclareFunOp::create(
-                  builder, loc, newTy, builder.getStringAttr(name)));
+                  builder, loc, newTy, getNameAttr(inputIdx, false)));
             }
           }
 
@@ -696,7 +714,8 @@ void circt::populateVerifToSMTConversionPatterns(
 void ConvertVerifToSMTPass::runOnOperation() {
   ConversionTarget target(getContext());
   target.addIllegalDialect<verif::VerifDialect>();
-  target.addLegalDialect<smt::SMTDialect, arith::ArithDialect, scf::SCFDialect,
+  target.addLegalDialect<debug::DebugDialect, smt::SMTDialect,
+                         arith::ArithDialect, scf::SCFDialect,
                          func::FuncDialect>();
   target.addLegalOp<UnrealizedConversionCastOp>();
 

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -38,17 +38,19 @@ using namespace hw;
 //===----------------------------------------------------------------------===//
 
 namespace {
-static llvm::SmallDenseMap<unsigned, StringAttr>
-collectDebugNames(Block &block) {
+llvm::SmallDenseMap<unsigned, StringAttr> collectDebugNames(Block &block) {
   llvm::SmallDenseMap<unsigned, StringAttr> debugNames;
-  for (auto varOp : block.getOps<debug::VariableOp>()) {
-    auto name = varOp.getNameAttr();
-    if (name.getValue().empty())
-      continue;
-    auto arg = dyn_cast<BlockArgument>(varOp.getValue());
-    if (!arg || arg.getOwner() != &block)
-      continue;
-    debugNames.try_emplace(arg.getArgNumber(), name);
+  for (auto arg : block.getArguments()) {
+    for (auto *user : arg.getUsers()) {
+      auto varOp = dyn_cast<debug::VariableOp>(user);
+      if (!varOp)
+        continue;
+      auto name = varOp.getNameAttr();
+      if (name.getValue().empty())
+        continue;
+      debugNames.try_emplace(arg.getArgNumber(), name);
+      break;
+    }
   }
   return debugNames;
 }

--- a/test/Conversion/VerifToSMT/bmc-debug-names.mlir
+++ b/test/Conversion/VerifToSMT/bmc-debug-names.mlir
@@ -1,0 +1,30 @@
+// RUN: circt-opt %s --convert-verif-to-smt --reconcile-unrealized-casts -allow-unregistered-dialect | FileCheck %s
+
+// CHECK-LABEL: func.func @test_bmc_debug_names() -> i1 {
+// CHECK: [[INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
+// CHECK: [[REG_DECL:%.+]] = smt.declare_fun "state_q" : !smt.bv<8>
+// CHECK-NOT: smt.declare_fun "input_1"
+// CHECK-NOT: smt.declare_fun "reg_0"
+// CHECK: [[NEXT_INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
+
+func.func @test_bmc_debug_names() -> i1 {
+  %bmc = verif.bmc bound 2 num_regs 1 initial_values [unit]
+  init {
+    %clk = seq.const_clock low
+    verif.yield %clk : !seq.clock
+  }
+  loop {
+  ^bb0(%clk: !seq.clock):
+    verif.yield %clk : !seq.clock
+  }
+  circuit {
+  ^bb0(%clk: !seq.clock, %arg0: i8, %state0: i8):
+    %scope = dbg.scope "Top", "Top"
+    dbg.variable "data_in", %arg0 scope %scope : i8
+    dbg.variable "state_q", %state0 scope %scope : i8
+    %true = hw.constant true
+    verif.assert %true : i1
+    verif.yield %arg0 : i8
+  }
+  func.return %bmc : i1
+}

--- a/test/Conversion/VerifToSMT/bmc-debug-names.mlir
+++ b/test/Conversion/VerifToSMT/bmc-debug-names.mlir
@@ -3,9 +3,13 @@
 // CHECK-LABEL: func.func @test_bmc_debug_names() -> i1 {
 // CHECK: [[INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
 // CHECK: [[REG_DECL:%.+]] = smt.declare_fun "state_q" : !smt.bv<8>
+// CHECK: scf.for {{%.+}} iter_args([[CLK_ARG:%.+]] = {{%.+}}, [[INPUT_ARG:%.+]] = [[INPUT_DECL]], [[REG_ARG:%.+]] = [[REG_DECL]], {{%.+}})
+// CHECK: [[CIRCUIT_RESULT:%.+]] = func.call @bmc_circuit([[CLK_ARG]], [[INPUT_ARG]], [[REG_ARG]]) : (!smt.bv<1>, !smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
 // CHECK-NOT: smt.declare_fun "input_1"
 // CHECK-NOT: smt.declare_fun "reg_0"
 // CHECK: [[NEXT_INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
+// CHECK: [[NEXT_REG:%.+]] = smt.ite {{%.+}}, [[CIRCUIT_RESULT]], [[REG_ARG]] : !smt.bv<8>
+// CHECK: scf.yield {{%.+}}, [[NEXT_INPUT_DECL]], [[NEXT_REG]], {{%.+}} : !smt.bv<1>, !smt.bv<8>, !smt.bv<8>, i1
 
 func.func @test_bmc_debug_names() -> i1 {
   %bmc = verif.bmc bound 2 num_regs 1 initial_values [unit]


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
This teaches `convert-verif-to-smt` to reuse `dbg.variable` names on BMC circuit block arguments when creating `smt.declare_fun` values.

If no debug name is present, it still falls back to the existing `input_N` / `reg_N` naming.

Adds a small regression test for the named case.

Assisted-by: codex:gpt-5.4(medium) for tests and some debugging.