### PR TITLE
[ci] Remove Python 3.10 wheels

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -16,7 +16,6 @@ on:
         type: choice
         options:
           - all
-          - cp310-manylinux_x86_64
           - cp313-manylinux_x86_64
           - cp314-manylinux_x86_64
           - cp313-macosx_arm64
@@ -36,7 +35,6 @@ jobs:
           if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ inputs.cibw-build }}" == "all" ]]; then
             matrix='{
               "config": [
-                {"os":"ubuntu-22.04","cibw_build":"cp310-manylinux_x86_64"},
                 {"os":"ubuntu-22.04","cibw_build":"cp313-manylinux_x86_64"},
                 {"os":"ubuntu-22.04","cibw_build":"cp314-manylinux_x86_64"},
                 {"os":"macos-14","cibw_build":"cp313-macosx_arm64"},
@@ -81,20 +79,13 @@ jobs:
         run: |
           git fetch --force --unshallow --tags --no-recurse-submodules
 
-      - name: Determine Python and cibuildwheel versions
+      - name: Determine Python version
         id: python-version
         shell: bash
         run: |
           cibw_build="${{ matrix.config.cibw_build }}"
           python_version=$(echo "${cibw_build%%-*}" | sed -E 's/^cp([0-9])([0-9]+)$/\1.\2/')
           echo "python-version=${python_version}" >> "$GITHUB_OUTPUT"
-          # cibuildwheel 3.x dropped Python 3.10 as a supported host
-          # interpreter, so pin to the last 2.x release in that case.
-          if [[ "$python_version" == "3.10" ]]; then
-            echo "cibuildwheel-version=2.23.4" >> "$GITHUB_OUTPUT"
-          else
-            echo "cibuildwheel-version=3.3.0" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -102,7 +93,7 @@ jobs:
           python-version: ${{ steps.python-version.outputs.python-version }}
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==${{ steps.python-version.outputs.cibuildwheel-version }}
+        run: python -m pip install cibuildwheel==3.3.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse ./lib/Bindings/Python


### PR DESCRIPTION
Stop building Python 3.10 circt-python wheels for Linux.  Python 3.10 is
end of life in October 2026.  While this is _ahead_ of that, it should be
fine to drop support now.

This has a secondary benefit of making the GitHub action for uploading
wheels simpler as there can be a single version of `cibuildwheel`
installed.

Assisted-by: pi.dev:claude-opus-4-8
