### PR TITLE
[MooreToCore] Legalize sim.queue as a target type to fix hierarchical  queue refs

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -3354,6 +3354,13 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
                                type.getBound());
   });
 
+  typeConverter.addConversion([&](sim::QueueType type) -> std::optional<Type> {
+    if (auto elementType = typeConverter.convertType(type.getElementType()))
+      return sim::QueueType::get(type.getContext(), elementType,
+                                 type.getBound());
+    return {};
+  });
+
   typeConverter.addConversion([&](ArrayType type) -> std::optional<Type> {
     if (auto elementType = typeConverter.convertType(type.getElementType()))
       return hw::ArrayType::get(elementType, type.getSize());

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -614,6 +614,24 @@ moore.module @UnpackedArray(in %arr : !moore.uarray<2 x i32>, in %sel : !moore.i
   moore.output %0 : !moore.i32
 }
 
+// CHECK-LABEL: hw.module private @QueueRefPort(out mem : !llhd.ref<!sim.queue<i8, 0>>)
+moore.module private @QueueRefPort(out mem : !moore.ref<queue<i8, 0>>) {
+  // CHECK: [[EMPTY:%.+]] = sim.queue.empty : <i8, 0>
+  // CHECK: [[SIG:%.+]] = llhd.sig [[EMPTY]] : !sim.queue<i8, 0>
+  %mem = moore.variable : <queue<i8, 0>>
+  // CHECK: hw.output [[SIG]] : !llhd.ref<!sim.queue<i8, 0>>
+  moore.output %mem : !moore.ref<queue<i8, 0>>
+}
+
+// CHECK-LABEL: hw.module @QueueHierRef()
+moore.module @QueueHierRef() {
+  // CHECK: [[INST:%.+]] = hw.instance "u_leaf" @QueueRefPort() -> (mem: !llhd.ref<!sim.queue<i8, 0>>)
+  %u_leaf.mem = moore.instance "u_leaf" @QueueRefPort() -> (mem: !moore.ref<queue<i8, 0>>)
+  // CHECK: llhd.prb [[INST]] : !sim.queue<i8, 0>
+  %0 = moore.read %u_leaf.mem : <queue<i8, 0>>
+  moore.output
+}
+
 // CHECK-LABEL: hw.module @Struct
 moore.module @Struct(in %a : !moore.i32, in %b : !moore.i32, in %arg0 : !moore.struct<{exp_bits: i32, man_bits: i32}>, in %arg1 : !moore.ref<!moore.struct<{exp_bits: i32, man_bits: i32}>>, out a : !moore.i32, out b : !moore.struct<{exp_bits: i32, man_bits: i32}>, out c : !moore.struct<{exp_bits: i32, man_bits: i32}>) {
   // CHECK: hw.struct_extract %arg0["exp_bits"] : !hw.struct<exp_bits: i32, man_bits: i32>


### PR DESCRIPTION
Hierarchical references to queue variables failed to legalize.

**For example:**
```
module leaf;
  bit [7:0] mem [$];
endmodule

module toy_hier_queue_port;
  leaf u_leaf ();
  initial begin
    $display("%0d", u_leaf.mem.size());
  end
endmodule
```

**Output:**
```
error: failed to legalize operation 'moore.module': "moore.module"() <{module_type = !hw.modty<output mem : !moore.ref<queue<i8, 0>>>, sym_name = "leaf", sym_visibility = "private"}> ({...}) : () -> ()
module leaf;
       ^
note: see current operation: "moore.module"() <{module_type = !hw.modty<output mem : !moore.ref<queue<i8, 0>>>, sym_name = "leaf", sym_visibility = "private"}> ({
  %0 = "moore.variable"() <{name = "mem"}> : () -> !moore.ref<queue<i8, 0>>
  "moore.output"(%0) : (!moore.ref<queue<i8, 0>>) -> ()
}) : () -> ()
```
`sim::QueueType` was missing from the type converter's target-type conversions, so the `hw.module` signature legality check failed to re-convert the nested `!sim.queue` type, making the newly created `hw.module` illegal.

**Fix:**
Register a target-type conversion for `sim::QueueType` in `populateTypeConversion` (`MooreToCore`), recursing into the element type, mirroring the existing container-type conversions (`hw::ArrayType`, `hw::StructType`).