### PR TITLE
[MooreToCore] Fix bool cast lowering for $time

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1755,9 +1755,12 @@ struct BoolCastOpConversion : public OpConversionPattern<BoolCastOp> {
       return success();
     }
     if (isa_and_nonnull<llhd::TimeType>(resultType)) {
-      Value timeInt = llhd::TimeToIntOp::create(rewriter, op->getLoc(), adaptor.getInput());
-      Value zero = hw::ConstantOp::create(rewriter, op->getLoc(), rewriter.getI64Type(), 0);
-      rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne, timeInt, zero);
+      Value timeInt =
+          llhd::TimeToIntOp::create(rewriter, op->getLoc(), adaptor.getInput());
+      Value zero = hw::ConstantOp::create(rewriter, op->getLoc(),
+                                          rewriter.getI64Type(), 0);
+      rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne,
+                                                timeInt, zero);
       return success();
     }
     return failure();

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1754,6 +1754,12 @@ struct BoolCastOpConversion : public OpConversionPattern<BoolCastOp> {
                                                  adaptor.getInput(), zero);
       return success();
     }
+    if (isa_and_nonnull<llhd::TimeType>(resultType)) {
+      Value timeInt = llhd::TimeToIntOp::create(rewriter, op->getLoc(), adaptor.getInput());
+      Value zero = hw::ConstantOp::create(rewriter, op->getLoc(), rewriter.getI64Type(), 0);
+      rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne, timeInt, zero);
+      return success();
+    }
     return failure();
   }
 };


### PR DESCRIPTION
`BoolCastOpConversion` handled `IntegerType` and `FloatType` inputs but returned failure for `llhd::TimeType` causing `$time` used as a boolean condition to fail legalization.

For example: 
```
module bug_time64_cast;
  logic r;
  initial r = $time ? 1'b1 : 1'b0;
endmodule
```

Output: 
```
...
error: failed to legalize operation 'moore.bool_cast': %9 = "moore.bool_cast"(%8) : (!moore.time) -> !moore.l1
  initial r = $time ? 1'b1 : 1'b0;
                  ^
note: see current operation: %9 = "moore.bool_cast"(%8) : (!moore.time) -> !moore.l1
```

Fix:
Convert the time value to i64 via `llhd::TimeToIntOp`, then compare with zero using `comb::ICmpOp::ne`.
