### PR TITLE
[FIRRTL] Avoid invalid TieOffCache w/ circt-reduce

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -64,9 +64,6 @@ class TieOffCache {
 public:
   TieOffCache(ImplicitLocOpBuilder &builder) : builder(builder) {}
 
-  /// Get or create an InvalidValueOp for the given base type.
-  Value getInvalid(FIRRTLBaseType type);
-
   /// Get or create an UnknownValueOp for the given property type.
   Value getUnknown(PropertyType type);
 

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -284,7 +284,7 @@ static void invalidateOutputs(ImplicitLocOpBuilder &builder, Value value,
       builder.create<RefDefineOp>(value, refSend.getResult());
 
       // Invalidate the underlying wire.
-      auto invalid = tieOffCache.getInvalid(underlyingType);
+      auto invalid = InvalidValueOp::create(builder, underlyingType);
       MatchingConnectOp::create(builder, targetWire.getResult(), invalid);
       return;
     }
@@ -304,7 +304,7 @@ static void invalidateOutputs(ImplicitLocOpBuilder &builder, Value value,
     builder.create<RefDefineOp>(value, forceableRef);
 
     // Invalidate the underlying wire.
-    auto invalid = tieOffCache.getInvalid(underlyingType);
+    auto invalid = InvalidValueOp::create(builder, underlyingType);
     MatchingConnectOp::create(builder, targetWire, invalid);
     return;
   }
@@ -338,7 +338,7 @@ static void invalidateOutputs(ImplicitLocOpBuilder &builder, Value value,
 
   // Create InvalidValueOp for FIRRTLBaseType.
   if (auto baseType = type_dyn_cast<FIRRTLBaseType>(type)) {
-    auto invalid = tieOffCache.getInvalid(baseType);
+    auto invalid = InvalidValueOp::create(builder, baseType);
     ConnectOp::create(builder, value, invalid);
     return;
   }
@@ -1056,7 +1056,7 @@ struct ExtmoduleInstanceRemover : public OpReduction<firrtl::InstanceOp> {
       if (info.isOutput()) {
         // Tie off output ports using TieOffCache.
         if (auto baseType = dyn_cast<firrtl::FIRRTLBaseType>(info.type)) {
-          auto inv = tieOffCache.getInvalid(baseType);
+          auto inv = InvalidValueOp::create(builder, baseType);
           firrtl::ConnectOp::create(builder, wire, inv);
         } else if (auto propType = dyn_cast<firrtl::PropertyType>(info.type)) {
           auto unknown = tieOffCache.getUnknown(propType);

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -28,13 +28,6 @@ using namespace firrtl;
 // TieOffCache
 //===----------------------------------------------------------------------===//
 
-Value TieOffCache::getInvalid(FIRRTLBaseType type) {
-  Value &cached = cache[type];
-  if (!cached)
-    cached = InvalidValueOp::create(builder, type);
-  return cached;
-}
-
 Value TieOffCache::getUnknown(PropertyType type) {
   Value &cached = cache[type];
   if (!cached)


### PR DESCRIPTION
Avoid use of the `TieOffCache::getInvalid` member function in FIRRTL's
reductions.  This, while reasonable for a reducer to do, creates false
reductions that involve FIRRTL domains.  Specifically, because an invalid
value must be exactly one value, the `InferDomains` pass views a single
invalid value as unifying the domains of all users.

Fixes #10600.

Assisted-by: pi.dev:claude-opus-4-7
