### PR TITLE
[Sim][MooreToCore][SimToSV] Add sim.string.format_to_string and lower moore.fstring_to_string

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -772,6 +772,16 @@ def IntToStringOp: SimOp<"string.int_to_string", [Pure]> {
   let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
 }
 
+def FormatToStringOp : SimOp<"string.format_to_string", [Pure]> {
+  let summary = "Create a dynamic string by evaluating a format string";
+  let description = [{
+    Evaluates a format string and produces the result as a dynamic string.
+  }];
+  let arguments = (ins FormatStringType:$fmtstring);
+  let results = (outs DynamicStringType:$result);
+  let assemblyFormat = "$fmtstring attr-dict";
+}
+
 def StringGetOp : SimOp<"string.get", [Pure]> {
   let summary = "Get a character from a string at a given index";
   let description = [{

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -772,7 +772,7 @@ def IntToStringOp: SimOp<"string.int_to_string", [Pure]> {
   let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
 }
 
-def FormatToStringOp : SimOp<"string.format_to_string", [Pure]> {
+def FormatToStringOp : SimOp<"string.format_to_string", [ProceduralOp]> {
   let summary = "Create a dynamic string by evaluating a format string";
   let description = [{
     Evaluates a format string and produces the result as a dynamic string.

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2060,6 +2060,19 @@ struct IntToStringOpConversion : public OpConversionPattern<IntToStringOp> {
   }
 };
 
+struct FormatStringToStringOpConversion
+    : public OpConversionPattern<FormatStringToStringOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(FormatStringToStringOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::FormatToStringOp>(op,
+                                                       adaptor.getFmtstring());
+    return success();
+  }
+};
+
 struct RealToIntOpConversion : public OpConversionPattern<RealToIntOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -3393,6 +3406,7 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
   typeConverter.addConversion([](IntegerType type) { return type; });
   typeConverter.addConversion([](FloatType type) { return type; });
   typeConverter.addConversion([](sim::DynamicStringType type) { return type; });
+  typeConverter.addConversion([](sim::FormatStringType type) { return type; });
   typeConverter.addConversion([](llhd::TimeType type) { return type; });
   typeConverter.addConversion([](debug::ArrayType type) { return type; });
   typeConverter.addConversion([](debug::ScopeType type) { return type; });
@@ -3491,6 +3505,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     SIntToRealOpConversion,
     UIntToRealOpConversion,
     IntToStringOpConversion,
+    FormatStringToStringOpConversion,
     RealToIntOpConversion,
     ConvertRealOpConversion,
 

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -912,6 +912,32 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
     cleanupSeeds.push_back(printOp);
   }
 
+  SmallVector<FormatToStringOp> formatToStringOps;
+  module.walk([&](FormatToStringOp op) { formatToStringOps.push_back(op); });
+
+  for (auto op : formatToStringOps) {
+    OpBuilder builder(op);
+    SmallString<128> formatStr;
+    SmallVector<Value> args;
+    if (failed(lowerFormatStringToSVFormat(op.getFmtstring(), formatStr, args,
+                                           builder)))
+      return op.emitError(
+          "cannot lower 'sim.string.format_to_string' to SystemVerilog");
+
+    Value svResult;
+    if (args.empty())
+      svResult = sv::ConstantStrOp::create(builder, op.getLoc(),
+                                           builder.getStringAttr(formatStr));
+    else
+      svResult = sv::SFormatFOp::create(builder, op.getLoc(),
+                                        builder.getStringAttr(formatStr), args);
+
+    auto cast = mlir::UnrealizedConversionCastOp::create(
+        builder, op.getLoc(), op.getType(), svResult);
+    op.replaceAllUsesWith(cast.getResult(0));
+    cleanupSeeds.push_back(op);
+  }
+
   cleanupDeadSimFmtOps(cleanupSeeds);
 
   return success();

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -801,14 +801,21 @@ LogicalResult appendFormatFragmentToSVFormat(Value fragment,
 LogicalResult lowerFormatStringToSVFormat(Value input,
                                           SmallString<128> &formatString,
                                           SmallVectorImpl<Value> &args,
-                                          OpBuilder &builder) {
+                                          OpBuilder &builder,
+                                          bool &requiresFormatting) {
   SmallVector<Value, 8> fragments;
   if (failed(getFlattenedFormatFragments(input, fragments)))
     return failure();
-  for (auto fragment : fragments)
+  requiresFormatting = false;
+  for (auto fragment : fragments) {
     if (failed(appendFormatFragmentToSVFormat(fragment, formatString, args,
                                               builder)))
       return failure();
+    // Non-literal fragments (e.g. %m/%M from FormatHierPathOp) may need
+    // runtime substitution even though they append no argument.
+    if (!isa<FormatLiteralOp>(fragment.getDefiningOp()))
+      requiresFormatting = true;
+  }
   return success();
 }
 
@@ -816,8 +823,9 @@ FailureOr<Value> createFileDescriptorGetterForGetFile(GetFileOp getFileOp,
                                                       OpBuilder &builder) {
   SmallString<128> formatString;
   SmallVector<Value> args;
+  bool requiresFormatting = false;
   if (failed(lowerFormatStringToSVFormat(getFileOp.getFileName(), formatString,
-                                         args, builder))) {
+                                         args, builder, requiresFormatting))) {
     getFileOp.emitError("cannot lower 'sim.get_file' to SystemVerilog")
             .attachNote(getFileOp.getFileName().getLoc())
         << "while lowering file name";
@@ -825,12 +833,12 @@ FailureOr<Value> createFileDescriptorGetterForGetFile(GetFileOp getFileOp,
   }
 
   Value fileName =
-      args.empty()
-          ? sv::ConstantStrOp::create(builder, getFileOp.getLoc(),
-                                      builder.getStringAttr(formatString))
-                .getResult()
-          : sv::SFormatFOp::create(builder, getFileOp.getLoc(),
+      requiresFormatting
+          ? sv::SFormatFOp::create(builder, getFileOp.getLoc(),
                                    builder.getStringAttr(formatString), args)
+                .getResult()
+          : sv::ConstantStrOp::create(builder, getFileOp.getLoc(),
+                                      builder.getStringAttr(formatString))
                 .getResult();
 
   return sv::createProceduralFileDescriptorGetterCall(
@@ -893,8 +901,10 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
     OpBuilder builder(printOp);
     SmallString<128> formatString;
     SmallVector<Value> args;
+    bool requiresFormatting = false;
     if (failed(lowerFormatStringToSVFormat(printOp.getInput(), formatString,
-                                           args, builder))) {
+                                           args, builder,
+                                           requiresFormatting))) {
       printOp.emitError("cannot lower 'sim.proc.print' to SystemVerilog")
               .attachNote(printOp.getInput().getLoc())
           << "while lowering format string";
@@ -919,18 +929,19 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
     OpBuilder builder(op);
     SmallString<128> formatStr;
     SmallVector<Value> args;
+    bool requiresFormatting = false;
     if (failed(lowerFormatStringToSVFormat(op.getFmtstring(), formatStr, args,
-                                           builder)))
+                                           builder, requiresFormatting)))
       return op.emitError(
           "cannot lower 'sim.string.format_to_string' to SystemVerilog");
 
     Value svResult;
-    if (args.empty())
-      svResult = sv::ConstantStrOp::create(builder, op.getLoc(),
-                                           builder.getStringAttr(formatStr));
-    else
+    if (requiresFormatting)
       svResult = sv::SFormatFOp::create(builder, op.getLoc(),
                                         builder.getStringAttr(formatStr), args);
+    else
+      svResult = sv::ConstantStrOp::create(builder, op.getLoc(),
+                                           builder.getStringAttr(formatStr));
 
     auto cast = mlir::UnrealizedConversionCastOp::create(
         builder, op.getLoc(), op.getType(), svResult);

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -863,12 +863,15 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
                                           SimConversionState &state) {
   SmallVector<GetFileOp> getFileOps;
   SmallVector<PrintFormattedProcOp> printOps;
+  SmallVector<FormatToStringOp> formatToStringOps;
   SmallVector<Operation *, 8> cleanupSeeds;
   module.walk([&](Operation *op) {
     if (auto getFileOp = dyn_cast<GetFileOp>(op))
       getFileOps.push_back(getFileOp);
     if (auto printOp = dyn_cast<PrintFormattedProcOp>(op))
       printOps.push_back(printOp);
+    if (auto formatToStringOp = dyn_cast<FormatToStringOp>(op))
+      formatToStringOps.push_back(formatToStringOp);
   });
 
   for (auto getFileOp : getFileOps) {
@@ -911,9 +914,6 @@ LogicalResult lowerPrintFormattedProcToSV(hw::HWModuleOp module,
     }
     cleanupSeeds.push_back(printOp);
   }
-
-  SmallVector<FormatToStringOp> formatToStringOps;
-  module.walk([&](FormatToStringOp op) { formatToStringOps.push_back(op); });
 
   for (auto op : formatToStringOps) {
     OpBuilder builder(op);

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1517,6 +1517,13 @@ func.func @IntToStringConversion(%arg0: !moore.i45) {
   return
 }
 
+// CHECK-LABEL: func.func @FormatStringToStringConversion
+func.func @FormatStringToStringConversion(%arg0: !moore.format_string) {
+  // CHECK-NEXT: sim.string.format_to_string %arg0
+  %0 = moore.fstring_to_string %arg0
+  return
+}
+
 // CHECK-LABEL: func.func @ConvertRealOperations
 func.func @ConvertRealOperations(%arg0: !moore.f32, %arg1: !moore.f64) {
   // CHECK: arith.extf %arg0 : f32 to f64

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
@@ -239,3 +239,34 @@ hw.module @format_to_string_dynamic(in %clk: i1, in %val: i8) {
     sim.proc.print %fmt
   }
 }
+
+// CHECK-LABEL: hw.module @format_to_string_hier_path_only
+hw.module @format_to_string_hier_path_only(in %clk: i1) {
+  hw.triggered posedge %clk {
+    %fmtin = sim.fmt.hier_path
+    %str = sim.string.format_to_string %fmtin
+    %fmt = sim.fmt.string %str : !sim.dstring
+    // CHECK: %[[STR:.+]] = sv.sformatf "%m"
+    // CHECK-NEXT: sv.write "%s"(%[[STR]]) : !hw.string
+    sim.proc.print %fmt
+  }
+}
+
+// CHECK-LABEL: hw.module @format_to_string_hier_path_with_arg
+hw.module @format_to_string_hier_path_with_arg(in %clk: i1, in %val: i8) {
+  hw.triggered posedge %clk (%val) : i8 {
+    ^bb0(%val_in: i8):
+    %prefix = sim.fmt.literal "path="
+    %hier = sim.fmt.hier_path
+    %suffix = sim.fmt.literal " val="
+    %fval = sim.fmt.dec %val_in : i8
+    %fmtin = sim.fmt.concat (%prefix, %hier, %suffix, %fval)
+    %str = sim.string.format_to_string %fmtin
+    %fmt = sim.fmt.string %str : !sim.dstring
+    // CHECK: ^bb0(%[[VAL:.+]]: i8):
+    // CHECK-NEXT: %[[UNSIGNED:.+]] = sv.system "unsigned"(%[[VAL]]) : (i8) -> i8
+    // CHECK-NEXT: %[[STR:.+]] = sv.sformatf "path=%m val=%d"(%[[UNSIGNED]]) : i8
+    // CHECK-NEXT: sv.write "%s"(%[[STR]]) : !hw.string
+    sim.proc.print %fmt
+  }
+}

--- a/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
+++ b/test/Conversion/SimToSV/lower-print-formatted-proc-to-sv.mlir
@@ -211,3 +211,31 @@ hw.module @print_to_file_under_condition(in %clk : i1, in %idx : i8, in %en : i1
     }
   }
 }
+
+// CHECK-LABEL: hw.module @format_to_string_static
+hw.module @format_to_string_static(in %clk: i1) {
+  hw.triggered posedge %clk {
+    %lit = sim.fmt.literal "hello"
+    %str = sim.string.format_to_string %lit
+    %fmt = sim.fmt.string %str : !sim.dstring
+    // CHECK: %[[STR:.+]] = sv.constantStr "hello"
+    // CHECK-NEXT: sv.write "%s"(%[[STR]]) : !hw.string
+    sim.proc.print %fmt
+  }
+}
+
+// CHECK-LABEL: hw.module @format_to_string_dynamic
+hw.module @format_to_string_dynamic(in %clk: i1, in %val: i8) {
+  hw.triggered posedge %clk (%val) : i8 {
+    ^bb0(%val_in: i8):
+    %prefix = sim.fmt.literal "v="
+    %fval = sim.fmt.hex %val_in, isUpper false specifierWidth 2 : i8
+    %fmtin = sim.fmt.concat (%prefix, %fval)
+    %str = sim.string.format_to_string %fmtin
+    %fmt = sim.fmt.string %str : !sim.dstring
+    // CHECK: ^bb0(%[[VAL:.+]]: i8):
+    // CHECK-NEXT: %[[STR:.+]] = sv.sformatf "v=%02x"(%[[VAL]]) : i8
+    // CHECK-NEXT: sv.write "%s"(%[[STR]]) : !hw.string
+    sim.proc.print %fmt
+  }
+}


### PR DESCRIPTION
`moore.fstring_to_string` had no MooreToCore lowering pattern, causing "failed to legalize operation" errors when compiling SystemVerilog that assigns a formatted string to a string variable, e.g., `$swrite` or `$sformat`.

For example:
```
module bug_fstring_to_string;
  string s;
  initial begin
    $swrite(s, "val = %0d", 42);
    $display(s);
  end
endmodule
```

Output:
```
error: failed to legalize operation 'moore.fstring_to_string': %11 = "moore.fstring_to_string"(%10) : (!moore.format_string) -> !moore.string
    $swrite(s, "val = %0d", 42);
    ^
note: see current operation: %11 = "moore.fstring_to_string"(%10) : (!moore.format_string) -> !moore.string
```

The existing Sim string ops (`sim.string.literal`, `sim.string.concat`, etc.) all operate on `!sim.dstring` and cannot represent format string evaluation.

This PR introduces `sim.string.format_to_string`, which bridges the two type domains `!sim.fstring` -> `!sim.dstring` and adds a `MooreToCore` conversion pattern and a `SimToSV` lowering.