### PR TITLE
[Synth] Add declarative cut rewrite pattern and yield op

### DIFF
--- a/include/circt/Dialect/Synth/SynthAttributes.td
+++ b/include/circt/Dialect/Synth/SynthAttributes.td
@@ -71,6 +71,19 @@ def LinearTimingArcAttr : AttrDef<Synth_Dialect, "LinearTimingArc"> {
     "$polarity `>`";
 }
 
+def PositionalLinearTimingArcAttr : AttrDef<Synth_Dialect, "PositionalLinearTimingArc"> {
+  let mnemonic = "positional_linear_timing_arc";
+  let summary = "A simplified linear timing arc using positional input index";
+  let parameters = (ins
+    "uint64_t":$inputIndex,
+    "int64_t":$intrinsic,
+    "int64_t":$sensitivity,
+    "PolarityAttr":$polarity
+  );
+  let assemblyFormat =
+    "`<` $inputIndex `,` $intrinsic `,` $sensitivity `,` $polarity `>`";
+}
+
 def MappingCostAttr : AttrDef<Synth_Dialect, "MappingCost"> {
   let mnemonic = "mapping_cost";
   let summary = "Simplified timing and area cost for tech mapping";

--- a/include/circt/Dialect/Synth/SynthAttributes.td
+++ b/include/circt/Dialect/Synth/SynthAttributes.td
@@ -71,19 +71,6 @@ def LinearTimingArcAttr : AttrDef<Synth_Dialect, "LinearTimingArc"> {
     "$polarity `>`";
 }
 
-def PositionalLinearTimingArcAttr : AttrDef<Synth_Dialect, "PositionalLinearTimingArc"> {
-  let mnemonic = "positional_linear_timing_arc";
-  let summary = "A simplified linear timing arc using positional input index";
-  let parameters = (ins
-    "uint64_t":$inputIndex,
-    "int64_t":$intrinsic,
-    "int64_t":$sensitivity,
-    "PolarityAttr":$polarity
-  );
-  let assemblyFormat =
-    "`<` $inputIndex `,` $intrinsic `,` $sensitivity `,` $polarity `>`";
-}
-
 def MappingCostAttr : AttrDef<Synth_Dialect, "MappingCost"> {
   let mnemonic = "mapping_cost";
   let summary = "Simplified timing and area cost for tech mapping";

--- a/include/circt/Dialect/Synth/SynthAttributes.td
+++ b/include/circt/Dialect/Synth/SynthAttributes.td
@@ -76,12 +76,14 @@ def MappingCostAttr : AttrDef<Synth_Dialect, "MappingCost"> {
   let summary = "Simplified timing and area cost for tech mapping";
   let parameters = (ins
     "::mlir::FloatAttr":$area,
-    "::mlir::ArrayAttr":$arcs,
-    "::mlir::DictionaryAttr":$inputCaps
+    OptionalParameter<"::mlir::ArrayAttr">:$arcs,
+    OptionalParameter<"::mlir::DictionaryAttr">:$inputCaps
   );
+  let genVerifyDecl = 1;
   let assemblyFormat =
-    "`<` `area` `=` $area `,` `arcs` `=` $arcs `,` "
-    "`input_caps` `=` $inputCaps `>`";
+    "`<` `area` `=` $area "
+    "(`,` `arcs` `=` $arcs^)? "
+    "(`,` `input_caps` `=` $inputCaps^)? `>`";
 }
 
 #endif // CIRCT_DIALECT_SYNTH_SYNTHATTRIBUTES_TD

--- a/include/circt/Dialect/Synth/SynthOps.h
+++ b/include/circt/Dialect/Synth/SynthOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_SYNTH_SYNTHOPS_H
 #define CIRCT_DIALECT_SYNTH_SYNTHOPS_H
 
+#include "circt/Dialect/Synth/SynthAttributes.h"
 #include "circt/Dialect/Synth/SynthDialect.h"
 #include "circt/Dialect/Synth/SynthOpInterfaces.h"
 #include "circt/Support/LLVM.h"

--- a/include/circt/Dialect/Synth/SynthOps.td
+++ b/include/circt/Dialect/Synth/SynthOps.td
@@ -305,6 +305,29 @@ def GambleOp : SymmetricThreeInputOp<"gamble", "evaluateGambleLogic"> {
 }];
 }
 
+def CutRewritePatternOp : SynthOp<"cut_rewrite_pattern", [
+  IsolatedFromAbove,
+  SingleBlockImplicitTerminator<"YieldOp">
+]> {
+  let summary = "Declarative cut rewrite pattern";
+
+  let arguments = (ins
+    TypeAttrOf<FunctionType>:$function_type,
+    MappingCostAttr:$cost
+  );
+
+  let regions = (region SizedRegion<1>:$body);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def YieldOp : SynthOp<"yield",
+                   [Pure, Terminator]> {
+  let summary = "Yield synth operations";
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let assemblyFormat = "$operands attr-dict `:` type($operands)";
+}
 
 
 #endif // CIRCT_DIALECT_SYNTH_SYNTHOPS_TD

--- a/lib/Dialect/Synth/CMakeLists.txt
+++ b/lib/Dialect/Synth/CMakeLists.txt
@@ -5,6 +5,7 @@
 ##===----------------------------------------------------------------------===//
 
 add_circt_dialect_library(CIRCTSynth
+  SynthAttributes.cpp
   SynthDialect.cpp
   SynthOpInterfaces.cpp
   SynthOps.cpp

--- a/lib/Dialect/Synth/SynthAttributes.cpp
+++ b/lib/Dialect/Synth/SynthAttributes.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Synth/SynthAttributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace circt::synth;
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// MappingCostAttr
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+MappingCostAttr::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
+                        FloatAttr area, ArrayAttr arcs,
+                        DictionaryAttr inputCaps) {
+  if (arcs)
+    for (auto attr : arcs)
+      if (!isa<LinearTimingArcAttr>(attr))
+        return emitError()
+               << "expected arcs to contain synth.linear_timing_arc";
+
+  if (inputCaps)
+    for (auto entry : inputCaps)
+      if (!isa<FloatAttr>(entry.getValue()))
+        return emitError()
+               << "expected input_caps values to be floating-point attributes";
+
+  return success();
+}

--- a/lib/Dialect/Synth/SynthAttributes.cpp
+++ b/lib/Dialect/Synth/SynthAttributes.cpp
@@ -25,8 +25,9 @@ MappingCostAttr::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
                         DictionaryAttr inputCaps) {
   if (arcs)
     for (auto attr : arcs)
-      if (!isa<LinearTimingArcAttr, PositionalLinearTimingArcAttr>(attr))
-        return emitError() << "expected arcs to contain timing arc attributes";
+      if (!isa<LinearTimingArcAttr>(attr))
+        return emitError()
+               << "expected arcs to contain synth.linear_timing_arc";
 
   if (inputCaps)
     for (auto entry : inputCaps)

--- a/lib/Dialect/Synth/SynthAttributes.cpp
+++ b/lib/Dialect/Synth/SynthAttributes.cpp
@@ -25,9 +25,8 @@ MappingCostAttr::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
                         DictionaryAttr inputCaps) {
   if (arcs)
     for (auto attr : arcs)
-      if (!isa<LinearTimingArcAttr>(attr))
-        return emitError()
-               << "expected arcs to contain synth.linear_timing_arc";
+      if (!isa<LinearTimingArcAttr, PositionalLinearTimingArcAttr>(attr))
+        return emitError() << "expected arcs to contain timing arc attributes";
 
   if (inputCaps)
     for (auto entry : inputCaps)

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -712,16 +712,11 @@ LogicalResult CutRewritePatternOp::verify() {
                          << blockArg.getType();
 
   auto cost = getCost();
-  if (auto arcs = cost.getArcs())
-    for (auto attr : arcs) {
-      // TODO: LinearTimingArcAttr pin names are currently ignored for cut
-      // rewrite patterns. In the future MappingCostAttr should use a 2D
-      // ArrayAttr container for arcs. Names may be dropped from
-      // LinearTimingArcAttr in a future cleanup.
-      if (!isa<LinearTimingArcAttr>(attr))
-        return emitError()
-               << "mapping cost arcs must use synth.linear_timing_arc";
-    }
+
+  // TODO: Cut rewrite patterns currently accept LinearTimingArcAttr timing
+  // arcs, but pin names are ignored because pattern arguments/results have no
+  // names. Teach MappingCostAttr to carry nameless per-input/per-output delay
+  // data, likely as a 2D ArrayAttr, and use it to populate cut pattern delays.
 
   if (auto inputCaps = cost.getInputCaps())
     if (inputCaps.size() != functionType.getNumInputs())

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -712,19 +712,16 @@ LogicalResult CutRewritePatternOp::verify() {
                          << blockArg.getType();
 
   auto cost = getCost();
-  if (auto arcs = cost.getArcs()) {
+  if (auto arcs = cost.getArcs())
     for (auto attr : arcs) {
-      auto arc = dyn_cast<PositionalLinearTimingArcAttr>(attr);
-      if (!arc)
+      // TODO: LinearTimingArcAttr pin names are currently ignored for cut
+      // rewrite patterns. In the future MappingCostAttr should use a 2D
+      // ArrayAttr container for arcs. Names may be dropped from
+      // LinearTimingArcAttr in a future cleanup.
+      if (!isa<LinearTimingArcAttr>(attr))
         return emitError()
-               << "mapping cost arcs for cut rewrite patterns must use "
-                  "synth.positional_linear_timing_arc";
-
-      if (arc.getInputIndex() >= functionType.getNumInputs())
-        return emitError()
-               << "mapping cost arc input index exceeds number of arguments";
+               << "mapping cost arcs must use synth.linear_timing_arc";
     }
-  }
 
   if (auto inputCaps = cost.getInputCaps())
     if (inputCaps.size() != functionType.getNumInputs())

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -19,7 +19,10 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/FunctionImplementation.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/LogicalResult.h"
@@ -625,4 +628,99 @@ void GambleOp::emitCNFWithoutInversion(
 
   // out = allSet | ~orSet
   circt::addOrClauses(outVar, {allSet, -orSet}, addClause);
+}
+
+//===----------------------------------------------------------------------===//
+// CutRewritePatternOp
+//===----------------------------------------------------------------------===//
+
+ParseResult CutRewritePatternOp::parse(OpAsmParser &parser,
+                                       OperationState &result) {
+
+  SmallVector<OpAsmParser::Argument> entryArgs;
+  SmallVector<Type> resultTypes;
+  SmallVector<DictionaryAttr> resultAttrs;
+  bool isVariadic = false;
+
+  if (function_interface_impl::parseFunctionSignatureWithArguments(
+          parser, /*allowVariadic=*/false, entryArgs, isVariadic, resultTypes,
+          resultAttrs))
+    return failure();
+
+  auto inputTypes = llvm::map_to_vector(
+      entryArgs, [](auto &arg) -> Type { return arg.type; });
+  auto functionType =
+      parser.getBuilder().getFunctionType(inputTypes, resultTypes);
+
+  result.addAttribute(getFunctionTypeAttrName(result.name),
+                      TypeAttr::get(functionType));
+  if (parser.parseOptionalAttrDictWithKeyword(result.attributes))
+    return failure();
+
+  return parser.parseRegion(*result.addRegion(), entryArgs,
+                            /*enableNameShadowing=*/false);
+}
+
+void CutRewritePatternOp::print(OpAsmPrinter &p) {
+  auto functionType = getFunctionType();
+  call_interface_impl::printFunctionSignature(
+      p, functionType.getInputs(), /*argAttrs=*/{}, /*isVariadic=*/false,
+      functionType.getResults(), /*resultAttrs=*/{}, &getBody(),
+      /*printEmptyResult=*/false);
+
+  p.printOptionalAttrDictWithKeyword((*this)->getAttrs(),
+                                     {getFunctionTypeAttrName()});
+
+  p << ' ';
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/true);
+}
+
+LogicalResult CutRewritePatternOp::verify() {
+  auto functionType = getFunctionType();
+
+  if (functionType.getNumResults() != 1)
+    return emitError() << "requires exactly one result";
+
+  for (auto type : functionType.getInputs())
+    if (!type.isInteger(1))
+      return emitError() << "argument type must be i1, but got " << type;
+
+  for (auto type : functionType.getResults())
+    if (!type.isInteger(1))
+      return emitError() << "result type must be i1, but got " << type;
+
+  // Check outputs.
+  auto *terminator = this->getBody().front().getTerminator();
+  if (terminator->getOperands().size() != functionType.getNumResults())
+    return emitError() << "result type doesn't match with the terminator";
+
+  for (auto [lhs, rhs] : llvm::zip(terminator->getOperands().getTypes(),
+                                   functionType.getResults()))
+    if (rhs != lhs)
+      return emitError() << rhs << " is expected but got " << lhs;
+
+  auto blockArgs = this->getBody().front().getArguments();
+  if (blockArgs.size() != functionType.getNumInputs())
+    return emitError() << "operand type doesn't match with the block arg";
+
+  for (auto [blockArg, inputType] :
+       llvm::zip(blockArgs, functionType.getInputs()))
+    if (blockArg.getType() != inputType)
+      return emitError() << inputType << " is expected but got "
+                         << blockArg.getType();
+
+  auto cost = getCost();
+  if (auto arcs = cost.getArcs())
+    if (!arcs.empty())
+      return emitError()
+             << "mapping cost arcs for cut rewrite patterns must not use "
+                "input/output names";
+
+  if (auto inputCaps = cost.getInputCaps())
+    if (inputCaps.size() != functionType.getNumInputs())
+      return emitError()
+             << "input_caps size must match the number of arguments";
+
+  return success();
 }

--- a/lib/Dialect/Synth/SynthOps.cpp
+++ b/lib/Dialect/Synth/SynthOps.cpp
@@ -10,6 +10,7 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Synth/SynthAttributes.h"
 #include "circt/Support/CustomDirectiveImpl.h"
 #include "circt/Support/Naming.h"
 #include "circt/Support/SATSolver.h"
@@ -711,11 +712,19 @@ LogicalResult CutRewritePatternOp::verify() {
                          << blockArg.getType();
 
   auto cost = getCost();
-  if (auto arcs = cost.getArcs())
-    if (!arcs.empty())
-      return emitError()
-             << "mapping cost arcs for cut rewrite patterns must not use "
-                "input/output names";
+  if (auto arcs = cost.getArcs()) {
+    for (auto attr : arcs) {
+      auto arc = dyn_cast<PositionalLinearTimingArcAttr>(attr);
+      if (!arc)
+        return emitError()
+               << "mapping cost arcs for cut rewrite patterns must use "
+                  "synth.positional_linear_timing_arc";
+
+      if (arc.getInputIndex() >= functionType.getNumInputs())
+        return emitError()
+               << "mapping cost arc input index exceeds number of arguments";
+    }
+  }
 
   if (auto inputCaps = cost.getInputCaps())
     if (inputCaps.size() != functionType.getNumInputs())

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -222,14 +222,15 @@ struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
       }
 
       llvm::DenseMap<StringAttr, DelayType> delayByInput;
-      for (auto attr : mappingCost.getArcs()) {
-        auto arc = cast<LinearTimingArcAttr>(attr);
-        if (!arc) {
-          hwModule.emitError(
-              "expected synth.linear_timing_arc in synth.mapping_cost arcs");
-          signalPassFailure();
-          return;
-        }
+      auto arcs = mappingCost.getArcs();
+      if (!arcs) {
+        hwModule.emitError(
+            "expected synth.linear_timing_arc in synth.mapping_cost arcs");
+        signalPassFailure();
+        return;
+      }
+      for (auto attr : arcs) {
+        auto arc = dyn_cast<LinearTimingArcAttr>(attr);
 
         if (arc.getPin() != outputName) {
           hwModule.emitError("mapping cost arc output '")

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -224,13 +224,18 @@ struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
       llvm::DenseMap<StringAttr, DelayType> delayByInput;
       auto arcs = mappingCost.getArcs();
       if (!arcs) {
-        hwModule.emitError(
-            "expected synth.linear_timing_arc in synth.mapping_cost arcs");
+        hwModule.emitError("expected synth.mapping_cost to contain arcs");
         signalPassFailure();
         return;
       }
       for (auto attr : arcs) {
         auto arc = dyn_cast<LinearTimingArcAttr>(attr);
+        if (!arc) {
+          hwModule.emitError(
+              "expected synth.linear_timing_arc in synth.mapping_cost arcs");
+          signalPassFailure();
+          return;
+        }
 
         if (arc.getPin() != outputName) {
           hwModule.emitError("mapping cost arc output '")

--- a/test/Dialect/Synth/errors.mlir
+++ b/test/Dialect/Synth/errors.mlir
@@ -43,3 +43,25 @@ synth.cut_rewrite_pattern (%a: i1) -> i1 attributes {cost = #synth.mapping_cost<
   %0 = hw.constant 0 : i2
   synth.yield %0 : i2
 }
+
+// -----
+
+// expected-error @below {{mapping cost arcs for cut rewrite patterns must use synth.positional_linear_timing_arc}}
+synth.cut_rewrite_pattern (%a: i1) -> i1 attributes {
+  cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [
+    #synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>
+  ]>
+} {
+  synth.yield %a : i1
+}
+
+// -----
+
+// expected-error @below {{mapping cost arc input index exceeds number of arguments}}
+synth.cut_rewrite_pattern (%a: i1) -> i1 attributes {
+  cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [
+    #synth.positional_linear_timing_arc<1, 1, 0, #synth.polarity<positive>>
+  ]>
+} {
+  synth.yield %a : i1
+}

--- a/test/Dialect/Synth/errors.mlir
+++ b/test/Dialect/Synth/errors.mlir
@@ -5,3 +5,41 @@ hw.module @test(out result : i1) {
     %0 = synth.choice : i1
     hw.output %0 : i1
 }
+
+// -----
+
+// expected-error @below {{argument type must be i1, but got 'i2'}}
+synth.cut_rewrite_pattern (%a: i2) -> i1 attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+  %0 = comb.extract %a from 0 : (i2) -> i1
+  synth.yield %0 : i1
+}
+
+// -----
+
+// expected-error @below {{result type must be i1, but got 'i2'}}
+synth.cut_rewrite_pattern (%a: i1) -> i2 attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+  %0 = hw.constant 0 : i2
+  synth.yield %0 : i2
+}
+
+// -----
+
+// expected-error @below {{requires exactly one result}}
+synth.cut_rewrite_pattern (%a: i1) -> (i1, i1) attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+  synth.yield %a, %a : i1, i1
+}
+
+// -----
+
+// expected-error @below {{result type doesn't match with the terminator}}
+synth.cut_rewrite_pattern (%a: i1) -> i1 attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+  "synth.yield"() : () -> ()
+}
+
+// -----
+
+// expected-error @below {{'i1' is expected but got 'i2'}}
+synth.cut_rewrite_pattern (%a: i1) -> i1 attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+  %0 = hw.constant 0 : i2
+  synth.yield %0 : i2
+}

--- a/test/Dialect/Synth/errors.mlir
+++ b/test/Dialect/Synth/errors.mlir
@@ -43,25 +43,3 @@ synth.cut_rewrite_pattern (%a: i1) -> i1 attributes {cost = #synth.mapping_cost<
   %0 = hw.constant 0 : i2
   synth.yield %0 : i2
 }
-
-// -----
-
-// expected-error @below {{mapping cost arcs for cut rewrite patterns must use synth.positional_linear_timing_arc}}
-synth.cut_rewrite_pattern (%a: i1) -> i1 attributes {
-  cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [
-    #synth.linear_timing_arc<"result", "a", 1, 0, #synth.polarity<positive>>
-  ]>
-} {
-  synth.yield %a : i1
-}
-
-// -----
-
-// expected-error @below {{mapping cost arc input index exceeds number of arguments}}
-synth.cut_rewrite_pattern (%a: i1) -> i1 attributes {
-  cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [
-    #synth.positional_linear_timing_arc<1, 1, 0, #synth.polarity<positive>>
-  ]>
-} {
-  synth.yield %a : i1
-}

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -57,11 +57,11 @@ hw.module @gamble(in %x: i1, in %y: i1, in %z: i1) {
 
 // CHECK-LABEL: synth.cut_rewrite_pattern
 // CHECK-SAME: (%{{.*}}: i1, %{{.*}}: i1, %{{.*}}: i1) -> i1
-// CHECK-SAME: attributes {cost = #synth.mapping_cost<area =
-// CHECK-SAME: #synth.positional_linear_timing_arc<1, 1, 0, <positive>>
+// CHECK-SAME: attributes {cost = #synth.mapping_cost<area = 
+// CHECK-SAME: #synth.linear_timing_arc<"result", "b", 1, 0, <positive>>
 synth.cut_rewrite_pattern (%a: i1, %b: i1, %c: i1) -> i1 attributes {
   cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [
-    #synth.positional_linear_timing_arc<1, 1, 0, #synth.polarity<positive>>
+    #synth.linear_timing_arc<"result", "b", 1, 0, #synth.polarity<positive>>
   ]>
 } {
   %0 = synth.aig.and_inv %a, not %b, %c : i1

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -57,14 +57,22 @@ hw.module @gamble(in %x: i1, in %y: i1, in %z: i1) {
 
 // CHECK-LABEL: synth.cut_rewrite_pattern
 // CHECK-SAME: (%{{.*}}: i1, %{{.*}}: i1, %{{.*}}: i1) -> i1
-synth.cut_rewrite_pattern (%a: i1, %b: i1, %c: i1) -> i1 attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+// CHECK-SAME: attributes {cost = #synth.mapping_cost<area =
+// CHECK-SAME: #synth.positional_linear_timing_arc<1, 1, 0, #synth.polarity<positive>>
+synth.cut_rewrite_pattern (%a: i1, %b: i1, %c: i1) -> i1 attributes {
+  cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [
+    #synth.positional_linear_timing_arc<1, 1, 0, #synth.polarity<positive>>
+  ]>
+} {
   %0 = synth.aig.and_inv %a, not %b, %c : i1
   synth.yield %0 : i1
 }
 
 // CHECK-LABEL: synth.cut_rewrite_pattern
 // CHECK-SAME: (%{{.*}}: i1, %{{.*}}: i1) -> i1 attributes {cost = #synth.mapping_cost<area =
-synth.cut_rewrite_pattern (%a: i1, %b: i1) -> i1 attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+synth.cut_rewrite_pattern (%a: i1, %b: i1) -> i1 attributes {
+  cost = #synth.mapping_cost<area = 1.0 : f64>
+} {
   %0 = synth.aig.and_inv %a, %b : i1
   synth.yield %0 : i1
 }

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -58,7 +58,7 @@ hw.module @gamble(in %x: i1, in %y: i1, in %z: i1) {
 // CHECK-LABEL: synth.cut_rewrite_pattern
 // CHECK-SAME: (%{{.*}}: i1, %{{.*}}: i1, %{{.*}}: i1) -> i1
 // CHECK-SAME: attributes {cost = #synth.mapping_cost<area =
-// CHECK-SAME: #synth.positional_linear_timing_arc<1, 1, 0, #synth.polarity<positive>>
+// CHECK-SAME: #synth.positional_linear_timing_arc<1, 1, 0, <positive>>
 synth.cut_rewrite_pattern (%a: i1, %b: i1, %c: i1) -> i1 attributes {
   cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [
     #synth.positional_linear_timing_arc<1, 1, 0, #synth.polarity<positive>>

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -54,3 +54,17 @@ hw.module @mux_inv(in %c: i4, in %a: i4, in %b: i4) {
 hw.module @gamble(in %x: i1, in %y: i1, in %z: i1) {
   %0 = synth.gamble %x, not %y, %z : i1
 }
+
+// CHECK-LABEL: synth.cut_rewrite_pattern
+// CHECK-SAME: (%{{.*}}: i1, %{{.*}}: i1, %{{.*}}: i1) -> i1
+synth.cut_rewrite_pattern (%a: i1, %b: i1, %c: i1) -> i1 attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+  %0 = synth.aig.and_inv %a, not %b, %c : i1
+  synth.yield %0 : i1
+}
+
+// CHECK-LABEL: synth.cut_rewrite_pattern
+// CHECK-SAME: (%{{.*}}: i1, %{{.*}}: i1) -> i1 attributes {cost = #synth.mapping_cost<area =
+synth.cut_rewrite_pattern (%a: i1, %b: i1) -> i1 attributes {cost = #synth.mapping_cost<area = 1.0 : f64>} {
+  %0 = synth.aig.and_inv %a, %b : i1
+  synth.yield %0 : i1
+}

--- a/test/Dialect/Synth/round-trip.mlir
+++ b/test/Dialect/Synth/round-trip.mlir
@@ -57,7 +57,7 @@ hw.module @gamble(in %x: i1, in %y: i1, in %z: i1) {
 
 // CHECK-LABEL: synth.cut_rewrite_pattern
 // CHECK-SAME: (%{{.*}}: i1, %{{.*}}: i1, %{{.*}}: i1) -> i1
-// CHECK-SAME: attributes {cost = #synth.mapping_cost<area = 
+// CHECK-SAME: attributes {cost = #synth.mapping_cost<area =
 // CHECK-SAME: #synth.linear_timing_arc<"result", "b", 1, 0, <positive>>
 synth.cut_rewrite_pattern (%a: i1, %b: i1, %c: i1) -> i1 attributes {
   cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [


### PR DESCRIPTION
Concerns  #10485

We introduce the declarative operation `synth.cut_rewrite_pattern` and also the terminator operation `synth.yield`.

`synth.cut_rewrite_pattern` denotes cut rewrite patterns for `i1` input and result types as function-shaped regions. We also implement a custom printer and parser with attribute support for `synth.mapping_cost`.

In this PR we only introduce the IR representation; wiring this into consumers, for example `TechMapper.cpp`, can be added later.