### PR TITLE
[Arcilator] Register the UB dialect

### DIFF
--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -40,6 +40,7 @@ set(libs
   MLIRParser
   MLIRSCFDialect
   MLIRTargetLLVMIRExport
+  MLIRUBDialect
 )
 
 add_circt_tool(arcilator arcilator.cpp DEPENDS ${libs} ${ARCILATOR_JIT_DEPS})

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -49,6 +49,7 @@
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/IR/AsmState.h"
@@ -726,6 +727,7 @@ static LogicalResult executeArcilator(MLIRContext &context) {
     mlir::index::IndexDialect,
     mlir::LLVM::LLVMDialect,
     mlir::scf::SCFDialect,
+    mlir::ub::UBDialect,
     om::OMDialect,
     seq::SeqDialect,
     sim::SimDialect,


### PR DESCRIPTION
This allows IR containing `ub.poison` (generated by the coroutine lowering) to round-trip.

Assisted-by: Claude Opus 4.7