### PR TITLE
[Moore][ImportVerilog][MooreToCore][Sim] Add $fflush

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3117,6 +3117,22 @@ def FCloseBIOp : Builtin<"fclose"> {
   let assemblyFormat = "$fd attr-dict";
 }
 
+def FFlushBIOp : Builtin<"fflush"> {
+  let summary = "Flush a descriptor's output buffer";
+  let description = [{
+    Flushes the output buffer of the specified file(s).
+    This corresponds to the `$fflush` system task. If a file descriptor is provided,
+    writes any buffered output to the file associated with that descriptor.
+    If the descriptor is a multi-channel descriptor, all associated files are flushed.
+    If invoked with no arguments, flushes all open files.
+
+    See IEEE 1800-2017 § 21.3.6 "Flushing output".
+  }];
+  let arguments = (ins Optional<TwoValuedI32>:$fd);
+  let results = (outs);
+  let assemblyFormat = "($fd^)? attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Math Builtins
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1273,24 +1273,23 @@ def SVFFlushAllOp : SimOp<"sv.fflush_all", [ProceduralOp]> {
   let summary = "Flush all open files";
   let description = [{
     Implements the SystemVerilog `$fflush` system tasks when called with no
-    arguments, which flushes all open files.
+    arguments, which flushes all files opened by `sim.sv.fopen`.
 
     See IEEE 1800-2017 § 21.3.6 "Flushing output".
   }];
 
-  let arguments = (ins);
   let assemblyFormat = "attr-dict";
 }
 
-def FFlushOp : SimOp<"fflush", [ProceduralOp]> {
+def FlushOp : SimOp<"flush", [ProceduralOp]> {
   let summary = "Flush a output stream";
   let description = [{
     Flushes the output buffer of an output stream.
     This ensures that any buffered data is written to the file immediately.
   }];
 
-  let arguments = (ins OutputStreamType:$fd);
-  let assemblyFormat = "$fd attr-dict";
+  let arguments = (ins OutputStreamType:$stream);
+  let assemblyFormat = "$stream attr-dict";
 }
 
 #endif // CIRCT_DIALECT_SIM_SIMOPS_TD

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1269,4 +1269,28 @@ def SVChannelToOutputStreamOp : SimOp<"sv.channel_to_output_stream", [Procedural
   let assemblyFormat = "$channel attr-dict";
 }
 
+def SVFFlushAllOp : SimOp<"sv.fflush_all", [ProceduralOp]> {
+  let summary = "Flush all open files";
+  let description = [{
+    Implements the SystemVerilog `$fflush` system tasks when called with no
+    arguments, which flushes all open files.
+
+    See IEEE 1800-2017 § 21.3.6 "Flushing output".
+  }];
+
+  let arguments = (ins);
+  let assemblyFormat = "attr-dict";
+}
+
+def FFlushOp : SimOp<"fflush", [ProceduralOp]> {
+  let summary = "Flush a output stream";
+  let description = [{
+    Flushes the output buffer of an output stream.
+    This ensures that any buffered data is written to the file immediately.
+  }];
+
+  let arguments = (ins OutputStreamType:$fd);
+  let assemblyFormat = "$fd attr-dict";
+}
+
 #endif // CIRCT_DIALECT_SIM_SIMOPS_TD

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1112,6 +1112,19 @@ struct StmtVisitor {
       return true;
     }
 
+    if (nameId == ksn::FFlush) {
+      assert(args.size() <= 1 && "$fflush takes at most 1 argument");
+      Value fd;
+      if (args.size() == 1) {
+        fd = context.convertRvalueExpression(
+            *args[0], moore::IntType::getInt(builder.getContext(), 32));
+        if (!fd)
+          return failure();
+      }
+      moore::FFlushBIOp::create(builder, loc, fd);
+      return true;
+    }
+
     // Queue Tasks
 
     if (args.size() >= 1 && args[0]->type->isQueue()) {

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -3008,7 +3008,7 @@ struct FFlushBIOpConversion : public OpConversionPattern<FFlushBIOp> {
     } else {
       auto stream = sim::SVChannelToOutputStreamOp::create(
           rewriter, op.getLoc(), adaptor.getFd());
-      rewriter.replaceOpWithNewOp<sim::FFlushOp>(op, stream);
+      rewriter.replaceOpWithNewOp<sim::FlushOp>(op, stream);
     }
     return success();
   }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2997,6 +2997,23 @@ struct FCloseBIOpConversion : public OpConversionPattern<FCloseBIOp> {
   }
 };
 
+struct FFlushBIOpConversion : public OpConversionPattern<FFlushBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(FFlushBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!adaptor.getFd()) {
+      rewriter.replaceOpWithNewOp<sim::SVFFlushAllOp>(op);
+    } else {
+      auto stream = sim::SVChannelToOutputStreamOp::create(
+          rewriter, op.getLoc(), adaptor.getFd());
+      rewriter.replaceOpWithNewOp<sim::FFlushOp>(op, stream);
+    }
+    return success();
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -3548,6 +3565,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     // File I/O operations
     FOpenBIOpConversion,
     FCloseBIOpConversion,
+    FFlushBIOpConversion,
 
     // Dynamic string operations
     StringLenOpConversion,

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -778,4 +778,10 @@ function void FileIOBuiltins(int fd_int, integer fd_integer);
   // CHECK-NEXT: moore.builtin.fclose [[FDVAL]]
   $fclose(fd);
 
+  // CHECK: [[FDVAL:%.+]] = moore.read {{%.+}} : <i32>
+  // CHECK-NEXT: moore.builtin.fflush [[FDVAL]]
+  $fflush(fd);
+
+  // CHECK: moore.builtin.fflush
+  $fflush();
 endfunction

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1852,7 +1852,7 @@ func.func @FFlushNoArg() {
 // CHECK-LABEL: func.func @FFlushWithArg
 func.func @FFlushWithArg(%arg0: !moore.i32) {
   // CHECK: [[STREAM:%.+]] = sim.sv.channel_to_output_stream %arg0
-  // CHECK-NEXT: sim.fflush [[STREAM]]
+  // CHECK-NEXT: sim.flush [[STREAM]]
   moore.builtin.fflush %arg0
   return
 }

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1841,3 +1841,18 @@ moore.module @MooreTypedArithSelect(in %s: i1, in %a: !moore.i8, in %b: !moore.i
   %sel = arith.select %s, %a, %b : !moore.i8
   moore.output %sel : !moore.i8
 }
+
+// CHECK-LABEL: func.func @FFlushNoArg
+func.func @FFlushNoArg() {
+  // CHECK: sim.sv.fflush_all
+  moore.builtin.fflush
+  return
+}
+
+// CHECK-LABEL: func.func @FFlushWithArg
+func.func @FFlushWithArg(%arg0: !moore.i32) {
+  // CHECK: [[STREAM:%.+]] = sim.sv.channel_to_output_stream %arg0
+  // CHECK-NEXT: sim.fflush [[STREAM]]
+  moore.builtin.fflush %arg0
+  return
+}


### PR DESCRIPTION
Implement $fflush system task in the ImportVerilog pipeline.

- Add `moore.builtins.fflush` ops in Moore dialect.
- Add `sim.fflush` and `sim.sv.fflush_all` ops in Sim dialect 
- Lower Moore fflush ops in Sim dialect with `SVChannelToOutputStreamOp` to `sim.fflush` if it provides a descriptor else to `sim.sv.fflush_all`
- Add tests covering in ImportVerilog/builtin.sv and MooreToCore/basic.mlir
