### PR TITLE
[Moore][ImportVerilog][MooreToCore][Sim] Add $fdisplay and $fwrite

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3133,6 +3133,19 @@ def FFlushBIOp : Builtin<"fflush"> {
   let assemblyFormat = "($fd^)? attr-dict";
 }
 
+def FDisplayBIOp : Builtin<"fdisplay"> {
+  let summary = "Print a text message to a file";
+  let description = [{
+    Prints the given format string to the file corresponding to the given
+    descriptor. This corresponds to the `$fdisplay` and `$fwrite` system tasks.
+    Message formatting is handled by `moore.fmt.*` ops.
+
+    See IEEE 1800-2017 § 21.3.2 "File output system tasks".
+  }];
+  let arguments = (ins TwoValuedI32:$fd, FormatStringType:$message);
+  let assemblyFormat = "$fd `,` $message attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Math Builtins
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1005,10 +1005,12 @@ struct StmtVisitor {
       return true;
     }
 
-    // Display and Write Tasks (`$display[boh]?` or `$write[boh]?`)
+    // Display and Write Tasks (`$display[boh]?` or `$write[boh]?` or
+    // `$fdisplay[boh]?` or `$fwrite[boh]?`)
 
     using moore::IntFormat;
     bool isDisplay = false;
+    bool isFDisplay = false;
     bool appendNewline = false;
     IntFormat defaultFormat = IntFormat::Decimal;
     switch (nameId) {
@@ -1046,6 +1048,40 @@ struct StmtVisitor {
       isDisplay = true;
       defaultFormat = IntFormat::HexLower;
       break;
+    case ksn::FDisplay:
+      isFDisplay = true;
+      appendNewline = true;
+      break;
+    case ksn::FDisplayB:
+      isFDisplay = true;
+      appendNewline = true;
+      defaultFormat = IntFormat::Binary;
+      break;
+    case ksn::FDisplayO:
+      isFDisplay = true;
+      appendNewline = true;
+      defaultFormat = IntFormat::Octal;
+      break;
+    case ksn::FDisplayH:
+      isFDisplay = true;
+      appendNewline = true;
+      defaultFormat = IntFormat::HexLower;
+      break;
+    case ksn::FWrite:
+      isFDisplay = true;
+      break;
+    case ksn::FWriteB:
+      isFDisplay = true;
+      defaultFormat = IntFormat::Binary;
+      break;
+    case ksn::FWriteO:
+      isFDisplay = true;
+      defaultFormat = IntFormat::Octal;
+      break;
+    case ksn::FWriteH:
+      isFDisplay = true;
+      defaultFormat = IntFormat::HexLower;
+      break;
     default:
       break;
     }
@@ -1058,6 +1094,25 @@ struct StmtVisitor {
       if (*message == Value{})
         return true;
       moore::DisplayBIOp::create(builder, loc, *message);
+      return true;
+    }
+
+    if (isFDisplay) {
+      assert(!args.empty() && "$fdisplay/$fwrite takes at least 1 argument");
+
+      auto fd = context.convertRvalueExpression(
+          *args[0], moore::IntType::getInt(builder.getContext(), 32));
+      if (!fd)
+        return failure();
+      args = args.subspan(1);
+
+      auto message =
+          context.convertFormatString(args, loc, defaultFormat, appendNewline);
+      if (failed(message))
+        return failure();
+      if (*message == Value{})
+        return true;
+      moore::FDisplayBIOp::create(builder, loc, fd, *message);
       return true;
     }
 

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2953,6 +2953,19 @@ struct DisplayBIOpConversion : public OpConversionPattern<DisplayBIOp> {
   }
 };
 
+struct FDisplayBIOpConversion : public OpConversionPattern<FDisplayBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(FDisplayBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto stream = sim::SVChannelToOutputStreamOp::create(rewriter, op.getLoc(),
+                                                         adaptor.getFd());
+    rewriter.replaceOpWithNewOp<sim::PrintFormattedProcOp>(
+        op, adaptor.getMessage(), stream.getStream());
+    return success();
+  }
+};
+
 struct FOpenBIOpConversion : public OpConversionPattern<FOpenBIOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -3561,6 +3574,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FormatIntOpConversion,
     FormatRealOpConversion,
     DisplayBIOpConversion,
+    FDisplayBIOpConversion,
 
     // File I/O operations
     FOpenBIOpConversion,

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -785,3 +785,64 @@ function void FileIOBuiltins(int fd_int, integer fd_integer);
   // CHECK: moore.builtin.fflush
   $fflush();
 endfunction
+
+// IEEE 1800-2017 § 21.3.2 "File output system tasks"
+// CHECK-LABEL: func.func private @FileDisplayBuiltins(
+// CHECK-SAME: [[FD:%[^ ,]+]]: !moore.i32
+// CHECK-SAME: [[X:%[^ ,]+]]: !moore.i32
+function void FileDisplayBuiltins(int fd, int x);
+  // $fwrite with no message
+  // CHECK-NOT: moore.builtin.fdisplay
+  $fwrite(fd);
+
+  // $fdisplay with no args
+  // CHECK: [[TMP:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP]]
+  $fdisplay(fd);
+
+  // CHECK: [[TMP:%.+]] = moore.fmt.literal "hello"
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP]]
+  $fwrite(fd, "hello");
+
+  // $fdisplay adds \0A newline
+  // CHECK: [[TMP1:%.+]] = moore.fmt.literal "hello"
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP3]]
+  $fdisplay(fd, "hello");
+
+  // CHECK: [[TMP:%.+]] = moore.fmt.int decimal [[X]], align right, pad space signed : i32
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP]]
+  $fwrite(fd, x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.int binary [[X]], align right, pad zero : i32
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP]]
+  $fwriteb(fd, x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.int octal [[X]], align right, pad zero : i32
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP]]
+  $fwriteo(fd, x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.int hex_lower [[X]], align right, pad zero : i32
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP]]
+  $fwriteh(fd, x);
+
+  // CHECK: [[TMP1:%.+]] = moore.fmt.int decimal [[X]], align right, pad space signed : i32
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP3]]
+  $fdisplay(fd, x);
+  // CHECK: [[TMP1:%.+]] = moore.fmt.int binary [[X]], align right, pad zero : i32
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP3]]
+  $fdisplayb(fd, x);
+  // CHECK: [[TMP1:%.+]] = moore.fmt.int octal [[X]], align right, pad zero : i32
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP3]]
+  $fdisplayo(fd, x);
+  // CHECK: [[TMP1:%.+]] = moore.fmt.int hex_lower [[X]], align right, pad zero : i32
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.fdisplay [[FD]], [[TMP3]]
+  $fdisplayh(fd, x);
+
+endfunction

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -245,13 +245,6 @@ module Foo;
 endmodule
 
 // -----
-function Foo;
-  logic [1:0] a;
-  // expected-error @below {{unsupported system call `$fwrite`}}
-  $fwrite(32'h0, "%x", a);
-endfunction
-
-// -----
 module Foo;
   string s;
   byte b;

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1835,6 +1835,16 @@ func.func @FClose(%arg0: !moore.i32) {
   return
 }
 
+// CHECK-LABEL: func.func @FDisplay
+func.func @FDisplay(%arg0: !moore.i32) {
+  // CHECK: [[MSG:%.+]] = sim.fmt.literal "hello"
+  %msg = moore.fmt.literal "hello"
+  // CHECK: [[STREAM:%.+]] = sim.sv.channel_to_output_stream %arg0
+  // CHECK: sim.proc.print [[MSG]] to [[STREAM]]
+  moore.builtin.fdisplay %arg0, %msg
+  return
+}
+
 // CHECK-LABEL: hw.module @MooreTypedArithSelect
 moore.module @MooreTypedArithSelect(in %s: i1, in %a: !moore.i8, in %b: !moore.i8, out o: !moore.i8) {
   // CHECK-NOT: !moore.i8


### PR DESCRIPTION
Implement $fdisplay, and $fwrite system task in the ImportVerilog pipeline.

- Add moore.builtins.fdisplay ops in Moore dialect.
- Lower Moore fdisplay ops in Sim dialect with SVChannelToOutputStreamOp to sim.proc.print
- Add tests covering in ImportVerilog/builtin.sv / MooreToCore/basic.mlir