### PR TITLE
[Verif][FIRRTL] Lower verif.contract in FIRRTL body

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -38,6 +38,7 @@ class HardwareDeclOp<string mnemonic, list <Trait> traits = []> :
   ReferableDeclOp<mnemonic, traits # [
     ParentOneOf<[
       "firrtl::ContractOp",
+      "verif::ContractOp",
       "firrtl::FModuleOp",
       "firrtl::LayerBlockOp",
       "firrtl::MatchOp",

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -21,6 +21,7 @@
 #include "circt/Dialect/HW/InnerSymbolTable.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqAttributes.h"
+#include "circt/Dialect/Verif/VerifOps.h"
 #include "circt/Support/FieldRef.h"
 #include "circt/Support/InstanceGraph.h"
 #include "mlir/IR/Builders.h"

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -508,7 +508,6 @@ def SymbolicValueOp : VerifOp<"symbolic_value", [
 
 def ContractOp : VerifOp<"contract", [
   AllTypesMatch<["inputs", "outputs"]>,
-  NoRegionArguments,
   NoTerminator,
   RegionKindInterface,
   SingleBlock,
@@ -531,6 +530,11 @@ def ContractOp : VerifOp<"contract", [
     inlining them and replacing `require` with `assert` and `ensure` with
     `assume`. The results of the contract are replaced with symbolic values.
 
+    The body region may optionally carry block arguments matching the input
+    types, which a frontend can use to reference the inputs when its dialect
+    requires SSA dominance (e.g. FIRRTL); lowering remaps them to the results.
+    Without block arguments the body refers to the contract's results directly.
+
     See the documentation of the Verif dialect for more details.
   }];
   let arguments = (ins Variadic<AnyType>:$inputs);
@@ -539,6 +543,7 @@ def ContractOp : VerifOp<"contract", [
   let assemblyFormat = [{
     ($inputs^ `:` type($inputs))? attr-dict-with-keyword $body
   }];
+  let hasVerifier = 1;
   let extraClassDeclaration = [{
     static RegionKind getRegionKind(unsigned index) {
       return RegionKind::Graph;

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3398,12 +3398,9 @@ FIRRTLLowering::handleUnloweredOp(Operation *op) {
     return LoweringFailure;
   }
 
-  // A `verif.contract` may be emitted directly (e.g. by a frontend) rather than
-  // produced from a `firrtl.contract`, in which case it carries FIRRTL-typed
-  // operands/results. The generic non-FIRRTL passthrough below would remap its
-  // operands but leave the result types as FIRRTL types, violating
-  // verif.contract's AllTypesMatch invariant. Re-create it with lowered types,
-  // mirroring visitDecl(firrtl::ContractOp).
+  // A directly-emitted verif.contract carries FIRRTL-typed results; the generic
+  // passthrough below would leave them FIRRTL-typed and break AllTypesMatch, so
+  // re-create it with lowered types instead.
   if (auto contract = dyn_cast<verif::ContractOp>(op)) {
     if (failed(lowerVerifContract(contract)))
       return LoweringFailure;
@@ -4337,13 +4334,8 @@ LogicalResult FIRRTLLowering::visitDecl(ContractOp oldOp) {
   return success();
 }
 
-// Lower a `verif.contract` that already exists in the FIRRTL module body (e.g.
-// emitted directly by a frontend) rather than being produced from a
-// `firrtl.contract`. Its operands/results are FIRRTL-typed; re-create it with
-// the lowered types (so it satisfies AllTypesMatch) and re-lower its body in
-// place. Unlike `firrtl.contract`, `verif.contract` has no block arguments
-// (NoRegionArguments): its body refers to the contract's results directly, so
-// only the results are remapped.
+// Re-create a directly-emitted verif.contract with lowered operand/result types
+// and re-lower its body in place.
 LogicalResult FIRRTLLowering::lowerVerifContract(verif::ContractOp oldOp) {
   SmallVector<Value> inputs;
   SmallVector<Type> types;
@@ -4362,6 +4354,12 @@ LogicalResult FIRRTLLowering::lowerVerifContract(verif::ContractOp oldOp) {
   for (auto [oldResult, newResult] :
        llvm::zip(oldOp.getResults(), newOp.getResults()))
     if (failed(setLowering(oldResult, newResult)))
+      return failure();
+
+  // Remap body block arguments (if any) to the results, like firrtl.contract.
+  for (auto [oldArg, newResult] :
+       llvm::zip(oldOp.getBody().getArguments(), newOp.getResults()))
+    if (failed(setLowering(oldArg, newResult)))
       return failure();
 
   body.getOperations().splice(body.end(),

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1860,6 +1860,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitDecl(InstanceChoiceOp oldInstanceChoice);
   LogicalResult visitDecl(VerbatimWireOp op);
   LogicalResult visitDecl(ContractOp op);
+  LogicalResult lowerVerifContract(verif::ContractOp op);
 
   // Unary Ops.
   LogicalResult lowerNoopCast(Operation *op);
@@ -3397,6 +3398,18 @@ FIRRTLLowering::handleUnloweredOp(Operation *op) {
     return LoweringFailure;
   }
 
+  // A `verif.contract` may be emitted directly (e.g. by a frontend) rather than
+  // produced from a `firrtl.contract`, in which case it carries FIRRTL-typed
+  // operands/results. The generic non-FIRRTL passthrough below would remap its
+  // operands but leave the result types as FIRRTL types, violating
+  // verif.contract's AllTypesMatch invariant. Re-create it with lowered types,
+  // mirroring visitDecl(firrtl::ContractOp).
+  if (auto contract = dyn_cast<verif::ContractOp>(op)) {
+    if (failed(lowerVerifContract(contract)))
+      return LoweringFailure;
+    return NowLowered;
+  }
+
   // Simply pass through non-FIRRTL operations and consider them already
   // lowered. This allows us to handled partially lowered inputs, and also allow
   // other FIRRTL operations to spawn additional already-lowered operations,
@@ -4316,6 +4329,40 @@ LogicalResult FIRRTLLowering::visitDecl(ContractOp oldOp) {
     if (failed(setLowering(oldArg, newResult)))
       return failure();
   }
+
+  body.getOperations().splice(body.end(),
+                              oldOp.getBody().front().getOperations());
+  addToWorklist(body);
+
+  return success();
+}
+
+// Lower a `verif.contract` that already exists in the FIRRTL module body (e.g.
+// emitted directly by a frontend) rather than being produced from a
+// `firrtl.contract`. Its operands/results are FIRRTL-typed; re-create it with
+// the lowered types (so it satisfies AllTypesMatch) and re-lower its body in
+// place. Unlike `firrtl.contract`, `verif.contract` has no block arguments
+// (NoRegionArguments): its body refers to the contract's results directly, so
+// only the results are remapped.
+LogicalResult FIRRTLLowering::lowerVerifContract(verif::ContractOp oldOp) {
+  SmallVector<Value> inputs;
+  SmallVector<Type> types;
+  for (auto input : oldOp.getInputs()) {
+    auto lowered = getLoweredValue(input);
+    if (!lowered)
+      return failure();
+    inputs.push_back(lowered);
+    types.push_back(lowered.getType());
+  }
+
+  auto newOp = verif::ContractOp::create(builder, types, inputs);
+  newOp->setDiscardableAttrs(oldOp->getDiscardableAttrDictionary());
+  auto &body = newOp.getBody().emplaceBlock();
+
+  for (auto [oldResult, newResult] :
+       llvm::zip(oldOp.getResults(), newOp.getResults()))
+    if (failed(setLowering(oldResult, newResult)))
+      return failure();
 
   body.getOperations().splice(body.end(),
                               oldOp.getBody().front().getOperations());

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -49,6 +49,7 @@ add_circt_dialect_library(CIRCTFIRRTL
   CIRCTOM
   CIRCTSeq
   CIRCTSV
+  CIRCTVerif
   MLIRIR
   MLIRPass
 )

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -24,6 +24,7 @@
 #include "circt/Dialect/FIRRTL/LayerSet.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Verif/VerifOps.h"
 #include "circt/Support/CustomDirectiveImpl.h"
 #include "circt/Support/Utils.h"
 #include "mlir/IR/BuiltinTypes.h"

--- a/lib/Dialect/Verif/Transforms/LowerContracts.cpp
+++ b/lib/Dialect/Verif/Transforms/LowerContracts.cpp
@@ -88,6 +88,10 @@ void assumeContractHolds(OpBuilder &builder, IRMapping &mapping,
                                        result.getType(), StringAttr({}));
     mapping.map(result, sym);
   }
+  // Block arguments (if any) alias the results; map them to the same values.
+  for (auto [arg, result] :
+       llvm::zip(contract.getBody().getArguments(), contract.getResults()))
+    mapping.map(arg, mapping.lookup(result));
   auto &contractOps = contract.getBody().front().getOperations();
   for (auto it = contractOps.rbegin(); it != contractOps.rend(); ++it) {
     workList.push(&*it);
@@ -200,6 +204,11 @@ LogicalResult inlineContract(ContractOp &contract, OpBuilder &builder,
       mapping.map(result, mapping.lookup(input));
     }
   }
+  // Block arguments (if any) alias the results; map them to the same values so
+  // a body built against the block arguments clones correctly.
+  for (auto [arg, result] :
+       llvm::zip(contract.getBody().getArguments(), contract.getResults()))
+    mapping.map(arg, mapping.lookup(result));
 
   // Clone body of the contract
   for (auto &op : contract.getBody().front().getOperations()) {

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -345,6 +345,19 @@ void SymbolicValueOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 //===----------------------------------------------------------------------===//
+// ContractOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ContractOp::verify() {
+  // Body block arguments are optional, but if present must match the inputs.
+  auto args = getBody().getArgumentTypes();
+  if (!args.empty() && args != getInputs().getType())
+    return emitOpError(
+        "body block arguments must be empty or match the input types");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Generated code
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/FIRRTLToHW/verif-contract-direct.mlir
+++ b/test/Conversion/FIRRTLToHW/verif-contract-direct.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt --lower-firrtl-to-hw --verify-diagnostics %s | FileCheck %s
+
+// A `verif.contract` emitted directly into a FIRRTL module body (instead of via
+// `firrtl.contract`) must survive FIRRTL-to-HW lowering: its FIRRTL-typed
+// operands/results are lowered, and its body is re-lowered in place. The
+// frontend inserts the property type conversion (firrtl.uint<1> -> i1) so that
+// verif.require/verif.ensure only ever see core types.
+
+firrtl.circuit "VerifContractDirect" {
+  // CHECK-LABEL: hw.module @VerifContractDirect
+  // CHECK-NEXT:    [[R:%.+]] = verif.contract %a : i42 {
+  // CHECK-NEXT:      verif.require %p : i1
+  // CHECK-NEXT:      verif.ensure %p : i1
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    hw.output [[R]] : i42
+  
+  firrtl.module @VerifContractDirect(in %a: !firrtl.uint<42>, in %p: !firrtl.uint<1>, out %b: !firrtl.uint<42>) {
+    %0 = verif.contract %a : !firrtl.uint<42> {
+      %p_i1 = builtin.unrealized_conversion_cast %p : !firrtl.uint<1> to i1
+      verif.require %p_i1 : i1
+      verif.ensure %p_i1 : i1
+    }
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<42>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/verif-contract-direct.mlir
+++ b/test/Conversion/FIRRTLToHW/verif-contract-direct.mlir
@@ -1,10 +1,7 @@
 // RUN: circt-opt --lower-firrtl-to-hw --verify-diagnostics %s | FileCheck %s
 
-// A `verif.contract` emitted directly into a FIRRTL module body (instead of via
-// `firrtl.contract`) must survive FIRRTL-to-HW lowering: its FIRRTL-typed
-// operands/results are lowered, and its body is re-lowered in place. The
-// frontend inserts the property type conversion (firrtl.uint<1> -> i1) so that
-// verif.require/verif.ensure only ever see core types.
+// A verif.contract emitted directly into a FIRRTL module body must survive
+// FIRRTL-to-HW lowering: operands/results are lowered and the body re-lowered.
 
 firrtl.circuit "VerifContractDirect" {
   // CHECK-LABEL: hw.module @VerifContractDirect
@@ -13,12 +10,31 @@ firrtl.circuit "VerifContractDirect" {
   // CHECK-NEXT:      verif.ensure %p : i1
   // CHECK-NEXT:    }
   // CHECK-NEXT:    hw.output [[R]] : i42
-  
   firrtl.module @VerifContractDirect(in %a: !firrtl.uint<42>, in %p: !firrtl.uint<1>, out %b: !firrtl.uint<42>) {
     %0 = verif.contract %a : !firrtl.uint<42> {
       %p_i1 = builtin.unrealized_conversion_cast %p : !firrtl.uint<1> to i1
       verif.require %p_i1 : i1
       verif.ensure %p_i1 : i1
+    }
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<42>
+  }
+
+  // With optional block arguments, the body references the input through the
+  // block argument (which dominates the body), not the contract's result.
+  // CHECK-LABEL: hw.module @VerifContractBlockArgs
+  // CHECK-NEXT:    [[R:%.+]] = verif.contract %a : i42 {
+  // CHECK-NEXT:      [[BIT:%.+]] = comb.extract [[R]] from 0 : (i42) -> i1
+  // CHECK-NEXT:      verif.ensure [[BIT]] : i1
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    hw.output [[R]] : i42
+  firrtl.module @VerifContractBlockArgs(
+      in %a: !firrtl.uint<42>, out %b: !firrtl.uint<42>) {
+    %0 = verif.contract %a : !firrtl.uint<42> {
+    ^bb0(%arg0: !firrtl.uint<42>):
+      %n = firrtl.node %arg0 : !firrtl.uint<42>
+      %bit = firrtl.bits %n 0 to 0 : (!firrtl.uint<42>) -> !firrtl.uint<1>
+      %biti1 = builtin.unrealized_conversion_cast %bit : !firrtl.uint<1> to i1
+      verif.ensure %biti1 : i1
     }
     firrtl.matchingconnect %b, %0 : !firrtl.uint<42>
   }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -279,7 +279,7 @@ firrtl.circuit "Foo" {
 
 firrtl.circuit "Foo" {
   firrtl.extmodule @Foo()
-  // expected-error @+1 {{'firrtl.instance' op expects parent op to be one of 'firrtl.contract, firrtl.module, firrtl.layerblock, firrtl.match, firrtl.when, sv.ifdef'}}
+  // expected-error @+1 {{'firrtl.instance' op expects parent op to be one of 'firrtl.contract, verif.contract, firrtl.module, firrtl.layerblock, firrtl.match, firrtl.when, sv.ifdef'}}
   firrtl.instance "" @Foo()
 }
 
@@ -1914,7 +1914,7 @@ firrtl.circuit "ClassCannotHaveHardwarePorts" {
 firrtl.circuit "ClassCannotHaveWires" {
   firrtl.module @ClassCannotHaveWires() {}
   firrtl.class @ClassWithWire() {
-    // expected-error @below {{'firrtl.wire' op expects parent op to be one of 'firrtl.contract, firrtl.module, firrtl.layerblock, firrtl.match, firrtl.when, sv.ifdef'}}
+    // expected-error @below {{'firrtl.wire' op expects parent op to be one of 'firrtl.contract, verif.contract, firrtl.module, firrtl.layerblock, firrtl.match, firrtl.when, sv.ifdef'}}
     %w = firrtl.wire : !firrtl.uint<8>
   }
 }

--- a/test/Dialect/Verif/lower-contracts.mlir
+++ b/test/Dialect/Verif/lower-contracts.mlir
@@ -348,3 +348,39 @@ hw.module @Counter(in %in : i2, out out : i2, in %clock : !seq.clock, in %reset 
   }
   hw.output %4 : i2
 }
+
+// Same as @Mul9, but the contract body references its input through a block
+// argument (which aliases the result) instead of the result directly. The
+// lowering must map the block argument like the result, producing identical IR.
+
+// CHECK-LABEL: hw.module @Mul9BlockArg
+// CHECK-NEXT:   %c9_i42 = hw.constant 9 : i42
+// CHECK-NEXT:   [[TMP:%.+]] = comb.mul %a, %c9_i42 : i42
+// CHECK-NEXT:   hw.output [[TMP]] : i42
+// CHECK-NEXT: }
+
+// CHECK-LABEL: verif.formal @Mul9BlockArg_CheckContract_0
+// CHECK-NEXT:   %c0_i3 = hw.constant 0 : i3
+// CHECK-NEXT:   %c9_i42 = hw.constant 9 : i42
+// CHECK-NEXT:   [[A:%.+]] = verif.symbolic_value : i42
+// CHECK-NEXT:   [[TMP1:%.+]] = comb.extract [[A]] from 0 : (i42) -> i39
+// CHECK-NEXT:   [[TMP2:%.+]] = comb.concat [[TMP1]], %c0_i3 : i39, i3
+// CHECK-NEXT:   [[TMP1:%.+]] = comb.add [[A]], [[TMP2]] : i42
+// CHECK-NEXT:   [[TMP2:%.+]] = comb.mul [[A]], %c9_i42 : i42
+// CHECK-NEXT:   [[TMP3:%.+]] = comb.icmp eq [[TMP1]], [[TMP2]] : i42
+// CHECK-NEXT:   verif.assert [[TMP3]] : i1
+// CHECK-NEXT: }
+
+hw.module @Mul9BlockArg(in %a: i42, out z: i42) {
+  %c3_i42 = hw.constant 3 : i42
+  %c9_i42 = hw.constant 9 : i42
+  %0 = comb.shl %a, %c3_i42 : i42    // 8*a
+  %1 = comb.add %a, %0 : i42         // a + 8*a
+  %2 = verif.contract %1 : i42 {
+  ^bb0(%arg0: i42):
+    %3 = comb.mul %a, %c9_i42 : i42  // 9*a
+    %4 = comb.icmp eq %arg0, %3 : i42  // 9*a == a + 8*a, via the block argument
+    verif.ensure %4 : i1
+  }
+  hw.output %2 : i42
+}


### PR DESCRIPTION
## Summary

This PR allows frontends to emit `verif.contract` directly inside FIRRTL module bodies and have it survive FIRRTL-to-HW lowering correctly.

Previously, `firrtl.contract` could be lowered into `verif.contract`, but a pre-existing `verif.contract` in FIRRTL IR would be treated as a generic non-FIRRTL op. That left FIRRTL-typed operands/results in place and could violate `verif.contract`'s type invariants.

Sometimes we want to reduce the dependency of `firrtl` dialect in frontend language so we use `verif.contract` / `verif.ensure` / `verif.require` instead of they were in `firrtl` dialect.

## Details

- FIRRTL-to-HW lowering to handle a pre-existing `verif.contract` in a FIRRTL module body.
  - Recreates the contract with lowered operand/result types.
  - Moves the original body into the new contract.
  - Re-lowers the contract body in place.

- Allow FIRRTL hardware declarations inside frontend-built `verif.contract` bodies.
  - Extends FIRRTL hardware declaration parent constraints to include `verif.contract`.
  - Adds the required FIRRTL-to-Verif dependency.

- Allow `verif.contract` body regions to optionally use block arguments matching the contract inputs.
  - This gives frontends a region-local SSA value to reference inside the body.
  - The old no-block-argument form remains valid.
  - Lowering maps those block arguments as aliases of the contract results.

- Update contract lowering so both forms are handled consistently:
  - Body directly referencing contract results.
  - Body referencing matching block arguments.

Assisted-by: codex:gpt-5.5

