### PR TITLE
[FIRRTLToHW] Support printing SimulationTime in lower-to-core

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2929,9 +2929,8 @@ FIRRTLLowering::lowerSimFormatString(StringRef originalFormatString,
                 return success();
               })
               .template Case<TimeOp>([&](auto) {
-                emitError(builder.getLoc(), "lower-to-core does not support "
-                                            "{{SimulationTime}} in printf");
-                return failure();
+                fragments.push_back(sim::FormatCurrentTimeOp::create(builder));
+                return success();
               })
               .Default([&](auto) {
                 emitError(builder.getLoc(), "has a substitution with "

--- a/test/Conversion/FIRRTLToHW/lower-to-core-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-core-errors.mlir
@@ -1,20 +1,5 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(lower-firrtl-to-hw{lower-to-core=true})' --verify-diagnostics --split-input-file %s
 
-firrtl.circuit "time_printf" {
-  firrtl.module @time_printf(
-      in %clock: !firrtl.clock,
-      in %enable: !firrtl.uint<1>) {
-    %time = firrtl.fstring.time : !firrtl.fstring
-    // expected-error @+2 {{lower-to-core does not support {{SimulationTime}} in printf}}
-    // expected-error @below {{'firrtl.printf' op LowerToHW couldn't handle this operation}}
-    firrtl.printf %clock, %enable, "{{}}\0A"(%time)
-        : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring
-    firrtl.skip
-  }
-}
-
-// -----
-
 firrtl.circuit "fflush_unsupported" {
   firrtl.module @fflush_unsupported(
       in %clock: !firrtl.clock,

--- a/test/Conversion/FIRRTLToHW/lower-to-core.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-core.mlir
@@ -52,6 +52,17 @@ firrtl.circuit "LowerToCore" {
     firrtl.fprintf %clock, %enable, "out%d.txt"(%x), "value=%d @ {{}}\0A"(%x, %hier)
         : !firrtl.clock, !firrtl.uint<1>, !firrtl.sint<4>, !firrtl.sint<4>, !firrtl.fstring
 
+    // CHECK: [[TIME:%.+]] = sim.fmt.current_time
+    // CHECK: [[LIT4:%.+]] = sim.fmt.literal "\0A"
+    // CHECK: [[MSG:%.+]] = sim.fmt.concat ([[TIME]], [[LIT4]])
+    // CHECK: [[STDERR:%.+]] = sim.stderr_stream
+    // CHECK: sim.triggered %clock if %enable {
+    // CHECK-NEXT:   sim.proc.print [[MSG]] to [[STDERR]]
+    // CHECK-NEXT: }
+    %time = firrtl.fstring.time : !firrtl.fstring
+    firrtl.printf %clock, %enable, "{{}}\0A"(%time)
+        : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring
+
     firrtl.skip
   }
 

--- a/test/firtool/lower-to-core.fir
+++ b/test/firtool/lower-to-core.fir
@@ -12,6 +12,7 @@ circuit LowerToCore:
     printf(clock, enable, "value=%d\n", x)
     fprintf(clock, enable, "out.txt", "value=%d\n", x)
     fprintf(clock, enable, "out%d.txt", x, "value=%d\n", x)
+    printf(clock, enable, "{{SimulationTime}}")
 
 ; CHECK-LABEL: hw.module @LowerToCore
 ; CHECK-DAG: [[LITFILE1:%.+]] = sim.fmt.literal "out"
@@ -35,6 +36,10 @@ circuit LowerToCore:
 ; CHECK: sim.triggered %clock if %enable {
 ; CHECK-NEXT:   [[FILE2:%.+]] = sim.get_file [[FMTFILE2]]
 ; CHECK-NEXT:   sim.proc.print [[MSG]] to [[FILE2]]
+; CHECK-NEXT: }
+; CHECK: [[TIME:%.+]] = sim.fmt.current_time
+; CHECK: sim.triggered %clock if %enable {
+; CHECK-NEXT:   sim.proc.print [[TIME]] to [[STDERR]]
 ; CHECK-NEXT: }
 ; CHECK-NOT: sv.assert
 ; CHECK-NOT: sv.fwrite


### PR DESCRIPTION
Support printing SimulationTime in lower-to-core