### PR TITLE
 [FIRRTL][Dedup] Reuse NLA in addAnnotationContext for singly instantiated module 

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1228,6 +1228,25 @@ private:
     auto moduleNLAs = nlaTable->lookup(fromModule.getNameAttr()).vec();
     // Change the NLA to target the toModule.
     nlaTable->renameModuleAndInnerRef(toName, fromName, renameMap);
+
+    // Fast path: if `fromModule` has exactly one instantiation, prepend that
+    // single instance reference to the namepath in place, keeping the NLA's
+    // symbol name so all annotations and targetMap entries stay valid.
+    auto *fromNode = instanceGraph.lookup(fromName);
+    bool fromHasOneUse = fromNode->hasOneUse();
+    std::optional<std::pair<Attribute, StringAttr>> singlePrefixAndName;
+    auto getPrefixAndName = [&] {
+      assert(fromHasOneUse);
+      if (!singlePrefixAndName) {
+        auto *instanceRecord = *fromNode->uses().begin();
+        auto parent =
+            cast<FModuleOp>(*instanceRecord->getParent()->getModule());
+        singlePrefixAndName = {OpAnnoTarget(instanceRecord->getInstance())
+                                   .getNLAReference(getNamespace(parent)),
+                               parent.getNameAttr()};
+      }
+      return *singlePrefixAndName;
+    };
     // Now we walk the NLA searching for ones that require more context to be
     // added.
     for (auto nla : moduleNLAs) {
@@ -1235,6 +1254,26 @@ private:
       // If we don't need to add more context, we're done here.
       if (nla.root() != toName)
         continue;
+
+      // Fast path: See the comment above.
+      if (fromHasOneUse) {
+        SmallVector<Attribute> newNamepath;
+        newNamepath.reserve(elements.size() + 1);
+        auto [singlePrefix, singleParentName] = getPrefixAndName();
+        newNamepath.push_back(singlePrefix);
+        newNamepath.append(elements.begin(), elements.end());
+        auto newPath = ArrayAttr::get(context, newNamepath);
+        // Skip if this path already exists; fall back to the general path
+        // below which merges duplicates via the cache.
+        if (!nlaCache.count(newPath)) {
+          nlaCache.erase(nla.getNamepathAttr());
+          nla.setNamepathAttr(newPath);
+          nlaCache[newPath] = nla.getNameAttr();
+          nlaTable->addNLAtoModule(nla, singleParentName);
+          continue;
+        }
+      }
+
       // Create the replacement NLAs.
       SmallVector<Attribute> namepath(elements.begin(), elements.end());
       auto nlaRefs = createNLAs(fromModule, namepath, nla.getVisibility());

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1233,20 +1233,7 @@ private:
     // single instance reference to the namepath in place, keeping the NLA's
     // symbol name so all annotations and targetMap entries stay valid.
     auto *fromNode = instanceGraph.lookup(fromName);
-    bool fromHasOneUse = fromNode->hasOneUse();
     std::optional<std::pair<Attribute, StringAttr>> singlePrefixAndName;
-    auto getPrefixAndName = [&] {
-      assert(fromHasOneUse);
-      if (!singlePrefixAndName) {
-        auto *instanceRecord = *fromNode->uses().begin();
-        auto parent =
-            cast<FModuleOp>(*instanceRecord->getParent()->getModule());
-        singlePrefixAndName = {OpAnnoTarget(instanceRecord->getInstance())
-                                   .getNLAReference(getNamespace(parent)),
-                               parent.getNameAttr()};
-      }
-      return *singlePrefixAndName;
-    };
     // Now we walk the NLA searching for ones that require more context to be
     // added.
     for (auto nla : moduleNLAs) {
@@ -1256,10 +1243,18 @@ private:
         continue;
 
       // Fast path: See the comment above.
-      if (fromHasOneUse) {
+      if (fromNode->hasOneUse()) {
+        if (!singlePrefixAndName) {
+          auto *instanceRecord = *fromNode->uses().begin();
+          auto parent =
+              cast<FModuleOp>(*instanceRecord->getParent()->getModule());
+          singlePrefixAndName = {OpAnnoTarget(instanceRecord->getInstance())
+                                     .getNLAReference(getNamespace(parent)),
+                                 parent.getNameAttr()};
+        }
         SmallVector<Attribute> newNamepath;
         newNamepath.reserve(elements.size() + 1);
-        auto [singlePrefix, singleParentName] = getPrefixAndName();
+        auto [singlePrefix, singleParentName] = *singlePrefixAndName;
         newNamepath.push_back(singlePrefix);
         newNamepath.append(elements.begin(), elements.end());
         auto newPath = ArrayAttr::get(context, newNamepath);

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -310,14 +310,12 @@ firrtl.circuit "Breadcrumb" {
 // and the annotation should be cloned for each parent of the root module.
 // CHECK-LABEL: firrtl.circuit "Context"
 firrtl.circuit "Context" {
-  // CHECK: hw.hierpath private [[NLA3:@nla.*]] [@Context::@[[CONTEXT1:.+]], @Context0::@c0, @ContextLeaf::@w]
-  // CHECK: hw.hierpath private [[NLA1:@nla.*]] [@Context::@[[CONTEXT1]], @Context0::@c0, @ContextLeaf::@in]
-  // CHECK: hw.hierpath private [[NLA2:@nla.*]] [@Context::@[[CONTEXT0:.+]], @Context0::@c0, @ContextLeaf::@w]
-  // CHECK: hw.hierpath private [[NLA0:@nla.*]] [@Context::@[[CONTEXT0]], @Context0::@c0, @ContextLeaf::@in]
-  // CHECK-NOT: @context_nla0
-  // CHECK-NOT: @context_nla1
-  // CHECK-NOT: @context_nla2
-  // CHECK-NOT: @context_nla3
+
+  // Check re-use of singlely used hierpath ops.
+  // CHECK: hw.hierpath private [[NLA0:@context_nla0]] [@Context::@[[CONTEXT0:.+]], @Context0::@c0, @ContextLeaf::@in]
+  // CHECK: hw.hierpath private [[NLA2:@context_nla1]] [@Context::@[[CONTEXT0]], @Context0::@c0, @ContextLeaf::@w]
+  // CHECK: hw.hierpath private [[NLA1:@context_nla2]] [@Context::@[[CONTEXT1:.+]], @Context0::@c0, @ContextLeaf::@in]
+  // CHECK: hw.hierpath private [[NLA3:@context_nla3]] [@Context::@[[CONTEXT1]], @Context0::@c0, @ContextLeaf::@w]
   hw.hierpath private @context_nla0 [@Context0::@c0, @ContextLeaf::@in]
   hw.hierpath private @context_nla1 [@Context0::@c0, @ContextLeaf::@w]
   hw.hierpath private @context_nla2 [@Context1::@c1, @ContextLeaf::@in]
@@ -362,19 +360,16 @@ firrtl.circuit "Context" {
 // CHECK-LABEL: firrtl.circuit "Context"
 firrtl.circuit "Context" {
 
-  // CHECK-NOT: hw.hierpath private @nla0
+  // CHECK: hw.hierpath private [[NLA0:@nla0]] [@Context::@[[CONTEXT0:.+]], @Context0::@leaf0, @ContextLeaf0::@w0]
   hw.hierpath private @nla0 [@Context0::@leaf0, @ContextLeaf0::@w0]
-  // CHECK-NOT: hw.hierpath private @nla1
+  // CHECK: hw.hierpath private [[NLA1:@nla1]] [@Context::@[[CONTEXT1:.+]], @Context0::@leaf0, @ContextLeaf0::@w0]
   hw.hierpath private @nla1 [@Context1::@leaf1, @ContextLeaf1::@w1]
-
-  // CHECK: hw.hierpath private [[NLA0:@.+]] [@Context::@[[CONTEXT1:.+]], @Context0::@leaf0, @ContextLeaf0::@w0]
-  // CHECK: hw.hierpath private [[NLA1:@.+]] [@Context::@[[CONTEXT0:.+]], @Context0::@leaf0, @ContextLeaf0::@w0]
 
   // CHECK: firrtl.module private @ContextLeaf0()
   firrtl.module private @ContextLeaf0() {
     // CHECK: %w0 = firrtl.wire sym @w0  {annotations = [
-    // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "fake0"}
-    // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "fake1"}]}
+    // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "fake0"}
+    // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "fake1"}]}
     %w0 = firrtl.wire sym @w0 {annotations = [
       {circt.nonlocal = @nla0, class = "fake0"}]}: !firrtl.uint<3>
   }
@@ -411,9 +406,9 @@ firrtl.circuit "DuplicateNLAs" {
   hw.hierpath private @annos_nla_2 [@Mid_2::@core, @Core_2]
   hw.hierpath private @annos_nla_3 [@Mid_3::@core, @Core_3]
 
-  // CHECK: hw.hierpath private [[NLA0:@.+]] [@DuplicateNLAs::@core_3, @Mid_1::@core, @Core_1]
-  // CHECK: hw.hierpath private [[NLA1:@.+]] [@DuplicateNLAs::@core_2, @Mid_1::@core, @Core_1]
-  // CHECK: hw.hierpath private [[NLA2:@.+]] [@DuplicateNLAs::@core_1, @Mid_1::@core, @Core_1]
+  // CHECK: hw.hierpath private [[NLA0:@annos_nla_1]] [@DuplicateNLAs::@core_1, @Mid_1::@core, @Core_1]
+  // CHECK: hw.hierpath private [[NLA1:@annos_nla_2]] [@DuplicateNLAs::@core_2, @Mid_1::@core, @Core_1]
+  // CHECK: hw.hierpath private [[NLA2:@annos_nla_3]] [@DuplicateNLAs::@core_3, @Mid_1::@core, @Core_1]
 
   firrtl.module @DuplicateNLAs() {
     firrtl.instance core_1 sym @core_1 @Mid_1()
@@ -434,9 +429,9 @@ firrtl.circuit "DuplicateNLAs" {
   }
 
   // CHECK: firrtl.module private @Core_1() attributes {annotations = [
-  // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "SomeAnno1"}
+  // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "SomeAnno1"}
   // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "SomeAnno2"}
-  // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "SomeAnno3"}
+  // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "SomeAnno3"}
   firrtl.module private @Core_1() attributes {
     annotations = [
       {circt.nonlocal = @annos_nla_1, class = "SomeAnno1"}


### PR DESCRIPTION
When the module being deduplicated has exactly one instantiation site,
NLA context can be added by prepending one element to the namepath in
place rather than erasing and recreating the HierPathOp. This keeps
the NLA's symbol name stable, so annotations and targetMap entries
need no rewriting.

This avoids the O(N^2) blowup when a canonical module accumulates many
NLAs across repeated dedup merges: the general path allocates new
DictionaryAttr/ArrayAttr objects (annotation clones + namepaths) in
the MLIR context's uniquer on every merge, and those are never freed.
With the fast path, no annotation DictionaryAttrs are created at all.

Assisted-by: Claude Code: Opus 4.8

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
