### PR TITLE
[Moore] Handle delayed assignments in concat-ref lowering

### DIFF
--- a/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
+++ b/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
@@ -22,6 +22,8 @@
 #include "circt/Dialect/Moore/MoorePasses.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include <type_traits>
+
 namespace circt {
 namespace moore {
 #define GEN_PASS_DEF_SIMPLIFYREFS
@@ -49,6 +51,16 @@ static void collectOperands(Value operand, SmallVectorImpl<Value> &operands,
 
   } else
     operands.push_back(operand);
+}
+
+template <typename OpTy>
+static void createSplitAssign(OpTy op, ConversionPatternRewriter &rewriter,
+                              Value dst, Value src) {
+  if constexpr (std::is_same_v<OpTy, DelayedContinuousAssignOp> ||
+                std::is_same_v<OpTy, DelayedNonBlockingAssignOp>)
+    OpTy::create(rewriter, op.getLoc(), dst, src, op.getDelay());
+  else
+    OpTy::create(rewriter, op.getLoc(), dst, src);
 }
 
 template <typename OpTy>
@@ -83,7 +95,7 @@ struct ConcatRefLowering : public OpConversionPattern<OpTy> {
       // description mentioned.
       srcWidth = srcWidth - width;
 
-      OpTy::create(rewriter, op.getLoc(), operand, extract);
+      createSplitAssign(op, rewriter, operand, extract);
     }
     rewriter.eraseOp(op);
     return success();
@@ -137,16 +149,20 @@ void SimplifyRefsPass::runOnOperation() {
   MLIRContext &context = getContext();
   ConversionTarget target(context);
 
-  target.addDynamicallyLegalOp<ContinuousAssignOp, BlockingAssignOp,
-                               NonBlockingAssignOp>([](auto op) {
+  target.addDynamicallyLegalOp<ContinuousAssignOp, DelayedContinuousAssignOp,
+                               BlockingAssignOp, NonBlockingAssignOp,
+                               DelayedNonBlockingAssignOp>([](auto op) {
     return !op->getOperand(0).template getDefiningOp<ConcatRefOp>();
   });
 
   target.addLegalDialect<MooreDialect>();
   RewritePatternSet concatRefPatterns(&context);
   concatRefPatterns.add<ConcatRefLowering<ContinuousAssignOp>,
+                        ConcatRefLowering<DelayedContinuousAssignOp>,
                         ConcatRefLowering<BlockingAssignOp>,
-                        ConcatRefLowering<NonBlockingAssignOp>>(&context);
+                        ConcatRefLowering<NonBlockingAssignOp>,
+                        ConcatRefLowering<DelayedNonBlockingAssignOp>>(
+      &context);
 
   if (failed(applyPartialConversion(getOperation(), target,
                                     std::move(concatRefPatterns)))) {

--- a/test/Dialect/Moore/simplify-refs.mlir
+++ b/test/Dialect/Moore/simplify-refs.mlir
@@ -115,3 +115,24 @@ moore.module @QueueRefsWithConcat() {
     moore.return
   }
 }
+
+// CHECK-LABEL: moore.module @DelayedConcatRef()
+moore.module @DelayedConcatRef() {
+  %a = moore.variable : <l7>
+  %b = moore.variable : <l1>
+  %c = moore.variable : <l8>
+  moore.procedure initial {
+    %delay = moore.constant_time 1 fs
+    // CHECK-NOT: moore.concat_ref %a, %b
+    %dst = moore.concat_ref %a, %b : (!moore.ref<l7>, !moore.ref<l1>) -> <l8>
+    // CHECK: %[[C_READ:.+]] = moore.read %c : <l8>
+    %src = moore.read %c : <l8>
+    // CHECK: %[[A_SLICE:.+]] = moore.extract %[[C_READ]] from 1 : l8 -> l7
+    // CHECK: moore.delayed_nonblocking_assign %a, %[[A_SLICE]], %{{.*}} : l7
+    // CHECK: %[[B_SLICE:.+]] = moore.extract %[[C_READ]] from 0 : l8 -> l1
+    // CHECK: moore.delayed_nonblocking_assign %b, %[[B_SLICE]], %{{.*}} : l1
+    moore.delayed_nonblocking_assign %dst, %src, %delay : l8
+    moore.return
+  }
+  moore.output
+}


### PR DESCRIPTION
`SimplifyRefs`' concat-ref splitting created a plain assignment for each extracted slice, which dropped the delay operand on `DelayedContinuousAssignOp` / `DelayedNonBlockingAssignOp` and left those ops illegal after the conversion. Route slice creation through a small helper that preserves the delay operand for the delayed variants, and mark the delayed assign ops dynamically legal alongside their non-delayed counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
