### PR TITLE
[FIRRTL] Allow arbitrary LowerMemory dedup

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -340,13 +340,6 @@ parseFormatString(mlir::OpBuilder &builder, mlir::Location loc,
                   llvm::SmallVectorImpl<mlir::Value> &operands);
 
 //===----------------------------------------------------------------------===//
-// File utilities
-//===----------------------------------------------------------------------===//
-
-/// Truncate `a` to the common prefix of `a` and `b`.
-void makeCommonPrefix(SmallString<64> &a, StringRef b);
-
-//===----------------------------------------------------------------------===//
 // Object related utilities
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Support/Path.h
+++ b/include/circt/Support/Path.h
@@ -26,6 +26,12 @@ namespace circt {
 void appendPossiblyAbsolutePath(llvm::SmallVectorImpl<char> &base,
                                 const llvm::Twine &suffix);
 
+/// Truncate `a` in place to the longest common directory prefix of `a` and `b`,
+/// ensuring that the result ends on a directory separator (or is empty). This
+/// computes the lowest common ancestor directory of two paths and is used, for
+/// example, to pick a shared output directory for deduplicated operations.
+void makeCommonDirectoryPrefix(llvm::SmallVectorImpl<char> &a, StringRef b);
+
 /// Creates an output file with the given filename in the specified directory.
 /// The function will create any parent directories as needed. If an error
 /// occurs during file or directory creation, it will use the provided emitError

--- a/lib/Conversion/SeqToSV/CMakeLists.txt
+++ b/lib/Conversion/SeqToSV/CMakeLists.txt
@@ -13,5 +13,6 @@ add_circt_conversion_library(CIRCTSeqToSV
   LINK_LIBS PUBLIC
   CIRCTEmit
   CIRCTSeq
+  CIRCTSupport
   CIRCTSV
 )

--- a/lib/Conversion/SeqToSV/FirMemLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirMemLowering.cpp
@@ -7,9 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "FirMemLowering.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Support/Path.h"
 #include "mlir/IR/Threading.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/Path.h"
 
 using namespace circt;
 using namespace hw;
@@ -17,6 +20,27 @@ using namespace seq;
 using llvm::MapVector;
 
 #define DEBUG_TYPE "lower-seq-firmem"
+
+/// Return the lowest common ancestor directory of all memory ops provided.
+static Attribute computeCommonOutputFile(ArrayRef<seq::FirMemOp> memOps) {
+  auto getDirectory = [](seq::FirMemOp op) -> StringRef {
+    if (auto file = op->getAttrOfType<hw::OutputFileAttr>("output_file"))
+      return file.getDirectory();
+    return "";
+  };
+
+  SmallString<64> commonDir(getDirectory(memOps.front()));
+  for (auto memOp : memOps.drop_front()) {
+    if (commonDir.empty())
+      break;
+    makeCommonDirectoryPrefix(commonDir, getDirectory(memOp));
+  }
+
+  if (commonDir.empty())
+    return {};
+  return hw::OutputFileAttr::getAsDirectory(memOps.front()->getContext(),
+                                            commonDir);
+}
 
 FirMemLowering::FirMemLowering(ModuleOp circuit)
     : context(circuit.getContext()), circuit(circuit) {
@@ -295,8 +319,10 @@ FirMemLowering::createMemoryModule(FirMemConfig &mem,
   auto genOp =
       hw::HWModuleGeneratedOp::create(builder, loc, schemaSymRef, name, ports,
                                       StringRef{}, ArrayAttr{}, genAttrs);
-  if (mem.outputFile)
-    genOp->setAttr("output_file", mem.outputFile);
+
+  // Put the memory in the lowest common ancestor directory.
+  if (auto outputFile = computeCommonOutputFile(memOps))
+    genOp->setAttr("output_file", outputFile);
 
   return genOp;
 }

--- a/lib/Conversion/SeqToSV/FirMemLowering.h
+++ b/lib/Conversion/SeqToSV/FirMemLowering.h
@@ -43,16 +43,15 @@ struct FirMemConfig {
                               dataWidth, depth, readLatency, writeLatency,
                               maskBits, readUnderWrite, writeUnderWrite,
                               initFilename, initIsBinary, initIsInline,
-                              outputFile, prefix) ^
+                              prefix) ^
            llvm::hash_combine_range(writeClockIDs.begin(), writeClockIDs.end());
   }
 
   auto getTuple() const {
-    return std::make_tuple(numReadPorts, numWritePorts, numReadWritePorts,
-                           dataWidth, depth, readLatency, writeLatency,
-                           maskBits, readUnderWrite, writeUnderWrite,
-                           writeClockIDs, initFilename, initIsBinary,
-                           initIsInline, outputFile, prefix);
+    return std::make_tuple(
+        numReadPorts, numWritePorts, numReadWritePorts, dataWidth, depth,
+        readLatency, writeLatency, maskBits, readUnderWrite, writeUnderWrite,
+        writeClockIDs, initFilename, initIsBinary, initIsInline, prefix);
   }
 
   bool operator==(const FirMemConfig &other) const {

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -19,7 +19,6 @@
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Path.h"
 
 using namespace circt;
 using namespace firrtl;
@@ -1083,21 +1082,6 @@ Type circt::firrtl::lowerType(
     return IntegerType::get(type.getContext(), width);
 
   return {};
-}
-
-void circt::firrtl::makeCommonPrefix(SmallString<64> &a, StringRef b) {
-  // truncate 'a' to the common prefix of 'a' and 'b'.
-  size_t i = 0;
-  size_t e = std::min(a.size(), b.size());
-  for (; i < e; ++i)
-    if (a[i] != b[i])
-      break;
-  a.resize(i);
-
-  // truncate 'a' so it ends on a directory seperator.
-  auto sep = llvm::sys::path::get_separator();
-  while (!a.empty() && !a.ends_with(sep))
-    a.pop_back();
 }
 
 PathOp circt::firrtl::createPathRef(Operation *op, hw::HierPathOp nla,

--- a/lib/Dialect/FIRRTL/Transforms/AssignOutputDirs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AssignOutputDirs.cpp
@@ -13,6 +13,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Support/Debug.h"
+#include "circt/Support/Path.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
@@ -59,9 +60,9 @@ static void makeCommonPrefix(StringRef outputDir, SmallString<64> &a,
   if (attr) {
     SmallString<64> b(attr.getDirectory());
     makeAbsolute(outputDir, b);
-    makeCommonPrefix(a, b);
+    makeCommonDirectoryPrefix(a, b);
   } else {
-    makeCommonPrefix(a, outputDir);
+    makeCommonDirectoryPrefix(a, outputDir);
   }
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -214,8 +214,8 @@ void BlackBoxReaderPass::runOnOperation() {
       } else {
         auto &fileAttr = ptr->second.outputFileAttr;
         SmallString<64> directory(fileAttr.getDirectory());
-        makeCommonPrefix(directory,
-                         annotationInfo.outputFileAttr.getDirectory());
+        makeCommonDirectoryPrefix(directory,
+                                  annotationInfo.outputFileAttr.getDirectory());
         fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
             context, directory, annotationInfo.name.getValue(),
             /*excludeFromFileList=*/

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -9,7 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "circt/Analysis/FIRRTLInstanceInfo.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
@@ -112,14 +111,12 @@ struct LowerMemoryPass
   FMemModuleOp emitMemoryModule(MemOp op, const FirMemory &summary,
                                 const SmallVectorImpl<PortInfo> &ports);
   FMemModuleOp getOrCreateMemModule(MemOp op, const FirMemory &summary,
-                                    const SmallVectorImpl<PortInfo> &ports,
-                                    bool shouldDedup);
-  FModuleOp createWrapperModule(MemOp op, const FirMemory &summary,
-                                bool shouldDedup);
+                                    const SmallVectorImpl<PortInfo> &ports);
+  FModuleOp createWrapperModule(MemOp op, const FirMemory &summary);
   InstanceOp emitMemoryInstance(MemOp op, FModuleOp moduleOp,
                                 const FirMemory &summary);
-  void lowerMemory(MemOp mem, const FirMemory &summary, bool shouldDedup);
-  LogicalResult runOnModule(FModuleOp moduleOp, bool shouldDedup);
+  void lowerMemory(MemOp mem, const FirMemory &summary);
+  LogicalResult runOnModule(FModuleOp moduleOp);
   void runOnOperation() override;
 
   /// Cached module namespaces.
@@ -214,30 +211,23 @@ LowerMemoryPass::emitMemoryModule(MemOp op, const FirMemory &mem,
 
 FMemModuleOp
 LowerMemoryPass::getOrCreateMemModule(MemOp op, const FirMemory &summary,
-                                      const SmallVectorImpl<PortInfo> &ports,
-                                      bool shouldDedup) {
-  // Try to find a matching memory blackbox that we already created.  If
-  // shouldDedup is true, we will just generate a new memory module.
-  if (shouldDedup) {
-    auto it = memories.find(summary);
-    if (it != memories.end())
-      return it->second;
-  }
+                                      const SmallVectorImpl<PortInfo> &ports) {
+  // Try to find a matching memory blackbox that we already created.
+  auto it = memories.find(summary);
+  if (it != memories.end())
+    return it->second;
 
   // Create a new module for this memory. This can update the name recorded in
   // the memory's summary.
   auto moduleOp = emitMemoryModule(op, summary, ports);
 
-  // Record the memory module.  We don't want to use this module for other
-  // memories, then we don't add it to the table.
-  if (shouldDedup)
-    memories[summary] = moduleOp;
+  // Record the memory module so it can be reused for equivalent memories.
+  memories[summary] = moduleOp;
 
   return moduleOp;
 }
 
-void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
-                                  bool shouldDedup) {
+void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary) {
   auto *context = &getContext();
   auto ports = getMemoryModulePorts(summary);
 
@@ -258,7 +248,7 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
 
   // Create an instance of the external memory module. The instance has the
   // same name as the target module.
-  auto memModule = getOrCreateMemModule(mem, summary, ports, shouldDedup);
+  auto memModule = getOrCreateMemModule(mem, summary, ports);
   b.setInsertionPointToStart(wrapper.getBodyBlock());
   auto memInst = InstanceOp::create(
       b, mem->getLoc(), memModule, (mem.getName() + "_ext").str(),
@@ -513,8 +503,7 @@ InstanceOp LowerMemoryPass::emitMemoryInstance(MemOp op, FModuleOp module,
   return inst;
 }
 
-LogicalResult LowerMemoryPass::runOnModule(FModuleOp moduleOp,
-                                           bool shouldDedup) {
+LogicalResult LowerMemoryPass::runOnModule(FModuleOp moduleOp) {
   assert(operationsToErase.empty() && "operationsToErase must be empty");
 
   auto result = moduleOp.walk([&](MemOp op) {
@@ -526,7 +515,7 @@ LogicalResult LowerMemoryPass::runOnModule(FModuleOp moduleOp,
 
     auto summary = getSummary(op);
     if (summary.isSeqMem())
-      lowerMemory(op, summary, shouldDedup);
+      lowerMemory(op, summary);
 
     return WalkResult::advance();
   });
@@ -544,18 +533,16 @@ LogicalResult LowerMemoryPass::runOnModule(FModuleOp moduleOp,
 
 void LowerMemoryPass::runOnOperation() {
   auto circuit = getOperation();
-  auto &instanceInfo = getAnalysis<InstanceInfo>();
   symbolTable = &getAnalysis<SymbolTable>();
   circuitNamespace.add(circuit);
 
   // We iterate the circuit from top-to-bottom.  This ensures that we get
   // consistent memory names.  (Memory modules will be inserted before the
   // module we are processing to prevent these being unnecessarily visited.)
-  // Deduplication of memories is allowed if the module is under the "effective"
-  // design-under-test (DUT).
+  // All memories are eligible for deduplication with equivalent memories,
+  // regardless of whether they are in the design.
   for (auto moduleOp : circuit.getBodyBlock()->getOps<FModuleOp>()) {
-    auto shouldDedup = instanceInfo.anyInstanceInEffectiveDesign(moduleOp);
-    if (failed(runOnModule(moduleOp, shouldDedup)))
+    if (failed(runOnModule(moduleOp)))
       return signalPassFailure();
   }
 

--- a/lib/Support/Path.cpp
+++ b/lib/Support/Path.cpp
@@ -33,6 +33,24 @@ void circt::appendPossiblyAbsolutePath(llvm::SmallVectorImpl<char> &base,
   }
 }
 
+void circt::makeCommonDirectoryPrefix(llvm::SmallVectorImpl<char> &a,
+                                      StringRef b) {
+  // Truncate `a` to the common character prefix of `a` and `b`.
+  StringRef aRef(a.data(), a.size());
+  size_t e = std::min(aRef.size(), b.size());
+  size_t i = 0;
+  for (; i < e; ++i)
+    if (aRef[i] != b[i])
+      break;
+  a.truncate(i);
+
+  // Truncate `a` so it ends on a directory separator.
+  auto sep = llvm::sys::path::get_separator();
+  StringRef sepRef(sep);
+  while (!a.empty() && !StringRef(a.data(), a.size()).ends_with(sepRef))
+    a.pop_back();
+}
+
 std::unique_ptr<llvm::ToolOutputFile>
 circt::createOutputFile(StringRef filename, StringRef dirname,
                         function_ref<InFlightDiagnostic()> emitError) {

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -96,20 +96,20 @@ firrtl.module @Prefix() {
 }
 }
 
-// Test that memories in the testharness are not deduped with other memories in
+// Test that memories in the testharness are deduped with other memories in
 // the test harness.
-// CHECK-LABEL: firrtl.circuit "NoTestharnessDedup0"
-firrtl.circuit "NoTestharnessDedup0" {
+// CHECK-LABEL: firrtl.circuit "TestharnessDedup0"
+firrtl.circuit "TestharnessDedup0" {
 // CHECK: firrtl.module private @mem0
 // CHECK-NEXT: firrtl.instance mem0_ext  @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
 
 // CHECK: firrtl.memmodule private @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, ruw = #firrtl<ruwbehavior Undefined>, writeLatency = 1 : ui32}
 
 // CHECK: firrtl.module private @mem1
-// CHECK-NEXT: firrtl.instance mem1_ext  @mem1_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+// CHECK-NEXT: firrtl.instance mem1_ext  @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
 
-// CHECK: firrtl.memmodule private @mem1_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, ruw = #firrtl<ruwbehavior Undefined>, writeLatency = 1 : ui32}
-firrtl.module @NoTestharnessDedup0() {
+// CHECK-NOT: firrtl.memmodule private @mem1_ext
+firrtl.module @TestharnessDedup0() {
   %mem0_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
   // CHECK: firrtl.instance mem0  @mem0
   %mem1_write = firrtl.mem Undefined {depth = 12 :i64, name = "mem1", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
@@ -119,22 +119,22 @@ firrtl.module @NoTestharnessDedup0() {
 firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} { }
 }
 
-// Test that memories in the testharness are not deduped with other memories in the DUT.
-// CHECK-LABEL: firrtl.circuit "NoTestharnessDedup1"
-firrtl.circuit "NoTestharnessDedup1" {
+// Test that memories in the testharness are deduped with memories in the DUT.
+// CHECK-LABEL: firrtl.circuit "TestharnessDedup1"
+firrtl.circuit "TestharnessDedup1" {
 // CHECK: firrtl.module private @mem0
 // CHECK-NEXT: firrtl.instance mem0_ext  @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
 
 // CHECK: firrtl.memmodule private @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, ruw = #firrtl<ruwbehavior Undefined>, writeLatency = 1 : ui32}
-firrtl.module @NoTestharnessDedup1() {
+firrtl.module @TestharnessDedup1() {
   %mem0_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
   // CHECK: firrtl.instance mem0  @mem0
   firrtl.instance dut @DUT()
 }
 // CHECK: firrtl.module private @mem1
-// CHECK-NEXT: firrtl.instance mem1_ext  @mem1_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+// CHECK-NEXT: firrtl.instance mem1_ext  @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
 
-// CHECK: firrtl.memmodule private @mem1_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, ruw = #firrtl<ruwbehavior Undefined>, writeLatency = 1 : ui32}
+// CHECK-NOT: firrtl.memmodule private @mem1_ext
 firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
   %mem1_write = firrtl.mem Undefined {depth = 12 :i64, name = "mem1", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
   // CHECK: firrtl.instance mem1  @mem1

--- a/test/Dialect/Seq/lower-firmem.mlir
+++ b/test/Dialect/Seq/lower-firmem.mlir
@@ -77,15 +77,37 @@ hw.module @Foo(in %clk: !seq.clock, in %en: i1, in %addr: i4, in %wdata: i42, in
   comb.xor %3, %4 : i42
 }
 
-// CHECK: hw.module.generated @m1_mem1_24x1337, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 1337 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, output_file = "foo", readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 1337 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// CHECK: hw.module.generated @m1_mem2_24x1337, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 1337 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, output_file = "bar", readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 1337 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// Memories that share a configuration but live in different output directories
+// are deduplicated into a single generated module.  The module is emitted in
+// the longest common directory prefix of all the memories so that it is visible
+// from every instantiation site and does not leak into a broader scope than
+// necessary.
+//
+// Disjoint directories collapse to the root, so no output file is set.
+// CHECK: hw.module.generated @m1_mem_24x1337, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 1337 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 1337 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK-NOT: hw.module.generated @m1_mem2_24x1337
+//
+// CHECK-LABEL: hw.module @DedupDisjointOutputDirs
+hw.module @DedupDisjointOutputDirs() {
+  // CHECK-NEXT: hw.instance "m1_mem1_ext" @m1_mem_24x1337(
+  // CHECK-NEXT: hw.instance "m1_mem2_ext" @m1_mem_24x1337(
+  %m1_mem1 = seq.firmem 0, 1, undefined, port_order {name = "m1_mem1", output_file = #hw.output_file<"foo/">} : <24 x 1337>
+  %m1_mem2 = seq.firmem 0, 1, undefined, port_order {name = "m1_mem2", output_file = #hw.output_file<"bar/">} : <24 x 1337>
+}
 
-// CHECK-LABEL: hw.module @SeparateOutputFiles
-hw.module @SeparateOutputFiles() {
-  // CHECK-NEXT: hw.instance "m1_mem1_ext" @m1_mem1_24x1337(
-  // CHECK-NEXT: hw.instance "m1_mem2_ext" @m1_mem2_24x1337(
-  %m1_mem1 = seq.firmem 0, 1, undefined, port_order {output_file = "foo"} : <24 x 1337>
-  %m1_mem2 = seq.firmem 0, 1, undefined, port_order {output_file = "bar"} : <24 x 1337>
+// A shared parent directory becomes the output directory of the deduped
+// module.  Here "x/LayerA/" and "x/LayerB/" have the common prefix "x/".
+// A distinct width (1338) keeps this memory from deduplicating with the one
+// above.
+// CHECK: hw.module.generated @m1a_mem_24x1338, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 1338 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, output_file = #hw.output_file<"x{{/|\\\\}}">, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 1338 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK-NOT: hw.module.generated @m1a_mem2_24x1338
+//
+// CHECK-LABEL: hw.module @DedupCommonOutputDir
+hw.module @DedupCommonOutputDir() {
+  // CHECK-NEXT: hw.instance "m1a_mem1_ext" @m1a_mem_24x1338(
+  // CHECK-NEXT: hw.instance "m1a_mem2_ext" @m1a_mem_24x1338(
+  %m1a_mem1 = seq.firmem 0, 1, undefined, port_order {name = "m1a_mem1", output_file = #hw.output_file<"x/LayerA/">} : <24 x 1338>
+  %m1a_mem2 = seq.firmem 0, 1, undefined, port_order {name = "m1a_mem2", output_file = #hw.output_file<"x/LayerB/">} : <24 x 1338>
 }
 
 // CHECK: hw.module.generated @foo_m2_mem1_24x9001, @FIRRTLMem() attributes {depth = 24 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 9001 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 9001 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}


### PR DESCRIPTION
Remove the restriction on allowing design/ex-design deduplication of
memories in FIRRTL's `LowerMemory` pass.  This is done to avoid problems
with unpredictable naming.  It is unclear why this restriction was put on
the pass originally.

Assisted-by: pi.dev:claude-opus-4-8
