### PR TITLE
[FIRRTL] unsafe_domain_cast in InferResets

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -826,7 +826,8 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
             traceResets(baseType, op.getResult(), 0, baseType.getPassiveType(),
                         ref.getValue(), ref.getFieldID(), op.getLoc());
           })
-          .Case<UninferredResetCastOp, ConstCastOp, RefCastOp>([&](auto op) {
+          .Case<UninferredResetCastOp, ConstCastOp, RefCastOp,
+                UnsafeDomainCastOp>([&](auto op) {
             traceResets(op.getResult(), op.getInput(), op.getLoc());
           })
           .Case<InvalidValueOp>([&](auto op) {

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -1439,3 +1439,23 @@ firrtl.circuit "InstanceChoiceTest" {
     firrtl.matchingconnect %inst_reset, %reset : !firrtl.reset
   }
 }
+
+// -----
+
+// Reset inference should look through `unsafe_domain_cast` so that reset
+// networks connected across a domain cast are inferred to a concrete type.
+// CHECK-LABEL: firrtl.circuit "UnsafeDomainCast"
+firrtl.circuit "UnsafeDomainCast" {
+  firrtl.domain @ClockDomain
+  // CHECK-LABEL: firrtl.module @UnsafeDomainCast
+  firrtl.module @UnsafeDomainCast(
+    in %B: !firrtl.domain<@ClockDomain()>,
+    in %a: !firrtl.uint<1>
+  ) {
+    // CHECK: %b = firrtl.wire : !firrtl.uint<1>
+    %b = firrtl.wire : !firrtl.reset
+    %0 = firrtl.resetCast %a : (!firrtl.uint<1>) -> !firrtl.reset
+    %1 = firrtl.unsafe_domain_cast %0 domains[%B] : !firrtl.reset domains[!firrtl.domain<@ClockDomain()>]
+    firrtl.matchingconnect %b, %1 : !firrtl.reset
+  }
+}


### PR DESCRIPTION
Add `firrtl.unsafe_domain_cast` to the list of operations that are
passthrough when doing reset inference.  Previously, users could get
errors related reset networks not resolving to a concrete value as
connections through unsafe casts were not considered.

Assisted-by: pi.dev:claude-opus-4-8
