### PR TITLE
[slang] Update dependency to version 11.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,7 +563,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG v10.0
+      GIT_TAG v11.0
       GIT_SHALLOW ON
     )
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
@@ -614,7 +614,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang)
     install(TARGETS slang_slang EXPORT CIRCTTargets)
   else()
-    find_package(slang 10.0 REQUIRED)
+    find_package(slang 11.0 REQUIRED)
   endif()
 endif()
 

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -473,7 +473,8 @@ Value Context::convertToI1(Value value) {
 
 namespace {
 struct AssertionClockVisitor
-    : slang::ast::ASTVisitor<AssertionClockVisitor, true, true> {
+    : slang::ast::ASTVisitor<AssertionClockVisitor,
+                             slang::ast::VisitFlags::AllGood> {
   Context &context;
   const slang::analysis::AnalyzedAssertion &assertion;
   const slang::ast::TimingControl *currentClock = nullptr;

--- a/lib/Conversion/ImportVerilog/CaptureAnalysis.cpp
+++ b/lib/Conversion/ImportVerilog/CaptureAnalysis.cpp
@@ -79,10 +79,7 @@ namespace {
 /// each function. Uses slang's `ASTVisitor` with both statement and expression
 /// visiting enabled so that we recurse into all function bodies.
 struct CaptureWalker
-    : public ASTVisitor<CaptureWalker, /*VisitStatements=*/true,
-                        /*VisitExpressions=*/true,
-                        /*VisitBad=*/false,
-                        /*VisitCanonical=*/true> {
+    : public ASTVisitor<CaptureWalker, VisitFlags::AllCanonical> {
 
   /// The function whose body we are currently inside, or nullptr if we are at
   /// a scope outside any function.

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -73,7 +73,7 @@ static Value getSelectIndex(Context &context, Location loc, Value index,
   // Compute offset first so we know if it is negative.
   auto lo = range.lower();
   auto hi = range.upper();
-  auto offset = range.isLittleEndian() ? lo : hi;
+  auto offset = range.isDescending() ? lo : hi;
 
   // If any bound is negative we need a signed index type.
   const bool needSigned = (lo < 0) || (hi < 0);
@@ -96,7 +96,7 @@ static Value getSelectIndex(Context &context, Location loc, Value index,
   index = context.materializeConversion(intType, index, needSigned, loc);
 
   if (offset == 0) {
-    if (range.isLittleEndian())
+    if (range.isDescending())
       return index;
     else
       return moore::NegOp::create(builder, loc, index);
@@ -104,7 +104,7 @@ static Value getSelectIndex(Context &context, Location loc, Value index,
 
   auto offsetConst =
       moore::ConstantOp::create(builder, loc, intType, offset, needSigned);
-  if (range.isLittleEndian())
+  if (range.isDescending())
     return moore::SubOp::create(builder, loc, index, offsetConst);
   else
     return moore::SubOp::create(builder, loc, offsetConst, index);
@@ -539,7 +539,7 @@ struct ExprVisitor {
       // therefore have to take the `a` from above and adjust it by `-b+1` to
       // arrive at the right bound.
       if (expr.getSelectionKind() == RangeSelectionKind::IndexedDown &&
-          range.isLittleEndian()) {
+          range.isDescending()) {
         assert(constRight && "constness checked in slang");
         offsetAdd = 1 - *constRight;
       }
@@ -548,7 +548,7 @@ struct ExprVisitor {
       // therefore have to take the `a` from above and adjust it by `+b-1` to
       // arrive at the right bound.
       if (expr.getSelectionKind() == RangeSelectionKind::IndexedUp &&
-          !range.isLittleEndian()) {
+          !range.isDescending()) {
         assert(constRight && "constness checked in slang");
         offsetAdd = *constRight - 1;
       }

--- a/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
+++ b/lib/Conversion/ImportVerilog/HierarchicalNames.cpp
@@ -15,8 +15,7 @@ using namespace ImportVerilog;
 namespace {
 struct InstBodyVisitor
     : public slang::ast::ASTVisitor<InstBodyVisitor,
-                                    /*VisitStatements=*/true,
-                                    /*VisitExpressions=*/true> {
+                                    slang::ast::VisitFlags::AllGood> {
   InstBodyVisitor(
       Context &context, const slang::ast::Symbol &outermostModule,
       DenseSet<const slang::ast::InstanceBodySymbol *> &visitedBodies)

--- a/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogIndex.cpp
+++ b/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogIndex.cpp
@@ -60,8 +60,10 @@ inline bool definitelyOutsideMainBuffer(const T &t, slang::BufferID bufferId) {
 }
 
 // Index the AST to find symbol uses and definitions.
-struct VerilogIndexer : slang::ast::ASTVisitor<VerilogIndexer, true, true> {
-  using ASTBase = slang::ast::ASTVisitor<VerilogIndexer, true, true>;
+struct VerilogIndexer
+    : slang::ast::ASTVisitor<VerilogIndexer, slang::ast::VisitFlags::AllGood> {
+  using ASTBase =
+      slang::ast::ASTVisitor<VerilogIndexer, slang::ast::VisitFlags::AllGood>;
   VerilogIndexer(VerilogIndex &index) : index(index) {}
   VerilogIndex &index;
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -2489,30 +2489,36 @@ module ImmediateAssert(input clk);
   // CHECK: [[A:%.+]] = moore.variable : <i1>
   bit a;
 
-  // CHECK: moore.procedure always
+  // CHECK: moore.procedure always_comb
     // CHECK: [[READ_CLK:%.+]] = moore.read [[CLK]] : <l1>
     // CHECK: [[OneBX:%.+]] = moore.constant bX : l1
     // CHECK: [[NE:%.+]] = moore.ne [[READ_CLK]], [[OneBX]] : l1 -> l1
     // CHECK: moore.assert immediate [[NE]] : l1
-  assert (clk != 1'bx);
+  always_comb begin
+    assert (clk != 1'bx);
+  end
 
-  // CHECK: moore.procedure always
+  // CHECK: moore.procedure always_comb
     // CHECK: [[C100:%.+]] = moore.constant 100 : i32
     // CHECK: [[BC:%.+]] = moore.bool_cast [[C100]] : i32 -> i1
     // CHECK: moore.assume observed [[BC]] : i1
-  assume #0 (100);
+  always_comb begin
+    assume #0 (100);
+  end
 
-  // CHECK: moore.procedure always
+  // CHECK: moore.procedure always_comb
     // CHECK: [[READ_A:%.+]] = moore.read [[A]] : <i1>
     // CHECK: moore.cover final [[READ_A]] : i1
-  cover final (a);
+  always_comb begin
+    cover final (a);
+  end
 endmodule
 
 // CHECK-LABEL: moore.module @ImmediateAssertiWithActionBlock() 
 module ImmediateAssertiWithActionBlock;
   logic x;
-  int a;
-// CHECK: moore.procedure always {
+  int a, b, c;
+// CHECK: moore.procedure always_comb {
   // CHECK: [[READ_X:%.+]] = moore.read %x : <l1>
   // CHECK: [[X_INT:%.+]] = moore.logic_to_int [[READ_X]] : l1
   // CHECK: [[CONV_X:%.+]] = moore.to_builtin_int [[X_INT]] : i1
@@ -2524,9 +2530,11 @@ module ImmediateAssertiWithActionBlock;
 // CHECK: ^bb2:  // 2 preds: ^bb0, ^bb1
   // CHECK:   moore.return
 // CHECK: }
-  assert (x) a = 1;
+  always_comb begin
+    assert (x) a = 1;
+  end
 
-// CHECK: moore.procedure always {
+// CHECK: moore.procedure always_comb {
   // CHECK: [[READ_X:%.+]] = moore.read %x : <l1>
   // CHECK: [[X_INT:%.+]] = moore.logic_to_int [[READ_X]] : l1
   // CHECK: [[CONV_X:%.+]] = moore.to_builtin_int [[X_INT]] : i1
@@ -2535,30 +2543,34 @@ module ImmediateAssertiWithActionBlock;
   // CHECK: cf.br ^bb3
 // CHECK: ^bb2:  // pred: ^bb0
   // CHECK: [[C0:%.+]] = moore.constant 0 : i32
-  // CHECK: moore.blocking_assign %a, [[C0]] : i32
+  // CHECK: moore.blocking_assign %b, [[C0]] : i32
   // CHECK: cf.br ^bb3
 // CHECK: ^bb3:  // 2 preds: ^bb1, ^bb2
   // CHECK: moore.return
 // CHECK: }
-  assert (x) else a = 0;
+  always_comb begin
+    assert (x) else b = 0;
+  end
 
-// CHECK: moore.procedure always {
+// CHECK: moore.procedure always_comb {
   // CHECK: [[READ_X:%.+]] = moore.read %x : <l1>
   // CHECK: [[X_INT:%.+]] = moore.logic_to_int [[READ_X]] : l1
   // CHECK: [[CONV_X:%.+]] = moore.to_builtin_int [[X_INT]] : i1
   // CHECK: cf.cond_br [[CONV_X]], ^bb1, ^bb2
 // CHECK: ^bb1:  // pred: ^bb0
   // CHECK: [[C1:%.+]] = moore.constant 1 : i32
-  // CHECK: moore.blocking_assign %a, [[C1]] : i32
+  // CHECK: moore.blocking_assign %c, [[C1]] : i32
   // CHECK: cf.br ^bb3
 // CHECK: ^bb2:  // pred: ^bb0
   // CHECK: [[C0:%.+]] = moore.constant 0 : i32
-  // CHECK: moore.blocking_assign %a, [[C0]] : i32
+  // CHECK: moore.blocking_assign %c, [[C0]] : i32
   // CHECK: cf.br ^bb3
 // CHECK: ^bb3:  // 2 preds: ^bb1, ^bb2
   // CHECK: moore.return
 // CHECK: }
-  assert (x) a = 1; else a = 0;
+  always_comb begin
+    assert (x) c = 1; else c = 0;
+  end
 endmodule
 
 // CHECK-LABEL: moore.module @AssertNoActionBlock

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -21,7 +21,7 @@ endmodule
 module Foo;
   mailbox a;
   string b;
-  // expected-error @below {{value of type 'string' cannot be assigned to type 'mailbox'}}
+  // expected-error @below {{value of type 'string' cannot be assigned to type 'mailbox#(untyped)'}}
   initial a = b;
 endmodule
 

--- a/test/Tools/circt-verilog-lsp-server/diagnostic.test
+++ b/test/Tools/circt-verilog-lsp-server/diagnostic.test
@@ -8,7 +8,7 @@
   "uri":"test:///diagnostic.sv",
   "languageId":"verilog",
   "version":1,
-  "text":"function foo()\n int bar = 0;\nendfunction"
+  "text":"function foo()\n int bar = 0;\nendfunction\n"
 }}}
 // CHECK:      "method": "textDocument/publishDiagnostics",
 // CHECK-NEXT:   "params": {

--- a/test/Tools/circt-verilog-lsp-server/include.test
+++ b/test/Tools/circt-verilog-lsp-server/include.test
@@ -9,7 +9,7 @@
   "uri":"test:///diagnostic.sv",
   "languageId":"verilog",
   "version":1,
-  "text":"module Foo();\n Bar bar();\nendmodule"
+  "text":"module Foo();\n Bar bar();\nendmodule\n"
 }}}
 // CHECK:        "method": "textDocument/publishDiagnostics",
 // CHECK-NEXT:   "params": {

--- a/test/Tools/circt-verilog-lsp-server/textdocument-didchange.test
+++ b/test/Tools/circt-verilog-lsp-server/textdocument-didchange.test
@@ -8,7 +8,7 @@
   "uri":"test:///foo.sv",
   "languageId":"verilog",
   "version":1,
-  "text":"module Foo(); "
+  "text":"module Foo();\n"
 }}}
 // CHECK: "method": "textDocument/publishDiagnostics",
 // CHECK-NEXT: "params": {

--- a/test/circt-verilog/commandline.sv
+++ b/test/circt-verilog/commandline.sv
@@ -4,4 +4,4 @@
 // UNSUPPORTED: valgrind
 
 // CHECK-HELP: OVERVIEW: Verilog and SystemVerilog frontend
-// CHECK-VERSION: slang version 10.
+// CHECK-VERSION: slang version 11.


### PR DESCRIPTION
This required to adapt to a few upstream changes:

* https://github.com/MikePopoloski/slang/commit/790427a8: Follow rename of `ConstantRange::{isLittleEndian => isDescending}`.
* https://github.com/MikePopoloski/slang/commit/6f4c2469: Use flags instead of Boolean parameters for `ASTVisitor` template.