### PR TITLE
[MooreToCore] Handle zero-width real conversions

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -351,6 +351,11 @@ static Value adjustIntegerWidth(OpBuilder &builder, Value value,
   return comb::MuxOp::create(builder, loc, isZero, lo, max, false);
 }
 
+static bool isZeroWidthInteger(Type type) {
+  auto intType = dyn_cast<IntegerType>(type);
+  return intType && intType.getWidth() == 0;
+}
+
 /// Get the ModulePortInfo from a SVModuleOp.
 static FailureOr<hw::ModulePortInfo>
 getModulePortInfo(const TypeConverter &typeConverter, SVModuleOp op) {
@@ -2031,8 +2036,15 @@ struct SIntToRealOpConversion : public OpConversionPattern<SIntToRealOp> {
   LogicalResult
   matchAndRewrite(SIntToRealOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<arith::SIToFPOp>(
-        op, typeConverter->convertType(op.getType()), adaptor.getInput());
+    auto resultType = typeConverter->convertType(op.getType());
+    if (isZeroWidthInteger(adaptor.getInput().getType())) {
+      rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+          op, rewriter.getFloatAttr(resultType, 0.0));
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<arith::SIToFPOp>(op, resultType,
+                                                 adaptor.getInput());
     return success();
   }
 };
@@ -2043,8 +2055,15 @@ struct UIntToRealOpConversion : public OpConversionPattern<UIntToRealOp> {
   LogicalResult
   matchAndRewrite(UIntToRealOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<arith::UIToFPOp>(
-        op, typeConverter->convertType(op.getType()), adaptor.getInput());
+    auto resultType = typeConverter->convertType(op.getType());
+    if (isZeroWidthInteger(adaptor.getInput().getType())) {
+      rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+          op, rewriter.getFloatAttr(resultType, 0.0));
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<arith::UIToFPOp>(op, resultType,
+                                                 adaptor.getInput());
     return success();
   }
 };
@@ -2066,8 +2085,15 @@ struct RealToIntOpConversion : public OpConversionPattern<RealToIntOp> {
   LogicalResult
   matchAndRewrite(RealToIntOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<arith::FPToSIOp>(
-        op, typeConverter->convertType(op.getType()), adaptor.getInput());
+    auto resultType = typeConverter->convertType(op.getType());
+    if (isZeroWidthInteger(resultType)) {
+      rewriter.replaceOpWithNewOp<hw::ConstantOp>(
+          op, resultType, rewriter.getIntegerAttr(resultType, 0));
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<arith::FPToSIOp>(op, resultType,
+                                                 adaptor.getInput());
     return success();
   }
 };

--- a/test/Conversion/MooreToCore/zero-width-real-conversions.mlir
+++ b/test/Conversion/MooreToCore/zero-width-real-conversions.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @ZeroWidthRealToInt(
+func.func @ZeroWidthRealToInt(%input: !moore.f64) -> !moore.i0 {
+  // CHECK: %[[ZERO:.+]] = hw.constant 0 : i0
+  // CHECK-NEXT: return %[[ZERO]] : i0
+  %0 = moore.real_to_int %input : f64 -> i0
+  return %0 : !moore.i0
+}
+
+// CHECK-LABEL: func.func @ZeroWidthSIntToReal(
+func.func @ZeroWidthSIntToReal(%input: !moore.i0) -> !moore.f64 {
+  // CHECK: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f64
+  // CHECK-NEXT: return %[[ZERO]] : f64
+  %0 = moore.sint_to_real %input : i0 -> f64
+  return %0 : !moore.f64
+}
+
+// CHECK-LABEL: func.func @ZeroWidthUIntToReal(
+func.func @ZeroWidthUIntToReal(%input: !moore.i0) -> !moore.f32 {
+  // CHECK: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+  // CHECK-NEXT: return %[[ZERO]] : f32
+  %0 = moore.uint_to_real %input : i0 -> f32
+  return %0 : !moore.f32
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before.

Handle real-integer conversions with zero-width integer operands in MooreToCore (IEEE 1800-2023 § 6.24.1, § 6.12). Zero-width inputs to uint/sint_to_real and zero-width results from real_to_int fold to constant zero (integer) or 0.0 (real), bypassing SIToFP/UIToFP/FPToSI ops. Maps to hw.constant and arith.constant. Standalone.

Tests: zero-width-real-conversions.mlir
