### PR TITLE
[ImportVerilog] Introduce some string-builtin methods

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3579,6 +3579,32 @@ def StringLenOp : StringBuiltin<"len"> {
   let assemblyFormat = "$str attr-dict";
 }
 
+def StringPutOp : StringBuiltin<"put"> {
+  let summary = "Replace a character in a string";
+  let description = [{
+    Replaces the character at the specified index with the character
+    represented by the integer value.
+  }];
+  let arguments = (ins
+    StringRefType:$str,
+    TwoValuedI32:$index,
+    TwoValuedI8:$character
+  );
+  let assemblyFormat = [{
+    $str `[` $index `]` `,` $character attr-dict `:` type($str)
+  }];
+}
+
+def StringGetOp : StringBuiltin<"get"> {
+  let summary = "Get a character from a string";
+  let description = [{
+    Returns the character at the specified index in the given string.
+  }];
+  let arguments = (ins StringType:$str, TwoValuedI32:$index);
+  let results = (outs TwoValuedI8:$result);
+  let assemblyFormat = "$str `[` $index `]` attr-dict";
+}
+
 def StringToUpperOp : StringBuiltin<"toupper"> {
   let summary = "Convert a string to uppercase";
   let description = [{
@@ -3599,14 +3625,89 @@ def StringToLowerOp : StringBuiltin<"tolower"> {
   let assemblyFormat = "$str attr-dict";
 }
 
-def StringGetOp : StringBuiltin<"get"> {
-  let summary = "Get a character from a string";
+class StringCompareOpBase<string mnemonic> : StringBuiltin<mnemonic> {
+  let summary = "Lexicographically compare two strings";
   let description = [{
-    Returns the character at the specified index in the given string.
+    As in the ANSI C `strcmp` function with regard to lexical ordering
+    and return value.
   }];
-  let arguments = (ins StringType:$str, TwoValuedI32:$index);
-  let results = (outs TwoValuedI8:$result);
-  let assemblyFormat = "$str `[` $index `]` attr-dict";
+  let arguments = (ins StringType:$lhs, StringType:$rhs);
+  let results = (outs TwoValuedI32:$result);
+  let assemblyFormat = "$lhs `,` $rhs attr-dict";
+}
+
+def StringCompareOp : StringCompareOpBase<"compare">;
+def StringICompareOp : StringCompareOpBase<"icompare"> {
+  let summary = "Case-insensitive compare";
+}
+
+def StringSubstrOp : StringBuiltin<"substr"> {
+  let summary = "Extract a substring";
+  let description = [{
+    Returns the characters from the start through end indices inclusive, or
+    the empty string if the range is invalid.
+  }];
+  let arguments = (ins
+    StringType:$str,
+    TwoValuedI32:$start,
+    TwoValuedI32:$end
+  );
+  let results = (outs StringType:$result);
+  let assemblyFormat = [{
+    $str `[` $start `:` $end `]` attr-dict
+  }];
+}
+
+class StringAToIOpBase<string mnemonic> : StringBuiltin<mnemonic> {
+  let summary = "Convert a string to an integer";
+  let description = [{
+    Converts the ASCII representation in the given string into a 32-bit
+    integer value, or returns zero if no digits were encountered.
+  }];
+  let arguments = (ins StringType:$str);
+  let results = (outs FourValuedI32:$result);
+  let assemblyFormat = [{
+    $str attr-dict `:` type($result)
+  }];
+}
+
+def StringAtoiOp : StringAToIOpBase<"atoi">;
+def StringAtohexOp : StringAToIOpBase<"atohex">;
+def StringAtooctOp : StringAToIOpBase<"atooct">;
+def StringAtobinOp : StringAToIOpBase<"atobin">;
+
+def StringAtorealOp : StringBuiltin<"atoreal"> {
+  let summary = "Convert a string to a real number";
+  let description = [{
+    Converts the ASCII decimal representation in the given string into a
+    real number, or returns zero if no digits were encountered.
+  }];
+  let arguments = (ins StringType:$str);
+  let results = (outs RealType:$result);
+  let assemblyFormat = [{
+    $str attr-dict `:` type($result)
+  }];
+}
+
+class StringIToAOpBase<string mnemonic> : StringBuiltin<mnemonic> {
+  let summary = "inverse of StringAToIOpBase";
+  let arguments = (ins StringRefType:$str, FourValuedI32:$input);
+  let assemblyFormat = [{
+    $str `,` $input attr-dict `:` type($str) `,` type($input)
+  }];
+}
+
+def StringItoaOp : StringIToAOpBase<"itoa">;
+def StringHextoaOp : StringIToAOpBase<"hextoa">;
+def StringOcttoaOp : StringIToAOpBase<"octtoa">;
+def StringBintoaOp : StringIToAOpBase<"bintoa">;
+
+def StringRealtoaOp : StringBuiltin<"realtoa"> {
+  let summary = "inverse of atoreal";
+  let arguments = (ins StringRefType:$str, RealType:$input);
+  let assemblyFormat = [{
+    $str `,` $input attr-dict `:` type($str) `,` type($input)
+  }];
 }
 
 def StringConcatOp : StringBuiltin<"concat"> {

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -585,6 +585,9 @@ class SpecificRefType<Type type> : ConfinedType<RefType,
   Type nestedType = type;
 }
 
+/// String references.
+def StringRefType : SpecificRefType<StringType>;
+
 /// Struct references.
 def StructRefType : SpecificRefType<StructType>;
 def UnpackedStructRefType : SpecificRefType<UnpackedStructType>;

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3506,6 +3506,17 @@ Value Context::convertSystemCall(
     return moore::StringLenOp::create(builder, loc, value);
   }
 
+  if (nameId == ksn::Getc) {
+    // Slang already checks the arity of string methods.
+    assert(numArgs == 2 && "`getc` takes 2 arguments");
+    auto stringType = moore::StringType::get(getContext());
+    auto str = convertRvalueExpression(*args[0], stringType);
+    auto index = convertRvalueExpression(*args[1]);
+    if (!str || !index)
+      return {};
+    return moore::StringGetOp::create(builder, loc, str, index);
+  }
+
   if (nameId == ksn::ToUpper) {
     // Slang already checks the arity of string methods.
     assert(numArgs == 1 && "`toupper` takes 1 argument");
@@ -3526,15 +3537,63 @@ Value Context::convertSystemCall(
     return moore::StringToLowerOp::create(builder, loc, value);
   }
 
-  if (nameId == ksn::Getc) {
+  if (nameId == ksn::Compare || nameId == ksn::ICompare) {
     // Slang already checks the arity of string methods.
-    assert(numArgs == 2 && "`getc` takes 2 arguments");
+    assert(numArgs == 2);
+    auto stringType = moore::StringType::get(getContext());
+    auto lhs = convertRvalueExpression(*args[0], stringType);
+    auto rhs = convertRvalueExpression(*args[1], stringType);
+    if (!lhs || !rhs)
+      return {};
+    if (nameId == ksn::Compare)
+      return moore::StringCompareOp::create(builder, loc, lhs, rhs);
+    return moore::StringICompareOp::create(builder, loc, lhs, rhs);
+  }
+
+  if (nameId == ksn::Substr) {
+    // Slang already checks the arity of string methods.
+    assert(numArgs == 3 && "`substr` takes 3 arguments");
     auto stringType = moore::StringType::get(getContext());
     auto str = convertRvalueExpression(*args[0], stringType);
-    auto index = convertRvalueExpression(*args[1]);
-    if (!str || !index)
+    auto start = convertRvalueExpression(*args[1]);
+    auto end = convertRvalueExpression(*args[2]);
+    if (!str || !start || !end)
       return {};
-    return moore::StringGetOp::create(builder, loc, str, index);
+    return moore::StringSubstrOp::create(builder, loc, str, start, end);
+  }
+
+  if (nameId == ksn::AToI || nameId == ksn::AToHex || nameId == ksn::AToOct ||
+      nameId == ksn::AToBin) {
+    // Slang already checks the arity of string methods.
+    assert(numArgs == 1 && "`atoi/hex/oct/bin` takes 1 argument");
+    auto stringType = moore::StringType::get(getContext());
+    auto str = convertRvalueExpression(*args[0], stringType);
+    if (!str)
+      return {};
+    auto integerType = moore::IntType::getLogic(builder.getContext(), 32);
+    switch (nameId) {
+    case ksn::AToI:
+      return moore::StringAtoiOp::create(builder, loc, integerType, str);
+    case ksn::AToHex:
+      return moore::StringAtohexOp::create(builder, loc, integerType, str);
+    case ksn::AToOct:
+      return moore::StringAtooctOp::create(builder, loc, integerType, str);
+    case ksn::AToBin:
+      return moore::StringAtobinOp::create(builder, loc, integerType, str);
+    default:
+      llvm_unreachable("unexpected string to integer conversion");
+    }
+  }
+
+  if (nameId == ksn::AToReal) {
+    // Slang already checks the arity of string methods.
+    assert(numArgs == 1 && "`atoreal` takes 1 argument");
+    auto stringType = moore::StringType::get(getContext());
+    auto str = convertRvalueExpression(*args[0], stringType);
+    if (!str)
+      return {};
+    auto realType = moore::RealType::get(getContext(), moore::RealWidth::f64);
+    return moore::StringAtorealOp::create(builder, loc, realType, str);
   }
 
   //===--------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1180,8 +1180,59 @@ struct StmtVisitor {
       return true;
     }
 
-    // Queue Tasks
+    // String Tasks
+    if (args.size() >= 1 && args[0]->type->isString()) {
+      auto str = context.convertLvalueExpression(*args[0]);
 
+      if (nameId == ksn::Putc) {
+        // Slang already checks the arity of string tasks.
+        assert(args.size() == 3 && "`putc` takes 3 arguments");
+        auto index = context.convertRvalueExpression(*args[1]);
+        auto character = context.convertRvalueExpression(*args[2]);
+        moore::StringPutOp::create(builder, loc, str, index, character);
+        return true;
+      }
+
+      if (nameId == ksn::IToA || nameId == ksn::HexToA ||
+          nameId == ksn::OctToA || nameId == ksn::BinToA) {
+        // Slang already checks the arity of string tasks.
+        assert(args.size() == 2 && "`itoa/hex/oct/bin` takes 2 arguments");
+        auto integerType = moore::IntType::getLogic(builder.getContext(), 32);
+        auto input = context.convertRvalueExpression(*args[1], integerType);
+
+        switch (nameId) {
+        case ksn::IToA:
+          moore::StringItoaOp::create(builder, loc, str, input);
+          break;
+        case ksn::HexToA:
+          moore::StringHextoaOp::create(builder, loc, str, input);
+          break;
+        case ksn::OctToA:
+          moore::StringOcttoaOp::create(builder, loc, str, input);
+          break;
+        case ksn::BinToA:
+          moore::StringBintoaOp::create(builder, loc, str, input);
+          break;
+        default:
+          llvm_unreachable("unexpected ASCII integer to string conversion");
+          return false;
+        }
+        return true;
+      }
+
+      if (nameId == ksn::RealToA) {
+        // Slang already checks the arity of string tasks.
+        assert(args.size() == 2 && "`realtoa` takes 2 arguments");
+        auto realType =
+            moore::RealType::get(context.getContext(), moore::RealWidth::f64);
+        auto input = context.convertRvalueExpression(*args[1], realType);
+        moore::StringRealtoaOp::create(builder, loc, str, input);
+        return true;
+      }
+      return false;
+    }
+
+    // Queue Tasks
     if (args.size() >= 1 && args[0]->type->isQueue()) {
       auto queue = context.convertLvalueExpression(*args[0]);
 

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -695,17 +695,52 @@ module SampleValueBuiltins #() (
 endmodule
 
 // CHECK-LABEL: func.func private @StringBuiltins(
-// CHECK-SAME: [[STR:%.+]]: !moore.string
-// CHECK-SAME: [[INT:%.+]]: !moore.i32
-function void StringBuiltins(string string_in, int int_in);
-  // CHECK: [[LEN:%.+]] = moore.string.len [[STR]]
+// CHECK-SAME: [[STR:%.+]]: !moore.string,
+// CHECK-SAME: [[INT:%.+]]: !moore.i32,
+// CHECK-SAME: [[Other:%.+]]: !moore.string) {
+function void StringBuiltins(string string_in, int int_in, string other);
+  // CHECK: [[VAR:%.+]] = moore.variable [[STR]] : <string>
+  // CHECK: [[READ:%.+]] = moore.read [[VAR]] : <string>
+  // CHECK: [[LEN:%.+]] = moore.string.len [[READ]]
   dummyA(string_in.len());
-  // CHECK: [[LEN:%.+]] = moore.string.toupper [[STR]]
-  dummyD(string_in.toupper());
-  // CHECK: [[LEN:%.+]] = moore.string.tolower [[STR]]
-  dummyD(string_in.tolower());
-  // CHECK: [[CHAR:%.+]] = moore.string.get [[STR]]{{\[}}[[INT]]]
+  // CHECK: moore.string.put [[VAR]]{{\[}}[[INT]]{{\]}}, {{%.+}} : <string>
+  string_in.putc(int_in, "A");
+  // CHECK: [[GET:%.+]] = moore.string.get {{%.+}}{{\[}}{{%.+}}{{\]}}
   dummyE(string_in.getc(int_in));
+  // CHECK: [[UPPER:%.+]] = moore.string.toupper {{%.+}}
+  dummyD(string_in.toupper());
+  // CHECK: [[LOWER:%.+]] = moore.string.tolower {{%.+}}
+  dummyD(string_in.tolower());
+  // CHECK: [[CMP:%.+]] = moore.string.compare {{%.+}}, [[Other]]
+  dummyA(string_in.compare(other));
+  // CHECK: [[ICMP:%.+]] = moore.string.icompare {{%.+}}, [[Other]]
+  dummyA(string_in.icompare(other));
+  // CHECK: [[SUBSTR:%.+]] = moore.string.substr {{%.+}}{{\[}}{{%.+}} : {{%.+}}{{\]}}
+  dummyD(string_in.substr(0, 2));
+  // CHECK: [[ATOI:%.+]] = moore.string.atoi {{%.+}} : l32
+  // CHECK: moore.logic_to_int [[ATOI]]
+  dummyA(string_in.atoi());
+  // CHECK: [[ATOHEX:%.+]] = moore.string.atohex {{%.+}} : l32
+  // CHECK: moore.logic_to_int [[ATOHEX]]
+  dummyA(string_in.atohex());
+  // CHECK: [[ATOOCT:%.+]] = moore.string.atooct {{%.+}} : l32
+  // CHECK: moore.logic_to_int [[ATOOCT]]
+  dummyA(string_in.atooct());
+  // CHECK: [[ATOBIN:%.+]] = moore.string.atobin {{%.+}} : l32
+  // CHECK: moore.logic_to_int [[ATOBIN]]
+  dummyA(string_in.atobin());
+  // CHECK: [[ATOREAL:%.+]] = moore.string.atoreal {{%.+}} : f64
+  dummyB(string_in.atoreal());
+  // CHECK: moore.string.itoa [[VAR]], {{%.+}} : <string>, l32
+  string_in.itoa(int_in);
+  // CHECK: moore.string.hextoa [[VAR]], {{%.+}} : <string>, l32
+  string_in.hextoa(int_in);
+  // CHECK: moore.string.octtoa [[VAR]], {{%.+}} : <string>, l32
+  string_in.octtoa(int_in);
+  // CHECK: moore.string.bintoa [[VAR]], {{%.+}} : <string>, l32
+  string_in.bintoa(int_in);
+  // CHECK: moore.string.realtoa [[VAR]], {{%.+}} : <string>, f64
+  string_in.realtoa(1.5);
 endfunction
 
 // IEEE 1800-2017 § 21.3 "File I/O system tasks and functions"


### PR DESCRIPTION
Add `moore.string.*` ops for string builtins. Methods `(compare/icompare, substr, atoi/atohex/atooct/atobin, atoreal,)` with a result are lowered in `Expressions.cpp`. Methods `(putc, itoa/hextoa/octtoa/bintoa, realtoa)` without a result (void) are lowered in `Statements.cpp`, using `StringRefType` for the string receiver to model in-place update.