### PR TITLE
[MooreToCore] Handle integer width edge cases

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1534,6 +1534,15 @@ struct DynExtractOpConversion : public OpConversionPattern<DynExtractOp> {
       Value value = comb::ShrUOp::create(rewriter, op->getLoc(),
                                          adaptor.getInput(), amount);
 
+      int64_t resultWidth = hw::getBitWidth(resultType);
+      if (resultWidth < 0)
+        return failure();
+      if (resultWidth > intType.getWidth()) {
+        rewriter.replaceOp(
+            op, adjustIntegerWidth(rewriter, value, resultWidth, op->getLoc()));
+        return success();
+      }
+
       rewriter.replaceOpWithNewOp<comb::ExtractOp>(op, resultType, value, 0);
       return success();
     }
@@ -2018,6 +2027,13 @@ struct SExtOpConversion : public OpConversionPattern<SExtOp> {
   matchAndRewrite(SExtOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto type = typeConverter->convertType(op.getType());
+    if (op.getInput().getType().getWidth() == 0) {
+      auto intType = cast<IntegerType>(type);
+      auto zeroAttr = rewriter.getIntegerAttr(intType, 0);
+      rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, intType, zeroAttr);
+      return success();
+    }
+
     auto value =
         comb::createOrFoldSExt(rewriter, op.getLoc(), adaptor.getInput(), type);
     rewriter.replaceOp(op, value);

--- a/test/Conversion/MooreToCore/dyn-extract-wide-int.mlir
+++ b/test/Conversion/MooreToCore/dyn-extract-wide-int.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @DynExtractWideInt
+// CHECK-SAME: (%arg0: i4, %arg1: i2) -> i8
+func.func @DynExtractWideInt(%value: !moore.i4, %idx: !moore.i2) -> !moore.i8 {
+  // CHECK: [[ZERO:%.*]] = hw.constant 0 : i2
+  // CHECK: [[AMOUNT:%.*]] = comb.concat [[ZERO]], %arg1 : i2, i2
+  // CHECK: [[SHIFTED:%.*]] = comb.shru %arg0, [[AMOUNT]] : i4
+  // CHECK: [[PAD:%.*]] = hw.constant 0 : i4
+  // CHECK: [[WIDE:%.*]] = comb.concat [[PAD]], [[SHIFTED]] : i4, i4
+  // CHECK: return [[WIDE]] : i8
+  %0 = moore.dyn_extract %value from %idx : !moore.i4, !moore.i2 -> !moore.i8
+  return %0 : !moore.i8
+}
+
+// CHECK-LABEL: func.func @DynExtractNarrowInt
+// CHECK-SAME: (%arg0: i4, %arg1: i2) -> i2
+func.func @DynExtractNarrowInt(%value: !moore.i4, %idx: !moore.i2) -> !moore.i2 {
+  // CHECK: [[ZERO:%.*]] = hw.constant 0 : i2
+  // CHECK: [[AMOUNT:%.*]] = comb.concat [[ZERO]], %arg1 : i2, i2
+  // CHECK: [[SHIFTED:%.*]] = comb.shru %arg0, [[AMOUNT]] : i4
+  // CHECK: [[NARROW:%.*]] = comb.extract [[SHIFTED]] from 0 : (i4) -> i2
+  // CHECK: return [[NARROW]] : i2
+  %0 = moore.dyn_extract %value from %idx : !moore.i4, !moore.i2 -> !moore.i2
+  return %0 : !moore.i2
+}

--- a/test/Conversion/MooreToCore/sext-zero-width.mlir
+++ b/test/Conversion/MooreToCore/sext-zero-width.mlir
@@ -1,0 +1,10 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @zero_width_sext
+// CHECK-SAME: (%arg0: i0) -> i1
+func.func @zero_width_sext(%z: !moore.i0) -> !moore.i1 {
+  // CHECK: %[[ZERO:.*]] = hw.constant false
+  %0 = moore.sext %z : i0 -> i1
+  // CHECK: return %[[ZERO]] : i1
+  return %0 : !moore.i1
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before.

Handle dynamic extract with result width exceeding input width, and sign-extension of zero-width integers in MooreToCore. Dynamically extracted values wider than source use adjustIntegerWidth; zero-width sign-extension folds to constant zero. Maps to existing comb.extract and hw.constant ops. Standalone.

Tests: dyn-extract-wide-int.mlir, sext-zero-width.mlir
