### PR TITLE
[MooreToCore] Support zero-init for aggregates without static bit width

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -962,6 +962,31 @@ static Value createZeroValue(Type type, Location loc,
   if (auto queueType = dyn_cast<sim::QueueType>(type))
     return sim::QueueEmptyOp::create(rewriter, loc, queueType);
 
+  // Handle aggregate
+  if (auto arrayType = dyn_cast<hw::ArrayType>(type)) {
+    if (hw::getBitWidth(type) == -1) {
+      Value zeroElement =
+          createZeroValue(arrayType.getElementType(), loc, rewriter);
+      if (!zeroElement)
+        return {};
+      SmallVector<Value> elements(arrayType.getNumElements(), zeroElement);
+      return hw::ArrayCreateOp::create(rewriter, loc, elements);
+    }
+  }
+
+  if (auto structType = dyn_cast<hw::StructType>(type)) {
+    if (hw::getBitWidth(type) == -1) {
+      SmallVector<Value> fields;
+      for (auto field : structType.getElements()) {
+        Value zeroField = createZeroValue(field.type, loc, rewriter);
+        if (!zeroField)
+          return {};
+        fields.push_back(zeroField);
+      }
+      return hw::StructCreateOp::create(rewriter, loc, structType, fields);
+    }
+  }
+
   // Otherwise try to create a zero integer and bitcast it to the result type.
   int64_t width = hw::getBitWidth(type);
   if (width == -1)

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1989,3 +1989,34 @@ moore.module @ReadMem() {
   }
   moore.output
 }
+
+// CHECK-LABEL: hw.module @StringArrayVariable
+moore.module @StringArrayVariable() {
+  // CHECK-NEXT: [[ZERO:%.+]] = sim.string.literal ""
+  // CHECK-NEXT: [[INIT:%.+]] = hw.array_create [[ZERO]], [[ZERO]] : !sim.dstring
+  // CHECK-NEXT: [[SIG:%.+]] = llhd.sig [[INIT]] : !hw.array<2x!sim.dstring>
+  %names = moore.variable : <uarray<2 x string>>
+
+  // CHECK-NEXT: llhd.process
+  moore.procedure initial {
+    // CHECK-NEXT: [[LIT:%.+]] = hw.constant {{.*}} : i32
+    %0 = moore.constant_string "zero" : i32
+    // CHECK-NEXT: [[STR:%.+]] = sim.string.int_to_string [[LIT]] : i32
+    %1 = moore.int_to_string %0 : i32
+    // CHECK-NEXT: [[IDX:%.+]] = hw.constant false
+    // CHECK-NEXT: [[ELEM:%.+]] = llhd.sig.array_get [[SIG]]{{\[}}[[IDX]]{{\]}} : <!hw.array<2x!sim.dstring>>
+    %ref = moore.extract_ref %names from 0 : !moore.ref<!moore.uarray<2 x string>> -> !moore.ref<!moore.string>
+    // CHECK-NEXT: [[TIME:%.+]] = llhd.constant_time <0ns, 0d, 1e>
+    // CHECK-NEXT: llhd.drv [[ELEM]], [[STR]] after [[TIME]] : !sim.dstring
+    moore.blocking_assign %ref, %1 : string
+
+    // CHECK-NEXT: [[READ:%.+]] = llhd.prb [[ELEM]] : !sim.dstring
+    %2 = moore.read %ref : <string>
+    // CHECK-NEXT: [[FMT:%.+]] = sim.fmt.string [[READ]] : !sim.dstring
+    %3 = moore.fmt.string %2
+    // CHECK-NEXT: sim.proc.print [[FMT]]
+    moore.builtin.display %3
+    // CHECK-NEXT: llhd.halt
+    moore.return
+  }
+}


### PR DESCRIPTION
`createZeroValue` only knew ho to zero-init dynamic strings/queues directly, or fixed-width scalars via a bitcast. An unpacked array (or struct) whose element type has no static bit width.

**For example (Struct):**
```
module toy_struct_string_var;
  typedef struct {
    string name;
    int age;
  } person_t;

  person_t p;

  initial begin
    p.name = "Alice";
    p.age = 30;
    $display("%s is %0d", p.name, p.age);
  end
endmodule
```

**Output:**

```
error: failed to legalize operation 'moore.variable': %2 = "moore.variable"() <{name = "p"}> : () -> !moore.ref<ustruct<{name: string, age: i32}>>
  person_t p;
           ^
note: see current operation: %2 = "moore.variable"() <{name = "p"}> : () -> !moore.ref<ustruct<{name: string, age: i32}>>
```

**For example (Array):**
```
module toy_string_array_var;
  string names[32];

  initial begin
    names[0] = "zero";
    $display("%s", names[0]);
  end
endmodule
```

**Output:**

```
error: failed to legalize operation 'moore.variable': %0 = "moore.variable"() <{name = "names"}> : () -> !moore.ref<uarray<32 x string>>
  string names[32];
         ^
note: see current operation: %0 = "moore.variable"() <{name = "names"}> : () -> !moore.ref<uarray<32 x string>>
```


**Fix:** 

Extend `createZeroValue` to recurse into `hw::ArrayType`/`hw::StructType` when their bit width can't be computed statically; build the zero value recursively using the existing `hw.array_create`/`hw.struct_create` ops, instead of relying on the bitcast fallback.