### PR TITLE
[ESI][Runtime] Support for integrals >64 bits

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Values.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Values.h
@@ -39,6 +39,15 @@ class MutableBitVector;
 /// BitVector is immutable wrt. modifying the underlying bits, and provides
 /// read-only access to bits. It supports bit-level access and returns new views
 /// for operations.
+///
+/// Lifetime: `BitVector`, `IntView`, and `UIntView` (defined just below)
+/// are non-owning views, in the same family as `std::span` /
+/// `std::string_view`. They store only a span pointer + width + bitIndex
+/// and do not extend the lifetime of the underlying buffer. A view
+/// returned from an accessor of a temporary dangles once the temporary
+/// is destroyed; bind the parent to a named local, or construct an
+/// owning `Int` / `UInt` / `MutableBitVector` from the view if the value
+/// needs to outlive its source.
 class BitVector {
 public:
   using byte = uint8_t;
@@ -178,6 +187,90 @@ protected:
   std::span<const byte> data{};
   size_t bitWidth = 0;  // Number of valid bits.
   uint8_t bitIndex = 0; // Starting bit offset in first byte.
+
+  // Scan bits [lowExclusive, width()-1] in byte-sized chunks and throw
+  // `std::overflow_error(std::vformat(fmt, std::make_format_args(target)))`
+  // if any of them differ from `expectedByte` (0x00 to check
+  // "all-zero" for the unsigned narrow-conversion case; 0xFF to check
+  // "all-one" for the signed narrow-conversion case with the sign bit
+  // set).
+  void checkHighBytesEqual(unsigned lowExclusive, uint8_t expectedByte,
+                           const char *fmt, unsigned target) const;
+};
+
+/// Non-owning view of an unsigned bit vector with `toUI64()` and implicit
+/// conversions to unsigned scalar types. Adds only static-type tagging and
+/// conversion methods on top of `BitVector`. See the lifetime note on
+/// `BitVector`.
+class UIntView : public BitVector {
+public:
+  using BitVector::BitVector;
+  UIntView() = default;
+  /// Adopt an existing view as unsigned. Cheap (no copy of bytes); the
+  /// resulting UIntView aliases the same buffer.
+  UIntView(const BitVector &v) : BitVector(v) {}
+
+  /// Convert to a `uint64_t`, throwing if the value does not fit.
+  uint64_t toUI64() const;
+  operator uint64_t() const { return toUI64(); }
+  operator uint32_t() const { return toUInt<uint32_t>(); }
+  operator uint16_t() const { return toUInt<uint16_t>(); }
+  operator uint8_t() const { return toUInt<uint8_t>(); }
+
+private:
+  template <typename T>
+  T toUInt() const {
+    static_assert(std::is_integral<T>::value && std::is_unsigned<T>::value,
+                  "T must be an unsigned integral type");
+    constexpr unsigned N = sizeof(T) * 8;
+    // Pre-conversion range check: bits [N, width-1] must all be zero
+    // for the value to fit in unsigned `T`. We have to do this
+    // *before* `toUI64()` because `toUI64()` would itself throw
+    // "does not fit in uint64_t" for any wide value where bits 64+
+    // are set -- even if the low N bits would have fit in `T`.
+    if (this->width() > N)
+      this->checkHighBytesEqual(N, /*expectedByte=*/uint8_t{0},
+                                "UInt does not fit in uint{}_t", N);
+    return static_cast<T>(toUI64());
+  }
+};
+
+/// Non-owning view of a signed bit vector with `toI64()` and implicit
+/// conversions to signed scalar types. See the lifetime note on `BitVector`.
+class IntView : public BitVector {
+public:
+  using BitVector::BitVector;
+  IntView() = default;
+  /// Adopt an existing view as signed. Cheap (no copy of bytes); the
+  /// resulting IntView aliases the same buffer.
+  IntView(const BitVector &v) : BitVector(v) {}
+
+  /// Convert to an `int64_t`, sign-extending from the high bit and throwing
+  /// if the value does not fit.
+  int64_t toI64() const;
+  operator int64_t() const { return toI64(); }
+  operator int32_t() const { return toInt<int32_t>(); }
+  operator int16_t() const { return toInt<int16_t>(); }
+  operator int8_t() const { return toInt<int8_t>(); }
+
+private:
+  template <typename T>
+  T toInt() const {
+    static_assert(std::is_integral<T>::value && std::is_signed<T>::value,
+                  "T must be a signed integral type");
+    constexpr unsigned N = sizeof(T) * 8;
+    // Pre-conversion range check: bits [N, width-1] must all equal
+    // the sign bit (bit N-1) for the value to fit in signed `T`. We
+    // have to do this *before* `toI64()` because `toI64()` would
+    // itself throw "does not fit in int64_t" for any wide value
+    // whose bits 64+ don't sign-extend bit 63 -- even if the actual
+    // problem is that the value doesn't fit in `T`.
+    if (this->width() > N) {
+      const uint8_t expected = this->getBit(N - 1) ? uint8_t{0xFF} : uint8_t{0};
+      this->checkHighBytesEqual(N, expected, "Int does not fit in int{}_t", N);
+    }
+    return static_cast<T>(toI64());
+  }
 };
 
 /// A mutable bit vector that owns its underlying storage.
@@ -245,59 +338,31 @@ private:
 
 std::ostream &operator<<(std::ostream &os, const BitVector &bv);
 
-// Arbitrary width signed integer type built on MutableBitVector.
+// Arbitrary width signed integer type built on MutableBitVector. The
+// scalar-conversion operators all delegate to `IntView` so the
+// canonical width-check + i64 conversion lives in one place.
 class Int : public MutableBitVector {
 public:
   using MutableBitVector::MutableBitVector;
   Int() = default;
   Int(int64_t v, unsigned width = 64);
-  operator int64_t() const { return toI64(); }
-  operator int32_t() const { return toInt<int32_t>(); }
-  operator int16_t() const { return toInt<int16_t>(); }
-  operator int8_t() const { return toInt<int8_t>(); }
-
-private:
-  template <typename T>
-  T toInt() const {
-    static_assert(std::is_integral<T>::value && std::is_signed<T>::value,
-                  "T must be a signed integral type");
-    int64_t v = toI64();
-    fits(v, sizeof(T) * 8);
-    return static_cast<T>(v);
-  }
-
-  // Convert the bitvector to a signed intN_t, throwing if the value doesn't
-  // fit.
-  int64_t toI64() const;
-
-  // Check if the given value fits in the specified bit width.
-  static void fits(int64_t v, unsigned n);
+  operator int64_t() const { return IntView(*this); }
+  operator int32_t() const { return IntView(*this); }
+  operator int16_t() const { return IntView(*this); }
+  operator int8_t() const { return IntView(*this); }
 };
 
-// Arbitrary width unsigned integer type built on MutableBitVector.
+// Arbitrary width unsigned integer type built on MutableBitVector. The
+// scalar-conversion operators all delegate to `UIntView`.
 class UInt : public MutableBitVector {
 public:
   using MutableBitVector::MutableBitVector;
   UInt() = default;
   UInt(uint64_t v, unsigned width = 64);
-  operator uint64_t() const { return toUI64(); }
-  operator uint32_t() const { return toUInt<uint32_t>(); }
-  operator uint16_t() const { return toUInt<uint16_t>(); }
-  operator uint8_t() const { return toUInt<uint8_t>(); }
-
-private:
-  uint64_t toUI64() const;
-
-  static void fits(uint64_t v, unsigned n);
-
-  template <typename T>
-  T toUInt() const {
-    static_assert(std::is_integral<T>::value && std::is_unsigned<T>::value,
-                  "T must be an unsigned integral type");
-    uint64_t v = toUI64();
-    fits(v, sizeof(T) * 8);
-    return static_cast<T>(v);
-  }
+  operator uint64_t() const { return UIntView(*this); }
+  operator uint32_t() const { return UIntView(*this); }
+  operator uint16_t() const { return UIntView(*this); }
+  operator uint8_t() const { return UIntView(*this); }
 };
 
 } // namespace esi

--- a/lib/Dialect/ESI/runtime/cpp/lib/Values.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Values.cpp
@@ -543,17 +543,23 @@ int64_t IntView::toI64() const {
   for (size_t i = 0; i < limit; ++i)
     if (this->getBit(i))
       u |= (1ULL << i);
-  bool signBit = this->getBit(this->bitWidth - 1);
   if (this->bitWidth < 64) {
-    if (signBit) {
+    // Source is narrower than int64_t: sign-extend from the source's top bit.
+    if (this->getBit(this->bitWidth - 1))
       for (size_t i = this->bitWidth; i < 64; ++i)
         u |= (1ULL << i);
-    }
     return static_cast<int64_t>(u);
   }
-  if (this->bitWidth > 64)
-    checkHighBytesEqual(64, signBit ? uint8_t{0xFF} : uint8_t{0x00},
+  if (this->bitWidth > 64) {
+    // Source is wider than int64_t: bits [64, width-1] must all equal the
+    // destination's sign bit (bit 63 of the low 64 we're about to return),
+    // not bit `width-1` of the source. A wide value like 2^63 has source
+    // top-bit 0 but cannot fit in int64_t -- the low 64 would alias
+    // INT64_MIN if we used the source's top bit as the expected fill.
+    const bool destSignBit = (u >> 63) & 1ULL;
+    checkHighBytesEqual(64, destSignBit ? uint8_t{0xFF} : uint8_t{0x00},
                         "Int does not fit in int{}_t", 64);
+  }
   return static_cast<int64_t>(u);
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Values.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Values.cpp
@@ -423,6 +423,46 @@ bool BitVector::operator==(const BitVector &rhs) const {
   return std::ranges::equal(*this, rhs);
 }
 
+// Loop-peeled byte-walk over bits [lowExclusive, bitWidth-1]: the first
+// and last bytes may start/end mid-byte and need masked comparisons; every
+// byte in between is a full-byte XOR-with-expected. The masked mismatches
+// are OR-accumulated into a single byte so the only branch is the final
+// throw decision, and the middle-byte loop body is just
+// `diff |= data[b] ^ expected` -- which the compiler can auto-vectorise.
+//
+// In the common emitted-accessor case where `bitIndex == 0` and
+// `lowExclusive` is a multiple of 8 (it always is: 8, 16, 32, or 64 for
+// the narrow-int conversions), `loBit == 0` and the first-byte peel
+// collapses to a full-byte compare too -- the optimiser folds it.
+void BitVector::checkHighBytesEqual(unsigned lowExclusive, uint8_t expectedByte,
+                                    const char *fmt, unsigned target) const {
+  const size_t absLo = bitIndex + lowExclusive;
+  const size_t absHi = bitIndex + bitWidth - 1;
+  const size_t byteLo = absLo / 8;
+  const size_t byteHi = absHi / 8;
+  const unsigned loBit = absLo & 7u;
+  const unsigned hiBit = absHi & 7u;
+  uint8_t diff;
+  if (byteLo == byteHi) {
+    // Whole range fits in one byte; mask = bits [loBit, hiBit].
+    const uint8_t mask =
+        static_cast<uint8_t>(((1u << (hiBit - loBit + 1u)) - 1u) << loBit);
+    diff = static_cast<uint8_t>(data[byteLo] ^ expectedByte) & mask;
+  } else {
+    // Peel the first byte: mask off bits below loBit.
+    const uint8_t firstMask = static_cast<uint8_t>(0xFFu << loBit);
+    diff = static_cast<uint8_t>(data[byteLo] ^ expectedByte) & firstMask;
+    // Middle bytes: full-byte mask, branchless body.
+    for (size_t b = byteLo + 1; b < byteHi; ++b)
+      diff |= static_cast<uint8_t>(data[b] ^ expectedByte);
+    // Peel the last byte: mask off bits above hiBit.
+    const uint8_t lastMask = static_cast<uint8_t>((1u << (hiBit + 1u)) - 1u);
+    diff |= static_cast<uint8_t>(data[byteHi] ^ expectedByte) & lastMask;
+  }
+  if (diff != 0)
+    throw std::overflow_error(std::vformat(fmt, std::make_format_args(target)));
+}
+
 UInt::UInt(uint64_t v, unsigned width) : MutableBitVector(width) {
   if (width > 0 && width < 64 && (v >> width) != 0)
     throw std::overflow_error(
@@ -495,7 +535,7 @@ MutableBitVector::operator^(const MutableBitVector &other) const {
   return result;
 }
 
-int64_t Int::toI64() const {
+int64_t IntView::toI64() const {
   if (this->bitWidth == 0)
     return 0;
   uint64_t u = 0;
@@ -511,42 +551,19 @@ int64_t Int::toI64() const {
     }
     return static_cast<int64_t>(u);
   }
-  for (size_t i = 64; i < this->bitWidth; ++i) {
-    if (this->getBit(i) != signBit)
-      throw std::overflow_error("Int does not fit in int64_t");
-  }
+  if (this->bitWidth > 64)
+    checkHighBytesEqual(64, signBit ? uint8_t{0xFF} : uint8_t{0x00},
+                        "Int does not fit in int{}_t", 64);
   return static_cast<int64_t>(u);
 }
 
-void Int::fits(int64_t v, unsigned n) {
-  if (n == 0 || n > 64)
-    throw std::invalid_argument(std::format("Invalid bit width: {}", n));
-  int64_t min = -(1LL << (n - 1));
-  int64_t max = (1LL << (n - 1)) - 1;
-  if (v < min || v > max)
-    throw std::overflow_error(
-        std::format("Value {} does not fit in int{}_t", v, n));
-}
-
-uint64_t UInt::toUI64() const {
-  if (this->bitWidth > 64) {
-    for (size_t i = 64; i < this->bitWidth; ++i)
-      if (this->getBit(i))
-        throw std::overflow_error("Int does not fit in uint64_t");
-  }
+uint64_t UIntView::toUI64() const {
+  if (this->bitWidth > 64)
+    checkHighBytesEqual(64, uint8_t{0x00}, "UInt does not fit in uint{}_t", 64);
   uint64_t u = 0;
   size_t limit = this->bitWidth < 64 ? this->bitWidth : 64;
   for (size_t i = 0; i < limit; ++i)
     if (this->getBit(i))
       u |= (1ULL << i);
   return u;
-}
-
-void UInt::fits(uint64_t v, unsigned n) {
-  if (n == 0 || n > 64)
-    throw std::invalid_argument(std::format("Invalid bit width: {}", n));
-  uint64_t max = (n == 64) ? UINT64_MAX : ((1ULL << n) - 1);
-  if (v > max)
-    throw std::overflow_error(
-        std::format("Value {} does not fit in uint{}_t", v, n));
 }

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -1108,14 +1108,41 @@ class CppTypeEmitter:
     return f'"{escaped}"'
 
   def _get_bitvector_str(self, type: types.ESIType) -> str:
-    """Get the textual code for the storage class of an integer type."""
+    """Get the textual code for the C++ type used to represent an integer
+    field's value at the API boundary.
+
+    Integers up to 64 bits map to the native `int{N}_t` / `uint{N}_t`
+    (or `bool` for a single bit) storage types so common scalars stay
+    zero-overhead, behave identically to plain C ints, and stay valid as
+    template parameters for the existing `TypedReadPort<T>` /
+    `TypedWritePort<T>` / `TypedFunction<...>` machinery.
+
+    Wider integers (signed > 64 bits, unsigned > 64 bits, or any
+    `BitsType` > 64 bits) fall back to the non-owning view classes from
+    `esi/Values.h`: `esi::BitVector` for `BitsType`, `esi::IntView` for
+    signed integers, `esi::UIntView` for unsigned. All three are
+    non-owning views over the parent struct's bytes, so generated
+    getters are zero-allocation; see the lifetime note on `BitVector`
+    and at the top of the generated header.
+    """
     assert isinstance(type, (types.BitsType, types.IntType))
+
+    if type.bit_width > 64:
+      if isinstance(type, types.BitsType):
+        return "esi::BitVector"
+      if isinstance(type, types.UIntType):
+        return "esi::UIntView"
+      return "esi::IntView"
 
     return self._storage_type(
         type.bit_width, not isinstance(type, (types.BitsType, types.UIntType)))
 
   def _storage_type(self, bit_width: int, signed: bool) -> str:
-    """Get the textual code for a byte-addressable integer storage type."""
+    """Get the textual code for a native byte-addressable integer storage
+    type. Only valid for widths 1..64; wider integers are handled by
+    `_get_bitvector_str` via the `esi::IntView` / `esi::UIntView` view
+    classes.
+    """
 
     if bit_width == 1:
       return "bool"
@@ -1128,11 +1155,21 @@ class CppTypeEmitter:
     elif bit_width <= 64:
       storage_width = 64
     else:
-      raise ValueError(f"Unsupported integer width: {bit_width}")
+      raise ValueError(f"Unsupported native integer width: {bit_width}")
 
     if not signed:
       return f"uint{storage_width}_t"
     return f"int{storage_width}_t"
+
+  def _is_value_class_type(self, field_type: types.ESIType) -> bool:
+    """True if the C++ representation of this integer field is one of
+    the `esi::{BitVector,IntView,UIntView}` view classes from
+    `esi/Values.h` rather than a native integer.
+    """
+    wrapped = self._unwrap_aliases(field_type)
+    if not isinstance(wrapped, (types.BitsType, types.IntType)):
+      return False
+    return wrapped.bit_width > 64
 
   def _type_byte_width(self, wrapped: types.ESIType) -> int:
     """Return the size of a fixed-width type in bytes."""
@@ -1222,6 +1259,8 @@ class CppTypeEmitter:
     field_cpp = self._cpp_type(field_type)
     wrapped = self._unwrap_aliases(field_type)
     if isinstance(wrapped, (types.BitsType, types.IntType)):
+      if self._is_value_class_type(field_type):
+        return f"const {field_cpp} &{field_name}"
       return f"{field_cpp} {field_name}"
     return f"const {field_cpp} &{field_name}"
 
@@ -1387,7 +1426,7 @@ class CppTypeEmitter:
     `self_type &` so the caller can chain calls (e.g.
     `Foo{}.a(1).b(2).inner(x)`).
 
-    For integer fields the emitter picks between three inline strategies,
+    For integer fields the emitter picks between four inline strategies,
     fastest first:
 
       * Path A — 8/16/32/64-bit fields at a byte-aligned offset. Read/write
@@ -1402,6 +1441,14 @@ class CppTypeEmitter:
       * Path C — sub-byte alignment. Fall back to the
         `esi::detail::{read,write}{Un,}signedBits` helpers from
         `esi/BitAccess.h`, which loop over the constituent bits.
+      * Path D — view-class fields (`BitsType` at any width, and signed /
+        unsigned integers wider than 64 bits). Return a non-owning
+        `esi::BitVector` / `esi::IntView` / `esi::UIntView` view *into*
+        the parent struct's `_bytes` -- zero allocation, no copy. The
+        setter accepts any `esi::BitVector` (so views and owning
+        subclasses both work) and writes back via `copyBitsOut`. The
+        returned view dangles when the parent buffer dies; see the
+        lifetime warning at the top of the generated header.
     """
     field_cpp = self._cpp_type(field_type)
     if field_cpp == "void":
@@ -1410,6 +1457,44 @@ class CppTypeEmitter:
     wrapped = self._unwrap_aliases(field_type)
 
     if isinstance(wrapped, (types.BitsType, types.IntType)):
+      # Path D: view-class field (BitsType at any width, or signed /
+      # unsigned integers wider than 64 bits).
+      if self._is_value_class_type(field_type):
+        byte_offset = bit_offset // 8
+        sub_bit_index = bit_offset % 8
+        # Number of bytes the view needs to span: the high bit is at
+        # `sub_bit_index + bit_width - 1`, so we cover
+        # ceil((sub_bit_index + bit_width) / 8) bytes starting at
+        # `_bytes.data() + byte_offset`.
+        span_bytes = (sub_bit_index + bit_width + 7) // 8
+        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+        hdr.write(f"{indent}  return {field_cpp}(\n")
+        hdr.write(f"{indent}      std::span<const uint8_t>("
+                  f"{raw_member}.data() + {byte_offset}, {span_bytes}),\n")
+        hdr.write(f"{indent}      static_cast<std::size_t>({bit_width}),\n")
+        hdr.write(f"{indent}      static_cast<uint8_t>({sub_bit_index}));\n")
+        hdr.write(f"{indent}}}\n")
+        hdr.write(f"{indent}{self_type} &{field_name}("
+                  f"const {field_cpp} &v) {{\n")
+        # Walk the input view bit-by-bit and write each bit straight
+        # into `_bytes` at its target position.
+        hdr.write(f"{indent}  const std::size_t n = "
+                  f"std::min<std::size_t>(v.width(), {bit_width});\n")
+        hdr.write(
+            f"{indent}  for (std::size_t b = 0; b < {bit_width}; ++b) {{\n")
+        hdr.write(f"{indent}    const std::size_t g = {bit_offset} + b;\n")
+        hdr.write(f"{indent}    const bool val = (b < n) && v.getBit(b);\n")
+        hdr.write(f"{indent}    if (val)\n")
+        hdr.write(f"{indent}      {raw_member}[g / 8] |= "
+                  f"static_cast<uint8_t>(uint8_t{{1}} << (g % 8));\n")
+        hdr.write(f"{indent}    else\n")
+        hdr.write(f"{indent}      {raw_member}[g / 8] &= "
+                  f"static_cast<uint8_t>(~(uint8_t{{1}} << (g % 8)));\n")
+        hdr.write(f"{indent}  }}\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+        return
+
       # `bool` is the storage choice for a single bit; bit-precise helpers
       # are the simplest fit and the optimiser collapses them on -O2.
       if bit_width == 1 and field_cpp == "bool":
@@ -1547,40 +1632,48 @@ class CppTypeEmitter:
     byte_offset = bit_offset // 8
     byte_width = (bit_width + 7) // 8
 
-    if byte_aligned:
-      # Byte-aligned: direct byte copy between the parent's buffer slice
-      # and the inner aggregate's `_bytes`. An explicit per-byte loop
-      # avoids `memcpy` while still collapsing to one on -O2.
-      hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-      hdr.write(f"{indent}  {field_cpp} out{{}};\n")
-      hdr.write(f"{indent}  for (std::size_t i = 0; i < {byte_width}; ++i)\n")
-      hdr.write(f"{indent}    reinterpret_cast<uint8_t *>(&out)[i] = "
-                f"{raw_member}[{byte_offset} + i];\n")
-      hdr.write(f"{indent}  return out;\n")
-      hdr.write(f"{indent}}}\n")
-      hdr.write(f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
-      hdr.write(f"{indent}  for (std::size_t i = 0; i < {byte_width}; ++i)\n")
-      hdr.write(f"{indent}    {raw_member}[{byte_offset} + i] = "
-                f"reinterpret_cast<const uint8_t *>(&v)[i];\n")
-      hdr.write(f"{indent}  return *this;\n")
-      hdr.write(f"{indent}}}\n")
-    else:
-      # Non-byte-aligned: delegate to the per-bit copy helpers. The inner's
-      # `out{}` zero-initialiser is required by `copyBitsIn`, which only
-      # OR-sets the `1` bits.
-      hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-      hdr.write(f"{indent}  {field_cpp} out{{}};\n")
-      hdr.write(f"{indent}  esi::detail::copyBitsIn<{bit_offset}, "
-                f"{bit_width}>({raw_member}.data(), "
-                f"reinterpret_cast<uint8_t *>(&out));\n")
-      hdr.write(f"{indent}  return out;\n")
-      hdr.write(f"{indent}}}\n")
-      hdr.write(f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
-      hdr.write(f"{indent}  esi::detail::copyBitsOut<{bit_offset}, "
-                f"{bit_width}>({raw_member}.data(), "
-                f"reinterpret_cast<const uint8_t *>(&v));\n")
-      hdr.write(f"{indent}  return *this;\n")
-      hdr.write(f"{indent}}}\n")
+    # An array whose element is one of the `esi::{BitVector,IntView,
+    # UIntView}`.
+    is_view_array = (isinstance(wrapped, types.ArrayType) and
+                     self._is_value_class_type(wrapped.element_type))
+
+    if not is_view_array:
+      if byte_aligned:
+        # Byte-aligned: direct byte copy between the parent's buffer slice
+        # and the inner aggregate's `_bytes`. An explicit per-byte loop
+        # avoids `memcpy` while still collapsing to one on -O2.
+        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+        hdr.write(f"{indent}  {field_cpp} out{{}};\n")
+        hdr.write(f"{indent}  for (std::size_t i = 0; i < {byte_width}; ++i)\n")
+        hdr.write(f"{indent}    reinterpret_cast<uint8_t *>(&out)[i] = "
+                  f"{raw_member}[{byte_offset} + i];\n")
+        hdr.write(f"{indent}  return out;\n")
+        hdr.write(f"{indent}}}\n")
+        hdr.write(
+            f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
+        hdr.write(f"{indent}  for (std::size_t i = 0; i < {byte_width}; ++i)\n")
+        hdr.write(f"{indent}    {raw_member}[{byte_offset} + i] = "
+                  f"reinterpret_cast<const uint8_t *>(&v)[i];\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+      else:
+        # Non-byte-aligned: delegate to the per-bit copy helpers. The
+        # inner's `out{}` zero-initialiser is required by `copyBitsIn`,
+        # which only OR-sets the `1` bits.
+        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+        hdr.write(f"{indent}  {field_cpp} out{{}};\n")
+        hdr.write(f"{indent}  esi::detail::copyBitsIn<{bit_offset}, "
+                  f"{bit_width}>({raw_member}.data(), "
+                  f"reinterpret_cast<uint8_t *>(&out));\n")
+        hdr.write(f"{indent}  return out;\n")
+        hdr.write(f"{indent}}}\n")
+        hdr.write(
+            f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
+        hdr.write(f"{indent}  esi::detail::copyBitsOut<{bit_offset}, "
+                  f"{bit_width}>({raw_member}.data(), "
+                  f"reinterpret_cast<const uint8_t *>(&v));\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
 
     # Convenience indexed accessors for fixed-size arrays. The whole-array
     # getter/setter above is always sufficient; these helpers just save a
@@ -1589,8 +1682,8 @@ class CppTypeEmitter:
     # position and the element width is a whole number of bytes — anything
     # else has to go through the whole-array accessor since per-element
     # bit shuffling would require its own per-element offset arithmetic.
-    if (isinstance(wrapped, types.ArrayType) and byte_aligned and
-        wrapped.element_type.bit_width % 8 == 0):
+    if (not is_view_array and isinstance(wrapped, types.ArrayType) and
+        byte_aligned and wrapped.element_type.bit_width % 8 == 0):
       elem_cpp = self._cpp_type(wrapped.element_type)
       if elem_cpp != "void":
         elem_bytes = self._field_byte_width(wrapped.element_type)
@@ -1608,6 +1701,81 @@ class CppTypeEmitter:
                   f" + j] = reinterpret_cast<const uint8_t *>(&v)[j];\n")
         hdr.write(f"{indent}  return *this;\n")
         hdr.write(f"{indent}}}\n")
+
+    # Indexed accessors for arrays whose element is one of the view
+    # classes (`BitVector` / `IntView` / `UIntView`). The whole-array
+    # byte-copy path is intentionally skipped (the view's storage layout
+    # doesn't match the wire layout). Instead we emit three accessors:
+    #
+    #   * `field(i)` / `field(i, v)` -- per-element getter (zero-copy
+    #     view into the relevant slice of `_bytes`) and setter
+    #     (runtime per-bit copy, since `copyBitsOut` needs a
+    #     compile-time offset and the array index is runtime).
+    #   * `field()` -- a lazy `std::views::iota | std::views::transform`
+    #     range that yields the per-element views on demand. Random
+    #     access, no allocation, no element materialised until accessed.
+    #   * `field(const std::array<view, N> &)` -- whole-array setter
+    #     that delegates to the per-element setter N times. Lets the
+    #     emplace-style struct ctor accept view-array fields as a
+    #     single argument.
+    #
+    # All three share the parent struct's lifetime; see the warning at
+    # the top of the generated header.
+    if is_view_array:
+      assert isinstance(wrapped, types.ArrayType)
+      elem_type = wrapped.element_type
+      elem_cpp = self._cpp_type(elem_type)
+      elem_width = elem_type.bit_width
+      elem_count = wrapped.size
+      hdr.write(f"{indent}{elem_cpp} {field_name}(std::size_t i) const {{\n")
+      hdr.write(f"{indent}  const std::size_t bit_off = "
+                f"{bit_offset} + i * {elem_width};\n")
+      hdr.write(f"{indent}  return {elem_cpp}(\n")
+      hdr.write(f"{indent}      std::span<const uint8_t>("
+                f"{raw_member}.data() + bit_off / 8,\n")
+      hdr.write(f"{indent}                               "
+                f"(bit_off % 8 + {elem_width} + 7) / 8),\n")
+      hdr.write(f"{indent}      static_cast<std::size_t>({elem_width}),\n")
+      hdr.write(f"{indent}      static_cast<uint8_t>(bit_off % 8));\n")
+      hdr.write(f"{indent}}}\n")
+      hdr.write(f"{indent}{self_type} &{field_name}(std::size_t i, "
+                f"const {elem_cpp} &v) {{\n")
+      hdr.write(f"{indent}  const std::size_t bit_off = "
+                f"{bit_offset} + i * {elem_width};\n")
+      hdr.write(f"{indent}  const std::size_t n = "
+                f"std::min<std::size_t>(v.width(), {elem_width});\n")
+      hdr.write(
+          f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
+      hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
+      hdr.write(f"{indent}    const bool val = (b < n) && v.getBit(b);\n")
+      hdr.write(f"{indent}    if (val)\n")
+      hdr.write(f"{indent}      {raw_member}[g / 8] |= "
+                f"static_cast<uint8_t>(uint8_t{{1}} << (g % 8));\n")
+      hdr.write(f"{indent}    else\n")
+      hdr.write(f"{indent}      {raw_member}[g / 8] &= "
+                f"static_cast<uint8_t>(~(uint8_t{{1}} << (g % 8)));\n")
+      hdr.write(f"{indent}  }}\n")
+      hdr.write(f"{indent}  return *this;\n")
+      hdr.write(f"{indent}}}\n")
+      # Lazy whole-array view: `iota(0, N) | transform([this](i){ ... })`
+      # gives a random-access range of `elem_cpp` views computed on
+      # access, with zero up-front allocation.
+      hdr.write(f"{indent}auto {field_name}() const {{\n")
+      hdr.write(f"{indent}  return std::views::iota("
+                f"std::size_t{{0}}, std::size_t{{{elem_count}}}) |\n")
+      hdr.write(f"{indent}         std::views::transform("
+                f"[this](std::size_t i) {{\n")
+      hdr.write(f"{indent}           return this->{field_name}(i);\n")
+      hdr.write(f"{indent}         }});\n")
+      hdr.write(f"{indent}}}\n")
+      # Whole-array setter: forwards to the per-element setter for
+      # each index.
+      hdr.write(f"{indent}{self_type} &{field_name}("
+                f"const std::array<{elem_cpp}, {elem_count}> &v) {{\n")
+      hdr.write(f"{indent}  for (std::size_t i = 0; i < {elem_count}; ++i)\n")
+      hdr.write(f"{indent}    {field_name}(i, v[i]);\n")
+      hdr.write(f"{indent}  return *this;\n")
+      hdr.write(f"{indent}}}\n")
 
   def _ctor_param_type(self, field_type: types.ESIType) -> str:
     """Return the C++ constructor-parameter type for a setter call."""
@@ -1994,11 +2162,21 @@ class CppTypeEmitter:
       hdr.write(
           textwrap.dedent(f"""
         // Generated header for {system_name} types.
+        //
+        // Lifetime note: accessors that return `esi::BitVector` (for
+        // `Bits<N>` fields), `esi::IntView` (for `Int<N>`, N > 64), or
+        // `esi::UIntView` (for `UInt<N>`, N > 64) hand back non-owning
+        // views into the parent struct's bytes. The view is only valid
+        // while the parent is alive. Bind the parent to a named local
+        // first, or construct an owning `esi::Int` / `esi::UInt` /
+        // `esi::MutableBitVector` from the view if you need the value
+        // to outlive its source. See `esi/Values.h` for details.
         #pragma once
 
         #include <cstdint>
         #include <cstddef>
         #include <cstring>
+        #include <algorithm>
         #include <any>
         #include <array>
         #include <limits>
@@ -2011,6 +2189,7 @@ class CppTypeEmitter:
         #include "esi/BitAccess.h"
         #include "esi/Common.h"
         #include "esi/TypedPorts.h"
+        #include "esi/Values.h"
 
         namespace {system_name} {{
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -1441,8 +1441,9 @@ class CppTypeEmitter:
       * Path C — sub-byte alignment. Fall back to the
         `esi::detail::{read,write}{Un,}signedBits` helpers from
         `esi/BitAccess.h`, which loop over the constituent bits.
-      * Path D — view-class fields (`BitsType` at any width, and signed /
-        unsigned integers wider than 64 bits). Return a non-owning
+      * Path D — view-class fields. Triggered when `_is_value_class_type`
+        is true — currently widths above 64 bits, for any of `BitsType`,
+        signed, or unsigned. Returns a non-owning
         `esi::BitVector` / `esi::IntView` / `esi::UIntView` view *into*
         the parent struct's `_bytes` -- zero allocation, no copy. The
         setter accepts any `esi::BitVector` (so views and owning
@@ -1457,8 +1458,9 @@ class CppTypeEmitter:
     wrapped = self._unwrap_aliases(field_type)
 
     if isinstance(wrapped, (types.BitsType, types.IntType)):
-      # Path D: view-class field (BitsType at any width, or signed /
-      # unsigned integers wider than 64 bits).
+      # Path D: view-class field. Today this is exactly the
+      # wider-than-64-bit integer / Bits cases; gated by
+      # `_is_value_class_type` so the rule lives in one place.
       if self._is_value_class_type(field_type):
         byte_offset = bit_offset // 8
         sub_bit_index = bit_offset % 8

--- a/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeValuesTest.cpp
+++ b/lib/Dialect/ESI/runtime/tests/cpp/ESIRuntimeValuesTest.cpp
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include <any>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <sstream>
 #include <stdexcept>
@@ -398,6 +399,26 @@ TEST(IntTest, LargeWidthBadSignExtensionOverflow) {
 
   Int v(mbv_v);
   EXPECT_THROW((void)static_cast<int64_t>(v), std::overflow_error);
+}
+
+TEST(IntTest, LargeWidthBoundaryFitsInI64) {
+  // The wide value 2^63 (bit 63 set, all bits >= 64 clear) has a source
+  // top bit of 0 but cannot fit in int64_t -- its low 64 bits alias
+  // INT64_MIN. The narrowing must throw rather than silently flipping
+  // sign. Regression test for a bug where the high-byte equality check
+  // used the source's top bit instead of the destination's sign bit.
+  MutableBitVector mbv(128);
+  mbv.setBit(63, true);
+  Int v(mbv);
+  EXPECT_THROW((void)static_cast<int64_t>(v), std::overflow_error);
+
+  // The mirror case: bits 64..127 all set and bit 63 set is the wide
+  // representation of INT64_MIN; that one *does* fit.
+  MutableBitVector neg(128);
+  for (size_t i = 63; i < 128; ++i)
+    neg.setBit(i, true);
+  Int n(neg);
+  EXPECT_EQ(static_cast<int64_t>(n), std::numeric_limits<int64_t>::min());
 }
 
 TEST(UIntTest, BasicConstruction) {

--- a/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
+++ b/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
@@ -18,8 +18,11 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <ranges>
 #include <type_traits>
 #include <vector>
+
+#include "esi/Values.h"
 
 using namespace esi_system;
 
@@ -369,6 +372,285 @@ void testWindowList() {
   assert(footer_seg.data[1] == 0);
 }
 
+// ---------------------------------------------------------------------------
+// Path D — value-class fields (esi::MutableBitVector, esi::Int, esi::UInt)
+// ---------------------------------------------------------------------------
+
+// Build a wide MutableBitVector from an arbitrary-length byte buffer
+// (LSB-first wire order). Useful for hand-constructing > 64-bit values in
+// the harness.
+esi::MutableBitVector bvFromBytes(std::initializer_list<uint8_t> bytes,
+                                  std::size_t width) {
+  std::vector<uint8_t> storage(bytes.begin(), bytes.end());
+  // The MutableBitVector(vector<byte>&&, width) ctor requires the storage
+  // size to cover `width` bits. Pad with zeros if the caller supplied
+  // fewer bytes than that.
+  std::size_t need = (width + 7) / 8;
+  if (storage.size() < need)
+    storage.resize(need, 0);
+  return esi::MutableBitVector(std::move(storage), width);
+}
+
+void testWideUnsigned() {
+  // WideU has two byte-aligned wide-int fields: ui128 at the LSB end
+  // (bits 0..127), ui96 at bits 128..223. Total 224 bits = 28 bytes.
+  WideU s;
+  // Construct a 96-bit value: low half = 0x0123456789ABCDEF,
+  // high half = 0xCAFEBABEu (32 bits worth of upper bytes).
+  auto u96 = bvFromBytes(
+      {
+          0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01, // low 64 bits
+          0xBE, 0xBA, 0xFE, 0xCA,                         // bits 64..95
+      },
+      96);
+  auto u128 = bvFromBytes(
+      {
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, // low 64 bits
+          0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, // high 64 bits
+      },
+      128);
+
+  s.u96(u96).u128(u128);
+
+  // Round-trip: read the field back out and compare byte-for-byte.
+  auto got96 = s.u96();
+  assert(got96.width() == 96);
+  for (std::size_t i = 0; i < 96; ++i)
+    assert(got96.getBit(i) == u96.getBit(i));
+  auto got128 = s.u128();
+  assert(got128.width() == 128);
+  for (std::size_t i = 0; i < 128; ++i)
+    assert(got128.getBit(i) == u128.getBit(i));
+
+  // Wire layout: ui128 at byte 0..15 (LSB), then ui96 at byte 16..27.
+  std::array<uint8_t, 28> expected{
+      // u128 first (LSB):
+      0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, //
+      0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, //
+      // u96 next:
+      0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01, //
+      0xBE, 0xBA, 0xFE, 0xCA,                         //
+  };
+  expectBytes(s, expected, "WideU");
+
+  // Constructor takes the same value-class params, in manifest order.
+  WideU cons(u96, u128);
+  assert(wireBytes(cons) == wireBytes(s));
+}
+
+void testWideSigned() {
+  // si128 max = all ones except the sign bit = 0x7FFF...FF.
+  // si128 -1  = all ones.
+  WideS s;
+  auto s96_zero = bvFromBytes({}, 96);
+  auto s128_neg_one = bvFromBytes(
+      {
+          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //
+          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //
+      },
+      128);
+  s.s96(s96_zero).s128(s128_neg_one);
+
+  auto got = s.s128();
+  for (std::size_t i = 0; i < 128; ++i)
+    assert(got.getBit(i)); // -1 has every bit set
+  auto got96 = s.s96();
+  for (std::size_t i = 0; i < 96; ++i)
+    assert(!got96.getBit(i));
+
+  // Wire bytes: low 16 bytes all-ones (s128), then 12 zero bytes (s96).
+  std::array<uint8_t, 28> expected{};
+  for (std::size_t i = 0; i < 16; ++i)
+    expected[i] = 0xFF;
+  expectBytes(s, expected, "WideS s128=-1, s96=0");
+}
+
+void testBitsField() {
+  // BitsType > 64 routes through Path D (non-owning `esi::BitVector`
+  // view); narrower Bits stay on the native int paths and are covered
+  // by the other tests above.
+  BitsField f;
+  auto wide = bvFromBytes(
+      {
+          0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE, //
+          0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, //
+      },
+      128);
+  f.wide(wide);
+
+  auto got_wide = f.wide();
+  assert(got_wide.width() == 128);
+  for (std::size_t i = 0; i < 128; ++i)
+    assert(got_wide.getBit(i) == wide.getBit(i));
+}
+
+void testWideMisaligned() {
+  // WideMisaligned: tag (ui3) at bits 0..2, payload (ui128) at bits
+  // 3..130 — i.e. a wide value at a non-byte-aligned offset. Hits the
+  // `copyBitsIn` / `copyBitsOut` arm of Path D.
+  WideMisaligned m;
+  auto payload = bvFromBytes(
+      {
+          0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, //
+          0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, //
+      },
+      128);
+  m.tag(0b101).payload(payload);
+  assert(m.tag() == 0b101);
+
+  auto got = m.payload();
+  assert(got.width() == 128);
+  for (std::size_t i = 0; i < 128; ++i)
+    assert(got.getBit(i) == payload.getBit(i));
+
+  // Re-setting `tag` must not disturb `payload`, and vice versa.
+  m.tag(0b010);
+  auto got2 = m.payload();
+  for (std::size_t i = 0; i < 128; ++i)
+    assert(got2.getBit(i) == payload.getBit(i));
+  assert(m.tag() == 0b010);
+
+  // A narrower input value must be zero-extended; a wider input is
+  // truncated. Verify the former here (the latter is exercised
+  // implicitly because the Path D setter clamps to bit_width).
+  auto narrow = bvFromBytes({0xAA}, 8); // only 8 bits of input
+  m.payload(narrow);
+  auto got3 = m.payload();
+  // Low 8 bits == 0xAA, upper 120 bits == 0.
+  for (std::size_t i = 0; i < 8; ++i)
+    assert(got3.getBit(i) == ((0xAA >> i) & 1));
+  for (std::size_t i = 8; i < 128; ++i)
+    assert(!got3.getBit(i));
+  assert(m.tag() == 0b010); // still preserved
+}
+
+// ---------------------------------------------------------------------------
+// Array of view-class elements: indexed-only accessors
+// ---------------------------------------------------------------------------
+
+// Round-trip a 3-element array of `ui128` through the per-element
+// indexed accessors. The whole-array accessor is intentionally absent
+// for view-class element types; only `items(i)` / `items(i, v)` exist.
+void testArrayOfViewsAligned() {
+  ArrViews a;
+  std::array<esi::MutableBitVector, 3> source;
+  for (std::size_t i = 0; i < 3; ++i) {
+    source[i] = bvFromBytes(
+        {
+            static_cast<uint8_t>(0x10 + i),
+            static_cast<uint8_t>(0x20 + i),
+            static_cast<uint8_t>(0x30 + i),
+            static_cast<uint8_t>(0x40 + i),
+            static_cast<uint8_t>(0x50 + i),
+            static_cast<uint8_t>(0x60 + i),
+            static_cast<uint8_t>(0x70 + i),
+            static_cast<uint8_t>(0x80 + i),
+            static_cast<uint8_t>(0x91 + i),
+            static_cast<uint8_t>(0xA2 + i),
+            static_cast<uint8_t>(0xB3 + i),
+            static_cast<uint8_t>(0xC4 + i),
+            static_cast<uint8_t>(0xD5 + i),
+            static_cast<uint8_t>(0xE6 + i),
+            static_cast<uint8_t>(0xF7 + i),
+            static_cast<uint8_t>(0x08 + i),
+        },
+        128);
+    a.items(i, source[i]);
+  }
+  for (std::size_t i = 0; i < 3; ++i) {
+    auto got = a.items(i);
+    assert(got.width() == 128);
+    for (std::size_t b = 0; b < 128; ++b)
+      assert(got.getBit(b) == source[i].getBit(b));
+  }
+
+  // Independence: writing element 1 must not disturb elements 0 or 2.
+  auto fresh = bvFromBytes({0xAA}, 128);
+  a.items(1, fresh);
+  for (std::size_t b = 0; b < 128; ++b) {
+    assert(a.items(0).getBit(b) == source[0].getBit(b));
+    assert(a.items(2).getBit(b) == source[2].getBit(b));
+  }
+
+  // Lazy whole-array accessor (std::views::iota | std::views::transform):
+  // yields per-element views on demand. Random-access, so size() and
+  // r[i] both work, and we can range-for it.
+  auto range = a.items();
+  assert(std::ranges::size(range) == 3);
+  std::size_t i = 0;
+  for (auto view : range) {
+    assert(view.width() == 128);
+    for (std::size_t b = 0; b < 128; ++b)
+      assert(view.getBit(b) == a.items(i).getBit(b));
+    ++i;
+  }
+  assert(i == 3);
+
+  // Whole-array setter taking `std::array<view, N>` and the matching
+  // ctor: build a fresh struct from the array argument and confirm the
+  // round-trip matches.
+  std::array<esi::UIntView, 3> bulk = {
+      esi::UIntView(source[0]),
+      esi::UIntView(source[1]),
+      esi::UIntView(source[2]),
+  };
+  ArrViews ctor_built(bulk);
+  for (std::size_t k = 0; k < 3; ++k) {
+    auto got = ctor_built.items(k);
+    for (std::size_t b = 0; b < 128; ++b)
+      assert(got.getBit(b) == source[k].getBit(b));
+  }
+  // Whole-array setter on an existing instance.
+  ArrViews bulk_set;
+  bulk_set.items(bulk);
+  for (std::size_t k = 0; k < 3; ++k) {
+    auto got = bulk_set.items(k);
+    for (std::size_t b = 0; b < 128; ++b)
+      assert(got.getBit(b) == source[k].getBit(b));
+  }
+}
+
+void testArrayOfViewsMisaligned() {
+  // `items` is the FIRST manifest field, so on the wire it lands at the
+  // top of the buffer with `tag` (ui3) at bits 0..2 and the 3 ui128
+  // elements at bits 3..130, 131..258, 259..386. Every element is
+  // bit-misaligned -- exercises the runtime per-bit setter loop and the
+  // sub-byte BitVector view constructor.
+  ArrViewsMis m;
+  m.tag(0b101);
+  std::array<esi::MutableBitVector, 3> source;
+  for (std::size_t i = 0; i < 3; ++i) {
+    source[i] = bvFromBytes(
+        {
+            static_cast<uint8_t>(0xC0 + i),
+            static_cast<uint8_t>(0xC1 + i),
+            static_cast<uint8_t>(0xC2 + i),
+            static_cast<uint8_t>(0xC3 + i),
+            static_cast<uint8_t>(0xC4 + i),
+            static_cast<uint8_t>(0xC5 + i),
+            static_cast<uint8_t>(0xC6 + i),
+            static_cast<uint8_t>(0xC7 + i),
+            static_cast<uint8_t>(0xC8 + i),
+            static_cast<uint8_t>(0xC9 + i),
+            static_cast<uint8_t>(0xCA + i),
+            static_cast<uint8_t>(0xCB + i),
+            static_cast<uint8_t>(0xCC + i),
+            static_cast<uint8_t>(0xCD + i),
+            static_cast<uint8_t>(0xCE + i),
+            static_cast<uint8_t>(0xCF + i),
+        },
+        128);
+    m.items(i, source[i]);
+  }
+  assert(m.tag() == 0b101);
+  for (std::size_t i = 0; i < 3; ++i) {
+    auto got = m.items(i);
+    assert(got.width() == 128);
+    for (std::size_t b = 0; b < 128; ++b)
+      assert(got.getBit(b) == source[i].getBit(b));
+  }
+}
+
 } // namespace
 
 int main() {
@@ -384,6 +666,12 @@ int main() {
   testArrayOfIntegers();
   testUnion();
   testWindowList();
+  testWideUnsigned();
+  testWideSigned();
+  testBitsField();
+  testWideMisaligned();
+  testArrayOfViewsAligned();
+  testArrayOfViewsMisaligned();
   std::printf("OK\n");
   return 0;
 }

--- a/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
+++ b/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
@@ -525,12 +525,17 @@ void testWideMisaligned() {
 }
 
 // ---------------------------------------------------------------------------
-// Array of view-class elements: indexed-only accessors
+// Array of view-class elements: indexed + lazy whole-array accessors
 // ---------------------------------------------------------------------------
 
-// Round-trip a 3-element array of `ui128` through the per-element
-// indexed accessors. The whole-array accessor is intentionally absent
-// for view-class element types; only `items(i)` / `items(i, v)` exist.
+// Round-trip a 3-element array of `ui128` through both the per-element
+// indexed accessors (`items(i)` / `items(i, v)`) and the lazy
+// whole-array accessor (`items()` returning a
+// `std::views::iota | std::views::transform` range of per-element
+// views, plus the `std::array<view, N>` whole-array setter and matching
+// ctor). The byte-copy whole-array path used for native-int arrays
+// doesn't apply here because the view's storage layout differs from
+// the wire layout.
 void testArrayOfViewsAligned() {
   ArrViews a;
   std::array<esi::MutableBitVector, 3> source;

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -48,6 +48,16 @@ _sint24 = types.SIntType("si24", 24)
 _sint32 = types.SIntType("si32", 32)
 _sint64 = types.SIntType("si64", 64)
 
+# Path D: value-class fields backed by `esi::IntView` / `esi::UIntView` /
+# `esi::BitVector` (any width supported; only wider-than-64 cases route
+# through the view classes -- narrower Bits/Int/UInt stay on the native
+# int paths). Tested below with 96- and 128-bit widths.
+_bits128 = types.BitsType("bits128", 128)
+_uint96 = types.UIntType("ui96", 96)
+_uint128 = types.UIntType("ui128", 128)
+_sint96 = types.SIntType("si96", 96)
+_sint128 = types.SIntType("si128", 128)
+
 # ---------------------------------------------------------------------------
 # Harness Manifest Builder
 # ---------------------------------------------------------------------------
@@ -167,9 +177,69 @@ def _build_harness_manifest():
   # Hand-name the window so the harness can spell `ListWindow` directly.
   list_window = types.TypeAlias("@ListWindow", "ListWindow", list_window_inner)
 
+  # Path D: value-class fields backed by `esi::MutableBitVector` /
+  # `esi::Int` / `esi::UInt` from `esi/Values.h`. Covers BitsType at
+  # both narrow and wide widths, plus signed/unsigned integers above
+  # the 64-bit native ceiling. Layout fields cover byte-aligned and
+  # bit-misaligned wide-int offsets so both branches of `copyBitsIn`
+  # / `copyBitsOut` get exercised.
+  wide_u_inner = types.StructType(
+      "@WideU::inner",
+      [("u96", _uint96), ("u128", _uint128)],
+  )
+  wide_u = types.TypeAlias("@WideU", "WideU", wide_u_inner)
+  wide_s_inner = types.StructType(
+      "@WideS::inner",
+      [("s96", _sint96), ("s128", _sint128)],
+  )
+  wide_s = types.TypeAlias("@WideS", "WideS", wide_s_inner)
+  # Bits-typed fields > 64 bits route through the value-class path
+  # (`esi::BitVector` view); narrower Bits stay on the native int paths
+  # and don't need a dedicated harness here.
+  bits_inner = types.StructType(
+      "@BitsField::inner",
+      [("wide", _bits128)],
+  )
+  bits_field = types.TypeAlias("@BitsField", "BitsField", bits_inner)
+  # Place the wide UInt field *before* a 3-bit tag in the manifest.
+  # Field order is reversed on the wire (`cpp_type.reverse=True`), so the
+  # LAST manifest field lands at wire bit 0. Listing `payload` first and
+  # `tag` last puts `tag` at bits 0..2 (byte-aligned) and the 128-bit
+  # `payload` at bits 3..130 — exercising the
+  # `copyBitsIn<bit_offset, 128>` / `copyBitsOut` arm of Path D rather
+  # than only the byte-aligned case.
+  wide_mis_inner = types.StructType(
+      "@WideMisaligned::inner",
+      [("payload", _uint128), ("tag", _uint3)],
+  )
+  wide_mis = types.TypeAlias("@WideMisaligned", "WideMisaligned",
+                             wide_mis_inner)
+
+  # Array of view-class elements. The planner used to skip parent types
+  # that reached this construct; now the emitter handles them by emitting
+  # per-element indexed accessors that build fresh views into `_bytes`.
+  # Use ui128 (a view-class type) at multiple element widths to exercise
+  # both byte-aligned and bit-misaligned per-element offsets.
+  arr3_u128_type = types.ArrayType("!hw.array<3xui128>", _uint128, 3)
+  arr_views_inner = types.StructType(
+      "@ArrViews::inner",
+      [("items", arr3_u128_type)],
+  )
+  arr_views = types.TypeAlias("@ArrViews", "ArrViews", arr_views_inner)
+  # Same array placed after a 3-bit tag so the array starts at bit 3
+  # and successive elements land at non-byte-aligned per-element
+  # offsets (3, 131, 259, ...).
+  arr_views_mis_inner = types.StructType(
+      "@ArrViewsMis::inner",
+      [("items", arr3_u128_type), ("tag", _uint3)],
+  )
+  arr_views_mis = types.TypeAlias("@ArrViewsMis", "ArrViewsMis",
+                                  arr_views_mis_inner)
+
   return [
       std_u, std_s, odd_u, odd_s, sub_u, sub_s, bool_field, outer, misaligned,
-      arr4, union_two, list_window
+      arr4, union_two, list_window, wide_u, wide_s, bits_field, wide_mis,
+      arr_views, arr_views_mis
   ]
 
 


### PR DESCRIPTION
Switch to BitVector for all `Bits` types. Create IntView and UIntView for `SInt`s and `UInt`s. Use the for more that 64-bit types.

Assisted-by: vscode:Claude Opus 4.7
