### PR TITLE
[MooreToCore] Fold case equality against x/z-bearing constants to its static verdict

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1865,6 +1865,28 @@ struct ICmpOpConversion : public OpConversionPattern<SourceOp> {
     Type resultType =
         ConversionPattern::typeConverter->convertType(op.getResult().getType());
 
+    // Case equality against a constant carrying x/z bits: this two-valued
+    // lowering never materializes x/z at run time, so an x/z constant bit
+    // can never case-match (IEEE 1800-2017 11.4.5: `===` compares x/z
+    // literally). Dropping the unknown bits in the converted constant would
+    // silently turn `v === 'x` into `v === 0` -- the `$isunknown` payload
+    // shape, which then fails on every all-zero sample -- so fold the
+    // comparison to its static verdict instead.
+    if constexpr (std::is_same_v<SourceOp, CaseEqOp> ||
+                  std::is_same_v<SourceOp, CaseNeOp>) {
+      auto hasUnknownConstBits = [](Value value) {
+        auto constant = value.getDefiningOp<ConstantOp>();
+        return constant && constant.getValue().hasUnknown();
+      };
+      if (hasUnknownConstBits(op.getLhs()) ||
+          hasUnknownConstBits(op.getRhs())) {
+        bool verdict = std::is_same_v<SourceOp, CaseNeOp>;
+        rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, resultType,
+                                                    verdict ? 1 : 0);
+        return success();
+      }
+    }
+
     rewriter.replaceOpWithNewOp<comb::ICmpOp>(
         op, resultType, pred, adaptor.getLhs(), adaptor.getRhs());
     return success();

--- a/test/Conversion/MooreToCore/caseeq-unknown-constant.mlir
+++ b/test/Conversion/MooreToCore/caseeq-unknown-constant.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// Case equality against a constant carrying x/z bits folds to its static
+// verdict in this two-valued lowering: runtime values never hold x/z, so an
+// x/z constant bit can never case-match (IEEE 1800-2017 11.4.5). Previously
+// the unknown bits were dropped from the converted constant, turning
+// `v === 'x` into `v === 0` — the `$isunknown` payload shape, which then
+// reported every all-zero sample as unknown.
+
+// CHECK-LABEL: func.func @CaseEqUnknownConst
+func.func @CaseEqUnknownConst(%arg0: !moore.l1, %arg1: !moore.l8) {
+  %x1 = moore.constant bX : l1
+  %mixed = moore.constant b1XX01ZZ0 : l8
+
+  // `v === 1'bx` can never hold on two-valued runtime data.
+  // CHECK: hw.constant false
+  // CHECK-NOT: comb.icmp ceq
+  %0 = moore.case_eq %arg0, %x1 : l1
+  // CHECK: hw.constant true
+  // CHECK-NOT: comb.icmp cne
+  %1 = moore.case_ne %arg0, %x1 : l1
+  // Constant operand order does not matter.
+  // CHECK: hw.constant false
+  %2 = moore.case_eq %x1, %arg0 : l1
+  // Partially-unknown constants also force a static verdict: the x/z bit
+  // positions can never match.
+  // CHECK: hw.constant false
+  %3 = moore.case_eq %arg1, %mixed : l8
+
+  // Fully two-valued case comparisons keep the genuine comparison.
+  // CHECK: comb.icmp ceq
+  %k = moore.constant 42 : l8
+  %4 = moore.case_eq %arg1, %k : l8
+  return
+}


### PR DESCRIPTION
The two-valued lowering converts `===`/`!==` straight to `comb.icmp ceq/cne` on the domain-converted operands, and the domain conversion silently drops x/z bits from constant operands. The practical casualty is `$isunknown`: slang rewrites `$isunknown(v)` as a case equality against an x constant, so on current main

```systemverilog
module isunknown_demo(input logic [3:0] v, output logic unk, output logic cq);
  assign unk = $isunknown(v);
  assign cq = (v === 4'bxxxx);
endmodule
```

lowers to

```mlir
%0 = comb.parity %v : i4
%1 = comb.icmp ceq %0, %false : i1   // unk = (^v == 0): true for every even-parity sample
%2 = comb.icmp ceq %v, %c0_i4 : i4   // cq = (v == 0)
```

i.e. `$isunknown` reports "unknown" for perfectly driven values, and `v === 4'bxxxx` becomes `v == 0`. A stock protocol assertion of the ubiquitous `assert property (!$isunknown(sig))` shape then fails on every armed clock edge for a correctly driven signal.

Runtime values in this lowering never materialize x/z, so a constant x/z bit can never case-match — IEEE 1800-2017 § 11.4.5 requires `===` to compare x/z bits literally. This folds `case_eq` with any x/z-bearing constant operand to false and `case_ne` to true. Fully two-valued comparisons keep the genuine comparison, and the casez/casexz wildcard ops keep their existing mask handling (they are lowered by a separate pattern and are not touched).

Tested: new `test/Conversion/MooreToCore/caseeq-unknown-constant.mlir` (all-x constant, partially-unknown constant, operand order, two-valued control keeps `comb.icmp`); `test/Conversion/MooreToCore` passes 7/7.

Written with AI assistance; I've reviewed the diff and tests.
