### PR TITLE
[MooreToCore] Lower bool_cast of packed aggregates

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1734,6 +1734,54 @@ struct ReduceXorOpConversion : public OpConversionPattern<ReduceXorOp> {
   }
 };
 
+// Reduce an integer or packed-aggregate value to a single bit that is set iff
+// any bit of the value is non-zero. Packed structs and arrays are reduced by
+// OR-ing the per-element non-zero results, matching the IEEE 1800-2023 6.3.2
+// semantics of a packed value in a self-determined boolean context.
+static FailureOr<Value> createAggregateNonZero(OpBuilder &builder, Location loc,
+                                               Value input) {
+  Type type = input.getType();
+  auto i1Type = builder.getI1Type();
+
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    Value zero = hw::ConstantOp::create(builder, loc, intType, 0);
+    return comb::ICmpOp::create(builder, loc, comb::ICmpPredicate::ne, input,
+                                zero)
+        .getResult();
+  }
+
+  if (auto arrayType = dyn_cast<hw::ArrayType>(type)) {
+    Value anySet = hw::ConstantOp::create(builder, loc, i1Type, 0);
+    unsigned idxWidth =
+        std::max(1u, llvm::Log2_64_Ceil(arrayType.getNumElements()));
+    for (unsigned i = 0, e = arrayType.getNumElements(); i < e; ++i) {
+      Value idx = hw::ConstantOp::create(builder, loc,
+                                         builder.getIntegerType(idxWidth), i);
+      Value element = builder.createOrFold<hw::ArrayGetOp>(loc, input, idx);
+      auto elementNonZero = createAggregateNonZero(builder, loc, element);
+      if (failed(elementNonZero))
+        return failure();
+      anySet = builder.createOrFold<comb::OrOp>(loc, anySet, *elementNonZero);
+    }
+    return anySet;
+  }
+
+  if (auto structType = dyn_cast<hw::StructType>(type)) {
+    Value anySet = hw::ConstantOp::create(builder, loc, i1Type, 0);
+    for (auto field : structType.getElements()) {
+      Value fieldValue =
+          builder.createOrFold<hw::StructExtractOp>(loc, input, field.name);
+      auto fieldNonZero = createAggregateNonZero(builder, loc, fieldValue);
+      if (failed(fieldNonZero))
+        return failure();
+      anySet = builder.createOrFold<comb::OrOp>(loc, anySet, *fieldNonZero);
+    }
+    return anySet;
+  }
+
+  return failure();
+}
+
 struct BoolCastOpConversion : public OpConversionPattern<BoolCastOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -1752,6 +1800,14 @@ struct BoolCastOpConversion : public OpConversionPattern<BoolCastOp> {
           rewriter, op->getLoc(), rewriter.getFloatAttr(resultType, 0.0));
       rewriter.replaceOpWithNewOp<arith::CmpFOp>(op, arith::CmpFPredicate::ONE,
                                                  adaptor.getInput(), zero);
+      return success();
+    }
+    if (isa_and_nonnull<hw::StructType, hw::ArrayType>(resultType)) {
+      auto nonZero =
+          createAggregateNonZero(rewriter, op->getLoc(), adaptor.getInput());
+      if (failed(nonZero))
+        return failure();
+      rewriter.replaceOp(op, *nonZero);
       return success();
     }
     return failure();

--- a/test/Conversion/MooreToCore/bool-cast-aggregate.mlir
+++ b/test/Conversion/MooreToCore/bool-cast-aggregate.mlir
@@ -1,0 +1,30 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// A packed struct used in a self-determined boolean context (IEEE 1800-2023
+// 6.3.2) reduces to "any bit set" by OR-ing the per-field non-zero results.
+// CHECK-LABEL: func.func @packedStruct(
+// CHECK-SAME:    %arg0: !hw.struct<a: i1, b: i1>) -> i1
+func.func @packedStruct(%arg0: !moore.struct<{a: i1, b: i1}>) -> !moore.i1 {
+  // CHECK: %[[A:.+]] = hw.struct_extract %arg0["a"]
+  // CHECK: %[[NZA:.+]] = comb.icmp ne %[[A]], %{{.+}} : i1
+  // CHECK: %[[B:.+]] = hw.struct_extract %arg0["b"]
+  // CHECK: %[[NZB:.+]] = comb.icmp ne %[[B]], %{{.+}} : i1
+  // CHECK: %[[OR:.+]] = comb.or %[[NZA]], %[[NZB]] : i1
+  // CHECK: return %[[OR]] : i1
+  %0 = moore.bool_cast %arg0 : struct<{a: i1, b: i1}> -> i1
+  return %0 : !moore.i1
+}
+
+// A packed array reduces the same way over its elements.
+// CHECK-LABEL: func.func @packedArray(
+// CHECK-SAME:    %arg0: !hw.array<2xi1>) -> i1
+func.func @packedArray(%arg0: !moore.array<2 x i1>) -> !moore.i1 {
+  // CHECK: %[[E0:.+]] = hw.array_get %arg0[%{{.+}}]
+  // CHECK: %[[NZ0:.+]] = comb.icmp ne %[[E0]], %{{.+}} : i1
+  // CHECK: %[[E1:.+]] = hw.array_get %arg0[%{{.+}}]
+  // CHECK: %[[NZ1:.+]] = comb.icmp ne %[[E1]], %{{.+}} : i1
+  // CHECK: %[[OR:.+]] = comb.or %[[NZ0]], %[[NZ1]] : i1
+  // CHECK: return %[[OR]] : i1
+  %0 = moore.bool_cast %arg0 : array<2 x i1> -> i1
+  return %0 : !moore.i1
+}


### PR DESCRIPTION
Full disclosure: AI generated text, via a human in CLI.

A packed struct or array used in a self-determined boolean context lowers to a
`moore.bool_cast` with an aggregate input — for example:

```systemverilog
module m(input struct packed { logic a; logic b; } s, output logic o);
  assign o = s ? 1'b1 : 1'b0;
endmodule
```

Today this fails to legalize in `--convert-moore-to-core`:

```
error: failed to legalize operation 'moore.bool_cast'
    %2 = moore.bool_cast %s : struct<{a: l1, b: l1}> -> l1
```

because `BoolCastOpConversion` only handled `IntegerType` and `FloatType` inputs
and returned `failure()` for everything else.

This adds a `createAggregateNonZero` helper that reduces a packed aggregate to a
single "any bit set" bit by recursively OR-ing the per-element non-zero results
(reusing the existing integer `icmp ne 0` at the leaves), and wires it into
`BoolCastOpConversion` for `hw::StructType` / `hw::ArrayType` inputs — matching
the IEEE 1800-2023 §6.3.2 semantics of a packed value in a self-determined
boolean context.

Test: `test/Conversion/MooreToCore/bool-cast-aggregate.mlir` covers the struct
and array cases.
