### PR TITLE
[FIRRTL] InferDomains: Fix domain casting for constants

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -1017,6 +1017,9 @@ LogicalResult ModuleState::unifyAssociations(Operation *op, Value lhs,
   if (lhs == rhs)
     return success();
 
+  if (!isHardware(lhs) || !isHardware(rhs))
+    return success();
+
   LLVM_DEBUG({
     llvm::dbgs().indent(6) << "unify domains(" << render(lhs) << ") = domains("
                            << render(rhs) << ")\n";
@@ -1204,8 +1207,13 @@ LogicalResult ModuleState::processOp(UnsafeDomainCastOp op) {
     return unifyAssociations(op, op.getInput(), op.getResult());
 
   auto input = op.getInput();
-  RowTerm *inputRow = getDomainAssociationAsRow(input);
-  SmallVector<Term *> elements(inputRow->elements);
+
+  SmallVector<Term *> elements(getNumDomains());
+  if (isHardware(input)) {
+    auto *inputRow = getDomainAssociationAsRow(input);
+    elements.assign(inputRow->elements);
+  }
+
   for (auto value : op.getDomains()) {
     auto domain = cast<DomainValue>(value);
     auto typeID = getDomainTypeID(domain);

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -744,3 +744,33 @@ firrtl.circuit "DriveWireWithInputDomain" {
     firrtl.matchingconnect %w2, %i : !firrtl.uint<1>
   }
 }
+
+// CHECK-LABEL: "CastConstant"
+firrtl.circuit "CastConstant" {
+  firrtl.domain @ClockDomain
+  firrtl.domain @PowerDomain
+  // CHECK:      @CastConstant(
+  // CHECK-SAME:   in %a: !firrtl.domain<@ClockDomain()>,
+  // CHECK-SAME:   in %PowerDomain: !firrtl.domain<@PowerDomain()>,
+  // CHECK-SAME:   out %o: !firrtl.uint<1> domains [%a, %PowerDomain]
+  // CHECK-SAME: )
+  firrtl.module @CastConstant(in %a: !firrtl.domain<@ClockDomain()>, out %o : !firrtl.uint<1>) {
+    %0 = firrtl.constant 0 : !firrtl.uint<1>
+    %1 = firrtl.unsafe_domain_cast %0 domains[%a] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
+    firrtl.connect %o, %1 : !firrtl.uint<1>
+  }
+}
+
+// CHECK-LABEL: "CastConstantNoDomains"
+firrtl.circuit "CastConstantNoDomains" {
+  firrtl.domain @ClockDomain
+  // CHECK:      @CastConstantNoDomains(
+  // CHECK-SAME:   in %ClockDomain: !firrtl.domain<@ClockDomain()>,
+  // CHECK-SAME:   out %o: !firrtl.uint<1> domains [%ClockDomain]
+  // CHECK-SAME: )
+  firrtl.module @CastConstantNoDomains(out %o : !firrtl.uint<1>) {
+    %0 = firrtl.constant 0 : !firrtl.uint<1>
+    %1 = firrtl.unsafe_domain_cast %0 domains[] : !firrtl.uint<1>
+    firrtl.connect %o, %1 : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
When inferring domains for an unsafe domain cast op, the pass attempts to inherit missing domain associations from the input operand. However, because constants do not have domain associations, casting a constant previously triggered an internal assertion failure.

This commit fixes the issue by checking if the input actually supports domain associations before attempting to copy them. If the input lacks associations (e.g., constants), we now fall back to filling them in with metavariables.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
