### PR TITLE
[FIRRTL][circt-reduce] Add LayerEnableRemover to strip enabled layers

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -2559,6 +2559,34 @@ struct LayerDisable : public OpReduction<CircuitOp> {
   DenseMap<uint64_t, SymbolRefAttr> symbolRefAttrMap;
 };
 
+/// A reduction pattern that removes initialized layer entries
+/// from the FIRRTL module operations.
+struct LayerEnableRemover : public OpReduction<FModuleOp> {
+  void matches(FModuleOp moduleOp,
+               llvm::function_ref<void(uint64_t, uint64_t)> addMatch) override {
+
+    auto layers = moduleOp.getLayersAttr();
+    for (size_t i = 0, e = layers.size(); i != e; ++i)
+      addMatch(1, i);
+  }
+
+  LogicalResult rewriteMatches(FModuleOp moduleOp,
+                               ArrayRef<uint64_t> matches) override {
+
+    llvm::SmallDenseSet<uint64_t, 4> removed(matches.begin(), matches.end());
+    SmallVector<Attribute> newLayers;
+    auto layers = moduleOp.getLayersAttr();
+    for (size_t i = 0, e = layers.size(); i != e; ++i)
+      if (!removed.contains(i))
+        newLayers.push_back(layers[i]);
+
+    moduleOp.setLayersAttr(ArrayAttr::get(moduleOp.getContext(), newLayers));
+    return success();
+  }
+
+  std::string getName() const override { return "firrtl-layer-enable-remover"; }
+};
+
 } // namespace
 
 /// A reduction pattern that removes elements from FIRRTL list create
@@ -2652,6 +2680,7 @@ void firrtl::FIRRTLReducePatternDialectInterface::populateReducePatterns(
   patterns.add<AnnotationRemover, 32>();
   patterns.add<ModuleSwapper, 31>();
   patterns.add<LayerDisable, 30>(getContext());
+  patterns.add<LayerEnableRemover, 30>();
   patterns.add<PassReduction, 29>(
       getContext(),
       firrtl::createDropName({/*preserveMode=*/PreserveValues::None}), false,

--- a/test/Dialect/FIRRTL/Reduction/layer-enable-remover.mlir
+++ b/test/Dialect/FIRRTL/Reduction/layer-enable-remover.mlir
@@ -1,0 +1,22 @@
+// UNSUPPORTED: system-windows
+//   See https://github.com/llvm/circt/issues/4129
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg '@Foo' --include firrtl-layer-enable-remover --include firrtl-layer-disable --keep-best=0 | FileCheck %s --check-prefix=ALL-LAYERS --implicit-check-not='firrtl.layer' --implicit-check-not='layers ='
+// RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg '@A::@B' --include firrtl-layer-enable-remover --keep-best=0 | FileCheck %s --check-prefix=KEEP-LAYER-B
+
+// ALL-LAYERS-LABEL: firrtl.circuit "Foo"
+// ALL-LAYERS: firrtl.module @Foo()
+// ALL-LAYERS-NEXT: }
+
+// KEEP-LAYER-B-LABEL: firrtl.circuit "Foo"
+// KEEP-LAYER-B: firrtl.module @Foo() attributes {layers = [@A::@B]}
+// KEEP-LAYER-B-NEXT: }
+firrtl.circuit "Foo" {
+  firrtl.layer @A bind attributes {output_file = #hw.output_file<"a/">, sym_visibility = "private"} {
+    firrtl.layer @B bind attributes {output_file = #hw.output_file<"a/b/">} {
+    }
+    firrtl.layer @C bind attributes {output_file = #hw.output_file<"a/c/">} {
+    }
+  }
+  firrtl.module @Foo() attributes {layers = [@A, @A::@B, @A::@C]} {
+  }
+}


### PR DESCRIPTION
Concerns  #10527 

We add  a `LayerEnableRemover` reduction that removes module layer enable entries, allowing the existing LayerDisable reduction to remove the layer declarations.