### PR TITLE
[FIRRTL][Inliner] Handle single-element hierpath in writeback

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -174,14 +174,14 @@ public:
       // Root of the namepath. If the next module has been inlined, set lastMod
       // to root and skip adding to the namepath. Otherwise, add the root with
       // its inner ref.
-      if (!inlinedSymbols.test(1)) {
+      if (inlinedSymbols.size() == 1 || !inlinedSymbols.test(1)) {
         lastMod = root;
       } else {
         namepath.push_back(InnerRefAttr::get(root, lookupRename(root)));
       }
 
       // Everything in the middle of the namepath (excluding the root and leaf).
-      for (signed i = 1, e = inlinedSymbols.size() - 1; i != e; ++i) {
+      for (signed i = 1, e = inlinedSymbols.size() - 1; i < e; ++i) {
         if (!inlinedSymbols.test(i + 1)) {
           if (!lastMod)
             lastMod = nla.modPart(i);
@@ -260,7 +260,7 @@ public:
       // Root of the namepath. If the next module has been inlined, set lastMod
       // to root and skip adding to the output. Otherwise, write the root with
       // its inner ref.
-      if (!x.inlinedSymbols.test(1)) {
+      if (x.inlinedSymbols.size() == 1 || !x.inlinedSymbols.test(1)) {
         lastMod = root;
       } else {
         writePathSegment(root, x.lookupRename(root));
@@ -268,7 +268,7 @@ public:
       }
 
       // Everything in the middle of the namepath (excluding the root and leaf).
-      for (signed i = 1, e = x.inlinedSymbols.size() - 1; i != e; ++i) {
+      for (signed i = 1, e = x.inlinedSymbols.size() - 1; i < e; ++i) {
         if (!x.inlinedSymbols.test(i + 1)) {
           if (!lastMod)
             lastMod = x.nla.modPart(i);

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1696,3 +1696,22 @@ firrtl.circuit "Issue10674" {
     firrtl.instance p @Parent()
   }
 }
+
+// -----
+// https://github.com/llvm/circt/issues/10682
+//
+// Single-element hierpath.
+// CHECK-LABEL: "Issue10682"
+firrtl.circuit "Issue10682" {
+  hw.hierpath private @nla [@M::@w]
+  // CHECK: firrtl.module @Issue10682
+  firrtl.module @Issue10682() {
+    firrtl.instance m @M()
+  }
+  // After inlining @M, the wire is moved into @Issue10682 and localized:
+  // CHECK-NEXT: firrtl.wire sym @w {annotations = [{class = "test"}]}
+  // CHECK-NOT: circt.nonlocal
+  firrtl.module private @M() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla, class = "test"}]} : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
A hierpath with one namepath element is degenerate: the single element is both root and leaf.

Fix the writeback and debug/dump() code to accommodate this, instead of crashing or assertion failure.

Fixes #10682.
