### PR TITLE
[Arc] Removed unused `isAlways` function, NFC

### DIFF
--- a/lib/Dialect/Arc/ArcFolds.cpp
+++ b/lib/Dialect/Arc/ArcFolds.cpp
@@ -25,16 +25,6 @@ static bool isAlways(Attribute attr, bool expected) {
   return false;
 }
 
-static bool isAlways(Value value, bool expected) {
-  if (!value)
-    return false;
-
-  if (auto constOp = value.getDefiningOp<hw::ConstantOp>())
-    return constOp.getValue().getBoolValue() == expected;
-
-  return false;
-}
-
 //===----------------------------------------------------------------------===//
 // StateOp
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Fixes another compile-time warning.

All users of the helper have been removed in #10411.