### PR TITLE
[FIRRTLToHW] Fix firrtl enum lowering

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -881,7 +881,8 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
 
   // Helper function to emit #ifndef guard.
   auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
-    sv::IfDefOp::create(b, guard, [] {}, body);
+    sv::IfDefOp::create(
+        b, guard, [] {}, body);
   };
 
   if (state.usedFileDescriptorLib)
@@ -3231,7 +3232,8 @@ void FIRRTLLowering::addToAlwaysBlock(
       auto createIfOp = [&]() {
         // It is weird but intended. Here we want to create an empty sv.if
         // with an else block.
-        insideIfOp = sv::IfOp::create(builder, reset, [] {}, [] {});
+        insideIfOp = sv::IfOp::create(
+            builder, reset, [] {}, [] {});
       };
       if (resetStyle == sv::ResetType::AsyncReset) {
         sv::EventControl events[] = {clockEdge, resetEdge};

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3594,6 +3594,10 @@ LogicalResult FIRRTLLowering::visitExpr(AggregateConstantOp op) {
 }
 
 LogicalResult FIRRTLLowering::visitExpr(IsTagOp op) {
+  // A zero-width enum has exactly one variant, so the tag check is trivially
+  // true.
+  if (isZeroBitFIRRTLType(op.getInput().getType()))
+    return setLowering(op, getOrCreateIntConstant(1, 1));
 
   auto tagName = op.getFieldNameAttr();
   auto lhs = getLoweredValue(op.getInput());

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -881,8 +881,7 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
 
   // Helper function to emit #ifndef guard.
   auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
-    sv::IfDefOp::create(
-        b, guard, [] {}, body);
+    sv::IfDefOp::create(b, guard, [] {}, body);
   };
 
   if (state.usedFileDescriptorLib)
@@ -3232,8 +3231,7 @@ void FIRRTLLowering::addToAlwaysBlock(
       auto createIfOp = [&]() {
         // It is weird but intended. Here we want to create an empty sv.if
         // with an else block.
-        insideIfOp = sv::IfOp::create(
-            builder, reset, [] {}, [] {});
+        insideIfOp = sv::IfOp::create(builder, reset, [] {}, [] {});
       };
       if (resetStyle == sv::ResetType::AsyncReset) {
         sv::EventControl events[] = {clockEdge, resetEdge};
@@ -3566,6 +3564,13 @@ LogicalResult FIRRTLLowering::visitExpr(FEnumCreateOp op) {
   auto element = *oldType.getElement(op.getFieldNameAttr());
 
   if (auto structType = dyn_cast<hw::StructType>(newType)) {
+    // If the input is zero-width, getLoweredValue returns a null Value.
+    // We still need a valid operand for the union body; create an i0 constant.
+    if (!input) {
+      if (!isZeroBitFIRRTLType(op.getInput().getType()))
+        return failure();
+      input = getOrCreateIntConstant(0, 0);
+    }
     auto tagType = structType.getFieldType("tag");
     auto tagValue = IntegerAttr::get(tagType, element.value.getValue());
     auto tag = sv::LocalParamOp::create(builder, op.getLoc(), tagType, tagValue,

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -927,6 +927,22 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.matchingconnect %sink, %0 : !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>
   }
 
+  // Test for https://github.com/llvm/circt/issues/7388
+  // enumcreate with a zero-width input on a data enum should not crash.
+  // CHECK-LABEL: hw.module private @DataEnumCreateZeroWidth(out sink : !hw.struct<tag: i1, body: !hw.union<Some: i8, None: i0>>) {
+  // CHECK-NEXT:   %c0_i0 = hw.constant 0 : i0
+  // CHECK-NEXT:   %None = sv.localparam {value = true} : i1
+  // CHECK-NEXT:   %0 = hw.union_create "None", %c0_i0 : !hw.union<Some: i8, None: i0>
+  // CHECK-NEXT:   %1 = hw.struct_create (%None, %0) : !hw.struct<tag: i1, body: !hw.union<Some: i8, None: i0>>
+  // CHECK-NEXT:   hw.output %1 : !hw.struct<tag: i1, body: !hw.union<Some: i8, None: i0>>
+  // CHECK-NEXT: }
+  firrtl.module private @DataEnumCreateZeroWidth(
+      out %sink: !firrtl.enum<Some: uint<8>, None: uint<0>>) {
+    %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
+    %0 = firrtl.enumcreate None(%c0_ui0) : (!firrtl.uint<0>) -> !firrtl.enum<Some: uint<8>, None: uint<0>>
+    firrtl.matchingconnect %sink, %0 : !firrtl.enum<Some: uint<8>, None: uint<0>>
+  }
+
   // CHECK-LABEL: IsInvalidIssue572
   // https://github.com/llvm/circt/issues/572
   firrtl.module private @IsInvalidIssue572(in %a: !firrtl.analog<1>) {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -943,6 +943,19 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.matchingconnect %sink, %0 : !firrtl.enum<Some: uint<8>, None: uint<0>>
   }
 
+  // Test for https://github.com/llvm/circt/issues/7388
+  // istag on a zero-width enum (single variant, zero-width data) should not
+  // crash. The tag check is trivially true.
+  // CHECK-LABEL: hw.module private @IsTagZeroWidthEnum(out o : i1) {
+  // CHECK-NEXT:   %true = hw.constant true
+  // CHECK-NEXT:   hw.output %true : i1
+  // CHECK-NEXT: }
+  firrtl.module private @IsTagZeroWidthEnum(
+      in %e: !firrtl.enum<A: uint<0>>, out %o: !firrtl.uint<1>) {
+    %0 = firrtl.istag %e A : !firrtl.enum<A: uint<0>>
+    firrtl.matchingconnect %o, %0 : !firrtl.uint<1>
+  }
+
   // CHECK-LABEL: IsInvalidIssue572
   // https://github.com/llvm/circt/issues/572
   firrtl.module private @IsInvalidIssue572(in %a: !firrtl.analog<1>) {


### PR DESCRIPTION
This PR Fixes #7388

When lowering a FIRRTL enum to HW, if that enum has at least one payload variant of zero-width and at least one payload variant of non-zero width, creating an instance of the zero-width variant of that enum causes a segfault in the lowering pass. The reason for this is that the pass passes the output of getLoweredValue(), which returns null on a zero width value, directly into hw::UnionCreateOp::create() -> Operation::create() -> IROperandBase::insertInto(), where that null is dereferenced.

This PR fixes the issue by checking if the output of getLoweredValue() is null because of a zero-width payload. If so it overwrites that null variable with an i0 hw.constant. If null for any other reason, the visitor fails gracefully rather than with a segfault.

Additionally, this PR fixes another related bug. When lowering a FIRRTL enum to HW, if that enum has only one variant (tag width 0) and that variant has zero width, it will crash in visitExpr(IsTagOp), because getLoweredValue() returns a null Value for the zero-width enum input, and visitExpr(IsTagOp) dereferences that null value in lhs.getType().

This PR fixes this problem with an early return at the top of visitExpr(IsTagOp) if the entire enum has zero width.

Additionally, two changes from running clang-format on LowerToHW.cpp are included.

Code changes for this PR were generated by Claude Code. All code changes were reviewed and tested by a human. This PR was written by a human.

Assisted-by: Claude-Code:Claude Opus 4.6
Co-Authored-By: Claude-Code:Claude Opus 4.6


<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
