### PR TITLE
[FIRRTL] Fix when flattening with layerblocks domination issue

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/SaveAndRestore.h"
 
 namespace circt {
 namespace firrtl {
@@ -711,15 +712,11 @@ void WhenOpVisitor::visitStmt(LayerBlockOp layerBlockOp) {
   // afterward so that ops created inside one layerblock are not reused by a
   // sibling, which would cause dominance violations. Parent-scope cached ops
   // remain available inside the layerblock since they dominate it.
-  auto savedLTLAndOps = createdLTLAndOps;
-  auto savedLTLImplicationOps = createdLTLImplicationOps;
-  auto savedLTLClockOps = createdLTLClockOps;
+  llvm::SaveAndRestore savedLTLAndOps(createdLTLAndOps);
+  llvm::SaveAndRestore savedLTLImplicationOps(createdLTLImplicationOps);
+  llvm::SaveAndRestore savedLTLClockOps(createdLTLClockOps);
 
   process(*layerBlockOp.getBody());
-
-  createdLTLAndOps = std::move(savedLTLAndOps);
-  createdLTLImplicationOps = std::move(savedLTLImplicationOps);
-  createdLTLClockOps = std::move(savedLTLClockOps);
 }
 
 void WhenOpVisitor::visitStmt(RefForceOp op) {

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -706,7 +706,21 @@ void WhenOpVisitor::visitStmt(WhenOp whenOp) {
 
 // NOLINTNEXTLINE(misc-no-recursion)
 void WhenOpVisitor::visitStmt(LayerBlockOp layerBlockOp) {
+  // Operations created inside a layerblock are not accessible in sibling
+  // layerblocks. Save and restore the LTL op caches to prevent reusing values
+  // across layerblock boundaries, which would cause dominance violations.
+  decltype(createdLTLAndOps) savedLTLAndOps;
+  decltype(createdLTLImplicationOps) savedLTLImplicationOps;
+  decltype(createdLTLClockOps) savedLTLClockOps;
+  std::swap(createdLTLAndOps, savedLTLAndOps);
+  std::swap(createdLTLImplicationOps, savedLTLImplicationOps);
+  std::swap(createdLTLClockOps, savedLTLClockOps);
+
   process(*layerBlockOp.getBody());
+
+  std::swap(createdLTLAndOps, savedLTLAndOps);
+  std::swap(createdLTLImplicationOps, savedLTLImplicationOps);
+  std::swap(createdLTLClockOps, savedLTLClockOps);
 }
 
 void WhenOpVisitor::visitStmt(RefForceOp op) {

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -707,20 +707,19 @@ void WhenOpVisitor::visitStmt(WhenOp whenOp) {
 // NOLINTNEXTLINE(misc-no-recursion)
 void WhenOpVisitor::visitStmt(LayerBlockOp layerBlockOp) {
   // Operations created inside a layerblock are not accessible in sibling
-  // layerblocks. Save and restore the LTL op caches to prevent reusing values
-  // across layerblock boundaries, which would cause dominance violations.
-  decltype(createdLTLAndOps) savedLTLAndOps;
-  decltype(createdLTLImplicationOps) savedLTLImplicationOps;
-  decltype(createdLTLClockOps) savedLTLClockOps;
-  std::swap(createdLTLAndOps, savedLTLAndOps);
-  std::swap(createdLTLImplicationOps, savedLTLImplicationOps);
-  std::swap(createdLTLClockOps, savedLTLClockOps);
+  // layerblocks. Snapshot the LTL op caches before entering and restore them
+  // afterward so that ops created inside one layerblock are not reused by a
+  // sibling, which would cause dominance violations. Parent-scope cached ops
+  // remain available inside the layerblock since they dominate it.
+  auto savedLTLAndOps = createdLTLAndOps;
+  auto savedLTLImplicationOps = createdLTLImplicationOps;
+  auto savedLTLClockOps = createdLTLClockOps;
 
   process(*layerBlockOp.getBody());
 
-  std::swap(createdLTLAndOps, savedLTLAndOps);
-  std::swap(createdLTLImplicationOps, savedLTLImplicationOps);
-  std::swap(createdLTLClockOps, savedLTLClockOps);
+  createdLTLAndOps = std::move(savedLTLAndOps);
+  createdLTLImplicationOps = std::move(savedLTLImplicationOps);
+  createdLTLClockOps = std::move(savedLTLClockOps);
 }
 
 void WhenOpVisitor::visitStmt(RefForceOp op) {

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -776,4 +776,36 @@ firrtl.module @instance_choice_test(in %a : !firrtl.uint<1>,
   }
 }
 
+
+// Test that sibling layerblocks inside a when each get their own LTL ops and do
+// not share cached values across layerblock boundaries (which would cause
+// dominance violations). See https://github.com/llvm/circt/issues/10104.
+firrtl.layer @LayerBar bind attributes {sym_visibility = "private"} {}
+// CHECK-LABEL: firrtl.module @SiblingLayerblocksImplication
+firrtl.module @SiblingLayerblocksImplication() {
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  // CHECK: firrtl.layerblock @LayerBar {
+  // CHECK:   firrtl.int.ltl.implication
+  // CHECK:   [[AND1:%.+]] = firrtl.int.ltl.and %c0_ui1, %c0_ui1
+  // CHECK:   [[IMPL1:%.+]] = firrtl.int.ltl.implication [[AND1]], %c0_ui1
+  // CHECK:   firrtl.int.verif.assert [[IMPL1]], %c0_ui1
+  // CHECK: }
+  // CHECK: firrtl.layerblock @LayerBar {
+  // CHECK:   firrtl.int.ltl.implication
+  // CHECK:   [[AND2:%.+]] = firrtl.int.ltl.and %c0_ui1, %c0_ui1
+  // CHECK:   [[IMPL2:%.+]] = firrtl.int.ltl.implication [[AND2]], %c0_ui1
+  // CHECK:   firrtl.int.verif.assert [[IMPL2]], %c0_ui1
+  // CHECK: }
+  firrtl.when %c0_ui1 : !firrtl.uint<1> {
+    firrtl.layerblock @LayerBar {
+      %0 = firrtl.int.ltl.implication %c0_ui1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      firrtl.int.verif.assert %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+    firrtl.layerblock @LayerBar {
+      %0 = firrtl.int.ltl.implication %c0_ui1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      firrtl.int.verif.assert %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+  }
+}
+
 }


### PR DESCRIPTION
This PR Fixes #10104

When flattening a when block, statements like asserts are merged with ltlAndWithCondition and ltlImplicationWithCondition. In the process of flattening, flattened ops that are identical become shared as an optimization strategy. However, an op created inside of a layerblock should not be shared by sibling layerblocks because an op defined in one layerblock's region does not dominate a sibling layerblock.

This PR fixes the issue by saving a copy of the LTL op caches before we descend into processing a layerblock inside of a when statement. The LTL op caches are restored to the saved copy when we finish processing the layerblock, to avoid ops added during the layerblock from being used in sibling layerblocks.

Code changes for this PR were generated by [Claude Code]. All code changes were reviewed and tested by a human. This PR was written by a human.

Assisted-by: Claude-Code:Claude Opus 4.6
Co-Authored-By: Claude-Code:Claude Opus 4.6

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
