### PR TITLE
[Moore] SimplifyRefs: lower concat_ref destinations of delayed assignments

### DIFF
--- a/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
+++ b/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
@@ -83,7 +83,16 @@ struct ConcatRefLowering : public OpConversionPattern<OpTy> {
       // description mentioned.
       srcWidth = srcWidth - width;
 
-      OpTy::create(rewriter, op.getLoc(), operand, extract);
+      // Delayed assignment variants carry their delay over to every slice:
+      // the RHS is still evaluated at statement execution time (the extract
+      // above), and each slice is scheduled with the original delay, which
+      // matches the intra-assignment delay semantics of the unsliced
+      // assignment (IEEE 1800-2017 § 9.4.5).
+      if constexpr (std::is_same_v<OpTy, DelayedNonBlockingAssignOp> ||
+                    std::is_same_v<OpTy, DelayedContinuousAssignOp>)
+        OpTy::create(rewriter, op.getLoc(), operand, extract, op.getDelay());
+      else
+        OpTy::create(rewriter, op.getLoc(), operand, extract);
     }
     rewriter.eraseOp(op);
     return success();
@@ -138,7 +147,8 @@ void SimplifyRefsPass::runOnOperation() {
   ConversionTarget target(context);
 
   target.addDynamicallyLegalOp<ContinuousAssignOp, BlockingAssignOp,
-                               NonBlockingAssignOp>([](auto op) {
+                               NonBlockingAssignOp, DelayedContinuousAssignOp,
+                               DelayedNonBlockingAssignOp>([](auto op) {
     return !op->getOperand(0).template getDefiningOp<ConcatRefOp>();
   });
 
@@ -146,7 +156,10 @@ void SimplifyRefsPass::runOnOperation() {
   RewritePatternSet concatRefPatterns(&context);
   concatRefPatterns.add<ConcatRefLowering<ContinuousAssignOp>,
                         ConcatRefLowering<BlockingAssignOp>,
-                        ConcatRefLowering<NonBlockingAssignOp>>(&context);
+                        ConcatRefLowering<NonBlockingAssignOp>,
+                        ConcatRefLowering<DelayedContinuousAssignOp>,
+                        ConcatRefLowering<DelayedNonBlockingAssignOp>>(
+      &context);
 
   if (failed(applyPartialConversion(getOperation(), target,
                                     std::move(concatRefPatterns)))) {

--- a/test/Dialect/Moore/simplify-refs.mlir
+++ b/test/Dialect/Moore/simplify-refs.mlir
@@ -77,6 +77,42 @@ moore.module @Nested() {
   moore.output
 }
 
+// Delayed assignment variants keep their delay on every slice
+// (`{a, b} <= #1 c;` and `assign #1 {a, b} = c;`).
+// CHECK-LABEL: moore.module @DelayedConcatDst()
+moore.module @DelayedConcatDst() {
+  %a = moore.variable : <l7>
+  %b = moore.variable : <l1>
+  %c = moore.variable : <l8>
+  %d = moore.variable : <l8>
+  // CHECK: [[T0:%.+]] = moore.constant_time 2000000 fs
+  %t0 = moore.constant_time 2000000 fs
+  // CHECK-NOT: moore.concat_ref
+  %2 = moore.concat_ref %a, %b : (!moore.ref<l7>, !moore.ref<l1>) -> <l8>
+  // CHECK: %[[D_READ:.+]] = moore.read %d : <l8>
+  %3 = moore.read %d : <l8>
+  // CHECK: %[[SL1:.+]] = moore.extract %[[D_READ]] from 1 : l8 -> l7
+  // CHECK: moore.delayed_assign %a, %[[SL1]], [[T0]] : l7
+  // CHECK: %[[SL2:.+]] = moore.extract %[[D_READ]] from 0 : l8 -> l1
+  // CHECK: moore.delayed_assign %b, %[[SL2]], [[T0]] : l1
+  moore.delayed_assign %2, %3, %t0 : l8
+  moore.procedure always {
+    // CHECK: [[T1:%.+]] = moore.constant_time 1000000 fs
+    %t = moore.constant_time 1000000 fs
+    // CHECK-NOT: moore.concat_ref
+    %0 = moore.concat_ref %a, %b : (!moore.ref<l7>, !moore.ref<l1>) -> <l8>
+    // CHECK: %[[C_READ:.+]] = moore.read %c : <l8>
+    %1 = moore.read %c : <l8>
+    // CHECK: %[[TMP1:.+]] = moore.extract %[[C_READ]] from 1 : l8 -> l7
+    // CHECK: moore.delayed_nonblocking_assign %a, %[[TMP1]], [[T1]] : l7
+    // CHECK: %[[TMP2:.+]] = moore.extract %[[C_READ]] from 0 : l8 -> l1
+    // CHECK: moore.delayed_nonblocking_assign %b, %[[TMP2]], [[T1]] : l1
+    moore.delayed_nonblocking_assign %0, %1, %t : l8
+    moore.return
+  }
+  moore.output
+}
+
 // CHECK-LABEL: moore.module @QueueRefs()
 moore.module @QueueRefs() {
   %q = moore.variable : <queue<i32, 5>>


### PR DESCRIPTION
A concatenation lvalue on a delayed assignment — `{a, b} <= #1 c;` (imported as `moore.delayed_nonblocking_assign`) and `assign #1 {a, b} = c;` (as `moore.delayed_assign`) — is left untouched by SimplifyRefs, which only disassembles the plain assign variants. The surviving `moore.concat_ref` then fails to legalize:

```
error: failed to legalize operation 'moore.concat_ref': ...
    {so, bo} <= #1 d;
```

The nonblocking form is common in ordinary RTL; uart_transmitter.v's `{shift_out[6:0], bit_out} <= #1 tf_data_out;` is the shape that surfaced this.

Disassemble the delayed variants exactly like the plain ones, carrying the delay over to every slice: the RHS is still evaluated at statement execution time (the extract of the read value), and each slice is scheduled with the original delay, which matches the intra-assignment delay semantics of the unsliced assignment (IEEE 1800-2017 § 9.4.5). After the change the example lowers to a process driving both slices with the original `#1`:

```mlir
%6 = comb.extract %d from 1 : (i8) -> i7
llhd.drv %so, %6 after %0 : i7        // %0 = llhd.constant_time <1000000fs, 0d, 0e>
%7 = comb.extract %d from 0 : (i8) -> i1
llhd.drv %bo, %7 after %0 : i1
```

Tested: `test/Dialect/Moore/simplify-refs.mlir` gains a `@DelayedConcatDst` module covering both delayed variants (delay preserved per slice); `test/Dialect/Moore` passes 13/13.

Written with AI assistance; I've reviewed the diff and tests.
