### PR TITLE
[ci] Bump manylinux version for Linux wheels

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -99,7 +99,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse ./lib/Bindings/Python
         env:
           CIBW_BUILD: ${{ matrix.config.cibw_build }}
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BUILD_FRONTEND: build
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14.0
           SETUPTOOLS_SCM_DEBUG: True


### PR DESCRIPTION
Bump the manylinux version used to build the Linux wheels.  Numpy recently
bumped the minimum GCC version to 10.3.0 and the current manylinux 2014
uses an older version [[1]].

[1]: https://github.com/numpy/numpy/releases/tag/v2.5.1

Assisted-by: pi.dev:claude-opus-4-8

I'm testing this here: https://github.com/llvm/circt/actions/runs/29131348601
