### PR TITLE
[ESI] Slim down manifest

### DIFF
--- a/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
+++ b/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
@@ -46,14 +46,37 @@ private:
   llvm::json::Value json(Operation *errorOp, Attribute, bool elideType = false);
 
   // Output a node in the appid hierarchy.
-  void emitNode(llvm::json::OStream &, AppIDHierNodeOp nodeOp);
-  // Output the manifest data of a node in the appid hierarchy.
-  void emitBlock(llvm::json::OStream &, Block &block, StringRef manifestClass);
+  void emitNode(llvm::json::OStream &, AppIDHierNodeOp nodeOp,
+                ArrayRef<Attribute> parentPath);
+  // Output the manifest data of a node in the appid hierarchy. 'nodePath' is
+  // the absolute appID path of the node which owns 'block'.
+  void emitBlock(llvm::json::OStream &, Block &block, StringRef manifestClass,
+                 ArrayRef<Attribute> nodePath);
 
   AppIDHierRootOp appidRoot;
 
   /// Get a JSON representation of the manifest.
   std::string json();
+
+  /// Walk the appID hierarchy and record the absolute appID paths of all client
+  /// ports whose channels are bound to a host-reachable engine (i.e. which
+  /// appear in some engine's channel assignment table). These are the only
+  /// ports which are "user accessible": present in the runtime's Accelerator
+  /// design tree.
+  void collectAssignedPorts(Block &block, SmallVectorImpl<Attribute> &path);
+
+  /// Walk the appID hierarchy and populate 'keepNodes' with the hierarchy nodes
+  /// which contain (or have a descendant which contains) a user-accessible
+  /// client port. Returns true if 'block' or any descendant is to be kept.
+  bool computeKeepNodes(Block &block, SmallVectorImpl<Attribute> &path);
+
+  /// Is the client port with appID 'portID' under the node at 'nodePath' user
+  /// accessible?
+  bool isPortAccessible(ArrayRef<Attribute> nodePath, Attribute portID) {
+    SmallVector<Attribute> portPath(nodePath.begin(), nodePath.end());
+    portPath.push_back(portID);
+    return assignedPortPaths.contains(ArrayAttr::get(&getContext(), portPath));
+  }
 
   // Type table.
   std::string useType(Type type) {
@@ -73,6 +96,13 @@ private:
   DenseSet<SymbolRefAttr> symbols;
   DenseSet<SymbolRefAttr> modules;
 
+  // Absolute appID paths of user-accessible client ports (those bound to a
+  // host-reachable engine via a channel assignment).
+  DenseSet<ArrayAttr> assignedPortPaths;
+  // AppID hierarchy nodes to retain (those whose subtree contains a
+  // user-accessible client port).
+  DenseSet<Operation *> keepNodes;
+
   hw::HWSymbolCache symCache;
 };
 } // anonymous namespace
@@ -89,6 +119,16 @@ void ESIBuildManifestPass::runOnOperation() {
       appidRoot = root;
   if (!appidRoot)
     return;
+
+  // Determine which client ports are user-accessible and which hierarchy nodes
+  // need to be retained as a result. This must happen before JSONification
+  // since the latter relies on these sets to prune the manifest.
+  {
+    SmallVector<Attribute> path;
+    collectAssignedPorts(appidRoot.getChildren().front(), path);
+    path.clear();
+    computeKeepNodes(appidRoot.getChildren().front(), path);
+  }
 
   // JSONify the manifest.
   std::string jsonManifest = json();
@@ -131,8 +171,51 @@ void ESIBuildManifestPass::runOnOperation() {
   }
 }
 
+void ESIBuildManifestPass::collectAssignedPorts(
+    Block &block, SmallVectorImpl<Attribute> &path) {
+  for (auto svc : block.getOps<ServiceImplRecordOp>())
+    for (auto client :
+         svc.getReqDetails().front().getOps<ServiceImplClientRecordOp>()) {
+      DictionaryAttr chanAssigns = client.getChannelAssignmentsAttr();
+      // A client port is only user-accessible if its channels are bound to a
+      // host-reachable engine, recorded via a non-empty channel assignment.
+      if (!chanAssigns || chanAssigns.empty())
+        continue;
+      SmallVector<Attribute> portPath(path.begin(), path.end());
+      for (auto id : client.getRelAppIDPath().getAsRange<AppIDAttr>())
+        portPath.push_back(id);
+      assignedPortPaths.insert(ArrayAttr::get(&getContext(), portPath));
+    }
+  for (auto node : block.getOps<AppIDHierNodeOp>()) {
+    path.push_back(node.getAppIDAttr());
+    collectAssignedPorts(node.getChildren().front(), path);
+    path.pop_back();
+  }
+}
+
+bool ESIBuildManifestPass::computeKeepNodes(Block &block,
+                                            SmallVectorImpl<Attribute> &path) {
+  bool keep = false;
+  for (auto req : block.getOps<ServiceRequestRecordOp>())
+    if (isPortAccessible(path, req.getRequestorAttr()))
+      keep = true;
+  for (auto node : block.getOps<AppIDHierNodeOp>()) {
+    path.push_back(node.getAppIDAttr());
+    bool childKeep = computeKeepNodes(node.getChildren().front(), path);
+    path.pop_back();
+    if (childKeep) {
+      keepNodes.insert(node);
+      keep = true;
+    }
+  }
+  return keep;
+}
+
 void ESIBuildManifestPass::emitNode(llvm::json::OStream &j,
-                                    AppIDHierNodeOp nodeOp) {
+                                    AppIDHierNodeOp nodeOp,
+                                    ArrayRef<Attribute> parentPath) {
+  SmallVector<Attribute> nodePath(parentPath.begin(), parentPath.end());
+  nodePath.push_back(nodeOp.getAppIDAttr());
   std::set<StringRef> classesToEmit;
   for (auto manifestData : nodeOp.getOps<IsManifestData>())
     classesToEmit.insert(manifestData.getManifestClass());
@@ -141,20 +224,30 @@ void ESIBuildManifestPass::emitNode(llvm::json::OStream &j,
     j.attribute("instanceOf", json(nodeOp, nodeOp.getModuleRefAttr()));
     for (StringRef manifestClass : classesToEmit)
       j.attributeArray(manifestClass.str() + "s", [&]() {
-        emitBlock(j, nodeOp.getChildren().front(), manifestClass);
+        emitBlock(j, nodeOp.getChildren().front(), manifestClass, nodePath);
       });
     j.attributeArray("children", [&]() {
-      for (auto nodeOp : nodeOp.getChildren().front().getOps<AppIDHierNodeOp>())
-        emitNode(j, nodeOp);
+      for (auto childOp :
+           nodeOp.getChildren().front().getOps<AppIDHierNodeOp>())
+        if (keepNodes.contains(childOp))
+          emitNode(j, childOp, nodePath);
     });
   });
 }
 
 void ESIBuildManifestPass::emitBlock(llvm::json::OStream &j, Block &block,
-                                     StringRef manifestClass) {
+                                     StringRef manifestClass,
+                                     ArrayRef<Attribute> nodePath) {
   for (auto manifestData : block.getOps<IsManifestData>()) {
     if (manifestData.getManifestClass() != manifestClass)
       continue;
+    // Prune client ports which are not user-accessible (i.e. whose channels are
+    // not bound to a host-reachable engine). Such ports never appear in the
+    // runtime's Accelerator design tree, so they (and their types) are omitted.
+    if (auto req =
+            dyn_cast<ServiceRequestRecordOp>(manifestData.getOperation()))
+      if (!isPortAccessible(nodePath, req.getRequestorAttr()))
+        continue;
     j.object([&] {
       SmallVector<NamedAttribute, 4> attrs;
       manifestData.getDetails(attrs);
@@ -183,12 +276,13 @@ std::string ESIBuildManifestPass::json() {
     modules.insert(appidRoot.getTopModuleRefAttr());
     for (StringRef manifestClass : classesToEmit)
       j.attributeArray(manifestClass.str() + "s", [&]() {
-        emitBlock(j, appidRoot.getChildren().front(), manifestClass);
+        emitBlock(j, appidRoot.getChildren().front(), manifestClass, {});
       });
     j.attributeArray("children", [&]() {
       for (auto nodeOp :
            appidRoot.getChildren().front().getOps<AppIDHierNodeOp>())
-        emitNode(j, nodeOp);
+        if (keepNodes.contains(nodeOp))
+          emitNode(j, nodeOp, {});
     });
   });
 
@@ -208,7 +302,12 @@ std::string ESIBuildManifestPass::json() {
           for (auto port : ports) {
             j.object([&] {
               j.attribute("name", port.port.getName().getValue());
-              j.attribute("typeID", useType(port.type));
+              // Emit the port type as a plain string rather than registering it
+              // in the type table: the runtime never resolves service
+              // declaration port types, so they would only bloat the manifest.
+              std::string typeID;
+              llvm::raw_string_ostream(typeID) << port.type;
+              j.attribute("typeID", typeID);
             });
           }
         });
@@ -227,7 +326,14 @@ std::string ESIBuildManifestPass::json() {
     // Gather all manifest data for each symbol.
     for (auto symInfo : mod.getBody()->getOps<IsManifestData>()) {
       FlatSymbolRefAttr sym = symInfo.getSymbolRefAttr();
-      if (!sym || !symbols.contains(sym))
+      if (!sym)
+        continue;
+      // Keep a module's metadata if it is instantiated somewhere in the
+      // (pruned) design hierarchy. Additionally, always keep module constants:
+      // they are semantically significant (e.g. for codegen) even when the
+      // module itself is not user-accessible.
+      bool isConstants = symInfo.getManifestClass() == "symConsts";
+      if (!symbols.contains(sym) && !isConstants)
         continue;
       symbolInfoLookup[sym].push_back(symInfo);
     }

--- a/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
+++ b/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
@@ -58,25 +58,24 @@ private:
   /// Get a JSON representation of the manifest.
   std::string json();
 
-  /// Walk the appID hierarchy and record the absolute appID paths of all client
-  /// ports which are served by a service or engine (i.e. which appear in some
-  /// service implementation's client record). These are the only ports which
-  /// are "user accessible": those for which the runtime materializes a port in
-  /// the Accelerator design tree. Ports with no service record (e.g. host
-  /// memory ports, or function ports with no implementing engine) are not.
-  void collectServedPorts(Block &block, SmallVectorImpl<Attribute> &path);
+  /// Walk the appID hierarchy to populate 'servedPortPaths' (absolute appID
+  /// paths of user-accessible client ports, i.e. those appearing in a service
+  /// implementation's client record) and 'instantiatedModules' (every module
+  /// instantiated in the unpruned hierarchy, whose metadata must be retained).
+  void collectAccessibilityInfo(Block &block);
 
   /// Walk the appID hierarchy and populate 'keepNodes' with the hierarchy nodes
   /// which contain (or have a descendant which contains) a user-accessible
-  /// client port. Returns true if 'block' or any descendant is to be kept.
-  bool computeKeepNodes(Block &block, SmallVectorImpl<Attribute> &path);
+  /// client port.
+  void computeKeepNodes(Block &block);
 
   /// Is the client port with appID 'portID' under the node at 'nodePath' user
   /// accessible?
-  bool isPortAccessible(ArrayRef<Attribute> nodePath, Attribute portID) {
+  bool isPortAccessible(ArrayRef<Attribute> nodePath, Attribute portID) const {
     SmallVector<Attribute> portPath(nodePath.begin(), nodePath.end());
     portPath.push_back(portID);
-    return servedPortPaths.contains(ArrayAttr::get(&getContext(), portPath));
+    return servedPortPaths.contains(
+        ArrayAttr::get(portID.getContext(), portPath));
   }
 
   // Type table.
@@ -97,9 +96,9 @@ private:
   DenseSet<SymbolRefAttr> symbols;
   DenseSet<SymbolRefAttr> modules;
 
-  // Modules instantiated anywhere in the (full, unpruned) design hierarchy.
-  // Their metadata is always retained so that 'module_infos' stays complete
-  // even when an instance's subtree is pruned from the design tree.
+  // Modules instantiated anywhere in the (full, unpruned) AppID design
+  // hierarchy. Their metadata is always retained so that 'module_infos' stays
+  // complete even when an instance's subtree is pruned from the design tree.
   DenseSet<SymbolRefAttr> instantiatedModules;
 
   // Absolute appID paths of user-accessible client ports (those served by a
@@ -127,14 +126,9 @@ void ESIBuildManifestPass::runOnOperation() {
     return;
 
   // Determine which client ports are user-accessible and which hierarchy nodes
-  // need to be retained as a result. This must happen before JSONification
-  // since the latter relies on these sets to prune the manifest.
-  {
-    SmallVector<Attribute> path;
-    collectServedPorts(appidRoot.getChildren().front(), path);
-    path.clear();
-    computeKeepNodes(appidRoot.getChildren().front(), path);
-  }
+  // need to be retained as a result.
+  collectAccessibilityInfo(appidRoot.getChildren().front());
+  computeKeepNodes(appidRoot.getChildren().front());
 
   // JSONify the manifest.
   std::string jsonManifest = json();
@@ -177,48 +171,80 @@ void ESIBuildManifestPass::runOnOperation() {
   }
 }
 
-void ESIBuildManifestPass::collectServedPorts(
-    Block &block, SmallVectorImpl<Attribute> &path) {
-  for (auto svc : block.getOps<ServiceImplRecordOp>())
-    for (auto client :
-         svc.getReqDetails().front().getOps<ServiceImplClientRecordOp>()) {
-      // Any client port with a service implementation record is served by that
-      // service/engine and is therefore user-accessible. Note that the channel
-      // assignments may be empty (e.g. for MMIO ports, which are described by
-      // 'offset'/'size' options rather than channel assignments).
-      SmallVector<Attribute> portPath(path.begin(), path.end());
-      for (auto id : client.getRelAppIDPath().getAsRange<AppIDAttr>())
-        portPath.push_back(id);
-      servedPortPaths.insert(ArrayAttr::get(&getContext(), portPath));
-    }
-  for (auto node : block.getOps<AppIDHierNodeOp>()) {
-    // Record every module instantiated in the (full, unpruned) design
-    // hierarchy so that its metadata (module_infos) is always retained, even
-    // when the instance's subtree is pruned from the design tree because it
-    // contains no user-accessible ports.
+void ESIBuildManifestPass::collectAccessibilityInfo(Block &rootBlock) {
+  // Record every module instantiated in the (full, unpruned) AppID design
+  // hierarchy so that its metadata (module_infos) is always retained.
+  rootBlock.getParentOp()->walk([&](AppIDHierNodeOp node) {
     instantiatedModules.insert(node.getModuleRefAttr());
-    path.push_back(node.getAppIDAttr());
-    collectServedPorts(node.getChildren().front(), path);
-    path.pop_back();
+  });
+
+  // Iterative pre-order walk over the appID hierarchy to collect served port
+  // paths. Each work item pairs a block with the absolute appID path of the
+  // node which owns it.
+  SmallVector<std::pair<Block *, SmallVector<Attribute>>> worklist;
+  worklist.emplace_back(&rootBlock, SmallVector<Attribute>{});
+  while (!worklist.empty()) {
+    auto [block, path] = worklist.pop_back_val();
+    for (auto svc : block->getOps<ServiceImplRecordOp>())
+      for (auto client :
+           svc.getReqDetails().front().getOps<ServiceImplClientRecordOp>()) {
+        // Any client port with a service implementation record is served by
+        // that service/engine and is therefore user-accessible. Note that the
+        // channel assignments may be empty (e.g. for MMIO ports, which are
+        // described by 'offset'/'size' options rather than channel
+        // assignments).
+        SmallVector<Attribute> portPath(path.begin(), path.end());
+        for (auto id : client.getRelAppIDPath().getAsRange<AppIDAttr>())
+          portPath.push_back(id);
+        servedPortPaths.insert(ArrayAttr::get(&getContext(), portPath));
+      }
+    for (auto node : block->getOps<AppIDHierNodeOp>()) {
+      SmallVector<Attribute> childPath(path.begin(), path.end());
+      childPath.push_back(node.getAppIDAttr());
+      worklist.emplace_back(&node.getChildren().front(), std::move(childPath));
+    }
   }
 }
 
-bool ESIBuildManifestPass::computeKeepNodes(Block &block,
-                                            SmallVectorImpl<Attribute> &path) {
-  bool keep = false;
-  for (auto req : block.getOps<ServiceRequestRecordOp>())
-    if (isPortAccessible(path, req.getRequestorAttr()))
-      keep = true;
-  for (auto node : block.getOps<AppIDHierNodeOp>()) {
-    path.push_back(node.getAppIDAttr());
-    bool childKeep = computeKeepNodes(node.getChildren().front(), path);
-    path.pop_back();
-    if (childKeep) {
-      keepNodes.insert(node);
-      keep = true;
+void ESIBuildManifestPass::computeKeepNodes(Block &rootBlock) {
+  // A node is kept if its child block has a user-accessible request port or any
+  // descendant node is kept. Compute this bottom-up without recursion: first
+  // collect every block in pre-order (so each block precedes its descendants),
+  // then process the list in reverse (so every descendant is visited before its
+  // ancestor).
+  struct WorkItem {
+    Block *block;
+    SmallVector<Attribute> path;
+    AppIDHierNodeOp owner; // Node owning 'block' (null for the root block).
+  };
+  SmallVector<WorkItem> worklist;
+  SmallVector<WorkItem> order;
+  worklist.push_back({&rootBlock, {}, {}});
+  while (!worklist.empty()) {
+    WorkItem item = worklist.pop_back_val();
+    for (auto node : item.block->getOps<AppIDHierNodeOp>()) {
+      SmallVector<Attribute> childPath(item.path.begin(), item.path.end());
+      childPath.push_back(node.getAppIDAttr());
+      worklist.push_back(
+          {&node.getChildren().front(), std::move(childPath), node});
     }
+    order.push_back(std::move(item));
   }
-  return keep;
+
+  // Maps a block to whether it (or a descendant) is to be kept.
+  DenseMap<Block *, bool> blockKeeps;
+  for (WorkItem &item : llvm::reverse(order)) {
+    bool keep = false;
+    for (auto req : item.block->getOps<ServiceRequestRecordOp>())
+      if (isPortAccessible(item.path, req.getRequestorAttr()))
+        keep = true;
+    for (auto node : item.block->getOps<AppIDHierNodeOp>())
+      if (blockKeeps.lookup(&node.getChildren().front()))
+        keep = true;
+    blockKeeps[item.block] = keep;
+    if (keep && item.owner)
+      keepNodes.insert(item.owner);
+  }
 }
 
 void ESIBuildManifestPass::emitNode(llvm::json::OStream &j,

--- a/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
+++ b/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
@@ -59,11 +59,12 @@ private:
   std::string json();
 
   /// Walk the appID hierarchy and record the absolute appID paths of all client
-  /// ports whose channels are bound to a host-reachable engine (i.e. which
-  /// appear in some engine's channel assignment table). These are the only
-  /// ports which are "user accessible": present in the runtime's Accelerator
-  /// design tree.
-  void collectAssignedPorts(Block &block, SmallVectorImpl<Attribute> &path);
+  /// ports which are served by a service or engine (i.e. which appear in some
+  /// service implementation's client record). These are the only ports which
+  /// are "user accessible": those for which the runtime materializes a port in
+  /// the Accelerator design tree. Ports with no service record (e.g. host
+  /// memory ports, or function ports with no implementing engine) are not.
+  void collectServedPorts(Block &block, SmallVectorImpl<Attribute> &path);
 
   /// Walk the appID hierarchy and populate 'keepNodes' with the hierarchy nodes
   /// which contain (or have a descendant which contains) a user-accessible
@@ -75,7 +76,7 @@ private:
   bool isPortAccessible(ArrayRef<Attribute> nodePath, Attribute portID) {
     SmallVector<Attribute> portPath(nodePath.begin(), nodePath.end());
     portPath.push_back(portID);
-    return assignedPortPaths.contains(ArrayAttr::get(&getContext(), portPath));
+    return servedPortPaths.contains(ArrayAttr::get(&getContext(), portPath));
   }
 
   // Type table.
@@ -96,9 +97,14 @@ private:
   DenseSet<SymbolRefAttr> symbols;
   DenseSet<SymbolRefAttr> modules;
 
-  // Absolute appID paths of user-accessible client ports (those bound to a
-  // host-reachable engine via a channel assignment).
-  DenseSet<ArrayAttr> assignedPortPaths;
+  // Modules instantiated anywhere in the (full, unpruned) design hierarchy.
+  // Their metadata is always retained so that 'module_infos' stays complete
+  // even when an instance's subtree is pruned from the design tree.
+  DenseSet<SymbolRefAttr> instantiatedModules;
+
+  // Absolute appID paths of user-accessible client ports (those served by a
+  // service or engine via a client record).
+  DenseSet<ArrayAttr> servedPortPaths;
   // AppID hierarchy nodes to retain (those whose subtree contains a
   // user-accessible client port).
   DenseSet<Operation *> keepNodes;
@@ -125,7 +131,7 @@ void ESIBuildManifestPass::runOnOperation() {
   // since the latter relies on these sets to prune the manifest.
   {
     SmallVector<Attribute> path;
-    collectAssignedPorts(appidRoot.getChildren().front(), path);
+    collectServedPorts(appidRoot.getChildren().front(), path);
     path.clear();
     computeKeepNodes(appidRoot.getChildren().front(), path);
   }
@@ -171,24 +177,28 @@ void ESIBuildManifestPass::runOnOperation() {
   }
 }
 
-void ESIBuildManifestPass::collectAssignedPorts(
+void ESIBuildManifestPass::collectServedPorts(
     Block &block, SmallVectorImpl<Attribute> &path) {
   for (auto svc : block.getOps<ServiceImplRecordOp>())
     for (auto client :
          svc.getReqDetails().front().getOps<ServiceImplClientRecordOp>()) {
-      DictionaryAttr chanAssigns = client.getChannelAssignmentsAttr();
-      // A client port is only user-accessible if its channels are bound to a
-      // host-reachable engine, recorded via a non-empty channel assignment.
-      if (!chanAssigns || chanAssigns.empty())
-        continue;
+      // Any client port with a service implementation record is served by that
+      // service/engine and is therefore user-accessible. Note that the channel
+      // assignments may be empty (e.g. for MMIO ports, which are described by
+      // 'offset'/'size' options rather than channel assignments).
       SmallVector<Attribute> portPath(path.begin(), path.end());
       for (auto id : client.getRelAppIDPath().getAsRange<AppIDAttr>())
         portPath.push_back(id);
-      assignedPortPaths.insert(ArrayAttr::get(&getContext(), portPath));
+      servedPortPaths.insert(ArrayAttr::get(&getContext(), portPath));
     }
   for (auto node : block.getOps<AppIDHierNodeOp>()) {
+    // Record every module instantiated in the (full, unpruned) design
+    // hierarchy so that its metadata (module_infos) is always retained, even
+    // when the instance's subtree is pruned from the design tree because it
+    // contains no user-accessible ports.
+    instantiatedModules.insert(node.getModuleRefAttr());
     path.push_back(node.getAppIDAttr());
-    collectAssignedPorts(node.getChildren().front(), path);
+    collectServedPorts(node.getChildren().front(), path);
     path.pop_back();
   }
 }
@@ -328,12 +338,14 @@ std::string ESIBuildManifestPass::json() {
       FlatSymbolRefAttr sym = symInfo.getSymbolRefAttr();
       if (!sym)
         continue;
-      // Keep a module's metadata if it is instantiated somewhere in the
-      // (pruned) design hierarchy. Additionally, always keep module constants:
-      // they are semantically significant (e.g. for codegen) even when the
-      // module itself is not user-accessible.
+      // Keep a module's metadata if it is instantiated anywhere in the design
+      // hierarchy ('instantiatedModules', collected from the full unpruned
+      // hierarchy) or is otherwise referenced ('symbols'). Additionally, always
+      // keep module constants: they are semantically significant (e.g. for
+      // codegen) even when the module itself is not user-accessible.
       bool isConstants = symInfo.getManifestClass() == "symConsts";
-      if (!symbols.contains(sym) && !isConstants)
+      if (!symbols.contains(sym) && !instantiatedModules.contains(sym) &&
+          !isConstants)
         continue;
       symbolInfoLookup[sym].push_back(symInfo);
     }

--- a/test/Dialect/ESI/manifest.mlir
+++ b/test/Dialect/ESI/manifest.mlir
@@ -157,18 +157,7 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 
 // CHECK-LABEL:   "design": {
 // CHECK-NEXT:      "instanceOf": "@top",
-// CHECK-NEXT:      "clientPorts": [
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "appID": {
-// CHECK-NEXT:            "name": "func1"
-// CHECK-NEXT:          },
-// CHECK-NEXT:          "typeID": "!esi.bundle<[!esi.channel<i16> to \"arg\", !esi.channel<i16> from \"result\"]>",
-// CHECK-NEXT:          "servicePort": {
-// CHECK-NEXT:            "port": "call",
-// CHECK-NEXT:            "serviceName": "@funcs"
-// CHECK-NEXT:          }
-// CHECK-NEXT:        }
-// CHECK-NEXT:      ],
+// CHECK-NEXT:      "clientPorts": [],
 
 // CHECK-LABEL:     "engines": [
 // CHECK-NEXT:        {
@@ -507,16 +496,6 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // CHECK-NEXT:        ]
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
-// CHECK-NEXT:        "symbol": "@funcs",
-// CHECK-NEXT:        "serviceName": "esi.service.std.func",
-// CHECK-NEXT:        "ports": [
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "name": "call",
-// CHECK-NEXT:            "typeID": "!esi.bundle<[!esi.channel<!esi.any> to \"arg\", !esi.channel<!esi.any> from \"result\"]>"
-// CHECK-NEXT:          }
-// CHECK-NEXT:        ]
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
 // CHECK-NEXT:        "symbol": "@WindowService",
 // CHECK-NEXT:        "ports": [
 // CHECK-NEXT:          {
@@ -561,48 +540,6 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // CHECK-NEXT:    ],
 
 // CHECK-LABEL:   "types": [
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "channels": [
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "direction": "to",
-// CHECK-NEXT:            "name": "arg",
-// CHECK-NEXT:            "type": {
-// CHECK-NEXT:              "dialect": "esi",
-// CHECK-NEXT:              "hwBitwidth": 16,
-// CHECK-NEXT:              "id": "!esi.channel<i16>",
-// CHECK-NEXT:              "inner": {
-// CHECK-NEXT:                "dialect": "builtin",
-// CHECK-NEXT:                "hwBitwidth": 16,
-// CHECK-NEXT:                "id": "i16",
-// CHECK-NEXT:                "mnemonic": "int",
-// CHECK-NEXT:                "signedness": "signless"
-// CHECK-NEXT:              },
-// CHECK-NEXT:              "mnemonic": "channel"
-// CHECK-NEXT:            }
-// CHECK-NEXT:          },
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "direction": "from",
-// CHECK-NEXT:            "name": "result",
-// CHECK-NEXT:            "type": {
-// CHECK-NEXT:              "dialect": "esi",
-// CHECK-NEXT:              "hwBitwidth": 16,
-// CHECK-NEXT:              "id": "!esi.channel<i16>",
-// CHECK-NEXT:              "inner": {
-// CHECK-NEXT:                "dialect": "builtin",
-// CHECK-NEXT:                "hwBitwidth": 16,
-// CHECK-NEXT:                "id": "i16",
-// CHECK-NEXT:                "mnemonic": "int",
-// CHECK-NEXT:                "signedness": "signless"
-// CHECK-NEXT:              },
-// CHECK-NEXT:              "mnemonic": "channel"
-// CHECK-NEXT:            }
-// CHECK-NEXT:          }
-// CHECK-NEXT:        ],
-// CHECK-NEXT:        "dialect": "esi",
-// CHECK-NEXT:        "hwBitwidth": 36,
-// CHECK-NEXT:        "id": "!esi.bundle<[!esi.channel<i16> to \"arg\", !esi.channel<i16> from \"result\"]>",
-// CHECK-NEXT:        "mnemonic": "bundle"
-// CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "channels": [
 // CHECK-NEXT:          {
@@ -946,41 +883,6 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // CHECK-NEXT:        "dialect": "esi",
 // CHECK-NEXT:        "hwBitwidth": 258,
 // CHECK-NEXT:        "id": "!esi.bundle<[!esi.channel<!esi.window<\"BulkTransferWindow\", !hw.struct<address: i32, data: !esi.list<i64>>, [<\"HeaderFrame\", [<\"address\">, <\"data\" countWidth 8>]>, <\"DataFrame\", [<\"data\", 4>]>]>> to \"bulk_in\"]>",
-// CHECK-NEXT:        "mnemonic": "bundle"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "channels": [
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "direction": "to",
-// CHECK-NEXT:            "name": "arg",
-// CHECK-NEXT:            "type": {
-// CHECK-NEXT:              "dialect": "esi",
-// CHECK-NEXT:              "id": "!esi.channel<!esi.any>",
-// CHECK-NEXT:              "inner": {
-// CHECK-NEXT:                "dialect": "esi",
-// CHECK-NEXT:                "id": "!esi.any",
-// CHECK-NEXT:                "mnemonic": "any"
-// CHECK-NEXT:              },
-// CHECK-NEXT:              "mnemonic": "channel"
-// CHECK-NEXT:            }
-// CHECK-NEXT:          },
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "direction": "from",
-// CHECK-NEXT:            "name": "result",
-// CHECK-NEXT:            "type": {
-// CHECK-NEXT:              "dialect": "esi",
-// CHECK-NEXT:              "id": "!esi.channel<!esi.any>",
-// CHECK-NEXT:              "inner": {
-// CHECK-NEXT:                "dialect": "esi",
-// CHECK-NEXT:                "id": "!esi.any",
-// CHECK-NEXT:                "mnemonic": "any"
-// CHECK-NEXT:              },
-// CHECK-NEXT:              "mnemonic": "channel"
-// CHECK-NEXT:            }
-// CHECK-NEXT:          }
-// CHECK-NEXT:        ],
-// CHECK-NEXT:        "dialect": "esi",
-// CHECK-NEXT:        "id": "!esi.bundle<[!esi.channel<!esi.any> to \"arg\", !esi.channel<!esi.any> from \"result\"]>",
 // CHECK-NEXT:        "mnemonic": "bundle"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {


### PR DESCRIPTION
There's a bunch of unnecessary stuff in ESI (in-accelerator) manifests. This commit slims it down to only the stuff which the user can actually use. In an internal build of the internal version of esitester, it reduces the size of the manifest by ~60% and the compressed manifest by ~50%.

Assisted-b: vscode:Claude Opus 4.8
