### PR TITLE
[ImportVerilog][Moore][Sim][SV][ExportVerilog] Add `$fscanf`/`$sscanf` and scan format support

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2840,6 +2840,167 @@ def FormatHierPathOp : MooreOp<"fmt.hier_path", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Scan String Operations
+//===----------------------------------------------------------------------===//
+
+def ScanLiteralOp : MooreOp<"scan.literal", [Pure]> {
+  let summary = "Match a literal string in the scan input";
+  let description = [{
+    Matches the given literal text. If the input does not match, the scan
+    operation fails and no input is consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3 "Reading formatted data".
+  }];
+  let arguments = (ins StrAttr:$literal);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "$literal attr-dict";
+}
+
+def ScanIntOp : MooreOp<"scan.int", [Pure]> {
+  let summary = "Scan an integer value from input";
+  let description = [{
+    Reads an integer according to the given format
+    (binary, octal, decimal, or hexadecimal).
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+    maxWidth limits the number of input characters consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (b, o, d, h, x).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    IntFormatAttr:$format,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? $format (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanRealOp : MooreOp<"scan.real", [Pure]> {
+  let summary = "Scan a floating-point value from input";
+  let description = [{
+    Reads a floating-point number (f, e, g specifiers) and writes it to dest.
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+    maxWidth limits the number of input characters consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (f, e, g).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanTimeOp : MooreOp<"scan.time", [Pure]> {
+  let summary = "Scan a timescale-adjusted floating-point value from input";
+  let description = [{
+    Reads a floating-point number and scales it according to the current
+    timescale and $timeformat settings (%t specifier).
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+    maxWidth limits the number of input characters consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (t).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanCharOp : MooreOp<"scan.char", [Pure]> {
+  let summary = "Scan a single character from input";
+  let description = [{
+    Reads a single 8-bit ASCII character from the input stream (%c specifier).
+    Unlike other specifiers, leading whitespace is NOT skipped.
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (c).
+  }];
+  let arguments = (ins Optional<RefType>:$dest);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "($dest^ `:` type($dest))? attr-dict";
+}
+
+def ScanStrOp : MooreOp<"scan.str", [Pure]> {
+  let summary = "Scan a whitespace-delimited string from input";
+  let description = [{
+    Reads a sequence of non-whitespace characters (%s specifier) and writes
+    the result to dest.
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+    maxWidth limits the number of characters consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (s).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanUnformattedOp : MooreOp<"scan.unformatted", [Pure]> {
+  let summary = "Scan unformatted binary data from input";
+  let description = [{
+    Reads raw binary data from the input stream into dest.
+    %u reads 2-value binary data; %z reads 4-value (x/z-preserving) data.
+    The fourValue attribute distinguishes the two.
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (u, z).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    UnitAttr:$fourValue
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`four_value` $fourValue^)? attr-dict
+  }];
+}
+
+def ScanHierPathMatchOp : MooreOp<"scan.hier_path_match", [Pure]> {
+  let summary = "Match the current hierarchical path in the scan input";
+  let description = [{
+    Matches the current hierarchical scope path in the input stream (%m
+    specifier). Does not consume a destination argument and does not
+    store any value.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (m).
+  }];
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def ScanConcatOp : MooreOp<"scan.concat", [Pure]> {
+  let summary = "Concatenate scan format fragments";
+  let description = [{
+    Combines multiple scan format fragments into a single scan format
+    directive. Fragments are applied left to right against the input stream.
+  }];
+  let arguments = (ins Variadic<ScanStringType>:$inputs);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "` ` `(` $inputs `)` attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // Builtin System Tasks and Functions
 //===----------------------------------------------------------------------===//
 
@@ -3144,6 +3305,35 @@ def FDisplayBIOp : Builtin<"fdisplay"> {
   }];
   let arguments = (ins TwoValuedI32:$fd, FormatStringType:$message);
   let assemblyFormat = "$fd `,` $message attr-dict";
+}
+
+def FScanFBIOp : Builtin<"fscanf"> {
+  let summary = "Read formatted data from a file";
+  let description = [{
+    Reads characters from the file specified by fd, interprets them according
+    to the scan format, and stores the results in the destination lvalues
+    embedded in the format. Returns the number of successfully matched and
+    assigned items, or EOF (-1) on end of file before any match.
+
+    See IEEE 1800-2017 § 21.3.4 "Reading data from a file".
+  }];
+  let arguments = (ins TwoValuedI32:$fd, ScanStringType:$format);
+  let results = (outs TwoValuedI32:$count);
+  let assemblyFormat = "$fd $format attr-dict";
+}
+
+def SScanFBIOp : Builtin<"sscanf"> {
+  let summary = "Read formatted data from a string";
+  let description = [{
+    Reads characters from str, interprets them according to the scan format,
+    and stores the results in the destination lvalues embedded in the format.
+    Returns the number of successfully matched and assigned items, or EOF (-1).
+
+    See IEEE 1800-2017 § 21.3.4 "Reading data from a file".
+  }];
+  let arguments = (ins StringType:$str, ScanStringType:$format);
+  let results = (outs TwoValuedI32:$count);
+  let assemblyFormat = "$str $format attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -455,6 +455,19 @@ def FormatStringType : MooreTypeDef<"FormatString"> {
   }];
 }
 
+def ScanStringType : MooreTypeDef<"ScanString"> {
+  let mnemonic = "scan_string";
+  let summary = "a scan format string type";
+  let description = [{
+    Represents a parsed scan format directive specifying how to read values
+    from an input string or file. Each fragment captures a format specifier
+    and, for non-suppressed assignments, the destination lvalue reference
+    where the parsed value will be stored.
+
+    See IEEE 1800-2017 § 21.3.4.3 "Reading formatted data".
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Constraints
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -542,6 +542,34 @@ def FWriteOp : SVOp<"fwrite", [ProceduralOp]> {
   }];
 }
 
+def FScanFOp : SVOp<"fscanf", [ProceduralOp]> {
+  let summary = "'$fscanf' statement";
+  let arguments = (ins
+    I32:$fd,
+    StrAttr:$format_string,
+    Variadic<AnyType>:$outputs
+  );
+  let results = (outs I32:$count);
+  let assemblyFormat = [{
+    $fd `,` $format_string attr-dict
+    (`(` $outputs^ `)` `:` qualified(type($outputs)))?
+  }];
+}
+
+def SScanFOp : SVOp<"sscanf", [ProceduralOp]> {
+  let summary = "'$sscanf' statement";
+  let arguments = (ins
+    StrAttr:$input_string,
+    StrAttr:$format_string,
+    Variadic<AnyType>:$outputs
+  );
+  let results = (outs I32:$count);
+  let assemblyFormat = [{
+    $input_string `,` $format_string attr-dict
+    (`(` $outputs^ `)` `:` qualified(type($outputs)))?
+  }];
+}
+
 def FFlushOp : SVOp<"fflush", [ProceduralOp]> {
   let summary = "'$fflush' statement";
 

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -40,9 +40,9 @@ public:
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
             // Other Statements.
             AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
-            WriteOp, FWriteOp, FFlushOp, SystemFunctionOp, VerbatimOp,
-            MacroRefOp, FuncCallOp, FuncCallProceduralOp, ReturnOp, IncludeOp,
-            MacroErrorOp,
+            WriteOp, FWriteOp, FScanFOp, SScanFOp, FFlushOp, SystemFunctionOp,
+            VerbatimOp, MacroRefOp, FuncCallOp, FuncCallProceduralOp, ReturnOp,
+            IncludeOp, MacroErrorOp,
             // Type declarations.
             InterfaceOp, SVVerbatimSourceOp, InterfaceSignalOp,
             InterfaceModportOp, InterfaceInstanceOp, GetModportOp,
@@ -138,6 +138,8 @@ public:
   HANDLE(AliasOp, Unhandled);
   HANDLE(WriteOp, Unhandled);
   HANDLE(FWriteOp, Unhandled);
+  HANDLE(FScanFOp, Unhandled);
+  HANDLE(SScanFOp, Unhandled);
   HANDLE(FFlushOp, Unhandled);
   HANDLE(SystemFunctionOp, Unhandled);
   HANDLE(FuncCallProceduralOp, Unhandled);

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -680,6 +680,213 @@ def StderrStreamOp : SimOp<"stderr_stream", [Pure]> {
   let assemblyFormat = "attr-dict";
 }
 
+def StdinStreamOp : SimOp<"stdin_stream", [Pure]> {
+  let summary = "The standard input stream";
+  let description = [{
+    Returns a reference to the standard input stream, which can be consumed
+    by `sim.proc.scan`.
+  }];
+
+  let results = (outs InputStreamType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// Scan string ops
+//===----------------------------------------------------------------------===//
+
+def ScanLiteralOp : SimOp<"scan.literal", [Pure, ConstantLike]> {
+  let summary = "Literal string fragment";
+  let description = [{
+    Creates a constant, raw ASCII string literal for scan matching.
+    The given string attribute will be matched verbatim against the input,
+    including non-printable characters. The literal may be empty or contain
+    null characters ('\0') which must not be interpreted as string terminators
+    by backends.
+  }];
+  let arguments = (ins StrAttr:$literal);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "$literal attr-dict";
+  let hasFolder = true;
+}
+
+def ScanDecOp : SimOp<"scan.dec", [Pure]> {
+  let summary = "Scan a decimal integer from input";
+  let description = [{
+    Scan a decimal integer from the input. The scanned value may be optionally
+    stored into the provided destination, which must be of an integer
+    type. If the destination is not provided, the scanned value is discarded.
+  }];
+  let arguments = (ins Optional<AnyType>:$dest, OptionalAttr<I32Attr>:$maxWidth);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict";
+}
+
+def ScanBinOp : SimOp<"scan.bin", [Pure]> {
+  let summary = "Scan a binary integer from input";
+  let description = [{
+    Scan a binary integer from the input. The scanned value may be optionally
+    stored into the provided destination, which must be of an integer
+    type. If the destination is not provided, the scanned value is discarded.
+  }];
+  let arguments = (ins Optional<AnyType>:$dest, OptionalAttr<I32Attr>:$maxWidth);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict";
+}
+
+def ScanOctOp : SimOp<"scan.oct", [Pure]> {
+  let summary = "Scan an octal integer from input";
+  let description = [{
+    Scan an octal integer from the input. The scanned value may be optionally
+    stored into the provided destination, which must be of an integer
+    type. If the destination is not provided, the scanned value is discarded.
+  }];
+  let arguments = (ins Optional<AnyType>:$dest, OptionalAttr<I32Attr>:$maxWidth);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict";
+}
+
+def ScanHexOp : SimOp<"scan.hex", [Pure]> {
+  let summary = "Scan a hexadecimal integer from input";
+  let description = [{
+    Scan a hexadecimal integer from the input. The scanned value may be optionally
+    stored into the provided destination, which must be of an integer type.
+    If the destination is not provided, the scanned value is discarded.
+    The `isUpper` attribute selects the lowercase or uppercase hexadecimal
+    format specifier.
+  }];
+  let arguments = (ins
+    Optional<AnyType>:$dest,
+    BoolAttr:$isUpper,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? `isUpper` $isUpper (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanRealOp : SimOp<"scan.real", [Pure]> {
+  let summary = "Scan a floating-point value from input";
+  let description = [{
+    Scan a floating-point value from the input. The scanned value may be optionally
+    stored into the provided destination, which must be of a floating-point
+    type. If the destination is not provided, the scanned value is discarded.
+  }];
+  let arguments = (ins Optional<AnyType>:$dest, OptionalAttr<I32Attr>:$maxWidth);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanTimeOp : SimOp<"scan.time", [Pure]> {
+  let summary = "Scan a timescale-adjusted floating-point value from input";
+  let description = [{
+    Scan a timescale-adjusted floating-point value from the input.
+    The scanned value may be optionally stored into the provided destination,
+    which must be of a floating-point type.
+    If the destination is not provided, the scanned value is discarded.
+  }];
+  let arguments = (ins Optional<AnyType>:$dest, OptionalAttr<I32Attr>:$maxWidth);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanCharOp : SimOp<"scan.char", [Pure]> {
+  let summary = "Scan a single character from input";
+  let description = [{
+    Scan a single character from the input. The scanned value may be optionally
+    stored into the provided destination, which must be of an integer
+    type. If the destination is not provided, the scanned value is discarded.
+  }];
+  let arguments = (ins Optional<AnyType>:$dest);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "($dest^ `:` type($dest))? attr-dict";
+}
+
+def ScanStrOp : SimOp<"scan.str", [Pure]> {
+  let summary = "Scan a whitespace-delimited string from input";
+  let description = [{
+    Scan a whitespace-delimited string from the input. The scanned value may be optionally
+    stored into the provided destination, which must be of a string type.
+    If the destination is not provided, the scanned value is discarded.
+  }];
+  let arguments = (ins Optional<AnyType>:$dest, OptionalAttr<I32Attr>:$maxWidth);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanUnformattedOp : SimOp<"scan.unformatted", [Pure]> {
+  let summary = "Scan unformatted binary data from input";
+  let description = [{
+    Scan unformatted binary data from the input. The scanned value may be optionally
+    stored into the provided destination, which must be of an integer type.
+    If the destination is not provided, the scanned value is discarded.
+  }];
+  let arguments = (ins Optional<AnyType>:$dest, UnitAttr:$fourValue);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`four_value` $fourValue^)? attr-dict
+  }];
+}
+
+def ScanHierPathMatchOp : SimOp<"scan.hier_path_match", [Pure]> {
+  let summary = "Match the current hierarchical path in the scan input";
+  let description = [{
+    Match the hierarchical path of the module instance containing this
+    operation in the scan input. Does not consume a destination argument
+    and does not store any value.
+  }];
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def ScanConcatOp : SimOp<"scan.concat", [Pure]> {
+  let summary = "Concatenate scan format fragments";
+  let description = [{
+    Concatenates an arbitrary number of scan format fragments from
+    left to right. If the argument list is empty, the empty string
+    literal is produced.
+
+    Concatenations must not be recursive. I.e., a concatenated string should
+    not contain itself directly or indirectly.
+  }];
+  let arguments = (ins Variadic<ScanStringType>:$inputs);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "` ` `(` $inputs `)` attr-dict";
+  let hasFolder = true;
+  let hasCanonicalizeMethod = true;
+  let hasVerifier = true;
+  let extraClassDeclaration = [{
+    bool isFlat() {
+      return llvm::none_of(getInputs(), [](Value operand) {
+        return !!operand.getDefiningOp<circt::sim::ScanConcatOp>();
+      });
+    };
+    LogicalResult getFlattenedInputs(
+        llvm::SmallVectorImpl<Value> &flatOperands);
+  }];
+}
+
+def ScanFormattedProcOp : SimOp<"proc.scan", [ProceduralOp]> {
+  let summary = "Scan formatted values from an input stream";
+  let description = [{
+    Evaluate a scan format string and scan values from the given input stream.
+    The scanned values are stored into the destination specified by
+    the format string operands.
+
+    This operation must be within a procedural region.
+  }];
+  let arguments = (ins InputStreamType:$stream, ScanStringType:$format);
+  let results = (outs I32:$count);
+  let assemblyFormat = "$stream $format attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Dynamic Strings
 //===----------------------------------------------------------------------===//
@@ -1269,6 +1476,20 @@ def SVChannelToOutputStreamOp : SimOp<"sv.channel_to_output_stream", [Procedural
   let assemblyFormat = "$channel attr-dict";
 }
 
+def SVChannelToInputStreamOp : SimOp<"sv.channel_to_input_stream", [ProceduralOp]> {
+let summary = "Cast a SV file descriptor to an input stream";
+  let description = [{
+    Casts a SystemVerilog file descriptor (integer returned by `$fopen` with
+    a read mode) to an `!sim.input_stream` or a predefined input stream stdin (`32'h8000_0000`).
+    The fd must have been opened for reading. Otherwise, this operation causes undefined behavior.
+
+    See IEEE 1800-2017 § 21.3.1 "Opening and closing files".
+  }];
+  let arguments = (ins I32:$fd);
+  let results = (outs InputStreamType:$stream);
+  let assemblyFormat = "$fd attr-dict";
+}
+
 def SVFFlushAllOp : SimOp<"sv.fflush_all", [ProceduralOp]> {
   let summary = "Flush all open files";
   let description = [{
@@ -1290,6 +1511,16 @@ def FlushOp : SimOp<"flush", [ProceduralOp]> {
 
   let arguments = (ins OutputStreamType:$stream);
   let assemblyFormat = "$stream attr-dict";
+}
+
+def StringToInputStreamOp : SimOp<"string_to_input_stream", [Pure]> {
+  let summary = "Wrap a string as an input stream";
+  let description = [{
+    Creates an input stream that read sequentially from the given string.
+  }];
+  let arguments = (ins DynamicStringType:$str);
+  let results = (outs InputStreamType:$stream);
+  let assemblyFormat = "$str attr-dict";
 }
 
 #endif // CIRCT_DIALECT_SIM_SIMOPS_TD

--- a/include/circt/Dialect/Sim/SimTypes.td
+++ b/include/circt/Dialect/Sim/SimTypes.td
@@ -27,6 +27,18 @@ def FormatStringType : SimTypeDef<"FormatString"> {
   }];
 }
 
+def ScanStringType : SimTypeDef<"ScanString"> {
+  let summary = "a scan format string type";
+  let description = [{
+    A scan format string type represents either a single scanning fragment or
+    the concatenation of an arbitrary but finite number of fragements.
+    A scanning fragment is either a static string literal to match verbatim,
+    or the association of a format specifier with an optional destination
+    operand into which the parsed value is stored.
+  }];
+  let mnemonic = "scan_string";
+}
+
 def DynamicStringType : SimTypeDef<"DynamicString"> {
   let mnemonic = "dstring";
 
@@ -122,6 +134,20 @@ def OutputStreamType : SimTypeDef<"OutputStream"> {
   }];
 
   let mnemonic = "output_stream";
+}
+
+
+def InputStreamType : SimTypeDef<"InputStream"> {
+  let summary = "a type representing an input stream";
+  let description = [{
+    Represents a simulation input stream resource.
+    This type models the existence of a stream resource at the Sim dialect level,
+    while leaving its concrete representation to the lowering backend. Backends may
+    realize this as a file descriptor, object handle, pointer, or any other target-
+    specific resource representation.
+  }];
+
+  let mnemonic = "input_stream";
 }
 
 #endif // CIRCT_DIALECT_SIM_SIMTYPES_TD

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3985,8 +3985,8 @@ void NameCollector::collectNames(Block &block) {
     // Instances have an instance name to recognize but we don't need to look
     // at the result values since wires used by instances should be traversed
     // anyway.
-    if (isa<InstanceOp, InterfaceInstanceOp, FuncCallProceduralOp, FuncCallOp>(
-            op))
+    if (isa<InstanceOp, InterfaceInstanceOp, FuncCallProceduralOp, FuncCallOp,
+            FScanFOp, SScanFOp>(op))
       continue;
     if (isa<ltl::LTLDialect, debug::DebugDialect>(op.getDialect()))
       continue;
@@ -4201,6 +4201,8 @@ private:
   LogicalResult visitSV(FuncCallOp op);
   LogicalResult visitSV(ReturnOp op);
   LogicalResult visitSV(IncludeOp op);
+  LogicalResult visitSV(FScanFOp op);
+  LogicalResult visitSV(SScanFOp op);
 
 public:
   ModuleEmitter &emitter;
@@ -4298,7 +4300,9 @@ LogicalResult StmtEmitter::visitSV(AssignOp op) {
 }
 
 LogicalResult StmtEmitter::visitSV(BPAssignOp op) {
-  if (op.getSrc().getDefiningOp<FuncCallProceduralOp>())
+  if (op.getSrc().getDefiningOp<FuncCallProceduralOp>() ||
+      op.getSrc().getDefiningOp<FScanFOp>() ||
+      op.getSrc().getDefiningOp<SScanFOp>())
     return success();
 
   // If the assign is emitted into logic declaration, we must not emit again.
@@ -5925,6 +5929,66 @@ LogicalResult StmtEmitter::visitSV(MacroDefOp op) {
   }
   ps.addCallback({op, false});
   setPendingNewline();
+  return success();
+}
+
+LogicalResult StmtEmitter::visitSV(FScanFOp op) {
+  startStatement();
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  ps.addCallback({op, true});
+
+  if (!op.getCount().use_empty()) {
+    auto assign = cast<sv::BPAssignOp>(*op.getCount().user_begin());
+    ops.insert(assign);
+    emitExpression(assign.getDest(), ops);
+    ps << PP::nbsp << "=" << PP::nbsp;
+  }
+
+  ps << "$fscanf(";
+  ps.scopedBox(PP::ibox0, [&]() {
+    emitExpression(op.getFd(), ops);
+    ps << "," << PP::space;
+    ps.writeQuotedEscaped(op.getFormatString());
+    for (auto output : op.getOutputs()) {
+      ps << "," << PP::space;
+      emitExpression(output, ops);
+    }
+    ps << ");";
+  });
+
+  ps.addCallback({op, false});
+  emitLocationInfoAndNewLine(ops);
+  return success();
+}
+
+LogicalResult StmtEmitter::visitSV(SScanFOp op) {
+  startStatement();
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  ps.addCallback({op, true});
+
+  if (!op.getCount().use_empty()) {
+    auto assign = cast<sv::BPAssignOp>(*op.getCount().user_begin());
+    ops.insert(assign);
+    emitExpression(assign.getDest(), ops);
+    ps << PP::nbsp << "=" << PP::nbsp;
+  }
+
+  ps << "$sscanf(";
+  ps.scopedBox(PP::ibox0, [&]() {
+    ps.writeQuotedEscaped(op.getInputString());
+    ps << "," << PP::space;
+    ps.writeQuotedEscaped(op.getFormatString());
+    for (auto output : op.getOutputs()) {
+      ps << "," << PP::space;
+      emitExpression(output, ops);
+    }
+    ps << ");";
+  });
+
+  ps.addCallback({op, false});
+  emitLocationInfoAndNewLine(ops);
   return success();
 }
 

--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_translation_library(CIRCTImportVerilog
   CaptureAnalysis.cpp
   Expressions.cpp
   FormatStrings.cpp
+  ScanStrings.cpp
   HierarchicalNames.cpp
   ImportVerilog.cpp
   Statements.cpp

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3561,6 +3561,48 @@ Value Context::convertSystemCall(
     return moore::FOpenBIOp::create(builder, loc, filename, modeAttr);
   }
 
+  if (nameId == ksn::FScanf) {
+    auto fd = convertRvalueExpression(
+        *args[0], moore::IntType::getInt(builder.getContext(), 32));
+    if (!fd)
+      return {};
+    auto *fmtLit =
+        args[1]->unwrapImplicitConversions().as_if<slang::ast::StringLiteral>();
+    if (!fmtLit)
+      return (mlir::emitError(loc)
+              << "$fscanf requires a string literal format string"),
+             Value{};
+    auto scanFmt = convertScanString(fmtLit->getValue(), args.subspan(2), loc);
+    if (failed(scanFmt))
+      return {};
+    if (!*scanFmt) {
+      auto i32Ty = moore::IntType::getInt(builder.getContext(), 32);
+      return moore::ConstantOp::create(builder, loc, i32Ty, 0);
+    }
+    return moore::FScanFBIOp::create(builder, loc, fd, *scanFmt);
+  }
+
+  if (nameId == ksn::SScanf) {
+    auto str =
+        convertRvalueExpression(*args[0], moore::StringType::get(getContext()));
+    if (!str)
+      return {};
+    auto *fmtLit =
+        args[1]->unwrapImplicitConversions().as_if<slang::ast::StringLiteral>();
+    if (!fmtLit)
+      return (mlir::emitError(loc)
+              << "$sscanf requires a string literal format string"),
+             Value{};
+    auto scanFmt = convertScanString(fmtLit->getValue(), args.subspan(2), loc);
+    if (failed(scanFmt))
+      return {};
+    if (!*scanFmt) {
+      auto i32Ty = moore::IntType::getInt(builder.getContext(), 32);
+      return moore::ConstantOp::create(builder, loc, i32Ty, 0);
+    }
+    return moore::SScanFBIOp::create(builder, loc, str, *scanFmt);
+  }
+
   // Unrecognized system call
   emitError(loc) << "unsupported system call `" << name << "`";
   return {};

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -400,6 +400,15 @@ struct Context {
       moore::IntFormat defaultFormat = moore::IntFormat::Decimal,
       bool appendNewline = false);
 
+  /// Convert a scan format string literal with format specifiers and
+  /// destination lvalue expressions into a `!moore.scan_string` value.
+  /// Returns failure if an error occurs. Returns a null value if the format
+  /// string is trivially empty. Otherwise returns the scan format string.
+  FailureOr<Value>
+  convertScanString(StringRef formatStr,
+                    std::span<const slang::ast::Expression *const> destinations,
+                    Location loc);
+
   /// Convert system function calls. Returns a null `Value` on failure after
   /// emitting an error.
   Value convertSystemCall(const slang::ast::SystemSubroutine &subroutine,

--- a/lib/Conversion/ImportVerilog/ScanStrings.cpp
+++ b/lib/Conversion/ImportVerilog/ScanStrings.cpp
@@ -1,0 +1,284 @@
+//===- ScanStrings.cpp - Scan format string conversion --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImportVerilogInternals.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace ImportVerilog;
+using moore::IntFormat;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Scan format string parser
+//===----------------------------------------------------------------------===//
+
+static bool parseScanFormat(StringRef format,
+                            function_ref<void(StringRef text)> onText,
+                            function_ref<void(char specifier, bool suppress,
+                                              std::optional<uint32_t> maxWidth)>
+                                onArg,
+                            function_ref<void(StringRef msg)> onError) {
+
+  size_t i = 0;
+  size_t textStart = 0;
+
+  while (i < format.size()) {
+    if (format[i] != '%') {
+      ++i;
+      continue;
+    }
+
+    if (i > textStart)
+      onText(format.substr(textStart, i - textStart));
+
+    ++i; // consume '%'
+    if (i >= format.size()) {
+      onError("unexpected end of format string after '%'");
+      return false;
+    }
+
+    if (format[i] == '%') {
+      onText("%");
+      ++i;
+      textStart = i;
+      continue;
+    }
+
+    // Optional assignment suppression '*'.
+    bool suppress = false;
+    if (format[i] == '*') {
+      suppress = true;
+      ++i;
+      if (i >= format.size()) {
+        onError("unexpected end of format string after '%*'");
+        return false;
+      }
+    }
+
+    // Optional maximum field width.
+    std::optional<uint32_t> maxWidth;
+    if (std::isdigit(format[i])) {
+      uint32_t w = 0;
+      while (i < format.size() && std::isdigit(format[i]))
+        w = w * 10 + (format[i++] - '0');
+      maxWidth = w;
+      if (w == 0) {
+        onError("field width must be at least 1");
+        return false;
+      }
+    }
+
+    if (i >= format.size()) {
+      onError("unexpected end of format string: missing conversion specifier");
+      return false;
+    }
+
+    char specifier = format[i++];
+    onArg(specifier, suppress, maxWidth);
+    textStart = i;
+  }
+
+  // Flush any trailing literal text.
+  if (textStart < format.size())
+    onText(format.substr(textStart));
+
+  return true;
+}
+
+struct ScanStringParser {
+  Context &context;
+  OpBuilder &builder;
+  /// Remaining destination arguments (lvalue expressions to write into).
+  /// Suppressed assignments do not consume from this list.
+  ArrayRef<const slang::ast::Expression *> destinations;
+  /// Current location for ops and diagnostics.
+  Location loc;
+  /// Accumulated scan format fragments.
+  SmallVector<Value> fragments;
+
+  ScanStringParser(Context &context,
+                   ArrayRef<const slang::ast::Expression *> destinations,
+                   Location loc)
+      : context(context), builder(context.builder), destinations(destinations),
+        loc(loc) {}
+
+  /// Parse the format string and produce a ScanStringType value combining
+  /// all fragments. Returns failure if any error occurs.
+  FailureOr<Value> parse(StringRef formatStr) {
+    bool anyFailure = false;
+
+    auto onText = [&](StringRef text) {
+      if (!anyFailure)
+        emitLiteral(text);
+    };
+
+    auto onArg = [&](char specifier, bool suppress,
+                     std::optional<uint32_t> maxWidth) {
+      if (anyFailure)
+        return;
+      if (failed(emitScanArg(specifier, suppress, maxWidth)))
+        anyFailure = true;
+    };
+
+    auto onError = [&](StringRef msg) {
+      if (!anyFailure) {
+        mlir::emitError(loc) << "scan format string error: " << msg;
+        anyFailure = true;
+      }
+    };
+
+    if (!parseScanFormat(formatStr, onText, onArg, onError) || anyFailure)
+      return failure();
+
+    if (fragments.empty())
+      return Value{};
+    if (fragments.size() == 1)
+      return fragments[0];
+    return moore::ScanConcatOp::create(builder, loc, fragments).getResult();
+  }
+
+  /// Emit a literal text fragment that must match verbatim in the input.
+  void emitLiteral(StringRef text) {
+    if (text.empty())
+      return;
+    fragments.push_back(moore::ScanLiteralOp::create(builder, loc, text));
+  }
+
+  /// Resolve a destination expression to an lvalue reference value.
+  FailureOr<Value> resolveDest(const slang::ast::Expression &destExpr) {
+    const auto *expr = &destExpr;
+    if (auto assign = expr->as_if<slang::ast::AssignmentExpression>())
+      expr = &assign->left();
+    auto lhs = context.convertLvalueExpression(*expr);
+    if (!lhs)
+      return failure();
+    return lhs;
+  }
+
+  /// Consume the next destination argument (if not suppressed) and emit a
+  /// scan fragment op.
+  LogicalResult emitScanArg(char specifier, bool suppress,
+                            std::optional<uint32_t> maxWidth) {
+    auto specifierLower = std::tolower(specifier);
+
+    // Hierarchical path specifier (%m), no argument consumed.
+    if (specifierLower == 'm') {
+      fragments.push_back(moore::ScanHierPathMatchOp::create(builder, loc));
+      return success();
+    }
+
+    // All other specifiers consume a destination argument (if not suppressed).
+    Value dest;
+    if (!suppress) {
+      if (destinations.empty())
+        return mlir::emitError(loc)
+               << "too few arguments for scan format specifier '%" << specifier
+               << "'";
+      auto destOrFailure = resolveDest(*destinations.front());
+      destinations = destinations.drop_front();
+      if (failed(destOrFailure))
+        return failure();
+      dest = *destOrFailure;
+    }
+
+    IntegerAttr maxWidthAttr = nullptr;
+    if (maxWidth)
+      maxWidthAttr = builder.getI32IntegerAttr(*maxWidth);
+
+    switch (specifierLower) {
+    // Integer specifiers (%b, %o, %d, %h, %x)
+    case 'b':
+      return emitScanInt(dest, IntFormat::Binary, maxWidthAttr);
+    case 'o':
+      return emitScanInt(dest, IntFormat::Octal, maxWidthAttr);
+    case 'd':
+      return emitScanInt(dest, IntFormat::Decimal, maxWidthAttr);
+    case 'h':
+    case 'x':
+      return emitScanInt(dest,
+                         std::isupper(specifier) ? IntFormat::HexUpper
+                                                 : IntFormat::HexLower,
+                         maxWidthAttr);
+
+    // Floating-point specifiers (%f, %e, %g)
+    case 'f':
+    case 'e':
+    case 'g':
+      return emitScanReal(dest, maxWidthAttr);
+
+    // Time specifier (%t)
+    case 't':
+      return emitScanTime(dest, maxWidthAttr);
+
+    // Character specifier (%c)
+    case 'c':
+      return emitScanChar(dest);
+
+    // String specifier (%s)
+    case 's':
+      return emitScanStr(dest, maxWidthAttr);
+
+    // Unformatted binary (%u, %z)
+    case 'u':
+      return emitScanUnformatted(dest, /*fourValue=*/false);
+    case 'z':
+      return emitScanUnformatted(dest, /*fourValue=*/true);
+
+    default:
+      return mlir::emitError(loc)
+             << "unknown scan format specifier '%" << specifier << "'";
+    }
+  }
+
+  LogicalResult emitScanInt(Value dest, IntFormat format,
+                            IntegerAttr maxWidth) {
+    fragments.push_back(
+        moore::ScanIntOp::create(builder, loc, dest, format, maxWidth));
+    return success();
+  }
+
+  LogicalResult emitScanReal(Value dest, IntegerAttr maxWidth) {
+    fragments.push_back(
+        moore::ScanRealOp::create(builder, loc, dest, maxWidth));
+    return success();
+  }
+
+  LogicalResult emitScanTime(Value dest, IntegerAttr maxWidth) {
+    fragments.push_back(
+        moore::ScanTimeOp::create(builder, loc, dest, maxWidth));
+    return success();
+  }
+
+  LogicalResult emitScanChar(Value dest) {
+    fragments.push_back(moore::ScanCharOp::create(builder, loc, dest));
+    return success();
+  }
+
+  LogicalResult emitScanStr(Value dest, IntegerAttr maxWidth) {
+    fragments.push_back(moore::ScanStrOp::create(builder, loc, dest, maxWidth));
+    return success();
+  }
+
+  LogicalResult emitScanUnformatted(Value dest, bool fourValue) {
+    fragments.push_back(
+        moore::ScanUnformattedOp::create(builder, loc, dest, fourValue));
+    return success();
+  }
+};
+
+} // namespace
+
+FailureOr<Value> Context::convertScanString(
+    StringRef formatStr,
+    std::span<const slang::ast::Expression *const> destinations, Location loc) {
+  ScanStringParser parser(
+      *this, ArrayRef(destinations.data(), destinations.size()), loc);
+  return parser.parse(formatStr);
+}

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2624,6 +2624,148 @@ struct FormatRealOpConversion : public OpConversionPattern<FormatRealOp> {
   }
 };
 
+struct ScanLiteralOpConversion : public OpConversionPattern<ScanLiteralOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanLiteralOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::ScanLiteralOp>(op, adaptor.getLiteral());
+    return success();
+  }
+};
+
+struct ScanIntOpConversion : public OpConversionPattern<ScanIntOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanIntOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto dest = adaptor.getDest();
+    auto maxWidth = adaptor.getMaxWidthAttr();
+    switch (op.getFormat()) {
+    case IntFormat::Decimal:
+      rewriter.replaceOpWithNewOp<sim::ScanDecOp>(op, dest, maxWidth);
+      return success();
+    case IntFormat::Binary:
+      rewriter.replaceOpWithNewOp<sim::ScanBinOp>(op, dest, maxWidth);
+      return success();
+    case IntFormat::Octal:
+      rewriter.replaceOpWithNewOp<sim::ScanOctOp>(op, dest, maxWidth);
+      return success();
+    case IntFormat::HexLower:
+      rewriter.replaceOpWithNewOp<sim::ScanHexOp>(
+          op, dest, rewriter.getBoolAttr(false), maxWidth);
+      return success();
+    case IntFormat::HexUpper:
+      rewriter.replaceOpWithNewOp<sim::ScanHexOp>(
+          op, dest, rewriter.getBoolAttr(true), maxWidth);
+      return success();
+    }
+    return rewriter.notifyMatchFailure(op, "unsupported int format");
+  }
+};
+
+struct ScanRealOpConversion : public OpConversionPattern<ScanRealOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanRealOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::ScanRealOp>(op, adaptor.getDest(),
+                                                 adaptor.getMaxWidthAttr());
+    return success();
+  }
+};
+
+struct ScanTimeOpConversion : public OpConversionPattern<ScanTimeOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanTimeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::ScanTimeOp>(op, adaptor.getDest(),
+                                                 adaptor.getMaxWidthAttr());
+    return success();
+  }
+};
+
+struct ScanCharOpConversion : public OpConversionPattern<ScanCharOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanCharOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::ScanCharOp>(op, adaptor.getDest());
+    return success();
+  }
+};
+
+struct ScanStrOpConversion : public OpConversionPattern<ScanStrOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanStrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::ScanStrOp>(op, adaptor.getDest(),
+                                                adaptor.getMaxWidthAttr());
+    return success();
+  }
+};
+
+struct ScanUnformattedOpConversion
+    : public OpConversionPattern<ScanUnformattedOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanUnformattedOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::ScanUnformattedOp>(
+        op, adaptor.getDest(), adaptor.getFourValueAttr());
+    return success();
+  }
+};
+
+struct ScanHierPathMatchOpConversion
+    : public OpConversionPattern<ScanHierPathMatchOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanHierPathMatchOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::ScanHierPathMatchOp>(op);
+    return success();
+  }
+};
+
+struct ScanConcatOpConversion : public OpConversionPattern<ScanConcatOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ScanConcatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::ScanConcatOp>(op, adaptor.getInputs());
+    return success();
+  }
+};
+
+struct FScanFBIOpConversion : public OpConversionPattern<FScanFBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(FScanFBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto stream = sim::SVChannelToInputStreamOp::create(rewriter, op.getLoc(),
+                                                        adaptor.getFd());
+    rewriter.replaceOpWithNewOp<sim::ScanFormattedProcOp>(op, stream,
+                                                          adaptor.getFormat());
+    return success();
+  }
+};
+
+struct SScanFBIOpConversion : public OpConversionPattern<SScanFBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(SScanFBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto stream = sim::StringToInputStreamOp::create(rewriter, op.getLoc(),
+                                                     adaptor.getStr());
+    rewriter.replaceOpWithNewOp<sim::ScanFormattedProcOp>(op, stream,
+                                                          adaptor.getFormat());
+    return success();
+  }
+};
+
 struct StringLenOpConversion : public OpConversionPattern<StringLenOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -3223,6 +3365,10 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
     return sim::FormatStringType::get(type.getContext());
   });
 
+  typeConverter.addConversion([&](ScanStringType type) {
+    return sim::ScanStringType::get(type.getContext());
+  });
+
   typeConverter.addConversion([&](StringType type) {
     return sim::DynamicStringType::get(type.getContext());
   });
@@ -3352,6 +3498,8 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
   typeConverter.addConversion([](debug::ArrayType type) { return type; });
   typeConverter.addConversion([](debug::ScopeType type) { return type; });
   typeConverter.addConversion([](debug::StructType type) { return type; });
+  typeConverter.addConversion([](sim::ScanStringType type) { return type; });
+  typeConverter.addConversion([](sim::InputStreamType type) { return type; });
 
   typeConverter.addConversion([&](llhd::RefType type) -> std::optional<Type> {
     if (auto innerType = typeConverter.convertType(type.getNestedType()))
@@ -3575,6 +3723,19 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FormatRealOpConversion,
     DisplayBIOpConversion,
     FDisplayBIOpConversion,
+
+    // Scan strings.
+    ScanLiteralOpConversion,
+    ScanIntOpConversion,
+    ScanRealOpConversion,
+    ScanTimeOpConversion,
+    ScanCharOpConversion,
+    ScanStrOpConversion,
+    ScanUnformattedOpConversion,
+    ScanHierPathMatchOpConversion,
+    ScanConcatOpConversion,
+    FScanFBIOpConversion,
+    SScanFBIOpConversion,
 
     // File I/O operations
     FOpenBIOpConversion,

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -77,6 +77,9 @@ struct SimTypeConverter : public TypeConverter {
     addConversion([&](OutputStreamType type) -> Type {
       return IntegerType::get(type.getContext(), 32);
     });
+    addConversion([&](InputStreamType type) -> Type {
+      return IntegerType::get(type.getContext(), 32);
+    });
   }
 };
 
@@ -133,6 +136,17 @@ public:
     });
 
     rewriter.replaceOpWithNewOp<sv::ReadInOutOp>(op, reg);
+    return success();
+  }
+};
+
+struct SVFdToInputStreamLowering
+    : public OpConversionPattern<SVChannelToInputStreamOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(SVChannelToInputStreamOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(op, adaptor.getFd());
     return success();
   }
 };
@@ -763,6 +777,228 @@ LogicalResult lowerFormatStringToSVFormat(Value input,
   return success();
 }
 
+static void appendScanSpecifier(SmallString<128> &formatString,
+                                std::optional<int32_t> maxWidth, char spec,
+                                bool suppress = false) {
+  formatString.push_back('%');
+  if (suppress)
+    formatString.push_back('*');
+  if (maxWidth)
+    llvm::Twine(*maxWidth).toVector(formatString);
+  formatString.push_back(spec);
+}
+
+LogicalResult getFlattenedScanFragments(Value input,
+                                        SmallVectorImpl<Value> &fragments) {
+  if (auto concat = input.getDefiningOp<ScanConcatOp>()) {
+    if (failed(concat.getFlattenedInputs(fragments)))
+      return mlir::emitError(input.getLoc(),
+                             "cyclic sim.scan.concat is unsupported");
+    return success();
+  }
+  fragments.push_back(input);
+  return success();
+}
+
+LogicalResult appendScanFragmentToSVFormat(Value fragment,
+                                           SmallString<128> &formatString,
+                                           SmallVectorImpl<Value> &outputs) {
+  Operation *op = fragment.getDefiningOp();
+  if (!op)
+    return mlir::emitError(fragment.getLoc(),
+                           "block argument scan strings are unsupported");
+
+  return TypeSwitch<Operation *, LogicalResult>(op)
+      .Case<ScanLiteralOp>([&](auto lit) -> LogicalResult {
+        appendLiteralToSVFormat(formatString, lit.getLiteral());
+        return success();
+      })
+      .Case<ScanDecOp>([&](auto s) -> LogicalResult {
+        appendScanSpecifier(formatString, s.getMaxWidth(), 'd', !s.getDest());
+        if (s.getDest())
+          outputs.push_back(s.getDest());
+        return success();
+      })
+      .Case<ScanBinOp>([&](auto s) -> LogicalResult {
+        appendScanSpecifier(formatString, s.getMaxWidth(), 'b', !s.getDest());
+        if (s.getDest())
+          outputs.push_back(s.getDest());
+        return success();
+      })
+      .Case<ScanOctOp>([&](auto s) -> LogicalResult {
+        appendScanSpecifier(formatString, s.getMaxWidth(), 'o', !s.getDest());
+        if (s.getDest())
+          outputs.push_back(s.getDest());
+        return success();
+      })
+      .Case<ScanHexOp>([&](auto s) -> LogicalResult {
+        appendScanSpecifier(formatString, s.getMaxWidth(),
+                            s.getIsUpper() ? 'X' : 'x', !s.getDest());
+        if (s.getDest())
+          outputs.push_back(s.getDest());
+        return success();
+      })
+      .Case<ScanRealOp>([&](auto s) -> LogicalResult {
+        appendScanSpecifier(formatString, s.getMaxWidth(), 'g', !s.getDest());
+        if (s.getDest())
+          outputs.push_back(s.getDest());
+        return success();
+      })
+      .Case<ScanTimeOp>([&](auto s) -> LogicalResult {
+        appendScanSpecifier(formatString, s.getMaxWidth(), 't', !s.getDest());
+        if (s.getDest())
+          outputs.push_back(s.getDest());
+        return success();
+      })
+      .Case<ScanCharOp>([&](auto s) -> LogicalResult {
+        formatString += s.getDest() ? "%c" : "%*c";
+        if (s.getDest())
+          outputs.push_back(s.getDest());
+        return success();
+      })
+      .Case<ScanStrOp>([&](auto s) -> LogicalResult {
+        appendScanSpecifier(formatString, s.getMaxWidth(), 's', !s.getDest());
+        if (s.getDest())
+          outputs.push_back(s.getDest());
+        return success();
+      })
+      .Case<ScanUnformattedOp>([&](auto s) -> LogicalResult {
+        if (s.getDest()) {
+          formatString += s.getFourValue() ? "%z" : "%u";
+          outputs.push_back(s.getDest());
+        } else {
+          formatString += s.getFourValue() ? "%*z" : "%*u";
+        }
+        return success();
+      })
+      .Case<ScanHierPathMatchOp>([&](auto) -> LogicalResult {
+        formatString += "%m";
+        return success();
+      })
+      .Default([&](auto unsupported) {
+        return mlir::emitError(unsupported->getLoc())
+               << "unsupported scan fragment '"
+               << unsupported->getName().getStringRef() << "'";
+      });
+}
+
+LogicalResult lowerScanStringToSVFormat(Value input,
+                                        SmallString<128> &formatString,
+                                        SmallVectorImpl<Value> &outputs) {
+  SmallVector<Value, 8> fragments;
+  if (failed(getFlattenedScanFragments(input, fragments)))
+    return failure();
+  for (auto fragment : fragments)
+    if (failed(appendScanFragmentToSVFormat(fragment, formatString, outputs)))
+      return failure();
+  return success();
+}
+
+static void cleanupDeadSimScanOps(ArrayRef<Operation *> seedOps) {
+  auto filter = [](Operation *op, OpOperand &operand) {
+    return isa<ScanStringType>(operand.get().getType()) &&
+           isa_and_present<SimDialect>(op->getDialect());
+  };
+  SparseOpSCC<OpSCCDirection::Backward> sccs(filter);
+  sccs.visit(seedOps);
+  assert(sccs.getNumCyclicSCCs() == 0 &&
+         "Cyclic scan graph should have been rejected");
+  for (OpSCC entry : sccs.reverseTopological()) {
+    auto *op = cast<Operation *>(entry);
+    if (op->use_empty())
+      op->erase();
+    else
+      op->emitWarning("sim scan op still has users after lowering; "
+                      "dialect conversion will fail");
+  }
+}
+
+static void materializeScanCount(OpBuilder &builder, ScanFormattedProcOp scanOp,
+                                 Value countResult) {
+  if (scanOp.getCount().use_empty())
+    return;
+  auto loc = scanOp.getLoc();
+  auto countReg = sv::RegOp::create(builder, loc, builder.getIntegerType(32),
+                                    builder.getStringAttr("scan_count"));
+  sv::BPAssignOp::create(builder, loc, countReg, countResult);
+  scanOp.getCount().replaceAllUsesWith(
+      sv::ReadInOutOp::create(builder, loc, countReg).getResult());
+}
+
+static LogicalResult lowerFScanFProc(ScanFormattedProcOp scanOp,
+                                     const TypeConverter &typeConverter,
+                                     OpBuilder &builder, StringRef formatString,
+                                     ArrayRef<Value> outputs) {
+  auto fdType = typeConverter.convertType(scanOp.getStream().getType());
+  assert(fdType && "expected input stream type conversion");
+  Value fd = mlir::UnrealizedConversionCastOp::create(
+                 builder, scanOp.getLoc(), fdType, scanOp.getStream())
+                 ->getResult(0);
+  auto fscanf =
+      sv::FScanFOp::create(builder, scanOp.getLoc(), fd,
+                           builder.getStringAttr(formatString), outputs);
+  materializeScanCount(builder, scanOp, fscanf.getCount());
+  return success();
+}
+
+static LogicalResult lowerSScanFProc(ScanFormattedProcOp scanOp,
+                                     StringToInputStreamOp strOp,
+                                     OpBuilder &builder, StringRef formatString,
+                                     ArrayRef<Value> outputs) {
+  auto srcLit = strOp.getStr().getDefiningOp<sim::StringConstantOp>();
+  if (!srcLit) {
+    return strOp.emitError(
+        "$sscanf with non-constant string source is not supported");
+  }
+
+  auto sscanf =
+      sv::SScanFOp::create(builder, scanOp.getLoc(), srcLit.getLiteralAttr(),
+                           builder.getStringAttr(formatString), outputs);
+  materializeScanCount(builder, scanOp, sscanf.getCount());
+  return success();
+}
+
+LogicalResult lowerScanFormattedProcToSV(hw::HWModuleOp module,
+                                         const TypeConverter &typeConverter) {
+  SmallVector<ScanFormattedProcOp> scanOps;
+  SmallVector<Operation *, 8> cleanupSeeds;
+  SmallVector<sim::StringConstantOp> stringLiteralsToErase;
+  module.walk([&](ScanFormattedProcOp op) { scanOps.push_back(op); });
+
+  for (auto scanOp : scanOps) {
+    OpBuilder builder(scanOp);
+    SmallString<128> formatString;
+    SmallVector<Value> outputs;
+
+    if (failed(lowerScanStringToSVFormat(scanOp.getFormat(), formatString,
+                                         outputs))) {
+      scanOp.emitError("cannot lower 'sim.proc.scan' to SystemVerilog");
+      return failure();
+    }
+
+    if (auto strOp =
+            scanOp.getStream().getDefiningOp<StringToInputStreamOp>()) {
+      if (failed(
+              lowerSScanFProc(scanOp, strOp, builder, formatString, outputs)))
+        return failure();
+      if (auto litOp = strOp.getStr().getDefiningOp<sim::StringConstantOp>())
+        stringLiteralsToErase.push_back(litOp);
+      cleanupSeeds.push_back(strOp);
+    } else {
+      if (failed(lowerFScanFProc(scanOp, typeConverter, builder, formatString,
+                                 outputs)))
+        return failure();
+    }
+    cleanupSeeds.push_back(scanOp);
+  }
+
+  cleanupDeadSimScanOps(cleanupSeeds);
+  for (auto litOp : stringLiteralsToErase)
+    if (litOp->use_empty())
+      litOp->erase();
+  return success();
+}
+
 FailureOr<Value> createFileDescriptorGetterForGetFile(GetFileOp getFileOp,
                                                       OpBuilder &builder) {
   SmallString<128> formatString;
@@ -888,6 +1124,9 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
       if (failed(lowerPrintFormattedProcToSV(module, typeConverter, state)))
         return failure();
 
+      if (failed(lowerScanFormattedProcToSV(module, typeConverter)))
+        return failure();
+
       if (moveOpsIntoIfdefGuardsAndProcesses(module))
         usedSynthesisMacro = true;
 
@@ -915,6 +1154,7 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
       patterns.add<PauseOp>(convert);
       patterns.add<TriggeredLowering>(context, state);
       patterns.add<DPICallLowering>(context, state);
+      patterns.add<SVFdToInputStreamLowering>(typeConverter, context);
       auto result = applyPartialConversion(module, target, std::move(patterns));
 
       if (failed(result))

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -811,8 +811,8 @@ void TriggeredOp::build(OpBuilder &builder, OperationState &odsState,
 
 OpFoldResult ScanLiteralOp::fold(FoldAdaptor) { return getLiteralAttr(); }
 
-LogicalResult ScanConcatOp::getFlattenedInputs(
-    llvm::SmallVectorImpl<Value> &flatOperands) {
+LogicalResult
+ScanConcatOp::getFlattenedInputs(llvm::SmallVectorImpl<Value> &flatOperands) {
   llvm::SmallMapVector<ScanConcatOp, unsigned, 4> concatStack;
   bool isCyclic = false;
   concatStack.insert({*this, 0});

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -806,6 +806,166 @@ void TriggeredOp::build(OpBuilder &builder, OperationState &odsState,
 }
 
 //===----------------------------------------------------------------------===//
+// Scan operations
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ScanLiteralOp::fold(FoldAdaptor) { return getLiteralAttr(); }
+
+LogicalResult ScanConcatOp::getFlattenedInputs(
+    llvm::SmallVectorImpl<Value> &flatOperands) {
+  llvm::SmallMapVector<ScanConcatOp, unsigned, 4> concatStack;
+  bool isCyclic = false;
+  concatStack.insert({*this, 0});
+
+  // Perform a DFS on this operation's concatenated operands,
+  // collect the leaf format string fragments.
+  while (!concatStack.empty()) {
+    auto &top = concatStack.back();
+    auto currentConcat = top.first;
+    unsigned operandIndex = top.second;
+
+    // Iterate over concatenated operands
+    while (operandIndex < currentConcat.getNumOperands()) {
+      auto currentOperand = currentConcat.getOperand(operandIndex);
+      if (auto nextConcat = currentOperand.getDefiningOp<ScanConcatOp>()) {
+        // Concat of a concat
+        if (!concatStack.contains(nextConcat)) {
+          // Save the next operand index to visit on the
+          // stack and put the new concat on top.
+          top.second = operandIndex + 1;
+          concatStack.insert({nextConcat, 0});
+          break;
+        }
+        // Cyclic concatenation encountered. Don't recurse.
+        isCyclic = true;
+      }
+      flatOperands.push_back(currentOperand);
+      operandIndex++;
+    }
+    if (operandIndex >= currentConcat.getNumOperands())
+      // Pop the concat off of the stack if we have visited all operands.
+      concatStack.pop_back();
+  }
+  return success(!isCyclic);
+}
+
+LogicalResult ScanConcatOp::verify() {
+  llvm::SmallVector<Value> flattened;
+  if (getFlattenedInputs(flattened).failed())
+    return emitOpError("scan format string concatenation is recursive");
+  return success();
+}
+
+OpFoldResult ScanConcatOp::fold(FoldAdaptor adaptor) {
+  if (getNumOperands() == 0)
+    return StringAttr::get(getContext(), "");
+  if (getNumOperands() == 1) {
+    // Don't fold to our own result to avoid an infinte loop.
+    if (getResult() == getOperand(0))
+      return {};
+    return getOperand(0);
+  }
+
+  // Fold if all operands are literals.
+  SmallVector<StringRef> lits;
+  for (auto attr : adaptor.getInputs()) {
+    auto lit = dyn_cast_or_null<StringAttr>(attr);
+    if (!lit)
+      return {};
+    lits.push_back(lit);
+  }
+  return concatLiterals(getContext(), lits);
+}
+
+LogicalResult ScanConcatOp::canonicalize(ScanConcatOp op,
+                                         PatternRewriter &rewriter) {
+  // Any helper literals created during canonicalization must dominate `op`.
+  rewriter.setInsertionPoint(op);
+
+  auto scanStrType = ScanStringType::get(op.getContext());
+
+  // Check if we can flatten concats of concats
+  bool hasBeenFlattened = false;
+  SmallVector<Value, 0> flatOperands;
+  if (!op.isFlat()) {
+    // Get a new, flattened list of operands
+    flatOperands.reserve(op.getNumOperands() + 4);
+    auto isAcyclic = op.getFlattenedInputs(flatOperands);
+
+    if (failed(isAcyclic)) {
+      // Infinite recursion, but we cannot fail compilation right here (can we?)
+      // so just emit a warning and bail out.
+      op.emitWarning("Cyclic concatenation detected.");
+      return failure();
+    }
+
+    hasBeenFlattened = true;
+  }
+
+  if (!hasBeenFlattened && op.getNumOperands() < 2)
+    return failure(); // Should be handled by the folder
+
+  // Check if there are adjacent literals we can merge or empty literals to
+  // remove
+  SmallVector<StringRef> litSequence;
+  SmallVector<Value> newOperands;
+  newOperands.reserve(op.getNumOperands());
+  ScanLiteralOp prevLitOp;
+
+  auto oldOperands = hasBeenFlattened ? flatOperands : op.getOperands();
+  for (auto operand : oldOperands) {
+    if (auto litOp = operand.getDefiningOp<ScanLiteralOp>()) {
+      if (!litOp.getLiteral().empty()) {
+        prevLitOp = litOp;
+        litSequence.push_back(litOp.getLiteral());
+      }
+    } else {
+      if (!litSequence.empty()) {
+        if (litSequence.size() > 1) {
+          // Create a fused literal.
+          auto newLit = rewriter.createOrFold<ScanLiteralOp>(
+              op.getLoc(), scanStrType,
+              concatLiterals(op.getContext(), litSequence));
+          newOperands.push_back(newLit);
+        } else {
+          // Reuse the existing literal.
+          newOperands.push_back(prevLitOp.getResult());
+        }
+        litSequence.clear();
+      }
+      newOperands.push_back(operand);
+    }
+  }
+
+  // Push trailing literals into the new operand list
+  if (!litSequence.empty()) {
+    if (litSequence.size() > 1) {
+      // Create a fused literal.
+      auto newLit = rewriter.createOrFold<ScanLiteralOp>(
+          op.getLoc(), scanStrType,
+          concatLiterals(op.getContext(), litSequence));
+      newOperands.push_back(newLit);
+    } else {
+      // Reuse the existing literal.
+      newOperands.push_back(prevLitOp.getResult());
+    }
+  }
+
+  if (!hasBeenFlattened && newOperands.size() == op.getNumOperands())
+    return failure(); // Nothing changed
+
+  if (newOperands.empty())
+    rewriter.replaceOpWithNewOp<ScanLiteralOp>(op, scanStrType,
+                                               rewriter.getStringAttr(""));
+  else if (newOperands.size() == 1)
+    rewriter.replaceOp(op, newOperands);
+  else
+    rewriter.modifyOpInPlace(op, [&]() { op->setOperands(newOperands); });
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/ExportVerilog/sv-scan.mlir
+++ b/test/Conversion/ExportVerilog/sv-scan.mlir
@@ -1,0 +1,123 @@
+// RUN: circt-opt -export-verilog %s | FileCheck %s
+
+// CHECK-LABEL: module fscanf_no_count(
+// CHECK: reg [31:0] x;
+// CHECK: always @(posedge clk)
+// CHECK-NEXT: $fscanf(fd, "%d", x);
+hw.module @fscanf_no_count(in %clk : i1, in %fd : i32) {
+  %x = sv.reg : !hw.inout<i32>
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "%d"(%x) : !hw.inout<i32>
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_with_count(
+// CHECK: reg [31:0] x;
+// CHECK: reg [31:0] count;
+// CHECK: always @(posedge clk)
+// CHECK-NEXT: count = $fscanf(fd, "%d", x);
+hw.module @fscanf_with_count(in %clk : i1, in %fd : i32) {
+  %x = sv.reg : !hw.inout<i32>
+  %count = sv.reg : !hw.inout<i32>
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "%d"(%x) : !hw.inout<i32>
+    sv.bpassign %count, %0 : i32
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_multiple_outputs(
+// CHECK: $fscanf(fd, "%d%x", a, b);
+hw.module @fscanf_multiple_outputs(in %clk : i1, in %fd : i32) {
+  %a = sv.reg : !hw.inout<i32>
+  %b = sv.reg : !hw.inout<i32>
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "%d%x"(%a, %b) : !hw.inout<i32>, !hw.inout<i32>
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_no_outputs(
+// CHECK: $fscanf({{.+}}, "%m");
+hw.module @fscanf_no_outputs(in %clk : i1, in %fd : i32) {
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "%m"
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_suppressed(
+// CHECK: $fscanf({{.+}}, "%*d%d", {{.+}});
+hw.module @fscanf_suppressed(in %clk : i1, in %fd : i32) {
+  %x = sv.reg : !hw.inout<i32>
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "%*d%d"(%x) : !hw.inout<i32>
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_width(
+// CHECK: $fscanf({{.+}}, "%8d", {{.+}});
+hw.module @fscanf_width(in %clk : i1, in %fd : i32) {
+  %x = sv.reg : !hw.inout<i32>
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "%8d"(%x) : !hw.inout<i32>
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_literal_text(
+// CHECK: $fscanf({{.+}}, "val=%d", {{.+}});
+hw.module @fscanf_literal_text(in %clk : i1, in %fd : i32) {
+  %x = sv.reg : !hw.inout<i32>
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "val=%d"(%x) : !hw.inout<i32>
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_percent_literal(
+// CHECK: $fscanf({{.+}}, "100%%");
+hw.module @fscanf_percent_literal(in %clk : i1, in %fd : i32) {
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "100%%"
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_all_integer_specifiers(
+// CHECK: $fscanf({{.+}}, "%d%b%o%x%X", {{.+}}, {{.+}}, {{.+}}, {{.+}}, {{.+}});
+hw.module @fscanf_all_integer_specifiers(in %clk : i1, in %fd : i32) {
+  %dec = sv.reg : !hw.inout<i32>
+  %bin = sv.reg : !hw.inout<i32>
+  %oct = sv.reg : !hw.inout<i32>
+  %hex_l = sv.reg : !hw.inout<i32>
+  %hex_u = sv.reg : !hw.inout<i32>
+  sv.always posedge %clk {
+    %0 = sv.fscanf %fd, "%d%b%o%x%X"(%dec, %bin, %oct, %hex_l, %hex_u) : !hw.inout<i32>, !hw.inout<i32>, !hw.inout<i32>, !hw.inout<i32>, !hw.inout<i32>
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module fscanf_count_in_always(
+hw.module @fscanf_count_in_always(in %clk : i1, in %fd : i32) {
+  %x = sv.reg : !hw.inout<i32>
+  sv.always posedge %clk {
+    %count = sv.reg : !hw.inout<i32>
+    %0 = sv.fscanf %fd, "%d"(%x) : !hw.inout<i32>
+    sv.bpassign %count, %0 : i32
+  }
+  hw.output
+}
+
+// CHECK-LABEL: module sscanf_basic(
+hw.module @sscanf_basic(in %clk : i1) {
+  %x = sv.reg : !hw.inout<i32>
+  // CHECK: always @(posedge clk)
+  sv.always posedge %clk {
+    // CHECK-NEXT: $sscanf({{.+}}, "%d", x);
+    %0 = sv.sscanf "hello", "%d"(%x) : !hw.inout<i32>
+  }
+  hw.output
+}

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -846,3 +846,304 @@ function void FileDisplayBuiltins(int fd, int x);
   $fdisplayh(fd, x);
 
 endfunction
+
+// CHECK-LABEL: func.func private @FScanfIntegerSpecifiers(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfIntegerSpecifiers(int fd);
+  int x;
+  int res;
+
+  // CHECK: [[VAR:%.+]] = moore.variable : <i32>
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> decimal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%d", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> decimal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%D", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> binary
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%b", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> binary
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%B", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> octal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%o", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> octal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%O", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_lower
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%h", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_lower
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%x", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_upper
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%H", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_upper
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%X", x);
+endfunction
+
+// CHECK-LABEL: func.func private @FScanfRealSpecifiers(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfRealSpecifiers(int fd);
+  real r;
+  int res;
+  // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%f", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%e", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%g", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%F", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%E", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%G", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.time [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%t", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.time [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%T", r);
+endfunction
+
+// CHECK-LABEL: func.func private @FScanfOtherSpecifiers(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfOtherSpecifiers(int fd);
+  string s;
+  byte c;
+  int raw;
+  int res;
+
+  // CHECK: [[SVAR:%.+]] = moore.variable : <string>
+  // CHECK: [[CVAR:%.+]] = moore.variable : <i8>
+  // CHECK: [[RVAR:%.+]] = moore.variable : <i32>
+
+  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%s", s);
+
+  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%S", s);
+
+  // CHECK: [[S:%.+]] = moore.scan.char [[CVAR]] : !moore.ref<i8>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%c", c);
+
+  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32>
+  // CHECK-NOT: four_value
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%u", raw);
+
+  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32> four_value
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%z", raw);
+
+  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32> four_value
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%Z", raw);
+
+  // CHECK: [[S:%.+]] = moore.scan.hier_path_match
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%m");
+
+  // CHECK: [[S:%.+]] = moore.scan.hier_path_match
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%M");
+
+  // CHECK: [[S:%.+]] = moore.scan.literal "%"
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%%");
+endfunction
+
+// CHECK-LABEL: func.func private @FScanfModifiers(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfModifiers(int fd);
+  int x;
+  string s;
+  real r;
+  int res;
+
+  // CHECK: [[IVAR:%.+]] = moore.variable : <i32>
+  // CHECK: [[SVAR:%.+]] = moore.variable : <string>
+  // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+
+  // CHECK: [[S:%.+]] = moore.scan.int decimal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*d");
+
+  // CHECK: [[S:%.+]] = moore.scan.int binary
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*b");
+
+  // CHECK: [[S:%.+]] = moore.scan.str
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*s");
+
+  // CHECK: [[S:%.+]] = moore.scan.real
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*f");
+
+  // CHECK: [[S:%.+]] = moore.scan.char
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*c");
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[IVAR]] : !moore.ref<i32> decimal width 8
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%8d", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string> width 16
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%16s", s);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64> width 10
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%10f", r);
+
+
+  // CHECK: [[S:%.+]] = moore.scan.int decimal width 42
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*42d");
+
+  // CHECK: [[S:%.+]] = moore.scan.str width 42
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*42s");
+
+  // CHECK: [[S:%.+]] = moore.scan.int hex_lower width 42
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*42h");
+endfunction
+
+// CHECK-LABEL: func.func private @FScanfComposition(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfComposition(int fd);
+  int a;
+  string b;
+  real r;
+  int res;
+
+  // CHECK: [[AVAR:%.+]] = moore.variable : <i32>
+  // CHECK: [[BVAR:%.+]] = moore.variable : <string>
+  // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+
+  // CHECK: [[S1:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[S2]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%d%s", a, b);
+
+  // CHECK: [[SA:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[SB:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: [[SC:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SA]], [[SB]], [[SC]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%d%f%s", a, r, b);
+
+  // CHECK: [[LIT:%.+]] = moore.scan.literal "val="
+  // CHECK: [[SPEC:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[LIT]], [[SPEC]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "val=%d", a);
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[LIT:%.+]] = moore.scan.literal " end"
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SPEC]], [[LIT]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%d end", a);
+
+  // CHECK: [[S1:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[LIT:%.+]] = moore.scan.literal " , "
+  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[LIT]], [[S2]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%d , %s", a, b);
+
+  // CHECK: [[S1:%.+]] = moore.scan.int decimal
+  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[S2]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%*d%s", b);
+
+  // CHECK: [[LIT:%.+]] = moore.scan.literal "prefix"
+  // CHECK-NOT: moore.scan.concat
+  // CHECK: moore.builtin.fscanf [[FD]] [[LIT]]
+  res = $fscanf(fd, "prefix");
+
+  // CHECK: [[LIT:%.+]] = moore.scan.literal " "
+  // CHECK: moore.builtin.fscanf [[FD]] [[LIT]]
+  res = $fscanf(fd, " ");
+
+  // CHECK-NOT: moore.builtin.fscanf
+  // CHECK: moore.constant 0 : i32
+  res = $fscanf(fd, "");
+endfunction
+
+// CHECK-LABEL: func.func private @SScanfBuiltins(
+// CHECK-SAME:  [[SRC:%[^ ,]+]]: !moore.string
+function void SScanfBuiltins(string src);
+  int x;
+  string s;
+  real r;
+  int res;
+
+  // CHECK: [[XVAR:%.+]] = moore.variable : <i32>
+  // CHECK: [[SVAR:%.+]] = moore.variable : <string>
+  // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.int [[XVAR]] : !moore.ref<i32> decimal
+  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  res = $sscanf(src, "%d", x);
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
+  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  res = $sscanf(src, "%s", s);
+
+  // CHECK: [[SA:%.+]] = moore.scan.int [[XVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[LIT:%.+]] = moore.scan.literal " "
+  // CHECK: [[SB:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SA]], [[LIT]], [[SB]])
+  // CHECK: moore.builtin.sscanf [[SRC]] [[CAT]]
+  res = $sscanf(src, "%d %f", x, r);
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.int decimal width 8
+  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  res = $sscanf(src, "%*8d");
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.unformatted [[XVAR]] : !moore.ref<i32> four_value
+  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  res = $sscanf(src, "%z", x);
+
+  // CHECK-NOT: moore.builtin.sscanf
+  // CHECK: moore.constant 0 : i32
+  res = $sscanf(src, "");
+endfunction

--- a/test/Conversion/SimToSV/lower-scan-formatted-proc-to-sv-errors.mlir
+++ b/test/Conversion/SimToSV/lower-scan-formatted-proc-to-sv-errors.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-opt --lower-sim-to-sv --split-input-file --verify-diagnostics %s
+
+hw.module @block_arg_scan_format(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    // expected-error @below {{block argument scan strings are unsupported}}
+    ^bb0(%fd_in : i32, %fmt : !sim.scan_string):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    // expected-error @below {{cannot lower 'sim.proc.scan' to SystemVerilog}}
+    %count = sim.proc.scan %stream %fmt
+  }
+}

--- a/test/Conversion/SimToSV/lower-scan-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-scan-formatted-proc-to-sv.mlir
@@ -1,0 +1,383 @@
+// RUN: circt-opt --lower-sim-to-sv %s | FileCheck %s
+
+// CHECK-NOT: !sim.scan_string
+// CHECK-NOT: sim.proc.scan
+// CHECK-NOT: sim.scan.
+// CHECK-NOT: sim.sv.channel_to_input_stream
+
+// CHECK-LABEL: hw.module @scan_decimal
+hw.module @scan_decimal(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.dec %x : !hw.inout<i32>
+    // CHECK: sv.fscanf {{%.+}}, "%d"
+    // CHECK-NOT: sim.proc.scan
+    // CHECK-NOT: sim.scan.dec
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_binary
+hw.module @scan_binary(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.bin %x : !hw.inout<i32>
+    // CHECK: sv.fscanf {{%.+}}, "%b"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_octal
+hw.module @scan_octal(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.oct %x : !hw.inout<i32>
+    // CHECK: sv.fscanf {{%.+}}, "%o"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_hex_lower
+hw.module @scan_hex_lower(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.hex %x : !hw.inout<i32> isUpper false
+    // CHECK: sv.fscanf {{%.+}}, "%x"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_hex_upper
+hw.module @scan_hex_upper(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.hex %x : !hw.inout<i32> isUpper true
+    // CHECK: sv.fscanf {{%.+}}, "%X"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_real
+hw.module @scan_real(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %r = sv.reg : !hw.inout<i64>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.real %r : !hw.inout<i64>
+    // CHECK: sv.fscanf {{%.+}}, "%g"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_time
+hw.module @scan_time(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %r = sv.reg : !hw.inout<i64>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.time %r : !hw.inout<i64>
+    // CHECK: sv.fscanf {{%.+}}, "%t"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_char
+hw.module @scan_char(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %c = sv.reg : !hw.inout<i8>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.char %c : !hw.inout<i8>
+    // CHECK: sv.fscanf {{%.+}}, "%c"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_unformatted_2val
+hw.module @scan_unformatted_2val(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.unformatted %x : !hw.inout<i32>
+    // CHECK: sv.fscanf {{%.+}}, "%u"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_unformatted_4val
+hw.module @scan_unformatted_4val(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.unformatted %x : !hw.inout<i32> four_value
+    // CHECK: sv.fscanf {{%.+}}, "%z"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_with_max_width
+hw.module @scan_with_max_width(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.dec %x : !hw.inout<i32> width 8
+    // CHECK: sv.fscanf {{%.+}}, "%8d"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_suppressed
+hw.module @scan_suppressed(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s_skip = sim.scan.dec {}
+    %s_keep = sim.scan.dec %x : !hw.inout<i32>
+    %fmt = sim.scan.concat (%s_skip, %s_keep)
+    // CHECK: {{%.+}} = sv.fscanf {{%.+}}, "%*d%d"(%{{.+}}) : !hw.inout<i32>
+    %count = sim.proc.scan %stream %fmt
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_literal_text
+hw.module @scan_literal_text(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %lit = sim.scan.literal "val="
+    %s = sim.scan.dec %x : !hw.inout<i32>
+    %fmt = sim.scan.concat (%lit, %s)
+    // CHECK: sv.fscanf {{%.+}}, "val=%d"
+    %count = sim.proc.scan %stream %fmt
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_percent_in_literal
+hw.module @scan_percent_in_literal(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %lit = sim.scan.literal "100%"
+    // CHECK: {{%.+}} = sv.fscanf {{%.+}}, "100%%"
+    %count = sim.proc.scan %stream %lit
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_hier_path
+hw.module @scan_hier_path(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s_hier = sim.scan.hier_path_match
+    %s_dec = sim.scan.dec %x : !hw.inout<i32>
+    %fmt = sim.scan.concat (%s_hier, %s_dec)
+    // CHECK: {{%.+}} = sv.fscanf {{%.+}}, "%m%d"(%{{.+}}) : !hw.inout<i32>
+    %count = sim.proc.scan %stream %fmt
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_count_used
+hw.module @scan_count_used(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %done = sv.reg : !hw.inout<i1>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.dec %x : !hw.inout<i32>
+    // CHECK: %[[RES:.+]] = sv.fscanf {{%.+}}, "%d"(%{{.+}}) : !hw.inout<i32>
+    // CHECK-NEXT: %[[REG:.+]] = sv.reg
+    // CHECK-NEXT: sv.bpassign %[[REG]], %[[RES]] : i32
+    // CHECK-NEXT: %[[VAL:.+]] = sv.read_inout %[[REG]]
+    %count = sim.proc.scan %stream %s
+    %c1 = hw.constant 1 : i32
+    %ok = comb.icmp eq %count, %c1 : i32
+    sv.bpassign %done, %ok : i1
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_multiple_ops
+hw.module @scan_multiple_ops(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %a = sv.reg : !hw.inout<i32>
+    %b = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %sa = sim.scan.dec %a : !hw.inout<i32>
+    %sb = sim.scan.hex %b : !hw.inout<i32> isUpper false
+    // CHECK: sv.fscanf {{%.+}}, "%d"
+    %count_a = sim.proc.scan %stream %sa
+    // CHECK: sv.fscanf {{%.+}}, "%x"
+    %count_b = sim.proc.scan %stream %sb
+  }
+}
+
+// CHECK-LABEL: hw.module @all_scan_fragments
+hw.module @all_scan_fragments(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %i32_reg = sv.reg : !hw.inout<i32>
+    %i8_reg = sv.reg : !hw.inout<i8>
+    %f64_reg = sv.reg : !hw.inout<i64>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s_lit = sim.scan.literal "prefix="
+    %s_dec = sim.scan.dec %i32_reg : !hw.inout<i32>
+    %s_bin = sim.scan.bin %i32_reg : !hw.inout<i32>
+    %s_oct = sim.scan.oct %i32_reg : !hw.inout<i32>
+    %s_hexl = sim.scan.hex %i32_reg : !hw.inout<i32> isUpper false
+    %s_hexu = sim.scan.hex %i32_reg : !hw.inout<i32> isUpper true
+    %s_real = sim.scan.real %f64_reg : !hw.inout<i64>
+    %s_char = sim.scan.char %i8_reg : !hw.inout<i8>
+    %s_hier = sim.scan.hier_path_match
+    %fmt = sim.scan.concat (%s_lit, %s_dec, %s_bin, %s_oct, %s_hexl, %s_hexu, %s_real, %s_char, %s_hier)
+    // CHECK: {{%.+}} = sv.fscanf {{%.+}}, "prefix=%d%b%o%x%X%g%c%m"(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}) : !hw.inout<i32>, !hw.inout<i32>, !hw.inout<i32>, !hw.inout<i32>, !hw.inout<i32>, !hw.inout<i64>, !hw.inout<i8>
+    %count = sim.proc.scan %stream %fmt
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_str_basic
+hw.module @scan_str_basic(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %buf = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.str %buf : !hw.inout<i32>
+    // CHECK: sv.fscanf {{%.+}}, "%s"(%{{.+}}) : !hw.inout<i32>
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_str_suppressed
+hw.module @scan_str_suppressed(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.str {}
+    // CHECK: sv.fscanf {{%.+}}, "%*s"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_str_width
+hw.module @scan_str_width(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %buf = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.str %buf : !hw.inout<i32> width 16
+    // CHECK: sv.fscanf {{%.+}}, "%16s"(%{{.+}}) : !hw.inout<i32>
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_unformatted_suppressed_2val
+hw.module @scan_unformatted_suppressed_2val(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.unformatted {}
+    // CHECK: sv.fscanf {{%.+}}, "%*u"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_unformatted_suppressed_4val
+hw.module @scan_unformatted_suppressed_4val(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.unformatted four_value
+    // CHECK: sv.fscanf {{%.+}}, "%*z"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_suppressed_with_width
+hw.module @scan_suppressed_with_width(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %x = sv.reg : !hw.inout<i32>
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s_skip = sim.scan.dec width 8
+    %s_keep = sim.scan.dec %x : !hw.inout<i32>
+    %fmt = sim.scan.concat (%s_skip, %s_keep)
+    // CHECK: sv.fscanf {{%.+}}, "%*8d%d"(%{{.+}}) : !hw.inout<i32>
+    %count = sim.proc.scan %stream %fmt
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_literal_newline
+hw.module @scan_literal_newline(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.literal "line\nend"
+    // CHECK: sv.fscanf {{%.+}}, "line\0Aend"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_literal_backslash
+hw.module @scan_literal_backslash(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.literal "path\\to"
+    // CHECK: sv.fscanf {{%.+}}, "path\\to"
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_hier_path_only
+hw.module @scan_hier_path_only(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %s = sim.scan.hier_path_match
+    // CHECK: sv.fscanf {{%.+}}, "%m"
+    // CHECK-NOT: sv.fscanf {{%.+}}, "%m"(
+    %count = sim.proc.scan %stream %s
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_empty_concat
+hw.module @scan_empty_concat(in %clk : i1, in %fd : i32) {
+  hw.triggered posedge %clk (%fd) : i32 {
+    ^bb0(%fd_in : i32):
+    %stream = sim.sv.channel_to_input_stream %fd_in
+    %fmt = sim.scan.concat ()
+    // CHECK: sv.fscanf {{%.+}}, ""
+    %count = sim.proc.scan %stream %fmt
+  }
+}
+
+// CHECK-LABEL: hw.module @scan_sscanf_basic
+hw.module @scan_sscanf_basic(in %clk : i1) {
+  hw.triggered posedge %clk {
+    ^bb0:
+    %str = sim.string.literal "42 0xAB"
+    %x = sv.reg : !hw.inout<i32>
+    %y = sv.reg : !hw.inout<i32>
+    %stream = sim.string_to_input_stream %str
+    %sd = sim.scan.dec %x : !hw.inout<i32>
+    %sh = sim.scan.hex %y : !hw.inout<i32> isUpper false
+    %fmt = sim.scan.concat (%sd, %sh)
+    // CHECK: sv.sscanf "42 0xAB", "%d%x"({{.+}}, {{.+}}) : !hw.inout<i32>, !hw.inout<i32>
+    %count = sim.proc.scan %stream %fmt
+  }
+}


### PR DESCRIPTION
Implement end-to-end support for the SystemVerilog `$fscanf` and `$sscanf` system functions, covering the scan format.

The lowering is structured into the following step:

- ImportVerilog / Moore dialect: A new  parser converts scan format strings into a tree of Moore scan fragment ops (`moore.scan.literal`, `moore.scan.int`, `moore.scan.real`, `moore.scan.time`, `moore.scan.char`, `moore.scan.str`, `moore.scan.unformatted`, `moore.scan.hier_path_match`, and `moore.scan.concat`).

- MooreToCore / Sim dialect: Moore scan ops are converted to their Sim dialect counterparts. The input source is bridged via `sim.sv.channel_to_input_stream` for `$fscanf` or via `sim.string_to_input_stream` for `$sscanf`. Both producing a `sim.input_stream` value consumed by `sim.proc.scan`.

- SimToSV / ExportVerilog / SV Dialect: `sim.proc.scan` is lowered to `sv.fscanf` or `sv.sscanf` depending on the stream source. The count result is materialized via `sv.reg` + `sv.bpassign` + `sv.read_inout`. ExportVerilog emits the final `$fscanf`/`$sscanf` Verilog system functions.

I've submitted several PRs before, but never one this substantial. I've also never submitted a PR that has been merged for SV or ExportVerilog. Please feel free to send me your feedback.
