### PR TITLE
[Arc] Generate simulation driver function for each model

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -615,10 +615,11 @@ def GetNextWakeupOp : ArcOp<"get_next_wakeup", [
 ]> {
   let summary = "Read the model's next wakeup time";
   let description = [{
-    Reads the next wakeup time from the model's storage. The time is
-    represented as an `i64` value in femtoseconds. A value of `0` indicates
-    "wake up immediately"; a value of `UINT64_MAX` indicates that no wakeup
-    is pending.
+    Reads the next wakeup time from the model's storage. The time is an
+    absolute timestamp in femtoseconds, not a duration relative to the current
+    simulation time. A wakeup at the current time requests an immediate
+    re-evaluation in the same time step; a value of `UINT64_MAX` indicates that
+    no wakeup is pending.
   }];
   let arguments = (ins StorageType:$storage);
   let results = (outs I64:$time);
@@ -1136,11 +1137,12 @@ def SimGetNextWakeupOp : ArcOp<"sim.get_next_wakeup", [
 ]> {
   let summary = "Gets the next wakeup time of the model instance";
   let description = [{
-    Gets the next wakeup time of the given model instance. The time is
-    represented as an `i64` value in femtoseconds. A value of `0` indicates
-    "wake up immediately"; a value of `UINT64_MAX` indicates that no wakeup
-    is pending. The slot is recomputed on every evaluation, so a driver
-    typically reads it after each `arc.sim.step` to decide how far to
+    Gets the next wakeup time of the given model instance. The time is an
+    absolute timestamp in femtoseconds, not a duration relative to the current
+    simulation time. A wakeup at the current time requests an immediate
+    re-evaluation in the same time step; a value of `UINT64_MAX` indicates that
+    no wakeup is pending. The slot is recomputed on every evaluation, so a
+    driver typically reads it after each `arc.sim.step` to decide how far to
     advance simulation time before the next step.
   }];
   let arguments = (ins SimModelInstance:$instance);

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -199,6 +199,23 @@ def LowerArrays : Pass<"arc-lower-arrays", "mlir::ModuleOp"> {
   let dependentDialects = ["arc::ArcDialect"];
 }
 
+def GenerateDriver : Pass<"arc-generate-driver", "mlir::ModuleOp"> {
+  let summary = "Generate a simulation driver function for each model";
+  let description = [{
+    Emit a `func.func @<model>_main` for every `arc.model` that instantiates the
+    model and drives it forward in time until no more events are scheduled: it
+    repeatedly advances simulation time to the next scheduled wakeup and
+    evaluates the model until no further wakeup is pending. This lets a model be
+    run directly through the arcilator JIT without a hand-written driver loop.
+  }];
+  let dependentDialects = [
+    "arc::ArcDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::func::FuncDialect",
+    "mlir::scf::SCFDialect",
+  ];
+}
+
 def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {
   let summary = "Lowers arc.lut into a comb and hw only representation.";
   let dependentDialects = ["hw::HWDialect", "comb::CombDialect"];

--- a/include/circt/Tools/arcilator/pipelines.h
+++ b/include/circt/Tools/arcilator/pipelines.h
@@ -114,6 +114,10 @@ void populateArcStateAllocationPipeline(
 // Lower the arcs and update functions to LLVM. This pipeline lowers modules to
 // LLVM IR.
 struct ArcToLLVMOptions : mlir::PassPipelineOptions<ArcToLLVMOptions> {
+  Option<bool> noGenerateDriver{
+      *this, "no-generate-driver",
+      llvm::cl::desc("Don't emit a simulation driver function for each model"),
+      llvm::cl::init(false)};
   Option<bool> noRuntime{
       *this, "no-runtime",
       llvm::cl::desc("Don't emit calls to the runtime library"),

--- a/integration_test/arcilator/JIT/coroutine-instance.mlir
+++ b/integration_test/arcilator/JIT/coroutine-instance.mlir
@@ -1,4 +1,4 @@
-// RUN: arcilator --run %s --jit-entry=entry --jit-vcd-file=%t | FileCheck %s
+// RUN: arcilator --run %s --jit-entry=CoroutineProc_main --jit-vcd-file=%t | FileCheck %s
 // RUN: FileCheck %s --check-prefix=VCD --input-file=%t
 // REQUIRES: arcilator-jit
 
@@ -11,26 +11,15 @@
 // `now + delay`.
 
 // CHECK:      A 0 @ 0
-// CHECK-NEXT: out=42
 // CHECK-NEXT: A 1 @ 100
-// CHECK-NEXT: out=43
 // CHECK-NEXT: A 2 @ 200
-// CHECK-NEXT: out=44
 // CHECK-NEXT: A 3 @ 300
-// CHECK-NEXT: out=45
 // CHECK-NEXT: A 4 @ 400
-// CHECK-NEXT: out=46
 // CHECK-NEXT: B 0 @ 500
-// CHECK-NEXT: out=42
 // CHECK-NEXT: B 1 @ 511
-// CHECK-NEXT: out=43
 // CHECK-NEXT: B 2 @ 522
-// CHECK-NEXT: out=44
 // CHECK-NEXT: B 3 @ 533
-// CHECK-NEXT: out=45
 // CHECK-NEXT: B 4 @ 544
-// CHECK-NEXT: out=46
-// CHECK-NEXT: out=47
 
 // Two counting loops with different suspension delays. The current time is
 // supplied as the `%now` argument on every entry. Each iteration yields the
@@ -106,35 +95,6 @@ hw.module @CoroutineProc(out o: i42) {
   %c42 = hw.constant 42 : i42
   %sum = comb.add %0, %c42 : i42
   hw.output %sum : i42
-}
-
-// Drives the model like a simulator: query the next wakeup, advance time to it,
-// evaluate, and print the latched output. Stops once no wakeup is pending.
-func.func @entry() {
-  arc.sim.instantiate @CoroutineProc as %inst {
-    %never = hw.constant -1 : i64
-    %w0 = arc.sim.get_next_wakeup %inst : !arc.sim.instance<@CoroutineProc>
-
-    scf.while (%w = %w0) : (i64) -> i64 {
-      %pending = comb.icmp ne %w, %never : i64
-      scf.condition(%pending) %w : i64
-    } do {
-    ^bb0(%w: i64):
-      arc.sim.set_time %inst, %w : !arc.sim.instance<@CoroutineProc>
-      arc.sim.step %inst : !arc.sim.instance<@CoroutineProc>
-
-      %out = arc.sim.get_port %inst, "o" : i42, !arc.sim.instance<@CoroutineProc>
-      %lit = sim.fmt.literal "out="
-      %dec = sim.fmt.dec %out specifierWidth 0 : i42
-      %nl = sim.fmt.literal "\n"
-      %msg = sim.fmt.concat (%lit, %dec, %nl)
-      sim.proc.print %msg
-
-      %wn = arc.sim.get_next_wakeup %inst : !arc.sim.instance<@CoroutineProc>
-      scf.yield %wn : i64
-    }
-  }
-  return
 }
 
 // The VCD trace records `o` against simulation time, advancing in steps of 100

--- a/integration_test/arcilator/JIT/initial-shift-reg.mlir
+++ b/integration_test/arcilator/JIT/initial-shift-reg.mlir
@@ -1,11 +1,11 @@
-// RUN: arcilator %s --run --jit-entry=main | FileCheck --match-full-lines %s
+// RUN: arcilator %s --run --jit-entry=main --no-generate-driver | FileCheck --match-full-lines %s
 // REQUIRES: arcilator-jit
 
 // VCD test - runs always with arcilator-jit
-// RUN: arcilator %s --run --jit-entry=main --jit-vcd-file=%t && cat %t | FileCheck %s --match-full-lines --check-prefix VCD
+// RUN: arcilator %s --run --jit-entry=main --no-generate-driver --jit-vcd-file=%t && cat %t | FileCheck %s --match-full-lines --check-prefix VCD
 
 // FST test - only runs when libfst is available (binary format, smoke test only)
-// RUN: %if libfst %{ arcilator %s --run --jit-entry=main --jit-fst-file=%t %}
+// RUN: %if libfst %{ arcilator %s --run --jit-entry=main --no-generate-driver --jit-fst-file=%t %}
 
 // CHECK-LABEL: output = ca
 // CHECK-NEXT:  output = ca

--- a/integration_test/arcilator/JIT/runtime-vcd-nochange.mlir
+++ b/integration_test/arcilator/JIT/runtime-vcd-nochange.mlir
@@ -1,4 +1,4 @@
-// RUN: arcilator %s --run --jit-entry=main --jit-vcd-file=%t && cat %t | FileCheck %s --match-full-lines --check-prefix VCD
+// RUN: arcilator %s --run --jit-entry=main --no-generate-driver --jit-vcd-file=%t && cat %t | FileCheck %s --match-full-lines --check-prefix VCD
 // REQUIRES: arcilator-jit
 
 hw.module @dut(out dout : i136) {

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   ArcCanonicalizer.cpp
   Dedup.cpp
   FindInitialVectors.cpp
+  GenerateDriver.cpp
   InferMemories.cpp
   InferStateProperties.cpp
   InlineArcs.cpp

--- a/lib/Dialect/Arc/Transforms/GenerateDriver.cpp
+++ b/lib/Dialect/Arc/Transforms/GenerateDriver.cpp
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass generates a self-contained simulation driver for every `arc.model`
+// in the module, so that the model can be run directly through the arcilator
+// JIT without a hand-written driver loop.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Arc/ArcTypes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_GENERATEDRIVER
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+//===----------------------------------------------------------------------===//
+// Generate Simulation Drivers
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct GenerateDriverPass
+    : public arc::impl::GenerateDriverBase<GenerateDriverPass> {
+  void runOnOperation() override;
+  void generateDriver(ModelOp modelOp, SymbolTable &symbolTable);
+};
+} // namespace
+
+void GenerateDriverPass::runOnOperation() {
+  auto &symbolTable = getAnalysis<SymbolTable>();
+  for (auto modelOp : getOperation().getOps<ModelOp>())
+    generateDriver(modelOp, symbolTable);
+}
+
+/// Generate a `func.func @<model>_main` that runs the given model to
+/// completion.
+void GenerateDriverPass::generateDriver(ModelOp modelOp,
+                                        SymbolTable &symbolTable) {
+  auto *context = &getContext();
+  auto loc = modelOp.getLoc();
+  auto i64Type = IntegerType::get(context, 64);
+  auto instanceType = SimModelInstanceType::get(
+      context, FlatSymbolRefAttr::get(modelOp.getSymNameAttr()));
+
+  // Create the driver function as a sibling placed before the model. The symbol
+  // table uniquifies the name if it happens to collide.
+  OpBuilder builder(modelOp);
+  auto funcName = builder.getStringAttr(modelOp.getSymName() + "_main");
+  auto funcType = builder.getFunctionType({}, {});
+  auto funcOp = func::FuncOp::create(builder, loc, funcName, funcType);
+  symbolTable.insert(funcOp);
+  builder.setInsertionPointToStart(funcOp.addEntryBlock());
+
+  // Instantiate the model. Its lifetime spans the body region, in which the
+  // model storage is available as the instance block argument.
+  auto instanceOp = SimInstantiateOp::create(builder, loc);
+  func::ReturnOp::create(builder, loc);
+  auto *instanceBlock = builder.createBlock(&instanceOp.getBody());
+  auto instance = instanceBlock->addArgument(instanceType, loc);
+
+  // Loop until no further wakeup is scheduled. The next wakeup slot uses
+  // `UINT64_MAX` to signal that the model has gone quiescent.
+  auto never = arith::ConstantOp::create(builder, loc,
+                                         builder.getIntegerAttr(i64Type, -1));
+  auto firstWakeup = SimGetNextWakeupOp::create(builder, loc, instance);
+
+  auto whileOp =
+      scf::WhileOp::create(builder, loc, i64Type, ValueRange{firstWakeup});
+
+  // The "before" region tests whether a wakeup is still pending and forwards
+  // the wakeup time into the loop body.
+  auto *beforeBlock = builder.createBlock(&whileOp.getBefore());
+  auto wakeup = beforeBlock->addArgument(i64Type, loc);
+  auto pending = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::ne,
+                                       wakeup, never);
+  scf::ConditionOp::create(builder, loc, pending, ValueRange{wakeup});
+
+  // The "after" region advances time to the scheduled wakeup, evaluates the
+  // model, and reads the next wakeup time to feed back into the condition.
+  auto *afterBlock = builder.createBlock(&whileOp.getAfter());
+  auto resumeTime = afterBlock->addArgument(i64Type, loc);
+  SimSetTimeOp::create(builder, loc, instance, resumeTime);
+  SimStepOp::create(builder, loc, instance);
+  auto nextWakeup = SimGetNextWakeupOp::create(builder, loc, instance);
+  scf::YieldOp::create(builder, loc, ValueRange{nextWakeup});
+}

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -150,6 +150,8 @@ void circt::populateArcStateAllocationPipeline(
 
 void circt::populateArcToLLVMPipeline(OpPassManager &pm,
                                       const ArcToLLVMOptions &options) {
+  if (!options.noGenerateDriver)
+    pm.addPass(createGenerateDriver());
   {
     hw::HWConvertBitcastsOptions options;
     options.allowPartialConversion = false;

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -252,6 +252,11 @@ static llvm::cl::list<std::string>
             llvm::cl::ZeroOrMore, llvm::cl::CommaSeparated,
             llvm::cl::cat(mainCategory));
 
+static llvm::cl::opt<bool> noGenerateDriver(
+    "no-generate-driver",
+    llvm::cl::desc("Don't emit a simulation driver function for each model"),
+    llvm::cl::init(false), llvm::cl::cat(mainCategory));
+
 static llvm::cl::opt<bool>
     noRuntime("no-runtime",
               llvm::cl::desc("Don't emit calls to the runtime library"),
@@ -445,6 +450,7 @@ static LogicalResult processBuffer(
 
   if (!untilReached(UntilLLVMLowering)) {
     ArcToLLVMOptions opts;
+    opts.noGenerateDriver = noGenerateDriver;
     opts.noRuntime = noRuntime;
     std::string runtimeArgs;
     if (!jitVcdFile.empty()) {


### PR DESCRIPTION
Add an `arc-generate-driver` pass that emits a `func.func @<model>_main` for every `arc.model`. The driver instantiates the model and drives it forward in time until no more events are scheduled: it advances simulation time to the next scheduled wakeup, evaluates the model, and repeats until no wakeup is pending. This lets a model be run directly through the arcilator JIT via `--jit-entry=<model>_main` without a hand-written driver loop.

Wire the pass into the arcilator lowering pipeline ahead of the `arc.sim.*` lowering, and switch the coroutine instance integration test over to the auto-generated driver.

Also clarify the `get_next_wakeup` documentation: the wakeup time is an absolute timestamp, not a duration relative to the current simulation time. An immediate re-evaluation is requested by a wakeup at the current time, not by a value of zero.

Assisted-by: Claude Opus 4.8