### PR TITLE
[circt-synth] Reduce the LEC test size to i4 for divmod, NFC

### DIFF
--- a/integration_test/circt-synth/divmod.mlir
+++ b/integration_test/circt-synth/divmod.mlir
@@ -53,28 +53,28 @@ hw.module @divmod_mix_constant(in %in: i1, in %lhs: i1, in %rhs: i1, out out_div
 
 // RUN: circt-lec %t.mlir %s -c1=divmodu_constants -c2=divmodu_constants --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_DIVMODU_CONSTANTS
 // COMB_DIVMODU_CONSTANTS: c1 == c2
-hw.module @divmodu_constants(in %lhs: i8, out out_divu_7: i8, out out_divu_10: i8, out out_modu_3: i8) {
-  %c7_i8 = hw.constant 7 : i8
-  %c10_i8 = hw.constant 10 : i8
-  %c3_i8 = hw.constant 3 : i8
+hw.module @divmodu_constants(in %lhs: i4, out out_divu_7: i4, out out_divu_10: i4, out out_modu_3: i4) {
+  %c7_i4 = hw.constant 7 : i4
+  %c10_i4 = hw.constant 10 : i4
+  %c3_i4 = hw.constant 3 : i4
 
-  %0 = comb.divu %lhs, %c7_i8 : i8
-  %1 = comb.divu %lhs, %c10_i8 : i8
-  %2 = comb.modu %lhs, %c3_i8 : i8
-  hw.output %0, %1, %2 : i8, i8, i8
+  %0 = comb.divu %lhs, %c7_i4 : i4
+  %1 = comb.divu %lhs, %c10_i4 : i4
+  %2 = comb.modu %lhs, %c3_i4 : i4
+  hw.output %0, %1, %2 : i4, i4, i4
 }
 
 // RUN: circt-lec %t.mlir %s -c1=divmods_constants -c2=divmods_constants --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_DIVMODS_CONSTANTS
 // COMB_DIVMODS_CONSTANTS: c1 == c2
-hw.module @divmods_constants(in %lhs: i8, out out_divs_3: i8, out out_divs_neg3: i8, out out_mods_3: i8, out out_mods_neg3: i8) {
-  %c3_i8 = hw.constant 3 : i8
-  %c-3_i8 = hw.constant -3 : i8
+hw.module @divmods_constants(in %lhs: i4, out out_divs_3: i4, out out_divs_neg3: i4, out out_mods_3: i4, out out_mods_neg3: i4) {
+  %c3_i4 = hw.constant 3 : i4
+  %c-3_i4 = hw.constant -3 : i4
 
-  %0 = comb.divs %lhs, %c3_i8 : i8
-  %1 = comb.divs %lhs, %c-3_i8 : i8
-  %2 = comb.mods %lhs, %c3_i8 : i8
-  %3 = comb.mods %lhs, %c-3_i8 : i8
-  hw.output %0, %1, %2, %3 : i8, i8, i8, i8
+  %0 = comb.divs %lhs, %c3_i4 : i4
+  %1 = comb.divs %lhs, %c-3_i4 : i4
+  %2 = comb.mods %lhs, %c3_i4 : i4
+  %3 = comb.mods %lhs, %c-3_i4 : i4
+  hw.output %0, %1, %2, %3 : i4, i4, i4, i4
 }
 
 // RUN: circt-lec %t.mlir %s -c1=const_divmod_mods_neg1_i3 -c2=const_divmod_mods_neg1_i3 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MODS_NEG1_I3


### PR DESCRIPTION
Fix https://github.com/llvm/circt/issues/10617

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
