### PR TITLE
[firtool] register verif passes

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -886,7 +886,7 @@ int main(int argc, char **argv) {
     om::registerPasses();
     sv::registerPasses();
     hw::registerFlattenModulesPass();
-    verif::registerVerifyClockedAssertLikePass();
+    verif::registerPasses();
 
     // Export passes:
     registerExportSplitVerilogPass();


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

Register all Verif dialect passes in `firtool` instead of only `verify-clocked-assert-like`.

This makes the other Verif passes available through the firtool CLI/pass registry, including passes such as `lower-contracts`, `verif-lower-tests`, and `verif-lower-symbolic-values`. This is needed when using Verif-specific passes and their options from firtool command-line flows.

This does not change the default firtool pipeline. It only makes the full Verif pass set discoverable/parsable by the CLI. The previously registered `verify-clocked-assert-like` pass is still included through `verif::registerPasses()`.


Assisted-by: Codex:GPT-5.5