### PR TITLE
[ImportVerilog] Fix bit-vector builtins rejecting packed non-integer types

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3300,11 +3300,18 @@ Value Context::convertSystemCall(
     auto value = convertRvalueExpression(*args[0]);
     if (!value)
       return {};
-    auto valTy = dyn_cast<moore::IntType>(value.getType());
-    if (!valTy) {
-      mlir::emitError(loc) << "expected integer argument for `$isunknown`";
-      return {};
+
+    if (!isa<moore::IntType>(value.getType())) {
+      if (!isa<moore::PackedType>(value.getType())) {
+        mlir::emitError(loc) << "expected integer argument for `$isunknown`";
+        return {};
+      }
+      value = materializePackedToSBVConversion(*this, value, loc,
+                                               /*fallible=*/false);
+      if (!value)
+        return {};
     }
+    auto valTy = dyn_cast<moore::IntType>(value.getType());
     return getIsUnknown(builder, loc, value, valTy, getContext());
   }
 
@@ -3313,6 +3320,17 @@ Value Context::convertSystemCall(
     auto value = convertRvalueExpression(*args[0]);
     if (!value)
       return {};
+    if (!isa<moore::IntType>(value.getType())) {
+      if (!isa<moore::PackedType>(value.getType())) {
+        mlir::emitError(loc)
+            << "expected integer argument for `$onehot`/`$onehot0`";
+        return {};
+      }
+      value = materializePackedToSBVConversion(*this, value, loc,
+                                               /*fallible=*/false);
+      if (!value)
+        return {};
+    }
     auto valTy = dyn_cast<moore::IntType>(value.getType());
     if (!valTy) {
       mlir::emitError(loc) << "expected integer argument for `"
@@ -3364,6 +3382,16 @@ Value Context::convertSystemCall(
     auto value = convertRvalueExpression(*args[0]);
     if (!value)
       return {};
+    if (!isa<moore::IntType>(value.getType())) {
+      if (!isa<moore::PackedType>(value.getType())) {
+        mlir::emitError(loc) << "expected integer argument for `$countones`";
+        return {};
+      }
+      value = materializePackedToSBVConversion(*this, value, loc,
+                                               /*fallible=*/false);
+      if (!value)
+        return {};
+    }
     auto valTy = dyn_cast<moore::IntType>(value.getType());
     if (!valTy) {
       mlir::emitError(loc) << "expected integer argument for `$countones`";

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -708,6 +708,42 @@ module SampleValueBuiltins #() (
     assert property (@(posedge clk_i) $countones(data_bit_i) == 0);
 endmodule
 
+// CHECK-LABEL: func.func private @BitVectorPackedBuiltins(
+// CHECK-SAME: [[S:%[^ ,]+]]: !moore.struct<{a: l4, b: l4}>,
+// CHECK-SAME: [[A:%[^ ,]+]]: !moore.array<2 x l4>)
+function void BitVectorPackedBuiltins(
+    struct packed { logic [3:0] a; logic [3:0] b; } s,
+    logic [1:0][3:0] arr);
+  bit result;
+  int cnt;
+
+  // CHECK: [[SBV:%.+]] = moore.packed_to_sbv [[S]] : struct<{a: l4, b: l4}>
+  // CHECK-NEXT: [[RED:%.+]] = moore.reduce_xor [[SBV]] : l8 -> l1
+  // CHECK-NEXT: [[X:%.+]] = moore.constant bX : l1
+  // CHECK-NEXT: moore.case_eq [[RED]], [[X]] : l1
+  result = $isunknown(s);
+
+  // CHECK: [[SBV2:%.+]] = moore.packed_to_sbv [[S]] : struct<{a: l4, b: l4}>
+  // CHECK: moore.reduce_xor [[SBV2]] : l8 -> l1
+  // CHECK: comb.icmp eq
+  result = $onehot0(s);
+
+  // CHECK: [[SBV3:%.+]] = moore.packed_to_sbv [[S]] : struct<{a: l4, b: l4}>
+  // CHECK: moore.reduce_xor [[SBV3]] : l8 -> l1
+  // CHECK: comb.icmp ne
+  result = $onehot(s);
+
+  // CHECK: [[SBV4:%.+]] = moore.packed_to_sbv [[S]] : struct<{a: l4, b: l4}>
+  // CHECK-NEXT: moore.logic_to_int [[SBV4]] : l8
+  cnt = $countones(s);
+
+  // CHECK: [[SBV5:%.+]] = moore.packed_to_sbv [[A]] : array<2 x l4>
+  // CHECK-NEXT: [[RED2:%.+]] = moore.reduce_xor [[SBV5]] : l8 -> l1
+  // CHECK-NEXT: [[X2:%.+]] = moore.constant bX : l1
+  // CHECK-NEXT: moore.case_eq [[RED2]], [[X2]] : l1
+  result = $isunknown(arr);
+endfunction
+
 // CHECK-LABEL: func.func private @StringBuiltins(
 // CHECK-SAME: [[STR:%.+]]: !moore.string,
 // CHECK-SAME: [[INT:%.+]]: !moore.i32,


### PR DESCRIPTION
$isunknown, $onehot, $onehot0, and $countones each checked for moore::IntType and emitted an error for any other arguemnt, but per IEEE 1800-2017 §20.9 "Bit vector system functions" the expression argument shall be of a bit-stream type, which uncludes packed structs, packed arrays, and packed unions.

**Example:**
```
typedef struct packed {
  logic [3:0] a;
  logic [3:0] b;
} my_struct_t;

module test_isunknown;
  my_struct_t s;
  logic result;
  logic [7:0][3:0] arr;

  initial begin
    result = $isunknown(s);
    result = $isunknown(arr);
  end
endmodule
```
```
error: expected integer argument for `$isunknown`
```

Fix:
Insert a materializePackedToSBVConversion before the existing integer handle so that any packed type is first flattened to its simple bit vector equivalent.

