### PR TITLE
[ImportVerilog] Thread $stacktrace caller context

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2028,6 +2028,12 @@ struct RvalueExprVisitor : public ExprVisitor {
       arguments.push_back(value);
     }
 
+    // Pass the hidden `$stacktrace` caller-location argument, if this callee
+    // needs one. It is appended after the user arguments and before captures,
+    // matching the order established in `getFunctionSignature`.
+    if (context.needsStacktraceCallerArgument(*subroutine))
+      arguments.push_back(context.materializeStackTraceCallerLocation(loc));
+
     // Pass captured variables as extra arguments. Each captured AST symbol is
     // resolved to an MLIR value through the scoped symbol table, which
     // naturally handles transitive captures (the caller’s own capture block

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -252,6 +252,10 @@ struct Context {
   FunctionLowering *
   declareFunction(const slang::ast::SubroutineSymbol &subroutine);
   LogicalResult defineFunction(const slang::ast::SubroutineSymbol &subroutine);
+  bool
+  needsStacktraceCallerArgument(const slang::ast::SubroutineSymbol &subroutine);
+  Value materializeStackTraceCallerLocation(Location loc);
+  Value materializeStackTraceMessage(Location loc);
   LogicalResult
   convertPrimitiveInstance(const slang::ast::PrimitiveInstanceSymbol &prim);
   ClassLowering *declareClass(const slang::ast::ClassType &cls);
@@ -486,6 +490,12 @@ struct Context {
            std::unique_ptr<FunctionLowering>>
       functions;
 
+  /// Tri-state cache used to decide whether a subroutine needs a hidden
+  /// `$stacktrace` caller-location argument. Values are:
+  /// 1 = currently visiting, 2 = no, 3 = yes.
+  DenseMap<const slang::ast::SubroutineSymbol *, uint8_t>
+      stacktraceCallerArgState;
+
   /// DPI-C export directives keyed by the SystemVerilog subroutine they expose.
   DenseMap<const slang::ast::SubroutineSymbol *, std::string> dpiExportCNames;
 
@@ -570,6 +580,12 @@ struct Context {
   /// Variable to track the value of the current function's implicit `this`
   /// reference
   Value currentThisRef = {};
+
+  /// A stack of subroutines currently being lowered.
+  SmallVector<const slang::ast::SubroutineSymbol *> currentSubroutineStack;
+  /// Hidden caller-location strings available while lowering a subroutine that
+  /// may execute `$stacktrace`.
+  SmallVector<Value> stacktraceCallerStack;
 
   /// Variable that tracks the queue which we are currently converting the index
   /// expression for. This is necessary to implement the `$` operator, which

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -25,6 +25,122 @@ using namespace mlir;
 using namespace circt;
 using namespace ImportVerilog;
 
+/// Collect the qualified-name components (instances, packages, classes) for a
+/// scope, outermost first.
+static void collectScopeNameParts(const slang::ast::Scope *scope,
+                                  SmallVectorImpl<std::string> &parts) {
+  SmallVector<std::string, 8> reversed;
+  while (scope) {
+    const auto &sym = scope->asSymbol();
+    switch (sym.kind) {
+    case slang::ast::SymbolKind::Root:
+      scope = nullptr;
+      continue;
+    case slang::ast::SymbolKind::Instance:
+    case slang::ast::SymbolKind::InstanceBody:
+    case slang::ast::SymbolKind::Package:
+    case slang::ast::SymbolKind::ClassType:
+    case slang::ast::SymbolKind::GenericClassDef:
+      if (!sym.name.empty())
+        reversed.emplace_back(sym.name);
+      break;
+    default:
+      break;
+    }
+    scope = sym.getParentScope();
+  }
+  for (auto &part : llvm::reverse(reversed))
+    parts.push_back(part);
+}
+
+/// Build the `Pkg::Class::method` qualified name for a subroutine.
+static std::string
+getQualifiedSubroutineName(const slang::ast::SubroutineSymbol &subroutine) {
+  SmallVector<std::string, 8> parts;
+  collectScopeNameParts(subroutine.getParentScope(), parts);
+  if (!subroutine.name.empty())
+    parts.emplace_back(subroutine.name);
+
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  llvm::interleave(
+      parts, os, [&](const std::string &part) { os << part; }, "::");
+  return out;
+}
+
+/// Render a location as `file:line:col` if available, otherwise its default
+/// textual form.
+static std::string getLocationString(Location loc) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  if (auto fileLoc = dyn_cast<FileLineColLoc>(loc)) {
+    os << fileLoc.getFilename();
+    if (fileLoc.getLine())
+      os << ":" << fileLoc.getLine();
+    if (fileLoc.getColumn())
+      os << ":" << fileLoc.getColumn();
+    return out;
+  }
+  loc.print(os);
+  return out;
+}
+
+/// Append the stack frame for the subroutines currently being lowered, plus the
+/// location of the `$stacktrace` call itself.
+static void buildStackTraceFrame(Context &context, Location loc,
+                                 llvm::raw_ostream &os) {
+  if (context.currentSubroutineStack.empty()) {
+    os << "\n    <procedural scope>";
+  } else {
+    for (const auto *subroutine : llvm::reverse(context.currentSubroutineStack))
+      if (subroutine)
+        os << "\n    " << getQualifiedSubroutineName(*subroutine);
+  }
+  os << "\n    at " << getLocationString(loc);
+}
+
+static std::string buildStackTraceFrame(Context &context, Location loc) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  buildStackTraceFrame(context, loc, os);
+  return out;
+}
+
+static std::string buildStackTraceMessage(Context &context, Location loc) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  os << "Stack trace:";
+  buildStackTraceFrame(context, loc, os);
+  return out;
+}
+
+Value Context::materializeStackTraceCallerLocation(Location loc) {
+  SmallVector<Value, 2> fragments;
+  fragments.push_back(moore::FormatLiteralOp::create(
+      builder, loc, buildStackTraceFrame(*this, loc)));
+  if (!stacktraceCallerStack.empty())
+    fragments.push_back(moore::FormatStringOp::create(
+        builder, loc, stacktraceCallerStack.back(), {}, {}, {}));
+  Value chain = fragments.size() == 1
+                    ? fragments.front()
+                    : moore::FormatConcatOp::create(builder, loc, fragments);
+  return moore::FormatStringToStringOp::create(builder, loc, chain);
+}
+
+Value Context::materializeStackTraceMessage(Location loc) {
+  if (stacktraceCallerStack.empty())
+    return moore::FormatLiteralOp::create(
+        builder, loc, buildStackTraceMessage(*this, loc) + "\n");
+
+  SmallVector<Value, 3> fragments;
+  fragments.push_back(moore::FormatLiteralOp::create(
+      builder, loc, buildStackTraceMessage(*this, loc)));
+  fragments.push_back(moore::FormatStringOp::create(
+      builder, loc, stacktraceCallerStack.back(), {}, {}, {}));
+  fragments.push_back(moore::FormatLiteralOp::create(builder, loc, "\n"));
+  return moore::FormatConcatOp::create(builder, loc, fragments);
+}
+
 /// Build the message printed by the `$printtimescale` system task. If a module
 /// instance or `$unit` is passed as argument, report that scope's time scale;
 /// otherwise report the time scale of the current scope.
@@ -1037,6 +1153,16 @@ struct StmtVisitor {
     if (nameId == ksn::PrintTimeScale) {
       auto message = moore::FormatLiteralOp::create(
           builder, loc, buildPrintTimeScaleMessage(context, args));
+      moore::DisplayBIOp::create(builder, loc, message);
+      return true;
+    }
+
+    // Stack trace task (`$stacktrace`)
+
+    if (nameId == ksn::Stacktrace) {
+      if (!args.empty())
+        return emitError(loc) << "`$stacktrace` expects no arguments";
+      auto message = context.materializeStackTraceMessage(loc);
       moore::DisplayBIOp::create(builder, loc, message);
       return true;
     }

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1773,6 +1773,56 @@ Context::declareFunction(const slang::ast::SubroutineSymbol &subroutine) {
   return fLowering;
 }
 
+/// Determine whether a subroutine may reach a `$stacktrace` call, either
+/// directly in its own body or transitively through another subroutine that
+/// itself needs the hidden caller-location argument. Such subroutines receive
+/// an extra hidden `!moore.string` argument carrying the caller's stack frame.
+bool Context::needsStacktraceCallerArgument(
+    const slang::ast::SubroutineSymbol &subroutine) {
+  auto state = stacktraceCallerArgState.lookup(&subroutine);
+  if (state == 3)
+    return true;
+  if (state == 2)
+    return false;
+  if (state == 1)
+    return false;
+
+  if (subroutine.flags.has(slang::ast::MethodFlags::DPIImport)) {
+    stacktraceCallerArgState[&subroutine] = 2;
+    return false;
+  }
+
+  stacktraceCallerArgState[&subroutine] = 1;
+
+  struct Visitor : public slang::ast::ASTVisitor<Visitor,
+                                                 /*VisitStatements=*/true,
+                                                 /*VisitExpressions=*/true> {
+    Context &context;
+    bool needs = false;
+
+    explicit Visitor(Context &context) : context(context) {}
+
+    void handle(const slang::ast::CallExpression &expr) {
+      if (needs)
+        return;
+
+      if (expr.getSubroutineName() == "$stacktrace") {
+        needs = true;
+        return;
+      }
+
+      if (auto *callee = std::get_if<const slang::ast::SubroutineSymbol *>(
+              &expr.subroutine))
+        if (*callee && context.needsStacktraceCallerArgument(**callee))
+          needs = true;
+    }
+  } visitor(*this);
+
+  subroutine.getBody().visit(visitor);
+  stacktraceCallerArgState[&subroutine] = visitor.needs ? 3 : 2;
+  return visitor.needs;
+}
+
 /// Helper function to generate the function signature from a SubroutineSymbol
 /// and optional extra arguments (used for %this argument)
 static FunctionType getFunctionSignature(
@@ -1795,6 +1845,11 @@ static FunctionType getFunctionSignature(
           moore::RefType::get(cast<moore::UnpackedType>(type)));
     }
   }
+
+  // Subroutines that may execute `$stacktrace` receive a hidden caller-location
+  // string argument, inserted after the user arguments and before any captures.
+  if (context.needsStacktraceCallerArgument(subroutine))
+    inputTypes.push_back(moore::StringType::get(context.getContext()));
 
   inputTypes.append(suffixParams.begin(), suffixParams.end());
 
@@ -1973,6 +2028,11 @@ Context::defineFunction(const slang::ast::SubroutineSymbol &subroutine) {
 
   ValueSymbolScope scope(valueSymbols);
   VirtualInterfaceMemberScope vifMemberScope(virtualIfaceMembers);
+  // Track the subroutine being lowered so `$stacktrace` can report the call
+  // stack of frames currently being imported.
+  currentSubroutineStack.push_back(&subroutine);
+  auto currentSubroutineGuard =
+      llvm::make_scope_exit([&] { currentSubroutineStack.pop_back(); });
   if (isMethod) {
     if (const auto *classTy =
             subroutine.thisVar->getType().as_if<slang::ast::ClassType>()) {
@@ -2015,6 +2075,7 @@ Context::defineFunction(const slang::ast::SubroutineSymbol &subroutine) {
   auto valInputs = llvm::ArrayRef<Type>(inputs)
                        .drop_front(prefixCount)
                        .take_front(astArgs.size());
+  const bool needsStacktraceCaller = needsStacktraceCallerArgument(subroutine);
 
   for (auto [astArg, type] : llvm::zip(astArgs, valInputs)) {
     auto loc = convertLocation(astArg->location);
@@ -2037,6 +2098,29 @@ Context::defineFunction(const slang::ast::SubroutineSymbol &subroutine) {
     if (const auto *vi = argCanon.as_if<slang::ast::VirtualInterfaceType>())
       if (failed(registerVirtualInterfaceMembers(*astArg, *vi, loc)))
         return failure();
+  }
+
+  // Bind the hidden `$stacktrace` caller-location argument. It sits right after
+  // the user arguments and before any capture arguments in the block-argument
+  // list, mirroring the layout produced by `getFunctionSignature`.
+  bool pushedStacktraceCaller = false;
+  auto stacktraceCallerGuard = llvm::make_scope_exit([&] {
+    if (pushedStacktraceCaller)
+      stacktraceCallerStack.pop_back();
+  });
+  if (needsStacktraceCaller) {
+    size_t callerIndex = prefixCount + astArgs.size();
+    if (callerIndex >= inputs.size()) {
+      mlir::emitError(
+          lowering->op.getLoc(),
+          "internal error: missing `$stacktrace` caller argument for `")
+          << lowering->op.getName() << "`";
+      return failure();
+    }
+    auto callerLoc = convertLocation(subroutine.location);
+    Value callerArg = block.addArgument(inputs[callerIndex], callerLoc);
+    stacktraceCallerStack.push_back(callerArg);
+    pushedStacktraceCaller = true;
   }
 
   // Convert the body of the function.

--- a/test/Conversion/ImportVerilog/stacktrace.sv
+++ b/test/Conversion/ImportVerilog/stacktrace.sv
@@ -1,0 +1,31 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// A `$stacktrace` in a procedural scope lowers to a display of a constant
+// stack-trace message naming the surrounding procedural scope.
+// CHECK-LABEL: moore.module @Top
+module Top;
+  initial begin
+    // CHECK: moore.fmt.literal "Stack trace:\0A    <procedural scope>\0A    at
+    // CHECK: moore.builtin.display
+    $stacktrace;
+  end
+endmodule
+
+// A subroutine that can reach `$stacktrace` gains a hidden caller-location
+// string argument. Its body materializes the stack-trace message from the
+// constant frame, the threaded caller string, and a trailing newline. The
+// `initial` call site passes the caller location, so the produced IR is
+// well-typed.
+// CHECK-LABEL: func.func private @foo
+// CHECK-SAME: !moore.string
+// CHECK: moore.fmt.literal "Stack trace:\0A
+// CHECK: moore.fmt.string
+// CHECK: moore.builtin.display
+module Caller;
+  function automatic void foo();
+    $stacktrace;
+  endfunction
+  initial foo();
+endmodule


### PR DESCRIPTION
Lower the `$stacktrace` system task by threading a hidden caller-location argument through to the called subroutine, so the stack trace reflects the SV call site. The caller context is recovered during import and passed as a synthesized argument.

Part of a series upstreaming SystemVerilog/UVM simulation support validated against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
