### PR TITLE
[FIRRTL] Add edge attribute to LTL clock intrinsic

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1832,9 +1832,10 @@ def LTLPastIntrinsicOp : LTLIntrinsicOp<"past"> {
 
 // Clocking
 def LTLClockIntrinsicOp : LTLIntrinsicOp<"clock"> {
-  let arguments = (ins NonConstUInt1Type:$input, ClockType:$clock);
+  let arguments = (ins NonConstUInt1Type:$input, EventControlAttr:$edge,
+                       ClockType:$clock);
   let assemblyFormat = [{
-    $input `,` $clock attr-dict `:` functional-type(operands, results)
+    $input `,` $edge $clock attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -4813,9 +4813,21 @@ LogicalResult FIRRTLLowering::visitExpr(LTLPastIntrinsicOp op) {
                                        op.getDelayAttr(), clk);
 }
 
+static ltl::ClockEdge firrtlToLTLClockEdge(EventControl eventControl) {
+  switch (eventControl) {
+  case EventControl::AtPosEdge:
+    return ltl::ClockEdge::Pos;
+  case EventControl::AtEdge:
+    return ltl::ClockEdge::Both;
+  case EventControl::AtNegEdge:
+    return ltl::ClockEdge::Neg;
+  }
+  llvm_unreachable("unknown event control");
+}
+
 LogicalResult FIRRTLLowering::visitExpr(LTLClockIntrinsicOp op) {
   return setLoweringToLTL<ltl::ClockOp>(op, getLoweredValue(op.getInput()),
-                                        ltl::ClockEdge::Pos,
+                                        firrtlToLTLClockEdge(op.getEdge()),
                                         getLoweredNonClockValue(op.getClock()));
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -400,15 +400,55 @@ public:
   }
 };
 
-class CirctLTLClockConverter
-    : public IntrinsicOpConverter<LTLClockIntrinsicOp> {
+class CirctLTLClockConverter : public IntrinsicConverter {
 public:
-  using IntrinsicOpConverter::IntrinsicOpConverter;
+  using IntrinsicConverter::IntrinsicConverter;
 
   bool check(GenericIntrinsic gi) override {
-    return gi.hasNInputs(2) || gi.sizedInput<UIntType>(0, 1) ||
-           gi.typedInput<ClockType>(1) || gi.sizedOutput<UIntType>(1) ||
-           gi.hasNParam(0);
+    if (gi.hasNInputs(2) || gi.sizedInput<UIntType>(0, 1) ||
+        gi.typedInput<ClockType>(1) || gi.sizedOutput<UIntType>(1) ||
+        gi.hasNParam(0, 1))
+      return true;
+
+    auto params = gi.op.getParameters();
+    if (!params || params.empty())
+      return false;
+
+    auto param = cast<ParamDeclAttr>(*params.begin());
+    if (param.getName().getValue() != "edge") {
+      gi.emitError() << " has unexpected parameter '" << param.getName()
+                     << "', expected 'edge'";
+      return true;
+    }
+    if (!isa<StringAttr>(param.getValue())) {
+      gi.emitError() << " has parameter '" << param.getName()
+                     << "' which should be a string but is not";
+      return true;
+    }
+    return false;
+  }
+
+  LogicalResult checkAndConvert(GenericIntrinsic gi,
+                                GenericIntrinsicOpAdaptor adaptor,
+                                PatternRewriter &rewriter) override {
+    if (check(gi))
+      return failure();
+
+    auto edge = EventControl::AtPosEdge;
+    if (auto edgeAttr = gi.getParamValue<StringAttr>("edge")) {
+      auto parsedEdge = symbolizeEventControl(edgeAttr.getValue());
+      if (!parsedEdge)
+        return gi.emitError()
+               << " has invalid edge parameter '" << edgeAttr.getValue()
+               << "', expected one of [posedge, negedge, edge]";
+      edge = *parsedEdge;
+    }
+
+    auto operands = adaptor.getOperands();
+    rewriter.replaceOpWithNewOp<LTLClockIntrinsicOp>(
+        gi.op, gi.op.getResultTypes(), operands[0],
+        EventControlAttr::get(rewriter.getContext(), edge), operands[1]);
+    return success();
   }
 };
 

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -274,6 +274,10 @@ def CirctLTLClock : FIRRTLIntrinsic {
     Associates a clock with a boolean or sequence. This is used to indicate the
     clock domain in which a property is evaluated.
 
+    | Parameter | Type   | Description                                  |
+    | --------- | ------ | -------------------------------------------- |
+    | edge      | string | clock edge: `posedge`, `negedge`, or `edge` |
+
     | Argument | Type    | Description               |
     | -------- | ------- | ------------------------- |
     | in       | UInt<1> | input boolean or sequence |

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -108,7 +108,9 @@ firrtl.circuit "Intrinsics" {
     %p1 = firrtl.int.ltl.past %b, 3, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
 
     // CHECK-NEXT: [[K0:%.+]] = ltl.clock [[I0]], posedge [[CLK]] : !ltl.property
-    %k0 = firrtl.int.ltl.clock %i0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+    %k0 = firrtl.int.ltl.clock %i0, posedge %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+    // CHECK-NEXT: [[K1:%.+]] = ltl.clock [[I0]], negedge [[CLK]] : !ltl.property
+    %k1 = firrtl.int.ltl.clock %i0, negedge %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
 
     // CHECK-NEXT: verif.assert %a : i1
     firrtl.int.verif.assert %a : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -688,14 +688,14 @@ firrtl.module @WhenAroundPropertyAssertAssumeCover(
   %0 = firrtl.int.ltl.implication %b, %c : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %p0 = firrtl.node interesting_name %0 : !firrtl.uint<1>
   // @(posedge clock) b |-> c
-  %1 = firrtl.int.ltl.clock %p0, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  %1 = firrtl.int.ltl.clock %p0, posedge %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
   %p1 = firrtl.node interesting_name %1 : !firrtl.uint<1>
 
   // CHECK-NOT: firrtl.when
   firrtl.when %a : !firrtl.uint<1> {
     // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and %a, %b
     // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.implication [[TMP1]], %c
-    // CHECK: [[TMP3:%.+]] = firrtl.int.ltl.clock [[TMP2]], %clock
+    // CHECK: [[TMP3:%.+]] = firrtl.int.ltl.clock [[TMP2]], posedge %clock
     // CHECK: firrtl.int.verif.assert [[TMP3]], %d :
     // CHECK: firrtl.int.verif.assert [[TMP3]] :
     // CHECK: firrtl.int.verif.assume [[TMP3]], %d :
@@ -705,7 +705,7 @@ firrtl.module @WhenAroundPropertyAssertAssumeCover(
     firrtl.int.verif.assume %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.int.verif.assume %p1 : !firrtl.uint<1>
     // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and %a, [[P0]]
-    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.clock [[TMP1]], %clock
+    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.clock [[TMP1]], posedge %clock
     // CHECK: firrtl.int.verif.cover [[TMP2]], %d :
     // CHECK: firrtl.int.verif.cover [[TMP2]] :
     firrtl.int.verif.cover %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
@@ -714,7 +714,7 @@ firrtl.module @WhenAroundPropertyAssertAssumeCover(
     // CHECK: [[NOTA:%.+]] = firrtl.not %a
     // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and [[NOTA]], %b
     // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.implication [[TMP1]], %c
-    // CHECK: [[TMP3:%.+]] = firrtl.int.ltl.clock [[TMP2]], %clock
+    // CHECK: [[TMP3:%.+]] = firrtl.int.ltl.clock [[TMP2]], posedge %clock
     // CHECK: firrtl.int.verif.assert [[TMP3]], %d :
     // CHECK: firrtl.int.verif.assert [[TMP3]] :
     // CHECK: firrtl.int.verif.assume [[TMP3]], %d :
@@ -724,7 +724,7 @@ firrtl.module @WhenAroundPropertyAssertAssumeCover(
     firrtl.int.verif.assume %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.int.verif.assume %p1 : !firrtl.uint<1>
     // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and [[NOTA]], [[P0]]
-    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.clock [[TMP1]], %clock
+    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.clock [[TMP1]], posedge %clock
     // CHECK: firrtl.int.verif.cover [[TMP2]], %d :
     // CHECK: firrtl.int.verif.cover [[TMP2]] :
     firrtl.int.verif.cover %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
@@ -805,6 +805,34 @@ firrtl.module @SiblingLayerblocksImplication() {
       %0 = firrtl.int.ltl.implication %c0_ui1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       firrtl.int.verif.assert %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     }
+  }
+}
+
+// Test that expand-whens preserves an explicit negedge on ltl.clock.
+// CHECK-LABEL: firrtl.module @WhenAroundNegedgeProperty
+firrtl.module @WhenAroundNegedgeProperty(
+  in %clock: !firrtl.clock,
+  in %a: !firrtl.uint<1>,
+  in %b: !firrtl.uint<1>,
+  in %c: !firrtl.uint<1>,
+  in %d: !firrtl.uint<1>
+) {
+  // CHECK: [[P0:%.+]] = firrtl.int.ltl.implication %b, %c :
+  %0 = firrtl.int.ltl.implication %b, %c : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %1 = firrtl.int.ltl.clock %0, negedge %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+
+  // CHECK-NOT: firrtl.when
+  firrtl.when %a : !firrtl.uint<1> {
+    // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and %a, %b
+    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.implication [[TMP1]], %c
+    // CHECK: [[TMP3:%.+]] = firrtl.int.ltl.clock [[TMP2]], negedge %clock
+    // CHECK: firrtl.int.verif.assert [[TMP3]], %d :
+    firrtl.int.verif.assert %1, %d : !firrtl.uint<1>, !firrtl.uint<1>
+
+    // CHECK: [[TMP4:%.+]] = firrtl.int.ltl.and %a, [[P0]]
+    // CHECK: [[TMP5:%.+]] = firrtl.int.ltl.clock [[TMP4]], negedge %clock
+    // CHECK: firrtl.int.verif.cover [[TMP5]] :
+    firrtl.int.verif.cover %1 : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
@@ -32,6 +32,16 @@ firrtl.circuit "MissingParam" {
 
 // -----
 
+firrtl.circuit "InvalidLTLClockEdge" {
+  firrtl.module @InvalidLTLClockEdge(in %in: !firrtl.uint<1>, in %clk: !firrtl.clock) {
+    // expected-error @below {{circt_ltl_clock has invalid edge parameter 'falling', expected one of [posedge, negedge, edge]}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_ltl_clock" <edge: none = "falling"> %in, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  }
+}
+
+// -----
+
 firrtl.circuit "ViewNotBundle" {
   firrtl.module public @ViewNotBundle() {
     // expected-error @below {{'info' must be augmented bundle}}

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -80,8 +80,14 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: firrtl.int.ltl.past %in0, 42, %clk :
     firrtl.int.generic "circt_ltl_past" <delay: i64 = 42> %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
 
-    // CHECK-NEXT: firrtl.int.ltl.clock %in0, %clk :
+    // CHECK-NEXT: firrtl.int.ltl.clock %in0, posedge %clk :
     firrtl.int.generic "circt_ltl_clock"  %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.int.ltl.clock %in0, posedge %clk :
+    firrtl.int.generic "circt_ltl_clock" <edge: none = "posedge"> %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.int.ltl.clock %in0, edge %clk :
+    firrtl.int.generic "circt_ltl_clock" <edge: none = "edge"> %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.int.ltl.clock %in0, negedge %clk :
+    firrtl.int.generic "circt_ltl_clock" <edge: none = "negedge"> %in0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
   }
 
   // CHECK-LABEL: firrtl.module @Verif(


### PR DESCRIPTION
Add edge attribute to LTL clock intrinsic in FIRRTL dialect, which should be aligned to [ltl dialect](https://circt.llvm.org/docs/Dialects/LTL/#ltlclock-circtltlclockop)

Assisted-by: Codex:gpt-5.5

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
