### PR TITLE
[MooreToCore] Lower real math and clog2 builtins

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/IRInterface.h
+++ b/include/circt/Dialect/Arc/Runtime/IRInterface.h
@@ -100,6 +100,9 @@ ARC_IR_EXPORT void arcRuntimeIR_onInitialized(uint8_t *modelState);
 ARC_IR_EXPORT void
 arcRuntimeIR_format(const circt::arc::runtime::FmtDescriptor *fmt, ...);
 
+/// Computes the hypotenuse of two real values.
+ARC_IR_EXPORT double arcRuntimeIR_realHypot(double lhs, double rhs);
+
 /// Release the active trace buffer and request an empty new buffer.
 ///
 /// Invoked by the model to signal that the currently active trace buffer,

--- a/include/circt/Dialect/Arc/Runtime/JITBind.h
+++ b/include/circt/Dialect/Arc/Runtime/JITBind.h
@@ -33,6 +33,7 @@ struct APICallbacks {
   void (*fnOnEval)(uint8_t *simState);
   void (*fnOnInitialized)(uint8_t *simState);
   void (*fnFormat)(const FmtDescriptor *fmt, ...);
+  double (*fnRealHypot)(double lhs, double rhs);
   uint64_t *(*fnSwapTraceBuffer)(const uint8_t *simState);
 
   static constexpr char symNameAllocInstance[] = "arcRuntimeIR_allocInstance";
@@ -40,6 +41,7 @@ struct APICallbacks {
   static constexpr char symNameOnEval[] = "arcRuntimeIR_onEval";
   static constexpr char symNameOnInitialized[] = "arcRuntimeIR_onInitialized";
   static constexpr char symNameFormat[] = "arcRuntimeIR_format";
+  static constexpr char symNameRealHypot[] = "arcRuntimeIR_realHypot";
   static constexpr char symNameSwapTraceBuffer[] =
       "arcRuntimeIR_swapTraceBuffer";
 };

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3211,6 +3211,20 @@ class RealMathFunc<string mnemonic, list<Trait> traits = []> :
   let assemblyFormat = "$value attr-dict `:` type($value)";
 }
 
+class BinaryRealMathFunc<string mnemonic, list<Trait> traits = []> :
+    Builtin<mnemonic, traits # [SameOperandsAndResultType]> {
+  let description = [{
+    The system real math functions shall accept real value arguments and return
+    a real result type. Their behavior shall match the equivalent C language
+    standard math library function indicated.
+
+    See IEEE 1800-2017 section 20.8.2 "Real math functions".
+   }];
+  let arguments = (ins RealF64:$lhs, RealF64:$rhs);
+  let results = (outs RealF64:$result);
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs)";
+}
+
 def Clog2BIOp : Builtin<"clog2", [SameOperandsAndResultType]> {
   let summary = "Compute ceil(log2(x)) of x";
   let description = [{
@@ -3277,6 +3291,10 @@ def AtanBIOp : RealMathFunc<"atan"> {
   let summary = "Arc-tangent";
 }
 
+def Atan2BIOp : BinaryRealMathFunc<"atan2"> {
+  let summary = "Two-argument arc-tangent";
+}
+
 def SinhBIOp : RealMathFunc<"sinh"> {
   let summary = "Hyperbolic sine";
 }
@@ -3299,6 +3317,10 @@ def AcoshBIOp : RealMathFunc<"acosh"> {
 
 def AtanhBIOp : RealMathFunc<"atanh"> {
   let summary = "Arc-hyperbolic tangent";
+}
+
+def HypotBIOp : BinaryRealMathFunc<"hypot"> {
+  let summary = "Hypotenuse";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -439,6 +439,18 @@ def FormatGeneralOp : SimOp<"fmt.gen",
   }];
 }
 
+def RealHypotOp : SimOp<"real.hypot", [Pure, SameOperandsAndResultType]> {
+  let summary = "Hypotenuse";
+  let description = [{
+    Computes the hypotenuse of two real values. Runtime backends should implement
+    the same behavior as the C standard library `hypot` function.
+  }];
+
+  let arguments = (ins AnyFloat:$lhs, AnyFloat:$rhs);
+  let results = (outs AnyFloat:$result);
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` qualified(type($lhs))";
+}
+
 def FormatDecOp : SimOp<"fmt.dec",
     [Pure, DeclareOpInterfaceMethods<SimValueFormatter>]
 > {

--- a/integration_test/arcilator/JIT/sim-real-math-runtime.mlir
+++ b/integration_test/arcilator/JIT/sim-real-math-runtime.mlir
@@ -1,0 +1,16 @@
+// RUN: arcilator --run %s --jit-entry=entry | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
+func.func @entry() {
+  %three = arith.constant 3.0 : f64
+  %four = arith.constant 4.0 : f64
+  %five = arith.constant 5.0 : f64
+
+  %hypot = sim.real.hypot %three, %four : f64
+  %ok = arith.cmpf oeq, %hypot, %five : f64
+
+  // CHECK: hypot_ok = 1
+  arc.sim.emit "hypot_ok", %ok : i1
+
+  return
+}

--- a/lib/Bindings/Python/setup.py
+++ b/lib/Bindings/Python/setup.py
@@ -148,7 +148,7 @@ setup(
     ],
     cmdclass={
         "build": CustomBuild,
-        "built_ext": NoopBuildExtension,
+        "build_ext": NoopBuildExtension,
         "build_py": CMakeBuild,
     },
     zip_safe=False,

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1064,6 +1064,45 @@ struct SimPrintFormattedProcOpLowering
   StringCache &stringCache;
 };
 
+struct SimRealHypotOpLowering : public OpConversionPattern<sim::RealHypotOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(sim::RealHypotOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    Type resultType = getTypeConverter()->convertType(op.getType());
+    bool resultIsF32 = isa<Float32Type>(resultType);
+    if (!resultIsF32 && !isa<Float64Type>(resultType))
+      return rewriter.notifyMatchFailure(op, "unsupported real type");
+
+    Type f64Ty = rewriter.getF64Type();
+    Value lhs = adaptor.getLhs();
+    Value rhs = adaptor.getRhs();
+    if (resultIsF32) {
+      lhs = LLVM::FPExtOp::create(rewriter, loc, f64Ty, lhs);
+      rhs = LLVM::FPExtOp::create(rewriter, loc, f64Ty, rhs);
+    }
+
+    auto module = op->getParentOfType<ModuleOp>();
+    SmallVector<Type> argTypes{f64Ty, f64Ty};
+    auto fn = LLVM::lookupOrCreateFn(rewriter, module,
+                                     runtime::APICallbacks::symNameRealHypot,
+                                     argTypes, f64Ty);
+    if (failed(fn))
+      return failure();
+
+    Value result =
+        LLVM::CallOp::create(rewriter, loc, fn.value(), ValueRange{lhs, rhs})
+            .getResult();
+    if (resultIsF32)
+      result = LLVM::FPTruncOp::create(rewriter, loc, resultType, result);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 struct TerminateOpLowering : public OpConversionPattern<arc::TerminateOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -1912,6 +1951,7 @@ void LowerArcToLLVMPass::runOnOperation() {
   StringCache stringCache;
   patterns.add<SimEmitValueOpLowering, SimPrintFormattedProcOpLowering>(
       converter, &getContext(), stringCache);
+  patterns.add<SimRealHypotOpLowering>(converter, &getContext());
 
   auto &modelInfo = getAnalysis<ModelInfoAnalysis>();
   llvm::DenseMap<StringRef, ModelInfoMap> modelMap(modelInfo.infoMap.size());

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1858,6 +1858,53 @@ struct FCmpOpConversion : public OpConversionPattern<SourceOp> {
   }
 };
 
+template <typename SourceOp, typename TargetOp>
+struct UnaryRealBuiltinOpConversion : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+  using OpAdaptor = typename SourceOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<TargetOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getValue());
+    return success();
+  }
+};
+
+struct Clog2BIOpConversion : public OpConversionPattern<Clog2BIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(Clog2BIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resultType =
+        dyn_cast<IntegerType>(typeConverter->convertType(op.getType()));
+    if (!resultType)
+      return failure();
+
+    Location loc = op.getLoc();
+    unsigned width = resultType.getWidth();
+    Value result = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
+
+    for (unsigned i = 1; i <= width; ++i) {
+      APInt threshold(width, 0);
+      threshold.setBit(i - 1);
+      Value thresholdValue = hw::ConstantOp::create(rewriter, loc, threshold);
+      Value isGreater =
+          comb::ICmpOp::create(rewriter, loc, comb::ICmpPredicate::ugt,
+                               adaptor.getValue(), thresholdValue, false);
+      Value nextResult = hw::ConstantOp::create(rewriter, loc, APInt(width, i));
+      result = comb::MuxOp::create(rewriter, loc, isGreater, nextResult, result,
+                                   false);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 template <typename SourceOp, bool withoutX>
 struct CaseXZEqOpConversion : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
@@ -2083,6 +2130,20 @@ struct ConvertRealOpConversion : public OpConversionPattern<ConvertRealOp> {
               op, typeConverter->convertType(op.getType()), adaptor.getInput())
         : rewriter.replaceOpWithNewOp<arith::TruncFOp>(
               op, typeConverter->convertType(op.getType()), adaptor.getInput());
+    return success();
+  }
+};
+
+template <typename SourceOp>
+struct RealBitcastBuiltinOpConversion : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.template replaceOpWithNewOp<arith::BitcastOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getValue());
     return success();
   }
 };
@@ -3493,6 +3554,10 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     IntToStringOpConversion,
     RealToIntOpConversion,
     ConvertRealOpConversion,
+    RealBitcastBuiltinOpConversion<RealtobitsBIOp>,
+    RealBitcastBuiltinOpConversion<BitstorealBIOp>,
+    RealBitcastBuiltinOpConversion<ShortrealtobitsBIOp>,
+    RealBitcastBuiltinOpConversion<BitstoshortrealBIOp>,
 
     // Patterns of miscellaneous operations.
     ConstantOpConv,
@@ -3546,6 +3611,27 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     BinaryRealOpConversion<DivRealOp, arith::DivFOp>,
     BinaryRealOpConversion<MulRealOp, arith::MulFOp>,
     BinaryRealOpConversion<PowRealOp, math::PowFOp>,
+    BinaryRealOpConversion<Atan2BIOp, math::Atan2Op>,
+    BinaryRealOpConversion<HypotBIOp, sim::RealHypotOp>,
+    UnaryRealBuiltinOpConversion<LnBIOp, math::LogOp>,
+    UnaryRealBuiltinOpConversion<Log10BIOp, math::Log10Op>,
+    UnaryRealBuiltinOpConversion<ExpBIOp, math::ExpOp>,
+    UnaryRealBuiltinOpConversion<SqrtBIOp, math::SqrtOp>,
+    UnaryRealBuiltinOpConversion<FloorBIOp, math::FloorOp>,
+    UnaryRealBuiltinOpConversion<CeilBIOp, math::CeilOp>,
+    UnaryRealBuiltinOpConversion<SinBIOp, math::SinOp>,
+    UnaryRealBuiltinOpConversion<CosBIOp, math::CosOp>,
+    UnaryRealBuiltinOpConversion<TanBIOp, math::TanOp>,
+    UnaryRealBuiltinOpConversion<AsinBIOp, math::AsinOp>,
+    UnaryRealBuiltinOpConversion<AcosBIOp, math::AcosOp>,
+    UnaryRealBuiltinOpConversion<AtanBIOp, math::AtanOp>,
+    UnaryRealBuiltinOpConversion<SinhBIOp, math::SinhOp>,
+    UnaryRealBuiltinOpConversion<CoshBIOp, math::CoshOp>,
+    UnaryRealBuiltinOpConversion<TanhBIOp, math::TanhOp>,
+    UnaryRealBuiltinOpConversion<AsinhBIOp, math::AsinhOp>,
+    UnaryRealBuiltinOpConversion<AcoshBIOp, math::AcoshOp>,
+    UnaryRealBuiltinOpConversion<AtanhBIOp, math::AtanhOp>,
+    Clog2BIOpConversion,
 
     // Patterns of power operations.
     PowUOpConversion, PowSOpConversion,

--- a/lib/Dialect/Arc/Runtime/ArcRuntime.cpp
+++ b/lib/Dialect/Arc/Runtime/ArcRuntime.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <cassert>
+#include <cmath>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
@@ -150,6 +151,10 @@ void arcRuntimeIR_format(const FmtDescriptor *fmt, ...) {
   va_end(args);
 }
 
+double arcRuntimeIR_realHypot(double lhs, double rhs) {
+  return std::hypot(lhs, rhs);
+}
+
 uint64_t *arcRuntimeIR_swapTraceBuffer(const uint8_t *modelState) {
   auto *modPtr = static_cast<const uint8_t *>(modelState);
   auto *statePtr =
@@ -163,9 +168,10 @@ uint64_t *arcRuntimeIR_swapTraceBuffer(const uint8_t *modelState) {
 namespace circt::arc::runtime {
 
 static const APICallbacks apiCallbacksGlobal{
-    &arcRuntimeIR_allocInstance, &arcRuntimeIR_deleteInstance,
-    &arcRuntimeIR_onEval,        &arcRuntimeIR_onInitialized,
-    &arcRuntimeIR_format,        &arcRuntimeIR_swapTraceBuffer};
+    &arcRuntimeIR_allocInstance,  &arcRuntimeIR_deleteInstance,
+    &arcRuntimeIR_onEval,         &arcRuntimeIR_onInitialized,
+    &arcRuntimeIR_format,         &arcRuntimeIR_realHypot,
+    &arcRuntimeIR_swapTraceBuffer};
 
 const APICallbacks &getArcRuntimeAPICallbacks() { return apiCallbacksGlobal; }
 

--- a/test/Conversion/ArcToLLVM/sim-real-math-runtime.mlir
+++ b/test/Conversion/ArcToLLVM/sim-real-math-runtime.mlir
@@ -1,0 +1,8 @@
+// RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
+
+// CHECK-DAG: llvm.func @arcRuntimeIR_realHypot(f64, f64) -> f64
+func.func @real_hypot(%lhs: f64, %rhs: f64) -> f64 {
+  // CHECK: llvm.call @arcRuntimeIR_realHypot(%{{.*}}, %{{.*}}) : (f64, f64) -> f64
+  %result = sim.real.hypot %lhs, %rhs : f64
+  return %result : f64
+}

--- a/test/Conversion/MooreToCore/clog2-builtin.mlir
+++ b/test/Conversion/MooreToCore/clog2-builtin.mlir
@@ -1,0 +1,16 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @clog2_builtin(
+  // CHECK-SAME: %[[INPUT:.+]]: i8
+  func.func @clog2_builtin(%input: !moore.i8) -> !moore.i8 {
+    // CHECK: %[[ZERO:.+]] = hw.constant 0 : i8
+    // CHECK: %[[GT:.+]] = comb.icmp ugt %[[INPUT]],
+    // CHECK: %[[ONE:.+]] = hw.constant 1 : i8
+    // CHECK: comb.mux %[[GT]], %[[ONE]], %[[ZERO]] : i8
+    // CHECK: hw.constant 8 : i8
+    // CHECK-NOT: moore.builtin.clog2
+    %result = moore.builtin.clog2 %input : i8
+    return %result : !moore.i8
+  }
+}

--- a/test/Conversion/MooreToCore/real-bit-conversion-builtins.mlir
+++ b/test/Conversion/MooreToCore/real-bit-conversion-builtins.mlir
@@ -1,0 +1,37 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @RealToBits
+// CHECK-SAME: (%arg0: f64) -> i64
+func.func @RealToBits(%value: !moore.f64) -> !moore.i64 {
+  // CHECK: %[[BITS:.*]] = arith.bitcast %arg0 : f64 to i64
+  %bits = moore.builtin.realtobits %value
+  // CHECK: return %[[BITS]] : i64
+  return %bits : !moore.i64
+}
+
+// CHECK-LABEL: func.func @BitsToReal
+// CHECK-SAME: (%arg0: i64) -> f64
+func.func @BitsToReal(%value: !moore.i64) -> !moore.f64 {
+  // CHECK: %[[REAL:.*]] = arith.bitcast %arg0 : i64 to f64
+  %real = moore.builtin.bitstoreal %value : !moore.i64
+  // CHECK: return %[[REAL]] : f64
+  return %real : !moore.f64
+}
+
+// CHECK-LABEL: func.func @ShortRealToBits
+// CHECK-SAME: (%arg0: f32) -> i32
+func.func @ShortRealToBits(%value: !moore.f32) -> !moore.i32 {
+  // CHECK: %[[BITS:.*]] = arith.bitcast %arg0 : f32 to i32
+  %bits = moore.builtin.shortrealtobits %value
+  // CHECK: return %[[BITS]] : i32
+  return %bits : !moore.i32
+}
+
+// CHECK-LABEL: func.func @BitsToShortReal
+// CHECK-SAME: (%arg0: i32) -> f32
+func.func @BitsToShortReal(%value: !moore.i32) -> !moore.f32 {
+  // CHECK: %[[REAL:.*]] = arith.bitcast %arg0 : i32 to f32
+  %real = moore.builtin.bitstoshortreal %value : !moore.i32
+  // CHECK: return %[[REAL]] : f32
+  return %real : !moore.f32
+}

--- a/test/Conversion/MooreToCore/real-math-builtins.mlir
+++ b/test/Conversion/MooreToCore/real-math-builtins.mlir
@@ -1,0 +1,48 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @RealMathBuiltins
+// CHECK-SAME: (%arg0: f64) -> f64
+func.func @RealMathBuiltins(%value: !moore.f64) -> !moore.f64 {
+  // CHECK: %[[LN:.*]] = math.log %arg0 : f64
+  %ln = moore.builtin.ln %value : !moore.f64
+  // CHECK: %[[LOG10:.*]] = math.log10 %[[LN]] : f64
+  %log10 = moore.builtin.log10 %ln : !moore.f64
+  // CHECK: %[[EXP:.*]] = math.exp %[[LOG10]] : f64
+  %exp = moore.builtin.exp %log10 : !moore.f64
+  // CHECK: %[[SQRT:.*]] = math.sqrt %[[EXP]] : f64
+  %sqrt = moore.builtin.sqrt %exp : !moore.f64
+  // CHECK: %[[FLOOR:.*]] = math.floor %[[SQRT]] : f64
+  %floor = moore.builtin.floor %sqrt : !moore.f64
+  // CHECK: %[[CEIL:.*]] = math.ceil %[[FLOOR]] : f64
+  %ceil = moore.builtin.ceil %floor : !moore.f64
+  // CHECK: %[[SIN:.*]] = math.sin %[[CEIL]] : f64
+  %sin = moore.builtin.sin %ceil : !moore.f64
+  // CHECK: %[[COS:.*]] = math.cos %[[SIN]] : f64
+  %cos = moore.builtin.cos %sin : !moore.f64
+  // CHECK: %[[TAN:.*]] = math.tan %[[COS]] : f64
+  %tan = moore.builtin.tan %cos : !moore.f64
+  // CHECK: %[[ASIN:.*]] = math.asin %[[TAN]] : f64
+  %asin = moore.builtin.asin %tan : !moore.f64
+  // CHECK: %[[ACOS:.*]] = math.acos %[[ASIN]] : f64
+  %acos = moore.builtin.acos %asin : !moore.f64
+  // CHECK: %[[ATAN:.*]] = math.atan %[[ACOS]] : f64
+  %atan = moore.builtin.atan %acos : !moore.f64
+  // CHECK: %[[ATAN2:.*]] = math.atan2 %[[ATAN]], %[[ATAN]] : f64
+  %atan2 = moore.builtin.atan2 %atan, %atan : !moore.f64
+  // CHECK: %[[SINH:.*]] = math.sinh %[[ATAN2]] : f64
+  %sinh = moore.builtin.sinh %atan2 : !moore.f64
+  // CHECK: %[[COSH:.*]] = math.cosh %[[SINH]] : f64
+  %cosh = moore.builtin.cosh %sinh : !moore.f64
+  // CHECK: %[[TANH:.*]] = math.tanh %[[COSH]] : f64
+  %tanh = moore.builtin.tanh %cosh : !moore.f64
+  // CHECK: %[[ASINH:.*]] = math.asinh %[[TANH]] : f64
+  %asinh = moore.builtin.asinh %tanh : !moore.f64
+  // CHECK: %[[ACOSH:.*]] = math.acosh %[[ASINH]] : f64
+  %acosh = moore.builtin.acosh %asinh : !moore.f64
+  // CHECK: %[[ATANH:.*]] = math.atanh %[[ACOSH]] : f64
+  %atanh = moore.builtin.atanh %acosh : !moore.f64
+  // CHECK: %[[HYPOT:.*]] = sim.real.hypot %[[ATANH]], %[[ATANH]] : f64
+  %hypot = moore.builtin.hypot %atanh, %atanh : !moore.f64
+  // CHECK: return %[[HYPOT]] : f64
+  return %hypot : !moore.f64
+}

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -89,6 +89,13 @@ func.func @FormatStrings() {
   return
 }
 
+// CHECK-LABEL: func.func @RealMath
+func.func @RealMath(%lhs: f64, %rhs: f64) -> f64 {
+  // CHECK: sim.real.hypot %{{.*}}, %{{.*}} : f64
+  %hypot = sim.real.hypot %lhs, %rhs : f64
+  return %hypot : f64
+}
+
 // CHECK-LABEL: func.func @DynamicStrings
 func.func @DynamicStrings(%idx: i32) {
   // CHECK: sim.string.literal "Hello"

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -322,6 +322,9 @@ static void bindArcRuntimeSymbols(ExecutionEngine &executionEngine) {
                               runtimeCallbacks.symNameFormat,
                               runtimeCallbacks.fnFormat);
     bindExecutionEngineSymbol(symbolMap, interner,
+                              runtimeCallbacks.symNameRealHypot,
+                              runtimeCallbacks.fnRealHypot);
+    bindExecutionEngineSymbol(symbolMap, interner,
                               runtimeCallbacks.symNameSwapTraceBuffer,
                               runtimeCallbacks.fnSwapTraceBuffer);
     return symbolMap;


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Lower real bit conversion builtins ($realtobits, $bitstoreal) and real math functions ($pow, $atan2, $log, $exp, $sin, $cos, $tan, $asin, $acos, $atan, etc.) and $clog2 system function in MooreToCore (IEEE 1800-2023 §20.8). Previously dropped; maps to math dialect and comb ops. Standalone.

Tests: clog2-builtin.mlir, real-bit-conversion-builtins.mlir, real-math-builtins.mlir.
