### PR TITLE
[Moore][MooreToCore][Sim] Add lowering for associative array operations

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2248,6 +2248,31 @@ def AssocArrayExtractRefOp : MooreOp<"assoc_array_extract_ref",
   }];
 }
 
+def AssocArraySetOp : MooreOp<"assoc_array.set", [
+    TypesMatchWith<"element type of associative array and given value must match",
+    "assoc_array", "value",
+    "cast<AssocArrayType>(cast<RefType>($_self).getNestedType()).getElementType()">,
+    TypesMatchWith<"associative array index and given index must match",
+    "assoc_array", "index",
+    "cast<AssocArrayType>(cast<RefType>($_self).getNestedType()).getIndexType()">]> {
+  let summary = "Overwrite (or insert) the element at a given index in an "
+                "associative array";
+  let description = [{
+    See IEEE 1800-2017 § 7.8.7 "Allocating associative array elements".
+    Writes $value at $index in the associative array, creating the entry
+    if it did not already exist.
+    This op is produced by the `SimplifyRefs` pass folding an
+    `assoc_array_extract_ref` immediately consumed by a blocking assignment;
+    ImportVerilog never emits it directly.
+  }];
+  let arguments = (ins AssocArrayRefType:$assoc_array, UnpackedType:$index,
+    UnpackedType:$value);
+  let results = (outs);
+  let assemblyFormat = [{
+    $assoc_array `[` $index `]` `=` $value attr-dict `:` type($assoc_array)
+  }];
+}
+
 def AssocArrayDeleteOp : MooreOp<"assoc_array.delete", 
     [TypesMatchWith<"associative array index and given index must match",
     "assoc_array", "index", "cast<AssocArrayType>(cast<RefType>($_self).getNestedType()).getIndexType()">]> {

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1123,6 +1123,150 @@ def QueueConcatOp : SimOp<"queue.concat", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Associative array operations
+//===----------------------------------------------------------------------===//
+
+def AssocArrayEmptyOp : SimOp<"assoc_array.empty", [Pure]> {
+  let summary = "Creates an empty associative array";
+  let description = [{
+    Creates an empty associative array, which is the default value for a
+    variable holding an associative array.
+  }];
+  let arguments = (ins);
+  let results = (outs AssocArrayType:$result);
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+def AssocArrayGetOp : SimOp<"assoc_array.get", [Pure,
+    TypesMatchWith<"array and index types must match",
+      "array", "index", "cast<AssocArrayType>($_self).getIndexType()">,
+    TypesMatchWith<"array and result types must match",
+      "array", "result", "cast<AssocArrayType>($_self).getElementType()">]> {
+  let summary = "Reads an element from an associative array";
+  let description = [{
+    Returns the element stored at $index. If no entry exists for $index, the
+    returned value is unspecified; use `assoc_array.exists` to distinguish a
+    missing entry from a stored value.
+  }];
+  let arguments = (ins AssocArrayType:$array, AnyType:$index);
+  let results = (outs AnyType:$result);
+  let assemblyFormat = "$array `[` $index `]` attr-dict `:` type($array)";
+}
+
+def AssocArraySetOp : SimOp<"assoc_array.set", [Pure,
+    TypesMatchWith<"array and index types must match",
+      "array", "index", "cast<AssocArrayType>($_self).getIndexType()">,
+    TypesMatchWith<"array and value types must match",
+      "array", "value", "cast<AssocArrayType>($_self).getElementType()">,
+    AllTypesMatch<["array", "outArray"]>]> {
+  let summary = "Writes an element into an associative array";
+  let description = [{
+    Returns an updated associative array with $value stored at $index,
+    creating the entry if it did not already exist.
+  }];
+  let arguments = (ins AssocArrayType:$array, AnyType:$index, AnyType:$value);
+  let results = (outs AssocArrayType:$outArray);
+  let assemblyFormat = "$array `[` $index `]` `=` $value attr-dict `:` type($array)";
+}
+
+def AssocArrayDeleteOp : SimOp<"assoc_array.delete", [Pure,
+    TypesMatchWith<"array and index types must match",
+      "array", "index", "cast<AssocArrayType>($_self).getIndexType()">,
+    AllTypesMatch<["array", "outArray"]>]> {
+  let summary = "Deletes an entry from an associative array";
+  let description = [{
+    Returns an updated associative array with the entry at $index removed.
+    Deleting an entry that does not exist returns the array unchanged.
+  }];
+  let arguments = (ins AssocArrayType:$array, AnyType:$index);
+  let results = (outs AssocArrayType:$outArray);
+  let assemblyFormat = "`index` $index `of` $array attr-dict `:` type($array)";
+}
+
+def AssocArraySizeOp : SimOp<"assoc_array.size", [Pure]> {
+  let summary = "Number of entries in an associative array";
+  let description = [{
+    Returns the number of entries stored in the associative array. An empty
+    array has size 0.
+  }];
+  let arguments = (ins AssocArrayType:$array);
+  let results = (outs I32:$result);
+  let assemblyFormat = "$array attr-dict `:` type($array)";
+}
+
+def AssocArrayExistsOp : SimOp<"assoc_array.exists", [Pure,
+    TypesMatchWith<"array and index types must match",
+      "array", "index", "cast<AssocArrayType>($_self).getIndexType()">]> {
+  let summary = "Checks whether an entry exists in an associative array";
+  let description = [{
+    Returns a nonzero value if an entry exists at $index, and 0 otherwise.
+  }];
+  let arguments = (ins AssocArrayType:$array, AnyType:$index);
+  let results = (outs I32:$result);
+  let assemblyFormat = "$index `in` $array attr-dict `:` type($array)";
+}
+
+def AssocArrayFirstOp : SimOp<"assoc_array.first", [Pure,
+    TypesMatchWith<"array and index types must match",
+      "array", "index", "cast<AssocArrayType>($_self).getIndexType()">]> {
+  let summary = "Finds the first (lowest) index in an associative array";
+  let description = [{
+    Finds the smallest index that has an entry in the array. If the array is
+    not empty, $found is nonzero and $index is that index. Otherwise $found
+    is 0 and $index is unspecified.
+  }];
+  let arguments = (ins AssocArrayType:$array);
+  let results = (outs I32:$found, AnyType:$index);
+  let assemblyFormat = "$array attr-dict `:` type($array)";
+}
+
+def AssocArrayLastOp : SimOp<"assoc_array.last", [Pure,
+    TypesMatchWith<"array and index types must match",
+      "array", "index", "cast<AssocArrayType>($_self).getIndexType()">]> {
+  let summary = "Finds the last (highest) index in an associative array";
+  let description = [{
+    Finds the largest index that has an entry in the array. If the array is
+    not empty, $found is nonzero and $index is that index. Otherwise $found
+    is 0 and $index is unspecified.
+  }];
+  let arguments = (ins AssocArrayType:$array);
+  let results = (outs I32:$found, AnyType:$index);
+  let assemblyFormat = "$array attr-dict `:` type($array)";
+}
+
+def AssocArrayNextOp : SimOp<"assoc_array.next", [Pure,
+    TypesMatchWith<"array and index types must match",
+      "array", "index", "cast<AssocArrayType>($_self).getIndexType()">,
+    TypesMatchWith<"array and nextIndex types must match",
+      "array", "nextIndex", "cast<AssocArrayType>($_self).getIndexType()">]> {
+  let summary = "Finds the next index in an associative array";
+  let description = [{
+    Finds the smallest index strictly greater than $index. If such an entry
+    exists, $found is nonzero and $nextIndex is that index. Otherwise $found
+    is 0 and $nextIndex is $index, unchanged.
+  }];
+  let arguments = (ins AssocArrayType:$array, AnyType:$index);
+  let results = (outs I32:$found, AnyType:$nextIndex);
+  let assemblyFormat = "$array `[` $index `]` attr-dict `:` type($array)";
+}
+
+def AssocArrayPrevOp : SimOp<"assoc_array.prev", [Pure,
+    TypesMatchWith<"array and index types must match",
+      "array", "index", "cast<AssocArrayType>($_self).getIndexType()">,
+    TypesMatchWith<"array and prevIndex types must match",
+      "array", "prevIndex", "cast<AssocArrayType>($_self).getIndexType()">]> {
+  let summary = "Finds the previous index in an associative array";
+  let description = [{
+    Finds the largest index strictly smaller than $index. If such an entry
+    exists, $found is nonzero and $prevIndex is that index. Otherwise $found
+    is 0 and $prevIndex is $index, unchanged.
+  }];
+  let arguments = (ins AssocArrayType:$array, AnyType:$index);
+  let results = (outs I32:$found, AnyType:$prevIndex);
+  let assemblyFormat = "$array `[` $index `]` attr-dict `:` type($array)";
+}
+
+//===----------------------------------------------------------------------===//
 // Simulation Control
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/Sim/SimTypes.td
+++ b/include/circt/Dialect/Sim/SimTypes.td
@@ -73,6 +73,30 @@ def QueueType : SimTypeDef<"Queue"> {
   ];
 }
 
+def AssocArrayType : SimTypeDef<"AssocArray"> {
+  let mnemonic = "assoc_array";
+  let summary = "an associative array type";
+  let description = [{
+    An associative array (hash map) type. Even though practical lowerings of
+    this type likely have to hold the contents in dynamically-allocated heap
+    memory, *this type has value semantics*.
+  }];
+
+  let parameters = (ins
+    "::mlir::Type":$elementType,
+    "::mlir::Type":$indexType
+  );
+  let assemblyFormat = [{
+    `<` $elementType `,` $indexType `>`
+  }];
+  let builders = [
+    AttrBuilderWithInferredContext<
+      (ins "Type":$elementType, "Type":$indexType), [{
+        return $_get(elementType.getContext(), elementType, indexType);
+      }]>
+  ];
+}
+
 def DPIFunctionType : SimTypeDef<"DPIFunction"> {
   let summary = "DPI function type with first-class argument directions";
   let description = [{

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -958,6 +958,10 @@ static Value createZeroValue(Type type, Location loc,
   if (auto strType = dyn_cast<sim::DynamicStringType>(type))
     return sim::StringConstantOp::create(rewriter, loc, strType, "");
 
+  // Handle associative arrays
+  if (auto assocArrayType = dyn_cast<sim::AssocArrayType>(type))
+    return sim::AssocArrayEmptyOp::create(rewriter, loc, assocArrayType);
+
   // Handle queues
   if (auto queueType = dyn_cast<sim::QueueType>(type))
     return sim::QueueEmptyOp::create(rewriter, loc, queueType);
@@ -3002,6 +3006,172 @@ struct QueueConcatOpConversion : public OpConversionPattern<QueueConcatOp> {
   }
 };
 
+struct AssocArrayExtractOpConversion
+    : public OpConversionPattern<AssocArrayExtractOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AssocArrayExtractOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType)
+      return failure();
+
+    Value zero = createZeroValue(resultType, op.getLoc(), rewriter);
+    if (!zero)
+      return failure();
+    Value raw =
+        sim::AssocArrayGetOp::create(rewriter, op.getLoc(), resultType,
+                                     adaptor.getInput(), adaptor.getIndex());
+    Value exists = sim::AssocArrayExistsOp::create(
+        rewriter, op.getLoc(), adaptor.getInput(), adaptor.getIndex());
+    Value zeroI32 = hw::ConstantOp::create(rewriter, op.getLoc(), APInt(32, 0));
+    Value existsBit = comb::ICmpOp::create(
+        rewriter, op.getLoc(), comb::ICmpPredicate::ne, exists, zeroI32, false);
+    rewriter.replaceOpWithNewOp<comb::MuxOp>(op, existsBit, raw, zero, false);
+    return success();
+  }
+};
+
+struct AssocArraySetOpConversion : public OpConversionPattern<AssocArraySetOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AssocArraySetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    probeRefAndDriveWithResult(
+        rewriter, op.getLoc(), adaptor.getAssocArray(), [&](Value array) {
+          return sim::AssocArraySetOp::create(rewriter, op.getLoc(), array,
+                                              adaptor.getIndex(),
+                                              adaptor.getValue())
+              .getOutArray();
+        });
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct AssocArrayDeleteOpConversion
+    : public OpConversionPattern<AssocArrayDeleteOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AssocArrayDeleteOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    probeRefAndDriveWithResult(
+        rewriter, op.getLoc(), adaptor.getAssocArray(), [&](Value array) {
+          return sim::AssocArrayDeleteOp::create(rewriter, op.getLoc(), array,
+                                                 adaptor.getIndex())
+              .getOutArray();
+        });
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct AssocArrayClearOpConversion
+    : public OpConversionPattern<AssocArrayClearOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AssocArrayClearOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto refType = cast<llhd::RefType>(adaptor.getAssocArray().getType());
+    Value emptyArray = sim::AssocArrayEmptyOp::create(rewriter, op->getLoc(),
+                                                      refType.getNestedType());
+    Value delay = llhd::ConstantTimeOp::create(
+        rewriter, op.getLoc(),
+        getBlockingOrContinuousAssignDelay(rewriter.getContext()));
+    llhd::DriveOp::create(rewriter, op.getLoc(), adaptor.getAssocArray(),
+                          emptyArray, delay, Value{});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct AssocArraySizeOpConversion
+    : public OpConversionPattern<AssocArraySizeOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AssocArraySizeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value array =
+        llhd::ProbeOp::create(rewriter, op.getLoc(), adaptor.getAssocArray());
+    rewriter.replaceOpWithNewOp<sim::AssocArraySizeOp>(op, array);
+    return success();
+  }
+};
+
+struct AssocArrayExistsOpConversion
+    : public OpConversionPattern<AssocArrayExistsOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AssocArrayExistsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value array =
+        llhd::ProbeOp::create(rewriter, op.getLoc(), adaptor.getAssocArray());
+    rewriter.replaceOpWithNewOp<sim::AssocArrayExistsOp>(op, array,
+                                                         adaptor.getIndex());
+    return success();
+  }
+};
+
+template <typename MooreOpTy, typename SimOpTy>
+struct AssocArrayEndpointOpConversion : public OpConversionPattern<MooreOpTy> {
+  using OpConversionPattern<MooreOpTy>::OpConversionPattern;
+  using OpAdaptor = typename MooreOpTy::Adaptor;
+  LogicalResult
+  matchAndRewrite(MooreOpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value array =
+        llhd::ProbeOp::create(rewriter, op.getLoc(), adaptor.getAssocArray());
+    auto endpointOp = SimOpTy::create(rewriter, op.getLoc(), array);
+    Value curIndex =
+        llhd::ProbeOp::create(rewriter, op.getLoc(), adaptor.getIndex());
+    Value zero = hw::ConstantOp::create(rewriter, op.getLoc(), APInt(32, 0));
+    Value foundBit =
+        comb::ICmpOp::create(rewriter, op.getLoc(), comb::ICmpPredicate::ne,
+                             endpointOp->getResult(0), zero, false);
+    Value newIndex =
+        comb::MuxOp::create(rewriter, op.getLoc(), foundBit,
+                            endpointOp->getResult(1), curIndex, false);
+    Value delay = llhd::ConstantTimeOp::create(
+        rewriter, op.getLoc(),
+        getBlockingOrContinuousAssignDelay(rewriter.getContext()));
+    llhd::DriveOp::create(rewriter, op.getLoc(), adaptor.getIndex(), newIndex,
+                          delay, Value{});
+    rewriter.replaceOp(op, endpointOp->getResult(0));
+    return success();
+  }
+};
+
+template <typename MooreOpTy, typename SimOpTy>
+struct AssocArrayStepOpConversion : public OpConversionPattern<MooreOpTy> {
+  using OpConversionPattern<MooreOpTy>::OpConversionPattern;
+  using OpAdaptor = typename MooreOpTy::Adaptor;
+  LogicalResult
+  matchAndRewrite(MooreOpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value array =
+        llhd::ProbeOp::create(rewriter, op.getLoc(), adaptor.getAssocArray());
+    Value curIndex =
+        llhd::ProbeOp::create(rewriter, op.getLoc(), adaptor.getIndex());
+    auto stepOp = SimOpTy::create(rewriter, op.getLoc(), array, curIndex);
+    Value delay = llhd::ConstantTimeOp::create(
+        rewriter, op.getLoc(),
+        getBlockingOrContinuousAssignDelay(rewriter.getContext()));
+    llhd::DriveOp::create(rewriter, op.getLoc(), adaptor.getIndex(),
+                          stepOp->getResult(1), delay, Value{});
+    rewriter.replaceOp(op, stepOp->getResult(0));
+    return success();
+  }
+};
+
+using AssocArrayFirstOpConversion =
+    AssocArrayEndpointOpConversion<AssocArrayFirstOp, sim::AssocArrayFirstOp>;
+using AssocArrayLastOpConversion =
+    AssocArrayEndpointOpConversion<AssocArrayLastOp, sim::AssocArrayLastOp>;
+using AssocArrayNextOpConversion =
+    AssocArrayStepOpConversion<AssocArrayNextOp, sim::AssocArrayNextOp>;
+using AssocArrayPrevOpConversion =
+    AssocArrayStepOpConversion<AssocArrayPrevOp, sim::AssocArrayPrevOp>;
+
 struct DisplayBIOpConversion : public OpConversionPattern<DisplayBIOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -3360,6 +3530,14 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
     return {};
   });
 
+  typeConverter.addConversion([&](AssocArrayType type) -> std::optional<Type> {
+    auto elementType = typeConverter.convertType(type.getElementType());
+    auto indexType = typeConverter.convertType(type.getIndexType());
+    if (!elementType || !indexType)
+      return {};
+    return sim::AssocArrayType::get(type.getContext(), elementType, indexType);
+  });
+
   // FIXME: Unpacked arrays support more element types than their packed
   // variants, and as such, mapping them to hw::Array is somewhat naive. See
   // also the analogous note below concerning unpacked struct type conversion.
@@ -3470,6 +3648,7 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
   typeConverter.addConversion([](FloatType type) { return type; });
   typeConverter.addConversion([](sim::DynamicStringType type) { return type; });
   typeConverter.addConversion([](sim::FormatStringType type) { return type; });
+  typeConverter.addConversion([](sim::AssocArrayType type) { return type; });
   typeConverter.addConversion([](llhd::TimeType type) { return type; });
   typeConverter.addConversion([](debug::ArrayType type) { return type; });
   typeConverter.addConversion([](debug::ScopeType type) { return type; });
@@ -3729,7 +3908,19 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     QueueSetOpConversion,
     QueueCmpOpConversion,
     QueueFromUnpackedArrayOpConversion,
-    QueueConcatOpConversion
+    QueueConcatOpConversion,
+
+    // Associative array operations
+    AssocArrayExtractOpConversion,
+    AssocArraySetOpConversion,
+    AssocArrayDeleteOpConversion,
+    AssocArrayClearOpConversion,
+    AssocArraySizeOpConversion,
+    AssocArrayExistsOpConversion,
+    AssocArrayFirstOpConversion,
+    AssocArrayLastOpConversion,
+    AssocArrayNextOpConversion,
+    AssocArrayPrevOpConversion
   >(typeConverter, patterns.getContext());
   // clang-format on
 

--- a/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
+++ b/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
@@ -122,6 +122,33 @@ struct QueueRefLowering : public OpConversionPattern<DynQueueRefElementOp> {
   }
 };
 
+struct AssocArrayRefLowering
+    : public OpConversionPattern<AssocArrayExtractRefOp> {
+  using OpConversionPattern<AssocArrayExtractRefOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(AssocArrayExtractRefOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    for (auto *consumer : op->getUsers()) {
+      if (isa<BlockingAssignOp>(consumer)) {
+        auto assignOp = cast<BlockingAssignOp>(consumer);
+        rewriter.setInsertionPoint(consumer);
+        moore::AssocArraySetOp::create(rewriter, op->getLoc(), op.getInput(),
+                                       op.getIndex(), assignOp.getSrc());
+        rewriter.eraseOp(assignOp);
+      } else {
+        return mlir::emitError(op.getLoc())
+               << "Associative array element reference couldn't be reduced "
+                  "to setting the value at an index: consuming op "
+               << consumer << " is not supported";
+      }
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct SimplifyRefsPass
     : public circt::moore::impl::SimplifyRefsBase<SimplifyRefsPass> {
   void runOnOperation() override;
@@ -161,5 +188,14 @@ void SimplifyRefsPass::runOnOperation() {
   queueRefPatterns.add<QueueRefLowering>(&context);
   if (failed(applyPartialConversion(getOperation(), target,
                                     std::move(queueRefPatterns))))
+    signalPassFailure();
+
+  // Once we have removed AssocArrayExtractRefOps, attempt to rewrite any
+  // associative array element references to assoc_array.set
+  RewritePatternSet assocArrayRefPatterns(&context);
+  target.addIllegalOp<AssocArrayExtractRefOp>();
+  assocArrayRefPatterns.add<AssocArrayRefLowering>(&context);
+  if (failed(applyPartialConversion(getOperation(), target,
+                                    std::move(assocArrayRefPatterns))))
     signalPassFailure();
 }

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -510,6 +510,18 @@ moore.module private @PreservePortOrder(in %x: !moore.i42, out y: !moore.i42, in
   moore.output %x : !moore.i42
 }
 
+// CHECK-LABEL: hw.module @AssocArrayInputPort
+// CHECK-SAME: (in %assoc_array_port : !sim.assoc_array<i32, !sim.dstring>)
+moore.module @AssocArrayInputPort(in %assoc_array_port : !moore.assoc_array<i32, string>) {
+  moore.output
+}
+
+// CHECK-LABEL: hw.module @MixedPortsWithAssocArray
+// CHECK-SAME: (in %valid : i1, in %data : !sim.assoc_array<i32, !sim.dstring>, out out : i1)
+moore.module @MixedPortsWithAssocArray(in %valid : !moore.l1, in %data : !moore.assoc_array<i32, string>, out out : !moore.l1) {
+  moore.output %valid : !moore.l1
+}
+
 // CHECK-LABEL: hw.module @Variable
 moore.module @Variable() {
   // CHECK: [[TMP0:%.+]] = hw.constant 0 : i32
@@ -1695,6 +1707,68 @@ func.func @QueueOperations(%arg0: !moore.i32, %arg1: !moore.i32) {
 
   // CHECK: [[CONCAT:%.+]] = sim.queue.concat ([[QR]], [[DIFFB]]) : (!sim.queue<i32, 10>, !sim.queue<i32, 0>) <i32, 5>
   %concatres = moore.queue.concat (%qr, %diffbounds) : (!moore.queue<i32, 10>, !moore.queue<i32, 0>) <i32, 5>
+
+  return
+}
+
+// CHECK-LABEL: func.func @AssocArrayOperations
+func.func @AssocArrayOperations(%arg0: !moore.i32, %arg1: !moore.i8) {
+  // CHECK: [[EMPTY:%.+]] = sim.assoc_array.empty : <i8, i32>
+  // CHECK: [[AA:%.+]] = llhd.sig [[EMPTY]] : !sim.assoc_array<i8, i32>
+  %aa = moore.variable : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[AAR:%.+]] = llhd.prb [[AA]]
+  %aar = moore.read %aa : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[ZERO:%.+]] = hw.constant 0 : i8
+  // CHECK: [[RAW:%.+]] = sim.assoc_array.get [[AAR]][%arg0] : <i8, i32>
+  // CHECK: [[FOUND:%.+]] = sim.assoc_array.exists %arg0 in [[AAR]] : <i8, i32>
+  // CHECK: [[C0:%.+]] = hw.constant 0 : i32
+  // CHECK: [[EXISTSBIT:%.+]] = comb.icmp ne [[FOUND]], [[C0]] : i32
+  // CHECK: [[EL:%.+]] = comb.mux [[EXISTSBIT]], [[RAW]], [[ZERO]] : i8
+  %el = moore.assoc_array_extract %aar[%arg0] : <i8, i32>
+
+  // CHECK: [[AAR2:%.+]] = llhd.prb [[AA]]
+  // CHECK: [[NEWAA:%.+]] = sim.assoc_array.set [[AAR2]][%arg0] = %arg1 : <i8, i32>
+  // CHECK: llhd.drv [[AA]], [[NEWAA]]
+  moore.assoc_array.set %aa[%arg0] = %arg1 : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[AAR3:%.+]] = llhd.prb [[AA]]
+  // CHECK: [[NEWAA2:%.+]] = sim.assoc_array.delete index %arg0 of [[AAR3]] : <i8, i32>
+  // CHECK: llhd.drv [[AA]], [[NEWAA2]]
+  moore.assoc_array.delete index %arg0 from %aa : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[NEWAA3:%.+]] = sim.assoc_array.empty : <i8, i32>
+  // CHECK: llhd.drv [[AA]], [[NEWAA3]]
+  moore.assoc_array.clear %aa : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[AAR4:%.+]] = llhd.prb [[AA]]
+  // CHECK: sim.assoc_array.size [[AAR4]] : <i8, i32>
+  moore.assoc_array.size %aa : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[AAR5:%.+]] = llhd.prb [[AA]]
+  // CHECK: sim.assoc_array.exists %arg0 in [[AAR5]] : <i8, i32>
+  moore.assoc_array.exists %arg0 in %aa : <!moore.assoc_array<i8, i32>>
+
+  %idx = moore.variable : <i32>
+
+  // CHECK: [[AAR6:%.+]] = llhd.prb [[AA]]
+  // CHECK: sim.assoc_array.first [[AAR6]] : <i8, i32>
+  moore.assoc_array.first to %idx from %aa : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[AAR7:%.+]] = llhd.prb [[AA]]
+  // CHECK: sim.assoc_array.last [[AAR7]] : <i8, i32>
+  moore.assoc_array.last to %idx from %aa : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[AAR8:%.+]] = llhd.prb [[AA]]
+  // CHECK: [[CURIDX1:%.+]] = llhd.prb
+  // CHECK: sim.assoc_array.next [[AAR8]][[[CURIDX1]]] : <i8, i32>
+  moore.assoc_array.next to %idx from %aa : <!moore.assoc_array<i8, i32>>
+
+  // CHECK: [[AAR9:%.+]] = llhd.prb [[AA]]
+  // CHECK: [[CURIDX2:%.+]] = llhd.prb
+  // CHECK: sim.assoc_array.prev [[AAR9]][[[CURIDX2]]] : <i8, i32>
+  moore.assoc_array.prev to %idx from %aa : <!moore.assoc_array<i8, i32>>
 
   return
 }

--- a/test/Conversion/MooreToCore/errors.mlir
+++ b/test/Conversion/MooreToCore/errors.mlir
@@ -1,14 +1,5 @@
 // RUN: circt-opt %s --convert-moore-to-core --split-input-file --verify-diagnostics
 
-func.func @invalidType() {
-  // expected-error @below {{failed to legalize operation 'moore.variable'}}
-  %var = moore.variable : <!moore.assoc_array<i32, i32>>
-
-  return
-}
-
-// -----
-
 func.func @dynamicArrayVariable() {
   // expected-error @below {{failed to legalize operation 'moore.variable'}}
   %var = moore.variable : <!moore.open_uarray<i32>>
@@ -53,17 +44,17 @@ func.func @unsupportedOpenArrayCastUnpackedToPacked(%arg0: !moore.uarray<8 x i8>
 
 // -----
 
-// expected-error @below {{port '"queue_port"' has unsupported type '!moore.assoc_array<i32, string>' that cannot be converted to hardware type}}
+// expected-error @below {{port '"e"' has unsupported type '!moore.event' that cannot be converted to hardware type}}
 // expected-error @below {{failed to legalize}}
-moore.module @UnsupportedInputPortType(in %queue_port : !moore.assoc_array<i32, string>) {
+moore.module @UnsupportedInputPortType(in %e : !moore.event) {
   moore.output
 }
 
 // -----
 
-// expected-error @below {{port '"data"' has unsupported type '!moore.assoc_array<i32, string>' that cannot be converted to hardware type}}
+// expected-error @below {{port '"data"' has unsupported type '!moore.event' that cannot be converted to hardware type}}
 // expected-error @below {{failed to legalize}}
-moore.module @MixedPortsWithUnsupported(in %valid : !moore.l1, in %data : !moore.assoc_array<i32, string>, out out : !moore.l1) {
+moore.module @MixedPortsWithUnsupported(in %valid : !moore.l1, in %data : !moore.event, out out : !moore.l1) {
   moore.output %valid : !moore.l1
 }
 

--- a/test/Dialect/Moore/simplify-refs.mlir
+++ b/test/Dialect/Moore/simplify-refs.mlir
@@ -115,3 +115,17 @@ moore.module @QueueRefsWithConcat() {
     moore.return
   }
 }
+
+// CHECK-LABEL: moore.module @AssocArrayRefs()
+moore.module @AssocArrayRefs() {
+  %aa = moore.variable : <assoc_array<i32, i32>>
+  moore.procedure initial {
+    %0 = moore.constant 0 : i32
+    %1 = moore.constant 1 : i32
+
+    // CHECK: moore.assoc_array.set %aa[%0] = %1 : <assoc_array<i32, i32>>
+    %el = moore.assoc_array_extract_ref %aa[%0] : <assoc_array<i32, i32>>
+    moore.blocking_assign %el, %1 : i32
+    moore.return
+  }
+}


### PR DESCRIPTION
ImportVerilog has been able to produce the Moore associative array ops (`assoc_array_extract[_ref]`, `.delete`, `.size`, `.exists`, `.first`, `.last`, `.next`, `.prev`), but `MooreToCore` had no lowering for them, so any design using an associative array failed to legalize.

**Fix:**
- Add a value-semantics `!sim.assoc_array<element, index>` type and the corresponding Sim ops (`empty`, `get`, `set`, `delete`, `size`, `exists`, `first`, `last`, `next`, `prev`), following the queue precedent.
- Convert `!moore.assoc_array` to `!sim.assoc_array` in `MooreToCore`, and lower the Moore ops by probing/driving the LLHD signal around the pure Sim ops.
- Fold `assoc_array_extract_ref` cosumed by blocking assignment into a new `moore.assoc_array.set` op, mirroring the existing queue handling in `SimplifyRefs`.

**Limitations:**
- Element references are only supported as blocking-assignment targets: no read-modify-write, pass-by-reference allocation, or nonblocking assignment to elements.
- Reads of missing entries return the zero value: no 4-state `'x` default, no user-specified `{default:}` value, and no runtime warning.
- Traversal-argument truncation returning `-1` is not supported. The index argument must match the index type exactly.