### PR TITLE
[circt-verilog][cmake] Bump slang commit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,7 +563,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG 6933832c97c39976890e5f12b69245f061d60a9a # June 9, 2026: v11.0 + ~60 commits
+      GIT_TAG 44dc55f99b9c64971893013e7931e643fbedcf23 # June 19, 2026: v11.0 + ~85 commits
       # GIT_SHALLOW ON # TODO: re-enable once we use a released version again.
     )
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1660,8 +1660,8 @@ module Expressions;
     arr = '{3{'{2{4'd1, 4'd2, 4'd3}}}};
 
     // CHECK: [[TMP0:%.+]] = moore.constant 0 :
-    // CHECK: [[TMP1:%.+]] = moore.constant 0 :
-    // CHECK: [[TMP2:%.+]] = moore.constant 1 :
+    // CHECK: [[TMP1:%.+]] = moore.constant 1 :
+    // CHECK: [[TMP2:%.+]] = moore.constant 0 :
     // CHECK: [[TMP3:%.+]] = moore.constant 0 :
     // CHECK: moore.concat [[TMP3]], [[TMP2]], [[TMP1]], [[TMP0]] : (!moore.l1, !moore.l1, !moore.l1, !moore.l1) -> l4
     m = '{default: '0, 2: '1};
@@ -1859,7 +1859,7 @@ module PortsTop;
   // CHECK: %a = moore.net wire : <l1>
   // CHECK: [[A_VALUE:%.+]] = moore.read %a
   // CHECK: [[X4:%.+]] = moore.read %x4
-  // CHECK: %c = moore.variable : <l1>
+  // CHECK: %c = moore.net wire : <l1>
   // CHECK: [[C_VALUE:%.+]] = moore.read %c
   // CHECK: [[D_VALUE:%.+]], [[E_VALUE:%.+]] = moore.instance "p4" @PortsUnconnected(
   // CHECK-SAME: a: [[A_VALUE]]: !moore.l1
@@ -1990,7 +1990,7 @@ module PortsUnconnected(
   // Internal nets and variables created by Slang for each port.
   // CHECK: [[A_INT:%.+]] = moore.net name "a" wire : <l1>
   // CHECK: [[B_INT:%.+]] = moore.net name "b" wire : <l1>
-  // CHECK: [[C_INT:%.+]] = moore.variable name "c" : <l1>
+  // CHECK: [[C_INT:%.+]] = moore.net name "c" wire : <l1>
   // CHECK: [[D_INT:%.+]] = moore.net wire : <l1>
   // CHECK: [[E_INT:%.+]] = moore.net wire : <l1>
   
@@ -3231,8 +3231,8 @@ module RangeElementSelection(
     input reg [3:0] a [0:2],
     output reg [3:0] b,
     input reg [1:0] c);
-    // CHECK: [[A:%.+]] = moore.variable name "a" : <uarray<3 x l4>
-    // CHECK: [[C:%.+]] = moore.variable name "c" : <l2>
+    // CHECK: [[A:%.+]] = moore.net name "a" wire : <uarray<3 x l4>
+    // CHECK: [[C:%.+]] = moore.net name "c" wire : <l2>
 
     always_comb begin
       // CHECK: [[READ_A:%.+]] = moore.read [[A]] : <uarray<3 x l4>>
@@ -4111,7 +4111,7 @@ function void testRealOps;
 endfunction // testStrLiteralReturn
 
 // CHECK-LABEL:  moore.module @RejectInnerCapture(in %u : !moore.i1, out v : !moore.i1) {
-// CHECK:    [[UVAR:%.*]] = moore.variable name "u" : <i1>
+// CHECK:    [[UVAR:%.*]] = moore.net name "u" wire : <i1>
 // CHECK:    [[VVAR:%.*]] = moore.variable : <i1>
 // CHECK:    [[READU:%.*]] = moore.read [[UVAR]] : <i1>
 // CHECK:    [[CALLBAR:%.*]] = func.call @bar([[READU]]) : (!moore.i1) -> !moore.i1

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -428,7 +428,7 @@ module SampleValueBuiltins #() (
 );
   // CHECK: [[CLKWIRE:%.+]] = moore.net name "clk_i" wire : <l1>
   // CHECK: [[DATAWIRE:%.+]] = moore.net name "data_i" wire : <l8>
-  // CHECK: [[DATABITWIRE:%.+]] = moore.variable name "data_bit_i" : <i8>
+  // CHECK: [[DATABITWIRE:%.+]] = moore.net name "data_bit_i" wire : <i8>
   // CHECK: moore.procedure always {
   // CHECK-NEXT: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[C_INT:%.+]] = moore.logic_to_int [[C]] : l1

--- a/test/Conversion/ImportVerilog/interface-instance-expansion.sv
+++ b/test/Conversion/ImportVerilog/interface-instance-expansion.sv
@@ -34,7 +34,7 @@ module InterfaceProceduralAssign(input logic clk, output logic y);
   sample_if vif(clk);
   assign y = vif.sampled;
 
-  // CHECK: %[[INNER_CLK:.+]] = moore.variable name "clk" : <l1>
+  // CHECK: %[[INNER_CLK:.+]] = moore.net name "clk" wire : <l1>
   // CHECK: %[[SAMPLED:.+]] = moore.variable : <l1>
   // CHECK: moore.procedure always_comb {
   // CHECK:   %[[CLK_READ:.+]] = moore.read %[[INNER_CLK]] : <l1>


### PR DESCRIPTION
Pulls in a more recent Slang commit that includes improved detection for boost (https://github.com/MikePopoloski/slang/pull/1879), which fixes some hiccups with building on Ubuntu that are still around after #10689 