### PR TITLE
Warn when FIRRTL needs and implicit truncation

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -165,6 +165,10 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
 
   // The source must be extended or truncated.
   if (dstWidth < srcWidth) {
+    mlir::emitWarning(builder.getLoc())
+        << "RHS width " << srcWidth << " exceeds LHS width " << dstWidth
+        << ", inserting implicit truncation";
+
     // firrtl.tail always returns uint even for sint operands.
     IntType tmpType =
         type_cast<IntType>(dstType).getConstType(srcType.isConst());
@@ -172,14 +176,14 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     if (isSignedDest)
       tmpType =
           UIntType::get(dstType.getContext(), dstWidth, srcType.isConst());
-    mlir::emitWarning(builder.getLoc())
-        << "RHS width " << srcWidth << " exceeds LHS width " << dstWidth
-        << ", inserting implicit truncation";
     src = TailPrimOp::create(builder, tmpType, src, srcWidth - dstWidth);
     // Insert the cast back to signed if needed.
     if (isSignedDest)
       src = AsSIntPrimOp::create(builder,
-                                  dstType.getConstType(tmpType.isConst()), src);
+                                 dstType.getConstType(tmpType.isConst()), src);
+  } else if (srcWidth < dstWidth) {
+    // Need to extend arg.
+    src = PadPrimOp::create(builder, src, dstWidth);
   }
 
   if (auto srcType = type_cast<FIRRTLBaseType>(src.getType());

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -172,14 +172,14 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     if (isSignedDest)
       tmpType =
           UIntType::get(dstType.getContext(), dstWidth, srcType.isConst());
+    mlir::emitWarning(builder.getLoc())
+        << "RHS width " << srcWidth << " exceeds LHS width " << dstWidth
+        << ", inserting implicit truncation";
     src = TailPrimOp::create(builder, tmpType, src, srcWidth - dstWidth);
     // Insert the cast back to signed if needed.
     if (isSignedDest)
       src = AsSIntPrimOp::create(builder,
-                                 dstType.getConstType(tmpType.isConst()), src);
-  } else if (srcWidth < dstWidth) {
-    // Need to extend arg.
-    src = PadPrimOp::create(builder, src, dstWidth);
+                                  dstType.getConstType(tmpType.isConst()), src);
   }
 
   if (auto srcType = type_cast<FIRRTLBaseType>(src.getType());

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -2097,6 +2097,8 @@ FailureOr<bool> InferenceTypeUpdate::updateOperation(Operation *op) {
     auto lhsWidth = lhsType.getBitWidthOrSentinel();
     auto rhsWidth = rhsType.getBitWidthOrSentinel();
     if (lhsWidth >= 0 && rhsWidth >= 0 && lhsWidth < rhsWidth) {
+      con.emitWarning() << "RHS width " << rhsWidth << " exceeds LHS width "
+                        << lhsWidth << ", inserting implicit truncation";
       OpBuilder builder(op);
       auto trunc = builder.createOrFold<TailPrimOp>(con.getLoc(), con.getSrc(),
                                                     rhsWidth - lhsWidth);

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -179,6 +179,6 @@ firrtl.circuit "MuxSelTooWide" {
     // expected-note @below {{width is constrained to be at most 1 here:}}
     %1 = firrtl.mux(%0, %c1_ui1, %c1_ui1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     // expected-note @below {{width is constrained to be at least 2 here:}}
-     firrtl.connect %0, %c2_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %0, %c2_ui2 : !firrtl.uint, !firrtl.uint<2>
   }
 }

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -182,23 +182,3 @@ firrtl.circuit "MuxSelTooWide" {
      firrtl.connect %0, %c2_ui2 : !firrtl.uint, !firrtl.uint<2>
   }
 }
-
-// ---
-
-firrtl.circuit "TruncateConnectWarning" {
-  firrtl.module @TruncateConnectWarning() {
-    // LHS wire will be inferred as uint<8>
-    %lhs = firrtl.wire : !firrtl.uint
-    %c8 = firrtl.constant 8 : !firrtl.uint<8>
-    firrtl.connect %lhs, %c8 : !firrtl.uint, !firrtl.uint<8>
-    
-    // RHS wire will be inferred as uint<16>
-    %rhs = firrtl.wire : !firrtl.uint
-    %c16 = firrtl.constant 16 : !firrtl.uint<16>
-    firrtl.connect %rhs, %c16 : !firrtl.uint, !firrtl.uint<16>
-    
-    // Trigger truncation warning: LHS=8, RHS=16, so 8 < 16 triggers truncation
-    // expected-warning @+1 {{RHS width 16 exceeds LHS width 8, inserting implicit truncation}}
-    firrtl.connect %lhs, %rhs : !firrtl.uint, !firrtl.uint
-  }
-}

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -179,6 +179,26 @@ firrtl.circuit "MuxSelTooWide" {
     // expected-note @below {{width is constrained to be at most 1 here:}}
     %1 = firrtl.mux(%0, %c1_ui1, %c1_ui1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     // expected-note @below {{width is constrained to be at least 2 here:}}
-    firrtl.connect %0, %c2_ui2 : !firrtl.uint, !firrtl.uint<2>
+     firrtl.connect %0, %c2_ui2 : !firrtl.uint, !firrtl.uint<2>
+  }
+}
+
+// ---
+
+firrtl.circuit "TruncateConnectWarning" {
+  firrtl.module @TruncateConnectWarning() {
+    // LHS wire will be inferred as uint<8>
+    %lhs = firrtl.wire : !firrtl.uint
+    %c8 = firrtl.constant 8 : !firrtl.uint<8>
+    firrtl.connect %lhs, %c8 : !firrtl.uint, !firrtl.uint<8>
+    
+    // RHS wire will be inferred as uint<16>
+    %rhs = firrtl.wire : !firrtl.uint
+    %c16 = firrtl.constant 16 : !firrtl.uint<16>
+    firrtl.connect %rhs, %c16 : !firrtl.uint, !firrtl.uint<16>
+    
+    // Trigger truncation warning: LHS=8, RHS=16, so 8 < 16 triggers truncation
+    // expected-warning @+1 {{RHS width 16 exceeds LHS width 8, inserting implicit truncation}}
+    firrtl.connect %lhs, %rhs : !firrtl.uint, !firrtl.uint
   }
 }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -479,6 +479,7 @@ firrtl.circuit "Foo" {
     // CHECK: firrtl.connect %x, %c200_si9 : !firrtl.sint<9>
     %x = firrtl.wire : !firrtl.sint
     %c200_si = firrtl.constant 200 : !firrtl.sint
+    // expected-warning @+1 {{RHS width 9 exceeds LHS width 4, inserting implicit truncation}}
     firrtl.connect %y, %x : !firrtl.sint<4>, !firrtl.sint
     firrtl.connect %x, %c200_si : !firrtl.sint, !firrtl.sint
   }
@@ -492,6 +493,7 @@ firrtl.circuit "Foo" {
     %w1 = firrtl.wire  : !firrtl.uint<0>
     // CHECK: %0 = firrtl.tail %w, 1 : (!firrtl.uint<1>) -> !firrtl.uint<0>
     // CHECK: firrtl.connect %w1, %0 : !firrtl.uint<0>
+    // expected-warning @+1 {{RHS width 1 exceeds LHS width 0, inserting implicit truncation}}
     firrtl.connect %w1, %w : !firrtl.uint<0>, !firrtl.uint
   }
 


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
