### PR TITLE
[ESI][Runtime] Fix codegen for arrays of odd widths

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -1415,6 +1415,35 @@ class CppTypeEmitter:
     return (isinstance(wrapped, types.IntType) and
             not isinstance(wrapped, types.UIntType))
 
+  def _is_byte_packable(self, esi_type: types.ESIType) -> bool:
+    """True if the type's in-memory C++ layout is byte-for-byte identical to
+    its on-wire bit layout, so a flat per-byte copy round-trips it correctly.
+
+    This holds only when every scalar leaf occupies a whole number of bytes
+    that exactly matches its native storage size:
+
+      * an integer / bits type whose width is one of the native storage
+        widths (8/16/32/64). `ui3`, `si5`, a 1-bit `bool`, and even `ui24`
+        (stored in a wider `uint32_t`) all have storage wider than their
+        wire width and are therefore *not* byte-packable.
+      * a struct / union whose total width is a whole number of bytes -- its
+        `_bytes` buffer already mirrors the wire layout.
+      * an array whose element type is itself byte-packable, so successive
+        elements share the same byte stride on the wire and in memory.
+
+    Anything that is not byte-packable must be (un)packed element-by-element
+    from its individual wire bit offset rather than flat-copied.
+    """
+    wrapped = self._unwrap_aliases(esi_type)
+    if isinstance(wrapped, (types.BitsType, types.IntType)):
+      return wrapped.bit_width in (8, 16, 32, 64)
+    if isinstance(wrapped, types.ArrayType):
+      return self._is_byte_packable(wrapped.element_type)
+    if isinstance(wrapped, (types.StructType, types.UnionType)):
+      bit_width = wrapped.bit_width
+      return bit_width is not None and bit_width > 0 and bit_width % 8 == 0
+    return False
+
   def _emit_field_accessor(self, hdr: TextIO, indent: str, raw_member: str,
                            self_type: str, field_name: str,
                            field_type: types.ESIType, bit_offset: int,
@@ -1638,6 +1667,154 @@ class CppTypeEmitter:
     # UIntView}`.
     is_view_array = (isinstance(wrapped, types.ArrayType) and
                      self._is_value_class_type(wrapped.element_type))
+
+    # An array whose C++ element layout does not match its on-wire layout,
+    # so the flat byte-copy / `copyBitsIn` / `copyBitsOut` paths below would
+    # truncate or misplace elements. Two element kinds need this treatment:
+    #
+    #   * native-integer elements whose storage is wider than the wire
+    #     width -- sub-byte elements (`i1` -> `bool`, `ui3`) or odd widths
+    #     that round up to a wider storage type (`ui24` -> `uint32_t`).
+    #   * struct / union elements whose total width is not a whole number of
+    #     bytes (e.g. a 5-bit `{ui3, ui2}`): successive elements pack at a
+    #     sub-byte stride on the wire but at a padded whole-byte stride in
+    #     the C++ `std::array`.
+    #
+    # In both cases each element is (un)packed one at a time from its own
+    # wire bit offset `bit_offset + i * elem_width`. Nested-array and
+    # view-class elements keep their own paths below.
+    packed_elem = (self._unwrap_aliases(wrapped.element_type) if isinstance(
+        wrapped, types.ArrayType) else None)
+    is_packed_array = (isinstance(wrapped, types.ArrayType) and
+                       not is_view_array and
+                       isinstance(packed_elem,
+                                  (types.BitsType, types.IntType,
+                                   types.StructType, types.UnionType)) and
+                       not self._is_byte_packable(wrapped.element_type))
+
+    if is_packed_array:
+      assert isinstance(wrapped, types.ArrayType)
+      elem_type = wrapped.element_type
+      elem_cpp = self._cpp_type(elem_type)
+      elem_width = elem_type.bit_width
+      elem_count = wrapped.size
+
+      if isinstance(packed_elem, (types.StructType, types.UnionType)):
+        # Aggregate element: its own `_bytes` buffer already mirrors the
+        # wire layout, so copy `elem_width` bits between the parent buffer
+        # and the element's bytes (which start at the element's bit 0). The
+        # `reinterpret_cast<uint8_t *>` mirrors the whole-aggregate byte
+        # copy emitted further below.
+        hdr.write(f"{indent}{elem_cpp} {field_name}(std::size_t i) const {{\n")
+        hdr.write(f"{indent}  {elem_cpp} out{{}};\n")
+        hdr.write(f"{indent}  auto *dst = reinterpret_cast<uint8_t *>(&out);\n")
+        hdr.write(f"{indent}  const std::size_t bit_off = "
+                  f"{bit_offset} + i * {elem_width};\n")
+        hdr.write(
+            f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
+        hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
+        hdr.write(f"{indent}    if (({raw_member}[g / 8] >> (g % 8)) & 1u)\n")
+        hdr.write(f"{indent}      dst[b / 8] |= "
+                  f"static_cast<uint8_t>(uint8_t{{1}} << (b % 8));\n")
+        hdr.write(f"{indent}  }}\n")
+        hdr.write(f"{indent}  return out;\n")
+        hdr.write(f"{indent}}}\n")
+
+        hdr.write(f"{indent}{self_type} &{field_name}(std::size_t i, "
+                  f"const {elem_cpp} &v) {{\n")
+        hdr.write(f"{indent}  const auto *src = "
+                  f"reinterpret_cast<const uint8_t *>(&v);\n")
+        hdr.write(f"{indent}  const std::size_t bit_off = "
+                  f"{bit_offset} + i * {elem_width};\n")
+        hdr.write(
+            f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
+        hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
+        hdr.write(f"{indent}    const uint8_t bit = static_cast<uint8_t>("
+                  f"(src[b / 8] >> (b % 8)) & 1u);\n")
+        hdr.write(f"{indent}    {raw_member}[g / 8] = static_cast<uint8_t>(\n")
+        hdr.write(
+            f"{indent}        ({raw_member}[g / 8] & static_cast<uint8_t>("
+            f"~(uint8_t{{1}} << (g % 8)))) |\n")
+        hdr.write(f"{indent}        static_cast<uint8_t>(bit << (g % 8)));\n")
+        hdr.write(f"{indent}  }}\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+      else:
+        signed = self._is_signed_int_field(elem_type)
+        is_bool = (elem_cpp == "bool")
+        # Unsigned storage used to assemble/disassemble the element bits; a
+        # signed value is recovered afterwards with an explicit
+        # sign-extension so the shifts never touch the sign bit (mirrors
+        # `readSignedBits`).
+        if is_bool:
+          unsigned_cpp = "uint8_t"
+        elif signed:
+          unsigned_cpp = "u" + elem_cpp
+        else:
+          unsigned_cpp = elem_cpp
+
+        # Per-element getter: assemble `elem_width` bits LSB-first starting
+        # at the element's wire offset `bit_offset + i * elem_width`.
+        hdr.write(f"{indent}{elem_cpp} {field_name}(std::size_t i) const {{\n")
+        hdr.write(f"{indent}  const std::size_t bit_off = "
+                  f"{bit_offset} + i * {elem_width};\n")
+        if is_bool:
+          hdr.write(f"{indent}  return (({raw_member}[bit_off / 8] >> "
+                    f"(bit_off % 8)) & 1u) != 0;\n")
+        else:
+          hdr.write(f"{indent}  {unsigned_cpp} u = 0;\n")
+          hdr.write(
+              f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
+          hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
+          hdr.write(f"{indent}    u = static_cast<{unsigned_cpp}>(\n")
+          hdr.write(f"{indent}        u | (static_cast<{unsigned_cpp}>("
+                    f"({raw_member}[g / 8] >> (g % 8)) & 1u) << b));\n")
+          hdr.write(f"{indent}  }}\n")
+          if signed:
+            hdr.write(f"{indent}  constexpr {unsigned_cpp} signBit = "
+                      f"static_cast<{unsigned_cpp}>({unsigned_cpp}{{1}} << "
+                      f"{elem_width - 1});\n")
+            hdr.write(f"{indent}  u = static_cast<{unsigned_cpp}>("
+                      f"(u ^ signBit) - signBit);\n")
+          hdr.write(f"{indent}  return static_cast<{elem_cpp}>(u);\n")
+        hdr.write(f"{indent}}}\n")
+
+        # Per-element setter: write `elem_width` bits LSB-first into the
+        # element's wire offset, leaving the surrounding bits untouched.
+        hdr.write(f"{indent}{self_type} &{field_name}(std::size_t i, "
+                  f"{elem_cpp} v) {{\n")
+        hdr.write(f"{indent}  const std::size_t bit_off = "
+                  f"{bit_offset} + i * {elem_width};\n")
+        hdr.write(f"{indent}  const {unsigned_cpp} u = "
+                  f"static_cast<{unsigned_cpp}>(v);\n")
+        hdr.write(
+            f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
+        hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
+        hdr.write(f"{indent}    const uint8_t bit = static_cast<uint8_t>("
+                  f"(u >> b) & {unsigned_cpp}{{1}});\n")
+        hdr.write(f"{indent}    {raw_member}[g / 8] = static_cast<uint8_t>(\n")
+        hdr.write(
+            f"{indent}        ({raw_member}[g / 8] & static_cast<uint8_t>("
+            f"~(uint8_t{{1}} << (g % 8)))) |\n")
+        hdr.write(f"{indent}        static_cast<uint8_t>(bit << (g % 8)));\n")
+        hdr.write(f"{indent}  }}\n")
+        hdr.write(f"{indent}  return *this;\n")
+        hdr.write(f"{indent}}}\n")
+
+      # Whole-array getter/setter forward to the per-element accessors so the
+      # public API matches the byte-packable array case exactly.
+      hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
+      hdr.write(f"{indent}  {field_cpp} out{{}};\n")
+      hdr.write(f"{indent}  for (std::size_t i = 0; i < {elem_count}; ++i)\n")
+      hdr.write(f"{indent}    out[i] = {field_name}(i);\n")
+      hdr.write(f"{indent}  return out;\n")
+      hdr.write(f"{indent}}}\n")
+      hdr.write(f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
+      hdr.write(f"{indent}  for (std::size_t i = 0; i < {elem_count}; ++i)\n")
+      hdr.write(f"{indent}    {field_name}(i, v[i]);\n")
+      hdr.write(f"{indent}  return *this;\n")
+      hdr.write(f"{indent}}}\n")
+      return
 
     if not is_view_array:
       if byte_aligned:

--- a/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
+++ b/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
@@ -313,6 +313,124 @@ void testArrayOfIntegers() {
 }
 
 // ---------------------------------------------------------------------------
+// Packed arrays: element storage size != on-wire element width
+// ---------------------------------------------------------------------------
+//
+// These exercise the per-element bit-unpacking path. Unlike `Arr4` (whose
+// `ui8` elements are whole bytes), the C++ `std::array` here is wider in
+// memory than the bit-packed wire layout, so a flat byte copy would both
+// truncate the field and misplace every element after the first.
+
+void testSubByteUnsignedArray() {
+  // `8 x ui3` => 24 wire bits (3 bytes) packed into a `std::array<uint8_t, 8>`
+  // (8 bytes in memory). Each element occupies its own 3-bit window.
+  U3Arr a;
+  a.vals({1, 2, 3, 4, 5, 6, 7, 0});
+  const std::array<uint8_t, 8> expected = {1, 2, 3, 4, 5, 6, 7, 0};
+  auto whole = a.vals();
+  for (std::size_t i = 0; i < 8; ++i) {
+    assert(whole[i] == expected[i]);
+    assert(a.vals(i) == expected[i]);
+  }
+  // bit-packed LSB-first: elem i at bits [3i, 3i+2].
+  expectBytes(a, std::array<uint8_t, 3>{0xD1, 0x58, 0x1F}, "U3Arr packed");
+
+  // A single element straddling a byte boundary (elem 2 spans bits 6..8).
+  U3Arr b;
+  b.vals(2, 7);
+  assert(b.vals(2) == 7);
+  for (std::size_t i = 0; i < 8; ++i)
+    if (i != 2)
+      assert(b.vals(i) == 0);
+  expectBytes(b, std::array<uint8_t, 3>{0xC0, 0x01, 0x00}, "U3Arr cross-byte");
+}
+
+void testSubByteBoolArray() {
+  // `8 x ui1` => 8 wire bits (1 byte) packed into a `std::array<bool, 8>`
+  // (8 bytes in memory). Each element is a single bit; reads must yield a
+  // valid `bool` (0/1) rather than dumping a raw byte into bool storage.
+  Bits1Arr a;
+  const std::array<bool, 8> flags = {true, true,  false, false,
+                                     true, false, true,  true};
+  a.flags(flags);
+  auto whole = a.flags();
+  for (std::size_t i = 0; i < 8; ++i) {
+    assert(whole[i] == flags[i]);
+    assert(a.flags(i) == flags[i]);
+  }
+  expectBytes(a, std::array<uint8_t, 1>{0xD3}, "Bits1Arr");
+}
+
+void testSubByteSignedArray() {
+  // `4 x si5` => 20 wire bits (3 bytes) packed into a `std::array<int8_t, 4>`
+  // (4 bytes in memory). Reads must sign-extend the 5-bit value.
+  S5Arr a;
+  const std::array<int8_t, 4> vals = {-1, -16, 15, 0};
+  a.vals(vals);
+  auto whole = a.vals();
+  for (std::size_t i = 0; i < 4; ++i) {
+    assert(whole[i] == vals[i]);
+    assert(a.vals(i) == vals[i]);
+  }
+  expectBytes(a, std::array<uint8_t, 3>{0x1F, 0x3E, 0x00}, "S5Arr");
+}
+
+void testOddWidthArray() {
+  // `2 x ui24` => 48 wire bits (6 bytes) packed into a `std::array<uint32_t,
+  // 2>` (8 bytes in memory). The element wire stride (3 bytes) differs from
+  // the storage stride (4 bytes), so a flat copy would corrupt elem 1.
+  U24Arr a;
+  const std::array<uint32_t, 2> vals = {0xABCDEFu, 0x123456u};
+  a.vals(vals);
+  auto whole = a.vals();
+  for (std::size_t i = 0; i < 2; ++i) {
+    assert(whole[i] == vals[i]);
+    assert(a.vals(i) == vals[i]);
+  }
+  expectBytes(a, std::array<uint8_t, 6>{0xEF, 0xCD, 0xAB, 0x56, 0x34, 0x12},
+              "U24Arr");
+}
+
+void testSubByteStructArray() {
+  // `4 x {ui3 hi, ui2 lo}`: each element is 5 wire bits (20 bits = 3 bytes)
+  // but a padded 1-byte `SbCell` in memory, so the whole-array accessor must
+  // unpack each element from its own 5-bit window. Within a cell `lo` lands
+  // at bits 0..1 and `hi` at bits 2..4 (wire order is reversed manifest
+  // order).
+  SbCellArr a;
+  std::array<SbCell, 4> cells;
+  cells[0] = SbCell(1, 0);
+  cells[1] = SbCell(2, 1);
+  cells[2] = SbCell(3, 2);
+  cells[3] = SbCell(7, 3);
+  a.cells(cells);
+
+  auto whole = a.cells();
+  for (std::size_t i = 0; i < 4; ++i) {
+    assert(whole[i].hi() == cells[i].hi());
+    assert(whole[i].lo() == cells[i].lo());
+    assert(a.cells(i).hi() == cells[i].hi());
+    assert(a.cells(i).lo() == cells[i].lo());
+  }
+  // cell i value = (hi << 2) | lo, placed at bits [5i, 5i+4].
+  expectBytes(a, std::array<uint8_t, 3>{0x24, 0xB9, 0x0F}, "SbCellArr");
+
+  // Indexed setter on a single element straddling a byte boundary (cell 1
+  // spans bits 5..9). Other cells stay zero.
+  SbCellArr b;
+  b.cells(1, SbCell(7, 3));
+  assert(b.cells(1).hi() == 7);
+  assert(b.cells(1).lo() == 3);
+  for (std::size_t i = 0; i < 4; ++i)
+    if (i != 1) {
+      assert(b.cells(i).hi() == 0);
+      assert(b.cells(i).lo() == 0);
+    }
+  expectBytes(b, std::array<uint8_t, 3>{0xE0, 0x03, 0x00},
+              "SbCellArr cross-byte");
+}
+
+// ---------------------------------------------------------------------------
 // Unions
 // ---------------------------------------------------------------------------
 
@@ -683,6 +801,11 @@ int main() {
   testNestedStruct();
   testNestedStructMisaligned();
   testArrayOfIntegers();
+  testSubByteUnsignedArray();
+  testSubByteBoolArray();
+  testSubByteSignedArray();
+  testOddWidthArray();
+  testSubByteStructArray();
   testUnion();
   testWindowList();
   testWideUnsigned();

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -35,6 +35,7 @@ requires_cmake = pytest.mark.skipif(shutil.which("cmake") is None,
 
 # Small set of pre-built ESI scalar types shared by the manifest builders.
 _uint1 = types.UIntType("ui1", 1)
+_uint2 = types.UIntType("ui2", 2)
 _uint3 = types.UIntType("ui3", 3)
 _uint7 = types.UIntType("ui7", 7)
 _uint8 = types.UIntType("ui8", 8)
@@ -130,6 +131,45 @@ def _build_harness_manifest():
   arr4_type = types.ArrayType("!hw.array<4xui8>", _uint8, 4)
   arr4_inner = types.StructType("@Arr4::inner", [("r", arr4_type)])
   arr4 = types.TypeAlias("@Arr4", "Arr4", arr4_inner)
+
+  # Arrays whose element storage size differs from the on-wire element
+  # width, so the whole-array accessor must unpack each element from its
+  # own wire bit offset instead of flat-copying. `std::array<uint8_t, 8>`
+  # (ui3), `std::array<bool, 8>` (ui1), `std::array<int8_t, 4>` (si5), and
+  # `std::array<uint32_t, 2>` (ui24) are all wider in memory than the
+  # bit-packed wire layout they represent.
+  u3_arr_inner = types.StructType(
+      "@U3Arr::inner",
+      [("vals", types.ArrayType("!hw.array<8xui3>", _uint3, 8))])
+  u3_arr = types.TypeAlias("@U3Arr", "U3Arr", u3_arr_inner)
+
+  bits1_arr_inner = types.StructType(
+      "@Bits1Arr::inner",
+      [("flags", types.ArrayType("!hw.array<8xui1>", _uint1, 8))])
+  bits1_arr = types.TypeAlias("@Bits1Arr", "Bits1Arr", bits1_arr_inner)
+
+  s5_arr_inner = types.StructType(
+      "@S5Arr::inner",
+      [("vals", types.ArrayType("!hw.array<4xsi5>", _sint5, 4))])
+  s5_arr = types.TypeAlias("@S5Arr", "S5Arr", s5_arr_inner)
+
+  u24_arr_inner = types.StructType(
+      "@U24Arr::inner",
+      [("vals", types.ArrayType("!hw.array<2xui24>", _uint24, 2))])
+  u24_arr = types.TypeAlias("@U24Arr", "U24Arr", u24_arr_inner)
+
+  # Array of sub-byte STRUCT elements. Each `{ui3 hi, ui2 lo}` cell is 5
+  # wire bits, so successive cells pack at a 5-bit stride on the wire but a
+  # padded 1-byte stride in the C++ `std::array<SbCell, 4>`. Exercises the
+  # aggregate arm of the packed-array accessor, which copies each element's
+  # bits into its own `_bytes` buffer.
+  sb_cell_inner = types.StructType("@SbCell::inner", [("hi", _uint3),
+                                                      ("lo", _uint2)])
+  sb_cell = types.TypeAlias("@SbCell", "SbCell", sb_cell_inner)
+  sb_cell_arr_inner = types.StructType(
+      "@SbCellArr::inner",
+      [("cells", types.ArrayType("!hw.array<4xSbCell>", sb_cell, 4))])
+  sb_cell_arr = types.TypeAlias("@SbCellArr", "SbCellArr", sb_cell_arr_inner)
 
   # Union with one narrow and one wide variant.
   union_inner = types.UnionType("@UnionTwo::inner", [("small", _uint8),
@@ -241,8 +281,9 @@ def _build_harness_manifest():
 
   return [
       std_u, std_s, odd_u, odd_s, sub_u, sub_s, bool_field, outer, misaligned,
-      arr4, union_two, list_window, wide_u, wide_s, bits_field, wide_mis,
-      arr_views, arr_views_mis
+      arr4, u3_arr, bits1_arr, s5_arr, u24_arr, sb_cell, sb_cell_arr, union_two,
+      list_window, wide_u, wide_s, bits_field, wide_mis, arr_views,
+      arr_views_mis
   ]
 
 


### PR DESCRIPTION
Arrays of non-power-of-two integrals and structs whose size wasn't a multiple of 8 were broken. This fixes them.

Assisted-by: vscode:Claude Opus 4.8
