### PR TITLE
[MooreToCore] Convert operands of arith SelectOp

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -3153,7 +3153,7 @@ static void populateLegality(ConversionTarget &target,
   target.addDynamicallyLegalOp<scf::YieldOp, func::CallOp, func::ReturnOp,
                                UnrealizedConversionCastOp, hw::OutputOp,
                                hw::InstanceOp, debug::ArrayOp, debug::StructOp,
-                               debug::VariableOp>(
+                               debug::VariableOp, arith::SelectOp>(
       [&](Operation *op) { return converter.isLegal(op); });
 
   target.addDynamicallyLegalOp<scf::IfOp, scf::ForOp, scf::ExecuteRegionOp,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1834,3 +1834,10 @@ func.func @FClose(%arg0: !moore.i32) {
   moore.builtin.fclose %arg0
   return
 }
+
+// CHECK-LABEL: hw.module @MooreTypedArithSelect
+moore.module @MooreTypedArithSelect(in %s: i1, in %a: !moore.i8, in %b: !moore.i8, out o: !moore.i8) {
+  // CHECK-NOT: !moore.i8
+  %sel = arith.select %s, %a, %b : !moore.i8
+  moore.output %sel : !moore.i8
+}


### PR DESCRIPTION
Add `arith.select` to the list of dynamically legal operations, depending on the legality of their value types.

This fixes a bug in circt-verilog where values with Moore types are missed by the lowering when the SimplifyCondBranchIdenticalSuccessors canonicalization pattern of the ControlFlow dialect introduces SelectOps before MooreToCore.

H/t @fzi-haxel for figuring this out.