### PR TITLE
[MooreToCore][Transforms] Fix always_comb lowering for string-typed signals

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -522,9 +522,15 @@ static void getValuesToObserve(Region *region,
   Location loc = region->getLoc();
 
   auto probeIfSignal = [&](Value value) -> Value {
-    if (!isa<llhd::RefType>(value.getType()))
-      return value;
-    return llhd::ProbeOp::create(rewriter, loc, value);
+    Type type = value.getType();
+    if (auto refType = dyn_cast<llhd::RefType>(type)) {
+      if (!hw::isHWValueType(refType.getNestedType()))
+        return {};
+      return llhd::ProbeOp::create(rewriter, loc, value);
+    }
+    if (!hw::isHWValueType(type))
+      return {};
+    return value;
   };
 
   region->getParentOp()->walk<WalkOrder::PreOrder, ForwardDominanceIterator<>>(
@@ -544,13 +550,15 @@ static void getValuesToObserve(Region *region,
           OpBuilder::InsertionGuard g(rewriter);
           if (auto remapped = rewriter.getRemappedValue(value)) {
             setInsertionPoint(remapped);
-            observeValues.push_back(probeIfSignal(remapped));
+            if (auto observed = probeIfSignal(remapped))
+              observeValues.push_back(observed);
           } else {
             setInsertionPoint(value);
             auto type = typeConverter->convertType(value.getType());
             auto converted = typeConverter->materializeTargetConversion(
                 rewriter, loc, type, value);
-            observeValues.push_back(probeIfSignal(converted));
+            if (auto observed = probeIfSignal(converted))
+              observeValues.push_back(observed);
           }
         }
       });

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -234,9 +234,8 @@ public:
         return !isa<IntegerType>(op->getResult(0).getType());
       });
 
-      target.addDynamicallyLegalOp<arith::SelectOp>([](arith::SelectOp op) {
-        return !hw::isHWValueType(op.getType());
-      });
+      target.addDynamicallyLegalOp<arith::SelectOp>(
+          [](arith::SelectOp op) { return !hw::isHWValueType(op.getType()); });
     }
     MapArithTypeConverter typeConverter;
     RewritePatternSet patterns(ctx);

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -220,7 +220,6 @@ public:
       target.addIllegalOp<arith::ShLIOp>();
       target.addIllegalOp<arith::ShRSIOp>();
       target.addIllegalOp<arith::ShRUIOp>();
-      target.addIllegalOp<arith::SelectOp>();
       target.addIllegalOp<arith::ExtSIOp>();
       target.addIllegalOp<arith::ExtUIOp>();
       target.addIllegalOp<arith::TruncIOp>();
@@ -233,6 +232,10 @@ public:
       // Force integer constants to be mapped to `hw.constant`.
       target.addDynamicallyLegalOp<arith::ConstantOp>([](Operation *op) {
         return !isa<IntegerType>(op->getResult(0).getType());
+      });
+
+      target.addDynamicallyLegalOp<arith::SelectOp>([](arith::SelectOp op) {
+        return !hw::isHWValueType(op.getType());
       });
     }
     MapArithTypeConverter typeConverter;

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1358,6 +1358,29 @@ moore.module @blockArgAsObservedValue(in %in0: !moore.i32, in %in1: !moore.i32) 
   }
 }
 
+// CHECK-LABEL: hw.module @StringAssignInAlwaysComb
+moore.module @StringAssignInAlwaysComb(in %cond: !moore.i1) {
+  %str = moore.variable : <!moore.string>
+  // CHECK: llhd.process
+  moore.procedure always_comb {
+    %on = moore.constant_string "on" : i16
+    %on_s = moore.int_to_string %on : i16
+    %off = moore.constant_string "off" : i24
+    %off_s = moore.int_to_string %off : i24
+    %c = moore.to_builtin_int %cond :i1
+    cf.cond_br %c, ^bb1, ^bb2
+  ^bb1:
+    moore.blocking_assign %str, %on_s : string
+    cf.br ^bb3
+  ^bb2:
+    moore.blocking_assign %str, %off_s : string
+    cf.br ^bb3
+  ^bb3:
+    // CHECK: llhd.wait (%cond : i1), ^bb1
+    moore.return
+  }
+}
+
 // CHECK-LABEL: @Time
 // CHECK-SAME: (%arg0: !llhd.time) -> (!llhd.time, !llhd.time)
 func.func @Time(%arg0: !moore.time) -> (!moore.time, !moore.time) {

--- a/test/Transforms/map-arith-to-comb.mlir
+++ b/test/Transforms/map-arith-to-comb.mlir
@@ -68,6 +68,13 @@ func.func @allow_hw_structs(%arg0: !hw.struct<a: i42, b: i1337>, %arg1: !hw.stru
   return
 }
 
+// CHECK-LABEL: func @allow_non_hw_types
+func.func @allow_non_hw_types(%arg0: !sim.dstring, %arg1: !sim.dstring, %arg2: i1) {
+  // CHECK: arith.select %arg2, %arg0, %arg1 : !sim.dstring
+  %0 = arith.select %arg2, %arg0, %arg1 : !sim.dstring
+  return
+}
+
 // CHECK-LABEL: func @min_max_ops
 func.func @min_max_ops(%arg0: i32, %arg1: i32) {
   // CHECK: [[CMP_MAXS:%.*]] = comb.icmp sge %arg0, %arg1 : i32


### PR DESCRIPTION
Compiling a SystemVerilog `always @*` block that assigns a string-typed variable crashes with two cascading errors.

For example:
```
module bug_dstring_in_wait;
  logic  trigger;
  string s;

  always @* begin
    if (trigger) s = "on";
    else s = "off";
  end
endmodule
```

Output:
```
error: 'llhd.wait' op operand #1 must be variadic of a known primitive element, but got '!sim.dstring'
  always @* begin
  ^
note: see current operation: "llhd.wait"(%4, %5)[^bb1] <{operandSegmentSizes = array<i32: 0, 0, 2, 0>}> : (i1, !sim.dstring) -> ()
```

The root is that `getValuesToObserve`, which builds the implicit sensitivity list for `always_comb` and `always_latch`, collected every SSA value referenced outside the region without filtering by type. A string variable's backing ref becomes `!llhd.ref<!sim.dstring>`, which is probed and passed to `llhd.wait`. But `llhd.wait` enforces a structural invariant: all observed operands must be values of known HW primitive types, and `!sim.dstring` is not one, so the lowering fails.

Once the sensitivity list is corrected, `LowerProcessesPass` successfully converts the `llhd.process`to `llhd.combinational` and merges the identical successor blocks of the diamond CFG. The subsequent canonicalizer then folds the resulting `cf.cond_br` into an `arith.select %cond, "on", "off" : !sim.dstring`. `MapArithToCombPass` then runs and hits a second failure. It had marked all `arith.select` ops unconditionally illegal, expecting to lower each one to `comb.mux`. But the pass's type converter has no conversion for non-HW type, it returns a null type for `!sim.dstring`, so the `arith.select` to `comb.mux` pattern fails to resolve the result type and the conversion signals:

`error: failed to legalize operation 'arith.select' that was explicitly marked illegal`

Both issues are fixed together. In `getValuesToObserve`, `probeIfSignal` now returns an empty Value for any type that does not satisfy `hw::isHWValueType`, callers skip such values instead of pushing them into the observed list. In `MapArithToCombPass`, `arith.select` is made dynamically legal when its result type is not an HW value type, so only selects on integers, arrays, and structs are converted to `comb.mux`, while non-HW selects are left as-is for downstream passes to handle.