### PR TITLE
[Arc] Add string comparison and slicing to the SV runtime

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/RuntimeSymbol.h
+++ b/include/circt/Dialect/Arc/Runtime/RuntimeSymbol.h
@@ -1,0 +1,28 @@
+//===- RuntimeSymbol.h - Runtime JIT symbol declarations --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_RUNTIME_RUNTIMESYMBOL_H
+#define CIRCT_DIALECT_ARC_RUNTIME_RUNTIMESYMBOL_H
+
+namespace circt {
+namespace arc {
+namespace runtime {
+
+/// A single JIT-bindable runtime symbol with its actual function pointer type,
+/// so `ExecutorAddr::fromPtr` sees the precise function pointer.
+template <typename FunctionPtrT>
+struct RuntimeSymbol {
+  const char *name;
+  FunctionPtrT addr;
+};
+
+} // namespace runtime
+} // namespace arc
+} // namespace circt
+
+#endif // CIRCT_DIALECT_ARC_RUNTIME_RUNTIMESYMBOL_H

--- a/include/circt/Dialect/Arc/Runtime/SimString.h
+++ b/include/circt/Dialect/Arc/Runtime/SimString.h
@@ -1,0 +1,47 @@
+//===- SimString.h - Simulation string runtime ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Declares runtime support for dynamic strings in the sim dialect. These leaf
+// C functions are statically linked into arcilator and bound to the JIT
+// alongside the core Arc runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_RUNTIME_SIMSTRING_H
+#define CIRCT_DIALECT_ARC_RUNTIME_SIMSTRING_H
+
+#include "circt/Dialect/Arc/Runtime/RuntimeSymbol.h"
+
+#include <cstdint>
+#include <tuple>
+
+extern "C" {
+
+/// Return the length of a NUL-terminated string (a null pointer is treated as
+/// the empty string).
+int32_t circt_sim_string_len(const char *str);
+
+} // extern "C"
+
+namespace circt {
+namespace arc {
+namespace runtime {
+
+using SimStringRuntimeSymbols =
+    std::tuple<RuntimeSymbol<decltype(&circt_sim_string_len)>>;
+
+#ifdef ARC_RUNTIME_JITBIND_FNDECL
+/// Return the sim string runtime symbols to register with the JIT.
+const SimStringRuntimeSymbols &getSimStringRuntimeSymbols();
+#endif // ARC_RUNTIME_JITBIND_FNDECL
+
+} // namespace runtime
+} // namespace arc
+} // namespace circt
+
+#endif // CIRCT_DIALECT_ARC_RUNTIME_SIMSTRING_H

--- a/include/circt/Dialect/Arc/Runtime/SimString.h
+++ b/include/circt/Dialect/Arc/Runtime/SimString.h
@@ -26,6 +26,29 @@ extern "C" {
 /// the empty string).
 int32_t circt_sim_string_len(const char *str);
 
+/// Compare two NUL-terminated strings (each null pointer is treated as the
+/// empty string), returning the result of `strcmp`.
+int32_t circt_sim_string_cmp(const char *lhs, const char *rhs);
+
+/// Concatenate two NUL-terminated strings (each null pointer is treated as the
+/// empty string), returning a freshly allocated NUL-terminated string.
+const char *circt_sim_string_concat(const char *lhs, const char *rhs);
+
+/// Convert a little-endian integer byte buffer into a freshly allocated
+/// NUL-terminated string using packed-byte string assignment semantics.
+const char *circt_sim_string_int_to_string(const void *input,
+                                           uint32_t bitWidth);
+
+/// Return the byte at index `idx` of a NUL-terminated string, or 0 if the
+/// index is out of range or the string is null.
+uint8_t circt_sim_string_get_char(const char *str, int32_t idx);
+
+/// Return the substring `str[start..end]` (inclusive) as a freshly allocated
+/// NUL-terminated string. Out-of-range bounds are clamped; an empty result is
+/// returned as "".
+const char *circt_sim_string_substr(const char *str, int32_t start,
+                                    int32_t end);
+
 } // extern "C"
 
 namespace circt {
@@ -33,7 +56,12 @@ namespace arc {
 namespace runtime {
 
 using SimStringRuntimeSymbols =
-    std::tuple<RuntimeSymbol<decltype(&circt_sim_string_len)>>;
+    std::tuple<RuntimeSymbol<decltype(&circt_sim_string_len)>,
+               RuntimeSymbol<decltype(&circt_sim_string_cmp)>,
+               RuntimeSymbol<decltype(&circt_sim_string_concat)>,
+               RuntimeSymbol<decltype(&circt_sim_string_int_to_string)>,
+               RuntimeSymbol<decltype(&circt_sim_string_get_char)>,
+               RuntimeSymbol<decltype(&circt_sim_string_substr)>>;
 
 #ifdef ARC_RUNTIME_JITBIND_FNDECL
 /// Return the sim string runtime symbols to register with the JIT.

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -713,6 +713,19 @@ def StringLengthOp : SimOp<"string.length", [Pure]> {
   let assemblyFormat = "$input attr-dict";
 }
 
+def StringCmpOp : SimOp<"string.cmp", [Pure]> {
+  let summary = "Lexicographically compare two strings";
+  let description = [{
+    Compares two dynamic strings using the same ordering as the ANSI C
+    `strcmp` function.
+  }];
+
+  let arguments = (ins DynamicStringType:$lhs, DynamicStringType:$rhs);
+  let results = (outs I32:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict";
+}
+
 def StringConcatOp : SimOp<"string.concat", [Pure]> {
   let summary = "Concatenate strings";
   let description = [{
@@ -796,6 +809,32 @@ def StringGetOp : SimOp<"string.get", [Pure]> {
   let hasFolder = true;
 
   let assemblyFormat = "$str `[` $index `]` attr-dict";
+}
+
+def StringGetCharOp : SimOp<"string.get_char", [Pure]> {
+  let summary = "Get a character from a string at a given index";
+  let description = [{
+    Returns the character byte at the specified zero-based index within a
+    dynamic string. Out-of-bounds accesses return 0.
+  }];
+
+  let arguments = (ins DynamicStringType:$str, I32:$index);
+  let results = (outs I8:$result);
+
+  let assemblyFormat = "$str `[` $index `]` attr-dict";
+}
+
+def StringSubstrOp : SimOp<"string.substr", [Pure]> {
+  let summary = "Extract a substring";
+  let description = [{
+    Returns the characters from the start through end indices inclusive, or the
+    empty string if the range is invalid.
+  }];
+
+  let arguments = (ins DynamicStringType:$str, I32:$start, I32:$end);
+  let results = (outs DynamicStringType:$result);
+
+  let assemblyFormat = "$str `[` $start `:` $end `]` attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/integration_test/arcilator/JIT/sim-string-length.mlir
+++ b/integration_test/arcilator/JIT/sim-string-length.mlir
@@ -1,0 +1,14 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
+// Exercise sim.string.length lowering through the sim string runtime bound into
+// the JIT.
+
+func.func @entry() {
+  %str = sim.string.literal "hello"
+  %len64 = sim.string.length %str
+  %len = arith.trunci %len64 : i64 to i32
+  // CHECK: len = 00000005
+  arc.sim.emit "len", %len : i32
+  return
+}

--- a/integration_test/arcilator/JIT/sim-string-runtime.mlir
+++ b/integration_test/arcilator/JIT/sim-string-runtime.mlir
@@ -1,0 +1,221 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
+func.func @entry() {
+  %hello = sim.string.literal "hello"
+  %bang = sim.string.literal "!"
+  %empty = sim.string.literal ""
+  %h = sim.string.literal "h"
+  %e = sim.string.literal "e"
+  %o = sim.string.literal "o"
+  %he = sim.string.literal "he"
+  %ab = sim.string.literal "AB"
+  %abc = sim.string.literal "ABC"
+  %abcdefghijklmnop = sim.string.literal "ABCDEFGHIJKLMNOP"
+  %hello_bang = sim.string.literal "hello!"
+  %lo = sim.string.literal "lo"
+  %zero8 = arith.constant 0 : i8
+  %ab_i16 = arith.constant 16706 : i16
+  %ab_i15 = arith.constant 16706 : i15
+  %abc_i24 = arith.constant 4276803 : i24
+  %abcdefghijklmnop_i128 = arith.constant 0x4142434445464748494a4b4c4d4e4f50 : i128
+  %zero = arith.constant 0 : i32
+  %one = arith.constant 1 : i32
+  %three = arith.constant 3 : i32
+  %four = arith.constant 4 : i32
+  %neg = arith.constant -1 : i32
+  %too_far = arith.constant 99 : i32
+
+  %eq = sim.string.cmp %hello, %hello
+  // CHECK: eq = 00000000
+  arc.sim.emit "eq", %eq : i32
+
+  %ne_cmp = sim.string.cmp %hello, %hello_bang
+  %ne_nonzero = arith.cmpi ne, %ne_cmp, %zero : i32
+  %ne_nonzero_i32 = arith.extui %ne_nonzero : i1 to i32
+  // CHECK: ne_nonzero = 00000001
+  arc.sim.emit "ne_nonzero", %ne_nonzero_i32 : i32
+
+  %empty_cmp = sim.string.cmp %empty, %hello
+  %empty_cmp_nonzero = arith.cmpi ne, %empty_cmp, %zero : i32
+  %empty_cmp_nonzero_i32 = arith.extui %empty_cmp_nonzero : i1 to i32
+  // CHECK: empty_cmp_nonzero = 00000001
+  arc.sim.emit "empty_cmp_nonzero", %empty_cmp_nonzero_i32 : i32
+
+  %ch = sim.string.get_char %hello[%one]
+  // CHECK: getc = 65
+  arc.sim.emit "getc", %ch : i8
+
+  %first_ch = sim.string.get_char %hello[%zero]
+  // CHECK: first_getc = 68
+  arc.sim.emit "first_getc", %first_ch : i8
+
+  %last_ch = sim.string.get_char %hello[%four]
+  // CHECK: last_getc = 6f
+  arc.sim.emit "last_getc", %last_ch : i8
+
+  %legacy_ch = sim.string.get %hello[%one]
+  // CHECK: legacy_getc = 65
+  arc.sim.emit "legacy_getc", %legacy_ch : i8
+
+  %legacy_first_ch = sim.string.get %hello[%zero]
+  // CHECK: legacy_first_getc = 68
+  arc.sim.emit "legacy_first_getc", %legacy_first_ch : i8
+
+  %legacy_last_ch = sim.string.get %hello[%four]
+  // CHECK: legacy_last_getc = 6f
+  arc.sim.emit "legacy_last_getc", %legacy_last_ch : i8
+
+  %neg_ch = sim.string.get_char %hello[%neg]
+  // CHECK: neg_getc = 00
+  arc.sim.emit "neg_getc", %neg_ch : i8
+
+  %legacy_neg_ch = sim.string.get %hello[%neg]
+  // CHECK: legacy_neg_getc = 00
+  arc.sim.emit "legacy_neg_getc", %legacy_neg_ch : i8
+
+  %far_ch = sim.string.get_char %hello[%too_far]
+  // CHECK: far_getc = 00
+  arc.sim.emit "far_getc", %far_ch : i8
+
+  %legacy_far_ch = sim.string.get %hello[%too_far]
+  // CHECK: legacy_far_getc = 00
+  arc.sim.emit "legacy_far_getc", %legacy_far_ch : i8
+
+  %empty_ch = sim.string.get_char %empty[%zero]
+  // CHECK: empty_getc = 00
+  arc.sim.emit "empty_getc", %empty_ch : i8
+
+  %legacy_empty_ch = sim.string.get %empty[%one]
+  // CHECK: legacy_empty_getc = 00
+  arc.sim.emit "legacy_empty_getc", %legacy_empty_ch : i8
+
+  %chstr = sim.string.int_to_string %ch : i8
+  %chstrcmp = sim.string.cmp %chstr, %e
+  // CHECK: chstrcmp = 00000000
+  arc.sim.emit "chstrcmp", %chstrcmp : i32
+
+  %zero_str = sim.string.int_to_string %zero8 : i8
+  %zero_strlen64 = sim.string.length %zero_str
+  %zero_strlen = arith.trunci %zero_strlen64 : i64 to i32
+  // CHECK: zero_strlen = 00000000
+  arc.sim.emit "zero_strlen", %zero_strlen : i32
+
+  %ab_str = sim.string.int_to_string %ab_i16 : i16
+  %abstrcmp = sim.string.cmp %ab_str, %ab
+  // CHECK: abstrcmp = 00000000
+  arc.sim.emit "abstrcmp", %abstrcmp : i32
+
+  %ab_i15_str = sim.string.int_to_string %ab_i15 : i15
+  %ab_i15_strcmp = sim.string.cmp %ab_i15_str, %ab
+  // CHECK: ab_i15_strcmp = 00000000
+  arc.sim.emit "ab_i15_strcmp", %ab_i15_strcmp : i32
+
+  %abc_str = sim.string.int_to_string %abc_i24 : i24
+  %abcstrcmp = sim.string.cmp %abc_str, %abc
+  // CHECK: abcstrcmp = 00000000
+  arc.sim.emit "abcstrcmp", %abcstrcmp : i32
+
+  %wide_str = sim.string.int_to_string %abcdefghijklmnop_i128 : i128
+  %widestrcmp = sim.string.cmp %wide_str, %abcdefghijklmnop
+  // CHECK: widestrcmp = 00000000
+  arc.sim.emit "widestrcmp", %widestrcmp : i32
+
+  %sub = sim.string.substr %hello[%one : %three]
+  %sublen64 = sim.string.length %sub
+  %sublen = arith.trunci %sublen64 : i64 to i32
+  // CHECK: sublen = 00000003
+  arc.sim.emit "sublen", %sublen : i32
+
+  %single_sub = sim.string.substr %hello[%zero : %zero]
+  %single_sub_cmp = sim.string.cmp %single_sub, %h
+  // CHECK: single_sub_cmp = 00000000
+  arc.sim.emit "single_sub_cmp", %single_sub_cmp : i32
+
+  %last_single_sub = sim.string.substr %hello[%four : %four]
+  %last_single_sub_cmp = sim.string.cmp %last_single_sub, %o
+  // CHECK: last_single_sub_cmp = 00000000
+  arc.sim.emit "last_single_sub_cmp", %last_single_sub_cmp : i32
+
+  %prefix_sub = sim.string.substr %hello[%zero : %one]
+  %prefix_sub_cmp = sim.string.cmp %prefix_sub, %he
+  // CHECK: prefix_sub_cmp = 00000000
+  arc.sim.emit "prefix_sub_cmp", %prefix_sub_cmp : i32
+
+  %clamped_start = sim.string.substr %hello[%neg : %one]
+  %clamped_start_cmp = sim.string.cmp %clamped_start, %he
+  // CHECK: clamped_start_cmp = 00000000
+  arc.sim.emit "clamped_start_cmp", %clamped_start_cmp : i32
+
+  %inverted_sub = sim.string.substr %hello[%three : %one]
+  %inverted_sublen64 = sim.string.length %inverted_sub
+  %inverted_sublen = arith.trunci %inverted_sublen64 : i64 to i32
+  // CHECK: inverted_sublen = 00000000
+  arc.sim.emit "inverted_sublen", %inverted_sublen : i32
+
+  %negative_end_sub = sim.string.substr %hello[%zero : %neg]
+  %negative_end_sublen64 = sim.string.length %negative_end_sub
+  %negative_end_sublen = arith.trunci %negative_end_sublen64 : i64 to i32
+  // CHECK: negative_end_sublen = 00000000
+  arc.sim.emit "negative_end_sublen", %negative_end_sublen : i32
+
+  %far_sub = sim.string.substr %hello[%too_far : %too_far]
+  %far_sublen64 = sim.string.length %far_sub
+  %far_sublen = arith.trunci %far_sublen64 : i64 to i32
+  // CHECK: far_sublen = 00000000
+  arc.sim.emit "far_sublen", %far_sublen : i32
+
+  %clamped_end = sim.string.substr %hello[%three : %too_far]
+  %clamped_end_cmp = sim.string.cmp %clamped_end, %lo
+  // CHECK: clamped_end_cmp = 00000000
+  arc.sim.emit "clamped_end_cmp", %clamped_end_cmp : i32
+
+  %clamped_full = sim.string.substr %hello[%neg : %too_far]
+  %clamped_full_cmp = sim.string.cmp %clamped_full, %hello
+  // CHECK: clamped_full_cmp = 00000000
+  arc.sim.emit "clamped_full_cmp", %clamped_full_cmp : i32
+
+  %empty_sub = sim.string.substr %empty[%zero : %one]
+  %empty_sublen64 = sim.string.length %empty_sub
+  %empty_sublen = arith.trunci %empty_sublen64 : i64 to i32
+  // CHECK: empty_sublen = 00000000
+  arc.sim.emit "empty_sublen", %empty_sublen : i32
+
+  %empty_cat = sim.string.concat ()
+  %empty_cat_len64 = sim.string.length %empty_cat
+  %empty_cat_len = arith.trunci %empty_cat_len64 : i64 to i32
+  // CHECK: empty_cat_len = 00000000
+  arc.sim.emit "empty_cat_len", %empty_cat_len : i32
+
+  %single_cat = sim.string.concat (%hello)
+  %single_cat_cmp = sim.string.cmp %single_cat, %hello
+  // CHECK: single_cat_cmp = 00000000
+  arc.sim.emit "single_cat_cmp", %single_cat_cmp : i32
+
+  %cat_empty = sim.string.concat (%hello, %empty)
+  %cat_empty_cmp = sim.string.cmp %cat_empty, %hello
+  // CHECK: cat_empty_cmp = 00000000
+  arc.sim.emit "cat_empty_cmp", %cat_empty_cmp : i32
+
+  %empty_cat_left = sim.string.concat (%empty, %hello)
+  %empty_cat_left_cmp = sim.string.cmp %empty_cat_left, %hello
+  // CHECK: empty_cat_left_cmp = 00000000
+  arc.sim.emit "empty_cat_left_cmp", %empty_cat_left_cmp : i32
+
+  %empty_cat_middle = sim.string.concat (%hello, %empty, %bang)
+  %empty_cat_middle_cmp = sim.string.cmp %empty_cat_middle, %hello_bang
+  // CHECK: empty_cat_middle_cmp = 00000000
+  arc.sim.emit "empty_cat_middle_cmp", %empty_cat_middle_cmp : i32
+
+  %cat = sim.string.concat (%hello, %bang)
+  %catlen64 = sim.string.length %cat
+  %catlen = arith.trunci %catlen64 : i64 to i32
+  // CHECK: catlen = 00000006
+  arc.sim.emit "catlen", %catlen : i32
+
+  %catcmp = sim.string.cmp %cat, %hello_bang
+  // CHECK: catcmp = 00000000
+  arc.sim.emit "catcmp", %catcmp : i32
+
+  return
+}

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -71,6 +71,22 @@ static llvm::Twine evalSymbolFromModelName(StringRef modelName) {
 
 namespace {
 
+static Value reg2mem(ConversionPatternRewriter &rewriter, Location loc,
+                     Value value);
+
+static LLVM::LLVMFuncOp
+getOrCreateRuntimeFunction(ModuleOp module, Location loc, OpBuilder &builder,
+                           StringRef name, Type resultType,
+                           ArrayRef<Type> argTypes) {
+  if (auto fn = module.lookupSymbol<LLVM::LLVMFuncOp>(name))
+    return fn;
+
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(module.getBody());
+  auto fnTy = LLVM::LLVMFunctionType::get(resultType, argTypes);
+  return LLVM::LLVMFuncOp::create(builder, loc, name, fnTy);
+}
+
 struct DynamicStringConstantOpLowering
     : public OpConversionPattern<sim::StringConstantOp> {
   DynamicStringConstantOpLowering(LLVMTypeConverter &converter,
@@ -147,6 +163,165 @@ struct DynamicStringLengthOpLowering
       length = LLVM::TruncOp::create(rewriter, op.getLoc(), resultTy, length);
 
     rewriter.replaceOp(op, length);
+    return success();
+  }
+};
+
+struct DynamicStringCmpOpLowering
+    : public OpConversionPattern<sim::StringCmpOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::StringCmpOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(i32Ty, {ptrTy, ptrTy});
+    auto cmpFn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                            "circt_sim_string_cmp", i32Ty,
+                                            {ptrTy, ptrTy});
+
+    Value result =
+        LLVM::CallOp::create(rewriter, op.getLoc(), fnTy, cmpFn.getSymName(),
+                             ValueRange{adaptor.getLhs(), adaptor.getRhs()})
+            .getResult();
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct DynamicStringConcatOpLowering
+    : public OpConversionPattern<sim::StringConcatOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::StringConcatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto inputs = adaptor.getInputs();
+    if (inputs.size() == 1) {
+      rewriter.replaceOp(op, inputs.front());
+      return success();
+    }
+
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto fnTy = LLVM::LLVMFunctionType::get(ptrTy, {ptrTy, ptrTy});
+    auto fn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                         "circt_sim_string_concat", ptrTy,
+                                         {ptrTy, ptrTy});
+
+    Value result;
+    if (inputs.empty()) {
+      Value nullPtr = LLVM::ZeroOp::create(rewriter, op.getLoc(), ptrTy);
+      result =
+          LLVM::CallOp::create(rewriter, op.getLoc(), fnTy, fn.getSymName(),
+                               ValueRange{nullPtr, nullPtr})
+              .getResult();
+    } else {
+      result = inputs.front();
+      for (Value next : inputs.drop_front())
+        result = LLVM::CallOp::create(rewriter, op.getLoc(), fnTy,
+                                      fn.getSymName(), ValueRange{result, next})
+                     .getResult();
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct DynamicStringIntToStringOpLowering
+    : public OpConversionPattern<sim::IntToStringOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::IntToStringOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto inputIntTy = dyn_cast<IntegerType>(op.getInput().getType());
+    if (!inputIntTy)
+      return failure();
+
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(ptrTy, {ptrTy, i32Ty});
+    auto fn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                         "circt_sim_string_int_to_string",
+                                         ptrTy, {ptrTy, i32Ty});
+    Value inputPtr = reg2mem(rewriter, op.getLoc(), adaptor.getInput());
+    Value bitWidth = LLVM::ConstantOp::create(rewriter, op.getLoc(), i32Ty,
+                                              inputIntTy.getWidth());
+    Value result =
+        LLVM::CallOp::create(rewriter, op.getLoc(), fnTy, fn.getSymName(),
+                             ValueRange{inputPtr, bitWidth})
+            .getResult();
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+template <typename OpTy>
+struct DynamicStringGetCharLikeOpLowering : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto module = op->template getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto i8Ty = rewriter.getI8Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(i8Ty, {ptrTy, i32Ty});
+    auto getcFn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                             "circt_sim_string_get_char", i8Ty,
+                                             {ptrTy, i32Ty});
+
+    Value result =
+        LLVM::CallOp::create(rewriter, op.getLoc(), fnTy, getcFn.getSymName(),
+                             ValueRange{adaptor.getStr(), adaptor.getIndex()})
+            .getResult();
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct DynamicStringSubstrOpLowering
+    : public OpConversionPattern<sim::StringSubstrOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::StringSubstrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(ptrTy, {ptrTy, i32Ty, i32Ty});
+    auto substrFn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                               "circt_sim_string_substr", ptrTy,
+                                               {ptrTy, i32Ty, i32Ty});
+
+    Value result =
+        LLVM::CallOp::create(
+            rewriter, op.getLoc(), fnTy, substrFn.getSymName(),
+            ValueRange{adaptor.getStr(), adaptor.getStart(), adaptor.getEnd()})
+            .getResult();
+    rewriter.replaceOp(op, result);
     return success();
   }
 };
@@ -1018,38 +1193,42 @@ foldFormatString(ConversionPatternRewriter &rewriter, Value fstringValue,
             FmtDescriptor d = FmtDescriptor::createChar();
             return FormatInfo{{d}, {op.getValue()}};
           })
-      .Case<sim::FormatDecOp>([&](sim::FormatDecOp op)
-                                  -> FailureOr<FormatInfo> {
-        FmtDescriptor d = FmtDescriptor::createInt(
-            op.getValue().getType().getWidth(), 10, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
-            op.getIsSigned());
-        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
-      })
-      .Case<sim::FormatHexOp>([&](sim::FormatHexOp op)
-                                  -> FailureOr<FormatInfo> {
-        FmtDescriptor d = FmtDescriptor::createInt(
-            op.getValue().getType().getWidth(), 16, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(),
-            op.getIsHexUppercase(), false);
-        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
-      })
-      .Case<sim::FormatOctOp>([&](sim::FormatOctOp op)
-                                  -> FailureOr<FormatInfo> {
-        FmtDescriptor d = FmtDescriptor::createInt(
-            op.getValue().getType().getWidth(), 8, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
-            false);
-        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
-      })
-      .Case<sim::FormatBinOp>([&](sim::FormatBinOp op)
-                                  -> FailureOr<FormatInfo> {
-        FmtDescriptor d = FmtDescriptor::createInt(
-            op.getValue().getType().getWidth(), 2, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
-            false);
-        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
-      })
+      .Case<sim::FormatDecOp>(
+          [&](sim::FormatDecOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d = FmtDescriptor::createInt(
+                op.getValue().getType().getWidth(), 10, op.getIsLeftAligned(),
+                op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+                op.getIsSigned());
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
+      .Case<sim::FormatHexOp>(
+          [&](sim::FormatHexOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d = FmtDescriptor::createInt(
+                op.getValue().getType().getWidth(), 16, op.getIsLeftAligned(),
+                op.getSpecifierWidth().value_or(-1), op.getPaddingChar(),
+                op.getIsHexUppercase(), false);
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
+      .Case<sim::FormatOctOp>(
+          [&](sim::FormatOctOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d = FmtDescriptor::createInt(
+                op.getValue().getType().getWidth(), 8, op.getIsLeftAligned(),
+                op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+                false);
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
+      .Case<sim::FormatBinOp>(
+          [&](sim::FormatBinOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d = FmtDescriptor::createInt(
+                op.getValue().getType().getWidth(), 2, op.getIsLeftAligned(),
+                op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+                false);
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
       .Case<sim::FormatLiteralOp>(
           [&](sim::FormatLiteralOp op) -> FailureOr<FormatInfo> {
             if (op.getLiteral().size() < 8 &&
@@ -1951,7 +2130,13 @@ void LowerArcToLLVMPass::runOnOperation() {
   unsigned nextStringId = 0;
   patterns.add<DynamicStringConstantOpLowering>(converter, &getContext(),
                                                 &nextStringId);
-  patterns.add<DynamicStringLengthOpLowering>(converter, &getContext());
+  patterns
+      .add<DynamicStringLengthOpLowering, DynamicStringCmpOpLowering,
+           DynamicStringConcatOpLowering,
+           DynamicStringGetCharLikeOpLowering<sim::StringGetOp>,
+           DynamicStringGetCharLikeOpLowering<sim::StringGetCharOp>,
+           DynamicStringIntToStringOpLowering, DynamicStringSubstrOpLowering>(
+          converter, &getContext());
 
   // Arc patterns.
   // clang-format off

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -71,6 +71,86 @@ static llvm::Twine evalSymbolFromModelName(StringRef modelName) {
 
 namespace {
 
+struct DynamicStringConstantOpLowering
+    : public OpConversionPattern<sim::StringConstantOp> {
+  DynamicStringConstantOpLowering(LLVMTypeConverter &converter,
+                                  MLIRContext *ctx, unsigned *nextStringId)
+      : OpConversionPattern(converter, ctx), nextStringId(nextStringId) {}
+
+  LogicalResult
+  matchAndRewrite(sim::StringConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module || !nextStringId)
+      return failure();
+
+    SmallVector<char> bytes(op.getLiteral().begin(), op.getLiteral().end());
+    bytes.push_back(0);
+
+    LLVM::GlobalOp global;
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(module.getBody());
+
+      SmallString<32> name;
+      name.append("_sim_str_");
+      name.append(Twine((*nextStringId)++).str());
+
+      auto i8Ty = rewriter.getI8Type();
+      auto globalType = LLVM::LLVMArrayType::get(i8Ty, bytes.size());
+      global = LLVM::GlobalOp::create(
+          rewriter, op.getLoc(), globalType, /*isConstant=*/true,
+          LLVM::Linkage::Internal, name, rewriter.getStringAttr(bytes),
+          /*alignment=*/0);
+    }
+
+    rewriter.replaceOpWithNewOp<LLVM::AddressOfOp>(op, global);
+    return success();
+  }
+
+  unsigned *nextStringId;
+};
+
+struct DynamicStringLengthOpLowering
+    : public OpConversionPattern<sim::StringLengthOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::StringLengthOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto resultTy = typeConverter->convertType(op.getType());
+    auto resultIntTy = dyn_cast<IntegerType>(resultTy);
+    if (!resultIntTy)
+      return failure();
+
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(i32Ty, {ptrTy});
+    auto lenFn = module.lookupSymbol<LLVM::LLVMFuncOp>("circt_sim_string_len");
+    if (!lenFn) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(module.getBody());
+      lenFn = LLVM::LLVMFuncOp::create(rewriter, op.getLoc(),
+                                       "circt_sim_string_len", fnTy);
+    }
+
+    Value length = LLVM::CallOp::create(rewriter, op.getLoc(), fnTy,
+                                        lenFn.getSymName(), adaptor.getInput())
+                       .getResult();
+    if (resultIntTy.getWidth() > 32)
+      length = LLVM::ZExtOp::create(rewriter, op.getLoc(), resultTy, length);
+    else if (resultIntTy.getWidth() < 32)
+      length = LLVM::TruncOp::create(rewriter, op.getLoc(), resultTy, length);
+
+    rewriter.replaceOp(op, length);
+    return success();
+  }
+};
+
 struct ModelOpLowering : public OpConversionPattern<arc::ModelOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -1821,6 +1901,9 @@ void LowerArcToLLVMPass::runOnOperation() {
   converter.addConversion([&](sim::FormatStringType type) {
     return LLVM::LLVMPointerType::get(type.getContext());
   });
+  converter.addConversion([&](sim::DynamicStringType type) {
+    return LLVM::LLVMPointerType::get(type.getContext());
+  });
   converter.addConversion([&](llhd::TimeType type) {
     // LLHD time is represented as i64 femtoseconds.
     return IntegerType::get(type.getContext(), 64);
@@ -1864,6 +1947,11 @@ void LowerArcToLLVMPass::runOnOperation() {
 
   populateCombToArithConversionPatterns(converter, patterns);
   populateCombToLLVMConversionPatterns(converter, patterns);
+
+  unsigned nextStringId = 0;
+  patterns.add<DynamicStringConstantOpLowering>(converter, &getContext(),
+                                                &nextStringId);
+  patterns.add<DynamicStringLengthOpLowering>(converter, &getContext());
 
   // Arc patterns.
   // clang-format off

--- a/lib/Dialect/Arc/Runtime/CMakeLists.txt
+++ b/lib/Dialect/Arc/Runtime/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(ArcRuntimeLibSources
   ArcRuntime.cpp
   ModelInstance.cpp
+  SimString.cpp
   TraceEncoder.cpp
   VCDTraceEncoder.cpp
 )
@@ -38,6 +39,8 @@ endif()
 install(FILES
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/ArcRuntime.h
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/Common.h
+  ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/RuntimeSymbol.h
+  ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/SimString.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/circt/Dialect/Arc/Runtime
   COMPONENT CIRCTArcRuntime
 )

--- a/lib/Dialect/Arc/Runtime/SimString.cpp
+++ b/lib/Dialect/Arc/Runtime/SimString.cpp
@@ -14,7 +14,9 @@
 
 #include "circt/Dialect/Arc/Runtime/SimString.h"
 
+#include <cstdlib>
 #include <cstring>
+#include <limits>
 
 extern "C" int32_t circt_sim_string_len(const char *str) {
   if (!str)
@@ -22,14 +24,119 @@ extern "C" int32_t circt_sim_string_len(const char *str) {
   return static_cast<int32_t>(std::strlen(str));
 }
 
+extern "C" int32_t circt_sim_string_cmp(const char *lhs, const char *rhs) {
+  if (!lhs)
+    lhs = "";
+  if (!rhs)
+    rhs = "";
+  return std::strcmp(lhs, rhs);
+}
+
+extern "C" const char *circt_sim_string_concat(const char *lhs,
+                                               const char *rhs) {
+  if (!lhs)
+    lhs = "";
+  if (!rhs)
+    rhs = "";
+
+  size_t lhsLen = std::strlen(lhs);
+  size_t rhsLen = std::strlen(rhs);
+  if (rhsLen > std::numeric_limits<size_t>::max() - lhsLen - 1)
+    return "";
+
+  char *out = static_cast<char *>(std::malloc(lhsLen + rhsLen + 1));
+  if (!out)
+    return "";
+  std::memcpy(out, lhs, lhsLen);
+  std::memcpy(out + lhsLen, rhs, rhsLen);
+  out[lhsLen + rhsLen] = '\0';
+  return out;
+}
+
+extern "C" const char *circt_sim_string_int_to_string(const void *input,
+                                                      uint32_t bitWidth) {
+  if (!input || bitWidth == 0)
+    return "";
+
+  const auto *bytes = static_cast<const uint8_t *>(input);
+  uint32_t byteCount = (bitWidth + 7) / 8;
+  uint32_t validBitsInTopByte = bitWidth % 8;
+  uint8_t topByteMask =
+      validBitsInTopByte == 0
+          ? 0xff
+          : static_cast<uint8_t>((1u << validBitsInTopByte) - 1u);
+
+  char *out = static_cast<char *>(std::malloc(byteCount + 1));
+  if (!out)
+    return "";
+
+  uint32_t outLen = 0;
+  for (uint32_t index = byteCount; index > 0; --index) {
+    uint8_t byte = bytes[index - 1];
+    if (index == byteCount)
+      byte &= topByteMask;
+    if (byte)
+      out[outLen++] = static_cast<char>(byte);
+  }
+  out[outLen] = '\0';
+  return out;
+}
+
+extern "C" uint8_t circt_sim_string_get_char(const char *str, int32_t idx) {
+  if (!str || idx < 0)
+    return 0;
+  size_t len = std::strlen(str);
+  size_t pos = static_cast<size_t>(idx);
+  if (pos >= len)
+    return 0;
+  return static_cast<uint8_t>(static_cast<unsigned char>(str[pos]));
+}
+
+extern "C" const char *circt_sim_string_substr(const char *str, int32_t start,
+                                               int32_t end) {
+  if (!str)
+    str = "";
+  if (start < 0)
+    start = 0;
+  if (end < start)
+    return "";
+
+  size_t len = std::strlen(str);
+  size_t startPos = static_cast<size_t>(start);
+  if (startPos >= len)
+    return "";
+
+  size_t endPos = static_cast<size_t>(end);
+  if (endPos >= len)
+    endPos = len - 1;
+
+  size_t outLen = endPos - startPos + 1;
+  char *out = static_cast<char *>(std::malloc(outLen + 1));
+  if (!out)
+    return "";
+  std::memcpy(out, str + startPos, outLen);
+  out[outLen] = '\0';
+  return out;
+}
+
 #ifdef ARC_RUNTIME_JIT_BIND
 namespace circt {
 namespace arc {
 namespace runtime {
 
-static const SimStringRuntimeSymbols simStringRuntimeSymbols =
-    std::make_tuple(RuntimeSymbol<decltype(&circt_sim_string_len)>{
-        "circt_sim_string_len", &circt_sim_string_len});
+static const SimStringRuntimeSymbols simStringRuntimeSymbols = std::make_tuple(
+    RuntimeSymbol<decltype(&circt_sim_string_len)>{"circt_sim_string_len",
+                                                   &circt_sim_string_len},
+    RuntimeSymbol<decltype(&circt_sim_string_cmp)>{"circt_sim_string_cmp",
+                                                   &circt_sim_string_cmp},
+    RuntimeSymbol<decltype(&circt_sim_string_concat)>{"circt_sim_string_concat",
+                                                      &circt_sim_string_concat},
+    RuntimeSymbol<decltype(&circt_sim_string_int_to_string)>{
+        "circt_sim_string_int_to_string", &circt_sim_string_int_to_string},
+    RuntimeSymbol<decltype(&circt_sim_string_get_char)>{
+        "circt_sim_string_get_char", &circt_sim_string_get_char},
+    RuntimeSymbol<decltype(&circt_sim_string_substr)>{
+        "circt_sim_string_substr", &circt_sim_string_substr});
 
 const SimStringRuntimeSymbols &getSimStringRuntimeSymbols() {
   return simStringRuntimeSymbols;

--- a/lib/Dialect/Arc/Runtime/SimString.cpp
+++ b/lib/Dialect/Arc/Runtime/SimString.cpp
@@ -1,0 +1,41 @@
+//===- SimString.cpp - Simulation string runtime --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements runtime support for dynamic strings in the sim dialect. Functions
+// here are plain `extern "C"` leaf utilities; the JIT-binding table at the
+// bottom is only compiled into the copy linked into arcilator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/Runtime/SimString.h"
+
+#include <cstring>
+
+extern "C" int32_t circt_sim_string_len(const char *str) {
+  if (!str)
+    return 0;
+  return static_cast<int32_t>(std::strlen(str));
+}
+
+#ifdef ARC_RUNTIME_JIT_BIND
+namespace circt {
+namespace arc {
+namespace runtime {
+
+static const SimStringRuntimeSymbols simStringRuntimeSymbols =
+    std::make_tuple(RuntimeSymbol<decltype(&circt_sim_string_len)>{
+        "circt_sim_string_len", &circt_sim_string_len});
+
+const SimStringRuntimeSymbols &getSimStringRuntimeSymbols() {
+  return simStringRuntimeSymbols;
+}
+
+} // namespace runtime
+} // namespace arc
+} // namespace circt
+#endif // ARC_RUNTIME_JIT_BIND

--- a/test/Conversion/ArcToLLVM/sim-string-length.mlir
+++ b/test/Conversion/ArcToLLVM/sim-string-length.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
+
+// CHECK-DAG: llvm.func @circt_sim_string_len(!llvm.ptr) -> i32
+// CHECK-DAG: llvm.mlir.global internal constant @_sim_str_0("hello\00")
+
+// CHECK-LABEL: llvm.func @string_length_arg(
+// CHECK-SAME:    %[[STR:.+]]: !llvm.ptr
+func.func @string_length_arg(%str: !sim.dstring) -> i64 {
+  %len = sim.string.length %str
+  return %len : i64
+  // CHECK: %[[LEN32:.+]] = llvm.call @circt_sim_string_len(%[[STR]]) : (!llvm.ptr) -> i32
+  // CHECK: %[[LEN64:.+]] = llvm.zext %[[LEN32]] : i32 to i64
+  // CHECK: llvm.return %[[LEN64]] : i64
+}
+
+// CHECK-LABEL: llvm.func @string_length_literal()
+func.func @string_length_literal() -> i64 {
+  %str = sim.string.literal "hello"
+  %len = sim.string.length %str
+  return %len : i64
+  // CHECK: %[[STR:.+]] = llvm.mlir.addressof @_sim_str_0 : !llvm.ptr
+  // CHECK: %[[LEN32:.+]] = llvm.call @circt_sim_string_len(%[[STR]]) : (!llvm.ptr) -> i32
+  // CHECK: %[[LEN64:.+]] = llvm.zext %[[LEN32]] : i32 to i64
+  // CHECK: llvm.return %[[LEN64]] : i64
+}

--- a/test/Conversion/ArcToLLVM/sim-string-runtime.mlir
+++ b/test/Conversion/ArcToLLVM/sim-string-runtime.mlir
@@ -1,0 +1,59 @@
+// RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
+
+// CHECK-DAG: llvm.func @circt_sim_string_cmp(!llvm.ptr, !llvm.ptr) -> i32
+// CHECK-DAG: llvm.func @circt_sim_string_concat(!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+// CHECK-DAG: llvm.func @circt_sim_string_int_to_string(!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-DAG: llvm.func @circt_sim_string_get_char(!llvm.ptr, i32) -> i8
+// CHECK-DAG: llvm.func @circt_sim_string_substr(!llvm.ptr, i32, i32) -> !llvm.ptr
+
+// CHECK-LABEL: llvm.func @string_runtime(
+// CHECK-SAME:    %[[LHS:[^:]+]]: !llvm.ptr
+// CHECK-SAME:    %[[RHS:[^:]+]]: !llvm.ptr
+// CHECK-SAME:    %[[IDX:[^:]+]]: i32
+// CHECK-SAME:    %[[END:[^:]+]]: i32
+// CHECK-SAME:    %[[VALUE:[^:]+]]: i40
+func.func @string_runtime(%lhs: !sim.dstring, %rhs: !sim.dstring, %idx: i32, %end: i32, %value: i40) {
+  %cmp = sim.string.cmp %lhs, %rhs
+  %cat = sim.string.concat (%lhs, %rhs)
+  %legacy_ch = sim.string.get %lhs[%idx]
+  %ch = sim.string.get_char %lhs[%idx]
+  %sub = sim.string.substr %lhs[%idx : %end]
+  %str = sim.string.int_to_string %value : i40
+  return
+  // CHECK: llvm.call @circt_sim_string_cmp(%[[LHS]], %[[RHS]]) : (!llvm.ptr, !llvm.ptr) -> i32
+  // CHECK: llvm.call @circt_sim_string_concat(%[[LHS]], %[[RHS]]) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+  // CHECK: llvm.call @circt_sim_string_get_char(%[[LHS]], %[[IDX]]) : (!llvm.ptr, i32) -> i8
+  // CHECK: llvm.call @circt_sim_string_get_char(%[[LHS]], %[[IDX]]) : (!llvm.ptr, i32) -> i8
+  // CHECK: llvm.call @circt_sim_string_substr(%[[LHS]], %[[IDX]], %[[END]]) : (!llvm.ptr, i32, i32) -> !llvm.ptr
+  // CHECK: %[[BITS:.+]] = llvm.mlir.constant(40 : i32) : i32
+  // CHECK: llvm.call @circt_sim_string_int_to_string({{.*}}, %[[BITS]]) : (!llvm.ptr, i32) -> !llvm.ptr
+  // CHECK: llvm.return
+}
+
+// CHECK-LABEL: llvm.func @string_concat_zero()
+func.func @string_concat_zero() -> !sim.dstring {
+  %cat = sim.string.concat ()
+  return %cat : !sim.dstring
+  // CHECK: %[[EMPTY:.+]] = llvm.mlir.addressof @_sim_str_0 : !llvm.ptr
+  // CHECK: llvm.return %[[EMPTY]] : !llvm.ptr
+}
+
+// CHECK-LABEL: llvm.func @string_concat_single(
+// CHECK-SAME:    %[[LHS:[^:]+]]: !llvm.ptr
+func.func @string_concat_single(%lhs: !sim.dstring) -> !sim.dstring {
+  %cat = sim.string.concat (%lhs)
+  return %cat : !sim.dstring
+  // CHECK: llvm.return %[[LHS]] : !llvm.ptr
+}
+
+// CHECK-LABEL: llvm.func @string_int_to_string_i128(
+// CHECK-SAME:    %[[VALUE:[^:]+]]: i128
+func.func @string_int_to_string_i128(%value: i128) -> !sim.dstring {
+  %str = sim.string.int_to_string %value : i128
+  return %str : !sim.dstring
+  // CHECK: llvm.store
+  // CHECK: llvm.store
+  // CHECK: %[[BITS:.+]] = llvm.mlir.constant(128 : i32) : i32
+  // CHECK: llvm.call @circt_sim_string_int_to_string({{.*}}, %[[BITS]]) : (!llvm.ptr, i32) -> !llvm.ptr
+  // CHECK: llvm.return
+}

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -90,15 +90,23 @@ func.func @FormatStrings() {
 }
 
 // CHECK-LABEL: func.func @DynamicStrings
-func.func @DynamicStrings(%idx: i32) {
+func.func @DynamicStrings(%idx: i32, %end: i32) {
   // CHECK: sim.string.literal "Hello"
   %str = sim.string.literal "Hello"
+  // CHECK: sim.string.literal "World"
+  %rhs = sim.string.literal "World"
   // CHECK: sim.string.length
   %len = sim.string.length %str
+  // CHECK: sim.string.cmp
+  %cmp = sim.string.cmp %str, %rhs
   // CHECK: sim.string.concat
   %concat = sim.string.concat (%str, %str)
   // CHECK: sim.string.get
   %char = sim.string.get %str[%idx]
+  // CHECK: sim.string.get_char
+  %char2 = sim.string.get_char %str[%idx]
+  // CHECK: sim.string.substr
+  %substr = sim.string.substr %str[%idx : %end]
   return
 }
 

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -79,9 +79,11 @@
 #define ARC_RUNTIME_JITBIND_FNDECL
 #include "circt/Dialect/Arc/Runtime/Common.h"
 #include "circt/Dialect/Arc/Runtime/JITBind.h"
+#include "circt/Dialect/Arc/Runtime/SimString.h"
 #endif
 
 #include <optional>
+#include <tuple>
 
 using namespace mlir;
 using namespace circt;
@@ -302,6 +304,16 @@ static void bindExecutionEngineSymbol(llvm::orc::SymbolMap &symbolMap,
                                   llvm::JITSymbolFlags::Exported};
 }
 
+template <typename RuntimeSymbols>
+static void bindRuntimeSymbolTuple(llvm::orc::SymbolMap &symbolMap,
+                                   llvm::orc::MangleAndInterner &interner,
+                                   const RuntimeSymbols &symbols) {
+  auto bindSymbol = [&](const auto &sym) {
+    bindExecutionEngineSymbol(symbolMap, interner, sym.name, sym.addr);
+  };
+  std::apply([&](const auto &...sym) { (bindSymbol(sym), ...); }, symbols);
+}
+
 static void bindArcRuntimeSymbols(ExecutionEngine &executionEngine) {
   auto &runtimeCallbacks = runtime::getArcRuntimeAPICallbacks();
   executionEngine.registerSymbols([&](llvm::orc::MangleAndInterner interner) {
@@ -324,6 +336,16 @@ static void bindArcRuntimeSymbols(ExecutionEngine &executionEngine) {
     bindExecutionEngineSymbol(symbolMap, interner,
                               runtimeCallbacks.symNameSwapTraceBuffer,
                               runtimeCallbacks.fnSwapTraceBuffer);
+    return symbolMap;
+  });
+}
+
+// Bind sim dialect runtime symbols to the JIT execution engine.
+static void bindArcSimRuntimeSymbols(ExecutionEngine &executionEngine) {
+  executionEngine.registerSymbols([&](llvm::orc::MangleAndInterner interner) {
+    llvm::orc::SymbolMap symbolMap;
+    bindRuntimeSymbolTuple(symbolMap, interner,
+                           runtime::getSimStringRuntimeSymbols());
     return symbolMap;
   });
 }
@@ -545,8 +567,10 @@ static LogicalResult processBuffer(
       return failure();
     }
 
-    if (!noJitRuntime)
+    if (!noJitRuntime) {
       bindArcRuntimeSymbols(**executionEngine);
+      bindArcSimRuntimeSymbols(**executionEngine);
+    }
 
     auto expectedFunc = (*executionEngine)->lookupPacked(jitEntryPoint);
     if (!expectedFunc) {


### PR DESCRIPTION
Stacked on #10642 — please review/merge that first; the parent commit shows here until it lands, after which this rebases to a single commit.

Extends the SystemVerilog execution runtime introduced in #10642 with three more leaf string helpers, bound into the arcilator JIT alongside `circt_sv_string_len`:

- `circt_sv_strcmp` — `strcmp` over two NUL-terminated strings
- `circt_sv_string_getc` — byte at an index (0 if out of range)
- `circt_sv_string_substr` — inclusive substring, bounds clamped

These cover the string operations that lowered models invoke for the dynamic SystemVerilog string type, which has no fixed-width hardware lowering. Null pointers are treated as the empty string throughout.

The JIT integration test (`integration_test/arcilator/JIT/sv-runtime-string.mlir`) is extended to exercise all three end-to-end under `arcilator --run` (`substr` is checked by feeding its result back through `string_len`).