### PR TITLE
[ESI][Runtime] pytest: fix the setup for integrated builds

### DIFF
--- a/lib/Dialect/ESI/runtime/tests/conftest.py
+++ b/lib/Dialect/ESI/runtime/tests/conftest.py
@@ -10,16 +10,26 @@ collect_ignore_glob = [
 
 
 def _looks_like_runtime_root(root: Path) -> bool:
+  return _has_runtime_root_markers(root) or _has_runtime_library_markers(root)
+
+
+def _has_runtime_root_markers(root: Path) -> bool:
   markers = [
       root / "cmake" / "esiaccelConfig.cmake",
       root / "cpp" / "cmake" / "esiaccelConfig.cmake",
       root / "cpp" / "include" / "esi" / "Accelerator.h",
       root / "include" / "esi" / "Accelerator.h",
+      root / "tests" / "cpp",
+      root / "bin",
+  ]
+  return any(marker.exists() for marker in markers)
+
+
+def _has_runtime_library_markers(root: Path) -> bool:
+  markers = [
       root / "lib" / "libESICppRuntime.so",
       root / "lib" / "libESICppRuntime.dylib",
       root / "ESICppRuntime.dll",
-      root / "tests" / "cpp",
-      root / "bin",
   ]
   return any(marker.exists() for marker in markers)
 
@@ -46,10 +56,21 @@ def get_runtime_root() -> Path:
   ]
 
   seen = set()
+  unique_candidates = []
   for candidate in candidates:
-    if candidate in seen:
-      continue
-    seen.add(candidate)
+    if candidate not in seen:
+      unique_candidates.append(candidate)
+      seen.add(candidate)
+
+  # Prefer roots with headers, CMake package files, binaries, or the runtime
+  # test tree over lib-only package directories. In integrated CIRCT builds,
+  # the Python package may contain library symlinks while the source headers
+  # are only discoverable by walking up from the broader runtime build root.
+  for candidate in unique_candidates:
+    if _has_runtime_root_markers(candidate):
+      return candidate
+
+  for candidate in unique_candidates:
     if _looks_like_runtime_root(candidate):
       return candidate
 

--- a/lib/Dialect/ESI/runtime/tests/integration/conftest.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/conftest.py
@@ -92,7 +92,7 @@ def build_cpp_test(sources_dir: Path,
   * ``build_subdir``: name for the build directory under ``sources_dir``.
     Defaults to ``target``.
 
-  The configure step is skipped when the build directory already exists;
+  The configure step is skipped when the Ninja build file already exists;
   ``cmake --build`` always runs so that CMake's own dependency tracking
   picks up any source or generated-header changes.
   """
@@ -109,7 +109,10 @@ def build_cpp_test(sources_dir: Path,
   include_dir = sources_dir / "cpp_include"
   generated_dir = include_dir / header_subdir
 
-  if not build_dir.exists():
+  if not (build_dir / "build.ninja").exists():
+    if build_dir.exists():
+      shutil.rmtree(build_dir)
+
     generated_dir.mkdir(parents=True, exist_ok=True)
 
     codegen_src = sources_dir / "generated"


### PR DESCRIPTION
The paths are different for integrated builds. Add support for them as well.

Assisted-by: vscode:GPT-5.5
