### PR TITLE
[Arc] Move storage size attribute from type to owning op

### DIFF
--- a/include/circt-c/Dialect/Arc.h
+++ b/include/circt-c/Dialect/Arc.h
@@ -39,9 +39,6 @@ MLIR_CAPI_EXPORTED unsigned arcMemoryTypeGetStride(MlirType type);
 
 MLIR_CAPI_EXPORTED bool arcTypeIsAStorage(MlirType type);
 MLIR_CAPI_EXPORTED MlirType arcStorageTypeGet(MlirContext ctx);
-MLIR_CAPI_EXPORTED MlirType arcStorageTypeGetWithSize(MlirContext ctx,
-                                                      unsigned size);
-MLIR_CAPI_EXPORTED unsigned arcStorageTypeGetSize(MlirType type);
 
 MLIR_CAPI_EXPORTED bool arcTypeIsASimModelInstance(MlirType type);
 MLIR_CAPI_EXPORTED MlirType arcSimModelInstanceTypeGet(MlirAttribute model);

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -482,7 +482,9 @@ def AllocMemoryOp : ArcOp<"alloc_memory", [MemoryEffects<[MemAlloc]>]> {
 
 def AllocStorageOp : ArcOp<"alloc_storage", [MemoryEffects<[MemAlloc]>]> {
   let summary = "Allocate contiguous storage space from a larger storage space";
-  let arguments = (ins StorageType:$input, UI32Attr:$size, OptionalAttr<I32Attr>:$offset);
+  let arguments = (ins StorageType:$input,
+                       UI32Attr:$size,
+                       OptionalAttr<I32Attr>:$offset);
   let results = (outs StorageType:$output);
   let assemblyFormat = [{
     $input (`[` $offset^ `]`)? `,` $size attr-dict

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -482,10 +482,10 @@ def AllocMemoryOp : ArcOp<"alloc_memory", [MemoryEffects<[MemAlloc]>]> {
 
 def AllocStorageOp : ArcOp<"alloc_storage", [MemoryEffects<[MemAlloc]>]> {
   let summary = "Allocate contiguous storage space from a larger storage space";
-  let arguments = (ins StorageType:$input, OptionalAttr<I32Attr>:$offset);
+  let arguments = (ins StorageType:$input, UI32Attr:$size, OptionalAttr<I32Attr>:$offset);
   let results = (outs StorageType:$output);
   let assemblyFormat = [{
-    $input (`[` $offset^ `]`)? attr-dict `:` functional-type($input, $output)
+    $input (`[` $offset^ `]`)? `,` $size attr-dict
   }];
 }
 
@@ -1178,6 +1178,7 @@ def ModelOp : ArcOp<"model", [
   }];
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<ModuleType>:$io,
+                       OptionalAttr<UI32Attr>:$storageBytes,
                        OptionalAttr<FlatSymbolRefAttr>:$initialFn,
                        OptionalAttr<FlatSymbolRefAttr>:$finalFn,
                        OptionalAttr<TraceTapArrayAttr>:$traceTaps);
@@ -1185,6 +1186,7 @@ def ModelOp : ArcOp<"model", [
 
   let assemblyFormat = [{
     $sym_name `io` $io
+    (`storageBytes` $storageBytes^)?
     (`initializer` $initialFn^)?
     (`finalizer` $finalFn^)?
     (`traceTaps` $traceTaps^)?

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -49,8 +49,8 @@ def MemoryType : ArcTypeDef<"Memory"> {
 
 def StorageType : ArcTypeDef<"Storage"> {
   let mnemonic = "storage";
-  let parameters = (ins OptionalParameter<"unsigned">:$size);
-  let assemblyFormat = "(`<` $size^ `>`)?";
+//  let parameters = (ins OptionalParameter<"unsigned">:$size);
+//  let assemblyFormat = "(`<` $size^ `>`)?";
 }
 
 def SimModelInstance : ArcTypeDef<"SimModelInstance"> {

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -49,8 +49,6 @@ def MemoryType : ArcTypeDef<"Memory"> {
 
 def StorageType : ArcTypeDef<"Storage"> {
   let mnemonic = "storage";
-//  let parameters = (ins OptionalParameter<"unsigned">:$size);
-//  let assemblyFormat = "(`<` $size^ `>`)?";
 }
 
 def SimModelInstance : ArcTypeDef<"SimModelInstance"> {

--- a/integration_test/Bindings/Python/dialects/arc.py
+++ b/integration_test/Bindings/Python/dialects/arc.py
@@ -41,21 +41,10 @@ with Context() as ctx, Location.unknown():
   print(f"address_type: {memory_type.address_type}")
   print(f"stride: {memory_type.stride}")
 
-  # Test StorageType without size
+  # Test StorageType
   # CHECK: !arc.storage
-  storage_type_no_size = arc.StorageType.get(ctx)
-  print(storage_type_no_size)
-
-  # CHECK: size: 0
-  print(f"size: {storage_type_no_size.size}")
-
-  # Test StorageType with size
-  # CHECK: !arc.storage<256>
-  storage_type_with_size = arc.StorageType.get(ctx, 256)
-  print(storage_type_with_size)
-
-  # CHECK: size: 256
-  print(f"size: {storage_type_with_size.size}")
+  storage_type = arc.StorageType.get(ctx)
+  print(storage_type)
 
   # Test SimModelInstanceType
   # CHECK: !arc.sim.instance<@model_name>

--- a/lib/Bindings/Python/ArcModule.cpp
+++ b/lib/Bindings/Python/ArcModule.cpp
@@ -60,16 +60,10 @@ void circt::python::populateDialectArcSubmodule(nb::module_ &m) {
   mlir_type_subclass(m, "StorageType", arcTypeIsAStorage)
       .def_classmethod(
           "get",
-          [](nb::object cls, MlirContext ctx, nb::object size) {
-            if (size.is_none())
-              return cls(arcStorageTypeGet(ctx));
-            return cls(
-                arcStorageTypeGetWithSize(ctx, nb::cast<unsigned>(size)));
+          [](nb::object cls, MlirContext ctx) {
+            return cls(arcStorageTypeGet(ctx));
           },
-          nb::arg("cls"), nb::arg("context") = nb::none(),
-          nb::arg("size") = nb::none())
-      .def_property_readonly(
-          "size", [](MlirType self) { return arcStorageTypeGetSize(self); });
+          nb::arg("cls"), nb::arg("context") = nb::none());
 
   mlir_type_subclass(m, "SimModelInstanceType", arcTypeIsASimModelInstance)
       .def_classmethod(

--- a/lib/CAPI/Dialect/Arc.cpp
+++ b/lib/CAPI/Dialect/Arc.cpp
@@ -77,15 +77,7 @@ bool arcTypeIsAStorage(MlirType type) {
 }
 
 MlirType arcStorageTypeGet(MlirContext ctx) {
-  return wrap(StorageType::get(unwrap(ctx), 0));
-}
-
-MlirType arcStorageTypeGetWithSize(MlirContext ctx, unsigned size) {
-  return wrap(StorageType::get(unwrap(ctx), size));
-}
-
-unsigned arcStorageTypeGetSize(MlirType type) {
-  return llvm::cast<StorageType>(unwrap(type)).getSize();
+  return wrap(StorageType::get(unwrap(ctx)));
 }
 
 bool arcTypeIsASimModelInstance(MlirType type) {

--- a/lib/Dialect/Arc/ModelInfo.cpp
+++ b/lib/Dialect/Arc/ModelInfo.cpp
@@ -13,6 +13,7 @@
 #include "circt/Dialect/Arc/ModelInfo.h"
 #include "circt/Dialect/Arc/ArcOps.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/LogicalResult.h"
 
 using namespace mlir;
 using namespace circt;
@@ -123,18 +124,19 @@ LogicalResult circt::arc::collectModels(mlir::ModuleOp module,
                                         SmallVector<ModelInfo> &models) {
 
   for (auto modelOp : module.getOps<ModelOp>()) {
+    if (!modelOp.getStorageBytes().has_value())
+      return modelOp->emitOpError(
+          "missing `storageBytes` attribute; run state allocation first");
     auto storageArg = modelOp.getBody().getArgument(0);
-    auto storageType = cast<StorageType>(storageArg.getType());
 
     SmallVector<StateInfo> states;
     if (failed(collectStates(storageArg, 0, states)))
       return failure();
     llvm::stable_sort(states,
                       [](auto &a, auto &b) { return a.offset < b.offset; });
-
-    models.emplace_back(std::string(modelOp.getName()), storageType.getSize(),
-                        std::move(states), modelOp.getInitialFnAttr(),
-                        modelOp.getFinalFnAttr());
+    models.emplace_back(std::string(modelOp.getName()),
+                        *modelOp.getStorageBytes(), std::move(states),
+                        modelOp.getInitialFnAttr(), modelOp.getFinalFnAttr());
   }
 
   return success();
@@ -196,7 +198,6 @@ circt::arc::ModelInfoAnalysis::ModelInfoAnalysis(Operation *container) {
   for (auto modelOp :
        container->getRegion(0).getBlocks().front().getOps<ModelOp>()) {
     auto storageArg = modelOp.getBody().getArgument(0);
-    auto storageType = cast<StorageType>(storageArg.getType());
 
     SmallVector<StateInfo> states;
     if (failed(collectStates(storageArg, 0, states))) {
@@ -205,8 +206,10 @@ circt::arc::ModelInfoAnalysis::ModelInfoAnalysis(Operation *container) {
     }
     llvm::stable_sort(states,
                       [](auto &a, auto &b) { return a.offset < b.offset; });
+    assert(modelOp.getStorageBytes().has_value() &&
+           "Expected size of storage to be known");
     infoMap.try_emplace(modelOp, std::string(modelOp.getName()),
-                        storageType.getSize(), std::move(states),
+                        *modelOp.getStorageBytes(), std::move(states),
                         modelOp.getInitialFnAttr(), modelOp.getFinalFnAttr());
   }
 }

--- a/lib/Dialect/Arc/ModelInfo.cpp
+++ b/lib/Dialect/Arc/ModelInfo.cpp
@@ -13,7 +13,6 @@
 #include "circt/Dialect/Arc/ModelInfo.h"
 #include "circt/Dialect/Arc/ArcOps.h"
 #include "llvm/Support/JSON.h"
-#include "llvm/Support/LogicalResult.h"
 
 using namespace mlir;
 using namespace circt;

--- a/lib/Dialect/Arc/Transforms/AllocateState.cpp
+++ b/lib/Dialect/Arc/Transforms/AllocateState.cpp
@@ -121,6 +121,10 @@ void AllocateStatePass::allocateBlock(Block *block, Value rootStorage) {
   // Actually allocate each operation. Root storage gets padding for the model
   // header.
   bool isRootBlock = block == rootStorage.getParentBlock();
+  // Ensure `allocateOps` runs on the root storage, even without allocations,
+  // to set the `storageBytes` attribute.
+  if (isRootBlock)
+    opsByStorage.insert({rootStorage, {}});
   for (auto &[storage, ops] : opsByStorage) {
     unsigned padding = isRootBlock && storage == rootStorage ? kStateOffset : 0;
     allocateOps(storage, block, ops, padding);

--- a/lib/Dialect/Arc/Transforms/AllocateState.cpp
+++ b/lib/Dialect/Arc/Transforms/AllocateState.cpp
@@ -171,8 +171,8 @@ void AllocateStatePass::allocateOps(Value storage, Block *block,
     }
 
     if (auto allocStorageOp = dyn_cast<AllocStorageOp>(op)) {
-      auto offset = builder.getI32IntegerAttr(
-          allocBytes(allocStorageOp.getType().getSize()));
+      auto offset =
+          builder.getI32IntegerAttr(allocBytes(allocStorageOp.getSize()));
       allocStorageOp.setOffsetAttr(offset);
       gettersToCreate.emplace_back(allocStorageOp, allocStorageOp.getInput(),
                                    offset);
@@ -213,11 +213,11 @@ void AllocateStatePass::allocateOps(Value storage, Block *block,
   // root storage type to reflect the total allocation size. Root storage is
   // indicated by non-zero padding.
   if (padding != 0) {
-    storage.setType(StorageType::get(&getContext(), currentByte));
+    getOperation().setStorageBytes(currentByte);
   } else {
     auto substorage = AllocStorageOp::create(
         builder, block->getParentOp()->getLoc(),
-        StorageType::get(&getContext(), currentByte), storage);
+        StorageType::get(&getContext()), storage, currentByte, {});
     for (auto *op : ops)
       op->replaceUsesOfWith(storage, substorage);
     for (auto op : getters)

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -15,7 +15,6 @@
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Dialect/Sim/SimOps.h"
 #include "circt/Support/BackedgeBuilder.h"
-#include "circt/Support/LLVM.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -15,6 +15,7 @@
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Dialect/Sim/SimOps.h"
 #include "circt/Support/BackedgeBuilder.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -202,11 +203,11 @@ LogicalResult ModuleLowering::run() {
   // Create the replacement `ModelOp`.
   auto modelOp =
       ModelOp::create(builder, moduleOp.getLoc(), moduleOp.getModuleNameAttr(),
-                      TypeAttr::get(moduleOp.getModuleType()),
+                      TypeAttr::get(moduleOp.getModuleType()), IntegerAttr{},
                       FlatSymbolRefAttr{}, FlatSymbolRefAttr{}, ArrayAttr{});
   auto &modelBlock = modelOp.getBody().emplaceBlock();
-  storageArg = modelBlock.addArgument(
-      StorageType::get(builder.getContext(), {}), modelOp.getLoc());
+  storageArg = modelBlock.addArgument(StorageType::get(builder.getContext()),
+                                      modelOp.getLoc());
   builder.setInsertionPointToStart(&modelBlock);
 
   // Reset the next wakeup slot to `UINT64_MAX` ("no wakeup pending") at the

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -8,8 +8,8 @@ func.func @Types(%arg0: !arc.arrayref<2xi32>) -> !arc.arrayref<2xi32> {
 }
 
 // CHECK-LABEL: @StorageGet
-func.func @StorageGet(%arg0: !arc.storage<12>) -> !arc.state<!arc.arrayref<2xi32>> {
-  %0 = arc.storage.get %arg0[4] : !arc.storage<12> -> !arc.state<!arc.arrayref<2xi32>>
+func.func @StorageGet(%arg0: !arc.storage) -> !arc.state<!arc.arrayref<2xi32>> {
+  %0 = arc.storage.get %arg0[4] : !arc.storage -> !arc.state<!arc.arrayref<2xi32>>
   return %0 : !arc.state<!arc.arrayref<2xi32>>
 }
 

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -52,16 +52,16 @@ func.func @StorageTypes(%arg0: !arc.storage) -> (!arc.state<i1>, !arc.memory<4 x
 
 // CHECK-LABEL: llvm.func @StateAllocation(
 // CHECK-SAME:    %arg0: !llvm.ptr) {
-func.func @StateAllocation(%arg0: !arc.storage<10>) {
-  arc.root_input "a", %arg0 {offset = 0} : (!arc.storage<10>) -> !arc.state<i1>
+func.func @StateAllocation(%arg0: !arc.storage) {
+  arc.root_input "a", %arg0 {offset = 0} : (!arc.storage) -> !arc.state<i1>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[0]
-  arc.root_output "b", %arg0 {offset = 1} : (!arc.storage<10>) -> !arc.state<i2>
+  arc.root_output "b", %arg0 {offset = 1} : (!arc.storage) -> !arc.state<i2>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[1]
-  arc.alloc_state %arg0 {offset = 2} : (!arc.storage<10>) -> !arc.state<i3>
+  arc.alloc_state %arg0 {offset = 2} : (!arc.storage) -> !arc.state<i3>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[2]
-  arc.alloc_memory %arg0 {offset = 3, stride = 1} : (!arc.storage<10>) -> !arc.memory<4 x i1, i2>
+  arc.alloc_memory %arg0 {offset = 3, stride = 1} : (!arc.storage) -> !arc.memory<4 x i1, i2>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[3]
-  arc.alloc_storage %arg0[7] : (!arc.storage<10>) -> !arc.storage<3>
+  arc.alloc_storage %arg0[7], 3
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[7]
   return
   // CHECK-NEXT: llvm.return
@@ -70,8 +70,8 @@ func.func @StateAllocation(%arg0: !arc.storage<10>) {
 
 // CHECK-LABEL: llvm.func @StateUpdates(
 // CHECK-SAME:    %arg0: !llvm.ptr) {
-func.func @StateUpdates(%arg0: !arc.storage<1>) {
-  %0 = arc.alloc_state %arg0 {offset = 0} : (!arc.storage<1>) -> !arc.state<i1>
+func.func @StateUpdates(%arg0: !arc.storage) {
+  %0 = arc.alloc_state %arg0 {offset = 0} : (!arc.storage) -> !arc.state<i1>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[0]
   %1 = arc.state_read %0 : <i1>
   // CHECK-NEXT: [[LOAD:%.+]] = llvm.load [[PTR]] : !llvm.ptr -> i1
@@ -84,8 +84,8 @@ func.func @StateUpdates(%arg0: !arc.storage<1>) {
 
 // CHECK-LABEL: llvm.func @MemoryUpdates(
 // CHECK-SAME:    %arg0: !llvm.ptr, %arg1: i1) {
-func.func @MemoryUpdates(%arg0: !arc.storage<24>, %enable: i1) {
-  %0 = arc.alloc_memory %arg0 {offset = 0, stride = 6} : (!arc.storage<24>) -> !arc.memory<4 x i42, i19>
+func.func @MemoryUpdates(%arg0: !arc.storage, %enable: i1) {
+  %0 = arc.alloc_memory %arg0 {offset = 0, stride = 6} : (!arc.storage) -> !arc.memory<4 x i42, i19>
   // CHECK-NEXT: [[PTR:%.+]] = llvm.getelementptr %arg0[0]
 
   %clk = hw.constant true
@@ -299,11 +299,11 @@ func.func private @Dummy(%arg0: i42, %arg1: !hw.array<4xi19>, %arg2: !arc.storag
 // CHECK-LABEL: llvm.func @Time
 // CHECK-SAME: (%arg0: !llvm.ptr)
 // CHECK-SAME: -> !llvm.struct<(i64, i64, i64)>
-func.func @Time(%arg0: !arc.storage<42>) -> (i64, !llhd.time, i64) {
+func.func @Time(%arg0: !arc.storage) -> (i64, !llhd.time, i64) {
   // CHECK-NEXT: [[TIME:%.+]] = llvm.load %arg0 : !llvm.ptr -> i64
   // CHECK-NOT: int_to_time
   // CHECK-NOT: time_to_int
-  %0 = arc.current_time %arg0 : !arc.storage<42>
+  %0 = arc.current_time %arg0 : !arc.storage
   %1 = llhd.int_to_time %0
   %2 = llhd.time_to_int %1
   // CHECK-NEXT: [[TMP1:%.+]] = llvm.mlir.poison : !llvm.struct<(i64, i64, i64)>
@@ -330,13 +330,13 @@ func.func @ConstantTime() -> (!llhd.time, !llhd.time, !llhd.time) {
 
 // CHECK-LABEL: llvm.func @NextWakeup
 // CHECK-SAME: (%[[STATE:.*]]: !llvm.ptr, %[[T:.*]]: i64)
-func.func @NextWakeup(%state: !arc.storage<42>, %t: i64) -> i64 {
+func.func @NextWakeup(%state: !arc.storage, %t: i64) -> i64 {
   // CHECK-NEXT: %[[WGEP:.*]] = llvm.getelementptr %[[STATE]][16] : (!llvm.ptr) -> !llvm.ptr, i8
   // CHECK-NEXT: llvm.store %[[T]], %[[WGEP]] : i64, !llvm.ptr
-  arc.set_next_wakeup %state, %t : !arc.storage<42>
+  arc.set_next_wakeup %state, %t : !arc.storage
   // CHECK-NEXT: %[[RGEP:.*]] = llvm.getelementptr %[[STATE]][16] : (!llvm.ptr) -> !llvm.ptr, i8
   // CHECK-NEXT: %[[OUT:.*]] = llvm.load %[[RGEP]] : !llvm.ptr -> i64
-  %0 = arc.get_next_wakeup %state : !arc.storage<42>
+  %0 = arc.get_next_wakeup %state : !arc.storage
   // CHECK-NEXT: llvm.return %[[OUT]]
   return %0 : i64
 }

--- a/test/Dialect/Arc/Export/info-gathering-errors.mlir
+++ b/test/Dialect/Arc/Export/info-gathering-errors.mlir
@@ -1,50 +1,56 @@
 // RUN: circt-translate %s --export-arc-model-info --split-input-file --verify-diagnostics
 
-arc.model @Foo io !hw.modty<> {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 {
+^bb0(%arg0: !arc.storage):
   // expected-error @below {{'arc.alloc_storage' op without allocated offset}}
-  arc.alloc_storage %arg0 : (!arc.storage<42>) -> !arc.storage<42>
+  arc.alloc_storage %arg0, 42
 }
 
 // -----
-arc.model @Foo io !hw.modty<> {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 {
+^bb0(%arg0: !arc.storage):
   // ignore unnamed
-  arc.alloc_state %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+  arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
   // expected-error @below {{'arc.alloc_state' op without allocated offset}}
-  arc.alloc_state %arg0 {name = "foo"} : (!arc.storage<42>) -> !arc.state<i1>
+  arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i1>
 }
 
 // -----
-arc.model @Foo io !hw.modty<input foo : i1> {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<input foo : i1> storageBytes 42 {
+^bb0(%arg0: !arc.storage):
   // ignore unnamed
-  arc.root_input "", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+  arc.root_input "", %arg0 : (!arc.storage) -> !arc.state<i1>
   // expected-error @below {{'arc.root_input' op without allocated offset}}
-  arc.root_input "foo", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+  arc.root_input "foo", %arg0 : (!arc.storage) -> !arc.state<i1>
 }
 
 // -----
-arc.model @Foo io !hw.modty<output foo : i1> {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<output foo : i1> storageBytes 42 {
+^bb0(%arg0: !arc.storage):
   // ignore unnamed
-  arc.root_output "", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+  arc.root_output "", %arg0 : (!arc.storage) -> !arc.state<i1>
   // expected-error @below {{'arc.root_output' op without allocated offset}}
-  arc.root_output "foo", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
+  arc.root_output "foo", %arg0 : (!arc.storage) -> !arc.state<i1>
 }
 
 // -----
-arc.model @Foo io !hw.modty<> {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 {
+^bb0(%arg0: !arc.storage):
   // ignore unnamed
-  arc.alloc_memory %arg0 : (!arc.storage<42>) -> !arc.memory<4 x i1, i2>
+  arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i1, i2>
   // expected-error @below {{'arc.alloc_memory' op without allocated offset}}
-  arc.alloc_memory %arg0 {name = "foo"} : (!arc.storage<42>) -> !arc.memory<4 x i1, i2>
+  arc.alloc_memory %arg0 {name = "foo"} : (!arc.storage) -> !arc.memory<4 x i1, i2>
 }
 
 // -----
-arc.model @Foo io !hw.modty<> {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 {
+^bb0(%arg0: !arc.storage):
   // expected-error @below {{'arc.alloc_memory' op without allocated stride}}
-  arc.alloc_memory %arg0 {name = "foo", offset = 8} : (!arc.storage<42>) -> !arc.memory<4 x i1, i2>
+  arc.alloc_memory %arg0 {name = "foo", offset = 8} : (!arc.storage) -> !arc.memory<4 x i1, i2>
+}
+
+// -----
+// expected-error @below {{'arc.model' op missing `storageBytes` attribute}}
+arc.model @Foo io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
 }

--- a/test/Dialect/Arc/Export/serialize-state-info.mlir
+++ b/test/Dialect/Arc/Export/serialize-state-info.mlir
@@ -2,33 +2,33 @@
 
 // CHECK-LABEL: "name": "Foo"
 // CHECK-DAG: "numStateBytes": 5724
-arc.model @Foo io !hw.modty<input a : i19, output b : i42> {
-^bb0(%arg0: !arc.storage<5724>):
+arc.model @Foo io !hw.modty<input a : i19, output b : i42> storageBytes 5724 {
+^bb0(%arg0: !arc.storage):
   // CHECK:      "name": "a"
   // CHECK-NEXT: "offset": 0
   // CHECK-NEXT: "numBits": 19
   // CHECK-NEXT: "type": "input"
-  arc.root_input "a", %arg0 {offset = 0} : (!arc.storage<5724>) -> !arc.state<i19>
+  arc.root_input "a", %arg0 {offset = 0} : (!arc.storage) -> !arc.state<i19>
 
   // CHECK:      "name": "b"
   // CHECK-NEXT: "offset": 16
   // CHECK-NEXT: "numBits": 42
   // CHECK-NEXT: "type": "output"
-  arc.root_output "b", %arg0 {offset = 16} : (!arc.storage<5724>) -> !arc.state<i42>
+  arc.root_output "b", %arg0 {offset = 16} : (!arc.storage) -> !arc.state<i42>
 }
 
 // CHECK-LABEL: "name": "Bar"
 // CHECK-DAG: "numStateBytes": 9001
-arc.model @Bar io !hw.modty<> {
-^bb0(%arg0: !arc.storage<9001>):
+arc.model @Bar io !hw.modty<> storageBytes 9001  {
+^bb0(%arg0: !arc.storage):
   // CHECK-NOT: "offset": "420"
-  arc.alloc_state %arg0 {offset = 420} : (!arc.storage<9001>) -> !arc.state<i11>
+  arc.alloc_state %arg0 {offset = 420} : (!arc.storage) -> !arc.state<i11>
 
   // CHECK:      "name": "x"
   // CHECK-NEXT: "offset": 24
   // CHECK-NEXT: "numBits": 63
   // CHECK-NEXT: "type": "register"
-  arc.alloc_state %arg0 {name = "x", offset = 24} : (!arc.storage<9001>) -> !arc.state<i63>
+  arc.alloc_state %arg0 {name = "x", offset = 24} : (!arc.storage) -> !arc.state<i63>
 
   // CHECK:      "name": "y"
   // CHECK-NEXT: "offset": 48
@@ -36,21 +36,21 @@ arc.model @Bar io !hw.modty<> {
   // CHECK-NEXT: "type": "memory"
   // CHECK-NEXT: "stride": 3
   // CHECK-NEXT: "depth": 5
-  arc.alloc_memory %arg0 {name = "y", offset = 48, stride = 3} : (!arc.storage<9001>) -> !arc.memory<5 x i17, i3>
+  arc.alloc_memory %arg0 {name = "y", offset = 48, stride = 3} : (!arc.storage) -> !arc.memory<5 x i17, i3>
 
   // CHECK:      "name": "z"
   // CHECK-NEXT: "offset": 92
   // CHECK-NEXT: "numBits": 1337
   // CHECK-NEXT: "type": "wire"
-  arc.alloc_state %arg0 tap {name = "z", offset = 92} : (!arc.storage<9001>) -> !arc.state<i1337>
+  arc.alloc_state %arg0 tap {name = "z", offset = 92} : (!arc.storage) -> !arc.state<i1337>
 }
 
 // CHECK-LABEL: "name": "Alpha"
 // CHECK: "initialFnSym": "AlphaInitialize"
 // CHECK: "finalFnSym": "AlphaFinalize"
-arc.model @Alpha io !hw.modty<> initializer @AlphaInitialize finalizer @AlphaFinalize {
-^bb0(%arg0: !arc.storage<1>):
+arc.model @Alpha io !hw.modty<> storageBytes 4 initializer @AlphaInitialize finalizer @AlphaFinalize {
+^bb0(%arg0: !arc.storage):
 }
 
-func.func private @AlphaInitialize(!arc.storage<1>)
-func.func private @AlphaFinalize(!arc.storage<1>)
+func.func private @AlphaInitialize(!arc.storage)
+func.func private @AlphaFinalize(!arc.storage)

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -2,16 +2,17 @@
 // RUN: circt-opt %s --arc-allocate-state=trace-taps=true  | FileCheck %s --check-prefixes=CHECK,TAPS
 
 // CHECK-LABEL: arc.model @test
+// CHECK-SAME:  storageBytes 5815
 // NOTAPS-NOT:  traceTaps
 // TAPS-SAME:   traceTaps [#arc.trace_tap<i16, 0, ["foo", "bar"]>, #arc.trace_tap<i1, 2, ["baz"]>]
-arc.model @test io !hw.modty<input x : i1, output y : i1> {
+arc.model @test io !hw.modty<input x : i1, output y : i1> storageBytes 5815 {
 ^bb0(%arg0: !arc.storage):
-  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5815>):
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage):
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][32] : (!arc.storage<5815>) -> !arc.storage<1159>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][32], 1159
   // CHECK-NEXT: arc.initial {
   arc.initial {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][32] : !arc.storage<5815> -> !arc.storage<1159>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][32] : !arc.storage -> !arc.storage
     %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i8>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i16>
@@ -31,11 +32,11 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
     // CHECK-NEXT: scf.execute_region {
     scf.execute_region {
       arc.state_read %0 : <i1>
-      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][32] : !arc.storage<5815> -> !arc.storage<1159>
-      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][0] : !arc.storage<1159> -> !arc.state<i1>
+      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][32] : !arc.storage -> !arc.storage
+      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][0] : !arc.storage -> !arc.state<i1>
       // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
       arc.state_read %1 : <i1>
-      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][1158] : !arc.storage<1159> -> !arc.state<i1>
+      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][1158] : !arc.storage -> !arc.state<i1>
       // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
       scf.yield
       // CHECK-NEXT: scf.yield
@@ -44,10 +45,10 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][1200] : (!arc.storage<5815>) -> !arc.storage<4609>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][1200], 4609
   // CHECK-NEXT: arc.initial {
   arc.initial {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1200] : !arc.storage<5815> -> !arc.storage<4609>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1200] : !arc.storage -> !arc.storage
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i1, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i8, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i16, i1>
@@ -71,18 +72,18 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage %arg0[5810] : (!arc.storage<5815>) -> !arc.storage<2>
+  // CHECK-NEXT: arc.alloc_storage %arg0[5810], 2
   // CHECK-NEXT: arc.initial {
   arc.initial {
     arc.root_input "x", %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.root_output "y", %arg0 : (!arc.storage) -> !arc.state<i1>
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5810] : !arc.storage<5815> -> !arc.storage<2>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5810] : !arc.storage -> !arc.storage
     // CHECK-NEXT: arc.root_input "x", [[SUBPTR]] {offset = 0 : i32}
     // CHECK-NEXT: arc.root_output "y", [[SUBPTR]] {offset = 1 : i32}
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][5812] : (!arc.storage<5815>) -> !arc.storage<3>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][5812], 3
   // CHECK-NEXT: arc.initial {
   arc.initial {
     %cstCAFE = hw.constant 0xCAFE: i16
@@ -102,7 +103,7 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
 }
 
 // CHECK-LABEL: arc.model @StructPadding
-// CHECK-NEXT: !arc.storage<28>
+// CHECK-NEXT: !arc.storage
 arc.model @StructPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // This !hw.struct is only 19 bits wide, but mapped to an !llvm.struct, each
@@ -111,7 +112,7 @@ arc.model @StructPadding io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @ArrayPadding
-// CHECK-NEXT: !arc.storage<28>
+// CHECK-NEXT: !arc.storage
 arc.model @ArrayPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // This !hw.array is only 18 bits wide, but mapped to an !llvm.array, each
@@ -120,7 +121,7 @@ arc.model @ArrayPadding io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @UnionMaxVariant
-// CHECK-NEXT: !arc.storage<32>
+// CHECK-NEXT: !arc.storage
 arc.model @UnionMaxVariant io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // A !hw.union is sized by its largest variant, not the sum of its variants,
@@ -129,7 +130,7 @@ arc.model @UnionMaxVariant io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @UnionVariantPadding
-// CHECK-NEXT: !arc.storage<26>
+// CHECK-NEXT: !arc.storage
 arc.model @UnionVariantPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // Like struct fields and array elements, each variant is widened to a byte
@@ -138,7 +139,7 @@ arc.model @UnionVariantPadding io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @UnionOffset
-// CHECK-NEXT: !arc.storage<41>
+// CHECK-NEXT: !arc.storage
 arc.model @UnionOffset io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // An explicit per-variant bit offset is honored when sizing the union: the
@@ -147,7 +148,7 @@ arc.model @UnionOffset io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @UnionNested
-// CHECK-NEXT: !arc.storage<28>
+// CHECK-NEXT: !arc.storage
 arc.model @UnionNested io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // Variant widths are computed recursively, so the larger struct variant of

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -5,7 +5,7 @@
 // CHECK-SAME:  storageBytes 5815
 // NOTAPS-NOT:  traceTaps
 // TAPS-SAME:   traceTaps [#arc.trace_tap<i16, 0, ["foo", "bar"]>, #arc.trace_tap<i1, 2, ["baz"]>]
-arc.model @test io !hw.modty<input x : i1, output y : i1> storageBytes 5815 {
+arc.model @test io !hw.modty<input x : i1, output y : i1> {
 ^bb0(%arg0: !arc.storage):
   // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage):
 
@@ -103,7 +103,7 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> storageBytes 5815 {
 }
 
 // CHECK-LABEL: arc.model @StructPadding
-// CHECK-NEXT: !arc.storage
+// CHECK-SAME:  storageBytes 28
 arc.model @StructPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // This !hw.struct is only 19 bits wide, but mapped to an !llvm.struct, each
@@ -112,7 +112,7 @@ arc.model @StructPadding io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @ArrayPadding
-// CHECK-NEXT: !arc.storage
+// CHECK-SAME:  storageBytes 28
 arc.model @ArrayPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // This !hw.array is only 18 bits wide, but mapped to an !llvm.array, each
@@ -121,7 +121,7 @@ arc.model @ArrayPadding io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @UnionMaxVariant
-// CHECK-NEXT: !arc.storage
+// CHECK-SAME:  storageBytes 32
 arc.model @UnionMaxVariant io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // A !hw.union is sized by its largest variant, not the sum of its variants,
@@ -130,7 +130,7 @@ arc.model @UnionMaxVariant io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @UnionVariantPadding
-// CHECK-NEXT: !arc.storage
+// CHECK-SAME:  storageBytes 26
 arc.model @UnionVariantPadding io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // Like struct fields and array elements, each variant is widened to a byte
@@ -139,7 +139,7 @@ arc.model @UnionVariantPadding io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @UnionOffset
-// CHECK-NEXT: !arc.storage
+// CHECK-SAME:  storageBytes 41
 arc.model @UnionOffset io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // An explicit per-variant bit offset is honored when sizing the union: the
@@ -148,10 +148,17 @@ arc.model @UnionOffset io !hw.modty<> {
 }
 
 // CHECK-LABEL: arc.model @UnionNested
-// CHECK-NEXT: !arc.storage
+// CHECK-SAME:  storageBytes 28
 arc.model @UnionNested io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   // Variant widths are computed recursively, so the larger struct variant of
   // two i16 fields determines the 4-byte size.
   arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.union<x: !hw.struct<a: i16, b: i16>, y: i8>>
+}
+
+// Check that we always allocate some bytes for the header
+// CHECK-LABEL: arc.model @HeaderOnly
+// CHECK-SAME:  storageBytes {{[1-9]}}
+arc.model @HeaderOnly io !hw.modty<> {
+  ^bb0(%arg0: !arc.storage):
 }

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -438,21 +438,21 @@ func.func @InvalidStateType(%arg0: !arc.state<index>)
 
 // expected-error @below {{initializer 'Bar' does not reference a valid function}}
 arc.model @Foo io !hw.modty<> initializer @Bar {
-^bb0(%arg0: !arc.storage<42>):
+^bb0(%arg0: !arc.storage):
 }
 
 // -----
 
 // expected-error @below {{finalizer 'Bar' does not reference a valid function}}
-arc.model @Foo io !hw.modty<> finalizer @Bar {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 finalizer @Bar {
+^bb0(%arg0: !arc.storage):
 }
 
 // -----
 
 // expected-error @below {{initializer 'Bar' does not reference a valid function}}
-arc.model @Foo io !hw.modty<> initializer @Bar {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 initializer @Bar {
+^bb0(%arg0: !arc.storage):
 }
 hw.module @Bar() {
 }
@@ -460,8 +460,8 @@ hw.module @Bar() {
 // -----
 
 // expected-error @below {{finalizer 'Bar' does not reference a valid function}}
-arc.model @Foo io !hw.modty<> finalizer @Bar {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 finalizer @Bar {
+^bb0(%arg0: !arc.storage):
 }
 hw.module @Bar() {
 }
@@ -469,26 +469,26 @@ hw.module @Bar() {
 // -----
 
 // expected-error @below {{initializer 'Bar' arguments must match arguments of model}}
-arc.model @Foo io !hw.modty<> initializer @Bar {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 initializer @Bar {
+^bb0(%arg0: !arc.storage):
 }
 
 // expected-note @below {{initializer declared here:}}
-func.func @Bar(!arc.storage<24>) {
-^bb0(%arg0: !arc.storage<24>):
+func.func @Bar(!arc.state<i1>) {
+^bb0(%arg0: !arc.state<i1>):
   return
 }
 
 // -----
 
 // expected-error @below {{finalizer 'Bar' arguments must match arguments of model}}
-arc.model @Foo io !hw.modty<> finalizer @Bar {
-^bb0(%arg0: !arc.storage<42>):
+arc.model @Foo io !hw.modty<> storageBytes 42 finalizer @Bar {
+^bb0(%arg0: !arc.storage):
 }
 
 // expected-note @below {{finalizer declared here:}}
-func.func @Bar(!arc.storage<24>) {
-^bb0(%arg0: !arc.storage<24>):
+func.func @Bar(!arc.state<i1>) {
+^bb0(%arg0: !arc.state<i1>):
   return
 }
 

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -55,13 +55,13 @@ arc.define @LookupTable(%arg0: i32, %arg1: i8) -> () {
 }
 
 // CHECK-LABEL: func.func @StorageAccess
-func.func @StorageAccess(%arg0: !arc.storage<10000>) {
-  // CHECK-NEXT: arc.storage.get %arg0[42] : !arc.storage<10000> -> !arc.state<i9>
-  // CHECK-NEXT: arc.storage.get %arg0[1337] : !arc.storage<10000> -> !arc.memory<4 x i19, i32>
-  // CHECK-NEXT: arc.storage.get %arg0[9001] : !arc.storage<10000> -> !arc.storage<123>
-  %0 = arc.storage.get %arg0[42] : !arc.storage<10000> -> !arc.state<i9>
-  %1 = arc.storage.get %arg0[1337] : !arc.storage<10000> -> !arc.memory<4 x i19, i32>
-  %2 = arc.storage.get %arg0[9001] : !arc.storage<10000> -> !arc.storage<123>
+func.func @StorageAccess(%arg0: !arc.storage) {
+  // CHECK-NEXT: arc.storage.get %arg0[42] : !arc.storage -> !arc.state<i9>
+  // CHECK-NEXT: arc.storage.get %arg0[1337] : !arc.storage -> !arc.memory<4 x i19, i32>
+  // CHECK-NEXT: arc.storage.get %arg0[9001] : !arc.storage -> !arc.storage
+  %0 = arc.storage.get %arg0[42] : !arc.storage -> !arc.state<i9>
+  %1 = arc.storage.get %arg0[1337] : !arc.storage -> !arc.memory<4 x i19, i32>
+  %2 = arc.storage.get %arg0[9001] : !arc.storage -> !arc.storage
   return
 }
 
@@ -348,18 +348,18 @@ func.func @Execute(%arg0: i42) {
 }
 
 // CHECK-LABEL: func.func @CurrentTime
-func.func @CurrentTime(%arg0: !arc.storage<100>) {
-  // CHECK-NEXT: arc.current_time %arg0 : !arc.storage<100>
-  %0 = arc.current_time %arg0 : !arc.storage<100>
+func.func @CurrentTime(%arg0: !arc.storage) {
+  // CHECK-NEXT: arc.current_time %arg0 : !arc.storage
+  %0 = arc.current_time %arg0 : !arc.storage
   return
 }
 
 // CHECK-LABEL: func.func @NextWakeup
-func.func @NextWakeup(%arg0: !arc.storage<100>, %arg1: i64) {
-  // CHECK-NEXT: arc.get_next_wakeup %arg0 : !arc.storage<100>
-  %0 = arc.get_next_wakeup %arg0 : !arc.storage<100>
-  // CHECK-NEXT: arc.set_next_wakeup %arg0, %arg1 : !arc.storage<100>
-  arc.set_next_wakeup %arg0, %arg1 : !arc.storage<100>
+func.func @NextWakeup(%arg0: !arc.storage, %arg1: i64) {
+  // CHECK-NEXT: arc.get_next_wakeup %arg0 : !arc.storage
+  %0 = arc.get_next_wakeup %arg0 : !arc.storage
+  // CHECK-NEXT: arc.set_next_wakeup %arg0, %arg1 : !arc.storage
+  arc.set_next_wakeup %arg0, %arg1 : !arc.storage
   return
 }
 

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -73,14 +73,14 @@ arc.define @Passthrough2(%arg0: i32, %arg1: i32) -> (i32, i32) {
 // CHECK-LABEL: arc.model @StorageGetCanonicalizers
 arc.model @StorageGetCanonicalizers io !hw.modty<> {
 // CHECK-NEXT: ^bb
-^bb0(%arg0: !arc.storage<512>):
-  %0 = arc.storage.get %arg0[16] : !arc.storage<512> -> !arc.storage<16>
-  %1 = arc.storage.get %0[0] : !arc.storage<16> -> !arc.state<i64>
-  %2 = arc.storage.get %0[8] : !arc.storage<16> -> !arc.state<i64>
+^bb0(%arg0: !arc.storage):
+  %0 = arc.storage.get %arg0[16] : !arc.storage -> !arc.storage
+  %1 = arc.storage.get %0[0] : !arc.storage -> !arc.state<i64>
+  %2 = arc.storage.get %0[8] : !arc.storage -> !arc.state<i64>
   %3 = arc.state_read %1 : <i64>
   arc.state_write %2 = %3 : <i64>
-  // CHECK-NEXT: [[V0:%.+]] = arc.storage.get %arg0[16] : !arc.storage<512> -> !arc.state<i64>
-  // CHECK-NEXT: [[V1:%.+]] = arc.storage.get %arg0[24] : !arc.storage<512> -> !arc.state<i64>
+  // CHECK-NEXT: [[V0:%.+]] = arc.storage.get %arg0[16] : !arc.storage -> !arc.state<i64>
+  // CHECK-NEXT: [[V1:%.+]] = arc.storage.get %arg0[24] : !arc.storage -> !arc.state<i64>
   // CHECK-NEXT: [[V2:%.+]] = arc.state_read [[V0]] : <i64>
   // CHECK-NEXT: arc.state_write [[V1]] = [[V2]] : <i64>
 }

--- a/test/Dialect/Arc/insert-runtime.mlir
+++ b/test/Dialect/Arc/insert-runtime.mlir
@@ -8,29 +8,29 @@
 
 arc.runtime.model @noTouchy "dontTouch" numStateBytes 4
 
-arc.model @counter io !hw.modty<input clk : i1, output o : i8> {
-^bb0(%arg0: !arc.storage<4>):
+arc.model @counter io !hw.modty<input clk : i1, output o : i8> storageBytes 4 {
+^bb0(%arg0: !arc.storage):
     %c1_i8 = hw.constant 1 : i8
-    %in_clk = arc.root_input "clk", %arg0 {offset = 0 : i32} : (!arc.storage<4>) -> !arc.state<i1>
-    %0 = arc.alloc_state %arg0 {offset = 1 : i32} : (!arc.storage<4>) -> !arc.state<i8>
-    %1 = arc.alloc_state %arg0 {offset = 2 : i32} : (!arc.storage<4>) -> !arc.state<i1>
-    %out_o = arc.root_output "o", %arg0 {offset = 3 : i32} : (!arc.storage<4>) -> !arc.state<i8>
-    %2 = arc.storage.get %arg0[0] : !arc.storage<4> -> !arc.state<i1>
+    %in_clk = arc.root_input "clk", %arg0 {offset = 0 : i32} : (!arc.storage) -> !arc.state<i1>
+    %0 = arc.alloc_state %arg0 {offset = 1 : i32} : (!arc.storage) -> !arc.state<i8>
+    %1 = arc.alloc_state %arg0 {offset = 2 : i32} : (!arc.storage) -> !arc.state<i1>
+    %out_o = arc.root_output "o", %arg0 {offset = 3 : i32} : (!arc.storage) -> !arc.state<i8>
+    %2 = arc.storage.get %arg0[0] : !arc.storage -> !arc.state<i1>
     %3 = arc.state_read %2 : <i1>
-    %4 = arc.storage.get %arg0[2] : !arc.storage<4> -> !arc.state<i1>
+    %4 = arc.storage.get %arg0[2] : !arc.storage -> !arc.state<i1>
     %5 = arc.state_read %4 : <i1>
     arc.state_write %4 = %3 : <i1>
     %6 = comb.xor %5, %3 : i1
     %7 = comb.and %6, %3 : i1
     scf.if %7 {
-        %11 = arc.storage.get %arg0[1] : !arc.storage<4> -> !arc.state<i8>
+        %11 = arc.storage.get %arg0[1] : !arc.storage -> !arc.state<i8>
         %12 = arc.state_read %11 : <i8>
         %13 = comb.add %12, %c1_i8 : i8
         arc.state_write %11 = %13 : <i8>
     }
-    %8 = arc.storage.get %arg0[1] : !arc.storage<4> -> !arc.state<i8>
+    %8 = arc.storage.get %arg0[1] : !arc.storage -> !arc.state<i8>
     %9 = arc.state_read %8 : <i8>
-    %10 = arc.storage.get %arg0[3] : !arc.storage<4> -> !arc.state<i8>
+    %10 = arc.storage.get %arg0[3] : !arc.storage -> !arc.state<i8>
     arc.state_write %10 = %9 : <i8>
 }
 
@@ -87,28 +87,28 @@ func.func @main() {
 // CHECK: arc.runtime.model @arcRuntimeModel_counter "counter" numStateBytes 4
 // CHECK-NOT: llvm.func @arcRuntimeIR_
 
-arc.model @counter io !hw.modty<input clk : i1, output o : i8> {
-^bb0(%arg0: !arc.storage<4>):
+arc.model @counter io !hw.modty<input clk : i1, output o : i8> storageBytes 4 {
+^bb0(%arg0: !arc.storage):
     %c1_i8 = hw.constant 1 : i8
-    %in_clk = arc.root_input "clk", %arg0 {offset = 0 : i32} : (!arc.storage<4>) -> !arc.state<i1>
-    %0 = arc.alloc_state %arg0 {offset = 1 : i32} : (!arc.storage<4>) -> !arc.state<i8>
-    %1 = arc.alloc_state %arg0 {offset = 2 : i32} : (!arc.storage<4>) -> !arc.state<i1>
-    %out_o = arc.root_output "o", %arg0 {offset = 3 : i32} : (!arc.storage<4>) -> !arc.state<i8>
-    %2 = arc.storage.get %arg0[0] : !arc.storage<4> -> !arc.state<i1>
+    %in_clk = arc.root_input "clk", %arg0 {offset = 0 : i32} : (!arc.storage) -> !arc.state<i1>
+    %0 = arc.alloc_state %arg0 {offset = 1 : i32} : (!arc.storage) -> !arc.state<i8>
+    %1 = arc.alloc_state %arg0 {offset = 2 : i32} : (!arc.storage) -> !arc.state<i1>
+    %out_o = arc.root_output "o", %arg0 {offset = 3 : i32} : (!arc.storage) -> !arc.state<i8>
+    %2 = arc.storage.get %arg0[0] : !arc.storage -> !arc.state<i1>
     %3 = arc.state_read %2 : <i1>
-    %4 = arc.storage.get %arg0[2] : !arc.storage<4> -> !arc.state<i1>
+    %4 = arc.storage.get %arg0[2] : !arc.storage -> !arc.state<i1>
     %5 = arc.state_read %4 : <i1>
     arc.state_write %4 = %3 : <i1>
     %6 = comb.xor %5, %3 : i1
     %7 = comb.and %6, %3 : i1
     scf.if %7 {
-        %11 = arc.storage.get %arg0[1] : !arc.storage<4> -> !arc.state<i8>
+        %11 = arc.storage.get %arg0[1] : !arc.storage -> !arc.state<i8>
         %12 = arc.state_read %11 : <i8>
         %13 = comb.add %12, %c1_i8 : i8
         arc.state_write %11 = %13 : <i8>
     }
-    %8 = arc.storage.get %arg0[1] : !arc.storage<4> -> !arc.state<i8>
+    %8 = arc.storage.get %arg0[1] : !arc.storage -> !arc.state<i8>
     %9 = arc.state_read %8 : <i8>
-    %10 = arc.storage.get %arg0[3] : !arc.storage<4> -> !arc.state<i8>
+    %10 = arc.storage.get %arg0[3] : !arc.storage -> !arc.state<i8>
     arc.state_write %10 = %9 : <i8>
 }

--- a/test/Dialect/Arc/lower-arrays.mlir
+++ b/test/Dialect/Arc/lower-arrays.mlir
@@ -92,10 +92,10 @@ func.func @test_array_create(%a: i32, %b: i32) -> !hw.array<2xi32> {
 
 // CHECK-LABEL: func.func @test_storage_get
 // CHECK-SAME: -> !arc.state<!arc.arrayref<2xi32>>
-// CHECK-NEXT: %0 = arc.storage.get %arg0[0] : !arc.storage<8> -> !arc.state<!arc.arrayref<2xi32>>
+// CHECK-NEXT: %0 = arc.storage.get %arg0[0] : !arc.storage -> !arc.state<!arc.arrayref<2xi32>>
 // CHECK-NEXT: return %0 : !arc.state<!arc.arrayref<2xi32>>
-func.func @test_storage_get(%a: !arc.storage<8>) -> !arc.state<!hw.array<2xi32>> {
-  %0 = arc.storage.get %a[0] : !arc.storage<8> -> !arc.state<!hw.array<2xi32>>
+func.func @test_storage_get(%a: !arc.storage) -> !arc.state<!hw.array<2xi32>> {
+  %0 = arc.storage.get %a[0] : !arc.storage -> !arc.state<!hw.array<2xi32>>
   return %0 : !arc.state<!hw.array<2xi32>>
 }
 
@@ -109,9 +109,9 @@ func.func @test_mux(%a: !hw.array<2xi32>, %b: !hw.array<2xi32>, %c: i1) -> !hw.a
 }
 
 // CHECK-LABEL: func.func @test_alloc_state
-// CHECK: arc.alloc_state %arg0 : (!arc.storage<8>) -> !arc.state<!arc.arrayref<2xi32>>
-func.func @test_alloc_state(%arg0: !arc.storage<8>) -> !arc.state<!hw.array<2xi32>> {
-  %0 = arc.alloc_state %arg0 : (!arc.storage<8>) -> !arc.state<!hw.array<2xi32>>
+// CHECK: arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!arc.arrayref<2xi32>>
+func.func @test_alloc_state(%arg0: !arc.storage) -> !arc.state<!hw.array<2xi32>> {
+  %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!hw.array<2xi32>>
   return %0 : !arc.state<!hw.array<2xi32>>
 }
 

--- a/test/Dialect/Arc/lower-clocks-to-funcs-errors.mlir
+++ b/test/Dialect/Arc/lower-clocks-to-funcs-errors.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --arc-lower-clocks-to-funcs --split-input-file --verify-diagnostics
 
 arc.model @NonConstExternalValue io !hw.modty<> {
-^bb0(%arg0: !arc.storage<42>):
+^bb0(%arg0: !arc.storage):
   %c0_i9001 = hw.constant 0 : i9001
   // expected-note @+1 {{external value defined here:}}
   %0 = comb.add %c0_i9001, %c0_i9001 : i9001
@@ -15,12 +15,12 @@ arc.model @NonConstExternalValue io !hw.modty<> {
 
 // -----
 
-func.func private @Victim(!arc.storage<42>)
+func.func private @Victim(!arc.storage)
 
 // expected-warning @below {{Existing model initializer 'Victim' will be overridden.}}
 // expected-warning @below {{Existing model finalizer 'Victim' will be overridden.}}
 arc.model @ExistingInitializerAndFinalizer io !hw.modty<> initializer @Victim finalizer @Victim {
-^bb0(%arg0: !arc.storage<42>):
+^bb0(%arg0: !arc.storage):
   arc.initial {}
   arc.final {}
 }
@@ -30,7 +30,7 @@ arc.model @ExistingInitializerAndFinalizer io !hw.modty<> initializer @Victim fi
 // expected-error @below {{op containing multiple InitialOps is currently unsupported.}}
 // expected-error @below {{op containing multiple FinalOps is currently unsupported.}}
 arc.model @MultiInitAndPassThrough io !hw.modty<> {
-^bb0(%arg0: !arc.storage<1>):
+^bb0(%arg0: !arc.storage):
   // expected-note @below {{Conflicting InitialOp:}}
   arc.initial {}
   // expected-note @below {{Conflicting FinalOp:}}

--- a/test/Dialect/Arc/lower-clocks-to-funcs.mlir
+++ b/test/Dialect/Arc/lower-clocks-to-funcs.mlir
@@ -1,12 +1,12 @@
 // RUN: circt-opt %s --arc-lower-clocks-to-funcs --verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL: func.func @Trivial_initial(%arg0: !arc.storage<42>) {
+// CHECK-LABEL: func.func @Trivial_initial(%arg0: !arc.storage) {
 // CHECK-NEXT:    [[TMP:%.+]] = hw.constant 9002
 // CHECK-NEXT:    call @DummyB([[TMP]]) {b}
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func.func @Trivial_final(%arg0: !arc.storage<42>) {
+// CHECK-LABEL: func.func @Trivial_final(%arg0: !arc.storage) {
 // CHECK-NEXT:    [[TMP:%.+]] = hw.constant 9003
 // CHECK-NEXT:    call @DummyB([[TMP]]) {c}
 // CHECK-NEXT:    return
@@ -17,13 +17,13 @@
 // CHECK-SAME:    initializer @Trivial_initial
 // CHECK-SAME:    finalizer @Trivial_final
 // CHECK-SAME:  {
-// CHECK-NEXT:  ^bb0(%arg0: !arc.storage<42>):
+// CHECK-NEXT:  ^bb0(%arg0: !arc.storage):
 // CHECK-NEXT:    [[TMP:%.+]] = hw.constant 9001
 // CHECK-NEXT:    call @DummyB([[TMP]]) {a}
 // CHECK-NEXT:  }
 
 arc.model @Trivial io !hw.modty<> {
-^bb0(%arg0: !arc.storage<42>):
+^bb0(%arg0: !arc.storage):
   %0 = hw.constant 9001 : i42
   %1 = hw.constant 9002 : i42
   %2 = hw.constant 9003 : i42

--- a/test/Dialect/Arc/trace-instrumentation.mlir
+++ b/test/Dialect/Arc/trace-instrumentation.mlir
@@ -1,17 +1,17 @@
 // RUN: circt-opt %s -arc-insert-runtime -lower-arc-to-llvm -canonicalize | FileCheck %s
 
-func.func @bar(%s: !arc.storage<17>, %v: i130) {
-  %s1 = arc.storage.get %s[4] : !arc.storage<17> -> !arc.state<i130>
+func.func @bar(%s: !arc.storage, %v: i130) {
+  %s1 = arc.storage.get %s[4] : !arc.storage -> !arc.state<i130>
   arc.state_write %s1 = %v tap @foo[1] : <i130>
   return
 }
 
-arc.model @foo io !hw.modty<> traceTaps [#arc.trace_tap<i32, 0, ["sig32"]>, #arc.trace_tap<i130, 4, ["sig130"]>] {
-  ^bb0(%arg0: !arc.storage<17>):
+arc.model @foo io !hw.modty<> storageBytes 17 traceTaps [#arc.trace_tap<i32, 0, ["sig32"]>, #arc.trace_tap<i130, 4, ["sig130"]>] {
+  ^bb0(%arg0: !arc.storage):
   %cst_i32 = hw.constant 123 : i32
   %cst_i130 = hw.constant -1 : i130
-  %s0 = arc.storage.get %arg0[0] : !arc.storage<17> -> !arc.state<i32>
-  func.call @bar(%arg0, %cst_i130): (!arc.storage<17>, i130) -> ()
+  %s0 = arc.storage.get %arg0[0] : !arc.storage -> !arc.state<i32>
+  func.call @bar(%arg0, %cst_i130): (!arc.storage, i130) -> ()
   arc.state_write %s0 = %cst_i32 tap @foo[0] : <i32>
 }
 


### PR DESCRIPTION
Simplify handling of the `arc.storage` type by removing its size parameter and attaching it to the owner of the value (ModelOp or AllocStorageOp) instead. We don't really have a strong motivation to make the size of the storage available at every use site. 

The total required size for an `arc.model` is now indicated by its `storageBytes` attribute instead of the type of its first block argument. This change has uncovered an existing bug in AllocateState for models that don't carry any state other than the predefined state header (current time, etc.). The storage type had not been updated in that case, which (due to the way optional type parameters are implemented) was incorrectly interpreted as zero bytes.