### PR TITLE
[Synth] Fix NPN input permutation mapping

### DIFF
--- a/integration_test/circt-synth/mapping-lec.mlir
+++ b/integration_test/circt-synth/mapping-lec.mlir
@@ -4,8 +4,10 @@
 // RUN: circt-synth %s -o %t1.mlir
 // RUN: cat %t1.mlir | FileCheck %s
 // RUN: circt-lec %t1.mlir %s -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_TECHMAP
+// RUN: circt-lec %t1.mlir %s -c1=dot_test -c2=dot_test --shared-libs=%libz3 | FileCheck %s --check-prefix=TECHMAP_PERMUTATION
 
 // COMB_MUL_TECHMAP: c1 == c2
+// TECHMAP_PERMUTATION: c1 == c2
 
 // RUN: circt-synth %s -o %t.lut.mlir --top mul --lower-to-k-lut 6
 // RUN: cat %t.lut.mlir | FileCheck %s --check-prefix=LUT
@@ -42,6 +44,16 @@ hw.module @some(in %a : i1, in %b : i1, out result : i1) attributes {synth.mappi
     %1 = synth.aig.and_inv %a, %b : i1
     %2 = synth.aig.and_inv not %0, not %1 : i1
     hw.output %2 : i1
+}
+
+hw.module @dot_lib(in %x : i1, in %y : i1, in %z : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "x", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "y", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "z", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+    %0 = synth.dot %z, not %x, not %y : i1
+    hw.output %0 : i1
+}
+
+hw.module @dot_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
+    %0 = synth.dot %x, not %y, not %z : i1
+    hw.output %0 : i1
 }
 
 // Make sure @mul is mapped to modules above.

--- a/lib/Support/TruthTable.cpp
+++ b/lib/Support/TruthTable.cpp
@@ -484,18 +484,19 @@ void NPNClass::getInputPermutation(
   assert(equivalentOtherThanPermutation(targetNPN) &&
          "NPN classes must be equivalent for input mapping");
 
-  // Create inverse permutation for this NPN class
-  auto thisInverse = invertPermutation(inputPermutation);
+  auto targetInverse = invertPermutation(targetNPN.inputPermutation);
 
   // For each input position in the target NPN class, find the corresponding
   // input position in this NPN class
+  permutation.clear();
   permutation.reserve(targetNPN.inputPermutation.size());
-  for (unsigned i = 0; i < targetNPN.inputPermutation.size(); ++i) {
-    // Target input i maps to canonical position targetNPN.inputPermutation[i]
-    // We need the input in this NPN class that maps to the same canonical
-    // position
-    unsigned canonicalPos = targetNPN.inputPermutation[i];
-    permutation.push_back(thisInverse[canonicalPos]);
+  for (unsigned targetInput = 0;
+       targetInput < targetNPN.inputPermutation.size(); ++targetInput) {
+    // `inputPermutation[canonicalPos]` is the original input at that canonical
+    // position. Find the canonical position of the target input and return the
+    // input in this NPN class at the same canonical position.
+    unsigned canonicalPos = targetInverse[targetInput];
+    permutation.push_back(inputPermutation[canonicalPos]);
   }
 }
 

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -47,7 +47,7 @@ hw.module @permutation(in %a: i1, in %b: i1, in %c: i1, in %d: i1, out result: i
 
 // CHECK-LABEL: hw.module @permutation_test(in %p : i1, in %q : i1, in %r : i1, in %s : i1, out result : i1) {
 hw.module @permutation_test(in %p: i1, in %q: i1, in %r: i1, in %s: i1, out result: i1) {
-    // CHECK-NEXT: %[[r0:.+]] = hw.instance "{{.+}}" @permutation(a: %r: i1, b: %p: i1, c: %s: i1, d: %q: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: %[[r0:.+]] = hw.instance "{{.+}}" @permutation(a: %s: i1, b: %p: i1, c: %q: i1, d: %r: i1) -> (result: i1) {test.arrival_times = [1]}
     %0 = synth.aig.and_inv %s, not %p : i1
     %1 = synth.aig.and_inv %q, not %r : i1
     %2 = synth.aig.and_inv %0, not %1 : i1
@@ -71,7 +71,7 @@ hw.module @and_inv_5_test(in %a : i1, in %b : i1, in %c : i1, in %d : i1, in %e:
     %5 = synth.aig.and_inv not %b, %e : i1
     %6 = synth.aig.and_inv %5, %c : i1
     %7 = synth.aig.and_inv %6, %4 : i1
-    // CHECK-NEXT: %[[result_1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_5(a: %d: i1, b: %e: i1, c: %c: i1, d: %a: i1, e: %b: i1)
+    // CHECK-NEXT: %[[result_1:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @and_inv_5(a: %a: i1, b: %c: i1, c: %b: i1, d: %e: i1, e: %d: i1)
     
     hw.output %3, %7 : i1, i1
     // CHECK-NEXT: hw.output %[[result_0]], %[[result_1]] : i1, i1
@@ -171,7 +171,7 @@ hw.module @dot_lib(in %x : i1, in %y : i1, in %z : i1, out result : i1) attribut
 // CHECK-LABEL: @dot_test
 hw.module @dot_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
     // Permute inputs to test the truth table computation and input handling of the dot operation.
-    // CHECK-NEXT: %[[DOT:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @dot_lib(x: %z: i1, y: %y: i1, z: %x: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: %[[DOT:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @dot_lib(x: %y: i1, y: %x: i1, z: %z: i1) -> (result: i1) {test.arrival_times = [1]}
     // CHECK-NEXT: hw.output %[[DOT]] : i1
     %0 = synth.dot %x, not %y, not %z : i1
     hw.output %0 : i1

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -164,16 +164,16 @@ hw.module @extract_concat_test(in %data : i4, in %ctrl : i2, out result : i3) {
 }
 
 hw.module @dot_lib(in %x : i1, in %y : i1, in %z : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "x", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "y", 1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "z", 1, 0, #synth.polarity<positive>>], input_caps = {}>} {
-    %0 = synth.dot %z, not %x, not %y : i1
+    %0 = synth.dot %z, not %x, %y : i1
     hw.output %0 : i1
 }
 
 // CHECK-LABEL: @dot_test
 hw.module @dot_test(in %x : i1, in %y : i1, in %z : i1, out result : i1) {
     // Permute inputs to test the truth table computation and input handling of the dot operation.
-    // CHECK-NEXT: %[[DOT:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @dot_lib(x: %y: i1, y: %x: i1, z: %z: i1) -> (result: i1) {test.arrival_times = [1]}
+    // CHECK-NEXT: %[[DOT:.+]] = hw.instance "{{[a-zA-Z0-9_]+}}" @dot_lib(x: %y: i1, y: %z: i1, z: %x: i1) -> (result: i1) {test.arrival_times = [1]}
     // CHECK-NEXT: hw.output %[[DOT]] : i1
-    %0 = synth.dot %x, not %y, not %z : i1
+    %0 = synth.dot %x, not %y, %z : i1
     hw.output %0 : i1
 }
 

--- a/unittests/Support/TruthTableTest.cpp
+++ b/unittests/Support/TruthTableTest.cpp
@@ -220,17 +220,9 @@ TEST(NPNClassTest, InputMapping) {
 
   SmallVector<unsigned> permutation;
   npn1.getInputPermutation(npn2, permutation);
-  // Verify the mapping is correct
-  EXPECT_EQ(permutation.size(), 3u);
-
-  // For each input in the target NPN class, mapping[i] gives the input in npn1
-  // at the same canonical position.
-  for (unsigned i = 0; i < 3; ++i) {
-    auto it = llvm::find(npn2.inputPermutation, i);
-    ASSERT_NE(it, npn2.inputPermutation.end());
-    unsigned canonicalPos = it - npn2.inputPermutation.begin();
-    EXPECT_EQ(permutation[i], npn1.inputPermutation[canonicalPos]);
-  }
+  // Target input 0 is at canonical slot 2, input 1 at slot 0, and input 2 at
+  // slot 1. Read npn1's input at those canonical slots: [1, 2, 0].
+  EXPECT_EQ(permutation, SmallVector<unsigned>({1, 2, 0}));
 }
 
 TEST(NPNClassTest, LexicographicalOrdering) {

--- a/unittests/Support/TruthTableTest.cpp
+++ b/unittests/Support/TruthTableTest.cpp
@@ -223,14 +223,13 @@ TEST(NPNClassTest, InputMapping) {
   // Verify the mapping is correct
   EXPECT_EQ(permutation.size(), 3u);
 
-  // For each target input position i, mapping[i] should give us the input
-  // position in npn1 that corresponds to the same canonical position
+  // For each input in the target NPN class, mapping[i] gives the input in npn1
+  // at the same canonical position.
   for (unsigned i = 0; i < 3; ++i) {
-    // Target input i maps to canonical position npn2.inputPermutation[i]
-    unsigned targetCanonicalPos = npn2.inputPermutation[i];
-    // npn1's input mapping[i] should map to the same canonical position
-    unsigned npn1CanonicalPos = npn1.inputPermutation[permutation[i]];
-    EXPECT_EQ(targetCanonicalPos, npn1CanonicalPos);
+    auto it = llvm::find(npn2.inputPermutation, i);
+    ASSERT_NE(it, npn2.inputPermutation.end());
+    unsigned canonicalPos = it - npn2.inputPermutation.begin();
+    EXPECT_EQ(permutation[i], npn1.inputPermutation[canonicalPos]);
   }
 }
 
@@ -534,11 +533,12 @@ TEST(NPNClassTest, MultiBitOutputMapping) {
   npn1.getInputPermutation(npn2, permutation);
   EXPECT_EQ(permutation.size(), 2u);
 
-  // Verify the mapping relationship
+  // Verify the mapping relationship.
   for (unsigned i = 0; i < 2; ++i) {
-    unsigned targetCanonicalPos = npn2.inputPermutation[i];
-    unsigned npn1CanonicalPos = npn1.inputPermutation[permutation[i]];
-    EXPECT_EQ(targetCanonicalPos, npn1CanonicalPos);
+    auto it = llvm::find(npn2.inputPermutation, i);
+    ASSERT_NE(it, npn2.inputPermutation.end());
+    unsigned canonicalPos = it - npn2.inputPermutation.begin();
+    EXPECT_EQ(permutation[i], npn1.inputPermutation[canonicalPos]);
   }
 }
 


### PR DESCRIPTION
There was a bug in `NPNCClass::getInputPermutation` that confuses permutation and its inverse which makes CutRewriter unsound. 

Assisted-by: codex: gpt-5.5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
