### PR TITLE
[ImportVerilog] Support default clocking blocks and procedural sampled value functions

### DIFF
--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -371,7 +371,8 @@ Value Context::convertSampledValueCallExpression(
     const slang::ast::CallExpression::SystemCallInfo &info, Location loc) {
   const auto clockIt = sampledValueCallClocks.find(&expr);
   if (clockIt == sampledValueCallClocks.end()) {
-    mlir::emitError(loc, "couldn't infer clock for sampled value function");
+    mlir::emitError(loc) << "could not determine clocking event for `"
+                         << expr.getSubroutineName() << "`";
     return {};
   }
 

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -376,7 +376,7 @@ Value Context::convertSampledValueCallExpression(
     clock = clockIt->second;
 
   // Non-procedural expressions don't have a clock registered in
-  // assertionCallClocks but we can get it from their scope's default clock
+  // sampledValueCallClocks but we can get it from their scope's default clock
   if (!clock && !info.scope->isProceduralContext())
     if (auto defClk =
             info.scope->getCompilation().getDefaultClocking(*info.scope))

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -369,20 +369,30 @@ FailureOr<Value> Context::convertSampledValueCallArity1(
 Value Context::convertSampledValueCallExpression(
     const slang::ast::CallExpression &expr,
     const slang::ast::CallExpression::SystemCallInfo &info, Location loc) {
-  const auto clockIt = sampledValueCallClocks.find(&expr);
-  if (clockIt == sampledValueCallClocks.end()) {
+
+  const slang::ast::TimingControl *clock = nullptr;
+  auto clockIt = sampledValueCallClocks.find(&expr);
+  if (clockIt != sampledValueCallClocks.end())
+    clock = clockIt->second;
+
+  // Non-procedural expressions don't have a clock registered in
+  // assertionCallClocks but we can get it from their scope's default clock
+  if (!clock && !info.scope->isProceduralContext())
+    if (auto defClk =
+            info.scope->getCompilation().getDefaultClocking(*info.scope))
+      clock = &defClk->as<slang::ast::ClockingBlockSymbol>().getEvent();
+
+  if (!clock) {
     mlir::emitError(loc) << "could not determine clocking event for `"
                          << expr.getSubroutineName() << "`";
     return {};
   }
 
-  const slang::ast::TimingControl &clock = *clockIt->second;
-
   Value clockVal;
   const slang::ast::SignalEventControl *signal = nullptr;
-  if (clock.kind == slang::ast::TimingControlKind::SignalEvent) {
-    signal = &clock.as<slang::ast::SignalEventControl>();
-  } else if (clock.kind == slang::ast::TimingControlKind::EventList) {
+  if (clock->kind == slang::ast::TimingControlKind::SignalEvent) {
+    signal = &clock->as<slang::ast::SignalEventControl>();
+  } else if (clock->kind == slang::ast::TimingControlKind::EventList) {
     mlir::emitError(loc, "sampled value functions with multiple event "
                          "triggers are not supported");
     return {};

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -301,7 +301,7 @@ struct AssertionExprVisitor {
 };
 } // namespace
 
-FailureOr<Value> Context::convertAssertionSystemCallArity1(
+FailureOr<Value> Context::convertSampledValueCallArity1(
     const slang::ast::SystemSubroutine &subroutine, Location loc, Value value,
     Type originalType, Value clockVal) {
   using ksn = slang::parsing::KnownSystemName;
@@ -366,40 +366,39 @@ FailureOr<Value> Context::convertAssertionSystemCallArity1(
   }
 }
 
-Value Context::convertAssertionCallExpression(
+Value Context::convertSampledValueCallExpression(
     const slang::ast::CallExpression &expr,
     const slang::ast::CallExpression::SystemCallInfo &info, Location loc) {
+  const auto clockIt = sampledValueCallClocks.find(&expr);
+  if (clockIt == sampledValueCallClocks.end()) {
+    mlir::emitError(loc, "couldn't infer clock for sampled value function");
+    return {};
+  }
 
-  const slang::ast::TimingControl *clock = nullptr;
-  auto clockIt = assertionCallClocks.find(&expr);
-  if (clockIt != assertionCallClocks.end())
-    clock = clockIt->second;
+  const slang::ast::TimingControl &clock = *clockIt->second;
 
   Value clockVal;
-  if (clock) {
-    const slang::ast::SignalEventControl *signal = nullptr;
-    if (clock->kind == slang::ast::TimingControlKind::SignalEvent) {
-      signal = &clock->as<slang::ast::SignalEventControl>();
-    } else if (clock->kind == slang::ast::TimingControlKind::EventList) {
-      mlir::emitError(loc, "sampled value functions with multiple event "
-                           "triggers are not supported");
-      return {};
-    } else {
-      llvm_unreachable("unexpected clock kind for assertion");
-    }
-
-    if (signal->edge != slang::ast::EdgeKind::PosEdge) {
-      mlir::emitError(
-          loc,
-          "sampled value functions are only supported with posedge clocks");
-      return {};
-    }
-    clockVal = convertRvalueExpression(signal->expr);
-    if (clockVal)
-      clockVal = convertToI1(clockVal);
-    if (!clockVal)
-      return {};
+  const slang::ast::SignalEventControl *signal = nullptr;
+  if (clock.kind == slang::ast::TimingControlKind::SignalEvent) {
+    signal = &clock.as<slang::ast::SignalEventControl>();
+  } else if (clock.kind == slang::ast::TimingControlKind::EventList) {
+    mlir::emitError(loc, "sampled value functions with multiple event "
+                         "triggers are not supported");
+    return {};
+  } else {
+    llvm_unreachable("unexpected clock kind for assertion");
   }
+
+  if (signal->edge != slang::ast::EdgeKind::PosEdge) {
+    mlir::emitError(
+        loc, "sampled value functions are only supported with posedge clocks");
+    return {};
+  }
+  clockVal = convertRvalueExpression(signal->expr);
+  if (clockVal)
+    clockVal = convertToI1(clockVal);
+  if (!clockVal)
+    return {};
 
   const auto &subroutine = *info.subroutine;
   auto args = expr.arguments();
@@ -429,8 +428,8 @@ Value Context::convertAssertionCallExpression(
     intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
     if (!intVal)
       return {};
-    result = this->convertAssertionSystemCallArity1(subroutine, loc, intVal,
-                                                    originalType, clockVal);
+    result = this->convertSampledValueCallArity1(subroutine, loc, intVal,
+                                                 originalType, clockVal);
     break;
 
   default:
@@ -486,7 +485,7 @@ struct AssertionClockVisitor
 
   void handle(const slang::ast::CallExpression &node) {
     if (currentClock)
-      context.assertionCallClocks[&node] = currentClock;
+      context.sampledValueCallClocks[&node] = currentClock;
     visitDefault(node);
   }
 
@@ -502,12 +501,18 @@ struct AssertionClockVisitor
 };
 } // namespace
 
-void Context::populateAssertionClocks() {
+void Context::populateSampledValueClocks() {
   compilation.freeze();
   slang::analysis::AnalysisManager am;
   am.addListener([this](const slang::analysis::AnalyzedAssertion &assertion) {
     AssertionClockVisitor visitor{*this, assertion};
     assertion.getRoot().visit(visitor);
+  });
+  // AnalyzedProcedure captures both procedures and continuous assignments
+  am.addListener([this](const slang::analysis::AnalyzedProcedure &procedure) {
+    if (const auto clock = procedure.getInferredClock())
+      for (const auto *call : procedure.getCallExpressions())
+        sampledValueCallClocks[call] = clock;
   });
   am.analyze(compilation);
   compilation.unfreeze();

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2112,8 +2112,7 @@ struct RvalueExprVisitor : public ExprVisitor {
     auto nameId = subroutine.knownNameId;
 
     // $rose, $fell, $stable, $changed, $past, and $sampled are only valid in
-    // the context of properties and assertions. Those are treated in the
-    // LTLDialect; treat them there instead.
+    // the contexts with clocks. Those are treated in AssertionExpr.
     switch (nameId) {
     case ksn::Rose:
     case ksn::Fell:
@@ -2121,7 +2120,7 @@ struct RvalueExprVisitor : public ExprVisitor {
     case ksn::Changed:
     case ksn::Past:
     case ksn::Sampled:
-      return context.convertAssertionCallExpression(expr, info, loc);
+      return context.convertSampledValueCallExpression(expr, info, loc);
     default:
       break;
     }

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -300,13 +300,14 @@ struct Context {
     return currentThisRef; // block arg added in declareFunction
   }
 
-  /// Maps assertion system calls to their corresponding clocks
+  /// Maps sampled value system calls to their corresponding clocks
   DenseMap<const slang::ast::CallExpression *,
            const slang::ast::TimingControl *>
-      assertionCallClocks;
+      sampledValueCallClocks;
 
-  /// Generates a map from assertions to clocks using Slang's analysis
-  void populateAssertionClocks();
+  /// Generates a map from sampled value system calls to clocks using Slang's
+  /// analysis
+  void populateSampledValueClocks();
 
   Value getIndexedQueue() const { return currentQueue; }
 
@@ -322,8 +323,8 @@ struct Context {
   Value convertAssertionExpression(const slang::ast::AssertionExpr &expr,
                                    Location loc);
 
-  // Convert an assertion expression AST node to MLIR ops.
-  Value convertAssertionCallExpression(
+  // Convert a sampled value system call expression AST node to MLIR ops.
+  Value convertSampledValueCallExpression(
       const slang::ast::CallExpression &expr,
       const slang::ast::CallExpression::SystemCallInfo &info, Location loc);
 
@@ -445,11 +446,11 @@ struct Context {
                           Location loc,
                           std::span<const slang::ast::Expression *const> args);
 
-  /// Convert system function calls within properties and assertion with a
-  /// single argument.
-  FailureOr<Value> convertAssertionSystemCallArity1(
-      const slang::ast::SystemSubroutine &subroutine, Location loc, Value value,
-      Type originalType, Value clockVal);
+  /// Convert sampled value system function calls with a single argument.
+  FailureOr<Value>
+  convertSampledValueCallArity1(const slang::ast::SystemSubroutine &subroutine,
+                                Location loc, Value value, Type originalType,
+                                Value clockVal);
 
   /// Evaluate the constant value of an expression.
   slang::ConstantValue evaluateConstant(const slang::ast::Expression &expr);

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -947,6 +947,12 @@ struct ModuleVisitor : public BaseVisitor {
     return success();
   }
 
+  // Ignore clocking blocks. The clocking is already inferred by slang at
+  // each use.
+  LogicalResult visit(const slang::ast::ClockingBlockSymbol &) {
+    return success();
+  }
+
   // Ignore let declarations. Slang expands uses into AssertionInstance
   // expressions, which are lowered when the use site is imported.
   LogicalResult visit(const slang::ast::LetDeclSymbol &) { return success(); }
@@ -1244,7 +1250,7 @@ LogicalResult Context::convertCompilation() {
 
   // Analyze the compilation to infer clocks for assertion system calls
   // using Slang's LRM clock inference.
-  populateAssertionClocks();
+  populateSampledValueClocks();
 
   // Visit all top-level declarations in all compilation units. This does not
   // include instantiable constructs like modules, interfaces, and programs,

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -410,7 +410,7 @@ Value VariableOp::getDefaultValue(const MemorySlot &slot, OpBuilder &builder) {
       builder, getLoc(),
       IntType::get(getContext(), *bitWidth, packedType.getDomain()), fvint);
   if (value.getType() != packedType)
-    SBVToPackedOp::create(builder, getLoc(), packedType, value);
+    value = SBVToPackedOp::create(builder, getLoc(), packedType, value);
   return value;
 }
 

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -850,6 +850,32 @@ module SampleValueBuiltinsDefaultClocking #() (
   always_ff @(posedge clk2_i) clk2_assign_past <= $past(data_i);
 endmodule
 
+// IEEE 1800-2023 § 16.9.3 "Sampled value functions" with default clocking
+// outside of procedures
+// CHECK-LABEL: moore.module @SampleValueBuiltinsDefaultClockingNoProcedure(
+// CHECK-SAME: in [[CLK:%.+]] : !moore.l1
+module SampleValueBuiltinsDefaultClockingNoProcedure #() (
+    input clk_i,
+    input [7:0] data_i
+);
+  // CHECK: [[CLKWIRE:%.+]] = moore.net name "clk_i" wire : <l1>
+  // CHECK: [[DATAWIRE:%.+]] = moore.net name "data_i" wire : <l8>
+  // CHECK: [[WIRE_PAST:%.+]] = moore.net wire [[WIRE_PAST_VAL:%.+]] : <l8>
+
+  default clocking @(posedge clk_i); endclocking
+
+  // CHECK: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
+  // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
+  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D1_INT:%.+]] = moore.logic_to_int [[D1]] : l8
+  // CHECK-NEXT: [[DB:%.+]] = moore.to_builtin_int [[D1_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 1 clk [[CLK_I1]] : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[WIRE_PAST_VAL:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  wire [7:0] wire_past = $past(data_i);
+endmodule
+
 // CHECK-LABEL: func.func private @BitVectorPackedBuiltins(
 // CHECK-SAME: [[S:%[^ ,]+]]: !moore.struct<{a: l4, b: l4}>,
 // CHECK-SAME: [[A:%[^ ,]+]]: !moore.array<2 x l4>)

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -622,6 +622,25 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[D1]], [[PAST_LOGIC]] : l8 -> l1
   past_data: assert property (@(posedge clk_i) data_i == $past(data_i));
 
+  // Test $past in a process
+  // CHECK: moore.procedure always {
+  // CHECK-NEXT: moore.wait_event {
+  // CHECK-NEXT:   [[CLKEDGE:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK-NEXT:   moore.detect_event posedge [[CLKEDGE]] : l1
+  // CHECK-NEXT: }
+  // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
+  // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
+  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D1_INT:%.+]] = moore.logic_to_int [[D1]] : l8
+  // CHECK-NEXT: [[DB:%.+]] = moore.to_builtin_int [[D1_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 1 clk [[CLK_I1]] : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  // CHECK-NEXT: moore.nonblocking_assign {{%.+}}, [[PAST_LOGIC]] : l8
+  logic [7:0] past_data_i;
+  always @(posedge clk_i) past_data_i <= $past(data_i);
+
   // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK: [[RED:%.+]] = moore.reduce_xor [[D]] : l8 -> l1
@@ -734,6 +753,101 @@ module SampleValueBuiltins #() (
   // CHECK: [[EQ:%.+]] = moore.eq [[SEXT]], [[ZERO]] : i32 -> i1
   countones_bit_data:
     assert property (@(posedge clk_i) $countones(data_bit_i) == 0);
+endmodule
+
+// IEEE 1800-2023 § 16.9.3 "Sampled value functions" with default clocking
+// This is in a separate module to SampleValueBuiltins as default clocking
+// silently propagates to all potential users in the scope.
+// CHECK-LABEL: moore.module @SampleValueBuiltinsDefaultClocking(
+// CHECK-SAME: in [[CLK:%.+]] : !moore.l1
+module SampleValueBuiltinsDefaultClocking #() (
+    input clk_i,
+    input clk2_i,
+    input [7:0] data_i
+);
+  // CHECK: [[CLKWIRE:%.+]] = moore.net name "clk_i" wire : <l1>
+  // CHECK: [[CLK2WIRE:%.+]] = moore.net name "clk2_i" wire : <l1>
+  // CHECK: [[DATAWIRE:%.+]] = moore.net name "data_i" wire : <l8>
+
+  default clocking @(posedge clk_i); endclocking
+
+  // Test default clocking inference for $past in an assertion
+  // CHECK: moore.procedure always {
+  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
+  // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
+  // CHECK-NEXT: [[D2:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D2_INT:%.+]] = moore.logic_to_int [[D2]] : l8
+  // CHECK-NEXT: [[DB:%.+]] = moore.to_builtin_int [[D2_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 1 clk [[CLK_I1]] : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[D1]], [[PAST_LOGIC]] : l8 -> l1
+  assert_past: assert property (data_i == $past(data_i));
+
+  // Test overriden clock in an assertion
+  // CHECK: moore.procedure always {
+  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLK2WIRE]] : <l1>
+  // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
+  // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
+  // CHECK-NEXT: [[D2:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D2_INT:%.+]] = moore.logic_to_int [[D2]] : l8
+  // CHECK-NEXT: [[DB:%.+]] = moore.to_builtin_int [[D2_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 1 clk [[CLK_I1]] : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[D1]], [[PAST_LOGIC]] : l8 -> l1
+  assert_past_clk2: assert property (@(posedge clk2_i) data_i == $past(data_i));
+
+  // Test default clocking inference for $past in a continuous assignment
+  // CHECK: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
+  // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
+  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D1_INT:%.+]] = moore.logic_to_int [[D1]] : l8
+  // CHECK-NEXT: [[DB:%.+]] = moore.to_builtin_int [[D1_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 1 clk [[CLK_I1]] : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  // CHECK-NEXT: moore.assign {{%.+}}, [[PAST_LOGIC]] : l8
+  logic [7:0] assign_past;
+  assign assign_past = $past(data_i);
+
+  // Test default clocking inference for $past in a combinational procedure
+  // CHECK: moore.procedure always_comb {
+  // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
+  // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
+  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D1_INT:%.+]] = moore.logic_to_int [[D1]] : l8
+  // CHECK-NEXT: [[DB:%.+]] = moore.to_builtin_int [[D1_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 1 clk [[CLK_I1]] : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  // CHECK-NEXT: moore.blocking_assign {{%.+}}, [[PAST_LOGIC]] : l8
+  logic [7:0] comb_assign_past;
+  always_comb comb_assign_past = $past(data_i);
+
+  // Test overriden clock for $past in a procedure
+  // CHECK: moore.procedure always_ff {
+  // CHECK-NEXT: moore.wait_event {
+  // CHECK-NEXT:   [[CLKEDGE:%.+]] = moore.read [[CLK2WIRE]] : <l1>
+  // CHECK-NEXT:   moore.detect_event posedge [[CLKEDGE]] : l1
+  // CHECK-NEXT: }
+  // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLK2WIRE]] : <l1>
+  // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
+  // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
+  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK-NEXT: [[D1_INT:%.+]] = moore.logic_to_int [[D1]] : l8
+  // CHECK-NEXT: [[DB:%.+]] = moore.to_builtin_int [[D1_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 1 clk [[CLK_I1]] : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  // CHECK-NEXT: moore.nonblocking_assign {{%.+}}, [[PAST_LOGIC]] : l8
+  logic [7:0] clk2_assign_past;
+  always_ff @(posedge clk2_i) clk2_assign_past <= $past(data_i);
 endmodule
 
 // CHECK-LABEL: func.func private @BitVectorPackedBuiltins(

--- a/test/Dialect/Moore/mem2reg.mlir
+++ b/test/Dialect/Moore/mem2reg.mlir
@@ -46,3 +46,13 @@ func.func @InitialValueDoesNotDominateDefault() {
   moore.blocking_assign %1, %2 : i32
   cf.br ^bb1
 }
+
+// CHECK-LABEL: func.func @StructDefaultValue(
+// CHECK-NEXT: [[DEFAULT:%.+]] = moore.constant hXXXXXX : l24
+// CHECK-NEXT: [[PACKED:%.+]] = moore.sbv_to_packed [[DEFAULT]] : struct<{a: l8, b: l16}>
+// CHECK-NEXT: return [[PACKED]] : !moore.struct<{a: l8, b: l16}>
+func.func @StructDefaultValue() -> !moore.struct<{a: l8, b: l16}> {
+  %0 = moore.variable : <struct<{a: l8, b: l16}>>
+  %1 = moore.read %0 : <struct<{a: l8, b: l16}>>
+  return %1 : !moore.struct<{a: l8, b: l16}>
+}


### PR DESCRIPTION
`default clocking` blocks set a default clock edge for assertions and sampled value functions (`$past`, `$rose`, etc.) which can appear both in assertions as well as continuous assignments, procedures and non-procedural contexts (like `wire a = $past(b)`).

Slang already computes clock inference for assertions and sampled value functions that takes `default clocking` into account. This PR makes use of this by ignoring `ClockingBlockSymbol`s, and extending the use of Slang's analysis manager to also extract clock inference results for sampled value functions in procedures and continuous assignments. For non-procedural contexts, we fall back to looking up if there is a default clocking for the scope.

This PR additionally renames methods/values that refer to "assertion calls" to "sampled value calls", as they are only relevant/used in the context of sampled value system function calls and can appear outside assertions.

One thing I would appreciate opinions about is whether we should actually be lowering to `ltl.past` outside of assertion contexts, as it is slightly weird to end up with an `ltl.past` rather than a register in a procedure or continuous assignment.