### PR TITLE
[ImportVerilog][Moore] Add $fscanf/$sscanf and scan format support

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2917,6 +2917,7 @@ def ScanIntOp : MooreOp<"scan.int", [Pure]> {
     maxWidth limits the number of input characters consumed.
     When suppress is set, the value is consumed but not stored (%*
     modifier).
+    Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (b, o, d, h, x).
   }];
@@ -2926,9 +2927,9 @@ def ScanIntOp : MooreOp<"scan.int", [Pure]> {
     OptionalAttr<I32Attr>:$maxWidth,
     UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$remaining, AnyInteger:$value);
+  let results = (outs ScanStringType:$remaining, AnyInteger:$value, BitType:$matched);
   let assemblyFormat = [{
-    $input $format (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value)
+    $input $format (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
   }];
 }
 
@@ -2939,6 +2940,7 @@ def ScanRealOp : MooreOp<"scan.real", [Pure]> {
     maxWidth limits the number of input characters consumed.
     When suppress is set, the value is consumed but not stored (%*
     modifier).
+    Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (f, e, g).
   }];
@@ -2947,9 +2949,9 @@ def ScanRealOp : MooreOp<"scan.real", [Pure]> {
     OptionalAttr<I32Attr>:$maxWidth,
     UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$remaining, RealType:$value);
+  let results = (outs ScanStringType:$remaining, RealType:$value, BitType:$matched);
   let assemblyFormat = [{
-    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value)
+    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
   }];
 }
 
@@ -2961,6 +2963,7 @@ def ScanTimeOp : MooreOp<"scan.time", [Pure]> {
     maxWidth limits the number of input characters consumed.
     When suppress is set, the value is consumed but not stored (%*
     modifier).
+    Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (t).
   }];
@@ -2969,9 +2972,9 @@ def ScanTimeOp : MooreOp<"scan.time", [Pure]> {
     OptionalAttr<I32Attr>:$maxWidth,
     UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$remaining, TimeType:$value);
+  let results = (outs ScanStringType:$remaining, TimeType:$value, BitType:$matched);
   let assemblyFormat = [{
-    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value)
+    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
   }];
 }
 
@@ -2982,12 +2985,15 @@ def ScanCharOp : MooreOp<"scan.char", [Pure]> {
     Unlike other specifiers, leading whitespace is NOT skipped.
     When suppress is set, the value is consumed but not stored (%*
     modifier).
+    Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (c).
   }];
   let arguments = (ins ScanStringType:$input, UnitAttr:$suppress);
-  let results = (outs ScanStringType:$remaining, AnyInteger:$value);
-  let assemblyFormat = "$input (`suppress` $suppress^)? attr-dict `:` type($value)";
+  let results = (outs ScanStringType:$remaining, AnyInteger:$value, BitType:$matched);
+  let assemblyFormat = [{
+    $input (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
+  }];
 }
 
 def ScanStrOp : MooreOp<"scan.str", [Pure]> {
@@ -2998,6 +3004,7 @@ def ScanStrOp : MooreOp<"scan.str", [Pure]> {
     maxWidth limits the number of characters consumed.
     When suppress is set, the value is consumed but not stored (%*
     modifier).
+    Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (s).
   }];
@@ -3006,9 +3013,9 @@ def ScanStrOp : MooreOp<"scan.str", [Pure]> {
     OptionalAttr<I32Attr>:$maxWidth,
     UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$remaining, StringType:$value);
+  let results = (outs ScanStringType:$remaining, StringType:$value, BitType:$matched);
   let assemblyFormat = [{
-    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value)
+    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
   }];
 }
 
@@ -3020,6 +3027,7 @@ def ScanUnformattedOp : MooreOp<"scan.unformatted", [Pure]> {
     The fourValue attribute distinguishes the two.
     When suppress is set, the value is consumed but not stored (%*
     modifier).
+    Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (u, z).
   }];
@@ -3028,9 +3036,9 @@ def ScanUnformattedOp : MooreOp<"scan.unformatted", [Pure]> {
     UnitAttr:$fourValue,
     UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$remaining, AnyInteger:$value);
+  let results = (outs ScanStringType:$remaining, AnyInteger:$value, BitType:$matched);
   let assemblyFormat = [{
-    $input (`four_value` $fourValue^)? (`suppress` $suppress^)? attr-dict `:` type($value)
+    $input (`four_value` $fourValue^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
   }];
 }
 

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2857,6 +2857,45 @@ def FormatCharOp : MooreOp<"fmt.char", [Pure]> {
 // Scan String Operations
 //===----------------------------------------------------------------------===//
 
+def ScanBeginFScanFOp : MooreOp<"scan.begin_fscanf"> {
+  let summary = "Begin a $fscanf scan operation";
+  let description = [{
+    Opens a consuming scan chain that reads from the given channel.
+    The returned cursor is threaded through subsequent `moore.scan.*`
+    operations and closed with `moore.scan.end` to obtain the match count.
+
+    See IEEE 1800-2017 § 21.3.4.3 "Reading formatted data".
+  }];
+  let arguments = (ins TwoValuedI32:$channel);
+  let results = (outs ScanStringType:$cursor);
+  let assemblyFormat = "$channel attr-dict";
+}
+
+def ScanBeginSScanFOp : MooreOp<"scan.begin_sscanf"> {
+  let summary = "Begin a $sscanf scan operation";
+  let description = [{
+    Opens a consuming scan chain over the input `string`. The returned cursor
+    is threaded through subsequent `moore.scan.*` operations and closed with
+    `moore.scan.end` to obtain the match count.
+
+    See IEEE 1800-2017 § 21.3.4.3 "Reading formatted data".
+  }];
+  let arguments = (ins StringType:$string);
+  let results = (outs ScanStringType:$cursor);
+  let assemblyFormat = "$string attr-dict";
+}
+
+def ScanEndOp : MooreOp<"scan.end"> {
+  let summary = "Finalize a scan chain and return the match count";
+  let description = [{
+    Closes a consuming scan chain and returns the number of successfully
+    matched and assigned items. Returns -1 on EOF before the first match.
+  }];
+  let arguments = (ins ScanStringType:$cursor);
+  let results = (outs TwoValuedI32:$count);
+  let assemblyFormat = "$cursor attr-dict";
+}
+
 def ScanLiteralOp : MooreOp<"scan.literal", [Pure]> {
   let summary = "Match a literal string in the scan input";
   let description = [{
@@ -2865,9 +2904,9 @@ def ScanLiteralOp : MooreOp<"scan.literal", [Pure]> {
 
     See IEEE 1800-2017 § 21.3.4.3 "Reading formatted data".
   }];
-  let arguments = (ins StrAttr:$literal);
-  let results = (outs ScanStringType:$result);
-  let assemblyFormat = "$literal attr-dict";
+  let arguments = (ins ScanStringType:$input, StrAttr:$literal);
+  let results = (outs ScanStringType:$remaining);
+  let assemblyFormat = "$input $literal attr-dict";
 }
 
 def ScanIntOp : MooreOp<"scan.int", [Pure]> {
@@ -2875,40 +2914,42 @@ def ScanIntOp : MooreOp<"scan.int", [Pure]> {
   let description = [{
     Reads an integer according to the given format
     (binary, octal, decimal, or hexadecimal).
-    If dest is absent, assignment suppression (*) is active and the field
-    is consumed but not stored.
     maxWidth limits the number of input characters consumed.
+    When suppress is set, the value is consumed but not stored (%*
+    modifier).
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (b, o, d, h, x).
   }];
   let arguments = (ins
-    Optional<RefType>:$dest,
+    ScanStringType:$input,
     IntFormatAttr:$format,
-    OptionalAttr<I32Attr>:$maxWidth
+    OptionalAttr<I32Attr>:$maxWidth,
+    UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$result);
+  let results = (outs ScanStringType:$remaining, AnyInteger:$value);
   let assemblyFormat = [{
-    ($dest^ `:` type($dest))? $format (`width` $maxWidth^)? attr-dict
+    $input $format (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value)
   }];
 }
 
 def ScanRealOp : MooreOp<"scan.real", [Pure]> {
   let summary = "Scan a floating-point value from input";
   let description = [{
-    Reads a floating-point number (f, e, g specifiers) and writes it to dest.
-    If dest is absent, assignment suppression (*) is active and the field
-    is consumed but not stored.
+    Reads a floating-point number (f, e, g specifiers).
     maxWidth limits the number of input characters consumed.
+    When suppress is set, the value is consumed but not stored (%*
+    modifier).
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (f, e, g).
   }];
   let arguments = (ins
-    Optional<RefType>:$dest,
-    OptionalAttr<I32Attr>:$maxWidth
+    ScanStringType:$input,
+    OptionalAttr<I32Attr>:$maxWidth,
+    UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$result);
+  let results = (outs ScanStringType:$remaining, RealType:$value);
   let assemblyFormat = [{
-    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value)
   }];
 }
 
@@ -2917,19 +2958,20 @@ def ScanTimeOp : MooreOp<"scan.time", [Pure]> {
   let description = [{
     Reads a floating-point number and scales it according to the current
     timescale and $timeformat settings (%t specifier).
-    If dest is absent, assignment suppression (*) is active and the field
-    is consumed but not stored.
     maxWidth limits the number of input characters consumed.
+    When suppress is set, the value is consumed but not stored (%*
+    modifier).
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (t).
   }];
   let arguments = (ins
-    Optional<RefType>:$dest,
-    OptionalAttr<I32Attr>:$maxWidth
+    ScanStringType:$input,
+    OptionalAttr<I32Attr>:$maxWidth,
+    UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$result);
+  let results = (outs ScanStringType:$remaining, TimeType:$value);
   let assemblyFormat = [{
-    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value)
   }];
 }
 
@@ -2938,55 +2980,57 @@ def ScanCharOp : MooreOp<"scan.char", [Pure]> {
   let description = [{
     Reads a single 8-bit ASCII character from the input stream (%c specifier).
     Unlike other specifiers, leading whitespace is NOT skipped.
-    If dest is absent, assignment suppression (*) is active and the field
-    is consumed but not stored.
+    When suppress is set, the value is consumed but not stored (%*
+    modifier).
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (c).
   }];
-  let arguments = (ins Optional<RefType>:$dest);
-  let results = (outs ScanStringType:$result);
-  let assemblyFormat = "($dest^ `:` type($dest))? attr-dict";
+  let arguments = (ins ScanStringType:$input, UnitAttr:$suppress);
+  let results = (outs ScanStringType:$remaining, AnyInteger:$value);
+  let assemblyFormat = "$input (`suppress` $suppress^)? attr-dict `:` type($value)";
 }
 
 def ScanStrOp : MooreOp<"scan.str", [Pure]> {
   let summary = "Scan a whitespace-delimited string from input";
   let description = [{
-    Reads a sequence of non-whitespace characters (%s specifier) and writes
-    the result to dest.
-    If dest is absent, assignment suppression (*) is active and the field
-    is consumed but not stored.
+    Reads a sequence of non-whitespace characters (%s specifier) and write
+    it to value.
     maxWidth limits the number of characters consumed.
+    When suppress is set, the value is consumed but not stored (%*
+    modifier).
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (s).
   }];
   let arguments = (ins
-    Optional<RefType>:$dest,
-    OptionalAttr<I32Attr>:$maxWidth
+    ScanStringType:$input,
+    OptionalAttr<I32Attr>:$maxWidth,
+    UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$result);
+  let results = (outs ScanStringType:$remaining, StringType:$value);
   let assemblyFormat = [{
-    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value)
   }];
 }
 
 def ScanUnformattedOp : MooreOp<"scan.unformatted", [Pure]> {
   let summary = "Scan unformatted binary data from input";
   let description = [{
-    Reads raw binary data from the input stream into dest.
+    Reads raw binary data from the input stream.
     %u reads 2-value binary data; %z reads 4-value (x/z-preserving) data.
     The fourValue attribute distinguishes the two.
-    If dest is absent, assignment suppression (*) is active and the field
-    is consumed but not stored.
+    When suppress is set, the value is consumed but not stored (%*
+    modifier).
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (u, z).
   }];
   let arguments = (ins
-    Optional<RefType>:$dest,
-    UnitAttr:$fourValue
+    ScanStringType:$input,
+    UnitAttr:$fourValue,
+    UnitAttr:$suppress
   );
-  let results = (outs ScanStringType:$result);
+  let results = (outs ScanStringType:$remaining, AnyInteger:$value);
   let assemblyFormat = [{
-    ($dest^ `:` type($dest))? (`four_value` $fourValue^)? attr-dict
+    $input (`four_value` $fourValue^)? (`suppress` $suppress^)? attr-dict `:` type($value)
   }];
 }
 
@@ -2999,19 +3043,9 @@ def ScanHierPathMatchOp : MooreOp<"scan.hier_path_match", [Pure]> {
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (m).
   }];
-  let results = (outs ScanStringType:$result);
-  let assemblyFormat = "attr-dict";
-}
-
-def ScanConcatOp : MooreOp<"scan.concat", [Pure]> {
-  let summary = "Concatenate scan format fragments";
-  let description = [{
-    Combines multiple scan format fragments into a single scan format
-    directive. Fragments are applied left to right against the input stream.
-  }];
-  let arguments = (ins Variadic<ScanStringType>:$inputs);
-  let results = (outs ScanStringType:$result);
-  let assemblyFormat = "` ` `(` $inputs `)` attr-dict";
+  let arguments = (ins ScanStringType:$input);
+  let results = (outs ScanStringType:$remaining);
+  let assemblyFormat = "$input attr-dict";
 }
 
 //===----------------------------------------------------------------------===//
@@ -3319,35 +3353,6 @@ def FDisplayBIOp : Builtin<"fdisplay"> {
   }];
   let arguments = (ins TwoValuedI32:$fd, FormatStringType:$message);
   let assemblyFormat = "$fd `,` $message attr-dict";
-}
-
-def FScanFBIOp : Builtin<"fscanf"> {
-  let summary = "Read formatted data from a file";
-  let description = [{
-    Reads characters from the file specified by fd, interprets them according
-    to the scan format, and stores the results in the destination lvalues
-    embedded in the format. Returns the number of successfully matched and
-    assigned items, or EOF (-1) on end of file before any match.
-
-    See IEEE 1800-2017 § 21.3.4 "Reading data from a file".
-  }];
-  let arguments = (ins TwoValuedI32:$fd, ScanStringType:$format);
-  let results = (outs TwoValuedI32:$count);
-  let assemblyFormat = "$fd $format attr-dict";
-}
-
-def SScanFBIOp : Builtin<"sscanf"> {
-  let summary = "Read formatted data from a string";
-  let description = [{
-    Reads characters from str, interprets them according to the scan format,
-    and stores the results in the destination lvalues embedded in the format.
-    Returns the number of successfully matched and assigned items, or EOF (-1).
-
-    See IEEE 1800-2017 § 21.3.4 "Reading data from a file".
-  }];
-  let arguments = (ins StringType:$str, ScanStringType:$format);
-  let results = (outs TwoValuedI32:$count);
-  let assemblyFormat = "$str $format attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2909,14 +2909,14 @@ def ScanLiteralOp : MooreOp<"scan.literal", [Pure]> {
   let assemblyFormat = "$input $literal attr-dict";
 }
 
-def ScanIntOp : MooreOp<"scan.int", [Pure]> {
+def ScanIntOp : MooreOp<"scan.int", [Pure, SameVariadicResultSize]> {
   let summary = "Scan an integer value from input";
   let description = [{
     Reads an integer according to the given format
     (binary, octal, decimal, or hexadecimal).
     maxWidth limits the number of input characters consumed.
-    When suppress is set, the value is consumed but not stored (%*
-    modifier).
+    If the value/matched results are omitted, the field is consumed but
+    not stored (%* modifier).
     Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (b, o, d, h, x).
@@ -2924,121 +2924,140 @@ def ScanIntOp : MooreOp<"scan.int", [Pure]> {
   let arguments = (ins
     ScanStringType:$input,
     IntFormatAttr:$format,
-    OptionalAttr<I32Attr>:$maxWidth,
-    UnitAttr:$suppress
+    OptionalAttr<I32Attr>:$maxWidth
   );
-  let results = (outs ScanStringType:$remaining, AnyInteger:$value, BitType:$matched);
+  let results = (outs
+    ScanStringType:$remaining,
+    Optional<AnyInteger>:$value,
+    Optional<BitType>:$matched
+  );
   let assemblyFormat = [{
-    $input $format (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
+    $input $format (`width` $maxWidth^)? attr-dict (`:` type($value)^ `,` type($matched))?
   }];
 }
 
-def ScanRealOp : MooreOp<"scan.real", [Pure]> {
+def ScanRealOp : MooreOp<"scan.real", [Pure, SameVariadicResultSize]> {
   let summary = "Scan a floating-point value from input";
   let description = [{
     Reads a floating-point number (f, e, g specifiers).
     maxWidth limits the number of input characters consumed.
-    When suppress is set, the value is consumed but not stored (%*
-    modifier).
+    If the value/matched results are omitted, the field is consumed but
+    not stored (%* modifier).
     Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (f, e, g).
   }];
   let arguments = (ins
     ScanStringType:$input,
-    OptionalAttr<I32Attr>:$maxWidth,
-    UnitAttr:$suppress
+    OptionalAttr<I32Attr>:$maxWidth
   );
-  let results = (outs ScanStringType:$remaining, RealType:$value, BitType:$matched);
+  let results = (outs
+    ScanStringType:$remaining,
+    Optional<RealType>:$value,
+    Optional<BitType>:$matched
+);
   let assemblyFormat = [{
-    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
+    $input (`width` $maxWidth^)? attr-dict (`:` type($value)^ `,` type($matched))?
   }];
 }
 
-def ScanTimeOp : MooreOp<"scan.time", [Pure]> {
+def ScanTimeOp : MooreOp<"scan.time", [Pure, SameVariadicResultSize]> {
   let summary = "Scan a timescale-adjusted floating-point value from input";
   let description = [{
     Reads a floating-point number and scales it according to the current
     timescale and $timeformat settings (%t specifier).
     maxWidth limits the number of input characters consumed.
-    When suppress is set, the value is consumed but not stored (%*
-    modifier).
+    If the value/matched results are omitted, the field is consumed but
+    not stored (%* modifier).
     Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (t).
   }];
   let arguments = (ins
     ScanStringType:$input,
-    OptionalAttr<I32Attr>:$maxWidth,
-    UnitAttr:$suppress
+    OptionalAttr<I32Attr>:$maxWidth
   );
-  let results = (outs ScanStringType:$remaining, TimeType:$value, BitType:$matched);
+  let results = (outs
+    ScanStringType:$remaining,
+    Optional<TimeType>:$value,
+    Optional<BitType>:$matched
+  );
   let assemblyFormat = [{
-    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
+    $input (`width` $maxWidth^)? attr-dict (`:` type($value)^ `,` type($matched))?
   }];
 }
 
-def ScanCharOp : MooreOp<"scan.char", [Pure]> {
+def ScanCharOp : MooreOp<"scan.char", [Pure, SameVariadicResultSize]> {
   let summary = "Scan a single character from input";
   let description = [{
     Reads a single 8-bit ASCII character from the input stream (%c specifier).
     Unlike other specifiers, leading whitespace is NOT skipped.
-    When suppress is set, the value is consumed but not stored (%*
-    modifier).
+    If the value/matched results are omitted, the field is consumed but
+    not stored (%* modifier).
     Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (c).
   }];
-  let arguments = (ins ScanStringType:$input, UnitAttr:$suppress);
-  let results = (outs ScanStringType:$remaining, AnyInteger:$value, BitType:$matched);
+  let arguments = (ins ScanStringType:$input);
+  let results = (outs
+    ScanStringType:$remaining,
+    Optional<AnyInteger>:$value,
+    Optional<BitType>:$matched
+  );
   let assemblyFormat = [{
-    $input (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
+    $input attr-dict (`:` type($value)^ `,` type($matched))?
   }];
 }
 
-def ScanStrOp : MooreOp<"scan.str", [Pure]> {
+def ScanStrOp : MooreOp<"scan.str", [Pure, SameVariadicResultSize]> {
   let summary = "Scan a whitespace-delimited string from input";
   let description = [{
     Reads a sequence of non-whitespace characters (%s specifier) and write
     it to value.
     maxWidth limits the number of characters consumed.
-    When suppress is set, the value is consumed but not stored (%*
-    modifier).
+    If the value/matched results are omitted, the field is consumed but
+    not stored (%* modifier).
     Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (s).
   }];
   let arguments = (ins
     ScanStringType:$input,
-    OptionalAttr<I32Attr>:$maxWidth,
-    UnitAttr:$suppress
+    OptionalAttr<I32Attr>:$maxWidth
   );
-  let results = (outs ScanStringType:$remaining, StringType:$value, BitType:$matched);
+  let results = (outs
+    ScanStringType:$remaining,
+    Optional<StringType>:$value,
+    Optional<BitType>:$matched
+  );
   let assemblyFormat = [{
-    $input (`width` $maxWidth^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
+    $input (`width` $maxWidth^)? attr-dict (`:` type($value)^ `,` type($matched))?
   }];
 }
 
-def ScanUnformattedOp : MooreOp<"scan.unformatted", [Pure]> {
+def ScanUnformattedOp : MooreOp<"scan.unformatted", [Pure, SameVariadicResultSize]> {
   let summary = "Scan unformatted binary data from input";
   let description = [{
     Reads raw binary data from the input stream.
     %u reads 2-value binary data; %z reads 4-value (x/z-preserving) data.
     The fourValue attribute distinguishes the two.
-    When suppress is set, the value is consumed but not stored (%*
-    modifier).
+    If the value/matched results are omitted, the field is consumed but
+    not stored (%* modifier).
     Matched indicates whether a value was successfully scanned.
 
     See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (u, z).
   }];
   let arguments = (ins
     ScanStringType:$input,
-    UnitAttr:$fourValue,
-    UnitAttr:$suppress
+    UnitAttr:$fourValue
   );
-  let results = (outs ScanStringType:$remaining, AnyInteger:$value, BitType:$matched);
+  let results = (outs
+    ScanStringType:$remaining,
+    Optional<AnyInteger>:$value,
+    Optional<BitType>:$matched
+  );
   let assemblyFormat = [{
-    $input (`four_value` $fourValue^)? (`suppress` $suppress^)? attr-dict `:` type($value) `,` type($matched)
+    $input (`four_value` $fourValue^)? attr-dict (`:` type($value)^ `,` type($matched))?
   }];
 }
 

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2854,6 +2854,167 @@ def FormatCharOp : MooreOp<"fmt.char", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Scan String Operations
+//===----------------------------------------------------------------------===//
+
+def ScanLiteralOp : MooreOp<"scan.literal", [Pure]> {
+  let summary = "Match a literal string in the scan input";
+  let description = [{
+    Matches the given literal text. If the input does not match, the scan
+    operation fails and no input is consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3 "Reading formatted data".
+  }];
+  let arguments = (ins StrAttr:$literal);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "$literal attr-dict";
+}
+
+def ScanIntOp : MooreOp<"scan.int", [Pure]> {
+  let summary = "Scan an integer value from input";
+  let description = [{
+    Reads an integer according to the given format
+    (binary, octal, decimal, or hexadecimal).
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+    maxWidth limits the number of input characters consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (b, o, d, h, x).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    IntFormatAttr:$format,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? $format (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanRealOp : MooreOp<"scan.real", [Pure]> {
+  let summary = "Scan a floating-point value from input";
+  let description = [{
+    Reads a floating-point number (f, e, g specifiers) and writes it to dest.
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+    maxWidth limits the number of input characters consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (f, e, g).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanTimeOp : MooreOp<"scan.time", [Pure]> {
+  let summary = "Scan a timescale-adjusted floating-point value from input";
+  let description = [{
+    Reads a floating-point number and scales it according to the current
+    timescale and $timeformat settings (%t specifier).
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+    maxWidth limits the number of input characters consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (t).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanCharOp : MooreOp<"scan.char", [Pure]> {
+  let summary = "Scan a single character from input";
+  let description = [{
+    Reads a single 8-bit ASCII character from the input stream (%c specifier).
+    Unlike other specifiers, leading whitespace is NOT skipped.
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (c).
+  }];
+  let arguments = (ins Optional<RefType>:$dest);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "($dest^ `:` type($dest))? attr-dict";
+}
+
+def ScanStrOp : MooreOp<"scan.str", [Pure]> {
+  let summary = "Scan a whitespace-delimited string from input";
+  let description = [{
+    Reads a sequence of non-whitespace characters (%s specifier) and writes
+    the result to dest.
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+    maxWidth limits the number of characters consumed.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (s).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    OptionalAttr<I32Attr>:$maxWidth
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`width` $maxWidth^)? attr-dict
+  }];
+}
+
+def ScanUnformattedOp : MooreOp<"scan.unformatted", [Pure]> {
+  let summary = "Scan unformatted binary data from input";
+  let description = [{
+    Reads raw binary data from the input stream into dest.
+    %u reads 2-value binary data; %z reads 4-value (x/z-preserving) data.
+    The fourValue attribute distinguishes the two.
+    If dest is absent, assignment suppression (*) is active and the field
+    is consumed but not stored.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (u, z).
+  }];
+  let arguments = (ins
+    Optional<RefType>:$dest,
+    UnitAttr:$fourValue
+  );
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = [{
+    ($dest^ `:` type($dest))? (`four_value` $fourValue^)? attr-dict
+  }];
+}
+
+def ScanHierPathMatchOp : MooreOp<"scan.hier_path_match", [Pure]> {
+  let summary = "Match the current hierarchical path in the scan input";
+  let description = [{
+    Matches the current hierarchical scope path in the input stream (%m
+    specifier). Does not consume a destination argument and does not
+    store any value.
+
+    See IEEE 1800-2017 § 21.3.4.3, Table 21-8 (m).
+  }];
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def ScanConcatOp : MooreOp<"scan.concat", [Pure]> {
+  let summary = "Concatenate scan format fragments";
+  let description = [{
+    Combines multiple scan format fragments into a single scan format
+    directive. Fragments are applied left to right against the input stream.
+  }];
+  let arguments = (ins Variadic<ScanStringType>:$inputs);
+  let results = (outs ScanStringType:$result);
+  let assemblyFormat = "` ` `(` $inputs `)` attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // Builtin System Tasks and Functions
 //===----------------------------------------------------------------------===//
 
@@ -3158,6 +3319,35 @@ def FDisplayBIOp : Builtin<"fdisplay"> {
   }];
   let arguments = (ins TwoValuedI32:$fd, FormatStringType:$message);
   let assemblyFormat = "$fd `,` $message attr-dict";
+}
+
+def FScanFBIOp : Builtin<"fscanf"> {
+  let summary = "Read formatted data from a file";
+  let description = [{
+    Reads characters from the file specified by fd, interprets them according
+    to the scan format, and stores the results in the destination lvalues
+    embedded in the format. Returns the number of successfully matched and
+    assigned items, or EOF (-1) on end of file before any match.
+
+    See IEEE 1800-2017 § 21.3.4 "Reading data from a file".
+  }];
+  let arguments = (ins TwoValuedI32:$fd, ScanStringType:$format);
+  let results = (outs TwoValuedI32:$count);
+  let assemblyFormat = "$fd $format attr-dict";
+}
+
+def SScanFBIOp : Builtin<"sscanf"> {
+  let summary = "Read formatted data from a string";
+  let description = [{
+    Reads characters from str, interprets them according to the scan format,
+    and stores the results in the destination lvalues embedded in the format.
+    Returns the number of successfully matched and assigned items, or EOF (-1).
+
+    See IEEE 1800-2017 § 21.3.4 "Reading data from a file".
+  }];
+  let arguments = (ins StringType:$str, ScanStringType:$format);
+  let results = (outs TwoValuedI32:$count);
+  let assemblyFormat = "$str $format attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -455,6 +455,19 @@ def FormatStringType : MooreTypeDef<"FormatString"> {
   }];
 }
 
+def ScanStringType : MooreTypeDef<"ScanString"> {
+  let mnemonic = "scan_string";
+  let summary = "a scan format string type";
+  let description = [{
+    Represents a parsed scan format directive specifying how to read values
+    from an input string or file. Each fragment captures a format specifier
+    and, for non-suppressed assignments, the destination lvalue reference
+    where the parsed value will be stored.
+
+    See IEEE 1800-2017 § 21.3.4.3 "Reading formatted data".
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Constraints
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -457,12 +457,14 @@ def FormatStringType : MooreTypeDef<"FormatString"> {
 
 def ScanStringType : MooreTypeDef<"ScanString"> {
   let mnemonic = "scan_string";
-  let summary = "a scan format string type";
+  let summary = "a scan cursor type";
   let description = [{
-    Represents a parsed scan format directive specifying how to read values
-    from an input string or file. Each fragment captures a format specifier
-    and, for non-suppressed assignments, the destination lvalue reference
-    where the parsed value will be stored.
+    Represents the state of an in-progress scan operation: the remaining
+    text to be consumed and the accumulated match/failure state. Each
+    `moore.scan.*` operation takes a cursor as input, attempts to consume
+    the front of the remaining text, and forwards either a new cursor
+    (with the matched prefix removed) or a failure sentinel to the next
+    operation in the chain.
 
     See IEEE 1800-2017 § 21.3.4.3 "Reading formatted data".
   }];

--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_translation_library(CIRCTImportVerilog
   CaptureAnalysis.cpp
   Expressions.cpp
   FormatStrings.cpp
+  ScanStrings.cpp
   HierarchicalNames.cpp
   ImportVerilog.cpp
   Statements.cpp

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3869,14 +3869,20 @@ Value Context::convertSystemCall(
       return (mlir::emitError(loc)
               << "$fscanf requires a string literal format string"),
              Value{};
-    auto scanFmt = convertScanString(fmtLit->getValue(), args.subspan(2), loc);
-    if (failed(scanFmt))
+    auto cursor =
+        moore::ScanBeginFScanFOp::create(builder, loc, fd).getCursor();
+    auto result =
+        convertScanString(fmtLit->getValue(), cursor, args.subspan(2), loc);
+    if (failed(result))
       return {};
-    if (!*scanFmt) {
-      auto i32Ty = moore::IntType::getInt(builder.getContext(), 32);
-      return moore::ConstantOp::create(builder, loc, i32Ty, 0);
+    for (auto [destExpr, value] : result->assignments) {
+      auto lhs = convertLvalueExpression(*destExpr);
+      if (!lhs)
+        return {};
+      moore::BlockingAssignOp::create(builder, loc, lhs, value);
     }
-    return moore::FScanFBIOp::create(builder, loc, fd, *scanFmt);
+    return moore::ScanEndOp::create(builder, loc, result->finalCursor)
+        .getCount();
   }
 
   if (nameId == ksn::SScanf) {
@@ -3890,14 +3896,20 @@ Value Context::convertSystemCall(
       return (mlir::emitError(loc)
               << "$sscanf requires a string literal format string"),
              Value{};
-    auto scanFmt = convertScanString(fmtLit->getValue(), args.subspan(2), loc);
-    if (failed(scanFmt))
+    auto cursor =
+        moore::ScanBeginSScanFOp::create(builder, loc, str).getCursor();
+    auto result =
+        convertScanString(fmtLit->getValue(), cursor, args.subspan(2), loc);
+    if (failed(result))
       return {};
-    if (!*scanFmt) {
-      auto i32Ty = moore::IntType::getInt(builder.getContext(), 32);
-      return moore::ConstantOp::create(builder, loc, i32Ty, 0);
+    for (auto [destExpr, value] : result->assignments) {
+      auto lhs = convertLvalueExpression(*destExpr);
+      if (!lhs)
+        return {};
+      moore::BlockingAssignOp::create(builder, loc, lhs, value);
     }
-    return moore::SScanFBIOp::create(builder, loc, str, *scanFmt);
+    return moore::ScanEndOp::create(builder, loc, result->finalCursor)
+        .getCount();
   }
 
   // Unrecognized system call

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3858,6 +3858,48 @@ Value Context::convertSystemCall(
     return op.getFound();
   }
 
+  if (nameId == ksn::FScanf) {
+    auto fd = convertRvalueExpression(
+        *args[0], moore::IntType::getInt(builder.getContext(), 32));
+    if (!fd)
+      return {};
+    auto *fmtLit =
+        args[1]->unwrapImplicitConversions().as_if<slang::ast::StringLiteral>();
+    if (!fmtLit)
+      return (mlir::emitError(loc)
+              << "$fscanf requires a string literal format string"),
+             Value{};
+    auto scanFmt = convertScanString(fmtLit->getValue(), args.subspan(2), loc);
+    if (failed(scanFmt))
+      return {};
+    if (!*scanFmt) {
+      auto i32Ty = moore::IntType::getInt(builder.getContext(), 32);
+      return moore::ConstantOp::create(builder, loc, i32Ty, 0);
+    }
+    return moore::FScanFBIOp::create(builder, loc, fd, *scanFmt);
+  }
+
+  if (nameId == ksn::SScanf) {
+    auto str =
+        convertRvalueExpression(*args[0], moore::StringType::get(getContext()));
+    if (!str)
+      return {};
+    auto *fmtLit =
+        args[1]->unwrapImplicitConversions().as_if<slang::ast::StringLiteral>();
+    if (!fmtLit)
+      return (mlir::emitError(loc)
+              << "$sscanf requires a string literal format string"),
+             Value{};
+    auto scanFmt = convertScanString(fmtLit->getValue(), args.subspan(2), loc);
+    if (failed(scanFmt))
+      return {};
+    if (!*scanFmt) {
+      auto i32Ty = moore::IntType::getInt(builder.getContext(), 32);
+      return moore::ConstantOp::create(builder, loc, i32Ty, 0);
+    }
+    return moore::SScanFBIOp::create(builder, loc, str, *scanFmt);
+  }
+
   // Unrecognized system call
   emitError(loc) << "unsupported system call `" << name << "`";
   return {};

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3252,24 +3252,28 @@ static LogicalResult
 emitScanAssignments(Context &context, const Context::ScanStringResult &result,
                     Location loc) {
   auto &builder = context.builder;
+  auto newBlockAfter = [&](Block *after) -> Block * {
+    auto block = std::make_unique<Block>();
+    block->insertAfter(after);
+    return block.release();
+  };
+
   for (auto [destExpr, value, matched] : result.assignments) {
     auto lhs = context.convertLvalueExpression(*destExpr);
     if (!lhs)
       return failure();
-    auto refType = dyn_cast<moore::RefType>(lhs.getType());
-    if (!refType)
-      return mlir::emitError(loc) << "scan destination is not an lvalue";
-    auto destType = refType.getNestedType();
-    auto sel = moore::ConditionalOp::create(builder, loc, destType, matched);
-    {
-      OpBuilder::InsertionGuard g(builder);
-      builder.setInsertionPointToStart(&sel.getTrueRegion().emplaceBlock());
-      moore::YieldOp::create(builder, loc, value);
-      builder.setInsertionPointToStart(&sel.getFalseRegion().emplaceBlock());
-      moore::YieldOp::create(builder, loc,
-                             moore::ReadOp::create(builder, loc, lhs));
-    }
-    moore::BlockingAssignOp::create(builder, loc, lhs, sel.getResult());
+    auto cond = moore::ToBuiltinIntOp::create(builder, loc, matched);
+
+    auto *assignBlock = newBlockAfter(builder.getInsertionBlock());
+    auto *continuedBlock = newBlockAfter(assignBlock);
+    mlir::cf::CondBranchOp::create(builder, loc, cond, assignBlock,
+                                   continuedBlock);
+
+    builder.setInsertionPointToEnd(assignBlock);
+    moore::BlockingAssignOp::create(builder, loc, lhs, value);
+    mlir::cf::BranchOp::create(builder, loc, continuedBlock);
+
+    builder.setInsertionPointToEnd(continuedBlock);
   }
   return success();
 }

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3248,6 +3248,32 @@ convertRealMathBI(Context &context, Location loc, StringRef name,
   return OpTy::create(context.builder, loc, value);
 }
 
+static LogicalResult
+emitScanAssignments(Context &context, const Context::ScanStringResult &result,
+                    Location loc) {
+  auto &builder = context.builder;
+  for (auto [destExpr, value, matched] : result.assignments) {
+    auto lhs = context.convertLvalueExpression(*destExpr);
+    if (!lhs)
+      return failure();
+    auto refType = dyn_cast<moore::RefType>(lhs.getType());
+    if (!refType)
+      return mlir::emitError(loc) << "scan destination is not an lvalue";
+    auto destType = refType.getNestedType();
+    auto sel = moore::ConditionalOp::create(builder, loc, destType, matched);
+    {
+      OpBuilder::InsertionGuard g(builder);
+      builder.setInsertionPointToStart(&sel.getTrueRegion().emplaceBlock());
+      moore::YieldOp::create(builder, loc, value);
+      builder.setInsertionPointToStart(&sel.getFalseRegion().emplaceBlock());
+      moore::YieldOp::create(builder, loc,
+                             moore::ReadOp::create(builder, loc, lhs));
+    }
+    moore::BlockingAssignOp::create(builder, loc, lhs, sel.getResult());
+  }
+  return success();
+}
+
 Value Context::convertSystemCall(
     const slang::ast::SystemSubroutine &subroutine, Location loc,
     std::span<const slang::ast::Expression *const> args) {
@@ -3875,12 +3901,8 @@ Value Context::convertSystemCall(
         convertScanString(fmtLit->getValue(), cursor, args.subspan(2), loc);
     if (failed(result))
       return {};
-    for (auto [destExpr, value] : result->assignments) {
-      auto lhs = convertLvalueExpression(*destExpr);
-      if (!lhs)
-        return {};
-      moore::BlockingAssignOp::create(builder, loc, lhs, value);
-    }
+    if (failed(emitScanAssignments(*this, *result, loc)))
+      return {};
     return moore::ScanEndOp::create(builder, loc, result->finalCursor)
         .getCount();
   }
@@ -3902,12 +3924,8 @@ Value Context::convertSystemCall(
         convertScanString(fmtLit->getValue(), cursor, args.subspan(2), loc);
     if (failed(result))
       return {};
-    for (auto [destExpr, value] : result->assignments) {
-      auto lhs = convertLvalueExpression(*destExpr);
-      if (!lhs)
-        return {};
-      moore::BlockingAssignOp::create(builder, loc, lhs, value);
-    }
+    if (failed(emitScanAssignments(*this, *result, loc)))
+      return {};
     return moore::ScanEndOp::create(builder, loc, result->finalCursor)
         .getCount();
   }

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -413,11 +413,12 @@ struct Context {
       bool appendNewline = false);
 
   /// Result of converting a scan format string. The final cursor of the
-  /// consuming chain and the list of (destination expression, scanned value)
-  /// pairs to assign
+  /// consuming chain and the list of (destination expression, scanned value,
+  /// matched flag) tuples to assign
   struct ScanStringResult {
     Value finalCursor;
-    SmallVector<std::pair<const slang::ast::Expression *, Value>> assignments;
+    SmallVector<std::tuple<const slang::ast::Expression *, Value, Value>>
+        assignments;
   };
 
   /// Convert a scan format string into a consuming chain of `moore.scan.*`

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -412,6 +412,15 @@ struct Context {
       moore::IntFormat defaultFormat = moore::IntFormat::Decimal,
       bool appendNewline = false);
 
+  /// Convert a scan format string literal with format specifiers and
+  /// destination lvalue expressions into a `!moore.scan_string` value.
+  /// Returns failure if an error occurs. Returns a null value if the format
+  /// string is trivially empty. Otherwise returns the scan format string.
+  FailureOr<Value>
+  convertScanString(StringRef formatStr,
+                    std::span<const slang::ast::Expression *const> destinations,
+                    Location loc);
+
   /// Convert system function calls. Returns a null `Value` on failure after
   /// emitting an error.
   Value convertSystemCall(const slang::ast::SystemSubroutine &subroutine,

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -412,12 +412,21 @@ struct Context {
       moore::IntFormat defaultFormat = moore::IntFormat::Decimal,
       bool appendNewline = false);
 
-  /// Convert a scan format string literal with format specifiers and
-  /// destination lvalue expressions into a `!moore.scan_string` value.
-  /// Returns failure if an error occurs. Returns a null value if the format
-  /// string is trivially empty. Otherwise returns the scan format string.
-  FailureOr<Value>
-  convertScanString(StringRef formatStr,
+  /// Result of converting a scan format string. The final cursor of the
+  /// consuming chain and the list of (destination expression, scanned value)
+  /// pairs to assign
+  struct ScanStringResult {
+    Value finalCursor;
+    SmallVector<std::pair<const slang::ast::Expression *, Value>> assignments;
+  };
+
+  /// Convert a scan format string into a consuming chain of `moore.scan.*`
+  /// operations starting from `initialCursor`. Each non-suppressed specifier
+  /// produces an entry in `assignments`; the caller is responsible for emitting
+  /// the corresponding `moore.blocking_assign` ops. Returns failur if an erro
+  /// occurs.
+  FailureOr<ScanStringResult>
+  convertScanString(StringRef formatStr, Value initialCursor,
                     std::span<const slang::ast::Expression *const> destinations,
                     Location loc);
 

--- a/lib/Conversion/ImportVerilog/ScanStrings.cpp
+++ b/lib/Conversion/ImportVerilog/ScanStrings.cpp
@@ -102,9 +102,10 @@ struct ScanStringParser {
   Location loc;
   /// The current tail of the consuming chain.
   Value cursor;
-  /// Accumulated (unwrapped destination expression, scanned value) pairs to be
-  /// assigned with a moore.blocking_assign by the caller.
-  SmallVector<std::pair<const slang::ast::Expression *, Value>> assignments;
+  /// Accumulated (unwrapped destination expression, scanned value, matched)
+  /// tuples to be assigned with a moore.blocking_assign by the caller.
+  SmallVector<std::tuple<const slang::ast::Expression *, Value, Value>>
+      assignments;
 
   ScanStringParser(Context &context, Value initialCursor,
                    ArrayRef<const slang::ast::Expression *> destinations,
@@ -112,8 +113,8 @@ struct ScanStringParser {
       : context(context), builder(context.builder), destinations(destinations),
         loc(loc), cursor(initialCursor) {}
 
-  /// Thread the consuming chain and collect (destination, value) assignments
-  /// pairs.
+  /// Thread the consuming chain and collect (destination, value, matched)
+  /// assignments tuples.
   FailureOr<Context::ScanStringResult> parse(StringRef formatStr) {
     bool anyFailure = false;
 
@@ -247,8 +248,10 @@ struct ScanStringParser {
     }
 
     auto scanStringTy = moore::ScanStringType::get(builder.getContext());
-    auto op = moore::ScanIntOp::create(builder, loc, scanStringTy, mlirIntTy,
-                                       cursor, format, maxWidth, suppress);
+    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
+    auto op =
+        moore::ScanIntOp::create(builder, loc, scanStringTy, mlirIntTy,
+                                 matchedTy, cursor, format, maxWidth, suppress);
     cursor = op.getRemaining();
     if (!suppress) {
       auto mooreVal =
@@ -258,7 +261,7 @@ struct ScanStringParser {
         mooreVal =
             moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
                 .getResult();
-      assignments.push_back({destExpr, mooreVal});
+      assignments.push_back({destExpr, mooreVal, op.getMatched()});
     }
     return success();
   }
@@ -270,11 +273,12 @@ struct ScanStringParser {
                             : llvm::dyn_cast<moore::RealType>(
                                   context.convertType(*destExpr->type));
     auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
     auto op = moore::ScanRealOp::create(builder, loc, scanStringTy, valueTy,
-                                        cursor, maxWidth, suppress);
+                                        matchedTy, cursor, maxWidth, suppress);
     cursor = op.getRemaining();
     if (!suppress)
-      assignments.push_back({destExpr, op.getValue()});
+      assignments.push_back({destExpr, op.getValue(), op.getMatched()});
     return success();
   }
 
@@ -284,7 +288,7 @@ struct ScanStringParser {
         moore::ScanTimeOp::create(builder, loc, cursor, maxWidth, suppress);
     cursor = op.getRemaining();
     if (!suppress)
-      assignments.push_back({destExpr, op.getValue()});
+      assignments.push_back({destExpr, op.getValue(), op.getMatched()});
     return success();
   }
 
@@ -301,8 +305,9 @@ struct ScanStringParser {
       mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
     }
     auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
     auto op = moore::ScanCharOp::create(builder, loc, scanStringTy, mlirIntTy,
-                                        cursor, suppress);
+                                        matchedTy, cursor, suppress);
     cursor = op.getRemaining();
     if (!suppress) {
       auto mooreVal =
@@ -312,7 +317,7 @@ struct ScanStringParser {
         mooreVal =
             moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
                 .getResult();
-      assignments.push_back({destExpr, mooreVal});
+      assignments.push_back({destExpr, mooreVal, op.getMatched()});
     }
     return success();
   }
@@ -322,8 +327,23 @@ struct ScanStringParser {
     auto op =
         moore::ScanStrOp::create(builder, loc, cursor, maxWidth, suppress);
     cursor = op.getRemaining();
-    if (!suppress)
-      assignments.push_back({destExpr, op.getValue()});
+    if (!suppress) {
+      Value val = op.getValue();
+      auto destTy = context.convertType(*destExpr->type);
+      if (auto intTy = llvm::dyn_cast<moore::IntType>(destTy)) {
+        val = moore::StringToIntOp::create(builder, loc, intTy.getTwoValued(),
+                                           val)
+                  .getResult();
+        if (intTy.getDomain() == moore::Domain::FourValued)
+          val =
+              moore::IntToLogicOp::create(builder, loc, intTy, val).getResult();
+      } else if (!llvm::isa<moore::StringType>(destTy)) {
+        return mlir::emitError(loc)
+               << "destination of string scan specifier must be a string or "
+                  "integer";
+      }
+      assignments.push_back({destExpr, val, op.getMatched()});
+    }
     return success();
   }
 
@@ -341,8 +361,10 @@ struct ScanStringParser {
     }
 
     auto scanStringTy = moore::ScanStringType::get(builder.getContext());
-    auto op = moore::ScanUnformattedOp::create(
-        builder, loc, scanStringTy, mlirIntTy, cursor, fourValue, suppress);
+    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
+    auto op = moore::ScanUnformattedOp::create(builder, loc, scanStringTy,
+                                               mlirIntTy, matchedTy, cursor,
+                                               fourValue, suppress);
     cursor = op.getRemaining();
 
     if (!suppress) {
@@ -353,7 +375,7 @@ struct ScanStringParser {
         mooreVal =
             moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
                 .getResult();
-      assignments.push_back({destExpr, mooreVal});
+      assignments.push_back({destExpr, mooreVal, op.getMatched()});
     }
     return success();
   }

--- a/lib/Conversion/ImportVerilog/ScanStrings.cpp
+++ b/lib/Conversion/ImportVerilog/ScanStrings.cpp
@@ -236,8 +236,9 @@ struct ScanStringParser {
                             bool suppress, IntFormat format,
                             IntegerAttr maxWidth) {
     Type mlirIntTy = builder.getIntegerType(32);
+    moore::IntType mooreIntTy;
     if (!suppress) {
-      auto mooreIntTy =
+      mooreIntTy =
           llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
       if (!mooreIntTy)
         return mlir::emitError(loc)
@@ -253,6 +254,10 @@ struct ScanStringParser {
       auto mooreVal =
           moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
               .getResult();
+      if (mooreIntTy.getDomain() == moore::Domain::FourValued)
+        mooreVal =
+            moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
+                .getResult();
       assignments.push_back({destExpr, mooreVal});
     }
     return success();
@@ -286,8 +291,9 @@ struct ScanStringParser {
   LogicalResult emitScanChar(const slang::ast::Expression *destExpr,
                              bool suppress) {
     Type mlirIntTy = builder.getIntegerType(8);
+    moore::IntType mooreIntTy;
     if (!suppress) {
-      auto mooreIntTy =
+      mooreIntTy =
           llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
       if (!mooreIntTy)
         return mlir::emitError(loc)
@@ -302,6 +308,10 @@ struct ScanStringParser {
       auto mooreVal =
           moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
               .getResult();
+      if (mooreIntTy.getDomain() == moore::Domain::FourValued)
+        mooreVal =
+            moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
+                .getResult();
       assignments.push_back({destExpr, mooreVal});
     }
     return success();
@@ -320,8 +330,9 @@ struct ScanStringParser {
   LogicalResult emitScanUnformatted(const slang::ast::Expression *destExpr,
                                     bool suppress, bool fourValue) {
     Type mlirIntTy = builder.getIntegerType(32);
+    moore::IntType mooreIntTy;
     if (!suppress) {
-      auto mooreIntTy =
+      mooreIntTy =
           llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
       if (!mooreIntTy)
         return mlir::emitError(loc) << "destination of unformatted scan "
@@ -338,6 +349,10 @@ struct ScanStringParser {
       auto mooreVal =
           moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
               .getResult();
+      if (mooreIntTy.getDomain() == moore::Domain::FourValued)
+        mooreVal =
+            moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
+                .getResult();
       assignments.push_back({destExpr, mooreVal});
     }
     return success();

--- a/lib/Conversion/ImportVerilog/ScanStrings.cpp
+++ b/lib/Conversion/ImportVerilog/ScanStrings.cpp
@@ -236,147 +236,165 @@ struct ScanStringParser {
   LogicalResult emitScanInt(const slang::ast::Expression *destExpr,
                             bool suppress, IntFormat format,
                             IntegerAttr maxWidth) {
-    Type mlirIntTy = builder.getIntegerType(32);
-    moore::IntType mooreIntTy;
-    if (!suppress) {
-      mooreIntTy =
-          llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
-      if (!mooreIntTy)
-        return mlir::emitError(loc)
-               << "destination of integer scan specifier must be an integer";
-      mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
+    auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+
+    if (suppress) {
+      auto op = moore::ScanIntOp::create(builder, loc, TypeRange{scanStringTy},
+                                         cursor, format, maxWidth);
+      cursor = op.getRemaining();
+      return success();
     }
 
-    auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    auto mooreIntTy =
+        llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
+    if (!mooreIntTy)
+      return mlir::emitError(loc)
+             << "destination of integer scan specifier must be an integer";
+    auto mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
     auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
-    auto op =
-        moore::ScanIntOp::create(builder, loc, scanStringTy, mlirIntTy,
-                                 matchedTy, cursor, format, maxWidth, suppress);
+    auto op = moore::ScanIntOp::create(builder, loc, scanStringTy, mlirIntTy,
+                                       matchedTy, cursor, format, maxWidth);
     cursor = op.getRemaining();
-    if (!suppress) {
-      auto mooreVal =
-          moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
-              .getResult();
-      if (mooreIntTy.getDomain() == moore::Domain::FourValued)
-        mooreVal =
-            moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
-                .getResult();
-      assignments.push_back({destExpr, mooreVal, op.getMatched()});
-    }
+    auto mooreVal = moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
+                        .getResult();
+    if (mooreIntTy.getDomain() == moore::Domain::FourValued)
+      mooreVal = moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
+                     .getResult();
+    assignments.push_back({destExpr, mooreVal, op.getMatched()});
     return success();
   }
 
   LogicalResult emitScanReal(const slang::ast::Expression *destExpr,
                              bool suppress, IntegerAttr maxWidth) {
-    auto valueTy = suppress ? moore::RealType::get(builder.getContext(),
-                                                   moore::RealWidth::f64)
-                            : llvm::dyn_cast<moore::RealType>(
-                                  context.convertType(*destExpr->type));
     auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    if (suppress) {
+      auto op = moore::ScanRealOp::create(builder, loc, TypeRange{scanStringTy},
+                                          cursor, maxWidth);
+      cursor = op.getRemaining();
+      return success();
+    }
+
+    auto valueTy =
+        llvm::dyn_cast<moore::RealType>(context.convertType(*destExpr->type));
+    if (!valueTy)
+      return mlir::emitError(loc)
+             << "destination of real scan specifier must be a real";
     auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
-    auto op = moore::ScanRealOp::create(builder, loc, scanStringTy, valueTy,
-                                        matchedTy, cursor, maxWidth, suppress);
+    auto op = moore::ScanRealOp::create(
+        builder, loc, TypeRange{scanStringTy, valueTy, matchedTy}, cursor,
+        maxWidth);
     cursor = op.getRemaining();
-    if (!suppress)
-      assignments.push_back({destExpr, op.getValue(), op.getMatched()});
+    assignments.push_back({destExpr, op.getValue(), op.getMatched()});
     return success();
   }
 
   LogicalResult emitScanTime(const slang::ast::Expression *destExpr,
                              bool suppress, IntegerAttr maxWidth) {
-    auto op =
-        moore::ScanTimeOp::create(builder, loc, cursor, maxWidth, suppress);
+    auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    if (suppress) {
+      auto op = moore::ScanTimeOp::create(builder, loc, TypeRange{scanStringTy},
+                                          cursor, maxWidth);
+      cursor = op.getRemaining();
+      return success();
+    }
+    auto valueTy = moore::TimeType::get(builder.getContext());
+    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
+    auto op = moore::ScanTimeOp::create(
+        builder, loc, TypeRange{scanStringTy, valueTy, matchedTy}, cursor,
+        maxWidth);
     cursor = op.getRemaining();
-    if (!suppress)
-      assignments.push_back({destExpr, op.getValue(), op.getMatched()});
+    assignments.push_back({destExpr, op.getValue(), op.getMatched()});
     return success();
   }
 
   LogicalResult emitScanChar(const slang::ast::Expression *destExpr,
                              bool suppress) {
-    Type mlirIntTy = builder.getIntegerType(8);
-    moore::IntType mooreIntTy;
-    if (!suppress) {
-      mooreIntTy =
-          llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
-      if (!mooreIntTy)
-        return mlir::emitError(loc)
-               << "destination of char scan specifier must be an integer";
-      mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
-    }
     auto scanStringTy = moore::ScanStringType::get(builder.getContext());
-    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
-    auto op = moore::ScanCharOp::create(builder, loc, scanStringTy, mlirIntTy,
-                                        matchedTy, cursor, suppress);
-    cursor = op.getRemaining();
-    if (!suppress) {
-      auto mooreVal =
-          moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
-              .getResult();
-      if (mooreIntTy.getDomain() == moore::Domain::FourValued)
-        mooreVal =
-            moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
-                .getResult();
-      assignments.push_back({destExpr, mooreVal, op.getMatched()});
+    if (suppress) {
+      auto op = moore::ScanCharOp::create(builder, loc, TypeRange{scanStringTy},
+                                          cursor);
+      cursor = op.getRemaining();
+      return success();
     }
+    auto mooreIntTy =
+        llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
+    if (!mooreIntTy)
+      return mlir::emitError(loc)
+             << "destination of char scan specifier must be an integer";
+    auto mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
+    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
+    auto op = moore::ScanCharOp::create(
+        builder, loc, TypeRange{scanStringTy, mlirIntTy, matchedTy}, cursor);
+    cursor = op.getRemaining();
+    auto mooreVal = moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
+                        .getResult();
+    if (mooreIntTy.getDomain() == moore::Domain::FourValued)
+      mooreVal = moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
+                     .getResult();
+    assignments.push_back({destExpr, mooreVal, op.getMatched()});
     return success();
   }
 
   LogicalResult emitScanStr(const slang::ast::Expression *destExpr,
                             bool suppress, IntegerAttr maxWidth) {
-    auto op =
-        moore::ScanStrOp::create(builder, loc, cursor, maxWidth, suppress);
-    cursor = op.getRemaining();
-    if (!suppress) {
-      Value val = op.getValue();
-      auto destTy = context.convertType(*destExpr->type);
-      if (auto intTy = llvm::dyn_cast<moore::IntType>(destTy)) {
-        val = moore::StringToIntOp::create(builder, loc, intTy.getTwoValued(),
-                                           val)
-                  .getResult();
-        if (intTy.getDomain() == moore::Domain::FourValued)
-          val =
-              moore::IntToLogicOp::create(builder, loc, intTy, val).getResult();
-      } else if (!llvm::isa<moore::StringType>(destTy)) {
-        return mlir::emitError(loc)
-               << "destination of string scan specifier must be a string or "
-                  "integer";
-      }
-      assignments.push_back({destExpr, val, op.getMatched()});
+    auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    if (suppress) {
+      auto op = moore::ScanStrOp::create(builder, loc, TypeRange{scanStringTy},
+                                         cursor, maxWidth);
+      cursor = op.getRemaining();
+      return success();
     }
+    auto stringTy = moore::StringType::get(builder.getContext());
+    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
+    auto op = moore::ScanStrOp::create(
+        builder, loc, TypeRange{scanStringTy, stringTy, matchedTy}, cursor,
+        maxWidth);
+    cursor = op.getRemaining();
+    Value val = op.getValue();
+    auto destTy = context.convertType(*destExpr->type);
+    if (auto intTy = llvm::dyn_cast<moore::IntType>(destTy)) {
+      val =
+          moore::StringToIntOp::create(builder, loc, intTy.getTwoValued(), val)
+              .getResult();
+      if (intTy.getDomain() == moore::Domain::FourValued)
+        val = moore::IntToLogicOp::create(builder, loc, intTy, val).getResult();
+    } else if (!llvm::isa<moore::StringType>(destTy)) {
+      return mlir::emitError(loc)
+             << "destination of string scan specifier must be a string or "
+                "integer type";
+    }
+    assignments.push_back({destExpr, val, op.getMatched()});
     return success();
   }
 
   LogicalResult emitScanUnformatted(const slang::ast::Expression *destExpr,
                                     bool suppress, bool fourValue) {
-    Type mlirIntTy = builder.getIntegerType(32);
-    moore::IntType mooreIntTy;
-    if (!suppress) {
-      mooreIntTy =
-          llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
-      if (!mooreIntTy)
-        return mlir::emitError(loc) << "destination of unformatted scan "
-                                       "specifier must be an integer";
-      mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
-    }
-
     auto scanStringTy = moore::ScanStringType::get(builder.getContext());
-    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
-    auto op = moore::ScanUnformattedOp::create(builder, loc, scanStringTy,
-                                               mlirIntTy, matchedTy, cursor,
-                                               fourValue, suppress);
-    cursor = op.getRemaining();
 
-    if (!suppress) {
-      auto mooreVal =
-          moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
-              .getResult();
-      if (mooreIntTy.getDomain() == moore::Domain::FourValued)
-        mooreVal =
-            moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
-                .getResult();
-      assignments.push_back({destExpr, mooreVal, op.getMatched()});
+    if (suppress) {
+      auto op = moore::ScanUnformattedOp::create(
+          builder, loc, TypeRange{scanStringTy}, cursor, fourValue);
+      cursor = op.getRemaining();
+      return success();
     }
+    auto mooreIntTy =
+        llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
+    if (!mooreIntTy)
+      return mlir::emitError(loc)
+             << "destination of unformatted scan specifier must be an integer";
+
+    auto mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
+    auto matchedTy = moore::IntType::getInt(builder.getContext(), 1);
+    auto op = moore::ScanUnformattedOp::create(
+        builder, loc, TypeRange{scanStringTy, mlirIntTy, matchedTy}, cursor,
+        fourValue);
+    cursor = op.getRemaining();
+    auto mooreVal = moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
+                        .getResult();
+    if (mooreIntTy.getDomain() == moore::Domain::FourValued)
+      mooreVal = moore::IntToLogicOp::create(builder, loc, mooreIntTy, mooreVal)
+                     .getResult();
+    assignments.push_back({destExpr, mooreVal, op.getMatched()});
     return success();
   }
 };

--- a/lib/Conversion/ImportVerilog/ScanStrings.cpp
+++ b/lib/Conversion/ImportVerilog/ScanStrings.cpp
@@ -1,0 +1,284 @@
+//===- ScanStrings.cpp - Scan format string conversion --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImportVerilogInternals.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace ImportVerilog;
+using moore::IntFormat;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Scan format string parser
+//===----------------------------------------------------------------------===//
+
+static bool parseScanFormat(StringRef format,
+                            function_ref<void(StringRef text)> onText,
+                            function_ref<void(char specifier, bool suppress,
+                                              std::optional<uint32_t> maxWidth)>
+                                onArg,
+                            function_ref<void(StringRef msg)> onError) {
+
+  size_t i = 0;
+  size_t textStart = 0;
+
+  while (i < format.size()) {
+    if (format[i] != '%') {
+      ++i;
+      continue;
+    }
+
+    if (i > textStart)
+      onText(format.substr(textStart, i - textStart));
+
+    ++i; // consume '%'
+    if (i >= format.size()) {
+      onError("unexpected end of format string after '%'");
+      return false;
+    }
+
+    if (format[i] == '%') {
+      onText("%");
+      ++i;
+      textStart = i;
+      continue;
+    }
+
+    // Optional assignment suppression '*'.
+    bool suppress = false;
+    if (format[i] == '*') {
+      suppress = true;
+      ++i;
+      if (i >= format.size()) {
+        onError("unexpected end of format string after '%*'");
+        return false;
+      }
+    }
+
+    // Optional maximum field width.
+    std::optional<uint32_t> maxWidth;
+    if (std::isdigit(format[i])) {
+      uint32_t w = 0;
+      while (i < format.size() && std::isdigit(format[i]))
+        w = w * 10 + (format[i++] - '0');
+      maxWidth = w;
+      if (w == 0) {
+        onError("field width must be at least 1");
+        return false;
+      }
+    }
+
+    if (i >= format.size()) {
+      onError("unexpected end of format string: missing conversion specifier");
+      return false;
+    }
+
+    char specifier = format[i++];
+    onArg(specifier, suppress, maxWidth);
+    textStart = i;
+  }
+
+  // Flush any trailing literal text.
+  if (textStart < format.size())
+    onText(format.substr(textStart));
+
+  return true;
+}
+
+struct ScanStringParser {
+  Context &context;
+  OpBuilder &builder;
+  /// Remaining destination arguments (lvalue expressions to write into).
+  /// Suppressed assignments do not consume from this list.
+  ArrayRef<const slang::ast::Expression *> destinations;
+  /// Current location for ops and diagnostics.
+  Location loc;
+  /// Accumulated scan format fragments.
+  SmallVector<Value> fragments;
+
+  ScanStringParser(Context &context,
+                   ArrayRef<const slang::ast::Expression *> destinations,
+                   Location loc)
+      : context(context), builder(context.builder), destinations(destinations),
+        loc(loc) {}
+
+  /// Parse the format string and produce a ScanStringType value combining
+  /// all fragments. Returns failure if any error occurs.
+  FailureOr<Value> parse(StringRef formatStr) {
+    bool anyFailure = false;
+
+    auto onText = [&](StringRef text) {
+      if (!anyFailure)
+        emitLiteral(text);
+    };
+
+    auto onArg = [&](char specifier, bool suppress,
+                     std::optional<uint32_t> maxWidth) {
+      if (anyFailure)
+        return;
+      if (failed(emitScanArg(specifier, suppress, maxWidth)))
+        anyFailure = true;
+    };
+
+    auto onError = [&](StringRef msg) {
+      if (!anyFailure) {
+        mlir::emitError(loc) << "scan format string error: " << msg;
+        anyFailure = true;
+      }
+    };
+
+    if (!parseScanFormat(formatStr, onText, onArg, onError) || anyFailure)
+      return failure();
+
+    if (fragments.empty())
+      return Value{};
+    if (fragments.size() == 1)
+      return fragments[0];
+    return moore::ScanConcatOp::create(builder, loc, fragments).getResult();
+  }
+
+  /// Emit a literal text fragment that must match verbatim in the input.
+  void emitLiteral(StringRef text) {
+    if (text.empty())
+      return;
+    fragments.push_back(moore::ScanLiteralOp::create(builder, loc, text));
+  }
+
+  /// Resolve a destination expression to an lvalue reference value.
+  FailureOr<Value> resolveDest(const slang::ast::Expression &destExpr) {
+    const auto *expr = &destExpr;
+    if (auto assign = expr->as_if<slang::ast::AssignmentExpression>())
+      expr = &assign->left();
+    auto lhs = context.convertLvalueExpression(*expr);
+    if (!lhs)
+      return failure();
+    return lhs;
+  }
+
+  /// Consume the next destination argument (if not suppressed) and emit a
+  /// scan fragment op.
+  LogicalResult emitScanArg(char specifier, bool suppress,
+                            std::optional<uint32_t> maxWidth) {
+    auto specifierLower = std::tolower(specifier);
+
+    // Hierarchical path specifier (%m), no argument consumed.
+    if (specifierLower == 'm') {
+      fragments.push_back(moore::ScanHierPathMatchOp::create(builder, loc));
+      return success();
+    }
+
+    // All other specifiers consume a destination argument (if not suppressed).
+    Value dest;
+    if (!suppress) {
+      if (destinations.empty())
+        return mlir::emitError(loc)
+               << "too few arguments for scan format specifier '%" << specifier
+               << "'";
+      auto destOrFailure = resolveDest(*destinations.front());
+      destinations = destinations.drop_front();
+      if (failed(destOrFailure))
+        return failure();
+      dest = *destOrFailure;
+    }
+
+    IntegerAttr maxWidthAttr = nullptr;
+    if (maxWidth)
+      maxWidthAttr = builder.getI32IntegerAttr(*maxWidth);
+
+    switch (specifierLower) {
+    // Integer specifiers (%b, %o, %d, %h, %x)
+    case 'b':
+      return emitScanInt(dest, IntFormat::Binary, maxWidthAttr);
+    case 'o':
+      return emitScanInt(dest, IntFormat::Octal, maxWidthAttr);
+    case 'd':
+      return emitScanInt(dest, IntFormat::Decimal, maxWidthAttr);
+    case 'h':
+    case 'x':
+      return emitScanInt(dest,
+                         std::isupper(specifier) ? IntFormat::HexUpper
+                                                 : IntFormat::HexLower,
+                         maxWidthAttr);
+
+    // Floating-point specifiers (%f, %e, %g)
+    case 'f':
+    case 'e':
+    case 'g':
+      return emitScanReal(dest, maxWidthAttr);
+
+    // Time specifier (%t)
+    case 't':
+      return emitScanTime(dest, maxWidthAttr);
+
+    // Character specifier (%c)
+    case 'c':
+      return emitScanChar(dest);
+
+    // String specifier (%s)
+    case 's':
+      return emitScanStr(dest, maxWidthAttr);
+
+    // Unformatted binary (%u, %z)
+    case 'u':
+      return emitScanUnformatted(dest, /*fourValue=*/false);
+    case 'z':
+      return emitScanUnformatted(dest, /*fourValue=*/true);
+
+    default:
+      return mlir::emitError(loc)
+             << "unknown scan format specifier '%" << specifier << "'";
+    }
+  }
+
+  LogicalResult emitScanInt(Value dest, IntFormat format,
+                            IntegerAttr maxWidth) {
+    fragments.push_back(
+        moore::ScanIntOp::create(builder, loc, dest, format, maxWidth));
+    return success();
+  }
+
+  LogicalResult emitScanReal(Value dest, IntegerAttr maxWidth) {
+    fragments.push_back(
+        moore::ScanRealOp::create(builder, loc, dest, maxWidth));
+    return success();
+  }
+
+  LogicalResult emitScanTime(Value dest, IntegerAttr maxWidth) {
+    fragments.push_back(
+        moore::ScanTimeOp::create(builder, loc, dest, maxWidth));
+    return success();
+  }
+
+  LogicalResult emitScanChar(Value dest) {
+    fragments.push_back(moore::ScanCharOp::create(builder, loc, dest));
+    return success();
+  }
+
+  LogicalResult emitScanStr(Value dest, IntegerAttr maxWidth) {
+    fragments.push_back(moore::ScanStrOp::create(builder, loc, dest, maxWidth));
+    return success();
+  }
+
+  LogicalResult emitScanUnformatted(Value dest, bool fourValue) {
+    fragments.push_back(
+        moore::ScanUnformattedOp::create(builder, loc, dest, fourValue));
+    return success();
+  }
+};
+
+} // namespace
+
+FailureOr<Value> Context::convertScanString(
+    StringRef formatStr,
+    std::span<const slang::ast::Expression *const> destinations, Location loc) {
+  ScanStringParser parser(
+      *this, ArrayRef(destinations.data(), destinations.size()), loc);
+  return parser.parse(formatStr);
+}

--- a/lib/Conversion/ImportVerilog/ScanStrings.cpp
+++ b/lib/Conversion/ImportVerilog/ScanStrings.cpp
@@ -100,18 +100,21 @@ struct ScanStringParser {
   ArrayRef<const slang::ast::Expression *> destinations;
   /// Current location for ops and diagnostics.
   Location loc;
-  /// Accumulated scan format fragments.
-  SmallVector<Value> fragments;
+  /// The current tail of the consuming chain.
+  Value cursor;
+  /// Accumulated (unwrapped destination expression, scanned value) pairs to be
+  /// assigned with a moore.blocking_assign by the caller.
+  SmallVector<std::pair<const slang::ast::Expression *, Value>> assignments;
 
-  ScanStringParser(Context &context,
+  ScanStringParser(Context &context, Value initialCursor,
                    ArrayRef<const slang::ast::Expression *> destinations,
                    Location loc)
       : context(context), builder(context.builder), destinations(destinations),
-        loc(loc) {}
+        loc(loc), cursor(initialCursor) {}
 
-  /// Parse the format string and produce a ScanStringType value combining
-  /// all fragments. Returns failure if any error occurs.
-  FailureOr<Value> parse(StringRef formatStr) {
+  /// Thread the consuming chain and collect (destination, value) assignments
+  /// pairs.
+  FailureOr<Context::ScanStringResult> parse(StringRef formatStr) {
     bool anyFailure = false;
 
     auto onText = [&](StringRef text) {
@@ -137,29 +140,24 @@ struct ScanStringParser {
     if (!parseScanFormat(formatStr, onText, onArg, onError) || anyFailure)
       return failure();
 
-    if (fragments.empty())
-      return Value{};
-    if (fragments.size() == 1)
-      return fragments[0];
-    return moore::ScanConcatOp::create(builder, loc, fragments).getResult();
+    return Context::ScanStringResult{cursor, std::move(assignments)};
   }
 
   /// Emit a literal text fragment that must match verbatim in the input.
   void emitLiteral(StringRef text) {
     if (text.empty())
       return;
-    fragments.push_back(moore::ScanLiteralOp::create(builder, loc, text));
+    cursor =
+        moore::ScanLiteralOp::create(builder, loc, cursor, text).getRemaining();
   }
 
-  /// Resolve a destination expression to an lvalue reference value.
-  FailureOr<Value> resolveDest(const slang::ast::Expression &destExpr) {
-    const auto *expr = &destExpr;
-    if (auto assign = expr->as_if<slang::ast::AssignmentExpression>())
-      expr = &assign->left();
-    auto lhs = context.convertLvalueExpression(*expr);
-    if (!lhs)
-      return failure();
-    return lhs;
+  /// Strip an outer AssignmentExpression wrapper if present,
+  /// returning the actual lvalue subexpression.
+  static const slang::ast::Expression *
+  unwrapDest(const slang::ast::Expression *expr) {
+    if (auto *assign = expr->as_if<slang::ast::AssignmentExpression>())
+      return &assign->left();
+    return expr;
   }
 
   /// Consume the next destination argument (if not suppressed) and emit a
@@ -170,39 +168,36 @@ struct ScanStringParser {
 
     // Hierarchical path specifier (%m), no argument consumed.
     if (specifierLower == 'm') {
-      fragments.push_back(moore::ScanHierPathMatchOp::create(builder, loc));
+      cursor = moore::ScanHierPathMatchOp::create(builder, loc, cursor)
+                   .getRemaining();
       return success();
-    }
-
-    // All other specifiers consume a destination argument (if not suppressed).
-    Value dest;
-    if (!suppress) {
-      if (destinations.empty())
-        return mlir::emitError(loc)
-               << "too few arguments for scan format specifier '%" << specifier
-               << "'";
-      auto destOrFailure = resolveDest(*destinations.front());
-      destinations = destinations.drop_front();
-      if (failed(destOrFailure))
-        return failure();
-      dest = *destOrFailure;
     }
 
     IntegerAttr maxWidthAttr = nullptr;
     if (maxWidth)
       maxWidthAttr = builder.getI32IntegerAttr(*maxWidth);
 
+    const slang::ast::Expression *destExpr = nullptr;
+    if (!suppress) {
+      if (destinations.empty())
+        return mlir::emitError(loc)
+               << "too few arguments for scan format specifier '%" << specifier
+               << "'";
+      destExpr = unwrapDest(destinations.front());
+      destinations = destinations.drop_front();
+    }
+
     switch (specifierLower) {
     // Integer specifiers (%b, %o, %d, %h, %x)
     case 'b':
-      return emitScanInt(dest, IntFormat::Binary, maxWidthAttr);
+      return emitScanInt(destExpr, suppress, IntFormat::Binary, maxWidthAttr);
     case 'o':
-      return emitScanInt(dest, IntFormat::Octal, maxWidthAttr);
+      return emitScanInt(destExpr, suppress, IntFormat::Octal, maxWidthAttr);
     case 'd':
-      return emitScanInt(dest, IntFormat::Decimal, maxWidthAttr);
+      return emitScanInt(destExpr, suppress, IntFormat::Decimal, maxWidthAttr);
     case 'h':
     case 'x':
-      return emitScanInt(dest,
+      return emitScanInt(destExpr, suppress,
                          std::isupper(specifier) ? IntFormat::HexUpper
                                                  : IntFormat::HexLower,
                          maxWidthAttr);
@@ -211,25 +206,25 @@ struct ScanStringParser {
     case 'f':
     case 'e':
     case 'g':
-      return emitScanReal(dest, maxWidthAttr);
+      return emitScanReal(destExpr, suppress, maxWidthAttr);
 
     // Time specifier (%t)
     case 't':
-      return emitScanTime(dest, maxWidthAttr);
+      return emitScanTime(destExpr, suppress, maxWidthAttr);
 
     // Character specifier (%c)
     case 'c':
-      return emitScanChar(dest);
+      return emitScanChar(destExpr, suppress);
 
     // String specifier (%s)
     case 's':
-      return emitScanStr(dest, maxWidthAttr);
+      return emitScanStr(destExpr, suppress, maxWidthAttr);
 
     // Unformatted binary (%u, %z)
     case 'u':
-      return emitScanUnformatted(dest, /*fourValue=*/false);
+      return emitScanUnformatted(destExpr, suppress, /*fourValue=*/false);
     case 'z':
-      return emitScanUnformatted(dest, /*fourValue=*/true);
+      return emitScanUnformatted(destExpr, suppress, /*fourValue=*/true);
 
     default:
       return mlir::emitError(loc)
@@ -237,48 +232,125 @@ struct ScanStringParser {
     }
   }
 
-  LogicalResult emitScanInt(Value dest, IntFormat format,
+  LogicalResult emitScanInt(const slang::ast::Expression *destExpr,
+                            bool suppress, IntFormat format,
                             IntegerAttr maxWidth) {
-    fragments.push_back(
-        moore::ScanIntOp::create(builder, loc, dest, format, maxWidth));
+    Type mlirIntTy = builder.getIntegerType(32);
+    if (!suppress) {
+      auto mooreIntTy =
+          llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
+      if (!mooreIntTy)
+        return mlir::emitError(loc)
+               << "destination of integer scan specifier must be an integer";
+      mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
+    }
+
+    auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    auto op = moore::ScanIntOp::create(builder, loc, scanStringTy, mlirIntTy,
+                                       cursor, format, maxWidth, suppress);
+    cursor = op.getRemaining();
+    if (!suppress) {
+      auto mooreVal =
+          moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
+              .getResult();
+      assignments.push_back({destExpr, mooreVal});
+    }
     return success();
   }
 
-  LogicalResult emitScanReal(Value dest, IntegerAttr maxWidth) {
-    fragments.push_back(
-        moore::ScanRealOp::create(builder, loc, dest, maxWidth));
+  LogicalResult emitScanReal(const slang::ast::Expression *destExpr,
+                             bool suppress, IntegerAttr maxWidth) {
+    auto valueTy = suppress ? moore::RealType::get(builder.getContext(),
+                                                   moore::RealWidth::f64)
+                            : llvm::dyn_cast<moore::RealType>(
+                                  context.convertType(*destExpr->type));
+    auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    auto op = moore::ScanRealOp::create(builder, loc, scanStringTy, valueTy,
+                                        cursor, maxWidth, suppress);
+    cursor = op.getRemaining();
+    if (!suppress)
+      assignments.push_back({destExpr, op.getValue()});
     return success();
   }
 
-  LogicalResult emitScanTime(Value dest, IntegerAttr maxWidth) {
-    fragments.push_back(
-        moore::ScanTimeOp::create(builder, loc, dest, maxWidth));
+  LogicalResult emitScanTime(const slang::ast::Expression *destExpr,
+                             bool suppress, IntegerAttr maxWidth) {
+    auto op =
+        moore::ScanTimeOp::create(builder, loc, cursor, maxWidth, suppress);
+    cursor = op.getRemaining();
+    if (!suppress)
+      assignments.push_back({destExpr, op.getValue()});
     return success();
   }
 
-  LogicalResult emitScanChar(Value dest) {
-    fragments.push_back(moore::ScanCharOp::create(builder, loc, dest));
+  LogicalResult emitScanChar(const slang::ast::Expression *destExpr,
+                             bool suppress) {
+    Type mlirIntTy = builder.getIntegerType(8);
+    if (!suppress) {
+      auto mooreIntTy =
+          llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
+      if (!mooreIntTy)
+        return mlir::emitError(loc)
+               << "destination of char scan specifier must be an integer";
+      mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
+    }
+    auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    auto op = moore::ScanCharOp::create(builder, loc, scanStringTy, mlirIntTy,
+                                        cursor, suppress);
+    cursor = op.getRemaining();
+    if (!suppress) {
+      auto mooreVal =
+          moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
+              .getResult();
+      assignments.push_back({destExpr, mooreVal});
+    }
     return success();
   }
 
-  LogicalResult emitScanStr(Value dest, IntegerAttr maxWidth) {
-    fragments.push_back(moore::ScanStrOp::create(builder, loc, dest, maxWidth));
+  LogicalResult emitScanStr(const slang::ast::Expression *destExpr,
+                            bool suppress, IntegerAttr maxWidth) {
+    auto op =
+        moore::ScanStrOp::create(builder, loc, cursor, maxWidth, suppress);
+    cursor = op.getRemaining();
+    if (!suppress)
+      assignments.push_back({destExpr, op.getValue()});
     return success();
   }
 
-  LogicalResult emitScanUnformatted(Value dest, bool fourValue) {
-    fragments.push_back(
-        moore::ScanUnformattedOp::create(builder, loc, dest, fourValue));
+  LogicalResult emitScanUnformatted(const slang::ast::Expression *destExpr,
+                                    bool suppress, bool fourValue) {
+    Type mlirIntTy = builder.getIntegerType(32);
+    if (!suppress) {
+      auto mooreIntTy =
+          llvm::dyn_cast<moore::IntType>(context.convertType(*destExpr->type));
+      if (!mooreIntTy)
+        return mlir::emitError(loc) << "destination of unformatted scan "
+                                       "specifier must be an integer";
+      mlirIntTy = builder.getIntegerType(mooreIntTy.getWidth());
+    }
+
+    auto scanStringTy = moore::ScanStringType::get(builder.getContext());
+    auto op = moore::ScanUnformattedOp::create(
+        builder, loc, scanStringTy, mlirIntTy, cursor, fourValue, suppress);
+    cursor = op.getRemaining();
+
+    if (!suppress) {
+      auto mooreVal =
+          moore::FromBuiltinIntOp::create(builder, loc, op.getValue())
+              .getResult();
+      assignments.push_back({destExpr, mooreVal});
+    }
     return success();
   }
 };
 
 } // namespace
 
-FailureOr<Value> Context::convertScanString(
-    StringRef formatStr,
+FailureOr<Context::ScanStringResult> Context::convertScanString(
+    StringRef formatStr, Value initialCursor,
     std::span<const slang::ast::Expression *const> destinations, Location loc) {
-  ScanStringParser parser(
-      *this, ArrayRef(destinations.data(), destinations.size()), loc);
+  ScanStringParser parser(*this, initialCursor,
+                          ArrayRef(destinations.data(), destinations.size()),
+                          loc);
   return parser.parse(formatStr);
 }

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -977,82 +977,112 @@ function void FScanfIntegerSpecifiers(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%d", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%D", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] binary : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] binary : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%b", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] binary : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] binary : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%B", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] octal : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] octal : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%o", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] octal : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] octal : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%O", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_lower : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_lower : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%h", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_lower : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_lower : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%x", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_upper : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_upper : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%H", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_upper : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_upper : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%X", x);
 endfunction
@@ -1068,58 +1098,82 @@ function void FScanfRealSpecifiers(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : !moore.f64, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]] : f64
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%f", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : !moore.f64, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]] : f64
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%e", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : !moore.f64, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]] : f64
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%g", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : !moore.f64, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]] : f64
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%F", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : !moore.f64, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]] : f64
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%E", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : !moore.f64, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]] : f64
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%G", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.time [[C]] : time, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> time
-  // CHECK: moore.blocking_assign [[TVAR]], [[SEL]] : time
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.time [[C]] : !moore.time, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[TVAR]], [[V]] : time
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%t", t);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.time [[C]] : time, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> time
-  // CHECK: moore.blocking_assign [[TVAR]], [[SEL]] : time
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.time [[C]] : !moore.time, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[TVAR]], [[V]] : time
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%T", t);
 endfunction
@@ -1138,49 +1192,67 @@ function void FScanfOtherSpecifiers(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : string, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> string
-  // CHECK: moore.blocking_assign [[SVAR]], [[SEL]] : string
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : !moore.string, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[SVAR]], [[V]] : string
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%s", s);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : string, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> string
-  // CHECK: moore.blocking_assign [[SVAR]], [[SEL]] : string
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : !moore.string, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[SVAR]], [[V]] : string
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%S", s);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.char [[C]] : i8, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.char [[C]] : i8, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i8
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i8
-  // CHECK: moore.blocking_assign [[CVAR]], [[SEL]] : i8
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[CVAR]], [[MV]] : i8
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%c", c);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] : i32, !moore.i1
   // CHECK-NOT: four_value
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%u", raw);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%z", raw);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%Z", raw);
 
@@ -1214,64 +1286,73 @@ function void FScanfModifiers(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] decimal suppress : i32, i1
+  // CHECK: [[R:%.+]] = moore.scan.int [[C]] decimal
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*d");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] binary suppress : i32, i1
+  // CHECK: [[R:%.+]] = moore.scan.int [[C]] binary
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*b");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.str [[C]] suppress : string, i1
+  // CHECK: [[R:%.+]] = moore.scan.str [[C]]
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*s");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.real [[C]] suppress : f64, i1
+  // CHECK: [[R:%.+]] = moore.scan.real [[C]]
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*f");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.char [[C]] suppress : i8, i1
+  // CHECK: [[R:%.+]] = moore.scan.char [[C]]
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*c");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal width 8 : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal width 8 : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[IVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[IVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%8d", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] width 16 : string, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> string
-  // CHECK: moore.blocking_assign [[SVAR]], [[SEL]] : string
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] width 16 : !moore.string, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[SVAR]], [[V]] : string
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%16s", s);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] width 10 : f64, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] width 10 : !moore.f64, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]] : f64
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%10f", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] decimal width 42 suppress : i32, i1
+  // CHECK: [[R:%.+]] = moore.scan.int [[C]] decimal width 42
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42d");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.str [[C]] width 42 suppress : string, i1
+  // CHECK: [[R:%.+]] = moore.scan.str [[C]] width 42
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42s");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] hex_lower width 42 suppress : i32, i1
+  // CHECK: [[R:%.+]] = moore.scan.int [[C]] hex_lower width 42
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42h");
 endfunction
@@ -1290,65 +1371,95 @@ function void FScanfComposition(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, !moore.i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
-  // CHECK: [[C2:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.str [[C1]] : string, i1
-  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
-  // CHECK: [[SEL2:%.+]] = moore.conditional [[M2]] : i1 -> string
-  // CHECK: moore.blocking_assign [[BVAR]], [[SEL2]] : string
+  // CHECK: [[C2:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.str [[C1]] : !moore.string, !moore.i1
+  // CHECK: [[CB1:%.+]] = moore.to_builtin_int [[M1]] : i1
+  // CHECK: cf.cond_br [[CB1]], ^[[A1:.+]], ^[[K1:.+]]
+  // CHECK: ^[[A1]]:
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]] : i32
+  // CHECK: ^[[K1]]:
+  // CHECK: [[CB2:%.+]] = moore.to_builtin_int [[M2]] : i1
+  // CHECK: cf.cond_br [[CB2]], ^[[A2:.+]], ^[[K2:.+]]
+  // CHECK: ^[[A2]]:
+  // CHECK: moore.blocking_assign [[BVAR]], [[V2]] : string
+  // CHECK: ^[[K2]]:
   // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%d%s", a, b);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, !moore.i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
-  // CHECK: [[C2:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.real [[C1]] : f64, i1
-  // CHECK: [[C3:%.+]], [[V3:%.+]], [[M3:%.+]] = moore.scan.str [[C2]] : string, i1
-  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
-  // CHECK: [[SEL2:%.+]] = moore.conditional [[M2]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL2]] : f64
-  // CHECK: [[SEL3:%.+]] = moore.conditional [[M3]] : i1 -> string
-  // CHECK: moore.blocking_assign [[BVAR]], [[SEL3]] : string
+  // CHECK: [[C2:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.real [[C1]] : !moore.f64, !moore.i1
+  // CHECK: [[C3:%.+]], [[V3:%.+]], [[M3:%.+]] = moore.scan.str [[C2]] : !moore.string, !moore.i1
+  // CHECK: [[CB1:%.+]] = moore.to_builtin_int [[M1]] : i1
+  // CHECK: cf.cond_br [[CB1]], ^[[A1:.+]], ^[[K1:.+]]
+  // CHECK: ^[[A1]]:
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]] : i32
+  // CHECK: ^[[K1]]:
+  // CHECK: [[CB2:%.+]] = moore.to_builtin_int [[M2]] : i1
+  // CHECK: cf.cond_br [[CB2]], ^[[A2:.+]], ^[[K2:.+]]
+  // CHECK: ^[[A2]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V2]] : f64
+  // CHECK: ^[[K2]]:
+  // CHECK: [[CB3:%.+]] = moore.to_builtin_int [[M3]] : i1
+  // CHECK: cf.cond_br [[CB3]], ^[[A3:.+]], ^[[K3:.+]]
+  // CHECK: ^[[A3]]:
+  // CHECK: moore.blocking_assign [[BVAR]], [[V3]] : string
+  // CHECK: ^[[K3]]:
   // CHECK: moore.scan.end [[C3]]
   res = $fscanf(fd, "%d%f%s", a, r, b);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
   // CHECK: [[C1:%.+]] = moore.scan.literal [[C0]] "val="
-  // CHECK: [[C2:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C1]] decimal : i32, i1
+  // CHECK: [[C2:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C1]] decimal : i32, !moore.i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
-  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
+  // CHECK: [[CB1:%.+]] = moore.to_builtin_int [[M1]] : i1
+  // CHECK: cf.cond_br [[CB1]], ^[[A1:.+]], ^[[K1:.+]]
+  // CHECK: ^[[A1]]:
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]] : i32
+  // CHECK: ^[[K1]]:
   // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "val=%d", a);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, !moore.i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
   // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " end"
-  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
+  // CHECK: [[CB1:%.+]] = moore.to_builtin_int [[M1]] : i1
+  // CHECK: cf.cond_br [[CB1]], ^[[A1:.+]], ^[[K1:.+]]
+  // CHECK: ^[[A1]]:
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]] : i32
+  // CHECK: ^[[K1]]:
   // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%d end", a);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, !moore.i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
   // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " , "
-  // CHECK: [[C3:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.str [[C2]] : string, i1
-  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
-  // CHECK: [[SEL2:%.+]] = moore.conditional [[M2]] : i1 -> string
-  // CHECK: moore.blocking_assign [[BVAR]], [[SEL2]] : string
+  // CHECK: [[C3:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.str [[C2]] : !moore.string, !moore.i1
+  // CHECK: [[CB1:%.+]] = moore.to_builtin_int [[M1]] : i1
+  // CHECK: cf.cond_br [[CB1]], ^[[A1:.+]], ^[[K1:.+]]
+  // CHECK: ^[[A1]]:
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]] : i32
+  // CHECK: ^[[K1]]:
+  // CHECK: [[CB2:%.+]] = moore.to_builtin_int [[M2]] : i1
+  // CHECK: cf.cond_br [[CB2]], ^[[A2:.+]], ^[[K2:.+]]
+  // CHECK: ^[[A2]]:
+  // CHECK: moore.blocking_assign [[BVAR]], [[V2]] : string
+  // CHECK: ^[[K2]]:
   // CHECK: moore.scan.end [[C3]]
   res = $fscanf(fd, "%d , %s", a, b);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C0]] decimal suppress : i32, i1
-  // CHECK: [[C2:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.str [[C1]] : string, i1
-  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> string
-  // CHECK: moore.blocking_assign [[BVAR]], [[SEL1]] : string
+  // CHECK: [[C1:%.+]] = moore.scan.int [[C0]] decimal
+  // CHECK: [[C2:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.str [[C1]] : !moore.string, !moore.i1
+  // CHECK: [[CB1:%.+]] = moore.to_builtin_int [[M1]] : i1
+  // CHECK: cf.cond_br [[CB1]], ^[[A1:.+]], ^[[K1:.+]]
+  // CHECK: ^[[A1]]:
+  // CHECK: moore.blocking_assign [[BVAR]], [[V1]] : string
+  // CHECK: ^[[K1]]:
   // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%*d%s", b);
 
@@ -1381,42 +1492,57 @@ function void SScanfBuiltins(string src);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%d", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : string, i1
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> string
-  // CHECK: moore.blocking_assign [[SVAR]], [[SEL]] : string
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : !moore.string, !moore.i1
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[SVAR]], [[V]] : string
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%s", s);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, !moore.i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
   // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " "
-  // CHECK: [[C3:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.real [[C2]] : f64, i1
-  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL1]] : i32
-  // CHECK: [[SEL2:%.+]] = moore.conditional [[M2]] : i1 -> f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[SEL2]] : f64
+  // CHECK: [[C3:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.real [[C2]] : !moore.f64, !moore.i1
+  // CHECK: [[CB1:%.+]] = moore.to_builtin_int [[M1]] : i1
+  // CHECK: cf.cond_br [[CB1]], ^[[A1:.+]], ^[[K1:.+]]
+  // CHECK: ^[[A1]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV1]] : i32
+  // CHECK: ^[[K1]]:
+  // CHECK: [[CB2:%.+]] = moore.to_builtin_int [[M2]] : i1
+  // CHECK: cf.cond_br [[CB2]], ^[[A2:.+]], ^[[K2:.+]]
+  // CHECK: ^[[A2]]:
+  // CHECK: moore.blocking_assign [[RVAR]], [[V2]] : f64
+  // CHECK: ^[[K2]]:
   // CHECK: moore.scan.end [[C3]]
   res = $sscanf(src, "%d %f", x, r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] decimal width 8 suppress : i32, i1
+  // CHECK: [[R:%.+]] = moore.scan.int [[C]] decimal width 8
   // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%*8d");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, i1
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, !moore.i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
+  // CHECK: [[CB:%.+]] = moore.to_builtin_int [[M]] : i1
+  // CHECK: cf.cond_br [[CB]], ^[[ASSIGN:.+]], ^[[CONT:.+]]
+  // CHECK: ^[[ASSIGN]]:
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]] : i32
+  // CHECK: ^[[CONT]]:
   // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%z", x);
 

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -973,46 +973,77 @@ function void FScanfIntegerSpecifiers(int fd);
   int x;
   int res;
 
-  // CHECK: [[VAR:%.+]] = moore.variable : <i32>
+  // CHECK: [[XVAR:%.+]] = moore.variable : <i32>
+  // CHECK: moore.variable : <i32>
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> decimal
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] decimal : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%d", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> decimal
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] decimal : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%D", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> binary
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] binary : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%b", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> binary
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] binary : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%B", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> octal
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] octal : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%o", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> octal
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] octal : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%O", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_lower
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] hex_lower : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%h", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_lower
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] hex_lower : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%x", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_upper
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] hex_upper : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%H", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_upper
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] hex_upper : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%X", x);
 endfunction
 
@@ -1020,40 +1051,59 @@ endfunction
 // CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
 function void FScanfRealSpecifiers(int fd);
   real r;
+  time t;
   int res;
   // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+  // CHECK: [[TVAR:%.+]] = moore.variable : <time>
+  // CHECK: moore.variable : <i32>
 
-  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%f", r);
 
-  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%e", r);
 
-  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%g", r);
 
-  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%F", r);
 
-  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%E", r);
 
-  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%G", r);
 
-  // CHECK: [[S:%.+]] = moore.scan.time [[RVAR]] : !moore.ref<f64>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
-  res = $fscanf(fd, "%t", r);
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.time [[C]] : time
+  // CHECK: moore.blocking_assign [[TVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
+  res = $fscanf(fd, "%t", t);
 
-  // CHECK: [[S:%.+]] = moore.scan.time [[RVAR]] : !moore.ref<f64>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
-  res = $fscanf(fd, "%T", r);
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.time [[C]] : time
+  // CHECK: moore.blocking_assign [[TVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
+  res = $fscanf(fd, "%T", t);
 endfunction
 
 // CHECK-LABEL: func.func private @FScanfOtherSpecifiers(
@@ -1067,42 +1117,60 @@ function void FScanfOtherSpecifiers(int fd);
   // CHECK: [[SVAR:%.+]] = moore.variable : <string>
   // CHECK: [[CVAR:%.+]] = moore.variable : <i8>
   // CHECK: [[RVAR:%.+]] = moore.variable : <i32>
+  // CHECK: moore.variable : <i32>
 
-  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.str [[C]] : string
+  // CHECK: moore.blocking_assign [[SVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%s", s);
 
-  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.str [[C]] : string
+  // CHECK: moore.blocking_assign [[SVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%S", s);
 
-  // CHECK: [[S:%.+]] = moore.scan.char [[CVAR]] : !moore.ref<i8>
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.char [[C]] : i8
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i8
+  // CHECK: moore.blocking_assign [[CVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%c", c);
 
-  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32>
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.unformatted [[C]] : i32
   // CHECK-NOT: four_value
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%u", raw);
 
-  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32> four_value
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.unformatted [[C]] four_value : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[RVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%z", raw);
 
-  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32> four_value
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.unformatted [[C]] four_value : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[RVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%Z", raw);
 
-  // CHECK: [[S:%.+]] = moore.scan.hier_path_match
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]] = moore.scan.hier_path_match [[C]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%m");
 
-  // CHECK: [[S:%.+]] = moore.scan.hier_path_match
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]] = moore.scan.hier_path_match [[C]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%M");
 
-  // CHECK: [[S:%.+]] = moore.scan.literal "%"
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]] = moore.scan.literal [[C]] "%"
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%%");
 endfunction
 
@@ -1117,50 +1185,65 @@ function void FScanfModifiers(int fd);
   // CHECK: [[IVAR:%.+]] = moore.variable : <i32>
   // CHECK: [[SVAR:%.+]] = moore.variable : <string>
   // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+  // CHECK: moore.variable : <i32>
 
-  // CHECK: [[S:%.+]] = moore.scan.int decimal
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] decimal suppress : i32
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*d");
 
-  // CHECK: [[S:%.+]] = moore.scan.int binary
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] binary suppress : i32
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*b");
 
-  // CHECK: [[S:%.+]] = moore.scan.str
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.str [[C]] suppress : string
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*s");
 
-  // CHECK: [[S:%.+]] = moore.scan.real
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.real [[C]] suppress : f64
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*f");
 
-  // CHECK: [[S:%.+]] = moore.scan.char
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.char [[C]] suppress : i8
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*c");
 
-  // CHECK: [[S:%.+]] = moore.scan.int [[IVAR]] : !moore.ref<i32> decimal width 8
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] decimal width 8 : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[IVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%8d", x);
 
-  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string> width 16
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.str [[C]] width 16 : string
+  // CHECK: moore.blocking_assign [[SVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%16s", s);
 
-  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64> width 10
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] width 10 : f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%10f", r);
 
-
-  // CHECK: [[S:%.+]] = moore.scan.int decimal width 42
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] decimal width 42 suppress : i32
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42d");
 
-  // CHECK: [[S:%.+]] = moore.scan.str width 42
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.str [[C]] width 42 suppress : string
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42s");
 
-  // CHECK: [[S:%.+]] = moore.scan.int hex_lower width 42
-  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] hex_lower width 42 suppress : i32
+  // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42h");
 endfunction
 
@@ -1175,56 +1258,73 @@ function void FScanfComposition(int fd);
   // CHECK: [[AVAR:%.+]] = moore.variable : <i32>
   // CHECK: [[BVAR:%.+]] = moore.variable : <string>
   // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+  // CHECK: moore.variable : <i32>
 
-  // CHECK: [[S1:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
-  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
-  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[S2]])
-  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
+  // CHECK: [[C2:%.+]], [[V2:%.+]] = moore.scan.str [[C1]] : string
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
+  // CHECK: moore.blocking_assign [[BVAR]], [[V2]]
+  // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%d%s", a, b);
 
-  // CHECK: [[SA:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
-  // CHECK: [[SB:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
-  // CHECK: [[SC:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
-  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SA]], [[SB]], [[SC]])
-  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
+  // CHECK: [[C2:%.+]], [[V2:%.+]] = moore.scan.real [[C1]] : f64
+  // CHECK: [[C3:%.+]], [[V3:%.+]] = moore.scan.str [[C2]] : string
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
+  // CHECK: moore.blocking_assign [[RVAR]], [[V2]]
+  // CHECK: moore.blocking_assign [[BVAR]], [[V3]]
+  // CHECK: moore.scan.end [[C3]]
   res = $fscanf(fd, "%d%f%s", a, r, b);
 
-  // CHECK: [[LIT:%.+]] = moore.scan.literal "val="
-  // CHECK: [[SPEC:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
-  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[LIT]], [[SPEC]])
-  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[C1:%.+]] = moore.scan.literal [[C0]] "val="
+  // CHECK: [[C2:%.+]], [[V1:%.+]] = moore.scan.int [[C1]] decimal : i32
+  // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
+  // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "val=%d", a);
 
-  // CHECK: [[SPEC:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
-  // CHECK: [[LIT:%.+]] = moore.scan.literal " end"
-  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SPEC]], [[LIT]])
-  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
+  // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " end"
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
+  // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%d end", a);
 
-  // CHECK: [[S1:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
-  // CHECK: [[LIT:%.+]] = moore.scan.literal " , "
-  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
-  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[LIT]], [[S2]])
-  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
+  // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " , "
+  // CHECK: [[C3:%.+]], [[V2:%.+]] = moore.scan.str [[C2]] : string
+  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
+  // CHECK: moore.blocking_assign [[BVAR]], [[V2]]
+  // CHECK: moore.scan.end [[C3]]
   res = $fscanf(fd, "%d , %s", a, b);
 
-  // CHECK: [[S1:%.+]] = moore.scan.int decimal
-  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
-  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[S2]])
-  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[C1:%.+]], {{%.+}} = moore.scan.int [[C0]] decimal suppress : i32
+  // CHECK: [[C2:%.+]], [[V1:%.+]] = moore.scan.str [[C1]] : string
+  // CHECK: moore.blocking_assign [[BVAR]], [[V1]]
+  // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%*d%s", b);
 
-  // CHECK: [[LIT:%.+]] = moore.scan.literal "prefix"
-  // CHECK-NOT: moore.scan.concat
-  // CHECK: moore.builtin.fscanf [[FD]] [[LIT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[C1:%.+]] = moore.scan.literal [[C0]] "prefix"
+  // CHECK: moore.scan.end [[C1]]
   res = $fscanf(fd, "prefix");
 
-  // CHECK: [[LIT:%.+]] = moore.scan.literal " "
-  // CHECK: moore.builtin.fscanf [[FD]] [[LIT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: [[C1:%.+]] = moore.scan.literal [[C0]] " "
+  // CHECK: moore.scan.end [[C1]]
   res = $fscanf(fd, " ");
 
-  // CHECK-NOT: moore.builtin.fscanf
-  // CHECK: moore.constant 0 : i32
+  // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
+  // CHECK: moore.scan.end [[C0]]
   res = $fscanf(fd, "");
 endfunction
 
@@ -1239,31 +1339,44 @@ function void SScanfBuiltins(string src);
   // CHECK: [[XVAR:%.+]] = moore.variable : <i32>
   // CHECK: [[SVAR:%.+]] = moore.variable : <string>
   // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+  // CHECK: moore.variable : <i32>
 
-  // CHECK: [[SPEC:%.+]] = moore.scan.int [[XVAR]] : !moore.ref<i32> decimal
-  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] decimal : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%d", x);
 
-  // CHECK: [[SPEC:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
-  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.str [[C]] : string
+  // CHECK: moore.blocking_assign [[SVAR]], [[V]]
+  // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%s", s);
 
-  // CHECK: [[SA:%.+]] = moore.scan.int [[XVAR]] : !moore.ref<i32> decimal
-  // CHECK: [[LIT:%.+]] = moore.scan.literal " "
-  // CHECK: [[SB:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
-  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SA]], [[LIT]], [[SB]])
-  // CHECK: moore.builtin.sscanf [[SRC]] [[CAT]]
+  // CHECK: [[C0:%.+]] = moore.scan.begin_sscanf [[SRC]]
+  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
+  // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " "
+  // CHECK: [[C3:%.+]], [[V2:%.+]] = moore.scan.real [[C2]] : f64
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV1]]
+  // CHECK: moore.blocking_assign [[RVAR]], [[V2]]
+  // CHECK: moore.scan.end [[C3]]
   res = $sscanf(src, "%d %f", x, r);
 
-  // CHECK: [[SPEC:%.+]] = moore.scan.int decimal width 8
-  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
+  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] decimal width 8 suppress : i32
+  // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%*8d");
 
-  // CHECK: [[SPEC:%.+]] = moore.scan.unformatted [[XVAR]] : !moore.ref<i32> four_value
-  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
+  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.unformatted [[C]] four_value : i32
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%z", x);
 
-  // CHECK-NOT: moore.builtin.sscanf
-  // CHECK: moore.constant 0 : i32
+  // CHECK: [[C0:%.+]] = moore.scan.begin_sscanf [[SRC]]
+  // CHECK: moore.scan.end [[C0]]
   res = $sscanf(src, "");
 endfunction

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -977,72 +977,82 @@ function void FScanfIntegerSpecifiers(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] decimal : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%d", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] decimal : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%D", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] binary : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] binary : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%b", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] binary : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] binary : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%B", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] octal : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] octal : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%o", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] octal : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] octal : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%O", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] hex_lower : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_lower : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%h", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] hex_lower : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_lower : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%x", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] hex_upper : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_upper : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%H", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] hex_upper : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] hex_upper : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%X", x);
 endfunction
@@ -1058,50 +1068,58 @@ function void FScanfRealSpecifiers(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%f", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%e", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%g", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%F", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%E", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] : f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] : f64, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%G", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.time [[C]] : time
-  // CHECK: moore.blocking_assign [[TVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.time [[C]] : time, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> time
+  // CHECK: moore.blocking_assign [[TVAR]], [[SEL]] : time
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%t", t);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.time [[C]] : time
-  // CHECK: moore.blocking_assign [[TVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.time [[C]] : time, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> time
+  // CHECK: moore.blocking_assign [[TVAR]], [[SEL]] : time
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%T", t);
 endfunction
@@ -1120,41 +1138,49 @@ function void FScanfOtherSpecifiers(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.str [[C]] : string
-  // CHECK: moore.blocking_assign [[SVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : string, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> string
+  // CHECK: moore.blocking_assign [[SVAR]], [[SEL]] : string
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%s", s);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.str [[C]] : string
-  // CHECK: moore.blocking_assign [[SVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : string, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> string
+  // CHECK: moore.blocking_assign [[SVAR]], [[SEL]] : string
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%S", s);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.char [[C]] : i8
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.char [[C]] : i8, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i8
-  // CHECK: moore.blocking_assign [[CVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i8
+  // CHECK: moore.blocking_assign [[CVAR]], [[SEL]] : i8
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%c", c);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.unformatted [[C]] : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] : i32, i1
   // CHECK-NOT: four_value
+  // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%u", raw);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.unformatted [[C]] four_value : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[RVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%z", raw);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.unformatted [[C]] four_value : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[RVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%Z", raw);
 
@@ -1188,61 +1214,64 @@ function void FScanfModifiers(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] decimal suppress : i32
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] decimal suppress : i32, i1
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*d");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] binary suppress : i32
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] binary suppress : i32, i1
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*b");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.str [[C]] suppress : string
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.str [[C]] suppress : string, i1
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*s");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.real [[C]] suppress : f64
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.real [[C]] suppress : f64, i1
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*f");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.char [[C]] suppress : i8
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.char [[C]] suppress : i8, i1
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*c");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] decimal width 8 : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal width 8 : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[IVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[IVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%8d", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.str [[C]] width 16 : string
-  // CHECK: moore.blocking_assign [[SVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] width 16 : string, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> string
+  // CHECK: moore.blocking_assign [[SVAR]], [[SEL]] : string
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%16s", s);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.real [[C]] width 10 : f64
-  // CHECK: moore.blocking_assign [[RVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.real [[C]] width 10 : f64, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL]] : f64
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%10f", r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] decimal width 42 suppress : i32
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] decimal width 42 suppress : i32, i1
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42d");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.str [[C]] width 42 suppress : string
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.str [[C]] width 42 suppress : string, i1
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42s");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] hex_lower width 42 suppress : i32
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] hex_lower width 42 suppress : i32, i1
   // CHECK: moore.scan.end [[R]]
   res = $fscanf(fd, "%*42h");
 endfunction
@@ -1261,55 +1290,65 @@ function void FScanfComposition(int fd);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
-  // CHECK: [[C2:%.+]], [[V2:%.+]] = moore.scan.str [[C1]] : string
-  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
-  // CHECK: moore.blocking_assign [[BVAR]], [[V2]]
+  // CHECK: [[C2:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.str [[C1]] : string, i1
+  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
+  // CHECK: [[SEL2:%.+]] = moore.conditional [[M2]] : i1 -> string
+  // CHECK: moore.blocking_assign [[BVAR]], [[SEL2]] : string
   // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%d%s", a, b);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
-  // CHECK: [[C2:%.+]], [[V2:%.+]] = moore.scan.real [[C1]] : f64
-  // CHECK: [[C3:%.+]], [[V3:%.+]] = moore.scan.str [[C2]] : string
-  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
-  // CHECK: moore.blocking_assign [[RVAR]], [[V2]]
-  // CHECK: moore.blocking_assign [[BVAR]], [[V3]]
+  // CHECK: [[C2:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.real [[C1]] : f64, i1
+  // CHECK: [[C3:%.+]], [[V3:%.+]], [[M3:%.+]] = moore.scan.str [[C2]] : string, i1
+  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
+  // CHECK: [[SEL2:%.+]] = moore.conditional [[M2]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL2]] : f64
+  // CHECK: [[SEL3:%.+]] = moore.conditional [[M3]] : i1 -> string
+  // CHECK: moore.blocking_assign [[BVAR]], [[SEL3]] : string
   // CHECK: moore.scan.end [[C3]]
   res = $fscanf(fd, "%d%f%s", a, r, b);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
   // CHECK: [[C1:%.+]] = moore.scan.literal [[C0]] "val="
-  // CHECK: [[C2:%.+]], [[V1:%.+]] = moore.scan.int [[C1]] decimal : i32
+  // CHECK: [[C2:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C1]] decimal : i32, i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
-  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
+  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
   // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "val=%d", a);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
   // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " end"
-  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
+  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
   // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%d end", a);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
   // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " , "
-  // CHECK: [[C3:%.+]], [[V2:%.+]] = moore.scan.str [[C2]] : string
-  // CHECK: moore.blocking_assign [[AVAR]], [[MV1]]
-  // CHECK: moore.blocking_assign [[BVAR]], [[V2]]
+  // CHECK: [[C3:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.str [[C2]] : string, i1
+  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[AVAR]], [[SEL1]] : i32
+  // CHECK: [[SEL2:%.+]] = moore.conditional [[M2]] : i1 -> string
+  // CHECK: moore.blocking_assign [[BVAR]], [[SEL2]] : string
   // CHECK: moore.scan.end [[C3]]
   res = $fscanf(fd, "%d , %s", a, b);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_fscanf [[FD]]
-  // CHECK: [[C1:%.+]], {{%.+}} = moore.scan.int [[C0]] decimal suppress : i32
-  // CHECK: [[C2:%.+]], [[V1:%.+]] = moore.scan.str [[C1]] : string
-  // CHECK: moore.blocking_assign [[BVAR]], [[V1]]
+  // CHECK: [[C1:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C0]] decimal suppress : i32, i1
+  // CHECK: [[C2:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.str [[C1]] : string, i1
+  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> string
+  // CHECK: moore.blocking_assign [[BVAR]], [[SEL1]] : string
   // CHECK: moore.scan.end [[C2]]
   res = $fscanf(fd, "%*d%s", b);
 
@@ -1342,37 +1381,42 @@ function void SScanfBuiltins(string src);
   // CHECK: moore.variable : <i32>
 
   // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.int [[C]] decimal : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.int [[C]] decimal : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%d", x);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.str [[C]] : string
-  // CHECK: moore.blocking_assign [[SVAR]], [[V]]
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.str [[C]] : string, i1
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> string
+  // CHECK: moore.blocking_assign [[SVAR]], [[SEL]] : string
   // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%s", s);
 
   // CHECK: [[C0:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[C1:%.+]], [[V1:%.+]] = moore.scan.int [[C0]] decimal : i32
+  // CHECK: [[C1:%.+]], [[V1:%.+]], [[M1:%.+]] = moore.scan.int [[C0]] decimal : i32, i1
   // CHECK: [[MV1:%.+]] = moore.from_builtin_int [[V1]] : i32
   // CHECK: [[C2:%.+]] = moore.scan.literal [[C1]] " "
-  // CHECK: [[C3:%.+]], [[V2:%.+]] = moore.scan.real [[C2]] : f64
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV1]]
-  // CHECK: moore.blocking_assign [[RVAR]], [[V2]]
+  // CHECK: [[C3:%.+]], [[V2:%.+]], [[M2:%.+]] = moore.scan.real [[C2]] : f64, i1
+  // CHECK: [[SEL1:%.+]] = moore.conditional [[M1]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL1]] : i32
+  // CHECK: [[SEL2:%.+]] = moore.conditional [[M2]] : i1 -> f64
+  // CHECK: moore.blocking_assign [[RVAR]], [[SEL2]] : f64
   // CHECK: moore.scan.end [[C3]]
   res = $sscanf(src, "%d %f", x, r);
 
   // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[R:%.+]], {{%.+}} = moore.scan.int [[C]] decimal width 8 suppress : i32
+  // CHECK: [[R:%.+]], {{%.+}}, {{%.+}} = moore.scan.int [[C]] decimal width 8 suppress : i32, i1
   // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%*8d");
 
   // CHECK: [[C:%.+]] = moore.scan.begin_sscanf [[SRC]]
-  // CHECK: [[R:%.+]], [[V:%.+]] = moore.scan.unformatted [[C]] four_value : i32
+  // CHECK: [[R:%.+]], [[V:%.+]], [[M:%.+]] = moore.scan.unformatted [[C]] four_value : i32, i1
   // CHECK: [[MV:%.+]] = moore.from_builtin_int [[V]] : i32
-  // CHECK: moore.blocking_assign [[XVAR]], [[MV]]
+  // CHECK: [[SEL:%.+]] = moore.conditional [[M]] : i1 -> i32
+  // CHECK: moore.blocking_assign [[XVAR]], [[SEL]] : i32
   // CHECK: moore.scan.end [[R]]
   res = $sscanf(src, "%z", x);
 

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -966,3 +966,304 @@ function void PlusArgsBuiltins();
   // CHECK: moore.blocking_assign {{%.+}}, [[RESULT]] : i32
   rv = $value$plusargs("BAR=%d", val);
 endfunction
+
+// CHECK-LABEL: func.func private @FScanfIntegerSpecifiers(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfIntegerSpecifiers(int fd);
+  int x;
+  int res;
+
+  // CHECK: [[VAR:%.+]] = moore.variable : <i32>
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> decimal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%d", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> decimal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%D", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> binary
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%b", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> binary
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%B", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> octal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%o", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> octal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%O", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_lower
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%h", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_lower
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%x", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_upper
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%H", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[VAR]] : !moore.ref<i32> hex_upper
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%X", x);
+endfunction
+
+// CHECK-LABEL: func.func private @FScanfRealSpecifiers(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfRealSpecifiers(int fd);
+  real r;
+  int res;
+  // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%f", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%e", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%g", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%F", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%E", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%G", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.time [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%t", r);
+
+  // CHECK: [[S:%.+]] = moore.scan.time [[RVAR]] : !moore.ref<f64>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%T", r);
+endfunction
+
+// CHECK-LABEL: func.func private @FScanfOtherSpecifiers(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfOtherSpecifiers(int fd);
+  string s;
+  byte c;
+  int raw;
+  int res;
+
+  // CHECK: [[SVAR:%.+]] = moore.variable : <string>
+  // CHECK: [[CVAR:%.+]] = moore.variable : <i8>
+  // CHECK: [[RVAR:%.+]] = moore.variable : <i32>
+
+  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%s", s);
+
+  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%S", s);
+
+  // CHECK: [[S:%.+]] = moore.scan.char [[CVAR]] : !moore.ref<i8>
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%c", c);
+
+  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32>
+  // CHECK-NOT: four_value
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%u", raw);
+
+  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32> four_value
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%z", raw);
+
+  // CHECK: [[S:%.+]] = moore.scan.unformatted [[RVAR]] : !moore.ref<i32> four_value
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%Z", raw);
+
+  // CHECK: [[S:%.+]] = moore.scan.hier_path_match
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%m");
+
+  // CHECK: [[S:%.+]] = moore.scan.hier_path_match
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%M");
+
+  // CHECK: [[S:%.+]] = moore.scan.literal "%"
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%%");
+endfunction
+
+// CHECK-LABEL: func.func private @FScanfModifiers(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfModifiers(int fd);
+  int x;
+  string s;
+  real r;
+  int res;
+
+  // CHECK: [[IVAR:%.+]] = moore.variable : <i32>
+  // CHECK: [[SVAR:%.+]] = moore.variable : <string>
+  // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+
+  // CHECK: [[S:%.+]] = moore.scan.int decimal
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*d");
+
+  // CHECK: [[S:%.+]] = moore.scan.int binary
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*b");
+
+  // CHECK: [[S:%.+]] = moore.scan.str
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*s");
+
+  // CHECK: [[S:%.+]] = moore.scan.real
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*f");
+
+  // CHECK: [[S:%.+]] = moore.scan.char
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*c");
+
+  // CHECK: [[S:%.+]] = moore.scan.int [[IVAR]] : !moore.ref<i32> decimal width 8
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%8d", x);
+
+  // CHECK: [[S:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string> width 16
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%16s", s);
+
+  // CHECK: [[S:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64> width 10
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%10f", r);
+
+
+  // CHECK: [[S:%.+]] = moore.scan.int decimal width 42
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*42d");
+
+  // CHECK: [[S:%.+]] = moore.scan.str width 42
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*42s");
+
+  // CHECK: [[S:%.+]] = moore.scan.int hex_lower width 42
+  // CHECK: moore.builtin.fscanf [[FD]] [[S]]
+  res = $fscanf(fd, "%*42h");
+endfunction
+
+// CHECK-LABEL: func.func private @FScanfComposition(
+// CHECK-SAME:  [[FD:%[^ ,]+]]: !moore.i32
+function void FScanfComposition(int fd);
+  int a;
+  string b;
+  real r;
+  int res;
+
+  // CHECK: [[AVAR:%.+]] = moore.variable : <i32>
+  // CHECK: [[BVAR:%.+]] = moore.variable : <string>
+  // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+
+  // CHECK: [[S1:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[S2]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%d%s", a, b);
+
+  // CHECK: [[SA:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[SB:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: [[SC:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SA]], [[SB]], [[SC]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%d%f%s", a, r, b);
+
+  // CHECK: [[LIT:%.+]] = moore.scan.literal "val="
+  // CHECK: [[SPEC:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[LIT]], [[SPEC]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "val=%d", a);
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[LIT:%.+]] = moore.scan.literal " end"
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SPEC]], [[LIT]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%d end", a);
+
+  // CHECK: [[S1:%.+]] = moore.scan.int [[AVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[LIT:%.+]] = moore.scan.literal " , "
+  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[LIT]], [[S2]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%d , %s", a, b);
+
+  // CHECK: [[S1:%.+]] = moore.scan.int decimal
+  // CHECK: [[S2:%.+]] = moore.scan.str [[BVAR]] : !moore.ref<string>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[S1]], [[S2]])
+  // CHECK: moore.builtin.fscanf [[FD]] [[CAT]]
+  res = $fscanf(fd, "%*d%s", b);
+
+  // CHECK: [[LIT:%.+]] = moore.scan.literal "prefix"
+  // CHECK-NOT: moore.scan.concat
+  // CHECK: moore.builtin.fscanf [[FD]] [[LIT]]
+  res = $fscanf(fd, "prefix");
+
+  // CHECK: [[LIT:%.+]] = moore.scan.literal " "
+  // CHECK: moore.builtin.fscanf [[FD]] [[LIT]]
+  res = $fscanf(fd, " ");
+
+  // CHECK-NOT: moore.builtin.fscanf
+  // CHECK: moore.constant 0 : i32
+  res = $fscanf(fd, "");
+endfunction
+
+// CHECK-LABEL: func.func private @SScanfBuiltins(
+// CHECK-SAME:  [[SRC:%[^ ,]+]]: !moore.string
+function void SScanfBuiltins(string src);
+  int x;
+  string s;
+  real r;
+  int res;
+
+  // CHECK: [[XVAR:%.+]] = moore.variable : <i32>
+  // CHECK: [[SVAR:%.+]] = moore.variable : <string>
+  // CHECK: [[RVAR:%.+]] = moore.variable : <f64>
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.int [[XVAR]] : !moore.ref<i32> decimal
+  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  res = $sscanf(src, "%d", x);
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.str [[SVAR]] : !moore.ref<string>
+  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  res = $sscanf(src, "%s", s);
+
+  // CHECK: [[SA:%.+]] = moore.scan.int [[XVAR]] : !moore.ref<i32> decimal
+  // CHECK: [[LIT:%.+]] = moore.scan.literal " "
+  // CHECK: [[SB:%.+]] = moore.scan.real [[RVAR]] : !moore.ref<f64>
+  // CHECK: [[CAT:%.+]] = moore.scan.concat ([[SA]], [[LIT]], [[SB]])
+  // CHECK: moore.builtin.sscanf [[SRC]] [[CAT]]
+  res = $sscanf(src, "%d %f", x, r);
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.int decimal width 8
+  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  res = $sscanf(src, "%*8d");
+
+  // CHECK: [[SPEC:%.+]] = moore.scan.unformatted [[XVAR]] : !moore.ref<i32> four_value
+  // CHECK: moore.builtin.sscanf [[SRC]] [[SPEC]]
+  res = $sscanf(src, "%z", x);
+
+  // CHECK-NOT: moore.builtin.sscanf
+  // CHECK: moore.constant 0 : i32
+  res = $sscanf(src, "");
+endfunction


### PR DESCRIPTION
- Add a new parser converts scan format strings into a tree of Moore scan fragment ops (`moore.scan.literal`, `moore.scan.int`, `moore.scan.real`, `moore.scan.time`, `moore.scan.char`, `moore.scan.str`, `moore.scan.unformatted`, `moore.scan.hier_path_match`, and `moore.scan.concat`).
- Add $fscanf/$sscanf tests in `ImportVerilog/builtins.sv`

