### PR TITLE
Add BMCTrace runtime support and unit tests for text counterexample formatting

### DIFF
--- a/include/circt/Tools/circt-bmc/BMCTrace.h
+++ b/include/circt/Tools/circt-bmc/BMCTrace.h
@@ -27,28 +27,41 @@ namespace circt::bmc {
 
 class BMCTrace {
 public:
+  /// Opaque per-signal value reference recorded for a specific cycle.
   using Handle = const void *;
+  /// Callback used to materialize a recorded handle into a concrete value when
+  /// formatting a trace. The provided width is the declared width of the
+  /// signal, which may be zero for i0 values.
   using Evaluator =
       llvm::function_ref<std::optional<llvm::APInt>(Handle, unsigned width)>;
 
+  /// Metadata for a tracked signal in the trace.
   struct Signal {
     std::string name;
     unsigned width;
   };
 
+  /// Create an empty trace for the given top-level design/module name.
   explicit BMCTrace(llvm::StringRef topName = "bmc");
 
+  /// Register a signal to be tracked and return its stable index. Signals may
+  /// have zero width to represent i0 values.
   size_t addSignal(llvm::StringRef name, unsigned width);
+  /// Record the value handle for a tracked signal at the given cycle.
   void record(size_t step, size_t signal, Handle handle);
 
   llvm::StringRef getTopName() const { return topName; }
   llvm::ArrayRef<Signal> getSignals() const { return signals; }
   size_t getNumSteps() const { return recorded.size(); }
+  /// Return the recorded handle for a signal at a given cycle, if present.
   std::optional<Handle> lookup(size_t step, size_t signal) const;
 
+  /// Render the trace as cycle-by-cycle text using the provided evaluator to
+  /// materialize values from recorded handles.
   bool printTextTrace(llvm::raw_ostream &os, Evaluator evaluate) const;
 
 private:
+  /// Per-cycle storage for all tracked signals.
   using Step = std::vector<std::optional<Handle>>;
 
   void ensureStep(size_t step);

--- a/include/circt/Tools/circt-bmc/BMCTrace.h
+++ b/include/circt/Tools/circt-bmc/BMCTrace.h
@@ -1,0 +1,63 @@
+//===- BMCTrace.h - Runtime trace storage for circt-bmc ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the runtime trace store used by circt-bmc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_TOOLS_CIRCT_BMC_BMCTRACE_H
+#define CIRCT_TOOLS_CIRCT_BMC_BMCTRACE_H
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace circt::bmc {
+
+class BMCTrace {
+public:
+  using Handle = const void *;
+  using Evaluator =
+      llvm::function_ref<std::optional<llvm::APInt>(Handle, unsigned width)>;
+
+  struct Signal {
+    std::string name;
+    unsigned width;
+  };
+
+  explicit BMCTrace(llvm::StringRef topName = "bmc");
+
+  size_t addSignal(llvm::StringRef name, unsigned width);
+  void record(size_t step, size_t signal, Handle handle);
+
+  llvm::StringRef getTopName() const { return topName; }
+  llvm::ArrayRef<Signal> getSignals() const { return signals; }
+  size_t getNumSteps() const { return recorded.size(); }
+  std::optional<Handle> lookup(size_t step, size_t signal) const;
+
+  bool printTextTrace(llvm::raw_ostream &os, Evaluator evaluate) const;
+
+private:
+  using Step = std::vector<std::optional<Handle>>;
+
+  void ensureStep(size_t step);
+
+  std::string topName;
+  std::vector<Signal> signals;
+  std::vector<Step> recorded;
+};
+
+} // namespace circt::bmc
+
+#endif // CIRCT_TOOLS_CIRCT_BMC_BMCTRACE_H

--- a/lib/Tools/circt-bmc/CMakeLists.txt
+++ b/lib/Tools/circt-bmc/CMakeLists.txt
@@ -21,3 +21,5 @@ add_circt_library(CIRCTBMCTransforms
   MLIRSCFDialect
   MLIRTransforms
 )
+
+add_subdirectory(Runtime)

--- a/lib/Tools/circt-bmc/Runtime/BMCTrace.cpp
+++ b/lib/Tools/circt-bmc/Runtime/BMCTrace.cpp
@@ -1,0 +1,63 @@
+//===- BMCTrace.cpp -------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Tools/circt-bmc/BMCTrace.h"
+
+#include "llvm/ADT/SmallString.h"
+
+#include <cassert>
+
+circt::bmc::BMCTrace::BMCTrace(llvm::StringRef topName) : topName(topName) {}
+
+size_t circt::bmc::BMCTrace::addSignal(llvm::StringRef name, unsigned width) {
+  assert(width > 0 && "tracked signals must have a positive width");
+  signals.push_back({name.str(), width});
+  for (auto &step : recorded)
+    step.resize(signals.size());
+  return signals.size() - 1;
+}
+
+void circt::bmc::BMCTrace::ensureStep(size_t step) {
+  if (step >= recorded.size())
+    recorded.resize(step + 1, Step(signals.size()));
+}
+
+void circt::bmc::BMCTrace::record(size_t step, size_t signal, Handle handle) {
+  assert(signal < signals.size() && "signal index out of range");
+  ensureStep(step);
+  recorded[step][signal] = handle;
+}
+
+std::optional<circt::bmc::BMCTrace::Handle>
+circt::bmc::BMCTrace::lookup(size_t step, size_t signal) const {
+  if (step >= recorded.size() || signal >= signals.size())
+    return std::nullopt;
+  return recorded[step][signal];
+}
+
+bool circt::bmc::BMCTrace::printTextTrace(llvm::raw_ostream &os,
+                                          Evaluator evaluate) const {
+  os << "counterexample for " << topName << ":\n";
+  for (size_t step = 0, e = recorded.size(); step != e; ++step) {
+    os << "cycle " << step << ":\n";
+    for (size_t signal = 0, numSignals = signals.size(); signal != numSignals;
+         ++signal) {
+      auto handle = recorded[step][signal];
+      if (!handle)
+        return false;
+      auto value = evaluate(*handle, signals[signal].width);
+      if (!value || value->getBitWidth() != signals[signal].width)
+        return false;
+      llvm::SmallString<40> str;
+      value->toString(str, /*Radix=*/16, /*Signed=*/false,
+                      /*formatAsCLiteral=*/false, /*UpperCase=*/false);
+      os << "  " << signals[signal].name << " = 0x" << str << "\n";
+    }
+  }
+  return true;
+}

--- a/lib/Tools/circt-bmc/Runtime/BMCTrace.cpp
+++ b/lib/Tools/circt-bmc/Runtime/BMCTrace.cpp
@@ -15,7 +15,6 @@
 circt::bmc::BMCTrace::BMCTrace(llvm::StringRef topName) : topName(topName) {}
 
 size_t circt::bmc::BMCTrace::addSignal(llvm::StringRef name, unsigned width) {
-  assert(width > 0 && "tracked signals must have a positive width");
   signals.push_back({name.str(), width});
   for (auto &step : recorded)
     step.resize(signals.size());

--- a/lib/Tools/circt-bmc/Runtime/CMakeLists.txt
+++ b/lib/Tools/circt-bmc/Runtime/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_circt_library(CIRCTBMCRuntime
+  EXCLUDE_FROM_LIBMLIR
+  BMCTrace.cpp
+
+  LINK_COMPONENTS
+  Support
+)

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LLVM_LINK_COMPONENTS Support ${CIRCT_BMC_JIT_LLVM_COMPONENTS})
 add_circt_tool(circt-bmc circt-bmc.cpp)
 target_link_libraries(circt-bmc
   PRIVATE
+  CIRCTBMCRuntime
   CIRCTBMCTransforms
   CIRCTComb
   CIRCTCombToSMT

--- a/unittests/Tools/CMakeLists.txt
+++ b/unittests/Tools/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(circt-bmc)
+
 if(CIRCT_SLANG_FRONTEND_ENABLED)
   add_subdirectory(circt-verilog-lsp-server)
 endif()

--- a/unittests/Tools/circt-bmc/BMCTraceTest.cpp
+++ b/unittests/Tools/circt-bmc/BMCTraceTest.cpp
@@ -1,0 +1,86 @@
+//===- BMCTraceTest.cpp ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Tools/circt-bmc/BMCTrace.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <cstdint>
+#include <optional>
+
+using namespace circt::bmc;
+using testing::HasSubstr;
+
+namespace {
+
+static std::optional<llvm::APInt> evaluateWord(BMCTrace::Handle handle,
+                                               unsigned width) {
+  auto value = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(handle));
+  return llvm::APInt(width, value);
+}
+
+TEST(BMCTraceTest, RecordsSignalsByStep) {
+  BMCTrace trace("top");
+  auto dataIn = trace.addSignal("data_in", 8);
+  auto stateQ = trace.addSignal("state_q", 8);
+
+  trace.record(
+      0, dataIn,
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0xff)));
+  trace.record(
+      0, stateQ,
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x00)));
+  trace.record(
+      1, dataIn,
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x12)));
+  trace.record(
+      1, stateQ,
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0xff)));
+
+  EXPECT_EQ(trace.getSignals().size(), 2u);
+  EXPECT_EQ(trace.getNumSteps(), 2u);
+  EXPECT_EQ(trace.lookup(0, dataIn),
+            reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0xff)));
+  EXPECT_EQ(trace.lookup(1, stateQ),
+            reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0xff)));
+}
+
+TEST(BMCTraceTest, PrintsTextTrace) {
+  BMCTrace trace("top");
+  auto dataIn = trace.addSignal("data_in", 8);
+  auto stateQ = trace.addSignal("state_q", 8);
+
+  trace.record(
+      0, dataIn,
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0xff)));
+  trace.record(
+      0, stateQ,
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x00)));
+  trace.record(
+      1, dataIn,
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x12)));
+  trace.record(
+      1, stateQ,
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0xff)));
+
+  std::string output;
+  llvm::raw_string_ostream os(output);
+  ASSERT_TRUE(trace.printTextTrace(os, evaluateWord));
+  os.flush();
+  llvm::errs() << output;
+
+  EXPECT_THAT(output, HasSubstr("counterexample for top:\n"));
+  EXPECT_THAT(output,
+              HasSubstr("cycle 0:\n  data_in = 0xff\n  state_q = 0x0\n"));
+  EXPECT_THAT(output,
+              HasSubstr("cycle 1:\n  data_in = 0x12\n  state_q = 0xff\n"));
+}
+
+} // namespace

--- a/unittests/Tools/circt-bmc/BMCTraceTest.cpp
+++ b/unittests/Tools/circt-bmc/BMCTraceTest.cpp
@@ -74,13 +74,27 @@ TEST(BMCTraceTest, PrintsTextTrace) {
   llvm::raw_string_ostream os(output);
   ASSERT_TRUE(trace.printTextTrace(os, evaluateWord));
   os.flush();
-  llvm::errs() << output;
 
   EXPECT_THAT(output, HasSubstr("counterexample for top:\n"));
   EXPECT_THAT(output,
               HasSubstr("cycle 0:\n  data_in = 0xff\n  state_q = 0x0\n"));
   EXPECT_THAT(output,
               HasSubstr("cycle 1:\n  data_in = 0x12\n  state_q = 0xff\n"));
+}
+
+TEST(BMCTraceTest, SupportsZeroWidthSignals) {
+  BMCTrace trace("top");
+  auto empty = trace.addSignal("empty", 0);
+
+  trace.record(0, empty,
+               reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x0)));
+
+  std::string output;
+  llvm::raw_string_ostream os(output);
+  ASSERT_TRUE(trace.printTextTrace(os, evaluateWord));
+  os.flush();
+
+  EXPECT_THAT(output, HasSubstr("cycle 0:\n  empty = 0x0\n"));
 }
 
 } // namespace

--- a/unittests/Tools/circt-bmc/CMakeLists.txt
+++ b/unittests/Tools/circt-bmc/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_circt_unittest(CIRCTBMCToolsTests
+  BMCTraceTest.cpp
+)
+
+target_link_libraries(CIRCTBMCToolsTests
+  PRIVATE
+  CIRCTBMCRuntime
+)


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

This change adds a circt-bmc runtime trace container for storing cycle-by-cycle signal values and rendering them as a textual counterexample trace. It also adds focused unit coverage for trace recording and text formatting.

BMCTrace models a trace as a cycle-oriented structure:

  - signals are registered once with name and width
  - values are recorded by (step, signal)
  - printTextTrace materializes values through an evaluator callback and emits a
    readable counterexample trace
    
Assisted-by: codex:gpt-5.4(medium)