### PR TITLE
[ImportVerilog][MooreToCore] Legalize format string boundaries

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2108,7 +2108,8 @@ struct RvalueExprVisitor : public ExprVisitor {
     // According to IEEE 1800-2023 Section 21.3.3 "Formatting data to a
     // string" $sformatf works just like the string formatting but returns
     // a StringType.
-    if (nameId == ksn::SFormatF) {
+    if (nameId == ksn::SFormatF || nameId == ksn::PSPrintF ||
+        subroutine.name == "$psprintf") {
       // Create the FormatString
       auto fmtValue = context.convertFormatString(
           expr.arguments(), loc, moore::IntFormat::Decimal, false);
@@ -3255,6 +3256,15 @@ Value Context::convertSystemCall(
   StringRef name = subroutine.name;
   auto nameId = subroutine.knownNameId;
   size_t numArgs = args.size();
+
+  if (nameId == ksn::SFormatF || nameId == ksn::PSPrintF ||
+      subroutine.name == "$psprintf") {
+    auto fmtValue =
+        convertFormatString(args, loc, moore::IntFormat::Decimal, false);
+    if (failed(fmtValue))
+      return {};
+    return moore::FormatStringToStringOp::create(builder, loc, *fmtValue);
+  }
 
   //===--------------------------------------------------------------------===//
   // Random Number System Functions

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -798,7 +798,11 @@ struct StmtVisitor {
       return mlir::emitError(loc) << "unsupported return statement context";
 
     if (stmt.expr) {
-      auto expr = context.convertRvalueExpression(*stmt.expr);
+      auto func = cast<mlir::func::FuncOp>(parentOp);
+      auto results =
+          cast<mlir::FunctionType>(func.getFunctionType()).getResults();
+      auto expr = context.convertRvalueExpression(
+          *stmt.expr, results.size() == 1 ? results.front() : Type{});
       if (!expr)
         return failure();
       mlir::func::ReturnOp::create(builder, loc, expr);

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1918,6 +1918,19 @@ struct ConversionOpConversion : public OpConversionPattern<ConversionOp> {
       op.emitError("conversion result type is not currently supported");
       return failure();
     }
+    if (isa<sim::FormatStringType>(resultType) &&
+        isa<sim::DynamicStringType>(adaptor.getInput().getType())) {
+      rewriter.replaceOpWithNewOp<sim::FormatStringOp>(
+          op, adaptor.getInput(), rewriter.getBoolAttr(false),
+          rewriter.getI8IntegerAttr(32), IntegerAttr{});
+      return success();
+    }
+    if (isa<sim::DynamicStringType>(resultType) &&
+        isa<sim::FormatStringType>(adaptor.getInput().getType())) {
+      rewriter.replaceOpWithNewOp<UnrealizedConversionCastOp>(
+          op, resultType, adaptor.getInput());
+      return success();
+    }
     int64_t inputBw = hw::getBitWidth(adaptor.getInput().getType());
     int64_t resultBw = hw::getBitWidth(resultType);
     if (inputBw == -1 || resultBw == -1) {
@@ -2527,6 +2540,20 @@ struct FormatStringOpConversion : public OpConversionPattern<FormatStringOp> {
 
     rewriter.replaceOpWithNewOp<sim::FormatStringOp>(
         op, adaptor.getString(), isLeftAlignedAttr, padCharAttr, widthAttr);
+    return success();
+  }
+};
+
+struct FormatStringToStringOpConversion
+    : public OpConversionPattern<FormatStringToStringOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(FormatStringToStringOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<UnrealizedConversionCastOp>(
+        op, typeConverter->convertType(op.getResult().getType()),
+        adaptor.getFmtstring());
     return success();
   }
 };
@@ -3392,6 +3419,7 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
   // Valid target types.
   typeConverter.addConversion([](IntegerType type) { return type; });
   typeConverter.addConversion([](FloatType type) { return type; });
+  typeConverter.addConversion([](sim::FormatStringType type) { return type; });
   typeConverter.addConversion([](sim::DynamicStringType type) { return type; });
   typeConverter.addConversion([](llhd::TimeType type) { return type; });
   typeConverter.addConversion([](debug::ArrayType type) { return type; });
@@ -3614,6 +3642,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     // Format strings.
     FormatLiteralOpConversion,
     FormatStringOpConversion,
+    FormatStringToStringOpConversion,
     FormatConcatOpConversion,
     FormatHierPathOpConversion,
     FormatIntOpConversion,

--- a/test/Conversion/ImportVerilog/psprintf.sv
+++ b/test/Conversion/ImportVerilog/psprintf.sv
@@ -1,0 +1,30 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// CHECK-LABEL: func.func private @ReturnPSPrintf(
+// CHECK-SAME: [[ARG:%[^,)]+]]: !moore.string
+function automatic string ReturnPSPrintf
+    (string arg);
+  // CHECK: [[FMTARG:%.+]] = moore.fmt.string [[ARG]]
+  // CHECK: [[LIT:%.+]] = moore.fmt.literal "!"
+  // CHECK: [[FMT:%.+]] = moore.fmt.concat ([[FMTARG]], [[LIT]])
+  // CHECK: [[STR:%.+]] = moore.fstring_to_string [[FMT]]
+  // CHECK: return [[STR]] : !moore.string
+  return $psprintf("%s!",
+                   arg);
+endfunction
+
+// CHECK-LABEL: func.func private @ReturnSFormatF(
+// CHECK-SAME: [[ARG:%[^,)]+]]: !moore.string
+function automatic string ReturnSFormatF
+    (string arg);
+  // CHECK: [[FMTARG:%.+]] = moore.fmt.string [[ARG]]
+  // CHECK: [[LIT:%.+]] = moore.fmt.literal "?"
+  // CHECK: [[FMT:%.+]] = moore.fmt.concat ([[FMTARG]], [[LIT]])
+  // CHECK: [[STR:%.+]] = moore.fstring_to_string [[FMT]]
+  // CHECK: return [[STR]] : !moore.string
+  return $sformatf("%s?",
+                   arg);
+endfunction

--- a/test/Conversion/MooreToCore/format-string-type-conversion.mlir
+++ b/test/Conversion/MooreToCore/format-string-type-conversion.mlir
@@ -1,0 +1,95 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @FormatStringSignature
+// CHECK-SAME: (%arg0: !sim.fstring) -> !sim.fstring
+func.func @FormatStringSignature(%fmt: !moore.format_string) -> !moore.format_string {
+  // CHECK: return %arg0 : !sim.fstring
+  return %fmt : !moore.format_string
+}
+
+// CHECK-LABEL: func.func @FormatStringLiteralReturn
+// CHECK-SAME: () -> !sim.fstring
+func.func @FormatStringLiteralReturn() -> !moore.format_string {
+  // CHECK: %[[FMT:.*]] = sim.fmt.literal "agent11"
+  %fmt = moore.fmt.literal "agent11"
+  // CHECK: return %[[FMT]] : !sim.fstring
+  return %fmt : !moore.format_string
+}
+
+// CHECK-LABEL: func.func @FormatStringToString
+// CHECK-SAME: (%arg0: !sim.dstring) -> !sim.dstring
+func.func @FormatStringToString(%arg0: !moore.string) -> !moore.string {
+  // CHECK: %[[FMT:.*]] = sim.fmt.string %arg0
+  %fmt = moore.fmt.string %arg0
+  // CHECK: %[[STR:.*]] = builtin.unrealized_conversion_cast %[[FMT]] : !sim.fstring to !sim.dstring
+  %str = moore.fstring_to_string %fmt
+  // CHECK: return %[[STR]] : !sim.dstring
+  return %str : !moore.string
+}
+
+// CHECK-LABEL: func.func @FormatLiteralToString
+// CHECK-SAME: () -> !sim.dstring
+func.func @FormatLiteralToString() -> !moore.string {
+  // CHECK: %[[FMT:.*]] = sim.fmt.literal "agent11"
+  %fmt = moore.fmt.literal "agent11"
+  // CHECK: %[[STR:.*]] = builtin.unrealized_conversion_cast %[[FMT]] : !sim.fstring to !sim.dstring
+  %str = moore.fstring_to_string %fmt
+  // CHECK: return %[[STR]] : !sim.dstring
+  return %str : !moore.string
+}
+
+// CHECK: llhd.global_signal @GlobalStringInit : !sim.dstring init {
+// CHECK: %[[GLOBAL_FMT:.*]] = sim.fmt.literal "global"
+// CHECK: %[[GLOBAL_STR:.*]] = builtin.unrealized_conversion_cast %[[GLOBAL_FMT]] : !sim.fstring to !sim.dstring
+// CHECK: llhd.yield %[[GLOBAL_STR]] : !sim.dstring
+moore.global_variable @GlobalStringInit : !moore.string init {
+  %fmt = moore.fmt.literal "global"
+  %str = moore.fstring_to_string %fmt
+  moore.yield %str : !moore.string
+}
+
+// CHECK-LABEL: func.func @StringToFormatStringConversion
+// CHECK-SAME: (%arg0: !sim.dstring) -> !sim.dstring
+func.func @StringToFormatStringConversion(%input: !moore.string) -> !moore.string {
+  // CHECK: %[[FMT:.*]] = sim.fmt.string %arg0 : !sim.dstring
+  %fmt = moore.conversion %input : !moore.string -> !moore.format_string
+  // CHECK: %[[STR:.*]] = builtin.unrealized_conversion_cast %[[FMT]] : !sim.fstring to !sim.dstring
+  %str = moore.fstring_to_string %fmt
+  // CHECK: return %[[STR]] : !sim.dstring
+  return %str : !moore.string
+}
+
+// CHECK-LABEL: func.func @FormatStringToStringConversion
+// CHECK-SAME: (%arg0: !sim.dstring) -> !sim.dstring
+func.func @FormatStringToStringConversion(%input: !moore.string) -> !moore.string {
+  // CHECK: %[[FMT:.*]] = sim.fmt.string %arg0
+  %fmt = moore.fmt.string %input
+  // CHECK: %[[STR:.*]] = builtin.unrealized_conversion_cast %[[FMT]] : !sim.fstring to !sim.dstring
+  %str = moore.conversion %fmt : !moore.format_string -> !moore.string
+  // CHECK: return %[[STR]] : !sim.dstring
+  return %str : !moore.string
+}
+
+// CHECK-LABEL: hw.module @FormatStringModulePorts
+// CHECK-SAME: in %fmt_in : !sim.fstring
+// CHECK-SAME: out fmt_out : !sim.fstring
+moore.module @FormatStringModulePorts(in %fmt_in : !moore.format_string, out fmt_out : !moore.format_string) {
+  // CHECK: hw.output %fmt_in : !sim.fstring
+  moore.output %fmt_in : !moore.format_string
+}
+
+// CHECK-LABEL: hw.module @FormatStringInstTop
+// CHECK-SAME: in %fmt_in : !sim.fstring
+// CHECK-SAME: out fmt_out : !sim.fstring
+moore.module @FormatStringInstTop(in %fmt_in : !moore.format_string, out fmt_out : !moore.format_string) {
+  // CHECK: hw.instance "child" @FormatStringInstChild(fmt_in: %fmt_in: !sim.fstring) -> (fmt_out: !sim.fstring)
+  %child.fmt_out = moore.instance "child" @FormatStringInstChild(fmt_in: %fmt_in : !moore.format_string) -> (fmt_out: !moore.format_string)
+  // CHECK: hw.output %child.fmt_out : !sim.fstring
+  moore.output %child.fmt_out : !moore.format_string
+}
+
+// CHECK-LABEL: hw.module private @FormatStringInstChild
+moore.module private @FormatStringInstChild(in %fmt_in : !moore.format_string, out fmt_out : !moore.format_string) {
+  // CHECK: hw.output %fmt_in : !sim.fstring
+  moore.output %fmt_in : !moore.format_string
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Legalize format string argument type conversions at ImportVerilog/MooreToCore boundary (IEEE 1800-2023 §20.7). Previously dropped; inserts conversions for $psprintf, display format arguments. Maps to existing conversion ops. Standalone.

Tests: psprintf.sv, format-string-type-conversion.mlir.
