### PR TITLE
[ImportVerilog] Lower procedural fork/wait/assert/loop statements

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -238,10 +238,9 @@ struct StmtVisitor {
       }
       threads.push_back(item);
     }
-    // If the fork contained only declarations, there are no threads to spawn
-    // and the fork degenerates to the declarations themselves. Genuinely
-    // empty forks keep producing an empty fork op.
-    if (threads.empty() && !items.empty())
+    // If the fork has no spawned threads, it degenerates to any declarations
+    // that were already converted above.
+    if (threads.empty())
       return success();
 
     auto forkOp = moore::ForkJoinOp::create(builder, loc, kind, threads.size());

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -845,6 +845,34 @@ struct StmtVisitor {
       else if (stmt.isDeferred)
         defer = moore::DeferAssert::Observed;
 
+      auto *parentOp = builder.getInsertionBlock()->getParentOp();
+      if (!isa<moore::ProcedureOp>(parentOp)) {
+        if (defer != moore::DeferAssert::Immediate)
+          return emitError(loc) << "unsupported deferred immediate assertion "
+                                   "outside a procedure";
+
+        cond = context.convertToI1(cond);
+        if (!cond)
+          return failure();
+
+        switch (stmt.assertionKind) {
+        case slang::ast::AssertionKind::Assert:
+          verif::AssertOp::create(builder, loc, cond, Value{}, StringAttr{});
+          return success();
+        case slang::ast::AssertionKind::Assume:
+          verif::AssumeOp::create(builder, loc, cond, Value{}, StringAttr{});
+          return success();
+        case slang::ast::AssertionKind::CoverProperty:
+          verif::CoverOp::create(builder, loc, cond, Value{}, StringAttr{});
+          return success();
+        default:
+          break;
+        }
+        mlir::emitError(loc) << "unsupported immediate assertion kind: "
+                             << slang::ast::toString(stmt.assertionKind);
+        return failure();
+      }
+
       switch (stmt.assertionKind) {
       case slang::ast::AssertionKind::Assert:
         moore::AssertOp::create(builder, loc, defer, cond, StringAttr{});

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -579,25 +579,27 @@ struct StmtVisitor {
     auto &exitBlock = createBlock();
     auto &stepBlock = createBlock();
     auto &bodyBlock = createBlock();
-    auto &checkBlock = createBlock();
-    cf::BranchOp::create(builder, loc, &checkBlock);
+    Block *checkBlock = stmt.stopExpr ? &createBlock() : nullptr;
+    cf::BranchOp::create(builder, loc, checkBlock ? checkBlock : &bodyBlock);
 
     // Push the blocks onto the loop stack such that we can continue and break.
     context.loopStack.push_back({&stepBlock, &exitBlock});
     llvm::scope_exit done([&] { context.loopStack.pop_back(); });
 
     // Generate the loop condition check.
-    builder.setInsertionPointToEnd(&checkBlock);
-    auto cond = context.convertRvalueExpression(*stmt.stopExpr);
-    if (!cond)
-      return failure();
-    cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
-    if (auto ty = dyn_cast<moore::IntType>(cond.getType());
-        ty && ty.getDomain() == Domain::FourValued) {
-      cond = moore::LogicToIntOp::create(builder, loc, cond);
+    if (checkBlock) {
+      builder.setInsertionPointToEnd(checkBlock);
+      auto cond = context.convertRvalueExpression(*stmt.stopExpr);
+      if (!cond)
+        return failure();
+      cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
+      if (auto ty = dyn_cast<moore::IntType>(cond.getType());
+          ty && ty.getDomain() == Domain::FourValued) {
+        cond = moore::LogicToIntOp::create(builder, loc, cond);
+      }
+      cond = moore::ToBuiltinIntOp::create(builder, loc, cond);
+      cf::CondBranchOp::create(builder, loc, cond, &bodyBlock, &exitBlock);
     }
-    cond = moore::ToBuiltinIntOp::create(builder, loc, cond);
-    cf::CondBranchOp::create(builder, loc, cond, &bodyBlock, &exitBlock);
 
     // Generate the loop body.
     builder.setInsertionPointToEnd(&bodyBlock);
@@ -612,7 +614,7 @@ struct StmtVisitor {
       if (!context.convertRvalueExpression(*stepExpr))
         return failure();
     if (!isTerminated())
-      cf::BranchOp::create(builder, loc, &checkBlock);
+      cf::BranchOp::create(builder, loc, checkBlock ? checkBlock : &bodyBlock);
 
     // If control never reaches the exit block, remove it and mark control flow
     // as terminated. Otherwise we continue inserting ops in the exit block.

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -903,6 +903,126 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
   }
 };
 
+struct WaitLevelOpConversion : public OpConversionPattern<WaitLevelOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(WaitLevelOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto *resumeBlock =
+        rewriter.splitBlock(op->getBlock(), ++Block::iterator(op));
+
+    auto loc = op.getLoc();
+    if (op.getBody().front().empty()) {
+      rewriter.setInsertionPoint(op);
+      cf::BranchOp::create(rewriter, loc, resumeBlock);
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    auto *checkBlock = rewriter.createBlock(resumeBlock);
+    auto *waitBlock = rewriter.createBlock(resumeBlock);
+    auto *afterWaitBlock = rewriter.createBlock(resumeBlock);
+
+    rewriter.setInsertionPoint(op);
+    cf::BranchOp::create(rewriter, loc, checkBlock);
+
+    // If the level check fails, wait for any value used by the check to change
+    // and then execute the check again. Similar to event controls, keep a copy
+    // of the pre-wait condition values live across the wait so later LLHD
+    // cleanup preserves the actual values being observed.
+    rewriter.setInsertionPointToEnd(waitBlock);
+    auto beforeOp = cast<WaitLevelOp>(rewriter.clone(*op));
+    SmallVector<Value> valuesBefore;
+    for (auto detectOp :
+         llvm::make_early_inc_range(beforeOp.getOps<DetectLevelOp>())) {
+      valuesBefore.push_back(detectOp.getCondition());
+      rewriter.eraseOp(detectOp);
+    }
+
+    SmallVector<Value> observeValues;
+    auto setInsertionPointAfterDef = [&](Value value) {
+      if (auto *op = value.getDefiningOp())
+        rewriter.setInsertionPointAfter(op);
+      if (auto arg = dyn_cast<BlockArgument>(value))
+        rewriter.setInsertionPointToStart(value.getParentBlock());
+    };
+    getValuesToObserve(&beforeOp.getBody(), setInsertionPointAfterDef,
+                       typeConverter, rewriter, observeValues);
+    auto waitOp =
+        llhd::WaitOp::create(rewriter, loc, ValueRange{}, Value(),
+                             observeValues, ValueRange{}, afterWaitBlock);
+    rewriter.inlineBlockBefore(&beforeOp.getBody().front(), waitOp);
+    rewriter.eraseOp(beforeOp);
+
+    rewriter.setInsertionPointToEnd(afterWaitBlock);
+    auto afterOp = cast<WaitLevelOp>(rewriter.clone(*op));
+    SmallVector<DetectLevelOp> detectOpsAfter(
+        afterOp.getBody().getOps<DetectLevelOp>());
+    rewriter.inlineBlockBefore(&afterOp.getBody().front(), afterWaitBlock,
+                               afterWaitBlock->end());
+    rewriter.eraseOp(afterOp);
+
+    auto changed = [&](Value before, Value after) -> FailureOr<Value> {
+      auto type = typeConverter->convertType(before.getType());
+      if (!type)
+        return failure();
+      before = typeConverter->materializeTargetConversion(rewriter, loc, type,
+                                                          before);
+      after = typeConverter->materializeTargetConversion(rewriter, loc, type,
+                                                         after);
+      if (!before || !after)
+        return failure();
+      return comb::ICmpOp::create(rewriter, loc, ICmpPredicate::ne, before,
+                                  after, true)
+          .getResult();
+    };
+
+    SmallVector<Value> changes;
+    for (auto [detectOp, before] : llvm::zip(detectOpsAfter, valuesBefore)) {
+      rewriter.setInsertionPoint(detectOp);
+      auto change = changed(before, detectOp.getCondition());
+      if (failed(change))
+        return failure();
+      changes.push_back(*change);
+      rewriter.eraseOp(detectOp);
+    }
+    rewriter.setInsertionPointToEnd(afterWaitBlock);
+    if (changes.empty()) {
+      cf::BranchOp::create(rewriter, loc, checkBlock);
+    } else {
+      auto anyChanged = rewriter.createOrFold<comb::OrOp>(loc, changes, true);
+      cf::CondBranchOp::create(rewriter, loc, anyChanged, checkBlock,
+                               waitBlock);
+    }
+
+    SmallVector<DetectLevelOp> detectOps(op.getBody().getOps<DetectLevelOp>());
+    rewriter.inlineBlockBefore(&op.getBody().front(), checkBlock,
+                               checkBlock->end());
+    rewriter.eraseOp(op);
+
+    SmallVector<Value> triggers;
+    for (auto detectOp : detectOps) {
+      rewriter.setInsertionPoint(detectOp);
+      auto trigger = typeConverter->materializeTargetConversion(
+          rewriter, loc, rewriter.getI1Type(), detectOp.getCondition());
+      triggers.push_back(trigger);
+      rewriter.eraseOp(detectOp);
+    }
+
+    rewriter.setInsertionPointToEnd(checkBlock);
+    if (triggers.empty()) {
+      cf::BranchOp::create(rewriter, loc, resumeBlock);
+    } else {
+      auto triggered = rewriter.createOrFold<comb::OrOp>(loc, triggers, true);
+      cf::CondBranchOp::create(rewriter, loc, triggered, resumeBlock,
+                               waitBlock);
+    }
+
+    return success();
+  }
+};
+
 // moore.wait_delay -> llhd.wait
 static LogicalResult convert(WaitDelayOp op, WaitDelayOp::Adaptor adaptor,
                              ConversionPatternRewriter &rewriter) {
@@ -3581,6 +3701,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     CoroutineOpConversion,
     CallCoroutineOpConversion,
     WaitEventOpConversion,
+    WaitLevelOpConversion,
 
     // Patterns of shifting operations.
     ShrOpConversion,

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4703,7 +4703,6 @@ endmodule
 // CHECK:             moore.blocking_assign [[VAR_A]], [[CONST_1]] : i32
 // CHECK:             moore.complete
 // CHECK:           }
-// CHECK:           moore.fork join_all
 // CHECK:           moore.return
 // CHECK:         }
 // CHECK:         moore.output

--- a/test/Conversion/ImportVerilog/procedural-to-core.sv
+++ b/test/Conversion/ImportVerilog/procedural-to-core.sv
@@ -1,6 +1,7 @@
 // RUN: circt-verilog --ir-moore %s | FileCheck %s --check-prefix=MOORE
 // RUN: circt-verilog %s | FileCheck %s --check-prefix=CORE
 // REQUIRES: slang
+// UNSUPPORTED: valgrind
 
 module ForLoopNoCondition(output int out);
   initial begin
@@ -91,3 +92,20 @@ endmodule
 // CORE:       verif.assume %a : i1
 // CORE:       verif.cover %a : i1
 // CORE:       llhd.call_coroutine @ImmediateAssertTask(%a) : (i1) -> ()
+
+module EmptyForkToCore(output int y);
+  initial begin
+    fork
+    join
+    y = 1;
+  end
+endmodule
+
+// MOORE-LABEL: moore.module @EmptyForkToCore
+// MOORE-NOT:   moore.fork
+// MOORE:       moore.blocking_assign
+// MOORE:       moore.return
+
+// CORE-LABEL: hw.module @EmptyForkToCore
+// CORE:       [[C1:%.+]] = hw.constant 1 : i32
+// CORE:       hw.output [[C1]] : i32

--- a/test/Conversion/ImportVerilog/procedural-to-core.sv
+++ b/test/Conversion/ImportVerilog/procedural-to-core.sv
@@ -57,3 +57,37 @@ endmodule
 // CORE:       [[CHANGED:%.+]] = comb.icmp bin ne [[BEFORE]], %enable : i1
 // CORE:       cf.cond_br [[CHANGED]], ^[[CHECK]], ^[[WAIT]]
 // CORE:     ^[[RESUME]]:
+
+function automatic int ImmediateAssertFunction(input bit a);
+  assert (a);
+  assume (a);
+  cover (a);
+  return 1;
+endfunction
+
+task automatic ImmediateAssertTask(input bit a);
+  assert (a);
+  assume (a);
+  cover (a);
+endtask
+
+module ImmediateAssertInSubroutine(input bit a, output int y);
+  initial begin
+    y = ImmediateAssertFunction(a);
+    ImmediateAssertTask(a);
+  end
+endmodule
+
+// CORE-LABEL: llhd.coroutine private @ImmediateAssertTask
+// CORE-SAME:  (%arg0: i1)
+// CORE:       verif.assert %arg0 : i1
+// CORE:       verif.assume %arg0 : i1
+// CORE:       verif.cover %arg0 : i1
+// CORE:       llhd.return
+
+// CORE-LABEL: hw.module @ImmediateAssertInSubroutine
+// CORE:       llhd.process
+// CORE:       verif.assert %a : i1
+// CORE:       verif.assume %a : i1
+// CORE:       verif.cover %a : i1
+// CORE:       llhd.call_coroutine @ImmediateAssertTask(%a) : (i1) -> ()

--- a/test/Conversion/ImportVerilog/procedural-to-core.sv
+++ b/test/Conversion/ImportVerilog/procedural-to-core.sv
@@ -1,0 +1,59 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s --check-prefix=MOORE
+// RUN: circt-verilog %s | FileCheck %s --check-prefix=CORE
+// REQUIRES: slang
+
+module ForLoopNoCondition(output int out);
+  initial begin
+    int i;
+    for (i = 0; ; i++) begin
+      if (i == 4)
+        break;
+    end
+    out = i;
+  end
+endmodule
+
+// MOORE-LABEL: moore.module @ForLoopNoCondition
+// MOORE:       [[C1:%.+]] = moore.constant 1 : i32
+// MOORE:       [[C4:%.+]] = moore.constant 4 : i32
+// MOORE:       [[C0:%.+]] = moore.constant 0 : i32
+// MOORE:       cf.br ^[[LOOP:.+]]([[C0]] : !moore.i32)
+// MOORE:     ^[[LOOP]]([[I:%.+]]: !moore.i32):
+// MOORE:       [[EQ:%.+]] = moore.eq [[I]], [[C4]] : i32 -> i1
+// MOORE:       cf.cond_br {{%.+}}, ^[[EXIT:.+]], ^[[STEP:.+]]
+// MOORE:     ^[[STEP]]:
+// MOORE:       [[NEXT:%.+]] = moore.add [[I]], [[C1]] : i32
+// MOORE:       cf.br ^[[LOOP]]([[NEXT]] : !moore.i32)
+// MOORE:     ^[[EXIT]]:
+
+// CORE-LABEL: hw.module @ForLoopNoCondition
+// CORE:       [[C1:%.+]] = hw.constant 1 : i32
+// CORE:       [[C4:%.+]] = hw.constant 4 : i32
+// CORE:       [[C0:%.+]] = hw.constant 0 : i32
+// CORE:       cf.br ^[[LOOP:.+]]([[C0]] : i32)
+// CORE:     ^[[LOOP]]([[I:%.+]]: i32):
+// CORE:       [[EQ:%.+]] = comb.icmp eq [[I]], [[C4]] : i32
+// CORE:       cf.cond_br [[EQ]], ^[[EXIT:.+]], ^[[STEP:.+]]
+// CORE:     ^[[STEP]]:
+// CORE:       [[NEXT:%.+]] = comb.add [[I]], [[C1]] : i32
+// CORE:       cf.br ^[[LOOP]]([[NEXT]] : i32)
+// CORE:     ^[[EXIT]]:
+
+module WaitLevelToCore(input bit enable, output bit y);
+  initial begin
+    wait (enable)
+      y = 1'b1;
+  end
+endmodule
+
+// CORE-LABEL: hw.module @WaitLevelToCore
+// CORE:       llhd.process
+// CORE:       cf.br ^[[CHECK:.+]]
+// CORE:     ^[[CHECK]]:
+// CORE:       cf.cond_br %enable, ^[[RESUME:.+]], ^[[WAIT:.+]]
+// CORE:     ^[[WAIT]]:
+// CORE:       llhd.wait{{.*}}(%enable : i1), ^[[AFTER:.+]](%enable : i1)
+// CORE:     ^[[AFTER]]([[BEFORE:%.+]]: i1):
+// CORE:       [[CHANGED:%.+]] = comb.icmp bin ne [[BEFORE]], %enable : i1
+// CORE:       cf.cond_br [[CHANGED]], ^[[CHECK]], ^[[WAIT]]
+// CORE:     ^[[RESUME]]:

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1144,6 +1144,44 @@ moore.module @EmptyWaitEvent(out out : !moore.l32) {
   moore.output %1 : !moore.l32
 }
 
+// CHECK-LABEL: hw.module @WaitLevel
+moore.module @WaitLevel() {
+  // CHECK: [[OBS_A:%.+]] = llhd.prb %a : i1
+  // CHECK: [[OBS_B:%.+]] = llhd.prb %b : i1
+  %a = moore.variable : <i1>
+  %b = moore.variable : <i1>
+
+  // CHECK: llhd.process {
+  // CHECK:   cf.br ^[[CHECK:.+]]
+  // CHECK: ^[[CHECK]]:
+  // CHECK:   [[CHECK_A:%.+]] = llhd.prb %a : i1
+  // CHECK:   [[CHECK_B:%.+]] = llhd.prb %b : i1
+  // CHECK:   [[LEVEL:%.+]] = comb.and [[CHECK_A]], [[CHECK_B]] : i1
+  // CHECK:   cf.cond_br [[LEVEL]], ^[[RESUME:.+]], ^[[WAIT:.+]]
+  // CHECK: ^[[WAIT]]:
+  // CHECK:   [[BEFORE_A:%.+]] = llhd.prb %a : i1
+  // CHECK:   [[BEFORE_B:%.+]] = llhd.prb %b : i1
+  // CHECK:   [[BEFORE:%.+]] = comb.and [[BEFORE_A]], [[BEFORE_B]] : i1
+  // CHECK:   llhd.wait ([[OBS_A]], [[OBS_B]] : i1, i1), ^[[AFTER:.+]]
+  // CHECK: ^[[AFTER]]:
+  // CHECK:   [[AFTER_A:%.+]] = llhd.prb %a : i1
+  // CHECK:   [[AFTER_B:%.+]] = llhd.prb %b : i1
+  // CHECK:   [[AFTER_VAL:%.+]] = comb.and [[AFTER_A]], [[AFTER_B]] : i1
+  // CHECK:   [[CHANGED:%.+]] = comb.icmp bin ne [[BEFORE]], [[AFTER_VAL]] : i1
+  // CHECK:   cf.cond_br [[CHANGED]], ^[[CHECK]], ^[[WAIT]]
+  // CHECK: ^[[RESUME]]:
+  // CHECK:   llhd.halt
+  // CHECK: }
+  moore.procedure initial {
+    moore.wait_level {
+      %0 = moore.read %a : <i1>
+      %1 = moore.read %b : <i1>
+      %2 = moore.and %0, %1 : i1
+      moore.detect_level %2 : i1
+    }
+    moore.return
+  }
+}
 
 // CHECK-LABEL: hw.module @WaitDelay
 moore.module @WaitDelay(in %d: !moore.time) {


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Lower procedural fork-join, immediate assertions in subroutines, and wait-level conditions in ImportVerilog/MooreToCore (IEEE 1800-2023 §16.4, §16.3.1, §12.4.3), previously unsupported. Empty fork blocks are dropped during import; immediate assertions in functions/tasks map to verif.* ops; procedural wait-level conditions lower in MooreToCore to control-flow plus llhd.wait with value observation; open-ended for loops supported through existing cf.br control flow. Standalone across three commits.

Tests: procedural-to-core.sv, basic.mlir.
