### PR TITLE
[HWToLLVM] Lower union types and operations

### DIFF
--- a/lib/Conversion/HWToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HWToLLVM/CMakeLists.txt
@@ -10,6 +10,8 @@ add_circt_conversion_library(CIRCTHWToLLVM
   LINK_LIBS PUBLIC
   CIRCTHW
   CIRCTSupport
+  MLIRFuncDialect
+  MLIRFuncTransforms
   MLIRLLVMCommonConversion
   MLIRTransforms
 )

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -439,6 +439,83 @@ struct StructInjectOpConversion
 } // namespace
 
 //===----------------------------------------------------------------------===//
+// Union operations conversion
+//===----------------------------------------------------------------------===//
+//
+// A `!hw.union` is lowered to a flat `!llvm.array<N x i8>` byte buffer that is
+// large enough to hold the LLVM representation of its widest member (see
+// `convertUnionType`). Because the members keep their natural LLVM layout
+// inside that buffer -- including any alignment padding -- the conversion works
+// uniformly for integer and aggregate members alike.
+//
+// Both directions go through a stack slot. Creating a union allocates a buffer,
+// stores the member value into it, and reads the whole buffer back. Extracting
+// a member stores the buffer and reads back only the member's bytes. Bytes not
+// covered by the active member are left undefined, which matches the union
+// semantics. Members are placed at the start of the buffer; the field offset is
+// not honored, as nothing downstream of this lowering interprets the buffer's
+// bit layout.
+
+namespace {
+/// Allocate a stack slot of the given type, suitably aligned to hold a value of
+/// `accessType`, and return the pointer to it.
+static Value allocateUnionBuffer(ConversionPatternRewriter &rewriter,
+                                 Location loc, Type bufferType,
+                                 Type accessType) {
+  auto *context = rewriter.getContext();
+  auto align =
+      std::max<uint64_t>(1, DataLayout().getTypePreferredAlignment(accessType));
+  Value one = LLVM::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                       rewriter.getI32IntegerAttr(1));
+  return LLVM::AllocaOp::create(rewriter, loc,
+                                LLVM::LLVMPointerType::get(context), bufferType,
+                                one, align);
+}
+
+/// Convert a UnionCreateOp to the LLVM dialect by storing the member value into
+/// a fresh union buffer and reading the buffer back.
+struct UnionCreateOpConversion
+    : public ConvertOpToLLVMPattern<hw::UnionCreateOp> {
+  using ConvertOpToLLVMPattern<hw::UnionCreateOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(hw::UnionCreateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto bufferType = typeConverter->convertType(op.getType());
+    if (!bufferType)
+      return failure();
+    Value input = adaptor.getInput();
+    Value ptr = allocateUnionBuffer(rewriter, loc, bufferType, input.getType());
+    LLVM::StoreOp::create(rewriter, loc, input, ptr);
+    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, bufferType, ptr);
+    return success();
+  }
+};
+
+/// Convert a UnionExtractOp to the LLVM dialect by storing the union buffer and
+/// reading back the requested member's bytes.
+struct UnionExtractOpConversion
+    : public ConvertOpToLLVMPattern<hw::UnionExtractOp> {
+  using ConvertOpToLLVMPattern<hw::UnionExtractOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(hw::UnionExtractOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto memberType = typeConverter->convertType(op.getType());
+    if (!memberType)
+      return failure();
+    Value input = adaptor.getInput();
+    Value ptr = allocateUnionBuffer(rewriter, loc, input.getType(), memberType);
+    LLVM::StoreOp::create(rewriter, loc, input, ptr);
+    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, memberType, ptr);
+    return success();
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // Concat operations conversion
 //===----------------------------------------------------------------------===//
 
@@ -792,6 +869,22 @@ static Type convertStructType(hw::StructType type,
   return LLVM::LLVMStructType::getLiteral(&converter.getContext(), elements);
 }
 
+/// Convert a union to a flat byte buffer large enough to hold the LLVM
+/// representation of its widest member, including any alignment padding.
+static Type convertUnionType(hw::UnionType type, LLVMTypeConverter &converter) {
+  DataLayout layout;
+  uint64_t maxBytes = 0;
+  for (auto field : type.getElements()) {
+    auto llvmFieldTy = converter.convertType(field.type);
+    if (!llvmFieldTy)
+      return {};
+    maxBytes =
+        std::max(maxBytes, layout.getTypeSize(llvmFieldTy).getFixedValue());
+  }
+  return LLVM::LLVMArrayType::get(IntegerType::get(&converter.getContext(), 8),
+                                  maxBytes);
+}
+
 //===----------------------------------------------------------------------===//
 // Pass initialization
 //===----------------------------------------------------------------------===//
@@ -826,6 +919,9 @@ void circt::populateHWToLLVMConversionPatterns(
   patterns.add<StructExplodeOpConversion, StructExtractOpConversion,
                StructInjectOpConversion>(converter);
 
+  // Union operation conversion patterns.
+  patterns.add<UnionCreateOpConversion, UnionExtractOpConversion>(converter);
+
   patterns.add<ArrayGetOpConversion, ArrayInjectOpConversion,
                ArraySliceOpConversion, ArrayConcatOpConversion>(converter,
                                                                 spillCacheOpt);
@@ -836,6 +932,8 @@ void circt::populateHWToLLVMTypeConversions(LLVMTypeConverter &converter) {
       [&](hw::ArrayType arr) { return convertArrayType(arr, converter); });
   converter.addConversion(
       [&](hw::StructType tup) { return convertStructType(tup, converter); });
+  converter.addConversion(
+      [&](hw::UnionType uni) { return convertUnionType(uni, converter); });
 }
 
 void HWToLLVMLoweringPass::runOnOperation() {

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -16,6 +16,8 @@
 #include "circt/Support/Namespace.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
@@ -859,14 +861,39 @@ void HWToLLVMLoweringPass::runOnOperation() {
   // Don't touch non-HW operations
   target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 
+  // Rewrite the aggregate HW types carried by function signatures and the
+  // `return`/`call` ops that wire values through them, so that no leftover
+  // values of HW type remain once the HW ops have been lowered. The op
+  // legality is keyed on the type converter.
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+    return converter.isSignatureLegal(op.getFunctionType()) &&
+           converter.isLegal(&op.getBody());
+  });
+  target.addDynamicallyLegalOp<func::ReturnOp, func::CallOp>(
+      [&](Operation *op) { return converter.isLegal(op); });
+
   // Setup the conversion.
   populateHWToLLVMConversionPatterns(converter, patterns, globals,
                                      constAggregateGlobalsMap, spillCacheOpt);
+  populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
+                                                                 converter);
+  populateReturnOpTypeConversionPattern(patterns, converter);
+  populateCallOpTypeConversionPattern(patterns, converter);
 
   // Apply the partial conversion.
   ConversionConfig config;
   config.allowPatternRollback = false;
   if (failed(applyPartialConversion(getOperation(), target, std::move(patterns),
                                     config)))
-    signalPassFailure();
+    return signalPassFailure();
+
+  // Reconcile the temporary `unrealized_conversion_cast` ops the conversion
+  // left behind -- in particular the `hw -> llvm -> hw` round-trips that the
+  // framework materializes around spilled values whose signature was
+  // converted. This keeps the pass self-contained instead of relying on a
+  // downstream reconcile pass; genuine boundary casts are left in place.
+  SmallVector<UnrealizedConversionCastOp> castOps;
+  getOperation()->walk(
+      [&](UnrealizedConversionCastOp op) { castOps.push_back(op); });
+  reconcileUnrealizedCasts(castOps, /*remainingCastOps=*/nullptr);
 }

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -1,15 +1,11 @@
 // RUN: circt-opt %s --convert-hw-to-llvm=spill-arrays-early=false | FileCheck %s
 
 // CHECK-LABEL: @convertArray
+// CHECK-SAME: (%arg0: i1, %arg1: !llvm.array<2 x i32>,
 func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32) {
-  // CHECK-NEXT: %[[CAST0:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[CAST1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[CAST2:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-NEXT: %[[CAST3:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi32> to !llvm.array<2 x i32>
-
   // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA:.*]] = llvm.alloca %[[ONE]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST3]], %[[ALLOCA]] : !llvm.array<2 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg1, %[[ALLOCA]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[ZEXT:.*]] = llvm.zext %arg0 : i1 to i2
   // CHECK-NEXT: %[[GEP:.*]] = llvm.getelementptr %[[ALLOCA]][0, %[[ZEXT]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.load %[[GEP]] : !llvm.ptr -> i32
@@ -17,20 +13,20 @@ func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: 
 
   // CHECK-NEXT: %[[ONE4:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE4]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST2]], %[[ALLOCA1]] : !llvm.array<2 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg1, %[[ALLOCA1]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[ZEXT1:.*]] = llvm.zext %arg0 : i1 to i2
   // CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[ALLOCA1]][0, %[[ZEXT1]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<1 x i32>
   // CHECK-NEXT: llvm.load %[[GEP1]] : !llvm.ptr -> !llvm.array<1 x i32>
   %1 = hw.array_slice %arg1[%arg0] : (!hw.array<2xi32>) -> !hw.array<1xi32>
 
   // CHECK-NEXT: %[[UNDEF:.*]] = llvm.mlir.undef : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[E1:.*]] = llvm.extractvalue %[[CAST0]][0] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E1:.*]] = llvm.extractvalue %arg1[0] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I1:.*]] = llvm.insertvalue %[[E1]], %[[UNDEF]][0] : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[E2:.*]] = llvm.extractvalue %[[CAST0]][1] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E2:.*]] = llvm.extractvalue %arg1[1] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I2:.*]] = llvm.insertvalue %[[E2]], %[[I1]][1] : !llvm.array<4 x i32>
-  // CHECK-NEXT: %[[E3:.*]] = llvm.extractvalue %[[CAST1]][0] : !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[E3:.*]] = llvm.extractvalue %arg1[0] : !llvm.array<2 x i32>
   // CHECK-NEXT: %[[I3:.*]] = llvm.insertvalue %[[E3]], %[[I2]][2] : !llvm.array<4 x i32>
-  // CHECK: %[[E4:.*]] = llvm.extractvalue %[[CAST1]][1] : !llvm.array<2 x i32>
+  // CHECK: %[[E4:.*]] = llvm.extractvalue %arg1[1] : !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.insertvalue %[[E4]], %[[I3]][3] : !llvm.array<4 x i32>
   %2 = hw.array_concat %arg1, %arg1 : !hw.array<2xi32>, !hw.array<2xi32>
 
@@ -48,11 +44,6 @@ func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: 
 func.func @convertArrayInject(
   %arg0: !hw.array<0xi32>, %arg1: !hw.array<1xi32>, %arg2: !hw.array<2xi32>, %arg3: !hw.array<5xi32>,
   %arg4: i32, %arg5: i64, %arg6: i1, %arg7: i3, %arg8: i64) {
-  // CHECK-DAG: %[[CAST0:.*]] = builtin.unrealized_conversion_cast %arg0 : !hw.array<0xi32> to !llvm.array<0 x i32>
-  // CHECK-DAG: %[[CAST1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<1xi32> to !llvm.array<1 x i32>
-  // CHECK-DAG: %[[CAST2:.*]] = builtin.unrealized_conversion_cast %arg2 : !hw.array<2xi32> to !llvm.array<2 x i32>
-  // CHECK-DAG: %[[CAST3:.*]] = builtin.unrealized_conversion_cast %arg3 : !hw.array<5xi32> to !llvm.array<5 x i32>
-
   %0 = hw.array_inject %arg0[%arg5], %arg4 : !hw.array<0xi32>, i64
 
   // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
@@ -60,7 +51,7 @@ func.func @convertArrayInject(
   // CHECK-NEXT: %[[MAX1:.*]] = llvm.mlir.constant(1 : i32) : i2
   // CHECK-NEXT: %[[UMIN1:.*]] = llvm.intr.umin(%[[ZEXT1]], %[[MAX1]]) : (i2, i2) -> i2
   // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE1]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST1]], %[[ALLOCA1]] : !llvm.array<1 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg1, %[[ALLOCA1]] : !llvm.array<1 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[ALLOCA1]][0, %[[UMIN1]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP1]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA1]] : !llvm.ptr -> !llvm.array<1 x i32>
@@ -69,7 +60,7 @@ func.func @convertArrayInject(
   // CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ZEXT2:.*]] = llvm.zext %arg6 : i1 to i2
   // CHECK-NEXT: %[[ALLOCA2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST2]], %[[ALLOCA2]] : !llvm.array<2 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg2, %[[ALLOCA2]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP2:.*]] = llvm.getelementptr %[[ALLOCA2]][0, %[[ZEXT2]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP2]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA2]] : !llvm.ptr -> !llvm.array<2 x i32>
@@ -80,7 +71,7 @@ func.func @convertArrayInject(
   // CHECK-NEXT: %[[MAX3:.*]] = llvm.mlir.constant(5 : i32) : i4
   // CHECK-NEXT: %[[UMIN3:.*]] = llvm.intr.umin(%[[ZEXT3]], %[[MAX3]]) : (i4, i4) -> i4
   // CHECK-NEXT: %[[ALLOCA3:.*]] = llvm.alloca %[[ONE3]] x !llvm.array<6 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST3]], %[[ALLOCA3]] : !llvm.array<5 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg3, %[[ALLOCA3]] : !llvm.array<5 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP3:.*]] = llvm.getelementptr %[[ALLOCA3]][0, %[[UMIN3]]] : (!llvm.ptr, i4) -> !llvm.ptr, !llvm.array<6 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP3]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA3]] : !llvm.ptr -> !llvm.array<5 x i32>
@@ -88,7 +79,7 @@ func.func @convertArrayInject(
 
   // CHECK-NEXT: %[[ONE4:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA4:.*]] = llvm.alloca %[[ONE4]] x !llvm.array<0 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST0]], %[[ALLOCA4]] : !llvm.array<0 x i32>, !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg0, %[[ALLOCA4]] : !llvm.array<0 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[ZEXT4:.*]] = llvm.zext %arg8 : i64 to i65
   // CHECK-NEXT: %[[GEP4:.*]] = llvm.getelementptr %[[ALLOCA4]][0, %[[ZEXT4]]] : (!llvm.ptr, i65) -> !llvm.ptr, !llvm.array<0 x i32>
   // CHECK-NEXT: llvm.load %[[GEP4]] : !llvm.ptr -> i32
@@ -171,18 +162,16 @@ func.func @convertConstStruct() {
 }
 
 // CHECK-LABEL: @convertStruct
+// CHECK-SAME: (%arg0: i32, %arg1: !llvm.struct<(i8, i32)>, %arg2: !llvm.struct<()>, %arg3: i1, %arg4: i2)
 func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>, %arg2: !hw.struct<>, %arg3 : i1, %arg4 : i2) {
-  // CHECK-NEXT: [[ARG1_0:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<foo: i32, bar: i8> to !llvm.struct<(i8, i32)>
-  // CHECK-NEXT: [[ARG1_1:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<foo: i32, bar: i8> to !llvm.struct<(i8, i32)>
-  // CHECK-NEXT: [[ARG1_2:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<foo: i32, bar: i8> to !llvm.struct<(i8, i32)>
-  // CHECK-NEXT: llvm.extractvalue [[ARG1_2]][1] : !llvm.struct<(i8, i32)>
+  // CHECK-NEXT: llvm.extractvalue %arg1[1] : !llvm.struct<(i8, i32)>
   %0 = hw.struct_extract %arg1["foo"] : !hw.struct<foo: i32, bar: i8>
 
-  // CHECK: llvm.insertvalue %arg0, [[ARG1_1]][1] : !llvm.struct<(i8, i32)>
+  // CHECK: llvm.insertvalue %arg0, %arg1[1] : !llvm.struct<(i8, i32)>
   %1 = hw.struct_inject %arg1["foo"], %arg0 : !hw.struct<foo: i32, bar: i8>
 
-  // CHECK: llvm.extractvalue [[ARG1_0]][1] : !llvm.struct<(i8, i32)>
-  // CHECK: llvm.extractvalue [[ARG1_0]][0] : !llvm.struct<(i8, i32)>
+  // CHECK: llvm.extractvalue %arg1[1] : !llvm.struct<(i8, i32)>
+  // CHECK: llvm.extractvalue %arg1[0] : !llvm.struct<(i8, i32)>
   %2:2 = hw.struct_explode %arg1 : !hw.struct<foo: i32, bar: i8>
 
   hw.struct_explode %arg2 : !hw.struct<>
@@ -197,10 +186,9 @@ func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>, %arg
 }
 
 // CHECK-LABEL: @nestedStructInject
+// CHECK-SAME: (%arg0: !llvm.struct<(struct<(i1)>, i1)>, %arg1: !llvm.struct<(i1)>)
 func.func @nestedStructInject(%arg0: !hw.struct<a: i1, b: !hw.struct<c: i1>>, %arg1: !hw.struct<c: i1>) {
-  // CHECK-NEXT: [[ARG1:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.struct<c: i1> to !llvm.struct<(i1)>
-  // CHECK-NEXT: [[ARG0:%.+]] = builtin.unrealized_conversion_cast %arg0 : !hw.struct<a: i1, b: !hw.struct<c: i1>> to !llvm.struct<(struct<(i1)>, i1)>
-  // CHECK-NEXT: llvm.insertvalue [[ARG1]], [[ARG0]][0] : !llvm.struct<(struct<(i1)>, i1)>
+  // CHECK-NEXT: llvm.insertvalue %arg1, %arg0[0] : !llvm.struct<(struct<(i1)>, i1)>
   %0 = hw.struct_inject %arg0["b"], %arg1 : !hw.struct<a: i1, b: !hw.struct<c: i1>>
   return
 }

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -185,6 +185,39 @@ func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>, %arg
   return
 }
 
+// A union is represented as a flat byte buffer large enough to hold its widest
+// member. Creating a union stores the member into a fresh buffer and reads the
+// buffer back; extracting reverses the process.
+// CHECK-LABEL: @convertUnion
+// CHECK-SAME: (%arg0: i32, %arg1: i8, %[[ARG2:.*]]: !llvm.array<4 x i8>)
+func.func @convertUnion(%arg0: i32, %arg1: i8, %arg2: !hw.union<foo: i32, bar: i8>) {
+  // CHECK: %[[ONE0:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[BUF0:.*]] = llvm.alloca %[[ONE0]] x !llvm.array<4 x i8> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg0, %[[BUF0]] : i32, !llvm.ptr
+  // CHECK-NEXT: llvm.load %[[BUF0]] : !llvm.ptr -> !llvm.array<4 x i8>
+  %0 = hw.union_create "foo", %arg0 : !hw.union<foo: i32, bar: i8>
+
+  // CHECK: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[BUF1:.*]] = llvm.alloca %[[ONE1]] x !llvm.array<4 x i8> {alignment = 1 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %arg1, %[[BUF1]] : i8, !llvm.ptr
+  // CHECK-NEXT: llvm.load %[[BUF1]] : !llvm.ptr -> !llvm.array<4 x i8>
+  %1 = hw.union_create "bar", %arg1 : !hw.union<foo: i32, bar: i8>
+
+  // CHECK: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[BUF2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<4 x i8> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %[[ARG2]], %[[BUF2]] : !llvm.array<4 x i8>, !llvm.ptr
+  // CHECK-NEXT: llvm.load %[[BUF2]] : !llvm.ptr -> i32
+  %2 = hw.union_extract %arg2["foo"] : !hw.union<foo: i32, bar: i8>
+
+  // CHECK: %[[ONE3:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[BUF3:.*]] = llvm.alloca %[[ONE3]] x !llvm.array<4 x i8> {alignment = 1 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %[[ARG2]], %[[BUF3]] : !llvm.array<4 x i8>, !llvm.ptr
+  // CHECK-NEXT: llvm.load %[[BUF3]] : !llvm.ptr -> i8
+  %3 = hw.union_extract %arg2["bar"] : !hw.union<foo: i32, bar: i8>
+
+  return
+}
+
 // CHECK-LABEL: @nestedStructInject
 // CHECK-SAME: (%arg0: !llvm.struct<(struct<(i1)>, i1)>, %arg1: !llvm.struct<(i1)>)
 func.func @nestedStructInject(%arg0: !hw.struct<a: i1, b: !hw.struct<c: i1>>, %arg1: !hw.struct<c: i1>) {

--- a/test/Conversion/HWToLLVM/early_spill.mlir
+++ b/test/Conversion/HWToLLVM/early_spill.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --allow-unregistered-dialect --convert-hw-to-llvm=spill-arrays-early=true --reconcile-unrealized-casts | FileCheck %s
+// RUN: circt-opt %s --allow-unregistered-dialect --convert-hw-to-llvm=spill-arrays-early=true | FileCheck %s
 
 
 // CHECK-LABEL: func.func @spillNonHWGet
@@ -24,11 +24,11 @@ func.func @spillNonHWGet(%idx0 : i4, %idx1 : i4) -> (i32, i32) {
 }
 
 // CHECK-LABEL: func.func @spillArgumentGet
+// CHECK-SAME: (%arg0: i4, %arg1: !llvm.array<16 x i32>) -> i32
 func.func @spillArgumentGet(%idx : i4, %arr : !hw.array<16xi32>) -> (i32) {
-    // CHECK: [[LLVAL:%.+]]  = builtin.unrealized_conversion_cast %arg1 : !hw.array<16xi32> to !llvm.array<16 x i32>
     // CHECK: [[CST1:%.+]]   = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[ALLOCA:%.+]] = llvm.alloca [[CST1]] x !llvm.array<16 x i32>
-    // CHECK: llvm.store [[LLVAL]], [[ALLOCA]]
+    // CHECK: llvm.store %arg1, [[ALLOCA]]
     // CHECK: "foo.bar"
     "foo.bar" () : () -> ()
     // CHECK-NOT: llvm.alloca

--- a/test/Conversion/HWToLLVM/spill_alignment.mlir
+++ b/test/Conversion/HWToLLVM/spill_alignment.mlir
@@ -6,11 +6,11 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<
 >} {
 
   // CHECK-LABEL: func.func @wideArrayGet
+  // CHECK-SAME: (%arg0: i1, %arg1: !llvm.array<2 x i65>) -> i65
   func.func @wideArrayGet(%idx : i1, %arr: !hw.array<2xi65>) -> i65 {
-    // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<2xi65> to !llvm.array<2 x i65>
     // CHECK: [[ONE:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[ALLOCA:%.+]] = llvm.alloca [[ONE]] x !llvm.array<2 x i65> {alignment = 16 : i64} : (i32) -> !llvm.ptr
-    // CHECK: llvm.store [[CAST]], [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
+    // CHECK: llvm.store %arg1, [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
     // CHECK: [[IDX:%.+]] = llvm.zext %arg0 : i1 to i2
     // CHECK: [[GEP:%.+]] = llvm.getelementptr [[ALLOCA]][0, [[IDX]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i65>
     // CHECK: [[VAL:%.+]] = llvm.load [[GEP]] : !llvm.ptr -> i65
@@ -20,18 +20,17 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<
   }
 
   // CHECK-LABEL: func.func @wideArrayInject
+  // CHECK-SAME: (%arg0: !llvm.array<2 x i65>, %arg1: i1, %arg2: i65) -> !llvm.array<2 x i65>
   func.func @wideArrayInject(%arr: !hw.array<2xi65>, %idx: i1, %elt: i65) -> !hw.array<2xi65> {
-    // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !hw.array<2xi65> to !llvm.array<2 x i65>
     // CHECK: [[ONE:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[ZEXT:%.+]] = llvm.zext %arg1 : i1 to i2
     // CHECK: [[ALLOCA:%.+]] = llvm.alloca [[ONE]] x !llvm.array<2 x i65> {alignment = 16 : i64} : (i32) -> !llvm.ptr
-    // CHECK: llvm.store [[CAST]], [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
+    // CHECK: llvm.store %arg0, [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
     // CHECK: [[GEP:%.+]] = llvm.getelementptr [[ALLOCA]][0, [[ZEXT]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i65>
     // CHECK: llvm.store %arg2, [[GEP]] : i65, !llvm.ptr
     // CHECK: [[OUT:%.+]] = llvm.load [[ALLOCA]] : !llvm.ptr -> !llvm.array<2 x i65>
     %0 = hw.array_inject %arr[%idx], %elt : !hw.array<2xi65>, i1
-    // CHECK: [[CASTOUT:%.+]] = builtin.unrealized_conversion_cast [[OUT]] : !llvm.array<2 x i65> to !hw.array<2xi65>
-    // CHECK: return [[CASTOUT]] : !hw.array<2xi65>
+    // CHECK: return [[OUT]] : !llvm.array<2 x i65>
     return %0 : !hw.array<2xi65>
   }
 }


### PR DESCRIPTION
The HW to LLVM conversion had no support for `!hw.union`, so any design carrying a union through to LLVM failed to legalize.

Lower a union to a flat `!llvm.array<N x i8>` byte buffer sized to hold the LLVM representation of its widest member, padding included. The `union_create` and `union_extract` ops go through a stack slot: creating a union stores the member into a fresh buffer and reads the whole buffer back, while extracting stores the buffer and reads back the member's bytes. Keeping members in their natural LLVM layout makes this work uniformly for integer and aggregate members alike.

Assisted-by: Claude Opus 4.8