### PR TITLE
[PrettifyVerilog] Stop inlining reduction operators

### DIFF
--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -66,9 +66,9 @@ private:
 };
 } // end anonymous namespace
 
-/// Return true if this is something that will get printed as a unary operator
-/// by the Verilog printer.
-static bool isVerilogUnaryOperator(Operation *op) {
+/// Return true if this is a unary operator that is cheap enough to sink or
+/// duplicate into its users as part of prettification.
+static bool isPrettifiableUnaryOperator(Operation *op) {
   // NOTE: Don't allow reduction operators (^, &, |) here since they are not
   //       cheap.
   if (auto xorOp = dyn_cast<comb::XorOp>(op))
@@ -505,7 +505,7 @@ void PrettifyVerilogPass::processPostOrder(Block &body) {
     }
 
     // Sink and duplicate unary operators.
-    if (isVerilogUnaryOperator(&op) && prettifyUnaryOperator(&op))
+    if (isPrettifiableUnaryOperator(&op) && prettifyUnaryOperator(&op))
       continue;
 
     // Sink or duplicate constant ops and invisible "free" ops into the same

--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -69,14 +69,10 @@ private:
 /// Return true if this is something that will get printed as a unary operator
 /// by the Verilog printer.
 static bool isVerilogUnaryOperator(Operation *op) {
-  if (isa<comb::ParityOp>(op))
-    return true;
-
+  // NOTE: Don't allow reduction operators (^, &, |) here since they are not
+  //       cheap.
   if (auto xorOp = dyn_cast<comb::XorOp>(op))
     return xorOp.isBinaryNot();
-
-  if (auto icmpOp = dyn_cast<comb::ICmpOp>(op))
-    return icmpOp.isEqualAllOnes() || icmpOp.isNotEqualZero();
 
   return false;
 }

--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -589,6 +589,37 @@ hw.module private @SelfConnect(in %clock: i1, in %reset: i1) {
   //VERILOG:   r <= r;
 }
 
+// CHECK-LABEL: hw.module @no_inline_reduction_ops
+// https://github.com/llvm/circt/issues/10623
+hw.module @no_inline_reduction_ops(in %arg0: i8, in %arg1: i8, out a: i1, out b: i1, out c: i1, out d: i1) {
+  %c-1_i8 = hw.constant -1 : i8
+  %c0_i8 = hw.constant 0 : i8
+
+  // Reduction operators should NOT be duplicated.
+  %parity = comb.parity %arg0 : i8
+  %a = comb.add %parity, %parity : i1
+  %eq_allones = comb.icmp eq %arg1, %c-1_i8 : i8
+  %b = comb.add %eq_allones, %eq_allones : i1
+  %ne_zero = comb.icmp ne %arg1, %c0_i8 : i8
+  %c = comb.add %ne_zero, %ne_zero : i1
+
+  // Binary NOT is still duplicated.
+  %bin_not = comb.xor %arg0, %c-1_i8 : i8
+  %d = comb.icmp eq %bin_not, %bin_not : i8
+
+  hw.output %a, %b, %c, %d : i1, i1, i1, i1
+}
+
+// VERILOG-LABEL: module no_inline_reduction_ops
+// VERILOG-NEXT: input  [7:0] arg0,
+// VERILOG:      wire [[PARITY:.+]] = ^arg0;
+// VERILOG-NEXT: wire [[REDAND:.+]] = &arg1;
+// VERILOG-NEXT: wire [[REDOR:.+]] = |arg1;
+// VERILOG-NEXT: assign a = [[PARITY]] + [[PARITY]];
+// VERILOG-NEXT: assign b = [[REDAND]] + [[REDAND]];
+// VERILOG-NEXT: assign c = [[REDOR]] + [[REDOR]];
+// VERILOG-NEXT: assign d = ~arg0 == ~arg0;
+
 // CHECK-LABEL: Issue4030
 hw.module @Issue4030(in %a: i1, in %clock: i1, in %in1: !hw.array<2xi1>, out b: !hw.array<5xi1>) {
   %c0_i3 = hw.constant 0 : i3

--- a/test/firtool/reduction-no-duplicate.fir
+++ b/test/firtool/reduction-no-duplicate.fir
@@ -1,0 +1,28 @@
+; RUN: firtool %s --format=fir -verilog | FileCheck %s
+
+; Test that reduction operators with multiple uses are not duplicated.
+
+FIRRTL version 7.0.0
+
+circuit Foo :
+  public module Foo :
+    input x : UInt<8>
+    input y : UInt<8>
+    output out : UInt<6>
+
+    node parity = xorr(x)
+    node reduce_and = andr(y)
+    node reduce_or = orr(y)
+
+    ; Use parity twice
+    connect out, cat(parity, reduce_and, reduce_or, parity, reduce_and, reduce_or)
+
+; CHECK-LABEL: module Foo(
+; CHECK:      wire [[PARITY:.+]] = ^x;
+; CHECK-NOT:  ^x
+; CHECK:      wire [[REDAND:.+]] = &y;
+; CHECK-NOT:  &y
+; CHECK:      wire [[REDOR:.+]] = |y;
+; CHECK-NOT:  |y
+; CHECK:      assign out = {[[PARITY]], [[REDAND]], [[REDOR]], [[PARITY]], [[REDAND]], [[REDOR]]};
+; CHECK:      endmodule


### PR DESCRIPTION

This stops cloning of reduction operators (^, |, &) inlining. 

https://github.com/llvm/circt/issues/10623
```verilog
module Foo(
  input        clock,
               reset,
  input  [7:0] x_0,
               x_1,
               x_2,
               x_3,
               y_0,
               y_1,
               y_2,
               y_3,
  output [7:0] out
);

  wire       _out_T_3 = ^x_0;
  wire       _xb_T_1 = ^x_1;
  wire       _xb_T_2 = ^x_2;
  wire       _out_T_12 = ^x_3;
  wire [3:0] yb = {^y_0, ^y_1, ^y_2, ^y_3};
  assign out =
    {4'h0,
     ^({_out_T_3, _xb_T_1, _xb_T_2, _out_T_12} ^ yb),
     ^({_xb_T_1, _xb_T_2, _out_T_12, _out_T_3} ^ yb),
     ^({_xb_T_2, _out_T_12, _out_T_3, _xb_T_1} ^ yb),
     ^({_out_T_12, _out_T_3, _xb_T_1, _xb_T_2} ^ yb)};
endmodule 
```

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
