### PR TITLE
[ESI][Runtime] Fix Windows linking issue

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -396,7 +396,7 @@ protected:
 
   /// Backing storage for `maybePadEmptyMessage` return so that the returned
   /// reference outlives the call.
-  const static MessageData transportPad0Bytes;
+  inline static const MessageData transportPad0Bytes = MessageData({0});
 
 public:
 protected:

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -583,8 +583,6 @@ bool ReadChannelPort::translateIncoming(MessageData &data) {
   return false;
 }
 
-const MessageData WriteChannelPort::transportPad0Bytes = MessageData({0});
-
 void WriteChannelPort::translateOutgoing(const MessageData &data) {
   assert(translationInfo &&
          "Translation type must be set for window translation.");


### PR DESCRIPTION
`transportPad0Bytes` wasn't being exported by msvc.

