### PR TITLE
[ImportVerilog] Lower type reference comparisons

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1495,6 +1495,34 @@ struct RvalueExprVisitor : public ExprVisitor {
 
   // Handle binary operators.
   Value visit(const slang::ast::BinaryExpression &expr) {
+    if (expr.left().kind == slang::ast::ExpressionKind::TypeReference &&
+        expr.right().kind == slang::ast::ExpressionKind::TypeReference) {
+      auto &lhsType =
+          expr.left().as<slang::ast::TypeReferenceExpression>().targetType;
+      auto &rhsType =
+          expr.right().as<slang::ast::TypeReferenceExpression>().targetType;
+      bool value = lhsType.isMatching(rhsType);
+
+      using slang::ast::BinaryOperator;
+      switch (expr.op) {
+      case BinaryOperator::Equality:
+      case BinaryOperator::CaseEquality:
+        break;
+      case BinaryOperator::Inequality:
+      case BinaryOperator::CaseInequality:
+        value = !value;
+        break;
+      default:
+        mlir::emitError(loc, "unsupported type reference binary operator");
+        return {};
+      }
+
+      auto type = moore::IntType::get(context.getContext(), /*width=*/1,
+                                      moore::Domain::TwoValued);
+      return moore::ConstantOp::create(builder, loc, type, value,
+                                       /*isSigned=*/false);
+    }
+
     // First check whether we need real or integral BOps
     const auto *rhsFloatType =
         expr.right().type->as_if<slang::ast::FloatingType>();

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -327,6 +327,36 @@ struct StmtVisitor {
   LogicalResult visit(const slang::ast::CaseStatement &caseStmt) {
     using slang::ast::AttributeSymbol;
     using slang::ast::CaseStatementCondition;
+    if (auto *caseType =
+            caseStmt.expr.as_if<slang::ast::TypeReferenceExpression>()) {
+      if (caseStmt.condition != CaseStatementCondition::Normal)
+        return mlir::emitError(loc,
+                               "unsupported type reference case condition");
+
+      const slang::ast::Statement *matchedStmt = nullptr;
+      for (const auto &item : caseStmt.items) {
+        for (const auto *expr : item.expressions) {
+          auto *itemType = expr->as_if<slang::ast::TypeReferenceExpression>();
+          if (!itemType)
+            return mlir::emitError(
+                context.convertLocation(expr->sourceRange),
+                "unsupported non-type item in type reference case statement");
+          if (itemType->targetType.isMatching(caseType->targetType)) {
+            matchedStmt = item.stmt;
+            break;
+          }
+        }
+        if (matchedStmt)
+          break;
+      }
+
+      if (matchedStmt)
+        return context.convertStatement(*matchedStmt);
+      if (caseStmt.defaultCase)
+        return context.convertStatement(*caseStmt.defaultCase);
+      return success();
+    }
+
     auto caseExpr = context.convertRvalueExpression(caseStmt.expr);
     if (!caseExpr)
       return failure();

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -169,3 +169,18 @@ module Event;
   // CHECK: %e = moore.variable : <i1>
   event e;
 endmodule
+
+// CHECK-LABEL: moore.module @TypeReferenceCompare
+module TypeReferenceCompare #(parameter type T = logic [11:0]);
+  initial begin
+    case (type(T))
+      type(logic [11:0]): ;
+      default: $stop;
+    endcase
+    if (type(T) == type(logic [12:0])) $stop;
+    if (type(T) != type(logic [11:0])) $stop;
+    if (type(T) === type(logic [12:0])) $stop;
+    if (type(T) !== type(logic [11:0])) $stop;
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Lower equality, case-equality, inequality, and case-inequality between two type references to a constant by evaluating slang's type matching at import time, and support type references as case statement selectors the same way. This covers the common `type(a) == type(b)` and `case (type(x))` patterns used in generic/parameterized code.

Part of a series upstreaming SystemVerilog/UVM simulation support validated against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
