### PR TITLE
[FIRRTL] Lower non-domain.define domain operands

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -709,9 +709,16 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
     SmallVector<Value> connectValues;
     Namespace portNs;
 
-    // Create an input port for a domain-type operand.  The source is not in the
-    // current layer block.
-    auto createInputPort = [&](Value src, Location loc) -> LogicalResult {
+    // Create an input port for a domain-type source captured from outside the
+    // current layer block.  Returns the block argument that should be used in
+    // place of the original source within the layer block.  Repeated calls with
+    // the same source reuse the previously created, cached port.
+    DenseMap<Value, BlockArgument> domainInputPorts;
+    auto getOrCreateDomainInputPort =
+        [&](Value src, Location loc) -> FailureOr<BlockArgument> {
+      if (auto it = domainInputPorts.find(src); it != domainInputPorts.end())
+        return it->getSecond();
+
       Attribute domain;
       if (failed(getDomain(src, domain)))
         return failure();
@@ -736,7 +743,18 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
       connectValues.push_back(src);
       BlockArgument replacement =
           layerBlock.getBody()->addArgument(port.type, port.loc);
-      src.replaceUsesWithIf(replacement, [&](OpOperand &use) {
+      domainInputPorts[src] = replacement;
+      return replacement;
+    };
+
+    // Create an input port for a domain-type operand that is connected to a
+    // value inside the current layer block.  The source is not in the current
+    // layer block.
+    auto createInputPort = [&](Value src, Location loc) -> LogicalResult {
+      auto replacement = getOrCreateDomainInputPort(src, loc);
+      if (failed(replacement))
+        return failure();
+      src.replaceUsesWithIf(*replacement, [&](OpOperand &use) {
         auto *user = use.getOwner();
         if (!layerBlock->isAncestor(user))
           return false;
@@ -991,6 +1009,16 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
         // Note: This check is what avoids handling ConnectOp destinations.
         if (isAncestorOfValueOwner(layerBlock, operand))
           continue;
+
+        // Domain-type operands have no XMR representation and need to have
+        // input ports created.
+        if (type_isa<DomainType>(operand.getType())) {
+          auto replacement = getOrCreateDomainInputPort(operand, op->getLoc());
+          if (failed(replacement))
+            return WalkResult::interrupt();
+          op->setOperand(i, *replacement);
+          continue;
+        }
 
         op->setOperand(i, getReplacement(op, operand));
       }

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -572,6 +572,30 @@ firrtl.circuit "Test" {
     }
   }
 
+  // Test that a domain captured directly as an operand (here, by an
+  // `unsafe_domain_cast`) results in an input domain port being created and
+  // hooked up.  Or: this should work for things which aren't `domain.define`.
+  //
+  // See: https://github.com/llvm/circt/issues/10729
+  //
+  // CHECK:      firrtl.module private @DomainCaptureUnsafeCast_A(
+  // CHECK-SAME:   in %a: !firrtl.domain<@ClockDomain()>
+  // CHECK:        %[[xmr:.+]] = firrtl.xmr.deref {{.+}} : !firrtl.uint<1>
+  // CHECK-NEXT:   firrtl.unsafe_domain_cast %[[xmr]] domains[%a]
+  //
+  // CHECK:      firrtl.module @DomainCaptureUnsafeCast(
+  // CHECK-SAME:   in %a: !firrtl.domain<@ClockDomain()>
+  // CHECK:        %[[port:.+]] = firrtl.instance a {{.*}} @DomainCaptureUnsafeCast_A(in a: !firrtl.domain<@ClockDomain()>)
+  // CHECK-NEXT:   firrtl.domain.define %[[port]], %a : !firrtl.domain<@ClockDomain()>
+  firrtl.module @DomainCaptureUnsafeCast(
+    in %a: !firrtl.domain<@ClockDomain()>
+  ) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.layerblock @A {
+      %0 = firrtl.unsafe_domain_cast %c0_ui1 domains[%a] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
+    }
+  }
+
   //===--------------------------------------------------------------------===//
   // Cloning of special operations
   //===--------------------------------------------------------------------===//
@@ -1142,5 +1166,5 @@ firrtl.circuit "DoNotIncludeDummyBindfiles" {
 
   // CHECK-NOT: sv.include local "layers-Child1-A.sv"
   // CHECK: sv.include local "layers-Child2-A.sv"
-  // CHECK-NOT: sv.include local "layers-Child1-A.sv"  
+  // CHECK-NOT: sv.include local "layers-Child1-A.sv"
 }


### PR DESCRIPTION
Fix a bug where FIRRTL's LowerLayers pass assumed that operands of
default-handled operations could not be domains.  Any domain type operand
needs to result in the creation on an input port on the module created
from a bind convention layer.  Test for domain type operands and create
input ports.

Refactor the existing domain input port creation logic (which does RAUW
automatically) into two functions: a first that just creates ports and a
second that calls the first and does the RAUW.  This allows code sharing
of the first function by the domain type handling this commit adds.

Fixes #10729.

Assisted-by: pi.dev:claude-opus-4-8
