### PR TITLE
[ImportVerilog] Support field width on %s format specifiers

### DIFF
--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -279,9 +279,22 @@ struct FormatStringParser {
 
   LogicalResult emitString(const slang::ast::Expression &arg,
                            const FormatOptions &options) {
-    if (options.width)
-      return mlir::emitError(loc)
-             << "string format specifier with width not supported";
+    // A field width (e.g. `%20s` / `%-20s`) prints the string in a field of at
+    // least that many characters, right- or left-justified and space-padded
+    // (IEEE 1800-2017 § 21.2.1.2). `moore.fmt.string` carries these attributes.
+    if (options.width) {
+      auto value = context.convertRvalueExpression(
+          arg, moore::StringType::get(context.getContext()));
+      if (!value)
+        return failure();
+      auto alignment = options.leftJustify ? IntAlign::Left : IntAlign::Right;
+      auto padding = options.zeroPad ? IntPadding::Zero : IntPadding::Space;
+      fragments.push_back(moore::FormatStringOp::create(
+          builder, loc, value, builder.getI32IntegerAttr(*options.width),
+          moore::IntAlignAttr::get(context.getContext(), alignment),
+          moore::IntPaddingAttr::get(context.getContext(), padding)));
+      return success();
+    }
 
     // Simplified handling for literals.
     if (auto *lit = arg.as_if<slang::ast::StringLiteral>()) {

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -138,12 +138,6 @@ module Foo;
 endmodule
 
 // -----
-function Foo;
-  // expected-error @below {{string format specifier with width not supported}}
-  $write("%42s", "foo");
-endfunction
-
-// -----
 function time Foo;
   // expected-error @below {{time value is larger than 18446744073709549568 fs}}
   return 100000s;

--- a/test/Conversion/ImportVerilog/format-string-width.sv
+++ b/test/Conversion/ImportVerilog/format-string-width.sv
@@ -1,0 +1,22 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// A field width on a `%s` specifier prints the string in a field of at least
+// that many characters, right- or left-justified and space-padded
+// (IEEE 1800-2017 § 21.2.1.2). Carried on `moore.fmt.string` as width /
+// alignment / padding. (pulp-platform cheshire cva6 instr_trace_item.svh:368
+// uses `%-36s`.)
+
+// CHECK-LABEL: moore.module @FmtWidth(
+module FmtWidth;
+  string name;
+  initial begin
+    // CHECK: moore.fmt.string %{{.+}}, width 36, alignment left, padding space
+    $display("%-36s", name);
+    // CHECK: moore.fmt.string %{{.+}}, width 20, alignment right, padding space
+    $display("%20s", name);
+    // CHECK: moore.fmt.string %{{.+}}, width 42, alignment right, padding space
+    $write("%42s", "foo");
+  end
+endmodule


### PR DESCRIPTION
`$display`/`$write`/`$sformatf` with a width on a string specifier (e.g. `%-36s` or `%20s`) was rejected with "string format specifier with width not supported".

`moore.fmt.string` already carries optional width / alignment / padding attributes and lowers them to `sim.fmt.string` in MooreToCore, so populate them from the format options instead of erroring: width from the specifier, alignment from left-justify (`%-`), and space padding. The no-width path is unchanged (literals still use `fmt.literal`).

Update errors.sv: `$write("%42s", ...)` is now supported, so drop that negative test.

Assisted-by: Claude Code:claude-opus-4-8

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
