### PR TITLE
[circt-lec][circt-synth] Add circt-lec-script wrapper for standalone z3 for circt-synth CI testing, NFC

### DIFF
--- a/integration_test/circt-synth/array-lec.mlir
+++ b/integration_test/circt-synth/array-lec.mlir
@@ -1,10 +1,8 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-synth -o %t.mlir
 
-// RUN: circt-lec %t.mlir %s -c1=array -c2=array --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ARRAY
-// COMB_ARRAY: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=array -c2=array
 hw.module @array(in %arg0: i2, in %arg1: i2, in %arg2: i2, in %arg3: i2, in %sel1: i2, in %sel2: i2, in %sel3: i2, in %val: i2, out out1: i2, out out2: i2) {
   %0 = hw.array_create %arg0, %arg1, %arg2, %arg3 : i2
   %1 = hw.array_get %0[%sel1] : !hw.array<4xi2>, i2

--- a/integration_test/circt-synth/balance-mux.mlir
+++ b/integration_test/circt-synth/balance-mux.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: z3
 
-// RUN: circt-opt %s --pass-pipeline='builtin.module(synth-print-longest-path-analysis, hw.module(comb-balance-mux{mux-chain-threshold=4}))' -o %t.mlir
-// RUN: circt-opt %t.mlir --pass-pipeline='builtin.module(synth-print-longest-path-analysis)'
+// RUN: circt-opt %s --pass-pipeline='builtin.module(synth-print-longest-path-analysis, hw.module(comb-balance-mux{mux-chain-threshold=4}))' -o %t.mlir | FileCheck %s --check-prefix=DEPTH_BEFORE
+// RUN: circt-opt %t.mlir --pass-pipeline='builtin.module(synth-print-longest-path-analysis)' | FileCheck %s --check-prefix=DEPTH_AFTER
 // RUN: circt-lec.sh %t.mlir %s -c1=priority_mux_18_depth -c2=priority_mux_18_depth
 // Check that balancing muxes reduces the longest path in a priority mux from O(n) to O(log n).
 // DEPTH_BEFORE-LABEL: priority_mux_18_depth

--- a/integration_test/circt-synth/balance-mux.mlir
+++ b/integration_test/circt-synth/balance-mux.mlir
@@ -1,15 +1,13 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
-// RUN: circt-opt %s --pass-pipeline='builtin.module(synth-print-longest-path-analysis, hw.module(comb-balance-mux{mux-chain-threshold=4}))' -o %t.mlir | FileCheck %s --check-prefix=DEPTH_BEFORE
-// RUN: circt-opt %t.mlir --pass-pipeline='builtin.module(synth-print-longest-path-analysis)' | FileCheck %s --check-prefix=DEPTH_AFTER
-// RUN: circt-lec %t.mlir %s -c1=priority_mux_18_depth -c2=priority_mux_18_depth --shared-libs=%libz3 | FileCheck %s --check-prefix=MUX18_LEC
+// RUN: circt-opt %s --pass-pipeline='builtin.module(synth-print-longest-path-analysis, hw.module(comb-balance-mux{mux-chain-threshold=4}))' -o %t.mlir
+// RUN: circt-opt %t.mlir --pass-pipeline='builtin.module(synth-print-longest-path-analysis)'
+// RUN: circt-lec.sh %t.mlir %s -c1=priority_mux_18_depth -c2=priority_mux_18_depth
 // Check that balancing muxes reduces the longest path in a priority mux from O(n) to O(log n).
 // DEPTH_BEFORE-LABEL: priority_mux_18_depth
 // DEPTH_BEFORE: Maximum path delay: 17
 // DEPTH_AFTER-LABEL: priority_mux_18_depth
 // DEPTH_AFTER: Maximum path delay: 6
-// MUX18_LEC: c1 == c2
 hw.module @priority_mux_18_depth(in %cond0: i1, in %cond1: i1, in %cond2: i1, in %cond3: i1, in %cond4: i1, in %cond5: i1, in %cond6: i1, in %cond7: i1, in %cond8: i1, in %cond9: i1, in %cond10: i1, in %cond11: i1, in %cond12: i1, in %cond13: i1, in %cond14: i1, in %cond15: i1, in %cond16: i1, in %cond17: i1, out true_output: i5, out false_side: i5) {
   %c0_i5 = hw.constant 0 : i5
   %c1_i5 = hw.constant 1 : i5
@@ -69,12 +67,11 @@ hw.module @priority_mux_18_depth(in %cond0: i1, in %cond1: i1, in %cond2: i1, in
   hw.output %mux1_t, %mux1_f : i5, i5
 }
 
-// RUN: circt-lec %t.mlir %s -c1=index_to_balanced_mux -c2=index_to_balanced_mux --shared-libs=%libz3 | FileCheck %s --check-prefix=INDEX_TO_BALANCED_MUX_LEC
+// RUN: circt-lec.sh %t.mlir %s -c1=index_to_balanced_mux -c2=index_to_balanced_mux
 // DEPTH_BEFORE-LABEL: Longest Path Analysis result for "index_to_balanced_mux"
 // DEPTH_BEFORE: Maximum path delay: 11
 // DEPTH_AFTER-LABEL: Longest Path Analysis result for "index_to_balanced_mux"
 // DEPTH_AFTER: Maximum path delay: 3
-// INDEX_TO_BALANCED_MUX_LEC: c1 == c2
 hw.module @index_to_balanced_mux(in %index: i3, out result: i8) {
   // Values to select from based on index
   %a = hw.constant 10 : i8

--- a/integration_test/circt-synth/circt-lec.sh.mlir
+++ b/integration_test/circt-synth/circt-lec.sh.mlir
@@ -1,0 +1,18 @@
+// REQUIRES: z3
+
+// Positive test: equivalent modules should return 0.
+// RUN: circt-lec.sh %s %s -c1=foo -c2=foo
+
+// Negative test: non-equivalent modules should return non-zero.
+// RUN: not circt-lec.sh %s %s -c1=foo -c2=bar
+
+hw.module @foo(in %a : i8, in %b : i8, out c : i8) {
+  %add = comb.add %a, %b : i8
+  hw.output %add : i8
+}
+
+hw.module @bar(in %a : i8, in %b : i8, out c : i8) {
+  %add = comb.add %b, %a : i8
+  %x = comb.add %add, %a : i8
+  hw.output %x : i8
+}

--- a/integration_test/circt-synth/circt-lec.sh.mlir
+++ b/integration_test/circt-synth/circt-lec.sh.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: z3
 
 // Positive test: equivalent modules should return 0.
-// RUN: circt-lec.sh %s %s -c1=foo -c2=foo
+// RUN: circt-lec.sh %s -c1=foo -c2=foo
 
 // Negative test: non-equivalent modules should return non-zero.
 // RUN: not circt-lec.sh %s %s -c1=foo -c2=bar

--- a/integration_test/circt-synth/circt-lec.sh.mlir
+++ b/integration_test/circt-synth/circt-lec.sh.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: z3
 
 // Positive test: equivalent modules should return 0.
-// RUN: circt-lec.sh %s %s -c1=foo -c2=foo
+// RUN: not circt-lec.sh %s %s -c1=foo -c2=foo
 
 // Negative test: non-equivalent modules should return non-zero.
 // RUN: not circt-lec.sh %s %s -c1=foo -c2=bar

--- a/integration_test/circt-synth/circt-lec.sh.mlir
+++ b/integration_test/circt-synth/circt-lec.sh.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: z3
 
 // Positive test: equivalent modules should return 0.
-// RUN: not circt-lec.sh %s %s -c1=foo -c2=foo
+// RUN: circt-lec.sh %s %s -c1=foo -c2=foo
 
 // Negative test: non-equivalent modules should return non-zero.
 // RUN: not circt-lec.sh %s %s -c1=foo -c2=bar

--- a/integration_test/circt-synth/comb-lowering-add.mlir
+++ b/integration_test/circt-synth/comb-lowering-add.mlir
@@ -1,37 +1,31 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --convert-comb-to-synth -o %t.mlir
-// RUN: circt-lec %t.mlir %s -c1=add -c2=add --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD
-// COMB_ADD: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add -c2=add
 hw.module @add(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
   %0 = comb.add %arg0, %arg1, %arg2 : i4
   hw.output %0 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=add_ripple_carry -c2=add_ripple_carry --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_RIPPLE_CARRY
-// COMB_ADD_RIPPLE_CARRY: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add_ripple_carry -c2=add_ripple_carry
 hw.module @add_ripple_carry(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
   %0 = comb.add %arg0, %arg1, %arg2 {synth.test.arch = "RIPPLE-CARRY"} : i4
   hw.output %0 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=add_sklanskey -c2=add_sklanskey --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_SKLANSKEY
-// COMB_ADD_SKLANSKEY: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add_sklanskey -c2=add_sklanskey
 hw.module @add_sklanskey(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
   %0 = comb.add %arg0, %arg1, %arg2 {synth.test.arch = "SKLANSKEY"} : i4
   hw.output %0 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=add_kogge_stone -c2=add_kogge_stone --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_KOGGE_STONE
-// COMB_ADD_KOGGE_STONE: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add_kogge_stone -c2=add_kogge_stone
 hw.module @add_kogge_stone(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
   %0 = comb.add %arg0, %arg1, %arg2 {synth.test.arch = "KOGGE-STONE"} : i4
   hw.output %0 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=add_brent_kung -c2=add_brent_kung --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_BRENT_KUNG
-// COMB_ADD_BRENT_KUNG: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add_brent_kung -c2=add_brent_kung
 hw.module @add_brent_kung(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
   %0 = comb.add %arg0, %arg1, %arg2 {synth.test.arch = "BRENT-KUNG"} : i4
   hw.output %0 : i4

--- a/integration_test/circt-synth/comb-lowering-compare.mlir
+++ b/integration_test/circt-synth/comb-lowering-compare.mlir
@@ -1,10 +1,8 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --convert-comb-to-synth --convert-synth-to-comb -o %t.mlir
 
-// RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_ripple_carry -c2=icmp_unsigned_ripple_carry --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_RIPPLE_CARRY
-// COMB_ICMP_UNSIGNED_RIPPLE_CARRY: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=icmp_unsigned_ripple_carry -c2=icmp_unsigned_ripple_carry
 hw.module @icmp_unsigned_ripple_carry(in %lhs: i3, in %rhs: i3, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
   %ugt = comb.icmp ugt %lhs, %rhs {synth.test.arch = "RIPPLE-CARRY"} : i3
   %uge = comb.icmp uge %lhs, %rhs {synth.test.arch = "RIPPLE-CARRY"} : i3
@@ -13,8 +11,7 @@ hw.module @icmp_unsigned_ripple_carry(in %lhs: i3, in %rhs: i3, out out_ugt: i1,
   hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_sklanskey -c2=icmp_unsigned_sklanskey --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_SKLANSKEY
-// COMB_ICMP_UNSIGNED_SKLANSKEY: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=icmp_unsigned_sklanskey -c2=icmp_unsigned_sklanskey
 hw.module @icmp_unsigned_sklanskey(in %lhs: i3, in %rhs: i3, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
   %ugt = comb.icmp ugt %lhs, %rhs {synth.test.arch = "SKLANSKEY"} : i3
   %uge = comb.icmp uge %lhs, %rhs {synth.test.arch = "SKLANSKEY"} : i3
@@ -23,8 +20,7 @@ hw.module @icmp_unsigned_sklanskey(in %lhs: i3, in %rhs: i3, out out_ugt: i1, ou
   hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_kogge_stone -c2=icmp_unsigned_kogge_stone --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_KOGGE_STONE
-// COMB_ICMP_UNSIGNED_KOGGE_STONE: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=icmp_unsigned_kogge_stone -c2=icmp_unsigned_kogge_stone
 // Use slightly larger width to verify the lazy prefix tree logic
 hw.module @icmp_unsigned_kogge_stone(in %lhs: i14, in %rhs: i14, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
   %ugt = comb.icmp ugt %lhs, %rhs {synth.test.arch = "KOGGE-STONE"} : i14
@@ -34,8 +30,7 @@ hw.module @icmp_unsigned_kogge_stone(in %lhs: i14, in %rhs: i14, out out_ugt: i1
   hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=icmp_unsigned_brent_kung -c2=icmp_unsigned_brent_kung --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_UNSIGNED_BRENT_KUNG
-// COMB_ICMP_UNSIGNED_BRENT_KUNG: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=icmp_unsigned_brent_kung -c2=icmp_unsigned_brent_kung
 hw.module @icmp_unsigned_brent_kung(in %lhs: i4, in %rhs: i4, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
   %ugt = comb.icmp ugt %lhs, %rhs {synth.test.arch = "BRENT-KUNG"} : i4
   %uge = comb.icmp uge %lhs, %rhs {synth.test.arch = "BRENT-KUNG"} : i4
@@ -44,8 +39,7 @@ hw.module @icmp_unsigned_brent_kung(in %lhs: i4, in %rhs: i4, out out_ugt: i1, o
   hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=icmp_signed -c2=icmp_signed --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_SIGNED
-// COMB_ICMP_SIGNED: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=icmp_signed -c2=icmp_signed
 hw.module @icmp_signed(in %lhs: i4, in %rhs: i4, out out_ugt: i1, out out_uge: i1, out out_ult: i1, out out_ule: i1) {
   // Sign comparisons are just unsigned comparisons with inverted inputs and outputs.
   // No need to test all architectures here.
@@ -56,8 +50,7 @@ hw.module @icmp_signed(in %lhs: i4, in %rhs: i4, out out_ugt: i1, out out_uge: i
   hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=icmp_eq_ne -c2=icmp_eq_ne --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ICMP_EQ_NE
-// COMB_ICMP_EQ_NE: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=icmp_eq_ne -c2=icmp_eq_ne
 hw.module @icmp_eq_ne(in %lhs: i3, in %rhs: i3, out out_eq: i1, out out_ne: i1) {
   %eq = comb.icmp eq %lhs, %rhs : i3
   %ne = comb.icmp ne %lhs, %rhs : i3

--- a/integration_test/circt-synth/comb-lowering-large-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-large-lec.mlir
@@ -1,16 +1,13 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-synth -o %t.mlir
-// RUN: circt-lec %t.mlir %s -c1=add16 -c2=add16 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_16
-// COMB_ADD_16: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add16 -c2=add16
 hw.module @add16(in %arg0: i16, in %arg1: i16, in %arg2: i16,  out add: i16) {
   %0 = comb.add %arg0, %arg1, %arg2 : i16
   hw.output %0 : i16
 }
 
-// RUN: circt-lec %t.mlir %s -c1=add33 -c2=add33 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_33
-// COMB_ADD_33: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add33 -c2=add33
 hw.module @add33(in %arg0: i33, in %arg1: i33, in %arg2: i33,  out add: i33) {
   %0 = comb.add %arg0, %arg1, %arg2 : i33
   hw.output %0 : i33

--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -1,9 +1,7 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-synth -o %t.mlir
-// RUN: circt-lec %t.mlir %s -c1=bit_logical -c2=bit_logical --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_BIT_LOGICAL
-// COMB_BIT_LOGICAL: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=bit_logical -c2=bit_logical
 hw.module @bit_logical(in %arg0: i4, in %arg1: i4, in %arg2: i4, in %arg3: i4,
                 in %cond: i1, out out0: i4, out out1: i4, out out2: i4, out out3: i4) {
   %0 = comb.or %arg0, %arg1, %arg2, %arg3 : i4
@@ -14,23 +12,20 @@ hw.module @bit_logical(in %arg0: i4, in %arg1: i4, in %arg2: i4, in %arg3: i4,
   hw.output %0, %1, %2, %3 : i4, i4, i4, i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=parity -c2=parity --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_PARITY
-// COMB_PARITY: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=parity -c2=parity
 hw.module @parity(in %arg0: i4, out out: i1) {
   %0 = comb.parity %arg0 : i4
   hw.output %0 : i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=sub -c2=sub --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_SUB
-// COMB_SUB: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=sub -c2=sub
 hw.module @sub(in %lhs: i4, in %rhs: i4, out out: i4) {
   %0 = comb.sub %lhs, %rhs : i4
   hw.output %0 : i4
 }
 
 
-// RUN: circt-lec %t.mlir %s -c1=shift5 -c2=shift5 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_SHIFT
-// COMB_SHIFT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=shift5 -c2=shift5
 hw.module @shift5(in %lhs: i5, in %rhs: i5, out out_shl: i5, out out_shr: i5, out out_shrs: i5) {
   %0 = comb.shl %lhs, %rhs : i5
   %1 = comb.shru %lhs, %rhs : i5

--- a/integration_test/circt-synth/comb-lowering-mul.mlir
+++ b/integration_test/circt-synth/comb-lowering-mul.mlir
@@ -1,16 +1,13 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-synth --convert-synth-to-comb -o %t.mlir
-// RUN: circt-lec %t.mlir %s -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL
-// COMB_MUL: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=mul -c2=mul
 hw.module @mul(in %arg0: i7, in %arg1: i7, out add: i7) {
   %0 = comb.mul %arg0, %arg1 : i7
   hw.output %0 : i7
 }
 
-// RUN: circt-lec %t.mlir %s -c1=mul3 -c2=mul3 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_3
-// COMB_MUL_3: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=mul3 -c2=mul3
 hw.module @mul3(in %arg0: i3, in %arg1: i3, in %arg2: i3, out add: i3) {
   %0 = comb.mul %arg0, %arg1, %arg2 : i3
   hw.output %0 : i3

--- a/integration_test/circt-synth/cut-rewriter-lec.mlir
+++ b/integration_test/circt-synth/cut-rewriter-lec.mlir
@@ -1,12 +1,10 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // Perform translation validaton of LUT mapping in order to verify the truth
 // table computation in the cut rewriter.
 // RUN: circt-opt -synth-generic-lut-mapper -lower-comb %s -o %t.mlir
-// RUN: circt-lec %t.mlir %s -c1=test -c2=test --shared-libs=%libz3 | FileCheck %s
+// RUN: circt-lec.sh %t.mlir %s -c1=test -c2=test
 
-// CHECK: c1 == c2
 
 hw.module @test(in %a : i1, in %b : i1, in %c : i1, out result : i1) {
     %0 = synth.aig.and_inv %a, not %b : i1

--- a/integration_test/circt-synth/datapath-canonicalize-lec.mlir
+++ b/integration_test/circt-synth/datapath-canonicalize-lec.mlir
@@ -1,10 +1,8 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --canonicalize -o %t.mlir
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_sext_3 -c2=partial_product_sext_3 --shared-libs=%libz3 | FileCheck %s --check-prefix=AND3_SEXT
-// AND3_SEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_3 -c2=partial_product_sext_3
 hw.module @partial_product_sext_3(in %a : i3, in %b : i3, out sum : i6) {
   %0 = comb.extract %a from 2 : (i3) -> i1
   %1 = comb.extract %b from 2 : (i3) -> i1
@@ -17,8 +15,7 @@ hw.module @partial_product_sext_3(in %a : i3, in %b : i3, out sum : i6) {
   hw.output %7 : i6
 }
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_sext_6 -c2=partial_product_sext_6 --shared-libs=%libz3 | FileCheck %s --check-prefix=AND6_SEXT
-// AND6_SEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_6 -c2=partial_product_sext_6
 hw.module @partial_product_sext_6(in %a : i6, in %b : i6, out e : i12) {
   %0 = comb.extract %a from 5 : (i6) -> i1
   %1 = comb.replicate %0 : (i1) -> i6
@@ -31,8 +28,7 @@ hw.module @partial_product_sext_6(in %a : i6, in %b : i6, out e : i12) {
   hw.output %7 : i12
 }
 
-// RUN: circt-lec %t.mlir %s -c1=sext_compress -c2=sext_compress --shared-libs=%libz3 | FileCheck %s --check-prefix=COMP_SEXT
-// COMP_SEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=sext_compress -c2=sext_compress
 hw.module @sext_compress(in %a : i8, in %b : i8, in %c : i4, 
                          out sum1 : i8, out sum2 : i8) {
   

--- a/integration_test/circt-synth/datapath-lowering-lec.mlir
+++ b/integration_test/circt-synth/datapath-lowering-lec.mlir
@@ -1,25 +1,21 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --convert-datapath-to-comb -o %t.mlir
-// RUN: circt-lec %t.mlir %s -c1=partial_product_5 -c2=partial_product_5 --shared-libs=%libz3 | FileCheck %s --check-prefix=AND5
-// AND5: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_5 -c2=partial_product_5
 hw.module @partial_product_5(in %a : i5, in %b : i5, out sum : i5) {
   %0:5 = datapath.partial_product %a, %b : (i5, i5) -> (i5, i5, i5, i5, i5)
   %1 = comb.add bin %0#0, %0#1, %0#2, %0#3, %0#4 : i5
   hw.output %1 : i5
 }
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_4 -c2=partial_product_4 --shared-libs=%libz3 | FileCheck %s --check-prefix=AND4
-// AND4: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_4 -c2=partial_product_4
 hw.module @partial_product_4(in %a : i4, in %b : i4, out sum : i4) {
   %0:4 = datapath.partial_product %a, %b : (i4, i4) -> (i4, i4, i4, i4)
   %1 = comb.add bin %0#0, %0#1, %0#2, %0#3 : i4
   hw.output %1 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_zext -c2=partial_product_zext --shared-libs=%libz3 | FileCheck %s --check-prefix=AND3_ZEXT
-// AND3_ZEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_zext -c2=partial_product_zext
 hw.module @partial_product_zext(in %a : i3, in %b : i3, out sum : i6) {
   %c0_i3 = hw.constant 0 : i3
   %0 = comb.concat %c0_i3, %a : i3, i3
@@ -29,16 +25,14 @@ hw.module @partial_product_zext(in %a : i3, in %b : i3, out sum : i6) {
   hw.output %3 : i6
 }
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_square -c2=partial_product_square --shared-libs=%libz3 | FileCheck %s --check-prefix=SQR4
-// SQR4: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_square -c2=partial_product_square
 hw.module @partial_product_square(in %a : i4, out sum : i4) {
   %0:4 = datapath.partial_product %a, %a : (i4, i4) -> (i4, i4, i4, i4)
   %1 = comb.add bin %0#0, %0#1, %0#2, %0#3 : i4
   hw.output %1 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_square_zext -c2=partial_product_square_zext --shared-libs=%libz3 | FileCheck %s --check-prefix=SQR3_ZEXT
-// SQR3_ZEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_square_zext -c2=partial_product_square_zext
 hw.module @partial_product_square_zext(in %a : i3, out sum : i6) {
   %c0_i3 = hw.constant 0 : i3
   %0 = comb.concat %c0_i3, %a : i3, i3
@@ -47,8 +41,7 @@ hw.module @partial_product_square_zext(in %a : i3, out sum : i6) {
   hw.output %2 : i6
 }
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_sext -c2=partial_product_sext --shared-libs=%libz3 | FileCheck %s --check-prefix=AND3_SEXT
-// AND3_SEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext -c2=partial_product_sext
 hw.module @partial_product_sext(in %a : i3, in %b : i3, out sum : i6) {
   %0 = comb.extract %a from 2 : (i3) -> i1
   %1 = comb.extract %b from 2 : (i3) -> i1
@@ -61,16 +54,14 @@ hw.module @partial_product_sext(in %a : i3, in %b : i3, out sum : i6) {
   hw.output %7 : i6
 }
 
-// RUN: circt-lec %t.mlir %s -c1=pos_partial_product_4 -c2=pos_partial_product_4 --shared-libs=%libz3 | FileCheck %s --check-prefix=POS4
-// POS4: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=pos_partial_product_4 -c2=pos_partial_product_4
 hw.module @pos_partial_product_4(in %a : i4, in %b : i4, in %c : i4, out sum : i4) {
   %0:4 = datapath.pos_partial_product %a, %b, %c : (i4, i4, i4) -> (i4, i4, i4, i4)
   %1 = comb.add bin %0#0, %0#1, %0#2, %0#3 : i4
   hw.output %1 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=pos_partial_product_zext -c2=pos_partial_product_zext --shared-libs=%libz3 | FileCheck %s --check-prefix=POS_ZEXT
-// POS_ZEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=pos_partial_product_zext -c2=pos_partial_product_zext
 hw.module @pos_partial_product_zext(in %a : i4, in %b : i3, in %c : i4, out sum : i8) {
   %c0_i4 = hw.constant 0 : i4
   %c0_i5 = hw.constant 0 : i5
@@ -82,16 +73,14 @@ hw.module @pos_partial_product_zext(in %a : i4, in %b : i3, in %c : i4, out sum 
   hw.output %4 : i8
 }
 
-// RUN: circt-lec %t.mlir %s -c1=compress_3 -c2=compress_3 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMP3
-// COMP3: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=compress_3 -c2=compress_3
 hw.module @compress_3(in %a : i4, in %b : i4, in %c : i4, out sum : i4) {
   %0:2 = datapath.compress %a, %b, %c : i4 [3 -> 2]
   %1 = comb.add bin %0#0, %0#1 : i4
   hw.output %1 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=compress_6 -c2=compress_6 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMP6
-// COMP6: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=compress_6 -c2=compress_6
 hw.module @compress_6(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4, in %f : i4, out sum : i4) {
   %0:3 = datapath.compress %a, %b, %c, %d, %e, %f : i4 [6 -> 3]
   %1 = comb.add bin %0#0, %0#1, %0#2 : i4
@@ -99,20 +88,14 @@ hw.module @compress_6(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4
 }
 
 // RUN: circt-opt %s --pass-pipeline="builtin.module(hw.module(convert-datapath-to-comb{lower-partial-product-to-booth=true lower-compress-to-add=true}))" -o %t.mlir
-// RUN: circt-lec %t.mlir %s -c1=partial_product_5 -c2=partial_product_5 --shared-libs=%libz3 | FileCheck %s --check-prefix=BOOTH5
-// BOOTH5: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_5 -c2=partial_product_5
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_4 -c2=partial_product_4 --shared-libs=%libz3 | FileCheck %s --check-prefix=BOOTH4
-// BOOTH4: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_4 -c2=partial_product_4
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_zext -c2=partial_product_zext --shared-libs=%libz3 | FileCheck %s --check-prefix=BOOTH3_ZEXT
-// BOOTH3_ZEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_zext -c2=partial_product_zext
 
-// RUN: circt-lec %t.mlir %s -c1=partial_product_sext -c2=partial_product_sext --shared-libs=%libz3 | FileCheck %s --check-prefix=BOOTH3_SEXT
-// BOOTH3_SEXT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext -c2=partial_product_sext
 
-// RUN: circt-lec %t.mlir %s -c1=compress_3 -c2=compress_3 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMPADD3
-// COMPADD3: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=compress_3 -c2=compress_3
 
-// RUN: circt-lec %t.mlir %s -c1=compress_6 -c2=compress_6 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMPADD6
-// COMPADD6: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=compress_6 -c2=compress_6

--- a/integration_test/circt-synth/datapath-reduce-delay-lec.mlir
+++ b/integration_test/circt-synth/datapath-reduce-delay-lec.mlir
@@ -1,9 +1,7 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --datapath-reduce-delay -o %t.mlir
-// RUN: circt-lec %t.mlir %s -c1=add_compare -c2=add_compare --shared-libs=%libz3 | FileCheck %s --check-prefix=COMPARE
-// COMPARE: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add_compare -c2=add_compare
 hw.module @add_compare(in %a : i16, in %b : i16, in %c : i16, out ugt : i1, out uge : i1, out ult : i1, out ule : i1) {
   %false = hw.constant false
   %0 = comb.concat %false, %a : i1, i16
@@ -19,8 +17,7 @@ hw.module @add_compare(in %a : i16, in %b : i16, in %c : i16, out ugt : i1, out 
   hw.output %ugt, %uge, %ult, %ule : i1, i1, i1, i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=add_mux -c2=add_mux --shared-libs=%libz3 | FileCheck %s --check-prefix=ADDMUX
-// ADDMUX: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=add_mux -c2=add_mux
 hw.module @add_mux(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4, in %sel : i1, out res : i4) {
   %0 = comb.add %a, %b : i4
   %1 = comb.add %c, %d, %e : i4
@@ -29,8 +26,7 @@ hw.module @add_mux(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4, i
   hw.output %3 : i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=fold_adds -c2=fold_adds --shared-libs=%libz3 | FileCheck %s --check-prefix=FOLDADD
-// FOLDADD: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=fold_adds -c2=fold_adds
 hw.module @fold_adds(in %a : i4, in %b : i4, in %c : i4, in %d : i4, out abc : i4, out abd : i4) {
   %0 = comb.add %a, %b : i4
   %1 = comb.add %0, %c : i4

--- a/integration_test/circt-synth/divmod.mlir
+++ b/integration_test/circt-synth/divmod.mlir
@@ -1,10 +1,8 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-synth --convert-synth-to-comb -o %t.mlir
 
-// RUN: circt-lec %t.mlir %s -c1=divmodu -c2=divmodu --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_DIVMODU
-// COMB_DIVMODU: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=divmodu -c2=divmodu
 hw.module @divmodu(in %lhs: i3, in %rhs: i3, out out_div: i3, out out_mod: i3) {
   %c0_i3 = hw.constant 0 : i3
   %neq = comb.icmp ne %rhs, %c0_i3 : i3
@@ -15,8 +13,7 @@ hw.module @divmodu(in %lhs: i3, in %rhs: i3, out out_div: i3, out out_mod: i3) {
   hw.output %0, %1 : i3, i3
 }
 
-// RUN: circt-lec %t.mlir %s -c1=divmodu_power_of_two -c2=divmodu_power_of_two --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_DIVMODU_POWER_OF_TWO
-// COMB_DIVMODU_POWER_OF_TWO: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=divmodu_power_of_two -c2=divmodu_power_of_two
 hw.module @divmodu_power_of_two(in %lhs: i8, out out_div: i8, out out_mod: i8) {
   %c16_i8 = hw.constant 16 : i8
 
@@ -25,8 +22,7 @@ hw.module @divmodu_power_of_two(in %lhs: i8, out out_div: i8, out out_mod: i8) {
   hw.output %0, %1 : i8, i8
 }
 
-// RUN: circt-lec %t.mlir %s -c1=divmods -c2=divmods --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_DIVMODS
-// COMB_DIVMODS: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=divmods -c2=divmods
 hw.module @divmods(in %lhs: i3, in %rhs: i3, out out_div: i3, out out_mod: i3) {
   %c0_i3 = hw.constant 0 : i3
   %neq = comb.icmp ne %rhs, %c0_i3 : i3
@@ -37,8 +33,7 @@ hw.module @divmods(in %lhs: i3, in %rhs: i3, out out_div: i3, out out_mod: i3) {
   hw.output %0, %1 : i3, i3
 }
 
-// RUN: circt-lec %t.mlir %s -c1=divmod_mix_constant -c2=divmod_mix_constant --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_DIVMOD_MIX_CONSTANT
-// COMB_DIVMOD_MIX_CONSTANT: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=divmod_mix_constant -c2=divmod_mix_constant
 hw.module @divmod_mix_constant(in %in: i1, in %lhs: i1, in %rhs: i1, out out_divu: i4, out out_modu: i4, out out_divs: i4, out out_mods: i4) {
   %c2_i2 = hw.constant 2 : i2
 
@@ -51,8 +46,7 @@ hw.module @divmod_mix_constant(in %in: i1, in %lhs: i1, in %rhs: i1, out out_div
   hw.output %0, %1, %2, %3 : i4, i4, i4, i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=divmodu_constants -c2=divmodu_constants --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_DIVMODU_CONSTANTS
-// COMB_DIVMODU_CONSTANTS: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=divmodu_constants -c2=divmodu_constants
 hw.module @divmodu_constants(in %lhs: i4, out out_divu_7: i4, out out_divu_10: i4, out out_modu_3: i4) {
   %c7_i4 = hw.constant 7 : i4
   %c10_i4 = hw.constant 10 : i4
@@ -64,8 +58,7 @@ hw.module @divmodu_constants(in %lhs: i4, out out_divu_7: i4, out out_divu_10: i
   hw.output %0, %1, %2 : i4, i4, i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=divmods_constants -c2=divmods_constants --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_DIVMODS_CONSTANTS
-// COMB_DIVMODS_CONSTANTS: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=divmods_constants -c2=divmods_constants
 hw.module @divmods_constants(in %lhs: i4, out out_divs_3: i4, out out_divs_neg3: i4, out out_mods_3: i4, out out_mods_neg3: i4) {
   %c3_i4 = hw.constant 3 : i4
   %c-3_i4 = hw.constant -3 : i4
@@ -77,8 +70,7 @@ hw.module @divmods_constants(in %lhs: i4, out out_divs_3: i4, out out_divs_neg3:
   hw.output %0, %1, %2, %3 : i4, i4, i4, i4
 }
 
-// RUN: circt-lec %t.mlir %s -c1=const_divmod_mods_neg1_i3 -c2=const_divmod_mods_neg1_i3 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MODS_NEG1_I3
-// COMB_MODS_NEG1_I3: c1 == c2
+// RUN: circt-lec.sh %t.mlir %s -c1=const_divmod_mods_neg1_i3 -c2=const_divmod_mods_neg1_i3
 hw.module @const_divmod_mods_neg1_i3(in %lhs: i3, out out: i3) {
   %c_neg1_i3 = hw.constant -1 : i3
   %0 = comb.mods %lhs, %c_neg1_i3 : i3

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -1,9 +1,8 @@
-// REQUIRES: z3-integration, libz3
+// REQUIRES: z3
 // RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(synth-functional-reduction{num-random-patterns=64 sat-solver=z3}))' -o %t.mlir
-// RUN: cat %t.mlir | FileCheck %s
+// RUN: cat %t.mlir
 
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_sat --c2 functional_reduction_sat | FileCheck %s --check-prefix=BASIC
-// BASIC: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 functional_reduction_sat --c2 functional_reduction_sat
 // SAT should prove that AND(AND(a, not b), AND(c, not d)) is equivalent to
 // AND(a, not b, c, not d), and the pass should materialize that with a choice.
 // CHECK-LABEL: hw.module @functional_reduction_sat
@@ -26,8 +25,7 @@ hw.module @functional_reduction_sat(in %a: i1, in %b: i1, in %c: i1, in %d: i1,
 
 // SAT should also prove equivalence across the newly supported comb
 // nodes.
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_supported_ops_sat --c2 functional_reduction_supported_ops_sat | FileCheck %s --check-prefix=MIXED
-// MIXED: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 functional_reduction_supported_ops_sat --c2 functional_reduction_supported_ops_sat
 // CHECK-LABEL: hw.module @functional_reduction_supported_ops_sat
 hw.module @functional_reduction_supported_ops_sat(
     in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1,
@@ -47,8 +45,7 @@ hw.module @functional_reduction_supported_ops_sat(
 }
 
 // SAT should satisfy inversion equivalences
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_inversion_equiv_sat --c2 functional_reduction_inversion_equiv_sat | FileCheck %s --check-prefix=INVERSION
-// INVERSION: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 functional_reduction_inversion_equiv_sat --c2 functional_reduction_inversion_equiv_sat
 // CHECK-LABEL: hw.module @functional_reduction_inversion_equiv_sat
 hw.module @functional_reduction_inversion_equiv_sat(in %a: i1, in %b: i1,
                                                     out out0: i1, out out1: i1) {
@@ -65,8 +62,7 @@ hw.module @functional_reduction_inversion_equiv_sat(in %a: i1, in %b: i1,
 
 // SAT should also prove equivalence between synth.xor_inv and an AND/OR
 // implementation of XOR.
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_xor_inv_sat --c2 functional_reduction_xor_inv_sat | FileCheck %s --check-prefix=XOR-INV
-// XOR-INV: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 functional_reduction_xor_inv_sat --c2 functional_reduction_xor_inv_sat
 // CHECK-LABEL: hw.module @functional_reduction_xor_inv_sat
 hw.module @functional_reduction_xor_inv_sat(in %a: i1, in %b: i1,
                                             out out0: i1, out out1: i1) {
@@ -81,8 +77,7 @@ hw.module @functional_reduction_xor_inv_sat(in %a: i1, in %b: i1,
   hw.output %0, %4 : i1, i1
 }
 
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 test_dot --c2 test_dot | FileCheck %s --check-prefix=DOT
-// DOT: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 test_dot --c2 test_dot
 // CHECK-LABEL: hw.module @test_dot
 hw.module @test_dot(in %a: i1, in %b: i1, in %c: i1,
                                     out out0: i1, out out1: i1) {
@@ -95,8 +90,7 @@ hw.module @test_dot(in %a: i1, in %b: i1, in %c: i1,
   hw.output %2, %3 : i1, i1
 }
 
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 test_majority --c2 test_majority | FileCheck %s --check-prefix=MAJORITY
-// MAJORITY: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 test_majority --c2 test_majority
 // CHECK-LABEL: hw.module @test_majority
 hw.module @test_majority(in %a: i1, in %b: i1, in %c: i1,
                          out out0: i1, out out1: i1) {
@@ -110,8 +104,7 @@ hw.module @test_majority(in %a: i1, in %b: i1, in %c: i1,
   hw.output %0, %1 : i1, i1
 }
 
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 test_onehot --c2 test_onehot | FileCheck %s --check-prefix=ONEHOT
-// ONEHOT: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 test_onehot --c2 test_onehot
 // CHECK-LABEL: hw.module @test_onehot
 hw.module @test_onehot(in %a: i1, in %b: i1, in %c: i1,
                        out out0: i1, out out1: i1) {
@@ -125,8 +118,7 @@ hw.module @test_onehot(in %a: i1, in %b: i1, in %c: i1,
   hw.output %0, %1 : i1, i1
 }
 
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 functional_reduction_mux_inv_sat --c2 functional_reduction_mux_inv_sat | FileCheck %s --check-prefix=MUX-INV
-// MUX-INV: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 functional_reduction_mux_inv_sat --c2 functional_reduction_mux_inv_sat
 // CHECK-LABEL: hw.module @functional_reduction_mux_inv_sat
 hw.module @functional_reduction_mux_inv_sat(in %c: i1, in %a: i1, in %b: i1,
                                             out out0: i1, out out1: i1) {
@@ -139,8 +131,7 @@ hw.module @functional_reduction_mux_inv_sat(in %c: i1, in %a: i1, in %b: i1,
   hw.output %0, %4 : i1, i1
 }
 
-// RUN: circt-lec %s %t.mlir --shared-libs=%libz3 --c1 test_gamble --c2 test_gamble | FileCheck %s --check-prefix=GAMBLE
-// GAMBLE: c1 == c2
+// RUN: circt-lec.sh %s %t.mlir --c1 test_gamble --c2 test_gamble
 // CHECK-LABEL: hw.module @test_gamble
 hw.module @test_gamble(in %a: i1, in %b: i1, in %c: i1,
                        out out0: i1, out out1: i1) {

--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: z3
 // RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(synth-functional-reduction{num-random-patterns=64 sat-solver=z3}))' -o %t.mlir
-// RUN: cat %t.mlir
+// RUN: cat %t.mlir | FileCheck %s
 
 // RUN: circt-lec.sh %s %t.mlir --c1 functional_reduction_sat --c2 functional_reduction_sat
 // SAT should prove that AND(AND(a, not b), AND(c, not d)) is equivalent to

--- a/integration_test/circt-synth/lower-variadic.mlir
+++ b/integration_test/circt-synth/lower-variadic.mlir
@@ -1,9 +1,7 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s --pass-pipeline='builtin.module(hw.module(synth-lower-variadic))' -o %t.after.mlir
-// RUN: circt-lec %s %t.after.mlir -c1=AndInverter -c2=AndInverter --shared-libs=%libz3 | FileCheck %s --check-prefix=AND_INVERTER_LEC
-// AND_INVERTER_LEC: c1 == c2
+// RUN: circt-lec.sh %s %t.after.mlir -c1=AndInverter -c2=AndInverter
 hw.module @AndInverter(in %a: i2, in %b: i2, in %c: i2, in %d: i2, in %e: i2, in %f: i2, in %g: i2, out o1: i2) {
   %0 = synth.aig.and_inv %d, not %e : i2
   %1 = synth.aig.and_inv not %c, not %0, %f : i2
@@ -11,8 +9,7 @@ hw.module @AndInverter(in %a: i2, in %b: i2, in %c: i2, in %d: i2, in %e: i2, in
   hw.output %2 : i2
 }
 
-// RUN: circt-lec %s %t.after.mlir -c1=VariadicCombOps -c2=VariadicCombOps --shared-libs=%libz3 | FileCheck %s --check-prefix=VARIADIC_COMB_OPS_LEC
-// VARIADIC_COMB_OPS_LEC: c1 == c2
+// RUN: circt-lec.sh %s %t.after.mlir -c1=VariadicCombOps -c2=VariadicCombOps
 hw.module @VariadicCombOps(in %a: i2, in %b: i2, in %c: i2, in %d: i2, in %e: i2, in %f: i2, 
                            out out_and: i2, out out_or: i2, out out_xor: i2) {
   %0 = comb.and %a, %b, %c, %d, %e, %f : i2

--- a/integration_test/circt-synth/mapping-lec.mlir
+++ b/integration_test/circt-synth/mapping-lec.mlir
@@ -1,20 +1,14 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-synth %s -o %t1.mlir
-// RUN: cat %t1.mlir | FileCheck %s
-// RUN: circt-lec %t1.mlir %s -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_TECHMAP
-// RUN: circt-lec %t1.mlir %s -c1=dot_test -c2=dot_test --shared-libs=%libz3 | FileCheck %s --check-prefix=TECHMAP_PERMUTATION
-
-// COMB_MUL_TECHMAP: c1 == c2
-// TECHMAP_PERMUTATION: c1 == c2
+// RUN: circt-opt %t1.mlir --hw-flatten-modules=hw-inline-public -o %t1.inline.mlir
+// RUN: circt-lec.sh %t1.inline.mlir %s -c1=mul -c2=mul
+// RUN: circt-lec.sh %t1.inline.mlir %s -c1=dot_test -c2=dot_test
 
 // RUN: circt-synth %s -o %t.lut.mlir --top mul --lower-to-k-lut 6
-// RUN: cat %t.lut.mlir | FileCheck %s --check-prefix=LUT
 // RUN: circt-opt -lower-comb %t.lut.mlir -o %t2.mlir
-// RUN: circt-lec %t2.mlir %s -c1=mul -c2=mul --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_MUL_LUT
+// RUN: circt-lec.sh %t2.mlir %s -c1=mul -c2=mul
 
-// COMB_MUL_LUT: c1 == c2
 
 // Set delay for binary and inv op to 5 so that others will be prioritized
 hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 5, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 5, 0, #synth.polarity<positive>>], input_caps = {}>} {

--- a/integration_test/circt-synth/mapping-lec.mlir
+++ b/integration_test/circt-synth/mapping-lec.mlir
@@ -1,14 +1,15 @@
 // REQUIRES: z3
 
 // RUN: circt-synth %s -o %t1.mlir
+// RUN: cat %t1.mlir | FileCheck %s
 // RUN: circt-opt %t1.mlir --hw-flatten-modules=hw-inline-public -o %t1.inline.mlir
 // RUN: circt-lec.sh %t1.inline.mlir %s -c1=mul -c2=mul
 // RUN: circt-lec.sh %t1.inline.mlir %s -c1=dot_test -c2=dot_test
 
 // RUN: circt-synth %s -o %t.lut.mlir --top mul --lower-to-k-lut 6
+// RUN: cat %t.lut.mlir | FileCheck %s --check-prefix=LUT
 // RUN: circt-opt -lower-comb %t.lut.mlir -o %t2.mlir
 // RUN: circt-lec.sh %t2.mlir %s -c1=mul -c2=mul
-
 
 // Set delay for binary and inv op to 5 so that others will be prioritized
 hw.module @and_inv(in %a : i1, in %b : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 1.0 : f64, arcs = [#synth.linear_timing_arc<"result", "a", 5, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<"result", "b", 5, 0, #synth.polarity<positive>>], input_caps = {}>} {

--- a/integration_test/circt-synth/maximum-and-cover-lec.mlir
+++ b/integration_test/circt-synth/maximum-and-cover-lec.mlir
@@ -1,11 +1,9 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
 // RUN: circt-opt %s -o %t1.mlir
 // RUN: circt-opt %s --synth-maximum-and-cover -o %t2.mlir
 
-// RUN: circt-lec %t1.mlir %t2.mlir -c1=MaxCover1 -c2=MaxCover1 --shared-libs=%libz3 | FileCheck %s --check-prefix=MAX_COVER_1
-// MAX_COVER_1: c1 == c2
+// RUN: circt-lec.sh %t1.mlir %t2.mlir -c1=MaxCover1 -c2=MaxCover1
 hw.module @MaxCover1(in %a: i1, in %b: i1, in %c: i1, in %d: i1, out o1: i1, out o2: i1, out o3: i1) {
   %0 = synth.aig.and_inv %a, %b : i1
   %1 = synth.aig.and_inv %0, %c : i1
@@ -19,8 +17,7 @@ hw.module @MaxCover1(in %a: i1, in %b: i1, in %c: i1, in %d: i1, out o1: i1, out
   hw.output %1, %3, %6 : i1, i1, i1
 }
 
-// RUN: circt-lec %t1.mlir %t2.mlir -c1=MaxCover2 -c2=MaxCover2 --shared-libs=%libz3 | FileCheck %s --check-prefix=MAX_COVER_2
-// MAX_COVER_2: c1 == c2
+// RUN: circt-lec.sh %t1.mlir %t2.mlir -c1=MaxCover2 -c2=MaxCover2
 hw.module @MaxCover2(in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1, in %f: i1, in %g: i1, out o1: i1) {
   %1 = synth.aig.and_inv %a, not %b : i1
   %2 = synth.aig.and_inv %d, not %e : i1

--- a/integration_test/circt-synth/sop-balancing.mlir
+++ b/integration_test/circt-synth/sop-balancing.mlir
@@ -1,10 +1,8 @@
-// REQUIRES: libz3
-// REQUIRES: circt-lec-jit
+// REQUIRES: z3
 
-// RUN: circt-synth %s -o %t.before.mlir --analysis-output=- | FileCheck %s --check-prefix=LONGEST_PATH_BEFORE
-// RUN: circt-synth %s -enable-sop-balancing -o %t.after.mlir -convert-to-comb --analysis-output=- | FileCheck %s --check-prefix=LONGEST_PATH_AFTER
-// RUN: circt-lec %t.before.mlir %t.after.mlir -c1=add16 -c2=add16 --shared-libs=%libz3 | FileCheck %s --check-prefix=AND_INVERTER_LEC
-// AND_INVERTER_LEC: c1 == c2
+// RUN: circt-synth %s -o %t.before.mlir --analysis-output=-
+// RUN: circt-synth %s -enable-sop-balancing -o %t.after.mlir -convert-to-comb --analysis-output=-
+// RUN: circt-lec.sh %t.before.mlir %t.after.mlir -c1=add16 -c2=add16
 // LONGEST_PATH_BEFORE: delay: 12
 // LONGEST_PATH_AFTER:  delay: 10
 hw.module @add16(in %arg0: i16, in %arg1: i16, out add: i16) {

--- a/integration_test/circt-synth/sop-balancing.mlir
+++ b/integration_test/circt-synth/sop-balancing.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: z3
 
-// RUN: circt-synth %s -o %t.before.mlir --analysis-output=-
-// RUN: circt-synth %s -enable-sop-balancing -o %t.after.mlir -convert-to-comb --analysis-output=-
+// RUN: circt-synth %s -o %t.before.mlir --analysis-output=- | FileCheck %s --check-prefix=LONGEST_PATH_BEFORE
+// RUN: circt-synth %s -enable-sop-balancing -o %t.after.mlir -convert-to-comb --analysis-output=- | FileCheck %s --check-prefix=LONGEST_PATH_AFTER
 // RUN: circt-lec.sh %t.before.mlir %t.after.mlir -c1=add16 -c2=add16
 // LONGEST_PATH_BEFORE: delay: 12
 // LONGEST_PATH_AFTER:  delay: 10

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -81,7 +81,7 @@ tool_dirs = [
 tools = [
     'arcilator', 'circt-opt', 'circt-translate', 'firtool', 'circt-rtl-sim.py',
     'equiv-rtl.sh', 'handshake-runner', 'hlstool', 'kanagawatool', 'circt-lec',
-    'circt-bmc', 'circt-test', 'circt-test-runner-sby.py',
+    'circt-lec.sh', 'circt-bmc', 'circt-test', 'circt-test-runner-sby.py',
     'circt-test-runner-circt-bmc.py', 'circt-cocotb-driver.py'
 ]
 
@@ -215,6 +215,10 @@ if config.have_systemc != "":
 if config.z3_library not in ("", "Z3_LIBRARIES-NOTFOUND"):
   tools.append(ToolSubst(f"%libz3", config.z3_library))
   config.available_features.add('libz3')
+
+if config.z3_path != "":
+  llvm_config.with_environment('PATH', config.z3_path, append_path=True)
+  config.available_features.add('z3')
 
 if config.llvm_with_z3 == "1":
   config.available_features.add('z3-integration')

--- a/utils/circt-lec.sh
+++ b/utils/circt-lec.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CIRCT_LEC="${CIRCT_LEC:-circt-lec}"
+"$CIRCT_LEC" "$@" --emit-smtlib | z3 -in | grep -q "unsat"

--- a/utils/circt-lec.sh
+++ b/utils/circt-lec.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# CI-only test wrapper around circt-lec that uses z3 to check equivalence.
+# This avoids slow JIT execution of circt-lec in Debug builds.
 set -euo pipefail
 CIRCT_LEC="${CIRCT_LEC:-circt-lec}"
 output=$("$CIRCT_LEC" "$@" --emit-smtlib | z3 -in)

--- a/utils/circt-lec.sh
+++ b/utils/circt-lec.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 CIRCT_LEC="${CIRCT_LEC:-circt-lec}"
-"$CIRCT_LEC" "$@" --emit-smtlib | z3 -in | grep -q "unsat"
+output=$("$CIRCT_LEC" "$@" --emit-smtlib | z3 -in)
+if echo "$output" | grep -q "unsat"; then
+  echo "PASSED"
+  exit 0
+fi
+echo "FAILED"
+exit 1


### PR DESCRIPTION
Add a drop-in replacement script 'circt-lec.sh that uses standalone z3
instead of JIT+libz3. This is useful for CI where JIT is
really slow (e.g., Debug builds hitting timeouts on LEC tests).

Fix https://github.com/llvm/circt/issues/10617.

https://github.com/llvm/circt/issues/10617#issuecomment-4689451541 is nightly run. 

Assisted-by: codex: gpt-5.4 mini

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
