### PR TITLE
[FIRRTL] Domains and -fixup-eicg-wrapper working

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -133,14 +133,6 @@ static LogicalResult lowerDomainEICGWrapperInstance(FExtModuleOp op,
   auto out =
       replaceResultWithWire(builder, inst.getResult(outIdx), outputDomain);
 
-  // The lowered intrinsic operates inside an anonymous domain.  This keeps
-  // custom domain inference rules out of intrinsics and uses the default rule
-  // that all operands and results are in one domain.
-  auto anon = DomainCreateAnonOp::create(builder, domA.getType(), "");
-  for (auto &input : inputs)
-    input = UnsafeDomainCastOp::create(builder, input.getType(), input,
-                                       ValueRange{anon});
-
   // en and test_en are swapped between extmodule and intrinsic.
   if (failed(swapEICGEnableInputs(op, inst, inputs)))
     return failure();

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -154,6 +154,9 @@ void LowerIntmodulesPass::runOnOperation() {
   }
 
   // Special handling for magic EICG wrapper extmodule.  Deprecate and remove.
+  //
+  // This supports both a domain-less form and a form with domains.  Both are
+  // rigid in their structure and expect an exact port order.
   if (fixupEICGWrapper) {
     constexpr StringRef eicgName = "EICG_wrapper";
     for (auto op :
@@ -174,6 +177,17 @@ void LowerIntmodulesPass::runOnOperation() {
       if (failed(checkModForAnnotations(op, eicgName)))
         return signalPassFailure();
 
+      // Detect the optional domain-port form.  When present, the wrapper has
+      // exactly two trailing domain input ports (A, B) and every preceding
+      // port has its `domains [...]` association resolved by them: data
+      // inputs bind to A, the output binds to B.  Without this, the layout is
+      // the legacy `[in, test_en?, en, out]`.
+      auto numPorts = op.getNumPorts();
+      bool hasDomains =
+          numPorts >= 2 && isa<DomainType>(op.getPortType(numPorts - 1));
+      unsigned numDataInputs = hasDomains ? numPorts - 3 : numPorts - 1;
+      unsigned outIdx = numDataInputs;
+
       auto *node = ig.lookup(op);
       changed = true;
       for (auto *use : llvm::make_early_inc_range(node->uses())) {
@@ -188,15 +202,57 @@ void LowerIntmodulesPass::runOnOperation() {
           return signalPassFailure();
 
         ImplicitLocOpBuilder builder(op.getLoc(), inst);
-        auto replaceResults = [](OpBuilder &b, auto &&range) {
-          return llvm::map_to_vector(range, [&b](auto v) {
-            auto w = WireOp::create(b, v.getLoc(), v.getType()).getResult();
-            v.replaceAllUsesWith(w);
-            return w;
-          });
-        };
 
-        auto inputs = replaceResults(builder, inst.getResults().drop_back());
+        // Replace each instance result with a wire.  Domain ports (A, B) are
+        // emitted first so that subsequent data port wires can reference them
+        // in their `domains [...]` operand list.
+        SmallVector<Value> wires(numPorts);
+        Value domA, domB;
+        if (hasDomains) {
+          auto rA = inst.getResult(numPorts - 2),
+               rB = inst.getResult(numPorts - 1);
+          domA = wires[numPorts - 2] =
+              WireOp::create(builder, rA.getLoc(), rA.getType()).getResult();
+          domB = wires[numPorts - 1] =
+              WireOp::create(builder, rB.getLoc(), rB.getType()).getResult();
+          rA.replaceAllUsesWith(domA);
+          rB.replaceAllUsesWith(domB);
+        }
+        auto wireWithDomain = [&](unsigned i, Value domain) {
+          auto r = inst.getResult(i);
+          ValueRange domains = domain ? ValueRange(domain) : ValueRange{};
+          wires[i] = WireOp::create(builder, r.getType(), /*name=*/StringRef{},
+                                    NameKindEnum::DroppableName,
+                                    /*annotations=*/ArrayRef<Attribute>{},
+                                    /*innerSym=*/StringAttr{},
+                                    /*forceable=*/false, domains)
+                         .getResult();
+          r.replaceAllUsesWith(wires[i]);
+        };
+        for (unsigned i = 0; i != numDataInputs; ++i)
+          wireWithDomain(i, domA);
+        wireWithDomain(outIdx, domB);
+
+        // If domains are in play, build a single anonymous domain that the
+        // lowered intrinsic operates within.  Data values are unsafe-cast in
+        // and out of it.  This is done because domain inference should not have
+        // custom domain inference rules for intrinsics and should, instead, use
+        // the default inference of all operands and results are single domain.
+        Value anon;
+        if (hasDomains)
+          anon = DomainCreateAnonOp::create(builder, domA.getType(), "");
+
+        // Build intrinsic operands from the data input wires, casting through
+        // the anonymous domain when domains are in play.
+        SmallVector<Value> inputs;
+        for (unsigned i = 0; i != numDataInputs; ++i) {
+          Value v = wires[i];
+          if (anon)
+            v = UnsafeDomainCastOp::create(builder, v.getType(), v,
+                                           ValueRange{anon});
+          inputs.push_back(v);
+        }
+
         // en and test_en are swapped between extmodule and intrinsic.
         if (inputs.size() > 2) {
           auto port1 = inst.getPortName(1);
@@ -214,7 +270,21 @@ void LowerIntmodulesPass::runOnOperation() {
         auto intop = GenericIntrinsicOp::create(
             builder, builder.getType<ClockType>(), "circt_clock_gate", inputs,
             op.getParameters());
-        inst.getResults().back().replaceAllUsesWith(intop.getResult());
+
+        // Drive the output.  Without domains, the output wire is unnecessary
+        // and is RAUW'd away to keep the legacy IR shape.  With domains, cast
+        // the intrinsic result back into the output's domain and connect.
+        Value out = wires[outIdx];
+        if (anon) {
+          auto cast =
+              UnsafeDomainCastOp::create(builder, out.getType(),
+                                         intop.getResult(), ValueRange{domB})
+                  .getResult();
+          MatchingConnectOp::create(builder, out, cast);
+        } else {
+          out.replaceAllUsesWith(intop.getResult());
+          out.getDefiningOp()->erase();
+        }
 
         // Remove instance from IR and instance graph.
         use->erase();

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -56,16 +56,8 @@ static LogicalResult checkInstForAnnotations(FInstanceLike inst,
   return success();
 }
 
-static Value replaceResultWithWire(ImplicitLocOpBuilder &builder,
-                                   Value result) {
-  auto wire =
-      WireOp::create(builder, result.getLoc(), result.getType()).getResult();
-  result.replaceAllUsesWith(wire);
-  return wire;
-}
-
 static Value replaceResultWithWire(ImplicitLocOpBuilder &builder, Value result,
-                                   ValueRange domains) {
+                                   ValueRange domains = {}) {
   auto wire = WireOp::create(builder, result.getType(), /*name=*/StringRef{},
                              NameKindEnum::DroppableName,
                              /*annotations=*/ArrayRef<Attribute>{},

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -56,6 +56,105 @@ static LogicalResult checkInstForAnnotations(FInstanceLike inst,
   return success();
 }
 
+static Value replaceResultWithWire(ImplicitLocOpBuilder &builder,
+                                   Value result) {
+  auto wire =
+      WireOp::create(builder, result.getLoc(), result.getType()).getResult();
+  result.replaceAllUsesWith(wire);
+  return wire;
+}
+
+static Value replaceResultWithWire(ImplicitLocOpBuilder &builder, Value result,
+                                   ValueRange domains) {
+  auto wire = WireOp::create(builder, result.getType(), /*name=*/StringRef{},
+                             NameKindEnum::DroppableName,
+                             /*annotations=*/ArrayRef<Attribute>{},
+                             /*innerSym=*/StringAttr{},
+                             /*forceable=*/false, domains)
+                  .getResult();
+  result.replaceAllUsesWith(wire);
+  return wire;
+}
+
+static LogicalResult swapEICGEnableInputs(FExtModuleOp op, InstanceOp inst,
+                                          SmallVectorImpl<Value> &inputs) {
+  if (inputs.size() <= 2)
+    return success();
+
+  auto port1 = inst.getPortName(1);
+  auto port2 = inst.getPortName(2);
+  if (port1 != "test_en")
+    return mlir::emitError(op.getPortLocation(1),
+                           "expected port named 'test_en'");
+  if (port2 != "en")
+    return mlir::emitError(op.getPortLocation(2), "expected port named 'en'");
+  std::swap(inputs[1], inputs[2]);
+  return success();
+}
+
+static LogicalResult lowerLegacyEICGWrapperInstance(FExtModuleOp op,
+                                                    InstanceOp inst) {
+  ImplicitLocOpBuilder builder(op.getLoc(), inst);
+
+  SmallVector<Value> inputs;
+  for (auto result : inst.getResults().drop_back())
+    inputs.push_back(replaceResultWithWire(builder, result));
+
+  // en and test_en are swapped between extmodule and intrinsic.
+  if (failed(swapEICGEnableInputs(op, inst, inputs)))
+    return failure();
+
+  auto intop = GenericIntrinsicOp::create(builder, builder.getType<ClockType>(),
+                                          "circt_clock_gate", inputs,
+                                          op.getParameters());
+  inst.getResults().back().replaceAllUsesWith(intop.getResult());
+  return success();
+}
+
+static LogicalResult lowerDomainEICGWrapperInstance(FExtModuleOp op,
+                                                    InstanceOp inst) {
+  ImplicitLocOpBuilder builder(op.getLoc(), inst);
+
+  auto numPorts = op.getNumPorts();
+  unsigned numDataInputs = numPorts - 3;
+  unsigned outIdx = numDataInputs;
+
+  // Domain ports are emitted first so that data wires can refer to them in
+  // their `domains [...]` operand list.
+  auto domA = replaceResultWithWire(builder, inst.getResult(numPorts - 2));
+  auto domB = replaceResultWithWire(builder, inst.getResult(numPorts - 1));
+
+  SmallVector<Value, 1> inputDomain{domA};
+  SmallVector<Value, 1> outputDomain{domB};
+  SmallVector<Value> inputs;
+  for (unsigned i = 0; i != numDataInputs; ++i)
+    inputs.push_back(
+        replaceResultWithWire(builder, inst.getResult(i), inputDomain));
+  auto out =
+      replaceResultWithWire(builder, inst.getResult(outIdx), outputDomain);
+
+  // The lowered intrinsic operates inside an anonymous domain.  This keeps
+  // custom domain inference rules out of intrinsics and uses the default rule
+  // that all operands and results are in one domain.
+  auto anon = DomainCreateAnonOp::create(builder, domA.getType(), "");
+  for (auto &input : inputs)
+    input = UnsafeDomainCastOp::create(builder, input.getType(), input,
+                                       ValueRange{anon});
+
+  // en and test_en are swapped between extmodule and intrinsic.
+  if (failed(swapEICGEnableInputs(op, inst, inputs)))
+    return failure();
+
+  auto intop = GenericIntrinsicOp::create(builder, builder.getType<ClockType>(),
+                                          "circt_clock_gate", inputs,
+                                          op.getParameters());
+  auto cast = UnsafeDomainCastOp::create(builder, out.getType(),
+                                         intop.getResult(), ValueRange{domB})
+                  .getResult();
+  MatchingConnectOp::create(builder, out, cast);
+  return success();
+}
+
 // This is the main entrypoint for the conversion pass.
 void LowerIntmodulesPass::runOnOperation() {
   auto &ig = getAnalysis<InstanceGraph>();
@@ -183,10 +282,8 @@ void LowerIntmodulesPass::runOnOperation() {
       // inputs bind to A, the output binds to B.  Without this, the layout is
       // the legacy `[in, test_en?, en, out]`.
       auto numPorts = op.getNumPorts();
-      bool hasDomains =
+      bool hasDomainPorts =
           numPorts >= 2 && isa<DomainType>(op.getPortType(numPorts - 1));
-      unsigned numDataInputs = hasDomains ? numPorts - 3 : numPorts - 1;
-      unsigned outIdx = numDataInputs;
 
       auto *node = ig.lookup(op);
       changed = true;
@@ -201,90 +298,9 @@ void LowerIntmodulesPass::runOnOperation() {
         if (failed(checkInstForAnnotations(inst, eicgName)))
           return signalPassFailure();
 
-        ImplicitLocOpBuilder builder(op.getLoc(), inst);
-
-        // Replace each instance result with a wire.  Domain ports (A, B) are
-        // emitted first so that subsequent data port wires can reference them
-        // in their `domains [...]` operand list.
-        SmallVector<Value> wires(numPorts);
-        Value domA, domB;
-        if (hasDomains) {
-          auto rA = inst.getResult(numPorts - 2),
-               rB = inst.getResult(numPorts - 1);
-          domA = wires[numPorts - 2] =
-              WireOp::create(builder, rA.getLoc(), rA.getType()).getResult();
-          domB = wires[numPorts - 1] =
-              WireOp::create(builder, rB.getLoc(), rB.getType()).getResult();
-          rA.replaceAllUsesWith(domA);
-          rB.replaceAllUsesWith(domB);
-        }
-        auto wireWithDomain = [&](unsigned i, Value domain) {
-          auto r = inst.getResult(i);
-          ValueRange domains = domain ? ValueRange(domain) : ValueRange{};
-          wires[i] = WireOp::create(builder, r.getType(), /*name=*/StringRef{},
-                                    NameKindEnum::DroppableName,
-                                    /*annotations=*/ArrayRef<Attribute>{},
-                                    /*innerSym=*/StringAttr{},
-                                    /*forceable=*/false, domains)
-                         .getResult();
-          r.replaceAllUsesWith(wires[i]);
-        };
-        for (unsigned i = 0; i != numDataInputs; ++i)
-          wireWithDomain(i, domA);
-        wireWithDomain(outIdx, domB);
-
-        // If domains are in play, build a single anonymous domain that the
-        // lowered intrinsic operates within.  Data values are unsafe-cast in
-        // and out of it.  This is done because domain inference should not have
-        // custom domain inference rules for intrinsics and should, instead, use
-        // the default inference of all operands and results are single domain.
-        Value anon;
-        if (hasDomains)
-          anon = DomainCreateAnonOp::create(builder, domA.getType(), "");
-
-        // Build intrinsic operands from the data input wires, casting through
-        // the anonymous domain when domains are in play.
-        SmallVector<Value> inputs;
-        for (unsigned i = 0; i != numDataInputs; ++i) {
-          Value v = wires[i];
-          if (anon)
-            v = UnsafeDomainCastOp::create(builder, v.getType(), v,
-                                           ValueRange{anon});
-          inputs.push_back(v);
-        }
-
-        // en and test_en are swapped between extmodule and intrinsic.
-        if (inputs.size() > 2) {
-          auto port1 = inst.getPortName(1);
-          auto port2 = inst.getPortName(2);
-          if (port1 != "test_en") {
-            mlir::emitError(op.getPortLocation(1),
-                            "expected port named 'test_en'");
-            return signalPassFailure();
-          } else if (port2 != "en") {
-            mlir::emitError(op.getPortLocation(2), "expected port named 'en'");
-            return signalPassFailure();
-          } else
-            std::swap(inputs[1], inputs[2]);
-        }
-        auto intop = GenericIntrinsicOp::create(
-            builder, builder.getType<ClockType>(), "circt_clock_gate", inputs,
-            op.getParameters());
-
-        // Drive the output.  Without domains, the output wire is unnecessary
-        // and is RAUW'd away to keep the legacy IR shape.  With domains, cast
-        // the intrinsic result back into the output's domain and connect.
-        Value out = wires[outIdx];
-        if (anon) {
-          auto cast =
-              UnsafeDomainCastOp::create(builder, out.getType(),
-                                         intop.getResult(), ValueRange{domB})
-                  .getResult();
-          MatchingConnectOp::create(builder, out, cast);
-        } else {
-          out.replaceAllUsesWith(intop.getResult());
-          out.getDefiningOp()->erase();
-        }
+        if (failed(hasDomainPorts ? lowerDomainEICGWrapperInstance(op, inst)
+                                  : lowerLegacyEICGWrapperInstance(op, inst)))
+          return signalPassFailure();
 
         // Remove instance from IR and instance graph.
         use->erase();

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -116,14 +116,10 @@ static LogicalResult lowerDomainEICGWrapperInstance(FExtModuleOp op,
   auto domA = replaceResultWithWire(builder, inst.getResult(numPorts - 2));
   auto domB = replaceResultWithWire(builder, inst.getResult(numPorts - 1));
 
-  SmallVector<Value, 1> inputDomain{domA};
-  SmallVector<Value, 1> outputDomain{domB};
   SmallVector<Value> inputs;
   for (unsigned i = 0; i != numDataInputs; ++i)
-    inputs.push_back(
-        replaceResultWithWire(builder, inst.getResult(i), inputDomain));
-  auto out =
-      replaceResultWithWire(builder, inst.getResult(outIdx), outputDomain);
+    inputs.push_back(replaceResultWithWire(builder, inst.getResult(i), {domA}));
+  auto out = replaceResultWithWire(builder, inst.getResult(outIdx), {domB});
 
   // en and test_en are swapped between extmodule and intrinsic.
   if (failed(swapEICGEnableInputs(op, inst, inputs)))

--- a/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
+++ b/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
@@ -48,6 +48,83 @@ firrtl.circuit "EICGWrapperPortName" {
 
 // -----
 
+// Test that an EICG wrapper with domain ports is properly lowered.
+// CHECK-LABEL: "FixupEICGWrapperDomains"
+firrtl.circuit "FixupEICGWrapperDomains" {
+  firrtl.domain @ClockDomain
+  // CHECK-NOEICG: LegacyClockGateDomains
+  // CHECK-EICG-NOT: LegacyClockGateDomains
+  firrtl.extmodule @LegacyClockGateDomains(
+    in in: !firrtl.clock domains [A],
+    in test_en: !firrtl.uint<1> domains [A],
+    in en: !firrtl.uint<1> domains [A],
+    out out: !firrtl.clock domains [B],
+    in A: !firrtl.domain<@ClockDomain()>,
+    in B: !firrtl.domain<@ClockDomain()>
+  ) attributes {defname = "EICG_wrapper"}
+
+  // CHECK: FixupEICGWrapperDomains
+  firrtl.module @FixupEICGWrapperDomains(
+    in %clock: !firrtl.clock domains [%A],
+    in %test_en: !firrtl.uint<1> domains [%A],
+    in %en: !firrtl.uint<1> domains [%A],
+    out %out: !firrtl.clock domains [%B],
+    in %A: !firrtl.domain<@ClockDomain()>,
+    in %B: !firrtl.domain<@ClockDomain()>
+  ) {
+    // CHECK-NOEICG: firrtl.instance
+    // CHECK-EICG-NOT: firrtl.instance
+    //
+    // Domain ports become plain domain wires, created before any data wires.
+    // CHECK-EICG-NEXT: %[[A:.+]] = firrtl.wire : !firrtl.domain<@ClockDomain()>
+    // CHECK-EICG-NEXT: %[[B:.+]] = firrtl.wire : !firrtl.domain<@ClockDomain()>
+    //
+    // Data port wires preserve their original domain associations.
+    // CHECK-EICG-NEXT: %[[CLK:.+]] = firrtl.wire domains[%[[A]]]
+    // CHECK-EICG-NEXT: %[[TEST_EN:.+]] = firrtl.wire domains[%[[A]]]
+    // CHECK-EICG-NEXT: %[[EN:.+]] = firrtl.wire domains[%[[A]]]
+    // CHECK-EICG-NEXT: %[[OUT:.+]] = firrtl.wire domains[%[[B]]]
+    //
+    // Each input is unsafe-cast into the anonymous domain before reaching
+    // the intrinsic.
+    // CHECK-EICG-NEXT: %[[ANON:.+]] = firrtl.domain.anon : !firrtl.domain<@ClockDomain()>
+    // CHECK-EICG-NEXT: %[[CLK_C:.+]] = firrtl.unsafe_domain_cast %[[CLK]] domains[%[[ANON]]]
+    // CHECK-EICG-NEXT: %[[TEST_EN_C:.+]] = firrtl.unsafe_domain_cast %[[TEST_EN]] domains[%[[ANON]]]
+    // CHECK-EICG-NEXT: %[[EN_C:.+]] = firrtl.unsafe_domain_cast %[[EN]] domains[%[[ANON]]]
+    //
+    // The intrinsic uses the cast inputs with en/test_en swapped.
+    // CHECK-EICG: %[[INT:.+]] = firrtl.int.generic "circt_clock_gate" %[[CLK_C]], %[[EN_C]], %[[TEST_EN_C]]
+    //
+    // The result is unsafe-cast back to the output's real domain and
+    // connected to the output wire.
+    // CHECK-EICG: %[[OUT_C:.+]] = firrtl.unsafe_domain_cast %[[INT]] domains[%[[B]]]
+    // CHECK-EICG: firrtl.matchingconnect %[[OUT]], %[[OUT_C]]
+    %ckg_in, %ckg_test_en, %ckg_en, %ckg_out, %ckg_A, %ckg_B = firrtl.instance ckg @LegacyClockGateDomains(
+      in in: !firrtl.clock domains [A],
+      in test_en: !firrtl.uint<1> domains [A],
+      in en: !firrtl.uint<1> domains [A],
+      out out: !firrtl.clock domains [B],
+      in A: !firrtl.domain<@ClockDomain()>,
+      in B: !firrtl.domain<@ClockDomain()>
+    )
+    // All uses are properly RAUW'd.
+    // CHECK-EICG-NEXT: firrtl.domain.define %[[A]], %A
+    // CHECK-EICG-NEXT: firrtl.domain.define %[[B]], %B
+    // CHECK-EICG-NEXT: firrtl.matchingconnect %[[CLK]], %clock
+    // CHECK-EICG-NEXT: firrtl.matchingconnect %[[TEST_EN]], %test_en
+    // CHECK-EICG-NEXT: firrtl.matchingconnect %[[EN]], %en
+    // CHECK-EICG-NEXT: firrtl.matchingconnect %out, %[[OUT]]
+    firrtl.domain.define %ckg_A, %A : !firrtl.domain<@ClockDomain()>
+    firrtl.domain.define %ckg_B, %B : !firrtl.domain<@ClockDomain()>
+    firrtl.matchingconnect %ckg_in, %clock : !firrtl.clock
+    firrtl.matchingconnect %ckg_test_en, %test_en : !firrtl.uint<1>
+    firrtl.matchingconnect %ckg_en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %ckg_out : !firrtl.clock
+  }
+}
+
+// -----
+
 // CHECK-LABEL: "FixupEICGWrapper2"
 firrtl.circuit "FixupEICGWrapper2" {
   // CHECK-NOEICG: LegacyClockGateNoTestEn

--- a/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
+++ b/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
@@ -52,8 +52,8 @@ firrtl.circuit "EICGWrapperPortName" {
 // CHECK-LABEL: "FixupEICGWrapperDomains"
 firrtl.circuit "FixupEICGWrapperDomains" {
   firrtl.domain @ClockDomain
-  // CHECK-NOEICG: LegacyClockGateDomains
-  // CHECK-EICG-NOT: LegacyClockGateDomains
+  // CHECK-NOEICG: firrtl.extmodule @LegacyClockGateDomains
+  // CHECK-EICG-NOT: firrtl.extmodule @LegacyClockGateDomains
   firrtl.extmodule @LegacyClockGateDomains(
     in in: !firrtl.clock domains [A],
     in test_en: !firrtl.uint<1> domains [A],
@@ -63,7 +63,7 @@ firrtl.circuit "FixupEICGWrapperDomains" {
     in B: !firrtl.domain<@ClockDomain()>
   ) attributes {defname = "EICG_wrapper"}
 
-  // CHECK: FixupEICGWrapperDomains
+  // CHECK: firrtl.module @FixupEICGWrapperDomains
   firrtl.module @FixupEICGWrapperDomains(
     in %clock: !firrtl.clock domains [%A],
     in %test_en: !firrtl.uint<1> domains [%A],
@@ -85,15 +85,8 @@ firrtl.circuit "FixupEICGWrapperDomains" {
     // CHECK-EICG-NEXT: %[[EN:.+]] = firrtl.wire domains[%[[A]]]
     // CHECK-EICG-NEXT: %[[OUT:.+]] = firrtl.wire domains[%[[B]]]
     //
-    // Each input is unsafe-cast into the anonymous domain before reaching
-    // the intrinsic.
-    // CHECK-EICG-NEXT: %[[ANON:.+]] = firrtl.domain.anon : !firrtl.domain<@ClockDomain()>
-    // CHECK-EICG-NEXT: %[[CLK_C:.+]] = firrtl.unsafe_domain_cast %[[CLK]] domains[%[[ANON]]]
-    // CHECK-EICG-NEXT: %[[TEST_EN_C:.+]] = firrtl.unsafe_domain_cast %[[TEST_EN]] domains[%[[ANON]]]
-    // CHECK-EICG-NEXT: %[[EN_C:.+]] = firrtl.unsafe_domain_cast %[[EN]] domains[%[[ANON]]]
-    //
     // The intrinsic uses the cast inputs with en/test_en swapped.
-    // CHECK-EICG: %[[INT:.+]] = firrtl.int.generic "circt_clock_gate" %[[CLK_C]], %[[EN_C]], %[[TEST_EN_C]]
+    // CHECK-EICG-NEXT: %[[INT:.+]] = firrtl.int.generic "circt_clock_gate" %[[CLK]], %[[EN]], %[[TEST_EN]]
     //
     // The result is unsafe-cast back to the output's real domain and
     // connected to the output wire.
@@ -141,4 +134,3 @@ firrtl.circuit "FixupEICGWrapper2" {
     firrtl.matchingconnect %ckg_en, %en : !firrtl.uint<1>
   }
 }
-


### PR DESCRIPTION
Update the `LowerIntModules` pass to make its `-fixup-eicg-wrapper` option
work with domains.  This now accepts one of two possible EICG wrapper port
representations: (1) one with no domain information and (2) one with full
domain information.

Once this is turned on internally and stable, I will plan to remove the
non-domain variant.

Fixes #10482.

Assisted-by: pi.dev:claude-opus-4-7
