### PR TITLE
Bump LLVM

### DIFF
--- a/examples/circt-standalone/test/lit.cfg.py
+++ b/examples/circt-standalone/test/lit.cfg.py
@@ -6,7 +6,7 @@ import lit.formats
 from lit.llvm import llvm_config
 
 config.name = "CIRCT_STANDALONE"
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 config.suffixes = [".mlir"]
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = os.path.join(config.circt_standalone_obj_root, "test")

--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -70,9 +70,9 @@ systemc.module @systemCTypes (%p0: !systemc.in<!systemc.int_base>,
 systemc.module @emitcEmission () {
   systemc.ctor {
     %0 = "emitc.constant"() {value = #emitc.opaque<"5"> : !emitc.opaque<"int">} : () -> !emitc.opaque<"int">
-    %f = "emitc.variable"() {value=#emitc.opaque<"5">, name="f"} : () -> !emitc.lvalue<!emitc.opaque<"int">>  
-    %1 = emitc.apply "&"(%f) : (!emitc.lvalue<!emitc.opaque<"int">>) -> !emitc.ptr<!emitc.opaque<"int">>
-    %2 = emitc.apply "*"(%1) : (!emitc.ptr<!emitc.opaque<"int">>) -> !emitc.opaque<"int">
+    %f = "emitc.variable"() {value=#emitc.opaque<"5">, name="f"} : () -> !emitc.lvalue<!emitc.opaque<"int">>
+    %1 = emitc.address_of %f : !emitc.lvalue<!emitc.opaque<"int">>
+    %2 = emitc.dereference %1 : !emitc.ptr<!emitc.opaque<"int">>
     %3 = emitc.cast %2: !emitc.opaque<"int"> to !emitc.opaque<"long">
     emitc.call_opaque "printf" (%3) {args=["result: %ld\n", 0 : index]} : (!emitc.opaque<"long">) -> ()
 

--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -73,7 +73,7 @@ systemc.module @emitcEmission () {
     %f = "emitc.variable"() {value=#emitc.opaque<"5">, name="f"} : () -> !emitc.lvalue<!emitc.opaque<"int">>
     %1 = emitc.address_of %f : !emitc.lvalue<!emitc.opaque<"int">>
     %2 = emitc.dereference %1 : !emitc.ptr<!emitc.opaque<"int">>
-    %3 = emitc.cast %2: !emitc.opaque<"int"> to !emitc.opaque<"long">
+    %3 = emitc.cast %0: !emitc.opaque<"int"> to !emitc.opaque<"long">
     emitc.call_opaque "printf" (%3) {args=["result: %ld\n", 0 : index]} : (!emitc.opaque<"long">) -> ()
 
     %idx = systemc.cpp.variable : index

--- a/integration_test/arcilator/JIT/err-jit-with-until.mlir
+++ b/integration_test/arcilator/JIT/err-jit-with-until.mlir
@@ -1,5 +1,5 @@
-// RUN: ! (arcilator %s --run --jit-entry=main --until-after=state-alloc 2> %t) && FileCheck --input-file=%t %s
-// RUN: ! (arcilator %s --run --jit-entry=main --until-before=state-alloc 2> %t) && FileCheck --input-file=%t %s
+// RUN: not arcilator %s --run --jit-entry=main --until-after=state-alloc 2> %t && FileCheck --input-file=%t %s
+// RUN: not arcilator %s --run --jit-entry=main --until-before=state-alloc 2> %t && FileCheck --input-file=%t %s
 // REQUIRES: arcilator-jit
 
 // CHECK: full pipeline must be run for JIT execution

--- a/integration_test/arcilator/JIT/err-not-found.mlir
+++ b/integration_test/arcilator/JIT/err-not-found.mlir
@@ -1,4 +1,4 @@
-// RUN: ! (arcilator %s --run --jit-entry=unknown 2> %t) && FileCheck --input-file=%t %s
+// RUN: not arcilator %s --run --jit-entry=unknown 2> %t && FileCheck --input-file=%t %s
 // REQUIRES: arcilator-jit
 
 // CHECK: entry point not found: 'unknown'

--- a/integration_test/arcilator/JIT/err-not-func.mlir
+++ b/integration_test/arcilator/JIT/err-not-func.mlir
@@ -1,4 +1,4 @@
-// RUN: ! (arcilator %s --run --jit-entry=foo 2> %t) && FileCheck --input-file=%t %s
+// RUN: not arcilator %s --run --jit-entry=foo 2> %t && FileCheck --input-file=%t %s
 // REQUIRES: arcilator-jit
 
 // CHECK: entry point 'foo' was found but on an operation of type 'llvm.mlir.global' while an LLVM function was expected

--- a/integration_test/arcilator/JIT/err-wrong-func.mlir
+++ b/integration_test/arcilator/JIT/err-wrong-func.mlir
@@ -1,4 +1,4 @@
-// RUN: ! (arcilator %s --run --jit-entry=main 2> %t) && FileCheck --input-file=%t %s
+// RUN: not arcilator %s --run --jit-entry=main 2> %t && FileCheck --input-file=%t %s
 // REQUIRES: arcilator-jit
 
 // CHECK: entry point 'main' must have no arguments

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -20,7 +20,7 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = 'CIRCT'
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.td', '.mlir', '.ll', '.fir', '.sv', '.py', '.tcl']

--- a/lib/Dialect/LLHD/Transforms/DeseqUtils.h
+++ b/lib/Dialect/LLHD/Transforms/DeseqUtils.h
@@ -314,9 +314,6 @@ template <>
 struct DenseMapInfo<circt::llhd::deseq::FixedValue> {
   using Value = mlir::Value;
   using FixedValue = circt::llhd::deseq::FixedValue;
-  static inline FixedValue getEmptyKey() {
-    return FixedValue{DenseMapInfo<Value>::getEmptyKey(), false, false};
-  }
   static unsigned getHashValue(const FixedValue &key) {
     return hash_value(key);
   }
@@ -330,9 +327,6 @@ template <>
 struct DenseMapInfo<circt::llhd::deseq::FixedValues> {
   using FixedValue = circt::llhd::deseq::FixedValue;
   using FixedValues = circt::llhd::deseq::FixedValues;
-  static inline FixedValues getEmptyKey() {
-    return {DenseMapInfo<FixedValue>::getEmptyKey()};
-  }
   static unsigned getHashValue(const FixedValues &key) {
     return hash_value(key);
   }
@@ -345,9 +339,6 @@ struct DenseMapInfo<circt::llhd::deseq::FixedValues> {
 template <>
 struct DenseMapInfo<circt::llhd::deseq::ValueField> {
   using VF = circt::llhd::deseq::ValueField;
-  static inline VF getEmptyKey() {
-    return VF(DenseMapInfo<mlir::Value>::getEmptyKey(), ~0ULL);
-  }
   static unsigned getHashValue(const VF &key) {
     return DenseMapInfo<mlir::Value>::getHashValue(key.value) ^
            DenseMapInfo<uint64_t>::getHashValue(key.fieldID) ^

--- a/lib/Target/ExportSystemC/Patterns/EmitCEmissionPatterns.cpp
+++ b/lib/Target/ExportSystemC/Patterns/EmitCEmissionPatterns.cpp
@@ -34,25 +34,39 @@ struct IncludeEmitter : OpEmissionPattern<IncludeOp> {
   }
 };
 
-/// Emit emitc.apply operations.
-struct ApplyOpEmitter : OpEmissionPattern<ApplyOp> {
+/// Emit emitc.address_of operations.
+struct AddressOfOpEmitter : OpEmissionPattern<AddressOfOp> {
   using OpEmissionPattern::OpEmissionPattern;
 
   MatchResult matchInlinable(Value value) override {
-    if (value.getDefiningOp<ApplyOp>()) {
-      // We would need to check the 'applicableOperator' to select the
-      // precedence to return. However, since the dereference and address_of
-      // operators have the same precedence, we can omit that (for better
-      // performance).
+    if (value.getDefiningOp<AddressOfOp>())
       return Precedence::ADDRESS_OF;
-    }
     return {};
   }
 
   void emitInlined(Value value, EmissionPrinter &p) override {
-    auto applyOp = value.getDefiningOp<ApplyOp>();
-    p << applyOp.getApplicableOperator();
-    p.getInlinable(applyOp.getOperand())
+    auto addressOfOp = value.getDefiningOp<AddressOfOp>();
+    p << "&";
+    p.getInlinable(addressOfOp.getReference())
+        .emitWithParensOnLowerPrecedence(Precedence::ADDRESS_OF);
+  }
+};
+
+/// Emit emitc.dereference operations.
+struct DereferenceOpEmitter : OpEmissionPattern<DereferenceOp> {
+  using OpEmissionPattern::OpEmissionPattern;
+
+  MatchResult matchInlinable(Value value) override {
+    // 	`dereference` has the same precedence as `address_of`.
+    if (value.getDefiningOp<DereferenceOp>())
+      return Precedence::ADDRESS_OF;
+    return {};
+  }
+
+  void emitInlined(Value value, EmissionPrinter &p) override {
+    auto dereferenceOp = value.getDefiningOp<DereferenceOp>();
+    p << "*";
+    p.getInlinable(dereferenceOp.getPointer())
         .emitWithParensOnLowerPrecedence(Precedence::ADDRESS_OF);
   }
 };
@@ -237,8 +251,9 @@ struct OpaqueAttrEmitter : AttrEmissionPattern<OpaqueAttr> {
 
 void circt::ExportSystemC::populateEmitCOpEmitters(
     OpEmissionPatternSet &patterns, MLIRContext *context) {
-  patterns.add<IncludeEmitter, ApplyOpEmitter, CallOpEmitter, CastOpEmitter,
-               ConstantEmitter, VariableEmitter>(context);
+  patterns.add<IncludeEmitter, AddressOfOpEmitter, DereferenceOpEmitter,
+               CallOpEmitter, CastOpEmitter, ConstantEmitter, VariableEmitter>(
+      context);
 }
 
 void circt::ExportSystemC::populateEmitCTypeEmitters(

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -148,22 +148,22 @@ systemc.module @emitcEmission () {
     %0 = "emitc.constant"() {value = #emitc.opaque<"5"> : !emitc.opaque<"int">} : () -> !emitc.opaque<"int">
     %five = systemc.cpp.variable %0 : !emitc.opaque<"int">
 
-    // Test: emitc.apply "&" without having to emit parentheses
+    // Test: emitc.address_of without having to emit parentheses
     // CHECK-NEXT: int f = 5;
     // CHECK-NEXT: int* fiveptr = &f;
-    %f = "emitc.variable"() {value=#emitc.opaque<"5">, name="f"} : () -> !emitc.lvalue<!emitc.opaque<"int">>  
-    %1 = emitc.apply "&"(%f) : (!emitc.lvalue<!emitc.opaque<"int">>) -> !emitc.ptr<!emitc.opaque<"int">>
+    %f = "emitc.variable"() {value=#emitc.opaque<"5">, name="f"} : () -> !emitc.lvalue<!emitc.opaque<"int">>
+    %1 = emitc.address_of %f : !emitc.lvalue<!emitc.opaque<"int">>
     %fiveptr = systemc.cpp.variable %1: !emitc.ptr<!emitc.opaque<"int">>
 
-    // Test: emitc.apply "&" with parentheses to conform to the precedence rules
+    // Test: emitc.address_of with parentheses to conform to the precedence rules
     // TODO: add this test-case once we have support for an inlinable operation that has lower precedence
 
-    // Test: emitc.apply "*" without having to emit parentheses
+    // Test: emitc.dereference without having to emit parentheses
     // CHECK-NEXT: int fivederef = *fiveptr;
-    %2 = emitc.apply "*"(%fiveptr) : (!emitc.ptr<!emitc.opaque<"int">>) -> !emitc.opaque<"int">
-    %fivederef = systemc.cpp.variable %2: !emitc.opaque<"int">
+    %2 = emitc.dereference %fiveptr : !emitc.ptr<!emitc.opaque<"int">>
+    %fivederef = systemc.cpp.variable %2: !emitc.lvalue<!emitc.opaque<"int">>
 
-    // Test: emitc.apply "*" with parentheses to conform to the precedence rules
+    // Test: emitc.dereference with parentheses to conform to the precedence rules
     // TODO: add this test-case once we have support for an inlinable operation that has lower precedence
 
     // Test: emit.call without a result is emitted as a statement, having operands and attribute arguments

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -19,7 +19,7 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = 'CIRCT'
 
-config.test_format = lit.formats.ShTest(execute_external=False)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -19,7 +19,7 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = 'CIRCT'
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(execute_external=False)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [

--- a/tools/circt-test/circt-test.cpp
+++ b/tools/circt-test/circt-test.cpp
@@ -307,12 +307,24 @@ LogicalResult RunnerSuite::resolve() {
   // If the user has provided a concrete list of runners to use, mark all other
   // runners as to be ignored.
   if (opts.runners.getNumOccurrences() > 0) {
+    // Strip leading backslashes from runner names to handle lit shell escaping.
+    // This allows test files to use `-r \verilator` to prevent lit substitution
+    // while still matching the actual runner name "verilator".
+    SmallVector<std::string> normalizedRunners;
+    for (const auto &name : opts.runners) {
+      StringRef runnerName = name;
+      if (runnerName.starts_with("\\"))
+        normalizedRunners.push_back(runnerName.substr(1).str());
+      else
+        normalizedRunners.push_back(name);
+    }
+
     for (auto &runner : runners)
-      if (!llvm::is_contained(opts.runners, runner.name))
+      if (!llvm::is_contained(normalizedRunners, runner.name))
         runner.ignore = true;
 
     // Produce errors if the user listed any runners that don't exist.
-    for (auto &name : opts.runners) {
+    for (const auto &name : normalizedRunners) {
       if (!llvm::is_contained(
               llvm::map_range(runners,
                               [](auto &runner) { return runner.name; }),


### PR DESCRIPTION
* [SystemC] ApplyOp was deprecated. https://github.com/llvm/llvm-project/pull/203712
* DenseMap getEmpty removal. 
* External shell deprecation (e.g. https://github.com/llvm/llvm-project/pull/203450)
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
