### PR TITLE
[DCToHW] Fix invalid ESI connections from Unpack(pack())

### DIFF
--- a/include/circt/Dialect/DC/DCOps.td
+++ b/include/circt/Dialect/DC/DCOps.td
@@ -199,6 +199,7 @@ def PackOp : DCOp<"pack", [
     let results = (outs ValueType:$output);
     let assemblyFormat = "$token `,` $input attr-dict `:` type($input)";
     let hasFolder = 1;
+    let hasCanonicalizer = 1;
 }
 
 def UnpackOp : DCOp<"unpack", [

--- a/include/circt/Dialect/DC/DCOps.td
+++ b/include/circt/Dialect/DC/DCOps.td
@@ -198,7 +198,6 @@ def PackOp : DCOp<"pack", [
     let arguments = (ins TokenType:$token, AnyType:$input);
     let results = (outs ValueType:$output);
     let assemblyFormat = "$token `,` $input attr-dict `:` type($input)";
-    let hasFolder = 1;
     let hasCanonicalizer = 1;
 }
 
@@ -215,7 +214,6 @@ def UnpackOp : DCOp<"unpack", [
     let results = (outs TokenType:$token, AnyType:$output);
     let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
     let hasCanonicalizer = 1;
-    let hasFolder = 1;
 }
 
 def MergeOp : DCOp<"merge"> {

--- a/lib/Dialect/DC/DCOps.cpp
+++ b/lib/Dialect/DC/DCOps.cpp
@@ -309,21 +309,29 @@ LogicalResult ForkOp::fold(FoldAdaptor adaptor,
 // =============================================================================
 
 struct EliminateRedundantUnpackPattern : public OpRewritePattern<UnpackOp> {
-  // Eliminates unpacks where only the token is used.
+  // Eliminates unpack(pack(token, data)) by replacing the unpack results with
+  // the pack inputs directly. This is done as a canonicalization pattern
+  // (rather than a fold) so that the dead pack can be erased in the same step.
+  // Performing this in a fold is problematic because the conversion framework's
+  // OperationLegalizer applies folds before patterns. The fold would leave the
+  // dead pack in the IR; during DCToHW conversion this dead pack would still be
+  // converted, creating a spurious ESI channel consumer and violating the
+  // single-consumer constraint (see github.com/llvm/circt/issues/7949).
   using OpRewritePattern<UnpackOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(UnpackOp unpack,
                                 PatternRewriter &rewriter) const override {
-    // Is the value-side of the unpack used?
-    if (!unpack.getOutput().use_empty())
-      return failure();
-
     auto pack = unpack.getInput().getDefiningOp<PackOp>();
     if (!pack)
       return failure();
 
-    // Replace all uses of the unpack token with the packed token.
-    rewriter.replaceAllUsesWith(unpack.getToken(), pack.getToken());
-    rewriter.eraseOp(unpack);
+    // Replace unpack(pack(token, data)) -> (token, data).
+    rewriter.replaceOp(unpack, {pack.getToken(), pack.getInput()});
+
+    // The pack is now dead (its sole consumer was the unpack). Erase it so
+    // that the token/data values don't pick up a stale extra user.
+    if (pack->use_empty())
+      rewriter.eraseOp(pack);
+
     return success();
   }
 };
@@ -335,13 +343,9 @@ void UnpackOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 LogicalResult UnpackOp::fold(FoldAdaptor adaptor,
                              SmallVectorImpl<OpFoldResult> &results) {
-  // Unpack of a pack is a no-op.
-  if (auto pack = getInput().getDefiningOp<PackOp>()) {
-    results.push_back(pack.getToken());
-    results.push_back(pack.getInput());
-    return success();
-  }
-
+  // NOTE: unpack(pack(token, data)) -> (token, data) is intentionally NOT
+  // folded here. A fold cannot erase the now-dead pack op, which causes
+  // a spurious ESI channel consumer (see github.com/llvm/circt/issues/7949).
   return failure();
 }
 
@@ -359,14 +363,38 @@ LogicalResult UnpackOp::inferReturnTypes(
 // PackOp
 // =============================================================================
 
-OpFoldResult PackOp::fold(FoldAdaptor adaptor) {
-  auto token = getToken();
+struct EliminatePackOfUnpackPattern : public OpRewritePattern<PackOp> {
+  // Eliminates pack(unpack(v).token, unpack(v).data) by replacing the pack
+  // result with v directly. Like EliminateRedundantUnpackPattern, this is a
+  // canonicalization pattern rather than a fold so that the dead unpack can be
+  // erased in the same step (see github.com/llvm/circt/issues/7949).
+  using OpRewritePattern<PackOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(PackOp pack,
+                                PatternRewriter &rewriter) const override {
+    auto unpack = pack.getToken().getDefiningOp<UnpackOp>();
+    if (!unpack || unpack.getOutput() != pack.getInput())
+      return failure();
 
-  // Pack of an unpack is a no-op.
-  if (auto unpack = token.getDefiningOp<UnpackOp>()) {
-    if (unpack.getOutput() == getInput())
-      return unpack.getInput();
+    rewriter.replaceOp(pack, unpack.getInput());
+
+    // Erase the now-dead unpack.
+    if (unpack.getToken().use_empty() && unpack.getOutput().use_empty())
+      rewriter.eraseOp(unpack);
+
+    return success();
   }
+};
+
+void PackOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                         MLIRContext *context) {
+  results.insert<EliminatePackOfUnpackPattern>(context);
+}
+
+OpFoldResult PackOp::fold(FoldAdaptor adaptor) {
+  // NOTE: pack(unpack(v).token, unpack(v).data) -> v is intentionally NOT
+  // folded here for the same reason as UnpackOp::fold (see above and
+  // github.com/llvm/circt/issues/7949). The simplification is instead
+  // performed as a canonicalization pattern (EliminatePackOfUnpackPattern).
   return {};
 }
 

--- a/lib/Dialect/DC/DCOps.cpp
+++ b/lib/Dialect/DC/DCOps.cpp
@@ -311,12 +311,8 @@ LogicalResult ForkOp::fold(FoldAdaptor adaptor,
 struct EliminateRedundantUnpackPattern : public OpRewritePattern<UnpackOp> {
   // Eliminates unpack(pack(token, data)) by replacing the unpack results with
   // the pack inputs directly. This is done as a canonicalization pattern
-  // (rather than a fold) so that the dead pack can be erased in the same step.
-  // Performing this in a fold is problematic because the conversion framework's
-  // OperationLegalizer applies folds before patterns. The fold would leave the
-  // dead pack in the IR; during DCToHW conversion this dead pack would still be
-  // converted, creating a spurious ESI channel consumer and violating the
-  // single-consumer constraint (see github.com/llvm/circt/issues/7949).
+  // (rather than a fold) so that the dead pack can be erased in the same step
+  // (see github.com/llvm/circt/issues/7949).
   using OpRewritePattern<UnpackOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(UnpackOp unpack,
                                 PatternRewriter &rewriter) const override {
@@ -327,8 +323,7 @@ struct EliminateRedundantUnpackPattern : public OpRewritePattern<UnpackOp> {
     // Replace unpack(pack(token, data)) -> (token, data).
     rewriter.replaceOp(unpack, {pack.getToken(), pack.getInput()});
 
-    // The pack is now dead (its sole consumer was the unpack). Erase it so
-    // that the token/data values don't pick up a stale extra user.
+    // Erase the pack in case it no longer has users.
     if (pack->use_empty())
       rewriter.eraseOp(pack);
 
@@ -339,14 +334,6 @@ struct EliminateRedundantUnpackPattern : public OpRewritePattern<UnpackOp> {
 void UnpackOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                            MLIRContext *context) {
   results.insert<EliminateRedundantUnpackPattern>(context);
-}
-
-LogicalResult UnpackOp::fold(FoldAdaptor adaptor,
-                             SmallVectorImpl<OpFoldResult> &results) {
-  // NOTE: unpack(pack(token, data)) -> (token, data) is intentionally NOT
-  // folded here. A fold cannot erase the now-dead pack op, which causes
-  // a spurious ESI channel consumer (see github.com/llvm/circt/issues/7949).
-  return failure();
 }
 
 LogicalResult UnpackOp::inferReturnTypes(
@@ -365,9 +352,7 @@ LogicalResult UnpackOp::inferReturnTypes(
 
 struct EliminatePackOfUnpackPattern : public OpRewritePattern<PackOp> {
   // Eliminates pack(unpack(v).token, unpack(v).data) by replacing the pack
-  // result with v directly. Like EliminateRedundantUnpackPattern, this is a
-  // canonicalization pattern rather than a fold so that the dead unpack can be
-  // erased in the same step (see github.com/llvm/circt/issues/7949).
+  // result with v directly (see github.com/llvm/circt/issues/7949).
   using OpRewritePattern<PackOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(PackOp pack,
                                 PatternRewriter &rewriter) const override {
@@ -388,14 +373,6 @@ struct EliminatePackOfUnpackPattern : public OpRewritePattern<PackOp> {
 void PackOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                          MLIRContext *context) {
   results.insert<EliminatePackOfUnpackPattern>(context);
-}
-
-OpFoldResult PackOp::fold(FoldAdaptor adaptor) {
-  // NOTE: pack(unpack(v).token, unpack(v).data) -> v is intentionally NOT
-  // folded here for the same reason as UnpackOp::fold (see above and
-  // github.com/llvm/circt/issues/7949). The simplification is instead
-  // performed as a canonicalization pattern (EliminatePackOfUnpackPattern).
-  return {};
 }
 
 LogicalResult PackOp::inferReturnTypes(

--- a/lib/Dialect/DC/DCOps.cpp
+++ b/lib/Dialect/DC/DCOps.cpp
@@ -311,8 +311,7 @@ LogicalResult ForkOp::fold(FoldAdaptor adaptor,
 struct EliminateRedundantUnpackPattern : public OpRewritePattern<UnpackOp> {
   // Eliminates unpack(pack(token, data)) by replacing the unpack results with
   // the pack inputs directly. This is done as a canonicalization pattern
-  // (rather than a fold) so that the dead pack can be erased in the same step
-  // (see github.com/llvm/circt/issues/7949).
+  // (rather than a fold) so that the dead pack can be erased in the same step.
   using OpRewritePattern<UnpackOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(UnpackOp unpack,
                                 PatternRewriter &rewriter) const override {
@@ -352,7 +351,7 @@ LogicalResult UnpackOp::inferReturnTypes(
 
 struct EliminatePackOfUnpackPattern : public OpRewritePattern<PackOp> {
   // Eliminates pack(unpack(v).token, unpack(v).data) by replacing the pack
-  // result with v directly (see github.com/llvm/circt/issues/7949).
+  // result with v directly.
   using OpRewritePattern<PackOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(PackOp pack,
                                 PatternRewriter &rewriter) const override {

--- a/test/Conversion/DCToHW/basic.mlir
+++ b/test/Conversion/DCToHW/basic.mlir
@@ -202,3 +202,22 @@ hw.module.extern @ext(in %a : i32, out b : i32)
 
 // CHECK:  hw.module.extern @extDC(in %a : !esi.channel<i32>, out b : i32)
 hw.module.extern @extDC(in %a : !dc.value<i32>, out b : i32)
+
+// Regression test for https://github.com/llvm/circt/issues/7949
+// When a dc.fork result feeds through dc.pack+dc.unpack, the
+// UnpackOp::fold must not fire during conversion (it would leave a
+// dead pack whose conversion creates a second ESI channel consumer).
+// CHECK-LABEL: hw.module @forkPackUnpack
+// CHECK:       esi.wrap.vr
+// CHECK:       hw.output
+hw.module @forkPackUnpack(in %in : !dc.token,
+                          in %clk : !seq.clock {dc.clock},
+                          in %rst : i1 {dc.reset},
+                          out out0 : !dc.token,
+                          out out1 : !dc.token) {
+  %c0 = hw.constant 0 : i32
+  %0:2 = dc.fork [2] %in
+  %1 = dc.pack %0#1, %c0 : i32
+  %token, %output = dc.unpack %1 : !dc.value<i32>
+  hw.output %0#0, %token : !dc.token, !dc.token
+}

--- a/test/Dialect/DC/canonicalization.mlir
+++ b/test/Dialect/DC/canonicalization.mlir
@@ -166,3 +166,26 @@ hw.module @TestForkCanonicalization(in %arg0: !dc.token, out out0: !dc.token, ou
   dc.sink %0#2
   hw.output %1, %2 : !dc.token, !dc.token
 }
+
+// CHECK-LABEL:   func.func @unpackPack(
+// CHECK-SAME:                          %[[VAL_0:.*]]: !dc.value<i32>) -> !dc.value<i32> {
+// CHECK:           return %[[VAL_0]] : !dc.value<i32>
+// CHECK:         }
+func.func @unpackPack(%a: !dc.value<i32>) -> (!dc.value<i32>) {
+    %token, %data = dc.unpack %a : !dc.value<i32>
+    %0 = dc.pack %token, %data : i32
+    return %0 : !dc.value<i32>
+}
+
+// Like @unpackPack, but the unpack token has another user so the unpack
+// must be preserved while the pack is still eliminated.
+// CHECK-LABEL:   func.func @unpackPackTokenLive(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: !dc.value<i32>) -> (!dc.value<i32>, !dc.token) {
+// CHECK:           %[[TOKEN:.*]], %[[DATA:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i32>
+// CHECK:           return %[[VAL_0]], %[[TOKEN]] : !dc.value<i32>, !dc.token
+// CHECK:         }
+func.func @unpackPackTokenLive(%a: !dc.value<i32>) -> (!dc.value<i32>, !dc.token) {
+    %token, %data = dc.unpack %a : !dc.value<i32>
+    %0 = dc.pack %token, %data : i32
+    return %0, %token : !dc.value<i32>, !dc.token
+}


### PR DESCRIPTION
This PR Fixes #7949

Unpack(pack(token, data)) should be optimized away as an identity operation. This optimization was implemented as a fold method, but fold callbacks cannot erase the pack operation, leaving a dead pack operation. This is a problem because the pack's token input lowers to an ESI channel which can only have at most 1 consumer. The use of that channel and the dead pack operation makes two consumers, and DC would fail to lower to HW. The fold for pack(unpack(v)) causes a similar problem where an ESI channel has two consumers.

This PR fixes this problem. First it removes the folds which perform this optimization, taking this optimization out of the lower-dc-to-hw step. Then it moves the logic for performing this optimization into canonicalization patterns for these ops (dc.pack and dc.unpack), such that a canonicalization pass on DC will perform this optimization. The canonicalization pattern does not face the same limitations as the fold method (canonicalization patterns have a PatternRewriter) and so can eliminate spurious operations.

Users who continue to use the hack prescribed in issue #7949 will still see successful lowering with the optimization.

Code changes for this PR were generated by Claude Code. All code changes were reviewed and tested by a human. This PR was written by a human.

Assisted-by: Claude-Code:Claude Opus 4.6
Co-Authored-By: Claude-Code:Claude Opus 4.6

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
