### PR TITLE
[FIRRTL][Inliner] Fix hasRoot, drop rootSet, fix crash.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -91,10 +91,6 @@ class MutableNLA {
   /// migrates to each instantiator of the original NLA.
   SmallVector<InnerRefAttr> newTops;
 
-  /// Cache of roots that this module participates in.  This is only valid when
-  /// newTops is non-empty.
-  DenseSet<StringAttr> rootSet;
-
   /// Stores the size of the NLA path.
   unsigned int size;
 
@@ -330,15 +326,12 @@ public:
     return inlinedSymbols.find_first_in(1, inlinedSymbols.size()) == -1;
   }
 
-  /// Return true if this NLA has a root that originates from a specific module.
-  bool hasRoot(FModuleLike mod) {
-    return (isDead() && nla.root() == mod.getModuleNameAttr()) ||
-           rootSet.contains(mod.getModuleNameAttr());
-  }
+  /// Return true if either this NLA is rooted at modName, or is retoped to it.
+  bool hasRoot(FModuleLike mod) { return hasRoot(mod.getModuleNameAttr()); }
 
   /// Return true if either this NLA is rooted at modName, or is retoped to it.
   bool hasRoot(StringAttr modName) {
-    return (nla.root() == modName) || rootSet.contains(modName);
+    return symIdx.lookup_or(modName, -1) == 0;
   }
 
   /// Mark a module as inlined.  This will remove it from the NLA.
@@ -376,7 +369,6 @@ public:
       sym = StringAttr::get(nla.getContext(),
                             circuitNamespace->newName(sym.getValue()));
     newTops.push_back(InnerRefAttr::get(module.getNameAttr(), sym));
-    rootSet.insert(module.getNameAttr());
     symIdx.insert({module.getNameAttr(), 0});
     markDead();
     return sym;
@@ -1596,7 +1588,7 @@ LogicalResult Inliner::run() {
         //  - otherwise it is local elsewhere but not here (this module needed
         //    the NLA to selectively enable it), so just drop the annotation.
         if (mnla.isLocal()) {
-          if (mnla.hasRoot(fmodule.getModuleNameAttr())) {
+          if (mnla.hasRoot(fmodule)) {
             anno.removeMember("circt.nonlocal");
             newAnnotations.push_back(anno.getAttr());
           }


### PR DESCRIPTION
Align the two hasRoot implementations.

Don't define `hasRoot` in terms of `nla` -- we may have deleted that operation in `applyUpdates`.
Instead get the needed information from other existing fields.

Remove the very funky `isDead() && nla.root() == (name)` logic; we only use that overload in code that's dominated by a isDead() check, and it will crash if we didn't do this after applyUpdates which might delete the nla op.
It's unclear what this was intended for, to be honest.

Instead have hasRoot check by using our symIdx map -- which is redundant on the conditionally valid rootSet.
(see comment above it)

Drop redundant rootSet.

Fixes #10761.