### PR TITLE
[Synth] Move three-input boilerplate to ODS

### DIFF
--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -150,6 +150,13 @@ inline llvm::KnownBits invertBooleanLogic(llvm::KnownBits value) {
   return value;
 }
 
+inline llvm::KnownBits applyInputInversion(llvm::KnownBits value,
+                                           bool inverted) {
+  if (inverted)
+    std::swap(value.Zero, value.One);
+  return value;
+}
+
 template <typename T>
 T evaluateOneHotLogic(const T &a, const T &b, const T &c) {
   auto allSet = a & b & c;

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -287,7 +287,7 @@ def MuxInverterOp : ThreeInputOp<"mux_inv", "evaluateMuxLogic"> {
   }];
 }
 
-def GambleOp : SymmetricThreeInputOp<"gamble", "evaluateGambleLogic">{
+def GambleOp : SymmetricThreeInputOp<"gamble", "evaluateGambleLogic"> {
   let summary = "3-input Gamble gate with invertible inputs";
   let description = [{
   The `synth.gamble` operation computes the gamble function of its three

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -31,7 +31,7 @@ class InvertibleOperandsOp<string mnemonic, list<Trait> traits = []>
       DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
         "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
         "supportsNumInputs", "createBooleanLogicOp", "getLogicDepthCost",
-        "getLogicAreaCost"
+        "getLogicAreaCost", "emitCNFWithoutInversion"
       ]> ] # traits> {
   // TODO: Restrict to HWIntegerType.
   let arguments = (ins Variadic<AnyType>:$inputs,
@@ -42,20 +42,13 @@ class InvertibleOperandsOp<string mnemonic, list<Trait> traits = []>
   }];
 }
 
-class SymmetricThreeInputOp<string mnemonic, list<Trait> traits = []>
-  : SynthOp<mnemonic, [
-      SameOperandsAndResultType, Pure,
-      DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
-        "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
-        "supportsNumInputs", "createBooleanLogicOp",
-        "getLogicAreaCost"
-      ]>] # traits> {
-  let arguments = (ins Variadic<AnyType>:$inputs,
-                       DenseBoolArrayAttr:$inverted);
-  let results = (outs AnyType:$result);
-  let assemblyFormat = [{
-    custom<VariadicInvertibleOperands>($inputs, type($result), $inverted, attr-dict)
-  }];
+class ThreeInputOp<string mnemonic, string logicFn, bit symmetric = false,
+                   list<Trait> traits = []>
+  : InvertibleOperandsOp<mnemonic, [
+      PredOpTrait<"requires exactly three operands",
+                  CPred<"getOperation()->getNumOperands() == 3">>,
+      PredOpTrait<"requires exactly three inversion flags",
+                  CPred<"getInverted().size() == 3">>] # traits> {
   let builders = [
     OpBuilder<(ins "Value":$a, "Value":$b, "Value":$c,
                                 CArg<"bool", "false">:$invertA,
@@ -66,8 +59,39 @@ class SymmetricThreeInputOp<string mnemonic, list<Trait> traits = []>
                    $_builder.getDenseBoolArrayAttr(inverted));
     }]>
   ];
-  let hasVerifier = 1;
+  let extraClassDefinition = [{
+    bool $cppClass::areInputsPermutationInvariant() {
+      return }] # !if(symmetric, "true", "false") # [{;
+    }
+    bool $cppClass::supportsNumInputs(unsigned numInputs) {
+      return numInputs == 3;
+    }
+    int64_t $cppClass::getLogicDepthCost() { return 1; }
+    std::optional<uint64_t> $cppClass::getLogicAreaCost() {
+      int64_t bitWidth = hw::getBitWidth(getType());
+      if (bitWidth < 0)
+        return std::nullopt;
+      return static_cast<uint64_t>(bitWidth);
+    }
+    ::llvm::KnownBits $cppClass::computeKnownBits(
+        ::llvm::function_ref<const ::llvm::KnownBits &(unsigned)>
+            getInputKnownBits) {
+      auto a = applyInputInversion(getInputKnownBits(0), isInverted(0));
+      auto b = applyInputInversion(getInputKnownBits(1), isInverted(1));
+      auto c = applyInputInversion(getInputKnownBits(2), isInverted(2));
+      return }] # logicFn # [{(a, b, c);
+    }
+    ::llvm::APInt $cppClass::evaluateBooleanLogicWithoutInversion(
+        ::llvm::ArrayRef<::llvm::APInt> inputs) {
+      assert(inputs.size() == 3 && "expected exactly three inputs");
+      return }] # logicFn # [{(inputs[0], inputs[1], inputs[2]);
+    }
+  }];
 }
+
+class SymmetricThreeInputOp<string mnemonic, string logicFn,
+                            list<Trait> traits = []>
+  : ThreeInputOp<mnemonic, logicFn, true, traits>;
 
 def AndInverterOp : InvertibleOperandsOp<"aig.and_inv"> {
   let summary = "AIG dialect AND operation";
@@ -162,14 +186,7 @@ def XorInverterOp : InvertibleOperandsOp<"xor_inv"> {
 
 }
 
-def DotOp : SynthOp<"dot", [
-    SameOperandsAndResultType, Pure,
-    DeclareOpInterfaceMethods<BooleanLogicOpInterface, [
-      "areInputsPermutationInvariant", "evaluateBooleanLogicWithoutInversion",
-      "supportsNumInputs", "createBooleanLogicOp",
-      "getLogicAreaCost"
-    ]>
-  ]> {
+def DotOp : ThreeInputOp<"dot", "evaluateDotLogic"> {
   let summary = "Ordered 3-input DOT gate with invertible inputs";
   let description = [{
     The `synth.dot` operation represents the ordered three-input Boolean
@@ -188,33 +205,6 @@ def DotOp : SynthOp<"dot", [
       %r1 = synth.dot not %x, %y, not %z : i8
     ```
   }];
-
-  let arguments = (ins AnyType:$x, AnyType:$y, AnyType:$z,
-                       DenseBoolArrayAttr:$inverted);
-  let results = (outs AnyType:$result);
-
-  let builders = [
-    OpBuilder<(ins "Value":$x, "Value":$y, "Value":$z,
-                                CArg<"bool", "false">:$invertX,
-                                CArg<"bool", "false">:$invertY,
-                                CArg<"bool", "false">:$invertZ), [{
-      SmallVector<bool> inverted{invertX, invertY, invertZ};
-      return build($_builder, $_state, x.getType(), x, y, z,
-                   $_builder.getDenseBoolArrayAttr(inverted));
-    }]>,
-    OpBuilder<(ins "ValueRange":$inputs, "ArrayRef<bool>":$inverted), [{
-      assert(inputs.size() == 3 && "dot expects exactly three operands");
-      assert(inverted.size() == 3 && "dot expects exactly three inversion flags");
-      return build($_builder, $_state, inputs[0].getType(), inputs[0], inputs[1],
-                   inputs[2], $_builder.getDenseBoolArrayAttr(inverted));
-    }]>,
-    OpBuilder<(ins "Type":$resultType, "ValueRange":$inputs,
-                                "ArrayRef<bool>":$inverted), [{
-      return build($_builder, $_state, inputs, inverted);
-    }]>];
-
-  let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
 }
 
 def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
@@ -241,7 +231,7 @@ def ChoiceOp : SynthOp<"choice", [SameOperandsAndResultType, Pure]> {
   let assemblyFormat = "$inputs attr-dict `:` type($result)";
 }
 
-def MajorityOp : SymmetricThreeInputOp<"majority"> {
+def MajorityOp : SymmetricThreeInputOp<"majority", "evaluateMajorityLogic"> {
   let summary = "Majority gate with invertible inputs";
   let description = [{
     The `synth.majority` operation computes the majority function of its
@@ -260,7 +250,7 @@ def MajorityOp : SymmetricThreeInputOp<"majority"> {
   }];
 }
 
-def OneHotOp : SymmetricThreeInputOp<"onehot"> {
+def OneHotOp : SymmetricThreeInputOp<"onehot", "evaluateOneHotLogic"> {
    let summary = "3-input Onehot gate with invertible inputs";
   let description = [{
     The `synth.onehot` operation computes the one-hot function of its three
@@ -278,7 +268,7 @@ def OneHotOp : SymmetricThreeInputOp<"onehot"> {
   }];
 }
 
-def MuxInverterOp : InvertibleOperandsOp<"mux_inv"> {
+def MuxInverterOp : ThreeInputOp<"mux_inv", "evaluateMuxLogic"> {
   let summary = "MUX gate with invertible inputs";
   let description = [{
     The `synth.mux_inv` operation represents a 3-input multiplexer node
@@ -295,22 +285,9 @@ def MuxInverterOp : InvertibleOperandsOp<"mux_inv"> {
       %r1 = synth.mux_inv not %a, %b, not %c : i8
     ```
   }];
-  
-  let builders = [
-  OpBuilder<(ins "Value":$cond, "Value":$trueValue, "Value":$falseValue,
-                  CArg<"bool", "false">:$invertCond,
-                  CArg<"bool", "false">:$invertTrue,
-                  CArg<"bool", "false">:$invertFalse),
-                  [{
-    SmallVector<bool> inverted {invertCond, invertTrue, invertFalse};
-    return build($_builder, $_state, {cond, trueValue, falseValue}, inverted);
-  }]>
-];
-let hasVerifier = 1;
-
 }
 
-def GambleOp : SymmetricThreeInputOp<"gamble">{
+def GambleOp : SymmetricThreeInputOp<"gamble", "evaluateGambleLogic">{
   let summary = "3-input Gamble gate with invertible inputs";
   let description = [{
   The `synth.gamble` operation computes the gamble function of its three

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -440,66 +440,6 @@ void XorInverterOp::emitCNFWithoutInversion(
 // DotOp
 //===----------------------------------------------------------------------===//
 
-ParseResult DotOp::parse(OpAsmParser &parser, OperationState &result) {
-  SmallVector<OpAsmParser::UnresolvedOperand> operands;
-  Type resultType;
-  DenseBoolArrayAttr inverted;
-  NamedAttrList attrs;
-
-  if (parseVariadicInvertibleOperands(parser, operands, resultType, inverted,
-                                      attrs))
-    return failure();
-  if (operands.size() != 3)
-    return parser.emitError(parser.getCurrentLocation())
-           << "expected exactly three operands";
-  if (parser.resolveOperands(operands, resultType, result.operands))
-    return failure();
-
-  result.addTypes(resultType);
-  result.addAttributes(attrs);
-  result.addAttribute("inverted", inverted);
-  return success();
-}
-
-void DotOp::print(OpAsmPrinter &printer) {
-  printer << ' ';
-  printVariadicInvertibleOperands(printer, getOperation(), getOperands(),
-                                  getType(), getInvertedAttr(),
-                                  (*this)->getAttrDictionary());
-}
-
-LogicalResult DotOp::verify() {
-  if (getInverted().size() != 3)
-    return emitOpError("requires exactly three inversion flags");
-  return success();
-}
-
-APInt DotOp::evaluateBooleanLogicWithoutInversion(
-    llvm::ArrayRef<APInt> inputs) {
-  assert(supportsNumInputs(inputs.size()) &&
-         "dot expects exactly three operands");
-  return evaluateDotLogic(inputs[0], inputs[1], inputs[2]);
-}
-
-bool DotOp::areInputsPermutationInvariant() { return false; }
-
-bool DotOp::supportsNumInputs(unsigned numInputs) { return numInputs == 3; }
-
-llvm::KnownBits DotOp::computeKnownBits(
-    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
-  auto x = applyInversion(getInputKnownBits(0), isInverted(0));
-  auto y = applyInversion(getInputKnownBits(1), isInverted(1));
-  auto z = applyInversion(getInputKnownBits(2), isInverted(2));
-  return evaluateDotLogic(x, y, z);
-}
-
-std::optional<uint64_t> DotOp::getLogicAreaCost() {
-  int64_t bitWidth = hw::getBitWidth(getType());
-  if (bitWidth < 0)
-    return std::nullopt;
-  return static_cast<uint64_t>(bitWidth);
-}
-
 void DotOp::emitCNFWithoutInversion(
     int outVar, llvm::ArrayRef<int> inputVars,
     llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
@@ -518,41 +458,6 @@ void DotOp::emitCNFWithoutInversion(
 //===----------------------------------------------------------------------===//
 // MajorityOp
 //===----------------------------------------------------------------------===//
-
-LogicalResult MajorityOp::verify() {
-  if (getNumOperands() != 3)
-    return emitOpError("requires exactly three operands");
-  if (getInverted().size() != 3)
-    return emitOpError("requires exactly three inversion flags");
-  return success();
-}
-
-bool MajorityOp::areInputsPermutationInvariant() { return true; }
-
-bool MajorityOp::supportsNumInputs(unsigned numInputs) {
-  return numInputs == 3;
-}
-
-std::optional<uint64_t> MajorityOp::getLogicAreaCost() {
-  int64_t bitWidth = hw::getBitWidth(getType());
-  if (bitWidth < 0)
-    return std::nullopt;
-  return static_cast<uint64_t>(bitWidth);
-}
-
-llvm::KnownBits MajorityOp::computeKnownBits(
-    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
-  auto a = applyInversion(getInputKnownBits(0), isInverted(0));
-  auto b = applyInversion(getInputKnownBits(1), isInverted(1));
-  auto c = applyInversion(getInputKnownBits(2), isInverted(2));
-  return evaluateMajorityLogic(a, b, c);
-}
-
-APInt MajorityOp::evaluateBooleanLogicWithoutInversion(
-    llvm::ArrayRef<APInt> inputs) {
-  assert(inputs.size() == 3 && "majority requires exactly three inputs");
-  return evaluateMajorityLogic(inputs[0], inputs[1], inputs[2]);
-}
 
 void MajorityOp::emitCNFWithoutInversion(
     int outVar, llvm::ArrayRef<int> inputVars,
@@ -657,39 +562,6 @@ LogicalResult circt::synth::topologicallySortGraphRegionBlocks(
 // OneHotOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult OneHotOp::verify() {
-  if (getNumOperands() != 3)
-    return emitOpError("requires exactly three operands");
-  if (getInverted().size() != 3)
-    return emitOpError("requires exactly three inversion flags");
-  return success();
-}
-
-bool OneHotOp::areInputsPermutationInvariant() { return true; }
-
-bool OneHotOp::supportsNumInputs(unsigned numInputs) { return numInputs == 3; }
-
-std::optional<uint64_t> OneHotOp::getLogicAreaCost() {
-  int64_t bitWidth = hw::getBitWidth(getType());
-  if (bitWidth < 0)
-    return std::nullopt;
-  return static_cast<uint64_t>(bitWidth);
-}
-
-llvm::KnownBits OneHotOp::computeKnownBits(
-    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
-  auto a = applyInversion(getInputKnownBits(0), isInverted(0));
-  auto b = applyInversion(getInputKnownBits(1), isInverted(1));
-  auto c = applyInversion(getInputKnownBits(2), isInverted(2));
-  return evaluateOneHotLogic(a, b, c);
-}
-
-APInt OneHotOp::evaluateBooleanLogicWithoutInversion(
-    llvm::ArrayRef<APInt> inputs) {
-  assert(inputs.size() == 3 && "onehot requires exactly three inputs");
-  return evaluateOneHotLogic(inputs[0], inputs[1], inputs[2]);
-}
-
 void OneHotOp::emitCNFWithoutInversion(
     int outVar, llvm::ArrayRef<int> inputVars,
     llvm::function_ref<void(llvm::ArrayRef<int>)> addClause,
@@ -711,46 +583,6 @@ void OneHotOp::emitCNFWithoutInversion(
 //===----------------------------------------------------------------------===//
 // MuxInverterOp
 //===----------------------------------------------------------------------===//
-
-LogicalResult MuxInverterOp::verify() {
-  if (getNumOperands() != 3)
-    return emitOpError("requires exactly three operands");
-  if (getInverted().size() != 3)
-    return emitOpError("requires exactly three inversion flags");
-  return success();
-}
-
-bool MuxInverterOp::areInputsPermutationInvariant() { return false; }
-
-APInt MuxInverterOp::evaluateBooleanLogicWithoutInversion(
-    llvm::ArrayRef<APInt> inputs) {
-  assert(inputs.size() == 3 && "expected exactly three inputs");
-  return evaluateMuxLogic(inputs[0], inputs[1], inputs[2]);
-}
-
-bool MuxInverterOp::supportsNumInputs(unsigned numInputs) {
-  return numInputs == 3;
-}
-
-llvm::KnownBits MuxInverterOp::computeKnownBits(
-    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
-  assert(getNumOperands() == 3 && "expected exactly three inputs");
-
-  auto a = applyInversion(getInputKnownBits(0), isInverted(0));
-  auto b = applyInversion(getInputKnownBits(1), isInverted(1));
-  auto c = applyInversion(getInputKnownBits(2), isInverted(2));
-
-  return evaluateMuxLogic(a, b, c);
-}
-
-int64_t MuxInverterOp::getLogicDepthCost() { return 2; }
-
-std::optional<uint64_t> MuxInverterOp::getLogicAreaCost() {
-  int64_t bitWidth = hw::getBitWidth(getType());
-  if (bitWidth < 0)
-    return std::nullopt;
-  return static_cast<uint64_t>(bitWidth);
-}
 
 void MuxInverterOp::emitCNFWithoutInversion(
     int outVar, llvm::ArrayRef<int> inputVars,
@@ -776,39 +608,6 @@ void MuxInverterOp::emitCNFWithoutInversion(
 //===----------------------------------------------------------------------===//
 // GambleOp
 //===----------------------------------------------------------------------===//
-
-LogicalResult GambleOp::verify() {
-  if (getNumOperands() != 3)
-    return emitOpError("requires exactly three operands");
-  if (getInverted().size() != 3)
-    return emitOpError("requires exactly three inversion flags");
-  return success();
-}
-
-bool GambleOp::areInputsPermutationInvariant() { return true; }
-
-bool GambleOp::supportsNumInputs(unsigned numInputs) { return numInputs == 3; }
-
-std::optional<uint64_t> GambleOp::getLogicAreaCost() {
-  int64_t bitWidth = hw::getBitWidth(getType());
-  if (bitWidth < 0)
-    return std::nullopt;
-  return static_cast<uint64_t>(bitWidth);
-}
-
-llvm::KnownBits GambleOp::computeKnownBits(
-    llvm::function_ref<const llvm::KnownBits &(unsigned)> getInputKnownBits) {
-  auto a = applyInversion(getInputKnownBits(0), isInverted(0));
-  auto b = applyInversion(getInputKnownBits(1), isInverted(1));
-  auto c = applyInversion(getInputKnownBits(2), isInverted(2));
-  return evaluateGambleLogic(a, b, c);
-}
-
-APInt GambleOp::evaluateBooleanLogicWithoutInversion(
-    llvm::ArrayRef<APInt> inputs) {
-  assert(inputs.size() == 3 && "onehot requires exactly three inputs");
-  return evaluateGambleLogic(inputs[0], inputs[1], inputs[2]);
-}
 
 void GambleOp::emitCNFWithoutInversion(
     int outVar, llvm::ArrayRef<int> inputVars,

--- a/test/Dialect/Synth/longest-paths.mlir
+++ b/test/Dialect/Synth/longest-paths.mlir
@@ -147,11 +147,10 @@ hw.module private @top(in %clock : !seq.clock) {
   %1 = hw.instance "inst2" @nest(clock: %clock: !seq.clock, a: %0: i1) -> (x: i1)
 }
 
-// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.a[0], delay=2, history=[{{.+}}])}}
-// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.b[0], delay=2, history=[{{.+}}])}}
-// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.c[0], delay=2, history=[{{.+}}])}}
+// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.a[0], delay=1, history=[{{.+}}])}}
+// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.b[0], delay=1, history=[{{.+}}])}}
+// expected-remark-re @below {{endPoint=Object($root.x[0]), startPoint=Object($root.c[0], delay=1, history=[{{.+}}])}}
 hw.module private @mux_inv_basic(in %a : i1, in %b : i1, in %c : i1, out x : i1) {
   %m = synth.mux_inv %a, not %b, %c : i1
   hw.output %m : i1
 }
-


### PR DESCRIPTION
This extends SymmetricThreeInputOp (thanks @okekayode !) to ThreeInputOp by factoring common three-input invertible-operand behavior into a shared ThreeInputOp ODS base.  

Keep only the op-specific CNF emitters in C++ and use a symmetric flag for permutation-invariant gates.  Treat all three-input gates as depth 1 and update the mux_inv longest-path expectation accordingly.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
