### PR TITLE
[ci] Specify Python version in uploadWheels

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.3.0


### PR DESCRIPTION
Fix an issue observed when trying to publish Python wheels off of main.
The newer `actions/setup-python` seems to require a Python version to be
specified.  Set this to 3.14 as that was what was being used empirically
before changes were made to bump the action.

The observed failure was here: https://github.com/llvm/circt/actions/runs/27858792317