### PR TITLE
[VerifToSMT] Keep debug names in BMC

### DIFF
--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -55,6 +55,21 @@ llvm::SmallDenseMap<unsigned, StringAttr> collectDebugNames(Block &block) {
   return debugNames;
 }
 
+static void attachDebugVariables(
+    OpBuilder &builder, Location loc, ArrayRef<Type> originalTypes,
+    ValueRange values,
+    const llvm::SmallDenseMap<unsigned, StringAttr> &debugNames) {
+  for (auto [argIndex, value] : llvm::enumerate(values)) {
+    if (isa<seq::ClockType>(originalTypes[argIndex]))
+      continue;
+    auto it = debugNames.find(argIndex);
+    if (it == debugNames.end())
+      continue;
+    debug::VariableOp::create(builder, loc, it->second, value,
+                              /*scope=*/Value{});
+  }
+}
+
 /// Lower a verif::AssertOp operation with an i1 operand to a smt::AssertOp,
 /// negated to check for unsatisfiability.
 struct VerifAssertOpConversion : OpConversionPattern<verif::AssertOp> {
@@ -518,6 +533,11 @@ struct VerifBoundedModelCheckingOpConversion
     for (; initIndex < initVals.size(); ++initIndex)
       inputDecls.push_back(initVals[initIndex]);
 
+    attachDebugVariables(
+        rewriter, loc, oldCircuitInputTy,
+        ValueRange(inputDecls).take_front(circuitFuncOp.getNumArguments()),
+        debugNames);
+
     Value lowerBound =
         arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
     Value step =
@@ -536,6 +556,10 @@ struct VerifBoundedModelCheckingOpConversion
     auto forOp = scf::ForOp::create(
         rewriter, loc, lowerBound, upperBound, step, inputDecls,
         [&](OpBuilder &builder, Location loc, Value i, ValueRange iterArgs) {
+          attachDebugVariables(
+              builder, loc, oldCircuitInputTy,
+              iterArgs.take_front(circuitFuncOp.getNumArguments()), debugNames);
+
           // Drop existing assertions
           smt::PopOp::create(builder, loc, 1);
           smt::PushOp::create(builder, loc, 1);
@@ -670,6 +694,11 @@ struct VerifBoundedModelCheckingOpConversion
           // Add the rest of the loop state args
           for (; loopIndex < loopVals.size(); ++loopIndex)
             newDecls.push_back(loopVals[loopIndex]);
+
+          attachDebugVariables(
+              builder, loc, oldCircuitInputTy,
+              ValueRange(newDecls).take_front(circuitFuncOp.getNumArguments()),
+              debugNames);
 
           newDecls.push_back(violated);
 

--- a/test/Conversion/VerifToSMT/bmc-debug-names.mlir
+++ b/test/Conversion/VerifToSMT/bmc-debug-names.mlir
@@ -3,16 +3,103 @@
 // CHECK-LABEL: func.func @test_bmc_debug_names() -> i1 {
 // CHECK: [[INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
 // CHECK: [[REG_DECL:%.+]] = smt.declare_fun "state_q" : !smt.bv<8>
+// CHECK: dbg.variable "data_in", [[INPUT_DECL]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[REG_DECL]] : !smt.bv<8>
 // CHECK: scf.for {{%.+}} iter_args([[CLK_ARG:%.+]] = {{%.+}}, [[INPUT_ARG:%.+]] = [[INPUT_DECL]], [[REG_ARG:%.+]] = [[REG_DECL]], {{%.+}})
-// CHECK: [[CIRCUIT_RESULT:%.+]] = func.call @bmc_circuit([[CLK_ARG]], [[INPUT_ARG]], [[REG_ARG]]) : (!smt.bv<1>, !smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+// CHECK: dbg.variable "data_in", [[INPUT_ARG]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[REG_ARG]] : !smt.bv<8>
+// CHECK: [[CIRCUIT_RESULT:%.+]] = func.call @bmc_circuit{{(_[0-9]+)?}}([[CLK_ARG]], [[INPUT_ARG]], [[REG_ARG]]) : (!smt.bv<1>, !smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
 // CHECK-NOT: smt.declare_fun "input_1"
 // CHECK-NOT: smt.declare_fun "reg_0"
 // CHECK: [[NEXT_INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
 // CHECK: [[NEXT_REG:%.+]] = smt.ite {{%.+}}, [[CIRCUIT_RESULT]], [[REG_ARG]] : !smt.bv<8>
+// CHECK: dbg.variable "data_in", [[NEXT_INPUT_DECL]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[NEXT_REG]] : !smt.bv<8>
+// CHECK: scf.yield {{%.+}}, [[NEXT_INPUT_DECL]], [[NEXT_REG]], {{%.+}} : !smt.bv<1>, !smt.bv<8>, !smt.bv<8>, i1
+// CHECK-LABEL: func.func @test_bmc_debug_names_extra_loop_state() -> i1 {
+// CHECK: [[INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
+// CHECK: [[REG_DECL:%.+]] = smt.declare_fun "state_q" : !smt.bv<8>
+// CHECK: [[REG_CONST:%.+]] = smt.bv.constant #smt.bv<7> : !smt.bv<8>
+// CHECK: dbg.variable "data_in", [[INPUT_DECL]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[REG_DECL]] : !smt.bv<8>
+// CHECK: dbg.variable "state_r", [[REG_CONST]] : !smt.bv<8>
+// CHECK: scf.for {{%.+}} iter_args([[CLK_ARG:%.+]] = {{%.+}}, [[INPUT_ARG:%.+]] = [[INPUT_DECL]], [[REG0_ARG:%.+]] = [[REG_DECL]], [[REG1_ARG:%.+]] = [[REG_CONST]], {{%.+}}, {{%.+}})
+// CHECK: dbg.variable "data_in", [[INPUT_ARG]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[REG0_ARG]] : !smt.bv<8>
+// CHECK: dbg.variable "state_r", [[REG1_ARG]] : !smt.bv<8>
+// CHECK: [[CIRCUIT_RESULT0:%.+]]:2 = func.call @bmc_circuit{{(_[0-9]+)?}}([[CLK_ARG]], [[INPUT_ARG]], [[REG0_ARG]], [[REG1_ARG]]) : (!smt.bv<1>, !smt.bv<8>, !smt.bv<8>, !smt.bv<8>) -> (!smt.bv<8>, !smt.bv<8>)
+// CHECK: [[NEXT_INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
+// CHECK: [[NEXT_REG0:%.+]] = smt.ite {{%.+}}, [[CIRCUIT_RESULT0]]#0, [[REG0_ARG]] : !smt.bv<8>
+// CHECK: [[NEXT_REG1:%.+]] = smt.ite {{%.+}}, [[CIRCUIT_RESULT0]]#1, [[REG1_ARG]] : !smt.bv<8>
+// CHECK: dbg.variable "data_in", [[NEXT_INPUT_DECL]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[NEXT_REG0]] : !smt.bv<8>
+// CHECK: dbg.variable "state_r", [[NEXT_REG1]] : !smt.bv<8>
+// CHECK: scf.yield {{%.+}}, [[NEXT_INPUT_DECL]], [[NEXT_REG0]], [[NEXT_REG1]], {{%.+}}, {{%.+}} : !smt.bv<1>, !smt.bv<8>, !smt.bv<8>, !smt.bv<8>, !smt.bv<1>, i1
+// CHECK-LABEL: func.func @test_bmc_debug_names_const_init() -> i1 {
+// CHECK: [[INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
+// CHECK: [[REG_CONST:%.+]] = smt.bv.constant #smt.bv<42> : !smt.bv<8>
+// CHECK: dbg.variable "data_in", [[INPUT_DECL]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[REG_CONST]] : !smt.bv<8>
+// CHECK: scf.for {{%.+}} iter_args([[CLK_ARG:%.+]] = {{%.+}}, [[INPUT_ARG:%.+]] = [[INPUT_DECL]], [[REG_ARG:%.+]] = [[REG_CONST]], {{%.+}})
+// CHECK: dbg.variable "data_in", [[INPUT_ARG]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[REG_ARG]] : !smt.bv<8>
+// CHECK: [[CIRCUIT_RESULT:%.+]] = func.call @bmc_circuit{{(_[0-9]+)?}}([[CLK_ARG]], [[INPUT_ARG]], [[REG_ARG]]) : (!smt.bv<1>, !smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+// CHECK: [[NEXT_INPUT_DECL:%.+]] = smt.declare_fun "data_in" : !smt.bv<8>
+// CHECK: [[NEXT_REG:%.+]] = smt.ite {{%.+}}, [[CIRCUIT_RESULT]], [[REG_ARG]] : !smt.bv<8>
+// CHECK: dbg.variable "data_in", [[NEXT_INPUT_DECL]] : !smt.bv<8>
+// CHECK: dbg.variable "state_q", [[NEXT_REG]] : !smt.bv<8>
 // CHECK: scf.yield {{%.+}}, [[NEXT_INPUT_DECL]], [[NEXT_REG]], {{%.+}} : !smt.bv<1>, !smt.bv<8>, !smt.bv<8>, i1
 
 func.func @test_bmc_debug_names() -> i1 {
   %bmc = verif.bmc bound 2 num_regs 1 initial_values [unit]
+  init {
+    %clk = seq.const_clock low
+    verif.yield %clk : !seq.clock
+  }
+  loop {
+  ^bb0(%clk: !seq.clock):
+    verif.yield %clk : !seq.clock
+  }
+  circuit {
+  ^bb0(%clk: !seq.clock, %arg0: i8, %state0: i8):
+    %scope = dbg.scope "Top", "Top"
+    dbg.variable "data_in", %arg0 scope %scope : i8
+    dbg.variable "state_q", %state0 scope %scope : i8
+    %true = hw.constant true
+    verif.assert %true : i1
+    verif.yield %arg0 : i8
+  }
+  func.return %bmc : i1
+}
+
+func.func @test_bmc_debug_names_extra_loop_state() -> i1 {
+  %bmc = verif.bmc bound 2 num_regs 2 initial_values [unit, 7 : i8]
+  init {
+    %clk = seq.const_clock low
+    %false = hw.constant false
+    verif.yield %clk, %false : !seq.clock, i1
+  }
+  loop {
+  ^bb0(%clk: !seq.clock, %shadow: i1):
+    %true = hw.constant true
+    %next_shadow = comb.xor %shadow, %true : i1
+    verif.yield %clk, %next_shadow : !seq.clock, i1
+  }
+  circuit {
+  ^bb0(%clk: !seq.clock, %arg0: i8, %state0: i8, %state1: i8):
+    %scope = dbg.scope "Top", "Top"
+    dbg.variable "data_in", %arg0 scope %scope : i8
+    dbg.variable "state_q", %state0 scope %scope : i8
+    dbg.variable "state_r", %state1 scope %scope : i8
+    %true = hw.constant true
+    verif.assert %true : i1
+    verif.yield %state0, %arg0 : i8, i8
+  }
+  func.return %bmc : i1
+}
+
+func.func @test_bmc_debug_names_const_init() -> i1 {
+  %bmc = verif.bmc bound 2 num_regs 1 initial_values [42 : i8]
   init {
     %clk = seq.const_clock low
     verif.yield %clk : !seq.clock


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

This keeps `dbg.variable` names alive in `verif.bmc` lowering to SMT.

Before this change, the BMC wrapper preserved the SMT behavior, but the debug names from the circuit block arguments were not reattached to the symbolic values created and threaded by the BMC loop. That made SMT-level debugging harder because values like inputs and registers lost their user-facing names outside the lowered circuit body.

Assisted-by: codex:gpt-5.4(medium)