### PR TITLE
[MooreToCore] Handle extreme static integer extracts

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1360,29 +1360,35 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
     int32_t low = adaptor.getLowBit();
 
     if (isa<IntegerType>(inputType)) {
-      int32_t inputWidth = inputType.getIntOrFloatBitWidth();
-      int32_t resultWidth = hw::getBitWidth(resultType);
-      int32_t high = low + resultWidth;
+      int64_t inputWidth = inputType.getIntOrFloatBitWidth();
+      int64_t resultWidth = hw::getBitWidth(resultType);
+      int64_t high = int64_t(low) + resultWidth;
 
       SmallVector<Value> toConcat;
-      if (low < 0)
-        toConcat.push_back(hw::ConstantOp::create(
-            rewriter, op.getLoc(), APInt(std::min(-low, resultWidth), 0)));
-
-      if (low < inputWidth && high > 0) {
-        int32_t lowIdx = std::max(low, 0);
-        Value middle = rewriter.createOrFold<comb::ExtractOp>(
-            op.getLoc(),
-            rewriter.getIntegerType(
-                std::min(resultWidth, std::min(high, inputWidth) - lowIdx)),
-            adaptor.getInput(), lowIdx);
-        toConcat.push_back(middle);
+      int64_t emittedWidth = 0;
+      if (low < 0) {
+        int64_t prefixWidth = std::min<int64_t>(-int64_t(low), resultWidth);
+        toConcat.push_back(hw::ConstantOp::create(rewriter, op.getLoc(),
+                                                  APInt(prefixWidth, 0)));
+        emittedWidth += prefixWidth;
       }
 
-      int32_t diff = high - inputWidth;
-      if (diff > 0) {
-        Value val =
-            hw::ConstantOp::create(rewriter, op.getLoc(), APInt(diff, 0));
+      if (low < inputWidth && high > 0) {
+        int64_t lowIdx = std::max<int64_t>(low, 0);
+        int64_t middleWidth =
+            std::min<int64_t>(resultWidth - emittedWidth,
+                              std::min<int64_t>(high, inputWidth) - lowIdx);
+        Value middle = rewriter.createOrFold<comb::ExtractOp>(
+            op.getLoc(), rewriter.getIntegerType(middleWidth),
+            adaptor.getInput(), lowIdx);
+        toConcat.push_back(middle);
+        emittedWidth += middleWidth;
+      }
+
+      int64_t suffixWidth = resultWidth - emittedWidth;
+      if (suffixWidth > 0) {
+        Value val = hw::ConstantOp::create(rewriter, op.getLoc(),
+                                           APInt(suffixWidth, 0));
         toConcat.push_back(val);
       }
 

--- a/test/Conversion/MooreToCore/extract-extreme-lowbits.mlir
+++ b/test/Conversion/MooreToCore/extract-extreme-lowbits.mlir
@@ -1,0 +1,15 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @ExtractIntLowI32Max
+func.func @ExtractIntLowI32Max(%arg0: !moore.i4) -> !moore.i2 {
+  // CHECK: hw.constant 0 : i2
+  %0 = moore.extract %arg0 from 2147483647 : !moore.i4 -> !moore.i2
+  return %0 : !moore.i2
+}
+
+// CHECK-LABEL: func.func @ExtractIntLowI32Min
+func.func @ExtractIntLowI32Min(%arg0: !moore.i4) -> !moore.i2 {
+  // CHECK: hw.constant 0 : i2
+  %0 = moore.extract %arg0 from -2147483648 : !moore.i4 -> !moore.i2
+  return %0 : !moore.i2
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before.

Handle integer extract with extreme static offsets (INT32_MIN, INT32_MAX) in MooreToCore (IEEE 1800-2017 § 11.8.1). Promotes intermediate arithmetic to i64 to prevent overflow in high = low + resultWidth computation; pads out-of-bounds ranges with zero bits. Standalone.

Tests: extract-extreme-lowbits.mlir
