### PR TITLE
[slang] Update dependency to latest version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,8 +563,8 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG v11.0
-      GIT_SHALLOW ON
+      GIT_TAG 6933832c97c39976890e5f12b69245f061d60a9a # June 9, 2026: v11.0 + ~60 commits
+      # GIT_SHALLOW ON # TODO: re-enable once we use a released version again.
     )
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
 
@@ -612,6 +612,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
       endif()
     endforeach()
     set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang)
+    set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS tomlplusplus_tomlplusplus)
     install(TARGETS slang_slang EXPORT CIRCTTargets)
   else()
     find_package(slang 11.0 REQUIRED)


### PR DESCRIPTION
This PR updates the slang dependency to the latest (non-released) version. This requires to (temporarily) disable `GIT_SHALLOW`. The new version takes on toml++ as dependency, which requires adding that dependency to CIRCT's export set.

I understand if we don't want to upgrade to a non-released version. In this case, this PR may serve as a base for integrating the next released version and already provides the fix for the change with the toml++ dependency.