### PR TITLE
[ESI][Runtime] Fix engine teardown oversight

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -100,7 +100,10 @@ public:
   Context &getCtxt() const { return ctxt; }
   Logger &getLogger() const { return ctxt.getLogger(); }
 
-  /// Disconnect from the accelerator cleanly.
+  /// Disconnect from the accelerator cleanly. Drains owned engines before the
+  /// accelerator is released. Backends _must_ call this from their destructor
+  /// while still fully constructed (their vtable/resources alive), since engine
+  /// teardown may reference accelerator-owned objects. Must be idempotent.
   virtual void disconnect();
 
   /// Request a reset of the accelerator design. Returns true if the reset was

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Engines.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Engines.h
@@ -45,7 +45,10 @@ public:
   virtual ~Engine() = default;
   /// Start the engine, if applicable.
   virtual void connect() { connected = true; };
-  /// Stop the engine, if applicable.
+  /// Stop the engine, if applicable. Guaranteed to be called (via the
+  /// connection's disconnect()) while the Accelerator and its MMIO regions are
+  /// still alive, so port teardown here may safely touch them. This method
+  /// _must_ be idempotent.
   virtual void disconnect() { connected = false; };
   /// Get a port for a channel, from the cache if it exists or create it. An
   /// engine may override this method if different behavior is desired.

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -121,10 +121,12 @@ AcceleratorConnection::takeOwnership(std::unique_ptr<Accelerator> acc) {
 }
 
 void AcceleratorConnection::clearOwnedObjects() {
-  ownedAccelerator.reset();
-  serviceCache.clear();
+  // Destroy engines (and the ports they own) before the accelerator they may
+  // reference during teardown -- order matters.
   clientEngines.clear();
   ownedEngines.clear();
+  serviceCache.clear();
+  ownedAccelerator.reset();
 }
 
 /// Get the path to the currently running executable.
@@ -499,10 +501,19 @@ void AcceleratorServiceThread::addPoll(HWModule &module) {
 }
 
 void AcceleratorConnection::disconnect() {
+  // Stop polling before tearing down engines.
   if (serviceThread) {
     serviceThread->stop();
     serviceThread.reset();
   }
+  // Drain engines while the accelerator (and its MMIO regions/services) is
+  // still alive, since engine/port teardown may touch accelerator-owned
+  // resources. Idempotent: disconnect() may be called more than once (e.g.
+  // explicitly and again from the destructor).
+  for (auto &[idPath, engine] : ownedEngines)
+    engine->disconnect();
+  clientEngines.clear();
+  ownedEngines.clear();
 }
 
 } // namespace esi


### PR DESCRIPTION
Some engines need to touch accelerator resources (e.g. MMIO regions) in their `disconnect`. So we need to ensure that those resources persist though engine disconnect/destruction.

Assisted-by: Githut-Copilot:Claude Opus 4.8
