### PR TITLE
[Synth] Use LinearTimingArcAttr sensitivity in TechMappper

### DIFF
--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -87,22 +87,12 @@ static llvm::FailureOr<NPNClass> getNPNClassFromModule(hw::HWModuleOp module) {
   return NPNClass::computeNPNCanonicalForm(*truthTable);
 }
 
-struct TechTimingArc {
-  DelayType intrinsic;
-  DelayType sensitivity;
-
-  DelayType getDelay() const {
-    // TODO: Replace unit-load approximation with load-aware delay.
-    return intrinsic + sensitivity;
-  }
-};
-
 /// Simple technology library encoded as a HWModuleOp.
 struct TechLibraryPattern : public CutRewritePattern {
   TechLibraryPattern(hw::HWModuleOp module, double area,
-                     SmallVector<TechTimingArc> arcs, NPNClass npnClass)
+                     SmallVector<DelayType> delay, NPNClass npnClass)
       : CutRewritePattern(module->getContext()), area(area),
-        arcs(std::move(arcs)), module(module), npnClass(std::move(npnClass)) {
+        delay(std::move(delay)), module(module), npnClass(std::move(npnClass)) {
 
     LLVM_DEBUG({
       llvm::dbgs() << "Created Tech Library Pattern for module: "
@@ -128,16 +118,7 @@ struct TechLibraryPattern : public CutRewritePattern {
              .equivalentOtherThanPermutation(npnClass))
       return std::nullopt;
 
-    SmallVector<DelayType, 6> delays;
-    delays.reserve(arcs.size());
-
-    for (const auto &arc : arcs)
-      delays.push_back(arc.getDelay());
-
-    MatchResult result;
-    result.area = area;
-    result.setOwnedDelays(std::move(delays));
-    return result;
+    return MatchResult(area, delay);
   }
 
   /// Enable truth table matching for this pattern
@@ -188,7 +169,7 @@ struct TechLibraryPattern : public CutRewritePattern {
 
 private:
   const double area;
-  const SmallVector<TechTimingArc> arcs;
+  const SmallVector<DelayType> delay;
   hw::HWModuleOp module;
   NPNClass npnClass;
 };
@@ -256,11 +237,10 @@ struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
         return;
       }
 
-      SmallVector<TechTimingArc> timingArcs;
+      SmallVector<DelayType> delay;
       for (auto attr : arcs) {
         auto arc = cast<LinearTimingArcAttr>(attr);
-        timingArcs.push_back({static_cast<DelayType>(arc.getIntrinsic()),
-                              static_cast<DelayType>(arc.getSensitivity())});
+        delay.push_back(arc.getIntrinsic() + arc.getSensitivity());
       }
 
       // Compute NPN Class for the module.
@@ -272,8 +252,8 @@ struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
 
       // Create a CutRewritePattern for the library module
       std::unique_ptr<TechLibraryPattern> pattern =
-          std::make_unique<TechLibraryPattern>(
-              hwModule, area, std::move(timingArcs), std::move(*npnClass));
+          std::make_unique<TechLibraryPattern>(hwModule, area, std::move(delay),
+                                               std::move(*npnClass));
 
       // Update the maximum input size
       maxInputSize = std::max(maxInputSize, pattern->getNumInputs());

--- a/lib/Dialect/Synth/Transforms/TechMapper.cpp
+++ b/lib/Dialect/Synth/Transforms/TechMapper.cpp
@@ -87,12 +87,22 @@ static llvm::FailureOr<NPNClass> getNPNClassFromModule(hw::HWModuleOp module) {
   return NPNClass::computeNPNCanonicalForm(*truthTable);
 }
 
+struct TechTimingArc {
+  DelayType intrinsic;
+  DelayType sensitivity;
+
+  DelayType getDelay() const {
+    // TODO: Replace unit-load approximation with load-aware delay.
+    return intrinsic + sensitivity;
+  }
+};
+
 /// Simple technology library encoded as a HWModuleOp.
 struct TechLibraryPattern : public CutRewritePattern {
   TechLibraryPattern(hw::HWModuleOp module, double area,
-                     SmallVector<DelayType> delay, NPNClass npnClass)
+                     SmallVector<TechTimingArc> arcs, NPNClass npnClass)
       : CutRewritePattern(module->getContext()), area(area),
-        delay(std::move(delay)), module(module), npnClass(std::move(npnClass)) {
+        arcs(std::move(arcs)), module(module), npnClass(std::move(npnClass)) {
 
     LLVM_DEBUG({
       llvm::dbgs() << "Created Tech Library Pattern for module: "
@@ -118,7 +128,16 @@ struct TechLibraryPattern : public CutRewritePattern {
              .equivalentOtherThanPermutation(npnClass))
       return std::nullopt;
 
-    return MatchResult(area, delay);
+    SmallVector<DelayType, 6> delays;
+    delays.reserve(arcs.size());
+
+    for (const auto &arc : arcs)
+      delays.push_back(arc.getDelay());
+
+    MatchResult result;
+    result.area = area;
+    result.setOwnedDelays(std::move(delays));
+    return result;
   }
 
   /// Enable truth table matching for this pattern
@@ -169,7 +188,7 @@ struct TechLibraryPattern : public CutRewritePattern {
 
 private:
   const double area;
-  const SmallVector<DelayType> delay;
+  const SmallVector<TechTimingArc> arcs;
   hw::HWModuleOp module;
   NPNClass npnClass;
 };
@@ -237,14 +256,11 @@ struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
         return;
       }
 
-      SmallVector<DelayType> delay;
+      SmallVector<TechTimingArc> timingArcs;
       for (auto attr : arcs) {
         auto arc = cast<LinearTimingArcAttr>(attr);
-
-        // TechMapper currently preserves the old integer per-pin delay model.
-        // The sensitivity, polarity, and input capacitance fields are carried
-        // in the attribute for future load-aware mapping.
-        delay.push_back(static_cast<DelayType>(arc.getIntrinsic()));
+        timingArcs.push_back({static_cast<DelayType>(arc.getIntrinsic()),
+                              static_cast<DelayType>(arc.getSensitivity())});
       }
 
       // Compute NPN Class for the module.
@@ -256,8 +272,8 @@ struct TechMapperPass : public impl::TechMapperBase<TechMapperPass> {
 
       // Create a CutRewritePattern for the library module
       std::unique_ptr<TechLibraryPattern> pattern =
-          std::make_unique<TechLibraryPattern>(hwModule, area, std::move(delay),
-                                               std::move(*npnClass));
+          std::make_unique<TechLibraryPattern>(
+              hwModule, area, std::move(timingArcs), std::move(*npnClass));
 
       // Update the maximum input size
       maxInputSize = std::max(maxInputSize, pattern->getNumInputs());

--- a/test/Dialect/Synth/tech-mapper.mlir
+++ b/test/Dialect/Synth/tech-mapper.mlir
@@ -19,8 +19,9 @@ hw.module @and_inv_nn(in %a : i1, in %b : i1, out result : i1) attributes {synth
 }
 
 // Delay is shorter than @and_inv + @and_inv_n_n. Area is (significantly) larger than @and_inv_n + @and_inv_n_n.
+// @and_inv_3 uses intrinsic 0 and sensitivity 1, so the unit-load delay is 1.
 // Check that we use @and_inv_3 if strategy = timing, and @and_inv_n + @and_inv_n_n if strategy = area.
-hw.module @and_inv_3(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 10.0 : f64, arcs = [#synth.linear_timing_arc<1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<1, 0, #synth.polarity<positive>>, #synth.linear_timing_arc<1, 0, #synth.polarity<positive>>], input_caps = {}>} {
+hw.module @and_inv_3(in %a : i1, in %b : i1, in %c : i1, out result : i1) attributes {synth.mapping_cost = #synth.mapping_cost<area = 10.0 : f64, arcs = [#synth.linear_timing_arc<0, 1, #synth.polarity<positive>>, #synth.linear_timing_arc<0, 1, #synth.polarity<positive>>, #synth.linear_timing_arc<0, 1, #synth.polarity<positive>>], input_caps = {}>} {
     %0 = synth.aig.and_inv %a, %b : i1
     %1 = synth.aig.and_inv not %0, %c : i1
     hw.output %1 : i1


### PR DESCRIPTION
Concerns #10732 

We implement sensitivity to be used in TechMapper's timing cost. Currently, we use a unit-load approximation (load = 1); in follow-up PRs, we will use real load in TechMapper delay via the wiring of input caps.