### PR TITLE
[circt-synth] Handle Add with Carry-In

### DIFF
--- a/integration_test/circt-synth/comb-lowering-add.mlir
+++ b/integration_test/circt-synth/comb-lowering-add.mlir
@@ -31,3 +31,18 @@ hw.module @add_brent_kung(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4
   hw.output %0 : i4
 }
 
+// RUN: circt-lec.sh %t.mlir %s -c1=add_ripple_carry_with_carry -c2=add_ripple_carry_with_carry
+hw.module @add_ripple_carry_with_carry(in %arg0: i4, in %arg1: i4, out add: i4) {
+  %c1_i4 = hw.constant 1 : i4
+  %0 = comb.add %arg0, %arg1, %c1_i4 {synth.test.arch = "RIPPLE-CARRY"} : i4
+  hw.output %0 : i4
+}
+
+// RUN: circt-lec.sh %t.mlir %s -c1=add_kogge_stone_with_carry -c2=add_kogge_stone_with_carry
+hw.module @add_kogge_stone_with_carry(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
+  %c1_i4 = hw.constant 1 : i4
+  %0 = comb.add %arg0, %arg1, %c1_i4 {synth.test.arch = "KOGGE-STONE"} : i4
+  hw.output %0 : i4
+}
+
+

--- a/lib/Conversion/CombToDatapath/CombToDatapath.cpp
+++ b/lib/Conversion/CombToDatapath/CombToDatapath.cpp
@@ -108,8 +108,7 @@ void ConvertCombToDatapathPass::runOnOperation() {
       return true;
 
     if (op.getNumOperands() == 3) {
-      if (auto constOp = dyn_cast_or_null<hw::ConstantOp>(
-              op.getOperand(2).getDefiningOp()))
+      if (auto constOp = op.getOperand(2).getDefiningOp<hw::ConstantOp>())
         return constOp.getValue().isOne();
     }
     return false;

--- a/lib/Conversion/CombToDatapath/CombToDatapath.cpp
+++ b/lib/Conversion/CombToDatapath/CombToDatapath.cpp
@@ -101,8 +101,8 @@ void ConvertCombToDatapathPass::runOnOperation() {
   target.addLegalDialect<datapath::DatapathDialect, comb::CombDialect,
                          hw::HWDialect>();
 
-  // Permit 2-input adders (carry-propagate adders) and 3-input adds with a
-  // constant-1 carry-in operand.
+  // Permit 2-input adders and 3-input adds with a constant-1 carry-in operand
+  // (carry-propagate adders).
   target.addDynamicallyLegalOp<comb::AddOp>([](comb::AddOp op) {
     if (op.getNumOperands() <= 2)
       return true;

--- a/lib/Conversion/CombToDatapath/CombToDatapath.cpp
+++ b/lib/Conversion/CombToDatapath/CombToDatapath.cpp
@@ -101,9 +101,19 @@ void ConvertCombToDatapathPass::runOnOperation() {
   target.addLegalDialect<datapath::DatapathDialect, comb::CombDialect,
                          hw::HWDialect>();
 
-  // Permit 2-input adders (carry-propagate adders)
-  target.addDynamicallyLegalOp<comb::AddOp>(
-      [](comb::AddOp op) { return op.getNumOperands() <= 2; });
+  // Permit 2-input adders (carry-propagate adders) and 3-input adds with a
+  // constant-1 carry-in operand.
+  target.addDynamicallyLegalOp<comb::AddOp>([](comb::AddOp op) {
+    if (op.getNumOperands() <= 2)
+      return true;
+
+    if (op.getNumOperands() == 3) {
+      if (auto constOp = dyn_cast_or_null<hw::ConstantOp>(
+              op.getOperand(2).getDefiningOp()))
+        return constOp.getValue().isOne();
+    }
+    return false;
+  });
   // TODO: determine lowering of multi-input multipliers
   target.addDynamicallyLegalOp<comb::MulOp>(
       [](comb::MulOp op) { return op.getNumOperands() > 2; });

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -823,11 +823,11 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
       if (!constOp || !constOp.getValue().isOne())
         return failure();
 
-      // Make a single bit value of width 
+      // Make a single bit constant 1 
       auto constOne = hw::ConstantOp::create(rewriter, op.getLoc(), APInt(1,1));
 
-      // Detected a add with a constant carryIn of 1 - this can be fed into the
-      // parallel prefix adder as a carry-in - essentially for free
+      // Every adder (parallel prefix or ripple-carry) can consume a single-bit 
+      // carry-in without additional logic.
       return lowerAdder(op, inputs.take_front(2), constOne, rewriter);
     }
 
@@ -897,8 +897,10 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
   LogicalResult lowerAdder(comb::AddOp op, ValueRange inputs, Value carryIn,
                            ConversionPatternRewriter &rewriter) const {
 
+    // Check that the carryIn is a 1-bit value if it is provided (not necessarily a constant 1).
     assert(carryIn == nullptr || carryIn.getType().getIntOrFloatBitWidth() == 1 &&
            "carryIn must be a 1-bit value");
+    
     // Check if the architecture is specified by an attribute.
     auto width = op.getType().getIntOrFloatBitWidth();
     auto arch = determineAdderArch(op, width);
@@ -934,8 +936,12 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
       for (int64_t i = 0; i < width; ++i) {
         // p_i = a_i XOR b_i
         llvm::dbgs() << "P0" << i << " = A" << i << " XOR B" << i << "\n";
-        // g_i = a_i AND b_i
-        llvm::dbgs() << "G0" << i << " = A" << i << " AND B" << i << "\n";
+        if (i==0 && carryIn)
+          llvm::dbgs() << "G0" << i << " = (A" << i << " AND B" << i
+                       << ") OR (P" << i << " AND CARRY_IN)\n";
+        else
+          // g_i = a_i AND b_i
+          llvm::dbgs() << "G0" << i << " = A" << i << " AND B" << i << "\n";
       }
     });
 
@@ -946,7 +952,7 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     // Select the Parallel Prefix Architecture
     switch (arch) {
     case AdderArchitecture::RippleCarry:
-      llvm_unreachable("Ripple-Carry should be handled separately");
+      llvm_unreachable("Ripple-Carry handled above");
       break;
     case AdderArchitecture::Sklanskey:
       lowerSklanskeyPrefixTree(rewriter, op.getLoc(), pPrefix, gPrefix);

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -823,10 +823,11 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
       if (!constOp || !constOp.getValue().isOne())
         return failure();
 
-      // Make a single bit constant 1 
-      auto constOne = hw::ConstantOp::create(rewriter, op.getLoc(), APInt(1,1));
+      // Make a single bit constant 1
+      auto constOne =
+          hw::ConstantOp::create(rewriter, op.getLoc(), APInt(1, 1));
 
-      // Every adder (parallel prefix or ripple-carry) can consume a single-bit 
+      // Every adder (parallel prefix or ripple-carry) can consume a single-bit
       // carry-in without additional logic.
       return lowerAdder(op, inputs.take_front(2), constOne, rewriter);
     }
@@ -897,10 +898,12 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
   LogicalResult lowerAdder(comb::AddOp op, ValueRange inputs, Value carryIn,
                            ConversionPatternRewriter &rewriter) const {
 
-    // Check that the carryIn is a 1-bit value if it is provided (not necessarily a constant 1).
-    assert(carryIn == nullptr || carryIn.getType().getIntOrFloatBitWidth() == 1 &&
-           "carryIn must be a 1-bit value");
-    
+    // Check that the carryIn is a 1-bit value if it is provided (not
+    // necessarily a constant 1).
+    assert(carryIn == nullptr ||
+           carryIn.getType().getIntOrFloatBitWidth() == 1 &&
+               "carryIn must be a 1-bit value");
+
     // Check if the architecture is specified by an attribute.
     auto width = op.getType().getIntOrFloatBitWidth();
     auto arch = determineAdderArch(op, width);
@@ -936,7 +939,7 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
       for (int64_t i = 0; i < width; ++i) {
         // p_i = a_i XOR b_i
         llvm::dbgs() << "P0" << i << " = A" << i << " XOR B" << i << "\n";
-        if (i==0 && carryIn)
+        if (i == 0 && carryIn)
           llvm::dbgs() << "G0" << i << " = (A" << i << " AND B" << i
                        << ") OR (P" << i << " AND CARRY_IN)\n";
         else
@@ -983,8 +986,12 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     replaceOpWithNewOpAndCopyNamehint<comb::ConcatOp>(rewriter, op, results);
 
     LLVM_DEBUG({
-      llvm::dbgs() << "--------------------------------------- Completion\n"
-                   << "RES0 = P0\n";
+      llvm::dbgs() << "--------------------------------------- Completion\n";
+
+      if (carryIn)
+        llvm::dbgs() << "RES0 = P0 XOR CARRY_IN\n";
+      else
+        llvm::dbgs() << "RES0 = P0\n";
       for (int64_t i = 1; i < width; ++i)
         llvm::dbgs() << "RES" << i << " = P" << i << " XOR G" << i - 1 << "\n";
     });

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -555,7 +555,6 @@ AdderArchitecture determineAdderArch(Operation *op, int64_t width) {
 //===----------------------------------------------------------------------===//
 // Parallel Prefix Tree
 //===----------------------------------------------------------------------===//
-
 // Implement the Kogge-Stone parallel prefix tree
 // Described in https://en.wikipedia.org/wiki/Kogge%E2%80%93Stone_adder
 // Slightly better delay than Brent-Kung, but more area.
@@ -816,6 +815,19 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
   matchAndRewrite(AddOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto inputs = adaptor.getInputs();
+
+    if (inputs.size == 3) {
+      // Detect add with a constant carryIn
+      auto constOp =
+          dyn_cast_or_null<hw::ConstantOp>(op.getOperand(2).getDefiningOp());
+      if (!constOp || !constOp.getValue().isOne())
+        return failure();
+
+      // Detected a add with a constant carryIn of 1 - this can be fed into the
+      // parallel prefix adder as a carry-in - essentially for free
+      return lowerAdder(op, inputs.take_front(2), constOp, rewriter);
+    }
+
     // Lower only when there are two inputs.
     // Variadic operands must be lowered in a different pattern.
     if (inputs.size() != 2)
@@ -829,20 +841,19 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
       return success();
     }
 
+    return lowerAdder(op, inputs, Value(), rewriter);
     // Check if the architecture is specified by an attribute.
-    auto arch = determineAdderArch(op, width);
-    if (arch == AdderArchitecture::RippleCarry)
-      return lowerRippleCarryAdder(op, inputs, rewriter);
+
     return lowerParallelPrefixAdder(op, inputs, rewriter);
   }
 
   // Implement a basic ripple-carry adder for small bitwidths.
   LogicalResult
-  lowerRippleCarryAdder(comb::AddOp op, ValueRange inputs,
+  lowerRippleCarryAdder(comb::AddOp op, ValueRange inputs, Value carryIn,
                         ConversionPatternRewriter &rewriter) const {
     auto width = op.getType().getIntOrFloatBitWidth();
     // Implement a naive Ripple-carry full adder.
-    Value carry;
+    Value carry = carryIn;
 
     auto aBits = extractBits(rewriter, inputs[0]);
     auto bBits = extractBits(rewriter, inputs[1]);
@@ -883,9 +894,14 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
   // Implement a parallel prefix adder - with Kogge-Stone or Brent-Kung trees
   // Will introduce unused signals for the carry bits but these will be removed
   // by the AIG pass.
-  LogicalResult
-  lowerParallelPrefixAdder(comb::AddOp op, ValueRange inputs,
+  LogicalResult lowerAdder(comb::AddOp op, ValueRange inputs, Value carryIn,
                            ConversionPatternRewriter &rewriter) const {
+
+    // Check if the architecture is specified by an attribute.
+    auto arch = determineAdderArch(op, width);
+    if (arch == AdderArchitecture::RippleCarry)
+      return lowerRippleCarryAdder(op, inputs, carryIn, rewriter);
+
     auto width = op.getType().getIntOrFloatBitWidth();
 
     auto aBits = extractBits(rewriter, inputs[0]);
@@ -901,6 +917,13 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
       p.push_back(comb::XorOp::create(rewriter, op.getLoc(), aBit, bBit));
       // g_i = a_i AND b_i
       g.push_back(comb::AndOp::create(rewriter, op.getLoc(), aBit, bBit));
+    }
+
+    // With carry_in, adjust g[0]: g[0] = (a[0] AND b[0]) OR (p[0] AND carry_in)
+    // This bakes the carry_in into the prefix tree, avoiding a separate adder.
+    if (carryIn) {
+      Value pAndC = comb::AndOp::create(rewriter, op.getLoc(), p[0], carryIn);
+      g[0] = comb::OrOp::create(rewriter, op.getLoc(), g[0], pAndC);
     }
 
     LLVM_DEBUG({
@@ -919,9 +942,7 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     SmallVector<Value> pPrefix = p;
     SmallVector<Value> gPrefix = g;
 
-    // Check if the architecture is specified by an attribute.
-    auto arch = determineAdderArch(op, width);
-
+    // Select the Parallel Prefix Architecture
     switch (arch) {
     case AdderArchitecture::RippleCarry:
       llvm_unreachable("Ripple-Carry should be handled separately");
@@ -941,8 +962,10 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     // NOTE: The result is stored in reverse order.
     SmallVector<Value> results;
     results.resize(width);
-    // Sum bit 0 is just p[0] since carry_in = 0
-    results[width - 1] = p[0];
+    // sum[0] = p[0] XOR carry_in (carry_in = 0 when null -> just p[0])
+    results[width - 1] =
+        carryIn ? comb::XorOp::create(rewriter, op.getLoc(), p[0], carryIn)
+                : p[0];
 
     // For remaining bits, sum_i = p_i XOR g_(i-1)
     // The carry into position i is the group generate from position i-1

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -816,8 +816,8 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto inputs = adaptor.getInputs();
 
+    // Detect add with a constant carryIn
     if (inputs.size() == 3) {
-      // Detect add with a constant carryIn
       auto constOp =
           dyn_cast_or_null<hw::ConstantOp>(op.getOperand(2).getDefiningOp());
       if (!constOp || !constOp.getValue().isOne())

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -816,16 +816,19 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto inputs = adaptor.getInputs();
 
-    if (inputs.size == 3) {
+    if (inputs.size() == 3) {
       // Detect add with a constant carryIn
       auto constOp =
           dyn_cast_or_null<hw::ConstantOp>(op.getOperand(2).getDefiningOp());
       if (!constOp || !constOp.getValue().isOne())
         return failure();
 
+      // Make a single bit value of width 
+      auto constOne = hw::ConstantOp::create(rewriter, op.getLoc(), APInt(1,1));
+
       // Detected a add with a constant carryIn of 1 - this can be fed into the
       // parallel prefix adder as a carry-in - essentially for free
-      return lowerAdder(op, inputs.take_front(2), constOp, rewriter);
+      return lowerAdder(op, inputs.take_front(2), constOne, rewriter);
     }
 
     // Lower only when there are two inputs.
@@ -842,9 +845,6 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     }
 
     return lowerAdder(op, inputs, Value(), rewriter);
-    // Check if the architecture is specified by an attribute.
-
-    return lowerParallelPrefixAdder(op, inputs, rewriter);
   }
 
   // Implement a basic ripple-carry adder for small bitwidths.
@@ -897,12 +897,13 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
   LogicalResult lowerAdder(comb::AddOp op, ValueRange inputs, Value carryIn,
                            ConversionPatternRewriter &rewriter) const {
 
+    assert(carryIn == nullptr || carryIn.getType().getIntOrFloatBitWidth() == 1 &&
+           "carryIn must be a 1-bit value");
     // Check if the architecture is specified by an attribute.
+    auto width = op.getType().getIntOrFloatBitWidth();
     auto arch = determineAdderArch(op, width);
     if (arch == AdderArchitecture::RippleCarry)
       return lowerRippleCarryAdder(op, inputs, carryIn, rewriter);
-
-    auto width = op.getType().getIntOrFloatBitWidth();
 
     auto aBits = extractBits(rewriter, inputs[0]);
     auto bBits = extractBits(rewriter, inputs[1]);

--- a/test/Conversion/CombToDatapath/comb-to-datapath.mlir
+++ b/test/Conversion/CombToDatapath/comb-to-datapath.mlir
@@ -38,11 +38,10 @@ hw.module @carry_in_one(in %arg0: i4, in %arg1: i4) {
 // CHECK-LABEL: @sub
 hw.module @sub(in %arg0: i4, in %arg1: i4, out out: i4) {
   %0 = comb.sub %arg0, %arg1 : i4
-  // CHECK-NEXT: %[[C_NEG1:.+]] = hw.constant -1 : i4
-  // CHECK-NEXT: %[[XOR:.+]] = comb.xor %arg1, %[[C_NEG1]] : i4
-  // CHECK-NEXT: %[[C1:.+]] = hw.constant 1 : i4
-  // CHECK-NEXT: %[[COMP:.+]]:2 = datapath.compress %arg0, %[[XOR]], %[[C1]] : i4 [3 -> 2]
-  // CHECK-NEXT: %[[ADD:.+]] = comb.add bin %[[COMP]]#0, %[[COMP]]#1 : i4
+  // CHECK-NEXT: %c-1_i4 = hw.constant -1 : i4
+  // CHECK-NEXT: %[[XOR:.+]] = comb.xor %arg1, %c-1_i4 : i4
+  // CHECK-NEXT: %c1_i4 = hw.constant 1 : i4
+  // CHECK-NEXT: %[[ADD:.+]] = comb.add %arg0, %[[XOR]], %c1_i4 : i4
   // CHECK-NEXT: hw.output %[[ADD]] : i4
   hw.output %0 : i4
 }

--- a/test/Conversion/CombToDatapath/comb-to-datapath.mlir
+++ b/test/Conversion/CombToDatapath/comb-to-datapath.mlir
@@ -29,10 +29,10 @@ hw.module @zero_width(in %arg0: i0, in %arg1: i0, in %arg2: i0) {
 
 // CHECK-LABEL: @carry_in_one
 hw.module @carry_in_one(in %arg0: i4, in %arg1: i4) {
-  // CHECK-NEXT: %[[C1:.+]] = hw.constant 1 : i4
-  %c1 = hw.constant 1 : i4
-  // CHECK-NEXT: comb.add %arg0, %arg1, %[[C1]] : i4
-  %0 = comb.add %arg0, %arg1, %c1 : i4
+  // CHECK-NEXT: %c1_i4 = hw.constant 1 : i4
+  %c1_i4 = hw.constant 1 : i4
+  // CHECK-NEXT: comb.add %arg0, %arg1, %c1_i4 : i4
+  %0 = comb.add %arg0, %arg1, %c1_i4 : i4
 }
 
 // CHECK-LABEL: @sub

--- a/test/Conversion/CombToDatapath/comb-to-datapath.mlir
+++ b/test/Conversion/CombToDatapath/comb-to-datapath.mlir
@@ -26,6 +26,15 @@ hw.module @zero_width(in %arg0: i0, in %arg1: i0, in %arg2: i0) {
   // CHECK-NEXT: hw.constant 0 : i0
   %0 = comb.add %arg0, %arg1, %arg2 : i0
 }
+
+// CHECK-LABEL: @carry_in_one
+hw.module @carry_in_one(in %arg0: i4, in %arg1: i4) {
+  // CHECK-NEXT: %[[C1:.+]] = hw.constant 1 : i4
+  %c1 = hw.constant 1 : i4
+  // CHECK-NEXT: comb.add %arg0, %arg1, %[[C1]] : i4
+  %0 = comb.add %arg0, %arg1, %c1 : i4
+}
+
 // CHECK-LABEL: @sub
 hw.module @sub(in %arg0: i4, in %arg1: i4, out out: i4) {
   %0 = comb.sub %arg0, %arg1 : i4


### PR DESCRIPTION
## Overview

Any adder circuit can handle a single carry-in bit for free. 
Adding patterns to detect 3-input adders with a carry-in signal that is a single bit constant 1.

## Implementation
For a ripple-carry adder the carry-in is simply connected to the LSB full-adder. 
For any parallel prefix tree - the LSB generate signal just needs to be modified to account for the carry-in (and the output LSB needs to factor in the carry-in).

## TODO: 
detect cases where we've got a single non-constant carry-in bit too.

## Benchmarks:
sub_16: 200 AIG nodes -> 160 AIG nodes

Assisted-by: co-pilot:auto
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
