### PR TITLE
[MooreToCore] Fold zero-width unpacked array comparisons

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2687,6 +2687,31 @@ struct QueueSizeBIOpConversion : public OpConversionPattern<QueueSizeBIOp> {
   }
 };
 
+struct ZeroWidthUArrayCmpOpConversion
+    : public OpConversionPattern<UArrayCmpOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(UArrayCmpOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (hw::getBitWidth(adaptor.getLhs().getType()) != 0)
+      return failure();
+
+    bool result;
+    switch (adaptor.getPredicateAttr().getValue()) {
+    case circt::moore::UArrayCmpPredicate::eq:
+      result = true;
+      break;
+    case circt::moore::UArrayCmpPredicate::ne:
+      result = false;
+      break;
+    }
+
+    rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, APInt(1, result));
+    return success();
+  }
+};
+
 struct DynQueueExtractOpConversion
     : public OpConversionPattern<DynQueueExtractOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -3637,6 +3662,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     StringGetOpConversion,
 
     // Queue operations
+    ZeroWidthUArrayCmpOpConversion,
     QueueSizeBIOpConversion,
     QueuePushBackOpConversion,
     QueuePushFrontOpConversion,

--- a/test/Conversion/MooreToCore/zero-width-uarray-cmp.mlir
+++ b/test/Conversion/MooreToCore/zero-width-uarray-cmp.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt --convert-moore-to-core %s | FileCheck %s
+
+// CHECK-LABEL: func.func @empty_uarray_cmp
+// CHECK-SAME: (%arg0: !hw.array<0xi8>, %arg1: !hw.array<0xi8>) -> (i1, i1)
+// CHECK-NOT: moore.uarray_cmp
+// CHECK-DAG: %[[TRUE:.*]] = hw.constant true
+// CHECK-DAG: %[[FALSE:.*]] = hw.constant false
+// CHECK: return %[[TRUE]], %[[FALSE]] : i1, i1
+func.func @empty_uarray_cmp(%a: !moore.uarray<0x!moore.i8>, %b: !moore.uarray<0x!moore.i8>) -> (!moore.i1, !moore.i1) {
+  %eq = moore.uarray_cmp eq %a, %b : !moore.uarray<0x!moore.i8> -> !moore.i1
+  %ne = moore.uarray_cmp ne %a, %b : !moore.uarray<0x!moore.i8> -> !moore.i1
+  return %eq, %ne : !moore.i1, !moore.i1
+}
+
+// CHECK-LABEL: func.func @zero_bit_uarray_cmp
+// CHECK-SAME: (%arg0: !hw.array<4xi0>, %arg1: !hw.array<4xi0>) -> (i1, i1)
+// CHECK-NOT: moore.uarray_cmp
+// CHECK-DAG: %[[TRUE:.*]] = hw.constant true
+// CHECK-DAG: %[[FALSE:.*]] = hw.constant false
+// CHECK: return %[[TRUE]], %[[FALSE]] : i1, i1
+func.func @zero_bit_uarray_cmp(%a: !moore.uarray<4x!moore.i0>, %b: !moore.uarray<4x!moore.i0>) -> (!moore.i1, !moore.i1) {
+  %eq = moore.uarray_cmp eq %a, %b : !moore.uarray<4x!moore.i0> -> !moore.i1
+  %ne = moore.uarray_cmp ne %a, %b : !moore.uarray<4x!moore.i0> -> !moore.i1
+  return %eq, %ne : !moore.i1, !moore.i1
+}


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Fold unpacked array comparisons of empty or zero-bit-width arrays in MooreToCore. Equality comparisons always true, inequality always false, bypassing uarray_cmp ops. Adds ZeroWidthUArrayCmpOpConversion pattern. Standalone.

Tests: zero-width-uarray-cmp.mlir
