### PR TITLE
[HW] Make struct and union field types walkable, replaceable

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -19,6 +19,7 @@
 #include "mlir/Interfaces/MemorySlotInterfaces.h"
 
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/AttrTypeSubElements.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 
@@ -103,6 +104,44 @@ struct OffsetFieldInfo {
 } // namespace detail
 } // namespace hw
 } // namespace circt
+
+namespace mlir {
+/// Expose the field names and types of struct and union types to the generic
+/// attribute and type walking and replacement infrastructure. This allows
+/// walkers to recurse into the fields of `!hw.struct` and `!hw.union` types,
+/// and replacers such as `mlir::AttrTypeReplacer` to replace types nested
+/// within the fields.
+template <>
+struct AttrTypeSubElementHandler<circt::hw::detail::FieldInfo> {
+  static void walk(const circt::hw::detail::FieldInfo &param,
+                   AttrTypeImmediateSubElementWalker &walker) {
+    walker.walk(param.name);
+    walker.walk(param.type);
+  }
+  static circt::hw::detail::FieldInfo
+  replace(const circt::hw::detail::FieldInfo &param,
+          AttrSubElementReplacements &attrRepls,
+          TypeSubElementReplacements &typeRepls) {
+    return {cast<StringAttr>(attrRepls.take_front(1)[0]),
+            typeRepls.take_front(1)[0]};
+  }
+};
+template <>
+struct AttrTypeSubElementHandler<circt::hw::detail::OffsetFieldInfo> {
+  static void walk(const circt::hw::detail::OffsetFieldInfo &param,
+                   AttrTypeImmediateSubElementWalker &walker) {
+    walker.walk(param.name);
+    walker.walk(param.type);
+  }
+  static circt::hw::detail::OffsetFieldInfo
+  replace(const circt::hw::detail::OffsetFieldInfo &param,
+          AttrSubElementReplacements &attrRepls,
+          TypeSubElementReplacements &typeRepls) {
+    return {cast<StringAttr>(attrRepls.take_front(1)[0]),
+            typeRepls.take_front(1)[0], param.offset};
+  }
+};
+} // namespace mlir
 
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/HW/HWTypes.h.inc"

--- a/unittests/Dialect/HW/CMakeLists.txt
+++ b/unittests/Dialect/HW/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_unittest(CIRCTHWTests
   InstanceGraphTest.cpp
   InstancePathTest.cpp
   MaterializerTest.cpp
+  TypesTest.cpp
 )
 
 target_link_libraries(CIRCTHWTests

--- a/unittests/Dialect/HW/TypesTest.cpp
+++ b/unittests/Dialect/HW/TypesTest.cpp
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "gtest/gtest.h"
+
+using namespace circt;
+using namespace hw;
+
+namespace {
+
+// Check that the generic attribute and type walkers see into the fields of
+// struct and union types.
+TEST(TypesTest, WalkStructAndUnionFields) {
+  MLIRContext context;
+  context.loadDialect<HWDialect>();
+  Builder builder(&context);
+
+  auto i8Type = builder.getIntegerType(8);
+  auto i16Type = builder.getIntegerType(16);
+  auto unionType =
+      UnionType::get(&context, {{builder.getStringAttr("x"), i8Type, 0},
+                                {builder.getStringAttr("y"), i16Type, 0}});
+  auto structType =
+      StructType::get(&context, {{builder.getStringAttr("a"), unionType},
+                                 {builder.getStringAttr("b"), i8Type}});
+
+  SmallVector<Type> visited;
+  structType.walk([&](Type type) { visited.push_back(type); });
+  EXPECT_TRUE(llvm::is_contained(visited, Type(unionType)));
+  EXPECT_TRUE(llvm::is_contained(visited, Type(i8Type)));
+  EXPECT_TRUE(llvm::is_contained(visited, Type(i16Type)));
+}
+
+// Check that the generic type replacers can replace types nested within the
+// fields of struct and union types.
+TEST(TypesTest, ReplaceStructAndUnionFieldTypes) {
+  MLIRContext context;
+  context.loadDialect<HWDialect>();
+  Builder builder(&context);
+
+  auto i8Type = builder.getIntegerType(8);
+  auto i16Type = builder.getIntegerType(16);
+  auto i32Type = builder.getIntegerType(32);
+  auto unionType =
+      UnionType::get(&context, {{builder.getStringAttr("x"), i8Type, 0},
+                                {builder.getStringAttr("y"), i16Type, 42}});
+  auto structType =
+      StructType::get(&context, {{builder.getStringAttr("a"), unionType},
+                                 {builder.getStringAttr("b"), i8Type}});
+
+  // Replace i8 with i32 everywhere.
+  mlir::AttrTypeReplacer replacer;
+  replacer.addReplacement([&](IntegerType type) -> std::optional<Type> {
+    if (type == i8Type)
+      return i32Type;
+    return std::nullopt;
+  });
+  auto replaced = cast<StructType>(replacer.replace(Type(structType)));
+
+  auto fields = replaced.getElements();
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0].name, builder.getStringAttr("a"));
+  EXPECT_EQ(fields[1].name, builder.getStringAttr("b"));
+  EXPECT_EQ(fields[1].type, i32Type);
+
+  // The union field offsets must survive the replacement.
+  auto replacedUnion = cast<UnionType>(fields[0].type);
+  auto unionFields = replacedUnion.getElements();
+  ASSERT_EQ(unionFields.size(), 2u);
+  EXPECT_EQ(unionFields[0].name, builder.getStringAttr("x"));
+  EXPECT_EQ(unionFields[0].type, i32Type);
+  EXPECT_EQ(unionFields[0].offset, 0u);
+  EXPECT_EQ(unionFields[1].type, i16Type);
+  EXPECT_EQ(unionFields[1].offset, 42u);
+}
+
+} // namespace


### PR DESCRIPTION
Add `AttrTypeSubElementHandler` specializations for the `FieldInfo` and `OffsetFieldInfo` type parameters used by `hw.struct` and `hw.union`. Without these, the generic attribute and type walking and replacement infrastructure in MLIR treats both types as opaque: walkers never visit the field names and types, and replacers such as `mlir::AttrTypeReplacer` fail to replace types nested within the fields.

This surfaced while lowering Arc coroutines, where a type replacer has to concretize opaque coroutine state types nested inside the structs and unions that hold a coroutine's persistent state.

Assisted-by: Claude Opus 4.8
