### PR TITLE
[FIRRTL][Inliner] Make setInnerSym idempotent for same-sym re-rename

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -386,8 +386,11 @@ public:
 
   void setInnerSym(Attribute module, StringAttr innerSym) {
     assert(symIdx.count(module) && "Mutable NLA did not contain symbol");
-    assert(!renames.count(module) && "Module already renamed");
-    renames.insert({module, innerSym});
+    // Idempotent: a module may be renamed more than once in the same context
+    // (e.g., one wire carrying two annotations that reference the same NLA).
+    // Allow this as long as its the /same/ symbol.
+    [[maybe_unused]] auto [it, inserted] = renames.insert({module, innerSym});
+    assert((inserted || it->second == innerSym) && "Conflicting rename");
   }
 };
 } // namespace

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1669,3 +1669,30 @@ firrtl.circuit "Issue3374Derived" {
     firrtl.instance e @Quux()
   }
 }
+
+// -----
+// https://github.com/llvm/circt/issues/10674
+//
+// Idempotent renames of inner symbols.
+// CHECK-LABEL: "Issue10674"
+firrtl.circuit "Issue10674" {
+  hw.hierpath private @nla [@Parent::@inst, @Child::@w]
+  firrtl.module private @Child() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    // @Child persists, nothing annotated here (@nla is rooted at @Parent).
+    %w = firrtl.wire sym @w {annotations = [
+      {circt.nonlocal = @nla, class = "anno1"},
+      {circt.nonlocal = @nla, class = "anno2"}
+    ]} : !firrtl.uint<1>
+  }
+  // CHECK: firrtl.module @Parent
+  firrtl.module @Parent() {
+    // CHECK: %existing = firrtl.wire sym @w
+    %existing = firrtl.wire sym @w : !firrtl.uint<1>
+    // both annotations localized onto the inlined copy:
+    // CHECK: firrtl.wire sym @w_0 {annotations = [{class = "anno1"}, {class = "anno2"}]}
+    firrtl.instance inst sym @inst @Child()
+  }
+  firrtl.module @Issue10674() {
+    firrtl.instance p @Parent()
+  }
+}


### PR DESCRIPTION
A single wire can carry two annotations that reference the same NLA. When a symbol collision occurs, the inliner tries to record the same per-module rename twice, tripping the 'Module already renamed' assert.

Allow an idempotent re-set to the /same/ symbol,
keep asserting on conflicting renames to different symbols.

Fixes #10674.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
