### PR TITLE
[Arc] Add $timeformat rendering to the SV runtime

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/SVRuntime.h
+++ b/include/circt/Dialect/Arc/Runtime/SVRuntime.h
@@ -38,6 +38,21 @@ uint8_t circt_sv_string_getc(const char *str, int32_t idx);
 /// returned as "".
 const char *circt_sv_string_substr(const char *str, int32_t start, int32_t end);
 
+/// Print a two-state integer to `stdout`. `data` points at `bitWidth` bits in
+/// little-endian byte order; `base` is 2/8/10/16; `minWidth` is the minimum
+/// field width; `flags` is a bitmask shared with the backend's console lowering
+/// (bit 0 uppercase, bit 1 left-justify, bit 2 zero-pad, bit 3 signed).
+void circt_sv_print_int(const void *data, int32_t bitWidth, int32_t base,
+                        int32_t minWidth, int32_t flags);
+
+/// Print a four-state integer to `stdout`. Like `circt_sv_print_int`, but
+/// `unknownData` carries the per-bit unknown mask: a set unknown bit prints `x`
+/// (or `z` when the corresponding value bit is set). With no unknown bits this
+/// delegates to `circt_sv_print_int`.
+void circt_sv_print_fvint(const void *valueData, const void *unknownData,
+                          int32_t bitWidth, int32_t base, int32_t minWidth,
+                          int32_t flags);
+
 } // extern "C"
 
 namespace circt {

--- a/include/circt/Dialect/Arc/Runtime/SVRuntime.h
+++ b/include/circt/Dialect/Arc/Runtime/SVRuntime.h
@@ -1,0 +1,53 @@
+//===- SVRuntime.h - SystemVerilog execution runtime ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Declares the SystemVerilog execution runtime: leaf C functions that lowered
+// models call (via `func.call`) to evaluate dynamic SystemVerilog constructs
+// which have no fixed-width hardware lowering (strings, dynamic containers,
+// ...). They are statically linked into arcilator and bound to the JIT
+// alongside the core Arc runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ARC_RUNTIME_SVRUNTIME_H
+#define CIRCT_DIALECT_ARC_RUNTIME_SVRUNTIME_H
+
+#include <cstdint>
+
+extern "C" {
+
+/// Return the length of a NUL-terminated string (a null pointer is treated as
+/// the empty string).
+int32_t circt_sv_string_len(const char *str);
+
+} // extern "C"
+
+namespace circt {
+namespace arc {
+namespace runtime {
+
+/// A single JIT-bindable SystemVerilog runtime symbol: its name and the address
+/// of its `extern "C"` implementation, held as a generic function pointer so
+/// `ExecutorAddr::fromPtr` keeps the function-pointer unwrap (e.g. the correct
+/// pointer-authentication strip) rather than the data-pointer one.
+struct SVRuntimeSymbol {
+  const char *name;
+  void (*addr)();
+};
+
+#ifdef ARC_RUNTIME_JITBIND_FNDECL
+/// Return the table of SystemVerilog runtime symbols to register with the JIT,
+/// terminated by a `{nullptr, nullptr}` sentinel.
+const SVRuntimeSymbol *getSVRuntimeSymbols();
+#endif // ARC_RUNTIME_JITBIND_FNDECL
+
+} // namespace runtime
+} // namespace arc
+} // namespace circt
+
+#endif // CIRCT_DIALECT_ARC_RUNTIME_SVRUNTIME_H

--- a/include/circt/Dialect/Arc/Runtime/SVRuntime.h
+++ b/include/circt/Dialect/Arc/Runtime/SVRuntime.h
@@ -53,6 +53,18 @@ void circt_sv_print_fvint(const void *valueData, const void *unknownData,
                           int32_t bitWidth, int32_t base, int32_t minWidth,
                           int32_t flags);
 
+/// Set the global `$timeformat` state used by `circt_sv_print_time` (the `%t`
+/// format specifier): `unit` is the base-10 exponent of the time unit (clamped
+/// to -15..0), `precision` the number of fractional digits, `suffix` an
+/// optional unit string, and `minFieldWidth` the minimum field width.
+void circt_sv_set_timeformat(int32_t unit, int32_t precision,
+                             const char *suffix, int32_t minFieldWidth);
+
+/// Print a femtosecond time value to `stdout` using the current `$timeformat`
+/// state. `widthOverride` overrides the configured minimum field width when
+/// non-negative.
+void circt_sv_print_time(int64_t timeFs, int32_t widthOverride);
+
 } // extern "C"
 
 namespace circt {

--- a/include/circt/Dialect/Arc/Runtime/SVRuntime.h
+++ b/include/circt/Dialect/Arc/Runtime/SVRuntime.h
@@ -25,6 +25,19 @@ extern "C" {
 /// the empty string).
 int32_t circt_sv_string_len(const char *str);
 
+/// Compare two NUL-terminated strings (each null pointer is treated as the
+/// empty string), returning the result of `strcmp`.
+int32_t circt_sv_strcmp(const char *lhs, const char *rhs);
+
+/// Return the byte at index `idx` of a NUL-terminated string, or 0 if the
+/// index is out of range or the string is null.
+uint8_t circt_sv_string_getc(const char *str, int32_t idx);
+
+/// Return the substring `str[start..end]` (inclusive) as a freshly allocated
+/// NUL-terminated string. Out-of-range bounds are clamped; an empty result is
+/// returned as "".
+const char *circt_sv_string_substr(const char *str, int32_t start, int32_t end);
+
 } // extern "C"
 
 namespace circt {

--- a/integration_test/arcilator/JIT/sv-runtime-print.mlir
+++ b/integration_test/arcilator/JIT/sv-runtime-print.mlir
@@ -1,0 +1,53 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck %s
+// REQUIRES: arcilator-jit
+
+// Exercise the SystemVerilog integer-formatting runtime bound into the JIT.
+// Each call writes to stdout with no separator, so the checks below match the
+// concatenation of every print in order.
+
+llvm.mlir.global internal constant @b42(42 : i8) : i8
+llvm.mlir.global internal constant @bff(-1 : i8) : i8
+llvm.mlir.global internal constant @b10(10 : i8) : i8
+llvm.mlir.global internal constant @fval(2 : i8) : i8
+llvm.mlir.global internal constant @funk(1 : i8) : i8
+
+func.func private @circt_sv_print_int(!llvm.ptr, i32, i32, i32, i32)
+func.func private @circt_sv_print_fvint(!llvm.ptr, !llvm.ptr, i32, i32, i32, i32)
+
+func.func @entry() {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %c4 = arith.constant 4 : i32
+  %c8 = arith.constant 8 : i32
+  %c10 = arith.constant 10 : i32
+  %c16 = arith.constant 16 : i32
+
+  %b42 = llvm.mlir.addressof @b42 : !llvm.ptr
+  %bff = llvm.mlir.addressof @bff : !llvm.ptr
+  %b10 = llvm.mlir.addressof @b10 : !llvm.ptr
+  %fval = llvm.mlir.addressof @fval : !llvm.ptr
+  %funk = llvm.mlir.addressof @funk : !llvm.ptr
+
+  // 42 as i8, base 10 -> "42"
+  func.call @circt_sv_print_int(%b42, %c8, %c10, %c0, %c0)
+      : (!llvm.ptr, i32, i32, i32, i32) -> ()
+  // 0xFF as i8, base 16 lowercase -> "ff"
+  func.call @circt_sv_print_int(%bff, %c8, %c16, %c0, %c0)
+      : (!llvm.ptr, i32, i32, i32, i32) -> ()
+  // 0xFF as i8, base 16 uppercase (flag bit0) -> "FF"
+  func.call @circt_sv_print_int(%bff, %c8, %c16, %c0, %c1)
+      : (!llvm.ptr, i32, i32, i32, i32) -> ()
+  // low 4 bits of 0x0A, base 2 -> "1010"
+  func.call @circt_sv_print_int(%b10, %c4, %c2, %c0, %c0)
+      : (!llvm.ptr, i32, i32, i32, i32) -> ()
+  // 0xFF as signed i8, base 10 (flag bit3) -> "-1"
+  func.call @circt_sv_print_int(%bff, %c8, %c10, %c0, %c8)
+      : (!llvm.ptr, i32, i32, i32, i32) -> ()
+  // i2 value 0b10 with unknown mask 0b01, base 2 -> "1x"
+  func.call @circt_sv_print_fvint(%fval, %funk, %c2, %c2, %c0, %c0)
+      : (!llvm.ptr, !llvm.ptr, i32, i32, i32, i32) -> ()
+
+  // CHECK: 42ffFF1010-11x
+  return
+}

--- a/integration_test/arcilator/JIT/sv-runtime-string.mlir
+++ b/integration_test/arcilator/JIT/sv-runtime-string.mlir
@@ -1,17 +1,42 @@
 // RUN: arcilator --run %s --jit-entry=entry | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
 
-// Exercise the SystemVerilog execution runtime bound into the JIT: a model that
-// calls `circt_sv_string_len` and emits the result.
+// Exercise the SystemVerilog string runtime bound into the JIT.
 
 llvm.mlir.global internal constant @hello("hello\00")
+llvm.mlir.global internal constant @world("world\00")
 
 func.func private @circt_sv_string_len(!llvm.ptr) -> i32
+func.func private @circt_sv_strcmp(!llvm.ptr, !llvm.ptr) -> i32
+func.func private @circt_sv_string_getc(!llvm.ptr, i32) -> i8
+func.func private @circt_sv_string_substr(!llvm.ptr, i32, i32) -> !llvm.ptr
 
 func.func @entry() {
-  %p = llvm.mlir.addressof @hello : !llvm.ptr
-  %len = func.call @circt_sv_string_len(%p) : (!llvm.ptr) -> i32
+  %hello = llvm.mlir.addressof @hello : !llvm.ptr
+  %world = llvm.mlir.addressof @world : !llvm.ptr
+
   // CHECK: len = 00000005
+  %len = func.call @circt_sv_string_len(%hello) : (!llvm.ptr) -> i32
   arc.sim.emit "len", %len : i32
+
+  // strcmp("hello", "hello") == 0
+  // CHECK: eq = 00000000
+  %eq = func.call @circt_sv_strcmp(%hello, %hello) : (!llvm.ptr, !llvm.ptr) -> i32
+  arc.sim.emit "eq", %eq : i32
+
+  // "hello"[1] == 'e' == 0x65
+  %c1 = arith.constant 1 : i32
+  // CHECK: getc = 65
+  %ch = func.call @circt_sv_string_getc(%hello, %c1) : (!llvm.ptr, i32) -> i8
+  arc.sim.emit "getc", %ch : i8
+
+  // substr("hello", 1, 3) == "ell"; check via its length.
+  %c3 = arith.constant 3 : i32
+  %sub = func.call @circt_sv_string_substr(%hello, %c1, %c3)
+      : (!llvm.ptr, i32, i32) -> !llvm.ptr
+  // CHECK: sublen = 00000003
+  %sublen = func.call @circt_sv_string_len(%sub) : (!llvm.ptr) -> i32
+  arc.sim.emit "sublen", %sublen : i32
+
   return
 }

--- a/integration_test/arcilator/JIT/sv-runtime-string.mlir
+++ b/integration_test/arcilator/JIT/sv-runtime-string.mlir
@@ -1,0 +1,17 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
+// Exercise the SystemVerilog execution runtime bound into the JIT: a model that
+// calls `circt_sv_string_len` and emits the result.
+
+llvm.mlir.global internal constant @hello("hello\00")
+
+func.func private @circt_sv_string_len(!llvm.ptr) -> i32
+
+func.func @entry() {
+  %p = llvm.mlir.addressof @hello : !llvm.ptr
+  %len = func.call @circt_sv_string_len(%p) : (!llvm.ptr) -> i32
+  // CHECK: len = 00000005
+  arc.sim.emit "len", %len : i32
+  return
+}

--- a/integration_test/arcilator/JIT/sv-runtime-time.mlir
+++ b/integration_test/arcilator/JIT/sv-runtime-time.mlir
@@ -1,0 +1,29 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck %s
+// REQUIRES: arcilator-jit
+
+// Exercise the SystemVerilog $timeformat runtime bound into the JIT: configure
+// nanosecond units with two fractional digits and a " ns" suffix, then render a
+// femtosecond time value (1500000 fs == 1.5 ns).
+
+llvm.mlir.global internal constant @suffix(" ns\00")
+
+func.func private @circt_sv_set_timeformat(i32, i32, !llvm.ptr, i32)
+func.func private @circt_sv_print_time(i64, i32)
+
+func.func @entry() {
+  %unit = arith.constant -9 : i32
+  %prec = arith.constant 2 : i32
+  %width = arith.constant 0 : i32
+  %suffix = llvm.mlir.addressof @suffix : !llvm.ptr
+
+  // set_timeformat(unit = -9 (ns), precision = 2, suffix = " ns", width = 0)
+  func.call @circt_sv_set_timeformat(%unit, %prec, %suffix, %width)
+      : (i32, i32, !llvm.ptr, i32) -> ()
+
+  %time = arith.constant 1500000 : i64
+  %override = arith.constant -1 : i32
+  // CHECK: 1.50 ns
+  func.call @circt_sv_print_time(%time, %override) : (i64, i32) -> ()
+
+  return
+}

--- a/lib/Dialect/Arc/Runtime/CMakeLists.txt
+++ b/lib/Dialect/Arc/Runtime/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(ArcRuntimeLibSources
   ArcRuntime.cpp
   ModelInstance.cpp
+  SVRuntime.cpp
   TraceEncoder.cpp
   VCDTraceEncoder.cpp
 )
@@ -38,6 +39,7 @@ endif()
 install(FILES
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/ArcRuntime.h
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/Common.h
+  ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Arc/Runtime/SVRuntime.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/circt/Dialect/Arc/Runtime
   COMPONENT CIRCTArcRuntime
 )

--- a/lib/Dialect/Arc/Runtime/SVRuntime.cpp
+++ b/lib/Dialect/Arc/Runtime/SVRuntime.cpp
@@ -1,0 +1,41 @@
+//===- SVRuntime.cpp - SystemVerilog execution runtime --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements the SystemVerilog execution runtime. See SVRuntime.h. Functions
+// here are plain `extern "C"` leaf utilities; the JIT-binding table at the
+// bottom is only compiled into the copy linked into arcilator
+// (ARC_RUNTIME_JIT_BIND).
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/Runtime/SVRuntime.h"
+
+#include <cstring>
+
+extern "C" int32_t circt_sv_string_len(const char *str) {
+  if (!str)
+    return 0;
+  return static_cast<int32_t>(std::strlen(str));
+}
+
+#ifdef ARC_RUNTIME_JIT_BIND
+namespace circt {
+namespace arc {
+namespace runtime {
+
+static const SVRuntimeSymbol svRuntimeSymbols[] = {
+    {"circt_sv_string_len", reinterpret_cast<void (*)()>(&circt_sv_string_len)},
+    {nullptr, nullptr},
+};
+
+const SVRuntimeSymbol *getSVRuntimeSymbols() { return svRuntimeSymbols; }
+
+} // namespace runtime
+} // namespace arc
+} // namespace circt
+#endif // ARC_RUNTIME_JIT_BIND

--- a/lib/Dialect/Arc/Runtime/SVRuntime.cpp
+++ b/lib/Dialect/Arc/Runtime/SVRuntime.cpp
@@ -89,6 +89,33 @@ uint8_t getBitLE(const uint8_t *bytes, uint32_t bitIndex) {
   return (bytes[bitIndex / 8] >> (bitIndex % 8)) & 1u;
 }
 
+uint64_t pow10u64(uint32_t exp) {
+  static const uint64_t kPow10[] = {
+      1ull,
+      10ull,
+      100ull,
+      1000ull,
+      10000ull,
+      100000ull,
+      1000000ull,
+      10000000ull,
+      100000000ull,
+      1000000000ull,
+      10000000000ull,
+      100000000000ull,
+      1000000000000ull,
+      10000000000000ull,
+      100000000000000ull,
+      1000000000000000ull,
+      10000000000000000ull,
+      100000000000000000ull,
+      1000000000000000000ull,
+  };
+  if (exp >= (sizeof(kPow10) / sizeof(kPow10[0])))
+    return 0;
+  return kPow10[exp];
+}
+
 uint32_t getBitsLEMasked(const uint8_t *bytes, uint32_t bitWidth,
                          uint32_t bitIndex, uint32_t bitCount) {
   uint32_t out = 0;
@@ -381,6 +408,107 @@ extern "C" void circt_sv_print_fvint(const void *valueData,
   emitPadded(out, minWidth, leftJustify, padChar);
 }
 
+//===----------------------------------------------------------------------===//
+// `$timeformat` / `%t`
+//===----------------------------------------------------------------------===//
+
+namespace {
+// Global `$timeformat` state used by `%t`.
+int32_t timeformatUnit = -15;      // femtoseconds
+int32_t timeformatPrecision = 0;   // digits after the decimal point
+const char *timeformatSuffix = ""; // no suffix by default
+int32_t timeformatMinWidth = 20;   // slang-style default
+} // namespace
+
+extern "C" void circt_sv_set_timeformat(int32_t unit, int32_t precision,
+                                        const char *suffix,
+                                        int32_t minFieldWidth) {
+  // Clamp to the IEEE 1800 ranges.
+  if (unit < -15)
+    unit = -15;
+  if (unit > 0)
+    unit = 0;
+  if (precision < 0)
+    precision = 0;
+  if (precision > 18)
+    precision = 18;
+  if (minFieldWidth < 0)
+    minFieldWidth = 0;
+
+  timeformatUnit = unit;
+  timeformatPrecision = precision;
+  timeformatSuffix = suffix ? suffix : "";
+  timeformatMinWidth = minFieldWidth;
+}
+
+extern "C" void circt_sv_print_time(int64_t timeFs, int32_t widthOverride) {
+  int32_t unit = timeformatUnit;
+  int32_t precision = timeformatPrecision;
+  const char *suffix = timeformatSuffix ? timeformatSuffix : "";
+
+  int32_t fieldWidth = widthOverride >= 0 ? widthOverride : timeformatMinWidth;
+  if (fieldWidth < 0)
+    fieldWidth = 0;
+  if (precision < 0)
+    precision = 0;
+  if (precision > 18)
+    precision = 18;
+
+  bool neg = timeFs < 0;
+  uint64_t absFs;
+  if (neg)
+    absFs = static_cast<uint64_t>(-(timeFs + 1)) + 1; // avoid INT64_MIN UB
+  else
+    absFs = static_cast<uint64_t>(timeFs);
+
+  // Render `absFs * 10^(precision - unitPow)`, rounded to nearest. Both the
+  // unit scale and the precision scale are powers of ten, so the wide multiply
+  // in the naive formula cancels: when precision >= unitPow it is an exact
+  // multiply, otherwise it is a divide-by-power-of-ten with round-to-nearest.
+  // This keeps everything in uint64 (no `__int128`, which MSVC lacks).
+  uint32_t unitPow = static_cast<uint32_t>(unit + 15);
+  uint64_t scale = pow10u64(static_cast<uint32_t>(precision));
+  if (scale == 0)
+    scale = 1;
+
+  uint64_t scaled;
+  if (static_cast<uint32_t>(precision) >= unitPow) {
+    uint64_t factor = pow10u64(static_cast<uint32_t>(precision) - unitPow);
+    if (factor == 0)
+      factor = 1;
+    scaled = absFs * factor;
+  } else {
+    uint64_t divisor = pow10u64(unitPow - static_cast<uint32_t>(precision));
+    if (divisor == 0)
+      divisor = 1;
+    scaled = (absFs + divisor / 2) / divisor;
+  }
+
+  uint64_t intPart = precision == 0 ? scaled : (scaled / scale);
+  uint64_t fracPart = precision == 0 ? 0 : (scaled % scale);
+
+  std::string num;
+  if (neg)
+    num.push_back('-');
+  num.append(std::to_string(intPart));
+  if (precision > 0) {
+    num.push_back('.');
+    auto fracStr = std::to_string(fracPart);
+    if (fracStr.size() < static_cast<size_t>(precision))
+      num.append(static_cast<size_t>(precision) - fracStr.size(), '0');
+    num.append(fracStr);
+  }
+
+  if (fieldWidth > 0 && static_cast<int32_t>(num.size()) < fieldWidth) {
+    int32_t padCount = fieldWidth - static_cast<int32_t>(num.size());
+    for (int32_t i = 0; i < padCount; ++i)
+      std::fputc(' ', stdout);
+  }
+  std::fwrite(num.data(), 1, num.size(), stdout);
+  if (suffix && *suffix)
+    std::fputs(suffix, stdout);
+}
+
 #ifdef ARC_RUNTIME_JIT_BIND
 namespace circt {
 namespace arc {
@@ -396,6 +524,9 @@ static const SVRuntimeSymbol svRuntimeSymbols[] = {
     {"circt_sv_print_int", reinterpret_cast<void (*)()>(&circt_sv_print_int)},
     {"circt_sv_print_fvint",
      reinterpret_cast<void (*)()>(&circt_sv_print_fvint)},
+    {"circt_sv_set_timeformat",
+     reinterpret_cast<void (*)()>(&circt_sv_set_timeformat)},
+    {"circt_sv_print_time", reinterpret_cast<void (*)()>(&circt_sv_print_time)},
     {nullptr, nullptr},
 };
 

--- a/lib/Dialect/Arc/Runtime/SVRuntime.cpp
+++ b/lib/Dialect/Arc/Runtime/SVRuntime.cpp
@@ -15,12 +15,58 @@
 
 #include "circt/Dialect/Arc/Runtime/SVRuntime.h"
 
+#include <cstdlib>
 #include <cstring>
 
 extern "C" int32_t circt_sv_string_len(const char *str) {
   if (!str)
     return 0;
   return static_cast<int32_t>(std::strlen(str));
+}
+
+extern "C" int32_t circt_sv_strcmp(const char *lhs, const char *rhs) {
+  if (!lhs)
+    lhs = "";
+  if (!rhs)
+    rhs = "";
+  return std::strcmp(lhs, rhs);
+}
+
+extern "C" uint8_t circt_sv_string_getc(const char *str, int32_t idx) {
+  if (!str || idx < 0)
+    return 0;
+  size_t len = std::strlen(str);
+  size_t pos = static_cast<size_t>(idx);
+  if (pos >= len)
+    return 0;
+  return static_cast<uint8_t>(static_cast<unsigned char>(str[pos]));
+}
+
+extern "C" const char *circt_sv_string_substr(const char *str, int32_t start,
+                                              int32_t end) {
+  if (!str)
+    str = "";
+  if (start < 0)
+    start = 0;
+  if (end < start)
+    return "";
+
+  size_t len = std::strlen(str);
+  size_t startPos = static_cast<size_t>(start);
+  if (startPos >= len)
+    return "";
+
+  size_t endPos = static_cast<size_t>(end);
+  if (endPos >= len)
+    endPos = len - 1;
+
+  size_t outLen = endPos - startPos + 1;
+  char *out = static_cast<char *>(std::malloc(outLen + 1));
+  if (!out)
+    return "";
+  std::memcpy(out, str + startPos, outLen);
+  out[outLen] = '\0';
+  return out;
 }
 
 #ifdef ARC_RUNTIME_JIT_BIND
@@ -30,6 +76,11 @@ namespace runtime {
 
 static const SVRuntimeSymbol svRuntimeSymbols[] = {
     {"circt_sv_string_len", reinterpret_cast<void (*)()>(&circt_sv_string_len)},
+    {"circt_sv_strcmp", reinterpret_cast<void (*)()>(&circt_sv_strcmp)},
+    {"circt_sv_string_getc",
+     reinterpret_cast<void (*)()>(&circt_sv_string_getc)},
+    {"circt_sv_string_substr",
+     reinterpret_cast<void (*)()>(&circt_sv_string_substr)},
     {nullptr, nullptr},
 };
 

--- a/lib/Dialect/Arc/Runtime/SVRuntime.cpp
+++ b/lib/Dialect/Arc/Runtime/SVRuntime.cpp
@@ -15,8 +15,12 @@
 
 #include "circt/Dialect/Arc/Runtime/SVRuntime.h"
 
+#include <algorithm>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
+#include <vector>
 
 extern "C" int32_t circt_sv_string_len(const char *str) {
   if (!str)
@@ -69,6 +73,314 @@ extern "C" const char *circt_sv_string_substr(const char *str, int32_t start,
   return out;
 }
 
+//===----------------------------------------------------------------------===//
+// Integer formatting (`$display`-style)
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// Backend-defined formatting flags; keep in sync with the console lowering.
+constexpr int32_t kFmtUppercase = 1 << 0;
+constexpr int32_t kFmtLeftJustify = 1 << 1;
+constexpr int32_t kFmtPadZero = 1 << 2;
+constexpr int32_t kFmtSigned = 1 << 3;
+
+uint8_t getBitLE(const uint8_t *bytes, uint32_t bitIndex) {
+  return (bytes[bitIndex / 8] >> (bitIndex % 8)) & 1u;
+}
+
+uint32_t getBitsLEMasked(const uint8_t *bytes, uint32_t bitWidth,
+                         uint32_t bitIndex, uint32_t bitCount) {
+  uint32_t out = 0;
+  for (uint32_t i = 0; i < bitCount; ++i) {
+    uint32_t b = bitIndex + i;
+    if (b >= bitWidth)
+      break;
+    out |= static_cast<uint32_t>(getBitLE(bytes, b)) << i;
+  }
+  return out;
+}
+
+// Emit `out` to stdout with the requested minimum field width / justification,
+// after trimming the leading zeros produced by the per-base digit loops.
+void emitPadded(std::string &out, int32_t minWidth, bool leftJustify,
+                char padChar) {
+  size_t firstNonZero = out.find_first_not_of('0');
+  if (firstNonZero == std::string::npos)
+    out.erase(0, out.size() - 1);
+  else if (firstNonZero > 0)
+    out.erase(0, firstNonZero);
+
+  int32_t padCount = 0;
+  if (minWidth > 0 && static_cast<int32_t>(out.size()) < minWidth)
+    padCount = minWidth - static_cast<int32_t>(out.size());
+  if (!leftJustify)
+    for (int32_t i = 0; i < padCount; ++i)
+      std::fputc(padChar, stdout);
+  std::fwrite(out.data(), 1, out.size(), stdout);
+  if (leftJustify)
+    for (int32_t i = 0; i < padCount; ++i)
+      std::fputc(padChar, stdout);
+}
+
+} // namespace
+
+extern "C" void circt_sv_print_int(const void *data, int32_t bitWidth,
+                                   int32_t base, int32_t minWidth,
+                                   int32_t flags) {
+  if (bitWidth < 0)
+    bitWidth = 0;
+  if (minWidth < 0)
+    minWidth = 0;
+
+  const bool uppercase = (flags & kFmtUppercase) != 0;
+  const bool leftJustify = (flags & kFmtLeftJustify) != 0;
+  const bool padZero = (flags & kFmtPadZero) != 0;
+  const bool isSigned = (flags & kFmtSigned) != 0;
+  char padChar = padZero ? '0' : ' ';
+
+  // Handle zero-width integers.
+  if (bitWidth == 0) {
+    if (base == 10)
+      std::fputc('0', stdout);
+    return;
+  }
+
+  uint32_t bw = static_cast<uint32_t>(bitWidth);
+  auto numBytes = static_cast<uint32_t>((bw + 7u) / 8u);
+  const auto *bytes = static_cast<const uint8_t *>(data);
+  if (!bytes) {
+    static const uint8_t zero = 0;
+    bytes = &zero;
+    numBytes = 1;
+  }
+
+  std::string out;
+  switch (base) {
+  case 2:
+    out.reserve(bw);
+    for (uint32_t b = bw; b > 0; --b)
+      out.push_back(getBitLE(bytes, b - 1) ? '1' : '0');
+    break;
+  case 8: {
+    uint32_t digits = (bw + 2u) / 3u;
+    out.reserve(digits);
+    for (uint32_t d = digits; d > 0; --d)
+      out.push_back(static_cast<char>(
+          '0' + getBitsLEMasked(bytes, bw, (d - 1) * 3u, 3u)));
+    break;
+  }
+  case 16: {
+    uint32_t digits = (bw + 3u) / 4u;
+    out.reserve(digits);
+    for (uint32_t d = digits; d > 0; --d) {
+      uint32_t digit = getBitsLEMasked(bytes, bw, (d - 1) * 4u, 4u);
+      if (digit < 10)
+        out.push_back(static_cast<char>('0' + digit));
+      else
+        out.push_back(
+            static_cast<char>((uppercase ? 'A' : 'a') + (digit - 10)));
+    }
+    break;
+  }
+  case 10: {
+    uint32_t limbs = (bw + 31u) / 32u;
+    std::vector<uint32_t> value(limbs, 0);
+    for (uint32_t i = 0; i < limbs; ++i) {
+      uint32_t limb = 0;
+      for (uint32_t b = 0; b < 4; ++b) {
+        uint32_t byteIdx = i * 4u + b;
+        if (byteIdx < numBytes)
+          limb |= static_cast<uint32_t>(bytes[byteIdx]) << (8u * b);
+      }
+      value[i] = limb;
+    }
+    auto maskTop = [&]() {
+      if (bw % 32u) {
+        uint32_t bitsInTop = bw % 32u;
+        value.back() &= (1u << bitsInTop) - 1u;
+      }
+    };
+    maskTop();
+
+    bool neg = isSigned && getBitLE(bytes, bw - 1u) != 0;
+    if (neg) {
+      for (auto &limb : value)
+        limb = ~limb;
+      maskTop();
+      uint64_t carry = 1;
+      for (auto &limb : value) {
+        uint64_t sum = static_cast<uint64_t>(limb) + carry;
+        limb = static_cast<uint32_t>(sum);
+        carry = sum >> 32;
+        if (!carry)
+          break;
+      }
+    }
+
+    auto isZero = [&]() {
+      for (auto limb : value)
+        if (limb != 0)
+          return false;
+      return true;
+    };
+
+    std::string digits;
+    if (isZero()) {
+      digits = "0";
+    } else {
+      while (!isZero()) {
+        uint64_t rem = 0;
+        for (uint32_t i = value.size(); i > 0; --i) {
+          uint64_t cur = (rem << 32) | value[i - 1];
+          value[i - 1] = static_cast<uint32_t>(cur / 10);
+          rem = cur % 10;
+        }
+        digits.push_back(static_cast<char>('0' + rem));
+      }
+      std::reverse(digits.begin(), digits.end());
+    }
+
+    if (neg)
+      out.push_back('-');
+    out.append(digits);
+    break;
+  }
+  default:
+    std::fputs("<unsupported base>", stdout);
+    return;
+  }
+
+  emitPadded(out, minWidth, leftJustify, padChar);
+}
+
+extern "C" void circt_sv_print_fvint(const void *valueData,
+                                     const void *unknownData, int32_t bitWidth,
+                                     int32_t base, int32_t minWidth,
+                                     int32_t flags) {
+  if (bitWidth < 0)
+    bitWidth = 0;
+  if (minWidth < 0)
+    minWidth = 0;
+
+  const bool uppercase = (flags & kFmtUppercase) != 0;
+  const bool leftJustify = (flags & kFmtLeftJustify) != 0;
+  const bool padZero = (flags & kFmtPadZero) != 0;
+  char padChar = padZero ? '0' : ' ';
+
+  // Handle zero-width integers.
+  if (bitWidth == 0) {
+    if (base == 10)
+      std::fputc('0', stdout);
+    return;
+  }
+
+  uint32_t bw = static_cast<uint32_t>(bitWidth);
+  uint32_t numBytes = static_cast<uint32_t>((bw + 7u) / 8u);
+  const auto *valueBytes = static_cast<const uint8_t *>(valueData);
+  const auto *unknownBytes = static_cast<const uint8_t *>(unknownData);
+  static const uint8_t zero = 0;
+  if (!valueBytes)
+    valueBytes = &zero;
+  if (!unknownBytes)
+    unknownBytes = &zero;
+
+  bool anyUnknown = false;
+  for (uint32_t i = 0; i < numBytes; ++i)
+    if (unknownBytes[i] != 0) {
+      anyUnknown = true;
+      break;
+    }
+
+  // Fast path: no unknown bits, so it formats like a two-state value.
+  if (!anyUnknown) {
+    circt_sv_print_int(valueBytes, bitWidth, base, minWidth, flags);
+    return;
+  }
+
+  std::string out;
+  switch (base) {
+  case 2:
+    out.reserve(bw);
+    for (uint32_t b = bw; b > 0; --b) {
+      if (!getBitLE(unknownBytes, b - 1)) {
+        out.push_back(getBitLE(valueBytes, b - 1) ? '1' : '0');
+      } else {
+        bool isZ = getBitLE(valueBytes, b - 1) != 0;
+        out.push_back(isZ ? (uppercase ? 'Z' : 'z') : (uppercase ? 'X' : 'x'));
+      }
+    }
+    break;
+  case 8:
+  case 16: {
+    const uint32_t groupBits = base == 8 ? 3u : 4u;
+    uint32_t digits = (bw + (groupBits - 1u)) / groupBits;
+    out.reserve(digits);
+    for (uint32_t d = digits; d > 0; --d) {
+      uint32_t startBit = (d - 1u) * groupBits;
+      uint32_t bitsThisDigit =
+          std::min(groupBits, bw > startBit ? (bw - startBit) : 0u);
+      if (bitsThisDigit == 0) {
+        out.push_back('0');
+        continue;
+      }
+      uint32_t digitUnknown =
+          getBitsLEMasked(unknownBytes, bw, startBit, groupBits);
+      if (digitUnknown == 0) {
+        uint32_t digitVal =
+            getBitsLEMasked(valueBytes, bw, startBit, groupBits);
+        if (digitVal < 10)
+          out.push_back(static_cast<char>('0' + digitVal));
+        else
+          out.push_back(
+              static_cast<char>((uppercase ? 'A' : 'a') + (digitVal - 10)));
+        continue;
+      }
+      uint32_t mask =
+          bitsThisDigit == 32u ? 0xFFFFFFFFu : ((1u << bitsThisDigit) - 1u);
+      uint32_t digitVal =
+          getBitsLEMasked(valueBytes, bw, startBit, groupBits) & mask;
+      digitUnknown &= mask;
+      // A fully-unknown digit preserves `z` when all bits are Z.
+      if (digitUnknown == mask) {
+        if (digitVal == mask) {
+          out.push_back(uppercase ? 'Z' : 'z');
+          continue;
+        }
+        if (digitVal == 0) {
+          out.push_back(uppercase ? 'X' : 'x');
+          continue;
+        }
+      }
+      out.push_back(uppercase ? 'X' : 'x');
+    }
+    break;
+  }
+  case 10: {
+    // Decimal with any unknown bit prints `x` (or `z` if every bit is Z).
+    bool allUnknown = true;
+    bool allZ = true;
+    for (uint32_t b = 0; b < bw; ++b) {
+      if (!getBitLE(unknownBytes, b)) {
+        allUnknown = false;
+        break;
+      }
+      if (getBitLE(valueBytes, b) == 0)
+        allZ = false;
+    }
+    std::fputc(allUnknown && allZ ? (uppercase ? 'Z' : 'z')
+                                  : (uppercase ? 'X' : 'x'),
+               stdout);
+    return;
+  }
+  default:
+    std::fputs("<unsupported base>", stdout);
+    return;
+  }
+
+  emitPadded(out, minWidth, leftJustify, padChar);
+}
+
 #ifdef ARC_RUNTIME_JIT_BIND
 namespace circt {
 namespace arc {
@@ -81,6 +393,9 @@ static const SVRuntimeSymbol svRuntimeSymbols[] = {
      reinterpret_cast<void (*)()>(&circt_sv_string_getc)},
     {"circt_sv_string_substr",
      reinterpret_cast<void (*)()>(&circt_sv_string_substr)},
+    {"circt_sv_print_int", reinterpret_cast<void (*)()>(&circt_sv_print_int)},
+    {"circt_sv_print_fvint",
+     reinterpret_cast<void (*)()>(&circt_sv_print_fvint)},
     {nullptr, nullptr},
 };
 

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -79,6 +79,7 @@
 #define ARC_RUNTIME_JITBIND_FNDECL
 #include "circt/Dialect/Arc/Runtime/Common.h"
 #include "circt/Dialect/Arc/Runtime/JITBind.h"
+#include "circt/Dialect/Arc/Runtime/SVRuntime.h"
 #endif
 
 #include <optional>
@@ -327,6 +328,16 @@ static void bindArcRuntimeSymbols(ExecutionEngine &executionEngine) {
     return symbolMap;
   });
 }
+
+// Bind the SystemVerilog execution runtime symbols to the JIT execution engine.
+static void bindArcSVRuntimeSymbols(ExecutionEngine &executionEngine) {
+  executionEngine.registerSymbols([&](llvm::orc::MangleAndInterner interner) {
+    llvm::orc::SymbolMap symbolMap;
+    for (const auto *sym = runtime::getSVRuntimeSymbols(); sym->name; ++sym)
+      bindExecutionEngineSymbol(symbolMap, interner, sym->name, sym->addr);
+    return symbolMap;
+  });
+}
 #endif
 
 /// Populate a pass manager with the arc simulator pipeline for the given
@@ -545,8 +556,10 @@ static LogicalResult processBuffer(
       return failure();
     }
 
-    if (!noJitRuntime)
+    if (!noJitRuntime) {
       bindArcRuntimeSymbols(**executionEngine);
+      bindArcSVRuntimeSymbols(**executionEngine);
+    }
 
     auto expectedFunc = (*executionEngine)->lookupPacked(jitEntryPoint);
     if (!expectedFunc) {


### PR DESCRIPTION
Stacked on #10644 → #10643 → #10642 — please review/merge those first; the parent commits show here until they land.

Adds the runtime backing for the `%t` format specifier:

- `circt_sv_set_timeformat` — stores the global `$timeformat` state (unit exponent, fractional precision, suffix string, minimum field width).
- `circt_sv_print_time` — renders a femtosecond time value using that state, scaled to the configured unit/precision with round-to-nearest.

The scaling deliberately avoids `__int128` (which MSVC lacks — the Arc JIT runtime is compiled on the Windows CI job too). Because the unit scale and the precision scale are both powers of ten, the wide multiply in the naive `(absFs * 10^precision + half) / 10^unitPow` formula cancels: it becomes either an exact multiply (when precision ≥ unit exponent) or a round-to-nearest divide by a power of ten, kept entirely in `uint64`.

The JIT integration test (`integration_test/arcilator/JIT/sv-runtime-time.mlir`) configures nanosecond units with two fractional digits and renders `1500000` fs as `1.50 ns`.