### PR TITLE
[Sim] Make integer format width specifier disable padding

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -260,6 +260,11 @@ def FormatHexOp : SimOp<"fmt.hex",
     length required to print the maximum value of the argument's
     type. Zero width values will produce the empty string.
     No further prefix will be added.
+
+    An optional `specifierWidth` overrides this default field width; a
+    `specifierWidth` of 0 disables padding entirely and prints the value in its
+    minimal representation. This mirrors the SystemVerilog `%h`, `%0h`, and
+    `%<N>h` specifiers.
   }];
 
 
@@ -293,6 +298,11 @@ def FormatOctOp : SimOp<"fmt.oct",
     length required to print the maximum value of the argument's
     type. Zero width values will produce the empty string.
     No further prefix will be added.
+
+    An optional `specifierWidth` overrides this default field width; a
+    `specifierWidth` of 0 disables padding entirely and prints the value in its
+    minimal representation. This mirrors the SystemVerilog `%o`, `%0o`, and
+    `%<N>o` specifiers.
   }];
 
 
@@ -324,6 +334,11 @@ def FormatBinOp : SimOp<"fmt.bin",
     The printed value will be left-padded with '0' up to the number
     of bits of the argument's type. Zero width values will produce
     the empty string. No further prefix will be added.
+
+    An optional `specifierWidth` overrides this default field width; a
+    `specifierWidth` of 0 disables padding entirely and prints the value in its
+    minimal representation. This mirrors the SystemVerilog `%b`, `%0b`, and
+    `%<N>b` specifiers.
   }];
 
   let arguments = (ins AnyInteger:$value,
@@ -447,6 +462,11 @@ def FormatDecOp : SimOp<"fmt.dec",
     padded to the same width. Zero width values will produce
     a single '0'.
 
+    An optional `specifierWidth` overrides this default field width; a
+    `specifierWidth` of 0 disables padding entirely and prints the value in its
+    minimal representation. This mirrors the SystemVerilog `%d`, `%0d`, and
+    `%<N>d` specifiers.
+
     Backends are recommended to not exceed the required amount of padding.
   }];
 
@@ -466,25 +486,6 @@ def FormatDecOp : SimOp<"fmt.dec",
     (`specifierWidth` $specifierWidth^)?
     (`signed` $isSigned^)?
     attr-dict `:` qualified(type($value))
-  }];
-
-  let extraClassDeclaration = [{
-      static inline unsigned getDecimalWidth(unsigned bits, bool isSigned) {
-        if (bits == 0)
-          return 1;
-        if (bits == 1)
-          return isSigned ? 2 : 1;
-
-        if (isSigned)
-          bits--;
-
-        // Should be precise up until bits = 13301
-        // log(2) / log(10) + epsilon
-        const double baseConversionFactor = 0.30103;
-        unsigned digits = std::ceil(bits * baseConversionFactor);
-
-        return isSigned ? digits + 1 : digits;
-      }
   }];
 }
 

--- a/include/circt/Support/FormatInteger.h
+++ b/include/circt/Support/FormatInteger.h
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Integer formatting shared between the Sim dialect's constant folder and the
+// Arc runtime. Keeping it in a header-only utility lets both produce identical
+// output without the Sim dialect depending on the Arc runtime or vice versa.
+//
+// The formatting follows the SystemVerilog `%d`/`%h`/`%o`/`%b` family. By
+// default a value is padded to the *natural* width of its type -- the number
+// of digits required to print the type's largest value -- so values of the
+// same type line up. An explicit field width overrides this natural width; a
+// field width of 0 disables padding and prints the value in its minimal
+// representation, matching SystemVerilog's `%0d` and friends.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_FORMATINTEGER_H
+#define CIRCT_SUPPORT_FORMATINTEGER_H
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cmath>
+
+namespace circt {
+
+/// Number of decimal digits required to print the largest value of an integer
+/// type of the given bit width.
+inline unsigned getDecimalDigitWidth(unsigned bits, bool isSigned) {
+  if (bits == 0)
+    return 1;
+  if (bits == 1)
+    return isSigned ? 2 : 1;
+  if (isSigned)
+    bits--;
+  // Should be precise up until bits = 13301; log(2) / log(10) + epsilon.
+  const double baseConversionFactor = 0.30103;
+  unsigned digits = std::ceil(bits * baseConversionFactor);
+  return isSigned ? digits + 1 : digits;
+}
+
+/// Natural field width of an integer type printed in the given radix: the
+/// number of digits required to print the type's largest value. `radix` must be
+/// one of {2, 8, 10, 16}.
+inline unsigned getNaturalIntegerWidth(unsigned bits, unsigned radix,
+                                       bool isSigned) {
+  switch (radix) {
+  case 2:
+    return bits;
+  case 8:
+    return llvm::divideCeil(bits, 3);
+  case 16:
+    return llvm::divideCeil(bits, 4);
+  default: // radix 10
+    return getDecimalDigitWidth(bits, isSigned);
+  }
+}
+
+/// Format `value` in the given `radix` and emit it to `os`, padded to a field
+/// width. The field width defaults to the natural width of the value's type and
+/// is overridden by `specifierWidth` when present; a `specifierWidth` of 0
+/// therefore disables padding. Right-aligned output (the default) is padded on
+/// the leading side with `paddingChar`, matching the SystemVerilog `%d`/`%h`
+/// family. Left-aligned output is padded on the trailing side with spaces,
+/// matching C `printf`, whose zero-pad flag is ignored under left
+/// justification; SystemVerilog's `$display` has no left-aligned form. `radix`
+/// must be one of {2, 8, 10, 16}.
+inline void formatInteger(llvm::raw_ostream &os, const llvm::APInt &value,
+                          unsigned radix, bool isUpperCase, bool isLeftAligned,
+                          char paddingChar,
+                          std::optional<int32_t> specifierWidth,
+                          bool isSigned) {
+  llvm::SmallVector<char, 32> digits;
+  value.toString(digits, radix, isSigned, /*formatAsCLiteral=*/false,
+                 isUpperCase);
+
+  unsigned fieldWidth =
+      specifierWidth.has_value() && *specifierWidth >= 0
+          ? static_cast<unsigned>(*specifierWidth)
+          : getNaturalIntegerWidth(value.getBitWidth(), radix, isSigned);
+  unsigned padWidth =
+      fieldWidth > digits.size() ? fieldWidth - digits.size() : 0;
+
+  if (isLeftAligned) {
+    llvm::SmallVector<char, 32> padding(padWidth, ' ');
+    os << digits << padding;
+  } else {
+    llvm::SmallVector<char, 32> padding(padWidth, paddingChar);
+    os << padding << digits;
+  }
+}
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_FORMATINTEGER_H

--- a/integration_test/arcilator/JIT/fmt-padding.mlir
+++ b/integration_test/arcilator/JIT/fmt-padding.mlir
@@ -1,26 +1,57 @@
 // RUN: arcilator --run %s --jit-entry=entry | FileCheck %s --strict-whitespace --match-full-lines
 // REQUIRES: arcilator-jit
 
-// The integer formatters must pad with the format op's padding character -- a
-// space for `sim.fmt.dec` and '0' for `sim.fmt.hex` -- rather than with NUL
-// bytes. The value is bracketed so the padding is visible to FileCheck under
-// `--strict-whitespace`.
+// The integer formatters pad to the natural width of the value's type using the
+// format op's padding character -- a space for `sim.fmt.dec` and '0' for the
+// others -- rather than with NUL bytes. A `specifierWidth` of 0 disables padding
+// and prints the value in its minimal representation. Values are bracketed so
+// the padding is visible to FileCheck under `--strict-whitespace`.
+//
+// `sim.fmt.bin` is omitted because the arcilator runtime only lowers the
+// decimal, hexadecimal, and octal formatters; binary is covered by the
+// constant-folder test in test/Dialect/Sim/format-strings.mlir.
 
 func.func @entry() {
   %open = sim.fmt.literal "["
   %close = sim.fmt.literal "]\n"
 
-  // CHECK:[   5]
-  %c4 = hw.constant 5 : i4
-  %dec = sim.fmt.dec %c4 : i4
+  %c5_4 = hw.constant 5 : i4
+  %c5_8 = hw.constant 5 : i8
+  %c106 = hw.constant 106 : i16
+
+  // Default field width: pad to the type's natural width.
+
+  // CHECK:[ 5]
+  %dec = sim.fmt.dec %c5_4 : i4
   %decMsg = sim.fmt.concat (%open, %dec, %close)
   sim.proc.print %decMsg
 
   // CHECK:[05]
-  %c8 = hw.constant 5 : i8
-  %hex = sim.fmt.hex %c8, isUpper false : i8
+  %hex = sim.fmt.hex %c5_8, isUpper false : i8
   %hexMsg = sim.fmt.concat (%open, %hex, %close)
   sim.proc.print %hexMsg
+
+  // CHECK:[000152]
+  %oct = sim.fmt.oct %c106 : i16
+  %octMsg = sim.fmt.concat (%open, %oct, %close)
+  sim.proc.print %octMsg
+
+  // A `specifierWidth` of 0 disables padding for every radix.
+
+  // CHECK:[106]
+  %d0 = sim.fmt.dec %c106 specifierWidth 0 : i16
+  %d0Msg = sim.fmt.concat (%open, %d0, %close)
+  sim.proc.print %d0Msg
+
+  // CHECK:[6a]
+  %h0 = sim.fmt.hex %c106, isUpper false specifierWidth 0 : i16
+  %h0Msg = sim.fmt.concat (%open, %h0, %close)
+  sim.proc.print %h0Msg
+
+  // CHECK:[152]
+  %o0 = sim.fmt.oct %c106 specifierWidth 0 : i16
+  %o0Msg = sim.fmt.concat (%open, %o0, %close)
+  sim.proc.print %o0Msg
 
   return
 }

--- a/lib/Dialect/Arc/Runtime/ArcRuntime.cpp
+++ b/lib/Dialect/Arc/Runtime/ArcRuntime.cpp
@@ -19,6 +19,7 @@
 #include "circt/Dialect/Arc/Runtime/IRInterface.h"
 #include "circt/Dialect/Arc/Runtime/Internal.h"
 #include "circt/Dialect/Arc/Runtime/ModelInstance.h"
+#include "circt/Support/FormatInteger.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -107,52 +108,6 @@ void arcRuntimeIR_deleteInstance(uint8_t *modelState) {
   arcRuntimeDeleteInstance(arcRuntimeGetStateFromModelState(modelState, 0));
 }
 
-// Emits an integer to `os` using the given format specifiers.
-//
-// Note that this is a copy of formatIntegersByRadix from SimOps.cpp.
-static void formatIntegersByRadix(llvm::raw_ostream &os, int width, int radix,
-                                  const llvm::APInt &value, bool isUpperCase,
-                                  bool isLeftAligned, char paddingChar,
-                                  int specifierWidth, bool isSigned) {
-  llvm::SmallVector<char, 32> strBuf;
-  value.toString(strBuf, radix, isSigned, false, isUpperCase);
-  int strBufSize = static_cast<int>(strBuf.size());
-
-  int padWidth;
-  switch (radix) {
-  case 2:
-    padWidth = width;
-    break;
-  case 8:
-    padWidth = (width + 2) / 3;
-    break;
-  case 16:
-    padWidth = (width + 3) / 4;
-    break;
-  default:
-    padWidth = width;
-    break;
-  }
-
-  int numSpaces = 0;
-  if (specifierWidth >= 0 &&
-      (specifierWidth > std::max(padWidth, strBufSize))) {
-    numSpaces = std::max(0, specifierWidth - std::max(padWidth, strBufSize));
-  }
-
-  llvm::SmallVector<char, 1> spacePadding(numSpaces, ' ');
-
-  padWidth = padWidth > strBufSize ? padWidth - strBufSize : 0;
-
-  llvm::SmallVector<char, 32> padding(padWidth, paddingChar);
-
-  if (isLeftAligned) {
-    os << padding << strBuf << spacePadding;
-  } else {
-    os << spacePadding << padding << strBuf;
-  }
-}
-
 void arcRuntimeIR_format(const FmtDescriptor *fmt, ...) {
   va_list args;
   va_start(args, fmt);
@@ -174,10 +129,13 @@ void arcRuntimeIR_format(const FmtDescriptor *fmt, ...) {
       uint64_t *words = va_arg(args, uint64_t *);
       int64_t numWords = llvm::divideCeil(fmt->intFmt.bitwidth, 64);
       llvm::APInt apInt(fmt->intFmt.bitwidth, llvm::ArrayRef(words, numWords));
-      formatIntegersByRadix(os, fmt->intFmt.bitwidth, fmt->intFmt.radix, apInt,
-                            fmt->intFmt.isUpperCase, fmt->intFmt.isLeftAligned,
-                            fmt->intFmt.paddingChar, fmt->intFmt.specifierWidth,
-                            fmt->intFmt.isSigned);
+      std::optional<int32_t> specifierWidth;
+      if (fmt->intFmt.specifierWidth >= 0)
+        specifierWidth = fmt->intFmt.specifierWidth;
+      circt::formatInteger(os, apInt, fmt->intFmt.radix,
+                           fmt->intFmt.isUpperCase, fmt->intFmt.isLeftAligned,
+                           fmt->intFmt.paddingChar, specifierWidth,
+                           fmt->intFmt.isSigned);
       break;
     }
     case FmtDescriptor::Action_Char:

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -15,6 +15,7 @@
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Support/CustomDirectiveImpl.h"
+#include "circt/Support/FormatInteger.h"
 #include "circt/Support/ProceduralRegionTrait.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -239,11 +240,15 @@ sim::DPICallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
          << referencedOp->getName() << "'";
 }
 
+// Render `value` in the given `radix` and pad it to a field width, returning
+// the result as a `StringAttr`. The field width and padding semantics are
+// shared with the Arc runtime through `circt::formatInteger` (see
+// FormatInteger.h). Zero-width values produce the empty string.
 static StringAttr formatIntegersByRadix(MLIRContext *ctx, unsigned radix,
                                         const Attribute &value,
                                         bool isUpperCase, bool isLeftAligned,
                                         char paddingChar,
-                                        std::optional<unsigned> specifierWidth,
+                                        std::optional<int32_t> specifierWidth,
                                         bool isSigned = false) {
   auto intAttr = llvm::dyn_cast_or_null<IntegerAttr>(value);
   if (!intAttr)
@@ -251,46 +256,11 @@ static StringAttr formatIntegersByRadix(MLIRContext *ctx, unsigned radix,
   if (intAttr.getType().getIntOrFloatBitWidth() == 0)
     return StringAttr::get(ctx, "");
 
-  SmallVector<char, 32> strBuf;
-  intAttr.getValue().toString(strBuf, radix, isSigned, false, isUpperCase);
-  unsigned width = intAttr.getType().getIntOrFloatBitWidth();
-
-  unsigned padWidth;
-  switch (radix) {
-  case 2:
-    padWidth = width;
-    break;
-  case 8:
-    padWidth = (width + 2) / 3;
-    break;
-  case 16:
-    padWidth = (width + 3) / 4;
-    break;
-  default:
-    padWidth = width;
-    break;
-  }
-
-  unsigned numSpaces = 0;
-  if (specifierWidth.has_value() &&
-      (specifierWidth.value() >
-       std::max(padWidth, static_cast<unsigned>(strBuf.size())))) {
-    numSpaces = std::max(
-        0U, specifierWidth.value() -
-                std::max(padWidth, static_cast<unsigned>(strBuf.size())));
-  }
-
-  SmallVector<char, 1> spacePadding(numSpaces, ' ');
-
-  padWidth = padWidth > strBuf.size() ? padWidth - strBuf.size() : 0;
-
-  SmallVector<char, 32> padding(padWidth, paddingChar);
-  if (isLeftAligned) {
-    return StringAttr::get(ctx, Twine(padding) + Twine(strBuf) +
-                                    Twine(spacePadding));
-  }
-  return StringAttr::get(ctx,
-                         Twine(spacePadding) + Twine(padding) + Twine(strBuf));
+  SmallString<32> str;
+  llvm::raw_svector_ostream os(str);
+  formatInteger(os, intAttr.getValue(), radix, isUpperCase, isLeftAligned,
+                paddingChar, specifierWidth, isSigned);
+  return StringAttr::get(ctx, str);
 }
 
 static StringAttr formatFloatsBySpecifier(MLIRContext *ctx, Attribute value,
@@ -352,22 +322,12 @@ StringAttr FormatDecOp::formatConstant(Attribute constVal) {
   auto intAttr = llvm::dyn_cast<IntegerAttr>(constVal);
   if (!intAttr)
     return {};
-  SmallVector<char, 16> strBuf;
-  intAttr.getValue().toString(strBuf, 10, getIsSigned());
-  unsigned padWidth;
-  if (getSpecifierWidth().has_value()) {
-    padWidth = getSpecifierWidth().value();
-  } else {
-    unsigned width = intAttr.getType().getIntOrFloatBitWidth();
-    padWidth = FormatDecOp::getDecimalWidth(width, getIsSigned());
-  }
-
-  padWidth = padWidth > strBuf.size() ? padWidth - strBuf.size() : 0;
-
-  SmallVector<char, 10> padding(padWidth, getPaddingChar());
-  if (getIsLeftAligned())
-    return StringAttr::get(getContext(), Twine(strBuf) + Twine(padding));
-  return StringAttr::get(getContext(), Twine(padding) + Twine(strBuf));
+  SmallString<16> str;
+  llvm::raw_svector_ostream os(str);
+  formatInteger(os, intAttr.getValue(), /*radix=*/10, /*isUpperCase=*/false,
+                getIsLeftAligned(), getPaddingChar(), getSpecifierWidth(),
+                getIsSigned());
+  return StringAttr::get(getContext(), str);
 }
 
 OpFoldResult FormatDecOp::fold(FoldAdaptor adaptor) {

--- a/test/Dialect/Sim/format-strings.mlir
+++ b/test/Dialect/Sim/format-strings.mlir
@@ -137,7 +137,7 @@ hw.module @constant_fold3(in %zeroWitdh: i0, out res: !sim.fstring) {
 }
 
 // CHECK-LABEL: hw.module @constant_fold4
-// CHECK: sim.fmt.literal "  106,106  ,   106,106   ,       106,106       ,       106,106       ;006A,006A,   006A,006A   ;000152,000152,   000152,000152   ;0000000001101010,0000000001101010,   0000000001101010,0000000001101010   "
+// CHECK: sim.fmt.literal "  106,106  ,   106,106   ,       106,106       ,       106,106       ;006A,6A  ,000006A,6A     ;000152,152   ,000000152,152      ;0000000001101010,1101010         ,0000000000001101010,1101010            "
 hw.module @constant_fold4(out res: !sim.fstring) {
   %1 = hw.constant 106 : i16
   %2 = hw.constant -106 : i16
@@ -177,7 +177,7 @@ hw.module @constant_fold4(out res: !sim.fstring) {
   hw.output %catout : !sim.fstring
 }
 
-// CHECK: sim.fmt.literal "  106,106  ,006A,006A,   006A,006A   "
+// CHECK: sim.fmt.literal "  106,106  ,006A,6A  ,000006A,6A     "
 hw.module @constant_fold5(out res: !sim.fstring) {
   %1 = hw.constant 106 : i16
   %2 = hw.constant -106 : i16
@@ -189,6 +189,22 @@ hw.module @constant_fold5(out res: !sim.fstring) {
   %wRightHexPad = sim.fmt.hex %1, isUpper true specifierWidth 7 : i16
   %wLeftHexPad = sim.fmt.hex %1, isUpper true isLeftAligned true specifierWidth 7: i16
   %cat = sim.fmt.concat (%wRightDec, %comma, %wLeftDec, %comma, %wRightHex, %comma, %wLeftHex, %comma, %wRightHexPad, %comma, %wLeftHexPad)
+  hw.output %cat : !sim.fstring
+}
+
+// A `specifierWidth` of 0 disables padding for every radix and prints the
+// value in its minimal representation.
+// CHECK: sim.fmt.literal "106,-106,6a,152,1101010"
+hw.module @constant_fold_width0(out res: !sim.fstring) {
+  %pos = hw.constant 106 : i16
+  %neg = hw.constant -106 : i16
+  %comma = sim.fmt.literal ","
+  %d = sim.fmt.dec %pos specifierWidth 0 : i16
+  %ds = sim.fmt.dec %neg specifierWidth 0 signed : i16
+  %h = sim.fmt.hex %pos, isUpper false specifierWidth 0 : i16
+  %o = sim.fmt.oct %pos specifierWidth 0 : i16
+  %b = sim.fmt.bin %pos specifierWidth 0 : i16
+  %cat = sim.fmt.concat (%d, %comma, %ds, %comma, %h, %comma, %o, %comma, %b)
   hw.output %cat : !sim.fstring
 }
 


### PR DESCRIPTION
Unify the padding semantics of the `sim.fmt.dec`, `sim.fmt.hex`, `sim.fmt.oct`, and `sim.fmt.bin` ops with the SystemVerilog `%d`/`%h` specifier family (IEEE 1800-2017 §21.2.1.3). The field width defaults to the natural width of the value's type, an explicit `specifierWidth` overrides it, and a `specifierWidth` of 0 disables padding and prints the value in its minimal representation, matching SystemVerilog's `%0d`.

Previously the constant folder and the Arc runtime disagreed: the runtime padded decimals to the type's bit width and treated `specifierWidth` as additive, so a width of 0 never removed padding. The hexadecimal, octal, and binary paths added the specifier width as extra spaces on top of the natural zero-padding in both the folder and the runtime, so a width of 0 left the natural padding in place.

Factor the shared formatting into a header-only `circt/Support/ FormatInteger.h` so the Sim dialect and the Arc runtime produce identical output without depending on each other. Left-aligned output, which has no SystemVerilog `$display` equivalent, pads with trailing spaces to match the C `printf` behavior that the SimToSV lowering targets.

Assisted-by: Claude Opus 4.8
