### PR TITLE
[LTLToCore] Lower boolean
  ltl.intersect to comb.and

### DIFF
--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -166,6 +166,27 @@ struct LTLOrOpConversion : public OpConversionPattern<ltl::OrOp> {
   }
 };
 
+struct LTLIntersectOpConversion
+    : public OpConversionPattern<ltl::IntersectOp> {
+  using OpConversionPattern<ltl::IntersectOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ltl::IntersectOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Can only lower boolean intersects to comb ops; booleans are
+    // instantaneous matches, so intersection is conjunction.
+    if (!isa<IntegerType>(op->getOperandTypes()[0]) ||
+        !isa<IntegerType>(op->getOperandTypes()[1]))
+      return failure();
+    auto loc = op.getLoc();
+    // Explicit twoState value to disambiguate builders
+    auto andOp =
+        comb::AndOp::create(rewriter, loc, adaptor.getOperands(), false);
+    rewriter.replaceOp(op, andOp);
+    return success();
+  }
+};
+
 struct LTLPastOpConversion : public OpConversionPattern<ltl::PastOp> {
   using OpConversionPattern<ltl::PastOp>::OpConversionPattern;
 
@@ -235,6 +256,7 @@ void LowerLTLToCorePass::runOnOperation() {
   target.addDynamicallyLegalOp<ltl::NotOp>(isLegal);
   target.addDynamicallyLegalOp<ltl::AndOp>(isLegal);
   target.addDynamicallyLegalOp<ltl::OrOp>(isLegal);
+  target.addDynamicallyLegalOp<ltl::IntersectOp>(isLegal);
 
   // Create type converters, mostly just to convert an ltl property to a bool
   mlir::TypeConverter converter;
@@ -273,8 +295,8 @@ void LowerLTLToCorePass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   patterns
       .add<HasBeenResetOpConversion, LTLImplicationConversion, LTLNotConversion,
-           LTLAndOpConversion, LTLOrOpConversion, LTLPastOpConversion>(
-          converter, patterns.getContext());
+           LTLAndOpConversion, LTLOrOpConversion, LTLIntersectOpConversion,
+           LTLPastOpConversion>(converter, patterns.getContext());
   // Apply the conversions
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -166,8 +166,7 @@ struct LTLOrOpConversion : public OpConversionPattern<ltl::OrOp> {
   }
 };
 
-struct LTLIntersectOpConversion
-    : public OpConversionPattern<ltl::IntersectOp> {
+struct LTLIntersectOpConversion : public OpConversionPattern<ltl::IntersectOp> {
   using OpConversionPattern<ltl::IntersectOp>::OpConversionPattern;
 
   LogicalResult
@@ -293,10 +292,10 @@ void LowerLTLToCorePass::runOnOperation() {
 
   // Create the operation rewrite patters
   RewritePatternSet patterns(&getContext());
-  patterns
-      .add<HasBeenResetOpConversion, LTLImplicationConversion, LTLNotConversion,
-           LTLAndOpConversion, LTLOrOpConversion, LTLIntersectOpConversion,
-           LTLPastOpConversion>(converter, patterns.getContext());
+  patterns.add<HasBeenResetOpConversion, LTLImplicationConversion,
+               LTLNotConversion, LTLAndOpConversion, LTLOrOpConversion,
+               LTLIntersectOpConversion, LTLPastOpConversion>(
+      converter, patterns.getContext());
   // Apply the conversions
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))

--- a/test/Conversion/LTLToCore/ltl-to-core.mlir
+++ b/test/Conversion/LTLToCore/ltl-to-core.mlir
@@ -109,7 +109,7 @@ hw.module @Intersect(in %a: i1, in %b: i1, in %c: !ltl.sequence, in %clk: i1) {
   // Convert if there are non-assert users but the result type is i1
   %int2 = ltl.intersect %a, %b : i1, i1
   %user = hw.wire %int2 : i1
-  // Or if there are non-i1 operands (and therefore results)
+  // Don't convert if there are non-i1 operands (and therefore results)
   %int3 = ltl.intersect %b, %c : i1, !ltl.sequence
   verif.assert %int3 : !ltl.sequence
 }

--- a/test/Conversion/LTLToCore/ltl-to-core.mlir
+++ b/test/Conversion/LTLToCore/ltl-to-core.mlir
@@ -91,6 +91,29 @@ hw.module @Or(in %a: i1, in %b: i1, in %c: !ltl.property, in %clk: i1) {
   verif.assert %or3 : !ltl.property
 }
 
+// CHECK: hw.module @Intersect(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[C:%.+]] : !ltl.sequence, in [[CLK:%.+]] : i1)
+// CHECK: [[INT1:%.+]] = comb.and [[A]], [[B]] : i1
+// CHECK: verif.assert [[INT1]] : i1
+// CHECK: verif.clocked_assert [[INT1]], posedge [[CLK]] : i1
+// CHECK: [[INT2:%.+]] = comb.and [[A]], [[B]] : i1
+// CHECK: [[USER:%.+]] = hw.wire [[INT2]] : i1
+// CHECK: [[INT3:%.+]] = ltl.intersect [[B]], [[C]] : i1, !ltl.sequence
+// CHECK: verif.assert [[INT3]] : !ltl.sequence
+
+hw.module @Intersect(in %a: i1, in %b: i1, in %c: !ltl.sequence, in %clk: i1) {
+  // Boolean intersection is instantaneous, i.e. conjunction. Convert if both
+  // operands are i1 and the only users are asserts
+  %int1 = ltl.intersect %a, %b : i1, i1
+  verif.assert %int1 : i1
+  verif.clocked_assert %int1, posedge %clk : i1
+  // Convert if there are non-assert users but the result type is i1
+  %int2 = ltl.intersect %a, %b : i1, i1
+  %user = hw.wire %int2 : i1
+  // Or if there are non-i1 operands (and therefore results)
+  %int3 = ltl.intersect %b, %c : i1, !ltl.sequence
+  verif.assert %int3 : !ltl.sequence
+}
+
 // CHECK: hw.module @Past(in [[A:%.+]] : i32, in [[CLK:%.+]] : i1)
 // CHECK: [[TOCLK1:%.+]] = seq.to_clock [[CLK]]
 // CHECK: [[TRUE:%.+]] = hw.constant true


### PR DESCRIPTION
## Issue
`ltl.intersect` is the only boolean-shaped LTL op LTLToCore doesn't lower: boolean `and`/`or`/`not`/`implication` all have patterns. Since nothing downstream of this pass handles LTL, an i1 assert over an intersection fails legalization in circt-bmc while the identical assert over `ltl.and` verifies fine.

## Note
The "fix" is lifted and duplicated from LTL canonicalization. LTLToCore already has a precedent for doing this with other patterns. I assume the intention is that lowering should idempotent w.r.t canonicalization and that this is fine. 

Assisted-by: Claude:Fable-5
