### PR TITLE
[FIRRTL] EliminateWires: preserve sv.attributes when converting WireOp to NodeOp

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EliminateWires.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EliminateWires.cpp
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Support/Debug.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -87,6 +88,7 @@ void EliminateWiresPass::runOnOperation() {
     auto node = NodeOp::create(builder, writer.getSrc(), wire.getName(),
                                wire.getNameKind(), wire.getAnnotations(),
                                wire.getInnerSymAttr(), wire.getForceable());
+    sv::setSVAttributes(node, sv::getSVAttributes(wire));
     wire.replaceAllUsesWith(node);
     wire.erase();
     writer.erase();

--- a/test/Dialect/FIRRTL/eliminate-wires.mlir
+++ b/test/Dialect/FIRRTL/eliminate-wires.mlir
@@ -3,7 +3,7 @@
 firrtl.circuit "TopLevel" {
 
   // CHECK-LABEL: @TopLevel
-  firrtl.module @TopLevel(in %source: !firrtl.uint<1>, 
+  firrtl.module @TopLevel(in %source: !firrtl.uint<1>,
                              out %sink: !firrtl.uint<1>) {
     // CHECK-NOT: firrtl.wire
     %w = firrtl.wire : !firrtl.uint<1>
@@ -25,5 +25,17 @@ firrtl.circuit "TopLevel" {
     // CHECK: %[[inv:.*]] = firrtl.invalidvalue : !firrtl.uint<3>
     // CHECK-NEXT:  %b = firrtl.node %[[inv]] : !firrtl.uint<3>
     // CHECK-NEXT:  %a = firrtl.node %b : !firrtl.uint<3>
+  }
+
+  // CHECK-LABEL: @SvAttributesPreserved
+  // Verify that wire SV attributes are propagated to nodes.
+  firrtl.module private @SvAttributesPreserved(in %source: !firrtl.uint<1>,
+                                               out %sink: !firrtl.uint<1>) {
+    // CHECK-NOT: firrtl.wire
+    // CHECK-NEXT: %w = firrtl.node
+    // CHECK-SAME: sv.attributes = [#sv.attribute<"mark_debug = \22true\22">]
+    %w = firrtl.wire {sv.attributes = [#sv.attribute<"mark_debug = \"true\"">]} : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %sink, %w : !firrtl.uint<1>
   }
 }


### PR DESCRIPTION
Hi,

I ran into this while trying to use Chisel's `addAttribute()` to annotate a wire with `(* mark_debug = "true" *)` for Vivado debug probes. The attribute was set correctly by `LowerAnnotations` (as `sv.attributes` on the FIRRTL `WireOp`), but never appeared in the emitted SystemVerilog.

Root cause: `EliminateWires` converts single-writer passive `WireOp`s to `NodeOp`s without copying `sv.attributes`, so they get silently dropped before `LowerToHW` runs.

Proposed fix: copy `sv.attributes` from the `WireOp` to the replacement `NodeOp`, matching the existing pattern in `LowerToHW.cpp` for `RegOp` and `RegResetOp`.

Assisted-by: vscode/eicp:Claude Opus 4.6