### PR TITLE
[MooreToCore] Support bit-range extract on packed structs

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1364,8 +1364,18 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
     // TODO: return X if the domain is four-valued for out-of-bounds accesses
     // once we support four-valued lowering
     Type resultType = typeConverter->convertType(op.getResult().getType());
-    Type inputType = adaptor.getInput().getType();
+    Value input = adaptor.getInput();
+    Type inputType = input.getType();
     int32_t low = adaptor.getLowBit();
+
+    if (auto structTy = dyn_cast<hw::StructType>(inputType)) {
+      int32_t width = hw::getBitWidth(structTy);
+      if (width == -1)
+        return failure();
+      input = rewriter.createOrFold<hw::BitcastOp>(
+          op.getLoc(), rewriter.getIntegerType(width), input);
+      inputType = input.getType();
+    }
 
     if (isa<IntegerType>(inputType)) {
       int32_t inputWidth = inputType.getIntOrFloatBitWidth();
@@ -1383,7 +1393,7 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
             op.getLoc(),
             rewriter.getIntegerType(
                 std::min(resultWidth, std::min(high, inputWidth) - lowIdx)),
-            adaptor.getInput(), lowIdx);
+            input, lowIdx);
         toConcat.push_back(middle);
       }
 

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -359,6 +359,15 @@ func.func @DynExtractRefArrayElement(%j: !moore.ref<array<2 x array<1 x l3>>>, %
   return %0 : !moore.ref<array<1 x l3>>
 }
 
+// CHECK-LABEL: func.func @ExtractFromPackedStruct
+func.func @ExtractFromPackedStruct(%arg0: !moore.struct<{a: l1, b: l1, c: l2}>) -> !moore.l3 {
+  // CHECK: [[BITCAST:%.+]] = hw.bitcast %arg0 : (!hw.struct<a: i1, b: i1, c: i2>) -> i4
+  // CHECK: [[RES:%.+]] = comb.extract [[BITCAST]] from 1 : (i4) -> i3
+  %0 = moore.extract %arg0 from 1 : struct<{a: l1, b: l1, c: l2}> -> l3
+  // CHECK: return [[RES]]
+  return %0 : !moore.l3
+}
+
 // CHECK-LABEL: func @AdvancedConversion
 func.func @AdvancedConversion(%arg0: !moore.array<5 x struct<{exp_bits: i32, man_bits: i32}>>) -> (!moore.array<5 x struct<{exp_bits: i32, man_bits: i32}>>, !moore.i320) {
   // CHECK: [[V0:%.+]] = hw.constant 3978585893941511189997889893581765703992223160870725712510875979948892565035285336817671 : i320


### PR DESCRIPTION
A bit-range part-select on a packed struct value fails to legalize. `ExtractOpConversion` only handles `IntegerType` and `hw::ArrayType` operands and falls through to failure for everything else, including `hw::StructType`.

**For example:**
```
module toy_struct_extract;
  typedef struct packed {
    logic a;
    logic b;
    logic [1:0] c;
  } pkt_t;

  pkt_t in;
  logic [$bits(pkt_t)-1:1] out;

  assign out = in[$bits(pkt_t)-1:1];
endmodule
```

**Output:**
```
error: failed to legalize operation 'moore.extract': %8 = "moore.extract"(%7) <{lowBit = 1 : i32}> : (!moore.struct<{a: l1, b: l1, c: l2}>) -> !moore.l3
  assign out = in[$bits(pkt_t)-1:1];
               ^
note: see current operation: %8 = "moore.extract"(%7) <{lowBit = 1 : i32}> : (!moore.struct<{a: l1, b: l1, c: l2}>) -> !moore.l3
```

**Fix:**
A packed struct has a well-defined flattened bit width, so treat it like a plain integer: bitcast it to that width first, then reuse the existing integer bit-range extraction logic unchanged.

**Limitation:**
Only the read case. The lvalue case needs a signal-level bitcast that doesn't exist yet in LLHD, and is left as a follow-up.