### PR TITLE
[MooreToCore][MapArithToComb] Lower queue and non-HW select boundaries

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1933,6 +1933,19 @@ struct ConversionOpConversion : public OpConversionPattern<ConversionOp> {
             << op.getInput().getType() << " to " << op.getResult().getType();
         return failure();
       }
+      auto inputQueue = dyn_cast<QueueType>(op.getInput().getType());
+      auto resultQueue = dyn_cast<QueueType>(op.getResult().getType());
+      if (inputQueue && resultQueue) {
+        auto inputElementType =
+            getTypeConverter()->convertType(inputQueue.getElementType());
+        auto resultElementType =
+            getTypeConverter()->convertType(resultQueue.getElementType());
+        if (inputElementType && inputElementType == resultElementType) {
+          rewriter.replaceOpWithNewOp<sim::QueueResizeOp>(op, resultType,
+                                                          adaptor.getInput());
+          return success();
+        }
+      }
       return failure();
     }
 
@@ -3393,6 +3406,7 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
   typeConverter.addConversion([](IntegerType type) { return type; });
   typeConverter.addConversion([](FloatType type) { return type; });
   typeConverter.addConversion([](sim::DynamicStringType type) { return type; });
+  typeConverter.addConversion([](sim::QueueType type) { return type; });
   typeConverter.addConversion([](llhd::TimeType type) { return type; });
   typeConverter.addConversion([](debug::ArrayType type) { return type; });
   typeConverter.addConversion([](debug::ScopeType type) { return type; });

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -17,13 +17,16 @@ add_circt_library(CIRCTTransforms
   LINK_LIBS PUBLIC
   CIRCTComb
   CIRCTHW
+  CIRCTLLHD
   CIRCTSeq
+  CIRCTSim
   CIRCTOpCountAnalysis
   MLIRArithDialect
   MLIRControlFlowDialect
   MLIRControlFlowTransforms
   MLIRFuncDialect
   MLIRIR
+  MLIRLLVMDialect
   MLIRMemRefDialect
   MLIRSupport
   MLIRTransforms

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -13,8 +13,11 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/LLHD/LLHDTypes.h"
+#include "circt/Dialect/Sim/SimTypes.h"
 #include "circt/Transforms/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -28,6 +31,37 @@ using namespace circt;
 
 namespace {
 
+static bool isCombMuxPayloadType(Type type) {
+  if (hw::isHWValueType(type))
+    return true;
+
+  if (isa<FloatType, LLVM::LLVMPointerType, llhd::TimeType,
+          sim::DynamicStringType, sim::FormatStringType, sim::QueueType>(type))
+    return true;
+
+  if (auto array = hw::type_dyn_cast<hw::ArrayType>(type))
+    return isCombMuxPayloadType(array.getElementType());
+
+  if (auto array = hw::type_dyn_cast<hw::UnpackedArrayType>(type))
+    return isCombMuxPayloadType(array.getElementType());
+
+  if (auto structType = hw::type_dyn_cast<hw::StructType>(type)) {
+    for (auto field : structType.getElements())
+      if (!isCombMuxPayloadType(field.type))
+        return false;
+    return true;
+  }
+
+  if (auto unionType = hw::type_dyn_cast<hw::UnionType>(type)) {
+    for (auto field : unionType.getElements())
+      if (!isCombMuxPayloadType(field.type))
+        return false;
+    return true;
+  }
+
+  return false;
+}
+
 // A type converter which legalizes integer types, thus ensuring that vector
 // types are illegal.
 class MapArithTypeConverter : public mlir::TypeConverter {
@@ -38,6 +72,12 @@ public:
         return type;
 
       return Type();
+    });
+    addConversion([](Type type) -> std::optional<Type> {
+      if (isCombMuxPayloadType(type))
+        return type;
+
+      return std::nullopt;
     });
   }
 };

--- a/test/Conversion/MooreToCore/queue-bound-conversions.mlir
+++ b/test/Conversion/MooreToCore/queue-bound-conversions.mlir
@@ -1,0 +1,82 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+moore.class.classdecl @QueueBoundClass {
+}
+
+// CHECK-LABEL: hw.module @QueueBoundConversions
+moore.module @QueueBoundConversions() {
+  moore.procedure initial {
+    // CHECK: [[EMPTY_BOUND:%.+]] = sim.queue.empty : <i32, 4>
+    // CHECK: [[BOUND_REF:%.+]] = llhd.sig [[EMPTY_BOUND]] : !sim.queue<i32, 4>
+    %bound = moore.variable : <!moore.queue<i32, 4>>
+    // CHECK: [[EMPTY_UNBOUND:%.+]] = sim.queue.empty : <i32, 0>
+    // CHECK: [[UNBOUND_REF:%.+]] = llhd.sig [[EMPTY_UNBOUND]] : !sim.queue<i32, 0>
+    %unbound = moore.variable : <!moore.queue<i32, 0>>
+    // CHECK: [[EMPTY_STRUCT_BOUND:%.+]] = sim.queue.empty : <!hw.struct<a: i3, b: i2>, 4>
+    // CHECK: [[STRUCT_BOUND_REF:%.+]] = llhd.sig [[EMPTY_STRUCT_BOUND]] : !sim.queue<!hw.struct<a: i3, b: i2>, 4>
+    %struct_bound = moore.variable : <!moore.queue<ustruct<{a: i3, b: i2}>, 4>>
+    // CHECK: [[EMPTY_STRUCT_UNBOUND:%.+]] = sim.queue.empty : <!hw.struct<a: i3, b: i2>, 0>
+    // CHECK: [[STRUCT_UNBOUND_REF:%.+]] = llhd.sig [[EMPTY_STRUCT_UNBOUND]] : !sim.queue<!hw.struct<a: i3, b: i2>, 0>
+    %struct_unbound = moore.variable : <!moore.queue<ustruct<{a: i3, b: i2}>, 0>>
+    // CHECK: [[EMPTY_CLASS_BOUND:%.+]] = sim.queue.empty : <!llvm.ptr, 4>
+    // CHECK: [[CLASS_BOUND_REF:%.+]] = llhd.sig [[EMPTY_CLASS_BOUND]] : !sim.queue<!llvm.ptr, 4>
+    %class_bound = moore.variable : <!moore.queue<class<@QueueBoundClass>, 4>>
+    // CHECK: [[EMPTY_CLASS_UNBOUND:%.+]] = sim.queue.empty : <!llvm.ptr, 0>
+    // CHECK: [[CLASS_UNBOUND_REF:%.+]] = llhd.sig [[EMPTY_CLASS_UNBOUND]] : !sim.queue<!llvm.ptr, 0>
+    %class_unbound = moore.variable : <!moore.queue<class<@QueueBoundClass>, 0>>
+    // CHECK: [[EMPTY_REAL_BOUND:%.+]] = sim.queue.empty : <f64, 4>
+    // CHECK: [[REAL_BOUND_REF:%.+]] = llhd.sig [[EMPTY_REAL_BOUND]] : !sim.queue<f64, 4>
+    %real_bound = moore.variable : <!moore.queue<f64, 4>>
+    // CHECK: [[EMPTY_REAL_UNBOUND:%.+]] = sim.queue.empty : <f64, 0>
+    // CHECK: [[REAL_UNBOUND_REF:%.+]] = llhd.sig [[EMPTY_REAL_UNBOUND]] : !sim.queue<f64, 0>
+    %real_unbound = moore.variable : <!moore.queue<f64, 0>>
+    // CHECK: [[EMPTY_TIME_BOUND:%.+]] = sim.queue.empty : <!llhd.time, 4>
+    // CHECK: [[TIME_BOUND_REF:%.+]] = llhd.sig [[EMPTY_TIME_BOUND]] : !sim.queue<!llhd.time, 4>
+    %time_bound = moore.variable : <!moore.queue<time, 4>>
+    // CHECK: [[EMPTY_TIME_UNBOUND:%.+]] = sim.queue.empty : <!llhd.time, 0>
+    // CHECK: [[TIME_UNBOUND_REF:%.+]] = llhd.sig [[EMPTY_TIME_UNBOUND]] : !sim.queue<!llhd.time, 0>
+    %time_unbound = moore.variable : <!moore.queue<time, 0>>
+
+    // CHECK: [[BOUND:%.+]] = llhd.prb [[BOUND_REF]] : !sim.queue<i32, 4>
+    %bound_v = moore.read %bound : <!moore.queue<i32, 4>>
+    // CHECK: [[UNBOUND:%.+]] = llhd.prb [[UNBOUND_REF]] : !sim.queue<i32, 0>
+    %unbound_v = moore.read %unbound : <!moore.queue<i32, 0>>
+    // CHECK: [[STRUCT_BOUND:%.+]] = llhd.prb [[STRUCT_BOUND_REF]] : !sim.queue<!hw.struct<a: i3, b: i2>, 4>
+    %struct_bound_v = moore.read %struct_bound : <!moore.queue<ustruct<{a: i3, b: i2}>, 4>>
+    // CHECK: [[CLASS_BOUND:%.+]] = llhd.prb [[CLASS_BOUND_REF]] : !sim.queue<!llvm.ptr, 4>
+    %class_bound_v = moore.read %class_bound : <!moore.queue<class<@QueueBoundClass>, 4>>
+    // CHECK: [[REAL_BOUND:%.+]] = llhd.prb [[REAL_BOUND_REF]] : !sim.queue<f64, 4>
+    %real_bound_v = moore.read %real_bound : <!moore.queue<f64, 4>>
+    // CHECK: [[TIME_BOUND:%.+]] = llhd.prb [[TIME_BOUND_REF]] : !sim.queue<!llhd.time, 4>
+    %time_bound_v = moore.read %time_bound : <!moore.queue<time, 4>>
+
+    // CHECK: [[TO_UNBOUND:%.+]] = sim.queue.resize [[BOUND]] : <i32, 4> -> <i32, 0>
+    %to_unbound = moore.conversion %bound_v : !moore.queue<i32, 4> -> !moore.queue<i32, 0>
+    // CHECK: [[TO_BOUND:%.+]] = sim.queue.resize [[UNBOUND]] : <i32, 0> -> <i32, 4>
+    %to_bound = moore.conversion %unbound_v : !moore.queue<i32, 0> -> !moore.queue<i32, 4>
+    // CHECK: [[STRUCT_TO_UNBOUND:%.+]] = sim.queue.resize [[STRUCT_BOUND]] : <!hw.struct<a: i3, b: i2>, 4> -> <!hw.struct<a: i3, b: i2>, 0>
+    %struct_to_unbound = moore.conversion %struct_bound_v : !moore.queue<ustruct<{a: i3, b: i2}>, 4> -> !moore.queue<ustruct<{a: i3, b: i2}>, 0>
+    // CHECK: [[CLASS_TO_UNBOUND:%.+]] = sim.queue.resize [[CLASS_BOUND]] : <!llvm.ptr, 4> -> <!llvm.ptr, 0>
+    %class_to_unbound = moore.conversion %class_bound_v : !moore.queue<class<@QueueBoundClass>, 4> -> !moore.queue<class<@QueueBoundClass>, 0>
+    // CHECK: [[REAL_TO_UNBOUND:%.+]] = sim.queue.resize [[REAL_BOUND]] : <f64, 4> -> <f64, 0>
+    %real_to_unbound = moore.conversion %real_bound_v : !moore.queue<f64, 4> -> !moore.queue<f64, 0>
+    // CHECK: [[TIME_TO_UNBOUND:%.+]] = sim.queue.resize [[TIME_BOUND]] : <!llhd.time, 4> -> <!llhd.time, 0>
+    %time_to_unbound = moore.conversion %time_bound_v : !moore.queue<time, 4> -> !moore.queue<time, 0>
+
+    // CHECK: llhd.drv [[UNBOUND_REF]], [[TO_UNBOUND]]
+    moore.blocking_assign %unbound, %to_unbound : !moore.queue<i32, 0>
+    // CHECK: llhd.drv [[BOUND_REF]], [[TO_BOUND]]
+    moore.blocking_assign %bound, %to_bound : !moore.queue<i32, 4>
+    // CHECK: llhd.drv [[STRUCT_UNBOUND_REF]], [[STRUCT_TO_UNBOUND]]
+    moore.blocking_assign %struct_unbound, %struct_to_unbound : !moore.queue<ustruct<{a: i3, b: i2}>, 0>
+    // CHECK: llhd.drv [[CLASS_UNBOUND_REF]], [[CLASS_TO_UNBOUND]]
+    moore.blocking_assign %class_unbound, %class_to_unbound : !moore.queue<class<@QueueBoundClass>, 0>
+    // CHECK: llhd.drv [[REAL_UNBOUND_REF]], [[REAL_TO_UNBOUND]]
+    moore.blocking_assign %real_unbound, %real_to_unbound : !moore.queue<f64, 0>
+    // CHECK: llhd.drv [[TIME_UNBOUND_REF]], [[TIME_TO_UNBOUND]]
+    moore.blocking_assign %time_unbound, %time_to_unbound : !moore.queue<time, 0>
+    moore.return
+  }
+}
+
+// CHECK-NOT: moore.conversion

--- a/test/Conversion/MooreToCore/queue-type-conversion.mlir
+++ b/test/Conversion/MooreToCore/queue-type-conversion.mlir
@@ -1,0 +1,238 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @QueueSignature
+// CHECK-SAME: (%arg0: !sim.queue<i3, 4>) -> !sim.queue<i3, 4>
+func.func @QueueSignature(%queue: !moore.queue<i3, 4>) -> !moore.queue<i3, 4> {
+  // CHECK: return %arg0 : !sim.queue<i3, 4>
+  return %queue : !moore.queue<i3, 4>
+}
+
+// CHECK-LABEL: func.func @QueueSizeResult
+// CHECK-SAME: (%arg0: !sim.queue<i8, 4>) -> i32
+func.func @QueueSizeResult(%queue: !moore.queue<i8, 4>) -> !moore.i32 {
+  // CHECK: %[[SIZE:.*]] = sim.queue.size %arg0 : <i8, 4>
+  %size = moore.builtin.size %queue : <i8, 4>
+  // CHECK: %[[SIZE_I32:.*]] = builtin.unrealized_conversion_cast %[[SIZE]] : i64 to i32
+  // CHECK: return %[[SIZE_I32]] : i32
+  return %size : !moore.i32
+}
+
+// CHECK-LABEL: func.func @QueueAggregateSignature
+// CHECK-SAME: (%arg0: !sim.queue<!hw.struct<a: i3, b: i2>, 4>) -> !sim.queue<!hw.struct<a: i3, b: i2>, 4>
+func.func @QueueAggregateSignature(%queue: !moore.queue<ustruct<{a: i3, b: i2}>, 4>) -> !moore.queue<ustruct<{a: i3, b: i2}>, 4> {
+  // CHECK: return %arg0 : !sim.queue<!hw.struct<a: i3, b: i2>, 4>
+  return %queue : !moore.queue<ustruct<{a: i3, b: i2}>, 4>
+}
+
+moore.class.classdecl @QueueClass {
+}
+
+// CHECK-LABEL: func.func @QueueClassBoundary
+// CHECK-SAME: (%arg0: !sim.queue<!llvm.ptr, 4>) -> !sim.queue<!llvm.ptr, 4>
+func.func @QueueClassBoundary(%queue: !moore.queue<class<@QueueClass>, 4>) -> !moore.queue<class<@QueueClass>, 4> {
+  // CHECK: return %arg0 : !sim.queue<!llvm.ptr, 4>
+  return %queue : !moore.queue<class<@QueueClass>, 4>
+}
+
+// CHECK-LABEL: func.func @QueueClassConditional
+// CHECK-SAME: (%arg0: i1, %arg1: !sim.queue<!llvm.ptr, 4>, %arg2: !sim.queue<!llvm.ptr, 4>) -> !sim.queue<!llvm.ptr, 4>
+func.func @QueueClassConditional(%cond: !moore.i1, %lhs: !moore.queue<class<@QueueClass>, 4>, %rhs: !moore.queue<class<@QueueClass>, 4>) -> !moore.queue<class<@QueueClass>, 4> {
+  // CHECK: comb.mux %arg0, %arg1, %arg2 : !sim.queue<!llvm.ptr, 4>
+  %out = moore.conditional %cond : i1 -> queue<class<@QueueClass>, 4> {
+    moore.yield %lhs : queue<class<@QueueClass>, 4>
+  } {
+    moore.yield %rhs : queue<class<@QueueClass>, 4>
+  }
+  return %out : !moore.queue<class<@QueueClass>, 4>
+}
+
+// CHECK-LABEL: func.func @QueueRealBoundary
+// CHECK-SAME: (%arg0: !sim.queue<f64, 4>) -> !sim.queue<f64, 4>
+func.func @QueueRealBoundary(%queue: !moore.queue<f64, 4>) -> !moore.queue<f64, 4> {
+  // CHECK: return %arg0 : !sim.queue<f64, 4>
+  return %queue : !moore.queue<f64, 4>
+}
+
+// CHECK-LABEL: func.func @QueueTimeBoundary
+// CHECK-SAME: (%arg0: !sim.queue<!llhd.time, 4>) -> !sim.queue<!llhd.time, 4>
+func.func @QueueTimeBoundary(%queue: !moore.queue<time, 4>) -> !moore.queue<time, 4> {
+  // CHECK: return %arg0 : !sim.queue<!llhd.time, 4>
+  return %queue : !moore.queue<time, 4>
+}
+
+// CHECK-LABEL: func.func @QueueRealConditional
+// CHECK-SAME: (%arg0: i1, %arg1: !sim.queue<f64, 4>, %arg2: !sim.queue<f64, 4>) -> !sim.queue<f64, 4>
+func.func @QueueRealConditional(%cond: !moore.i1, %lhs: !moore.queue<f64, 4>, %rhs: !moore.queue<f64, 4>) -> !moore.queue<f64, 4> {
+  // CHECK: comb.mux %arg0, %arg1, %arg2 : !sim.queue<f64, 4>
+  %out = moore.conditional %cond : i1 -> queue<f64, 4> {
+    moore.yield %lhs : queue<f64, 4>
+  } {
+    moore.yield %rhs : queue<f64, 4>
+  }
+  return %out : !moore.queue<f64, 4>
+}
+
+// CHECK-LABEL: func.func @QueueTimeConditional
+// CHECK-SAME: (%arg0: i1, %arg1: !sim.queue<!llhd.time, 4>, %arg2: !sim.queue<!llhd.time, 4>) -> !sim.queue<!llhd.time, 4>
+func.func @QueueTimeConditional(%cond: !moore.i1, %lhs: !moore.queue<time, 4>, %rhs: !moore.queue<time, 4>) -> !moore.queue<time, 4> {
+  // CHECK: comb.mux %arg0, %arg1, %arg2 : !sim.queue<!llhd.time, 4>
+  %out = moore.conditional %cond : i1 -> queue<time, 4> {
+    moore.yield %lhs : queue<time, 4>
+  } {
+    moore.yield %rhs : queue<time, 4>
+  }
+  return %out : !moore.queue<time, 4>
+}
+
+// CHECK-LABEL: func.func @UArrayQueueSignature
+// CHECK-SAME: (%arg0: !hw.array<2x!sim.queue<i3, 4>>) -> !hw.array<2x!sim.queue<i3, 4>>
+func.func @UArrayQueueSignature(%arg0: !moore.uarray<2 x queue<i3, 4>>) -> !moore.uarray<2 x queue<i3, 4>> {
+  // CHECK: return %arg0 : !hw.array<2x!sim.queue<i3, 4>>
+  return %arg0 : !moore.uarray<2 x queue<i3, 4>>
+}
+
+// CHECK-LABEL: func.func @UStructQueueSignature
+// CHECK-SAME: (%arg0: !hw.struct<q: !sim.queue<i3, 4>, bits: i2>) -> !hw.struct<q: !sim.queue<i3, 4>, bits: i2>
+func.func @UStructQueueSignature(%arg0: !moore.ustruct<{q: queue<i3, 4>, bits: i2}>) -> !moore.ustruct<{q: queue<i3, 4>, bits: i2}> {
+  // CHECK: return %arg0 : !hw.struct<q: !sim.queue<i3, 4>, bits: i2>
+  return %arg0 : !moore.ustruct<{q: queue<i3, 4>, bits: i2}>
+}
+
+// CHECK-LABEL: func.func @UUnionQueueSignature
+// CHECK-SAME: (%arg0: !hw.union<q: !sim.queue<i3, 4>, bits: i3>) -> !hw.union<q: !sim.queue<i3, 4>, bits: i3>
+func.func @UUnionQueueSignature(%arg0: !moore.uunion<{q: queue<i3, 4>, bits: i3}>) -> !moore.uunion<{q: queue<i3, 4>, bits: i3}> {
+  // CHECK: return %arg0 : !hw.union<q: !sim.queue<i3, 4>, bits: i3>
+  return %arg0 : !moore.uunion<{q: queue<i3, 4>, bits: i3}>
+}
+
+// CHECK-LABEL: func.func @QueueRefSignature
+// CHECK-SAME: (%arg0: !llhd.ref<!sim.queue<i3, 4>>) -> !llhd.ref<!sim.queue<i3, 4>>
+func.func @QueueRefSignature(%queue: !moore.ref<queue<i3, 4>>) -> !moore.ref<queue<i3, 4>> {
+  // CHECK: return %arg0 : !llhd.ref<!sim.queue<i3, 4>>
+  return %queue : !moore.ref<queue<i3, 4>>
+}
+
+// CHECK-LABEL: func.func @QueueConditional
+func.func @QueueConditional(%cond: !moore.i1) {
+  // CHECK: [[A_EMPTY:%.+]] = sim.queue.empty : <i32, 4>
+  // CHECK: [[A_REF:%.+]] = llhd.sig [[A_EMPTY]] : !sim.queue<i32, 4>
+  %a_ref = moore.variable : <!moore.queue<i32, 4>>
+  // CHECK: [[B_EMPTY:%.+]] = sim.queue.empty : <i32, 4>
+  // CHECK: [[B_REF:%.+]] = llhd.sig [[B_EMPTY]] : !sim.queue<i32, 4>
+  %b_ref = moore.variable : <!moore.queue<i32, 4>>
+  // CHECK: [[A:%.+]] = llhd.prb [[A_REF]] : !sim.queue<i32, 4>
+  %a = moore.read %a_ref : <!moore.queue<i32, 4>>
+  // CHECK: [[B:%.+]] = llhd.prb [[B_REF]] : !sim.queue<i32, 4>
+  %b = moore.read %b_ref : <!moore.queue<i32, 4>>
+  // CHECK: comb.mux %arg0, [[A]], [[B]] : !sim.queue<i32, 4>
+  %sel = moore.conditional %cond : i1 -> queue<i32, 4> {
+    moore.yield %a : queue<i32, 4>
+  } {
+    moore.yield %b : queue<i32, 4>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @QueueUnionConditional
+// CHECK-SAME: (%arg0: i1, %arg1: !hw.union<q: !sim.queue<i3, 4>, bits: i3>, %arg2: !hw.union<q: !sim.queue<i3, 4>, bits: i3>)
+func.func @QueueUnionConditional(%cond: !moore.i1, %lhs: !moore.uunion<{q: queue<i3, 4>, bits: i3}>, %rhs: !moore.uunion<{q: queue<i3, 4>, bits: i3}>) -> !moore.uunion<{q: queue<i3, 4>, bits: i3}> {
+  // CHECK: comb.mux %arg0, %arg1, %arg2 : !hw.union<q: !sim.queue<i3, 4>, bits: i3>
+  %result = moore.conditional %cond : i1 -> uunion<{q: queue<i3, 4>, bits: i3}> {
+    moore.yield %lhs : uunion<{q: queue<i3, 4>, bits: i3}>
+  } {
+    moore.yield %rhs : uunion<{q: queue<i3, 4>, bits: i3}>
+  }
+  return %result : !moore.uunion<{q: queue<i3, 4>, bits: i3}>
+}
+
+// CHECK-LABEL: hw.module @QueueModulePorts
+// CHECK-SAME: in %queue_in : !sim.queue<i3, 4>
+// CHECK-SAME: out queue_out : !sim.queue<i3, 4>
+moore.module @QueueModulePorts(in %queue_in : !moore.queue<i3, 4>, out queue_out : !moore.queue<i3, 4>) {
+  // CHECK: hw.output %queue_in : !sim.queue<i3, 4>
+  moore.output %queue_in : !moore.queue<i3, 4>
+}
+
+// CHECK-LABEL: hw.module @QueueClassModulePorts
+// CHECK-SAME: in %queue_in : !sim.queue<!llvm.ptr, 4>
+// CHECK-SAME: out queue_out : !sim.queue<!llvm.ptr, 4>
+moore.module @QueueClassModulePorts(in %queue_in : !moore.queue<class<@QueueClass>, 4>, out queue_out : !moore.queue<class<@QueueClass>, 4>) {
+  // CHECK: hw.output %queue_in : !sim.queue<!llvm.ptr, 4>
+  moore.output %queue_in : !moore.queue<class<@QueueClass>, 4>
+}
+
+// CHECK-LABEL: hw.module @QueueRealModulePorts
+// CHECK-SAME: in %queue_in : !sim.queue<f64, 4>
+// CHECK-SAME: out queue_out : !sim.queue<f64, 4>
+moore.module @QueueRealModulePorts(in %queue_in : !moore.queue<f64, 4>, out queue_out : !moore.queue<f64, 4>) {
+  // CHECK: hw.output %queue_in : !sim.queue<f64, 4>
+  moore.output %queue_in : !moore.queue<f64, 4>
+}
+
+// CHECK-LABEL: hw.module @QueueTimeModulePorts
+// CHECK-SAME: in %queue_in : !sim.queue<!llhd.time, 4>
+// CHECK-SAME: out queue_out : !sim.queue<!llhd.time, 4>
+moore.module @QueueTimeModulePorts(in %queue_in : !moore.queue<time, 4>, out queue_out : !moore.queue<time, 4>) {
+  // CHECK: hw.output %queue_in : !sim.queue<!llhd.time, 4>
+  moore.output %queue_in : !moore.queue<time, 4>
+}
+
+// CHECK-LABEL: hw.module @QueueInstTop
+// CHECK-SAME: in %queue_in : !sim.queue<i3, 4>
+// CHECK-SAME: out queue_out : !sim.queue<i3, 4>
+moore.module @QueueInstTop(in %queue_in : !moore.queue<i3, 4>, out queue_out : !moore.queue<i3, 4>) {
+  // CHECK: hw.instance "child" @QueueInstChild(queue_in: %queue_in: !sim.queue<i3, 4>) -> (queue_out: !sim.queue<i3, 4>)
+  %child.queue_out = moore.instance "child" @QueueInstChild(queue_in: %queue_in : !moore.queue<i3, 4>) -> (queue_out: !moore.queue<i3, 4>)
+  // CHECK: hw.output %child.queue_out : !sim.queue<i3, 4>
+  moore.output %child.queue_out : !moore.queue<i3, 4>
+}
+
+// CHECK-LABEL: hw.module private @QueueInstChild
+moore.module private @QueueInstChild(in %queue_in : !moore.queue<i3, 4>, out queue_out : !moore.queue<i3, 4>) {
+  // CHECK: hw.output %queue_in : !sim.queue<i3, 4>
+  moore.output %queue_in : !moore.queue<i3, 4>
+}
+
+// CHECK-LABEL: hw.module @QueueClassInstTop
+// CHECK-SAME: in %queue_in : !sim.queue<!llvm.ptr, 4>
+// CHECK-SAME: out queue_out : !sim.queue<!llvm.ptr, 4>
+moore.module @QueueClassInstTop(in %queue_in : !moore.queue<class<@QueueClass>, 4>, out queue_out : !moore.queue<class<@QueueClass>, 4>) {
+  // CHECK: hw.instance "child" @QueueClassInstChild(queue_in: %queue_in: !sim.queue<!llvm.ptr, 4>) -> (queue_out: !sim.queue<!llvm.ptr, 4>)
+  %child.queue_out = moore.instance "child" @QueueClassInstChild(queue_in: %queue_in : !moore.queue<class<@QueueClass>, 4>) -> (queue_out: !moore.queue<class<@QueueClass>, 4>)
+  // CHECK: hw.output %child.queue_out : !sim.queue<!llvm.ptr, 4>
+  moore.output %child.queue_out : !moore.queue<class<@QueueClass>, 4>
+}
+
+// CHECK-LABEL: hw.module private @QueueClassInstChild
+moore.module private @QueueClassInstChild(in %queue_in : !moore.queue<class<@QueueClass>, 4>, out queue_out : !moore.queue<class<@QueueClass>, 4>) {
+  // CHECK: hw.output %queue_in : !sim.queue<!llvm.ptr, 4>
+  moore.output %queue_in : !moore.queue<class<@QueueClass>, 4>
+}
+
+// CHECK-LABEL: hw.module @QueueRefModulePorts
+// CHECK-SAME: in %queue_ref : !llhd.ref<!sim.queue<i3, 4>>
+moore.module @QueueRefModulePorts(in %queue_ref : !moore.ref<queue<i3, 4>>) {
+  // CHECK: hw.output
+  moore.output
+}
+
+// CHECK-LABEL: hw.module @QueueClassRefModulePorts
+// CHECK-SAME: in %queue_ref : !llhd.ref<!sim.queue<!llvm.ptr, 4>>
+moore.module @QueueClassRefModulePorts(in %queue_ref : !moore.ref<queue<class<@QueueClass>, 4>>) {
+  // CHECK: hw.output
+  moore.output
+}
+
+// CHECK-LABEL: hw.module @QueueRealRefModulePorts
+// CHECK-SAME: in %queue_ref : !llhd.ref<!sim.queue<f64, 4>>
+moore.module @QueueRealRefModulePorts(in %queue_ref : !moore.ref<queue<f64, 4>>) {
+  // CHECK: hw.output
+  moore.output
+}
+
+// CHECK-LABEL: hw.module @QueueTimeRefModulePorts
+// CHECK-SAME: in %queue_ref : !llhd.ref<!sim.queue<!llhd.time, 4>>
+moore.module @QueueTimeRefModulePorts(in %queue_ref : !moore.ref<queue<time, 4>>) {
+  // CHECK: hw.output
+  moore.output
+}

--- a/test/Transforms/map-arith-to-comb-non-hw-selects.mlir
+++ b/test/Transforms/map-arith-to-comb-non-hw-selects.mlir
@@ -1,0 +1,85 @@
+// RUN: circt-opt --split-input-file --verify-diagnostics --map-arith-to-comb=enable-best-effort-lowering %s | FileCheck %s
+
+// CHECK-LABEL: func @allow_dynamic_strings
+func.func @allow_dynamic_strings(%arg0: !sim.dstring, %arg1: !sim.dstring, %arg2: i1) -> !sim.dstring {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !sim.dstring
+  %0 = arith.select %arg2, %arg0, %arg1 : !sim.dstring
+  return %0 : !sim.dstring
+}
+
+// CHECK-LABEL: func @allow_format_strings
+func.func @allow_format_strings(%arg0: !sim.fstring, %arg1: !sim.fstring, %arg2: i1) -> !sim.fstring {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !sim.fstring
+  %0 = arith.select %arg2, %arg0, %arg1 : !sim.fstring
+  return %0 : !sim.fstring
+}
+
+// CHECK-LABEL: func @allow_real_values
+func.func @allow_real_values(%arg0: f64, %arg1: f64, %arg2: i1) -> f64 {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : f64
+  %0 = arith.select %arg2, %arg0, %arg1 : f64
+  return %0 : f64
+}
+
+// CHECK-LABEL: func @allow_time_values
+func.func @allow_time_values(%arg0: !llhd.time, %arg1: !llhd.time, %arg2: i1) -> !llhd.time {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !llhd.time
+  %0 = arith.select %arg2, %arg0, %arg1 : !llhd.time
+  return %0 : !llhd.time
+}
+
+// CHECK-LABEL: func @allow_llvm_pointers
+func.func @allow_llvm_pointers(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: i1) -> !llvm.ptr {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !llvm.ptr
+  %0 = arith.select %arg2, %arg0, %arg1 : !llvm.ptr
+  return %0 : !llvm.ptr
+}
+
+// CHECK-LABEL: func @allow_sim_queues
+func.func @allow_sim_queues(%arg0: !sim.queue<i32, 3>, %arg1: !sim.queue<i32, 3>, %arg2: i1) -> !sim.queue<i32, 3> {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !sim.queue<i32, 3>
+  %0 = arith.select %arg2, %arg0, %arg1 : !sim.queue<i32, 3>
+  return %0 : !sim.queue<i32, 3>
+}
+
+// CHECK-LABEL: func @allow_structs_with_non_hw_leaves
+func.func @allow_structs_with_non_hw_leaves(%arg0: !hw.struct<s: !sim.dstring, t: !llhd.time>, %arg1: !hw.struct<s: !sim.dstring, t: !llhd.time>, %arg2: i1) -> !hw.struct<s: !sim.dstring, t: !llhd.time> {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !hw.struct<s: !sim.dstring, t: !llhd.time>
+  %0 = arith.select %arg2, %arg0, %arg1 : !hw.struct<s: !sim.dstring, t: !llhd.time>
+  return %0 : !hw.struct<s: !sim.dstring, t: !llhd.time>
+}
+
+// CHECK-LABEL: func @allow_arrays_with_non_hw_leaves
+func.func @allow_arrays_with_non_hw_leaves(%arg0: !hw.array<2x!llvm.ptr>, %arg1: !hw.array<2x!llvm.ptr>, %arg2: i1) -> !hw.array<2x!llvm.ptr> {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !hw.array<2x!llvm.ptr>
+  %0 = arith.select %arg2, %arg0, %arg1 : !hw.array<2x!llvm.ptr>
+  return %0 : !hw.array<2x!llvm.ptr>
+}
+
+// CHECK-LABEL: func @allow_unions_with_non_hw_leaves
+func.func @allow_unions_with_non_hw_leaves(%arg0: !hw.union<s: !sim.dstring, r: f64>, %arg1: !hw.union<s: !sim.dstring, r: f64>, %arg2: i1) -> !hw.union<s: !sim.dstring, r: f64> {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !hw.union<s: !sim.dstring, r: f64>
+  %0 = arith.select %arg2, %arg0, %arg1 : !hw.union<s: !sim.dstring, r: f64>
+  return %0 : !hw.union<s: !sim.dstring, r: f64>
+}
+
+// CHECK-LABEL: func @allow_structs_with_queue_leaves
+func.func @allow_structs_with_queue_leaves(%arg0: !hw.struct<q: !sim.queue<i32, 4>>, %arg1: !hw.struct<q: !sim.queue<i32, 4>>, %arg2: i1) -> !hw.struct<q: !sim.queue<i32, 4>> {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !hw.struct<q: !sim.queue<i32, 4>>
+  %0 = arith.select %arg2, %arg0, %arg1 : !hw.struct<q: !sim.queue<i32, 4>>
+  return %0 : !hw.struct<q: !sim.queue<i32, 4>>
+}
+
+// CHECK-LABEL: func @allow_nested_queue_aggregates
+func.func @allow_nested_queue_aggregates(%arg0: !hw.array<2xstruct<q: !sim.queue<i32, 4>>>, %arg1: !hw.array<2xstruct<q: !sim.queue<i32, 4>>>, %arg2: i1) -> !hw.array<2xstruct<q: !sim.queue<i32, 4>>> {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !hw.array<2xstruct<q: !sim.queue<i32, 4>>>
+  %0 = arith.select %arg2, %arg0, %arg1 : !hw.array<2xstruct<q: !sim.queue<i32, 4>>>
+  return %0 : !hw.array<2xstruct<q: !sim.queue<i32, 4>>>
+}
+
+// CHECK-LABEL: func @allow_mixed_queue_and_non_hw_aggregates
+func.func @allow_mixed_queue_and_non_hw_aggregates(%arg0: !hw.struct<q: !sim.queue<i32, 4>, s: !sim.dstring, t: !llhd.time>, %arg1: !hw.struct<q: !sim.queue<i32, 4>, s: !sim.dstring, t: !llhd.time>, %arg2: i1) -> !hw.struct<q: !sim.queue<i32, 4>, s: !sim.dstring, t: !llhd.time> {
+  // CHECK: comb.mux %arg2, %arg0, %arg1 : !hw.struct<q: !sim.queue<i32, 4>, s: !sim.dstring, t: !llhd.time>
+  %0 = arith.select %arg2, %arg0, %arg1 : !hw.struct<q: !sim.queue<i32, 4>, s: !sim.dstring, t: !llhd.time>
+  return %0 : !hw.struct<q: !sim.queue<i32, 4>, s: !sim.dstring, t: !llhd.time>
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Lower queue type boundaries and non-HW select operand legalization in MooreToCore and MapArithToComb (IEEE 1800-2023 §6.20.7). Previously dropped; inserts queue type conversions in comparisons and assignments; legalizes non-HW select operands in arithmetic maps. Maps to existing ops. Standalone.

Tests: queue-bound-conversions.mlir, queue-type-conversion.mlir, map-arith-to-comb-non-hw-selects.mlir.
