### PR TITLE
[MooreToCore] Convert debug value and enum wrappers

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -3225,10 +3225,10 @@ static void populateLegality(ConversionTarget &target,
 
   target.addLegalOp<debug::ScopeOp>();
 
-  target.addDynamicallyLegalOp<scf::YieldOp, func::CallOp, func::ReturnOp,
-                               UnrealizedConversionCastOp, hw::OutputOp,
-                               hw::InstanceOp, debug::ArrayOp, debug::StructOp,
-                               debug::VariableOp, arith::SelectOp>(
+  target.addDynamicallyLegalOp<
+      scf::YieldOp, func::CallOp, func::ReturnOp, UnrealizedConversionCastOp,
+      hw::OutputOp, hw::InstanceOp, debug::ArrayOp, debug::EnumOp,
+      debug::StructOp, debug::ValueOp, debug::VariableOp, arith::SelectOp>(
       [&](Operation *op) { return converter.isLegal(op); });
 
   target.addDynamicallyLegalOp<scf::IfOp, scf::ForOp, scf::ExecuteRegionOp,
@@ -3395,8 +3395,10 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
   typeConverter.addConversion([](sim::DynamicStringType type) { return type; });
   typeConverter.addConversion([](llhd::TimeType type) { return type; });
   typeConverter.addConversion([](debug::ArrayType type) { return type; });
+  typeConverter.addConversion([](debug::EnumType type) { return type; });
   typeConverter.addConversion([](debug::ScopeType type) { return type; });
   typeConverter.addConversion([](debug::StructType type) { return type; });
+  typeConverter.addConversion([](debug::ValueType type) { return type; });
 
   typeConverter.addConversion([&](llhd::RefType type) -> std::optional<Type> {
     if (auto innerType = typeConverter.convertType(type.getNestedType()))
@@ -3603,7 +3605,9 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FuncDPICallOpConversion,
     UnrealizedConversionCastConversion,
     InPlaceOpConversion<debug::ArrayOp>,
+    InPlaceOpConversion<debug::EnumOp>,
     InPlaceOpConversion<debug::StructOp>,
+    InPlaceOpConversion<debug::ValueOp>,
     InPlaceOpConversion<debug::VariableOp>,
 
     // Patterns of assert-like operations

--- a/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
+++ b/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
@@ -1279,34 +1280,49 @@ struct IntAbsOpLowering : public SMTLoweringPattern<IntAbsOp> {
 //===----------------------------------------------------------------------===//
 // Placeholder Debug Patterns
 //===----------------------------------------------------------------------===//
-// For now we want to ignore Debug variable and scope ops - eventually we'll
-// give this debug info to Z3
+// For now we want to ignore Debug ops - eventually we'll give this debug info
+// to Z3.
 
-/// Strip dbg.variable ops.
-struct DbgVariableLowering : public OpConversionPattern<debug::VariableOp> {
-  using OpConversionPattern::OpConversionPattern;
+static bool debugOpHasOnlyDebugUsers(Operation *op,
+                                     SmallPtrSetImpl<Operation *> &visited) {
+  if (!visited.insert(op).second)
+    return true;
+  return llvm::all_of(op->getUsers(), [&](Operation *user) {
+    if (!isa<debug::DebugDialect>(user->getDialect()))
+      return false;
+    return debugOpHasOnlyDebugUsers(user, visited);
+  });
+}
+
+static void eraseDebugOpAndUsers(Operation *op,
+                                 ConversionPatternRewriter &rewriter,
+                                 SmallPtrSetImpl<Operation *> &erased) {
+  if (!erased.insert(op).second)
+    return;
+
+  SmallVector<Operation *> users;
+  for (auto *user : op->getUsers())
+    if (!llvm::is_contained(users, user))
+      users.push_back(user);
+  for (auto *user : users)
+    eraseDebugOpAndUsers(user, rewriter, erased);
+
+  rewriter.eraseOp(op);
+}
+
+template <typename OpTy>
+struct DbgOpLowering : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(debug::VariableOp op, OpAdaptor adaptor,
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    rewriter.eraseOp(op);
-    return success();
-  }
-};
-
-/// Strip dbg.scope ops.
-struct DbgScopeLowering : public OpConversionPattern<debug::ScopeOp> {
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(debug::ScopeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const final {
-    // Make sure scope's only users are variables and therefore being deleted
-    if (llvm::any_of(op->getUsers(), [](Operation *user) {
-          return !isa<debug::VariableOp>(user);
-        }))
+    SmallPtrSet<Operation *, 8> visited;
+    if (!debugOpHasOnlyDebugUsers(op, visited))
       return failure();
-    rewriter.eraseOp(op);
+
+    SmallPtrSet<Operation *, 8> erased;
+    eraseDebugOpAndUsers(op, rewriter, erased);
     return success();
   }
 };
@@ -1546,7 +1562,10 @@ void circt::populateSMTToZ3LLVMConversionPatterns(
                BV2IntOpLowering, QuantifierLowering<ForallOp>,
                QuantifierLowering<ExistsOp>>(converter, patterns.getContext(),
                                              globals, options);
-  patterns.add<DbgVariableLowering, DbgScopeLowering>(patterns.getContext());
+  patterns.add<DbgOpLowering<debug::ArrayOp>, DbgOpLowering<debug::EnumOp>,
+               DbgOpLowering<debug::ScopeOp>, DbgOpLowering<debug::StructOp>,
+               DbgOpLowering<debug::ValueOp>, DbgOpLowering<debug::VariableOp>>(
+      patterns.getContext());
 }
 
 void LowerSMTToZ3LLVMPass::runOnOperation() {

--- a/lib/Target/DebugInfo/EmitHGLDD.cpp
+++ b/lib/Target/DebugInfo/EmitHGLDD.cpp
@@ -736,6 +736,13 @@ EmittedExpr FileEmitter::emitExpression(Value value) {
     return {JObject({{"bit_vector", buffer}}), type};
   }
 
+  // Look through debug metadata wrappers to the value they annotate.
+  if (auto valueOp = dyn_cast<debug::ValueOp>(op))
+    return emitExpression(valueOp.getValue());
+
+  if (auto enumOp = dyn_cast<debug::EnumOp>(op))
+    return emitExpression(enumOp.getValue());
+
   // Emit structs as assignment patterns and generate corresponding struct
   // definitions for inclusion in the main "objects" array.
   if (auto structOp = dyn_cast<debug::StructOp>(op)) {

--- a/test/Conversion/MooreToCore/debug-info.mlir
+++ b/test/Conversion/MooreToCore/debug-info.mlir
@@ -1,0 +1,15 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// CHECK-LABEL: func.func @DebugValueAndEnum
+// CHECK-SAME: (%arg0: i2)
+func.func @DebugValueAndEnum(%arg0: !moore.i2) {
+  // CHECK: %[[ENUM:.+]] = dbg.enum %arg0, "State", {Idle = 0 : i64, Run = 1 : i64} fqn "pkg.State" : i2
+  %enum = dbg.enum %arg0, "State", {Idle = 0 : i64, Run = 1 : i64} fqn "pkg.State" : !moore.i2
+
+  // CHECK: %[[VALUE:.+]] = dbg.value %[[ENUM]] typeName "State" : !dbg.enum
+  %value = dbg.value %enum typeName "State" : !dbg.enum
+
+  // CHECK: dbg.variable "state", %[[VALUE]] : !dbg.value
+  dbg.variable "state", %value : !dbg.value
+  return
+}

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -399,6 +399,18 @@ func.func @test(%arg0: i32) {
     %scope = dbg.scope "a", "A"
     dbg.variable "var2", %true scope %scope : !smt.bool
 
+    // CHECK-NOT: dbg.enum
+    // CHECK-NOT: dbg.value
+    // CHECK-NOT: dbg.array
+    // CHECK-NOT: dbg.struct
+    // CHECK-NOT: dbg.variable
+    %enum = dbg.enum %c0_bv4, "State", {Idle = 0 : i64, Run = 1 : i64} : !smt.bv<4>
+    %value = dbg.value %enum typeName "State" : !dbg.enum
+    dbg.variable "state", %value : !dbg.value
+    %array = dbg.array [%c0_bv4, %c0_bv4] : !smt.bv<4>
+    %struct = dbg.struct {"raw": %c0_bv4, "array": %array} : !smt.bv<4>, !dbg.array
+    dbg.variable "packed", %struct : !dbg.struct
+
     // CHECK: [[C0:%.+]] = llvm.mlir.constant(0 : i32)
     // CHECK: [[C2:%.+]] = llvm.mlir.constant(2 : i32)
     // CHECK: [[ZERO:%.+]] = llvm.mlir.zero : !llvm.ptr

--- a/test/Target/DebugInfo/emit-hgldd.mlir
+++ b/test/Target/DebugInfo/emit-hgldd.mlir
@@ -225,6 +225,19 @@ hw.module @Expressions(in %a: i1, in %b: i1) {
   dbg.variable "constC", %k2 : i4
   dbg.variable "constD", %k3 : i0
 
+  // CHECK-LABEL: "var_name": "directEnum"
+  // CHECK: "value": {"bit_vector":"01"}
+  // CHECK: "type_name": "logic"
+  //
+  // CHECK-LABEL: "var_name": "wrappedEnum"
+  // CHECK: "value": {"bit_vector":"01"}
+  // CHECK: "type_name": "logic"
+  %k4 = hw.constant 1 : i2
+  %enum = dbg.enum %k4, "State", {Idle = 0 : i64, Run = 1 : i64} : i2
+  %value = dbg.value %enum typeName "State" : !dbg.enum
+  dbg.variable "directEnum", %enum : !dbg.enum
+  dbg.variable "wrappedEnum", %value : !dbg.value
+
   // CHECK-LABEL: "var_name": "readWire"
   // CHECK: "value": {"sig_name":"svWire"}
   // CHECK: "type_name": "logic"


### PR DESCRIPTION
AI generated content follows. Some of this work is gated on PRs that are yet to merge but are also filed by me before. Aware there are a lot of open PRs from me right now, but parallelizing — apologies in advance!

Support debug.value and debug.enum wrapper ops—new debug dialect ops—across three dialects: MooreToCore adds InPlaceOpConversion patterns for in-place conversion; SMTToZ3LLVM strips debug ops when they have only debug users; DebugInfo/HGLDD emitter unwraps wrappers to access underlying values for expression annotation. Wrappers map to existing debug dialect infrastructure; no new core lowering surface. Standalone across three commits.

Tests: debug-info.mlir, smt-to-z3-llvm.mlir, emit-hgldd.mlir.
