### PR TITLE
[Moore] Fix VariableOp::getDefaultValue for packed types

### DIFF
--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -410,7 +410,7 @@ Value VariableOp::getDefaultValue(const MemorySlot &slot, OpBuilder &builder) {
       builder, getLoc(),
       IntType::get(getContext(), *bitWidth, packedType.getDomain()), fvint);
   if (value.getType() != packedType)
-    SBVToPackedOp::create(builder, getLoc(), packedType, value);
+    value = SBVToPackedOp::create(builder, getLoc(), packedType, value);
   return value;
 }
 

--- a/test/Dialect/Moore/mem2reg.mlir
+++ b/test/Dialect/Moore/mem2reg.mlir
@@ -46,3 +46,13 @@ func.func @InitialValueDoesNotDominateDefault() {
   moore.blocking_assign %1, %2 : i32
   cf.br ^bb1
 }
+
+// CHECK-LABEL: func.func @StructDefaultValue(
+// CHECK-NEXT: [[DEFAULT:%.+]] = moore.constant hXXXXXX : l24
+// CHECK-NEXT: [[PACKED:%.+]] = moore.sbv_to_packed [[DEFAULT]] : struct<{a: l8, b: l16}>
+// CHECK-NEXT: return [[PACKED]] : !moore.struct<{a: l8, b: l16}>
+func.func @StructDefaultValue() -> !moore.struct<{a: l8, b: l16}> {
+  %0 = moore.variable : <struct<{a: l8, b: l16}>>
+  %1 = moore.read %0 : <struct<{a: l8, b: l16}>>
+  return %1 : !moore.struct<{a: l8, b: l16}>
+}


### PR DESCRIPTION
`VariableOp::getDefaultValue` first creates an SBV integer of the correct width, which it then needs to cast if the variable type is not a simple integer. Although the `SBVToPackedOp` needed was created, it was not actually being returned.