### PR TITLE
[OM] Use FlatSymbolRefAttr for object class names

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -188,7 +188,7 @@ def ObjectOp : OMOp<"object", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
 ]> {
   let arguments = (ins
-    SymbolNameAttr:$className,
+    FlatSymbolRefAttr:$className,
     Variadic<AnyType>:$actualParams
   );
 
@@ -220,7 +220,7 @@ def ElaboratedObjectOp : OMOp<"elaborated_object", [
   }];
 
   let arguments = (ins
-    SymbolNameAttr:$className,
+    FlatSymbolRefAttr:$className,
     Variadic<AnyType>:$fieldValues
   );
 

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -1011,7 +1011,8 @@ circt::om::Evaluator::evaluateElaboratedObject(ElaboratedObjectOp op,
   if (object->isFullyEvaluated())
     return objectValue;
 
-  auto classLike = symbolTable.lookup<ClassLike>(op.getClassNameAttr().getAttr());
+  auto classLike =
+      symbolTable.lookup<ClassLike>(op.getClassNameAttr().getAttr());
   if (!classLike)
     return symbolTable.getOp()->emitError("unknown class name ")
            << op.getClassNameAttr();

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -996,8 +996,8 @@ circt::om::Evaluator::evaluateObjectInstance(ObjectOp op,
       createParametersFromOperands(op.getOperands(), actualParams, loc);
   if (failed(params))
     return failure();
-  return evaluateObjectInstance(op.getClassNameAttr(), params.value(), loc,
-                                {op, actualParams});
+  return evaluateObjectInstance(op.getClassNameAttr().getAttr(), params.value(),
+                                loc, {op, actualParams});
 }
 
 FailureOr<evaluator::EvaluatorValuePtr>
@@ -1011,7 +1011,7 @@ circt::om::Evaluator::evaluateElaboratedObject(ElaboratedObjectOp op,
   if (object->isFullyEvaluated())
     return objectValue;
 
-  auto classLike = symbolTable.lookup<ClassLike>(op.getClassNameAttr());
+  auto classLike = symbolTable.lookup<ClassLike>(op.getClassNameAttr().getAttr());
   if (!classLike)
     return symbolTable.getOp()->emitError("unknown class name ")
            << op.getClassNameAttr();

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -546,7 +546,8 @@ void circt::om::ObjectOp::build(::mlir::OpBuilder &odsBuilder,
   return build(odsBuilder, odsState,
                om::ClassType::get(odsBuilder.getContext(),
                                   mlir::FlatSymbolRefAttr::get(classOp)),
-               mlir::FlatSymbolRefAttr::get(classOp.getNameAttr()), actualParams);
+               mlir::FlatSymbolRefAttr::get(classOp.getNameAttr()),
+               actualParams);
 }
 
 static FailureOr<ClassLike>
@@ -568,8 +569,9 @@ verifyClassLikeSymbolUser(Operation *op, SymbolTableCollection &symbolTable,
 
 LogicalResult
 circt::om::ObjectOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  auto classDef = verifyClassLikeSymbolUser(
-      (*this), symbolTable, getResult().getType(), getClassNameAttr().getAttr());
+  auto classDef =
+      verifyClassLikeSymbolUser((*this), symbolTable, getResult().getType(),
+                                getClassNameAttr().getAttr());
   if (failed(classDef))
     return failure();
 
@@ -648,8 +650,9 @@ void circt::om::ElaboratedObjectOp::build(OpBuilder &odsBuilder,
 
 LogicalResult circt::om::ElaboratedObjectOp::verifySymbolUses(
     SymbolTableCollection &symbolTable) {
-  auto classDef = verifyClassLikeSymbolUser(
-      (*this), symbolTable, getResult().getType(), getClassNameAttr().getAttr());
+  auto classDef =
+      verifyClassLikeSymbolUser((*this), symbolTable, getResult().getType(),
+                                getClassNameAttr().getAttr());
   if (failed(classDef))
     return failure();
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -546,7 +546,7 @@ void circt::om::ObjectOp::build(::mlir::OpBuilder &odsBuilder,
   return build(odsBuilder, odsState,
                om::ClassType::get(odsBuilder.getContext(),
                                   mlir::FlatSymbolRefAttr::get(classOp)),
-               classOp.getNameAttr(), actualParams);
+               mlir::FlatSymbolRefAttr::get(classOp.getNameAttr()), actualParams);
 }
 
 static FailureOr<ClassLike>
@@ -569,7 +569,7 @@ verifyClassLikeSymbolUser(Operation *op, SymbolTableCollection &symbolTable,
 LogicalResult
 circt::om::ObjectOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto classDef = verifyClassLikeSymbolUser(
-      (*this), symbolTable, getResult().getType(), getClassNameAttr());
+      (*this), symbolTable, getResult().getType(), getClassNameAttr().getAttr());
   if (failed(classDef))
     return failure();
 
@@ -642,13 +642,14 @@ void circt::om::ElaboratedObjectOp::build(OpBuilder &odsBuilder,
                om::ClassType::get(
                    odsBuilder.getContext(),
                    mlir::FlatSymbolRefAttr::get(classOp.getSymNameAttr())),
-               classOp.getSymNameAttr(), fieldValues);
+               mlir::FlatSymbolRefAttr::get(classOp.getSymNameAttr()),
+               fieldValues);
 }
 
 LogicalResult circt::om::ElaboratedObjectOp::verifySymbolUses(
     SymbolTableCollection &symbolTable) {
   auto classDef = verifyClassLikeSymbolUser(
-      (*this), symbolTable, getResult().getType(), getClassNameAttr());
+      (*this), symbolTable, getResult().getType(), getClassNameAttr().getAttr());
   if (failed(classDef))
     return failure();
 

--- a/lib/Dialect/OM/OMReductions.cpp
+++ b/lib/Dialect/OM/OMReductions.cpp
@@ -147,7 +147,7 @@ struct OMClassFieldPruner : public OpReduction<ClassOp> {
 
     moduleOp.walk([&](ObjectOp objectOp) {
       // Check if this object is an instance of our class
-      if (objectOp.getClassNameAttr() != classOp.getSymNameAttr())
+      if (objectOp.getClassNameAttr().getAttr() != classOp.getSymNameAttr())
         return;
 
       // Check all object field uses of this object
@@ -234,7 +234,7 @@ struct OMClassParameterPruner : public OpReduction<ClassOp> {
     SmallVector<ObjectOp> objectsToUpdate;
     auto moduleOp = classOp->getParentOfType<mlir::ModuleOp>();
     moduleOp.walk([&](ObjectOp objectOp) {
-      if (objectOp.getClassNameAttr() == classOp.getSymNameAttr())
+      if (objectOp.getClassNameAttr().getAttr() == classOp.getSymNameAttr())
         objectsToUpdate.push_back(objectOp);
     });
 
@@ -290,7 +290,7 @@ struct OMUnusedClassRemover : public OpReduction<ClassOp> {
 
     // Check if this class is instantiated via om.object anywhere
     auto result = moduleOp.walk([&](ObjectOp objectOp) {
-      if (objectOp.getClassNameAttr() == classOp.getSymNameAttr())
+      if (objectOp.getClassNameAttr().getAttr() == classOp.getSymNameAttr())
         return WalkResult::interrupt();
       return WalkResult::advance();
     });

--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -53,7 +53,7 @@ struct ObjectOpInliningPattern : public OpRewritePattern<ObjectOp> {
 
   LogicalResult matchAndRewrite(ObjectOp objOp,
                                 PatternRewriter &rewriter) const override {
-    auto classLike = symTable.lookup<ClassLike>(objOp.getClassNameAttr());
+    auto classLike = symTable.lookup<ClassLike>(objOp.getClassNameAttr().getAttr());
     assert(classLike);
 
     // External classes cannot be elaborated; replace with unknown values.
@@ -117,7 +117,7 @@ struct EvaluateObjectField : OpRewritePattern<ObjectFieldOp> {
       return failure();
 
     auto classLike =
-        symTable.lookup<ClassLike>(elaboratedOp.getClassNameAttr());
+        symTable.lookup<ClassLike>(elaboratedOp.getClassNameAttr().getAttr());
     assert(classLike);
 
     // Find the field index and get the corresponding value.

--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -53,7 +53,8 @@ struct ObjectOpInliningPattern : public OpRewritePattern<ObjectOp> {
 
   LogicalResult matchAndRewrite(ObjectOp objOp,
                                 PatternRewriter &rewriter) const override {
-    auto classLike = symTable.lookup<ClassLike>(objOp.getClassNameAttr().getAttr());
+    auto classLike =
+        symTable.lookup<ClassLike>(objOp.getClassNameAttr().getAttr());
     assert(classLike);
 
     // External classes cannot be elaborated; replace with unknown values.

--- a/lib/Dialect/OM/Transforms/LinkModules.cpp
+++ b/lib/Dialect/OM/Transforms/LinkModules.cpp
@@ -112,10 +112,11 @@ void ModuleInfo::postProcess(const SymMappingTy &symMapping) {
           classOp.replaceFieldTypes(replacer);
         })
         .Case<ObjectOp, ElaboratedObjectOp>([&](auto objectLike) {
-          auto it = symMapping.find({module, objectLike.getClassNameAttr()});
+          auto it = symMapping.find(
+              {module, objectLike.getClassNameAttr().getAttr()});
           // Update its class name if changed.
           if (it != symMapping.end())
-            objectLike.setClassNameAttr(it->second);
+            objectLike.setClassNameAttr(FlatSymbolRefAttr::get(it->second));
           replacer.replaceElementsIn(objectLike, false, false, true);
         });
 

--- a/test/Dialect/OM/symbol-dce.mlir
+++ b/test/Dialect/OM/symbol-dce.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt -symbol-dce %s | FileCheck %s
+
+// CHECK-LABEL: om.class private @Referenced
+// CHECK-NOT:   om.class private @Unreferenced
+om.class private @Referenced() -> () {
+  om.class.fields
+}
+
+om.class private @Unreferenced() -> () {
+  om.class.fields
+}
+
+// CHECK-LABEL: om.class @Top
+// CHECK-NEXT: om.object @Referenced
+// CHECK-NEXT: om.elaborated_object @Referenced
+om.class @Top() -> () {
+  %0 = om.object @Referenced() : () -> !om.class.type<@Referenced>
+  %1 = om.elaborated_object @Referenced() : () -> !om.class.type<@Referenced>
+  om.class.fields
+}
+


### PR DESCRIPTION
ObjectOp and ElaboratedObjectOp refer to OM class-like symbols through their
className attribute, but this was previously stored as SymbolNameAttr. This
prevented getSymbolUses from recognizing the reference, so SymbolDCE could
remove classes that were still used by object operations.

Change the attribute type to FlatSymbolRefAttr, update the affected users.
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
