### PR TITLE
[HW] Change specification of union operations, NFC

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -343,8 +343,9 @@ def StructExplodeOp : HWOp<"struct_explode", [Pure,
 def UnionCreateOp : HWOp<"union_create", [Pure]> {
   let summary = "Create a union with the specified value.";
   let description = [{
-    Create a union with the value 'input', which can then be accessed via the
-    specified field.
+    Create a union with the value 'input' at the specified field's offset. The
+    value of the bits in the underlying representation that are not covered by
+    the specified field is undefined.
 
     ```
       %x = hw.constant 0 : i3
@@ -378,14 +379,13 @@ def UnionCreateOp : HWOp<"union_create", [Pure]> {
   }];
 }
 
-def UnionExtractOp : HWOp<"union_extract", [Pure, 
+def UnionExtractOp : HWOp<"union_extract", [Pure,
     DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   ]> {
   let summary = "Get a union member.";
   let description = [{
     Get the value of a union, interpreting it as the type of the specified
-    member field.  Extracting a value belonging to a different field than the
-    union was initially created will result in undefined behavior.
+    member field.
 
     ```
       %u = ...


### PR DESCRIPTION
The current specification of UnionExtract states that its behavior is undefined if the union was created with a different field than the one being extracted. However, union members have an explicitly specified offset, union values have defined behavior for bitcasts (cf. RationaleComb.md), and HW unions are lowered to packed unions in SV.

All of this implies that HW unions have a known bitvector representation and each member maps to a defined slice of that vector. Consequently, extracting a value from a union should always be defined behavior, while creating a union may produce non-deterministically chosen padding bits.
