### PR TITLE
[MooreToCore] Fix crash on variable of unsupported type with initialiser

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1164,13 +1164,14 @@ struct VariableOpConversion : public OpConversionPattern<VariableOp> {
     if (!resultType)
       return rewriter.notifyMatchFailure(op.getLoc(), "invalid variable type");
 
+    auto refType = dyn_cast<llhd::RefType>(resultType);
+    if (!refType)
+      return rewriter.notifyMatchFailure(
+          op.getLoc(), "variable type did not convert to llhd::RefType");
+
     // Determine the initial value of the signal.
     Value init = adaptor.getInitial();
     if (!init) {
-      auto refType = dyn_cast<llhd::RefType>(resultType);
-      if (!refType)
-        return rewriter.notifyMatchFailure(
-            op.getLoc(), "variable type did not convert to llhd::RefType");
       init = createZeroValue(refType.getNestedType(), loc, rewriter);
       if (!init)
         return failure();


### PR DESCRIPTION
CIRCT crashes with an assertion failure on a dynamic array variable that has an initializer.

The type converter lowers `!moore.ref<open_uarray<T>>` to `!llvm.ptr`, not to `!llhd.ref`. `VariableOpConversion` only verified that the converted type is an `llhd::RefType` in the no-initializer branch, where it is needed to build the zero init value. A variable with an initializer skipped that check and produced an `llhd.sig` with an invalid `!llvm.ptr` result type.
The subsequent `moore.read` lowering then built an `llhd.prb` on that value, and `ProbeOp::inferReturnTypes crashes on `cast<llhd::RefType>`.

**For example:**
```
module top ();
string s[] = { "hello", "sad", "world" };
initial begin
	$display(":assert: (('%s' == 'hello') and ('%s' == 'sad') and ('%s' == 'world'))",
		s[0], s[1], s[2]);
end
endmodule
```

**Output:**
```
Assertion failed: (isa<To>(Val) && "cast<Ty>() argument of incompatible type!"), function cast, file Casting.h, line 560.
```

This example comes from a simplified version of [TESTS](https://chipsalliance.github.io/sv-tests-results/?v=circt_verilog+7.4.2+ordering-methods-reverse), which currently fails on:
```
error: unsupported system call `reverse`
        s.reverse;
```
However, this seems to have already been the case for these tests, as shown in #8173.

**Fix:**
The `llhd::RefType` check out of the no-initializer branch so it applies unconditionally: whether a variable can lower to an `llhd.sig` depends only on its type, not on the presence of an initializer.
