### PR TITLE
[ArcToLLVM] Lower sim.fmt.bin for the arcilator runtime

### DIFF
--- a/integration_test/arcilator/JIT/fmt-padding.mlir
+++ b/integration_test/arcilator/JIT/fmt-padding.mlir
@@ -6,10 +6,6 @@
 // others -- rather than with NUL bytes. A `specifierWidth` of 0 disables padding
 // and prints the value in its minimal representation. Values are bracketed so
 // the padding is visible to FileCheck under `--strict-whitespace`.
-//
-// `sim.fmt.bin` is omitted because the arcilator runtime only lowers the
-// decimal, hexadecimal, and octal formatters; binary is covered by the
-// constant-folder test in test/Dialect/Sim/format-strings.mlir.
 
 func.func @entry() {
   %open = sim.fmt.literal "["
@@ -36,6 +32,11 @@ func.func @entry() {
   %octMsg = sim.fmt.concat (%open, %oct, %close)
   sim.proc.print %octMsg
 
+  // CHECK:[0000000001101010]
+  %bin = sim.fmt.bin %c106 : i16
+  %binMsg = sim.fmt.concat (%open, %bin, %close)
+  sim.proc.print %binMsg
+
   // A `specifierWidth` of 0 disables padding for every radix.
 
   // CHECK:[106]
@@ -52,6 +53,11 @@ func.func @entry() {
   %o0 = sim.fmt.oct %c106 specifierWidth 0 : i16
   %o0Msg = sim.fmt.concat (%open, %o0, %close)
   sim.proc.print %o0Msg
+
+  // CHECK:[1101010]
+  %b0 = sim.fmt.bin %c106 specifierWidth 0 : i16
+  %b0Msg = sim.fmt.concat (%open, %b0, %close)
+  sim.proc.print %b0Msg
 
   return
 }

--- a/integration_test/arcilator/JIT/sim-print.mlir
+++ b/integration_test/arcilator/JIT/sim-print.mlir
@@ -37,6 +37,11 @@ module {
     sim.proc.print %o0
     sim.proc.print %endl
 
+    // CHECK: {{0*}}1111011
+    %b0 = sim.fmt.bin %c123 : i32
+    sim.proc.print %b0
+    sim.proc.print %endl
+
     // CHECK: {
     %c123_8 = hw.constant 123 : i8
     %ch0 = sim.fmt.char %c123_8 : i8

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -962,6 +962,14 @@ foldFormatString(ConversionPatternRewriter &rewriter, Value fstringValue,
             false);
         return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
       })
+      .Case<sim::FormatBinOp>([&](sim::FormatBinOp op)
+                                  -> FailureOr<FormatInfo> {
+        FmtDescriptor d = FmtDescriptor::createInt(
+            op.getValue().getType().getWidth(), 2, op.getIsLeftAligned(),
+            op.getSpecifierWidth().value_or(-1), op.getPaddingChar(), false,
+            false);
+        return FormatInfo{{d}, {reg2mem(rewriter, op.getLoc(), op.getValue())}};
+      })
       .Case<sim::FormatLiteralOp>(
           [&](sim::FormatLiteralOp op) -> FailureOr<FormatInfo> {
             if (op.getLiteral().size() < 8 &&


### PR DESCRIPTION
Add the missing `sim.fmt.bin` case to the format-string lowering so binary integer formatting reaches the runtime exactly like the decimal, hexadecimal, and octal formatters. The op was already marked legal and the runtime already handles radix 2; only the descriptor emission was missing, so binary format ops previously failed to legalize.

Extend the JIT integration tests to cover binary formatting, including the default field width and the padding-disabling `specifierWidth 0`.

Assisted-by: Claude Opus 4.8