### PR TITLE
[ESI][Runtime] Codegen: emit structs with accessors

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -137,6 +137,7 @@ set(ESICppRuntimeSources
 set(ESICppRuntimeHeaders
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Utils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Accelerator.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/BitAccess.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/CLI.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Common.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Context.h

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/BitAccess.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/BitAccess.h
@@ -1,0 +1,153 @@
+//===- BitAccess.h - Bit-level helpers for generated types ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT.
+//
+// Helpers used by `esiaccel.codegen`-generated headers to read and write
+// arbitrary-width integer fields out of a contiguous wire-byte buffer. The
+// runtime emits each struct/union as a `std::array<uint8_t, N>` matching the
+// on-wire bit layout exactly, and these helpers handle the shift/mask work
+// (including signed sign-extension) without depending on C++ bit-fields,
+// which have implementation-defined layout that differs between the Itanium
+// ABI (GCC/Clang) and MSVC.
+//
+// `BitOffset` and `Width` are non-type template parameters so the per-field
+// constants from the generated code (a) participate in `static_assert`
+// checks against `Storage`, and (b) let the optimiser fully unroll the
+// per-bit loop.
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef ESI_BITACCESS_H
+#define ESI_BITACCESS_H
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace esi {
+namespace detail {
+
+/// Read `Width` bits starting at `BitOffset` (LSB-first within `bytes`) and
+/// return them zero-extended in `Storage`. `Storage` must be an unsigned
+/// integer type wide enough to hold `Width` bits.
+template <typename Storage, std::size_t BitOffset, std::size_t Width>
+inline constexpr Storage readUnsignedBits(const uint8_t *bytes) {
+  static_assert(std::is_unsigned<Storage>::value,
+                "readUnsignedBits Storage must be unsigned");
+  static_assert(Width != 0, "readUnsignedBits Width must be non-zero");
+  static_assert(sizeof(Storage) * 8 >= Width,
+                "readUnsignedBits Storage is narrower than Width");
+  Storage result = 0;
+  for (std::size_t i = 0; i < Width; ++i) {
+    std::size_t src = BitOffset + i;
+    Storage bit = static_cast<Storage>((bytes[src >> 3] >> (src & 7)) & 1u);
+    result |= static_cast<Storage>(bit << i);
+  }
+  return result;
+}
+
+/// Read `Width` bits starting at `BitOffset` (LSB-first) and sign-extend
+/// into the signed integer type `Signed`. `Signed` must be at least `Width`
+/// bits wide.
+template <typename Signed, std::size_t BitOffset, std::size_t Width>
+inline constexpr Signed readSignedBits(const uint8_t *bytes) {
+  static_assert(std::is_signed<Signed>::value,
+                "readSignedBits Signed must be signed");
+  static_assert(Width != 0, "readSignedBits Width must be non-zero");
+  static_assert(sizeof(Signed) * 8 >= Width,
+                "readSignedBits Signed is narrower than Width");
+  using Unsigned = typename std::make_unsigned<Signed>::type;
+  Unsigned u = readUnsignedBits<Unsigned, BitOffset, Width>(bytes);
+  if constexpr (Width < sizeof(Unsigned) * 8) {
+    // Branch-free sign extend: `(u ^ signBit) - signBit` flips the sign
+    // bit and subtracts it back, leaving the high bits all-ones when the
+    // sign bit was set and unchanged otherwise. Avoids relying on the
+    // arithmetic-shift behaviour of signed right-shift.
+    constexpr Unsigned signBit = static_cast<Unsigned>(1) << (Width - 1);
+    u = static_cast<Unsigned>((u ^ signBit) - signBit);
+  }
+  return static_cast<Signed>(u);
+}
+
+/// Write the low `Width` bits of `value` into `bytes` starting at
+/// `BitOffset` (LSB-first). Other bits in the affected bytes are preserved.
+template <typename Storage, std::size_t BitOffset, std::size_t Width>
+inline constexpr void writeUnsignedBits(uint8_t *bytes, Storage value) {
+  static_assert(std::is_unsigned<Storage>::value,
+                "writeUnsignedBits Storage must be unsigned");
+  static_assert(Width != 0, "writeUnsignedBits Width must be non-zero");
+  static_assert(sizeof(Storage) * 8 >= Width,
+                "writeUnsignedBits Storage is narrower than Width");
+  for (std::size_t i = 0; i < Width; ++i) {
+    std::size_t dst = BitOffset + i;
+    std::size_t shift = dst & 7;
+    uint8_t mask = static_cast<uint8_t>(1u << shift);
+    uint8_t bit = static_cast<uint8_t>((value >> i) & static_cast<Storage>(1));
+    bytes[dst >> 3] =
+        static_cast<uint8_t>((bytes[dst >> 3] & static_cast<uint8_t>(~mask)) |
+                             static_cast<uint8_t>(bit << shift));
+  }
+}
+
+/// Convenience overload for signed values. Reinterprets the value as
+/// unsigned (two's complement) and writes the low `Width` bits.
+template <typename Signed, std::size_t BitOffset, std::size_t Width>
+inline constexpr void writeSignedBits(uint8_t *bytes, Signed value) {
+  static_assert(std::is_signed<Signed>::value,
+                "writeSignedBits Signed must be signed");
+  static_assert(Width != 0, "writeSignedBits Width must be non-zero");
+  static_assert(sizeof(Signed) * 8 >= Width,
+                "writeSignedBits Signed is narrower than Width");
+  using Unsigned = typename std::make_unsigned<Signed>::type;
+  writeUnsignedBits<Unsigned, BitOffset, Width>(bytes,
+                                                static_cast<Unsigned>(value));
+}
+
+/// Copy `Width` bits out of `src` starting at `BitOffset` into `dst`
+/// packed LSB-first from bit 0. Used to embed an aggregate (struct, union,
+/// or array) at an arbitrary bit position inside a parent wire buffer:
+/// the inner type already stores its bits LSB-first in `dst`, so the
+/// destination bits land at the same positions they'd occupy if the inner
+/// was read out at byte alignment. `dst` must be zero-initialised on entry
+/// (the helper only sets `1` bits) and must hold at least
+/// `ceil(Width / 8)` bytes.
+template <std::size_t BitOffset, std::size_t Width>
+inline constexpr void copyBitsIn(const uint8_t *src, uint8_t *dst) {
+  static_assert(Width != 0, "copyBitsIn Width must be non-zero");
+  for (std::size_t i = 0; i < Width; ++i) {
+    std::size_t s = BitOffset + i;
+    uint8_t bit = static_cast<uint8_t>((src[s >> 3] >> (s & 7)) & 1u);
+    dst[i >> 3] = static_cast<uint8_t>(dst[i >> 3] | (bit << (i & 7)));
+  }
+}
+
+/// Inverse of `copyBitsIn`: take `Width` bits packed LSB-first from bit 0
+/// of `src` and write them into `dst` starting at `BitOffset`. Other bits
+/// in the affected bytes of `dst` are preserved.
+template <std::size_t BitOffset, std::size_t Width>
+inline constexpr void copyBitsOut(uint8_t *dst, const uint8_t *src) {
+  static_assert(Width != 0, "copyBitsOut Width must be non-zero");
+  for (std::size_t i = 0; i < Width; ++i) {
+    std::size_t d = BitOffset + i;
+    std::size_t shift = d & 7;
+    uint8_t mask = static_cast<uint8_t>(1u << shift);
+    uint8_t bit = static_cast<uint8_t>((src[i >> 3] >> (i & 7)) & 1u);
+    dst[d >> 3] =
+        static_cast<uint8_t>((dst[d >> 3] & static_cast<uint8_t>(~mask)) |
+                             static_cast<uint8_t>(bit << shift));
+  }
+}
+
+} // namespace detail
+} // namespace esi
+
+#endif // ESI_BITACCESS_H

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -664,7 +664,6 @@ class CppGenerator(Generator):
         else:
           port_groups = []
       except (NotImplementedError, ValueError) as e:
-        sys.stderr.write(f"Warning: skipping module '{name}': {e}\n")
         hdr_file = output_dir / f"{name}.h"
         with open(hdr_file, "w", encoding="utf-8") as hdr:
           hdr.write(f"// Skipped: {e}\n")
@@ -2023,7 +2022,6 @@ class CppTypeEmitter:
             "  Emitted code may fail to compile due to ordering issues.\n")
 
       for skipped_type, reason in self.skipped_types:
-        sys.stderr.write(f"Warning: skipping type '{skipped_type}': {reason}\n")
         hdr.write(f"// Unsupported type '{skipped_type}': {reason}\n\n")
 
       for emit_type in self.ordered_types:

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -999,12 +999,17 @@ class CppTypePlanner:
       if isinstance(esi_type,
                     types.StructType) and esi_type in window_into_types:
         skip_set.add(esi_type)
+        self.skipped_types.append(
+            (esi_type,
+             "into-type of a windowed helper; subsumed by the helper class"))
         continue
       if isinstance(esi_type, types.TypeAlias):
         inner = esi_type.inner_type
         if inner is not None and self._unwrap_aliases(
             inner) in window_into_types:
           skip_set.add(esi_type)
+          self.skipped_types.append(
+              (esi_type, "alias of a windowed helper's into-type"))
           continue
       # Skip structs/unions/aliases that transitively embed a WindowType
       # field. WindowType itself is fine — it emits as its own helper
@@ -1428,17 +1433,21 @@ class CppTypeEmitter:
         byte_offset = bit_offset // 8
         byte_width = bit_width // 8
 
-        # Path A: standard-width byte-aligned integer. The `reinterpret_cast`
-        # aliases through the `std::array<uint8_t, N>` storage the runtime
-        # already treats as wire bytes elsewhere.
+        # Path A: standard-width byte-aligned integer. `std::memcpy`
+        # avoids the unaligned-load / strict-aliasing / object-lifetime
+        # UB that a `reinterpret_cast` deref through a `uint8_t` buffer
+        # would invoke (MSVC / ASan / UBSan in particular). The compiler
+        # collapses both calls to a single mov on -O1+.
         if bit_width in (8, 16, 32, 64):
           hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-          hdr.write(f"{indent}  return *reinterpret_cast<const {field_cpp} *>("
-                    f"{raw_member}.data() + {byte_offset});\n")
+          hdr.write(f"{indent}  {field_cpp} out;\n")
+          hdr.write(f"{indent}  std::memcpy(&out, {raw_member}.data() + "
+                    f"{byte_offset}, sizeof({field_cpp}));\n")
+          hdr.write(f"{indent}  return out;\n")
           hdr.write(f"{indent}}}\n")
           hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
-          hdr.write(f"{indent}  *reinterpret_cast<{field_cpp} *>("
-                    f"{raw_member}.data() + {byte_offset}) = v;\n")
+          hdr.write(f"{indent}  std::memcpy({raw_member}.data() + "
+                    f"{byte_offset}, &v, sizeof({field_cpp}));\n")
           hdr.write(f"{indent}  return *this;\n")
           hdr.write(f"{indent}}}\n")
           return
@@ -1895,11 +1904,19 @@ class CppTypeEmitter:
         elem_cpp = "value_type"
       else:
         elem_cpp = self._cpp_type(field_type)
-      # The data-frame accessor is now a member function returning by value,
-      # so the projection has to call it rather than form a
-      # pointer-to-data-member. A lambda keeps the projection valid even
-      # when the accessor overload set includes an indexed `field(size_t)`
-      # variant for fixed-size arrays.
+      # The data-frame accessor is now a member function returning by value
+      # (the underlying `_bytes` is private; getters reconstruct the field
+      # value from its wire bytes), so the projection has to call it
+      # rather than form a pointer-to-data-member.
+      #
+      # TODO: For byte-aligned aggregate data fields this means iterating
+      # `field()` copies each element; the pre-B3 pointer-to-member form
+      # could yield references for free. If profiling shows it matters,
+      # we can add a separate `field_ref()` accessor on `data_frame` for
+      # byte-aligned aggregate fields (they're stored contiguously inside
+      # `_bytes` and the inner type's only member is itself a byte array,
+      # so a `reinterpret_cast`-backed reference is well-defined) and
+      # project on that instead.
       projection = (f"[](const data_frame &f) -> {elem_cpp} "
                     f"{{ return f.{field_name}(); }}")
       hdr.write(

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -692,6 +692,10 @@ class CppTypePlanner:
     # Track alias base names to warn on collisions.
     self.alias_base_names: Set[str] = set()
     self.ordered_types: List[types.ESIType] = []
+    # Types the planner chose not to emit, paired with the reason. The
+    # emitter writes a `// Unsupported type ...` comment for each so the
+    # generated header explains the omission.
+    self.skipped_types: List[Tuple[types.ESIType, str]] = []
     self.has_cycle = False
     self._prepare_types(type_table)
 
@@ -953,6 +957,31 @@ class CppTypePlanner:
       return self._contains_window(unwrapped.element_type)
     return False
 
+  def _contains_unbounded(self, esi_type: types.ESIType) -> bool:
+    """Return True if `esi_type` is or transitively contains a type with
+    no bounded bit width (e.g. `!esi.any`, or a list that the window
+    helper can't wrap).
+
+    A struct can't be emitted as a fixed-size raw-bytes buffer if any
+    field's width is unbounded — there's no `std::array<uint8_t, N>` size
+    that would match the wire layout — so the planner excludes such
+    structs (and aliases/unions/arrays that reach one) from the emission
+    list, the same way `_contains_window` does for nested windows.
+    """
+    unwrapped = self._unwrap_aliases(esi_type)
+    try:
+      if unwrapped.bit_width < 0:
+        return True
+    except Exception:
+      return True
+    if isinstance(unwrapped, types.StructType):
+      return any(self._contains_unbounded(ft) for _, ft in unwrapped.fields)
+    if isinstance(unwrapped, types.UnionType):
+      return any(self._contains_unbounded(ft) for _, ft in unwrapped.fields)
+    if isinstance(unwrapped, types.ArrayType):
+      return self._contains_unbounded(unwrapped.element_type)
+    return False
+
   def _ordered_emit_types(self) -> Tuple[List[types.ESIType], bool]:
     """Collect and order types for deterministic emission."""
     window_into_types: Set[types.ESIType] = set()
@@ -961,20 +990,45 @@ class CppTypePlanner:
         continue
       assert isinstance(esi_type, types.WindowType)
       window_into_types.add(self._unwrap_aliases(esi_type.into_type))
-    emit_types: List[types.ESIType] = []
+
+    # Build the skip set up front so the DFS dep-walk below can filter
+    # against it too — otherwise a top-level type can pull a skipped
+    # inner struct back into the emission list via `_collect_decls_*`.
+    skip_set: Set[types.ESIType] = set()
     for esi_type in self.type_id_map.keys():
       if isinstance(esi_type,
                     types.StructType) and esi_type in window_into_types:
+        skip_set.add(esi_type)
         continue
       if isinstance(esi_type, types.TypeAlias):
         inner = esi_type.inner_type
         if inner is not None and self._unwrap_aliases(
             inner) in window_into_types:
+          skip_set.add(esi_type)
           continue
-      # Skip structs/unions/aliases that transitively embed a WindowType field.
-      # WindowType itself is fine — it emits as its own helper class.
+      # Skip structs/unions/aliases that transitively embed a WindowType
+      # field. WindowType itself is fine — it emits as its own helper
+      # class.
       if (not isinstance(self._unwrap_aliases(esi_type), types.WindowType) and
           self._contains_window(esi_type)):
+        skip_set.add(esi_type)
+        self.skipped_types.append((esi_type, "contains a windowed sub-type"))
+        continue
+      # Skip structs/unions/aliases that transitively contain an
+      # unbounded type (e.g. `!esi.any`). No fixed-size raw-bytes buffer
+      # can hold them, so the per-field emitter has no width to embed.
+      # WindowType itself reports unbounded width but emits as its own
+      # helper class, so leave that branch alone.
+      if (not isinstance(self._unwrap_aliases(esi_type), types.WindowType) and
+          self._contains_unbounded(esi_type)):
+        skip_set.add(esi_type)
+        self.skipped_types.append(
+            (esi_type, "contains an unbounded sub-type (e.g. !esi.any)"))
+        continue
+
+    emit_types: List[types.ESIType] = []
+    for esi_type in self.type_id_map.keys():
+      if esi_type in skip_set:
         continue
       if (isinstance(esi_type,
                      (types.StructType, types.UnionType, types.TypeAlias)) or
@@ -992,7 +1046,10 @@ class CppTypePlanner:
     visiting: Set[types.ESIType] = set()
     has_cycle = False
 
-    # Visit callback: DFS to emit dependencies before their users.
+    # Visit callback: DFS to emit dependencies before their users. Skipped
+    # types are filtered out of the dep set so they can't sneak back in
+    # via a non-skipped type that happens to reference them (e.g. an
+    # alias whose dep walk reaches the into-struct of a window helper).
     def visit(current: types.ESIType) -> None:
       nonlocal has_cycle
       if current in visited:
@@ -1014,6 +1071,8 @@ class CppTypePlanner:
         assert isinstance(current, types.WindowType)
         deps.update(self._collect_decls_from_window(current))
       for dep in sorted(deps, key=lambda dep: self.type_id_map[dep]):
+        if dep in skip_set:
+          continue
         visit(dep)
 
       visiting.remove(current)
@@ -1032,6 +1091,7 @@ class CppTypeEmitter:
   def __init__(self, planner: CppTypePlanner) -> None:
     self.type_id_map = planner.type_id_map
     self.ordered_types = planner.ordered_types
+    self.skipped_types = planner.skipped_types
     self.has_cycle = planner.has_cycle
 
   def type_identifier(self, type: types.ESIType) -> str:
@@ -1148,20 +1208,6 @@ class CppTypeEmitter:
       wrapped = wrapped.inner_type
     return wrapped
 
-  def _format_window_field_decl(self, field_name: str,
-                                field_type: types.ESIType) -> str:
-    """Emit a packed field declaration for generated window helpers.
-
-    Arrays use `std::array` (handled by `_cpp_type`), so no bracket syntax is
-    needed and a single uniform declaration form covers every type.
-    """
-    field_cpp = self._cpp_type(field_type)
-    wrapped = self._unwrap_aliases(field_type)
-    if isinstance(wrapped, (types.BitsType, types.IntType)) and \
-       wrapped.bit_width % 8 != 0:
-      return f"{field_cpp} {field_name} : {wrapped.bit_width};"
-    return f"{field_cpp} {field_name};"
-
   def _format_window_ctor_param(self, field_name: str,
                                 field_type: types.ESIType) -> str:
     """Emit a constructor parameter for generated window helpers.
@@ -1174,11 +1220,6 @@ class CppTypeEmitter:
     if isinstance(wrapped, (types.BitsType, types.IntType)):
       return f"{field_cpp} {field_name}"
     return f"const {field_cpp} &{field_name}"
-
-  def _emit_window_field_copy(self, hdr: TextIO, dest_expr: str, src_expr: str,
-                              field_type: types.ESIType) -> None:
-    """Copy a generated window field."""
-    hdr.write(f"    {dest_expr} = {src_expr};\n")
 
   def _field_byte_width(self, field_type: types.ESIType) -> int:
     """Compute the byte width of a field type, rounding up to full bytes."""
@@ -1303,124 +1344,422 @@ class CppTypeEmitter:
         "window_name": self.type_id_map[window_type],
     }
 
+  def _compute_field_bit_offsets(
+      self, struct_type: types.StructType) -> Tuple[Dict[str, int], int]:
+    """Return `(bit_offset_by_name, total_bits)` for non-void fields.
+
+    Fields are laid out LSB-first in wire order, which is reversed manifest
+    order when `cpp_type.reverse` is set. Caller already knows each field's
+    type/width from `struct_type.fields`; we only need the per-name offset
+    and the resulting total bit width to size the storage array.
+    """
+    declared = struct_type.fields
+    if struct_type.cpp_type.reverse:
+      declared = list(reversed(declared))
+    bit_offsets: Dict[str, int] = {}
+    bit_offset = 0
+    for field_name, field_type in declared:
+      if self._cpp_type(field_type) == "void":
+        continue
+      bit_offsets[field_name] = bit_offset
+      bit_offset += field_type.bit_width
+    return bit_offsets, bit_offset
+
+  def _is_signed_int_field(self, field_type: types.ESIType) -> bool:
+    """True if the field is a signed integer (only `IntType`, not `UIntType`
+    or `BitsType`)."""
+    wrapped = self._unwrap_aliases(field_type)
+    return (isinstance(wrapped, types.IntType) and
+            not isinstance(wrapped, types.UIntType))
+
+  def _emit_field_accessor(self, hdr: TextIO, indent: str, raw_member: str,
+                           self_type: str, field_name: str,
+                           field_type: types.ESIType, bit_offset: int,
+                           bit_width: int) -> None:
+    """Emit a getter/setter pair that reads/writes `field_name` out of the
+    raw bytes member `raw_member` at `bit_offset` / `bit_width`.
+
+    Setters share the field's name (no `set_` prefix) and return
+    `self_type &` so the caller can chain calls (e.g.
+    `Foo{}.a(1).b(2).inner(x)`).
+
+    For integer fields the emitter picks between three inline strategies,
+    fastest first:
+
+      * Path A — 8/16/32/64-bit fields at a byte-aligned offset. Read/write
+        via a `reinterpret_cast` through the underlying `std::array<uint8_t>`,
+        matching the same aliasing pattern the runtime already relies on in
+        `MessageData::from<T>()` / `MessageData::as<T>()`.
+      * Path B — byte-aligned offset and width but a non-standard width
+        (e.g. `i24`, `i48`). Read each byte directly out of `_bytes` and
+        OR-shift them together (and the reverse on write — split the
+        value out one byte at a time). Signed fields read into the
+        matching unsigned, then sign-extend before returning.
+      * Path C — sub-byte alignment. Fall back to the
+        `esi::detail::{read,write}{Un,}signedBits` helpers from
+        `esi/BitAccess.h`, which loop over the constituent bits.
+    """
+    field_cpp = self._cpp_type(field_type)
+    if field_cpp == "void":
+      return
+
+    wrapped = self._unwrap_aliases(field_type)
+
+    if isinstance(wrapped, (types.BitsType, types.IntType)):
+      # `bool` is the storage choice for a single bit; bit-precise helpers
+      # are the simplest fit and the optimiser collapses them on -O2.
+      if bit_width == 1 and field_cpp == "bool":
+        hdr.write(f"{indent}bool {field_name}() const {{\n")
+        hdr.write(f"{indent}  return esi::detail::readUnsignedBits<uint8_t, "
+                  f"{bit_offset}, 1>({raw_member}.data()) != 0;\n")
+        hdr.write(f"{indent}}}\n")
+        hdr.write(f"{indent}{self_type} &{field_name}(bool v) {{\n")
+        hdr.write(f"{indent}  esi::detail::writeUnsignedBits<uint8_t, "
+                  f"{bit_offset}, 1>({raw_member}.data(), "
+                  f"static_cast<uint8_t>(v) & uint8_t{{1}});\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+        return
+
+      signed = self._is_signed_int_field(field_type)
+      byte_aligned = (bit_offset % 8 == 0 and bit_width % 8 == 0)
+
+      if byte_aligned:
+        byte_offset = bit_offset // 8
+        byte_width = bit_width // 8
+
+        # Path A: standard-width byte-aligned integer. The `reinterpret_cast`
+        # aliases through the `std::array<uint8_t, N>` storage the runtime
+        # already treats as wire bytes elsewhere.
+        if bit_width in (8, 16, 32, 64):
+          hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+          hdr.write(f"{indent}  return *reinterpret_cast<const {field_cpp} *>("
+                    f"{raw_member}.data() + {byte_offset});\n")
+          hdr.write(f"{indent}}}\n")
+          hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
+          hdr.write(f"{indent}  *reinterpret_cast<{field_cpp} *>("
+                    f"{raw_member}.data() + {byte_offset}) = v;\n")
+          hdr.write(f"{indent}  return *this;\n")
+          hdr.write(f"{indent}}}\n")
+          return
+
+        # Path B: byte-aligned but non-standard width (e.g. i24, i48). Build
+        # the value from per-byte shifts in little-endian wire order. For
+        # signed fields the result is assembled into the matching unsigned
+        # type first so the sign-extension step can mask cleanly without
+        # invoking implementation-defined right-shift behaviour on signed
+        # types.
+        # `field_cpp` already names the rounded-up storage type
+        # (e.g. `int32_t` for `i24`); flip the leading `int`/`uint` rather
+        # than reconstructing the width to avoid emitting non-standard names
+        # like `uint24_t`.
+        if signed:
+          unsigned_cpp = "u" + field_cpp
+        else:
+          unsigned_cpp = field_cpp
+        # Assemble the unsigned value.
+        read_terms = [
+            f"static_cast<{unsigned_cpp}>({raw_member}[{byte_offset}])"
+        ]
+        for i in range(1, byte_width):
+          read_terms.append(
+              f"(static_cast<{unsigned_cpp}>({raw_member}[{byte_offset + i}])"
+              f" << {i * 8})")
+        read_expr = " |\n                ".join(read_terms)
+
+        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+        if signed:
+          hdr.write(f"{indent}  {unsigned_cpp} u = {read_expr};\n")
+          # Sign-extend from the value's high bit.
+          hdr.write(
+              f"{indent}  if (u & ({unsigned_cpp}{{1}} << {bit_width - 1}))\n")
+          hdr.write(f"{indent}    u |= ~(({unsigned_cpp}{{1}} << {bit_width})"
+                    f" - {unsigned_cpp}{{1}});\n")
+          hdr.write(f"{indent}  return static_cast<{field_cpp}>(u);\n")
+        else:
+          hdr.write(f"{indent}  return {read_expr};\n")
+        hdr.write(f"{indent}}}\n")
+
+        hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
+        if signed:
+          hdr.write(f"{indent}  {unsigned_cpp} u = "
+                    f"static_cast<{unsigned_cpp}>(v);\n")
+          value_expr = "u"
+        else:
+          value_expr = "v"
+        for i in range(byte_width):
+          if i == 0:
+            hdr.write(f"{indent}  {raw_member}[{byte_offset}] = "
+                      f"static_cast<uint8_t>({value_expr});\n")
+          else:
+            hdr.write(f"{indent}  {raw_member}[{byte_offset + i}] = "
+                      f"static_cast<uint8_t>({value_expr} >> {i * 8});\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+        return
+
+      # Path C: sub-byte alignment. Delegate to the generic bit helpers.
+      if signed:
+        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+        hdr.write(f"{indent}  return esi::detail::readSignedBits<{field_cpp}, "
+                  f"{bit_offset}, {bit_width}>({raw_member}.data());\n")
+        hdr.write(f"{indent}}}\n")
+        hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
+        hdr.write(f"{indent}  esi::detail::writeSignedBits<{field_cpp}, "
+                  f"{bit_offset}, {bit_width}>({raw_member}.data(), v);\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+      else:
+        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+        hdr.write(
+            f"{indent}  return esi::detail::readUnsignedBits<{field_cpp}, "
+            f"{bit_offset}, {bit_width}>({raw_member}.data());\n")
+        hdr.write(f"{indent}}}\n")
+        hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
+        hdr.write(f"{indent}  esi::detail::writeUnsignedBits<{field_cpp}, "
+                  f"{bit_offset}, {bit_width}>({raw_member}.data(), v);\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+      return
+
+    # Aggregate field (struct/union/array). Supports both byte-aligned and
+    # arbitrary-bit-aligned embedding. The inner aggregate stores its bits
+    # LSB-first in its own `_bytes` buffer, so reading/writing reduces to
+    # copying `bit_width` bits between the parent buffer at `bit_offset`
+    # and the inner buffer at bit 0. When both the offset and width happen
+    # to be byte-aligned we emit a direct per-byte copy; otherwise we fall
+    # back to `esi::detail::copyBitsIn` / `copyBitsOut`, which shuffle the
+    # bits at whatever position they actually land in the parent's wire
+    # layout.
+    assert bit_width >= 0, (
+        f"field '{field_name}': unbounded aggregate field reached the "
+        f"emitter; the planner should have excluded the parent struct "
+        f"via `_contains_unbounded`")
+    byte_aligned = (bit_offset % 8 == 0 and bit_width % 8 == 0)
+    byte_offset = bit_offset // 8
+    byte_width = (bit_width + 7) // 8
+
+    if byte_aligned:
+      # Byte-aligned: direct byte copy between the parent's buffer slice
+      # and the inner aggregate's `_bytes`. An explicit per-byte loop
+      # avoids `memcpy` while still collapsing to one on -O2.
+      hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+      hdr.write(f"{indent}  {field_cpp} out{{}};\n")
+      hdr.write(f"{indent}  for (std::size_t i = 0; i < {byte_width}; ++i)\n")
+      hdr.write(f"{indent}    reinterpret_cast<uint8_t *>(&out)[i] = "
+                f"{raw_member}[{byte_offset} + i];\n")
+      hdr.write(f"{indent}  return out;\n")
+      hdr.write(f"{indent}}}\n")
+      hdr.write(f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
+      hdr.write(f"{indent}  for (std::size_t i = 0; i < {byte_width}; ++i)\n")
+      hdr.write(f"{indent}    {raw_member}[{byte_offset} + i] = "
+                f"reinterpret_cast<const uint8_t *>(&v)[i];\n")
+      hdr.write(f"{indent}  return *this;\n")
+      hdr.write(f"{indent}}}\n")
+    else:
+      # Non-byte-aligned: delegate to the per-bit copy helpers. The inner's
+      # `out{}` zero-initialiser is required by `copyBitsIn`, which only
+      # OR-sets the `1` bits.
+      hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+      hdr.write(f"{indent}  {field_cpp} out{{}};\n")
+      hdr.write(f"{indent}  esi::detail::copyBitsIn<{bit_offset}, "
+                f"{bit_width}>({raw_member}.data(), "
+                f"reinterpret_cast<uint8_t *>(&out));\n")
+      hdr.write(f"{indent}  return out;\n")
+      hdr.write(f"{indent}}}\n")
+      hdr.write(f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
+      hdr.write(f"{indent}  esi::detail::copyBitsOut<{bit_offset}, "
+                f"{bit_width}>({raw_member}.data(), "
+                f"reinterpret_cast<const uint8_t *>(&v));\n")
+      hdr.write(f"{indent}  return *this;\n")
+      hdr.write(f"{indent}}}\n")
+
+    # Convenience indexed accessors for fixed-size arrays. The whole-array
+    # getter/setter above is always sufficient; these helpers just save a
+    # round-trip through a local `std::array` when callers only touch one
+    # element. Only emitted when the array starts at a byte-aligned
+    # position and the element width is a whole number of bytes — anything
+    # else has to go through the whole-array accessor since per-element
+    # bit shuffling would require its own per-element offset arithmetic.
+    if (isinstance(wrapped, types.ArrayType) and byte_aligned and
+        wrapped.element_type.bit_width % 8 == 0):
+      elem_cpp = self._cpp_type(wrapped.element_type)
+      if elem_cpp != "void":
+        elem_bytes = self._field_byte_width(wrapped.element_type)
+        hdr.write(f"{indent}{elem_cpp} {field_name}(std::size_t i) const {{\n")
+        hdr.write(f"{indent}  {elem_cpp} out{{}};\n")
+        hdr.write(f"{indent}  for (std::size_t j = 0; j < {elem_bytes}; ++j)\n")
+        hdr.write(f"{indent}    reinterpret_cast<uint8_t *>(&out)[j] = "
+                  f"{raw_member}[{byte_offset} + i * {elem_bytes} + j];\n")
+        hdr.write(f"{indent}  return out;\n")
+        hdr.write(f"{indent}}}\n")
+        hdr.write(f"{indent}{self_type} &{field_name}(std::size_t i, "
+                  f"const {elem_cpp} &v) {{\n")
+        hdr.write(f"{indent}  for (std::size_t j = 0; j < {elem_bytes}; ++j)\n")
+        hdr.write(f"{indent}    {raw_member}[{byte_offset} + i * {elem_bytes}"
+                  f" + j] = reinterpret_cast<const uint8_t *>(&v)[j];\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+
+  def _ctor_param_type(self, field_type: types.ESIType) -> str:
+    """Return the C++ constructor-parameter type for a setter call."""
+    field_cpp = self._cpp_type(field_type)
+    wrapped = self._unwrap_aliases(field_type)
+    if isinstance(wrapped, (types.BitsType, types.IntType)):
+      return field_cpp
+    return f"const {field_cpp} &"
+
   def _emit_struct(self, hdr: TextIO, struct_type: types.StructType) -> None:
-    """Emit a packed struct declaration plus its type id string."""
+    """Emit a packed struct as a raw byte buffer with bit-precise accessors.
+
+    The struct's storage is a single `std::array<uint8_t, N>` (where `N`
+    is the byte width derived from the manifest) whose layout matches the
+    on-wire bit-packing exactly. Per-field accessors (generated below)
+    read/write the bits so the wire format does not depend on C++ bit-field
+    allocation rules, which differ between the Itanium ABI (GCC/Clang) and MSVC.
+    """
     # Zero-width composite types collapse to `void` everywhere they appear
     # (see _cpp_type), so there is nothing meaningful to emit here.
     if struct_type.bit_width == 0:
       return
-    fields = list(struct_type.fields)
-    if struct_type.cpp_type.reverse:
-      fields = list(reversed(fields))
-    field_decls: List[str] = []
-    for field_name, field_type in fields:
-      field_cpp = self._cpp_type(field_type)
-      if field_cpp == "void":
-        # `void` is not a valid C++ field type; emit a comment so the field
-        # remains visible in the generated header without breaking compilation.
-        field_decls.append(f"// void {field_name};")
-        continue
-      wrapped = self._unwrap_aliases(field_type)
-      if isinstance(wrapped, (types.BitsType, types.IntType)):
-        # TODO: Bitfield layout is implementation-defined; consider
-        # byte-aligned storage with explicit pack/unpack helpers.
-        bitfield_width = wrapped.bit_width
-        if bitfield_width >= 0:
-          field_decls.append(f"{field_cpp} {field_name} : {bitfield_width};")
-        else:
-          field_decls.append(f"{field_cpp} {field_name};")
-      else:
-        field_decls.append(f"{field_cpp} {field_name};")
     struct_name = self.type_id_map[struct_type]
-    hdr.write("#pragma pack(push, 1)\n")
-    hdr.write(f"struct {struct_name} {{\n")
-    for decl in field_decls:
-      hdr.write(f"  {decl}\n")
-    hdr.write("\n")
-    # Logical-order constructor: parameters follow `struct_type.fields` order
-    # (the user-facing order from the manifest), independent of any wire-layout
-    # reversal applied to the member declarations above.
+    bit_offsets, total_bits = self._compute_field_bit_offsets(struct_type)
+    total_bytes = (total_bits + 7) // 8
+
+    # Logical-order field list (manifest order) for the constructor and the
+    # public accessor list.
     logical_fields = [(name, ftype)
                       for name, ftype in struct_type.fields
                       if self._cpp_type(ftype) != "void"]
-    if logical_fields:
-      hdr.write(f"  {struct_name}() = default;\n")
-      ctor_params = ", ".join(
-          self._format_window_ctor_param(name, ftype)
-          for name, ftype in logical_fields)
-      inits = ", ".join(f"{name}({name})" for name, _ in logical_fields)
-      hdr.write(f"  {struct_name}({ctor_params}) : {inits} {{}}\n\n")
-    hdr.write(
-        f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(struct_type.id)};\n"
-    )
+
+    # A struct whose every field collapses to void carries no data the
+    # generated header can expose. Emit nothing rather than a 1-byte
+    # placeholder, since (a) the placeholder doesn't reflect any real wire
+    # layout and (b) a size_assert built from the manifest's `bit_width`
+    # (which includes void padding) would fail to compile.
+    if not logical_fields:
+      return
+
+    hdr.write(f"struct {struct_name} {{\n")
+    # `_bytes` holds the wire layout and is private; the only legitimate
+    # external view of those bytes is via `MessageData::from()` /
+    # `MessageData::as()` which reinterpret-cast through the whole struct
+    # and don't need member-level access.
+    hdr.write("private:\n")
+    hdr.write(f"  std::array<uint8_t, {max(total_bytes, 1)}> _bytes{{}};\n\n")
+    hdr.write("public:\n")
+
+    hdr.write(f"  {struct_name}() = default;\n")
+    ctor_params = ", ".join(f"{self._ctor_param_type(ftype)} {name}"
+                            for name, ftype in logical_fields)
+    hdr.write(f"  {struct_name}({ctor_params}) {{\n")
+    # `this->` disambiguates the chained setter calls from the like-named
+    # parameters that shadow the member functions inside the ctor body.
+    chain = ".".join(f"{name}({name})" for name, _ in logical_fields)
+    hdr.write(f"    this->{chain};\n")
+    hdr.write("  }\n\n")
+
+    # Per-field accessors in logical (manifest) order so the user-facing
+    # API mirrors the manifest field order rather than the wire reversal.
+    for name, ftype in logical_fields:
+      self._emit_field_accessor(hdr, "  ", "_bytes", struct_name, name, ftype,
+                                bit_offsets[name], ftype.bit_width)
+      hdr.write("\n")
+
+    hdr.write(f"  static constexpr std::string_view _ESI_ID = "
+              f"{self._cpp_string_literal(struct_type.id)};\n")
     hdr.write("};\n")
-    # Void / zero-width fields are commented out and contribute 0 to the
-    # struct's bit_width (see VoidType.bit_width), so the manifest-derived
-    # size already matches the emitted C++ layout. An all-void or empty
-    # struct still has `sizeof >= 1` in C++, so skip the assert in that
-    # degenerate case.
     expected_bytes = self._safe_byte_width(struct_type)
     if expected_bytes is not None and expected_bytes > 0:
       self._emit_size_assert(hdr, struct_name, expected_bytes)
-    hdr.write("#pragma pack(pop)\n\n")
+    hdr.write("\n")
 
   def _emit_union(self, hdr: TextIO, union_type: types.UnionType) -> None:
-    """Emit a packed union declaration plus its type id string.
+    """Emit a union as a raw byte buffer with per-variant accessors.
 
-    Fields narrower than the union width get wrapper structs with a `_pad`
-    byte array so the data sits at the MSB end, matching SV packed union
-    layout where padding occupies the LSBs / lower addresses.
+    The union's storage is a single `std::array<uint8_t, N>` sized to the
+    widest variant. Each variant lives at the MSB end of the buffer
+    (matching the existing SV-style packed union layout where padding
+    occupies the lower bytes), so the byte offset for a variant of size
+    V is `union_bytes - V`. Sub-byte integer variants are byte-padded to
+    full bytes within that region, matching the Python runtime's union
+    serialization.
     """
     # Zero-width unions collapse to `void` (see _cpp_type) so there is
     # nothing meaningful to emit here.
     if union_type.bit_width == 0:
       return
     union_name = self.type_id_map[union_type]
-    fields = list(union_type.fields)
     union_bytes = self._field_byte_width(union_type)
 
-    hdr.write("#pragma pack(push, 1)\n")
-    # First pass: emit wrapper structs for fields that need padding.
-    wrapper_names: Dict[str, str] = {}
-    for field_name, field_type in fields:
-      if self._cpp_type(field_type) == "void":
-        continue
-      field_bytes = self._field_byte_width(field_type)
-      pad_bytes = union_bytes - field_bytes
-      if pad_bytes > 0:
-        wrapper = f"{union_name}_{field_name}"
-        wrapper_names[field_name] = wrapper
-        hdr.write(f"struct {wrapper} {{\n")
-        hdr.write(f"  uint8_t _pad[{pad_bytes}];\n")
-        field_cpp = self._cpp_type(field_type)
-        hdr.write(f"  {field_cpp} {field_name};\n")
-        hdr.write("};\n")
-        self._emit_size_assert(hdr, wrapper, union_bytes)
+    hdr.write(f"struct {union_name} {{\n")
+    # See `_emit_struct` for the access-control rationale.
+    hdr.write("private:\n")
+    hdr.write(f"  std::array<uint8_t, {union_bytes}> _bytes{{}};\n\n")
+    hdr.write("public:\n")
+    hdr.write(f"  {union_name}() = default;\n\n")
 
-    # Second pass: emit the union itself.
-    union_field_decls: List[str] = []
-    for field_name, field_type in fields:
+    for field_name, field_type in union_type.fields:
       field_cpp = self._cpp_type(field_type)
       if field_cpp == "void":
-        # `void` is not a valid C++ union member; emit a comment placeholder.
-        union_field_decls.append(f"// void {field_name};")
-      elif field_name in wrapper_names:
-        union_field_decls.append(f"{wrapper_names[field_name]} {field_name};")
-      else:
-        union_field_decls.append(f"{field_cpp} {field_name};")
-    hdr.write(f"union {union_name} {{\n")
-    for decl in union_field_decls:
-      hdr.write(f"  {decl}\n")
-    hdr.write("\n")
-    hdr.write(
-        f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(union_type.id)};\n"
-    )
+        continue
+      field_bytes = self._field_byte_width(field_type)
+      byte_offset = union_bytes - field_bytes
+      bit_offset = byte_offset * 8
+      bit_width = field_type.bit_width
+      # Each variant is reached at the same MSB-aligned position regardless
+      # of width. Reuse `_emit_field_accessor` so we share the integer /
+      # aggregate code paths and don't duplicate the bit-access boilerplate.
+      self._emit_field_accessor(hdr, "  ", "_bytes", union_name, field_name,
+                                field_type, bit_offset, bit_width)
+      hdr.write("\n")
+
+    hdr.write(f"  static constexpr std::string_view _ESI_ID = "
+              f"{self._cpp_string_literal(union_type.id)};\n")
     hdr.write("};\n")
-    # Skip the assertion for all-void / empty unions; an empty union has
-    # `sizeof >= 1` in C++ and would always fail an `== 0` assert.
     if union_bytes > 0:
       self._emit_size_assert(hdr, union_name, union_bytes)
-    hdr.write("#pragma pack(pop)\n\n")
+    hdr.write("\n")
+
+  def _compute_window_frame_layout(self, fields, pad_bytes, count_type_synth):
+    """Compute (name, type, byte_offset, bit_width) for each window frame field.
+
+    Fields are listed in C++ declaration order. They start after `pad_bytes`
+    bytes of padding and each field consumes `ceil(bit_width/8)` bytes —
+    matching what the `#pragma pack(1)` layout produced.
+
+    The sentinel `(name, None)` count field is materialised as
+    `count_type_synth` so it can flow through the standard
+    `_emit_field_accessor` path.
+    """
+    layout = []
+    byte_offset = pad_bytes
+    for name, ftype in fields:
+      actual_type = count_type_synth if ftype is None else ftype
+      bit_width = actual_type.bit_width
+      layout.append((name, actual_type, byte_offset, bit_width))
+      byte_offset += (bit_width + 7) // 8
+    return layout
+
+  def _emit_window_frame(self, hdr: TextIO, frame_name: str, frame_bytes: int,
+                         layout) -> None:
+    """Emit a window header/data frame as a raw-bytes struct with accessors.
+
+    Nested inside the window helper class (`indent` = 2 spaces) and uses
+    the same B3 accessor pattern as top-level structs/unions: a private
+    `_bytes` array plus per-field getter/setter pairs returning
+    `frame_name &` to allow chaining.
+    """
+    hdr.write(f"  struct {frame_name} {{\n")
+    hdr.write("   private:\n")
+    hdr.write(f"    std::array<uint8_t, {frame_bytes}> _bytes{{}};\n\n")
+    hdr.write("   public:\n")
+    for name, ftype, byte_offset, bit_width in layout:
+      self._emit_field_accessor(hdr, "    ", "_bytes", frame_name, name, ftype,
+                                byte_offset * 8, bit_width)
+      hdr.write("\n")
+    hdr.write("  };\n")
+    self._emit_size_assert(hdr, frame_name, frame_bytes, indent="  ")
 
   def _emit_window(self, hdr: TextIO, window_type: types.WindowType) -> None:
     """Emit a SegmentedMessageData helper for a serial list window."""
@@ -1439,41 +1778,29 @@ class CppTypeEmitter:
     helper_args = ", ".join(name for name, _ in info["ctor_params"])
     helper_call = f"{helper_args}, std::move(frames)" if helper_args else "std::move(frames)"
 
+    # Synthesise an unsigned integer type for the sentinel "count" header
+    # field so it flows through `_emit_field_accessor` like any other
+    # integer.
+    count_type_synth = types.UIntType(f"_count_ui{info['count_width']}",
+                                      info["count_width"])
+    data_layout = self._compute_window_frame_layout(info["data_fields"],
+                                                    info["data_pad_bytes"],
+                                                    count_type_synth)
+    header_layout = self._compute_window_frame_layout(info["header_fields"],
+                                                      info["header_pad_bytes"],
+                                                      count_type_synth)
+
     hdr.write(
         f"struct {info['window_name']} : public esi::SegmentedMessageData {{\n")
     hdr.write("public:\n")
     hdr.write(f"  using value_type = {info['element_cpp']};\n")
     hdr.write(f"  using count_type = {info['count_cpp']};\n\n")
-    hdr.write("#pragma pack(push, 1)\n")
-    hdr.write("  struct data_frame {\n")
-    if info["data_pad_bytes"] > 0:
-      hdr.write(f"    uint8_t _pad[{info['data_pad_bytes']}];\n")
-    for field_name, field_type in info["data_fields"]:
-      decl = self._format_window_field_decl(field_name, field_type)
-      hdr.write(f"    {decl}\n")
-    hdr.write("  };\n")
-    self._emit_size_assert(hdr, "data_frame", info["frame_bytes"], indent="  ")
-    hdr.write("#pragma pack(pop)\n\n")
+    self._emit_window_frame(hdr, "data_frame", info["frame_bytes"], data_layout)
+    hdr.write("\n")
     hdr.write("private:\n")
-    hdr.write("#pragma pack(push, 1)\n")
-    hdr.write("  struct header_frame {\n")
-    if info["header_pad_bytes"] > 0:
-      hdr.write(f"    uint8_t _pad[{info['header_pad_bytes']}];\n")
-    for field_name, field_type in info["header_fields"]:
-      if field_type is None:
-        if info["count_width"] % 8 == 0:
-          decl = f"count_type {field_name};"
-        else:
-          decl = f"count_type {field_name} : {info['count_width']};"
-      else:
-        decl = self._format_window_field_decl(field_name, field_type)
-      hdr.write(f"    {decl}\n")
-    hdr.write("  };\n")
-    self._emit_size_assert(hdr,
-                           "header_frame",
-                           info["frame_bytes"],
-                           indent="  ")
-    hdr.write("#pragma pack(pop)\n\n")
+    self._emit_window_frame(hdr, "header_frame", info["frame_bytes"],
+                            header_layout)
+    hdr.write("\n")
     hdr.write("  header_frame header{};\n")
     hdr.write("  std::vector<data_frame> data_frames;\n")
     hdr.write("  header_frame footer{};\n\n")
@@ -1488,14 +1815,11 @@ class CppTypeEmitter:
         f"      throw std::invalid_argument(\"{info['window_name']}: list too large for encoded count\");\n"
     )
     hdr.write(
-        f"    header.{info['count_field_name']} = static_cast<count_type>(frames.size());\n"
+        f"    header.{info['count_field_name']}(static_cast<count_type>(frames.size()));\n"
     )
     for name, _ in info["ctor_params"]:
-      field_type = next(
-          field_type for field_name, field_type in info["ctor_params"]
-          if field_name == name)
-      self._emit_window_field_copy(hdr, f"header.{name}", name, field_type)
-    hdr.write(f"    footer.{info['count_field_name']} = 0;\n")
+      hdr.write(f"    header.{name}({name});\n")
+    hdr.write(f"    footer.{info['count_field_name']}(0);\n")
     hdr.write("    data_frames = std::move(frames);\n")
     hdr.write("  }\n\n")
     hdr.write("public:\n")
@@ -1507,7 +1831,7 @@ class CppTypeEmitter:
     hdr.write(f"    frames.reserve({info['list_field_name']}.size());\n")
     hdr.write(f"    for (const auto &element : {info['list_field_name']}) {{\n")
     hdr.write("      auto &frame = frames.emplace_back();\n")
-    hdr.write(f"      frame.{info['list_field_name']} = element;\n")
+    hdr.write(f"      frame.{info['list_field_name']}(element);\n")
     hdr.write("    }\n")
     hdr.write(f"    construct({helper_call});\n")
     hdr.write("  }\n\n")
@@ -1558,40 +1882,26 @@ class CppTypeEmitter:
       if field_type is None:
         continue
       cpp = self._cpp_type(field_type)
-      unwrapped_header = self._unwrap_aliases(field_type)
-      # Aggregate types (structs/unions/std::array) get a const-ref accessor;
-      # bit-vector scalars are returned by value.
-      if isinstance(unwrapped_header,
-                    (types.BitsType, types.IntType, types.VoidType)):
-        hdr.write(
-            f"  {cpp} {field_name}() const {{ return header.{field_name}; }}\n")
-      else:
-        hdr.write(
-            f"  const {cpp} &{field_name}() const {{ return header.{field_name}; }}\n"
-        )
+      # The header-frame accessor returns by value (it pulls bytes out of
+      # the raw buffer), so this is also returned by value regardless of
+      # whether the underlying type is a scalar or an aggregate.
+      hdr.write(
+          f"  {cpp} {field_name}() const {{ return header.{field_name}(); }}\n")
     hdr.write(
         f"  size_t {list_field_name}_count() const {{ return data_frames.size(); }}\n"
     )
     for field_name, field_type in info["data_fields"]:
-      # All field types — scalars, structs, and arrays-as-`std::array` — are
-      # uniformly addressable via pointer-to-member, except bit-fields which
-      # have no pointer-to-member representation.
-      unwrapped_data = self._unwrap_aliases(field_type)
       if field_name == list_field_name:
         elem_cpp = "value_type"
       else:
         elem_cpp = self._cpp_type(field_type)
-      # C++ does not allow forming a pointer-to-member for a bit-field, so for
-      # non-byte-aligned integer fields we fall back to a lambda projection
-      # (which copies by value on each dereference) instead of a
-      # pointer-to-member projection.
-      is_bitfield = (isinstance(unwrapped_data,
-                                (types.BitsType, types.IntType)) and
-                     unwrapped_data.bit_width % 8 != 0)
-      if is_bitfield:
-        projection = f"[](const data_frame &f) {{ return f.{field_name}; }}"
-      else:
-        projection = f"&data_frame::{field_name}"
+      # The data-frame accessor is now a member function returning by value,
+      # so the projection has to call it rather than form a
+      # pointer-to-data-member. A lambda keeps the projection valid even
+      # when the accessor overload set includes an indexed `field(size_t)`
+      # variant for fixed-size arrays.
+      projection = (f"[](const data_frame &f) -> {elem_cpp} "
+                    f"{{ return f.{field_name}(); }}")
       hdr.write(
           f"  auto {field_name}() const {{\n"
           f"    return std::views::transform(data_frames, {projection});\n"
@@ -1600,7 +1910,7 @@ class CppTypeEmitter:
                 f"    std::vector<{elem_cpp}> out;\n"
                 f"    out.reserve(data_frames.size());\n"
                 f"    for (const auto &frame : data_frames)\n"
-                f"      out.push_back(frame.{field_name});\n"
+                f"      out.push_back(frame.{field_name}());\n"
                 f"    return out;\n"
                 f"  }}\n")
 
@@ -1620,7 +1930,7 @@ class CppTypeEmitter:
     """
     window_name = info["window_name"]
     count_field_name = info["count_field_name"]
-    ctor_args = ", ".join(f"h.{name}" for name, _ in info["ctor_params"])
+    ctor_args = ", ".join(f"h.{name}()" for name, _ in info["ctor_params"])
     if ctor_args:
       ctor_args = f"{ctor_args}, std::move(frames)"
     else:
@@ -1635,7 +1945,7 @@ class CppTypeEmitter:
     hdr.write(
         "  // reaches into `header_frame` via the friend declaration below.\n")
     hdr.write("  static count_type _headerCount(const header_frame &h) {\n")
-    hdr.write(f"    return h.{count_field_name};\n")
+    hdr.write(f"    return h.{count_field_name}();\n")
     hdr.write("  }\n")
     hdr.write(f"  static std::unique_ptr<{window_name}> _fromFrames(\n")
     hdr.write(
@@ -1672,6 +1982,7 @@ class CppTypeEmitter:
 
         #include <cstdint>
         #include <cstddef>
+        #include <cstring>
         #include <any>
         #include <array>
         #include <limits>
@@ -1681,6 +1992,7 @@ class CppTypeEmitter:
         #include <utility>
         #include <vector>
 
+        #include "esi/BitAccess.h"
         #include "esi/Common.h"
         #include "esi/TypedPorts.h"
 
@@ -1693,19 +2005,23 @@ class CppTypeEmitter:
         sys.stderr.write(
             "  Emitted code may fail to compile due to ordering issues.\n")
 
+      for skipped_type, reason in self.skipped_types:
+        sys.stderr.write(f"Warning: skipping type '{skipped_type}': {reason}\n")
+        hdr.write(f"// Unsupported type '{skipped_type}': {reason}\n\n")
+
       for emit_type in self.ordered_types:
-        try:
-          if isinstance(emit_type, types.StructType):
-            self._emit_struct(hdr, emit_type)
-          elif isinstance(emit_type, types.UnionType):
-            self._emit_union(hdr, emit_type)
-          elif isinstance(emit_type, types.WindowType):
-            self._emit_window(hdr, emit_type)
-          elif isinstance(emit_type, types.TypeAlias):
-            self._emit_alias(hdr, emit_type)
-        except (ValueError, NotImplementedError) as e:
-          sys.stderr.write(f"Warning: skipping type '{emit_type}': {e}\n")
-          hdr.write(f"// Unsupported type '{emit_type}': {e}\n\n")
+        # Anything that wasn't expressible should have been caught by
+        # CppTypePlanner and recorded in `skipped_types`; if a problem
+        # leaks past that, treat it as a planner bug rather than emitting
+        # a half-written header.
+        if isinstance(emit_type, types.StructType):
+          self._emit_struct(hdr, emit_type)
+        elif isinstance(emit_type, types.UnionType):
+          self._emit_union(hdr, emit_type)
+        elif isinstance(emit_type, types.WindowType):
+          self._emit_window(hdr, emit_type)
+        elif isinstance(emit_type, types.TypeAlias):
+          self._emit_alias(hdr, emit_type)
 
       hdr.write(textwrap.dedent(f"""
     }} // namespace {system_name}

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/loopback.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/loopback.cpp
@@ -57,18 +57,18 @@ static int runStructFunc(Accelerator *accel) {
   func->connect();
 
   esi_system::ArgStruct arg{};
-  arg.a = 0x1234;
-  arg.b = static_cast<int8_t>(-7);
+  arg.a(0x1234);
+  arg.b(static_cast<int8_t>(-7));
 
   MessageData resMsg = func->call(MessageData::from(arg)).get();
   const auto *res = resMsg.as<esi_system::ResultStruct>();
 
-  int8_t expectedX = static_cast<int8_t>(arg.b + 1);
-  if (res->x != expectedX || res->y != arg.b)
+  int8_t expectedX = static_cast<int8_t>(arg.b() + 1);
+  if (res->x() != expectedX || res->y() != arg.b())
     throw std::runtime_error("Struct func result mismatch");
 
-  std::cout << "struct_func ok: b=" << (int)arg.b << " x=" << (int)res->x
-            << " y=" << (int)res->y << "\n";
+  std::cout << "struct_func ok: b=" << (int)arg.b() << " x=" << (int)res->x()
+            << " y=" << (int)res->y() << "\n";
   return 0;
 }
 
@@ -83,32 +83,30 @@ static int runOddStructFunc(Accelerator *accel) {
     throw std::runtime_error("oddStructFunc not a FuncService::Function");
   func->connect();
 
-  esi_system::OddStruct arg{};
-  arg.a = 0xabc;
-  arg.b = static_cast<int8_t>(-17);
-  arg.inner.p = 5;
-  arg.inner.q = static_cast<int8_t>(-7);
-  arg.inner.r[0] = 3;
-  arg.inner.r[1] = 4;
+  esi_system::OddStruct arg{
+      /*a=*/0xabc,
+      /*b=*/static_cast<int8_t>(-17),
+      /*inner=*/{/*p=*/5, /*q=*/static_cast<int8_t>(-7), /*r=*/{3, 4}},
+  };
 
   MessageData resMsg = func->call(MessageData::from(arg)).get();
   const auto *res = resMsg.as<esi_system::OddStruct>();
 
-  uint16_t expectA = static_cast<uint16_t>(arg.a + 1);
-  int8_t expectB = static_cast<int8_t>(arg.b - 3);
-  uint8_t expectP = static_cast<uint8_t>(arg.inner.p + 5);
-  int8_t expectQ = static_cast<int8_t>(arg.inner.q + 2);
-  uint8_t expectR0 = static_cast<uint8_t>(arg.inner.r[0] + 1);
-  uint8_t expectR1 = static_cast<uint8_t>(arg.inner.r[1] + 2);
-  if (res->a != expectA || res->b != expectB || res->inner.p != expectP ||
-      res->inner.q != expectQ || res->inner.r[0] != expectR0 ||
-      res->inner.r[1] != expectR1)
+  uint16_t expectA = static_cast<uint16_t>(arg.a() + 1);
+  int8_t expectB = static_cast<int8_t>(arg.b() - 3);
+  uint8_t expectP = static_cast<uint8_t>(arg.inner().p() + 5);
+  int8_t expectQ = static_cast<int8_t>(arg.inner().q() + 2);
+  uint8_t expectR0 = static_cast<uint8_t>(arg.inner().r()[0] + 1);
+  uint8_t expectR1 = static_cast<uint8_t>(arg.inner().r()[1] + 2);
+  if (res->a() != expectA || res->b() != expectB ||
+      res->inner().p() != expectP || res->inner().q() != expectQ ||
+      res->inner().r()[0] != expectR0 || res->inner().r()[1] != expectR1)
     throw std::runtime_error("Odd struct func result mismatch");
 
-  std::cout << "odd_struct_func ok: a=" << res->a << " b=" << (int)res->b
-            << " p=" << (int)res->inner.p << " q=" << (int)res->inner.q
-            << " r0=" << (int)res->inner.r[0] << " r1=" << (int)res->inner.r[1]
-            << "\n";
+  std::cout << "odd_struct_func ok: a=" << res->a() << " b=" << (int)res->b()
+            << " p=" << (int)res->inner().p() << " q=" << (int)res->inner().q()
+            << " r0=" << (int)res->inner().r()[0]
+            << " r1=" << (int)res->inner().r()[1] << "\n";
   return 0;
 }
 

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/loopback_typed.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/loopback_typed.cpp
@@ -57,17 +57,17 @@ static int runStructFunc(Accelerator *accel) {
   func.connect();
 
   esi_system::ArgStruct arg{};
-  arg.a = 0x1234;
-  arg.b = static_cast<int8_t>(-7);
+  arg.a(0x1234);
+  arg.b(static_cast<int8_t>(-7));
 
   esi_system::ResultStruct res = func.call(arg).get();
 
-  int8_t expectedX = static_cast<int8_t>(arg.b + 1);
-  if (res.x != expectedX || res.y != arg.b)
+  int8_t expectedX = static_cast<int8_t>(arg.b() + 1);
+  if (res.x() != expectedX || res.y() != arg.b())
     throw std::runtime_error("Struct func result mismatch");
 
-  std::cout << "struct_func ok: b=" << (int)arg.b << " x=" << (int)res.x
-            << " y=" << (int)res.y << "\n";
+  std::cout << "struct_func ok: b=" << (int)arg.b() << " x=" << (int)res.x()
+            << " y=" << (int)res.y() << "\n";
   return 0;
 }
 
@@ -83,30 +83,31 @@ static int runOddStructFunc(Accelerator *accel) {
   func.connect();
 
   esi_system::OddStruct arg{};
-  arg.a = 0xabc;
-  arg.b = static_cast<int8_t>(-17);
-  arg.inner.p = 5;
-  arg.inner.q = static_cast<int8_t>(-7);
-  arg.inner.r[0] = 3;
-  arg.inner.r[1] = 4;
+  arg.a(0xabc);
+  arg.b(static_cast<int8_t>(-17));
+  auto inner = arg.inner();
+  inner.p(5);
+  inner.q(static_cast<int8_t>(-7));
+  inner.r({3, 4});
+  arg.inner(inner);
 
   esi_system::OddStruct res = func.call(arg).get();
 
-  uint16_t expectA = static_cast<uint16_t>(arg.a + 1);
-  int8_t expectB = static_cast<int8_t>(arg.b - 3);
-  uint8_t expectP = static_cast<uint8_t>(arg.inner.p + 5);
-  int8_t expectQ = static_cast<int8_t>(arg.inner.q + 2);
-  uint8_t expectR0 = static_cast<uint8_t>(arg.inner.r[0] + 1);
-  uint8_t expectR1 = static_cast<uint8_t>(arg.inner.r[1] + 2);
-  if (res.a != expectA || res.b != expectB || res.inner.p != expectP ||
-      res.inner.q != expectQ || res.inner.r[0] != expectR0 ||
-      res.inner.r[1] != expectR1)
+  uint16_t expectA = static_cast<uint16_t>(arg.a() + 1);
+  int8_t expectB = static_cast<int8_t>(arg.b() - 3);
+  uint8_t expectP = static_cast<uint8_t>(arg.inner().p() + 5);
+  int8_t expectQ = static_cast<int8_t>(arg.inner().q() + 2);
+  uint8_t expectR0 = static_cast<uint8_t>(arg.inner().r()[0] + 1);
+  uint8_t expectR1 = static_cast<uint8_t>(arg.inner().r()[1] + 2);
+  if (res.a() != expectA || res.b() != expectB || res.inner().p() != expectP ||
+      res.inner().q() != expectQ || res.inner().r()[0] != expectR0 ||
+      res.inner().r()[1] != expectR1)
     throw std::runtime_error("Odd struct func result mismatch");
 
-  std::cout << "odd_struct_func ok: a=" << res.a << " b=" << (int)res.b
-            << " p=" << (int)res.inner.p << " q=" << (int)res.inner.q
-            << " r0=" << (int)res.inner.r[0] << " r1=" << (int)res.inner.r[1]
-            << "\n";
+  std::cout << "odd_struct_func ok: a=" << res.a() << " b=" << (int)res.b()
+            << " p=" << (int)res.inner().p() << " q=" << (int)res.inner().q()
+            << " r0=" << (int)res.inner().r()[0]
+            << " r1=" << (int)res.inner().r()[1] << "\n";
   return 0;
 }
 
@@ -220,9 +221,9 @@ static int serialCoordTranslateTest(Accelerator *accel) {
     throw std::runtime_error("Serial coord translate result size mismatch");
   size_t i = 0;
   for (const SerialCoordValue &got : result.coords()) {
-    uint32_t expX = coords[i].x + xTrans;
-    uint32_t expY = coords[i].y + yTrans;
-    if (got.x != expX || got.y != expY)
+    uint32_t expX = coords[i].x() + xTrans;
+    uint32_t expY = coords[i].y() + yTrans;
+    if (got.x() != expX || got.y() != expY)
       throw std::runtime_error("Serial coord translate result mismatch");
     ++i;
   }

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/serialization_probes.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/serialization_probes.cpp
@@ -149,7 +149,8 @@ static int runSignProbe(Accelerator *accel) {
   };
   for (const Case &c : cases) {
     esi_system::SignResult r = connected->sign_probe(c.arg).get();
-    if (r.plus_one != c.plus_one || r.neg != c.neg || r.sign_bit != c.sign_bit)
+    if (r.plus_one() != c.plus_one || r.neg() != c.neg ||
+        r.sign_bit() != c.sign_bit)
       throw std::runtime_error("sign_probe mismatch for arg=" +
                                std::to_string(c.arg));
   }
@@ -185,11 +186,13 @@ static int runSignProbe13(Accelerator *accel) {
   };
   for (const Case &c : cases) {
     esi_system::SignResult13 r = connected->sign_probe13(c.arg).get();
-    if (r.plus_one != c.plus_one || r.neg != c.neg || r.sign_bit != c.sign_bit)
+    if (r.plus_one() != c.plus_one || r.neg() != c.neg ||
+        r.sign_bit() != c.sign_bit)
       throw std::runtime_error(
           "sign_probe13 mismatch for arg=" + std::to_string(c.arg) +
-          " got plus_one=" + std::to_string(r.plus_one) + " neg=" +
-          std::to_string(r.neg) + " sign_bit=" + std::to_string(r.sign_bit));
+          " got plus_one=" + std::to_string(r.plus_one()) +
+          " neg=" + std::to_string(r.neg()) +
+          " sign_bit=" + std::to_string(r.sign_bit()));
   }
 
   // TODO: Out-of-range si13 args. The generated facade declares
@@ -222,17 +225,17 @@ static int runPackProbe(Accelerator *accel) {
   auto connected = mod.connect();
 
   esi_system::PackStruct arg{};
-  arg.a = 0x01;
-  arg.b = 0x0002;
-  arg.c = 0x03;
-  arg.d = 0x00000004;
+  arg.a(0x01);
+  arg.b(0x0002);
+  arg.c(0x03);
+  arg.d(0x00000004);
 
   esi_system::PackStruct r = connected->pack_probe(arg).get();
-  if (r.a != 0xA1 || r.b != 0xB002 || r.c != 0xC3 || r.d != 0xD0000004)
+  if (r.a() != 0xA1 || r.b() != 0xB002 || r.c() != 0xC3 || r.d() != 0xD0000004)
     throw std::runtime_error("pack_probe field mismatch");
-  std::cout << "pack_probe ok: a=0x" << std::hex << (unsigned)r.a << " b=0x"
-            << r.b << " c=0x" << (unsigned)r.c << " d=0x" << r.d << std::dec
-            << "\n";
+  std::cout << "pack_probe ok: a=0x" << std::hex << (unsigned)r.a() << " b=0x"
+            << r.b() << " c=0x" << (unsigned)r.c() << " d=0x" << r.d()
+            << std::dec << "\n";
   return 0;
 }
 
@@ -244,14 +247,14 @@ static int runBitPackProbe(Accelerator *accel) {
   // Distinct values within each width: x=001, y=10001, z=1001, w=1100. A
   // shift error to a different field width would produce a value outside
   // these picks.
-  arg.x = 0b001;
-  arg.y = 0b10001;
-  arg.z = 0b1001;
-  arg.w = 0b1100;
+  arg.x(0b001);
+  arg.y(0b10001);
+  arg.z(0b1001);
+  arg.w(0b1100);
 
   esi_system::BitPackResult r = connected->bit_pack_probe(arg).get();
-  if (r.w_field != arg.x || r.z_field != arg.y || r.y_field != arg.z ||
-      r.x_field != arg.w)
+  if (r.w_field() != arg.x() || r.z_field() != arg.y() ||
+      r.y_field() != arg.z() || r.x_field() != arg.w())
     throw std::runtime_error("bit_pack_probe field rotation mismatch");
   std::cout << "bit_pack_probe ok\n";
   return 0;

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/test_codegen.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/test_codegen.cpp
@@ -139,14 +139,14 @@ static int runCallServiceCallback(Accelerator *accel) {
     throw std::runtime_error(
         "call_service_callback: callback did not fire within timeout");
 
-  if (seen.tag != 0xA5)
+  if (seen.tag() != 0xA5)
     throw std::runtime_error(
         "call_service_callback: wrong tag, expected 0xA5 got 0x" +
-        toHex(static_cast<uint64_t>(seen.tag)));
-  if (seen.payload != kPayload)
+        toHex(static_cast<uint64_t>(seen.tag())));
+  if (seen.payload() != kPayload)
     throw std::runtime_error(
         "call_service_callback: wrong payload, expected 0x" + toHex(kPayload) +
-        " got 0x" + toHex(seen.payload));
+        " got 0x" + toHex(seen.payload()));
   std::cout << "call_service_callback ok\n";
   return 0;
 }
@@ -167,15 +167,15 @@ static int runTypedReadChannelStruct(Accelerator *accel) {
       throw std::runtime_error(
           "typed_read_channel_struct: null read result at i=" +
           std::to_string(i));
-    if (ev->ts != i)
+    if (ev->ts() != i)
       throw std::runtime_error(
           "typed_read_channel_struct: wrong ts at i=" + std::to_string(i) +
-          ", got " + std::to_string(ev->ts));
+          ", got " + std::to_string(ev->ts()));
     int32_t expected = -static_cast<int32_t>(i);
-    if (ev->val != expected)
+    if (ev->val() != expected)
       throw std::runtime_error(
           "typed_read_channel_struct: wrong val at i=" + std::to_string(i) +
-          ", got " + std::to_string(ev->val));
+          ", got " + std::to_string(ev->val()));
   }
   std::cout << "typed_read_channel_struct ok (" << kNum << " events)\n";
   return 0;
@@ -343,13 +343,14 @@ static int runTypedFuncStruct(Accelerator *accel) {
 
   esi_system::StructArgs arg(0x1234, static_cast<int8_t>(-7));
   esi_system::StructResult res = c->call(arg).get();
-  int8_t expectedX = static_cast<int8_t>(arg.b + 1);
-  if (res.x != expectedX || res.y != arg.b)
+  int8_t expectedX = static_cast<int8_t>(arg.b() + 1);
+  if (res.x() != expectedX || res.y() != arg.b())
     throw std::runtime_error(
-        "typed_func_struct: wrong result (b=" + std::to_string(arg.b) +
-        " x=" + std::to_string(res.x) + " y=" + std::to_string(res.y) + ")");
-  std::cout << "typed_func_struct ok (b=" << (int)arg.b
-            << " -> x=" << (int)res.x << " y=" << (int)res.y << ")\n";
+        "typed_func_struct: wrong result (b=" + std::to_string(arg.b()) +
+        " x=" + std::to_string(res.x()) + " y=" + std::to_string(res.y()) +
+        ")");
+  std::cout << "typed_func_struct ok (b=" << (int)arg.b()
+            << " -> x=" << (int)res.x() << " y=" << (int)res.y() << ")\n";
   return 0;
 }
 
@@ -362,26 +363,30 @@ static int runTypedFuncNestedStruct(Accelerator *accel) {
   auto c = mod.connect();
 
   esi_system::OddStruct arg;
-  arg.a = 0xabc;
-  arg.b = static_cast<int8_t>(-17);
-  arg.inner.p = 5;
-  arg.inner.q = static_cast<int8_t>(-7);
-  arg.inner.r[0] = 3;
-  arg.inner.r[1] = 4;
+  arg.a(0xabc);
+  arg.b(static_cast<int8_t>(-17));
+  auto inner = arg.inner();
+  inner.p(5);
+  inner.q(static_cast<int8_t>(-7));
+  inner.r({3, 4});
+  arg.inner(inner);
 
   esi_system::OddStruct res = c->call(arg).get();
-  uint16_t expA = static_cast<uint16_t>(arg.a + 1);
-  int8_t expB = static_cast<int8_t>(arg.b - 3);
-  uint8_t expP = static_cast<uint8_t>(arg.inner.p + 5);
-  int8_t expQ = static_cast<int8_t>(arg.inner.q + 2);
-  uint8_t expR0 = static_cast<uint8_t>(arg.inner.r[0] + 1);
-  uint8_t expR1 = static_cast<uint8_t>(arg.inner.r[1] + 2);
-  if (res.a != expA || res.b != expB || res.inner.p != expP ||
-      res.inner.q != expQ || res.inner.r[0] != expR0 || res.inner.r[1] != expR1)
+  uint16_t expA = static_cast<uint16_t>(arg.a() + 1);
+  int8_t expB = static_cast<int8_t>(arg.b() - 3);
+  uint8_t expP = static_cast<uint8_t>(arg.inner().p() + 5);
+  int8_t expQ = static_cast<int8_t>(arg.inner().q() + 2);
+  uint8_t expR0 = static_cast<uint8_t>(arg.inner().r()[0] + 1);
+  uint8_t expR1 = static_cast<uint8_t>(arg.inner().r()[1] + 2);
+  if (res.a() != expA || res.b() != expB || res.inner().p() != expP ||
+      res.inner().q() != expQ || res.inner().r()[0] != expR0 ||
+      res.inner().r()[1] != expR1)
     throw std::runtime_error("typed_func_nested_struct: result mismatch");
-  std::cout << "typed_func_nested_struct ok (a=" << res.a << " b=" << (int)res.b
-            << " p=" << (int)res.inner.p << " q=" << (int)res.inner.q << " r=["
-            << (int)res.inner.r[0] << "," << (int)res.inner.r[1] << "])\n";
+  std::cout << "typed_func_nested_struct ok (a=" << res.a()
+            << " b=" << (int)res.b() << " p=" << (int)res.inner().p()
+            << " q=" << (int)res.inner().q() << " r=["
+            << (int)res.inner().r()[0] << "," << (int)res.inner().r()[1]
+            << "])\n";
   return 0;
 }
 
@@ -454,12 +459,12 @@ static int runTypedFuncWindowedList(Accelerator *accel) {
         std::to_string(result.data_count()) + ")");
   size_t i = 0;
   for (const esi_system::TransformListItem &item : result.data()) {
-    uint32_t expected = input[i].v + input[i].v;
-    if (item.v != expected)
+    uint32_t expected = input[i].v() + input[i].v();
+    if (item.v() != expected)
       throw std::runtime_error("typed_func_windowed_list: element " +
                                std::to_string(i) + " expected " +
                                std::to_string(expected) + ", got " +
-                               std::to_string(item.v));
+                               std::to_string(item.v()));
     ++i;
   }
   std::cout << "typed_func_windowed_list ok (" << input.size()

--- a/lib/Dialect/ESI/runtime/tests/unit/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/tests/unit/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Driven by `tests/unit/test_codegen.py`. Two inputs:
+#
+#   CODEGEN_HARNESS_GENERATED_DIR  - directory holding the freshly
+#                                    generated `codegen_harness/types.h`.
+#   ESI_RUNTIME_LIB                - absolute path to
+#                                    `libESICppRuntime.{so,dylib,dll}` to
+#                                    link against (resolved Python-side
+#                                    from the in-tree `esiaccel` package).
+#
+# The in-tree `esi/` headers sit at a fixed relative path from this file.
+
+cmake_minimum_required(VERSION 3.20)
+project(codegen_harness LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CODEGEN_HARNESS_GENERATED_DIR "" CACHE PATH
+    "Root directory containing the generated `codegen_harness/types.h`")
+set(ESI_RUNTIME_LIB "" CACHE FILEPATH
+    "Absolute path to libESICppRuntime.{so,dylib,dll}")
+if(NOT CODEGEN_HARNESS_GENERATED_DIR)
+  message(FATAL_ERROR "CODEGEN_HARNESS_GENERATED_DIR must be set")
+endif()
+if(NOT ESI_RUNTIME_LIB)
+  message(FATAL_ERROR "ESI_RUNTIME_LIB must be set")
+endif()
+
+add_executable(codegen_harness codegen_harness.cpp)
+target_include_directories(codegen_harness PRIVATE
+  "${CODEGEN_HARNESS_GENERATED_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../cpp/include")
+target_link_libraries(codegen_harness PRIVATE "${ESI_RUNTIME_LIB}")
+
+get_filename_component(_esi_runtime_lib_dir "${ESI_RUNTIME_LIB}" DIRECTORY)
+if(UNIX)
+  set_target_properties(codegen_harness PROPERTIES
+    BUILD_RPATH "${_esi_runtime_lib_dir}")
+elseif(WIN32)
+  # Stage the DLL next to the .exe so the harness runs without PATH edits.
+  add_custom_command(TARGET codegen_harness POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${ESI_RUNTIME_LIB}"
+      "$<TARGET_FILE_DIR:codegen_harness>")
+endif()

--- a/lib/Dialect/ESI/runtime/tests/unit/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/tests/unit/CMakeLists.txt
@@ -1,11 +1,19 @@
-# Driven by `tests/unit/test_codegen.py`. Two inputs:
+# Driven by `tests/unit/test_codegen.py`. Inputs:
 #
 #   CODEGEN_HARNESS_GENERATED_DIR  - directory holding the freshly
 #                                    generated `codegen_harness/types.h`.
-#   ESI_RUNTIME_LIB                - absolute path to
-#                                    `libESICppRuntime.{so,dylib,dll}` to
-#                                    link against (resolved Python-side
-#                                    from the in-tree `esiaccel` package).
+#   ESI_RUNTIME_LIB                - absolute path to the artifact to
+#                                    link against. On Unix this is the
+#                                    shared object (`.so` / `.dylib`);
+#                                    on Windows it's the MSVC import
+#                                    library (`.lib`) — linking a `.dll`
+#                                    directly does not work with MSVC,
+#                                    which is why we split the link vs
+#                                    runtime artifacts.
+#   ESI_RUNTIME_DLL                - Windows only, optional. Absolute
+#                                    path to `ESICppRuntime.dll` to
+#                                    stage next to the executable so it
+#                                    runs without modifying `PATH`.
 #
 # The in-tree `esi/` headers sit at a fixed relative path from this file.
 
@@ -19,7 +27,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CODEGEN_HARNESS_GENERATED_DIR "" CACHE PATH
     "Root directory containing the generated `codegen_harness/types.h`")
 set(ESI_RUNTIME_LIB "" CACHE FILEPATH
-    "Absolute path to libESICppRuntime.{so,dylib,dll}")
+    "Absolute path to the ESI runtime link artifact (.so/.dylib/.lib)")
+set(ESI_RUNTIME_DLL "" CACHE FILEPATH
+    "Absolute path to ESICppRuntime.dll (Windows runtime staging only)")
 if(NOT CODEGEN_HARNESS_GENERATED_DIR)
   message(FATAL_ERROR "CODEGEN_HARNESS_GENERATED_DIR must be set")
 endif()
@@ -33,14 +43,21 @@ target_include_directories(codegen_harness PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/../../cpp/include")
 target_link_libraries(codegen_harness PRIVATE "${ESI_RUNTIME_LIB}")
 
-get_filename_component(_esi_runtime_lib_dir "${ESI_RUNTIME_LIB}" DIRECTORY)
 if(UNIX)
+  get_filename_component(_esi_runtime_lib_dir "${ESI_RUNTIME_LIB}" DIRECTORY)
   set_target_properties(codegen_harness PROPERTIES
     BUILD_RPATH "${_esi_runtime_lib_dir}")
 elseif(WIN32)
-  # Stage the DLL next to the .exe so the harness runs without PATH edits.
+  # Prefer the explicit ESI_RUNTIME_DLL when one was provided (MSVC link
+  # via .lib, runtime via .dll). Fall back to ESI_RUNTIME_LIB itself for
+  # the MinGW case where linking is done directly against the .dll.
+  if(ESI_RUNTIME_DLL)
+    set(_esi_runtime_dll "${ESI_RUNTIME_DLL}")
+  else()
+    set(_esi_runtime_dll "${ESI_RUNTIME_LIB}")
+  endif()
   add_custom_command(TARGET codegen_harness POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      "${ESI_RUNTIME_LIB}"
+      "${_esi_runtime_dll}"
       "$<TARGET_FILE_DIR:codegen_harness>")
 endif()

--- a/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
+++ b/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Round-trip harness driven by `tests/unit/test_codegen.py`. The Python
+// fixture builds a small manifest, runs `esiaccel.codegen` on it, and
+// compiles this file against the resulting `types.h`. The harness asserts
+// the generated accessors round-trip user-visible values *and* that the
+// underlying wire bytes match the manifest's bit-packed layout exactly.
+//
+// Reviewing this file is the easiest way to see what the C++ codegen
+// promises end-to-end; if anything here changes the runtime semantics
+// (rather than just the textual emission), this harness is what will
+// catch it.
+
+#include "codegen_harness/types.h"
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <type_traits>
+#include <vector>
+
+using namespace esi_system;
+
+namespace {
+
+// Reinterpret `value` as a `std::array<uint8_t, sizeof(T)>` view of its
+// wire bytes. Used to assert the underlying byte layout of generated
+// types — the only safe API for that is `reinterpret_cast<uint8_t *>`,
+// which the runtime already uses internally via `MessageData::from()`.
+template <typename T>
+std::array<uint8_t, sizeof(T)> wireBytes(const T &value) {
+  std::array<uint8_t, sizeof(T)> out{};
+  const auto *src = reinterpret_cast<const uint8_t *>(&value);
+  for (std::size_t i = 0; i < sizeof(T); ++i)
+    out[i] = src[i];
+  return out;
+}
+
+template <typename T, std::size_t N>
+void expectBytes(const T &value, const std::array<uint8_t, N> &expected,
+                 const char *label) {
+  static_assert(sizeof(T) == N, "wire-byte assertion size mismatch");
+  auto got = wireBytes(value);
+  for (std::size_t i = 0; i < N; ++i) {
+    if (got[i] != expected[i]) {
+      std::fprintf(stderr,
+                   "%s: byte %zu mismatch: got 0x%02x expected 0x%02x\n", label,
+                   i, got[i], expected[i]);
+      std::fprintf(stderr, "  got     :");
+      for (auto b : got)
+        std::fprintf(stderr, " %02x", b);
+      std::fprintf(stderr, "\n  expected:");
+      for (auto b : expected)
+        std::fprintf(stderr, " %02x", b);
+      std::fprintf(stderr, "\n");
+      std::abort();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path A — 8/16/32/64-bit byte-aligned integers
+// ---------------------------------------------------------------------------
+
+void testStandardWidthUnsigned() {
+  StdU s;
+  s.u8(0xAB).u16(0xCAFE).u32(0xDEADBEEFu).u64(0x0123456789ABCDEFull);
+  assert(s.u8() == 0xAB);
+  assert(s.u16() == 0xCAFE);
+  assert(s.u32() == 0xDEADBEEFu);
+  assert(s.u64() == 0x0123456789ABCDEFull);
+
+  // Wire order is reverse of declaration: u64 at byte 0, u32 at byte 8,
+  // u16 at byte 12, u8 at byte 14. Each value is little-endian within
+  // its own bytes.
+  expectBytes(s,
+              std::array<uint8_t, 15>{
+                  // u64 = 0x0123456789ABCDEF, little-endian:
+                  0xEF,
+                  0xCD,
+                  0xAB,
+                  0x89,
+                  0x67,
+                  0x45,
+                  0x23,
+                  0x01,
+                  // u32 = 0xDEADBEEF, little-endian:
+                  0xEF,
+                  0xBE,
+                  0xAD,
+                  0xDE,
+                  // u16 = 0xCAFE, little-endian:
+                  0xFE,
+                  0xCA,
+                  // u8 = 0xAB:
+                  0xAB,
+              },
+              "StdU");
+
+  // Default construction zero-initialises the wire bytes.
+  StdU empty;
+  expectBytes(
+      empty,
+      std::array<uint8_t, 15>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      "StdU empty");
+
+  // Logical-order ctor matches manifest field order.
+  StdU cons(0xAB, 0xCAFE, 0xDEADBEEFu, 0x0123456789ABCDEFull);
+  assert(wireBytes(cons) == wireBytes(s));
+}
+
+void testStandardWidthSigned() {
+  StdS s;
+  s.s8(-7).s16(-1000).s32(-1234567).s64(INT64_MIN);
+  assert(s.s8() == -7);
+  assert(s.s16() == -1000);
+  assert(s.s32() == -1234567);
+  assert(s.s64() == INT64_MIN);
+
+  // Default-construct a fresh value to confirm round-trip without the
+  // chained setter; check INT64_MAX as well to verify both ends of the
+  // range.
+  StdS pos(127, 32767, 2147483647, INT64_MAX);
+  assert(pos.s8() == 127);
+  assert(pos.s64() == INT64_MAX);
+}
+
+// ---------------------------------------------------------------------------
+// Path B — byte-aligned non-standard width (e.g. i24, i48)
+// ---------------------------------------------------------------------------
+
+void testByteAlignedOddWidthUnsigned() {
+  OddU s;
+  s.u24(0xABCDEFu);
+  assert(s.u24() == 0xABCDEFu);
+  // ui24 is 3 bytes little-endian on the wire.
+  expectBytes(s, std::array<uint8_t, 3>{0xEF, 0xCD, 0xAB}, "OddU");
+}
+
+void testByteAlignedOddWidthSigned() {
+  OddS s;
+  s.s24(-1);
+  assert(s.s24() == -1);
+  expectBytes(s, std::array<uint8_t, 3>{0xFF, 0xFF, 0xFF}, "OddS -1");
+
+  s.s24(-8388608); // si24 min
+  assert(s.s24() == -8388608);
+  expectBytes(s, std::array<uint8_t, 3>{0x00, 0x00, 0x80}, "OddS min");
+
+  s.s24(8388607); // si24 max
+  assert(s.s24() == 8388607);
+  expectBytes(s, std::array<uint8_t, 3>{0xFF, 0xFF, 0x7F}, "OddS max");
+
+  // Negative value with all three bytes non-zero. Round-trip + bit pattern.
+  s.s24(-1234567);
+  assert(s.s24() == -1234567);
+}
+
+// ---------------------------------------------------------------------------
+// Path C — sub-byte alignment (uses the BitAccess helpers)
+// ---------------------------------------------------------------------------
+
+void testSubByteUnsigned() {
+  SubU s;
+  s.u3(0b101).u12(0xABC);
+  assert(s.u3() == 0b101);
+  assert(s.u12() == 0xABC);
+
+  // Wire layout: u12 (low 12 bits) then u3 (next 3 bits), tightly packed.
+  // bit 0..11  = 0xABC -> bytes 0=0xBC, byte 1 low nibble = 0xA, high
+  //                      nibble starts u3
+  // bit 12..14 = 0b101 -> byte 1 high 3 bits = 0b101 << 4 = 0x50
+  // total 15 bits in 2 bytes: byte 0 = 0xBC, byte 1 = 0x5A.
+  expectBytes(s, std::array<uint8_t, 2>{0xBC, 0x5A}, "SubU");
+}
+
+void testSubByteSigned() {
+  SubS s;
+  s.s5(-3).s7(-50);
+  assert(s.s5() == -3);
+  assert(s.s7() == -50);
+
+  // s5 = -3 (5-bit two's complement = 0x1D); s7 = -50 (7-bit = 0x4E).
+  // Wire (reversed): s7 in bit 0..6, s5 in bit 7..11.
+  // bit 0..6 = 0b1001110 (0x4E)
+  // bit 7    = s5 bit 0 (LSB of -3 = 1)
+  // bit 8..11 = s5 bit 1..4
+  // s5 = 0x1D = 0b11101 -> bits 7..11 = 11101
+  // byte 0 = (0x4E) | (1 << 7) = 0xCE
+  // byte 1 = 0b00001110 = 0x0E
+  expectBytes(s, std::array<uint8_t, 2>{0xCE, 0x0E}, "SubS");
+}
+
+void testBoolField() {
+  BoolField f;
+  f.flag(true).pad(0x5A);
+  assert(f.flag() == true);
+  assert(f.pad() == 0x5A);
+  // flag is at bit 7 (after the ui7 pad, which is wire-reversed first).
+  // byte 0 = 0x80 | 0x5A = 0xDA
+  expectBytes(f, std::array<uint8_t, 1>{0xDA}, "BoolField true");
+
+  f.flag(false);
+  expectBytes(f, std::array<uint8_t, 1>{0x5A}, "BoolField false");
+}
+
+// ---------------------------------------------------------------------------
+// Nested struct fields (aggregate accessor)
+// ---------------------------------------------------------------------------
+
+void testNestedStruct() {
+  Inner in;
+  in.x(0x12).y(0x34);
+
+  Outer o;
+  o.label(0xAB).inner(in);
+  assert(o.label() == 0xAB);
+  assert(o.inner().x() == 0x12);
+  assert(o.inner().y() == 0x34);
+
+  // Wire order: inner first (in declaration-reversed order), then label.
+  // Inner has y at byte 0, x at byte 1 (reversed inside inner too).
+  expectBytes(o, std::array<uint8_t, 3>{0x34, 0x12, 0xAB}, "Outer");
+
+  // Modifying a returned inner does NOT alias back into the outer
+  // (accessor returns a value, not a reference) — the caller has to
+  // hand the modified inner back via `outer.inner(modified)`.
+  Outer o2;
+  o2.inner(in);
+  auto copy = o2.inner();
+  copy.x(0xFF);
+  assert(o2.inner().x() == 0x12); // unchanged
+  o2.inner(copy);
+  assert(o2.inner().x() == 0xFF);
+}
+
+void testNestedStructMisaligned() {
+  // `Misaligned` wire layout (LSB-first):
+  //   bits  0..2  = tag (ui3)         = 0b101                       (= 5)
+  //   bits  3..10 = inner.y (ui8 LSB at outer bit 3) = 0x34
+  //   bits 11..18 = inner.x (ui8)                     = 0x12
+  //   bits 19..23 = padding (0)
+  // Inner is byte-aligned internally (x at inner bit 8, y at inner bit 0
+  // with the standard reverse), but the inner aggregate as a whole lands
+  // at outer bit 3 — exercising the `copyBitsIn`/`copyBitsOut` path
+  // rather than the byte-aligned fast copy.
+  MisInner mi;
+  mi.x(0x12).y(0x34);
+
+  Misaligned m;
+  m.tag(0b101).inner(mi);
+  assert(m.tag() == 0b101);
+  assert(m.inner().x() == 0x12);
+  assert(m.inner().y() == 0x34);
+
+  // Hand-derived bytes from the bit layout above.
+  expectBytes(m, std::array<uint8_t, 3>{0xA5, 0x91, 0x00},
+              "Misaligned all-set");
+
+  // Setting tag again after writing inner must not disturb inner's bits
+  // (the writer is supposed to mask only the tag's bit range).
+  m.tag(0b000);
+  assert(m.inner().x() == 0x12);
+  assert(m.inner().y() == 0x34);
+  expectBytes(m, std::array<uint8_t, 3>{0xA0, 0x91, 0x00},
+              "Misaligned tag cleared");
+
+  // Setting inner again after writing tag must not disturb tag.
+  m.tag(0b101);
+  MisInner mi2;
+  mi2.x(0xFF).y(0x00);
+  m.inner(mi2);
+  assert(m.tag() == 0b101);
+  assert(m.inner().x() == 0xFF);
+  assert(m.inner().y() == 0x00);
+  // bits  0..2  = 0b101                = 5
+  // bits  3..10 = 0x00                 = 0
+  // bits 11..18 = 0xFF                 = all 1s spanning byte 1 high and
+  //                                      byte 2 low bits
+  // byte 0: tag(3) | y[0..4]<<3 = 0b00000101 = 0x05
+  // byte 1: y[5..7] | x[0..4]<<3 = 0 | 0b11111<<3 = 0b11111000 = 0xF8
+  // byte 2: x[5..7] | pad = 0b00000111 = 0x07
+  expectBytes(m, std::array<uint8_t, 3>{0x05, 0xF8, 0x07},
+              "Misaligned inner all-ones");
+}
+
+// ---------------------------------------------------------------------------
+// Array fields: whole-array and indexed accessors
+// ---------------------------------------------------------------------------
+
+void testArrayOfIntegers() {
+  Arr4 a;
+  a.r({0x10, 0x20, 0x30, 0x40});
+  auto r = a.r();
+  assert(r[0] == 0x10 && r[1] == 0x20 && r[2] == 0x30 && r[3] == 0x40);
+  // Indexed read/write convenience overloads.
+  assert(a.r(2) == 0x30);
+  a.r(2, 0x99);
+  assert(a.r(2) == 0x99);
+
+  // Arrays are laid out element-0-first on the wire (matching the
+  // existing `std::array` layout), not reversed.
+  expectBytes(a, std::array<uint8_t, 4>{0x10, 0x20, 0x99, 0x40}, "Arr4");
+}
+
+// ---------------------------------------------------------------------------
+// Unions
+// ---------------------------------------------------------------------------
+
+void testUnion() {
+  UnionTwo u;
+  u.big(0xCAFE);
+  assert(u.big() == 0xCAFE);
+  // Narrow variant at MSB end: small = high byte of big (little-endian
+  // layout means high byte is at byte_offset = union_bytes - 1 = 1).
+  assert(u.small() == 0xCA);
+  expectBytes(u, std::array<uint8_t, 2>{0xFE, 0xCA}, "Union big");
+
+  u.small(0xA5);
+  assert(u.small() == 0xA5);
+  // Writing the narrow variant overwrites only its byte slot at the
+  // MSB end; the LSB byte retains its previous content.
+  expectBytes(u, std::array<uint8_t, 2>{0xFE, 0xA5}, "Union small");
+}
+
+// ---------------------------------------------------------------------------
+// Window helpers (header / data frame round-trip)
+// ---------------------------------------------------------------------------
+
+void testWindowList() {
+  std::vector<uint32_t> elements = {0xAAAA0001u, 0xBBBB0002u, 0xCCCC0003u};
+  ListWindow win(0xDEAD, elements);
+
+  // Header-field accessor reads the static `tag`. Count comes from the
+  // `<list>_count()` accessor and matches the number of data frames.
+  assert(win.tag() == 0xDEAD);
+  assert(win.items_count() == elements.size());
+
+  // Vector helper materialises the data into a flat std::vector.
+  auto got = win.items_vector();
+  assert(got.size() == elements.size());
+  for (std::size_t i = 0; i < elements.size(); ++i)
+    assert(got[i] == elements[i]);
+
+  // Range accessor produces the same values lazily.
+  std::size_t i = 0;
+  for (uint32_t v : win.items())
+    assert(v == elements[i++]);
+
+  // The window splits into three wire segments: header, data, footer.
+  assert(win.numSegments() == 3);
+  auto header_seg = win.segment(0);
+  auto data_seg = win.segment(1);
+  auto footer_seg = win.segment(2);
+  assert(data_seg.size == elements.size() * sizeof(uint32_t));
+  // Header carries `tag` at the MSB end and the count at the LSB end.
+  // Layout: count (ui16, 2 bytes) then tag (ui16, 2 bytes) in reversed
+  // declaration order; header bytes = [count_lo, count_hi, tag_lo, tag_hi].
+  assert(header_seg.size == 4);
+  assert(header_seg.data[0] == (static_cast<uint8_t>(elements.size()) & 0xFF));
+  assert(header_seg.data[1] == 0); // count high byte (size < 256)
+  assert(header_seg.data[2] == 0xAD);
+  assert(header_seg.data[3] == 0xDE);
+  // Footer is a zero-count header with the same layout.
+  assert(footer_seg.size == 4);
+  assert(footer_seg.data[0] == 0);
+  assert(footer_seg.data[1] == 0);
+}
+
+} // namespace
+
+int main() {
+  testStandardWidthUnsigned();
+  testStandardWidthSigned();
+  testByteAlignedOddWidthUnsigned();
+  testByteAlignedOddWidthSigned();
+  testSubByteUnsigned();
+  testSubByteSigned();
+  testBoolField();
+  testNestedStruct();
+  testNestedStructMisaligned();
+  testArrayOfIntegers();
+  testUnion();
+  testWindowList();
+  std::printf("OK\n");
+  return 0;
+}

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import sys
 import sysconfig
 import tempfile
 from pathlib import Path
@@ -182,10 +183,16 @@ def _harness_env():
   """Resolve `cmake` and the runtime shared library, or skip.
 
   The runtime library always ships next to the `esiaccel` Python package
-  at `<esiaccel>/lib/libESICppRuntime.{so,dylib,dll}`, which is the same
-  binary the rest of the Python test suite already loads. Using that as
-  the anchor avoids needing to plumb in a separate `ESI_RUNTIME_ROOT`,
-  parse `esiaccelConfig.cmake`, or walk the build tree.
+  at `<esiaccel>/lib/...`, which is the same binary the rest of the Python
+  test suite already loads. Using that as the anchor avoids needing to
+  plumb in a separate `ESI_RUNTIME_ROOT`, parse `esiaccelConfig.cmake`,
+  or walk the build tree.
+
+  On Windows, MSVC needs the `.lib` import library to link against and
+  the `.dll` to load at runtime, so we look up both separately and feed
+  them through to CMake as `ESI_RUNTIME_LIB` (link target) and
+  `ESI_RUNTIME_DLL` (runtime artifact to stage next to the executable).
+  On Unix the single shared object covers both jobs.
   """
   if shutil.which("cmake") is None:
     pytest.skip("cmake not available")
@@ -195,17 +202,32 @@ def _harness_env():
   except ImportError:
     pytest.skip("esiaccel not importable")
   esiaccel_lib_dir = Path(esiaccel.__file__).parent / "lib"
-  runtime_lib = None
-  for name in ("libESICppRuntime.so", "libESICppRuntime.dylib",
-               "ESICppRuntime.dll"):
-    candidate = esiaccel_lib_dir / name
-    if candidate.exists():
-      runtime_lib = candidate
-      break
-  if runtime_lib is None:
-    pytest.skip(f"libESICppRuntime not found under {esiaccel_lib_dir}")
 
-  return {"runtime_lib": runtime_lib}
+  runtime_lib = None
+  runtime_dll = None
+  if sys.platform == "win32":
+    # Prefer the MSVC import library for linking; fall back to the DLL
+    # itself (which works with MinGW) if no `.lib` was shipped.
+    lib = esiaccel_lib_dir / "ESICppRuntime.lib"
+    dll = esiaccel_lib_dir / "ESICppRuntime.dll"
+    if lib.exists():
+      runtime_lib = lib
+    if dll.exists():
+      runtime_dll = dll
+      if runtime_lib is None:
+        runtime_lib = dll
+  else:
+    for name in ("libESICppRuntime.so", "libESICppRuntime.dylib"):
+      candidate = esiaccel_lib_dir / name
+      if candidate.exists():
+        runtime_lib = candidate
+        break
+
+  if runtime_lib is None:
+    pytest.skip(f"ESICppRuntime link artifact not found under "
+                f"{esiaccel_lib_dir}")
+
+  return {"runtime_lib": runtime_lib, "runtime_dll": runtime_dll}
 
 
 def test_codegen_round_trip(_harness_env, tmp_path):
@@ -233,6 +255,8 @@ def test_codegen_round_trip(_harness_env, tmp_path):
       f"-DCODEGEN_HARNESS_GENERATED_DIR={generated_dir}",
       f"-DESI_RUNTIME_LIB={_harness_env['runtime_lib']}",
   ]
+  if _harness_env["runtime_dll"] is not None:
+    configure_cmd.append(f"-DESI_RUNTIME_DLL={_harness_env['runtime_dll']}")
   configure_proc = subprocess.run(configure_cmd, capture_output=True, text=True)
   if configure_proc.returncode != 0:
     pytest.fail(

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -1,15 +1,299 @@
-"""Tests for UnionType support in codegen (CppTypePlanner + CppTypeEmitter)."""
+"""End-to-end tests for `esiaccel.codegen`.
 
-import re
+The bulk of the verification is delegated to `codegen_harness.cpp` in this
+directory: the Python side generates a `types.h` from a representative
+manifest, compiles the harness against it, and runs the result. The harness
+exercises every accessor path (Path A / B / C, bool, nested struct, array,
+union, window) and checks both the user-visible round-trip and the
+underlying wire bytes. Reviewers can read the harness directly to see what
+the codegen is contracted to do.
+
+A small number of Python-level tests cover behaviours the harness can't
+exercise — ordering, name collisions, type aliases, and the "skip with a
+comment" path for unsupported / window-containing / fully-collapsed
+structs.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sysconfig
 import tempfile
 from pathlib import Path
+
+import pytest
 
 import esiaccel.types as types
 from esiaccel.codegen import CppTypePlanner, CppTypeEmitter
 
+_HARNESS_DIR = Path(__file__).parent
 
-def _generate_header(type_table, system_name="test_ns"):
-  """Helper: run the planner + emitter on a type table and return the header."""
+# Small set of pre-built ESI scalar types shared by the manifest builders.
+_uint1 = types.UIntType("ui1", 1)
+_uint3 = types.UIntType("ui3", 3)
+_uint7 = types.UIntType("ui7", 7)
+_uint8 = types.UIntType("ui8", 8)
+_uint12 = types.UIntType("ui12", 12)
+_uint16 = types.UIntType("ui16", 16)
+_uint24 = types.UIntType("ui24", 24)
+_uint32 = types.UIntType("ui32", 32)
+_uint64 = types.UIntType("ui64", 64)
+_sint5 = types.SIntType("si5", 5)
+_sint7 = types.SIntType("si7", 7)
+_sint8 = types.SIntType("si8", 8)
+_sint16 = types.SIntType("si16", 16)
+_sint24 = types.SIntType("si24", 24)
+_sint32 = types.SIntType("si32", 32)
+_sint64 = types.SIntType("si64", 64)
+
+# ---------------------------------------------------------------------------
+# Harness Manifest Builder
+# ---------------------------------------------------------------------------
+
+
+def _build_harness_manifest():
+  """Build the type table the `codegen_harness.cpp` test program references.
+
+  The aliases below give every emitted struct a stable, hand-written C++
+  name (e.g. `StdU`) so the harness can use plain identifiers rather than
+  spelling the auto-generated mangled names.
+  """
+  # Path A: standard widths.
+  std_u_inner = types.StructType(
+      "@StdU::inner",
+      [("u8", _uint8), ("u16", _uint16), ("u32", _uint32), ("u64", _uint64)],
+  )
+  std_u = types.TypeAlias("@StdU", "StdU", std_u_inner)
+
+  std_s_inner = types.StructType(
+      "@StdS::inner",
+      [("s8", _sint8), ("s16", _sint16), ("s32", _sint32), ("s64", _sint64)],
+  )
+  std_s = types.TypeAlias("@StdS", "StdS", std_s_inner)
+
+  # Path B: byte-aligned but non-standard width.
+  odd_u_inner = types.StructType("@OddU::inner", [("u24", _uint24)])
+  odd_u = types.TypeAlias("@OddU", "OddU", odd_u_inner)
+  odd_s_inner = types.StructType("@OddS::inner", [("s24", _sint24)])
+  odd_s = types.TypeAlias("@OddS", "OddS", odd_s_inner)
+
+  # Path C: sub-byte alignment.
+  sub_u_inner = types.StructType("@SubU::inner", [("u3", _uint3),
+                                                  ("u12", _uint12)])
+  sub_u = types.TypeAlias("@SubU", "SubU", sub_u_inner)
+  sub_s_inner = types.StructType("@SubS::inner", [("s5", _sint5),
+                                                  ("s7", _sint7)])
+  sub_s = types.TypeAlias("@SubS", "SubS", sub_s_inner)
+
+  # 1-bit bool field.
+  bool_inner = types.StructType("@BoolField::inner", [("flag", _uint1),
+                                                      ("pad", _uint7)])
+  bool_field = types.TypeAlias("@BoolField", "BoolField", bool_inner)
+
+  # Nested struct field.
+  inner_inner = types.StructType("@Inner::inner", [("x", _uint8),
+                                                   ("y", _uint8)])
+  inner = types.TypeAlias("@Inner", "Inner", inner_inner)
+  outer_inner = types.StructType("@Outer::inner", [("label", _uint8),
+                                                   ("inner", inner)])
+  outer = types.TypeAlias("@Outer", "Outer", outer_inner)
+
+  # Nested struct embedded at a sub-byte bit offset. With the default
+  # `cpp_type.reverse=True`, the LAST manifest field ends up at wire bit
+  # 0, so listing `inner` first and `tag` (ui3) second puts `tag` in
+  # bits 0..2 and the 16-bit inner in bits 3..18 — i.e. the inner
+  # aggregate starts at bit 3, not byte-aligned. Exercises the
+  # `copyBitsIn`/`copyBitsOut` paths.
+  mis_inner_inner = types.StructType("@MisInner::inner", [("x", _uint8),
+                                                          ("y", _uint8)])
+  mis_inner = types.TypeAlias("@MisInner", "MisInner", mis_inner_inner)
+  misaligned_inner = types.StructType("@Misaligned::inner",
+                                      [("inner", mis_inner), ("tag", _uint3)])
+  misaligned = types.TypeAlias("@Misaligned", "Misaligned", misaligned_inner)
+
+  # Array-of-integers field with the indexed accessor pair.
+  arr4_type = types.ArrayType("!hw.array<4xui8>", _uint8, 4)
+  arr4_inner = types.StructType("@Arr4::inner", [("r", arr4_type)])
+  arr4 = types.TypeAlias("@Arr4", "Arr4", arr4_inner)
+
+  # Union with one narrow and one wide variant.
+  union_inner = types.UnionType("@UnionTwo::inner", [("small", _uint8),
+                                                     ("big", _uint16)])
+  union_two = types.TypeAlias("@UnionTwo", "UnionTwo", union_inner)
+
+  # Window helper with one static `tag` header field and a list of ui32.
+  list_id = "!esi.list<ui32>"
+  list_type = types.ListType(list_id, _uint32)
+  win_arg_inner = types.StructType(
+      "@ListWindow::arg",
+      [("tag", _uint16), ("items", list_type)],
+  )
+  win_header_inner = types.StructType(
+      "@ListWindow::header",
+      [("tag", _uint16), ("items_count", _uint16)],
+  )
+  win_data_inner = types.StructType(
+      "@ListWindow::data",
+      [("items", types.ArrayType("!hw.array<1xui32>", _uint32, 1))],
+  )
+  win_lowered = types.UnionType(
+      "@ListWindow::lowered",
+      [("header", win_header_inner), ("data", win_data_inner)],
+  )
+  window_id = ('!esi.window<"ListWindow", @ListWindow::arg, '
+               '[<"header", [<"tag">, <"items" countWidth 16>]>, '
+               '<"data", [<"items", 1>]>]>')
+  list_window_inner = types.WindowType(
+      window_id,
+      "ListWindow",
+      win_arg_inner,
+      win_lowered,
+      [
+          types.WindowType.Frame(
+              "header",
+              [
+                  types.WindowType.Field("tag", 0, 0),
+                  types.WindowType.Field("items", 0, 16),
+              ],
+          ),
+          types.WindowType.Frame(
+              "data",
+              [types.WindowType.Field("items", 1, 0)],
+          ),
+      ],
+  )
+  # Hand-name the window so the harness can spell `ListWindow` directly.
+  list_window = types.TypeAlias("@ListWindow", "ListWindow", list_window_inner)
+
+  return [
+      std_u, std_s, odd_u, odd_s, sub_u, sub_s, bool_field, outer, misaligned,
+      arr4, union_two, list_window
+  ]
+
+
+# ---------------------------------------------------------------------------
+# Harness build + run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _harness_env():
+  """Resolve `cmake` and the runtime shared library, or skip.
+
+  The runtime library always ships next to the `esiaccel` Python package
+  at `<esiaccel>/lib/libESICppRuntime.{so,dylib,dll}`, which is the same
+  binary the rest of the Python test suite already loads. Using that as
+  the anchor avoids needing to plumb in a separate `ESI_RUNTIME_ROOT`,
+  parse `esiaccelConfig.cmake`, or walk the build tree.
+  """
+  if shutil.which("cmake") is None:
+    pytest.skip("cmake not available")
+
+  try:
+    import esiaccel
+  except ImportError:
+    pytest.skip("esiaccel not importable")
+  esiaccel_lib_dir = Path(esiaccel.__file__).parent / "lib"
+  runtime_lib = None
+  for name in ("libESICppRuntime.so", "libESICppRuntime.dylib",
+               "ESICppRuntime.dll"):
+    candidate = esiaccel_lib_dir / name
+    if candidate.exists():
+      runtime_lib = candidate
+      break
+  if runtime_lib is None:
+    pytest.skip(f"libESICppRuntime not found under {esiaccel_lib_dir}")
+
+  return {"runtime_lib": runtime_lib}
+
+
+def test_codegen_round_trip(_harness_env, tmp_path):
+  """Compile `codegen_harness.cpp` against a freshly-generated `types.h`
+  and run it. The harness asserts every wire-format and accessor invariant
+  end-to-end; this Python test just drives the cmake build and reports
+  failures.
+  """
+  # Generate the header into `<generated>/codegen_harness/types.h` so the
+  # harness's `#include "codegen_harness/types.h"` resolves under
+  # `<generated>`, which we feed to CMake as the include root.
+  generated_dir = tmp_path / "generated"
+  (generated_dir / "codegen_harness").mkdir(parents=True)
+  planner = CppTypePlanner(_build_harness_manifest())
+  emitter = CppTypeEmitter(planner)
+  emitter.write_header(generated_dir / "codegen_harness", "esi_system")
+
+  build_dir = tmp_path / "build"
+  configure_cmd = [
+      "cmake",
+      "-S",
+      str(_HARNESS_DIR),
+      "-B",
+      str(build_dir),
+      f"-DCODEGEN_HARNESS_GENERATED_DIR={generated_dir}",
+      f"-DESI_RUNTIME_LIB={_harness_env['runtime_lib']}",
+  ]
+  configure_proc = subprocess.run(configure_cmd, capture_output=True, text=True)
+  if configure_proc.returncode != 0:
+    pytest.fail(
+        "cmake configure failed for the codegen harness "
+        f"(rc={configure_proc.returncode}):\n"
+        f"--- cmd ---\n{' '.join(configure_cmd)}\n"
+        f"--- stdout ---\n{configure_proc.stdout}\n"
+        f"--- stderr ---\n{configure_proc.stderr}",
+        pytrace=False,
+    )
+
+  build_cmd = [
+      "cmake", "--build",
+      str(build_dir), "--target", "codegen_harness"
+  ]
+  build_proc = subprocess.run(build_cmd, capture_output=True, text=True)
+  if build_proc.returncode != 0:
+    # Print the generated header alongside the compile failure so a
+    # reviewer can diff the codegen output against what the harness
+    # expects to see.
+    pytest.fail(
+        "codegen_harness.cpp failed to compile against the generated "
+        f"types.h (rc={build_proc.returncode}):\n"
+        f"--- cmd ---\n{' '.join(build_cmd)}\n"
+        f"--- stdout ---\n{build_proc.stdout}\n"
+        f"--- stderr ---\n{build_proc.stderr}\n"
+        "--- generated types.h ---\n" +
+        (generated_dir / "codegen_harness" / "types.h").read_text(),
+        pytrace=False,
+    )
+
+  # CMake places the executable under the build directory; on multi-config
+  # generators (e.g. Visual Studio) the output lives under
+  # `build_dir/<Config>/`. Walk the build dir to find whatever was built.
+  binary_name = "codegen_harness" + sysconfig.get_config_var("EXE")
+  candidates = list(build_dir.rglob(binary_name))
+  if not candidates:
+    pytest.fail(
+        f"codegen_harness binary not found under {build_dir}; "
+        "the cmake build reported success but produced no executable.",
+        pytrace=False,
+    )
+  binary = candidates[0]
+
+  run_proc = subprocess.run([str(binary)], capture_output=True, text=True)
+  if run_proc.returncode != 0 or run_proc.stdout.strip() != "OK":
+    pytest.fail(
+        f"codegen_harness reported failure (rc={run_proc.returncode}):\n"
+        f"--- stdout ---\n{run_proc.stdout}\n"
+        f"--- stderr ---\n{run_proc.stderr}",
+        pytrace=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lightweight Python-level checks for behaviours the harness can't drive.
+# ---------------------------------------------------------------------------
+
+
+def _emit(type_table, system_name: str = "test_ns") -> str:
+  """Run the planner + emitter against `type_table` and return `types.h`."""
   planner = CppTypePlanner(type_table)
   emitter = CppTypeEmitter(planner)
   with tempfile.TemporaryDirectory() as tmpdir:
@@ -17,729 +301,13 @@ def _generate_header(type_table, system_name="test_ns"):
     return (Path(tmpdir) / "types.h").read_text()
 
 
-def _window_struct_name(hdr, window_name_suffix):
-  """Find the generated SegmentedMessageData subclass name for a window.
-
-  Auto-names compose `{into_name}_{window_name}`, so locate the helper by its
-  trailing window-name suffix instead of hard-coding the full identifier.
-  """
-  match = re.search(
-      rf"struct (\S*{re.escape(window_name_suffix)}) "
-      r": public esi::SegmentedMessageData", hdr)
-  assert match, f"Window helper for '*{window_name_suffix}' not found in:\n{hdr}"
-  return match.group(1)
-
-
-def test_union_basic():
-  """A simple union with two scalar fields produces a C++ union."""
-  uint8 = types.UIntType("ui8", 8)
-  uint16 = types.UIntType("ui16", 16)
-  union_t = types.UnionType("!hw.union<a: ui8, b: ui16>", [("a", uint8),
-                                                           ("b", uint16)])
-
-  hdr = _generate_header([union_t])
-  assert "union " in hdr
-  assert '_ESI_ID = "!hw.union<a: ui8, b: ui16>"' in hdr
-  # Field "a" (8 bits) is narrower than the 16-bit union → wrapper struct
-  # with _pad before the data field.
-  assert "struct _union_a_ui8_b_ui16_a" in hdr
-  assert "uint8_t _pad[1]" in hdr
-  assert "uint8_t a;" in hdr
-  # In the wrapper struct, _pad appears before the field.
-  pad_pos = hdr.index("uint8_t _pad[1]")
-  field_a_pos = hdr.index("uint8_t a;")
-  assert pad_pos < field_a_pos
-  # Field "b" (16 bits) is full width → no wrapper, appears directly in union.
-  assert "uint16_t b;" in hdr
-  # Wrapper struct for "a" is emitted before the union keyword.
-  wrapper_pos = hdr.index("struct _union_a_ui8_b_ui16_a")
-  union_pos = hdr.index("union ")
-  assert wrapper_pos < union_pos
-  # Inside the union, "a" comes before "b" (declaration order preserved).
-  union_body = hdr[union_pos:]
-  assert union_body.index("a;") < union_body.index("b;")
-  # The union member for "a" uses the wrapper struct type, not a raw int.
-  assert "_union_a_ui8_b_ui16_a a;" in union_body
-
-
-def test_union_with_struct_field():
-  """A union containing a struct field emits the struct before the union."""
-  uint8 = types.UIntType("ui8", 8)
-  uint16 = types.UIntType("ui16", 16)
-  inner = types.StructType("!hw.struct<x: ui8, y: ui8>", [("x", uint8),
-                                                          ("y", uint8)])
-  union_t = types.UnionType("!hw.union<header: ui16, data: !s>",
-                            [("header", uint16), ("data", inner)])
-
-  hdr = _generate_header([union_t])
-  # The inner struct must appear before the wrapper structs and union.
-  struct_pos = hdr.index("struct _struct")
-  union_pos = hdr.index("union ")
-  assert struct_pos < union_pos
-  assert "data;" in hdr
-  # "header" is 16 bits in a 16-bit union (both fields are 16 bits),
-  # so no padding wrapper is needed for either field.
-  assert "_pad" not in hdr
-
-
-def test_union_ordering_among_structs():
-  """Unions are properly ordered with respect to struct dependencies."""
-  uint8 = types.UIntType("ui8", 8)
-  s1 = types.StructType("!hw.struct<p: ui8>", [("p", uint8)])
-  s2 = types.StructType("!hw.struct<q: ui8>", [("q", uint8)])
-  union_t = types.UnionType("!hw.union<a: !s1, b: !s2>", [("a", s1), ("b", s2)])
-
-  hdr = _generate_header([union_t])
-  union_pos = hdr.index("union ")
-  # Both structs should appear before the union.
-  for keyword in ["struct _struct_p_ui8", "struct _struct_q_ui8"]:
-    assert keyword in hdr
-    assert hdr.index(keyword) < union_pos
-
-
-def test_union_in_struct():
-  """A struct with a union field emits the union before the struct."""
-  uint8 = types.UIntType("ui8", 8)
-  uint16 = types.UIntType("ui16", 16)
-  union_t = types.UnionType("!hw.union<a: ui8, b: ui16>", [("a", uint8),
-                                                           ("b", uint16)])
-  outer = types.StructType("!hw.struct<tag: ui8, data: !u>",
-                           [("tag", uint8), ("data", union_t)])
-
-  hdr = _generate_header([outer])
-  assert "union " in hdr
-  # Wrapper struct for padded field "a" and the union both precede the
-  # outer struct that references the union.
-  wrapper_pos = hdr.index("struct _union")
-  union_pos = hdr.index("union ")
-  struct_pos = hdr.index("struct _struct")
-  assert wrapper_pos < union_pos < struct_pos
-
-
-def test_union_planner_naming():
-  """The planner auto-generates deterministic names for unions."""
-  uint8 = types.UIntType("ui8", 8)
-  union_t = types.UnionType("!hw.union<x: ui8>", [("x", uint8)])
-
-  planner = CppTypePlanner([union_t])
-  assert union_t in planner.type_id_map
-  name = planner.type_id_map[union_t]
-  assert name.startswith("_union")
-
-
-def test_union_alias():
-  """A TypeAlias wrapping a union emits the union then a using alias."""
-  uint8 = types.UIntType("ui8", 8)
-  uint16 = types.UIntType("ui16", 16)
-  union_t = types.UnionType("!hw.union<a: ui8, b: ui16>", [("a", uint8),
-                                                           ("b", uint16)])
-  alias = types.TypeAlias("!hw.typealias<MyUnion>", "MyUnion", union_t)
-
-  hdr = _generate_header([alias])
-  assert "union " in hdr
-  assert "using MyUnion" in hdr
-
-
-def test_union_same_width_integrals():
-  """Integrals of the same width don't need padding wrappers."""
-  uint16 = types.UIntType("ui16", 16)
-  sint16 = types.SIntType("si16", 16)
-  union_t = types.UnionType("!hw.union<a: ui16, b: si16>", [("a", uint16),
-                                                            ("b", sint16)])
-
-  hdr = _generate_header([union_t])
-  assert "union " in hdr
-  assert "_pad" not in hdr
-  # Both fields appear directly in the union as raw types.
-  union_body = hdr[hdr.index("union "):]
-  assert "uint16_t a;" in union_body
-  assert "int16_t b;" in union_body
-
-
-def test_union_field_order_preserved():
-  """Union fields are emitted in declaration order, not reversed."""
-  uint8 = types.UIntType("ui8", 8)
-  sint16 = types.SIntType("si16", 16)
-  uint32 = types.UIntType("ui32", 32)
-  union_t = types.UnionType("!hw.union<z: ui8, m: si16, a: ui32>",
-                            [("z", uint8), ("m", sint16), ("a", uint32)])
-
-  hdr = _generate_header([union_t])
-  # Fields z (8 bit) and m (16 bit) need padding wrappers; a (32 bit) doesn't.
-  assert "_pad[3]" in hdr  # z wrapper: 4 - 1 = 3 bytes padding
-  assert "_pad[2]" in hdr  # m wrapper: 4 - 2 = 2 bytes padding
-  # In each wrapper struct, _pad appears before the data field.
-  z_pad = hdr.index("_pad[3]")
-  z_field = hdr.index("uint8_t z;")
-  assert z_pad < z_field
-  m_pad = hdr.index("_pad[2]")
-  m_field = hdr.index("int16_t m;")
-  assert m_pad < m_field
-  # Inside the union body, field order is preserved (z, m, a).
-  union_body = hdr[hdr.index("union "):]
-  z_pos = union_body.index(" z;")
-  m_pos = union_body.index(" m;")
-  a_pos = union_body.index(" a;")
-  assert z_pos < m_pos < a_pos
-  # Field a (full width) has no wrapper.
-  assert "uint32_t a;" in union_body
-  # Wrapped fields use wrapper struct types as union members.
-  assert "_union_z_ui8_m_si16_a_ui32_z z;" in union_body
-  assert "_union_z_ui8_m_si16_a_ui32_m m;" in union_body
-
-
-def test_windowed_list_bulk_message_wrapper():
-  """Bulk-encoded list windows emit a SegmentedMessageData helper."""
-  uint16 = types.UIntType("ui16", 16)
-  uint32 = types.UIntType("ui32", 32)
-  coord_struct_id = "!hw.struct<x: ui32, y: ui32>"
-  coord_alias_id = (
-      f"!hw.typealias<@esi_runtime_codegen::@Coord, {coord_struct_id}>")
-  coord_list_id = f"!esi.list<{coord_alias_id}>"
-  arg_struct_id = (
-      f"!hw.struct<x_translation: ui32, y_translation: ui32, coords: "
-      f"{coord_list_id}>")
-  header_struct_id = (
-      "!hw.struct<x_translation: ui32, y_translation: ui32, coords_count: "
-      "ui16>")
-  data_struct_id = f"!hw.struct<coords: !hw.array<1x{coord_alias_id}>>"
-  lowered_id = f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>"
-  serial_args_id = (f'!esi.window<"serial_coord_args", {arg_struct_id}, '
-                    '[<"header", [<"x_translation">, <"y_translation">, '
-                    '<"coords" countWidth 16>]>, <"data", [<"coords", 1>]>]>')
-
-  coord_inner = types.StructType(coord_struct_id, [("x", uint32),
-                                                   ("y", uint32)])
-  coord = types.TypeAlias(coord_alias_id, "Coord", coord_inner)
-  coord_list = types.ListType(coord_list_id, coord)
-  arg_struct = types.StructType(arg_struct_id, [("x_translation", uint32),
-                                                ("y_translation", uint32),
-                                                ("coords", coord_list)])
-  header_struct = types.StructType(header_struct_id, [("x_translation", uint32),
-                                                      ("y_translation", uint32),
-                                                      ("coords_count", uint16)])
-  data_struct = types.StructType(
-      data_struct_id,
-      [("coords", types.ArrayType(f"!hw.array<1x{coord_alias_id}>", coord, 1))],
-  )
-  lowered = types.UnionType(lowered_id, [("header", header_struct),
-                                         ("data", data_struct)])
-  serial_args = types.WindowType(
-      serial_args_id, "serial_coord_args", arg_struct, lowered, [
-          types.WindowType.Frame(
-              "header",
-              [
-                  types.WindowType.Field("x_translation", 0, 0),
-                  types.WindowType.Field("y_translation", 0, 0),
-                  types.WindowType.Field("coords", 0, 16),
-              ],
-          ),
-          types.WindowType.Frame(
-              "data",
-              [types.WindowType.Field("coords", 1, 0)],
-          ),
-      ])
-
-  hdr = _generate_header([coord, serial_args])
-  assert "Unsupported type" not in hdr
-  win_name = _window_struct_name(hdr, "_serial_coord_args")
-  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
-  assert "using value_type = Coord;" in hdr
-  assert "using count_type = uint16_t;" in hdr
-  assert "count_type coords_count;" in hdr
-  assert "uint8_t _pad[2];" in hdr
-  assert "Coord coords;" in hdr
-  assert hdr.index("struct data_frame {") < hdr.index(
-      "private:\n#pragma pack(push, 1)\n  struct header_frame {")
-  assert "std::vector<data_frame> data_frames;" in hdr
-  assert "esi::Segment segment(size_t idx) const override" in hdr
-  assert "footer.coords_count = 0;" in hdr
-  assert "const std::vector<value_type> &coords" in hdr
-  assert "void construct(uint32_t x_translation, uint32_t y_translation, std::vector<data_frame> frames)" in hdr
-  assert "construct(x_translation, y_translation, std::move(frames));" in hdr
-  assert "auto &frame = frames.emplace_back();" in hdr
-  assert "for (const auto &element : coords) {" in hdr
-  assert "frame.coords = element;" in hdr
-  # Inner struct id is _ESI_ID; window id (with escaped quotes) is
-  # _ESI_WINDOW_ID so the runtime can verify the wire format too.
-  assert f'_ESI_ID = "{arg_struct_id}"' in hdr
-  escaped_serial_args_id = serial_args_id.replace('"', '\\"')
-  assert f'_ESI_WINDOW_ID = "{escaped_serial_args_id}"' in hdr
-  assert f'throw std::out_of_range("{win_name}: invalid segment index")' in hdr
-  # Accessor methods for header fields and data fields.
-  assert "uint32_t x_translation() const { return header.x_translation; }" in hdr
-  assert "uint32_t y_translation() const { return header.y_translation; }" in hdr
-  assert "size_t coords_count() const { return data_frames.size(); }" in hdr
-  # Byte-aligned data field: pointer-to-member projection (zero-copy view).
-  assert "return std::views::transform(data_frames, &data_frame::coords);" in hdr
-  assert "std::vector<value_type> coords_vector() const" in hdr
-  assert "out.push_back(frame.coords);" in hdr
-
-
-def test_windowed_list_header_padding_matches_frame_width():
-  """Headers pad out to the data frame width for count-only windows."""
-  uint16 = types.UIntType("ui16", 16)
-  uint32 = types.UIntType("ui32", 32)
-  element_id = "!hw.struct<x: ui32, y: ui32>"
-  list_id = f"!esi.list<{element_id}>"
-  arg_struct_id = f"!hw.struct<coords: {list_id}>"
-  header_struct_id = "!hw.struct<coords_count: ui16>"
-  data_struct_id = f"!hw.struct<coords: !hw.array<1x{element_id}>>"
-  lowered_id = f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>"
-  window_id = (f'!esi.window<"coords_only", {arg_struct_id}, '
-               '[<"header", [<"coords" countWidth 16>]>, '
-               '<"data", [<"coords", 1>]>]>')
-
-  element = types.StructType(element_id, [("x", uint32), ("y", uint32)])
-  coord_list = types.ListType(list_id, element)
-  arg_struct = types.StructType(arg_struct_id, [("coords", coord_list)])
-  header_struct = types.StructType(header_struct_id, [("coords_count", uint16)])
-  data_struct = types.StructType(
-      data_struct_id,
-      [("coords", types.ArrayType(f"!hw.array<1x{element_id}>", element, 1))],
-  )
-  lowered = types.UnionType(lowered_id, [("header", header_struct),
-                                         ("data", data_struct)])
-  window = types.WindowType(window_id, "coords_only", arg_struct, lowered, [
-      types.WindowType.Frame("header",
-                             [types.WindowType.Field("coords", 0, 16)]),
-      types.WindowType.Frame("data", [types.WindowType.Field("coords", 1, 0)]),
-  ])
-
-  hdr = _generate_header([window])
-  win_name = _window_struct_name(hdr, "_coords_only")
-  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
-  assert "struct header_frame {\n    uint8_t _pad[6];\n    count_type coords_count;\n  };" in hdr
-  assert "header_frame footer{};" in hdr
-  assert "void construct(std::vector<data_frame> frames)" in hdr
-
-
-def test_windowed_list_arrays_in_header_and_value_type():
-  """Window helpers copy array header fields and array-valued elements."""
-  uint8 = types.UIntType("ui8", 8)
-  uint16 = types.UIntType("ui16", 16)
-  header_array_id = "!hw.array<2xui16>"
-  value_array_id = "!hw.array<4xui8>"
-  list_id = f"!esi.list<{value_array_id}>"
-  arg_struct_id = (
-      f"!hw.struct<header_words: {header_array_id}, payloads: {list_id}>")
-  header_struct_id = (
-      f"!hw.struct<header_words: {header_array_id}, payloads_count: ui16>")
-  data_struct_id = f"!hw.struct<payloads: !hw.array<1x{value_array_id}>>"
-  lowered_id = f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>"
-  window_id = (f'!esi.window<"array_payloads", {arg_struct_id}, '
-               '[<"header", [<"header_words">, <"payloads" countWidth 16>]>, '
-               '<"data", [<"payloads", 1>]>]>')
-
-  header_array = types.ArrayType(header_array_id, uint16, 2)
-  value_array = types.ArrayType(value_array_id, uint8, 4)
-  payload_list = types.ListType(list_id, value_array)
-  arg_struct = types.StructType(arg_struct_id, [("header_words", header_array),
-                                                ("payloads", payload_list)])
-  header_struct = types.StructType(header_struct_id,
-                                   [("header_words", header_array),
-                                    ("payloads_count", uint16)])
-  data_struct = types.StructType(
-      data_struct_id,
-      [("payloads",
-        types.ArrayType(f"!hw.array<1x{value_array_id}>", value_array, 1))],
-  )
-  lowered = types.UnionType(lowered_id, [("header", header_struct),
-                                         ("data", data_struct)])
-  window = types.WindowType(window_id, "array_payloads", arg_struct, lowered, [
-      types.WindowType.Frame(
-          "header",
-          [
-              types.WindowType.Field("header_words", 0, 0),
-              types.WindowType.Field("payloads", 0, 16),
-          ],
-      ),
-      types.WindowType.Frame(
-          "data",
-          [types.WindowType.Field("payloads", 1, 0)],
-      ),
-  ])
-
-  hdr = _generate_header([window])
-  assert "#include <array>" in hdr
-  win_name = _window_struct_name(hdr, "_array_payloads")
-  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
-  # `value_type` is exposed as `std::array` so it is storable in `std::vector`.
-  assert "using value_type = std::array<uint8_t, 4>;" in hdr
-  assert "using count_type = uint16_t;" in hdr
-  # All array-typed fields (header and data) are emitted as `std::array`.
-  assert "std::array<uint16_t, 2> header_words;" in hdr
-  assert "std::array<uint8_t, 4> payloads;" in hdr
-  # Constructor params for arrays are simple const-refs to `std::array`.
-  assert f"{win_name}(const std::array<uint16_t, 2> &header_words, const std::vector<value_type> &payloads)" in hdr
-  assert "void construct(const std::array<uint16_t, 2> &header_words, std::vector<data_frame> frames)" in hdr
-  # Plain `=` assignment for both header and data array fields.
-  assert "header.header_words = header_words;" in hdr
-  assert "frame.payloads = element;" in hdr
-  assert f'throw std::out_of_range("{win_name}: invalid segment index")' in hdr
-  # Array-typed header field: const-ref accessor with std::array return type.
-  assert "const std::array<uint16_t, 2> &header_words() const { return header.header_words; }" in hdr
-  # Array-typed data field: pointer-to-member projection (zero-copy view) and
-  # std::array-valued vector helper. The list field uses the `value_type`
-  # alias (which equals `std::array<uint8_t, 4>`).
-  assert "return std::views::transform(data_frames, &data_frame::payloads);" in hdr
-  assert "std::vector<value_type> payloads_vector() const" in hdr
-  assert "out.push_back(frame.payloads);" in hdr
-
-
-def test_windowed_list_struct_element_data_uses_pointer_to_member():
-  """Struct-typed data fields use a pointer-to-member projection, not a lambda.
-
-  Even if the struct contains a non-byte-aligned (bit-field) member, the data
-  field itself is a struct type, which is byte-aligned and supports
-  pointer-to-member projection.
-  """
-  sint3 = types.SIntType("si3", 3)
-  uint16 = types.UIntType("ui16", 16)
-  list_id = f"!esi.list<!hw.struct<v: si3>>"
-  elem_id = "!hw.struct<v: si3>"
-  elem_struct = types.StructType(elem_id, [("v", sint3)])
-  elem_list = types.ListType(list_id, elem_struct)
-  arg_struct_id = f"!hw.struct<items: {list_id}>"
-  arg_struct = types.StructType(arg_struct_id, [("items", elem_list)])
-  header_struct_id = "!hw.struct<items_count: ui16>"
-  header_struct = types.StructType(header_struct_id, [("items_count", uint16)])
-  data_struct_id = f"!hw.struct<items: !hw.array<1x{elem_id}>>"
-  data_struct = types.StructType(
-      data_struct_id,
-      [("items", types.ArrayType(f"!hw.array<1x{elem_id}>", elem_struct, 1))],
-  )
-  lowered_id = (
-      f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>")
-  lowered = types.UnionType(lowered_id, [("header", header_struct),
-                                         ("data", data_struct)])
-  window_id = (f'!esi.window<"bitfield_items", {arg_struct_id}, '
-               '[<"header", [<"items" countWidth 16>]>, '
-               '<"data", [<"items", 1>]>]>')
-  window = types.WindowType(window_id, "bitfield_items", arg_struct, lowered, [
-      types.WindowType.Frame("header",
-                             [types.WindowType.Field("items", 0, 16)]),
-      types.WindowType.Frame("data", [types.WindowType.Field("items", 1, 0)]),
-  ])
-
-  hdr = _generate_header([elem_struct, window])
-  win_name = _window_struct_name(hdr, "_bitfield_items")
-  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
-  # The data field "items" is a struct type (byte-aligned), so pointer-to-member
-  # IS valid.  The generated accessor must use &data_frame::items, not a lambda.
-  assert "return std::views::transform(data_frames, &data_frame::items);" in hdr
-  assert "[](const data_frame &f) { return f.items; }" not in hdr
-  assert "std::vector<value_type> items_vector() const" in hdr
-
-
-def test_windowed_list_bitfield_scalar_data_uses_lambda():
-  """A window data field that is itself a non-byte-aligned int uses a lambda projection."""
-  uint3 = types.UIntType("ui3", 3)
-  uint16 = types.UIntType("ui16", 16)
-  # Build a window where the data field is directly a 3-bit uint.
-  list_id = "!esi.list<ui3>"
-  elem_list = types.ListType(list_id, uint3)
-  arg_struct_id = f"!hw.struct<vals: {list_id}>"
-  arg_struct = types.StructType(arg_struct_id, [("vals", elem_list)])
-  header_struct_id = "!hw.struct<vals_count: ui16>"
-  header_struct = types.StructType(header_struct_id, [("vals_count", uint16)])
-  data_struct_id = "!hw.struct<vals: !hw.array<1xui3>>"
-  data_struct = types.StructType(
-      data_struct_id,
-      [("vals", types.ArrayType("!hw.array<1xui3>", uint3, 1))],
-  )
-  lowered_id = (
-      f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>")
-  lowered = types.UnionType(lowered_id, [("header", header_struct),
-                                         ("data", data_struct)])
-  window_id = (f'!esi.window<"bitval_window", {arg_struct_id}, '
-               '[<"header", [<"vals" countWidth 16>]>, '
-               '<"data", [<"vals", 1>]>]>')
-  window = types.WindowType(window_id, "bitval_window", arg_struct, lowered, [
-      types.WindowType.Frame("header", [types.WindowType.Field("vals", 0, 16)]),
-      types.WindowType.Frame("data", [types.WindowType.Field("vals", 1, 0)]),
-  ])
-
-  hdr = _generate_header([window])
-  win_name = _window_struct_name(hdr, "_bitval_window")
-  assert f"struct {win_name} : public esi::SegmentedMessageData" in hdr
-  # The data field "vals" stores a 3-bit uint, which becomes a bit-field.
-  # The range accessor must use a lambda, not &data_frame::vals.
-  assert "[](const data_frame &f) { return f.vals; }" in hdr
-  assert "&data_frame::vals" not in hdr
-  assert "std::vector<value_type> vals_vector() const" in hdr
-
-
-def test_size_assert_emitted_for_struct():
-  """Each packed struct gets a `static_assert` pinning its `sizeof`."""
-  uint16 = types.UIntType("ui16", 16)
-  sint8 = types.SIntType("si8", 8)
-  s = types.StructType("!hw.struct<a: ui16, b: si8>", [("a", uint16),
-                                                       ("b", sint8)])
-
-  hdr = _generate_header([s])
-  # Total: 16 + 8 = 24 bits = 3 bytes.
-  assert "static_assert(sizeof(_struct_a_ui16_b_si8) == 3," in hdr
-  assert "packed layout does not match manifest size" in hdr
-
-
-def test_size_assert_emitted_for_union_and_wrappers():
-  """Unions and their padding wrapper structs each get a size assert."""
-  uint8 = types.UIntType("ui8", 8)
-  uint16 = types.UIntType("ui16", 16)
-  union_t = types.UnionType("!hw.union<a: ui8, b: ui16>", [("a", uint8),
-                                                           ("b", uint16)])
-
-  hdr = _generate_header([union_t])
-  # The union itself is 2 bytes (max(8, 16) = 16 bits).
-  assert "static_assert(sizeof(_union_a_ui8_b_ui16) == 2," in hdr
-  # The wrapper around the narrow `a` field is also 2 bytes.
-  assert "static_assert(sizeof(_union_a_ui8_b_ui16_a) == 2," in hdr
-
-
-def test_size_assert_emitted_for_window_frames():
-  """Both `data_frame` and `header_frame` get size asserts inside the window."""
-  uint16 = types.UIntType("ui16", 16)
-  uint32 = types.UIntType("ui32", 32)
-  element_id = "!hw.struct<x: ui32, y: ui32>"
-  list_id = f"!esi.list<{element_id}>"
-  arg_struct_id = f"!hw.struct<coords: {list_id}>"
-  header_struct_id = "!hw.struct<coords_count: ui16>"
-  data_struct_id = f"!hw.struct<coords: !hw.array<1x{element_id}>>"
-  lowered_id = f"!hw.union<header: {header_struct_id}, data: {data_struct_id}>"
-  window_id = (f'!esi.window<"coords_only", {arg_struct_id}, '
-               '[<"header", [<"coords" countWidth 16>]>, '
-               '<"data", [<"coords", 1>]>]>')
-
-  element = types.StructType(element_id, [("x", uint32), ("y", uint32)])
-  coord_list = types.ListType(list_id, element)
-  arg_struct = types.StructType(arg_struct_id, [("coords", coord_list)])
-  header_struct = types.StructType(header_struct_id, [("coords_count", uint16)])
-  data_struct = types.StructType(
-      data_struct_id,
-      [("coords", types.ArrayType(f"!hw.array<1x{element_id}>", element, 1))],
-  )
-  lowered = types.UnionType(lowered_id, [("header", header_struct),
-                                         ("data", data_struct)])
-  window = types.WindowType(window_id, "coords_only", arg_struct, lowered, [
-      types.WindowType.Frame("header",
-                             [types.WindowType.Field("coords", 0, 16)]),
-      types.WindowType.Frame("data", [types.WindowType.Field("coords", 1, 0)]),
-  ])
-
-  hdr = _generate_header([window])
-  # Both inner frames are sized to the wider data frame: 8 bytes per coord.
-  assert "static_assert(sizeof(data_frame) == 8," in hdr
-  assert "static_assert(sizeof(header_frame) == 8," in hdr
-
-
-def test_size_assert_skipped_for_unbounded_struct():
-  """Structs containing an `!esi.any` field have no static size, so no assert."""
-  uint8 = types.UIntType("ui8", 8)
+def test_unbounded_field_skips_struct_with_comment():
+  """A struct whose payload type has no bounded width (e.g. `!esi.any`)
+  cannot be expressed in the raw-bytes layout; the codegen drops the
+  whole struct and leaves an `Unsupported type` comment behind so callers
+  see why the symbol they expected is missing."""
   any_t = types.AnyType("!esi.any")
-  s = types.StructType("!hw.struct<tag: ui8, data: !esi.any>",
-                       [("tag", uint8), ("data", any_t)])
+  s = types.StructType("@any_struct", [("tag", _uint8), ("data", any_t)])
 
-  hdr = _generate_header([s])
-  # The struct is still emitted, but no size assert (its size is unbounded).
-  assert "struct _struct_tag_ui8_data__esi_any" in hdr
-  assert "static_assert(sizeof(_struct_tag_ui8_data__esi_any)" not in hdr
-
-
-def test_struct_with_void_field_commented_out():
-  """Void-typed struct fields are commented out so the header stays valid C++.
-
-  `void x;` is not a valid C++ field declaration. The codegen must instead
-  emit `// void x;` and exclude the field from the generated constructor.
-  """
-  uint8 = types.UIntType("ui8", 8)
-  void_t = types.VoidType("!esi.void")
-  s = types.StructType(
-      "!hw.struct<valid: ui8, client_data: void>",
-      [("valid", uint8), ("client_data", void_t)],
-  )
-
-  hdr = _generate_header([s])
-  # No uncommented `void <name>;` declaration may appear in the header.
-  assert re.search(r"^\s*void\s+\w+;", hdr, re.M) is None, hdr
-  # The void field must instead show up as a commented-out placeholder.
-  assert "// void client_data;" in hdr
-  # The non-void field is still emitted normally.
-  assert "uint8_t valid" in hdr
-  # The constructor must not take a `void` parameter (which would be
-  # invalid C++); only the non-void field is in the parameter list.
-  ctor_match = re.search(r"_struct_[^\s(]*\(([^)]*)\) :", hdr)
-  assert ctor_match, f"Constructor not found in:\n{hdr}"
-  ctor_params = ctor_match.group(1)
-  assert "client_data" not in ctor_params
-  assert "valid" in ctor_params
-  # The generated struct only contains the non-void field, so the size
-  # assertion must not include the void field's wire-format byte. With one
-  # ui8 field the struct must be exactly 1 byte.
-  assert "static_assert(sizeof(_struct_valid_ui8_client_data__esi_void) == 1," \
-      in hdr
-
-
-def test_union_with_void_field_commented_out():
-  """Void-typed union members are commented out and skip wrapper generation."""
-  uint16 = types.UIntType("ui16", 16)
-  void_t = types.VoidType("!esi.void")
-  u = types.UnionType(
-      "!hw.union<a: ui16, b: void>",
-      [("a", uint16), ("b", void_t)],
-  )
-
-  hdr = _generate_header([u])
-  # No uncommented `void <name>;` declaration may appear in the header;
-  # the void member must show up as a commented-out placeholder instead.
-  assert re.search(r"^\s*void\s+\w+;", hdr, re.M) is None, hdr
-  assert "// void b;" in hdr
-  # No padding wrapper struct is generated for the void field.
-  assert "_union_a_ui16_b__esi_void_b" not in hdr
-  # The non-void member is still present in the union body.
-  union_body = hdr[hdr.index("union "):]
-  assert "uint16_t a;" in union_body
-
-
-def test_nested_struct_with_void_field_size_assert():
-  """An outer struct containing an inner struct with a void field must use
-  the inner struct's effective (post-void-elimination) size in its size
-  assertion, not the manifest's wire-format size.
-  """
-  uint8 = types.UIntType("ui8", 8)
-  uint64 = types.UIntType("ui64", 64)
-  void_t = types.VoidType("!esi.void")
-  inner = types.StructType(
-      "!hw.struct<valid: ui8, client_data: void>",
-      [("valid", uint8), ("client_data", void_t)],
-  )
-  outer = types.StructType(
-      "!hw.struct<address: ui64, tag: ui8, "
-      "data: !hw.struct<valid: ui8, client_data: void>>",
-      [("address", uint64), ("tag", uint8), ("data", inner)],
-  )
-
-  hdr = _generate_header([outer])
-  # Inner struct: 1 byte (only the ui8 field).
-  assert "static_assert(sizeof(_struct_valid_ui8_client_data__esi_void) == 1," \
-      in hdr
-  # Outer struct: 8 (address) + 1 (tag) + 1 (inner) == 10 bytes; the manifest
-  # wire-format width would have been 11 if the inner's void byte leaked
-  # through, so the regression fix must pull the inner's effective width.
-  outer_assert = re.search(
-      r"static_assert\(sizeof\(_struct_address_ui64_tag_ui8_data_[^)]+\) == (\d+),",
-      hdr,
-  )
-  assert outer_assert, f"Outer size assertion not found in:\n{hdr}"
-  assert outer_assert.group(1) == "10", \
-      f"Expected outer struct size 10, got {outer_assert.group(1)}"
-
-
-def test_all_void_struct_collapses_to_void():
-  """A struct whose fields are all void collapses to `void` everywhere.
-
-  The all-void inner struct must not be emitted at all, and an outer struct
-  that references it must comment out that field and exclude it from the
-  generated constructor.
-  """
-  uint8 = types.UIntType("ui8", 8)
-  uint64 = types.UIntType("ui64", 64)
-  void_t = types.VoidType("!esi.void")
-  inner = types.StructType(
-      "!hw.struct<a: void, b: void>",
-      [("a", void_t), ("b", void_t)],
-  )
-  outer = types.StructType(
-      "!hw.struct<address: ui64, tag: ui8, "
-      "data: !hw.struct<a: void, b: void>>",
-      [("address", uint64), ("tag", uint8), ("data", inner)],
-  )
-
-  hdr = _generate_header([outer])
-  # The inner all-void struct must not appear as a struct declaration.
-  assert "struct _struct_a__esi_void_b__esi_void" not in hdr
-  # The outer struct's `data` field collapses to a commented-out void.
-  assert "// void data;" in hdr
-  # No uncommented `void <name>;` declaration may appear anywhere.
-  assert re.search(r"^\s*void\s+\w+;", hdr, re.M) is None, hdr
-  # The outer constructor must not take the void-collapsed `data` parameter.
-  outer_ctor = re.search(
-      r"_struct_address_ui64_tag_ui8_data_[^\s(]*\(([^)]*)\) :", hdr)
-  assert outer_ctor, f"Outer constructor not found in:\n{hdr}"
-  assert "data" not in outer_ctor.group(1)
-  # The outer struct's size assert reflects the actual emitted layout
-  # (8 address + 1 tag + 0 data == 9 bytes).
-  outer_assert = re.search(
-      r"static_assert\(sizeof\(_struct_address_ui64_tag_ui8_data_[^)]+\) "
-      r"== (\d+),",
-      hdr,
-  )
-  assert outer_assert, f"Outer size assertion not found in:\n{hdr}"
-  assert outer_assert.group(1) == "9", \
-      f"Expected outer struct size 9, got {outer_assert.group(1)}"
-
-
-def test_struct_containing_window_is_skipped():
-  """Structs that embed a WindowType field (e.g. DMA transport wrappers like
-  {valid: i8, client_data: <window>}) should not be emitted because the C++
-  window helper is a variable-size multi-frame container whose sizeof cannot
-  match the manifest's compact frame bit-width."""
-  uint8 = types.UIntType("ui8", 8)
-  uint16 = types.UIntType("ui16", 16)
-  uint32 = types.UIntType("ui32", 32)
-
-  # Build a simple window type over a struct with a list field.
-  list_t = types.ListType("!esi.list<ui32>", uint32)
-  into_struct = types.StructType("!hw.struct<data: !esi.list<ui32>>",
-                                 [("data", list_t)])
-  header_struct = types.StructType("!hw.struct<data_count: ui16>",
-                                   [("data_count", uint16)])
-  data_struct = types.StructType("!hw.struct<data: ui32>", [("data", uint32)])
-  lowered = types.UnionType(
-      "!hw.union<header: !hw.struct<data_count: ui16>, "
-      "data: !hw.struct<data: ui32>>",
-      [("header", header_struct), ("data", data_struct)],
-  )
-  window = types.WindowType(
-      '!esi.window<"test_win", !hw.struct<data: !esi.list<ui32>>, '
-      '[<"header", [<"data" countWidth 16>]>, <"data", [<"data", 1>]>]>',
-      "test_win",
-      into_struct,
-      lowered,
-      [
-          types.WindowType.Frame("header",
-                                 [types.WindowType.Field("data", 0, 16)]),
-          types.WindowType.Frame("data",
-                                 [types.WindowType.Field("data", 1, 0)]),
-      ],
-  )
-
-  # DMA-style wrapper: {valid: i8, client_data: <window>}
-  dma_wrapper = types.StructType(
-      "!hw.struct<valid: i8, client_data: !the_window>",
-      [("valid", uint8), ("client_data", window)],
-  )
-  # Nested DMA wrapper: {address: ui64, tag: ui8, data: <dma_wrapper>}
-  uint64 = types.UIntType("ui64", 64)
-  outer_wrapper = types.StructType(
-      "!hw.struct<address: ui64, tag: ui8, data: !dma_wrapper>",
-      [("address", uint64), ("tag", uint8), ("data", dma_wrapper)],
-  )
-
-  hdr = _generate_header([window, dma_wrapper, outer_wrapper])
-
-  # The window helper itself should still be emitted.
-  assert "esi::SegmentedMessageData" in hdr
-
-  # But the DMA wrapper structs containing the window should NOT be emitted.
-  assert "struct _struct_valid" not in hdr, \
-      "DMA wrapper struct with window field should not be emitted"
-  assert "struct _struct_address" not in hdr, \
-      "Outer struct nesting a window-containing struct should not be emitted"
-
-  # A TypeAlias targeting a window-containing struct should also be excluded
-  # (otherwise codegen emits `using Foo = <missing>;`).
-  alias = types.TypeAlias("!hw.typealias<@dma_wrap>", "DmaWrap", dma_wrapper)
-  hdr2 = _generate_header([window, dma_wrapper, alias])
-  assert "using DmaWrap" not in hdr2, \
-      "Alias of a window-containing struct should not be emitted"
+  hdr = _emit([s])
+  assert "// Unsupported type '<@any_struct>'" in hdr


### PR DESCRIPTION
Emit structs which don't rely on bit packing. Bit packing is apparantly compiler-defined ABI. While the Itanium ABI (used by GCC and Clang) is hardware compatible, the MSVC ABI is not. So writing code to do the bitpacking oneself is pretty much the only way to get hardware compatible code on Windows.

Assisted-by: vscode:Claude Opus 4.7