### PR TITLE
[ImportVerilog] Fix corrupted constant string materialization

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2775,20 +2775,14 @@ Value Context::materializeSVReal(const slang::ConstantValue &svreal,
 Value Context::materializeString(const slang::ConstantValue &stringLiteral,
                                  const slang::ast::Type &astType,
                                  Location loc) {
-  slang::ConstantValue intVal = stringLiteral.convertToInt();
-  auto effectiveWidth = intVal.getEffectiveWidth();
-  if (!effectiveWidth)
+  if (!astType.isString())
     return {};
-
-  auto intTy = moore::IntType::getInt(getContext(), effectiveWidth.value());
-
-  if (astType.isString()) {
-    auto immInt = moore::ConstantStringOp::create(builder, loc, intTy,
-                                                  stringLiteral.toString())
-                      .getResult();
-    return moore::IntToStringOp::create(builder, loc, immInt).getResult();
-  }
-  return {};
+  const std::string &str = stringLiteral.str();
+  auto intTy = moore::IntType::getInt(getContext(),
+                                      static_cast<unsigned>(str.size() * 8));
+  auto immInt =
+      moore::ConstantStringOp::create(builder, loc, intTy, str).getResult();
+  return moore::IntToStringOp::create(builder, loc, immInt).getResult();
 }
 
 /// Materialize a Slang integer literal as a constant op.

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -3896,8 +3896,8 @@ endmodule
 // CHECK-LABEL: func.func private @testStrLiteralReturn()
 // CHECK-SAME: -> !moore.string {
 function string testStrLiteralReturn;
-    // CHECK-NEXT: [[INT:%.+]] = moore.constant_string "\22A string literal\22" : i127
-    // CHECK-NEXT: [[STR:%.+]] = moore.int_to_string [[INT]] : i127
+    // CHECK-NEXT: [[INT:%.+]] = moore.constant_string "A string literal" : i128
+    // CHECK-NEXT: [[STR:%.+]] = moore.int_to_string [[INT]] : i128
     parameter string testStrLiteral = "A string literal";
     // CHECK-NEXT: return [[STR]] : !moore.string
     return testStrLiteral;
@@ -3906,9 +3906,9 @@ endfunction // testStrLiteralReturn
 // CHECK-LABEL: func.func private @testStrLiteralAsIntReturn()
 // CHECK-SAME: -> !moore.i1 {
 function bit testStrLiteralAsIntReturn;
-    // CHECK-NEXT: [[CONST:%.+]] = moore.constant_string "\22A string literal\22" : i127 
-    // CHECK-NEXT: [[STR:%.+]] = moore.int_to_string [[CONST]] : i127 
-    // CHECK-NEXT: [[INT:%.+]] = moore.string_to_int [[STR]] : i1 
+    // CHECK-NEXT: [[CONST:%.+]] = moore.constant_string "A string literal" : i128
+    // CHECK-NEXT: [[STR:%.+]] = moore.int_to_string [[CONST]] : i128
+    // CHECK-NEXT: [[INT:%.+]] = moore.string_to_int [[STR]] : i1
     // CHECK-NEXT: return [[INT]] : !moore.i1
     parameter string testStrLiteral = "A string literal";
     return bit'(testStrLiteral);


### PR DESCRIPTION
`materializeString` built compile-time-constant `string` values using `ConstantValue::toString()`, a quoted pretty-print, not a raw bytes and a bit width derived from `getEffectiveWidth()` (minimal active bits, not byte-aligned). Combined with `ConstantStringOpConv`'s byte-aligned packing, this corrupted or truncated the resulting string content.

**For example:**
```
module bug_materialize_string;
  function automatic string make_label();
    parameter string label = "item_3";
    return label;
  endfunction

  initial $display(make_label());
endmodule
```

**Output:**
```
module {
  hw.module @bug_materialize_string() {
    %0 = sim.string.literal "em_3\22"
    %1 = sim.fmt.literal "\0A"
    llhd.process {
      %2 = sim.fmt.string %0 : !sim.dstring
      %3 = sim.fmt.concat (%2, %1)
      sim.proc.print %3
      llhd.halt
    }
    hw.output
  }
}
```

Fix by using `.str()` and `size() * 8`. I also updated `testStrLiteralReturn`/`testStrLiteralAsIntReturn` in `test/Conversion/ImportVerilog/basic.sv` to check the correct uncorrupted output.