### PR TITLE
[ImportVerilog] Make making source locations proximate optional

### DIFF
--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -131,6 +131,10 @@ struct ImportVerilogOptions {
   /// A list of paths in which to suppress warnings.
   std::vector<std::string> suppressWarningsPaths;
 
+  /// If true, make paths for source file debug locations relative to the
+  /// current working directory. Otherwise, leave them unchanged.
+  bool makeLocationPathsProximate = true;
+
   //===--------------------------------------------------------------------===//
   // File lists
   //===--------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -223,6 +223,8 @@ LogicalResult ImportDriver::prepareDriver(SourceMgr &sourceMgr) {
   // source text in memory. At a later stage we'll want to extend slang's
   // SourceManager such that it can contain non-owned buffers. This will do
   // for now.
+  driver.sourceManager.setDisableProximatePaths(
+      !options.makeLocationPathsProximate);
   DenseSet<StringRef> seenBuffers;
   for (unsigned i = 0, e = sourceMgr.getNumBuffers(); i < e; ++i) {
     const llvm::MemoryBuffer *mlirBuffer = sourceMgr.getMemoryBuffer(i + 1);

--- a/test/Conversion/ImportVerilog/proximate-source-locations.sv
+++ b/test/Conversion/ImportVerilog/proximate-source-locations.sv
@@ -1,0 +1,27 @@
+// RUN: circt-verilog --ir-moore -mlir-print-debuginfo %s \
+// RUN:   | FileCheck %s --check-prefix=DEFAULT
+// RUN: circt-verilog --ir-moore -mlir-print-debuginfo --make-source-locations-proximate=false %s \
+// RUN:   | FileCheck %s --check-prefix=NOPROX
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// Windows uses different paths formats; only check the Unix format.
+// UNSUPPORTED: system-windows
+
+// The "proximate" locations are relative paths, so they don't start with a `/`.
+// DEFAULT:      moore.module @Empty()
+// DEFAULT-NEXT:   moore.output
+// DEFAULT-NEXT: } loc(#[[LOC:.+]])
+// DEFAULT:      #[[LOC]] = loc("{{[^/].*}}":{{[0-9]+:[0-9]+}})
+
+// The "non-proximate" locations use the path given on the command line,
+// i.e., `%s`, which is absolute.
+// NOPROX:      moore.module @Empty()
+// NOPROX-NEXT:   moore.output
+// NOPROX-NEXT: } loc(#[[LOC:.+]])
+// NOPROX:      #[[LOC]] = loc("/{{[^.].*}}":{{[0-9]+:[0-9]+}})
+
+module Empty;
+endmodule

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -264,6 +264,11 @@ struct CLOptions {
       cl::desc("One or more paths in which to suppress warnings"),
       cl::value_desc("filename"), cl::cat(cat)};
 
+  cl::opt<bool> makeSourceLocationsProximate{
+      "make-source-locations-proximate",
+      cl::desc("Make paths for source file debug locations proximate"),
+      cl::init(true), cl::cat(cat)};
+
   //===--------------------------------------------------------------------===//
   // File lists
   //===--------------------------------------------------------------------===//
@@ -367,6 +372,7 @@ static LogicalResult executeWithSources(MLIRContext *context,
   if (opts.errorLimit.getNumOccurrences() > 0)
     options.errorLimit = opts.errorLimit;
   options.suppressWarningsPaths = opts.suppressWarningsPaths;
+  options.makeLocationPathsProximate = opts.makeSourceLocationsProximate;
 
   options.singleUnit = opts.singleUnit;
   options.libraryFiles = opts.libraryFiles;


### PR DESCRIPTION
This is an alternative to #10599. It depends on a recent change in slang, so it won't actually work until that has been released and integrated in CIRCT.

Introduce the `makeLocationPathsProximate` option to `ImportVerilogOptions` that instructs slang to not make the paths of the debug source locations "proximate" (i.e., relative to the CWD) during Verilog import. Concretely, the flag controls slang's `disableProximatePaths` option: By default (`makeLocationPathsProximate = true`), slang makes paths "proximate"; if the new flag is set, that mechanism is disabled, i.e., the paths are kept as is.

The CWD-relative behavior (the default) calls `SourceManager::getFileName()`, which returns the path made relative to the CWD. This has several problems:

1. Thread safety: `proximate()` internally reads `current_path()`, which is a process-global state. `importVerilog` can be used in multi-threaded context while other threads change the CWD (even though they probably shouldn't), leading to inconsistent `Location`s.
2. Arbitrary semantics: The resulting paths have no semantic relationship with the CWD. The source files only have a relationship with the command files they come from but those command files may be in arbitrary and different locations with no relationship to the CWD. In the most extreme (but realistic!) case, the CWD shares no prefix with the source files, such that the `Location`s start with `../../../../../../` to encode `/`.

Unmodified paths give the user full control, including the possiblity to use absolute paths. These are thread-safe and unambiguous. They encode `/` with the shortest possible representation and embrace the fact that there is no base folder to which relative paths would make sense. In order to protect existing users against breaking changes, the new semantics are behind a flag.

Note that this only affects `Location`s, i.e., debug symbols and any debugging infrastructure that may use them, not the actual reading of the files.

Expose the option to `circt-verilog` via the new `--make-source-locations-proximate` command-line flag.