### PR TITLE
[Arc] Add sensitivity mask attribute to CoroutineInstanceOp

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -818,6 +818,8 @@ def CoroutineInstanceOp : ArcOp<"coroutine.instance", [
   CallOpInterface,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   HasParent<"hw::HWModuleOp">,
+  PredOpTrait<"`sensitivityMask` has one bit per argument",
+    CPred<"$sensitivityMask.size() == $args.size()">>,
 ]> {
   let summary = "Continuously run a coroutine in an hw.module";
   let description = [{
@@ -832,17 +834,20 @@ def CoroutineInstanceOp : ArcOp<"coroutine.instance", [
     - An observe bitmask as its second-to-last result, an integer with one bit
       per coroutine argument. A set bit requests that the instance re-enter the
       coroutine whenever the corresponding argument changes value, on top of the
-      time-based wakeup.
+      time-based wakeup. The dynamic returned mask is AND-combined with the
+      `sensitivityMask` attribute. Only arguments with the corresponding static
+      sensitivity bit set are checked for changes.
     - A wakeup time as its last result value, used to schedule the next
       time-based execution.
   }];
   let arguments = (ins
     FlatSymbolRefAttr:$callee,
-    Variadic<AnyType>:$args
+    Variadic<AnyType>:$args,
+    DenseBoolArrayAttr:$sensitivityMask
   );
   let results = (outs Variadic<AnyType>:$results);
   let assemblyFormat = [{
-    $callee `(` $args `)` attr-dict `:` functional-type(operands, results)
+    $callee `(` $args `)` `sensitive` $sensitivityMask attr-dict `:` functional-type(operands, results)
   }];
 
   let extraClassDeclaration = [{

--- a/integration_test/arcilator/JIT/coroutine-instance.mlir
+++ b/integration_test/arcilator/JIT/coroutine-instance.mlir
@@ -93,7 +93,7 @@ arc.coroutine.define @Proc(%now: i64) -> (i42, i1, i64) {
 hw.module @CoroutineProc(out o: i42) {
   %now = llhd.current_time
   %nowi = llhd.time_to_int %now
-  %0 = arc.coroutine.instance @Proc(%nowi) : (i64) -> i42
+  %0 = arc.coroutine.instance @Proc(%nowi) sensitive [false] : (i64) -> i42
   %c42 = hw.constant 42 : i42
   %sum = comb.add %0, %c42 : i42
   hw.output %sum : i42

--- a/lib/Dialect/Arc/Transforms/LowerProcesses.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerProcesses.cpp
@@ -110,6 +110,10 @@ private:
   /// `addEntryAndResumeBlockArguments` and used by `rewriteTerminators` to
   /// build the observe bitmask.
   SmallDenseMap<Value, uint32_t> argIndices;
+
+  /// Indicates which arguments are relevant for the sensitivity check. This
+  /// matches the bit-wise OR of all dynamically returned sensitivity masks.
+  SmallVector<bool> staticSensitivityMask;
 };
 
 } // namespace
@@ -282,6 +286,7 @@ LogicalResult ProcessLowering::rewriteTerminators() {
   // operands) and values defined inside the body are absent from the map and
   // therefore cannot be observed for changes.
   auto maskWidth = entryArgs.size();
+  staticSensitivityMask.resize(maskWidth, false);
   for (auto &block : coroOp.getBody()) {
     auto *term = block.getTerminator();
     auto loc = term->getLoc();
@@ -294,8 +299,10 @@ LogicalResult ProcessLowering::rewriteTerminators() {
       // (which can never change) and forwarded block arguments contribute none.
       APInt maskBits(maskWidth, 0);
       for (auto observed : wait.getObserved())
-        if (auto it = argIndices.find(observed); it != argIndices.end())
+        if (auto it = argIndices.find(observed); it != argIndices.end()) {
           maskBits.setBit(it->second);
+          staticSensitivityMask[it->second] = true;
+        }
       auto mask = hw::ConstantOp::create(builder, loc, maskBits);
 
       // A wait without a delay never resumes on time; use the sentinel `-1` as
@@ -448,9 +455,11 @@ void ProcessLowering::buildInstance() {
   SmallVector<Value> args(captures.begin(), captures.end());
   args.push_back(nowI64);
 
+  assert(args.size() == staticSensitivityMask.size());
   auto instanceOp = CoroutineInstanceOp::create(
       builder, loc, processOp.getResultTypes(),
-      FlatSymbolRefAttr::get(coroOp.getSymNameAttr()), args);
+      FlatSymbolRefAttr::get(coroOp.getSymNameAttr()), args,
+      builder.getDenseBoolArrayAttr(staticSensitivityMask));
 
   processOp.replaceAllUsesWith(instanceOp.getResults());
   processOp.erase();

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -933,6 +933,8 @@ LogicalResult OpLowering::lower(CoroutineInstanceOp op) {
         module.allocBuilder, loc, StateType::get(maskType), module.storageArg);
     auto mask = StateReadOp::create(module.builder, loc, maskSlot);
     for (auto [index, input] : llvm::enumerate(inputs)) {
+      if (!op.getSensitivityMask()[index])
+        continue;
       auto prevSlot = AllocStateOp::create(module.allocBuilder, loc,
                                            StateType::get(input.getType()),
                                            module.storageArg);

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -549,7 +549,7 @@ func.func @NotACoroutine() {
 
 hw.module @Foo() {
   // expected-error @below {{`NotACoroutine` does not reference a valid `arc.coroutine.define`}}
-  arc.coroutine.instance @NotACoroutine() : () -> ()
+  arc.coroutine.instance @NotACoroutine() sensitive [] : () -> ()
 }
 func.func @NotACoroutine() {
   return
@@ -574,7 +574,7 @@ hw.module @Foo(in %a: i9001) {
   // expected-error @below {{operand type mismatch: operand #0}}
   // expected-note @below {{expected type: 'i42'}}
   // expected-note @below {{actual type: 'i9001'}}
-  arc.coroutine.instance @NeedsI42(%a) : (i9001) -> ()
+  arc.coroutine.instance @NeedsI42(%a) sensitive [false] : (i9001) -> ()
 }
 arc.coroutine.define @NeedsI42(%arg0: i42) -> (i1, i64) {
   %c0_i1 = hw.constant 0 : i1
@@ -600,7 +600,7 @@ arc.coroutine.define @BarB() {
 
 hw.module @Foo() {
   // expected-error @below {{`DoesNotExist` does not reference a valid `arc.coroutine.define`}}
-  arc.coroutine.instance @DoesNotExist() : () -> ()
+  arc.coroutine.instance @DoesNotExist() sensitive [] : () -> ()
 }
 
 // -----
@@ -615,7 +615,7 @@ func.func @Foo(%arg0: !arc.coroutine_state<@DoesNotExist>, %arg1: !arc.coroutine
 
 hw.module @Foo() {
   // expected-error @below {{referenced coroutine `Bar` must produce an `i64` wakeup time as its last result}}
-  arc.coroutine.instance @Bar() : () -> ()
+  arc.coroutine.instance @Bar() sensitive [] : () -> ()
 }
 arc.coroutine.define @Bar() {
   arc.coroutine.return
@@ -625,7 +625,7 @@ arc.coroutine.define @Bar() {
 
 hw.module @Foo() {
   // expected-error @below {{referenced coroutine `Bar` must produce an `i64` wakeup time as its last result}}
-  arc.coroutine.instance @Bar() : () -> i42
+  arc.coroutine.instance @Bar() sensitive [] : () -> i42
 }
 arc.coroutine.define @Bar() -> i42 {
   %c0_i42 = hw.constant 0 : i42
@@ -636,7 +636,7 @@ arc.coroutine.define @Bar() -> i42 {
 
 hw.module @Foo(in %a: i42) {
   // expected-error @below {{referenced coroutine `Bar` must produce an observe bitmask with one bit per argument (`i1`) as its second-to-last result}}
-  arc.coroutine.instance @Bar(%a) : (i42) -> ()
+  arc.coroutine.instance @Bar(%a) sensitive [false] : (i42) -> ()
 }
 // One argument, so the bitmask must be `i1`, but here it is `i8`.
 arc.coroutine.define @Bar(%arg0: i42) -> (i8, i64) {
@@ -646,6 +646,16 @@ arc.coroutine.define @Bar(%arg0: i42) -> (i8, i64) {
 }
 
 // -----
+
+hw.module @Foo(in %a: i42) {
+  // expected-error @below {{`sensitivityMask` has one bit per argument}}
+  arc.coroutine.instance @Bar(%a) sensitive [false, false] : (i42) -> ()
+}
+arc.coroutine.define @Bar(%arg0: i42) -> (i1, i64) {
+  %c0_i1 = hw.constant 0 : i1
+  %c0_i64 = hw.constant 0 : i64
+  arc.coroutine.return %c0_i1, %c0_i64 : i1, i64
+}
 
 arc.coroutine.define @Foo() -> i42 {
   // expected-error @below {{incorrect number of yielded values: expected 1, but got 0}}

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -443,8 +443,8 @@ arc.coroutine.start_pc : !arc.coroutine_pc<@CoroutineEmpty>
 
 // CHECK-LABEL: hw.module @CoroutineInstanceA
 hw.module @CoroutineInstanceA(in %a: i42, out z: i9001) {
-  // CHECK: arc.coroutine.instance @CoroutineInstanceB(%a) : (i42) -> i9001
-  %0 = arc.coroutine.instance @CoroutineInstanceB(%a) : (i42) -> i9001
+  // CHECK: arc.coroutine.instance @CoroutineInstanceB(%a) sensitive [false] : (i42) -> i9001
+  %0 = arc.coroutine.instance @CoroutineInstanceB(%a) sensitive [false] : (i42) -> i9001
   hw.output %0 : i9001
 }
 // The coroutine produces its result, then an observe bitmask (one bit per

--- a/test/Dialect/Arc/lower-coroutines-errors.mlir
+++ b/test/Dialect/Arc/lower-coroutines-errors.mlir
@@ -35,7 +35,7 @@ arc.coroutine.define @WithWakeup(%arg0: i42) -> (i1, i64) {
 
 hw.module @Module(in %a: i42) {
   // expected-error @below {{must be lowered before LowerCoroutines}}
-  arc.coroutine.instance @WithWakeup(%a) : (i42) -> ()
+  arc.coroutine.instance @WithWakeup(%a) sensitive [false] : (i42) -> ()
 }
 
 // -----

--- a/test/Dialect/Arc/lower-processes.mlir
+++ b/test/Dialect/Arc/lower-processes.mlir
@@ -28,7 +28,7 @@
 hw.module @Foo(in %a: i32, out x: i32) {
   // CHECK: [[NOW:%.+]] = llhd.current_time
   // CHECK: [[NOWI:%.+]] = llhd.time_to_int [[NOW]]
-  // CHECK: [[OUT:%.+]] = arc.coroutine.instance @Foo.llhd.process(%a, [[NOWI]]) : (i32, i64) -> i32
+  // CHECK: [[OUT:%.+]] = arc.coroutine.instance @Foo.llhd.process(%a, [[NOWI]]) sensitive [false, false] : (i32, i64) -> i32
   // CHECK: hw.output [[OUT]]
   %c1_i32 = hw.constant 1 : i32
   %c2_i32 = hw.constant 2 : i32
@@ -56,7 +56,7 @@ hw.module @Foo(in %a: i32, out x: i32) {
 
 // CHECK-LABEL: hw.module @NoResults
 hw.module @NoResults() {
-  // CHECK: arc.coroutine.instance @NoResults.llhd.process({{%.+}}) : (i64) -> ()
+  // CHECK: arc.coroutine.instance @NoResults.llhd.process({{%.+}}) sensitive [false] : (i64) -> ()
   %t = llhd.constant_time <1ns, 0d, 0e>
   llhd.process {
     llhd.wait delay %t, ^bb1
@@ -75,7 +75,7 @@ hw.module @NoResults() {
 // CHECK-LABEL: hw.module @NoCaptures
 hw.module @NoCaptures(out o: i32) {
   // CHECK: [[NOWI:%.+]] = llhd.time_to_int
-  // CHECK: arc.coroutine.instance @NoCaptures.llhd.process([[NOWI]]) : (i64) -> i32
+  // CHECK: arc.coroutine.instance @NoCaptures.llhd.process([[NOWI]]) sensitive [false] : (i64) -> i32
   %c7 = hw.constant 7 : i32
   %t = llhd.constant_time <5ns, 0d, 0e>
   %r = llhd.process -> i32 {
@@ -96,7 +96,7 @@ hw.module @NoCaptures(out o: i32) {
 
 // CHECK-LABEL: hw.module @MultiResult
 hw.module @MultiResult(out a: i32, out b: i8) {
-  // CHECK: arc.coroutine.instance @MultiResult.llhd.process({{%.+}}) : (i64) -> (i32, i8)
+  // CHECK: arc.coroutine.instance @MultiResult.llhd.process({{%.+}}) sensitive [false] : (i64) -> (i32, i8)
   %c32 = hw.constant 9 : i32
   %c8 = hw.constant 3 : i8
   %t = llhd.constant_time <1ns, 0d, 0e>
@@ -117,7 +117,7 @@ hw.module @MultiResult(out a: i32, out b: i8) {
 
 // CHECK-LABEL: hw.module @MultiCapture
 hw.module @MultiCapture(in %a: i32, in %b: i8, out o: i32) {
-  // CHECK: arc.coroutine.instance @MultiCapture.llhd.process(%a, %b, {{%.+}}) : (i32, i8, i64) -> i32
+  // CHECK: arc.coroutine.instance @MultiCapture.llhd.process(%a, %b, {{%.+}}) sensitive [false, false, false] : (i32, i8, i64) -> i32
   %c1 = hw.constant 1 : i32
   %t = llhd.constant_time <1ns, 0d, 0e>
   %res = llhd.process -> i32 {
@@ -487,6 +487,7 @@ hw.module @ZeroDelay() {
 
 // CHECK-LABEL: hw.module @ObserveOnly
 hw.module @ObserveOnly(in %clk: i1) {
+  // CHECK: arc.coroutine.instance @ObserveOnly.llhd.process(%clk, %1) sensitive [true, false]
   llhd.process {
     llhd.wait (%clk : i1), ^bb1
   ^bb1:
@@ -508,6 +509,7 @@ hw.module @ObserveOnly(in %clk: i1) {
 
 // CHECK-LABEL: hw.module @ObserveAndDelay
 hw.module @ObserveAndDelay(in %clk: i1) {
+  // CHECK: arc.coroutine.instance @ObserveAndDelay.llhd.process(%clk, %2) sensitive [true, false] : (i1, i64)
   %t = llhd.constant_time <1ns, 0d, 0e>
   llhd.process {
     llhd.wait delay %t, (%clk : i1), ^bb1
@@ -528,6 +530,7 @@ hw.module @ObserveAndDelay(in %clk: i1) {
 
 // CHECK-LABEL: hw.module @ObserveMulti
 hw.module @ObserveMulti(in %a: i1, in %b: i1) {
+  // CHECK: arc.coroutine.instance @ObserveMulti.llhd.process(%a, %b, %2) sensitive [true, true, false]
   %t = llhd.constant_time <1ns, 0d, 0e>
   llhd.process {
     llhd.wait delay %t, (%a, %b : i1, i1), ^bb1
@@ -535,6 +538,26 @@ hw.module @ObserveMulti(in %a: i1, in %b: i1) {
     llhd.halt
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Observe only one of two arguments.
+
+// CHECK-LABEL: arc.coroutine.define @ObserveSome.llhd.process
+// CHECK-SAME: ({{%.+}}: i1, {{%.+}}: i1, {{%.+}}: i64) -> (i1, i3, i64)
+// CHECK:   [[MASK:%.+]] = hw.constant 2 : i3
+// CHECK:   arc.coroutine.yield ({{%.+}}, [[MASK]], {{%.+}} : i1, i3, i64), ^{{.+}}
+
+// CHECK-LABEL: hw.module @ObserveSome
+hw.module @ObserveSome(in %a: i1, in %b: i1) {
+  // CHECK: arc.coroutine.instance @ObserveSome.llhd.process(%a, %b, %2) sensitive [false, true, false]
+  %t = llhd.constant_time <1ns, 0d, 0e>
+  llhd.process -> i1 {
+    llhd.wait yield (%a : i1), delay %t, (%b : i1), ^bb1
+  ^bb1:
+    llhd.halt %a : i1
+  }
+}
+
 
 //===----------------------------------------------------------------------===//
 // An observed value that is defined *inside* the process body can never change

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -813,8 +813,8 @@ hw.module @TestSimToArcTerminateFailure(in %clock: !seq.clock, in %cond: i1) {
   sim.clocked_terminate %clock, %cond, failure, verbose
 }
 
-// CHECK-LABEL: arc.model @CoroutineInstance
-hw.module @CoroutineInstance(in %in: i42, out o: i42) {
+// CHECK-LABEL: arc.model @CoroutineSensitiveInstance
+hw.module @CoroutineSensitiveInstance(in %in: i42, out o: i42) {
   // CHECK-DAG: [[PC:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!arc.coroutine_pc<@DummyCoroutine>>
   // CHECK-DAG: [[STATE:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!arc.coroutine_state<@DummyCoroutine>>
   // CHECK-DAG: [[WAKEUP:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i64>
@@ -854,7 +854,7 @@ hw.module @CoroutineInstance(in %in: i42, out o: i42) {
   // CHECK: [[NEXT:%.+]] = arc.get_next_wakeup %arg0 : !arc.storage
   // CHECK: [[MIN:%.+]] = arith.minui [[CUR]], [[NEXT]] : i64
   // CHECK: arc.set_next_wakeup %arg0, [[MIN]] : !arc.storage
-  %0 = arc.coroutine.instance @DummyCoroutine(%in) : (i42) -> i42
+  %0 = arc.coroutine.instance @DummyCoroutine(%in) sensitive [true] : (i42) -> i42
 
   // CHECK: [[OUT:%.+]] = arc.state_read [[RESULT]] : <i42>
   // CHECK: func.call @ConsumeI42([[OUT]])
@@ -862,6 +862,24 @@ hw.module @CoroutineInstance(in %in: i42, out o: i42) {
 
   // CHECK: [[OUT2:%.+]] = arc.state_read [[RESULT]] : <i42>
   // CHECK: arc.state_write %out_o = [[OUT2]] : <i42>
+  hw.output %0 : i42
+}
+
+// CHECK-LABEL: arc.model @CoroutineInsensitiveInstance
+hw.module @CoroutineInsensitiveInstance(in %in: i42, out o: i42) {
+  // Allocate i42 result but not previous value
+  // CHECK:     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i42>
+  // CHECK-NOT: arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i42>
+
+  // CHECK: [[FALSE:%.+]] = hw.constant false
+  // CHECK: [[READY:%.+]] = comb.or %{{.+}}, [[FALSE]] : i1
+  // CHECK: scf.if [[READY]] {
+  // CHECK:   arc.coroutine.call @DummyCoroutine
+  // CHECK: }
+
+  %0 = arc.coroutine.instance @DummyCoroutine(%in) sensitive [false] : (i42) -> i42
+
+  func.call @ConsumeI42(%0) : (i42) -> ()
   hw.output %0 : i42
 }
 


### PR DESCRIPTION
Annotate CoroutineInstanceOp with a static sensitivity mask, indicating which arguments can never cause the coroutine to be unsuspended. This allows LowerState to omit the sensitivity check logic and allocations for these arguments.

Assisted-by: vscode:Claude Sonnet 5

CC #10757 #10780