### PR TITLE
[OM] Fix IntegerShlOp evaluation to allow arbitrary bitwidth

### DIFF
--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -836,15 +836,8 @@ IntegerShlOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
     return emitOpError("shift amount must be representable in 64 bits");
 
   int64_t shiftAmt = rhs.getExtValue();
-  // Extend lhs to at least 64 bits, matching the Python path which always
-  // produces si64. This handles shifts where the amount exceeds the lhs
-  // bitwidth without truncating the result.
-  llvm::APSInt extLhs = lhs.getBitWidth() < 64 ? lhs.extend(64) : lhs;
-  if ((uint64_t)shiftAmt >= extLhs.getBitWidth())
-    return emitOpError("shift amount ")
-           << shiftAmt << " is too large for integer width "
-           << extLhs.getBitWidth();
-  return success(extLhs << (unsigned)shiftAmt);
+  // Extend lhs to lhsWidth + shiftAmt bits so no bits are truncated.
+  return success(lhs.extend(lhs.getBitWidth() + shiftAmt) << shiftAmt);
 }
 
 OpFoldResult IntegerShlOp::fold(FoldAdaptor adaptor) {

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -834,7 +834,17 @@ IntegerShlOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
   // Check size constraint from implementation detail of using getExtValue.
   if (!rhs.isRepresentableByInt64())
     return emitOpError("shift amount must be representable in 64 bits");
-  return success(lhs << rhs.getExtValue());
+
+  int64_t shiftAmt = rhs.getExtValue();
+  // Extend lhs to at least 64 bits, matching the Python path which always
+  // produces si64. This handles shifts where the amount exceeds the lhs
+  // bitwidth without truncating the result.
+  llvm::APSInt extLhs = lhs.getBitWidth() < 64 ? lhs.extend(64) : lhs;
+  if ((uint64_t)shiftAmt >= extLhs.getBitWidth())
+    return emitOpError("shift amount ")
+           << shiftAmt << " is too large for integer width "
+           << extLhs.getBitWidth();
+  return success(extLhs << (unsigned)shiftAmt);
 }
 
 OpFoldResult IntegerShlOp::fold(FoldAdaptor adaptor) {

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -89,7 +89,7 @@ om.class @IntegerBinaryArithmeticFold(%x: !om.integer) -> (out1: !om.integer, ou
   // 3 * 4 folds to si4 -4 here.
   // CHECK-DAG: [[MUL:%.+]] = om.constant #om.integer<-4 : si4> : !om.integer
   // CHECK-DAG: [[SHR:%.+]] = om.constant #om.integer<1 : si4> : !om.integer
-  // CHECK-DAG: [[SHL:%.+]] = om.constant #om.integer<-2 : si4> : !om.integer
+  // CHECK-DAG: [[SHL:%.+]] = om.constant #om.integer<-2 : si64> : !om.integer
   // CHECK-DAG: [[WIDEADD:%.+]] = om.constant #om.integer<9 : si6> : !om.integer
   // CHECK: [[DYN:%.+]] = om.integer.add %x, %{{.+}} : !om.integer
   %0 = om.integer.add %i3, %i4 : !om.integer

--- a/test/Dialect/OM/canonicalizers.mlir
+++ b/test/Dialect/OM/canonicalizers.mlir
@@ -89,7 +89,7 @@ om.class @IntegerBinaryArithmeticFold(%x: !om.integer) -> (out1: !om.integer, ou
   // 3 * 4 folds to si4 -4 here.
   // CHECK-DAG: [[MUL:%.+]] = om.constant #om.integer<-4 : si4> : !om.integer
   // CHECK-DAG: [[SHR:%.+]] = om.constant #om.integer<1 : si4> : !om.integer
-  // CHECK-DAG: [[SHL:%.+]] = om.constant #om.integer<-2 : si64> : !om.integer
+  // CHECK-DAG: [[SHL:%.+]] = om.constant #om.integer<-2 : si5> : !om.integer
   // CHECK-DAG: [[WIDEADD:%.+]] = om.constant #om.integer<9 : si6> : !om.integer
   // CHECK: [[DYN:%.+]] = om.integer.add %x, %{{.+}} : !om.integer
   %0 = om.integer.add %i3, %i4 : !om.integer

--- a/test/Dialect/OM/elaborate-object-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-errors.mlir
@@ -60,7 +60,7 @@ om.class @ShlTooLarge() -> (result: !om.integer) {
   %c1 = om.constant #om.integer<1 : si8> : !om.integer
   %c64 = om.constant #om.integer<64 : si8> : !om.integer
   // expected-error @below {{shift amount 64 is too large for integer width 64}}
-  // expected-error @below {{failed to evaluate integer operation}}
+  // expected-error @below {{failed to evaluate om.integer.shl}}
   %result = om.integer.shl %c1, %c64 : !om.integer
   om.class.fields %result : !om.integer
 }

--- a/test/Dialect/OM/elaborate-object-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-errors.mlir
@@ -55,18 +55,6 @@ om.class private @BoolWrapper(%in: i1) -> (out: i1) {
 
 // -----
 
-// Negative shift amount is an error.
-om.class @ShlNegative() -> (result: !om.integer) {
-  %c1 = om.constant #om.integer<1 : si8> : !om.integer
-  %c_neg = om.constant #om.integer<-1 : si8> : !om.integer
-  // expected-error @below {{shift amount must be non-negative}}
-  // expected-error @below {{failed to evaluate om.integer.shl}}
-  %result = om.integer.shl %c1, %c_neg : !om.integer
-  om.class.fields %result : !om.integer
-}
-
-// -----
-
 // Cycle in dataflow (field access creates a cycle that can't be evaluated)
 om.class private @WrapperCycle(%val: !om.integer) -> (out: !om.integer) {
   om.class.fields %val : !om.integer

--- a/test/Dialect/OM/elaborate-object-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-errors.mlir
@@ -55,6 +55,18 @@ om.class private @BoolWrapper(%in: i1) -> (out: i1) {
 
 // -----
 
+// Shift amount too large (>= 64 after auto-extending lhs to si64)
+om.class @ShlTooLarge() -> (result: !om.integer) {
+  %c1 = om.constant #om.integer<1 : si8> : !om.integer
+  %c64 = om.constant #om.integer<64 : si8> : !om.integer
+  // expected-error @below {{shift amount 64 is too large for integer width 64}}
+  // expected-error @below {{failed to evaluate integer operation}}
+  %result = om.integer.shl %c1, %c64 : !om.integer
+  om.class.fields %result : !om.integer
+}
+
+// -----
+
 // Cycle in dataflow (field access creates a cycle that can't be evaluated)
 om.class private @WrapperCycle(%val: !om.integer) -> (out: !om.integer) {
   om.class.fields %val : !om.integer

--- a/test/Dialect/OM/elaborate-object-errors.mlir
+++ b/test/Dialect/OM/elaborate-object-errors.mlir
@@ -55,13 +55,13 @@ om.class private @BoolWrapper(%in: i1) -> (out: i1) {
 
 // -----
 
-// Shift amount too large (>= 64 after auto-extending lhs to si64)
-om.class @ShlTooLarge() -> (result: !om.integer) {
+// Negative shift amount is an error.
+om.class @ShlNegative() -> (result: !om.integer) {
   %c1 = om.constant #om.integer<1 : si8> : !om.integer
-  %c64 = om.constant #om.integer<64 : si8> : !om.integer
-  // expected-error @below {{shift amount 64 is too large for integer width 64}}
+  %c_neg = om.constant #om.integer<-1 : si8> : !om.integer
+  // expected-error @below {{shift amount must be non-negative}}
   // expected-error @below {{failed to evaluate om.integer.shl}}
-  %result = om.integer.shl %c1, %c64 : !om.integer
+  %result = om.integer.shl %c1, %c_neg : !om.integer
   om.class.fields %result : !om.integer
 }
 

--- a/test/Dialect/OM/elaborate-object.mlir
+++ b/test/Dialect/OM/elaborate-object.mlir
@@ -53,6 +53,18 @@ om.class @IntegerOps() -> (sum: !om.integer, product: !om.integer, shr: !om.inte
   om.class.fields %sum, %product, %shr_result, %shl_result : !om.integer, !om.integer, !om.integer, !om.integer
 }
 
+// Test shl with shift amount exceeding the lhs bitwidth (auto-extends lhs to si64)
+// CHECK-LABEL: om.class @IntegerShlAutoExtend() -> (result: !om.integer) {
+// CHECK:   %[[R:.+]] = om.constant #om.integer<65536 : si64> : !om.integer
+// CHECK:   om.class.fields %[[R]] : !om.integer
+// CHECK: }
+om.class @IntegerShlAutoExtend() -> (result: !om.integer) {
+  %c1 = om.constant #om.integer<1 : si8> : !om.integer
+  %c16 = om.constant #om.integer<16 : si8> : !om.integer
+  %result = om.integer.shl %c1, %c16 : !om.integer
+  om.class.fields %result : !om.integer
+}
+
 // More complex tests
 
 !list = !om.class.type<@LinkedList>

--- a/test/Dialect/OM/elaborate-object.mlir
+++ b/test/Dialect/OM/elaborate-object.mlir
@@ -36,7 +36,7 @@ om.class @SimpleList() -> (result: !om.list<!om.integer>) {
 // CHECK-DAG:   %[[SUM:.+]] = om.constant #om.integer<7 : si4> : !om.integer
 // CHECK-DAG:   %[[PRODUCT:.+]] = om.constant #om.integer<12 : si8> : !om.integer
 // CHECK-DAG:   %[[SHR:.+]] = om.constant #om.integer<2 : si8> : !om.integer
-// CHECK-DAG:   %[[SHL:.+]] = om.constant #om.integer<16 : si8> : !om.integer
+// CHECK-DAG:   %[[SHL:.+]] = om.constant #om.integer<16 : si64> : !om.integer
 // CHECK:   om.class.fields %[[SUM]], %[[PRODUCT]], %[[SHR]], %[[SHL]] : !om.integer, !om.integer, !om.integer, !om.integer
 // CHECK: }
 om.class @IntegerOps() -> (sum: !om.integer, product: !om.integer, shr: !om.integer, shl: !om.integer) {

--- a/test/Dialect/OM/elaborate-object.mlir
+++ b/test/Dialect/OM/elaborate-object.mlir
@@ -36,7 +36,7 @@ om.class @SimpleList() -> (result: !om.list<!om.integer>) {
 // CHECK-DAG:   %[[SUM:.+]] = om.constant #om.integer<7 : si4> : !om.integer
 // CHECK-DAG:   %[[PRODUCT:.+]] = om.constant #om.integer<12 : si8> : !om.integer
 // CHECK-DAG:   %[[SHR:.+]] = om.constant #om.integer<2 : si8> : !om.integer
-// CHECK-DAG:   %[[SHL:.+]] = om.constant #om.integer<16 : si64> : !om.integer
+// CHECK-DAG:   %[[SHL:.+]] = om.constant #om.integer<16 : si10> : !om.integer
 // CHECK:   om.class.fields %[[SUM]], %[[PRODUCT]], %[[SHR]], %[[SHL]] : !om.integer, !om.integer, !om.integer, !om.integer
 // CHECK: }
 om.class @IntegerOps() -> (sum: !om.integer, product: !om.integer, shr: !om.integer, shl: !om.integer) {
@@ -53,9 +53,9 @@ om.class @IntegerOps() -> (sum: !om.integer, product: !om.integer, shr: !om.inte
   om.class.fields %sum, %product, %shr_result, %shl_result : !om.integer, !om.integer, !om.integer, !om.integer
 }
 
-// Test shl with shift amount exceeding the lhs bitwidth (auto-extends lhs to si64)
+// Test shl with shift amount exceeding the lhs bitwidth (extends lhs to lhsWidth + shiftAmt)
 // CHECK-LABEL: om.class @IntegerShlAutoExtend() -> (result: !om.integer) {
-// CHECK:   %[[R:.+]] = om.constant #om.integer<65536 : si64> : !om.integer
+// CHECK:   %[[R:.+]] = om.constant #om.integer<65536 : si24> : !om.integer
 // CHECK:   om.class.fields %[[R]] : !om.integer
 // CHECK: }
 om.class @IntegerShlAutoExtend() -> (result: !om.integer) {


### PR DESCRIPTION
  Shifting a small integer (e.g. si8) by an amount >= its bitwidth
  triggered an assertion in APInt::shl. Auto-extend the lhs 
  before shifting.


Assisted-by: Claude Code: sonnet 4.6
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
