### PR TITLE
[arcilator] Add target DLTI attribute to MLIR module

### DIFF
--- a/test/arcilator/dlti.mlir
+++ b/test/arcilator/dlti.mlir
@@ -1,0 +1,20 @@
+// REQUIRES: host=aarch64{{.*}} || host=x86_64{{.*}} || host=arm64{{.*}}
+// RUN: arcilator %s --until-before=state-alloc --add-data-layout-information=false                                    | FileCheck %s --check-prefix=DLTIOFF
+// RUN: arcilator %s --until-before=state-alloc --add-data-layout-information=true                                     | FileCheck %s --check-prefix=DLTION
+// RUN: arcilator %s --until-before=state-alloc --add-data-layout-information=true --target-triple=arm64-apple-macosx  | FileCheck %s --check-prefix=DLTION
+// RUN: arcilator %s --until-before=state-alloc --add-data-layout-information=true --target-triple=x86_64              | FileCheck %s --check-prefix=DLTION
+// RUN: not arcilator %s --add-data-layout-information=true --target-triple=i386
+// RUN: not arcilator %s --add-data-layout-information=true --target-triple=notARealArch
+
+// Check that DLTI information is available before state allocation, unless disabled
+
+// DLTION-LABEL: module
+// DLTION-SAME:  dlti.dl_spec = #dlti.dl_spec
+
+// DLTIOFF-LABEL: module
+// DLTIOFF-NOT:   dlti
+
+module {
+  hw.module @Dummy() {
+  }
+}

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -28,6 +28,7 @@ set(libs
   CIRCTSupport
   CIRCTTransforms
   CIRCTVerif
+  LLVMTargetParser
   MLIRArithDialect
   MLIRBuiltinToLLVMIRTranslation
   MLIRControlFlowDialect
@@ -40,6 +41,7 @@ set(libs
   MLIRParser
   MLIRSCFDialect
   MLIRTargetLLVMIRExport
+  MLIRTargetLLVMIRImport
   MLIRUBDialect
 )
 

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -60,12 +60,15 @@
 #include "mlir/Pass/PassInstrumentation.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/Timing.h"
 #include "mlir/Support/ToolUtilities.h"
 #include "mlir/Target/LLVMIR/Dialect/All.h"
 #include "mlir/Target/LLVMIR/Export.h"
+#include "mlir/Target/LLVMIR/Import.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/IR/DataLayout.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
@@ -75,6 +78,8 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "llvm/TargetParser/Host.h"
+#include "llvm/TargetParser/Triple.h"
 
 #ifdef ARCILATOR_ENABLE_JIT
 #define ARC_RUNTIME_JITBIND_FNDECL
@@ -199,6 +204,19 @@ static llvm::cl::opt<bool> traceTaps(
     "trace-taps",
     llvm::cl::desc("Insert trace instrumentation for observed values"),
     llvm::cl::init(false), llvm::cl::cat(mainCategory));
+
+static llvm::cl::opt<bool> shouldAddDataLayoutAttribute(
+    "add-data-layout-information",
+    llvm::cl::desc(
+        "Add Data Layout and Target Information (DLTI) to the module"),
+    llvm::cl::init(true), llvm::cl::cat(mainCategory));
+
+static llvm::cl::opt<std::string> dltiTargetTriple(
+    "target-triple",
+    llvm::cl::desc("Target Triple for creating DLTI. If unspecified, the DLTI "
+                   "of the current process is used."),
+    llvm::cl::value_desc("triple"), llvm::cl::init(""),
+    llvm::cl::cat(mainCategory));
 
 // Options to control early-out from pipeline.
 enum Until {
@@ -413,6 +431,38 @@ static void populateHwModuleToArcPipeline(PassManager &pm) {
   populateArcStateAllocationPipeline(pm, allocationOpt);
 }
 
+static LogicalResult addDataLayoutAttribute(ModuleOp moduleOp) {
+  moduleOp.getContext()->loadDialect<DLTIDialect, LLVM::LLVMDialect>();
+
+  auto tripleStr = dltiTargetTriple.empty() ? llvm::sys::getProcessTriple()
+                                            : dltiTargetTriple;
+  auto triple = llvm::Triple(tripleStr);
+  if (triple.getArch() == llvm::Triple::UnknownArch) {
+    llvm::errs() << "Failed to determine architecture for target triple \""
+                 << tripleStr << "\".\n";
+    return failure();
+  }
+
+  // These assumptions are hardcoded in various passes:
+  if (!triple.isArch64Bit() || !triple.isLittleEndian()) {
+    llvm::errs() << "Unsupported target architecture \"" << tripleStr
+                 << "\".\n";
+    return failure();
+  }
+
+  // Check if there already is an DLTI attribute.
+  if (moduleOp->getAttr(DLTIDialect::kDataLayoutAttrName))
+    moduleOp.emitWarning("Existing DLTI specification will be overridden. Use "
+                         "`--add-data-layout-information=false` to retain it.");
+
+  // Create the attribute.
+  auto dataLayout = llvm::DataLayout(triple.computeDataLayout());
+  auto dataLayoutSpec =
+      mlir::translateDataLayout(dataLayout, moduleOp->getContext());
+  moduleOp->setAttr(DLTIDialect::kDataLayoutAttrName, dataLayoutSpec);
+  return success();
+}
+
 static LogicalResult processBuffer(
     MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     std::optional<std::unique_ptr<llvm::ToolOutputFile>> &outputFile) {
@@ -422,6 +472,8 @@ static LogicalResult processBuffer(
     module = parseSourceFile<ModuleOp>(sourceMgr, &context);
   }
   if (!module)
+    return failure();
+  if (shouldAddDataLayoutAttribute && failed(addDataLayoutAttribute(*module)))
     return failure();
 
   // Lower HwModule to Arc model.


### PR DESCRIPTION
Not honoring the data layout of the target architecture has repeatedly caused hard to find bugs. Until now, the only option to properly consider this was manually adding the DLTI attribute to the IR.

This commit allows the `arcilator` tool to automatically add this attribute based on either a user provided target specification, or by inferring it form the current process.

An explicit target can be specified by the `--target-triple=...` option. The previous behavior can be restored with
`--add-data-layout-information=false`.

Ensuring that the DLTI is actually used by the lowering passes is left to a follow up.

Assisted-by: vscode:Claude Opus 4.8