### PR TITLE
[ImportVerilog] Introduce enum builtin methods

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3724,6 +3724,50 @@ def StringConcatOp : StringBuiltin<"concat"> {
   let assemblyFormat = "` ` `(` $inputs `)` attr-dict";
 }
 
+//===----------------------------------------------------------------------===//
+// Enumerated type methods
+//===----------------------------------------------------------------------===//
+
+class EnumBuiltin<string mnemonic, list<Trait> traits = []> :
+    MooreOp<"enum." # mnemonic, traits>;
+
+class EnumReturnOpBase<string mnemonic, list<Trait> traits = []> :
+    EnumBuiltin<mnemonic, traits # [TypesMatchWith<"src and result types match",
+    "src", "result", "$_self"
+  >]> {
+  let summary = "Builtin methods with a enum return type";
+  let arguments = (ins
+    IntType:$src,
+    Optional<TwoValuedI32>:$step
+  );
+  let results = (outs IntType:$result);
+  let assemblyFormat = [{
+    $src (`step` $step^)? attr-dict `:` type($src)
+  }];
+}
+
+def EnumFirstOp : EnumReturnOpBase<"first">;
+def EnumLastOp : EnumReturnOpBase<"last">;
+def EnumNextOp : EnumReturnOpBase<"next">;
+def EnumPrevOp : EnumReturnOpBase<"prev">;
+
+def EnumNumOp : EnumBuiltin<"num"> {
+  let summary = "The number of elements in the given enumeration";
+  let arguments = (ins IntType:$src);
+  let results = (outs TwoValuedI32:$result);
+  let assemblyFormat = [{
+    $src attr-dict `:` type($src)
+  }];
+}
+
+def EnumNameOp : EnumBuiltin<"name"> {
+  let summary = "A name of the given enumeration value";
+  let arguments = (ins IntType:$src);
+  let results = (outs StringType:$result);
+  let assemblyFormat = [{
+    $src attr-dict `:` type($src)
+  }];
+}
 
 //===----------------------------------------------------------------------===//
 // Forking

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3663,16 +3663,25 @@ Value Context::convertSystemCall(
   }
 
   //===--------------------------------------------------------------------===//
-  // Associative Array Methods
+  // Associative Array/Enum Methods
   //===--------------------------------------------------------------------===//
 
   if (nameId == ksn::Num) {
+    assert(numArgs == 1 && "`num` takes 1 argument");
+    // Associative array size
     if (args[0]->type->isAssociativeArray()) {
-      assert(numArgs == 1 && "`num` takes 1 argument");
       auto value = convertLvalueExpression(*args[0]);
       if (!value)
         return {};
       return moore::AssocArraySizeOp::create(builder, loc, value);
+    }
+
+    // The number of values in an enum
+    if (args[0]->type->isEnum()) {
+      auto value = convertRvalueExpression(*args[0]);
+      if (!value)
+        return {};
+      return moore::EnumNumOp::create(builder, loc, value);
     }
     emitError(loc) << "unsupported system call `" << name << "`";
     return {};
@@ -3692,10 +3701,11 @@ Value Context::convertSystemCall(
 
   // Associative array traversal methods (all take 2 arguments: array ref, key
   // ref). These names are shared with enum built-in methods (next/prev/first/
-  // last), which take 1 or 2 arguments. Only handle the associative array case
+  // last), which take 1 or 2 arguments. Handle the associative array/enum case
   // here; fall through to the unsupported diagnostic for other types.
   if (nameId == ksn::First || nameId == ksn::Last || nameId == ksn::Next ||
       nameId == ksn::Prev) {
+    // Associative array methods
     if (args[0]->type->isAssociativeArray()) {
       assert(numArgs == 2 && "traversal methods take 2 arguments");
       auto array = convertLvalueExpression(*args[0]);
@@ -3711,6 +3721,49 @@ Value Context::convertSystemCall(
       if (nameId == ksn::Prev)
         return moore::AssocArrayPrevOp::create(builder, loc, array, key);
       llvm_unreachable("all traversal cases handled above");
+    }
+
+    // Enum methods
+    if (args[0]->type->isEnum()) {
+      assert((numArgs == 1 || numArgs == 2) &&
+             "enum traversal methods take 1 or 2 arguments");
+      ValueRange operands;
+      auto src = convertRvalueExpression(*args[0]);
+      if (!src)
+        return {};
+      operands = {src};
+
+      if (numArgs == 2) {
+        auto step = convertRvalueExpression(*args[1]);
+        if (!step)
+          return {};
+        operands = {src, step};
+      }
+
+      switch (nameId) {
+      case ksn::First:
+        return moore::EnumFirstOp::create(builder, loc, operands);
+      case ksn::Last:
+        return moore::EnumLastOp::create(builder, loc, operands);
+      case ksn::Next:
+        return moore::EnumNextOp::create(builder, loc, operands);
+      case ksn::Prev:
+        return moore::EnumPrevOp::create(builder, loc, operands);
+      default:
+        llvm_unreachable("all traversal cases handled above");
+      }
+    }
+    emitError(loc) << "unsupported system call `" << name << "`";
+    return {};
+  }
+
+  if (nameId == ksn::Name) {
+    assert(numArgs == 1 && "`name` takes 1 argument");
+    if (args[0]->type->isEnum()) {
+      auto value = convertRvalueExpression(*args[0]);
+      if (!value)
+        return {};
+      return moore::EnumNameOp::create(builder, loc, value);
     }
     emitError(loc) << "unsupported system call `" << name << "`";
     return {};

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -743,6 +743,28 @@ function void StringBuiltins(string string_in, int int_in, string other);
   string_in.realtoa(1.5);
 endfunction
 
+// IEEE 1800-2017 § 6.19 "Enumerations"
+typedef enum { A, B, C, D } enum_t;
+
+// CHECK-LABEL: func.func private @EnumBuiltins(
+// CHECK-SAME: [[VAL:%[^ ,]+]]: !moore.i32
+// CHECK-SAME: [[STEP:%[^ ,]+]]: !moore.i32
+function void EnumBuiltins(enum_t val, int step, output enum_t out,
+                           output int num, output string name);
+  // CHECK: [[FIRST:%.+]] = moore.constant 0 : i32
+  out = val.first();
+  // CHECK: [[LAST:%.+]] = moore.constant 3 : i32
+  out = val.last();
+  // CHECK: [[NEXT:%.+]] = moore.enum.next [[VAL]] step [[STEP]] : i32
+  out = val.next(step);
+  // CHECK: [[PREV:%.+]] = moore.enum.prev [[VAL]] : i32
+  out = val.prev();
+  // CHECK: [[NUM:%.+]] = moore.constant 4 : i32
+  num = val.num();
+  // CHECK: [[NAME:%.+]] = moore.enum.name [[VAL]] : i32
+  name = val.name();
+endfunction
+
 // IEEE 1800-2017 § 21.3 "File I/O system tasks and functions"
 // CHECK-LABEL: func.func private @FileIOBuiltins(
 // CHECK-SAME: [[FD_INT:%[^ ,]+]]: !moore.i32

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -208,26 +208,6 @@ endmodule
 
 // -----
 module Foo;
-  typedef enum { A, B, C } e;
-  e val;
-  initial begin
-    // expected-error @below {{unsupported system call `next`}}
-    val = val.next();
-  end
-endmodule
-
-// -----
-module Foo;
-  typedef enum { A, B, C } e;
-  e val;
-  initial begin
-    // expected-error @below {{unsupported system call `prev`}}
-    val = val.prev();
-  end
-endmodule
-
-// -----
-module Foo;
   int inp[];
   int tmp[];
   initial begin


### PR DESCRIPTION
Add the number of new `moore.enum.*` operations to represent enum builtins.