### PR TITLE
[FIRRTL] Add LTLClockedDelayIntrinsicOp in FIRRTL

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1782,6 +1782,17 @@ def LTLDelayIntrinsicOp : LTLIntrinsicOp<"delay"> {
     functional-type(operands, results)
   }];
 }
+def LTLClockedDelayIntrinsicOp : LTLIntrinsicOp<"clocked_delay"> {
+  let arguments = (ins NonConstUInt1Type:$input,
+                       EventControlAttr:$edge,
+                       ClockType:$clock,
+                       I64Attr:$delay,
+                       OptionalAttr<I64Attr>:$length);
+  let assemblyFormat = [{
+    $input `,` $edge $clock `,` $delay (`,` $length^)? attr-dict `:`
+    functional-type(operands, results)
+  }];
+}
 def LTLConcatIntrinsicOp : BinaryLTLIntrinsicOp<"concat">;
 def LTLRepeatIntrinsicOp : LTLIntrinsicOp<"repeat"> {
   let arguments = (ins NonConstUInt1Type:$input,

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -53,9 +53,9 @@ public:
             SizeOfIntrinsicOp, ClockGateIntrinsicOp, ClockInverterIntrinsicOp,
             ClockDividerIntrinsicOp, LTLAndIntrinsicOp, LTLOrIntrinsicOp,
             LTLIntersectIntrinsicOp, LTLDelayIntrinsicOp, LTLConcatIntrinsicOp,
-            LTLRepeatIntrinsicOp, LTLGoToRepeatIntrinsicOp,
-            LTLNonConsecutiveRepeatIntrinsicOp, LTLNotIntrinsicOp,
-            LTLImplicationIntrinsicOp, LTLUntilIntrinsicOp,
+            LTLClockedDelayIntrinsicOp, LTLRepeatIntrinsicOp,
+            LTLGoToRepeatIntrinsicOp, LTLNonConsecutiveRepeatIntrinsicOp,
+            LTLNotIntrinsicOp, LTLImplicationIntrinsicOp, LTLUntilIntrinsicOp,
             LTLEventuallyIntrinsicOp, LTLPastIntrinsicOp, LTLClockIntrinsicOp,
             Mux2CellIntrinsicOp, Mux4CellIntrinsicOp, HasBeenResetIntrinsicOp,
             // Miscellaneous.
@@ -182,6 +182,7 @@ public:
   HANDLE(LTLOrIntrinsicOp, Unhandled);
   HANDLE(LTLIntersectIntrinsicOp, Unhandled);
   HANDLE(LTLDelayIntrinsicOp, Unhandled);
+  HANDLE(LTLClockedDelayIntrinsicOp, Unhandled);
   HANDLE(LTLConcatIntrinsicOp, Unhandled);
   HANDLE(LTLRepeatIntrinsicOp, Unhandled);
   HANDLE(LTLGoToRepeatIntrinsicOp, Unhandled);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1961,6 +1961,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(LTLOrIntrinsicOp op);
   LogicalResult visitExpr(LTLIntersectIntrinsicOp op);
   LogicalResult visitExpr(LTLDelayIntrinsicOp op);
+  LogicalResult visitExpr(LTLClockedDelayIntrinsicOp op);
   LogicalResult visitExpr(LTLConcatIntrinsicOp op);
   LogicalResult visitExpr(LTLRepeatIntrinsicOp op);
   LogicalResult visitExpr(LTLGoToRepeatIntrinsicOp op);
@@ -4765,6 +4766,27 @@ LogicalResult FIRRTLLowering::visitExpr(LTLDelayIntrinsicOp op) {
                                         op.getDelayAttr(), op.getLengthAttr());
 }
 
+static ltl::ClockEdge firrtlToLTLClockEdge(EventControl eventControl) {
+  switch (eventControl) {
+  case EventControl::AtPosEdge:
+    return ltl::ClockEdge::Pos;
+  case EventControl::AtEdge:
+    return ltl::ClockEdge::Both;
+  case EventControl::AtNegEdge:
+    return ltl::ClockEdge::Neg;
+  }
+  llvm_unreachable("unhandled FIRRTL event control");
+}
+
+LogicalResult FIRRTLLowering::visitExpr(LTLClockedDelayIntrinsicOp op) {
+  auto edge = ltl::ClockEdgeAttr::get(builder.getContext(),
+                                      firrtlToLTLClockEdge(op.getEdge()));
+  return setLoweringToLTL<ltl::ClockedDelayOp>(
+      op, getLoweredValue(op.getInput()), edge,
+      getLoweredNonClockValue(op.getClock()), op.getDelayAttr(),
+      op.getLengthAttr());
+}
+
 LogicalResult FIRRTLLowering::visitExpr(LTLConcatIntrinsicOp op) {
   return setLoweringToLTL<ltl::ConcatOp>(
       op,
@@ -4811,18 +4833,6 @@ LogicalResult FIRRTLLowering::visitExpr(LTLPastIntrinsicOp op) {
   Value clk = getLoweredNonClockValue(op.getClock());
   return setLoweringToLTL<ltl::PastOp>(op, getLoweredValue(op.getInput()),
                                        op.getDelayAttr(), clk);
-}
-
-static ltl::ClockEdge firrtlToLTLClockEdge(EventControl eventControl) {
-  switch (eventControl) {
-  case EventControl::AtPosEdge:
-    return ltl::ClockEdge::Pos;
-  case EventControl::AtEdge:
-    return ltl::ClockEdge::Both;
-  case EventControl::AtNegEdge:
-    return ltl::ClockEdge::Neg;
-  }
-  llvm_unreachable("unknown event control");
 }
 
 LogicalResult FIRRTLLowering::visitExpr(LTLClockIntrinsicOp op) {

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -351,6 +351,20 @@ public:
   }
 };
 
+static FailureOr<EventControl> parseLTLEdgeParam(GenericIntrinsic gi) {
+  auto edgeAttr = gi.getParamValue<StringAttr>("edge");
+  if (!edgeAttr)
+    return EventControl::AtPosEdge;
+
+  auto edge = symbolizeEventControl(edgeAttr.getValue());
+  if (!edge) {
+    gi.emitError() << " has invalid edge parameter '" << edgeAttr.getValue()
+                   << "', expected one of [posedge, negedge, edge]";
+    return failure();
+  }
+  return *edge;
+}
+
 class CirctLTLDelayConverter : public IntrinsicConverter {
 public:
   using IntrinsicConverter::IntrinsicConverter;
@@ -372,6 +386,43 @@ public:
     auto length = getI64Attr(gi.getParamValue<IntegerAttr>("length"));
     rewriter.replaceOpWithNewOp<LTLDelayIntrinsicOp>(
         gi.op, gi.op.getResultTypes(), adaptor.getOperands()[0], delay, length);
+  }
+};
+
+class CirctLTLClockedDelayConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check(GenericIntrinsic gi) override {
+    return gi.hasNInputs(2) || gi.sizedInput<UIntType>(0, 1) ||
+           gi.typedInput<ClockType>(1) || gi.sizedOutput<UIntType>(1) ||
+           gi.namedIntParam("delay") || gi.namedIntParam("length", true) ||
+           gi.namedParam("edge") || gi.hasNParam(2, 1);
+  }
+
+  LogicalResult checkAndConvert(GenericIntrinsic gi,
+                                GenericIntrinsicOpAdaptor adaptor,
+                                PatternRewriter &rewriter) override {
+    if (check(gi))
+      return failure();
+
+    auto edge = parseLTLEdgeParam(gi);
+    if (failed(edge))
+      return failure();
+
+    auto getI64Attr = [&](IntegerAttr val) {
+      if (!val)
+        return IntegerAttr();
+      return rewriter.getI64IntegerAttr(val.getValue().getZExtValue());
+    };
+    auto operands = adaptor.getOperands();
+    auto delay = getI64Attr(gi.getParamValue<IntegerAttr>("delay"));
+    auto length = getI64Attr(gi.getParamValue<IntegerAttr>("length"));
+    rewriter.replaceOpWithNewOp<LTLClockedDelayIntrinsicOp>(
+        gi.op, gi.op.getResultTypes(), operands[0],
+        EventControlAttr::get(rewriter.getContext(), *edge), operands[1], delay,
+        length);
+    return success();
   }
 };
 
@@ -434,20 +485,14 @@ public:
     if (check(gi))
       return failure();
 
-    auto edge = EventControl::AtPosEdge;
-    if (auto edgeAttr = gi.getParamValue<StringAttr>("edge")) {
-      auto parsedEdge = symbolizeEventControl(edgeAttr.getValue());
-      if (!parsedEdge)
-        return gi.emitError()
-               << " has invalid edge parameter '" << edgeAttr.getValue()
-               << "', expected one of [posedge, negedge, edge]";
-      edge = *parsedEdge;
-    }
+    auto edge = parseLTLEdgeParam(gi);
+    if (failed(edge))
+      return failure();
 
     auto operands = adaptor.getOperands();
     rewriter.replaceOpWithNewOp<LTLClockIntrinsicOp>(
         gi.op, gi.op.getResultTypes(), operands[0],
-        EventControlAttr::get(rewriter.getContext(), edge), operands[1]);
+        EventControlAttr::get(rewriter.getContext(), *edge), operands[1]);
     return success();
   }
 };

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -183,6 +183,30 @@ def CirctLTLDelay : FIRRTLIntrinsic {
   }];
 }
 
+def CirctLTLClockedDelay : FIRRTLIntrinsic {
+  let mnemonic = "circt.ltl.clocked_delay";
+  let description = [{
+    Delays the occurrence of a boolean or sequence by a specified number of
+    cycles on an explicit clock and edge, with an optional bound on the length
+    of the delay.
+
+    | Parameter | Type   | Description                               |
+    | --------- | ------ | ----------------------------------------- |
+    | delay     | int    | minimum number of cycles to delay         |
+    | edge      | string | `posedge`, `negedge`, or `edge`           |
+    | length    | int    | maximum additional delay cycles; optional |
+
+    | Argument | Type    | Description               |
+    | -------- | ------- | ------------------------- |
+    | in       | UInt<1> | input boolean or sequence |
+    | clock    | Clock   | clock for delay           |
+
+    | Result | Type    | Description             |
+    | ------ | ------- | ----------------------- |
+    | out    | UInt<1> | clocked delay sequence  |
+  }];
+}
+
 def CirctLTLRepeat : FIRRTLIntrinsic {
   let mnemonic = "circt.ltl.repeat";
   let description = [{

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -66,6 +66,12 @@ firrtl.circuit "Intrinsics" {
     %d0 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK-NEXT: [[D1:%.+]] = ltl.delay %b, 42, 1337 : i1
     %d1 = firrtl.int.ltl.delay %b, 42, 1337 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: [[CD0:%.+]] = ltl.clocked_delay %a, posedge [[CLK]], 1, 1 : i1
+    %cd0 = firrtl.int.ltl.clocked_delay %a, posedge %clk, 1, 1 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+    // CHECK-NEXT: [[CD0:%.+]] = ltl.clocked_delay %a, negedge [[CLK]], 2, 0 : i1
+    %cd1 = firrtl.int.ltl.clocked_delay %a, negedge %clk, 2, 0 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+    // CHECK-NEXT: [[CD1:%.+]] = ltl.clocked_delay %b, edge [[CLK]], 3 : i1
+    %cd2 = firrtl.int.ltl.clocked_delay %b, edge %clk, 3 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
 
     // CHECK-NEXT: [[L0:%.+]] = ltl.and [[D0]], [[D1]] : !ltl.sequence, !ltl.sequence
     %l0 = firrtl.int.ltl.and %d0, %d1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
@@ -42,6 +42,26 @@ firrtl.circuit "InvalidLTLClockEdge" {
 
 // -----
 
+firrtl.circuit "InvalidLTLEdge" {
+  firrtl.module @InvalidLTLEdge(in %in: !firrtl.uint<1>, in %clk: !firrtl.clock) {
+    // expected-error @below {{circt_ltl_clocked_delay has invalid edge parameter 'foo', expected one of [posedge, negedge, edge]}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_ltl_clocked_delay" <delay: i64 = 1, edge: none = "foo"> %in, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "MissingLTLEdge" {
+  firrtl.module @MissingLTLEdge(in %in: !firrtl.uint<1>, in %clk: !firrtl.clock) {
+    // expected-error @below {{circt_ltl_clocked_delay is missing parameter edge}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_ltl_clocked_delay" <delay: i64 = 1> %in, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  }
+}
+
+// -----
+
 firrtl.circuit "ViewNotBundle" {
   firrtl.module public @ViewNotBundle() {
     // expected-error @below {{'info' must be augmented bundle}}

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -56,6 +56,11 @@ firrtl.circuit "Foo" {
     firrtl.int.generic "circt_ltl_delay" <delay: i64 = 42> %in0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK-NEXT: firrtl.int.ltl.delay %in0, 42, 1337 :
     firrtl.int.generic "circt_ltl_delay" <delay: i64 = 42, length: i64 = 1337> %in0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    
+    // CHECK-NEXT: firrtl.int.ltl.clocked_delay %in0, posedge %clk, 42 :
+    firrtl.int.generic "circt_ltl_clocked_delay" <delay: i64 = 42, edge: none = "posedge"> %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.int.ltl.clocked_delay %in0, negedge %clk, 42, 1337 :
+    firrtl.int.generic "circt_ltl_clocked_delay" <delay: i64 = 42, length: i64 = 1337, edge: none = "negedge"> %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
 
     // CHECK-NEXT: firrtl.int.ltl.repeat %in0, 42 :
     firrtl.int.generic "circt_ltl_repeat" <base: i64 = 42> %in0 : (!firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/firtool/verif-clock-edge.fir
+++ b/test/firtool/verif-clock-edge.fir
@@ -1,0 +1,15 @@
+; RUN: firtool %s | FileCheck %s
+FIRRTL version 4.0.0
+
+circuit Foo:
+  public module Foo:
+    input clock: Clock
+    input a: UInt<1>
+    input b: UInt<1>
+
+    node delay = intrinsic(circt_ltl_clocked_delay<delay=2, length=0, edge="negedge"> : UInt<1>, b, clock)
+    node prop = intrinsic(circt_ltl_implication : UInt<1>, a, delay)
+    node clocked = intrinsic(circt_ltl_clock : UInt<1>, prop, clock)
+
+    ; CHECK: assert property (@(posedge clock) a |-> (@(negedge clock) ##2 b));
+    intrinsic(circt_verif_assert, clocked)


### PR DESCRIPTION
Align to the new `ltl.clocked_delay` op which added in the #10415 and the following pr

Assisted-by: Codex:gpt-5.5