### PR TITLE
[Sim][Moore] Make zero-operand queue.concat round-trippable

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2080,11 +2080,17 @@ def QueueConcatOp : MooreOp<"queue.concat", [Pure]> {
 
     If the total length of the inputs doesn't fit into the queue bound of
     $result, then the excess elements are discarded at the end of the queue.
+
+    With zero inputs (the empty queue literal `{}`) the result is an empty
+    queue.
   }];
   let arguments = (ins Variadic<QueueType>:$inputs);
   let results = (outs QueueType:$result);
+  // Note: functional-type (rather than a plain parenthesized type list) keeps
+  // the zero-input form parseable: `() <i8, 0>` is rejected as a function
+  // type, while `() -> !moore.queue<i8, 0>` round-trips.
   let assemblyFormat = [{
-    ` ` `(` $inputs `)` attr-dict `:` `(` type($inputs) `)` type($result)
+    ` ` `(` $inputs `)` attr-dict `:` functional-type($inputs, $result)
   }];
   let hasVerifier = 1;
 }

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1113,11 +1113,16 @@ def QueueConcatOp : SimOp<"queue.concat", [Pure]> {
 
     If the total length of the inputs doesn't fit into the queue bound of
     $result, then the excess elements at the end of the queue are discarded.
+
+    With zero inputs the result is an empty queue.
   }];
   let arguments = (ins Variadic<QueueType>:$inputs);
   let results = (outs QueueType:$result);
+  // Note: functional-type (rather than a plain parenthesized type list) keeps
+  // the zero-input form parseable: `() <i8, 0>` is rejected as a function
+  // type, while `() -> !sim.queue<i8, 0>` round-trips.
   let assemblyFormat = [{
-    ` ` `(` $inputs `)` attr-dict `:` `(` type($inputs) `)` type($result)
+    ` ` `(` $inputs `)` attr-dict `:` functional-type($inputs, $result)
   }];
   let hasVerifier = 1;
 }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2995,9 +2995,15 @@ struct QueueConcatOpConversion : public OpConversionPattern<QueueConcatOp> {
   LogicalResult
   matchAndRewrite(QueueConcatOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<sim::QueueConcatOp>(
-        op, getTypeConverter()->convertType(op.getResult().getType()),
-        adaptor.getInputs());
+    auto resultType = getTypeConverter()->convertType(op.getResult().getType());
+    // A zero-operand concat (the empty queue literal `{}`) is just an empty
+    // queue; emit the canonical constructor instead of a degenerate concat.
+    if (adaptor.getInputs().empty()) {
+      rewriter.replaceOpWithNewOp<sim::QueueEmptyOp>(op, resultType);
+      return success();
+    }
+    rewriter.replaceOpWithNewOp<sim::QueueConcatOp>(op, resultType,
+                                                    adaptor.getInputs());
     return success();
   }
 };

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4533,7 +4533,7 @@ endmodule
 // CHECK:             [[TWO:%.+]] = moore.constant 2 : i32
 // CHECK:             moore.push_back [[TWO]] into [[TMP3]] : <queue<i32, 0>>
 // CHECK:             [[TMP3R:%.+]] = moore.read [[TMP3]] : <queue<i32, 0>>
-// CHECK:             [[RESV:%.+]] = moore.queue.concat ([[TMP1R]], [[Q1R]], [[TMP2]], [[TMP3R]]) : (!moore.queue<i32, 0>, !moore.queue<i32, 5>, !moore.queue<i32, 0>, !moore.queue<i32, 0>) <i32, 0>
+// CHECK:             [[RESV:%.+]] = moore.queue.concat ([[TMP1R]], [[Q1R]], [[TMP2]], [[TMP3R]]) : (!moore.queue<i32, 0>, !moore.queue<i32, 5>, !moore.queue<i32, 0>, !moore.queue<i32, 0>) -> !moore.queue<i32, 0>
 // CHECK:             moore.blocking_assign [[QRES]], [[RESV]] : queue<i32, 0>
 // CHECK:           }
 // CHECK:           moore.output

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1693,8 +1693,14 @@ func.func @QueueOperations(%arg0: !moore.i32, %arg1: !moore.i32) {
   // CHECK: [[QFROMUP:%.+]] = sim.queue.from_array [[UPR]] : !hw.array<4xi32> -> <i32, 0>
   %2 = moore.queue.from_unpacked_array %upr : !moore.uarray<4 x i32> -> <i32, 0>
 
-  // CHECK: [[CONCAT:%.+]] = sim.queue.concat ([[QR]], [[DIFFB]]) : (!sim.queue<i32, 10>, !sim.queue<i32, 0>) <i32, 5>
-  %concatres = moore.queue.concat (%qr, %diffbounds) : (!moore.queue<i32, 10>, !moore.queue<i32, 0>) <i32, 5>
+  // CHECK: [[CONCAT:%.+]] = sim.queue.concat ([[QR]], [[DIFFB]]) : (!sim.queue<i32, 10>, !sim.queue<i32, 0>) -> !sim.queue<i32, 5>
+  %concatres = moore.queue.concat (%qr, %diffbounds) : (!moore.queue<i32, 10>, !moore.queue<i32, 0>) -> !moore.queue<i32, 5>
+
+  // A zero-operand concat (the empty queue literal `{}`) lowers to the
+  // canonical empty-queue constructor, not a degenerate 0-ary concat.
+  // CHECK: sim.queue.empty : <i32, 5>
+  // CHECK-NOT: sim.queue.concat ()
+  %emptyconcat = moore.queue.concat () : () -> !moore.queue<i32, 5>
 
   return
 }

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -193,3 +193,21 @@ hw.module @FormatString(in %str: !sim.dstring) {
   // CHECK: sim.fmt.string %str isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
   %fmt1 = sim.fmt.string %str isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
 }
+
+// Queue concat must round-trip at every arity; the zero-operand form (the
+// empty queue literal) regressed under the old parenthesized-type-list
+// format, which printed `() <i8, 0>` and could not be reparsed.
+// CHECK-LABEL: func.func @QueueConcat
+func.func @QueueConcat(%arg0: !sim.queue<i8, 0>, %arg1: !sim.queue<i8, 4>) -> !sim.queue<i8, 0> {
+  // CHECK: sim.queue.concat () : () -> !sim.queue<i8, 0>
+  %0 = sim.queue.concat () : () -> !sim.queue<i8, 0>
+  // CHECK: sim.queue.concat (%arg0) : (!sim.queue<i8, 0>) -> !sim.queue<i8, 0>
+  %1 = sim.queue.concat (%arg0) : (!sim.queue<i8, 0>) -> !sim.queue<i8, 0>
+  // CHECK: sim.queue.concat (%arg0, %arg1) : (!sim.queue<i8, 0>, !sim.queue<i8, 4>) -> !sim.queue<i8, 0>
+  %2 = sim.queue.concat (%arg0, %arg1) : (!sim.queue<i8, 0>, !sim.queue<i8, 4>) -> !sim.queue<i8, 0>
+  // The generic form must stay parseable as well (regression guard for IR
+  // printed with --mlir-print-op-generic).
+  // CHECK: sim.queue.concat () : () -> !sim.queue<i8, 0>
+  %3 = "sim.queue.concat"() : () -> !sim.queue<i8, 0>
+  return %0 : !sim.queue<i8, 0>
+}

--- a/test/Dialect/Sim/sim-errors.mlir
+++ b/test/Dialect/Sim/sim-errors.mlir
@@ -133,7 +133,7 @@ sim.func.dpi @dpi_bad_ref_type(ref %arg : i32)
 
 hw.module @queue_concat(in %q1: !sim.queue<i32, 0>, in %q2: !sim.queue<i16, 0>) {
   // expected-error @below {{'sim.queue.concat' op sim::Queue element type 'i16' doesn't match result sim::Queue element type 'i32'}}
-  sim.queue.concat (%q1, %q2) : (!sim.queue<i32, 0>, !sim.queue<i16, 0>) <i32, 5>
+  sim.queue.concat (%q1, %q2) : (!sim.queue<i32, 0>, !sim.queue<i16, 0>) -> !sim.queue<i32, 5>
 }
 
 hw.module @queue_from_array(in %uparr: !hw.array<5xi33>) {


### PR DESCRIPTION
The empty queue literal `{}` lowers to a `queue.concat` with no operands, which the parenthesized-type-list assembly format prints as

```
%62 = sim.queue.concat () : () <i8, 0>
```

and the parser rejects ("expected non-function type": after the colon the `()` reads as the start of a function type). The op cannot round-trip its own printed form, so any flow that prints and re-parses the IR (`circt-verilog --ir-hw` piped into `arcilator`, for example) dies on it. Forms with one or more operands are unaffected.

Two changes, each standing alone: switch `sim.queue.concat` and `moore.queue.concat` to functional-type assembly format, which parses unambiguously at every arity (existing tests updated mechanically), and stop emitting the degenerate op at its only production site by lowering a zero-operand concat to `sim.queue.empty` in MooreToCore. `q = {};` is a stock testbench idiom, so this surfaces quickly in practice.

Tested: round-trip at arity 0/1/2 plus the generic-form guard in `test/Dialect/Sim/round-trip.mlir`; a MooreToCore case for zero-operand concat to `sim.queue.empty`.

Written with AI assistance; I've reviewed the diff and tests.
