### PR TITLE
[MooreToCore] Observe class-backed event waits

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -790,6 +790,27 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
     getValuesToObserve(&clonedOp.getBody(), setInsertionPointAfterDef,
                        typeConverter, rewriter, observeValues);
 
+    // If the analysis above did not find any values to observe, the event
+    // operands are read through storage that is invisible to the observer
+    // analysis, such as class fields or virtual interface members accessed
+    // through a pointer. An `llhd.wait` without observed values would suspend
+    // the process forever. Instead, observe the values sampled before the
+    // wait, such that the process wakes up and re-checks for events whenever
+    // any of them changes. The conversion casts are created at the end of the
+    // cloned body, which is inlined before the `llhd.wait` op below.
+    if (observeValues.empty()) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToEnd(&clonedOp.getBody().front());
+      for (auto value : valuesBefore) {
+        auto type = typeConverter->convertType(value.getType());
+        if (!type || !hw::isHWValueType(type))
+          continue;
+        if (auto converted = typeConverter->materializeTargetConversion(
+                rewriter, loc, type, value))
+          observeValues.push_back(converted);
+      }
+    }
+
     // Create the `llhd.wait` op that suspends the current process and waits for
     // a change in the interesting values listed in `observeValues`. When a
     // change is detected, execution resumes in the "check" block.

--- a/test/Conversion/MooreToCore/class-event-wait.mlir
+++ b/test/Conversion/MooreToCore/class-event-wait.mlir
@@ -1,0 +1,67 @@
+// RUN: circt-opt %s --convert-moore-to-core --verify-diagnostics | FileCheck %s
+
+module {
+  // Keep the func dialect loaded for class allocation helper declarations.
+  func.func private @load_func_dialect()
+
+  moore.class.classdecl @ClassEventWait {
+    moore.class.propertydecl @changed : !moore.i1
+  }
+
+  // All event operands are read out of class-backed storage that is created
+  // inside the wait body, so observer analysis cannot see anything to observe
+  // outside the region. Without observing the sampled pre-wait values, the
+  // resulting `llhd.wait` would have no observed values and hang forever.
+  // CHECK-LABEL: hw.module @ClassPropertyWaitEvent
+  moore.module @ClassPropertyWaitEvent() {
+    moore.procedure initial {
+      // CHECK: llhd.process {
+      // CHECK: cf.br ^[[WAIT:.+]]
+      // CHECK: ^[[WAIT]]:
+      // CHECK: func.call @malloc
+      // CHECK: [[REF:%.+]] = builtin.unrealized_conversion_cast {{%.+}} : !llvm.ptr to !llhd.ref<i1>
+      // CHECK: [[EVENT:%.+]] = llhd.prb [[REF]] : i1
+      // CHECK: llhd.wait ([[EVENT]] : i1), ^[[CHECKBB:.+]]
+      // CHECK: ^[[CHECKBB]]:
+      // CHECK-NOT: comb.icmp
+      // CHECK: cf.br
+      moore.wait_event {
+        %obj = moore.class.new : <@ClassEventWait>
+        %ref = moore.class.property_ref %obj[@changed] : <@ClassEventWait> -> !moore.ref<i1>
+        %v = moore.read %ref : <i1>
+        moore.detect_event any %v : i1
+      }
+      moore.return
+    }
+    moore.output
+  }
+
+  // Same situation for edge-sensitive waits on storage behind a pointer that
+  // observer analysis cannot see: the sampled pre-wait value must show up as
+  // the observed value of the `llhd.wait`, and the edge detection compares it
+  // against the value probed after the wait.
+  // CHECK-LABEL: hw.module @DynamicRefPosedgeWait
+  moore.module @DynamicRefPosedgeWait() {
+    moore.procedure initial {
+      // CHECK: llhd.process {
+      // CHECK: cf.br ^[[WAIT:.+]]
+      // CHECK: ^[[WAIT]]:
+      // CHECK: [[BEFORE:%.+]] = llhd.prb {{%.+}} : i1
+      // CHECK: llhd.wait ([[BEFORE]] : i1), ^[[CHECKBB:.+]]
+      // CHECK: ^[[CHECKBB]]:
+      // CHECK: [[AFTER:%.+]] = llhd.prb {{%.+}} : i1
+      // CHECK: [[TRUE:%.+]] = hw.constant true
+      // CHECK: [[TMP1:%.+]] = comb.xor bin [[BEFORE]], [[TRUE]]
+      // CHECK: [[TMP2:%.+]] = comb.and bin [[TMP1]], [[AFTER]]
+      // CHECK: cf.cond_br [[TMP2]]
+      moore.wait_event {
+        %arg0 = llvm.mlir.zero : !llvm.ptr
+        %ref = builtin.unrealized_conversion_cast %arg0 : !llvm.ptr to !moore.ref<i1>
+        %v = moore.read %ref : <i1>
+        moore.detect_event posedge %v : i1
+      }
+      moore.return
+    }
+    moore.output
+  }
+}


### PR DESCRIPTION
When `getValuesToObserve` finds no out-of-region operands for a `moore.wait_event` — which happens when the awaited storage is class-backed or reached through a virtual interface handle, invisible to observer analysis — the lowered `llhd.wait` observes nothing and the process can never wake up.

In that case, materialize the pre-wait sampled detect values to HW value types and use them as the wait's observed values, so the process wakes on changes to the very values the event detection compares. Behavior is unchanged when observer analysis does find values to observe.

Includes a regression test with a class-allocated event source (previously lowered to an observer-less `llhd.wait` that hangs forever) and a dynamic-ref posedge wait.

Part of a series upstreaming SystemVerilog/UVM simulation support validated against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
