### PR TITLE
[HWArith] HW lowering: add support for unions

### DIFF
--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -119,6 +119,11 @@ static bool isSignednessType(Type type) {
               return isSignednessType(element.type);
             });
           })
+          .Case<hw::UnionType>([](auto type) {
+            return llvm::any_of(type.getElements(), [](auto element) {
+              return isSignednessType(element.type);
+            });
+          })
           .Case<hw::InOutType>(
               [](auto type) { return isSignednessType(type.getElementType()); })
           .Case<hw::TypeAliasType>(
@@ -382,6 +387,15 @@ Type HWArithToHWTypeConverter::removeSignedness(Type type) {
                   {element.name, removeSignedness(element.type)});
             }
             return hw::StructType::get(type.getContext(), convertedElements);
+          })
+          .Case<hw::UnionType>([this](auto type) {
+            llvm::SmallVector<hw::UnionType::FieldInfo> convertedElements;
+            for (auto element : type.getElements()) {
+              convertedElements.push_back({element.name,
+                                           removeSignedness(element.type),
+                                           element.offset});
+            }
+            return hw::UnionType::get(type.getContext(), convertedElements);
           })
           .Case<hw::InOutType>([this](auto type) {
             return hw::InOutType::get(removeSignedness(type.getElementType()));

--- a/test/Conversion/HWArithToHW/test_basic.mlir
+++ b/test/Conversion/HWArithToHW/test_basic.mlir
@@ -314,6 +314,18 @@ hw.module @structAndArrays(in %a: ui8, in %b: ui8, out out: !hw.struct<foo: !hw.
 
 // -----
 
+// Type conversions of union ops.
+// CHECK:      hw.module @unions(in %a : i8, out out : !hw.union<foo: i8>) {
+// CHECK-NEXT:   %[[OUT:.*]] = hw.union_create "foo", %a : !hw.union<foo: i8>
+// CHECK-NEXT:   hw.output %[[OUT]] : !hw.union<foo: i8>
+// CHECK-NEXT: }
+hw.module @unions(in %a: ui8, out out: !hw.union<foo: ui8>) {
+  %out = hw.union_create "foo", %a : !hw.union<foo: ui8>
+  hw.output %out : !hw.union<foo: ui8>
+}
+
+// -----
+
 // CHECK: hw.module.extern @externHWModule(in %a : i8, in %b : i8, out out : !hw.struct<foo: !hw.array<2xi8>>)
 hw.module.extern @externHWModule(in %a: ui8, in %b: ui8, out out: !hw.struct<foo: !hw.array<2xui8>>)
 


### PR DESCRIPTION
The HWArithToHW pass was lacking support for hw.union types. Add it.

Assisted-by: vscode:GPT-5.5
