### PR TITLE
[MooreToCore] Lower bool casts for scalar object types

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1739,19 +1739,46 @@ struct BoolCastOpConversion : public OpConversionPattern<BoolCastOp> {
   LogicalResult
   matchAndRewrite(BoolCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Type resultType = typeConverter->convertType(op.getInput().getType());
-    if (isa_and_nonnull<IntegerType>(resultType)) {
-      Value zero =
-          hw::ConstantOp::create(rewriter, op->getLoc(), resultType, 0);
+    Type inputType = typeConverter->convertType(op.getInput().getType());
+    if (isa_and_nonnull<IntegerType>(inputType)) {
+      Value zero = hw::ConstantOp::create(rewriter, op->getLoc(), inputType, 0);
       rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne,
                                                 adaptor.getInput(), zero);
       return success();
     }
-    if (isa_and_nonnull<FloatType>(resultType)) {
+    if (isa_and_nonnull<FloatType>(inputType)) {
       Value zero = arith::ConstantOp::create(
-          rewriter, op->getLoc(), rewriter.getFloatAttr(resultType, 0.0));
+          rewriter, op->getLoc(), rewriter.getFloatAttr(inputType, 0.0));
       rewriter.replaceOpWithNewOp<arith::CmpFOp>(op, arith::CmpFPredicate::ONE,
                                                  adaptor.getInput(), zero);
+      return success();
+    }
+    if (isa_and_nonnull<llhd::TimeType>(inputType)) {
+      Value input =
+          llhd::TimeToIntOp::create(rewriter, op->getLoc(), adaptor.getInput());
+      Value zero = hw::ConstantOp::create(rewriter, op->getLoc(),
+                                          rewriter.getI64Type(), 0);
+      rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne,
+                                                input, zero);
+      return success();
+    }
+    if (isa_and_nonnull<sim::DynamicStringType>(inputType)) {
+      Value length = sim::StringLengthOp::create(rewriter, op->getLoc(),
+                                                 adaptor.getInput());
+      Value zero = hw::ConstantOp::create(rewriter, op->getLoc(),
+                                          rewriter.getI64Type(), 0);
+      rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne,
+                                                length, zero);
+      return success();
+    }
+    if (isa<ChandleType, ClassHandleType>(op.getInput().getType())) {
+      auto pointerType = dyn_cast_or_null<LLVM::LLVMPointerType>(inputType);
+      if (!pointerType)
+        return failure();
+      Value nullPointer =
+          LLVM::ZeroOp::create(rewriter, op->getLoc(), pointerType);
+      rewriter.replaceOpWithNewOp<LLVM::ICmpOp>(
+          op, LLVM::ICmpPredicate::ne, adaptor.getInput(), nullPointer);
       return success();
     }
     return failure();

--- a/test/Conversion/MooreToCore/bool-cast-chandle.mlir
+++ b/test/Conversion/MooreToCore/bool-cast-chandle.mlir
@@ -1,0 +1,24 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @BoolCastChandle
+// CHECK-SAME: (%arg0: !llvm.ptr) -> i1
+func.func @BoolCastChandle(%arg0: !moore.chandle) -> !moore.i1 {
+  // CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: [[BOOL:%.+]] = llvm.icmp "ne" %arg0, [[NULL]] : !llvm.ptr
+  %0 = moore.bool_cast %arg0 : !moore.chandle -> !moore.i1
+  // CHECK: return [[BOOL]] : i1
+  return %0 : !moore.i1
+}
+
+moore.class.classdecl @BoolCastClassT {
+}
+
+// CHECK-LABEL: func.func @BoolCastClassHandle
+// CHECK-SAME: (%arg0: !llvm.ptr) -> i1
+func.func @BoolCastClassHandle(%arg0: !moore.class<@BoolCastClassT>) -> !moore.i1 {
+  // CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: [[BOOL:%.+]] = llvm.icmp "ne" %arg0, [[NULL]] : !llvm.ptr
+  %0 = moore.bool_cast %arg0 : !moore.class<@BoolCastClassT> -> !moore.i1
+  // CHECK: return [[BOOL]] : i1
+  return %0 : !moore.i1
+}

--- a/test/Conversion/MooreToCore/bool-cast-string.mlir
+++ b/test/Conversion/MooreToCore/bool-cast-string.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @BoolCastString
+// CHECK-SAME: (%arg0: !sim.dstring) -> i1
+func.func @BoolCastString(%arg0: !moore.string) -> !moore.i1 {
+  // CHECK: [[LENGTH:%.+]] = sim.string.length %arg0
+  // CHECK: [[ZERO:%.+]] = hw.constant 0 : i64
+  // CHECK: [[BOOL:%.+]] = comb.icmp ne [[LENGTH]], [[ZERO]] : i64
+  %0 = moore.bool_cast %arg0 : !moore.string -> !moore.i1
+  // CHECK: return [[BOOL]] : i1
+  return %0 : !moore.i1
+}

--- a/test/Conversion/MooreToCore/bool-cast-time.mlir
+++ b/test/Conversion/MooreToCore/bool-cast-time.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @BoolCastTime
+// CHECK-SAME: (%arg0: !llhd.time) -> i1
+func.func @BoolCastTime(%arg0: !moore.time) -> !moore.l1 {
+  // CHECK: [[INT:%.+]] = llhd.time_to_int %arg0
+  // CHECK: [[ZERO:%.+]] = hw.constant 0 : i64
+  // CHECK: [[CMP:%.+]] = comb.icmp ne [[INT]], [[ZERO]] : i64
+  // CHECK: return [[CMP]] : i1
+  %0 = moore.bool_cast %arg0 : !moore.time -> !moore.l1
+  return %0 : !moore.l1
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Lower bool casts for time, string, and chandle scalar types in MooreToCore (IEEE 1800-2023 §6.20.3, §6.20.6). Previously dropped; converts time-to-int + icmp ne zero, string length test, chandle null check. Maps to existing conversion ops. Standalone.

Tests: bool-cast-chandle.mlir, bool-cast-string.mlir, bool-cast-time.mlir.
