### PR TITLE
[ESI][Runtime][Codegen] Fix lists with non 8/16/32/64 bit counts

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/codegen/generator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/codegen/generator.py
@@ -979,12 +979,6 @@ class CppTypeEmitter:
       return False
     return wrapped.bit_width > 64
 
-  def _type_byte_width(self, wrapped: types.ESIType) -> int:
-    """Return the size of a fixed-width type in bytes."""
-    if wrapped.bit_width < 0:
-      raise ValueError(f"Unsupported unbounded type width for '{wrapped}'")
-    return (wrapped.bit_width + 7) // 8
-
   def _array_base_and_dims(
       self, array_type: types.ArrayType) -> Tuple[str, List[int]]:
     """Return the base C++ type and outer-to-inner dimensions of a nested array."""
@@ -1148,33 +1142,42 @@ class CppTypeEmitter:
                    for name, field_type in into_type.fields
                    if name != list_field_name]
 
+    # Frame fields are kept in declared (MSB-first) order and laid out
+    # MSB-aligned within the frame/union bit width, matching how CIRCT
+    # lowers the frame union (content packed from the most-significant bit
+    # down, with any slack as low-end padding). Widths are exact bit widths
+    # -- no per-field byte rounding -- so sub-byte count/static fields land
+    # at the same offsets the hardware uses.
     header_fields = []
-    header_bytes = 0
+    header_bits = 0
     count_field_name = f"{list_field_name}_count"
     count_width = header_field.bulk_count_width
     count_cpp = self._storage_type(count_width, signed=False)
-    count_bytes = (count_width + 7) // 8
-    for field in reversed(header_frame.fields):
+    for field in header_frame.fields:
       if field.name == list_field_name:
         header_fields.append((count_field_name, None))
-        header_bytes += count_bytes
+        header_bits += count_width
       else:
         field_type = field_map[field.name]
         header_fields.append((field.name, field_type))
-        header_bytes += self._type_byte_width(field_type)
+        header_bits += field_type.bit_width
 
     data_fields = []
-    data_bytes = 0
-    for field in reversed(data_frame.fields):
+    data_bits = 0
+    for field in data_frame.fields:
       if field.name == list_field_name:
         data_fields.append((list_field_name, list_type.element_type))
-        data_bytes += self._type_byte_width(list_type.element_type)
+        data_bits += list_type.element_type.bit_width
       else:
         field_type = field_map[field.name]
         data_fields.append((field.name, field_type))
-        data_bytes += self._type_byte_width(field_type)
+        data_bits += field_type.bit_width
 
-    frame_bytes = max(header_bytes, data_bytes)
+    # The frame/union width is the wider of the two variants' content. The
+    # byte-array storage rounds that up to whole bytes (any extra high bits
+    # stay zero); both frames share it so `sizeof(header) == sizeof(data)`.
+    frame_bits = max(header_bits, data_bits)
+    frame_bytes = (frame_bits + 7) // 8
 
     return {
         "ctor_params": ctor_params,
@@ -1182,11 +1185,10 @@ class CppTypeEmitter:
         "count_field_name": count_field_name,
         "count_width": count_width,
         "data_fields": data_fields,
-        "data_pad_bytes": frame_bytes - data_bytes,
         "element_cpp": self._cpp_type(list_type.element_type),
+        "frame_bits": frame_bits,
         "frame_bytes": frame_bytes,
         "header_fields": header_fields,
-        "header_pad_bytes": frame_bytes - header_bytes,
         "list_field_name": list_field_name,
         "window_name": self.type_id_map[window_type],
     }
@@ -1710,26 +1712,43 @@ class CppTypeEmitter:
     w.line()
 
   def _compute_window_frame_layout(
-      self, fields: List[Tuple[str, Optional[types.ESIType]]], pad_bytes: int,
+      self, fields: List[Tuple[str, Optional[types.ESIType]]], frame_bits: int,
       count_type_synth: types.ESIType
   ) -> List[Tuple[str, types.ESIType, int, int]]:
-    """Compute (name, type, byte_offset, bit_width) for each window frame field.
+    """Compute (name, type, bit_offset, bit_width) for each window frame field.
 
-    Fields are listed in C++ declaration order. They start after `pad_bytes`
-    bytes of padding and each field consumes `ceil(bit_width/8)` bytes —
-    matching what the `#pragma pack(1)` layout produced.
+    Fields are listed in declared (MSB-first) order and laid out MSB-aligned
+    within `frame_bits`, matching how CIRCT lowers the serial-window frame
+    union: the first field occupies the highest bits, each subsequent field
+    sits immediately below it with no inter-field padding, and any slack
+    (`frame_bits - content_bits`) is left as zero padding at the LSB end.
+    The returned `bit_offset` is the field's LSB position within the frame's
+    little-endian `_bytes` array, ready to hand straight to
+    `_emit_field_accessor`.
 
     The sentinel `(name, None)` count field is materialised as
     `count_type_synth` so it can flow through the standard
     `_emit_field_accessor` path.
+
+    Raises `ValueError` if a field is unbounded (`bit_width < 0`) or if the
+    accumulated content overflows `frame_bits` -- either would produce bogus
+    offsets, so fail fast rather than emit silently-wrong accessors.
     """
     layout = []
-    byte_offset = pad_bytes
+    bit_top = frame_bits
     for name, ftype in fields:
       actual_type = count_type_synth if ftype is None else ftype
       bit_width = actual_type.bit_width
-      layout.append((name, actual_type, byte_offset, bit_width))
-      byte_offset += (bit_width + 7) // 8
+      if bit_width < 0:
+        raise ValueError(
+            f"window frame field '{name}' has an unbounded width; window "
+            f"codegen requires every frame field to be fixed-width")
+      bit_top -= bit_width
+      if bit_top < 0:
+        raise ValueError(
+            f"window frame field '{name}' overflows the {frame_bits}-bit frame "
+            f"(content is wider than the frame width)")
+      layout.append((name, actual_type, bit_top, bit_width))
     return layout
 
   def _emit_window_frame(
@@ -1746,9 +1765,9 @@ class CppTypeEmitter:
       w.line(f"std::array<uint8_t, {frame_bytes}> _bytes{{}};")
       w.line()
       w.access("public:")
-      for name, ftype, byte_offset, bit_width in layout:
+      for name, ftype, bit_offset, bit_width in layout:
         self._emit_field_accessor(w, "_bytes", frame_name, name, ftype,
-                                  byte_offset * 8, bit_width)
+                                  bit_offset, bit_width)
         w.line()
     self._emit_size_assert(w, frame_name, frame_bytes)
 
@@ -1783,10 +1802,10 @@ class CppTypeEmitter:
     count_type_synth = types.UIntType(f"_count_ui{info['count_width']}",
                                       info["count_width"])
     data_layout = self._compute_window_frame_layout(info["data_fields"],
-                                                    info["data_pad_bytes"],
+                                                    info["frame_bits"],
                                                     count_type_synth)
     header_layout = self._compute_window_frame_layout(info["header_fields"],
-                                                      info["header_pad_bytes"],
+                                                      info["frame_bits"],
                                                       count_type_synth)
 
     # Largest list length encodable in a single burst's count field. Lists

--- a/lib/Dialect/ESI/runtime/tests/integration/hw/test_codegen.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/hw/test_codegen.py
@@ -984,6 +984,100 @@ class ChannelMultiBurstListWrite(Module):
             lambda _: final_match.as_bits(1).pad_or_truncate(64).as_bits(64)))
 
 
+# Narrow (sub-byte) bulk count with a static header field. The 2-bit count caps
+# each burst at 3 items, so the host serializer splits a 7-element list into
+# three bursts (3 + 3 + 1). Unlike `ChannelMultiBurstListWrite` (8-bit,
+# byte-aligned count where every frame fills whole bytes), the header frame
+# here is `{tag: ui16, items_count: ui2}` -- 18 bits of content that does NOT
+# fill the 32-bit data frame. CIRCT lowers the frame union MSB-first, so on the
+# wire `tag` occupies bits [31:16] and the 2-bit count sits at bits [15:14].
+# The C++ facade codegen must place them at exactly those offsets; the old
+# byte-granular layout put the count in the low bits and the HW would read a
+# garbage (zero) count and stall. This probe therefore exercises the sub-byte /
+# misaligned-static-field frame layout end-to-end.
+_NARROW_TAG = 0xBEEF
+_NARROW_ITEMS = [0x1000 + i for i in range(7)]
+_NARROW_BULK_WIDTH = 2
+_NARROW_ITEMS_PER_FRAME = 1
+_narrow_struct = StructType([("tag", Bits(16)), ("items", List(Bits(32)))])
+_narrow_window = Window.serial_of(_narrow_struct, _NARROW_BULK_WIDTH,
+                                  _NARROW_ITEMS_PER_FRAME)
+
+
+class ChannelNarrowCountListWrite(Module):
+  """From-host ``window<{tag, list<ui32>}>`` with a 2-bit bulk count.
+
+  The 2-bit count caps each burst at 3 items, so the host splits the 7-element
+  list into three bursts (3 + 3 + 1). Because the header content (ui16 tag +
+  2-bit count = 18 bits) is narrower than the 32-bit data frame, this is the
+  sub-byte / misaligned-static-field frame layout the byte-granular codegen got
+  wrong. Hardware reassembles the bursts via `ListWindowToParallel`, checks the
+  tag and every item, and latches the result into the ``match`` MMIO region.
+  """
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    clk = ports.clk
+    rst = ports.rst
+
+    chan = esi.ChannelService.from_host(AppID("data"), _narrow_window)
+    s2p = ListWindowToParallel(_narrow_window)(clk=clk, rst=rst, serial_in=chan)
+    par_ready = Wire(Bits(1))
+    par_window, par_valid = s2p.parallel_out.unwrap(par_ready)
+    par_struct = par_window.unwrap()
+    par_ready.assign(Bits(1)(1))
+
+    handshake = par_valid
+    last_bit = par_struct["last"].as_bits(1)
+
+    # Counter cycles 0..N-1 over the reassembled list, clears on the burst-end
+    # beat. Each item is checked against the expected pattern by index.
+    n_items = len(_NARROW_ITEMS)
+    idx_clr = (handshake & last_bit).as_bits(1)
+    idx_counter = Counter(3)(clk=clk,
+                             rst=rst,
+                             clear=idx_clr,
+                             increment=handshake,
+                             instance_name="narrow_write_idx")
+    idx = idx_counter.out
+
+    expected_bits = Array(Bits(32), n_items)(_NARROW_ITEMS)[idx.as_bits()]
+    tag_ok = (par_struct["tag"].as_bits(16) == Bits(16)(_NARROW_TAG))
+    item_ok = (par_struct["items"].as_bits(32) == expected_bits)
+    beat_ok = (tag_ok & item_ok).as_bits(1)
+
+    # Running AND-reduce across the whole (reassembled) list; latches into
+    # ``final_match`` on the last item's beat.
+    running_match = Wire(Bits(1))
+    running_match_reg = Reg(Bits(1),
+                            clk=clk,
+                            rst=rst,
+                            rst_value=1,
+                            ce=handshake,
+                            name="narrow_match_running")
+    running_match.assign((running_match_reg & beat_ok).as_bits(1))
+    running_match_reg.assign(running_match)
+
+    final_match = Reg(Bits(1),
+                      clk=clk,
+                      rst=rst,
+                      rst_value=0,
+                      ce=idx_clr,
+                      name="narrow_match_final")
+    final_match.assign(running_match)
+
+    # Expose the latched flag via MMIO read.
+    mmio_bundle = esi.MMIO.read(appid=AppID("match"))
+    resp_chan = Wire(Channel(Bits(64)))
+    addr_chan = mmio_bundle.unpack(data=resp_chan)["offset"]
+    resp_chan.assign(
+        addr_chan.transform(
+            lambda _: final_match.as_bits(1).pad_or_truncate(64).as_bits(64)))
+
+
 class Top(Module):
   clk = Clock()
   rst = Reset()
@@ -1052,6 +1146,10 @@ class Top(Module):
         clk=ports.clk,
         rst=ports.rst,
         appid=AppID("channel_multiburst_list_write_inst"))
+    ChannelNarrowCountListWrite(
+        clk=ports.clk,
+        rst=ports.rst,
+        appid=AppID("channel_narrow_count_list_write_inst"))
     CallbackWindowedList(clk=ports.clk,
                          rst=ports.rst,
                          appid=AppID("callback_windowed_list_inst"))

--- a/lib/Dialect/ESI/runtime/tests/integration/sw/test_codegen.cpp
+++ b/lib/Dialect/ESI/runtime/tests/integration/sw/test_codegen.cpp
@@ -12,6 +12,7 @@
 #include "test_codegen/CallbackWindowedList.h"
 #include "test_codegen/ChannelMultiBurstListRead.h"
 #include "test_codegen/ChannelMultiBurstListWrite.h"
+#include "test_codegen/ChannelNarrowCountListWrite.h"
 #include "test_codegen/ChannelWindowedListRead.h"
 #include "test_codegen/ChannelWindowedListWrite.h"
 #include "test_codegen/CustomServiceDeclChannel.h"
@@ -648,6 +649,50 @@ static int runChannelMultiBurstListWrite(Accelerator *accel) {
 }
 
 //===----------------------------------------------------------------------===//
+// From-host channel of a windowed list with a *narrow* (2-bit) bulk count and
+// a static header field. The 2-bit count caps each burst at 3 items, so the
+// host serializer splits the 7-item list into three bursts (3 + 3 + 1). The
+// header content (ui16 tag + 2-bit count = 18 bits) does not fill the 32-bit
+// data frame, so this exercises the MSB-aligned, sub-byte frame layout
+// end-to-end: the generated facade must place the count at bits [15:14] and
+// the tag at bits [31:16] to match CIRCT's frame lowering, or the HW reads a
+// garbage count and never reports a match.
+//===----------------------------------------------------------------------===//
+static int runChannelNarrowCountListWrite(Accelerator *accel) {
+  esi_system::ChannelNarrowCountListWrite mod(
+      findInst(accel, "channel_narrow_count_list_write_inst"));
+  auto c = mod.connect();
+
+  using WinT = esi_system::ChannelNarrowCountListWrite::dataData;
+
+  static constexpr uint16_t kTag = 0xBEEF;
+  std::vector<uint32_t> items{0x1000u, 0x1001u, 0x1002u, 0x1003u,
+                              0x1004u, 0x1005u, 0x1006u};
+  c->data.write(WinT(kTag, items));
+
+  // Poll the match flag MMIO until the (reassembled) list has been processed
+  // or we time out. The HW updates the latch on the final item's beat.
+  using clock = std::chrono::steady_clock;
+  auto deadline = clock::now() + std::chrono::seconds(5);
+  uint64_t match = 0;
+  while (clock::now() < deadline) {
+    match = c->match.read(0);
+    if (match & 1)
+      break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  if (!(match & 1))
+    throw std::runtime_error(
+        "channel_narrow_count_list_write: HW did not report a match within "
+        "timeout (got 0x" +
+        toHex(match) + ")");
+  std::cout << "channel_narrow_count_list_write ok (2-bit count, tag=0x"
+            << toHex(static_cast<uint64_t>(kTag))
+            << ", 7 items split across 3 bursts)\n";
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
 // Callback with windowed list argument: HW sends a serial-burst windowed
 // list (tag + items) into a host callback. Verifies that the
 // `SerialListTypeDeserializer` works end-to-end through the
@@ -737,4 +782,5 @@ ESI_PROBE_REGISTRY(
     {"channel_multiburst_list_read", &runChannelMultiBurstListRead},
     {"channel_windowed_list_write", &runChannelWindowedListWrite},
     {"channel_multiburst_list_write", &runChannelMultiBurstListWrite},
+    {"channel_narrow_count_list_write", &runChannelNarrowCountListWrite},
     {"callback_windowed_list", &runCallbackWindowedList}, );

--- a/lib/Dialect/ESI/runtime/tests/integration/test_codegen_cpp.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_codegen_cpp.py
@@ -45,6 +45,7 @@ PROBES = [
     "channel_multiburst_list_read",
     "channel_windowed_list_write",
     "channel_multiburst_list_write",
+    "channel_narrow_count_list_write",
     "callback_windowed_list",
 ]
 

--- a/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
+++ b/lib/Dialect/ESI/runtime/tests/unit/codegen_harness.cpp
@@ -540,9 +540,10 @@ void testWindowList() {
   auto data_seg = win.segment(1);
   auto footer_seg = win.segment(2);
   assert(data_seg.size == elements.size() * sizeof(uint32_t));
-  // Header carries `tag` at the MSB end and the count at the LSB end.
-  // Layout: count (ui16, 2 bytes) then tag (ui16, 2 bytes) in reversed
-  // declaration order; header bytes = [count_lo, count_hi, tag_lo, tag_hi].
+  // Content is MSB-aligned within the 32-bit frame: `tag` (ui16) occupies
+  // the top 16 bits (bytes 2..3) and the count (ui16) the low 16 bits
+  // (bytes 0..1). Here the content fills the frame exactly, so header bytes =
+  // [count_lo, count_hi, tag_lo, tag_hi].
   assert(header_seg.size == 4);
   assert(header_seg.data[0] == (static_cast<uint8_t>(elements.size()) & 0xFF));
   assert(header_seg.data[1] == 0); // count high byte (size < 256)
@@ -586,13 +587,34 @@ void testWindowListMultiBurst() {
   assert(win.segment(5).size == 1 * sizeof(uint32_t)); // burst 2 data
   assert(win.segment(6).size == 4);                    // footer
 
-  // The per-burst count lives in the low 2 bits of header byte 1 (a 1-byte
-  // pad precedes it because the data frame is wider than the header). Verify
-  // the encoded batch counts: 3, 3, 1, and a zero-count footer.
-  assert((win.segment(0).data[1] & 0x3) == 3);
-  assert((win.segment(2).data[1] & 0x3) == 3);
-  assert((win.segment(4).data[1] & 0x3) == 1);
-  assert((win.segment(6).data[1] & 0x3) == 0);
+  // The header content is MSB-aligned within the 32-bit frame, exactly as
+  // CIRCT lowers the frame union: `tag` (ui16) sits at bits [31:16]
+  // (bytes 2..3) and the 2-bit count immediately below it at bits [15:14] --
+  // the top two bits of byte 1 -- with the remaining low bits zero. Only the
+  // first burst's header carries the static tag; later bursts and the footer
+  // leave it zero. (The old byte-granular codegen put the count in the low
+  // bits of byte 1, which the hardware would have read as zero.)
+  auto headerCount = [](const auto &s) -> unsigned {
+    return (s.data[1] >> 6) & 0x3;
+  };
+  assert(headerCount(win.segment(0)) == 3);
+  assert(headerCount(win.segment(2)) == 3);
+  assert(headerCount(win.segment(4)) == 1);
+  assert(headerCount(win.segment(6)) == 0);
+  // Exact header-frame bytes. Burst 0 (count 3, tag 0xBEEF):
+  //   byte0 = 0x00 (pad), byte1 = 0xC0 (count 3 at bits [15:14]),
+  //   byte2 = 0xEF, byte3 = 0xBE (tag, little-endian, at bits [31:16]).
+  assert(win.segment(0).data[0] == 0x00);
+  assert(win.segment(0).data[1] == 0xC0);
+  assert(win.segment(0).data[2] == 0xEF);
+  assert(win.segment(0).data[3] == 0xBE);
+  // Later bursts repeat the count but not the tag (bytes 2..3 stay zero).
+  assert(win.segment(2).data[1] == 0xC0); // count 3
+  assert(win.segment(2).data[2] == 0x00);
+  assert(win.segment(2).data[3] == 0x00);
+  assert(win.segment(4).data[1] == 0x40); // count 1
+  // Footer: zero count, zero tag.
+  assert(win.segment(6).data[1] == 0x00);
 
   // Round-trip: flatten the multi-burst stream and feed it back through the
   // generated serial-list deserializer. It must rebuild one window holding


### PR DESCRIPTION
Fix / support lists with non-power-of-2 length counts. Adds both unit and integration tests for this case.

Assisted-by: Github-Copilot:Claude Opus 4.8
