### PR TITLE
[RFC][Sim] Add declarations and reads for externally controlled configuration bits

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -45,6 +45,36 @@ def DPIDirection : I32EnumAttr<"DPIDirection",
 // Simulation Operations
 //===----------------------------------------------------------------------===//
 
+def ConfigDeclOp : SimOp<"config.decl",
+    [Symbol, HasParent<"mlir::ModuleOp">]> {
+  let summary = "Declare an externally controlled simulation value";
+  let description = [{
+    Declares a named configuration value for simulation-related behavior. The
+    concrete mechanism used to override the value is backend-defined and may be
+    a preprocessor macro, a plusarg, a parameter, or another backend-specific
+    facility. If no override is provided, the configuration value has the given
+    default value.
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name, BoolAttr:$defaultValue);
+  let assemblyFormat = "$sym_name `default` $defaultValue attr-dict";
+}
+
+def ConfigGetOp : SimOp<"config.get",
+    [Pure, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Read an externally controlled simulation value";
+  let description = [{
+    Reads a named configuration value declared by `sim.config.decl`. The result
+    is an SSA value that can be used to guard simulation, verification, or other
+    behavior. The operation does not prescribe whether the value is provided by
+    a compile-time, elaboration-time, or runtime mechanism.
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$config);
+  let results = (outs I1:$result);
+  let assemblyFormat = "$config attr-dict";
+}
+
 def PlusArgsTestOp : SimOp<"plusargs.test", [Pure]> {
   let summary = "SystemVerilog `$test$plusargs` call";
 

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -205,6 +205,18 @@ LogicalResult DPIFuncOp::verify() {
 }
 
 LogicalResult
+sim::ConfigGetOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto referencedOp =
+      symbolTable.lookupNearestSymbolFrom(*this, getConfigAttr());
+  if (!referencedOp)
+    return emitError("cannot find config declaration '") << getConfig() << "'";
+  if (!isa<sim::ConfigDeclOp>(referencedOp))
+    return emitError("config must reference 'sim.config.decl' but got '")
+           << referencedOp->getName() << "'";
+  return success();
+}
+
+LogicalResult
 sim::DPICallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto referencedOp =
       symbolTable.lookupNearestSymbolFrom(*this, getCalleeAttr());

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -8,6 +8,19 @@ hw.module @plusargs_value() {
   %1, %2 = sim.plusargs.value "bar" : i5
 }
 
+// CHECK-LABEL: sim.config.decl @PRINTF_COND default true
+sim.config.decl @PRINTF_COND default true
+// CHECK-LABEL: sim.config.decl @STOP_COND default false
+sim.config.decl @STOP_COND default false
+
+// CHECK-LABEL: hw.module @config_get
+hw.module @config_get() {
+  // CHECK: sim.config.get @PRINTF_COND
+  %0 = sim.config.get @PRINTF_COND
+  // CHECK: sim.config.get @STOP_COND
+  %1 = sim.config.get @STOP_COND
+}
+
 // CHECK-LABEL: sim.func.dpi @dpi(out arg0 : i1, in %arg1 : i1, return ret : i1)
 sim.func.dpi @dpi(out arg0: i1, in %arg1: i1, return ret: i1)
 // CHECK-LABEL: sim.func.dpi @dpi_inout(in %arg0 : i1, inout %arg1 : i1)

--- a/test/Dialect/Sim/sim-errors.mlir
+++ b/test/Dialect/Sim/sim-errors.mlir
@@ -140,3 +140,19 @@ hw.module @queue_from_array(in %uparr: !hw.array<5xi33>) {
   // expected-error @below {{'sim.queue.from_array' op sim::Queue element type 'i32' doesn't match hw::ArrayType element type 'i33'}}
   sim.queue.from_array %uparr : !hw.array<5xi33> -> <i32, 0>
 }
+
+// -----
+
+hw.module @config_get() {
+  // expected-error @below {{cannot find config declaration 'PRINTF_COND'}}
+  sim.config.get @PRINTF_COND
+}
+
+// -----
+
+sv.macro.decl @PRINTF_COND 
+
+hw.module @config_get() {
+  // expected-error @below {{config must reference 'sim.config.decl' but got 'sv.macro.decl'}}
+  sim.config.get @PRINTF_COND
+}


### PR DESCRIPTION
I think we need a mechanism to replace some of the functionality of the SV macros in FIRRTLToHW. From my observation, STOP_COND and PRINTF_COND behave like configurations that allow external injection, and I want to introduce this abstraction into the Sim dialect.

I've implemented a preliminary approach to naming and designing this Op.
