### PR TITLE
[MooreToCore] Register func dialect for urandom lowering

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -534,6 +534,7 @@ def ConvertMooreToCore : Pass<"convert-moore-to-core", "mlir::ModuleOp"> {
     "llhd::LLHDDialect",
     "mlir::arith::ArithDialect",
     "mlir::cf::ControlFlowDialect",
+    "mlir::func::FuncDialect",
     "mlir::scf::SCFDialect",
     "mlir::math::MathDialect",
     "mlir::LLVM::LLVMDialect",

--- a/test/Conversion/MooreToCore/urandom-range-seeded-procedure.mlir
+++ b/test/Conversion/MooreToCore/urandom-range-seeded-procedure.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK: func.func private @__circt_urandom_range(i32, i32, !llvm.ptr) -> i32
+// CHECK-LABEL: hw.module @URandomSeedModule
+moore.module @URandomSeedModule(in %lo: !moore.i32, in %hi: !moore.i32) {
+  %seed = moore.variable : <!moore.i32>
+  moore.procedure initial {
+    // CHECK: llhd.process
+    // CHECK: llvm.alloca
+    // CHECK: llhd.prb
+    // CHECK: llvm.store
+    // CHECK: func.call @__circt_urandom_range
+    // CHECK: llvm.load
+    // CHECK: llhd.drv
+    %0 = moore.builtin.urandom_range %lo, %hi, %seed
+    moore.return
+  }
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before.

Register mlir::func::FuncDialect in ConvertMooreToCore pass to support lowering of urandom builtins that emit internal helper functions. Ensures func.func ops created during lowering are legal. Standalone.

Tests: urandom-range-seeded-procedure.mlir
