### PR TITLE
[MooreToCore] Handle empty array slices and creation

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1402,46 +1402,56 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
         if (elementWidth < 0)
           return failure();
 
-        int32_t high = low + resArrTy.getNumElements();
-        int32_t resWidth = resArrTy.getNumElements();
-
-        SmallVector<Value> toConcat;
-        if (low < 0) {
-          Value val = hw::ConstantOp::create(
-              rewriter, op.getLoc(),
-              APInt(std::min((-low) * elementWidth, resWidth * elementWidth),
-                    0));
-          Value res = rewriter.createOrFold<hw::BitcastOp>(
-              op.getLoc(), hw::ArrayType::get(arrTy.getElementType(), -low),
-              val);
-          toConcat.push_back(res);
+        int64_t high = int64_t(low) + resArrTy.getNumElements();
+        int64_t resWidth = resArrTy.getNumElements();
+        if (resWidth == 0) {
+          Value zero = createZeroValue(resultType, op.getLoc(), rewriter);
+          if (!zero)
+            return failure();
+          rewriter.replaceOp(op, zero);
+          return success();
         }
 
+        auto createZeroArray = [&](int64_t numElements) -> Value {
+          Value constZero = hw::ConstantOp::create(
+              rewriter, op.getLoc(), APInt(numElements * elementWidth, 0));
+          return rewriter.createOrFold<hw::BitcastOp>(
+              op.getLoc(),
+              hw::ArrayType::get(arrTy.getElementType(), numElements),
+              constZero);
+        };
+
+        SmallVector<Value> toConcat;
+        int64_t prefixElements = 0;
+        if (low < 0) {
+          prefixElements = std::min<int64_t>(-int64_t(low), resWidth);
+          if (prefixElements > 0)
+            toConcat.push_back(createZeroArray(prefixElements));
+        }
+
+        int64_t middleElements = 0;
         if (low < inputWidth && high > 0) {
-          int32_t lowIdx = std::max(0, low);
+          int64_t lowIdx = std::max<int64_t>(0, low);
+          middleElements =
+              std::min<int64_t>(resWidth - prefixElements,
+                                std::min<int64_t>(inputWidth, high) - lowIdx);
           Value lowIdxVal = hw::ConstantOp::create(
               rewriter, op.getLoc(), rewriter.getIntegerType(width), lowIdx);
           Value middle = rewriter.createOrFold<hw::ArraySliceOp>(
               op.getLoc(),
-              hw::ArrayType::get(
-                  arrTy.getElementType(),
-                  std::min(resWidth, std::min(inputWidth, high) - lowIdx)),
+              hw::ArrayType::get(arrTy.getElementType(), middleElements),
               adaptor.getInput(), lowIdxVal);
           toConcat.push_back(middle);
         }
 
-        int32_t diff = high - inputWidth;
-        if (diff > 0) {
-          Value constZero = hw::ConstantOp::create(
-              rewriter, op.getLoc(), APInt(diff * elementWidth, 0));
-          Value val = hw::BitcastOp::create(
-              rewriter, op.getLoc(),
-              hw::ArrayType::get(arrTy.getElementType(), diff), constZero);
-          toConcat.push_back(val);
-        }
+        int64_t suffixElements = resWidth - prefixElements - middleElements;
+        if (suffixElements > 0)
+          toConcat.push_back(createZeroArray(suffixElements));
 
-        Value concat =
-            rewriter.createOrFold<hw::ArrayConcatOp>(op.getLoc(), toConcat);
+        Value concat = toConcat.size() == 1
+                           ? toConcat.front()
+                           : rewriter.createOrFold<hw::ArrayConcatOp>(
+                                 op.getLoc(), toConcat);
         rewriter.replaceOp(op, concat);
         return success();
       }
@@ -1613,6 +1623,14 @@ struct ArrayCreateOpConversion : public OpConversionPattern<ArrayCreateOp> {
   matchAndRewrite(ArrayCreateOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = typeConverter->convertType(op.getResult().getType());
+    if (adaptor.getElements().empty()) {
+      Value zero = createZeroValue(resultType, op.getLoc(), rewriter);
+      if (!zero)
+        return failure();
+      rewriter.replaceOp(op, zero);
+      return success();
+    }
+
     rewriter.replaceOpWithNewOp<hw::ArrayCreateOp>(op, resultType,
                                                    adaptor.getElements());
     return success();

--- a/test/Conversion/MooreToCore/array-create-empty.mlir
+++ b/test/Conversion/MooreToCore/array-create-empty.mlir
@@ -1,0 +1,23 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @empty_packed_array_create
+// CHECK-NOT: hw.array_create
+// CHECK: %[[ZERO0:.+]] = hw.constant 0 : i0
+// CHECK: %[[ARRAY0:.+]] = hw.bitcast %[[ZERO0]] : (i0) -> !hw.array<0xi8>
+// CHECK: return %[[ARRAY0]] : !hw.array<0xi8>
+// CHECK-NOT: hw.array_create
+func.func @empty_packed_array_create() -> !moore.array<0 x !moore.i8> {
+  %0 = "moore.array_create"() : () -> !moore.array<0 x !moore.i8>
+  return %0 : !moore.array<0 x !moore.i8>
+}
+
+// CHECK-LABEL: func.func @empty_unpacked_array_create
+// CHECK-NOT: hw.array_create
+// CHECK: %[[ZERO1:.+]] = hw.constant 0 : i0
+// CHECK: %[[ARRAY1:.+]] = hw.bitcast %[[ZERO1]] : (i0) -> !hw.array<0xi8>
+// CHECK: return %[[ARRAY1]] : !hw.array<0xi8>
+// CHECK-NOT: hw.array_create
+func.func @empty_unpacked_array_create() -> !moore.uarray<0 x !moore.i8> {
+  %0 = "moore.array_create"() : () -> !moore.uarray<0 x !moore.i8>
+  return %0 : !moore.uarray<0 x !moore.i8>
+}

--- a/test/Conversion/MooreToCore/array-extract-negative-slice.mlir
+++ b/test/Conversion/MooreToCore/array-extract-negative-slice.mlir
@@ -1,0 +1,44 @@
+// RUN: circt-opt --convert-moore-to-core %s | FileCheck %s
+
+// CHECK-LABEL: func.func @negative_low_array_slice
+// CHECK-SAME: (%arg0: !hw.array<4xi8>) -> !hw.array<2xi8>
+// CHECK: %[[ZERO:.*]] = hw.constant 0 : i16
+// CHECK-NEXT: %[[PADDING:.*]] = hw.bitcast %[[ZERO]] : (i16) -> !hw.array<2xi8>
+// CHECK-NEXT: return %[[PADDING]] : !hw.array<2xi8>
+func.func @negative_low_array_slice(%arg0: !moore.array<4 x !moore.i8>) -> !moore.array<2 x !moore.i8> {
+  %0 = moore.extract %arg0 from -3 : !moore.array<4 x !moore.i8> -> !moore.array<2 x !moore.i8>
+  return %0 : !moore.array<2 x !moore.i8>
+}
+
+// CHECK-LABEL: func.func @negative_low_i32_min_array_slice
+// CHECK-SAME: (%arg0: !hw.array<4xi8>) -> !hw.array<2xi8>
+// CHECK: %[[ZERO:.*]] = hw.constant 0 : i16
+// CHECK-NEXT: %[[PADDING:.*]] = hw.bitcast %[[ZERO]] : (i16) -> !hw.array<2xi8>
+// CHECK-NEXT: return %[[PADDING]] : !hw.array<2xi8>
+func.func @negative_low_i32_min_array_slice(%arg0: !moore.array<4 x !moore.i8>) -> !moore.array<2 x !moore.i8> {
+  %0 = moore.extract %arg0 from -2147483648 : !moore.array<4 x !moore.i8> -> !moore.array<2 x !moore.i8>
+  return %0 : !moore.array<2 x !moore.i8>
+}
+
+// CHECK-LABEL: func.func @negative_low_i32_min_uarray_slice
+// CHECK-SAME: (%arg0: !hw.array<4xi8>) -> !hw.array<2xi8>
+// CHECK: %[[ZERO:.*]] = hw.constant 0 : i16
+// CHECK-NEXT: %[[PADDING:.*]] = hw.bitcast %[[ZERO]] : (i16) -> !hw.array<2xi8>
+// CHECK-NEXT: return %[[PADDING]] : !hw.array<2xi8>
+func.func @negative_low_i32_min_uarray_slice(%arg0: !moore.uarray<4 x !moore.i8>) -> !moore.uarray<2 x !moore.i8> {
+  %0 = moore.extract %arg0 from -2147483648 : !moore.uarray<4 x !moore.i8> -> !moore.uarray<2 x !moore.i8>
+  return %0 : !moore.uarray<2 x !moore.i8>
+}
+
+// CHECK-LABEL: func.func @negative_low_partial_array_slice
+// CHECK-SAME: (%arg0: !hw.array<4xi8>) -> !hw.array<3xi8>
+// CHECK: %[[ZERO:.*]] = hw.constant 0 : i8
+// CHECK-NEXT: %[[PADDING:.*]] = hw.bitcast %[[ZERO]] : (i8) -> !hw.array<1xi8>
+// CHECK-NEXT: %[[LOW:.*]] = hw.constant 0 : i2
+// CHECK-NEXT: %[[SLICE:.*]] = hw.array_slice %arg0[%[[LOW]]] : (!hw.array<4xi8>) -> !hw.array<2xi8>
+// CHECK-NEXT: %[[RESULT:.*]] = hw.array_concat %[[PADDING]], %[[SLICE]] : !hw.array<1xi8>, !hw.array<2xi8>
+// CHECK-NEXT: return %[[RESULT]] : !hw.array<3xi8>
+func.func @negative_low_partial_array_slice(%arg0: !moore.array<4 x !moore.i8>) -> !moore.array<3 x !moore.i8> {
+  %0 = moore.extract %arg0 from -1 : !moore.array<4 x !moore.i8> -> !moore.array<3 x !moore.i8>
+  return %0 : !moore.array<3 x !moore.i8>
+}

--- a/test/Conversion/MooreToCore/array-extract-zero-slice.mlir
+++ b/test/Conversion/MooreToCore/array-extract-zero-slice.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt --convert-moore-to-core %s | FileCheck %s
+
+// CHECK-LABEL: func.func @zero_packed_array_slice
+// CHECK-NOT: hw.array_concat
+// CHECK: %[[ZERO:.*]] = hw.constant 0 : i0
+// CHECK-NEXT: %[[ARR:.*]] = hw.bitcast %[[ZERO]] : (i0) -> !hw.array<0xi8>
+// CHECK-NEXT: return %[[ARR]] : !hw.array<0xi8>
+func.func @zero_packed_array_slice(%arg0: !moore.array<0 x !moore.i8>) -> !moore.array<0 x !moore.i8> {
+  %0 = moore.extract %arg0 from 0 : !moore.array<0 x !moore.i8> -> !moore.array<0 x !moore.i8>
+  return %0 : !moore.array<0 x !moore.i8>
+}
+
+// CHECK-LABEL: func.func @zero_unpacked_array_slice
+// CHECK-NOT: hw.array_concat
+// CHECK: %[[ZERO:.*]] = hw.constant 0 : i0
+// CHECK-NEXT: %[[ARR:.*]] = hw.bitcast %[[ZERO]] : (i0) -> !hw.array<0xi8>
+// CHECK-NEXT: return %[[ARR]] : !hw.array<0xi8>
+func.func @zero_unpacked_array_slice(%arg0: !moore.uarray<0 x !moore.i8>) -> !moore.uarray<0 x !moore.i8> {
+  %0 = moore.extract %arg0 from 0 : !moore.uarray<0 x !moore.i8> -> !moore.uarray<0 x !moore.i8>
+  return %0 : !moore.uarray<0 x !moore.i8>
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before.

Handle empty array creation and array extract with negative/zero slice widths in MooreToCore (IEEE 1800-2017 § 11.8.1). Empty arrays bitcast from zero constants; slices with out-of-bounds or zero-size windows fold using createZeroArray helper with proper padding and prefix/middle/suffix composition. Standalone.

Tests: array-create-empty.mlir, array-extract-negative-slice.mlir, array-extract-zero-slice.mlir
