### PR TITLE
[ArcToLLVM] Fix padding of integer format ops

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/FmtDescriptor.h
+++ b/include/circt/Dialect/Arc/Runtime/FmtDescriptor.h
@@ -76,13 +76,15 @@ struct FmtDescriptor {
   /// The integer value will be passed as a variadic argument by *pointer*.
   static FmtDescriptor createInt(int32_t bitwidth, int8_t radix,
                                  bool isLeftAligned, int32_t specifierWidth,
-                                 bool isUpperCase, bool isSigned) {
+                                 char paddingChar, bool isUpperCase,
+                                 bool isSigned) {
     FmtDescriptor d;
     d.action = Action_Int;
     d.intFmt.bitwidth = bitwidth;
     d.intFmt.radix = radix;
     d.intFmt.isLeftAligned = isLeftAligned;
     d.intFmt.specifierWidth = specifierWidth;
+    d.intFmt.paddingChar = paddingChar;
     d.intFmt.isUpperCase = isUpperCase;
     d.intFmt.isSigned = isSigned;
     return d;

--- a/integration_test/arcilator/JIT/fmt-padding.mlir
+++ b/integration_test/arcilator/JIT/fmt-padding.mlir
@@ -1,0 +1,26 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck %s --strict-whitespace --match-full-lines
+// REQUIRES: arcilator-jit
+
+// The integer formatters must pad with the format op's padding character -- a
+// space for `sim.fmt.dec` and '0' for `sim.fmt.hex` -- rather than with NUL
+// bytes. The value is bracketed so the padding is visible to FileCheck under
+// `--strict-whitespace`.
+
+func.func @entry() {
+  %open = sim.fmt.literal "["
+  %close = sim.fmt.literal "]\n"
+
+  // CHECK:[   5]
+  %c4 = hw.constant 5 : i4
+  %dec = sim.fmt.dec %c4 : i4
+  %decMsg = sim.fmt.concat (%open, %dec, %close)
+  sim.proc.print %decMsg
+
+  // CHECK:[05]
+  %c8 = hw.constant 5 : i8
+  %hex = sim.fmt.hex %c8, isUpper false : i8
+  %hexMsg = sim.fmt.concat (%open, %hex, %close)
+  sim.proc.print %hexMsg
+
+  return
+}

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -941,21 +941,24 @@ foldFormatString(ConversionPatternRewriter &rewriter, Value fstringValue,
                                   -> FailureOr<FormatInfo> {
         FmtDescriptor d = FmtDescriptor::createInt(
             op.getValue().getType().getWidth(), 10, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), false, op.getIsSigned());
+            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+            op.getIsSigned());
         return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
       })
       .Case<sim::FormatHexOp>([&](sim::FormatHexOp op)
                                   -> FailureOr<FormatInfo> {
         FmtDescriptor d = FmtDescriptor::createInt(
             op.getValue().getType().getWidth(), 16, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getIsHexUppercase(), false);
+            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(),
+            op.getIsHexUppercase(), false);
         return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
       })
       .Case<sim::FormatOctOp>([&](sim::FormatOctOp op)
                                   -> FailureOr<FormatInfo> {
         FmtDescriptor d = FmtDescriptor::createInt(
             op.getValue().getType().getWidth(), 8, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), false, false);
+            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+            false);
         return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
       })
       .Case<sim::FormatLiteralOp>(


### PR DESCRIPTION
When lowering `sim.fmt.dec`, `sim.fmt.hex`, and `sim.fmt.oct` for the JIT, the `FmtDescriptor` was built without the op's padding character, leaving that descriptor field uninitialized. At runtime this padded formatted integers with NUL bytes instead of the intended character -- spaces for decimal, '0' for hex and octal -- corrupting the printed output.

Thread the padding character through `FmtDescriptor::createInt` and pass `op.getPaddingChar()` at each call site. Add a JIT test that brackets a padded value so the padding bytes are checked under `--strict-whitespace`.

Assisted-by: Claude Opus 4.8
