### PR TITLE
[ImportVerilog] Ignore let declarations

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -9,6 +9,7 @@
 #include "ImportVerilogInternals.h"
 #include "slang/ast/Compilation.h"
 #include "slang/ast/symbols/ClassSymbols.h"
+#include "slang/ast/symbols/MemberSymbols.h"
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxVisitor.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
@@ -930,6 +931,10 @@ struct ModuleVisitor : public BaseVisitor {
   LogicalResult visit(const slang::ast::PropertySymbol &propNode) {
     return success();
   }
+
+  // Ignore let declarations. Slang expands uses into AssertionInstance
+  // expressions, which are lowered when the use site is imported.
+  LogicalResult visit(const slang::ast::LetDeclSymbol &) { return success(); }
 
   // Handle functions and tasks.
   LogicalResult visit(const slang::ast::SubroutineSymbol &subroutine) {

--- a/test/Conversion/ImportVerilog/let.sv
+++ b/test/Conversion/ImportVerilog/let.sv
@@ -1,0 +1,26 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// CHECK-LABEL: moore.module @LetConstruct()
+module LetConstruct;
+  logic [3:0] a = 12;
+  logic [3:0] b = 15;
+  logic [3:0] c = 7;
+  logic d;
+
+  let op(x, y, z) = |((x | y) & z);
+
+  initial begin
+    // CHECK: moore.procedure initial
+    // CHECK:   [[A:%.+]] = moore.read {{%.+}} : <l4>
+    // CHECK:   [[B:%.+]] = moore.read {{%.+}} : <l4>
+    // CHECK:   [[OR:%.+]] = moore.or [[A]], [[B]] : l4
+    // CHECK:   [[C:%.+]] = moore.read {{%.+}} : <l4>
+    // CHECK:   [[AND:%.+]] = moore.and [[OR]], [[C]] : l4
+    // CHECK:   [[REDUCE:%.+]] = moore.reduce_or [[AND]] : l4 -> l1
+    // CHECK:   moore.blocking_assign {{%.+}}, [[REDUCE]] : l1
+    d = op(.x(a), .y(b), .z(c));
+  end
+endmodule


### PR DESCRIPTION
Ignore `let` declarations as module members. Slang expands let uses into `AssertionInstance` expressions, which are lowered when the use site is imported, so the declaration itself needs no lowering — previously it hit the unsupported-member error.

Part of a series upstreaming SystemVerilog/UVM simulation support validated against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
