### PR TITLE
[Arc] Size hw.union types in computeLLVMBitWidth

### DIFF
--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -80,6 +80,32 @@ std::optional<uint64_t> circt::arc::computeLLVMBitWidth(Type type) {
     return llvm::alignToPowerOf2(structWidth, structAlignment);
   }
 
+  // A union's variants all overlap at the same base address, so its size is
+  // determined by the largest variant rather than their sum. Honor any explicit
+  // per-variant bit offset, and pad the whole thing to the union's alignment.
+  if (auto unionType = dyn_cast<hw::UnionType>(type)) {
+    uint64_t unionWidth = 0;
+    uint64_t unionAlignment = 8;
+    for (auto element : unionType.getElements()) {
+      // Compute variant width.
+      auto maybeWidth = computeLLVMBitWidth(element.type);
+      if (!maybeWidth)
+        return {};
+      // Each variant must be at least one byte.
+      auto width = std::max<uint64_t>(*maybeWidth, 8);
+      // Align variants to their own size, up to 16 bytes.
+      auto alignment = llvm::bit_ceil(std::min<uint64_t>(width, 16 * 8));
+      auto alignedWidth = llvm::alignToPowerOf2(width, alignment);
+      // The union must be large enough to hold this variant at its offset.
+      unionWidth =
+          std::max<uint64_t>(unionWidth, element.offset + alignedWidth);
+      // Keep track of the union's alignment need.
+      unionAlignment = std::max<uint64_t>(alignment, unionAlignment);
+    }
+    // Pad the union size to align its end with the alignment.
+    return llvm::alignToPowerOf2(unionWidth, unionAlignment);
+  }
+
   // We don't know anything about any other types.
   return {};
 }

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -118,3 +118,39 @@ arc.model @ArrayPadding io !hw.modty<> {
   // element gets aligned to the next power-of-two.
   arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.array<2xi9>>
 }
+
+// CHECK-LABEL: arc.model @UnionMaxVariant
+// CHECK-NEXT: !arc.storage<32>
+arc.model @UnionMaxVariant io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // A !hw.union is sized by its largest variant, not the sum of its variants,
+  // so this allocates 8 bytes for the i64 rather than 9 for both fields.
+  arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.union<small: i8, big: i64>>
+}
+
+// CHECK-LABEL: arc.model @UnionVariantPadding
+// CHECK-NEXT: !arc.storage<26>
+arc.model @UnionVariantPadding io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // Like struct fields and array elements, each variant is widened to a byte
+  // and aligned to a power of two: the i9 maps to 16 bits, giving 2 bytes.
+  arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.union<x: i9, y: i3>>
+}
+
+// CHECK-LABEL: arc.model @UnionOffset
+// CHECK-NEXT: !arc.storage<41>
+arc.model @UnionOffset io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // An explicit per-variant bit offset is honored when sizing the union: the
+  // i8 sits at bit 64, requiring 9 bytes of storage.
+  arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.union<x: i8 offset 64, y: i8>>
+}
+
+// CHECK-LABEL: arc.model @UnionNested
+// CHECK-NEXT: !arc.storage<28>
+arc.model @UnionNested io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // Variant widths are computed recursively, so the larger struct variant of
+  // two i16 fields determines the 4-byte size.
+  arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.union<x: !hw.struct<a: i16, b: i16>, y: i8>>
+}


### PR DESCRIPTION
Teach the Arc storage layout helper how to compute the bit width of an `!hw.union`. The width is the largest variant rather than the sum of all variants, honoring any explicit per-variant bit offset and padding the result to the union's alignment, mirroring the existing struct handling.

This lets `!hw.union` types flow through `AllocateState`, which queries state slot widths via `computeLLVMBitWidth`. Previously such types had no known width and could not be allocated storage.

Assisted-by: Claude Opus 4.8