### PR TITLE
[ArcRuntime][InsertRuntime] Improve handling of trace file paths

### DIFF
--- a/include/circt/Dialect/Arc/Runtime/ModelInstance.h
+++ b/include/circt/Dialect/Arc/Runtime/ModelInstance.h
@@ -47,13 +47,32 @@ public:
   uint64_t *swapTraceBuffer();
 
 private:
+  // Runtime argument keys
+  /// Enable verbose debug output
+  inline static const std::string kArgKeyDebug = "debug";
+  /// Select FST trace mode
+  inline static const std::string kArgKeyFst = "fst";
+  /// Workdir-relative or absolute path to trace file
+  inline static const std::string kArgKeyTraceFile = "traceFile";
+  /// Select VCD trace mode
+  inline static const std::string kArgKeyVcd = "vcd";
+  /// Instance's working directory. Absolute or relative to process workdir.
+  inline static const std::string kArgKeyWorkDir = "workDir";
+
+  /// Parse and initialize the instance settings from the given argument string.
   void parseArgs(const char *args);
+  /// Get the path to the output trace file. Creates a default file name within
+  /// with the given suffix within working directory if not explicitly set
+  /// by the runtime arguments.
   std::filesystem::path getTraceFilePath(const std::string &suffix);
 
   const uint64_t instanceID;
   const ArcRuntimeModelInfo *const modelInfo;
   const ArcState *const state;
   std::map<std::string, std::optional<std::string>> arguments;
+  /// The path to the instance's working directory. Matches the process
+  /// working directory if not provided by a runtime argument.
+  std::filesystem::path workDir;
   // FST is always in the enum so headers don't depend on build configuration.
   // If FST is selected at runtime but not compiled in, an error is emitted.
   enum class TraceMode { DUMMY, VCD, FST };

--- a/include/circt/Dialect/Arc/Runtime/ModelInstance.h
+++ b/include/circt/Dialect/Arc/Runtime/ModelInstance.h
@@ -61,9 +61,9 @@ private:
 
   /// Parse and initialize the instance settings from the given argument string.
   void parseArgs(const char *args);
-  /// Get the path to the output trace file. Creates a default file name within
-  /// with the given suffix within working directory if not explicitly set
-  /// by the runtime arguments.
+  /// Get the path to the output trace file. Creates a default file name with
+  /// the given suffix within the working directory if not explicitly set by the
+  /// runtime arguments.
   std::filesystem::path getTraceFilePath(const std::string &suffix);
 
   const uint64_t instanceID;

--- a/integration_test/arcilator/JIT/runtime-lib-argparse.mlir
+++ b/integration_test/arcilator/JIT/runtime-lib-argparse.mlir
@@ -31,6 +31,14 @@
 // STDOUT-NOT:  [ArcRuntime] Argument string
 // STDOUT-NOT:  [ArcRuntime] Parsed argument
 
+// STDOUT:      [ArcRuntime] Argument string for instance ID 3: workDir=tmpWorkDir;traceFile=overridden;debug;traceFile=overriding
+// STDOUT-NEXT: [ArcRuntime] Parsed argument(s):
+// STDOUT-NEXT: [ArcRuntime]   debug
+// STDOUT-NEXT: [ArcRuntime]   traceFile = "overriding"
+// STDOUT-NEXT: [ArcRuntime]   workDir = "tmpWorkDir"
+// STDOUT-NEXT: [ArcRuntime] Working directory for instance ID 3: {{.+}}{{/|\\}}tmpWorkDir
+
+
 hw.module @dummy() {
   hw.output
 }
@@ -41,6 +49,8 @@ func.func @main() {
   arc.sim.instantiate @dummy as %model runtime ("debug;=badKey;=;\"=;badVal=x\"\";badVal2=\"\"x;badVal3=\"\\x\";foo;unterm=\"") {
   }
   arc.sim.instantiate @dummy as %model runtime ("foo;truncEscape=\"\\") {
+  }
+  arc.sim.instantiate @dummy as %model runtime ("workDir=tmpWorkDir;traceFile=overridden;debug;traceFile=overriding") {
   }
   return
 }

--- a/integration_test/arcilator/JIT/runtime-vcd-file.mlir
+++ b/integration_test/arcilator/JIT/runtime-vcd-file.mlir
@@ -1,0 +1,41 @@
+// RUN: arcilator %s --run --jit-entry=main --jit-vcd-file=trace.vcd
+// RUN: FileCheck %s --input-file=TestWorkDir0%{fs-sep}trace.vcd --check-prefixes=CHECK,VCD1
+// RUN: FileCheck %s --input-file=TestWorkDir1%{fs-sep}trace.vcd --check-prefixes=CHECK,VCD2
+// RUN: FileCheck %s --input-file=overriddenFileName.vcd --check-prefixes=CHECK,VCD3
+// REQUIRES: arcilator-jit
+
+hw.module @dut(in %in : i2, out o : i2) {
+  hw.output %in : i2
+}
+
+func.func @main() {
+  %inc = arith.constant 1 : i64
+  %one    = arith.constant 1 : i2
+  %two    = arith.constant 2 : i2
+  %three  = arith.constant 3 : i2
+
+  arc.sim.instantiate @dut as %model runtime ("workDir=TestWorkDir0") {
+    arc.sim.set_time %model, %inc : !arc.sim.instance<@dut>
+    arc.sim.set_input %model, "in" = %one : i2, !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+  }
+
+  arc.sim.instantiate @dut as %model runtime ("workDir=TestWorkDir1") {
+    arc.sim.set_time %model, %inc : !arc.sim.instance<@dut>
+    arc.sim.set_input %model, "in" = %two : i2, !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+  }
+
+  arc.sim.instantiate @dut as %model runtime ("traceFile=overriddenFileName.vcd") {
+    arc.sim.set_time %model, %inc : !arc.sim.instance<@dut>
+    arc.sim.set_input %model, "in" = %three : i2, !arc.sim.instance<@dut>
+    arc.sim.step %model by %inc : !arc.sim.instance<@dut>
+  }
+
+  return
+}
+
+// CHECK-LABEL: #1
+// VCD1-NEXT:   b01
+// VCD2-NEXT:   b10
+// VCD3-NEXT:   b11

--- a/lib/Dialect/Arc/Runtime/ModelInstance.cpp
+++ b/lib/Dialect/Arc/Runtime/ModelInstance.cpp
@@ -22,6 +22,7 @@
 #include <cctype>
 #include <iostream>
 #include <string_view>
+#include <system_error>
 #include <vector>
 
 using namespace circt::arc::runtime;
@@ -103,9 +104,9 @@ ModelInstance::~ModelInstance() {
 
 std::filesystem::path
 ModelInstance::getTraceFilePath(const std::string &suffix) {
-  auto it = arguments.find("traceFile");
+  auto it = arguments.find(kArgKeyTraceFile);
   if (it != arguments.end() && it->second.has_value())
-    return std::filesystem::path(*it->second);
+    return workDir / std::filesystem::path(*it->second);
 
   std::string saneName;
   if (modelInfo->modelName)
@@ -117,7 +118,7 @@ ModelInstance::getTraceFilePath(const std::string &suffix) {
   saneName += '_';
   saneName += std::to_string(instanceID);
   saneName += suffix;
-  return std::filesystem::current_path() / std::filesystem::path(saneName);
+  return workDir / std::filesystem::path(saneName);
 }
 
 void ModelInstance::onEval(ArcState *mutableState) {
@@ -282,13 +283,8 @@ void ModelInstance::parseArgs(const char *args) {
     return;
   auto argStr = std::string_view(args);
   arguments = parseArgsToMap(argStr);
-
-  if (arguments.count("debug"))
+  if (arguments.count(kArgKeyDebug))
     verbose = true;
-  if (arguments.count("vcd"))
-    traceMode = TraceMode::VCD;
-  if (arguments.count("fst"))
-    traceMode = TraceMode::FST;
 
   // Dump arguments
   if (verbose) {
@@ -302,6 +298,38 @@ void ModelInstance::parseArgs(const char *args) {
       std::cout << std::endl;
     }
   }
+
+  // Initialize workDir. A relative argument is resolved against the process
+  // working directory; an absolute argument replaces it entirely.
+  std::error_code ec;
+  workDir = std::filesystem::current_path(ec);
+  if (ec) {
+    std::cerr << "[ArcRuntime] WARNING: Could not determine current working "
+                 "directory: "
+              << ec.message() << std::endl;
+    workDir.clear();
+  }
+  auto workDirIt = arguments.find(kArgKeyWorkDir);
+  if (workDirIt != arguments.end() && workDirIt->second.has_value()) {
+    workDir /= *workDirIt->second;
+    workDir = workDir.lexically_normal();
+
+    // Create the working directory if it does not exist yet.
+    std::filesystem::create_directories(workDir, ec);
+    if (ec)
+      std::cerr << "[ArcRuntime] WARNING: Could not create working directory \""
+                << workDir.string() << "\": " << ec.message() << std::endl;
+  }
+
+  if (verbose)
+    std::cout << "[ArcRuntime] Working directory for instance ID " << instanceID
+              << ": " << workDir.string() << std::endl;
+
+  // Select Trace Mode
+  if (arguments.count(kArgKeyVcd))
+    traceMode = TraceMode::VCD;
+  if (arguments.count(kArgKeyFst))
+    traceMode = TraceMode::FST;
 }
 
 } // namespace circt::arc::runtime::impl

--- a/lib/Dialect/Arc/Transforms/InsertRuntime.cpp
+++ b/lib/Dialect/Arc/Transforms/InsertRuntime.cpp
@@ -283,32 +283,17 @@ private:
   }
 
   // Construct the runtime argument string for an instance
-  SmallString<32> buildArgString(unsigned instIdx, StringAttr existingArgs) {
+  SmallString<32> buildArgString(StringAttr existingArgs) {
     SmallString<32> str;
-    if (existingArgs)
-      str.append(existingArgs);
-    // If requested, append the trace file name
+    // If requested, prepend the trace file name
     if (!traceFileName.empty()) {
+      str += "traceFile=";
+      str += quoteAndEscapeRuntimeArgument(traceFileName);
+    }
+    if (existingArgs) {
       if (!str.empty())
         str += ';';
-      str += "traceFile=";
-      // Create a unique per-instance file name by adding a suffix before the
-      // the file extension
-      if (instIdx == 0) {
-        str += quoteAndEscapeRuntimeArgument(traceFileName);
-      } else {
-        SmallString<32> fileNameWithSuffix;
-        auto extension =
-            std::filesystem::path(static_cast<std::string>(traceFileName))
-                .extension()
-                .string();
-        fileNameWithSuffix +=
-            traceFileName.substr(0, traceFileName.size() - extension.size());
-        fileNameWithSuffix += '_';
-        fileNameWithSuffix += std::to_string(instIdx);
-        fileNameWithSuffix += extension;
-        str += quoteAndEscapeRuntimeArgument(fileNameWithSuffix);
-      }
+      str.append(existingArgs);
     }
     // Append extra arguments from pass option
     if (!extraArgs.empty()) {
@@ -649,8 +634,8 @@ void InsertRuntimePass::runOnOperation() {
   for (auto &[_, model] : globalContext->models) {
     // If provided, append extra instance arguments
     if (!extraArgs.empty() || !traceFileName.empty()) {
-      for (auto [idx, instance] : llvm::enumerate(model->instances)) {
-        auto newArgs = buildArgString(idx, instance.getRuntimeArgsAttr());
+      for (auto instance : model->instances) {
+        auto newArgs = buildArgString(instance.getRuntimeArgsAttr());
         auto newArgAttr = StringAttr::get(&getContext(), newArgs);
         instance.setRuntimeArgsAttr(newArgAttr);
       }

--- a/test/Dialect/Arc/insert-runtime.mlir
+++ b/test/Dialect/Arc/insert-runtime.mlir
@@ -60,9 +60,9 @@ func.func @main() {
     }
   }
 
-  // NOARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("foo")
-  // RTARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("foo;traceFile=\22C:\\\\tcf_1.abc\22;debug;bar")
-  arc.sim.instantiate @counter as %model runtime ("foo") {
+  // NOARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("workDir=\22./myWorkDir\22;traceFile=overrides.vcd")
+  // RTARGS-LABEL: arc.sim.instantiate @counter as %arg0 runtime @arcRuntimeModel_counter("traceFile=\22C:\\\\tcf.abc\22;workDir=\22./myWorkDir\22;traceFile=overrides.vcd;debug;bar")
+  arc.sim.instantiate @counter as %model runtime ("workDir=\22./myWorkDir\22;traceFile=overrides.vcd") {
     // CHECK: [[RTINST:%.*]] = builtin.unrealized_conversion_cast %arg0 : !arc.sim.instance<@counter> to !llvm.ptr
     // CHECK-NEXT: llvm.call @arcRuntimeIR_onEval([[RTINST]])
     // CHECK-NEXT: arc.sim.step


### PR DESCRIPTION
Stop creating unique per-instance trace file names in the InsertRuntime pass. This was intended to avoid collisions when multiple `arc.sim.instance` ops for the same model are present. But it ended up being confusing as the final file name may not exactly match the one provided on the CLI, especially when auto-generated instances are added.

Two additional changes are made to compensate:
First, any `traceFile` argument present on the instance before InsertRuntime now takes precedence over the file name passed in via the options.
Second, a `workDir` argument is added to the runtime model instance controlling its working directory without changing the actual working directory of the process. When provided in the IR, the specified trace file path is relative to this directory.

Assisted-by: vscode:Claude Sonnet 5