### PR TITLE
[ImportVerilog] Support dynamic `foreach` loops

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -62,11 +62,8 @@ static Value coerceToBuiltinInt(OpBuilder &builder, Location loc, Value value,
   return builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
 }
 
-/// Map an index into an array, with bounds `range`, to a bit offset of the
-/// underlying bit storage. This is a dynamic version of
-/// `slang::ConstantRange::translateIndex`.
-static Value getSelectIndex(Context &context, Location loc, Value index,
-                            const slang::ConstantRange &range) {
+Value ImportVerilog::getSelectIndex(Context &context, Location loc, Value index,
+                                    const slang::ConstantRange &range) {
   auto &builder = context.builder;
   auto indexType = cast<moore::UnpackedType>(index.getType());
 

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -656,6 +656,12 @@ private:
                       llvm::SmallVectorImpl<Type> &extraParams);
 };
 
+/// Map an index into an array, with bounds `range`, to a bit offset of the
+/// underlying bit storage. This is a dynamic version of
+/// `slang::ConstantRange::translateIndex`.
+Value getSelectIndex(Context &context, Location loc, Value index,
+                     const slang::ConstantRange &range);
+
 } // namespace ImportVerilog
 } // namespace circt
 #endif // CONVERSION_IMPORTVERILOG_IMPORTVERILOGINTERNALS_H

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -8,6 +8,7 @@
 
 #include "ImportVerilogInternals.h"
 #include "circt/Dialect/Moore/MooreOps.h"
+#include "circt/Dialect/Moore/MooreTypes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Diagnostics.h"
@@ -74,6 +75,63 @@ static std::array<Value, 4> getDefaultTimeFormatValues(OpBuilder &builder,
   return {unit, precision, suffix, minWidth};
 }
 
+// Get the runtime size of a dynamically-sized array at the given level of a
+// foreach loop.
+static FailureOr<Value>
+getRuntimeSizeAtLevel(Context &context, Location loc,
+                      const slang::ast::ForeachLoopStatement &stmt,
+                      uint32_t level, const moore::IntType &idxType) {
+  auto &builder = context.builder;
+  const auto &loopDim = stmt.loopDims[level];
+
+  // Get array at the current level
+  Value array = context.convertRvalueExpression(stmt.arrayRef);
+  for (uint32_t i = 0; i < level; ++i) {
+    const auto &dim = stmt.loopDims[i];
+    const auto &loopVar = dim.loopVar;
+    if (!dim.loopVar)
+      mlir::emitError(loc, "unsupported foreach with missing loop variable");
+
+    auto nestedType =
+        llvm::TypeSwitch<Type, Type>(array.getType())
+            .Case<moore::OpenUnpackedArrayType, moore::UnpackedArrayType,
+                  moore::ArrayType, moore::OpenArrayType, moore::QueueType,
+                  moore::AssocArrayType>(
+                [](auto ty) { return ty.getElementType(); })
+            .Default([](Type) { return Type(); });
+
+    auto curIdx = moore::ReadOp::create(builder, loc,
+                                        context.valueSymbols.lookup(loopVar));
+    if (dim.range.has_value()) {
+      Value offset = getSelectIndex(context, loc, curIdx, dim.range.value());
+      array =
+          moore::DynExtractOp::create(builder, loc, nestedType, array, offset);
+    } else {
+      array =
+          moore::DynExtractOp::create(builder, loc, nestedType, array, curIdx);
+    }
+  }
+
+  Value size;
+  if (loopDim.loopVar->arrayType.isQueue()) {
+    size = moore::QueueSizeBIOp::create(builder, loc, array);
+  } else if (loopDim.loopVar->arrayType.getCanonicalType().kind ==
+             slang::ast::SymbolKind::DynamicArrayType) {
+    size = moore::OpenUArraySizeOp::create(builder, loc, array);
+  } else {
+    // TODO: Associative arrays cannot be iterated on using an induction
+    // variable. Supporting them requires rewriting `recursiveForeach` to use
+    // the correct iterator type. For now, we just emit an error.
+    mlir::emitError(loc, "unsupported foreach loop on type: ")
+        << loopDim.loopVar->arrayType.toString();
+    return failure();
+  }
+
+  auto one = moore::ConstantOp::create(builder, loc, idxType, 1);
+  auto sizeMinusOne = moore::SubOp::create(builder, loc, size, one).getResult();
+  return sizeMinusOne;
+}
+
 // NOLINTBEGIN(misc-no-recursion)
 namespace {
 struct StmtVisitor {
@@ -96,10 +154,8 @@ struct StmtVisitor {
 
   LogicalResult recursiveForeach(const slang::ast::ForeachLoopStatement &stmt,
                                  uint32_t level) {
-    // find current dimension we are operate.
+    // find current dimension we are operating on.
     const auto &loopDim = stmt.loopDims[level];
-    if (!loopDim.range.has_value())
-      return mlir::emitError(loc) << "dynamic loop variable is unsupported";
     auto &exitBlock = createBlock();
     auto &stepBlock = createBlock();
     auto &bodyBlock = createBlock();
@@ -109,17 +165,23 @@ struct StmtVisitor {
     context.loopStack.push_back({&stepBlock, &exitBlock});
     llvm::scope_exit done([&] { context.loopStack.pop_back(); });
 
+    // Get the loop variable's type
     const auto &iter = loopDim.loopVar;
-    auto type = context.convertType(*iter->getDeclaredType());
-    if (!type)
+    auto idxType = context.convertType(*iter->getDeclaredType());
+    if (!idxType)
       return failure();
+    auto intIdxType = cast<moore::IntType>(idxType);
 
-    Value initial = moore::ConstantOp::create(
-        builder, loc, cast<moore::IntType>(type), loopDim.range->lower());
+    // Get the loop's lower bound
+    Value initial =
+        loopDim.range.has_value()
+            ? moore::ConstantOp::create(builder, loc, intIdxType,
+                                        loopDim.range->lower())
+            : moore::ConstantOp::create(builder, loc, intIdxType, 0);
 
-    // Create loop varirable in this dimension
+    // Create loop variable in this dimension
     Value varOp = moore::VariableOp::create(
-        builder, loc, moore::RefType::get(cast<moore::UnpackedType>(type)),
+        builder, loc, moore::RefType::get(cast<moore::UnpackedType>(idxType)),
         builder.getStringAttr(iter->name), initial);
     context.valueSymbols.insertIntoScope(context.valueSymbols.getCurScope(),
                                          iter, varOp);
@@ -128,8 +190,14 @@ struct StmtVisitor {
     builder.setInsertionPointToEnd(&checkBlock);
 
     // When the loop variable is greater than the upper bound, goto exit
-    auto upperBound = moore::ConstantOp::create(
-        builder, loc, cast<moore::IntType>(type), loopDim.range->upper());
+    auto upperBound =
+        loopDim.range.has_value()
+            ? moore::ConstantOp::create(builder, loc, intIdxType,
+                                        loopDim.range->upper())
+            : getRuntimeSizeAtLevel(context, loc, stmt, level, intIdxType)
+                  .value_or(Value());
+    if (!upperBound)
+      return failure();
 
     auto var = moore::ReadOp::create(builder, loc, varOp);
     Value cond = moore::SleOp::create(builder, loc, var, upperBound);
@@ -169,8 +237,7 @@ struct StmtVisitor {
 
     // add one to loop variable
     var = moore::ReadOp::create(builder, loc, varOp);
-    auto one =
-        moore::ConstantOp::create(builder, loc, cast<moore::IntType>(type), 1);
+    auto one = moore::ConstantOp::create(builder, loc, intIdxType, 1);
     auto postValue = moore::AddOp::create(builder, loc, var, one).getResult();
     moore::BlockingAssignOp::create(builder, loc, varOp, postValue);
     cf::BranchOp::create(builder, loc, &checkBlock);

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -542,6 +542,100 @@ function void ForeachStatements(int x, bit y);
   end
 endfunction
 
+// CHECK: func.func private @UnboundedArrayForeachStatements(%[[ARG0:.*]]: !moore.i32, %[[ARG1:.*]]: !moore.i1) {
+function void UnboundedArrayForeachStatements(int x, bit y);
+  // CHECK: %[[ARRAY:.*]] = moore.variable : <uarray<3 x open_uarray<queue<l8, 0>>>>
+  logic [7:0] array[4:2][][$];
+
+  // CHECK: %[[C2:.*]] = moore.constant 2 : i32
+  // CHECK: %[[I:.*]] = moore.variable %[[C2]] : <i32>
+  // CHECK: cf.br ^[[BB1:.*]]
+  // CHECK: ^[[BB1]]:
+  // CHECK: %[[C4:.*]] = moore.constant 4 : i32
+  // CHECK: %[[I_VAL:.*]] = moore.read %[[I]] : <i32>
+  // CHECK: %[[CMP1:.*]] = moore.sle %[[I_VAL]], %[[C4]] : i32 -> i1
+  // CHECK: %[[CONV1:.*]] = moore.to_builtin_int %[[CMP1]] : i1
+  // CHECK: cf.cond_br %[[CONV1]], ^[[BB2:.*]], ^[[BB14:.*]]
+  // CHECK: ^[[BB2]]:
+  // CHECK: %[[C0_J:.*]] = moore.constant 0 : i32
+  // CHECK: %[[J:.*]] = moore.variable %[[C0_J]] : <i32>
+  // CHECK: cf.br ^[[BB3:.*]]
+  // CHECK: ^[[BB3]]:
+  // CHECK: %[[ARRAY_VAL1:.*]] = moore.read %[[ARRAY]] : <uarray<3 x open_uarray<queue<l8, 0>>>>
+  // CHECK: %[[I_VAL2:.*]] = moore.read %[[I]] : <i32>
+  // CHECK: %[[C2_0:.*]] = moore.constant 2 : i32
+  // CHECK: %[[I_VAL_FINAL:.*]] = moore.sub %[[I_VAL2]], %[[C2_0]] : i32
+  // CHECK: %[[DYN1:.*]] = moore.dyn_extract %[[ARRAY_VAL1]] from %[[I_VAL_FINAL]] : uarray<3 x open_uarray<queue<l8, 0>>>, i32 -> open_uarray<queue<l8, 0>>
+  // CHECK: %[[SIZE1:.*]] = moore.open_uarray_size %[[DYN1]] : <queue<l8, 0>>
+  // CHECK: %[[C1_J:.*]] = moore.constant 1 : i32
+  // CHECK: %[[SUB1:.*]] = moore.sub %[[SIZE1]], %[[C1_J]] : i32
+  // CHECK: %[[J_VAL:.*]] = moore.read %[[J]] : <i32>
+  // CHECK: %[[CMP2:.*]] = moore.sle %[[J_VAL]], %[[SUB1]] : i32 -> i1
+  // CHECK: %[[CONV2:.*]] = moore.to_builtin_int %[[CMP2]] : i1
+  // CHECK: cf.cond_br %[[CONV2]], ^[[BB4:.*]], ^[[BB12:.*]]
+  // CHECK: ^[[BB4]]:
+  // CHECK: %[[C0_K:.*]] = moore.constant 0 : i32
+  // CHECK: %[[K:.*]] = moore.variable %[[C0_K]] : <i32>
+  // CHECK: cf.br ^[[BB5:.*]]
+  // CHECK: ^[[BB5]]:
+  // CHECK: %[[ARRAY_VAL2:.*]] = moore.read %[[ARRAY]] : <uarray<3 x open_uarray<queue<l8, 0>>>>
+  // CHECK: %[[I_VAL3:.*]] = moore.read %[[I]] : <i32>
+  // CHECK: %[[C2_1:.*]] = moore.constant 2 : i32
+  // CHECK: %[[I_VAL3_FINAL:.*]] = moore.sub %[[I_VAL3]], %[[C2_1]] : i32
+  // CHECK: %[[DYN2:.*]] = moore.dyn_extract %[[ARRAY_VAL2]] from %[[I_VAL3_FINAL]] : uarray<3 x open_uarray<queue<l8, 0>>>, i32 -> open_uarray<queue<l8, 0>>
+  // CHECK: %[[J_VAL2:.*]] = moore.read %[[J]] : <i32>
+  // CHECK: %[[DYN3:.*]] = moore.dyn_extract %[[DYN2]] from %[[J_VAL2]] : open_uarray<queue<l8, 0>>, i32 -> queue<l8, 0>
+  // CHECK: %[[SIZE2:.*]] = moore.builtin.size %[[DYN3]] : <l8, 0>
+  // CHECK: %[[C1_K:.*]] = moore.constant 1 : i32
+  // CHECK: %[[SUB2:.*]] = moore.sub %[[SIZE2]], %[[C1_K]] : i32
+  // CHECK: %[[K_VAL:.*]] = moore.read %[[K]] : <i32>
+  // CHECK: %[[CMP3:.*]] = moore.sle %[[K_VAL]], %[[SUB2]] : i32 -> i1
+  // CHECK: %[[CONV3:.*]] = moore.to_builtin_int %[[CMP3]] : i1
+  // CHECK: cf.cond_br %[[CONV3]], ^[[BB6:.*]], ^[[BB10:.*]]
+  foreach (array[i, j, k]) begin
+    // CHECK: ^[[BB6]]:
+    // CHECK: %[[CONV4:.*]] = moore.to_builtin_int %[[ARG1]] : i1
+    // CHECK: cf.cond_br %[[CONV4]], ^[[BB7:.*]], ^[[BB8:.*]]
+    if (y) begin
+      // CHECK: ^[[BB7]]:
+      // CHECK: call @dummyA() : () -> ()
+      // CHECK: cf.br ^[[BB10]]
+      dummyA();
+      break;
+    end else begin
+      // CHECK: ^[[BB8]]:
+      // CHECK: call @dummyB() : () -> ()
+      // CHECK: cf.br ^[[BB9:.*]]
+      dummyB();
+      continue;
+    end
+  end
+  // CHECK: ^[[BB9]]:
+  // CHECK: %[[K_VAL2:.*]] = moore.read %[[K]] : <i32>
+  // CHECK: %[[C1_K2:.*]] = moore.constant 1 : i32
+  // CHECK: %[[ADD1:.*]] = moore.add %[[K_VAL2]], %[[C1_K2]] : i32
+  // CHECK: moore.blocking_assign %[[K]], %[[ADD1]] : i32
+  // CHECK: cf.br ^[[BB5]]
+  // CHECK: ^[[BB10]]:
+  // CHECK: cf.br ^[[BB11:.*]]
+  // CHECK: ^[[BB11]]:
+  // CHECK: %[[J_VAL3:.*]] = moore.read %[[J]] : <i32>
+  // CHECK: %[[C1_J2:.*]] = moore.constant 1 : i32
+  // CHECK: %[[ADD2:.*]] = moore.add %[[J_VAL3]], %[[C1_J2]] : i32
+  // CHECK: moore.blocking_assign %[[J]], %[[ADD2]] : i32
+  // CHECK: cf.br ^[[BB3]]
+  // CHECK: ^[[BB12]]:
+  // CHECK: cf.br ^[[BB13:.*]]
+  // CHECK: ^[[BB13]]:
+  // CHECK: %[[I_VAL4:.*]] = moore.read %[[I]] : <i32>
+  // CHECK: %[[C1_I:.*]] = moore.constant 1 : i32
+  // CHECK: %[[ADD3:.*]] = moore.add %[[I_VAL4]], %[[C1_I]] : i32
+  // CHECK: moore.blocking_assign %[[I]], %[[ADD3]] : i32
+  // CHECK: cf.br ^[[BB1]]
+  // CHECK: ^[[BB14]]:
+  // CHECK: return
+endfunction
+
 
 // CHECK-LABEL: func.func private @WhileLoopStatements(
 // CHECK-SAME: %arg0: !moore.i1


### PR DESCRIPTION
Add support for `ForeachLoopStatement`s that loop on unbounded arrays and queues.

**What this does**

`foreach` statements on unbounded arrays were previously rejected. This PR adds support for this case by modifying the lowering logic for `slang::ast::ForeachLoopStatement`s.

Basically, the fix is to compute the upper bound of the loop dynamically whenever the loop is visiting a dynamically-sized type. 

Supported:

* Unbounded arrays (`array[]`)
* Queues (`array[$]`)
* Nesting (`array[4][][$]`)

Limitations:

* Associative arrays are not supported