### PR TITLE
[ImportVerilog] Normalize aggregate source operands

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1493,6 +1493,113 @@ struct RvalueExprVisitor : public ExprVisitor {
     return ConcreteOp::create(builder, loc, lhs, rhs);
   }
 
+  Value createStructCompare(slang::ast::BinaryOperator op, Value lhs, Value rhs,
+                            Type resultType) {
+    using slang::ast::BinaryOperator;
+    auto structType = cast<moore::UnpackedStructType>(lhs.getType());
+    const bool isEquality =
+        op == BinaryOperator::Equality || op == BinaryOperator::CaseEquality;
+
+    Value result;
+    for (auto member : structType.getMembers()) {
+      auto lhsField = moore::StructExtractOp::create(builder, loc, member.type,
+                                                     member.name, lhs);
+      auto rhsField = moore::StructExtractOp::create(builder, loc, member.type,
+                                                     member.name, rhs);
+      auto fieldCmp = createFieldCompare(op, lhsField, rhsField, resultType);
+      if (!fieldCmp)
+        return {};
+      fieldCmp =
+          context.materializeConversion(resultType, fieldCmp, false, loc);
+      if (!fieldCmp)
+        return {};
+
+      if (!result) {
+        result = fieldCmp;
+        continue;
+      }
+
+      result =
+          isEquality
+              ? moore::AndOp::create(builder, loc, result, fieldCmp).getResult()
+              : moore::OrOp::create(builder, loc, result, fieldCmp).getResult();
+    }
+
+    if (result)
+      return result;
+
+    auto intType = cast<moore::IntType>(resultType);
+    return moore::ConstantOp::create(builder, loc, intType, isEquality,
+                                     /*isSigned=*/false);
+  }
+
+  Value createFieldCompare(slang::ast::BinaryOperator op, Value lhs, Value rhs,
+                           Type resultType) {
+    using slang::ast::BinaryOperator;
+
+    if (isa<moore::UnpackedStructType>(lhs.getType()))
+      return createStructCompare(op, lhs, rhs, resultType);
+
+    if (isa<moore::ChandleType, moore::ClassHandleType>(lhs.getType())) {
+      switch (op) {
+      case BinaryOperator::Equality:
+        return moore::HandleEqOp::create(builder, loc, lhs, rhs);
+      case BinaryOperator::Inequality:
+        return moore::HandleNeOp::create(builder, loc, lhs, rhs);
+      case BinaryOperator::CaseEquality:
+        return moore::HandleCaseEqOp::create(builder, loc, lhs, rhs);
+      case BinaryOperator::CaseInequality:
+        return moore::HandleCaseNeOp::create(builder, loc, lhs, rhs);
+      default:
+        return {};
+      }
+    }
+
+    if (isa<moore::RealType>(lhs.getType())) {
+      switch (op) {
+      case BinaryOperator::Equality:
+      case BinaryOperator::CaseEquality:
+        return moore::EqRealOp::create(builder, loc, lhs, rhs);
+      case BinaryOperator::Inequality:
+      case BinaryOperator::CaseInequality:
+        return moore::NeRealOp::create(builder, loc, lhs, rhs);
+      default:
+        return {};
+      }
+    }
+
+    switch (op) {
+    case BinaryOperator::Equality:
+      if (isa<moore::UnpackedArrayType>(lhs.getType()))
+        return moore::UArrayCmpOp::create(
+            builder, loc, moore::UArrayCmpPredicate::eq, lhs, rhs);
+      if (isa<moore::StringType>(lhs.getType()))
+        return moore::StringCmpOp::create(
+            builder, loc, moore::StringCmpPredicate::eq, lhs, rhs);
+      if (isa<moore::QueueType>(lhs.getType()))
+        return moore::QueueCmpOp::create(
+            builder, loc, moore::UArrayCmpPredicate::eq, lhs, rhs);
+      return createBinary<moore::EqOp>(lhs, rhs);
+    case BinaryOperator::Inequality:
+      if (isa<moore::UnpackedArrayType>(lhs.getType()))
+        return moore::UArrayCmpOp::create(
+            builder, loc, moore::UArrayCmpPredicate::ne, lhs, rhs);
+      if (isa<moore::StringType>(lhs.getType()))
+        return moore::StringCmpOp::create(
+            builder, loc, moore::StringCmpPredicate::ne, lhs, rhs);
+      if (isa<moore::QueueType>(lhs.getType()))
+        return moore::QueueCmpOp::create(
+            builder, loc, moore::UArrayCmpPredicate::ne, lhs, rhs);
+      return createBinary<moore::NeOp>(lhs, rhs);
+    case BinaryOperator::CaseEquality:
+      return createBinary<moore::CaseEqOp>(lhs, rhs);
+    case BinaryOperator::CaseInequality:
+      return createBinary<moore::CaseNeOp>(lhs, rhs);
+    default:
+      return {};
+    }
+  }
+
   // Handle binary operators.
   Value visit(const slang::ast::BinaryExpression &expr) {
     if (expr.left().kind == slang::ast::ExpressionKind::TypeReference &&
@@ -1554,6 +1661,8 @@ struct RvalueExprVisitor : public ExprVisitor {
     if (expr.type->isFourState() || expr.left().type->isFourState() ||
         expr.right().type->isFourState())
       domain = Domain::FourValued;
+    auto resultType =
+        moore::IntType::get(context.getContext(), /*width=*/1, domain);
 
     using slang::ast::BinaryOperator;
     switch (expr.op) {
@@ -1600,7 +1709,9 @@ struct RvalueExprVisitor : public ExprVisitor {
     }
 
     case BinaryOperator::Equality:
-      if (isa<moore::UnpackedArrayType>(lhs.getType()))
+      if (isa<moore::UnpackedStructType>(lhs.getType()))
+        return createStructCompare(expr.op, lhs, rhs, resultType);
+      else if (isa<moore::UnpackedArrayType>(lhs.getType()))
         return moore::UArrayCmpOp::create(
             builder, loc, moore::UArrayCmpPredicate::eq, lhs, rhs);
       else if (isa<moore::StringType>(lhs.getType()))
@@ -1612,7 +1723,9 @@ struct RvalueExprVisitor : public ExprVisitor {
       else
         return createBinary<moore::EqOp>(lhs, rhs);
     case BinaryOperator::Inequality:
-      if (isa<moore::UnpackedArrayType>(lhs.getType()))
+      if (isa<moore::UnpackedStructType>(lhs.getType()))
+        return createStructCompare(expr.op, lhs, rhs, resultType);
+      else if (isa<moore::UnpackedArrayType>(lhs.getType()))
         return moore::UArrayCmpOp::create(
             builder, loc, moore::UArrayCmpPredicate::ne, lhs, rhs);
       else if (isa<moore::StringType>(lhs.getType()))
@@ -1624,8 +1737,12 @@ struct RvalueExprVisitor : public ExprVisitor {
       else
         return createBinary<moore::NeOp>(lhs, rhs);
     case BinaryOperator::CaseEquality:
+      if (isa<moore::UnpackedStructType>(lhs.getType()))
+        return createStructCompare(expr.op, lhs, rhs, resultType);
       return createBinary<moore::CaseEqOp>(lhs, rhs);
     case BinaryOperator::CaseInequality:
+      if (isa<moore::UnpackedStructType>(lhs.getType()))
+        return createStructCompare(expr.op, lhs, rhs, resultType);
       return createBinary<moore::CaseNeOp>(lhs, rhs);
     case BinaryOperator::WildcardEquality:
       return createBinary<moore::WildcardEqOp>(lhs, rhs);
@@ -2932,6 +3049,13 @@ Value Context::convertToSimpleBitVector(Value value) {
   if (auto packed = dyn_cast<moore::PackedType>(value.getType()))
     if (auto sbvType = packed.getSimpleBitVector())
       return materializeConversion(sbvType, value, false, value.getLoc());
+
+  if (auto unpacked = dyn_cast<moore::UnpackedType>(value.getType()))
+    if (auto bitSize = unpacked.getBitSize()) {
+      auto sbvType = moore::IntType::get(value.getContext(), bitSize.value(),
+                                         unpacked.getDomain());
+      return materializeConversion(sbvType, value, false, value.getLoc());
+    }
 
   mlir::emitError(value.getLoc()) << "expression of type " << value.getType()
                                   << " cannot be cast to a simple bit vector";

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -452,16 +452,21 @@ struct StmtVisitor {
           if (auto defOp = maybeConst.getDefiningOp<moore::ConstantOp>())
             itemConsts.push_back(defOp.getValueAttr());
 
+          auto lhs = context.convertToSimpleBitVector(caseExpr);
+          auto rhs = context.convertToSimpleBitVector(value);
+          if (!lhs || !rhs)
+            return failure();
+
           // Generate the appropriate equality operator.
           switch (caseStmt.condition) {
           case CaseStatementCondition::Normal:
-            cond = moore::CaseEqOp::create(builder, itemLoc, caseExpr, value);
+            cond = moore::CaseEqOp::create(builder, itemLoc, lhs, rhs);
             break;
           case CaseStatementCondition::WildcardXOrZ:
-            cond = moore::CaseXZEqOp::create(builder, itemLoc, caseExpr, value);
+            cond = moore::CaseXZEqOp::create(builder, itemLoc, lhs, rhs);
             break;
           case CaseStatementCondition::WildcardJustZ:
-            cond = moore::CaseZEqOp::create(builder, itemLoc, caseExpr, value);
+            cond = moore::CaseZEqOp::create(builder, itemLoc, lhs, rhs);
             break;
           case CaseStatementCondition::Inside:
             llvm_unreachable("Inside condition has been handled already");

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -394,6 +394,70 @@ function void CaseStatements(int x, int a, int b, int c);
   endcase
 endfunction
 
+typedef struct packed {
+  logic [3 : 0] a;
+  logic [1 : 0] b;
+} CasePackedAggregatePair;
+
+// CHECK-LABEL: moore.module @CasePackedAggregateStatements
+module CasePackedAggregateStatements
+    (input logic [5 : 0][4 : 0] state_array,
+     input CasePackedAggregatePair state_struct,
+     input CasePackedAggregatePair match_struct,
+     input logic [3 : 0] lhs_bits,
+     input logic [3 : 0] rhs_bits,
+     output logic array_hit,
+     output logic struct_hit,
+     output logic union_hit);
+  typedef union packed {
+    logic [3 : 0] bits;
+    struct packed {
+      logic [1 : 0] hi;
+      logic [1 : 0] lo;
+    } parts;
+  } CasePackedAggregateUnion;
+
+  CasePackedAggregateUnion lhs;
+  CasePackedAggregateUnion rhs;
+
+  always_comb begin
+    // CHECK: moore.packed_to_sbv {{%.+}} : array<6 x l5>
+    // CHECK: moore.case_eq {{%.+}}, {{%.+}} : l30
+    array_hit = 1'b0;
+    unique case (state_array)
+      {6{5'h03}}:
+        array_hit = 1'b1;
+      default:
+        array_hit = 1'b0;
+    endcase
+
+    // CHECK: moore.packed_to_sbv {{%.+}} : struct<{a: l4, b: l2}>
+    // CHECK: moore.packed_to_sbv {{%.+}} : struct<{a: l4, b: l2}>
+    // CHECK: moore.case_eq {{%.+}}, {{%.+}} : l6
+    struct_hit = 1'b0;
+    unique case (state_struct)
+      match_struct:
+        struct_hit = 1'b1;
+      default:
+        struct_hit = 1'b0;
+    endcase
+
+    lhs.bits = lhs_bits;
+    rhs.bits = rhs_bits;
+
+    // CHECK: moore.packed_to_sbv {{%.+}} : union
+    // CHECK: moore.packed_to_sbv {{%.+}} : union
+    // CHECK: moore.case_eq {{%.+}}, {{%.+}} : l4
+    union_hit = 1'b0;
+    case (lhs)
+      rhs:
+        union_hit = 1'b1;
+      default:
+        union_hit = 1'b0;
+    endcase
+  end
+endmodule
+
 // CHECK-LABEL: func.func private @ForLoopStatements(
 // CHECK-SAME: %arg0: !moore.i32
 // CHECK-SAME: %arg1: !moore.i32
@@ -5253,6 +5317,68 @@ module DisplayWithStringArg;
   initial $display(i, s);
 endmodule
 
+// CHECK-LABEL: moore.module @StreamingUnpackedArray() {
+// CHECK: [[ARR:%.+]] = moore.variable : <uarray<12 x i8>>
+// CHECK: [[READ:%.+]] = moore.read [[ARR]] : <uarray<12 x i8>>
+// CHECK: [[AS_BITS:%.+]] = moore.conversion [[READ]]
+// CHECK-SAME: : !moore.uarray<12 x i8> -> !moore.i96
+// CHECK: [[SLICE0:%.+]] = moore.extract [[AS_BITS]] from 0 : i96 -> i32
+// CHECK: [[SLICE1:%.+]] = moore.extract [[AS_BITS]] from 32 : i96 -> i32
+// CHECK: [[SLICE2:%.+]] = moore.extract [[AS_BITS]] from 64 : i96 -> i32
+// CHECK: [[STREAMED:%.+]] = moore.concat
+// CHECK-SAME: [[SLICE0]], [[SLICE1]], [[SLICE2]]
+// CHECK: [[AS_ARRAY:%.+]] = moore.conversion [[STREAMED]]
+// CHECK-SAME: : !moore.i96 -> !moore.uarray<12 x i8>
+// CHECK: moore.blocking_assign [[ARR]], [[AS_ARRAY]]
+// CHECK-SAME: : uarray<12 x i8>
+// CHECK: moore.output
+// CHECK: }
+module StreamingUnpackedArray;
+  bit [7 : 0] my_array[12];
+  initial
+    my_array = {<<32{my_array}};
+endmodule
+
+// CHECK-LABEL: moore.module @CompareUnpackedUnionAsBits(
+// CHECK: [[LHS:%.+]] = moore.variable : <uunion<{x: l4, y: l4}>>
+// CHECK: [[RHS:%.+]] = moore.variable : <uunion<{x: l4, y: l4}>>
+// CHECK: [[LHS_READ0:%.+]] = moore.read [[LHS]] : <uunion<{x: l4, y: l4}>>
+// CHECK: [[RHS_READ0:%.+]] = moore.read [[RHS]] : <uunion<{x: l4, y: l4}>>
+// CHECK: [[LHS_BITS0:%.+]] = moore.conversion [[LHS_READ0]]
+// CHECK-SAME: : !moore.uunion<{x: l4, y: l4}> -> !moore.l4
+// CHECK: [[RHS_BITS0:%.+]] = moore.conversion [[RHS_READ0]]
+// CHECK-SAME: : !moore.uunion<{x: l4, y: l4}> -> !moore.l4
+// CHECK: moore.eq [[LHS_BITS0]], [[RHS_BITS0]] : l4 -> l1
+// CHECK: [[LHS_READ1:%.+]] = moore.read [[LHS]] : <uunion<{x: l4, y: l4}>>
+// CHECK: [[RHS_READ1:%.+]] = moore.read [[RHS]] : <uunion<{x: l4, y: l4}>>
+// CHECK: [[LHS_BITS1:%.+]] = moore.conversion [[LHS_READ1]]
+// CHECK-SAME: : !moore.uunion<{x: l4, y: l4}> -> !moore.l4
+// CHECK: [[RHS_BITS1:%.+]] = moore.conversion [[RHS_READ1]]
+// CHECK-SAME: : !moore.uunion<{x: l4, y: l4}> -> !moore.l4
+// CHECK: moore.ne [[LHS_BITS1]], [[RHS_BITS1]] : l4 -> l1
+// CHECK: moore.output
+// CHECK: }
+module CompareUnpackedUnionAsBits
+      (input logic [3 : 0] a,
+       input logic [3 : 0] b,
+       output logic eq,
+       output logic ne);
+  typedef union {
+    logic [3 : 0] x;
+    logic [3 : 0] y;
+  } u_t;
+
+  u_t lhs;
+  u_t rhs;
+
+  always_comb begin
+    lhs.x = a;
+    rhs.y = b;
+    eq = lhs == rhs;
+    ne = lhs != rhs;
+  end
+endmodule
+
 // CHECK-LABEL: func.func private @BuiltinCastTrue(
 // CHECK-SAME:    %arg0: !moore.ref<l32>
 // CHECK-SAME:  ) -> !moore.i32 {
@@ -5304,3 +5430,105 @@ task BuiltinCastFalse;
   $cast(s, 2.3);
   $cast(q, 2.3);
 endtask
+
+// CHECK-LABEL: moore.module @UnpackedStructCompare() {
+// CHECK: moore.struct_extract
+// CHECK: moore.eq
+// CHECK: moore.and
+// CHECK: moore.struct_extract
+// CHECK: moore.ne
+// CHECK: moore.or
+// CHECK: moore.struct_extract
+// CHECK: moore.case_eq
+// CHECK: moore.and
+// CHECK: moore.struct_extract
+// CHECK: moore.case_ne
+// CHECK: moore.or
+// CHECK: moore.output
+// CHECK: }
+module UnpackedStructCompare;
+  typedef struct {
+    logic [2 : 0] a;
+    logic [1 : 0] b;
+  } item_t;
+
+  item_t lhs;
+  item_t rhs;
+  logic eq;
+  logic ne;
+  logic ceq;
+  logic cne;
+
+  always_comb begin
+    eq = lhs == rhs;
+    ne = lhs != rhs;
+    ceq = lhs === rhs;
+    cne = lhs !== rhs;
+  end
+endmodule
+
+// CHECK-LABEL: moore.module @UnpackedStructRealTimeCompare() {
+// CHECK: moore.struct_extract
+// CHECK: moore.feq
+// CHECK: moore.and
+// CHECK: moore.struct_extract
+// CHECK: moore.fne
+// CHECK: moore.or
+// CHECK: moore.output
+// CHECK: }
+module UnpackedStructRealTimeCompare;
+  typedef struct {
+    real r;
+    time t;
+  } item_t;
+
+  item_t lhs;
+  item_t rhs;
+  logic eq;
+  logic ne;
+
+  always_comb begin
+    eq = lhs == rhs;
+    ne = lhs != rhs;
+  end
+endmodule
+
+class UnpackedStructHandleBox;
+endclass
+
+// CHECK-LABEL: moore.module @UnpackedStructHandleCompare() {
+// CHECK: moore.handle_eq
+// CHECK: moore.handle_eq
+// CHECK: moore.and
+// CHECK: moore.handle_ne
+// CHECK: moore.handle_ne
+// CHECK: moore.or
+// CHECK: moore.handle_case_eq
+// CHECK: moore.handle_case_eq
+// CHECK: moore.and
+// CHECK: moore.handle_case_ne
+// CHECK: moore.handle_case_ne
+// CHECK: moore.or
+// CHECK: moore.output
+// CHECK: }
+module UnpackedStructHandleCompare;
+  typedef struct {
+    chandle c;
+    UnpackedStructHandleBox h;
+    logic [2 : 0] bits;
+  } item_t;
+
+  item_t lhs;
+  item_t rhs;
+  logic eq;
+  logic ne;
+  logic ceq;
+  logic cne;
+
+  initial begin
+    eq = lhs == rhs;
+    ne = lhs != rhs;
+    ceq = lhs === rhs;
+    cne = lhs !== rhs;
+  end
+endmodule


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Normalize unpacked struct field comparisons (==, !=, ===, !==) and streaming unpacked array conversions to simple bit vectors in ImportVerilog (IEEE 1800-2023 §11.4.13, §4.8). Previously dropped; recursively decomposes struct comparisons to field-wise comparisons with appropriate ops (struct_extract + eq/ne/case_eq/case_ne), and normalizes packed aggregates to bit vectors. Maps to existing Moore ops. Standalone.

Tests: basic.sv.
