### PR TITLE
[ExportVerilog] Don't inline operations used in StructInjectOp and StructExplodeOp

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -779,7 +779,8 @@ static bool isExpressionUnableToInline(Operation *op,
     //
     // To handle these, we push the subexpression into a temporary.
     if (isa<ExtractOp, ArraySliceOp, ArrayGetOp, ArrayInjectOp, StructExtractOp,
-            UnionExtractOp, IndexedPartSelectOp>(user))
+            StructInjectOp, StructExplodeOp, UnionExtractOp,
+            IndexedPartSelectOp>(user))
       if (use.getOperandNumber() == 0 && // ignore index operands.
           !isOkToBitSelectFrom(use.get()))
         return true;

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1504,3 +1504,23 @@ hw.module @ArrayInjectProcedural(in %a: !hw.array<4xi42>, in %b: i42, in %i: i2)
   }
   // CHECK-NEXT: end
 }
+
+// CHECK-LABEL: module CondStructExtract(
+// CHECK-NOT: ).el1
+hw.module @CondStructExtract(in %sel : i1, out o : !hw.struct<el0: i1, el1 : i1>) {
+  %0 = hw.aggregate_constant [false, false] : !hw.struct<el0: i1, el1 : i1>
+  %1 = hw.aggregate_constant [true, true] : !hw.struct<el0: i1, el1 : i1>
+  %2 = comb.mux %sel, %0, %1 : !hw.struct<el0: i1, el1 : i1>
+  %3 = hw.struct_inject %2["el0"], %sel : !hw.struct<el0: i1, el1 : i1>
+  hw.output %3 : !hw.struct<el0: i1, el1 : i1>
+}
+
+// CHECK-LABEL: module CondStructExplode(
+// CHECK-NOT: ).el
+hw.module private @CondStructExplode(in %sel : i1, in %i : !hw.struct<el : i1>, out o : i1) {
+  %0 = hw.aggregate_constant [false] : !hw.struct<el : i1>
+  %1 = hw.aggregate_constant [true] : !hw.struct<el : i1>
+  %2 = comb.mux %sel, %0, %1 : !hw.struct<el : i1>
+  %el = hw.struct_explode %2 : !hw.struct<el : i1>
+  hw.output %el : i1
+}


### PR DESCRIPTION
Adds `StructInjectOp` and `StructExplodeOp` to the list of operations that require their operands to be emitted as temporaries.

This prevents invalid Verilog emission like: `(sel ? _GEN : _GEN_0).el`.
