### PR TITLE
[ImportVerilog][MooreToCore] Adds support for System Verilog real maths functions

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3506,6 +3506,22 @@ class RealMathFunc<string mnemonic, list<Trait> traits = []> :
   let assemblyFormat = "$value attr-dict `:` type($value)";
 }
 
+class RealMathFuncTwoIn<string mnemonic, list<Trait> traits = []> :
+    Builtin<mnemonic, traits # [SameOperandsAndResultType]> {
+  let description = [{
+    The system real math functions shall accept two real value arguments and return
+    a real result type. Their behavior shall match the equivalent C language
+    standard math library function indicated.
+
+    See IEEE 1800-2017 § 20.8.2 "Real math functions".
+   }];
+  let arguments = (ins RealType:$lhs, RealType:$rhs);
+  let results = (outs RealType:$result);
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` type($result)
+  }];
+}
+
 def Clog2BIOp : Builtin<"clog2", [SameOperandsAndResultType]> {
   let summary = "Compute ceil(log2(x)) of x";
   let description = [{
@@ -3540,6 +3556,22 @@ def SqrtBIOp : RealMathFunc<"sqrt"> {
   let summary = "Square root";
 }
 
+def MinBIOp : RealMathFuncTwoIn<"min"> {
+  let summary = "Minimum";
+}
+
+def MaxBIOp : RealMathFuncTwoIn<"max"> {
+  let summary = "Maximum";
+}
+
+def AbsBIOp : RealMathFunc<"abs"> {
+  let summary = "Absolute";
+}
+
+def PowBIOp : RealMathFuncTwoIn<"pow"> {
+  let summary = "Power (x^y)";
+}
+
 def FloorBIOp : RealMathFunc<"floor"> {
   let summary = "Floor";
 }
@@ -3570,6 +3602,14 @@ def AcosBIOp : RealMathFunc<"acos"> {
 
 def AtanBIOp : RealMathFunc<"atan"> {
   let summary = "Arc-tangent";
+}
+
+def Atan2BIOp : RealMathFuncTwoIn<"atan2"> {
+  let summary = "Arc-tangent of y/x";
+}
+
+def HypotBIOp : RealMathFuncTwoIn<"hypot"> {
+  let summary = "Hypotenusis function ((x^2+y^2)^(1/2))";
 }
 
 def SinhBIOp : RealMathFunc<"sinh"> {

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -3568,10 +3568,6 @@ def AbsBIOp : RealMathFunc<"abs"> {
   let summary = "Absolute";
 }
 
-def PowBIOp : RealMathFuncTwoIn<"pow"> {
-  let summary = "Power (x^y)";
-}
-
 def FloorBIOp : RealMathFunc<"floor"> {
   let summary = "Floor";
 }

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3279,6 +3279,21 @@ convertRealMathBI(Context &context, Location loc, StringRef name,
   return OpTy::create(context.builder, loc, value);
 }
 
+/// Helper function to convert real math builtin functions that take exactly
+/// two arguments.
+template <typename OpTy>
+static Value
+convertRealMathTwoBI(Context &context, Location loc, StringRef name,
+                     std::span<const slang::ast::Expression *const> args) {
+  // Slang already checks the arity of real math builtins.
+  assert(args.size() == 2 && "real math builtin expects 2 arguments");
+  auto lhs = context.convertRvalueExpression(*args[0]);
+  auto rhs = context.convertRvalueExpression(*args[1]);
+  if (!lhs || !rhs)
+    return {};
+  return OpTy::create(context.builder, loc, lhs, rhs);
+}
+
 static LogicalResult
 emitScanAssignments(Context &context, const Context::ScanStringResult &result,
                     Location loc) {
@@ -3551,6 +3566,13 @@ Value Context::convertSystemCall(
     return convertRealMathBI<moore::AcoshBIOp>(*this, loc, name, args);
   if (nameId == ksn::Atanh)
     return convertRealMathBI<moore::AtanhBIOp>(*this, loc, name, args);
+  // Real math functions (all take 2 real arguments)
+  if (nameId == ksn::Pow)
+    return convertRealMathTwoBI<moore::PowRealOp>(*this, loc, name, args);
+  if (nameId == ksn::Atan2)
+    return convertRealMathTwoBI<moore::Atan2BIOp>(*this, loc, name, args);
+  if (nameId == ksn::Hypot)
+    return convertRealMathTwoBI<moore::HypotBIOp>(*this, loc, name, args);
 
   if (nameId == ksn::Pow) {
     assert(numArgs == 2 && "`$pow` takes 2 arguments");

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3574,16 +3574,6 @@ Value Context::convertSystemCall(
   if (nameId == ksn::Hypot)
     return convertRealMathTwoBI<moore::HypotBIOp>(*this, loc, name, args);
 
-  if (nameId == ksn::Pow) {
-    assert(numArgs == 2 && "`$pow` takes 2 arguments");
-    auto realType = moore::RealType::get(getContext(), moore::RealWidth::f64);
-    auto lhs = convertRvalueExpression(*args[0], realType);
-    auto rhs = convertRvalueExpression(*args[1], realType);
-    if (!lhs || !rhs)
-      return {};
-    return moore::PowRealOp::create(builder, loc, lhs, rhs);
-  }
-
   //===--------------------------------------------------------------------===//
   // Type Conversion System Functions
   //===--------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3287,8 +3287,9 @@ convertRealMathTwoBI(Context &context, Location loc, StringRef name,
                      std::span<const slang::ast::Expression *const> args) {
   // Slang already checks the arity of real math builtins.
   assert(args.size() == 2 && "real math builtin expects 2 arguments");
-  auto lhs = context.convertRvalueExpression(*args[0]);
-  auto rhs = context.convertRvalueExpression(*args[1]);
+  auto realType = moore::RealType::get(context.getContext(), moore::RealWidth::f64);
+  auto lhs = context.convertRvalueExpression(*args[0], realType);
+  auto rhs = context.convertRvalueExpression(*args[1], realType);
   if (!lhs || !rhs)
     return {};
   return OpTy::create(context.builder, loc, lhs, rhs);

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3287,7 +3287,8 @@ convertRealMathTwoBI(Context &context, Location loc, StringRef name,
                      std::span<const slang::ast::Expression *const> args) {
   // Slang already checks the arity of real math builtins.
   assert(args.size() == 2 && "real math builtin expects 2 arguments");
-  auto realType = moore::RealType::get(context.getContext(), moore::RealWidth::f64);
+  auto realType =
+      moore::RealType::get(context.getContext(), moore::RealWidth::f64);
   auto lhs = context.convertRvalueExpression(*args[0], realType);
   auto rhs = context.convertRvalueExpression(*args[1], realType);
   if (!lhs || !rhs)

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1867,6 +1867,24 @@ struct NegRealOpConversion : public OpConversionPattern<NegRealOp> {
   }
 };
 
+struct Clog2BIOpConversion : public OpConversionPattern<Clog2BIOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(Clog2BIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto intBitWidth = adaptor.getValue().getType().getIntOrFloatBitWidth();
+    Type withType = rewriter.getIntegerType(intBitWidth);
+    Value bitWidth = rewriter.create<arith::ConstantOp>(
+        op.getLoc(), withType, rewriter.getIntegerAttr(withType, intBitWidth));
+    auto leadingZeros = math::CountLeadingZerosOp::create(rewriter, op.getLoc(),
+                                                          adaptor.getValue());
+    Value out =
+        arith::SubIOp::create(rewriter, op.getLoc(), bitWidth, leadingZeros);
+    rewriter.replaceOp(op, out);
+    return success();
+  }
+};
+
 template <typename SourceOp, typename TargetOp>
 struct BinaryOpConversion : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
@@ -1883,6 +1901,50 @@ struct BinaryOpConversion : public OpConversionPattern<SourceOp> {
 
 template <typename SourceOp, typename TargetOp>
 struct BinaryRealOpConversion : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+  using OpAdaptor = typename SourceOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<TargetOp>(op, adaptor.getLhs(),
+                                          adaptor.getRhs());
+    return success();
+  }
+};
+
+struct HypotBIOpConversion : public OpConversionPattern<HypotBIOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(HypotBIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value lhs = adaptor.getLhs();
+    Value rhs = adaptor.getRhs();
+    ImplicitLocOpBuilder b(op->getLoc(), rewriter);
+    auto left = arith::MulFOp::create(b, lhs, lhs);
+    auto right = arith::MulFOp::create(b, rhs, rhs);
+    auto sum = arith::AddFOp::create(b, left, right);
+    auto out = math::SqrtOp::create(b, sum);
+    rewriter.replaceOp(op, out);
+    return success();
+  }
+};
+
+template <typename SourceOp, typename TargetOp>
+struct RealMathFunc : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+  using OpAdaptor = typename SourceOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<TargetOp>(op, adaptor.getValue());
+    return success();
+  }
+};
+
+template <typename SourceOp, typename TargetOp>
+struct RealMathFuncTwoArg : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
   using OpAdaptor = typename SourceOp::Adaptor;
 
@@ -3887,6 +3949,35 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     BinaryRealOpConversion<DivRealOp, arith::DivFOp>,
     BinaryRealOpConversion<MulRealOp, arith::MulFOp>,
     BinaryRealOpConversion<PowRealOp, math::PowFOp>,
+
+    // Pattern for Verilog standard integer mathematical functions
+    Clog2BIOpConversion,
+
+    // Pattern for Verilog standard mathematical functions
+    RealMathFunc<LnBIOp, math::LogOp>,
+    RealMathFunc<Log10BIOp, math::Log10Op>,
+    RealMathFunc<ExpBIOp, math::ExpOp>,
+    RealMathFunc<SqrtBIOp, math::SqrtOp>,
+    RealMathFuncTwoArg<MinBIOp, arith::MinimumFOp>,
+    RealMathFuncTwoArg<MaxBIOp, arith::MaximumFOp>,
+    RealMathFunc<AbsBIOp, math::AbsFOp>,
+    RealMathFuncTwoArg<PowBIOp, math::PowFOp>,
+    RealMathFunc<FloorBIOp, math::FloorOp>,
+    RealMathFunc<CeilBIOp, math::CeilOp>,
+    RealMathFunc<SinBIOp, math::SinOp>,
+    RealMathFunc<CosBIOp, math::CosOp>,
+    RealMathFunc<TanBIOp, math::TanOp>,
+    RealMathFunc<AsinBIOp, math::AsinOp>,
+    RealMathFunc<AcosBIOp, math::AcosOp>,
+    RealMathFunc<AtanBIOp, math::AtanOp>,
+    RealMathFuncTwoArg<Atan2BIOp, math::Atan2Op>,
+    HypotBIOpConversion,
+    RealMathFunc<SinhBIOp, math::SinhOp>,
+    RealMathFunc<CoshBIOp, math::CoshOp>,
+    RealMathFunc<TanhBIOp, math::TanhOp>,
+    RealMathFunc<AsinhBIOp, math::AsinhOp>,
+    RealMathFunc<AcoshBIOp, math::AcoshOp>,
+    RealMathFunc<AtanhBIOp, math::AtanhOp>,
 
     // Patterns of power operations.
     PowUOpConversion, PowSOpConversion,

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1867,24 +1867,6 @@ struct NegRealOpConversion : public OpConversionPattern<NegRealOp> {
   }
 };
 
-struct Clog2BIOpConversion : public OpConversionPattern<Clog2BIOp> {
-  using OpConversionPattern::OpConversionPattern;
-  LogicalResult
-  matchAndRewrite(Clog2BIOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto intBitWidth = adaptor.getValue().getType().getIntOrFloatBitWidth();
-    Type withType = rewriter.getIntegerType(intBitWidth);
-    Value bitWidth = rewriter.create<arith::ConstantOp>(
-        op.getLoc(), withType, rewriter.getIntegerAttr(withType, intBitWidth));
-    auto leadingZeros = math::CountLeadingZerosOp::create(rewriter, op.getLoc(),
-                                                          adaptor.getValue());
-    Value out =
-        arith::SubIOp::create(rewriter, op.getLoc(), bitWidth, leadingZeros);
-    rewriter.replaceOp(op, out);
-    return success();
-  }
-};
-
 template <typename SourceOp, typename TargetOp>
 struct BinaryOpConversion : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
@@ -1939,20 +1921,6 @@ struct RealMathFunc : public OpConversionPattern<SourceOp> {
   matchAndRewrite(SourceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<TargetOp>(op, adaptor.getValue());
-    return success();
-  }
-};
-
-template <typename SourceOp, typename TargetOp>
-struct RealMathFuncTwoArg : public OpConversionPattern<SourceOp> {
-  using OpConversionPattern<SourceOp>::OpConversionPattern;
-  using OpAdaptor = typename SourceOp::Adaptor;
-
-  LogicalResult
-  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<TargetOp>(op, adaptor.getLhs(),
-                                          adaptor.getRhs());
     return success();
   }
 };
@@ -4062,18 +4030,14 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     BinaryRealOpConversion<MulRealOp, arith::MulFOp>,
     BinaryRealOpConversion<PowRealOp, math::PowFOp>,
 
-    // Pattern for Verilog standard integer mathematical functions
-    Clog2BIOpConversion,
-
     // Pattern for Verilog standard mathematical functions
     RealMathFunc<LnBIOp, math::LogOp>,
     RealMathFunc<Log10BIOp, math::Log10Op>,
     RealMathFunc<ExpBIOp, math::ExpOp>,
     RealMathFunc<SqrtBIOp, math::SqrtOp>,
-    RealMathFuncTwoArg<MinBIOp, arith::MinimumFOp>,
-    RealMathFuncTwoArg<MaxBIOp, arith::MaximumFOp>,
+    BinaryRealOpConversion<MinBIOp, arith::MinimumFOp>,
+    BinaryRealOpConversion<MaxBIOp, arith::MaximumFOp>,
     RealMathFunc<AbsBIOp, math::AbsFOp>,
-    RealMathFuncTwoArg<PowBIOp, math::PowFOp>,
     RealMathFunc<FloorBIOp, math::FloorOp>,
     RealMathFunc<CeilBIOp, math::CeilOp>,
     RealMathFunc<SinBIOp, math::SinOp>,
@@ -4082,7 +4046,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     RealMathFunc<AsinBIOp, math::AsinOp>,
     RealMathFunc<AcosBIOp, math::AcosOp>,
     RealMathFunc<AtanBIOp, math::AtanOp>,
-    RealMathFuncTwoArg<Atan2BIOp, math::Atan2Op>,
+    BinaryRealOpConversion<Atan2BIOp, math::Atan2Op>,
     HypotBIOpConversion,
     RealMathFunc<SinhBIOp, math::SinhOp>,
     RealMathFunc<CoshBIOp, math::CoshOp>,

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -306,8 +306,6 @@ function void MathBuiltins(int x, logic [41:0] y, real r, real s);
   dummyB($ln(r));
   // CHECK:  moore.builtin.log10 [[R]] : f64
   dummyB($log10(r));
-  // CHECK:  moore.fpow [[R]], [[R]] : f64
-  dummyB($pow(r, r));
   // CHECK:  moore.builtin.exp [[R]] : f64
   dummyB($exp(r));
   // CHECK:  moore.builtin.sqrt [[R]] : f64
@@ -330,10 +328,10 @@ function void MathBuiltins(int x, logic [41:0] y, real r, real s);
   dummyB($atan(r));
   // CHECK:  moore.builtin.sinh [[R]] : f64
   dummyB($sinh(r));
-  // CHECK:  moore.builtin.atan2 [[R]], [[R]] : f64
-  dummyB($atan2(r, r));
-  // CHECK:  moore.builtin.hypot [[R]], [[R]] : f64
-  dummyB($hypot(r, r));
+  // CHECK:  moore.builtin.atan2 [[R]], [[S]] : f64
+  dummyB($atan2(r, s));
+  // CHECK:  moore.builtin.hypot [[R]], [[S]] : f64
+  dummyB($hypot(r, s));
   // CHECK:  moore.builtin.cosh [[R]] : f64
   dummyB($cosh(r));
   // CHECK:  moore.builtin.tanh [[R]] : f64

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -306,6 +306,8 @@ function void MathBuiltins(int x, logic [41:0] y, real r, real s);
   dummyB($ln(r));
   // CHECK:  moore.builtin.log10 [[R]] : f64
   dummyB($log10(r));
+  // CHECK:  moore.fpow [[R]], [[R]] : f64
+  dummyB($pow(r, r));
   // CHECK:  moore.builtin.exp [[R]] : f64
   dummyB($exp(r));
   // CHECK:  moore.builtin.sqrt [[R]] : f64
@@ -328,6 +330,10 @@ function void MathBuiltins(int x, logic [41:0] y, real r, real s);
   dummyB($atan(r));
   // CHECK:  moore.builtin.sinh [[R]] : f64
   dummyB($sinh(r));
+  // CHECK:  moore.builtin.atan2 [[R]], [[R]] : f64
+  dummyB($atan2(r, r));
+  // CHECK:  moore.builtin.hypot [[R]], [[R]] : f64
+  dummyB($hypot(r, r));
   // CHECK:  moore.builtin.cosh [[R]] : f64
   dummyB($cosh(r));
   // CHECK:  moore.builtin.tanh [[R]] : f64

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -839,6 +839,63 @@ func.func @BinaryRealOps(%arg0: !moore.f32, %arg1: !moore.f32) {
   return
 }
 
+// CHECK-LABEL: func.func @MathBuiltins
+func.func @MathBuiltins(%arg0: !moore.i32, %arg1: !moore.l42,
+                            %arg2: !moore.f64, %arg3: !moore.f64) {
+    // CHECK-DAG: [[V0:%.+]] = arith.constant 32 : i32
+    // CHECK-DAG: [[V1:%.+]] = math.ctlz %arg0 : i32
+    // CHECK: [[V2:%.+]] = arith.subi [[V0]], [[V1]] : i32
+    moore.builtin.clog2 %arg0 : i32
+    // CHECK-DAG: [[V3:%.+]] = arith.constant 42 : i42
+    // CHECK-DAG: [[V4:%.+]] = math.ctlz %arg1 : i42
+    // CHECK: [[V5:%.+]] = arith.subi [[V3]], [[V4]] : i42
+    moore.builtin.clog2 %arg1 : l42
+    // CHECK: math.log %arg2 : f64
+    moore.builtin.ln %arg2 : f64
+    // CHECK: math.log10 %arg2 : f64
+    moore.builtin.log10 %arg2 : f64
+    // CHECK: math.powf %arg2, %arg3 : f64
+    moore.builtin.pow %arg2, %arg3 : f64
+    // CHECK: math.exp %arg2 : f64
+    moore.builtin.exp %arg2 : f64
+    // CHECK: math.floor %arg2 : f64
+    moore.builtin.floor %arg2 : f64
+    // CHECK: math.ceil %arg2 : f64
+    moore.builtin.ceil %arg2 : f64
+    // CHECK: math.sin %arg2 : f64
+    moore.builtin.sin %arg2 : f64
+    // CHECK: math.cos %arg2 : f64
+    moore.builtin.cos %arg2 : f64
+    // CHECK: math.tan %arg2 : f64
+    moore.builtin.tan %arg2 : f64
+    // CHECK: math.asin %arg2 : f64
+    moore.builtin.asin %arg2 : f64
+    // CHECK: math.acos %arg2 : f64
+    moore.builtin.acos %arg2 : f64
+    // CHECK: math.atan %arg2 : f64
+    moore.builtin.atan %arg2 : f64
+    // CHECK math.atan2 %arg2, %arg3 : f64
+    moore.builtin.atan2 %arg2, %arg3  : f64
+    // CHECK-DAG: [[V6:%.+]] = arith.mulf %arg2, %arg2 : f64
+    // CHECK-DAG: [[V7:%.+]] = arith.mulf %arg3, %arg3 : f64
+    // CHECK-DAG: [[V8:%.+]] = arith.addf [[V6]], [[V7]] : f64
+    // CHECK: math.sqrt [[V8]] : f64
+    moore.builtin.hypot %arg2, %arg3  : f64
+    // CHECK: math.sinh %arg2 : f64
+    moore.builtin.sinh %arg2 : f64
+    // CHECK: math.cosh %arg2 : f64
+    moore.builtin.cosh %arg2 : f64
+    // CHECK: math.tanh %arg2 : f64
+    moore.builtin.tanh %arg2 : f64
+    // CHECK: math.asinh %arg2 : f64
+    moore.builtin.asinh %arg2 : f64
+    // CHECK: math.acosh %arg2 : f64
+    moore.builtin.acosh %arg2 : f64
+    // CHECK: math.atanh %arg2 : f64
+    moore.builtin.atanh %arg2 : f64
+  return
+}
+
 // CHECK-LABEL: hw.module @Procedures
 moore.module @Procedures() {
   // CHECK: llhd.process {

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -842,20 +842,30 @@ func.func @BinaryRealOps(%arg0: !moore.f32, %arg1: !moore.f32) {
 // CHECK-LABEL: func.func @MathBuiltins
 func.func @MathBuiltins(%arg0: !moore.i32, %arg1: !moore.l42,
                             %arg2: !moore.f64, %arg3: !moore.f64) {
-    // CHECK-DAG: [[V0:%.+]] = arith.constant 32 : i32
-    // CHECK-DAG: [[V1:%.+]] = math.ctlz %arg0 : i32
-    // CHECK: [[V2:%.+]] = arith.subi [[V0]], [[V1]] : i32
+    // CHECK-DAG: %c0_i32 = hw.constant 0 : i32
+    // CHECK-DAG: %c32_i32 = hw.constant 32 : i32
+    // CHECK-DAG: %c1_i32 = hw.constant 1 : i32
+    // CHECK-DAG: [[V0:%.+]] = comb.sub %arg0, %c1_i32 : i32
+    // CHECK-DAG: [[V1:%.+]] = math.ctlz [[V0:%.+]] : i32
+    // CHECK-DAG: [[V2:%.+]] = comb.sub %c32_i32, [[V1:%.+]] : i32
+    // CHECK-DAG: [[V3:%.+]] = comb.icmp eq %arg0, %c0_i32  : i32
+    // CHECK: [[V4:%.+]] = comb.mux [[V3:%.+]], %c0_i32, [[V2:%.+]]: i32
     moore.builtin.clog2 %arg0 : i32
-    // CHECK-DAG: [[V3:%.+]] = arith.constant 42 : i42
-    // CHECK-DAG: [[V4:%.+]] = math.ctlz %arg1 : i42
-    // CHECK: [[V5:%.+]] = arith.subi [[V3]], [[V4]] : i42
+    // CHECK-DAG: %c0_i42 = hw.constant 0 : i42
+    // CHECK-DAG: %c42_i42 = hw.constant 42 : i42
+    // CHECK-DAG: %c1_i42 = hw.constant 1 : i42
+    // CHECK-DAG: [[V5:%.+]] = comb.sub %arg1, %c1_i42 : i42
+    // CHECK-DAG: [[V6:%.+]] = math.ctlz [[V5:%.+]] : i42
+    // CHECK-DAG: [[V7:%.+]] = comb.sub %c42_i42, [[V5:%.+]] : i42
+    // CHECK-DAG: [[V8:%.+]] = comb.icmp eq %arg1, %c0_i42 : i42
+    // CHECK: [[V9:%.+]] = comb.mux [[V14:%.+]], %c0_i42, [[V7:%.+]]: i42
     moore.builtin.clog2 %arg1 : l42
     // CHECK: math.log %arg2 : f64
     moore.builtin.ln %arg2 : f64
     // CHECK: math.log10 %arg2 : f64
     moore.builtin.log10 %arg2 : f64
     // CHECK: math.powf %arg2, %arg3 : f64
-    moore.builtin.pow %arg2, %arg3 : f64
+    moore.fpow %arg2, %arg3 : f64
     // CHECK: math.exp %arg2 : f64
     moore.builtin.exp %arg2 : f64
     // CHECK: math.floor %arg2 : f64

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -478,11 +478,53 @@ func.func @SeverityAndDisplayBuiltins(%arg0: !moore.format_string) {
 }
 
 // CHECK-LABEL: func.func @MathBuiltins
-func.func @MathBuiltins(%arg0: !moore.i32, %arg1: !moore.l42) {
+func.func @MathBuiltins(%arg0: !moore.i32, %arg1: !moore.l42, %arg2: !moore.f64) {
   // CHECK: moore.builtin.clog2 %arg0 : i32
   moore.builtin.clog2 %arg0 : i32
   // CHECK: moore.builtin.clog2 %arg1 : l42
   moore.builtin.clog2 %arg1 : l42
+    // CHECK: moore.builtin.ln %arg2 : f64
+  moore.builtin.ln %arg2 : f64
+  // CHECK: moore.builtin.log10 %arg2 : f64
+  moore.builtin.log10 %arg2 : f64
+  // CHECK: moore.builtin.pow %arg2, %arg2 : f64
+  moore.builtin.pow %arg2, %arg2 : f64
+  // CHECK: moore.builtin.exp %arg2 : f64
+  moore.builtin.exp %arg2 : f64
+  // CHECK: moore.builtin.sqrt %arg2 : f64
+  moore.builtin.sqrt %arg2 : f64
+  // CHECK: moore.builtin.floor %arg2 : f64
+  moore.builtin.floor %arg2 : f64
+  // CHECK: moore.builtin.ceil %arg2 : f64
+  moore.builtin.ceil %arg2 : f64
+  // CHECK: moore.builtin.sin %arg2 : f64
+  moore.builtin.sin %arg2 : f64
+  // CHECK: moore.builtin.cos %arg2 : f64
+  moore.builtin.cos %arg2 : f64
+  // CHECK: moore.builtin.tan %arg2 : f64
+  moore.builtin.tan %arg2 : f64
+  // CHECK: moore.builtin.asin %arg2 : f64
+  moore.builtin.asin %arg2 : f64
+  // CHECK: moore.builtin.acos %arg2 : f64
+  moore.builtin.acos %arg2 : f64
+  // CHECK: moore.builtin.atan %arg2 : f64
+  moore.builtin.atan %arg2 : f64
+  // CHECK: moore.builtin.atan2 %arg2, %arg2 : f64
+  moore.builtin.atan2 %arg2, %arg2  : f64
+  // CHECK: moore.builtin.hypot %arg2, %arg2 : f64
+  moore.builtin.hypot %arg2, %arg2  : f64
+  // CHECK: moore.builtin.sinh %arg2 : f64
+  moore.builtin.sinh %arg2 : f64
+  // CHECK: moore.builtin.cosh %arg2 : f64
+  moore.builtin.cosh %arg2 : f64
+  // CHECK: moore.builtin.tanh %arg2 : f64
+  moore.builtin.tanh %arg2 : f64
+  // CHECK: moore.builtin.asinh %arg2 : f64
+  moore.builtin.asinh %arg2 : f64
+  // CHECK: moore.builtin.acosh %arg2 : f64
+  moore.builtin.acosh %arg2 : f64
+  // CHECK: moore.builtin.atanh %arg2 : f64
+  moore.builtin.atanh %arg2 : f64
   return
 }
 

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -487,8 +487,8 @@ func.func @MathBuiltins(%arg0: !moore.i32, %arg1: !moore.l42, %arg2: !moore.f64)
   moore.builtin.ln %arg2 : f64
   // CHECK: moore.builtin.log10 %arg2 : f64
   moore.builtin.log10 %arg2 : f64
-  // CHECK: moore.builtin.pow %arg2, %arg2 : f64
-  moore.builtin.pow %arg2, %arg2 : f64
+  // CHECK: moore.fpow %arg2, %arg2 : f64
+  moore.fpow %arg2, %arg2 : f64
   // CHECK: moore.builtin.exp %arg2 : f64
   moore.builtin.exp %arg2 : f64
   // CHECK: moore.builtin.sqrt %arg2 : f64


### PR DESCRIPTION
This commit adds support for the System Verilog real math functions (IEEE1800-2017 Chapter 20.8) by adding previously missing patterns for conversion from Verilog to the 'moore' dialect and adds patterns for conversion using the MLIR dialects 'arith' and  'math' to allow the use of the real math functions as non-synthesizable constructs.

In combination with adding explicit conversion between int and real from the pull requests [#9088](https://github.com/llvm/circt/commit/a1e24844a431f3a05e89287db3b8db256199cb43) and [#9317](https://github.com/llvm/circt/commit/ae7ac8725bae22b34baf3a36554441485b53d200) this addresses the issue using the math functions as raised in issue [#8930](https://github.com/llvm/circt/issues/8930). 

This is done by adding:

- A class RealMathFuncTwoIn in include/circt/Dialect/Moore/MooreOps.td for real math functions with two operants.
- A template convertRealMathTwoBI in lib/Conversion/ImportVerilog/Expressions.cpp for real math functions with two operants that can converted into a single operation in the 'arith' or 'math' dialect.
-  A struct Clog2BIOpConversion in lib/Conversion/MooreToCore/MooreToCore.cpp for conversion of the clog2 function from 'moore' a 'math' and 'arith' representation.  
-   A struct RealMathFunc and a struct RealMathFuncTwoArg in lib/Conversion/MooreToCore/MooreToCore.cpp for conversion of real math functions into the 'math' and 'arith' dialects.
- A struct HypotBIOpConversion and a struct RealMathFuncTwoArg in lib/Conversion/MooreToCore/MooreToCore.cpp for conversion of the hypot-function the 'math' and 'arith' dialects.
- Tests for the import of real math functions with two arguments in test/Conversion/ImportVerilog/builtins.sv.
- Tests for conversion to core dialects of real math functions in test/Conversion/MooreToCore/basic.mlir.
- Tests for real math functions in 'moore' dialect in test/Dialect/Moore/basic.mlir.
