### PR TITLE
[ImportVerilog] Support $test$plusargs and $value$plusargs

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3161,6 +3161,39 @@ def FDisplayBIOp : Builtin<"fdisplay"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Command Line Input System Functions
+//===----------------------------------------------------------------------===//
+
+def PlusArgsTestBIOp : Builtin<"plusargs_test"> {
+  let summary = "Test for the presence of a command-line plusarg";
+  let description = [{
+    Returns true if a command-line plus-argument matching the given format
+    string was supplied to the simulation. This corresponds to the
+    `$test$plusargs` system function.
+
+    See IEEE 1800-2017 § 21.6 "Command line input".
+  }];
+  let arguments = (ins StrAttr:$formatString);
+  let results = (outs BitType:$found);
+  let assemblyFormat = "$formatString attr-dict `:` type($found)";
+}
+
+def PlusArgsValueBIOp : Builtin<"plusargs_value"> {
+  let summary = "Read the value of a command-line plusarg";
+  let description = [{
+    Returns true if a command-line plus-argument matching the given format
+    string was supplied to the simulation, and parses the argument's value into
+    `result`. This corresponds to the `$value$plusargs` system function.
+
+    See IEEE 1800-2017 § 21.6 "Command line input".
+  }];
+  let arguments = (ins StrAttr:$formatString);
+  let results = (outs BitType:$found, UnpackedType:$result);
+  let assemblyFormat =
+      "$formatString attr-dict `:` type($found) `,` type($result)";
+}
+
+//===----------------------------------------------------------------------===//
 // Math Builtins
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3755,6 +3755,53 @@ Value Context::convertSystemCall(
     return moore::FOpenBIOp::create(builder, loc, filename, modeAttr);
   }
 
+  //===--------------------------------------------------------------------===//
+  // Command Line Input System Functions
+  //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::TestPlusArgs) {
+    // Slang already checks the arity of `$test$plusargs`.
+    assert(numArgs == 1 && "`$test$plusargs` takes 1 argument");
+    auto *strLit =
+        args[0]->unwrapImplicitConversions().as_if<slang::ast::StringLiteral>();
+    if (!strLit)
+      return emitError(loc) << "`$test$plusargs` argument must be a string "
+                               "literal",
+             Value{};
+    auto foundTy = moore::IntType::getInt(getContext(), 1);
+    return moore::PlusArgsTestBIOp::create(
+        builder, loc, foundTy, builder.getStringAttr(strLit->getValue()));
+  }
+
+  if (nameId == ksn::ValuePlusArgs) {
+    // Slang already checks the arity of `$value$plusargs`. The parsed value is
+    // written back into the second (lvalue) argument, and the function returns
+    // whether a matching plusarg was found.
+    assert(numArgs == 2 && "`$value$plusargs` takes 2 arguments");
+    auto *strLit =
+        args[0]->unwrapImplicitConversions().as_if<slang::ast::StringLiteral>();
+    if (!strLit)
+      return emitError(loc) << "`$value$plusargs` format must be a string "
+                               "literal",
+             Value{};
+    // Slang emits output arguments as a `<lvalue> = EmptyArgument` assignment;
+    // unpack it to recover the lvalue that receives the parsed value.
+    const auto *valueArg = args[1];
+    if (const auto *assign =
+            valueArg->as_if<slang::ast::AssignmentExpression>())
+      valueArg = &assign->left();
+    auto lvalue = convertLvalueExpression(*valueArg);
+    if (!lvalue)
+      return {};
+    auto resultType = cast<moore::RefType>(lvalue.getType()).getNestedType();
+    auto foundTy = moore::IntType::getInt(getContext(), 1);
+    auto op = moore::PlusArgsValueBIOp::create(
+        builder, loc, foundTy, resultType,
+        builder.getStringAttr(strLit->getValue()));
+    moore::BlockingAssignOp::create(builder, loc, lvalue, op.getResult());
+    return op.getFound();
+  }
+
   // Unrecognized system call
   emitError(loc) << "unsupported system call `" << name << "`";
   return {};

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -3010,6 +3010,33 @@ struct FOpenBIOpConversion : public OpConversionPattern<FOpenBIOp> {
   }
 };
 
+struct PlusArgsTestBIOpConversion
+    : public OpConversionPattern<PlusArgsTestBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(PlusArgsTestBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::PlusArgsTestOp>(op, rewriter.getI1Type(),
+                                                     op.getFormatStringAttr());
+    return success();
+  }
+};
+
+struct PlusArgsValueBIOpConversion
+    : public OpConversionPattern<PlusArgsValueBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(PlusArgsValueBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resultType = typeConverter->convertType(op.getResult().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op, "unsupported result type");
+    rewriter.replaceOpWithNewOp<sim::PlusArgsValueOp>(
+        op, rewriter.getI1Type(), resultType, op.getFormatStringAttr());
+    return success();
+  }
+};
+
 struct FCloseBIOpConversion : public OpConversionPattern<FCloseBIOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -3592,6 +3619,10 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FOpenBIOpConversion,
     FCloseBIOpConversion,
     FFlushBIOpConversion,
+
+    // Command line input operations
+    PlusArgsTestBIOpConversion,
+    PlusArgsValueBIOpConversion,
 
     // Dynamic string operations
     StringLenOpConversion,

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -916,3 +916,17 @@ function void FileDisplayBuiltins(int fd, int x);
   $fdisplayh(fd, x);
 
 endfunction
+
+// IEEE 1800-2017 § 21.6 "Command line input"
+// CHECK-LABEL: func.func private @PlusArgsBuiltins(
+function void PlusArgsBuiltins();
+  bit rv;
+  int val;
+
+  // CHECK: [[T:%.+]] = moore.builtin.plusargs_test "FOO" : i1
+  rv = $test$plusargs("FOO");
+
+  // CHECK: [[FOUND:%.+]], [[RESULT:%.+]] = moore.builtin.plusargs_value "BAR=%d" : i1, i32
+  // CHECK: moore.blocking_assign {{%.+}}, [[RESULT]] : i32
+  rv = $value$plusargs("BAR=%d", val);
+endfunction

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1850,6 +1850,15 @@ func.func @FDisplay(%arg0: !moore.i32) {
   return
 }
 
+// CHECK-LABEL: func.func @PlusArgs
+func.func @PlusArgs() {
+  // CHECK: sim.plusargs.test "FOO"
+  %0 = moore.builtin.plusargs_test "FOO" : i1
+  // CHECK: %{{.+}}, %{{.+}} = sim.plusargs.value "BAR=%d" : i32
+  %found, %result = moore.builtin.plusargs_value "BAR=%d" : i1, i32
+  return
+}
+
 // CHECK-LABEL: hw.module @MooreTypedArithSelect
 moore.module @MooreTypedArithSelect(in %s: i1, in %a: !moore.i8, in %b: !moore.i8, out o: !moore.i8) {
   // CHECK-NOT: !moore.i8


### PR DESCRIPTION
Add support for the `$test$plusargs` and `$value$plusargs` command-line input system functions (IEEE 1800-2017 § 21.6).

Introduce two Moore builtin ops, `moore.builtin.plusargs_test` and `moore.builtin.plusargs_value`, that carry the (string-literal) format string as an attribute. ImportVerilog lowers the system calls to these ops; for `$value$plusargs` the parsed value is blocking-assigned into the output lvalue argument and the call returns whether a match was found.

MooreToCore lowers the new ops to the existing `sim.plusargs.test` and `sim.plusargs.value` operations -- the same ops that the FIRRTL `PlusArgsTest`/`PlusArgsValue` intrinsics lower to in lib/Conversion/FIRRTLToHW/LowerToHW.cpp.

Assisted-by: Claude Code:claude-opus-4-8

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
