### PR TITLE
[ESI][Runtime] Support for multi-burst lists

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen.py
@@ -2145,6 +2145,14 @@ class CppTypeEmitter:
                                                       info["header_pad_bytes"],
                                                       count_type_synth)
 
+    # Largest list length encodable in a single burst's count field. Lists
+    # longer than this are split across multiple header/data bursts (the
+    # read-side `SerialListTypeDeserializer` reassembles them), each burst
+    # carrying at most this many data frames. `count_width` is <= 64 (the
+    # count field's storage type tops out at 64 bits), so this literal always
+    # fits in a `size_t`.
+    max_batch_val = (1 << info["count_width"]) - 1
+
     hdr.write(
         f"struct {info['window_name']} : public esi::SegmentedMessageData {{\n")
     hdr.write("public:\n")
@@ -2156,26 +2164,43 @@ class CppTypeEmitter:
     self._emit_window_frame(hdr, "header_frame", info["frame_bytes"],
                             header_layout)
     hdr.write("\n")
-    hdr.write("  header_frame header{};\n")
+    hdr.write("  // One header per burst (bursts 2..N are continuations whose\n"
+              "  // only meaningful field is the count); the data frames of\n"
+              "  // every burst are stored contiguously in `data_frames` and\n"
+              "  // sliced per burst by `segment()`.\n")
+    hdr.write("  std::vector<header_frame> headers;\n")
     hdr.write("  std::vector<data_frame> data_frames;\n")
     hdr.write("  header_frame footer{};\n\n")
+    hdr.write("  // Largest list length encodable in one burst's count field.\n"
+              "  // Longer lists are chunked across multiple bursts.\n")
+    hdr.write(f"  static constexpr size_t _kMaxBatch = {max_batch_val}ULL;\n\n")
     hdr.write(f"  void construct({frame_ctor_signature}) {{\n")
     hdr.write("    if (frames.empty())\n")
     hdr.write(
         f"      throw std::invalid_argument(\"{info['window_name']}: bulk windowed lists cannot be empty\");\n"
     )
-    hdr.write(
-        "    if (frames.size() > std::numeric_limits<count_type>::max())\n")
-    hdr.write(
-        f"      throw std::invalid_argument(\"{info['window_name']}: list too large for encoded count\");\n"
-    )
-    hdr.write(
-        f"    header.{info['count_field_name']}(static_cast<count_type>(frames.size()));\n"
-    )
-    for name, _ in info["ctor_params"]:
-      hdr.write(f"    header.{name}({name});\n")
-    hdr.write(f"    footer.{info['count_field_name']}(0);\n")
     hdr.write("    data_frames = std::move(frames);\n")
+    hdr.write("    // Split the list into bursts no larger than the count\n"
+              "    // field can encode. The read side reassembles the bursts\n"
+              "    // back into a single list.\n")
+    hdr.write("    const size_t total = data_frames.size();\n")
+    hdr.write(
+        "    const size_t numBatches = (total + _kMaxBatch - 1) / _kMaxBatch;\n"
+    )
+    hdr.write("    headers.assign(numBatches, header_frame{});\n")
+    hdr.write("    for (size_t b = 0; b < numBatches; ++b) {\n")
+    hdr.write(
+        "      const size_t batchSize =\n"
+        "          std::min<size_t>(_kMaxBatch, total - b * _kMaxBatch);\n")
+    hdr.write(
+        f"      headers[b].{info['count_field_name']}(static_cast<count_type>(batchSize));\n"
+    )
+    hdr.write("    }\n")
+    hdr.write(
+        "    // Only the first burst's header carries the static fields.\n")
+    for name, _ in info["ctor_params"]:
+      hdr.write(f"    headers.front().{name}({name});\n")
+    hdr.write(f"    footer.{info['count_field_name']}(0);\n")
     hdr.write("  }\n\n")
     hdr.write("public:\n")
     hdr.write(f"  {info['window_name']}({frame_ctor_signature}) {{\n")
@@ -2190,24 +2215,30 @@ class CppTypeEmitter:
     hdr.write("    }\n")
     hdr.write(f"    construct({helper_call});\n")
     hdr.write("  }\n\n")
-    hdr.write("  size_t numSegments() const override { return 3; }\n")
+    hdr.write("  size_t numSegments() const override {\n"
+              "    return 2 * headers.size() + 1;\n"
+              "  }\n")
     hdr.write("  esi::Segment segment(size_t idx) const override {\n")
-    hdr.write("    if (idx == 0)\n")
-    hdr.write(
-        "      return {reinterpret_cast<const uint8_t *>(&header), sizeof(header)};\n"
-    )
-    hdr.write("    if (idx == 1)\n")
-    hdr.write(
-        "      return {reinterpret_cast<const uint8_t *>(data_frames.data()),\n"
-    )
-    hdr.write("              data_frames.size() * sizeof(data_frame)};\n")
-    hdr.write("    if (idx == 2)\n")
+    hdr.write("    const size_t footerIdx = 2 * headers.size();\n")
+    hdr.write("    if (idx == footerIdx)\n")
     hdr.write(
         "      return {reinterpret_cast<const uint8_t *>(&footer), sizeof(footer)};\n"
     )
+    hdr.write("    if (idx > footerIdx)\n")
     hdr.write(
-        f"    throw std::out_of_range(\"{info['window_name']}: invalid segment index\");\n"
+        f"      throw std::out_of_range(\"{info['window_name']}: invalid segment index\");\n"
     )
+    hdr.write("    const size_t b = idx / 2;\n")
+    hdr.write("    if (idx % 2 == 0)\n")
+    hdr.write("      return {reinterpret_cast<const uint8_t *>(&headers[b]),\n"
+              "              sizeof(header_frame)};\n")
+    hdr.write("    const size_t start = b * _kMaxBatch;\n")
+    hdr.write(
+        "    const size_t batchSize =\n"
+        "        std::min<size_t>(_kMaxBatch, data_frames.size() - start);\n")
+    hdr.write(
+        "    return {reinterpret_cast<const uint8_t *>(data_frames.data() + start),\n"
+        "            batchSize * sizeof(data_frame)};\n")
     hdr.write("  }\n\n")
     hdr.write(
         f"  static constexpr std::string_view _ESI_ID = {self._cpp_string_literal(self._unwrap_aliases(window_type.into_type).id)};\n"
@@ -2239,9 +2270,11 @@ class CppTypeEmitter:
       cpp = self._cpp_type(field_type)
       # The header-frame accessor returns by value (it pulls bytes out of
       # the raw buffer), so this is also returned by value regardless of
-      # whether the underlying type is a scalar or an aggregate.
+      # whether the underlying type is a scalar or an aggregate. The static
+      # fields live on the first burst's header.
       hdr.write(
-          f"  {cpp} {field_name}() const {{ return header.{field_name}(); }}\n")
+          f"  {cpp} {field_name}() const {{ return headers.front().{field_name}(); }}\n"
+      )
     hdr.write(
         f"  size_t {list_field_name}_count() const {{ return data_frames.size(); }}\n"
     )

--- a/lib/Dialect/ESI/runtime/tests/integration/hw/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/hw/test_codegen.py
@@ -735,6 +735,85 @@ class ChannelWindowedListRead(Module):
     esi.ChannelService.to_host(AppID("data"), p2s.serial_out)
 
 
+# Multi-burst read: the list is longer than the serial encoder's data FIFO, so
+# `ListWindowToSerial` emits it as several header/data bursts (via its
+# split-on-full path) terminated by a single count==0 footer, rather than one
+# big burst. The host-side `SerialListTypeDeserializer` must stitch those
+# bursts back into a single list. The count field stays 16 bits (byte-aligned,
+# header fills the frame), so this exercises the multi-burst *reassembly*
+# without depending on the sub-byte frame layout the C++ facade codegen does
+# not yet model.
+_MULTIBURST_READ_TAG = 0xF00D
+_MULTIBURST_READ_ITEMS = [0x1000 + i for i in range(10)]
+_MULTIBURST_READ_FIFO_DEPTH = 4
+
+
+class ChannelMultiBurstListRead(Module):
+  """To-host channel that emits a list split across multiple serial bursts.
+
+  Same shape as `ChannelWindowedListRead`, but the ten-element list exceeds
+  the serial encoder's data FIFO (depth 4), so `ListWindowToSerial` emits the
+  list as several header/data bursts (4 + 4 + 2) followed by a single count==0
+  footer. Verifies that the host-side `SerialListTypeDeserializer` reassembles
+  a multi-burst transfer back into one list. A write to offset ``0x10`` of the
+  ``trigger`` MMIO region arms one transfer.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    clk = ports.clk
+    rst = ports.rst
+
+    # MMIO trigger: any write to offset 0x10 arms one transfer.
+    trigger_bundle = esi.MMIO.read_write(appid=AppID("trigger"))
+    resp_chan = Wire(Channel(Bits(64)))
+    cmd_chan = trigger_bundle.unpack(data=resp_chan)["cmd"]
+    cmd_xact, cmd = cmd_chan.snoop_xact()
+    resp_chan.assign(cmd_chan.transform(lambda c: Bits(64)(c.data)))
+    trigger_xact = cmd_xact & (cmd.offset == UInt(32)(0x10))
+
+    n_items = len(_MULTIBURST_READ_ITEMS)
+    burst_end = Wire(Bits(1))
+
+    # ``armed`` is high for the duration of one list: set on a trigger write,
+    # cleared on the cycle the final item handshakes. The producer streams all
+    # ten items with a single ``last`` on item 9 -- the split into bursts
+    # happens entirely inside `ListWindowToSerial`.
+    armed = ControlReg(clk, rst, asserts=[trigger_xact], resets=[burst_end])
+
+    par_ready = Wire(Bits(1))
+    handshake = armed & par_ready
+    idx_counter = Counter(4)(clk=clk,
+                             rst=rst,
+                             clear=burst_end,
+                             increment=handshake,
+                             instance_name="multiburst_read_idx")
+    idx = idx_counter.out
+    last_bit = (idx == UInt(4)(n_items - 1))
+    burst_end.assign(handshake & last_bit)
+    item_value = Array(Bits(32), n_items)(_MULTIBURST_READ_ITEMS)[idx.as_bits()]
+
+    parallel_window_type = Window.default_of(_window_probe_struct)
+    par_struct = parallel_window_type.lowered_type({
+        "tag": Bits(16)(_MULTIBURST_READ_TAG),
+        "items": item_value,
+        "last": last_bit,
+    })
+    par_window = parallel_window_type.wrap(par_struct)
+    parallel_chan, parallel_ready = Channel(parallel_window_type).wrap(
+        par_window, armed)
+    par_ready.assign(parallel_ready)
+
+    p2s = ListWindowToSerial(parallel_window_type, _WINDOW_PROBE_BULK_WIDTH,
+                             _WINDOW_PROBE_ITEMS_PER_FRAME,
+                             _MULTIBURST_READ_FIFO_DEPTH)(
+                                 clk=clk, rst=rst, parallel_in=parallel_chan)
+    esi.ChannelService.to_host(AppID("data"), p2s.serial_out)
+
+
 class ChannelWindowedListWrite(Module):
   """From-host channel of ``window<{tag, list<si32>}>``.
 
@@ -812,6 +891,99 @@ class ChannelWindowedListWrite(Module):
             lambda _: final_match.as_bits(1).pad_or_truncate(64).as_bits(64)))
 
 
+# Multi-burst bare-list window. The bulk count is 8 bits, so each burst can
+# carry at most 255 items; a 256-element list must therefore be split by the
+# host serializer into two bursts (255 + 1). Hardware reassembles the bursts
+# via `ListWindowToParallel` and validates every item in order, proving the
+# write-side burst chunking round-trips through hardware.
+#
+# The window is a *bare* list of byte-sized items (no static header fields)
+# with an 8-bit count, so both the header frame (a single ui8 count) and each
+# data frame (one ui8) fill exactly one byte with no frame padding. That keeps
+# the on-wire layout unambiguous: a narrower (sub-byte) count would introduce
+# sub-byte frame padding, which the C++ facade codegen does not currently
+# model.
+_MULTIBURST_N_ITEMS = 256
+_MULTIBURST_BULK_WIDTH = 8
+_MULTIBURST_ITEMS_PER_FRAME = 1
+_multiburst_struct = StructType([("items", List(Bits(8)))])
+_multiburst_window = Window.serial_of(_multiburst_struct,
+                                      _MULTIBURST_BULK_WIDTH,
+                                      _MULTIBURST_ITEMS_PER_FRAME)
+
+
+class ChannelMultiBurstListWrite(Module):
+  """From-host channel of ``window<{list<ui8>}>`` with an 8-bit bulk count.
+
+  The 8-bit bulk count caps each burst at 255 items, so the host splits the
+  256-element list into two bursts (255 + 1). Hardware reassembles the bursts
+  via `ListWindowToParallel`, AND-reduces per-beat equality against the
+  expected ``item[i] == i`` pattern, and latches the result into the ``match``
+  MMIO region. This is the end-to-end check that the host-side multi-burst
+  serialization is correct.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    clk = ports.clk
+    rst = ports.rst
+
+    chan = esi.ChannelService.from_host(AppID("data"), _multiburst_window)
+    s2p = ListWindowToParallel(_multiburst_window)(clk=clk,
+                                                   rst=rst,
+                                                   serial_in=chan)
+    par_ready = Wire(Bits(1))
+    par_window, par_valid = s2p.parallel_out.unwrap(par_ready)
+    par_struct = par_window.unwrap()
+    par_ready.assign(Bits(1)(1))
+
+    handshake = par_valid
+    last_bit = par_struct["last"].as_bits(1)
+
+    # Counter cycles 0..255, clears on the burst-end beat. Each item's value
+    # equals its position, so the expected value is simply the index.
+    idx_clr = (handshake & last_bit).as_bits(1)
+    idx_counter = Counter(8)(clk=clk,
+                             rst=rst,
+                             clear=idx_clr,
+                             increment=handshake,
+                             instance_name="multiburst_write_idx")
+    idx = idx_counter.out
+
+    beat_ok = (par_struct["items"].as_bits(8) == idx.as_bits(8)).as_bits(1)
+
+    # Running AND-reduce across the whole (reassembled) list; latches into
+    # ``final_match`` on the last item's beat.
+    running_match = Wire(Bits(1))
+    running_match_reg = Reg(Bits(1),
+                            clk=clk,
+                            rst=rst,
+                            rst_value=1,
+                            ce=handshake,
+                            name="multiburst_match_running")
+    running_match.assign((running_match_reg & beat_ok).as_bits(1))
+    running_match_reg.assign(running_match)
+
+    final_match = Reg(Bits(1),
+                      clk=clk,
+                      rst=rst,
+                      rst_value=0,
+                      ce=idx_clr,
+                      name="multiburst_match_final")
+    final_match.assign(running_match)
+
+    # Expose the latched flag via MMIO read.
+    mmio_bundle = esi.MMIO.read(appid=AppID("match"))
+    resp_chan = Wire(Channel(Bits(64)))
+    addr_chan = mmio_bundle.unpack(data=resp_chan)["offset"]
+    resp_chan.assign(
+        addr_chan.transform(
+            lambda _: final_match.as_bits(1).pad_or_truncate(64).as_bits(64)))
+
+
 class Top(Module):
   clk = Clock()
   rst = Reset()
@@ -870,9 +1042,16 @@ class Top(Module):
     ChannelWindowedListRead(clk=ports.clk,
                             rst=ports.rst,
                             appid=AppID("channel_windowed_list_read_inst"))
+    ChannelMultiBurstListRead(clk=ports.clk,
+                              rst=ports.rst,
+                              appid=AppID("channel_multiburst_list_read_inst"))
     ChannelWindowedListWrite(clk=ports.clk,
                              rst=ports.rst,
                              appid=AppID("channel_windowed_list_write_inst"))
+    ChannelMultiBurstListWrite(
+        clk=ports.clk,
+        rst=ports.rst,
+        appid=AppID("channel_multiburst_list_write_inst"))
     CallbackWindowedList(clk=ports.clk,
                          rst=ports.rst,
                          appid=AppID("callback_windowed_list_inst"))

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/test_codegen.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/test_codegen.cpp
@@ -10,6 +10,8 @@
 
 #include "test_codegen/CallServiceCallback.h"
 #include "test_codegen/CallbackWindowedList.h"
+#include "test_codegen/ChannelMultiBurstListRead.h"
+#include "test_codegen/ChannelMultiBurstListWrite.h"
 #include "test_codegen/ChannelWindowedListRead.h"
 #include "test_codegen/ChannelWindowedListWrite.h"
 #include "test_codegen/CustomServiceDeclChannel.h"
@@ -517,6 +519,54 @@ static int runChannelWindowedListRead(Accelerator *accel) {
 }
 
 //===----------------------------------------------------------------------===//
+// To-host channel whose list is longer than the HW serial encoder's data FIFO,
+// so `ListWindowToSerial` emits it as several header/data bursts terminated by
+// a single count==0 footer. Exercises the host-side
+// `SerialListTypeDeserializer` multi-burst *reassembly* path end-to-end.
+//===----------------------------------------------------------------------===//
+static int runChannelMultiBurstListRead(Accelerator *accel) {
+  esi_system::ChannelMultiBurstListRead mod(
+      findInst(accel, "channel_multiburst_list_read_inst"));
+  auto c = mod.connect();
+
+  using WinT = esi_system::ChannelMultiBurstListRead::dataData;
+
+  // Arm one transfer via the MMIO trigger.
+  c->trigger.write(0x10, 0u);
+
+  std::unique_ptr<WinT> got = c->data.read();
+  if (!got)
+    throw std::runtime_error("channel_multiburst_list_read: null read result");
+  // The HW streams ten items ``[0x1000 .. 0x1009]`` with ``tag = 0xF00D``; the
+  // depth-4 encoder FIFO splits them into three bursts (4 + 4 + 2) that the
+  // host deserializer must reassemble into a single ten-element list.
+  static constexpr uint16_t kTag = 0xF00D;
+  static constexpr size_t kNumItems = 10;
+  if (got->tag() != kTag)
+    throw std::runtime_error(
+        "channel_multiburst_list_read: wrong tag, expected 0x" +
+        toHex(static_cast<uint64_t>(kTag)) + " got 0x" +
+        toHex(static_cast<uint64_t>(got->tag())));
+  if (got->items_count() != kNumItems)
+    throw std::runtime_error(
+        "channel_multiburst_list_read: wrong item count, expected " +
+        std::to_string(kNumItems) + " got " +
+        std::to_string(got->items_count()));
+  size_t i = 0;
+  for (uint32_t v : got->items()) {
+    uint32_t expected = 0x1000u + static_cast<uint32_t>(i);
+    if (v != expected)
+      throw std::runtime_error("channel_multiburst_list_read: element " +
+                               std::to_string(i) + " expected 0x" +
+                               toHex(expected) + " got 0x" + toHex(v));
+    ++i;
+  }
+  std::cout << "channel_multiburst_list_read ok (10 items reassembled from 3 "
+               "bursts)\n";
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
 // From-host channel of windowed list-with-header. Exercises the typed write
 // path: the host constructs a complete burst from a header tag plus a list of
 // items, and the HW AND-reduces each beat against the expected pattern. The
@@ -551,6 +601,49 @@ static int runChannelWindowedListWrite(Accelerator *accel) {
         toHex(match) + ")");
   std::cout << "channel_windowed_list_write ok (tag=0x"
             << toHex(static_cast<uint64_t>(kTag)) << ", items=[10,20,30,40])\n";
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
+// From-host channel of a windowed list whose count field is too narrow to
+// encode the whole list in one burst. The host serializer must split the
+// 256-item list into multiple bursts (the window's 8-bit count caps each
+// burst at 255 items); the HW reassembles them and validates every item.
+// Exercises the write-side multi-burst chunking end-to-end.
+//===----------------------------------------------------------------------===//
+static int runChannelMultiBurstListWrite(Accelerator *accel) {
+  esi_system::ChannelMultiBurstListWrite mod(
+      findInst(accel, "channel_multiburst_list_write_inst"));
+  auto c = mod.connect();
+
+  using WinT = esi_system::ChannelMultiBurstListWrite::dataData;
+
+  // 256 items, value == index. The window's 8-bit count caps each burst at
+  // 255, so the host serializer splits this into two bursts (255 + 1).
+  std::vector<uint8_t> items;
+  items.reserve(256);
+  for (int v = 0; v < 256; ++v)
+    items.push_back(static_cast<uint8_t>(v));
+  c->data.write(WinT(items));
+
+  // Poll the match flag MMIO until the (reassembled) burst has been processed
+  // or we time out. The HW updates the latch on the final item's beat.
+  using clock = std::chrono::steady_clock;
+  auto deadline = clock::now() + std::chrono::seconds(5);
+  uint64_t match = 0;
+  while (clock::now() < deadline) {
+    match = c->match.read(0);
+    if (match & 1)
+      break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  if (!(match & 1))
+    throw std::runtime_error(
+        "channel_multiburst_list_write: HW did not report a match within "
+        "timeout (got 0x" +
+        toHex(match) + ")");
+  std::cout << "channel_multiburst_list_write ok (256 items split across 2 "
+               "bursts)\n";
   return 0;
 }
 
@@ -641,5 +734,7 @@ ESI_PROBE_REGISTRY(
     {"typed_func_array_result", &runTypedFuncArrayResult},
     {"typed_func_windowed_list", &runTypedFuncWindowedList},
     {"channel_windowed_list_read", &runChannelWindowedListRead},
+    {"channel_multiburst_list_read", &runChannelMultiBurstListRead},
     {"channel_windowed_list_write", &runChannelWindowedListWrite},
+    {"channel_multiburst_list_write", &runChannelMultiBurstListWrite},
     {"callback_windowed_list", &runCallbackWindowedList}, );

--- a/lib/Dialect/ESI/runtime/tests/integration/test_codegen_cpp.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_codegen_cpp.py
@@ -42,7 +42,9 @@ PROBES = [
     "typed_func_array_result",
     "typed_func_windowed_list",
     "channel_windowed_list_read",
+    "channel_multiburst_list_read",
     "channel_windowed_list_write",
+    "channel_multiburst_list_write",
     "callback_windowed_list",
 ]
 

--- a/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
+++ b/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <ranges>
 #include <type_traits>
 #include <vector>
@@ -495,6 +496,66 @@ void testWindowList() {
 }
 
 // ---------------------------------------------------------------------------
+// Multi-burst chunking: a window whose count field is too narrow to encode
+// the whole list in one burst must split the list across several
+// header/data bursts (terminated by a zero-count footer) and the read-side
+// deserializer must reassemble it back into the original list.
+// ---------------------------------------------------------------------------
+
+void testWindowListMultiBurst() {
+  // SmallListWindow has a 2-bit count field, so at most 3 items fit in one
+  // burst. A 7-item list therefore splits into 3 bursts of 3 + 3 + 1 items.
+  std::vector<uint32_t> elements = {0x11111111u, 0x22222222u, 0x33333333u,
+                                    0x44444444u, 0x55555555u, 0x66666666u,
+                                    0x77777777u};
+  SmallListWindow win(0xBEEF, elements);
+
+  assert(win.tag() == 0xBEEF);
+  assert(win.items_count() == elements.size());
+
+  // ceil(7 / 3) = 3 bursts -> 3 headers + 3 data + 1 footer = 7 segments.
+  assert(win.numSegments() == 2 * 3 + 1);
+
+  // Each header / footer frame is 4 bytes. Data segments carry 3, 3, then 1
+  // item(s), one ui32 (4 bytes) per item.
+  assert(win.segment(0).size == 4);                    // burst 0 header
+  assert(win.segment(1).size == 3 * sizeof(uint32_t)); // burst 0 data
+  assert(win.segment(2).size == 4);                    // burst 1 header
+  assert(win.segment(3).size == 3 * sizeof(uint32_t)); // burst 1 data
+  assert(win.segment(4).size == 4);                    // burst 2 header
+  assert(win.segment(5).size == 1 * sizeof(uint32_t)); // burst 2 data
+  assert(win.segment(6).size == 4);                    // footer
+
+  // The per-burst count lives in the low 2 bits of header byte 1 (a 1-byte
+  // pad precedes it because the data frame is wider than the header). Verify
+  // the encoded batch counts: 3, 3, 1, and a zero-count footer.
+  assert((win.segment(0).data[1] & 0x3) == 3);
+  assert((win.segment(2).data[1] & 0x3) == 3);
+  assert((win.segment(4).data[1] & 0x3) == 1);
+  assert((win.segment(6).data[1] & 0x3) == 0);
+
+  // Round-trip: flatten the multi-burst stream and feed it back through the
+  // generated serial-list deserializer. It must rebuild one window holding
+  // all 7 items with the original tag.
+  std::unique_ptr<SmallListWindow> decoded;
+  SmallListWindow::TypeDeserializer deser(
+      [&](std::unique_ptr<SmallListWindow> &out) {
+        decoded = std::move(out);
+        return true;
+      });
+  std::unique_ptr<esi::SegmentedMessageData> msg =
+      std::make_unique<esi::MessageData>(win.toMessageData());
+  bool pushed = deser.push(msg);
+  assert(pushed);
+  assert(decoded);
+  assert(decoded->tag() == 0xBEEF);
+  auto reassembled = decoded->items_vector();
+  assert(reassembled.size() == elements.size());
+  for (std::size_t j = 0; j < elements.size(); ++j)
+    assert(reassembled[j] == elements[j]);
+}
+
+// ---------------------------------------------------------------------------
 // Path D — value-class fields (esi::MutableBitVector, esi::Int, esi::UInt)
 // ---------------------------------------------------------------------------
 
@@ -808,6 +869,7 @@ int main() {
   testSubByteStructArray();
   testUnion();
   testWindowList();
+  testWindowListMultiBurst();
   testWideUnsigned();
   testWideSigned();
   testBitsField();

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -220,6 +220,51 @@ def _build_harness_manifest():
   # Hand-name the window so the harness can spell `ListWindow` directly.
   list_window = types.TypeAlias("@ListWindow", "ListWindow", list_window_inner)
 
+  # Window helper with a *narrow* (2-bit) count field. `maxBatch = 3`, so any
+  # list longer than three items must be chunked into multiple header/data
+  # bursts on the write side (and reassembled by the read-side
+  # `SerialListTypeDeserializer`). Mirrors `ListWindow` otherwise.
+  sw_arg_inner = types.StructType(
+      "@SmallListWindow::arg",
+      [("tag", _uint16), ("items", list_type)],
+  )
+  sw_header_inner = types.StructType(
+      "@SmallListWindow::header",
+      [("tag", _uint16), ("items_count", _uint2)],
+  )
+  sw_data_inner = types.StructType(
+      "@SmallListWindow::data",
+      [("items", types.ArrayType("!hw.array<1xui32>", _uint32, 1))],
+  )
+  sw_lowered = types.UnionType(
+      "@SmallListWindow::lowered",
+      [("header", sw_header_inner), ("data", sw_data_inner)],
+  )
+  sw_window_id = ('!esi.window<"SmallListWindow", @SmallListWindow::arg, '
+                  '[<"header", [<"tag">, <"items" countWidth 2>]>, '
+                  '<"data", [<"items", 1>]>]>')
+  small_list_window_inner = types.WindowType(
+      sw_window_id,
+      "SmallListWindow",
+      sw_arg_inner,
+      sw_lowered,
+      [
+          types.WindowType.Frame(
+              "header",
+              [
+                  types.WindowType.Field("tag", 0, 0),
+                  types.WindowType.Field("items", 0, 2),
+              ],
+          ),
+          types.WindowType.Frame(
+              "data",
+              [types.WindowType.Field("items", 1, 0)],
+          ),
+      ],
+  )
+  small_list_window = types.TypeAlias("@SmallListWindow", "SmallListWindow",
+                                      small_list_window_inner)
+
   # Path D: value-class fields backed by `esi::MutableBitVector` /
   # `esi::Int` / `esi::UInt` from `esi/Values.h`. Covers BitsType at
   # both narrow and wide widths, plus signed/unsigned integers above
@@ -282,8 +327,8 @@ def _build_harness_manifest():
   return [
       std_u, std_s, odd_u, odd_s, sub_u, sub_s, bool_field, outer, misaligned,
       arr4, u3_arr, bits1_arr, s5_arr, u24_arr, sb_cell, sb_cell_arr, union_two,
-      list_window, wide_u, wide_s, bits_field, wide_mis, arr_views,
-      arr_views_mis
+      list_window, small_list_window, wide_u, wide_s, bits_field, wide_mis,
+      arr_views, arr_views_mis
   ]
 
 


### PR DESCRIPTION
When a list cannot be contained in one burst, it needs to get split up into more than one burst. This was supported in the read direction, but not in the write direction. Add an integration test for the read direction and support for the write direction.

Assisted-by: Github-Copilot:Claude Opus 4.8