### PR TITLE
[Moore][Sim][SV] Add $strobe[boh] lowering via sim.defer

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3053,6 +3053,42 @@ def DisplayBIOp : Builtin<"display"> {
   let assemblyFormat = "$message attr-dict";
 }
 
+def StrobeYieldOp : MooreOp<"strobe_yield", [
+  Pure, Terminator, HasParent<"StrobeBIOp">,
+]> {
+  let summary = "terminates a moore.builtin.strobe body, yielding its message";
+  let description = [{
+    Terminates the `body` region of a `moore.builtin.strobe` op, yielding the
+    `!moore.format_string` to print once the region is executed. See
+    `moore.builtin.strobe` for the scope of the Postponed region guarantee
+    this is meant to support.
+  }];
+  let arguments = (ins FormatStringType:$message);
+  let assemblyFormat = "$message attr-dict";
+}
+
+def StrobeBIOp : Builtin<"strobe"> {
+  let summary = "Display formatted values at end of simulation timestep";
+  let description = [{
+    Schedules a display of the formatted message in the Postponed region of
+    the current simulation time, after all Active and NBA updates have
+    settled. The `body` region is built lazily, at the point where the
+    message is needed, rather than at the original `$strobe` call site, so
+    that the ops that read variables or signals while building the message
+    can be relocated as a single, indivisible unit relative to surrounding ops.
+    Corresponds to `$strobe[boh]` system task.
+
+    See IEEE 1800-2017 § 21.2.2 "Strobed monitoring".
+  }];
+  let arguments = (ins);
+  let results = (outs);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "$body attr-dict";
+  let extraClassDeclaration = [{
+    Block *getBodyBlock() { return &getBody().front(); }
+  }];
+}
+
 def SeverityInfo : I32EnumAttrCase<"Info", 0, "info">;
 def SeverityWarning : I32EnumAttrCase<"Warning", 1, "warning">;
 def SeverityError : I32EnumAttrCase<"Error", 2, "error">;

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -528,6 +528,17 @@ def WriteOp : SVOp<"write", [ProceduralOp]> {
   }];
 }
 
+def StrobeOp : SVOp<"strobe", [ProceduralOp]> {
+  let summary = "'$strobe' statement";
+  let arguments = (ins StrAttr:$format_string,
+                        Variadic<AnyType>:$substitutions);
+  let results = (outs);
+  let assemblyFormat = [{
+    $format_string attr-dict (`(` $substitutions^ `)` `:`
+    qualified(type($substitutions)))?
+  }];
+}
+
 def FWriteOp : SVOp<"fwrite", [ProceduralOp]> {
   let summary = "'$fwrite' statement";
 

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -40,7 +40,7 @@ public:
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
             // Other Statements.
             AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
-            WriteOp, FWriteOp, FFlushOp, SystemFunctionOp, VerbatimOp,
+            WriteOp, StrobeOp, FWriteOp, FFlushOp, SystemFunctionOp, VerbatimOp,
             MacroRefOp, FuncCallOp, FuncCallProceduralOp, ReturnOp, IncludeOp,
             MacroErrorOp,
             // Type declarations.
@@ -137,6 +137,7 @@ public:
   HANDLE(ReleaseOp, Unhandled);
   HANDLE(AliasOp, Unhandled);
   HANDLE(WriteOp, Unhandled);
+  HANDLE(StrobeOp, Unhandled);
   HANDLE(FWriteOp, Unhandled);
   HANDLE(FFlushOp, Unhandled);
   HANDLE(SystemFunctionOp, Unhandled);

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1213,6 +1213,20 @@ def TriggeredOp : SimOp<"triggered", [
   ];
 }
 
+def DeferOp : SimOp<"defer", [
+    SingleBlock, NoTerminator, ProceduralOp, ProceduralRegion]> {
+  let summary = "Execute a region at the end of the current simulation time";
+  let description = [{
+    Schedules its body for execution in the Postponed region of the current
+    simulation time.
+  }];
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "$body attr-dict";
+  let extraClassDeclaration = [{
+    Block *getBodyBlock() { return &getBody().front(); }
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // File I/O
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4114,6 +4114,7 @@ private:
   emitFormattedWriteLikeOp(OpTy op, StringRef callee, StringRef formatString,
                            ValueRange substitutions, EmitPrefixFn emitPrefix);
   LogicalResult visitSV(WriteOp op);
+  LogicalResult visitSV(StrobeOp op);
   LogicalResult visitSV(FWriteOp op);
   LogicalResult visitSV(FFlushOp op);
   LogicalResult visitSV(VerbatimOp op);
@@ -4679,6 +4680,12 @@ LogicalResult StmtEmitter::emitFormattedWriteLikeOp(OpTy op, StringRef callee,
 
 LogicalResult StmtEmitter::visitSV(WriteOp op) {
   return emitFormattedWriteLikeOp(op, "$write(", op.getFormatString(),
+                                  op.getSubstitutions(),
+                                  [&](SmallPtrSetImpl<Operation *> &) {});
+}
+
+LogicalResult StmtEmitter::visitSV(StrobeOp op) {
+  return emitFormattedWriteLikeOp(op, "$strobe(", op.getFormatString(),
                                   op.getSubstitutions(),
                                   [&](SmallPtrSetImpl<Operation *> &) {});
 }

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1054,13 +1054,15 @@ struct StmtVisitor {
     }
 
     // Display and Write Tasks (`$display[boh]?` or `$write[boh]?` or
-    // `$fdisplay[boh]?` or `$fwrite[boh]?` or `$swrite[boh]` or `$sformat`)
+    // `$fdisplay[boh]?` or `$fwrite[boh]?` or `$sformat` or
+    // `$swrite[boh]`or `$strobe[boh]?`)
 
     using moore::IntFormat;
     bool isDisplay = false;
     bool isFDisplay = false;
     bool isSWrite = false;
     bool isSFormat = false;
+    bool isStrobe = false;
     bool appendNewline = false;
     IntFormat defaultFormat = IntFormat::Decimal;
     switch (nameId) {
@@ -1150,6 +1152,25 @@ struct StmtVisitor {
       isSWrite = true;
       defaultFormat = IntFormat::HexLower;
       break;
+    case ksn::Strobe:
+      isStrobe = true;
+      appendNewline = true;
+      break;
+    case ksn::StrobeB:
+      isStrobe = true;
+      appendNewline = true;
+      defaultFormat = IntFormat::Binary;
+      break;
+    case ksn::StrobeO:
+      isStrobe = true;
+      appendNewline = true;
+      defaultFormat = IntFormat::Octal;
+      break;
+    case ksn::StrobeH:
+      isStrobe = true;
+      appendNewline = true;
+      defaultFormat = IntFormat::HexLower;
+      break;
     default:
       break;
     }
@@ -1219,6 +1240,23 @@ struct StmtVisitor {
         return true;
       }
       return failure();
+    }
+
+    if (isStrobe) {
+      OpBuilder::InsertionGuard guard(builder);
+      auto strobeOp = moore::StrobeBIOp::create(builder, loc);
+      auto *body = builder.createBlock(&strobeOp.getBody());
+      builder.setInsertionPointToEnd(body);
+      auto message =
+          context.convertFormatString(args, loc, defaultFormat, appendNewline);
+      if (failed(message)) {
+        strobeOp.erase();
+        return failure();
+      }
+      if (*message == Value{})
+        *message = moore::FormatLiteralOp::create(builder, loc, "");
+      moore::StrobeYieldOp::create(builder, loc, *message);
+      return true;
     }
 
     // Severity Tasks

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2984,6 +2984,29 @@ struct FDisplayBIOpConversion : public OpConversionPattern<FDisplayBIOp> {
   }
 };
 
+struct StrobeBIOpConversion : public OpConversionPattern<StrobeBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StrobeBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto deferOp = sim::DeferOp::create(rewriter, loc);
+    Block *deferBlock = rewriter.createBlock(&deferOp.getBody());
+
+    Block *strobeBlock = &op.getBody().front();
+    Operation *yieldOp =
+        cast<moore::StrobeYieldOp>(strobeBlock->getTerminator());
+    rewriter.inlineBlockBefore(strobeBlock, deferBlock, deferBlock->end());
+
+    auto message = rewriter.getRemappedValue(yieldOp->getOperand(0));
+    sim::PrintFormattedProcOp::create(rewriter, loc, message);
+    rewriter.eraseOp(yieldOp);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct FOpenBIOpConversion : public OpConversionPattern<FOpenBIOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -3621,6 +3644,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FormatCharOpConversion,
     DisplayBIOpConversion,
     FDisplayBIOpConversion,
+    StrobeBIOpConversion,
 
     // File I/O operations
     FOpenBIOpConversion,

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -815,6 +815,7 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
   SmallVector<GetFileOp> getFileOps;
   SmallVector<PrintFormattedProcOp> printOps;
   SmallVector<Operation *, 8> cleanupSeeds;
+  llvm::SetVector<sim::DeferOp> deferOpsToInline;
   module.walk([&](Operation *op) {
     if (auto getFileOp = dyn_cast<GetFileOp>(op))
       getFileOps.push_back(getFileOp);
@@ -848,8 +849,12 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
           << "while lowering format string";
       return failure();
     }
+    bool isDeferred = isa<sim::DeferOp>(printOp->getParentOp());
     auto stream = printOp.getStream();
-    if (!stream) {
+    if (isDeferred) {
+      sv::StrobeOp::create(builder, printOp.getLoc(), formatString, args);
+      deferOpsToInline.insert(cast<sim::DeferOp>(printOp->getParentOp()));
+    } else if (!stream) {
       // no stream is specified, emit sv.write.
       sv::WriteOp::create(builder, printOp.getLoc(), formatString, args);
     } else {
@@ -864,6 +869,14 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
   }
 
   cleanupDeadSimFmtOps(cleanupSeeds);
+
+  for (auto deferOp : deferOpsToInline) {
+    auto *body = deferOp.getBodyBlock();
+    auto *parentBlock = deferOp->getBlock();
+    parentBlock->getOperations().splice(Block::iterator(deferOp),
+                                        body->getOperations());
+    deferOp.erase();
+  }
 
   return success();
 }

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1998,6 +1998,23 @@ hw.module @write_task_test(in %clock : i1) {
   }
 }
 
+// CHECK-LABEL: module strobe_task_test(
+// CHECK:      always_ff @(posedge clock) begin
+// CHECK-NEXT:   $strobe("stdout");
+// CHECK-NEXT:   $strobe("%d", 32'h2A);
+// CHECK-NEXT:   $strobe("%d %d", 32'h80000001, 32'h80000002);
+// CHECK-NEXT: end
+hw.module @strobe_task_test(in %clock : i1) {
+  sv.alwaysff(posedge %clock) {
+    %c0 = hw.constant 42 : i32
+    %c1 = hw.constant 0x80000001 : i32
+    %c2 = hw.constant 0x80000002 : i32
+    sv.strobe "stdout"
+    sv.strobe "%d"(%c0) : i32
+    sv.strobe "%d %d"(%c1, %c2) : i32, i32
+  }
+}
+
 // CHECK-LABEL: module fwrite_task_test(
 // CHECK:      always_ff @(posedge clock) begin
 // CHECK-NEXT:   $fwrite(32'h80000001, "stdout");

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -966,3 +966,54 @@ function void PlusArgsBuiltins();
   // CHECK: moore.blocking_assign {{%.+}}, [[RESULT]] : i32
   rv = $value$plusargs("BAR=%d", val);
 endfunction
+
+// IEEE 1800-2017 § 21.2.2 "Strobed monitoring"
+// CHECK-LABEL: func.func private @StrobeBuiltins(
+// CHECK-SAME: [[X:%.+]]: !moore.i32
+function void StrobeBuiltins(int x);
+  // CHECK: moore.builtin.strobe {
+  // CHECK-NEXT: [[TMP:%.+]] = moore.fmt.literal "\0A"
+  // CHECK-NEXT: moore.strobe_yield [[TMP]]
+  // CHECK-NEXT: }
+  $strobe;
+
+  // CHECK: moore.builtin.strobe {
+  // CHECK-NEXT: [[TMP1:%.+]] = moore.fmt.literal "hello"
+  // CHECK-NEXT: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK-NEXT: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK-NEXT: moore.strobe_yield [[TMP3]]
+  // CHECK-NEXT: }
+  $strobe("hello");
+
+  // CHECK: moore.builtin.strobe {
+  // CHECK-NEXT: [[TMP1:%.+]] = moore.fmt.int decimal [[X]], align right, pad space signed : i32
+  // CHECK-NEXT: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK-NEXT: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK-NEXT: moore.strobe_yield [[TMP3]]
+  // CHECK-NEXT: }
+  $strobe(x);
+
+  // CHECK: moore.builtin.strobe {
+  // CHECK-NEXT: [[TMP1:%.+]] = moore.fmt.int binary [[X]], align right, pad zero : i32
+  // CHECK-NEXT: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK-NEXT: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK-NEXT: moore.strobe_yield [[TMP3]]
+  // CHECK-NEXT: }
+  $strobeb(x);
+
+  // CHECK: moore.builtin.strobe {
+  // CHECK-NEXT: [[TMP1:%.+]] = moore.fmt.int octal [[X]], align right, pad zero : i32
+  // CHECK-NEXT: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK-NEXT: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK-NEXT: moore.strobe_yield [[TMP3]]
+  // CHECK-NEXT: }
+  $strobeo(x);
+
+  // CHECK: moore.builtin.strobe {
+  // CHECK-NEXT: [[TMP1:%.+]] = moore.fmt.int hex_lower [[X]], align right, pad zero : i32
+  // CHECK-NEXT: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK-NEXT: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK-NEXT: moore.strobe_yield [[TMP3]]
+  // CHECK-NEXT: }
+  $strobeh(x);
+endfunction

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -448,6 +448,19 @@ func.func @FormatStrings(%arg0: !moore.i42, %arg1: !moore.f32, %arg2: !moore.f64
   return
 }
 
+// CHECK-LABEL: func @StrobeToPrint
+func.func @StrobeToPrint() {
+  // CHECK: sim.defer {
+  // CHECK-NEXT: [[TMP:%.+]] = sim.fmt.literal "hello\0A"
+  // CHECK-NEXT: sim.proc.print [[TMP]]
+  // CHECK-NEXT: }
+  moore.builtin.strobe {
+    %0 = moore.fmt.literal "hello\0A"
+    moore.strobe_yield %0
+  }
+  return
+}
+
 // CHECK-LABEL: hw.module @InstanceNull() {
 moore.module @InstanceNull() {
 

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
@@ -192,3 +192,21 @@ hw.module @print_to_file_under_condition(in %clk : i1, in %idx : i8, in %en : i1
     }
   }
 }
+
+// CHECK-LABEL: hw.module @deferred_print
+hw.module @deferred_print(in %clk : i1, in %arg : i8) {
+  hw.triggered posedge %clk (%arg) : i8 {
+    ^bb0(%arg_in : i8):
+    %l0 = sim.fmt.literal "val="
+    %f0 = sim.fmt.dec %arg_in specifierWidth 3 : i8
+    %msg = sim.fmt.concat (%l0, %f0)
+
+    // CHECK: ^bb0(%[[ARG:.+]]: i8):
+    // CHECK-NEXT: %[[UNSIGNED:.+]] = sv.system "unsigned"(%[[ARG]]) : (i8) -> i8
+    // CHECK-NEXT: sv.strobe "val=%3d"(%[[UNSIGNED]]) : i8
+    // CHECK-NOT: sim.defer
+    sim.defer {
+      sim.proc.print %msg
+    }
+  }
+}


### PR DESCRIPTION
Implement the SV `$strobe[boh]`system tasks.
- Add `moore.builtin.strobe` op in the Moore dialect to represent `$strobe[boh]`.
- Add `sim.defer`op in the Sim dialect: a procedural region who schedules its body in the postponed region. Underlying primitive for `$strobe`, `$fstrobe`, `$monitor`, and VHDL postponed processes.
- Add `StrobeBIOpConverion` in MooreTocore lowering.
- Add `sv.strobe` op to SV dialect, analogous to `sv.write` and wire it in SVVisitors.h and ExportVerilog to emit `$strobe(...)`
- Extend `lowerPrintFormattedProcToSV`in SimToSV to detect `sim.proc.print` inside `sim.defer`, and emit `sv.strobe`.
- Add tests for each stage of the pipeline.