### PR TITLE
[SimToSV] Fix an error occurred when a sim.pause is nested in a scf.if

### DIFF
--- a/include/circt/Support/ProceduralRegionTrait.h
+++ b/include/circt/Support/ProceduralRegionTrait.h
@@ -33,6 +33,11 @@ LogicalResult verifyNotInProceduralRegion(Operation *op);
 /// non-procedural region.
 LogicalResult verifyNotInNonProceduralRegion(Operation *op);
 
+/// Returns true if `op` has a parent marked as a procedural region that is
+/// closer than any parent marked as a non-procedural region. Returns false
+/// otherwise, including when no parent is marked as either.
+bool isInProceduralRegion(Operation *op);
+
 /// Signals that an operation's regions are procedural.
 template <typename ConcreteType>
 class ProceduralRegion

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -499,7 +499,7 @@ static bool moveOpsIntoIfdefGuardsAndProcesses(Operation *rootOp) {
       // If there was no pre-existing guard, create one.
       if (!block) {
         OpBuilder builder(op);
-        if (op->getParentOp()->hasTrait<ProceduralRegion>())
+        if (isInProceduralRegion(op))
           block = sv::IfDefProceduralOp::create(
                       builder, loc, "SYNTHESIS", [] {}, [] {})
                       .getElseBlock();

--- a/lib/Support/ProceduralRegionTrait.cpp
+++ b/lib/Support/ProceduralRegionTrait.cpp
@@ -35,4 +35,15 @@ LogicalResult verifyNotInNonProceduralRegion(Operation *op) {
   return success();
 }
 
+bool isInProceduralRegion(Operation *op) {
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (parent->hasTrait<NonProceduralRegion>())
+      return false;
+    if (parent->hasTrait<ProceduralRegion>())
+      return true;
+  }
+  return false;
+}
+
 } // namespace circt

--- a/test/Conversion/SimToSV/simulation-control.mlir
+++ b/test/Conversion/SimToSV/simulation-control.mlir
@@ -117,3 +117,22 @@ hw.module @DontMergeDifferentClocksOrConditions(
   sim.clocked_pause %clockA, %condA, quiet
   sim.clocked_pause %clockA, %condB, verbose
 }
+
+// CHECK-LABEL: hw.module @NestedProceduralGuardInTriggered
+hw.module @NestedProceduralGuardInTriggered(in %trg: i1, in %cond: i1) {
+  // CHECK: hw.triggered posedge %trg(%cond) : i1 {
+  // CHECK-NEXT: ^bb0(%[[COND:.*]]: i1):
+  // CHECK-NEXT:   scf.if %[[COND]] {
+  // CHECK-NEXT:     sv.ifdef.procedural @SYNTHESIS {
+  // CHECK-NEXT:     } else {
+  // CHECK-NEXT:       sv.stop 0
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  hw.triggered posedge %trg(%cond) : i1 {
+  ^bb0(%cond_in: i1):
+    scf.if %cond_in {
+      sim.pause quiet
+    }
+  }
+}


### PR DESCRIPTION
Fix an error occurred when a `sim.pause` is nested in a `scf.if`

Fix #10536 

