### PR TITLE
[ESI] Support lowering array of channels ports

### DIFF
--- a/lib/Dialect/ESI/ESIFolds.cpp
+++ b/lib/Dialect/ESI/ESIFolds.cpp
@@ -72,7 +72,8 @@ LogicalResult UnwrapValidReadyOp::canonicalize(UnwrapValidReadyOp op,
 
 LogicalResult UnwrapFIFOOp::mergeAndErase(UnwrapFIFOOp unwrap, WrapFIFOOp wrap,
                                           PatternRewriter &rewriter) {
-  if (unwrap && wrap) {
+  // Only merge when the wrap's channel feeds nothing but this unwrap.
+  if (unwrap && wrap && wrap.getChanOutput().hasOneUse()) {
     // Capture the rden operand before replacing `unwrap`, which erases it.
     Value rden = unwrap.getRden();
     rewriter.replaceOp(unwrap, {wrap.getData(), wrap.getEmpty()});
@@ -126,7 +127,8 @@ LogicalResult WrapFIFOOp::canonicalize(WrapFIFOOp op,
 LogicalResult UnwrapValidOnlyOp::mergeAndErase(UnwrapValidOnlyOp unwrap,
                                                WrapValidOnlyOp wrap,
                                                PatternRewriter &rewriter) {
-  if (unwrap && wrap) {
+  // Only merge when the wrap's channel feeds nothing but this unwrap.
+  if (unwrap && wrap && wrap.getChanOutput().hasOneUse()) {
     rewriter.replaceOp(unwrap, {wrap.getRawInput(), wrap.getValid()});
     rewriter.eraseOp(wrap);
     return success();

--- a/lib/Dialect/ESI/Passes/ESILowerPorts.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerPorts.cpp
@@ -254,6 +254,16 @@ public:
             }
             return PortConversionBuilder::build(port);
           }
+          // The lowering decomposes the array element-by-element, so the size
+          // must be a known, non-zero constant. A parametric size makes
+          // `getNumElements()` return -1 and a zero size would assert in
+          // hw.array_create; emit a diagnostic rather than crash.
+          if (!isa<IntegerAttr>(arrTy.getSizeAttr()) ||
+              arrTy.getNumElements() == 0)
+            return converter.getModule()
+                .emitOpError("cannot lower array-of-channels port with a "
+                             "non-constant or zero-length size")
+                .attachNote(port.loc);
           return buildChannelPort<ArrayChannelPort>(converter, port,
                                                     chanTy.getSignaling());
         })

--- a/lib/Dialect/ESI/Passes/ESILowerPorts.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerPorts.cpp
@@ -18,6 +18,8 @@
 
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "llvm/Support/MathExtras.h"
+
 namespace circt {
 namespace esi {
 #define GEN_PASS_DEF_LOWERESIPORTS
@@ -42,19 +44,120 @@ inline static StringRef getStringAttributeOr(Operation *op, StringRef attrName,
 
 namespace {
 
-// Base class for all ESI signaling standards, which handles potentially funky
-// attribute-based naming conventions.
-struct ESISignalingStandad : public PortConversion {
-  ESISignalingStandad(PortConverterImpl &converter, hw::PortInfo origPort)
-      : PortConversion(converter, origPort) {}
+/// Per-channel ESI signaling protocol policies (ValidReady, FIFO, ValidOnly).
+/// These are stateless policy types with only static methods; they are never
+/// instantiated. They are used as the policy type parameter of the
+/// channel-port lowering containers below, which share their logic between
+/// scalar channel ports and arrays of channel ports.
+///
+/// Each protocol has one or more control signals associated with the channel
+/// data to, at minimum, indicate the validity of the data. The protocol defines
+/// how these signals are named and whether there is a backpressure handshake
+/// signal.
+///
+/// Each policy provides:
+///  - getValiditySuffix(module): suffix for the forward validity signal.
+///  - hasBackpressure: compile-time flag, true iff the protocol has a
+///    backpressure handshake signal.
+///  - getBackpressureSuffix(module): suffix for the backpressure handshake
+///    signal (only defined when 'hasBackpressure' is true).
+///  - wrap(b, loc, chanTy, data, validity): recreate a channel of type 'chanTy'
+///    from its 'data' and 'validity' signals; returns {channel, backpressure}
+///    (the backpressure value is null if the protocol has no backpressure
+///    signal).
+///  - unwrap(b, loc, chan, backpressure): break 'chan' into its {data,
+///    validity} signals ('backpressure' is unused for protocols without a
+///    backpressure signal).
+///
+/// Note: if we add a credit control signaling protocol in the future, this will
+/// have to be re-thought.
+
+/// ValidReady: 'valid' validity, 'ready' backpressure handshake.
+struct ValidReadyProtocol {
+  static constexpr bool hasBackpressure = true;
+  static StringRef getValiditySuffix(Operation *module) {
+    return getStringAttributeOr(module, extModPortValidSuffix, "_valid");
+  }
+  static StringRef getBackpressureSuffix(Operation *module) {
+    return getStringAttributeOr(module, extModPortReadySuffix, "_ready");
+  }
+  static std::pair<Value, Value> wrap(OpBuilder &b, Location loc,
+                                      ChannelType chanTy, Value data,
+                                      Value validity) {
+    auto wrap = WrapValidReadyOp::create(b, loc, data, validity);
+    return {wrap.getChanOutput(), wrap.getReady()};
+  }
+  static std::pair<Value, Value> unwrap(OpBuilder &b, Location loc, Value chan,
+                                        Value backpressure) {
+    auto unwrap = UnwrapValidReadyOp::create(b, loc, chan, backpressure);
+    return {unwrap.getRawOutput(), unwrap.getValid()};
+  }
 };
 
-/// Implement the Valid/Ready signaling standard.
-class ValidReady : public ESISignalingStandad {
+/// FIFO: 'empty' validity (empty == !valid), 'rden' (read-enable)
+/// "backpressure" handshake.
+struct FIFOProtocol {
+  static constexpr bool hasBackpressure = true;
+  static StringRef getValiditySuffix(Operation *module) {
+    return getStringAttributeOr(module, extModPortEmptySuffix, "_empty");
+  }
+  static StringRef getBackpressureSuffix(Operation *module) {
+    return getStringAttributeOr(module, extModPortRdenSuffix, "_rden");
+  }
+  static std::pair<Value, Value> wrap(OpBuilder &b, Location loc,
+                                      ChannelType chanTy, Value data,
+                                      Value validity) {
+    auto wrap = WrapFIFOOp::create(
+        b, loc, ArrayRef<Type>({chanTy, b.getI1Type()}), data, validity);
+    return {wrap.getChanOutput(), wrap.getRden()};
+  }
+  static std::pair<Value, Value> unwrap(OpBuilder &b, Location loc, Value chan,
+                                        Value backpressure) {
+    auto unwrap = UnwrapFIFOOp::create(b, loc, chan, backpressure);
+    return {unwrap.getData(), unwrap.getEmpty()};
+  }
+};
+
+/// ValidOnly: forward 'valid' validity, no backpressure handshake.
+struct ValidOnlyProtocol {
+  static constexpr bool hasBackpressure = false;
+  static StringRef getValiditySuffix(Operation *module) {
+    return getStringAttributeOr(module, extModPortValidSuffix, "_valid");
+  }
+  static std::pair<Value, Value> wrap(OpBuilder &b, Location loc,
+                                      ChannelType chanTy, Value data,
+                                      Value validity) {
+    auto wrap = WrapValidOnlyOp::create(b, loc, data, validity);
+    return {wrap.getChanOutput(), Value()};
+  }
+  static std::pair<Value, Value> unwrap(OpBuilder &b, Location loc, Value chan,
+                                        Value /*backpressure*/) {
+    auto unwrap = UnwrapValidOnlyOp::create(b, loc, chan);
+    return {unwrap.getRawOutput(), unwrap.getValid()};
+  }
+};
+
+/// Return true if 'type' contains an ESI channel nested inside an aggregate.
+/// Used to detect (and reject) ports which embed channels in a way this pass
+/// cannot lower (e.g. arrays of arrays of channels, or structs of channels).
+static bool containsChannel(Type type) {
+  if (auto arr = dyn_cast<hw::ArrayType>(type)) {
+    Type elem = arr.getElementType();
+    return isa<esi::ChannelType>(elem) || containsChannel(elem);
+  }
+  if (auto str = dyn_cast<hw::StructType>(type))
+    return llvm::any_of(str.getElements(), [](const auto &field) {
+      return isa<esi::ChannelType>(field.type) || containsChannel(field.type);
+    });
+  return false;
+}
+
+/// Lower a single ESI channel port into its constituent wire-level signals
+/// using the 'Protocol' signaling policy.
+template <typename Protocol>
+class ScalarChannelPort : public PortConversion {
 public:
-  ValidReady(PortConverterImpl &converter, hw::PortInfo origPort)
-      : ESISignalingStandad(converter, origPort), validPort(origPort),
-        readyPort(origPort) {}
+  using PortConversion::PortConversion;
 
   void mapInputSignals(OpBuilder &b, Operation *inst, Value instValue,
                        SmallVectorImpl<Value> &newOperands,
@@ -67,16 +170,18 @@ private:
   void buildInputSignals() override;
   void buildOutputSignals() override;
 
-  // Keep around information about the port numbers of the relevant ports and
-  // use that later to update the instances.
-  PortInfo validPort, readyPort, dataPort;
+  // Port info for the lowered signals. 'backpressurePort' is only valid when
+  // 'Protocol::hasBackpressure' is true.
+  PortInfo dataPort, validityPort, backpressurePort;
 };
 
-/// Implement the FIFO signaling standard.
-class FIFO : public ESISignalingStandad {
+/// Lower a port which is an array of ESI channels into arrays of the
+/// constituent wire-level signals (one array element per channel) using the
+/// 'Protocol' signaling policy.
+template <typename Protocol>
+class ArrayChannelPort : public PortConversion {
 public:
-  FIFO(PortConverterImpl &converter, hw::PortInfo origPort)
-      : ESISignalingStandad(converter, origPort) {}
+  using PortConversion::PortConversion;
 
   void mapInputSignals(OpBuilder &b, Operation *inst, Value instValue,
                        SmallVectorImpl<Value> &newOperands,
@@ -89,32 +194,39 @@ private:
   void buildInputSignals() override;
   void buildOutputSignals() override;
 
-  // Keep around information about the port numbers of the relevant ports and
-  // use that later to update the instances.
-  PortInfo rdenPort, emptyPort, dataPort;
+  // Port info for the lowered signal arrays. 'backpressurePort' is only valid
+  // when 'Protocol::hasBackpressure' is true.
+  PortInfo dataPort, validityPort, backpressurePort;
 };
 
-/// Implement the Valid-only signaling standard (no backpressure).
-class ValidOnly : public ESISignalingStandad {
-public:
-  ValidOnly(PortConverterImpl &converter, hw::PortInfo origPort)
-      : ESISignalingStandad(converter, origPort), validPort(origPort) {}
+// Emit an error about an unknown signaling standard on 'port'.
+static FailureOr<std::unique_ptr<PortConversion>>
+emitUnknownSignaling(Operation *op, hw::PortInfo port,
+                     ChannelSignaling signaling) {
+  auto error =
+      op->emitOpError("encountered unknown signaling standard on port '")
+      << stringifyEnum(signaling) << "'";
+  error.attachNote(port.loc);
+  return error;
+}
 
-  void mapInputSignals(OpBuilder &b, Operation *inst, Value instValue,
-                       SmallVectorImpl<Value> &newOperands,
-                       ArrayRef<Backedge> newResults) override;
-  void mapOutputSignals(OpBuilder &b, Operation *inst, Value instValue,
-                        SmallVectorImpl<Value> &newOperands,
-                        ArrayRef<Backedge> newResults) override;
-
-private:
-  void buildInputSignals() override;
-  void buildOutputSignals() override;
-
-  // Keep around information about the port numbers of the relevant ports and
-  // use that later to update the instances.
-  PortInfo validPort, dataPort;
-};
+/// Instantiate the channel-port lowering container 'PortKind' (e.g.
+/// ScalarChannelPort or ArrayChannelPort) with the protocol policy selected by
+/// 'signaling'. Returns failure for an unknown signaling standard.
+template <template <typename> class PortKind>
+static FailureOr<std::unique_ptr<PortConversion>>
+buildChannelPort(PortConverterImpl &converter, hw::PortInfo port,
+                 ChannelSignaling signaling) {
+  switch (signaling) {
+  case ChannelSignaling::ValidReady:
+    return {std::make_unique<PortKind<ValidReadyProtocol>>(converter, port)};
+  case ChannelSignaling::FIFO:
+    return {std::make_unique<PortKind<FIFOProtocol>>(converter, port)};
+  case ChannelSignaling::ValidOnly:
+    return {std::make_unique<PortKind<ValidOnlyProtocol>>(converter, port)};
+  }
+  return emitUnknownSignaling(converter.getModule(), port, signaling);
+}
 
 class ESIPortConversionBuilder : public PortConversionBuilder {
 public:
@@ -124,276 +236,301 @@ public:
                port.type)
         .Case([&](esi::ChannelType chanTy)
                   -> FailureOr<std::unique_ptr<PortConversion>> {
-          // Determine which ESI signaling standard is specified.
-          ChannelSignaling signaling = chanTy.getSignaling();
-          if (signaling == ChannelSignaling::ValidReady)
-            return {std::make_unique<ValidReady>(converter, port)};
-
-          if (signaling == ChannelSignaling::FIFO)
-            return {std::make_unique<FIFO>(converter, port)};
-
-          if (signaling == ChannelSignaling::ValidOnly)
-            return {std::make_unique<ValidOnly>(converter, port)};
-
-          auto error = converter.getModule().emitOpError(
-                           "encountered unknown signaling standard on port '")
-                       << stringifyEnum(signaling) << "'";
-          error.attachNote(port.loc);
-          return error;
+          return buildChannelPort<ScalarChannelPort>(converter, port,
+                                                     chanTy.getSignaling());
+        })
+        .Case([&](hw::ArrayType arrTy)
+                  -> FailureOr<std::unique_ptr<PortConversion>> {
+          auto chanTy = dyn_cast<esi::ChannelType>(arrTy.getElementType());
+          if (!chanTy) {
+            // Channels nested deeper than a top-level array of channels are
+            // not supported.
+            if (containsChannel(arrTy)) {
+              auto error = converter.getModule().emitOpError(
+                  "cannot lower port containing channels nested inside an "
+                  "aggregate other than a single array of channels");
+              error.attachNote(port.loc);
+              return error;
+            }
+            return PortConversionBuilder::build(port);
+          }
+          return buildChannelPort<ArrayChannelPort>(converter, port,
+                                                    chanTy.getSignaling());
         })
         .Default([&](auto) { return PortConversionBuilder::build(port); });
   }
 };
 } // namespace
 
-void ValidReady::buildInputSignals() {
-  Type i1 = IntegerType::get(getContext(), 1, IntegerType::Signless);
-
-  StringRef inSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortInSuffix, "");
-  StringRef validSuffix(getStringAttributeOr(converter.getModule(),
-                                             extModPortValidSuffix, "_valid"));
-
-  // When we find one, add a data and valid signal to the new args.
-  Value data = converter.createNewInput(
-      origPort, inSuffix, cast<esi::ChannelType>(origPort.type).getInner(),
-      dataPort);
-  Value valid =
-      converter.createNewInput(origPort, validSuffix + inSuffix, i1, validPort);
-
-  Value ready;
-  if (body) {
-    ImplicitLocOpBuilder b(origPort.loc, body, body->begin());
-    // Build the ESI wrap operation to translate the lowered signals to what
-    // they were. (A later pass takes care of eliminating the ESI ops.)
-    auto wrap = WrapValidReadyOp::create(b, data, valid);
-    ready = wrap.getReady();
-    // Replace uses of the old ESI port argument with the new one from the
-    // wrap.
-    body->getArgument(origPort.argNum).replaceAllUsesWith(wrap.getChanOutput());
-  }
-
-  StringRef readySuffix = getStringAttributeOr(converter.getModule(),
-                                               extModPortReadySuffix, "_ready");
-  StringRef outSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortOutSuffix, "");
-  converter.createNewOutput(origPort, readySuffix + outSuffix, i1, ready,
-                            readyPort);
+/// Extract element 'idx' from the array-typed value 'array'.
+static Value getArrayElement(OpBuilder &b, Location loc, Value array,
+                             size_t idx) {
+  auto arrTy = cast<hw::ArrayType>(array.getType());
+  IntegerType idxType = b.getIntegerType(
+      std::max(1u, llvm::Log2_64_Ceil(arrTy.getNumElements())));
+  Value idxVal = hw::ConstantOp::create(b, loc, idxType, idx);
+  return hw::ArrayGetOp::create(b, loc, array, idxVal);
 }
 
-void ValidReady::mapInputSignals(OpBuilder &b, Operation *inst, Value instValue,
-                                 SmallVectorImpl<Value> &newOperands,
-                                 ArrayRef<Backedge> newResults) {
-  auto unwrap = UnwrapValidReadyOp::create(b, inst->getLoc(),
-                                           inst->getOperand(origPort.argNum),
-                                           newResults[readyPort.argNum]);
-  newOperands[dataPort.argNum] = unwrap.getRawOutput();
-  newOperands[validPort.argNum] = unwrap.getValid();
+/// Pack a list of element values (with 'elements[i]' destined for array index
+/// 'i') into an hw.array. hw.array_create takes its operands in reverse order
+/// (operand 0 becomes the highest index), so the list is reversed to keep
+/// 'elements[i]' at array index 'i'.
+static Value packArray(OpBuilder &b, Location loc, ArrayRef<Value> elements) {
+  SmallVector<Value> reversed(elements.rbegin(), elements.rend());
+  return hw::ArrayCreateOp::create(b, loc, reversed);
 }
 
-void ValidReady::buildOutputSignals() {
-  Type i1 = IntegerType::get(getContext(), 1, IntegerType::Signless);
+//===----------------------------------------------------------------------===//
+// ScalarChannelPort
+//===----------------------------------------------------------------------===//
 
-  StringRef readySuffix = getStringAttributeOr(converter.getModule(),
-                                               extModPortReadySuffix, "_ready");
-  StringRef inSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortInSuffix, "");
-
-  Value ready =
-      converter.createNewInput(origPort, readySuffix + inSuffix, i1, readyPort);
-  Value data, valid;
-  if (body) {
-    auto *terminator = body->getTerminator();
-    ImplicitLocOpBuilder b(origPort.loc, terminator);
-
-    auto unwrap = UnwrapValidReadyOp::create(
-        b, terminator->getOperand(origPort.argNum), ready);
-    data = unwrap.getRawOutput();
-    valid = unwrap.getValid();
-  }
-
-  // New outputs.
-  StringRef outSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortOutSuffix, "");
-  StringRef validSuffix = getStringAttributeOr(converter.getModule(),
-                                               extModPortValidSuffix, "_valid");
-  converter.createNewOutput(origPort, outSuffix,
-                            cast<esi::ChannelType>(origPort.type).getInner(),
-                            data, dataPort);
-  converter.createNewOutput(origPort, validSuffix + outSuffix, i1, valid,
-                            validPort);
-}
-
-void ValidReady::mapOutputSignals(OpBuilder &b, Operation *inst,
-                                  Value instValue,
-                                  SmallVectorImpl<Value> &newOperands,
-                                  ArrayRef<Backedge> newResults) {
-  auto wrap =
-      WrapValidReadyOp::create(b, inst->getLoc(), newResults[dataPort.argNum],
-                               newResults[validPort.argNum]);
-  inst->getResult(origPort.argNum).replaceAllUsesWith(wrap.getChanOutput());
-  newOperands[readyPort.argNum] = wrap.getReady();
-}
-
-void FIFO::buildInputSignals() {
+template <typename Protocol>
+void ScalarChannelPort<Protocol>::buildInputSignals() {
+  Operation *module = converter.getModule();
   Type i1 = IntegerType::get(getContext(), 1, IntegerType::Signless);
   auto chanTy = cast<ChannelType>(origPort.type);
 
-  StringRef rdenSuffix(getStringAttributeOr(converter.getModule(),
-                                            extModPortRdenSuffix, "_rden"));
-  StringRef emptySuffix(getStringAttributeOr(converter.getModule(),
-                                             extModPortEmptySuffix, "_empty"));
-  StringRef inSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortInSuffix, "");
-  StringRef outSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortOutSuffix, "");
+  StringRef inSuffix = getStringAttributeOr(module, extModPortInSuffix, "");
+  StringRef outSuffix = getStringAttributeOr(module, extModPortOutSuffix, "");
 
-  // When we find one, add a data and valid signal to the new args.
-  Value data = converter.createNewInput(
-      origPort, inSuffix, cast<esi::ChannelType>(origPort.type).getInner(),
-      dataPort);
-  Value empty =
-      converter.createNewInput(origPort, emptySuffix + inSuffix, i1, emptyPort);
+  // The data and forward validity signals come into the module alongside the
+  // data.
+  Value data =
+      converter.createNewInput(origPort, inSuffix, chanTy.getInner(), dataPort);
+  Value validity = converter.createNewInput(
+      origPort, Protocol::getValiditySuffix(module) + inSuffix, i1,
+      validityPort);
 
-  Value rden;
+  Value backpressure;
   if (body) {
     ImplicitLocOpBuilder b(origPort.loc, body, body->begin());
-    // Build the ESI wrap operation to translate the lowered signals to what
-    // they were. (A later pass takes care of eliminating the ESI ops.)
-    auto wrap = WrapFIFOOp::create(b, ArrayRef<Type>({chanTy, b.getI1Type()}),
-                                   data, empty);
-    rden = wrap.getRden();
-    // Replace uses of the old ESI port argument with the new one from the
-    // wrap.
-    body->getArgument(origPort.argNum).replaceAllUsesWith(wrap.getChanOutput());
+    // Recreate the original channel value from the lowered signals. (A later
+    // pass takes care of eliminating the ESI ops.)
+    auto [chan, bp] = Protocol::wrap(b, b.getLoc(), chanTy, data, validity);
+    backpressure = bp;
+    body->getArgument(origPort.argNum).replaceAllUsesWith(chan);
   }
 
-  converter.createNewOutput(origPort, rdenSuffix + outSuffix, i1, rden,
-                            rdenPort);
+  // The backpressure handshake signal (if any) leaves the module.
+  if constexpr (Protocol::hasBackpressure)
+    converter.createNewOutput(
+        origPort, Protocol::getBackpressureSuffix(module) + outSuffix, i1,
+        backpressure, backpressurePort);
 }
 
-void FIFO::mapInputSignals(OpBuilder &b, Operation *inst, Value instValue,
-                           SmallVectorImpl<Value> &newOperands,
-                           ArrayRef<Backedge> newResults) {
-  auto unwrap =
-      UnwrapFIFOOp::create(b, inst->getLoc(), inst->getOperand(origPort.argNum),
-                           newResults[rdenPort.argNum]);
-  newOperands[dataPort.argNum] = unwrap.getData();
-  newOperands[emptyPort.argNum] = unwrap.getEmpty();
+template <typename Protocol>
+void ScalarChannelPort<Protocol>::mapInputSignals(
+    OpBuilder &b, Operation *inst, Value, SmallVectorImpl<Value> &newOperands,
+    ArrayRef<Backedge> newResults) {
+  Value backpressure;
+  if constexpr (Protocol::hasBackpressure)
+    backpressure = newResults[backpressurePort.argNum];
+  auto [data, validity] = Protocol::unwrap(
+      b, inst->getLoc(), inst->getOperand(origPort.argNum), backpressure);
+  newOperands[dataPort.argNum] = data;
+  newOperands[validityPort.argNum] = validity;
 }
 
-void FIFO::buildOutputSignals() {
+template <typename Protocol>
+void ScalarChannelPort<Protocol>::buildOutputSignals() {
+  Operation *module = converter.getModule();
   Type i1 = IntegerType::get(getContext(), 1, IntegerType::Signless);
+  auto chanTy = cast<ChannelType>(origPort.type);
 
-  StringRef inSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortInSuffix, "");
-  StringRef outSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortOutSuffix, "");
-  StringRef rdenSuffix(getStringAttributeOr(converter.getModule(),
-                                            extModPortRdenSuffix, "_rden"));
-  StringRef emptySuffix(getStringAttributeOr(converter.getModule(),
-                                             extModPortEmptySuffix, "_empty"));
-  Value rden =
-      converter.createNewInput(origPort, rdenSuffix + inSuffix, i1, rdenPort);
-  Value data, empty;
+  StringRef inSuffix = getStringAttributeOr(module, extModPortInSuffix, "");
+  StringRef outSuffix = getStringAttributeOr(module, extModPortOutSuffix, "");
+
+  // The backpressure handshake signal (if any) comes into the module.
+  Value backpressure;
+  if constexpr (Protocol::hasBackpressure)
+    backpressure = converter.createNewInput(
+        origPort, Protocol::getBackpressureSuffix(module) + inSuffix, i1,
+        backpressurePort);
+
+  Value data, validity;
   if (body) {
     auto *terminator = body->getTerminator();
     ImplicitLocOpBuilder b(origPort.loc, terminator);
-
-    auto unwrap =
-        UnwrapFIFOOp::create(b, terminator->getOperand(origPort.argNum), rden);
-    data = unwrap.getData();
-    empty = unwrap.getEmpty();
+    auto unwrapped = Protocol::unwrap(
+        b, b.getLoc(), terminator->getOperand(origPort.argNum), backpressure);
+    data = unwrapped.first;
+    validity = unwrapped.second;
   }
 
-  // New outputs.
-  converter.createNewOutput(origPort, outSuffix,
-                            cast<esi::ChannelType>(origPort.type).getInner(),
-                            data, dataPort);
-  converter.createNewOutput(origPort, emptySuffix + outSuffix, i1, empty,
-                            emptyPort);
+  // The data and forward validity signals leave the module.
+  converter.createNewOutput(origPort, outSuffix, chanTy.getInner(), data,
+                            dataPort);
+  converter.createNewOutput(origPort,
+                            Protocol::getValiditySuffix(module) + outSuffix, i1,
+                            validity, validityPort);
 }
 
-void FIFO::mapOutputSignals(OpBuilder &b, Operation *inst, Value instValue,
-                            SmallVectorImpl<Value> &newOperands,
-                            ArrayRef<Backedge> newResults) {
-  auto wrap = WrapFIFOOp::create(
-      b, inst->getLoc(), ArrayRef<Type>({origPort.type, b.getI1Type()}),
-      newResults[dataPort.argNum], newResults[emptyPort.argNum]);
-  inst->getResult(origPort.argNum).replaceAllUsesWith(wrap.getChanOutput());
-  newOperands[rdenPort.argNum] = wrap.getRden();
+template <typename Protocol>
+void ScalarChannelPort<Protocol>::mapOutputSignals(
+    OpBuilder &b, Operation *inst, Value, SmallVectorImpl<Value> &newOperands,
+    ArrayRef<Backedge> newResults) {
+  auto chanTy = cast<ChannelType>(origPort.type);
+  auto [chan, backpressure] =
+      Protocol::wrap(b, inst->getLoc(), chanTy, newResults[dataPort.argNum],
+                     newResults[validityPort.argNum]);
+  inst->getResult(origPort.argNum).replaceAllUsesWith(chan);
+  if constexpr (Protocol::hasBackpressure)
+    newOperands[backpressurePort.argNum] = backpressure;
 }
 
 //===----------------------------------------------------------------------===//
-// ValidOnly signaling standard implementation.
+// ArrayChannelPort
 //===----------------------------------------------------------------------===//
 
-void ValidOnly::buildInputSignals() {
+template <typename Protocol>
+void ArrayChannelPort<Protocol>::buildInputSignals() {
+  Operation *module = converter.getModule();
   Type i1 = IntegerType::get(getContext(), 1, IntegerType::Signless);
+  auto arrTy = cast<hw::ArrayType>(origPort.type);
+  auto chanTy = cast<ChannelType>(arrTy.getElementType());
+  size_t numElems = arrTy.getNumElements();
+  auto dataArrTy = hw::ArrayType::get(chanTy.getInner(), numElems);
+  auto validityArrTy = hw::ArrayType::get(i1, numElems);
 
-  StringRef inSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortInSuffix, "");
-  StringRef validSuffix(getStringAttributeOr(converter.getModule(),
-                                             extModPortValidSuffix, "_valid"));
+  StringRef inSuffix = getStringAttributeOr(module, extModPortInSuffix, "");
+  StringRef outSuffix = getStringAttributeOr(module, extModPortOutSuffix, "");
 
-  // When we find one, add a data and valid signal to the new args.
-  Value data = converter.createNewInput(
-      origPort, inSuffix, cast<esi::ChannelType>(origPort.type).getInner(),
-      dataPort);
-  Value valid =
-      converter.createNewInput(origPort, validSuffix + inSuffix, i1, validPort);
+  // The data and forward validity signal arrays come into the module alongside
+  // the data.
+  Value dataArr =
+      converter.createNewInput(origPort, inSuffix, dataArrTy, dataPort);
+  Value validityArr = converter.createNewInput(
+      origPort, Protocol::getValiditySuffix(module) + inSuffix, validityArrTy,
+      validityPort);
 
+  Value backpressureArr;
   if (body) {
     ImplicitLocOpBuilder b(origPort.loc, body, body->begin());
-    auto wrap = WrapValidOnlyOp::create(b, data, valid);
-    body->getArgument(origPort.argNum).replaceAllUsesWith(wrap.getChanOutput());
+    // Recreate the original array of channels by wrapping each element's
+    // lowered signals back into a channel.
+    SmallVector<Value> chans, backpressures;
+    for (size_t i = 0; i < numElems; ++i) {
+      Value data = getArrayElement(b, b.getLoc(), dataArr, i);
+      Value validity = getArrayElement(b, b.getLoc(), validityArr, i);
+      auto [chan, bp] = Protocol::wrap(b, b.getLoc(), chanTy, data, validity);
+      chans.push_back(chan);
+      if constexpr (Protocol::hasBackpressure)
+        backpressures.push_back(bp);
+    }
+    body->getArgument(origPort.argNum)
+        .replaceAllUsesWith(packArray(b, b.getLoc(), chans));
+    if (!backpressures.empty())
+      backpressureArr = packArray(b, b.getLoc(), backpressures);
   }
-  // No ready/rden output port for ValidOnly.
+
+  // The backpressure handshake signal array (if any) leaves the module.
+  if constexpr (Protocol::hasBackpressure)
+    converter.createNewOutput(
+        origPort, Protocol::getBackpressureSuffix(module) + outSuffix,
+        validityArrTy, backpressureArr, backpressurePort);
 }
 
-void ValidOnly::mapInputSignals(OpBuilder &b, Operation *inst, Value instValue,
-                                SmallVectorImpl<Value> &newOperands,
-                                ArrayRef<Backedge> newResults) {
-  auto unwrap = UnwrapValidOnlyOp::create(b, inst->getLoc(),
-                                          inst->getOperand(origPort.argNum));
-  newOperands[dataPort.argNum] = unwrap.getRawOutput();
-  newOperands[validPort.argNum] = unwrap.getValid();
+template <typename Protocol>
+void ArrayChannelPort<Protocol>::mapInputSignals(
+    OpBuilder &b, Operation *inst, Value, SmallVectorImpl<Value> &newOperands,
+    ArrayRef<Backedge> newResults) {
+  Location loc = inst->getLoc();
+  Value chanArr = inst->getOperand(origPort.argNum);
+  size_t numElems = cast<hw::ArrayType>(origPort.type).getNumElements();
+
+  Value backpressureArr;
+  if constexpr (Protocol::hasBackpressure)
+    backpressureArr = newResults[backpressurePort.argNum];
+
+  // Unwrap each channel element into its data and validity signals.
+  SmallVector<Value> datas, validities;
+  for (size_t i = 0; i < numElems; ++i) {
+    Value chan = getArrayElement(b, loc, chanArr, i);
+    Value backpressure;
+    if constexpr (Protocol::hasBackpressure)
+      backpressure = getArrayElement(b, loc, backpressureArr, i);
+    auto [data, validity] = Protocol::unwrap(b, loc, chan, backpressure);
+    datas.push_back(data);
+    validities.push_back(validity);
+  }
+  newOperands[dataPort.argNum] = packArray(b, loc, datas);
+  newOperands[validityPort.argNum] = packArray(b, loc, validities);
 }
 
-void ValidOnly::buildOutputSignals() {
+template <typename Protocol>
+void ArrayChannelPort<Protocol>::buildOutputSignals() {
+  Operation *module = converter.getModule();
   Type i1 = IntegerType::get(getContext(), 1, IntegerType::Signless);
+  auto arrTy = cast<hw::ArrayType>(origPort.type);
+  auto chanTy = cast<ChannelType>(arrTy.getElementType());
+  size_t numElems = arrTy.getNumElements();
+  auto dataArrTy = hw::ArrayType::get(chanTy.getInner(), numElems);
+  auto validityArrTy = hw::ArrayType::get(i1, numElems);
 
-  Value data, valid;
+  StringRef inSuffix = getStringAttributeOr(module, extModPortInSuffix, "");
+  StringRef outSuffix = getStringAttributeOr(module, extModPortOutSuffix, "");
+
+  // The backpressure handshake signal array (if any) comes into the module.
+  Value backpressureArr;
+  if constexpr (Protocol::hasBackpressure)
+    backpressureArr = converter.createNewInput(
+        origPort, Protocol::getBackpressureSuffix(module) + inSuffix,
+        validityArrTy, backpressurePort);
+
+  Value dataArr, validityArr;
   if (body) {
     auto *terminator = body->getTerminator();
     ImplicitLocOpBuilder b(origPort.loc, terminator);
-
-    auto unwrap =
-        UnwrapValidOnlyOp::create(b, terminator->getOperand(origPort.argNum));
-    data = unwrap.getRawOutput();
-    valid = unwrap.getValid();
+    Value chanArr = terminator->getOperand(origPort.argNum);
+    // Unwrap each channel element into its data and validity signals.
+    SmallVector<Value> datas, validities;
+    for (size_t i = 0; i < numElems; ++i) {
+      Value chan = getArrayElement(b, b.getLoc(), chanArr, i);
+      Value backpressure;
+      if constexpr (Protocol::hasBackpressure)
+        backpressure = getArrayElement(b, b.getLoc(), backpressureArr, i);
+      auto [data, validity] =
+          Protocol::unwrap(b, b.getLoc(), chan, backpressure);
+      datas.push_back(data);
+      validities.push_back(validity);
+    }
+    dataArr = packArray(b, b.getLoc(), datas);
+    validityArr = packArray(b, b.getLoc(), validities);
   }
 
-  // New outputs.
-  StringRef outSuffix =
-      getStringAttributeOr(converter.getModule(), extModPortOutSuffix, "");
-  StringRef validSuffix = getStringAttributeOr(converter.getModule(),
-                                               extModPortValidSuffix, "_valid");
-  converter.createNewOutput(origPort, outSuffix,
-                            cast<esi::ChannelType>(origPort.type).getInner(),
-                            data, dataPort);
-  converter.createNewOutput(origPort, validSuffix + outSuffix, i1, valid,
-                            validPort);
-  // No ready/rden input port for ValidOnly.
+  // The data and forward validity signal arrays leave the module.
+  converter.createNewOutput(origPort, outSuffix, dataArrTy, dataArr, dataPort);
+  converter.createNewOutput(origPort,
+                            Protocol::getValiditySuffix(module) + outSuffix,
+                            validityArrTy, validityArr, validityPort);
 }
 
-void ValidOnly::mapOutputSignals(OpBuilder &b, Operation *inst, Value instValue,
-                                 SmallVectorImpl<Value> &newOperands,
-                                 ArrayRef<Backedge> newResults) {
-  auto wrap =
-      WrapValidOnlyOp::create(b, inst->getLoc(), newResults[dataPort.argNum],
-                              newResults[validPort.argNum]);
-  inst->getResult(origPort.argNum).replaceAllUsesWith(wrap.getChanOutput());
+template <typename Protocol>
+void ArrayChannelPort<Protocol>::mapOutputSignals(
+    OpBuilder &b, Operation *inst, Value, SmallVectorImpl<Value> &newOperands,
+    ArrayRef<Backedge> newResults) {
+  Location loc = inst->getLoc();
+  auto arrTy = cast<hw::ArrayType>(origPort.type);
+  auto chanTy = cast<ChannelType>(arrTy.getElementType());
+  size_t numElems = arrTy.getNumElements();
+
+  Value dataArr = newResults[dataPort.argNum];
+  Value validityArr = newResults[validityPort.argNum];
+
+  // Wrap each element's data and validity signals back into a channel.
+  SmallVector<Value> chans, backpressures;
+  for (size_t i = 0; i < numElems; ++i) {
+    Value data = getArrayElement(b, loc, dataArr, i);
+    Value validity = getArrayElement(b, loc, validityArr, i);
+    auto [chan, bp] = Protocol::wrap(b, loc, chanTy, data, validity);
+    chans.push_back(chan);
+    if (bp)
+      backpressures.push_back(bp);
+  }
+  inst->getResult(origPort.argNum).replaceAllUsesWith(packArray(b, loc, chans));
+  if constexpr (Protocol::hasBackpressure)
+    newOperands[backpressurePort.argNum] = packArray(b, loc, backpressures);
 }
 
 namespace {

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -424,26 +424,186 @@ hw.module @voSnoopXactPassthrough(in %chan_in: !esi.channel<i32, ValidOnly>, out
 // HW-LABEL: hw.module @voSnoopXactPassthrough(in %chan_in : i32, in %chan_in_valid : i1, out chan_out : i32, out chan_out_valid : i1, out snoop_xact : i1, out snoop_data : i32) {
 // HW-NEXT:    hw.output %chan_in, %chan_in_valid, %chan_in_valid, %chan_in : i32, i1, i1, i32
 
-// --- Full HW lowering: channel-typed hw.array ops are eliminated ---
-// Channels bundled into an `hw.array` and indexed back out with constant
-// indices must be folded away so the wrap/unwrap pairs can be lowered. After
-// `lower-esi-to-hw` no channel-typed (or channel-containing aggregate) IR may
-// remain.
-hw.module @ChannelArray(in %data0: i32, in %data1: i32, in %valid: i1, in %ready0: i1, in %ready1: i1, out rdy0: i1, out rdy1: i1, out out0: i32, out v0: i1, out out1: i32, out v1: i1) {
-  %c0 = hw.constant 0 : i1
-  %c1 = hw.constant 1 : i1
-  %chan0, %r0 = esi.wrap.vr %data0, %valid : i32
-  %chan1, %r1 = esi.wrap.vr %data1, %valid : i32
-  %arr = hw.array_create %chan1, %chan0 : !esi.channel<i32>
-  %e0 = hw.array_get %arr[%c0] : !hw.array<2x!esi.channel<i32>>, i1
-  %e1 = hw.array_get %arr[%c1] : !hw.array<2x!esi.channel<i32>>, i1
-  %d0, %dv0 = esi.unwrap.vr %e0, %ready0 : i32
-  %d1, %dv1 = esi.unwrap.vr %e1, %ready1 : i32
-  hw.output %r0, %r1, %d0, %dv0, %d1, %dv1 : i1, i1, i32, i1, i32, i1
-}
-// HW-LABEL: hw.module @ChannelArray(in %data0 : i32, in %data1 : i32, in %valid : i1, in %ready0 : i1, in %ready1 : i1, out rdy0 : i1, out rdy1 : i1, out out0 : i32, out v0 : i1, out out1 : i32, out v1 : i1) {
-// HW-NOT:     esi.
-// HW-NOT:     !esi.channel
-// HW-NOT:     hw.array
-// HW:         hw.output %ready0, %ready1, %data0, %valid, %data1, %valid : i1, i1, i32, i1, i32, i1
+//===----------------------------------------------------------------------===//
+// Arrays of channels
+//
+// An `!hw.array<N x !esi.channel<T>>` port lowers into parallel arrays of the
+// constituent wire signals: one array element per channel.
+//===----------------------------------------------------------------------===//
 
+// A successful full HW lowering implies the per-element esi.wrap/unwrap ops were
+// all eliminated; only the data/valid/ready signal arrays remain.
+
+// --- ValidReady array swizzle: reverse the channel order. ---
+// This checks that the per-element data/valid signals are routed forward
+// through the swizzle while the ready backpressure is routed back through the
+// inverse permutation.
+// HW-LABEL: hw.module @arrSwizzleVR(in %in : !hw.array<4xi8>, in %in_valid : !hw.array<4xi1>, in %out_ready : !hw.array<4xi1>, out in_ready : !hw.array<4xi1>, out out : !hw.array<4xi8>, out out_valid : !hw.array<4xi1>)
+// Unpack data + valid for each input channel; each get is preceded by its own
+// index constant (elements 0..3 -> 0, 1, -2, -1 as a 2-bit value).
+// HW:       hw.constant 0 : i2
+// HW-NEXT:  %[[D0:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant 0 : i2
+// HW-NEXT:  %[[V0:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[D1:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[V1:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[D2:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[V2:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[D3:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[V3:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// Backpressure travels the opposite way: in_ready is built from out_ready[0..3]
+// in order, then reversed by array_create, so in_ready[3] is driven by
+// out_ready[0] (the channel that input 3 was swizzled to).
+// HW-NEXT:  %[[INR:.+]] = hw.array_create %[[R0:.+]], %[[R1:.+]], %[[R2:.+]], %[[R3:.+]] : i1
+// HW-NEXT:  hw.constant 0 : i2
+// HW-NEXT:  %[[R0]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[R1]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[R2]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[R3]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// Data + valid are reversed into the outputs: out[0]=in[3] ... out[3]=in[0].
+// HW-NEXT:  %[[OUT:.+]] = hw.array_create %[[D0]], %[[D1]], %[[D2]], %[[D3]] : i8
+// HW-NEXT:  %[[OUTV:.+]] = hw.array_create %[[V0]], %[[V1]], %[[V2]], %[[V3]] : i1
+// HW-NEXT:  hw.output %[[INR]], %[[OUT]], %[[OUTV]] : !hw.array<4xi1>, !hw.array<4xi8>, !hw.array<4xi1>
+hw.module @arrSwizzleVR(in %in: !hw.array<4 x !esi.channel<i8>>, out out: !hw.array<4 x !esi.channel<i8>>) {
+  %c0 = hw.constant 0 : i2
+  %c1 = hw.constant 1 : i2
+  %c2 = hw.constant 2 : i2
+  %c3 = hw.constant 3 : i2
+  %ch0 = hw.array_get %in[%c0] : !hw.array<4 x !esi.channel<i8>>, i2
+  %ch1 = hw.array_get %in[%c1] : !hw.array<4 x !esi.channel<i8>>, i2
+  %ch2 = hw.array_get %in[%c2] : !hw.array<4 x !esi.channel<i8>>, i2
+  %ch3 = hw.array_get %in[%c3] : !hw.array<4 x !esi.channel<i8>>, i2
+  // array_create operand 0 lands at the highest index, so this reverses.
+  %swizzled = hw.array_create %ch0, %ch1, %ch2, %ch3 : !esi.channel<i8>
+  hw.output %swizzled : !hw.array<4 x !esi.channel<i8>>
+}
+
+// De-swizzle around the instance: the instance reverses the channels, so
+// reversing its output again recovers the original order (an identity loopback
+// through the swizzle). This precisely checks the array operands feeding and
+// produced by the instance.
+// HW-LABEL: hw.module @arrSwizzleVRTop(in %in : !hw.array<4xi8>, in %in_valid : !hw.array<4xi1>, in %out_ready : !hw.array<4xi1>, out in_ready : !hw.array<4xi1>, out out : !hw.array<4xi8>, out out_valid : !hw.array<4xi1>)
+// Unpack the module's %in data + valid (passed straight into the instance).
+// HW:       hw.constant 0 : i2
+// HW-NEXT:  %[[D0:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant 0 : i2
+// HW-NEXT:  %[[V0:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[D1:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[V1:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[D2:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[V2:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[D3:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[V3:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// The module's in_ready output reverses the instance's in_ready (operand 0 ->
+// highest index): in_ready[3] is driven by foo.in_ready[0].
+// HW-NEXT:  %[[INRDY:.+]] = hw.array_create %[[IR3:.+]], %[[IR2:.+]], %[[IR1:.+]], %[[IR0:.+]] : i1
+// HW-NEXT:  hw.constant 0 : i2
+// HW-NEXT:  %[[IR0]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[IR1]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[IR2]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[IR3]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
+// The instance input data/valid are the unpacked %in elements, repacked in
+// order (in[i] -> instance in[i]).
+// HW-NEXT:  %[[INST_IN:.+]] = hw.array_create %[[D3]], %[[D2]], %[[D1]], %[[D0]] : i8
+// HW-NEXT:  %[[INST_INV:.+]] = hw.array_create %[[V3]], %[[V2]], %[[V1]], %[[V0]] : i1
+// Unpack the instance's output data + valid.
+// HW-NEXT:  hw.constant 0 : i2
+// HW-NEXT:  %[[O0:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant 0 : i2
+// HW-NEXT:  %[[OV0:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[O1:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[OV1:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[O2:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[OV2:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[O3:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[OV3:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
+// The instance's out_ready input reverses the module's out_ready.
+// HW-NEXT:  %[[INST_ORDY:.+]] = hw.array_create %[[OR0:.+]], %[[OR1:.+]], %[[OR2:.+]], %[[OR3:.+]] : i1
+// HW-NEXT:  %foo.in_ready, %foo.out, %foo.out_valid = hw.instance "foo" @arrSwizzleVR(in: %[[INST_IN]]: !hw.array<4xi8>, in_valid: %[[INST_INV]]: !hw.array<4xi1>, out_ready: %[[INST_ORDY]]: !hw.array<4xi1>) -> (in_ready: !hw.array<4xi1>, out: !hw.array<4xi8>, out_valid: !hw.array<4xi1>)
+// HW-NEXT:  hw.constant 0 : i2
+// HW-NEXT:  %[[OR0]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant 1 : i2
+// HW-NEXT:  %[[OR1]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -2 : i2
+// HW-NEXT:  %[[OR2]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-NEXT:  hw.constant -1 : i2
+// HW-NEXT:  %[[OR3]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// The module output reverses the instance output (de-swizzle): out[0] is driven
+// by foo.out[3].
+// HW-NEXT:  %[[OUT:.+]] = hw.array_create %[[O0]], %[[O1]], %[[O2]], %[[O3]] : i8
+// HW-NEXT:  %[[OUTV:.+]] = hw.array_create %[[OV0]], %[[OV1]], %[[OV2]], %[[OV3]] : i1
+// HW-NEXT:  hw.output %[[INRDY]], %[[OUT]], %[[OUTV]] : !hw.array<4xi1>, !hw.array<4xi8>, !hw.array<4xi1>
+hw.module @arrSwizzleVRTop(in %in: !hw.array<4 x !esi.channel<i8>>, out out: !hw.array<4 x !esi.channel<i8>>) {
+  %foo.out = hw.instance "foo" @arrSwizzleVR(in: %in: !hw.array<4 x !esi.channel<i8>>) -> (out: !hw.array<4 x !esi.channel<i8>>)
+  %c0 = hw.constant 0 : i2
+  %c1 = hw.constant 1 : i2
+  %c2 = hw.constant 2 : i2
+  %c3 = hw.constant 3 : i2
+  %o0 = hw.array_get %foo.out[%c0] : !hw.array<4 x !esi.channel<i8>>, i2
+  %o1 = hw.array_get %foo.out[%c1] : !hw.array<4 x !esi.channel<i8>>, i2
+  %o2 = hw.array_get %foo.out[%c2] : !hw.array<4 x !esi.channel<i8>>, i2
+  %o3 = hw.array_get %foo.out[%c3] : !hw.array<4 x !esi.channel<i8>>, i2
+  // Reverse again to undo the swizzle.
+  %deswizzled = hw.array_create %o0, %o1, %o2, %o3 : !esi.channel<i8>
+  hw.output %deswizzled : !hw.array<4 x !esi.channel<i8>>
+}
+
+// --- FIFO array: data + empty (forward) + rden (backward) arrays ---
+// HW-LABEL:  hw.module @arrLoopbackFIFO(in %in : !hw.array<4xi8>, in %in_empty : !hw.array<4xi1>, in %out_rden : !hw.array<4xi1>, out in_rden : !hw.array<4xi1>, out out : !hw.array<4xi8>, out out_empty : !hw.array<4xi1>)
+// HW-DAG:      hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:      hw.array_get %in_empty[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:      hw.array_get %out_rden[%{{.+}}] : !hw.array<4xi1>
+// HW:          hw.output %{{.+}}, %{{.+}}, %{{.+}} : !hw.array<4xi1>, !hw.array<4xi8>, !hw.array<4xi1>
+hw.module @arrLoopbackFIFO(in %in: !hw.array<4 x !esi.channel<i8, FIFO>>, out out: !hw.array<4 x !esi.channel<i8, FIFO>>) {
+  hw.output %in : !hw.array<4 x !esi.channel<i8, FIFO>>
+}
+
+// --- ValidOnly array: only data + valid, no backward (ready/rden) array ---
+// HW-LABEL:  hw.module @arrLoopbackVO(in %in : !hw.array<4xi8>, in %in_valid : !hw.array<4xi1>, out out : !hw.array<4xi8>, out out_valid : !hw.array<4xi1>)
+// HW-DAG:      hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:      hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW:          hw.output %{{.+}}, %{{.+}} : !hw.array<4xi8>, !hw.array<4xi1>
+hw.module @arrLoopbackVO(in %in: !hw.array<4 x !esi.channel<i8, ValidOnly>>, out out: !hw.array<4 x !esi.channel<i8, ValidOnly>>) {
+  hw.output %in : !hw.array<4 x !esi.channel<i8, ValidOnly>>
+}
+
+// --- Single-element array of channels (index width is 1). ---
+// HW-LABEL:  hw.module @arrLoopbackN1(in %in : !hw.array<1xi8>, in %in_valid : !hw.array<1xi1>, in %out_ready : !hw.array<1xi1>, out in_ready : !hw.array<1xi1>, out out : !hw.array<1xi8>, out out_valid : !hw.array<1xi1>)
+// The single-element array uses a 1-bit index.
+// HW:          hw.array_get %in[%{{.+}}] : !hw.array<1xi8>, i1
+hw.module @arrLoopbackN1(in %in: !hw.array<1 x !esi.channel<i8>>, out out: !hw.array<1 x !esi.channel<i8>>) {
+  hw.output %in : !hw.array<1 x !esi.channel<i8>>
+}
+
+// --- External modules with array-of-channel ports are lowered too. ---
+// HW-LABEL:  hw.module.extern @arrExtern(in %in : !hw.array<2xi8>, in %in_valid : !hw.array<2xi1>, in %out_ready : !hw.array<2xi1>, out in_ready : !hw.array<2xi1>, out out : !hw.array<2xi8>, out out_valid : !hw.array<2xi1>)
+hw.module.extern @arrExtern(in %in: !hw.array<2 x !esi.channel<i8>>, out out: !hw.array<2 x !esi.channel<i8>>)
+// HW-LABEL:  hw.module @arrExternTop()
+// HW:          hw.instance "foo" @arrExtern(in: %{{.+}}: !hw.array<2xi8>, in_valid: %{{.+}}: !hw.array<2xi1>, out_ready: %{{.+}}: !hw.array<2xi1>) -> (in_ready: !hw.array<2xi1>, out: !hw.array<2xi8>, out_valid: !hw.array<2xi1>)
+hw.module @arrExternTop() {
+  %chan = hw.instance "foo" @arrExtern(in: %chan: !hw.array<2 x !esi.channel<i8>>) -> (out: !hw.array<2 x !esi.channel<i8>>)
+}

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -439,40 +439,10 @@ hw.module @voSnoopXactPassthrough(in %chan_in: !esi.channel<i32, ValidOnly>, out
 // through the swizzle while the ready backpressure is routed back through the
 // inverse permutation.
 // HW-LABEL: hw.module @arrSwizzleVR(in %in : !hw.array<4xi8>, in %in_valid : !hw.array<4xi1>, in %out_ready : !hw.array<4xi1>, out in_ready : !hw.array<4xi1>, out out : !hw.array<4xi8>, out out_valid : !hw.array<4xi1>)
-// Unpack data + valid for each input channel; each get is preceded by its own
-// index constant (elements 0..3 -> 0, 1, -2, -1 as a 2-bit value).
-// HW:       hw.constant 0 : i2
-// HW-NEXT:  %[[D0:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant 0 : i2
-// HW-NEXT:  %[[V0:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[D1:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[V1:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[D2:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[V2:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[D3:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[V3:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
-// Backpressure travels the opposite way: in_ready is built from out_ready[0..3]
-// in order, then reversed by array_create, so in_ready[3] is driven by
-// out_ready[0] (the channel that input 3 was swizzled to).
-// HW-NEXT:  %[[INR:.+]] = hw.array_create %[[R0:.+]], %[[R1:.+]], %[[R2:.+]], %[[R3:.+]] : i1
-// HW-NEXT:  hw.constant 0 : i2
-// HW-NEXT:  %[[R0]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[R1]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[R2]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[R3]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
-// Data + valid are reversed into the outputs: out[0]=in[3] ... out[3]=in[0].
-// HW-NEXT:  %[[OUT:.+]] = hw.array_create %[[D0]], %[[D1]], %[[D2]], %[[D3]] : i8
-// HW-NEXT:  %[[OUTV:.+]] = hw.array_create %[[V0]], %[[V1]], %[[V2]], %[[V3]] : i1
-// HW-NEXT:  hw.output %[[INR]], %[[OUT]], %[[OUTV]] : !hw.array<4xi1>, !hw.array<4xi8>, !hw.array<4xi1>
+// HW-DAG:   hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:   hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:   hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW:       hw.output %{{.+}}, %{{.+}}, %{{.+}} : !hw.array<4xi1>, !hw.array<4xi8>, !hw.array<4xi1>
 hw.module @arrSwizzleVR(in %in: !hw.array<4 x !esi.channel<i8>>, out out: !hw.array<4 x !esi.channel<i8>>) {
   %c0 = hw.constant 0 : i2
   %c1 = hw.constant 1 : i2
@@ -494,69 +464,69 @@ hw.module @arrSwizzleVR(in %in: !hw.array<4 x !esi.channel<i8>>, out out: !hw.ar
 // HW-LABEL: hw.module @arrSwizzleVRTop(in %in : !hw.array<4xi8>, in %in_valid : !hw.array<4xi1>, in %out_ready : !hw.array<4xi1>, out in_ready : !hw.array<4xi1>, out out : !hw.array<4xi8>, out out_valid : !hw.array<4xi1>)
 // Unpack the module's %in data + valid (passed straight into the instance).
 // HW:       hw.constant 0 : i2
-// HW-NEXT:  %[[D0:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant 0 : i2
-// HW-NEXT:  %[[V0:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[D1:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[V1:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[D2:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[V2:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[D3:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[V3:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  %[[D0:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:  hw.constant 0 : i2
+// HW-DAG:  %[[V0:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant 1 : i2
+// HW-DAG:  %[[D1:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:  hw.constant 1 : i2
+// HW-DAG:  %[[V1:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant -2 : i2
+// HW-DAG:  %[[D2:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:  hw.constant -2 : i2
+// HW-DAG:  %[[V2:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant -1 : i2
+// HW-DAG:  %[[D3:.+]] = hw.array_get %in[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:  hw.constant -1 : i2
+// HW-DAG:  %[[V3:.+]] = hw.array_get %in_valid[%{{.+}}] : !hw.array<4xi1>
 // The module's in_ready output reverses the instance's in_ready (operand 0 ->
 // highest index): in_ready[3] is driven by foo.in_ready[0].
-// HW-NEXT:  %[[INRDY:.+]] = hw.array_create %[[IR3:.+]], %[[IR2:.+]], %[[IR1:.+]], %[[IR0:.+]] : i1
-// HW-NEXT:  hw.constant 0 : i2
-// HW-NEXT:  %[[IR0]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[IR1]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[IR2]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[IR3]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  %[[INRDY:.+]] = hw.array_create %[[IR3:.+]], %[[IR2:.+]], %[[IR1:.+]], %[[IR0:.+]] : i1
+// HW-DAG:  hw.constant 0 : i2
+// HW-DAG:  %[[IR0]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant 1 : i2
+// HW-DAG:  %[[IR1]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant -2 : i2
+// HW-DAG:  %[[IR2]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant -1 : i2
+// HW-DAG:  %[[IR3]] = hw.array_get %foo.in_ready[%{{.+}}] : !hw.array<4xi1>
 // The instance input data/valid are the unpacked %in elements, repacked in
 // order (in[i] -> instance in[i]).
-// HW-NEXT:  %[[INST_IN:.+]] = hw.array_create %[[D3]], %[[D2]], %[[D1]], %[[D0]] : i8
-// HW-NEXT:  %[[INST_INV:.+]] = hw.array_create %[[V3]], %[[V2]], %[[V1]], %[[V0]] : i1
+// HW-DAG:  %[[INST_IN:.+]] = hw.array_create %[[D3]], %[[D2]], %[[D1]], %[[D0]] : i8
+// HW-DAG:  %[[INST_INV:.+]] = hw.array_create %[[V3]], %[[V2]], %[[V1]], %[[V0]] : i1
 // Unpack the instance's output data + valid.
-// HW-NEXT:  hw.constant 0 : i2
-// HW-NEXT:  %[[O0:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant 0 : i2
-// HW-NEXT:  %[[OV0:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[O1:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[OV1:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[O2:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[OV2:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[O3:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[OV3:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant 0 : i2
+// HW-DAG:  %[[O0:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:  hw.constant 0 : i2
+// HW-DAG:  %[[OV0:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant 1 : i2
+// HW-DAG:  %[[O1:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:  hw.constant 1 : i2
+// HW-DAG:  %[[OV1:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant -2 : i2
+// HW-DAG:  %[[O2:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:  hw.constant -2 : i2
+// HW-DAG:  %[[OV2:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant -1 : i2
+// HW-DAG:  %[[O3:.+]] = hw.array_get %foo.out[%{{.+}}] : !hw.array<4xi8>
+// HW-DAG:  hw.constant -1 : i2
+// HW-DAG:  %[[OV3:.+]] = hw.array_get %foo.out_valid[%{{.+}}] : !hw.array<4xi1>
 // The instance's out_ready input reverses the module's out_ready.
-// HW-NEXT:  %[[INST_ORDY:.+]] = hw.array_create %[[OR0:.+]], %[[OR1:.+]], %[[OR2:.+]], %[[OR3:.+]] : i1
-// HW-NEXT:  %foo.in_ready, %foo.out, %foo.out_valid = hw.instance "foo" @arrSwizzleVR(in: %[[INST_IN]]: !hw.array<4xi8>, in_valid: %[[INST_INV]]: !hw.array<4xi1>, out_ready: %[[INST_ORDY]]: !hw.array<4xi1>) -> (in_ready: !hw.array<4xi1>, out: !hw.array<4xi8>, out_valid: !hw.array<4xi1>)
-// HW-NEXT:  hw.constant 0 : i2
-// HW-NEXT:  %[[OR0]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant 1 : i2
-// HW-NEXT:  %[[OR1]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -2 : i2
-// HW-NEXT:  %[[OR2]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
-// HW-NEXT:  hw.constant -1 : i2
-// HW-NEXT:  %[[OR3]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  %[[INST_ORDY:.+]] = hw.array_create %[[OR0:.+]], %[[OR1:.+]], %[[OR2:.+]], %[[OR3:.+]] : i1
+// HW-DAG:  %foo.in_ready, %foo.out, %foo.out_valid = hw.instance "foo" @arrSwizzleVR(in: %[[INST_IN]]: !hw.array<4xi8>, in_valid: %[[INST_INV]]: !hw.array<4xi1>, out_ready: %[[INST_ORDY]]: !hw.array<4xi1>) -> (in_ready: !hw.array<4xi1>, out: !hw.array<4xi8>, out_valid: !hw.array<4xi1>)
+// HW-DAG:  hw.constant 0 : i2
+// HW-DAG:  %[[OR0]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant 1 : i2
+// HW-DAG:  %[[OR1]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant -2 : i2
+// HW-DAG:  %[[OR2]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
+// HW-DAG:  hw.constant -1 : i2
+// HW-DAG:  %[[OR3]] = hw.array_get %out_ready[%{{.+}}] : !hw.array<4xi1>
 // The module output reverses the instance output (de-swizzle): out[0] is driven
 // by foo.out[3].
-// HW-NEXT:  %[[OUT:.+]] = hw.array_create %[[O0]], %[[O1]], %[[O2]], %[[O3]] : i8
-// HW-NEXT:  %[[OUTV:.+]] = hw.array_create %[[OV0]], %[[OV1]], %[[OV2]], %[[OV3]] : i1
-// HW-NEXT:  hw.output %[[INRDY]], %[[OUT]], %[[OUTV]] : !hw.array<4xi1>, !hw.array<4xi8>, !hw.array<4xi1>
+// HW-DAG:  %[[OUT:.+]] = hw.array_create %[[O0]], %[[O1]], %[[O2]], %[[O3]] : i8
+// HW-DAG:  %[[OUTV:.+]] = hw.array_create %[[OV0]], %[[OV1]], %[[OV2]], %[[OV3]] : i1
+// HW-DAG:  hw.output %[[INRDY]], %[[OUT]], %[[OUTV]] : !hw.array<4xi1>, !hw.array<4xi8>, !hw.array<4xi1>
 hw.module @arrSwizzleVRTop(in %in: !hw.array<4 x !esi.channel<i8>>, out out: !hw.array<4 x !esi.channel<i8>>) {
   %foo.out = hw.instance "foo" @arrSwizzleVR(in: %in: !hw.array<4 x !esi.channel<i8>>) -> (out: !hw.array<4 x !esi.channel<i8>>)
   %c0 = hw.constant 0 : i2

--- a/test/Dialect/ESI/passes/lower_ports_errors.mlir
+++ b/test/Dialect/ESI/passes/lower_ports_errors.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt --lower-esi-ports %s --verify-diagnostics --split-input-file
+
+// Channels nested more than one array deep cannot be lowered.
+// expected-error @+2 {{cannot lower port containing channels nested inside an aggregate other than a single array of channels}}
+// expected-note @+1 {{}}
+hw.module @nestedArrayOfChannels(in %in: !hw.array<2 x !hw.array<3 x !esi.channel<i8>>>) {
+  hw.output
+}
+
+// -----
+
+// Channels nested inside a struct (inside an array) cannot be lowered.
+// expected-error @+2 {{cannot lower port containing channels nested inside an aggregate other than a single array of channels}}
+// expected-note @+1 {{}}
+hw.module @arrayOfStructOfChannels(in %in: !hw.array<2 x !hw.struct<a: !esi.channel<i8>>>) {
+  hw.output
+}

--- a/test/Dialect/ESI/passes/lower_ports_errors.mlir
+++ b/test/Dialect/ESI/passes/lower_ports_errors.mlir
@@ -15,3 +15,21 @@ hw.module @nestedArrayOfChannels(in %in: !hw.array<2 x !hw.array<3 x !esi.channe
 hw.module @arrayOfStructOfChannels(in %in: !hw.array<2 x !hw.struct<a: !esi.channel<i8>>>) {
   hw.output
 }
+
+// -----
+
+// A zero-length array of channels cannot be lowered.
+// expected-error @+2 {{cannot lower array-of-channels port with a non-constant or zero-length size}}
+// expected-note @+1 {{}}
+hw.module @zeroLengthArrayOfChannels(in %in: !hw.array<0 x !esi.channel<i8>>) {
+  hw.output
+}
+
+// -----
+
+// A parametric (non-constant) array of channels cannot be lowered.
+// expected-error @+2 {{cannot lower array-of-channels port with a non-constant or zero-length size}}
+// expected-note @+1 {{}}
+hw.module @parametricArrayOfChannels<N: i32>(in %in: !hw.array<#hw.param.decl.ref<"N"> x !esi.channel<i8>>) {
+  hw.output
+}


### PR DESCRIPTION
Adds support for lowering module ports which are `hw::array` with the element type `esi.channel`. We lower to arrays of the individual channel power lowerings. E.g. `input <name>_valid: !hw.array<N, i1>`.

Assisted-by: vscode:Claude Opus 4.8

