### PR TITLE
[MooreToCore][Sim] Support lowering of unpacked array equality

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -855,9 +855,9 @@ def StringCmpOp : SimOp<"string.cmp", [Pure]> {
 // Queues
 //===----------------------------------------------------------------------===//
 
-def QueueCmpPredicateAttr : I64EnumAttr<
-    "QueueCmpPredicate",
-    "queue.cmp comparison predicate",
+def UArrayCmpPredicateAttr : I64EnumAttr<
+    "UArrayCmpPredicate",
+    "unpacked-array-like container comparison predicate",
     [I64EnumAttrCase<"eq", 0>,
       I64EnumAttrCase<"ne", 1>]> {
   let cppNamespace = "circt::sim";
@@ -872,7 +872,7 @@ def QueueCmpOp : SimOp<"queue.cmp", [Pure, Commutative, SameTypeOperands]> {
     Comparing for equality and inequality are both supported.
   }];
 
-  let arguments = (ins QueueCmpPredicateAttr:$predicate, QueueType:$lhs, QueueType:$rhs);
+  let arguments = (ins UArrayCmpPredicateAttr:$predicate, QueueType:$lhs, QueueType:$rhs);
   let results = (outs I1:$result);
 
   let assemblyFormat = "$predicate $lhs `,` $rhs attr-dict `:` type($lhs)";
@@ -1208,6 +1208,23 @@ def AssocArraySizeOp : SimOp<"assoc_array.size", [Pure]> {
   let arguments = (ins AssocArrayType:$array);
   let results = (outs I32:$result);
   let assemblyFormat = "$array attr-dict `:` type($array)";
+}
+
+def AssocArrayCmpOp : SimOp<"assoc_array.cmp",
+    [Pure, Commutative, SameTypeOperands]> {
+  let summary = "Compares two associative arrays";
+  let description = [{
+    Carries out a comparison on two associative arrays. Two associative
+    arrays are equal if they have the same set of keys and each key maps to
+    an equal value in both arrays.
+
+    Comparing for equality and inequality are both supported.
+  }];
+
+  let arguments = (ins UArrayCmpPredicateAttr:$predicate, AssocArrayType:$lhs, AssocArrayType:$rhs);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = "$predicate $lhs `,` $rhs attr-dict `:` type($lhs)";
 }
 
 def AssocArrayExistsOp : SimOp<"assoc_array.exists", [Pure,

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2998,34 +2998,94 @@ struct QueueSetOpConversion : public OpConversionPattern<QueueSetOp> {
   }
 };
 
+// SystemVerilog unpacked array elements may be of any type. Bitcast handles
+// statically-sized elements; reals bypass it so NaN/signed zero still compare
+// correctly. Everything else recurses or dispatches to the matching comparison
+// op.
+static Value buildUArrayElementEq(ConversionPatternRewriter &rewriter,
+                                  Location loc, Value lhs, Value rhs, Type type,
+                                  UArrayCmpPredicate pred) {
+  bool isEq = pred == UArrayCmpPredicate::eq;
+
+  if (isa<mlir::FloatType>(type))
+    return arith::CmpFOp::create(
+        rewriter, loc,
+        isEq ? arith::CmpFPredicate::OEQ : arith::CmpFPredicate::UNE, lhs, rhs);
+
+  if (int64_t width = hw::getBitWidth(type); width != -1) {
+    auto intTy = rewriter.getIntegerType(width);
+    Value lhsInt = hw::BitcastOp::create(rewriter, loc, intTy, lhs);
+    Value rhsInt = hw::BitcastOp::create(rewriter, loc, intTy, rhs);
+    return comb::ICmpOp::create(rewriter, loc,
+                                isEq ? ICmpPredicate::eq : ICmpPredicate::ne,
+                                lhsInt, rhsInt);
+  }
+
+  if (isa<sim::DynamicStringType>(type))
+    return sim::StringCmpOp::create(rewriter, loc,
+                                    isEq ? sim::StringCmpPredicate::eq
+                                         : sim::StringCmpPredicate::ne,
+                                    lhs, rhs);
+
+  if (isa<sim::QueueType>(type)) {
+    auto pred = sim::UArrayCmpPredicateAttr::get(
+        rewriter.getContext(),
+        isEq ? sim::UArrayCmpPredicate::eq : sim::UArrayCmpPredicate::ne);
+    return sim::QueueCmpOp::create(rewriter, loc, pred, lhs, rhs);
+  }
+
+  if (isa<sim::AssocArrayType>(type)) {
+    auto pred = sim::UArrayCmpPredicateAttr::get(
+        rewriter.getContext(),
+        isEq ? sim::UArrayCmpPredicate::eq : sim::UArrayCmpPredicate::ne);
+    return sim::AssocArrayCmpOp::create(rewriter, loc, pred, lhs, rhs);
+  }
+
+  auto arrayTy = dyn_cast<hw::ArrayType>(type);
+  if (!arrayTy)
+    return {};
+
+  unsigned size = arrayTy.getNumElements();
+  if (size == 0)
+    return hw::ConstantOp::create(rewriter, loc, APInt(1, isEq ? 1 : 0));
+
+  unsigned idxWidth = size == 1 ? 1 : llvm::Log2_64_Ceil(size);
+  auto idxTy = rewriter.getIntegerType(idxWidth);
+
+  SmallVector<Value> elemEqs;
+  elemEqs.reserve(size);
+  for (unsigned i = 0; i < size; ++i) {
+    Value idx = hw::ConstantOp::create(rewriter, loc, idxTy, i);
+    Value lhsElem = hw::ArrayGetOp::create(rewriter, loc, lhs, idx);
+    Value rhsElem = hw::ArrayGetOp::create(rewriter, loc, rhs, idx);
+    Value elemEq = buildUArrayElementEq(rewriter, loc, lhsElem, rhsElem,
+                                        arrayTy.getElementType(), pred);
+    if (!elemEq)
+      return {};
+    elemEqs.push_back(elemEq);
+  }
+
+  return (isEq ? comb::AndOp::create(rewriter, loc, elemEqs, /*twoState=*/true)
+                     .getResult()
+               : comb::OrOp::create(rewriter, loc, elemEqs, /*twoState=*/true)
+                     .getResult());
+}
+
 struct QueueCmpOpConversion : public OpConversionPattern<QueueCmpOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(QueueCmpOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // TODO: Right now Moore uses `UArrayCmpPredicate` for both queues/unpacked
-    // arrays - reasonable because, per SV spec, queues *are* a type of unpacked
-    // array). Once we support comparing unpacked arrays in core, it will make
-    // sense to rename `QueueCmpPredicate` to `UArrayCmpPredicate` and use it
-    // for both forms of comparisons.
-
-    // Convert the UArrayCmpPredicate into a QueueCmpPredicate
-    auto unpackedPred = adaptor.getPredicateAttr().getValue();
-    sim::QueueCmpPredicate queuePred;
-    switch (unpackedPred) {
-    case circt::moore::UArrayCmpPredicate::eq:
-      queuePred = sim::QueueCmpPredicate::eq;
-      break;
-    case circt::moore::UArrayCmpPredicate::ne:
-      queuePred = sim::QueueCmpPredicate::ne;
-      break;
-    }
-
-    auto cmpPred = sim::QueueCmpPredicateAttr::get(getContext(), queuePred);
-
-    rewriter.replaceOpWithNewOp<sim::QueueCmpOp>(op, cmpPred, adaptor.getLhs(),
-                                                 adaptor.getRhs());
+    // Per IEEE 1800-2017 7.4.2, queues are themselves a form of unpacked array,
+    // so this reuses the same element-comparison dispatch as
+    // UArrayCmpOpConversion (see buildUArrayElementEq), for a QueueType operand
+    // it resolves directly to `sim.queue.cmp`.
+    Value lhs = adaptor.getLhs();
+    Value result =
+        buildUArrayElementEq(rewriter, op.getLoc(), lhs, adaptor.getRhs(),
+                             lhs.getType(), op.getPredicate());
+    rewriter.replaceOp(op, result);
     return success();
   }
 };
@@ -3079,6 +3139,26 @@ struct AssocArrayExtractOpConversion
     Value existsBit = comb::ICmpOp::create(
         rewriter, op.getLoc(), comb::ICmpPredicate::ne, exists, zeroI32, false);
     rewriter.replaceOpWithNewOp<comb::MuxOp>(op, existsBit, raw, zero, false);
+    return success();
+  }
+};
+
+struct UArrayCmpOpConversion : public OpConversionPattern<UArrayCmpOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(UArrayCmpOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value lhs = adaptor.getLhs();
+    Value rhs = adaptor.getRhs();
+    auto pred = op.getPredicate();
+    Value eq = buildUArrayElementEq(rewriter, op.getLoc(), lhs, rhs,
+                                    lhs.getType(), pred);
+
+    if (!eq)
+      return rewriter.notifyMatchFailure(
+          op, "unpacked array element type does not support comparison");
+
+    rewriter.replaceOp(op, eq);
     return success();
   }
 };
@@ -3852,6 +3932,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     UnionExtractRefOpConversion,
     ConditionalOpConversion,
     ArrayCreateOpConversion,
+    UArrayCmpOpConversion,
     YieldOpConversion,
     OutputOpConversion,
     ConstantStringOpConv,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1736,6 +1736,16 @@ func.func @QueueOperations(%arg0: !moore.i32, %arg1: !moore.i32) {
   // CHECK: [[UPR:%.+]] = llhd.prb [[UPVAR]]
   %upr = moore.read %uparray : <!moore.uarray<4 x i32>>
 
+  // CHECK: [[LHSI:%.+]] = hw.bitcast [[UPR]] : (!hw.array<4xi32>) -> i128
+  // CHECK: [[RHSI:%.+]] = hw.bitcast [[UPR]] : (!hw.array<4xi32>) -> i128
+  // CHECK: comb.icmp eq [[LHSI]], [[RHSI]] : i128
+  moore.uarray_cmp eq %upr, %upr : !moore.uarray<4 x i32> -> i1
+
+  // CHECK: [[LHSI2:%.+]] = hw.bitcast [[UPR]] : (!hw.array<4xi32>) -> i128
+  // CHECK: [[RHSI2:%.+]] = hw.bitcast [[UPR]] : (!hw.array<4xi32>) -> i128
+  // CHECK: comb.icmp ne [[LHSI2]], [[RHSI2]] : i128
+  moore.uarray_cmp ne %upr, %upr : !moore.uarray<4 x i32> -> i1
+
   // CHECK: [[QFROMUP:%.+]] = sim.queue.from_array [[UPR]] : !hw.array<4xi32> -> <i32, 0>
   %2 = moore.queue.from_unpacked_array %upr : !moore.uarray<4 x i32> -> <i32, 0>
 
@@ -2118,4 +2128,44 @@ moore.module @StringArrayVariable() {
     // CHECK-NEXT: llhd.halt
     moore.return
   }
+}
+
+// CHECK-LABEL: func.func @UArrayCmpElementFallback
+func.func @UArrayCmpElementFallback(
+  %s1: !moore.uarray<2 x string>, %s2: !moore.uarray<2 x string>,
+  %q1: !moore.uarray<2 x queue<i32, 0>>, %q2: !moore.uarray<2 x queue<i32, 0>>,
+  %a1: !moore.uarray<2 x assoc_array<i32, string>>,
+  %a2: !moore.uarray<2 x assoc_array<i32, string>>,
+  %r1: !moore.uarray<2 x f64>, %r2: !moore.uarray<2 x f64>) {
+
+  // CHECK: arith.cmpf oeq, %{{.+}}, %{{.+}} : f64
+  // CHECK: arith.cmpf oeq, %{{.+}}, %{{.+}} : f64
+  // CHECK: comb.and bin %{{.+}}, %{{.+}} : i1
+  %0 = moore.uarray_cmp eq %r1, %r2 : !moore.uarray<2 x f64> -> i1
+
+  // CHECK: [[SL0:%.+]] = hw.array_get %{{.+}}[%{{.+}}] : !hw.array<2x!sim.dstring>
+  // CHECK: [[SR0:%.+]] = hw.array_get %{{.+}}[%{{.+}}] : !hw.array<2x!sim.dstring>
+  // CHECK: [[SEQ0:%.+]] = sim.string.cmp eq [[SL0]], [[SR0]] : !sim.dstring
+  // CHECK: [[SL1:%.+]] = hw.array_get %{{.+}}[%{{.+}}] : !hw.array<2x!sim.dstring>
+  // CHECK: [[SR1:%.+]] = hw.array_get %{{.+}}[%{{.+}}] : !hw.array<2x!sim.dstring>
+  // CHECK: [[SEQ1:%.+]] = sim.string.cmp eq [[SL1]], [[SR1]] : !sim.dstring
+  // CHECK: comb.and bin [[SEQ0]], [[SEQ1]] : i1
+  %1 = moore.uarray_cmp eq %s1, %s2 : !moore.uarray<2 x string> -> i1
+
+  // CHECK: sim.string.cmp ne %{{.+}}, %{{.+}} : !sim.dstring
+  // CHECK: sim.string.cmp ne %{{.+}}, %{{.+}} : !sim.dstring
+  // CHECK: comb.or bin %{{.+}}, %{{.+}} : i1
+  %2 = moore.uarray_cmp ne %s1, %s2 : !moore.uarray<2 x string> -> i1
+
+  // CHECK: sim.queue.cmp eq %{{.+}}, %{{.+}} : <i32, 0>
+  // CHECK: sim.queue.cmp eq %{{.+}}, %{{.+}} : <i32, 0>
+  // CHECK: comb.and bin %{{.+}}, %{{.+}} : i1
+  %3 = moore.uarray_cmp eq %q1, %q2 : !moore.uarray<2 x queue<i32, 0>> -> i1
+
+  // CHECK: sim.assoc_array.cmp eq %{{.+}}, %{{.+}}
+  // CHECK: sim.assoc_array.cmp eq %{{.+}}, %{{.+}}
+  // CHECK: comb.and bin %{{.+}}, %{{.+}} : i1
+  %4 = moore.uarray_cmp eq %a1, %a2 : !moore.uarray<2 x assoc_array<i32, string>> -> i1
+
+  func.return
 }


### PR DESCRIPTION
`moore.uarray_cmp` had no conversion pattern in MooreToCore, so any comparison of fixed-size unpacked arrays caused a failed to legalize operation.

**For example:**
```
module top(
  input logic clk,
  input logic [7:0] data1[2],
  input logic [7:0] data2[2],
  output logic out
);

assign out = data1 == data2;

endmodule
```

**Output:**
```
error: failed to legalize operation 'moore.uarray_cmp': %0 = "moore.uarray_cmp"(<<UNKNOWN SSA VALUE>>, <<UNKNOWN SSA VALUE>>) <{predicate = 0 : i64}> : (!moore.uarray<2 x l8>, !moore.uarray<2 x l8>) -> !moore.i1
assign out = data1 == data2;
             ^
note: see current operation: %0 = "moore.uarray_cmp"(<<UNKNOWN SSA VALUE>>, <<UNKNOWN SSA VALUE>>) <{predicate = 0 : i64}> : (!moore.uarray<2 x l8>, !moore.uarray<2 x l8>) -> !moore.i1
```

**Fix:**
Add `UArrayCmpOpConversion`, backed by a recursive helper `buildUArrayElementEq`, that picks a comparison strategy per element type:
- Statically-sized elements: bitcast the whole array to an integer and compare with a single `comb.icmp`.
- Reals: compared with `arith.cmpf` instead of a bitcast, so NaN and signed zero compare correctly.
- Strings, queues, associative arrays: no static width, so recurse element-by-element and dispatch to `sim.string.cmp`, `sim.queue.cmp`, or the newly added `sim.assoc_array.cmp`, then AND/OR-reduce.

`sim::QueueCmpPredicate` is renamed to `sim::UArrayCmpPredicate` and shared with `sim.assoc_array.cmp`, since both are plain eq/ne comparisons on unpacked-array like containers (as suggested by a pre-existing TODO). `QueueCmpOpConversion` now reuses the same helper instead of duplicating the predicate conversion.