### PR TITLE
[ImportVerilog] Add support for countones.

### DIFF
--- a/docs/Dialects/LTL.md
+++ b/docs/Dialects/LTL.md
@@ -315,8 +315,31 @@ lowering above on the coerced 2-state value:
 %onehot = comb.mux %isunknown, %zero, %onehot_2state : i1
 ```
 
-> The following functions are not yet supported by CIRCT:  
-> - **`$countones(a)`**     
+- **`$countones(a)`**:
+For 2-state input `%a` (where `%a` has type `iN`):
+The popcount is computed by extracting each bit, zero-extending to
+`iM` (where `M = ceil(log2(N+1))`), and summing them:
+
+```mlir
+// For an 8-bit input, M=4 and padding is i3:
+%b0 = comb.extract %a from 0 : (i8) -> i1
+%ext0 = comb.concat %zeros3, %b0 : i3, i1
+%b1 = comb.extract %a from 1 : (i8) -> i1
+%ext1 = comb.concat %zeros3, %b1 : i3, i1
+%sum = comb.add %ext0, %ext1 : i4
+// ... for each bit
+```
+
+For 4-state input `%a` (where `%a` has type `!moore.lN`):
+x/z bits do not match logic value 1 and are excluded from the count. The value
+is coerced to 2-state (`logic_to_int` maps x/z to 0) and then the 2-state
+lowering is applied:
+
+```mlir
+%coerced_a = moore.logic_to_int %a
+%int_a = moore.to_builtin_int %coerced_a
+%countones = ... // 2-state lowering on %int_a
+```
   
   
 - **`a ##n b`**:   

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -9,11 +9,9 @@
 #include "slang/ast/expressions/AssertionExpr.h"
 
 #include "ImportVerilogInternals.h"
-#include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/LTL/LTLOps.h"
 #include "circt/Dialect/Moore/MooreOps.h"
-#include "circt/Support/FVInt.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Support/LLVM.h"
@@ -362,69 +360,9 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
   case ksn::Past:
     return castToMoore(ltl::PastOp::create(builder, loc, value, 1, clockVal));
 
-  case ksn::OneHot0: {
-    auto one = hw::ConstantOp::create(builder, loc, value.getType(), 1);
-    auto minusOne = comb::SubOp::create(builder, loc, value, one);
-    auto anded = comb::AndOp::create(builder, loc, value, minusOne);
-    auto zero = hw::ConstantOp::create(builder, loc, value.getType(), 0);
-    return castToTwoValued(comb::ICmpOp::create(
-        builder, loc, comb::ICmpPredicate::eq, anded, zero, false));
-  }
-
-  case ksn::OneHot: {
-    auto one = hw::ConstantOp::create(builder, loc, value.getType(), 1);
-    auto minusOne = comb::SubOp::create(builder, loc, value, one);
-    auto anded = comb::AndOp::create(builder, loc, value, minusOne);
-    auto zero = hw::ConstantOp::create(builder, loc, value.getType(), 0);
-    auto isOneHot0 = comb::ICmpOp::create(builder, loc, comb::ICmpPredicate::eq,
-                                          anded, zero, false);
-    auto isNotZero = comb::ICmpOp::create(builder, loc, comb::ICmpPredicate::ne,
-                                          value, zero, false);
-    auto result = comb::AndOp::create(builder, loc, isOneHot0, isNotZero);
-    return castToTwoValued(result);
-  }
-
-  case ksn::CountOnes: {
-    // Popcount: extract each bit, zero-extend to result width, and sum.
-    auto intTy = cast<IntegerType>(value.getType());
-    unsigned width = intTy.getWidth();
-    unsigned resultWidth = llvm::Log2_32_Ceil(width + 1);
-    auto i1Ty = builder.getI1Type();
-    unsigned padWidth = resultWidth - 1;
-    auto zeros = hw::ConstantOp::create(builder, loc,
-                                        builder.getIntegerType(padWidth), 0);
-
-    // Zero-extend the first bit to seed the accumulator.
-    auto bit0 = comb::ExtractOp::create(builder, loc, i1Ty, value, 0);
-    Value sum = comb::ConcatOp::create(builder, loc, ValueRange{zeros, bit0});
-
-    for (unsigned i = 1; i < width; ++i) {
-      auto bit = comb::ExtractOp::create(builder, loc, i1Ty, value, i);
-      auto extended =
-          comb::ConcatOp::create(builder, loc, ValueRange{zeros, bit});
-      sum = comb::AddOp::create(builder, loc, sum, extended);
-    }
-    return castToTwoValued(sum);
-  }
-
   default:
     return Value{};
   }
-}
-
-static Value getIsUnknown(OpBuilder &builder, Location loc, Value value,
-                          moore::IntType valTy, MLIRContext *ctx) {
-  Value bitVal = value;
-  if (valTy.getWidth() > 1) {
-    auto mooreI1Type = moore::IntType::get(ctx, 1, valTy.getDomain());
-    bitVal = moore::ReduceXorOp::create(builder, loc, mooreI1Type, value);
-  }
-
-  auto xType = moore::IntType::get(ctx, 1, moore::Domain::FourValued);
-  auto xValue = FVInt::getAllX(1);
-  auto xConst = moore::ConstantOp::create(builder, loc, xType, xValue);
-
-  return moore::CaseEqOp::create(builder, loc, bitVal, xConst).getResult();
 }
 
 Value Context::convertAssertionCallExpression(
@@ -482,54 +420,6 @@ Value Context::convertAssertionCallExpression(
       return {};
     }
 
-    // IsUnknown is handled here rather than below with the others as below it
-    // would have already been converted to an integer type rather than bool
-    // type as here.
-    if (subroutine.knownNameId == slang::parsing::KnownSystemName::IsUnknown) {
-      result = getIsUnknown(builder, loc, value, valTy, getContext());
-      break;
-    }
-
-    // OneHot/OneHot0 are handled both here and below.
-    if ((subroutine.knownNameId == slang::parsing::KnownSystemName::OneHot ||
-         subroutine.knownNameId == slang::parsing::KnownSystemName::OneHot0) &&
-        (valTy.getDomain() == Domain::FourValued)) {
-      // In SystemVerilog, these system only returns 1b1 if the expression is
-      // fully known and the condition is met. So if any x or y bits, then
-      // these must return 1'b0.
-
-      // Detect if input contain unknown bits.
-      Value isUnknownMoore =
-          getIsUnknown(builder, loc, value, valTy, getContext());
-      Value isUnknown =
-          builder.createOrFold<moore::ToBuiltinIntOp>(loc, isUnknownMoore);
-
-      Value coerced = builder.createOrFold<moore::LogicToIntOp>(loc, value);
-      Value state2IntVal =
-          builder.createOrFold<moore::ToBuiltinIntOp>(loc, coerced);
-      if (!state2IntVal)
-        return {};
-
-      auto systemResult = this->convertAssertionSystemCallArity1(
-          subroutine, loc, state2IntVal, originalType, clockVal);
-      if (failed(systemResult) || !*systemResult)
-        return {};
-      Value onehot2state = *systemResult;
-
-      // Squash to 0 if unknown bits exist.
-      Value onehot2stateBuiltin = convertToI1(onehot2state);
-      Value zeroBuiltin =
-          hw::ConstantOp::create(builder, loc, builder.getI1Type(), 0);
-      Value resultBuiltin = comb::MuxOp::create(
-          builder, loc, isUnknown, zeroBuiltin, onehot2stateBuiltin);
-
-      Value finalResult =
-          moore::FromBuiltinIntOp::create(builder, loc, resultBuiltin);
-      result =
-          moore::IntToLogicOp::create(builder, loc, finalResult).getResult();
-      break;
-    }
-
     // If the value is four-valued, we need to map it to two-valued before we
     // cast it to a builtin int
     if (valTy.getDomain() == Domain::FourValued) {
@@ -550,10 +440,7 @@ Value Context::convertAssertionCallExpression(
     return {};
   if (*result) {
     auto expectedTy = convertType(*expr.type);
-    return materializeConversion(expectedTy, *result,
-                                 (subroutine.knownNameId !=
-                                  slang::parsing::KnownSystemName::CountOnes) &&
-                                     expr.type->isSigned(),
+    return materializeConversion(expectedTy, *result, expr.type->isSigned(),
                                  loc);
   }
 

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -550,7 +550,10 @@ Value Context::convertAssertionCallExpression(
     return {};
   if (*result) {
     auto expectedTy = convertType(*expr.type);
-    return materializeConversion(expectedTy, *result, expr.type->isSigned(),
+    return materializeConversion(expectedTy, *result,
+                                 (subroutine.knownNameId !=
+                                  slang::parsing::KnownSystemName::CountOnes) &&
+                                     expr.type->isSigned(),
                                  loc);
   }
 

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -318,6 +318,11 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
     return v;
   };
 
+  // Helper to cast a builtin integer result to a two-valued Moore integer type.
+  auto castToTwoValued = [&](Value v) -> Value {
+    return moore::FromBuiltinIntOp::create(builder, loc, v);
+  };
+
   switch (nameId) {
   case ksn::Sampled:
     return castToMoore(ltl::SampledOp::create(builder, loc, value));
@@ -326,7 +331,7 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
   case ksn::Fell: {
     auto past =
         ltl::PastOp::create(builder, loc, value, 1, clockVal).getResult();
-    return castToMoore(comb::ICmpOp::create(
+    return castToTwoValued(comb::ICmpOp::create(
         builder, loc, comb::ICmpPredicate::ugt, past, value, false));
   }
 
@@ -334,7 +339,7 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
   case ksn::Rose: {
     auto past =
         ltl::PastOp::create(builder, loc, value, 1, clockVal).getResult();
-    return castToMoore(comb::ICmpOp::create(
+    return castToTwoValued(comb::ICmpOp::create(
         builder, loc, comb::ICmpPredicate::ult, past, value, false));
   }
 
@@ -342,7 +347,7 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
   case ksn::Changed: {
     auto past =
         ltl::PastOp::create(builder, loc, value, 1, clockVal).getResult();
-    return castToMoore(comb::ICmpOp::create(
+    return castToTwoValued(comb::ICmpOp::create(
         builder, loc, comb::ICmpPredicate::ne, past, value, false));
   }
 
@@ -350,7 +355,7 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
   case ksn::Stable: {
     auto past =
         ltl::PastOp::create(builder, loc, value, 1, clockVal).getResult();
-    return castToMoore(comb::ICmpOp::create(
+    return castToTwoValued(comb::ICmpOp::create(
         builder, loc, comb::ICmpPredicate::eq, past, value, false));
   }
 
@@ -362,7 +367,7 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
     auto minusOne = comb::SubOp::create(builder, loc, value, one);
     auto anded = comb::AndOp::create(builder, loc, value, minusOne);
     auto zero = hw::ConstantOp::create(builder, loc, value.getType(), 0);
-    return castToMoore(comb::ICmpOp::create(
+    return castToTwoValued(comb::ICmpOp::create(
         builder, loc, comb::ICmpPredicate::eq, anded, zero, false));
   }
 
@@ -376,7 +381,30 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
     auto isNotZero = comb::ICmpOp::create(builder, loc, comb::ICmpPredicate::ne,
                                           value, zero, false);
     auto result = comb::AndOp::create(builder, loc, isOneHot0, isNotZero);
-    return castToMoore(result);
+    return castToTwoValued(result);
+  }
+
+  case ksn::CountOnes: {
+    // Popcount: extract each bit, zero-extend to result width, and sum.
+    auto intTy = cast<IntegerType>(value.getType());
+    unsigned width = intTy.getWidth();
+    unsigned resultWidth = llvm::Log2_32_Ceil(width + 1);
+    auto i1Ty = builder.getI1Type();
+    unsigned padWidth = resultWidth - 1;
+    auto zeros = hw::ConstantOp::create(builder, loc,
+                                        builder.getIntegerType(padWidth), 0);
+
+    // Zero-extend the first bit to seed the accumulator.
+    auto bit0 = comb::ExtractOp::create(builder, loc, i1Ty, value, 0);
+    Value sum = comb::ConcatOp::create(builder, loc, ValueRange{zeros, bit0});
+
+    for (unsigned i = 1; i < width; ++i) {
+      auto bit = comb::ExtractOp::create(builder, loc, i1Ty, value, i);
+      auto extended =
+          comb::ConcatOp::create(builder, loc, ValueRange{zeros, bit});
+      sum = comb::AddOp::create(builder, loc, sum, extended);
+    }
+    return castToTwoValued(sum);
   }
 
   default:
@@ -458,7 +486,8 @@ Value Context::convertAssertionCallExpression(
     // would have already been converted to an integer type rather than bool
     // type as here.
     if (subroutine.knownNameId == slang::parsing::KnownSystemName::IsUnknown) {
-      return getIsUnknown(builder, loc, value, valTy, getContext());
+      result = getIsUnknown(builder, loc, value, valTy, getContext());
+      break;
     }
 
     // OneHot/OneHot0 are handled both here and below.
@@ -496,7 +525,9 @@ Value Context::convertAssertionCallExpression(
 
       Value finalResult =
           moore::FromBuiltinIntOp::create(builder, loc, resultBuiltin);
-      return moore::IntToLogicOp::create(builder, loc, finalResult);
+      result =
+          moore::IntToLogicOp::create(builder, loc, finalResult).getResult();
+      break;
     }
 
     // If the value is four-valued, we need to map it to two-valued before we
@@ -517,8 +548,11 @@ Value Context::convertAssertionCallExpression(
 
   if (failed(result))
     return {};
-  if (*result)
-    return *result;
+  if (*result) {
+    auto expectedTy = convertType(*expr.type);
+    return materializeConversion(expectedTy, *result, expr.type->isSigned(),
+                                 loc);
+  }
 
   mlir::emitError(loc) << "unsupported system call `" << subroutine.name << "`";
   return {};

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2044,6 +2044,7 @@ struct RvalueExprVisitor : public ExprVisitor {
     case ksn::IsUnknown:
     case ksn::OneHot:
     case ksn::OneHot0:
+    case ksn::CountOnes:
       return context.convertAssertionCallExpression(expr, info, loc);
     default:
       break;

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -7,8 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImportVerilogInternals.h"
+#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/Moore/MooreOps.h"
 #include "circt/Dialect/Moore/MooreTypes.h"
+#include "circt/Support/FVInt.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 #include "slang/ast/EvalContext.h"
@@ -2031,7 +2033,7 @@ struct RvalueExprVisitor : public ExprVisitor {
     const auto &subroutine = *info.subroutine;
     auto nameId = subroutine.knownNameId;
 
-    // $rose, $fell, $stable, $changed, and $past are only valid in
+    // $rose, $fell, $stable, $changed, $past, and $sampled are only valid in
     // the context of properties and assertions. Those are treated in the
     // LTLDialect; treat them there instead.
     switch (nameId) {
@@ -2041,10 +2043,6 @@ struct RvalueExprVisitor : public ExprVisitor {
     case ksn::Changed:
     case ksn::Past:
     case ksn::Sampled:
-    case ksn::IsUnknown:
-    case ksn::OneHot:
-    case ksn::OneHot0:
-    case ksn::CountOnes:
       return context.convertAssertionCallExpression(expr, info, loc);
     default:
       break;
@@ -2073,8 +2071,14 @@ struct RvalueExprVisitor : public ExprVisitor {
       return {};
 
     auto ty = context.convertType(*expr.type);
-    return context.materializeConversion(ty, result, expr.type->isSigned(),
-                                         loc);
+    // Bit vector builtins ($countones, $isunknown, $onehot, $onehot0) return
+    // inherently unsigned results that must be zero-extended, even though
+    // Slang's declared return type may be signed int.
+    bool isSigned = expr.type->isSigned();
+    if (nameId == ksn::CountOnes || nameId == ksn::IsUnknown ||
+        nameId == ksn::OneHot || nameId == ksn::OneHot0)
+      isSigned = false;
+    return context.materializeConversion(ty, result, isSigned, loc);
   }
 
   /// Handle string literals.
@@ -3261,6 +3265,151 @@ Value Context::convertSystemCall(
     if (!value)
       return {};
     return moore::Clog2BIOp::create(builder, loc, value);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bit Vector System Functions
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::IsUnknown) {
+    assert(numArgs == 1 && "`$isunknown` takes 1 argument");
+    auto value = convertRvalueExpression(*args[0]);
+    if (!value)
+      return {};
+    auto valTy = dyn_cast<moore::IntType>(value.getType());
+    if (!valTy) {
+      mlir::emitError(loc) << "expected integer argument for `$isunknown`";
+      return {};
+    }
+    Value bitVal = value;
+    if (valTy.getWidth() > 1) {
+      auto mooreI1Type =
+          moore::IntType::get(getContext(), 1, valTy.getDomain());
+      bitVal = moore::ReduceXorOp::create(builder, loc, mooreI1Type, value);
+    }
+    auto xType =
+        moore::IntType::get(getContext(), 1, moore::Domain::FourValued);
+    auto xValue = FVInt::getAllX(1);
+    auto xConst = moore::ConstantOp::create(builder, loc, xType, xValue);
+    return moore::CaseEqOp::create(builder, loc, bitVal, xConst).getResult();
+  }
+
+  if (nameId == ksn::OneHot0 || nameId == ksn::OneHot) {
+    assert(numArgs == 1 && "`$onehot`/`$onehot0` takes 1 argument");
+    auto value = convertRvalueExpression(*args[0]);
+    if (!value)
+      return {};
+    auto valTy = dyn_cast<moore::IntType>(value.getType());
+    if (!valTy) {
+      mlir::emitError(loc) << "expected integer argument for `"
+                           << subroutine.name << "`";
+      return {};
+    }
+
+    // In SystemVerilog, $onehot/$onehot0 return 1'b0 if the expression
+    // contains any unknown (x/z) bits. Detect and squash if four-valued.
+    Value isUnknown;
+    if (valTy.getDomain() == Domain::FourValued) {
+      Value bitVal = value;
+      if (valTy.getWidth() > 1) {
+        auto mooreI1Type =
+            moore::IntType::get(getContext(), 1, valTy.getDomain());
+        bitVal = moore::ReduceXorOp::create(builder, loc, mooreI1Type, value);
+      }
+      auto xType =
+          moore::IntType::get(getContext(), 1, moore::Domain::FourValued);
+      auto xConst =
+          moore::ConstantOp::create(builder, loc, xType, FVInt::getAllX(1));
+      Value isUnknownMoore =
+          moore::CaseEqOp::create(builder, loc, bitVal, xConst).getResult();
+      isUnknown =
+          builder.createOrFold<moore::ToBuiltinIntOp>(loc, isUnknownMoore);
+    }
+
+    // Coerce four-valued input to two-valued for the comb ops.
+    Value intVal;
+    if (valTy.getDomain() == Domain::FourValued) {
+      Value coerced = builder.createOrFold<moore::LogicToIntOp>(loc, value);
+      intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, coerced);
+    } else {
+      intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
+    }
+
+    // Compute onehot0: (value & (value - 1)) == 0
+    auto one = hw::ConstantOp::create(builder, loc, intVal.getType(), 1);
+    auto minusOne = comb::SubOp::create(builder, loc, intVal, one);
+    auto anded = comb::AndOp::create(builder, loc, intVal, minusOne);
+    auto zero = hw::ConstantOp::create(builder, loc, intVal.getType(), 0);
+    Value result = comb::ICmpOp::create(builder, loc, comb::ICmpPredicate::eq,
+                                        anded, zero, false);
+
+    // For $onehot, additionally require value != 0.
+    if (nameId == ksn::OneHot) {
+      auto isNotZero = comb::ICmpOp::create(
+          builder, loc, comb::ICmpPredicate::ne, intVal, zero, false);
+      result = comb::AndOp::create(builder, loc, result, isNotZero);
+    }
+
+    // Wrap back into Moore type.
+    result = moore::FromBuiltinIntOp::create(builder, loc, result);
+
+    // If four-valued, squash to 0 when unknown bits exist.
+    if (isUnknown) {
+      Value resultI1 = convertToI1(result);
+      Value zeroI1 =
+          hw::ConstantOp::create(builder, loc, builder.getI1Type(), 0);
+      Value squashed =
+          comb::MuxOp::create(builder, loc, isUnknown, zeroI1, resultI1);
+      Value squashedMoore =
+          moore::FromBuiltinIntOp::create(builder, loc, squashed);
+      return moore::IntToLogicOp::create(builder, loc, squashedMoore)
+          .getResult();
+    }
+    return result;
+  }
+
+  if (nameId == ksn::CountOnes) {
+    assert(numArgs == 1 && "`$countones` takes 1 argument");
+    auto value = convertRvalueExpression(*args[0]);
+    if (!value)
+      return {};
+    auto valTy = dyn_cast<moore::IntType>(value.getType());
+    if (!valTy) {
+      mlir::emitError(loc) << "expected integer argument for `$countones`";
+      return {};
+    }
+
+    // Coerce four-valued input to two-valued for the comb ops.
+    Value intVal;
+    if (valTy.getDomain() == Domain::FourValued) {
+      Value coerced = builder.createOrFold<moore::LogicToIntOp>(loc, value);
+      intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, coerced);
+    } else {
+      intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
+    }
+
+    // Popcount: extract each bit, zero-extend to result width, and sum.
+    auto builtinIntTy = cast<IntegerType>(intVal.getType());
+    unsigned width = builtinIntTy.getWidth();
+    unsigned resultWidth = llvm::Log2_32_Ceil(width + 1);
+    auto i1Ty = builder.getI1Type();
+    unsigned padWidth = resultWidth - 1;
+    auto zeros = hw::ConstantOp::create(builder, loc,
+                                        builder.getIntegerType(padWidth), 0);
+
+    // Zero-extend the first bit to seed the accumulator.
+    auto bit0 = comb::ExtractOp::create(builder, loc, i1Ty, intVal, 0);
+    Value sum = comb::ConcatOp::create(builder, loc, ValueRange{zeros, bit0});
+
+    for (unsigned i = 1; i < width; ++i) {
+      auto bit = comb::ExtractOp::create(builder, loc, i1Ty, intVal, i);
+      auto extended =
+          comb::ConcatOp::create(builder, loc, ValueRange{zeros, bit});
+      sum = comb::AddOp::create(builder, loc, sum, extended);
+    }
+
+    // Wrap back into Moore type (unsigned — CountOnes result is never signed).
+    return moore::FromBuiltinIntOp::create(builder, loc, sum);
   }
 
   // Real math functions (all take 1 real argument)

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -38,6 +38,30 @@ static FVInt convertSVIntToFVInt(const slang::SVInt &svint) {
   return FVInt(APInt(svint.getBitWidth(), value));
 }
 
+/// Check if a Moore integer value contains any unknown (x/z) bits.
+/// Returns a Moore i1 result: 1 if any bit is unknown, 0 otherwise.
+static Value getIsUnknown(OpBuilder &builder, Location loc, Value value,
+                          moore::IntType valTy, MLIRContext *ctx) {
+  Value bitVal = value;
+  if (valTy.getWidth() > 1) {
+    auto mooreI1Type = moore::IntType::get(ctx, 1, valTy.getDomain());
+    bitVal = moore::ReduceXorOp::create(builder, loc, mooreI1Type, value);
+  }
+  auto xType = moore::IntType::get(ctx, 1, moore::Domain::FourValued);
+  auto xConst =
+      moore::ConstantOp::create(builder, loc, xType, FVInt::getAllX(1));
+  return moore::CaseEqOp::create(builder, loc, bitVal, xConst).getResult();
+}
+
+/// Coerce a Moore integer value to a builtin integer, handling four-valued
+/// inputs by first mapping x/z to 0 via LogicToIntOp.
+static Value coerceToBuiltinInt(OpBuilder &builder, Location loc, Value value,
+                                moore::IntType valTy) {
+  if (valTy.getDomain() == moore::Domain::FourValued)
+    value = builder.createOrFold<moore::LogicToIntOp>(loc, value);
+  return builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
+}
+
 /// Map an index into an array, with bounds `range`, to a bit offset of the
 /// underlying bit storage. This is a dynamic version of
 /// `slang::ConstantRange::translateIndex`.
@@ -3281,17 +3305,7 @@ Value Context::convertSystemCall(
       mlir::emitError(loc) << "expected integer argument for `$isunknown`";
       return {};
     }
-    Value bitVal = value;
-    if (valTy.getWidth() > 1) {
-      auto mooreI1Type =
-          moore::IntType::get(getContext(), 1, valTy.getDomain());
-      bitVal = moore::ReduceXorOp::create(builder, loc, mooreI1Type, value);
-    }
-    auto xType =
-        moore::IntType::get(getContext(), 1, moore::Domain::FourValued);
-    auto xValue = FVInt::getAllX(1);
-    auto xConst = moore::ConstantOp::create(builder, loc, xType, xValue);
-    return moore::CaseEqOp::create(builder, loc, bitVal, xConst).getResult();
+    return getIsUnknown(builder, loc, value, valTy, getContext());
   }
 
   if (nameId == ksn::OneHot0 || nameId == ksn::OneHot) {
@@ -3310,30 +3324,14 @@ Value Context::convertSystemCall(
     // contains any unknown (x/z) bits. Detect and squash if four-valued.
     Value isUnknown;
     if (valTy.getDomain() == Domain::FourValued) {
-      Value bitVal = value;
-      if (valTy.getWidth() > 1) {
-        auto mooreI1Type =
-            moore::IntType::get(getContext(), 1, valTy.getDomain());
-        bitVal = moore::ReduceXorOp::create(builder, loc, mooreI1Type, value);
-      }
-      auto xType =
-          moore::IntType::get(getContext(), 1, moore::Domain::FourValued);
-      auto xConst =
-          moore::ConstantOp::create(builder, loc, xType, FVInt::getAllX(1));
       Value isUnknownMoore =
-          moore::CaseEqOp::create(builder, loc, bitVal, xConst).getResult();
+          getIsUnknown(builder, loc, value, valTy, getContext());
       isUnknown =
           builder.createOrFold<moore::ToBuiltinIntOp>(loc, isUnknownMoore);
     }
 
     // Coerce four-valued input to two-valued for the comb ops.
-    Value intVal;
-    if (valTy.getDomain() == Domain::FourValued) {
-      Value coerced = builder.createOrFold<moore::LogicToIntOp>(loc, value);
-      intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, coerced);
-    } else {
-      intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
-    }
+    Value intVal = coerceToBuiltinInt(builder, loc, value, valTy);
 
     // Compute onehot0: (value & (value - 1)) == 0
     auto one = hw::ConstantOp::create(builder, loc, intVal.getType(), 1);
@@ -3350,22 +3348,15 @@ Value Context::convertSystemCall(
       result = comb::AndOp::create(builder, loc, result, isNotZero);
     }
 
-    // Wrap back into Moore type.
-    result = moore::FromBuiltinIntOp::create(builder, loc, result);
-
     // If four-valued, squash to 0 when unknown bits exist.
     if (isUnknown) {
-      Value resultI1 = convertToI1(result);
       Value zeroI1 =
           hw::ConstantOp::create(builder, loc, builder.getI1Type(), 0);
-      Value squashed =
-          comb::MuxOp::create(builder, loc, isUnknown, zeroI1, resultI1);
-      Value squashedMoore =
-          moore::FromBuiltinIntOp::create(builder, loc, squashed);
-      return moore::IntToLogicOp::create(builder, loc, squashedMoore)
-          .getResult();
+      result = comb::MuxOp::create(builder, loc, isUnknown, zeroI1, result);
+      Value resultMoore = moore::FromBuiltinIntOp::create(builder, loc, result);
+      return moore::IntToLogicOp::create(builder, loc, resultMoore).getResult();
     }
-    return result;
+    return moore::FromBuiltinIntOp::create(builder, loc, result);
   }
 
   if (nameId == ksn::CountOnes) {
@@ -3380,13 +3371,7 @@ Value Context::convertSystemCall(
     }
 
     // Coerce four-valued input to two-valued for the comb ops.
-    Value intVal;
-    if (valTy.getDomain() == Domain::FourValued) {
-      Value coerced = builder.createOrFold<moore::LogicToIntOp>(loc, value);
-      intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, coerced);
-    } else {
-      intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
-    }
+    Value intVal = coerceToBuiltinInt(builder, loc, value, valTy);
 
     // Popcount: extract each bit, zero-extend to result width, and sum.
     auto builtinIntTy = cast<IntegerType>(intVal.getType());

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -675,7 +675,7 @@ module SampleValueBuiltins #() (
   // CHECK: [[B1:%.+]] = comb.extract [[DB]] from 1 : (i8) -> i1
   // CHECK: [[EXT1:%.+]] = comb.concat [[Z3]], [[B1]] : i3, i1
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int {{%.+}} : i4
-  // CHECK: [[SEXT:%.+]] = moore.sext [[RES_INT]] : i4 -> i32
+  // CHECK: [[SEXT:%.+]] = moore.zext [[RES_INT]] : i4 -> i32
   // CHECK: [[ZERO:%.+]] = moore.constant 0 : i32
   // CHECK: [[EQ:%.+]] = moore.eq [[SEXT]], [[ZERO]] : i32 -> i1
   countones_data:
@@ -691,7 +691,7 @@ module SampleValueBuiltins #() (
   // CHECK: [[EXT1:%.+]] = comb.concat [[Z3]], [[B1]] : i3, i1
   // CHECK: comb.add
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int {{%.+}} : i4
-  // CHECK: [[SEXT:%.+]] = moore.sext [[RES_INT]] : i4 -> i32
+  // CHECK: [[SEXT:%.+]] = moore.zext [[RES_INT]] : i4 -> i32
   // CHECK: [[ZERO:%.+]] = moore.constant 0 : i32
   // CHECK: [[EQ:%.+]] = moore.eq [[SEXT]], [[ZERO]] : i32 -> i1
   countones_bit_data:

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -603,15 +603,12 @@ module SampleValueBuiltins #() (
   // CHECK: [[ZERO:%.+]] = hw.constant 0 : i8
   // CHECK: [[EQ:%.+]] = comb.icmp eq [[AND]], [[ZERO]] : i8
   // CHECK: [[EQ_INT:%.+]] = moore.from_builtin_int [[EQ]] : i1
-  // CHECK: [[EQ_LOGIC:%.+]] = moore.int_to_logic [[EQ_INT]] : i1
-  // CHECK: [[EQ_L2I:%.+]] = moore.logic_to_int [[EQ_LOGIC]] : l1
-  // CHECK: [[EQ_BUILTIN:%.+]] = moore.to_builtin_int [[EQ_L2I]] : i1
+  // CHECK: [[EQ_BUILTIN:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
   // CHECK: [[FALSE:%.+]] = hw.constant false
   // CHECK: [[MUX:%.+]] = comb.mux [[ISUNKNOWN_I1]], [[FALSE]], [[EQ_BUILTIN]] : i1
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int [[MUX]] : i1
   // CHECK: [[RES_LOGIC:%.+]] = moore.int_to_logic [[RES_INT]] : i1
-  // CHECK: [[RES_L2I:%.+]] = moore.logic_to_int [[RES_LOGIC]] : l1
-  // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_L2I]] : i1
+  // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_INT]] : i1
   // CHECK: ltl.clock [[RES_BUILTIN]]
   onehot0_data: assert property (@(posedge clk_i) $onehot0(data_i));
 
@@ -631,15 +628,12 @@ module SampleValueBuiltins #() (
   // CHECK: [[NE:%.+]] = comb.icmp ne [[DB]], [[ZERO]] : i8
   // CHECK: [[AND2:%.+]] = comb.and [[EQ]], [[NE]] : i1
   // CHECK: [[RES_INT_2:%.+]] = moore.from_builtin_int [[AND2]] : i1
-  // CHECK: [[RES_LOGIC_2:%.+]] = moore.int_to_logic [[RES_INT_2]] : i1
-  // CHECK: [[RES_L2I_2:%.+]] = moore.logic_to_int [[RES_LOGIC_2]] : l1
-  // CHECK: [[RES_BUILTIN_2:%.+]] = moore.to_builtin_int [[RES_L2I_2]] : i1
+  // CHECK: [[RES_BUILTIN_2:%.+]] = moore.to_builtin_int [[RES_INT_2]] : i1
   // CHECK: [[FALSE:%.+]] = hw.constant false
   // CHECK: [[MUX:%.+]] = comb.mux [[ISUNKNOWN_I1]], [[FALSE]], [[RES_BUILTIN_2]] : i1
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int [[MUX]] : i1
   // CHECK: [[RES_LOGIC:%.+]] = moore.int_to_logic [[RES_INT]] : i1
-  // CHECK: [[RES_L2I:%.+]] = moore.logic_to_int [[RES_LOGIC]] : l1
-  // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_L2I]] : i1
+  // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_INT]] : i1
   // CHECK: ltl.clock [[RES_BUILTIN]]
   onehot_data: assert property (@(posedge clk_i) $onehot(data_i));
 
@@ -671,6 +665,37 @@ module SampleValueBuiltins #() (
   // CHECK: ltl.clock [[RES_BUILTIN]]
   onehot_bit_data: assert property (@(posedge clk_i) $onehot(data_bit_i));
 
+  // CHECK: moore.procedure always {
+  // CHECK: [[D:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK: [[D_L2I:%.+]] = moore.logic_to_int [[D]] : l8
+  // CHECK: [[DB:%.+]] = moore.to_builtin_int [[D_L2I]] : i8
+  // CHECK: [[Z3:%.+]] = hw.constant 0 : i3
+  // CHECK: [[B0:%.+]] = comb.extract [[DB]] from 0 : (i8) -> i1
+  // CHECK: [[EXT0:%.+]] = comb.concat [[Z3]], [[B0]] : i3, i1
+  // CHECK: [[B1:%.+]] = comb.extract [[DB]] from 1 : (i8) -> i1
+  // CHECK: [[EXT1:%.+]] = comb.concat [[Z3]], [[B1]] : i3, i1
+  // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int {{%.+}} : i4
+  // CHECK: [[SEXT:%.+]] = moore.sext [[RES_INT]] : i4 -> i32
+  // CHECK: [[ZERO:%.+]] = moore.constant 0 : i32
+  // CHECK: [[EQ:%.+]] = moore.eq [[SEXT]], [[ZERO]] : i32 -> i1
+  countones_data:
+    assert property (@(posedge clk_i) $countones(data_i) == 0);
+
+  // CHECK: moore.procedure always {
+  // CHECK: [[D:%.+]] = moore.read [[DATABITWIRE]] : <i8>
+  // CHECK: [[DB:%.+]] = moore.to_builtin_int [[D]] : i8
+  // CHECK: [[Z3:%.+]] = hw.constant 0 : i3
+  // CHECK: [[B0:%.+]] = comb.extract [[DB]] from 0 : (i8) -> i1
+  // CHECK: [[EXT0:%.+]] = comb.concat [[Z3]], [[B0]] : i3, i1
+  // CHECK: [[B1:%.+]] = comb.extract [[DB]] from 1 : (i8) -> i1
+  // CHECK: [[EXT1:%.+]] = comb.concat [[Z3]], [[B1]] : i3, i1
+  // CHECK: comb.add
+  // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int {{%.+}} : i4
+  // CHECK: [[SEXT:%.+]] = moore.sext [[RES_INT]] : i4 -> i32
+  // CHECK: [[ZERO:%.+]] = moore.constant 0 : i32
+  // CHECK: [[EQ:%.+]] = moore.eq [[SEXT]], [[ZERO]] : i32 -> i1
+  countones_bit_data:
+    assert property (@(posedge clk_i) $countones(data_bit_i) == 0);
 endmodule
 
 // CHECK-LABEL: func.func private @StringBuiltins(

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -602,10 +602,8 @@ module SampleValueBuiltins #() (
   // CHECK: [[AND:%.+]] = comb.and [[DB]], [[SUB]] : i8
   // CHECK: [[ZERO:%.+]] = hw.constant 0 : i8
   // CHECK: [[EQ:%.+]] = comb.icmp eq [[AND]], [[ZERO]] : i8
-  // CHECK: [[EQ_INT:%.+]] = moore.from_builtin_int [[EQ]] : i1
-  // CHECK: [[EQ_BUILTIN:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
   // CHECK: [[FALSE:%.+]] = hw.constant false
-  // CHECK: [[MUX:%.+]] = comb.mux [[ISUNKNOWN_I1]], [[FALSE]], [[EQ_BUILTIN]] : i1
+  // CHECK: [[MUX:%.+]] = comb.mux [[ISUNKNOWN_I1]], [[FALSE]], [[EQ]] : i1
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int [[MUX]] : i1
   // CHECK: [[RES_LOGIC:%.+]] = moore.int_to_logic [[RES_INT]] : i1
   // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_INT]] : i1
@@ -627,10 +625,8 @@ module SampleValueBuiltins #() (
   // CHECK: [[EQ:%.+]] = comb.icmp eq [[AND]], [[ZERO]] : i8
   // CHECK: [[NE:%.+]] = comb.icmp ne [[DB]], [[ZERO]] : i8
   // CHECK: [[AND2:%.+]] = comb.and [[EQ]], [[NE]] : i1
-  // CHECK: [[RES_INT_2:%.+]] = moore.from_builtin_int [[AND2]] : i1
-  // CHECK: [[RES_BUILTIN_2:%.+]] = moore.to_builtin_int [[RES_INT_2]] : i1
   // CHECK: [[FALSE:%.+]] = hw.constant false
-  // CHECK: [[MUX:%.+]] = comb.mux [[ISUNKNOWN_I1]], [[FALSE]], [[RES_BUILTIN_2]] : i1
+  // CHECK: [[MUX:%.+]] = comb.mux [[ISUNKNOWN_I1]], [[FALSE]], [[AND2]] : i1
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int [[MUX]] : i1
   // CHECK: [[RES_LOGIC:%.+]] = moore.int_to_logic [[RES_INT]] : i1
   // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_INT]] : i1


### PR DESCRIPTION
Squash to 2 valued and then count in naive way (given this is for
testing/simulation goals, kept the sum direct/naive). Used the
minimum-width needed as the type here.

Using the minimum width resulted in some type mismatches due to
different type used by slang constant. To address this, changed
the convertAssertionCallExpression to use materializeConversion for
all returned system call values.

As part of this also noticed there were redundant conversions being
inserted. Introduced castToTwoValued to ensure system functions natively
returning standard SV two-valued types do not undergo redundant 4-valued
logic domain round-tripping. (could also perhaps have relied on
canonicalize or createOrFold, but seemed local enough).

Assisted-by: Antigravity:Gemini
