### PR TITLE
Bump LLVM

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -369,7 +369,7 @@ protected:
 /// An annotation target is used to keep track of something that is targeted by
 /// an Annotation.
 struct AnnoTarget {
-  AnnoTarget(detail::AnnoTargetImpl impl = nullptr) : impl(impl) {};
+  AnnoTarget(detail::AnnoTargetImpl impl = nullptr) : impl(impl){};
 
   operator bool() const { return impl; }
   bool operator==(const AnnoTarget &other) const { return impl == other.impl; }

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -480,11 +480,6 @@ struct PointerLikeTypeTraits<circt::firrtl::Annotation>
 template <>
 struct DenseMapInfo<circt::firrtl::Annotation> {
   using Annotation = circt::firrtl::Annotation;
-  static Annotation getEmptyKey() {
-    return Annotation(
-        mlir::DictionaryAttr(static_cast<mlir::Attribute::ImplType *>(
-            DenseMapInfo<void *>::getEmptyKey())));
-  }
   static unsigned getHashValue(Annotation val) {
     return mlir::hash_value(val.getAttr());
   }
@@ -496,11 +491,6 @@ template <>
 struct DenseMapInfo<circt::firrtl::AnnoTarget> {
   using AnnoTarget = circt::firrtl::AnnoTarget;
   using AnnoTargetImpl = circt::firrtl::detail::AnnoTargetImpl;
-  static AnnoTarget getEmptyKey() {
-    auto *o = DenseMapInfo<mlir::Operation *>::getEmptyKey();
-    auto i = DenseMapInfo<unsigned>::getEmptyKey();
-    return AnnoTarget(AnnoTargetImpl(o, i));
-  }
   static unsigned getHashValue(AnnoTarget val) {
     auto impl = val.getImpl();
     return hash_combine(impl.getOp(), impl.getPortNo());

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -369,7 +369,7 @@ protected:
 /// An annotation target is used to keep track of something that is targeted by
 /// an Annotation.
 struct AnnoTarget {
-  AnnoTarget(detail::AnnoTargetImpl impl = nullptr) : impl(impl){};
+  AnnoTarget(detail::AnnoTargetImpl impl = nullptr) : impl(impl) {};
 
   operator bool() const { return impl; }
   bool operator==(const AnnoTarget &other) const { return impl == other.impl; }
@@ -485,11 +485,6 @@ struct DenseMapInfo<circt::firrtl::Annotation> {
         mlir::DictionaryAttr(static_cast<mlir::Attribute::ImplType *>(
             DenseMapInfo<void *>::getEmptyKey())));
   }
-  static Annotation getTombstoneKey() {
-    return Annotation(
-        mlir::DictionaryAttr(static_cast<mlir::Attribute::ImplType *>(
-            llvm::DenseMapInfo<void *>::getTombstoneKey())));
-  }
   static unsigned getHashValue(Annotation val) {
     return mlir::hash_value(val.getAttr());
   }
@@ -504,11 +499,6 @@ struct DenseMapInfo<circt::firrtl::AnnoTarget> {
   static AnnoTarget getEmptyKey() {
     auto *o = DenseMapInfo<mlir::Operation *>::getEmptyKey();
     auto i = DenseMapInfo<unsigned>::getEmptyKey();
-    return AnnoTarget(AnnoTargetImpl(o, i));
-  }
-  static AnnoTarget getTombstoneKey() {
-    auto *o = DenseMapInfo<mlir::Operation *>::getTombstoneKey();
-    auto i = DenseMapInfo<unsigned>::getTombstoneKey();
     return AnnoTarget(AnnoTargetImpl(o, i));
   }
   static unsigned getHashValue(AnnoTarget val) {

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -237,10 +237,6 @@ struct DenseMapInfo<circt::firrtl::FModuleOp> {
     return FModuleOp::getFromOpaquePointer(
         DenseMapInfo<Operation *>::getEmptyKey());
   }
-  static inline FModuleOp getTombstoneKey() {
-    return FModuleOp::getFromOpaquePointer(
-        DenseMapInfo<Operation *>::getTombstoneKey());
-  }
   static unsigned getHashValue(const FModuleOp &val) {
     return DenseMapInfo<Operation *>::getHashValue(val);
   }

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -233,10 +233,6 @@ template <>
 struct DenseMapInfo<circt::firrtl::FModuleOp> {
   using Operation = mlir::Operation;
   using FModuleOp = circt::firrtl::FModuleOp;
-  static inline FModuleOp getEmptyKey() {
-    return FModuleOp::getFromOpaquePointer(
-        DenseMapInfo<Operation *>::getEmptyKey());
-  }
   static unsigned getHashValue(const FModuleOp &val) {
     return DenseMapInfo<Operation *>::getHashValue(val);
   }

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -416,10 +416,6 @@ struct DenseMapInfo<circt::firrtl::FIRRTLType> {
     auto pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return FIRRTLType(static_cast<mlir::Type::ImplType *>(pointer));
   }
-  static FIRRTLType getTombstoneKey() {
-    auto pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return FIRRTLType(static_cast<mlir::Type::ImplType *>(pointer));
-  }
   static unsigned getHashValue(FIRRTLType val) { return mlir::hash_value(val); }
   static bool isEqual(FIRRTLType LHS, FIRRTLType RHS) { return LHS == RHS; }
 };

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -412,10 +412,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<circt::firrtl::FIRRTLType> {
   using FIRRTLType = circt::firrtl::FIRRTLType;
-  static FIRRTLType getEmptyKey() {
-    auto pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
-    return FIRRTLType(static_cast<mlir::Type::ImplType *>(pointer));
-  }
   static unsigned getHashValue(FIRRTLType val) { return mlir::hash_value(val); }
   static bool isEqual(FIRRTLType LHS, FIRRTLType RHS) { return LHS == RHS; }
 };

--- a/include/circt/Dialect/FIRRTL/NLATable.h
+++ b/include/circt/Dialect/FIRRTL/NLATable.h
@@ -83,10 +83,7 @@ public:
     // Handle the case when there are more than one Instances for the same
     // target module. Getting the `commonNLA`, in that case is not enough,
     // remove the NLAs that donot have the InstanceOp as the innerSym.
-    for (auto nla : llvm::make_early_inc_range(nlas)) {
-      if (!nla.hasInnerSym(mod, instSym))
-        nlas.erase(nla);
-    }
+    nlas.remove_if([&](auto nla) { return !nla.hasInnerSym(mod, instSym); });
   }
 
   /// Get the NLAs that the module `modName` particiaptes in, and insert them

--- a/include/circt/Dialect/Synth/Analysis/LongestPathAnalysis.h
+++ b/include/circt/Dialect/Synth/Analysis/LongestPathAnalysis.h
@@ -337,7 +337,7 @@ public:
 // for computing statistics and CAPI.
 class LongestPathCollection {
 public:
-  LongestPathCollection(MLIRContext *ctx) : ctx(ctx){};
+  LongestPathCollection(MLIRContext *ctx) : ctx(ctx) {};
   const DataflowPath &getPath(unsigned index) const { return paths[index]; }
   MLIRContext *getContext() const { return ctx; }
   llvm::SmallVector<DataflowPath, 64> paths;
@@ -379,11 +379,6 @@ struct DenseMapInfo<circt::synth::Object> {
   using Object = circt::synth::Object;
   static Object getEmptyKey() {
     auto [path, value, bitPos] = Info::getEmptyKey();
-    return Object(path, value, bitPos);
-  }
-
-  static Object getTombstoneKey() {
-    auto [path, value, bitPos] = Info::getTombstoneKey();
     return Object(path, value, bitPos);
   }
   static llvm::hash_code getHashValue(Object object) {

--- a/include/circt/Dialect/Synth/Analysis/LongestPathAnalysis.h
+++ b/include/circt/Dialect/Synth/Analysis/LongestPathAnalysis.h
@@ -377,10 +377,6 @@ struct DenseMapInfo<circt::synth::Object> {
   using Info = llvm::DenseMapInfo<
       std::tuple<circt::igraph::InstancePath, mlir::Value, size_t>>;
   using Object = circt::synth::Object;
-  static Object getEmptyKey() {
-    auto [path, value, bitPos] = Info::getEmptyKey();
-    return Object(path, value, bitPos);
-  }
   static llvm::hash_code getHashValue(Object object) {
     return Info::getHashValue(
         {object.instancePath, object.value, object.bitPos});

--- a/include/circt/Dialect/Synth/Analysis/LongestPathAnalysis.h
+++ b/include/circt/Dialect/Synth/Analysis/LongestPathAnalysis.h
@@ -337,7 +337,7 @@ public:
 // for computing statistics and CAPI.
 class LongestPathCollection {
 public:
-  LongestPathCollection(MLIRContext *ctx) : ctx(ctx) {};
+  LongestPathCollection(MLIRContext *ctx) : ctx(ctx){};
   const DataflowPath &getPath(unsigned index) const { return paths[index]; }
   MLIRContext *getContext() const { return ctx; }
   llvm::SmallVector<DataflowPath, 64> paths;

--- a/include/circt/Scheduling/DependenceIterator.h
+++ b/include/circt/Scheduling/DependenceIterator.h
@@ -131,10 +131,6 @@ struct DenseMapInfo<Dependence> {
   static inline Dependence getEmptyKey() {
     return Dependence(DenseMapInfo<mlir::Operation *>::getEmptyKey(), nullptr);
   }
-  static inline Dependence getTombstoneKey() {
-    return Dependence(DenseMapInfo<mlir::Operation *>::getTombstoneKey(),
-                      nullptr);
-  }
   static unsigned getHashValue(const Dependence &val) {
     return llvm::hash_value(val.getAsTuple());
   }

--- a/include/circt/Scheduling/DependenceIterator.h
+++ b/include/circt/Scheduling/DependenceIterator.h
@@ -128,9 +128,6 @@ using circt::scheduling::detail::Dependence;
 
 template <>
 struct DenseMapInfo<Dependence> {
-  static inline Dependence getEmptyKey() {
-    return Dependence(DenseMapInfo<mlir::Operation *>::getEmptyKey(), nullptr);
-  }
   static unsigned getHashValue(const Dependence &val) {
     return llvm::hash_value(val.getAsTuple());
   }

--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -581,11 +581,6 @@ struct DenseMapInfo<circt::scheduling::Problem::OperatorType> {
         DenseMapInfo<mlir::StringAttr>::getEmptyKey());
   }
 
-  static inline circt::scheduling::Problem::OperatorType getTombstoneKey() {
-    return circt::scheduling::Problem::OperatorType{
-        DenseMapInfo<mlir::StringAttr>::getTombstoneKey()};
-  }
-
   static unsigned
   getHashValue(const circt::scheduling::Problem::OperatorType &val) {
     return DenseMapInfo<mlir::StringAttr>::getHashValue(val.attr);
@@ -602,11 +597,6 @@ struct DenseMapInfo<circt::scheduling::Problem::ResourceType> {
   static inline circt::scheduling::Problem::ResourceType getEmptyKey() {
     return circt::scheduling::Problem::ResourceType(
         DenseMapInfo<mlir::StringAttr>::getEmptyKey());
-  }
-
-  static inline circt::scheduling::Problem::ResourceType getTombstoneKey() {
-    return circt::scheduling::Problem::ResourceType(
-        DenseMapInfo<mlir::StringAttr>::getTombstoneKey());
   }
 
   static unsigned

--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -576,11 +576,6 @@ namespace llvm {
 
 template <>
 struct DenseMapInfo<circt::scheduling::Problem::OperatorType> {
-  static inline circt::scheduling::Problem::OperatorType getEmptyKey() {
-    return circt::scheduling::Problem::OperatorType(
-        DenseMapInfo<mlir::StringAttr>::getEmptyKey());
-  }
-
   static unsigned
   getHashValue(const circt::scheduling::Problem::OperatorType &val) {
     return DenseMapInfo<mlir::StringAttr>::getHashValue(val.attr);
@@ -594,11 +589,6 @@ struct DenseMapInfo<circt::scheduling::Problem::OperatorType> {
 
 template <>
 struct DenseMapInfo<circt::scheduling::Problem::ResourceType> {
-  static inline circt::scheduling::Problem::ResourceType getEmptyKey() {
-    return circt::scheduling::Problem::ResourceType(
-        DenseMapInfo<mlir::StringAttr>::getEmptyKey());
-  }
-
   static unsigned
   getHashValue(const circt::scheduling::Problem::ResourceType &val) {
     return DenseMapInfo<mlir::StringAttr>::getHashValue(val.attr);

--- a/include/circt/Support/FVInt.h
+++ b/include/circt/Support/FVInt.h
@@ -724,10 +724,6 @@ namespace llvm {
 /// Provide DenseMapInfo for FVInt.
 template <>
 struct DenseMapInfo<circt::FVInt, void> {
-  static inline circt::FVInt getEmptyKey() {
-    return circt::FVInt(DenseMapInfo<APInt>::getEmptyKey());
-  }
-
   static unsigned getHashValue(const circt::FVInt &Key);
 
   static bool isEqual(const circt::FVInt &LHS, const circt::FVInt &RHS) {

--- a/include/circt/Support/FVInt.h
+++ b/include/circt/Support/FVInt.h
@@ -728,10 +728,6 @@ struct DenseMapInfo<circt::FVInt, void> {
     return circt::FVInt(DenseMapInfo<APInt>::getEmptyKey());
   }
 
-  static inline circt::FVInt getTombstoneKey() {
-    return circt::FVInt(DenseMapInfo<APInt>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const circt::FVInt &Key);
 
   static bool isEqual(const circt::FVInt &LHS, const circt::FVInt &RHS) {

--- a/include/circt/Support/FieldRef.h
+++ b/include/circt/Support/FieldRef.h
@@ -105,9 +105,6 @@ struct DenseMapInfo<circt::FieldRef> {
   static inline circt::FieldRef getEmptyKey() {
     return circt::FieldRef(DenseMapInfo<mlir::Value>::getEmptyKey(), 0);
   }
-  static inline circt::FieldRef getTombstoneKey() {
-    return circt::FieldRef(DenseMapInfo<mlir::Value>::getTombstoneKey(), 0);
-  }
   static unsigned getHashValue(const circt::FieldRef &val) {
     return circt::hash_value(val);
   }

--- a/include/circt/Support/FieldRef.h
+++ b/include/circt/Support/FieldRef.h
@@ -102,9 +102,6 @@ namespace llvm {
 /// identity and field ID.
 template <>
 struct DenseMapInfo<circt::FieldRef> {
-  static inline circt::FieldRef getEmptyKey() {
-    return circt::FieldRef(DenseMapInfo<mlir::Value>::getEmptyKey(), 0);
-  }
   static unsigned getHashValue(const circt::FieldRef &val) {
     return circt::hash_value(val);
   }

--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -590,10 +590,6 @@ struct llvm::DenseMapInfo<circt::igraph::InstancePath> {
     return circt::igraph::InstancePath(ArrayRefInfo::getEmptyKey());
   }
 
-  static circt::igraph::InstancePath getTombstoneKey() {
-    return circt::igraph::InstancePath(ArrayRefInfo::getTombstoneKey());
-  }
-
   static llvm::hash_code getHashValue(circt::igraph::InstancePath path) {
     auto range =
         llvm::map_range(path, [](auto op) { return op.getAsOpaquePointer(); });

--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -586,9 +586,6 @@ template <>
 struct llvm::DenseMapInfo<circt::igraph::InstancePath> {
   using ArrayRefInfo =
       llvm::DenseMapInfo<ArrayRef<circt::igraph::InstanceOpInterface>>;
-  static circt::igraph::InstancePath getEmptyKey() {
-    return circt::igraph::InstancePath(ArrayRefInfo::getEmptyKey());
-  }
 
   static llvm::hash_code getHashValue(circt::igraph::InstancePath path) {
     auto range =

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -47,7 +47,7 @@ llvm_config.use_default_substitutions()
 
 # Set the timeout, if requested.
 if config.timeout is not None and config.timeout != "":
-  lit_config.maxIndividualTestTime = int(config.timeout)
+  config.maxIndividualTestTime = int(config.timeout)
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent

--- a/lib/Conversion/DCToHW/DCToHW.cpp
+++ b/lib/Conversion/DCToHW/DCToHW.cpp
@@ -85,7 +85,7 @@ static Type toESIHWType(Type t) {
             return esi::ChannelType::get(vt.getContext(),
                                          toHWType(vt.getInnerType()));
           })
-          .Case([](TokenType tt) {
+          .Case([](dc::TokenType tt) {
             return esi::ChannelType::get(tt.getContext(),
                                          IntegerType::get(tt.getContext(), 0));
           })
@@ -837,7 +837,7 @@ public:
 
 } // namespace
 
-static bool isDCType(Type type) { return isa<TokenType, ValueType>(type); }
+static bool isDCType(Type type) { return isa<dc::TokenType, ValueType>(type); }
 
 ///  Returns true if the given `op` is considered as legal - i.e. it does not
 ///  contain any dc-typed values.

--- a/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
+++ b/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
@@ -95,7 +95,7 @@ public:
       return dc::ValueType::get(type.getContext(), type);
     });
     addConversion([](ValueType type) { return type; });
-    addConversion([](TokenType type) { return type; });
+    addConversion([](dc::TokenType type) { return type; });
 
     addTargetMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
                                 mlir::ValueRange inputs,

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -1204,6 +1204,25 @@ public:
   };
 };
 
+// Pattern for arith min/max operations.
+// These lower to: cmp + mux
+template <typename ArithOp, comb::ICmpPredicate pred>
+class MinMaxConversionPattern : public HandshakeConversionPattern<ArithOp> {
+public:
+  using HandshakeConversionPattern<ArithOp>::HandshakeConversionPattern;
+  void buildModule(ArithOp op, BackedgeBuilder &bb, RTLBuilder &s,
+                   hw::HWModulePortAccessor &ports) const override {
+    auto unwrappedIO = this->unwrapIO(s, bb, ports);
+    this->buildUnitRateJoinLogic(s, unwrappedIO, [&](ValueRange inputs) {
+      // max(a, b) = mux(cmp(a, b), a, b)
+      // min(a, b) = mux(cmp(a, b), a, b)
+      auto cmp =
+          comb::ICmpOp::create(s.b, op.getLoc(), pred, inputs[0], inputs[1]);
+      return comb::MuxOp::create(s.b, op.getLoc(), cmp, inputs[0], inputs[1]);
+    });
+  };
+};
+
 class ComparisonConversionPattern
     : public HandshakeConversionPattern<arith::CmpIOp> {
 public:
@@ -1930,6 +1949,10 @@ static LogicalResult convertFuncOp(ESITypeConverter &typeConverter,
       UnitRateConversionPattern<arith::ShRUIOp, comb::ShrUOp>,
       UnitRateConversionPattern<arith::ShRSIOp, comb::ShrSOp>,
       UnitRateConversionPattern<arith::SelectOp, comb::MuxOp>,
+      MinMaxConversionPattern<arith::MaxSIOp, comb::ICmpPredicate::sge>,
+      MinMaxConversionPattern<arith::MaxUIOp, comb::ICmpPredicate::uge>,
+      MinMaxConversionPattern<arith::MinSIOp, comb::ICmpPredicate::sle>,
+      MinMaxConversionPattern<arith::MinUIOp, comb::ICmpPredicate::ule>,
       // HW operations.
       StructCreateConversionPattern,
       // Handshake operations.

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -171,10 +171,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<slang::BufferID> {
   static slang::BufferID getEmptyKey() { return slang::BufferID(); }
-  static slang::BufferID getTombstoneKey() {
-    return slang::BufferID(UINT32_MAX - 1, ""sv);
-    // UINT32_MAX is already used by `BufferID::getPlaceholder`.
-  }
   static unsigned getHashValue(slang::BufferID id) {
     return llvm::hash_value(id.getId());
   }

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -170,7 +170,6 @@ private:
 namespace llvm {
 template <>
 struct DenseMapInfo<slang::BufferID> {
-  static slang::BufferID getEmptyKey() { return slang::BufferID(); }
   static unsigned getHashValue(slang::BufferID id) {
     return llvm::hash_value(id.getId());
   }

--- a/lib/Conversion/SeqToSV/FirMemLowering.h
+++ b/lib/Conversion/SeqToSV/FirMemLowering.h
@@ -117,11 +117,6 @@ private:
 namespace llvm {
 template <>
 struct DenseMapInfo<circt::FirMemConfig> {
-  static inline circt::FirMemConfig getEmptyKey() {
-    circt::FirMemConfig cfg;
-    cfg.depth = DenseMapInfo<size_t>::getEmptyKey();
-    return cfg;
-  }
   static unsigned getHashValue(const circt::FirMemConfig &cfg) {
     return cfg.hashValue();
   }

--- a/lib/Conversion/SeqToSV/FirMemLowering.h
+++ b/lib/Conversion/SeqToSV/FirMemLowering.h
@@ -122,11 +122,6 @@ struct DenseMapInfo<circt::FirMemConfig> {
     cfg.depth = DenseMapInfo<size_t>::getEmptyKey();
     return cfg;
   }
-  static inline circt::FirMemConfig getTombstoneKey() {
-    circt::FirMemConfig cfg;
-    cfg.depth = DenseMapInfo<size_t>::getTombstoneKey();
-    return cfg;
-  }
   static unsigned getHashValue(const circt::FirMemConfig &cfg) {
     return cfg.hashValue();
   }

--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -735,10 +735,6 @@ static unsigned hashValue(const SmallVector<Value> &inputs) {
 
 template <>
 struct DenseMapInfo<SmallVector<Value>> {
-  static inline SmallVector<Value> getEmptyKey() {
-    return SmallVector<Value>();
-  }
-
   static unsigned getHashValue(const SmallVector<Value> &inputs) {
     return hashValue(inputs);
   }

--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -739,10 +739,6 @@ struct DenseMapInfo<SmallVector<Value>> {
     return SmallVector<Value>();
   }
 
-  static inline SmallVector<Value> getTombstoneKey() {
-    return SmallVector<Value>();
-  }
-
   static unsigned getHashValue(const SmallVector<Value> &inputs) {
     return hashValue(inputs);
   }

--- a/lib/Dialect/Arc/Transforms/FindInitialVectors.cpp
+++ b/lib/Dialect/Arc/Transforms/FindInitialVectors.cpp
@@ -157,13 +157,6 @@ struct DenseMapInfo<Key> {
                DictionaryAttr());
   }
 
-  static inline Key getTombstoneKey() {
-    static StringRef tombStoneKeyOpName =
-        DenseMapInfo<StringRef>::getTombstoneKey();
-    return Key(1, tombStoneKeyOpName, SmallVector<Type>(), SmallVector<Type>(),
-               DictionaryAttr());
-  }
-
   static unsigned getHashValue(const Key &key) {
     return hash_value(std::get<0>(key)) ^ hash_value(std::get<1>(key)) ^
            hash_value(std::get<2>(key)) ^ hash_value(std::get<3>(key)) ^

--- a/lib/Dialect/Arc/Transforms/FindInitialVectors.cpp
+++ b/lib/Dialect/Arc/Transforms/FindInitialVectors.cpp
@@ -152,11 +152,6 @@ struct Vectorizer {
 namespace llvm {
 template <>
 struct DenseMapInfo<Key> {
-  static inline Key getEmptyKey() {
-    return Key(0, StringRef(), SmallVector<Type>(), SmallVector<Type>(),
-               DictionaryAttr());
-  }
-
   static unsigned getHashValue(const Key &key) {
     return hash_value(std::get<0>(key)) ^ hash_value(std::get<1>(key)) ^
            hash_value(std::get<2>(key)) ^ hash_value(std::get<3>(key)) ^

--- a/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
@@ -56,10 +56,6 @@ struct DenseMapInfo<AffineAccessExpr> {
     return {DenseMapInfo<Value>::getEmptyKey(), {}, {}};
   }
 
-  static AffineAccessExpr getTombstoneKey() {
-    return {DenseMapInfo<Value>::getTombstoneKey(), {}, {}};
-  }
-
   static unsigned getHashValue(const AffineAccessExpr &expr) {
     unsigned h = DenseMapInfo<Value>::getHashValue(expr.memref);
     h = llvm::hash_combine(h, DenseMapInfo<AffineMap>::getHashValue(expr.map));

--- a/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
@@ -52,10 +52,6 @@ struct AffineAccessExpr {
 namespace llvm {
 template <>
 struct DenseMapInfo<AffineAccessExpr> {
-  static AffineAccessExpr getEmptyKey() {
-    return {DenseMapInfo<Value>::getEmptyKey(), {}, {}};
-  }
-
   static unsigned getHashValue(const AffineAccessExpr &expr) {
     unsigned h = DenseMapInfo<Value>::getHashValue(expr.memref);
     h = llvm::hash_combine(h, DenseMapInfo<AffineMap>::getHashValue(expr.map));

--- a/lib/Dialect/DC/DCOps.cpp
+++ b/lib/Dialect/DC/DCOps.cpp
@@ -350,7 +350,7 @@ LogicalResult UnpackOp::inferReturnTypes(
     DictionaryAttr attrs, mlir::PropertyRef properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
   auto inputType = cast<ValueType>(operands.front().getType());
-  results.push_back(TokenType::get(context));
+  results.push_back(dc::TokenType::get(context));
   results.push_back(inputType.getInnerType());
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -428,10 +428,6 @@ struct ModuleInfoRef {
 /// `ModuleInfo` the ref points to.
 template <>
 struct llvm::DenseMapInfo<ModuleInfoRef> {
-  static inline ModuleInfoRef getEmptyKey() {
-    return DenseMapInfo<ModuleInfo *>::getEmptyKey();
-  }
-
   static unsigned getHashValue(const ModuleInfoRef &ref) {
     // We assume SHA256 is already a good hash and just truncate down to the
     // number of bytes we need for DenseMap.
@@ -445,8 +441,7 @@ struct llvm::DenseMapInfo<ModuleInfoRef> {
   }
 
   static bool isEqual(const ModuleInfoRef &lhs, const ModuleInfoRef &rhs) {
-    auto *empty = getEmptyKey().info;
-    if (lhs.info == empty || rhs.info == empty)
+    if (!lhs.info || !rhs.info)
       return lhs.info == rhs.info;
     return *lhs.info == *rhs.info;
   }

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -432,10 +432,6 @@ struct llvm::DenseMapInfo<ModuleInfoRef> {
     return DenseMapInfo<ModuleInfo *>::getEmptyKey();
   }
 
-  static inline ModuleInfoRef getTombstoneKey() {
-    return DenseMapInfo<ModuleInfo *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const ModuleInfoRef &ref) {
     // We assume SHA256 is already a good hash and just truncate down to the
     // number of bytes we need for DenseMap.
@@ -450,9 +446,7 @@ struct llvm::DenseMapInfo<ModuleInfoRef> {
 
   static bool isEqual(const ModuleInfoRef &lhs, const ModuleInfoRef &rhs) {
     auto *empty = getEmptyKey().info;
-    auto *tombstone = getTombstoneKey().info;
-    if (lhs.info == empty || rhs.info == empty || lhs.info == tombstone ||
-        rhs.info == tombstone)
+    if (lhs.info == empty || rhs.info == empty)
       return lhs.info == rhs.info;
     return *lhs.info == *rhs.info;
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -319,9 +319,6 @@ struct DenseMapInfo<ResetSignal> {
   static inline ResetSignal getEmptyKey() {
     return ResetSignal{DenseMapInfo<FieldRef>::getEmptyKey(), {}};
   }
-  static inline ResetSignal getTombstoneKey() {
-    return ResetSignal{DenseMapInfo<FieldRef>::getTombstoneKey(), {}};
-  }
   static unsigned getHashValue(const ResetSignal &x) {
     return circt::hash_value(x.field);
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -316,9 +316,6 @@ static StringRef resetKindToStringRef(const ResetKind &kind) {
 namespace llvm {
 template <>
 struct DenseMapInfo<ResetSignal> {
-  static inline ResetSignal getEmptyKey() {
-    return ResetSignal{DenseMapInfo<FieldRef>::getEmptyKey(), {}};
-  }
   static unsigned getHashValue(const ResetSignal &x) {
     return circt::hash_value(x.field);
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -336,15 +336,10 @@ struct InternedSlotInfo : DenseMapInfo<T *> {
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return static_cast<T *>(pointer);
   }
-  static T *getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return static_cast<T *>(pointer);
-  }
   static unsigned getHashValue(const T *val) { return mlir::hash_value(*val); }
   static bool isEqual(const T *lhs, const T *rhs) {
     auto empty = getEmptyKey();
-    auto tombstone = getTombstoneKey();
-    if (lhs == empty || rhs == empty || lhs == tombstone || rhs == tombstone)
+    if (lhs == empty || rhs == empty)
       return lhs == rhs;
     return *lhs == *rhs;
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -332,14 +332,9 @@ namespace {
 // itself.
 template <typename T>
 struct InternedSlotInfo : DenseMapInfo<T *> {
-  static T *getEmptyKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
-    return static_cast<T *>(pointer);
-  }
   static unsigned getHashValue(const T *val) { return mlir::hash_value(*val); }
   static bool isEqual(const T *lhs, const T *rhs) {
-    auto empty = getEmptyKey();
-    if (lhs == empty || rhs == empty)
+    if (!lhs || !rhs)
       return lhs == rhs;
     return *lhs == *rhs;
   }

--- a/lib/Dialect/FIRRTL/Transforms/ModuleSummary.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleSummary.cpp
@@ -103,7 +103,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<ModuleSummaryPass::KeyTy> {
   using KeyTy = ModuleSummaryPass::KeyTy;
-  static KeyTy getEmptyKey() { return {{}, ~0ULL}; }
   static unsigned getHashValue(const KeyTy &val) {
     return mlir::hash_value(val);
   }

--- a/lib/Dialect/FIRRTL/Transforms/ModuleSummary.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleSummary.cpp
@@ -104,7 +104,6 @@ template <>
 struct DenseMapInfo<ModuleSummaryPass::KeyTy> {
   using KeyTy = ModuleSummaryPass::KeyTy;
   static KeyTy getEmptyKey() { return {{}, ~0ULL}; }
-  static KeyTy getTombstoneKey() { return {{}, ~0ULL - 1}; }
   static unsigned getHashValue(const KeyTy &val) {
     return mlir::hash_value(val);
   }

--- a/lib/Dialect/LLHD/Transforms/DeseqUtils.h
+++ b/lib/Dialect/LLHD/Transforms/DeseqUtils.h
@@ -317,9 +317,6 @@ struct DenseMapInfo<circt::llhd::deseq::FixedValue> {
   static inline FixedValue getEmptyKey() {
     return FixedValue{DenseMapInfo<Value>::getEmptyKey(), false, false};
   }
-  static inline FixedValue getTombstoneKey() {
-    return FixedValue{DenseMapInfo<Value>::getTombstoneKey(), false, false};
-  }
   static unsigned getHashValue(const FixedValue &key) {
     return hash_value(key);
   }
@@ -336,9 +333,6 @@ struct DenseMapInfo<circt::llhd::deseq::FixedValues> {
   static inline FixedValues getEmptyKey() {
     return {DenseMapInfo<FixedValue>::getEmptyKey()};
   }
-  static inline FixedValues getTombstoneKey() {
-    return {DenseMapInfo<FixedValue>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const FixedValues &key) {
     return hash_value(key);
   }
@@ -353,9 +347,6 @@ struct DenseMapInfo<circt::llhd::deseq::ValueField> {
   using VF = circt::llhd::deseq::ValueField;
   static inline VF getEmptyKey() {
     return VF(DenseMapInfo<mlir::Value>::getEmptyKey(), ~0ULL);
-  }
-  static inline VF getTombstoneKey() {
-    return VF(DenseMapInfo<mlir::Value>::getTombstoneKey(), ~0ULL - 1);
   }
   static unsigned getHashValue(const VF &key) {
     return DenseMapInfo<mlir::Value>::getHashValue(key.value) ^

--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -182,9 +182,6 @@ Value Def::getConditionOrPlaceholder() {
 // Allow `DriveCondition` to be used as hash map key.
 template <>
 struct llvm::DenseMapInfo<DriveCondition> {
-  static DriveCondition getEmptyKey() {
-    return DenseMapInfo<DriveCondition::ConditionAndMode>::getEmptyKey();
-  }
   static unsigned getHashValue(DriveCondition d) {
     return DenseMapInfo<DriveCondition::ConditionAndMode>::getHashValue(
         d.conditionAndMode);

--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -185,9 +185,6 @@ struct llvm::DenseMapInfo<DriveCondition> {
   static DriveCondition getEmptyKey() {
     return DenseMapInfo<DriveCondition::ConditionAndMode>::getEmptyKey();
   }
-  static DriveCondition getTombstoneKey() {
-    return DenseMapInfo<DriveCondition::ConditionAndMode>::getTombstoneKey();
-  }
   static unsigned getHashValue(DriveCondition d) {
     return DenseMapInfo<DriveCondition::ConditionAndMode>::getHashValue(
         d.conditionAndMode);

--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -946,9 +946,10 @@ void Promoter::findPromotableSlots() {
 
   // Populate `promotable` with the slots and projections we are promoting.
   promotable.insert(slots.begin(), slots.end());
-  for (auto [projection, slot] : llvm::make_early_inc_range(projections))
-    if (!promotable.contains(slot))
-      projections.erase(projection);
+  projections.remove_if([&](auto elem) {
+    auto [projection, slot] = elem;
+    return !promotable.contains(slot);
+  });
   for (auto [projection, slot] : projections)
     promotable.insert(projection);
 

--- a/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
@@ -136,7 +136,6 @@ namespace llvm {
 
 template <>
 struct DenseMapInfo<bool> {
-  static inline unsigned getEmptyKey() { return false; }
   static unsigned getHashValue(const bool &val) { return val * 37U; }
 
   static bool isEqual(const bool &lhs, const bool &rhs) { return lhs == rhs; }
@@ -169,11 +168,6 @@ struct HashedStorage {
 /// 'isEqual' method.
 template <typename StorageTy>
 struct StorageKeyInfo {
-  static inline HashedStorage<StorageTy> getEmptyKey() {
-    return HashedStorage<StorageTy>(0,
-                                    DenseMapInfo<StorageTy *>::getEmptyKey());
-  }
-
   static inline unsigned getHashValue(const HashedStorage<StorageTy> &key) {
     return key.hashcode;
   }
@@ -187,7 +181,7 @@ struct StorageKeyInfo {
   }
   static inline bool isEqual(const StorageTy &lhs,
                              const HashedStorage<StorageTy> &rhs) {
-    if (isEqual(rhs, getEmptyKey()))
+    if (!rhs.storage)
       return false;
 
     return lhs.isEqual(rhs.storage);

--- a/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
@@ -137,7 +137,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<bool> {
   static inline unsigned getEmptyKey() { return false; }
-  static inline unsigned getTombstoneKey() { return true; }
   static unsigned getHashValue(const bool &val) { return val * 37U; }
 
   static bool isEqual(const bool &lhs, const bool &rhs) { return lhs == rhs; }
@@ -174,10 +173,6 @@ struct StorageKeyInfo {
     return HashedStorage<StorageTy>(0,
                                     DenseMapInfo<StorageTy *>::getEmptyKey());
   }
-  static inline HashedStorage<StorageTy> getTombstoneKey() {
-    return HashedStorage<StorageTy>(
-        0, DenseMapInfo<StorageTy *>::getTombstoneKey());
-  }
 
   static inline unsigned getHashValue(const HashedStorage<StorageTy> &key) {
     return key.hashcode;
@@ -192,7 +187,7 @@ struct StorageKeyInfo {
   }
   static inline bool isEqual(const StorageTy &lhs,
                              const HashedStorage<StorageTy> &rhs) {
-    if (isEqual(rhs, getEmptyKey()) || isEqual(rhs, getTombstoneKey()))
+    if (isEqual(rhs, getEmptyKey()))
       return false;
 
     return lhs.isEqual(rhs.storage);

--- a/lib/Dialect/SV/Transforms/HWCleanup.cpp
+++ b/lib/Dialect/SV/Transforms/HWCleanup.cpp
@@ -51,9 +51,8 @@ struct AlwaysLikeOpInfo : public llvm::DenseMapInfo<Operation *> {
     // Trivially the same.
     if (lhs == rhs)
       return true;
-    // Filter out tombstones and empty ops.
-    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
-        rhs == getTombstoneKey() || rhs == getEmptyKey())
+    // Filter out empty ops.
+    if (lhs == getEmptyKey() || rhs == getEmptyKey())
       return false;
     // Compare attributes.
     if (lhs->getName() != rhs->getName() ||

--- a/lib/Dialect/SV/Transforms/HWCleanup.cpp
+++ b/lib/Dialect/SV/Transforms/HWCleanup.cpp
@@ -51,8 +51,8 @@ struct AlwaysLikeOpInfo : public llvm::DenseMapInfo<Operation *> {
     // Trivially the same.
     if (lhs == rhs)
       return true;
-    // Filter out empty ops.
-    if (lhs == getEmptyKey() || rhs == getEmptyKey())
+    // Filter out null ops.
+    if (!lhs || !rhs)
       return false;
     // Compare attributes.
     if (lhs->getName() != rhs->getName() ||

--- a/lib/Dialect/Synth/Transforms/LowerVariadic.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerVariadic.cpp
@@ -109,11 +109,6 @@ using OperandKey = llvm::SmallVector<std::pair<mlir::Value, bool>>;
 namespace llvm {
 template <>
 struct DenseMapInfo<OperandKey> {
-  static OperandKey getEmptyKey() {
-    // Return a vector containing the mlir::Value empty key
-    return {{DenseMapInfo<mlir::Value>::getEmptyKey(), false}};
-  }
-
   static unsigned getHashValue(const OperandKey &val) {
     llvm::hash_code hash = 0;
     // Iteratively combine the hash of each pair in the vector

--- a/lib/Dialect/Synth/Transforms/LowerVariadic.cpp
+++ b/lib/Dialect/Synth/Transforms/LowerVariadic.cpp
@@ -114,11 +114,6 @@ struct DenseMapInfo<OperandKey> {
     return {{DenseMapInfo<mlir::Value>::getEmptyKey(), false}};
   }
 
-  static OperandKey getTombstoneKey() {
-    // Return a vector containing the mlir::Value tombstone key
-    return {{DenseMapInfo<mlir::Value>::getTombstoneKey(), false}};
-  }
-
   static unsigned getHashValue(const OperandKey &val) {
     llvm::hash_code hash = 0;
     // Iteratively combine the hash of each pair in the vector

--- a/lib/Dialect/Synth/Transforms/StructuralHash.cpp
+++ b/lib/Dialect/Synth/Transforms/StructuralHash.cpp
@@ -60,11 +60,6 @@ struct StructuralHashKey {
 // DenseMapInfo specialization for StructuralHashKey
 template <>
 struct llvm::DenseMapInfo<StructuralHashKey> {
-  static StructuralHashKey getEmptyKey() {
-    return StructuralHashKey(llvm::DenseMapInfo<OperationName>::getEmptyKey(),
-                             {});
-  }
-
   static unsigned getHashValue(const StructuralHashKey &key) {
     auto hash = hash_value(key.opName);
     for (const auto &operand : key.operandPairs)

--- a/lib/Dialect/Synth/Transforms/StructuralHash.cpp
+++ b/lib/Dialect/Synth/Transforms/StructuralHash.cpp
@@ -65,11 +65,6 @@ struct llvm::DenseMapInfo<StructuralHashKey> {
                              {});
   }
 
-  static StructuralHashKey getTombstoneKey() {
-    return StructuralHashKey(
-        llvm::DenseMapInfo<OperationName>::getTombstoneKey(), {});
-  }
-
   static unsigned getHashValue(const StructuralHashKey &key) {
     auto hash = hash_value(key.opName);
     for (const auto &operand : key.operandPairs)

--- a/lib/Scheduling/ChainingSupport.cpp
+++ b/lib/Scheduling/ChainingSupport.cpp
@@ -73,17 +73,21 @@ LogicalResult scheduling::computeChainBreakingDependences(
 
     // All chains/accumulated delays incoming at `op` are now known.
     auto opr = *prob.getLinkedOperatorType(op);
+    // Collect the chains that need to be broken.
+    SmallVector<Operation *, 4> chainsToBreak;
     for (auto incomingChain : chains[op]) {
       Operation *origin = incomingChain.first;
       float delay = incomingChain.second;
       // Check whether `op` could be appended to the incoming chain without
       // violating the cycle time constraint.
       if (delay + *prob.getIncomingDelay(opr) > cycleTime) {
-        // If not, add a chain-breaking auxiliary dep ...
-        result.emplace_back(origin, op);
-        // ... and end the chain here.
-        chains[op].erase(origin);
+        chainsToBreak.push_back(origin);
       }
+    }
+    // Break the chains and add the auxiliary dependences.
+    for (Operation *origin : chainsToBreak) {
+      result.emplace_back(origin, op);
+      chains[op].erase(origin);
     }
 
     return success();

--- a/lib/Target/DebugInfo/EmitHGLDD.cpp
+++ b/lib/Target/DebugInfo/EmitHGLDD.cpp
@@ -104,7 +104,6 @@ static FileLineColLoc findBestLocation(Location loc, bool emitted,
 namespace llvm {
 template <>
 struct DenseMapInfo<JValue> {
-  static JValue getEmptyKey() { return nullptr; }
   static unsigned getHashValue(const JValue &x) {
     SmallString<128> buffer;
     llvm::raw_svector_ostream(buffer) << x;

--- a/lib/Target/DebugInfo/EmitHGLDD.cpp
+++ b/lib/Target/DebugInfo/EmitHGLDD.cpp
@@ -105,7 +105,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<JValue> {
   static JValue getEmptyKey() { return nullptr; }
-  static JValue getTombstoneKey() { return JArray({nullptr}); }
   static unsigned getHashValue(const JValue &x) {
     SmallString<128> buffer;
     llvm::raw_svector_ostream(buffer) << x;

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -169,6 +169,27 @@ struct ConstantConversionPattern
   }
 };
 
+// Pattern for arith min/max operations.
+// These lower to: cmp + mux
+template <typename ArithOp, comb::ICmpPredicate pred>
+class MinMaxConversionPattern : public OpConversionPattern<ArithOp> {
+public:
+  using OpConversionPattern<ArithOp>::OpConversionPattern;
+  using OpAdaptor = typename ArithOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(ArithOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // max(a, b) = mux(cmp(a, b), a, b)
+    // min(a, b) = mux(cmp(a, b), a, b)
+    auto cmp = comb::ICmpOp::create(rewriter, op.getLoc(), pred,
+                                    adaptor.getLhs(), adaptor.getRhs());
+    rewriter.replaceOpWithNewOp<comb::MuxOp>(op, cmp, adaptor.getLhs(),
+                                             adaptor.getRhs());
+    return success();
+  }
+};
+
 struct MapArithToCombPass
     : public circt::impl::MapArithToCombPassBase<MapArithToCombPass> {
 public:
@@ -204,6 +225,10 @@ public:
       target.addIllegalOp<arith::ExtUIOp>();
       target.addIllegalOp<arith::TruncIOp>();
       target.addIllegalOp<arith::CmpIOp>();
+      target.addIllegalOp<arith::MaxSIOp>();
+      target.addIllegalOp<arith::MaxUIOp>();
+      target.addIllegalOp<arith::MinSIOp>();
+      target.addIllegalOp<arith::MinUIOp>();
 
       // Force integer constants to be mapped to `hw.constant`.
       target.addDynamicallyLegalOp<arith::ConstantOp>([](Operation *op) {
@@ -224,24 +249,28 @@ public:
 
 void circt::populateArithToCombPatterns(mlir::RewritePatternSet &patterns,
                                         TypeConverter &typeConverter) {
-  patterns.insert<OneToOnePattern<arith::AddIOp, comb::AddOp>,
-                  OneToOnePattern<arith::SubIOp, comb::SubOp>,
-                  OneToOnePattern<arith::MulIOp, comb::MulOp>,
-                  OneToOnePattern<arith::DivSIOp, comb::DivSOp>,
-                  OneToOnePattern<arith::DivUIOp, comb::DivUOp>,
-                  OneToOnePattern<arith::RemSIOp, comb::ModSOp>,
-                  OneToOnePattern<arith::RemUIOp, comb::ModUOp>,
-                  OneToOnePattern<arith::AndIOp, comb::AndOp>,
-                  OneToOnePattern<arith::OrIOp, comb::OrOp>,
-                  OneToOnePattern<arith::XOrIOp, comb::XorOp>,
-                  OneToOnePattern<arith::ShLIOp, comb::ShlOp>,
-                  OneToOnePattern<arith::ShRSIOp, comb::ShrSOp>,
-                  OneToOnePattern<arith::ShRUIOp, comb::ShrUOp>,
-                  OneToOnePattern<arith::SelectOp, comb::MuxOp>,
-                  ExtSConversionPattern, ExtZConversionPattern,
-                  TruncateConversionPattern, CompConversionPattern,
-                  ConstantConversionPattern>(typeConverter,
-                                             patterns.getContext());
+  patterns.insert<
+      OneToOnePattern<arith::AddIOp, comb::AddOp>,
+      OneToOnePattern<arith::SubIOp, comb::SubOp>,
+      OneToOnePattern<arith::MulIOp, comb::MulOp>,
+      OneToOnePattern<arith::DivSIOp, comb::DivSOp>,
+      OneToOnePattern<arith::DivUIOp, comb::DivUOp>,
+      OneToOnePattern<arith::RemSIOp, comb::ModSOp>,
+      OneToOnePattern<arith::RemUIOp, comb::ModUOp>,
+      OneToOnePattern<arith::AndIOp, comb::AndOp>,
+      OneToOnePattern<arith::OrIOp, comb::OrOp>,
+      OneToOnePattern<arith::XOrIOp, comb::XorOp>,
+      OneToOnePattern<arith::ShLIOp, comb::ShlOp>,
+      OneToOnePattern<arith::ShRSIOp, comb::ShrSOp>,
+      OneToOnePattern<arith::ShRUIOp, comb::ShrUOp>,
+      OneToOnePattern<arith::SelectOp, comb::MuxOp>,
+      MinMaxConversionPattern<arith::MaxSIOp, comb::ICmpPredicate::sge>,
+      MinMaxConversionPattern<arith::MaxUIOp, comb::ICmpPredicate::uge>,
+      MinMaxConversionPattern<arith::MinSIOp, comb::ICmpPredicate::sle>,
+      MinMaxConversionPattern<arith::MinUIOp, comb::ICmpPredicate::ule>,
+      ExtSConversionPattern, ExtZConversionPattern, TruncateConversionPattern,
+      CompConversionPattern, ConstantConversionPattern>(typeConverter,
+                                                        patterns.getContext());
 }
 
 std::unique_ptr<mlir::Pass>

--- a/test/Conversion/HandshakeToHW/test_select.mlir
+++ b/test/Conversion/HandshakeToHW/test_select.mlir
@@ -15,3 +15,39 @@ handshake.func @test_select(%arg0: i1, %arg1: i32, %arg2: i32, %arg3: none, ...)
   %0 = arith.select %arg0, %arg1, %arg2 : i32
   return %0, %arg3 : i32, none
 }
+
+// -----
+
+// CHECK:   hw.module @arith_maxsi_in_ui32_ui32_out_ui32(in %[[VAL_0:.*]] : !esi.channel<i32>, in %[[VAL_1:.*]] : !esi.channel<i32>, out out0 : !esi.channel<i32>) {
+// CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_4:.*]] : i32
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_4]] : i32
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.wrap.vr %[[VAL_11:.*]], %[[VAL_10:.*]] : i32
+// CHECK:           %[[VAL_10]] = comb.and %[[VAL_3]], %[[VAL_6]] : i1
+// CHECK:           %[[VAL_4]] = comb.and %[[VAL_8]], %[[VAL_10]] : i1
+// CHECK:           %[[VAL_9:.*]] = comb.icmp sge %[[VAL_2]], %[[VAL_5]] : i32
+// CHECK:           %[[VAL_11]] = comb.mux %[[VAL_9]], %[[VAL_2]], %[[VAL_5]] : i32
+// CHECK:           hw.output %[[VAL_7]] : !esi.channel<i32>
+// CHECK:         }
+
+handshake.func @test_maxsi(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i32, none) {
+  %0 = arith.maxsi %arg0, %arg1 : i32
+  return %0, %arg2 : i32, none
+}
+
+// -----
+
+// CHECK:   hw.module @arith_minui_in_ui64_ui64_out_ui64(in %[[VAL_0:.*]] : !esi.channel<i64>, in %[[VAL_1:.*]] : !esi.channel<i64>, out out0 : !esi.channel<i64>) {
+// CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_4:.*]] : i64
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_4]] : i64
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.wrap.vr %[[VAL_11:.*]], %[[VAL_10:.*]] : i64
+// CHECK:           %[[VAL_10]] = comb.and %[[VAL_3]], %[[VAL_6]] : i1
+// CHECK:           %[[VAL_4]] = comb.and %[[VAL_8]], %[[VAL_10]] : i1
+// CHECK:           %[[VAL_9:.*]] = comb.icmp ule %[[VAL_2]], %[[VAL_5]] : i64
+// CHECK:           %[[VAL_11]] = comb.mux %[[VAL_9]], %[[VAL_2]], %[[VAL_5]] : i64
+// CHECK:           hw.output %[[VAL_7]] : !esi.channel<i64>
+// CHECK:         }
+
+handshake.func @test_minui(%arg0: i64, %arg1: i64, %arg2: none, ...) -> (i64, none) {
+  %0 = arith.minui %arg0, %arg1 : i64
+  return %0, %arg2 : i64, none
+}

--- a/test/Dialect/Kanagawa/inner_ref_errors.mlir
+++ b/test/Dialect/Kanagawa/inner_ref_errors.mlir
@@ -23,7 +23,7 @@ kanagawa.class sym @InvalidGetVar {
     %parent = kanagawa.path [
       #kanagawa.step<parent : !kanagawa.scoperef<@foo::@InvalidGetVar>>
     ]
-    // expected-error @+1 {{'kanagawa.get_var' op result #0 must be memref of any type values, but got 'i32'}}
+    // expected-error @+1 {{'kanagawa.get_var' op result #0 must be memref of any non-token type values, but got 'i32'}}
     %var = kanagawa.get_var %parent, @var : !kanagawa.scoperef<@foo::@InvalidGetVar> -> i32
     kanagawa.return
   }

--- a/test/Transforms/map-arith-to-comb.mlir
+++ b/test/Transforms/map-arith-to-comb.mlir
@@ -68,6 +68,24 @@ func.func @allow_hw_structs(%arg0: !hw.struct<a: i42, b: i1337>, %arg1: !hw.stru
   return
 }
 
+// CHECK-LABEL: func @min_max_ops
+func.func @min_max_ops(%arg0: i32, %arg1: i32) {
+  // CHECK: [[CMP_MAXS:%.*]] = comb.icmp sge %arg0, %arg1 : i32
+  // CHECK: comb.mux [[CMP_MAXS]], %arg0, %arg1 : i32
+  arith.maxsi %arg0, %arg1 : i32
+  // CHECK: [[CMP_MAXU:%.*]] = comb.icmp uge %arg0, %arg1 : i32
+  // CHECK: comb.mux [[CMP_MAXU]], %arg0, %arg1 : i32
+  arith.maxui %arg0, %arg1 : i32
+  // CHECK: [[CMP_MINS:%.*]] = comb.icmp sle %arg0, %arg1 : i32
+  // CHECK: comb.mux [[CMP_MINS]], %arg0, %arg1 : i32
+  arith.minsi %arg0, %arg1 : i32
+  // CHECK: [[CMP_MINU:%.*]] = comb.icmp ule %arg0, %arg1 : i32
+  // CHECK: comb.mux [[CMP_MINU]], %arg0, %arg1 : i32
+  arith.minui %arg0, %arg1 : i32
+  // CHECK: return
+  return
+}
+
 // -----
 
 hw.module @invalidVector(in %arg0 : vector<4xi32>) {


### PR DESCRIPTION
* TokenType was introduced and conflicted with dc::TokenType. 
* https://github.com/llvm/llvm-project/commit/1f10f1ca8af3dff956b353d7ff3ea169c82ed909 Tombstone was removed from DenseMap. Importantly `for (auto op: densemap) if(foo(op)) densemap.erase(op);` is not legal anymore. 
*https://github.com/llvm/llvm-project/commit/e26ef0c943415ec3c3bd88c9c3e9bdca3791d4fd started to introduce max/min operations to Arith dialect. HandshakeToHW/MapArithToComb are updated to handle them.

Non trivial change are only HandshakeToDC and MapArithToComb. 

Assisted-by: augment: sonnet 4.5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
