### PR TITLE
[circt-synth] Use correct reqires in integration test

### DIFF
--- a/integration_test/circt-synth/functional-reduction-z3.mlir
+++ b/integration_test/circt-synth/functional-reduction-z3.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: z3
+// REQUIRES: z3-integration
 // RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(synth-functional-reduction{num-random-patterns=64 sat-solver=z3}))' -o %t.mlir
 // RUN: cat %t.mlir | FileCheck %s
 


### PR DESCRIPTION
Test uses the Z3 LLVM integration (`z3-integration`), not the Z3 library (`z3`) itself.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
