### PR TITLE
[Python] Fix ModuleLike.is_external for ops with no region

### DIFF
--- a/integration_test/Bindings/Python/dialects/sv_verbatim.py
+++ b/integration_test/Bindings/Python/dialects/sv_verbatim.py
@@ -84,5 +84,13 @@ with ir.Context() as ctx, ir.Location.unknown():
     # CHECK-SAME:   }
     print(param_verbatim_module)
 
+  # Test is_external on sv.verbatim.module (no region — always external)
+  # CHECK: verbatim_module.is_external = True
+  print(f"verbatim_module.is_external = {verbatim_module.is_external}")
+  # CHECK: param_verbatim_module.is_external = True
+  print(
+      f"param_verbatim_module.is_external = {param_verbatim_module.is_external}"
+  )
+
   print("=== SV Verbatim Operations Test Completed ===")
   # CHECK: === SV Verbatim Operations Test Completed ===

--- a/lib/Bindings/Python/dialects/hw.py
+++ b/lib/Bindings/Python/dialects/hw.py
@@ -198,7 +198,7 @@ class ModuleLike:
 
   @staticmethod
   def is_external(op):
-    return len(op.regions[0].blocks) == 0
+    return len(op.regions) == 0 or len(op.regions[0].blocks) == 0
 
   @staticmethod
   def parameters(op) -> list[ParamDeclAttr]:


### PR DESCRIPTION
Guard against ops that have no regions at all (not just an empty region) by checking `len(op.regions) == 0` before accessing `op.regions[0]`. 

Though I'm not sure whether verbatim module op should have regions or external module shouldn't have a region, but I think it's reasonable not to crash in both cases. 

Assisted-by: Claude Code: Sonnet 4.6
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
