### PR TITLE
[Synth] Run structural hash on nested blocks

### DIFF
--- a/lib/Dialect/Synth/Transforms/StructuralHash.cpp
+++ b/lib/Dialect/Synth/Transforms/StructuralHash.cpp
@@ -112,6 +112,9 @@ public:
   llvm::LogicalResult run(Operation *op);
 
 private:
+  /// Runs the structural hashing pass on the given block.
+  llvm::LogicalResult runOnBlock(Block &block);
+
   /// Maps values to unique numbers for deterministic operand sorting.
   DenseMap<Value, uint64_t> valueNumber;
   uint64_t constantCounter = 0;
@@ -246,17 +249,14 @@ uint64_t StructuralHashDriver::getNumber(Value v) {
       .first->second;
 }
 
-llvm::LogicalResult StructuralHashDriver::run(Operation *moduleOp) {
+llvm::LogicalResult StructuralHashDriver::runOnBlock(Block &block) {
+  hashTable.clear();
+
   auto isOperationReady = [&](Value value, Operation *op) -> bool {
     // Other than target ops, all other ops are always ready.
     return !isa<BooleanLogicOpInterface>(op);
   };
 
-  if (moduleOp->getNumRegions() != 1 ||
-      moduleOp->getRegion(0).getBlocks().size() != 1)
-    return llvm::success();
-
-  Block &block = moduleOp->getRegion(0).front();
   if (!mlir::sortTopologically(&block, isOperationReady))
     return failure();
 
@@ -264,12 +264,21 @@ llvm::LogicalResult StructuralHashDriver::run(Operation *moduleOp) {
     (void)getNumber(arg);
 
   // Process target ops.
-  // NOTE: Don't use walk here since the pass currently doesn't handle nested
-  // regions.
   for (auto op :
        llvm::make_early_inc_range(block.getOps<BooleanLogicOpInterface>())) {
     visitOp(op);
   }
+
+  return mlir::success();
+}
+
+llvm::LogicalResult StructuralHashDriver::run(Operation *moduleOp) {
+  auto result = moduleOp->walk([&](Block *block) {
+    return failed(runOnBlock(*block)) ? WalkResult::interrupt()
+                                      : WalkResult::advance();
+  });
+  if (result.wasInterrupted())
+    return failure();
 
   // Run DCE to remove dangling ops.
   mlir::PatternRewriter rewriter(moduleOp->getContext());

--- a/test/Dialect/Synth/structural_hash.mlir
+++ b/test/Dialect/Synth/structural_hash.mlir
@@ -53,6 +53,28 @@ func.func @test_func(%a: i2, %b: i2) -> (i2, i2) {
   return %0, %1 : i2, i2
 }
 
+// CHECK-LABEL: func.func @nested_blocks
+func.func @nested_blocks(%a: i1, %b: i1, %cond: i1) -> (i1, i1) {
+  // CHECK:      scf.if
+  // CHECK:        %[[THEN:.+]] = synth.aig.and_inv not %[[A:.+]], %[[B:.+]] : i1
+  // CHECK-NEXT:   scf.yield %[[THEN]], %[[THEN]] : i1, i1
+  // CHECK:      } else {
+  // CHECK-NEXT:   %[[ELSE:.+]] = synth.aig.and_inv not %[[A]], %[[B]] : i1
+  // CHECK-NEXT:   scf.yield %[[ELSE]], %[[ELSE]] : i1, i1
+  // CHECK-NEXT: }
+  %r:2 = scf.if %cond -> (i1, i1) {
+    %0 = synth.aig.and_inv not %a, %b : i1
+    %1 = synth.aig.and_inv %b, not %a : i1
+    scf.yield %0, %1 : i1, i1
+  } else {
+    %notA = synth.aig.and_inv not %a : i1
+    %fromNot = synth.aig.and_inv %notA, %b : i1
+    %commuted = synth.aig.and_inv %b, not %a : i1
+    scf.yield %fromNot, %commuted : i1, i1
+  }
+  return %r#0, %r#1 : i1, i1
+}
+
 // CHECK-LABEL: hw.module @xor_inv_hash
 hw.module @xor_inv_hash(in %a: i1, in %b: i1, in %c: i1, out o0: i1, out o1: i1) {
   // CHECK: %[[X:.+]] = synth.xor_inv %a, not %b, %c : i1


### PR DESCRIPTION
Structural hashing previously only processed the root operation's top-level
block, missing equivalent operations inside nested regions.

For simplicity, this reconstructs the hash table for each block independently. 
This could be improved later with a scoped hash table to reuse entries across
nested scopes.

Assisted-by: codex: gpt-5.5

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
