### PR TITLE
[ImportVerilog] Skip bodies for pure virtual non-void methods

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1973,6 +1973,10 @@ Context::defineFunction(const slang::ast::SubroutineSymbol &subroutine) {
   // symbol and calls to it are not eliminated.
   if (subroutine.flags.has(slang::ast::MethodFlags::DPIImport))
     return success();
+  // Pure virtual methods only contribute class method declarations and vtable
+  // slots. They have no body to define, including for non-void return types.
+  if (subroutine.flags.has(slang::ast::MethodFlags::Pure))
+    return success();
 
   const bool isMethod = (subroutine.thisVar != nullptr);
 

--- a/test/Conversion/ImportVerilog/pure-virtual-nonvoid.sv
+++ b/test/Conversion/ImportVerilog/pure-virtual-nonvoid.sv
@@ -1,0 +1,25 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// clang-format off
+// CHECK-LABEL: moore.class.classdecl @StringBase {
+// CHECK:         moore.class.methoddecl @text : (!moore.class<@StringBase>) -> !moore.string
+// CHECK:       }
+virtual class StringBase;
+  pure virtual function string text();
+endclass
+
+// CHECK-LABEL: moore.class.classdecl @StringLeaf extends @StringBase {
+// CHECK:         moore.class.methoddecl @text -> @"StringLeaf::text" : (!moore.class<@StringLeaf>) -> !moore.string
+// CHECK:       }
+// CHECK-LABEL: func.func private @"StringLeaf::text"(%arg0: !moore.class<@StringLeaf>) -> !moore.string {
+// CHECK:         return
+// CHECK:       }
+class StringLeaf extends StringBase;
+  virtual function string text();
+    return "leaf";
+  endfunction
+endclass
+  // clang-format on


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Skip body generation for pure virtual non-void methods in ImportVerilog (IEEE 1800-2023 §8.3.5). Previously generated empty bodies; now omits bodies entirely for pure virtuals. Maps to existing structure lowering. Standalone.

Tests: pure-virtual-nonvoid.sv.
