### PR TITLE
[ESI][Runtime] Fixes for `void` DMA transfers

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
@@ -257,7 +257,6 @@ bool OneItemBuffersToHostReadPort::pollImpl() {
   // If it has, copy the data out and retain it until the consumer accepts it.
   pendingMessage = std::make_unique<MessageData>(bufferData, bufferSize - 1);
   return tryDeliverPending();
-  return tryDeliverPending();
 }
 
 REGISTER_ENGINE("OneItemBuffersToHost", OneItemBuffersToHost);

--- a/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
@@ -77,7 +77,13 @@ public:
                                AppIDPath idPath, const std::string &channelName)
       : ReadChannelPort(type), engine(engine), idPath(idPath),
         channelName(channelName) {
-    bufferSize = (type->getBitWidth() / 8) + 1;
+    // Use ceiling division so sub-byte types (e.g. SInt<4>) get at least 1
+    // byte of data space, matching the byte-aligned padding applied in the
+    // PyCDE DMA hardware (OneItemBuffersToHost pads client_data).
+    // +1 for the valid flag byte at the end of the buffer.
+    bufferSize =
+        utils::bitsToBytes(std::max(type->getBitWidth(), std::ptrdiff_t{8})) +
+        1;
   }
 
   // Write the location of the buffer to the MMIO space.
@@ -250,6 +256,7 @@ bool OneItemBuffersToHostReadPort::pollImpl() {
 
   // If it has, copy the data out and retain it until the consumer accepts it.
   pendingMessage = std::make_unique<MessageData>(bufferData, bufferSize - 1);
+  return tryDeliverPending();
   return tryDeliverPending();
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -508,15 +508,14 @@ public:
     // send a single response.
     uint64_t *dataPtr = reinterpret_cast<uint64_t *>(req->address);
     uint32_t numDataResps = (req->length + 7) / 8;
-    if (numDataResps == 0) {
+    if (numDataResps == 0)
       acc.getLogger().error(
           "hostmem",
           std::format("Read request with length=0 from addr=0x{} tag={}. "
                       "Reads of length 0 are not valid and indicate a bug "
                       "in the requester.",
                       toHex(req->address), req->tag));
-    }
-    uint32_t numResps = std::max(numDataResps, 1u);
+    uint32_t numResps = std::max(numDataResps, 1);
     for (uint32_t i = 0; i < numResps; ++i) {
       HostMemReadResp resp{.data = i < numDataResps ? dataPtr[i] : 0,
                            .tag = req->tag};

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -515,7 +515,7 @@ public:
                       "Reads of length 0 are not valid and indicate a bug "
                       "in the requester.",
                       toHex(req->address), req->tag));
-    uint32_t numResps = std::max(numDataResps, 1);
+    uint32_t numResps = std::max(numDataResps, 1u);
     for (uint32_t i = 0; i < numResps; ++i) {
       HostMemReadResp resp{.data = i < numDataResps ? dataPtr[i] : 0,
                            .tag = req->tag};

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -21,6 +21,7 @@
 #include "esi/backends/RpcClient.h"
 
 #include <cstring>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <set>
@@ -502,10 +503,23 @@ public:
                 " len=" + std::to_string(req->length) +
                 " tag=" + std::to_string(req->tag);
         });
-    // Send one response per 8 bytes.
+    // Send one response per 8 bytes. Zero-length reads (e.g. void / zero-width
+    // types) indicates a bug in the hardware and we log an error, but we still
+    // send a single response.
     uint64_t *dataPtr = reinterpret_cast<uint64_t *>(req->address);
-    for (uint32_t i = 0, e = (req->length + 7) / 8; i < e; ++i) {
-      HostMemReadResp resp{.data = dataPtr[i], .tag = req->tag};
+    uint32_t numDataResps = (req->length + 7) / 8;
+    if (numDataResps == 0) {
+      acc.getLogger().error(
+          "hostmem",
+          std::format("Read request with length=0 from addr=0x{} tag={}. "
+                      "Reads of length 0 are not valid and indicate a bug "
+                      "in the requester.",
+                      toHex(req->address), req->tag));
+    }
+    uint32_t numResps = std::max(numDataResps, 1u);
+    for (uint32_t i = 0; i < numResps; ++i) {
+      HostMemReadResp resp{.data = i < numDataResps ? dataPtr[i] : 0,
+                           .tag = req->tag};
       acc.getLogger().trace(
           [&](std::string &subsystem, std::string &msg,
               std::unique_ptr<std::map<std::string, std::any>> &details) {

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -241,6 +241,9 @@ private:
                                getType()->getID());
 
     std::ptrdiff_t size = (numBits + 7) / 8;
+    // Zero-width types need a 1-byte placeholder.
+    if (size == 0)
+      return MessageData({0});
     std::vector<uint8_t> bytes(size);
     for (std::ptrdiff_t i = 0; i < size; ++i)
       bytes[i] = rand() % 256;

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -321,7 +321,7 @@ class ChannelMMIO(esi.ServiceImplementation):
   relatively easy to adapt to physical interfaces by wrapping the wires to
   channels then bundles. Allows the implementation to be shared and (hopefully)
   platform independent.
-  
+
   Whether or not to support unaligned accesses is up to the clients. The header
   and manifest do not support unaligned accesses and throw away the lower three
   bits.
@@ -739,7 +739,6 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
             c.channel for c in client.type.channels if c.name == 'resp'
         ][0]
         demuxed_upstream_channel = demux.get_out(idx)
-
 
         # TODO: Should responses come back out-of-order (interleaved tags),
         # re-order them here so the gearbox doesn't get confused. (Longer term.)

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -740,6 +740,7 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
         ][0]
         demuxed_upstream_channel = demux.get_out(idx)
 
+
         # TODO: Should responses come back out-of-order (interleaved tags),
         # re-order them here so the gearbox doesn't get confused. (Longer term.)
         # For now, only support one outstanding transaction at a time.  This has
@@ -748,6 +749,10 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
 
         # Gearbox the data to the client's data type.
         client_type = resp_type.inner_type
+        if client_type.data.bitwidth == 0:
+          raise ValueError("Client data type cannot be zero-width. Use a "
+                           "single-bit type if no data is needed.")
+
         gearbox = TaggedReadGearbox(read_width, client_type.data.bitwidth)(
             clk=ports.clk, rst=ports.rst, in_=demuxed_upstream_channel)
         client_resp_channel = gearbox.out.transform(lambda m: client_type({
@@ -1208,16 +1213,27 @@ def ChannelEngineService(
       def build_engine(bc: BundledChannel, input_channel=None) -> Type:
         idbase = build_engine_appid(bundle.client_name, bc.name)
         eng_appid = esi.AppID(idbase)
+        # DMA engines require at least 1 byte of data; substitute Bits(8)
+        # for zero-width (void) channel types so the engine never sees a
+        # zero-length transfer.
+        engine_client_type = bc.channel.inner_type
+        is_void = (engine_client_type.bitwidth == 0)
+        if is_void:
+          engine_client_type = Bits(8)
         if bc.direction == ChannelDirection.FROM:
-          engine_mod = to_host_engine_gen(bc.channel.inner_type)
+          engine_mod = to_host_engine_gen(engine_client_type)
         else:
-          engine_mod = from_host_engine_gen(bc.channel.inner_type)
+          engine_mod = from_host_engine_gen(engine_client_type)
         eng_inputs = {
             "clk": ports.clk,
             "rst": ports.rst,
         }
         eng_details: Dict[str, object] = {"engine_inst": eng_appid}
         if input_channel is not None:
+          # For void channels, widen the 0-bit input to the 8-bit
+          # placeholder the engine expects.
+          if is_void:
+            input_channel = input_channel.transform(lambda _: Bits(8)(0))
           if (engine_mod.input_channel.type.signaling
               != input_channel.type.signaling):
             input_channel = input_channel.buffer(
@@ -1249,7 +1265,11 @@ def ChannelEngineService(
         for bc in bundle_type.channels:
           if bc.direction == ChannelDirection.TO:
             engine = build_engine(bc)
-            to_channels[bc.name] = engine.output_channel
+            out_chan = engine.output_channel
+            # For void channels, narrow the 8-bit placeholder back to 0-bit.
+            if bc.channel.inner_type.bitwidth == 0:
+              out_chan = out_chan.transform(lambda _: Bits(0)(0))
+            to_channels[bc.name] = out_chan
 
         client_bundle_sig, froms = bundle_type.pack(**to_channels)
         bundle.assign(client_bundle_sig)

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/dma.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/dma.py
@@ -41,14 +41,15 @@ def OneItemBuffersToHost(client_type: Type):
     # Compute the byte-aligned width of client_data. The DMA protocol
     # requires the valid flag to be the last byte of the transfer, which
     # only works when client_data is byte-aligned.
-    _client_bits = client_type.bitwidth
-    _padded_bits = ((_client_bits + 7) // 8) * 8
-    _needs_pad = (_padded_bits != _client_bits)
+    client_data_bitwidth = client_type.bitwidth
+    client_data_padded_bits = ((client_data_bitwidth + 7) // 8) * 8
+    client_data_needs_pad = (client_data_padded_bits != client_data_bitwidth)
     # When padding is needed, widen client_data to Bits so the struct is
     # byte-aligned.  Otherwise keep the original type.
-    _wire_client_type = Bits(_padded_bits) if _needs_pad else client_type
+    client_data_wire_type = Bits(
+        client_data_padded_bits) if client_data_needs_pad else client_type
     xfer_data_type = StructType([("valid", Bits(8)),
-                                 ("client_data", _wire_client_type)])
+                                 ("client_data", client_data_wire_type)])
     hostmem_write = Input(esi.HostMem.write_req_bundle_type(xfer_data_type))
 
     @generator
@@ -99,16 +100,15 @@ def OneItemBuffersToHost(client_type: Type):
       hostwr_type = esi.HostMem.write_req_channel_type(
           OneItemBuffersToHost.xfer_data_type)
       hostwr_joined = Channel.join(next_buffer_loc_chan, ports.input_channel)
-      _np = OneItemBuffersToHost._needs_pad
-      _pb = OneItemBuffersToHost._padded_bits
-      _cb = OneItemBuffersToHost._client_bits
 
       def _pad_client_data(raw):
         """Widen the client data to byte-aligned Bits for the DMA struct."""
-        if not _np:
+        if not OneItemBuffersToHost.client_data_needs_pad:
           return raw
         # bitcast to Bits of original width, then zero-extend.
-        return raw.bitcast(Bits(_cb)).pad_or_truncate(_pb)
+        return raw.bitcast(Bits(
+            OneItemBuffersToHost.client_data_bitwidth)).pad_or_truncate(
+                OneItemBuffersToHost.client_data_padded_bits)
 
       hostwr = hostwr_joined.transform(lambda joined: hostwr_type({
           "address": joined.a.as_uint(),

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/dma.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/dma.py
@@ -38,8 +38,17 @@ def OneItemBuffersToHost(client_type: Type):
     # compiler), the module (usually a service implementation) must issue the
     # service requests for us then connect the input ports.
     mmio = Input(esi.MMIO.read_write.type)
+    # Compute the byte-aligned width of client_data. The DMA protocol
+    # requires the valid flag to be the last byte of the transfer, which
+    # only works when client_data is byte-aligned.
+    _client_bits = client_type.bitwidth
+    _padded_bits = ((_client_bits + 7) // 8) * 8
+    _needs_pad = (_padded_bits != _client_bits)
+    # When padding is needed, widen client_data to Bits so the struct is
+    # byte-aligned.  Otherwise keep the original type.
+    _wire_client_type = Bits(_padded_bits) if _needs_pad else client_type
     xfer_data_type = StructType([("valid", Bits(8)),
-                                 ("client_data", client_type)])
+                                 ("client_data", _wire_client_type)])
     hostmem_write = Input(esi.HostMem.write_req_bundle_type(xfer_data_type))
 
     @generator
@@ -90,12 +99,23 @@ def OneItemBuffersToHost(client_type: Type):
       hostwr_type = esi.HostMem.write_req_channel_type(
           OneItemBuffersToHost.xfer_data_type)
       hostwr_joined = Channel.join(next_buffer_loc_chan, ports.input_channel)
+      _np = OneItemBuffersToHost._needs_pad
+      _pb = OneItemBuffersToHost._padded_bits
+      _cb = OneItemBuffersToHost._client_bits
+
+      def _pad_client_data(raw):
+        """Widen the client data to byte-aligned Bits for the DMA struct."""
+        if not _np:
+          return raw
+        # bitcast to Bits of original width, then zero-extend.
+        return raw.bitcast(Bits(_cb)).pad_or_truncate(_pb)
+
       hostwr = hostwr_joined.transform(lambda joined: hostwr_type({
           "address": joined.a.as_uint(),
           "tag": 0,
           "data": {
               "valid": 1,
-              "client_data": joined.b
+              "client_data": _pad_client_data(joined.b)
           },
       }))
       ports.hostmem_write.unpack(req=hostwr)

--- a/lib/Dialect/ESI/runtime/tests/integration/test_codegen_cpp.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_codegen_cpp.py
@@ -8,98 +8,67 @@ suite exercises the *port-kind* surface area of the ESI runtime + facade
 codegen end-to-end. It builds the C++ driver under ``sw/test_codegen.cpp``
 against generated ESI facade headers and runs each probe individually
 against a cosim-driven instance of ``hw/test_codegen.py``.
+
+Two test classes are generated — one for the default ``cosim`` BSP and one
+for ``cosim_dma`` — so every probe is exercised through both channel
+transport paths.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from esiaccel.cosim.pytest import cosim_test
 
 from .conftest import HW_DIR, build_cpp_test, run_probe
+
+PROBES = [
+    "typed_func_multi_arg",
+    "typed_func_void_arg",
+    "typed_func_void_result",
+    "call_service_callback",
+    "typed_read_channel_struct",
+    "typed_write_channel_byte",
+    "mmio_read_write",
+    "telemetry_metric",
+    "indexed_func_group",
+    "custom_service_decl_channel_0",
+    "custom_service_decl_channel_1",
+    "typed_func_struct",
+    "typed_func_nested_struct",
+    "typed_func_subbyte_signed",
+    "typed_func_array_result",
+    "typed_func_windowed_list",
+    "channel_windowed_list_read",
+    "channel_windowed_list_write",
+    "callback_windowed_list",
+]
 
 
 def _build(sources_dir: Path) -> Path:
   return build_cpp_test(sources_dir, "test_codegen_test", "test_codegen")
 
 
-@cosim_test(HW_DIR / "test_codegen.py")
-class TestCodegen:
-  """One pytest method per probe; each gets its own cosim simulator process
-  but shares the (cached) build of ``test_codegen_test``."""
+def _make_probe_test(probe: str):
+  """Create a test method that runs a single probe."""
 
-  def test_typed_func_multi_arg(self, host: str, port: int,
-                                sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_func_multi_arg")
+  def test_method(self, host: str, port: int, sources_dir: Path) -> None:
+    run_probe(_build(sources_dir), host, port, probe)
 
-  def test_typed_func_void_arg(self, host: str, port: int,
-                               sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_func_void_arg")
+  test_method.__name__ = f"test_{probe}"
+  test_method.__qualname__ = f"<dynamic>.test_{probe}"
+  return test_method
 
-  def test_typed_func_void_result(self, host: str, port: int,
-                                  sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_func_void_result")
 
-  def test_call_service_callback(self, host: str, port: int,
-                                 sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "call_service_callback")
+def _make_codegen_class(name: str, bsp_args):
+  """Build a test class with one method per probe, decorated with cosim_test."""
+  ns = {f"test_{p}": _make_probe_test(p) for p in PROBES}
+  cls = type(name, (), ns)
+  return cosim_test(HW_DIR / "test_codegen.py", args=bsp_args)(cls)
 
-  def test_typed_read_channel_struct(self, host: str, port: int,
-                                     sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_read_channel_struct")
 
-  def test_typed_write_channel_byte(self, host: str, port: int,
-                                    sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_write_channel_byte")
-
-  def test_mmio_read_write(self, host: str, port: int,
-                           sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "mmio_read_write")
-
-  def test_telemetry_metric(self, host: str, port: int,
-                            sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "telemetry_metric")
-
-  def test_indexed_func_group(self, host: str, port: int,
-                              sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "indexed_func_group")
-
-  def test_custom_service_decl_channel_0(self, host: str, port: int,
-                                         sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "custom_service_decl_channel_0")
-
-  def test_custom_service_decl_channel_1(self, host: str, port: int,
-                                         sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "custom_service_decl_channel_1")
-
-  def test_typed_func_struct(self, host: str, port: int,
-                             sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_func_struct")
-
-  def test_typed_func_nested_struct(self, host: str, port: int,
-                                    sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_func_nested_struct")
-
-  def test_typed_func_subbyte_signed(self, host: str, port: int,
-                                     sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_func_subbyte_signed")
-
-  def test_typed_func_array_result(self, host: str, port: int,
-                                   sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_func_array_result")
-
-  def test_typed_func_windowed_list(self, host: str, port: int,
-                                    sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "typed_func_windowed_list")
-
-  def test_channel_windowed_list_read(self, host: str, port: int,
-                                      sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "channel_windowed_list_read")
-
-  def test_channel_windowed_list_write(self, host: str, port: int,
-                                       sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "channel_windowed_list_write")
-
-  def test_callback_windowed_list(self, host: str, port: int,
-                                  sources_dir: Path) -> None:
-    run_probe(_build(sources_dir), host, port, "callback_windowed_list")
+TestCodegen = _make_codegen_class("TestCodegen", ("{tmp_dir}",))
+TestCodegenDma = _make_codegen_class("TestCodegenDma",
+                                     ("{tmp_dir}", "cosim_dma"))


### PR DESCRIPTION
It does not make sense for a DMA engine to transport `void` data since there's nothing to transport aside from 'valid' counts. Move the `i1` hack into the DMA engine instantiation site to reflect the same decision on the runtime side. Since zero bits is an edge case, this means that DMA engines don't have to reason about it.

Also fix some related bugs.

Assisted-by: vscode:Claude Opus 4.6

