### PR TITLE
[MooreToCore] Lower handle and event value conversions

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -812,7 +812,9 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
     auto computeTrigger = [&](Value before, Value after, Edge edge) -> Value {
       assert(before.getType() == after.getType() &&
              "mismatched types after clone op");
-      auto beforeType = cast<IntType>(before.getType());
+      auto beforeType = dyn_cast<IntType>(before.getType());
+      if (!beforeType && isa<EventType>(before.getType()))
+        beforeType = IntType::get(rewriter.getContext(), 1, Domain::TwoValued);
 
       // 9.4.2 IEEE 1800-2017: An edge event shall be detected only on the LSB
       // of the expression
@@ -864,7 +866,7 @@ struct WaitEventOpConversion : public OpConversionPattern<WaitEventOp> {
     SmallVector<Value> triggers;
     for (auto [detectOp, before] : llvm::zip(detectOps, valuesBefore)) {
       if (!allDetectsAreAnyChange) {
-        if (!isa<IntType>(before.getType()))
+        if (!isa<IntType, EventType>(before.getType()))
           return detectOp->emitError() << "requires int operand";
 
         rewriter.setInsertionPoint(detectOp);
@@ -1320,6 +1322,34 @@ struct ConstantStringOpConv : public OpConversionPattern<ConstantStringOp> {
 
     rewriter.replaceOpWithNewOp<hw::ConstantOp>(
         op, resultType, rewriter.getIntegerAttr(resultType, value));
+    return success();
+  }
+};
+
+template <typename SourceOp, LLVM::ICmpPredicate pred>
+struct HandleCompareOpConversion : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+  using OpAdaptor = typename SourceOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<LLVM::ICmpOp>(op, pred, adaptor.getLhs(),
+                                              adaptor.getRhs());
+    return success();
+  }
+};
+
+struct NullOpConversion : public OpConversionPattern<NullOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(NullOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = typeConverter->convertType(op.getResult().getType());
+    if (!resultType)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, resultType);
     return success();
   }
 };
@@ -1918,6 +1948,19 @@ struct ConversionOpConversion : public OpConversionPattern<ConversionOp> {
       op.emitError("conversion result type is not currently supported");
       return failure();
     }
+    auto nullIntResult = dyn_cast<IntType>(op.getResult().getType());
+    if (isa<NullType>(op.getInput().getType()) && nullIntResult &&
+        nullIntResult.getWidth() == 1) {
+      rewriter.replaceOp(op, createZeroValue(resultType, loc, rewriter));
+      return success();
+    }
+    if (adaptor.getInput().getType() == resultType &&
+        (op.getInput().getType() == op.getResult().getType() ||
+         isa<NullType>(op.getInput().getType()))) {
+      rewriter.replaceOp(op, adaptor.getInput());
+      return success();
+    }
+
     int64_t inputBw = hw::getBitWidth(adaptor.getInput().getType());
     int64_t resultBw = hw::getBitWidth(resultType);
     if (inputBw == -1 || resultBw == -1) {
@@ -1932,6 +1975,10 @@ struct ConversionOpConversion : public OpConversionPattern<ConversionOp> {
         op.emitError("unsupported DPI open-array conversion from ")
             << op.getInput().getType() << " to " << op.getResult().getType();
         return failure();
+      }
+      if (adaptor.getInput().getType() == resultType) {
+        rewriter.replaceOp(op, adaptor.getInput());
+        return success();
       }
       return failure();
     }
@@ -3272,6 +3319,13 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
     return sim::DynamicStringType::get(type.getContext());
   });
 
+  typeConverter.addConversion(
+      [&](EventType type) { return IntegerType::get(type.getContext(), 1); });
+
+  typeConverter.addConversion([&](NullType type) {
+    return LLVM::LLVMPointerType::get(type.getContext());
+  });
+
   typeConverter.addConversion([&](QueueType type) {
     return sim::QueueType::get(type.getContext(),
                                typeConverter.convertType(type.getElementType()),
@@ -3497,6 +3551,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     // Patterns of miscellaneous operations.
     ConstantOpConv,
     ConstantRealOpConv,
+    NullOpConversion,
     ConcatOpConversion,
     ReplicateOpConversion,
     ConstantTimeOpConv,
@@ -3565,6 +3620,10 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     ICmpOpConversion<CaseNeOp, ICmpPredicate::cne>,
     ICmpOpConversion<WildcardEqOp, ICmpPredicate::weq>,
     ICmpOpConversion<WildcardNeOp, ICmpPredicate::wne>,
+    HandleCompareOpConversion<HandleEqOp, LLVM::ICmpPredicate::eq>,
+    HandleCompareOpConversion<HandleNeOp, LLVM::ICmpPredicate::ne>,
+    HandleCompareOpConversion<HandleCaseEqOp, LLVM::ICmpPredicate::eq>,
+    HandleCompareOpConversion<HandleCaseNeOp, LLVM::ICmpPredicate::ne>,
     FCmpOpConversion<NeRealOp, arith::CmpFPredicate::UNE>,
     FCmpOpConversion<FltOp, arith::CmpFPredicate::OLT>,
     FCmpOpConversion<FleOp, arith::CmpFPredicate::OLE>,

--- a/test/Conversion/MooreToCore/event-type-conversion.mlir
+++ b/test/Conversion/MooreToCore/event-type-conversion.mlir
@@ -1,0 +1,182 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @EventVariable
+func.func @EventVariable() {
+  // CHECK: [[FALSE:%.+]] = hw.constant false
+  // CHECK: llhd.sig [[FALSE]] : i1
+  %event = moore.variable : <!moore.event>
+  return
+}
+
+// CHECK-LABEL: func.func @EventBoolCast
+// CHECK-SAME: ([[ARG:%.+]]: i1) -> i1
+func.func @EventBoolCast(%arg0: !moore.event) -> !moore.i1 {
+  // CHECK: [[FALSE:%.+]] = hw.constant false
+  // CHECK: [[RESULT:%.+]] = comb.icmp ne [[ARG]], [[FALSE]] : i1
+  // CHECK: return [[RESULT]] : i1
+  %0 = moore.bool_cast %arg0 : !moore.event -> !moore.i1
+  return %0 : !moore.i1
+}
+
+// CHECK-LABEL: func.func @EventRefSignature
+// CHECK-SAME: ([[ARG:%.+]]: !llhd.ref<i1>) -> !llhd.ref<i1>
+func.func @EventRefSignature(%event: !moore.ref<event>) -> !moore.ref<event> {
+  // CHECK: return [[ARG]] : !llhd.ref<i1>
+  return %event : !moore.ref<event>
+}
+
+// CHECK-LABEL: func.func @EventConditional
+// CHECK-SAME: ([[COND:%.+]]: i1, [[LHS:%.+]]: i1, [[RHS:%.+]]: i1)
+func.func @EventConditional(%cond: !moore.i1, %lhs: !moore.event, %rhs: !moore.event) {
+  // CHECK: comb.mux [[COND]], [[LHS]], [[RHS]] : i1
+  %0 = moore.conditional %cond : i1 -> event {
+    moore.yield %lhs : event
+  } {
+    moore.yield %rhs : event
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @UArrayEventSignature
+// CHECK-SAME: ([[ARG:%.+]]: !hw.array<2xi1>) -> !hw.array<2xi1>
+func.func @UArrayEventSignature(%arg0: !moore.uarray<2 x event>) -> !moore.uarray<2 x event> {
+  // CHECK: return [[ARG]] : !hw.array<2xi1>
+  return %arg0 : !moore.uarray<2 x event>
+}
+
+// CHECK-LABEL: func.func @UStructEventSignature
+// CHECK-SAME: ([[ARG:%.+]]: !hw.struct<e: i1, bits: i2>) -> !hw.struct<e: i1, bits: i2>
+func.func @UStructEventSignature(%arg0: !moore.ustruct<{e: event, bits: i2}>) -> !moore.ustruct<{e: event, bits: i2}> {
+  // CHECK: return [[ARG]] : !hw.struct<e: i1, bits: i2>
+  return %arg0 : !moore.ustruct<{e: event, bits: i2}>
+}
+
+// CHECK-LABEL: func.func @UUnionEventSignature
+// CHECK-SAME: ([[ARG:%.+]]: !hw.union<e: i1, bits: i1>) -> !hw.union<e: i1, bits: i1>
+func.func @UUnionEventSignature(%arg0: !moore.uunion<{e: event, bits: i1}>) -> !moore.uunion<{e: event, bits: i1}> {
+  // CHECK: return [[ARG]] : !hw.union<e: i1, bits: i1>
+  return %arg0 : !moore.uunion<{e: event, bits: i1}>
+}
+
+moore.class.classdecl @EventClass {
+  moore.class.propertydecl @e : !moore.event
+  moore.class.propertydecl @bits : !moore.i8
+}
+
+// CHECK-LABEL: func.func @EventClassNew() -> !llvm.ptr
+func.func @EventClassNew() -> !moore.class<@EventClass> {
+  // CHECK: call @malloc
+  // CHECK: return {{%.+}} : !llvm.ptr
+  %h = moore.class.new : <@EventClass>
+  return %h : !moore.class<@EventClass>
+}
+
+// CHECK-LABEL: func.func @EventClassProperty
+// CHECK-SAME: ([[ARG:%.+]]: !llvm.ptr) -> !llhd.ref<i1>
+func.func @EventClassProperty(%h: !moore.class<@EventClass>) -> !moore.ref<event> {
+  // CHECK: llvm.getelementptr [[ARG]]
+  // CHECK: builtin.unrealized_conversion_cast {{%.+}} : !llvm.ptr to !llhd.ref<i1>
+  %ref = moore.class.property_ref %h[@e] : <@EventClass> -> !moore.ref<event>
+  return %ref : !moore.ref<event>
+}
+
+// CHECK-LABEL: func.func @EventUnionConditional
+// CHECK-SAME: ([[COND:%.+]]: i1, [[LHS:%.+]]: !hw.union<e: i1, bits: i1>, [[RHS:%.+]]: !hw.union<e: i1, bits: i1>)
+func.func @EventUnionConditional(%cond: !moore.i1, %lhs: !moore.uunion<{e: event, bits: i1}>, %rhs: !moore.uunion<{e: event, bits: i1}>) -> !moore.uunion<{e: event, bits: i1}> {
+  // CHECK: comb.mux [[COND]], [[LHS]], [[RHS]] : !hw.union<e: i1, bits: i1>
+  %result = moore.conditional %cond : i1 -> uunion<{e: event, bits: i1}> {
+    moore.yield %lhs : uunion<{e: event, bits: i1}>
+  } {
+    moore.yield %rhs : uunion<{e: event, bits: i1}>
+  }
+  return %result : !moore.uunion<{e: event, bits: i1}>
+}
+
+// CHECK-LABEL: func.func @EventNetAndAssigned
+// CHECK-SAME: ([[ARG:%.+]]: i1)
+func.func @EventNetAndAssigned(%input: !moore.event) {
+  // CHECK: [[FALSE:%.+]] = hw.constant false
+  // CHECK: [[NET:%.+]] = llhd.sig [[FALSE]] : i1
+  // CHECK: llhd.drv [[NET]], [[ARG]] after
+  %net = moore.net wire %input : <!moore.event>
+  // CHECK: hw.wire [[ARG]]  : i1
+  %assigned = moore.assigned_variable %input : event
+  return
+}
+
+// CHECK-LABEL: hw.module @EventWaitControls
+moore.module @EventWaitControls() {
+  %event = moore.variable : <event>
+  %gate = moore.variable : <i1>
+
+  // CHECK: llhd.process
+  // CHECK: llhd.wait
+  moore.procedure initial {
+    moore.wait_event {
+      %0 = moore.read %event : <event>
+      moore.detect_event any %0 : event
+    }
+    moore.return
+  }
+
+  // CHECK: llhd.process
+  // CHECK: llhd.wait
+  // CHECK: comb.icmp bin ne
+  // CHECK: comb.and bin
+  moore.procedure initial {
+    moore.wait_event {
+      %0 = moore.read %event : <event>
+      %1 = moore.read %gate : <i1>
+      moore.detect_event any %0 if %1 : event
+    }
+    moore.return
+  }
+}
+
+// CHECK-LABEL: llhd.global_signal @GlobalEvent : i1
+moore.global_variable @GlobalEvent : !moore.event
+
+// CHECK-LABEL: hw.module @EventGlobalValues
+moore.module @EventGlobalValues() {
+  // CHECK: llhd.process
+  // CHECK: llhd.get_global_signal @GlobalEvent : <i1>
+  // CHECK: llhd.prb
+  // CHECK: hw.wire
+  moore.procedure initial {
+    %event = moore.get_global_variable @GlobalEvent : <!moore.event>
+    %value = moore.read %event : <event>
+    %assigned = moore.assigned_variable %value : event
+    moore.return
+  }
+}
+
+// CHECK-LABEL: hw.module @EventModulePorts
+// CHECK-SAME: in %event_in : i1
+// CHECK-SAME: out event_out : i1
+moore.module @EventModulePorts(in %event_in : !moore.event, out event_out : !moore.event) {
+  // CHECK: hw.output %event_in : i1
+  moore.output %event_in : !moore.event
+}
+
+// CHECK-LABEL: hw.module @EventInstTop
+// CHECK-SAME: in %event_in : i1
+// CHECK-SAME: out event_out : i1
+moore.module @EventInstTop(in %event_in : !moore.event, out event_out : !moore.event) {
+  // CHECK: hw.instance "child" @EventInstChild(event_in: %event_in: i1) -> (event_out: i1)
+  %child.event_out = moore.instance "child" @EventInstChild(event_in: %event_in : !moore.event) -> (event_out: !moore.event)
+  // CHECK: hw.output %child.event_out : i1
+  moore.output %child.event_out : !moore.event
+}
+
+// CHECK-LABEL: hw.module private @EventInstChild
+moore.module private @EventInstChild(in %event_in : !moore.event, out event_out : !moore.event) {
+  // CHECK: hw.output %event_in : i1
+  moore.output %event_in : !moore.event
+}
+
+// CHECK-LABEL: hw.module @EventRefModulePorts
+// CHECK-SAME: in %event_ref : !llhd.ref<i1>
+moore.module @EventRefModulePorts(in %event_ref : !moore.ref<event>) {
+  // CHECK: hw.output
+  moore.output
+}

--- a/test/Conversion/MooreToCore/handle-comparisons.mlir
+++ b/test/Conversion/MooreToCore/handle-comparisons.mlir
@@ -1,0 +1,34 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+moore.class.classdecl @HandleCompareClass {
+}
+
+// CHECK-LABEL: func.func @ChandleCompare
+// CHECK-SAME: ([[LHS:%.+]]: !llvm.ptr, [[RHS:%.+]]: !llvm.ptr)
+func.func @ChandleCompare(%lhs: !moore.chandle, %rhs: !moore.chandle) -> (!moore.i1, !moore.i1, !moore.i1, !moore.i1) {
+  // CHECK: [[EQ:%.+]] = llvm.icmp "eq" [[LHS]], [[RHS]] : !llvm.ptr
+  // CHECK: [[NE:%.+]] = llvm.icmp "ne" [[LHS]], [[RHS]] : !llvm.ptr
+  // CHECK: [[CASE_EQ:%.+]] = llvm.icmp "eq" [[LHS]], [[RHS]] : !llvm.ptr
+  // CHECK: [[CASE_NE:%.+]] = llvm.icmp "ne" [[LHS]], [[RHS]] : !llvm.ptr
+  // CHECK: return [[EQ]], [[NE]], [[CASE_EQ]], [[CASE_NE]] : i1, i1, i1, i1
+  %eq = moore.handle_eq %lhs, %rhs : !moore.chandle : !moore.chandle -> !moore.i1
+  %ne = moore.handle_ne %lhs, %rhs : !moore.chandle : !moore.chandle -> !moore.i1
+  %case_eq = moore.handle_case_eq %lhs, %rhs : !moore.chandle, !moore.chandle
+  %case_ne = moore.handle_case_ne %lhs, %rhs : !moore.chandle, !moore.chandle
+  return %eq, %ne, %case_eq, %case_ne : !moore.i1, !moore.i1, !moore.i1, !moore.i1
+}
+
+// CHECK-LABEL: func.func @ClassCompare
+// CHECK-SAME: ([[LHS:%.+]]: !llvm.ptr, [[RHS:%.+]]: !llvm.ptr)
+func.func @ClassCompare(%lhs: !moore.class<@HandleCompareClass>, %rhs: !moore.class<@HandleCompareClass>) -> (!moore.i1, !moore.i1, !moore.i1, !moore.i1) {
+  // CHECK: [[CLASS_EQ:%.+]] = llvm.icmp "eq" [[LHS]], [[RHS]] : !llvm.ptr
+  // CHECK: [[CLASS_NE:%.+]] = llvm.icmp "ne" [[LHS]], [[RHS]] : !llvm.ptr
+  // CHECK: [[CLASS_CASE_EQ:%.+]] = llvm.icmp "eq" [[LHS]], [[RHS]] : !llvm.ptr
+  // CHECK: [[CLASS_CASE_NE:%.+]] = llvm.icmp "ne" [[LHS]], [[RHS]] : !llvm.ptr
+  // CHECK: return [[CLASS_EQ]], [[CLASS_NE]], [[CLASS_CASE_EQ]], [[CLASS_CASE_NE]] : i1, i1, i1, i1
+  %eq = moore.handle_eq %lhs, %rhs : !moore.class<@HandleCompareClass> : !moore.class<@HandleCompareClass> -> !moore.i1
+  %ne = moore.handle_ne %lhs, %rhs : !moore.class<@HandleCompareClass> : !moore.class<@HandleCompareClass> -> !moore.i1
+  %case_eq = moore.handle_case_eq %lhs, %rhs : !moore.class<@HandleCompareClass>, !moore.class<@HandleCompareClass>
+  %case_ne = moore.handle_case_ne %lhs, %rhs : !moore.class<@HandleCompareClass>, !moore.class<@HandleCompareClass>
+  return %eq, %ne, %case_eq, %case_ne : !moore.i1, !moore.i1, !moore.i1, !moore.i1
+}

--- a/test/Conversion/MooreToCore/handle-like-conversions.mlir
+++ b/test/Conversion/MooreToCore/handle-like-conversions.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+moore.class.classdecl @C {
+}
+
+// CHECK-LABEL: func.func @ClassToChandle(
+// CHECK-SAME: %[[ARG:.*]]: !llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT: return %[[ARG]] : !llvm.ptr
+func.func @ClassToChandle(%obj: !moore.class<@C>) -> !moore.chandle {
+  %handle = moore.conversion %obj : !moore.class<@C> -> !moore.chandle
+  return %handle : !moore.chandle
+}
+
+// CHECK-LABEL: func.func @ChandleToClass(
+// CHECK-SAME: %[[ARG:.*]]: !llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT: return %[[ARG]] : !llvm.ptr
+func.func @ChandleToClass(%handle: !moore.chandle) -> !moore.class<@C> {
+  %obj = moore.conversion %handle : !moore.chandle -> !moore.class<@C>
+  return %obj : !moore.class<@C>
+}
+
+// CHECK-LABEL: func.func @ClassRefToChandleRef(
+// CHECK-SAME: %[[ARG:.*]]: !llhd.ref<!llvm.ptr>) -> !llhd.ref<!llvm.ptr>
+// CHECK-NEXT: return %[[ARG]] : !llhd.ref<!llvm.ptr>
+func.func @ClassRefToChandleRef(%obj: !moore.ref<class<@C>>) -> !moore.ref<chandle> {
+  %handle = moore.conversion %obj : !moore.ref<class<@C>> -> !moore.ref<chandle>
+  return %handle : !moore.ref<chandle>
+}
+
+// CHECK-LABEL: func.func @ChandleRefToClassRef(
+// CHECK-SAME: %[[ARG:.*]]: !llhd.ref<!llvm.ptr>) -> !llhd.ref<!llvm.ptr>
+// CHECK-NEXT: return %[[ARG]] : !llhd.ref<!llvm.ptr>
+func.func @ChandleRefToClassRef(%handle: !moore.ref<chandle>) -> !moore.ref<class<@C>> {
+  %obj = moore.conversion %handle : !moore.ref<chandle> -> !moore.ref<class<@C>>
+  return %obj : !moore.ref<class<@C>>
+}
+
+// CHECK-NOT: moore.conversion

--- a/test/Conversion/MooreToCore/null-handles.mlir
+++ b/test/Conversion/MooreToCore/null-handles.mlir
@@ -1,0 +1,36 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+moore.class.classdecl @NullClass {
+}
+
+// CHECK-LABEL: func.func @NullToChandle() -> !llvm.ptr {
+// CHECK-NEXT:    [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+// CHECK-NEXT:    return [[NULL]] : !llvm.ptr
+// CHECK-NEXT:  }
+func.func @NullToChandle() -> !moore.chandle {
+  %null = moore.null
+  %0 = moore.conversion %null : !moore.null -> !moore.chandle
+  return %0 : !moore.chandle
+}
+
+// CHECK-LABEL: func.func @NullToClass() -> !llvm.ptr {
+// CHECK-NEXT:    [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+// CHECK-NEXT:    return [[NULL]] : !llvm.ptr
+// CHECK-NEXT:  }
+func.func @NullToClass() -> !moore.class<@NullClass> {
+  %null = moore.null
+  %0 = moore.conversion %null : !moore.null -> !moore.class<@NullClass>
+  return %0 : !moore.class<@NullClass>
+}
+
+// Source event variables lower to one-bit Moore values; assigning null to such
+// an event must produce the event's inactive value.
+// CHECK-LABEL: func.func @NullToEventBit() -> i1 {
+// CHECK:         [[FALSE:%.+]] = hw.constant false
+// CHECK:         return [[FALSE]] : i1
+// CHECK-NEXT:  }
+func.func @NullToEventBit() -> !moore.i1 {
+  %null = moore.null
+  %0 = moore.conversion %null : !moore.null -> !moore.i1
+  return %0 : !moore.i1
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Lower handle (chandle, class) and event type value conversions in MooreToCore (IEEE 1800-2023 §3.11, §4.8). Previously dropped; lowers event to i1, handles to llvm.ptr; supports conversions in conditionals, comparisons, aggregate containers. Maps to existing lowering. Standalone.

Tests: event-type-conversion.mlir, handle-comparisons.mlir, handle-like-conversions.mlir, null-handles.mlir.
