### PR TITLE
[Support] Add noWrap option to PrettyPrinter

### DIFF
--- a/include/circt/Support/PrettyPrinter.h
+++ b/include/circt/Support/PrettyPrinter.h
@@ -188,14 +188,15 @@ public:
   /// - baseIndent: always indent at least this much (starting 'indent' value).
   /// - currentColumn: current column, used to calculate space remaining.
   /// - maxStartingIndent: max column indentation starts at, must be >= margin.
+  /// - noWrap: disable line wrapping; only explicit newlines break.
   PrettyPrinter(llvm::raw_ostream &os, uint32_t margin, uint32_t baseIndent = 0,
                 uint32_t currentColumn = 0,
                 uint32_t maxStartingIndent = kInfinity / 4,
-                Listener *listener = nullptr)
+                Listener *listener = nullptr, bool noWrap = false)
       : space(margin - std::max(currentColumn, baseIndent)),
         defaultFrame{baseIndent, PrintBreaks::Inconsistent}, indent(baseIndent),
         margin(margin), maxStartingIndent(std::max(maxStartingIndent, margin)),
-        os(os), listener(listener) {
+        os(os), listener(listener), noWrap(noWrap) {
     assert(maxStartingIndent < kInfinity / 2);
     assert(maxStartingIndent > baseIndent);
     assert(margin > currentColumn);
@@ -317,6 +318,9 @@ private:
 
   /// Flag to identify a state when the clear cannot be called.
   bool donotClear = false;
+
+  /// Disables line wrapping on non-newline whitespace
+  const bool noWrap;
 
   /// Threshold for walking scan state and "rebasing" totals/offsets.
   static constexpr decltype(leftTotal) rebaseThreshold =

--- a/lib/Support/PrettyPrinter.cpp
+++ b/lib/Support/PrettyPrinter.cpp
@@ -260,6 +260,7 @@ void PrettyPrinter::print(const FormattedToken &f) {
                "newline inside never group");
         bool fits =
             (alwaysFits > 0) || b->neverbreak() ||
+            (noWrap && b->spaces() != kInfinity) ||
             frame.breaks == PrintBreaks::Fits ||
             (frame.breaks == PrintBreaks::Inconsistent && f.size <= space);
         if (fits) {

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -765,6 +765,32 @@ test
 )"""));
 }
 
+TEST(PrettyPrinterTest, NoWrap) {
+  SmallString<128> out;
+  raw_svector_ostream os(out);
+
+  auto test = [&](bool noWrap) {
+    out = "";
+    PrettyPrinter pp(os, 7, 0, 0, PrettyPrinter::kInfinity / 4, nullptr,
+                     noWrap);
+    TokenBuilder<> b(pp);
+    b.ibox();
+    b.literal("test");
+    b.space();
+    b.literal("test");
+    b.newline();
+    b.literal("test");
+    b.end();
+    pp.eof();
+  };
+
+  test(false);
+  EXPECT_EQ(out.str(), StringRef("test\ntest\ntest"));
+
+  test(true);
+  EXPECT_EQ(out.str(), StringRef("test test\ntest"));
+}
+
 TEST(PrettyPrinterTest, NeverBreakGroup) {
   SmallString<128> out;
   raw_svector_ostream os(out);


### PR DESCRIPTION
Allows pretty printer to disable implicit line wrapping - this is so that this can be used in the FIRRTL emitter (in a follow-up) to emit FIRRTL that's backwards compatible with SFC (which doesn't support line wrapping). The target-line-length option isn't quite fit for purpose as it also space pads to the given width, which massively bloats the files if you're having to set a high limit to avoid wrapping.