### PR TITLE
[MooreToCore][Sim] Add lowering for moore.string_to_int

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -772,6 +772,22 @@ def IntToStringOp: SimOp<"string.int_to_string", [Pure]> {
   let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
 }
 
+def StringToIntOp : SimOp<"string.string_to_int", [Pure]> {
+  let summary = "Convert a string into an integer";
+  let description = [{
+    Packs the characters of a string into a big-endian bit sequence, one
+    byte per character, with the last character forming the
+    least-significant bits of the sequence. That sequence is then fit to
+    the result width: zero-extended on the most-significant end if the
+    result is wider, or truncated from the most-significant end if it is
+    narrower.
+  }];
+  let arguments = (ins DynamicStringType:$input);
+  let results = (outs AnyInteger:$result);
+
+  let assemblyFormat = "$input attr-dict `:` qualified(type($result))";
+}
+
 def FormatToStringOp : SimOp<"string.format_to_string", [ProceduralOp]> {
   let summary = "Create a dynamic string by evaluating a format string";
   let description = [{

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2100,6 +2100,21 @@ struct IntToStringOpConversion : public OpConversionPattern<IntToStringOp> {
   }
 };
 
+struct StringToIntOpConversion : public OpConversionPattern<StringToIntOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StringToIntOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultTy = typeConverter->convertType(op.getType());
+    if (!resultTy)
+      return failure();
+    rewriter.replaceOpWithNewOp<sim::StringToIntOp>(op, resultTy,
+                                                    adaptor.getInput());
+    return success();
+  }
+};
+
 struct FormatStringToStringOpConversion
     : public OpConversionPattern<FormatStringToStringOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -3601,6 +3616,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     SIntToRealOpConversion,
     UIntToRealOpConversion,
     IntToStringOpConversion,
+    StringToIntOpConversion,
     FormatStringToStringOpConversion,
     RealToIntOpConversion,
     ConvertRealOpConversion,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1563,6 +1563,13 @@ func.func @IntToStringConversion(%arg0: !moore.i45) {
   return
 }
 
+// CHECK-LABEL: func.func @StringToIntConversion
+func.func @StringToIntConversion(%arg0: !moore.string) {
+  // CHECK-NEXT: sim.string.string_to_int %arg0 : i45
+  moore.string_to_int %arg0 : i45
+  return
+}
+
 // CHECK-LABEL: func.func @FormatStringToStringConversion
 func.func @FormatStringToStringConversion(%arg0: !moore.format_string) {
   // CHECK-NEXT: sim.string.format_to_string %arg0

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -99,6 +99,8 @@ func.func @DynamicStrings(%idx: i32) {
   %concat = sim.string.concat (%str, %str)
   // CHECK: sim.string.get
   %char = sim.string.get %str[%idx]
+  // CHECK: sim.string.string_to_int
+  %int = sim.string.string_to_int %str : i32
   return
 }
 


### PR DESCRIPTION
ImportVerilog already produces `moore.string_to_int` for string to integer casts, but `MooreToCore` had no lowering pattern for it, so any design performing this cast failed to legalize.

**For example:**
```
module t;
  string s;
  int v;
  initial v = int'(s);
endmodule
```

**Output:**
```
error: failed to legalize operation 'moore.string_to_int': %8 = "moore.string_to_int"(%7) : (!moore.string) -> !moore.i32
  initial v = int'(s);
                   ^
note: see current operation: %8 = "moore.string_to_int"(%7) : (!moore.string) -> !moore.i32
```
**Fix:**
Add `sim.string.string_to_int`, the missing counterpart to the existing `sim.string.int_to_string`, and add `StringToIntConversion` in `MooreToCore` to lower `moore.string_to_int` to the new Sim op.