### PR TITLE
[OM] Fuse class field locations into values during object inlining

### DIFF
--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -154,7 +154,7 @@ print(obj.reference)
 for (name, field) in obj:
   # location from om.class.field "child"
   # CHECK: name: child, field: <circt.dialects.om.Object object
-  # CHECK-SAME: loc: loc("-":{{.*}}:{{.*}})
+  # CHECK-SAME: loc: loc(fused
   # location from om.class.field "field"
   # CHECK: name: field, field: 42
   # CHECK-SAME: loc: loc("-":{{.*}}:{{.*}})

--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -80,6 +80,12 @@ struct ObjectOpInliningPattern : public OpRewritePattern<ObjectOp> {
 
     auto clonedFields = cast<ClassFieldsOp>(clonedBlock->getTerminator());
     SmallVector<Value> fieldValues(clonedFields.getFields());
+    // Propagate the class's per-field locations onto each field value, fused
+    // with the value's existing location.
+    if (auto classOp = dyn_cast<ClassOp>(classLike.getOperation()))
+      for (auto [i, v] : llvm::enumerate(fieldValues))
+        v.setLoc(
+            rewriter.getFusedLoc({classOp.getFieldLocByIndex(i), v.getLoc()}));
 
     // Erase the terminator and inline the body at the object instantiation.
     rewriter.eraseOp(clonedFields);

--- a/test/Dialect/OM/elaborate-object-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-errors.mlir
@@ -57,12 +57,14 @@ om.class private @BoolWrapper(%in: i1) -> (out: i1) {
 
 // Cycle in dataflow (field access creates a cycle that can't be evaluated)
 om.class private @WrapperCycle(%val: !om.integer) -> (out: !om.integer) {
+  // FIXME: Currently the primary location points at om.field.class field op due
+  //        to backward compatibility with the old evaluator implementation.
+  // expected-error @below {{failed to evaluate om.object.field}}
   om.class.fields %val : !om.integer
 }
 
 om.class @DataflowCycle() -> (result: !om.integer) {
   %obj = om.object @WrapperCycle(%feedback) : (!om.integer) -> !om.class.type<@WrapperCycle>
-  // expected-error @below {{failed to evaluate om.object.field}}
   %feedback = om.object.field %obj["out"] : (!om.class.type<@WrapperCycle>) -> !om.integer
   om.class.fields %feedback : !om.integer
 }


### PR DESCRIPTION
When ObjectOpInliningPattern clones a class body, fuse each field value's location with the class's per-field location (getFieldLocByIndex). This mirrors the runtime Evaluator's evaluateParameter behaviour, which stamps the instantiation-site location onto formal parameter. 
 
 Assisted-by: Claude code: sonnet 4.6

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
