### PR TITLE
[FIRRTL] Add a Gated Clock Conversion utility

### DIFF
--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -1,12 +1,8 @@
-//===- GatedClockConversion.h - Gated clock conversion ----------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-//
-// This file defines the GatedClockConversion utility class.
 //
 //===----------------------------------------------------------------------===//
 
@@ -15,10 +11,6 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/LogicalResult.h"
 
 namespace circt {
 namespace firrtl {
@@ -27,123 +19,77 @@ namespace firrtl {
 // GatedClockConversion
 //===----------------------------------------------------------------------===//
 
-/// Describes how a source clock drives a destination clock in the flow graph.
 enum class EdgeKind { Alias, Gate, InstanceIn, InstanceOut };
 
-/// One edge in the clock flow graph built during backward BFS.
 struct ClockEdge {
   Value dst;
-  Operation *op; ///< gate or instance op; null for Alias
+  Operation *op; // null for Alias
   EdgeKind kind;
+
+  // Typed views of `op` for the kinds that carry one. The cast is checked, so
+  // calling the wrong accessor for an edge kind is a hard error.
+  ClockGateIntrinsicOp gate() const { return cast<ClockGateIntrinsicOp>(op); }
+  InstanceOp instance() const { return cast<InstanceOp>(op); }
 };
 
-/// Sink gated-clock enables into "interesting" ops across module boundaries.
+/// Sink gated-clock enables into ops across module boundaries.
 ///
-/// Usage:
-///   1. Construct with the design's `InstanceGraph`.
-///   2. Call `addRoot(op)` for every op whose clock should be rewritten
-///      (RefForce/RefRelease/Reg/RegReset; *_initial variants are no-ops).
-///   3. Call `run()`.
+/// Algorithm: backward DFS from each root's clock operand through aliases.
+/// Build `srcToDstClocks` mapping during BFS. Forward pass materializes
+/// (base, AND-of-enables) pairs per module, lazily inserting port pairs.
+/// Rewrite each root: replace clock with base, fold enable into predicate/mux.
+/// Eliminate temporary wires when safe.
 ///
-/// Algorithm: from each root's clock operand we BFS backward through the
-/// IR, looking through node/wire/cast aliases.  At each step:
-///     - input-port BlockArgument → fan out to every caller's operand at
-///                                  every instance of the module;
-///     - `firrtl.int.clock_gate`  → push the gate's base input;
-///     - InstanceOp result        → descend into the referenced module and
-///                                  push the driver of the matching output
-///                                  port;
-///     - anything else            → reached the base clock.
-///
-/// We build a source-to-destination clock mapping (`srcToDstClocks`) during
-/// the backward BFS, tracking how clock values flow through the design.
-/// Then a forward walk from each base clock materializes (baseClock,
-/// AND-of-enables) pairs locally in each module — lazily inserting
-/// `(base, enable)` input or output port pairs on intermediate modules as
-/// needed.  Each registered root op is then rewritten in place: its clock
-/// is replaced with the base, and the AND-reduced enable is folded into
-/// the op's predicate / next-state mux per op kind.  Finally, temporary
-/// wires created during materialization are eliminated by forwarding their
-/// values directly when safe to do so.
-///
-/// `run()` is sequential and NOT thread-safe — port insertion mutates
-/// module signatures and replaces instance ops globally.
+/// NOT thread-safe: port insertion mutates module signatures globally.
 class GatedClockConversion {
 public:
   explicit GatedClockConversion(InstanceGraph &ig) : ig(ig) {}
 
-  /// Register an op whose clock operand should be sunk.  The clock operand
-  /// is identified per op kind:
-  ///   RefForceOp / RefReleaseOp        → getClock()
-  ///   RegOp / RegResetOp               → getClockVal()
-  ///   RefForceInitialOp /
-  ///   RefReleaseInitialOp              → no clock; recorded but ignored.
-  void addRoot(Operation *op) { roots.push_back(op); }
+  LogicalResult addRoot(Operation *op);
 
-  /// Perform the worklist + materialisation + IR rewrite on every
-  /// registered root.  Sequential; NOT thread-safe.
   LogicalResult run();
 
-  /// Dump the analysis results (srcToDstClocks and baseClks) to llvm::dbgs().
   void dump() const;
 
 private:
-  /// Indices of a (base, enable) sibling pair on a module's port list.
-  struct PortPair {
-    unsigned baseIdx;
-    unsigned enableIdx;
-  };
-
   // ── Worklist analysis (no IR mutation) ───────────────────────────────
 
-  /// Reset per-call analysis state (`visited`).
-  void clearAnalysis();
-
-  /// BFS from each value in `seeds`, populating `srcToDstClocks`, `baseClks`,
-  /// and `visited`.  Pure read of IR.
   void analyzeFrom(ArrayRef<Value> seeds);
+
+  // Returns a cycle node if found, else null.
+  Value findClockFlowCycle() const;
 
   // ── Materialisation (IR-mutating) ────────────────────────────────────
 
-  /// Forward pass that propagates (base, enable) pairs from base clocks through
-  /// the clock flow graph, inserting ports and wires as needed.
   void materialize();
 
-  /// Apply the per-op-kind IR rewrite given the materialized
-  /// `(base, enable)` pair for `op`'s clock.  No-op when `enable` is null.
+  // Materialize a single outgoing edge of `srcClk` during the forward pass and
+  // return the clock value(s) to enqueue next: the freshly-reachable
+  // destination, plus `srcClk` again when a multiply-instantiated input edge
+  // must be retried.
+  SmallVector<Value, 2> processEdge(const ClockEdge &edge, Value srcClk,
+                                    FModuleOp srcMod, Value materializedClk,
+                                    Value materializedEn);
+
   LogicalResult rewriteRoot(Operation *op, Value base, Value enable);
 
   // ── Helpers ──────────────────────────────────────────────────────────
 
-  /// Collect clock operands from pending roots and prepare them for analysis.
-  /// Takes ownership of the pending roots, clearing the `roots` queue.
-  /// Returns a pair of (seeds, rootClocks) where seeds are clock values for
-  /// analysis and rootClocks map each operation to its original clock value.
-  /// Skips operations without clock operands (*_initial variants).
+  // Skips operations without clock operands (*_initial variants).
   std::pair<SmallVector<Value>, SmallVector<std::pair<Operation *, Value>>>
   collectSeeds();
 
-  /// Insert a (base, enable) port pair into `mod`'s signature and
-  /// propagate the new slots to every existing instance.
-  /// If `existingClockIdx` is provided, reuses that port for the clock;
-  /// otherwise, creates a new clock port.
-  /// If `existingEnableIdx` is provided, reuses that port for the enable;
-  /// otherwise, creates a new enable port.
-  /// Returns the indices of the clock and enable ports (reused or newly
-  /// created).
-  PortPair insertOrReusePort(FModuleOp mod, StringRef tag, Direction dir,
-                             std::optional<unsigned> existingClockIdx = {},
-                             std::optional<unsigned> existingEnableIdx = {});
+  // Updates all instances of `mod` globally.
+  std::pair<unsigned, unsigned> insertPorts(FModuleOp mod, StringRef tag,
+                                            Direction dir);
 
-  /// Materialize `enable | test_enable` for `gate` (just `enable` when
-  /// the gate has no test_enable).  Cached.
+  // Cached: returns `enable | test_enable` or just `enable`.
   Value gateEnableOf(ClockGateIntrinsicOp gate);
 
-  /// Connect materialized clock and enable values to instance ports.
-  /// This helper creates MatchingConnectOps to drive the instance's
-  /// clock and enable input ports with the materialized values.
-  /// If `checkUseEmpty` is true, connections are only created if the
-  /// port values are not yet used.
+  // Cached: returns a constant 1 value for the given module, creating it at the
+  // beginning of the module body block if not already cached.
+  Value getOrCreateConstU1One(FModuleOp mod);
+
   void connectMaterializedToInstancePorts(InstanceOp inst,
                                           unsigned clkPortIndex,
                                           unsigned enPortIndex,
@@ -151,51 +97,32 @@ private:
                                           Value materializedEn, Location loc,
                                           bool checkUseEmpty = false);
 
-  /// Eliminate temporary wires created during materialization.
-  /// For each wire in `wireOps`, check if there are exactly two uses:
-  /// one connect writing to the wire and one connect reading from it.
-  /// If so, and if the write dominates the read, replace the read with
-  /// the write source and erase the wire and both connects.
+  // Forward wire to source when exactly one writer dominates one reader.
   void eliminateTemporaryWires();
 
   // ── materialize() dispatched handlers ────────────────────────────────
 
-  /// Handle a wire/node/cast alias edge: create temporary wires in `srcMod`
-  /// and record `materialized[dstClk]`.
   void materializeAlias(Value dstClk, FModuleOp srcMod, Value materializedClk,
                         Value materializedEn);
 
-  /// Handle a clock-gate edge: AND the gate enable with any upstream enable
-  /// and record `materialized[dstClk]`.
   void materializeGate(ClockGateIntrinsicOp gate, Value dstClk,
                        Value materializedClk, Value materializedEn);
 
-  /// Unified handler for instance input (dir=In) and output (dir=Out) edges.
-  /// `liveAnchor` is the live instance result whose result-number gives the
-  /// gated-clock port index: `liveValue(dstClk)` for Out, `liveValue(srcClk)`
-  /// for In.
-  void materializeInstancePort(Direction dir, InstanceOp inst, Value dstClk,
-                               Value liveAnchor, Value materializedClk,
+  bool materializeInstancePort(Direction dir, InstanceOp inst, Value dstClk,
+                               Value srcClk, Value materializedClk,
                                Value materializedEn);
 
-  /// Re-initialize the gated (base, enable) ports of `inst` when an
-  /// InstanceIn destination has already been materialized by another caller
-  /// (multiply-instantiated module case).
+  // Handle multiply-instantiated modules.
   void reinitMultiplyInstantiatedInput(Value liveSrc, Value materializedClk,
                                        Value materializedEn);
 
-  /// Look up or create the (base-clock, enable) port pair for `(childMod,
-  /// gatedClkIndex)` in direction `dir`, wire connects on first creation, and
-  /// return the resulting port indices.  `inst` is updated in-place if a new
-  /// instance is cloned to accommodate inserted ports.
-  PortPair findOrInsertGatedPorts(InstanceOp &inst, FModuleOp childMod,
-                                  unsigned gatedClkIndex, Direction dir,
-                                  Value materializedClk, Value materializedEn);
+  // Updates `inst` reference if ports are inserted.
+  std::pair<unsigned, unsigned>
+  findOrInsertGatedPorts(InstanceOp &inst, FModuleOp childMod,
+                         unsigned gatedClkIndex, Direction dir,
+                         Value materializedClk, Value materializedEn);
 
-  /// Resolve a value through `valueReplaceMap` to its currently-live SSA value.
-  /// `insertOrReusePort` erases the old instance and records old-result →
-  /// new-result mappings here; the lookup is purely pointer-based so it is safe
-  /// to chase even though the original value's IR storage has been freed.
+  // Pointer-based lookup safe for erased IR.
   Value liveValue(Value v) const {
     while (true) {
       auto it = valueReplaceMap.find(v);
@@ -207,26 +134,20 @@ private:
 
   InstanceGraph &ig;
 
-  /// Roots registered via `addRoot`.
+  // Single-use guard: `run()` may only be called once per instance.
+  bool hasRun = false;
+
   SmallVector<Operation *> roots;
 
   // ── Per-call analysis state (cleared by `clearAnalysis`) ─────────────
 
-  /// Dedup set; prevents revisiting a value via aliasing paths.
   DenseSet<Value> visited;
 
   // ── Long-lived port-plumbing caches ──────────────────────────────────
 
-  /// Track instance replacements as `insertOrReusePort` erases old instances.
-  mutable DenseMap<InstanceOp, InstanceOp> instReplaceMap;
+  DenseMap<InstanceOp, InstanceOp> opReplaceMap;
 
-  /// Same replacement chain as `instReplaceMap`, but keyed by the raw
-  /// `Operation *` so a stale (erased) instance pointer can be resolved to its
-  /// live replacement without ever dereferencing the dangling pointer.
-  DenseMap<Operation *, Operation *> opReplaceMap;
-
-  /// Chase `opReplaceMap` to the live operation for a possibly-erased op.
-  Operation *liveOp(Operation *op) const {
+  InstanceOp liveOp(InstanceOp op) const {
     while (true) {
       auto it = opReplaceMap.find(op);
       if (it == opReplaceMap.end())
@@ -235,42 +156,28 @@ private:
     }
   }
 
-  /// Track per-result SSA value replacements as `insertOrReusePort` erases old
-  /// instances.  Maps old (now-dangling) result values to the corresponding
-  /// result of the replacement instance, accounting for inserted port indices.
   DenseMap<Value, Value> valueReplaceMap;
 
-  /// Cache of gate → materialized `enable | test_enable`.
   DenseMap<ClockGateIntrinsicOp, Value> gateEnableCache;
 
-  /// Maps source clocks to their driven destination clocks. Built during
-  /// backward BFS analysis; each edge carries an explicit EdgeKind.
   DenseMap<Value, SmallVector<ClockEdge>> srcToDstClocks;
 
-  /// List of base clocks (clocks with no further source) found during analysis.
   SmallVector<Value> baseClks;
 
-  /// Maps each clock value to its materialized (base, enable) pair.
-  /// Built during forward materialization pass.
-  DenseMap<Value, std::pair<Value, Value>> materialized;
+  DenseMap<Value, std::pair<Value, Value>> clockEnablePairs;
 
-  /// Maps (module, port-index) to the inserted (base-port-index,
-  /// enable-port-index). Caches port insertions to avoid duplicating ports
-  /// across multiple uses.
   DenseMap<std::pair<FModuleOp, unsigned>, std::pair<unsigned, unsigned>>
       modArgToMaterialized;
 
-  /// MLIR context, cached from the first seed value during run().
+  // Cache of constant 1 values per module
+  DenseMap<FModuleOp, Value> constU1Cache;
+
   MLIRContext *context;
 
-  /// Clock and U1 type, cached to avoid repeated creation.
   Type clockType, u1Type;
 
-  /// Operations to be erased, collected during transformation and erased at
-  /// end.
   SmallVector<InstanceOp> opsToErase;
 
-  /// Temporary wires created during transformation. Try to eliminate them.
   SmallVector<WireOp> wireOps;
 };
 

--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -1,0 +1,280 @@
+//===- GatedClockConversion.h - Gated clock conversion ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the GatedClockConversion utility class.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_GATEDCLOCKCONVERSION_H
+#define CIRCT_DIALECT_FIRRTL_GATEDCLOCKCONVERSION_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/LogicalResult.h"
+
+namespace circt {
+namespace firrtl {
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion
+//===----------------------------------------------------------------------===//
+
+/// Describes how a source clock drives a destination clock in the flow graph.
+enum class EdgeKind { Alias, Gate, InstanceIn, InstanceOut };
+
+/// One edge in the clock flow graph built during backward BFS.
+struct ClockEdge {
+  Value dst;
+  Operation *op; ///< gate or instance op; null for Alias
+  EdgeKind kind;
+};
+
+/// Sink gated-clock enables into "interesting" ops across module boundaries.
+///
+/// Usage:
+///   1. Construct with the design's `InstanceGraph`.
+///   2. Call `addRoot(op)` for every op whose clock should be rewritten
+///      (RefForce/RefRelease/Reg/RegReset; *_initial variants are no-ops).
+///   3. Call `run()`.
+///
+/// Algorithm: from each root's clock operand we BFS backward through the
+/// IR, looking through node/wire/cast aliases.  At each step:
+///     - input-port BlockArgument → fan out to every caller's operand at
+///                                  every instance of the module;
+///     - `firrtl.int.clock_gate`  → push the gate's base input;
+///     - InstanceOp result        → descend into the referenced module and
+///                                  push the driver of the matching output
+///                                  port;
+///     - anything else            → reached the base clock.
+///
+/// We build a source-to-destination clock mapping (`srcToDstClocks`) during
+/// the backward BFS, tracking how clock values flow through the design.
+/// Then a forward walk from each base clock materializes (baseClock,
+/// AND-of-enables) pairs locally in each module — lazily inserting
+/// `(base, enable)` input or output port pairs on intermediate modules as
+/// needed.  Each registered root op is then rewritten in place: its clock
+/// is replaced with the base, and the AND-reduced enable is folded into
+/// the op's predicate / next-state mux per op kind.  Finally, temporary
+/// wires created during materialization are eliminated by forwarding their
+/// values directly when safe to do so.
+///
+/// `run()` is sequential and NOT thread-safe — port insertion mutates
+/// module signatures and replaces instance ops globally.
+class GatedClockConversion {
+public:
+  explicit GatedClockConversion(InstanceGraph &ig) : ig(ig) {}
+
+  /// Register an op whose clock operand should be sunk.  The clock operand
+  /// is identified per op kind:
+  ///   RefForceOp / RefReleaseOp        → getClock()
+  ///   RegOp / RegResetOp               → getClockVal()
+  ///   RefForceInitialOp /
+  ///   RefReleaseInitialOp              → no clock; recorded but ignored.
+  void addRoot(Operation *op) { roots.push_back(op); }
+
+  /// Perform the worklist + materialisation + IR rewrite on every
+  /// registered root.  Sequential; NOT thread-safe.
+  LogicalResult run();
+
+  /// Dump the analysis results (srcToDstClocks and baseClks) to llvm::dbgs().
+  void dump() const;
+
+private:
+  /// Indices of a (base, enable) sibling pair on a module's port list.
+  struct PortPair {
+    unsigned baseIdx;
+    unsigned enableIdx;
+  };
+
+  // ── Worklist analysis (no IR mutation) ───────────────────────────────
+
+  /// Reset per-call analysis state (`visited`).
+  void clearAnalysis();
+
+  /// BFS from each value in `seeds`, populating `srcToDstClocks`, `baseClks`,
+  /// and `visited`.  Pure read of IR.
+  void analyzeFrom(ArrayRef<Value> seeds);
+
+  // ── Materialisation (IR-mutating) ────────────────────────────────────
+
+  /// Forward pass that propagates (base, enable) pairs from base clocks through
+  /// the clock flow graph, inserting ports and wires as needed.
+  void materialize();
+
+  /// Apply the per-op-kind IR rewrite given the materialized
+  /// `(base, enable)` pair for `op`'s clock.  No-op when `enable` is null.
+  LogicalResult rewriteRoot(Operation *op, Value base, Value enable);
+
+  // ── Helpers ──────────────────────────────────────────────────────────
+
+  /// Collect clock operands from pending roots and prepare them for analysis.
+  /// Takes ownership of the pending roots, clearing the `roots` queue.
+  /// Returns a pair of (seeds, rootClocks) where seeds are clock values for
+  /// analysis and rootClocks map each operation to its original clock value.
+  /// Skips operations without clock operands (*_initial variants).
+  std::pair<SmallVector<Value>, SmallVector<std::pair<Operation *, Value>>>
+  collectSeeds();
+
+  /// Insert a (base, enable) port pair into `mod`'s signature and
+  /// propagate the new slots to every existing instance.
+  /// If `existingClockIdx` is provided, reuses that port for the clock;
+  /// otherwise, creates a new clock port.
+  /// If `existingEnableIdx` is provided, reuses that port for the enable;
+  /// otherwise, creates a new enable port.
+  /// Returns the indices of the clock and enable ports (reused or newly
+  /// created).
+  PortPair insertOrReusePort(FModuleOp mod, StringRef tag, Direction dir,
+                             std::optional<unsigned> existingClockIdx = {},
+                             std::optional<unsigned> existingEnableIdx = {});
+
+  /// Materialize `enable | test_enable` for `gate` (just `enable` when
+  /// the gate has no test_enable).  Cached.
+  Value gateEnableOf(ClockGateIntrinsicOp gate);
+
+  /// Connect materialized clock and enable values to instance ports.
+  /// This helper creates MatchingConnectOps to drive the instance's
+  /// clock and enable input ports with the materialized values.
+  /// If `checkUseEmpty` is true, connections are only created if the
+  /// port values are not yet used.
+  void connectMaterializedToInstancePorts(InstanceOp inst,
+                                          unsigned clkPortIndex,
+                                          unsigned enPortIndex,
+                                          Value materializedClk,
+                                          Value materializedEn, Location loc,
+                                          bool checkUseEmpty = false);
+
+  /// Eliminate temporary wires created during materialization.
+  /// For each wire in `wireOps`, check if there are exactly two uses:
+  /// one connect writing to the wire and one connect reading from it.
+  /// If so, and if the write dominates the read, replace the read with
+  /// the write source and erase the wire and both connects.
+  void eliminateTemporaryWires();
+
+  // ── materialize() dispatched handlers ────────────────────────────────
+
+  /// Handle a wire/node/cast alias edge: create temporary wires in `srcMod`
+  /// and record `materialized[dstClk]`.
+  void materializeAlias(Value dstClk, FModuleOp srcMod, Value materializedClk,
+                        Value materializedEn);
+
+  /// Handle a clock-gate edge: AND the gate enable with any upstream enable
+  /// and record `materialized[dstClk]`.
+  void materializeGate(ClockGateIntrinsicOp gate, Value dstClk,
+                       Value materializedClk, Value materializedEn);
+
+  /// Unified handler for instance input (dir=In) and output (dir=Out) edges.
+  /// `liveAnchor` is the live instance result whose result-number gives the
+  /// gated-clock port index: `liveValue(dstClk)` for Out, `liveValue(srcClk)`
+  /// for In.
+  void materializeInstancePort(Direction dir, InstanceOp inst, Value dstClk,
+                               Value liveAnchor, Value materializedClk,
+                               Value materializedEn);
+
+  /// Re-initialize the gated (base, enable) ports of `inst` when an
+  /// InstanceIn destination has already been materialized by another caller
+  /// (multiply-instantiated module case).
+  void reinitMultiplyInstantiatedInput(Value liveSrc, Value materializedClk,
+                                       Value materializedEn);
+
+  /// Look up or create the (base-clock, enable) port pair for `(childMod,
+  /// gatedClkIndex)` in direction `dir`, wire connects on first creation, and
+  /// return the resulting port indices.  `inst` is updated in-place if a new
+  /// instance is cloned to accommodate inserted ports.
+  PortPair findOrInsertGatedPorts(InstanceOp &inst, FModuleOp childMod,
+                                  unsigned gatedClkIndex, Direction dir,
+                                  Value materializedClk, Value materializedEn);
+
+  /// Resolve a value through `valueReplaceMap` to its currently-live SSA value.
+  /// `insertOrReusePort` erases the old instance and records old-result →
+  /// new-result mappings here; the lookup is purely pointer-based so it is safe
+  /// to chase even though the original value's IR storage has been freed.
+  Value liveValue(Value v) const {
+    while (true) {
+      auto it = valueReplaceMap.find(v);
+      if (it == valueReplaceMap.end())
+        return v;
+      v = it->second;
+    }
+  }
+
+  InstanceGraph &ig;
+
+  /// Roots registered via `addRoot`.
+  SmallVector<Operation *> roots;
+
+  // ── Per-call analysis state (cleared by `clearAnalysis`) ─────────────
+
+  /// Dedup set; prevents revisiting a value via aliasing paths.
+  DenseSet<Value> visited;
+
+  // ── Long-lived port-plumbing caches ──────────────────────────────────
+
+  /// Track instance replacements as `insertOrReusePort` erases old instances.
+  mutable DenseMap<InstanceOp, InstanceOp> instReplaceMap;
+
+  /// Same replacement chain as `instReplaceMap`, but keyed by the raw
+  /// `Operation *` so a stale (erased) instance pointer can be resolved to its
+  /// live replacement without ever dereferencing the dangling pointer.
+  DenseMap<Operation *, Operation *> opReplaceMap;
+
+  /// Chase `opReplaceMap` to the live operation for a possibly-erased op.
+  Operation *liveOp(Operation *op) const {
+    while (true) {
+      auto it = opReplaceMap.find(op);
+      if (it == opReplaceMap.end())
+        return op;
+      op = it->second;
+    }
+  }
+
+  /// Track per-result SSA value replacements as `insertOrReusePort` erases old
+  /// instances.  Maps old (now-dangling) result values to the corresponding
+  /// result of the replacement instance, accounting for inserted port indices.
+  DenseMap<Value, Value> valueReplaceMap;
+
+  /// Cache of gate → materialized `enable | test_enable`.
+  DenseMap<ClockGateIntrinsicOp, Value> gateEnableCache;
+
+  /// Maps source clocks to their driven destination clocks. Built during
+  /// backward BFS analysis; each edge carries an explicit EdgeKind.
+  DenseMap<Value, SmallVector<ClockEdge>> srcToDstClocks;
+
+  /// List of base clocks (clocks with no further source) found during analysis.
+  SmallVector<Value> baseClks;
+
+  /// Maps each clock value to its materialized (base, enable) pair.
+  /// Built during forward materialization pass.
+  DenseMap<Value, std::pair<Value, Value>> materialized;
+
+  /// Maps (module, port-index) to the inserted (base-port-index,
+  /// enable-port-index). Caches port insertions to avoid duplicating ports
+  /// across multiple uses.
+  DenseMap<std::pair<FModuleOp, unsigned>, std::pair<unsigned, unsigned>>
+      modArgToMaterialized;
+
+  /// MLIR context, cached from the first seed value during run().
+  MLIRContext *context;
+
+  /// Clock and U1 type, cached to avoid repeated creation.
+  Type clockType, u1Type;
+
+  /// Operations to be erased, collected during transformation and erased at
+  /// end.
+  SmallVector<InstanceOp> opsToErase;
+
+  /// Temporary wires created during transformation. Try to eliminate them.
+  SmallVector<WireOp> wireOps;
+};
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_GATEDCLOCKCONVERSION_H

--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -232,6 +232,8 @@ private:
   // node emits at most one `and`. Null for `kNoEnable`.
   Value lower(unsigned enableId);
 
+  LogicalResult rewriteRoot(Operation *op, Value baseClk, Value enable);
+
   // -- Helpers ----------------------------------------------------------
 
   // Cached: returns `enable | test_enable` or just `enable`.

--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -11,6 +11,7 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "llvm/ADT/MapVector.h"
 
 namespace circt {
 namespace firrtl {
@@ -55,6 +56,146 @@ public:
   void dump() const;
 
 private:
+  // -- The plan data model --------------------------------------------
+
+  /// Sentinel `EnableNode` index meaning "no enable at all".
+  static constexpr unsigned kNoEnable = ~0u;
+
+  /// A reference to a clock/enable value that can also name values which do not
+  /// exist yet (a planned port, a planned wire).
+  ///
+  /// Inserting a port re-creates every instance of a module, so instance
+  /// results are the only values `applyPlan()` invalidates. Hence the rule this
+  /// class enforces: name them symbolically as `(instance, resultIndex)`, never
+  /// raw.
+  class MatRef {
+  public:
+    enum class Kind {
+      None,        ///< Null reference, e.g. "no enable".
+      Direct,      ///< A `Value` that `applyPlan()` never invalidates.
+      InstResult,  ///< Result #index of an instance (existing or planned port).
+      ModuleArg,   ///< Block argument #index of a module (existing or planned).
+      PlannedWire, ///< Entry #index of `plannedWireValues`.
+      GateEnable,  ///< `gate.enable | gate.test_enable`, lowered on demand.
+    };
+
+    MatRef() = default;
+
+    static MatRef direct(Value v) {
+      assert(v && "use MatRef() for a null reference");
+      assert(!v.getDefiningOp<FInstanceLike>() &&
+             "instance results must be symbolic; use MatRef::instResult()");
+      MatRef r;
+      r.kind = Kind::Direct;
+      r.value = v;
+      return r;
+    }
+    static MatRef instResult(FInstanceLike inst, unsigned index) {
+      return opRef(Kind::InstResult, inst, index);
+    }
+    static MatRef moduleArg(FModuleOp mod, unsigned index) {
+      return opRef(Kind::ModuleArg, mod, index);
+    }
+    static MatRef plannedWire(unsigned index) {
+      return opRef(Kind::PlannedWire, nullptr, index);
+    }
+    static MatRef gateEnable(ClockGateIntrinsicOp gate) {
+      return opRef(Kind::GateEnable, gate, 0);
+    }
+
+    /// Instance results become symbolic refs, every other value is stable.
+    static MatRef of(Value v) {
+      if (!v)
+        return MatRef();
+      if (auto inst = v.getDefiningOp<FInstanceLike>())
+        return instResult(inst, cast<OpResult>(v).getResultNumber());
+      return direct(v);
+    }
+
+    Kind getKind() const { return kind; }
+    Value getValue() const { return value; }
+    unsigned getIndex() const { return index; }
+    Operation *getOp() const { return op; }
+    ClockGateIntrinsicOp gate() const { return cast<ClockGateIntrinsicOp>(op); }
+
+    void print(llvm::raw_ostream &os) const;
+
+  private:
+    static MatRef opRef(Kind kind, Operation *op, unsigned index) {
+      MatRef r;
+      r.kind = kind;
+      r.op = op;
+      r.index = index;
+      return r;
+    }
+
+    Kind kind = Kind::None;
+    Value value;             ///< `Direct` only.
+    Operation *op = nullptr; ///< Instance / module / gate, by kind.
+    unsigned index = 0;      ///< Result, argument or wire index.
+  };
+
+  /// Enable accumulation DAG node:
+  ///   value(id) = parent == kNoEnable ? term : (value(parent) & term)
+  /// Nodes are shared by every consumer of a pair, so a cascade of gates emits
+  /// one `and` per gate no matter how many roots it feeds.
+  struct EnableNode {
+    unsigned parent;
+    MatRef term;
+    /// Insert the `and` after this value.
+    MatRef anchor;
+    Location loc;
+  };
+
+  /// (baseClk, enable) pair planned for a clock value.
+  struct ClockPairPlan {
+    MatRef baseClk;
+    unsigned enableId = kNoEnable;
+  };
+
+  /// Root rewrite applied by `applyPlan()`: clock the op by `baseClk` and sink
+  /// `enableId` into it.
+  struct RootRewrite {
+    Operation *op;
+    MatRef baseClk;
+    unsigned enableId = kNoEnable;
+  };
+
+  /// (baseClock, enable) port pair to append to a module.
+  struct PortPairPlan {
+    FModuleOp mod;
+    /// Clock port this pair shadows (naming only).
+    unsigned gatedClkIndex;
+    Direction dir;
+    /// Final port indices, pre-assigned at planning time.
+    unsigned baseIdx, enIdx;
+    /// `dir == Out` only: values inside `mod` driving the new output ports.
+    MatRef outBaseClk = MatRef();
+    unsigned outEnableId = kNoEnable;
+  };
+
+  /// The `(module, clock port index)` key of a `PortPairPlan`.
+  using PortPlanKey = std::pair<FModuleOp, unsigned>;
+
+  /// Caller-side connects driving a planned *input* port pair.
+  struct InstanceDrive {
+    InstanceOp inst;
+    unsigned baseIdx, enIdx;
+    MatRef baseClk;
+    /// `kNoEnable` drives a constant 1.
+    unsigned enableId = kNoEnable;
+  };
+
+  /// Temporary (base clock, enable) carrier wires at the top of `mod`, standing
+  /// in for a wire/node alias of a gated clock.
+  /// Wires `2*i` / `2*i+1` of `plannedWireValues` belong to `wirePlans[i]`.
+  struct WirePairPlan {
+    FModuleOp mod;
+    MatRef baseClk;
+    unsigned enableId;
+    Location loc;
+  };
+
   // -- Worklist analysis (no IR mutation) -------------------------------
 
   // Fails on an undriven clock net, which this utility cannot plan around.
@@ -65,6 +206,35 @@ private:
   // that planning never has to block on a sibling instance. Monotone, hence a
   // single sweep suffices and a cycle saturates instead of diverging.
   void computeGatedClocks();
+
+  // Append an accumulation node and return its id. A node with no parent is a
+  // leaf: its value is `term` and the anchor is unused.
+  unsigned newEnableNode(unsigned parent, MatRef term, Location loc,
+                         MatRef anchor);
+  unsigned newEnableLeaf(MatRef term, Location loc) {
+    return newEnableNode(kNoEnable, term, loc, MatRef());
+  }
+
+  // Resolve a reference to the live value it names. Only valid once the sweep
+  // that creates the referenced value has run.
+  Value resolve(MatRef ref);
+
+  // Materialize the accumulated enable of a node, memoized per node so each
+  // node emits at most one `and`. Null for `kNoEnable`.
+  Value lower(unsigned enableId);
+
+  // -- Helpers ----------------------------------------------------------
+
+  // Cached: returns `enable | test_enable` or just `enable`.
+  Value gateEnableOf(ClockGateIntrinsicOp gate);
+
+  // The live instance for `inst`, which `insertPlannedPorts()` may have
+  // re-created. A single lookup suffices: all of a module's port pairs are
+  // inserted in one call, so an instance is re-created at most once.
+  Operation *liveInstance(Operation *inst) const {
+    auto *clone = instClones.lookup(inst);
+    return clone ? clone : inst;
+  }
 
   InstanceGraph &ig;
 
@@ -80,6 +250,45 @@ private:
 
   // Every clock value downstream of a clock gate; see `computeGatedClocks()`.
   DenseSet<Value> gatedClocks;
+
+  DenseMap<Value, ClockPairPlan> clockEnablePairs;
+
+  // -- The plan ---------------------------------------------------------
+
+  SmallVector<EnableNode> enableNodes;
+
+  // Values of the wires created by `applyPlan()`, indexed by
+  // `MatRef::plannedWire`.
+  SmallVector<Value> plannedWireValues;
+
+  // Memoized result of `lower()`, indexed like `enableNodes`.
+  SmallVector<Value> loweredEnables;
+
+  SmallVector<RootRewrite> rootRewrites;
+
+  SmallVector<WirePairPlan> wirePlans;
+
+  // The gated port pairs to append, and the order in which each module's pairs
+  // are appended. `MapVector` keeps emission deterministic.
+  llvm::MapVector<PortPlanKey, PortPairPlan> portPlans;
+  llvm::MapVector<FModuleOp, SmallVector<PortPlanKey>> plansPerModule;
+
+  // Per-module port index allocator, seeded with the module's port count.
+  DenseMap<FModuleOp, unsigned> nextPortIdx;
+
+  // Keyed by `(caller instance, base port index)`, which de-duplicates repeated
+  // drives of the same port pair.
+  llvm::MapVector<std::pair<InstanceOp, unsigned>, InstanceDrive>
+      instanceDrives;
+
+  // -- applyPlan() state ------------------------------------------------
+
+  DenseMap<ClockGateIntrinsicOp, Value> gateEnableCache;
+
+  // Old instance -> the instance re-created with the planned ports.
+  DenseMap<Operation *, Operation *> instClones;
+
+  MLIRContext *context;
 };
 
 } // namespace firrtl

--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_GATEDCLOCKCONVERSION_H
+#define CIRCT_DIALECT_FIRRTL_GATEDCLOCKCONVERSION_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+
+namespace circt {
+namespace firrtl {
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion
+//===----------------------------------------------------------------------===//
+
+enum class EdgeKind { Alias, Gate, InstanceIn, InstanceOut };
+
+struct ClockEdge {
+  Value dst;
+  Operation *op; // null for Alias
+  EdgeKind kind;
+
+  // Checked views of `op`, so using the wrong one for a kind is a hard error.
+  ClockGateIntrinsicOp gate() const { return cast<ClockGateIntrinsicOp>(op); }
+  InstanceOp instance() const { return cast<InstanceOp>(op); }
+};
+
+/// Sink gated-clock enables into ops across module boundaries.
+///
+/// Backward traversal from each root's clock builds the clock flow graph, a
+/// forward pass *plans* the (base, AND-of-enables) pair of every clock value,
+/// and `applyPlan()` then materializes the whole plan in one shot.
+///
+/// Invariant: analysis and planning never mutate the IR, and no plan record is
+/// read after the mutation it describes happened. That is what makes stale
+/// value remapping structurally impossible; see `MatRef`.
+///
+/// Preconditions: run after `firrtl-expand-whens`, so every clock net and
+/// register has a single driver. Clock loops are not diagnosed here; see
+/// `firrtl-check-comb-loops`.
+///
+/// NOT thread-safe: port insertion mutates module signatures globally.
+class GatedClockConversion {
+public:
+  explicit GatedClockConversion(InstanceGraph &ig) : ig(ig) {}
+
+  LogicalResult addRoot(Operation *op);
+
+  void dump() const;
+
+private:
+  // -- Worklist analysis (no IR mutation) -------------------------------
+
+  // Fails on an undriven clock net, which this utility cannot plan around.
+  LogicalResult analyzeFrom(ArrayRef<Value> seeds);
+
+  // Mark every clock value downstream of a clock gate. This answers "does this
+  // module clock port need a (base, enable) pair?" before planning starts, so
+  // that planning never has to block on a sibling instance. Monotone, hence a
+  // single sweep suffices and a cycle saturates instead of diverging.
+  void computeGatedClocks();
+
+  InstanceGraph &ig;
+
+  SmallVector<std::pair<Operation *, Value>> roots;
+
+  // -- Analysis state and output ----------------------------------------
+
+  DenseSet<Value> visited;
+
+  DenseMap<Value, SmallVector<ClockEdge>> srcToDstClocks;
+
+  SmallVector<Value> baseClks;
+
+  // Every clock value downstream of a clock gate; see `computeGatedClocks()`.
+  DenseSet<Value> gatedClocks;
+};
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_GATEDCLOCKCONVERSION_H

--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -224,6 +224,19 @@ private:
     return newEnableNode(kNoEnable, term, loc, MatRef());
   }
 
+  // -- Plan application (the only IR-mutating phase) --------------------
+
+  LogicalResult applyPlan();
+
+  // Sweep A: create the planned carrier wires.
+  void createPlannedWires();
+
+  // Sweep B: append the planned ports and re-create every affected instance.
+  void insertPlannedPorts();
+
+  // Sweep C: emit the planned expressions, connects and root rewrites.
+  LogicalResult emitPlannedIR();
+
   // Resolve a reference to the live value it names. Only valid once the sweep
   // that creates the referenced value has run.
   Value resolve(MatRef ref);
@@ -238,6 +251,15 @@ private:
 
   // Cached: returns `enable | test_enable` or just `enable`.
   Value gateEnableOf(ClockGateIntrinsicOp gate);
+
+  // Cached: a constant 1 at the top of `mod`, so it dominates every use.
+  Value getOrCreateConstU1One(FModuleOp mod);
+
+  void connectMaterializedToInstancePorts(InstanceOp inst,
+                                          unsigned clkPortIndex,
+                                          unsigned enPortIndex,
+                                          Value materializedClk,
+                                          Value materializedEn);
 
   // The live instance for `inst`, which `insertPlannedPorts()` may have
   // re-created. A single lookup suffices: all of a module's port pairs are
@@ -322,10 +344,21 @@ private:
 
   DenseMap<ClockGateIntrinsicOp, Value> gateEnableCache;
 
+  // Cache of constant 1 values per module
+  DenseMap<FModuleOp, Value> constU1Cache;
+
   // Old instance -> the instance re-created with the planned ports.
   DenseMap<Operation *, Operation *> instClones;
 
+  // Replaced instances, erased once nothing reads the plan any more.
+  SmallVector<InstanceOp> deadInstances;
+
+  // Temporary carrier wires awaiting elimination.
+  SmallVector<WireOp> wireOps;
+
   MLIRContext *context;
+
+  Type clockType, u1Type;
 };
 
 } // namespace firrtl

--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -207,6 +207,15 @@ private:
   // single sweep suffices and a cycle saturates instead of diverging.
   void computeGatedClocks();
 
+  // -- Planning (no IR mutation) ----------------------------------------
+
+  void plan();
+
+  // Plan one outgoing edge of `srcClk` and return the value to enqueue next:
+  // the destination, or null if it was already planned.
+  Value processEdge(const ClockEdge &edge, Value srcClk, FModuleOp srcMod,
+                    MatRef baseClk, unsigned enableId);
+
   // Append an accumulation node and return its id. A node with no parent is a
   // leaf: its value is `term` and the anchor is unused.
   unsigned newEnableNode(unsigned parent, MatRef term, Location loc,
@@ -235,6 +244,32 @@ private:
     auto *clone = instClones.lookup(inst);
     return clone ? clone : inst;
   }
+
+  void dumpPlan() const;
+
+  // -- plan() dispatched handlers ---------------------------------------
+
+  void planAlias(Value dstClk, FModuleOp srcMod, MatRef baseClk,
+                 unsigned enableId);
+
+  void planGate(ClockGateIntrinsicOp gate, Value dstClk, MatRef baseClk,
+                unsigned enableId);
+
+  void planInstancePort(Direction dir, InstanceOp inst, Value dstClk,
+                        Value srcClk, MatRef baseClk, unsigned enableId);
+
+  // Handle the 2nd-and-later callers of a multiply-instantiated module.
+  void planMultiplyInstantiatedInput(Value srcClk, MatRef baseClk,
+                                     unsigned enableId);
+
+  // Plan (or look up) the gated port pair of a child module, and record the
+  // drive of a planned input pair at `inst`.
+  std::pair<unsigned, unsigned>
+  planGatedPorts(InstanceOp inst, FModuleOp childMod, unsigned gatedClkIndex,
+                 Direction dir, MatRef baseClk, unsigned enableId);
+
+  void recordInstanceDrive(InstanceOp inst, const PortPairPlan &plan,
+                           MatRef baseClk, unsigned enableId);
 
   InstanceGraph &ig;
 

--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -261,6 +261,9 @@ private:
                                           Value materializedClk,
                                           Value materializedEn);
 
+  // Forward wire to source when exactly one writer dominates one reader.
+  void eliminateTemporaryWires();
+
   // The live instance for `inst`, which `insertPlannedPorts()` may have
   // re-created. A single lookup suffices: all of a module's port pairs are
   // inserted in one call, so an instance is re-created at most once.

--- a/include/circt/Dialect/FIRRTL/GatedClockConversion.h
+++ b/include/circt/Dialect/FIRRTL/GatedClockConversion.h
@@ -53,6 +53,8 @@ public:
 
   LogicalResult addRoot(Operation *op);
 
+  LogicalResult run();
+
   void dump() const;
 
 private:

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -298,15 +298,14 @@ void FIRRTLGatedClockConversionPass::runOnOperation() {
   circuit.walk([&](Operation *op) {
     if (isa<firrtl::RegOp, firrtl::RegResetOp, firrtl::RefForceOp,
             firrtl::RefReleaseOp>(op)) {
-      converter.addRoot(op);
+      if (failed(converter.addRoot(op)))
+        return signalPassFailure();
     }
   });
 
   // Run the conversion
-  if (failed(converter.run())) {
-    signalPassFailure();
-    return;
-  }
+  if (failed(converter.run()))
+    return signalPassFailure();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -16,6 +16,7 @@
 #include "circt/Analysis/OpCountAnalysis.h"
 #include "circt/Analysis/SchedulingAnalysis.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/GatedClockConversion.h"
 #include "circt/Dialect/HW/HWInstanceGraph.h"
 #include "circt/Scheduling/Problems.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
@@ -268,6 +269,47 @@ void FIRRTLInstanceInfoPass::runOnOperation() {
 }
 
 //===----------------------------------------------------------------------===//
+// FIRRTL GatedClockConversion
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct FIRRTLGatedClockConversionPass
+    : public PassWrapper<FIRRTLGatedClockConversionPass,
+                         OperationPass<firrtl::CircuitOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FIRRTLGatedClockConversionPass)
+
+  void runOnOperation() override;
+  StringRef getArgument() const override {
+    return "test-firrtl-gated-clock-conversion";
+  }
+  StringRef getDescription() const override {
+    return "Run firrtl::GatedClockConversion utility and show the results.  "
+           "This pass is intended to be used for testing purposes only.";
+  }
+};
+} // namespace
+
+void FIRRTLGatedClockConversionPass::runOnOperation() {
+  auto circuit = getOperation();
+  auto &instanceGraph = getAnalysis<firrtl::InstanceGraph>();
+  firrtl::GatedClockConversion converter(instanceGraph);
+
+  // Collect all register and ref force/release operations
+  circuit.walk([&](Operation *op) {
+    if (isa<firrtl::RegOp, firrtl::RegResetOp, firrtl::RefForceOp,
+            firrtl::RefReleaseOp>(op)) {
+      converter.addRoot(op);
+    }
+  });
+
+  // Run the conversion
+  if (failed(converter.run())) {
+    signalPassFailure();
+    return;
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // Comb IntRange Analysis
 //===----------------------------------------------------------------------===//
 
@@ -351,6 +393,9 @@ void registerAnalysisTestPasses() {
   });
   registerPass([]() -> std::unique_ptr<Pass> {
     return std::make_unique<FIRRTLInstanceInfoPass>();
+  });
+  registerPass([]() -> std::unique_ptr<Pass> {
+    return std::make_unique<FIRRTLGatedClockConversionPass>();
   });
   registerPass([]() -> std::unique_ptr<Pass> {
     return std::make_unique<TestCombIntegerRangeAnalysisPass>();

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -16,6 +16,7 @@
 #include "circt/Analysis/OpCountAnalysis.h"
 #include "circt/Analysis/SchedulingAnalysis.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/GatedClockConversion.h"
 #include "circt/Dialect/HW/HWInstanceGraph.h"
 #include "circt/Scheduling/Problems.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
@@ -268,6 +269,46 @@ void FIRRTLInstanceInfoPass::runOnOperation() {
 }
 
 //===----------------------------------------------------------------------===//
+// FIRRTL GatedClockConversion
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct FIRRTLGatedClockConversionPass
+    : public PassWrapper<FIRRTLGatedClockConversionPass,
+                         OperationPass<firrtl::CircuitOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FIRRTLGatedClockConversionPass)
+
+  void runOnOperation() override;
+  StringRef getArgument() const override {
+    return "test-firrtl-gated-clock-conversion";
+  }
+  StringRef getDescription() const override {
+    return "Run firrtl::GatedClockConversion utility and show the results.  "
+           "This pass is intended to be used for testing purposes only.";
+  }
+};
+} // namespace
+
+void FIRRTLGatedClockConversionPass::runOnOperation() {
+  auto circuit = getOperation();
+  auto &instanceGraph = getAnalysis<firrtl::InstanceGraph>();
+  firrtl::GatedClockConversion converter(instanceGraph);
+
+  // Collect all register and ref force/release operations
+  circuit.walk([&](Operation *op) {
+    if (isa<firrtl::RegOp, firrtl::RegResetOp, firrtl::RefForceOp,
+            firrtl::RefReleaseOp>(op)) {
+      if (failed(converter.addRoot(op)))
+        return signalPassFailure();
+    }
+  });
+
+  // Run the conversion
+  if (failed(converter.run()))
+    return signalPassFailure();
+}
+
+//===----------------------------------------------------------------------===//
 // Comb IntRange Analysis
 //===----------------------------------------------------------------------===//
 
@@ -351,6 +392,9 @@ void registerAnalysisTestPasses() {
   });
   registerPass([]() -> std::unique_ptr<Pass> {
     return std::make_unique<FIRRTLInstanceInfoPass>();
+  });
+  registerPass([]() -> std::unique_ptr<Pass> {
+    return std::make_unique<FIRRTLGatedClockConversionPass>();
   });
   registerPass([]() -> std::unique_ptr<Pass> {
     return std::make_unique<TestCombIntegerRangeAnalysisPass>();

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CIRCT_FIRRTL_Sources
   FIRRTLOps.cpp
   FIRRTLTypes.cpp
   FIRRTLUtils.cpp
+  GatedClockConversion.cpp
   NLATable.cpp
 )
 

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -1,0 +1,768 @@
+//===- GatedClockConversion.cpp - Gated clock conversion -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the GatedClockConversion utility class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/GatedClockConversion.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Value.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
+#include <deque>
+
+#define DEBUG_TYPE "firrtl-gated-clock-conversion"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+
+/// Internal enum to specify which ports to insert in insertOrReusePort.
+enum class PortInsertMode {
+  Both,      ///< Insert both base clock and enable ports
+  ClockOnly, ///< Insert only the base clock port
+  EnableOnly ///< Insert only the enable port
+};
+
+/// Compute the gate's effective enable as `enable | test_enable` (or just
+/// `enable`), materialising the OR after the gate op.
+static Value materializeGateEnable(ClockGateIntrinsicOp gate) {
+  if (!gate.getTestEnable())
+    return gate.getEnable();
+  ImplicitLocOpBuilder b(gate.getLoc(), gate);
+  b.setInsertionPointAfter(gate);
+  return b.createOrFold<OrPrimOp>(gate.getEnable(), gate.getTestEnable());
+}
+
+/// Build the (baseClock, gateEnable) PortInfo pair for the given direction.
+static std::pair<PortInfo, PortInfo>
+makeGatedClockPortInfos(MLIRContext *ctx, StringRef tag, Direction dir,
+                        Location loc, Type clockType, Type u1Type) {
+  return {PortInfo(StringAttr::get(ctx, ("_gatedClock_baseClock_" + tag).str()),
+                   clockType, dir, /*symName=*/StringAttr(), loc),
+          PortInfo(StringAttr::get(ctx, ("_gatedClock_enable_" + tag).str()),
+                   u1Type, dir, /*symName=*/StringAttr(), loc)};
+}
+
+/// Materialize a 1-bit constant 1 at `b`'s insertion point.
+static Value constU1One(ImplicitLocOpBuilder &b) {
+  return b.createOrFold<ConstantOp>(
+      APSInt(APInt(1, 1, /*isSigned=*/false), /*isUnsigned=*/true));
+}
+
+/// Return the clock operand of a registered root op, or null for ops that
+/// have no clock (RefForceInitialOp / RefReleaseInitialOp).
+static Value clockOperandOf(Operation *op) {
+  if (auto fop = dyn_cast<RefForceOp>(op))
+    return fop.getClock();
+  if (auto rop = dyn_cast<RefReleaseOp>(op))
+    return rop.getClock();
+  if (auto reg = dyn_cast<RegOp>(op))
+    return reg.getClockVal();
+  if (auto regr = dyn_cast<RegResetOp>(op))
+    return regr.getClockVal();
+  if (auto gc = dyn_cast<ClockGateIntrinsicOp>(op))
+    return gc.getInput();
+  return Value();
+}
+
+/// Result of scanning existing ports for a (clock, enable) pair match.
+struct ExistingPortMatch {
+  bool foundClk = false, foundEn = false;
+  unsigned clkIndex = 0, enIndex = 0;
+};
+
+/// Check if existing ports already match the materialized clock or enable
+/// values. Used for both output port reuse (checking module port arguments) and
+/// input port reuse (checking instance port results).
+static ExistingPortMatch checkExistingPorts(
+    unsigned numPorts, llvm::function_ref<Value(unsigned)> getPortValue,
+    Value materializedClk, Value materializedEn, Type clockType, Type u1Type) {
+  ExistingPortMatch result;
+  for (unsigned i = 0; i < numPorts; ++i) {
+    auto portValue = getPortValue(i);
+    if (!portValue)
+      continue;
+    if (portValue.getType() != clockType && portValue.getType() != u1Type)
+      continue;
+    if (auto driver = getDriverFromConnect(portValue)) {
+      if (materializedEn && driver == materializedEn) {
+        result.foundEn = true;
+        result.enIndex = i;
+      }
+      if (driver == materializedClk) {
+        result.foundClk = true;
+        result.clkIndex = i;
+      }
+    }
+    if (result.foundClk && (!materializedEn || result.foundEn))
+      break;
+  }
+  return result;
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: gate-enable cache + lazy port-pair insertion
+//===----------------------------------------------------------------------===//
+
+Value GatedClockConversion::gateEnableOf(ClockGateIntrinsicOp gate) {
+  auto it = gateEnableCache.find(gate);
+  if (it != gateEnableCache.end())
+    return it->second;
+  Value v = materializeGateEnable(gate);
+  gateEnableCache[gate] = v;
+  return v;
+}
+
+void GatedClockConversion::connectMaterializedToInstancePorts(
+    InstanceOp inst, unsigned clkPortIndex, unsigned enPortIndex,
+    Value materializedClk, Value materializedEn, Location loc,
+    bool checkUseEmpty) {
+  ImplicitLocOpBuilder builder(loc, context);
+  // To ensure the materializedClk dominates the connect, create it at the end
+  // of the block containing instance.
+  builder.setInsertionPointToEnd(inst->getBlock());
+
+  auto clkPort = inst->getResult(clkPortIndex);
+  if (!checkUseEmpty || clkPort.use_empty())
+    MatchingConnectOp::create(builder, clkPort, materializedClk);
+
+  if (materializedEn) {
+    auto enPort = inst->getResult(enPortIndex);
+    if (!checkUseEmpty || enPort.use_empty())
+      MatchingConnectOp::create(builder, enPort, materializedEn);
+  }
+}
+
+GatedClockConversion::PortPair GatedClockConversion::insertOrReusePort(
+    FModuleOp mod, StringRef tag, Direction dir,
+    std::optional<unsigned> existingClockIdx,
+    std::optional<unsigned> existingEnableIdx) {
+  unsigned baseIdx;
+  unsigned enableIdx;
+
+  // Infer the mode based on which optional indices are provided
+  PortInsertMode mode;
+  if (existingClockIdx.has_value() && existingEnableIdx.has_value()) {
+    // Both indices provided: reuse both, no insertion needed
+    baseIdx = *existingClockIdx;
+    enableIdx = *existingEnableIdx;
+    return {baseIdx, enableIdx};
+  }
+  if (existingClockIdx.has_value()) {
+    // Only clock index provided: reuse clock, insert enable only
+    mode = PortInsertMode::EnableOnly;
+    baseIdx = *existingClockIdx;
+  } else if (existingEnableIdx.has_value()) {
+    // Only enable index provided: reuse enable, insert clock only
+    mode = PortInsertMode::ClockOnly;
+    enableIdx = *existingEnableIdx;
+  } else {
+    // Neither provided: insert both
+    mode = PortInsertMode::Both;
+  }
+
+  auto [baseInfo, enableInfo] = makeGatedClockPortInfos(
+      mod.getContext(), tag, dir, mod.getLoc(), clockType, u1Type);
+
+  SmallVector<std::pair<unsigned, PortInfo>> newPorts;
+  switch (mode) {
+  case PortInsertMode::EnableOnly:
+    // Only insert the enable port
+    enableIdx = mod.getNumPorts();
+    mod.insertPorts({{enableIdx, enableInfo}});
+    newPorts.push_back({enableIdx, enableInfo});
+    break;
+  case PortInsertMode::ClockOnly:
+    // Only insert the base clock port
+    baseIdx = mod.getNumPorts();
+    mod.insertPorts({{baseIdx, baseInfo}});
+    newPorts.push_back({baseIdx, baseInfo});
+    break;
+  case PortInsertMode::Both:
+    // Insert both base and enable ports
+    baseIdx = mod.getNumPorts();
+    enableIdx = baseIdx + 1;
+    mod.insertPorts({{baseIdx, baseInfo}, {baseIdx, enableInfo}});
+    newPorts.push_back({baseIdx, baseInfo});
+    newPorts.push_back({enableIdx, enableInfo});
+    break;
+  }
+
+  auto *node = ig.lookup(mod);
+  SmallVector<InstanceOp> oldInsts;
+  for (auto *use : node->uses())
+    if (auto i = dyn_cast<InstanceOp>(*use->getInstance()))
+      oldInsts.push_back(i);
+
+  for (auto oldInst : oldInsts) {
+    auto cloneIface = oldInst.cloneWithInsertedPortsAndReplaceUses(newPorts);
+    auto newInst = cast<InstanceOp>(cloneIface.getOperation());
+    ig.replaceInstance(oldInst, newInst);
+    instReplaceMap[oldInst] = newInst;
+    opReplaceMap[oldInst.getOperation()] = newInst.getOperation();
+    // Record old-result → new-result value mappings before erasing `oldInst`,
+    // so any of its result values cached in the analysis maps can be resolved
+    // to the live instance.  New result index = old index + number of inserted
+    // ports at or before that index (mirrors
+    // replaceUsesRespectingInsertedPorts).
+    for (unsigned i = 0, e = oldInst->getNumResults(); i < e; ++i)
+      valueReplaceMap[oldInst->getResult(i)] = newInst->getResult(i);
+
+    // Defer erasure until all transformations are complete
+    opsToErase.push_back(oldInst);
+  }
+  return {baseIdx, enableIdx};
+}
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: worklist analysis (no IR mutation)
+//===----------------------------------------------------------------------===//
+
+void GatedClockConversion::clearAnalysis() {
+  visited.clear();
+  srcToDstClocks.clear();
+  baseClks.clear();
+  modArgToMaterialized.clear();
+  wireOps.clear();
+}
+
+void GatedClockConversion::analyzeFrom(ArrayRef<Value> seeds) {
+  clearAnalysis();
+  SmallVector<Value> worklist(seeds.begin(), seeds.end());
+
+  // Helper to record the clock flow relationship and push to worklist.
+  // Looks through wire/node/cast aliases to find the actual driver, then
+  // records both the direct and transitive relationships in srcToDstClocks.
+  // `srcClk` is an operand of `op` and `dstClk` is the result of it.
+  auto pushIfFresh = [&](Value dstClk, Value srcClk, Operation *op,
+                         EdgeKind kind) {
+    if (!dstClk || !srcClk)
+      return;
+    // Record the `op` through which srcClk drives `dstClk`. This map will be
+    // used to backtrack the traversal from base clock to users.
+    srcToDstClocks[srcClk].push_back({dstClk, op, kind});
+    Value baseClkDriver =
+        getModuleScopedDriver(srcClk, /*lookThroughWires=*/true,
+                              /*lookThroughNodes=*/true,
+                              /*lookThroughCasts=*/true);
+    if (baseClkDriver) {
+      // `baseClkDriver` drives `srcClk`, through wires/nodes/casts. No op
+      // needed.
+      srcToDstClocks[baseClkDriver].push_back(
+          {srcClk, nullptr, EdgeKind::Alias});
+    } else
+      baseClkDriver = srcClk;
+    // Only add to worklist if not already visited.
+    if (!visited.insert(baseClkDriver).second)
+      return;
+    worklist.push_back(baseClkDriver);
+  };
+
+  // This is a (backward) DFS traversal from leaf clock values to the base clock
+  // that drives them.
+  while (!worklist.empty()) {
+    Value clk = worklist.pop_back_val();
+    // Case 1: clk is an input-port BlockArg (fan out to every caller).
+    if (auto blockArg = dyn_cast<BlockArgument>(clk)) {
+      auto mod = dyn_cast<FModuleOp>(blockArg.getOwner()->getParentOp());
+      assert(mod &&
+             mod.getPortDirection(blockArg.getArgNumber()) == Direction::In &&
+             "expected input port of an FModuleOp");
+      unsigned portIdx = blockArg.getArgNumber();
+      auto *node = ig.lookup(mod);
+      for (auto *use : node->uses()) {
+        // Can only handle InstanceOp.
+        if (auto callerInst = dyn_cast<InstanceOp>(*use->getInstance())) {
+          // The input-port "operand" at a caller InstanceOp is exposed as
+          // the corresponding SSA result (drivable via firrtl.connect).
+          // `getModuleScopedDriver` follows the connect chain to find the
+          // driving value in the caller's module.
+          pushIfFresh(clk, callerInst.getResult(portIdx), callerInst,
+                      EdgeKind::InstanceIn);
+        }
+      }
+      // If top level module, then we have reached the base clock, nothing else
+      // to traverse from here.
+      if (node->uses().empty())
+        baseClks.push_back(clk);
+      continue;
+    }
+    auto *defOp = clk.getDefiningOp();
+
+    // Case 2: clk is the result of a clock gate.
+    if (isa_and_nonnull<ClockGateIntrinsicOp>(defOp)) {
+      pushIfFresh(clk, clockOperandOf(defOp), defOp, EdgeKind::Gate);
+      continue;
+    }
+
+    // Case 3: clk is an instance result (descend into the referenced module).
+    if (auto inst = dyn_cast_or_null<InstanceOp>(defOp)) {
+      auto refMod = inst.getReferencedModule(ig);
+      auto childMod = dyn_cast_or_null<FModuleOp>(refMod.getOperation());
+      if (!childMod) {
+        // external module: treat as base
+        baseClks.push_back(clk);
+        continue;
+      }
+      auto *childBody = childMod.getBodyBlock();
+      unsigned portIdx = cast<OpResult>(clk).getResultNumber();
+      pushIfFresh(clk, childBody->getArgument(portIdx), inst,
+                  EdgeKind::InstanceOut);
+      continue;
+    }
+
+    // Case 4: clk flows through a wire/node/cast alias (e.g. a register
+    // clocked by a wire that is connected to a gated clock).  Look through the
+    // alias to the real driver and record the alias relationship so the
+    // forward pass materializes the (base, enable) pair onto `clk`.
+    if (Value driver = getModuleScopedDriver(clk, /*lookThroughWires=*/true,
+                                             /*lookThroughNodes=*/true,
+                                             /*lookThroughCasts=*/true)) {
+      if (driver != clk) {
+        srcToDstClocks[driver].push_back({clk, nullptr, EdgeKind::Alias});
+        if (visited.insert(driver).second)
+          worklist.push_back(driver);
+        continue;
+      }
+    }
+
+    // Base case: clk is a base clock (no further source to trace).
+    baseClks.push_back(clk);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: rewriteRoot, run
+//===----------------------------------------------------------------------===//
+
+LogicalResult GatedClockConversion::rewriteRoot(Operation *op, Value base,
+                                                Value enable) {
+  if (!enable)
+    return success();
+  if (auto fop = dyn_cast<RefForceOp>(op)) {
+    fop.getClockMutable().assign(base);
+    ImplicitLocOpBuilder b(fop.getLoc(), fop);
+    Value newPred = b.createOrFold<AndPrimOp>(fop.getPredicate(), enable);
+    fop.getPredicateMutable().assign(newPred);
+    return success();
+  }
+
+  if (auto rop = dyn_cast<RefReleaseOp>(op)) {
+    rop.getClockMutable().assign(base);
+    ImplicitLocOpBuilder b(rop.getLoc(), rop);
+    Value newPred = b.createOrFold<AndPrimOp>(rop.getPredicate(), enable);
+    rop.getPredicateMutable().assign(newPred);
+    return success();
+  }
+
+  if (isa<RefForceInitialOp, RefReleaseInitialOp>(op))
+    return success();
+
+  Value regData;
+  if (auto reg = dyn_cast<RegOp>(op))
+    regData = reg.getData();
+  else if (auto regr = dyn_cast<RegResetOp>(op))
+    regData = regr.getData();
+  else
+    return success();
+
+  // Rebind the register clock to the ungated base.
+  op->setOperand(0, base);
+
+  // Wrap the unique connect driving regData with mux(enable, RHS, regData)
+  // so the register holds when the clock gate is closed.
+  for (auto &use : llvm::make_early_inc_range(regData.getUses())) {
+    auto fconn = dyn_cast<FConnectLike>(use.getOwner());
+    if (!fconn || fconn.getDest() != regData)
+      continue;
+    ImplicitLocOpBuilder b(fconn.getLoc(), fconn);
+    Value newRhs = b.createOrFold<MuxPrimOp>(enable, fconn.getSrc(), regData);
+    fconn->setOperand(1, newRhs);
+    break;
+  }
+  return success();
+}
+
+void GatedClockConversion::materializeAlias(Value dstClk, FModuleOp srcMod,
+                                            Value materializedClk,
+                                            Value materializedEn) {
+  auto liveDst = liveValue(dstClk);
+  // Create temporary wires at the top of srcMod to carry (base, enable).
+  // eliminateTemporaryWires() will forward them away when safe.
+  auto builder = ImplicitLocOpBuilder::atBlockBegin(liveDst.getLoc(),
+                                                    srcMod.getBodyBlock());
+  auto createWire = [&](Type type) {
+    auto w = WireOp::create(builder, type);
+    wireOps.push_back(w);
+    return w.getData();
+  };
+  auto clockWire = createWire(clockType);
+  auto enWire = createWire(u1Type);
+  if (!isa<BlockArgument>(materializedClk))
+    builder.setInsertionPointAfterValue(materializedClk);
+  MatchingConnectOp::create(builder, clockWire, materializedClk);
+  if (materializedEn && !isa<BlockArgument>(materializedEn))
+    builder.setInsertionPointAfterValue(materializedEn);
+  MatchingConnectOp::create(
+      builder, enWire, materializedEn ? materializedEn : constU1One(builder));
+  materialized[dstClk] = {clockWire, enWire};
+}
+
+void GatedClockConversion::materializeGate(ClockGateIntrinsicOp gate,
+                                           Value dstClk, Value materializedClk,
+                                           Value materializedEn) {
+  auto gateEn = gateEnableOf(gate);
+  if (materializedEn) {
+    // AND upstream enable with this gate's enable so the register holds
+    // whenever any gate in the chain is closed.
+    ImplicitLocOpBuilder builder(gate.getLoc(), gate);
+    builder.setInsertionPointAfterValue(liveValue(dstClk));
+    gateEn = builder.createOrFold<AndPrimOp>(materializedEn, gateEn);
+  }
+  // Propagate the true ungated base clock through cascaded gates.
+  materialized[dstClk] = {materializedClk, gateEn};
+}
+
+GatedClockConversion::PortPair GatedClockConversion::findOrInsertGatedPorts(
+    InstanceOp &inst, FModuleOp childMod, unsigned gatedClkIndex, Direction dir,
+    Value materializedClk, Value materializedEn) {
+  // Cache hit: ports already inserted for this (module, port) pair.
+  auto modIt = modArgToMaterialized.find({childMod, gatedClkIndex});
+  if (modIt != modArgToMaterialized.end())
+    return {modIt->second.first, modIt->second.second};
+
+  unsigned baseClkIndex = 0, enableIndex = 0;
+  StringRef portName = childMod.getPortName(gatedClkIndex);
+
+  if (dir == Direction::Out) {
+    auto getPortValue = [&](unsigned i) -> Value {
+      if (childMod.getPortDirection(i) != Direction::Out)
+        return Value();
+      return childMod.getBodyBlock()->getArgument(i);
+    };
+    auto match =
+        checkExistingPorts(childMod.getNumPorts(), getPortValue,
+                           materializedClk, materializedEn, clockType, u1Type);
+    if (!match.foundClk || !match.foundEn) {
+      auto [cIdx, eIdx] = insertOrReusePort(
+          childMod, portName, Direction::Out,
+          match.foundClk ? std::optional<unsigned>(match.clkIndex)
+                         : std::nullopt,
+          match.foundEn ? std::optional<unsigned>(match.enIndex)
+                        : std::nullopt);
+      baseClkIndex = cIdx;
+      enableIndex = eIdx;
+      inst = instReplaceMap[inst];
+    } else {
+      baseClkIndex = match.clkIndex;
+      enableIndex = match.enIndex;
+    }
+    auto newClkOut = childMod.getBodyBlock()->getArgument(baseClkIndex);
+    auto enableOut = childMod.getBodyBlock()->getArgument(enableIndex);
+    ImplicitLocOpBuilder builder(childMod.getLoc(), childMod);
+    builder.setInsertionPointToEnd(childMod.getBodyBlock());
+    MatchingConnectOp::create(builder, newClkOut, materializedClk);
+    if (materializedEn)
+      MatchingConnectOp::create(builder, enableOut, materializedEn);
+  } else {
+    auto getPortValue = [&](unsigned i) -> Value { return inst->getResult(i); };
+    auto match =
+        checkExistingPorts(inst->getNumResults(), getPortValue, materializedClk,
+                           materializedEn, clockType, u1Type);
+    if (!match.foundClk || !match.foundEn) {
+      auto [cIdx, eIdx] = insertOrReusePort(
+          childMod, portName, Direction::In,
+          match.foundClk ? std::optional<unsigned>(match.clkIndex)
+                         : std::nullopt,
+          match.foundEn ? std::optional<unsigned>(match.enIndex)
+                        : std::nullopt);
+      baseClkIndex = cIdx;
+      enableIndex = eIdx;
+      inst = instReplaceMap[inst];
+    } else {
+      baseClkIndex = match.clkIndex;
+      enableIndex = match.enIndex;
+    }
+    connectMaterializedToInstancePorts(inst, baseClkIndex, enableIndex,
+                                       materializedClk, materializedEn,
+                                       inst.getLoc());
+  }
+
+  modArgToMaterialized[{childMod, gatedClkIndex}] = {baseClkIndex, enableIndex};
+  return {baseClkIndex, enableIndex};
+}
+
+void GatedClockConversion::materializeInstancePort(
+    Direction dir, InstanceOp inst, Value dstClk, Value liveAnchor,
+    Value materializedClk, Value materializedEn) {
+  auto childMod = dyn_cast_or_null<FModuleOp>(inst.getReferencedModule(ig));
+  auto gatedClkIndex = cast<OpResult>(liveAnchor).getResultNumber();
+  auto [baseClkIndex, enableIndex] = findOrInsertGatedPorts(
+      inst, childMod, gatedClkIndex, dir, materializedClk, materializedEn);
+  if (dir == Direction::Out)
+    materialized[dstClk] = {inst.getResult(baseClkIndex),
+                            inst.getResult(enableIndex)};
+  else
+    materialized[dstClk] = {childMod.getBodyBlock()->getArgument(baseClkIndex),
+                            childMod.getBodyBlock()->getArgument(enableIndex)};
+}
+
+void GatedClockConversion::reinitMultiplyInstantiatedInput(
+    Value liveSrc, Value materializedClk, Value materializedEn) {
+  // liveSrc is a result of the live caller instance; drive the already-inserted
+  // gated ports for the second (or later) caller of this module.
+  auto inst = dyn_cast_or_null<InstanceOp>(liveSrc.getDefiningOp());
+  if (!inst)
+    return;
+  auto childMod = dyn_cast_or_null<FModuleOp>(inst.getReferencedModule(ig));
+  auto gatedClkIndex = cast<OpResult>(liveSrc).getResultNumber();
+  auto modIt = modArgToMaterialized.find({childMod, gatedClkIndex});
+  assert(modIt != modArgToMaterialized.end());
+  auto [newClkIndex, newEnIndex] = modIt->second;
+  connectMaterializedToInstancePorts(inst, newClkIndex, newEnIndex,
+                                     materializedClk, materializedEn,
+                                     liveSrc.getLoc(), /*checkUseEmpty=*/true);
+}
+
+void GatedClockConversion::materialize() {
+  // Forward pass: propagate (base, enable) pairs from base clocks through the
+  // clock flow graph built by analyzeFrom(), inserting ports as needed.
+  std::deque<Value> worklist(baseClks.begin(), baseClks.end());
+  for (auto base : baseClks)
+    materialized[base] = {base, {}};
+
+  while (!worklist.empty()) {
+    auto srcClk = worklist.front();
+    worklist.pop_front();
+    // Resolve to the live SSA value — a prior port insertion may have replaced
+    // the defining instance.
+    auto liveSrc = liveValue(srcClk);
+    FModuleOp srcMod;
+    if (auto blockArg = dyn_cast<BlockArgument>(liveSrc))
+      srcMod = cast<FModuleOp>(liveSrc.getParentBlock()->getParentOp());
+    else if (auto *def = liveSrc.getDefiningOp())
+      srcMod = def->getParentOfType<FModuleOp>();
+
+    auto it = materialized.find(srcClk);
+    if (it == materialized.end()) {
+      // Not yet materialized; re-queue until its upstream is done.
+      worklist.push_back(srcClk);
+      continue;
+    }
+    auto materializedClk = liveValue(it->second.first);
+    auto materializedEn = liveValue(it->second.second);
+
+    for (auto &edge : srcToDstClocks[srcClk]) {
+      liveSrc = liveValue(srcClk);
+      if (materialized.count(edge.dst)) {
+        // dst already done — for InstanceIn this means a multiply-instantiated
+        // module whose ports were inserted by an earlier caller; re-init them.
+        if (edge.kind == EdgeKind::InstanceIn)
+          reinitMultiplyInstantiatedInput(liveSrc, materializedClk,
+                                          materializedEn);
+        continue;
+      }
+      worklist.push_back(edge.dst);
+      switch (edge.kind) {
+      case EdgeKind::Alias:
+        materializeAlias(edge.dst, srcMod, materializedClk, materializedEn);
+        break;
+      case EdgeKind::Gate:
+        materializeGate(cast<ClockGateIntrinsicOp>(edge.op), edge.dst,
+                        materializedClk, materializedEn);
+        break;
+      case EdgeKind::InstanceIn: {
+        auto inst = cast<InstanceOp>(liveOp(edge.op));
+        materializeInstancePort(Direction::In, inst, edge.dst, liveSrc,
+                                materializedClk, materializedEn);
+        break;
+      }
+      case EdgeKind::InstanceOut: {
+        auto liveDst = liveValue(edge.dst);
+        auto inst = cast<InstanceOp>(liveOp(edge.op));
+        materializeInstancePort(Direction::Out, inst, edge.dst, liveDst,
+                                materializedClk, materializedEn);
+        break;
+      }
+      }
+    }
+  }
+}
+
+std::pair<SmallVector<Value>, SmallVector<std::pair<Operation *, Value>>>
+GatedClockConversion::collectSeeds() {
+  // Take ownership of the pending roots — `collectSeeds()` consumes them so
+  // the caller's `addRoot` queue is empty afterwards (a subsequent visit can
+  // collect a fresh batch without reprocessing — and without dereferencing
+  // ops that may have been erased between visits).
+  SmallVector<Operation *> pending;
+  pending.swap(roots);
+
+  // Collect each root's clock operand as a seed.
+  // Remember the (op, original-clock) pairing: `materialized` is keyed by the
+  // original analysis-era clock value, but the op's live clock operand may be
+  // remapped to a replacement instance result before the rewrite runs.
+  SmallVector<Value> seeds;
+  SmallVector<std::pair<Operation *, Value>> rootClocks;
+  seeds.reserve(pending.size());
+  for (Operation *op : pending)
+    if (Value clk = clockOperandOf(op)) {
+      seeds.push_back(clk);
+      rootClocks.push_back({op, clk});
+    }
+
+  return {seeds, rootClocks};
+}
+
+void GatedClockConversion::eliminateTemporaryWires() {
+  // Eliminate temporary wires created during materialization by forwarding
+  // their values directly. For each wire, check if there are exactly two uses:
+  // one connect writing to the wire and one connect reading from it. If the
+  // write dominates the read, bypass the wire by replacing all uses of the wire
+  // with the write source, then erase the wire and write connect.
+  DenseMap<FModuleOp, mlir::DominanceInfo> dominanceInfo;
+  for (auto wire : wireOps) {
+    auto wireData = wire.getData();
+    FModuleOp mod = wire->getParentOfType<FModuleOp>();
+    auto domIter = dominanceInfo.find(mod);
+    if (domIter == dominanceInfo.end()) {
+      dominanceInfo[mod] = mlir::DominanceInfo(mod);
+    }
+    auto &modDomInfo = dominanceInfo[mod];
+
+    // Find all connect operations using this wire.
+    FConnectLike writeConnect = {}; // Connect writing to wire (wire is dest)
+    FConnectLike readConnect = {};  // Connect reading from wire (wire is src)
+
+    for (auto *user : wireData.getUsers()) {
+      if (auto connect = dyn_cast<FConnectLike>(user)) {
+        if (connect.getDest() == wireData) {
+          // Found a write to the wire. If we already have one, bail out.
+          if (writeConnect) {
+            writeConnect = {};
+            break;
+          }
+          writeConnect = connect;
+        } else if (connect.getSrc() == wireData) {
+          // Found a read from the wire. If we already have one, bail out.
+          if (readConnect) {
+            readConnect = {};
+            break;
+          }
+          readConnect = connect;
+        }
+      } else
+        // Wire has a non-connect user; can't optimize.
+        break;
+    }
+    // Skip wires that don't have exactly one write and one read.
+    if (!readConnect || !writeConnect)
+      continue;
+
+    // Optimize: bypass the wire if the write dominates the read.
+    // Replace all uses of the wire with the write source.
+    Value writeSource = writeConnect.getSrc();
+    if (modDomInfo.dominates(writeConnect, readConnect)) {
+      wireData.replaceAllUsesWith(writeSource);
+      // Erase the write connect and the wire itself. The read connect is
+      // implicitly removed by replaceAllUsesWith updating its source operand.
+      writeConnect.erase();
+      wire.erase();
+    }
+  }
+}
+
+LogicalResult GatedClockConversion::run() {
+  // Collect clock operands from pending roots.
+  auto [seeds, rootClocks] = collectSeeds();
+
+  if (seeds.empty())
+    return success();
+  context = seeds[0].getContext();
+  clockType = ClockType::get(context);
+  u1Type = UIntType::get(context, 1);
+
+  // Phase 1: pure analysis.
+  analyzeFrom(seeds);
+  LLVM_DEBUG(dump());
+  // Phase 2: per-root materialisation + IR rewrite.
+  materialize();
+  for (auto &[op, clk] : rootClocks) {
+    assert(materialized.find(clk) != materialized.end());
+    // Resolve to live values: the materialized (base, enable) pair may have
+    // been instance results that were since replaced by port insertion.
+    auto materializedClk = liveValue(materialized[clk].first);
+    auto materializedEn = liveValue(materialized[clk].second);
+    if (failed(rewriteRoot(op, materializedClk, materializedEn)))
+      return failure();
+  }
+  // Eliminate temporary wires created during materialization.
+  eliminateTemporaryWires();
+
+  // Phase 3: erase all replaced instances now that transformations are
+  // complete.
+  for (auto oldInst : opsToErase)
+    oldInst.erase();
+  opsToErase.clear();
+
+  return success();
+}
+
+void GatedClockConversion::dump() const {
+  llvm::dbgs() << "=== srcToDstClocks ===\n";
+  for (const auto &[srcClk, dstList] : srcToDstClocks) {
+    llvm::dbgs() << "Source clock: ";
+    srcClk.print(llvm::dbgs());
+    llvm::dbgs() << "\n";
+    for (const auto &edge : dstList) {
+      llvm::dbgs() << "  -> Destination clock: ";
+      edge.dst.print(llvm::dbgs());
+      llvm::dbgs() << " via op: ";
+      if (edge.op)
+        edge.op->print(llvm::dbgs());
+      else
+        llvm::dbgs() << "<alias>";
+      llvm::dbgs() << " [";
+      switch (edge.kind) {
+      case EdgeKind::Alias:
+        llvm::dbgs() << "Alias";
+        break;
+      case EdgeKind::Gate:
+        llvm::dbgs() << "Gate";
+        break;
+      case EdgeKind::InstanceIn:
+        llvm::dbgs() << "InstanceIn";
+        break;
+      case EdgeKind::InstanceOut:
+        llvm::dbgs() << "InstanceOut";
+        break;
+      }
+      llvm::dbgs() << "]\n";
+    }
+  }
+  llvm::dbgs() << "=== Base clocks ===\n";
+  for (const auto &baseClk : baseClks) {
+    llvm::dbgs() << "  ";
+    baseClk.print(llvm::dbgs());
+    llvm::dbgs() << "\n";
+  }
+  llvm::dbgs() << "======================\n";
+}

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/FIRRTL/GatedClockConversion.h"
+#include "circt/Dialect/FIRRTL/FIRRTLEnums.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
@@ -18,10 +19,9 @@
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Dominance.h"
-#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Value.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 #include <deque>
 
@@ -32,25 +32,31 @@ using namespace firrtl;
 
 namespace {
 
-/// Internal enum to specify which ports to insert in insertOrReusePort.
-enum class PortInsertMode {
-  Both,      ///< Insert both base clock and enable ports
-  ClockOnly, ///< Insert only the base clock port
-  EnableOnly ///< Insert only the enable port
-};
+StringRef edgeKindName(EdgeKind kind) {
+  switch (kind) {
+  case EdgeKind::Alias:
+    return "Alias";
+  case EdgeKind::Gate:
+    return "Gate";
+  case EdgeKind::InstanceIn:
+    return "InstanceIn";
+  case EdgeKind::InstanceOut:
+    return "InstanceOut";
+  }
+  return "?";
+}
 
 /// Compute the gate's effective enable as `enable | test_enable` (or just
 /// `enable`), materialising the OR after the gate op.
-static Value materializeGateEnable(ClockGateIntrinsicOp gate) {
+Value materializeGateEnable(ClockGateIntrinsicOp gate) {
   if (!gate.getTestEnable())
     return gate.getEnable();
   ImplicitLocOpBuilder b(gate.getLoc(), gate);
-  b.setInsertionPointAfter(gate);
   return b.createOrFold<OrPrimOp>(gate.getEnable(), gate.getTestEnable());
 }
 
 /// Build the (baseClock, gateEnable) PortInfo pair for the given direction.
-static std::pair<PortInfo, PortInfo>
+std::pair<PortInfo, PortInfo>
 makeGatedClockPortInfos(MLIRContext *ctx, StringRef tag, Direction dir,
                         Location loc, Type clockType, Type u1Type) {
   return {PortInfo(StringAttr::get(ctx, ("_gatedClock_baseClock_" + tag).str()),
@@ -59,15 +65,17 @@ makeGatedClockPortInfos(MLIRContext *ctx, StringRef tag, Direction dir,
                    u1Type, dir, /*symName=*/StringAttr(), loc)};
 }
 
-/// Materialize a 1-bit constant 1 at `b`'s insertion point.
-static Value constU1One(ImplicitLocOpBuilder &b) {
-  return b.createOrFold<ConstantOp>(
-      APSInt(APInt(1, 1, /*isSigned=*/false), /*isUnsigned=*/true));
+/// Return the parent FModuleOp of a given value: for a BlockArgument the module
+/// owning its block, otherwise the module containing its defining op.
+FModuleOp getParentModule(Value value) {
+  if (isa<BlockArgument>(value))
+    return cast<FModuleOp>(value.getParentBlock()->getParentOp());
+  return value.getDefiningOp()->getParentOfType<FModuleOp>();
 }
 
 /// Return the clock operand of a registered root op, or null for ops that
 /// have no clock (RefForceInitialOp / RefReleaseInitialOp).
-static Value clockOperandOf(Operation *op) {
+Value clockOperandOf(Operation *op) {
   if (auto fop = dyn_cast<RefForceOp>(op))
     return fop.getClock();
   if (auto rop = dyn_cast<RefReleaseOp>(op))
@@ -78,42 +86,8 @@ static Value clockOperandOf(Operation *op) {
     return regr.getClockVal();
   if (auto gc = dyn_cast<ClockGateIntrinsicOp>(op))
     return gc.getInput();
+  op->emitError("unsupported operation in gated clock conversion");
   return Value();
-}
-
-/// Result of scanning existing ports for a (clock, enable) pair match.
-struct ExistingPortMatch {
-  bool foundClk = false, foundEn = false;
-  unsigned clkIndex = 0, enIndex = 0;
-};
-
-/// Check if existing ports already match the materialized clock or enable
-/// values. Used for both output port reuse (checking module port arguments) and
-/// input port reuse (checking instance port results).
-static ExistingPortMatch checkExistingPorts(
-    unsigned numPorts, llvm::function_ref<Value(unsigned)> getPortValue,
-    Value materializedClk, Value materializedEn, Type clockType, Type u1Type) {
-  ExistingPortMatch result;
-  for (unsigned i = 0; i < numPorts; ++i) {
-    auto portValue = getPortValue(i);
-    if (!portValue)
-      continue;
-    if (portValue.getType() != clockType && portValue.getType() != u1Type)
-      continue;
-    if (auto driver = getDriverFromConnect(portValue)) {
-      if (materializedEn && driver == materializedEn) {
-        result.foundEn = true;
-        result.enIndex = i;
-      }
-      if (driver == materializedClk) {
-        result.foundClk = true;
-        result.clkIndex = i;
-      }
-    }
-    if (result.foundClk && (!materializedEn || result.foundEn))
-      break;
-  }
-  return result;
 }
 
 } // namespace
@@ -131,80 +105,55 @@ Value GatedClockConversion::gateEnableOf(ClockGateIntrinsicOp gate) {
   return v;
 }
 
+Value GatedClockConversion::getOrCreateConstU1One(FModuleOp mod) {
+  auto it = constU1Cache.find(mod);
+  if (it != constU1Cache.end())
+    return it->second;
+
+  // Create the constant at the beginning of the module body so it dominates
+  // every possible use.
+  ImplicitLocOpBuilder builder(mod.getLoc(), context);
+  builder.setInsertionPointToStart(mod.getBodyBlock());
+  Value constOne = builder.createOrFold<ConstantOp>(
+      APSInt(APInt(1, 1, /*isSigned=*/false), /*isUnsigned=*/true));
+  constU1Cache[mod] = constOne;
+  return constOne;
+}
+
 void GatedClockConversion::connectMaterializedToInstancePorts(
     InstanceOp inst, unsigned clkPortIndex, unsigned enPortIndex,
     Value materializedClk, Value materializedEn, Location loc,
     bool checkUseEmpty) {
   ImplicitLocOpBuilder builder(loc, context);
-  // To ensure the materializedClk dominates the connect, create it at the end
-  // of the block containing instance.
+  // Insert at the end of the instance's block so the materialized clock
+  // dominates the connect.
   builder.setInsertionPointToEnd(inst->getBlock());
 
   auto clkPort = inst->getResult(clkPortIndex);
   if (!checkUseEmpty || clkPort.use_empty())
     MatchingConnectOp::create(builder, clkPort, materializedClk);
 
-  if (materializedEn) {
-    auto enPort = inst->getResult(enPortIndex);
-    if (!checkUseEmpty || enPort.use_empty())
-      MatchingConnectOp::create(builder, enPort, materializedEn);
+  auto enPort = inst->getResult(enPortIndex);
+  if (!checkUseEmpty || enPort.use_empty()) {
+    if (!materializedEn)
+      materializedEn =
+          getOrCreateConstU1One(inst->getParentOfType<FModuleOp>());
+    MatchingConnectOp::create(builder, enPort, materializedEn);
   }
 }
 
-GatedClockConversion::PortPair GatedClockConversion::insertOrReusePort(
-    FModuleOp mod, StringRef tag, Direction dir,
-    std::optional<unsigned> existingClockIdx,
-    std::optional<unsigned> existingEnableIdx) {
-  unsigned baseIdx;
-  unsigned enableIdx;
-
-  // Infer the mode based on which optional indices are provided
-  PortInsertMode mode;
-  if (existingClockIdx.has_value() && existingEnableIdx.has_value()) {
-    // Both indices provided: reuse both, no insertion needed
-    baseIdx = *existingClockIdx;
-    enableIdx = *existingEnableIdx;
-    return {baseIdx, enableIdx};
-  }
-  if (existingClockIdx.has_value()) {
-    // Only clock index provided: reuse clock, insert enable only
-    mode = PortInsertMode::EnableOnly;
-    baseIdx = *existingClockIdx;
-  } else if (existingEnableIdx.has_value()) {
-    // Only enable index provided: reuse enable, insert clock only
-    mode = PortInsertMode::ClockOnly;
-    enableIdx = *existingEnableIdx;
-  } else {
-    // Neither provided: insert both
-    mode = PortInsertMode::Both;
-  }
-
+std::pair<unsigned, unsigned>
+GatedClockConversion::insertPorts(FModuleOp mod, StringRef tag, Direction dir) {
   auto [baseInfo, enableInfo] = makeGatedClockPortInfos(
       mod.getContext(), tag, dir, mod.getLoc(), clockType, u1Type);
 
-  SmallVector<std::pair<unsigned, PortInfo>> newPorts;
-  switch (mode) {
-  case PortInsertMode::EnableOnly:
-    // Only insert the enable port
-    enableIdx = mod.getNumPorts();
-    mod.insertPorts({{enableIdx, enableInfo}});
-    newPorts.push_back({enableIdx, enableInfo});
-    break;
-  case PortInsertMode::ClockOnly:
-    // Only insert the base clock port
-    baseIdx = mod.getNumPorts();
-    mod.insertPorts({{baseIdx, baseInfo}});
-    newPorts.push_back({baseIdx, baseInfo});
-    break;
-  case PortInsertMode::Both:
-    // Insert both base and enable ports
-    baseIdx = mod.getNumPorts();
-    enableIdx = baseIdx + 1;
-    mod.insertPorts({{baseIdx, baseInfo}, {baseIdx, enableInfo}});
-    newPorts.push_back({baseIdx, baseInfo});
-    newPorts.push_back({enableIdx, enableInfo});
-    break;
-  }
+  // Append a fresh (base clock, enable) port pair at the end of the module
+  // signature.
+  unsigned baseIdx = mod.getNumPorts();
+  unsigned enableIdx = baseIdx + 1;
+  SmallVector<std::pair<unsigned, PortInfo>> newPorts = {{baseIdx, baseInfo},
+                                                         {baseIdx, enableInfo}};
+  mod.insertPorts(newPorts);
 
   auto *node = ig.lookup(mod);
   SmallVector<InstanceOp> oldInsts;
@@ -216,17 +165,15 @@ GatedClockConversion::PortPair GatedClockConversion::insertOrReusePort(
     auto cloneIface = oldInst.cloneWithInsertedPortsAndReplaceUses(newPorts);
     auto newInst = cast<InstanceOp>(cloneIface.getOperation());
     ig.replaceInstance(oldInst, newInst);
-    instReplaceMap[oldInst] = newInst;
-    opReplaceMap[oldInst.getOperation()] = newInst.getOperation();
+    opReplaceMap[oldInst] = newInst;
     // Record old-result → new-result value mappings before erasing `oldInst`,
     // so any of its result values cached in the analysis maps can be resolved
-    // to the live instance.  New result index = old index + number of inserted
-    // ports at or before that index (mirrors
-    // replaceUsesRespectingInsertedPorts).
+    // to the live instance. New result index = old index + number of inserted
+    // ports at or before that index.
     for (unsigned i = 0, e = oldInst->getNumResults(); i < e; ++i)
       valueReplaceMap[oldInst->getResult(i)] = newInst->getResult(i);
 
-    // Defer erasure until all transformations are complete
+    // Defer erasure until all transformations are complete.
     opsToErase.push_back(oldInst);
   }
   return {baseIdx, enableIdx};
@@ -236,48 +183,56 @@ GatedClockConversion::PortPair GatedClockConversion::insertOrReusePort(
 // GatedClockConversion: worklist analysis (no IR mutation)
 //===----------------------------------------------------------------------===//
 
-void GatedClockConversion::clearAnalysis() {
-  visited.clear();
-  srcToDstClocks.clear();
-  baseClks.clear();
-  modArgToMaterialized.clear();
-  wireOps.clear();
+LogicalResult GatedClockConversion::addRoot(Operation *op) {
+  // Single-use: roots must not be added after the conversion has run. Create a
+  // new instance for a fresh set of roots rather than reusing this one.
+  assert(!hasRun && "GatedClockConversion::addRoot() called after run(); "
+                    "create a new instance for a fresh set of roots");
+
+  if (!isa<RefForceOp, RefReleaseOp, RefForceInitialOp, RefReleaseInitialOp,
+           RegOp, RegResetOp>(op))
+    return op->emitError("unsupported operation type for gated clock "
+                         "conversion; expected RefForceOp, RefReleaseOp, "
+                         "RefForceInitialOp, RefReleaseInitialOp, RegOp, or "
+                         "RegResetOp");
+
+  roots.push_back(op);
+  return success();
 }
 
 void GatedClockConversion::analyzeFrom(ArrayRef<Value> seeds) {
-  clearAnalysis();
+  LLVM_DEBUG(llvm::dbgs() << "[analyzeFrom] " << seeds.size() << " seeds\n");
   SmallVector<Value> worklist(seeds.begin(), seeds.end());
 
-  // Helper to record the clock flow relationship and push to worklist.
-  // Looks through wire/node/cast aliases to find the actual driver, then
-  // records both the direct and transitive relationships in srcToDstClocks.
-  // `srcClk` is an operand of `op` and `dstClk` is the result of it.
+  // Record the clock-flow relationship and push to the worklist. Looks through
+  // wire/node/cast aliases to find the actual driver, recording both the direct
+  // and transitive relationships in srcToDstClocks. `srcClk` is an operand of
+  // `op` and `dstClk` is its result.
   auto pushIfFresh = [&](Value dstClk, Value srcClk, Operation *op,
                          EdgeKind kind) {
     if (!dstClk || !srcClk)
       return;
-    // Record the `op` through which srcClk drives `dstClk`. This map will be
-    // used to backtrack the traversal from base clock to users.
-    srcToDstClocks[srcClk].push_back({dstClk, op, kind});
+    LLVM_DEBUG(llvm::dbgs()
+               << "  [pushIfFresh] edge kind=" << edgeKindName(kind) << "\n");
+    // Record the `op` through which srcClk drives `dstClk`. This map is used to
+    // backtrack the traversal from base clock to users.
+    if (kind != EdgeKind::Alias)
+      srcToDstClocks[srcClk].push_back({dstClk, op, kind});
     Value baseClkDriver =
         getModuleScopedDriver(srcClk, /*lookThroughWires=*/true,
                               /*lookThroughNodes=*/true,
                               /*lookThroughCasts=*/true);
-    if (baseClkDriver) {
-      // `baseClkDriver` drives `srcClk`, through wires/nodes/casts. No op
+    if (baseClkDriver != srcClk)
+      // `baseClkDriver` drives `srcClk` through wires/nodes/casts. No op
       // needed.
       srcToDstClocks[baseClkDriver].push_back(
           {srcClk, nullptr, EdgeKind::Alias});
-    } else
-      baseClkDriver = srcClk;
-    // Only add to worklist if not already visited.
     if (!visited.insert(baseClkDriver).second)
       return;
     worklist.push_back(baseClkDriver);
   };
 
-  // This is a (backward) DFS traversal from leaf clock values to the base clock
-  // that drives them.
+  // Backward DFS from leaf clock values to the base clock that drives them.
   while (!worklist.empty()) {
     Value clk = worklist.pop_back_val();
     // Case 1: clk is an input-port BlockArg (fan out to every caller).
@@ -288,65 +243,57 @@ void GatedClockConversion::analyzeFrom(ArrayRef<Value> seeds) {
              "expected input port of an FModuleOp");
       unsigned portIdx = blockArg.getArgNumber();
       auto *node = ig.lookup(mod);
+      // Top-level module: this is the base clock, nothing else to traverse.
+      if (node->uses().empty()) {
+        LLVM_DEBUG(llvm::dbgs() << "  top-level port, base clock\n");
+        baseClks.push_back(clk);
+        continue;
+      }
       for (auto *use : node->uses()) {
-        // Can only handle InstanceOp.
-        if (auto callerInst = dyn_cast<InstanceOp>(*use->getInstance())) {
-          // The input-port "operand" at a caller InstanceOp is exposed as
-          // the corresponding SSA result (drivable via firrtl.connect).
-          // `getModuleScopedDriver` follows the connect chain to find the
-          // driving value in the caller's module.
+        if (auto callerInst = dyn_cast<InstanceOp>(*use->getInstance()))
+          // `getModuleScopedDriver` will be used to follow the connect chain to
+          // find the driving value for the input port, in the caller's module.
           pushIfFresh(clk, callerInst.getResult(portIdx), callerInst,
                       EdgeKind::InstanceIn);
-        }
+        else
+          use->getInstance()->emitError("can only handle InstanceOp");
       }
-      // If top level module, then we have reached the base clock, nothing else
-      // to traverse from here.
-      if (node->uses().empty())
-        baseClks.push_back(clk);
       continue;
     }
     auto *defOp = clk.getDefiningOp();
 
     // Case 2: clk is the result of a clock gate.
-    if (isa_and_nonnull<ClockGateIntrinsicOp>(defOp)) {
+    if (isa<ClockGateIntrinsicOp>(defOp)) {
       pushIfFresh(clk, clockOperandOf(defOp), defOp, EdgeKind::Gate);
       continue;
     }
 
     // Case 3: clk is an instance result (descend into the referenced module).
-    if (auto inst = dyn_cast_or_null<InstanceOp>(defOp)) {
+    if (auto inst = dyn_cast<InstanceOp>(defOp)) {
       auto refMod = inst.getReferencedModule(ig);
       auto childMod = dyn_cast_or_null<FModuleOp>(refMod.getOperation());
       if (!childMod) {
-        // external module: treat as base
+        // External module: treat as base.
+        LLVM_DEBUG(llvm::dbgs() << "  external module, base clock\n");
         baseClks.push_back(clk);
         continue;
       }
-      auto *childBody = childMod.getBodyBlock();
       unsigned portIdx = cast<OpResult>(clk).getResultNumber();
-      pushIfFresh(clk, childBody->getArgument(portIdx), inst,
+      pushIfFresh(clk, childMod.getBodyBlock()->getArgument(portIdx), inst,
                   EdgeKind::InstanceOut);
       continue;
     }
-
-    // Case 4: clk flows through a wire/node/cast alias (e.g. a register
-    // clocked by a wire that is connected to a gated clock).  Look through the
-    // alias to the real driver and record the alias relationship so the
-    // forward pass materializes the (base, enable) pair onto `clk`.
-    if (Value driver = getModuleScopedDriver(clk, /*lookThroughWires=*/true,
-                                             /*lookThroughNodes=*/true,
-                                             /*lookThroughCasts=*/true)) {
-      if (driver != clk) {
-        srcToDstClocks[driver].push_back({clk, nullptr, EdgeKind::Alias});
-        if (visited.insert(driver).second)
-          worklist.push_back(driver);
-        continue;
-      }
+    if (isa<WireOp, NodeOp>(defOp)) {
+      pushIfFresh(clk, clk, defOp, EdgeKind::Alias);
+      continue;
     }
 
-    // Base case: clk is a base clock (no further source to trace).
+    // Any other op generating the clock is a base clock; stop tracing here.
+    LLVM_DEBUG(llvm::dbgs() << "  base clock\n");
     baseClks.push_back(clk);
   }
+  LLVM_DEBUG(llvm::dbgs() << "[analyzeFrom] " << baseClks.size()
+                          << " base clocks\n");
 }
 
 //===----------------------------------------------------------------------===//
@@ -357,19 +304,21 @@ LogicalResult GatedClockConversion::rewriteRoot(Operation *op, Value base,
                                                 Value enable) {
   if (!enable)
     return success();
+
+  // RefForce/RefRelease: rebind the clock to the ungated base and fold the
+  // enable into the predicate.
   if (auto fop = dyn_cast<RefForceOp>(op)) {
     fop.getClockMutable().assign(base);
     ImplicitLocOpBuilder b(fop.getLoc(), fop);
-    Value newPred = b.createOrFold<AndPrimOp>(fop.getPredicate(), enable);
-    fop.getPredicateMutable().assign(newPred);
+    fop.getPredicateMutable().assign(
+        b.createOrFold<AndPrimOp>(fop.getPredicate(), enable));
     return success();
   }
-
   if (auto rop = dyn_cast<RefReleaseOp>(op)) {
     rop.getClockMutable().assign(base);
     ImplicitLocOpBuilder b(rop.getLoc(), rop);
-    Value newPred = b.createOrFold<AndPrimOp>(rop.getPredicate(), enable);
-    rop.getPredicateMutable().assign(newPred);
+    rop.getPredicateMutable().assign(
+        b.createOrFold<AndPrimOp>(rop.getPredicate(), enable));
     return success();
   }
 
@@ -382,7 +331,7 @@ LogicalResult GatedClockConversion::rewriteRoot(Operation *op, Value base,
   else if (auto regr = dyn_cast<RegResetOp>(op))
     regData = regr.getData();
   else
-    return success();
+    return op->emitError("unsupported for gated clock conversion");
 
   // Rebind the register clock to the ungated base.
   op->setOperand(0, base);
@@ -405,6 +354,10 @@ void GatedClockConversion::materializeAlias(Value dstClk, FModuleOp srcMod,
                                             Value materializedClk,
                                             Value materializedEn) {
   auto liveDst = liveValue(dstClk);
+  if (!materializedEn) {
+    clockEnablePairs[dstClk] = {materializedClk, {}};
+    return;
+  }
   // Create temporary wires at the top of srcMod to carry (base, enable).
   // eliminateTemporaryWires() will forward them away when safe.
   auto builder = ImplicitLocOpBuilder::atBlockBegin(liveDst.getLoc(),
@@ -419,11 +372,10 @@ void GatedClockConversion::materializeAlias(Value dstClk, FModuleOp srcMod,
   if (!isa<BlockArgument>(materializedClk))
     builder.setInsertionPointAfterValue(materializedClk);
   MatchingConnectOp::create(builder, clockWire, materializedClk);
-  if (materializedEn && !isa<BlockArgument>(materializedEn))
+  if (!isa<BlockArgument>(materializedEn))
     builder.setInsertionPointAfterValue(materializedEn);
-  MatchingConnectOp::create(
-      builder, enWire, materializedEn ? materializedEn : constU1One(builder));
-  materialized[dstClk] = {clockWire, enWire};
+  MatchingConnectOp::create(builder, enWire, materializedEn);
+  clockEnablePairs[dstClk] = {clockWire, enWire};
 }
 
 void GatedClockConversion::materializeGate(ClockGateIntrinsicOp gate,
@@ -438,10 +390,10 @@ void GatedClockConversion::materializeGate(ClockGateIntrinsicOp gate,
     gateEn = builder.createOrFold<AndPrimOp>(materializedEn, gateEn);
   }
   // Propagate the true ungated base clock through cascaded gates.
-  materialized[dstClk] = {materializedClk, gateEn};
+  clockEnablePairs[dstClk] = {materializedClk, gateEn};
 }
 
-GatedClockConversion::PortPair GatedClockConversion::findOrInsertGatedPorts(
+std::pair<unsigned, unsigned> GatedClockConversion::findOrInsertGatedPorts(
     InstanceOp &inst, FModuleOp childMod, unsigned gatedClkIndex, Direction dir,
     Value materializedClk, Value materializedEn) {
   // Cache hit: ports already inserted for this (module, port) pair.
@@ -453,54 +405,24 @@ GatedClockConversion::PortPair GatedClockConversion::findOrInsertGatedPorts(
   StringRef portName = childMod.getPortName(gatedClkIndex);
 
   if (dir == Direction::Out) {
-    auto getPortValue = [&](unsigned i) -> Value {
-      if (childMod.getPortDirection(i) != Direction::Out)
-        return Value();
-      return childMod.getBodyBlock()->getArgument(i);
-    };
-    auto match =
-        checkExistingPorts(childMod.getNumPorts(), getPortValue,
-                           materializedClk, materializedEn, clockType, u1Type);
-    if (!match.foundClk || !match.foundEn) {
-      auto [cIdx, eIdx] = insertOrReusePort(
-          childMod, portName, Direction::Out,
-          match.foundClk ? std::optional<unsigned>(match.clkIndex)
-                         : std::nullopt,
-          match.foundEn ? std::optional<unsigned>(match.enIndex)
-                        : std::nullopt);
-      baseClkIndex = cIdx;
-      enableIndex = eIdx;
-      inst = instReplaceMap[inst];
-    } else {
-      baseClkIndex = match.clkIndex;
-      enableIndex = match.enIndex;
-    }
+    auto [cIdx, eIdx] = insertPorts(childMod, portName, Direction::Out);
+    baseClkIndex = cIdx;
+    enableIndex = eIdx;
+    inst = liveOp(inst);
     auto newClkOut = childMod.getBodyBlock()->getArgument(baseClkIndex);
     auto enableOut = childMod.getBodyBlock()->getArgument(enableIndex);
     ImplicitLocOpBuilder builder(childMod.getLoc(), childMod);
     builder.setInsertionPointToEnd(childMod.getBodyBlock());
     MatchingConnectOp::create(builder, newClkOut, materializedClk);
-    if (materializedEn)
-      MatchingConnectOp::create(builder, enableOut, materializedEn);
+
+    assert(materializedEn &&
+           "unless this is a gated clock, no need to add output enable port");
+    MatchingConnectOp::create(builder, enableOut, materializedEn);
   } else {
-    auto getPortValue = [&](unsigned i) -> Value { return inst->getResult(i); };
-    auto match =
-        checkExistingPorts(inst->getNumResults(), getPortValue, materializedClk,
-                           materializedEn, clockType, u1Type);
-    if (!match.foundClk || !match.foundEn) {
-      auto [cIdx, eIdx] = insertOrReusePort(
-          childMod, portName, Direction::In,
-          match.foundClk ? std::optional<unsigned>(match.clkIndex)
-                         : std::nullopt,
-          match.foundEn ? std::optional<unsigned>(match.enIndex)
-                        : std::nullopt);
-      baseClkIndex = cIdx;
-      enableIndex = eIdx;
-      inst = instReplaceMap[inst];
-    } else {
-      baseClkIndex = match.clkIndex;
-      enableIndex = match.enIndex;
-    }
+    auto [cIdx, eIdx] = insertPorts(childMod, portName, Direction::In);
+    baseClkIndex = cIdx;
+    enableIndex = eIdx;
+    inst = liveOp(inst);
     connectMaterializedToInstancePorts(inst, baseClkIndex, enableIndex,
                                        materializedClk, materializedEn,
                                        inst.getLoc());
@@ -510,180 +432,297 @@ GatedClockConversion::PortPair GatedClockConversion::findOrInsertGatedPorts(
   return {baseClkIndex, enableIndex};
 }
 
-void GatedClockConversion::materializeInstancePort(
-    Direction dir, InstanceOp inst, Value dstClk, Value liveAnchor,
-    Value materializedClk, Value materializedEn) {
-  auto childMod = dyn_cast_or_null<FModuleOp>(inst.getReferencedModule(ig));
-  auto gatedClkIndex = cast<OpResult>(liveAnchor).getResultNumber();
+bool GatedClockConversion::materializeInstancePort(Direction dir,
+                                                   InstanceOp inst,
+                                                   Value dstClk, Value srcClk,
+                                                   Value materializedClk,
+                                                   Value materializedEn) {
+  auto childMod =
+      dyn_cast_or_null<FModuleOp>(inst.getReferencedModule(ig).getOperation());
+  auto gatedClkIndex = cast<OpResult>(srcClk).getResultNumber();
+  if (!materializedEn) {
+    if (dir == Direction::Out) {
+      clockEnablePairs[dstClk] = {dstClk, {}};
+      return true;
+    }
+    // This instance has an ungated clock input, but a different instance of the
+    // same module may have a gated clock. Iterate over all instances of
+    // childMod to check whether any have gated inputs.
+    auto *node = ig.lookup(childMod);
+    bool allHaveNullEnable = true;
+
+    for (auto *use : node->uses()) {
+      if (auto instance = dyn_cast<InstanceOp>(*use->getInstance())) {
+        auto instanceIn = instance.getResult(gatedClkIndex);
+        auto it = clockEnablePairs.find(instanceIn);
+        if (it == clockEnablePairs.end())
+          // Not yet processed; wait for all instance inputs before deciding.
+          return false;
+        if (it->second.second) {
+          allHaveNullEnable = false;
+          break;
+        }
+      }
+    }
+
+    // All instances processed with null enable: ungated for all uses.
+    if (allHaveNullEnable) {
+      clockEnablePairs[dstClk] = {dstClk, {}};
+      return true;
+    }
+
+    // Some instance has a gated clock and others are ungated. Add the enable
+    // port to the ungated ones too, but connect it to a constant 1.
+    materializedEn = getOrCreateConstU1One(inst->getParentOfType<FModuleOp>());
+  }
   auto [baseClkIndex, enableIndex] = findOrInsertGatedPorts(
       inst, childMod, gatedClkIndex, dir, materializedClk, materializedEn);
-  if (dir == Direction::Out)
-    materialized[dstClk] = {inst.getResult(baseClkIndex),
-                            inst.getResult(enableIndex)};
-  else
-    materialized[dstClk] = {childMod.getBodyBlock()->getArgument(baseClkIndex),
-                            childMod.getBodyBlock()->getArgument(enableIndex)};
+
+  // An output port is exposed on the instance result side; an input port on the
+  // child module's block-argument side. The materialized pair is recorded the
+  // same way either way.
+  Value baseVal, enVal;
+  if (dir == Direction::Out) {
+    baseVal = inst.getResult(baseClkIndex);
+    enVal = inst.getResult(enableIndex);
+  } else {
+    baseVal = childMod.getBodyBlock()->getArgument(baseClkIndex);
+    enVal = childMod.getBodyBlock()->getArgument(enableIndex);
+  }
+  assert(getParentModule(dstClk) == getParentModule(baseVal) &&
+         "parent modules must match");
+  clockEnablePairs[dstClk] = {baseVal, enVal};
+  return true;
 }
 
 void GatedClockConversion::reinitMultiplyInstantiatedInput(
     Value liveSrc, Value materializedClk, Value materializedEn) {
   // liveSrc is a result of the live caller instance; drive the already-inserted
   // gated ports for the second (or later) caller of this module.
-  auto inst = dyn_cast_or_null<InstanceOp>(liveSrc.getDefiningOp());
-  if (!inst)
-    return;
-  auto childMod = dyn_cast_or_null<FModuleOp>(inst.getReferencedModule(ig));
+  auto inst = liveSrc.getDefiningOp<InstanceOp>();
+  assert(inst);
+  auto childMod =
+      dyn_cast_or_null<FModuleOp>(inst.getReferencedModule(ig).getOperation());
   auto gatedClkIndex = cast<OpResult>(liveSrc).getResultNumber();
   auto modIt = modArgToMaterialized.find({childMod, gatedClkIndex});
-  assert(modIt != modArgToMaterialized.end());
+  // No mapping means this is an output port. Output ports are materialized when
+  // processing InstanceOut edges, not InstanceIn, so skip the reinit here and
+  // let the normal InstanceOut path handle it.
+  if (modIt == modArgToMaterialized.end()) {
+    LLVM_DEBUG(llvm::dbgs() << "  no mapping for index " << gatedClkIndex
+                            << ", skipping reinit (handled by InstanceOut)\n");
+    return;
+  }
   auto [newClkIndex, newEnIndex] = modIt->second;
   connectMaterializedToInstancePorts(inst, newClkIndex, newEnIndex,
                                      materializedClk, materializedEn,
                                      liveSrc.getLoc(), /*checkUseEmpty=*/true);
 }
 
+Value GatedClockConversion::findClockFlowCycle() const {
+  // Pure DFS over the clock-flow graph with the classic three-color marking.
+  // A Gray node reached again is an ancestor on the current path → back-edge →
+  // feedback loop. The materialization worklist propagates forward from
+  // `baseClks`, so we seed the search there; nodes unreachable from any base
+  // clock are never materialized and cannot stall the forward pass.
+  enum Color { White, Gray, Black };
+  DenseMap<Value, Color> color;
+  // Explicit stack of (node, next-edge-index) to avoid deep recursion.
+  SmallVector<std::pair<Value, unsigned>> stack;
+
+  for (auto base : baseClks) {
+    if (color.lookup(base) != White)
+      continue;
+    color[base] = Gray;
+    stack.push_back({base, 0});
+    while (!stack.empty()) {
+      auto &[node, idx] = stack.back();
+      auto edgesIt = srcToDstClocks.find(node);
+      if (edgesIt == srcToDstClocks.end() || idx >= edgesIt->second.size()) {
+        color[node] = Black;
+        stack.pop_back();
+        continue;
+      }
+      Value dst = edgesIt->second[idx++].dst;
+      switch (color.lookup(dst)) {
+      case Gray:
+        // Back-edge: `dst` is still on the active DFS path.
+        return liveValue(dst);
+      case White:
+        color[dst] = Gray;
+        stack.push_back({dst, 0});
+        break;
+      case Black:
+        break; // already fully explored
+      }
+    }
+  }
+  return Value();
+}
+
+SmallVector<Value, 2> GatedClockConversion::processEdge(const ClockEdge &edge,
+                                                        Value srcClk,
+                                                        FModuleOp srcMod,
+                                                        Value materializedClk,
+                                                        Value materializedEn) {
+  LLVM_DEBUG(llvm::dbgs() << "  edge kind=" << edgeKindName(edge.kind) << "\n");
+  Value liveSrc = liveValue(srcClk);
+
+  if (clockEnablePairs.count(edge.dst)) {
+    // dst already done — for InstanceIn this means a multiply-instantiated
+    // module whose ports were inserted by an earlier caller; re-init them.
+    if (edge.kind == EdgeKind::InstanceIn)
+      reinitMultiplyInstantiatedInput(liveSrc, materializedClk, materializedEn);
+    return {};
+  }
+
+  // The destination is now reachable; visit it next.
+  SmallVector<Value, 2> toEnqueue = {edge.dst};
+  switch (edge.kind) {
+  case EdgeKind::Alias:
+    materializeAlias(edge.dst, srcMod, materializedClk, materializedEn);
+    break;
+  case EdgeKind::Gate:
+    materializeGate(edge.gate(), edge.dst, materializedClk, materializedEn);
+    break;
+  case EdgeKind::InstanceIn:
+    if (!materializeInstancePort(Direction::In, liveOp(edge.instance()),
+                                 liveValue(edge.dst), liveSrc, materializedClk,
+                                 materializedEn))
+      // Multiply-instantiated module: wait for all instance inputs to be
+      // materialized, then re-queue. If all instances have an ungated clock the
+      // enable port is skipped; otherwise the ungated clocks get a const-1
+      // enable port.
+      toEnqueue.push_back(srcClk);
+    break;
+  case EdgeKind::InstanceOut:
+    materializeInstancePort(Direction::Out, liveOp(edge.instance()), edge.dst,
+                            liveValue(edge.dst), materializedClk,
+                            materializedEn);
+    break;
+  }
+  return toEnqueue;
+}
+
 void GatedClockConversion::materialize() {
+  LLVM_DEBUG(llvm::dbgs() << "[materialize] " << baseClks.size()
+                          << " base clocks\n");
   // Forward pass: propagate (base, enable) pairs from base clocks through the
   // clock flow graph built by analyzeFrom(), inserting ports as needed.
+  //
+  // The graph is acyclic here: run() calls findClockFlowCycle() before
+  // materialize() and bails on any feedback loop. So every item that is
+  // re-queued while blocked on an unmaterialized upstream is guaranteed to
+  // unblock eventually.
   std::deque<Value> worklist(baseClks.begin(), baseClks.end());
   for (auto base : baseClks)
-    materialized[base] = {base, {}};
+    clockEnablePairs[base] = {base, {}};
+
+  // This is a BFS traversal, that tries to materialize all the ancestors before
+  // moving on to the child nodes. For example, for a multiply instantiated
+  // module, all its instances must be materialized, before the algorithm can
+  // move into the module, which is required to infer if any of the instances of
+  // a module have a gated clock input port.
 
   while (!worklist.empty()) {
     auto srcClk = worklist.front();
     worklist.pop_front();
     // Resolve to the live SSA value — a prior port insertion may have replaced
     // the defining instance.
-    auto liveSrc = liveValue(srcClk);
-    FModuleOp srcMod;
-    if (auto blockArg = dyn_cast<BlockArgument>(liveSrc))
-      srcMod = cast<FModuleOp>(liveSrc.getParentBlock()->getParentOp());
-    else if (auto *def = liveSrc.getDefiningOp())
-      srcMod = def->getParentOfType<FModuleOp>();
+    FModuleOp srcMod = getParentModule(liveValue(srcClk));
 
-    auto it = materialized.find(srcClk);
-    if (it == materialized.end()) {
-      // Not yet materialized; re-queue until its upstream is done.
+    // Check the base-clock, enable pair that drives `srcClk`. If its not yet
+    // materialized, re-queue it.
+    auto it = clockEnablePairs.find(srcClk);
+    if (it == clockEnablePairs.end()) {
       worklist.push_back(srcClk);
       continue;
     }
     auto materializedClk = liveValue(it->second.first);
     auto materializedEn = liveValue(it->second.second);
 
-    for (auto &edge : srcToDstClocks[srcClk]) {
-      liveSrc = liveValue(srcClk);
-      if (materialized.count(edge.dst)) {
-        // dst already done — for InstanceIn this means a multiply-instantiated
-        // module whose ports were inserted by an earlier caller; re-init them.
-        if (edge.kind == EdgeKind::InstanceIn)
-          reinitMultiplyInstantiatedInput(liveSrc, materializedClk,
-                                          materializedEn);
-        continue;
-      }
-      worklist.push_back(edge.dst);
-      switch (edge.kind) {
-      case EdgeKind::Alias:
-        materializeAlias(edge.dst, srcMod, materializedClk, materializedEn);
-        break;
-      case EdgeKind::Gate:
-        materializeGate(cast<ClockGateIntrinsicOp>(edge.op), edge.dst,
-                        materializedClk, materializedEn);
-        break;
-      case EdgeKind::InstanceIn: {
-        auto inst = cast<InstanceOp>(liveOp(edge.op));
-        materializeInstancePort(Direction::In, inst, edge.dst, liveSrc,
-                                materializedClk, materializedEn);
-        break;
-      }
-      case EdgeKind::InstanceOut: {
-        auto liveDst = liveValue(edge.dst);
-        auto inst = cast<InstanceOp>(liveOp(edge.op));
-        materializeInstancePort(Direction::Out, inst, edge.dst, liveDst,
-                                materializedClk, materializedEn);
-        break;
-      }
-      }
-    }
+    for (auto &edge : srcToDstClocks[srcClk])
+      for (Value next :
+           processEdge(edge, srcClk, srcMod, materializedClk, materializedEn))
+        worklist.push_back(next);
   }
+  LLVM_DEBUG(llvm::dbgs() << "[materialize] complete\n");
 }
 
 std::pair<SmallVector<Value>, SmallVector<std::pair<Operation *, Value>>>
 GatedClockConversion::collectSeeds() {
-  // Take ownership of the pending roots — `collectSeeds()` consumes them so
-  // the caller's `addRoot` queue is empty afterwards (a subsequent visit can
-  // collect a fresh batch without reprocessing — and without dereferencing
-  // ops that may have been erased between visits).
+  // Take ownership of the pending roots — `collectSeeds()` consumes them so the
+  // caller's `addRoot` queue is empty afterwards (a subsequent visit can
+  // collect a fresh batch without reprocessing — and without dereferencing ops
+  // that may have been erased between visits).
   SmallVector<Operation *> pending;
   pending.swap(roots);
 
-  // Collect each root's clock operand as a seed.
-  // Remember the (op, original-clock) pairing: `materialized` is keyed by the
-  // original analysis-era clock value, but the op's live clock operand may be
-  // remapped to a replacement instance result before the rewrite runs.
+  // Collect each root's clock operand as a seed. Remember the
+  // (op, original-clock) pairing: `materialized` is keyed by the original
+  // analysis-era clock value, but the op's live clock operand may be remapped
+  // to a replacement instance result before the rewrite runs.
   SmallVector<Value> seeds;
   SmallVector<std::pair<Operation *, Value>> rootClocks;
   seeds.reserve(pending.size());
-  for (Operation *op : pending)
+  for (Operation *op : pending) {
     if (Value clk = clockOperandOf(op)) {
       seeds.push_back(clk);
       rootClocks.push_back({op, clk});
     }
+  }
 
+  LLVM_DEBUG(llvm::dbgs() << "[collectSeeds] " << seeds.size() << " seeds\n");
   return {seeds, rootClocks};
 }
 
 void GatedClockConversion::eliminateTemporaryWires() {
   // Eliminate temporary wires created during materialization by forwarding
-  // their values directly. For each wire, check if there are exactly two uses:
-  // one connect writing to the wire and one connect reading from it. If the
-  // write dominates the read, bypass the wire by replacing all uses of the wire
-  // with the write source, then erase the wire and write connect.
+  // their values directly. For each wire, expect exactly one connect writing to
+  // it plus reads from known ops; if the write dominates every read, bypass the
+  // wire by replacing its uses with the write source and erasing the wire.
   DenseMap<FModuleOp, mlir::DominanceInfo> dominanceInfo;
   for (auto wire : wireOps) {
     auto wireData = wire.getData();
     FModuleOp mod = wire->getParentOfType<FModuleOp>();
-    auto domIter = dominanceInfo.find(mod);
-    if (domIter == dominanceInfo.end()) {
-      dominanceInfo[mod] = mlir::DominanceInfo(mod);
-    }
-    auto &modDomInfo = dominanceInfo[mod];
+    if (!dominanceInfo.count(mod))
+      dominanceInfo.try_emplace(mod, mod);
+    auto &modDomInfo = dominanceInfo.find(mod)->second;
 
-    // Find all connect operations using this wire.
-    FConnectLike writeConnect = {}; // Connect writing to wire (wire is dest)
-    FConnectLike readConnect = {};  // Connect reading from wire (wire is src)
+    FConnectLike writeConnect = {}; // Connect writing to the wire.
+    bool cannotRemove = false;
+    SmallVector<Operation *> wireReaders;
 
     for (auto *user : wireData.getUsers()) {
-      if (auto connect = dyn_cast<FConnectLike>(user)) {
+      if (auto connect = dyn_cast<MatchingConnectOp>(user)) {
         if (connect.getDest() == wireData) {
-          // Found a write to the wire. If we already have one, bail out.
+          // A second write means we can't safely forward; bail out.
           if (writeConnect) {
-            writeConnect = {};
+            cannotRemove = true;
             break;
           }
           writeConnect = connect;
-        } else if (connect.getSrc() == wireData) {
-          // Found a read from the wire. If we already have one, bail out.
-          if (readConnect) {
-            readConnect = {};
-            break;
-          }
-          readConnect = connect;
+          continue;
         }
-      } else
-        // Wire has a non-connect user; can't optimize.
+      } else if (!isa<RegOp, RegResetOp, RefForceOp, RefReleaseOp, MuxPrimOp>(
+                     user)) {
+        // Unhandled user; can't optimize.
+        cannotRemove = true;
         break;
+      }
+      wireReaders.push_back(user);
     }
-    // Skip wires that don't have exactly one write and one read.
-    if (!readConnect || !writeConnect)
+    if (cannotRemove || !writeConnect)
       continue;
 
-    // Optimize: bypass the wire if the write dominates the read.
-    // Replace all uses of the wire with the write source.
+    // Bypass the wire if the write dominates every read.
     Value writeSource = writeConnect.getSrc();
-    if (modDomInfo.dominates(writeConnect, readConnect)) {
+    if (llvm::all_of(wireReaders, [&](Operation *user) {
+          return modDomInfo.dominates(writeConnect, user);
+        })) {
       wireData.replaceAllUsesWith(writeSource);
-      // Erase the write connect and the wire itself. The read connect is
-      // implicitly removed by replaceAllUsesWith updating its source operand.
+      // The read connect is implicitly removed by replaceAllUsesWith updating
+      // its source operand.
       writeConnect.erase();
       wire.erase();
     }
@@ -691,7 +730,10 @@ void GatedClockConversion::eliminateTemporaryWires() {
 }
 
 LogicalResult GatedClockConversion::run() {
-  // Collect clock operands from pending roots.
+  LLVM_DEBUG(llvm::dbgs() << "===== GatedClockConversion::run() =====\n");
+  // Single-use: mark this instance as run so a later addRoot() is rejected.
+  hasRun = true;
+
   auto [seeds, rootClocks] = collectSeeds();
 
   if (seeds.empty())
@@ -701,61 +743,69 @@ LogicalResult GatedClockConversion::run() {
   u1Type = UIntType::get(context, 1);
 
   // Phase 1: pure analysis.
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 1: Analysis ---\n");
   analyzeFrom(seeds);
   LLVM_DEBUG(dump());
-  // Phase 2: per-root materialisation + IR rewrite.
+
+  // Cyclic clock flow cannot be materialized. Detect it on the pure analysis
+  // graph *before* any IR mutation, so that on a cycle we leave the input
+  // untouched and complete successfully (a no-op conversion + warning) rather
+  // than failing the pass with a partially-mutated module.
+  if (Value cyc = findClockFlowCycle()) {
+    mlir::emitWarning(cyc.getLoc())
+        << "cyclic clock dependency: skipping gated-clock conversion "
+           "(clock flow contains a feedback loop); module left unchanged";
+    return success();
+  }
+
+  // Phase 2: per-root materialisation + IR rewrite. The clock-flow graph is
+  // acyclic (checked above), so materialization always succeeds.
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 2: Materialization ---\n");
   materialize();
+
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 2b: Root Rewriting ---\n");
   for (auto &[op, clk] : rootClocks) {
-    assert(materialized.find(clk) != materialized.end());
+    assert(clockEnablePairs.find(clk) != clockEnablePairs.end());
     // Resolve to live values: the materialized (base, enable) pair may have
     // been instance results that were since replaced by port insertion.
-    auto materializedClk = liveValue(materialized[clk].first);
-    auto materializedEn = liveValue(materialized[clk].second);
+    auto materializedClk = liveValue(clockEnablePairs[clk].first);
+    auto materializedEn = liveValue(clockEnablePairs[clk].second);
     if (failed(rewriteRoot(op, materializedClk, materializedEn)))
       return failure();
   }
-  // Eliminate temporary wires created during materialization.
+
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 2c: Wire Elimination ---\n");
   eliminateTemporaryWires();
 
   // Phase 3: erase all replaced instances now that transformations are
   // complete.
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 3: Cleanup (" << opsToErase.size()
+                          << " ops) ---\n");
   for (auto oldInst : opsToErase)
     oldInst.erase();
   opsToErase.clear();
 
+  LLVM_DEBUG(llvm::dbgs() << "===== run() complete =====\n");
   return success();
 }
 
 void GatedClockConversion::dump() const {
   llvm::dbgs() << "=== srcToDstClocks ===\n";
   for (const auto &[srcClk, dstList] : srcToDstClocks) {
-    llvm::dbgs() << "Source clock: ";
+    llvm::dbgs() << "Source clock: " << getParentModule(srcClk).getModuleName()
+                 << "\n";
     srcClk.print(llvm::dbgs());
     llvm::dbgs() << "\n";
     for (const auto &edge : dstList) {
-      llvm::dbgs() << "  -> Destination clock: ";
+      llvm::dbgs() << "  -> Destination clock: "
+                   << getParentModule(edge.dst).getModuleName() << "\n";
       edge.dst.print(llvm::dbgs());
       llvm::dbgs() << " via op: ";
       if (edge.op)
         edge.op->print(llvm::dbgs());
       else
         llvm::dbgs() << "<alias>";
-      llvm::dbgs() << " [";
-      switch (edge.kind) {
-      case EdgeKind::Alias:
-        llvm::dbgs() << "Alias";
-        break;
-      case EdgeKind::Gate:
-        llvm::dbgs() << "Gate";
-        break;
-      case EdgeKind::InstanceIn:
-        llvm::dbgs() << "InstanceIn";
-        break;
-      case EdgeKind::InstanceOut:
-        llvm::dbgs() << "InstanceOut";
-        break;
-      }
-      llvm::dbgs() << "]\n";
+      llvm::dbgs() << " [" << edgeKindName(edge.kind) << "]\n";
     }
   }
   llvm::dbgs() << "=== Base clocks ===\n";

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -53,6 +53,16 @@ Value materializeGateEnable(ClockGateIntrinsicOp gate) {
   return b.createOrFold<OrPrimOp>(gate.getEnable(), gate.getTestEnable());
 }
 
+/// Build the (baseClock, gateEnable) PortInfo pair for the given direction.
+std::pair<PortInfo, PortInfo>
+makeGatedClockPortInfos(MLIRContext *ctx, StringRef tag, Direction dir,
+                        Location loc, Type clockType, Type u1Type) {
+  return {PortInfo(StringAttr::get(ctx, ("_gatedClock_baseClock_" + tag).str()),
+                   clockType, dir, /*symName=*/StringAttr(), loc),
+          PortInfo(StringAttr::get(ctx, ("_gatedClock_enable_" + tag).str()),
+                   u1Type, dir, /*symName=*/StringAttr(), loc)};
+}
+
 /// The FModuleOp `value` lives in.
 FModuleOp getParentModule(Value value) {
   if (isa<BlockArgument>(value))
@@ -179,6 +189,36 @@ Value GatedClockConversion::gateEnableOf(ClockGateIntrinsicOp gate) {
   Value v = materializeGateEnable(gate);
   gateEnableCache[gate] = v;
   return v;
+}
+
+Value GatedClockConversion::getOrCreateConstU1One(FModuleOp mod) {
+  auto it = constU1Cache.find(mod);
+  if (it != constU1Cache.end())
+    return it->second;
+
+  // At the top of the body, so it dominates every possible use.
+  ImplicitLocOpBuilder builder(mod.getLoc(), context);
+  builder.setInsertionPointToStart(mod.getBodyBlock());
+  Value constOne = builder.createOrFold<ConstantOp>(
+      APSInt(APInt(1, 1, /*isSigned=*/false), /*isUnsigned=*/true));
+  constU1Cache[mod] = constOne;
+  return constOne;
+}
+
+void GatedClockConversion::connectMaterializedToInstancePorts(
+    InstanceOp inst, unsigned clkPortIndex, unsigned enPortIndex,
+    Value materializedClk, Value materializedEn) {
+  ImplicitLocOpBuilder builder(inst.getLoc(), context);
+  // At the end of the block, so the materialized clock dominates the connect.
+  builder.setInsertionPointToEnd(inst->getBlock());
+
+  MatchingConnectOp::create(builder, inst->getResult(clkPortIndex),
+                            materializedClk);
+
+  if (!materializedEn)
+    materializedEn = getOrCreateConstU1One(inst->getParentOfType<FModuleOp>());
+  MatchingConnectOp::create(builder, inst->getResult(enPortIndex),
+                            materializedEn);
 }
 
 //===----------------------------------------------------------------------===//
@@ -611,6 +651,120 @@ void GatedClockConversion::plan() {
         worklist.push_back(next);
   }
   LLVM_DEBUG(llvm::dbgs() << "[plan] complete\n");
+}
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: applyPlan (the only IR-mutating phase)
+//===----------------------------------------------------------------------===//
+
+void GatedClockConversion::createPlannedWires() {
+  auto createWire = [&](Type type, ImplicitLocOpBuilder &builder) {
+    auto w = WireOp::create(builder, type);
+    wireOps.push_back(w);
+    return w.getData();
+  };
+  plannedWireValues.reserve(2 * wirePlans.size());
+  for (auto &wirePlan : wirePlans) {
+    // Wires have no operands, so they can all be created up front.
+    auto builder = ImplicitLocOpBuilder::atBlockBegin(
+        wirePlan.loc, wirePlan.mod.getBodyBlock());
+    plannedWireValues.push_back(createWire(clockType, builder));
+    plannedWireValues.push_back(createWire(u1Type, builder));
+  }
+}
+
+void GatedClockConversion::insertPlannedPorts() {
+  for (auto &[mod, keys] : plansPerModule) {
+    // All pairs of a module are appended in one call, so every instance is
+    // re-created exactly once no matter how many pairs the module needs.
+    const unsigned origNumPorts = mod.getNumPorts();
+    SmallVector<std::pair<unsigned, PortInfo>> newPorts;
+    for (auto key : keys) {
+      const PortPairPlan &portPlan = portPlans.find(key)->second;
+      assert(portPlan.baseIdx == origNumPorts + newPorts.size() &&
+             "port index pre-assignment invalidated: ports were inserted "
+             "outside applyPlan()");
+      auto [baseInfo, enableInfo] = makeGatedClockPortInfos(
+          context, mod.getPortName(portPlan.gatedClkIndex), portPlan.dir,
+          mod.getLoc(), clockType, u1Type);
+      newPorts.emplace_back(origNumPorts, baseInfo);
+      newPorts.emplace_back(origNumPorts, enableInfo);
+    }
+    mod.insertPorts(newPorts);
+
+    // A result list cannot grow in place, so every instance has to be
+    // re-created. Collect them first: cloning updates the use list.
+    auto *node = ig.lookup(mod);
+    SmallVector<InstanceOp> oldInsts;
+    for (auto *use : node->uses())
+      if (auto i = dyn_cast<InstanceOp>(*use->getInstance()))
+        oldInsts.push_back(i);
+
+    for (auto oldInst : oldInsts) {
+      auto cloneIface = oldInst.cloneWithInsertedPortsAndReplaceUses(newPorts);
+      auto newInst = cast<InstanceOp>(cloneIface.getOperation());
+      ig.replaceInstance(oldInst, newInst);
+      assert(!instClones.count(oldInst) && "instance re-created twice");
+      instClones[oldInst] = newInst;
+      // Defer erasure until nothing reads the plan any more.
+      deadInstances.push_back(oldInst);
+    }
+  }
+}
+
+LogicalResult GatedClockConversion::emitPlannedIR() {
+  // Planned output port pairs: drive the new ports from inside the module.
+  for (auto &[key, portPlan] : portPlans) {
+    if (portPlan.dir != Direction::Out)
+      continue;
+    Value materializedClk = resolve(portPlan.outBaseClk);
+    Value materializedEn = lower(portPlan.outEnableId);
+    auto *body = portPlan.mod.getBodyBlock();
+    ImplicitLocOpBuilder builder(portPlan.mod.getLoc(), context);
+    builder.setInsertionPointToEnd(body);
+    MatchingConnectOp::create(builder, body->getArgument(portPlan.baseIdx),
+                              materializedClk);
+    MatchingConnectOp::create(builder, body->getArgument(portPlan.enIdx),
+                              materializedEn);
+  }
+
+  // Planned input port pairs: drive them at every caller instance.
+  for (auto &[key, drive] : instanceDrives) {
+    Value materializedClk = resolve(drive.baseClk);
+    Value materializedEn = lower(drive.enableId);
+    connectMaterializedToInstancePorts(
+        cast<InstanceOp>(liveInstance(drive.inst)), drive.baseIdx, drive.enIdx,
+        materializedClk, materializedEn);
+  }
+
+  // Planned carrier wires: connect them to their source pair.
+  for (auto [index, wirePlan] : llvm::enumerate(wirePlans)) {
+    Value clockWire = plannedWireValues[2 * index];
+    Value enWire = plannedWireValues[2 * index + 1];
+    Value materializedClk = resolve(wirePlan.baseClk);
+    Value materializedEn = lower(wirePlan.enableId);
+    ImplicitLocOpBuilder builder(wirePlan.loc, context);
+    builder.setInsertionPointAfter(enWire.getDefiningOp());
+    if (!isa<BlockArgument>(materializedClk))
+      builder.setInsertionPointAfterValue(materializedClk);
+    MatchingConnectOp::create(builder, clockWire, materializedClk);
+    if (!isa<BlockArgument>(materializedEn))
+      builder.setInsertionPointAfterValue(materializedEn);
+    MatchingConnectOp::create(builder, enWire, materializedEn);
+  }
+
+  // Root rewrites, last: they consume the fully materialized pairs.
+  for (const auto &rewrite : rootRewrites)
+    if (failed(rewriteRoot(rewrite.op, resolve(rewrite.baseClk),
+                           lower(rewrite.enableId))))
+      return failure();
+  return success();
+}
+
+LogicalResult GatedClockConversion::applyPlan() {
+  createPlannedWires();
+  insertPlannedPorts();
+  return emitPlannedIR();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -1,0 +1,258 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the GatedClockConversion utility class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/GatedClockConversion.h"
+#include "circt/Dialect/FIRRTL/FIRRTLEnums.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "firrtl-gated-clock-conversion"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+
+StringRef edgeKindName(EdgeKind kind) {
+  switch (kind) {
+  case EdgeKind::Alias:
+    return "Alias";
+  case EdgeKind::Gate:
+    return "Gate";
+  case EdgeKind::InstanceIn:
+    return "InstanceIn";
+  case EdgeKind::InstanceOut:
+    return "InstanceOut";
+  }
+  return "?";
+}
+
+/// The FModuleOp `value` lives in.
+FModuleOp getParentModule(Value value) {
+  if (isa<BlockArgument>(value))
+    return cast<FModuleOp>(value.getParentBlock()->getParentOp());
+  return value.getDefiningOp()->getParentOfType<FModuleOp>();
+}
+
+/// The clock operand of a supported root op, null otherwise. The `*_initial`
+/// ref force/release variants have no clock, so they are not roots.
+Value clockOperandOf(Operation *op) {
+  if (auto fop = dyn_cast<RefForceOp>(op))
+    return fop.getClock();
+  if (auto rop = dyn_cast<RefReleaseOp>(op))
+    return rop.getClock();
+  if (auto reg = dyn_cast<RegOp>(op))
+    return reg.getClockVal();
+  if (auto regr = dyn_cast<RegResetOp>(op))
+    return regr.getClockVal();
+  if (auto gc = dyn_cast<ClockGateIntrinsicOp>(op))
+    return gc.getInput();
+  return Value();
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: worklist analysis (no IR mutation)
+//===----------------------------------------------------------------------===//
+
+LogicalResult GatedClockConversion::addRoot(Operation *op) {
+  Value clk = clockOperandOf(op);
+  if (!clk)
+    return op->emitError(
+        "unsupported operation type for gated clock "
+        "conversion; expected RefForceOp, RefReleaseOp, RegOp, "
+        "RegResetOp or ClockGateIntrinsicOp");
+  roots.emplace_back(op, clk);
+  return success();
+}
+
+LogicalResult GatedClockConversion::analyzeFrom(ArrayRef<Value> seeds) {
+  LLVM_DEBUG(llvm::dbgs() << "[analyzeFrom] " << seeds.size() << " seeds\n");
+  SmallVector<Value> worklist(seeds.begin(), seeds.end());
+  LogicalResult result = success();
+
+  // Record the edge `srcClk` -> `dstClk` through `op` and enqueue the driver of
+  // `srcClk`, looking through wire/node/cast aliases.
+  auto pushIfFresh = [&](Value dstClk, Value srcClk, Operation *op,
+                         EdgeKind kind) {
+    if (!dstClk || !srcClk)
+      return;
+    LLVM_DEBUG(llvm::dbgs()
+               << "  [pushIfFresh] edge kind=" << edgeKindName(kind) << "\n");
+    Value baseClkDriver =
+        getModuleScopedDriver(srcClk, /*lookThroughWires=*/true,
+                              /*lookThroughNodes=*/true,
+                              /*lookThroughCasts=*/true);
+    // An undriven clock net has no source to thread a (base, enable) pair from,
+    // and skipping it would break the invariant that every caller drives a
+    // planned input pair. Report it while the IR is still untouched.
+    if (!baseClkDriver) {
+      mlir::emitError(srcClk.getLoc())
+          << "gated clock conversion: this clock is not driven; run this "
+             "utility after firrtl-expand-whens and firrtl-check-init";
+      result = failure();
+      return;
+    }
+    // `srcToDstClocks` is replayed forwards, from base clocks to users.
+    if (kind != EdgeKind::Alias)
+      srcToDstClocks[srcClk].push_back({dstClk, op, kind});
+    if (baseClkDriver != srcClk)
+      // Drives `srcClk` through wires/nodes/casts, so no op is needed.
+      srcToDstClocks[baseClkDriver].push_back(
+          {srcClk, nullptr, EdgeKind::Alias});
+    if (!visited.insert(baseClkDriver).second)
+      return;
+    worklist.push_back(baseClkDriver);
+  };
+
+  // Backward DFS from leaf clock values to the base clock that drives them.
+  while (!worklist.empty()) {
+    Value clk = worklist.pop_back_val();
+    // Case 1: clk is an input-port BlockArg (fan out to every caller).
+    if (auto blockArg = dyn_cast<BlockArgument>(clk)) {
+      auto mod = dyn_cast<FModuleOp>(blockArg.getOwner()->getParentOp());
+      assert(mod &&
+             mod.getPortDirection(blockArg.getArgNumber()) == Direction::In &&
+             "expected input port of an FModuleOp");
+      unsigned portIdx = blockArg.getArgNumber();
+      auto *node = ig.lookup(mod);
+      // Top-level module: this is the base clock, nothing else to traverse.
+      if (node->uses().empty()) {
+        LLVM_DEBUG(llvm::dbgs() << "  top-level port, base clock\n");
+        baseClks.push_back(clk);
+        continue;
+      }
+      for (auto *use : node->uses()) {
+        if (auto callerInst = dyn_cast<InstanceOp>(*use->getInstance()))
+          pushIfFresh(clk, callerInst.getResult(portIdx), callerInst,
+                      EdgeKind::InstanceIn);
+        else
+          use->getInstance()->emitError("can only handle InstanceOp");
+      }
+      continue;
+    }
+    auto *defOp = clk.getDefiningOp();
+
+    // Case 2: clk is the result of a clock gate.
+    if (auto gate = dyn_cast<ClockGateIntrinsicOp>(defOp)) {
+      pushIfFresh(clk, gate.getInput(), gate, EdgeKind::Gate);
+      continue;
+    }
+
+    // Case 3: clk is an instance result (descend into the referenced module).
+    if (auto inst = dyn_cast<InstanceOp>(defOp)) {
+      auto refMod = inst.getReferencedModule(ig);
+      auto childMod = dyn_cast_or_null<FModuleOp>(refMod.getOperation());
+      if (!childMod) {
+        // External module: treat as base.
+        LLVM_DEBUG(llvm::dbgs() << "  external module, base clock\n");
+        baseClks.push_back(clk);
+        continue;
+      }
+      unsigned portIdx = cast<OpResult>(clk).getResultNumber();
+      pushIfFresh(clk, childMod.getBodyBlock()->getArgument(portIdx), inst,
+                  EdgeKind::InstanceOut);
+      continue;
+    }
+    if (isa<WireOp, NodeOp>(defOp)) {
+      pushIfFresh(clk, clk, defOp, EdgeKind::Alias);
+      continue;
+    }
+
+    // A clock mux is the post-ExpandWhens form of a multi-driver gated clock.
+    // There is no single enable to sink through it, so say so rather than
+    // silently leaving the gate in place. Remark only when a gate feeds the
+    // mux, so that ordinary clock selection stays silent.
+    if (auto mux = dyn_cast<MuxPrimOp>(defOp)) {
+      Value inputs[] = {mux.getHigh(), mux.getLow()};
+      if (llvm::any_of(inputs, [](Value v) {
+            Value d = getModuleScopedDriver(v, /*lookThroughWires=*/true,
+                                            /*lookThroughNodes=*/true,
+                                            /*lookThroughCasts=*/true);
+            return d && d.getDefiningOp<ClockGateIntrinsicOp>();
+          }))
+        mlir::emitRemark(mux.getLoc())
+            << "gated clock conversion: clock selection is not supported; the "
+               "clock gate feeding this mux was left in place";
+    }
+
+    // Any other op generating the clock is a base clock; stop tracing here.
+    LLVM_DEBUG(llvm::dbgs() << "  base clock\n");
+    baseClks.push_back(clk);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "[analyzeFrom] " << baseClks.size()
+                          << " base clocks\n");
+  return result;
+}
+
+void GatedClockConversion::computeGatedClocks() {
+  // Forward closure of every `Gate` edge over `srcToDstClocks`.
+  SmallVector<Value> worklist;
+  for (const auto &[src, edges] : srcToDstClocks)
+    for (const auto &edge : edges)
+      if (edge.kind == EdgeKind::Gate && gatedClocks.insert(edge.dst).second)
+        worklist.push_back(edge.dst);
+
+  // Iterating a DenseMap above is fine: the result is a set, not an order.
+  while (!worklist.empty()) {
+    Value clk = worklist.pop_back_val();
+    auto it = srcToDstClocks.find(clk);
+    if (it == srcToDstClocks.end())
+      continue;
+    for (const auto &edge : it->second)
+      if (gatedClocks.insert(edge.dst).second)
+        worklist.push_back(edge.dst);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "[computeGatedClocks] " << gatedClocks.size()
+                          << " gated clock values\n");
+}
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: debug printing
+//===----------------------------------------------------------------------===//
+
+void GatedClockConversion::dump() const {
+  llvm::dbgs() << "=== srcToDstClocks ===\n";
+  for (const auto &[srcClk, dstList] : srcToDstClocks) {
+    llvm::dbgs() << "Source clock: " << getParentModule(srcClk).getModuleName()
+                 << "\n";
+    srcClk.print(llvm::dbgs());
+    llvm::dbgs() << "\n";
+    for (const auto &edge : dstList) {
+      llvm::dbgs() << "  -> Destination clock: "
+                   << getParentModule(edge.dst).getModuleName() << "\n";
+      edge.dst.print(llvm::dbgs());
+      llvm::dbgs() << " via op: ";
+      if (edge.op)
+        edge.op->print(llvm::dbgs());
+      else
+        llvm::dbgs() << "<alias>";
+      llvm::dbgs() << " [" << edgeKindName(edge.kind) << "]\n";
+    }
+  }
+  llvm::dbgs() << "=== Base clocks ===\n";
+  for (const auto &baseClk : baseClks) {
+    llvm::dbgs() << "  ";
+    baseClk.print(llvm::dbgs());
+    llvm::dbgs() << "\n";
+  }
+  llvm::dbgs() << "======================\n";
+}

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+#include <deque>
 
 #define DEBUG_TYPE "firrtl-gated-clock-conversion"
 
@@ -314,6 +315,150 @@ LogicalResult GatedClockConversion::analyzeFrom(ArrayRef<Value> seeds) {
   return result;
 }
 
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: planning (no IR mutation)
+//===----------------------------------------------------------------------===//
+
+void GatedClockConversion::planAlias(Value dstClk, FModuleOp srcMod,
+                                     MatRef baseClk, unsigned enableId) {
+  if (enableId == kNoEnable) {
+    clockEnablePairs[dstClk] = {baseClk, kNoEnable};
+    return;
+  }
+  // A wire pair carries (base, enable) past the alias;
+  // eliminateTemporaryWires() forwards it away when safe.
+  unsigned wireId = 2 * wirePlans.size();
+  wirePlans.push_back({srcMod, baseClk, enableId, dstClk.getLoc()});
+  clockEnablePairs[dstClk] = {
+      MatRef::plannedWire(wireId),
+      newEnableLeaf(MatRef::plannedWire(wireId + 1), dstClk.getLoc())};
+}
+
+void GatedClockConversion::planGate(ClockGateIntrinsicOp gate, Value dstClk,
+                                    MatRef baseClk, unsigned enableId) {
+  // The base clock passes through unchanged, so cascaded gates all resolve to
+  // the same ungated base.
+  auto gateEn = newEnableNode(enableId, MatRef::gateEnable(gate), gate.getLoc(),
+                              /*anchor=*/MatRef::of(dstClk));
+  clockEnablePairs[dstClk] = {baseClk, gateEn};
+}
+
+void GatedClockConversion::recordInstanceDrive(InstanceOp inst,
+                                               const PortPairPlan &plan,
+                                               MatRef baseClk,
+                                               unsigned enableId) {
+  assert(plan.dir == Direction::In &&
+         "only input port pairs are driven at the caller");
+  // A clock loop closed through an instance (`inst.clk_in <- inst.clk_out`) is
+  // deliberately not diagnosed here: doing it precisely needs an
+  // instance-path-sensitive analysis, and `firrtl-check-comb-loops` already
+  // rejects such input.
+
+  // Keyed by (instance, port index), so a second edge reaching an already
+  // planned pair from the same caller is a no-op, not a duplicate connect.
+  instanceDrives.try_emplace(
+      {inst, plan.baseIdx},
+      InstanceDrive{inst, plan.baseIdx, plan.enIdx, baseClk, enableId});
+}
+
+std::pair<unsigned, unsigned>
+GatedClockConversion::planGatedPorts(InstanceOp inst, FModuleOp childMod,
+                                     unsigned gatedClkIndex, Direction dir,
+                                     MatRef baseClk, unsigned enableId) {
+  PortPlanKey key{childMod, gatedClkIndex};
+  auto *it = portPlans.find(key);
+  if (it == portPlans.end()) {
+    // The final indices are known already: `insertPlannedPorts()` only appends
+    // ports, so existing indices never shift (asserted when applying).
+    unsigned &nextIdx =
+        nextPortIdx.try_emplace(childMod, childMod.getNumPorts()).first->second;
+    PortPairPlan plan({childMod, gatedClkIndex, dir, nextIdx, nextIdx + 1});
+    nextIdx += 2;
+    if (dir == Direction::Out) {
+      assert(enableId != kNoEnable &&
+             "unless this is a gated clock, no need to add output enable port");
+      plan.outBaseClk = baseClk;
+      plan.outEnableId = enableId;
+    }
+    it = portPlans.insert({key, plan}).first;
+    plansPerModule[childMod].push_back(key);
+  }
+
+  const PortPairPlan &plan = it->second;
+  assert(plan.dir == dir && "a port cannot change direction");
+  // Every caller of the module must drive a planned input pair.
+  if (dir == Direction::In)
+    recordInstanceDrive(inst, plan, baseClk, enableId);
+  return {plan.baseIdx, plan.enIdx};
+}
+
+void GatedClockConversion::planInstancePort(Direction dir, InstanceOp inst,
+                                            Value dstClk, Value srcClk,
+                                            MatRef baseClk, unsigned enableId) {
+  auto childMod =
+      dyn_cast_or_null<FModuleOp>(inst.getReferencedModule(ig).getOperation());
+  auto gatedClkIndex = cast<OpResult>(srcClk).getResultNumber();
+  if (enableId == kNoEnable) {
+    if (dir == Direction::Out) {
+      // Symbolic, because a port pair for a *different* clock port of this
+      // module would clone all of its instances.
+      clockEnablePairs[dstClk] = {MatRef::of(dstClk), kNoEnable};
+      return;
+    }
+    // This instance drives an ungated clock input, but a sibling instance may
+    // drive a gated one, in which case the pair is added for *every* instance.
+    // `gatedClocks` answers that without blocking on the sibling's pair, which
+    // in a same-module cascade would depend on this very port.
+    if (!gatedClocks.contains(dstClk)) {
+      clockEnablePairs[dstClk] = {MatRef::of(dstClk), kNoEnable};
+      return;
+    }
+
+    // A sibling is gated: add the pair here too. `kNoEnable` on the resulting
+    // instance drive connects a constant 1.
+  }
+  assert((enableId == kNoEnable || dir == Direction::Out ||
+          gatedClocks.contains(dstClk)) &&
+         "a gated pair must imply a gated mark");
+  auto [baseClkIndex, enableIndex] =
+      planGatedPorts(inst, childMod, gatedClkIndex, dir, baseClk, enableId);
+
+  // An output pair is read on the instance result side, an input pair on the
+  // child's block-argument side. Neither exists yet, hence symbolic refs.
+  MatRef baseRef, enRef;
+  if (dir == Direction::Out) {
+    baseRef = MatRef::instResult(inst, baseClkIndex);
+    enRef = MatRef::instResult(inst, enableIndex);
+  } else {
+    baseRef = MatRef::moduleArg(childMod, baseClkIndex);
+    enRef = MatRef::moduleArg(childMod, enableIndex);
+  }
+  assert((dir == Direction::Out ? inst->getParentOfType<FModuleOp>()
+                                : childMod) == getParentModule(dstClk) &&
+         "parent modules must match");
+  clockEnablePairs[dstClk] = {baseRef, newEnableLeaf(enRef, dstClk.getLoc())};
+}
+
+void GatedClockConversion::planMultiplyInstantiatedInput(Value srcClk,
+                                                         MatRef baseClk,
+                                                         unsigned enableId) {
+  // `srcClk` is a result of the caller instance; drive the port pair that an
+  // earlier caller of this module already planned.
+  auto inst = srcClk.getDefiningOp<InstanceOp>();
+  assert(inst);
+  auto childMod =
+      dyn_cast_or_null<FModuleOp>(inst.getReferencedModule(ig).getOperation());
+  auto gatedClkIndex = cast<OpResult>(srcClk).getResultNumber();
+  auto *it = portPlans.find({childMod, gatedClkIndex});
+  // No plan means an output port, which the InstanceOut path handles.
+  if (it == portPlans.end()) {
+    LLVM_DEBUG(llvm::dbgs() << "  no plan for index " << gatedClkIndex
+                            << ", skipping drive (handled by InstanceOut)\n");
+    return;
+  }
+  recordInstanceDrive(inst, it->second, baseClk, enableId);
+}
+
 void GatedClockConversion::computeGatedClocks() {
   // Forward closure of every `Gate` edge over `srcToDstClocks`.
   SmallVector<Value> worklist;
@@ -334,6 +479,75 @@ void GatedClockConversion::computeGatedClocks() {
   }
   LLVM_DEBUG(llvm::dbgs() << "[computeGatedClocks] " << gatedClocks.size()
                           << " gated clock values\n");
+}
+
+Value GatedClockConversion::processEdge(const ClockEdge &edge, Value srcClk,
+                                        FModuleOp srcMod, MatRef baseClk,
+                                        unsigned enableId) {
+  LLVM_DEBUG(llvm::dbgs() << "  edge kind=" << edgeKindName(edge.kind) << "\n");
+
+  if (clockEnablePairs.count(edge.dst)) {
+    // For InstanceIn this is a multiply-instantiated module whose ports an
+    // earlier caller planned; this caller still has to drive them.
+    if (edge.kind == EdgeKind::InstanceIn)
+      planMultiplyInstantiatedInput(srcClk, baseClk, enableId);
+    return Value();
+  }
+
+  switch (edge.kind) {
+  case EdgeKind::Alias:
+    planAlias(edge.dst, srcMod, baseClk, enableId);
+    break;
+  case EdgeKind::Gate:
+    planGate(edge.gate(), edge.dst, baseClk, enableId);
+    break;
+  case EdgeKind::InstanceIn:
+    planInstancePort(Direction::In, edge.instance(), edge.dst, srcClk, baseClk,
+                     enableId);
+    break;
+  case EdgeKind::InstanceOut:
+    planInstancePort(Direction::Out, edge.instance(), edge.dst, edge.dst,
+                     baseClk, enableId);
+    break;
+  }
+  // `edge.dst` now has a pair, so it is safe to visit next.
+  assert(clockEnablePairs.count(edge.dst) && "the destination must be planned");
+  return edge.dst;
+}
+
+void GatedClockConversion::plan() {
+  LLVM_DEBUG(llvm::dbgs() << "[plan] " << baseClks.size() << " base clocks\n");
+  // Propagate (base, enable) pairs from the base clocks through the clock flow
+  // graph, planning ports as needed.
+  //
+  // This terminates on any graph, cyclic or not: a node is enqueued only once
+  // it has a pair and `processEdge` skips destinations that already have one.
+  // Clocks in a loop with no base clock are never planned; `run()` reports
+  // them.
+  //
+  // BFS rather than DFS purely to keep the emission order stable.
+  std::deque<Value> worklist(baseClks.begin(), baseClks.end());
+  for (auto baseClk : baseClks)
+    clockEnablePairs[baseClk] = {MatRef::of(baseClk), kNoEnable};
+
+  while (!worklist.empty()) {
+    auto srcClk = worklist.front();
+    worklist.pop_front();
+    FModuleOp srcMod = getParentModule(srcClk);
+
+    auto it = clockEnablePairs.find(srcClk);
+    assert(it != clockEnablePairs.end() &&
+           "a node is only enqueued once it has a pair");
+    // Copy the pair out: `processEdge` inserts into `clockEnablePairs` and
+    // invalidates `it`.
+    MatRef baseClk = it->second.baseClk;
+    unsigned enableId = it->second.enableId;
+
+    for (auto &edge : srcToDstClocks[srcClk])
+      if (Value next = processEdge(edge, srcClk, srcMod, baseClk, enableId))
+        worklist.push_back(next);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "[plan] complete\n");
 }
 
 //===----------------------------------------------------------------------===//
@@ -366,4 +580,65 @@ void GatedClockConversion::dump() const {
     llvm::dbgs() << "\n";
   }
   llvm::dbgs() << "======================\n";
+}
+
+void GatedClockConversion::dumpPlan() const {
+  auto &os = llvm::dbgs();
+  auto printEnable = [&](unsigned id) {
+    if (id == kNoEnable) {
+      os << "<none>";
+      return;
+    }
+    // Print the accumulation chain leaf-to-root, i.e. as it will be ANDed.
+    for (unsigned cur = id; cur != kNoEnable; cur = enableNodes[cur].parent) {
+      if (cur != id)
+        os << " & ";
+      enableNodes[cur].term.print(os);
+    }
+  };
+
+  os << "=== Planned wire pairs ===\n";
+  for (auto [index, wirePlan] : llvm::enumerate(wirePlans)) {
+    FModuleOp mod = wirePlan.mod;
+    os << "  #" << 2 * index << "/" << 2 * index + 1 << " in "
+       << mod.getModuleName() << " <- ";
+    wirePlan.baseClk.print(os);
+    os << ", ";
+    printEnable(wirePlan.enableId);
+    os << "\n";
+  }
+  os << "=== Planned port pairs ===\n";
+  for (const auto &[key, portPlan] : portPlans) {
+    FModuleOp mod = portPlan.mod;
+    os << "  " << mod.getModuleName() << "."
+       << mod.getPortName(portPlan.gatedClkIndex) << ": "
+       << (portPlan.dir == Direction::In ? "in" : "out") << " @"
+       << portPlan.baseIdx << "/" << portPlan.enIdx;
+    if (portPlan.dir == Direction::Out) {
+      os << " <- ";
+      portPlan.outBaseClk.print(os);
+      os << ", ";
+      printEnable(portPlan.outEnableId);
+    }
+    os << "\n";
+  }
+  os << "=== Planned instance drives ===\n";
+  for (const auto &[key, drive] : instanceDrives) {
+    InstanceOp inst = drive.inst;
+    os << "  " << inst.getName() << " @" << drive.baseIdx << "/" << drive.enIdx
+       << " <- ";
+    drive.baseClk.print(os);
+    os << ", ";
+    printEnable(drive.enableId);
+    os << "\n";
+  }
+  os << "=== Planned root rewrites ===\n";
+  for (const auto &rewrite : rootRewrites) {
+    os << "  " << rewrite.op->getName() << " <- ";
+    rewrite.baseClk.print(os);
+    os << ", ";
+    printEnable(rewrite.enableId);
+    os << "\n";
+  }
+  os << "======================\n";
 }

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -44,6 +44,14 @@ StringRef edgeKindName(EdgeKind kind) {
   return "?";
 }
 
+/// The gate's effective enable, `enable | test_enable` or just `enable`.
+Value materializeGateEnable(ClockGateIntrinsicOp gate) {
+  if (!gate.getTestEnable())
+    return gate.getEnable();
+  ImplicitLocOpBuilder b(gate.getLoc(), gate);
+  return b.createOrFold<OrPrimOp>(gate.getEnable(), gate.getTestEnable());
+}
+
 /// The FModuleOp `value` lives in.
 FModuleOp getParentModule(Value value) {
   if (isa<BlockArgument>(value))
@@ -68,6 +76,109 @@ Value clockOperandOf(Operation *op) {
 }
 
 } // namespace
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: the plan's value model
+//===----------------------------------------------------------------------===//
+
+void GatedClockConversion::MatRef::print(llvm::raw_ostream &os) const {
+  switch (kind) {
+  case Kind::None:
+    os << "<none>";
+    return;
+  case Kind::Direct:
+    os << "direct(" << value << ")";
+    return;
+  case Kind::InstResult:
+    os << "instResult(" << cast<InstanceOp>(op).getName() << ", " << index
+       << ")";
+    return;
+  case Kind::ModuleArg:
+    os << "moduleArg(" << cast<FModuleOp>(op).getModuleName() << ", " << index
+       << ")";
+    return;
+  case Kind::PlannedWire:
+    os << "plannedWire(" << index << ")";
+    return;
+  case Kind::GateEnable:
+    os << "gateEnable(" << *op << ")";
+    return;
+  }
+}
+
+Value GatedClockConversion::resolve(MatRef ref) {
+  switch (ref.getKind()) {
+  case MatRef::Kind::None:
+    return Value();
+  case MatRef::Kind::Direct:
+    return ref.getValue();
+  case MatRef::Kind::InstResult:
+    return liveInstance(ref.getOp())->getResult(ref.getIndex());
+  case MatRef::Kind::ModuleArg:
+    return cast<FModuleOp>(ref.getOp())
+        .getBodyBlock()
+        ->getArgument(ref.getIndex());
+  case MatRef::Kind::PlannedWire:
+    return plannedWireValues[ref.getIndex()];
+  case MatRef::Kind::GateEnable:
+    return gateEnableOf(ref.gate());
+  }
+  llvm_unreachable("unhandled MatRef kind");
+}
+
+unsigned GatedClockConversion::newEnableNode(unsigned parent, MatRef term,
+                                             Location loc, MatRef anchor) {
+  enableNodes.push_back({parent, term, anchor, loc});
+  return enableNodes.size() - 1;
+}
+
+Value GatedClockConversion::lower(unsigned enableId) {
+  if (enableId == kNoEnable)
+    return Value();
+  loweredEnables.resize(enableNodes.size());
+  if (Value cached = loweredEnables[enableId])
+    return cached;
+
+  // Walk up to the first already-lowered node, then emit from there back down.
+  // Iterative so that a long gate cascade cannot overflow the stack.
+  SmallVector<unsigned> chain;
+  unsigned cur = enableId;
+  while (cur != kNoEnable && !loweredEnables[cur]) {
+    chain.push_back(cur);
+    cur = enableNodes[cur].parent;
+  }
+
+  Value upstream = cur == kNoEnable ? Value() : loweredEnables[cur];
+  for (unsigned id : llvm::reverse(chain)) {
+    const EnableNode &node = enableNodes[id];
+    Value result = resolve(node.term);
+    if (node.parent != kNoEnable) {
+      // AND with the upstream enable, so the register holds whenever any gate
+      // in the chain is closed. The anchor is the clock this enable
+      // accompanies, which dominates every consumer of the pair.
+      assert(upstream && "an upstream enable must lower to a value");
+      ImplicitLocOpBuilder builder(node.loc, context);
+      builder.setInsertionPointAfterValue(resolve(node.anchor));
+      result = builder.createOrFold<AndPrimOp>(upstream, result);
+    }
+    loweredEnables[id] = result;
+    upstream = result;
+  }
+  return upstream;
+}
+
+//===----------------------------------------------------------------------===//
+// GatedClockConversion: value materialization helpers
+//===----------------------------------------------------------------------===//
+
+Value GatedClockConversion::gateEnableOf(ClockGateIntrinsicOp gate) {
+  auto it = gateEnableCache.find(gate);
+  if (it != gateEnableCache.end())
+    return it->second;
+  Value v = materializeGateEnable(gate);
+  gateEnableCache[gate] = v;
+  return v;
+}
 
 //===----------------------------------------------------------------------===//
 // GatedClockConversion: worklist analysis (no IR mutation)

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -18,6 +18,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
@@ -765,6 +766,53 @@ LogicalResult GatedClockConversion::applyPlan() {
   createPlannedWires();
   insertPlannedPorts();
   return emitPlannedIR();
+}
+
+void GatedClockConversion::eliminateTemporaryWires() {
+  DenseMap<FModuleOp, mlir::DominanceInfo> dominanceInfo;
+  for (auto wire : wireOps) {
+    auto wireData = wire.getData();
+    FModuleOp mod = wire->getParentOfType<FModuleOp>();
+    if (!dominanceInfo.count(mod))
+      dominanceInfo.try_emplace(mod, mod);
+    auto &modDomInfo = dominanceInfo.find(mod)->second;
+
+    FConnectLike writeConnect = {}; // Connect writing to the wire.
+    bool cannotRemove = false;
+    SmallVector<Operation *> wireReaders;
+
+    for (auto *user : wireData.getUsers()) {
+      if (auto connect = dyn_cast<MatchingConnectOp>(user)) {
+        if (connect.getDest() == wireData) {
+          // A second write means we can't safely forward; bail out.
+          if (writeConnect) {
+            cannotRemove = true;
+            break;
+          }
+          writeConnect = connect;
+          continue;
+        }
+      } else if (!isa<RegOp, RegResetOp, RefForceOp, RefReleaseOp, MuxPrimOp>(
+                     user)) {
+        // Unhandled user; can't optimize.
+        cannotRemove = true;
+        break;
+      }
+      wireReaders.push_back(user);
+    }
+    if (cannotRemove || !writeConnect)
+      continue;
+
+    // Bypass the wire if the write dominates every read.
+    Value writeSource = writeConnect.getSrc();
+    if (llvm::all_of(wireReaders, [&](Operation *user) {
+          return modDomInfo.dominates(writeConnect, user);
+        })) {
+      wireData.replaceAllUsesWith(writeSource);
+      writeConnect.erase();
+      wire.erase();
+    }
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -316,6 +316,69 @@ LogicalResult GatedClockConversion::analyzeFrom(ArrayRef<Value> seeds) {
 }
 
 //===----------------------------------------------------------------------===//
+// GatedClockConversion: root rewriting
+//===----------------------------------------------------------------------===//
+
+LogicalResult GatedClockConversion::rewriteRoot(Operation *op, Value baseClk,
+                                                Value enable) {
+  if (!enable)
+    return success();
+
+  // RefForce/RefRelease: rebind the clock to the ungated base and fold the
+  // enable into the predicate.
+  if (auto fop = dyn_cast<RefForceOp>(op)) {
+    fop.getClockMutable().assign(baseClk);
+    ImplicitLocOpBuilder b(fop.getLoc(), fop);
+    fop.getPredicateMutable().assign(
+        b.createOrFold<AndPrimOp>(fop.getPredicate(), enable));
+    return success();
+  }
+  if (auto rop = dyn_cast<RefReleaseOp>(op)) {
+    rop.getClockMutable().assign(baseClk);
+    ImplicitLocOpBuilder b(rop.getLoc(), rop);
+    rop.getPredicateMutable().assign(
+        b.createOrFold<AndPrimOp>(rop.getPredicate(), enable));
+    return success();
+  }
+
+  Value regData;
+  if (auto reg = dyn_cast<RegOp>(op))
+    regData = reg.getData();
+  else if (auto regr = dyn_cast<RegResetOp>(op))
+    regData = regr.getData();
+  else
+    return op->emitError("unsupported for gated clock conversion");
+
+  // ExpandWhens leaves exactly one write per register. Rebinding the clock
+  // without sinking the enable would silently drop the gate, so bail out if
+  // that precondition does not hold.
+  FConnectLike dataWrite;
+  unsigned writers = 0;
+  for (auto &use : regData.getUses()) {
+    auto fconn = dyn_cast<FConnectLike>(use.getOwner());
+    if (fconn && fconn.getDest() == regData) {
+      ++writers;
+      dataWrite = fconn;
+    }
+  }
+  if (writers != 1) {
+    op->emitWarning() << "gated clock conversion: expected exactly one connect "
+                         "driving this register (run after "
+                         "firrtl-expand-whens); found "
+                      << writers << "; leaving the gated clock in place";
+    return success();
+  }
+
+  // Rebind to the ungated base and wrap the write with mux(enable, RHS,
+  // regData), so the register holds while the clock gate is closed.
+  op->setOperand(0, baseClk);
+  ImplicitLocOpBuilder b(dataWrite.getLoc(), dataWrite);
+  Value newRhs = b.createOrFold<MuxPrimOp>(enable, dataWrite.getSrc(), regData);
+  dataWrite->setOperand(1, newRhs);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // GatedClockConversion: planning (no IR mutation)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/GatedClockConversion.cpp
+++ b/lib/Dialect/FIRRTL/GatedClockConversion.cpp
@@ -816,6 +816,68 @@ void GatedClockConversion::eliminateTemporaryWires() {
 }
 
 //===----------------------------------------------------------------------===//
+// GatedClockConversion: the driver
+//===----------------------------------------------------------------------===//
+
+LogicalResult GatedClockConversion::run() {
+  LLVM_DEBUG(llvm::dbgs() << "===== GatedClockConversion::run() =====\n");
+
+  if (roots.empty())
+    return success();
+  context = roots[0].first->getContext();
+  clockType = ClockType::get(context);
+  u1Type = UIntType::get(context, 1);
+
+  // Phase 1: analysis. A failure here means invalid input; the IR is untouched,
+  // so returning early leaves it intact.
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 1: Analysis ---\n");
+  if (failed(analyzeFrom(llvm::to_vector(llvm::make_second_range(roots)))))
+    return failure();
+  LLVM_DEBUG(dump());
+
+  computeGatedClocks();
+
+  // Phase 2: plan the whole mutation. Still no IR mutation.
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 2: Planning ---\n");
+  plan();
+
+  // Record the root rewrites now, so that nothing reads `clockEnablePairs`
+  // after the IR has been mutated.
+  for (auto &[op, clk] : roots) {
+    auto it = clockEnablePairs.find(clk);
+    // An unplanned clock is one no base clock reaches, i.e. a clock feedback
+    // loop, which is invalid input. Skipping the rewrite is always safe.
+    if (it == clockEnablePairs.end()) {
+      mlir::emitWarning(clk.getLoc())
+          << "gated clock conversion: this clock is not reachable from any "
+             "free-running base clock (clock feedback loop?); leaving the op "
+             "unchanged";
+      continue;
+    }
+    rootRewrites.push_back({op, it->second.baseClk, it->second.enableId});
+  }
+  LLVM_DEBUG(dumpPlan());
+
+  // Phase 3: apply the plan. This is the only phase that mutates the IR.
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 3: Applying the plan ---\n");
+  if (failed(applyPlan()))
+    return failure();
+
+  // Phase 4: cleanup. Nothing reads the plan any more, so the instances that
+  // were replaced can be erased.
+  LLVM_DEBUG(llvm::dbgs() << "--- Phase 4: Cleanup (" << deadInstances.size()
+                          << " ops) ---\n");
+  eliminateTemporaryWires();
+  for (auto oldInst : deadInstances)
+    oldInst.erase();
+  deadInstances.clear();
+
+  roots.clear();
+  LLVM_DEBUG(llvm::dbgs() << "===== run() complete =====\n");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // GatedClockConversion: debug printing
 //===----------------------------------------------------------------------===//
 

--- a/test/Analysis/firrtl-gated-clock-conversion.mlir
+++ b/test/Analysis/firrtl-gated-clock-conversion.mlir
@@ -63,14 +63,12 @@ firrtl.circuit "TwoGates" {
 firrtl.circuit "WireAlias" {
   firrtl.module @WireAlias(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
                            in %d: !firrtl.uint<8>) {
-    // The base clock and enable are propagated onto wires; the register is
-    // rebound to the base-clock wire and muxed with the enable wire.
-    // CHECK: %[[CW:.+]] = firrtl.wire : !firrtl.clock
-    // CHECK: %[[EW:.+]] = firrtl.wire : !firrtl.uint<1>
-    // CHECK: firrtl.matchingconnect %[[CW]], %clk
-    // CHECK: firrtl.matchingconnect %[[EW]], %en
-    // CHECK: %[[R:.+]] = firrtl.reg %[[CW]] : !firrtl.clock, !firrtl.uint<8>
-    // CHECK: %[[MUX:.+]] = firrtl.mux(%[[EW]], %d, %[[R]])
+    // The gated clock is still created and connected to the wire
+    // CHECK: firrtl.int.clock_gate %clk, %en
+    // CHECK: %[[W:.+]] = firrtl.wire : !firrtl.clock
+    // The register is rebound to the base clock and muxed with the enable
+    // CHECK: %[[R:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX:.+]] = firrtl.mux(%en, %d, %[[R]])
     // CHECK: firrtl.matchingconnect %[[R]], %[[MUX]]
     %g = firrtl.int.clock_gate %clk, %en
     %w = firrtl.wire : !firrtl.clock
@@ -428,7 +426,9 @@ firrtl.circuit "TestEnableHierarchy" {
 
 // CHECK-LABEL: firrtl.module @DeeplyNested
 firrtl.circuit "DeeplyNested" {
-  firrtl.layer @A bind {}
+  firrtl.layer @A bind {
+    firrtl.layer @B bind {}
+  }
 
   firrtl.module @DeepChild(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
     %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
@@ -440,29 +440,21 @@ firrtl.circuit "DeeplyNested" {
                               in %selector: !firrtl.enum<A: uint<8>, B: uint<8>>,
                               in %cond: !firrtl.uint<1>,
                               in %d: !firrtl.uint<8>) {
-    // CHECK: %[[G:.+]] = firrtl.int.clock_gate %clk, %en
+    // CHECK: firrtl.int.clock_gate %clk, %en
     %g = firrtl.int.clock_gate %clk, %en
 
-    // CHECK: firrtl.match %selector
-    firrtl.match %selector : !firrtl.enum<A: uint<8>, B: uint<8>> {
-      case A(%arg0) {
-        // CHECK: firrtl.when %cond
-        firrtl.when %cond : !firrtl.uint<1> {
-          // CHECK: firrtl.layerblock @A
-          firrtl.layerblock @A {
-            // CHECK: %{{.+}}, %{{.+}}, %[[INST_BASE:.+]], %[[INST_EN:.+]] = firrtl.instance deep_child @DeepChild
-            // CHECK-SAME: in [[GBASE_NAME:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
-            // CHECK-SAME: in [[GEN_NAME:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
-            %child_clk, %child_data = firrtl.instance deep_child @DeepChild(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
-            firrtl.matchingconnect %child_clk, %g : !firrtl.clock
-            firrtl.matchingconnect %child_data, %arg0 : !firrtl.uint<8>
-            // CHECK: firrtl.matchingconnect %[[INST_BASE]], %clk
-            // CHECK: firrtl.matchingconnect %[[INST_EN]], %en
-          }
-        }
-      }
-      case B(%arg0) {
-        // Empty case
+    // CHECK: firrtl.layerblock @A
+    // CHECK: firrtl.layerblock @A::@B
+    // CHECK: %{{.+}}, %{{.+}}, %[[INST_BASE:.+]], %[[INST_EN:.+]] = firrtl.instance deep_child @DeepChild
+    // CHECK-SAME: in {{[A-Za-z0-9_]*_gatedClock_baseClock_clk}}: !firrtl.clock
+    // CHECK-SAME: in {{[A-Za-z0-9_]*_gatedClock_enable_clk}}: !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %[[INST_BASE]], %clk
+    // CHECK: firrtl.matchingconnect %[[INST_EN]], %en
+    firrtl.layerblock @A {
+      firrtl.layerblock @A::@B {
+        %child_clk, %child_data = firrtl.instance deep_child @DeepChild(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+        firrtl.matchingconnect %child_clk, %g : !firrtl.clock
+        firrtl.matchingconnect %child_data, %d : !firrtl.uint<8>
       }
     }
   }
@@ -492,8 +484,6 @@ firrtl.circuit "DeeplyNested" {
 // CHECK:         firrtl.matchingconnect %[[R2]], %[[MUX2]]
 
 // CHECK-LABEL: firrtl.module @DifferentGating
-// CHECK:         %[[C1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK:         %[[C1_0:.+]] = firrtl.constant 1 : !firrtl.uint<1>
 firrtl.circuit "DifferentGating" {
   firrtl.module @FlexibleChild(in %clk1: !firrtl.clock,
                                in %clk2: !firrtl.clock,
@@ -508,9 +498,10 @@ firrtl.circuit "DifferentGating" {
                                  in %en1: !firrtl.uint<1>,
                                  in %en2: !firrtl.uint<1>,
                                  in %d: !firrtl.uint<8>) {
-    // CHECK: %[[G1:.+]] = firrtl.int.clock_gate %base_clk, %en1
+    // CHECK: %[[C1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+    // CHECK: firrtl.int.clock_gate %base_clk, %en1
     %g1 = firrtl.int.clock_gate %base_clk, %en1
-    // CHECK: %[[G2:.+]] = firrtl.int.clock_gate %base_clk, %en2
+    // CHECK: firrtl.int.clock_gate %base_clk, %en2
     %g2 = firrtl.int.clock_gate %base_clk, %en2
 
     // First instance: gate on clk1, ungated on clk2
@@ -519,11 +510,8 @@ firrtl.circuit "DifferentGating" {
       in clk1: !firrtl.clock,
       in clk2: !firrtl.clock,
       in data: !firrtl.uint<8>)
-    // CHECK: firrtl.matchingconnect %{{.+}}, %[[G1]]
     firrtl.matchingconnect %inst1_clk1, %g1 : !firrtl.clock
-    // CHECK: firrtl.matchingconnect %{{.+}}, %base_clk
     firrtl.matchingconnect %inst1_clk2, %base_clk : !firrtl.clock
-    // CHECK: firrtl.matchingconnect %{{.+}}, %d
     firrtl.matchingconnect %inst1_data, %d : !firrtl.uint<8>
 
     // Second instance: ungated on clk1, gate on clk2
@@ -532,25 +520,22 @@ firrtl.circuit "DifferentGating" {
       in clk1: !firrtl.clock,
       in clk2: !firrtl.clock,
       in data: !firrtl.uint<8>)
-    // CHECK: firrtl.matchingconnect %{{.+}}, %base_clk
     firrtl.matchingconnect %inst2_clk1, %base_clk : !firrtl.clock
-    // CHECK: firrtl.matchingconnect %{{.+}}, %[[G2]]
     firrtl.matchingconnect %inst2_clk2, %g2 : !firrtl.clock
-    // CHECK: firrtl.matchingconnect %{{.+}}, %d
     firrtl.matchingconnect %inst2_data, %d : !firrtl.uint<8>
     // The new (base, enable) ports are connected after the original instance connects
     // Instance1: ungated clk2 connects
     // CHECK: firrtl.matchingconnect %[[I1_CLK2_BASE]], %base_clk
-    // CHECK: firrtl.matchingconnect %[[I1_CLK2_EN]], %[[C1_0]]
-    // Instance2: ungated clk1 connects
-    // CHECK: firrtl.matchingconnect %[[I2_CLK1_BASE]], %base_clk
-    // CHECK: firrtl.matchingconnect %[[I2_CLK1_EN]], %[[C1]]
+    // CHECK: firrtl.matchingconnect %[[I1_CLK2_EN]], %[[C1]]
     // Instance2: gated clk2 connects
     // CHECK: firrtl.matchingconnect %[[I2_CLK2_BASE]], %base_clk
     // CHECK: firrtl.matchingconnect %[[I2_CLK2_EN]], %en2
     // Instance1: gated clk1 connects
     // CHECK: firrtl.matchingconnect %[[I1_CLK1_BASE]], %base_clk
     // CHECK: firrtl.matchingconnect %[[I1_CLK1_EN]], %en1
+    // Instance2: ungated clk1 connects (reuses the same constant)
+    // CHECK: firrtl.matchingconnect %[[I2_CLK1_BASE]], %base_clk
+    // CHECK: firrtl.matchingconnect %[[I2_CLK1_EN]], %[[C1]]
   }
 }
 
@@ -584,6 +569,8 @@ firrtl.circuit "DifferentGating" {
 
 // CHECK-LABEL: firrtl.module @InstanceOutput
 firrtl.circuit "InstanceOutput" {
+  firrtl.layer @TestLayer bind {}
+
   firrtl.module @Producer(in %clk: !firrtl.clock, out %out_clk: !firrtl.clock) {
     firrtl.matchingconnect %out_clk, %clk : !firrtl.clock
   }
@@ -597,33 +584,205 @@ firrtl.circuit "InstanceOutput" {
                                 in %en: !firrtl.uint<1>,
                                 in %cond: !firrtl.uint<1>,
                                 in %d: !firrtl.uint<8>) {
-    // CHECK: %[[WIRE_BASE:.+]] = firrtl.wire : !firrtl.clock
-    // CHECK: %[[WIRE_EN:.+]] = firrtl.wire : !firrtl.uint<1>
     // CHECK: %[[GATE:.+]] = firrtl.int.clock_gate %base_clk, %en
     %gated = firrtl.int.clock_gate %base_clk, %en
-    // CHECK: %[[OUT_WIRE:.+]] = firrtl.wire : !firrtl.clock
-    %out_wire = firrtl.wire : !firrtl.clock
 
-    // CHECK: firrtl.when %cond
-    firrtl.when %cond : !firrtl.uint<1> {
+    // CHECK: firrtl.layerblock @TestLayer
+    firrtl.layerblock @TestLayer {
+      // CHECK: %[[OUT_WIRE:.+]] = firrtl.wire : !firrtl.clock
+      %out_wire = firrtl.wire : !firrtl.clock
+      // CHECK: %[[WIRE_BASE:.+]] = firrtl.wire : !firrtl.clock
+      %wire_base = firrtl.wire : !firrtl.clock
+      // CHECK: %[[WIRE_EN:.+]] = firrtl.wire : !firrtl.uint<1>
+      %wire_en = firrtl.wire : !firrtl.uint<1>
+
       // CHECK: %{{.+}}, %{{.+}}, %[[P_BASE_IN:.+]], %[[P_EN_IN:.+]], %[[P_BASE_OUT:.+]], %[[P_EN_OUT:.+]] = firrtl.instance producer @Producer
       %p_clk, %p_out = firrtl.instance producer @Producer(in clk: !firrtl.clock, out out_clk: !firrtl.clock)
-      // CHECK: firrtl.matchingconnect %[[WIRE_EN]], %[[P_EN_OUT]]
-      // CHECK: firrtl.matchingconnect %[[WIRE_BASE]], %[[P_BASE_OUT]]
-      // CHECK: firrtl.matchingconnect %{{.+}}, %[[GATE]]
       firrtl.matchingconnect %p_clk, %gated : !firrtl.clock
       firrtl.matchingconnect %out_wire, %p_out : !firrtl.clock
+      firrtl.matchingconnect %wire_base, %p_out : !firrtl.clock
+      %c1 = firrtl.constant 1 : !firrtl.uint<1>
+      firrtl.matchingconnect %wire_en, %c1 : !firrtl.uint<1>
+
+      // CHECK: %{{.+}}, %{{.+}}, %[[C_BASE:.+]], %[[C_EN:.+]] = firrtl.instance consumer @Consumer
+      %c_clk, %c_data = firrtl.instance consumer @Consumer(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+      firrtl.matchingconnect %c_clk, %out_wire : !firrtl.clock
+      firrtl.matchingconnect %c_data, %d : !firrtl.uint<8>
+      firrtl.matchingconnect %c_clk, %wire_base : !firrtl.clock
+      firrtl.matchingconnect %c_data, %d : !firrtl.uint<8>
       // CHECK: firrtl.matchingconnect %[[P_BASE_IN]], %base_clk
       // CHECK: firrtl.matchingconnect %[[P_EN_IN]], %en
+      // CHECK: firrtl.matchingconnect %[[C_BASE]], %[[P_BASE_OUT]]
+      // CHECK: firrtl.matchingconnect %[[C_EN]], %[[P_EN_OUT]]
     }
+  }
+}
 
-    // CHECK: %{{.+}}, %{{.+}}, %[[C_BASE:.+]], %[[C_EN:.+]] = firrtl.instance consumer @Consumer
-    %c_clk, %c_data = firrtl.instance consumer @Consumer(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
-    // CHECK: firrtl.matchingconnect %{{.+}}, %[[OUT_WIRE]]
-    firrtl.matchingconnect %c_clk, %out_wire : !firrtl.clock
-    // CHECK: firrtl.matchingconnect %{{.+}}, %d
-    firrtl.matchingconnect %c_data, %d : !firrtl.uint<8>
-    // CHECK: firrtl.matchingconnect %[[C_BASE]], %[[WIRE_BASE]]
-    // CHECK: firrtl.matchingconnect %[[C_EN]], %[[WIRE_EN]]
+// -----
+
+firrtl.circuit "ClockOutOfChild" {
+  firrtl.module @Gen(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                     out %gclk: !firrtl.clock) {
+    %g = firrtl.int.clock_gate %clk, %en
+    firrtl.matchingconnect %gclk, %g : !firrtl.clock
+  }
+  firrtl.module @ClockOutOfChild(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                                 in %d: !firrtl.uint<8>) {
+    %c_clk, %c_en, %c_gclk = firrtl.instance c @Gen(in clk: !firrtl.clock, in en: !firrtl.uint<1>, out gclk: !firrtl.clock)
+    firrtl.matchingconnect %c_clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %c_en, %en : !firrtl.uint<1>
+    %r = firrtl.reg %c_gclk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Same module instantiated twice: gated clock into one instance, ungated into another
+// This tests that the pass correctly inserts (base, enable) ports for the gated
+// instance and uses constant 1 for the enable on the ungated instance.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @FlexibleClockModule
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<8>
+// CHECK-SAME:    in %[[BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[EN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+firrtl.circuit "MixedGatingInstances" {
+  firrtl.module @FlexibleClockModule(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
+    // CHECK: %[[R:.+]] = firrtl.reg %[[BASE]] : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX:.+]] = firrtl.mux(%[[EN]], %data, %[[R]])
+    // CHECK: firrtl.matchingconnect %[[R]], %[[MUX]]
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+
+  // CHECK-LABEL: firrtl.module @MixedGatingInstances
+  firrtl.module @MixedGatingInstances(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>, in %d: !firrtl.uint<8>) {
+    // CHECK: %[[C1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+    // CHECK: firrtl.int.clock_gate %clk, %en
+    // CHECK: %{{.+}}, %{{.+}}, %[[I1_BASE:.+]], %[[I1_EN:.+]] = firrtl.instance inst1 @FlexibleClockModule
+    // CHECK: %{{.+}}, %{{.+}}, %[[I2_BASE:.+]], %[[I2_EN:.+]] = firrtl.instance inst2 @FlexibleClockModule
+    %g = firrtl.int.clock_gate %clk, %en
+
+    // First instance: ungated clock
+    %inst1_clk, %inst1_data = firrtl.instance inst1 @FlexibleClockModule(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %inst1_clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %inst1_data, %d : !firrtl.uint<8>
+
+    // Second instance: gated clock
+    %inst2_clk, %inst2_data = firrtl.instance inst2 @FlexibleClockModule(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %inst2_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %inst2_data, %d : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %[[I1_BASE]], %clk
+    // CHECK: firrtl.matchingconnect %[[I1_EN]], %[[C1]]
+    // CHECK: firrtl.matchingconnect %[[I2_BASE]], %clk
+    // CHECK: firrtl.matchingconnect %[[I2_EN]], %en
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multiple different clocks to the same module: one gated, one ungated
+// Tests that only the gated clock (clk2) gets (base, enable) port pair added.
+// The ungated clock (clk1) remains unchanged and uses the original clock directly.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @DualClockConsumer
+// CHECK-SAME:    in %clk1: !firrtl.clock
+// CHECK-SAME:    in %clk2: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<16>
+// CHECK-SAME:    in %[[CLK2_BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk2]]: !firrtl.clock
+// CHECK-SAME:    in %[[CLK2_EN:[A-Za-z0-9_]*_gatedClock_enable_clk2]]: !firrtl.uint<1>
+firrtl.circuit "MixedClockDomains" {
+  firrtl.module @DualClockConsumer(in %clk1: !firrtl.clock, in %clk2: !firrtl.clock, in %data: !firrtl.uint<16>) {
+    // r1 remains on the original ungated clk1
+    // CHECK: %[[R1:.+]] = firrtl.reg %clk1 : !firrtl.clock, !firrtl.uint<16>
+    // CHECK-NEXT: firrtl.matchingconnect %[[R1]], %data
+    %r1 = firrtl.reg %clk1 : !firrtl.clock, !firrtl.uint<16>
+    firrtl.matchingconnect %r1, %data : !firrtl.uint<16>
+
+    // r2 is rebound to the base clock and gets a mux with the enable
+    // CHECK: %[[R2:.+]] = firrtl.reg %[[CLK2_BASE]] : !firrtl.clock, !firrtl.uint<16>
+    // CHECK: %[[MUX2:.+]] = firrtl.mux(%[[CLK2_EN]], %data, %[[R2]])
+    // CHECK: firrtl.matchingconnect %[[R2]], %[[MUX2]]
+    %r2 = firrtl.reg %clk2 : !firrtl.clock, !firrtl.uint<16>
+    firrtl.matchingconnect %r2, %data : !firrtl.uint<16>
+  }
+
+  // CHECK-LABEL: firrtl.module @MixedClockDomains
+  firrtl.module @MixedClockDomains(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>, in %d: !firrtl.uint<16>) {
+    // CHECK: firrtl.int.clock_gate %clk, %en
+    %g = firrtl.int.clock_gate %clk, %en
+
+    // Instance with one ungated (clk1) and one gated (clk2) clock
+    // Only clk2 gets the gated clock ports
+    // CHECK: %{{.+}}, %{{.+}}, %{{.+}}, %[[C2_BASE:.+]], %[[C2_EN:.+]] = firrtl.instance consumer @DualClockConsumer
+    %c_clk1, %c_clk2, %c_data = firrtl.instance consumer @DualClockConsumer(in clk1: !firrtl.clock, in clk2: !firrtl.clock, in data: !firrtl.uint<16>)
+
+    // clk1 is ungated
+    firrtl.matchingconnect %c_clk1, %clk : !firrtl.clock
+    // clk2 is gated
+    firrtl.matchingconnect %c_clk2, %g : !firrtl.clock
+    firrtl.matchingconnect %c_data, %d : !firrtl.uint<16>
+
+    // Only clk2's base and enable are connected (clk1 needs no extra ports)
+    // CHECK: firrtl.matchingconnect %[[C2_BASE]], %clk
+    // CHECK: firrtl.matchingconnect %[[C2_EN]], %en
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Cyclic clock dependency detection
+// This tests that the pass correctly detects and reports cyclic clock
+// dependencies. In this case:
+// - gen1 creates a gated clock from base with en1
+// - gen2 creates a gated clock from gen1's output with en2
+// - A register uses gen2's output
+//
+// The ClockGen module outputs a clock that depends on its input clock,
+// creating a potential for cyclic dependencies when instances are connected
+// in certain ways.
+//
+// Expected behavior: The transformation detects a cyclic clock dependency
+// (the feedback loop in the clock flow graph) and emits a warning. The circuit
+// may be left unchanged or partially transformed depending on where the cycle
+// is detected.
+//===----------------------------------------------------------------------===//
+
+firrtl.circuit "ClockFeedback" {
+  // This module creates a gated clock from its input and outputs it.
+  // When instantiated in a chain (gen1 -> gen2), it creates a cyclic dependency
+  // in the clock flow graph that the pass detects and warns about:
+  // "warning: cyclic clock dependency: cannot materialize gated clocks"
+  // CHECK-LABEL: firrtl.module @ClockGen
+  // CHECK-SAME: (in %clk_in: !firrtl.clock, in %en: !firrtl.uint<1>, out %clk_out: !firrtl.clock)
+  firrtl.module @ClockGen(in %clk_in: !firrtl.clock, in %en: !firrtl.uint<1>, out %clk_out: !firrtl.clock) {
+    %g = firrtl.int.clock_gate %clk_in, %en
+    firrtl.matchingconnect %clk_out, %g : !firrtl.clock
+  }
+
+  // CHECK-LABEL: firrtl.module @ClockFeedback
+  firrtl.module @ClockFeedback(in %base: !firrtl.clock, in %en1: !firrtl.uint<1>, in %en2: !firrtl.uint<1>, in %d: !firrtl.uint<8>) {
+    // First clock generator: gates base with en1
+    %gen1_in, %gen1_en, %gen1_out = firrtl.instance gen1 @ClockGen(in clk_in: !firrtl.clock, in en: !firrtl.uint<1>, out clk_out: !firrtl.clock)
+    firrtl.matchingconnect %gen1_in, %base : !firrtl.clock
+    firrtl.matchingconnect %gen1_en, %en1 : !firrtl.uint<1>
+
+    // Second clock generator: gates gen1_out with en2 (cascaded gating)
+    // This creates a feedback loop when the pass tries to analyze the clock dependencies
+    %gen2_in, %gen2_en, %gen2_out = firrtl.instance gen2 @ClockGen(in clk_in: !firrtl.clock, in en: !firrtl.uint<1>, out clk_out: !firrtl.clock)
+    firrtl.matchingconnect %gen2_in, %gen1_out : !firrtl.clock
+    firrtl.matchingconnect %gen2_en, %en2 : !firrtl.uint<1>
+
+    // Register clocked by the doubly-gated clock
+    // Due to the cyclic dependency, the transformation cannot proceed and the
+    // circuit is left unchanged (no CHECK statements as the output is not transformed)
+    %r = firrtl.reg %gen2_out : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
   }
 }

--- a/test/Analysis/firrtl-gated-clock-conversion.mlir
+++ b/test/Analysis/firrtl-gated-clock-conversion.mlir
@@ -1,0 +1,629 @@
+// RUN: circt-opt %s -test-firrtl-gated-clock-conversion -split-input-file | FileCheck %s
+
+// Each case below exercises one path of the GatedClockConversion utility:
+// the gate's enable is sunk into the clocked op (register next-state mux or
+// ref-force/release predicate) and the op's clock is rebound to the ungated
+// base clock, eliminating the clock-gate from the clock path.
+
+
+//===----------------------------------------------------------------------===//
+// Cascaded clock gates: the enables are AND-reduced and the register is rebound
+// all the way to the true ungated base clock.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Cascaded
+firrtl.circuit "Cascaded" {
+  firrtl.module @Cascaded(in %clk: !firrtl.clock, in %en1: !firrtl.uint<1>,
+                          in %en2: !firrtl.uint<1>, in %d: !firrtl.uint<8>) {
+    // CHECK: %[[AND:.+]] = firrtl.and %en1, %en2
+    // CHECK: %[[R:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX:.+]] = firrtl.mux(%[[AND]], %d, %[[R]])
+    // CHECK: firrtl.matchingconnect %[[R]], %[[MUX]]
+    %g1 = firrtl.int.clock_gate %clk, %en1
+    %g2 = firrtl.int.clock_gate %g1, %en2
+    %r = firrtl.reg %g2 : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multiple independent clock gates in one module: each register gets its own
+// enable mux and is rebound to the shared base clock.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @TwoGates
+firrtl.circuit "TwoGates" {
+  firrtl.module @TwoGates(in %clk: !firrtl.clock, in %en1: !firrtl.uint<1>,
+                          in %en2: !firrtl.uint<1>, in %d: !firrtl.uint<8>) {
+    // CHECK: %[[R1:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX1:.+]] = firrtl.mux(%en1, %d, %[[R1]])
+    // CHECK: firrtl.matchingconnect %[[R1]], %[[MUX1]]
+    // CHECK: %[[R2:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX2:.+]] = firrtl.mux(%en2, %d, %[[R2]])
+    // CHECK: firrtl.matchingconnect %[[R2]], %[[MUX2]]
+    %g1 = firrtl.int.clock_gate %clk, %en1
+    %r1 = firrtl.reg %g1 : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r1, %d : !firrtl.uint<8>
+    %g2 = firrtl.int.clock_gate %clk, %en2
+    %r2 = firrtl.reg %g2 : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r2, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Gated clock flowing through a wire alias before reaching the register: the
+// utility looks through the wire/node/cast alias to find the gate.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @WireAlias
+firrtl.circuit "WireAlias" {
+  firrtl.module @WireAlias(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                           in %d: !firrtl.uint<8>) {
+    // The base clock and enable are propagated onto wires; the register is
+    // rebound to the base-clock wire and muxed with the enable wire.
+    // CHECK: %[[CW:.+]] = firrtl.wire : !firrtl.clock
+    // CHECK: %[[EW:.+]] = firrtl.wire : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %[[CW]], %clk
+    // CHECK: firrtl.matchingconnect %[[EW]], %en
+    // CHECK: %[[R:.+]] = firrtl.reg %[[CW]] : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX:.+]] = firrtl.mux(%[[EW]], %d, %[[R]])
+    // CHECK: firrtl.matchingconnect %[[R]], %[[MUX]]
+    %g = firrtl.int.clock_gate %clk, %en
+    %w = firrtl.wire : !firrtl.clock
+    firrtl.matchingconnect %w, %g : !firrtl.clock
+    %r = firrtl.reg %w : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// RefForceOp / RefReleaseOp on a gated clock: the clock is rebound to the base
+// and the gate enable is AND-ed into the predicate.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @ForceRelease
+firrtl.circuit "ForceRelease" {
+  firrtl.module @ForceRelease(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                              in %cond: !firrtl.uint<1>, in %val: !firrtl.uint<8>,
+                              in %d: !firrtl.uint<8>) {
+    // The register on the gated clock gets the holding mux ...
+    // CHECK: %[[R:.+]], %[[RREF:.+]] = firrtl.reg %clk forceable
+    // CHECK: firrtl.mux(%en, %d, %[[R]])
+    // ... and the force/release predicate is ANDed with the gate enable while
+    // the clock is rebound to the base.
+    // CHECK: %[[FAND:.+]] = firrtl.and %cond, %en
+    // CHECK: firrtl.ref.force %clk, %[[FAND]], %[[RREF]], %val
+    // CHECK: %[[RAND:.+]] = firrtl.and %cond, %en
+    // CHECK: firrtl.ref.release %clk, %[[RAND]], %[[RREF]]
+    %g = firrtl.int.clock_gate %clk, %en
+    %r, %r_ref = firrtl.reg %g forceable : !firrtl.clock, !firrtl.uint<8>, !firrtl.rwprobe<uint<8>>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+    firrtl.ref.force %g, %cond, %r_ref, %val : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<8>>, !firrtl.uint<8>
+    firrtl.ref.release %g, %cond, %r_ref : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<8>>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Register clocked by a plain (ungated) clock: nothing to sink, so the IR is
+// left unchanged (no mux, no rebind).
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @NoGate
+firrtl.circuit "NoGate" {
+  firrtl.module @NoGate(in %clk: !firrtl.clock, in %d: !firrtl.uint<8>) {
+    // CHECK: %[[R:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK-NEXT: firrtl.matchingconnect %[[R]], %d
+    // CHECK-NOT: firrtl.mux
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Force on the ungated base clock while a register lives on the gated clock:
+// only the register is muxed; the force predicate (on the free-running clock)
+// is left untouched.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @ForceOnBase
+firrtl.circuit "ForceOnBase" {
+  firrtl.module @ForceOnBase(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                             in %cond: !firrtl.uint<1>, in %val: !firrtl.uint<8>,
+                             in %d: !firrtl.uint<8>) {
+    // CHECK: %[[R:.+]], %[[RREF:.+]] = firrtl.reg %clk forceable
+    // CHECK: firrtl.mux(%en, %d, %[[R]])
+    // The force is on %clk (ungated), so its predicate stays %cond.
+    // CHECK: firrtl.ref.force %clk, %cond, %[[RREF]], %val
+    // CHECK-NOT: firrtl.and
+    %g = firrtl.int.clock_gate %clk, %en
+    %r, %r_ref = firrtl.reg %g forceable : !firrtl.clock, !firrtl.uint<8>, !firrtl.rwprobe<uint<8>>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+    firrtl.ref.force %clk, %cond, %r_ref, %val : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<8>>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Cross-module: the clock is gated in the parent and flows INTO a child module
+// where the register lives.  A (base, enable) input-port pair is inserted on
+// the child and driven from the parent's materialized values.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Child
+// CHECK-SAME:    in %[[CBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[CEN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[CBASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%[[CEN]], %d, %[[R]])
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]]
+
+// CHECK-LABEL: firrtl.module @ClockInToChild
+// CHECK:         %[[GATE:.+]] = firrtl.int.clock_gate %clk, %en
+// CHECK:         firrtl.instance c @Child
+// CHECK:         firrtl.matchingconnect %c__gatedClock_baseClock_clk
+// CHECK:         firrtl.matchingconnect %c__gatedClock_enable_clk
+firrtl.circuit "ClockInToChild" {
+  firrtl.module @Child(in %clk: !firrtl.clock, in %d: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+  firrtl.module @ClockInToChild(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                                in %d: !firrtl.uint<8>) {
+    %g = firrtl.int.clock_gate %clk, %en
+    %c_clk, %c_d = firrtl.instance c @Child(in clk: !firrtl.clock, in d: !firrtl.uint<8>)
+    firrtl.matchingconnect %c_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %c_d, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Cross-module: the clock is gated INSIDE a child module and flows OUT to a
+// register in the parent.  (base, enable) output ports are inserted on the
+// child so the parent register can rebind to the base and mux on the enable.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Gen
+// CHECK-SAME:    out %[[GBASE:[A-Za-z0-9_]*_gatedClock_baseClock_gclk]]: !firrtl.clock
+// CHECK-SAME:    out %[[GEN:[A-Za-z0-9_]*_gatedClock_enable_gclk]]: !firrtl.uint<1>
+
+// CHECK-LABEL: firrtl.module @ClockOutOfChild
+// CHECK:         firrtl.instance c @Gen
+// The parent register rebinds to the child's base-clock output port and muxes
+// on the child's enable output port.
+// CHECK:         %[[R:.+]] = firrtl.reg %c__gatedClock_baseClock_gclk : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%c__gatedClock_enable_gclk, %d, %[[R]])
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]]
+firrtl.circuit "ClockOutOfChild" {
+  firrtl.module @Gen(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                     out %gclk: !firrtl.clock) {
+    %g = firrtl.int.clock_gate %clk, %en
+    firrtl.matchingconnect %gclk, %g : !firrtl.clock
+  }
+  firrtl.module @ClockOutOfChild(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                                 in %d: !firrtl.uint<8>) {
+    %c_clk, %c_en, %c_gclk = firrtl.instance c @Gen(in clk: !firrtl.clock, in en: !firrtl.uint<1>, out gclk: !firrtl.clock)
+    firrtl.matchingconnect %c_clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %c_en, %en : !firrtl.uint<1>
+    %r = firrtl.reg %c_gclk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multi-level hierarchy: the clock is gated at the top and flows down through
+// two levels of instances; the leaf register is rebound to the threaded base
+// clock and muxed on the threaded enable.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Leaf
+// CHECK-SAME:    in %[[LBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[LEN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[LBASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         firrtl.mux(%[[LEN]], %data, %[[R]])
+
+// CHECK-LABEL: firrtl.module @Mid
+// CHECK:         firrtl.instance leaf @Leaf
+
+// CHECK-LABEL: firrtl.module @Top
+// CHECK:         %[[GATE:.+]] = firrtl.int.clock_gate %clk, %enable
+// CHECK:         firrtl.instance mid @Mid
+firrtl.circuit "Top" {
+  firrtl.module @Leaf(in %clk: !firrtl.clock, in %enable: !firrtl.uint<1>,
+                      in %data: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+  firrtl.module @Mid(in %clk: !firrtl.clock, in %enable: !firrtl.uint<1>,
+                     in %data: !firrtl.uint<8>) {
+    %leaf_clk, %leaf_enable, %leaf_data = firrtl.instance leaf @Leaf(in clk: !firrtl.clock, in enable: !firrtl.uint<1>, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %leaf_clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %leaf_enable, %enable : !firrtl.uint<1>
+    firrtl.matchingconnect %leaf_data, %data : !firrtl.uint<8>
+  }
+  firrtl.module @Top(in %clk: !firrtl.clock, in %enable: !firrtl.uint<1>,
+                     in %data: !firrtl.uint<8>) {
+    %g = firrtl.int.clock_gate %clk, %enable
+    %mid_clk, %mid_enable, %mid_data = firrtl.instance mid @Mid(in clk: !firrtl.clock, in enable: !firrtl.uint<1>, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %mid_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %mid_enable, %enable : !firrtl.uint<1>
+    firrtl.matchingconnect %mid_data, %data : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Dual independent gated clocks flowing through a multi-level hierarchy:
+// Two separate clock gates (fast and slow) at the top level flow down through
+// two levels of instances to registers in the leaf module. Each clock gets its
+// own (base, enable) port pair threaded through the hierarchy.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @DualClockLeaf
+// CHECK-SAME:    in %clk_fast: !firrtl.clock
+// CHECK-SAME:    in %clk_slow: !firrtl.clock
+// CHECK-SAME:    in %data_fast: !firrtl.uint<16>
+// CHECK-SAME:    in %data_slow: !firrtl.uint<16>
+// CHECK-SAME:    in %[[SBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk_slow]]: !firrtl.clock
+// CHECK-SAME:    in %[[SEN:[A-Za-z0-9_]*_gatedClock_enable_clk_slow]]: !firrtl.uint<1>
+// CHECK-SAME:    in %[[FBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk_fast]]: !firrtl.clock
+// CHECK-SAME:    in %[[FEN:[A-Za-z0-9_]*_gatedClock_enable_clk_fast]]: !firrtl.uint<1>
+// CHECK:         %[[RFAST:.+]] = firrtl.reg %[[FBASE]] : !firrtl.clock, !firrtl.uint<16>
+// CHECK:         %[[MUXFAST:.+]] = firrtl.mux(%[[FEN]], %data_fast, %[[RFAST]])
+// CHECK:         firrtl.matchingconnect %[[RFAST]], %[[MUXFAST]]
+// CHECK:         %[[RSLOW:.+]] = firrtl.reg %[[SBASE]] : !firrtl.clock, !firrtl.uint<16>
+// CHECK:         %[[MUXSLOW:.+]] = firrtl.mux(%[[SEN]], %data_slow, %[[RSLOW]])
+// CHECK:         firrtl.matchingconnect %[[RSLOW]], %[[MUXSLOW]]
+
+// CHECK-LABEL: firrtl.module @DualClockMid
+// CHECK:         firrtl.instance leaf @DualClockLeaf
+
+// CHECK-LABEL: firrtl.module @DualClockTop
+// CHECK:         %[[GFAST:.+]] = firrtl.int.clock_gate %clk, %fast_en
+// CHECK:         %[[GSLOW:.+]] = firrtl.int.clock_gate %clk, %slow_en
+// CHECK:         firrtl.instance mid @DualClockMid
+firrtl.circuit "DualClockTop" {
+  firrtl.module @DualClockLeaf(in %clk_fast: !firrtl.clock,
+                               in %clk_slow: !firrtl.clock,
+                               in %data_fast: !firrtl.uint<16>,
+                               in %data_slow: !firrtl.uint<16>) {
+    %r_fast = firrtl.reg %clk_fast : !firrtl.clock, !firrtl.uint<16>
+    firrtl.matchingconnect %r_fast, %data_fast : !firrtl.uint<16>
+
+
+    %r_slow = firrtl.reg %clk_slow : !firrtl.clock, !firrtl.uint<16>
+    firrtl.matchingconnect %r_slow, %data_slow : !firrtl.uint<16>
+  }
+
+  firrtl.module @DualClockMid(in %clk_fast: !firrtl.clock,
+                              in %clk_slow: !firrtl.clock,
+                              in %data_fast: !firrtl.uint<16>,
+                              in %data_slow: !firrtl.uint<16>) {
+    %leaf_fast, %leaf_slow, %leaf_df, %leaf_ds = firrtl.instance leaf @DualClockLeaf(in clk_fast: !firrtl.clock, in clk_slow: !firrtl.clock, in data_fast: !firrtl.uint<16>, in data_slow: !firrtl.uint<16>)
+    firrtl.matchingconnect %leaf_fast, %clk_fast : !firrtl.clock
+    firrtl.matchingconnect %leaf_slow, %clk_slow : !firrtl.clock
+    firrtl.matchingconnect %leaf_df, %data_fast : !firrtl.uint<16>
+    firrtl.matchingconnect %leaf_ds, %data_slow : !firrtl.uint<16>
+  }
+
+  firrtl.module @DualClockTop(in %clk: !firrtl.clock,
+                              in %fast_en: !firrtl.uint<1>,
+                              in %slow_en: !firrtl.uint<1>,
+                              in %data_fast: !firrtl.uint<16>,
+                              in %data_slow: !firrtl.uint<16>) {
+    %g_fast = firrtl.int.clock_gate %clk, %fast_en
+    %g_slow = firrtl.int.clock_gate %clk, %slow_en
+
+    %mid_fast, %mid_slow, %mid_df, %mid_ds = firrtl.instance mid @DualClockMid(in clk_fast: !firrtl.clock, in clk_slow: !firrtl.clock, in data_fast: !firrtl.uint<16>, in data_slow: !firrtl.uint<16>)
+    firrtl.matchingconnect %mid_fast, %g_fast : !firrtl.clock
+    firrtl.matchingconnect %mid_slow, %g_slow : !firrtl.clock
+    firrtl.matchingconnect %mid_df, %data_fast : !firrtl.uint<16>
+    firrtl.matchingconnect %mid_ds, %data_slow : !firrtl.uint<16>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: firrtl.module @MultipleSink
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    in %data_s: !firrtl.sint<16>
+// CHECK-SAME:    in %data_u: !firrtl.uint<32>
+// CHECK-SAME:    in %[[CBASE:[A-Za-z0-9_]*]]: !firrtl.clock
+// CHECK-SAME:    in %[[CEN:[A-Za-z0-9_]*]]: !firrtl.uint<1>
+// CHECK:         %[[RS:.+]] = firrtl.reg %[[CBASE]] : !firrtl.clock, !firrtl.sint<16>
+// CHECK:         %[[MUXS:.+]] = firrtl.mux(%[[CEN]], %data_s, %[[RS]]) : (!firrtl.uint<1>, !firrtl.sint<16>, !firrtl.sint<16>) -> !firrtl.sint<16>
+// CHECK:         firrtl.matchingconnect %[[RS]], %[[MUXS]] : !firrtl.sint<16>
+// CHECK:         %[[RU:.+]] = firrtl.reg %[[CBASE]] : !firrtl.clock, !firrtl.uint<32>
+// CHECK:         %[[MUXU:.+]] = firrtl.mux(%[[CEN]], %data_u, %[[RU]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+// CHECK:         firrtl.matchingconnect %[[RU]], %[[MUXU]] : !firrtl.uint<32>
+
+// CHECK-LABEL: firrtl.module @MultipleSinkParent
+firrtl.circuit "MultipleSinkParent" {
+  firrtl.module @MultipleSink(in %clk: !firrtl.clock,
+                                    in %data_s: !firrtl.sint<16>,
+                                    in %data_u: !firrtl.uint<32>) {
+    %rs = firrtl.reg %clk : !firrtl.clock, !firrtl.sint<16>
+    firrtl.matchingconnect %rs, %data_s : !firrtl.sint<16>
+    %ru = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<32>
+    firrtl.matchingconnect %ru, %data_u : !firrtl.uint<32>
+  }
+
+  firrtl.module @MultipleSinkParent(in %clk: !firrtl.clock,
+                                in %en: !firrtl.uint<1>,
+                                in %ds: !firrtl.sint<16>,
+                                in %du: !firrtl.uint<32>) {
+    %g = firrtl.int.clock_gate %clk, %en
+    %child_clk, %child_ds, %child_du = firrtl.instance child @MultipleSink(in clk: !firrtl.clock, in data_s: !firrtl.sint<16>, in data_u: !firrtl.uint<32>)
+    firrtl.matchingconnect %child_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %child_ds, %ds : !firrtl.sint<16>
+    firrtl.matchingconnect %child_du, %du : !firrtl.uint<32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Clock gate with test_enable in hierarchical context
+// - Parent creates a gated clock with test_enable
+// - Clock flows into child module
+// - Enable should be materialized as (enable | test_enable)
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @ChildWithTestEnable
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<8>
+// CHECK-SAME:    in %[[CBASE:[A-Za-z0-9_]*]]: !firrtl.clock
+// CHECK-SAME:    in %[[CEN:[A-Za-z0-9_]*]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[CBASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%[[CEN]], %data, %[[R]]) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]] : !firrtl.uint<8>
+
+// CHECK-LABEL: firrtl.module @TestEnableHierarchy
+firrtl.circuit "TestEnableHierarchy" {
+  firrtl.module @ChildWithTestEnable(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+
+  firrtl.module @TestEnableHierarchy(in %clk: !firrtl.clock,
+                                     in %en: !firrtl.uint<1>,
+                                     in %test_en: !firrtl.uint<1>,
+                                     in %d: !firrtl.uint<8>) {
+    // The effective enable should be (en | test_en)
+    // CHECK: %[[OR:.+]] = firrtl.or %en, %test_en
+    %g = firrtl.int.clock_gate %clk, %en, %test_en
+    %child_clk, %child_data = firrtl.instance child @ChildWithTestEnable(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %child_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %child_data, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Deeply nested: layerblock inside when inside match
+// - Tests if the transformation handles deeply nested instances correctly
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @DeepChild
+// CHECK-SAME:    in %[[DBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[DEN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[DBASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%[[DEN]], %data, %[[R]])
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]]
+
+// CHECK-LABEL: firrtl.module @DeeplyNested
+firrtl.circuit "DeeplyNested" {
+  firrtl.layer @A bind {}
+
+  firrtl.module @DeepChild(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+
+  firrtl.module @DeeplyNested(in %clk: !firrtl.clock,
+                              in %en: !firrtl.uint<1>,
+                              in %selector: !firrtl.enum<A: uint<8>, B: uint<8>>,
+                              in %cond: !firrtl.uint<1>,
+                              in %d: !firrtl.uint<8>) {
+    // CHECK: %[[G:.+]] = firrtl.int.clock_gate %clk, %en
+    %g = firrtl.int.clock_gate %clk, %en
+
+    // CHECK: firrtl.match %selector
+    firrtl.match %selector : !firrtl.enum<A: uint<8>, B: uint<8>> {
+      case A(%arg0) {
+        // CHECK: firrtl.when %cond
+        firrtl.when %cond : !firrtl.uint<1> {
+          // CHECK: firrtl.layerblock @A
+          firrtl.layerblock @A {
+            // CHECK: %{{.+}}, %{{.+}}, %[[INST_BASE:.+]], %[[INST_EN:.+]] = firrtl.instance deep_child @DeepChild
+            // CHECK-SAME: in [[GBASE_NAME:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+            // CHECK-SAME: in [[GEN_NAME:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+            %child_clk, %child_data = firrtl.instance deep_child @DeepChild(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+            firrtl.matchingconnect %child_clk, %g : !firrtl.clock
+            firrtl.matchingconnect %child_data, %arg0 : !firrtl.uint<8>
+            // CHECK: firrtl.matchingconnect %[[INST_BASE]], %clk
+            // CHECK: firrtl.matchingconnect %[[INST_EN]], %en
+          }
+        }
+      }
+      case B(%arg0) {
+        // Empty case
+      }
+    }
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Same module instantiated twice with different gated clocks
+// - First instance uses gated clock on clk1
+// - Second instance uses gated clock on clk2
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @FlexibleChild
+// CHECK-SAME:    in %clk1: !firrtl.clock
+// CHECK-SAME:    in %clk2: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<8>
+// CHECK-SAME:    in %[[CLK2_BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk2]]: !firrtl.clock
+// CHECK-SAME:    in %[[CLK2_EN:[A-Za-z0-9_]*_gatedClock_enable_clk2]]: !firrtl.uint<1>
+// CHECK-SAME:    in %[[CLK1_BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk1]]: !firrtl.clock
+// CHECK-SAME:    in %[[CLK1_EN:[A-Za-z0-9_]*_gatedClock_enable_clk1]]: !firrtl.uint<1>
+// CHECK:         %[[R1:.+]] = firrtl.reg %[[CLK1_BASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[R2:.+]] = firrtl.reg %[[CLK2_BASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX1:.+]] = firrtl.mux(%[[CLK1_EN]], %data, %[[R1]])
+// CHECK:         firrtl.matchingconnect %[[R1]], %[[MUX1]]
+// CHECK:         %[[MUX2:.+]] = firrtl.mux(%[[CLK2_EN]], %data, %[[R2]])
+// CHECK:         firrtl.matchingconnect %[[R2]], %[[MUX2]]
+
+// CHECK-LABEL: firrtl.module @DifferentGating
+// CHECK:         %[[C1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+// CHECK:         %[[C1_0:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+firrtl.circuit "DifferentGating" {
+  firrtl.module @FlexibleChild(in %clk1: !firrtl.clock,
+                               in %clk2: !firrtl.clock,
+                               in %data: !firrtl.uint<8>) {
+    %r1 = firrtl.reg %clk1 : !firrtl.clock, !firrtl.uint<8>
+    %r2 = firrtl.reg %clk2 : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r1, %data : !firrtl.uint<8>
+    firrtl.matchingconnect %r2, %data : !firrtl.uint<8>
+  }
+
+  firrtl.module @DifferentGating(in %base_clk: !firrtl.clock,
+                                 in %en1: !firrtl.uint<1>,
+                                 in %en2: !firrtl.uint<1>,
+                                 in %d: !firrtl.uint<8>) {
+    // CHECK: %[[G1:.+]] = firrtl.int.clock_gate %base_clk, %en1
+    %g1 = firrtl.int.clock_gate %base_clk, %en1
+    // CHECK: %[[G2:.+]] = firrtl.int.clock_gate %base_clk, %en2
+    %g2 = firrtl.int.clock_gate %base_clk, %en2
+
+    // First instance: gate on clk1, ungated on clk2
+    // CHECK: %{{.+}}, %{{.+}}, %{{.+}}, %[[I1_CLK2_BASE:.+]], %[[I1_CLK2_EN:.+]], %[[I1_CLK1_BASE:.+]], %[[I1_CLK1_EN:.+]] = firrtl.instance inst1 @FlexibleChild
+    %inst1_clk1, %inst1_clk2, %inst1_data = firrtl.instance inst1 @FlexibleChild(
+      in clk1: !firrtl.clock,
+      in clk2: !firrtl.clock,
+      in data: !firrtl.uint<8>)
+    // CHECK: firrtl.matchingconnect %{{.+}}, %[[G1]]
+    firrtl.matchingconnect %inst1_clk1, %g1 : !firrtl.clock
+    // CHECK: firrtl.matchingconnect %{{.+}}, %base_clk
+    firrtl.matchingconnect %inst1_clk2, %base_clk : !firrtl.clock
+    // CHECK: firrtl.matchingconnect %{{.+}}, %d
+    firrtl.matchingconnect %inst1_data, %d : !firrtl.uint<8>
+
+    // Second instance: ungated on clk1, gate on clk2
+    // CHECK: %{{.+}}, %{{.+}}, %{{.+}}, %[[I2_CLK2_BASE:.+]], %[[I2_CLK2_EN:.+]], %[[I2_CLK1_BASE:.+]], %[[I2_CLK1_EN:.+]] = firrtl.instance inst2 @FlexibleChild
+    %inst2_clk1, %inst2_clk2, %inst2_data = firrtl.instance inst2 @FlexibleChild(
+      in clk1: !firrtl.clock,
+      in clk2: !firrtl.clock,
+      in data: !firrtl.uint<8>)
+    // CHECK: firrtl.matchingconnect %{{.+}}, %base_clk
+    firrtl.matchingconnect %inst2_clk1, %base_clk : !firrtl.clock
+    // CHECK: firrtl.matchingconnect %{{.+}}, %[[G2]]
+    firrtl.matchingconnect %inst2_clk2, %g2 : !firrtl.clock
+    // CHECK: firrtl.matchingconnect %{{.+}}, %d
+    firrtl.matchingconnect %inst2_data, %d : !firrtl.uint<8>
+    // The new (base, enable) ports are connected after the original instance connects
+    // Instance1: ungated clk2 connects
+    // CHECK: firrtl.matchingconnect %[[I1_CLK2_BASE]], %base_clk
+    // CHECK: firrtl.matchingconnect %[[I1_CLK2_EN]], %[[C1_0]]
+    // Instance2: ungated clk1 connects
+    // CHECK: firrtl.matchingconnect %[[I2_CLK1_BASE]], %base_clk
+    // CHECK: firrtl.matchingconnect %[[I2_CLK1_EN]], %[[C1]]
+    // Instance2: gated clk2 connects
+    // CHECK: firrtl.matchingconnect %[[I2_CLK2_BASE]], %base_clk
+    // CHECK: firrtl.matchingconnect %[[I2_CLK2_EN]], %en2
+    // Instance1: gated clk1 connects
+    // CHECK: firrtl.matchingconnect %[[I1_CLK1_BASE]], %base_clk
+    // CHECK: firrtl.matchingconnect %[[I1_CLK1_EN]], %en1
+  }
+}
+
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Instance output port connected to wire outside when block
+// - Tests if transformation handles instance outputs from nested blocks
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Producer
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    out %out_clk: !firrtl.clock
+// CHECK-SAME:    in %[[PROD_BASE_IN:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[PROD_EN_IN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK-SAME:    out %[[PROD_BASE_OUT:[A-Za-z0-9_]*_gatedClock_baseClock_out_clk]]: !firrtl.clock
+// CHECK-SAME:    out %[[PROD_EN_OUT:[A-Za-z0-9_]*_gatedClock_enable_out_clk]]: !firrtl.uint<1>
+// CHECK:         firrtl.matchingconnect %out_clk, %clk
+// CHECK:         firrtl.matchingconnect %[[PROD_BASE_OUT]], %[[PROD_BASE_IN]]
+// CHECK:         firrtl.matchingconnect %[[PROD_EN_OUT]], %[[PROD_EN_IN]]
+
+// CHECK-LABEL: firrtl.module @Consumer
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<8>
+// CHECK-SAME:    in %[[CONS_BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[CONS_EN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[CONS_BASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%[[CONS_EN]], %data, %[[R]])
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]]
+
+// CHECK-LABEL: firrtl.module @InstanceOutput
+firrtl.circuit "InstanceOutput" {
+  firrtl.module @Producer(in %clk: !firrtl.clock, out %out_clk: !firrtl.clock) {
+    firrtl.matchingconnect %out_clk, %clk : !firrtl.clock
+  }
+
+  firrtl.module @Consumer(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+
+  firrtl.module @InstanceOutput(in %base_clk: !firrtl.clock,
+                                in %en: !firrtl.uint<1>,
+                                in %cond: !firrtl.uint<1>,
+                                in %d: !firrtl.uint<8>) {
+    // CHECK: %[[WIRE_BASE:.+]] = firrtl.wire : !firrtl.clock
+    // CHECK: %[[WIRE_EN:.+]] = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %[[GATE:.+]] = firrtl.int.clock_gate %base_clk, %en
+    %gated = firrtl.int.clock_gate %base_clk, %en
+    // CHECK: %[[OUT_WIRE:.+]] = firrtl.wire : !firrtl.clock
+    %out_wire = firrtl.wire : !firrtl.clock
+
+    // CHECK: firrtl.when %cond
+    firrtl.when %cond : !firrtl.uint<1> {
+      // CHECK: %{{.+}}, %{{.+}}, %[[P_BASE_IN:.+]], %[[P_EN_IN:.+]], %[[P_BASE_OUT:.+]], %[[P_EN_OUT:.+]] = firrtl.instance producer @Producer
+      %p_clk, %p_out = firrtl.instance producer @Producer(in clk: !firrtl.clock, out out_clk: !firrtl.clock)
+      // CHECK: firrtl.matchingconnect %[[WIRE_EN]], %[[P_EN_OUT]]
+      // CHECK: firrtl.matchingconnect %[[WIRE_BASE]], %[[P_BASE_OUT]]
+      // CHECK: firrtl.matchingconnect %{{.+}}, %[[GATE]]
+      firrtl.matchingconnect %p_clk, %gated : !firrtl.clock
+      firrtl.matchingconnect %out_wire, %p_out : !firrtl.clock
+      // CHECK: firrtl.matchingconnect %[[P_BASE_IN]], %base_clk
+      // CHECK: firrtl.matchingconnect %[[P_EN_IN]], %en
+    }
+
+    // CHECK: %{{.+}}, %{{.+}}, %[[C_BASE:.+]], %[[C_EN:.+]] = firrtl.instance consumer @Consumer
+    %c_clk, %c_data = firrtl.instance consumer @Consumer(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+    // CHECK: firrtl.matchingconnect %{{.+}}, %[[OUT_WIRE]]
+    firrtl.matchingconnect %c_clk, %out_wire : !firrtl.clock
+    // CHECK: firrtl.matchingconnect %{{.+}}, %d
+    firrtl.matchingconnect %c_data, %d : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %[[C_BASE]], %[[WIRE_BASE]]
+    // CHECK: firrtl.matchingconnect %[[C_EN]], %[[WIRE_EN]]
+  }
+}

--- a/test/Analysis/firrtl-gated-clock-conversion.mlir
+++ b/test/Analysis/firrtl-gated-clock-conversion.mlir
@@ -1,0 +1,737 @@
+// RUN: circt-opt %s -test-firrtl-gated-clock-conversion -split-input-file | FileCheck %s
+
+// Each case below exercises one path of the GatedClockConversion utility:
+// the gate's enable is sunk into the clocked op (register next-state mux or
+// ref-force/release predicate) and the op's clock is rebound to the ungated
+// base clock, eliminating the clock-gate from the clock path.
+
+
+//===----------------------------------------------------------------------===//
+// Cascaded clock gates: the enables are AND-reduced and the register is rebound
+// all the way to the true ungated base clock.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Cascaded
+firrtl.circuit "Cascaded" {
+  firrtl.module @Cascaded(in %clk: !firrtl.clock, in %en1: !firrtl.uint<1>,
+                          in %en2: !firrtl.uint<1>, in %d: !firrtl.uint<8>) {
+    // CHECK: %[[AND:.+]] = firrtl.and %en1, %en2
+    // CHECK: %[[R:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX:.+]] = firrtl.mux(%[[AND]], %d, %[[R]])
+    // CHECK: firrtl.matchingconnect %[[R]], %[[MUX]]
+    %g1 = firrtl.int.clock_gate %clk, %en1
+    %g2 = firrtl.int.clock_gate %g1, %en2
+    %r = firrtl.reg %g2 : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multiple independent clock gates in one module: each register gets its own
+// enable mux and is rebound to the shared base clock.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @TwoGates
+firrtl.circuit "TwoGates" {
+  firrtl.module @TwoGates(in %clk: !firrtl.clock, in %en1: !firrtl.uint<1>,
+                          in %en2: !firrtl.uint<1>, in %d: !firrtl.uint<8>) {
+    // CHECK: %[[R1:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX1:.+]] = firrtl.mux(%en1, %d, %[[R1]])
+    // CHECK: firrtl.matchingconnect %[[R1]], %[[MUX1]]
+    // CHECK: %[[R2:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX2:.+]] = firrtl.mux(%en2, %d, %[[R2]])
+    // CHECK: firrtl.matchingconnect %[[R2]], %[[MUX2]]
+    %g1 = firrtl.int.clock_gate %clk, %en1
+    %r1 = firrtl.reg %g1 : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r1, %d : !firrtl.uint<8>
+    %g2 = firrtl.int.clock_gate %clk, %en2
+    %r2 = firrtl.reg %g2 : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r2, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Gated clock flowing through a wire alias before reaching the register: the
+// utility looks through the wire/node/cast alias to find the gate.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @WireAlias
+firrtl.circuit "WireAlias" {
+  firrtl.module @WireAlias(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                           in %d: !firrtl.uint<8>) {
+    // The gated clock is still created and connected to the wire
+    // CHECK: firrtl.int.clock_gate %clk, %en
+    // CHECK: %[[W:.+]] = firrtl.wire : !firrtl.clock
+    // The register is rebound to the base clock and muxed with the enable
+    // CHECK: %[[R:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX:.+]] = firrtl.mux(%en, %d, %[[R]])
+    // CHECK: firrtl.matchingconnect %[[R]], %[[MUX]]
+    %g = firrtl.int.clock_gate %clk, %en
+    %w = firrtl.wire : !firrtl.clock
+    firrtl.matchingconnect %w, %g : !firrtl.clock
+    %r = firrtl.reg %w : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// RefForceOp / RefReleaseOp on a gated clock: the clock is rebound to the base
+// and the gate enable is AND-ed into the predicate.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @ForceRelease
+firrtl.circuit "ForceRelease" {
+  firrtl.module @ForceRelease(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                              in %cond: !firrtl.uint<1>, in %val: !firrtl.uint<8>,
+                              in %d: !firrtl.uint<8>) {
+    // The register on the gated clock gets the holding mux ...
+    // CHECK: %[[R:.+]], %[[RREF:.+]] = firrtl.reg %clk forceable
+    // CHECK: firrtl.mux(%en, %d, %[[R]])
+    // ... and the force/release predicate is ANDed with the gate enable while
+    // the clock is rebound to the base.
+    // CHECK: %[[FAND:.+]] = firrtl.and %cond, %en
+    // CHECK: firrtl.ref.force %clk, %[[FAND]], %[[RREF]], %val
+    // CHECK: %[[RAND:.+]] = firrtl.and %cond, %en
+    // CHECK: firrtl.ref.release %clk, %[[RAND]], %[[RREF]]
+    %g = firrtl.int.clock_gate %clk, %en
+    %r, %r_ref = firrtl.reg %g forceable : !firrtl.clock, !firrtl.uint<8>, !firrtl.rwprobe<uint<8>>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+    firrtl.ref.force %g, %cond, %r_ref, %val : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<8>>, !firrtl.uint<8>
+    firrtl.ref.release %g, %cond, %r_ref : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<8>>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Register clocked by a plain (ungated) clock: nothing to sink, so the IR is
+// left unchanged (no mux, no rebind).
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @NoGate
+firrtl.circuit "NoGate" {
+  firrtl.module @NoGate(in %clk: !firrtl.clock, in %d: !firrtl.uint<8>) {
+    // CHECK: %[[R:.+]] = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    // CHECK-NEXT: firrtl.matchingconnect %[[R]], %d
+    // CHECK-NOT: firrtl.mux
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Force on the ungated base clock while a register lives on the gated clock:
+// only the register is muxed; the force predicate (on the free-running clock)
+// is left untouched.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @ForceOnBase
+firrtl.circuit "ForceOnBase" {
+  firrtl.module @ForceOnBase(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                             in %cond: !firrtl.uint<1>, in %val: !firrtl.uint<8>,
+                             in %d: !firrtl.uint<8>) {
+    // CHECK: %[[R:.+]], %[[RREF:.+]] = firrtl.reg %clk forceable
+    // CHECK: firrtl.mux(%en, %d, %[[R]])
+    // The force is on %clk (ungated), so its predicate stays %cond.
+    // CHECK: firrtl.ref.force %clk, %cond, %[[RREF]], %val
+    // CHECK-NOT: firrtl.and
+    %g = firrtl.int.clock_gate %clk, %en
+    %r, %r_ref = firrtl.reg %g forceable : !firrtl.clock, !firrtl.uint<8>, !firrtl.rwprobe<uint<8>>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+    firrtl.ref.force %clk, %cond, %r_ref, %val : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<8>>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Cross-module: the clock is gated in the parent and flows INTO a child module
+// where the register lives.  A (base, enable) input-port pair is inserted on
+// the child and driven from the parent's materialized values.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Child
+// CHECK-SAME:    in %[[CBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[CEN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[CBASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%[[CEN]], %d, %[[R]])
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]]
+
+// CHECK-LABEL: firrtl.module @ClockInToChild
+// CHECK:         %[[GATE:.+]] = firrtl.int.clock_gate %clk, %en
+// CHECK:         firrtl.instance c @Child
+// CHECK:         firrtl.matchingconnect %c__gatedClock_baseClock_clk
+// CHECK:         firrtl.matchingconnect %c__gatedClock_enable_clk
+firrtl.circuit "ClockInToChild" {
+  firrtl.module @Child(in %clk: !firrtl.clock, in %d: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+  firrtl.module @ClockInToChild(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                                in %d: !firrtl.uint<8>) {
+    %g = firrtl.int.clock_gate %clk, %en
+    %c_clk, %c_d = firrtl.instance c @Child(in clk: !firrtl.clock, in d: !firrtl.uint<8>)
+    firrtl.matchingconnect %c_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %c_d, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Cross-module: the clock is gated INSIDE a child module and flows OUT to a
+// register in the parent.  (base, enable) output ports are inserted on the
+// child so the parent register can rebind to the base and mux on the enable.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Gen
+// CHECK-SAME:    out %[[GBASE:[A-Za-z0-9_]*_gatedClock_baseClock_gclk]]: !firrtl.clock
+// CHECK-SAME:    out %[[GEN:[A-Za-z0-9_]*_gatedClock_enable_gclk]]: !firrtl.uint<1>
+
+// CHECK-LABEL: firrtl.module @ClockOutOfChild
+// CHECK:         firrtl.instance c @Gen
+// The parent register rebinds to the child's base-clock output port and muxes
+// on the child's enable output port.
+// CHECK:         %[[R:.+]] = firrtl.reg %c__gatedClock_baseClock_gclk : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%c__gatedClock_enable_gclk, %d, %[[R]])
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]]
+firrtl.circuit "ClockOutOfChild" {
+  firrtl.module @Gen(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                     out %gclk: !firrtl.clock) {
+    %g = firrtl.int.clock_gate %clk, %en
+    firrtl.matchingconnect %gclk, %g : !firrtl.clock
+  }
+  firrtl.module @ClockOutOfChild(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                                 in %d: !firrtl.uint<8>) {
+    %c_clk, %c_en, %c_gclk = firrtl.instance c @Gen(in clk: !firrtl.clock, in en: !firrtl.uint<1>, out gclk: !firrtl.clock)
+    firrtl.matchingconnect %c_clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %c_en, %en : !firrtl.uint<1>
+    %r = firrtl.reg %c_gclk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multi-level hierarchy: the clock is gated at the top and flows down through
+// two levels of instances; the leaf register is rebound to the threaded base
+// clock and muxed on the threaded enable.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Leaf
+// CHECK-SAME:    in %[[LBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[LEN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[LBASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         firrtl.mux(%[[LEN]], %data, %[[R]])
+
+// CHECK-LABEL: firrtl.module @Mid
+// CHECK:         firrtl.instance leaf @Leaf
+
+// CHECK-LABEL: firrtl.module @Top
+// CHECK:         %[[GATE:.+]] = firrtl.int.clock_gate %clk, %enable
+// CHECK:         firrtl.instance mid @Mid
+firrtl.circuit "Top" {
+  firrtl.module @Leaf(in %clk: !firrtl.clock, in %enable: !firrtl.uint<1>,
+                      in %data: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+  firrtl.module @Mid(in %clk: !firrtl.clock, in %enable: !firrtl.uint<1>,
+                     in %data: !firrtl.uint<8>) {
+    %leaf_clk, %leaf_enable, %leaf_data = firrtl.instance leaf @Leaf(in clk: !firrtl.clock, in enable: !firrtl.uint<1>, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %leaf_clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %leaf_enable, %enable : !firrtl.uint<1>
+    firrtl.matchingconnect %leaf_data, %data : !firrtl.uint<8>
+  }
+  firrtl.module @Top(in %clk: !firrtl.clock, in %enable: !firrtl.uint<1>,
+                     in %data: !firrtl.uint<8>) {
+    %g = firrtl.int.clock_gate %clk, %enable
+    %mid_clk, %mid_enable, %mid_data = firrtl.instance mid @Mid(in clk: !firrtl.clock, in enable: !firrtl.uint<1>, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %mid_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %mid_enable, %enable : !firrtl.uint<1>
+    firrtl.matchingconnect %mid_data, %data : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Dual independent gated clocks flowing through a multi-level hierarchy:
+// Two separate clock gates (fast and slow) at the top level flow down through
+// two levels of instances to registers in the leaf module. Each clock gets its
+// own (base, enable) port pair threaded through the hierarchy.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @DualClockLeaf
+// CHECK-SAME:    in %clk_fast: !firrtl.clock
+// CHECK-SAME:    in %clk_slow: !firrtl.clock
+// CHECK-SAME:    in %data_fast: !firrtl.uint<16>
+// CHECK-SAME:    in %data_slow: !firrtl.uint<16>
+// CHECK-SAME:    in %[[SBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk_slow]]: !firrtl.clock
+// CHECK-SAME:    in %[[SEN:[A-Za-z0-9_]*_gatedClock_enable_clk_slow]]: !firrtl.uint<1>
+// CHECK-SAME:    in %[[FBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk_fast]]: !firrtl.clock
+// CHECK-SAME:    in %[[FEN:[A-Za-z0-9_]*_gatedClock_enable_clk_fast]]: !firrtl.uint<1>
+// CHECK:         %[[RFAST:.+]] = firrtl.reg %[[FBASE]] : !firrtl.clock, !firrtl.uint<16>
+// CHECK:         %[[MUXFAST:.+]] = firrtl.mux(%[[FEN]], %data_fast, %[[RFAST]])
+// CHECK:         firrtl.matchingconnect %[[RFAST]], %[[MUXFAST]]
+// CHECK:         %[[RSLOW:.+]] = firrtl.reg %[[SBASE]] : !firrtl.clock, !firrtl.uint<16>
+// CHECK:         %[[MUXSLOW:.+]] = firrtl.mux(%[[SEN]], %data_slow, %[[RSLOW]])
+// CHECK:         firrtl.matchingconnect %[[RSLOW]], %[[MUXSLOW]]
+
+// CHECK-LABEL: firrtl.module @DualClockMid
+// CHECK:         firrtl.instance leaf @DualClockLeaf
+
+// CHECK-LABEL: firrtl.module @DualClockTop
+// CHECK:         %[[GFAST:.+]] = firrtl.int.clock_gate %clk, %fast_en
+// CHECK:         %[[GSLOW:.+]] = firrtl.int.clock_gate %clk, %slow_en
+// CHECK:         firrtl.instance mid @DualClockMid
+firrtl.circuit "DualClockTop" {
+  firrtl.module @DualClockLeaf(in %clk_fast: !firrtl.clock,
+                               in %clk_slow: !firrtl.clock,
+                               in %data_fast: !firrtl.uint<16>,
+                               in %data_slow: !firrtl.uint<16>) {
+    %r_fast = firrtl.reg %clk_fast : !firrtl.clock, !firrtl.uint<16>
+    firrtl.matchingconnect %r_fast, %data_fast : !firrtl.uint<16>
+
+
+    %r_slow = firrtl.reg %clk_slow : !firrtl.clock, !firrtl.uint<16>
+    firrtl.matchingconnect %r_slow, %data_slow : !firrtl.uint<16>
+  }
+
+  firrtl.module @DualClockMid(in %clk_fast: !firrtl.clock,
+                              in %clk_slow: !firrtl.clock,
+                              in %data_fast: !firrtl.uint<16>,
+                              in %data_slow: !firrtl.uint<16>) {
+    %leaf_fast, %leaf_slow, %leaf_df, %leaf_ds = firrtl.instance leaf @DualClockLeaf(in clk_fast: !firrtl.clock, in clk_slow: !firrtl.clock, in data_fast: !firrtl.uint<16>, in data_slow: !firrtl.uint<16>)
+    firrtl.matchingconnect %leaf_fast, %clk_fast : !firrtl.clock
+    firrtl.matchingconnect %leaf_slow, %clk_slow : !firrtl.clock
+    firrtl.matchingconnect %leaf_df, %data_fast : !firrtl.uint<16>
+    firrtl.matchingconnect %leaf_ds, %data_slow : !firrtl.uint<16>
+  }
+
+  firrtl.module @DualClockTop(in %clk: !firrtl.clock,
+                              in %fast_en: !firrtl.uint<1>,
+                              in %slow_en: !firrtl.uint<1>,
+                              in %data_fast: !firrtl.uint<16>,
+                              in %data_slow: !firrtl.uint<16>) {
+    %g_fast = firrtl.int.clock_gate %clk, %fast_en
+    %g_slow = firrtl.int.clock_gate %clk, %slow_en
+
+    %mid_fast, %mid_slow, %mid_df, %mid_ds = firrtl.instance mid @DualClockMid(in clk_fast: !firrtl.clock, in clk_slow: !firrtl.clock, in data_fast: !firrtl.uint<16>, in data_slow: !firrtl.uint<16>)
+    firrtl.matchingconnect %mid_fast, %g_fast : !firrtl.clock
+    firrtl.matchingconnect %mid_slow, %g_slow : !firrtl.clock
+    firrtl.matchingconnect %mid_df, %data_fast : !firrtl.uint<16>
+    firrtl.matchingconnect %mid_ds, %data_slow : !firrtl.uint<16>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: firrtl.module @MultipleSink
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    in %data_s: !firrtl.sint<16>
+// CHECK-SAME:    in %data_u: !firrtl.uint<32>
+// CHECK-SAME:    in %[[CBASE:[A-Za-z0-9_]*]]: !firrtl.clock
+// CHECK-SAME:    in %[[CEN:[A-Za-z0-9_]*]]: !firrtl.uint<1>
+// CHECK:         %[[RS:.+]] = firrtl.reg %[[CBASE]] : !firrtl.clock, !firrtl.sint<16>
+// CHECK:         %[[MUXS:.+]] = firrtl.mux(%[[CEN]], %data_s, %[[RS]]) : (!firrtl.uint<1>, !firrtl.sint<16>, !firrtl.sint<16>) -> !firrtl.sint<16>
+// CHECK:         firrtl.matchingconnect %[[RS]], %[[MUXS]] : !firrtl.sint<16>
+// CHECK:         %[[RU:.+]] = firrtl.reg %[[CBASE]] : !firrtl.clock, !firrtl.uint<32>
+// CHECK:         %[[MUXU:.+]] = firrtl.mux(%[[CEN]], %data_u, %[[RU]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+// CHECK:         firrtl.matchingconnect %[[RU]], %[[MUXU]] : !firrtl.uint<32>
+
+// CHECK-LABEL: firrtl.module @MultipleSinkParent
+firrtl.circuit "MultipleSinkParent" {
+  firrtl.module @MultipleSink(in %clk: !firrtl.clock,
+                                    in %data_s: !firrtl.sint<16>,
+                                    in %data_u: !firrtl.uint<32>) {
+    %rs = firrtl.reg %clk : !firrtl.clock, !firrtl.sint<16>
+    firrtl.matchingconnect %rs, %data_s : !firrtl.sint<16>
+    %ru = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<32>
+    firrtl.matchingconnect %ru, %data_u : !firrtl.uint<32>
+  }
+
+  firrtl.module @MultipleSinkParent(in %clk: !firrtl.clock,
+                                in %en: !firrtl.uint<1>,
+                                in %ds: !firrtl.sint<16>,
+                                in %du: !firrtl.uint<32>) {
+    %g = firrtl.int.clock_gate %clk, %en
+    %child_clk, %child_ds, %child_du = firrtl.instance child @MultipleSink(in clk: !firrtl.clock, in data_s: !firrtl.sint<16>, in data_u: !firrtl.uint<32>)
+    firrtl.matchingconnect %child_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %child_ds, %ds : !firrtl.sint<16>
+    firrtl.matchingconnect %child_du, %du : !firrtl.uint<32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Clock gate with test_enable in hierarchical context
+// - Parent creates a gated clock with test_enable
+// - Clock flows into child module
+// - Enable should be materialized as (enable | test_enable)
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @ChildWithTestEnable
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<8>
+// CHECK-SAME:    in %[[CBASE:[A-Za-z0-9_]*]]: !firrtl.clock
+// CHECK-SAME:    in %[[CEN:[A-Za-z0-9_]*]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[CBASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%[[CEN]], %data, %[[R]]) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]] : !firrtl.uint<8>
+
+// CHECK-LABEL: firrtl.module @TestEnableHierarchy
+firrtl.circuit "TestEnableHierarchy" {
+  firrtl.module @ChildWithTestEnable(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+
+  firrtl.module @TestEnableHierarchy(in %clk: !firrtl.clock,
+                                     in %en: !firrtl.uint<1>,
+                                     in %test_en: !firrtl.uint<1>,
+                                     in %d: !firrtl.uint<8>) {
+    // The effective enable should be (en | test_en)
+    // CHECK: %[[OR:.+]] = firrtl.or %en, %test_en
+    %g = firrtl.int.clock_gate %clk, %en, %test_en
+    %child_clk, %child_data = firrtl.instance child @ChildWithTestEnable(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %child_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %child_data, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Deeply nested: layerblock inside when inside match
+// - Tests if the transformation handles deeply nested instances correctly
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @DeepChild
+// CHECK-SAME:    in %[[DBASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[DEN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[DBASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%[[DEN]], %data, %[[R]])
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]]
+
+// CHECK-LABEL: firrtl.module @DeeplyNested
+firrtl.circuit "DeeplyNested" {
+  firrtl.layer @A bind {
+    firrtl.layer @B bind {}
+  }
+
+  firrtl.module @DeepChild(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+
+  firrtl.module @DeeplyNested(in %clk: !firrtl.clock,
+                              in %en: !firrtl.uint<1>,
+                              in %selector: !firrtl.enum<A: uint<8>, B: uint<8>>,
+                              in %cond: !firrtl.uint<1>,
+                              in %d: !firrtl.uint<8>) {
+    // CHECK: firrtl.int.clock_gate %clk, %en
+    %g = firrtl.int.clock_gate %clk, %en
+
+    // CHECK: firrtl.layerblock @A
+    // CHECK: firrtl.layerblock @A::@B
+    // CHECK: %{{.+}}, %{{.+}}, %[[INST_BASE:.+]], %[[INST_EN:.+]] = firrtl.instance deep_child @DeepChild
+    // CHECK-SAME: in {{[A-Za-z0-9_]*_gatedClock_baseClock_clk}}: !firrtl.clock
+    // CHECK-SAME: in {{[A-Za-z0-9_]*_gatedClock_enable_clk}}: !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %[[INST_BASE]], %clk
+    // CHECK: firrtl.matchingconnect %[[INST_EN]], %en
+    firrtl.layerblock @A {
+      firrtl.layerblock @A::@B {
+        %child_clk, %child_data = firrtl.instance deep_child @DeepChild(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+        firrtl.matchingconnect %child_clk, %g : !firrtl.clock
+        firrtl.matchingconnect %child_data, %d : !firrtl.uint<8>
+      }
+    }
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Same module instantiated twice with different gated clocks
+// - First instance uses gated clock on clk1
+// - Second instance uses gated clock on clk2
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @FlexibleChild
+// CHECK-SAME:    in %clk1: !firrtl.clock
+// CHECK-SAME:    in %clk2: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<8>
+// CHECK-SAME:    in %[[CLK2_BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk2]]: !firrtl.clock
+// CHECK-SAME:    in %[[CLK2_EN:[A-Za-z0-9_]*_gatedClock_enable_clk2]]: !firrtl.uint<1>
+// CHECK-SAME:    in %[[CLK1_BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk1]]: !firrtl.clock
+// CHECK-SAME:    in %[[CLK1_EN:[A-Za-z0-9_]*_gatedClock_enable_clk1]]: !firrtl.uint<1>
+// CHECK:         %[[R1:.+]] = firrtl.reg %[[CLK1_BASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[R2:.+]] = firrtl.reg %[[CLK2_BASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX1:.+]] = firrtl.mux(%[[CLK1_EN]], %data, %[[R1]])
+// CHECK:         firrtl.matchingconnect %[[R1]], %[[MUX1]]
+// CHECK:         %[[MUX2:.+]] = firrtl.mux(%[[CLK2_EN]], %data, %[[R2]])
+// CHECK:         firrtl.matchingconnect %[[R2]], %[[MUX2]]
+
+// CHECK-LABEL: firrtl.module @DifferentGating
+firrtl.circuit "DifferentGating" {
+  firrtl.module @FlexibleChild(in %clk1: !firrtl.clock,
+                               in %clk2: !firrtl.clock,
+                               in %data: !firrtl.uint<8>) {
+    %r1 = firrtl.reg %clk1 : !firrtl.clock, !firrtl.uint<8>
+    %r2 = firrtl.reg %clk2 : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r1, %data : !firrtl.uint<8>
+    firrtl.matchingconnect %r2, %data : !firrtl.uint<8>
+  }
+
+  firrtl.module @DifferentGating(in %base_clk: !firrtl.clock,
+                                 in %en1: !firrtl.uint<1>,
+                                 in %en2: !firrtl.uint<1>,
+                                 in %d: !firrtl.uint<8>) {
+    // CHECK: %[[C1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+    // CHECK: firrtl.int.clock_gate %base_clk, %en1
+    %g1 = firrtl.int.clock_gate %base_clk, %en1
+    // CHECK: firrtl.int.clock_gate %base_clk, %en2
+    %g2 = firrtl.int.clock_gate %base_clk, %en2
+
+    // First instance: gate on clk1, ungated on clk2
+    // CHECK: %{{.+}}, %{{.+}}, %{{.+}}, %[[I1_CLK2_BASE:.+]], %[[I1_CLK2_EN:.+]], %[[I1_CLK1_BASE:.+]], %[[I1_CLK1_EN:.+]] = firrtl.instance inst1 @FlexibleChild
+    %inst1_clk1, %inst1_clk2, %inst1_data = firrtl.instance inst1 @FlexibleChild(
+      in clk1: !firrtl.clock,
+      in clk2: !firrtl.clock,
+      in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %inst1_clk1, %g1 : !firrtl.clock
+    firrtl.matchingconnect %inst1_clk2, %base_clk : !firrtl.clock
+    firrtl.matchingconnect %inst1_data, %d : !firrtl.uint<8>
+
+    // Second instance: ungated on clk1, gate on clk2
+    // CHECK: %{{.+}}, %{{.+}}, %{{.+}}, %[[I2_CLK2_BASE:.+]], %[[I2_CLK2_EN:.+]], %[[I2_CLK1_BASE:.+]], %[[I2_CLK1_EN:.+]] = firrtl.instance inst2 @FlexibleChild
+    %inst2_clk1, %inst2_clk2, %inst2_data = firrtl.instance inst2 @FlexibleChild(
+      in clk1: !firrtl.clock,
+      in clk2: !firrtl.clock,
+      in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %inst2_clk1, %base_clk : !firrtl.clock
+    firrtl.matchingconnect %inst2_clk2, %g2 : !firrtl.clock
+    firrtl.matchingconnect %inst2_data, %d : !firrtl.uint<8>
+    // The new (base, enable) ports are all connected after the original
+    // instance connects. The relative order of the drives is an artifact of the
+    // planning worklist and carries no meaning, so match them order-insensitively.
+    // Instance1: ungated clk2 connects
+    // CHECK-DAG: firrtl.matchingconnect %[[I1_CLK2_BASE]], %base_clk
+    // CHECK-DAG: firrtl.matchingconnect %[[I1_CLK2_EN]], %[[C1]]
+    // Instance2: gated clk2 connects
+    // CHECK-DAG: firrtl.matchingconnect %[[I2_CLK2_BASE]], %base_clk
+    // CHECK-DAG: firrtl.matchingconnect %[[I2_CLK2_EN]], %en2
+    // Instance2: ungated clk1 connects (reuses the same constant)
+    // CHECK-DAG: firrtl.matchingconnect %[[I2_CLK1_BASE]], %base_clk
+    // CHECK-DAG: firrtl.matchingconnect %[[I2_CLK1_EN]], %[[C1]]
+    // Instance1: gated clk1 connects
+    // CHECK-DAG: firrtl.matchingconnect %[[I1_CLK1_BASE]], %base_clk
+    // CHECK-DAG: firrtl.matchingconnect %[[I1_CLK1_EN]], %en1
+  }
+}
+
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Instance output port connected to wire outside when block
+// - Tests if transformation handles instance outputs from nested blocks
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @Producer
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    out %out_clk: !firrtl.clock
+// CHECK-SAME:    in %[[PROD_BASE_IN:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[PROD_EN_IN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK-SAME:    out %[[PROD_BASE_OUT:[A-Za-z0-9_]*_gatedClock_baseClock_out_clk]]: !firrtl.clock
+// CHECK-SAME:    out %[[PROD_EN_OUT:[A-Za-z0-9_]*_gatedClock_enable_out_clk]]: !firrtl.uint<1>
+// CHECK:         firrtl.matchingconnect %out_clk, %clk
+// CHECK:         firrtl.matchingconnect %[[PROD_BASE_OUT]], %[[PROD_BASE_IN]]
+// CHECK:         firrtl.matchingconnect %[[PROD_EN_OUT]], %[[PROD_EN_IN]]
+
+// CHECK-LABEL: firrtl.module @Consumer
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<8>
+// CHECK-SAME:    in %[[CONS_BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[CONS_EN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+// CHECK:         %[[R:.+]] = firrtl.reg %[[CONS_BASE]] : !firrtl.clock, !firrtl.uint<8>
+// CHECK:         %[[MUX:.+]] = firrtl.mux(%[[CONS_EN]], %data, %[[R]])
+// CHECK:         firrtl.matchingconnect %[[R]], %[[MUX]]
+
+// CHECK-LABEL: firrtl.module @InstanceOutput
+firrtl.circuit "InstanceOutput" {
+  firrtl.layer @TestLayer bind {}
+
+  firrtl.module @Producer(in %clk: !firrtl.clock, out %out_clk: !firrtl.clock) {
+    firrtl.matchingconnect %out_clk, %clk : !firrtl.clock
+  }
+
+  firrtl.module @Consumer(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+
+  firrtl.module @InstanceOutput(in %base_clk: !firrtl.clock,
+                                in %en: !firrtl.uint<1>,
+                                in %cond: !firrtl.uint<1>,
+                                in %d: !firrtl.uint<8>) {
+    // CHECK: %[[GATE:.+]] = firrtl.int.clock_gate %base_clk, %en
+    %gated = firrtl.int.clock_gate %base_clk, %en
+
+    // CHECK: firrtl.layerblock @TestLayer
+    firrtl.layerblock @TestLayer {
+      // CHECK: %[[OUT_WIRE:.+]] = firrtl.wire : !firrtl.clock
+      %out_wire = firrtl.wire : !firrtl.clock
+      // CHECK: %[[WIRE_BASE:.+]] = firrtl.wire : !firrtl.clock
+      %wire_base = firrtl.wire : !firrtl.clock
+      // CHECK: %[[WIRE_EN:.+]] = firrtl.wire : !firrtl.uint<1>
+      %wire_en = firrtl.wire : !firrtl.uint<1>
+
+      // CHECK: %{{.+}}, %{{.+}}, %[[P_BASE_IN:.+]], %[[P_EN_IN:.+]], %[[P_BASE_OUT:.+]], %[[P_EN_OUT:.+]] = firrtl.instance producer @Producer
+      %p_clk, %p_out = firrtl.instance producer @Producer(in clk: !firrtl.clock, out out_clk: !firrtl.clock)
+      firrtl.matchingconnect %p_clk, %gated : !firrtl.clock
+      firrtl.matchingconnect %out_wire, %p_out : !firrtl.clock
+      firrtl.matchingconnect %wire_base, %p_out : !firrtl.clock
+      %c1 = firrtl.constant 1 : !firrtl.uint<1>
+      firrtl.matchingconnect %wire_en, %c1 : !firrtl.uint<1>
+
+      // CHECK: %{{.+}}, %{{.+}}, %[[C_BASE:.+]], %[[C_EN:.+]] = firrtl.instance consumer @Consumer
+      %c_clk, %c_data = firrtl.instance consumer @Consumer(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+      firrtl.matchingconnect %c_clk, %out_wire : !firrtl.clock
+      firrtl.matchingconnect %c_data, %d : !firrtl.uint<8>
+      firrtl.matchingconnect %c_clk, %wire_base : !firrtl.clock
+      firrtl.matchingconnect %c_data, %d : !firrtl.uint<8>
+      // CHECK: firrtl.matchingconnect %[[P_BASE_IN]], %base_clk
+      // CHECK: firrtl.matchingconnect %[[P_EN_IN]], %en
+      // CHECK: firrtl.matchingconnect %[[C_BASE]], %[[P_BASE_OUT]]
+      // CHECK: firrtl.matchingconnect %[[C_EN]], %[[P_EN_OUT]]
+    }
+  }
+}
+
+// -----
+
+firrtl.circuit "ClockOutOfChild" {
+  firrtl.module @Gen(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                     out %gclk: !firrtl.clock) {
+    %g = firrtl.int.clock_gate %clk, %en
+    firrtl.matchingconnect %gclk, %g : !firrtl.clock
+  }
+  firrtl.module @ClockOutOfChild(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>,
+                                 in %d: !firrtl.uint<8>) {
+    %c_clk, %c_en, %c_gclk = firrtl.instance c @Gen(in clk: !firrtl.clock, in en: !firrtl.uint<1>, out gclk: !firrtl.clock)
+    firrtl.matchingconnect %c_clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %c_en, %en : !firrtl.uint<1>
+    %r = firrtl.reg %c_gclk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Same module instantiated twice: gated clock into one instance, ungated into another
+// This tests that the pass correctly inserts (base, enable) ports for the gated
+// instance and uses constant 1 for the enable on the ungated instance.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @FlexibleClockModule
+// CHECK-SAME:    in %clk: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<8>
+// CHECK-SAME:    in %[[BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk]]: !firrtl.clock
+// CHECK-SAME:    in %[[EN:[A-Za-z0-9_]*_gatedClock_enable_clk]]: !firrtl.uint<1>
+firrtl.circuit "MixedGatingInstances" {
+  firrtl.module @FlexibleClockModule(in %clk: !firrtl.clock, in %data: !firrtl.uint<8>) {
+    // CHECK: %[[R:.+]] = firrtl.reg %[[BASE]] : !firrtl.clock, !firrtl.uint<8>
+    // CHECK: %[[MUX:.+]] = firrtl.mux(%[[EN]], %data, %[[R]])
+    // CHECK: firrtl.matchingconnect %[[R]], %[[MUX]]
+    %r = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %r, %data : !firrtl.uint<8>
+  }
+
+  // CHECK-LABEL: firrtl.module @MixedGatingInstances
+  firrtl.module @MixedGatingInstances(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>, in %d: !firrtl.uint<8>) {
+    // CHECK: %[[C1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+    // CHECK: firrtl.int.clock_gate %clk, %en
+    // CHECK: %{{.+}}, %{{.+}}, %[[I1_BASE:.+]], %[[I1_EN:.+]] = firrtl.instance inst1 @FlexibleClockModule
+    // CHECK: %{{.+}}, %{{.+}}, %[[I2_BASE:.+]], %[[I2_EN:.+]] = firrtl.instance inst2 @FlexibleClockModule
+    %g = firrtl.int.clock_gate %clk, %en
+
+    // First instance: ungated clock
+    %inst1_clk, %inst1_data = firrtl.instance inst1 @FlexibleClockModule(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %inst1_clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %inst1_data, %d : !firrtl.uint<8>
+
+    // Second instance: gated clock
+    %inst2_clk, %inst2_data = firrtl.instance inst2 @FlexibleClockModule(in clk: !firrtl.clock, in data: !firrtl.uint<8>)
+    firrtl.matchingconnect %inst2_clk, %g : !firrtl.clock
+    firrtl.matchingconnect %inst2_data, %d : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %[[I1_BASE]], %clk
+    // CHECK: firrtl.matchingconnect %[[I1_EN]], %[[C1]]
+    // CHECK: firrtl.matchingconnect %[[I2_BASE]], %clk
+    // CHECK: firrtl.matchingconnect %[[I2_EN]], %en
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multiple different clocks to the same module: one gated, one ungated
+// Tests that only the gated clock (clk2) gets (base, enable) port pair added.
+// The ungated clock (clk1) remains unchanged and uses the original clock directly.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.module @DualClockConsumer
+// CHECK-SAME:    in %clk1: !firrtl.clock
+// CHECK-SAME:    in %clk2: !firrtl.clock
+// CHECK-SAME:    in %data: !firrtl.uint<16>
+// CHECK-SAME:    in %[[CLK2_BASE:[A-Za-z0-9_]*_gatedClock_baseClock_clk2]]: !firrtl.clock
+// CHECK-SAME:    in %[[CLK2_EN:[A-Za-z0-9_]*_gatedClock_enable_clk2]]: !firrtl.uint<1>
+firrtl.circuit "MixedClockDomains" {
+  firrtl.module @DualClockConsumer(in %clk1: !firrtl.clock, in %clk2: !firrtl.clock, in %data: !firrtl.uint<16>) {
+    // r1 remains on the original ungated clk1
+    // CHECK: %[[R1:.+]] = firrtl.reg %clk1 : !firrtl.clock, !firrtl.uint<16>
+    // CHECK-NEXT: firrtl.matchingconnect %[[R1]], %data
+    %r1 = firrtl.reg %clk1 : !firrtl.clock, !firrtl.uint<16>
+    firrtl.matchingconnect %r1, %data : !firrtl.uint<16>
+
+    // r2 is rebound to the base clock and gets a mux with the enable
+    // CHECK: %[[R2:.+]] = firrtl.reg %[[CLK2_BASE]] : !firrtl.clock, !firrtl.uint<16>
+    // CHECK: %[[MUX2:.+]] = firrtl.mux(%[[CLK2_EN]], %data, %[[R2]])
+    // CHECK: firrtl.matchingconnect %[[R2]], %[[MUX2]]
+    %r2 = firrtl.reg %clk2 : !firrtl.clock, !firrtl.uint<16>
+    firrtl.matchingconnect %r2, %data : !firrtl.uint<16>
+  }
+
+  // CHECK-LABEL: firrtl.module @MixedClockDomains
+  firrtl.module @MixedClockDomains(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>, in %d: !firrtl.uint<16>) {
+    // CHECK: firrtl.int.clock_gate %clk, %en
+    %g = firrtl.int.clock_gate %clk, %en
+
+    // Instance with one ungated (clk1) and one gated (clk2) clock
+    // Only clk2 gets the gated clock ports
+    // CHECK: %{{.+}}, %{{.+}}, %{{.+}}, %[[C2_BASE:.+]], %[[C2_EN:.+]] = firrtl.instance consumer @DualClockConsumer
+    %c_clk1, %c_clk2, %c_data = firrtl.instance consumer @DualClockConsumer(in clk1: !firrtl.clock, in clk2: !firrtl.clock, in data: !firrtl.uint<16>)
+
+    // clk1 is ungated
+    firrtl.matchingconnect %c_clk1, %clk : !firrtl.clock
+    // clk2 is gated
+    firrtl.matchingconnect %c_clk2, %g : !firrtl.clock
+    firrtl.matchingconnect %c_data, %d : !firrtl.uint<16>
+
+    // Only clk2's base and enable are connected (clk1 needs no extra ports)
+    // CHECK: firrtl.matchingconnect %[[C2_BASE]], %clk
+    // CHECK: firrtl.matchingconnect %[[C2_EN]], %en
+  }
+}


### PR DESCRIPTION
The PR adds a `GatedClockConversion` utility that transforms clock-gated
operations to instead use the ungated clock and sink the clock gate enable
 into the operation. This is a global analysis and transformation that is 
driven by a client, which selects the operations for the gated clock 
conversion. This gated clock conversion is required to support force/release
synthesis in the ProbesToSignals transformation. In this PR, 
_Registers, force and release are the only supported operations_ for the
 gated clock conversion transformation. 

### Algorithm

`run()` executes four phases:

| Phase | Function | Mutates IR? | Content |
|---|---|---|---|
| 0 | `addRoot` | no | register roots with their clock operands |
| 1 | `analyzeFrom` + `computeGatedClocks` | no | build clock-flow graph, mark gated clocks |
| 2 | `plan` | **no** | forward pass producing *the plan* |
| 3 | `applyPlan` | yes | wires → ports/instances → exprs, connects, root rewrites |
| 4 | cleanup in `run()` | yes | eliminate temp wires, erase replaced instances |

This PR can be reviewed commit-by-commit, each is a self-contained slice of the pipeline.

### Review guide (commit by commit)

| # | Commit | What to look at |
|---|--------|-----------------|
| 1 | `a5999ea8f` **clock flow analysis** | Backward walk from roots; builds `srcToDstClocks`, finds base clocks / gated values. **No IR mutation.** |
| 2 | `0240dc1e8` **plan data structures** | `MatRef` (names values that don't exist yet; keeps instance results symbolic). Shared enable DAG so gate cascades lower to one `and` per gate. |
| 3 | `fd5e644cc` **planning phase** | Forward replay of the clock graph → `(base, enable)` per clock, plus ports / instance drives / carrier wires. Still **no IR mutation**. Cyclic / unreachable clocks handled. |
| 4 | `8220bad15` **root rewriting** | Registers → `mux(en, rhs, reg)` on free clock; force/release fold enable into predicate. Multi-driver regs: warn + skip. |
| 5 | `a3d36eb42` **materialize the plan** | Three sweeps: carrier wires → ports + re-instance → enables, connects, root rewrites. Sweep order keeps `MatRef` resolution valid. |
| 6 | `b98d77750` **eliminate carrier wires** | Forward + delete temporary alias wires where a single write dominates. |
| 7 | `e90a68acd` **`run()` driver** | Wires phases together; reports roots whose clock was never planned. |
| 8 | `38d1516d8` **test pass + tests** | `-test-firrtl-gated-clock-conversion` + lit coverage (cascades, multi-instance, boundary clocks both ways, diagnostics). |



Assisted-by: opus-5, Grok 4.5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->