### PR TITLE
[Debug] [1/13] Add EnumOp and ValueOp to the Debug dialect

### DIFF
--- a/include/circt/Dialect/Debug/DebugOps.td
+++ b/include/circt/Dialect/Debug/DebugOps.td
@@ -65,6 +65,10 @@ def VariableOp : DebugOp<"variable"> {
     these source language values can be reconstituted from the actual IR values
     present at the end of compilation.
 
+    An enum-typed variable embeds a `dbg.enum` value, which carries the named
+    variants. Source-language type information is not carried on the variable
+    itself; wrap the value in a `dbg.value` to attach it.
+
     See the rationale for examples and details. See the `dbg.scope` operation
     for additional details on how to use the `scope` operand.
   }];
@@ -78,6 +82,68 @@ def VariableOp : DebugOp<"variable"> {
   }];
 }
 
+
+def ValueOp : DebugOp<"value"> {
+  let summary = "Attach source-language metadata to a value";
+  let description = [{
+    Annotates an SSA value with additional source-language information: the
+    source type name, its constructor parameters, and a dedicated location.
+    The result is a metadata wrapper accepted wherever other debug operations
+    accept plain values (`dbg.variable`, `dbg.struct`, `dbg.array`); consumers
+    unwrap it to reach the underlying value. Keeping the metadata on a
+    separate wrapper keeps `dbg.variable` and the aggregate ops orthogonal to
+    source-language type information.
+
+    An enum-typed value embeds a `dbg.enum`, so no enum linkage is carried on
+    the wrapper itself. Freshly-created ops with no users are tolerated by
+    the verifier to accommodate construction patterns; any surviving user
+    must be a debug-dialect op.
+  }];
+  let arguments = (ins
+    AnyType:$value,
+    OptionalAttr<StrAttr>:$typeName,
+    OptionalAttr<ArrayAttr>:$params
+  );
+  let results = (outs ValueType:$result);
+  let assemblyFormat = [{
+    $value (`typeName` $typeName^)? (`params` $params^)?
+        attr-dict `:` type($value)
+  }];
+  let hasVerifier = 1;
+}
+
+def EnumOp : DebugOp<"enum", [Pure]> {
+  let summary = "Interpret an integer value as an enumeration";
+  let description = [{
+    Wraps an integer value as a tag-only (C-style) enumeration, producing an
+    enum-typed debug value. Behaves like a cast: the `value` operand is the raw
+    integer tag, and `variantsMap` provides the `name -> tag` mapping consumers
+    use to reconstruct the named variant. The result is an ordinary value that
+    can be embedded in `dbg.variable`, `dbg.struct`, and `dbg.array` just like
+    any other debug value, so enum tracking needs no separate definition op,
+    scope, or subfield linkage.
+
+    `enumTypeName` is the source-language type name; the optional `fqn` is the
+    fully-qualified name used as the stable type-pool key. Consumers use it to
+    dedup identical enums that appear at many use sites or across modules.
+
+    This models tag-only enums: `variantsMap` is keyed by variant name with
+    `IntegerAttr` tags and has no slot for per-variant payload types, so
+    data-carrying variants are out of scope.
+  }];
+  let arguments = (ins
+    AnyType:$value,
+    StrAttr:$enumTypeName,
+    DictionaryAttr:$variantsMap,
+    OptionalAttr<StrAttr>:$fqn
+  );
+  let results = (outs EnumType:$result);
+  let assemblyFormat = [{
+    $value `,` $enumTypeName `,` $variantsMap (`fqn` $fqn^)? attr-dict
+        `:` type($value)
+  }];
+  let hasVerifier = 1;
+}
 
 def StructOp : DebugOp<"struct", [
   Pure,

--- a/include/circt/Dialect/Debug/DebugTypes.td
+++ b/include/circt/Dialect/Debug/DebugTypes.td
@@ -32,4 +32,16 @@ def ArrayType : DebugTypeDef<"Array"> {
   let description = "The result of a `dbg.array` operation.";
 }
 
+def ValueType : DebugTypeDef<"Value"> {
+  let mnemonic = "value";
+  let summary = "debug value annotated with source-language metadata";
+  let description = "The result of a `dbg.value` operation.";
+}
+
+def EnumType : DebugTypeDef<"Enum"> {
+  let mnemonic = "enum";
+  let summary = "debug enum value";
+  let description = "The result of a `dbg.enum` operation.";
+}
+
 #endif // CIRCT_DIALECT_DEBUG_DEBUGTYPES_TD

--- a/lib/Dialect/Debug/DebugOps.cpp
+++ b/lib/Dialect/Debug/DebugOps.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/Debug/DebugOps.h"
 #include "mlir/IR/OpImplementation.h"
+#include "llvm/ADT/DenseSet.h"
 
 using namespace circt;
 using namespace debug;
@@ -115,7 +116,9 @@ void ArrayOp::print(OpAsmPrinter &printer) {
   }
 }
 
-// Operation implementations generated from `Debug.td`
+//===----------------------------------------------------------------------===//
+// Generated operation code
+//===----------------------------------------------------------------------===//
 #define GET_OP_CLASSES
 #include "circt/Dialect/Debug/Debug.cpp.inc"
 
@@ -124,4 +127,45 @@ void DebugDialect::registerOps() {
 #define GET_OP_LIST
 #include "circt/Dialect/Debug/Debug.cpp.inc"
       >();
+}
+
+//===----------------------------------------------------------------------===//
+// ValueOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ValueOp::verify() {
+  // Final IR is expected to have >=1 user (dbg.variable/dbg.struct/dbg.array).
+  if (!llvm::all_of(getResult().getUsers(), [](Operation *user) {
+        return isa<VariableOp, StructOp, ArrayOp>(user);
+      }))
+    return emitOpError(
+        "must only be used as an operand of dbg.variable, dbg.struct, or "
+        "dbg.array");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// EnumOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult EnumOp::verify() {
+  if (getVariantsMap().empty())
+    return emitOpError("variantsMap must not be empty");
+
+  llvm::SmallDenseSet<int64_t> seenValues{};
+  for (auto namedAttr : getVariantsMap()) {
+    auto intAttr = dyn_cast<IntegerAttr>(namedAttr.getValue());
+    if (!intAttr)
+      return emitOpError("variantsMap entry '")
+             << namedAttr.getName().getValue()
+             << "' must be an IntegerAttr, got " << namedAttr.getValue();
+    if (!intAttr.getType().isSignlessInteger())
+      return emitOpError() << "variant '" << namedAttr.getName().getValue()
+                           << "' must have a signless integer value";
+    auto value = intAttr.getInt();
+    if (!seenValues.insert(value).second)
+      return emitOpError("duplicate enum value ") << value;
+  }
+  return success();
 }

--- a/test/Dialect/Debug/enum-ssa-roundtrip.mlir
+++ b/test/Dialect/Debug/enum-ssa-roundtrip.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt --verify-roundtrip %s | FileCheck %s
+
+module {
+  func.func @Test() {
+    %0 = arith.constant 0 : i2
+
+    // CHECK: %{{.+}} = dbg.enum %{{.*}}, "MyState", {A = 0 : i64, B = 1 : i64} fqn "pkg.MyState" : i2
+    %e = dbg.enum %0, "MyState", {A = 0 : i64, B = 1 : i64} fqn "pkg.MyState" : i2
+    dbg.variable "v", %e : !dbg.enum
+
+    // CHECK: %{{.+}} = dbg.enum %{{.*}}, "NoFqn", {X = 0 : i2} : i2
+    %f = dbg.enum %0, "NoFqn", {X = 0 : i2} : i2
+    dbg.variable "w", %f : !dbg.enum
+
+    return
+  }
+}

--- a/test/Dialect/Debug/enum-verify-errors.mlir
+++ b/test/Dialect/Debug/enum-verify-errors.mlir
@@ -1,0 +1,62 @@
+// RUN: circt-opt %s --verify-diagnostics --split-input-file
+
+// -----
+// dbg.enum with a non-IntegerAttr variant value.
+
+func.func @EnumNonIntegerAttr() {
+  %c = arith.constant 0 : i2
+  // expected-error @+1 {{variantsMap entry 'A' must be an IntegerAttr}}
+  %e = dbg.enum %c, "MyState", {A = "not-an-int"} : i2
+  return
+}
+
+// -----
+// dbg.enum with duplicate variant values.
+
+func.func @EnumDuplicateValues() {
+  %c = arith.constant 0 : i2
+  // expected-error @+1 {{duplicate enum value 0}}
+  %e = dbg.enum %c, "MyState", {A = 0 : i64, B = 0 : i64} : i2
+  return
+}
+
+// -----
+// dbg.value used by a non-variable/struct/array op triggers verifier error.
+
+func.func @ValueBadUser() {
+  %c = arith.constant 0 : i32
+  // expected-error @+1 {{must only be used as an operand of dbg.variable, dbg.struct, or dbg.array}}
+  %v = dbg.value %c : i32
+  %v2 = dbg.value %v : !dbg.value
+  return
+}
+
+// -----
+// dbg.enum with an empty variantsMap is semantically useless and rejected.
+
+func.func @EnumEmptyVariants() {
+  %c = arith.constant 0 : i2
+  // expected-error @+1 {{variantsMap must not be empty}}
+  %e = dbg.enum %c, "Empty", {} : i2
+  return
+}
+
+// -----
+// dbg.enum variant value with signed integer type (si64) must be rejected.
+
+func.func @EnumSignedVariant() {
+  %c = arith.constant 0 : i2
+  // expected-error @+1 {{variant 'A' must have a signless integer value}}
+  %e = dbg.enum %c, "MyState", {A = 0 : si64} : i2
+  return
+}
+
+// -----
+// dbg.enum variant value with unsigned integer type (ui64) must be rejected.
+
+func.func @EnumUnsignedVariant() {
+  %c = arith.constant 0 : i2
+  // expected-error @+1 {{variant 'A' must have a signless integer value}}
+  %e = dbg.enum %c, "MyState", {A = 0 : ui64} : i2
+  return
+}

--- a/test/Dialect/Debug/ops.mlir
+++ b/test/Dialect/Debug/ops.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt %s --verify-roundtrip | FileCheck %s
+//
+// Parser/printer round-trip for ops introduced alongside source-language
+// type tracking: dbg.enum embedded in a dbg.variable.
+// Aggregate/scope shapes are covered in basic.mlir.
+
+// CHECK-LABEL: func.func @EnumAndVariable
+func.func @EnumAndVariable() {
+  %c = arith.constant 0 : i2
+  // CHECK: %[[E:.+]] = dbg.enum %{{.*}}, "MyState", {Idle = 0 : i64, Run = 1 : i64} fqn "pkg.MyState$" : i2
+  %e = dbg.enum %c, "MyState", {Idle = 0 : i64, Run = 1 : i64} fqn "pkg.MyState$" : i2
+  // CHECK: %[[V:.+]] = dbg.value %[[E]] typeName "MyState" : !dbg.enum
+  %v = dbg.value %e typeName "MyState" : !dbg.enum
+  // CHECK: dbg.variable "state", %[[V]] : !dbg.value
+  dbg.variable "state", %v : !dbg.value
+  return
+}
+
+// CHECK-LABEL: func.func @EnumNoFqn
+func.func @EnumNoFqn() {
+  %c = arith.constant 0 : i2
+  // CHECK: dbg.enum %{{.*}}, "S", {A = 0 : i64} : i2
+  %e = dbg.enum %c, "S", {A = 0 : i64} : i2
+  dbg.variable "s", %e : !dbg.enum
+  return
+}


### PR DESCRIPTION
`EnumOp` interprets an integer value as a tag-only enumeration, carrying the name -> tag variant map in its attributes and producing an enum-typed debug value (`EnumType`). It behaves like a cast: the result embeds directly in `dbg.variable`, `dbg.struct`, and `dbg.array` like any other value, so enum tracking needs no separate definition op, scope, or wrapper linkage. The op is `Pure` since it has no side effects and its result is fully determined by its operands and attributes, so unused casts fold away under DCE while identical-content enums deduplicate across modules by content key at emission.

`ValueOp` annotates an SSA value with optional source-language type metadata (type name and constructor parameters) and a dedicated location. Its result is a metadata wrapper accepted by `dbg.variable`, `dbg.struct`, and `dbg.array`, keeping those ops orthogonal to source-language type information; an enum value wraps in a `dbg.enum` first, so no enum linkage is carried on the wrapper itself.

Based on @rameloni's work
