### PR TITLE
[CombFolds] Canonicalize parity(concat(x, c)) -> parity(x) when ^c == 0

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -169,17 +169,14 @@ def ICmpOp : CombOp<"icmp",
 // Unary Operations
 //===----------------------------------------------------------------------===//
 
-// Base class for unary reduction operations that produce an i1.
-class UnaryI1ReductionOp<string mnemonic, list<Trait> traits = []> :
-      CombOp<mnemonic, traits # [Pure]> {
+def ParityOp: CombOp<"parity", [Pure]> {
   let arguments = (ins HWIntegerType:$input, UnitAttr:$twoState);
   let results = (outs I1:$result);
   let hasFolder = 1;
+  let hasCanonicalizeMethod = true;
 
   let assemblyFormat = "(`bin` $twoState^)? $input attr-dict `:` qualified(type($input))";
 }
-
-def ParityOp : UnaryI1ReductionOp<"parity">;
 
 //===----------------------------------------------------------------------===//
 // Integer width modifying operations.

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -303,6 +303,41 @@ OpFoldResult ParityOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+LogicalResult ParityOp::canonicalize(ParityOp op, PatternRewriter &rewriter) {
+  if (isOpTriviallyRecursive(op))
+    return failure();
+
+  // Helper to check if a value has zero parity (even number of 1 bits)
+  auto isParityZero = [](Value v) {
+    APInt value;
+    return matchPattern(v, m_ConstantInt(&value)) && value.popcount() % 2 == 0;
+  };
+
+  // parity(concat(c, x)) -> parity(x) when parity(c) == 0
+  // parity(concat(x, c)) -> parity(x) when parity(c) == 0
+  auto concat = op.getInput().getDefiningOp<ConcatOp>();
+  if (!concat)
+    return failure();
+
+  auto operands = concat.getInputs();
+  if (operands.size() != 2)
+    return failure();
+
+  if (isParityZero(operands[0])) {
+    replaceOpWithNewOpAndCopyNamehint<ParityOp>(rewriter, op, operands[1],
+                                                op.getTwoState());
+    return success();
+  }
+
+  if (isParityZero(operands[1])) {
+    replaceOpWithNewOpAndCopyNamehint<ParityOp>(rewriter, op, operands[0],
+                                                op.getTwoState());
+    return success();
+  }
+
+  return failure();
+}
+
 //===----------------------------------------------------------------------===//
 // Binary Operations
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -504,6 +504,22 @@ hw.module @parity_constant_folding2(out result : i1) {
   hw.output %0 : i1
 }
 
+// CHECK-LABEL: hw.module @parity_concat_even_parity
+// CHECK-NEXT:  %[[RESULT0:.+]] = comb.parity %arg0 : i4
+// CHECK-NEXT:  %[[RESULT1:.+]] = comb.parity %arg0 : i4
+// CHECK-NEXT:  hw.output %[[RESULT0]], %[[RESULT1]]
+hw.module @parity_concat_even_parity(in %arg0 : i4, out o1 : i1, out o2 : i1) {
+  %c0_i4 = hw.constant 0 : i4
+  %c15_i8 = hw.constant 15 : i8
+  // parity(concat(0, x)) -> parity(x), 0 has even parity
+  %0 = comb.concat %c0_i4, %arg0 : i4, i4
+  %1 = comb.parity %0 : i8
+  // parity(concat(x, 15)) -> parity(x), 15 has even parity
+  %2 = comb.concat %arg0, %c15_i8 : i4, i8
+  %3 = comb.parity %2 : i12
+  hw.output %1, %3 : i1, i1
+}
+
 // CHECK-LABEL: hw.module @concat_fold_0
 // CHECK-NEXT:  %c120_i8 = hw.constant 120 : i8
 hw.module @concat_fold_0(out result : i8) {


### PR DESCRIPTION
Canonicalize `comb.parity` of a two-operand `comb.concat` by dropping a
constant operand when that constant has even parity.

This handles cases like:
```
  parity(concat(0, x))  -> parity(x)
  parity(concat(x, 15)) -> parity(x)
```

This is intentionally restricted to binary operands for now as it looked expensive to run caonicalization. 

Assisted-by: augment: sonnet 4.5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
