### PR TITLE
[MooreToCore] Defer yields until region parents convert

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2447,10 +2447,15 @@ struct YieldOpConversion : public OpConversionPattern<YieldOp> {
   LogicalResult
   matchAndRewrite(YieldOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (isa<llhd::GlobalSignalOp>(op->getParentOp()))
+    Operation *parent = op->getParentOp();
+    if (isa<llhd::GlobalSignalOp>(parent))
       rewriter.replaceOpWithNewOp<llhd::YieldOp>(op, adaptor.getResult());
-    else
+    else if (isa<scf::ExecuteRegionOp, scf::ForOp, scf::IfOp,
+                 scf::IndexSwitchOp, scf::WhileOp>(parent))
       rewriter.replaceOpWithNewOp<scf::YieldOp>(op, adaptor.getResult());
+    else
+      return rewriter.notifyMatchFailure(
+          op, "yield parent has not been converted to a legal region op yet");
     return success();
   }
 };

--- a/test/Conversion/MooreToCore/conditional-call-in-process.mlir
+++ b/test/Conversion/MooreToCore/conditional-call-in-process.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+func.func private @lhs() -> !moore.i32
+func.func private @rhs() -> !moore.i32
+
+// Regression for conditionals with call-bearing branches inside procedures.
+// These must lower to CFG branches without leaving orphaned scf.yield ops.
+// CHECK-LABEL: hw.module @ConditionalCallInInitial
+moore.module @ConditionalCallInInitial() {
+  // CHECK: llhd.process {
+  // CHECK:   [[COND:%.+]] = hw.constant true
+  // CHECK:   cf.cond_br [[COND]], ^[[THEN:bb[0-9]+]], ^[[ELSE:bb[0-9]+]]
+  // CHECK: ^[[THEN]]:
+  // CHECK:   [[LHS:%.+]] = func.call @lhs() : () -> i32
+  // CHECK:   cf.br ^[[JOIN:bb[0-9]+]]([[LHS]] : i32)
+  // CHECK: ^[[ELSE]]:
+  // CHECK:   [[RHS:%.+]] = func.call @rhs() : () -> i32
+  // CHECK:   cf.br ^[[JOIN]]([[RHS]] : i32)
+  // CHECK: ^[[JOIN]]([[VALUE:%.+]]: i32):
+  // CHECK:   cf.br ^[[EXIT:bb[0-9]+]]
+  // CHECK: ^[[EXIT]]:
+  // CHECK:   dbg.variable "v", [[VALUE]] : i32
+  moore.procedure initial {
+    %cond = moore.constant 1 : i1
+    %0 = moore.conditional %cond : i1 -> i32 {
+      %1 = func.call @lhs() : () -> !moore.i32
+      moore.yield %1 : i32
+    } {
+      %2 = func.call @rhs() : () -> !moore.i32
+      moore.yield %2 : i32
+    }
+    dbg.variable "v", %0 : !moore.i32
+    moore.return
+  }
+}


### PR DESCRIPTION
Only rewrite `moore.yield` when its parent has already been converted to an op with legal region semantics (`llhd.global_signal` or one of the SCF region ops). Rewriting the yield while the parent is still a Moore op left orphaned `scf.yield` terminators behind when conditionals with call-bearing branches inside procedures are lowered to CFG branches, which then failed block-argument type verification ("type mismatch for bb argument").

Includes a regression test with calls in both branches of a conditional inside an `initial` procedure.

Part of a series upstreaming SystemVerilog/UVM simulation support validated against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
