### PR TITLE
[ImportVerilog] Add option for absolute paths in source locations

### DIFF
--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -53,6 +53,9 @@ struct ImportVerilogOptions {
   /// Generate debug information in the form of debug dialect ops in the IR.
   bool debugInfo = false;
 
+  /// Use absolute paths for source locations.
+  bool absoluteSourceLocations = false;
+
   /// Interpret `always @(*)` as `always_comb`.
   bool lowerAlwaysAtStarAsComb = true;
 

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -54,12 +54,19 @@ std::string circt::getSlangVersion() {
 // Diagnostics
 //===----------------------------------------------------------------------===//
 
+std::string getFileName(const slang::SourceManager &sourceManager,
+                        slang::SourceLocation loc, bool useAbsolute) {
+  if (useAbsolute)
+    return sourceManager.getFullPath(loc.buffer()).string();
+  return std::string(sourceManager.getFileName(loc));
+}
+
 /// Convert a slang `SourceLocation` to an MLIR `Location`.
 static Location convertLocation(MLIRContext *context,
                                 const slang::SourceManager &sourceManager,
-                                slang::SourceLocation loc) {
+                                slang::SourceLocation loc, bool useAbsolute) {
   if (loc && loc.buffer() != slang::SourceLocation::NoLocation.buffer()) {
-    auto fileName = sourceManager.getFileName(loc);
+    std::string fileName = getFileName(sourceManager, loc, useAbsolute);
     auto line = sourceManager.getLineNumber(loc);
     auto column = sourceManager.getColumnNumber(loc);
     return FileLineColLoc::get(context, fileName, line, column);
@@ -70,11 +77,11 @@ static Location convertLocation(MLIRContext *context,
 /// Convert a slang `SourceRange` to an MLIR `Location`.
 static Location convertLocation(MLIRContext *context,
                                 const slang::SourceManager &sourceManager,
-                                slang::SourceRange range) {
+                                slang::SourceRange range, bool useAbsolute) {
   auto start = range.start();
   auto end = range.end();
   if (start && start.buffer() != slang::SourceLocation::NoLocation.buffer()) {
-    auto fileName = sourceManager.getFileName(start);
+    std::string fileName = getFileName(sourceManager, start, useAbsolute);
     auto startLine = sourceManager.getLineNumber(start);
     auto startColumn = sourceManager.getColumnNumber(start);
     if (end && end.buffer() == start.buffer()) {
@@ -89,11 +96,13 @@ static Location convertLocation(MLIRContext *context,
 }
 
 Location Context::convertLocation(slang::SourceLocation loc) {
-  return ::convertLocation(getContext(), sourceManager, loc);
+  return ::convertLocation(getContext(), sourceManager, loc,
+                           options.absoluteSourceLocations);
 }
 
 Location Context::convertLocation(slang::SourceRange range) {
-  return ::convertLocation(getContext(), sourceManager, range);
+  return ::convertLocation(getContext(), sourceManager, range,
+                           options.absoluteSourceLocations);
 }
 
 namespace {
@@ -101,7 +110,8 @@ namespace {
 /// that will map slang diagnostics to their MLIR counterpart and emit them.
 class MlirDiagnosticClient : public slang::DiagnosticClient {
 public:
-  MlirDiagnosticClient(MLIRContext *context) : context(context) {}
+  MlirDiagnosticClient(MLIRContext *context, bool useAbsolute)
+      : context(context), absoluteSourceLocations(useAbsolute) {}
 
   void report(const slang::ReportedDiagnostic &diag) override {
     // Generate the primary MLIR diagnostic.
@@ -138,12 +148,14 @@ public:
 
   /// Convert a slang `SourceLocation` to an MLIR `Location`.
   Location convertLocation(slang::SourceLocation loc) const {
-    return ::convertLocation(context, *sourceManager, loc);
+    return ::convertLocation(context, *sourceManager, loc,
+                             absoluteSourceLocations);
   }
 
   /// Convert a slang `SourceRange` to an MLIR `Location`.
   Location convertLocation(slang::SourceRange range) const {
-    return ::convertLocation(context, *sourceManager, range);
+    return ::convertLocation(context, *sourceManager, range,
+                             absoluteSourceLocations);
   }
 
   static DiagnosticSeverity getSeverity(slang::DiagnosticSeverity severity) {
@@ -163,6 +175,7 @@ public:
 
 private:
   MLIRContext *context;
+  bool absoluteSourceLocations;
 };
 } // namespace
 
@@ -215,7 +228,8 @@ struct ImportDriver {
 LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   // Use slang's driver which conveniently packages a lot of the things we
   // need for compilation.
-  auto diagClient = std::make_shared<MlirDiagnosticClient>(mlirContext);
+  auto diagClient = std::make_shared<MlirDiagnosticClient>(
+      mlirContext, options.absoluteSourceLocations);
   driver.diagEngine.addClient(diagClient);
 
   for (const auto &value : options.commandFiles)
@@ -433,6 +447,11 @@ LogicalResult circt::preprocessVerilog(SourceMgr &sourceMgr,
   return importDriver.preprocessVerilog(os);
 }
 
+static llvm::cl::opt<bool> importVerilogAbsoluteSourceLocations(
+    "import-verilog-absolute-source-locations",
+    llvm::cl::desc("Use absolute paths for source locations"),
+    llvm::cl::init(false));
+
 /// Entry point as an MLIR translation.
 void circt::registerFromVerilogTranslation() {
   static TranslateToMLIRRegistration fromVerilog(
@@ -444,6 +463,7 @@ void circt::registerFromVerilogTranslation() {
         ImportVerilogOptions options;
         options.debugInfo = true;
         options.warningOptions.push_back("no-missing-top");
+        options.absoluteSourceLocations = importVerilogAbsoluteSourceLocations;
         if (failed(
                 importVerilog(sourceMgr, context, ts, module.get(), &options)))
           module = {};

--- a/test/Conversion/ImportVerilog/absolute-source-locations.sv
+++ b/test/Conversion/ImportVerilog/absolute-source-locations.sv
@@ -1,0 +1,22 @@
+// RUN: circt-translate --import-verilog -mlir-print-debuginfo %s | FileCheck %s --check-prefix=DEFAULT
+// RUN: circt-translate --import-verilog --import-verilog-absolute-source-locations -mlir-print-debuginfo %s | FileCheck %s --check-prefix=ABSOLUTE
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// Windows uses different paths formats; only check the Unix format.
+// UNSUPPORTED: system-windows
+
+// DEFAULT:      moore.module @Empty()
+// DEFAULT-NEXT:   moore.output
+// DEFAULT-NEXT: } loc(#[[LOC:.+]])
+// DEFAULT:      #[[LOC]] = loc("{{[^/].*}}":{{[0-9]+:[0-9]+}})
+
+// ABSOLUTE:      moore.module @Empty()
+// ABSOLUTE-NEXT:   moore.output
+// ABSOLUTE-NEXT: } loc(#[[LOC:.+]])
+// ABSOLUTE:      #[[LOC]] = loc("/{{.*}}":{{[0-9]+:[0-9]+}})
+
+module Empty;
+endmodule


### PR DESCRIPTION
Introduce the `absoluteSourceLocations` option to `ImportVerilogOptions` to allow generating absolute paths for source locations during Verilog import.

By default (`absoluteSourceLocations = false`), locations continue to use relative paths as reported by slang (which depend on CWD). When enabled, locations use absolute paths obtained via slang's `SourceManager::getFullPath`.

The CWD-relative behavior (the default) calls `SourceManager::getFileName()`, which returns the path made relative to the CWD. This has several problems:

1. Thread safety: `proximate()` internally reads `current_path()`, which is a process-global state. `importVerilog` can be used in multi-threaded context while other threads change the CWD (even though they probably shouldn't), leading to inconsistent `Location`s.
2. Arbitrary semantics: The resulting paths have no semantic relationship with the CWD. The source files only have a relationship with the command files they come from but those command files may be in arbitrary and different locations with no relationship to the CWD. In the most extreme (but realistic!) case, the CWD shares no prefix with the source files, such that the `Location`s start with `../../../../../../` to encode `/`.

Absolute paths are thread-safe and unambiguous. They encode `/` with the shortest possible representation and embrace the fact that there is no base folder to which relative paths would make sense. In order to protect existing users against breaking changes, the usage of absolute paths is behind a flag.

Note that this only affects `Location`s, i.e., debug symbols and any debugging infrastructure that may use them, not the actual reading of the files.

Expose the option to `circt-translate` via the `--import-verilog-absolute-paths` command-line flag.
