### PR TITLE
[ci] Switch to unversioned clang in UBTI Static

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstallStatic.yml
+++ b/.github/workflows/unifiedBuildTestAndInstallStatic.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup (linux)
         run: |
           apk update
-          apk add bash clang19 cmake curl file git gzip perl-utils python3 samurai tar
+          apk add bash clang cmake curl file git gzip perl-utils python3 samurai tar
 # Clone the repository
       - name: Clone llvm/circt
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -122,14 +122,14 @@ jobs:
         run: |
           mkdir -p build/mimalloc/build
           cd build/mimalloc/build
-          cmake ../ -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DMI_OVERRIDE=ON -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19
+          cmake ../ -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DMI_OVERRIDE=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           ninja
 # Configure
       - name: Configure CIRCT
         run: |
           mkdir -p build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" $EXTRA_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_BUILD_STATIC=ON -DLLVM_LINK_LLVM_DYLIB=OFF -DLLVM_ENABLE_PIC=OFF -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=ON -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DCMAKE_EXE_LINKER_FLAGS_INIT="-Wl,-z,stack-size=8388608 -Wl,--whole-archive $(pwd)/../build/mimalloc/build/libmimalloc.a -Wl,--no-whole-archive"
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" $EXTRA_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_BUILD_STATIC=ON -DLLVM_LINK_LLVM_DYLIB=OFF -DLLVM_ENABLE_PIC=OFF -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=ON -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON -DCIRCT_SLANG_FRONTEND_ENABLED=ON -DCMAKE_EXE_LINKER_FLAGS_INIT="-Wl,-z,stack-size=8388608 -Wl,--whole-archive $(pwd)/../build/mimalloc/build/libmimalloc.a -Wl,--no-whole-archive"
 # Optionally test
       - name: Test CIRCT
         if: inputs.run_tests

--- a/.github/workflows/unifiedBuildTestAndInstallStatic.yml
+++ b/.github/workflows/unifiedBuildTestAndInstallStatic.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup (linux)
         run: |
           apk update
-          apk add bash clang cmake curl file git gzip perl-utils python3 samurai tar
+          apk add bash build-base clang cmake curl file git gzip lld perl-utils python3 samurai tar
 # Clone the repository
       - name: Clone llvm/circt
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Change the version of Clang used in the UBTI static builds from clang-19
to the unversioned package.  The former is not available in the latest
v3.24 packages.  Additionally, there isn't a strong reason to lock this to
clang-19 and it should be fine to let it float.
