### PR TITLE
[FIRRTL] Create minimal alt paths LowerClasses

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -29,7 +29,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 
 namespace circt {
@@ -131,8 +131,9 @@ struct PathInfoTable {
     }
   }
 
-  // The table mapping DistinctAttrs to PathInfo structs.
-  DenseMap<DistinctAttr, PathInfo> table;
+  // The table mapping DistinctAttrs to PathInfo structs.  This will be iterated
+  // over, so ensure stability.
+  llvm::MapVector<DistinctAttr, PathInfo> table;
 
 private:
   // Module name attributes indicating modules whose base path input should
@@ -737,9 +738,18 @@ LogicalResult LowerClassesPass::processPaths(
     PathInfoTable &pathInfoTable, SymbolTable &symbolTable) {
   auto circuit = getOperation();
 
-  // Collect the path declarations and owning modules.
+  // Collect the path declarations, owning modules, and containing modules.  An
+  // owning module is the lowest `FModuleOp` ancestor of a path.  This can be
+  // null if there are multiple lowest ancestors.  The containing module is the
+  // exact `FModuleLike` op that is the parent op of the path.  This may be a
+  // class op.
+  //
+  // Store one path op for each containing module, purely for diagnostic
+  // purposes if we need to generate an error.
   OwningModuleCache owningModuleCache(instanceGraph);
   DenseMap<DistinctAttr, FModuleOp> owningModules;
+  DenseMap<DistinctAttr, StringAttr> containingModules;
+  DenseMap<StringAttr, PathOp> containingModuleToPathOp;
   std::vector<Operation *> declarations;
   auto result = circuit.walk([&](Operation *op) {
     if (auto pathOp = dyn_cast<PathOp>(op)) {
@@ -761,6 +771,13 @@ LogicalResult LowerClassesPass::processPaths(
             << owningModule.getModuleNameAttr();
         return WalkResult::interrupt();
       }
+      // Record the FModuleLike that physically contains this path op.
+      auto container = pathOp->getParentOfType<FModuleLike>();
+      assert(container && "path op with a non-null owning module must be "
+                          "inside an FModuleLike");
+      auto containerName = container.getModuleNameAttr();
+      containingModules.try_emplace(target, containerName);
+      containingModuleToPathOp.try_emplace(containerName, pathOp);
     }
     return WalkResult::advance();
   });
@@ -772,44 +789,149 @@ LogicalResult LowerClassesPass::processPaths(
                               pathInfoTable, symbolTable, owningModules)))
     return failure();
 
-  // For each module that will be passing through a base path, compute its
-  // descendants that need this base path passed through.
-  for (auto rootModule : pathInfoTable.getAltBasePathRoots()) {
-    InstanceGraphNode *node = instanceGraph.lookup(rootModule);
+  // ---------------------------------------------------------------------------
+  // Update FModuleLikes with alt base passthrough information.  The end result
+  // of this is that every path from every alt base path root to the path op
+  // user gets marked for a new port.
+  //
+  // For each alt base path root, R, do a DFS to determine the descendant
+  // modules that it instantiates.  Then, do a reverse DFS from the containing
+  // FModuleLike for each path op P, only visiting descendants of R.
+  //
+  // There are two main error cases to consider:
+  //
+  //   1. a path is unreachable from its root,
+  //   2. a module along the path from a path to a root is instantiated by any
+  //      module that is unreachable from the root.
+  //
+  // As an example, the following shows both of these errors cases. R1 and R2
+  // are roots in module A.  P1 is a path in module C referencing R1.  P2 is a
+  // path in module D referencing R2.  The instantiation of module C by X and B
+  // by Y are both illegal by case (2).  Module D is illegal by case (1).
+  //
+  //                      X <-+
+  //                           \
+  //     A { R1, R2 } <-- B <-- C { P1(R1) }
+  //                     /
+  //                Y <-+
+  //
+  //                            D { P2(R2) }
+  //
+  // See `lower-classes-errors.mlir` for the circuit above.
+  // ---------------------------------------------------------------------------
+  // Step 1: Populate a map of R -> [P].
+  llvm::MapVector<StringAttr, SetVector<StringAttr>> rootToContainingMods;
+  for (const auto &[distinctAttr, pathInfo] : pathInfoTable.table) {
+    if (!pathInfo.altBasePathModule)
+      continue;
+    auto it = containingModules.find(distinctAttr);
+    assert(it != containingModules.end() &&
+           "path info entry with non-null altBasePathModule must have a "
+           "recorded containing FModuleLike");
+    rootToContainingMods[pathInfo.altBasePathModule].insert(it->second);
+  }
 
-    // Do a depth first traversal of the instance graph from rootModule,
-    // looking for descendants that need to be passed through.
-    auto start = llvm::df_begin(node);
-    auto end = llvm::df_end(node);
-    auto it = start;
-    while (it != end) {
-      // Nothing to do for the root module.
-      if (it == start) {
-        ++it;
+  // Step 2: Mark all paths for each (R, P) pair.  Accumulate errors.
+  InstancePathCache instancePathCache(instanceGraph);
+  bool failed = false;
+  for (auto &[altRoot, containingMods] : rootToContainingMods) {
+    InstanceGraphNode *rootNode = instanceGraph.lookup(altRoot);
+
+    // Step 2.a: For each P, use InstancePathCache to get all paths from R down
+    // to P.  An empty result means P is not reachable from R (error case 1).
+    // Collect the set of all InstanceGraphNodes that appear on any path.
+    SetVector<InstanceGraphNode *> markedNodes;
+    markedNodes.insert(rootNode);
+    // Track one reachable containing module to use as error attribution for
+    // case (2).  Any reachable P will do.
+    PathOp reachablePathOp;
+    for (StringAttr start : containingMods) {
+      auto startMod = instanceGraph.lookup(start)->getModule<FModuleLike>();
+      auto paths = instancePathCache.getRelativePaths(startMod, rootNode);
+
+      // Report error case (1): P is not reachable from R.
+      if (paths.empty()) {
+        PathOp pathOp = containingModuleToPathOp.lookup(start);
+        assert(pathOp && "every containing module name recorded in "
+                         "rootToContainingMods must have a representative "
+                         "path op");
+        auto diag = pathOp->emitOpError()
+                    << "in module " << start
+                    << " cannot be lowered because the module is not reachable "
+                       "from module "
+                    << altRoot << " which contains the target";
+        auto *pathInfoIt = pathInfoTable.table.find(pathOp.getTargetAttr());
+        assert(pathInfoIt != pathInfoTable.table.end() &&
+               pathInfoIt->second.loc.has_value() &&
+               "a path op being processed here must have a PathInfo entry "
+               "with a recorded tracked-op location");
+        diag.attachNote(pathInfoIt->second.loc.value())
+            << "path targets this operation in module " << altRoot;
+        failed = true;
         continue;
       }
 
-      // If we aren't creating a class for this child, skip this hierarchy.
-      if (!shouldCreateClass(it->getModule())) {
-        it = it.skipChildren();
-        continue;
+      // Record this as a reachable P for use in case (2) error attribution.
+      if (!reachablePathOp)
+        reachablePathOp = containingModuleToPathOp.lookup(start);
+
+      // Collect every module that appears on any path from R to P into
+      // markedNodes, and mark each for alt base path passthrough.
+      InstanceGraphNode *startNode = instanceGraph.lookup(start);
+      if (markedNodes.insert(startNode))
+        pathInfoTable.addAltBasePathPassthrough(
+            startNode->getModule().getModuleNameAttr(), altRoot);
+      for (auto path : paths) {
+        for (auto inst : path) {
+          auto *node = instanceGraph.lookup(
+              inst->getParentOfType<FModuleLike>().getModuleNameAttr());
+          if (markedNodes.insert(node))
+            pathInfoTable.addAltBasePathPassthrough(
+                node->getModule().getModuleNameAttr(), altRoot);
+        }
       }
+    }
 
-      // If we are at a leaf, nothing to do.
-      if (it->begin() == it->end()) {
-        ++it;
+    // Step 2.b: Check error case (2): walk every marked node and report any
+    // use whose parent is outside the marked set.
+    if (!reachablePathOp)
+      continue;
+    auto *pathInfoIt =
+        pathInfoTable.table.find(reachablePathOp.getTargetAttr());
+    assert(pathInfoIt != pathInfoTable.table.end() &&
+           pathInfoIt->second.loc.has_value() &&
+           "a path op being processed here must have a PathInfo entry "
+           "with a recorded tracked-op location");
+    StringAttr containing =
+        reachablePathOp->getParentOfType<FModuleLike>().getModuleNameAttr();
+    for (InstanceGraphNode *node : markedNodes) {
+      if (node == rootNode)
         continue;
+      for (InstanceRecord *use : node->uses()) {
+        if (markedNodes.contains(use->getParent()))
+          continue;
+        auto diag = reachablePathOp->emitOpError()
+                    << "in module " << containing
+                    << " cannot be lowered because there is an instantiation "
+                       "of module "
+                    << use->getTarget()->getModule().getModuleNameAttr()
+                    << " in module "
+                    << use->getParent()->getModule().getModuleNameAttr()
+                    << " which is not instantiated by module " << altRoot
+                    << " which contains the target";
+        diag.attachNote(pathInfoIt->second.loc.value())
+            << "the path op targets this operation in module " << altRoot;
+        diag.attachNote(use->getInstance()->getLoc())
+            << "the problematic instantiation of module "
+            << use->getTarget()->getModule().getModuleNameAttr()
+            << " in module "
+            << use->getParent()->getModule().getModuleNameAttr() << " is here";
+        failed = true;
       }
-
-      // Track state for this passthrough.
-      StringAttr passthroughModule = it->getModule().getModuleNameAttr();
-      pathInfoTable.addAltBasePathPassthrough(passthroughModule, rootModule);
-
-      ++it;
     }
   }
 
-  return success();
+  return failure(failed);
 }
 
 /// Lower FIRRTL Class and Object ops to OM Class and Object ops

--- a/test/Dialect/FIRRTL/lower-classes-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-classes-errors.mlir
@@ -91,3 +91,50 @@ firrtl.circuit "DontCrashOnUnassignedWire" {
     %wire = firrtl.wire : !firrtl.integer
   }
 }
+
+// -----
+
+// Cleanly error if a module containing a path op is instantiated outside of the
+// hierarchy of the module containing the path target.  This should report for
+// each path.
+//
+// This matches a documentation comment in `LowerClasses.cpp` which should be
+// kept synchronized with this.
+//
+// See: https://github.com/llvm/circt/issues/10505
+firrtl.circuit "AltBasePathStrandedInstance" {
+  firrtl.module private @D() {
+    // expected-error @below {{'firrtl.path' op in module "D" cannot be lowered because the module is not reachable from module "AltBasePathStrandedInstance" which contains the target}}
+    %P2 = firrtl.path reference distinct[1]<>
+  }
+  firrtl.module private @C() {
+    // expected-error @below {{'firrtl.path' op in module "C" cannot be lowered because there is an instantiation of module "B" in module "Y" which is not instantiated by module "AltBasePathStrandedInstance" which contains the target}}
+    // expected-error @below {{'firrtl.path' op in module "C" cannot be lowered because there is an instantiation of module "C" in module "X" which is not instantiated by module "AltBasePathStrandedInstance" which contains the target}}
+    %P1 = firrtl.path reference distinct[0]<>
+  }
+  firrtl.module private @X() {
+    // expected-note @below {{the problematic instantiation of module "C" in module "X" is here}}
+    firrtl.instance c @C()
+  }
+  firrtl.module private @B() {
+    firrtl.instance c @C()
+  }
+  firrtl.module private @Y() {
+    // expected-note @below {{the problematic instantiation of module "B" in module "Y" is here}}
+    firrtl.instance b @B()
+  }
+  firrtl.module @A() {
+    // expected-note @below {{path targets this operation in module "AltBasePathStrandedInstance"}}
+    // expected-note @below {{the path op targets this operation in module "AltBasePathStrandedInstance"}}
+    %R = firrtl.wire {
+      annotations = [
+        {class = "circt.tracker", id = distinct[0]<>},
+        {class = "circt.tracker", id = distinct[1]<>}
+      ]
+    } : !firrtl.uint<1>
+    firrtl.instance b @B()
+  }
+  firrtl.module @AltBasePathStrandedInstance() {
+    firrtl.instance a @A()
+  }
+}

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -787,3 +787,124 @@ firrtl.circuit "NoPropPorts" {
     firrtl.property_assert %2, "srcs must match" : !firrtl.bool
   }
 }
+
+// Ensure that trivial leaves with paths work.
+//
+// See: https://github.com/llvm/circt/issues/10510
+//
+// CHECK-LABEL: firrtl.circuit "PathOpInLeafModule"
+firrtl.circuit "PathOpInLeafModule" {
+  // CHECK: om.class @Bar_Class(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
+  // CHECK:   %0 = om.path_create reference %alt_basepath_0 {{@.+}}
+  firrtl.module @Bar() {
+    %0 = firrtl.path reference distinct[0]<>
+  }
+
+  firrtl.module @PathOpInLeafModule() {
+    firrtl.instance bar @Bar()
+    %a = firrtl.wire {
+      annotations = [
+        {class = "circt.tracker", id = distinct[0]<>}
+      ]
+    } : !firrtl.uint<1>
+  }
+}
+
+// Ensure that the need for an alt base path doesn't bore ports to every module
+// that contains properties.  Deeper modules may be multiply instantiated (e.g.,
+// by test benches) and this will create ports that are not driven.
+//
+// See: https://github.com/llvm/circt/issues/10509
+//
+// CHECK-LABEL: firrtl.circuit "MinimalAltBasePath"
+firrtl.circuit "MinimalAltBasePath" {
+  // CHECK:      om.class private @Bar_Class(%basepath: !om.basepath)
+  // CHECK-NOT:    %alt_basepath
+  firrtl.module private @Bar() {
+    %0 = firrtl.string "hello"
+  }
+
+  // CHECK:      om.class private @Baz_Class(%basepath: !om.basepath)
+  // CHECK-NOT:    %alt_basepath
+  firrtl.module private @Baz() {
+    firrtl.instance baz @Bar()
+  }
+
+  // CHECK:      om.class private @Foo_Class(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
+  // CHECK:        om.path_create reference %alt_basepath_0
+  firrtl.module private @Foo() {
+    %0 = firrtl.path reference distinct[0]<>
+    firrtl.instance baz @Bar()
+  }
+
+  // CHECK:      om.class @MinimalAltBasePath_Class(%basepath: !om.basepath)
+  // CHECK-NEXT:   %0 = om.basepath_create %basepath
+  // CHECK:        om.object @Foo_Class(%0, %basepath)
+  firrtl.module @MinimalAltBasePath() {
+    %a = firrtl.wire {
+      annotations = [
+        {class = "circt.tracker", id = distinct[0]<>}
+      ]
+    }: !firrtl.uint<1>
+    firrtl.instance bar @Foo()
+  }
+}
+
+// Test that alt base paths are shared where possible.  This test should create
+// one alt base path, not two.
+//
+// CHECK-LABEL: firrtl.circuit "AltBasePathSharing"
+firrtl.circuit "AltBasePathSharing" {
+  // CHECK:      om.class private @Bar_Class(%basepath: !om.basepath, %[[ALT:.+]]: !om.basepath)
+  // CHECK:        om.path_create reference %[[ALT]]
+  // CHECK-NEXT:   om.path_create reference %[[ALT]]
+  firrtl.module private @Bar() {
+    %0 = firrtl.path reference distinct[0]<>
+    %1 = firrtl.path reference distinct[1]<>
+  }
+
+  firrtl.module @AltBasePathSharing() {
+    %a = firrtl.wire {
+      annotations = [
+        {class = "circt.tracker", id = distinct[0]<>}
+      ]
+    } : !firrtl.uint<1>
+    %b = firrtl.wire {
+      annotations = [
+        {class = "circt.tracker", id = distinct[1]<>}
+      ]
+    } : !firrtl.uint<1>
+    firrtl.instance bar @Bar()
+  }
+}
+
+// Test that a containing module reached via multiple paths under an alt base
+// path root has every intermediate ancestor on every path marked.  Here, Bar
+// is reached as Foo->Bar (direct) and Foo->Baz->Bar (via Baz), so Baz must
+// also receive an alt base path port to forward.
+//
+// CHECK-LABEL: firrtl.circuit "AltBasePathMultiParent"
+firrtl.circuit "AltBasePathMultiParent" {
+  // CHECK:      om.class private @Bar_Class(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
+  firrtl.module private @Bar() {
+    %0 = firrtl.path reference distinct[0]<>
+  }
+
+  // CHECK:      om.class private @Baz_Class(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
+  firrtl.module private @Baz() {
+    firrtl.instance bar @Bar()
+  }
+
+  // CHECK:      om.class private @Foo_Class(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
+  firrtl.module private @Foo() {
+    firrtl.instance bar @Bar()
+    firrtl.instance baz @Baz()
+  }
+
+  firrtl.module @AltBasePathMultiParent() {
+    %a = firrtl.wire {
+      annotations = [{class = "circt.tracker", id = distinct[0]<>}]
+    } : !firrtl.uint<1>
+    firrtl.instance foo @Foo()
+  }
+}


### PR DESCRIPTION
When creating "alternative" base paths in the LowerClasses pass, do not
connect these to every module that has a class.  This avoids boring unused
ports to modules deep in the design.  This was problematic as if those
other modules were multiply instantiated (e.g., by a test harness compiled
with the circuit).  The other instantiations cannot drive the alternative
base paths with anything sane, so the circuit would be illegal.

I believe that this bug was preexisting based on how the original DFS from
the alternative base path root worked.  However, this was much more likely
to manifest after #10362 which creates classes for any module which has
properties in order to enable property assertions to fire.

Fixes #10509.  Note: this was manifesting as an assert
failure (out-of-bounds index of a vector to get a port that doesn't exist
on the other instantiation).

Fixes #10505.
Fixes #10510.

Closes #10513 (via supersession).

Assisted-by: pi.dev:claude-opus-4-7
