### PR TITLE
[ExportVerilog] Fix enum case labels for anonymous enumerations

### DIFF
--- a/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
@@ -161,16 +161,47 @@ struct LegalizeAnonEnums
     return {};
   };
 
+  /// Recursively update EnumFieldAttrs nested in attributes, replacing any
+  /// anonymous enum type on the field with its typedecl alias.
+  Attribute processAttribute(Attribute attr, Location loc) {
+    if (auto enumAttr = dyn_cast<EnumFieldAttr>(attr)) {
+      if (auto newType = processType(enumAttr.getType().getValue()))
+        return EnumFieldAttr::get(loc, enumAttr.getField(), newType);
+      return attr;
+    }
+
+    if (auto arrayAttr = dyn_cast<ArrayAttr>(attr)) {
+      bool changed = false;
+      SmallVector<Attribute> newElts;
+      for (auto elt : arrayAttr) {
+        auto newElt = processAttribute(elt, loc);
+        if (newElt != elt)
+          changed = true;
+        newElts.push_back(newElt);
+      }
+      if (changed)
+        return ArrayAttr::get(arrayAttr.getContext(), newElts);
+    }
+
+    return attr;
+  }
+
   void runOnOperation() override {
     enumCount = 0;
     typeScope = {};
 
     // Perform the actual walk looking for anonymous enumeration types.
     getOperation().walk([&](Operation *op) {
+      // Legalize EnumFieldAttrs in operation attributes (e.g. sv.case
+      // casePatterns).
+      for (auto namedAttr : op->getAttrs()) {
+        auto newAttr = processAttribute(namedAttr.getValue(), op->getLoc());
+        if (newAttr != namedAttr.getValue())
+          op->setAttr(namedAttr.getName(), newAttr);
+      }
+
       // If this is a constant operation, make sure to update the constant
       // to reference the typedef, otherwise we will emit the wrong constant.
-      // Theoretically we should be searching all attributes on every operation
-      // for EnumFieldAttrs.
       if (auto enumConst = dyn_cast<EnumConstantOp>(op)) {
         auto fieldAttr = enumConst.getField();
         if (auto newType = processType(fieldAttr.getType().getValue()))

--- a/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
@@ -13,6 +13,7 @@
 
 #include "ExportVerilogInternals.h"
 #include "circt/Conversion/ExportVerilog.h"
+#include "mlir/IR/AttrTypeSubElements.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseSet.h"
@@ -161,44 +162,26 @@ struct LegalizeAnonEnums
     return {};
   };
 
-  /// Recursively update EnumFieldAttrs nested in attributes, replacing any
-  /// anonymous enum type on the field with its typedecl alias.
-  Attribute processAttribute(Attribute attr, Location loc) {
-    if (auto enumAttr = dyn_cast<EnumFieldAttr>(attr)) {
-      if (auto newType = processType(enumAttr.getType().getValue()))
-        return EnumFieldAttr::get(loc, enumAttr.getField(), newType);
-      return attr;
-    }
-
-    if (auto arrayAttr = dyn_cast<ArrayAttr>(attr)) {
-      bool changed = false;
-      SmallVector<Attribute> newElts;
-      for (auto elt : arrayAttr) {
-        auto newElt = processAttribute(elt, loc);
-        if (newElt != elt)
-          changed = true;
-        newElts.push_back(newElt);
-      }
-      if (changed)
-        return ArrayAttr::get(arrayAttr.getContext(), newElts);
-    }
-
-    return attr;
-  }
-
   void runOnOperation() override {
     enumCount = 0;
     typeScope = {};
+
+    // Use an attribute/type replacer to replace EnumFieldAttrs with the
+    // processed type.
+    mlir::AttrTypeReplacer replacer;
+    replacer.addReplacement([&](EnumFieldAttr enumAttr) -> Attribute {
+      if (auto newType = processType(enumAttr.getType().getValue()))
+        return EnumFieldAttr::get(UnknownLoc::get(enumAttr.getContext()),
+                                  enumAttr.getField(), newType);
+      return enumAttr;
+    });
 
     // Perform the actual walk looking for anonymous enumeration types.
     getOperation().walk([&](Operation *op) {
       // Legalize EnumFieldAttrs in operation attributes (e.g. sv.case
       // casePatterns).
-      for (auto namedAttr : op->getAttrs()) {
-        auto newAttr = processAttribute(namedAttr.getValue(), op->getLoc());
-        if (newAttr != namedAttr.getValue())
-          op->setAttr(namedAttr.getName(), newAttr);
-      }
+      op->setAttrs(
+          cast<DictionaryAttr>(replacer.replace(op->getAttrDictionary())));
 
       // If this is a constant operation, make sure to update the constant
       // to reference the typedef, otherwise we will emit the wrong constant.

--- a/test/Conversion/ExportVerilog/hw-enums.mlir
+++ b/test/Conversion/ExportVerilog/hw-enums.mlir
@@ -47,7 +47,7 @@ hw.module @EnumCmp(in %test: !hw.enum<A, B>, out result: i1) {
 // OLD:   _state2     reg_state2;
 // CHECK:   always @(posedge clock) begin
 // CHECK:     case (reg_0)
-// CHECK:       A:
+// CHECK:       enum0_A:
 // CHECK:         reg_0 <= enum0_B;
 // CHECK:       default:
 // CHECK:         reg_0 <= enum0_A;


### PR DESCRIPTION
When legalizing anonymous enums to typedefs, EnumFieldAttrs embedded in operation attributes (e.g. sv.case patterns) were left pointing at the raw enum type. ExportVerilog then emitted bare field names like "A" instead of the typedef enumerator names like "enum0_A", which do not match the generated enum declaration.

https://github.com/llvm/circt/blob/2bdafe153dce6854e01e1176bbe707c3fe1bc7b0/test/Conversion/ExportVerilog/hw-enums.mlir#L35-L38 https://github.com/llvm/circt/blob/2bdafe153dce6854e01e1176bbe707c3fe1bc7b0/test/Conversion/ExportVerilog/hw-enums.mlir#L48-L55

This PR update LegalizeAnonEnums to recursively legalize EnumFieldAttrs nested in operation attributes, replacing any anonymous enum type on the field with its typedecl alias, so case labels use the same prefixed enumerator names as constants and typedefs.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
