### PR TITLE
[FIRRTL] Support constants in InferDomains

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -98,16 +98,7 @@ static bool isHardware(Type type) {
 }
 
 /// True if the given value could be association with a domain.
-static bool isHardware(Value value) {
-  if (!isHardware(value.getType()))
-    return false;
-
-  if (auto *op = value.getDefiningOp())
-    if (op->hasTrait<OpTrait::ConstantLike>())
-      return false;
-
-  return true;
-}
+static bool isHardware(Value value) { return isHardware(value.getType()); }
 
 //====--------------------------------------------------------------------------
 // Global State.
@@ -345,6 +336,12 @@ public:
   Term *getDomainAssociation(Value value);
   void setDomainAssociation(Value value, Term *term);
 
+  /// True if the value is "colorless": it is fully composed of constants and
+  /// therefore not tied to any domain. A colorless value imposes and inherits
+  /// no domain constraints, and may be freely consumed by a value in any
+  /// domain. Computed structurally over the SSA graph, memoized per module.
+  bool isColorless(Value value);
+
   void processDomainDefinition(DomainValue domain);
   RowTerm *getDomainAssociationAsRow(Value value);
 
@@ -447,6 +444,10 @@ private:
   CircuitState &globals;
   DenseMap<Value, Term *> termTable;
   DenseMap<Value, Term *> associationTable;
+  /// Memoization for isColorless. Absent = not computed; present = result.
+  /// A value currently being computed is marked pending in colorlessPending.
+  DenseMap<Value, bool> colorlessTable;
+  DenseSet<Value> colorlessPending;
   llvm::BumpPtrAllocator allocator;
 };
 } // namespace
@@ -701,7 +702,7 @@ void ModuleState::setTermForDomain(DomainValue value, Term *term) {
 }
 
 Term *ModuleState::getOptDomainAssociation(Value value) {
-  assert(isHardware(value));
+  assert(isHardware(value) && !isColorless(value));
   auto it = associationTable.find(value);
   if (it == associationTable.end())
     return nullptr;
@@ -715,7 +716,7 @@ Term *ModuleState::getDomainAssociation(Value value) {
 }
 
 void ModuleState::setDomainAssociation(Value value, Term *term) {
-  assert(isHardware(value));
+  assert(isHardware(value) && !isColorless(value));
   assert(term);
   term = find(term);
   associationTable.insert({value, term});
@@ -723,6 +724,121 @@ void ModuleState::setDomainAssociation(Value value, Term *term) {
     llvm::dbgs().indent(6) << "set domains(" << render(value)
                            << ") := " << render(term) << "\n";
   });
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+bool ModuleState::isColorless(Value value) {
+  // Only hardware-typed values can be colored; property/domain-typed operands
+  // never participate in coloring, so treat them as colorless (they impose no
+  // constraint).
+  if (!isHardware(value))
+    return true;
+
+  // Consult the memo table.
+  if (auto it = colorlessTable.find(value); it != colorlessTable.end())
+    return it->second;
+
+  // Cycle guard: a value currently being computed is treated conservatively as
+  // non-colorless. This breaks combinational loops (including wire -> connect
+  // src -> ... -> wire) without infinite recursion.
+  if (!colorlessPending.insert(value).second)
+    return false;
+
+  auto finish = [&](bool result) {
+    colorlessPending.erase(value);
+    colorlessTable[value] = result;
+    return result;
+  };
+
+  // Block arguments (ports) are never colorless by structure.
+  auto *op = value.getDefiningOp();
+  if (!op)
+    return finish(false);
+
+  // A wire is colorless iff every driver connected to it is colorless. An
+  // undriven wire has no colorless drivers to constrain it and is treated
+  // conservatively as non-colorless (it behaves like an invalid value). Wires
+  // with explicit declared domains are colored. A forceable wire (has an
+  // inner symbol, or an rwprobe result) can be targeted externally via
+  // `firrtl.ref.rwprobe` / force, so it is never colorless: a force could
+  // later drive it with a colored value regardless of its own connect
+  // drivers.
+  if (auto wireOp = dyn_cast<WireOp>(op)) {
+    if (!wireOp.getDomains().empty())
+      return finish(false);
+    if (wireOp.isForceable() || wireOp.getInnerSymAttr())
+      return finish(false);
+    bool hasDriver = false;
+    for (auto *user : value.getUsers()) {
+      auto connect = dyn_cast<FConnectLike>(user);
+      if (!connect || connect.getDest() != value)
+        continue;
+      hasDriver = true;
+      if (!isColorless(connect.getSrc()))
+        return finish(false);
+    }
+    return finish(hasDriver);
+  }
+
+  // Constants are colorless roots.
+  if (op->hasTrait<OpTrait::ConstantLike>())
+    return finish(true);
+
+  // A node is a transparent pass-through of its single input.
+  if (auto nodeOp = dyn_cast<NodeOp>(op))
+    return finish(isColorless(nodeOp.getInput()));
+
+  // An unsafe domain cast with explicit domain operands is always explicitly
+  // colored (regardless of whether its input is colorless): the whole point
+  // of the op is to assign a concrete domain. Only a cast with no domain
+  // operands (a pure forwarding cast) inherits colorlessness from its input.
+  if (auto castOp = dyn_cast<UnsafeDomainCastOp>(op)) {
+    if (!castOp.getDomains().empty())
+      return finish(false);
+    return finish(isColorless(castOp.getInput()));
+  }
+
+  // A rwprobe references its target by attribute (no value operand), so it
+  // is never colorless by structure -- it aliases a forced/probed value.
+  if (isa<RWProbeOp>(op))
+    return finish(false);
+
+  // ref.send sends a value through a reference that may be read/probed
+  // through module ports (e.g. RefDefineOp routes it to an output port);
+  // like other module-boundary-crossing constructs, do not treat it as
+  // colorless so its color, if any, is faithfully propagated to consumers on
+  // the other side.
+  if (isa<RefSendOp>(op))
+    return finish(false);
+
+  // Pure expression ops (prim ops, muxes, casts, aggregate projections) are
+  // colorless iff all their hardware-typed operands are colorless. Non-hardware
+  // operands (indices, domains, properties) are ignored by isColorless.
+  // invalidvalue is an expression but has a MemAlloc effect (it is a unique
+  // fresh value), so it is excluded by the memory-effect-free check.
+  //
+  // Ops with *no* hardware-typed operands are "roots". Only explicit
+  // constants are colorless roots (handled above); anything else that
+  // produces a hardware value with no hardware operands references external
+  // state (e.g. `xmr.ref`, `xmr.deref`, a `verbatim.expr` with no
+  // substitutions) and must not be treated as colorless.
+  if (isExpression(op) && mlir::isMemoryEffectFree(op)) {
+    bool sawHardwareOperand = false;
+    for (auto operand : op->getOperands()) {
+      if (!isHardware(operand))
+        continue;
+      sawHardwareOperand = true;
+      if (!isColorless(operand))
+        return finish(false);
+    }
+    if (!sawHardwareOperand)
+      return finish(false);
+    return finish(true);
+  }
+
+  // Anything else (instance results, reg, regreset, mem, invalidvalue,
+  // unsafe.domain.cast, forced/probed values) is not colorless by structure.
+  return finish(false);
 }
 
 void ModuleState::processDomainDefinition(DomainValue domain) {
@@ -739,7 +855,7 @@ void ModuleState::processDomainDefinition(DomainValue domain) {
 }
 
 RowTerm *ModuleState::getDomainAssociationAsRow(Value value) {
-  assert(isHardware(value));
+  assert(isHardware(value) && !isColorless(value));
   auto *term = getOptDomainAssociation(value);
 
   // If the term is unknown, allocate a fresh row and set the association.
@@ -1020,6 +1136,11 @@ LogicalResult ModuleState::unifyAssociations(Operation *op, Value lhs,
   if (!isHardware(lhs) || !isHardware(rhs))
     return success();
 
+  // Colorless values impose and receive no association: colorless is below
+  // every color in the lattice.
+  if (isColorless(lhs) || isColorless(rhs))
+    return success();
+
   LLVM_DEBUG({
     llvm::dbgs().indent(6) << "unify domains(" << render(lhs) << ") = domains("
                            << render(rhs) << ")\n";
@@ -1055,7 +1176,7 @@ template <typename T>
 LogicalResult ModuleState::unifyAssociations(Operation *op, T &&range) {
   Value lhs;
   for (auto rhs : std::forward<T>(range)) {
-    if (!isHardware(rhs))
+    if (!isHardware(rhs) || isColorless(rhs))
       continue;
     if (failed(unifyAssociations(op, lhs, rhs)))
       return failure();
@@ -1209,7 +1330,7 @@ LogicalResult ModuleState::processOp(UnsafeDomainCastOp op) {
   auto input = op.getInput();
 
   SmallVector<Term *> elements(getNumDomains());
-  if (isHardware(input)) {
+  if (isHardware(input) && !isColorless(input)) {
     auto *inputRow = getDomainAssociationAsRow(input);
     elements.assign(inputRow->elements);
   }
@@ -1250,8 +1371,14 @@ LogicalResult ModuleState::processOp(WireOp op) {
   // contains only fresh variables that unify unconditionally. Any conflict
   // between an explicit wire domain and a connection's inferred domain is
   // caught later by the connection's own processOp.
-  if (op.getDomains().empty())
+  if (op.getDomains().empty()) {
+    // A colorless wire (no explicit domains, all drivers colorless) imposes
+    // nothing and gets no association.
+    if (llvm::all_of(op.getResults(),
+                     [&](Value result) { return isColorless(result); }))
+      return success();
     return unifyAssociations(op, op.getResults());
+  }
 
   // Build a row with the explicitly-specified domain slots filled in and set
   // it as the association for this wire result.
@@ -1696,7 +1823,7 @@ ModuleState::updateWire(DenseMap<DomainValue, DomainValue> &domainsInScope,
     llvm_unreachable("unhandled domain term type");
   }
 
-  if (!isHardware(result))
+  if (!isHardware(result) || isColorless(result))
     return success();
 
   LLVM_DEBUG(llvm::dbgs().indent(4) << "update " << render(wireOp) << "\n");

--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -342,6 +342,10 @@ public:
   /// domain. Computed structurally over the SSA graph, memoized per module.
   bool isColorless(Value value);
 
+  /// Classify a value reached as a terminal driver by `walkDrivers`.
+  /// Returns true if colorless.
+  bool isColorlessDriver(Value value);
+
   void processDomainDefinition(DomainValue domain);
   RowTerm *getDomainAssociationAsRow(Value value);
 
@@ -445,9 +449,7 @@ private:
   DenseMap<Value, Term *> termTable;
   DenseMap<Value, Term *> associationTable;
   /// Memoization for isColorless. Absent = not computed; present = result.
-  /// A value currently being computed is marked pending in colorlessPending.
   DenseMap<Value, bool> colorlessTable;
-  DenseSet<Value> colorlessPending;
   llvm::BumpPtrAllocator allocator;
 };
 } // namespace
@@ -738,14 +740,7 @@ bool ModuleState::isColorless(Value value) {
   if (auto it = colorlessTable.find(value); it != colorlessTable.end())
     return it->second;
 
-  // Cycle guard: a value currently being computed is treated conservatively as
-  // non-colorless. This breaks combinational loops (including wire -> connect
-  // src -> ... -> wire) without infinite recursion.
-  if (!colorlessPending.insert(value).second)
-    return false;
-
   auto finish = [&](bool result) {
-    colorlessPending.erase(value);
     colorlessTable[value] = result;
     return result;
   };
@@ -763,82 +758,149 @@ bool ModuleState::isColorless(Value value) {
   // `firrtl.ref.rwprobe` / force, so it is never colorless: a force could
   // later drive it with a colored value regardless of its own connect
   // drivers.
-  if (auto wireOp = dyn_cast<WireOp>(op)) {
-    if (!wireOp.getDomains().empty())
-      return finish(false);
-    if (wireOp.isForceable() || wireOp.getInnerSymAttr())
-      return finish(false);
-    bool hasDriver = false;
-    for (auto *user : value.getUsers()) {
-      auto connect = dyn_cast<FConnectLike>(user);
-      if (!connect || connect.getDest() != value)
-        continue;
-      hasDriver = true;
-      if (!isColorless(connect.getSrc()))
-        return finish(false);
-    }
-    return finish(hasDriver);
-  }
-
-  // Constants are colorless roots.
-  if (op->hasTrait<OpTrait::ConstantLike>())
-    return finish(true);
-
-  // A node is a transparent pass-through of its single input.
-  if (auto nodeOp = dyn_cast<NodeOp>(op))
-    return finish(isColorless(nodeOp.getInput()));
-
-  // An unsafe domain cast with explicit domain operands is always explicitly
-  // colored (regardless of whether its input is colorless): the whole point
-  // of the op is to assign a concrete domain. Only a cast with no domain
-  // operands (a pure forwarding cast) inherits colorlessness from its input.
-  if (auto castOp = dyn_cast<UnsafeDomainCastOp>(op)) {
-    if (!castOp.getDomains().empty())
-      return finish(false);
-    return finish(isColorless(castOp.getInput()));
-  }
-
-  // A rwprobe references its target by attribute (no value operand), so it
-  // is never colorless by structure -- it aliases a forced/probed value.
-  if (isa<RWProbeOp>(op))
-    return finish(false);
-
-  // ref.send sends a value through a reference that may be read/probed
-  // through module ports (e.g. RefDefineOp routes it to an output port);
-  // like other module-boundary-crossing constructs, do not treat it as
-  // colorless so its color, if any, is faithfully propagated to consumers on
-  // the other side.
-  if (isa<RefSendOp>(op))
-    return finish(false);
-
-  // Pure expression ops (prim ops, muxes, casts, aggregate projections) are
-  // colorless iff all their hardware-typed operands are colorless. Non-hardware
-  // operands (indices, domains, properties) are ignored by isColorless.
-  // invalidvalue is an expression but has a MemAlloc effect (it is a unique
-  // fresh value), so it is excluded by the memory-effect-free check.
   //
-  // Ops with *no* hardware-typed operands are "roots". Only explicit
-  // constants are colorless roots (handled above); anything else that
-  // produces a hardware value with no hardware operands references external
-  // state (e.g. `xmr.ref`, `xmr.deref`, a `verbatim.expr` with no
-  // substitutions) and must not be treated as colorless.
-  if (isExpression(op) && mlir::isMemoryEffectFree(op)) {
-    bool sawHardwareOperand = false;
-    for (auto operand : op->getOperands()) {
-      if (!isHardware(operand))
-        continue;
-      sawHardwareOperand = true;
-      if (!isColorless(operand))
-        return finish(false);
-    }
-    if (!sawHardwareOperand)
-      return finish(false);
-    return finish(true);
-  }
+  // The only non-base hardware values are references (probe / rwprobe). A
+  // ref is never colorless: it is rooted at a real ref.send/rwprobe target,
+  // never a constant, and its color must propagate to probe consumers.
+  // (walkDrivers is also typed on FIRRTLBaseValue and cannot accept a ref.)
+  if (type_isa<RefType>(value.getType()))
+    return finish(false);
 
-  // Anything else (instance results, reg, regreset, mem, invalidvalue,
-  // unsafe.domain.cast, forced/probed values) is not colorless by structure.
-  return finish(false);
+  // Everything else is a passive base value. InferDomains runs after
+  // LowerFIRRTLTypes, which scalarizes every non-passive aggregate, so all
+  // base values are passive here.
+  assert(type_cast<FIRRTLBaseType>(value.getType()).isPassive() &&
+         "expected passive base values after LowerFIRRTLTypes");
+
+  // Per-walk visited set of looked-through drivers.  It serves two purposes:
+  //   * Wires: break combinational loops.  In valid SSA the only way to form a
+  //     combinational loop is through a wire (connect-driven, use may precede
+  //     def), so a re-visited wire closes a loop and is treated as a terminal
+  //     (conservatively non-colorless).
+  //   * Pure ops: dedup reconvergent fan-out.  A pure op's colorlessness
+  //     depends only on its operands, so once it has been walked on one branch
+  //     a later re-visit contributes nothing and is skipped.  Without this, a
+  //     reconvergent combinational cone would be re-walked exponentially.
+  // The set is keyed on `FieldRef` (not `Operation *`) so distinct subfields of
+  // one aggregate value are tracked independently.
+  DenseSet<FieldRef> walkVisited;
+
+  // Two callbacks steer the walk.  `lookThrough` decides, per driver, how to
+  // proceed: nodes and forwarding domain casts forward their input; pure
+  // memory-effect-free expression ops fan out to all their hardware-typed
+  // operands; wires are connect-driven (look through with no drivers) unless
+  // colored or loop-closing.  Colored/loop-closing wires, constants, explicit
+  // domain casts, rwprobe/ref.send, and everything else are terminals; an
+  // already-visited pure op is skipped.  `onTerminal` classifies each terminal
+  // driver: a colored terminal stops the walk (returns false), a colorless one
+  // keeps walking.  A completed walk that reached no terminal (e.g. an undriven
+  // wire) is not colorless.
+  bool sawTerminal = false;
+  auto lookThrough =
+      [&](const FieldRef &ref,
+          SmallVectorImpl<Value> &drivers) -> WalkDriverLookThrough {
+    auto *op = ref.getValue().getDefiningOp();
+    // Wires are connect-driven: look through by scanning their connects (push
+    // no drivers), unless colored or already visited.  A re-visited wire closes
+    // a combinational loop, so treat it as a terminal (conservatively
+    // non-colorless) rather than skipping it.
+    if (auto wireOp = dyn_cast<WireOp>(op)) {
+      bool colored = !wireOp.getDomains().empty() || wireOp.isForceable() ||
+                     wireOp.getInnerSymAttr();
+      if (colored || !walkVisited.insert(ref).second)
+        return WalkDriverLookThrough::Terminal;
+      return WalkDriverLookThrough::LookThrough;
+    }
+
+    // A node forwards its input.
+    if (auto node = dyn_cast<NodeOp>(op)) {
+      if (!walkVisited.insert(ref).second)
+        return WalkDriverLookThrough::Skip;
+      drivers.push_back(node.getInput());
+      return WalkDriverLookThrough::LookThrough;
+    }
+
+    // A forwarding domain cast (no explicit domains) is transparent; a cast
+    // with domain operands is an explicit coloring terminal.
+    if (auto castOp = dyn_cast<UnsafeDomainCastOp>(op)) {
+      if (!castOp.getDomains().empty())
+        return WalkDriverLookThrough::Terminal;
+      if (!walkVisited.insert(ref).second)
+        return WalkDriverLookThrough::Skip;
+      drivers.push_back(castOp.getInput());
+      return WalkDriverLookThrough::LookThrough;
+    }
+
+    // A rwprobe references its target by attribute (no value operand) and
+    // ref.send crosses a module boundary; both are structural terminals whose
+    // color must be propagated, so never fan into them.
+    if (isa<RWProbeOp, RefSendOp>(op))
+      return WalkDriverLookThrough::Terminal;
+
+    // Constants are colorless roots; keep them terminals so `onTerminal`
+    // classifies them (fanning would push no drivers and stall the walk).
+    if (op->hasTrait<OpTrait::ConstantLike>())
+      return WalkDriverLookThrough::Terminal;
+
+    // Pure, memory-effect-free expression ops (prim ops, muxes, casts,
+    // aggregate projections) fan out to all their hardware-typed operands;
+    // non-hardware operands (indices, domains, properties) impose no coloring
+    // constraint.  A pure op with no hardware operands is a non-constant root
+    // (e.g. `xmr.ref`, a substitution-free `verbatim.expr`) that references
+    // external state and stays a terminal.  invalidvalue is an expression but
+    // has a MemAlloc effect, so it is excluded here and treated as a terminal.
+    if (isExpression(op) && mlir::isMemoryEffectFree(op)) {
+      // A reconvergent re-visit contributes nothing (its colorlessness is fully
+      // determined by its operands, already walked on the first visit).
+      if (!walkVisited.insert(ref).second)
+        return WalkDriverLookThrough::Skip;
+      bool sawHardwareOperand = false;
+      for (auto operand : op->getOperands()) {
+        if (!isHardware(operand))
+          continue;
+        sawHardwareOperand = true;
+        drivers.push_back(operand);
+      }
+      return sawHardwareOperand ? WalkDriverLookThrough::LookThrough
+                                : WalkDriverLookThrough::Terminal;
+    }
+
+    // Everything else (instance results, reg, regreset, mem, invalidvalue,
+    // forced/probed values) is a terminal driver.
+    return WalkDriverLookThrough::Terminal;
+  };
+  auto onTerminal = [&](const FieldRef &dst, const FieldRef &src) -> bool {
+    sawTerminal = true;
+    return isColorlessDriver(src.getValue());
+  };
+  bool walkOk =
+      walkDrivers(cast<FIRRTLBaseValue>(value), lookThrough, onTerminal);
+  return finish(walkOk && sawTerminal);
+}
+
+// Classify a value reached as a terminal driver by `walkDrivers`. Returns true
+// if the value is colorless. `walkDrivers` looks through and fans into all the
+// ops that could inherit colorlessness (wires, nodes, forwarding domain casts,
+// pure expression ops), so terminals are only ever roots or coloring points
+// and this classification is a simple structural test.
+bool ModuleState::isColorlessDriver(Value value) {
+  // Non-hardware operands impose no coloring constraint.
+  if (!isHardware(value))
+    return true;
+
+  auto *op = value.getDefiningOp();
+  if (!op)
+    return false;
+
+  // Constants are the only colorless roots.
+  if (op->hasTrait<OpTrait::ConstantLike>())
+    return true;
+
+  // Everything else reported as a terminal is not colorless: colored or
+  // loop-closing wires, unsafe domain casts with explicit domains, rwprobe,
+  // ref.send, instance results, reg/regreset/mem, invalidvalue, and
+  // non-constant expression roots (e.g. xmr) that reference external state.
+  return false;
 }
 
 void ModuleState::processDomainDefinition(DomainValue domain) {
@@ -1216,6 +1278,11 @@ LogicalResult ModuleState::processModulePorts(FModuleOp moduleOp) {
     if (!isHardware(port))
       continue;
 
+    // A colorless port (e.g. an output driven only by constants) imposes and
+    // receives no domain association.
+    if (isColorless(port))
+      continue;
+
     LLVM_DEBUG(llvm::dbgs().indent(4)
                << "process port " << render(port) << "\n");
 
@@ -1270,6 +1337,11 @@ LogicalResult ModuleState::processInstancePorts(T op) {
   for (size_t i = 0; i < numPorts; ++i) {
     Value port = op->getResult(i);
     if (!isHardware(port))
+      continue;
+
+    // A colorless port (e.g. an input driven only by constants) imposes and
+    // receives no domain association.
+    if (isColorless(port))
       continue;
 
     SmallVector<IntegerAttr> associations(numDomains);

--- a/test/Dialect/FIRRTL/infer-domains-infer-all-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all-errors.mlir
@@ -261,3 +261,32 @@ firrtl.circuit "TraceThroughOutputPort" {
     firrtl.matchingconnect %a, %cg_a : !firrtl.uint<1>
   }
 }
+
+// A wire chain must not bypass an intermediate wire's explicit color: `w1`
+// has an explicit domain association, so `w2` (which is driven only by
+// `w1`) is colored by `w1`'s domain and is not colorless, even though `w1`
+// is itself ultimately driven only by a constant. This guards against a
+// `walkDrivers`-based implementation of `isColorless` that looks through
+// every wire in the chain (including colored ones) down to the constant.
+firrtl.circuit "WireChainDoesNotBypassColoredWire" {
+  firrtl.domain @ClockDomain
+  firrtl.module @WireChainDoesNotBypassColoredWire(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c = firrtl.constant 1 : !firrtl.uint<1>
+    %w1 = firrtl.wire domains[%A] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
+    firrtl.matchingconnect %w1, %c : !firrtl.uint<1>
+    // expected-note @below {{w2 has domains [A : ClockDomain]}}
+    %w2 = firrtl.wire : !firrtl.uint<1>
+    firrtl.matchingconnect %w2, %w1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %w2 : !firrtl.uint<1>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %w2 : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -582,18 +582,20 @@ firrtl.circuit "WireInferSecondDomain" {
 firrtl.circuit "DoNotReUseAnonDomain" {
   firrtl.domain @ClockDomain
   firrtl.domain @PowerDomain
-  firrtl.module @DoNotReUseAnonDomain() {
-    // CHECK: %ClockDomain = firrtl.domain.anon
-    // CHECK: %PowerDomain = firrtl.domain.anon
+  // CHECK: firrtl.module @DoNotReUseAnonDomain(
+  // CHECK-SAME: in %ClockDomain: !firrtl.domain<@ClockDomain()>,
+  // CHECK-SAME: in %PowerDomain: !firrtl.domain<@PowerDomain()>,
+  // CHECK-SAME: in %x: !firrtl.uint<1> domains [%ClockDomain, %PowerDomain],
+  // CHECK-SAME: in %ClockDomain_0: !firrtl.domain<@ClockDomain()>,
+  // CHECK-SAME: in %PowerDomain_0: !firrtl.domain<@PowerDomain()>,
+  // CHECK-SAME: in %y: !firrtl.uint<1> domains [%ClockDomain_0, %PowerDomain_0]
+  firrtl.module @DoNotReUseAnonDomain(in %x: !firrtl.uint<1>, in %y: !firrtl.uint<1>) {
     // CHECK: %w1 = firrtl.wire domains[%ClockDomain, %PowerDomain]
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %w1 = firrtl.wire : !firrtl.uint<1>
-    // CHECK: %ClockDomain_0 = firrtl.domain.anon
-    // CHECK: %PowerDomain_1 = firrtl.domain.anon
-    // CHECK: %w2 = firrtl.wire domains[%ClockDomain_0, %PowerDomain_1]
+    // CHECK: %w2 = firrtl.wire domains[%ClockDomain_0, %PowerDomain_0]
     %w2 = firrtl.wire : !firrtl.uint<1>
-    firrtl.matchingconnect %w1, %c0_ui1 : !firrtl.uint<1>
-    firrtl.matchingconnect %w2, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %w1, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %w2, %y : !firrtl.uint<1>
   }
 }
 
@@ -601,15 +603,16 @@ firrtl.circuit "DoNotReUseAnonDomain" {
 firrtl.circuit "ReUseAnonDomain" {
   firrtl.domain @ClockDomain
   firrtl.domain @PowerDomain
-  firrtl.module @ReUseAnonDomain() {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %ClockDomain = firrtl.domain.anon
-    // CHECK: %PowerDomain = firrtl.domain.anon
-    // CHECK: %w1 = firrtl.wire domains[%ClockDomain, %PowerDomain] 
+  // CHECK: firrtl.module @ReUseAnonDomain(
+  // CHECK-SAME: in %ClockDomain: !firrtl.domain<@ClockDomain()>,
+  // CHECK-SAME: in %PowerDomain: !firrtl.domain<@PowerDomain()>,
+  // CHECK-SAME: in %x: !firrtl.uint<1> domains [%ClockDomain, %PowerDomain]
+  firrtl.module @ReUseAnonDomain(in %x: !firrtl.uint<1>) {
+    // CHECK: %w1 = firrtl.wire domains[%ClockDomain, %PowerDomain]
     %w1 = firrtl.wire : !firrtl.uint<1>
     // CHECK: %w2 = firrtl.wire domains[%ClockDomain, %PowerDomain]
     %w2 = firrtl.wire : !firrtl.uint<1>
-    firrtl.matchingconnect %w1, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %w1, %x : !firrtl.uint<1>
     firrtl.matchingconnect %w2, %w1 : !firrtl.uint<1>
   }
 }
@@ -663,7 +666,9 @@ firrtl.circuit "ProbeWire" {
   // CHECK: firrtl.module @ProbeWire(in %ClockDomain: !firrtl.domain<@ClockDomain()>, out %probe: !firrtl.probe<uint<1>> domains [%ClockDomain]) {
   firrtl.module @ProbeWire(out %probe: !firrtl.probe<uint<1>>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %w = firrtl.wire domains[%ClockDomain] : !firrtl.uint<1> domains[!firrtl.domain<@ClockDomain()>]
+    // The wire is driven only by a constant, so it is colorless and gets no
+    // explicit domain annotation, even though it is read through a probe.
+    // CHECK: %w = firrtl.wire : !firrtl.uint<1>
     %w = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.send %w : !firrtl.uint<1>
     firrtl.ref.define %probe, %0 : !firrtl.probe<uint<1>>
@@ -772,5 +777,178 @@ firrtl.circuit "CastConstantNoDomains" {
     %0 = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.unsafe_domain_cast %0 domains[] : !firrtl.uint<1>
     firrtl.connect %o, %1 : !firrtl.uint<1>
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Colorless (constant-derived) values (llvm/circt#10830).
+//
+// A value is colorless iff it is a constant, or a pure expression / node /
+// wire whose inputs are all colorless. Colorless values impose no domain
+// constraint and may be freely used in any domain without an explicit cast.
+//===----------------------------------------------------------------------===//
+
+// A node bound directly to a constant may be used in two different domains.
+// CHECK-LABEL: firrtl.circuit "ConstantNodeTwoDomains"
+firrtl.circuit "ConstantNodeTwoDomains" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ConstantNodeTwoDomains(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %x = firrtl.node %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %x : !firrtl.uint<1>
+  }
+}
+
+// A node bound to a constant *expression* (not just a bare constant) may
+// also be used in two different domains.
+// CHECK-LABEL: firrtl.circuit "ConstantExprNodeTwoDomains"
+firrtl.circuit "ConstantExprNodeTwoDomains" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ConstantExprNodeTwoDomains(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %0 = firrtl.eq %c1_ui1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %x = firrtl.node %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %x : !firrtl.uint<1>
+  }
+}
+
+// A deeply nested constant expression is still colorless and can be used
+// across multiple domains.
+// CHECK-LABEL: firrtl.circuit "DeeplyNestedConstantExpr"
+firrtl.circuit "DeeplyNestedConstantExpr" {
+  firrtl.domain @ClockDomain
+  firrtl.module @DeeplyNestedConstantExpr(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<4> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<4> domains [%B]
+  ) {
+    %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
+    %c2_ui4 = firrtl.constant 2 : !firrtl.uint<4>
+    %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %0 = firrtl.mux(%c0_ui1, %c2_ui4, %c3_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+    %1 = firrtl.add %c1_ui4, %0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %2 = firrtl.bits %1 3 to 0 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+    %3 = firrtl.not %2 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+    firrtl.matchingconnect %a, %3 : !firrtl.uint<4>
+    firrtl.matchingconnect %b, %3 : !firrtl.uint<4>
+  }
+}
+
+// A colorless subexpression mixed with a colored operand takes on the
+// operand's color: the result is usable wherever the colored operand's
+// domain is legal, but no longer colorless.
+// CHECK-LABEL: firrtl.circuit "ColorlessMixedWithColoredAdoptsColor"
+firrtl.circuit "ColorlessMixedWithColoredAdoptsColor" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ColorlessMixedWithColoredAdoptsColor(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    in %x: !firrtl.uint<1> domains [%A],
+    // CHECK: out %y: !firrtl.uint<1> domains [%A]
+    out %y: !firrtl.uint<1>
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %0 = firrtl.not %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.eq %0, %x : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.matchingconnect %y, %1 : !firrtl.uint<1>
+  }
+}
+
+// constCast of a constant preserves colorlessness.
+// CHECK-LABEL: firrtl.circuit "ConstCastPreservesColorless"
+firrtl.circuit "ConstCastPreservesColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ConstCastPreservesColorless(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.const.uint<1>
+    %0 = firrtl.constCast %c1_ui1 : (!firrtl.const.uint<1>) -> !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
+  }
+}
+
+// specialconstant (e.g. a clock/reset constant) is a colorless root.
+// CHECK-LABEL: firrtl.circuit "SpecialConstantColorless"
+firrtl.circuit "SpecialConstantColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @SpecialConstantColorless(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.clock domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.clock domains [%B]
+  ) {
+    %c = firrtl.specialconstant 0 : !firrtl.clock
+    firrtl.matchingconnect %a, %c : !firrtl.clock
+    firrtl.matchingconnect %b, %c : !firrtl.clock
+  }
+}
+
+// aggregateconstant is a colorless root.
+// CHECK-LABEL: firrtl.circuit "AggregateConstantColorless"
+firrtl.circuit "AggregateConstantColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @AggregateConstantColorless(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.bundle<x: uint<1>> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.bundle<x: uint<1>> domains [%B]
+  ) {
+    %c = firrtl.aggregateconstant [1 : ui1] : !firrtl.bundle<x: uint<1>>
+    firrtl.matchingconnect %a, %c : !firrtl.bundle<x: uint<1>>
+    firrtl.matchingconnect %b, %c : !firrtl.bundle<x: uint<1>>
+  }
+}
+
+// A wire fed only by constants is colorless and may be used in two domains.
+// CHECK-LABEL: firrtl.circuit "ColorlessWireConstOnly"
+firrtl.circuit "ColorlessWireConstOnly" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ColorlessWireConstOnly(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %w = firrtl.wire : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %w : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %w : !firrtl.uint<1>
+  }
+}
+
+// A wire with mixed drivers (one constant, one colored) is not colorless: it
+// takes on the colored driver's domain.
+// CHECK-LABEL: firrtl.circuit "MixedDriverWireTakesColor"
+firrtl.circuit "MixedDriverWireTakesColor" {
+  firrtl.domain @ClockDomain
+  firrtl.module @MixedDriverWireTakesColor(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    in %x: !firrtl.uint<1> domains [%A],
+    // CHECK: out %a: !firrtl.uint<1> domains [%A]
+    out %a: !firrtl.uint<1>
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %w = firrtl.wire : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %w : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/infer-domains-infer-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-errors.mlir
@@ -52,3 +52,148 @@ firrtl.circuit "IllegalDomainCrossing" {
     firrtl.matchingconnect %b, %a : !firrtl.uint<1>
   }
 }
+
+// Negative colorless case: two genuinely different colors combined through an
+// otherwise-colorless-looking add is still an illegal crossing (neither
+// operand is actually colorless).
+
+// CHECK-LABEL: TwoColorsStillError
+firrtl.circuit "TwoColorsStillError" {
+  firrtl.domain @ClockDomain
+  firrtl.module @TwoColorsStillError(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{a has domains [A : ClockDomain]}}
+    in %a: !firrtl.uint<4> domains [%A],
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    in %b: !firrtl.uint<4> domains [%B],
+    out %c: !firrtl.uint<5> domains [%A]
+  ) {
+    // expected-error @below {{illegal domain crossing in operation}}
+    %0 = firrtl.add %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    firrtl.matchingconnect %c, %0 : !firrtl.uint<5>
+  }
+}
+
+// Negative colorless case: a value that mixes a colored operand with a
+// colorless one is colored, not colorless, and still conflicts when used in
+// a different domain.
+
+// CHECK-LABEL: ColorlessPlusColoredStillError
+firrtl.circuit "ColorlessPlusColoredStillError" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ColorlessPlusColoredStillError(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    in %x: !firrtl.uint<1> domains [%A],
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %y = firrtl.node %c1_ui1 : !firrtl.uint<1>
+    // expected-note @below {{%0 has domains [A : ClockDomain]}}
+    %0 = firrtl.eq %x, %y : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
+  }
+}
+
+// Negative colorless case: a public output port driven by a pure constant
+// still requires an explicit domain association (Q2 restriction preserved).
+
+// CHECK-LABEL: PublicPortConstantStillMissing
+firrtl.circuit "PublicPortConstantStillMissing" {
+  firrtl.domain @ClockDomain
+  // expected-note @below {{in module "PublicPortConstantStillMissing"}}
+  firrtl.module @PublicPortConstantStillMissing(
+    // expected-error @below {{missing "ClockDomain" association for port "a"}}
+    out %a: !firrtl.uint<1>
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %c1_ui1 : !firrtl.uint<1>
+  }
+}
+
+// Robustness: an undriven wire is not colorless (it behaves like an invalid
+// value) and still errors when used in two different domains.
+
+// CHECK-LABEL: UndrivenWireNotColorless
+firrtl.circuit "UndrivenWireNotColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @UndrivenWireNotColorless(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<1> domains [%B],
+    out %a: !firrtl.uint<1> domains [%A]
+  ) {
+    // expected-note @below {{w has domains [A : ClockDomain]}}
+    %w = firrtl.wire : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %w : !firrtl.uint<1>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %w : !firrtl.uint<1>
+  }
+}
+
+// Robustness: invalidvalue is not constant-like (it is a fresh unique value
+// on every use) and must not be treated as colorless.
+
+// CHECK-LABEL: InvalidValueNotColorless
+firrtl.circuit "InvalidValueNotColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @InvalidValueNotColorless(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    // expected-note @below {{%invalid_ui1 has domains [A : ClockDomain]}}
+    %0 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
+  }
+}
+
+// Known limitation (Q3, cross-module colorless propagation is out of scope):
+// a private module whose output is a purely-constant expression is *not*
+// treated as colorless at its instantiation sites, so this still errors.
+// This is intentional; a follow-up session may relax it.
+
+// CHECK-LABEL: PrivateModuleConstantOutputStillErrors
+firrtl.circuit "PrivateModuleConstantOutputStillErrors" {
+  firrtl.domain @ClockDomain
+
+  firrtl.module private @Bar(out %o: !firrtl.uint<4>) {
+    %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
+    %c2_ui4 = firrtl.constant 2 : !firrtl.uint<4>
+    %0 = firrtl.add %c1_ui4, %c2_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %1 = firrtl.bits %0 3 to 0 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+    firrtl.matchingconnect %o, %1 : !firrtl.uint<4>
+  }
+
+  firrtl.module @PrivateModuleConstantOutputStillErrors(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<4> domains [%A],
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<4> domains [%B]
+  ) {
+    // expected-note @below {{bar.o has domains [A : ClockDomain]}}
+    %bar_o = firrtl.instance bar @Bar(out o: !firrtl.uint<4>)
+    firrtl.matchingconnect %a, %bar_o : !firrtl.uint<4>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %bar_o : !firrtl.uint<4>
+  }
+}

--- a/test/firtool/domains-colorless.fir
+++ b/test/firtool/domains-colorless.fir
@@ -1,0 +1,37 @@
+; RUN: firtool %s -domain-mode=infer -o /dev/null
+; RUN: firtool %s -domain-mode=infer -output-final-mlir - -o /dev/null | FileCheck %s
+
+; Reproducer for llvm/circt#10830: a constant, or an expression fully composed
+; of constants, is colorless and may be consumed by values in two different
+; domains without being treated as an illegal domain crossing.
+;
+;   - `x` is a node bound directly to a constant.
+;   - `y` is a node bound to a constant *expression* (not just a bare
+;     constant).
+;
+; Both are used across two distinct domains A and B.
+
+FIRRTL version 7.0.0
+circuit Foo:
+
+  domain ClockDomain:
+
+  public module Foo:
+    input A: Domain of ClockDomain
+    input B: Domain of ClockDomain
+    output a: UInt<1> domains [A]
+    output b: UInt<1> domains [B]
+    output c: UInt<1> domains [A]
+    output d: UInt<1> domains [B]
+
+    ; Bare constant used in two domains.
+    node x = UInt<1>(1)
+    connect a, x
+    connect b, x
+
+    ; Constant expression used in two domains.
+    node y = eq(UInt<1>(1), UInt<1>(1))
+    connect c, y
+    connect d, y
+
+; CHECK-LABEL: om.class @Foo_Class


### PR DESCRIPTION
Use the more general `walkDrivers` utility to more accurately determine
when a value is entirely driven by a constant in the `InferDomains` pass.
These values are then treated as "colorless" and not assigned a domain.

This is used to allow for constants to be shared between domains while not
being assigned to any domain.

Note: this includes two logical commits.  The first does _not_ use
`walkDrivers` and uses an LLVM Developer Policy illegal recursion over the
IR.  This may be advantageous to revive or switch to (with a suitable
iterative implementation).

Fixes #10830.

**Warning: This has not been sufficiently self-reviewed by me at this time! I'm keeping this as draft while I sort through it and if we want to do this.**