### PR TITLE
[ImportVerilog] Fix return type mismatch for functions returning string

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -809,11 +809,14 @@ struct StmtVisitor {
       return success();
     }
 
-    if (!isa<mlir::func::FuncOp>(parentOp))
+    auto funcOp = dyn_cast<mlir::func::FuncOp>(parentOp);
+    if (!funcOp)
       return mlir::emitError(loc) << "unsupported return statement context";
 
     if (stmt.expr) {
-      auto expr = context.convertRvalueExpression(*stmt.expr);
+      auto resultTypes = funcOp.getFunctionType().getResults();
+      Type resultType = resultTypes.size() == 1 ? resultTypes[0] : Type();
+      auto expr = context.convertRvalueExpression(*stmt.expr, resultType);
       if (!expr)
         return failure();
       mlir::func::ReturnOp::create(builder, loc, expr);

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -2143,6 +2143,17 @@ function void simpleFunc5();
   // CHECK: return
 endfunction
 
+// CHECK-LABEL: func.func private @sformatReturn(
+// CHECK-SAME:   %arg0: !moore.i32
+// CHECK-SAME: ) -> !moore.string
+function string sformatReturn(int n);
+  // CHECK: [[FMT:%.+]] = moore.fmt.int
+  // CHECK: [[CONCAT:%.+]] = moore.fmt.concat
+  // CHECK: [[STR:%.+]] = moore.fstring_to_string [[CONCAT]]
+  // CHECK: return [[STR]]
+  return $sformatf("item_%0d", n);
+endfunction
+
 // CHECK-LABEL: func.func private @funcArgs1(
 // CHECK-SAME:    %arg0: !moore.i32
 // CHECK-SAME:    %arg1: !moore.ref<i32>


### PR DESCRIPTION
Return statements never converted their expression to the function's declared result type, so `return $sformatf(...)` inside a function declared `string` failed.

**For example:** 
```
module bug_format_string_return;
  function automatic string make_label(int unsigned n);
    return $sformatf("item_%0d", n);
  endfunction

  int unsigned x;
  initial begin
    x = 3;
    $display(make_label(x));
  end
endmodule
```

**Output:**
```
error: type of return operand 0 ('!moore.format_string') doesn't match function result type ('!moore.string') in function @make_label
    return $sformatf("item_%0d", n);
    ^
note: see current operation: "func.return"(%2) : (!moore.format_string) -> ()
```

Fix by passing the function's result type to `convertRvalueExpression`.

