### PR TITLE
[Arc] Add LowerProcesses pass

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -172,6 +172,21 @@ def LowerClocksToFuncs : Pass<"arc-lower-clocks-to-funcs", "mlir::ModuleOp"> {
   let dependentDialects = ["mlir::func::FuncDialect", "mlir::scf::SCFDialect"];
 }
 
+def LowerProcessesPass : Pass<"arc-lower-processes", "mlir::ModuleOp"> {
+  let summary = "Outline and instantiate LLHD processes as coroutines";
+  let description = [{
+    Convert each `llhd.process` op into an `arc.coroutine.define` outside of the
+    module, plus an `arc.coroutine.instance` inside the module where the process
+    used to be.
+  }];
+  let dependentDialects = [
+    "arc::ArcDialect",
+    "comb::CombDialect",
+    "hw::HWDialect",
+    "llhd::LLHDDialect",
+  ];
+}
+
 def LowerCoroutinesPass : Pass<"arc-lower-coroutines", "mlir::ModuleOp"> {
   let summary = "Lower coroutines to state machine functions";
   let description = [{

--- a/integration_test/arcilator/JIT/llhd-process.mlir
+++ b/integration_test/arcilator/JIT/llhd-process.mlir
@@ -1,0 +1,39 @@
+// RUN: arcilator --run %s --jit-entry=Foo_main --jit-vcd-file=%t
+// RUN: FileCheck %s --check-prefix=VCD --input-file=%t
+// REQUIRES: arcilator-jit
+
+// End-to-end test for the `arc-lower-processes` pass. The process yields
+// `1`, waits 42ns, yields the value of `%a`, waits 11ns, then halts with
+// `2`. `%a` is produced by a call to a trivial function that returns a fixed
+// constant, so the auto-generated driver can drive the simulation without
+// any external input.
+
+func.func @get_a() -> i32 {
+  %c = hw.constant 99 : i32
+  return %c : i32
+}
+
+hw.module @Foo(out x: i32) {
+  %a = func.call @get_a() : () -> i32
+  %c1_i32 = hw.constant 1 : i32
+  %c2_i32 = hw.constant 2 : i32
+  %0 = llhd.constant_time <42000000fs, 0d, 0e>
+  %1 = llhd.constant_time <11000000fs, 0d, 0e>
+  %2 = llhd.process -> i32 {
+    llhd.wait yield (%c1_i32 : i32), delay %0, ^bb1
+  ^bb1:
+    llhd.wait yield (%a : i32), delay %1, ^bb2
+  ^bb2:
+    llhd.halt %c2_i32 : i32
+  }
+  hw.output %2 : i32
+}
+
+// VCD:      $scope module Foo $end
+// VCD:       $var wire 32 [[X_ID:[^ ]+]] x $end
+// VCD:      #0
+// VCD:       b{{0*}}1 [[X_ID]]
+// VCD:      #42000000
+// VCD:       b{{0*}}1100011 [[X_ID]]
+// VCD:      #53000000
+// VCD:       b{{0*}}10 [[X_ID]]

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   LowerClocksToFuncs.cpp
   LowerCoroutines.cpp
   LowerLUT.cpp
+  LowerProcesses.cpp
   LowerState.cpp
   LowerVectorizations.cpp
   LowerVerifSimulations.cpp

--- a/lib/Dialect/Arc/Transforms/LowerProcesses.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerProcesses.cpp
@@ -1,0 +1,463 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Lower `llhd.process` ops into `arc.coroutine.define` and
+// `arc.coroutine.instance` pairs so the rest of the arcilator pipeline can
+// schedule them like any other coroutine.
+//
+// For each process, the lowering:
+//
+// - Captures values defined outside the body that are referenced inside.
+//   Constant-like ops are cloned into the body; all other values are threaded
+//   as coroutine arguments.
+//
+// - Lifts the body into a new top-level `arc.coroutine.define` whose function
+//   type appends an `i64` "now" argument after the captures and an `i64`
+//   wakeup time result after the process results. The entry block and every
+//   block targeted by an `llhd.wait` receive the coroutine's argument types
+//   as leading block arguments, and a per-value SSA renaming pass threads
+//   each coroutine argument through the CFG so uses see the value bound on
+//   the most recent re-entry.
+//
+// - Rewrites each `llhd.wait` into an `arc.coroutine.yield` whose final yield
+//   operand is `now + delay` (with the delay converted to `i64` via
+//   `llhd.time_to_int`, leaving the time unit opaque to this pass). Each
+//   `llhd.halt` becomes an `arc.coroutine.halt` whose wakeup is the
+//   unit-independent sentinel `-1`.
+//
+// - Replaces the original process with an `arc.coroutine.instance` that
+//   reads the current simulation time and forwards the captured values.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/LLHD/LLHDOps.h"
+#include "mlir/Analysis/Liveness.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/Support/GenericIteratedDominanceFrontier.h"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_LOWERPROCESSESPASS
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace circt;
+using namespace arc;
+using namespace mlir;
+using llvm::SmallDenseSet;
+
+namespace {
+
+/// Worker that lowers a single `llhd.process` op.
+struct ProcessLowering {
+  ProcessLowering(llhd::ProcessOp processOp, SymbolTable &symbolTable)
+      : processOp(processOp), symbolTable(symbolTable) {}
+
+  LogicalResult run();
+
+private:
+  void collectCaptures();
+  void createCoroutine();
+  void addEntryAndResumeBlockArguments();
+  LogicalResult rewriteTerminators();
+  void renameCoroutineArgument(unsigned argIdx, Liveness &liveness,
+                               DominanceInfo &dominance);
+  void buildInstance();
+
+  llhd::ProcessOp processOp;
+  SymbolTable &symbolTable;
+
+  /// The coroutine created for this process. Populated by `createCoroutine`.
+  CoroutineDefineOp coroOp;
+
+  /// External SSA values referenced inside the body that need to be threaded
+  /// as coroutine arguments.
+  SmallVector<Value> captures;
+
+  /// Block arguments of the coroutine entry block, in order: indices `0..N-1`
+  /// mirror `captures`, and the final index holds `%now`.
+  SmallVector<Value> entryArgs;
+
+  /// Blocks targeted by an `llhd.wait`. Each receives a copy of the
+  /// coroutine's argument-type prefix as its leading block arguments. (The
+  /// entry block cannot appear here: MLIR entry blocks have no predecessors.)
+  SetVector<Block *> resumeBlocks;
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+void ProcessLowering::collectCaptures() {
+  auto &body = processOp.getBody();
+  auto builder = OpBuilder::atBlockBegin(&body.front());
+  SmallDenseSet<Value> captureSet;
+  DenseMap<Operation *, Operation *> clonedConstants;
+  body.walk([&](Operation *op) {
+    for (auto &operand : op->getOpOperands()) {
+      auto value = operand.get();
+
+      // Skip values defined inside the body.
+      if (body.isAncestor(value.getParentRegion()))
+        continue;
+
+      // Remap references to outside-defined constants to clones of the
+      // constants in the entry block.
+      auto result = dyn_cast<OpResult>(value);
+      if (result && result.getOwner()->hasTrait<OpTrait::ConstantLike>()) {
+        auto *&cloned = clonedConstants[result.getOwner()];
+        if (!cloned)
+          cloned = builder.clone(*result.getOwner());
+        operand.set(cloned->getResult(result.getResultNumber()));
+        continue;
+      }
+
+      // Otherwise this is an outside-defined SSA value we need to capture as an
+      // argument of the coroutine.
+      if (captureSet.insert(value).second)
+        captures.push_back(value);
+    }
+  });
+}
+
+void ProcessLowering::createCoroutine() {
+  // Find the parent module and use it as the insertion anchor.
+  auto hwModule = processOp->getParentOfType<hw::HWModuleOp>();
+  assert(hwModule);
+  OpBuilder builder(hwModule);
+
+  // Build the function type: (captureTypes..., i64) -> (procResults..., i64).
+  auto i64Type = builder.getIntegerType(64);
+  SmallVector<Type> argTypes;
+  for (auto cap : captures)
+    argTypes.push_back(cap.getType());
+  argTypes.push_back(i64Type);
+  SmallVector<Type> resultTypes(processOp.getResultTypes());
+  resultTypes.push_back(i64Type);
+  auto funcType = builder.getFunctionType(argTypes, resultTypes);
+
+  // Pick a symbol name based on the parent hw.module's name. Insertion into
+  // the symbol table uniquifies the name.
+  auto funcName =
+      builder.getStringAttr(hwModule.getSymName() + ".llhd.process");
+  coroOp = CoroutineDefineOp::create(builder, processOp.getLoc(), funcName,
+                                     funcType);
+  symbolTable.insert(coroOp);
+
+  // Move the process body wholesale into the coroutine. Block arguments are
+  // added in a separate step.
+  coroOp.getBody().takeBody(processOp.getBody());
+}
+
+/// Prepend the coroutine function-type prefix as leading block arguments to
+/// the entry block and to every block targeted by an `llhd.wait`. After this
+/// step the resume blocks satisfy `arc.coroutine.yield`'s contract (its
+/// destination's first `N` arguments must match the coroutine's function
+/// type) and the entry block's first `N` arguments become the SSA values
+/// that the per-argument SSA renaming step will thread through the CFG.
+///
+/// Predecessor branches of resume blocks that are not `llhd.wait`s (e.g.,
+/// `cf.br` from inside the body looping back to a wait target) have their
+/// successor operands extended with placeholder values — the entry block
+/// arguments themselves — at positions 0..N-1, so that the operand count
+/// keeps matching the resume block's new argument count. The SSA renaming
+/// step run afterwards walks the body and rewrites these references to the
+/// correct reaching definition for the source block.
+///
+/// Uses of the original outside captures inside the body are also rewritten
+/// to the entry block's new capture arguments here, so by the time renaming
+/// runs every reference is to an internal SSA value defined at the entry.
+void ProcessLowering::addEntryAndResumeBlockArguments() {
+  auto &body = coroOp.getBody();
+  auto loc = processOp.getLoc();
+
+  // Assemble the initial resume block argument types that will be provided by
+  // callers entering or re-entering the coroutine.
+  SmallVector<Type> prefixTypes;
+  for (auto capture : captures)
+    prefixTypes.push_back(capture.getType());
+  prefixTypes.push_back(IntegerType::get(coroOp.getContext(), 64));
+
+  // Add arguments to the entry block.
+  auto &entry = body.front();
+  for (auto [index, type] : llvm::enumerate(prefixTypes))
+    entryArgs.push_back(entry.insertArgument(index, type, loc));
+
+  // Collect the resume blocks, which are targets of `llhd.wait` ops.
+  for (auto &block : body)
+    if (auto wait = dyn_cast<llhd::WaitOp>(block.getTerminator()))
+      resumeBlocks.insert(wait.getDest());
+
+  // Pre-add prefix args to each resume block, then extend non-wait predecessor
+  // branches with placeholder operands so the destination operand counts keep
+  // matching.
+  auto prefixSize = prefixTypes.size();
+  for (auto *resumeBlock : resumeBlocks) {
+    for (auto [index, type] : llvm::enumerate(prefixTypes))
+      resumeBlock->insertArgument(index, type, loc);
+
+    // Fix non-wait predecessors. The wait predecessors will become
+    // `arc.coroutine.yield`s in the next step; the yield's
+    // `getSuccessorOperands` treats the prefix as produced (not forwarded) so
+    // its operand count already matches.
+    for (auto *pred : resumeBlock->getPredecessors()) {
+      auto *term = pred->getTerminator();
+      if (isa<llhd::WaitOp>(term))
+        continue;
+      auto branchOp = cast<BranchOpInterface>(term);
+      for (unsigned succIdx = 0, succNum = term->getNumSuccessors();
+           succIdx < succNum; ++succIdx) {
+        if (term->getSuccessor(succIdx) != resumeBlock)
+          continue;
+        auto succOperands = branchOp.getSuccessorOperands(succIdx);
+        SmallVector<Value> newOperands(entryArgs.begin(),
+                                       entryArgs.begin() + prefixSize);
+        for (auto v : succOperands.getForwardedOperands())
+          newOperands.push_back(v);
+        succOperands.getMutableForwardedOperands().assign(newOperands);
+      }
+    }
+  }
+
+  // Replace in-body uses of the original outside captures with the entry
+  // block's new arguments. The per-argument SSA renaming step then refines
+  // these uses to the right reaching definitions, since each resume block
+  // provides its own set of resume arguments, and multiple resume blocks may
+  // converge on a single block.
+  for (auto [capture, entryArg] : llvm::zip(captures, entryArgs))
+    capture.replaceUsesWithIf(entryArg, [&](OpOperand &use) {
+      return body.isAncestor(use.getOwner()->getParentRegion());
+    });
+}
+
+/// Convert `llhd.wait`/`llhd.halt` terminators to their `arc.coroutine`
+/// equivalents. The wakeup operand is computed against the entry block's
+/// `%now` argument; the per-argument SSA renaming step run afterwards
+/// rewrites that reference to the correct block-local definition. `llhd.wait`
+/// ops with an `observed` clause are rejected; ops without a delay (and no
+/// observed values) can never resume and are treated as halts.
+LogicalResult ProcessLowering::rewriteTerminators() {
+  for (auto &block : coroOp.getBody()) {
+    auto *term = block.getTerminator();
+    auto loc = term->getLoc();
+    OpBuilder builder(term);
+
+    // Handle `llhd.wait` ops.
+    if (auto wait = dyn_cast<llhd::WaitOp>(term)) {
+      // Reject observed values for now.
+      if (!wait.getObserved().empty())
+        return wait.emitOpError(
+            "observed-value clauses are not supported by arc-lower-processes");
+
+      // Wait ops without delay and observed values can never resume. Treat them
+      // as a halt.
+      if (!wait.getDelay()) {
+        auto never =
+            hw::ConstantOp::create(builder, loc, APInt::getAllOnes(64));
+        SmallVector<Value> yieldOperands(wait.getYieldOperands());
+        yieldOperands.push_back(never);
+        CoroutineHaltOp::create(builder, loc, yieldOperands);
+        wait.erase();
+        continue;
+      }
+
+      auto now = entryArgs.back();
+      auto delay = llhd::TimeToIntOp::create(builder, loc, wait.getDelay());
+      auto wakeup = comb::AddOp::create(builder, loc, now, delay);
+      SmallVector<Value> yieldOperands(wait.getYieldOperands());
+      yieldOperands.push_back(wakeup);
+      CoroutineYieldOp::create(builder, loc, yieldOperands,
+                               wait.getDestOperands(), wait.getDest());
+      wait.erase();
+      continue;
+    }
+
+    // Handle `llhd.halt` ops.
+    if (auto halt = dyn_cast<llhd::HaltOp>(term)) {
+      auto never = hw::ConstantOp::create(builder, loc, APInt::getAllOnes(64));
+      SmallVector<Value> yieldOperands(halt.getYieldOperands());
+      yieldOperands.push_back(never);
+      CoroutineHaltOp::create(builder, loc, yieldOperands);
+      halt.erase();
+      continue;
+    }
+  }
+
+  return success();
+}
+
+/// SSA-rename uses of the coroutine's `argIdx`-th entry-block argument so
+/// that every use observes the reaching definition for its block.
+///
+/// The entry block's argument and the corresponding pre-added argument on
+/// each resume block are the per-block "redefinitions" of this value. Any
+/// block where two such reaching definitions converge — the iterated
+/// dominance frontier of the redefining blocks, restricted to blocks where
+/// the value is live-in — receives a fresh merge block argument and any
+/// branches reaching it gain the appropriate successor operand. Inside each
+/// block we then rewrite uses to that block's reaching definition.
+///
+/// This mirrors the capture rewriting we do in `LowerCoroutines` as part of the
+/// `captureValue` function.
+void ProcessLowering::renameCoroutineArgument(unsigned argIdx,
+                                              Liveness &liveness,
+                                              DominanceInfo &dominance) {
+  auto &body = coroOp.getBody();
+  auto entryArg = entryArgs[argIdx];
+  auto *entryBlock = &body.front();
+
+  // Defining blocks of the value: the entry block plus every resume block.
+  SmallPtrSet<Block *, 8> definingBlocks;
+  definingBlocks.insert(entryBlock);
+  for (auto *resumeBlock : resumeBlocks)
+    definingBlocks.insert(resumeBlock);
+
+  // Restrict the IDF to blocks where the value is live-in.
+  SmallPtrSet<Block *, 16> liveInBlocks;
+  for (auto &block : body)
+    if (liveness.getLiveness(&block)->isLiveIn(entryArg))
+      liveInBlocks.insert(&block);
+
+  auto &domTree = dominance.getDomTree(&body);
+  // Second template arg `false` means forward (not post-) dominance frontier.
+  llvm::IDFCalculatorBase<Block, false> idfCalculator(domTree);
+  idfCalculator.setDefiningBlocks(definingBlocks);
+  idfCalculator.setLiveInBlocks(liveInBlocks);
+  SmallVector<Block *> mergeBlocks;
+  idfCalculator.calculate(mergeBlocks);
+
+  SmallPtrSet<Block *, 16> mergeBlockSet(mergeBlocks.begin(),
+                                         mergeBlocks.end());
+
+  // Walk the dominator tree from the entry block, threading the reaching
+  // definition through each block.
+  struct WorklistItem {
+    DominanceInfoNode *domNode;
+    Value reachingDef;
+  };
+  SmallVector<WorklistItem> worklist;
+  worklist.push_back({domTree.getNode(entryBlock), entryArg});
+
+  while (!worklist.empty()) {
+    auto item = worklist.pop_back_val();
+    auto *block = item.domNode->getBlock();
+
+    if (resumeBlocks.contains(block)) {
+      item.reachingDef = block->getArgument(argIdx);
+    } else if (mergeBlockSet.contains(block)) {
+      item.reachingDef =
+          block->addArgument(entryArg.getType(), entryArg.getLoc());
+    }
+
+    // Rewrite uses in this block (including nested regions and successor
+    // operands of the terminator) to the reaching definition.
+    if (item.reachingDef != entryArg)
+      block->walk([&](Operation *nested) {
+        nested->replaceUsesOfWith(entryArg, item.reachingDef);
+      });
+
+    // For each edge leaving this block into a merge block, forward the
+    // reaching definition by appending it to the branch op's successor
+    // operands. Resume blocks are skipped even when the IDF also flags them
+    // as merge blocks: their prefix slots are filled by the runtime on the
+    // yield path and by the placeholder operands fixed up by the RAUW above
+    // on the non-yield paths, so an append would push an extra operand past
+    // the block's argument count.
+    auto *terminator = block->getTerminator();
+    if (auto branchOp = dyn_cast<BranchOpInterface>(terminator)) {
+      for (auto &blockOperand : terminator->getBlockOperands()) {
+        auto *succ = blockOperand.get();
+        if (!mergeBlockSet.contains(succ) || resumeBlocks.contains(succ))
+          continue;
+        branchOp.getSuccessorOperands(blockOperand.getOperandNumber())
+            .append(item.reachingDef);
+      }
+    }
+
+    for (auto *child : item.domNode->children())
+      worklist.push_back({child, item.reachingDef});
+  }
+}
+
+/// Create an `arc.coroutine.instance` that instantiates the outlined coroutine
+/// in place of the old `llhd.process`.
+void ProcessLowering::buildInstance() {
+  OpBuilder builder(processOp);
+  auto loc = processOp.getLoc();
+  auto now = llhd::CurrentTimeOp::create(builder, loc);
+  auto nowI64 = llhd::TimeToIntOp::create(builder, loc, now);
+
+  SmallVector<Value> args(captures.begin(), captures.end());
+  args.push_back(nowI64);
+
+  auto instanceOp = CoroutineInstanceOp::create(
+      builder, loc, processOp.getResultTypes(),
+      FlatSymbolRefAttr::get(coroOp.getSymNameAttr()), args);
+
+  processOp.replaceAllUsesWith(instanceOp.getResults());
+  processOp.erase();
+}
+
+LogicalResult ProcessLowering::run() {
+  collectCaptures();
+  createCoroutine();
+  addEntryAndResumeBlockArguments();
+  if (failed(rewriteTerminators()))
+    return failure();
+
+  // SSA-rename each coroutine entry argument through the CFG. With a single
+  // block, every use is already in the entry block and refers to the entry
+  // arg directly, so there is nothing to thread; `DominanceInfo` also asserts
+  // on single-block regions.
+  if (!coroOp.getBody().hasOneBlock()) {
+    Liveness liveness(coroOp);
+    DominanceInfo dominance(coroOp);
+    for (unsigned argIdx = 0, argNum = entryArgs.size(); argIdx != argNum;
+         ++argIdx)
+      renameCoroutineArgument(argIdx, liveness, dominance);
+  }
+
+  buildInstance();
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerProcessesPass
+    : public arc::impl::LowerProcessesPassBase<LowerProcessesPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void LowerProcessesPass::runOnOperation() {
+  auto module = getOperation();
+  auto &symbolTable = getAnalysis<SymbolTable>();
+
+  bool anyFailed = false;
+  module.walk([&](llhd::ProcessOp op) {
+    ProcessLowering lowering(op, symbolTable);
+    if (failed(lowering.run()))
+      anyFailed = true;
+  });
+  if (anyFailed)
+    signalPassFailure();
+}

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -64,6 +64,7 @@ void circt::populateArcConversionPipeline(OpPassManager &pm,
     opts.convertToHW = true;
     pm.addNestedPass<hw::HWModuleOp>(sim::createSquashSimTriggered(opts));
   }
+  pm.addPass(arc::createLowerProcessesPass());
   {
     ConvertToArcsPassOptions opts;
     opts.tapRegisters = options.observeRegisters;

--- a/test/Dialect/Arc/lower-processes-errors.mlir
+++ b/test/Dialect/Arc/lower-processes-errors.mlir
@@ -1,0 +1,24 @@
+// RUN: circt-opt --arc-lower-processes --verify-diagnostics --split-input-file %s
+
+// Observed-value clause on a wait: rejected.
+hw.module @ObservedOnly(in %clk: i1) {
+  llhd.process {
+    // expected-error @below {{observed-value clauses are not supported}}
+    llhd.wait (%clk : i1), ^bb1
+  ^bb1:
+    llhd.halt
+  }
+}
+
+// -----
+
+// Combined observed + delay: still rejected on the observed clause.
+hw.module @ObservedAndDelay(in %clk: i1) {
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  llhd.process {
+    // expected-error @below {{observed-value clauses are not supported}}
+    llhd.wait delay %t, (%clk : i1), ^bb1
+  ^bb1:
+    llhd.halt
+  }
+}

--- a/test/Dialect/Arc/lower-processes.mlir
+++ b/test/Dialect/Arc/lower-processes.mlir
@@ -1,0 +1,467 @@
+// RUN: circt-opt --arc-lower-processes %s | FileCheck %s
+
+// A process that reads an input port, suspends twice, and halts.
+
+// CHECK-LABEL: arc.coroutine.define @Foo.llhd.process
+// CHECK-SAME: ([[ENTRY_A:%.+]]: i32, [[ENTRY_NOW:%.+]]: i64) -> (i32, i64)
+// CHECK:   [[C1:%.+]] = hw.constant 1 : i32
+// CHECK:   [[T1:%.+]] = llhd.constant_time <42000000fs
+// CHECK:   [[T2:%.+]] = llhd.constant_time <11000000fs
+// CHECK:   [[C2:%.+]] = hw.constant 2 : i32
+// CHECK:   [[D1:%.+]] = llhd.time_to_int [[T1]]
+// CHECK:   [[W1:%.+]] = comb.add [[ENTRY_NOW]], [[D1]] : i64
+// CHECK:   arc.coroutine.yield ([[C1]], [[W1]] : i32, i64), ^[[BB1:.+]]
+// CHECK: ^[[BB1]]([[A1:%.+]]: i32, [[NOW1:%.+]]: i64):
+// CHECK:   [[D2:%.+]] = llhd.time_to_int [[T2]]
+// CHECK:   [[W2:%.+]] = comb.add [[NOW1]], [[D2]] : i64
+// CHECK:   arc.coroutine.yield ([[A1]], [[W2]] : i32, i64), ^[[BB2:.+]]
+// CHECK: ^[[BB2]]({{%.+}}: i32, {{%.+}}: i64):
+// CHECK:   [[NEVER:%.+]] = hw.constant -1 : i64
+// CHECK:   arc.coroutine.halt [[C2]], [[NEVER]] : i32, i64
+
+// CHECK-LABEL: hw.module @Foo
+// CHECK-SAME:    (in %a : i32, out x : i32)
+hw.module @Foo(in %a: i32, out x: i32) {
+  // CHECK: [[NOW:%.+]] = llhd.current_time
+  // CHECK: [[NOWI:%.+]] = llhd.time_to_int [[NOW]]
+  // CHECK: [[OUT:%.+]] = arc.coroutine.instance @Foo.llhd.process(%a, [[NOWI]]) : (i32, i64) -> i32
+  // CHECK: hw.output [[OUT]]
+  %c1_i32 = hw.constant 1 : i32
+  %c2_i32 = hw.constant 2 : i32
+  %0 = llhd.constant_time <42000000fs, 0d, 0e>
+  %1 = llhd.constant_time <11000000fs, 0d, 0e>
+  %2 = llhd.process -> i32 {
+    llhd.wait yield (%c1_i32 : i32), delay %0, ^bb1
+  ^bb1:
+    llhd.wait yield (%a : i32), delay %1, ^bb2
+  ^bb2:
+    llhd.halt %c2_i32 : i32
+  }
+  hw.output %2 : i32
+}
+
+//===----------------------------------------------------------------------===//
+// Process with no results: function type is `(i64) -> i64`, instance has no
+// non-wakeup results.
+
+// CHECK-LABEL: arc.coroutine.define @NoResults.llhd.process
+// CHECK-SAME: ({{%.+}}: i64) -> i64
+// CHECK:   arc.coroutine.yield ({{%.+}} : i64), ^[[BB:.+]]
+// CHECK: ^[[BB]]({{%.+}}: i64):
+// CHECK:   arc.coroutine.halt {{%.+}} : i64
+
+// CHECK-LABEL: hw.module @NoResults
+hw.module @NoResults() {
+  // CHECK: arc.coroutine.instance @NoResults.llhd.process({{%.+}}) : (i64) -> ()
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  llhd.process {
+    llhd.wait delay %t, ^bb1
+  ^bb1:
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// All values the body references are constants defined outside; they get
+// cloned in and the coroutine signature has no captures.
+
+// CHECK-LABEL: arc.coroutine.define @NoCaptures.llhd.process
+// CHECK-SAME: ({{%.+}}: i64) -> (i32, i64)
+
+// CHECK-LABEL: hw.module @NoCaptures
+hw.module @NoCaptures(out o: i32) {
+  // CHECK: [[NOWI:%.+]] = llhd.time_to_int
+  // CHECK: arc.coroutine.instance @NoCaptures.llhd.process([[NOWI]]) : (i64) -> i32
+  %c7 = hw.constant 7 : i32
+  %t = llhd.constant_time <5ns, 0d, 0e>
+  %r = llhd.process -> i32 {
+    llhd.wait yield (%c7 : i32), delay %t, ^bb1
+  ^bb1:
+    llhd.halt %c7 : i32
+  }
+  hw.output %r : i32
+}
+
+//===----------------------------------------------------------------------===//
+// Process with multiple results.
+
+// CHECK-LABEL: arc.coroutine.define @MultiResult.llhd.process
+// CHECK-SAME: ({{%.+}}: i64) -> (i32, i8, i64)
+// CHECK: arc.coroutine.yield ({{%.+}}, {{%.+}}, {{%.+}} : i32, i8, i64), ^{{.+}}
+// CHECK: arc.coroutine.halt {{%.+}}, {{%.+}}, {{%.+}} : i32, i8, i64
+
+// CHECK-LABEL: hw.module @MultiResult
+hw.module @MultiResult(out a: i32, out b: i8) {
+  // CHECK: arc.coroutine.instance @MultiResult.llhd.process({{%.+}}) : (i64) -> (i32, i8)
+  %c32 = hw.constant 9 : i32
+  %c8 = hw.constant 3 : i8
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  %x, %y = llhd.process -> i32, i8 {
+    llhd.wait yield (%c32, %c8 : i32, i8), delay %t, ^bb1
+  ^bb1:
+    llhd.halt %c32, %c8 : i32, i8
+  }
+  hw.output %x, %y : i32, i8
+}
+
+//===----------------------------------------------------------------------===//
+// Multiple non-constant captures (both module input ports) plus an outside
+// constant. Constants are cloned in; both ports are threaded as args.
+
+// CHECK-LABEL: arc.coroutine.define @MultiCapture.llhd.process
+// CHECK-SAME: ({{%.+}}: i32, {{%.+}}: i8, {{%.+}}: i64) -> (i32, i64)
+
+// CHECK-LABEL: hw.module @MultiCapture
+hw.module @MultiCapture(in %a: i32, in %b: i8, out o: i32) {
+  // CHECK: arc.coroutine.instance @MultiCapture.llhd.process(%a, %b, {{%.+}}) : (i32, i8, i64) -> i32
+  %c1 = hw.constant 1 : i32
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  %res = llhd.process -> i32 {
+    %sum = comb.concat %a, %b : i32, i8
+    llhd.wait yield (%c1 : i32), delay %t, ^bb1
+  ^bb1:
+    llhd.halt %c1 : i32
+  }
+  hw.output %res : i32
+}
+
+//===----------------------------------------------------------------------===//
+// `llhd.wait` with destOperands: the wait passes a value to the resume block
+// as a regular block argument, which lands AFTER the coroutine's function-type
+// prefix.
+
+// CHECK-LABEL: arc.coroutine.define @WaitDestOperands.llhd.process
+// CHECK-SAME: ({{%.+}}: i32, {{%.+}}: i64) -> (i32, i64)
+// CHECK: arc.coroutine.yield ({{%.+}}, {{%.+}} : i32, i64), ^[[RB:.+]]({{%.+}} : i32)
+// CHECK: ^[[RB]]({{%.+}}: i32, {{%.+}}: i64, [[X:%.+]]: i32):
+// CHECK:   arc.coroutine.halt [[X]], {{%.+}} : i32, i64
+
+// CHECK-LABEL: hw.module @WaitDestOperands
+hw.module @WaitDestOperands(in %a: i32, out o: i32) {
+  %c0 = hw.constant 0 : i32
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  %r = llhd.process -> i32 {
+    %carry = comb.add %a, %c0 : i32
+    llhd.wait yield (%c0 : i32), delay %t, ^bb1(%carry : i32)
+  ^bb1(%x: i32):
+    llhd.halt %x : i32
+  }
+  hw.output %r : i32
+}
+
+//===----------------------------------------------------------------------===//
+// A `llhd.wait` with no delay and no observed values can never resume and is
+// equivalent to an `llhd.halt`. The wait's yield operands become the halt's
+// final yield.
+
+// CHECK-LABEL: arc.coroutine.define @WaitWithoutDelay.llhd.process
+// CHECK-SAME: ({{%.+}}: i64) -> (i32, i64)
+// CHECK:   [[C:%.+]] = hw.constant 7 : i32
+// CHECK:   [[N:%.+]] = hw.constant -1 : i64
+// CHECK:   arc.coroutine.halt [[C]], [[N]] : i32, i64
+
+// CHECK-LABEL: hw.module @WaitWithoutDelay
+hw.module @WaitWithoutDelay(out o: i32) {
+  %c7 = hw.constant 7 : i32
+  %r = llhd.process -> i32 {
+    llhd.wait yield (%c7 : i32), ^bb1
+  ^bb1:
+    llhd.halt %c7 : i32
+  }
+  hw.output %r : i32
+}
+
+//===----------------------------------------------------------------------===//
+// Same `llhd.constant_time` SSA value used by both waits is cloned once into
+// the body; both waits share the cloned constant.
+
+// CHECK-LABEL: arc.coroutine.define @SameDelayReused.llhd.process
+// CHECK:       [[CT:%.+]] = llhd.constant_time
+// CHECK-NOT:   llhd.constant_time
+// CHECK:       llhd.time_to_int [[CT]]
+// CHECK:       llhd.time_to_int [[CT]]
+
+// CHECK-LABEL: hw.module @SameDelayReused
+hw.module @SameDelayReused() {
+  %t = llhd.constant_time <2ns, 0d, 0e>
+  llhd.process {
+    llhd.wait delay %t, ^bb1
+  ^bb1:
+    llhd.wait delay %t, ^bb2
+  ^bb2:
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Diamond CFG where one arm yields and the other doesn't. The join block is
+// reached from two paths with different reaching defs of the capture, so the
+// SSA renamer adds a fresh merge block argument and patches both branches.
+
+// CHECK-LABEL: arc.coroutine.define @DiamondMerge.llhd.process
+// CHECK-SAME: ([[A:%.+]]: i32, [[NOW:%.+]]: i64) -> i64
+// CHECK:       cf.cond_br {{.+}}, ^[[LEFT:.+]], ^[[RIGHT:.+]]
+// CHECK: ^[[LEFT]]:
+// CHECK:       arc.coroutine.yield ({{.+}} : i64), ^[[LRESUME:.+]]
+// CHECK: ^[[LRESUME]]([[L_A:%.+]]: i32, %{{.+}}: i64):
+// CHECK:       cf.br ^[[JOIN:.+]]([[L_A]] : i32)
+// CHECK: ^[[RIGHT]]:
+// CHECK:       cf.br ^[[JOIN]]([[A]] : i32)
+// CHECK: ^[[JOIN]]([[M_A:%.+]]: i32):
+// CHECK:       comb.add [[M_A]], {{.+}} : i32
+// CHECK:       arc.coroutine.halt {{.+}} : i64
+
+// CHECK-LABEL: hw.module @DiamondMerge
+hw.module @DiamondMerge(in %a: i32) {
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  %c0 = hw.constant 0 : i32
+  llhd.process {
+    %cond = comb.icmp eq %a, %c0 : i32
+    cf.cond_br %cond, ^left, ^right
+  ^left:
+    llhd.wait delay %t, ^left_resume
+  ^left_resume:
+    cf.br ^join
+  ^right:
+    cf.br ^join
+  ^join:
+    %x = comb.add %a, %c0 : i32
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Two parallel arms both yield, then join. Both incoming branches into the
+// merge block must forward the resume-block reaching defs.
+
+// CHECK-LABEL: arc.coroutine.define @TwoYieldsJoin.llhd.process
+// CHECK-SAME: (%{{.+}}: i32, %{{.+}}: i64) -> i64
+// CHECK:       cf.cond_br {{.+}}, ^[[LEFT:.+]], ^[[RIGHT:.+]]
+// CHECK: ^[[LEFT]]:
+// CHECK:       arc.coroutine.yield ({{.+}} : i64), ^[[LR:.+]]
+// CHECK: ^[[LR]]([[L_A:%.+]]: i32, %{{.+}}: i64):
+// CHECK:       cf.br ^[[JOIN:.+]]([[L_A]] : i32)
+// CHECK: ^[[RIGHT]]:
+// CHECK:       arc.coroutine.yield ({{.+}} : i64), ^[[RR:.+]]
+// CHECK: ^[[RR]]([[R_A:%.+]]: i32, %{{.+}}: i64):
+// CHECK:       cf.br ^[[JOIN]]([[R_A]] : i32)
+// CHECK: ^[[JOIN]]([[M_A:%.+]]: i32):
+// CHECK:       comb.add [[M_A]], {{.+}} : i32
+// CHECK:       arc.coroutine.halt {{.+}} : i64
+
+// CHECK-LABEL: hw.module @TwoYieldsJoin
+hw.module @TwoYieldsJoin(in %a: i32) {
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  %c0 = hw.constant 0 : i32
+  llhd.process {
+    %cond = comb.icmp eq %a, %c0 : i32
+    cf.cond_br %cond, ^left, ^right
+  ^left:
+    llhd.wait delay %t, ^left_resume
+  ^left_resume:
+    cf.br ^join
+  ^right:
+    llhd.wait delay %t, ^right_resume
+  ^right_resume:
+    cf.br ^join
+  ^join:
+    %x = comb.add %a, %c0 : i32
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// A long chain of single-predecessor blocks between a yield and the use of a
+// capture. The reaching definition must propagate through all of the
+// intermediate blocks via dominator inheritance, and none of them should
+// gain a merge argument.
+
+// CHECK-LABEL: arc.coroutine.define @LongChain.llhd.process
+// CHECK-SAME: (%{{.+}}: i32, %{{.+}}: i64) -> i64
+// CHECK:       arc.coroutine.yield ({{.+}} : i64), ^[[BB1:.+]]
+// CHECK: ^[[BB1]]([[R_A:%.+]]: i32, %{{.+}}: i64):
+// CHECK:       cf.br ^[[BB2:.+]]
+// CHECK: ^[[BB2]]:
+// CHECK:       cf.br ^[[BB3:.+]]
+// CHECK: ^[[BB3]]:
+// CHECK:       cf.br ^[[BB4:.+]]
+// CHECK: ^[[BB4]]:
+// CHECK:       comb.add [[R_A]], [[R_A]] : i32
+// CHECK:       arc.coroutine.halt {{.+}} : i64
+
+// CHECK-LABEL: hw.module @LongChain
+hw.module @LongChain(in %a: i32) {
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  llhd.process {
+    llhd.wait delay %t, ^bb1
+  ^bb1:
+    cf.br ^bb2
+  ^bb2:
+    cf.br ^bb3
+  ^bb3:
+    cf.br ^bb4
+  ^bb4:
+    %x = comb.add %a, %a : i32
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// A loop header that is BOTH targeted by an `llhd.wait` (making it a resume
+// block) AND reached by a `cf.br` from outside the loop. The cf.br must be
+// patched with the prefix operand positions filled in by the renamer, and
+// the yield-to-self edge must not gain an extra successor operand.
+
+// CHECK-LABEL: arc.coroutine.define @LoopHeaderResume.llhd.process
+// CHECK-SAME: ([[A:%.+]]: i32, [[NOW:%.+]]: i64) -> i64
+// CHECK:       cf.br ^[[HEADER:.+]]([[A]], [[NOW]] : i32, i64)
+// CHECK: ^[[HEADER]]([[R_A:%.+]]: i32, [[R_NOW:%.+]]: i64):
+// CHECK:       comb.add [[R_A]], [[R_A]] : i32
+// CHECK:       [[D:%.+]] = llhd.time_to_int
+// CHECK:       [[WAKE:%.+]] = comb.add [[R_NOW]], [[D]] : i64
+// CHECK:       arc.coroutine.yield ([[WAKE]] : i64), ^[[HEADER]]
+
+// CHECK-LABEL: hw.module @LoopHeaderResume
+hw.module @LoopHeaderResume(in %a: i32) {
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  llhd.process {
+    cf.br ^header
+  ^header:
+    %x = comb.add %a, %a : i32
+    llhd.wait delay %t, ^header
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Two `llhd.process` ops in the same hw.module. The symbol table uniquifies
+// the second coroutine's name.
+
+// CHECK-DAG: arc.coroutine.define @MultiProcess.llhd.process(
+// CHECK-DAG: arc.coroutine.define @MultiProcess.llhd.process_0(
+
+// CHECK-LABEL: hw.module @MultiProcess
+hw.module @MultiProcess() {
+  // CHECK: arc.coroutine.instance @MultiProcess.llhd.process(
+  // CHECK: arc.coroutine.instance @MultiProcess.llhd.process_0(
+  llhd.process {
+    llhd.halt
+  }
+  llhd.process {
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Two distinct `llhd.wait` ops targeting the same resume block. The prefix
+// args are inserted exactly once on the shared destination.
+
+// CHECK-LABEL: arc.coroutine.define @SharedResumeBlock.llhd.process
+// CHECK-SAME: ([[A:%.+]]: i32, [[NOW:%.+]]: i64) -> i64
+// CHECK:       cf.cond_br {{.+}}, ^[[LEFT:.+]], ^[[RIGHT:.+]]
+// CHECK: ^[[LEFT]]:
+// CHECK:       arc.coroutine.yield ({{.+}} : i64), ^[[SHARED:.+]]
+// CHECK: ^[[RIGHT]]:
+// CHECK:       arc.coroutine.yield ({{.+}} : i64), ^[[SHARED]]
+// CHECK: ^[[SHARED]]([[S_A:%.+]]: i32, %{{.+}}: i64):
+// CHECK:       comb.add [[S_A]], {{.+}} : i32
+// CHECK:       arc.coroutine.halt
+
+// CHECK-LABEL: hw.module @SharedResumeBlock
+hw.module @SharedResumeBlock(in %a: i32) {
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  %c0 = hw.constant 0 : i32
+  llhd.process {
+    %cond = comb.icmp eq %a, %c0 : i32
+    cf.cond_br %cond, ^left, ^right
+  ^left:
+    llhd.wait delay %t, ^shared
+  ^right:
+    llhd.wait delay %t, ^shared
+  ^shared:
+    %x = comb.add %a, %c0 : i32
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// A block that is both a resume block (targeted by `llhd.wait`) and a CFG
+// merge point reached by a non-wait predecessor. The yield edge contributes
+// no successor operands (the runtime supplies the prefix on resume); the
+// `cf.br` edge gets the placeholder operands fixed up to the in-block
+// reaching definition.
+
+// CHECK-LABEL: arc.coroutine.define @ResumeAlsoMerges.llhd.process
+// CHECK-SAME: ([[A:%.+]]: i32, [[NOW:%.+]]: i64) -> i64
+// CHECK:       cf.cond_br {{.+}}, ^[[YIELDS:.+]], ^[[DIRECT:.+]]
+// CHECK: ^[[YIELDS]]:
+// CHECK:       arc.coroutine.yield ({{.+}} : i64), ^[[SHARED:.+]]
+// CHECK: ^[[DIRECT]]:
+// CHECK:       cf.br ^[[SHARED]]([[A]], [[NOW]] : i32, i64)
+// CHECK: ^[[SHARED]]([[S_A:%.+]]: i32, %{{.+}}: i64):
+// CHECK:       comb.add [[S_A]], [[S_A]] : i32
+
+// CHECK-LABEL: hw.module @ResumeAlsoMerges
+hw.module @ResumeAlsoMerges(in %a: i32) {
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  %c0 = hw.constant 0 : i32
+  llhd.process {
+    %cond = comb.icmp eq %a, %c0 : i32
+    cf.cond_br %cond, ^yields, ^direct
+  ^yields:
+    llhd.wait delay %t, ^shared
+  ^direct:
+    cf.br ^shared
+  ^shared:
+    %x = comb.add %a, %a : i32
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// A constant defined outside the body is referenced from inside a nested
+// region (an `scf.if` body) within the process. The walk recurses into the
+// nested region, clones the constant once at the entry, and rewrites the
+// nested use to the clone.
+
+// CHECK-LABEL: arc.coroutine.define @ConstInNestedRegion.llhd.process
+// CHECK-SAME: ([[COND:%.+]]: i1, [[NOW:%.+]]: i64) -> i64
+// CHECK:   [[C5:%.+]] = hw.constant 5 : i32
+// CHECK-NOT: hw.constant 5
+// CHECK:   scf.if [[COND]]
+// CHECK:     comb.add [[C5]], [[C5]] : i32
+
+// CHECK-LABEL: hw.module @ConstInNestedRegion
+hw.module @ConstInNestedRegion(in %cond: i1) {
+  %c5 = hw.constant 5 : i32
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  llhd.process {
+    scf.if %cond {
+      %sum = comb.add %c5, %c5 : i32
+      scf.yield
+    }
+    llhd.halt
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// A `llhd.wait` with a zero-fs delay is not treated as a halt: it still emits
+// a real yield with `wake = now + 0`.
+
+// CHECK-LABEL: arc.coroutine.define @ZeroDelay.llhd.process
+// CHECK-SAME: ([[NOW:%.+]]: i64) -> i64
+// CHECK:   [[T:%.+]] = llhd.constant_time <0fs
+// CHECK:   [[D:%.+]] = llhd.time_to_int [[T]]
+// CHECK:   [[W:%.+]] = comb.add [[NOW]], [[D]] : i64
+// CHECK:   arc.coroutine.yield ([[W]] : i64), ^[[BB:.+]]
+// CHECK: ^[[BB]]({{%.+}}: i64):
+// CHECK:   arc.coroutine.halt
+
+// CHECK-LABEL: hw.module @ZeroDelay
+hw.module @ZeroDelay() {
+  %t = llhd.constant_time <0fs, 0d, 0e>
+  llhd.process {
+    llhd.wait delay %t, ^bb1
+  ^bb1:
+    llhd.halt
+  }
+}


### PR DESCRIPTION
Lower `llhd.process` ops into `arc.coroutine.define` and `arc.coroutine.instance` pairs so the rest of the arcilator pipeline can schedule them like any other coroutine.

This gives Arcilator the limited ability to simulate `llhd.process`es in a design. Currently only timed processes are supported, and observing values for changes is not. But this is a first step.

Assisted-by: Claude Opus 4.8