### PR TITLE
[FIRRTL] Fix mux fold bug, 1 const, 2 SSA values

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1850,8 +1850,8 @@ static OpFoldResult foldMux(OpTy op, typename OpTy::FoldAdaptor adaptor) {
         // Ensure that this has an integer representation.  This specifically
         // avoids problems with clocks.
         if (auto intType = type_dyn_cast<IntType>(op.getType()))
-          if (intType.hasWidth() && (unsigned)intType.getWidthOrSentinel() ==
-                                        highCst->getBitWidth())
+          if (intType.hasWidth() &&
+              (unsigned)intType.getWidthOrSentinel() == highCst->getBitWidth())
             return getIntAttr(op.getType(), *highCst);
       // mux(cond, 1, 0) -> cond
       if (highCst->isOne() && lowCst->isZero() &&

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1847,7 +1847,12 @@ static OpFoldResult foldMux(OpTy op, typename OpTy::FoldAdaptor adaptor) {
       // mux(cond, cst, cst) -> cst
       if (highCst->getBitWidth() == lowCst->getBitWidth() &&
           *highCst == *lowCst)
-        return getIntAttr(op.getType(), *highCst);
+        // Ensure that this has an integer representation.  This specifically
+        // avoids problems with clocks.
+        if (auto intType = type_dyn_cast<IntType>(op.getType()))
+          if (intType.hasWidth() && (unsigned)intType.getWidthOrSentinel() ==
+                                        highCst->getBitWidth())
+            return getIntAttr(op.getType(), *highCst);
       // mux(cond, 1, 0) -> cond
       if (highCst->isOne() && lowCst->isZero() &&
           op.getType() == op.getSel().getType())

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2508,6 +2508,19 @@ firrtl.module @MuxCanon(in %c1: !firrtl.uint<1>, in %c2: !firrtl.uint<1>, in %d1
   // CHECK: firrtl.cat %[[mux2]], %d2
 }
 
+// See: https://github.com/llvm/circt/issues/10528
+// CHECK-LABEL: firrtl.module @MuxCanon10528
+firrtl.module @MuxCanon10528(in %cond: !firrtl.uint<1>, out %out: !firrtl.clock) {
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %clk = firrtl.asClock %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
+  %n0 = firrtl.node %clk : !firrtl.clock
+  %n1 = firrtl.node %clk {name = "n1"} : !firrtl.clock
+  %0 = firrtl.mux(%cond, %n0, %n1) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
+  firrtl.matchingconnect %out, %0 : !firrtl.clock
+  // CHECK: %[[CLK:.+]] = firrtl.specialconstant 0 : !firrtl.clock
+  // CHECK: firrtl.matchingconnect %out, %[[CLK]]
+}
+
 // CHECK-LABEL: firrtl.module @MuxShorten
 firrtl.module @MuxShorten(
   in %c1: !firrtl.uint<1>, in %c2: !firrtl.uint<1>,


### PR DESCRIPTION
Fix a bug where FIRRTL's mux folder could try to get an integer attribute
from a clock which cannot support this.  This could arise for situations
where both legs of the mux are constant, but are fed by different SSA
values that have the same constant value.  (See the test for an example.)

This appeared internally with the 1.148.0 release candidate, but it is
pre-existing in both 1.147.0 and 1.146.0.  I expect that there is
something in 1.147.0+ that was optimizing to the pattern which would
always fail.

Fixes #10528.

Assisted-by: pi.dev:claude-opus-4-7
