### PR TITLE
[CombFolds] Add fold for single-bit parity op

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -300,6 +300,10 @@ OpFoldResult ParityOp::fold(FoldAdaptor adaptor) {
   if (auto input = dyn_cast_or_null<IntegerAttr>(adaptor.getInput()))
     return getIntAttr(APInt(1, input.getValue().popcount() & 1), getContext());
 
+  // parity(x) -> x for single-bit values.
+  if (hw::getBitWidth(getInput().getType()) == 1)
+    return getInput();
+
   return {};
 }
 

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -2164,3 +2164,10 @@ hw.module @AndOfReplicateNot2State(in %p: i1, in %x: i4, out y: i4) {
   %and = comb.and %x, %r : i4
   hw.output %and : i4
 }
+
+// CHECK-LABEL: @paritySingleBit
+hw.module @paritySingleBit(in %a: i1, out o: i1) {
+  // CHECK-NEXT: hw.output %a : i1
+  %0 = comb.parity %a : i1
+  hw.output %0 : i1
+}


### PR DESCRIPTION
Fold comb.parity to identity for single-bit inputs.

Assisted-by: augment: sonnet 4.5

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
