### PR TITLE
[ImportVerilog] Add opt-in --detect-top to auto-select the runnable top

### DIFF
--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -114,6 +114,11 @@ struct ImportVerilogOptions {
   /// based on which modules are unreferenced elsewhere.
   std::vector<std::string> topModules;
 
+  /// If true, require elaboration to resolve to exactly one runnable top module
+  /// (unless `topModules` is set explicitly). Emit an error if the design is
+  /// ambiguous, i.e. zero or multiple top modules are found.
+  bool detectTop = false;
+
   /// A list of top-level module parameters to override, of the form
   /// `<name>=<value>`.
   std::vector<std::string> paramOverrides;

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -323,6 +323,19 @@ LogicalResult ImportDriver::importVerilog(ModuleOp module) {
     return failure();
   compileTimer.stop();
 
+  // If requested, require elaboration to resolve to exactly one runnable top
+  // module. This is an opt-in check; when `detectTop` is false this block does
+  // not execute and the default behavior is unchanged. If the user explicitly
+  // listed top modules via `topModules`, honor that instead.
+  if (options.detectTop && options.topModules.empty()) {
+    auto tops = compilation->getRoot().topInstances;
+    if (tops.size() != 1) {
+      mlir::emitError(module.getLoc())
+          << "expected exactly one runnable top module; found " << tops.size();
+      return failure();
+    }
+  }
+
   // If we were only supposed to lint the input, return here. This leaves the
   // module empty, but any Slang linting messages got reported as diagnostics.
   if (options.mode == ImportVerilogOptions::Mode::OnlyLint)

--- a/test/circt-verilog/detect-top.sv
+++ b/test/circt-verilog/detect-top.sv
@@ -1,0 +1,32 @@
+// RUN: split-file %s %t
+//
+// A single unreferenced top module is unambiguous: --detect-top succeeds and
+// the module lowers as usual.
+// RUN: circt-verilog --detect-top %t/single.sv | FileCheck %s --check-prefix=SINGLE
+//
+// Multiple unreferenced top modules are ambiguous: --detect-top errors out.
+// RUN: not circt-verilog --detect-top %t/multi.sv 2>&1 | FileCheck %s --check-prefix=MULTI
+//
+// The SAME multi-top input WITHOUT --detect-top still elaborates (the default
+// path is unchanged).
+// RUN: circt-verilog %t/multi.sv | FileCheck %s --check-prefix=DEFAULT
+//
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+//--- single.sv
+// SINGLE: hw.module @Top
+module Top(input logic a, output logic b);
+  assign b = a;
+endmodule
+
+//--- multi.sv
+// MULTI: expected exactly one runnable top module; found 2
+// DEFAULT-DAG: hw.module @TopA
+// DEFAULT-DAG: hw.module @TopB
+module TopA(input logic a, output logic b);
+  assign b = a;
+endmodule
+module TopB(input logic c, output logic d);
+  assign d = c;
+endmodule

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -239,6 +239,12 @@ struct CLOptions {
                "figuring it out automatically)"),
       cl::value_desc("name"), cl::cat(cat)};
 
+  cl::opt<bool> detectTop{
+      "detect-top",
+      cl::desc("Auto-detect the single runnable top module from elaboration; "
+               "error if ambiguous"),
+      cl::init(false), cl::cat(cat)};
+
   cl::list<std::string> paramOverrides{
       "G",
       cl::desc("One or more parameter overrides to apply when instantiating "
@@ -364,8 +370,10 @@ static LogicalResult executeWithSources(MLIRContext *context,
     options.timeScale = opts.timeScale;
   options.allowUseBeforeDeclare = opts.allowUseBeforeDeclare;
   options.ignoreUnknownModules = opts.ignoreUnknownModules;
-  if (opts.loweringMode != LoweringMode::OnlyLint)
+  if (opts.loweringMode != LoweringMode::OnlyLint) {
     options.topModules = opts.topModules;
+    options.detectTop = opts.detectTop;
+  }
   options.paramOverrides = opts.paramOverrides;
 
   options.warningOptions = opts.warningOptions;


### PR DESCRIPTION
Adds an opt-in `--detect-top` flag to circt-verilog. When set (and `--top` is not given), elaboration must yield exactly one runnable top module; otherwise it errors. Default behavior is unchanged when the flag is absent.

Motivation: downstream harnesses re-derive the runnable top with source-level regex (e.g. the sv-tests Arcilator runner, chipsalliance/sv-tests#8628). circt-verilog already has the elaborated hierarchy via slang's `getRoot().topInstances`, so the detection belongs in the frontend rather than the harness.

- Off by default; when the flag is absent the import path is byte-identical (verified against the prior binary on existing tests).
- Errors on 0 or >1 roots rather than guessing an arbitrary entry point.
- Adds `test/circt-verilog/detect-top.sv`.