### PR TITLE
[ArcRuntime][InsertRuntime] Improve runtime argument parsing

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/ModelInstance.h
+++ b/include/circt/Dialect/Arc/Runtime/ModelInstance.h
@@ -21,7 +21,9 @@
 #include "circt/Dialect/Arc/Runtime/TraceEncoder.h"
 
 #include <filesystem>
+#include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace circt {
@@ -51,11 +53,11 @@ private:
   const uint64_t instanceID;
   const ArcRuntimeModelInfo *const modelInfo;
   const ArcState *const state;
+  std::map<std::string, std::optional<std::string>> arguments;
   // FST is always in the enum so headers don't depend on build configuration.
   // If FST is selected at runtime but not compiled in, an error is emitted.
   enum class TraceMode { DUMMY, VCD, FST };
   TraceMode traceMode;
-  std::optional<std::string> traceFileArg;
   std::unique_ptr<TraceEncoder> traceEncoder;
   bool verbose = false;
   uint64_t stepCounter = 0;

--- a/integration_test/arcilator/JIT/runtime-lib-argparse.mlir
+++ b/integration_test/arcilator/JIT/runtime-lib-argparse.mlir
@@ -1,0 +1,46 @@
+// RUN: arcilator %s --run --jit-entry=main > %t.out 2>%t.err
+// RUN: FileCheck %s --check-prefixes=STDOUT --input-file %t.out
+// RUN: FileCheck %s --check-prefixes=STDERR --input-file %t.err
+// REQUIRES: arcilator-jit
+
+// Test the parser of the runtime argument string
+
+// STDOUT:      [ArcRuntime] Argument string for instance ID 0: debug;simple;empty=;;noQuote=foo;quote="foo \\ \" bar ";semi="a;b;c"
+// STDOUT-NEXT: [ArcRuntime] Parsed argument(s):
+// STDOUT-NEXT: [ArcRuntime]   debug
+// STDOUT-NEXT: [ArcRuntime]   empty = ""
+// STDOUT-NEXT: [ArcRuntime]   noQuote = "foo"
+// STDOUT-NEXT: [ArcRuntime]   quote = "foo \ " bar "
+// STDOUT-NEXT: [ArcRuntime]   semi = "a;b;c"
+// STDOUT-NEXT: [ArcRuntime]   simple
+
+// STDERR:      [ArcRuntime] WARNING: Malformed runtime argument: Invalid key, ignoring
+// STDERR-NEXT: [ArcRuntime] WARNING: Malformed runtime argument: Invalid key, ignoring
+// STDERR-NEXT: [ArcRuntime] WARNING: Malformed runtime argument: Invalid key, ignoring
+// STDERR-NEXT: [ArcRuntime] WARNING: Malformed runtime argument: Unquoted value contains forbidden character '"' for key "badVal", ignoring
+// STDERR-NEXT: [ArcRuntime] WARNING: Malformed runtime argument: Unexpected content after closing quote for key "badVal2", ignoring
+// STDERR-NEXT: [ArcRuntime] WARNING: Malformed runtime argument: Invalid escape sequence in quoted value for key "badVal3", ignoring
+// STDERR-NEXT: [ArcRuntime] WARNING: Malformed runtime argument: Unterminated quoted value for key "unterm", ignoring
+
+// STDOUT:      [ArcRuntime] Argument string for instance ID 1: debug;=badKey;=;"=;badVal=x"";badVal2=""x;badVal3="\x";foo;unterm="
+// STDOUT-NEXT: [ArcRuntime] Parsed argument(s):
+// STDOUT-NEXT: [ArcRuntime]   debug
+// STDOUT-NEXT: [ArcRuntime]   foo
+
+// STDERR:      [ArcRuntime] WARNING: Malformed runtime argument: Truncated escape sequence in quoted value for key "truncEscape", ignoring
+// STDOUT-NOT:  [ArcRuntime] Argument string
+// STDOUT-NOT:  [ArcRuntime] Parsed argument
+
+hw.module @dummy() {
+  hw.output
+}
+
+func.func @main() {
+  arc.sim.instantiate @dummy as %model runtime ("debug;simple;empty=;;noQuote=foo;quote=\"foo \\\\ \\\" bar \";semi=\"a;b;c\"") {
+  }
+  arc.sim.instantiate @dummy as %model runtime ("debug;=badKey;=;\"=;badVal=x\"\";badVal2=\"\"x;badVal3=\"\\x\";foo;unterm=\"") {
+  }
+  arc.sim.instantiate @dummy as %model runtime ("foo;truncEscape=\"\\") {
+  }
+  return
+}

--- a/integration_test/arcilator/JIT/runtime-lib.mlir
+++ b/integration_test/arcilator/JIT/runtime-lib.mlir
@@ -23,7 +23,7 @@
 // DBGOFF-NOT: [ArcRuntime] Created instance of model "flipflop" with ID 1
 // DBGOFF-NOT: [ArcRuntime] Instance with ID 1 initialized
 
-// DBGON-NEXT: [ArcRuntime] Created instance of model "flipflop" with ID 1
+// DBGON:      [ArcRuntime] Created instance of model "flipflop" with ID 1
 // DBGON:      [ArcRuntime] Instance with ID 1 initialized
 
 // CHECK:      d1 = 00

--- a/lib/Dialect/Arc/Runtime/ModelInstance.cpp
+++ b/lib/Dialect/Arc/Runtime/ModelInstance.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <cassert>
+#include <cctype>
 #include <iostream>
 #include <string_view>
 #include <vector>
@@ -102,8 +103,9 @@ ModelInstance::~ModelInstance() {
 
 std::filesystem::path
 ModelInstance::getTraceFilePath(const std::string &suffix) {
-  if (traceFileArg.has_value())
-    return std::filesystem::path(*traceFileArg);
+  auto it = arguments.find("traceFile");
+  if (it != arguments.end() && it->second.has_value())
+    return std::filesystem::path(*it->second);
 
   std::string saneName;
   if (modelInfo->modelName)
@@ -148,53 +150,156 @@ uint64_t *ModelInstance::swapTraceBuffer() {
   return traceEncoder->dispatch(state->traceBufferSize);
 }
 
-// Try to parse argument with "`key`=`value`" syntax
-static bool parseKeyValueArg(const std::string_view &input, std::string &key,
-                             std::string &value) {
-  key.clear();
-  value.clear();
-  auto eqPos = input.find('=');
-  if (eqPos == std::string_view::npos || eqPos == 0)
-    return false;
-  key = input.substr(0, eqPos);
-  value = input.substr(eqPos + 1);
-  return true;
+// Parse the argument string into a map of key to optional value.
+// Flags (bare keys without '=') map to std::nullopt. Keys occurring later
+// override identical earlier keys. Quoted values (key="...") may contain ';'
+// and support \" and \\ escape sequences. Malformed tokens are warned and
+// skipped.
+static std::map<std::string, std::optional<std::string>>
+parseArgsToMap(std::string_view argStr) {
+  std::map<std::string, std::optional<std::string>> result;
+
+  enum class State { Key, AfterEq, Unquoted, Quoted, Escape, AfterQuote, Skip };
+  State state = State::Key;
+
+  std::string key;
+  std::string value;
+  bool hasValue = false;
+
+  auto warn = [&](const char *msg) {
+    std::cerr << "[ArcRuntime] WARNING: Malformed runtime argument: " << msg;
+    if (!key.empty())
+      std::cerr << " for key \"" << key << "\"";
+    std::cerr << ", ignoring\n";
+  };
+
+  auto commit = [&] {
+    result[std::move(key)] =
+        hasValue ? std::optional(std::move(value)) : std::nullopt;
+    key.clear();
+    value.clear();
+    hasValue = false;
+    state = State::Key;
+  };
+
+  auto skipToNext = [&] {
+    key.clear();
+    value.clear();
+    hasValue = false;
+    state = State::Skip;
+  };
+
+  for (size_t i = 0; i <= argStr.size(); ++i) {
+    const bool atEnd = (i == argStr.size());
+    const char c = atEnd ? '\0' : argStr[i];
+
+    switch (state) {
+    case State::Key:
+      if (atEnd || c == ';') {
+        if (!key.empty())
+          commit();
+      } else if (std::isgraph(static_cast<unsigned char>(c)) && c != '"' &&
+                 c != '=') {
+        key += c;
+      } else if (c == '=' && !key.empty()) {
+        hasValue = true;
+        state = State::AfterEq;
+      } else {
+        warn("Invalid key");
+        skipToNext();
+      }
+      break;
+
+    case State::AfterEq:
+      if (c == '"' && !atEnd) {
+        state = State::Quoted;
+      } else if (atEnd || c == ';') {
+        commit(); // empty value
+      } else {
+        value += c;
+        state = State::Unquoted;
+      }
+      break;
+
+    case State::Unquoted:
+      if (atEnd || c == ';') {
+        commit();
+      } else if (c == '"') {
+        warn("Unquoted value contains forbidden character '\"'");
+        skipToNext();
+      } else {
+        value += c;
+      }
+      break;
+
+    case State::Quoted:
+      if (atEnd) {
+        warn("Unterminated quoted value");
+        skipToNext();
+      } else if (c == '"') {
+        state = State::AfterQuote;
+      } else if (c == '\\') {
+        state = State::Escape;
+      } else {
+        value += c;
+      }
+      break;
+
+    case State::Escape:
+      if (atEnd) {
+        warn("Truncated escape sequence in quoted value");
+        skipToNext();
+      } else if (c == '"' || c == '\\') {
+        value += c;
+        state = State::Quoted;
+      } else {
+        warn("Invalid escape sequence in quoted value");
+        skipToNext();
+      }
+      break;
+
+    case State::AfterQuote:
+      if (atEnd || c == ';') {
+        commit();
+      } else {
+        warn("Unexpected content after closing quote");
+        skipToNext();
+      }
+      break;
+
+    case State::Skip:
+      if (!atEnd && c == ';')
+        state = State::Key;
+      break;
+    }
+  }
+
+  return result;
 }
 
 void ModelInstance::parseArgs(const char *args) {
   if (!args)
     return;
-
-  // Split the argument string at semicolon delimiters
   auto argStr = std::string_view(args);
-  if (argStr.empty())
-    return;
-  std::vector<std::string_view> options;
-  size_t start = 0;
-  size_t end = 0;
+  arguments = parseArgsToMap(argStr);
 
-  while ((end = argStr.find(";", start)) != std::string_view::npos) {
-    options.push_back(argStr.substr(start, end - start));
-    start = end + 1;
-  }
-  if (start <= argStr.size())
-    options.push_back(argStr.substr(start));
+  if (arguments.count("debug"))
+    verbose = true;
+  if (arguments.count("vcd"))
+    traceMode = TraceMode::VCD;
+  if (arguments.count("fst"))
+    traceMode = TraceMode::FST;
 
-  std::string key;
-  std::string value;
-
-  // Parse the individual options
-  for (auto &option : options) {
-
-    if (option == "debug") {
-      verbose = true;
-    } else if (option == "vcd") {
-      traceMode = TraceMode::VCD;
-    } else if (option == "fst") {
-      traceMode = TraceMode::FST;
-    } else if (parseKeyValueArg(option, key, value) && !value.empty()) {
-      if (key == "traceFile")
-        traceFileArg = value;
+  // Dump arguments
+  if (verbose) {
+    std::cout << "[ArcRuntime] Argument string for instance ID " << instanceID
+              << ": " << argStr << std::endl;
+    std::cout << "[ArcRuntime] Parsed argument(s):" << std::endl;
+    for (const auto &[key, value] : arguments) {
+      std::cout << "[ArcRuntime]   " << key;
+      if (value.has_value())
+        std::cout << " = \"" << *value << "\"";
+      std::cout << std::endl;
     }
   }
 }

--- a/lib/Dialect/Arc/Transforms/InsertRuntime.cpp
+++ b/lib/Dialect/Arc/Transforms/InsertRuntime.cpp
@@ -270,6 +270,18 @@ struct InsertRuntimePass
   void runOnOperation() override;
 
 private:
+  SmallString<32> quoteAndEscapeRuntimeArgument(StringRef input) {
+    SmallString<32> result;
+    result += '"';
+    for (char c : input) {
+      if (c == '"' || c == '\\')
+        result += '\\';
+      result += c;
+    }
+    result += '"';
+    return result;
+  }
+
   // Construct the runtime argument string for an instance
   SmallString<32> buildArgString(unsigned instIdx, StringAttr existingArgs) {
     SmallString<32> str;
@@ -283,16 +295,19 @@ private:
       // Create a unique per-instance file name by adding a suffix before the
       // the file extension
       if (instIdx == 0) {
-        str += traceFileName;
+        str += quoteAndEscapeRuntimeArgument(traceFileName);
       } else {
+        SmallString<32> fileNameWithSuffix;
         auto extension =
             std::filesystem::path(static_cast<std::string>(traceFileName))
                 .extension()
                 .string();
-        str += traceFileName.substr(0, traceFileName.size() - extension.size());
-        str += '_';
-        str += std::to_string(instIdx);
-        str += extension;
+        fileNameWithSuffix +=
+            traceFileName.substr(0, traceFileName.size() - extension.size());
+        fileNameWithSuffix += '_';
+        fileNameWithSuffix += std::to_string(instIdx);
+        fileNameWithSuffix += extension;
+        str += quoteAndEscapeRuntimeArgument(fileNameWithSuffix);
       }
     }
     // Append extra arguments from pass option

--- a/test/Dialect/Arc/insert-runtime.mlir
+++ b/test/Dialect/Arc/insert-runtime.mlir
@@ -1,5 +1,5 @@
 // RUN: circt-opt %s --arc-insert-runtime --split-input-file | FileCheck %s --check-prefixes=CHECK,NOARGS
-// RUN: circt-opt %s --arc-insert-runtime="trace-file=tcf.abc extra-args='debug;bar'" --split-input-file | FileCheck %s --check-prefixes=CHECK,RTARGS
+// RUN: circt-opt %s --arc-insert-runtime="trace-file=C:\tcf.abc extra-args='debug;bar'" --split-input-file | FileCheck %s --check-prefixes=CHECK,RTARGS
 
 // CHECK-DAG: llvm.func @arcRuntimeIR_allocInstance(!llvm.ptr, !llvm.ptr) -> (!llvm.ptr {llvm.align = 16 : i64, llvm.noalias, llvm.nonnull, llvm.noundef})
 // CHECK-DAG: llvm.func @arcRuntimeIR_deleteInstance(!llvm.ptr)
@@ -42,7 +42,7 @@ func.func @main() {
   %step = arith.constant 1 : index
 
   // NOARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter()
-  // RTARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("traceFile=tcf.abc;debug;bar")
+  // RTARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("traceFile=\22C:\\\\tcf.abc\22;debug;bar")
   arc.sim.instantiate @counter as %model {
     // CHECK: [[RTINST:%.*]] = builtin.unrealized_conversion_cast %arg0 : !arc.sim.instance<@counter> to !llvm.ptr
     scf.for %i = %lb to %ub step %step {
@@ -61,7 +61,7 @@ func.func @main() {
   }
 
   // NOARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("foo")
-  // RTARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("foo;traceFile=tcf_1.abc;debug;bar")
+  // RTARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("foo;traceFile=\22C:\\\\tcf_1.abc\22;debug;bar")
   arc.sim.instantiate @counter as %model runtime ("foo") {
     // CHECK: [[RTINST:%.*]] = builtin.unrealized_conversion_cast %arg0 : !arc.sim.instance<@counter> to !llvm.ptr
     // CHECK-NEXT: llvm.call @arcRuntimeIR_onEval([[RTINST]])


### PR DESCRIPTION
Improve the key-value-pair parsing of the argument string in the arcilator runtime library. Enables parsing of an arbitrary (escaped) string within quotes as value.

Adapts the InsertRuntime pass to quote and escape the `traceFilename` argument, so arbitrary paths can be passed safely.

This is in preparation for a future commit allowing us to usa a per-instance working directory, CC #10723. 

Assisted-by: vscode:Claude Sonnet 4.6