### PR TITLE
[LLHD] Deseq: handle signals with multiple drivers soundly

### DIFF
--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -355,6 +355,39 @@ void Deseq::deseq() {
 // Process Analysis
 //===----------------------------------------------------------------------===//
 
+/// Match a drive that is the canonical lowered form of a one-shot `initial`
+/// block initialization of a register variable: an unconditional zero-time
+/// (delta/epsilon) drive of a constant, executed exactly once at time zero
+/// (it sits in the entry block of some *other* process, so it runs in that
+/// process's first activation, before any wait, and can never re-execute).
+/// Returns the constant as an IntegerAttr, or null if the drive does not
+/// match.
+static IntegerAttr matchOneShotInitDrive(DriveOp drive) {
+  // Unconditional drives only.
+  if (drive.getEnable())
+    return {};
+  // Must execute inside a process (drives at module level are continuous
+  // drivers; drives in `llhd.final` run at end of simulation).
+  auto proc = drive->getParentOfType<ProcessOp>();
+  if (!proc)
+    return {};
+  // Exactly-once-at-t=0: the process entry block executes in the first
+  // activation (at time zero, before any wait terminator) and has no
+  // predecessors, so it cannot re-execute.
+  auto *block = drive->getBlock();
+  if (block != &proc.getBody().front() || !block->hasNoPredecessors())
+    return {};
+  // The value must land at t=0: zero-time (delta/epsilon) delay.
+  TimeAttr time;
+  if (!matchPattern(drive.getTime(), m_Constant(&time)) || time.getTime() != 0)
+    return {};
+  // Constant integer value.
+  IntegerAttr value;
+  if (!matchPattern(drive.getValue(), m_Constant(&value)))
+    return {};
+  return value;
+}
+
 /// Determine whether we can desequentialize the current process. Also gather
 /// the wait and drive ops that are relevant.
 bool Deseq::analyzeProcess() {
@@ -426,6 +459,53 @@ bool Deseq::analyzeProcess() {
       continue;
 
     driveInfos.push_back(DriveInfo(driveOp));
+  }
+
+  // Desequentialization replaces each fed conditional drive with an
+  // UNCONDITIONAL (continuous) drive of a register result. That is only
+  // sound if this process is the signal's sole driver: a variable written
+  // by several processes takes the last write per write EVENT in the
+  // source semantics, and a continuous register drive would clobber every
+  // such write on the next delta.
+  //
+  // EXCEPTION (the ubiquitous bench idiom):
+  //   initial begin reg = K; ... end     // one-shot t=0 constant init
+  //   always @(posedge clk) reg <= ...;  // edge updates
+  // Here the extra driver writes a constant exactly once at t=0, which
+  // folds into the register's PRESET (power-on value): the continuous
+  // register drive then reproduces K from t=0 onward, byte-equivalent to
+  // the initial block's write for every t >= 0 observation. Folding is
+  // strictly better than keeping the process form: sibling registers on
+  // the same clock that DO promote commit their state before a kept
+  // process resumes, so a kept process observes post-edge values of
+  // same-clock registers -- a one-delta skew against the LRM's preponed
+  // sampling that breaks lockstep pipelines (receipt: the 16.10 SVA
+  // local-var rows' clk_gen DUT).
+  //
+  // Any other extra driver (non-constant, conditional, delayed, repeated,
+  // continuous, or in llhd.final) keeps the genuinely-correct process form.
+  for (auto &info : driveInfos) {
+    for (auto *user : info.op.getSignal().getUsers()) {
+      auto otherDrive = dyn_cast<DriveOp>(user);
+      if (!otherDrive || otherDrive.getSignal() != info.op.getSignal() ||
+          seenDrives.contains(otherDrive))
+        continue;
+      auto preset = matchOneShotInitDrive(otherDrive);
+      if (!preset) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Skipping " << process.getLoc()
+                   << ": drives multi-driven signal (other driver at "
+                   << otherDrive.getLoc() << ")\n");
+        return false;
+      }
+      if (info.initPreset && info.initPreset != preset) {
+        LLVM_DEBUG(llvm::dbgs() << "Skipping " << process.getLoc()
+                                << ": conflicting one-shot init drives on "
+                                << info.op.getSignal() << "\n");
+        return false;
+      }
+      info.initPreset = preset;
+    }
   }
 
   // Collect triggers from observed values. We support either:
@@ -1437,11 +1517,13 @@ void Deseq::implementRegister(DriveInfo &drive) {
   if (!name)
     name = builder.getStringAttr("");
 
-  // Create the register op.
-  auto reg = seq::FirRegOp::create(builder, loc, value, clock, name,
-                                   hw::InnerSymAttr{},
-                                   /*preset=*/IntegerAttr{}, reset, resetValue,
-                                   /*isAsync=*/reset != Value{});
+  // Create the register op. A one-shot t=0 constant init drive by another
+  // process (the `initial begin reg = K; end` idiom) has been folded into
+  // the register's preset (power-on value) by `analyzeProcess`.
+  auto reg = seq::FirRegOp::create(
+      builder, loc, value, clock, name, hw::InnerSymAttr{},
+      /*preset=*/drive.initPreset, reset, resetValue,
+      /*isAsync=*/reset != Value{});
 
   // If the register has an enable, insert a self-mux in front of the register.
   // Set the `bin` flag on the mux specifically to make up for a subtle

--- a/lib/Dialect/LLHD/Transforms/DeseqUtils.h
+++ b/lib/Dialect/LLHD/Transforms/DeseqUtils.h
@@ -262,6 +262,11 @@ struct DriveInfo {
   /// The optional reset that triggers a change of the driven value to a fixed
   /// reset value. Null if no reset was detected.
   ResetInfo reset;
+  /// The optional power-on value folded from another process's one-shot t=0
+  /// constant drive of the same signal (the `initial begin reg = K; end`
+  /// idiom next to an `always @(posedge clk)` driver). Becomes the lowered
+  /// register's preset. Null if the signal has no such extra driver.
+  IntegerAttr initPreset;
 
   DriveInfo() {}
   explicit DriveInfo(DriveOp op) : op(op) {}

--- a/test/Dialect/LLHD/Transforms/deseq.mlir
+++ b/test/Dialect/LLHD/Transforms/deseq.mlir
@@ -1253,3 +1253,110 @@ hw.module @ClockExtractedFromStructArrayGetThenExtractPosEdge(in %st: !hw.struct
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
   llhd.drv %sig, %out after %time if %en : i4
 }
+
+// A one-shot t=0 constant init drive by another process (the canonical
+// lowered `initial begin reg = K; end` next to an `always @(posedge clk)`
+// driver) must NOT block promotion: it folds into the register's preset
+// (power-on value), which the continuous register drive reproduces from
+// t=0 onward. Keeping the process form instead skews the DUT against
+// same-clock promoted registers (post-edge reads = one-delta lead).
+// CHECK-LABEL: @MultiDrivenInitFoldsToPreset(
+hw.module @MultiDrivenInitFoldsToPreset(in %clock: i1, in %d: i42) {
+  %c0_i42 = hw.constant 0 : i42
+  %c1_i42 = hw.constant 1 : i42
+  %0 = llhd.constant_time <0ns, 1d, 0e>
+  %1, %2 = llhd.process -> i42, i1 {
+    %true = hw.constant true
+    %false = hw.constant false
+    cf.br ^bb1(%c0_i42, %false : i42, i1)
+  ^bb1(%3: i42, %4: i1):
+    llhd.wait yield (%3, %4 : i42, i1), (%clock : i1), ^bb2(%clock : i1)
+  ^bb2(%5: i1):
+    %6 = comb.xor bin %5, %true : i1
+    %7 = comb.and bin %6, %clock : i1  // posedge clock
+    cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
+  }
+  %3 = llhd.sig %c0_i42 : i42
+  // The t=0 one-shot writer (the "initial process") stays; its write agrees
+  // with the preset. The always process is promoted: firreg with preset 1,
+  // unconditional (continuous) drive.
+  // CHECK: llhd.process
+  // CHECK-NEXT: llhd.drv {{%.+}}, %c1_i42 after
+  // CHECK-NEXT: llhd.halt
+  llhd.process {
+    llhd.drv %3, %c1_i42 after %0 : i42
+    llhd.halt
+  }
+  // CHECK: [[REG:%.+]] = seq.firreg %d clock {{%.+}} preset 1 : i42
+  // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
+  // CHECK-NOT: llhd.process
+  llhd.drv %3, %1 after %0 if %2 : i42
+}
+
+// Desequentialization must NOT promote a drive whose signal has another
+// driver that is not a one-shot t=0 constant init: the promoted drive
+// becomes unconditional (continuous) and would clobber the other process's
+// writes on every delta (last-write-per-event source semantics). Here the
+// other writer drives a NON-CONSTANT value.
+// CHECK-LABEL: @MultiDrivenSignalKeepsProcess(
+hw.module @MultiDrivenSignalKeepsProcess(in %clock: i1, in %d: i42) {
+  %c0_i42 = hw.constant 0 : i42
+  %0 = llhd.constant_time <0ns, 1d, 0e>
+  // CHECK: llhd.process
+  %1, %2 = llhd.process -> i42, i1 {
+    %true = hw.constant true
+    %false = hw.constant false
+    cf.br ^bb1(%c0_i42, %false : i42, i1)
+  ^bb1(%3: i42, %4: i1):
+    llhd.wait yield (%3, %4 : i42, i1), (%clock : i1), ^bb2(%clock : i1)
+  ^bb2(%5: i1):
+    %6 = comb.xor bin %5, %true : i1
+    %7 = comb.and bin %6, %clock : i1  // posedge clock
+    cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
+  }
+  %3 = llhd.sig %c0_i42 : i42
+  // Writes a non-constant at t=0: not foldable into a preset.
+  // CHECK: llhd.process
+  llhd.process {
+    llhd.drv %3, %d after %0 : i42
+    llhd.halt
+  }
+  // A wrongly-created register would be inserted right before the fed drive.
+  // CHECK-NOT: seq.firreg
+  // CHECK: llhd.drv {{%.+}}, {{%.+}} after {{%.+}} if {{%.+}} :
+  llhd.drv %3, %1 after %0 if %2 : i42
+}
+
+// A delayed init write (`initial reg <= #5ns K;`) does NOT fold: the value
+// must not appear before t=5ns, but a preset holds it from t=0. Keep the
+// process form.
+// CHECK-LABEL: @MultiDrivenDelayedInitKeepsProcess(
+hw.module @MultiDrivenDelayedInitKeepsProcess(in %clock: i1, in %d: i42) {
+  %c0_i42 = hw.constant 0 : i42
+  %c1_i42 = hw.constant 1 : i42
+  %0 = llhd.constant_time <0ns, 1d, 0e>
+  // CHECK: llhd.process
+  %1, %2 = llhd.process -> i42, i1 {
+    %true = hw.constant true
+    %false = hw.constant false
+    cf.br ^bb1(%c0_i42, %false : i42, i1)
+  ^bb1(%3: i42, %4: i1):
+    llhd.wait yield (%3, %4 : i42, i1), (%clock : i1), ^bb2(%clock : i1)
+  ^bb2(%5: i1):
+    %6 = comb.xor bin %5, %true : i1
+    %7 = comb.and bin %6, %clock : i1  // posedge clock
+    cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
+  }
+  %3 = llhd.sig %c0_i42 : i42
+  // Constant write with a nonzero drive delay: not foldable.
+  // CHECK: llhd.process
+  llhd.process {
+    %t5 = llhd.constant_time <5ns, 0d, 0e>
+    llhd.drv %3, %c1_i42 after %t5 : i42
+    llhd.halt
+  }
+  // A wrongly-created register would be inserted right before the fed drive.
+  // CHECK-NOT: seq.firreg
+  // CHECK: llhd.drv {{%.+}}, {{%.+}} after {{%.+}} if {{%.+}} :
+  llhd.drv %3, %1 after %0 if %2 : i42
+}


### PR DESCRIPTION
`llhd-deseq` promotes a fed conditional drive to a `seq.firreg` plus an unconditional continuous drive even when the analyzed process is not the signal's only driver. A signal written by several processes takes the last write per write event, so the register drive clobbers every other process's write on the next delta. The common casualty is the bench idiom

```
initial begin read = 1; ... end          // one-shot t=0 init
always @(posedge clk) read <= ...;       // edge updates
```

where the initial block's value is silently lost: the register holds its power-on zero until the first clock edge.

<details><summary>Reproducer on current main (circt-opt --llhd-deseq)</summary>

```mlir
hw.module @InitClobbered(in %clock: i1, in %d: i42) {
  %c0_i42 = hw.constant 0 : i42
  %c1_i42 = hw.constant 1 : i42
  %0 = llhd.constant_time <0ns, 1d, 0e>
  %1, %2 = llhd.process -> i42, i1 {          // always @(posedge clock)
    %true = hw.constant true
    %false = hw.constant false
    cf.br ^bb1(%c0_i42, %false : i42, i1)
  ^bb1(%3: i42, %4: i1):
    llhd.wait yield (%3, %4 : i42, i1), (%clock : i1), ^bb2(%clock : i1)
  ^bb2(%5: i1):
    %6 = comb.xor bin %5, %true : i1
    %7 = comb.and bin %6, %clock : i1
    cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
  }
  %3 = llhd.sig %c0_i42 : i42
  llhd.process {                              // initial begin sig = 1; end
    llhd.drv %3, %c1_i42 after %0 : i42
    llhd.halt
  }
  llhd.drv %3, %1 after %0 if %2 : i42
}
```

Output on current main: the init process survives, but the promoted register has no preset and its unconditional drive clobbers the init on the next delta.

```mlir
llhd.process {
  llhd.drv %1, %c1_i42 after %0 : i42
  llhd.halt
}
%3 = seq.firreg %d clock %2 : i42
llhd.drv %1, %3 after %4 : i42
```

</details>

The fix classifies extra drivers instead of promoting blindly. A drive that provably executes exactly once at t=0 with a constant value (unconditional, zero delay, in the entry block of another process, no predecessors, cannot re-execute) folds into the promoted register's preset, which reproduces the constant from t=0 onward. Any other extra driver (non-constant, conditional, delayed, repeated, module-level continuous, or in `llhd.final`) keeps the process form.

Folding rather than always bailing matters: in mixed form, promoted registers on the same clock commit at clock evaluation before kept processes resume, so a kept process observes post-edge values of same-clock registers, a one-delta lead that breaks lockstep pipelines. We measured exactly that regression on two SVA local-variable benches under the bare guard, before adding the preset fold.

Tested: `deseq.mlir` gains `@MultiDrivenInitFoldsToPreset`, `@MultiDrivenSignalKeepsProcess`, and `@MultiDrivenDelayedInitKeepsProcess`.

Written with AI assistance; I've reviewed the diff and tests.
