### PR TITLE
[HWToLLVM] Convert function signature, return, and call types

### DIFF
--- a/lib/Conversion/HWToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HWToLLVM/CMakeLists.txt
@@ -10,6 +10,8 @@ add_circt_conversion_library(CIRCTHWToLLVM
   LINK_LIBS PUBLIC
   CIRCTHW
   CIRCTSupport
+  MLIRFuncDialect
+  MLIRFuncTransforms
   MLIRLLVMCommonConversion
   MLIRTransforms
 )

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -16,6 +16,8 @@
 #include "circt/Support/Namespace.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
@@ -859,14 +861,39 @@ void HWToLLVMLoweringPass::runOnOperation() {
   // Don't touch non-HW operations
   target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 
+  // Rewrite the aggregate HW types carried by function signatures and the
+  // `return`/`call` ops that wire values through them, so that no leftover
+  // values of HW type remain once the HW ops have been lowered. The op
+  // legality is keyed on the type converter.
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+    return converter.isSignatureLegal(op.getFunctionType()) &&
+           converter.isLegal(&op.getBody());
+  });
+  target.addDynamicallyLegalOp<func::ReturnOp, func::CallOp>(
+      [&](Operation *op) { return converter.isLegal(op); });
+
   // Setup the conversion.
   populateHWToLLVMConversionPatterns(converter, patterns, globals,
                                      constAggregateGlobalsMap, spillCacheOpt);
+  populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
+                                                                 converter);
+  populateReturnOpTypeConversionPattern(patterns, converter);
+  populateCallOpTypeConversionPattern(patterns, converter);
 
   // Apply the partial conversion.
   ConversionConfig config;
   config.allowPatternRollback = false;
   if (failed(applyPartialConversion(getOperation(), target, std::move(patterns),
                                     config)))
-    signalPassFailure();
+    return signalPassFailure();
+
+  // Reconcile the temporary `unrealized_conversion_cast` ops the conversion
+  // left behind -- in particular the `hw -> llvm -> hw` round-trips that the
+  // framework materializes around spilled values whose signature was
+  // converted. This keeps the pass self-contained instead of relying on a
+  // downstream reconcile pass; genuine boundary casts are left in place.
+  SmallVector<UnrealizedConversionCastOp> castOps;
+  getOperation()->walk(
+      [&](UnrealizedConversionCastOp op) { castOps.push_back(op); });
+  reconcileUnrealizedCasts(castOps, /*remainingCastOps=*/nullptr);
 }

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -1,15 +1,11 @@
 // RUN: circt-opt %s --convert-hw-to-llvm=spill-arrays-early=false | FileCheck %s
 
 // CHECK-LABEL: @convertArray
+// CHECK-SAME: (%arg0: i1, %arg1: !llvm.array<2 x i32>,
 func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
-  // CHECK-NEXT: %[[CAST0:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[CAST1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[CAST2:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[CAST3:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-
   // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA:.*]] = llvm.alloca %[[ONE]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST3]], %[[ALLOCA]] : !llvm.array<2 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg1, %[[ALLOCA]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[ZEXT:.*]] = llvm.zext %arg0 : i1 to i2
   // CHECK-NEXT: %[[GEP:.*]] = llvm.getelementptr %[[ALLOCA]][0, %[[ZEXT]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.load %[[GEP]] : !llvm.ptr -> i32
@@ -17,20 +13,20 @@ func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: 
 
   // CHECK-NEXT: %[[ONE4:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE4]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST2]], %[[ALLOCA1]] : !llvm.array<2 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg1, %[[ALLOCA1]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[ZEXT1:.*]] = llvm.zext %arg0 : i1 to i2
   // CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[ALLOCA1]][0, %[[ZEXT1]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<1 x i32>
   // CHECK-NEXT: llvm.load %[[GEP1]] : !llvm.ptr -> !llvm.array<1 x i32>
   %1 = hw.array_slice %arg1[%arg0] : (!hw.array<2xi32>) -> !hw.array<1xi32>
 
   // CHECK-NEXT: %[[UNDEF:.*]] = llvm.mlir.undef : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[E1:.*]] = llvm.extractvalue %[[CAST0]][0] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E1:.*]] = llvm.extractvalue %arg1[0] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I1:.*]] = llvm.insertvalue %[[E1]], %[[UNDEF]][0] : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[E2:.*]] = llvm.extractvalue %[[CAST0]][1] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E2:.*]] = llvm.extractvalue %arg1[1] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I2:.*]] = llvm.insertvalue %[[E2]], %[[I1]][1] : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[E3:.*]] = llvm.extractvalue %[[CAST1]][0] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E3:.*]] = llvm.extractvalue %arg1[0] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I3:.*]] = llvm.insertvalue %[[E3]], %[[I2]][2] : !llvm.array<4 x i32>
-  // CHECK: %[[E4:.*]] = llvm.extractvalue %[[CAST1]][1] : !llvm.array<2 x i32>
+  // CHECK: %[[E4:.*]] = llvm.extractvalue %arg1[1] : !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.insertvalue %[[E4]], %[[I3]][3] : !llvm.array<4 x i32>
   %2 = hw.array_concat %arg1, %arg1 : !hw.array<2xi32>, !hw.array<2xi32>
 
@@ -48,11 +44,6 @@ func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: 
 func.func @convertArrayInject(
   %arg0: !hw.array<0xi32>, %arg1: !hw.array<1xi32>, %arg2: !hw.array<2xi32>, %arg3: !hw.array<5xi32>,
   %arg4: i32, %arg5: i64, %arg6: i1, %arg7: i3, %arg8: i64) {
-  // CHECK-DAG: %[[CAST0:.*]] = builtin.unrealized_conversion_cast %arg0 : !hw.array<0xi32> to !llvm.array<0 x i32>
-  // CHECK-DAG: %[[CAST1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<1xi32> to !llvm.array<1 x i32>
-  // CHECK-DAG: %[[CAST2:.*]] = builtin.unrealized_conversion_cast %arg2 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-DAG: %[[CAST3:.*]] = builtin.unrealized_conversion_cast %arg3 : !hw.array<5xi32> to !llvm.array<5 x i32>
-
   %0 = hw.array_inject %arg0[%arg5], %arg4 : !hw.array<0xi32>, i64
 
   // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
@@ -60,7 +51,7 @@ func.func @convertArrayInject(
   // CHECK-NEXT: %[[MAX1:.*]] = llvm.mlir.constant(1 : i32) : i2
   // CHECK-NEXT: %[[UMIN1:.*]] = llvm.intr.umin(%[[ZEXT1]], %[[MAX1]]) : (i2, i2) -> i2
   // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE1]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST1]], %[[ALLOCA1]] : !llvm.array<1 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg1, %[[ALLOCA1]] : !llvm.array<1 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[ALLOCA1]][0, %[[UMIN1]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP1]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA1]] : !llvm.ptr -> !llvm.array<1 x i32>
@@ -69,7 +60,7 @@ func.func @convertArrayInject(
   // CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ZEXT2:.*]] = llvm.zext %arg6 : i1 to i2
   // CHECK-NEXT: %[[ALLOCA2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST2]], %[[ALLOCA2]] : !llvm.array<2 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg2, %[[ALLOCA2]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP2:.*]] = llvm.getelementptr %[[ALLOCA2]][0, %[[ZEXT2]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP2]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA2]] : !llvm.ptr -> !llvm.array<2 x i32>
@@ -80,7 +71,7 @@ func.func @convertArrayInject(
   // CHECK-NEXT: %[[MAX3:.*]] = llvm.mlir.constant(5 : i32) : i4
   // CHECK-NEXT: %[[UMIN3:.*]] = llvm.intr.umin(%[[ZEXT3]], %[[MAX3]]) : (i4, i4) -> i4
   // CHECK-NEXT: %[[ALLOCA3:.*]] = llvm.alloca %[[ONE3]] x !llvm.array<6 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST3]], %[[ALLOCA3]] : !llvm.array<5 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg3, %[[ALLOCA3]] : !llvm.array<5 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP3:.*]] = llvm.getelementptr %[[ALLOCA3]][0, %[[UMIN3]]] : (!llvm.ptr, i4) -> !llvm.ptr, !llvm.array<6 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP3]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA3]] : !llvm.ptr -> !llvm.array<5 x i32>
@@ -88,7 +79,7 @@ func.func @convertArrayInject(
 
   // CHECK-NEXT: %[[ONE4:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA4:.*]] = llvm.alloca %[[ONE4]] x !llvm.array<0 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST0]], %[[ALLOCA4]] : !llvm.array<0 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg0, %[[ALLOCA4]] : !llvm.array<0 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[ZEXT4:.*]] = llvm.zext %arg8 : i64 to i65
   // CHECK-NEXT: %[[GEP4:.*]] = llvm.getelementptr %[[ALLOCA4]][0, %[[ZEXT4]]] : (!llvm.ptr, i65) -> !llvm.ptr, !llvm.array<0 x i32>
   // CHECK-NEXT: llvm.load %[[GEP4]] : !llvm.ptr -> i32
@@ -171,18 +162,16 @@ func.func @convertConstStruct() {
 }
 
 // CHECK-LABEL: @convertStruct
+// CHECK-SAME: (%arg0: i32, %arg1: !llvm.struct<(i8, i32)>, %arg2: !llvm.struct<()>, %arg3: i1, %arg4: i2)
 func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>, %arg2: !hw.struct<>, %arg3 : i1, %arg4 : i2) {
-  // CHECK-NEXT: [[ARG1_0:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<foo: i32, bar: i8> to !llvm.struct<(i8, i32)>
-  // CHECK-NEXT: [[ARG1_1:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<foo: i32, bar: i8> to !llvm.struct<(i8, i32)>
-  // CHECK-NEXT: [[ARG1_2:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<foo: i32, bar: i8> to !llvm.struct<(i8, i32)>
-  // CHECK-NEXT: llvm.extractvalue [[ARG1_2]][1] : !llvm.struct<(i8, i32)>
+  // CHECK-NEXT: llvm.extractvalue %arg1[1] : !llvm.struct<(i8, i32)>
   %0 = hw.struct_extract %arg1["foo"] : !hw.struct<foo: i32, bar: i8>
 
-  // CHECK: llvm.insertvalue %arg0, [[ARG1_1]][1] : !llvm.struct<(i8, i32)>
+  // CHECK: llvm.insertvalue %arg0, %arg1[1] : !llvm.struct<(i8, i32)>
   %1 = hw.struct_inject %arg1["foo"], %arg0 : !hw.struct<foo: i32, bar: i8>
 
-  // CHECK: llvm.extractvalue [[ARG1_0]][1] : !llvm.struct<(i8, i32)>
-  // CHECK: llvm.extractvalue [[ARG1_0]][0] : !llvm.struct<(i8, i32)>
+  // CHECK: llvm.extractvalue %arg1[1] : !llvm.struct<(i8, i32)>
+  // CHECK: llvm.extractvalue %arg1[0] : !llvm.struct<(i8, i32)>
   %2:2 = hw.struct_explode %arg1 : !hw.struct<foo: i32, bar: i8>
 
   hw.struct_explode %arg2 : !hw.struct<>
@@ -197,10 +186,9 @@ func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>, %arg
 }
 
 // CHECK-LABEL: @nestedStructInject
+// CHECK-SAME: (%arg0: !llvm.struct<(struct<(i1)>, i1)>, %arg1: !llvm.struct<(i1)>)
 func.func @nestedStructInject(%arg0: !hw.struct<a: i1, b: !hw.struct<c: i1>>, %arg1: !hw.struct<c: i1>) {
-  // CHECK-NEXT: [[ARG1:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<c: i1> to !llvm.struct<(i1)>
-  // CHECK-NEXT: [[ARG0:%.+]] = builtin.unrealized_conversion_cast %arg0 : !hw.struct<a: i1, b: !hw.struct<c: i1>> to !llvm.struct<(struct<(i1)>, i1)>
-  // CHECK-NEXT: llvm.insertvalue [[ARG1]], [[ARG0]][0] : !llvm.struct<(struct<(i1)>, i1)>
+  // CHECK-NEXT: llvm.insertvalue %arg1, %arg0[0] : !llvm.struct<(struct<(i1)>, i1)>
   %0 = hw.struct_inject %arg0["b"], %arg1 : !hw.struct<a: i1, b: !hw.struct<c: i1>>
   return
 }

--- a/test/Conversion/HWToLLVM/early_spill.mlir
+++ b/test/Conversion/HWToLLVM/early_spill.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --allow-unregistered-dialect --convert-hw-to-llvm=spill-arrays-early=true --reconcile-unrealized-casts | FileCheck %s
+// RUN: circt-opt %s --allow-unregistered-dialect --convert-hw-to-llvm=spill-arrays-early=true | FileCheck %s
 
 
 // CHECK-LABEL: func.func @spillNonHWGet
@@ -24,11 +24,11 @@ func.func @spillNonHWGet(%idx0 : i4, %idx1 : i4) -> (i32, i32) {
 }
 
 // CHECK-LABEL: func.func @spillArgumentGet
+// CHECK-SAME: (%arg0: i4, %arg1: !llvm.array<16 x i32>) -> i32
 func.func @spillArgumentGet(%idx : i4, %arr : !hw.array<16xi32>) -> (i32) {
-    // CHECK: [[LLVAL:%.+]]  = builtin.unrealized_conversion_cast %arg1 : !hw.array<16xi32> to !llvm.array<16 x i32>
     // CHECK: [[CST1:%.+]]   = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[ALLOCA:%.+]] = llvm.alloca [[CST1]] x !llvm.array<16 x i32>
-    // CHECK: llvm.store [[LLVAL]], [[ALLOCA]]
+    // CHECK: llvm.store %arg1, [[ALLOCA]]
     // CHECK: "foo.bar"
     "foo.bar" () : () -> ()
     // CHECK-NOT: llvm.alloca

--- a/test/Conversion/HWToLLVM/spill_alignment.mlir
+++ b/test/Conversion/HWToLLVM/spill_alignment.mlir
@@ -6,11 +6,11 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<
 >} {
 
   // CHECK-LABEL: func.func @wideArrayGet
+  // CHECK-SAME: (%arg0: i1, %arg1: !llvm.array<2 x i65>) -> i65
   func.func @wideArrayGet(%idx : i1, %arr: !hw.array<2xi65>) -> i65 {
-    // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi65> to !llvm.array<2 x i65>
     // CHECK: [[ONE:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[ALLOCA:%.+]] = llvm.alloca [[ONE]] x !llvm.array<2 x i65> {alignment = 16 : i64} : (i32) -> !llvm.ptr
-    // CHECK: llvm.store [[CAST]], [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
+    // CHECK: llvm.store %arg1, [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
     // CHECK: [[IDX:%.+]] = llvm.zext %arg0 : i1 to i2
     // CHECK: [[GEP:%.+]] = llvm.getelementptr [[ALLOCA]][0, [[IDX]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i65>
     // CHECK: [[VAL:%.+]] = llvm.load [[GEP]] : !llvm.ptr -> i65
@@ -20,18 +20,17 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<
   }
 
   // CHECK-LABEL: func.func @wideArrayInject
+  // CHECK-SAME: (%arg0: !llvm.array<2 x i65>, %arg1: i1, %arg2: i65) -> !llvm.array<2 x i65>
   func.func @wideArrayInject(%arr: !hw.array<2xi65>, %idx: i1, %elt: i65) -> !hw.array<2xi65> {
-    // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !hw.array<2xi65> to !llvm.array<2 x i65>
     // CHECK: [[ONE:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[ZEXT:%.+]] = llvm.zext %arg1 : i1 to i2
     // CHECK: [[ALLOCA:%.+]] = llvm.alloca [[ONE]] x !llvm.array<2 x i65> {alignment = 16 : i64} : (i32) -> !llvm.ptr
-    // CHECK: llvm.store [[CAST]], [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
+    // CHECK: llvm.store %arg0, [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
     // CHECK: [[GEP:%.+]] = llvm.getelementptr [[ALLOCA]][0, [[ZEXT]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i65>
     // CHECK: llvm.store %arg2, [[GEP]] : i65, !llvm.ptr
     // CHECK: [[OUT:%.+]] = llvm.load [[ALLOCA]] : !llvm.ptr -> !llvm.array<2 x i65>
     %0 = hw.array_inject %arr[%idx], %elt : !hw.array<2xi65>, i1
-    // CHECK: [[CASTOUT:%.+]] = builtin.unrealized_conversion_cast [[OUT]] : !llvm.array<2 x i65> to !hw.array<2xi65>
-    // CHECK: return [[CASTOUT]] : !hw.array<2xi65>
+    // CHECK: return [[OUT]] : !llvm.array<2 x i65>
     return %0 : !hw.array<2xi65>
   }
 }


### PR DESCRIPTION
The HW to LLVM conversion previously lowered only the HW operations and left the aggregate HW types on function signatures and on the `return` and `call` ops untouched, bridging them with `unrealized_conversion_cast` ops. This left dangling HW-typed values behind whenever an aggregate was passed through a function boundary.

Rewrite these signatures and terminator/call operand types as part of the conversion, keying their legality on the type converter. As a result the pass no longer emits leftover casts for aggregate arguments and results.

Converting signatures makes the framework materialize `hw -> llvm -> hw` round-trips around the casts the array spill cache wraps spilled values in. Reconcile the leftover casts at the end of the pass so it cleans up its own scaffolding and no longer depends on a downstream reconcile pass; genuine boundary casts around untouched non-HW ops are left in place.

Assisted-by: Claude Opus 4.8
