### PR TITLE
[Synth] add synth.gamble

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -161,6 +161,12 @@ T evaluateMuxLogic(const T &a, const T &b, const T &c) {
   return (a & b) | (invertBooleanLogic(a) & c);
 }
 
+template <typename T>
+T evaluateGambleLogic(const T &a, const T &b, const T &c) {
+  auto orSet = a | b | c;
+  return (a & b & c) | invertBooleanLogic(orSet);
+}
+
 } // namespace synth
 } // namespace circt
 

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -42,6 +42,33 @@ class InvertibleOperandsOp<string mnemonic, list<Trait> traits = []>
   }];
 }
 
+class SymmetricThreeInputOp<string mnemonic, list<Trait> traits = []>
+  : SynthOp<mnemonic, [
+      SameOperandsAndResultType, Pure,
+      DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
+        "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
+        "supportsNumInputs", "createBooleanLogicOp",
+        "getLogicAreaCost"
+      ]>] # traits> {
+  let arguments = (ins Variadic<AnyType>:$inputs,
+                       DenseBoolArrayAttr:$inverted);
+  let results = (outs AnyType:$result);
+  let assemblyFormat = [{
+    custom<VariadicInvertibleOperands>($inputs, type($result), $inverted, attr-dict)
+  }];
+  let builders = [
+    OpBuilder<(ins "Value":$a, "Value":$b, "Value":$c,
+                                CArg<"bool", "false">:$invertA,
+                                CArg<"bool", "false">:$invertB,
+                                CArg<"bool", "false">:$invertC), [{
+      SmallVector<bool> inverted{invertA, invertB, invertC};
+      return build($_builder, $_state, ValueRange{a, b, c},
+                   $_builder.getDenseBoolArrayAttr(inverted));
+    }]>
+  ];
+  let hasVerifier = 1;
+}
+
 def AndInverterOp : InvertibleOperandsOp<"aig.and_inv"> {
   let summary = "AIG dialect AND operation";
   let description = [{
@@ -214,14 +241,7 @@ def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
   let assemblyFormat = "$inputs attr-dict `:` type($result)";
 }
 
-def MajorityOp : SynthOp<"majority", [
-    SameOperandsAndResultType, Pure,
-    DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
-      "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
-      "supportsNumInputs", "createBooleanLogicOp",
-      "getLogicAreaCost"
-    ]>
-  ]>{
+def MajorityOp : SymmetricThreeInputOp<"majority"> {
   let summary = "Majority gate with invertible inputs";
   let description = [{
     The `synth.majority` operation computes the majority function of its
@@ -231,41 +251,16 @@ def MajorityOp : SynthOp<"majority", [
     and 0 otherwise. For three inputs, it's equivalent to:
     (a & b) | (a & c) | (b & c).
 
-    The number of inputs must be odd to avoid ties.
 
-     Example:
+    Example:
   ```mlir
       %r0 = synth.majority %a, %b, %c : i1
       %r1 = synth.majority not %a, %b, not %c : i1
   ```
   }];
-   let arguments = (ins Variadic<AnyType>:$inputs,
-                       DenseBoolArrayAttr:$inverted);
-  let results = (outs AnyType:$result);
-
-  let builders = [
-  OpBuilder<(ins "Value":$a, "Value":$b, "Value":$c,
-                              CArg<"bool", "false">:$invertA,
-                              CArg<"bool", "false">:$invertB,
-                              CArg<"bool", "false">:$invertC), [{
-    SmallVector<bool> inverted{invertA, invertB, invertC};
-    return build($_builder, $_state, ValueRange{a, b, c},
-                 $_builder.getDenseBoolArrayAttr(inverted));
-  }]>
-];
-
-  let hasVerifier = 1;
-  let hasCustomAssemblyFormat = 1;
 }
 
-def OneHotOp : SynthOp<"onehot", [
-    SameOperandsAndResultType, Pure,
-    DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
-      "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
-      "supportsNumInputs", "createBooleanLogicOp",
-      "getLogicAreaCost"
-    ]>
-  ]>{
+def OneHotOp : SymmetricThreeInputOp<"onehot"> {
    let summary = "3-input Onehot gate with invertible inputs";
   let description = [{
     The `synth.onehot` operation computes the one-hot function of its three
@@ -281,23 +276,6 @@ def OneHotOp : SynthOp<"onehot", [
       %r1 = synth.onehot not %a, %b, not %c : i1
 ```
   }];
-  
-  let arguments = (ins Variadic<AnyType>:$inputs,
-                       DenseBoolArrayAttr:$inverted);
-  let results = (outs AnyType:$result);
-  let builders = [
-  OpBuilder<(ins "Value":$a, "Value":$b, "Value":$c,
-                              CArg<"bool", "false">:$invertA,
-                              CArg<"bool", "false">:$invertB,
-                              CArg<"bool", "false">:$invertC), [{
-    SmallVector<bool> inverted{invertA, invertB, invertC};
-    return build($_builder, $_state, ValueRange{a, b, c},
-                 $_builder.getDenseBoolArrayAttr(inverted));
-  }]>
-];
-
-  let hasVerifier = 1;
-  let hasCustomAssemblyFormat = 1;
 }
 
 def MuxInverterOp : InvertibleOperandsOp<"mux_inv"> {
@@ -317,7 +295,7 @@ def MuxInverterOp : InvertibleOperandsOp<"mux_inv"> {
       %r1 = synth.mux_inv not %a, %b, not %c : i8
     ```
   }];
-
+  
   let builders = [
   OpBuilder<(ins "Value":$cond, "Value":$trueValue, "Value":$falseValue,
                   CArg<"bool", "false">:$invertCond,
@@ -331,6 +309,25 @@ def MuxInverterOp : InvertibleOperandsOp<"mux_inv"> {
 let hasVerifier = 1;
 
 }
+
+def GambleOp : SymmetricThreeInputOp<"gamble">{
+  let summary = "3-input Gamble gate with invertible inputs";
+  let description = [{
+  The `synth.gamble` operation computes the gamble function of its three
+  inputs, where each operand can be optionally inverted. The gamble function
+  returns 1 when all inputs are 1 or all inputs are 0, and 0 otherwise.
+  For three inputs, it is equivalent to:
+
+  `(a & b & c) | (~a & ~b & ~c)`
+
+  Example:
+```mlir
+    %r0 = synth.gamble %a, %b, %c : i1
+    %r1 = synth.gamble not %a, %b, not %c : i1
+```
+}];
+}
+
 
 
 #endif // CIRCT_DIALECT_SYNTH_SYNTHOPS_TD

--- a/include/circt/Dialect/Synth/Transforms/CutRewriter.h
+++ b/include/circt/Dialect/Synth/Transforms/CutRewriter.h
@@ -123,6 +123,7 @@ struct LogicNetworkGate {
     Dot3 = 7,         ///< Ordered DOT gate (3-input, synth.dot)
     OneHot3 = 8,      ///< OneHot gate (3-input, synth.onehot)
     Mux3 = 9,         ///< Ordered MUX gate (3-input, synth.mux_inv)
+    Gamble3 = 10,     ///< Ordered Gamble gate (3-input, synth.gamble)
   };
 
   /// Operation pointer and gate kind. Constants have a null operation pointer.
@@ -159,12 +160,10 @@ struct LogicNetworkGate {
     case Xor2:
       return 2;
     case Maj3:
-      return 3;
     case Dot3:
-      return 3;
     case OneHot3:
-      return 3;
     case Mux3:
+    case Gamble3:
       return 3;
     case Identity:
       return 1;
@@ -178,7 +177,8 @@ struct LogicNetworkGate {
   bool isLogicGate() const {
     Kind k = getKind();
     return k == And2 || k == Xor2 || k == Maj3 || k == Identity ||
-           k == Choice || k == Dot3 || k == OneHot3 || k == Mux3;
+           k == Choice || k == Dot3 || k == OneHot3 || k == Mux3 ||
+           k == Gamble3;
   }
 
   /// Check if this should always be a cut input (PI or constant).

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -138,3 +138,18 @@ hw.module @functional_reduction_mux_inv_sat(in %c: i1, in %a: i1, in %b: i1,
   %4 = synth.aig.and_inv not %3 : i1
   hw.output %0, %4 : i1, i1
 }
+
+// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 test_gamble --c2 test_gamble | FileCheck %s --check-prefix=GAMBLE
+// GAMBLE: c1 == c2
+// CHECK-LABEL: hw.module @test_gamble
+hw.module @test_gamble(in %a: i1, in %b: i1, in %c: i1,
+                       out out0: i1, out out1: i1) {
+  // CHECK: %[[CHOICE:.+]] = synth.choice
+  // CHECK: hw.output %[[CHOICE]], %[[CHOICE]] : i1, i1
+  %allSet = synth.aig.and_inv %a, %b, %c : i1
+  %orVar = comb.or %a, %b, %c : i1
+  %noneSet = synth.aig.and_inv not %orVar : i1
+  %0 = comb.or %allSet, %noneSet : i1
+  %1 = synth.gamble %a, %b, %c : i1
+  hw.output %0, %1 : i1, i1
+}

--- a/lib/Conversion/SynthToComb/SynthToComb.cpp
+++ b/lib/Conversion/SynthToComb/SynthToComb.cpp
@@ -180,6 +180,29 @@ struct SynthMuxInverterOpConversion
   }
 };
 
+struct SynthGambleOpConversion : SynthInverterOpConversion<synth::GambleOp> {
+  using SynthInverterOpConversion<synth::GambleOp>::SynthInverterOpConversion;
+  Value createOp(Location loc, ArrayRef<Value> inputs,
+                 ConversionPatternRewriter &rewriter) const override {
+    assert(inputs.size() == 3 && "expected exactly three inputs");
+    auto width = inputs[0].getType().getIntOrFloatBitWidth();
+    auto allOnes =
+        hw::ConstantOp::create(rewriter, loc, APInt::getAllOnes(width));
+
+    auto allSet = rewriter.createOrFold<comb::AndOp>(
+        loc, ValueRange{inputs[0], inputs[1], inputs[2]}, true);
+
+    auto orVar = rewriter.createOrFold<comb::OrOp>(
+        loc, ValueRange{inputs[0], inputs[1], inputs[2]}, true);
+
+    auto noneSet = rewriter.createOrFold<comb::XorOp>(
+        loc, orVar, allOnes.getResult(), true);
+
+    return rewriter.createOrFold<comb::OrOp>(loc, ValueRange{allSet, noneSet},
+                                             true);
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -199,7 +222,8 @@ static void populateSynthToCombConversionPatterns(RewritePatternSet &patterns) {
   patterns.add<SynthChoiceOpConversion, SynthAndInverterOpConversion,
                SynthXorInverterOpConversion, SynthMuxInverterOpConversion,
                SynthDotOpConversion, SynthMajorityOpConversion,
-               SynthOneHotOpConversion>(patterns.getContext());
+               SynthOneHotOpConversion, SynthGambleOpConversion>(
+      patterns.getContext());
 }
 
 void ConvertSynthToCombPass::runOnOperation() {

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -519,34 +519,6 @@ void DotOp::emitCNFWithoutInversion(
 // MajorityOp
 //===----------------------------------------------------------------------===//
 
-ParseResult MajorityOp::parse(OpAsmParser &parser, OperationState &result) {
-  SmallVector<OpAsmParser::UnresolvedOperand> operands;
-  Type resultType;
-  DenseBoolArrayAttr inverted;
-  NamedAttrList attrs;
-
-  if (parseVariadicInvertibleOperands(parser, operands, resultType, inverted,
-                                      attrs))
-    return failure();
-  if (operands.size() != 3)
-    return parser.emitError(parser.getCurrentLocation())
-           << "expected exactly three operands";
-  if (parser.resolveOperands(operands, resultType, result.operands))
-    return failure();
-
-  result.addTypes(resultType);
-  result.addAttributes(attrs);
-  result.addAttribute("inverted", inverted);
-  return success();
-}
-
-void MajorityOp::print(OpAsmPrinter &printer) {
-  printer << ' ';
-  printVariadicInvertibleOperands(printer, getOperation(), getOperands(),
-                                  getType(), getInvertedAttr(),
-                                  (*this)->getAttrDictionary());
-}
-
 LogicalResult MajorityOp::verify() {
   if (getNumOperands() != 3)
     return emitOpError("requires exactly three operands");
@@ -685,34 +657,6 @@ LogicalResult circt::synth::topologicallySortGraphRegionBlocks(
 // OneHotOp
 //===----------------------------------------------------------------------===//
 
-ParseResult OneHotOp::parse(OpAsmParser &parser, OperationState &result) {
-  SmallVector<OpAsmParser::UnresolvedOperand> operands;
-  Type resultType;
-  DenseBoolArrayAttr inverted;
-  NamedAttrList attrs;
-
-  if (parseVariadicInvertibleOperands(parser, operands, resultType, inverted,
-                                      attrs))
-    return failure();
-  if (operands.size() != 3)
-    return parser.emitError(parser.getCurrentLocation())
-           << "expected exactly three operands";
-  if (parser.resolveOperands(operands, resultType, result.operands))
-    return failure();
-
-  result.addTypes(resultType);
-  result.addAttributes(attrs);
-  result.addAttribute("inverted", inverted);
-  return success();
-}
-
-void OneHotOp::print(OpAsmPrinter &printer) {
-  printer << ' ';
-  printVariadicInvertibleOperands(printer, getOperation(), getOperands(),
-                                  getType(), getInvertedAttr(),
-                                  (*this)->getAttrDictionary());
-}
-
 LogicalResult OneHotOp::verify() {
   if (getNumOperands() != 3)
     return emitOpError("requires exactly three operands");
@@ -827,4 +771,59 @@ void MuxInverterOp::emitCNFWithoutInversion(
   circt::addAndClauses(rhs, {-cond, falseValue}, addClause);
   // out = lhs | rhs
   circt::addOrClauses(outVar, {lhs, rhs}, addClause);
+}
+
+//===----------------------------------------------------------------------===//
+// GambleOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult GambleOp::verify() {
+  if (getNumOperands() != 3)
+    return emitOpError("requires exactly three operands");
+  if (getInverted().size() != 3)
+    return emitOpError("requires exactly three inversion flags");
+  return success();
+}
+
+bool GambleOp::areInputsPermutationInvariant() { return true; }
+
+bool GambleOp::supportsNumInputs(unsigned numInputs) { return numInputs == 3; }
+
+std::optional<uint64_t> GambleOp::getLogicAreaCost() {
+  int64_t bitWidth = hw::getBitWidth(getType());
+  if (bitWidth < 0)
+    return std::nullopt;
+  return static_cast<uint64_t>(bitWidth);
+}
+
+llvm::KnownBits GambleOp::computeKnownBits(
+    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
+  auto a = applyInversion(getInputKnownBits(0), isInverted(0));
+  auto b = applyInversion(getInputKnownBits(1), isInverted(1));
+  auto c = applyInversion(getInputKnownBits(2), isInverted(2));
+  return evaluateGambleLogic(a, b, c);
+}
+
+APInt GambleOp::evaluateBooleanLogicWithoutInversion(
+    llvm::ArrayRef<APInt> inputs) {
+  assert(inputs.size() == 3 && "onehot requires exactly three inputs");
+  return evaluateGambleLogic(inputs[0], inputs[1], inputs[2]);
+}
+
+void GambleOp::emitCNFWithoutInversion(
+    int outVar, llvm::ArrayRef<int> inputVars,
+    llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
+    llvm::function_ref<int()> newVar) {
+  assert(inputVars.size() == 3 && "expected exactly three inputs");
+
+  // allSet = a & b & c
+  int allSet = newVar();
+  circt::addAndClauses(allSet, inputVars, addClause);
+
+  // orSet = a | b | c
+  int orSet = newVar();
+  circt::addOrClauses(orSet, inputVars, addClause);
+
+  // out = allSet | ~orSet
+  circt::addOrClauses(outVar, {allSet, -orSet}, addClause);
 }

--- a/lib/Dialect/Synth/Transforms/CutRewriter.cpp
+++ b/lib/Dialect/Synth/Transforms/CutRewriter.cpp
@@ -209,6 +209,10 @@ LogicalResult LogicNetwork::buildFromBlock(Block *block) {
               return handleInvertibleTernaryGate(oneHotOp,
                                                  LogicNetworkGate::OneHot3);
             })
+            .Case<synth::GambleOp>([&](synth::GambleOp gambleOp) {
+              return handleInvertibleTernaryGate(gambleOp,
+                                                 LogicNetworkGate::Gamble3);
+            })
             .Case<comb::XorOp>([&](comb::XorOp xorOp) {
               if (xorOp->getNumOperands() != 2) {
                 handleOtherResults(xorOp);
@@ -523,6 +527,8 @@ static inline llvm::APInt applyGateSemantics(LogicNetworkGate::Kind kind,
     return evaluateDotLogic(a, b, c);
   case LogicNetworkGate::OneHot3:
     return evaluateOneHotLogic(a, b, c);
+  case LogicNetworkGate::Gamble3:
+    return evaluateGambleLogic(a, b, c);
   default:
     llvm_unreachable(
         "Unsupported ternary operation for truth table computation");
@@ -621,21 +627,10 @@ struct MergedTruthTableBuilder {
           numMergedInputs, 1,
           applyGateSemantics(rootGate.getKind(), getEdgeTT(0), getEdgeTT(1)));
     case LogicNetworkGate::Mux3:
-      return BinaryTruthTable(numMergedInputs, 1,
-                              applyGateSemantics(rootGate.getKind(),
-                                                 getEdgeTT(0), getEdgeTT(1),
-                                                 getEdgeTT(2)));
     case LogicNetworkGate::Maj3:
-      return BinaryTruthTable(numMergedInputs, 1,
-                              applyGateSemantics(rootGate.getKind(),
-                                                 getEdgeTT(0), getEdgeTT(1),
-                                                 getEdgeTT(2)));
     case LogicNetworkGate::Dot3:
-      return BinaryTruthTable(numMergedInputs, 1,
-                              applyGateSemantics(rootGate.getKind(),
-                                                 getEdgeTT(0), getEdgeTT(1),
-                                                 getEdgeTT(2)));
     case LogicNetworkGate::OneHot3:
+    case LogicNetworkGate::Gamble3:
       return BinaryTruthTable(numMergedInputs, 1,
                               applyGateSemantics(rootGate.getKind(),
                                                  getEdgeTT(0), getEdgeTT(1),

--- a/test/Conversion/SynthToComb/synth-to-comb.mlir
+++ b/test/Conversion/SynthToComb/synth-to-comb.mlir
@@ -74,3 +74,14 @@ hw.module @test_mux_inv(in %c: i8, in %a: i8, in %b: i8, out out0: i8) {
   %0 = synth.mux_inv not %c, %a, not %b : i8
   hw.output %0 : i8
 }
+
+// CHECK-LABEL: @test_gamble
+hw.module @test_gamble(in %a: i8, in %b: i8, in %c: i8, out out0: i8) {
+  // CHECK: %c-1_i8 = hw.constant -1 : i8
+  // CHECK: %[[ALL_SET:.+]] = comb.and bin %a, %b, %c : i8
+  // CHECK: %[[OR_SET:.+]] = comb.or bin %a, %b, %c : i8
+  // CHECK: %[[NONE_SET:.+]] = comb.xor bin %[[OR_SET]], %c-1_i8 : i8
+  // CHECK: %[[RESULT:.+]] = comb.or bin %[[ALL_SET]], %[[NONE_SET]] : i8
+  %0 = synth.gamble %a, %b, %c : i8
+  hw.output %0 : i8
+}

--- a/test/Dialect/Synth/lower-word-to-bits.mlir
+++ b/test/Dialect/Synth/lower-word-to-bits.mlir
@@ -114,17 +114,19 @@ func.func @Basic_No_Module(%arg0: i2, %arg1: i2) -> i2 {
 // CHECK-LABEL: hw.module @Other
 // Other operation with BooleanLogicOpInterface
 // Only check that they are lowered.
-hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2, out z: i2, out w: i2, out v: i2) {
+hw.module @Other(in %a: i2, in %b: i2, in %c: i2, out x: i2, out y: i2, out z: i2, out w: i2, out v: i2, out u: i2) {
   %0 = synth.xor_inv %a, not %b, %c : i2
   %1 = synth.dot %a, not %b, %c : i2
   %2 = synth.majority %a, not %b, %c : i2
   %3 = synth.onehot %a, not %b, %c : i2
   %4 = synth.mux_inv %a, not %b, %c : i2
+  %5 = synth.gamble %a, not %b, %c : i2
   // CHECK-COUNT-2: synth.xor_inv %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.dot %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.majority %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.onehot %{{.+}}, not %{{.+}}, %{{.+}} : i1
   // CHECK-COUNT-2: synth.mux_inv %{{.+}}, not %{{.+}}, %{{.+}} : i1
-  hw.output %0, %1, %2, %3, %4 : i2, i2, i2, i2, i2
+  // CHECK-COUNT-2: synth.gamble %{{.+}}, not %{{.+}}, %{{.+}} : i1
+  hw.output %0, %1, %2, %3, %4, %5 : i2, i2, i2, i2, i2, i2
 }
 

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -48,3 +48,9 @@ hw.module @onehot(in %x: i1, in %y: i1, in %z: i1) {
 hw.module @mux_inv(in %c: i4, in %a: i4, in %b: i4) {
   %0 = synth.mux_inv %c, not %a, %b : i4
 }
+
+// CHECK-LABEL: @gamble
+// CHECK-NEXT: %[[R0:.+]] = synth.gamble %x, not %y, %z : i1
+hw.module @gamble(in %x: i1, in %y: i1, in %z: i1) {
+  %0 = synth.gamble %x, not %y, %z : i1
+}

--- a/test/Dialect/Synth/structural_hash.mlir
+++ b/test/Dialect/Synth/structural_hash.mlir
@@ -107,3 +107,13 @@ hw.module @mux_inv_ordered(in %c: i1, in %a: i1, in %b: i1, out o0: i1, out o1: 
   hw.output %0, %1, %2 : i1, i1, i1
 }
 
+// CHECK-LABEL: hw.module @gamble_commutative
+hw.module @gamble_commutative(in %x: i1, in %y: i1, in %z: i1, out o0: i1, out o1: i1) {
+  // gamble is permutation invariant so these should be CSE'd to the same op
+  // CHECK: %[[G0:.+]] = synth.gamble %x, not %y, %z : i1
+  // CHECK-NEXT: hw.output %[[G0]], %[[G0]] : i1, i1
+  %0 = synth.gamble %x, not %y, %z : i1
+  %1 = synth.gamble not %y, %x, %z : i1
+  hw.output %0, %1 : i1, i1
+}
+

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -216,3 +216,16 @@ hw.module @mux_inv_test(in %c : i1, in %a : i1, in %b : i1, out result : i1) {
   %0 = synth.mux_inv %c, %a, %b : i1
   hw.output %0 : i1
 }
+
+hw.module @gamble_lib(in %x : i1, in %y : i1, in %z : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "x", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "y", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "z", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+    %0 = synth.gamble %x, not %y, not %z : i1
+    hw.output %0 : i1
+}
+// CHECK-LABEL: @gamble_test
+hw.module @gamble_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
+    // Permute inputs to test the truth table computation and permutation invariance of the gamble operation.
+    // CHECK-NEXT: %[[GAMBLE:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @gamble_lib(x: %{{.+}}: i1, y: %{{.+}}: i1, z: %{{.+}}: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: hw.output %[[GAMBLE]] : i1
+    %0 = synth.gamble not %z, %x, not %y : i1
+    hw.output %0 : i1
+}


### PR DESCRIPTION
Concerns #10407 

Add synth.gamble, a permutation-invariant 3-input Boolean logic operation implementing the gamble function `(a & b & c) | (~a & ~b & ~c)` with per-input inversion support. The gamble function returns 1 when all inputs are 1 or all inputs are 0, and 0 otherwise. 

The gamble operation corresponds to the "Gamble" NPN input class described in the _Three-Input_ Gates for Logic Synthesis paper (https://si2.epfl.ch/~demichel/publications/archive/2021/3Input.pdf).
