### PR TITLE
[HW] Add canonicalizer for HW StructCreateOp

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -229,6 +229,7 @@ def StructCreateOp : HWOp<"struct_create", [Pure]> {
   let hasCustomAssemblyFormat = 1;
   let hasFolder = 1;
   let hasVerifier = 1;
+  let hasCanonicalizeMethod = 1;
 }
 
 // Extract the value of a field of a structure.

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2265,6 +2265,32 @@ OpFoldResult StructCreateOp::fold(FoldAdaptor adaptor) {
   return ArrayAttr::get(getContext(), inputs);
 }
 
+LogicalResult StructCreateOp::canonicalize(StructCreateOp op,
+                                           PatternRewriter &rewriter) {
+  // Fold away a struct_create whose inputs are struct_extract ops that
+  // reconstruct the same struct in field order from a single source value.
+  Value foldVal;
+  for (auto [i, operand] : llvm::enumerate(op.getInput())) {
+    auto extractOp = operand.getDefiningOp<StructExtractOp>();
+    if (!extractOp || extractOp.getFieldIndex() != i ||
+        extractOp.getInput().getType() != op.getType()) {
+      foldVal = {};
+      break;
+    }
+    if (i == 0) {
+      foldVal = extractOp.getInput();
+    } else if (extractOp.getInput() != foldVal) {
+      foldVal = {};
+      break;
+    }
+  }
+  if (foldVal) {
+    rewriter.replaceOp(op, foldVal);
+    return success();
+  }
+  return failure();
+}
+
 //===----------------------------------------------------------------------===//
 // StructExplodeOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2284,7 +2284,7 @@ LogicalResult StructCreateOp::canonicalize(StructCreateOp op,
       break;
     }
   }
-  if (foldVal) {
+  if (foldVal && foldVal != op.getResult()) {
     rewriter.replaceOp(op, foldVal);
     return success();
   }

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1142,6 +1142,25 @@ hw.module @struct_create1(in %in: !hw.struct<a: i2, b: i2, c: i2>, in %in1: i2, 
   hw.output %1, %2, %3 : !hw.struct<a: i2, b: i2, c: i2>, !hw.struct<a: i2, b: i2, d: i2>, !hw.struct<a: i2, b: i2, c: i2>
 }
 
+// CHECK-LABEL: hw.module @struct_create_extract_fold
+hw.module @struct_create_extract_fold(in %in_a: !hw.struct<a: i2, b: i2, c: i2>, in %in_b: !hw.struct<a: i2, b: i2, c: i2>, out out_a: !hw.struct<a: i2, b: i2, c: i2>, out out_b: !hw.struct<a: i2, b: i2, c: i2>, out out_c: !hw.struct<a: i2, b: i2, c: i2>) {
+  // One of the three StructCreateOps should be folded
+  // CHECK-COUNT-2: hw.struct_create
+  // CHECK-NOT:     hw.struct_create
+  %a = hw.struct_extract %in_a["a"] : !hw.struct<a: i2, b: i2, c: i2>
+  %b = hw.struct_extract %in_a["b"] : !hw.struct<a: i2, b: i2, c: i2>
+  %c = hw.struct_extract %in_a["c"] : !hw.struct<a: i2, b: i2, c: i2>
+  // Fold
+  %folded = hw.struct_create (%a, %b, %c) : !hw.struct<a: i2, b: i2, c: i2>
+  // Don't fold: Different field order
+  %nofold0 = hw.struct_create (%a, %c, %b) : !hw.struct<a: i2, b: i2, c: i2>
+  // Don't fold: Different inputs
+  %c_other = hw.struct_extract %in_b["c"] : !hw.struct<a: i2, b: i2, c: i2>
+  %nofold1 = hw.struct_create (%a, %b, %c_other) : !hw.struct<a: i2, b: i2, c: i2>
+  // CHECK: hw.output %in_a
+  hw.output %folded, %nofold0, %nofold1 : !hw.struct<a: i2, b: i2, c: i2>, !hw.struct<a: i2, b: i2, c: i2>, !hw.struct<a: i2, b: i2, c: i2>
+}
+
 // CHECK-LABEL: hw.module @struct_extract1
 // CHECK-NEXT:    hw.output %a0 : i3
 hw.module @struct_extract1(in %a0: i3, in %a1: i5, out r0: i3) {


### PR DESCRIPTION
Adds a canonoicalization that folds `hw.struct_create` ops which simply undo a destructuring of a given input struct.

Assisted-by: vscode:Claude Sonnet 4.6