### PR TITLE
[Arc] Add LowerCoroutines pass

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -172,6 +172,28 @@ def LowerClocksToFuncs : Pass<"arc-lower-clocks-to-funcs", "mlir::ModuleOp"> {
   let dependentDialects = ["mlir::func::FuncDialect", "mlir::scf::SCFDialect"];
 }
 
+def LowerCoroutinesPass : Pass<"arc-lower-coroutines", "mlir::ModuleOp"> {
+  let summary = "Lower coroutines to state machine functions";
+  let description = [{
+    Convert each `arc.coroutine.define` into a regular function that takes an
+    explicit state and program counter as its leading arguments, and that
+    dispatches to its entry block or one of its resume blocks accordingly.
+    Values that are live across suspension points are persisted in the
+    explicit state, which is a union with one struct variant per resume block.
+    Calls to coroutines become regular function calls, and all uses of the
+    opaque `!arc.coroutine_state` and `!arc.coroutine_pc` types anywhere in
+    the IR are replaced with the concrete union and integer types computed for
+    each coroutine.
+  }];
+  let dependentDialects = [
+    "comb::CombDialect",
+    "hw::HWDialect",
+    "mlir::cf::ControlFlowDialect",
+    "mlir::func::FuncDialect",
+    "mlir::ub::UBDialect",
+  ];
+}
+
 def LowerArrays : Pass<"arc-lower-arrays", "mlir::ModuleOp"> {
   let summary = "Lower arrays to use bufferized arrayrefs";
   let dependentDialects = ["arc::ArcDialect"];

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   LowerArcsToFuncs.cpp
   LowerArrays.cpp
   LowerClocksToFuncs.cpp
+  LowerCoroutines.cpp
   LowerLUT.cpp
   LowerState.cpp
   LowerVectorizations.cpp
@@ -44,11 +45,13 @@ add_circt_dialect_library(CIRCTArcTransforms
   CIRCTSupport
   CIRCTSV
   CIRCTVerif
+  MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRIR
   MLIRLLVMDialect
   MLIRPass
   MLIRSCFDialect
   MLIRTransformUtils
+  MLIRUBDialect
   MLIRVectorDialect
 )

--- a/lib/Dialect/Arc/Transforms/LowerCoroutines.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerCoroutines.cpp
@@ -1,0 +1,680 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Lower `arc.coroutine.define` ops into state machine functions. Coroutines
+// are functions that can suspend execution at `arc.coroutine.yield` ops and
+// be resumed at a later point. This pass converts each coroutine definition
+// into a plain `func.func` that dispatches on an explicit integer program
+// counter (PC) argument, and that persists all values live across suspension
+// points in an explicit state argument.
+//
+// The lowering proceeds in two steps. The first step lowers each coroutine
+// definition independently of all others:
+//
+// - Rewrite the body such that every resume block receives the values that
+//   are live across its suspension points as trailing block arguments, which
+//   makes the state that has to be persisted explicit. Values that do not
+//   cross a suspension point are left untouched, and constants are cloned
+//   into the resumed blocks instead, since they are cheaper to rematerialize
+//   than to persist.
+//
+// - Assign a PC value to each resume block and derive the concrete PC and
+//   state types. The PC type is an integer just wide enough to encode the
+//   start PC (0), one resume PC per resume block (1 to N), and the return and
+//   halt sentinels (the two largest values). The state type is a union with
+//   one struct variant per resume block that has values to persist.
+//
+// - Replace the definition with a `func.func` that takes the state and PC as
+//   leading arguments, dispatches on the PC to either the original entry
+//   block or one of the resume blocks (unpacking the corresponding state
+//   variant), and returns the new state, resume PC, and yielded values at
+//   each suspension point.
+//
+// At this point, the state and PC types of *other* coroutines may still occur
+// as opaque `!arc.coroutine_state` and `!arc.coroutine_pc` types within the
+// lowered functions, for example on calls to nested coroutines. The second
+// step performs a single global sweep over the module that concretizes all
+// such occurrences:
+//
+// - `arc.coroutine.call` ops become plain `func.call` ops, and the auxiliary
+//   coroutine ops become integer constants, comparisons, and poison values.
+//
+// - All remaining occurrences of the opaque types -- in block arguments,
+//   results of unrelated ops, function signatures, and nested within
+//   aggregate types -- are replaced by the concrete types computed in step
+//   one. Since a coroutine's persistent state may contain the state of the
+//   coroutines it calls, this replacement is recursive. Cyclic state
+//   containment, i.e. recursive coroutines, is detected and rejected.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "mlir/Analysis/Liveness.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/AttrTypeSubElements.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/GenericIteratedDominanceFrontier.h"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_LOWERCOROUTINESPASS
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace circt;
+using namespace arc;
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// Suspension Value Capture
+//===----------------------------------------------------------------------===//
+//
+// The following functions rewrite the body of a coroutine such that every
+// resume block receives the values that are live across the suspension points
+// it resumes from as trailing block arguments. After the lowering, control
+// re-enters a resume block directly from the dispatch logic, so the
+// definitions of these values no longer dominate their uses. Capturing them as
+// block arguments makes the state that has to be persisted explicit, and the
+// lowering picks the arguments up as the contents of the resume block's state
+// variant.
+//
+// Values that do not cross a suspension point are left untouched and keep
+// using their original definition through dominance. Where a control flow
+// path carrying a captured value rejoins a path carrying the original
+// definition, the join block receives a merging block argument as well.
+// Constants are not captured; they are cloned into the using blocks that are
+// reachable from a resume block instead, since they are cheaper to
+// rematerialize on re-entry than to persist across suspension points.
+
+/// Collect the resume blocks of a coroutine body, i.e. the blocks targeted by
+/// yield ops, in region order to make the lowering deterministic.
+static SmallVector<Block *> collectResumeBlocks(Region &region) {
+  SmallPtrSet<Block *, 8> resumeBlockSet;
+  for (auto &block : region)
+    if (auto yieldOp = dyn_cast<CoroutineYieldOp>(block.getTerminator()))
+      resumeBlockSet.insert(yieldOp.getDest());
+  SmallVector<Block *> resumeBlocks;
+  for (auto &block : region)
+    if (resumeBlockSet.contains(&block))
+      resumeBlocks.push_back(&block);
+  return resumeBlocks;
+}
+
+/// Capture a single value as a trailing block argument of each of the given
+/// resume blocks and rewrite all affected uses of the value.
+static LogicalResult captureValue(Value value, Region &region,
+                                  ArrayRef<Block *> captureBlocks,
+                                  Liveness &liveness,
+                                  DominanceInfo &dominance) {
+  auto *defBlock = value.getParentBlock();
+
+  // Determine the blocks that receive an argument for the value. The resume
+  // blocks capture it directly. In addition, wherever a path carrying the
+  // captured value rejoins a path carrying the original definition, the join
+  // block needs a merging argument. These join blocks are the iterated
+  // dominance frontier of the capture blocks plus the original definition,
+  // pruned to the blocks where the value is live-in.
+  auto &domTree = dominance.getDomTree(&region);
+  llvm::IDFCalculatorBase<Block, false> idfCalculator(domTree);
+
+  SmallPtrSet<Block *, 8> definingBlocks(captureBlocks.begin(),
+                                         captureBlocks.end());
+  definingBlocks.insert(defBlock);
+  idfCalculator.setDefiningBlocks(definingBlocks);
+
+  SmallPtrSet<Block *, 16> liveInBlocks;
+  for (auto &block : region)
+    if (liveness.getLiveness(&block)->isLiveIn(value))
+      liveInBlocks.insert(&block);
+  idfCalculator.setLiveInBlocks(liveInBlocks);
+
+  SmallVector<Block *> mergeBlocks;
+  idfCalculator.calculate(mergeBlocks);
+
+  SmallPtrSet<Block *, 16> argBlocks(mergeBlocks.begin(), mergeBlocks.end());
+  argBlocks.insert(captureBlocks.begin(), captureBlocks.end());
+
+  // Since the value is an SSA value, its defining block dominates its entire
+  // live range, and with it all argument blocks and their predecessors. Walk
+  // the dominator tree from there, tracking the reaching definition of the
+  // value, which is the original value until an argument block redefines it.
+  // Rewrite all uses to the reaching definition of their block, and pass the
+  // definition at the end of each block into any argument block successors.
+  struct WorklistItem {
+    DominanceInfoNode *domNode;
+    Value reachingDef;
+  };
+  SmallVector<WorklistItem> worklist;
+  worklist.push_back({domTree.getNode(defBlock), value});
+
+  while (!worklist.empty()) {
+    auto item = worklist.pop_back_val();
+    auto *block = item.domNode->getBlock();
+
+    if (argBlocks.contains(block))
+      item.reachingDef = block->addArgument(value.getType(), value.getLoc());
+
+    // Rewrite the uses in this block, including in nested regions.
+    if (item.reachingDef != value)
+      block->walk([&](Operation *nestedOp) {
+        nestedOp->replaceUsesOfWith(value, item.reachingDef);
+      });
+
+    // Append the reaching definition to the successor operands of every edge
+    // into an argument block.
+    auto *terminator = block->getTerminator();
+    auto branchOp = dyn_cast<BranchOpInterface>(terminator);
+    for (auto &blockOperand : terminator->getBlockOperands()) {
+      if (!argBlocks.contains(blockOperand.get()))
+        continue;
+      if (!branchOp)
+        return terminator->emitOpError()
+               << "does not implement `BranchOpInterface`; cannot pass value "
+                  "into successor block";
+      branchOp.getSuccessorOperands(blockOperand.getOperandNumber())
+          .append(item.reachingDef);
+    }
+
+    for (auto *child : item.domNode->children())
+      worklist.push_back({child, item.reachingDef});
+  }
+
+  return success();
+}
+
+/// Clone a constant into the using blocks that are reachable from a capturing
+/// resume block, where the original definition no longer dominates its uses
+/// after the lowering. All other uses keep using the original.
+static void rematerializeConstant(Value value, Region &region,
+                                  ArrayRef<Block *> captureBlocks,
+                                  Liveness &liveness) {
+  // Collect the blocks reachable from a capturing resume block in which the
+  // value is live-in.
+  DenseSet<Block *> resumedBlocks(captureBlocks.begin(), captureBlocks.end());
+  SmallVector<Block *> worklist(captureBlocks.begin(), captureBlocks.end());
+  while (!worklist.empty())
+    for (auto *successor : worklist.pop_back_val()->getSuccessors())
+      if (liveness.getLiveIn(successor).contains(value) &&
+          resumedBlocks.insert(successor).second)
+        worklist.push_back(successor);
+
+  // Redirect the uses in these blocks to a per-block clone of the constant.
+  auto *defOp = value.getDefiningOp();
+  DenseMap<Block *, Value> clones;
+  for (auto &use : llvm::make_early_inc_range(value.getUses())) {
+    auto *block = region.findAncestorBlockInRegion(*use.getOwner()->getBlock());
+    if (!resumedBlocks.contains(block))
+      continue;
+    auto &clone = clones[block];
+    if (!clone) {
+      OpBuilder builder(block, block->begin());
+      clone = builder.clone(*defOp)->getResult(0);
+    }
+    use.set(clone);
+  }
+  if (defOp->use_empty())
+    defOp->erase();
+}
+
+/// Rewrite the body of a coroutine such that every resume block captures the
+/// values that are live across the suspension points it resumes from as
+/// trailing block arguments.
+static LogicalResult captureValuesAcrossSuspension(CoroutineDefineOp defineOp) {
+  Region &region = defineOp.getBody();
+  if (region.hasOneBlock())
+    return success();
+
+  auto resumeBlocks = collectResumeBlocks(region);
+  if (resumeBlocks.empty())
+    return success();
+
+  // Compute the liveness and dominance of the original body once. The
+  // per-value rewrites below only ever change the liveness of the value
+  // currently being processed, never that of the other collected values, and
+  // they add no blocks or control flow edges, so both analyses remain valid
+  // throughout the loop.
+  Liveness liveness(defineOp);
+  DominanceInfo dominance(defineOp);
+
+  // Collect the candidate values up front, since the rewriting below adds new
+  // block arguments and constants which need no further treatment.
+  SmallVector<Value> values;
+  for (auto &block : region) {
+    llvm::append_range(values, block.getArguments());
+    for (auto &op : block)
+      llvm::append_range(values, op.getResults());
+  }
+
+  for (auto value : values) {
+    // Collect the resume blocks where the value is live-in. Values that are
+    // not live across any suspension point still dominate their uses after
+    // the lowering and need no rewriting at all.
+    SmallVector<Block *> captureBlocks;
+    for (auto *block : resumeBlocks)
+      if (liveness.getLiveIn(block).contains(value))
+        captureBlocks.push_back(block);
+    if (captureBlocks.empty())
+      continue;
+
+    // Rematerialize constants in the resumed blocks instead of capturing
+    // them; capture all other values as trailing resume block arguments.
+    auto *defOp = value.getDefiningOp();
+    if (defOp && defOp->hasTrait<OpTrait::ConstantLike>()) {
+      rematerializeConstant(value, region, captureBlocks, liveness);
+      continue;
+    }
+    if (failed(captureValue(value, region, captureBlocks, liveness, dominance)))
+      return failure();
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Coroutine Analysis
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Per-coroutine lowering info: the resume blocks and the concrete PC and
+/// state types derived from the body after the values live across suspension
+/// points have been captured.
+struct CoroutineLowering {
+  /// The original coroutine definition.
+  CoroutineDefineOp defineOp;
+  /// The blocks targeted by yield ops, in region order. The PC value of a
+  /// resume block is its index in this list plus one.
+  SmallVector<Block *> resumeBlocks;
+  /// The union field index holding the persisted state of each resume block,
+  /// or none if the resume block persists no state.
+  SmallVector<std::optional<unsigned>> variantIndices;
+  /// The concrete PC type.
+  IntegerType pcType;
+  /// The concrete state type. This is a union with one struct variant per
+  /// state-persisting resume block, and may still contain the opaque state
+  /// and PC types of other coroutines.
+  Type stateType;
+
+  /// Returns the sentinel PC value indicating that the coroutine returned.
+  uint64_t getReturnPC() { return getHaltPC() - 1; }
+  /// Returns the sentinel PC value indicating that the coroutine halted.
+  uint64_t getHaltPC() {
+    return APInt::getAllOnes(pcType.getWidth()).getZExtValue();
+  }
+  /// Returns the union variant persisting the state of the resume block with
+  /// the given index, or none if the resume block persists no state.
+  std::optional<hw::UnionType::FieldInfo> getVariant(unsigned resumeIndex) {
+    if (auto fieldIndex = variantIndices[resumeIndex])
+      return cast<hw::UnionType>(stateType).getElements()[*fieldIndex];
+    return std::nullopt;
+  }
+};
+} // namespace
+
+/// Determine the resume blocks of a coroutine and derive its concrete PC and
+/// state types. To be called after the values live across suspension points
+/// have been captured, such that the trailing block arguments of each resume
+/// block are exactly the values that have to be persisted.
+static CoroutineLowering analyzeDefinition(CoroutineDefineOp defineOp) {
+  auto *context = defineOp.getContext();
+  CoroutineLowering lowering;
+  lowering.defineOp = defineOp;
+
+  lowering.resumeBlocks = collectResumeBlocks(defineOp.getBody());
+
+  // The PC type must be wide enough to encode the start PC (0), one resume PC
+  // per resume block (1 to N), and the return and halt sentinels (the two
+  // largest values).
+  unsigned pcWidth = llvm::Log2_64_Ceil(lowering.resumeBlocks.size() + 3);
+  lowering.pcType = IntegerType::get(context, pcWidth);
+
+  // Build the state type as a union with one struct variant per resume block
+  // that has values to persist. The variants are named after the resume PC,
+  // and the struct fields after the resume block's trailing arguments.
+  unsigned numCoroutineArgs = defineOp.getArgumentTypes().size();
+  SmallVector<hw::UnionType::FieldInfo> variants;
+  for (auto [index, block] : llvm::enumerate(lowering.resumeBlocks)) {
+    auto persistedArgs = block->getArguments().drop_front(numCoroutineArgs);
+    if (persistedArgs.empty()) {
+      lowering.variantIndices.push_back(std::nullopt);
+      continue;
+    }
+    SmallVector<hw::StructType::FieldInfo> fields;
+    for (auto [fieldIndex, arg] : llvm::enumerate(persistedArgs))
+      fields.push_back(
+          {StringAttr::get(context, "f" + Twine(fieldIndex)), arg.getType()});
+    lowering.variantIndices.push_back(variants.size());
+    variants.push_back({StringAttr::get(context, "r" + Twine(index + 1)),
+                        hw::StructType::get(context, fields), 0});
+  }
+  if (variants.empty())
+    lowering.stateType = hw::StructType::get(context, {});
+  else
+    lowering.stateType = hw::UnionType::get(context, variants);
+
+  return lowering;
+}
+
+//===----------------------------------------------------------------------===//
+// Coroutine Lowering
+//===----------------------------------------------------------------------===//
+
+/// Replace a coroutine definition with a state machine function. The function
+/// takes the persistent state and PC as leading arguments and dispatches on
+/// the PC to either the original entry block or, through a trampoline block
+/// that unpacks the corresponding state variant, to one of the resume blocks.
+/// The coroutine terminators become function returns that produce the new
+/// state, resume PC, and yielded values.
+static void lowerDefinition(CoroutineLowering &lowering) {
+  auto defineOp = lowering.defineOp;
+  auto loc = defineOp.getLoc();
+  auto *context = defineOp.getContext();
+  unsigned pcWidth = lowering.pcType.getWidth();
+
+  // Create the replacement function. The signature wraps the coroutine's
+  // function type with the state and PC as leading arguments and results.
+  SmallVector<Type> inputTypes{lowering.stateType, lowering.pcType};
+  llvm::append_range(inputTypes, defineOp.getArgumentTypes());
+  SmallVector<Type> resultTypes{lowering.stateType, lowering.pcType};
+  llvm::append_range(resultTypes, defineOp.getResultTypes());
+  OpBuilder builder(defineOp);
+  auto funcOp =
+      func::FuncOp::create(builder, loc, defineOp.getSymName(),
+                           builder.getFunctionType(inputTypes, resultTypes));
+
+  // Move the body over and create the dispatch block in front of it.
+  funcOp.getBody().getBlocks().splice(funcOp.getBody().end(),
+                                      defineOp.getBody().getBlocks());
+  auto *entryBlock = &funcOp.getBody().front();
+  auto *dispatchBlock =
+      builder.createBlock(&funcOp.getBody(), funcOp.getBody().begin());
+  Value stateArg = dispatchBlock->addArgument(lowering.stateType, loc);
+  Value pcArg = dispatchBlock->addArgument(lowering.pcType, loc);
+  SmallVector<Value> callerArgs;
+  for (auto arg : entryBlock->getArguments())
+    callerArgs.push_back(
+        dispatchBlock->addArgument(arg.getType(), arg.getLoc()));
+
+  // Create a trampoline block for each resume block that unpacks the
+  // persisted values from the corresponding state variant and passes them to
+  // the resume block, alongside the fresh caller-supplied arguments.
+  SmallVector<APInt> caseValues;
+  SmallVector<Block *> caseBlocks;
+  for (auto [index, resumeBlock] : llvm::enumerate(lowering.resumeBlocks)) {
+    auto *trampolineBlock = builder.createBlock(resumeBlock);
+    SmallVector<Value> operands = callerArgs;
+    if (auto variant = lowering.getVariant(index)) {
+      Value variantValue =
+          hw::UnionExtractOp::create(builder, loc, stateArg, variant->name);
+      auto explodeOp = hw::StructExplodeOp::create(builder, loc, variantValue);
+      llvm::append_range(operands, explodeOp.getResults());
+    }
+    cf::BranchOp::create(builder, loc, resumeBlock, operands);
+    caseValues.push_back(APInt(pcWidth, index + 1));
+    caseBlocks.push_back(trampolineBlock);
+  }
+
+  // Dispatch on the PC. The start PC enters the original entry block;
+  // passing a return or halt PC is undefined behavior, so those simply fall
+  // into the default case alongside the start PC.
+  builder.setInsertionPointToEnd(dispatchBlock);
+  if (lowering.resumeBlocks.empty()) {
+    cf::BranchOp::create(builder, loc, entryBlock, callerArgs);
+  } else {
+    SmallVector<ValueRange> caseOperands(caseBlocks.size());
+    cf::SwitchOp::create(builder, loc, pcArg, entryBlock, callerArgs,
+                         caseValues, caseBlocks, caseOperands);
+  }
+
+  // Replace the coroutine terminators with function returns producing the new
+  // state, resume PC, and yielded values.
+  DenseMap<Block *, unsigned> resumePCs;
+  for (auto [index, block] : llvm::enumerate(lowering.resumeBlocks))
+    resumePCs[block] = index + 1;
+
+  auto lowerTerminator = [&](Operation *op, Value state, uint64_t pc,
+                             ValueRange yieldOperands) {
+    OpBuilder builder(op);
+    if (!state)
+      state = ub::PoisonOp::create(builder, op->getLoc(), lowering.stateType,
+                                   ub::PoisonAttr::get(context));
+    Value pcValue =
+        hw::ConstantOp::create(builder, op->getLoc(), APInt(pcWidth, pc));
+    SmallVector<Value> operands{state, pcValue};
+    llvm::append_range(operands, yieldOperands);
+    func::ReturnOp::create(builder, op->getLoc(), operands);
+    op->erase();
+  };
+
+  for (auto &block : funcOp.getBody()) {
+    TypeSwitch<Operation *>(block.getTerminator())
+        .Case<CoroutineYieldOp>([&](CoroutineYieldOp op) {
+          // Pack the values to persist into the state variant corresponding
+          // to the destination block. Resume blocks without persisted state
+          // have no variant and return a poison state.
+          unsigned pc = resumePCs.lookup(op.getDest());
+          Value state;
+          if (auto variant = lowering.getVariant(pc - 1)) {
+            OpBuilder builder(op);
+            Value variantValue = hw::StructCreateOp::create(
+                builder, op.getLoc(), variant->type, op.getDestOperands());
+            state = hw::UnionCreateOp::create(builder, op.getLoc(),
+                                              lowering.stateType, variant->name,
+                                              variantValue);
+          }
+          lowerTerminator(op, state, pc, op.getYieldOperands());
+        })
+        .Case<CoroutineReturnOp>([&](CoroutineReturnOp op) {
+          lowerTerminator(op, Value{}, lowering.getReturnPC(),
+                          op.getYieldOperands());
+        })
+        .Case<CoroutineHaltOp>([&](CoroutineHaltOp op) {
+          lowerTerminator(op, Value{}, lowering.getHaltPC(),
+                          op.getYieldOperands());
+        });
+  }
+
+  defineOp.erase();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerCoroutinesPass
+    : public arc::impl::LowerCoroutinesPassBase<LowerCoroutinesPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void LowerCoroutinesPass::runOnOperation() {
+  auto module = getOperation();
+
+  // Coroutine instances are expected to be lowered into explicit storage and
+  // calls before this pass runs. Reject any remaining instances instead of
+  // breaking their symbol references.
+  auto instanceResult = module->walk([](CoroutineInstanceOp op) {
+    op.emitOpError("must be lowered before LowerCoroutines");
+    return WalkResult::interrupt();
+  });
+  if (instanceResult.wasInterrupted())
+    return signalPassFailure();
+
+  // Step 1: Lower each coroutine definition independently. Capture the values
+  // live across suspension points as trailing resume block arguments and
+  // derive the concrete PC and state types. The state types may still contain
+  // opaque types of other coroutines, which the global sweep below
+  // concretizes.
+  SmallVector<CoroutineDefineOp> defineOps;
+  module->walk([&](CoroutineDefineOp op) { defineOps.push_back(op); });
+
+  DenseMap<StringAttr, CoroutineLowering> lowerings;
+  for (auto defineOp : defineOps) {
+    if (failed(captureValuesAcrossSuspension(defineOp)))
+      return signalPassFailure();
+    lowerings.insert({defineOp.getSymNameAttr(), analyzeDefinition(defineOp)});
+  }
+
+  // Reject recursive coroutines. A coroutine whose persistent state
+  // transitively contains its own state would require unbounded storage.
+  // Detect cycles in the state containment graph with a depth-first
+  // traversal. This must run before step 2, whose recursive type replacement
+  // would not terminate on cycles, and before the definitions are erased, so
+  // the error can point at the offending op.
+  enum class Color { Unvisited, InProgress, Done };
+  DenseMap<StringAttr, Color> colors;
+  std::function<LogicalResult(StringAttr)> checkCycles =
+      [&](StringAttr name) -> LogicalResult {
+    auto it = lowerings.find(name);
+    if (it == lowerings.end())
+      return success();
+    if (colors.lookup(name) == Color::Done)
+      return success();
+    if (colors.lookup(name) == Color::InProgress)
+      return it->second.defineOp.emitOpError(
+          "recursive coroutines are not supported");
+    colors[name] = Color::InProgress;
+    auto result = success();
+    it->second.stateType.walk([&](CoroutineStateType type) {
+      if (failed(checkCycles(type.getCoroutine().getAttr())))
+        result = failure();
+    });
+    colors[name] = Color::Done;
+    return result;
+  };
+  for (auto defineOp : defineOps)
+    if (failed(checkCycles(defineOp.getSymNameAttr())))
+      return signalPassFailure();
+
+  // Replace each coroutine definition with a state machine function,
+  // completing step 1.
+  for (auto defineOp : defineOps)
+    lowerDefinition(lowerings.find(defineOp.getSymNameAttr())->second);
+
+  // Step 2: Concretize all occurrences of the opaque coroutine state and PC
+  // types throughout the module. The replacer recurses into the replacement
+  // types, such that a coroutine state containing the state of a nested
+  // coroutine gets fully concretized; the cycle check above guarantees that
+  // this recursion terminates.
+  bool hasUnknownCoroutines = false;
+  auto lookupLowering =
+      [&](FlatSymbolRefAttr coroutine) -> CoroutineLowering * {
+    auto it = lowerings.find(coroutine.getAttr());
+    if (it != lowerings.end())
+      return &it->second;
+    hasUnknownCoroutines = true;
+    mlir::emitError(module.getLoc())
+        << "coroutine type references unknown coroutine " << coroutine;
+    return nullptr;
+  };
+  AttrTypeReplacer replacer;
+  replacer.addReplacement([&](CoroutineStateType type) -> std::optional<Type> {
+    if (auto *lowering = lookupLowering(type.getCoroutine()))
+      return lowering->stateType;
+    return std::nullopt;
+  });
+  replacer.addReplacement([&](CoroutinePCType type) -> std::optional<Type> {
+    if (auto *lowering = lookupLowering(type.getCoroutine()))
+      return lowering->pcType;
+    return std::nullopt;
+  });
+
+  // Rewrite the ops that consume or produce values of the opaque types. This
+  // must happen before the type sweep below, since some of these ops identify
+  // their coroutine solely through the symbol carried in their types.
+  SmallVector<Operation *> opsToLower;
+  module->walk([&](Operation *op) {
+    if (isa<CoroutineCallOp, CoroutineStartPCOp, CoroutineUndefinedStateOp,
+            CoroutinePCIsReturnOp, CoroutinePCIsHaltOp>(op))
+      opsToLower.push_back(op);
+  });
+
+  // Determine the PC width for a sentinel check. The PC operand either still
+  // has the opaque PC type, or has already been concretized to an integer if
+  // its producer was rewritten earlier in the loop below.
+  auto getPCWidth = [&](Value pc) -> std::optional<unsigned> {
+    if (auto intType = dyn_cast<IntegerType>(pc.getType()))
+      return intType.getWidth();
+    if (auto intType = dyn_cast<IntegerType>(replacer.replace(pc.getType())))
+      return intType.getWidth();
+    return std::nullopt;
+  };
+
+  for (auto *op : opsToLower) {
+    OpBuilder builder(op);
+    TypeSwitch<Operation *>(op)
+        .Case<CoroutineCallOp>([&](CoroutineCallOp op) {
+          // The lowered function signature matches the coroutine call ABI
+          // exactly, so the call maps to a plain function call.
+          auto resultTypes =
+              llvm::map_to_vector(op.getResultTypes(), [&](Type type) {
+                return replacer.replace(type);
+              });
+          auto callOp =
+              func::CallOp::create(builder, op.getLoc(), op.getCalleeAttr(),
+                                   resultTypes, op.getOperands());
+          op->replaceAllUsesWith(callOp);
+          op->erase();
+        })
+        .Case<CoroutineStartPCOp>([&](CoroutineStartPCOp op) {
+          auto pcType = dyn_cast<IntegerType>(replacer.replace(op.getType()));
+          if (!pcType)
+            return;
+          Value value = hw::ConstantOp::create(builder, op.getLoc(),
+                                               APInt(pcType.getWidth(), 0));
+          op->replaceAllUsesWith(ValueRange{value});
+          op->erase();
+        })
+        .Case<CoroutineUndefinedStateOp>([&](CoroutineUndefinedStateOp op) {
+          // The state passed on the very first entry into a coroutine is
+          // never read, so any value will do.
+          auto stateType = replacer.replace(op.getType());
+          if (stateType == op.getType())
+            return;
+          Value value =
+              ub::PoisonOp::create(builder, op.getLoc(), stateType,
+                                   ub::PoisonAttr::get(builder.getContext()));
+          op->replaceAllUsesWith(ValueRange{value});
+          op->erase();
+        })
+        .Case<CoroutinePCIsReturnOp, CoroutinePCIsHaltOp>([&](auto op) {
+          // Use the raw operand instead of the typed ODS getter; the PC may
+          // already have been concretized to an integer (see `getPCWidth`).
+          Value pc = op->getOperand(0);
+          auto pcWidth = getPCWidth(pc);
+          if (!pcWidth)
+            return;
+          auto sentinel = APInt::getAllOnes(*pcWidth);
+          if (isa<CoroutinePCIsReturnOp>(op))
+            sentinel -= 1;
+          Value constValue =
+              hw::ConstantOp::create(builder, op.getLoc(), sentinel);
+          Value cmpValue = comb::ICmpOp::create(
+              builder, op.getLoc(), comb::ICmpPredicate::eq, pc, constValue);
+          op->replaceAllUsesWith(ValueRange{cmpValue});
+          op->erase();
+        });
+  }
+
+  // Sweep over the entire module and replace all remaining occurrences of the
+  // opaque types. This covers block arguments, results of unrelated ops,
+  // function signatures, and types nested within aggregates.
+  replacer.recursivelyReplaceElementsIn(module, /*replaceAttrs=*/true,
+                                        /*replaceLocs=*/false,
+                                        /*replaceTypes=*/true);
+  if (hasUnknownCoroutines)
+    return signalPassFailure();
+}

--- a/test/Dialect/Arc/lower-coroutines-errors.mlir
+++ b/test/Dialect/Arc/lower-coroutines-errors.mlir
@@ -1,0 +1,45 @@
+// RUN: circt-opt %s --arc-lower-coroutines --split-input-file --verify-diagnostics
+
+// expected-error @below {{recursive coroutines are not supported}}
+arc.coroutine.define @Recursive() {
+  %state = arc.coroutine.undefined_state : !arc.coroutine_state<@Recursive>
+  arc.coroutine.yield ^bb1(%state : !arc.coroutine_state<@Recursive>)
+^bb1(%s: !arc.coroutine_state<@Recursive>):
+  arc.coroutine.return
+}
+
+// -----
+
+// expected-error @below {{recursive coroutines are not supported}}
+arc.coroutine.define @MutualA() {
+  %state = arc.coroutine.undefined_state : !arc.coroutine_state<@MutualB>
+  arc.coroutine.yield ^bb1(%state : !arc.coroutine_state<@MutualB>)
+^bb1(%s: !arc.coroutine_state<@MutualB>):
+  arc.coroutine.return
+}
+
+arc.coroutine.define @MutualB() {
+  %state = arc.coroutine.undefined_state : !arc.coroutine_state<@MutualA>
+  arc.coroutine.yield ^bb1(%state : !arc.coroutine_state<@MutualA>)
+^bb1(%s: !arc.coroutine_state<@MutualA>):
+  arc.coroutine.return
+}
+
+// -----
+
+arc.coroutine.define @WithWakeup() -> i64 {
+  %c0_i64 = hw.constant 0 : i64
+  arc.coroutine.return %c0_i64 : i64
+}
+
+hw.module @Module() {
+  // expected-error @below {{must be lowered before LowerCoroutines}}
+  arc.coroutine.instance @WithWakeup() : () -> ()
+}
+
+// -----
+
+// expected-error @below {{coroutine type references unknown coroutine @DoesNotExist}}
+module {
+  func.func private @Unknown(!arc.coroutine_state<@DoesNotExist>)
+}

--- a/test/Dialect/Arc/lower-coroutines.mlir
+++ b/test/Dialect/Arc/lower-coroutines.mlir
@@ -1,0 +1,370 @@
+// RUN: circt-opt %s --arc-lower-coroutines | FileCheck %s
+
+// Empty coroutine with an immediate return. No resume blocks, so the state
+// degenerates to an empty struct and the PC is dispatched by an unconditional
+// branch.
+// CHECK-LABEL: func.func @Empty
+// CHECK-SAME: (%arg0: !hw.struct<>, %arg1: i2) -> (!hw.struct<>, i2)
+arc.coroutine.define @Empty() {
+  // CHECK: cf.br ^[[BB:.+]]
+  // CHECK: ^[[BB]]:
+  // CHECK: [[STATE:%.+]] = ub.poison : !hw.struct<>
+  // CHECK: [[PC:%.+]] = hw.constant -2 : i2
+  // CHECK: return [[STATE]], [[PC]] : !hw.struct<>, i2
+  arc.coroutine.return
+}
+
+// CHECK-LABEL: func.func @HaltOnly
+// CHECK-SAME: (%arg0: !hw.struct<>, %arg1: i2, %arg2: i42) -> (!hw.struct<>, i2)
+arc.coroutine.define @HaltOnly(%arg0: i42) {
+  // CHECK: [[STATE:%.+]] = ub.poison : !hw.struct<>
+  // CHECK: [[PC:%.+]] = hw.constant -1 : i2
+  // CHECK: return [[STATE]], [[PC]] : !hw.struct<>, i2
+  arc.coroutine.halt
+}
+
+// CHECK-LABEL: func.func @ReturnOnly
+// CHECK-SAME: (%arg0: !hw.struct<>, %arg1: i2, %arg2: i42) -> (!hw.struct<>, i2, i42)
+arc.coroutine.define @ReturnOnly(%arg0: i42) -> i42 {
+  // CHECK: cf.br ^[[BB:.+]](%arg2 : i42)
+  // CHECK: ^[[BB]]([[ARG:%.+]]: i42):
+  // CHECK: [[STATE:%.+]] = ub.poison : !hw.struct<>
+  // CHECK: [[PC:%.+]] = hw.constant -2 : i2
+  // CHECK: return [[STATE]], [[PC]], [[ARG]] : !hw.struct<>, i2, i42
+  arc.coroutine.return %arg0 : i42
+}
+
+// A single yield whose resume block persists no state. No union variant is
+// allocated; the yield returns a poison state and the trampoline passes only
+// the fresh caller-supplied arguments.
+// CHECK-LABEL: func.func @YieldStateless
+// CHECK-SAME: (%arg0: !hw.struct<>, %arg1: i2, %arg2: i42) -> (!hw.struct<>, i2, i42)
+arc.coroutine.define @YieldStateless(%arg0: i42) -> i42 {
+  // CHECK: cf.switch %arg1 : i2, [
+  // CHECK-NEXT: default: ^[[ENTRY:.+]](%arg2 : i42),
+  // CHECK-NEXT: 1: ^[[TRAMPOLINE:.+]]
+  // CHECK-NEXT: ]
+  // CHECK: ^[[ENTRY]]([[ARG:%.+]]: i42):
+  // CHECK: [[STATE:%.+]] = ub.poison : !hw.struct<>
+  // CHECK: [[PC:%.+]] = hw.constant 1 : i2
+  // CHECK: return [[STATE]], [[PC]], [[ARG]]
+  arc.coroutine.yield (%arg0 : i42), ^bb1
+  // CHECK: ^[[TRAMPOLINE]]:
+  // CHECK: cf.br ^[[RESUME:.+]](%arg2 : i42)
+  // CHECK: ^[[RESUME]]([[FRESH:%.+]]: i42):
+  // CHECK: hw.constant -2 : i2
+  // CHECK: return {{%.+}}, {{%.+}}, [[FRESH]]
+^bb1(%arg1: i42):
+  arc.coroutine.return %arg1 : i42
+}
+
+// A yield with an explicit destination operand; the value is persisted in the
+// resume block's union variant.
+// CHECK-LABEL: func.func @YieldPersist
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: i42>>, %arg1: i2, %arg2: i42)
+// CHECK-SAME: -> (!hw.union<r1: !hw.struct<f0: i42>>, i2, i42)
+arc.coroutine.define @YieldPersist(%arg0: i42) -> i42 {
+  // CHECK: cf.switch %arg1 : i2, [
+  // CHECK-NEXT: default: ^[[ENTRY:.+]](%arg2 : i42),
+  // CHECK-NEXT: 1: ^[[TRAMPOLINE:.+]]
+  // CHECK-NEXT: ]
+  // CHECK: ^[[ENTRY]]([[ARG:%.+]]: i42):
+  // CHECK: [[VARIANT:%.+]] = hw.struct_create ([[ARG]]) : !hw.struct<f0: i42>
+  // CHECK: [[STATE:%.+]] = hw.union_create "r1", [[VARIANT]]
+  // CHECK: [[PC:%.+]] = hw.constant 1 : i2
+  // CHECK: return [[STATE]], [[PC]], [[ARG]]
+  arc.coroutine.yield (%arg0 : i42), ^bb1(%arg0 : i42)
+  // CHECK: ^[[TRAMPOLINE]]:
+  // CHECK: [[VARIANT2:%.+]] = hw.union_extract %arg0["r1"]
+  // CHECK: [[FIELD:%.+]] = hw.struct_explode [[VARIANT2]]
+  // CHECK: cf.br ^[[RESUME:.+]](%arg2, [[FIELD]] : i42, i42)
+  // CHECK: ^[[RESUME]]([[FRESH:%.+]]: i42, [[OLD:%.+]]: i42):
+  // CHECK: [[SUM:%.+]] = comb.add [[FRESH]], [[OLD]]
+  // CHECK: return {{%.+}}, {{%.+}}, [[SUM]]
+^bb1(%fresh: i42, %old: i42):
+  %sum = comb.add %fresh, %old : i42
+  arc.coroutine.return %sum : i42
+}
+
+// A value that is live across a yield without being a destination operand. It
+// must be captured as a trailing block argument of the resume block and
+// persisted.
+// CHECK-LABEL: func.func @LiveAcrossYield
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: i42>>, %arg1: i2, %arg2: i42)
+arc.coroutine.define @LiveAcrossYield(%arg0: i42) -> i42 {
+  // CHECK: ^[[ENTRY:.+]]([[ARG:%.+]]: i42):
+  // CHECK: [[MUL:%.+]] = comb.mul [[ARG]], [[ARG]]
+  // CHECK: [[VARIANT:%.+]] = hw.struct_create ([[MUL]]) : !hw.struct<f0: i42>
+  // CHECK: hw.union_create "r1", [[VARIANT]]
+  %0 = comb.mul %arg0, %arg0 : i42
+  arc.coroutine.yield (%arg0 : i42), ^bb1
+  // CHECK: [[VARIANT2:%.+]] = hw.union_extract %arg0["r1"]
+  // CHECK: [[FIELD:%.+]] = hw.struct_explode [[VARIANT2]]
+  // CHECK: cf.br ^[[RESUME:.+]](%arg2, [[FIELD]] : i42, i42)
+  // CHECK: ^[[RESUME]]([[FRESH:%.+]]: i42, [[OLD:%.+]]: i42):
+  // CHECK: comb.add [[OLD]], [[FRESH]]
+^bb1(%fresh: i42):
+  %1 = comb.add %0, %fresh : i42
+  arc.coroutine.return %1 : i42
+}
+
+// A constant that is live across a yield is rematerialized in the resume
+// block instead of being persisted; the coroutine ends up with no state.
+// CHECK-LABEL: func.func @ConstAcrossYield
+// CHECK-SAME: (%arg0: !hw.struct<>, %arg1: i2) -> (!hw.struct<>, i2, i42)
+arc.coroutine.define @ConstAcrossYield() -> i42 {
+  // CHECK: [[CONST:%.+]] = hw.constant 9001 : i42
+  // CHECK: return {{%.+}}, {{%.+}}, [[CONST]]
+  %0 = hw.constant 9001 : i42
+  arc.coroutine.yield (%0 : i42), ^bb1
+  // CHECK: [[CONST2:%.+]] = hw.constant 9001 : i42
+  // CHECK: return {{%.+}}, {{%.+}}, [[CONST2]]
+^bb1:
+  arc.coroutine.return %0 : i42
+}
+
+// A value used across an ordinary branch without crossing a suspension point
+// is not captured; the using block keeps referring to the dominating
+// definition instead of receiving a block argument.
+// CHECK-LABEL: func.func @DominatedUseAcrossBranch
+// CHECK-SAME: (%arg0: !hw.struct<>, %arg1: i2, %arg2: i42)
+arc.coroutine.define @DominatedUseAcrossBranch(%arg0: i42) -> i42 {
+  // CHECK: ^{{.+}}([[ARG:%.+]]: i42):
+  // CHECK: [[MUL:%.+]] = comb.mul [[ARG]], [[ARG]]
+  // CHECK-NEXT: cf.br ^[[BB:.+]]{{$}}
+  %0 = comb.mul %arg0, %arg0 : i42
+  cf.br ^bb1
+  // CHECK: ^[[BB]]:
+  // CHECK: comb.add [[MUL]], [[ARG]]
+^bb1:
+  %1 = comb.add %0, %arg0 : i42
+  arc.coroutine.yield (%1 : i42), ^bb2
+^bb2(%fresh: i42):
+  arc.coroutine.return %fresh : i42
+}
+
+// A value live across a yield is captured as a trailing block argument of the
+// resume block only. Blocks downstream of the resume block use the captured
+// value through dominance and receive no arguments of their own.
+// CHECK-LABEL: func.func @CaptureOnlyAtResume
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: i42>>, %arg1: i2, %arg2: i42)
+arc.coroutine.define @CaptureOnlyAtResume(%arg0: i42) -> i42 {
+  // CHECK: ^{{.+}}([[ARG:%.+]]: i42):
+  // CHECK: [[MUL:%.+]] = comb.mul [[ARG]], [[ARG]]
+  // CHECK: hw.struct_create ([[MUL]])
+  %0 = comb.mul %arg0, %arg0 : i42
+  arc.coroutine.yield (%arg0 : i42), ^bb1
+  // CHECK: ^[[RESUME:.+]]([[FRESH:%.+]]: i42, [[OLD:%.+]]: i42):
+  // CHECK-NEXT: cf.br ^[[TAIL:.+]]{{$}}
+^bb1(%fresh: i42):
+  cf.br ^bb2
+  // CHECK: ^[[TAIL]]:
+  // CHECK: [[ADD:%.+]] = comb.add [[OLD]], [[FRESH]]
+  // CHECK: return {{%.+}}, {{%.+}}, [[ADD]]
+^bb2:
+  %1 = comb.add %0, %fresh : i42
+  arc.coroutine.return %1 : i42
+}
+
+// Where a path through a resume block rejoins a path carrying the original
+// definition, the join block receives a merging block argument. Only the
+// resume block and the join block are touched.
+// CHECK-LABEL: func.func @RejoinAfterResume
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: i42>>, %arg1: i2, %arg2: i1, %arg3: i42)
+arc.coroutine.define @RejoinAfterResume(%arg0: i1, %arg1: i42) -> i42 {
+  // CHECK: ^{{.+}}([[COND:%.+]]: i1, [[INIT:%.+]]: i42):
+  // CHECK: [[MUL:%.+]] = comb.mul [[INIT]], [[INIT]]
+  // CHECK: cf.cond_br [[COND]], ^[[SUSPEND:.+]], ^[[JOIN:.+]]([[MUL]] : i42)
+  %0 = comb.mul %arg1, %arg1 : i42
+  cf.cond_br %arg0, ^suspend, ^join
+  // CHECK: ^[[SUSPEND]]:
+  // CHECK: hw.struct_create ([[MUL]])
+^suspend:
+  arc.coroutine.yield (%arg1 : i42), ^resume
+  // CHECK: ^{{.+}}({{%.+}}: i1, {{%.+}}: i42, [[OLD:%.+]]: i42):
+  // CHECK-NEXT: cf.br ^[[JOIN]]([[OLD]] : i42)
+^resume(%f0: i1, %f1: i42):
+  cf.br ^join
+  // CHECK: ^[[JOIN]]([[MERGED:%.+]]: i42):
+  // CHECK: return {{%.+}}, {{%.+}}, [[MERGED]]
+^join:
+  arc.coroutine.return %0 : i42
+}
+
+// A merge block whose predecessors all carry the original definition does not
+// receive a block argument; only the resume block captures the value.
+// CHECK-LABEL: func.func @MergeBeforeYield
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: i42>>, %arg1: i2, %arg2: i1, %arg3: i42)
+arc.coroutine.define @MergeBeforeYield(%arg0: i1, %arg1: i42) -> i42 {
+  // CHECK: ^{{.+}}([[COND:%.+]]: i1, [[INIT:%.+]]: i42):
+  // CHECK: [[MUL:%.+]] = comb.mul [[INIT]], [[INIT]]
+  // CHECK: cf.cond_br [[COND]], ^[[A:.+]], ^[[B:.+]]{{$}}
+  %0 = comb.mul %arg1, %arg1 : i42
+  cf.cond_br %arg0, ^a, ^b
+  // CHECK: ^[[A]]:
+  // CHECK-NEXT: cf.br ^[[MERGE:.+]]{{$}}
+^a:
+  cf.br ^merge
+  // CHECK: ^[[B]]:
+  // CHECK-NEXT: cf.br ^[[MERGE]]{{$}}
+^b:
+  cf.br ^merge
+  // CHECK: ^[[MERGE]]:
+  // CHECK: hw.struct_create ([[MUL]])
+^merge:
+  arc.coroutine.yield (%arg1 : i42), ^resume
+  // CHECK: ^{{.+}}({{%.+}}: i1, {{%.+}}: i42, [[OLD:%.+]]: i42):
+  // CHECK: return {{%.+}}, {{%.+}}, [[OLD]]
+^resume(%f0: i1, %f1: i42):
+  arc.coroutine.return %0 : i42
+}
+
+// All three terminators in one coroutine.
+// CHECK-LABEL: func.func @AllTerminators
+arc.coroutine.define @AllTerminators(%arg0: i1) -> i8 {
+  %c0 = hw.constant 0 : i8
+  cf.cond_br %arg0, ^suspend, ^stop
+  // CHECK: hw.constant 1 : i2
+  // CHECK: return
+^suspend:
+  arc.coroutine.yield (%c0 : i8), ^resume
+  // CHECK: hw.constant -2 : i2
+  // CHECK: return
+^resume(%fresh: i1):
+  %c1 = hw.constant 1 : i8
+  arc.coroutine.return %c1 : i8
+  // CHECK: hw.constant -1 : i2
+  // CHECK: return
+^stop:
+  arc.coroutine.halt %c0 : i8
+}
+
+// Two yields targeting the same resume block share the same PC and union
+// variant.
+// CHECK-LABEL: func.func @SharedResume
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: i32>>, %arg1: i2, %arg2: i1)
+arc.coroutine.define @SharedResume(%arg0: i1) -> i32 {
+  // CHECK: cf.switch %arg1 : i2, [
+  // CHECK-NEXT: default: ^{{.+}}(%arg2 : i1),
+  // CHECK-NEXT: 1: ^{{.+}}
+  // CHECK-NEXT: ]
+  %c0 = hw.constant 0 : i32
+  %c1 = hw.constant 1 : i32
+  cf.cond_br %arg0, ^a, ^b
+  // CHECK: hw.union_create "r1"
+  // CHECK: hw.constant 1 : i2
+  // CHECK: return
+^a:
+  arc.coroutine.yield (%c0 : i32), ^resume(%c0 : i32)
+  // CHECK: hw.union_create "r1"
+  // CHECK: hw.constant 1 : i2
+  // CHECK: return
+^b:
+  arc.coroutine.yield (%c1 : i32), ^resume(%c1 : i32)
+  // CHECK: hw.union_extract %arg0["r1"]
+  // CHECK: hw.struct_explode
+^resume(%fresh: i1, %old: i32):
+  arc.coroutine.return %old : i32
+}
+
+// Child coroutine used by the nesting tests below.
+// CHECK-LABEL: func.func @Child
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: i8>>, %arg1: i2)
+// CHECK-SAME: -> (!hw.union<r1: !hw.struct<f0: i8>>, i2, i8)
+arc.coroutine.define @Child() -> i8 {
+  %c1 = hw.constant 1 : i8
+  arc.coroutine.yield (%c1 : i8), ^bb1(%c1 : i8)
+^bb1(%old: i8):
+  arc.coroutine.return %old : i8
+}
+
+// A nested coroutine call. The call lowers to a regular function call, and
+// the sentinel value ops lower to constants and comparisons.
+// CHECK-LABEL: func.func @NestedCall
+arc.coroutine.define @NestedCall() -> i1 {
+  // CHECK: [[STATE:%.+]] = ub.poison : !hw.union<r1: !hw.struct<f0: i8>>
+  // CHECK: [[PC:%.+]] = hw.constant 0 : i2
+  // CHECK: [[CALL:%.+]]:3 = call @Child([[STATE]], [[PC]])
+  // CHECK-SAME: (!hw.union<r1: !hw.struct<f0: i8>>, i2) -> (!hw.union<r1: !hw.struct<f0: i8>>, i2, i8)
+  // CHECK: [[SENTINEL:%.+]] = hw.constant -2 : i2
+  // CHECK: [[DONE:%.+]] = comb.icmp eq [[CALL]]#1, [[SENTINEL]] : i2
+  // CHECK: return {{%.+}}, {{%.+}}, [[DONE]]
+  %state = arc.coroutine.undefined_state : !arc.coroutine_state<@Child>
+  %pc = arc.coroutine.start_pc : !arc.coroutine_pc<@Child>
+  %s, %p, %r = arc.coroutine.call @Child(%state, %pc) : (!arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>) -> (!arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>, i8)
+  %done = arc.coroutine.pc_is_return %p : !arc.coroutine_pc<@Child>
+  arc.coroutine.return %done : i1
+}
+
+// A nested coroutine call carried across a yield. The child's state and PC
+// are embedded in the parent's persisted state variant.
+// CHECK-LABEL: func.func @NestedCarried
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: !hw.union<r1: !hw.struct<f0: i8>>, f1: i2>>, %arg1: i2)
+arc.coroutine.define @NestedCarried() -> i8 {
+  %state = arc.coroutine.undefined_state : !arc.coroutine_state<@Child>
+  %pc = arc.coroutine.start_pc : !arc.coroutine_pc<@Child>
+  cf.br ^loop(%state, %pc : !arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>)
+  // CHECK: [[CALL:%.+]]:3 = call @Child
+  // CHECK: [[SENTINEL:%.+]] = hw.constant -1 : i2
+  // CHECK: comb.icmp eq [[CALL]]#1, [[SENTINEL]] : i2
+^loop(%s: !arc.coroutine_state<@Child>, %p: !arc.coroutine_pc<@Child>):
+  %s2, %p2, %r = arc.coroutine.call @Child(%s, %p) : (!arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>) -> (!arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>, i8)
+  %halted = arc.coroutine.pc_is_halt %p2 : !arc.coroutine_pc<@Child>
+  cf.cond_br %halted, ^done, ^suspend
+  // CHECK: [[VARIANT:%.+]] = hw.struct_create ({{%.+}}, {{%.+}}) : !hw.struct<f0: !hw.union<r1: !hw.struct<f0: i8>>, f1: i2>
+  // CHECK: hw.union_create "r1", [[VARIANT]]
+  // CHECK: hw.constant 1 : i2
+  // CHECK: return
+^suspend:
+  arc.coroutine.yield (%r : i8), ^resume(%s2, %p2 : !arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>)
+  // CHECK: [[VARIANT2:%.+]] = hw.union_extract %arg0["r1"]
+  // CHECK: [[F0:%.+]], [[F1:%.+]] = hw.struct_explode [[VARIANT2]]
+^resume(%s3: !arc.coroutine_state<@Child>, %p3: !arc.coroutine_pc<@Child>):
+  cf.br ^loop(%s3, %p3 : !arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>)
+^done:
+  arc.coroutine.return %r : i8
+}
+
+// A non-coroutine driver function polling a coroutine in a loop. The state
+// and PC flow through loop-carried block arguments, which must be retyped.
+// CHECK-LABEL: func.func @Driver
+func.func @Driver() -> i8 {
+  // CHECK: [[STATE:%.+]] = ub.poison : !hw.union<r1: !hw.struct<f0: i8>>
+  // CHECK: [[PC:%.+]] = hw.constant 0 : i2
+  // CHECK: cf.br ^[[LOOP:.+]]([[STATE]], [[PC]] : !hw.union<r1: !hw.struct<f0: i8>>, i2)
+  %state = arc.coroutine.undefined_state : !arc.coroutine_state<@Child>
+  %pc = arc.coroutine.start_pc : !arc.coroutine_pc<@Child>
+  cf.br ^loop(%state, %pc : !arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>)
+  // CHECK: ^[[LOOP]]([[S:%.+]]: !hw.union<r1: !hw.struct<f0: i8>>, [[P:%.+]]: i2):
+  // CHECK: [[CALL:%.+]]:3 = call @Child([[S]], [[P]])
+  // CHECK: [[DONE:%.+]] = comb.icmp eq [[CALL]]#1
+  // CHECK: cf.cond_br [[DONE]], ^[[EXIT:.+]], ^[[LOOP]]([[CALL]]#0, [[CALL]]#1 : !hw.union<r1: !hw.struct<f0: i8>>, i2)
+^loop(%s: !arc.coroutine_state<@Child>, %p: !arc.coroutine_pc<@Child>):
+  %s2, %p2, %r = arc.coroutine.call @Child(%s, %p) : (!arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>) -> (!arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>, i8)
+  %done = arc.coroutine.pc_is_return %p2 : !arc.coroutine_pc<@Child>
+  cf.cond_br %done, ^exit, ^loop(%s2, %p2 : !arc.coroutine_state<@Child>, !arc.coroutine_pc<@Child>)
+  // CHECK: ^[[EXIT]]:
+  // CHECK: return [[CALL]]#2 : i8
+^exit:
+  return %r : i8
+}
+
+// Unrelated ops referring to the opaque types directly. The function
+// signatures and call types must be concretized.
+// CHECK-LABEL: func.func private @Helper(!hw.union<r1: !hw.struct<f0: i8>>) -> i2
+func.func private @Helper(!arc.coroutine_state<@Child>) -> !arc.coroutine_pc<@Child>
+
+// CHECK-LABEL: func.func @CallsHelper
+// CHECK-SAME: (%arg0: !hw.union<r1: !hw.struct<f0: i8>>) -> i2
+func.func @CallsHelper(%arg0: !arc.coroutine_state<@Child>) -> !arc.coroutine_pc<@Child> {
+  // CHECK: [[RESULT:%.+]] = call @Helper(%arg0) : (!hw.union<r1: !hw.struct<f0: i8>>) -> i2
+  // CHECK: return [[RESULT]] : i2
+  %0 = func.call @Helper(%arg0) : (!arc.coroutine_state<@Child>) -> !arc.coroutine_pc<@Child>
+  return %0 : !arc.coroutine_pc<@Child>
+}
+
+// Opaque types nested within aggregate types on unrelated ops.
+// CHECK-LABEL: func.func private @AggregateHelper
+// CHECK-SAME: (!hw.struct<s: !hw.union<r1: !hw.struct<f0: i8>>, p: !hw.union<a: i2, b: i1>>)
+// CHECK-SAME: -> !hw.array<2xstruct<x: i2>>
+func.func private @AggregateHelper(!hw.struct<s: !arc.coroutine_state<@Child>, p: !hw.union<a: !arc.coroutine_pc<@Child>, b: i1>>) -> !hw.array<2xstruct<x: !arc.coroutine_pc<@Child>>>


### PR DESCRIPTION
Add an `arc-lower-coroutines` pass that converts coroutine definitions into plain state machine functions. The lowered functions take an explicit state and program counter as leading arguments, dispatch on the PC to the entry block or one of the resume blocks, and persist all values live across suspension points in a union with one struct variant per resume block.

Each definition is lowered independently: the values live across suspension points are first captured as trailing resume block arguments through a pruned SSA construction based on liveness and iterated dominance frontiers, with constants cloned into their using blocks instead of being persisted. A global sweep then rewrites coroutine calls into regular function calls, lowers the sentinel value ops to constants and comparisons, and replaces all occurrences of the opaque coroutine state and PC types -- including in unrelated ops and nested aggregates -- with the concrete union and integer types. Recursive coroutines are rejected, since their state would require unbounded storage.

Assisted-by: Claude Opus 4.8