### PR TITLE
[Arc] Add integer formatting to the SV runtime

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/FmtDescriptor.h
+++ b/include/circt/Dialect/Arc/Runtime/FmtDescriptor.h
@@ -90,12 +90,89 @@ struct FmtDescriptor {
     return d;
   }
 
+  /// Creates an integer descriptor with exact minimum-width semantics.
+  ///
+  /// Unlike `createInt`, this does not apply the natural binary/octal/hex
+  /// width of the value type before applying `specifierWidth`.
+  static FmtDescriptor createExactInt(int32_t bitwidth, int8_t radix,
+                                      bool isLeftAligned,
+                                      int32_t specifierWidth, char paddingChar,
+                                      bool isUpperCase, bool isSigned) {
+    FmtDescriptor d = createInt(bitwidth, radix, isLeftAligned, specifierWidth,
+                                paddingChar, isUpperCase, isSigned);
+    d.action = Action_IntExact;
+    return d;
+  }
+
+  /// Creates a four-valued integer descriptor. The value and unknown masks will
+  /// be passed as consecutive variadic arguments by pointer.
+  static FmtDescriptor createFVInt(int32_t bitwidth, int8_t radix,
+                                   bool isLeftAligned, int32_t specifierWidth,
+                                   char paddingChar, bool isUpperCase,
+                                   bool isSigned) {
+    FmtDescriptor d = createInt(bitwidth, radix, isLeftAligned, specifierWidth,
+                                paddingChar, isUpperCase, isSigned);
+    d.action = Action_FVInt;
+    return d;
+  }
+
   /// Creates a char descriptor.
   ///
   /// The character value will be passed as a variadic argument by value.
-  static FmtDescriptor createChar() {
+  static FmtDescriptor createChar(bool isLeftAligned = false,
+                                  char paddingChar = ' ',
+                                  int32_t specifierWidth = -1) {
     FmtDescriptor d;
     d.action = Action_Char;
+    d.stringFmt.specifierWidth = specifierWidth;
+    d.stringFmt.paddingChar = paddingChar;
+    d.stringFmt.isLeftAligned = isLeftAligned;
+    return d;
+  }
+
+  /// Creates a time descriptor.
+  ///
+  /// The time value will be passed as a variadic argument by value in
+  /// femtoseconds. A negative widthOverride uses the current `$timeformat`
+  /// minimum field width.
+  static FmtDescriptor createTime(int32_t widthOverride) {
+    FmtDescriptor d;
+    d.action = Action_Time;
+    d.timeFmt.widthOverride = widthOverride;
+    return d;
+  }
+
+  /// Creates a dynamic string descriptor.
+  ///
+  /// The string value will be passed as a variadic argument by pointer to a
+  /// NUL-terminated string.
+  static FmtDescriptor createString(bool isLeftAligned, char paddingChar,
+                                    int32_t specifierWidth) {
+    FmtDescriptor d;
+    d.action = Action_String;
+    d.stringFmt.specifierWidth = specifierWidth;
+    d.stringFmt.paddingChar = paddingChar;
+    d.stringFmt.isLeftAligned = isLeftAligned;
+    return d;
+  }
+
+  /// Creates a real descriptor.
+  ///
+  /// format: The printf-style conversion character to use. Must be one of
+  /// {'e', 'f', 'g'}.
+  /// isLeftAligned: Whether the value is left aligned.
+  /// fieldWidth: The minimum width of the output in characters.
+  /// fracDigits: The precision to use for the conversion.
+  ///
+  /// The real value will be passed as a variadic argument by value as a double.
+  static FmtDescriptor createReal(char format, bool isLeftAligned,
+                                  int32_t fieldWidth, int32_t fracDigits) {
+    FmtDescriptor d;
+    d.action = Action_Real;
+    d.realFmt.fieldWidth = fieldWidth;
+    d.realFmt.fracDigits = fracDigits;
+    d.realFmt.format = format;
+    d.realFmt.isLeftAligned = isLeftAligned;
     return d;
   }
 
@@ -112,8 +189,18 @@ struct FmtDescriptor {
     Action_LiteralSmall,
     /// Prints an integer.
     Action_Int,
+    /// Prints an integer with exact minimum-width semantics.
+    Action_IntExact,
+    /// Prints a four-valued integer.
+    Action_FVInt,
     /// Prints a character (%c).
     Action_Char,
+    /// Prints a time value (%t).
+    Action_Time,
+    /// Prints a dynamic string (%s).
+    Action_String,
+    /// Prints a real (%e, %f, or %g).
+    Action_Real,
   };
   Action action;
 
@@ -148,10 +235,43 @@ struct FmtDescriptor {
     char data[8];
   };
 
+  /// Time formatting options.
+  struct TimeFmt {
+    /// Optional minimum field width override, or -1 to use `$timeformat`.
+    int32_t widthOverride;
+    /// Reserved to keep the descriptor payload at 8 bytes.
+    int32_t reserved;
+  };
+
+  /// Dynamic string formatting options.
+  struct StringFmt {
+    /// The minimum width of the output in characters.
+    int16_t specifierWidth;
+    /// The padding character to use if width requires padding.
+    char paddingChar;
+    /// Whether the value is left aligned.
+    bool isLeftAligned;
+  };
+
+  /// Real formatting options.
+  struct RealFmt {
+    /// The minimum width of the output in characters.
+    int16_t fieldWidth;
+    /// The number of fractional digits or significant digits to print.
+    int16_t fracDigits;
+    /// The printf-style conversion character to use: 'e', 'f', or 'g'.
+    char format;
+    /// Whether the value is left aligned.
+    bool isLeftAligned;
+  };
+
   union {
     LiteralFmt literal;
     IntFmt intFmt;
     SmallLiteral smallLiteral;
+    TimeFmt timeFmt;
+    StringFmt stringFmt;
+    RealFmt realFmt;
   };
 };
 

--- a/include/circt/Dialect/Arc/Runtime/JITBind.h
+++ b/include/circt/Dialect/Arc/Runtime/JITBind.h
@@ -33,6 +33,9 @@ struct APICallbacks {
   void (*fnOnEval)(uint8_t *simState);
   void (*fnOnInitialized)(uint8_t *simState);
   void (*fnFormat)(const FmtDescriptor *fmt, ...);
+  const char *(*fnFormatToString)(const FmtDescriptor *fmt, ...);
+  void (*fnSetTimeFormat)(int32_t unit, int32_t precision, const char *suffix,
+                          int32_t minFieldWidth);
   uint64_t *(*fnSwapTraceBuffer)(const uint8_t *simState);
 
   static constexpr char symNameAllocInstance[] = "arcRuntimeIR_allocInstance";
@@ -40,6 +43,8 @@ struct APICallbacks {
   static constexpr char symNameOnEval[] = "arcRuntimeIR_onEval";
   static constexpr char symNameOnInitialized[] = "arcRuntimeIR_onInitialized";
   static constexpr char symNameFormat[] = "arcRuntimeIR_format";
+  static constexpr char symNameFormatToString[] = "arcRuntimeIR_formatToString";
+  static constexpr char symNameSetTimeFormat[] = "arcRuntimeIR_setTimeFormat";
   static constexpr char symNameSwapTraceBuffer[] =
       "arcRuntimeIR_swapTraceBuffer";
 };

--- a/include/circt/Dialect/Arc/Runtime/RuntimeSymbol.h
+++ b/include/circt/Dialect/Arc/Runtime/RuntimeSymbol.h
@@ -1,0 +1,28 @@
+//===- RuntimeSymbol.h - Runtime JIT symbol declarations --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_RUNTIME_RUNTIMESYMBOL_H
+#define CIRCT_DIALECT_ARC_RUNTIME_RUNTIMESYMBOL_H
+
+namespace circt {
+namespace arc {
+namespace runtime {
+
+/// A single JIT-bindable runtime symbol with its actual function pointer type,
+/// so `ExecutorAddr::fromPtr` sees the precise function pointer.
+template <typename FunctionPtrT>
+struct RuntimeSymbol {
+  const char *name;
+  FunctionPtrT addr;
+};
+
+} // namespace runtime
+} // namespace arc
+} // namespace circt
+
+#endif // CIRCT_DIALECT_ARC_RUNTIME_RUNTIMESYMBOL_H

--- a/include/circt/Dialect/Arc/Runtime/SimString.h
+++ b/include/circt/Dialect/Arc/Runtime/SimString.h
@@ -1,0 +1,47 @@
+//===- SimString.h - Simulation string runtime ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Declares runtime support for dynamic strings in the sim dialect. These leaf
+// C functions are statically linked into arcilator and bound to the JIT
+// alongside the core Arc runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_RUNTIME_SIMSTRING_H
+#define CIRCT_DIALECT_ARC_RUNTIME_SIMSTRING_H
+
+#include "circt/Dialect/Arc/Runtime/RuntimeSymbol.h"
+
+#include <cstdint>
+#include <tuple>
+
+extern "C" {
+
+/// Return the length of a NUL-terminated string (a null pointer is treated as
+/// the empty string).
+int32_t circt_sim_string_len(const char *str);
+
+} // extern "C"
+
+namespace circt {
+namespace arc {
+namespace runtime {
+
+using SimStringRuntimeSymbols =
+    std::tuple<RuntimeSymbol<decltype(&circt_sim_string_len)>>;
+
+#ifdef ARC_RUNTIME_JITBIND_FNDECL
+/// Return the sim string runtime symbols to register with the JIT.
+const SimStringRuntimeSymbols &getSimStringRuntimeSymbols();
+#endif // ARC_RUNTIME_JITBIND_FNDECL
+
+} // namespace runtime
+} // namespace arc
+} // namespace circt
+
+#endif // CIRCT_DIALECT_ARC_RUNTIME_SIMSTRING_H

--- a/include/circt/Dialect/Arc/Runtime/SimString.h
+++ b/include/circt/Dialect/Arc/Runtime/SimString.h
@@ -26,6 +26,29 @@ extern "C" {
 /// the empty string).
 int32_t circt_sim_string_len(const char *str);
 
+/// Compare two NUL-terminated strings (each null pointer is treated as the
+/// empty string), returning the result of `strcmp`.
+int32_t circt_sim_string_cmp(const char *lhs, const char *rhs);
+
+/// Concatenate two NUL-terminated strings (each null pointer is treated as the
+/// empty string), returning a freshly allocated NUL-terminated string.
+const char *circt_sim_string_concat(const char *lhs, const char *rhs);
+
+/// Convert a little-endian integer byte buffer into a freshly allocated
+/// NUL-terminated string using packed-byte string assignment semantics.
+const char *circt_sim_string_int_to_string(const void *input,
+                                           uint32_t bitWidth);
+
+/// Return the byte at index `idx` of a NUL-terminated string, or 0 if the
+/// index is out of range or the string is null.
+uint8_t circt_sim_string_get_char(const char *str, int32_t idx);
+
+/// Return the substring `str[start..end]` (inclusive) as a freshly allocated
+/// NUL-terminated string. Out-of-range bounds are clamped; an empty result is
+/// returned as "".
+const char *circt_sim_string_substr(const char *str, int32_t start,
+                                    int32_t end);
+
 } // extern "C"
 
 namespace circt {
@@ -33,7 +56,12 @@ namespace arc {
 namespace runtime {
 
 using SimStringRuntimeSymbols =
-    std::tuple<RuntimeSymbol<decltype(&circt_sim_string_len)>>;
+    std::tuple<RuntimeSymbol<decltype(&circt_sim_string_len)>,
+               RuntimeSymbol<decltype(&circt_sim_string_cmp)>,
+               RuntimeSymbol<decltype(&circt_sim_string_concat)>,
+               RuntimeSymbol<decltype(&circt_sim_string_int_to_string)>,
+               RuntimeSymbol<decltype(&circt_sim_string_get_char)>,
+               RuntimeSymbol<decltype(&circt_sim_string_substr)>>;
 
 #ifdef ARC_RUNTIME_JITBIND_FNDECL
 /// Return the sim string runtime symbols to register with the JIT.

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -503,14 +503,45 @@ def FormatCharOp : SimOp<"fmt.char",
     zero extended.
     If the width is greater than eight bits, the resulting formatted string
     is undefined.
+
+    If `specifierWidth` is present and larger than one, the result is padded
+    to that width using `paddingChar`. By default, characters are right-aligned
+    and padded with spaces.
   }];
 
-  let arguments = (ins AnyInteger:$value);
+  let arguments = (ins AnyInteger:$value,
+    DefaultValuedAttr<BoolAttr,"false">:$isLeftAligned,
+    DefaultValuedAttr<I8Attr,"32">:$paddingChar,
+    OptionalAttr<I32Attr>:$specifierWidth);
   let results = (outs FormatStringType:$result);
 
   let hasFolder = true;
 
-  let assemblyFormat = "$value attr-dict `:` qualified(type($value))";
+  let assemblyFormat = [{
+    $value
+    (`isLeftAligned` $isLeftAligned^)?
+    (`paddingChar` $paddingChar^)?
+    (`specifierWidth` $specifierWidth^)?
+    attr-dict `:` qualified(type($value))
+  }];
+}
+
+def FormatTimeOp : SimOp<"fmt.time", [Pure]> {
+  let summary = "Time format specifier";
+  let description = [{
+    Format the given femtoseconds time value (`i64`) as a string fragment
+    according to the current SystemVerilog `$timeformat` state.
+
+    The `width` attribute, if present, overrides the current `$timeformat`
+    minimum field width for this formatting operation (corresponds to `%<w>t`).
+  }];
+
+  let arguments = (ins AnyInteger:$value, OptionalAttr<I32Attr>:$width);
+  let results = (outs FormatStringType:$result);
+
+  let assemblyFormat = [{
+    $value (`,` `width` $width^)? attr-dict `:` qualified(type($value))
+  }];
 }
 
 def FormatCurrentTimeOp : SimOp<"fmt.current_time", [Pure]> {
@@ -539,6 +570,55 @@ def FormatHierPathOp : SimOp<"fmt.hier_path", [Pure]> {
   let arguments = (ins UnitAttr:$useEscapes);
   let results = (outs FormatStringType:$result);
   let assemblyFormat = "(`escaped` $useEscapes^)? attr-dict";
+}
+
+def FormatIntOp : SimOp<"fmt.int", [Pure]> {
+  let summary = "Integer format specifier with explicit width";
+  let description = [{
+    Format the given integer value as a string fragment according to the given
+    base and minimum field width.
+
+    This op carries SystemVerilog integer format options after lowering to the
+    Sim dialect.
+
+    Attributes:
+    - `base`: the radix (expected: 2, 8, 10, or 16)
+    - `width`: minimum field width in digits (0 disables padding)
+    - `flags`: bitset used by backends
+  }];
+
+  let arguments = (ins AnyInteger:$value, I32Attr:$base, I32Attr:$width,
+                   I32Attr:$flags);
+  let results = (outs FormatStringType:$result);
+
+  let assemblyFormat = [{
+    $base $width $flags $value attr-dict `:` qualified(type($value))
+  }];
+}
+
+def FormatFVIntOp : SimOp<"fmt.fvint",
+  [Pure, AllTypesMatch<["value", "unknown"]>]
+> {
+  let summary = "Four-valued integer format specifier";
+  let description = [{
+    Format a four-valued integer as a string fragment according to the given
+    base and minimum field width. The integer is passed in split form as a
+    `value` bitvector and an `unknown` bitvector.
+
+    Attributes:
+    - `base`: the radix (expected: 2, 8, 10, or 16)
+    - `width`: minimum field width in digits (0 disables padding)
+    - `flags`: bitset used by backends
+  }];
+
+  let arguments = (ins AnyInteger:$value, AnyInteger:$unknown, I32Attr:$base,
+                   I32Attr:$width, I32Attr:$flags);
+  let results = (outs FormatStringType:$result);
+
+  let assemblyFormat = [{
+    $base $width $flags $value `,` $unknown attr-dict `:`
+    qualified(type($value))
+  }];
 }
 
 def FormatStringConcatOp : SimOp<"fmt.concat", [Pure]> {
@@ -583,6 +663,21 @@ def FormatStringConcatOp : SimOp<"fmt.concat", [Pure]> {
     LogicalResult getFlattenedInputs(
       llvm::SmallVectorImpl<Value> &flatOperands);
   }];
+}
+
+def FormatStringToStringOp : SimOp<"fmt.to_string", [Pure]> {
+  let summary = "Evaluate a format string into a dynamic string";
+  let description = [{
+    Evaluates a format string into a newly-created dynamic string. This models
+    SystemVerilog formatting operations such as `$sformatf`, `$sformat`, and
+    `$swrite` after the frontend has converted their arguments into structured
+    format fragments.
+  }];
+
+  let arguments = (ins FormatStringType:$input);
+  let results = (outs DynamicStringType:$result);
+
+  let assemblyFormat = "$input attr-dict";
 }
 
 def PrintFormattedOp : SimOp<"print", [NonProceduralOp]> {
@@ -636,6 +731,23 @@ def PrintFormattedProcOp : SimOp<"proc.print", [ProceduralOp]> {
   ];
   let hasCanonicalizeMethod = true;
   let assemblyFormat = "$input (`to` $stream^)? attr-dict";
+}
+
+def TimeFormatProcOp : SimOp<"proc.timeformat", [ProceduralOp]> {
+  let summary = "Set SystemVerilog `$timeformat` state within a procedural region";
+  let description = [{
+    Set the global time formatting state used by `%t` formatting in
+    `$display`/`$write`/`$sformatf`.
+
+    This operation must be within a procedural region.
+  }];
+
+  let arguments = (ins I32Attr:$unit, I32Attr:$precision, StrAttr:$suffix,
+                   I32Attr:$minWidth);
+
+  let assemblyFormat = [{
+    $unit `,` $precision `,` $suffix `,` $minWidth attr-dict
+  }];
 }
 
 def GetFileOp : SimOp<"get_file", [ProceduralOp]> {

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -713,6 +713,19 @@ def StringLengthOp : SimOp<"string.length", [Pure]> {
   let assemblyFormat = "$input attr-dict";
 }
 
+def StringCmpOp : SimOp<"string.cmp", [Pure]> {
+  let summary = "Lexicographically compare two strings";
+  let description = [{
+    Compares two dynamic strings using the same ordering as the ANSI C
+    `strcmp` function.
+  }];
+
+  let arguments = (ins DynamicStringType:$lhs, DynamicStringType:$rhs);
+  let results = (outs I32:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict";
+}
+
 def StringConcatOp : SimOp<"string.concat", [Pure]> {
   let summary = "Concatenate strings";
   let description = [{
@@ -796,6 +809,32 @@ def StringGetOp : SimOp<"string.get", [Pure]> {
   let hasFolder = true;
 
   let assemblyFormat = "$str `[` $index `]` attr-dict";
+}
+
+def StringGetCharOp : SimOp<"string.get_char", [Pure]> {
+  let summary = "Get a character from a string at a given index";
+  let description = [{
+    Returns the character byte at the specified zero-based index within a
+    dynamic string. Out-of-bounds accesses return 0.
+  }];
+
+  let arguments = (ins DynamicStringType:$str, I32:$index);
+  let results = (outs I8:$result);
+
+  let assemblyFormat = "$str `[` $index `]` attr-dict";
+}
+
+def StringSubstrOp : SimOp<"string.substr", [Pure]> {
+  let summary = "Extract a substring";
+  let description = [{
+    Returns the characters from the start through end indices inclusive, or the
+    empty string if the range is invalid.
+  }];
+
+  let arguments = (ins DynamicStringType:$str, I32:$start, I32:$end);
+  let results = (outs DynamicStringType:$result);
+
+  let assemblyFormat = "$str `[` $start `:` $end `]` attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/integration_test/arcilator/JIT/sim-output-format-runtime.mlir
+++ b/integration_test/arcilator/JIT/sim-output-format-runtime.mlir
@@ -1,0 +1,74 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck --match-full-lines --strict-whitespace %s
+// REQUIRES: arcilator-jit
+
+module {
+  func.func @entry() {
+    %v42 = arith.constant 42 : i8
+    %v10 = arith.constant 10 : i8
+    %neg = arith.constant -1 : i8
+    %zero8 = arith.constant 0 : i8
+    %low_unknown = arith.constant 15 : i8
+    %high_unknown_z = arith.constant -16 : i8
+    %fval = arith.constant 2 : i2
+    %funk = arith.constant 1 : i2
+    %ch = arith.constant 65 : i8
+    %bin = sim.fmt.bin %v10 : i8
+    %sep0 = sim.fmt.literal "|"
+    %dec = sim.fmt.int 10 0 0 %v42 : i8
+    %sep1 = sim.fmt.literal "|"
+    %hex = sim.fmt.int 16 4 1 %v42 : i8
+    %sep2 = sim.fmt.literal "|"
+    %fv = sim.fmt.fvint 2 0 0 %fval, %funk : i2
+    %sep3 = sim.fmt.literal "|"
+    %signed = sim.fmt.int 10 0 8 %neg : i8
+    %endl = sim.fmt.literal "\n"
+    %msg = sim.fmt.concat (%bin, %sep0, %dec, %sep1, %hex, %sep2, %fv, %sep3, %signed, %endl)
+    // CHECK:{{^00001010[|]42[|]  2A[|]1x[|]-1$}}
+    sim.proc.print %msg
+
+    %oct_zero = sim.fmt.int 8 5 4 %v42 : i8
+    %sep4 = sim.fmt.literal "|"
+    %left_zero = sim.fmt.int 10 5 6 %v42 : i8
+    %sep5 = sim.fmt.literal "|"
+    %hex_lower_neg = sim.fmt.int 16 0 0 %neg : i8
+    %msg2 = sim.fmt.concat (%oct_zero, %sep4, %left_zero, %sep5, %hex_lower_neg, %endl)
+    // CHECK:{{^00052[|]42000[|]ff$}}
+    sim.proc.print %msg2
+
+    %fv_known_hex = sim.fmt.fvint 16 4 4 %v42, %zero8 : i8
+    %sep6 = sim.fmt.literal "|"
+    %fv_hex_z = sim.fmt.fvint 16 0 1 %high_unknown_z, %high_unknown_z : i8
+    %sep7 = sim.fmt.literal "|"
+    %fv_hex_x = sim.fmt.fvint 16 0 0 %zero8, %low_unknown : i8
+    %sep8 = sim.fmt.literal "|"
+    %fv_dec_z = sim.fmt.fvint 10 0 1 %neg, %neg : i8
+    %msg3 = sim.fmt.concat (%fv_known_hex, %sep6, %fv_hex_z, %sep7, %fv_hex_x, %sep8, %fv_dec_z, %endl)
+    // CHECK:{{^002a[|]Z0[|]x[|]Z$}}
+    sim.proc.print %msg3
+
+    %open = sim.fmt.literal "["
+    %close = sim.fmt.literal "]\n"
+    %right = sim.fmt.char %ch specifierWidth 3 : i8
+    %left = sim.fmt.char %ch isLeftAligned true paddingChar 95 specifierWidth 3 : i8
+    %zero = sim.fmt.char %ch paddingChar 48 specifierWidth 3 : i8
+    %msg4 = sim.fmt.concat (%open, %right, %close, %open, %left, %close, %open, %zero, %close)
+    // CHECK:[  A]
+    // CHECK:[A__]
+    // CHECK:[00A]
+    sim.proc.print %msg4
+
+    sim.proc.timeformat -9, 2, " ns", 0
+    %time = arith.constant 1500000 : i64
+    %fmt = sim.fmt.time %time, width 0 : i64
+    %time_msg = sim.fmt.concat (%fmt, %endl)
+    // CHECK:{{^1\.50 ns$}}
+    sim.proc.print %time_msg
+
+    %fmt_width = sim.fmt.time %time, width 12 : i64
+    %time_width_msg = sim.fmt.concat (%open, %fmt_width, %close)
+    // CHECK:[     1.50 ns]
+    sim.proc.print %time_width_msg
+
+    return
+  }
+}

--- a/integration_test/arcilator/JIT/sim-string-length.mlir
+++ b/integration_test/arcilator/JIT/sim-string-length.mlir
@@ -1,0 +1,14 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
+// Exercise sim.string.length lowering through the sim string runtime bound into
+// the JIT.
+
+func.func @entry() {
+  %str = sim.string.literal "hello"
+  %len64 = sim.string.length %str
+  %len = arith.trunci %len64 : i64 to i32
+  // CHECK: len = 00000005
+  arc.sim.emit "len", %len : i32
+  return
+}

--- a/integration_test/arcilator/JIT/sim-string-runtime.mlir
+++ b/integration_test/arcilator/JIT/sim-string-runtime.mlir
@@ -1,0 +1,221 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
+func.func @entry() {
+  %hello = sim.string.literal "hello"
+  %bang = sim.string.literal "!"
+  %empty = sim.string.literal ""
+  %h = sim.string.literal "h"
+  %e = sim.string.literal "e"
+  %o = sim.string.literal "o"
+  %he = sim.string.literal "he"
+  %ab = sim.string.literal "AB"
+  %abc = sim.string.literal "ABC"
+  %abcdefghijklmnop = sim.string.literal "ABCDEFGHIJKLMNOP"
+  %hello_bang = sim.string.literal "hello!"
+  %lo = sim.string.literal "lo"
+  %zero8 = arith.constant 0 : i8
+  %ab_i16 = arith.constant 16706 : i16
+  %ab_i15 = arith.constant 16706 : i15
+  %abc_i24 = arith.constant 4276803 : i24
+  %abcdefghijklmnop_i128 = arith.constant 0x4142434445464748494a4b4c4d4e4f50 : i128
+  %zero = arith.constant 0 : i32
+  %one = arith.constant 1 : i32
+  %three = arith.constant 3 : i32
+  %four = arith.constant 4 : i32
+  %neg = arith.constant -1 : i32
+  %too_far = arith.constant 99 : i32
+
+  %eq = sim.string.cmp %hello, %hello
+  // CHECK: eq = 00000000
+  arc.sim.emit "eq", %eq : i32
+
+  %ne_cmp = sim.string.cmp %hello, %hello_bang
+  %ne_nonzero = arith.cmpi ne, %ne_cmp, %zero : i32
+  %ne_nonzero_i32 = arith.extui %ne_nonzero : i1 to i32
+  // CHECK: ne_nonzero = 00000001
+  arc.sim.emit "ne_nonzero", %ne_nonzero_i32 : i32
+
+  %empty_cmp = sim.string.cmp %empty, %hello
+  %empty_cmp_nonzero = arith.cmpi ne, %empty_cmp, %zero : i32
+  %empty_cmp_nonzero_i32 = arith.extui %empty_cmp_nonzero : i1 to i32
+  // CHECK: empty_cmp_nonzero = 00000001
+  arc.sim.emit "empty_cmp_nonzero", %empty_cmp_nonzero_i32 : i32
+
+  %ch = sim.string.get_char %hello[%one]
+  // CHECK: getc = 65
+  arc.sim.emit "getc", %ch : i8
+
+  %first_ch = sim.string.get_char %hello[%zero]
+  // CHECK: first_getc = 68
+  arc.sim.emit "first_getc", %first_ch : i8
+
+  %last_ch = sim.string.get_char %hello[%four]
+  // CHECK: last_getc = 6f
+  arc.sim.emit "last_getc", %last_ch : i8
+
+  %legacy_ch = sim.string.get %hello[%one]
+  // CHECK: legacy_getc = 65
+  arc.sim.emit "legacy_getc", %legacy_ch : i8
+
+  %legacy_first_ch = sim.string.get %hello[%zero]
+  // CHECK: legacy_first_getc = 68
+  arc.sim.emit "legacy_first_getc", %legacy_first_ch : i8
+
+  %legacy_last_ch = sim.string.get %hello[%four]
+  // CHECK: legacy_last_getc = 6f
+  arc.sim.emit "legacy_last_getc", %legacy_last_ch : i8
+
+  %neg_ch = sim.string.get_char %hello[%neg]
+  // CHECK: neg_getc = 00
+  arc.sim.emit "neg_getc", %neg_ch : i8
+
+  %legacy_neg_ch = sim.string.get %hello[%neg]
+  // CHECK: legacy_neg_getc = 00
+  arc.sim.emit "legacy_neg_getc", %legacy_neg_ch : i8
+
+  %far_ch = sim.string.get_char %hello[%too_far]
+  // CHECK: far_getc = 00
+  arc.sim.emit "far_getc", %far_ch : i8
+
+  %legacy_far_ch = sim.string.get %hello[%too_far]
+  // CHECK: legacy_far_getc = 00
+  arc.sim.emit "legacy_far_getc", %legacy_far_ch : i8
+
+  %empty_ch = sim.string.get_char %empty[%zero]
+  // CHECK: empty_getc = 00
+  arc.sim.emit "empty_getc", %empty_ch : i8
+
+  %legacy_empty_ch = sim.string.get %empty[%one]
+  // CHECK: legacy_empty_getc = 00
+  arc.sim.emit "legacy_empty_getc", %legacy_empty_ch : i8
+
+  %chstr = sim.string.int_to_string %ch : i8
+  %chstrcmp = sim.string.cmp %chstr, %e
+  // CHECK: chstrcmp = 00000000
+  arc.sim.emit "chstrcmp", %chstrcmp : i32
+
+  %zero_str = sim.string.int_to_string %zero8 : i8
+  %zero_strlen64 = sim.string.length %zero_str
+  %zero_strlen = arith.trunci %zero_strlen64 : i64 to i32
+  // CHECK: zero_strlen = 00000000
+  arc.sim.emit "zero_strlen", %zero_strlen : i32
+
+  %ab_str = sim.string.int_to_string %ab_i16 : i16
+  %abstrcmp = sim.string.cmp %ab_str, %ab
+  // CHECK: abstrcmp = 00000000
+  arc.sim.emit "abstrcmp", %abstrcmp : i32
+
+  %ab_i15_str = sim.string.int_to_string %ab_i15 : i15
+  %ab_i15_strcmp = sim.string.cmp %ab_i15_str, %ab
+  // CHECK: ab_i15_strcmp = 00000000
+  arc.sim.emit "ab_i15_strcmp", %ab_i15_strcmp : i32
+
+  %abc_str = sim.string.int_to_string %abc_i24 : i24
+  %abcstrcmp = sim.string.cmp %abc_str, %abc
+  // CHECK: abcstrcmp = 00000000
+  arc.sim.emit "abcstrcmp", %abcstrcmp : i32
+
+  %wide_str = sim.string.int_to_string %abcdefghijklmnop_i128 : i128
+  %widestrcmp = sim.string.cmp %wide_str, %abcdefghijklmnop
+  // CHECK: widestrcmp = 00000000
+  arc.sim.emit "widestrcmp", %widestrcmp : i32
+
+  %sub = sim.string.substr %hello[%one : %three]
+  %sublen64 = sim.string.length %sub
+  %sublen = arith.trunci %sublen64 : i64 to i32
+  // CHECK: sublen = 00000003
+  arc.sim.emit "sublen", %sublen : i32
+
+  %single_sub = sim.string.substr %hello[%zero : %zero]
+  %single_sub_cmp = sim.string.cmp %single_sub, %h
+  // CHECK: single_sub_cmp = 00000000
+  arc.sim.emit "single_sub_cmp", %single_sub_cmp : i32
+
+  %last_single_sub = sim.string.substr %hello[%four : %four]
+  %last_single_sub_cmp = sim.string.cmp %last_single_sub, %o
+  // CHECK: last_single_sub_cmp = 00000000
+  arc.sim.emit "last_single_sub_cmp", %last_single_sub_cmp : i32
+
+  %prefix_sub = sim.string.substr %hello[%zero : %one]
+  %prefix_sub_cmp = sim.string.cmp %prefix_sub, %he
+  // CHECK: prefix_sub_cmp = 00000000
+  arc.sim.emit "prefix_sub_cmp", %prefix_sub_cmp : i32
+
+  %clamped_start = sim.string.substr %hello[%neg : %one]
+  %clamped_start_cmp = sim.string.cmp %clamped_start, %he
+  // CHECK: clamped_start_cmp = 00000000
+  arc.sim.emit "clamped_start_cmp", %clamped_start_cmp : i32
+
+  %inverted_sub = sim.string.substr %hello[%three : %one]
+  %inverted_sublen64 = sim.string.length %inverted_sub
+  %inverted_sublen = arith.trunci %inverted_sublen64 : i64 to i32
+  // CHECK: inverted_sublen = 00000000
+  arc.sim.emit "inverted_sublen", %inverted_sublen : i32
+
+  %negative_end_sub = sim.string.substr %hello[%zero : %neg]
+  %negative_end_sublen64 = sim.string.length %negative_end_sub
+  %negative_end_sublen = arith.trunci %negative_end_sublen64 : i64 to i32
+  // CHECK: negative_end_sublen = 00000000
+  arc.sim.emit "negative_end_sublen", %negative_end_sublen : i32
+
+  %far_sub = sim.string.substr %hello[%too_far : %too_far]
+  %far_sublen64 = sim.string.length %far_sub
+  %far_sublen = arith.trunci %far_sublen64 : i64 to i32
+  // CHECK: far_sublen = 00000000
+  arc.sim.emit "far_sublen", %far_sublen : i32
+
+  %clamped_end = sim.string.substr %hello[%three : %too_far]
+  %clamped_end_cmp = sim.string.cmp %clamped_end, %lo
+  // CHECK: clamped_end_cmp = 00000000
+  arc.sim.emit "clamped_end_cmp", %clamped_end_cmp : i32
+
+  %clamped_full = sim.string.substr %hello[%neg : %too_far]
+  %clamped_full_cmp = sim.string.cmp %clamped_full, %hello
+  // CHECK: clamped_full_cmp = 00000000
+  arc.sim.emit "clamped_full_cmp", %clamped_full_cmp : i32
+
+  %empty_sub = sim.string.substr %empty[%zero : %one]
+  %empty_sublen64 = sim.string.length %empty_sub
+  %empty_sublen = arith.trunci %empty_sublen64 : i64 to i32
+  // CHECK: empty_sublen = 00000000
+  arc.sim.emit "empty_sublen", %empty_sublen : i32
+
+  %empty_cat = sim.string.concat ()
+  %empty_cat_len64 = sim.string.length %empty_cat
+  %empty_cat_len = arith.trunci %empty_cat_len64 : i64 to i32
+  // CHECK: empty_cat_len = 00000000
+  arc.sim.emit "empty_cat_len", %empty_cat_len : i32
+
+  %single_cat = sim.string.concat (%hello)
+  %single_cat_cmp = sim.string.cmp %single_cat, %hello
+  // CHECK: single_cat_cmp = 00000000
+  arc.sim.emit "single_cat_cmp", %single_cat_cmp : i32
+
+  %cat_empty = sim.string.concat (%hello, %empty)
+  %cat_empty_cmp = sim.string.cmp %cat_empty, %hello
+  // CHECK: cat_empty_cmp = 00000000
+  arc.sim.emit "cat_empty_cmp", %cat_empty_cmp : i32
+
+  %empty_cat_left = sim.string.concat (%empty, %hello)
+  %empty_cat_left_cmp = sim.string.cmp %empty_cat_left, %hello
+  // CHECK: empty_cat_left_cmp = 00000000
+  arc.sim.emit "empty_cat_left_cmp", %empty_cat_left_cmp : i32
+
+  %empty_cat_middle = sim.string.concat (%hello, %empty, %bang)
+  %empty_cat_middle_cmp = sim.string.cmp %empty_cat_middle, %hello_bang
+  // CHECK: empty_cat_middle_cmp = 00000000
+  arc.sim.emit "empty_cat_middle_cmp", %empty_cat_middle_cmp : i32
+
+  %cat = sim.string.concat (%hello, %bang)
+  %catlen64 = sim.string.length %cat
+  %catlen = arith.trunci %catlen64 : i64 to i32
+  // CHECK: catlen = 00000006
+  arc.sim.emit "catlen", %catlen : i32
+
+  %catcmp = sim.string.cmp %cat, %hello_bang
+  // CHECK: catcmp = 00000000
+  arc.sim.emit "catcmp", %catcmp : i32
+
+  return
+}

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -71,6 +71,22 @@ static llvm::Twine evalSymbolFromModelName(StringRef modelName) {
 
 namespace {
 
+static Value reg2mem(ConversionPatternRewriter &rewriter, Location loc,
+                     Value value);
+
+static LLVM::LLVMFuncOp
+getOrCreateRuntimeFunction(ModuleOp module, Location loc, OpBuilder &builder,
+                           StringRef name, Type resultType,
+                           ArrayRef<Type> argTypes) {
+  if (auto fn = module.lookupSymbol<LLVM::LLVMFuncOp>(name))
+    return fn;
+
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(module.getBody());
+  auto fnTy = LLVM::LLVMFunctionType::get(resultType, argTypes);
+  return LLVM::LLVMFuncOp::create(builder, loc, name, fnTy);
+}
+
 struct DynamicStringConstantOpLowering
     : public OpConversionPattern<sim::StringConstantOp> {
   DynamicStringConstantOpLowering(LLVMTypeConverter &converter,
@@ -147,6 +163,165 @@ struct DynamicStringLengthOpLowering
       length = LLVM::TruncOp::create(rewriter, op.getLoc(), resultTy, length);
 
     rewriter.replaceOp(op, length);
+    return success();
+  }
+};
+
+struct DynamicStringCmpOpLowering
+    : public OpConversionPattern<sim::StringCmpOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::StringCmpOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(i32Ty, {ptrTy, ptrTy});
+    auto cmpFn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                            "circt_sim_string_cmp", i32Ty,
+                                            {ptrTy, ptrTy});
+
+    Value result =
+        LLVM::CallOp::create(rewriter, op.getLoc(), fnTy, cmpFn.getSymName(),
+                             ValueRange{adaptor.getLhs(), adaptor.getRhs()})
+            .getResult();
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct DynamicStringConcatOpLowering
+    : public OpConversionPattern<sim::StringConcatOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::StringConcatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto inputs = adaptor.getInputs();
+    if (inputs.size() == 1) {
+      rewriter.replaceOp(op, inputs.front());
+      return success();
+    }
+
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto fnTy = LLVM::LLVMFunctionType::get(ptrTy, {ptrTy, ptrTy});
+    auto fn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                         "circt_sim_string_concat", ptrTy,
+                                         {ptrTy, ptrTy});
+
+    Value result;
+    if (inputs.empty()) {
+      Value nullPtr = LLVM::ZeroOp::create(rewriter, op.getLoc(), ptrTy);
+      result =
+          LLVM::CallOp::create(rewriter, op.getLoc(), fnTy, fn.getSymName(),
+                               ValueRange{nullPtr, nullPtr})
+              .getResult();
+    } else {
+      result = inputs.front();
+      for (Value next : inputs.drop_front())
+        result = LLVM::CallOp::create(rewriter, op.getLoc(), fnTy,
+                                      fn.getSymName(), ValueRange{result, next})
+                     .getResult();
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct DynamicStringIntToStringOpLowering
+    : public OpConversionPattern<sim::IntToStringOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::IntToStringOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto inputIntTy = dyn_cast<IntegerType>(op.getInput().getType());
+    if (!inputIntTy)
+      return failure();
+
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(ptrTy, {ptrTy, i32Ty});
+    auto fn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                         "circt_sim_string_int_to_string",
+                                         ptrTy, {ptrTy, i32Ty});
+    Value inputPtr = reg2mem(rewriter, op.getLoc(), adaptor.getInput());
+    Value bitWidth = LLVM::ConstantOp::create(rewriter, op.getLoc(), i32Ty,
+                                              inputIntTy.getWidth());
+    Value result =
+        LLVM::CallOp::create(rewriter, op.getLoc(), fnTy, fn.getSymName(),
+                             ValueRange{inputPtr, bitWidth})
+            .getResult();
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+template <typename OpTy>
+struct DynamicStringGetCharLikeOpLowering : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto module = op->template getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto i8Ty = rewriter.getI8Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(i8Ty, {ptrTy, i32Ty});
+    auto getcFn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                             "circt_sim_string_get_char", i8Ty,
+                                             {ptrTy, i32Ty});
+
+    Value result =
+        LLVM::CallOp::create(rewriter, op.getLoc(), fnTy, getcFn.getSymName(),
+                             ValueRange{adaptor.getStr(), adaptor.getIndex()})
+            .getResult();
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct DynamicStringSubstrOpLowering
+    : public OpConversionPattern<sim::StringSubstrOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::StringSubstrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(ptrTy, {ptrTy, i32Ty, i32Ty});
+    auto substrFn = getOrCreateRuntimeFunction(module, op.getLoc(), rewriter,
+                                               "circt_sim_string_substr", ptrTy,
+                                               {ptrTy, i32Ty, i32Ty});
+
+    Value result =
+        LLVM::CallOp::create(
+            rewriter, op.getLoc(), fnTy, substrFn.getSymName(),
+            ValueRange{adaptor.getStr(), adaptor.getStart(), adaptor.getEnd()})
+            .getResult();
+    rewriter.replaceOp(op, result);
     return success();
   }
 };
@@ -1018,38 +1193,42 @@ foldFormatString(ConversionPatternRewriter &rewriter, Value fstringValue,
             FmtDescriptor d = FmtDescriptor::createChar();
             return FormatInfo{{d}, {op.getValue()}};
           })
-      .Case<sim::FormatDecOp>([&](sim::FormatDecOp op)
-                                  -> FailureOr<FormatInfo> {
-        FmtDescriptor d = FmtDescriptor::createInt(
-            op.getValue().getType().getWidth(), 10, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
-            op.getIsSigned());
-        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
-      })
-      .Case<sim::FormatHexOp>([&](sim::FormatHexOp op)
-                                  -> FailureOr<FormatInfo> {
-        FmtDescriptor d = FmtDescriptor::createInt(
-            op.getValue().getType().getWidth(), 16, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(),
-            op.getIsHexUppercase(), false);
-        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
-      })
-      .Case<sim::FormatOctOp>([&](sim::FormatOctOp op)
-                                  -> FailureOr<FormatInfo> {
-        FmtDescriptor d = FmtDescriptor::createInt(
-            op.getValue().getType().getWidth(), 8, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
-            false);
-        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
-      })
-      .Case<sim::FormatBinOp>([&](sim::FormatBinOp op)
-                                  -> FailureOr<FormatInfo> {
-        FmtDescriptor d = FmtDescriptor::createInt(
-            op.getValue().getType().getWidth(), 2, op.getIsLeftAligned(),
-            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
-            false);
-        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
-      })
+      .Case<sim::FormatDecOp>(
+          [&](sim::FormatDecOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d = FmtDescriptor::createInt(
+                op.getValue().getType().getWidth(), 10, op.getIsLeftAligned(),
+                op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+                op.getIsSigned());
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
+      .Case<sim::FormatHexOp>(
+          [&](sim::FormatHexOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d = FmtDescriptor::createInt(
+                op.getValue().getType().getWidth(), 16, op.getIsLeftAligned(),
+                op.getSpecifierWidth().value_or(-1), op.getPaddingChar(),
+                op.getIsHexUppercase(), false);
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
+      .Case<sim::FormatOctOp>(
+          [&](sim::FormatOctOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d = FmtDescriptor::createInt(
+                op.getValue().getType().getWidth(), 8, op.getIsLeftAligned(),
+                op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+                false);
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
+      .Case<sim::FormatBinOp>(
+          [&](sim::FormatBinOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d = FmtDescriptor::createInt(
+                op.getValue().getType().getWidth(), 2, op.getIsLeftAligned(),
+                op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+                false);
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
       .Case<sim::FormatLiteralOp>(
           [&](sim::FormatLiteralOp op) -> FailureOr<FormatInfo> {
             if (op.getLiteral().size() < 8 &&
@@ -1951,7 +2130,13 @@ void LowerArcToLLVMPass::runOnOperation() {
   unsigned nextStringId = 0;
   patterns.add<DynamicStringConstantOpLowering>(converter, &getContext(),
                                                 &nextStringId);
-  patterns.add<DynamicStringLengthOpLowering>(converter, &getContext());
+  patterns
+      .add<DynamicStringLengthOpLowering, DynamicStringCmpOpLowering,
+           DynamicStringConcatOpLowering,
+           DynamicStringGetCharLikeOpLowering<sim::StringGetOp>,
+           DynamicStringGetCharLikeOpLowering<sim::StringGetCharOp>,
+           DynamicStringIntToStringOpLowering, DynamicStringSubstrOpLowering>(
+          converter, &getContext());
 
   // Arc patterns.
   // clang-format off

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1182,16 +1182,145 @@ static Value reg2mem(ConversionPatternRewriter &rewriter, Location loc,
   return allocaOp;
 }
 
+static bool isSupportedIntegerFormatBase(int32_t base) {
+  return base == 2 || base == 8 || base == 10 || base == 16;
+}
+
+static char getIntegerFormatPaddingChar(int32_t flags) {
+  static constexpr int32_t fmtPadZero = 1 << 2;
+  return (flags & fmtPadZero) ? '0' : ' ';
+}
+
+static bool isIntegerFormatLeftAligned(int32_t flags) {
+  static constexpr int32_t fmtLeftJustify = 1 << 1;
+  return (flags & fmtLeftJustify) != 0;
+}
+
+static bool isIntegerFormatUppercase(int32_t flags) {
+  static constexpr int32_t fmtUppercase = 1 << 0;
+  return (flags & fmtUppercase) != 0;
+}
+
+static bool isIntegerFormatSigned(int32_t flags) {
+  static constexpr int32_t fmtSigned = 1 << 3;
+  return (flags & fmtSigned) != 0;
+}
+
 // Statically folds a value of type sim::FormatStringType to a FormatInfo.
 static FailureOr<FormatInfo>
 foldFormatString(ConversionPatternRewriter &rewriter, Value fstringValue,
                  StringCache &cache) {
   Operation *op = fstringValue.getDefiningOp();
+  auto foldRealFormat = [&](Operation *op, Value value, char format,
+                            bool isLeftAligned,
+                            std::optional<int32_t> fieldWidth,
+                            int32_t fracDigits) -> FailureOr<FormatInfo> {
+    if (isa<Float32Type>(value.getType()))
+      value = LLVM::FPExtOp::create(rewriter, op->getLoc(),
+                                    rewriter.getF64Type(), value);
+    if (!isa<Float64Type>(value.getType()))
+      return failure();
+    FmtDescriptor d = FmtDescriptor::createReal(
+        format, isLeftAligned, fieldWidth.value_or(-1), fracDigits);
+    return FormatInfo{{d}, {value}};
+  };
   return llvm::TypeSwitch<Operation *, FailureOr<FormatInfo>>(op)
       .Case<sim::FormatCharOp>(
           [&](sim::FormatCharOp op) -> FailureOr<FormatInfo> {
-            FmtDescriptor d = FmtDescriptor::createChar();
-            return FormatInfo{{d}, {op.getValue()}};
+            Value value = op.getValue();
+            auto i32Ty = rewriter.getI32Type();
+            auto intTy = cast<IntegerType>(value.getType());
+            if (intTy.getWidth() < 32)
+              value = LLVM::ZExtOp::create(rewriter, op.getLoc(), i32Ty, value);
+            else if (intTy.getWidth() > 32)
+              value =
+                  LLVM::TruncOp::create(rewriter, op.getLoc(), i32Ty, value);
+            FmtDescriptor d = FmtDescriptor::createChar(
+                op.getIsLeftAligned(), static_cast<char>(op.getPaddingChar()),
+                op.getSpecifierWidth().value_or(-1));
+            return FormatInfo{{d}, {value}};
+          })
+      .Case<sim::FormatTimeOp>(
+          [&](sim::FormatTimeOp op) -> FailureOr<FormatInfo> {
+            FmtDescriptor d =
+                FmtDescriptor::createTime(op.getWidth().value_or(-1));
+            Value time = op.getValue();
+            auto i64Ty = rewriter.getI64Type();
+            auto intTy = cast<IntegerType>(time.getType());
+            if (intTy.getWidth() < 64)
+              time = LLVM::SExtOp::create(rewriter, op.getLoc(), i64Ty, time);
+            else if (intTy.getWidth() > 64)
+              time = LLVM::TruncOp::create(rewriter, op.getLoc(), i64Ty, time);
+            return FormatInfo{{d}, {time}};
+          })
+      .Case<sim::FormatStringOp>(
+          [&](sim::FormatStringOp op) -> FailureOr<FormatInfo> {
+            Value value = rewriter.getRemappedValue(op.getValue());
+            if (!value)
+              value = op.getValue();
+            FmtDescriptor d = FmtDescriptor::createString(
+                op.getIsLeftAligned(), static_cast<char>(op.getPaddingChar()),
+                op.getSpecifierWidth().value_or(-1));
+            return FormatInfo{{d}, {value}};
+          })
+      .Case<sim::FormatScientificOp>(
+          [&](sim::FormatScientificOp op) -> FailureOr<FormatInfo> {
+            return foldRealFormat(op, op.getValue(), 'e', op.getIsLeftAligned(),
+                                  op.getFieldWidth(), op.getFracDigits());
+          })
+      .Case<sim::FormatFloatOp>(
+          [&](sim::FormatFloatOp op) -> FailureOr<FormatInfo> {
+            return foldRealFormat(op, op.getValue(), 'f', op.getIsLeftAligned(),
+                                  op.getFieldWidth(), op.getFracDigits());
+          })
+      .Case<sim::FormatGeneralOp>(
+          [&](sim::FormatGeneralOp op) -> FailureOr<FormatInfo> {
+            return foldRealFormat(op, op.getValue(), 'g', op.getIsLeftAligned(),
+                                  op.getFieldWidth(), op.getFracDigits());
+          })
+      .Case<sim::FormatIntOp>(
+          [&](sim::FormatIntOp op) -> FailureOr<FormatInfo> {
+            int32_t base = op.getBase();
+            int32_t width = op.getWidth();
+            int32_t flags = op.getFlags();
+            if (!isSupportedIntegerFormatBase(base)) {
+              op.emitError("unsupported integer format base");
+              return failure();
+            }
+            if (width < 0) {
+              op.emitError("negative integer format width");
+              return failure();
+            }
+            FmtDescriptor d = FmtDescriptor::createExactInt(
+                op.getValue().getType().getWidth(), base,
+                isIntegerFormatLeftAligned(flags), width,
+                getIntegerFormatPaddingChar(flags),
+                isIntegerFormatUppercase(flags), isIntegerFormatSigned(flags));
+            return FormatInfo{{d},
+                              {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+          })
+      .Case<sim::FormatFVIntOp>(
+          [&](sim::FormatFVIntOp op) -> FailureOr<FormatInfo> {
+            int32_t base = op.getBase();
+            int32_t width = op.getWidth();
+            int32_t flags = op.getFlags();
+            if (!isSupportedIntegerFormatBase(base)) {
+              op.emitError("unsupported integer format base");
+              return failure();
+            }
+            if (width < 0) {
+              op.emitError("negative integer format width");
+              return failure();
+            }
+            FmtDescriptor d = FmtDescriptor::createFVInt(
+                op.getValue().getType().getWidth(), base,
+                isIntegerFormatLeftAligned(flags), width,
+                getIntegerFormatPaddingChar(flags),
+                isIntegerFormatUppercase(flags), isIntegerFormatSigned(flags));
+            return FormatInfo{
+                {d},
+                {reg2mem(rewriter, op.getLoc(), op.getValue()),
+                 reg2mem(rewriter, op.getLoc(), op.getUnknown())}};
           })
       .Case<sim::FormatDecOp>(
           [&](sim::FormatDecOp op) -> FailureOr<FormatInfo> {
@@ -1293,6 +1422,37 @@ FailureOr<LLVM::CallOp> emitFmtCall(OpBuilder &builder, Location loc,
   return result;
 }
 
+FailureOr<LLVM::CallOp> emitFmtStringCall(OpBuilder &builder, Location loc,
+                                          StringCache &stringCache,
+                                          ArrayRef<FmtDescriptor> descriptors,
+                                          ValueRange args) {
+  ModuleOp moduleOp =
+      builder.getInsertionBlock()->getParent()->getParentOfType<ModuleOp>();
+  MLIRContext *ctx = builder.getContext();
+  auto ptrTy = LLVM::LLVMPointerType::get(ctx);
+  auto func = LLVM::lookupOrCreateFn(
+      builder, moduleOp, runtime::APICallbacks::symNameFormatToString, ptrTy,
+      ptrTy, true);
+  if (failed(func))
+    return func;
+
+  StringRef rawDescriptors(reinterpret_cast<const char *>(descriptors.data()),
+                           descriptors.size() * sizeof(FmtDescriptor));
+  Value fmtPtr = stringCache.getOrCreate(builder, rawDescriptors);
+
+  SmallVector<Value> argsVec(1, fmtPtr);
+  argsVec.append(args.begin(), args.end());
+  auto result = LLVM::CallOp::create(builder, loc, func.value(), argsVec);
+
+  for (Value arg : args) {
+    Operation *definingOp = arg.getDefiningOp();
+    if (auto alloca = dyn_cast_if_present<LLVM::AllocaOp>(definingOp))
+      LLVM::LifetimeEndOp::create(builder, loc, arg);
+  }
+
+  return result;
+}
+
 struct SimPrintFormattedProcOpLowering
     : public OpConversionPattern<sim::PrintFormattedProcOp> {
   SimPrintFormattedProcOpLowering(const TypeConverter &typeConverter,
@@ -1317,6 +1477,82 @@ struct SimPrintFormattedProcOpLowering
       return failure();
     rewriter.replaceOp(op, result.value());
 
+    return success();
+  }
+
+  StringCache &stringCache;
+};
+
+struct SimFormatStringToStringOpLowering
+    : public OpConversionPattern<sim::FormatStringToStringOp> {
+  SimFormatStringToStringOpLowering(const TypeConverter &typeConverter,
+                                    MLIRContext *context,
+                                    StringCache &stringCache)
+      : OpConversionPattern<sim::FormatStringToStringOp>(typeConverter,
+                                                         context),
+        stringCache(stringCache) {}
+
+  LogicalResult
+  matchAndRewrite(sim::FormatStringToStringOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    auto formatInfo = foldFormatString(rewriter, op.getInput(), stringCache);
+    if (failed(formatInfo))
+      return rewriter.notifyMatchFailure(op, "unsupported format string");
+
+    formatInfo->descriptors.push_back(FmtDescriptor());
+    auto result = emitFmtStringCall(rewriter, op.getLoc(), stringCache,
+                                    formatInfo->descriptors, formatInfo->args);
+    if (failed(result))
+      return failure();
+
+    rewriter.replaceOp(op, result->getResult());
+    return success();
+  }
+
+  StringCache &stringCache;
+};
+
+struct SimTimeFormatProcOpLowering
+    : public OpConversionPattern<sim::TimeFormatProcOp> {
+  SimTimeFormatProcOpLowering(const TypeConverter &typeConverter,
+                              MLIRContext *context, StringCache &stringCache)
+      : OpConversionPattern<sim::TimeFormatProcOp>(typeConverter, context),
+        stringCache(stringCache) {}
+
+  LogicalResult
+  matchAndRewrite(sim::TimeFormatProcOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    auto loc = op.getLoc();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto i32Ty = rewriter.getI32Type();
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto voidTy = LLVM::LLVMVoidType::get(op.getContext());
+    auto fnTy =
+        LLVM::LLVMFunctionType::get(voidTy, {i32Ty, i32Ty, ptrTy, i32Ty});
+    auto fn = module.lookupSymbol<LLVM::LLVMFuncOp>(
+        runtime::APICallbacks::symNameSetTimeFormat);
+    if (!fn) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(module.getBody());
+      fn = LLVM::LLVMFuncOp::create(
+          rewriter, loc, runtime::APICallbacks::symNameSetTimeFormat, fnTy);
+    }
+
+    Value unit =
+        LLVM::ConstantOp::create(rewriter, loc, i32Ty, op.getUnitAttr());
+    Value precision =
+        LLVM::ConstantOp::create(rewriter, loc, i32Ty, op.getPrecisionAttr());
+    Value suffix = stringCache.getOrCreate(rewriter, op.getSuffix());
+    Value minWidth =
+        LLVM::ConstantOp::create(rewriter, loc, i32Ty, op.getMinWidthAttr());
+    LLVM::CallOp::create(rewriter, loc, fn,
+                         ValueRange{unit, precision, suffix, minWidth});
+    rewriter.eraseOp(op);
     return success();
   }
 
@@ -2058,6 +2294,9 @@ void LowerArcToLLVMPass::runOnOperation() {
   // They are all marked Pure so are removed after the conversion.
   target.addLegalOp<sim::FormatLiteralOp, sim::FormatDecOp, sim::FormatHexOp,
                     sim::FormatBinOp, sim::FormatOctOp, sim::FormatCharOp,
+                    sim::FormatIntOp, sim::FormatFVIntOp, sim::FormatTimeOp,
+                    sim::FormatStringOp, sim::FormatScientificOp,
+                    sim::FormatFloatOp, sim::FormatGeneralOp,
                     sim::FormatStringConcatOp>();
 
   // Setup the arc dialect type conversion.
@@ -2183,7 +2422,8 @@ void LowerArcToLLVMPass::runOnOperation() {
   patterns.add<ExecuteOp>(convert);
 
   StringCache stringCache;
-  patterns.add<SimEmitValueOpLowering, SimPrintFormattedProcOpLowering>(
+  patterns.add<SimEmitValueOpLowering, SimPrintFormattedProcOpLowering,
+               SimFormatStringToStringOpLowering, SimTimeFormatProcOpLowering>(
       converter, &getContext(), stringCache);
 
   auto &modelInfo = getAnalysis<ModelInfoAnalysis>();

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -71,6 +71,86 @@ static llvm::Twine evalSymbolFromModelName(StringRef modelName) {
 
 namespace {
 
+struct DynamicStringConstantOpLowering
+    : public OpConversionPattern<sim::StringConstantOp> {
+  DynamicStringConstantOpLowering(LLVMTypeConverter &converter,
+                                  MLIRContext *ctx, unsigned *nextStringId)
+      : OpConversionPattern(converter, ctx), nextStringId(nextStringId) {}
+
+  LogicalResult
+  matchAndRewrite(sim::StringConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module || !nextStringId)
+      return failure();
+
+    SmallVector<char> bytes(op.getLiteral().begin(), op.getLiteral().end());
+    bytes.push_back(0);
+
+    LLVM::GlobalOp global;
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(module.getBody());
+
+      SmallString<32> name;
+      name.append("_sim_str_");
+      name.append(Twine((*nextStringId)++).str());
+
+      auto i8Ty = rewriter.getI8Type();
+      auto globalType = LLVM::LLVMArrayType::get(i8Ty, bytes.size());
+      global = LLVM::GlobalOp::create(
+          rewriter, op.getLoc(), globalType, /*isConstant=*/true,
+          LLVM::Linkage::Internal, name, rewriter.getStringAttr(bytes),
+          /*alignment=*/0);
+    }
+
+    rewriter.replaceOpWithNewOp<LLVM::AddressOfOp>(op, global);
+    return success();
+  }
+
+  unsigned *nextStringId;
+};
+
+struct DynamicStringLengthOpLowering
+    : public OpConversionPattern<sim::StringLengthOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::StringLengthOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto resultTy = typeConverter->convertType(op.getType());
+    auto resultIntTy = dyn_cast<IntegerType>(resultTy);
+    if (!resultIntTy)
+      return failure();
+
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return failure();
+
+    auto ptrTy = LLVM::LLVMPointerType::get(op.getContext());
+    auto i32Ty = rewriter.getI32Type();
+    auto fnTy = LLVM::LLVMFunctionType::get(i32Ty, {ptrTy});
+    auto lenFn = module.lookupSymbol<LLVM::LLVMFuncOp>("circt_sim_string_len");
+    if (!lenFn) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(module.getBody());
+      lenFn = LLVM::LLVMFuncOp::create(rewriter, op.getLoc(),
+                                       "circt_sim_string_len", fnTy);
+    }
+
+    Value length = LLVM::CallOp::create(rewriter, op.getLoc(), fnTy,
+                                        lenFn.getSymName(), adaptor.getInput())
+                       .getResult();
+    if (resultIntTy.getWidth() > 32)
+      length = LLVM::ZExtOp::create(rewriter, op.getLoc(), resultTy, length);
+    else if (resultIntTy.getWidth() < 32)
+      length = LLVM::TruncOp::create(rewriter, op.getLoc(), resultTy, length);
+
+    rewriter.replaceOp(op, length);
+    return success();
+  }
+};
+
 struct ModelOpLowering : public OpConversionPattern<arc::ModelOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -1821,6 +1901,9 @@ void LowerArcToLLVMPass::runOnOperation() {
   converter.addConversion([&](sim::FormatStringType type) {
     return LLVM::LLVMPointerType::get(type.getContext());
   });
+  converter.addConversion([&](sim::DynamicStringType type) {
+    return LLVM::LLVMPointerType::get(type.getContext());
+  });
   converter.addConversion([&](llhd::TimeType type) {
     // LLHD time is represented as i64 femtoseconds.
     return IntegerType::get(type.getContext(), 64);
@@ -1864,6 +1947,11 @@ void LowerArcToLLVMPass::runOnOperation() {
 
   populateCombToArithConversionPatterns(converter, patterns);
   populateCombToLLVMConversionPatterns(converter, patterns);
+
+  unsigned nextStringId = 0;
+  patterns.add<DynamicStringConstantOpLowering>(converter, &getContext(),
+                                                &nextStringId);
+  patterns.add<DynamicStringLengthOpLowering>(converter, &getContext());
 
   // Arc patterns.
   // clang-format off

--- a/lib/Dialect/Arc/Runtime/ArcRuntime.cpp
+++ b/lib/Dialect/Arc/Runtime/ArcRuntime.cpp
@@ -30,11 +30,17 @@
 #include "circt/Dialect/Arc/Runtime/JITBind.h"
 #endif
 
+#include <algorithm>
 #include <cassert>
 #include <cstdarg>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
 
 using namespace circt::arc::runtime;
 
@@ -108,11 +114,258 @@ void arcRuntimeIR_deleteInstance(uint8_t *modelState) {
   arcRuntimeDeleteInstance(arcRuntimeGetStateFromModelState(modelState, 0));
 }
 
-void arcRuntimeIR_format(const FmtDescriptor *fmt, ...) {
-  va_list args;
-  va_start(args, fmt);
+namespace {
 
-  llvm::raw_ostream &os = llvm::outs();
+uint64_t pow10u64(uint32_t exp) {
+  static const uint64_t kPow10[] = {
+      1ull,
+      10ull,
+      100ull,
+      1000ull,
+      10000ull,
+      100000ull,
+      1000000ull,
+      10000000ull,
+      100000000ull,
+      1000000000ull,
+      10000000000ull,
+      100000000000ull,
+      1000000000000ull,
+      10000000000000ull,
+      100000000000000ull,
+      1000000000000000ull,
+      10000000000000000ull,
+      100000000000000000ull,
+      1000000000000000000ull,
+  };
+  if (exp >= (sizeof(kPow10) / sizeof(kPow10[0])))
+    return 0;
+  return kPow10[exp];
+}
+
+bool getBit(const llvm::APInt &value, unsigned bit) {
+  return value.extractBits(1, bit).getBoolValue();
+}
+
+uint32_t getBits(const llvm::APInt &value, unsigned start, unsigned width) {
+  return value.extractBits(width, start).getZExtValue();
+}
+
+void trimLeadingZeros(std::string &str) {
+  if (str.empty())
+    return;
+  auto firstNonZero = str.find_first_not_of('0');
+  if (firstNonZero == std::string::npos) {
+    if (str.size() > 1)
+      str.erase(0, str.size() - 1);
+    return;
+  }
+  if (firstNonZero > 0)
+    str.erase(0, firstNonZero);
+}
+
+void emitPadded(llvm::raw_ostream &os, llvm::StringRef str, bool isLeftAligned,
+                char paddingChar, int32_t minWidth) {
+  if (minWidth < 0)
+    minWidth = 0;
+  if (paddingChar == '\0')
+    paddingChar = ' ';
+  int32_t padCount = 0;
+  if (static_cast<int32_t>(str.size()) < minWidth)
+    padCount = minWidth - static_cast<int32_t>(str.size());
+
+  if (!isLeftAligned)
+    for (int32_t i = 0; i < padCount; ++i)
+      os << paddingChar;
+  os << str;
+  if (isLeftAligned)
+    for (int32_t i = 0; i < padCount; ++i)
+      os << paddingChar;
+}
+
+void formatExactIntegerByRadix(llvm::raw_ostream &os, int width, int radix,
+                               const llvm::APInt &value, bool isUpperCase,
+                               bool isLeftAligned, char paddingChar,
+                               int specifierWidth, bool isSigned) {
+  llvm::SmallVector<char, 32> strBuf;
+  value.toString(strBuf, radix, isSigned && radix == 10, false, isUpperCase);
+  std::string out(strBuf.begin(), strBuf.end());
+  emitPadded(os, out, isLeftAligned, paddingChar, specifierWidth);
+}
+
+void formatFVIntegerByRadix(llvm::raw_ostream &os, int width, int radix,
+                            const llvm::APInt &value,
+                            const llvm::APInt &unknown, bool isUpperCase,
+                            bool isLeftAligned, char paddingChar,
+                            int specifierWidth, bool isSigned) {
+  if (unknown.isZero()) {
+    formatExactIntegerByRadix(os, width, radix, value, isUpperCase,
+                              isLeftAligned, paddingChar, specifierWidth,
+                              isSigned);
+    return;
+  }
+
+  std::string out;
+  switch (radix) {
+  case 2:
+    out.reserve(width);
+    for (int b = width; b > 0; --b) {
+      auto bit = static_cast<unsigned>(b - 1);
+      if (!getBit(unknown, bit)) {
+        out.push_back(getBit(value, bit) ? '1' : '0');
+        continue;
+      }
+      bool isZ = getBit(value, bit);
+      out.push_back(isZ ? (isUpperCase ? 'Z' : 'z')
+                        : (isUpperCase ? 'X' : 'x'));
+    }
+    break;
+  case 8:
+  case 16: {
+    unsigned groupBits = radix == 8 ? 3 : 4;
+    unsigned digits = llvm::divideCeil(width, static_cast<int>(groupBits));
+    out.reserve(digits);
+    for (unsigned d = digits; d > 0; --d) {
+      unsigned startBit = (d - 1) * groupBits;
+      unsigned bitsThisDigit =
+          std::min(groupBits, width > static_cast<int>(startBit)
+                                  ? static_cast<unsigned>(width) - startBit
+                                  : 0u);
+      if (bitsThisDigit == 0) {
+        out.push_back('0');
+        continue;
+      }
+
+      uint32_t digitUnknown = getBits(unknown, startBit, bitsThisDigit);
+      if (digitUnknown == 0) {
+        uint32_t digitVal = getBits(value, startBit, bitsThisDigit);
+        if (digitVal < 10)
+          out.push_back(static_cast<char>('0' + digitVal));
+        else
+          out.push_back(
+              static_cast<char>((isUpperCase ? 'A' : 'a') + (digitVal - 10)));
+        continue;
+      }
+
+      uint32_t mask = (1u << bitsThisDigit) - 1u;
+      uint32_t digitVal = getBits(value, startBit, bitsThisDigit) & mask;
+      if (digitUnknown == mask) {
+        if (digitVal == mask) {
+          out.push_back(isUpperCase ? 'Z' : 'z');
+          continue;
+        }
+        if (digitVal == 0) {
+          out.push_back(isUpperCase ? 'X' : 'x');
+          continue;
+        }
+      }
+      out.push_back(isUpperCase ? 'X' : 'x');
+    }
+    break;
+  }
+  case 10:
+    out.push_back(unknown.isAllOnes() && value.isAllOnes()
+                      ? (isUpperCase ? 'Z' : 'z')
+                      : (isUpperCase ? 'X' : 'x'));
+    break;
+  default:
+    out = "<unsupported base>";
+    break;
+  }
+
+  trimLeadingZeros(out);
+  emitPadded(os, out, isLeftAligned, paddingChar, specifierWidth);
+}
+
+int32_t timeformatUnit = -15;
+int32_t timeformatPrecision = 0;
+std::string timeformatSuffix;
+int32_t timeformatMinWidth = 20;
+
+void formatTime(llvm::raw_ostream &os, int64_t timeFs, int32_t widthOverride) {
+  int32_t unit = timeformatUnit;
+  int32_t precision = std::clamp(timeformatPrecision, 0, 18);
+  int32_t fieldWidth = widthOverride >= 0 ? widthOverride : timeformatMinWidth;
+  if (fieldWidth < 0)
+    fieldWidth = 0;
+
+  bool neg = timeFs < 0;
+  uint64_t absFs = neg ? static_cast<uint64_t>(-(timeFs + 1)) + 1
+                       : static_cast<uint64_t>(timeFs);
+
+  uint32_t unitPow = static_cast<uint32_t>(unit + 15);
+  uint64_t scale = pow10u64(static_cast<uint32_t>(precision));
+  if (scale == 0)
+    scale = 1;
+
+  uint64_t scaled;
+  if (static_cast<uint32_t>(precision) >= unitPow) {
+    uint64_t factor = pow10u64(static_cast<uint32_t>(precision) - unitPow);
+    if (factor == 0)
+      factor = 1;
+    scaled = absFs * factor;
+  } else {
+    uint64_t divisor = pow10u64(unitPow - static_cast<uint32_t>(precision));
+    if (divisor == 0)
+      divisor = 1;
+    scaled = (absFs + divisor / 2) / divisor;
+  }
+
+  uint64_t intPart = precision == 0 ? scaled : (scaled / scale);
+  uint64_t fracPart = precision == 0 ? 0 : (scaled % scale);
+
+  std::string num;
+  if (neg)
+    num.push_back('-');
+  num.append(std::to_string(intPart));
+  if (precision > 0) {
+    num.push_back('.');
+    auto fracStr = std::to_string(fracPart);
+    if (fracStr.size() < static_cast<size_t>(precision))
+      num.append(static_cast<size_t>(precision) - fracStr.size(), '0');
+    num.append(fracStr);
+  }
+
+  auto formattedWidth = num.size() + timeformatSuffix.size();
+  if (fieldWidth > 0 && static_cast<int32_t>(formattedWidth) < fieldWidth)
+    os.indent(fieldWidth - static_cast<int32_t>(formattedWidth));
+  os << num << timeformatSuffix;
+}
+
+void formatString(llvm::raw_ostream &os, const char *value,
+                  const FmtDescriptor::StringFmt &fmt) {
+  llvm::StringRef str(value ? value : "");
+  emitPadded(os, str, fmt.isLeftAligned, fmt.paddingChar, fmt.specifierWidth);
+}
+
+void formatReal(llvm::raw_ostream &os, double value,
+                const FmtDescriptor::RealFmt &fmt) {
+  int fieldWidth = fmt.fieldWidth > 0 ? fmt.fieldWidth : 0;
+  int fracDigits = fmt.fracDigits >= 0 ? fmt.fracDigits : 6;
+  char conversion = fmt.format;
+  if (conversion != 'e' && conversion != 'f' && conversion != 'g')
+    conversion = 'g';
+
+  char spec[32];
+  if (fmt.isLeftAligned)
+    std::snprintf(spec, sizeof(spec), "%%-%d.%d%c", fieldWidth, fracDigits,
+                  conversion);
+  else if (fieldWidth > 0)
+    std::snprintf(spec, sizeof(spec), "%%%d.%d%c", fieldWidth, fracDigits,
+                  conversion);
+  else
+    std::snprintf(spec, sizeof(spec), "%%.%d%c", fracDigits, conversion);
+
+  int numChars = std::snprintf(nullptr, 0, spec, value);
+  if (numChars <= 0)
+    return;
+  std::string buffer(static_cast<size_t>(numChars) + 1, '\0');
+  std::snprintf(buffer.data(), buffer.size(), spec, value);
+  os << std::string_view(buffer.data(), static_cast<size_t>(numChars));
+}
+
+void formatDescriptors(llvm::raw_ostream &os, const FmtDescriptor *fmt,
+                       va_list args) {
   while (fmt->action != FmtDescriptor::Action_End) {
     switch (fmt->action) {
     case FmtDescriptor::Action_Literal: {
@@ -138,16 +391,90 @@ void arcRuntimeIR_format(const FmtDescriptor *fmt, ...) {
                            fmt->intFmt.isSigned);
       break;
     }
-    case FmtDescriptor::Action_Char:
-      os << static_cast<char>(va_arg(args, int));
+    case FmtDescriptor::Action_IntExact: {
+      uint64_t *words = va_arg(args, uint64_t *);
+      int64_t numWords = llvm::divideCeil(fmt->intFmt.bitwidth, 64);
+      llvm::APInt apInt(fmt->intFmt.bitwidth, llvm::ArrayRef(words, numWords));
+      formatExactIntegerByRadix(
+          os, fmt->intFmt.bitwidth, fmt->intFmt.radix, apInt,
+          fmt->intFmt.isUpperCase, fmt->intFmt.isLeftAligned,
+          fmt->intFmt.paddingChar, fmt->intFmt.specifierWidth,
+          fmt->intFmt.isSigned);
+      break;
+    }
+    case FmtDescriptor::Action_FVInt: {
+      uint64_t *valueWords = va_arg(args, uint64_t *);
+      uint64_t *unknownWords = va_arg(args, uint64_t *);
+      int64_t numWords = llvm::divideCeil(fmt->intFmt.bitwidth, 64);
+      llvm::APInt value(fmt->intFmt.bitwidth,
+                        llvm::ArrayRef(valueWords, numWords));
+      llvm::APInt unknown(fmt->intFmt.bitwidth,
+                          llvm::ArrayRef(unknownWords, numWords));
+      formatFVIntegerByRadix(os, fmt->intFmt.bitwidth, fmt->intFmt.radix, value,
+                             unknown, fmt->intFmt.isUpperCase,
+                             fmt->intFmt.isLeftAligned, fmt->intFmt.paddingChar,
+                             fmt->intFmt.specifierWidth, fmt->intFmt.isSigned);
+      break;
+    }
+    case FmtDescriptor::Action_Char: {
+      char c = static_cast<char>(va_arg(args, int));
+      llvm::StringRef str(&c, 1);
+      emitPadded(os, str, fmt->stringFmt.isLeftAligned,
+                 fmt->stringFmt.paddingChar, fmt->stringFmt.specifierWidth);
+      break;
+    }
+    case FmtDescriptor::Action_Time:
+      formatTime(os, va_arg(args, int64_t), fmt->timeFmt.widthOverride);
+      break;
+    case FmtDescriptor::Action_String:
+      formatString(os, va_arg(args, const char *), fmt->stringFmt);
+      break;
+    case FmtDescriptor::Action_Real:
+      formatReal(os, va_arg(args, double), fmt->realFmt);
       break;
     case FmtDescriptor::Action_End:
       break;
     }
     fmt++;
   }
+}
+
+} // namespace
+
+void arcRuntimeIR_setTimeFormat(int32_t unit, int32_t precision,
+                                const char *suffix, int32_t minFieldWidth) {
+  timeformatUnit = std::clamp(unit, -15, 0);
+  timeformatPrecision = std::clamp(precision, 0, 18);
+  timeformatSuffix = suffix ? suffix : "";
+  timeformatMinWidth = std::max(minFieldWidth, 0);
+}
+
+void arcRuntimeIR_format(const FmtDescriptor *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+
+  formatDescriptors(llvm::outs(), fmt, args);
 
   va_end(args);
+}
+
+const char *arcRuntimeIR_formatToString(const FmtDescriptor *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+
+  std::string buffer;
+  llvm::raw_string_ostream os(buffer);
+  formatDescriptors(os, fmt, args);
+  os.flush();
+
+  va_end(args);
+
+  char *out = static_cast<char *>(std::malloc(buffer.size() + 1));
+  if (!out)
+    return "";
+  std::memcpy(out, buffer.data(), buffer.size());
+  out[buffer.size()] = '\0';
+  return out;
 }
 
 uint64_t *arcRuntimeIR_swapTraceBuffer(const uint8_t *modelState) {
@@ -165,7 +492,8 @@ namespace circt::arc::runtime {
 static const APICallbacks apiCallbacksGlobal{
     &arcRuntimeIR_allocInstance, &arcRuntimeIR_deleteInstance,
     &arcRuntimeIR_onEval,        &arcRuntimeIR_onInitialized,
-    &arcRuntimeIR_format,        &arcRuntimeIR_swapTraceBuffer};
+    &arcRuntimeIR_format,        &arcRuntimeIR_formatToString,
+    &arcRuntimeIR_setTimeFormat, &arcRuntimeIR_swapTraceBuffer};
 
 const APICallbacks &getArcRuntimeAPICallbacks() { return apiCallbacksGlobal; }
 

--- a/lib/Dialect/Arc/Runtime/CMakeLists.txt
+++ b/lib/Dialect/Arc/Runtime/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(ArcRuntimeLibSources
   ArcRuntime.cpp
   ModelInstance.cpp
+  SimString.cpp
   TraceEncoder.cpp
   VCDTraceEncoder.cpp
 )
@@ -38,6 +39,8 @@ endif()
 install(FILES
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/ArcRuntime.h
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/Common.h
+  ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/RuntimeSymbol.h
+  ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/SimString.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/circt/Dialect/Arc/Runtime
   COMPONENT CIRCTArcRuntime
 )

--- a/lib/Dialect/Arc/Runtime/SimString.cpp
+++ b/lib/Dialect/Arc/Runtime/SimString.cpp
@@ -14,7 +14,9 @@
 
 #include "circt/Dialect/Arc/Runtime/SimString.h"
 
+#include <cstdlib>
 #include <cstring>
+#include <limits>
 
 extern "C" int32_t circt_sim_string_len(const char *str) {
   if (!str)
@@ -22,14 +24,119 @@ extern "C" int32_t circt_sim_string_len(const char *str) {
   return static_cast<int32_t>(std::strlen(str));
 }
 
+extern "C" int32_t circt_sim_string_cmp(const char *lhs, const char *rhs) {
+  if (!lhs)
+    lhs = "";
+  if (!rhs)
+    rhs = "";
+  return std::strcmp(lhs, rhs);
+}
+
+extern "C" const char *circt_sim_string_concat(const char *lhs,
+                                               const char *rhs) {
+  if (!lhs)
+    lhs = "";
+  if (!rhs)
+    rhs = "";
+
+  size_t lhsLen = std::strlen(lhs);
+  size_t rhsLen = std::strlen(rhs);
+  if (rhsLen > std::numeric_limits<size_t>::max() - lhsLen - 1)
+    return "";
+
+  char *out = static_cast<char *>(std::malloc(lhsLen + rhsLen + 1));
+  if (!out)
+    return "";
+  std::memcpy(out, lhs, lhsLen);
+  std::memcpy(out + lhsLen, rhs, rhsLen);
+  out[lhsLen + rhsLen] = '\0';
+  return out;
+}
+
+extern "C" const char *circt_sim_string_int_to_string(const void *input,
+                                                      uint32_t bitWidth) {
+  if (!input || bitWidth == 0)
+    return "";
+
+  const auto *bytes = static_cast<const uint8_t *>(input);
+  uint32_t byteCount = (bitWidth + 7) / 8;
+  uint32_t validBitsInTopByte = bitWidth % 8;
+  uint8_t topByteMask =
+      validBitsInTopByte == 0
+          ? 0xff
+          : static_cast<uint8_t>((1u << validBitsInTopByte) - 1u);
+
+  char *out = static_cast<char *>(std::malloc(byteCount + 1));
+  if (!out)
+    return "";
+
+  uint32_t outLen = 0;
+  for (uint32_t index = byteCount; index > 0; --index) {
+    uint8_t byte = bytes[index - 1];
+    if (index == byteCount)
+      byte &= topByteMask;
+    if (byte)
+      out[outLen++] = static_cast<char>(byte);
+  }
+  out[outLen] = '\0';
+  return out;
+}
+
+extern "C" uint8_t circt_sim_string_get_char(const char *str, int32_t idx) {
+  if (!str || idx < 0)
+    return 0;
+  size_t len = std::strlen(str);
+  size_t pos = static_cast<size_t>(idx);
+  if (pos >= len)
+    return 0;
+  return static_cast<uint8_t>(static_cast<unsigned char>(str[pos]));
+}
+
+extern "C" const char *circt_sim_string_substr(const char *str, int32_t start,
+                                               int32_t end) {
+  if (!str)
+    str = "";
+  if (start < 0)
+    start = 0;
+  if (end < start)
+    return "";
+
+  size_t len = std::strlen(str);
+  size_t startPos = static_cast<size_t>(start);
+  if (startPos >= len)
+    return "";
+
+  size_t endPos = static_cast<size_t>(end);
+  if (endPos >= len)
+    endPos = len - 1;
+
+  size_t outLen = endPos - startPos + 1;
+  char *out = static_cast<char *>(std::malloc(outLen + 1));
+  if (!out)
+    return "";
+  std::memcpy(out, str + startPos, outLen);
+  out[outLen] = '\0';
+  return out;
+}
+
 #ifdef ARC_RUNTIME_JIT_BIND
 namespace circt {
 namespace arc {
 namespace runtime {
 
-static const SimStringRuntimeSymbols simStringRuntimeSymbols =
-    std::make_tuple(RuntimeSymbol<decltype(&circt_sim_string_len)>{
-        "circt_sim_string_len", &circt_sim_string_len});
+static const SimStringRuntimeSymbols simStringRuntimeSymbols = std::make_tuple(
+    RuntimeSymbol<decltype(&circt_sim_string_len)>{"circt_sim_string_len",
+                                                   &circt_sim_string_len},
+    RuntimeSymbol<decltype(&circt_sim_string_cmp)>{"circt_sim_string_cmp",
+                                                   &circt_sim_string_cmp},
+    RuntimeSymbol<decltype(&circt_sim_string_concat)>{"circt_sim_string_concat",
+                                                      &circt_sim_string_concat},
+    RuntimeSymbol<decltype(&circt_sim_string_int_to_string)>{
+        "circt_sim_string_int_to_string", &circt_sim_string_int_to_string},
+    RuntimeSymbol<decltype(&circt_sim_string_get_char)>{
+        "circt_sim_string_get_char", &circt_sim_string_get_char},
+    RuntimeSymbol<decltype(&circt_sim_string_substr)>{
+        "circt_sim_string_substr", &circt_sim_string_substr});
 
 const SimStringRuntimeSymbols &getSimStringRuntimeSymbols() {
   return simStringRuntimeSymbols;

--- a/lib/Dialect/Arc/Runtime/SimString.cpp
+++ b/lib/Dialect/Arc/Runtime/SimString.cpp
@@ -1,0 +1,41 @@
+//===- SimString.cpp - Simulation string runtime --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements runtime support for dynamic strings in the sim dialect. Functions
+// here are plain `extern "C"` leaf utilities; the JIT-binding table at the
+// bottom is only compiled into the copy linked into arcilator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/Runtime/SimString.h"
+
+#include <cstring>
+
+extern "C" int32_t circt_sim_string_len(const char *str) {
+  if (!str)
+    return 0;
+  return static_cast<int32_t>(std::strlen(str));
+}
+
+#ifdef ARC_RUNTIME_JIT_BIND
+namespace circt {
+namespace arc {
+namespace runtime {
+
+static const SimStringRuntimeSymbols simStringRuntimeSymbols =
+    std::make_tuple(RuntimeSymbol<decltype(&circt_sim_string_len)>{
+        "circt_sim_string_len", &circt_sim_string_len});
+
+const SimStringRuntimeSymbols &getSimStringRuntimeSymbols() {
+  return simStringRuntimeSymbols;
+}
+
+} // namespace runtime
+} // namespace arc
+} // namespace circt
+#endif // ARC_RUNTIME_JIT_BIND

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -411,17 +411,30 @@ StringAttr FormatCharOp::formatConstant(Attribute constVal) {
   auto intCst = dyn_cast<IntegerAttr>(constVal);
   if (!intCst)
     return {};
-  if (intCst.getType().getIntOrFloatBitWidth() == 0)
-    return StringAttr::get(getContext(), Twine(static_cast<char>(0)));
   if (intCst.getType().getIntOrFloatBitWidth() > 8)
     return {};
-  auto intValue = intCst.getValue().getZExtValue();
-  return StringAttr::get(getContext(), Twine(static_cast<char>(intValue)));
+
+  SmallString<8> strBuf;
+  if (intCst.getType().getIntOrFloatBitWidth() == 0)
+    strBuf.push_back(0);
+  else
+    strBuf.push_back(static_cast<char>(intCst.getValue().getZExtValue()));
+
+  if (getSpecifierWidth().has_value()) {
+    auto padChar = static_cast<char>(getPaddingChar());
+    unsigned padWidth = getSpecifierWidth().value();
+    padWidth = padWidth > strBuf.size() ? padWidth - strBuf.size() : 0;
+    if (getIsLeftAligned())
+      strBuf.append(padWidth, padChar);
+    else
+      strBuf.insert(strBuf.begin(), padWidth, padChar);
+  }
+  return StringAttr::get(getContext(), strBuf);
 }
 
 OpFoldResult FormatCharOp::fold(FoldAdaptor adaptor) {
   if (getValue().getType().getIntOrFloatBitWidth() == 0)
-    return StringAttr::get(getContext(), Twine(static_cast<char>(0)));
+    return formatConstant(IntegerAttr::get(getValue().getType(), 0));
   return {};
 }
 

--- a/test/Conversion/ArcToLLVM/sim-output-format-runtime.mlir
+++ b/test/Conversion/ArcToLLVM/sim-output-format-runtime.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
+
+// CHECK-DAG: llvm.func @arcRuntimeIR_format(!llvm.ptr, ...)
+// CHECK-DAG: llvm.func @arcRuntimeIR_formatToString(!llvm.ptr, ...) -> !llvm.ptr
+// CHECK-DAG: llvm.func @arcRuntimeIR_setTimeFormat(i32, i32, !llvm.ptr, i32)
+
+func.func @format_ints() {
+  %v8 = arith.constant 42 : i8
+  %v2 = arith.constant 2 : i2
+  %u2 = arith.constant 1 : i2
+  %bin = sim.fmt.bin %v8 : i8
+  %int = sim.fmt.int 10 0 0 %v8 : i8
+  %fv = sim.fmt.fvint 2 0 0 %v2, %u2 : i2
+  %msg = sim.fmt.concat (%bin, %int, %fv)
+  // CHECK: llvm.call @arcRuntimeIR_format
+  sim.proc.print %msg
+  return
+}
+
+func.func @timeformat_and_time() {
+  // CHECK: llvm.call @arcRuntimeIR_setTimeFormat
+  sim.proc.timeformat -9, 2, " ns", 0
+  %time = arith.constant 1500000 : i64
+  %fmt = sim.fmt.time %time, width 0 : i64
+  // CHECK: llvm.call @arcRuntimeIR_format
+  sim.proc.print %fmt
+  return
+}
+
+func.func @format_to_string(%input: !sim.dstring) -> !sim.dstring {
+  %str_fmt = sim.fmt.string %input specifierWidth 5 : !sim.dstring
+  %value = arith.constant 42 : i8
+  %int_fmt = sim.fmt.int 10 0 0 %value : i8
+  %msg = sim.fmt.concat (%str_fmt, %int_fmt)
+  %str = sim.fmt.to_string %msg
+  return %str : !sim.dstring
+  // CHECK: llvm.call @arcRuntimeIR_formatToString
+}

--- a/test/Conversion/ArcToLLVM/sim-string-length.mlir
+++ b/test/Conversion/ArcToLLVM/sim-string-length.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
+
+// CHECK-DAG: llvm.func @circt_sim_string_len(!llvm.ptr) -> i32
+// CHECK-DAG: llvm.mlir.global internal constant @_sim_str_0("hello\00")
+
+// CHECK-LABEL: llvm.func @string_length_arg(
+// CHECK-SAME:    %[[STR:.+]]: !llvm.ptr
+func.func @string_length_arg(%str: !sim.dstring) -> i64 {
+  %len = sim.string.length %str
+  return %len : i64
+  // CHECK: %[[LEN32:.+]] = llvm.call @circt_sim_string_len(%[[STR]]) : (!llvm.ptr) -> i32
+  // CHECK: %[[LEN64:.+]] = llvm.zext %[[LEN32]] : i32 to i64
+  // CHECK: llvm.return %[[LEN64]] : i64
+}
+
+// CHECK-LABEL: llvm.func @string_length_literal()
+func.func @string_length_literal() -> i64 {
+  %str = sim.string.literal "hello"
+  %len = sim.string.length %str
+  return %len : i64
+  // CHECK: %[[STR:.+]] = llvm.mlir.addressof @_sim_str_0 : !llvm.ptr
+  // CHECK: %[[LEN32:.+]] = llvm.call @circt_sim_string_len(%[[STR]]) : (!llvm.ptr) -> i32
+  // CHECK: %[[LEN64:.+]] = llvm.zext %[[LEN32]] : i32 to i64
+  // CHECK: llvm.return %[[LEN64]] : i64
+}

--- a/test/Conversion/ArcToLLVM/sim-string-runtime.mlir
+++ b/test/Conversion/ArcToLLVM/sim-string-runtime.mlir
@@ -1,0 +1,59 @@
+// RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
+
+// CHECK-DAG: llvm.func @circt_sim_string_cmp(!llvm.ptr, !llvm.ptr) -> i32
+// CHECK-DAG: llvm.func @circt_sim_string_concat(!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+// CHECK-DAG: llvm.func @circt_sim_string_int_to_string(!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-DAG: llvm.func @circt_sim_string_get_char(!llvm.ptr, i32) -> i8
+// CHECK-DAG: llvm.func @circt_sim_string_substr(!llvm.ptr, i32, i32) -> !llvm.ptr
+
+// CHECK-LABEL: llvm.func @string_runtime(
+// CHECK-SAME:    %[[LHS:[^:]+]]: !llvm.ptr
+// CHECK-SAME:    %[[RHS:[^:]+]]: !llvm.ptr
+// CHECK-SAME:    %[[IDX:[^:]+]]: i32
+// CHECK-SAME:    %[[END:[^:]+]]: i32
+// CHECK-SAME:    %[[VALUE:[^:]+]]: i40
+func.func @string_runtime(%lhs: !sim.dstring, %rhs: !sim.dstring, %idx: i32, %end: i32, %value: i40) {
+  %cmp = sim.string.cmp %lhs, %rhs
+  %cat = sim.string.concat (%lhs, %rhs)
+  %legacy_ch = sim.string.get %lhs[%idx]
+  %ch = sim.string.get_char %lhs[%idx]
+  %sub = sim.string.substr %lhs[%idx : %end]
+  %str = sim.string.int_to_string %value : i40
+  return
+  // CHECK: llvm.call @circt_sim_string_cmp(%[[LHS]], %[[RHS]]) : (!llvm.ptr, !llvm.ptr) -> i32
+  // CHECK: llvm.call @circt_sim_string_concat(%[[LHS]], %[[RHS]]) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+  // CHECK: llvm.call @circt_sim_string_get_char(%[[LHS]], %[[IDX]]) : (!llvm.ptr, i32) -> i8
+  // CHECK: llvm.call @circt_sim_string_get_char(%[[LHS]], %[[IDX]]) : (!llvm.ptr, i32) -> i8
+  // CHECK: llvm.call @circt_sim_string_substr(%[[LHS]], %[[IDX]], %[[END]]) : (!llvm.ptr, i32, i32) -> !llvm.ptr
+  // CHECK: %[[BITS:.+]] = llvm.mlir.constant(40 : i32) : i32
+  // CHECK: llvm.call @circt_sim_string_int_to_string({{.*}}, %[[BITS]]) : (!llvm.ptr, i32) -> !llvm.ptr
+  // CHECK: llvm.return
+}
+
+// CHECK-LABEL: llvm.func @string_concat_zero()
+func.func @string_concat_zero() -> !sim.dstring {
+  %cat = sim.string.concat ()
+  return %cat : !sim.dstring
+  // CHECK: %[[EMPTY:.+]] = llvm.mlir.addressof @_sim_str_0 : !llvm.ptr
+  // CHECK: llvm.return %[[EMPTY]] : !llvm.ptr
+}
+
+// CHECK-LABEL: llvm.func @string_concat_single(
+// CHECK-SAME:    %[[LHS:[^:]+]]: !llvm.ptr
+func.func @string_concat_single(%lhs: !sim.dstring) -> !sim.dstring {
+  %cat = sim.string.concat (%lhs)
+  return %cat : !sim.dstring
+  // CHECK: llvm.return %[[LHS]] : !llvm.ptr
+}
+
+// CHECK-LABEL: llvm.func @string_int_to_string_i128(
+// CHECK-SAME:    %[[VALUE:[^:]+]]: i128
+func.func @string_int_to_string_i128(%value: i128) -> !sim.dstring {
+  %str = sim.string.int_to_string %value : i128
+  return %str : !sim.dstring
+  // CHECK: llvm.store
+  // CHECK: llvm.store
+  // CHECK: %[[BITS:.+]] = llvm.mlir.constant(128 : i32) : i32
+  // CHECK: llvm.call @circt_sim_string_int_to_string({{.*}}, %[[BITS]]) : (!llvm.ptr, i32) -> !llvm.ptr
+  // CHECK: llvm.return
+}

--- a/test/Dialect/Sim/format-strings.mlir
+++ b/test/Dialect/Sim/format-strings.mlir
@@ -136,6 +136,21 @@ hw.module @constant_fold3(in %zeroWitdh: i0, out res: !sim.fstring) {
   hw.output %cat : !sim.fstring
 }
 
+// CHECK-LABEL: hw.module @constant_fold_char_width
+// CHECK: sim.fmt.literal "[  A][A__][00A]"
+hw.module @constant_fold_char_width(out res: !sim.fstring) {
+  %ch = hw.constant 65 : i8
+  %open = sim.fmt.literal "["
+  %close = sim.fmt.literal "]"
+
+  %right = sim.fmt.char %ch specifierWidth 3 : i8
+  %left = sim.fmt.char %ch isLeftAligned true paddingChar 95 specifierWidth 3 : i8
+  %zero = sim.fmt.char %ch paddingChar 48 specifierWidth 3 : i8
+  %cat = sim.fmt.concat (%open, %right, %close, %open, %left, %close, %open, %zero, %close)
+
+  hw.output %cat : !sim.fstring
+}
+
 // CHECK-LABEL: hw.module @constant_fold4
 // CHECK: sim.fmt.literal "  106,106  ,   106,106   ,       106,106       ,       106,106       ;006A,6A  ,000006A,6A     ;000152,152   ,000000152,152      ;0000000001101010,1101010         ,0000000000001101010,1101010            "
 hw.module @constant_fold4(out res: !sim.fstring) {

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -90,15 +90,23 @@ func.func @FormatStrings() {
 }
 
 // CHECK-LABEL: func.func @DynamicStrings
-func.func @DynamicStrings(%idx: i32) {
+func.func @DynamicStrings(%idx: i32, %end: i32) {
   // CHECK: sim.string.literal "Hello"
   %str = sim.string.literal "Hello"
+  // CHECK: sim.string.literal "World"
+  %rhs = sim.string.literal "World"
   // CHECK: sim.string.length
   %len = sim.string.length %str
+  // CHECK: sim.string.cmp
+  %cmp = sim.string.cmp %str, %rhs
   // CHECK: sim.string.concat
   %concat = sim.string.concat (%str, %str)
   // CHECK: sim.string.get
   %char = sim.string.get %str[%idx]
+  // CHECK: sim.string.get_char
+  %char2 = sim.string.get_char %str[%idx]
+  // CHECK: sim.string.substr
+  %substr = sim.string.substr %str[%idx : %end]
   return
 }
 

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -80,12 +80,27 @@ func.func @SimulationControl() {
 
 // CHECK-LABEL: func.func @FormatStrings
 func.func @FormatStrings() {
+  %time = arith.constant 42 : i64
+  %int = arith.constant 42 : i8
+  %unknown = arith.constant 1 : i8
+  // CHECK: sim.fmt.int 10 0 0 %{{.*}} : i8
+  %fmt_int = sim.fmt.int 10 0 0 %int : i8
+  // CHECK: sim.fmt.fvint 2 0 0 %{{.*}}, %{{.*}} : i8
+  %fmt_fvint = sim.fmt.fvint 2 0 0 %int, %unknown : i8
+  // CHECK: sim.fmt.time %{{.*}}, width 3 : i64
+  %fmt_time = sim.fmt.time %time, width 3 : i64
+  // CHECK: sim.proc.timeformat -9, 2, " ns", 0
+  sim.proc.timeformat -9, 2, " ns", 0
   // CHECK: sim.fmt.current_time
   sim.fmt.current_time
   // CHECK: sim.fmt.hier_path
   sim.fmt.hier_path
   // CHECK: sim.fmt.hier_path escaped
   sim.fmt.hier_path escaped
+  // CHECK: sim.fmt.concat
+  %fmt = sim.fmt.concat (%fmt_int, %fmt_fvint, %fmt_time)
+  // CHECK: sim.fmt.to_string
+  %str = sim.fmt.to_string %fmt
   return
 }
 

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -334,6 +334,12 @@ static void bindArcRuntimeSymbols(ExecutionEngine &executionEngine) {
                               runtimeCallbacks.symNameFormat,
                               runtimeCallbacks.fnFormat);
     bindExecutionEngineSymbol(symbolMap, interner,
+                              runtimeCallbacks.symNameFormatToString,
+                              runtimeCallbacks.fnFormatToString);
+    bindExecutionEngineSymbol(symbolMap, interner,
+                              runtimeCallbacks.symNameSetTimeFormat,
+                              runtimeCallbacks.fnSetTimeFormat);
+    bindExecutionEngineSymbol(symbolMap, interner,
                               runtimeCallbacks.symNameSwapTraceBuffer,
                               runtimeCallbacks.fnSwapTraceBuffer);
     return symbolMap;

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -79,9 +79,11 @@
 #define ARC_RUNTIME_JITBIND_FNDECL
 #include "circt/Dialect/Arc/Runtime/Common.h"
 #include "circt/Dialect/Arc/Runtime/JITBind.h"
+#include "circt/Dialect/Arc/Runtime/SimString.h"
 #endif
 
 #include <optional>
+#include <tuple>
 
 using namespace mlir;
 using namespace circt;
@@ -302,6 +304,16 @@ static void bindExecutionEngineSymbol(llvm::orc::SymbolMap &symbolMap,
                                   llvm::JITSymbolFlags::Exported};
 }
 
+template <typename RuntimeSymbols>
+static void bindRuntimeSymbolTuple(llvm::orc::SymbolMap &symbolMap,
+                                   llvm::orc::MangleAndInterner &interner,
+                                   const RuntimeSymbols &symbols) {
+  auto bindSymbol = [&](const auto &sym) {
+    bindExecutionEngineSymbol(symbolMap, interner, sym.name, sym.addr);
+  };
+  std::apply([&](const auto &...sym) { (bindSymbol(sym), ...); }, symbols);
+}
+
 static void bindArcRuntimeSymbols(ExecutionEngine &executionEngine) {
   auto &runtimeCallbacks = runtime::getArcRuntimeAPICallbacks();
   executionEngine.registerSymbols([&](llvm::orc::MangleAndInterner interner) {
@@ -324,6 +336,16 @@ static void bindArcRuntimeSymbols(ExecutionEngine &executionEngine) {
     bindExecutionEngineSymbol(symbolMap, interner,
                               runtimeCallbacks.symNameSwapTraceBuffer,
                               runtimeCallbacks.fnSwapTraceBuffer);
+    return symbolMap;
+  });
+}
+
+// Bind sim dialect runtime symbols to the JIT execution engine.
+static void bindArcSimRuntimeSymbols(ExecutionEngine &executionEngine) {
+  executionEngine.registerSymbols([&](llvm::orc::MangleAndInterner interner) {
+    llvm::orc::SymbolMap symbolMap;
+    bindRuntimeSymbolTuple(symbolMap, interner,
+                           runtime::getSimStringRuntimeSymbols());
     return symbolMap;
   });
 }
@@ -545,8 +567,10 @@ static LogicalResult processBuffer(
       return failure();
     }
 
-    if (!noJitRuntime)
+    if (!noJitRuntime) {
       bindArcRuntimeSymbols(**executionEngine);
+      bindArcSimRuntimeSymbols(**executionEngine);
+    }
 
     auto expectedFunc = (*executionEngine)->lookupPacked(jitEntryPoint);
     if (!expectedFunc) {


### PR DESCRIPTION
Stacked on #10643 (which stacks on #10642) — please review/merge those first; the parent commits show here until they land, after which this rebases to a single commit.

Adds the integer-formatting half of the SystemVerilog runtime's `$display` support, bound into the arcilator JIT:

- `circt_sv_print_int` — two-state integer in bases 2/8/10/16, honoring the shared formatting-flag bitmask (uppercase / left-justify / zero-pad / signed) and a minimum field width.
- `circt_sv_print_fvint` — four-state integer: unknown bits render as `x`/`z`; with no unknown bits it delegates to `circt_sv_print_int`.

Both read little-endian bit data and write to stdout. The bit-extraction helpers are file-local; only the two formatting entry points are exported and registered.

The JIT integration test (`integration_test/arcilator/JIT/sv-runtime-print.mlir`) renders values across all four bases plus the uppercase/signed flags and the four-state `x` path, checking the concatenated `arcilator --run` output.