### PR TITLE
[MooreToCore] Handle zero-width replicate operations

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1340,6 +1340,18 @@ struct ReplicateOpConversion : public OpConversionPattern<ReplicateOp> {
   matchAndRewrite(ReplicateOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = typeConverter->convertType(op.getResult().getType());
+    if (auto intType = dyn_cast<IntegerType>(resultType);
+        intType && intType.getWidth() == 0) {
+      rewriter.replaceOpWithNewOp<hw::ConstantOp>(
+          op, intType, rewriter.getIntegerAttr(intType, 0));
+      return success();
+    }
+    if (auto valueType = dyn_cast<IntegerType>(adaptor.getValue().getType());
+        valueType && valueType.getWidth() == 0) {
+      rewriter.replaceOpWithNewOp<hw::ConstantOp>(
+          op, resultType, rewriter.getIntegerAttr(resultType, 0));
+      return success();
+    }
 
     rewriter.replaceOpWithNewOp<comb::ReplicateOp>(op, resultType,
                                                    adaptor.getValue());

--- a/test/Conversion/MooreToCore/replicate-zero-width-source.mlir
+++ b/test/Conversion/MooreToCore/replicate-zero-width-source.mlir
@@ -1,0 +1,10 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @zero_width_replicate_source
+// CHECK-SAME: (%arg0: i0) -> i4
+func.func @zero_width_replicate_source(%zero: !moore.i0) -> !moore.i4 {
+  // CHECK-NEXT: %[[ZERO:.*]] = hw.constant 0 : i4
+  %0 = moore.replicate %zero : !moore.i0 -> !moore.i4
+  // CHECK-NEXT: return %[[ZERO]] : i4
+  return %0 : !moore.i4
+}

--- a/test/Conversion/MooreToCore/replicate-zero-width.mlir
+++ b/test/Conversion/MooreToCore/replicate-zero-width.mlir
@@ -1,0 +1,10 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @zero_width_replicate
+// CHECK-SAME: (%arg0: i1) -> i0
+func.func @zero_width_replicate(%one: !moore.i1) -> !moore.i0 {
+  // CHECK: %[[ZERO:.*]] = hw.constant 0 : i0
+  %0 = moore.replicate %one : i1 -> i0
+  // CHECK: return %[[ZERO]] : i0
+  return %0 : !moore.i0
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before.

Handle replicate operations with zero-width sources or targets in MooreToCore. Both source and result zero-width cases fold to constant zero instead of creating invalid comb.replicate ops. Maps to hw.constant. Standalone.

Tests: replicate-zero-width.mlir, replicate-zero-width-source.mlir
