### PR TITLE
[ESI][runtime] Make VoidType zero-width; collapse 0-bit types to void in codegen

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -212,9 +212,10 @@ public:
   /// byte, so void / zero-width port types are reported as 1 byte here; the
   /// transport pads or strips that placeholder byte transparently.
   size_t getFrameSizeBytes() const {
-    if (translationInfo)
-      return translationInfo->frameBytes;
-    return std::max<size_t>(1, utils::bitsToBytes(type->getBitWidth()));
+    size_t bytes = translationInfo
+                       ? translationInfo->frameBytes
+                       : utils::bitsToBytes(type->getBitWidth());
+    return std::max<size_t>(1, bytes);
   }
   const Type *getType() const { return type; }
 

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -20,6 +20,7 @@
 #include "esi/Types.h"
 #include "esi/Utils.h"
 
+#include <algorithm>
 #include <cassert>
 #include <condition_variable>
 #include <future>
@@ -206,11 +207,14 @@ public:
   }
 
   /// Get the size of each frame in bytes. For windowed types, this is the
-  /// lowered type's width; otherwise, the port type's width.
+  /// lowered type's width; otherwise, the port type's width. Transports
+  /// (DMA engines, cosim, etc.) require every message to be at least one
+  /// byte, so void / zero-width port types are reported as 1 byte here; the
+  /// transport pads or strips that placeholder byte transparently.
   size_t getFrameSizeBytes() const {
     if (translationInfo)
       return translationInfo->frameBytes;
-    return utils::bitsToBytes(type->getBitWidth());
+    return std::max<size_t>(1, utils::bitsToBytes(type->getBitWidth()));
   }
   const Type *getType() const { return type; }
 
@@ -326,10 +330,10 @@ public:
              "Cannot call write() with pending translated messages");
       translateOutgoing(data);
       for (auto &msg : translationBuffer)
-        writeImpl(msg);
+        writeImpl(maybePadEmptyMessage(msg));
       translationBuffer.clear();
     } else {
-      writeImpl(data);
+      writeImpl(maybePadEmptyMessage(data));
     }
   }
 
@@ -361,7 +365,7 @@ public:
       flush();
       return true;
     } else {
-      return tryWriteImpl(data);
+      return tryWriteImpl(maybePadEmptyMessage(data));
     }
   }
   /// Flush any buffered data. Returns true if all data was flushed.
@@ -370,7 +374,8 @@ public:
   /// true and perform no action, as there is no buffered data to flush.
   bool flush() {
     while (translationBufferIdx < translationBuffer.size()) {
-      if (!tryWriteImpl(translationBuffer[translationBufferIdx]))
+      if (!tryWriteImpl(
+              maybePadEmptyMessage(translationBuffer[translationBufferIdx])))
         return false;
       ++translationBufferIdx;
     }
@@ -379,6 +384,21 @@ public:
     return true;
   }
 
+protected:
+  /// Pad an empty payload with a single zero byte if the port type has a
+  /// zero-width logical width (e.g. `VoidType`). Transports (DMA engines,
+  /// cosim, etc.) require every message to carry at least one byte.
+  const MessageData &maybePadEmptyMessage(const MessageData &data) {
+    if (!data.getSize() && type && type->getBitWidth() == 0)
+      return transportPad0Bytes;
+    return data;
+  }
+
+  /// Backing storage for `maybePadEmptyMessage` return so that the returned
+  /// reference outlives the call.
+  const static MessageData transportPad0Bytes;
+
+public:
 protected:
   /// Implementation for write(). Subclasses must implement this.
   virtual void writeImpl(const MessageData &) = 0;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -212,9 +212,8 @@ public:
   /// byte, so void / zero-width port types are reported as 1 byte here; the
   /// transport pads or strips that placeholder byte transparently.
   size_t getFrameSizeBytes() const {
-    size_t bytes = translationInfo
-                       ? translationInfo->frameBytes
-                       : utils::bitsToBytes(type->getBitWidth());
+    size_t bytes = translationInfo ? translationInfo->frameBytes
+                                   : utils::bitsToBytes(type->getBitWidth());
     return std::max<size_t>(1, bytes);
   }
   const Type *getType() const { return type; }

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
@@ -142,8 +142,10 @@ class VoidType : public Type {
 public:
   using Type::deserialize;
   VoidType(const ID &id) : Type(id) {}
-  // 'void' is 1 bit by convention.
-  std::ptrdiff_t getBitWidth() const override { return 1; };
+  // 'void' carries no data. Transports (e.g. DMA engines, cosim) that require
+  // every message to be at least one byte add a placeholder byte themselves;
+  // the logical type width is 0.
+  std::ptrdiff_t getBitWidth() const override { return 0; };
 
   void ensureValid(const std::any &obj) const override;
   MutableBitVector serialize(const std::any &obj) const override;

--- a/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
@@ -288,9 +288,7 @@ public:
                                   AppIDPath idPath,
                                   const std::string &channelName)
       : WriteChannelPort(type), engine(engine), idPath(idPath),
-        channelName(channelName) {
-    frameSizeBytes = utils::bitsToBytes(type->getBitWidth());
-  }
+        channelName(channelName) {}
 
   // Connect allocate a buffer and prime the pump.
   void connectImpl(const ChannelPort::ConnectOptions &options) override;
@@ -307,8 +305,6 @@ protected:
   /// Poll for ability to send more data and send if able.
   bool pollImpl() override;
 
-  // Size of buffer based on type.
-  size_t frameSizeBytes;
   // Owning engine.
   OneItemBuffersFromHost *engine;
   // Single buffer.
@@ -319,7 +315,8 @@ protected:
   std::mutex bufferMutex;
 
   // FIFO of frame-sized messages to send. When a message is larger than
-  // frameSizeBytes, it's broken into frame-sized pieces and enqueued here.
+  // getFrameSizeBytes(), it's broken into frame-sized pieces and enqueued
+  // here.
   std::queue<MessageData> pendingFrames;
 
   // Identifing information.
@@ -409,8 +406,8 @@ void OneItemBuffersFromHost::connect() {
 void OneItemBuffersFromHostWritePort::connectImpl(
     const ChannelPort::ConnectOptions &options) {
   engine->connect();
-  data_buffer = engine->hostMem->allocate(std::max(frameSizeBytes, (size_t)512),
-                                          {false, false});
+  data_buffer = engine->hostMem->allocate(
+      std::max(getFrameSizeBytes(), (size_t)512), {false, false});
   completion_buffer = engine->hostMem->allocate(512, {true, false});
   // Set the last byte to '1' to indicate that the buffer is ready to be filled
   // and sent to the device.

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -113,6 +113,14 @@ bool ReadChannelPort::invokeCallback(
       callbackCv.notify_all();
   };
 
+  // For zero-width port types (e.g. `VoidType`), transports send a single
+  // placeholder byte to satisfy the "every message is at least one byte"
+  // invariant. Strip that byte here so consumers see an empty payload that
+  // matches the logical type width. The matching pad happens in
+  // `WriteChannelPort::maybePadEmptyMessage`.
+  if (msg && type && type->getBitWidth() == 0)
+    msg = std::make_unique<MessageData>();
+
   try {
     bool consumed = activeCallback(msg);
     finish();
@@ -565,6 +573,8 @@ bool ReadChannelPort::translateIncoming(MessageData &data) {
 
   return false;
 }
+
+const MessageData WriteChannelPort::transportPad0Bytes = MessageData({0});
 
 void WriteChannelPort::translateOutgoing(const MessageData &data) {
   assert(translationInfo &&

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -115,11 +115,17 @@ bool ReadChannelPort::invokeCallback(
 
   // For zero-width port types (e.g. `VoidType`), transports send a single
   // placeholder byte to satisfy the "every message is at least one byte"
-  // invariant. Strip that byte here so consumers see an empty payload that
-  // matches the logical type width. The matching pad happens in
-  // `WriteChannelPort::maybePadEmptyMessage`.
-  if (msg && type && type->getBitWidth() == 0)
-    msg = std::make_unique<MessageData>();
+  // invariant. Only strip the payload when it matches that encoding so
+  // malformed transport data is surfaced instead of silently discarded. The
+  // matching pad happens in `WriteChannelPort::maybePadEmptyMessage`.
+  if (msg && type && type->getBitWidth() == 0) {
+    if (msg->totalSize() == 1) {
+      msg = std::make_unique<MessageData>();
+    } else {
+      throw std::runtime_error(
+          "zero-width message must use a single-byte placeholder payload");
+    }
+  }
 
   try {
     bool consumed = activeCallback(msg);

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -292,6 +292,9 @@ void ChannelPort::TranslationInfo::precomputeFrameInfo() {
         throw std::runtime_error(
             "Cannot translate list with dynamically-sized element type: " +
             name);
+      if (elemBits == 0)
+        throw std::runtime_error(
+            "Cannot translate list with zero-width element type: " + name);
       if (elemBits % 8 != 0)
         throw std::runtime_error(
             "Cannot translate list element with non-byte-aligned size: " +

--- a/lib/Dialect/ESI/runtime/cpp/lib/Types.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Types.cpp
@@ -161,23 +161,17 @@ void VoidType::ensureValid(const std::any &obj) const {
 }
 
 std::any VoidType::deserialize(BitVector &data) const {
-  if (data.width() < 8)
-    throw std::runtime_error("void type cannot be represented by empty data");
-  // Extract one byte and return the rest. Check that the byte is 0.
-  BitVector value = data.lsb(8);
-  if (std::ranges::any_of(value, [](auto b) { return b; }))
-    throw std::runtime_error(std::format("void type byte must be 0, got {:b}",
-                                         value.getSpan().front()));
-
-  data >>= 8;
+  // Void carries no logical data. Transports that pad empty messages to one
+  // byte strip that byte before handing the BitVector to us, so we consume
+  // nothing here.
   return std::any{};
 }
 
 MutableBitVector VoidType::serialize(const std::any &obj) const {
   ensureValid(obj);
-  // By convention, void is represented by a single byte of value 0.
-  MutableBitVector bv(8);
-  return bv;
+  // Void carries no logical data. Transports that require a non-empty payload
+  // are responsible for adding their own placeholder byte.
+  return MutableBitVector(0);
 }
 
 void TypeAliasType::ensureValid(const std::any &obj) const {

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -1083,6 +1083,13 @@ class CppTypeEmitter:
       return self.type_id_map[wrapped]
     if isinstance(wrapped,
                   (types.TypeAlias, types.StructType, types.UnionType)):
+      # Zero-width composite types (e.g. a struct of only void fields, or an
+      # alias to such a struct) collapse to `void`. C++ structs are defined to
+      # have `sizeof >= 1`, so there is no meaningful storage to emit; treat them
+      # as void everywhere they appear so callers comment them out exactly
+      # like a direct `VoidType` field.
+      if wrapped.bit_width == 0:
+        return "void"
       return self.type_id_map[wrapped]
     if isinstance(wrapped, types.BundleType):
       return "void"
@@ -1095,8 +1102,16 @@ class CppTypeEmitter:
     if isinstance(wrapped, types.AnyType):
       return "std::any"
     if isinstance(wrapped, (types.BitsType, types.IntType)):
+      # A zero-width integer carries no data; emit it as `void` so it gets
+      # commented out in field positions like any other void.
+      if wrapped.bit_width == 0:
+        return "void"
       return self._get_bitvector_str(wrapped)
     if isinstance(wrapped, types.ArrayType):
+      # `std::array<void, N>` is ill-formed; arrays of zero-width elements
+      # also collapse to `void`.
+      if wrapped.bit_width == 0:
+        return "void"
       return self._std_array_type(wrapped)
     if type(wrapped) is types.ESIType:
       return "std::any"
@@ -1266,6 +1281,10 @@ class CppTypeEmitter:
 
   def _emit_struct(self, hdr: TextIO, struct_type: types.StructType) -> None:
     """Emit a packed struct declaration plus its type id string."""
+    # Zero-width composite types collapse to `void` everywhere they appear
+    # (see _cpp_type), so there is nothing meaningful to emit here.
+    if struct_type.bit_width == 0:
+      return
     fields = list(struct_type.fields)
     if struct_type.cpp_type.reverse:
       fields = list(reversed(fields))
@@ -1311,7 +1330,14 @@ class CppTypeEmitter:
         f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(struct_type.id)};\n"
     )
     hdr.write("};\n")
-    self._emit_size_assert(hdr, struct_name, self._safe_byte_width(struct_type))
+    # Void / zero-width fields are commented out and contribute 0 to the
+    # struct's bit_width (see VoidType.bit_width), so the manifest-derived
+    # size already matches the emitted C++ layout. An all-void or empty
+    # struct still has `sizeof >= 1` in C++, so skip the assert in that
+    # degenerate case.
+    expected_bytes = self._safe_byte_width(struct_type)
+    if expected_bytes is not None and expected_bytes > 0:
+      self._emit_size_assert(hdr, struct_name, expected_bytes)
     hdr.write("#pragma pack(pop)\n\n")
 
   def _emit_union(self, hdr: TextIO, union_type: types.UnionType) -> None:
@@ -1321,9 +1347,13 @@ class CppTypeEmitter:
     byte array so the data sits at the MSB end, matching SV packed union
     layout where padding occupies the LSBs / lower addresses.
     """
+    # Zero-width unions collapse to `void` (see _cpp_type) so there is
+    # nothing meaningful to emit here.
+    if union_type.bit_width == 0:
+      return
     union_name = self.type_id_map[union_type]
-    union_bytes = self._field_byte_width(union_type)
     fields = list(union_type.fields)
+    union_bytes = self._field_byte_width(union_type)
 
     hdr.write("#pragma pack(push, 1)\n")
     # First pass: emit wrapper structs for fields that need padding.
@@ -1362,7 +1392,10 @@ class CppTypeEmitter:
         f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(union_type.id)};\n"
     )
     hdr.write("};\n")
-    self._emit_size_assert(hdr, union_name, union_bytes)
+    # Skip the assertion for all-void / empty unions; an empty union has
+    # `sizeof >= 1` in C++ and would always fail an `== 0` assert.
+    if union_bytes > 0:
+      self._emit_size_assert(hdr, union_name, union_bytes)
     hdr.write("#pragma pack(pop)\n\n")
 
   def _emit_window(self, hdr: TextIO, window_type: types.WindowType) -> None:

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -117,6 +117,7 @@ NB_MODULE(esiCppAccel, m) {
   nb::class_<Type>(m, "Type")
       .def(nb::init<const Type::ID &>(), nb::arg("id"))
       .def_prop_ro("id", &Type::getID)
+      .def_prop_ro("bit_width", &Type::getBitWidth)
       .def("__repr__", [](Type &t) { return "<" + t.getID() + ">"; });
   nb::class_<ChannelType, Type>(m, "ChannelType")
       .def(nb::init<const Type::ID &, const Type *>(), nb::arg("id"),

--- a/lib/Dialect/ESI/runtime/python/esiaccel/types.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/types.py
@@ -75,7 +75,7 @@ class ESIType:
   @property
   def bit_width(self) -> int:
     """Size of this type, in bits. Negative for unbounded types."""
-    assert False, "unimplemented"
+    return self.cpp_type.bit_width
 
   @property
   def max_size(self) -> int:
@@ -112,10 +112,6 @@ class ChannelType(ESIType):
   def _init_from_cpp(self, cpp_type: cpp.ChannelType):
     super()._init_from_cpp(cpp_type)
     self.inner_type = _get_esi_type(cpp_type.inner)
-
-  @property
-  def bit_width(self) -> int:
-    return self.inner_type.bit_width
 
   @property
   def inner(self) -> "ESIType":
@@ -175,18 +171,15 @@ class VoidType(ESIType):
       return (False, f"void type cannot must represented by None, not {obj}")
     return (True, None)
 
-  @property
-  def bit_width(self) -> int:
-    return 8
-
   def serialize(self, obj) -> bytearray:
-    # By convention, void is represented by a single byte of value 0.
-    return bytearray([0])
+    # Void carries no logical data. Transports that require a non-empty
+    # payload are responsible for adding their own placeholder byte.
+    return bytearray()
 
   def deserialize(self, data: bytearray) -> Tuple[object, bytearray]:
-    if len(data) == 0:
-      raise ValueError(f"void type cannot be represented by {data}")
-    return (None, data[1:])
+    # Transports that pad empty messages to one byte strip that byte before
+    # invoking deserialize, so we consume nothing here.
+    return (None, data)
 
 
 __esi_mapping[cpp.VoidType] = VoidType
@@ -199,10 +192,6 @@ class AnyType(ESIType):
 
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     return (False, "any type is not supported for host communication")
-
-  @property
-  def bit_width(self) -> int:
-    return -1
 
   def serialize(self, obj) -> bytearray:
     raise ValueError("any type cannot be serialized")
@@ -229,10 +218,6 @@ class BitsType(ESIType):
       return (False, f"wrong size: {len(obj)}")
     return (True, None)
 
-  @property
-  def bit_width(self) -> int:
-    return self.cpp_type.width
-
   def serialize(self, obj: Union[bytearray, bytes, List[int]]) -> bytearray:
     if isinstance(obj, bytearray):
       return obj
@@ -251,10 +236,6 @@ class IntType(ESIType):
 
   def __init__(self, id: str, width: int):
     self._init_from_cpp(cpp.IntegerType(id, width))
-
-  @property
-  def bit_width(self) -> int:
-    return self.cpp_type.width
 
 
 class UIntType(IntType):
@@ -326,13 +307,6 @@ class StructType(ESIType):
     # For wrap_cpp path, we need to convert C++ fields back to Python
     self.fields = [(name, _get_esi_type(ty)) for (name, ty) in cpp_type.fields]
 
-  @property
-  def bit_width(self) -> int:
-    widths = [ty.bit_width for (_, ty) in self.fields]
-    if any([w < 0 for w in widths]):
-      return -1
-    return sum(widths)
-
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     fields_count = 0
     if not isinstance(obj, dict):
@@ -386,10 +360,6 @@ class ArrayType(ESIType):
     self.element_type = _get_esi_type(cpp_type.element)
     self.size = cpp_type.size
 
-  @property
-  def bit_width(self) -> int:
-    return self.element_type.bit_width * self.size
-
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     if not isinstance(obj, list):
       return (False, f"must be a list, not {type(obj)}")
@@ -431,10 +401,6 @@ class ListType(ESIType):
   @property
   def supports_host(self) -> Tuple[bool, Optional[str]]:
     return (False, "list types require an enclosing window encoding")
-
-  @property
-  def bit_width(self) -> int:
-    return -1
 
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     if not isinstance(obj, list):
@@ -499,10 +465,6 @@ class WindowType(ESIType):
   def supports_host(self) -> Tuple[bool, Optional[str]]:
     return (False, self._HOST_UNSUPPORTED_REASON)
 
-  @property
-  def bit_width(self) -> int:
-    return self.lowered_type.bit_width
-
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     return (False, self._HOST_UNSUPPORTED_REASON)
 
@@ -526,13 +488,6 @@ class UnionType(ESIType):
     """Initialize instance attributes from a C++ type object."""
     super()._init_from_cpp(cpp_type)
     self.fields = [(name, _get_esi_type(ty)) for (name, ty) in cpp_type.fields]
-
-  @property
-  def bit_width(self) -> int:
-    widths = [ty.bit_width for (_, ty) in self.fields]
-    if any([w < 0 for w in widths]):
-      return -1
-    return max(widths) if widths else 0
 
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     if not isinstance(obj, dict):
@@ -591,10 +546,6 @@ class TypeAlias(ESIType):
     super()._init_from_cpp(cpp_type)
     self.name = cpp_type.name
     self.inner_type = _get_esi_type(cpp_type.inner)
-
-  @property
-  def bit_width(self) -> int:
-    return self.inner_type.bit_width
 
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     return self.inner_type.is_valid(obj)

--- a/lib/Dialect/ESI/runtime/python/esiaccel/types.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/types.py
@@ -168,7 +168,7 @@ class VoidType(ESIType):
 
   def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
     if obj is not None:
-      return (False, f"void type cannot must represented by None, not {obj}")
+      return (False, f"void type must be represented by None, not {obj}")
     return (True, None)
 
   def serialize(self, obj) -> bytearray:

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTest.cpp
@@ -34,20 +34,24 @@ TEST(ESITypesTest, VoidTypeSerialization) {
   std::any invalidValue = std::any(42);
   EXPECT_THROW(voidType.ensureValid(invalidValue), std::runtime_error);
 
-  // Test serialization
-  MessageData serialized(voidType.serialize(voidValue).getSpan());
-  EXPECT_EQ(serialized.getSize(), 1UL)
-      << "VoidType serialization should produce exactly 1 byte";
-  EXPECT_EQ(serialized.getData()[0], 0)
-      << "VoidType serialization should produce a zero byte";
+  // Void carries no logical data, so serialize produces zero bits.
+  // Transports (DMA, cosim, etc.) that require a non-empty message add
+  // their own placeholder byte; that is handled in the typed port layer
+  // (TypedWritePort<void> / TypedReadPort<void>), not here.
+  EXPECT_EQ(voidType.getBitWidth(), 0)
+      << "VoidType should report a 0-bit logical width";
+  auto serialized = voidType.serialize(voidValue);
+  EXPECT_EQ(serialized.size(), 0UL)
+      << "VoidType serialization should produce zero bits";
 
-  // Test deserialization
-  BitVector v(serialized.getData());
+  // Test deserialization consumes nothing.
+  std::vector<uint8_t> empty;
+  BitVector v(empty);
   auto deserialized = voidType.deserialize(v);
   EXPECT_FALSE(deserialized.has_value())
       << "VoidType deserialization should not have a value";
   EXPECT_EQ(v.width(), 0UL)
-      << "VoidType deserialization should consume all data";
+      << "VoidType deserialization should consume no data";
 }
 
 // Test BitsType serialization and deserialization
@@ -755,7 +759,9 @@ TEST(ESITypesTest, ArrayTypeSerialization) {
 // Test bit width calculations
 TEST(ESITypesTest, BitWidthCalculations) {
   VoidType voidType("void");
-  EXPECT_EQ(voidType.getBitWidth(), 1) << "VoidType should have bit width of 1";
+  EXPECT_EQ(voidType.getBitWidth(), 0)
+      << "VoidType should have a 0-bit logical width; transport-level "
+         "placeholder bytes are added by the typed port layer.";
 
   BitsType bitsType("bits16", 16);
   EXPECT_EQ(bitsType.getBitWidth(), 16)

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTest.cpp
@@ -36,8 +36,9 @@ TEST(ESITypesTest, VoidTypeSerialization) {
 
   // Void carries no logical data, so serialize produces zero bits.
   // Transports (DMA, cosim, etc.) that require a non-empty message add
-  // their own placeholder byte; that is handled in the typed port layer
-  // (TypedWritePort<void> / TypedReadPort<void>), not here.
+  // their own placeholder byte; that pad/strip lives in the channel-port
+  // base classes (WriteChannelPort::maybePadEmptyMessage /
+  // ReadChannelPort::invokeCallback), not at the type-serialization layer.
   EXPECT_EQ(voidType.getBitWidth(), 0)
       << "VoidType should report a 0-bit logical width";
   auto serialized = voidType.serialize(voidValue);

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeTest.cpp
@@ -762,7 +762,7 @@ TEST(ESITypesTest, BitWidthCalculations) {
   VoidType voidType("void");
   EXPECT_EQ(voidType.getBitWidth(), 0)
       << "VoidType should have a 0-bit logical width; transport-level "
-         "placeholder bytes are added by the typed port layer.";
+         "placeholder bytes are added by the channel-port base classes.";
 
   BitsType bitsType("bits16", 16);
   EXPECT_EQ(bitsType.getBitWidth(), 16)

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -573,6 +573,11 @@ def test_struct_with_void_field_commented_out():
   ctor_params = ctor_match.group(1)
   assert "client_data" not in ctor_params
   assert "valid" in ctor_params
+  # The generated struct only contains the non-void field, so the size
+  # assertion must not include the void field's wire-format byte. With one
+  # ui8 field the struct must be exactly 1 byte.
+  assert "static_assert(sizeof(_struct_valid_ui8_client_data__esi_void) == 1," \
+      in hdr
 
 
 def test_union_with_void_field_commented_out():
@@ -594,3 +599,81 @@ def test_union_with_void_field_commented_out():
   # The non-void member is still present in the union body.
   union_body = hdr[hdr.index("union "):]
   assert "uint16_t a;" in union_body
+
+
+def test_nested_struct_with_void_field_size_assert():
+  """An outer struct containing an inner struct with a void field must use
+  the inner struct's effective (post-void-elimination) size in its size
+  assertion, not the manifest's wire-format size.
+  """
+  uint8 = types.UIntType("ui8", 8)
+  uint64 = types.UIntType("ui64", 64)
+  void_t = types.VoidType("!esi.void")
+  inner = types.StructType(
+      "!hw.struct<valid: ui8, client_data: void>",
+      [("valid", uint8), ("client_data", void_t)],
+  )
+  outer = types.StructType(
+      "!hw.struct<address: ui64, tag: ui8, "
+      "data: !hw.struct<valid: ui8, client_data: void>>",
+      [("address", uint64), ("tag", uint8), ("data", inner)],
+  )
+
+  hdr = _generate_header([outer])
+  # Inner struct: 1 byte (only the ui8 field).
+  assert "static_assert(sizeof(_struct_valid_ui8_client_data__esi_void) == 1," \
+      in hdr
+  # Outer struct: 8 (address) + 1 (tag) + 1 (inner) == 10 bytes; the manifest
+  # wire-format width would have been 11 if the inner's void byte leaked
+  # through, so the regression fix must pull the inner's effective width.
+  outer_assert = re.search(
+      r"static_assert\(sizeof\(_struct_address_ui64_tag_ui8_data_[^)]+\) == (\d+),",
+      hdr,
+  )
+  assert outer_assert, f"Outer size assertion not found in:\n{hdr}"
+  assert outer_assert.group(1) == "10", \
+      f"Expected outer struct size 10, got {outer_assert.group(1)}"
+
+
+def test_all_void_struct_collapses_to_void():
+  """A struct whose fields are all void collapses to `void` everywhere.
+
+  The all-void inner struct must not be emitted at all, and an outer struct
+  that references it must comment out that field and exclude it from the
+  generated constructor.
+  """
+  uint8 = types.UIntType("ui8", 8)
+  uint64 = types.UIntType("ui64", 64)
+  void_t = types.VoidType("!esi.void")
+  inner = types.StructType(
+      "!hw.struct<a: void, b: void>",
+      [("a", void_t), ("b", void_t)],
+  )
+  outer = types.StructType(
+      "!hw.struct<address: ui64, tag: ui8, "
+      "data: !hw.struct<a: void, b: void>>",
+      [("address", uint64), ("tag", uint8), ("data", inner)],
+  )
+
+  hdr = _generate_header([outer])
+  # The inner all-void struct must not appear as a struct declaration.
+  assert "struct _struct_a__esi_void_b__esi_void" not in hdr
+  # The outer struct's `data` field collapses to a commented-out void.
+  assert "// void data;" in hdr
+  # No uncommented `void <name>;` declaration may appear anywhere.
+  assert re.search(r"^\s*void\s+\w+;", hdr, re.M) is None, hdr
+  # The outer constructor must not take the void-collapsed `data` parameter.
+  outer_ctor = re.search(
+      r"_struct_address_ui64_tag_ui8_data_[^\s(]*\(([^)]*)\) :", hdr)
+  assert outer_ctor, f"Outer constructor not found in:\n{hdr}"
+  assert "data" not in outer_ctor.group(1)
+  # The outer struct's size assert reflects the actual emitted layout
+  # (8 address + 1 tag + 0 data == 9 bytes).
+  outer_assert = re.search(
+      r"static_assert\(sizeof\(_struct_address_ui64_tag_ui8_data_[^)]+\) "
+      r"== (\d+),",
+      hdr,
+  )
+  assert outer_assert, f"Outer size assertion not found in:\n{hdr}"
+  assert outer_assert.group(1) == "9", \
+      f"Expected outer struct size 9, got {outer_assert.group(1)}"


### PR DESCRIPTION
VoidType now has bit_width == 0 (was 1 bit / 1 byte). The placeholder byte that DMA / cosim transports require for non-empty messages is now added at the transport layer (WriteChannelPort pads, ReadChannelPort strips) rather than in the type's serialize/deserialize.

C++ codegen treats any 0-bit type (void, i0, struct/union/array of only voids, aliases thereof) uniformly: field declarations become '// void <name>;' comments, all-void struct/union declarations are omitted entirely, and size assertions exclude the void contribution.

ESIType.bit_width now delegates to the C++ Type::getBitWidth binding, removing the duplicated per-subclass overrides in types.py.

Assisted-by: GitHub Copilot:claude-opus-4-7