### PR TITLE
[ESI] Canonicalize ESI Channel related ops

### DIFF
--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -567,7 +567,7 @@ def WindowFieldType : ESI_Type<"WindowField"> {
   let genVerifyDecl = 1;
 }
 
-def WrapWindow : ESI_Physical_Op<"window.wrap", [Pure]> {
+def WrapWindow : ESI_Physical_Op<"window.wrap", [Pure, OperatesOnESITypes]> {
   let summary = "wrap a union into a data window";
 
   let arguments = (ins AnyType:$frame);
@@ -583,6 +583,7 @@ def WrapWindow : ESI_Physical_Op<"window.wrap", [Pure]> {
 
 def UnwrapWindow : ESI_Physical_Op<"window.unwrap", [
       Pure,
+      OperatesOnESITypes,
       DeclareOpInterfaceMethods<InferTypeOpInterface>
   ]> {
   let summary = "unwrap a data window into a union";

--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -207,11 +207,17 @@ def UnwrapValidReadyOp : ESI_Op<"unwrap.vr", [
   let arguments = (ins ChannelType:$chanInput, I1:$ready);
   let results = (outs AnyType:$rawOutput, I1:$valid);
   let hasCustomAssemblyFormat = 1;
+  let hasCanonicalizeMethod = 1;
   let hasVerifier = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$inChan, "mlir::Value":$ready)>
   ];
+
+  let extraClassDeclaration = [{
+    static LogicalResult mergeAndErase(UnwrapValidReadyOp, WrapValidReadyOp,
+                                       PatternRewriter&);
+  }];
 }
 
 def WrapFIFOOp : ESI_Op<"wrap.fifo", [

--- a/include/circt/Dialect/ESI/ESIDialect.td
+++ b/include/circt/Dialect/ESI/ESIDialect.td
@@ -39,7 +39,7 @@ class ESI_Op<string mnemonic, list<Trait> traits = []> :
     Op<ESI_Dialect, mnemonic, traits>;
 
 /// Marks an ESI op that legitimately operates on ESI types (e.g. data windows),
-/// which indicates that must be lowered after the channels.
+/// which indicates that it must be lowered after the channels.
 def OperatesOnESITypes : NativeOpTrait<"OperatesOnESITypes"> {
   let cppNamespace = "::circt::esi";
 }

--- a/include/circt/Dialect/ESI/ESIDialect.td
+++ b/include/circt/Dialect/ESI/ESIDialect.td
@@ -38,6 +38,12 @@ def ESI_Dialect : Dialect {
 class ESI_Op<string mnemonic, list<Trait> traits = []> :
     Op<ESI_Dialect, mnemonic, traits>;
 
+/// Marks an ESI op that legitimately operates on ESI types (e.g. data windows),
+/// which indicates that must be lowered after the channels.
+def OperatesOnESITypes : NativeOpTrait<"OperatesOnESITypes"> {
+  let cppNamespace = "::circt::esi";
+}
+
 // Divide ESI ops into abstract and physical. Abstract ops are ones which
 // need to be lowered to physical ops before they get lowered further (into
 // HW). The abstract to physical lowering may not be fully constrained -- this

--- a/include/circt/Dialect/ESI/ESIOps.h
+++ b/include/circt/Dialect/ESI/ESIOps.h
@@ -26,6 +26,13 @@
 
 namespace circt {
 namespace esi {
+
+/// Trait marking an ESI op that operates on ESI types (e.g. data windows) and
+/// must get lowered after all the "wrapper" ESI types (e.g. channels).
+template <typename ConcreteType>
+class OperatesOnESITypes
+    : public mlir::OpTrait::TraitBase<ConcreteType, OperatesOnESITypes> {};
+
 /// Describes a service port. In the unidirection case, either (but not both)
 /// type fields will be null.
 struct ServicePortInfo {

--- a/lib/Dialect/ESI/ESIFolds.cpp
+++ b/lib/Dialect/ESI/ESIFolds.cpp
@@ -32,6 +32,41 @@ LogicalResult WrapValidReadyOp::canonicalize(WrapValidReadyOp op,
     rewriter.eraseOp(op);
     return success();
   }
+
+  // If the sole consumer is an unwrap, merge and erase.
+  if (!op.getChanOutput().hasOneUse())
+    return rewriter.notifyMatchFailure(
+        op, "channel output doesn't have exactly one use");
+  auto unwrap = dyn_cast_or_null<UnwrapValidReadyOp>(
+      op.getChanOutput().getUses().begin()->getOwner());
+  if (succeeded(UnwrapValidReadyOp::mergeAndErase(unwrap, op, rewriter)))
+    return success();
+  return rewriter.notifyMatchFailure(
+      op, "could not find corresponding unwrap for wrap");
+}
+
+LogicalResult UnwrapValidReadyOp::mergeAndErase(UnwrapValidReadyOp unwrap,
+                                                WrapValidReadyOp wrap,
+                                                PatternRewriter &rewriter) {
+  // Only merge when the wrap's channel feeds nothing but this unwrap. Otherwise
+  // erasing the channel value (replacing it with null below) would corrupt the
+  // other users (e.g. a snoop op observing the same channel).
+  if (unwrap && wrap && wrap.getChanOutput().hasOneUse()) {
+    // Capture the ready operand before replacing `unwrap`, which erases it.
+    Value ready = unwrap.getReady();
+    rewriter.replaceOp(unwrap, {wrap.getRawInput(), wrap.getValid()});
+    rewriter.replaceOp(wrap, {{}, ready});
+    return success();
+  }
+  return failure();
+}
+
+LogicalResult UnwrapValidReadyOp::canonicalize(UnwrapValidReadyOp op,
+                                               PatternRewriter &rewriter) {
+  auto wrap =
+      dyn_cast_or_null<WrapValidReadyOp>(op.getChanInput().getDefiningOp());
+  if (succeeded(UnwrapValidReadyOp::mergeAndErase(op, wrap, rewriter)))
+    return success();
   return failure();
 }
 

--- a/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
@@ -795,6 +795,44 @@ static void canonicalizeChannelOps(Operation *top, MLIRContext *ctxt) {
       config);
 }
 
+/// Verify that no ESI channel ops or channel-typed values remain under `top`,
+/// which the channel lowering is responsible for removing. Returns true if all
+/// channels were removed; otherwise emits diagnostics on a handful of offenders
+/// (rather than all of them) and returns false.
+static bool verifyNoChannelsRemain(Operation *top, MLIRContext *ctxt) {
+  constexpr unsigned maxReported = 10;
+  unsigned numReported = 0;
+  auto *esiDialect = ctxt->getLoadedDialect<ESIDialect>();
+  top->walk([&](Operation *op) {
+    // Ops marked OperatesOnESITypes (e.g. the window wrap/unwrap ops)
+    // operate on ESI types and are lowered by a later pass.
+    if (op->hasTrait<OperatesOnESITypes>())
+      return WalkResult::advance();
+
+    // Other ESI ops must have been lowered away by now.
+    if (op->getDialect() == esiDialect) {
+      op->emitError("lower-esi-to-hw left behind a channel operation");
+      if (++numReported >= maxReported)
+        return WalkResult::interrupt();
+      return WalkResult::advance();
+    }
+
+    // Channel types should have been fully lowered away, even if they're buried
+    // inside aggregates. Look for any type that contains a channel anywhere
+    // within it.
+    bool hasChannelType =
+        llvm::any_of(op->getResultTypes(), typeContainsChannel) ||
+        llvm::any_of(op->getOperandTypes(), typeContainsChannel);
+    if (hasChannelType) {
+      op->emitError("lower-esi-to-hw left behind a channel-typed value");
+      if (++numReported >= maxReported)
+        return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return numReported == 0;
+}
+
 void ESItoHWPass::runOnOperation() {
   auto top = getOperation();
   auto *ctxt = &getContext();
@@ -874,19 +912,9 @@ void ESItoHWPass::runOnOperation() {
   // canonicalizers, including merging the adjacent wrap/unwrap pairs.
   canonicalizeChannelOps(top, ctxt);
 
-  // Verify that no channel operations remain. The canonicalizers above are
-  // responsible for removing every ESI op; this conversion provides a clear
-  // failure (rather than leaving channel-typed IR behind) if any survive.
-  ConversionTarget channelVerifyTarget(*ctxt);
-  channelVerifyTarget.addLegalDialect<comb::CombDialect>();
-  channelVerifyTarget.addLegalDialect<HWDialect>();
-  channelVerifyTarget.addLegalDialect<SVDialect>();
-  channelVerifyTarget.addIllegalDialect<ESIDialect>();
-  channelVerifyTarget.addLegalOp<WrapWindow, UnwrapWindow>();
-
-  RewritePatternSet channelVerifyPatterns(ctxt);
-  if (failed(applyPartialConversion(top, channelVerifyTarget,
-                                    std::move(channelVerifyPatterns))))
+  // The canonicalizers above are responsible for removing every ESI op and
+  // channel-typed value. Verify that none remain.
+  if (!verifyNoChannelsRemain(top, ctxt))
     signalPassFailure();
 }
 

--- a/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
@@ -795,6 +795,11 @@ static void canonicalizeChannelOps(Operation *top, MLIRContext *ctxt) {
       config);
 }
 
+/// Returns true if any of `types` is or contains an ESI channel.
+static bool anyTypeContainsChannel(TypeRange types) {
+  return llvm::any_of(types, typeContainsChannel);
+}
+
 /// Verify that no ESI channel ops or channel-typed values remain under `top`,
 /// which the channel lowering is responsible for removing. Returns true if all
 /// channels were removed; otherwise emits diagnostics on a handful of offenders
@@ -819,10 +824,13 @@ static bool verifyNoChannelsRemain(Operation *top, MLIRContext *ctxt) {
 
     // Channel types should have been fully lowered away, even if they're buried
     // inside aggregates. Look for any type that contains a channel anywhere
-    // within it.
-    bool hasChannelType =
-        llvm::any_of(op->getResultTypes(), typeContainsChannel) ||
-        llvm::any_of(op->getOperandTypes(), typeContainsChannel);
+    // within it: results, operands, and block arguments (e.g. module ports,
+    // which may not appear as an operand if they are unused).
+    bool hasChannelType = anyTypeContainsChannel(op->getResultTypes()) ||
+                          anyTypeContainsChannel(op->getOperandTypes());
+    for (Region &region : op->getRegions())
+      for (Block &block : region)
+        hasChannelType |= anyTypeContainsChannel(block.getArgumentTypes());
     if (hasChannelType) {
       op->emitError("lower-esi-to-hw left behind a channel-typed value");
       if (++numReported >= maxReported)

--- a/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
@@ -22,6 +22,7 @@
 #include "circt/Support/SymCache.h"
 
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -152,107 +153,6 @@ LogicalResult NullSourceOpLowering::matchAndRewrite(
   }
   return success();
 }
-
-namespace {
-/// Eliminate a WrapValidOnlyOp and its consumer UnwrapValidOnlyOp.
-struct RemoveWrapValidOnlyOp : public OpConversionPattern<WrapValidOnlyOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(WrapValidOnlyOp wrap, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    if (ChannelType::hasNoConsumers(wrap.getChanOutput())) {
-      rewriter.eraseOp(wrap);
-      return success();
-    }
-    if (!ChannelType::hasOneConsumer(wrap.getChanOutput()))
-      return rewriter.notifyMatchFailure(
-          wrap, "ValidOnly wrap didn't have exactly one consumer.");
-    auto unwrap = dyn_cast<UnwrapValidOnlyOp>(
-        ChannelType::getSingleConsumer(wrap.getChanOutput())->getOwner());
-    if (!unwrap)
-      return rewriter.notifyMatchFailure(
-          wrap, "ValidOnly wrap consumer is not an unwrap.vo.");
-    rewriter.replaceOp(unwrap, {adaptor.getRawInput(), adaptor.getValid()});
-    rewriter.eraseOp(wrap);
-    return success();
-  }
-};
-
-/// Eliminate an UnwrapValidOnlyOp by finding its producing WrapValidOnlyOp.
-struct RemoveUnwrapValidOnlyOp : public OpConversionPattern<UnwrapValidOnlyOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(UnwrapValidOnlyOp unwrap, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto wrap = dyn_cast_or_null<WrapValidOnlyOp>(
-        adaptor.getChanInput().getDefiningOp());
-    if (!wrap)
-      return rewriter.notifyMatchFailure(
-          unwrap, "unwrap.vo input must come from a wrap.vo.");
-    if (!ChannelType::hasOneConsumer(wrap.getChanOutput()))
-      return rewriter.notifyMatchFailure(
-          wrap, "ValidOnly wrap didn't have exactly one consumer.");
-    rewriter.replaceOp(unwrap, {wrap.getRawInput(), wrap.getValid()});
-    rewriter.eraseOp(wrap);
-    return success();
-  }
-};
-
-/// Eliminate a WrapValidReadyOp and its consumer UnwrapValidReadyOp.
-struct RemoveWrapValidReadyOp : public OpConversionPattern<WrapValidReadyOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(WrapValidReadyOp wrap, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    if (ChannelType::hasNoConsumers(wrap.getChanOutput())) {
-      auto c1 = hw::ConstantOp::create(rewriter, wrap.getLoc(),
-                                       rewriter.getI1Type(), 1);
-      rewriter.replaceOp(wrap, {nullptr, c1});
-      return success();
-    }
-    if (!ChannelType::hasOneConsumer(wrap.getChanOutput()))
-      return rewriter.notifyMatchFailure(
-          wrap, "Wrap didn't have exactly one consumer.");
-    auto unwrap = dyn_cast<UnwrapValidReadyOp>(
-        ChannelType::getSingleConsumer(wrap.getChanOutput())->getOwner());
-    if (!unwrap)
-      return rewriter.notifyMatchFailure(wrap,
-                                         "Wrap consumer is not an unwrap.vr.");
-    rewriter.replaceOp(wrap, {nullptr, unwrap.getReady()});
-    rewriter.replaceOp(unwrap, {adaptor.getRawInput(), adaptor.getValid()});
-    return success();
-  }
-};
-
-/// Eliminate an UnwrapValidReadyOp by finding its producing WrapValidReadyOp.
-struct RemoveUnwrapValidReadyOp
-    : public OpConversionPattern<UnwrapValidReadyOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(UnwrapValidReadyOp unwrap, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto wrap = dyn_cast_or_null<WrapValidReadyOp>(
-        adaptor.getChanInput().getDefiningOp());
-    if (!wrap)
-      return rewriter.notifyMatchFailure(
-          unwrap, "unwrap.vr input must come from a wrap.vr.");
-    if (!ChannelType::hasOneConsumer(wrap.getChanOutput()))
-      return rewriter.notifyMatchFailure(
-          wrap, "Wrap didn't have exactly one consumer.");
-    rewriter.replaceOp(wrap, {nullptr, adaptor.getReady()});
-    rewriter.replaceOp(unwrap, {wrap.getRawInput(), wrap.getValid()});
-    return success();
-  }
-};
-} // anonymous namespace
 
 namespace {
 /// Eliminate snoop operations by extracting signals from wrap operations.
@@ -859,6 +759,42 @@ LogicalResult CosimManifestLowering::matchAndRewrite(
   rewriter.eraseOp(op);
   return success();
 }
+
+/// Returns true if `type` is an ESI channel or an aggregate (e.g. array,
+/// struct) that contains a channel somewhere within it.
+static bool typeContainsChannel(Type type) {
+  return type.walk([](ChannelType) { return WalkResult::interrupt(); })
+      .wasInterrupted();
+}
+
+/// Greedily canonicalize every op whose type involves an ESI channel. This
+/// hopefully removes all channel ops: channel-typed aggregates (e.g.
+/// hw.array_create/ array_get over channels) fold away, exposing adjacent
+/// wrap/unwrap pairs that the wrap/unwrap canonicalizers then merge. A greedy
+/// rewrite is used (rather than a dialect conversion) because this requires
+/// folding, DCE, and iterating to a fixpoint, none of which the conversion
+/// driver does.
+static void canonicalizeChannelOps(Operation *top, MLIRContext *ctxt) {
+  SmallVector<Operation *> channelOps;
+  DenseSet<OperationName> seenOpNames;
+  RewritePatternSet canonPatterns(ctxt);
+  top->walk([&](Operation *op) {
+    if (!llvm::any_of(op->getResultTypes(), typeContainsChannel) &&
+        !llvm::any_of(op->getOperandTypes(), typeContainsChannel))
+      return;
+    channelOps.push_back(op);
+    if (std::optional<mlir::RegisteredOperationName> info =
+            op->getRegisteredInfo();
+        info && seenOpNames.insert(op->getName()).second)
+      info->getCanonicalizationPatterns(canonPatterns, ctxt);
+  });
+  mlir::GreedyRewriteConfig config;
+  config.setStrictness(mlir::GreedyRewriteStrictness::ExistingAndNewOps);
+  (void)mlir::applyOpPatternsGreedily(
+      channelOps, mlir::FrozenRewritePatternSet(std::move(canonPatterns)),
+      config);
+}
+
 void ESItoHWPass::runOnOperation() {
   auto top = getOperation();
   auto *ctxt = &getContext();
@@ -934,25 +870,23 @@ void ESItoHWPass::runOnOperation() {
     return;
   }
 
-  // Lower the channel operations.
-  ConversionTarget pass3Target(*ctxt);
-  pass3Target.addLegalDialect<comb::CombDialect>();
-  pass3Target.addLegalDialect<HWDialect>();
-  pass3Target.addLegalDialect<SVDialect>();
-  pass3Target.addIllegalDialect<ESIDialect>();
-  pass3Target.addLegalOp<WrapWindow, UnwrapWindow>();
+  // Eliminate all channel ops (and channel-typed aggregates) via their
+  // canonicalizers, including merging the adjacent wrap/unwrap pairs.
+  canonicalizeChannelOps(top, ctxt);
 
-  RewritePatternSet pass3Patterns(ctxt);
-  pass3Patterns.insert<CanonicalizerOpLowering<UnwrapFIFOOp>>(ctxt);
-  pass3Patterns.insert<CanonicalizerOpLowering<WrapFIFOOp>>(ctxt);
-  pass3Patterns.insert<CanonicalizerOpLowering<UnwrapValidOnlyOp>>(ctxt);
-  pass3Patterns.insert<CanonicalizerOpLowering<WrapValidOnlyOp>>(ctxt);
-  pass3Patterns.insert<RemoveWrapValidOnlyOp>(ctxt);
-  pass3Patterns.insert<RemoveUnwrapValidOnlyOp>(ctxt);
-  pass3Patterns.insert<RemoveWrapValidReadyOp>(ctxt);
-  pass3Patterns.insert<RemoveUnwrapValidReadyOp>(ctxt);
-  if (failed(
-          applyPartialConversion(top, pass3Target, std::move(pass3Patterns))))
+  // Verify that no channel operations remain. The canonicalizers above are
+  // responsible for removing every ESI op; this conversion provides a clear
+  // failure (rather than leaving channel-typed IR behind) if any survive.
+  ConversionTarget channelVerifyTarget(*ctxt);
+  channelVerifyTarget.addLegalDialect<comb::CombDialect>();
+  channelVerifyTarget.addLegalDialect<HWDialect>();
+  channelVerifyTarget.addLegalDialect<SVDialect>();
+  channelVerifyTarget.addIllegalDialect<ESIDialect>();
+  channelVerifyTarget.addLegalOp<WrapWindow, UnwrapWindow>();
+
+  RewritePatternSet channelVerifyPatterns(ctxt);
+  if (failed(applyPartialConversion(top, channelVerifyTarget,
+                                    std::move(channelVerifyPatterns))))
     signalPassFailure();
 }
 

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -423,3 +423,27 @@ hw.module @voSnoopXactPassthrough(in %chan_in: !esi.channel<i32, ValidOnly>, out
 }
 // HW-LABEL: hw.module @voSnoopXactPassthrough(in %chan_in : i32, in %chan_in_valid : i1, out chan_out : i32, out chan_out_valid : i1, out snoop_xact : i1, out snoop_data : i32) {
 // HW-NEXT:    hw.output %chan_in, %chan_in_valid, %chan_in_valid, %chan_in : i32, i1, i1, i32
+
+// --- Full HW lowering: channel-typed hw.array ops are eliminated ---
+// Channels bundled into an `hw.array` and indexed back out with constant
+// indices must be folded away so the wrap/unwrap pairs can be lowered. After
+// `lower-esi-to-hw` no channel-typed (or channel-containing aggregate) IR may
+// remain.
+hw.module @ChannelArray(in %data0: i32, in %data1: i32, in %valid: i1, in %ready0: i1, in %ready1: i1, out rdy0: i1, out rdy1: i1, out out0: i32, out v0: i1, out out1: i32, out v1: i1) {
+  %c0 = hw.constant 0 : i1
+  %c1 = hw.constant 1 : i1
+  %chan0, %r0 = esi.wrap.vr %data0, %valid : i32
+  %chan1, %r1 = esi.wrap.vr %data1, %valid : i32
+  %arr = hw.array_create %chan1, %chan0 : !esi.channel<i32>
+  %e0 = hw.array_get %arr[%c0] : !hw.array<2x!esi.channel<i32>>, i1
+  %e1 = hw.array_get %arr[%c1] : !hw.array<2x!esi.channel<i32>>, i1
+  %d0, %dv0 = esi.unwrap.vr %e0, %ready0 : i32
+  %d1, %dv1 = esi.unwrap.vr %e1, %ready1 : i32
+  hw.output %r0, %r1, %d0, %dv0, %d1, %dv1 : i1, i1, i32, i1, i32, i1
+}
+// HW-LABEL: hw.module @ChannelArray(in %data0 : i32, in %data1 : i32, in %valid : i1, in %ready0 : i1, in %ready1 : i1, out rdy0 : i1, out rdy1 : i1, out out0 : i32, out v0 : i1, out out1 : i32, out v1 : i1) {
+// HW-NOT:     esi.
+// HW-NOT:     !esi.channel
+// HW-NOT:     hw.array
+// HW:         hw.output %ready0, %ready1, %data0, %valid, %data1, %valid : i1, i1, i32, i1, i32, i1
+

--- a/test/Dialect/ESI/passes/lower_to_hw_errors.mlir
+++ b/test/Dialect/ESI/passes/lower_to_hw_errors.mlir
@@ -1,6 +1,7 @@
 // RUN: circt-opt --lower-esi-to-hw %s --verify-diagnostics --split-input-file
 
 // Issue #8219
+// expected-error@+1 {{lower-esi-to-hw left behind a channel-typed value}}
 hw.module @CoerceBundleTransform(in %b_out_result : !esi.channel<i16>, out b_in_resp : !esi.channel<i8>) {
   // expected-error@+1 {{lower-esi-to-hw left behind a channel operation}}
   %rawOutput, %valid = esi.unwrap.vr %b_out_result, %ready : i16

--- a/test/Dialect/ESI/passes/lower_to_hw_errors.mlir
+++ b/test/Dialect/ESI/passes/lower_to_hw_errors.mlir
@@ -2,9 +2,11 @@
 
 // Issue #8219
 hw.module @CoerceBundleTransform(in %b_out_result : !esi.channel<i16>, out b_in_resp : !esi.channel<i8>) {
-  // expected-error@+1 {{failed to legalize operation 'esi.unwrap.vr' that was explicitly marked illegal}}
+  // expected-error@+1 {{lower-esi-to-hw left behind a channel operation}}
   %rawOutput, %valid = esi.unwrap.vr %b_out_result, %ready : i16
   %0 = comb.extract %rawOutput from 0 : (i16) -> i8
+  // expected-error@+1 {{lower-esi-to-hw left behind a channel operation}}
   %chanOutput, %ready = esi.wrap.vr %0, %valid : i8
+  // expected-error@+1 {{lower-esi-to-hw left behind a channel-typed value}}
   hw.output %chanOutput : !esi.channel<i8>
 }


### PR DESCRIPTION
Run canonicalizers on anything which touches ESI channels in the hopes that they will be canonicalized away. The idea is that after the lower-esi-to-hw pass there shouldn't be any ESI channels.

Assisted-by: vscode:Claude Opus 4.8

