### PR TITLE
[MooreToCore] Fix bool cast lowering for packed aggregates

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1763,6 +1763,19 @@ struct BoolCastOpConversion : public OpConversionPattern<BoolCastOp> {
                                                 timeInt, zero);
       return success();
     }
+    if (isa_and_nonnull<hw::StructType, hw::ArrayType, hw::UnionType>(
+            resultType)) {
+      int64_t width = hw::getBitWidth(resultType);
+      if (width < 0)
+        return failure();
+      auto intTy = rewriter.getIntegerType(width);
+      Value input = rewriter.createOrFold<hw::BitcastOp>(op->getLoc(), intTy,
+                                                         adaptor.getInput());
+      Value zero = hw::ConstantOp::create(rewriter, op->getLoc(), intTy, 0);
+      rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, comb::ICmpPredicate::ne,
+                                                input, zero);
+      return success();
+    }
     return failure();
   }
 };

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1510,6 +1510,20 @@ func.func @TimeConversion(%arg0: !moore.l64, %arg1: !moore.time) -> (!moore.time
   return %0, %1 : !moore.time, !moore.l64
 }
 
+// CHECK-LABEL: func.func @BoolCastAggregates
+func.func @BoolCastAggregates(%arg0: !moore.struct<{valid: l1, is_read: l1}>, %arg1: !moore.array<4 x i8>) -> (!moore.l1, !moore.i1) {
+  // CHECK-NEXT: [[CAST0:%.+]] = hw.bitcast %arg0 : (!hw.struct<valid: i1, is_read: i1>) -> i2
+  // CHECK-NEXT: [[ZERO0:%.+]] = hw.constant 0 : i2
+  // CHECK-NEXT: [[NE0:%.+]] = comb.icmp ne [[CAST0]], [[ZERO0]] : i2
+  %0 = moore.bool_cast %arg0 : !moore.struct<{valid: l1, is_read: l1}> -> !moore.l1
+  // CHECK-NEXT: [[CAST1:%.+]] = hw.bitcast %arg1 : (!hw.array<4xi8>) -> i32
+  // CHECK-NEXT: [[ZERO1:%.+]] = hw.constant 0 : i32
+  // CHECK-NEXT: [[NE1:%.+]] = comb.icmp ne [[CAST1]], [[ZERO1]] : i32
+  %1 = moore.bool_cast %arg1 : !moore.array<4 x i8> -> !moore.i1
+  // CHECK-NEXT: return [[NE0]], [[NE1]]
+  return %0, %1 : !moore.l1, !moore.i1
+}
+
 // CHECK-LABEL: func.func @IntToStringConversion
 func.func @IntToStringConversion(%arg0: !moore.i45) {
   // CHECK-NEXT: sim.string.int_to_string %arg0 : i45


### PR DESCRIPTION
`moore.bool_cast` failed to legalize when its input was a packed aggregate.

**For example:**
```
module bug_bool_cast_struct;
  typedef struct packed {
    logic valid;
    logic is_read;
  } entry_t;

  entry_t e;
  logic r;

  initial begin
    e = '0;
    r = e ? 1'b1 : 1'b0;
  end
endmodule
```

**Output:**
```
error: failed to legalize operation 'moore.bool_cast': %18 = "moore.bool_cast"(%17) : (!moore.struct<{valid: l1, is_read: l1}>) -> !moore.l1
    r = e ? 1'b1 : 1'b0;
        ^
note: see current operation: %18 = "moore.bool_cast"(%17) : (!moore.struct<{valid: l1, is_read: l1}>) ->!moore.l1
```

Fix by bitcasting the aggregate to an integer of the same bit width and comparing against zero.