### PR TITLE
[FIRRTL] Fix leaf handling in LowerClasses

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -794,12 +794,6 @@ LogicalResult LowerClassesPass::processPaths(
         continue;
       }
 
-      // If we are at a leaf, nothing to do.
-      if (it->begin() == it->end()) {
-        ++it;
-        continue;
-      }
-
       // Track state for this passthrough.
       StringAttr passthroughModule = it->getModule().getModuleNameAttr();
       pathInfoTable.addAltBasePathPassthrough(passthroughModule, rootModule);

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -787,3 +787,25 @@ firrtl.circuit "NoPropPorts" {
     firrtl.property_assert %2, "srcs must match" : !firrtl.bool
   }
 }
+
+// Ensure that trivial leaves with paths work.
+//
+// See: https://github.com/llvm/circt/issues/10510
+//
+// CHECK-LABEL: firrtl.circuit "PathOpInLeafModule"
+firrtl.circuit "PathOpInLeafModule" {
+  // CHECK: om.class @Bar_Class(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
+  // CHECK:   %0 = om.path_create reference %alt_basepath_0 {{@.+}}
+  firrtl.module @Bar() {
+    %0 = firrtl.path reference distinct[0]<>
+  }
+
+  firrtl.module @PathOpInLeafModule() {
+    firrtl.instance bar @Bar()
+    %a = firrtl.wire {
+      annotations = [
+        {class = "circt.tracker", id = distinct[0]<>}
+      ]
+    } : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
Fix a bug in the `LowerClasses` FIRRTL pass where if a leaf module (one
which instantiated no others) included a path that had an upwards
reference, that the pass would assert out indicating that this was not a
"passthrough" module and could not create an "alternative" base path.

Fixes #10510.

Assisted-by: pi.dev:claude-opus-4-7
