### PR TITLE
[ESI][Runtime] Codegen refactor

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/BitAccess.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/BitAccess.h
@@ -147,6 +147,105 @@ inline constexpr void copyBitsOut(uint8_t *dst, const uint8_t *src) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Runtime-offset variants.
+//
+// The compile-time templates above are used for struct/union fields, whose
+// bit offset and width are known constants. Array elements, however, live at
+// `baseOffset + index * elementWidth`, where `index` is only known at run
+// time, so the generator emits per-element loops that call these `*Dyn`
+// overloads instead. They are otherwise bit-for-bit identical to their
+// templated counterparts; `bitOffset` / `width` simply move from template
+// parameters to ordinary arguments (so the per-bit loop is a real runtime
+// loop rather than a fully-unrolled one). Callers must ensure `width` is
+// non-zero and that `Storage` is wide enough to hold it.
+// ---------------------------------------------------------------------------
+
+/// Runtime-offset form of `readUnsignedBits`.
+template <typename Storage>
+inline Storage readUnsignedBitsDyn(const uint8_t *bytes, std::size_t bitOffset,
+                                   std::size_t width) {
+  static_assert(std::is_unsigned<Storage>::value,
+                "readUnsignedBitsDyn Storage must be unsigned");
+  Storage result = 0;
+  for (std::size_t i = 0; i < width; ++i) {
+    std::size_t src = bitOffset + i;
+    Storage bit = static_cast<Storage>((bytes[src >> 3] >> (src & 7)) & 1u);
+    result |= static_cast<Storage>(bit << i);
+  }
+  return result;
+}
+
+/// Runtime-offset form of `readSignedBits`.
+template <typename Signed>
+inline Signed readSignedBitsDyn(const uint8_t *bytes, std::size_t bitOffset,
+                                std::size_t width) {
+  static_assert(std::is_signed<Signed>::value,
+                "readSignedBitsDyn Signed must be signed");
+  using Unsigned = typename std::make_unsigned<Signed>::type;
+  Unsigned u = readUnsignedBitsDyn<Unsigned>(bytes, bitOffset, width);
+  if (width < sizeof(Unsigned) * 8) {
+    Unsigned signBit =
+        static_cast<Unsigned>(static_cast<Unsigned>(1) << (width - 1));
+    u = static_cast<Unsigned>((u ^ signBit) - signBit);
+  }
+  return static_cast<Signed>(u);
+}
+
+/// Runtime-offset form of `writeUnsignedBits`.
+template <typename Storage>
+inline void writeUnsignedBitsDyn(uint8_t *bytes, Storage value,
+                                 std::size_t bitOffset, std::size_t width) {
+  static_assert(std::is_unsigned<Storage>::value,
+                "writeUnsignedBitsDyn Storage must be unsigned");
+  for (std::size_t i = 0; i < width; ++i) {
+    std::size_t dst = bitOffset + i;
+    std::size_t shift = dst & 7;
+    uint8_t mask = static_cast<uint8_t>(1u << shift);
+    uint8_t bit = static_cast<uint8_t>((value >> i) & static_cast<Storage>(1));
+    bytes[dst >> 3] =
+        static_cast<uint8_t>((bytes[dst >> 3] & static_cast<uint8_t>(~mask)) |
+                             static_cast<uint8_t>(bit << shift));
+  }
+}
+
+/// Runtime-offset form of `writeSignedBits`.
+template <typename Signed>
+inline void writeSignedBitsDyn(uint8_t *bytes, Signed value,
+                               std::size_t bitOffset, std::size_t width) {
+  static_assert(std::is_signed<Signed>::value,
+                "writeSignedBitsDyn Signed must be signed");
+  using Unsigned = typename std::make_unsigned<Signed>::type;
+  writeUnsignedBitsDyn<Unsigned>(bytes, static_cast<Unsigned>(value), bitOffset,
+                                 width);
+}
+
+/// Runtime-offset form of `copyBitsIn`. `dst` must be zero-initialised on
+/// entry (only `1` bits are set) and hold at least `ceil(width / 8)` bytes.
+inline void copyBitsInDyn(const uint8_t *src, std::size_t srcBitOffset,
+                          uint8_t *dst, std::size_t width) {
+  for (std::size_t i = 0; i < width; ++i) {
+    std::size_t s = srcBitOffset + i;
+    uint8_t bit = static_cast<uint8_t>((src[s >> 3] >> (s & 7)) & 1u);
+    dst[i >> 3] = static_cast<uint8_t>(dst[i >> 3] | (bit << (i & 7)));
+  }
+}
+
+/// Runtime-offset form of `copyBitsOut`. Bits outside the written range in
+/// the affected bytes of `dst` are preserved.
+inline void copyBitsOutDyn(uint8_t *dst, std::size_t dstBitOffset,
+                           const uint8_t *src, std::size_t width) {
+  for (std::size_t i = 0; i < width; ++i) {
+    std::size_t d = dstBitOffset + i;
+    std::size_t shift = d & 7;
+    uint8_t mask = static_cast<uint8_t>(1u << shift);
+    uint8_t bit = static_cast<uint8_t>((src[i >> 3] >> (i & 7)) & 1u);
+    dst[d >> 3] =
+        static_cast<uint8_t>((dst[d >> 3] & static_cast<uint8_t>(~mask)) |
+                             static_cast<uint8_t>(bit << shift));
+  }
+}
+
 } // namespace detail
 } // namespace esi
 

--- a/lib/Dialect/ESI/runtime/python/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/python/CMakeLists.txt
@@ -5,7 +5,11 @@
 set(ESIPythonRuntimeSources
   esiaccel/__init__.py
   esiaccel/accelerator.py
-  esiaccel/codegen.py
+  esiaccel/codegen/__init__.py
+  esiaccel/codegen/__main__.py
+  esiaccel/codegen/generator.py
+  esiaccel/codegen/indented_writer.py
+  esiaccel/codegen/ports.py
   esiaccel/esitester.py
   esiaccel/types.py
   esiaccel/utils.py

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen/__init__.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen/__init__.py
@@ -1,0 +1,24 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Code generation from ESI manifests to source code.
+
+This package only re-exports the public API. The implementation lives in the
+sibling modules:
+
+  * `generator` -- the `Generator` base, `CppGenerator`, the C++ type planner /
+    emitter (`CppTypePlanner` / `CppTypeEmitter`), and the `run` CLI entry point.
+  * `indented_writer` -- the `IndentedWriter` used by the emitters.
+  * `ports` -- the per-port-kind strategy table and its rendering helpers.
+"""
+
+from .generator import (Generator, CppGenerator, CppTypePlanner, CppTypeEmitter,
+                        run)
+
+__all__ = [
+    "Generator",
+    "CppGenerator",
+    "CppTypePlanner",
+    "CppTypeEmitter",
+    "run",
+]

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen/__main__.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen/__main__.py
@@ -1,0 +1,11 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Entry point for `python -m esiaccel.codegen`."""
+
+import sys
+
+from . import run
+
+if __name__ == "__main__":
+  sys.exit(run())

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen/generator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen/generator.py
@@ -11,36 +11,19 @@ standalone and deterministic.
 # C++ header support included with the runtime, though it is intended to be
 # extensible for other languages.
 
-from typing import Dict, List, Set, TextIO, Tuple, Type, Optional
-from .accelerator import AcceleratorConnection, Context
-from .esiCppAccel import ModuleInfo
-from . import types
-from .types import (BundlePort as _BundlePort, FunctionPort as _FunctionPort,
-                    CallbackPort as _CallbackPort, ToHostPort as _ToHostPort,
-                    FromHostPort as _FromHostPort, MMIORegion as
-                    _MMIORegionPort, MetricPort as _MetricPort)
+from typing import Any, Callable, Dict, List, Set, TextIO, Tuple, Type, Optional, cast
+from ..accelerator import AcceleratorConnection, Context, Instance
+from ..esiCppAccel import AppID, ModuleInfo
+from .. import types
 
 import sys
 import os
 import textwrap
 import argparse
-from dataclasses import dataclass, field as _dc_field
 from pathlib import Path
 
-_thisdir = Path(__file__).absolute().resolve().parent
-
-
-@dataclass
-class _PortGroup:
-  """All strings needed to emit one port slot (member + ctor + find) in Connected."""
-  struct_decls: List[str] = _dc_field(default_factory=list)
-  member_decl: str = ""
-  ctor_params: List[str] = _dc_field(default_factory=list)
-  init_entry: str = ""
-  find_code: str = ""
-  make_unique_args: List[str] = _dc_field(default_factory=list)
-  post_connect: str = ""
-  using_aliases: List[Tuple[str, str]] = _dc_field(default_factory=list)
+from .indented_writer import IndentedWriter
+from .ports import CppPortGroup, CppPortKind, cpp_port_kind
 
 
 class Generator:
@@ -48,10 +31,10 @@ class Generator:
 
   language: Optional[str] = None
 
-  def __init__(self, conn: AcceleratorConnection):
+  def __init__(self, conn: AcceleratorConnection) -> None:
     self.manifest = conn.manifest()
 
-  def generate(self, output_dir: Path, system_name: str):
+  def generate(self, output_dir: Path, system_name: str) -> None:
     raise NotImplementedError("Generator.generate() must be overridden")
 
 
@@ -60,7 +43,7 @@ class CppGenerator(Generator):
 
   language = "C++"
 
-  def __init__(self, conn: AcceleratorConnection):
+  def __init__(self, conn: AcceleratorConnection) -> None:
     super().__init__(conn)
     self._conn = conn
     self.type_planner = CppTypePlanner(self.manifest.type_table)
@@ -91,10 +74,10 @@ class CppGenerator(Generator):
       result.insert(0, "_")
     return "".join(result)
 
-  def _build_module_instance_map(self) -> Dict[str, object]:
+  def _build_module_instance_map(self) -> Dict[str, Instance]:
     """Walk the live hierarchy and return {module_name: first Instance}."""
     accel = self._conn.build_accelerator()
-    result: Dict[str, object] = {}
+    result: Dict[str, Instance] = {}
     queue = list(accel.children.values())
     while queue:
       inst = queue.pop(0)
@@ -106,104 +89,33 @@ class CppGenerator(Generator):
       queue.extend(inst.children.values())
     return result
 
-  def _cpp_member_type(self, port, alias_prefix: Optional[str] = None) -> str:
-    """Return the C++ member type string for a port (no member name).
-
-    For typed ports (function/callback/to-host/from-host channels) `alias_prefix`
-    is required; the returned template parameters are written using the alias
-    names (`<prefix>Args`, `<prefix>Result`, `<prefix>Data`) that should be
-    emitted at module-class scope via `_port_using_aliases`. For non-typed
-    ports (MMIO regions, telemetry metrics, plain bundles) `alias_prefix` is
-    ignored and the runtime reference/pointer type is returned directly.
-    """
-    if isinstance(port, _FunctionPort):
-      assert alias_prefix is not None, (
-          "alias_prefix is required for FunctionPort to avoid emitting "
-          "long mangled type names inline (which would also collide across "
-          "modules' `using` declarations)")
-      return (f"esi::TypedFunction<{alias_prefix}Args, "
-              f"{alias_prefix}Result>")
-    if isinstance(port, _CallbackPort):
-      assert alias_prefix is not None, (
-          "alias_prefix is required for CallbackPort")
-      return (f"esi::TypedCallback<{alias_prefix}Args, "
-              f"{alias_prefix}Result>")
-    if isinstance(port, _ToHostPort):
-      assert alias_prefix is not None, (
-          "alias_prefix is required for ToHostPort")
-      return f"esi::TypedReadPort<{alias_prefix}Data>"
-    if isinstance(port, _FromHostPort):
-      assert alias_prefix is not None, (
-          "alias_prefix is required for FromHostPort")
-      return f"esi::TypedWritePort<{alias_prefix}Data>"
-    if isinstance(port, _MMIORegionPort):
-      return "esi::services::MMIO::MMIORegion &"
-    if isinstance(port, _MetricPort):
-      return "esi::services::TelemetryService::Metric &"
-    return "esi::BundlePort &"
-
-  def _port_using_aliases(self, alias_prefix: str,
-                          port) -> List[Tuple[str, str]]:
+  def _port_using_aliases(self, kind: CppPortKind, alias_prefix: str,
+                          port: types.BundlePort) -> List[Tuple[str, str]]:
     """Return (alias_name, type_id) pairs to emit as `using` declarations at
     module-class scope for the typed-port template parameters."""
-    if isinstance(port, (_FunctionPort, _CallbackPort)):
-      arg = self.type_emitter.type_identifier(port.arg_window_type or
-                                              port.arg_type)
-      res = self.type_emitter.type_identifier(port.result_window_type or
-                                              port.result_type)
-      return [(f"{alias_prefix}Args", arg), (f"{alias_prefix}Result", res)]
-    if isinstance(port, (_ToHostPort, _FromHostPort)):
-      data = self.type_emitter.type_identifier(port.data_window_type or
-                                               port.data_type)
+    if kind.alias_kind == "func":
+      # func kinds are always FunctionPort / CallbackPort, which share the
+      # arg/result attributes accessed here.
+      func_port = cast(types.FunctionPort, port)
+      arg = self.type_emitter.type_identifier(func_port.arg_window_type or
+                                              func_port.arg_type)
+      res = self.type_emitter.type_identifier(func_port.result_window_type or
+                                              func_port.result_type)
+      return [
+          (f"{alias_prefix}Args", arg),
+          (f"{alias_prefix}Result", res),
+      ]
+    if kind.alias_kind == "chan":
+      # chan kinds are always ToHostPort / FromHostPort, which share the
+      # data attributes accessed here.
+      chan_port = cast(types.ToHostPort, port)
+      data = self.type_emitter.type_identifier(chan_port.data_window_type or
+                                               chan_port.data_type)
       return [(f"{alias_prefix}Data", data)]
     return []
 
-  def _cpp_indexed_elem_type(self,
-                             port,
-                             alias_prefix: Optional[str] = None) -> str:
-    """Return the storage type used inside an `IndexedPorts<T>` for `port`.
-
-    Typed ports use the same `TypedFunction<...>` / `TypedReadPort<...>` etc.
-    that `_cpp_member_type` produces. MMIO regions, telemetry metrics, and
-    plain bundle ports are stored as raw pointers because `std::map<int, T&>`
-    is ill-formed.
-    """
-    if isinstance(port, _MMIORegionPort):
-      return "esi::services::MMIO::MMIORegion *"
-    if isinstance(port, _MetricPort):
-      return "esi::services::TelemetryService::Metric *"
-    if isinstance(port,
-                  (_FunctionPort, _CallbackPort, _ToHostPort, _FromHostPort)):
-      return self._cpp_member_type(port, alias_prefix=alias_prefix)
-    return "esi::BundlePort *"
-
-  def _cpp_ctor_param_type(self, port) -> str:
-    """Return the C++ constructor parameter type for a port."""
-    if isinstance(port, _FunctionPort):
-      return "esi::services::FuncService::Function *"
-    if isinstance(port, _CallbackPort):
-      return "esi::services::CallService::Callback *"
-    if isinstance(port, _ToHostPort):
-      return "esi::ReadChannelPort &"
-    if isinstance(port, _FromHostPort):
-      return "esi::WriteChannelPort &"
-    if isinstance(port, _MMIORegionPort):
-      return "esi::services::MMIO::MMIORegion &"
-    if isinstance(port, _MetricPort):
-      return "esi::services::TelemetryService::Metric &"
-    return "esi::BundlePort &"
-
   @staticmethod
-  def _cpp_ctor_param_suffix(port) -> str:
-    """Return the parameter name suffix ('_chan', '_svc', or '_port')."""
-    if isinstance(port, (_ToHostPort, _FromHostPort)):
-      return "_chan"
-    if isinstance(port, (_MMIORegionPort, _MetricPort)):
-      return "_svc"
-    return "_port"
-
-  @staticmethod
-  def _appid_expr(appid) -> str:
+  def _appid_expr(appid: AppID) -> str:
     """Return `esi::AppID(...)` expression for an AppID."""
     name = appid.name
     idx = appid.idx
@@ -211,75 +123,15 @@ class CppGenerator(Generator):
       return f'esi::AppID("{name}")'
     return f'esi::AppID("{name}", {idx})'
 
-  def _port_find_code(self, member_name: str, port, appid) -> str:
-    """Return the code snippet that resolves a scalar port in connect()."""
-    ae = self._appid_expr(appid)
-    if isinstance(port, _FunctionPort):
-      v = f"{member_name}_port"
-      return (
-          f"auto *{v} =\n"
-          f"    esi::findPortAsOrThrow<esi::services::FuncService::Function>(\n"
-          f"        rawModule, {ae});")
-    if isinstance(port, _CallbackPort):
-      v = f"{member_name}_port"
-      return (
-          f"auto *{v} =\n"
-          f"    esi::findPortAsOrThrow<esi::services::CallService::Callback>(\n"
-          f"        rawModule, {ae});")
-    if isinstance(port, _ToHostPort):
-      v = f"{member_name}_chan"
-      return (
-          f"auto &{v} =\n"
-          f"    esi::findPortAsOrThrow<esi::services::ChannelService::ToHost>(\n"
-          f'        rawModule, {ae})->getRawRead("data");')
-    if isinstance(port, _FromHostPort):
-      v = f"{member_name}_chan"
-      return (
-          f"auto &{v} =\n"
-          f"    esi::findPortAsOrThrow<esi::services::ChannelService::FromHost>(\n"
-          f'        rawModule, {ae})->getRawWrite("data");')
-    if isinstance(port, _MMIORegionPort):
-      v = f"{member_name}_svc"
-      return (f"auto &{v} =\n"
-              f"    *esi::findPortAsOrThrow<esi::services::MMIO::MMIORegion>(\n"
-              f"        rawModule, {ae});")
-    if isinstance(port, _MetricPort):
-      v = f"{member_name}_svc"
-      return (
-          f"auto &{v} =\n"
-          f"    *esi::findPortAsOrThrow<esi::services::TelemetryService::Metric>(\n"
-          f"        rawModule, {ae});")
-    # plain BundlePort fallback
-    v = f"{member_name}_port"
-    return f"auto &{v} = esi::findPortOrThrow(rawModule, {ae});"
-
-  @staticmethod
-  def _port_make_unique_arg(member_name: str, port) -> str:
-    """Return the argument expression for make_unique<Connected>(...)."""
-    if isinstance(port, (_ToHostPort, _FromHostPort)):
-      return f"{member_name}_chan"
-    if isinstance(port, (_MMIORegionPort, _MetricPort)):
-      return f"{member_name}_svc"
-    return f"{member_name}_port"
-
-  @staticmethod
-  def _port_is_connectable(port) -> bool:
-    """True if the generated connect() should call .connect() on this port.
-
-    CallbackPort.connect() requires a user-supplied callback — skip.
-    MMIORegion, BundlePort — no .connect() method."""
-    return isinstance(port,
-                      (_FunctionPort, _ToHostPort, _FromHostPort, _MetricPort))
-
-  def _scalar_port_group(self, member_name: str, port, appid) -> _PortGroup:
-    """Build a _PortGroup for a single scalar (non-indexed) port."""
-    aliases = self._port_using_aliases(member_name, port)
+  def _scalar_port_group(self, member_name: str, port: types.BundlePort,
+                         appid: AppID) -> CppPortGroup:
+    """Build a CppPortGroup for a single scalar (non-indexed) port."""
+    kind = cpp_port_kind(port)
+    aliases = self._port_using_aliases(kind, member_name, port)
     alias_prefix = member_name if aliases else None
-    member_type = self._cpp_member_type(port, alias_prefix=alias_prefix)
+    member_type = kind.member_type(alias_prefix=alias_prefix)
     is_ref = member_type.endswith(" &")
-    param_type = self._cpp_ctor_param_type(port)
-    param_suffix = self._cpp_ctor_param_suffix(port)
-    param_name = f"{member_name}{param_suffix}"
+    param_name = f"{member_name}{kind.param_suffix}"
 
     if is_ref:
       member_decl = f"{member_type}{member_name};"
@@ -287,28 +139,29 @@ class CppGenerator(Generator):
       member_decl = f"{member_type} {member_name};"
 
     post = ""
-    if self._port_is_connectable(port):
+    if kind.connectable:
       post = f"connected->{member_name}.connect();"
 
-    return _PortGroup(
+    return CppPortGroup(
         member_decl=member_decl,
-        ctor_params=[f"{param_type} {param_name}"],
+        ctor_params=[f"{kind.param_type} {param_name}"],
         init_entry=f"{member_name}({param_name})",
-        find_code=self._port_find_code(member_name, port, appid),
-        make_unique_args=[self._port_make_unique_arg(member_name, port)],
+        find_code=kind.scalar_find_code(param_name, self._appid_expr(appid)),
+        make_unique_args=[param_name],
         post_connect=post,
         using_aliases=aliases,
     )
 
-  def _indexed_ports_group(self, member_name: str, appid_name: str,
-                           port_list) -> _PortGroup:
-    """Build a _PortGroup for a same-name, same-type indexed port array."""
+  def _indexed_ports_group(
+      self, member_name: str, appid_name: str,
+      port_list: List[Tuple[AppID, types.BundlePort]]) -> CppPortGroup:
+    """Build a CppPortGroup for a same-name, same-type indexed port array."""
     # Derive the element type from the first port.
     first_port = port_list[0][1]
-    aliases = self._port_using_aliases(member_name, first_port)
+    kind = cpp_port_kind(first_port)
+    aliases = self._port_using_aliases(kind, member_name, first_port)
     alias_prefix = member_name if aliases else None
-    elem_type = self._cpp_indexed_elem_type(first_port,
-                                            alias_prefix=alias_prefix)
+    elem_type = kind.indexed_elem_type(alias_prefix=alias_prefix)
     indexed_type = f"esi::IndexedPorts<{elem_type}>"
     map_var = f"{member_name}_backing"
     map_type = f"std::map<int, {elem_type}>"
@@ -325,70 +178,17 @@ class CppGenerator(Generator):
         f"\"{appid_name}\")) {{",
     ]
     appid_expr = f'esi::AppID("{appid_name}", idx)'
-    if isinstance(first_port, _FunctionPort):
-      find_parts.append(
-          f"  {map_var}.try_emplace(\n"
-          f"      static_cast<int>(idx),\n"
-          f"      esi::findPortAsOrThrow<esi::services::FuncService::Function>"
-          f"(\n"
-          f"          rawModule, {appid_expr}));")
-    elif isinstance(first_port, _CallbackPort):
-      find_parts.append(
-          f"  {map_var}.try_emplace(\n"
-          f"      static_cast<int>(idx),\n"
-          f"      esi::findPortAsOrThrow<esi::services::CallService::Callback>"
-          f"(\n"
-          f"          rawModule, {appid_expr}));")
-    elif isinstance(first_port, _ToHostPort):
-      # TypedReadPort takes a ReadChannelPort&, not the service port. Resolve
-      # the service port first, then bind its underlying raw read channel.
-      find_parts.append(
-          f"  auto *svc =\n"
-          f"      esi::findPortAsOrThrow<esi::services::ChannelService::ToHost>"
-          f"(\n"
-          f"          rawModule, {appid_expr});\n"
-          f"  {map_var}.try_emplace(\n"
-          f"      static_cast<int>(idx),\n"
-          f"      svc->getRawRead(\"data\"));")
-    elif isinstance(first_port, _FromHostPort):
-      find_parts.append(
-          f"  auto *svc =\n"
-          f"      esi::findPortAsOrThrow<esi::services::ChannelService::"
-          f"FromHost>(\n"
-          f"          rawModule, {appid_expr});\n"
-          f"  {map_var}.try_emplace(\n"
-          f"      static_cast<int>(idx),\n"
-          f"      svc->getRawWrite(\"data\"));")
-    elif isinstance(first_port, _MMIORegionPort):
-      find_parts.append(
-          f"  {map_var}.try_emplace(\n"
-          f"      static_cast<int>(idx),\n"
-          f"      esi::findPortAsOrThrow<esi::services::MMIO::MMIORegion>(\n"
-          f"          rawModule, {appid_expr}));")
-    elif isinstance(first_port, _MetricPort):
-      find_parts.append(
-          f"  {map_var}.try_emplace(\n"
-          f"      static_cast<int>(idx),\n"
-          f"      esi::findPortAsOrThrow<esi::services::TelemetryService::"
-          f"Metric>(\n"
-          f"          rawModule, {appid_expr}));")
-    else:
-      # Plain BundlePort: any service port that doesn't match a standard
-      # specialization (e.g. a custom `@esi.ServiceDecl`-defined service).
-      find_parts.append(
-          f"  {map_var}.try_emplace(\n"
-          f"      static_cast<int>(idx),\n"
-          f"      &esi::findPortOrThrow(rawModule, {appid_expr}));")
+    find_parts.append(kind.indexed_find_code(map_var, appid_expr))
     find_parts.append("}")
     find_parts.append(f"{indexed_type} {indexed_var}(std::move({map_var}));")
 
     post = ""
-    if self._port_is_connectable(first_port):
+    if kind.connectable:
       # IndexedPorts now exposes mutable iteration so `port.connect()` is fine.
       post = (f"for (auto &[idx, port] : connected->{member_name})\n"
               f"  port.connect();")
 
-    return _PortGroup(
+    return CppPortGroup(
         member_decl=f"{indexed_type} {member_name};",
         ctor_params=[f"{indexed_type} {indexed_var}"],
         init_entry=f"{member_name}(std::move({indexed_var}))",
@@ -398,9 +198,10 @@ class CppGenerator(Generator):
         using_aliases=aliases,
     )
 
-  def _mixed_struct_group(self, member_name: str, appid_name: str,
-                          port_list) -> _PortGroup:
-    """Build a _PortGroup for a same-name, mixed-type indexed port group."""
+  def _mixed_struct_group(
+      self, member_name: str, appid_name: str,
+      port_list: List[Tuple[AppID, types.BundlePort]]) -> CppPortGroup:
+    """Build a CppPortGroup for a same-name, mixed-type indexed port group."""
     struct_name = f"{member_name}_ports"
     sub_member_decls: List[str] = []
     ctor_params: List[str] = []
@@ -411,34 +212,37 @@ class CppGenerator(Generator):
     using_aliases: List[Tuple[str, str]] = []
 
     for appid, port in port_list:
+      kind = cpp_port_kind(port)
       idx = appid.idx if appid.idx is not None else 0
       sub_name = f"_{idx}"
       sub_alias_prefix = f"{member_name}_{idx}"
-      sub_aliases = self._port_using_aliases(sub_alias_prefix, port)
+      sub_aliases = self._port_using_aliases(kind, sub_alias_prefix, port)
       using_aliases.extend(sub_aliases)
       alias_prefix = sub_alias_prefix if sub_aliases else None
-      member_type = self._cpp_member_type(port, alias_prefix=alias_prefix)
+      member_type = kind.member_type(alias_prefix=alias_prefix)
       is_ref = member_type.endswith(" &")
       if is_ref:
         sub_member_decls.append(f"{member_type}{sub_name};")
       else:
         sub_member_decls.append(f"{member_type} {sub_name};")
 
-      param_type = self._cpp_ctor_param_type(port)
-      param_suffix = self._cpp_ctor_param_suffix(port)
-      param_name = f"{member_name}_{idx}{param_suffix}"
-      ctor_params.append(f"{param_type} {param_name}")
+      param_name = f"{member_name}_{idx}{kind.param_suffix}"
+      ctor_params.append(f"{kind.param_type} {param_name}")
       init_args.append(param_name)
-      find_parts.append(self._port_find_code(param_name, port, appid))
-      make_args.append(self._port_make_unique_arg(param_name, port))
-      if self._port_is_connectable(port):
+      # The connect() local mirrors the ctor param name plus the kind's
+      # suffix; the find snippet declares it and make_unique passes it.
+      find_local = f"{param_name}{kind.param_suffix}"
+      find_parts.append(
+          kind.scalar_find_code(find_local, self._appid_expr(appid)))
+      make_args.append(find_local)
+      if kind.connectable:
         post_parts.append(f"connected->{member_name}.{sub_name}.connect();")
 
     struct_decl = (f"struct {struct_name} {{\n" +
                    "".join(f"      {d}\n" for d in sub_member_decls) + "    };")
     init_entry = f"{member_name}{{{', '.join(init_args)}}}"
 
-    return _PortGroup(
+    return CppPortGroup(
         struct_decls=[struct_decl],
         member_decl=f"{struct_name} {member_name};",
         ctor_params=ctor_params,
@@ -449,8 +253,9 @@ class CppGenerator(Generator):
         using_aliases=using_aliases,
     )
 
-  def _collect_port_groups(self, ports: dict) -> List[_PortGroup]:
-    """Group `ports` (AppID → BundlePort) into _PortGroup list."""
+  def _collect_port_groups(
+      self, ports: Dict[AppID, types.BundlePort]) -> List[CppPortGroup]:
+    """Group `ports` (AppID → BundlePort) into CppPortGroup list."""
     # Group by AppID name, preserving sorted order.
     groups_by_name: Dict[str, list] = {}
     for appid, port in ports.items():
@@ -459,7 +264,7 @@ class CppGenerator(Generator):
         groups_by_name[n] = []
       groups_by_name[n].append((appid, port))
 
-    result: List[_PortGroup] = []
+    result: List[CppPortGroup] = []
     for appid_name, port_list in groups_by_name.items():
       member_name = self._sanitize_id(appid_name)
       # Sort by idx (None → -1 so scalar ports sort first).
@@ -494,8 +299,8 @@ class CppGenerator(Generator):
     return result
 
   def _emit_module_class(self, name: str, system_name: str,
-                         module_info: ModuleInfo, port_groups: List[_PortGroup],
-                         out: TextIO) -> None:
+                         module_info: ModuleInfo,
+                         port_groups: List[CppPortGroup], out: TextIO) -> None:
     """Emit the full module class to `out`."""
     out.write(f"/// Generated header for {system_name} module {name}.\n"
               "#pragma once\n"
@@ -649,7 +454,7 @@ class CppGenerator(Generator):
     out.write("private:\n  esi::HWModule *rawModule;\n};\n\n")
     out.write(f"}} // namespace {system_name}\n")
 
-  def write_modules(self, output_dir: Path, system_name: str):
+  def write_modules(self, output_dir: Path, system_name: str) -> None:
     """Write the C++ header. One for each module in the manifest."""
     module_instances = self._build_module_instance_map()
 
@@ -674,7 +479,7 @@ class CppGenerator(Generator):
         self._emit_module_class(name, system_name, module_info, port_groups,
                                 hdr)
 
-  def generate(self, output_dir: Path, system_name: str):
+  def generate(self, output_dir: Path, system_name: str) -> None:
     self.type_emitter.write_header(output_dir, system_name)
     self.write_modules(output_dir, system_name)
 
@@ -682,7 +487,7 @@ class CppGenerator(Generator):
 class CppTypePlanner:
   """Plan C++ type naming and ordering from an ESI manifest."""
 
-  def __init__(self, type_table) -> None:
+  def __init__(self, type_table: List[types.ESIType]) -> None:
     """Initialize the generator with the manifest and target namespace."""
     # Map manifest type ids to their preferred C++ names.
     self.type_id_map: Dict[types.ESIType, str] = {}
@@ -698,7 +503,7 @@ class CppTypePlanner:
     self.has_cycle = False
     self._prepare_types(type_table)
 
-  def _prepare_types(self, type_table) -> None:
+  def _prepare_types(self, type_table: List[types.ESIType]) -> None:
     """Name the types and prepare for emission by registering all reachable
     types and assigning."""
     visited: Set[str] = set()
@@ -844,7 +649,8 @@ class CppTypePlanner:
       return [t.element_type]
     return []
 
-  def _visit_types(self, t: types.ESIType, visited: Set[str], visit_fn) -> None:
+  def _visit_types(self, t: types.ESIType, visited: Set[str],
+                   visit_fn: Callable[[types.ESIType], None]) -> None:
     """Traverse types with alphabetical child ordering in post-order."""
     if not isinstance(t, types.ESIType):
       raise TypeError(f"Expected ESIType, got {type(t)}")
@@ -902,17 +708,19 @@ class CppTypePlanner:
     """Collect types that require top-level declarations for a given type."""
     deps: Set[types.ESIType] = set()
 
-    # Visit callback: collect structs, unions, and non-struct aliases used by a
-    # type.
+    # Visit callback: collect structs, unions, and aliases used by a type.
     def visit(current: types.ESIType) -> None:
       if isinstance(current, types.TypeAlias):
-        inner = current.inner_type
-        if inner is not None and (isinstance(
-            inner, (types.StructType, types.UnionType)) or
-                                  self._is_supported_window(inner)):
-          deps.add(inner)
-        else:
-          deps.add(current)
+        # A type that references an alias is emitted using the alias *name*
+        # (see `_cpp_type`), so it must be ordered after the alias's own
+        # `using` declaration. Depend on the alias itself, not the type it
+        # unwraps to; the alias in turn depends on that underlying struct /
+        # union / window, so the full chain (underlying -> alias -> user) is
+        # ordered correctly. (Depending on the unwrapped inner type instead
+        # left the alias free to sort *after* a user that referenced it --
+        # e.g. a nested `array<array<Alias>>` field, where it only happened
+        # to work for the un-nested case by alphabetical luck.)
+        deps.add(current)
       elif isinstance(current, (types.StructType, types.UnionType)):
         deps.add(current)
       elif self._is_supported_window(current):
@@ -1280,11 +1088,8 @@ class CppTypeEmitter:
       return None
     return (bit_width + 7) // 8
 
-  def _emit_size_assert(self,
-                        hdr: TextIO,
-                        type_name: str,
-                        expected_bytes: Optional[int],
-                        indent: str = "") -> None:
+  def _emit_size_assert(self, w: IndentedWriter, type_name: str,
+                        expected_bytes: Optional[int]) -> None:
     """Emit a `static_assert` that pins the C++ `sizeof` of a packed type to
     the byte width derived from the manifest.
 
@@ -1295,12 +1100,11 @@ class CppTypeEmitter:
     """
     if expected_bytes is None:
       return
-    hdr.write(
-        f"{indent}static_assert(sizeof({type_name}) == {expected_bytes},\n"
-        f"{indent}              \"{type_name}: packed layout does not match "
-        f"manifest size\");\n")
+    w.line(f"static_assert(sizeof({type_name}) == {expected_bytes},")
+    w.line(f'              "{type_name}: packed layout does not match '
+           f'manifest size");')
 
-  def _analyze_window(self, window_type: types.WindowType):
+  def _analyze_window(self, window_type: types.WindowType) -> Dict[str, Any]:
     """Extract the metadata needed to emit a bulk list window wrapper."""
     into_type = self._unwrap_aliases(window_type.into_type)
     if not isinstance(into_type, types.StructType):
@@ -1415,36 +1219,27 @@ class CppTypeEmitter:
     return (isinstance(wrapped, types.IntType) and
             not isinstance(wrapped, types.UIntType))
 
-  def _is_byte_packable(self, esi_type: types.ESIType) -> bool:
-    """True if the type's in-memory C++ layout is byte-for-byte identical to
-    its on-wire bit layout, so a flat per-byte copy round-trips it correctly.
-
-    This holds only when every scalar leaf occupies a whole number of bytes
-    that exactly matches its native storage size:
-
-      * an integer / bits type whose width is one of the native storage
-        widths (8/16/32/64). `ui3`, `si5`, a 1-bit `bool`, and even `ui24`
-        (stored in a wider `uint32_t`) all have storage wider than their
-        wire width and are therefore *not* byte-packable.
-      * a struct / union whose total width is a whole number of bytes -- its
-        `_bytes` buffer already mirrors the wire layout.
-      * an array whose element type is itself byte-packable, so successive
-        elements share the same byte stride on the wire and in memory.
-
-    Anything that is not byte-packable must be (un)packed element-by-element
-    from its individual wire bit offset rather than flat-copied.
+  def _emit_view_store(self, w: IndentedWriter, raw_member: str, src: str,
+                       off_expr: str, width: int) -> None:
+    """Emit a loop writing the low `width` bits of the view `src` into
+    `raw_member`, with bit `b` landing at wire bit `off_expr + b`. Shared by
+    the scalar view-class field setter and the per-element view-array setter.
     """
-    wrapped = self._unwrap_aliases(esi_type)
-    if isinstance(wrapped, (types.BitsType, types.IntType)):
-      return wrapped.bit_width in (8, 16, 32, 64)
-    if isinstance(wrapped, types.ArrayType):
-      return self._is_byte_packable(wrapped.element_type)
-    if isinstance(wrapped, (types.StructType, types.UnionType)):
-      bit_width = wrapped.bit_width
-      return bit_width is not None and bit_width > 0 and bit_width % 8 == 0
-    return False
+    w.line(f"const std::size_t n = "
+           f"std::min<std::size_t>({src}.width(), {width});")
+    with w.block(f"for (std::size_t b = 0; b < {width}; ++b)"):
+      w.line(f"const std::size_t g = {off_expr} + b;")
+      w.line(f"const bool val = (b < n) && {src}.getBit(b);")
+      w.line("if (val)")
+      with w.indented():
+        w.line(f"{raw_member}[g / 8] |= "
+               f"static_cast<uint8_t>(uint8_t{{1}} << (g % 8));")
+      w.line("else")
+      with w.indented():
+        w.line(f"{raw_member}[g / 8] &= "
+               f"static_cast<uint8_t>(~(uint8_t{{1}} << (g % 8)));")
 
-  def _emit_field_accessor(self, hdr: TextIO, indent: str, raw_member: str,
+  def _emit_field_accessor(self, w: IndentedWriter, raw_member: str,
                            self_type: str, field_name: str,
                            field_type: types.ESIType, bit_offset: int,
                            bit_width: int) -> None:
@@ -1455,30 +1250,26 @@ class CppTypeEmitter:
     `self_type &` so the caller can chain calls (e.g.
     `Foo{}.a(1).b(2).inner(x)`).
 
-    For integer fields the emitter picks between four inline strategies,
-    fastest first:
+    For integer fields the emitter picks between three inline strategies:
 
-      * Path A — 8/16/32/64-bit fields at a byte-aligned offset. Read/write
-        via a `reinterpret_cast` through the underlying `std::array<uint8_t>`,
-        matching the same aliasing pattern the runtime already relies on in
-        `MessageData::from<T>()` / `MessageData::as<T>()`.
-      * Path B — byte-aligned offset and width but a non-standard width
-        (e.g. `i24`, `i48`). Read each byte directly out of `_bytes` and
-        OR-shift them together (and the reverse on write — split the
-        value out one byte at a time). Signed fields read into the
-        matching unsigned, then sign-extend before returning.
-      * Path C — sub-byte alignment. Fall back to the
+      * Native ints (<= 64 bits). Delegate to the compile-time
         `esi::detail::{read,write}{Un,}signedBits` helpers from
-        `esi/BitAccess.h`, which loop over the constituent bits.
-      * Path D — view-class fields. Triggered when `_is_value_class_type`
-        is true — currently widths above 64 bits, for any of `BitsType`,
-        signed, or unsigned. Returns a non-owning
+        `esi/BitAccess.h`, which loop over the constituent bits at the
+        field's constant offset/width. The non-type template parameters
+        let the optimiser fully unroll the loop, so a byte-aligned
+        standard-width field still collapses to a single load/store on
+        -O1+ -- no special-cased `memcpy` / per-byte fast path required.
+      * `bool` (a single bit). Same helpers, specialised to read/write one
+        bit and hand back a `bool`.
+      * View-class fields. Triggered when `_is_value_class_type` is true --
+        currently widths above 64 bits, for any of `BitsType`, signed, or
+        unsigned. Returns a non-owning
         `esi::BitVector` / `esi::IntView` / `esi::UIntView` view *into*
         the parent struct's `_bytes` -- zero allocation, no copy. The
         setter accepts any `esi::BitVector` (so views and owning
-        subclasses both work) and writes back via `copyBitsOut`. The
-        returned view dangles when the parent buffer dies; see the
-        lifetime warning at the top of the generated header.
+        subclasses both work) and writes back bit-by-bit. The returned
+        view dangles when the parent buffer dies; see the lifetime warning
+        at the top of the generated header.
     """
     field_cpp = self._cpp_type(field_type)
     if field_cpp == "void":
@@ -1487,9 +1278,9 @@ class CppTypeEmitter:
     wrapped = self._unwrap_aliases(field_type)
 
     if isinstance(wrapped, (types.BitsType, types.IntType)):
-      # Path D: view-class field. Today this is exactly the
-      # wider-than-64-bit integer / Bits cases; gated by
-      # `_is_value_class_type` so the rule lives in one place.
+      # View-class field. Today this is exactly the wider-than-64-bit
+      # integer / Bits cases; gated by `_is_value_class_type` so the rule
+      # lives in one place.
       if self._is_value_class_type(field_type):
         byte_offset = bit_offset // 8
         sub_bit_index = bit_offset % 8
@@ -1498,388 +1289,115 @@ class CppTypeEmitter:
         # ceil((sub_bit_index + bit_width) / 8) bytes starting at
         # `_bytes.data() + byte_offset`.
         span_bytes = (sub_bit_index + bit_width + 7) // 8
-        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-        hdr.write(f"{indent}  return {field_cpp}(\n")
-        hdr.write(f"{indent}      std::span<const uint8_t>("
-                  f"{raw_member}.data() + {byte_offset}, {span_bytes}),\n")
-        hdr.write(f"{indent}      static_cast<std::size_t>({bit_width}),\n")
-        hdr.write(f"{indent}      static_cast<uint8_t>({sub_bit_index}));\n")
-        hdr.write(f"{indent}}}\n")
-        hdr.write(f"{indent}{self_type} &{field_name}("
-                  f"const {field_cpp} &v) {{\n")
-        # Walk the input view bit-by-bit and write each bit straight
-        # into `_bytes` at its target position.
-        hdr.write(f"{indent}  const std::size_t n = "
-                  f"std::min<std::size_t>(v.width(), {bit_width});\n")
-        hdr.write(
-            f"{indent}  for (std::size_t b = 0; b < {bit_width}; ++b) {{\n")
-        hdr.write(f"{indent}    const std::size_t g = {bit_offset} + b;\n")
-        hdr.write(f"{indent}    const bool val = (b < n) && v.getBit(b);\n")
-        hdr.write(f"{indent}    if (val)\n")
-        hdr.write(f"{indent}      {raw_member}[g / 8] |= "
-                  f"static_cast<uint8_t>(uint8_t{{1}} << (g % 8));\n")
-        hdr.write(f"{indent}    else\n")
-        hdr.write(f"{indent}      {raw_member}[g / 8] &= "
-                  f"static_cast<uint8_t>(~(uint8_t{{1}} << (g % 8)));\n")
-        hdr.write(f"{indent}  }}\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
+        with w.block(f"{field_cpp} {field_name}() const"):
+          w.line(f"return {field_cpp}(")
+          w.line(f"    std::span<const uint8_t>("
+                 f"{raw_member}.data() + {byte_offset}, {span_bytes}),")
+          w.line(f"    static_cast<std::size_t>({bit_width}),")
+          w.line(f"    static_cast<uint8_t>({sub_bit_index}));")
+        with w.block(f"{self_type} &{field_name}(const {field_cpp} &v)"):
+          # Walk the input view bit-by-bit and write each bit straight
+          # into `_bytes` at its target position.
+          self._emit_view_store(w, raw_member, "v", str(bit_offset), bit_width)
+          w.line("return *this;")
         return
 
       # `bool` is the storage choice for a single bit; bit-precise helpers
       # are the simplest fit and the optimiser collapses them on -O2.
       if bit_width == 1 and field_cpp == "bool":
-        hdr.write(f"{indent}bool {field_name}() const {{\n")
-        hdr.write(f"{indent}  return esi::detail::readUnsignedBits<uint8_t, "
-                  f"{bit_offset}, 1>({raw_member}.data()) != 0;\n")
-        hdr.write(f"{indent}}}\n")
-        hdr.write(f"{indent}{self_type} &{field_name}(bool v) {{\n")
-        hdr.write(f"{indent}  esi::detail::writeUnsignedBits<uint8_t, "
-                  f"{bit_offset}, 1>({raw_member}.data(), "
-                  f"static_cast<uint8_t>(v) & uint8_t{{1}});\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
+        with w.block(f"bool {field_name}() const"):
+          w.line(f"return esi::detail::readUnsignedBits<uint8_t, "
+                 f"{bit_offset}, 1>({raw_member}.data()) != 0;")
+        with w.block(f"{self_type} &{field_name}(bool v)"):
+          w.line(f"esi::detail::writeUnsignedBits<uint8_t, "
+                 f"{bit_offset}, 1>({raw_member}.data(), "
+                 f"static_cast<uint8_t>(v) & uint8_t{{1}});")
+          w.line("return *this;")
         return
 
       signed = self._is_signed_int_field(field_type)
-      byte_aligned = (bit_offset % 8 == 0 and bit_width % 8 == 0)
+      kind = "Signed" if signed else "Unsigned"
 
-      if byte_aligned:
-        byte_offset = bit_offset // 8
-        byte_width = bit_width // 8
-
-        # Path A: standard-width byte-aligned integer. `std::memcpy`
-        # avoids the unaligned-load / strict-aliasing / object-lifetime
-        # UB that a `reinterpret_cast` deref through a `uint8_t` buffer
-        # would invoke (MSVC / ASan / UBSan in particular). The compiler
-        # collapses both calls to a single mov on -O1+.
-        if bit_width in (8, 16, 32, 64):
-          hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-          hdr.write(f"{indent}  {field_cpp} out;\n")
-          hdr.write(f"{indent}  std::memcpy(&out, {raw_member}.data() + "
-                    f"{byte_offset}, sizeof({field_cpp}));\n")
-          hdr.write(f"{indent}  return out;\n")
-          hdr.write(f"{indent}}}\n")
-          hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
-          hdr.write(f"{indent}  std::memcpy({raw_member}.data() + "
-                    f"{byte_offset}, &v, sizeof({field_cpp}));\n")
-          hdr.write(f"{indent}  return *this;\n")
-          hdr.write(f"{indent}}}\n")
-          return
-
-        # Path B: byte-aligned but non-standard width (e.g. i24, i48). Build
-        # the value from per-byte shifts in little-endian wire order. For
-        # signed fields the result is assembled into the matching unsigned
-        # type first so the sign-extension step can mask cleanly without
-        # invoking implementation-defined right-shift behaviour on signed
-        # types.
-        # `field_cpp` already names the rounded-up storage type
-        # (e.g. `int32_t` for `i24`); flip the leading `int`/`uint` rather
-        # than reconstructing the width to avoid emitting non-standard names
-        # like `uint24_t`.
-        if signed:
-          unsigned_cpp = "u" + field_cpp
-        else:
-          unsigned_cpp = field_cpp
-        # Assemble the unsigned value.
-        read_terms = [
-            f"static_cast<{unsigned_cpp}>({raw_member}[{byte_offset}])"
-        ]
-        for i in range(1, byte_width):
-          read_terms.append(
-              f"(static_cast<{unsigned_cpp}>({raw_member}[{byte_offset + i}])"
-              f" << {i * 8})")
-        read_expr = " |\n                ".join(read_terms)
-
-        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-        if signed:
-          hdr.write(f"{indent}  {unsigned_cpp} u = {read_expr};\n")
-          # Sign-extend from the value's high bit.
-          hdr.write(
-              f"{indent}  if (u & ({unsigned_cpp}{{1}} << {bit_width - 1}))\n")
-          hdr.write(f"{indent}    u |= ~(({unsigned_cpp}{{1}} << {bit_width})"
-                    f" - {unsigned_cpp}{{1}});\n")
-          hdr.write(f"{indent}  return static_cast<{field_cpp}>(u);\n")
-        else:
-          hdr.write(f"{indent}  return {read_expr};\n")
-        hdr.write(f"{indent}}}\n")
-
-        hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
-        if signed:
-          hdr.write(f"{indent}  {unsigned_cpp} u = "
-                    f"static_cast<{unsigned_cpp}>(v);\n")
-          value_expr = "u"
-        else:
-          value_expr = "v"
-        for i in range(byte_width):
-          if i == 0:
-            hdr.write(f"{indent}  {raw_member}[{byte_offset}] = "
-                      f"static_cast<uint8_t>({value_expr});\n")
-          else:
-            hdr.write(f"{indent}  {raw_member}[{byte_offset + i}] = "
-                      f"static_cast<uint8_t>({value_expr} >> {i * 8});\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
-        return
-
-      # Path C: sub-byte alignment. Delegate to the generic bit helpers.
-      if signed:
-        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-        hdr.write(f"{indent}  return esi::detail::readSignedBits<{field_cpp}, "
-                  f"{bit_offset}, {bit_width}>({raw_member}.data());\n")
-        hdr.write(f"{indent}}}\n")
-        hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
-        hdr.write(f"{indent}  esi::detail::writeSignedBits<{field_cpp}, "
-                  f"{bit_offset}, {bit_width}>({raw_member}.data(), v);\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
-      else:
-        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-        hdr.write(
-            f"{indent}  return esi::detail::readUnsignedBits<{field_cpp}, "
-            f"{bit_offset}, {bit_width}>({raw_member}.data());\n")
-        hdr.write(f"{indent}}}\n")
-        hdr.write(f"{indent}{self_type} &{field_name}({field_cpp} v) {{\n")
-        hdr.write(f"{indent}  esi::detail::writeUnsignedBits<{field_cpp}, "
-                  f"{bit_offset}, {bit_width}>({raw_member}.data(), v);\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
+      # Delegate to the generic compile-time bit helpers from
+      # `esi/BitAccess.h`. They read/write `Width` bits starting at the
+      # field's constant `BitOffset` (LSB-first) for any width up to 64 --
+      # byte-aligned or not -- and sign-extend signed fields. Because
+      # `BitOffset` / `Width` are non-type template parameters the optimiser
+      # fully unrolls the per-bit loop, so byte-aligned standard-width fields
+      # (`ui8` / `ui32` / ...) still collapse to a single load/store on
+      # -O1+, so a single helper covers every width without any
+      # hand-written byte-copy fast paths.
+      with w.block(f"{field_cpp} {field_name}() const"):
+        w.line(f"return esi::detail::read{kind}Bits<{field_cpp}, "
+               f"{bit_offset}, {bit_width}>({raw_member}.data());")
+      with w.block(f"{self_type} &{field_name}({field_cpp} v)"):
+        w.line(f"esi::detail::write{kind}Bits<{field_cpp}, "
+               f"{bit_offset}, {bit_width}>({raw_member}.data(), v);")
+        w.line("return *this;")
       return
 
-    # Aggregate field (struct/union/array). Supports both byte-aligned and
-    # arbitrary-bit-aligned embedding. The inner aggregate stores its bits
-    # LSB-first in its own `_bytes` buffer, so reading/writing reduces to
-    # copying `bit_width` bits between the parent buffer at `bit_offset`
-    # and the inner buffer at bit 0. When both the offset and width happen
-    # to be byte-aligned we emit a direct per-byte copy; otherwise we fall
-    # back to `esi::detail::copyBitsIn` / `copyBitsOut`, which shuffle the
-    # bits at whatever position they actually land in the parent's wire
-    # layout.
+    # Aggregate field (struct / union / array). The inner aggregate stores
+    # its bits LSB-first in its own `_bytes` buffer, so reading/writing a
+    # struct or union reduces to copying `bit_width` bits between the parent
+    # buffer at `bit_offset` and the inner buffer at bit 0. Arrays are
+    # delegated to `_emit_array_accessor`, a recursive per-element (un)packer
+    # that places every scalar leaf at its true wire offset -- so sub-byte
+    # ints, odd widths, sub-byte aggregates, and *arbitrarily nested* arrays
+    # of those all round-trip, instead of being flat-copied (which only works
+    # when the C++ element layout already matches the wire, e.g. `4 x ui8`).
     assert bit_width >= 0, (
         f"field '{field_name}': unbounded aggregate field reached the "
         f"emitter; the planner should have excluded the parent struct "
         f"via `_contains_unbounded`")
+
+    # Arrays of plain (non view-class) elements: one uniform recursion.
+    if (isinstance(wrapped, types.ArrayType) and
+        not self._is_value_class_type(wrapped.element_type)):
+      self._emit_array_accessor(w, raw_member, self_type, field_name, wrapped,
+                                bit_offset)
+      return
+
+    # An array whose element is a >64-bit view class is handled by the
+    # dedicated span / lazy-range accessors at the end of this method.
+    is_view_array = (isinstance(wrapped, types.ArrayType) and
+                     self._is_value_class_type(wrapped.element_type))
     byte_aligned = (bit_offset % 8 == 0 and bit_width % 8 == 0)
     byte_offset = bit_offset // 8
     byte_width = (bit_width + 7) // 8
-
-    # An array whose element is one of the `esi::{BitVector,IntView,
-    # UIntView}`.
-    is_view_array = (isinstance(wrapped, types.ArrayType) and
-                     self._is_value_class_type(wrapped.element_type))
-
-    # An array whose C++ element layout does not match its on-wire layout,
-    # so the flat byte-copy / `copyBitsIn` / `copyBitsOut` paths below would
-    # truncate or misplace elements. Two element kinds need this treatment:
-    #
-    #   * native-integer elements whose storage is wider than the wire
-    #     width -- sub-byte elements (`i1` -> `bool`, `ui3`) or odd widths
-    #     that round up to a wider storage type (`ui24` -> `uint32_t`).
-    #   * struct / union elements whose total width is not a whole number of
-    #     bytes (e.g. a 5-bit `{ui3, ui2}`): successive elements pack at a
-    #     sub-byte stride on the wire but at a padded whole-byte stride in
-    #     the C++ `std::array`.
-    #
-    # In both cases each element is (un)packed one at a time from its own
-    # wire bit offset `bit_offset + i * elem_width`. Nested-array and
-    # view-class elements keep their own paths below.
-    packed_elem = (self._unwrap_aliases(wrapped.element_type) if isinstance(
-        wrapped, types.ArrayType) else None)
-    is_packed_array = (isinstance(wrapped, types.ArrayType) and
-                       not is_view_array and
-                       isinstance(packed_elem,
-                                  (types.BitsType, types.IntType,
-                                   types.StructType, types.UnionType)) and
-                       not self._is_byte_packable(wrapped.element_type))
-
-    if is_packed_array:
-      assert isinstance(wrapped, types.ArrayType)
-      elem_type = wrapped.element_type
-      elem_cpp = self._cpp_type(elem_type)
-      elem_width = elem_type.bit_width
-      elem_count = wrapped.size
-
-      if isinstance(packed_elem, (types.StructType, types.UnionType)):
-        # Aggregate element: its own `_bytes` buffer already mirrors the
-        # wire layout, so copy `elem_width` bits between the parent buffer
-        # and the element's bytes (which start at the element's bit 0). The
-        # `reinterpret_cast<uint8_t *>` mirrors the whole-aggregate byte
-        # copy emitted further below.
-        hdr.write(f"{indent}{elem_cpp} {field_name}(std::size_t i) const {{\n")
-        hdr.write(f"{indent}  {elem_cpp} out{{}};\n")
-        hdr.write(f"{indent}  auto *dst = reinterpret_cast<uint8_t *>(&out);\n")
-        hdr.write(f"{indent}  const std::size_t bit_off = "
-                  f"{bit_offset} + i * {elem_width};\n")
-        hdr.write(
-            f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
-        hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
-        hdr.write(f"{indent}    if (({raw_member}[g / 8] >> (g % 8)) & 1u)\n")
-        hdr.write(f"{indent}      dst[b / 8] |= "
-                  f"static_cast<uint8_t>(uint8_t{{1}} << (b % 8));\n")
-        hdr.write(f"{indent}  }}\n")
-        hdr.write(f"{indent}  return out;\n")
-        hdr.write(f"{indent}}}\n")
-
-        hdr.write(f"{indent}{self_type} &{field_name}(std::size_t i, "
-                  f"const {elem_cpp} &v) {{\n")
-        hdr.write(f"{indent}  const auto *src = "
-                  f"reinterpret_cast<const uint8_t *>(&v);\n")
-        hdr.write(f"{indent}  const std::size_t bit_off = "
-                  f"{bit_offset} + i * {elem_width};\n")
-        hdr.write(
-            f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
-        hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
-        hdr.write(f"{indent}    const uint8_t bit = static_cast<uint8_t>("
-                  f"(src[b / 8] >> (b % 8)) & 1u);\n")
-        hdr.write(f"{indent}    {raw_member}[g / 8] = static_cast<uint8_t>(\n")
-        hdr.write(
-            f"{indent}        ({raw_member}[g / 8] & static_cast<uint8_t>("
-            f"~(uint8_t{{1}} << (g % 8)))) |\n")
-        hdr.write(f"{indent}        static_cast<uint8_t>(bit << (g % 8)));\n")
-        hdr.write(f"{indent}  }}\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
-      else:
-        signed = self._is_signed_int_field(elem_type)
-        is_bool = (elem_cpp == "bool")
-        # Unsigned storage used to assemble/disassemble the element bits; a
-        # signed value is recovered afterwards with an explicit
-        # sign-extension so the shifts never touch the sign bit (mirrors
-        # `readSignedBits`).
-        if is_bool:
-          unsigned_cpp = "uint8_t"
-        elif signed:
-          unsigned_cpp = "u" + elem_cpp
-        else:
-          unsigned_cpp = elem_cpp
-
-        # Per-element getter: assemble `elem_width` bits LSB-first starting
-        # at the element's wire offset `bit_offset + i * elem_width`.
-        hdr.write(f"{indent}{elem_cpp} {field_name}(std::size_t i) const {{\n")
-        hdr.write(f"{indent}  const std::size_t bit_off = "
-                  f"{bit_offset} + i * {elem_width};\n")
-        if is_bool:
-          hdr.write(f"{indent}  return (({raw_member}[bit_off / 8] >> "
-                    f"(bit_off % 8)) & 1u) != 0;\n")
-        else:
-          hdr.write(f"{indent}  {unsigned_cpp} u = 0;\n")
-          hdr.write(
-              f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
-          hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
-          hdr.write(f"{indent}    u = static_cast<{unsigned_cpp}>(\n")
-          hdr.write(f"{indent}        u | (static_cast<{unsigned_cpp}>("
-                    f"({raw_member}[g / 8] >> (g % 8)) & 1u) << b));\n")
-          hdr.write(f"{indent}  }}\n")
-          if signed:
-            hdr.write(f"{indent}  constexpr {unsigned_cpp} signBit = "
-                      f"static_cast<{unsigned_cpp}>({unsigned_cpp}{{1}} << "
-                      f"{elem_width - 1});\n")
-            hdr.write(f"{indent}  u = static_cast<{unsigned_cpp}>("
-                      f"(u ^ signBit) - signBit);\n")
-          hdr.write(f"{indent}  return static_cast<{elem_cpp}>(u);\n")
-        hdr.write(f"{indent}}}\n")
-
-        # Per-element setter: write `elem_width` bits LSB-first into the
-        # element's wire offset, leaving the surrounding bits untouched.
-        hdr.write(f"{indent}{self_type} &{field_name}(std::size_t i, "
-                  f"{elem_cpp} v) {{\n")
-        hdr.write(f"{indent}  const std::size_t bit_off = "
-                  f"{bit_offset} + i * {elem_width};\n")
-        hdr.write(f"{indent}  const {unsigned_cpp} u = "
-                  f"static_cast<{unsigned_cpp}>(v);\n")
-        hdr.write(
-            f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
-        hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
-        hdr.write(f"{indent}    const uint8_t bit = static_cast<uint8_t>("
-                  f"(u >> b) & {unsigned_cpp}{{1}});\n")
-        hdr.write(f"{indent}    {raw_member}[g / 8] = static_cast<uint8_t>(\n")
-        hdr.write(
-            f"{indent}        ({raw_member}[g / 8] & static_cast<uint8_t>("
-            f"~(uint8_t{{1}} << (g % 8)))) |\n")
-        hdr.write(f"{indent}        static_cast<uint8_t>(bit << (g % 8)));\n")
-        hdr.write(f"{indent}  }}\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
-
-      # Whole-array getter/setter forward to the per-element accessors so the
-      # public API matches the byte-packable array case exactly.
-      hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-      hdr.write(f"{indent}  {field_cpp} out{{}};\n")
-      hdr.write(f"{indent}  for (std::size_t i = 0; i < {elem_count}; ++i)\n")
-      hdr.write(f"{indent}    out[i] = {field_name}(i);\n")
-      hdr.write(f"{indent}  return out;\n")
-      hdr.write(f"{indent}}}\n")
-      hdr.write(f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
-      hdr.write(f"{indent}  for (std::size_t i = 0; i < {elem_count}; ++i)\n")
-      hdr.write(f"{indent}    {field_name}(i, v[i]);\n")
-      hdr.write(f"{indent}  return *this;\n")
-      hdr.write(f"{indent}}}\n")
-      return
 
     if not is_view_array:
       if byte_aligned:
         # Byte-aligned: direct byte copy between the parent's buffer slice
         # and the inner aggregate's `_bytes`. An explicit per-byte loop
         # avoids `memcpy` while still collapsing to one on -O2.
-        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-        hdr.write(f"{indent}  {field_cpp} out{{}};\n")
-        hdr.write(f"{indent}  for (std::size_t i = 0; i < {byte_width}; ++i)\n")
-        hdr.write(f"{indent}    reinterpret_cast<uint8_t *>(&out)[i] = "
-                  f"{raw_member}[{byte_offset} + i];\n")
-        hdr.write(f"{indent}  return out;\n")
-        hdr.write(f"{indent}}}\n")
-        hdr.write(
-            f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
-        hdr.write(f"{indent}  for (std::size_t i = 0; i < {byte_width}; ++i)\n")
-        hdr.write(f"{indent}    {raw_member}[{byte_offset} + i] = "
-                  f"reinterpret_cast<const uint8_t *>(&v)[i];\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
+        with w.block(f"{field_cpp} {field_name}() const"):
+          w.line(f"{field_cpp} out{{}};")
+          w.line(f"for (std::size_t i = 0; i < {byte_width}; ++i)")
+          with w.indented():
+            w.line(f"reinterpret_cast<uint8_t *>(&out)[i] = "
+                   f"{raw_member}[{byte_offset} + i];")
+          w.line("return out;")
+        with w.block(f"{self_type} &{field_name}(const {field_cpp} &v)"):
+          w.line(f"for (std::size_t i = 0; i < {byte_width}; ++i)")
+          with w.indented():
+            w.line(f"{raw_member}[{byte_offset} + i] = "
+                   f"reinterpret_cast<const uint8_t *>(&v)[i];")
+          w.line("return *this;")
       else:
         # Non-byte-aligned: delegate to the per-bit copy helpers. The
         # inner's `out{}` zero-initialiser is required by `copyBitsIn`,
         # which only OR-sets the `1` bits.
-        hdr.write(f"{indent}{field_cpp} {field_name}() const {{\n")
-        hdr.write(f"{indent}  {field_cpp} out{{}};\n")
-        hdr.write(f"{indent}  esi::detail::copyBitsIn<{bit_offset}, "
-                  f"{bit_width}>({raw_member}.data(), "
-                  f"reinterpret_cast<uint8_t *>(&out));\n")
-        hdr.write(f"{indent}  return out;\n")
-        hdr.write(f"{indent}}}\n")
-        hdr.write(
-            f"{indent}{self_type} &{field_name}(const {field_cpp} &v) {{\n")
-        hdr.write(f"{indent}  esi::detail::copyBitsOut<{bit_offset}, "
-                  f"{bit_width}>({raw_member}.data(), "
-                  f"reinterpret_cast<const uint8_t *>(&v));\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
-
-    # Convenience indexed accessors for fixed-size arrays. The whole-array
-    # getter/setter above is always sufficient; these helpers just save a
-    # round-trip through a local `std::array` when callers only touch one
-    # element. Only emitted when the array starts at a byte-aligned
-    # position and the element width is a whole number of bytes — anything
-    # else has to go through the whole-array accessor since per-element
-    # bit shuffling would require its own per-element offset arithmetic.
-    if (not is_view_array and isinstance(wrapped, types.ArrayType) and
-        byte_aligned and wrapped.element_type.bit_width % 8 == 0):
-      elem_cpp = self._cpp_type(wrapped.element_type)
-      if elem_cpp != "void":
-        elem_bytes = self._field_byte_width(wrapped.element_type)
-        hdr.write(f"{indent}{elem_cpp} {field_name}(std::size_t i) const {{\n")
-        hdr.write(f"{indent}  {elem_cpp} out{{}};\n")
-        hdr.write(f"{indent}  for (std::size_t j = 0; j < {elem_bytes}; ++j)\n")
-        hdr.write(f"{indent}    reinterpret_cast<uint8_t *>(&out)[j] = "
-                  f"{raw_member}[{byte_offset} + i * {elem_bytes} + j];\n")
-        hdr.write(f"{indent}  return out;\n")
-        hdr.write(f"{indent}}}\n")
-        hdr.write(f"{indent}{self_type} &{field_name}(std::size_t i, "
-                  f"const {elem_cpp} &v) {{\n")
-        hdr.write(f"{indent}  for (std::size_t j = 0; j < {elem_bytes}; ++j)\n")
-        hdr.write(f"{indent}    {raw_member}[{byte_offset} + i * {elem_bytes}"
-                  f" + j] = reinterpret_cast<const uint8_t *>(&v)[j];\n")
-        hdr.write(f"{indent}  return *this;\n")
-        hdr.write(f"{indent}}}\n")
+        with w.block(f"{field_cpp} {field_name}() const"):
+          w.line(f"{field_cpp} out{{}};")
+          w.line(f"esi::detail::copyBitsIn<{bit_offset}, "
+                 f"{bit_width}>({raw_member}.data(), "
+                 f"reinterpret_cast<uint8_t *>(&out));")
+          w.line("return out;")
+        with w.block(f"{self_type} &{field_name}(const {field_cpp} &v)"):
+          w.line(f"esi::detail::copyBitsOut<{bit_offset}, "
+                 f"{bit_width}>({raw_member}.data(), "
+                 f"reinterpret_cast<const uint8_t *>(&v));")
+          w.line("return *this;")
 
     # Indexed accessors for arrays whose element is one of the view
     # classes (`BitVector` / `IntView` / `UIntView`). The whole-array
@@ -1906,55 +1424,169 @@ class CppTypeEmitter:
       elem_cpp = self._cpp_type(elem_type)
       elem_width = elem_type.bit_width
       elem_count = wrapped.size
-      hdr.write(f"{indent}{elem_cpp} {field_name}(std::size_t i) const {{\n")
-      hdr.write(f"{indent}  const std::size_t bit_off = "
-                f"{bit_offset} + i * {elem_width};\n")
-      hdr.write(f"{indent}  return {elem_cpp}(\n")
-      hdr.write(f"{indent}      std::span<const uint8_t>("
-                f"{raw_member}.data() + bit_off / 8,\n")
-      hdr.write(f"{indent}                               "
-                f"(bit_off % 8 + {elem_width} + 7) / 8),\n")
-      hdr.write(f"{indent}      static_cast<std::size_t>({elem_width}),\n")
-      hdr.write(f"{indent}      static_cast<uint8_t>(bit_off % 8));\n")
-      hdr.write(f"{indent}}}\n")
-      hdr.write(f"{indent}{self_type} &{field_name}(std::size_t i, "
-                f"const {elem_cpp} &v) {{\n")
-      hdr.write(f"{indent}  const std::size_t bit_off = "
-                f"{bit_offset} + i * {elem_width};\n")
-      hdr.write(f"{indent}  const std::size_t n = "
-                f"std::min<std::size_t>(v.width(), {elem_width});\n")
-      hdr.write(
-          f"{indent}  for (std::size_t b = 0; b < {elem_width}; ++b) {{\n")
-      hdr.write(f"{indent}    const std::size_t g = bit_off + b;\n")
-      hdr.write(f"{indent}    const bool val = (b < n) && v.getBit(b);\n")
-      hdr.write(f"{indent}    if (val)\n")
-      hdr.write(f"{indent}      {raw_member}[g / 8] |= "
-                f"static_cast<uint8_t>(uint8_t{{1}} << (g % 8));\n")
-      hdr.write(f"{indent}    else\n")
-      hdr.write(f"{indent}      {raw_member}[g / 8] &= "
-                f"static_cast<uint8_t>(~(uint8_t{{1}} << (g % 8)));\n")
-      hdr.write(f"{indent}  }}\n")
-      hdr.write(f"{indent}  return *this;\n")
-      hdr.write(f"{indent}}}\n")
+      with w.block(f"{elem_cpp} {field_name}(std::size_t i) const"):
+        w.line(f"const std::size_t bit_off = {bit_offset} + i * {elem_width};")
+        w.line(f"return {elem_cpp}(")
+        w.line(f"    std::span<const uint8_t>("
+               f"{raw_member}.data() + bit_off / 8,")
+        w.line(f"                             "
+               f"(bit_off % 8 + {elem_width} + 7) / 8),")
+        w.line(f"    static_cast<std::size_t>({elem_width}),")
+        w.line(f"    static_cast<uint8_t>(bit_off % 8));")
+      with w.block(f"{self_type} &{field_name}(std::size_t i, "
+                   f"const {elem_cpp} &v)"):
+        w.line(f"const std::size_t bit_off = {bit_offset} + i * {elem_width};")
+        self._emit_view_store(w, raw_member, "v", "bit_off", elem_width)
+        w.line("return *this;")
       # Lazy whole-array view: `iota(0, N) | transform([this](i){ ... })`
       # gives a random-access range of `elem_cpp` views computed on
       # access, with zero up-front allocation.
-      hdr.write(f"{indent}auto {field_name}() const {{\n")
-      hdr.write(f"{indent}  return std::views::iota("
-                f"std::size_t{{0}}, std::size_t{{{elem_count}}}) |\n")
-      hdr.write(f"{indent}         std::views::transform("
-                f"[this](std::size_t i) {{\n")
-      hdr.write(f"{indent}           return this->{field_name}(i);\n")
-      hdr.write(f"{indent}         }});\n")
-      hdr.write(f"{indent}}}\n")
+      with w.block(f"auto {field_name}() const"):
+        w.line(f"return std::views::iota("
+               f"std::size_t{{0}}, std::size_t{{{elem_count}}}) |")
+        w.line("       std::views::transform([this](std::size_t i) {")
+        w.line(f"         return this->{field_name}(i);")
+        w.line("       });")
       # Whole-array setter: forwards to the per-element setter for
       # each index.
-      hdr.write(f"{indent}{self_type} &{field_name}("
-                f"const std::array<{elem_cpp}, {elem_count}> &v) {{\n")
-      hdr.write(f"{indent}  for (std::size_t i = 0; i < {elem_count}; ++i)\n")
-      hdr.write(f"{indent}    {field_name}(i, v[i]);\n")
-      hdr.write(f"{indent}  return *this;\n")
-      hdr.write(f"{indent}}}\n")
+      with w.block(f"{self_type} &{field_name}("
+                   f"const std::array<{elem_cpp}, {elem_count}> &v)"):
+        w.line(f"for (std::size_t i = 0; i < {elem_count}; ++i)")
+        with w.indented():
+          w.line(f"{field_name}(i, v[i]);")
+        w.line("return *this;")
+
+  def _emit_array_accessor(self, w: IndentedWriter, raw_member: str,
+                           self_type: str, field_name: str,
+                           array_type: types.ArrayType,
+                           bit_offset: int) -> None:
+    """Emit the accessor set for a fixed-size array field.
+
+    Four accessors are emitted, matching the existing array API:
+
+      * `Elem field(std::size_t i)` / `Self &field(std::size_t i, const Elem &)`
+        -- per-element get/set, where `Elem` is the (possibly itself an
+        array) element type.
+      * `Whole field()` / `Self &field(const Whole &)` -- whole-array
+        get/set, expressed in terms of the per-element accessors.
+
+    The per-element get/set bodies are produced by `_emit_unpack` /
+    `_emit_pack`, which recurse to the scalar leaves and place each leaf at
+    its true wire offset `bit_offset + i * elemWidth (+ ...)`. This is what
+    lets sub-byte, odd-width, sub-byte-aggregate, and *arbitrarily nested*
+    array elements round-trip even when the C++ element layout does not
+    match the wire layout.
+    """
+    elem_type = array_type.element_type
+    elem_cpp = self._cpp_type(elem_type)
+    elem_width = elem_type.bit_width
+    elem_count = array_type.size
+    whole_cpp = self._cpp_type(array_type)
+    elem_off = f"{bit_offset} + i * {elem_width}"
+
+    with w.block(f"{elem_cpp} {field_name}(std::size_t i) const"):
+      w.line(f"{elem_cpp} out{{}};")
+      self._emit_unpack(w, raw_member, "out", elem_off, elem_type, 1)
+      w.line("return out;")
+
+    with w.block(f"{self_type} &{field_name}(std::size_t i, "
+                 f"const {elem_cpp} &v)"):
+      self._emit_pack(w, raw_member, "v", elem_off, elem_type, 1)
+      w.line("return *this;")
+
+    with w.block(f"{whole_cpp} {field_name}() const"):
+      w.line(f"{whole_cpp} out{{}};")
+      w.line(f"for (std::size_t i = 0; i < {elem_count}; ++i)")
+      with w.indented():
+        w.line(f"out[i] = {field_name}(i);")
+      w.line("return out;")
+
+    with w.block(f"{self_type} &{field_name}(const {whole_cpp} &v)"):
+      w.line(f"for (std::size_t i = 0; i < {elem_count}; ++i)")
+      with w.indented():
+        w.line(f"{field_name}(i, v[i]);")
+      w.line("return *this;")
+
+  def _emit_unpack(self, w: IndentedWriter, raw_member: str, dst: str, off: str,
+                   esi_type: types.ESIType, depth: int) -> None:
+    """Emit statements that read a value of `esi_type` out of `raw_member`
+    at wire bit offset `off` (a C++ `size_t` expression) into the
+    already-declared, zero-initialised C++ lvalue `dst`.
+
+    Recurses through arrays (one loop per dimension) down to scalar / struct
+    / union leaves, which are read with the runtime-offset bit helpers.
+    """
+    wrapped = self._unwrap_aliases(esi_type)
+    if isinstance(wrapped, types.ArrayType):
+      idx = f"i{depth}"
+      ew = wrapped.element_type.bit_width
+      with w.block(f"for (std::size_t {idx} = 0; {idx} < "
+                   f"{wrapped.size}; ++{idx})"):
+        self._emit_unpack(w, raw_member, f"{dst}[{idx}]",
+                          f"{off} + {idx} * {ew}", wrapped.element_type,
+                          depth + 1)
+      return
+    if isinstance(wrapped, (types.StructType, types.UnionType)):
+      # The inner aggregate's own `_bytes` already mirror the wire layout, so
+      # copy its bits straight in. `dst` is zero-initialised by the caller,
+      # as `copyBitsInDyn` only OR-sets the `1` bits.
+      w.line(f"esi::detail::copyBitsInDyn({raw_member}.data(), {off},")
+      w.line(f"    reinterpret_cast<uint8_t *>(&{dst}), {wrapped.bit_width});")
+      return
+    if isinstance(wrapped, (types.BitsType, types.IntType)):
+      if self._is_value_class_type(esi_type):
+        raise NotImplementedError(
+            "arrays of integers wider than 64 bits are not supported")
+      cpp = self._cpp_type(esi_type)
+      if cpp == "bool":
+        w.line(f"{dst} = esi::detail::readUnsignedBitsDyn<uint8_t>("
+               f"{raw_member}.data(), {off}, 1) != 0;")
+      elif self._is_signed_int_field(esi_type):
+        w.line(f"{dst} = esi::detail::readSignedBitsDyn<{cpp}>("
+               f"{raw_member}.data(), {off}, {wrapped.bit_width});")
+      else:
+        w.line(f"{dst} = esi::detail::readUnsignedBitsDyn<{cpp}>("
+               f"{raw_member}.data(), {off}, {wrapped.bit_width});")
+      return
+    raise NotImplementedError(
+        f"unsupported array element type '{wrapped}' for C++ generation")
+
+  def _emit_pack(self, w: IndentedWriter, raw_member: str, src: str, off: str,
+                 esi_type: types.ESIType, depth: int) -> None:
+    """Inverse of `_emit_unpack`: write the C++ value `src` of `esi_type`
+    into `raw_member` at wire bit offset `off`."""
+    wrapped = self._unwrap_aliases(esi_type)
+    if isinstance(wrapped, types.ArrayType):
+      idx = f"i{depth}"
+      ew = wrapped.element_type.bit_width
+      with w.block(f"for (std::size_t {idx} = 0; {idx} < "
+                   f"{wrapped.size}; ++{idx})"):
+        self._emit_pack(w, raw_member, f"{src}[{idx}]", f"{off} + {idx} * {ew}",
+                        wrapped.element_type, depth + 1)
+      return
+    if isinstance(wrapped, (types.StructType, types.UnionType)):
+      w.line(f"esi::detail::copyBitsOutDyn({raw_member}.data(), {off},")
+      w.line(f"    reinterpret_cast<const uint8_t *>(&{src}), "
+             f"{wrapped.bit_width});")
+      return
+    if isinstance(wrapped, (types.BitsType, types.IntType)):
+      if self._is_value_class_type(esi_type):
+        raise NotImplementedError(
+            "arrays of integers wider than 64 bits are not supported")
+      cpp = self._cpp_type(esi_type)
+      if cpp == "bool":
+        w.line(f"esi::detail::writeUnsignedBitsDyn<uint8_t>("
+               f"{raw_member}.data(), "
+               f"static_cast<uint8_t>({src}) & uint8_t{{1}}, {off}, 1);")
+      elif self._is_signed_int_field(esi_type):
+        w.line(f"esi::detail::writeSignedBitsDyn<{cpp}>("
+               f"{raw_member}.data(), {src}, {off}, {wrapped.bit_width});")
+      else:
+        w.line(f"esi::detail::writeUnsignedBitsDyn<{cpp}>("
+               f"{raw_member}.data(), {src}, {off}, {wrapped.bit_width});")
+      return
+    raise NotImplementedError(
+        f"unsupported array element type '{wrapped}' for C++ generation")
 
   def _ctor_param_type(self, field_type: types.ESIType) -> str:
     """Return the C++ constructor-parameter type for a setter call."""
@@ -1964,7 +1596,8 @@ class CppTypeEmitter:
       return field_cpp
     return f"const {field_cpp} &"
 
-  def _emit_struct(self, hdr: TextIO, struct_type: types.StructType) -> None:
+  def _emit_struct(self, w: IndentedWriter,
+                   struct_type: types.StructType) -> None:
     """Emit a packed struct as a raw byte buffer with bit-precise accessors.
 
     The struct's storage is a single `std::array<uint8_t, N>` (where `N`
@@ -1995,41 +1628,40 @@ class CppTypeEmitter:
     if not logical_fields:
       return
 
-    hdr.write(f"struct {struct_name} {{\n")
-    # `_bytes` holds the wire layout and is private; the only legitimate
-    # external view of those bytes is via `MessageData::from()` /
-    # `MessageData::as()` which reinterpret-cast through the whole struct
-    # and don't need member-level access.
-    hdr.write("private:\n")
-    hdr.write(f"  std::array<uint8_t, {max(total_bytes, 1)}> _bytes{{}};\n\n")
-    hdr.write("public:\n")
+    with w.block(f"struct {struct_name}", tail=";"):
+      # `_bytes` holds the wire layout and is private; the only legitimate
+      # external view of those bytes is via `MessageData::from()` /
+      # `MessageData::as()` which reinterpret-cast through the whole struct
+      # and don't need member-level access.
+      w.access("private:")
+      w.line(f"std::array<uint8_t, {max(total_bytes, 1)}> _bytes{{}};")
+      w.line()
+      w.access("public:")
+      w.line(f"{struct_name}() = default;")
+      ctor_params = ", ".join(f"{self._ctor_param_type(ftype)} {name}"
+                              for name, ftype in logical_fields)
+      with w.block(f"{struct_name}({ctor_params})"):
+        # `this->` disambiguates the chained setter calls from the like-named
+        # parameters that shadow the member functions inside the ctor body.
+        chain = ".".join(f"{name}({name})" for name, _ in logical_fields)
+        w.line(f"this->{chain};")
+      w.line()
 
-    hdr.write(f"  {struct_name}() = default;\n")
-    ctor_params = ", ".join(f"{self._ctor_param_type(ftype)} {name}"
-                            for name, ftype in logical_fields)
-    hdr.write(f"  {struct_name}({ctor_params}) {{\n")
-    # `this->` disambiguates the chained setter calls from the like-named
-    # parameters that shadow the member functions inside the ctor body.
-    chain = ".".join(f"{name}({name})" for name, _ in logical_fields)
-    hdr.write(f"    this->{chain};\n")
-    hdr.write("  }\n\n")
+      # Per-field accessors in logical (manifest) order so the user-facing
+      # API mirrors the manifest field order rather than the wire reversal.
+      for name, ftype in logical_fields:
+        self._emit_field_accessor(w, "_bytes", struct_name, name, ftype,
+                                  bit_offsets[name], ftype.bit_width)
+        w.line()
 
-    # Per-field accessors in logical (manifest) order so the user-facing
-    # API mirrors the manifest field order rather than the wire reversal.
-    for name, ftype in logical_fields:
-      self._emit_field_accessor(hdr, "  ", "_bytes", struct_name, name, ftype,
-                                bit_offsets[name], ftype.bit_width)
-      hdr.write("\n")
-
-    hdr.write(f"  static constexpr std::string_view _ESI_ID = "
-              f"{self._cpp_string_literal(struct_type.id)};\n")
-    hdr.write("};\n")
+      w.line(f"static constexpr std::string_view _ESI_ID = "
+             f"{self._cpp_string_literal(struct_type.id)};")
     expected_bytes = self._safe_byte_width(struct_type)
     if expected_bytes is not None and expected_bytes > 0:
-      self._emit_size_assert(hdr, struct_name, expected_bytes)
-    hdr.write("\n")
+      self._emit_size_assert(w, struct_name, expected_bytes)
+    w.line()
 
-  def _emit_union(self, hdr: TextIO, union_type: types.UnionType) -> None:
+  def _emit_union(self, w: IndentedWriter, union_type: types.UnionType) -> None:
     """Emit a union as a raw byte buffer with per-variant accessors.
 
     The union's storage is a single `std::array<uint8_t, N>` sized to the
@@ -2047,36 +1679,40 @@ class CppTypeEmitter:
     union_name = self.type_id_map[union_type]
     union_bytes = self._field_byte_width(union_type)
 
-    hdr.write(f"struct {union_name} {{\n")
-    # See `_emit_struct` for the access-control rationale.
-    hdr.write("private:\n")
-    hdr.write(f"  std::array<uint8_t, {union_bytes}> _bytes{{}};\n\n")
-    hdr.write("public:\n")
-    hdr.write(f"  {union_name}() = default;\n\n")
+    with w.block(f"struct {union_name}", tail=";"):
+      # See `_emit_struct` for the access-control rationale.
+      w.access("private:")
+      w.line(f"std::array<uint8_t, {union_bytes}> _bytes{{}};")
+      w.line()
+      w.access("public:")
+      w.line(f"{union_name}() = default;")
+      w.line()
 
-    for field_name, field_type in union_type.fields:
-      field_cpp = self._cpp_type(field_type)
-      if field_cpp == "void":
-        continue
-      field_bytes = self._field_byte_width(field_type)
-      byte_offset = union_bytes - field_bytes
-      bit_offset = byte_offset * 8
-      bit_width = field_type.bit_width
-      # Each variant is reached at the same MSB-aligned position regardless
-      # of width. Reuse `_emit_field_accessor` so we share the integer /
-      # aggregate code paths and don't duplicate the bit-access boilerplate.
-      self._emit_field_accessor(hdr, "  ", "_bytes", union_name, field_name,
-                                field_type, bit_offset, bit_width)
-      hdr.write("\n")
+      for field_name, field_type in union_type.fields:
+        field_cpp = self._cpp_type(field_type)
+        if field_cpp == "void":
+          continue
+        field_bytes = self._field_byte_width(field_type)
+        byte_offset = union_bytes - field_bytes
+        bit_offset = byte_offset * 8
+        bit_width = field_type.bit_width
+        # Each variant is reached at the same MSB-aligned position regardless
+        # of width. Reuse `_emit_field_accessor` so we share the integer /
+        # aggregate code paths and don't duplicate the bit-access boilerplate.
+        self._emit_field_accessor(w, "_bytes", union_name, field_name,
+                                  field_type, bit_offset, bit_width)
+        w.line()
 
-    hdr.write(f"  static constexpr std::string_view _ESI_ID = "
-              f"{self._cpp_string_literal(union_type.id)};\n")
-    hdr.write("};\n")
+      w.line(f"static constexpr std::string_view _ESI_ID = "
+             f"{self._cpp_string_literal(union_type.id)};")
     if union_bytes > 0:
-      self._emit_size_assert(hdr, union_name, union_bytes)
-    hdr.write("\n")
+      self._emit_size_assert(w, union_name, union_bytes)
+    w.line()
 
-  def _compute_window_frame_layout(self, fields, pad_bytes, count_type_synth):
+  def _compute_window_frame_layout(
+      self, fields: List[Tuple[str, Optional[types.ESIType]]], pad_bytes: int,
+      count_type_synth: types.ESIType
+  ) -> List[Tuple[str, types.ESIType, int, int]]:
     """Compute (name, type, byte_offset, bit_width) for each window frame field.
 
     Fields are listed in C++ declaration order. They start after `pad_bytes`
@@ -2096,28 +1732,36 @@ class CppTypeEmitter:
       byte_offset += (bit_width + 7) // 8
     return layout
 
-  def _emit_window_frame(self, hdr: TextIO, frame_name: str, frame_bytes: int,
-                         layout) -> None:
+  def _emit_window_frame(
+      self, w: IndentedWriter, frame_name: str, frame_bytes: int,
+      layout: List[Tuple[str, types.ESIType, int, int]]) -> None:
     """Emit a window header/data frame as a raw-bytes struct with accessors.
 
-    Nested inside the window helper class (`indent` = 2 spaces) and uses
-    the same B3 accessor pattern as top-level structs/unions: a private
-    `_bytes` array plus per-field getter/setter pairs returning
-    `frame_name &` to allow chaining.
+    Nested inside the window helper class, it uses the same accessor pattern
+    as top-level structs/unions: a private `_bytes` array plus per-field
+    getter/setter pairs returning `frame_name &` to allow chaining.
     """
-    hdr.write(f"  struct {frame_name} {{\n")
-    hdr.write("   private:\n")
-    hdr.write(f"    std::array<uint8_t, {frame_bytes}> _bytes{{}};\n\n")
-    hdr.write("   public:\n")
-    for name, ftype, byte_offset, bit_width in layout:
-      self._emit_field_accessor(hdr, "    ", "_bytes", frame_name, name, ftype,
-                                byte_offset * 8, bit_width)
-      hdr.write("\n")
-    hdr.write("  };\n")
-    self._emit_size_assert(hdr, frame_name, frame_bytes, indent="  ")
+    with w.block(f"struct {frame_name}", tail=";"):
+      w.access("private:")
+      w.line(f"std::array<uint8_t, {frame_bytes}> _bytes{{}};")
+      w.line()
+      w.access("public:")
+      for name, ftype, byte_offset, bit_width in layout:
+        self._emit_field_accessor(w, "_bytes", frame_name, name, ftype,
+                                  byte_offset * 8, bit_width)
+        w.line()
+    self._emit_size_assert(w, frame_name, frame_bytes)
 
-  def _emit_window(self, hdr: TextIO, window_type: types.WindowType) -> None:
-    """Emit a SegmentedMessageData helper for a serial list window."""
+  def _emit_window(self, hdr: IndentedWriter,
+                   window_type: types.WindowType) -> None:
+    """Emit a SegmentedMessageData helper for a serial list window.
+
+    This emitter builds its own pre-indented text, so it uses the writer
+    purely as a verbatim `hdr.write(...)` sink. The nested frame structs,
+    however, are produced by the line-based `_emit_window_frame`, so their
+    calls are wrapped in `hdr.indented()` to place them at the window
+    class's member indent.
+    """
     info = self._analyze_window(window_type)
     ctor_params = [
         self._format_window_ctor_param(name, field_type)
@@ -2158,11 +1802,14 @@ class CppTypeEmitter:
     hdr.write("public:\n")
     hdr.write(f"  using value_type = {info['element_cpp']};\n")
     hdr.write(f"  using count_type = {info['count_cpp']};\n\n")
-    self._emit_window_frame(hdr, "data_frame", info["frame_bytes"], data_layout)
+    with hdr.indented():
+      self._emit_window_frame(hdr, "data_frame", info["frame_bytes"],
+                              data_layout)
     hdr.write("\n")
     hdr.write("private:\n")
-    self._emit_window_frame(hdr, "header_frame", info["frame_bytes"],
-                            header_layout)
+    with hdr.indented():
+      self._emit_window_frame(hdr, "header_frame", info["frame_bytes"],
+                              header_layout)
     hdr.write("\n")
     hdr.write("  // One header per burst (bursts 2..N are continuations whose\n"
               "  // only meaningful field is the count); the data frames of\n"
@@ -2253,7 +1900,8 @@ class CppTypeEmitter:
     self._emit_window_deserializer(hdr, info)
     hdr.write("};\n\n")
 
-  def _emit_window_data_accessors(self, hdr: TextIO, info) -> None:
+  def _emit_window_data_accessors(self, hdr: IndentedWriter,
+                                  info: Dict[str, Any]) -> None:
     """Emit accessors for the header and data fields of a window helper.
 
     Exposes each static header field as a scalar accessor, the count of data
@@ -2310,7 +1958,8 @@ class CppTypeEmitter:
                 f"    return out;\n"
                 f"  }}\n")
 
-  def _emit_window_deserializer(self, hdr: TextIO, info) -> None:
+  def _emit_window_deserializer(self, hdr: IndentedWriter,
+                                info: Dict[str, Any]) -> None:
     """Emit a few bridge helpers + a `TypeDeserializer` alias.
 
     The actual decoder lives in `esi::SerialListTypeDeserializer<T>`, which
@@ -2355,7 +2004,7 @@ class CppTypeEmitter:
         f"  using TypeDeserializer = esi::SerialListTypeDeserializer<{window_name}>;\n"
     )
 
-  def _emit_alias(self, hdr: TextIO, alias_type: types.TypeAlias) -> None:
+  def _emit_alias(self, w: IndentedWriter, alias_type: types.TypeAlias) -> None:
     """Emit a using alias when the alias targets a different C++ type."""
     inner_wrapped = alias_type.inner_type
     alias_name = self.type_id_map[alias_type]
@@ -2365,13 +2014,21 @@ class CppTypeEmitter:
     if inner_cpp is None:
       inner_cpp = self.type_id_map[alias_type]
     if inner_cpp != alias_name:
-      hdr.write(f"using {alias_name} = {inner_cpp};\n\n")
+      w.line(f"using {alias_name} = {inner_cpp};")
+      w.line()
 
   def write_header(self, output_dir: Path, system_name: str) -> None:
     """Emit the fully ordered types.h header into the output directory."""
+    if self.has_cycle:
+      sys.stderr.write("Warning: cyclic type dependencies detected.\n")
+      sys.stderr.write("  Logically this should not be possible.\n")
+      sys.stderr.write(
+          "  Emitted code may fail to compile due to ordering issues.\n")
+
     hdr_file = output_dir / "types.h"
     with open(hdr_file, "w", encoding="utf-8") as hdr:
-      hdr.write(
+      w = IndentedWriter(hdr)
+      w.write(
           textwrap.dedent(f"""
         // Generated header for {system_name} types.
         //
@@ -2406,14 +2063,9 @@ class CppTypeEmitter:
         namespace {system_name} {{
 
       """))
-      if self.has_cycle:
-        sys.stderr.write("Warning: cyclic type dependencies detected.\n")
-        sys.stderr.write("  Logically this should not be possible.\n")
-        sys.stderr.write(
-            "  Emitted code may fail to compile due to ordering issues.\n")
 
       for skipped_type, reason in self.skipped_types:
-        hdr.write(f"// Unsupported type '{skipped_type}': {reason}\n\n")
+        w.write(f"// Unsupported type '{skipped_type}': {reason}\n\n")
 
       for emit_type in self.ordered_types:
         # Anything that wasn't expressible should have been caught by
@@ -2421,21 +2073,21 @@ class CppTypeEmitter:
         # leaks past that, treat it as a planner bug rather than emitting
         # a half-written header.
         if isinstance(emit_type, types.StructType):
-          self._emit_struct(hdr, emit_type)
+          self._emit_struct(w, emit_type)
         elif isinstance(emit_type, types.UnionType):
-          self._emit_union(hdr, emit_type)
+          self._emit_union(w, emit_type)
         elif isinstance(emit_type, types.WindowType):
-          self._emit_window(hdr, emit_type)
+          self._emit_window(w, emit_type)
         elif isinstance(emit_type, types.TypeAlias):
-          self._emit_alias(hdr, emit_type)
+          self._emit_alias(w, emit_type)
 
-      hdr.write(textwrap.dedent(f"""
+      w.write(textwrap.dedent(f"""
     }} // namespace {system_name}
     """))
 
 
 def run(generator: Type[Generator] = CppGenerator,
-        cmdline_args=sys.argv) -> int:
+        cmdline_args: List[str] = sys.argv) -> int:
   """Create and run a generator reading options from the command line."""
 
   argparser = argparse.ArgumentParser(
@@ -2510,7 +2162,3 @@ def run(generator: Type[Generator] = CppGenerator,
   gen = generator(conn)
   gen.generate(output_dir, args.system_name)
   return 0
-
-
-if __name__ == '__main__':
-  sys.exit(run())

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen/indented_writer.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen/indented_writer.py
@@ -1,0 +1,74 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""A tiny indentation-aware writer for emitting source text.
+
+Lets the type/module emitters avoid threading an `indent` string or
+hand-writing trailing newlines and doubled `{{` / `}}` braces. Text is
+streamed straight to the underlying output sink as it is produced --
+nothing is buffered.
+"""
+
+from contextlib import contextmanager
+from typing import Iterator, TextIO
+
+
+class IndentedWriter:
+  """Stream indented source text to an output sink.
+
+  Wraps a `TextIO`-like `out` and tracks indentation as a stack of two-space
+  levels, so emit code never has to thread an `indent` string or hand-write
+  trailing newlines and doubled `{{` / `}}` braces. Every call writes through
+  to `out` immediately. The primitives are:
+
+    * `line(text)` -- write one line at the current indent (blank if empty).
+    * `block(header)` -- a context manager that writes `header {`, indents its
+      body, then closes with `}` (plus an optional `tail`, e.g. `;`).
+    * `access(label)` -- write an access specifier (`public:` / `private:`)
+      one level out from the members it introduces.
+
+  `write(text)` streams `text` verbatim (no indentation); it mirrors
+  `TextIO.write` so an `IndentedWriter` can itself stand in for a sink.
+  `indented()` opens a bare indent (e.g. a single-statement loop body)
+  without braces.
+  """
+
+  def __init__(self, out: TextIO, level: int = 0) -> None:
+    self._out = out
+    self._level = level
+
+  def line(self, text: str = "") -> None:
+    self._out.write(f"{'  ' * self._level}{text}\n" if text else "\n")
+
+  def lines(self, *texts: str) -> None:
+    for text in texts:
+      self.line(text)
+
+  def write(self, text: str) -> None:
+    """Write `text` verbatim (no indentation). Mirrors `TextIO.write` so the
+    writer can be passed to emitters that build pre-indented strings."""
+    self._out.write(text)
+
+  def access(self, label: str) -> None:
+    # Access specifiers conventionally sit one indent level out from the
+    # members they introduce.
+    outer = max(self._level - 1, 0)
+    self._out.write(f"{'  ' * outer}{label}\n")
+
+  @contextmanager
+  def indented(self) -> Iterator[None]:
+    self._level += 1
+    try:
+      yield
+    finally:
+      self._level -= 1
+
+  @contextmanager
+  def block(self, header: str, *, tail: str = "") -> Iterator[None]:
+    self.line(f"{header} {{")
+    self._level += 1
+    try:
+      yield
+    finally:
+      self._level -= 1
+      self.line(f"}}{tail}")

--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen/ports.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen/ports.py
@@ -1,0 +1,237 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Port-kind strategy table for the C++ module generator.
+
+Centralises everything that varies between the ESI port kinds (function,
+callback, to-host / from-host channel, MMIO region, telemetry metric, plain
+bundle) into a single `CppPortKind` record per kind plus two pure rendering
+functions, so the generator drives every port kind from one table. The
+renderers are pure functions of a `CppPortKind`, so they are golden-tested
+without a live accelerator.
+"""
+
+from dataclasses import dataclass, field as _dc_field
+from typing import List, Optional, Tuple
+
+from ..types import (BundlePort as _BundlePort, FunctionPort as _FunctionPort,
+                     CallbackPort as _CallbackPort, ToHostPort as _ToHostPort,
+                     FromHostPort as _FromHostPort, MMIORegion as
+                     _MMIORegionPort, MetricPort as _MetricPort)
+
+
+@dataclass
+class CppPortGroup:
+  """All strings needed to emit one port slot (member + ctor + find) in Connected."""
+  struct_decls: List[str] = _dc_field(default_factory=list)
+  member_decl: str = ""
+  ctor_params: List[str] = _dc_field(default_factory=list)
+  init_entry: str = ""
+  find_code: str = ""
+  make_unique_args: List[str] = _dc_field(default_factory=list)
+  post_connect: str = ""
+  using_aliases: List[Tuple[str, str]] = _dc_field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CppPortKind:
+  """Per-port-kind constants for generating a module's typed port slots.
+
+  Holds everything that varies between port kinds in one record.
+  `member_template` (typed channel/func ports) and `member_ref` (service /
+  bundle ports) are mutually exclusive. `find_style` / `indexed_find` select
+  the `connect()` resolution snippet for scalar and indexed ports
+  respectively; `alias_kind` selects which `using` aliases to emit for the
+  typed template parameters.
+  """
+  service_type: Optional[
+      str]  # findPortAs<...> service type (None = plain bundle)
+  find_style: str  # 'ptr' | 'read_chan' | 'write_chan' | 'deref' | 'bundle'
+  indexed_find: str  # 'as_ptr' | 'chan_read' | 'chan_write' | 'bundle_addr'
+  param_type: str  # ctor parameter type
+  param_suffix: str  # '_port' | '_chan' | '_svc'
+  member_template: Optional[
+      str]  # typed member, e.g. "esi::TypedFunction<{p}Args, {p}Result>"
+  member_ref: Optional[str]  # non-typed member / ctor ref type
+  indexed_elem: Optional[
+      str]  # IndexedPorts<...> element (None => use member_template)
+  alias_kind: Optional[str]  # None | 'func' (Args/Result) | 'chan' (Data)
+  connectable: bool  # whether generated connect() calls .connect()
+
+  def member_type(self, alias_prefix: Optional[str] = None) -> str:
+    """Return the C++ member type string for this kind (no member name).
+
+    For typed ports (function/callback/to-host/from-host channels)
+    `alias_prefix` is required; the returned template parameters are written
+    using the alias names (`<prefix>Args`, `<prefix>Result`, `<prefix>Data`)
+    that should be emitted at module-class scope. For non-typed ports (MMIO
+    regions, telemetry metrics, plain bundles) `alias_prefix` is ignored and
+    the runtime reference/pointer type is returned directly.
+    """
+    if self.member_template is not None:
+      assert alias_prefix is not None, (
+          "alias_prefix is required for typed ports to avoid emitting long "
+          "mangled type names inline (which would also collide across "
+          "modules' `using` declarations)")
+      return self.member_template.format(p=alias_prefix)
+    # Every non-typed kind defines a reference member type.
+    assert self.member_ref is not None
+    return self.member_ref
+
+  def indexed_elem_type(self, alias_prefix: Optional[str] = None) -> str:
+    """Return the storage type used inside an `IndexedPorts<T>` for this kind.
+
+    Typed ports use the same `TypedFunction<...>` / `TypedReadPort<...>` etc.
+    that `member_type` produces. MMIO regions, telemetry metrics, and plain
+    bundle ports are stored as raw pointers because `std::map<int, T&>` is
+    ill-formed.
+    """
+    if self.indexed_elem is not None:
+      return self.indexed_elem
+    return self.member_type(alias_prefix=alias_prefix)
+
+  def scalar_find_code(self, v: str, appid_expr: str) -> str:
+    """Render the connect()-body snippet that resolves one scalar port into the
+    local `v`. Pure function of the kind so it can be golden-tested without a
+    live accelerator (see `test_port_find_code_golden`)."""
+    if self.find_style == "ptr":
+      return (f"auto *{v} =\n"
+              f"    esi::findPortAsOrThrow<{self.service_type}>(\n"
+              f"        rawModule, {appid_expr});")
+    if self.find_style == "read_chan":
+      return (f"auto &{v} =\n"
+              f"    esi::findPortAsOrThrow<{self.service_type}>(\n"
+              f'        rawModule, {appid_expr})->getRawRead("data");')
+    if self.find_style == "write_chan":
+      return (f"auto &{v} =\n"
+              f"    esi::findPortAsOrThrow<{self.service_type}>(\n"
+              f'        rawModule, {appid_expr})->getRawWrite("data");')
+    if self.find_style == "deref":
+      return (f"auto &{v} =\n"
+              f"    *esi::findPortAsOrThrow<{self.service_type}>(\n"
+              f"        rawModule, {appid_expr});")
+    if self.find_style == "bundle":
+      # plain BundlePort
+      return f"auto &{v} = esi::findPortOrThrow(rawModule, {appid_expr});"
+    raise ValueError(f"unknown find_style: {self.find_style!r}")
+
+  def indexed_find_code(self, map_var: str, appid_expr: str) -> str:
+    """Render the per-index `try_emplace` body for an `IndexedPorts<T>` group.
+    Pure function of the kind (golden-tested alongside `scalar_find_code`)."""
+    if self.indexed_find == "as_ptr":
+      return (f"  {map_var}.try_emplace(\n"
+              f"      static_cast<int>(idx),\n"
+              f"      esi::findPortAsOrThrow<{self.service_type}>(\n"
+              f"          rawModule, {appid_expr}));")
+    if self.indexed_find == "chan_read":
+      return (f"  auto *svc =\n"
+              f"      esi::findPortAsOrThrow<{self.service_type}>(\n"
+              f"          rawModule, {appid_expr});\n"
+              f"  {map_var}.try_emplace(\n"
+              f"      static_cast<int>(idx),\n"
+              f'      svc->getRawRead("data"));')
+    if self.indexed_find == "chan_write":
+      return (f"  auto *svc =\n"
+              f"      esi::findPortAsOrThrow<{self.service_type}>(\n"
+              f"          rawModule, {appid_expr});\n"
+              f"  {map_var}.try_emplace(\n"
+              f"      static_cast<int>(idx),\n"
+              f'      svc->getRawWrite("data"));')
+    if self.indexed_find == "bundle_addr":
+      return (f"  {map_var}.try_emplace(\n"
+              f"      static_cast<int>(idx),\n"
+              f"      &esi::findPortOrThrow(rawModule, {appid_expr}));")
+    raise ValueError(f"unknown indexed_find: {self.indexed_find!r}")
+
+
+# Ordered list of (runtime port class, kind). `cpp_port_kind` returns the first
+# match, falling back to `CPP_BUNDLE_KIND` for any unrecognised service port.
+CPP_PORT_KINDS: List[Tuple[type, CppPortKind]] = [
+    (_FunctionPort,
+     CppPortKind(service_type="esi::services::FuncService::Function",
+                 find_style="ptr",
+                 indexed_find="as_ptr",
+                 param_type="esi::services::FuncService::Function *",
+                 param_suffix="_port",
+                 member_template="esi::TypedFunction<{p}Args, {p}Result>",
+                 member_ref=None,
+                 indexed_elem=None,
+                 alias_kind="func",
+                 connectable=True)),
+    (_CallbackPort,
+     CppPortKind(service_type="esi::services::CallService::Callback",
+                 find_style="ptr",
+                 indexed_find="as_ptr",
+                 param_type="esi::services::CallService::Callback *",
+                 param_suffix="_port",
+                 member_template="esi::TypedCallback<{p}Args, {p}Result>",
+                 member_ref=None,
+                 indexed_elem=None,
+                 alias_kind="func",
+                 connectable=False)),
+    (_ToHostPort,
+     CppPortKind(service_type="esi::services::ChannelService::ToHost",
+                 find_style="read_chan",
+                 indexed_find="chan_read",
+                 param_type="esi::ReadChannelPort &",
+                 param_suffix="_chan",
+                 member_template="esi::TypedReadPort<{p}Data>",
+                 member_ref=None,
+                 indexed_elem=None,
+                 alias_kind="chan",
+                 connectable=True)),
+    (_FromHostPort,
+     CppPortKind(service_type="esi::services::ChannelService::FromHost",
+                 find_style="write_chan",
+                 indexed_find="chan_write",
+                 param_type="esi::WriteChannelPort &",
+                 param_suffix="_chan",
+                 member_template="esi::TypedWritePort<{p}Data>",
+                 member_ref=None,
+                 indexed_elem=None,
+                 alias_kind="chan",
+                 connectable=True)),
+    (_MMIORegionPort,
+     CppPortKind(service_type="esi::services::MMIO::MMIORegion",
+                 find_style="deref",
+                 indexed_find="as_ptr",
+                 param_type="esi::services::MMIO::MMIORegion &",
+                 param_suffix="_svc",
+                 member_template=None,
+                 member_ref="esi::services::MMIO::MMIORegion &",
+                 indexed_elem="esi::services::MMIO::MMIORegion *",
+                 alias_kind=None,
+                 connectable=False)),
+    (_MetricPort,
+     CppPortKind(service_type="esi::services::TelemetryService::Metric",
+                 find_style="deref",
+                 indexed_find="as_ptr",
+                 param_type="esi::services::TelemetryService::Metric &",
+                 param_suffix="_svc",
+                 member_template=None,
+                 member_ref="esi::services::TelemetryService::Metric &",
+                 indexed_elem="esi::services::TelemetryService::Metric *",
+                 alias_kind=None,
+                 connectable=True)),
+]
+
+# Fallback for any service port that doesn't match a standard specialization
+# (e.g. a custom `@esi.ServiceDecl`-defined service).
+CPP_BUNDLE_KIND = CppPortKind(service_type=None,
+                              find_style="bundle",
+                              indexed_find="bundle_addr",
+                              param_type="esi::BundlePort &",
+                              param_suffix="_port",
+                              member_template=None,
+                              member_ref="esi::BundlePort &",
+                              indexed_elem="esi::BundlePort *",
+                              alias_kind=None,
+                              connectable=False)
+
+
+def cpp_port_kind(port: _BundlePort) -> CppPortKind:
+  """Return the `CppPortKind` describing `port`, or `CPP_BUNDLE_KIND` as fallback."""
+  for cls, kind in CPP_PORT_KINDS:
+    if isinstance(port, cls):
+      return kind
+  return CPP_BUNDLE_KIND

--- a/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
+++ b/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
@@ -69,7 +69,7 @@ void expectBytes(const T &value, const std::array<uint8_t, N> &expected,
 }
 
 // ---------------------------------------------------------------------------
-// Path A — 8/16/32/64-bit byte-aligned integers
+// Standard 8/16/32/64-bit byte-aligned integers
 // ---------------------------------------------------------------------------
 
 void testStandardWidthUnsigned() {
@@ -136,7 +136,7 @@ void testStandardWidthSigned() {
 }
 
 // ---------------------------------------------------------------------------
-// Path B — byte-aligned non-standard width (e.g. i24, i48)
+// Byte-aligned non-standard width (e.g. i24, i48)
 // ---------------------------------------------------------------------------
 
 void testByteAlignedOddWidthUnsigned() {
@@ -167,7 +167,7 @@ void testByteAlignedOddWidthSigned() {
 }
 
 // ---------------------------------------------------------------------------
-// Path C — sub-byte alignment (uses the BitAccess helpers)
+// Sub-byte alignment (uses the BitAccess helpers)
 // ---------------------------------------------------------------------------
 
 void testSubByteUnsigned() {
@@ -432,6 +432,65 @@ void testSubByteStructArray() {
 }
 
 // ---------------------------------------------------------------------------
+// Nested arrays (array-of-array) -- previously mis-handled by the flat-copy
+// path; now driven by the recursive per-element (un)packer.
+// ---------------------------------------------------------------------------
+
+void testNestedIntArray() {
+  // `2 x 4 x ui3`: the element type is itself the non-byte-packable array
+  // `4 x ui3` (12 wire bits, 4 bytes in memory). The old codegen emitted a
+  // corrupt whole-array copy and no indexed accessor; the recursive packer
+  // places each `ui3` leaf at wire bit `i * 12 + j * 3`.
+  Nested3 a;
+  std::array<std::array<uint8_t, 4>, 2> rows = {{{1, 2, 3, 4}, {5, 6, 7, 0}}};
+  a.rows(rows);
+
+  auto whole = a.rows();
+  for (std::size_t i = 0; i < 2; ++i)
+    for (std::size_t j = 0; j < 4; ++j) {
+      assert(whole[i][j] == rows[i][j]);
+      assert(a.rows(i)[j] == rows[i][j]);
+    }
+  // Flattened [1,2,3,4,5,6,7,0] at 3-bit strides -- identical wire bytes to
+  // the flat `8 x ui3` case.
+  expectBytes(a, std::array<uint8_t, 3>{0xD1, 0x58, 0x1F}, "Nested3");
+
+  // Indexed setter for one inner row; the other row must stay zero.
+  Nested3 b;
+  b.rows(1, {5, 6, 7, 0});
+  for (std::size_t j = 0; j < 4; ++j) {
+    assert(b.rows(1)[j] == rows[1][j]);
+    assert(b.rows(0)[j] == 0);
+  }
+  // Row 1 occupies bits 12..23: [5,6,7,0].
+  expectBytes(b, std::array<uint8_t, 3>{0x00, 0x50, 0x1F}, "Nested3 row1");
+}
+
+void testNestedStructArray() {
+  // `2 x 3 x SbCell` (each cell 5 wire bits). Array-of-array-of-sub-byte-
+  // aggregate: the recursive packer copies each cell's bits at its true
+  // wire offset `i * 15 + j * 5`.
+  NestedCell a;
+  std::array<std::array<SbCell, 3>, 2> grid = {{
+      {SbCell(1, 0), SbCell(2, 1), SbCell(3, 2)},
+      {SbCell(4, 3), SbCell(5, 0), SbCell(6, 1)},
+  }};
+  a.grid(grid);
+
+  auto whole = a.grid();
+  for (std::size_t i = 0; i < 2; ++i)
+    for (std::size_t j = 0; j < 3; ++j) {
+      assert(whole[i][j].hi() == grid[i][j].hi());
+      assert(whole[i][j].lo() == grid[i][j].lo());
+      assert(a.grid(i)[j].hi() == grid[i][j].hi());
+      assert(a.grid(i)[j].lo() == grid[i][j].lo());
+    }
+  // grid[0] reuses the first three SbCellArr cells, so bytes 0..1 match that
+  // test's leading bytes.
+  expectBytes(a, std::array<uint8_t, 4>{0x24, 0xB9, 0x49, 0x33}, "NestedCell");
+}
+
+// ---------------------------------------------------------------------------
 // Unions
 // ---------------------------------------------------------------------------
 
@@ -496,6 +555,7 @@ void testWindowList() {
 }
 
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // Multi-burst chunking: a window whose count field is too narrow to encode
 // the whole list in one burst must split the list across several
 // header/data bursts (terminated by a zero-count footer) and the read-side
@@ -556,7 +616,7 @@ void testWindowListMultiBurst() {
 }
 
 // ---------------------------------------------------------------------------
-// Path D — value-class fields (esi::MutableBitVector, esi::Int, esi::UInt)
+// View-class fields (esi::MutableBitVector, esi::Int, esi::UInt)
 // ---------------------------------------------------------------------------
 
 // Build a wide MutableBitVector from an arbitrary-length byte buffer
@@ -649,9 +709,9 @@ void testWideSigned() {
 }
 
 void testBitsField() {
-  // BitsType > 64 routes through Path D (non-owning `esi::BitVector`
-  // view); narrower Bits stay on the native int paths and are covered
-  // by the other tests above.
+  // BitsType > 64 routes through the view-class accessor (non-owning
+  // `esi::BitVector` view); narrower Bits stay on the native int
+  // accessors and are covered by the other tests above.
   BitsField f;
   auto wide = bvFromBytes(
       {
@@ -670,7 +730,7 @@ void testBitsField() {
 void testWideMisaligned() {
   // WideMisaligned: tag (ui3) at bits 0..2, payload (ui128) at bits
   // 3..130 — i.e. a wide value at a non-byte-aligned offset. Hits the
-  // `copyBitsIn` / `copyBitsOut` arm of Path D.
+  // bit-shifted view accessor.
   WideMisaligned m;
   auto payload = bvFromBytes(
       {
@@ -695,7 +755,7 @@ void testWideMisaligned() {
 
   // A narrower input value must be zero-extended; a wider input is
   // truncated. Verify the former here (the latter is exercised
-  // implicitly because the Path D setter clamps to bit_width).
+  // implicitly because the view-class setter clamps to bit_width).
   auto narrow = bvFromBytes({0xAA}, 8); // only 8 bits of input
   m.payload(narrow);
   auto got3 = m.payload();
@@ -867,6 +927,8 @@ int main() {
   testSubByteSignedArray();
   testOddWidthArray();
   testSubByteStructArray();
+  testNestedIntArray();
+  testNestedStructArray();
   testUnion();
   testWindowList();
   testWindowListMultiBurst();

--- a/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/unit/test_codegen.py
@@ -3,10 +3,10 @@
 The bulk of the verification is delegated to `codegen_harness.cpp` in this
 directory: the Python side generates a `types.h` from a representative
 manifest, compiles the harness against it, and runs the result. The harness
-exercises every accessor path (Path A / B / C, bool, nested struct, array,
-union, window) and checks both the user-visible round-trip and the
-underlying wire bytes. Reviewers can read the harness directly to see what
-the codegen is contracted to do.
+exercises every accessor category (standard / odd / sub-byte integer widths,
+bool, view-class, nested struct, array, union, window) and checks both the
+user-visible round-trip and the underlying wire bytes. Reviewers can read the
+harness directly to see what the codegen is contracted to do.
 
 A small number of Python-level tests cover behaviours the harness can't
 exercise — ordering, name collisions, type aliases, and the "skip with a
@@ -52,10 +52,10 @@ _sint24 = types.SIntType("si24", 24)
 _sint32 = types.SIntType("si32", 32)
 _sint64 = types.SIntType("si64", 64)
 
-# Path D: value-class fields backed by `esi::IntView` / `esi::UIntView` /
+# View-class fields backed by `esi::IntView` / `esi::UIntView` /
 # `esi::BitVector` (any width supported; only wider-than-64 cases route
 # through the view classes -- narrower Bits/Int/UInt stay on the native
-# int paths). Tested below with 96- and 128-bit widths.
+# int accessors). Tested below with 96- and 128-bit widths.
 _bits128 = types.BitsType("bits128", 128)
 _uint96 = types.UIntType("ui96", 96)
 _uint128 = types.UIntType("ui128", 128)
@@ -74,7 +74,7 @@ def _build_harness_manifest():
   name (e.g. `StdU`) so the harness can use plain identifiers rather than
   spelling the auto-generated mangled names.
   """
-  # Path A: standard widths.
+  # Standard 8/16/32/64-bit widths.
   std_u_inner = types.StructType(
       "@StdU::inner",
       [("u8", _uint8), ("u16", _uint16), ("u32", _uint32), ("u64", _uint64)],
@@ -87,13 +87,13 @@ def _build_harness_manifest():
   )
   std_s = types.TypeAlias("@StdS", "StdS", std_s_inner)
 
-  # Path B: byte-aligned but non-standard width.
+  # Byte-aligned but non-standard width (e.g. ui24).
   odd_u_inner = types.StructType("@OddU::inner", [("u24", _uint24)])
   odd_u = types.TypeAlias("@OddU", "OddU", odd_u_inner)
   odd_s_inner = types.StructType("@OddS::inner", [("s24", _sint24)])
   odd_s = types.TypeAlias("@OddS", "OddS", odd_s_inner)
 
-  # Path C: sub-byte alignment.
+  # Sub-byte alignment.
   sub_u_inner = types.StructType("@SubU::inner", [("u3", _uint3),
                                                   ("u12", _uint12)])
   sub_u = types.TypeAlias("@SubU", "SubU", sub_u_inner)
@@ -170,6 +170,30 @@ def _build_harness_manifest():
       "@SbCellArr::inner",
       [("cells", types.ArrayType("!hw.array<4xSbCell>", sb_cell, 4))])
   sb_cell_arr = types.TypeAlias("@SbCellArr", "SbCellArr", sb_cell_arr_inner)
+
+  # Nested array of sub-byte ints: `2 x 4 x ui3`. The element type is itself
+  # the non-byte-packable array `4 x ui3` (12 wire bits but 4 bytes in the
+  # C++ `std::array<uint8_t, 4>`). The old flat-copy path handled this case
+  # incorrectly -- it emitted a corrupt whole-array copy and no indexed
+  # accessor at all -- because `is_packed_array` only matched scalar/struct
+  # elements, not array elements. The recursive (un)packer places each `ui3`
+  # leaf at its true wire offset `i * 12 + j * 3`.
+  nested3_inner = types.StructType(
+      "@Nested3::inner",
+      [("rows",
+        types.ArrayType("!hw.array<2x!hw.array<4xui3>>",
+                        types.ArrayType("!hw.array<4xui3>", _uint3, 4), 2))])
+  nested3 = types.TypeAlias("@Nested3", "Nested3", nested3_inner)
+
+  # Nested array of sub-byte STRUCT elements: `2 x 3 x SbCell` (each cell 5
+  # wire bits). Array-of-array-of-aggregate: the recursive packer copies each
+  # cell's bits at its true wire offset `i * 15 + j * 5`.
+  nested_cell_inner = types.StructType("@NestedCell::inner", [
+      ("grid",
+       types.ArrayType("!hw.array<2x!hw.array<3xSbCell>>",
+                       types.ArrayType("!hw.array<3xSbCell>", sb_cell, 3), 2))
+  ])
+  nested_cell = types.TypeAlias("@NestedCell", "NestedCell", nested_cell_inner)
 
   # Union with one narrow and one wide variant.
   union_inner = types.UnionType("@UnionTwo::inner", [("small", _uint8),
@@ -265,12 +289,12 @@ def _build_harness_manifest():
   small_list_window = types.TypeAlias("@SmallListWindow", "SmallListWindow",
                                       small_list_window_inner)
 
-  # Path D: value-class fields backed by `esi::MutableBitVector` /
+  # View-class fields backed by `esi::MutableBitVector` /
   # `esi::Int` / `esi::UInt` from `esi/Values.h`. Covers BitsType at
   # both narrow and wide widths, plus signed/unsigned integers above
   # the 64-bit native ceiling. Layout fields cover byte-aligned and
-  # bit-misaligned wide-int offsets so both branches of `copyBitsIn`
-  # / `copyBitsOut` get exercised.
+  # bit-misaligned wide-int offsets so both the aligned and the
+  # bit-shifted view accessors get exercised.
   wide_u_inner = types.StructType(
       "@WideU::inner",
       [("u96", _uint96), ("u128", _uint128)],
@@ -293,8 +317,8 @@ def _build_harness_manifest():
   # Field order is reversed on the wire (`cpp_type.reverse=True`), so the
   # LAST manifest field lands at wire bit 0. Listing `payload` first and
   # `tag` last puts `tag` at bits 0..2 (byte-aligned) and the 128-bit
-  # `payload` at bits 3..130 — exercising the
-  # `copyBitsIn<bit_offset, 128>` / `copyBitsOut` arm of Path D rather
+  # `payload` at bits 3..130 — exercising the bit-shifted view
+  # accessor for a wide field at a non-byte-aligned offset rather
   # than only the byte-aligned case.
   wide_mis_inner = types.StructType(
       "@WideMisaligned::inner",
@@ -326,9 +350,9 @@ def _build_harness_manifest():
 
   return [
       std_u, std_s, odd_u, odd_s, sub_u, sub_s, bool_field, outer, misaligned,
-      arr4, u3_arr, bits1_arr, s5_arr, u24_arr, sb_cell, sb_cell_arr, union_two,
-      list_window, small_list_window, wide_u, wide_s, bits_field, wide_mis,
-      arr_views, arr_views_mis
+      arr4, u3_arr, bits1_arr, s5_arr, u24_arr, sb_cell, sb_cell_arr, nested3,
+      nested_cell, union_two, list_window, small_list_window, wide_u, wide_s,
+      bits_field, wide_mis, arr_views, arr_views_mis
   ]
 
 
@@ -453,3 +477,104 @@ def test_unbounded_field_skips_struct_with_comment():
 
   hdr = _emit([s])
   assert "// Unsupported type '<@any_struct>'" in hdr
+
+
+def test_port_find_code_golden():
+  """Golden check of the per-port-kind `connect()` snippets for ALL kinds.
+
+  The round-trip harness only exercises the types; the live port-kind paths
+  are covered by the (heavyweight) cosim integration suite. This test pins
+  the generated resolution code for every kind -- including the ones the
+  sample manifest doesn't contain (Callback / FromHost / MMIO / Metric /
+  Bundle) -- so a typo in the `CppPortKind` table can't slip through.
+  """
+  from esiaccel.codegen.ports import CPP_PORT_KINDS, CPP_BUNDLE_KIND
+
+  kinds = {cls.__name__: kind for cls, kind in CPP_PORT_KINDS}
+  kinds["BundlePort"] = CPP_BUNDLE_KIND
+  ae = 'esi::AppID("p")'
+  aei = 'esi::AppID("p", idx)'
+
+  def scalar(name: str) -> str:
+    k = kinds[name]
+    return k.scalar_find_code(f"p{k.param_suffix}", ae)
+
+  def indexed(name: str) -> str:
+    return kinds[name].indexed_find_code("p_backing", aei)
+
+  # --- scalar resolution snippets ---
+  assert scalar("FunctionPort") == (
+      "auto *p_port =\n"
+      "    esi::findPortAsOrThrow<esi::services::FuncService::Function>(\n"
+      '        rawModule, esi::AppID("p"));')
+  assert scalar("CallbackPort") == (
+      "auto *p_port =\n"
+      "    esi::findPortAsOrThrow<esi::services::CallService::Callback>(\n"
+      '        rawModule, esi::AppID("p"));')
+  assert scalar("ToHostPort") == (
+      "auto &p_chan =\n"
+      "    esi::findPortAsOrThrow<esi::services::ChannelService::ToHost>(\n"
+      '        rawModule, esi::AppID("p"))->getRawRead("data");')
+  assert scalar("FromHostPort") == (
+      "auto &p_chan =\n"
+      "    esi::findPortAsOrThrow<esi::services::ChannelService::FromHost>(\n"
+      '        rawModule, esi::AppID("p"))->getRawWrite("data");')
+  assert scalar("MMIORegion") == (
+      "auto &p_svc =\n"
+      "    *esi::findPortAsOrThrow<esi::services::MMIO::MMIORegion>(\n"
+      '        rawModule, esi::AppID("p"));')
+  assert scalar("MetricPort") == (
+      "auto &p_svc =\n"
+      "    *esi::findPortAsOrThrow<esi::services::TelemetryService::Metric>(\n"
+      '        rawModule, esi::AppID("p"));')
+  assert scalar("BundlePort") == (
+      'auto &p_port = esi::findPortOrThrow(rawModule, esi::AppID("p"));')
+
+  # --- indexed (IndexedPorts<T>) try_emplace bodies ---
+  assert indexed("FunctionPort") == (
+      "  p_backing.try_emplace(\n"
+      "      static_cast<int>(idx),\n"
+      "      esi::findPortAsOrThrow<esi::services::FuncService::Function>(\n"
+      '          rawModule, esi::AppID("p", idx)));')
+  assert indexed("ToHostPort") == (
+      "  auto *svc =\n"
+      "      esi::findPortAsOrThrow<esi::services::ChannelService::ToHost>(\n"
+      '          rawModule, esi::AppID("p", idx));\n'
+      "  p_backing.try_emplace(\n"
+      "      static_cast<int>(idx),\n"
+      '      svc->getRawRead("data"));')
+  assert indexed("FromHostPort") == (
+      "  auto *svc =\n"
+      "      esi::findPortAsOrThrow<esi::services::ChannelService::FromHost>(\n"
+      '          rawModule, esi::AppID("p", idx));\n'
+      "  p_backing.try_emplace(\n"
+      "      static_cast<int>(idx),\n"
+      '      svc->getRawWrite("data"));')
+  assert indexed("MMIORegion") == (
+      "  p_backing.try_emplace(\n"
+      "      static_cast<int>(idx),\n"
+      "      esi::findPortAsOrThrow<esi::services::MMIO::MMIORegion>(\n"
+      '          rawModule, esi::AppID("p", idx)));')
+  assert indexed("BundlePort") == (
+      "  p_backing.try_emplace(\n"
+      "      static_cast<int>(idx),\n"
+      "      &esi::findPortOrThrow(rawModule, esi::AppID(\"p\", idx)));")
+
+  # --- per-kind field invariants ---
+  assert [
+      k.connectable
+      for k in (kinds["FunctionPort"], kinds["CallbackPort"],
+                kinds["ToHostPort"], kinds["FromHostPort"], kinds["MMIORegion"],
+                kinds["MetricPort"], kinds["BundlePort"])
+  ] == [True, False, True, True, False, True, False]
+  assert kinds["FunctionPort"].param_suffix == "_port"
+  assert kinds["ToHostPort"].param_suffix == "_chan"
+  assert kinds["MMIORegion"].param_suffix == "_svc"
+  assert (kinds["FunctionPort"].member_template ==
+          "esi::TypedFunction<{p}Args, {p}Result>")
+  assert kinds["MMIORegion"].member_template is None
+  assert (
+      kinds["MMIORegion"].indexed_elem == "esi::services::MMIO::MMIORegion *")
+  assert kinds["FunctionPort"].alias_kind == "func"
+  assert kinds["ToHostPort"].alias_kind == "chan"
+  assert kinds["MMIORegion"].alias_kind is None


### PR DESCRIPTION
The codegen module has gotten too big and too unwieldy to understand. This refactors it.

Assisted-by: Github-Copilot:Claude Opus 4.8

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
