### PR TITLE
[ci] Python version in _all_ Upload Wheel Jobs

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -81,13 +81,20 @@ jobs:
         run: |
           git fetch --force --unshallow --tags --no-recurse-submodules
 
-      - name: Determine Python version
+      - name: Determine Python and cibuildwheel versions
         id: python-version
         shell: bash
         run: |
           cibw_build="${{ matrix.config.cibw_build }}"
           python_version=$(echo "${cibw_build%%-*}" | sed -E 's/^cp([0-9])([0-9]+)$/\1.\2/')
           echo "python-version=${python_version}" >> "$GITHUB_OUTPUT"
+          # cibuildwheel 3.x dropped Python 3.10 as a supported host
+          # interpreter, so pin to the last 2.x release in that case.
+          if [[ "$python_version" == "3.10" ]]; then
+            echo "cibuildwheel-version=2.23.4" >> "$GITHUB_OUTPUT"
+          else
+            echo "cibuildwheel-version=3.3.0" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -95,7 +102,7 @@ jobs:
           python-version: ${{ steps.python-version.outputs.python-version }}
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.3.0
+        run: python -m pip install cibuildwheel==${{ steps.python-version.outputs.cibuildwheel-version }}
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse ./lib/Bindings/Python

--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -81,10 +81,18 @@ jobs:
         run: |
           git fetch --force --unshallow --tags --no-recurse-submodules
 
+      - name: Determine Python version
+        id: python-version
+        shell: bash
+        run: |
+          cibw_build="${{ matrix.config.cibw_build }}"
+          python_version=$(echo "${cibw_build%%-*}" | sed -E 's/^cp([0-9])([0-9]+)$/\1.\2/')
+          echo "python-version=${python_version}" >> "$GITHUB_OUTPUT"
+
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.14'
+          python-version: ${{ steps.python-version.outputs.python-version }}
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.3.0

--- a/lib/Bindings/Python/setup.py
+++ b/lib/Bindings/Python/setup.py
@@ -148,7 +148,7 @@ setup(
     ],
     cmdclass={
         "build": CustomBuild,
-        "built_ext": NoopBuildExtension,
+        "build_ext": NoopBuildExtension,
         "build_py": CMakeBuild,
     },
     zip_safe=False,


### PR DESCRIPTION
Fix an observed issue in the firtool 1.50.1 release when uploading Python
wheels where macOS builds need to have the same Python version "installed"
via the setup-python action and can't rely on a generic version being
installed (which empirically works for Linux).

This was identified by @uenoku earlier [[1]] and I thought it was fine.
However, it appears to not be.

[1]: https://github.com/llvm/circt/pull/10691#pullrequestreview-4540265822

Assisted-by: pi.dev:claude-opus-4-8
