### PR TITLE
[Moore][ImportVerilog] Add %c format to FormatString pipeline

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2839,6 +2839,20 @@ def FormatHierPathOp : MooreOp<"fmt.hier_path", [Pure]> {
   let assemblyFormat = "(`escaped` $useEscapes^)? attr-dict";
 }
 
+def FormatCharOp : MooreOp<"fmt.char", [Pure]> {
+  let summary = "Display in ASCII character format";
+  let description = [{
+    Format string fragment that formats the given integer value as a single
+    ASCII character. This corresponds to the `%c` (or `%C`) format specifier
+    in SystemVerilog.
+
+    See IEEE 1800-2017 § 21.2.1.2 "Format specifications".
+  }];
+  let arguments = (ins IntType:$value);
+  let results = (outs FormatStringType:$result);
+  let assemblyFormat = "$value `:` type($value) attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Builtin System Tasks and Functions
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -150,6 +150,8 @@ struct FormatStringParser {
 
     case 's':
       return emitString(arg, options);
+    case 'c':
+      return emitChar(arg, options);
 
     default:
       return mlir::emitError(loc)
@@ -291,6 +293,24 @@ struct FormatStringParser {
 
     return mlir::emitError(context.convertLocation(arg.sourceRange))
            << "expression cannot be formatted as string";
+  }
+
+  LogicalResult emitChar(const slang::ast::Expression &arg,
+                         const FormatOptions &options) {
+    if (options.width)
+      return mlir::emitError(loc)
+             << "character format specifier with width not supported";
+
+    auto value = context.convertRvalueExpression(arg);
+    if (!value)
+      return failure();
+
+    auto bitValue = context.convertToSimpleBitVector(value);
+    if (!bitValue)
+      return failure();
+
+    fragments.push_back(moore::FormatCharOp::create(builder, loc, bitValue));
+    return success();
   }
 
   /// Emit an expression argument with the appropriate default formatting.

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2624,6 +2624,17 @@ struct FormatRealOpConversion : public OpConversionPattern<FormatRealOp> {
   }
 };
 
+struct FormatCharOpConversion
+    : public OpConversionPattern<moore::FormatCharOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(moore::FormatCharOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::FormatCharOp>(op, adaptor.getValue());
+    return success();
+  }
+};
+
 struct StringLenOpConversion : public OpConversionPattern<StringLenOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -3573,6 +3584,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FormatHierPathOpConversion,
     FormatIntOpConversion,
     FormatRealOpConversion,
+    FormatCharOpConversion,
     DisplayBIOpConversion,
     FDisplayBIOpConversion,
 

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -248,6 +248,20 @@ function void DisplayAndSeverityBuiltins(int x, real r);
   if (0) $fatal(1, "%f", r);
 endfunction
 
+// CHECK-LABEL: func.func private @FormatCharSpecifier(
+function void FormatCharSpecifier();
+  byte ch = 88;
+  int ch_int = 235800858;
+  // CHECK: moore.fmt.char {{%.+}} : i8
+  $display("%c", ch);
+  // CHECK: moore.fmt.char {{%.+}} : i8
+  $display("%C", ch);
+  // CHECK: moore.fmt.char {{%.+}} : i32
+  $display("%c", ch_int);
+  // CHECK: moore.fmt.char {{%.+}} : i32
+  $display("%C", ch_int);
+endfunction
+
 // IEEE 1800-2017 § 20.8 "Math functions"
 // CHECK-LABEL: func.func private @MathBuiltins(
 // CHECK-SAME: [[X:%.+]]: !moore.i32

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -386,7 +386,7 @@ func.func @Statements(%arg0: !moore.i42) {
 }
 
 // CHECK-LABEL: func @FormatStrings
-func.func @FormatStrings(%arg0: !moore.i42, %arg1: !moore.f32, %arg2: !moore.f64, %arg3: !moore.string) {
+func.func @FormatStrings(%arg0: !moore.i42, %arg1: !moore.f32, %arg2: !moore.f64, %arg3: !moore.string, %arg4: !moore.i8) {
   // CHECK: [[TMP:%.+]] = sim.fmt.literal "hello"
   %0 = moore.fmt.literal "hello"
   // CHECK: sim.fmt.concat ([[TMP]], [[TMP]])
@@ -440,6 +440,11 @@ func.func @FormatStrings(%arg0: !moore.i42, %arg1: !moore.f32, %arg2: !moore.f64
 
   // CHECK: sim.proc.print [[TMP]]
   moore.builtin.display %0
+
+  // CHECK: sim.fmt.char %arg0 : i42
+  moore.fmt.char %arg0 : i42
+  // CHECK: sim.fmt.char %arg4 : i8
+  moore.fmt.char %arg4 : i8
   return
 }
 


### PR DESCRIPTION
- Add Moore op `moore.fmt.char`, which corresponds to the %c format specifier.
- Lower it to `sim.fmt.char`.
- Add some tests in `builtins.sv`.
