### PR TITLE
[Arc] FindInitialVectors: Drop weak getHashValue specialization.

### DIFF
--- a/lib/Dialect/Arc/Transforms/FindInitialVectors.cpp
+++ b/lib/Dialect/Arc/Transforms/FindInitialVectors.cpp
@@ -149,19 +149,6 @@ struct Vectorizer {
 };
 } // namespace
 
-namespace llvm {
-template <>
-struct DenseMapInfo<Key> {
-  static unsigned getHashValue(const Key &key) {
-    return hash_value(std::get<0>(key)) ^ hash_value(std::get<1>(key)) ^
-           hash_value(std::get<2>(key)) ^ hash_value(std::get<3>(key)) ^
-           hash_value(std::get<4>(key));
-  }
-
-  static bool isEqual(const Key &lhs, const Key &rhs) { return lhs == rhs; }
-};
-} // namespace llvm
-
 // When calling this function we assume that we have the candidate groups of
 // isomorphic ops so we need to feed them to the `VectorizeOp`
 LogicalResult


### PR DESCRIPTION
Using xor to combine the fields has some undesirable properties, notably get same hash with different ordering.

Instead, prefer `hash_combine(...)`.

However, since there is already specialization that combines the hashes of tuple elements, just drop this code.
