### PR TITLE
[Calyx] Avoid invalid intermediate IR in common-tail canonicalization

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
+#include <type_traits>
 
 using namespace circt;
 using namespace circt::calyx;
@@ -2370,6 +2371,24 @@ static std::optional<EnableOp> getLastEnableOp(OpTy parent) {
   return std::nullopt;
 }
 
+static bool isOnlyNestedEnable(Block *body, EnableOp enableOp);
+
+static bool isOnlyNestedEnable(Operation *op, EnableOp enableOp) {
+  if (op == enableOp.getOperation())
+    return true;
+  if (auto seqOp = dyn_cast<SeqOp>(op))
+    return isOnlyNestedEnable(seqOp.getBodyBlock(), enableOp);
+  if (auto staticSeqOp = dyn_cast<StaticSeqOp>(op))
+    return isOnlyNestedEnable(staticSeqOp.getBodyBlock(), enableOp);
+  return false;
+}
+
+static bool isOnlyNestedEnable(Block *body, EnableOp enableOp) {
+  if (!llvm::hasSingleElement(*body))
+    return false;
+  return isOnlyNestedEnable(&body->front(), enableOp);
+}
+
 /// Returns a mapping of {enabled Group name, EnableOp} for all EnableOps within
 /// the immediate ParOp's body.
 template <typename OpTy>
@@ -2436,6 +2455,21 @@ static LogicalResult commonTailPatternWithSeq(IfOpTy ifOp,
     return failure();
   if (lastThenEnableOp->getGroupName() != lastElseEnableOp->getGroupName())
     return failure();
+
+  // If the common tail is the entire contents of both branches, replace the
+  // conditional directly. Otherwise, extracting the tail first may leave an
+  // invalid intermediate IR state before the empty-control canonicalizations
+  // run, which is rejected by MLIR expensive pattern API checks.
+  if (isOnlyNestedEnable(thenControl.getBodyBlock(), *lastThenEnableOp) &&
+      isOnlyNestedEnable(elseControl.getBodyBlock(), *lastElseEnableOp)) {
+    rewriter.setInsertionPoint(ifOp);
+    EnableOp::create(rewriter, ifOp.getLoc(), lastThenEnableOp->getGroupName());
+    if constexpr (std::is_same_v<IfOpTy, IfOp>)
+      eraseControlWithGroupAndConditional(ifOp, rewriter);
+    else
+      eraseControlWithConditional(ifOp, rewriter);
+    return success();
+  }
 
   // Place the IfOp and pulled EnableOp inside a sequential region, in case
   // this IfOp is nested in a ParOp. This avoids unintentionally

--- a/test/Dialect/Calyx/canonicalization.mlir
+++ b/test/Dialect/Calyx/canonicalization.mlir
@@ -445,7 +445,7 @@ module attributes {calyx.entrypoint = "main"} {
 
 // -----
 
-// Empty Then and Else regions lead to the removal of the IfOp (as well as unused cells and groups).
+// IfOp whose common tail is the entire Then and Else body is replaced directly.
 module attributes {calyx.entrypoint = "main"} {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
@@ -453,7 +453,7 @@ module attributes {calyx.entrypoint = "main"} {
     %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
-      // CHECK-NOT: calyx.comp_group @Cond
+      // CHECK-NOT: calyx.comb_group @Cond
       calyx.comb_group @Cond {
         calyx.assign %eq.left =  %c1_1 : i1
         calyx.assign %eq.right = %c1_1 : i1
@@ -477,6 +477,42 @@ module attributes {calyx.entrypoint = "main"} {
           }
         } else {
           calyx.seq {
+            calyx.enable @A
+          }
+        }
+      }
+    }
+  }
+}
+
+// -----
+
+// StaticIfOp whose common tail is the entire Then and Else body is replaced directly.
+module attributes {calyx.entrypoint = "main"} {
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    // CHECK-NOT: %eq.in, %eq.write_en, %eq.clk, %eq.reset, %eq.out, %eq.done = calyx.register @eq : i1, i1, i1, i1, i1, i1
+    %eq.in, %eq.write_en, %eq.clk, %eq.reset, %eq.out, %eq.done = calyx.register @eq : i1, i1, i1, i1, i1, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+      calyx.static_group latency<1> @A {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+      }
+    }
+    // CHECK-LABEL: calyx.control {
+    // CHECK-NEXT:    calyx.seq {
+    // CHECK-NEXT:      calyx.enable @A
+    // CHECK-NEXT:    }
+    // CHECK-NEXT:  }
+    calyx.control {
+      calyx.seq {
+        calyx.static_if %eq.out {
+          calyx.static_seq {
+            calyx.enable @A
+          }
+        } else {
+          calyx.static_seq {
             calyx.enable @A
           }
         }
@@ -555,7 +591,7 @@ module attributes {calyx.entrypoint = "main"} {
     %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
-      // CHECK-NOT: calyx.comp_group @Cond
+      // CHECK-NOT: calyx.comb_group @Cond
       calyx.comb_group @Cond {
         calyx.assign %eq.left =  %c1_1 : i1
         calyx.assign %eq.right = %c1_1 : i1


### PR DESCRIPTION
## Summary

This addresses one Calyx canonicalization failure exposed by `-DMLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON`.

The common-tail canonicalization for `calyx.if` / `calyx.static_if` can pull the same trailing `calyx.enable` out of both seq-like branches. When that enable is the entire contents of both branches, extracting the tail first may leave an invalid intermediate IR state before the empty-control canonicalizations run.

This patch handles that special case directly: if both branches contain only the same nested enable, replace the conditional with that enable and erase the conditional/condition cleanup in one rewrite.

Part of #7047.

## Changes

- Detect the “only nested enable” case in seq/static_seq branches.
- Replace the conditional directly for that case.
- Preserve the existing common-tail extraction path for non-trivial branches.
- Add Calyx canonicalization coverage for dynamic and static trivial common-tail cases.
- Fix `comb_group` CHECK spelling in nearby tests.

## Verification

Targeted expensive-check build:
- `build-expensive/bin/llvm-lit -sv test/Dialect/Calyx/canonicalization.mlir`
- `build-expensive/bin/circt-opt test/Dialect/Calyx/canonicalization.mlir -canonicalize -split-input-file | build-expensive/bin/FileCheck test/Dialect/Calyx/canonicalization.mlir`
- `git diff --check`

Also ran:
- `ninja -C build-expensive check-circt`

The full expensive-check run still reports remaining failures outside this patch's Calyx canonicalization scope, including SCFToCalyx, LoopScheduleToCalyx, OM, memory_banking, and firtool/domain tests. The run reached lit and reported 30 failing tests before I stopped it on a long-running Comb scaling test under expensive checks.

## AI disclosure

I used Codex to help inspect the failing pattern and draft the initial patch. I manually reviewed the change, verified the affected canonicalization behavior, and ran the commands listed above.

Assisted-by: Codex:GPT-5