### PR TITLE
[Debug][FIRRTL][2/13] Lower circt_debug_* intrinsics to Debug ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace circt {
 namespace firrtl {
@@ -184,6 +185,38 @@ struct GenericIntrinsic {
   }
 };
 
+/// key: parent fqn, value: subfield leaves.
+using DebugLeafMap =
+    llvm::DenseMap<mlir::StringAttr, llvm::SmallVector<mlir::DictionaryAttr>>;
+
+/// Enum definition data staged per FQN by `liftDebugIntrinsics`, for use sites
+/// to build a `dbg.enum` inline.
+struct EnumDefData {
+  mlir::StringAttr typeName;
+  mlir::DictionaryAttr variantsMap;
+  mlir::StringAttr fqn;
+};
+
+/// Named SSA declarations (ports, wires, nodes, regs) of one module, indexed by
+/// name for the 0-operand `circt_debug_var` lookup. A name maps to >1 value
+/// when it is ambiguous; memory names are tracked separately as they carry no
+/// single SSA value. Built once per module by `liftDebugIntrinsics`.
+struct NamedDeclIndex {
+  llvm::DenseMap<mlir::StringAttr, llvm::SmallVector<mlir::Value, 1>> byName;
+  llvm::DenseSet<mlir::StringAttr> memoryNames;
+};
+
+/// Per-invocation context for `IntrinsicLowerings::lower`. Non-owning;
+/// pointers may be null when no debug staging is needed.
+struct IntrinsicConvertContext {
+  const DebugLeafMap *debugLeaves = nullptr;
+  const llvm::StringMap<EnumDefData> *enumDefByFqn = nullptr;
+  const NamedDeclIndex *namedDecls = nullptr;
+  /// Accumulator for emitted `dbg.variable` names; a failed insert means a
+  /// duplicate was seen and triggers a warning. Null disables the check.
+  llvm::StringSet<> *existingVariableNames = nullptr;
+};
+
 /// Base class for Intrinsic Converters.
 ///
 /// Intrinsic converters contain validation logic, along with a converter
@@ -220,7 +253,8 @@ public:
   /// recomputing work done during check needed for the conversion.
   virtual LogicalResult checkAndConvert(GenericIntrinsic gi,
                                         GenericIntrinsicOpAdaptor adaptor,
-                                        PatternRewriter &rewriter) {
+                                        PatternRewriter &rewriter,
+                                        IntrinsicConvertContext ctx) {
     if (check(gi))
       return failure();
     convert(gi, adaptor, rewriter);
@@ -264,16 +298,18 @@ public:
   }
 
   /// Lowers all intrinsics in a module.  Returns number converted or failure.
-  FailureOr<size_t> lower(FModuleOp mod, bool allowUnknownIntrinsics = false);
+  FailureOr<size_t> lower(FModuleOp mod, bool allowUnknownIntrinsics = false,
+                          IntrinsicConvertContext ctx = {});
 
 private:
-  template <typename T>
+  template <typename T, typename... Args>
   typename std::enable_if_t<std::is_base_of_v<IntrinsicConverter, T>>
-  addConverter(StringRef name) {
+  addConverter(StringRef name, Args &&...args) {
     auto nameAttr = StringAttr::get(context, name);
     assert(!conversions.contains(nameAttr) &&
            "duplicate conversion for intrinsic");
-    conversions.try_emplace(nameAttr, std::make_unique<T>());
+    conversions.try_emplace(nameAttr,
+                            std::make_unique<T>(std::forward<Args>(args)...));
   }
 };
 
@@ -300,6 +336,15 @@ struct FIRRTLIntrinsicLoweringDialectInterface
   using IntrinsicLoweringDialectInterface::IntrinsicLoweringDialectInterface;
   void populateIntrinsicLowerings(IntrinsicLowerings &lowerings) const override;
 };
+
+/// Pre-pass over one module, run before `IntrinsicLowerings::lower`: stages
+/// enumdef data by fqn into `outEnumDefByFqn`, groups subfield leaves by
+/// `parent` into `outLeaves`, indexes named declarations into `outDecls`, and
+/// erases the lifted intrinsics. `parent` is the var<->leaf linkage key, `name`
+/// the dotted display path. Fails on a malformed intrinsic.
+LogicalResult liftDebugIntrinsics(FModuleOp mod, DebugLeafMap &outLeaves,
+                                  llvm::StringMap<EnumDefData> &outEnumDefByFqn,
+                                  NamedDeclIndex &outDecls);
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace circt {
 namespace firrtl {
@@ -184,6 +185,29 @@ struct GenericIntrinsic {
   }
 };
 
+/// key: parent fqn, value: subfield leaves.
+using DebugLeafMap =
+    llvm::DenseMap<mlir::StringAttr, llvm::SmallVector<mlir::DictionaryAttr>>;
+
+/// Named SSA declarations (ports, wires, nodes, regs) of one module, indexed by
+/// name for the 0-operand `circt_debug_var` lookup. A name maps to >1 value
+/// when it is ambiguous; memory names are tracked separately as they carry no
+/// single SSA value. Built once per module by `liftDebugIntrinsics`.
+struct NamedDeclIndex {
+  llvm::DenseMap<mlir::StringAttr, llvm::SmallVector<mlir::Value, 1>> byName;
+  llvm::DenseSet<mlir::StringAttr> memoryNames;
+};
+
+/// Per-invocation context for `IntrinsicLowerings::lower`. Non-owning;
+/// pointers may be null when no debug staging is needed.
+struct IntrinsicConvertContext {
+  const DebugLeafMap *debugLeaves = nullptr;
+  const NamedDeclIndex *namedDecls = nullptr;
+  /// Accumulator for emitted `dbg.variable` names; a failed insert means a
+  /// duplicate was seen and triggers a warning. Null disables the check.
+  llvm::StringSet<> *existingVariableNames = nullptr;
+};
+
 /// Base class for Intrinsic Converters.
 ///
 /// Intrinsic converters contain validation logic, along with a converter
@@ -220,7 +244,8 @@ public:
   /// recomputing work done during check needed for the conversion.
   virtual LogicalResult checkAndConvert(GenericIntrinsic gi,
                                         GenericIntrinsicOpAdaptor adaptor,
-                                        PatternRewriter &rewriter) {
+                                        PatternRewriter &rewriter,
+                                        IntrinsicConvertContext ctx) {
     if (check(gi))
       return failure();
     convert(gi, adaptor, rewriter);
@@ -264,16 +289,18 @@ public:
   }
 
   /// Lowers all intrinsics in a module.  Returns number converted or failure.
-  FailureOr<size_t> lower(FModuleOp mod, bool allowUnknownIntrinsics = false);
+  FailureOr<size_t> lower(FModuleOp mod, bool allowUnknownIntrinsics = false,
+                          IntrinsicConvertContext ctx = {});
 
 private:
-  template <typename T>
+  template <typename T, typename... Args>
   typename std::enable_if_t<std::is_base_of_v<IntrinsicConverter, T>>
-  addConverter(StringRef name) {
+  addConverter(StringRef name, Args &&...args) {
     auto nameAttr = StringAttr::get(context, name);
     assert(!conversions.contains(nameAttr) &&
            "duplicate conversion for intrinsic");
-    conversions.try_emplace(nameAttr, std::make_unique<T>());
+    conversions.try_emplace(nameAttr,
+                            std::make_unique<T>(std::forward<Args>(args)...));
   }
 };
 
@@ -300,6 +327,14 @@ struct FIRRTLIntrinsicLoweringDialectInterface
   using IntrinsicLoweringDialectInterface::IntrinsicLoweringDialectInterface;
   void populateIntrinsicLowerings(IntrinsicLowerings &lowerings) const override;
 };
+
+/// Pre-pass over one module, run before `IntrinsicLowerings::lower`: groups
+/// subfield leaves by `parent` into `outLeaves` (including any inline enum
+/// variants carried on the leaf), indexes named declarations into `outDecls`,
+/// and erases the lifted intrinsics. `parent` is the var<->leaf linkage key,
+/// `name` the dotted display path. Fails on a malformed intrinsic.
+LogicalResult liftDebugIntrinsics(FModuleOp mod, DebugLeafMap &outLeaves,
+                                  NamedDeclIndex &outDecls);
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -629,6 +629,7 @@ def LowerIntrinsics : Pass<"firrtl-lower-intrinsics", "firrtl::FModuleOp"> {
   let description = [{
     This pass lowers generic intrinsic ops to their implementation or op.
   }];
+  let dependentDialects = ["debug::DebugDialect"];
   let statistics = [
     Statistic<"numConverted", "num-converted", "Number of intrinsic operations lowered">,
   ];

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -45,6 +45,7 @@ add_circt_dialect_library(CIRCTFIRRTL
 
   LINK_LIBS PUBLIC
   CIRCTSupport
+  CIRCTDebug
   CIRCTHW
   CIRCTOM
   CIRCTSeq

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/FIRRTL/FIRRTLIntrinsics.h"
+#include "circt/Dialect/Debug/DebugOps.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/CHIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
@@ -115,10 +117,10 @@ public:
 
   IntrinsicOpConversion(TypeConverter &typeConverter, MLIRContext *context,
                         const ConversionMapTy &conversions,
-                        size_t &numConversions,
+                        size_t &numConversions, IntrinsicConvertContext convCtx,
                         bool allowUnknownIntrinsics = false)
       : OpConversionPattern(typeConverter, context), conversions(conversions),
-        numConversions(numConversions),
+        numConversions(numConversions), convCtx(convCtx),
         allowUnknownIntrinsics(allowUnknownIntrinsics) {}
 
   LogicalResult
@@ -133,7 +135,8 @@ public:
     }
 
     auto &conv = *it->second;
-    auto result = conv.checkAndConvert(GenericIntrinsic(op), adaptor, rewriter);
+    auto result =
+        conv.checkAndConvert(GenericIntrinsic(op), adaptor, rewriter, convCtx);
     if (succeeded(result))
       ++numConversions;
     return result;
@@ -142,6 +145,7 @@ public:
 private:
   const ConversionMapTy &conversions;
   size_t &numConversions;
+  IntrinsicConvertContext convCtx;
   const bool allowUnknownIntrinsics;
 };
 } // namespace
@@ -151,7 +155,8 @@ private:
 //===----------------------------------------------------------------------===//
 
 FailureOr<size_t> IntrinsicLowerings::lower(FModuleOp mod,
-                                            bool allowUnknownIntrinsics) {
+                                            bool allowUnknownIntrinsics,
+                                            IntrinsicConvertContext ctx) {
 
   ConversionTarget target(*context);
 
@@ -193,7 +198,7 @@ FailureOr<size_t> IntrinsicLowerings::lower(FModuleOp mod,
   RewritePatternSet patterns(context);
   size_t count = 0;
   patterns.add<IntrinsicOpConversion>(typeConverter, context, conversions,
-                                      count, allowUnknownIntrinsics);
+                                      count, ctx, allowUnknownIntrinsics);
 
   if (failed(mlir::applyPartialConversion(mod, target, std::move(patterns))))
     return failure();
@@ -570,7 +575,8 @@ public:
 
   LogicalResult checkAndConvert(GenericIntrinsic gi,
                                 GenericIntrinsicOpAdaptor adaptor,
-                                PatternRewriter &rewriter) override {
+                                PatternRewriter &rewriter,
+                                IntrinsicConvertContext) override {
     // Check structure of the intrinsic.
     if (gi.typedInput<ClockType>(0) || gi.sizedInput<UIntType>(1, 1) ||
         gi.sizedInput<UIntType>(2, 1) ||
@@ -756,6 +762,442 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// Debug intrinsic converters
+//===----------------------------------------------------------------------===//
+
+static ArrayAttr parseParamsJSON(MLIRContext *ctx, StringAttr paramsStr,
+                                 Operation *warnAt);
+
+class CirctDebugModuleInfoConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check(GenericIntrinsic gi) override {
+    return gi.hasNInputs(0) || gi.namedParam("typeName") ||
+           gi.namedParam("params", /*optional=*/true) || gi.hasNParam(1, 1) ||
+           gi.hasNoOutput();
+  }
+
+  void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor adaptor,
+               PatternRewriter &rewriter) override {
+    auto *context = rewriter.getContext();
+    auto typeName = gi.getParamValue<StringAttr>("typeName");
+    auto paramsStr = gi.getParamValue<StringAttr>("params");
+
+    // Module-level type info goes on a discardable attribute, not a dedicated
+    // op: it has no SSA semantics and survives FIRRTL->HW lowering unchanged.
+    SmallVector<NamedAttribute> fields;
+    fields.emplace_back(StringAttr::get(context, "typeName"), typeName);
+    if (paramsStr)
+      fields.emplace_back(StringAttr::get(context, "params"),
+                          parseParamsJSON(context, paramsStr, gi.op));
+    auto modOp = gi.op->getParentOfType<FModuleOp>();
+    rewriter.modifyOpInPlace(modOp, [&] {
+      modOp->setAttr("dbg.moduleinfo", DictionaryAttr::get(context, fields));
+    });
+    rewriter.eraseOp(gi.op);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Debug intrinsic helpers
+//===----------------------------------------------------------------------===//
+
+static std::optional<Attribute>
+jsonValueToAttr(MLIRContext *ctx, const llvm::json::Value &v, bool &skipped) {
+  if (auto b = v.getAsBoolean())
+    return BoolAttr::get(ctx, *b);
+  if (auto s = v.getAsString())
+    return StringAttr::get(ctx, *s);
+  if (auto i = v.getAsInteger())
+    return IntegerAttr::get(IntegerType::get(ctx, 64), *i);
+  if (v.getAsNumber() || v.getAsObject() || v.getAsArray())
+    skipped = true;
+  return std::nullopt;
+}
+
+static ArrayAttr parseParamsJSON(MLIRContext *ctx, StringAttr paramsStr,
+                                 Operation *warnAt) {
+  if (!paramsStr || paramsStr.getValue().empty())
+    return {};
+
+  auto parsed = llvm::json::parse(paramsStr.strref());
+  if (auto err = parsed.takeError()) {
+    auto msg = llvm::toString(std::move(err));
+    if (warnAt)
+      warnAt->emitWarning()
+          << "debug params JSON failed to parse (type-parameter info "
+             "dropped): "
+          << msg;
+    return {};
+  }
+
+  auto *arr = parsed->getAsArray();
+  if (!arr) {
+    if (warnAt)
+      warnAt->emitWarning()
+          << "debug params JSON is not a JSON array (type-parameter info "
+             "dropped)";
+    return {};
+  }
+
+  bool skippedUnsupported = false;
+  SmallVector<Attribute> entries{};
+  for (const auto &item : *arr) {
+    auto *obj = item.getAsObject();
+    if (!obj)
+      continue;
+
+    SmallVector<NamedAttribute> fields;
+    for (auto &[k, v] : *obj) {
+      if (auto attr = jsonValueToAttr(ctx, v, skippedUnsupported))
+        fields.push_back({StringAttr::get(ctx, StringRef(k)), *attr});
+    }
+
+    entries.push_back(DictionaryAttr::get(ctx, fields));
+  }
+
+  if (skippedUnsupported && warnAt)
+    warnAt->emitWarning() << "debug params JSON contains unsupported value "
+                             "types (float/object/array); those fields are "
+                             "dropped";
+  return ArrayAttr::get(ctx, entries);
+}
+
+namespace {
+struct LeafMeta {
+  StringAttr typeName;
+  ArrayAttr params;
+  StringAttr enumTypeName;
+  StringAttr enumFqn;
+  DictionaryAttr enumVariantsMap;
+};
+} // namespace
+using LeafMetaMap = llvm::StringMap<LeafMeta>;
+
+namespace {
+class DebugAggregateBuilder {
+public:
+  DebugAggregateBuilder(PatternRewriter &rewriter, Location loc,
+                        const LeafMetaMap &leafMetaMap, Operation *warnAt)
+      : rewriter(rewriter), leafMetaMap(leafMetaMap), loc(loc), warnAt(warnAt) {
+  }
+
+  /// Entry point. Builds the aggregate without wrapping the root; the caller
+  /// attaches root-level metadata. Children are wrapped by `build`.
+  Value buildRoot(Value value, StringRef parentPath) {
+    return FIRRTLTypeSwitch<Type, Value>(value.getType())
+        .Case<BundleType>(
+            [&](BundleType t) { return buildBundle(value, t, parentPath); })
+        .Case<FVectorType>(
+            [&](FVectorType t) { return buildVector(value, t, parentPath); })
+        .Case<FEnumType>([&](FEnumType t) -> Value { return value; })
+        .Case<FIRRTLBaseType>([&](FIRRTLBaseType t) -> Value {
+          return t.isGround() ? value : Value{};
+        })
+        .Default([](auto) -> Value { return {}; });
+  }
+
+private:
+  /// Recursive builder for non-root sub-values; each result is wrapped to
+  /// carry its own leaf metadata.
+  Value build(Value value, StringRef parentPath) {
+    return FIRRTLTypeSwitch<Type, Value>(value.getType())
+        .Case<BundleType>([&](BundleType t) {
+          Value agg = buildBundle(value, t, parentPath);
+          return agg ? wrap(agg, parentPath) : agg;
+        })
+        .Case<FVectorType>([&](FVectorType t) {
+          Value agg = buildVector(value, t, parentPath);
+          return agg ? wrap(agg, parentPath) : agg;
+        })
+        .Case<FEnumType>(
+            [&](FEnumType t) -> Value { return wrap(value, parentPath); })
+        .Case<FIRRTLBaseType>([&](FIRRTLBaseType t) -> Value {
+          if (!t.isGround())
+            return {};
+          return wrap(value, parentPath);
+        })
+        .Default([](auto) -> Value { return {}; });
+  }
+
+  Value wrap(Value inner, StringRef parentPath) {
+    ArrayAttr params{};
+    StringAttr typeName{};
+    StringAttr enumTypeName{};
+    StringAttr enumFqn{};
+    DictionaryAttr enumVariantsMap{};
+    if (auto it = leafMetaMap.find(parentPath); it != leafMetaMap.end()) {
+      typeName = it->second.typeName;
+      params = it->second.params;
+      enumTypeName = it->second.enumTypeName;
+      enumFqn = it->second.enumFqn;
+      enumVariantsMap = it->second.enumVariantsMap;
+    }
+
+    if (enumVariantsMap)
+      inner = debug::EnumOp::create(rewriter, loc, inner, enumTypeName,
+                                    enumVariantsMap, enumFqn)
+                  .getResult();
+
+    return debug::ValueOp::create(rewriter, loc, inner, typeName, params)
+        .getResult();
+  }
+
+  void eraseUnused(ArrayRef<Operation *> ops) {
+    for (auto *op : ops)
+      if (op->use_empty())
+        rewriter.eraseOp(op);
+  }
+
+  Value buildBundle(Value value, BundleType type, StringRef parentPath) {
+    SmallVector<Value> fields{};
+    SmallVector<Attribute> names{};
+    SmallVector<Operation *> subOps{};
+    for (auto [index, element] : llvm::enumerate(type.getElements())) {
+      auto subOp = SubfieldOp::create(rewriter, loc, value, index);
+      subOps.push_back(subOp.getOperation());
+
+      std::string fieldPath =
+          (Twine(parentPath) + "." + element.name.getValue()).str();
+      if (auto dbgVal = build(subOp.getResult(), fieldPath)) {
+        fields.push_back(dbgVal);
+        names.push_back(element.name);
+      } else if (warnAt) {
+        warnAt->emitWarning() << "dbg.struct field '" << element.name.getValue()
+                              << "' has unsupported type; skipping";
+      }
+    }
+
+    if (fields.empty())
+      return {};
+
+    Value result = debug::StructOp::create(rewriter, loc, fields,
+                                           rewriter.getArrayAttr(names));
+    eraseUnused(subOps);
+    return result;
+  }
+
+  Value buildVector(Value value, FVectorType type, StringRef parentPath) {
+    SmallVector<Value> elements{};
+    SmallVector<Operation *> subOps{};
+    for (std::size_t i = 0; i < type.getNumElements(); ++i) {
+      auto subOp = SubindexOp::create(rewriter, loc, value, i);
+      subOps.push_back(subOp.getOperation());
+
+      std::string elemPath = (Twine(parentPath) + "[" + Twine(i) + "]").str();
+      if (auto dbgVal = build(subOp.getResult(), elemPath))
+        elements.push_back(dbgVal);
+    }
+
+    if (elements.size() != type.getNumElements()) {
+      if (warnAt)
+        warnAt->emitWarning()
+            << "dbg.array for '" << parentPath << "' has " << elements.size()
+            << "/" << type.getNumElements()
+            << " elements due to unsupported element types; skipping";
+      eraseUnused(subOps);
+      return {};
+    }
+
+    Value result = debug::ArrayOp::create(rewriter, loc, elements);
+    eraseUnused(subOps);
+    return result;
+  }
+
+  PatternRewriter &rewriter;
+  const LeafMetaMap &leafMetaMap;
+
+  Location loc;
+  Operation *warnAt;
+};
+} // namespace
+
+/// Converts `circt_debug_var` to `dbg.variable`, reading the enum table and
+/// leaf list staged by `liftDebugIntrinsics` via `IntrinsicConvertContext`.
+class CirctDebugVarConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check(GenericIntrinsic gi) override {
+    // 0 operands for memories (no SSA), 1 operand for normal values.
+    unsigned n = gi.op.getNumOperands();
+    if (n != 0 && n != 1)
+      return true;
+    return gi.namedParam("name") || gi.namedParam("typeName") ||
+           gi.namedParam("params", /*optional=*/true) ||
+           gi.namedParam("enumFqn", /*optional=*/true) || gi.hasNParam(2, 2) ||
+           gi.hasNoOutput();
+  }
+
+  LogicalResult checkAndConvert(GenericIntrinsic gi,
+                                GenericIntrinsicOpAdaptor adaptor,
+                                PatternRewriter &rewriter,
+                                IntrinsicConvertContext ctx) override {
+    if (check(gi))
+      return failure();
+    auto varName = gi.getParamValue<StringAttr>("name");
+    auto typeName = gi.getParamValue<StringAttr>("typeName");
+    auto location = gi.op.getLoc();
+
+    if (varName && ctx.existingVariableNames &&
+        !ctx.existingVariableNames->insert(varName.getValue()).second)
+      gi.op->emitWarning("duplicate circt_debug_var with name '")
+          << varName.getValue() << "'";
+
+    ArrayAttr params;
+    if (auto paramAttr = gi.getParamValue<StringAttr>("params"))
+      params = parseParamsJSON(rewriter.getContext(), paramAttr, gi.op);
+
+    if (!ctx.enumDefByFqn) {
+      gi.op->emitError("CirctDebugVarConverter requires liftDebugIntrinsics to "
+                       "publish enumDefByFqn via IntrinsicConvertContext");
+      return success();
+    }
+
+    const EnumDefData *enumDef = lookupEnumDef(
+        *ctx.enumDefByFqn, gi.getParamValue<StringAttr>("enumFqn"), gi.op);
+    LeafMetaMap leafMap =
+        collectLeafMeta(*ctx.enumDefByFqn, ctx.debugLeaves, varName);
+
+    Value rawSignal = resolveRootSignal(gi, adaptor, ctx, varName, rewriter);
+    if (!rawSignal)
+      return success();
+
+    StringRef varPath = varName ? varName.getValue() : StringRef{};
+    Value dbgValue = DebugAggregateBuilder(rewriter, location, leafMap, gi.op)
+                         .buildRoot(rawSignal, varPath);
+    if (!dbgValue)
+      dbgValue = rawSignal;
+
+    // Scalar enum variable: wrap the value in a `dbg.enum` cast so the enum
+    // type travels with the value, with no separate op or FQN linkage.
+    if (enumDef)
+      dbgValue =
+          debug::EnumOp::create(rewriter, location, dbgValue, enumDef->typeName,
+                                enumDef->variantsMap, enumDef->fqn)
+              .getResult();
+
+    // Root type metadata goes on a `dbg.value` wrapper, so `dbg.variable`
+    // itself stays metadata-free.
+    if (typeName || params)
+      dbgValue =
+          debug::ValueOp::create(rewriter, location, dbgValue, typeName, params)
+              .getResult();
+
+    rewriter.replaceOpWithNewOp<debug::VariableOp>(gi.op, varName, dbgValue,
+                                                   /*scope=*/Value{});
+    return success();
+  }
+
+private:
+  /// Resolves `fqnAttr` against the staged enumdef table. An unresolved FQN is
+  /// not fatal: it warns on `warnAt` (when set) and returns null.
+  static const EnumDefData *
+  lookupEnumDef(const llvm::StringMap<EnumDefData> &enumDefByFqn,
+                StringAttr fqnAttr, Operation *warnAt) {
+    if (!fqnAttr || fqnAttr.getValue().empty())
+      return nullptr;
+    auto it = enumDefByFqn.find(fqnAttr.getValue());
+    if (it == enumDefByFqn.end()) {
+      if (warnAt)
+        warnAt->emitWarning()
+            << "no circt_debug_enumdef found for '" << fqnAttr.getValue()
+            << "'; leaf will be emitted without enum binding";
+      return nullptr;
+    }
+    return &it->second;
+  }
+
+  /// Collects this var's leaves, keyed by display path (what
+  /// `DebugAggregateBuilder` reconstructs). Linkage is by FQN: a leaf's
+  /// `parent` must exactly equal this var's FQN.
+  static LeafMetaMap
+  collectLeafMeta(const llvm::StringMap<EnumDefData> &enumDefByFqn,
+                  const DebugLeafMap *debugLeaves, StringAttr varName) {
+    LeafMetaMap leafMap;
+    if (!varName || !debugLeaves)
+      return leafMap;
+    auto it = debugLeaves->find(varName);
+    if (it == debugLeaves->end())
+      return leafMap;
+    for (auto entry : it->second) {
+      auto pathAttr = entry.getAs<StringAttr>("name");
+      if (!pathAttr)
+        continue;
+      LeafMeta meta;
+      meta.typeName = entry.getAs<StringAttr>("typeName");
+      meta.params = entry.getAs<ArrayAttr>("params");
+      // No warnAt: a missing enumdef is expected for a non-enum leaf; the FQN
+      // string on the leaf is the binding to the staged definition.
+      if (const EnumDefData *ed = lookupEnumDef(
+              enumDefByFqn, entry.getAs<StringAttr>("enumFqn"), nullptr)) {
+        meta.enumTypeName = ed->typeName;
+        meta.enumFqn = ed->fqn;
+        meta.enumVariantsMap = ed->variantsMap;
+      }
+      leafMap[pathAttr.getValue()] = meta;
+    }
+    return leafMap;
+  }
+
+  /// Locates the SSA root to walk: the direct operand, or (for 0-operand vars)
+  /// a port/wire/reg named `varName` from the staged declaration index. Returns
+  /// null and erases the op for the no-SSA cases (memory, unresolved name,
+  /// ambiguous name); the caller then returns early.
+  ///
+  /// Name lookup assumes this runs BEFORE LowerTypes/PrettifyVerilogNames,
+  /// which rewrite port/wire names. Re-ordering passes breaks it silently.
+  static Value resolveRootSignal(GenericIntrinsic gi,
+                                 GenericIntrinsicOpAdaptor adaptor,
+                                 IntrinsicConvertContext ctx,
+                                 StringAttr varName,
+                                 PatternRewriter &rewriter) {
+    if (!adaptor.getOperands().empty())
+      return adaptor.getOperands()[0];
+
+    bool isMemory = false;
+    if (ctx.namedDecls && varName) {
+      ArrayRef<Value> candidates;
+      if (auto it = ctx.namedDecls->byName.find(varName);
+          it != ctx.namedDecls->byName.end())
+        candidates = it->second;
+      isMemory = ctx.namedDecls->memoryNames.contains(varName);
+
+      size_t totalMatches = candidates.size() + (isMemory ? 1 : 0);
+      if (totalMatches > 1) {
+        gi.op->emitError("circt_debug_var: name '")
+            << varName.getValue() << "' is ambiguous (matches " << totalMatches
+            << " signals)";
+        rewriter.eraseOp(gi.op);
+        return {};
+      }
+      if (!isMemory && candidates.size() == 1)
+        return candidates[0];
+    }
+
+    // A memory has no single SSA root; drop the var silently. Anything else
+    // unresolved warns.
+    if (varName && !isMemory)
+      gi.op->emitWarning("circt_debug_var: no wire, port, or register named '")
+          << varName.getValue() << "' found";
+    rewriter.eraseOp(gi.op);
+    return {};
+  }
+};
+
+/// Drops `circt_debug_typedef`: there is no `dbg.typedef` op yet.
+class CirctDebugTypeDefConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+  bool check(GenericIntrinsic gi) override { return false; }
+  void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor,
+               PatternRewriter &rewriter) override {
+    rewriter.eraseOp(gi.op);
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // View intrinsic converter and helpers
 //===----------------------------------------------------------------------===//
 
@@ -910,7 +1352,8 @@ class ViewConverter : public IntrinsicConverter {
 public:
   LogicalResult checkAndConvert(GenericIntrinsic gi,
                                 GenericIntrinsicOpAdaptor adaptor,
-                                PatternRewriter &rewriter) override {
+                                PatternRewriter &rewriter,
+                                IntrinsicConvertContext) override {
     // Check structure of the intrinsic.
     if (gi.hasNoOutput() || gi.namedParam("info") || gi.namedParam("name") ||
         gi.namedParam("yaml", true))
@@ -1006,4 +1449,254 @@ public:
 void FIRRTLIntrinsicLoweringDialectInterface::populateIntrinsicLowerings(
     IntrinsicLowerings &lowering) const {
   populateLowerings(lowering);
+  lowering.add<CirctDebugTypeDefConverter>("circt_debug_typedef");
+  lowering.add<CirctDebugVarConverter>("circt_debug_var");
+  lowering.add<CirctDebugModuleInfoConverter>("circt_debug_moduleinfo");
 }
+
+namespace {
+
+/// Reads the optional `width` IntParam (default i64; width 0 keeps the default
+/// as i0 is meaningless) into `outWidth`.
+LogicalResult parseEnumWidth(GenericIntrinsic gi, GenericIntrinsicOp op,
+                             unsigned &outWidth) {
+  outWidth = 64;
+  auto w = gi.getParamValue<IntegerAttr>("width");
+  if (!w)
+    return success();
+  // `width` is an unsigned BigInt IntParam; use APInt (not .getInt(), which is
+  // signless) and guard getZExtValue(), which asserts above 64 bits.
+  if (w.getValue().getActiveBits() > 64)
+    return op.emitError("circt_debug_enumdef: 'width' parameter exceeds 64 "
+                        "bits");
+  uint64_t wv = w.getValue().getZExtValue();
+  if (wv == 0)
+    return success();
+  if (wv > IntegerType::kMaxWidth)
+    return op.emitError("circt_debug_enumdef: 'width' exceeds MLIR IntegerType "
+                        "max (")
+           << IntegerType::kMaxWidth << ")";
+  outWidth = static_cast<unsigned>(wv);
+  return success();
+}
+
+/// Parses the `variants` JSON array into a name->value DictionaryAttr.
+LogicalResult parseEnumVariants(const llvm::json::Array &arr,
+                                GenericIntrinsicOp op, MLIRContext *ctx,
+                                unsigned variantWidth,
+                                DictionaryAttr &outVariantsMap) {
+  auto variantIntType = IntegerType::get(ctx, variantWidth);
+  SmallVector<NamedAttribute> variants;
+  // `variantsMap` is built as a DictionaryAttr, which silently collapses
+  // duplicate keys; reject duplicate variant names up front so two source
+  // variants cannot merge into one.
+  llvm::SmallDenseSet<StringRef> seenNames;
+  for (const auto &item : arr) {
+    auto *obj = item.getAsObject();
+    if (!obj)
+      return op.emitError(
+          "circt_debug_enumdef: variant entry is not a JSON object");
+
+    auto varNameOpt = obj->getString("name");
+    if (!varNameOpt)
+      return op.emitError("circt_debug_enumdef: variant is missing 'name'");
+    if (!seenNames.insert(*varNameOpt).second)
+      return op.emitError("circt_debug_enumdef: duplicate variant name '")
+             << *varNameOpt << "'";
+
+    // Frontend emits value as a string; tolerate integers for tests.
+    APInt valAP;
+    if (auto s = obj->getString("value")) {
+      if (StringRef(*s).getAsInteger(10, valAP))
+        return op.emitError("circt_debug_enumdef: variant '")
+               << *varNameOpt << "' has non-integer value '" << *s << "'";
+    } else if (auto i = obj->getInteger("value")) {
+      valAP = APInt(64, static_cast<uint64_t>(*i), /*isSigned=*/true);
+    } else {
+      return op.emitError("circt_debug_enumdef: variant '")
+             << *varNameOpt << "' is missing 'value'";
+    }
+
+    // A value that does not fit `width` is an error, not a warning: truncating
+    // it can collapse two variants to the same tag and mislabel debug output.
+    unsigned checkWidth = std::max(variantWidth + 1, valAP.getBitWidth());
+    if (!valAP.zextOrTrunc(checkWidth).isIntN(variantWidth))
+      return op.emitError("circt_debug_enumdef: variant '")
+             << *varNameOpt << "' value "
+             << llvm::toString(valAP, 10, /*Signed=*/false)
+             << " does not fit in " << variantWidth << " bits";
+
+    variants.push_back(
+        {StringAttr::get(ctx, *varNameOpt),
+         IntegerAttr::get(variantIntType, valAP.zextOrTrunc(variantWidth))});
+  }
+
+  outVariantsMap = DictionaryAttr::get(ctx, variants);
+  return success();
+}
+
+/// Validate one `circt_debug_enumdef` and stage its data under `fqn` in
+/// `seen` (deduplicated by fqn).
+LogicalResult processEnumDefIntrinsic(GenericIntrinsicOp op, FModuleOp mod,
+                                      llvm::StringMap<EnumDefData> &seen) {
+  GenericIntrinsic gi{op};
+
+  auto fqn = gi.getParamValue<StringAttr>("fqn");
+  auto typeName = gi.getParamValue<StringAttr>("typeName");
+  auto variantsStr = gi.getParamValue<StringAttr>("variants");
+  if (!fqn || !typeName || !variantsStr)
+    return op.emitError("circt_debug_enumdef: missing required parameter(s) "
+                        "'fqn', 'typeName', or 'variants'");
+
+  auto parsed = llvm::json::parse(variantsStr.strref());
+  if (auto err = parsed.takeError())
+    return op.emitError("circt_debug_enumdef: failed to parse 'variants': ")
+           << llvm::toString(std::move(err));
+
+  auto *arr = parsed->getAsArray();
+  if (!arr)
+    return op.emitError("circt_debug_enumdef: 'variants' is not a JSON array");
+
+  auto *ctx = mod.getContext();
+
+  unsigned variantWidth;
+  if (failed(parseEnumWidth(gi, op, variantWidth)))
+    return failure();
+
+  DictionaryAttr variantsMap;
+  if (failed(parseEnumVariants(*arr, op, ctx, variantWidth, variantsMap)))
+    return failure();
+
+  auto [it, inserted] = seen.try_emplace(fqn.getValue(), EnumDefData{});
+  if (inserted) {
+    it->second = EnumDefData{typeName, variantsMap, fqn};
+  } else if (it->second.variantsMap != variantsMap ||
+             it->second.typeName != typeName) {
+    op.emitWarning("duplicate circt_debug_enumdef for fqn '")
+        << fqn.getValue()
+        << "' with differing variants or typeName; first definition wins";
+  }
+  return success();
+}
+
+/// Validate one `circt_debug_subfield` and append a leaf descriptor to
+/// `entries`.
+LogicalResult processSubfieldIntrinsic(GenericIntrinsicOp op,
+                                       DebugLeafMap &entries) {
+  GenericIntrinsic gi{op};
+  auto nameAttr = gi.getParamValue<StringAttr>("name");
+  if (!nameAttr)
+    return op.emitError(
+        "circt_debug_subfield: missing required parameter 'name'");
+
+  auto parentAttr = gi.getParamValue<StringAttr>("parent");
+  if (!parentAttr)
+    return op.emitError(
+        "circt_debug_subfield: missing required parameter 'parent' "
+        "(must equal the 'name' of the enclosing circt_debug_var)");
+
+  // `name` must be a path rooted at `parent`; this catches a frontend that
+  // drops or mangles the root prefix.
+  auto name = nameAttr.getValue();
+  auto parent = parentAttr.getValue();
+  if (name.empty())
+    return op.emitError("circt_debug_subfield: 'name' must not be empty");
+  if (parent.empty())
+    return op.emitError("circt_debug_subfield: 'parent' must not be empty");
+  if (!name.starts_with(parent))
+    return op.emitError("circt_debug_subfield: 'name' (")
+           << name << ") is not rooted at 'parent' (" << parent
+           << "); expected '" << parent << ".<field>' or '" << parent
+           << "[<idx>]...'";
+
+  auto rest = name.drop_front(parent.size());
+  if (rest.empty() || (rest[0] != '.' && rest[0] != '['))
+    return op.emitError("circt_debug_subfield: 'name' (")
+           << name << ") is not rooted at 'parent' (" << parent
+           << "); expected '" << parent << ".<field>' or '" << parent
+           << "[<idx>]...'";
+
+  auto *ctx = op.getContext();
+  SmallVector<NamedAttribute> fields{};
+  fields.push_back({StringAttr::get(ctx, "name"), nameAttr});
+  fields.push_back({StringAttr::get(ctx, "parent"), parentAttr});
+  if (auto tn = gi.getParamValue<StringAttr>("typeName"))
+    fields.push_back({StringAttr::get(ctx, "typeName"), tn});
+  if (auto fqn = gi.getParamValue<StringAttr>("enumFqn");
+      fqn && !fqn.getValue().empty())
+    fields.push_back({StringAttr::get(ctx, "enumFqn"), fqn});
+  // `enumTypeName` is the bare source name (e.g. "AluOp"), mirrored as a
+  // string so EmitUHDI can resolve the type-pool entry by FQN even when the
+  // `circt_debug_enumdef` is in another module (shared enums across modules).
+  if (auto etn = gi.getParamValue<StringAttr>("enumTypeName");
+      etn && !etn.getValue().empty())
+    fields.push_back({StringAttr::get(ctx, "enumTypeName"), etn});
+  if (auto paramsStr = gi.getParamValue<StringAttr>("params"))
+    if (auto params = parseParamsJSON(ctx, paramsStr, op))
+      fields.push_back({StringAttr::get(ctx, "params"), params});
+
+  entries[parentAttr].push_back(DictionaryAttr::get(ctx, fields));
+  return success();
+}
+
+} // namespace
+
+namespace circt::firrtl {
+
+LogicalResult liftDebugIntrinsics(FModuleOp mod, DebugLeafMap &outLeaves,
+                                  llvm::StringMap<EnumDefData> &outEnumDefByFqn,
+                                  NamedDeclIndex &outDecls) {
+  // Index ports up front; their SSA values are the module's block arguments.
+  for (auto [port, arg] : llvm::zip(mod.getPorts(), mod.getArguments()))
+    outDecls.byName[port.name].push_back(arg);
+
+  // A single walk collects the lifted intrinsics and the named declarations a
+  // 0-operand `circt_debug_var` may resolve to. Collecting enumdefs here (vs at
+  // their use site) also dedups ones nested in layerblocks by fqn.
+  SmallVector<GenericIntrinsicOp> intrinsics{};
+  mod.walk([&](Operation *op) {
+    TypeSwitch<Operation *>(op)
+        .Case<GenericIntrinsicOp>([&](auto gi) {
+          auto kind = gi.getIntrinsic();
+          if (kind == "circt_debug_enumdef" || kind == "circt_debug_subfield")
+            intrinsics.push_back(gi);
+        })
+        .Case<WireOp, NodeOp, RegOp, RegResetOp>([&](auto decl) {
+          outDecls.byName[decl.getNameAttr()].push_back(decl.getResult());
+        })
+        .Case<chirrtl::CombMemOp, chirrtl::SeqMemOp, MemOp>([&](auto mem) {
+          if (auto nameAttr = mem->template getAttrOfType<StringAttr>("name"))
+            outDecls.memoryNames.insert(nameAttr);
+        });
+  });
+
+  bool hadError = false;
+  SmallVector<GenericIntrinsicOp> toErase{};
+  for (auto op : intrinsics) {
+    auto kind = op.getIntrinsic();
+    if (kind == "circt_debug_enumdef") {
+      toErase.push_back(op);
+      if (failed(processEnumDefIntrinsic(op, mod, outEnumDefByFqn)))
+        hadError = true;
+    } else if (kind == "circt_debug_subfield") {
+      toErase.push_back(op);
+      if (failed(processSubfieldIntrinsic(op, outLeaves)))
+        hadError = true;
+    }
+  }
+
+  for (auto op : toErase)
+    op.erase();
+
+  if (hadError) {
+    outLeaves.clear();
+    outEnumDefByFqn.clear();
+    outDecls.byName.clear();
+    outDecls.memoryNames.clear();
+    return failure();
+  }
+
+  return success();
+}
+
+} // namespace circt::firrtl

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/FIRRTL/FIRRTLIntrinsics.h"
+#include "circt/Dialect/Debug/DebugOps.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/CHIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
@@ -115,10 +117,10 @@ public:
 
   IntrinsicOpConversion(TypeConverter &typeConverter, MLIRContext *context,
                         const ConversionMapTy &conversions,
-                        size_t &numConversions,
+                        size_t &numConversions, IntrinsicConvertContext convCtx,
                         bool allowUnknownIntrinsics = false)
       : OpConversionPattern(typeConverter, context), conversions(conversions),
-        numConversions(numConversions),
+        numConversions(numConversions), convCtx(convCtx),
         allowUnknownIntrinsics(allowUnknownIntrinsics) {}
 
   LogicalResult
@@ -133,7 +135,8 @@ public:
     }
 
     auto &conv = *it->second;
-    auto result = conv.checkAndConvert(GenericIntrinsic(op), adaptor, rewriter);
+    auto result =
+        conv.checkAndConvert(GenericIntrinsic(op), adaptor, rewriter, convCtx);
     if (succeeded(result))
       ++numConversions;
     return result;
@@ -142,6 +145,7 @@ public:
 private:
   const ConversionMapTy &conversions;
   size_t &numConversions;
+  IntrinsicConvertContext convCtx;
   const bool allowUnknownIntrinsics;
 };
 } // namespace
@@ -151,7 +155,8 @@ private:
 //===----------------------------------------------------------------------===//
 
 FailureOr<size_t> IntrinsicLowerings::lower(FModuleOp mod,
-                                            bool allowUnknownIntrinsics) {
+                                            bool allowUnknownIntrinsics,
+                                            IntrinsicConvertContext ctx) {
 
   ConversionTarget target(*context);
 
@@ -193,7 +198,7 @@ FailureOr<size_t> IntrinsicLowerings::lower(FModuleOp mod,
   RewritePatternSet patterns(context);
   size_t count = 0;
   patterns.add<IntrinsicOpConversion>(typeConverter, context, conversions,
-                                      count, allowUnknownIntrinsics);
+                                      count, ctx, allowUnknownIntrinsics);
 
   if (failed(mlir::applyPartialConversion(mod, target, std::move(patterns))))
     return failure();
@@ -570,7 +575,8 @@ public:
 
   LogicalResult checkAndConvert(GenericIntrinsic gi,
                                 GenericIntrinsicOpAdaptor adaptor,
-                                PatternRewriter &rewriter) override {
+                                PatternRewriter &rewriter,
+                                IntrinsicConvertContext) override {
     // Check structure of the intrinsic.
     if (gi.typedInput<ClockType>(0) || gi.sizedInput<UIntType>(1, 1) ||
         gi.sizedInput<UIntType>(2, 1) ||
@@ -756,6 +762,528 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// Debug intrinsic converters
+//===----------------------------------------------------------------------===//
+
+static ArrayAttr parseParamsJSON(MLIRContext *ctx, StringAttr paramsStr,
+                                 Operation *warnAt);
+
+class CirctDebugModuleInfoConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check(GenericIntrinsic gi) override {
+    return gi.hasNInputs(0) || gi.namedParam("typeName") ||
+           gi.namedParam("params", /*optional=*/true) || gi.hasNParam(1, 1) ||
+           gi.hasNoOutput();
+  }
+
+  void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor adaptor,
+               PatternRewriter &rewriter) override {
+    auto *context = rewriter.getContext();
+    auto typeName = gi.getParamValue<StringAttr>("typeName");
+    auto paramsStr = gi.getParamValue<StringAttr>("params");
+
+    // Module-level type info goes on a discardable attribute, not a dedicated
+    // op: it has no SSA semantics and survives FIRRTL->HW lowering unchanged.
+    SmallVector<NamedAttribute> fields;
+    fields.emplace_back(StringAttr::get(context, "typeName"), typeName);
+    if (paramsStr)
+      fields.emplace_back(StringAttr::get(context, "params"),
+                          parseParamsJSON(context, paramsStr, gi.op));
+    auto modOp = gi.op->getParentOfType<FModuleOp>();
+    rewriter.modifyOpInPlace(modOp, [&] {
+      modOp->setAttr("dbg.moduleinfo", DictionaryAttr::get(context, fields));
+    });
+    rewriter.eraseOp(gi.op);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Debug intrinsic helpers
+//===----------------------------------------------------------------------===//
+
+static std::optional<Attribute>
+jsonValueToAttr(MLIRContext *ctx, const llvm::json::Value &v, bool &skipped) {
+  if (auto b = v.getAsBoolean())
+    return BoolAttr::get(ctx, *b);
+  if (auto s = v.getAsString())
+    return StringAttr::get(ctx, *s);
+  if (auto i = v.getAsInteger())
+    return IntegerAttr::get(IntegerType::get(ctx, 64), *i);
+  if (v.getAsNumber() || v.getAsObject() || v.getAsArray())
+    skipped = true;
+  return std::nullopt;
+}
+
+static ArrayAttr parseParamsJSON(MLIRContext *ctx, StringAttr paramsStr,
+                                 Operation *warnAt) {
+  if (!paramsStr || paramsStr.getValue().empty())
+    return {};
+
+  auto parsed = llvm::json::parse(paramsStr.strref());
+  if (auto err = parsed.takeError()) {
+    auto msg = llvm::toString(std::move(err));
+    if (warnAt)
+      warnAt->emitWarning()
+          << "debug params JSON failed to parse (type-parameter info "
+             "dropped): "
+          << msg;
+    return {};
+  }
+
+  auto *arr = parsed->getAsArray();
+  if (!arr) {
+    if (warnAt)
+      warnAt->emitWarning()
+          << "debug params JSON is not a JSON array (type-parameter info "
+             "dropped)";
+    return {};
+  }
+
+  bool skippedUnsupported = false;
+  SmallVector<Attribute> entries{};
+  for (const auto &item : *arr) {
+    auto *obj = item.getAsObject();
+    if (!obj)
+      continue;
+
+    SmallVector<NamedAttribute> fields;
+    for (auto &[k, v] : *obj) {
+      if (auto attr = jsonValueToAttr(ctx, v, skippedUnsupported))
+        fields.push_back({StringAttr::get(ctx, StringRef(k)), *attr});
+    }
+
+    entries.push_back(DictionaryAttr::get(ctx, fields));
+  }
+
+  if (skippedUnsupported && warnAt)
+    warnAt->emitWarning() << "debug params JSON contains unsupported value "
+                             "types (float/object/array); those fields are "
+                             "dropped";
+  return ArrayAttr::get(ctx, entries);
+}
+
+namespace {
+struct LeafMeta {
+  StringAttr typeName;
+  ArrayAttr params;
+  StringAttr enumTypeName;
+  StringAttr enumFqn;
+  DictionaryAttr enumVariantsMap;
+};
+} // namespace
+using LeafMetaMap = llvm::StringMap<LeafMeta>;
+
+namespace {
+
+/// Reads the optional `width` IntParam (default i64; width 0 keeps the default
+/// as i0 is meaningless) into `outWidth`.
+LogicalResult parseEnumWidth(GenericIntrinsic gi, GenericIntrinsicOp op,
+                             unsigned &outWidth) {
+  outWidth = 64;
+  auto w = gi.getParamValue<IntegerAttr>("width");
+  if (!w)
+    return success();
+  // `width` is an unsigned BigInt IntParam; use APInt (not .getInt(), which is
+  // signless) and guard getZExtValue(), which asserts above 64 bits.
+  if (w.getValue().getActiveBits() > 64)
+    return op.emitError("debug enum: 'width' parameter exceeds 64 bits");
+  uint64_t wv = w.getValue().getZExtValue();
+  if (wv == 0)
+    return success();
+  if (wv > IntegerType::kMaxWidth)
+    return op.emitError("debug enum: 'width' exceeds MLIR IntegerType max (")
+           << IntegerType::kMaxWidth << ")";
+  outWidth = static_cast<unsigned>(wv);
+  return success();
+}
+
+/// Parses the `variants` JSON array into a name->value DictionaryAttr.
+LogicalResult parseEnumVariants(const llvm::json::Array &arr,
+                                GenericIntrinsicOp op, MLIRContext *ctx,
+                                unsigned variantWidth,
+                                DictionaryAttr &outVariantsMap) {
+  auto variantIntType = IntegerType::get(ctx, variantWidth);
+  SmallVector<NamedAttribute> variants;
+  // `variantsMap` is built as a DictionaryAttr, which silently collapses
+  // duplicate keys; reject duplicate variant names up front so two source
+  // variants cannot merge into one.
+  llvm::SmallDenseSet<StringRef> seenNames;
+  for (const auto &item : arr) {
+    auto *obj = item.getAsObject();
+    if (!obj)
+      return op.emitError("debug enum: variant entry is not a JSON object");
+
+    auto varNameOpt = obj->getString("name");
+    if (!varNameOpt)
+      return op.emitError("debug enum: variant is missing 'name'");
+    if (!seenNames.insert(*varNameOpt).second)
+      return op.emitError("debug enum: duplicate variant name '")
+             << *varNameOpt << "'";
+
+    // Frontend emits value as a string; tolerate integers for tests.
+    APInt valAP;
+    if (auto s = obj->getString("value")) {
+      if (StringRef(*s).getAsInteger(10, valAP))
+        return op.emitError("debug enum: variant '")
+               << *varNameOpt << "' has non-integer value '" << *s << "'";
+    } else if (auto i = obj->getInteger("value")) {
+      valAP = APInt(64, static_cast<uint64_t>(*i), /*isSigned=*/true);
+    } else {
+      return op.emitError("debug enum: variant '")
+             << *varNameOpt << "' is missing 'value'";
+    }
+
+    // A value that does not fit `width` is an error, not a warning: truncating
+    // it can collapse two variants to the same tag and mislabel debug output.
+    unsigned checkWidth = std::max(variantWidth + 1, valAP.getBitWidth());
+    if (!valAP.zextOrTrunc(checkWidth).isIntN(variantWidth))
+      return op.emitError("debug enum: variant '")
+             << *varNameOpt << "' value "
+             << llvm::toString(valAP, 10, /*Signed=*/false)
+             << " does not fit in " << variantWidth << " bits";
+
+    variants.push_back(
+        {StringAttr::get(ctx, *varNameOpt),
+         IntegerAttr::get(variantIntType, valAP.zextOrTrunc(variantWidth))});
+  }
+
+  outVariantsMap = DictionaryAttr::get(ctx, variants);
+  return success();
+}
+
+/// Reads inline enum metadata (`variants` JSON + optional `width`) off a
+/// `circt_debug_var`/`circt_debug_subfield` and parses it into a name->value
+/// `variantsMap`. Leaves `outVariantsMap` null when the node carries no
+/// `variants` param (i.e. it is not an enum). Fails on malformed data.
+LogicalResult parseInlineEnumVariants(GenericIntrinsic gi,
+                                      GenericIntrinsicOp op, MLIRContext *ctx,
+                                      DictionaryAttr &outVariantsMap) {
+  auto variantsStr = gi.getParamValue<StringAttr>("variants");
+  if (!variantsStr)
+    return success();
+
+  auto parsed = llvm::json::parse(variantsStr.strref());
+  if (auto err = parsed.takeError())
+    return op.emitError("debug enum: failed to parse 'variants': ")
+           << llvm::toString(std::move(err));
+
+  auto *arr = parsed->getAsArray();
+  if (!arr)
+    return op.emitError("debug enum: 'variants' is not a JSON array");
+
+  unsigned variantWidth;
+  if (failed(parseEnumWidth(gi, op, variantWidth)))
+    return failure();
+
+  return parseEnumVariants(*arr, op, ctx, variantWidth, outVariantsMap);
+}
+
+class DebugAggregateBuilder {
+public:
+  DebugAggregateBuilder(PatternRewriter &rewriter, Location loc,
+                        const LeafMetaMap &leafMetaMap, Operation *warnAt)
+      : rewriter(rewriter), leafMetaMap(leafMetaMap), loc(loc), warnAt(warnAt) {
+  }
+
+  /// Entry point. Builds the aggregate without wrapping the root; the caller
+  /// attaches root-level metadata. Children are wrapped by `build`.
+  Value buildRoot(Value value, StringRef parentPath) {
+    return FIRRTLTypeSwitch<Type, Value>(value.getType())
+        .Case<BundleType>(
+            [&](BundleType t) { return buildBundle(value, t, parentPath); })
+        .Case<FVectorType>(
+            [&](FVectorType t) { return buildVector(value, t, parentPath); })
+        .Case<FEnumType>([&](FEnumType t) -> Value { return value; })
+        .Case<FIRRTLBaseType>([&](FIRRTLBaseType t) -> Value {
+          return t.isGround() ? value : Value{};
+        })
+        .Default([](auto) -> Value { return {}; });
+  }
+
+private:
+  /// Recursive builder for non-root sub-values; each result is wrapped to
+  /// carry its own leaf metadata.
+  Value build(Value value, StringRef parentPath) {
+    return FIRRTLTypeSwitch<Type, Value>(value.getType())
+        .Case<BundleType>([&](BundleType t) {
+          Value agg = buildBundle(value, t, parentPath);
+          return agg ? wrap(agg, parentPath) : agg;
+        })
+        .Case<FVectorType>([&](FVectorType t) {
+          Value agg = buildVector(value, t, parentPath);
+          return agg ? wrap(agg, parentPath) : agg;
+        })
+        .Case<FEnumType>(
+            [&](FEnumType t) -> Value { return wrap(value, parentPath); })
+        .Case<FIRRTLBaseType>([&](FIRRTLBaseType t) -> Value {
+          if (!t.isGround())
+            return {};
+          return wrap(value, parentPath);
+        })
+        .Default([](auto) -> Value { return {}; });
+  }
+
+  Value wrap(Value inner, StringRef parentPath) {
+    ArrayAttr params{};
+    StringAttr typeName{};
+    StringAttr enumTypeName{};
+    StringAttr enumFqn{};
+    DictionaryAttr enumVariantsMap{};
+    if (auto it = leafMetaMap.find(parentPath); it != leafMetaMap.end()) {
+      typeName = it->second.typeName;
+      params = it->second.params;
+      enumTypeName = it->second.enumTypeName;
+      enumFqn = it->second.enumFqn;
+      enumVariantsMap = it->second.enumVariantsMap;
+    }
+
+    if (enumVariantsMap)
+      inner = debug::EnumOp::create(rewriter, loc, inner, enumTypeName,
+                                    enumVariantsMap, enumFqn)
+                  .getResult();
+
+    return debug::ValueOp::create(rewriter, loc, inner, typeName, params)
+        .getResult();
+  }
+
+  void eraseUnused(ArrayRef<Operation *> ops) {
+    for (auto *op : ops)
+      if (op->use_empty())
+        rewriter.eraseOp(op);
+  }
+
+  Value buildBundle(Value value, BundleType type, StringRef parentPath) {
+    SmallVector<Value> fields{};
+    SmallVector<Attribute> names{};
+    SmallVector<Operation *> subOps{};
+    for (auto [index, element] : llvm::enumerate(type.getElements())) {
+      auto subOp = SubfieldOp::create(rewriter, loc, value, index);
+      subOps.push_back(subOp.getOperation());
+
+      std::string fieldPath =
+          (Twine(parentPath) + "." + element.name.getValue()).str();
+      if (auto dbgVal = build(subOp.getResult(), fieldPath)) {
+        fields.push_back(dbgVal);
+        names.push_back(element.name);
+      } else if (warnAt) {
+        warnAt->emitWarning() << "dbg.struct field '" << element.name.getValue()
+                              << "' has unsupported type; skipping";
+      }
+    }
+
+    if (fields.empty())
+      return {};
+
+    Value result = debug::StructOp::create(rewriter, loc, fields,
+                                           rewriter.getArrayAttr(names));
+    eraseUnused(subOps);
+    return result;
+  }
+
+  Value buildVector(Value value, FVectorType type, StringRef parentPath) {
+    SmallVector<Value> elements{};
+    SmallVector<Operation *> subOps{};
+    for (std::size_t i = 0; i < type.getNumElements(); ++i) {
+      auto subOp = SubindexOp::create(rewriter, loc, value, i);
+      subOps.push_back(subOp.getOperation());
+
+      std::string elemPath = (Twine(parentPath) + "[" + Twine(i) + "]").str();
+      if (auto dbgVal = build(subOp.getResult(), elemPath))
+        elements.push_back(dbgVal);
+    }
+
+    if (elements.size() != type.getNumElements()) {
+      if (warnAt)
+        warnAt->emitWarning()
+            << "dbg.array for '" << parentPath << "' has " << elements.size()
+            << "/" << type.getNumElements()
+            << " elements due to unsupported element types; skipping";
+      eraseUnused(subOps);
+      return {};
+    }
+
+    Value result = debug::ArrayOp::create(rewriter, loc, elements);
+    eraseUnused(subOps);
+    return result;
+  }
+
+  PatternRewriter &rewriter;
+  const LeafMetaMap &leafMetaMap;
+
+  Location loc;
+  Operation *warnAt;
+};
+} // namespace
+
+/// Converts `circt_debug_var` to `dbg.variable`, reading the leaf list staged
+/// by `liftDebugIntrinsics` via `IntrinsicConvertContext` and the inline enum
+/// variants carried on the var/leaf intrinsics.
+class CirctDebugVarConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check(GenericIntrinsic gi) override {
+    // 0 operands for memories (no SSA), 1 operand for normal values.
+    unsigned n = gi.op.getNumOperands();
+    if (n != 0 && n != 1)
+      return true;
+    return gi.namedParam("name") || gi.namedParam("typeName") ||
+           gi.namedParam("params", /*optional=*/true) ||
+           gi.namedParam("enumFqn", /*optional=*/true) ||
+           gi.namedParam("enumTypeName", /*optional=*/true) ||
+           gi.namedParam("variants", /*optional=*/true) ||
+           gi.namedIntParam("width", /*optional=*/true) || gi.hasNParam(2, 5) ||
+           gi.hasNoOutput();
+  }
+
+  LogicalResult checkAndConvert(GenericIntrinsic gi,
+                                GenericIntrinsicOpAdaptor adaptor,
+                                PatternRewriter &rewriter,
+                                IntrinsicConvertContext ctx) override {
+    if (check(gi))
+      return failure();
+    auto varName = gi.getParamValue<StringAttr>("name");
+    auto typeName = gi.getParamValue<StringAttr>("typeName");
+    auto location = gi.op.getLoc();
+
+    if (varName && ctx.existingVariableNames &&
+        !ctx.existingVariableNames->insert(varName.getValue()).second)
+      gi.op->emitWarning("duplicate circt_debug_var with name '")
+          << varName.getValue() << "'";
+
+    ArrayAttr params;
+    if (auto paramAttr = gi.getParamValue<StringAttr>("params"))
+      params = parseParamsJSON(rewriter.getContext(), paramAttr, gi.op);
+
+    // A scalar enum var carries its variants inline; parse them here.
+    DictionaryAttr enumVariantsMap;
+    if (failed(parseInlineEnumVariants(gi, gi.op, rewriter.getContext(),
+                                       enumVariantsMap)))
+      return failure();
+
+    LeafMetaMap leafMap = collectLeafMeta(ctx.debugLeaves, varName);
+
+    auto root = resolveRootSignal(gi, adaptor, ctx, varName, rewriter);
+    if (failed(root))
+      return failure();
+    Value rawSignal = *root;
+    if (!rawSignal)
+      return success();
+
+    StringRef varPath = varName ? varName.getValue() : StringRef{};
+    Value dbgValue = DebugAggregateBuilder(rewriter, location, leafMap, gi.op)
+                         .buildRoot(rawSignal, varPath);
+    if (!dbgValue)
+      dbgValue = rawSignal;
+
+    // Scalar enum variable: wrap the value in a `dbg.enum` cast so the enum
+    // type travels with the value, with no separate op or FQN linkage.
+    if (enumVariantsMap)
+      dbgValue = debug::EnumOp::create(
+                     rewriter, location, dbgValue,
+                     gi.getParamValue<StringAttr>("enumTypeName"),
+                     enumVariantsMap, gi.getParamValue<StringAttr>("enumFqn"))
+                     .getResult();
+
+    // Root type metadata goes on a `dbg.value` wrapper, so `dbg.variable`
+    // itself stays metadata-free.
+    if (typeName || params)
+      dbgValue =
+          debug::ValueOp::create(rewriter, location, dbgValue, typeName, params)
+              .getResult();
+
+    rewriter.replaceOpWithNewOp<debug::VariableOp>(gi.op, varName, dbgValue,
+                                                   /*scope=*/Value{});
+    return success();
+  }
+
+private:
+  /// Collects this var's leaves, keyed by display path (what
+  /// `DebugAggregateBuilder` reconstructs). Linkage is by FQN: a leaf's
+  /// `parent` must exactly equal this var's FQN. Enum variant data rides
+  /// inline on the leaf descriptor (staged by `processSubfieldIntrinsic`).
+  static LeafMetaMap collectLeafMeta(const DebugLeafMap *debugLeaves,
+                                     StringAttr varName) {
+    LeafMetaMap leafMap;
+    if (!varName || !debugLeaves)
+      return leafMap;
+    auto it = debugLeaves->find(varName);
+    if (it == debugLeaves->end())
+      return leafMap;
+    for (auto entry : it->second) {
+      auto pathAttr = entry.getAs<StringAttr>("name");
+      if (!pathAttr)
+        continue;
+      LeafMeta meta;
+      meta.typeName = entry.getAs<StringAttr>("typeName");
+      meta.params = entry.getAs<ArrayAttr>("params");
+      meta.enumTypeName = entry.getAs<StringAttr>("enumTypeName");
+      meta.enumFqn = entry.getAs<StringAttr>("enumFqn");
+      meta.enumVariantsMap = entry.getAs<DictionaryAttr>("variantsMap");
+      leafMap[pathAttr.getValue()] = meta;
+    }
+    return leafMap;
+  }
+
+  /// Locates the SSA root to walk: the direct operand, or (for 0-operand vars)
+  /// a port/wire/reg named `varName` from the staged declaration index. Returns
+  /// null and erases the op for the no-SSA cases that are not errors (memory,
+  /// unresolved name); the caller then returns early. An ambiguous name is a
+  /// diagnosed error and returns failure with the op left in place.
+  ///
+  /// Name lookup assumes this runs BEFORE LowerTypes/PrettifyVerilogNames,
+  /// which rewrite port/wire names. Re-ordering passes breaks it silently.
+  static FailureOr<Value> resolveRootSignal(GenericIntrinsic gi,
+                                            GenericIntrinsicOpAdaptor adaptor,
+                                            IntrinsicConvertContext ctx,
+                                            StringAttr varName,
+                                            PatternRewriter &rewriter) {
+    if (!adaptor.getOperands().empty())
+      return adaptor.getOperands()[0];
+
+    bool isMemory = false;
+    if (ctx.namedDecls && varName) {
+      ArrayRef<Value> candidates;
+      if (auto it = ctx.namedDecls->byName.find(varName);
+          it != ctx.namedDecls->byName.end())
+        candidates = it->second;
+      isMemory = ctx.namedDecls->memoryNames.contains(varName);
+
+      size_t totalMatches = candidates.size() + (isMemory ? 1 : 0);
+      if (totalMatches > 1) {
+        gi.op->emitError("circt_debug_var: name '")
+            << varName.getValue() << "' is ambiguous (matches " << totalMatches
+            << " signals)";
+        return failure();
+      }
+      if (!isMemory && candidates.size() == 1)
+        return candidates[0];
+    }
+
+    // A memory has no single SSA root; drop the var silently. Anything else
+    // unresolved warns.
+    if (varName && !isMemory)
+      gi.op->emitWarning("circt_debug_var: no wire, port, or register named '")
+          << varName.getValue() << "' found";
+    rewriter.eraseOp(gi.op);
+    return Value{};
+  }
+};
+
+/// Drops `circt_debug_typedef`: there is no `dbg.typedef` op yet.
+class CirctDebugTypeDefConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+  bool check(GenericIntrinsic gi) override { return false; }
+  void convert(GenericIntrinsic gi, GenericIntrinsicOpAdaptor,
+               PatternRewriter &rewriter) override {
+    rewriter.eraseOp(gi.op);
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // View intrinsic converter and helpers
 //===----------------------------------------------------------------------===//
 
@@ -910,7 +1438,8 @@ class ViewConverter : public IntrinsicConverter {
 public:
   LogicalResult checkAndConvert(GenericIntrinsic gi,
                                 GenericIntrinsicOpAdaptor adaptor,
-                                PatternRewriter &rewriter) override {
+                                PatternRewriter &rewriter,
+                                IntrinsicConvertContext) override {
     // Check structure of the intrinsic.
     if (gi.hasNoOutput() || gi.namedParam("info") || gi.namedParam("name") ||
         gi.namedParam("yaml", true))
@@ -1006,4 +1535,125 @@ public:
 void FIRRTLIntrinsicLoweringDialectInterface::populateIntrinsicLowerings(
     IntrinsicLowerings &lowering) const {
   populateLowerings(lowering);
+  lowering.add<CirctDebugTypeDefConverter>("circt_debug_typedef");
+  lowering.add<CirctDebugVarConverter>("circt_debug_var");
+  lowering.add<CirctDebugModuleInfoConverter>("circt_debug_moduleinfo");
 }
+
+namespace {
+
+/// Validate one `circt_debug_subfield` and append a leaf descriptor to
+/// `entries`.
+LogicalResult processSubfieldIntrinsic(GenericIntrinsicOp op,
+                                       DebugLeafMap &entries) {
+  GenericIntrinsic gi{op};
+  auto nameAttr = gi.getParamValue<StringAttr>("name");
+  if (!nameAttr)
+    return op.emitError(
+        "circt_debug_subfield: missing required parameter 'name'");
+
+  auto parentAttr = gi.getParamValue<StringAttr>("parent");
+  if (!parentAttr)
+    return op.emitError(
+        "circt_debug_subfield: missing required parameter 'parent' "
+        "(must equal the 'name' of the enclosing circt_debug_var)");
+
+  // `name` must be a path rooted at `parent`; this catches a frontend that
+  // drops or mangles the root prefix.
+  auto name = nameAttr.getValue();
+  auto parent = parentAttr.getValue();
+  if (name.empty())
+    return op.emitError("circt_debug_subfield: 'name' must not be empty");
+  if (parent.empty())
+    return op.emitError("circt_debug_subfield: 'parent' must not be empty");
+  if (!name.starts_with(parent))
+    return op.emitError("circt_debug_subfield: 'name' (")
+           << name << ") is not rooted at 'parent' (" << parent
+           << "); expected '" << parent << ".<field>' or '" << parent
+           << "[<idx>]...'";
+
+  auto rest = name.drop_front(parent.size());
+  if (rest.empty() || (rest[0] != '.' && rest[0] != '['))
+    return op.emitError("circt_debug_subfield: 'name' (")
+           << name << ") is not rooted at 'parent' (" << parent
+           << "); expected '" << parent << ".<field>' or '" << parent
+           << "[<idx>]...'";
+
+  auto *ctx = op.getContext();
+  SmallVector<NamedAttribute> fields{};
+  fields.push_back({StringAttr::get(ctx, "name"), nameAttr});
+  fields.push_back({StringAttr::get(ctx, "parent"), parentAttr});
+  if (auto tn = gi.getParamValue<StringAttr>("typeName"))
+    fields.push_back({StringAttr::get(ctx, "typeName"), tn});
+  if (auto fqn = gi.getParamValue<StringAttr>("enumFqn");
+      fqn && !fqn.getValue().empty())
+    fields.push_back({StringAttr::get(ctx, "enumFqn"), fqn});
+  // `enumTypeName` is the bare source name (e.g. "AluOp"), mirrored as a
+  // string so EmitUHDI can resolve the type-pool entry by FQN. The variant
+  // data rides inline on this same leaf, so every enum use site is
+  // self-contained (no shared cross-module definition to resolve against).
+  if (auto etn = gi.getParamValue<StringAttr>("enumTypeName");
+      etn && !etn.getValue().empty())
+    fields.push_back({StringAttr::get(ctx, "enumTypeName"), etn});
+  // Parse the inline `variants`/`width` (if any) into a variantsMap, stored on
+  // the leaf for `DebugAggregateBuilder` to build a `dbg.enum` from.
+  DictionaryAttr variantsMap;
+  if (failed(parseInlineEnumVariants(gi, op, ctx, variantsMap)))
+    return failure();
+  if (variantsMap)
+    fields.push_back({StringAttr::get(ctx, "variantsMap"), variantsMap});
+  if (auto paramsStr = gi.getParamValue<StringAttr>("params"))
+    if (auto params = parseParamsJSON(ctx, paramsStr, op))
+      fields.push_back({StringAttr::get(ctx, "params"), params});
+
+  entries[parentAttr].push_back(DictionaryAttr::get(ctx, fields));
+  return success();
+}
+
+} // namespace
+
+namespace circt::firrtl {
+
+LogicalResult liftDebugIntrinsics(FModuleOp mod, DebugLeafMap &outLeaves,
+                                  NamedDeclIndex &outDecls) {
+  // Index ports up front; their SSA values are the module's block arguments.
+  for (auto [port, arg] : llvm::zip(mod.getPorts(), mod.getArguments()))
+    outDecls.byName[port.name].push_back(arg);
+
+  // A single walk collects the lifted subfield intrinsics and the named
+  // declarations a 0-operand `circt_debug_var` may resolve to.
+  SmallVector<GenericIntrinsicOp> intrinsics{};
+  mod.walk([&](Operation *op) {
+    TypeSwitch<Operation *>(op)
+        .Case<GenericIntrinsicOp>([&](auto gi) {
+          if (gi.getIntrinsic() == "circt_debug_subfield")
+            intrinsics.push_back(gi);
+        })
+        .Case<WireOp, NodeOp, RegOp, RegResetOp>([&](auto decl) {
+          outDecls.byName[decl.getNameAttr()].push_back(decl.getResult());
+        })
+        .Case<chirrtl::CombMemOp, chirrtl::SeqMemOp, MemOp>([&](auto mem) {
+          if (auto nameAttr = mem->template getAttrOfType<StringAttr>("name"))
+            outDecls.memoryNames.insert(nameAttr);
+        });
+  });
+
+  bool hadError = false;
+  for (auto op : intrinsics)
+    if (failed(processSubfieldIntrinsic(op, outLeaves)))
+      hadError = true;
+
+  for (auto op : intrinsics)
+    op.erase();
+
+  if (hadError) {
+    outLeaves.clear();
+    outDecls.byName.clear();
+    outDecls.memoryNames.clear();
+    return failure();
+  }
+
+  return success();
+}
+
+} // namespace circt::firrtl

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/Debug/DebugDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLIntrinsics.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/Pass/Pass.h"
@@ -39,20 +40,37 @@ struct LowerIntrinsicsPass
 };
 } // namespace
 
-/// Initialize the conversions for use during execution.
+/// Build the immutable converter set once, shared across module invocations.
 LogicalResult LowerIntrinsicsPass::initialize(MLIRContext *context) {
-  IntrinsicLowerings lowering(context);
-
-  IntrinsicLoweringInterfaceCollection loweringCollection(context);
-  loweringCollection.populateIntrinsicLowerings(lowering);
-
-  this->lowering = std::make_shared<IntrinsicLowerings>(std::move(lowering));
+  // The converter set is immutable, so it is safe to share across the parallel
+  // per-module invocations; per-module state rides in `lower`'s `ctx`.
+  this->lowering = std::make_shared<IntrinsicLowerings>(context);
+  IntrinsicLoweringInterfaceCollection collection(context);
+  collection.populateIntrinsicLowerings(*this->lowering);
   return success();
 }
 
 // This is the main entrypoint for the lowering pass.
 void LowerIntrinsicsPass::runOnOperation() {
-  auto result = lowering->lower(getOperation());
+  auto mod = getOperation();
+
+  // Phase 1: stage enumdef data, subfield leaves, and the named-declaration
+  // index into stack-local side channels (kept off the shared `lowering` for
+  // concurrency; see `lower`).
+  firrtl::DebugLeafMap debugLeaves;
+  llvm::StringMap<firrtl::EnumDefData> enumDefByFqn;
+  firrtl::NamedDeclIndex namedDecls;
+  if (mlir::failed(firrtl::liftDebugIntrinsics(mod, debugLeaves, enumDefByFqn,
+                                               namedDecls)))
+    return signalPassFailure();
+
+  // Phase 2: lower with a stack-local context. `seenVarNames` collects
+  // dbg.variable names as they are emitted; CirctDebugVarConverter uses it for
+  // O(1) duplicate detection instead of walking the growing IR each time.
+  llvm::StringSet<> seenVarNames;
+  firrtl::IntrinsicConvertContext convCtx{&debugLeaves, &enumDefByFqn,
+                                          &namedDecls, &seenVarNames};
+  auto result = lowering->lower(mod, /*allowUnknownIntrinsics=*/false, convCtx);
   if (failed(result))
     return signalPassFailure();
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/Debug/DebugDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLIntrinsics.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/Pass/Pass.h"
@@ -39,20 +40,35 @@ struct LowerIntrinsicsPass
 };
 } // namespace
 
-/// Initialize the conversions for use during execution.
+/// Build the immutable converter set once, shared across module invocations.
 LogicalResult LowerIntrinsicsPass::initialize(MLIRContext *context) {
-  IntrinsicLowerings lowering(context);
-
-  IntrinsicLoweringInterfaceCollection loweringCollection(context);
-  loweringCollection.populateIntrinsicLowerings(lowering);
-
-  this->lowering = std::make_shared<IntrinsicLowerings>(std::move(lowering));
+  // The converter set is immutable, so it is safe to share across the parallel
+  // per-module invocations; per-module state rides in `lower`'s `ctx`.
+  this->lowering = std::make_shared<IntrinsicLowerings>(context);
+  IntrinsicLoweringInterfaceCollection collection(context);
+  collection.populateIntrinsicLowerings(*this->lowering);
   return success();
 }
 
 // This is the main entrypoint for the lowering pass.
 void LowerIntrinsicsPass::runOnOperation() {
-  auto result = lowering->lower(getOperation());
+  auto mod = getOperation();
+
+  // Phase 1: stage subfield leaves and the named-declaration index into
+  // stack-local side channels (kept off the shared `lowering` for concurrency;
+  // see `lower`).
+  firrtl::DebugLeafMap debugLeaves;
+  firrtl::NamedDeclIndex namedDecls;
+  if (mlir::failed(firrtl::liftDebugIntrinsics(mod, debugLeaves, namedDecls)))
+    return signalPassFailure();
+
+  // Phase 2: lower with a stack-local context. `seenVarNames` collects
+  // dbg.variable names as they are emitted; CirctDebugVarConverter uses it for
+  // O(1) duplicate detection instead of walking the growing IR each time.
+  llvm::StringSet<> seenVarNames;
+  firrtl::IntrinsicConvertContext convCtx{&debugLeaves, &namedDecls,
+                                          &seenVarNames};
+  auto result = lowering->lower(mod, /*allowUnknownIntrinsics=*/false, convCtx);
   if (failed(result))
     return signalPassFailure();
 

--- a/test/Dialect/FIRRTL/lower-intrinsics-debug-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-debug-errors.mlir
@@ -1,0 +1,301 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-intrinsics)))' %s --split-input-file --verify-diagnostics
+
+// Malformed / missing-parameter cases for the FIRRTL debug intrinsics. The
+// pre-passes must diagnose these explicitly rather than silently dropping the
+// intrinsic and producing incomplete debug metadata.
+
+// -----
+
+// Missing 'fqn' param on circt_debug_enumdef.
+firrtl.circuit "EnumDefMissingFqn" {
+  firrtl.module @EnumDefMissingFqn() {
+    // expected-error @below {{circt_debug_enumdef: missing required parameter}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState",
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Missing 'typeName' param on circt_debug_enumdef.
+firrtl.circuit "EnumDefMissingTypeName" {
+  firrtl.module @EnumDefMissingTypeName() {
+    // expected-error @below {{circt_debug_enumdef: missing required parameter}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Missing 'variants' param on circt_debug_enumdef.
+firrtl.circuit "EnumDefMissingVariants" {
+  firrtl.module @EnumDefMissingVariants() {
+    // expected-error @below {{circt_debug_enumdef: missing required parameter}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$"> : () -> ()
+  }
+}
+
+// -----
+
+// Unparseable JSON in 'variants'.
+firrtl.circuit "EnumDefBadJSON" {
+  firrtl.module @EnumDefBadJSON() {
+    // expected-error @below {{circt_debug_enumdef: failed to parse 'variants'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{not valid json"> : () -> ()
+  }
+}
+
+// -----
+
+// Valid JSON that is not an array in 'variants'. Previously this silently
+// produced a dbg.enumdef with an empty variant map.
+firrtl.circuit "EnumDefVariantsNotArray" {
+  firrtl.module @EnumDefVariantsNotArray() {
+    // expected-error @below {{circt_debug_enumdef: 'variants' is not a JSON array}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "{}"> : () -> ()
+  }
+}
+
+// -----
+
+// Variant with a non-integer string value. Previously this silently produced a
+// variant with value 0.
+firrtl.circuit "EnumDefBadVariantValue" {
+  firrtl.module @EnumDefBadVariantValue() {
+    // expected-error @below {{circt_debug_enumdef: variant 'A' has non-integer value 'notanint'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"notanint\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Variant missing 'name'.
+firrtl.circuit "EnumDefVariantMissingName" {
+  firrtl.module @EnumDefVariantMissingName() {
+    // expected-error @below {{circt_debug_enumdef: variant is missing 'name'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"value\":\"0\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Variant missing 'value'.
+firrtl.circuit "EnumDefVariantMissingValue" {
+  firrtl.module @EnumDefVariantMissingValue() {
+    // expected-error @below {{circt_debug_enumdef: variant 'A' is missing 'value'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Two enumdefs with the same fqn but differing variants; the second must
+// not create a new dbg.enumdef, but the mismatch must be warned about.
+firrtl.circuit "EnumDefConflict" {
+  firrtl.module @EnumDefConflict() {
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"}]"> : () -> ()
+    // expected-warning @below {{duplicate circt_debug_enumdef for fqn 'pkg.MyState$' with differing variants}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"},{\"name\":\"B\",\"value\":\"1\"}]"> : () -> ()
+  }
+}
+
+// -----
+
+// Missing 'name' on circt_debug_subfield.
+firrtl.circuit "SubfieldMissingName" {
+  firrtl.module @SubfieldMissingName() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: missing required parameter 'name'}}
+    firrtl.int.generic "circt_debug_subfield"
+      <typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Missing 'parent' on circt_debug_subfield; without it the pre-pass cannot
+// link the leaf to its circt_debug_var.
+firrtl.circuit "SubfieldMissingParent" {
+  firrtl.module @SubfieldMissingParent() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: missing required parameter 'parent'}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var whose 'name' matches no wire/port/reg: converter
+// emits a warning and erases the op (see FIRRTLIntrinsics.cpp,
+// CirctDebugVarConverter::convert, the `!rawSignal` branch).
+firrtl.circuit "DebugVarUnresolved" {
+  firrtl.module @DebugVarUnresolved() {
+    // expected-warning @below {{circt_debug_var: no wire, port, or register named 'missing' found}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "missing", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// Two circt_debug_var with the same name="x" in one module; the second must
+// be diagnosed so metadata consumers (hgdb/tywaves) are not silently given a
+// duplicate variable entry. Implementation: walk of existing `dbg.variable`
+// ops at convert time (FIRRTLIntrinsics.cpp CirctDebugVarConverter::convert).
+firrtl.circuit "DebugVarDuplicateName" {
+  firrtl.module @DebugVarDuplicateName(in %x: !firrtl.uint<8>,
+                                       in %y: !firrtl.uint<8>) {
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt">
+      %x : (!firrtl.uint<8>) -> ()
+    // expected-warning @below {{duplicate circt_debug_var with name 'x'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt">
+      %y : (!firrtl.uint<8>) -> ()
+  }
+}
+
+// -----
+
+// 'name' is not rooted at 'parent'; frontend regression check.
+firrtl.circuit "SubfieldNameNotRooted" {
+  firrtl.module @SubfieldNameNotRooted() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'name' (state) is not rooted at 'parent' (io)}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "state", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Empty 'name' on circt_debug_subfield (finding #5).
+firrtl.circuit "SubfieldEmptyName" {
+  firrtl.module @SubfieldEmptyName() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'name' must not be empty}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Empty 'parent' on circt_debug_subfield (finding #5).
+firrtl.circuit "SubfieldEmptyParent" {
+  firrtl.module @SubfieldEmptyParent() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'parent' must not be empty}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt", parent: none = "">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Dangling enumFqn: circt_debug_var references an enumFqn for which no
+// circt_debug_enumdef exists. A warning must be emitted but UHDI lowering
+// continues (finding #4).
+firrtl.circuit "DanglingEnumFqn" {
+  firrtl.module @DanglingEnumFqn(in %s: !firrtl.uint<2>) {
+    // expected-warning @below {{no circt_debug_enumdef found for 'pkg.Missing$'; leaf will be emitted without enum binding}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "UInt", enumFqn: none = "pkg.Missing$">
+      %s : (!firrtl.uint<2>) -> ()
+  }
+}
+
+// -----
+
+// Wire and memory with the same name 'x': 0-operand debug_var must error
+// rather than silently picking the wire.
+firrtl.circuit "WireMemSameNameAmbiguity" {
+  firrtl.module @WireMemSameNameAmbiguity() {
+    %x = firrtl.wire : !firrtl.uint<8>
+    %x_mem = chirrtl.combmem {name = "x"} : !chirrtl.cmemory<uint<8>, 4>
+    // expected-error @below {{circt_debug_var: name 'x' is ambiguous (matches 2 signals)}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// Wide enum variant: a value that does not fit `width` is an error (truncating
+// it could collapse two variants onto one tag). The diagnostic formats the
+// value with APInt::toString, not getZExtValue() (which asserts on > 64 active
+// bits and used to abort here).
+firrtl.circuit "WideEnumVariant" {
+  firrtl.module @WideEnumVariant() {
+    // expected-error @below {{value 75557863725914323419136 does not fit in 70 bits}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "Big", fqn: none = "pkg.Big", width: i64 = 70,
+       variants: none = "[{\"name\":\"A\",\"value\":\"75557863725914323419136\"}]">
+      : () -> ()
+  }
+}
+
+// -----
+
+// Duplicate variant name: a DictionaryAttr would silently collapse the two
+// `A` entries, so the converter rejects it up front.
+firrtl.circuit "DupVariantName" {
+  firrtl.module @DupVariantName() {
+    // expected-error @below {{duplicate variant name 'A'}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "E", fqn: none = "pkg.E", width: i64 = 8,
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"},{\"name\":\"A\",\"value\":\"1\"}]">
+      : () -> ()
+  }
+}
+
+// -----
+
+// `width` with more than 64 active bits: getZExtValue() would assert, so the
+// converter rejects it before reading the value.
+firrtl.circuit "EnumWidthTooWide" {
+  firrtl.module @EnumWidthTooWide() {
+    // expected-error @below {{'width' parameter exceeds 64 bits}}
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "E", fqn: none = "pkg.E", width: i128 = 18446744073709551616,
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"}]">
+      : () -> ()
+  }
+}
+
+// -----
+
+// Malformed `params` JSON on circt_debug_var is non-fatal: the type-parameter
+// info is dropped with a warning and the variable is still emitted.
+firrtl.circuit "DebugVarBadParams" {
+  firrtl.module @DebugVarBadParams(in %x: !firrtl.uint<8>) {
+    // expected-warning @below {{debug params JSON failed to parse}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt", params: none = "[not valid json">
+      %x : (!firrtl.uint<8>) -> ()
+  }
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics-debug-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-debug-errors.mlir
@@ -1,0 +1,257 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-intrinsics)))' %s --split-input-file --verify-diagnostics
+
+// Malformed / missing-parameter cases for the FIRRTL debug intrinsics. The
+// pre-passes must diagnose these explicitly rather than silently dropping the
+// intrinsic and producing incomplete debug metadata. Enum variant data rides
+// inline on the var/subfield that uses it, so the enum diagnostics fire from
+// `parseInlineEnumVariants` on that intrinsic.
+//
+// A diagnosed var also leaves its `firrtl.int.generic` unlowered, hence the
+// second expected-error on those cases: the converter reports failure so the
+// conversion driver fails the pass, rather than letting the tool exit 0 with
+// an intrinsic it has already declared broken. Cases that only warn (a name
+// that resolves to nothing, unparseable `params`) still lower and drop the
+// var, so they carry no such line.
+
+// -----
+
+// Unparseable JSON in inline 'variants'.
+firrtl.circuit "EnumBadJSON" {
+  firrtl.module @EnumBadJSON(in %s: !firrtl.uint<2>) {
+    // expected-error @below {{debug enum: failed to parse 'variants'}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "MyState", enumFqn: none = "pkg.MyState$",
+       variants: none = "[{not valid json">
+      %s : (!firrtl.uint<2>) -> ()
+  }
+}
+
+// -----
+
+// Valid JSON that is not an array in 'variants'.
+firrtl.circuit "EnumVariantsNotArray" {
+  firrtl.module @EnumVariantsNotArray(in %s: !firrtl.uint<2>) {
+    // expected-error @below {{debug enum: 'variants' is not a JSON array}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "MyState", enumFqn: none = "pkg.MyState$",
+       variants: none = "{}">
+      %s : (!firrtl.uint<2>) -> ()
+  }
+}
+
+// -----
+
+// Variant with a non-integer string value.
+firrtl.circuit "EnumBadVariantValue" {
+  firrtl.module @EnumBadVariantValue(in %s: !firrtl.uint<2>) {
+    // expected-error @below {{debug enum: variant 'A' has non-integer value 'notanint'}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "MyState", enumFqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\",\"value\":\"notanint\"}]">
+      %s : (!firrtl.uint<2>) -> ()
+  }
+}
+
+// -----
+
+// Variant missing 'name'.
+firrtl.circuit "EnumVariantMissingName" {
+  firrtl.module @EnumVariantMissingName(in %s: !firrtl.uint<2>) {
+    // expected-error @below {{debug enum: variant is missing 'name'}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "MyState", enumFqn: none = "pkg.MyState$",
+       variants: none = "[{\"value\":\"0\"}]">
+      %s : (!firrtl.uint<2>) -> ()
+  }
+}
+
+// -----
+
+// Variant missing 'value'.
+firrtl.circuit "EnumVariantMissingValue" {
+  firrtl.module @EnumVariantMissingValue(in %s: !firrtl.uint<2>) {
+    // expected-error @below {{debug enum: variant 'A' is missing 'value'}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "MyState", enumFqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"A\"}]">
+      %s : (!firrtl.uint<2>) -> ()
+  }
+}
+
+// -----
+
+// Missing 'name' on circt_debug_subfield.
+firrtl.circuit "SubfieldMissingName" {
+  firrtl.module @SubfieldMissingName() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: missing required parameter 'name'}}
+    firrtl.int.generic "circt_debug_subfield"
+      <typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Missing 'parent' on circt_debug_subfield; without it the pre-pass cannot
+// link the leaf to its circt_debug_var.
+firrtl.circuit "SubfieldMissingParent" {
+  firrtl.module @SubfieldMissingParent() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: missing required parameter 'parent'}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var whose 'name' matches no wire/port/reg: converter
+// emits a warning and erases the op (see FIRRTLIntrinsics.cpp,
+// CirctDebugVarConverter::convert, the `!rawSignal` branch).
+firrtl.circuit "DebugVarUnresolved" {
+  firrtl.module @DebugVarUnresolved() {
+    // expected-warning @below {{circt_debug_var: no wire, port, or register named 'missing' found}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "missing", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// Two circt_debug_var with the same name="x" in one module; the second must
+// be diagnosed so metadata consumers (hgdb/tywaves) are not silently given a
+// duplicate variable entry. Implementation: walk of existing `dbg.variable`
+// ops at convert time (FIRRTLIntrinsics.cpp CirctDebugVarConverter::convert).
+firrtl.circuit "DebugVarDuplicateName" {
+  firrtl.module @DebugVarDuplicateName(in %x: !firrtl.uint<8>,
+                                       in %y: !firrtl.uint<8>) {
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt">
+      %x : (!firrtl.uint<8>) -> ()
+    // expected-warning @below {{duplicate circt_debug_var with name 'x'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt">
+      %y : (!firrtl.uint<8>) -> ()
+  }
+}
+
+// -----
+
+// 'name' is not rooted at 'parent'; frontend regression check.
+firrtl.circuit "SubfieldNameNotRooted" {
+  firrtl.module @SubfieldNameNotRooted() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'name' (state) is not rooted at 'parent' (io)}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "state", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Empty 'name' on circt_debug_subfield (finding #5).
+firrtl.circuit "SubfieldEmptyName" {
+  firrtl.module @SubfieldEmptyName() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'name' must not be empty}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Empty 'parent' on circt_debug_subfield (finding #5).
+firrtl.circuit "SubfieldEmptyParent" {
+  firrtl.module @SubfieldEmptyParent() {
+    %io = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    // expected-error @below {{circt_debug_subfield: 'parent' must not be empty}}
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt", parent: none = "">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+  }
+}
+
+// -----
+
+// Wire and memory with the same name 'x': 0-operand debug_var must error
+// rather than silently picking the wire.
+firrtl.circuit "WireMemSameNameAmbiguity" {
+  firrtl.module @WireMemSameNameAmbiguity() {
+    %x = firrtl.wire : !firrtl.uint<8>
+    %x_mem = chirrtl.combmem {name = "x"} : !chirrtl.cmemory<uint<8>, 4>
+    // expected-error @below {{circt_debug_var: name 'x' is ambiguous (matches 2 signals)}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// Wide enum variant: a value that does not fit `width` is an error (truncating
+// it could collapse two variants onto one tag). The diagnostic formats the
+// value with APInt::toString, not getZExtValue() (which asserts on > 64 active
+// bits and used to abort here).
+firrtl.circuit "WideEnumVariant" {
+  firrtl.module @WideEnumVariant(in %s: !firrtl.uint<70>) {
+    // expected-error @below {{value 75557863725914323419136 does not fit in 70 bits}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "Big", enumFqn: none = "pkg.Big", width: i64 = 70,
+       variants: none = "[{\"name\":\"A\",\"value\":\"75557863725914323419136\"}]">
+      %s : (!firrtl.uint<70>) -> ()
+  }
+}
+
+// -----
+
+// Duplicate variant name: a DictionaryAttr would silently collapse the two
+// `A` entries, so the converter rejects it up front.
+firrtl.circuit "DupVariantName" {
+  firrtl.module @DupVariantName(in %s: !firrtl.uint<8>) {
+    // expected-error @below {{duplicate variant name 'A'}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "E", enumFqn: none = "pkg.E", width: i64 = 8,
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"},{\"name\":\"A\",\"value\":\"1\"}]">
+      %s : (!firrtl.uint<8>) -> ()
+  }
+}
+
+// -----
+
+// `width` with more than 64 active bits: getZExtValue() would assert, so the
+// converter rejects it before reading the value.
+firrtl.circuit "EnumWidthTooWide" {
+  firrtl.module @EnumWidthTooWide(in %s: !firrtl.uint<8>) {
+    // expected-error @below {{'width' parameter exceeds 64 bits}}
+    // expected-error @below {{failed to legalize operation 'firrtl.int.generic'}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "E", enumFqn: none = "pkg.E", width: i128 = 18446744073709551616,
+       variants: none = "[{\"name\":\"A\",\"value\":\"0\"}]">
+      %s : (!firrtl.uint<8>) -> ()
+  }
+}
+
+// -----
+
+// Malformed `params` JSON on circt_debug_var is non-fatal: the type-parameter
+// info is dropped with a warning and the variable is still emitted.
+firrtl.circuit "DebugVarBadParams" {
+  firrtl.module @DebugVarBadParams(in %x: !firrtl.uint<8>) {
+    // expected-warning @below {{debug params JSON failed to parse}}
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt", params: none = "[not valid json">
+      %x : (!firrtl.uint<8>) -> ()
+  }
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics-debug-fatal.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-debug-fatal.mlir
@@ -1,0 +1,30 @@
+// A diagnosed debug intrinsic must fail the pass, not merely print. When the
+// converter reports an error but still returns success, the tool exits 0 and
+// leaves the unlowered `firrtl.int.generic` in the IR, so every downstream pass
+// sees an intrinsic that was already reported as broken.
+//
+// RUN: not circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-intrinsics)))' %s --split-input-file 2>&1 | FileCheck %s
+
+// CHECK: error: debug enum: failed to parse 'variants'
+// CHECK: failed to legalize operation 'firrtl.int.generic'
+firrtl.circuit "EnumBadJSON" {
+  firrtl.module @EnumBadJSON(in %s: !firrtl.uint<2>) {
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "MyState", enumFqn: none = "pkg.MyState$",
+       variants: none = "[{not valid json">
+      %s : (!firrtl.uint<2>) -> ()
+  }
+}
+
+// -----
+
+// CHECK: error: circt_debug_var: name 'x' is ambiguous
+// CHECK: failed to legalize operation 'firrtl.int.generic'
+firrtl.circuit "AmbiguousName" {
+  firrtl.module @AmbiguousName() {
+    %x = firrtl.wire : !firrtl.uint<8>
+    %x_mem = chirrtl.combmem {name = "x"} : !chirrtl.cmemory<uint<8>, 4>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "x", typeName: none = "UInt"> : () -> ()
+  }
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics-debug.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-debug.mlir
@@ -1,0 +1,649 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-intrinsics)))' %s --split-input-file | FileCheck %s
+
+// Scalar, bundle, and vec cases for the three FIRRTL debug intrinsics
+// (circt_debug_moduleinfo, circt_debug_var, circt_debug_subfield) and
+// circt_debug_enumdef.
+
+// moduleinfo lowers to a discardable attribute on the module (empty params
+// array is forwarded as []); DictionaryAttr keys sort lexicographically.
+// CHECK-LABEL: firrtl.module @DebugTest
+// CHECK-SAME: attributes {dbg.moduleinfo = {params = [], typeName = "MyModule"}}
+firrtl.circuit "DebugTest" {
+  firrtl.module @DebugTest(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+
+    // 1. moduleinfo -> module attribute, intrinsic erased
+    firrtl.int.generic "circt_debug_moduleinfo"
+      <typeName: none = "MyModule", params: none = "[]"> : () -> ()
+
+    // 2. enumdef with JSON array (value serialized as string by frontend).
+    //    No module-level op is materialised; the variant data is staged and
+    //    realised as an inline `dbg.enum` at each use site.
+    // CHECK-NOT: dbg.enumdef
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"Idle\",\"value\":\"0\"},{\"name\":\"Run\",\"value\":\"1\"}]">
+      : () -> ()
+
+    // 3. circt_debug_var on scalar wire -> dbg.value + dbg.variable
+    // CHECK: %[[W:.+]] = dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "w", %[[W]] : !dbg.value
+    %w = firrtl.wire : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "w", typeName: none = "UInt">
+      %w : (!firrtl.uint<8>) -> ()
+
+    // 4. circt_debug_var on a passive bundle -> dbg.struct + dbg.variable
+    //    The converter builds:
+    //      %a = firrtl.subfield %io[in]
+    //      %b = firrtl.subfield %io[out]
+    //      %s = dbg.struct {"in": %a, "out": %b}
+    //      %x = dbg.value %s typeName "MyBundle"
+    //      dbg.variable "io", %x
+    // CHECK:      firrtl.subfield %io[in]
+    // CHECK:      firrtl.subfield %io[out]
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK: %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK: dbg.variable "io", %[[IO]] : !dbg.value
+    %io = firrtl.wire : !firrtl.bundle<in: uint<8>, out: uint<8>>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<in: uint<8>, out: uint<8>>) -> ()
+
+    // 5. circt_debug_var on a Vec -> dbg.array + dbg.variable
+    // CHECK:      firrtl.subindex %v[0]
+    // CHECK:      firrtl.subindex %v[1]
+    // CHECK:      %[[A:.+]] = dbg.array
+    // CHECK-NEXT: %[[V:.+]] = dbg.value %[[A]] typeName "Vec" : !dbg.array
+    // CHECK-NEXT: dbg.variable "v", %[[V]] : !dbg.value
+    %v = firrtl.wire : !firrtl.vector<uint<4>, 2>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "Vec">
+      %v : (!firrtl.vector<uint<4>, 2>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Bundle with an enum-typed field -- the field must get a dbg.value
+// wrapping it with an enumDef reference.
+//
+// A frontend emits:
+//   circt_debug_enumdef for MyState
+//   circt_debug_subfield(parent="io", name="state") for io.state with enumFqn
+//   circt_debug_subfield(parent="io", name="data")  for io.data
+//   circt_debug_var(name="io")                      for io
+
+// CHECK-LABEL: firrtl.module @BundleEnumFieldTest
+firrtl.circuit "BundleEnumFieldTest" {
+  firrtl.module @BundleEnumFieldTest(
+      in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+
+    // No module-level enumdef op is materialised; the variant data is staged.
+    // CHECK-NOT: dbg.enumdef
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"Idle\",\"value\":\"0\"},{\"name\":\"Run\",\"value\":\"1\"}]">
+      : () -> ()
+
+    %io = firrtl.wire : !firrtl.bundle<state: uint<2>, data: uint<8>>
+
+    // Leaf io.state with enumFqn -- captured into leafMetaMap, erased
+    // CHECK-NOT: circt_debug_subfield
+    // CHECK-NOT: dbg.variable "state"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.state", typeName: none = "UInt", parent: none = "io",
+       enumTypeName: none = "MyState", enumFqn: none = "pkg.MyState$">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    // Leaf io.data without enum
+    // CHECK-NOT: dbg.variable "data"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.data", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    // Root circt_debug_var -- produces dbg.struct + dbg.variable. The enum
+    // leaf's value is wrapped in an inline `dbg.enum` carrying the variants.
+    // CHECK:      firrtl.subfield %{{.*}}[state]
+    // CHECK:      %[[E:.+]] = dbg.enum %{{.*}}, "MyState", {Idle = 0 : i64, Run = 1 : i64} fqn "pkg.MyState$" : !firrtl.uint<2>
+    // CHECK:      dbg.value %[[E]] typeName "UInt" : !dbg.enum
+    // CHECK:      firrtl.subfield %{{.*}}[data]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "io", %[[IO]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Bundle with a true FEnumType field -- FEnumType::isGround() returns false,
+// so the field must be routed through the FEnumType case in build(), not
+// dropped by the FIRRTLBaseType fallback.
+
+// CHECK-LABEL: firrtl.module @BundleFEnumFieldTest
+firrtl.circuit "BundleFEnumFieldTest" {
+  firrtl.module @BundleFEnumFieldTest(
+      in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+
+    // CHECK-NOT: dbg.enumdef
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "MyState", fqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"Idle\",\"value\":\"0\"},{\"name\":\"Run\",\"value\":\"1\"}]">
+      : () -> ()
+
+    %io = firrtl.wire : !firrtl.bundle<state: enum<Idle: uint<0>, Run: uint<0>>, data: uint<8>>
+
+    // CHECK-NOT: circt_debug_subfield
+    // CHECK-NOT: dbg.variable "state"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.state", typeName: none = "UInt", parent: none = "io",
+       enumTypeName: none = "MyState", enumFqn: none = "pkg.MyState$">
+      %io : (!firrtl.bundle<state: enum<Idle: uint<0>, Run: uint<0>>, data: uint<8>>) -> ()
+
+    // CHECK-NOT: dbg.variable "data"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.data", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<state: enum<Idle: uint<0>, Run: uint<0>>, data: uint<8>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[state]
+    // CHECK:      %[[E:.+]] = dbg.enum %{{.*}}, "MyState", {Idle = 0 : i64, Run = 1 : i64} fqn "pkg.MyState$" : !firrtl.enum<Idle, Run>
+    // CHECK:      dbg.value %[[E]] typeName "UInt" : !dbg.enum
+    // CHECK:      firrtl.subfield %{{.*}}[data]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "io", %[[IO]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<state: enum<Idle: uint<0>, Run: uint<0>>, data: uint<8>>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Bundle with a FixedPoint field carrying type parameters.
+// Verifies that the "params" JSON string is parsed and forwarded to
+// dbg.value as an ArrayAttr of DictionaryAttrs.
+
+// CHECK-LABEL: firrtl.module @BundleParamsFieldTest
+firrtl.circuit "BundleParamsFieldTest" {
+  firrtl.module @BundleParamsFieldTest(
+      in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+
+    %io = firrtl.wire : !firrtl.bundle<fp: uint<8>, data: uint<8>>
+
+    // Leaf io.fp with params
+    // CHECK-NOT: dbg.variable "fp"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.fp", typeName: none = "FixedPoint", parent: none = "io",
+       params: none = "[{\"name\":\"width\",\"value\":\"8\"},{\"name\":\"binaryPoint\",\"value\":\"4\"}]">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    // Leaf io.data without params
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.data", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    // Root circt_debug_var -- produces dbg.struct + dbg.variable
+    // CHECK:      firrtl.subfield %{{.*}}[fp]
+    // CHECK:      dbg.value %{{.*}} typeName "FixedPoint" params [{name = "width", value = "8"}, {name = "binaryPoint", value = "4"}] : !firrtl.uint<8>
+    // CHECK:      firrtl.subfield %{{.*}}[data]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "io", %[[IO]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// moduleinfo with constructor params
+
+// CHECK-LABEL: firrtl.module @ModuleInfoWithParams
+// CHECK-SAME: attributes {dbg.moduleinfo = {params = [{name = "width", value = "8"}], typeName = "Counter"}}
+firrtl.circuit "ModuleInfoWithParams" {
+  firrtl.module @ModuleInfoWithParams() {
+    firrtl.int.generic "circt_debug_moduleinfo"
+      <typeName: none = "Counter",
+       params: none = "[{\"name\":\"width\",\"value\":\"8\"}]">
+      : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var: the frontend emits no SSA operand when the
+// referenced value is a non-passive aggregate (e.g. a bidirectional bundle
+// port) whose SSA form is not directly assignable to a dbg.variable. The
+// converter must locate the matching port / wire / node / reg by name.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarPort
+firrtl.circuit "ZeroOperandVarPort" {
+  firrtl.module @ZeroOperandVarPort(
+      in %a: !firrtl.uint<8>,
+      out %b: !firrtl.uint<8>) {
+    // Match by port name; resolves to the block argument %a.
+    // CHECK: %[[V:.+]] = dbg.value %a typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "a", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "a", typeName: none = "UInt"> : () -> ()
+
+    firrtl.connect %b, %a : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a wire.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarWire
+firrtl.circuit "ZeroOperandVarWire" {
+  firrtl.module @ZeroOperandVarWire() {
+    // CHECK: %mywire = firrtl.wire
+    %mywire = firrtl.wire : !firrtl.uint<8>
+    // CHECK: %[[V:.+]] = dbg.value %mywire typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "mywire", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "mywire", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var with no matching port/wire/reg is silently erased
+// (a warning is emitted by the converter; the warning case is asserted by
+// `DebugVarUnresolved` in lower-intrinsics-debug-errors.mlir). Here we just
+// confirm no `dbg.variable` is produced.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarNoMatch
+firrtl.circuit "ZeroOperandVarNoMatch" {
+  firrtl.module @ZeroOperandVarNoMatch() {
+    // CHECK-NOT: dbg.variable
+    // CHECK-NOT: circt_debug_var
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "nonexistent", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.reg.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarReg
+firrtl.circuit "ZeroOperandVarReg" {
+  firrtl.module @ZeroOperandVarReg(in %clk: !firrtl.clock) {
+    // CHECK: %myreg = firrtl.reg
+    %myreg = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[V:.+]] = dbg.value %myreg typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "myreg", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "myreg", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.regreset (async reset)
+// with a bundle type.  The fallback name-walk must handle RegResetOp the same
+// way it handles RegOp.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarRegReset
+firrtl.circuit "ZeroOperandVarRegReset" {
+  firrtl.module @ZeroOperandVarRegReset(
+      in %clk: !firrtl.clock,
+      in %rst: !firrtl.asyncreset) {
+    // CHECK: %r = firrtl.regreset
+    %c0 = firrtl.aggregateconstant [0 : ui8, 0 : ui8] : !firrtl.bundle<x: uint<8>, y: uint<8>>
+    %r = firrtl.regreset %clk, %rst, %c0 :
+        !firrtl.clock, !firrtl.asyncreset,
+        !firrtl.bundle<x: uint<8>, y: uint<8>>,
+        !firrtl.bundle<x: uint<8>, y: uint<8>>
+    // CHECK:      firrtl.subfield %r[x]
+    // CHECK:      firrtl.subfield %r[y]
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[R:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "r", %[[R]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "r", typeName: none = "MyBundle"> : () -> ()
+  }
+}
+
+// -----
+
+// Nested aggregate: bundle whose field is itself a bundle. Exercises
+// recursion in DebugAggregateBuilder: the outer struct contains an inner
+// struct, with a leaf-meta entry on the deepest field.
+
+// CHECK-LABEL: firrtl.module @NestedBundleTest
+firrtl.circuit "NestedBundleTest" {
+  firrtl.module @NestedBundleTest() {
+    %io = firrtl.wire : !firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>
+
+    // Subfield meta on a deeply nested leaf: io.inner.a
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.inner.a", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[inner]
+    // CHECK:      firrtl.subfield %{{.*}}[a]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<4>
+    // CHECK:      firrtl.subfield %{{.*}}[b]
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "Outer">
+      %io : (!firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>) -> ()
+  }
+}
+
+// -----
+
+// circt_debug_typedef is silently consumed: no representation in the IR yet,
+// and no error.
+
+// CHECK-LABEL: firrtl.module @TypeDefDropped
+firrtl.circuit "TypeDefDropped" {
+  firrtl.module @TypeDefDropped() {
+    // CHECK-NOT: circt_debug_typedef
+    firrtl.int.generic "circt_debug_typedef"
+      <typeName: none = "MyAlias"> : () -> ()
+  }
+}
+
+// -----
+
+// Nested bundle: bundle<a: bundle<b: uint<8>>>.
+// A single circt_debug_subfield for the leaf "io.a.b" (parent="io") and a
+// circt_debug_var for the root "io".  The converter must recurse two levels:
+//   outer struct {"a": inner_struct}
+//   inner struct {"b": dbg.value with the leaf meta}
+//
+// Expected lowering:
+//   firrtl.subfield %io[a]            -- descend into outer field
+//   firrtl.subfield %<a_val>[b]       -- descend into inner field
+//   dbg.value ...                     -- leaf with meta
+//   dbg.struct {"b": ...}             -- inner struct
+//   dbg.struct {"a": ...}             -- outer struct
+//   dbg.value ... typeName "MyBundle" -- root metadata wrapper
+//   dbg.variable "io", ...            -- root variable
+
+// CHECK-LABEL: firrtl.module @NestedBundleSingleLeafTest
+firrtl.circuit "NestedBundleSingleLeafTest" {
+  firrtl.module @NestedBundleSingleLeafTest() {
+    %io = firrtl.wire : !firrtl.bundle<a: bundle<b: uint<8>>>
+
+    // Leaf at depth-2: io.a.b
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.a.b", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<a: bundle<b: uint<8>>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[a]
+    // CHECK:      firrtl.subfield %{{.*}}[b]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.struct
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "io", %[[IO]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<a: bundle<b: uint<8>>>) -> ()
+  }
+}
+
+// -----
+
+// Nested vector: vector<vector<uint<8>,2>,2> with a circt_debug_subfield leaf
+// for path v[0][1]. Exercises two levels of firrtl.subindex in
+// DebugAggregateBuilder, producing nested dbg.array ops with the leaf wrapped
+// in dbg.value at position [0][1]. Guards subindex-based leaf lookup through
+// vector-of-vector.
+
+// CHECK-LABEL: firrtl.module @NestedVecTest
+firrtl.circuit "NestedVecTest" {
+  firrtl.module @NestedVecTest() {
+    %v = firrtl.wire : !firrtl.vector<vector<uint<8>, 2>, 2>
+
+    // Leaf for v[0][1]: parent="v", name="v[0][1]"
+    // CHECK-NOT: circt_debug_subfield
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "v[0][1]", typeName: none = "UInt", parent: none = "v">
+      %v : (!firrtl.vector<vector<uint<8>, 2>, 2>) -> ()
+
+    // Root circt_debug_var -- must produce nested dbg.array ops:
+    //   outer dbg.array contains two inner dbg.array values;
+    //   inner dbg.array at index 0 has its element at index 1 wrapped in
+    //   a dbg.value carrying the leaf meta.
+    // CHECK:      firrtl.subindex %v[0]
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      firrtl.subindex %{{.*}}[1]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.array
+    // CHECK:      firrtl.subindex %v[1]
+    // CHECK:      dbg.array
+    // CHECK:      dbg.array
+    // CHECK:      dbg.variable "v"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "Vec">
+      %v : (!firrtl.vector<vector<uint<8>, 2>, 2>) -> ()
+  }
+}
+
+// -----
+
+// circt_debug_var inside a firrtl.layerblock must lower to dbg.variable
+// that remains nested inside the same layerblock (walk is recursive).
+
+// CHECK-LABEL: firrtl.module @LayerBlockDebugVar
+firrtl.circuit "LayerBlockDebugVar" {
+  firrtl.layer @MyLayer bind {}
+  firrtl.module @LayerBlockDebugVar(in %in: !firrtl.uint<8>) {
+    firrtl.layerblock @MyLayer {
+      // CHECK: firrtl.layerblock @MyLayer {
+      %w = firrtl.wire : !firrtl.uint<8>
+      firrtl.connect %w, %in : !firrtl.uint<8>, !firrtl.uint<8>
+      // CHECK: %[[V:.+]] = dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+      // CHECK: dbg.variable "w", %[[V]] : !dbg.value
+      firrtl.int.generic "circt_debug_var"
+        <name: none = "w", typeName: none = "UInt">
+        %w : (!firrtl.uint<8>) -> ()
+    }
+  }
+}
+
+// -----
+
+// Prefix-collision guard: two variables "io" and "iox" exist in the same
+// module. A circt_debug_subfield with parent="io" and name="io.x" must only
+// match the variable named exactly "io", not "iox". The boundary check in
+// processSubfieldIntrinsic uses `starts_with(parent + ".")` and
+// `starts_with(parent + "[")` -- bare `starts_with(parent)` would let "io.x"
+// match "iox" (since "io.x".starts_with("io") is true for both "io" and "iox"
+// after stripping the dot). This test pins that "iox" never gets the leaf.
+
+// CHECK-LABEL: firrtl.module @PrefixCollisionGuard
+firrtl.circuit "PrefixCollisionGuard" {
+  firrtl.module @PrefixCollisionGuard() {
+    %io  = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    %iox = firrtl.wire : !firrtl.uint<8>
+
+    // Leaf belongs to "io", NOT to "iox".
+    // CHECK-NOT: circt_debug_subfield
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+
+    // "io" variable: must receive the leaf and produce dbg.value.
+    // CHECK:      firrtl.subfield %{{.*}}[x]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+
+    // "iox" variable: no leaf should be associated; must NOT produce dbg.struct.
+    // CHECK:      %[[X:.+]] = dbg.value %iox typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.variable "iox", %[[X]] : !dbg.value
+    // CHECK-NOT:  dbg.struct
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "iox", typeName: none = "UInt">
+      %iox : (!firrtl.uint<8>) -> ()
+  }
+}
+
+// -----
+
+// Mixed-path regression guard (PASSING): verify that `starts_with` in
+// processSubfieldIntrinsic (FIRRTLIntrinsics.cpp ~1412) correctly accepts
+// both `parent + "["` (vec-rooted leaf) and `parent + "."` (bundle-rooted leaf).
+//
+// (a) vector<bundle<x: uint<8>>, 2>  with leaf "v[0].x"
+//     parent="v", name starts with "v[" -> starts_with(parent+"[") fires. PASSING.
+// (b) bundle<v: vector<uint<8>, 1>>  with leaf "b.v[0]"
+//     parent="b", name starts with "b." -> starts_with(parent+".") fires. PASSING.
+//     (size-1 vector keeps dbg.array operands homogeneous to avoid type mismatch)
+//
+// If either check regresses, processSubfieldIntrinsic emits a diagnostic and
+// firrtl-lower-intrinsics fails, making this FileCheck run fail. Guards:
+//   (a) starts_with(parent+"[") still matches vec-rooted paths
+//   (b) starts_with(parent+".") still matches bundle-rooted vec paths
+
+// CHECK-LABEL: firrtl.module @MixedPathSubfieldTest
+firrtl.circuit "MixedPathSubfieldTest" {
+  firrtl.module @MixedPathSubfieldTest() {
+
+    // (a) vector<bundle<x: uint<8>>, 2>, leaf "v[0].x"
+    // CHECK-NOT: circt_debug_subfield
+    %v = firrtl.wire : !firrtl.vector<bundle<x: uint<8>>, 2>
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "v[0].x", typeName: none = "UInt", parent: none = "v">
+      %v : (!firrtl.vector<bundle<x: uint<8>>, 2>) -> ()
+
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      firrtl.subfield %{{.*}}[x]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.variable "v"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "VecBundle">
+      %v : (!firrtl.vector<bundle<x: uint<8>>, 2>) -> ()
+
+    // (b) bundle<v: vector<uint<8>, 1>>, leaf "b.v[0]"
+    // Use size-1 vector so all dbg.array operands share one type (dbg.value),
+    // avoiding the mixed-type dbg.array constraint that would fire with size>1
+    // when only one element carries a dbg.value leaf.
+    %b = firrtl.wire : !firrtl.bundle<v: vector<uint<8>, 1>>
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "b.v[0]", typeName: none = "UInt", parent: none = "b">
+      %b : (!firrtl.bundle<v: vector<uint<8>, 1>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[v]
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.variable "b"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "b", typeName: none = "BundleVec">
+      %b : (!firrtl.bundle<v: vector<uint<8>, 1>>) -> ()
+  }
+}
+
+// -----
+
+// sint<8> operand: the signedness path must lower to dbg.variable just like
+// uint<8>. (FIRRTLBaseType::isGround() returns true for sint, so the scalar
+// branch in DebugAggregateBuilder fires.)
+
+// CHECK-LABEL: firrtl.module @SIntVar
+firrtl.circuit "SIntVar" {
+  firrtl.module @SIntVar(in %s: !firrtl.sint<8>) {
+    // CHECK: %[[V:.+]] = dbg.value %s typeName "SInt" : !firrtl.sint<8>
+    // CHECK: dbg.variable "s", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "SInt">
+      %s : (!firrtl.sint<8>) -> ()
+  }
+}
+
+// -----
+
+// uint<0> (zero-width): still a ground type -> dbg.variable is emitted.
+
+// CHECK-LABEL: firrtl.module @ZeroWidthVar
+firrtl.circuit "ZeroWidthVar" {
+  firrtl.module @ZeroWidthVar(in %z: !firrtl.uint<0>) {
+    // CHECK: %[[V:.+]] = dbg.value %z typeName "UInt" : !firrtl.uint<0>
+    // CHECK: dbg.variable "z", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "z", typeName: none = "UInt">
+      %z : (!firrtl.uint<0>) -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.node.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarNode
+firrtl.circuit "ZeroOperandVarNode" {
+  firrtl.module @ZeroOperandVarNode(in %in: !firrtl.uint<8>) {
+    // CHECK: %mynode = firrtl.node
+    %mynode = firrtl.node %in : !firrtl.uint<8>
+    // CHECK: %[[V:.+]] = dbg.value %mynode typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "mynode", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "mynode", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// Width-aware enumdef: optional `width` sizes variant IntegerAttrs (here
+// uint<2> -> i2). Without `width`, the i64 fallback keeps existing tests.
+
+// CHECK-LABEL: firrtl.module @EnumDefWithWidth
+firrtl.circuit "EnumDefWithWidth" {
+  firrtl.module @EnumDefWithWidth() {
+    // Width-aware parsing still runs (i2 variants), but with no use site the
+    // staged data is never materialised into an op, so nothing is emitted.
+    // CHECK-NOT: dbg.enum
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "AluOp", fqn: none = "pkg.AluOp$",
+       width: i64 = 2,
+       variants: none = "[{\"name\":\"ADD\",\"value\":\"0\"},{\"name\":\"SUB\",\"value\":\"1\"},{\"name\":\"AND\",\"value\":\"2\"},{\"name\":\"OR\",\"value\":\"3\"}]">
+      : () -> ()
+  }
+}
+
+// -----
+
+// Pins that width=64 variants with value >= 2^63 (upper unsigned half) parse.
+
+// CHECK-LABEL: firrtl.module @EnumDefWideVariantTest
+firrtl.circuit "EnumDefWideVariantTest" {
+  firrtl.module @EnumDefWideVariantTest() {
+    // Parsing of width=64 variants >= 2^63 still runs; no use site, no op.
+    // CHECK-NOT: dbg.enum
+    firrtl.int.generic "circt_debug_enumdef"
+      <typeName: none = "WideEnum", fqn: none = "pkg.WideEnum$",
+       width: i64 = 64,
+       variants: none = "[{\"name\":\"ZERO\",\"value\":\"0\"},{\"name\":\"TOP\",\"value\":\"9223372036854775808\"}]">
+      : () -> ()
+  }
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics-debug.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-debug.mlir
@@ -1,0 +1,640 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lower-intrinsics)))' %s --split-input-file | FileCheck %s
+
+// Scalar, bundle, and vec cases for the FIRRTL debug intrinsics
+// (circt_debug_moduleinfo, circt_debug_var, circt_debug_subfield). Enum
+// variants ride inline on the var/subfield that uses them.
+
+// moduleinfo lowers to a discardable attribute on the module (empty params
+// array is forwarded as []); DictionaryAttr keys sort lexicographically.
+// CHECK-LABEL: firrtl.module @DebugTest
+// CHECK-SAME: attributes {dbg.moduleinfo = {params = [], typeName = "MyModule"}}
+firrtl.circuit "DebugTest" {
+  firrtl.module @DebugTest(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+
+    // 1. moduleinfo -> module attribute, intrinsic erased
+    firrtl.int.generic "circt_debug_moduleinfo"
+      <typeName: none = "MyModule", params: none = "[]"> : () -> ()
+
+    // No `circt_debug_enumdef` intrinsic exists; enum data is inline.
+    // CHECK-NOT: dbg.enumdef
+
+    // 3. circt_debug_var on scalar wire -> dbg.value + dbg.variable
+    // CHECK: %[[W:.+]] = dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "w", %[[W]] : !dbg.value
+    %w = firrtl.wire : !firrtl.uint<8>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "w", typeName: none = "UInt">
+      %w : (!firrtl.uint<8>) -> ()
+
+    // 4. circt_debug_var on a passive bundle -> dbg.struct + dbg.variable
+    //    The converter builds:
+    //      %a = firrtl.subfield %io[in]
+    //      %b = firrtl.subfield %io[out]
+    //      %s = dbg.struct {"in": %a, "out": %b}
+    //      %x = dbg.value %s typeName "MyBundle"
+    //      dbg.variable "io", %x
+    // CHECK:      firrtl.subfield %io[in]
+    // CHECK:      firrtl.subfield %io[out]
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK: %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK: dbg.variable "io", %[[IO]] : !dbg.value
+    %io = firrtl.wire : !firrtl.bundle<in: uint<8>, out: uint<8>>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<in: uint<8>, out: uint<8>>) -> ()
+
+    // 5. circt_debug_var on a Vec -> dbg.array + dbg.variable
+    // CHECK:      firrtl.subindex %v[0]
+    // CHECK:      firrtl.subindex %v[1]
+    // CHECK:      %[[A:.+]] = dbg.array
+    // CHECK-NEXT: %[[V:.+]] = dbg.value %[[A]] typeName "Vec" : !dbg.array
+    // CHECK-NEXT: dbg.variable "v", %[[V]] : !dbg.value
+    %v = firrtl.wire : !firrtl.vector<uint<4>, 2>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "Vec">
+      %v : (!firrtl.vector<uint<4>, 2>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Bundle with an enum-typed field -- the field must get a dbg.value
+// wrapping it with an enumDef reference.
+//
+// A frontend emits:
+//   circt_debug_subfield(parent="io", name="state") for io.state, carrying the
+//     enum variants inline (enumTypeName/enumFqn/variants)
+//   circt_debug_subfield(parent="io", name="data")  for io.data
+//   circt_debug_var(name="io")                      for io
+
+// CHECK-LABEL: firrtl.module @BundleEnumFieldTest
+firrtl.circuit "BundleEnumFieldTest" {
+  firrtl.module @BundleEnumFieldTest(
+      in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+
+    // No module-level enumdef op is materialised.
+    // CHECK-NOT: dbg.enumdef
+
+    %io = firrtl.wire : !firrtl.bundle<state: uint<2>, data: uint<8>>
+
+    // Leaf io.state with inline enum variants -- captured into leafMetaMap,
+    // erased.
+    // CHECK-NOT: circt_debug_subfield
+    // CHECK-NOT: dbg.variable "state"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.state", typeName: none = "UInt", parent: none = "io",
+       enumTypeName: none = "MyState", enumFqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"Idle\",\"value\":\"0\"},{\"name\":\"Run\",\"value\":\"1\"}]">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    // Leaf io.data without enum
+    // CHECK-NOT: dbg.variable "data"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.data", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    // Root circt_debug_var -- produces dbg.struct + dbg.variable. The enum
+    // leaf's value is wrapped in an inline `dbg.enum` carrying the variants.
+    // CHECK:      firrtl.subfield %{{.*}}[state]
+    // CHECK:      %[[E:.+]] = dbg.enum %{{.*}}, "MyState", {Idle = 0 : i64, Run = 1 : i64} fqn "pkg.MyState$" : !firrtl.uint<2>
+    // CHECK:      dbg.value %[[E]] typeName "UInt" : !dbg.enum
+    // CHECK:      firrtl.subfield %{{.*}}[data]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "io", %[[IO]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<state: uint<2>, data: uint<8>>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Bundle with a true FEnumType field -- FEnumType::isGround() returns false,
+// so the field must be routed through the FEnumType case in build(), not
+// dropped by the FIRRTLBaseType fallback.
+
+// CHECK-LABEL: firrtl.module @BundleFEnumFieldTest
+firrtl.circuit "BundleFEnumFieldTest" {
+  firrtl.module @BundleFEnumFieldTest(
+      in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+
+    // CHECK-NOT: dbg.enumdef
+
+    %io = firrtl.wire : !firrtl.bundle<state: enum<Idle: uint<0>, Run: uint<0>>, data: uint<8>>
+
+    // CHECK-NOT: circt_debug_subfield
+    // CHECK-NOT: dbg.variable "state"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.state", typeName: none = "UInt", parent: none = "io",
+       enumTypeName: none = "MyState", enumFqn: none = "pkg.MyState$",
+       variants: none = "[{\"name\":\"Idle\",\"value\":\"0\"},{\"name\":\"Run\",\"value\":\"1\"}]">
+      %io : (!firrtl.bundle<state: enum<Idle: uint<0>, Run: uint<0>>, data: uint<8>>) -> ()
+
+    // CHECK-NOT: dbg.variable "data"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.data", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<state: enum<Idle: uint<0>, Run: uint<0>>, data: uint<8>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[state]
+    // CHECK:      %[[E:.+]] = dbg.enum %{{.*}}, "MyState", {Idle = 0 : i64, Run = 1 : i64} fqn "pkg.MyState$" : !firrtl.enum<Idle, Run>
+    // CHECK:      dbg.value %[[E]] typeName "UInt" : !dbg.enum
+    // CHECK:      firrtl.subfield %{{.*}}[data]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "io", %[[IO]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<state: enum<Idle: uint<0>, Run: uint<0>>, data: uint<8>>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Bundle with a FixedPoint field carrying type parameters.
+// Verifies that the "params" JSON string is parsed and forwarded to
+// dbg.value as an ArrayAttr of DictionaryAttrs.
+
+// CHECK-LABEL: firrtl.module @BundleParamsFieldTest
+firrtl.circuit "BundleParamsFieldTest" {
+  firrtl.module @BundleParamsFieldTest(
+      in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+
+    %io = firrtl.wire : !firrtl.bundle<fp: uint<8>, data: uint<8>>
+
+    // Leaf io.fp with params
+    // CHECK-NOT: dbg.variable "fp"
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.fp", typeName: none = "FixedPoint", parent: none = "io",
+       params: none = "[{\"name\":\"width\",\"value\":\"8\"},{\"name\":\"binaryPoint\",\"value\":\"4\"}]">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    // Leaf io.data without params
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.data", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    // Root circt_debug_var -- produces dbg.struct + dbg.variable
+    // CHECK:      firrtl.subfield %{{.*}}[fp]
+    // CHECK:      dbg.value %{{.*}} typeName "FixedPoint" params [{name = "width", value = "8"}, {name = "binaryPoint", value = "4"}] : !firrtl.uint<8>
+    // CHECK:      firrtl.subfield %{{.*}}[data]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "io", %[[IO]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<fp: uint<8>, data: uint<8>>) -> ()
+
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// moduleinfo with constructor params
+
+// CHECK-LABEL: firrtl.module @ModuleInfoWithParams
+// CHECK-SAME: attributes {dbg.moduleinfo = {params = [{name = "width", value = "8"}], typeName = "Counter"}}
+firrtl.circuit "ModuleInfoWithParams" {
+  firrtl.module @ModuleInfoWithParams() {
+    firrtl.int.generic "circt_debug_moduleinfo"
+      <typeName: none = "Counter",
+       params: none = "[{\"name\":\"width\",\"value\":\"8\"}]">
+      : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var: the frontend emits no SSA operand when the
+// referenced value is a non-passive aggregate (e.g. a bidirectional bundle
+// port) whose SSA form is not directly assignable to a dbg.variable. The
+// converter must locate the matching port / wire / node / reg by name.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarPort
+firrtl.circuit "ZeroOperandVarPort" {
+  firrtl.module @ZeroOperandVarPort(
+      in %a: !firrtl.uint<8>,
+      out %b: !firrtl.uint<8>) {
+    // Match by port name; resolves to the block argument %a.
+    // CHECK: %[[V:.+]] = dbg.value %a typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "a", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "a", typeName: none = "UInt"> : () -> ()
+
+    firrtl.connect %b, %a : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a wire.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarWire
+firrtl.circuit "ZeroOperandVarWire" {
+  firrtl.module @ZeroOperandVarWire() {
+    // CHECK: %mywire = firrtl.wire
+    %mywire = firrtl.wire : !firrtl.uint<8>
+    // CHECK: %[[V:.+]] = dbg.value %mywire typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "mywire", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "mywire", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var with no matching port/wire/reg is silently erased
+// (a warning is emitted by the converter; the warning case is asserted by
+// `DebugVarUnresolved` in lower-intrinsics-debug-errors.mlir). Here we just
+// confirm no `dbg.variable` is produced.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarNoMatch
+firrtl.circuit "ZeroOperandVarNoMatch" {
+  firrtl.module @ZeroOperandVarNoMatch() {
+    // CHECK-NOT: dbg.variable
+    // CHECK-NOT: circt_debug_var
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "nonexistent", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.reg.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarReg
+firrtl.circuit "ZeroOperandVarReg" {
+  firrtl.module @ZeroOperandVarReg(in %clk: !firrtl.clock) {
+    // CHECK: %myreg = firrtl.reg
+    %myreg = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[V:.+]] = dbg.value %myreg typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "myreg", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "myreg", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.regreset (async reset)
+// with a bundle type.  The fallback name-walk must handle RegResetOp the same
+// way it handles RegOp.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarRegReset
+firrtl.circuit "ZeroOperandVarRegReset" {
+  firrtl.module @ZeroOperandVarRegReset(
+      in %clk: !firrtl.clock,
+      in %rst: !firrtl.asyncreset) {
+    // CHECK: %r = firrtl.regreset
+    %c0 = firrtl.aggregateconstant [0 : ui8, 0 : ui8] : !firrtl.bundle<x: uint<8>, y: uint<8>>
+    %r = firrtl.regreset %clk, %rst, %c0 :
+        !firrtl.clock, !firrtl.asyncreset,
+        !firrtl.bundle<x: uint<8>, y: uint<8>>,
+        !firrtl.bundle<x: uint<8>, y: uint<8>>
+    // CHECK:      firrtl.subfield %r[x]
+    // CHECK:      firrtl.subfield %r[y]
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[R:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "r", %[[R]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "r", typeName: none = "MyBundle"> : () -> ()
+  }
+}
+
+// -----
+
+// Nested aggregate: bundle whose field is itself a bundle. Exercises
+// recursion in DebugAggregateBuilder: the outer struct contains an inner
+// struct, with a leaf-meta entry on the deepest field.
+
+// CHECK-LABEL: firrtl.module @NestedBundleTest
+firrtl.circuit "NestedBundleTest" {
+  firrtl.module @NestedBundleTest() {
+    %io = firrtl.wire : !firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>
+
+    // Subfield meta on a deeply nested leaf: io.inner.a
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.inner.a", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[inner]
+    // CHECK:      firrtl.subfield %{{.*}}[a]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<4>
+    // CHECK:      firrtl.subfield %{{.*}}[b]
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "Outer">
+      %io : (!firrtl.bundle<inner: bundle<a: uint<4>, b: uint<4>>>) -> ()
+  }
+}
+
+// -----
+
+// circt_debug_typedef is silently consumed: no representation in the IR yet,
+// and no error.
+
+// CHECK-LABEL: firrtl.module @TypeDefDropped
+firrtl.circuit "TypeDefDropped" {
+  firrtl.module @TypeDefDropped() {
+    // CHECK-NOT: circt_debug_typedef
+    firrtl.int.generic "circt_debug_typedef"
+      <typeName: none = "MyAlias"> : () -> ()
+  }
+}
+
+// -----
+
+// Nested bundle: bundle<a: bundle<b: uint<8>>>.
+// A single circt_debug_subfield for the leaf "io.a.b" (parent="io") and a
+// circt_debug_var for the root "io".  The converter must recurse two levels:
+//   outer struct {"a": inner_struct}
+//   inner struct {"b": dbg.value with the leaf meta}
+//
+// Expected lowering:
+//   firrtl.subfield %io[a]            -- descend into outer field
+//   firrtl.subfield %<a_val>[b]       -- descend into inner field
+//   dbg.value ...                     -- leaf with meta
+//   dbg.struct {"b": ...}             -- inner struct
+//   dbg.struct {"a": ...}             -- outer struct
+//   dbg.value ... typeName "MyBundle" -- root metadata wrapper
+//   dbg.variable "io", ...            -- root variable
+
+// CHECK-LABEL: firrtl.module @NestedBundleSingleLeafTest
+firrtl.circuit "NestedBundleSingleLeafTest" {
+  firrtl.module @NestedBundleSingleLeafTest() {
+    %io = firrtl.wire : !firrtl.bundle<a: bundle<b: uint<8>>>
+
+    // Leaf at depth-2: io.a.b
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.a.b", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<a: bundle<b: uint<8>>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[a]
+    // CHECK:      firrtl.subfield %{{.*}}[b]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.struct
+    // CHECK:      %[[S:.+]] = dbg.struct
+    // CHECK:      %[[IO:.+]] = dbg.value %[[S]] typeName "MyBundle" : !dbg.struct
+    // CHECK:      dbg.variable "io", %[[IO]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<a: bundle<b: uint<8>>>) -> ()
+  }
+}
+
+// -----
+
+// Nested vector: vector<vector<uint<8>,2>,2> with a circt_debug_subfield leaf
+// for path v[0][1]. Exercises two levels of firrtl.subindex in
+// DebugAggregateBuilder, producing nested dbg.array ops with the leaf wrapped
+// in dbg.value at position [0][1]. Guards subindex-based leaf lookup through
+// vector-of-vector.
+
+// CHECK-LABEL: firrtl.module @NestedVecTest
+firrtl.circuit "NestedVecTest" {
+  firrtl.module @NestedVecTest() {
+    %v = firrtl.wire : !firrtl.vector<vector<uint<8>, 2>, 2>
+
+    // Leaf for v[0][1]: parent="v", name="v[0][1]"
+    // CHECK-NOT: circt_debug_subfield
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "v[0][1]", typeName: none = "UInt", parent: none = "v">
+      %v : (!firrtl.vector<vector<uint<8>, 2>, 2>) -> ()
+
+    // Root circt_debug_var -- must produce nested dbg.array ops:
+    //   outer dbg.array contains two inner dbg.array values;
+    //   inner dbg.array at index 0 has its element at index 1 wrapped in
+    //   a dbg.value carrying the leaf meta.
+    // CHECK:      firrtl.subindex %v[0]
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      firrtl.subindex %{{.*}}[1]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.array
+    // CHECK:      firrtl.subindex %v[1]
+    // CHECK:      dbg.array
+    // CHECK:      dbg.array
+    // CHECK:      dbg.variable "v"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "Vec">
+      %v : (!firrtl.vector<vector<uint<8>, 2>, 2>) -> ()
+  }
+}
+
+// -----
+
+// circt_debug_var inside a firrtl.layerblock must lower to dbg.variable
+// that remains nested inside the same layerblock (walk is recursive).
+
+// CHECK-LABEL: firrtl.module @LayerBlockDebugVar
+firrtl.circuit "LayerBlockDebugVar" {
+  firrtl.layer @MyLayer bind {}
+  firrtl.module @LayerBlockDebugVar(in %in: !firrtl.uint<8>) {
+    firrtl.layerblock @MyLayer {
+      // CHECK: firrtl.layerblock @MyLayer {
+      %w = firrtl.wire : !firrtl.uint<8>
+      firrtl.connect %w, %in : !firrtl.uint<8>, !firrtl.uint<8>
+      // CHECK: %[[V:.+]] = dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+      // CHECK: dbg.variable "w", %[[V]] : !dbg.value
+      firrtl.int.generic "circt_debug_var"
+        <name: none = "w", typeName: none = "UInt">
+        %w : (!firrtl.uint<8>) -> ()
+    }
+  }
+}
+
+// -----
+
+// Prefix-collision guard: two variables "io" and "iox" exist in the same
+// module. A circt_debug_subfield with parent="io" and name="io.x" must only
+// match the variable named exactly "io", not "iox". The boundary check in
+// processSubfieldIntrinsic uses `starts_with(parent + ".")` and
+// `starts_with(parent + "[")` -- bare `starts_with(parent)` would let "io.x"
+// match "iox" (since "io.x".starts_with("io") is true for both "io" and "iox"
+// after stripping the dot). This test pins that "iox" never gets the leaf.
+
+// CHECK-LABEL: firrtl.module @PrefixCollisionGuard
+firrtl.circuit "PrefixCollisionGuard" {
+  firrtl.module @PrefixCollisionGuard() {
+    %io  = firrtl.wire : !firrtl.bundle<x: uint<8>>
+    %iox = firrtl.wire : !firrtl.uint<8>
+
+    // Leaf belongs to "io", NOT to "iox".
+    // CHECK-NOT: circt_debug_subfield
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "io.x", typeName: none = "UInt", parent: none = "io">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+
+    // "io" variable: must receive the leaf and produce dbg.value.
+    // CHECK:      firrtl.subfield %{{.*}}[x]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.struct
+    // CHECK:      dbg.variable "io"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "io", typeName: none = "MyBundle">
+      %io : (!firrtl.bundle<x: uint<8>>) -> ()
+
+    // "iox" variable: no leaf should be associated; must NOT produce dbg.struct.
+    // CHECK:      %[[X:.+]] = dbg.value %iox typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.variable "iox", %[[X]] : !dbg.value
+    // CHECK-NOT:  dbg.struct
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "iox", typeName: none = "UInt">
+      %iox : (!firrtl.uint<8>) -> ()
+  }
+}
+
+// -----
+
+// Mixed-path regression guard (PASSING): verify that `starts_with` in
+// processSubfieldIntrinsic (FIRRTLIntrinsics.cpp ~1412) correctly accepts
+// both `parent + "["` (vec-rooted leaf) and `parent + "."` (bundle-rooted leaf).
+//
+// (a) vector<bundle<x: uint<8>>, 2>  with leaf "v[0].x"
+//     parent="v", name starts with "v[" -> starts_with(parent+"[") fires. PASSING.
+// (b) bundle<v: vector<uint<8>, 1>>  with leaf "b.v[0]"
+//     parent="b", name starts with "b." -> starts_with(parent+".") fires. PASSING.
+//     (size-1 vector keeps dbg.array operands homogeneous to avoid type mismatch)
+//
+// If either check regresses, processSubfieldIntrinsic emits a diagnostic and
+// firrtl-lower-intrinsics fails, making this FileCheck run fail. Guards:
+//   (a) starts_with(parent+"[") still matches vec-rooted paths
+//   (b) starts_with(parent+".") still matches bundle-rooted vec paths
+
+// CHECK-LABEL: firrtl.module @MixedPathSubfieldTest
+firrtl.circuit "MixedPathSubfieldTest" {
+  firrtl.module @MixedPathSubfieldTest() {
+
+    // (a) vector<bundle<x: uint<8>>, 2>, leaf "v[0].x"
+    // CHECK-NOT: circt_debug_subfield
+    %v = firrtl.wire : !firrtl.vector<bundle<x: uint<8>>, 2>
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "v[0].x", typeName: none = "UInt", parent: none = "v">
+      %v : (!firrtl.vector<bundle<x: uint<8>>, 2>) -> ()
+
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      firrtl.subfield %{{.*}}[x]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.variable "v"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "v", typeName: none = "VecBundle">
+      %v : (!firrtl.vector<bundle<x: uint<8>>, 2>) -> ()
+
+    // (b) bundle<v: vector<uint<8>, 1>>, leaf "b.v[0]"
+    // Use size-1 vector so all dbg.array operands share one type (dbg.value),
+    // avoiding the mixed-type dbg.array constraint that would fire with size>1
+    // when only one element carries a dbg.value leaf.
+    %b = firrtl.wire : !firrtl.bundle<v: vector<uint<8>, 1>>
+    firrtl.int.generic "circt_debug_subfield"
+      <name: none = "b.v[0]", typeName: none = "UInt", parent: none = "b">
+      %b : (!firrtl.bundle<v: vector<uint<8>, 1>>) -> ()
+
+    // CHECK:      firrtl.subfield %{{.*}}[v]
+    // CHECK:      firrtl.subindex %{{.*}}[0]
+    // CHECK:      dbg.value %{{.*}} typeName "UInt" : !firrtl.uint<8>
+    // CHECK:      dbg.variable "b"
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "b", typeName: none = "BundleVec">
+      %b : (!firrtl.bundle<v: vector<uint<8>, 1>>) -> ()
+  }
+}
+
+// -----
+
+// sint<8> operand: the signedness path must lower to dbg.variable just like
+// uint<8>. (FIRRTLBaseType::isGround() returns true for sint, so the scalar
+// branch in DebugAggregateBuilder fires.)
+
+// CHECK-LABEL: firrtl.module @SIntVar
+firrtl.circuit "SIntVar" {
+  firrtl.module @SIntVar(in %s: !firrtl.sint<8>) {
+    // CHECK: %[[V:.+]] = dbg.value %s typeName "SInt" : !firrtl.sint<8>
+    // CHECK: dbg.variable "s", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "s", typeName: none = "SInt">
+      %s : (!firrtl.sint<8>) -> ()
+  }
+}
+
+// -----
+
+// uint<0> (zero-width): still a ground type -> dbg.variable is emitted.
+
+// CHECK-LABEL: firrtl.module @ZeroWidthVar
+firrtl.circuit "ZeroWidthVar" {
+  firrtl.module @ZeroWidthVar(in %z: !firrtl.uint<0>) {
+    // CHECK: %[[V:.+]] = dbg.value %z typeName "UInt" : !firrtl.uint<0>
+    // CHECK: dbg.variable "z", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "z", typeName: none = "UInt">
+      %z : (!firrtl.uint<0>) -> ()
+  }
+}
+
+// -----
+
+// 0-operand circt_debug_var resolving to a firrtl.node.
+
+// CHECK-LABEL: firrtl.module @ZeroOperandVarNode
+firrtl.circuit "ZeroOperandVarNode" {
+  firrtl.module @ZeroOperandVarNode(in %in: !firrtl.uint<8>) {
+    // CHECK: %mynode = firrtl.node
+    %mynode = firrtl.node %in : !firrtl.uint<8>
+    // CHECK: %[[V:.+]] = dbg.value %mynode typeName "UInt" : !firrtl.uint<8>
+    // CHECK: dbg.variable "mynode", %[[V]] : !dbg.value
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "mynode", typeName: none = "UInt"> : () -> ()
+  }
+}
+
+// -----
+
+// Width-aware enum: optional `width` sizes variant IntegerAttrs (here
+// uint<2> -> i2). Without `width`, the i64 fallback keeps existing tests.
+
+// CHECK-LABEL: firrtl.module @EnumWithWidth
+firrtl.circuit "EnumWithWidth" {
+  firrtl.module @EnumWithWidth() {
+    // The inline `width` sizes the variant IntegerAttrs to i2.
+    // CHECK: dbg.enum %{{.*}}, "AluOp", {ADD = 0 : i2, AND = -2 : i2, OR = -1 : i2, SUB = 1 : i2} fqn "pkg.AluOp$"
+    %e = firrtl.wire : !firrtl.uint<2>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "e", typeName: none = "AluOp",
+       enumTypeName: none = "AluOp", enumFqn: none = "pkg.AluOp$",
+       width: i64 = 2,
+       variants: none = "[{\"name\":\"ADD\",\"value\":\"0\"},{\"name\":\"SUB\",\"value\":\"1\"},{\"name\":\"AND\",\"value\":\"2\"},{\"name\":\"OR\",\"value\":\"3\"}]">
+      %e : (!firrtl.uint<2>) -> ()
+  }
+}
+
+// -----
+
+// Pins that width=64 variants with value >= 2^63 (upper unsigned half) parse.
+
+// CHECK-LABEL: firrtl.module @EnumWideVariantTest
+firrtl.circuit "EnumWideVariantTest" {
+  firrtl.module @EnumWideVariantTest() {
+    // CHECK: dbg.enum %{{.*}}, "WideEnum", {TOP = -9223372036854775808 : i64, ZERO = 0 : i64} fqn "pkg.WideEnum$"
+    %e = firrtl.wire : !firrtl.uint<64>
+    firrtl.int.generic "circt_debug_var"
+      <name: none = "e", typeName: none = "WideEnum",
+       enumTypeName: none = "WideEnum", enumFqn: none = "pkg.WideEnum$",
+       width: i64 = 64,
+       variants: none = "[{\"name\":\"ZERO\",\"value\":\"0\"},{\"name\":\"TOP\",\"value\":\"9223372036854775808\"}]">
+      %e : (!firrtl.uint<64>) -> ()
+  }
+}


### PR DESCRIPTION
Convert circt_debug_var, circt_debug_subfield, and circt_debug_enumdef into Debug-dialect ops carrying source-language type metadata.

A pre-pass stages subfield leaves and enumdef variant data (keyed by FQN), then erases both, so the converters stay stateless. Linkage is by FQN: a subfield's `parent` names the root variable and `name` is its dotted display path. Enum use sites build a dbg.enum inline from the staged variants, so no separate definition op is needed. Leaf matching descends bundles and vectors and treats FIRRTL enum fields as leaves; a dangling FQN or unmatched leaf is a warning, not an error.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
