### PR TITLE
[PyCDE] Don't run tests in an external shell

### DIFF
--- a/frontends/PyCDE/integration_test/lit.cfg.py
+++ b/frontends/PyCDE/integration_test/lit.cfg.py
@@ -20,7 +20,7 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = 'PyCDE Integration'
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.py']

--- a/frontends/PyCDE/test/lit.cfg.py
+++ b/frontends/PyCDE/test/lit.cfg.py
@@ -20,7 +20,7 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = 'PyCDE'
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.td', '.mlir', '.ll', '.fir', '.sv', '.py']


### PR DESCRIPTION
This feature is deprecated and doesn't seem to be necessary.