### PR TITLE
[ImportVerilog] Support packed aggregate arguments to sampled value functions

### DIFF
--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -416,9 +416,20 @@ Value Context::convertAssertionCallExpression(
     originalType = value.getType();
     valTy = dyn_cast<moore::IntType>(value.getType());
     if (!valTy) {
-      mlir::emitError(loc) << "expected integer argument for `"
-                           << subroutine.name << "`";
-      return {};
+      if (!isa<moore::PackedType>(value.getType())) {
+        mlir::emitError(loc)
+            << "expected integer argument for `" << subroutine.name << "`";
+        return {};
+      }
+      value = materializePackedToSBVConversion(value, loc, /*fallible=*/false);
+      if (!value)
+        return {};
+      valTy = dyn_cast<moore::IntType>(value.getType());
+      if (!valTy) {
+        mlir::emitError(loc)
+            << "expected integer argument for `" << subroutine.name << "`";
+        return {};
+      }
     }
 
     // If the value is four-valued, we need to map it to two-valued before we

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2970,15 +2970,11 @@ Value Context::convertToSimpleBitVector(Value value) {
   return {};
 }
 
-/// Create the necessary operations to convert from a `PackedType` to the
-/// corresponding simple bit vector `IntType`. This will apply special handling
-/// to time values, which requires scaling by the local timescale.
-static Value materializePackedToSBVConversion(Context &context, Value value,
-                                              Location loc, bool fallible) {
+Value Context::materializePackedToSBVConversion(Value value, Location loc,
+                                                bool fallible) {
   if (isa<moore::IntType>(value.getType()))
     return value;
 
-  auto &builder = context.builder;
   auto packedType = cast<moore::PackedType>(value.getType());
   auto intType = packedType.getSimpleBitVector();
   assert(intType);
@@ -2989,7 +2985,7 @@ static Value materializePackedToSBVConversion(Context &context, Value value,
       moore::isIntType(intType, 64, moore::Domain::FourValued)) {
     value = builder.createOrFold<moore::TimeToLogicOp>(loc, value);
     auto scale = moore::ConstantOp::create(builder, loc, intType,
-                                           getTimeScaleInFemtoseconds(context));
+                                           getTimeScaleInFemtoseconds(*this));
     return builder.createOrFold<moore::DivUOp>(loc, value, scale);
   }
 
@@ -3095,7 +3091,7 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
 
   if (dstInt && srcInt) {
     // Convert the value to a simple bit vector if it isn't one already.
-    value = materializePackedToSBVConversion(*this, value, loc, fallible);
+    value = materializePackedToSBVConversion(value, loc, fallible);
     if (!value)
       return {};
 
@@ -3396,7 +3392,7 @@ Value Context::convertSystemCall(
         mlir::emitError(loc) << "expected integer argument for `$isunknown`";
         return {};
       }
-      value = materializePackedToSBVConversion(*this, value, loc,
+      value = materializePackedToSBVConversion(value, loc,
                                                /*fallible=*/false);
       if (!value)
         return {};
@@ -3416,7 +3412,7 @@ Value Context::convertSystemCall(
             << "expected integer argument for `$onehot`/`$onehot0`";
         return {};
       }
-      value = materializePackedToSBVConversion(*this, value, loc,
+      value = materializePackedToSBVConversion(value, loc,
                                                /*fallible=*/false);
       if (!value)
         return {};
@@ -3477,7 +3473,7 @@ Value Context::convertSystemCall(
         mlir::emitError(loc) << "expected integer argument for `$countones`";
         return {};
       }
-      value = materializePackedToSBVConversion(*this, value, loc,
+      value = materializePackedToSBVConversion(value, loc,
                                                /*fallible=*/false);
       if (!value)
         return {};

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -382,6 +382,14 @@ struct Context {
   /// if the given value is null.
   Value convertToSimpleBitVector(Value value);
 
+  /// Helper function to convert a `PackedType` value to its simple bit
+  /// vector representation, with special handling for time values which
+  /// require scaling by the local timescale. If `fallible` is true,
+  /// conversion failures are reported by returning a null value without
+  /// emitting diagnostics.
+  Value materializePackedToSBVConversion(Value value, Location loc,
+                                         bool fallible);
+
   /// Helper function to insert the necessary operations to cast a value from
   /// one type to another. If `fallible` is true, conversion failures are
   /// reported by returning a null value without emitting diagnostics.


### PR DESCRIPTION
$past, $rose, $fell, $stable, and $changed share a single conversion path that required their argument to already be a `moore::IntType`. A packed struct/array argument failed this check, so any assertion using $past (etc.) on a packed aggregate failed to legalize.

**For example:**
```
typedef struct packed {
  logic [5:0] field;
} mystruct;

module top(
  input logic clk,
  input mystruct data,
  output mystruct out
);

assert property (@(posedge clk) $past(data));
assert property (@(posedge clk) $rose(data));
assert property (@(posedge clk) $fell(data));
assert property (@(posedge clk) $stable(data));
assert property (@(posedge clk) $changed(data));

endmodule
```

**Output:**
```
error: expected integer argument for `$past`
assert property (@(posedge clk) $past(data));
                                                        ^
```

**Fix:**
`$isunknow`, `$onehot`/`$onehot0`, and `$countones` already handle this by falling back to `materializePackedToSBVConversion`when the argument isn't already an integer. Apply the same  fallback to sampled value functions. Since that helper was `static` and local to `Expression.cpp`, promote it to a `Context::` member method so it  can be shared across translation units, and update its four existing call sites accordingly.