### PR TITLE
[LowerToHW] Lower zero-bit bundle, vector create

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1739,6 +1739,8 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
     return getOrCreateIntConstant(APInt(numBits, val, isSigned));
   }
   Attribute getOrCreateAggregateConstantAttribute(Attribute value, Type type);
+  Attribute getZeroAttributeForType(Type type);
+  Value getZeroValueForType(Type type);
   Value getOrCreateXConstant(unsigned numBits);
   Value getOrCreateZConstant(Type type);
   Value getPossiblyInoutLoweredValue(Value value);
@@ -2433,6 +2435,46 @@ Value FIRRTLLowering::getOrCreateZConstant(Type type) {
     entry = sv::ConstantZOp::create(entryBuilder, builder.getLoc(), type);
   }
   return entry;
+}
+
+/// Return a zero-valued attribute for the given lowered HW type, recursing
+/// into struct and array element types.  Used to materialize zero values for
+/// zero-width slots in `hw.struct_create` / `hw.array_create` operands.
+///
+/// The recursion is required because FIRRTL allows arbitrarily nested
+/// aggregates of zero-width content (e.g. `bundle<a: bundle<b: uint<0>>>`).
+/// Such a type lowers to a correspondingly nested HW aggregate (here
+/// `!hw.struct<a: !hw.struct<b: i0>>`), and `hw.aggregate_constant` requires
+/// the supplied `ArrayAttr` to mirror that nesting structure.
+Attribute FIRRTLLowering::getZeroAttributeForType(Type type) {
+  if (auto intType = hw::type_dyn_cast<IntegerType>(type))
+    return builder.getIntegerAttr(intType, 0);
+  if (auto array = hw::type_dyn_cast<hw::ArrayType>(type)) {
+    // All array elements share a single type, and every slot needs the same
+    // zero value, so we build the recursive zero attribute once and replicate
+    // it.  No reverse is necessary as all the types are the same.
+    auto element = getZeroAttributeForType(array.getElementType());
+    SmallVector<Attribute> values(array.getNumElements(), element);
+    return builder.getArrayAttr(values);
+  }
+  if (auto structType = hw::type_dyn_cast<hw::StructType>(type)) {
+    SmallVector<Attribute> values;
+    values.reserve(structType.getElements().size());
+    for (auto &field : structType.getElements())
+      values.push_back(getZeroAttributeForType(field.type));
+    return builder.getArrayAttr(values);
+  }
+  llvm_unreachable("unsupported lowered type for zero attribute");
+}
+
+/// Return a zero-valued constant for the given lowered HW type.  Used to fill
+/// in zero-width slots in `hw.struct_create` / `hw.array_create` when the
+/// corresponding FIRRTL operand was lowered away.
+Value FIRRTLLowering::getZeroValueForType(Type type) {
+  if (auto intType = hw::type_dyn_cast<IntegerType>(type))
+    return getOrCreateIntConstant(intType.getWidth(), 0);
+  return hw::AggregateConstantOp::create(
+      builder, type, cast<ArrayAttr>(getZeroAttributeForType(type)));
 }
 
 /// Return the lowered HW value corresponding to the specified original value.
@@ -3531,12 +3573,17 @@ LogicalResult FIRRTLLowering::visitExpr(SubfieldOp op) {
 
 LogicalResult FIRRTLLowering::visitExpr(VectorCreateOp op) {
   auto resultType = lowerType(op.getResult().getType());
+  auto arrayType = cast<hw::ArrayType>(resultType);
   SmallVector<Value> operands;
   // NOTE: The operand order must be inverted.
   for (auto oper : llvm::reverse(op.getOperands())) {
     auto val = getLoweredValue(oper);
-    if (!val)
-      return failure();
+    if (!val) {
+      // Lower zero-bit operands.
+      if (!isZeroBitFIRRTLType(oper.getType()))
+        return failure();
+      val = getZeroValueForType(arrayType.getElementType());
+    }
     operands.push_back(val);
   }
   return setLoweringTo<hw::ArrayCreateOp>(op, resultType, operands);
@@ -3544,11 +3591,17 @@ LogicalResult FIRRTLLowering::visitExpr(VectorCreateOp op) {
 
 LogicalResult FIRRTLLowering::visitExpr(BundleCreateOp op) {
   auto resultType = lowerType(op.getResult().getType());
+  auto structType = cast<hw::StructType>(resultType);
   SmallVector<Value> operands;
-  for (auto oper : op.getOperands()) {
+  for (auto [oper, field] :
+       llvm::zip_equal(op.getOperands(), structType.getElements())) {
     auto val = getLoweredValue(oper);
-    if (!val)
-      return failure();
+    if (!val) {
+      // Lower zero-bit operands.
+      if (!isZeroBitFIRRTLType(oper.getType()))
+        return failure();
+      val = getZeroValueForType(field.type);
+    }
     operands.push_back(val);
   }
   return setLoweringTo<hw::StructCreateOp>(op, resultType, operands);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -860,7 +860,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL:  hw.module private @SimpleEnum(in %source : i2, out sink : i2) {
   // CHECK-NEXT:    %valid = sv.localparam {value = 0 : i2} : i2
-  // CHECK-NEXT:    %0 = comb.icmp bin eq %source, %valid : i2 
+  // CHECK-NEXT:    %0 = comb.icmp bin eq %source, %valid : i2
   // CHECK-NEXT:    hw.output %source : i2
   // CHECK-NEXT:  }
   firrtl.module private @SimpleEnum(in %source: !firrtl.enum<valid: uint<0>, ready: uint<0>, data: uint<0>>,
@@ -1450,6 +1450,28 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %a : !hw.array<3xi1>
   }
 
+  // Bundle and vector creates with zero-bit operands must still produce well
+  // formed `hw.struct_create` / `hw.array_create` operations whose operand
+  // counts match the lowered aggregate type.  Use a deeply nested zero-width
+  // field (`bundle<a: bundle<b: vector<uint<0>, 2>>>`) so the recursion in
+  // `getZeroAttributeForType` is exercised at multiple levels.
+  // CHECK-LABEL: hw.module @MergeBundleZeroWidth
+  firrtl.module @MergeBundleZeroWidth(in %i: !firrtl.uint<8>, out %o: !firrtl.bundle<foo: bundle<a: bundle<b: vector<uint<0>, 2>>>, t: uint<8>>) {
+    %z = firrtl.aggregateconstant [[[0 : ui0, 0 : ui0]]] : !firrtl.bundle<a: bundle<b: vector<uint<0>, 2>>>
+    %0 = firrtl.bundlecreate %z, %i : (!firrtl.bundle<a: bundle<b: vector<uint<0>, 2>>>, !firrtl.uint<8>) -> !firrtl.bundle<foo: bundle<a: bundle<b: vector<uint<0>, 2>>>, t: uint<8>>
+    firrtl.matchingconnect %o, %0 : !firrtl.bundle<foo: bundle<a: bundle<b: vector<uint<0>, 2>>>, t: uint<8>>
+    // CHECK:               %[[ZAGG:.+]] = hw.aggregate_constant
+    // CHECK{LITERAL}-SAME: [[[0 : i0, 0 : i0]]] : !hw.struct<a: !hw.struct<b: !hw.array<2xi0>>>
+    // CHECK-NEXT:          %[[B:.+]] = hw.struct_create (%[[ZAGG]], %i) : !hw.struct<foo: !hw.struct<a: !hw.struct<b: !hw.array<2xi0>>>, t: i8>
+  }
+
+  // CHECK-LABEL: hw.module @MergeVectorZeroWidth
+  firrtl.module @MergeVectorZeroWidth(in %i: !firrtl.uint<0>, out %o: !firrtl.vector<uint<0>, 2>) {
+    %0 = firrtl.vectorcreate %i, %i : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.vector<uint<0>, 2>
+    firrtl.matchingconnect %o, %0 : !firrtl.vector<uint<0>, 2>
+    // CHECK:      %[[V:.+]] = hw.aggregate_constant {{.*}} : !hw.array<2xi0>
+  }
+
   // CHECK-LABEL: hw.module @aggregateconstant
   firrtl.module @aggregateconstant(out %out : !firrtl.bundle<a: vector<vector<uint<8>, 2>, 2>, b: vector<vector<uint<8>, 2>, 2>>) {
     %0 = firrtl.aggregateconstant [[[0 : ui8, 1: ui8], [2 : ui8, 3: ui8]], [[4: ui8, 5: ui8], [6: ui8, 7:ui8]]] :
@@ -1998,7 +2020,7 @@ firrtl.circuit "InstanceChoiceTest" {
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     // CHECK: hw.output %[[READ]]
-    %inst_in, %inst_out = firrtl.instance_choice inst {instance_macro = @targets$Opt$InstanceChoiceUnit$inst} @ModuleDefault alternatives @Opt 
+    %inst_in, %inst_out = firrtl.instance_choice inst {instance_macro = @targets$Opt$InstanceChoiceUnit$inst} @ModuleDefault alternatives @Opt
                           { @FPGA -> @ModuleFPGA, @ASIC -> @ModuleDefault } (in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     firrtl.matchingconnect %inst_in, %in : !firrtl.uint<8>
     firrtl.matchingconnect %out, %inst_out : !firrtl.uint<8>


### PR DESCRIPTION
Add handling for lowering `firrtl.bundlecreate` and `firrtl.vectorcreate`
of zero-bit types.

- Fixes #7721.
- Fixes #10664.

Assisted-by: pi.dev:claude-opus-4-7
Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>
