### PR TITLE
[HWToLLVM] Use module's DLTI to determine !hw.union buffer size

### DIFF
--- a/include/circt/Conversion/HWToLLVM.h
+++ b/include/circt/Conversion/HWToLLVM.h
@@ -16,6 +16,7 @@
 
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Support/LLVM.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include <memory>
 
 namespace mlir {
@@ -71,7 +72,8 @@ private:
 };
 
 /// Get the HW to LLVM type conversions.
-void populateHWToLLVMTypeConversions(mlir::LLVMTypeConverter &converter);
+void populateHWToLLVMTypeConversions(mlir::LLVMTypeConverter &converter,
+                                     mlir::DataLayout &layout);
 
 /// Get the HW to LLVM conversion patterns.
 /// Note: The spill cache may only be used when conversion

--- a/integration_test/arcilator/JIT/issue-10809-union-size.mlir
+++ b/integration_test/arcilator/JIT/issue-10809-union-size.mlir
@@ -1,0 +1,27 @@
+// RUN: arcilator %s --run | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
+// Issue #10809
+
+// CHECK: 12345678
+
+!union_ty = !hw.union<r: !hw.struct<f0: i32, f1: i64>>
+
+func.func @tick(%u: !union_ty) -> (i32, i64) {
+  %s = hw.union_extract %u["r"] : !union_ty
+  %counter, %delta = hw.struct_explode %s : !hw.struct<f0: i32, f1: i64>
+  return %counter, %delta : i32, i64
+}
+
+func.func @entry() {
+  %endl = sim.fmt.literal "\n"
+  %c = hw.constant 0x12345678 : i32
+  %d = hw.constant 1000000 : i64
+  %s = hw.struct_create (%c, %d) : !hw.struct<f0: i32, f1: i64>
+  %u = hw.union_create "r", %s : !union_ty
+  %r:2 = func.call @tick(%u) : (!union_ty) -> (i32, i64)
+  %h = sim.fmt.hex %r#0, isUpper false : i32
+  %m = sim.fmt.concat (%h, %endl)
+  sim.proc.print %m
+  return
+}

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -41,6 +41,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/Support/Debug.h"
@@ -1894,8 +1895,9 @@ void LowerArcToLLVMPass::runOnOperation() {
   populateAnyFunctionOpInterfaceTypeConversionPattern(patterns, converter);
 
   // CIRCT patterns.
+  DataLayout layout = DataLayout::closest(getOperation());
   DenseMap<std::pair<Type, ArrayAttr>, LLVM::GlobalOp> constAggregateGlobalsMap;
-  populateHWToLLVMTypeConversions(converter);
+  populateHWToLLVMTypeConversions(converter, layout);
   std::optional<HWToLLVMArraySpillCache> spillCacheOpt =
       HWToLLVMArraySpillCache();
   {

--- a/lib/Conversion/ConvertToLLVM/ConvertToLLVM.cpp
+++ b/lib/Conversion/ConvertToLLVM/ConvertToLLVM.cpp
@@ -26,6 +26,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -61,9 +62,10 @@ void ConvertToLLVMPass::convertFuncOp(func::FuncOp funcOp) {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   auto converter = mlir::LLVMTypeConverter(context);
+  DataLayout layout = DataLayout::closest(funcOp);
 
   // Add HW to LLVM type conversions
-  populateHWToLLVMTypeConversions(converter);
+  populateHWToLLVMTypeConversions(converter, layout);
 
   LLVMConversionTarget target(*context);
   target.addIllegalDialect<comb::CombDialect>();

--- a/lib/Conversion/HWToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HWToLLVM/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_conversion_library(CIRCTHWToLLVM
   LINK_LIBS PUBLIC
   CIRCTHW
   CIRCTSupport
+  MLIRDataLayoutInterfaces
   MLIRFuncDialect
   MLIRFuncTransforms
   MLIRLLVMCommonConversion

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -871,8 +871,8 @@ static Type convertStructType(hw::StructType type,
 
 /// Convert a union to a flat byte buffer large enough to hold the LLVM
 /// representation of its widest member, including any alignment padding.
-static Type convertUnionType(hw::UnionType type, LLVMTypeConverter &converter) {
-  DataLayout layout;
+static Type convertUnionType(hw::UnionType type, DataLayout &layout,
+                             LLVMTypeConverter &converter) {
   uint64_t maxBytes = 0;
   for (auto field : type.getElements()) {
     auto llvmFieldTy = converter.convertType(field.type);
@@ -927,18 +927,21 @@ void circt::populateHWToLLVMConversionPatterns(
                                                                 spillCacheOpt);
 }
 
-void circt::populateHWToLLVMTypeConversions(LLVMTypeConverter &converter) {
+void circt::populateHWToLLVMTypeConversions(LLVMTypeConverter &converter,
+                                            DataLayout &layout) {
   converter.addConversion(
       [&](hw::ArrayType arr) { return convertArrayType(arr, converter); });
   converter.addConversion(
       [&](hw::StructType tup) { return convertStructType(tup, converter); });
-  converter.addConversion(
-      [&](hw::UnionType uni) { return convertUnionType(uni, converter); });
+  converter.addConversion([&](hw::UnionType uni) {
+    return convertUnionType(uni, layout, converter);
+  });
 }
 
 void HWToLLVMLoweringPass::runOnOperation() {
   DenseMap<std::pair<Type, ArrayAttr>, LLVM::GlobalOp> constAggregateGlobalsMap;
   std::optional<HWToLLVMArraySpillCache> spillCacheOpt = {};
+  DataLayout layout = DataLayout::closest(getOperation());
   Namespace globals;
   SymbolCache cache;
   cache.addDefinitions(getOperation());
@@ -946,7 +949,7 @@ void HWToLLVMLoweringPass::runOnOperation() {
 
   RewritePatternSet patterns(&getContext());
   auto converter = mlir::LLVMTypeConverter(&getContext());
-  populateHWToLLVMTypeConversions(converter);
+  populateHWToLLVMTypeConversions(converter, layout);
 
   if (spillArraysEarly) {
     spillCacheOpt = HWToLLVMArraySpillCache();

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --convert-hw-to-llvm=spill-arrays-early=false | FileCheck %s
+// RUN: circt-opt %s --split-input-file  --convert-hw-to-llvm=spill-arrays-early=false | FileCheck %s
 
 // CHECK-LABEL: @convertArray
 // CHECK-SAME: (%arg0: i1, %arg1: !llvm.array<2 x i32>,
@@ -243,4 +243,15 @@ func.func @issue9171(%idx: i1) -> i32 {
   // CHECK: return [[RETVAL]]
   %get = hw.array_get %cst[%idx] : !hw.array<2xi32>, i1
   return %get : i32
+}
+
+// -----
+
+// Check that the DLTI is considered when calculating the size for the union by over-aligning i64 to 16 byte.
+module attributes {dlti.dl_spec = #dlti.dl_spec<i64 = dense<128> : vector<2xi64>>} {
+  func.func @unionOfStructSize(%arg0: !hw.struct<foo: i64, bar: i64>, %arg1: !hw.union<s: !hw.struct<foo: i64, bar: i64>, i: i32>) {
+    // CHECK: llvm.alloca %{{.*}} x !llvm.array<32 x i8>
+    %0 = hw.union_create "s", %arg0 : !hw.union<s: !hw.struct<foo: i64, bar: i64>, i: i32>
+    return
+  }
 }


### PR DESCRIPTION
Stop using the default DataLayout when calculating the size of the alloca'd buffers for !hw.union typed values and let the passes provide the DataLayout when populating the type conversion patterns instead.

Usually DataLayout should be provided by DLTI on the enclosing MLIR module. Note that if the DLTI attribute is missing, DataLayout will fall back to the default layout. Crucially, this specifies the ABI alignment of `i64` as 4 bytes (`kDefaultSmallIntAlignment`). Common 64-bit architectures use 8 bytes instead. This mismatch can lead to insufficient space being allocated for non-packed struct variants containing `i64` values.

Fixes #10809 