### PR TITLE
[MooreToCore] Lower packed aggregate extraction forms

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1347,6 +1347,47 @@ struct ReplicateOpConversion : public OpConversionPattern<ReplicateOp> {
   }
 };
 
+static FailureOr<Value> extractBitsFromInteger(OpBuilder &builder, Location loc,
+                                               Value input, int32_t low,
+                                               Type resultType) {
+  auto intType = dyn_cast<IntegerType>(input.getType());
+  if (!intType)
+    return failure();
+
+  int32_t inputWidth = intType.getWidth();
+  int32_t resultWidth = hw::getBitWidth(resultType);
+  if (resultWidth < 0)
+    return failure();
+
+  int32_t high = low + resultWidth;
+
+  SmallVector<Value> toConcat;
+  if (low < 0)
+    toConcat.push_back(hw::ConstantOp::create(
+        builder, loc, APInt(std::min(-low, resultWidth), 0)));
+
+  if (low < inputWidth && high > 0) {
+    int32_t lowIdx = std::max(low, 0);
+    Value middle = builder.createOrFold<comb::ExtractOp>(
+        loc,
+        builder.getIntegerType(
+            std::min(resultWidth, std::min(high, inputWidth) - lowIdx)),
+        input, lowIdx);
+    toConcat.push_back(middle);
+  }
+
+  int32_t diff = high - inputWidth;
+  if (diff > 0) {
+    Value val = hw::ConstantOp::create(builder, loc, APInt(diff, 0));
+    toConcat.push_back(val);
+  }
+
+  Value concat = builder.createOrFold<comb::ConcatOp>(loc, toConcat);
+  if (concat.getType() == resultType)
+    return concat;
+  return builder.createOrFold<hw::BitcastOp>(loc, resultType, concat);
+}
+
 struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -1356,39 +1397,21 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
     // TODO: return X if the domain is four-valued for out-of-bounds accesses
     // once we support four-valued lowering
     Type resultType = typeConverter->convertType(op.getResult().getType());
-    Type inputType = adaptor.getInput().getType();
+    Value input = adaptor.getInput();
+    Type inputType = input.getType();
     int32_t low = adaptor.getLowBit();
 
+    if (isa<llhd::TimeType>(inputType)) {
+      input = llhd::TimeToIntOp::create(rewriter, op.getLoc(), input);
+      inputType = input.getType();
+    }
+
     if (isa<IntegerType>(inputType)) {
-      int32_t inputWidth = inputType.getIntOrFloatBitWidth();
-      int32_t resultWidth = hw::getBitWidth(resultType);
-      int32_t high = low + resultWidth;
-
-      SmallVector<Value> toConcat;
-      if (low < 0)
-        toConcat.push_back(hw::ConstantOp::create(
-            rewriter, op.getLoc(), APInt(std::min(-low, resultWidth), 0)));
-
-      if (low < inputWidth && high > 0) {
-        int32_t lowIdx = std::max(low, 0);
-        Value middle = rewriter.createOrFold<comb::ExtractOp>(
-            op.getLoc(),
-            rewriter.getIntegerType(
-                std::min(resultWidth, std::min(high, inputWidth) - lowIdx)),
-            adaptor.getInput(), lowIdx);
-        toConcat.push_back(middle);
-      }
-
-      int32_t diff = high - inputWidth;
-      if (diff > 0) {
-        Value val =
-            hw::ConstantOp::create(rewriter, op.getLoc(), APInt(diff, 0));
-        toConcat.push_back(val);
-      }
-
-      Value concat =
-          rewriter.createOrFold<comb::ConcatOp>(op.getLoc(), toConcat);
-      rewriter.replaceOp(op, concat);
+      auto result =
+          extractBitsFromInteger(rewriter, op.getLoc(), input, low, resultType);
+      if (failed(result))
+        return failure();
+      rewriter.replaceOp(op, *result);
       return success();
     }
 
@@ -1446,6 +1469,48 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
         return success();
       }
 
+      if (arrTy.getElementType() != resultType) {
+        int32_t inputWidth = hw::getBitWidth(inputType);
+        int32_t resultWidth = hw::getBitWidth(resultType);
+        if (inputWidth < 0 || resultWidth < 0)
+          return failure();
+
+        Value input = rewriter.createOrFold<hw::BitcastOp>(
+            op.getLoc(), rewriter.getIntegerType(inputWidth),
+            adaptor.getInput());
+        int32_t high = low + resultWidth;
+
+        SmallVector<Value> toConcat;
+        if (low < 0)
+          toConcat.push_back(hw::ConstantOp::create(
+              rewriter, op.getLoc(), APInt(std::min(-low, resultWidth), 0)));
+
+        if (low < inputWidth && high > 0) {
+          int32_t lowIdx = std::max(low, 0);
+          Value middle = rewriter.createOrFold<comb::ExtractOp>(
+              op.getLoc(),
+              rewriter.getIntegerType(
+                  std::min(resultWidth, std::min(high, inputWidth) - lowIdx)),
+              input, lowIdx);
+          toConcat.push_back(middle);
+        }
+
+        int32_t diff = high - inputWidth;
+        if (diff > 0) {
+          Value val =
+              hw::ConstantOp::create(rewriter, op.getLoc(), APInt(diff, 0));
+          toConcat.push_back(val);
+        }
+
+        Value concat =
+            rewriter.createOrFold<comb::ConcatOp>(op.getLoc(), toConcat);
+        if (concat.getType() != resultType)
+          concat = rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), resultType,
+                                                        concat);
+        rewriter.replaceOp(op, concat);
+        return success();
+      }
+
       // Otherwise, it has to be the array's element type
       if (low < 0 || low >= inputWidth) {
         int32_t bw = hw::getBitWidth(resultType);
@@ -1466,12 +1531,175 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
       return success();
     }
 
+    int64_t inputWidth = hw::getBitWidth(inputType);
+    if (inputWidth > 0) {
+      Value input = rewriter.createOrFold<hw::BitcastOp>(
+          op.getLoc(), rewriter.getIntegerType(inputWidth), adaptor.getInput());
+      auto result =
+          extractBitsFromInteger(rewriter, op.getLoc(), input, low, resultType);
+      if (failed(result))
+        return failure();
+      rewriter.replaceOp(op, *result);
+      return success();
+    }
+
     return failure();
   }
 };
 
 struct ExtractRefOpConversion : public OpConversionPattern<ExtractRefOp> {
   using OpConversionPattern::OpConversionPattern;
+
+  static FailureOr<Value> extractRefFromAggregateBits(OpBuilder &builder,
+                                                      Location loc, Value input,
+                                                      int32_t low,
+                                                      Type resultType) {
+    if (low < 0)
+      return failure();
+
+    auto inputRefType = dyn_cast<llhd::RefType>(input.getType());
+    auto resultRefType = dyn_cast<llhd::RefType>(resultType);
+    if (!inputRefType || !resultRefType)
+      return failure();
+
+    Type inputType = inputRefType.getNestedType();
+    Type resultNestedType = resultRefType.getNestedType();
+    if (inputType == resultNestedType && low == 0)
+      return input;
+
+    int64_t resultWidth = hw::getBitWidth(resultNestedType);
+    if (resultWidth < 0)
+      return failure();
+
+    auto extractRefFromPackedBits = [&]() -> FailureOr<Value> {
+      int64_t inputWidth = hw::getBitWidth(inputType);
+      if (inputWidth < 0 || low + resultWidth > inputWidth)
+        return failure();
+
+      auto packedRefType =
+          llhd::RefType::get(builder.getIntegerType(inputWidth));
+      Value packedRef = input;
+      if (input.getType() != packedRefType) {
+        packedRef = UnrealizedConversionCastOp::create(builder, loc,
+                                                       packedRefType, input)
+                        .getResult(0);
+      }
+
+      Value lowBit = hw::ConstantOp::create(
+          builder, loc, builder.getIntegerType(llvm::Log2_64_Ceil(inputWidth)),
+          low);
+      auto resultIntRefType =
+          llhd::RefType::get(builder.getIntegerType(resultWidth));
+      Type extractResultType =
+          isa<IntegerType>(resultNestedType) ? resultType : resultIntRefType;
+      Value extracted = llhd::SigExtractOp::create(
+                            builder, loc, extractResultType, packedRef, lowBit)
+                            .getResult();
+      if (extractResultType == resultType)
+        return extracted;
+
+      return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                                extracted)
+          .getResult(0);
+    };
+
+    if (auto inputIntType = dyn_cast<IntegerType>(inputType)) {
+      if (low + resultWidth > inputIntType.getWidth())
+        return failure();
+
+      Value lowBit = hw::ConstantOp::create(
+          builder, loc,
+          builder.getIntegerType(llvm::Log2_64_Ceil(inputIntType.getWidth())),
+          low);
+      auto resultIntRefType =
+          llhd::RefType::get(builder.getIntegerType(resultWidth));
+      Type extractResultType =
+          isa<IntegerType>(resultNestedType) ? resultType : resultIntRefType;
+      Value extracted = llhd::SigExtractOp::create(
+                            builder, loc, extractResultType, input, lowBit)
+                            .getResult();
+      if (extractResultType == resultType)
+        return extracted;
+
+      return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                                extracted)
+          .getResult(0);
+    }
+
+    if (auto arrayType = dyn_cast<hw::ArrayType>(inputType)) {
+      int64_t elementWidth = hw::getBitWidth(arrayType.getElementType());
+      int64_t arrayWidth =
+          elementWidth * static_cast<int64_t>(arrayType.getNumElements());
+      if (elementWidth <= 0 || low + resultWidth > arrayWidth)
+        return failure();
+
+      int64_t elementOffset = low % elementWidth;
+      if (elementOffset + resultWidth > elementWidth)
+        return extractRefFromPackedBits();
+
+      Value index =
+          hw::ConstantOp::create(builder, loc,
+                                 builder.getIntegerType(llvm::Log2_64_Ceil(
+                                     arrayType.getNumElements())),
+                                 low / elementWidth);
+      auto elementRefType = llhd::RefType::get(arrayType.getElementType());
+      Value elementRef = llhd::SigArrayGetOp::create(
+          builder, loc, elementRefType, input, index);
+      return extractRefFromAggregateBits(builder, loc, elementRef,
+                                         elementOffset, resultType);
+    }
+
+    if (auto structType = dyn_cast<hw::StructType>(inputType)) {
+      int64_t totalWidth = hw::getBitWidth(structType);
+      if (totalWidth < 0 || low + resultWidth > totalWidth)
+        return failure();
+
+      int64_t consumedWidth = 0;
+      for (auto field : structType.getElements()) {
+        int64_t fieldWidth = hw::getBitWidth(field.type);
+        if (fieldWidth < 0)
+          return failure();
+
+        int64_t fieldLow = totalWidth - consumedWidth - fieldWidth;
+        if (low >= fieldLow && low + resultWidth <= fieldLow + fieldWidth) {
+          auto fieldRefType = llhd::RefType::get(field.type);
+          Value fieldRef = llhd::SigStructExtractOp::create(
+              builder, loc, fieldRefType, input, field.name);
+          return extractRefFromAggregateBits(builder, loc, fieldRef,
+                                             low - fieldLow, resultType);
+        }
+
+        consumedWidth += fieldWidth;
+      }
+
+      return extractRefFromPackedBits();
+    }
+
+    if (auto unionType = dyn_cast<hw::UnionType>(inputType)) {
+      int64_t totalWidth = hw::getBitWidth(unionType);
+      if (totalWidth < 0 || low + resultWidth > totalWidth)
+        return failure();
+
+      for (auto field : unionType.getElements()) {
+        int64_t fieldWidth = hw::getBitWidth(field.type);
+        if (fieldWidth < 0)
+          return failure();
+
+        int64_t fieldLow = field.offset;
+        if (low >= fieldLow && low + resultWidth <= fieldLow + fieldWidth) {
+          auto fieldRefType = llhd::RefType::get(field.type);
+          Value fieldRef = llhd::SigStructExtractOp::create(
+              builder, loc, fieldRefType, input, field.name);
+          return extractRefFromAggregateBits(builder, loc, fieldRef,
+                                             low - fieldLow, resultType);
+        }
+      }
+
+      return extractRefFromPackedBits();
+    }
+
+    return failure();
+  }
 
   LogicalResult
   matchAndRewrite(ExtractRefOp op, OpAdaptor adaptor,
@@ -1480,7 +1708,6 @@ struct ExtractRefOpConversion : public OpConversionPattern<ExtractRefOp> {
     Type resultType = typeConverter->convertType(op.getResult().getType());
     Type inputType =
         cast<llhd::RefType>(adaptor.getInput().getType()).getNestedType();
-
     if (auto intType = dyn_cast<IntegerType>(inputType)) {
       int64_t width = hw::getBitWidth(inputType);
       if (width == -1)
@@ -1496,22 +1723,47 @@ struct ExtractRefOpConversion : public OpConversionPattern<ExtractRefOp> {
     }
 
     if (auto arrType = dyn_cast<hw::ArrayType>(inputType)) {
-      Value lowBit = hw::ConstantOp::create(
-          rewriter, op.getLoc(),
-          rewriter.getIntegerType(llvm::Log2_64_Ceil(arrType.getNumElements())),
-          adaptor.getLowBit());
+      auto resultNestedType = cast<llhd::RefType>(resultType).getNestedType();
 
       // If the result type is not the same as the array's element type, then
       // it has to be a slice.
-      if (arrType.getElementType() !=
-          cast<llhd::RefType>(resultType).getNestedType()) {
+      if (arrType.getElementType() != resultNestedType) {
+        if (!isa<hw::ArrayType>(resultNestedType)) {
+          auto result = extractRefFromAggregateBits(
+              rewriter, op.getLoc(), adaptor.getInput(), adaptor.getLowBit(),
+              resultType);
+          if (failed(result))
+            return failure();
+          rewriter.replaceOp(op, *result);
+          return success();
+        }
+
+        Value lowBit =
+            hw::ConstantOp::create(rewriter, op.getLoc(),
+                                   rewriter.getIntegerType(llvm::Log2_64_Ceil(
+                                       arrType.getNumElements())),
+                                   adaptor.getLowBit());
         rewriter.replaceOpWithNewOp<llhd::SigArraySliceOp>(
             op, resultType, adaptor.getInput(), lowBit);
         return success();
       }
 
+      Value lowBit = hw::ConstantOp::create(
+          rewriter, op.getLoc(),
+          rewriter.getIntegerType(llvm::Log2_64_Ceil(arrType.getNumElements())),
+          adaptor.getLowBit());
       rewriter.replaceOpWithNewOp<llhd::SigArrayGetOp>(op, adaptor.getInput(),
                                                        lowBit);
+      return success();
+    }
+
+    if (isa<hw::StructType, hw::UnionType>(inputType)) {
+      auto result =
+          extractRefFromAggregateBits(rewriter, op.getLoc(), adaptor.getInput(),
+                                      adaptor.getLowBit(), resultType);
+      if (failed(result))
+        return failure();
+      rewriter.replaceOp(op, *result);
       return success();
     }
 
@@ -1526,15 +1778,28 @@ struct DynExtractOpConversion : public OpConversionPattern<DynExtractOp> {
   matchAndRewrite(DynExtractOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = typeConverter->convertType(op.getResult().getType());
-    Type inputType = adaptor.getInput().getType();
+    Value input = adaptor.getInput();
+    Type inputType = input.getType();
+
+    if (isa<llhd::TimeType>(inputType)) {
+      input = llhd::TimeToIntOp::create(rewriter, op.getLoc(), input);
+      inputType = input.getType();
+    }
 
     if (auto intType = dyn_cast<IntegerType>(inputType)) {
       Value amount = adjustIntegerWidth(rewriter, adaptor.getLowBit(),
                                         intType.getWidth(), op->getLoc());
-      Value value = comb::ShrUOp::create(rewriter, op->getLoc(),
-                                         adaptor.getInput(), amount);
+      Value value = comb::ShrUOp::create(rewriter, op->getLoc(), input, amount);
 
-      rewriter.replaceOpWithNewOp<comb::ExtractOp>(op, resultType, value, 0);
+      int64_t resultWidth = hw::getBitWidth(resultType);
+      if (resultWidth < 0)
+        return failure();
+      Value result = rewriter.createOrFold<comb::ExtractOp>(
+          op.getLoc(), rewriter.getIntegerType(resultWidth), value, 0);
+      if (result.getType() != resultType)
+        result = rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), resultType,
+                                                      result);
+      rewriter.replaceOp(op, result);
       return success();
     }
 
@@ -1543,15 +1808,54 @@ struct DynExtractOpConversion : public OpConversionPattern<DynExtractOp> {
       Value idx = adjustIntegerWidth(rewriter, adaptor.getLowBit(), idxWidth,
                                      op->getLoc());
 
-      bool isSingleElementExtract = arrType.getElementType() == resultType;
-
-      if (isSingleElementExtract)
+      if (arrType.getElementType() == resultType) {
         rewriter.replaceOpWithNewOp<hw::ArrayGetOp>(op, adaptor.getInput(),
                                                     idx);
-      else
+        return success();
+      }
+
+      if (isa<hw::ArrayType>(resultType)) {
         rewriter.replaceOpWithNewOp<hw::ArraySliceOp>(op, resultType,
                                                       adaptor.getInput(), idx);
+        return success();
+      }
 
+      int64_t inputWidth = hw::getBitWidth(inputType);
+      int64_t resultWidth = hw::getBitWidth(resultType);
+      if (inputWidth < 0 || resultWidth < 0)
+        return failure();
+
+      Value input = rewriter.createOrFold<hw::BitcastOp>(
+          op.getLoc(), rewriter.getIntegerType(inputWidth), adaptor.getInput());
+      Value amount = adjustIntegerWidth(rewriter, adaptor.getLowBit(),
+                                        inputWidth, op->getLoc());
+      Value shifted =
+          comb::ShrUOp::create(rewriter, op->getLoc(), input, amount);
+      Value result = rewriter.createOrFold<comb::ExtractOp>(
+          op.getLoc(), rewriter.getIntegerType(resultWidth), shifted, 0);
+      if (result.getType() != resultType)
+        result = rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), resultType,
+                                                      result);
+      rewriter.replaceOp(op, result);
+
+      return success();
+    }
+
+    int64_t inputWidth = hw::getBitWidth(inputType);
+    int64_t resultWidth = hw::getBitWidth(resultType);
+    if (inputWidth >= 0 && resultWidth >= 0) {
+      Value packedInput = rewriter.createOrFold<hw::BitcastOp>(
+          op.getLoc(), rewriter.getIntegerType(inputWidth), input);
+      Value amount = adjustIntegerWidth(rewriter, adaptor.getLowBit(),
+                                        inputWidth, op->getLoc());
+      Value shifted =
+          comb::ShrUOp::create(rewriter, op->getLoc(), packedInput, amount);
+      Value result = rewriter.createOrFold<comb::ExtractOp>(
+          op.getLoc(), rewriter.getIntegerType(resultWidth), shifted, 0);
+      if (result.getType() != resultType)
+        result = rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), resultType,
+                                                      result);
+      rewriter.replaceOp(op, result);
       return success();
     }
 
@@ -1569,38 +1873,91 @@ struct DynExtractRefOpConversion : public OpConversionPattern<DynExtractRefOp> {
     Type resultType = typeConverter->convertType(op.getResult().getType());
     Type inputType =
         cast<llhd::RefType>(adaptor.getInput().getType()).getNestedType();
+    auto resultNestedType = cast<llhd::RefType>(resultType).getNestedType();
+
+    auto extractRefFromPackedBits = [&]() -> LogicalResult {
+      int64_t inputWidth = hw::getBitWidth(inputType);
+      int64_t resultWidth = hw::getBitWidth(resultNestedType);
+      if (inputWidth < 0 || resultWidth < 0 || resultWidth > inputWidth)
+        return failure();
+
+      auto packedRefType =
+          llhd::RefType::get(rewriter.getIntegerType(inputWidth));
+      Value packedRef = adaptor.getInput();
+      if (adaptor.getInput().getType() != packedRefType) {
+        packedRef = UnrealizedConversionCastOp::create(rewriter, op.getLoc(),
+                                                       packedRefType,
+                                                       adaptor.getInput())
+                        .getResult(0);
+      }
+
+      Value lowBit =
+          adjustIntegerWidth(rewriter, adaptor.getLowBit(),
+                             llvm::Log2_64_Ceil(inputWidth), op->getLoc());
+      auto resultIntRefType =
+          llhd::RefType::get(rewriter.getIntegerType(resultWidth));
+      Type extractResultType =
+          isa<IntegerType>(resultNestedType) ? resultType : resultIntRefType;
+      Value extracted = llhd::SigExtractOp::create(
+          rewriter, op.getLoc(), extractResultType, packedRef, lowBit);
+      if (extractResultType != resultType) {
+        extracted = UnrealizedConversionCastOp::create(rewriter, op.getLoc(),
+                                                       resultType, extracted)
+                        .getResult(0);
+      }
+      rewriter.replaceOp(op, extracted);
+      return success();
+    };
 
     if (auto intType = dyn_cast<IntegerType>(inputType)) {
       int64_t width = hw::getBitWidth(inputType);
-      if (width == -1)
+      int64_t resultWidth = hw::getBitWidth(resultNestedType);
+      if (width == -1 || resultWidth < 0 || resultWidth > width)
         return failure();
 
       Value amount =
           adjustIntegerWidth(rewriter, adaptor.getLowBit(),
                              llvm::Log2_64_Ceil(width), op->getLoc());
-      rewriter.replaceOpWithNewOp<llhd::SigExtractOp>(
-          op, resultType, adaptor.getInput(), amount);
+      auto resultIntRefType =
+          llhd::RefType::get(rewriter.getIntegerType(resultWidth));
+      Type extractResultType =
+          isa<IntegerType>(resultNestedType) ? resultType : resultIntRefType;
+      Value extracted = llhd::SigExtractOp::create(
+          rewriter, op.getLoc(), extractResultType, adaptor.getInput(), amount);
+      if (extractResultType != resultType) {
+        extracted = UnrealizedConversionCastOp::create(rewriter, op.getLoc(),
+                                                       resultType, extracted)
+                        .getResult(0);
+      }
+      rewriter.replaceOp(op, extracted);
       return success();
     }
 
     if (auto arrType = dyn_cast<hw::ArrayType>(inputType)) {
-      Value idx = adjustIntegerWidth(
-          rewriter, adaptor.getLowBit(),
-          llvm::Log2_64_Ceil(arrType.getNumElements()), op->getLoc());
-
-      auto resultNestedType = cast<llhd::RefType>(resultType).getNestedType();
       bool isSingleElementExtract =
           arrType.getElementType() == resultNestedType;
 
-      if (isSingleElementExtract)
+      if (isSingleElementExtract) {
+        Value idx = adjustIntegerWidth(
+            rewriter, adaptor.getLowBit(),
+            llvm::Log2_64_Ceil(arrType.getNumElements()), op->getLoc());
         rewriter.replaceOpWithNewOp<llhd::SigArrayGetOp>(op, adaptor.getInput(),
                                                          idx);
-      else
+      } else if (isa<hw::ArrayType>(resultNestedType)) {
+        Value idx = adjustIntegerWidth(
+            rewriter, adaptor.getLowBit(),
+            llvm::Log2_64_Ceil(arrType.getNumElements()), op->getLoc());
         rewriter.replaceOpWithNewOp<llhd::SigArraySliceOp>(
             op, resultType, adaptor.getInput(), idx);
+      } else {
+        return extractRefFromPackedBits();
+      }
 
       return success();
     }
+
+    if (isa<hw::StructType, hw::UnionType>(inputType))
+      return extractRefFromPackedBits();
 
     return failure();
   }
@@ -1640,6 +1997,19 @@ struct StructExtractOpConversion : public OpConversionPattern<StructExtractOp> {
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<hw::StructExtractOp>(
         op, adaptor.getInput(), adaptor.getFieldNameAttr());
+    return success();
+  }
+};
+
+struct StructInjectOpConversion : public OpConversionPattern<StructInjectOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StructInjectOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<hw::StructInjectOp>(op, adaptor.getInput(),
+                                                    adaptor.getFieldNameAttr(),
+                                                    adaptor.getNewValue());
     return success();
   }
 };
@@ -1918,6 +2288,20 @@ struct ConversionOpConversion : public OpConversionPattern<ConversionOp> {
       op.emitError("conversion result type is not currently supported");
       return failure();
     }
+
+    if (auto inputRefType =
+            dyn_cast<llhd::RefType>(adaptor.getInput().getType())) {
+      if (auto resultRefType = dyn_cast<llhd::RefType>(resultType)) {
+        int64_t inputBw = hw::getBitWidth(inputRefType.getNestedType());
+        int64_t resultBw = hw::getBitWidth(resultRefType.getNestedType());
+        if (inputBw >= 0 && inputBw == resultBw) {
+          rewriter.replaceOpWithNewOp<UnrealizedConversionCastOp>(
+              op, resultType, adaptor.getInput());
+          return success();
+        }
+      }
+    }
+
     int64_t inputBw = hw::getBitWidth(adaptor.getInput().getType());
     int64_t resultBw = hw::getBitWidth(resultType);
     if (inputBw == -1 || resultBw == -1) {
@@ -1957,6 +2341,16 @@ struct BitcastConversion : public OpConversionPattern<SourceOp> {
   matchAndRewrite(SourceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto type = typeConverter->convertType(op.getResult().getType());
+    if (isa<llhd::TimeType>(adaptor.getInput().getType()) &&
+        type.isInteger(64)) {
+      rewriter.replaceOpWithNewOp<llhd::TimeToIntOp>(op, adaptor.getInput());
+      return success();
+    }
+    if (isa<llhd::TimeType>(type) &&
+        adaptor.getInput().getType().isInteger(64)) {
+      rewriter.replaceOpWithNewOp<llhd::IntToTimeOp>(op, adaptor.getInput());
+      return success();
+    }
     if (type == adaptor.getInput().getType())
       rewriter.replaceOp(op, adaptor.getInput());
     else
@@ -3508,6 +3902,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     StructExtractRefOpConversion,
     ExtractRefOpConversion,
     StructCreateOpConversion,
+    StructInjectOpConversion,
     UnionCreateOpConversion,
     UnionExtractOpConversion,
     UnionExtractRefOpConversion,

--- a/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
+++ b/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
@@ -21,6 +21,8 @@
 #include "circt/Dialect/Moore/MooreOps.h"
 #include "circt/Dialect/Moore/MoorePasses.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include <limits>
+#include <optional>
 
 namespace circt {
 namespace moore {
@@ -50,6 +52,97 @@ static void collectOperands(Value operand, SmallVectorImpl<Value> &operands,
   } else
     operands.push_back(operand);
 }
+
+static void collectLeafRefs(Value operand, SmallVectorImpl<Value> &operands) {
+  if (auto concatRefOp = operand.getDefiningOp<ConcatRefOp>()) {
+    for (auto nestedOperand : concatRefOp.getValues())
+      collectLeafRefs(nestedOperand, operands);
+  } else {
+    operands.push_back(operand);
+  }
+}
+
+static std::optional<uint64_t> getRefBitWidth(Value value) {
+  auto refType = dyn_cast<RefType>(value.getType());
+  if (!refType)
+    return std::nullopt;
+  auto bitSize = refType.getNestedType().getBitSize();
+  if (!bitSize)
+    return std::nullopt;
+  return *bitSize;
+}
+
+static void eraseDeadConcatRefs(Value value,
+                                ConversionPatternRewriter &rewriter) {
+  auto concatRefOp = value.getDefiningOp<ConcatRefOp>();
+  if (!concatRefOp || !concatRefOp->use_empty())
+    return;
+
+  SmallVector<Value> nestedOperands(concatRefOp.getValues().begin(),
+                                    concatRefOp.getValues().end());
+  rewriter.eraseOp(concatRefOp);
+  for (auto nestedOperand : nestedOperands)
+    eraseDeadConcatRefs(nestedOperand, rewriter);
+}
+
+struct ConcatRefExtractLowering : public OpConversionPattern<ExtractRefOp> {
+  using OpConversionPattern<ExtractRefOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ExtractRefOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto concatRefOp = op.getInput().getDefiningOp<ConcatRefOp>();
+    if (!concatRefOp)
+      return failure();
+
+    auto concatWidth = getRefBitWidth(concatRefOp.getResult());
+    auto resultWidth = getRefBitWidth(op.getResult());
+    if (!concatWidth || !resultWidth)
+      return failure();
+
+    SmallVector<Value> operands;
+    collectLeafRefs(op.getInput(), operands);
+
+    uint64_t lowBit = op.getLowBit();
+    uint64_t highBit = lowBit + *resultWidth;
+    uint64_t cursor = *concatWidth;
+    for (auto operand : operands) {
+      auto operandWidth = getRefBitWidth(operand);
+      if (!operandWidth || *operandWidth > cursor)
+        return failure();
+
+      cursor -= *operandWidth;
+      if (lowBit < cursor || highBit > cursor + *operandWidth)
+        continue;
+
+      Value replacement = operand;
+      uint64_t relativeLowBit = lowBit - cursor;
+      if (relativeLowBit != 0 || *resultWidth != *operandWidth ||
+          operand.getType() != op.getResult().getType()) {
+        if (relativeLowBit > std::numeric_limits<uint32_t>::max())
+          return failure();
+        replacement = ExtractRefOp::create(
+            rewriter, op.getLoc(), op.getResult().getType(), operand,
+            static_cast<uint32_t>(relativeLowBit));
+      }
+
+      bool eraseConcatRef = concatRefOp->hasOneUse();
+      SmallVector<Value> nestedOperands;
+      if (eraseConcatRef) {
+        nestedOperands.append(concatRefOp.getValues().begin(),
+                              concatRefOp.getValues().end());
+        rewriter.eraseOp(concatRefOp);
+      }
+
+      rewriter.replaceOp(op, replacement);
+      for (auto nestedOperand : nestedOperands)
+        eraseDeadConcatRefs(nestedOperand, rewriter);
+      return success();
+    }
+
+    return failure();
+  }
+};
 
 template <typename OpTy>
 struct ConcatRefLowering : public OpConversionPattern<OpTy> {
@@ -141,12 +234,17 @@ void SimplifyRefsPass::runOnOperation() {
                                NonBlockingAssignOp>([](auto op) {
     return !op->getOperand(0).template getDefiningOp<ConcatRefOp>();
   });
+  target.addDynamicallyLegalOp<ExtractRefOp>([](ExtractRefOp op) {
+    return !op.getInput().template getDefiningOp<ConcatRefOp>();
+  });
 
   target.addLegalDialect<MooreDialect>();
   RewritePatternSet concatRefPatterns(&context);
-  concatRefPatterns.add<ConcatRefLowering<ContinuousAssignOp>,
-                        ConcatRefLowering<BlockingAssignOp>,
-                        ConcatRefLowering<NonBlockingAssignOp>>(&context);
+  concatRefPatterns
+      .add<ConcatRefLowering<ContinuousAssignOp>,
+           ConcatRefLowering<BlockingAssignOp>,
+           ConcatRefLowering<NonBlockingAssignOp>, ConcatRefExtractLowering>(
+          &context);
 
   if (failed(applyPartialConversion(getOperation(), target,
                                     std::move(concatRefPatterns)))) {

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1510,6 +1510,31 @@ func.func @TimeConversion(%arg0: !moore.l64, %arg1: !moore.time) -> (!moore.time
   return %0, %1 : !moore.time, !moore.l64
 }
 
+// CHECK-LABEL: func.func @TimePackedCasts
+func.func @TimePackedCasts(%arg0: !moore.time, %arg1: !moore.l64) -> (!moore.l64, !moore.time) {
+  // CHECK-NEXT: [[TMP0:%.+]] = llhd.time_to_int %arg0
+  %0 = moore.packed_to_sbv %arg0 : time
+  // CHECK-NEXT: [[TMP1:%.+]] = llhd.int_to_time %arg1
+  %1 = moore.sbv_to_packed %arg1 : time
+  // CHECK-NEXT: return [[TMP0]], [[TMP1]]
+  return %0, %1 : !moore.l64, !moore.time
+}
+
+// CHECK-LABEL: func.func @TimeExtract
+func.func @TimeExtract(%arg0: !moore.time, %arg1: !moore.i32) -> (!moore.i4, !moore.i1) {
+  // CHECK-NEXT: [[TMP0:%.+]] = llhd.time_to_int %arg0
+  // CHECK-NEXT: [[TMP1:%.+]] = comb.extract [[TMP0]] from 8 : (i64) -> i4
+  %0 = moore.extract %arg0 from 8 : !moore.time -> !moore.i4
+  // CHECK-NEXT: [[TMP2:%.+]] = llhd.time_to_int %arg0
+  // CHECK-NEXT: [[ZERO:%.+]] = hw.constant 0 : i32
+  // CHECK-NEXT: [[TMP3:%.+]] = comb.concat [[ZERO]], %arg1 : i32, i32
+  // CHECK-NEXT: [[TMP4:%.+]] = comb.shru [[TMP2]], [[TMP3]] : i64
+  // CHECK-NEXT: [[TMP5:%.+]] = comb.extract [[TMP4]] from 0 : (i64) -> i1
+  %1 = moore.dyn_extract %arg0 from %arg1 : !moore.time, !moore.i32 -> !moore.i1
+  // CHECK-NEXT: return [[TMP1]], [[TMP5]]
+  return %0, %1 : !moore.i4, !moore.i1
+}
+
 // CHECK-LABEL: func.func @IntToStringConversion
 func.func @IntToStringConversion(%arg0: !moore.i45) {
   // CHECK-NEXT: sim.string.int_to_string %arg0 : i45

--- a/test/Conversion/MooreToCore/dyn-extract-packed-array.mlir
+++ b/test/Conversion/MooreToCore/dyn-extract-packed-array.mlir
@@ -1,0 +1,42 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @DynExtractPackedArrayToInt
+// CHECK-SAME: (%arg0: !hw.array<2xi3>, %arg1: i3) -> i2
+func.func @DynExtractPackedArrayToInt(
+    %arg0: !moore.array<2 x i3>,
+    %idx: !moore.i3
+) -> !moore.i2 {
+  // CHECK: [[BITS:%.+]] = hw.bitcast %arg0 : (!hw.array<2xi3>) -> i6
+  // CHECK: [[SHIFTED:%.+]] = comb.shru [[BITS]], {{%.+}} : i6
+  // CHECK: [[EXTRACT:%.+]] = comb.extract [[SHIFTED]] from 0 : (i6) -> i2
+  // CHECK: return [[EXTRACT]] : i2
+  %0 = moore.dyn_extract %arg0 from %idx : !moore.array<2 x i3>, !moore.i3 -> !moore.i2
+  return %0 : !moore.i2
+}
+
+// CHECK-LABEL: func.func @DynExtractPackedArrayToStruct
+// CHECK-SAME: (%arg0: !hw.array<2xi3>, %arg1: i3) -> !hw.struct<b: i2>
+func.func @DynExtractPackedArrayToStruct(
+    %arg0: !moore.array<2 x i3>,
+    %idx: !moore.i3
+) -> !moore.struct<{b: i2}> {
+  // CHECK: [[BITS:%.+]] = hw.bitcast %arg0 : (!hw.array<2xi3>) -> i6
+  // CHECK: [[SHIFTED:%.+]] = comb.shru [[BITS]], {{%.+}} : i6
+  // CHECK: [[EXTRACT:%.+]] = comb.extract [[SHIFTED]] from 0 : (i6) -> i2
+  // CHECK: [[RESULT:%.+]] = hw.bitcast [[EXTRACT]] : (i2) -> !hw.struct<b: i2>
+  // CHECK: return [[RESULT]] : !hw.struct<b: i2>
+  %0 = moore.dyn_extract %arg0 from %idx : !moore.array<2 x i3>, !moore.i3 -> !moore.struct<{b: i2}>
+  return %0 : !moore.struct<{b: i2}>
+}
+
+// CHECK-LABEL: func.func @DynExtractPackedArrayElement
+// CHECK-SAME: (%arg0: !hw.array<2xi3>, %arg1: i3) -> i3
+func.func @DynExtractPackedArrayElement(
+    %arg0: !moore.array<2 x i3>,
+    %idx: !moore.i3
+) -> !moore.i3 {
+  // CHECK: [[VALUE:%.+]] = hw.array_get %arg0{{\[}}{{%.+}}{{\]}} : !hw.array<2xi3>, i1
+  // CHECK: return [[VALUE]] : i3
+  %0 = moore.dyn_extract %arg0 from %idx : !moore.array<2 x i3>, !moore.i3 -> !moore.i3
+  return %0 : !moore.i3
+}

--- a/test/Conversion/MooreToCore/dyn-extract-packed-struct.mlir
+++ b/test/Conversion/MooreToCore/dyn-extract-packed-struct.mlir
@@ -1,0 +1,49 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @DynExtractPackedStructBit
+  // CHECK-SAME: (%[[INPUT:.+]]: !hw.struct<a: i3, b: i2>, %[[IDX:.+]]: i3) -> i1
+  func.func @DynExtractPackedStructBit(
+    %input: !moore.struct<{a: i3, b: i2}>,
+    %idx: !moore.i3
+  ) -> !moore.i1 {
+    // CHECK: %[[BITS:.+]] = hw.bitcast %[[INPUT]] : (!hw.struct<a: i3, b: i2>) -> i5
+    // CHECK: %[[AMOUNT:.+]] = comb.concat {{%.+}}, %[[IDX]] : i2, i3
+    // CHECK: %[[SHIFTED:.+]] = comb.shru %[[BITS]], %[[AMOUNT]] : i5
+    // CHECK: %[[RESULT:.+]] = comb.extract %[[SHIFTED]] from 0 : (i5) -> i1
+    // CHECK: return %[[RESULT]] : i1
+    %result = moore.dyn_extract %input from %idx : !moore.struct<{a: i3, b: i2}>, !moore.i3 -> !moore.i1
+    return %result : !moore.i1
+  }
+
+  // CHECK-LABEL: func.func @DynExtractPackedStructSlice
+  // CHECK-SAME: (%[[INPUT:.+]]: !hw.struct<a: i3, b: i2>, %[[IDX:.+]]: i3) -> i2
+  func.func @DynExtractPackedStructSlice(
+    %input: !moore.struct<{a: i3, b: i2}>,
+    %idx: !moore.i3
+  ) -> !moore.i2 {
+    // CHECK: %[[BITS:.+]] = hw.bitcast %[[INPUT]] : (!hw.struct<a: i3, b: i2>) -> i5
+    // CHECK: %[[AMOUNT:.+]] = comb.concat {{%.+}}, %[[IDX]] : i2, i3
+    // CHECK: %[[SHIFTED:.+]] = comb.shru %[[BITS]], %[[AMOUNT]] : i5
+    // CHECK: %[[RESULT:.+]] = comb.extract %[[SHIFTED]] from 0 : (i5) -> i2
+    // CHECK: return %[[RESULT]] : i2
+    %result = moore.dyn_extract %input from %idx : !moore.struct<{a: i3, b: i2}>, !moore.i3 -> !moore.i2
+    return %result : !moore.i2
+  }
+
+  // CHECK-LABEL: func.func @DynExtractPackedStructToStruct
+  // CHECK-SAME: (%[[INPUT:.+]]: !hw.struct<a: i3, b: i2>, %[[IDX:.+]]: i3) -> !hw.struct<b: i2>
+  func.func @DynExtractPackedStructToStruct(
+    %input: !moore.struct<{a: i3, b: i2}>,
+    %idx: !moore.i3
+  ) -> !moore.struct<{b: i2}> {
+    // CHECK: %[[BITS:.+]] = hw.bitcast %[[INPUT]] : (!hw.struct<a: i3, b: i2>) -> i5
+    // CHECK: %[[AMOUNT:.+]] = comb.concat {{%.+}}, %[[IDX]] : i2, i3
+    // CHECK: %[[SHIFTED:.+]] = comb.shru %[[BITS]], %[[AMOUNT]] : i5
+    // CHECK: %[[EXTRACT:.+]] = comb.extract %[[SHIFTED]] from 0 : (i5) -> i2
+    // CHECK: %[[RESULT:.+]] = hw.bitcast %[[EXTRACT]] : (i2) -> !hw.struct<b: i2>
+    // CHECK: return %[[RESULT]] : !hw.struct<b: i2>
+    %result = moore.dyn_extract %input from %idx : !moore.struct<{a: i3, b: i2}>, !moore.i3 -> !moore.struct<{b: i2}>
+    return %result : !moore.struct<{b: i2}>
+  }
+}

--- a/test/Conversion/MooreToCore/extract-packed-aggregate.mlir
+++ b/test/Conversion/MooreToCore/extract-packed-aggregate.mlir
@@ -1,0 +1,66 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @ExtractPackedStruct
+// CHECK-SAME: (%arg0: !hw.struct<a: i3, b: i2>) -> i2
+func.func @ExtractPackedStruct(%arg0: !moore.struct<{a: i3, b: i2}>) -> !moore.i2 {
+  // CHECK: [[BITS:%.+]] = hw.bitcast %arg0 : (!hw.struct<a: i3, b: i2>) -> i5
+  // CHECK: [[EXTRACT:%.+]] = comb.extract [[BITS]] from 1 : (i5) -> i2
+  // CHECK: return [[EXTRACT]] : i2
+  %0 = moore.extract %arg0 from 1 : !moore.struct<{a: i3, b: i2}> -> !moore.i2
+  return %0 : !moore.i2
+}
+
+// CHECK-LABEL: func.func @DynExtractPackedStruct
+// CHECK-SAME: (%arg0: !hw.struct<a: i3, b: i2>, %arg1: i3) -> i2
+func.func @DynExtractPackedStruct(%arg0: !moore.struct<{a: i3, b: i2}>, %idx: !moore.i3) -> !moore.i2 {
+  // CHECK: [[BITS:%.+]] = hw.bitcast %arg0 : (!hw.struct<a: i3, b: i2>) -> i5
+  // CHECK: [[AMOUNT:%.+]] = comb.concat {{%.+}}, %arg1 : i2, i3
+  // CHECK: [[SHIFTED:%.+]] = comb.shru [[BITS]], [[AMOUNT]] : i5
+  // CHECK: [[EXTRACT:%.+]] = comb.extract [[SHIFTED]] from 0 : (i5) -> i2
+  // CHECK: return [[EXTRACT]] : i2
+  %0 = moore.dyn_extract %arg0 from %idx : !moore.struct<{a: i3, b: i2}>, !moore.i3 -> !moore.i2
+  return %0 : !moore.i2
+}
+
+// CHECK-LABEL: func.func @ExtractPackedUnion
+// CHECK-SAME: (%arg0: !hw.union<a: i3, b: i5>) -> i2
+func.func @ExtractPackedUnion(%arg0: !moore.union<{a: i3, b: i5}>) -> !moore.i2 {
+  // CHECK: [[BITS:%.+]] = hw.bitcast %arg0 : (!hw.union<a: i3, b: i5>) -> i5
+  // CHECK: [[EXTRACT:%.+]] = comb.extract [[BITS]] from 1 : (i5) -> i2
+  // CHECK: return [[EXTRACT]] : i2
+  %0 = moore.extract %arg0 from 1 : !moore.union<{a: i3, b: i5}> -> !moore.i2
+  return %0 : !moore.i2
+}
+
+// CHECK-LABEL: func.func @ExtractPackedStructToStruct
+// CHECK-SAME: (%arg0: !hw.struct<a: i3, b: i2>) -> !hw.struct<b: i2>
+func.func @ExtractPackedStructToStruct(%arg0: !moore.struct<{a: i3, b: i2}>) -> !moore.struct<{b: i2}> {
+  // CHECK: [[BITS:%.+]] = hw.bitcast %arg0 : (!hw.struct<a: i3, b: i2>) -> i5
+  // CHECK: [[EXTRACT:%.+]] = comb.extract [[BITS]] from 0 : (i5) -> i2
+  // CHECK: [[RESULT:%.+]] = hw.bitcast [[EXTRACT]] : (i2) -> !hw.struct<b: i2>
+  // CHECK: return [[RESULT]] : !hw.struct<b: i2>
+  %0 = moore.extract %arg0 from 0 : !moore.struct<{a: i3, b: i2}> -> !moore.struct<{b: i2}>
+  return %0 : !moore.struct<{b: i2}>
+}
+
+// CHECK-LABEL: func.func @ExtractIntToPackedStruct
+// CHECK-SAME: (%arg0: i10) -> !hw.struct<a: i3, b: i2>
+func.func @ExtractIntToPackedStruct(%arg0: !moore.l10) -> !moore.struct<{a: l3, b: l2}> {
+  // CHECK: [[EXTRACT:%.+]] = comb.extract %arg0 from 5 : (i10) -> i5
+  // CHECK: [[RESULT:%.+]] = hw.bitcast [[EXTRACT]] : (i5) -> !hw.struct<a: i3, b: i2>
+  // CHECK-NOT: unrealized_conversion_cast
+  // CHECK: return [[RESULT]] : !hw.struct<a: i3, b: i2>
+  %0 = moore.extract %arg0 from 5 : !moore.l10 -> !moore.struct<{a: l3, b: l2}>
+  return %0 : !moore.struct<{a: l3, b: l2}>
+}
+
+// CHECK-LABEL: func.func @ExtractIntToPackedArray
+// CHECK-SAME: (%arg0: i12) -> !hw.array<2xi3>
+func.func @ExtractIntToPackedArray(%arg0: !moore.l12) -> !moore.array<2 x l3> {
+  // CHECK: [[EXTRACT:%.+]] = comb.extract %arg0 from 6 : (i12) -> i6
+  // CHECK: [[RESULT:%.+]] = hw.bitcast [[EXTRACT]] : (i6) -> !hw.array<2xi3>
+  // CHECK-NOT: unrealized_conversion_cast
+  // CHECK: return [[RESULT]] : !hw.array<2xi3>
+  %0 = moore.extract %arg0 from 6 : !moore.l12 -> !moore.array<2 x l3>
+  return %0 : !moore.array<2 x l3>
+}

--- a/test/Conversion/MooreToCore/extract-packed-array-bit-slice.mlir
+++ b/test/Conversion/MooreToCore/extract-packed-array-bit-slice.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @ExtractPackedArrayToInt
+// CHECK-SAME: (%arg0: !hw.array<2xi3>) -> i2
+func.func @ExtractPackedArrayToInt(%arg0: !moore.array<2 x i3>) -> !moore.i2 {
+  // CHECK: [[BITS:%.+]] = hw.bitcast %arg0 : (!hw.array<2xi3>) -> i6
+  // CHECK: [[EXTRACT:%.+]] = comb.extract [[BITS]] from 1 : (i6) -> i2
+  // CHECK-NOT: unrealized_conversion_cast
+  // CHECK: return [[EXTRACT]] : i2
+  %0 = moore.extract %arg0 from 1 : !moore.array<2 x i3> -> !moore.i2
+  return %0 : !moore.i2
+}
+
+// CHECK-LABEL: func.func @ExtractPackedArrayToStruct
+// CHECK-SAME: (%arg0: !hw.array<2xi3>) -> !hw.struct<b: i2>
+func.func @ExtractPackedArrayToStruct(
+    %arg0: !moore.array<2 x i3>
+) -> !moore.struct<{b: i2}> {
+  // CHECK: [[BITS:%.+]] = hw.bitcast %arg0 : (!hw.array<2xi3>) -> i6
+  // CHECK: [[EXTRACT:%.+]] = comb.extract [[BITS]] from 1 : (i6) -> i2
+  // CHECK: [[RESULT:%.+]] = hw.bitcast [[EXTRACT]] : (i2) -> !hw.struct<b: i2>
+  // CHECK-NOT: unrealized_conversion_cast
+  // CHECK: return [[RESULT]] : !hw.struct<b: i2>
+  %0 = moore.extract %arg0 from 1 : !moore.array<2 x i3> -> !moore.struct<{b: i2}>
+  return %0 : !moore.struct<{b: i2}>
+}
+
+// CHECK-LABEL: func.func @ExtractPackedArrayElement
+// CHECK-SAME: (%arg0: !hw.array<2xi3>) -> i3
+func.func @ExtractPackedArrayElement(%arg0: !moore.array<2 x i3>) -> !moore.i3 {
+  // CHECK: [[VALUE:%.+]] = hw.array_get %arg0
+  // CHECK: return [[VALUE]] : i3
+  %0 = moore.extract %arg0 from 1 : !moore.array<2 x i3> -> !moore.i3
+  return %0 : !moore.i3
+}

--- a/test/Conversion/MooreToCore/extract-ref-packed-aggregate.mlir
+++ b/test/Conversion/MooreToCore/extract-ref-packed-aggregate.mlir
@@ -1,0 +1,132 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @ExtractRefPackedArrayBitSlice
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.array<2xi3>>) -> !llhd.ref<i2>
+func.func @ExtractRefPackedArrayBitSlice(%arg0: !moore.ref<!moore.array<2 x i3>>) -> !moore.ref<!moore.i2> {
+  // CHECK: [[IDX:%.+]] = hw.constant false
+  // CHECK: [[ELEMENT:%.+]] = llhd.sig.array_get %arg0{{\[}}[[IDX]]{{\]}} : <!hw.array<2xi3>>
+  // CHECK: [[LOW:%.+]] = hw.constant 1 : i2
+  // CHECK: [[RESULT:%.+]] = llhd.sig.extract [[ELEMENT]] from [[LOW]] : <i3> -> <i2>
+  // CHECK: return [[RESULT]] : !llhd.ref<i2>
+  %0 = moore.extract_ref %arg0 from 1 : !moore.ref<!moore.array<2 x i3>> -> !moore.ref<!moore.i2>
+  return %0 : !moore.ref<!moore.i2>
+}
+
+// CHECK-LABEL: func.func @ExtractRefPackedArrayCrossElementBitSlice
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.array<2xi3>>) -> !llhd.ref<i2>
+func.func @ExtractRefPackedArrayCrossElementBitSlice(%arg0: !moore.ref<!moore.array<2 x i3>>) -> !moore.ref<!moore.i2> {
+  // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !llhd.ref<!hw.array<2xi3>> to !llhd.ref<i6>
+  // CHECK: [[LOW:%.+]] = hw.constant 2 : i3
+  // CHECK: [[RESULT:%.+]] = llhd.sig.extract [[CAST]] from [[LOW]] : <i6> -> <i2>
+  // CHECK: return [[RESULT]] : !llhd.ref<i2>
+  %0 = moore.extract_ref %arg0 from 2 : !moore.ref<!moore.array<2 x i3>> -> !moore.ref<!moore.i2>
+  return %0 : !moore.ref<!moore.i2>
+}
+
+// CHECK-LABEL: func.func @ExtractRefPackedStructField
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.struct<a: i3, b: i2>>) -> !llhd.ref<i2>
+func.func @ExtractRefPackedStructField(%arg0: !moore.ref<!moore.struct<{a: i3, b: i2}>>) -> !moore.ref<!moore.i2> {
+  // CHECK: [[RESULT:%.+]] = llhd.sig.struct_extract %arg0["b"] : <!hw.struct<a: i3, b: i2>>
+  // CHECK: return [[RESULT]] : !llhd.ref<i2>
+  %0 = moore.extract_ref %arg0 from 0 : !moore.ref<!moore.struct<{a: i3, b: i2}>> -> !moore.ref<!moore.i2>
+  return %0 : !moore.ref<!moore.i2>
+}
+
+// CHECK-LABEL: func.func @ExtractRefPackedStructFieldBitSlice
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.struct<a: i3, b: i2>>) -> !llhd.ref<i1>
+func.func @ExtractRefPackedStructFieldBitSlice(%arg0: !moore.ref<!moore.struct<{a: i3, b: i2}>>) -> !moore.ref<!moore.i1> {
+  // CHECK: [[FIELD:%.+]] = llhd.sig.struct_extract %arg0["b"] : <!hw.struct<a: i3, b: i2>>
+  // CHECK: [[LOW:%.+]] = hw.constant true
+  // CHECK: [[RESULT:%.+]] = llhd.sig.extract [[FIELD]] from [[LOW]] : <i2> -> <i1>
+  // CHECK: return [[RESULT]] : !llhd.ref<i1>
+  %0 = moore.extract_ref %arg0 from 1 : !moore.ref<!moore.struct<{a: i3, b: i2}>> -> !moore.ref<!moore.i1>
+  return %0 : !moore.ref<!moore.i1>
+}
+
+// CHECK-LABEL: func.func @ExtractRefPackedStructCrossFieldBitSlice
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.struct<a: i3, b: i2>>) -> !llhd.ref<i2>
+func.func @ExtractRefPackedStructCrossFieldBitSlice(%arg0: !moore.ref<!moore.struct<{a: i3, b: i2}>>) -> !moore.ref<!moore.i2> {
+  // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !llhd.ref<!hw.struct<a: i3, b: i2>> to !llhd.ref<i5>
+  // CHECK: [[LOW:%.+]] = hw.constant 1 : i3
+  // CHECK: [[RESULT:%.+]] = llhd.sig.extract [[CAST]] from [[LOW]] : <i5> -> <i2>
+  // CHECK: return [[RESULT]] : !llhd.ref<i2>
+  %0 = moore.extract_ref %arg0 from 1 : !moore.ref<!moore.struct<{a: i3, b: i2}>> -> !moore.ref<!moore.i2>
+  return %0 : !moore.ref<!moore.i2>
+}
+
+// CHECK-LABEL: func.func @DynExtractRefPackedArrayBitSlice
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.array<2xi3>>, %arg1: i3) -> !llhd.ref<i2>
+func.func @DynExtractRefPackedArrayBitSlice(%arg0: !moore.ref<!moore.array<2 x i3>>, %idx: !moore.i3) -> !moore.ref<!moore.i2> {
+  // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !llhd.ref<!hw.array<2xi3>> to !llhd.ref<i6>
+  // CHECK: [[RESULT:%.+]] = llhd.sig.extract [[CAST]] from %arg1 : <i6> -> <i2>
+  // CHECK: return [[RESULT]] : !llhd.ref<i2>
+  %0 = moore.dyn_extract_ref %arg0 from %idx : !moore.ref<!moore.array<2 x i3>>, !moore.i3 -> !moore.ref<!moore.i2>
+  return %0 : !moore.ref<!moore.i2>
+}
+
+// CHECK-LABEL: func.func @DynExtractRefPackedStructBitSlice
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.struct<a: i3, b: i2>>, %arg1: i3) -> !llhd.ref<i2>
+func.func @DynExtractRefPackedStructBitSlice(%arg0: !moore.ref<!moore.struct<{a: i3, b: i2}>>, %idx: !moore.i3) -> !moore.ref<!moore.i2> {
+  // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !llhd.ref<!hw.struct<a: i3, b: i2>> to !llhd.ref<i5>
+  // CHECK: [[RESULT:%.+]] = llhd.sig.extract [[CAST]] from %arg1 : <i5> -> <i2>
+  // CHECK: return [[RESULT]] : !llhd.ref<i2>
+  %0 = moore.dyn_extract_ref %arg0 from %idx : !moore.ref<!moore.struct<{a: i3, b: i2}>>, !moore.i3 -> !moore.ref<!moore.i2>
+  return %0 : !moore.ref<!moore.i2>
+}
+
+// CHECK-LABEL: func.func @ExtractRefPackedStructToStruct
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.struct<a: i3, b: i2>>) -> !llhd.ref<!hw.struct<x: i1, y: i1>>
+func.func @ExtractRefPackedStructToStruct(%arg0: !moore.ref<!moore.struct<{a: i3, b: i2}>>) -> !moore.ref<!moore.struct<{x: i1, y: i1}>> {
+  // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !llhd.ref<!hw.struct<a: i3, b: i2>> to !llhd.ref<i5>
+  // CHECK: [[LOW:%.+]] = hw.constant 1 : i3
+  // CHECK: [[EXTRACT:%.+]] = llhd.sig.extract [[CAST]] from [[LOW]] : <i5> -> <i2>
+  // CHECK: [[RESULT:%.+]] = builtin.unrealized_conversion_cast [[EXTRACT]] : !llhd.ref<i2> to !llhd.ref<!hw.struct<x: i1, y: i1>>
+  // CHECK: return [[RESULT]] : !llhd.ref<!hw.struct<x: i1, y: i1>>
+  %0 = moore.extract_ref %arg0 from 1 : !moore.ref<!moore.struct<{a: i3, b: i2}>> -> !moore.ref<!moore.struct<{x: i1, y: i1}>>
+  return %0 : !moore.ref<!moore.struct<{x: i1, y: i1}>>
+}
+
+// CHECK-LABEL: func.func @ExtractRefPackedArrayToStruct
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.array<2xi3>>) -> !llhd.ref<!hw.struct<x: i1, y: i1>>
+func.func @ExtractRefPackedArrayToStruct(%arg0: !moore.ref<!moore.array<2 x i3>>) -> !moore.ref<!moore.struct<{x: i1, y: i1}>> {
+  // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !llhd.ref<!hw.array<2xi3>> to !llhd.ref<i6>
+  // CHECK: [[LOW:%.+]] = hw.constant 2 : i3
+  // CHECK: [[EXTRACT:%.+]] = llhd.sig.extract [[CAST]] from [[LOW]] : <i6> -> <i2>
+  // CHECK: [[RESULT:%.+]] = builtin.unrealized_conversion_cast [[EXTRACT]] : !llhd.ref<i2> to !llhd.ref<!hw.struct<x: i1, y: i1>>
+  // CHECK: return [[RESULT]] : !llhd.ref<!hw.struct<x: i1, y: i1>>
+  %0 = moore.extract_ref %arg0 from 2 : !moore.ref<!moore.array<2 x i3>> -> !moore.ref<!moore.struct<{x: i1, y: i1}>>
+  return %0 : !moore.ref<!moore.struct<{x: i1, y: i1}>>
+}
+
+// CHECK-LABEL: func.func @DynExtractRefPackedStructToStruct
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.struct<a: i3, b: i2>>, %arg1: i3) -> !llhd.ref<!hw.struct<x: i1, y: i1>>
+func.func @DynExtractRefPackedStructToStruct(%arg0: !moore.ref<!moore.struct<{a: i3, b: i2}>>, %idx: !moore.i3) -> !moore.ref<!moore.struct<{x: i1, y: i1}>> {
+  // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !llhd.ref<!hw.struct<a: i3, b: i2>> to !llhd.ref<i5>
+  // CHECK: [[EXTRACT:%.+]] = llhd.sig.extract [[CAST]] from %arg1 : <i5> -> <i2>
+  // CHECK: [[RESULT:%.+]] = builtin.unrealized_conversion_cast [[EXTRACT]] : !llhd.ref<i2> to !llhd.ref<!hw.struct<x: i1, y: i1>>
+  // CHECK: return [[RESULT]] : !llhd.ref<!hw.struct<x: i1, y: i1>>
+  %0 = moore.dyn_extract_ref %arg0 from %idx : !moore.ref<!moore.struct<{a: i3, b: i2}>>, !moore.i3 -> !moore.ref<!moore.struct<{x: i1, y: i1}>>
+  return %0 : !moore.ref<!moore.struct<{x: i1, y: i1}>>
+}
+
+// CHECK-LABEL: func.func @DynExtractRefPackedArrayToStruct
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.array<2xi3>>, %arg1: i3) -> !llhd.ref<!hw.struct<x: i1, y: i1>>
+func.func @DynExtractRefPackedArrayToStruct(%arg0: !moore.ref<!moore.array<2 x i3>>, %idx: !moore.i3) -> !moore.ref<!moore.struct<{x: i1, y: i1}>> {
+  // CHECK: [[CAST:%.+]] = builtin.unrealized_conversion_cast %arg0 : !llhd.ref<!hw.array<2xi3>> to !llhd.ref<i6>
+  // CHECK: [[EXTRACT:%.+]] = llhd.sig.extract [[CAST]] from %arg1 : <i6> -> <i2>
+  // CHECK: [[RESULT:%.+]] = builtin.unrealized_conversion_cast [[EXTRACT]] : !llhd.ref<i2> to !llhd.ref<!hw.struct<x: i1, y: i1>>
+  // CHECK: return [[RESULT]] : !llhd.ref<!hw.struct<x: i1, y: i1>>
+  %0 = moore.dyn_extract_ref %arg0 from %idx : !moore.ref<!moore.array<2 x i3>>, !moore.i3 -> !moore.ref<!moore.struct<{x: i1, y: i1}>>
+  return %0 : !moore.ref<!moore.struct<{x: i1, y: i1}>>
+}
+
+// CHECK-LABEL: func.func @ExtractRefPackedUnionBitSlice
+// CHECK-SAME: (%arg0: !llhd.ref<!hw.union<bits: i4, parts: !hw.struct<hi: i2, lo: i2>>>) -> !llhd.ref<i2>
+func.func @ExtractRefPackedUnionBitSlice(%arg0: !moore.ref<!moore.union<{bits: i4, parts: struct<{hi: i2, lo: i2}>}>>) -> !moore.ref<!moore.i2> {
+  // CHECK: [[FIELD:%.+]] = llhd.sig.struct_extract %arg0["bits"] : <!hw.union<bits: i4, parts: !hw.struct<hi: i2, lo: i2>>>
+  // CHECK: [[LOW:%.+]] = hw.constant 0 : i2
+  // CHECK: [[RESULT:%.+]] = llhd.sig.extract [[FIELD]] from [[LOW]] : <i4> -> <i2>
+  // CHECK: return [[RESULT]] : !llhd.ref<i2>
+  %0 = moore.extract_ref %arg0 from 0 : !moore.ref<!moore.union<{bits: i4, parts: struct<{hi: i2, lo: i2}>}>> -> !moore.ref<!moore.i2>
+  return %0 : !moore.ref<!moore.i2>
+}

--- a/test/Conversion/MooreToCore/ref-conversions.mlir
+++ b/test/Conversion/MooreToCore/ref-conversions.mlir
@@ -1,0 +1,19 @@
+// RUN: circt-opt %s --split-input-file --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @uarray_ref_to_int_ref(
+// CHECK-SAME: %[[ARG0:.*]]: !llhd.ref<!hw.array<16xi1>>) -> !llhd.ref<i16>
+// CHECK: %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[ARG0]] : !llhd.ref<!hw.array<16xi1>> to !llhd.ref<i16>
+// CHECK: return %[[CAST]] : !llhd.ref<i16>
+func.func @uarray_ref_to_int_ref(%arg0: !moore.ref<uarray<16 x l1>>) -> !moore.ref<l16> {
+  %0 = moore.conversion %arg0 : !moore.ref<uarray<16 x l1>> -> !moore.ref<l16>
+  return %0 : !moore.ref<l16>
+}
+
+// CHECK-LABEL: func.func @struct_ref_to_int_ref(
+// CHECK-SAME: %[[ARG0:.*]]: !llhd.ref<!hw.struct<a: i3, b: i2>>) -> !llhd.ref<i5>
+// CHECK: %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[ARG0]] : !llhd.ref<!hw.struct<a: i3, b: i2>> to !llhd.ref<i5>
+// CHECK: return %[[CAST]] : !llhd.ref<i5>
+func.func @struct_ref_to_int_ref(%arg0: !moore.ref<struct<{a: l3, b: l2}>>) -> !moore.ref<l5> {
+  %0 = moore.conversion %arg0 : !moore.ref<struct<{a: l3, b: l2}>> -> !moore.ref<l5>
+  return %0 : !moore.ref<l5>
+}

--- a/test/Conversion/MooreToCore/struct-inject.mlir
+++ b/test/Conversion/MooreToCore/struct-inject.mlir
@@ -1,0 +1,72 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @StructInject
+// CHECK-SAME: (%arg0: !hw.struct<a: i3, b: i2>, %arg1: i3) -> !hw.struct<a: i3, b: i2>
+func.func @StructInject(%arg0: !moore.struct<{a: i3, b: i2}>, %arg1: !moore.i3) -> !moore.struct<{a: i3, b: i2}> {
+  // CHECK: [[RESULT:%.+]] = hw.struct_inject %arg0["a"], %arg1 : !hw.struct<a: i3, b: i2>
+  // CHECK: return [[RESULT]] : !hw.struct<a: i3, b: i2>
+  %0 = moore.struct_inject %arg0, "a", %arg1 : struct<{a: i3, b: i2}>, i3
+  return %0 : !moore.struct<{a: i3, b: i2}>
+}
+
+// CHECK-LABEL: func.func @UnpackedStructInject
+// CHECK-SAME: (%arg0: !hw.struct<a: i3, b: i2>, %arg1: i2) -> !hw.struct<a: i3, b: i2>
+func.func @UnpackedStructInject(%arg0: !moore.ustruct<{a: i3, b: i2}>, %arg1: !moore.i2) -> !moore.ustruct<{a: i3, b: i2}> {
+  // CHECK: [[RESULT:%.+]] = hw.struct_inject %arg0["b"], %arg1 : !hw.struct<a: i3, b: i2>
+  // CHECK: return [[RESULT]] : !hw.struct<a: i3, b: i2>
+  %0 = moore.struct_inject %arg0, "b", %arg1 : ustruct<{a: i3, b: i2}>, i2
+  return %0 : !moore.ustruct<{a: i3, b: i2}>
+}
+
+// CHECK-LABEL: func.func @UnpackedStructInjectString
+// CHECK-SAME: (%arg0: !hw.struct<s: !sim.dstring, h: !llvm.ptr>, %arg1: !sim.dstring)
+// CHECK-SAME: -> !hw.struct<s: !sim.dstring, h: !llvm.ptr>
+func.func @UnpackedStructInjectString(%arg0: !moore.ustruct<{s: string, h: chandle}>, %arg1: !moore.string) -> !moore.ustruct<{s: string, h: chandle}> {
+  // CHECK: [[RESULT:%.+]] = hw.struct_inject %arg0["s"], %arg1 : !hw.struct<s: !sim.dstring, h: !llvm.ptr>
+  // CHECK: return [[RESULT]] : !hw.struct<s: !sim.dstring, h: !llvm.ptr>
+  %0 = moore.struct_inject %arg0, "s", %arg1 : ustruct<{s: string, h: chandle}>, string
+  return %0 : !moore.ustruct<{s: string, h: chandle}>
+}
+
+// CHECK-LABEL: func.func @UnpackedStructInjectChandle
+// CHECK-SAME: (%arg0: !hw.struct<s: !sim.dstring, h: !llvm.ptr>, %arg1: !llvm.ptr)
+// CHECK-SAME: -> !hw.struct<s: !sim.dstring, h: !llvm.ptr>
+func.func @UnpackedStructInjectChandle(%arg0: !moore.ustruct<{s: string, h: chandle}>, %arg1: !moore.chandle) -> !moore.ustruct<{s: string, h: chandle}> {
+  // CHECK: [[RESULT:%.+]] = hw.struct_inject %arg0["h"], %arg1 : !hw.struct<s: !sim.dstring, h: !llvm.ptr>
+  // CHECK: return [[RESULT]] : !hw.struct<s: !sim.dstring, h: !llvm.ptr>
+  %0 = moore.struct_inject %arg0, "h", %arg1 : ustruct<{s: string, h: chandle}>, chandle
+  return %0 : !moore.ustruct<{s: string, h: chandle}>
+}
+
+moore.class.classdecl @StructInjectClass {
+}
+
+// CHECK-LABEL: func.func @UnpackedStructInjectClass
+// CHECK-SAME: (%arg0: !hw.struct<s: !sim.dstring, c: !llvm.ptr>, %arg1: !llvm.ptr)
+// CHECK-SAME: -> !hw.struct<s: !sim.dstring, c: !llvm.ptr>
+func.func @UnpackedStructInjectClass(%arg0: !moore.ustruct<{s: string, c: class<@StructInjectClass>}>, %arg1: !moore.class<@StructInjectClass>) -> !moore.ustruct<{s: string, c: class<@StructInjectClass>}> {
+  // CHECK: [[RESULT:%.+]] = hw.struct_inject %arg0["c"], %arg1 : !hw.struct<s: !sim.dstring, c: !llvm.ptr>
+  // CHECK: return [[RESULT]] : !hw.struct<s: !sim.dstring, c: !llvm.ptr>
+  %0 = moore.struct_inject %arg0, "c", %arg1 : ustruct<{s: string, c: class<@StructInjectClass>}>, class<@StructInjectClass>
+  return %0 : !moore.ustruct<{s: string, c: class<@StructInjectClass>}>
+}
+
+// CHECK-LABEL: func.func @UnpackedStructInjectReal
+// CHECK-SAME: (%arg0: !hw.struct<r: f64, t: !llhd.time>, %arg1: f64)
+// CHECK-SAME: -> !hw.struct<r: f64, t: !llhd.time>
+func.func @UnpackedStructInjectReal(%arg0: !moore.ustruct<{r: f64, t: time}>, %arg1: !moore.f64) -> !moore.ustruct<{r: f64, t: time}> {
+  // CHECK: [[RESULT:%.+]] = hw.struct_inject %arg0["r"], %arg1 : !hw.struct<r: f64, t: !llhd.time>
+  // CHECK: return [[RESULT]] : !hw.struct<r: f64, t: !llhd.time>
+  %0 = moore.struct_inject %arg0, "r", %arg1 : ustruct<{r: f64, t: time}>, f64
+  return %0 : !moore.ustruct<{r: f64, t: time}>
+}
+
+// CHECK-LABEL: func.func @UnpackedStructInjectTime
+// CHECK-SAME: (%arg0: !hw.struct<r: f64, t: !llhd.time>, %arg1: !llhd.time)
+// CHECK-SAME: -> !hw.struct<r: f64, t: !llhd.time>
+func.func @UnpackedStructInjectTime(%arg0: !moore.ustruct<{r: f64, t: time}>, %arg1: !moore.time) -> !moore.ustruct<{r: f64, t: time}> {
+  // CHECK: [[RESULT:%.+]] = hw.struct_inject %arg0["t"], %arg1 : !hw.struct<r: f64, t: !llhd.time>
+  // CHECK: return [[RESULT]] : !hw.struct<r: f64, t: !llhd.time>
+  %0 = moore.struct_inject %arg0, "t", %arg1 : ustruct<{r: f64, t: time}>, time
+  return %0 : !moore.ustruct<{r: f64, t: time}>
+}

--- a/test/Dialect/Moore/simplify-refs.mlir
+++ b/test/Dialect/Moore/simplify-refs.mlir
@@ -115,3 +115,20 @@ moore.module @QueueRefsWithConcat() {
     moore.return
   }
 }
+
+// CHECK-LABEL: moore.module @ExtractFromConcatRef()
+moore.module @ExtractFromConcatRef() {
+  // CHECK: %[[A:.+]] = moore.variable : <l32>
+  %a = moore.variable : <l32>
+  // CHECK: %[[B:.+]] = moore.variable : <l16>
+  %b = moore.variable : <l16>
+  moore.procedure always {
+    %cat = moore.concat_ref %a, %b : (!moore.ref<l32>, !moore.ref<l16>) -> <l48>
+    // CHECK: moore.extract_ref %[[B]] from 8 : <l16> -> <l8>
+    %lo = moore.extract_ref %cat from 8 : <l48> -> <l8>
+    // CHECK: moore.extract_ref %[[A]] from 8 : <l32> -> <l8>
+    %hi = moore.extract_ref %cat from 24 : <l48> -> <l8>
+    moore.return
+  }
+  moore.output
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Lower packed array/struct extraction operations (static, dynamic, bit-slice, ref forms) and struct injection in MooreToCore (IEEE 1800-2023 §4.7, §4.8). Previously incomplete; supports dynamic/bit-slice extraction, field ref extraction, reference reinterpret/concat extraction. Maps to existing comb/llhd ops. Standalone.

Tests: basic.mlir, dyn-extract-packed-array.mlir, dyn-extract-packed-struct.mlir, extract-packed-aggregate.mlir, extract-packed-array-bit-slice.mlir, extract-ref-packed-aggregate.mlir, ref-conversions.mlir, struct-inject.mlir, simplify-refs.mlir.
