### PR TITLE
[FIRRTL][Inliner] Only local-ize NLA's rooted in that module.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -1590,12 +1590,16 @@ LogicalResult Inliner::run() {
         if (mnla.isDead())
           return true;
 
-        // If the NLA becomes local after mutation (or sometimes an NLA is
-        // annotated even when the annotation is local in the first place),
-        // remove the nonlocal field.
+        // If the NLA has become local:
+        //  - if it is rooted at this module, replace it with a local version
+        //    of the annotation (drop the nonlocal field);
+        //  - otherwise it is local elsewhere but not here (this module needed
+        //    the NLA to selectively enable it), so just drop the annotation.
         if (mnla.isLocal()) {
-          anno.removeMember("circt.nonlocal");
-          newAnnotations.push_back(anno.getAttr());
+          if (mnla.hasRoot(fmodule.getModuleNameAttr())) {
+            anno.removeMember("circt.nonlocal");
+            newAnnotations.push_back(anno.getAttr());
+          }
           return true;
         }
 

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1585,7 +1585,8 @@ firrtl.circuit "FlattenAtRoot" {
   hw.hierpath private @nla [@Foo::@bar, @Bar::@b]
   // CHECK: firrtl.module @Bar
   firrtl.module @Bar() {
-    // CHECK: %b = firrtl.wire sym @b {annotations = [{class = "nla"}]}
+    // CHECK: %b = firrtl.wire sym @b
+    // CHECK-NOT: annotations
     %b = firrtl.wire sym @b {annotations = [{circt.nonlocal = @nla, class = "nla"}]} : !firrtl.uint<1>
   }
   // CHECK: firrtl.module @Foo


### PR DESCRIPTION
Otherwise, they're local elsewhere but here they aren't because this module needed the NLA to selectively enable it.

Fixes #10607.