### PR TITLE
[Comb] Fix O(NM) extract-of-concat resolution

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -512,60 +512,53 @@ OpFoldResult ExtractOp::fold(FoldAdaptor adaptor) {
 // Transforms extract(lo, cat(a, b, c, d, e)) into
 // cat(extract(lo1, b), c, extract(lo2, d)).
 // innerCat must be the argument of the provided ExtractOp.
-static LogicalResult extractConcatToConcatExtract(ExtractOp op,
-                                                  ConcatOp innerCat,
-                                                  PatternRewriter &rewriter) {
-  auto reversedConcatArgs = llvm::reverse(innerCat.getInputs());
-  size_t beginOfFirstRelevantElement = 0;
-  auto it = reversedConcatArgs.begin();
+//
+// When prefixWidths is non-empty it is used for O(log N) binary-search lookup
+// of the first relevant concat operand instead of the default O(N) linear scan.
+// The array must contain cumulative bit widths in LSB-first (reversed) order:
+//   prefixWidths[i] = sum of bitwidths of concat operands [N-1, N-2, ..., N-i]
+static LogicalResult
+extractConcatToConcatExtract(ExtractOp op, ConcatOp innerCat,
+                             PatternRewriter &rewriter,
+                             ArrayRef<size_t> prefixWidths = {}) {
+  auto concatInputs = innerCat.getInputs();
+  size_t numOperands = concatInputs.size();
   size_t lowBit = op.getLowBit();
 
-  // This loop finds the first concatArg that is covered by the ExtractOp
-  for (; it != reversedConcatArgs.end(); it++) {
-    assert(beginOfFirstRelevantElement <= lowBit &&
-           "incorrectly moved past an element that lowBit has coverage over");
-    auto operand = *it;
-
-    size_t operandWidth = operand.getType().getIntOrFloatBitWidth();
-    if (lowBit < beginOfFirstRelevantElement + operandWidth) {
-      // A bit other than the first bit will be used in this element.
-      // ...... ........ ...
-      //           ^---lowBit
-      //        ^---beginOfFirstRelevantElement
-      //
-      // Edge-case close to the end of the range.
-      // ...... ........ ...
-      //                 ^---(position + operandWidth)
-      //               ^---lowBit
-      //        ^---beginOfFirstRelevantElement
-      //
-      // Edge-case close to the beginning of the rang
-      // ...... ........ ...
-      //        ^---lowBit
-      //        ^---beginOfFirstRelevantElement
-      //
-      break;
+  // Find the first operand (in LSB-first order) that contains lowBit.
+  size_t firstIdx;
+  size_t beginOfFirst;
+  if (!prefixWidths.empty()) {
+    // O(log N) binary search path.
+    auto it =
+        std::upper_bound(prefixWidths.begin(), prefixWidths.end(), lowBit);
+    assert(it != prefixWidths.end());
+    firstIdx = it - prefixWidths.begin();
+    beginOfFirst = (firstIdx > 0) ? prefixWidths[firstIdx - 1] : 0;
+  } else {
+    // O(N) linear scan path.
+    firstIdx = 0;
+    beginOfFirst = 0;
+    for (size_t i = 0; i < numOperands; ++i) {
+      size_t w =
+          concatInputs[numOperands - 1 - i].getType().getIntOrFloatBitWidth();
+      if (lowBit < beginOfFirst + w) {
+        firstIdx = i;
+        break;
+      }
+      beginOfFirst += w;
     }
-
-    // extraction discards this element.
-    // ...... ........  ...
-    // |      ^---lowBit
-    // ^---beginOfFirstRelevantElement
-    beginOfFirstRelevantElement += operandWidth;
   }
-  assert(it != reversedConcatArgs.end() &&
-         "incorrectly failed to find an element which contains coverage of "
-         "lowBit");
 
   SmallVector<Value> reverseConcatArgs;
-  size_t widthRemaining = cast<IntegerType>(op.getType()).getWidth();
-  size_t extractLo = lowBit - beginOfFirstRelevantElement;
+  size_t widthRemaining = op.getType().getIntOrFloatBitWidth();
+  size_t extractLo = lowBit - beginOfFirst;
 
-  // Transform individual arguments of innerCat(..., a, b, c,) into
-  // [ extract(a), b, extract(c) ], skipping an extract operation where
-  // possible.
-  for (; widthRemaining != 0 && it != reversedConcatArgs.end(); it++) {
-    auto concatArg = *it;
+  // Walk forward from firstIdx in LSB-first order, building
+  // [ extract(a), b, extract(c) ], skipping an extract where possible (where
+  // the whole operand is consumed).
+  for (size_t i = firstIdx; widthRemaining != 0 && i < numOperands; ++i) {
+    Value concatArg = concatInputs[numOperands - 1 - i];
     size_t operandWidth = concatArg.getType().getIntOrFloatBitWidth();
     size_t widthToConsume = std::min(widthRemaining, operandWidth - extractLo);
 
@@ -573,12 +566,11 @@ static LogicalResult extractConcatToConcatExtract(ExtractOp op,
       reverseConcatArgs.push_back(concatArg);
     } else {
       auto resultType = IntegerType::get(rewriter.getContext(), widthToConsume);
-      reverseConcatArgs.push_back(
-          ExtractOp::create(rewriter, op.getLoc(), resultType, *it, extractLo));
+      reverseConcatArgs.push_back(ExtractOp::create(
+          rewriter, op.getLoc(), resultType, concatArg, extractLo));
     }
 
     widthRemaining -= widthToConsume;
-
     // Beyond the first element, all elements are extracted from position 0.
     extractLo = 0;
   }
@@ -1985,6 +1977,48 @@ LogicalResult ConcatOp::canonicalize(ConcatOp op, PatternRewriter &rewriter) {
     processedOperands.push_back(nextOperand);
   }
 
+  // Batch-resolve all ExtractOp users of this concat using a prefix-sum array
+  // and binary search. This avoids the O(M*N) cost of having each ExtractOp
+  // independently do a linear scan over the concat's operands.
+  //
+  // Only do this when:
+  //  - the concat operands are unchanged (if they changed, we'll replace the
+  //    concat below and the extract users will be re-enqueued naturally)
+  //  - there are enough extract users to justify batching (for small counts,
+  //    the per-ExtractOp canonicalization is fine and preserves output order)
+  constexpr size_t kBatchExtractThreshold = 16;
+  bool anyExtractsResolved = false;
+  if (!anyOperandChanged && processedOperands.size() > 1) {
+    SmallVector<ExtractOp, 8> extractUsers;
+    for (auto *user : op->getUsers()) {
+      if (auto extract = dyn_cast<ExtractOp>(user))
+        extractUsers.push_back(extract);
+    }
+
+    if (extractUsers.size() >= kBatchExtractThreshold) {
+      // Build prefix-sum of bit widths in LSB-first (reversed) order.
+      auto concatInputs = op.getInputs();
+      size_t numConcatOperands = concatInputs.size();
+      SmallVector<size_t> prefixWidths(numConcatOperands);
+      size_t cumWidth = 0;
+      for (size_t i = 0; i < numConcatOperands; ++i) {
+        // Note: we can just query bitwidth here as is as the ExtractOp above's
+        // type constraints means this is valid in valid IR.
+        cumWidth += concatInputs[numConcatOperands - 1 - i]
+                        .getType()
+                        .getIntOrFloatBitWidth();
+        prefixWidths[i] = cumWidth;
+      }
+
+      // Resolve each extract user.
+      for (auto extract : extractUsers) {
+        if (succeeded(extractConcatToConcatExtract(extract, op, rewriter,
+                                                   prefixWidths)))
+          anyExtractsResolved = true;
+      }
+    }
+  }
+
   if (processedOperands.size() == 1) {
     // If the operands were all the same, we'll reach here with a single
     // ReplicateOp.
@@ -1992,7 +2026,7 @@ LogicalResult ConcatOp::canonicalize(ConcatOp op, PatternRewriter &rewriter) {
   } else if (anyOperandChanged) {
     replaceOpWithNewOpAndCopyNamehint<ConcatOp>(rewriter, op, op.getType(),
                                                 processedOperands);
-  } else {
+  } else if (!anyExtractsResolved) {
     return failure();
   }
   return success();

--- a/test/Dialect/Comb/concat-canonicalize-scaling.py
+++ b/test/Dialect/Comb/concat-canonicalize-scaling.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 # Generate a Comb canonicalization scaling stress test.
 #
-# The produced MLIR module has N one-bit inputs and creates
-# a left-associative chain of binary concats:
+# The produced MLIR module has N one-bit inputs and creates:
+#   1. A left-associative chain of binary concats:
 #        concat(concat(concat(a0, a1), a2), a3) ...
-# When canonicalize flattens this, the old algorithm recreated the concat
-# on each step (O(N^2)).  The stack-based rewrite is O(N).
+#      When canonicalize flattens this, the old algorithm recreated the concat
+#      on each step (O(N^2)).  The stack-based rewrite is O(N).
+#   2. N extract ops that pull each individual bit back out of the final
+#      N-bit concatenation result.  The old extract-of-concat logic did a
+#      linear scan for every extract (O(N) per extract, O(N^2) total).
+#      The batched binary-search rewrite is O(N log N).
 #
 # Usage:
 #   python3 concat-canonicalize-scaling.py N > test.mlir
@@ -19,18 +23,33 @@ def generate(n: int) -> str:
 
   out = []
   w = out.append
-  w(f"// Stress test: {n} inputs, nested binary concat chain.")
+  w(f"// Stress test: {n} inputs, nested binary concat chain + {n} extracts.")
   w("")
 
-  w(f"hw.module @ConcatCanonicalizationScaling{n}(in %a0 : i1, in %a1 : i1, out z0 : i1) {{"
-   )
-  w("  %c0 = comb.concat %a0, %a1 : i1, i1")
-  args = ", ".join(["%c0" for _ in range(n)])
-  types = ", ".join(["i2" for _ in range(n)])
-  w(f"  %c1 = comb.concat {args} : {types}")
-  # Extract a bit from the final concat.
-  w(f"  %z0 = comb.extract %c1 from {n} : (i{2 * n}) -> i1")
-  w("hw.output %z0 : i1")
+  in_ports = ", ".join(f"in %a{i} : i1" for i in range(n))
+  out_ports = ", ".join(f"out z{i} : i1" for i in range(n))
+  w(f"hw.module @ConcatCanonicalizationScaling{n}({in_ports}, {out_ports}) {{")
+
+  # Build a left-associative chain of binary concats.
+  # Step 0: %c0 = concat(%a0, %a1)          -> i2
+  # Step 1: %c1 = concat(%c0, %a2)          -> i3
+  # ...
+  # Step N-2: %c{N-2} = concat(%c{N-3}, %a{N-1}) -> iN
+  w(f"  %c0 = comb.concat %a0, %a1 : i1, i1")
+  for i in range(2, n):
+    w(f"  %c{i-1} = comb.concat %c{i-2}, %a{i} : i{i}, i1")
+
+  final = f"%c{n-2}"
+  # Extract each bit from the final concat.
+  extract_names = []
+  for i in range(n):
+    name = f"%e{i}"
+    extract_names.append(name)
+    w(f"  {name} = comb.extract {final} from {i} : (i{n}) -> i1")
+
+  out_args = ", ".join(extract_names)
+  out_types = ", ".join(["i1"] * n)
+  w(f"  hw.output {out_args} : {out_types}")
   w("}")
   return "\n".join(out) + "\n"
 


### PR DESCRIPTION
Each ExtractOp user of a ConcatOp triggered a separate extractConcatToConcatExtract call that did a linear scan through the concat operands. For M extracts on an N-operand concat this is O(M*N). Here we batch in ConcatOp::canonicalize by building a prefix-sum array once and resolving all extract users via binary search in O(N) prefix-sum build + O(M*log N). The batch path activates only when there are >= 16 extract users (to both avoid overhead of creating prefix tree for small cases).

This does complicate the original optimization a bit (a linear scan is replaced by computing a prefix table for determining which operand contains which bit), but does greatly increase speed where one has many of these.

Assisted-by: Antigravity : Gemini
