### PR TITLE
[CI] Update github actions to node 24 and pin to commit hashes

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -24,7 +24,7 @@ jobs:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get CIRCT
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
           submodules: "false"
@@ -109,7 +109,7 @@ jobs:
       # Upload the format patches to an artifact (zip'd) associated
       # with the workflow run. Only run this on a failure.
       - name: Upload format patches
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         if: ${{ failure() }}
         with:
@@ -141,7 +141,7 @@ jobs:
       # Clone CIRCT as shallow as possible.  We just need the `.github`
       # directory.
       - name: Get CIRCT (for .github)
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           submodules: "false"
@@ -249,7 +249,7 @@ jobs:
           echo "${{ github.event.pull_request.number }}" \
             > dispatch-metadata/pr_number
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dispatch-metadata
           path: dispatch-metadata/

--- a/.github/workflows/dispatchCirctTests.yml
+++ b/.github/workflows/dispatchCirctTests.yml
@@ -30,7 +30,7 @@ jobs:
       # need is already on the `workflow_run` event payload.
       - name: Download dispatch metadata
         if: env.GH_TOKEN != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dispatch-metadata
           path: dispatch-metadata

--- a/.github/workflows/esiRuntimePublish.yml
+++ b/.github/workflows/esiRuntimePublish.yml
@@ -42,13 +42,13 @@ jobs:
 
     steps:
       - name: Get CIRCT
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           submodules: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -86,7 +86,7 @@ jobs:
           echo WHL=`ls *.whl` >> "$GITHUB_OUTPUT"
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.whl-name.outputs.WHL }}
           path: wheelhouse/${{ steps.whl-name.outputs.WHL }}
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ./wheelhouse/
           merge-multiple: true
@@ -115,7 +115,7 @@ jobs:
         working-directory: ./wheelhouse/
 
       - name: Upload wheels to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.repository == 'llvm/circt' && (github.ref_type == 'tag' || github.event_name == 'workflow_dispatch')
         with:
           packages-dir: wheelhouse/

--- a/.github/workflows/pycdePublish.yml
+++ b/.github/workflows/pycdePublish.yml
@@ -33,7 +33,7 @@ jobs:
           - cp314-manylinux_x86_64
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true
@@ -44,12 +44,12 @@ jobs:
           swap-storage: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Get CIRCT (no submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -89,7 +89,7 @@ jobs:
           echo WHL=`ls *.whl` >> "$GITHUB_OUTPUT"
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.whl-name.outputs.WHL }}
           path: wheelhouse/${{ steps.whl-name.outputs.WHL }}
@@ -128,7 +128,7 @@ jobs:
           & "${env:VCPKG_INSTALLATION_ROOT}/vcpkg" --triplet x64-windows install zlib
 
       - name: Get CIRCT
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -165,7 +165,7 @@ jobs:
           echo WHL=`ls *.whl` >> "$GITHUB_OUTPUT"
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.whl-name.outputs.WHL }}
           path: wheelhouse/${{ steps.whl-name.outputs.WHL }}
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ./wheelhouse/
           merge-multiple: true
@@ -202,7 +202,7 @@ jobs:
         working-directory: ./wheelhouse/
 
       - name: Upload wheels to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: wheelhouse/
           verify-metadata: false

--- a/.github/workflows/testESIRuntime.yml
+++ b/.github/workflows/testESIRuntime.yml
@@ -35,7 +35,7 @@ jobs:
       # Clone the CIRCT repo. Do not clone the submodule since we won't be
       # building CIRCT or PyCDE in this workflow.
       - name: Get CIRCT
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 
@@ -96,12 +96,12 @@ jobs:
       # Clone the CIRCT repo. Do not clone the submodule since we won't be
       # building CIRCT or PyCDE in this workflow.
       - name: Get CIRCT
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/testPycdeESI.yml
+++ b/.github/workflows/testPycdeESI.yml
@@ -47,7 +47,7 @@ jobs:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get CIRCT
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           submodules: true
@@ -64,7 +64,7 @@ jobs:
           pip install -r frontends/PyCDE/python/requirements.txt
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: pycde-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
           max-size: 500M

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -196,7 +196,7 @@ jobs:
           large-packages: false
           tool-cache: true
       - name: Clone llvm/circt
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
           submodules: "true"
@@ -227,14 +227,14 @@ jobs:
       - name: Restore Verilator Cache (Linux)
         if: inputs.run_integration_tests && runner.os == 'Linux'
         id: cache-verilator
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /opt/verilator
           key: verilator-${{ inputs.runner }}-${{ env.verilator-version-linux }}
       - name: Restore Yosys Cache (Linux)
         if: inputs.run_integration_tests && runner.os == 'Linux'
         id: cache-yosys
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /opt/yosys
           key: yosys-${{ inputs.runner }}-${{ env.yosys-version-linux }}
@@ -283,13 +283,13 @@ jobs:
           fi
       - name: Save Verilator Cache (Linux)
         if: inputs.run_integration_tests && runner.os == 'Linux' && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.cache-verilator.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /opt/verilator
           key: verilator-${{ inputs.runner }}-${{ env.verilator-version-linux }}
       - name: Save Yosys Cache (Linux)
         if: inputs.run_integration_tests && runner.os == 'Linux' && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.cache-yosys.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /opt/yosys
           key: yosys-${{ inputs.runner }}-${{ env.yosys-version-linux }}
@@ -341,7 +341,7 @@ jobs:
           echo "image_version=${runner_image_version}" >> "$GITHUB_OUTPUT"
       - name: sccache
         if: steps.canonicalize.outputs.cmake_build_type == 'release'
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: ${{ inputs.runner }}-${{ steps.runner-image.outputs.image_version }}-${{ steps.canonicalize.outputs.cmake_c_compiler }}-${{ steps.canonicalize.outputs.cmake_build_type }}-${{ steps.canonicalize.outputs.build_shared_libs }}-${{ steps.canonicalize.outputs.llvm_enable_assertions }}-${{ steps.canonicalize.outputs.extra_cmake_hash }}
           max-size: 500M
@@ -479,14 +479,14 @@ jobs:
 
 # Upload build artifacts
       - name: Upload Binary (Non-Tag)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: inputs.install_target && github.ref_type != 'tag'
         with:
           name: ${{ steps.name_archive.outputs.name }}
           path: ${{ steps.name_archive.outputs.name }}
           retention-days: 7
       - name: Upload SHA256 (Non-Tag)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: inputs.install_target && github.ref_type != 'tag'
         with:
           name: ${{ steps.name_archive.outputs.name }}.sha256
@@ -494,7 +494,7 @@ jobs:
           retention-days: 7
 
       - name: Upload Binaries (Tag)
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962 # v4.0.0
         if: inputs.install_target && github.ref_type == 'tag'
         with:
           # The * will grab the .sha256 as well

--- a/.github/workflows/unifiedBuildTestAndInstallStatic.yml
+++ b/.github/workflows/unifiedBuildTestAndInstallStatic.yml
@@ -82,7 +82,7 @@ jobs:
           apk add bash clang19 cmake curl file git gzip perl-utils python3 samurai tar
 # Clone the repository
       - name: Clone llvm/circt
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
           submodules: "true"
@@ -91,7 +91,7 @@ jobs:
           git config --global --add safe.directory /__w/circt/circt
           git fetch --unshallow --no-recurse-submodules
       - name: Clone microsoft/mimalloc
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: microsoft/mimalloc
           fetch-depth: 1
@@ -105,7 +105,7 @@ jobs:
 # Taken together, disable caching on non-release builds.
       - name: sccache
         if: inputs.cmake_build_type == 'release'
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: alpine-${{ inputs.cmake_build_type }}-${{ inputs.llvm_enable_assertions }}
           max-size: 500M
@@ -189,14 +189,14 @@ jobs:
 
 # Upload build artifacts
       - name: Upload Binary (Non-Tag)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: inputs.install_target && github.ref_type != 'tag'
         with:
           name: ${{ steps.name_archive.outputs.name }}
           path: ${{ steps.name_archive.outputs.name }}
           retention-days: 7
       - name: Upload SHA256 (Non-Tag)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: inputs.install_target && github.ref_type != 'tag'
         with:
           name: ${{ steps.name_archive.outputs.name }}.sha256
@@ -204,7 +204,7 @@ jobs:
           retention-days: 7
 
       - name: Upload Binaries (Tag)
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962 # v4.0.0
         if: inputs.install_target && github.ref_type == 'tag'
         with:
           # The * will grab the .sha256 as well

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -59,7 +59,7 @@ jobs:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get CIRCT and LLVM
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
           submodules: "true"
@@ -76,7 +76,7 @@ jobs:
           shasum -a 256 circt-full-sources.tar.gz | cut -d ' ' -f1 > circt-full-sources.tar.gz.sha256
 
       - name: Upload Source Archive
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962 # v4.0.0
         with:
           # The * will grab the .sha256 as well
           files: circt-full-sources.tar.gz*
@@ -90,7 +90,7 @@ jobs:
       # Clone CIRCT as shallow as possible.  We just need the `.github`
       # directory.
       - name: Get CIRCT and LLVM
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           submodules: "false"

--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -72,7 +72,7 @@ jobs:
       matrix: ${{ fromJSON(needs.select_matrix.outputs.matrix) }}
     steps:
       - name: Get CIRCT
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
           submodules: "true"
@@ -82,7 +82,7 @@ jobs:
           git fetch --force --unshallow --tags --no-recurse-submodules
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.3.0
@@ -97,7 +97,7 @@ jobs:
           SETUPTOOLS_SCM_DEBUG: True
 
       - name: Upload (stage) wheels as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-wheels-${{ matrix.config.cibw_build }}
           path: ./wheelhouse/*.whl
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: python-wheels-*
           merge-multiple: true
@@ -128,7 +128,7 @@ jobs:
         working-directory: ./wheelhouse/
 
       - name: Upload wheels to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: wheelhouse/
           verify-metadata: false


### PR DESCRIPTION
Update gha to versions compatible with node 24 since node 20 will be deprecated next week.
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v3. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
Also it pins every third-party action to a specific commit hash for supply-chain security.

* https://github.com/actions/checkout/commit/df4cb1c069e1874edd31b4311f1884172cec0e10
* https://github.com/actions/upload-artifact/commit/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
* https://github.com/actions/download-artifact/commit/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
* https://github.com/actions/cache/commit/27d5ce7f107fe9357f9df03efb73ab90386fccae
* https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405

3rd party
* https://github.com/hendrikmuhs/ccache-action/commit/d62db5f07c26379fc4b4e0916f098a92573c3b03 (pined the version)
* https://github.com/jlumbroso/free-disk-space/commit/54081f138730dfa15788a46383842cd2f914a1be  (not changed, simply pinned the version)
* https://github.com/pypa/gh-action-pypi-publish/commit/cef221092ed1bacb1cc03d23a2d87d1d172e277b (pined the version)
* https://github.com/AButler/upload-release-assets/commit/34491005a5d7ec239a784e460807ce844fde7962 (v3.0 -> v4.0)

