### PR TITLE
[MooreToCore] Lower real and time value conversions

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1918,6 +1918,53 @@ struct ConversionOpConversion : public OpConversionPattern<ConversionOp> {
       op.emitError("conversion result type is not currently supported");
       return failure();
     }
+
+    if (isa<llhd::TimeType>(adaptor.getInput().getType()) &&
+        isa<FloatType>(resultType)) {
+      auto timeAsInt =
+          llhd::TimeToIntOp::create(rewriter, loc, adaptor.getInput());
+      rewriter.replaceOpWithNewOp<arith::UIToFPOp>(op, resultType, timeAsInt);
+      return success();
+    }
+
+    if (isa<llhd::TimeType>(adaptor.getInput().getType()) &&
+        isa<IntegerType>(resultType)) {
+      Value input =
+          llhd::TimeToIntOp::create(rewriter, loc, adaptor.getInput());
+      Value result = adjustIntegerWidth(
+          rewriter, input, cast<IntegerType>(resultType).getWidth(), loc);
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    if (isa<IntegerType>(adaptor.getInput().getType()) &&
+        isa<llhd::TimeType>(resultType)) {
+      Value input = adjustIntegerWidth(rewriter, adaptor.getInput(), 64, loc);
+      rewriter.replaceOpWithNewOp<llhd::IntToTimeOp>(op, input);
+      return success();
+    }
+
+    if (isa<FloatType>(adaptor.getInput().getType()) &&
+        isa<IntegerType>(resultType)) {
+      rewriter.replaceOpWithNewOp<arith::FPToSIOp>(op, resultType,
+                                                   adaptor.getInput());
+      return success();
+    }
+
+    if (auto inputType = dyn_cast<FloatType>(adaptor.getInput().getType())) {
+      if (auto outputType = dyn_cast<FloatType>(resultType)) {
+        if (inputType == outputType) {
+          rewriter.replaceOp(op, adaptor.getInput());
+        } else if (inputType.getWidth() < outputType.getWidth()) {
+          rewriter.replaceOpWithNewOp<arith::ExtFOp>(op, resultType,
+                                                     adaptor.getInput());
+        } else {
+          rewriter.replaceOpWithNewOp<arith::TruncFOp>(op, resultType,
+                                                       adaptor.getInput());
+        }
+        return success();
+      }
+    }
     int64_t inputBw = hw::getBitWidth(adaptor.getInput().getType());
     int64_t resultBw = hw::getBitWidth(resultType);
     if (inputBw == -1 || resultBw == -1) {

--- a/test/Conversion/MooreToCore/real-to-int-conversion.mlir
+++ b/test/Conversion/MooreToCore/real-to-int-conversion.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @f64_to_i32
+// CHECK-SAME: (%arg0: f64) -> i32
+func.func @f64_to_i32(%input: !moore.f64) -> !moore.i32 {
+  // CHECK: arith.fptosi %arg0 : f64 to i32
+  %result = moore.conversion %input : !moore.f64 -> !moore.i32
+  return %result : !moore.i32
+}
+
+// CHECK-LABEL: func.func @f32_to_i64
+// CHECK-SAME: (%arg0: f32) -> i64
+func.func @f32_to_i64(%input: !moore.f32) -> !moore.i64 {
+  // CHECK: arith.fptosi %arg0 : f32 to i64
+  %result = moore.conversion %input : !moore.f32 -> !moore.i64
+  return %result : !moore.i64
+}

--- a/test/Conversion/MooreToCore/real-value-conversions.mlir
+++ b/test/Conversion/MooreToCore/real-value-conversions.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @f32_to_f64
+// CHECK-SAME: (%arg0: f32) -> f64
+func.func @f32_to_f64(%input: !moore.f32) -> !moore.f64 {
+  // CHECK: arith.extf %arg0 : f32 to f64
+  %result = moore.conversion %input : !moore.f32 -> !moore.f64
+  return %result : !moore.f64
+}
+
+// CHECK-LABEL: func.func @f64_to_f32
+// CHECK-SAME: (%arg0: f64) -> f32
+func.func @f64_to_f32(%input: !moore.f64) -> !moore.f32 {
+  // CHECK: arith.truncf %arg0 : f64 to f32
+  %result = moore.conversion %input : !moore.f64 -> !moore.f32
+  return %result : !moore.f32
+}

--- a/test/Conversion/MooreToCore/time-to-real-conversion.mlir
+++ b/test/Conversion/MooreToCore/time-to-real-conversion.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @time_to_f64
+// CHECK-SAME: (%arg0: !llhd.time) -> f64
+func.func @time_to_f64(%input: !moore.time) -> !moore.f64 {
+  // CHECK: %[[INT:.*]] = llhd.time_to_int %arg0
+  // CHECK: %[[REAL:.*]] = arith.uitofp %[[INT]] : i64 to f64
+  %result = moore.conversion %input : !moore.time -> !moore.f64
+  // CHECK: return %[[REAL]] : f64
+  return %result : !moore.f64
+}
+
+// CHECK-LABEL: func.func @time_to_f32
+// CHECK-SAME: (%arg0: !llhd.time) -> f32
+func.func @time_to_f32(%input: !moore.time) -> !moore.f32 {
+  // CHECK: %[[INT:.*]] = llhd.time_to_int %arg0
+  // CHECK: %[[REAL:.*]] = arith.uitofp %[[INT]] : i64 to f32
+  %result = moore.conversion %input : !moore.time -> !moore.f32
+  // CHECK: return %[[REAL]] : f32
+  return %result : !moore.f32
+}

--- a/test/Conversion/MooreToCore/time-value-conversions.mlir
+++ b/test/Conversion/MooreToCore/time-value-conversions.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @time_to_i64
+// CHECK-SAME: (%arg0: !llhd.time) -> i64
+func.func @time_to_i64(%input: !moore.time) -> !moore.l64 {
+  // CHECK: llhd.time_to_int %arg0
+  %result = moore.conversion %input : !moore.time -> !moore.l64
+  return %result : !moore.l64
+}
+
+// CHECK-LABEL: func.func @i64_to_time
+// CHECK-SAME: (%arg0: i64) -> !llhd.time
+func.func @i64_to_time(%input: !moore.l64) -> !moore.time {
+  // CHECK: llhd.int_to_time %arg0
+  %result = moore.conversion %input : !moore.l64 -> !moore.time
+  return %result : !moore.time
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Lower real and time value conversions and casts in MooreToCore (IEEE 1800-2023 §6.20.3, §6.20.6). Previously incomplete; handles time-to-int, real-to-int, time-to-real conversions in assignments and initializations. Maps to existing conversion ops. Standalone.

Tests: real-to-int-conversion.mlir, real-value-conversions.mlir, time-to-real-conversion.mlir, time-value-conversions.mlir.
