### PR TITLE
[MooreToCore] Lower aggregate storage and value materialization

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -174,6 +174,51 @@ static LLVM::LLVMStructType getClassObjectHeaderType(MLIRContext *ctx) {
                              LLVM::LLVMPointerType::get(ctx)});
 }
 
+/// Convert a Moore value type after normal MooreToCore type conversion into a
+/// type suitable for storage in an LLVM class object struct. Moore aggregates
+/// lower to HW aggregate types for value-level operations, but LLVM object
+/// structs cannot contain HW aggregate members directly.
+static Type getClassStorageType(Type type, const DataLayout &layout) {
+  if (LLVM::isCompatibleType(type))
+    return type;
+
+  if (isa<llhd::TimeType>(type))
+    return IntegerType::get(type.getContext(), 64);
+
+  if (auto arrayType = dyn_cast<hw::ArrayType>(type)) {
+    auto elementType = getClassStorageType(arrayType.getElementType(), layout);
+    if (!LLVM::isCompatibleType(elementType))
+      return type;
+    return LLVM::LLVMArrayType::get(elementType, arrayType.getNumElements());
+  }
+
+  if (auto structType = dyn_cast<hw::StructType>(type)) {
+    SmallVector<Type> elements;
+    for (auto field : structType.getElements()) {
+      auto fieldType = getClassStorageType(field.type, layout);
+      if (!LLVM::isCompatibleType(fieldType))
+        return type;
+      elements.push_back(fieldType);
+    }
+    return LLVM::LLVMStructType::getLiteral(type.getContext(), elements);
+  }
+
+  if (auto unionType = dyn_cast<hw::UnionType>(type)) {
+    uint64_t maxByteSize = 0;
+    for (auto field : unionType.getElements()) {
+      auto fieldType = getClassStorageType(field.type, layout);
+      if (!LLVM::isCompatibleType(fieldType))
+        return type;
+      maxByteSize =
+          std::max(maxByteSize, layout.getTypeSize(fieldType).getFixedValue());
+    }
+    return LLVM::LLVMArrayType::get(IntegerType::get(type.getContext(), 8),
+                                    maxByteSize);
+  }
+
+  return type;
+}
+
 static std::string getTypeInfoName(SymbolRefAttr className) {
   return className.getRootReference().str() + "::typeinfo";
 }
@@ -284,6 +329,7 @@ static LogicalResult resolveClassStructBody(ClassDeclOp op,
 
   // Properties in source order.
   unsigned iterator = derivedStartIdx;
+  DataLayout layout(op->getParentOfType<ModuleOp>());
   auto &block = op.getBody().front();
   for (Operation &child : block) {
     if (auto prop = dyn_cast<ClassPropertyDeclOp>(child)) {
@@ -293,6 +339,7 @@ static LogicalResult resolveClassStructBody(ClassDeclOp op,
         return prop.emitOpError()
                << "failed to convert property type " << mooreTy;
 
+      llvmTy = getClassStorageType(llvmTy, layout);
       structBodyMembers.push_back(llvmTy);
 
       // Derived field path: either {i} or {1+i} if base is present.
@@ -956,14 +1003,47 @@ static Value createZeroValue(Type type, Location loc,
 
   // Otherwise try to create a zero integer and bitcast it to the result type.
   int64_t width = hw::getBitWidth(type);
-  if (width == -1)
-    return {};
+  if (width != -1) {
+    // TODO: Once the core dialects support four-valued integers, this code
+    // will additionally need to generate an all-X value for four-valued
+    // variables.
+    Value constZero = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
+    return rewriter.createOrFold<hw::BitcastOp>(loc, type, constZero);
+  }
 
-  // TODO: Once the core dialects support four-valued integers, this code
-  // will additionally need to generate an all-X value for four-valued
-  // variables.
-  Value constZero = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
-  return rewriter.createOrFold<hw::BitcastOp>(loc, type, constZero);
+  if (auto arrayType = dyn_cast<hw::ArrayType>(type)) {
+    Value elementZero =
+        createZeroValue(arrayType.getElementType(), loc, rewriter);
+    if (!elementZero)
+      return {};
+
+    SmallVector<Value> elements(arrayType.getNumElements(), elementZero);
+    return hw::ArrayCreateOp::create(rewriter, loc, arrayType, elements);
+  }
+
+  if (auto structType = dyn_cast<hw::StructType>(type)) {
+    SmallVector<Value> fields;
+    for (auto field : structType.getElements()) {
+      Value fieldZero = createZeroValue(field.type, loc, rewriter);
+      if (!fieldZero)
+        return {};
+      fields.push_back(fieldZero);
+    }
+    return hw::StructCreateOp::create(rewriter, loc, structType, fields);
+  }
+
+  if (auto unionType = dyn_cast<hw::UnionType>(type)) {
+    if (unionType.getElements().empty())
+      return {};
+    auto field = unionType.getElements().front();
+    Value fieldZero = createZeroValue(field.type, loc, rewriter);
+    if (!fieldZero)
+      return {};
+    return hw::UnionCreateOp::create(rewriter, loc, unionType, field.name,
+                                     fieldZero);
+  }
+
+  return {};
 }
 
 struct ClassPropertyRefOpConversion
@@ -1188,11 +1268,12 @@ struct NetOpConversion : public OpConversionPattern<NetOp> {
 
     auto elementType = cast<llhd::RefType>(resultType).getNestedType();
     int64_t width = hw::getBitWidth(elementType);
-    if (width == -1)
+    auto init = width == -1 ? createZeroValue(elementType, loc, rewriter)
+                            : createInitialValue(op.getKind(), rewriter, loc,
+                                                 width, elementType);
+    if (!init)
       return failure();
 
-    auto init =
-        createInitialValue(op.getKind(), rewriter, loc, width, elementType);
     auto signal = rewriter.replaceOpWithNewOp<llhd::SignalOp>(
         op, resultType, op.getNameAttr(), init);
 
@@ -2932,6 +3013,114 @@ struct QueueCmpOpConversion : public OpConversionPattern<QueueCmpOp> {
   }
 };
 
+struct UArrayCmpOpConversion : public OpConversionPattern<UArrayCmpOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  static Value createAggregateEquality(Location loc, Value lhs, Value rhs,
+                                       ConversionPatternRewriter &rewriter) {
+    Type inputType = lhs.getType();
+    if (inputType != rhs.getType())
+      return {};
+
+    int64_t bitWidth = hw::getBitWidth(inputType);
+    if (bitWidth > 0) {
+      auto intType = rewriter.getIntegerType(bitWidth);
+      lhs = rewriter.createOrFold<hw::BitcastOp>(loc, intType, lhs);
+      rhs = rewriter.createOrFold<hw::BitcastOp>(loc, intType, rhs);
+      return comb::ICmpOp::create(rewriter, loc, ICmpPredicate::eq, lhs, rhs);
+    }
+
+    if (isa<LLVM::LLVMPointerType>(inputType))
+      return LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::eq, lhs,
+                                  rhs);
+
+    if (isa<FloatType>(inputType))
+      return arith::CmpFOp::create(rewriter, loc, arith::CmpFPredicate::OEQ,
+                                   lhs, rhs);
+
+    if (isa<llhd::TimeType>(inputType)) {
+      Value lhsInt = llhd::TimeToIntOp::create(rewriter, loc, lhs);
+      Value rhsInt = llhd::TimeToIntOp::create(rewriter, loc, rhs);
+      return comb::ICmpOp::create(rewriter, loc, ICmpPredicate::eq, lhsInt,
+                                  rhsInt);
+    }
+
+    SmallVector<Value> equalities;
+    if (auto arrayType = dyn_cast<hw::ArrayType>(inputType)) {
+      unsigned idxWidth = llvm::Log2_64_Ceil(arrayType.getNumElements());
+      auto idxType = rewriter.getIntegerType(idxWidth);
+      for (size_t index = 0, end = arrayType.getNumElements(); index != end;
+           ++index) {
+        Value idx = hw::ConstantOp::create(rewriter, loc, idxType, index);
+        Value lhsElement = hw::ArrayGetOp::create(rewriter, loc, lhs, idx);
+        Value rhsElement = hw::ArrayGetOp::create(rewriter, loc, rhs, idx);
+        Value elementEqual =
+            createAggregateEquality(loc, lhsElement, rhsElement, rewriter);
+        if (!elementEqual)
+          return {};
+        equalities.push_back(elementEqual);
+      }
+    } else if (auto structType = dyn_cast<hw::StructType>(inputType)) {
+      for (auto field : structType.getElements()) {
+        Value lhsElement =
+            hw::StructExtractOp::create(rewriter, loc, lhs, field.name);
+        Value rhsElement =
+            hw::StructExtractOp::create(rewriter, loc, rhs, field.name);
+        Value elementEqual =
+            createAggregateEquality(loc, lhsElement, rhsElement, rewriter);
+        if (!elementEqual)
+          return {};
+        equalities.push_back(elementEqual);
+      }
+    } else {
+      return {};
+    }
+
+    if (equalities.empty())
+      return hw::ConstantOp::create(rewriter, loc, APInt(1, 1));
+    return rewriter.createOrFold<comb::AndOp>(loc, equalities, true);
+  }
+
+  LogicalResult
+  matchAndRewrite(UArrayCmpOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ICmpPredicate predicate;
+    switch (op.getPredicate()) {
+    case UArrayCmpPredicate::eq:
+      predicate = ICmpPredicate::eq;
+      break;
+    case UArrayCmpPredicate::ne:
+      predicate = ICmpPredicate::ne;
+      break;
+    }
+
+    Type inputType = adaptor.getLhs().getType();
+    int64_t bitWidth = hw::getBitWidth(inputType);
+    if (bitWidth <= 0) {
+      Value equal = createAggregateEquality(op.getLoc(), adaptor.getLhs(),
+                                            adaptor.getRhs(), rewriter);
+      if (!equal)
+        return failure();
+      if (op.getPredicate() == UArrayCmpPredicate::eq) {
+        rewriter.replaceOp(op, equal);
+        return success();
+      }
+      Value trueVal =
+          hw::ConstantOp::create(rewriter, op.getLoc(), APInt(1, 1));
+      rewriter.replaceOpWithNewOp<comb::XorOp>(op, equal, trueVal, true);
+      return success();
+    }
+
+    auto intType = rewriter.getIntegerType(bitWidth);
+    Value lhs = rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), intType,
+                                                     adaptor.getLhs());
+    Value rhs = rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), intType,
+                                                     adaptor.getRhs());
+    rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, predicate, lhs, rhs);
+    return success();
+  }
+};
+
 struct QueueFromUnpackedArrayOpConversion
     : public OpConversionPattern<QueueFromUnpackedArrayOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -3648,6 +3837,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     DynQueueExtractOpConversion,
     QueueResizeOpConversion,
     QueueSetOpConversion,
+    UArrayCmpOpConversion,
     QueueCmpOpConversion,
     QueueFromUnpackedArrayOpConversion,
     QueueConcatOpConversion

--- a/test/Conversion/MooreToCore/aggregate-zero-values.mlir
+++ b/test/Conversion/MooreToCore/aggregate-zero-values.mlir
@@ -1,0 +1,60 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+moore.class.classdecl @AggregateZeroClass {
+}
+
+// CHECK-LABEL: func.func @ArrayOfChandleVariable
+func.func @ArrayOfChandleVariable() {
+  // CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: [[ARRAY:%.+]] = hw.array_create [[NULL]], [[NULL]] : !llvm.ptr
+  // CHECK: llhd.sig [[ARRAY]] : !hw.array<2x!llvm.ptr>
+  %0 = moore.variable : <!moore.uarray<2 x chandle>>
+  return
+}
+
+// CHECK-LABEL: func.func @ArrayOfClassVariable
+func.func @ArrayOfClassVariable() {
+  // CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: [[ARRAY:%.+]] = hw.array_create [[NULL]], [[NULL]] : !llvm.ptr
+  // CHECK: llhd.sig [[ARRAY]] : !hw.array<2x!llvm.ptr>
+  %0 = moore.variable : <!moore.uarray<2 x class<@AggregateZeroClass>>>
+  return
+}
+
+// CHECK-LABEL: func.func @StructOfStringAndChandleVariable
+func.func @StructOfStringAndChandleVariable() {
+  // CHECK: [[STRING:%.+]] = sim.string.literal ""
+  // CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: [[STRUCT:%.+]] = hw.struct_create ([[STRING]], [[NULL]]) : !hw.struct<s: !sim.dstring, h: !llvm.ptr>
+  // CHECK: llhd.sig [[STRUCT]] : !hw.struct<s: !sim.dstring, h: !llvm.ptr>
+  %0 = moore.variable : <!moore.ustruct<{s: string, h: chandle}>>
+  return
+}
+
+// CHECK-LABEL: func.func @ArrayOfRealVariable
+func.func @ArrayOfRealVariable() {
+  // CHECK: [[ZERO:%.+]] = arith.constant 0.000000e+00 : f64
+  // CHECK: [[ARRAY:%.+]] = hw.array_create [[ZERO]], [[ZERO]] : f64
+  // CHECK: llhd.sig [[ARRAY]] : !hw.array<2xf64>
+  %0 = moore.variable : <!moore.uarray<2 x f64>>
+  return
+}
+
+// CHECK-LABEL: func.func @StructOfTimeAndRealVariable
+func.func @StructOfTimeAndRealVariable() {
+  // CHECK: [[TIME:%.+]] = llhd.constant_time <0ns, 0d, 0e>
+  // CHECK: [[REAL:%.+]] = arith.constant 0.000000e+00 : f64
+  // CHECK: [[STRUCT:%.+]] = hw.struct_create ([[TIME]], [[REAL]]) : !hw.struct<t: !llhd.time, r: f64>
+  // CHECK: llhd.sig [[STRUCT]] : !hw.struct<t: !llhd.time, r: f64>
+  %0 = moore.variable : <!moore.ustruct<{t: time, r: f64}>>
+  return
+}
+
+// CHECK-LABEL: func.func @ArrayOfQueueVariable
+func.func @ArrayOfQueueVariable() {
+  // CHECK: [[QUEUE:%.+]] = sim.queue.empty : <i32, 4>
+  // CHECK: [[ARRAY:%.+]] = hw.array_create [[QUEUE]], [[QUEUE]] : !sim.queue<i32, 4>
+  // CHECK: llhd.sig [[ARRAY]] : !hw.array<2x!sim.queue<i32, 4>>
+  %0 = moore.variable : <!moore.uarray<2 x queue<i32, 4>>>
+  return
+}

--- a/test/Conversion/MooreToCore/classes.mlir
+++ b/test/Conversion/MooreToCore/classes.mlir
@@ -159,3 +159,79 @@ moore.class.classdecl @VirtualC {
   moore.class.propertydecl @a : !moore.i32
   moore.class.methoddecl @f : (!moore.class<@VirtualC>) -> ()
 }
+
+/// Check that class properties with aggregate Moore value types lower to
+/// LLVM-compatible class object storage types.
+
+// CHECK-LABEL: func.func private @test_new_aggregate_properties
+// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant({{[0-9]+}} : i64) : i64
+// CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   llvm.getelementptr [[PTR]]{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"AggregateProperties", (struct<(ptr, ptr)>, array<2 x ptr>, struct<(ptr, f64, i8)>, array<8 x i8>)>
+// CHECK:   return
+
+func.func private @test_new_aggregate_properties() {
+  %h = moore.class.new : <@AggregateProperties>
+  return
+}
+
+// CHECK-LABEL: func.func private @test_ref_aggregate_property
+// CHECK-SAME: (%arg0: !llvm.ptr) -> !llhd.ref<!hw.array<2x!llvm.ptr>> {
+// CHECK:   llvm.getelementptr %arg0{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"AggregateProperties", (struct<(ptr, ptr)>, array<2 x ptr>, struct<(ptr, f64, i8)>, array<8 x i8>)>
+// CHECK:   builtin.unrealized_conversion_cast {{.*}} : !llvm.ptr to !llhd.ref<!hw.array<2x!llvm.ptr>>
+// CHECK:   return
+
+func.func private @test_ref_aggregate_property(%arg0: !moore.class<@AggregateProperties>) -> !moore.ref<uarray<2 x chandle>> {
+  %gep = moore.class.property_ref %arg0[@handles] : <@AggregateProperties> -> !moore.ref<uarray<2 x chandle>>
+  return %gep : !moore.ref<uarray<2 x chandle>>
+}
+
+moore.class.classdecl @AggregateProperties {
+  moore.class.propertydecl @handles : !moore.uarray<2 x chandle>
+  moore.class.propertydecl @payload : !moore.ustruct<{h: chandle, r: f64, b: i8}>
+  moore.class.propertydecl @choice : !moore.uunion<{h: chandle, r: f64, b: i8}>
+}
+
+/// Check that time properties and aggregate time leaves use LLVM-compatible
+/// storage while refs still preserve the LLHD time element type.
+
+// CHECK-LABEL: func.func private @test_new_time_aggregate_properties
+// CHECK:   [[SIZE:%.*]] = llvm.mlir.constant({{[0-9]+}} : i64) : i64
+// CHECK:   [[PTR:%.*]] = call @malloc([[SIZE]]) : (i64) -> !llvm.ptr
+// CHECK:   llvm.getelementptr [[PTR]]{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"TimeAggregateProperties", (struct<(ptr, ptr)>, i64, array<2 x i64>, struct<(i64, i8)>, array<8 x i8>)>
+// CHECK:   return
+
+func.func private @test_new_time_aggregate_properties() {
+  %h = moore.class.new : <@TimeAggregateProperties>
+  return
+}
+
+// CHECK-LABEL: func.func private @test_read_time_property
+// CHECK-SAME: (%arg0: !llvm.ptr) -> !llhd.time {
+// CHECK:   [[GEP:%.*]] = llvm.getelementptr %arg0{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"TimeAggregateProperties", (struct<(ptr, ptr)>, i64, array<2 x i64>, struct<(i64, i8)>, array<8 x i8>)>
+// CHECK:   [[REF:%.*]] = builtin.unrealized_conversion_cast [[GEP]] : !llvm.ptr to !llhd.ref<!llhd.time>
+// CHECK:   [[VALUE:%.*]] = llhd.prb [[REF]] : !llhd.time
+// CHECK:   return [[VALUE]] : !llhd.time
+
+func.func private @test_read_time_property(%arg0: !moore.class<@TimeAggregateProperties>) -> !moore.time {
+  %ref = moore.class.property_ref %arg0[@stamp] : <@TimeAggregateProperties> -> !moore.ref<time>
+  %value = moore.read %ref : <!moore.time>
+  return %value : !moore.time
+}
+
+// CHECK-LABEL: func.func private @test_ref_time_array_property
+// CHECK-SAME: (%arg0: !llvm.ptr) -> !llhd.ref<!hw.array<2x!llhd.time>> {
+// CHECK:   llvm.getelementptr %arg0{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"TimeAggregateProperties", (struct<(ptr, ptr)>, i64, array<2 x i64>, struct<(i64, i8)>, array<8 x i8>)>
+// CHECK:   builtin.unrealized_conversion_cast {{.*}} : !llvm.ptr to !llhd.ref<!hw.array<2x!llhd.time>>
+// CHECK:   return
+
+func.func private @test_ref_time_array_property(%arg0: !moore.class<@TimeAggregateProperties>) -> !moore.ref<uarray<2 x time>> {
+  %ref = moore.class.property_ref %arg0[@stamps] : <@TimeAggregateProperties> -> !moore.ref<uarray<2 x time>>
+  return %ref : !moore.ref<uarray<2 x time>>
+}
+
+moore.class.classdecl @TimeAggregateProperties {
+  moore.class.propertydecl @stamp : !moore.time
+  moore.class.propertydecl @stamps : !moore.uarray<2 x time>
+  moore.class.propertydecl @payload : !moore.ustruct<{stamp: time, bits: i8}>
+  moore.class.propertydecl @choice : !moore.uunion<{stamp: time, bits: i64}>
+}

--- a/test/Conversion/MooreToCore/non-bitwidth-net-values.mlir
+++ b/test/Conversion/MooreToCore/non-bitwidth-net-values.mlir
@@ -1,0 +1,120 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+moore.class.classdecl @NetClass {
+}
+
+// CHECK-LABEL: func.func @StringWire
+func.func @StringWire() {
+  // CHECK: %[[EMPTY:.*]] = sim.string.literal ""
+  // CHECK: llhd.sig %[[EMPTY]] : !sim.dstring
+  %net = moore.net wire : <!moore.string>
+  return
+}
+
+// CHECK-LABEL: func.func @ChandleWire
+func.func @ChandleWire() {
+  // CHECK: %[[NULL:.*]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: llhd.sig %[[NULL]] : !llvm.ptr
+  %net = moore.net wire : <!moore.chandle>
+  return
+}
+
+// CHECK-LABEL: func.func @ClassWire
+func.func @ClassWire() {
+  // CHECK: %[[NULL:.*]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: llhd.sig %[[NULL]] : !llvm.ptr
+  %net = moore.net wire : <!moore.class<@NetClass>>
+  return
+}
+
+// CHECK-LABEL: func.func @StringWireWithAssignment
+// CHECK-SAME: (%arg0: !sim.dstring)
+func.func @StringWireWithAssignment(%value: !moore.string) {
+  // CHECK: %[[EMPTY:.*]] = sim.string.literal ""
+  // CHECK: %[[SIG:.*]] = llhd.sig %[[EMPTY]] : !sim.dstring
+  %net = moore.net wire %value : <!moore.string>
+  // CHECK: %[[DELAY:.*]] = llhd.constant_time <0ns, 0d, 1e>
+  // CHECK: llhd.drv %[[SIG]], %arg0 after %[[DELAY]] : !sim.dstring
+  return
+}
+
+// CHECK-LABEL: func.func @ClassWireWithAssignment
+// CHECK-SAME: (%arg0: !llvm.ptr)
+func.func @ClassWireWithAssignment(%value: !moore.class<@NetClass>) {
+  // CHECK: %[[NULL:.*]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: %[[SIG:.*]] = llhd.sig %[[NULL]] : !llvm.ptr
+  %net = moore.net wire %value : <!moore.class<@NetClass>>
+  // CHECK: %[[DELAY:.*]] = llhd.constant_time <0ns, 0d, 1e>
+  // CHECK: llhd.drv %[[SIG]], %arg0 after %[[DELAY]] : !llvm.ptr
+  return
+}
+
+// CHECK-LABEL: func.func @QueueWire
+func.func @QueueWire() {
+  // CHECK: %[[EMPTY:.*]] = sim.queue.empty : <i32, 4>
+  // CHECK: llhd.sig %[[EMPTY]] : !sim.queue<i32, 4>
+  %net = moore.net wire : <!moore.queue<i32, 4>>
+  return
+}
+
+// CHECK-LABEL: func.func @QueueClassWire
+func.func @QueueClassWire() {
+  // CHECK: %[[EMPTY:.*]] = sim.queue.empty : <!llvm.ptr, 4>
+  // CHECK: llhd.sig %[[EMPTY]] : !sim.queue<!llvm.ptr, 4>
+  %net = moore.net wire : <!moore.queue<class<@NetClass>, 4>>
+  return
+}
+
+// CHECK-LABEL: func.func @QueueRealWire
+func.func @QueueRealWire() {
+  // CHECK: %[[EMPTY:.*]] = sim.queue.empty : <f64, 4>
+  // CHECK: llhd.sig %[[EMPTY]] : !sim.queue<f64, 4>
+  %net = moore.net wire : <!moore.queue<f64, 4>>
+  return
+}
+
+// CHECK-LABEL: func.func @QueueTimeWire
+func.func @QueueTimeWire() {
+  // CHECK: %[[EMPTY:.*]] = sim.queue.empty : <!llhd.time, 4>
+  // CHECK: llhd.sig %[[EMPTY]] : !sim.queue<!llhd.time, 4>
+  %net = moore.net wire : <!moore.queue<time, 4>>
+  return
+}
+
+// CHECK-LABEL: func.func @RealWire
+func.func @RealWire() {
+  // CHECK: %[[ZERO:.*]] = arith.constant 0.000000e+00 : f64
+  // CHECK: llhd.sig %[[ZERO]] : f64
+  %net = moore.net wire : <!moore.f64>
+  return
+}
+
+// CHECK-LABEL: func.func @TimeWire
+func.func @TimeWire() {
+  // CHECK: %[[ZERO:.*]] = llhd.constant_time <0ns, 0d, 0e>
+  // CHECK: llhd.sig %[[ZERO]] : !llhd.time
+  %net = moore.net wire : <!moore.time>
+  return
+}
+
+// CHECK-LABEL: func.func @RealWireWithAssignment
+// CHECK-SAME: (%arg0: f64)
+func.func @RealWireWithAssignment(%value: !moore.f64) {
+  // CHECK: %[[ZERO:.*]] = arith.constant 0.000000e+00 : f64
+  // CHECK: %[[SIG:.*]] = llhd.sig %[[ZERO]] : f64
+  %net = moore.net wire %value : <!moore.f64>
+  // CHECK: %[[DELAY:.*]] = llhd.constant_time <0ns, 0d, 1e>
+  // CHECK: llhd.drv %[[SIG]], %arg0 after %[[DELAY]] : f64
+  return
+}
+
+// CHECK-LABEL: func.func @TimeWireWithAssignment
+// CHECK-SAME: (%arg0: !llhd.time)
+func.func @TimeWireWithAssignment(%value: !moore.time) {
+  // CHECK: %[[ZERO:.*]] = llhd.constant_time <0ns, 0d, 0e>
+  // CHECK: %[[SIG:.*]] = llhd.sig %[[ZERO]] : !llhd.time
+  %net = moore.net wire %value : <!moore.time>
+  // CHECK: %[[DELAY:.*]] = llhd.constant_time <0ns, 0d, 1e>
+  // CHECK: llhd.drv %[[SIG]], %arg0 after %[[DELAY]] : !llhd.time
+  return
+}

--- a/test/Conversion/MooreToCore/uarray-cmp.mlir
+++ b/test/Conversion/MooreToCore/uarray-cmp.mlir
@@ -1,0 +1,152 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+moore.class.classdecl @UArrayCmpClass {
+}
+
+// CHECK-LABEL: func.func @UnpackedArrayCmp
+// CHECK-SAME: (%arg0: !hw.array<2xi3>, %arg1: !hw.array<2xi3>) -> (i1, i1)
+func.func @UnpackedArrayCmp(%lhs: !moore.uarray<2 x i3>, %rhs: !moore.uarray<2 x i3>) -> (!moore.i1, !moore.i1) {
+  // CHECK: [[LHS:%.+]] = hw.bitcast %arg0 : (!hw.array<2xi3>) -> i6
+  // CHECK: [[RHS:%.+]] = hw.bitcast %arg1 : (!hw.array<2xi3>) -> i6
+  // CHECK: [[EQ:%.+]] = comb.icmp eq [[LHS]], [[RHS]] : i6
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x i3> -> !moore.i1
+  // CHECK: [[LHS2:%.+]] = hw.bitcast %arg0 : (!hw.array<2xi3>) -> i6
+  // CHECK: [[RHS2:%.+]] = hw.bitcast %arg1 : (!hw.array<2xi3>) -> i6
+  // CHECK: [[NE:%.+]] = comb.icmp ne [[LHS2]], [[RHS2]] : i6
+  %ne = moore.uarray_cmp ne %lhs, %rhs : !moore.uarray<2 x i3> -> !moore.i1
+  // CHECK: return [[EQ]], [[NE]] : i1, i1
+  return %eq, %ne : !moore.i1, !moore.i1
+}
+
+// CHECK-LABEL: func.func @UnpackedArrayOfChandleCmp
+// CHECK-SAME: (%arg0: !hw.array<2x!llvm.ptr>, %arg1: !hw.array<2x!llvm.ptr>) -> (i1, i1)
+func.func @UnpackedArrayOfChandleCmp(%lhs: !moore.uarray<2 x chandle>, %rhs: !moore.uarray<2 x chandle>) -> (!moore.i1, !moore.i1) {
+  // CHECK: [[LHS0:%.+]] = hw.array_get %arg0[{{%.+}}] : !hw.array<2x!llvm.ptr>, i1
+  // CHECK: [[RHS0:%.+]] = hw.array_get %arg1[{{%.+}}] : !hw.array<2x!llvm.ptr>, i1
+  // CHECK: [[EQ0:%.+]] = llvm.icmp "eq" [[LHS0]], [[RHS0]] : !llvm.ptr
+  // CHECK: [[LHS1:%.+]] = hw.array_get %arg0[{{%.+}}] : !hw.array<2x!llvm.ptr>, i1
+  // CHECK: [[RHS1:%.+]] = hw.array_get %arg1[{{%.+}}] : !hw.array<2x!llvm.ptr>, i1
+  // CHECK: [[EQ1:%.+]] = llvm.icmp "eq" [[LHS1]], [[RHS1]] : !llvm.ptr
+  // CHECK: [[EQ:%.+]] = comb.and bin [[EQ0]], [[EQ1]] : i1
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x chandle> -> !moore.i1
+  // CHECK: [[NE_EQ0:%.+]] = llvm.icmp "eq" {{%.+}}, {{%.+}} : !llvm.ptr
+  // CHECK: [[NE_EQ1:%.+]] = llvm.icmp "eq" {{%.+}}, {{%.+}} : !llvm.ptr
+  // CHECK: [[NE_EQUAL:%.+]] = comb.and bin [[NE_EQ0]], [[NE_EQ1]] : i1
+  // CHECK: [[TRUE:%.+]] = hw.constant true
+  // CHECK: [[NE:%.+]] = comb.xor bin [[NE_EQUAL]], [[TRUE]] : i1
+  %ne = moore.uarray_cmp ne %lhs, %rhs : !moore.uarray<2 x chandle> -> !moore.i1
+  // CHECK: return [[EQ]], [[NE]] : i1, i1
+  return %eq, %ne : !moore.i1, !moore.i1
+}
+
+// CHECK-LABEL: func.func @UnpackedArrayOfClassCmp
+// CHECK-SAME: (%arg0: !hw.array<2x!llvm.ptr>, %arg1: !hw.array<2x!llvm.ptr>) -> (i1, i1)
+func.func @UnpackedArrayOfClassCmp(%lhs: !moore.uarray<2 x class<@UArrayCmpClass>>, %rhs: !moore.uarray<2 x class<@UArrayCmpClass>>) -> (!moore.i1, !moore.i1) {
+  // CHECK: [[LHS0:%.+]] = hw.array_get %arg0[{{%.+}}] : !hw.array<2x!llvm.ptr>, i1
+  // CHECK: [[RHS0:%.+]] = hw.array_get %arg1[{{%.+}}] : !hw.array<2x!llvm.ptr>, i1
+  // CHECK: [[EQ0:%.+]] = llvm.icmp "eq" [[LHS0]], [[RHS0]] : !llvm.ptr
+  // CHECK: [[LHS1:%.+]] = hw.array_get %arg0[{{%.+}}] : !hw.array<2x!llvm.ptr>, i1
+  // CHECK: [[RHS1:%.+]] = hw.array_get %arg1[{{%.+}}] : !hw.array<2x!llvm.ptr>, i1
+  // CHECK: [[EQ1:%.+]] = llvm.icmp "eq" [[LHS1]], [[RHS1]] : !llvm.ptr
+  // CHECK: [[EQ:%.+]] = comb.and bin [[EQ0]], [[EQ1]] : i1
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x class<@UArrayCmpClass>> -> !moore.i1
+  // CHECK: [[NE_EQ0:%.+]] = llvm.icmp "eq" {{%.+}}, {{%.+}} : !llvm.ptr
+  // CHECK: [[NE_EQ1:%.+]] = llvm.icmp "eq" {{%.+}}, {{%.+}} : !llvm.ptr
+  // CHECK: [[NE_EQUAL:%.+]] = comb.and bin [[NE_EQ0]], [[NE_EQ1]] : i1
+  // CHECK: [[TRUE:%.+]] = hw.constant true
+  // CHECK: [[NE:%.+]] = comb.xor bin [[NE_EQUAL]], [[TRUE]] : i1
+  %ne = moore.uarray_cmp ne %lhs, %rhs : !moore.uarray<2 x class<@UArrayCmpClass>> -> !moore.i1
+  // CHECK: return [[EQ]], [[NE]] : i1, i1
+  return %eq, %ne : !moore.i1, !moore.i1
+}
+
+// CHECK-LABEL: func.func @UnpackedArrayOfRealCmp
+// CHECK-SAME: (%arg0: !hw.array<2xf64>, %arg1: !hw.array<2xf64>) -> (i1, i1)
+func.func @UnpackedArrayOfRealCmp(%lhs: !moore.uarray<2 x f64>, %rhs: !moore.uarray<2 x f64>) -> (!moore.i1, !moore.i1) {
+  // CHECK: [[LHS0:%.+]] = hw.array_get %arg0[{{%.+}}] : !hw.array<2xf64>, i1
+  // CHECK: [[RHS0:%.+]] = hw.array_get %arg1[{{%.+}}] : !hw.array<2xf64>, i1
+  // CHECK: [[EQ0:%.+]] = arith.cmpf oeq, [[LHS0]], [[RHS0]] : f64
+  // CHECK: [[LHS1:%.+]] = hw.array_get %arg0[{{%.+}}] : !hw.array<2xf64>, i1
+  // CHECK: [[RHS1:%.+]] = hw.array_get %arg1[{{%.+}}] : !hw.array<2xf64>, i1
+  // CHECK: [[EQ1:%.+]] = arith.cmpf oeq, [[LHS1]], [[RHS1]] : f64
+  // CHECK: [[EQ:%.+]] = comb.and bin [[EQ0]], [[EQ1]] : i1
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x f64> -> !moore.i1
+  // CHECK: [[NE_EQ0:%.+]] = arith.cmpf oeq, {{%.+}}, {{%.+}} : f64
+  // CHECK: [[NE_EQ1:%.+]] = arith.cmpf oeq, {{%.+}}, {{%.+}} : f64
+  // CHECK: [[NE_EQUAL:%.+]] = comb.and bin [[NE_EQ0]], [[NE_EQ1]] : i1
+  // CHECK: [[TRUE:%.+]] = hw.constant true
+  // CHECK: [[NE:%.+]] = comb.xor bin [[NE_EQUAL]], [[TRUE]] : i1
+  %ne = moore.uarray_cmp ne %lhs, %rhs : !moore.uarray<2 x f64> -> !moore.i1
+  // CHECK: return [[EQ]], [[NE]] : i1, i1
+  return %eq, %ne : !moore.i1, !moore.i1
+}
+
+// CHECK-LABEL: func.func @UnpackedArrayOfTimeCmp
+// CHECK-SAME: (%arg0: !hw.array<2x!llhd.time>, %arg1: !hw.array<2x!llhd.time>) -> (i1, i1)
+func.func @UnpackedArrayOfTimeCmp(%lhs: !moore.uarray<2 x time>, %rhs: !moore.uarray<2 x time>) -> (!moore.i1, !moore.i1) {
+  // CHECK: [[LHS0:%.+]] = hw.array_get %arg0[{{%.+}}] : !hw.array<2x!llhd.time>, i1
+  // CHECK: [[RHS0:%.+]] = hw.array_get %arg1[{{%.+}}] : !hw.array<2x!llhd.time>, i1
+  // CHECK: [[LHS0_INT:%.+]] = llhd.time_to_int [[LHS0]]
+  // CHECK: [[RHS0_INT:%.+]] = llhd.time_to_int [[RHS0]]
+  // CHECK: [[EQ0:%.+]] = comb.icmp eq [[LHS0_INT]], [[RHS0_INT]] : i64
+  // CHECK: [[LHS1:%.+]] = hw.array_get %arg0[{{%.+}}] : !hw.array<2x!llhd.time>, i1
+  // CHECK: [[RHS1:%.+]] = hw.array_get %arg1[{{%.+}}] : !hw.array<2x!llhd.time>, i1
+  // CHECK: [[LHS1_INT:%.+]] = llhd.time_to_int [[LHS1]]
+  // CHECK: [[RHS1_INT:%.+]] = llhd.time_to_int [[RHS1]]
+  // CHECK: [[EQ1:%.+]] = comb.icmp eq [[LHS1_INT]], [[RHS1_INT]] : i64
+  // CHECK: [[EQ:%.+]] = comb.and bin [[EQ0]], [[EQ1]] : i1
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x time> -> !moore.i1
+  // CHECK: [[NE_EQ0:%.+]] = comb.icmp eq {{%.+}}, {{%.+}} : i64
+  // CHECK: [[NE_EQ1:%.+]] = comb.icmp eq {{%.+}}, {{%.+}} : i64
+  // CHECK: [[NE_EQUAL:%.+]] = comb.and bin [[NE_EQ0]], [[NE_EQ1]] : i1
+  // CHECK: [[TRUE:%.+]] = hw.constant true
+  // CHECK: [[NE:%.+]] = comb.xor bin [[NE_EQUAL]], [[TRUE]] : i1
+  %ne = moore.uarray_cmp ne %lhs, %rhs : !moore.uarray<2 x time> -> !moore.i1
+  // CHECK: return [[EQ]], [[NE]] : i1, i1
+  return %eq, %ne : !moore.i1, !moore.i1
+}
+
+// CHECK-LABEL: func.func @UnpackedArrayOfUnpackedStructWithChandleCmp
+// CHECK-SAME: (%arg0: !hw.array<2xstruct<h: !llvm.ptr, bits: i3>>, %arg1: !hw.array<2xstruct<h: !llvm.ptr, bits: i3>>) -> i1
+func.func @UnpackedArrayOfUnpackedStructWithChandleCmp(%lhs: !moore.uarray<2 x ustruct<{h: chandle, bits: i3}>>, %rhs: !moore.uarray<2 x ustruct<{h: chandle, bits: i3}>>) -> !moore.i1 {
+  // CHECK: hw.struct_extract {{%.+}}["h"] : !hw.struct<h: !llvm.ptr, bits: i3>
+  // CHECK: [[HANDLE_EQ:%.+]] = llvm.icmp "eq" {{%.+}}, {{%.+}} : !llvm.ptr
+  // CHECK: hw.struct_extract {{%.+}}["bits"] : !hw.struct<h: !llvm.ptr, bits: i3>
+  // CHECK: [[BITS_EQ:%.+]] = comb.icmp eq {{%.+}}, {{%.+}} : i3
+  // CHECK: comb.and bin [[HANDLE_EQ]], [[BITS_EQ]] : i1
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x ustruct<{h: chandle, bits: i3}>> -> !moore.i1
+  return %eq : !moore.i1
+}
+
+// CHECK-LABEL: func.func @UnpackedArrayOfStructCmp
+// CHECK-SAME: (%arg0: !hw.array<2xstruct<a: i3, b: i2>>, %arg1: !hw.array<2xstruct<a: i3, b: i2>>) -> i1
+func.func @UnpackedArrayOfStructCmp(%lhs: !moore.uarray<2 x struct<{a: i3, b: i2}>>, %rhs: !moore.uarray<2 x struct<{a: i3, b: i2}>>) -> !moore.i1 {
+  // CHECK: [[LHS:%.+]] = hw.bitcast %arg0 : (!hw.array<2xstruct<a: i3, b: i2>>) -> i10
+  // CHECK: [[RHS:%.+]] = hw.bitcast %arg1 : (!hw.array<2xstruct<a: i3, b: i2>>) -> i10
+  // CHECK: [[EQ:%.+]] = comb.icmp eq [[LHS]], [[RHS]] : i10
+  // CHECK: return [[EQ]] : i1
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x struct<{a: i3, b: i2}>> -> !moore.i1
+  return %eq : !moore.i1
+}
+
+// CHECK-LABEL: func.func @UnpackedArrayOfUnpackedStructCmp
+// CHECK-SAME: (%arg0: !hw.array<2xstruct<a: i3, b: i2>>, %arg1: !hw.array<2xstruct<a: i3, b: i2>>) -> i1
+func.func @UnpackedArrayOfUnpackedStructCmp(%lhs: !moore.uarray<2 x ustruct<{a: i3, b: i2}>>, %rhs: !moore.uarray<2 x ustruct<{a: i3, b: i2}>>) -> !moore.i1 {
+  // CHECK: [[LHS:%.+]] = hw.bitcast %arg0 : (!hw.array<2xstruct<a: i3, b: i2>>) -> i10
+  // CHECK: [[RHS:%.+]] = hw.bitcast %arg1 : (!hw.array<2xstruct<a: i3, b: i2>>) -> i10
+  // CHECK: [[EQ:%.+]] = comb.icmp eq [[LHS]], [[RHS]] : i10
+  // CHECK: return [[EQ]] : i1
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x ustruct<{a: i3, b: i2}>> -> !moore.i1
+  return %eq : !moore.i1
+}
+
+// CHECK-LABEL: func.func @NestedUnpackedArrayCmp
+// CHECK-SAME: (%arg0: !hw.array<2xarray<2xi3>>, %arg1: !hw.array<2xarray<2xi3>>) -> i1
+func.func @NestedUnpackedArrayCmp(%lhs: !moore.uarray<2 x uarray<2 x i3>>, %rhs: !moore.uarray<2 x uarray<2 x i3>>) -> !moore.i1 {
+  // CHECK: [[LHS:%.+]] = hw.bitcast %arg0 : (!hw.array<2xarray<2xi3>>) -> i12
+  // CHECK: [[RHS:%.+]] = hw.bitcast %arg1 : (!hw.array<2xarray<2xi3>>) -> i12
+  // CHECK: [[EQ:%.+]] = comb.icmp eq [[LHS]], [[RHS]] : i12
+  // CHECK: return [[EQ]] : i1
+  %eq = moore.uarray_cmp eq %lhs, %rhs : !moore.uarray<2 x uarray<2 x i3>> -> !moore.i1
+  return %eq : !moore.i1
+}

--- a/test/Conversion/MooreToCore/union-zero-values.mlir
+++ b/test/Conversion/MooreToCore/union-zero-values.mlir
@@ -1,0 +1,67 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+moore.class.classdecl @UnionZeroClass {
+}
+
+// CHECK-LABEL: func.func @UnionStringVariable
+func.func @UnionStringVariable() {
+  // CHECK: [[STRING:%.+]] = sim.string.literal ""
+  // CHECK: [[UNION:%.+]] = hw.union_create "s", [[STRING]] : !hw.union<s: !sim.dstring, bits: i32>
+  // CHECK: llhd.sig [[UNION]] : !hw.union<s: !sim.dstring, bits: i32>
+  %0 = moore.variable : <!moore.uunion<{s: string, bits: i32}>>
+  return
+}
+
+// CHECK-LABEL: func.func @UnionChandleVariable
+func.func @UnionChandleVariable() {
+  // CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: [[UNION:%.+]] = hw.union_create "h", [[NULL]] : !hw.union<h: !llvm.ptr, bits: i32>
+  // CHECK: llhd.sig [[UNION]] : !hw.union<h: !llvm.ptr, bits: i32>
+  %0 = moore.variable : <!moore.uunion<{h: chandle, bits: i32}>>
+  return
+}
+
+// CHECK-LABEL: func.func @UnionClassVariable
+func.func @UnionClassVariable() {
+  // CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+  // CHECK: [[UNION:%.+]] = hw.union_create "c", [[NULL]] : !hw.union<c: !llvm.ptr, bits: i32>
+  // CHECK: llhd.sig [[UNION]] : !hw.union<c: !llvm.ptr, bits: i32>
+  %0 = moore.variable : <!moore.uunion<{c: class<@UnionZeroClass>, bits: i32}>>
+  return
+}
+
+// CHECK-LABEL: func.func @UnionIntegerFirstVariable
+func.func @UnionIntegerFirstVariable() {
+  // CHECK: [[ZERO:%.+]] = hw.constant 0 : i32
+  // CHECK: [[UNION:%.+]] = hw.union_create "bits", [[ZERO]] : !hw.union<bits: i32, s: !sim.dstring>
+  // CHECK: llhd.sig [[UNION]] : !hw.union<bits: i32, s: !sim.dstring>
+  %0 = moore.variable : <!moore.uunion<{bits: i32, s: string}>>
+  return
+}
+
+// CHECK-LABEL: func.func @UnionRealVariable
+func.func @UnionRealVariable() {
+  // CHECK: [[ZERO:%.+]] = arith.constant 0.000000e+00 : f64
+  // CHECK: [[UNION:%.+]] = hw.union_create "r", [[ZERO]] : !hw.union<r: f64, bits: i32>
+  // CHECK: llhd.sig [[UNION]] : !hw.union<r: f64, bits: i32>
+  %0 = moore.variable : <!moore.uunion<{r: f64, bits: i32}>>
+  return
+}
+
+// CHECK-LABEL: func.func @UnionTimeVariable
+func.func @UnionTimeVariable() {
+  // CHECK: [[TIME:%.+]] = llhd.constant_time <0ns, 0d, 0e>
+  // CHECK: [[UNION:%.+]] = hw.union_create "t", [[TIME]] : !hw.union<t: !llhd.time, bits: i32>
+  // CHECK: llhd.sig [[UNION]] : !hw.union<t: !llhd.time, bits: i32>
+  %0 = moore.variable : <!moore.uunion<{t: time, bits: i32}>>
+  return
+}
+
+// CHECK-LABEL: func.func @UnionQueueVariable
+func.func @UnionQueueVariable() {
+  // CHECK: [[QUEUE:%.+]] = sim.queue.empty : <i32, 4>
+  // CHECK: [[UNION:%.+]] = hw.union_create "q", [[QUEUE]] : !hw.union<q: !sim.queue<i32, 4>, bits: i32>
+  // CHECK: llhd.sig [[UNION]] : !hw.union<q: !sim.queue<i32, 4>, bits: i32>
+  %0 = moore.variable : <!moore.uunion<{q: queue<i32, 4>, bits: i32}>>
+  return
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Lower aggregate variable initialization and zero-value materialization for unpacked arrays/structs/unions containing non-bitwidth types in MooreToCore (IEEE 1800-2023 §4.8, §6.20). Previously dropped; materializes zero values for chandle, class handles, string, real, time, queue contained in aggregates via hw.array_create, hw.struct_create, appropriate zero constants. Maps to existing lowering patterns. Standalone.

Tests: aggregate-zero-values.mlir, classes.mlir, non-bitwidth-net-values.mlir, uarray-cmp.mlir, union-zero-values.mlir.
