### PR TITLE
[ImportVerilog] Preserve DPI export declarations

### DIFF
--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -486,6 +486,9 @@ struct Context {
            std::unique_ptr<FunctionLowering>>
       functions;
 
+  /// DPI-C export directives keyed by the SystemVerilog subroutine they expose.
+  DenseMap<const slang::ast::SubroutineSymbol *, std::string> dpiExportCNames;
+
   /// Classes that have already been converted.
   DenseMap<const slang::ast::ClassType *, std::unique_ptr<ClassLowering>>
       classes;

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -9,15 +9,52 @@
 #include "ImportVerilogInternals.h"
 #include "slang/ast/Compilation.h"
 #include "slang/ast/symbols/ClassSymbols.h"
+#include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxVisitor.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/ScopeExit.h"
 
 using namespace circt;
 using namespace ImportVerilog;
 
+static constexpr StringLiteral dpiExportAttrName = "circt.dpi.export";
+
 //===----------------------------------------------------------------------===//
 // Utilities
 //===----------------------------------------------------------------------===//
+
+/// Record `export "DPI-C"` directives in the given scope so that callable
+/// declarations can be tagged with the exported C name. Slang resolves the
+/// directives during elaboration but does not expose them on the subroutine
+/// symbols themselves, so walk the scope's syntax to recover them.
+static void recordDPIExportDirectives(Context &context,
+                                      const slang::ast::Scope &scope,
+                                      const slang::syntax::SyntaxNode *syntax) {
+  if (!syntax)
+    return;
+
+  auto visitor = slang::syntax::makeSyntaxVisitor(
+      [&](auto &visitor, const slang::syntax::DPIExportSyntax &exportSyntax) {
+        auto svName = exportSyntax.name.valueText();
+        if (svName.empty())
+          return;
+
+        const auto *symbol = scope.find(svName);
+        const auto *subroutine =
+            symbol ? symbol->as_if<slang::ast::SubroutineSymbol>() : nullptr;
+        if (!subroutine)
+          return;
+
+        auto cName = exportSyntax.c_identifier.valueText();
+        if (cName.empty())
+          cName = svName;
+        context.dpiExportCNames[subroutine] = std::string(cName);
+      },
+      [](auto &visitor, const slang::syntax::SyntaxNode &node) {
+        visitor.visitDefault(node);
+      });
+  syntax->visit(visitor);
+}
 
 static void guessNamespacePrefix(const slang::ast::Symbol &symbol,
                                  SmallString<64> &prefix) {
@@ -1182,6 +1219,7 @@ LogicalResult Context::convertCompilation() {
   // include instantiable constructs like modules, interfaces, and programs,
   // which are listed separately as top instances.
   for (auto *unit : root.compilationUnits) {
+    recordDPIExportDirectives(*this, *unit, unit->getSyntax());
     for (const auto &member : unit->members()) {
       auto loc = convertLocation(member.location);
       if (failed(member.visit(RootVisitor(*this, loc))))
@@ -1477,6 +1515,8 @@ Context::convertModuleHeader(const slang::ast::InstanceBodySymbol *module) {
 LogicalResult
 Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
   auto &lowering = *modules[module];
+  recordDPIExportDirectives(*this, *module, module->getSyntax());
+
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPointToEnd(lowering.op.getBody());
 
@@ -1665,6 +1705,8 @@ Context::convertPackage(const slang::ast::PackageSymbol &package) {
   timeScale = package.getTimeScale().value_or(slang::TimeScale());
   llvm::scope_exit timeScaleGuard([&] { timeScale = prevTimeScale; });
 
+  recordDPIExportDirectives(*this, package, package.getSyntax());
+
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPointToEnd(intoModuleOp.getBody());
   ValueSymbolScope scope(valueSymbols);
@@ -1848,6 +1890,19 @@ Context::declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
 
   std::unique_ptr<FunctionLowering> lowering;
   Operation *insertedOp = nullptr;
+  auto dpiExportIt = dpiExportCNames.find(&subroutine);
+  bool isDPIExport = dpiExportIt != dpiExportCNames.end();
+  // DPI-exported subroutines must keep a public symbol tagged with the
+  // exported C name so later pipeline stages can materialize the export.
+  auto setVisibilityAndExportAttr = [&](Operation *op) {
+    if (isDPIExport) {
+      op->setAttr(dpiExportAttrName,
+                  builder.getStringAttr(dpiExportIt->second));
+      SymbolTable::setSymbolVisibility(op, SymbolTable::Visibility::Public);
+      return;
+    }
+    SymbolTable::setSymbolVisibility(op, SymbolTable::Visibility::Private);
+  };
   if (!subroutine.thisVar &&
       subroutine.flags.has(slang::ast::MethodFlags::DPIImport)) {
     // DPI-imported function: create a moore.func.dpi declaration.
@@ -1859,20 +1914,20 @@ Context::declareCallableImpl(const slang::ast::SubroutineSymbol &subroutine,
         builder, loc, StringAttr::get(getContext(), qualifiedName), *dpiSig,
         /*argumentLocs=*/ArrayAttr(),
         StringAttr::get(getContext(), subroutine.name));
-    SymbolTable::setSymbolVisibility(dpiOp, SymbolTable::Visibility::Private);
+    setVisibilityAndExportAttr(dpiOp);
     lowering = std::make_unique<FunctionLowering>(dpiOp);
     insertedOp = dpiOp;
   } else if (subroutine.subroutineKind == slang::ast::SubroutineKind::Task) {
     // Create a coroutine for tasks (which can suspend).
     auto op = moore::CoroutineOp::create(builder, loc, qualifiedName, funcTy);
-    SymbolTable::setSymbolVisibility(op, SymbolTable::Visibility::Private);
+    setVisibilityAndExportAttr(op);
     lowering = std::make_unique<FunctionLowering>(op);
     insertedOp = op;
   } else {
     // Create a function for regular functions (which cannot suspend).
     auto funcOp =
         mlir::func::FuncOp::create(builder, loc, qualifiedName, funcTy);
-    SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
+    setVisibilityAndExportAttr(funcOp);
     lowering = std::make_unique<FunctionLowering>(funcOp);
     insertedOp = funcOp;
   }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -664,6 +664,8 @@ struct CoroutineOpConversion : public OpConversionPattern<CoroutineOp> {
     auto newOp = llhd::CoroutineOp::create(rewriter, op.getLoc(),
                                            op.getSymName(), newFuncType);
     newOp.setSymVisibilityAttr(op.getSymVisibilityAttr());
+    if (auto dpiExport = op->getAttr("circt.dpi.export"))
+      newOp->setAttr("circt.dpi.export", dpiExport);
     rewriter.inlineRegionBefore(op.getBody(), newOp.getBody(),
                                 newOp.getBody().end());
     if (failed(rewriter.convertRegionTypes(&newOp.getBody(), *typeConverter,

--- a/test/Conversion/ImportVerilog/dpi-export.sv
+++ b/test/Conversion/ImportVerilog/dpi-export.sv
@@ -1,0 +1,37 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s --check-prefix=MOORE
+// RUN: circt-verilog --ir-llhd %s | FileCheck %s --check-prefix=LLHD
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+package p;
+  function int exported_func(input int x);
+    return x + 1;
+  endfunction
+  export "DPI-C" c_exported_func = function exported_func;
+
+  task automatic exported_task(input int x);
+    #1ns;
+  endtask
+  export "DPI-C" task exported_task;
+endpackage
+
+module m;
+  function int module_func(input int x);
+    return x - 1;
+  endfunction
+  export "DPI-C" c_module_func = function module_func;
+endmodule
+
+// MOORE: func.func @"p::exported_func"
+// MOORE-SAME: circt.dpi.export = "c_exported_func"
+// MOORE: moore.coroutine @"p::exported_task"
+// MOORE-SAME: circt.dpi.export = "exported_task"
+// MOORE: func.func @module_func
+// MOORE-SAME: circt.dpi.export = "c_module_func"
+
+// LLHD: func.func @"p::exported_func"
+// LLHD-SAME: circt.dpi.export = "c_exported_func"
+// LLHD: llhd.coroutine @"p::exported_task"
+// LLHD-SAME: circt.dpi.export = "exported_task"
+// LLHD: func.func @module_func
+// LLHD-SAME: circt.dpi.export = "c_module_func"


### PR DESCRIPTION
Record `export "DPI-C"` directives while converting compilation units, modules, and packages. Slang resolves the directives during elaboration but does not expose them on the subroutine symbols, so walk the scope syntax to recover the exported C names.

Exported subroutines keep a public symbol and are tagged with a `circt.dpi.export` attribute carrying the C name; the attribute is propagated through the Moore-to-core coroutine lowering. This is the frontend half of generic DPI export support — materializing callable trampolines for the arcilator JIT builds on top of it and will be proposed separately (it interacts with the in-progress Arc coroutine lowering work).

Part of a series upstreaming SystemVerilog/UVM simulation support validated against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
