### PR TITLE
[SV][ExportVeriog] Add sv.concat_str in SV dialect

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -216,6 +216,23 @@ def SFormatFOp : SVOp<"sformatf", [Pure]> {
     "$format_string attr-dict (`(` $substitutions^ `)` `:` qualified(type($substitutions)))?";
 }
 
+def ConcatStrOp : SVOp<"concat_str", [Pure]> {
+  let summary = "Concatenate string values";
+  let description = [{
+    This operation concatenates two or more string values using the
+    SystemVerilog concatenation operator `{a, b, ...}` to produce a single
+    string. The result is a string whose contents are the operands joined in
+    order.
+
+    See section 11.4.12 of 1800-2023 for more details.
+  }];
+
+  let arguments = (ins Variadic<HWStringType>:$inputs);
+  let results = (outs HWStringType:$result);
+  let assemblyFormat = "`(` $inputs `)` attr-dict `:` type($result)";
+  let hasVerifier = 1;
+}
+
 def LocalParamOp : SVOp<"localparam",
       [FirstAttrDerivedResultType, Pure, HasCustomSSAName]> {
   let summary = "Declare a localparam";

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -219,7 +219,7 @@ def SFormatFOp : SVOp<"sformatf", [Pure]> {
 def ConcatStrOp : SVOp<"concat_str", [Pure]> {
   let summary = "Concatenate string values";
   let description = [{
-    This operation concatenates two or more string values using the
+    This operation concatenates one or more string values using the
     SystemVerilog concatenation operator `{a, b, ...}` to produce a single
     string. The result is a string whose contents are the operands joined in
     order.
@@ -231,6 +231,7 @@ def ConcatStrOp : SVOp<"concat_str", [Pure]> {
   let results = (outs HWStringType:$result);
   let assemblyFormat = "`(` $inputs `)` attr-dict `:` type($result)";
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 def LocalParamOp : SVOp<"localparam",

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -32,7 +32,7 @@ public:
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
             ConstantXOp, ConstantZOp, ConstantStrOp, MacroRefExprOp,
             MacroRefExprSEOp, UnpackedArrayCreateOp, UnpackedOpenArrayCastOp,
-            SFormatFOp,
+            SFormatFOp, ConcatStrOp,
             // Declarations.
             RegOp, WireOp, LogicOp, LocalParamOp, XMROp, XMRRefOp,
             // Control flow.
@@ -117,6 +117,7 @@ public:
   HANDLE(UnpackedArrayCreateOp, Unhandled);
   HANDLE(UnpackedOpenArrayCastOp, Unhandled);
   HANDLE(SFormatFOp, Unhandled);
+  HANDLE(ConcatStrOp, Unhandled);
 
   // Control flow.
   HANDLE(OrderedOutputOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -255,7 +255,7 @@ bool ExportVerilog::isVerilogExpression(Operation *op) {
           IndexedPartSelectInOutOp, StructFieldInOutOp, IndexedPartSelectOp,
           ParamValueOp, XMROp, XMRRefOp, SampledOp, EnumConstantOp, SFormatFOp,
           SystemFunctionOp, STimeOp, TimeOp, UnpackedArrayCreateOp,
-          UnpackedOpenArrayCastOp>(op))
+          UnpackedOpenArrayCastOp, ConcatStrOp>(op))
     return true;
 
   // These are Verif dialect expressions.
@@ -2357,6 +2357,7 @@ private:
   SubExprInfo visitSV(ConstantXOp op);
   SubExprInfo visitSV(ConstantZOp op);
   SubExprInfo visitSV(ConstantStrOp op);
+  SubExprInfo visitSV(ConcatStrOp op);
 
   SubExprInfo visitSV(sv::UnpackedArrayCreateOp op);
   SubExprInfo visitSV(sv::UnpackedOpenArrayCastOp op) {
@@ -2951,6 +2952,16 @@ SubExprInfo ExprEmitter::visitSV(ConstantStrOp op) {
 
   ps.writeQuotedEscaped(op.getStr());
   return {Symbol, IsUnsigned}; // is a string unsigned?  Yes! SV 5.9
+}
+
+SubExprInfo ExprEmitter::visitSV(ConcatStrOp op) {
+  if (hasSVAttributes(op))
+    emitError(op, "SV attributes emission is unimplemented for the op");
+
+  // Emits the SystemVerilog concatenation `{a, b, ...}`. Strings are unsigned
+  // (SV 5.9) and braces bind at the primary/Symbol level.
+  emitBracedList(op.getInputs());
+  return {Symbol, IsUnsigned};
 }
 
 SubExprInfo ExprEmitter::visitSV(ConstantZOp op) {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -362,6 +362,18 @@ LogicalResult ConstantZOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ConcatStrOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ConcatStrOp::verify() {
+  // Concatenation of fewer than two operands is meaningless and would emit
+  // invalid (`{}`) or trivial (`{x}`) SystemVerilog.
+  if (getInputs().size() < 2)
+    return emitError("sv.concat_str requires at least two operands");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // LocalParamOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -366,11 +366,16 @@ LogicalResult ConstantZOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ConcatStrOp::verify() {
-  // Concatenation of fewer than two operands is meaningless and would emit
-  // invalid (`{}`) or trivial (`{x}`) SystemVerilog.
-  if (getInputs().size() < 2)
-    return emitError("sv.concat_str requires at least two operands");
+  // Concatenation of zero operands would emit invalid (`{}`) SystemVerilog.
+  if (getInputs().empty())
+    return emitError("sv.concat_str requires at least one operand");
   return success();
+}
+
+OpFoldResult ConcatStrOp::fold(FoldAdaptor) {
+  if (getInputs().size() == 1)
+    return getInputs().front();
+  return {};
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1950,6 +1950,17 @@ hw.module @sformatf(in %a: i1, out o: i1) {
   hw.output %1 : i1
 }
 
+// CHECK-LABEL: module concat_str
+hw.module @concat_str(out o: i1) {
+  %foo = sv.constantStr "foo"
+  %bar = sv.constantStr "bar"
+  %baz = sv.constantStr "baz"
+  %cat = sv.concat_str (%foo, %bar, %baz) : !hw.string
+  // CHECK: assign o = $test$plusargs({"foo", "bar", "baz"})
+  %0 = sv.system "test$plusargs"(%cat) : (!hw.string) -> i1
+  hw.output %0 : i1
+}
+
 hw.module @bindInMod() {
   sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst>
   sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst3>

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -527,3 +527,14 @@ hw.module @test_generate_for() {
   }
   hw.output
 }
+
+// CHECK-LABEL: hw.module @test_concat_str
+hw.module @test_concat_str(out o : !hw.string) {
+  // CHECK: sv.constantStr "foo"
+  // CHECK: sv.constantStr "bar"
+  // CHECK: sv.concat_str({{[^)]*}}) : !hw.string
+  %a = sv.constantStr "foo"
+  %b = sv.constantStr "bar"
+  %c = sv.concat_str (%a, %b) : !hw.string
+  hw.output %c : !hw.string
+}

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -156,6 +156,16 @@ hw.module @svAttrPreventsCanonicalization(in %arg0: i1) {
   sv.assign %0, %arg0 {sv.attributes = [#sv.attribute<"attr">]} : i1
 }
 
+// CHECK-LABEL: hw.module @concat_str_single_operand
+hw.module @concat_str_single_operand(out o: !hw.string) {
+  // CHECK: %[[STR:.*]] = sv.constantStr "foo"
+  // CHECK-NOT: sv.concat_str
+  // CHECK: hw.output %[[STR]] : !hw.string
+  %0 = sv.constantStr "foo"
+  %1 = sv.concat_str (%0) : !hw.string
+  hw.output %1 : !hw.string
+}
+
 // CHECK-LABEL: @case_stmt
 hw.module @case_stmt(in %arg: i3) {
   %fd = hw.constant 0x80000002 : i32

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -374,18 +374,8 @@ hw.module @InvalidVerbatimExpr(out out: i32) {
 
 // -----
 
-hw.module @ConcatStrOneOperand(out o: i1) {
-  %foo = sv.constantStr "foo"
-  // expected-error @+1 {{sv.concat_str requires at least two operands}}
-  %cat = sv.concat_str (%foo) : !hw.string
-  %0 = sv.system "test$plusargs"(%cat) : (!hw.string) -> i1
-  hw.output %0 : i1
-}
-
-// -----
-
 hw.module @ConcatStrNoOperands(out o: i1) {
-  // expected-error @+1 {{sv.concat_str requires at least two operands}}
+  // expected-error @+1 {{sv.concat_str requires at least one operand}}
   %cat = sv.concat_str () : !hw.string
   %0 = sv.system "test$plusargs"(%cat) : (!hw.string) -> i1
   hw.output %0 : i1

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -371,3 +371,22 @@ hw.module @InvalidVerbatimExpr(out out: i32) {
   %0 = sv.verbatim.expr "MACRO" : () -> i32 {symbols=[@Foo]}
   hw.output %0 : i32
 }
+
+// -----
+
+hw.module @ConcatStrOneOperand(out o: i1) {
+  %foo = sv.constantStr "foo"
+  // expected-error @+1 {{sv.concat_str requires at least two operands}}
+  %cat = sv.concat_str (%foo) : !hw.string
+  %0 = sv.system "test$plusargs"(%cat) : (!hw.string) -> i1
+  hw.output %0 : i1
+}
+
+// -----
+
+hw.module @ConcatStrNoOperands(out o: i1) {
+  // expected-error @+1 {{sv.concat_str requires at least two operands}}
+  %cat = sv.concat_str () : !hw.string
+  %0 = sv.system "test$plusargs"(%cat) : (!hw.string) -> i1
+  hw.output %0 : i1
+}


### PR DESCRIPTION
CC #10725

Introduce the `sv.concat_str` operation so that we can use the `{a, b, ...}` syntax instead of manually concatenating the format string.