### PR TITLE
[ImportVerilog] Fix unpacked string array with a concatenation initialization

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -592,6 +592,37 @@ struct ExprVisitor {
     if (expr.type->isQueue()) {
       return handleQueueConcat(expr);
     }
+
+    if (expr.type->isUnpackedArray()) {
+      assert(!isLvalue && "checked by Slang");
+      auto loweredType = context.convertType(*expr.type, loc);
+      if (!loweredType)
+        return {};
+
+      moore::UnpackedType elementType;
+      if (auto arrayType = dyn_cast<moore::UnpackedArrayType>(loweredType))
+        elementType = arrayType.getElementType();
+      else if (auto openType =
+                   dyn_cast<moore::OpenUnpackedArrayType>(loweredType))
+        elementType = openType.getElementType();
+      else
+        return {};
+
+      SmallVector<Value> operands;
+      for (auto *operand : expr.operands()) {
+        if (operand->type->isVoid())
+          continue;
+        auto value = context.convertRvalueExpression(*operand, elementType);
+        if (!value)
+          return {};
+        operands.push_back(value);
+      }
+
+      auto arrayType = moore::UnpackedArrayType::get(
+          context.getContext(), operands.size(), elementType);
+      return moore::ArrayCreateOp::create(builder, loc, arrayType, operands);
+    }
+
     for (auto *operand : expr.operands()) {
       // Handle empty replications like `{0{...}}` which may occur within
       // concatenations. Slang assigns them a `void` type which we can check for
@@ -2212,6 +2243,19 @@ struct RvalueExprVisitor : public ExprVisitor {
       return moore::ArrayCreateOp::create(builder, loc, arrayType, *elements);
     }
 
+    // Handle open/dynamic unpacked arrays.
+    if (auto openType = dyn_cast<moore::OpenUnpackedArrayType>(type)) {
+      auto elements =
+          convertElements(expr, openType.getElementType(), replCount);
+
+      if (failed(elements))
+        return {};
+
+      auto arrayType = moore::UnpackedArrayType::get(
+          context.getContext(), elements->size(), openType.getElementType());
+      return moore::ArrayCreateOp::create(builder, loc, arrayType, *elements);
+    }
+
     mlir::emitError(loc) << "unsupported assignment pattern with type " << type;
     return {};
   }
@@ -2717,6 +2761,26 @@ Value Context::materializeFixedSizeUnpackedArrayType(
   auto type = convertType(astType);
   if (!type)
     return {};
+
+  // Handle string array constants.
+  if (astType.elementType.isString()) {
+    auto arrayType = dyn_cast<moore::UnpackedArrayType>(type);
+    if (!arrayType)
+      return {};
+
+    SmallVector<Value> elemVals;
+    for (const auto &elem : constant.elements()) {
+      if (!elem.isString())
+        return {};
+      auto value = materializeString(elem, astType.elementType, loc);
+      if (!value)
+        return {};
+      elemVals.push_back(value);
+    }
+    if (elemVals.size() != arrayType.getSize())
+      return {};
+    return moore::ArrayCreateOp::create(builder, loc, arrayType, elemVals);
+  }
 
   // Check whether underlying type is an integer, if so, get bit width
   unsigned bitWidth;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -778,6 +778,16 @@ module Expressions;
   // CHECK: [[CONV_CONCAT:%.+]] = moore.int_to_string [[STR_CONCAT]] : i48
   // CHECK: [[VAR_SCON:%.+]] = moore.variable [[CONV_CONCAT]] : <string>
   string concatstr = "Concat";
+  // CHECK: [[STR0:%.+]] = moore.constant_string "hello" : i40
+  // CHECK: [[INT_TO_STR0:%.+]] = moore.int_to_string [[STR0]] : i40
+  // CHECK: [[STR1:%.+]] = moore.constant_string "sad" : i24
+  // CHECK: [[INT_TO_STR1:%.+]] = moore.int_to_string [[STR1]] : i24
+  // CHECK: [[STR2:%.+]] = moore.constant_string "world" : i40
+  // CHECK: [[INT_TO_STR2:%.+]] = moore.int_to_string [[STR2]] : i40
+  // CHECK: [[ARR_CREATE:%.+]] = moore.array_create [[INT_TO_STR0]], [[INT_TO_STR1]], [[INT_TO_STR2]] : !moore.string, !moore.string, !moore.string -> uarray<3 x string>
+  // CHECK: [[STRARR_CONV:%.+]] = moore.conversion [[ARR_CREATE]] : !moore.uarray<3 x string> -> !moore.open_uarray<string>
+  // CHECK: %strArr = moore.variable [[STRARR_CONV]] : <open_uarray<string>>
+  string strArr[] = { "hello", "sad", "world" };
 
   initial begin
     // CHECK: moore.constant 0 : i32


### PR DESCRIPTION
Slang handles `string s[] = { "a", "b" }` as a `ConcatenationExpression` with an `unpacked array type`. `ImportVerilog` only special-cased `string` and `queue` concats and otherwise forced operands through `convertToSimpleBitVector()`, which fails for `!moore.string`. Handle `unpacked array concats` via `array_create`, extend assignment patterns for `open_uarray`, and materialize string array constants.

Assisted-by: cursor: GPT-5.5