### PR TITLE
[Arc] Add BranchOpInterface to coroutine.yield

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -862,6 +862,7 @@ def CoroutineInstanceOp : ArcOp<"coroutine.instance", [
 
 def CoroutineYieldOp : ArcOp<"coroutine.yield", [
   AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<BranchOpInterface>,
   HasParent<"CoroutineDefineOp">,
   Terminator,
 ]> {

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -855,33 +855,34 @@ LogicalResult CoroutineYieldOp::verify() {
   if (failed(verifyCoroutineTerminator(*this, getYieldOperands().getTypes())))
     return failure();
 
-  // Verify that the destination block's leading arguments match the
-  // coroutine's function type, and that the remaining arguments match the
-  // yield's destination operands.
+  // The `BranchOpInterface` already verifies that the destination block has
+  // the right number of arguments and that the trailing arguments match the
+  // yield's destination operands. Additionally verify that the leading
+  // arguments, which are supplied fresh by the caller upon resumption, match
+  // the coroutine's function type.
   auto parent = (*this)->getParentOfType<CoroutineDefineOp>();
   TypeRange coroutineArgTypes = parent.getArgumentTypes();
   TypeRange destArgTypes = getDest()->getArgumentTypes();
-  TypeRange destOperandTypes = getDestOperands().getTypes();
-  size_t expectedCount = coroutineArgTypes.size() + destOperandTypes.size();
-  if (destArgTypes.size() != expectedCount)
-    return emitOpError("destination block has ")
-           << destArgTypes.size() << " arguments, but expected "
-           << expectedCount << " (" << coroutineArgTypes.size()
-           << " coroutine arguments followed " << destOperandTypes.size()
-           << " yield destination operands)";
-
-  if (failed(verifyTypeListEquivalence(
-          *this, coroutineArgTypes,
-          destArgTypes.take_front(coroutineArgTypes.size()),
-          "destination resume argument")))
-    return failure();
-
-  if (failed(verifyTypeListEquivalence(
-          *this, destArgTypes.drop_front(coroutineArgTypes.size()),
-          destOperandTypes, "destination operand")))
-    return failure();
+  if (destArgTypes.size() >= coroutineArgTypes.size())
+    if (failed(verifyTypeListEquivalence(
+            *this, coroutineArgTypes,
+            destArgTypes.take_front(coroutineArgTypes.size()),
+            "destination resume argument")))
+      return failure();
 
   return success();
+}
+
+// The destination block's leading arguments match the coroutine's function
+// type and are supplied fresh by the caller upon resumption. They are
+// therefore "produced" operands from the branch's point of view. The
+// remaining destination block arguments map to the yield's destination
+// operands.
+SuccessorOperands CoroutineYieldOp::getSuccessorOperands(unsigned index) {
+  assert(index == 0 && "invalid successor index");
+  auto parent = (*this)->getParentOfType<CoroutineDefineOp>();
+  return SuccessorOperands(parent.getArgumentTypes().size(),
+                           getDestOperandsMutable());
 }
 
 LogicalResult CoroutineReturnOp::verify() {

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -691,7 +691,7 @@ arc.coroutine.define @Foo() -> i42 {
 // -----
 
 arc.coroutine.define @Foo(%arg0: i42) {
-  // expected-error @below {{destination block has 0 arguments, but expected 1}}
+  // expected-error @below {{branch has 1 operands for successor #0, but target block has 0}}
   arc.coroutine.yield ^bb1
 ^bb1:
   arc.coroutine.halt
@@ -701,7 +701,7 @@ arc.coroutine.define @Foo(%arg0: i42) {
 
 arc.coroutine.define @Foo(%arg0: i42) {
   %c0_i42 = hw.constant 0 : i42
-  // expected-error @below {{destination block has 1 arguments, but expected 2}}
+  // expected-error @below {{branch has 2 operands for successor #0, but target block has 1}}
   arc.coroutine.yield ^bb1(%c0_i42 : i42)
 ^bb1(%arg1: i42):
   arc.coroutine.halt
@@ -722,9 +722,7 @@ arc.coroutine.define @Foo(%arg0: i42) {
 
 arc.coroutine.define @Foo(%arg0: i42) {
   %c0_i42 = hw.constant 0 : i42
-  // expected-error @below {{destination operand type mismatch: destination operand #0}}
-  // expected-note @below {{expected type: 'i9001'}}
-  // expected-note @below {{actual type: 'i42'}}
+  // expected-error @below {{type mismatch for bb argument #1 of successor #0}}
   arc.coroutine.yield ^bb1(%c0_i42 : i42)
 ^bb1(%arg1: i42, %arg2: i9001):
   arc.coroutine.halt


### PR DESCRIPTION
Implement the branch op interface on `arc.coroutine.yield`, mapping the destination block's trailing arguments to the yield's destination operands. The leading arguments, which correspond to the coroutine's function type and are supplied fresh by the caller upon resumption, are modeled as produced operands.

This allows generic CFG utilities to reason about and modify the destination operands of yields, for example to thread values across basic blocks when lowering coroutines to explicit state machines. The interface also verifies the destination operand count and types against the destination block, making parts of the custom yield verifier redundant; only the check of the leading block arguments against the coroutine function type remains.

Assisted-by: Claude Opus 4.8
