### PR TITLE
[FIRRTL][InferWidths] Look through unsafe_domain_cast

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1534,7 +1534,8 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       })
 
       // Handle operations whose output width matches the input width.
-      .Case<NotPrimOp, AsSIntPrimOp, AsUIntPrimOp, ConstCastOp>(
+      .Case<NotPrimOp, AsSIntPrimOp, AsUIntPrimOp, ConstCastOp,
+            UnsafeDomainCastOp>(
           [&](auto op) { setExpr(op.getResult(), getExpr(op.getInput())); })
       .Case<mlir::UnrealizedConversionCastOp>(
           [&](auto op) { setExpr(op.getResult(0), getExpr(op.getOperand(0))); })

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -468,6 +468,26 @@ firrtl.circuit "Foo" {
     firrtl.domain.define %B, %A : !firrtl.domain<@ClockDomain()>
   }
 
+  // unsafe_domain_cast is node-like and should be looked through during width
+  // inference.
+  // https://github.com/llvm/circt/issues/10654
+  // CHECK-LABEL: @UnsafeDomainCast
+  firrtl.module @UnsafeDomainCast(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    in %B: !firrtl.domain<@ClockDomain()>
+  ) {
+    // CHECK: %a = firrtl.wire : !firrtl.uint<1>
+    %a = firrtl.wire : !firrtl.uint
+    %b = firrtl.wire : !firrtl.uint<1>
+    %c = firrtl.wire : !firrtl.uint<1>
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.connect %c, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: %0 = firrtl.unsafe_domain_cast %a domains[%B] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
+    %0 = firrtl.unsafe_domain_cast %a domains[%B] : !firrtl.uint domains[!firrtl.domain<@ClockDomain()>]
+    firrtl.connect %b, %0 : !firrtl.uint<1>, !firrtl.uint
+    firrtl.connect %a, %c : !firrtl.uint, !firrtl.uint<1>
+  }
+
   // Issue #1088
   // CHECK-LABEL: @Issue1088
   firrtl.module @Issue1088(out %y: !firrtl.sint<4>) {


### PR DESCRIPTION
Width inference treated unsafe_domain_cast as unsupported and aborted,
even though the cast only changes the domain of its operand and leaves
the value's width untouched. As a result, designs that fed an
uninferred-width value through a domain cast failed inference. Treat the
op like the other width-preserving casts so widths propagate through it.

Fixes #10654.

Assisted-by: pi.dev:claude-opus-4-8
