### PR TITLE
[FIRRTLToHW] Print to stderr in lower-to-core path

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -5455,8 +5455,9 @@ LogicalResult FIRRTLLowering::visitStmt(PrintFOp op) {
   if (failed(formatString))
     return failure();
 
+  auto stderrOp = sim::StderrStreamOp::create(builder);
   sim::TriggeredOp::create(builder, clock, cond, [&] {
-    sim::PrintFormattedProcOp::create(builder, *formatString);
+    sim::PrintFormattedProcOp::create(builder, *formatString, stderrOp);
   });
   return success();
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-core.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-core.mlir
@@ -22,8 +22,9 @@ firrtl.circuit "LowerToCore" {
     // CHECK: [[HIER:%.+]] = sim.fmt.hier_path
     // CHECK: [[NL:%.+]] = sim.fmt.literal "\0A"
     // CHECK: [[MSG:%.+]] = sim.fmt.concat ([[LIT0]], [[FMTVAL]], [[LIT1]], [[HIER]], [[NL]])
+    // CHECK: [[STDERR:%.+]] = sim.stderr_stream
     // CHECK: sim.triggered %clock if %enable { 
-    // CHECK-NEXT:   sim.proc.print [[MSG]]
+    // CHECK-NEXT:   sim.proc.print [[MSG]] to [[STDERR]]
     // CHECK-NEXT: }
     // CHECK-NOT: sv.assert
     // CHECK-NOT: sv.fwrite

--- a/test/firtool/lower-to-core.fir
+++ b/test/firtool/lower-to-core.fir
@@ -23,8 +23,9 @@ circuit LowerToCore:
 ; CHECK-DAG: verif.clocked_assert %pred if %enable, posedge [[CLK]] : i1
 ; CHECK-DAG: [[FMT:%.+]] = sim.fmt.dec %x signed : i4
 ; CHECK: [[MSG:%.+]] = sim.fmt.concat ([[LIT]], [[FMT]], [[NL]])
+; CHECK: [[STDERR:%.+]] = sim.stderr_stream
 ; CHECK: sim.triggered %clock if %enable {
-; CHECK-NEXT:   sim.proc.print [[MSG]]
+; CHECK-NEXT:   sim.proc.print [[MSG]] to [[STDERR]]
 ; CHECK-NEXT: }
 ; CHECK: sim.triggered %clock if %enable {
 ; CHECK-NEXT:   [[FILE1:%.+]] = sim.get_file [[FMTFILE1]]


### PR DESCRIPTION
In the lower-to-core path, maintain FIRRTL's default behavior of printing to stderr.