### PR TITLE
[ExportVerilog] Fix precedence of equality operators

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2532,8 +2532,12 @@ SubExprInfo ExprEmitter::emitBinary(Operation *op, VerilogPrecedence prec,
   auto operandSignReq =
       SubExprSignRequirement(emitBinaryFlags & EB_OperandSignRequirementMask);
   auto lhsInfo = emitSubExpr(op->getOperand(0), prec, operandSignReq);
-  // Bit of a kludge: if this is a comparison, don't break on either side.
-  auto lhsSpace = prec == VerilogPrecedence::Comparison ? PP::nbsp : PP::space;
+  // Bit of a kludge: if this is a comparison or equality, don't break on either
+  // side.
+  auto lhsSpace = (prec == VerilogPrecedence::Comparison ||
+                   prec == VerilogPrecedence::Equality)
+                      ? PP::nbsp
+                      : PP::space;
   // Use non-breaking space between op and RHS so breaking is consistent.
   ps << lhsSpace << syntax << PP::nbsp; // PP::space;
 
@@ -2785,7 +2789,21 @@ SubExprInfo ExprEmitter::visitComb(ICmpOp op) {
   if (op.isNotEqualZero())
     return emitUnary(op, "|", true);
 
-  auto result = emitBinary(op, Comparison, symop[pred], signop[pred]);
+  VerilogPrecedence precedence = Comparison;
+  switch (op.getPredicate()) {
+  case ICmpPredicate::eq:
+  case ICmpPredicate::ne:
+  case ICmpPredicate::ceq:
+  case ICmpPredicate::cne:
+  case ICmpPredicate::weq:
+  case ICmpPredicate::wne:
+    precedence = Equality;
+    break;
+  default:
+    precedence = Comparison;
+    break;
+  }
+  auto result = emitBinary(op, precedence, symop[pred], signop[pred]);
 
   // SystemVerilog 11.8.1: "Comparison... operator results are unsigned,
   // regardless of the operands".

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -799,6 +799,47 @@ hw.module @ModuleUsingMacroWithVerilogName(in %a : i1) {
   }
 }
 
+// CHECK-LABEL: module PrecedenceEqualityRelational(
+// CHECK-NEXT:   input  [3:0] a,{{.*}}
+// CHECK-NEXT:                b,{{.*}}
+// CHECK-NEXT:   input        c,{{.*}}
+// CHECK-NEXT:   output       out_eq,{{.*}}
+// CHECK-NEXT:                out_ne,{{.*}}
+// CHECK-NEXT:                out_ceq,{{.*}}
+// CHECK-NEXT:                out_cne,{{.*}}
+// CHECK-NEXT:                out_weq,{{.*}}
+// CHECK-NEXT:                out_wne{{.*}}
+// CHECK-NEXT:  );
+// CHECK-DAG:     assign out_eq = (a == b) < c;
+// CHECK-DAG:     assign out_ne = (a != b) < c;
+// CHECK-DAG:     assign out_ceq = (a === b) < c;
+// CHECK-DAG:     assign out_cne = (a !== b) < c;
+// CHECK-DAG:     assign out_weq = (a ==? b) < c;
+// CHECK-DAG:     assign out_wne = (a !=? b) < c;
+// CHECK-NEXT:  endmodule
+hw.module @PrecedenceEqualityRelational(in %a: i4, in %b: i4, in %c: i1,
+  out out_eq: i1, out out_ne: i1, out out_ceq: i1, out out_cne: i1, out out_weq: i1, out out_wne: i1) {
+  %eq = comb.icmp eq %a, %b : i4
+  %out_eq = comb.icmp ult %eq, %c : i1
+
+  %ne = comb.icmp ne %a, %b : i4
+  %out_ne = comb.icmp ult %ne, %c : i1
+
+  %ceq = comb.icmp ceq %a, %b : i4
+  %out_ceq = comb.icmp ult %ceq, %c : i1
+
+  %cne = comb.icmp cne %a, %b : i4
+  %out_cne = comb.icmp ult %cne, %c : i1
+
+  %weq = comb.icmp weq %a, %b : i4
+  %out_weq = comb.icmp ult %weq, %c : i1
+
+  %wne = comb.icmp wne %a, %b : i4
+  %out_wne = comb.icmp ult %wne, %c : i1
+
+  hw.output %out_eq, %out_ne, %out_ceq, %out_cne, %out_weq, %out_wne : i1, i1, i1, i1, i1, i1
+}
+
 hw.module @BindInterface() {
   %bar = sv.interface.instance sym @__Interface__ {doNotPrint} : !sv.interface<@Interface>
   hw.output


### PR DESCRIPTION
Equality operators (eq, ne, ceq, cne, weq, wne) have lower precedence than comparison operators (lt, le, gt, ge) in Verilog. Previously, the exporter treated all ICmpOp predicates with Comparison precedence. This resulted in missing parentheses when an equality comparison was used as an operand to a relational comparison, e.g. `(a == b) < c` was emitted as `a == b < c` (which Verilog parses as `a == (b < c)`).

This patch fixes this by assigning Equality precedence to the equality predicates in `visitComb(ICmpOp)`.

Assisted-by: Gemini