### PR TITLE
[ESI][Runtime] Don't cache gRPC build

### DIFF
--- a/.github/workflows/esiRuntimePublish.yml
+++ b/.github/workflows/esiRuntimePublish.yml
@@ -57,24 +57,6 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install ninja
 
-      - name: Setup vcpkg binary caching (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $vcpkgBinaryCacheDir = "${{ github.workspace }}\vcpkg-binary-cache"
-          New-Item -ItemType Directory -Force -Path $vcpkgBinaryCacheDir
-          echo "VCPKG_BINARY_SOURCES=clear;files,$vcpkgBinaryCacheDir,readwrite" >> $env:GITHUB_ENV
-
-      - name: Cache vcpkg binaries (Windows)
-        if: runner.os == 'Windows'
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}\vcpkg-binary-cache
-          key: vcpkg-${{ runner.os }}-x64-windows-zlib-grpc
-          restore-keys: |
-            vcpkg-${{ runner.os }}-x64-windows-zlib-grpc
-            vcpkg-${{ runner.os }}-x64-windows-
-
       - name: Build additional c++ deps (Windows)
         shell: pwsh
         if: runner.os == 'Windows'


### PR DESCRIPTION
I've never seen this hit in the cache so let's avoid cache pollution.

