### PR TITLE
[ImportVerilog][MooreToCore] Frontend completeness batch: severity tasks, packed-aggregate selects/case, interface-port arrays, OOB extract_ref

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -291,10 +291,22 @@ struct ExprVisitor {
 
     if (!isa<moore::IntType, moore::ArrayType, moore::UnpackedArrayType,
              moore::QueueType, moore::AssocArrayType, moore::StringType,
-             moore::OpenUnpackedArrayType>(derefType)) {
+             moore::OpenUnpackedArrayType, moore::StructType, moore::UnionType>(
+            derefType)) {
       mlir::emitError(loc) << "unsupported expression: element select into "
                            << expr.value().type->toString() << "\n";
       return {};
+    }
+
+    // A packed struct or union is a vector of bits (IEEE 1800-2017 § 7.2.1);
+    // element select into it is a bit select. The `extract_ref` and
+    // `dyn_extract_ref` ops support packed aggregates directly; for rvalues,
+    // convert the aggregate to its simple bit vector equivalent first.
+    if (!isLvalue && isa<moore::StructType, moore::UnionType>(derefType)) {
+      value = context.convertToSimpleBitVector(value);
+      if (!value)
+        return {};
+      derefType = value.getType();
     }
 
     // Associative Arrays are a special case so handle them separately.
@@ -438,6 +450,15 @@ struct ExprVisitor {
 
     if (isa<moore::QueueType>(derefType)) {
       return handleQueueRangeSelectExpressions(expr, type, value);
+    }
+    // Packed structs and unions are bit vectors (IEEE 1800-2017 § 7.2.1); a
+    // range select into them is a part select. The ref-typed extract ops
+    // support packed aggregates directly; convert rvalues to the simple bit
+    // vector equivalent first.
+    if (!isLvalue && isa<moore::StructType, moore::UnionType>(derefType)) {
+      value = context.convertToSimpleBitVector(value);
+      if (!value)
+        return {};
     }
     return handleArrayRangeSelectExpressions(expr, type, value);
   }

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -134,19 +134,45 @@ static uint64_t getTimeScaleInFemtoseconds(Context &context) {
 static Value lookupExpandedInterfaceMember(
     Context &context, const slang::ast::HierarchicalValueExpression &expr) {
   auto nameAttr = context.builder.getStringAttr(expr.symbol.name);
-  for (const auto &element : expr.ref.path) {
-    auto *inst = element.symbol->as_if<slang::ast::InstanceSymbol>();
-    if (!inst)
-      continue;
-    auto *lowering = context.interfaceInstances.lookup(inst);
+  auto findIn = [&](InterfaceLowering *lowering) -> Value {
     if (!lowering)
-      continue;
+      return {};
     if (auto it = lowering->expandedMembers.find(&expr.symbol);
         it != lowering->expandedMembers.end())
       return it->second;
     if (auto it = lowering->expandedMembersByName.find(nameAttr);
         it != lowering->expandedMembersByName.end())
       return it->second;
+    return {};
+  };
+  for (const auto &element : expr.ref.path) {
+    // Element accesses on interface-instance ARRAYS (`intr[K].member`)
+    // traverse with an index selector. Depending on how slang resolved the
+    // reference, the traversed symbol is the element InstanceSymbol itself
+    // (handled by the InstanceSymbol case below), the enclosing
+    // InstanceArraySymbol, or a generic interface PORT connected to an
+    // array (resolved through the per-element port lowerings).
+    if (const auto *idx = std::get_if<int32_t>(&element.selector);
+        idx && *idx >= 0) {
+      if (Value value = findIn(context.ifacePortElementLowerings.lookup(
+              {element.symbol.get(), static_cast<unsigned>(*idx)})))
+        return value;
+      if (const auto *array =
+              element.symbol->as_if<slang::ast::InstanceArraySymbol>()) {
+        if (static_cast<size_t>(*idx) < array->elements.size()) {
+          if (const auto *elemInst = array->elements[static_cast<size_t>(*idx)]
+                                         ->as_if<slang::ast::InstanceSymbol>())
+            if (Value value =
+                    findIn(context.interfaceInstances.lookup(elemInst)))
+              return value;
+        }
+      }
+    }
+    auto *inst = element.symbol->as_if<slang::ast::InstanceSymbol>();
+    if (!inst)
+      continue;
+    if (Value value = findIn(context.interfaceInstances.lookup(inst)))
+      return value;
   }
   return {};
 }

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -73,6 +73,15 @@ struct FlattenedIfacePort {
   /// not the underlying interface body variable, so we register both keys in
   /// `valueSymbols` to make the lookup find this port's `BlockArgument`.
   const slang::ast::Symbol *modportPortSym = nullptr;
+  /// For ports connected to an ARRAY of interface instances (`interface
+  /// intr[4]` connected to `interrupt_if IRQ[4]()`), the element index this
+  /// flattened port belongs to. Element ports are NOT registered in the plain
+  /// `valueSymbols` table (slang's canonical-body caching can alias
+  /// `intr[0].irq` and `intr[1].irq` to the same `VariableSymbol`, and a
+  /// last-wins insert would silently mis-resolve); in-body accesses resolve
+  /// through `lookupExpandedInterfaceMember` via the per-element
+  /// `InterfaceLowering` keyed by `ifaceInstance` instead.
+  std::optional<unsigned> elementIdx;
   /// Slot index in the module signature; see `PortLowering::outputIdx`.
   std::optional<unsigned> outputIdx;
   std::optional<unsigned> inputIdx;
@@ -498,6 +507,13 @@ struct Context {
   /// Owning storage for InterfaceLowering objects
   /// because ScopedHashTable stores values by copy.
   SmallVector<std::unique_ptr<InterfaceLowering>> interfaceInstanceStorage;
+  /// Per-element interface lowerings for generic interface ports connected to
+  /// an ARRAY of interface instances, keyed by (interface port symbol,
+  /// element index). Body-level accesses like `intr[K].member` resolve
+  /// through this map when the hierarchical reference path carries the port
+  /// symbol with an index selector (see `lookupExpandedInterfaceMember`).
+  DenseMap<std::pair<const slang::ast::Symbol *, unsigned>, InterfaceLowering *>
+      ifacePortElementLowerings;
 
   /// Module instances already emitted by the predeclaration pass. These are
   /// skipped during the later source-order module-body walk to avoid emitting

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -493,6 +493,15 @@ struct StmtVisitor {
     if (!caseExpr)
       return failure();
 
+    // Packed aggregates compare as their vector-of-bits equivalent (IEEE
+    // 1800-2017 § 7.2.1); the case comparison ops require simple bit
+    // vectors.
+    if (isa<moore::StructType, moore::UnionType>(caseExpr.getType())) {
+      caseExpr = context.convertToSimpleBitVector(caseExpr);
+      if (!caseExpr)
+        return failure();
+    }
+
     // Check each case individually. This currently ignores the `unique`,
     // `unique0`, and `priority` modifiers which would allow for additional
     // optimizations.
@@ -524,6 +533,13 @@ struct StmtVisitor {
           if (!value)
             return failure();
           itemLoc = value.getLoc();
+
+          // Packed aggregate items compare as bit vectors as well.
+          if (isa<moore::StructType, moore::UnionType>(value.getType())) {
+            value = context.convertToSimpleBitVector(value);
+            if (!value)
+              return failure();
+          }
 
           // Take note if the expression is a constant.
           auto maybeConst = value;

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -1083,8 +1083,12 @@ struct StmtVisitor {
       return context.convertRvalueExpression(
           *args[0], builder.getType<moore::FormatStringType>());
     }
-    // Otherwise this looks invalid. Raise an error.
-    return emitError(loc) << "Failed to convert Display Message!";
+    // Otherwise treat the arguments exactly like `$display` does (IEEE
+    // 1800-2023 Section 20.10: severity tasks display their arguments in the
+    // same way as `$display`). A leading non-string literal, as in
+    // `$warning(1, "fmt", ...)`, is simply a displayed argument; any string
+    // literal among the arguments acts as a format string.
+    return context.convertFormatString(args, loc);
   }
 
   /// Convert a `$readmemb`/`$readmemh` system task call into a

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -439,6 +439,16 @@ struct ModuleVisitor : public BaseVisitor {
     return success();
   }
 
+  // Interface (and module) instance ARRAYS: visit each element so interface
+  // instances inside arrays are expanded like their scalar siblings.
+  LogicalResult visit(const slang::ast::InstanceArraySymbol &arrayNode) {
+    for (const auto *element : arrayNode.elements) {
+      if (element && failed(element->visit(*this)))
+        return failure();
+    }
+    return success();
+  }
+
   // Handle instances.
   LogicalResult visit(const slang::ast::InstanceSymbol &instNode) {
     using slang::ast::ArgumentDirection;
@@ -480,9 +490,11 @@ struct ModuleVisitor : public BaseVisitor {
     SmallDenseMap<const PortSymbol *, Value> portValues;
     portValues.reserve(moduleType.getNumPorts());
 
-    // Map each InterfacePortSymbol to the connected interface instance.
+    // Map each InterfacePortSymbol to the connected interface instance(s):
+    // one element for a scalar connection, N for an interface-instance-array
+    // connection, in array order.
     SmallDenseMap<const slang::ast::InterfacePortSymbol *,
-                  const slang::ast::InstanceSymbol *>
+                  SmallVector<const slang::ast::InstanceSymbol *, 4>>
         ifaceConnMap;
 
     for (const auto *con : instNode.getPortConnections()) {
@@ -616,10 +628,27 @@ struct ModuleVisitor : public BaseVisitor {
       if (const auto *ifacePort =
               con->port.as_if<slang::ast::InterfacePortSymbol>()) {
         auto ifaceConn = con->getIfaceConn();
-        const auto *connInst =
-            ifaceConn.first->as_if<slang::ast::InstanceSymbol>();
-        if (connInst)
-          ifaceConnMap[ifacePort] = connInst;
+        if (const auto *connInst =
+                ifaceConn.first->as_if<slang::ast::InstanceSymbol>()) {
+          ifaceConnMap[ifacePort].push_back(connInst);
+        } else if (const auto *connArray =
+                       ifaceConn.first
+                           ->as_if<slang::ast::InstanceArraySymbol>()) {
+          // Array connection: collect the element instances in order.
+          auto &elements = ifaceConnMap[ifacePort];
+          for (const auto *element : connArray->elements) {
+            const auto *elemInst =
+                element ? element->as_if<slang::ast::InstanceSymbol>()
+                        : nullptr;
+            if (!elemInst) {
+              mlir::emitError(loc)
+                  << "unsupported interface array connection for port `"
+                  << con->port.name << "`";
+              return failure();
+            }
+            elements.push_back(elemInst);
+          }
+        }
         continue;
       }
 
@@ -651,12 +680,18 @@ struct ModuleVisitor : public BaseVisitor {
         continue;
       // Find which interface instance is connected to this port.
       auto it = ifaceConnMap.find(fp.origin);
-      if (it == ifaceConnMap.end()) {
+      if (it == ifaceConnMap.end() || it->second.empty()) {
         mlir::emitError(loc)
             << "no interface connection for port `" << fp.name << "`";
         return failure();
       }
-      const auto *connInst = it->second;
+      unsigned connIdx = fp.elementIdx.value_or(0);
+      if (connIdx >= it->second.size()) {
+        mlir::emitError(loc) << "interface array connection for port `"
+                             << fp.name << "` has too few elements";
+        return failure();
+      }
+      const auto *connInst = it->second[connIdx];
       // Look up the InterfaceLowering for that instance.
       auto *ifaceLowering = context.interfaceInstances.lookup(connInst);
       if (!ifaceLowering) {
@@ -1118,6 +1153,15 @@ struct ModulePredeclaration {
   LogicalResult predeclareInterfaceMember(const slang::ast::Symbol &member,
                                           StringRef blockNamePrefix) {
     auto loc = context.convertLocation(member.location);
+    if (const auto *arrayNode =
+            member.as_if<slang::ast::InstanceArraySymbol>()) {
+      for (const auto *element : arrayNode->elements)
+        if (element &&
+            failed(predeclareInterfaceMember(*element, blockNamePrefix)))
+          return failure();
+      return success();
+    }
+
     if (const auto *instNode = member.as_if<slang::ast::InstanceSymbol>()) {
       if (instNode->body.getDefinition().definitionKind ==
           slang::ast::DefinitionKind::Interface)
@@ -1143,6 +1187,15 @@ struct ModulePredeclaration {
   LogicalResult predeclareModuleInstanceMember(const slang::ast::Symbol &member,
                                                StringRef blockNamePrefix) {
     auto loc = context.convertLocation(member.location);
+    if (const auto *arrayNode =
+            member.as_if<slang::ast::InstanceArraySymbol>()) {
+      for (const auto *element : arrayNode->elements)
+        if (element &&
+            failed(predeclareModuleInstanceMember(*element, blockNamePrefix)))
+          return failure();
+      return success();
+    }
+
     if (const auto *instNode = member.as_if<slang::ast::InstanceSymbol>()) {
       if (instNode->body.getDefinition().definitionKind !=
           slang::ast::DefinitionKind::Interface) {
@@ -1433,41 +1486,86 @@ Context::convertModuleHeader(const slang::ast::InstanceBodySymbol *module) {
           }
           lowering.ifacePorts.push_back(
               {name, dir, type, portLoc, arg, &ifacePort, mpp->internalSymbol,
-               ifaceInst, mpp, ifaceOutputIdx, ifaceInputIdx});
+               ifaceInst, mpp, std::nullopt, ifaceOutputIdx, ifaceInputIdx});
         }
       } else {
         // No modport: iterate interface body for all variables and nets.
         // Treat them all as inout (input with ref type).
-        const auto *instSym = connSym->as_if<slang::ast::InstanceSymbol>();
-        if (!instSym) {
+        // `connSym` is null when the port has no connection at all, e.g. a
+        // generic interface port of a module elaborated as the top level
+        // (slang accepts that with a warning); there is no interface body
+        // to flatten, so reject with a diagnostic instead of crashing.
+        if (!connSym) {
+          mlir::emitError(portLoc)
+              << "unconnected interface port `" << ifacePort.name
+              << "`; a module with generic interface ports cannot be "
+                 "imported as a top-level module";
+          return failure();
+        }
+        // Flatten one connected interface instance's body members to ref
+        // ports. `pfx`/`elemIdx` distinguish the elements of an
+        // interface-instance-ARRAY connection (`interface intr[4]` connected
+        // to `interrupt_if IRQ[4]()`): each element is flattened with the
+        // port prefix `<port>_<i>_` and resolves through its own element
+        // instance.
+        auto flattenIfaceInstance =
+            [&](const slang::ast::InstanceSymbol *instSym, StringRef pfx,
+                std::optional<unsigned> elemIdx) -> LogicalResult {
+          for (const auto &member : instSym->body.members()) {
+            const slang::ast::Type *slangType = nullptr;
+            const slang::ast::Symbol *bodySym = nullptr;
+            if (const auto *var = member.as_if<slang::ast::VariableSymbol>()) {
+              slangType = &var->getType();
+              bodySym = var;
+            } else if (const auto *net =
+                           member.as_if<slang::ast::NetSymbol>()) {
+              slangType = &net->getType();
+              bodySym = net;
+            } else {
+              continue;
+            }
+            auto type = convertType(*slangType);
+            if (!type)
+              return failure();
+            auto name =
+                builder.getStringAttr(Twine(pfx) + StringRef(bodySym->name));
+            auto refType = moore::RefType::get(cast<moore::UnpackedType>(type));
+            modulePorts.push_back({name, refType, hw::ModulePort::Input});
+            auto arg = block->addArgument(refType, portLoc);
+            lowering.ifacePorts.push_back(
+                {name, hw::ModulePort::Input, refType, portLoc, arg, &ifacePort,
+                 bodySym, instSym, nullptr, elemIdx, std::nullopt, inputIdx++});
+          }
+          return success();
+        };
+
+        if (ifaceInst) {
+          if (failed(flattenIfaceInstance(ifaceInst, portPrefix, std::nullopt)))
+            return failure();
+        } else if (const auto *arraySym =
+                       connSym->as_if<slang::ast::InstanceArraySymbol>()) {
+          // Array-of-interface-instances connection: flatten each element.
+          for (auto [i, element] : llvm::enumerate(arraySym->elements)) {
+            const auto *elemInst =
+                element ? element->as_if<slang::ast::InstanceSymbol>()
+                        : nullptr;
+            if (!elemInst) {
+              mlir::emitError(portLoc)
+                  << "unsupported interface port array connection for `"
+                  << ifacePort.name
+                  << "` (multi-dimensional arrays are not supported)";
+              return failure();
+            }
+            auto pfx = (Twine(portPrefix) + Twine(i) + "_").str();
+            if (failed(flattenIfaceInstance(elemInst, pfx,
+                                            static_cast<unsigned>(i))))
+              return failure();
+          }
+        } else {
           mlir::emitError(portLoc)
               << "unsupported interface port connection for `" << ifacePort.name
               << "`";
           return failure();
-        }
-        for (const auto &member : instSym->body.members()) {
-          const slang::ast::Type *slangType = nullptr;
-          const slang::ast::Symbol *bodySym = nullptr;
-          if (const auto *var = member.as_if<slang::ast::VariableSymbol>()) {
-            slangType = &var->getType();
-            bodySym = var;
-          } else if (const auto *net = member.as_if<slang::ast::NetSymbol>()) {
-            slangType = &net->getType();
-            bodySym = net;
-          } else {
-            continue;
-          }
-          auto type = convertType(*slangType);
-          if (!type)
-            return failure();
-          auto name = builder.getStringAttr(Twine(portPrefix) +
-                                            StringRef(bodySym->name));
-          auto refType = moore::RefType::get(cast<moore::UnpackedType>(type));
-          modulePorts.push_back({name, refType, hw::ModulePort::Input});
-          auto arg = block->addArgument(refType, portLoc);
-          lowering.ifacePorts.push_back(
-              {name, hw::ModulePort::Input, refType, portLoc, arg, &ifacePort,
-               bodySym, instSym, nullptr, std::nullopt, inputIdx++});
         }
       }
       return success();
@@ -1626,6 +1724,23 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
           Value());
     } else {
       portValue = fp.arg;
+    }
+    if (fp.elementIdx.has_value()) {
+      // Element ports of an interface-array connection resolve ONLY through
+      // the per-element InterfaceLowering: slang's canonical-body caching can
+      // alias `intr[0].member` and `intr[1].member` to the same body
+      // `VariableSymbol`, so a plain last-wins `valueSymbols` insert would
+      // silently resolve every element access to the LAST element. The
+      // lookup side walks the hierarchical reference path for the element
+      // instance (and the port-with-index-selector form) instead.
+      if (auto *ifaceLowering = getIfacePortLowering(fp.ifaceInstance)) {
+        ifaceLowering->expandedMembers[fp.bodySym] = portValue;
+        ifaceLowering
+            ->expandedMembersByName[builder.getStringAttr(fp.bodySym->name)] =
+            portValue;
+        ifacePortElementLowerings[{fp.origin, *fp.elementIdx}] = ifaceLowering;
+      }
+      continue;
     }
     valueSymbols.insert(valueSym, portValue);
     // Slang resolves in-body accesses (e.g. `bus.r`) through the

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -490,10 +490,22 @@ struct ModuleVisitor : public BaseVisitor {
     SmallDenseMap<const PortSymbol *, Value> portValues;
     portValues.reserve(moduleType.getNumPorts());
 
-    // Map each InterfacePortSymbol to the connected interface instance(s):
+    // Map each interface port to the connected interface instance(s):
     // one element for a scalar connection, N for an interface-instance-array
-    // connection, in array order.
-    SmallDenseMap<const slang::ast::InterfacePortSymbol *,
+    // connection, in array order. Keyed by the port's SYNTAX node (falling
+    // back to the symbol pointer) rather than the `InterfacePortSymbol`
+    // itself: the flattened ports (`ifacePorts`) were built from the module's
+    // CANONICAL instance body, while the connections iterated here carry the
+    // port symbols of THIS instance's body — distinct symbols for the same
+    // source declaration on every non-canonical instance. The syntax node is
+    // shared across all instance bodies (same trick `portsBySyntaxNode` uses
+    // for regular ports above).
+    auto ifaceConnKey = [](const slang::ast::Symbol &port) -> const void * {
+      if (const auto *syntax = port.getSyntax())
+        return syntax;
+      return &port;
+    };
+    SmallDenseMap<const void *,
                   SmallVector<const slang::ast::InstanceSymbol *, 4>>
         ifaceConnMap;
 
@@ -630,12 +642,12 @@ struct ModuleVisitor : public BaseVisitor {
         auto ifaceConn = con->getIfaceConn();
         if (const auto *connInst =
                 ifaceConn.first->as_if<slang::ast::InstanceSymbol>()) {
-          ifaceConnMap[ifacePort].push_back(connInst);
+          ifaceConnMap[ifaceConnKey(*ifacePort)].push_back(connInst);
         } else if (const auto *connArray =
                        ifaceConn.first
                            ->as_if<slang::ast::InstanceArraySymbol>()) {
           // Array connection: collect the element instances in order.
-          auto &elements = ifaceConnMap[ifacePort];
+          auto &elements = ifaceConnMap[ifaceConnKey(*ifacePort)];
           for (const auto *element : connArray->elements) {
             const auto *elemInst =
                 element ? element->as_if<slang::ast::InstanceSymbol>()
@@ -679,7 +691,7 @@ struct ModuleVisitor : public BaseVisitor {
       if (!fp.bodySym || !fp.origin)
         continue;
       // Find which interface instance is connected to this port.
-      auto it = ifaceConnMap.find(fp.origin);
+      auto it = ifaceConnMap.find(ifaceConnKey(*fp.origin));
       if (it == ifaceConnMap.end() || it->second.empty()) {
         mlir::emitError(loc)
             << "no interface connection for port `" << fp.name << "`";
@@ -699,14 +711,23 @@ struct ModuleVisitor : public BaseVisitor {
             << "interface instance `" << connInst->name << "` was not expanded";
         return failure();
       }
-      // Find the expanded SSA value for this body member.
+      // Find the expanded SSA value for this body member. Fall back to the
+      // member NAME if the symbol pointer misses: the flattened port's
+      // `bodySym` was recorded from the canonical connection's body, while the
+      // connected instance here may have been expanded from a non-canonical
+      // body carrying distinct member symbols for the same declarations.
+      Value val;
       auto valIt = ifaceLowering->expandedMembers.find(fp.bodySym);
-      if (valIt == ifaceLowering->expandedMembers.end()) {
+      if (valIt != ifaceLowering->expandedMembers.end())
+        val = valIt->second;
+      else
+        val = ifaceLowering->expandedMembersByName.lookup(
+            builder.getStringAttr(fp.bodySym->name));
+      if (!val) {
         mlir::emitError(loc)
             << "unresolved interface port signal `" << fp.name << "`";
         return failure();
       }
-      Value val = valIt->second;
       if (fp.direction == hw::ModulePort::Output) {
         outputValues[*fp.outputIdx] = val;
       } else {
@@ -1459,35 +1480,72 @@ Context::convertModuleHeader(const slang::ast::InstanceBodySymbol *module) {
 
       if (modportSym) {
         // Modport specified: iterate modport members for signal directions.
-        for (const auto &member : modportSym->members()) {
-          const auto *mpp = member.as_if<slang::ast::ModportPortSymbol>();
-          if (!mpp)
-            continue;
-          auto type = convertType(mpp->getType());
-          if (!type)
-            return failure();
-          auto name =
-              builder.getStringAttr(Twine(portPrefix) + StringRef(mpp->name));
-          BlockArgument arg;
-          hw::ModulePort::Direction dir;
-          std::optional<unsigned> ifaceOutputIdx;
-          std::optional<unsigned> ifaceInputIdx;
-          if (mpp->direction == ArgumentDirection::Out) {
-            dir = hw::ModulePort::Output;
-            modulePorts.push_back({name, type, dir});
-            ifaceOutputIdx = outputIdx++;
-          } else {
-            dir = hw::ModulePort::Input;
-            if (mpp->direction != ArgumentDirection::In)
-              type = moore::RefType::get(cast<moore::UnpackedType>(type));
-            modulePorts.push_back({name, type, dir});
-            arg = block->addArgument(type, portLoc);
-            ifaceInputIdx = inputIdx++;
+        // `flattenModport` flattens the modport members once for a scalar
+        // connection; for an interface-instance-ARRAY connection each element
+        // is flattened separately (port prefix `<port>_<i>_`, per-element
+        // instance resolution), mirroring the generic (no-modport) array path
+        // below.
+        auto flattenModport =
+            [&](const slang::ast::InstanceSymbol *instSym, StringRef pfx,
+                std::optional<unsigned> elemIdx) -> LogicalResult {
+          for (const auto &member : modportSym->members()) {
+            const auto *mpp = member.as_if<slang::ast::ModportPortSymbol>();
+            if (!mpp)
+              continue;
+            auto type = convertType(mpp->getType());
+            if (!type)
+              return failure();
+            auto name =
+                builder.getStringAttr(Twine(pfx) + StringRef(mpp->name));
+            BlockArgument arg;
+            hw::ModulePort::Direction dir;
+            std::optional<unsigned> ifaceOutputIdx;
+            std::optional<unsigned> ifaceInputIdx;
+            if (mpp->direction == ArgumentDirection::Out) {
+              dir = hw::ModulePort::Output;
+              modulePorts.push_back({name, type, dir});
+              ifaceOutputIdx = outputIdx++;
+            } else {
+              dir = hw::ModulePort::Input;
+              if (mpp->direction != ArgumentDirection::In)
+                type = moore::RefType::get(cast<moore::UnpackedType>(type));
+              modulePorts.push_back({name, type, dir});
+              arg = block->addArgument(type, portLoc);
+              ifaceInputIdx = inputIdx++;
+            }
+            lowering.ifacePorts.push_back(
+                {name, dir, type, portLoc, arg, &ifacePort, mpp->internalSymbol,
+                 instSym, mpp, elemIdx, ifaceOutputIdx, ifaceInputIdx});
           }
-          lowering.ifacePorts.push_back(
-              {name, dir, type, portLoc, arg, &ifacePort, mpp->internalSymbol,
-               ifaceInst, mpp, std::nullopt, ifaceOutputIdx, ifaceInputIdx});
+          return success();
+        };
+        if (!ifaceInst && connSym) {
+          if (const auto *arraySym =
+                  connSym->as_if<slang::ast::InstanceArraySymbol>()) {
+            // Array-of-interface-instances connection: flatten the modport
+            // members once per element so element connections and in-body
+            // `port[i].member` accesses resolve per element.
+            for (auto [i, element] : llvm::enumerate(arraySym->elements)) {
+              const auto *elemInst =
+                  element ? element->as_if<slang::ast::InstanceSymbol>()
+                          : nullptr;
+              if (!elemInst) {
+                mlir::emitError(portLoc)
+                    << "unsupported interface port array connection for `"
+                    << ifacePort.name
+                    << "` (multi-dimensional arrays are not supported)";
+                return failure();
+              }
+              auto pfx = (Twine(portPrefix) + Twine(i) + "_").str();
+              if (failed(
+                      flattenModport(elemInst, pfx, static_cast<unsigned>(i))))
+                return failure();
+            }
+            return success();
+          }
         }
+        if (failed(flattenModport(ifaceInst, portPrefix, std::nullopt)))
+          return failure();
       } else {
         // No modport: iterate interface body for all variables and nets.
         // Treat them all as inout (input with ref type).
@@ -1834,6 +1892,14 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
     if (!valueSym)
       continue;
     Value ref = valueSymbols.lookup(valueSym);
+    if (!ref && fp.elementIdx) {
+      // Element ports of an interface-array connection are not registered in
+      // `valueSymbols` (by design; see the flattening comment above); resolve
+      // the internal reference through the per-element interface lowering.
+      if (auto *elemLowering =
+              ifacePortElementLowerings.lookup({fp.origin, *fp.elementIdx}))
+        ref = elemLowering->expandedMembers.lookup(fp.bodySym);
+    }
     if (!ref)
       continue;
     outputs[*fp.outputIdx] =

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1856,6 +1856,39 @@ struct NegOpConversion : public OpConversionPattern<NegOp> {
   }
 };
 
+struct Clog2BIOpConversion : public OpConversionPattern<Clog2BIOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(Clog2BIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value input = adaptor.getValue();
+    auto intType = dyn_cast<IntegerType>(input.getType());
+    if (!intType || intType.getWidth() == 0)
+      return failure();
+    unsigned width = intType.getWidth();
+
+    // $clog2(x) is the index of the highest set bit of (x - 1) plus one, and
+    // 0 for x <= 1 ($clog2(0) is defined as 0; IEEE 1800-2017 § 20.8.1).
+    // Priority-encode (x - 1) with a mux chain from LSB to MSB.
+    Value one = hw::ConstantOp::create(rewriter, loc, intType, 1);
+    Value zero = hw::ConstantOp::create(rewriter, loc, intType, 0);
+    Value xm1 = comb::SubOp::create(rewriter, loc, input, one);
+    Value result = zero;
+    for (unsigned i = 0; i < width; ++i) {
+      Value bit = comb::ExtractOp::create(rewriter, loc, xm1, i, 1);
+      Value count = hw::ConstantOp::create(rewriter, loc, intType, i + 1);
+      result = comb::MuxOp::create(rewriter, loc, bit, count, result, false);
+    }
+    // (0 - 1) is all-ones and would priority-encode to `width`; force the
+    // defined result 0 for a zero input.
+    Value isZero = comb::ICmpOp::create(rewriter, loc, comb::ICmpPredicate::eq,
+                                        input, zero);
+    rewriter.replaceOpWithNewOp<comb::MuxOp>(op, isZero, zero, result, false);
+    return success();
+  }
+};
+
 struct NegRealOpConversion : public OpConversionPattern<NegRealOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -3863,6 +3896,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     BoolCastOpConversion,
     NotOpConversion,
     NegOpConversion,
+    Clog2BIOpConversion,
 
     // Patterns of binary operations.
     BinaryOpConversion<AddOp, comb::AddOp>,

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1938,6 +1938,28 @@ struct ICmpOpConversion : public OpConversionPattern<SourceOp> {
     Type resultType =
         ConversionPattern::typeConverter->convertType(op.getResult().getType());
 
+    // Case equality against a constant carrying x/z bits: this two-valued
+    // lowering never materializes x/z at run time, so an x/z constant bit
+    // can never case-match (IEEE 1800-2017 11.4.5: `===` compares x/z
+    // literally). Dropping the unknown bits in the converted constant would
+    // silently turn `v === 'x` into `v === 0` -- the `$isunknown` payload
+    // shape, which then fails on every all-zero sample -- so fold the
+    // comparison to its static verdict instead.
+    if constexpr (std::is_same_v<SourceOp, CaseEqOp> ||
+                  std::is_same_v<SourceOp, CaseNeOp>) {
+      auto hasUnknownConstBits = [](Value value) {
+        auto constant = value.getDefiningOp<ConstantOp>();
+        return constant && constant.getValue().hasUnknown();
+      };
+      if (hasUnknownConstBits(op.getLhs()) ||
+          hasUnknownConstBits(op.getRhs())) {
+        bool verdict = std::is_same_v<SourceOp, CaseNeOp>;
+        rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, resultType,
+                                                    verdict ? 1 : 0);
+        return success();
+      }
+    }
+
     rewriter.replaceOpWithNewOp<comb::ICmpOp>(
         op, resultType, pred, adaptor.getLhs(), adaptor.getRhs());
     return success();

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1529,6 +1529,56 @@ struct ExtractRefOpConversion : public OpConversionPattern<ExtractRefOp> {
     Type inputType =
         cast<llhd::RefType>(adaptor.getInput().getType()).getNestedType();
 
+    // Statically fully out-of-range constant part/bit-select references
+    // (e.g. `slave_select[4] = 1;` on `logic [3:0] slave_select` under a
+    // statically-false parameter guard) reach lowering because the frontend
+    // demotes the diagnostic to a warning. IEEE 1800-2017 § 11.5.1 gives
+    // out-of-range select WRITES discard semantics (reads yield X; the
+    // two-valued core yields the scratch initializer instead). Route the
+    // reference at a detached scratch signal so the write lands nowhere.
+    // Partial straddles keep failing loudly below.
+    if (auto resultRefType = dyn_cast_or_null<llhd::RefType>(resultType)) {
+      int64_t inputWidth = hw::getBitWidth(inputType);
+      int64_t resultWidth = hw::getBitWidth(resultRefType.getNestedType());
+      if (inputWidth >= 0 && resultWidth >= 0 &&
+          adaptor.getLowBit() >= static_cast<uint64_t>(inputWidth)) {
+        Value init = createZeroValue(resultRefType.getNestedType(), op.getLoc(),
+                                     rewriter);
+        if (!init)
+          return failure();
+        op.emitRemark("out-of-range reference discards writes (IEEE "
+                      "1800-2017 11.5.1); routed to a scratch signal");
+        rewriter.replaceOpWithNewOp<llhd::SignalOp>(
+            op, resultType, rewriter.getStringAttr("oob_scratch"), init);
+        return success();
+      }
+    }
+
+    // Statically fully out-of-range constant part/bit-select references
+    // (e.g. `slave_select[4] = 1;` on `logic [3:0] slave_select` under a
+    // statically-false parameter guard) reach lowering because the frontend
+    // demotes the diagnostic to a warning. IEEE 1800-2017 § 11.5.1 gives
+    // out-of-range select WRITES discard semantics (reads yield X; the
+    // two-valued core yields the scratch initializer instead). Route the
+    // reference at a detached scratch signal so the write lands nowhere.
+    // Partial straddles keep failing loudly below.
+    if (auto resultRefType = dyn_cast_or_null<llhd::RefType>(resultType)) {
+      int64_t inputWidth = hw::getBitWidth(inputType);
+      int64_t resultWidth = hw::getBitWidth(resultRefType.getNestedType());
+      if (inputWidth >= 0 && resultWidth >= 0 &&
+          adaptor.getLowBit() >= static_cast<uint64_t>(inputWidth)) {
+        Value init = createZeroValue(resultRefType.getNestedType(), op.getLoc(),
+                                     rewriter);
+        if (!init)
+          return failure();
+        op.emitRemark("out-of-range reference discards writes (IEEE "
+                      "1800-2017 11.5.1); routed to a scratch signal");
+        rewriter.replaceOpWithNewOp<llhd::SignalOp>(
+            op, resultType, rewriter.getStringAttr("oob_scratch"), init);
+        return success();
+      }
+    }
+
     if (auto intType = dyn_cast<IntegerType>(inputType)) {
       int64_t width = hw::getBitWidth(inputType);
       if (width == -1)

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -229,6 +229,20 @@ function void DisplayAndSeverityBuiltins(int x, real r);
   // CHECK: [[TMP:%.+]] = moore.fmt.real
   // CHECK: moore.builtin.severity warning [[TMP]]
   $warning("%f", r);
+  // A leading non-string literal is a displayed argument, and any string
+  // literal among the arguments acts as a format string, exactly like
+  // `$display` (IEEE 1800-2023 § 20.10).
+  // CHECK: [[VERB:%.+]] = moore.fmt.int
+  // CHECK: [[MSG:%.+]] = moore.fmt.int
+  // CHECK: [[CAT:%.+]] = moore.fmt.concat ([[VERB]], [[MSG]])
+  // CHECK: moore.builtin.severity warning [[CAT]]
+  $warning(1, "%d", x);
+  // CHECK: [[ARG0:%.+]] = moore.fmt.int
+  // CHECK: [[LIT:%.+]] = moore.fmt.literal " x="
+  // CHECK: [[ARG1:%.+]] = moore.fmt.int
+  // CHECK: [[CAT:%.+]] = moore.fmt.concat ([[ARG0]], [[LIT]], [[ARG1]])
+  // CHECK: moore.builtin.severity error [[CAT]]
+  $error(x, " x=", x);
   // CHECK: [[TMP:%.+]] = moore.fmt.literal ""
   // CHECK: moore.builtin.severity error [[TMP]]
   $error;

--- a/test/Conversion/ImportVerilog/case-packed-aggregate.sv
+++ b/test/Conversion/ImportVerilog/case-packed-aggregate.sv
@@ -1,0 +1,25 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// Case comparisons over packed aggregates use the vector-of-bits
+// equivalent (IEEE 1800-2017 § 7.2.1).
+
+typedef union packed { logic [5:0] a; logic [5:0] b; } op_u;
+typedef struct packed { op_u t; } op_s;
+
+// CHECK-LABEL: moore.module @CasePackedAggregate
+module CasePackedAggregate;
+  op_s op;
+  logic r;
+  always_comb begin
+    // CHECK: [[SBV:%.+]] = moore.packed_to_sbv
+    // CHECK: moore.case_eq
+    // CHECK: moore.case_eq
+    unique case (op)
+      6'd1, 6'd2: r = 1'b0;
+      default:    r = 1'b1;
+    endcase
+  end
+endmodule

--- a/test/Conversion/ImportVerilog/interface-array-port.sv
+++ b/test/Conversion/ImportVerilog/interface-array-port.sv
@@ -1,0 +1,43 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+
+// Generic interface ports connected to an ARRAY of interface instances
+// (`interface p[2]` connected to `if_t X[2]()`): each element is flattened
+// with the port prefix `<port>_<i>_` and per-element accesses `p[K].member`
+// resolve to the K-th element's flattened ports — NOT last-wins across
+// elements (slang's canonical-body caching aliases the body member symbol
+// across elements, so element ports resolve through the per-element
+// interface lowering rather than the plain value-symbol table).
+
+interface array_if;
+  logic v;
+  logic w;
+endinterface
+
+// The DUT writes a different value to each element and reads one back:
+// distinct element ports must flow to distinct drives.
+// CHECK-LABEL: moore.module private @dut
+// CHECK-SAME: in %p_0_v : !moore.ref<l1>
+// CHECK-SAME: in %p_0_w : !moore.ref<l1>
+// CHECK-SAME: in %p_1_v : !moore.ref<l1>
+// CHECK-SAME: in %p_1_w : !moore.ref<l1>
+module dut (interface p[2], input logic a, input logic b, output logic y);
+  // CHECK: moore.procedure always
+  // CHECK: moore.nonblocking_assign %p_0_v, %{{.+}} : l1
+  // CHECK: moore.nonblocking_assign %p_1_v, %{{.+}} : l1
+  always @(a or b) begin
+    p[0].v <= a;
+    p[1].v <= b;
+  end
+  // Read-back rvalue path: y comes from element 1.
+  // CHECK: moore.read %p_1_w
+  assign y = p[1].w;
+endmodule
+
+// CHECK-LABEL: moore.module @ArrayIfTop
+module ArrayIfTop (input logic a, input logic b, output logic y);
+  array_if X[2] ();
+  // The instantiation resolves each element port to the matching element
+  // instance's expanded member storage.
+  // CHECK: moore.instance "u_dut" @dut
+  dut u_dut (.p(X), .a(a), .b(b), .y(y));
+endmodule

--- a/test/Conversion/ImportVerilog/interface-modport-array-port.sv
+++ b/test/Conversion/ImportVerilog/interface-modport-array-port.sv
@@ -1,0 +1,32 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+
+// Modport-qualified interface-ARRAY ports (`bus_if.slave bus[2]`) are
+// flattened once per element (prefix `<port>_<i>_`), so element connections
+// to child instances resolve through the per-element interface lowering
+// (previously: `interface instance was not expanded`).
+
+interface bus_if;
+  logic req;
+  logic ack;
+  modport slave(input req, output ack);
+endinterface
+
+module leaf(bus_if.slave bus);
+  assign bus.ack = bus.req;
+endmodule
+
+// CHECK: moore.module private @mid
+// CHECK-SAME: bus_0_req
+// CHECK-SAME: bus_1_req
+module mid(bus_if.slave bus[2]);
+  // CHECK: moore.instance "u0" @leaf
+  leaf u0(.bus(bus[0]));
+  // CHECK: moore.instance "u1" @leaf
+  leaf u1(.bus(bus[1]));
+endmodule
+
+// CHECK-LABEL: moore.module @top
+module top;
+  bus_if barr[2]();
+  mid u_mid(.bus(barr));
+endmodule

--- a/test/Conversion/ImportVerilog/interface-port-repeat-instances.sv
+++ b/test/Conversion/ImportVerilog/interface-port-repeat-instances.sv
@@ -1,0 +1,30 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+
+// Interface-port connections on NON-CANONICAL instance bodies: a module with
+// an interface port instantiated more than once (same specialization) carries
+// distinct InterfacePortSymbols per instance body for the same source
+// declaration. Connections must resolve to the canonical flattened ports via
+// the port's syntax node, for plain instance connections as well as for
+// element selects of a local interface instance array.
+
+interface bus_if;
+  logic req;
+  logic ack;
+endinterface
+
+module leaf(bus_if bus);
+  assign bus.ack = bus.req;
+endmodule
+
+// CHECK-LABEL: moore.module @top
+module top;
+  bus_if b0();
+  bus_if b1();
+  bus_if barr[2]();
+  // CHECK: moore.instance "u0" @leaf
+  leaf u0(.bus(b0));
+  // CHECK: moore.instance "u1" @leaf
+  leaf u1(.bus(b1));
+  // CHECK: moore.instance "u2" @leaf
+  leaf u2(.bus(barr[1]));
+endmodule

--- a/test/Conversion/ImportVerilog/packed-aggregate-select.sv
+++ b/test/Conversion/ImportVerilog/packed-aggregate-select.sv
@@ -1,0 +1,47 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// Element and range selects into packed structs and unions are bit selects
+// into the equivalent vector of bits (IEEE 1800-2017 § 7.2.1).
+
+typedef struct packed { logic [2:0] a; logic [1:0] b; } my_struct_t;
+typedef union packed { logic [4:0] bits; my_struct_t fields; } my_union_t;
+
+// CHECK-LABEL: moore.module @PackedAggregateSelect
+module PackedAggregateSelect;
+  my_struct_t s;
+  my_union_t u;
+  logic [2:0] i;
+  logic x;
+  logic [1:0] y;
+  initial begin
+    // Rvalue constant bit select: convert to the simple bit vector, then a
+    // plain extract.
+    // CHECK: [[SBV0:%.+]] = moore.packed_to_sbv
+    // CHECK: moore.extract [[SBV0]] from 4
+    x = s[4];
+    // Rvalue dynamic bit select.
+    // CHECK: [[SBV1:%.+]] = moore.packed_to_sbv
+    // CHECK: moore.dyn_extract [[SBV1]] from
+    x = s[i];
+    // Rvalue range select (part select).
+    // CHECK: [[SBV2:%.+]] = moore.packed_to_sbv
+    // CHECK: moore.extract [[SBV2]] from 1
+    y = s[2:1];
+    // Lvalue constant bit select: the ref-typed extract handles the packed
+    // aggregate directly.
+    // CHECK: moore.extract_ref %s from 0
+    s[0] = 1'b1;
+    // Lvalue dynamic bit select.
+    // CHECK: moore.dyn_extract_ref %s from
+    s[i] = 1'b0;
+    // Packed union rvalue and lvalue selects.
+    // CHECK: [[SBV3:%.+]] = moore.packed_to_sbv
+    // CHECK: moore.extract [[SBV3]] from 2
+    x = u[2];
+    // CHECK: moore.dyn_extract_ref %u from
+    u[i] = 1'b1;
+  end
+endmodule

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -2119,3 +2119,16 @@ moore.module @StringArrayVariable() {
     moore.return
   }
 }
+
+// Fully out-of-range constant ref extracts (statically-dead parameterized
+// writes like `slave_select[4] = 1;` on `logic [3:0]`) route to a detached
+// scratch signal: IEEE 1800-2017 11.5.1 discard semantics for writes.
+// CHECK-LABEL: func.func @OutOfBoundsExtractRef
+func.func @OutOfBoundsExtractRef(%arg0: !moore.ref<l4>) -> !moore.ref<l1> {
+  // CHECK: [[INIT:%.+]] = hw.constant false
+  // CHECK: %oob_scratch = llhd.sig [[INIT]] : i1
+  // CHECK: return %oob_scratch
+  // expected-remark @below {{out-of-range reference discards writes}}
+  %0 = moore.extract_ref %arg0 from 4 : <l4> -> <l1>
+  return %0 : !moore.ref<l1>
+}

--- a/test/Conversion/MooreToCore/caseeq-unknown-constant.mlir
+++ b/test/Conversion/MooreToCore/caseeq-unknown-constant.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// Case equality against a constant carrying x/z bits folds to its static
+// verdict in this two-valued lowering: runtime values never hold x/z, so an
+// x/z constant bit can never case-match (IEEE 1800-2017 11.4.5). Previously
+// the unknown bits were dropped from the converted constant, turning
+// `v === 'x` into `v === 0` — the `$isunknown` payload shape, which then
+// reported every all-zero sample as unknown.
+
+// CHECK-LABEL: func.func @CaseEqUnknownConst
+func.func @CaseEqUnknownConst(%arg0: !moore.l1, %arg1: !moore.l8) {
+  %x1 = moore.constant bX : l1
+  %mixed = moore.constant b1XX01ZZ0 : l8
+
+  // `v === 1'bx` can never hold on two-valued runtime data.
+  // CHECK: hw.constant false
+  // CHECK-NOT: comb.icmp ceq
+  %0 = moore.case_eq %arg0, %x1 : l1
+  // CHECK: hw.constant true
+  // CHECK-NOT: comb.icmp cne
+  %1 = moore.case_ne %arg0, %x1 : l1
+  // Constant operand order does not matter.
+  // CHECK: hw.constant false
+  %2 = moore.case_eq %x1, %arg0 : l1
+  // Partially-unknown constants also force a static verdict: the x/z bit
+  // positions can never match.
+  // CHECK: hw.constant false
+  %3 = moore.case_eq %arg1, %mixed : l8
+
+  // Fully two-valued case comparisons keep the genuine comparison.
+  // CHECK: comb.icmp ceq
+  %k = moore.constant 42 : l8
+  %4 = moore.case_eq %arg1, %k : l8
+  return
+}

--- a/test/Conversion/MooreToCore/clog2.mlir
+++ b/test/Conversion/MooreToCore/clog2.mlir
@@ -1,0 +1,28 @@
+// RUN: circt-opt %s --convert-moore-to-core | FileCheck %s
+
+// $clog2 lowers to a priority-encode mux chain over (x - 1), with a defined
+// result of 0 for a zero input (IEEE 1800-2017 § 20.8.1).
+
+// CHECK-LABEL: func.func @Clog2
+func.func @Clog2(%arg0: !moore.i4) -> !moore.i4 {
+  // CHECK-DAG: [[ONE:%.+]] = hw.constant 1 : i4
+  // CHECK-DAG: [[ZERO:%.+]] = hw.constant 0 : i4
+  // CHECK: [[XM1:%.+]] = comb.sub %arg0, [[ONE]]
+  // CHECK: [[B0:%.+]] = comb.extract [[XM1]] from 0 : (i4) -> i1
+  // CHECK: [[CNT1:%.+]] = hw.constant 1 : i4
+  // CHECK: [[M0:%.+]] = comb.mux [[B0]], [[CNT1]], [[ZERO]]
+  // CHECK: [[B1:%.+]] = comb.extract [[XM1]] from 1 : (i4) -> i1
+  // CHECK: [[CNT2:%.+]] = hw.constant 2 : i4
+  // CHECK: [[M1:%.+]] = comb.mux [[B1]], [[CNT2]], [[M0]]
+  // CHECK: [[B2:%.+]] = comb.extract [[XM1]] from 2 : (i4) -> i1
+  // CHECK: [[CNT3:%.+]] = hw.constant 3 : i4
+  // CHECK: [[M2:%.+]] = comb.mux [[B2]], [[CNT3]], [[M1]]
+  // CHECK: [[B3:%.+]] = comb.extract [[XM1]] from 3 : (i4) -> i1
+  // CHECK: [[CNT4:%.+]] = hw.constant 4 : i4
+  // CHECK: [[M3:%.+]] = comb.mux [[B3]], [[CNT4]], [[M2]]
+  // CHECK: [[ISZERO:%.+]] = comb.icmp eq %arg0, [[ZERO]]
+  // CHECK: [[RESULT:%.+]] = comb.mux [[ISZERO]], [[ZERO]], [[M3]]
+  %0 = moore.builtin.clog2 %arg0 : i4
+  // CHECK: return [[RESULT]]
+  return %0 : !moore.i4
+}


### PR DESCRIPTION
Supersedes #10807. 8 commits, ImportVerilog + MooreToCore only; no pass-pipeline, runner, or default changes; runtime ABI: none.
- `$error`/`$warning`/`$info`/`$fatal` with leading non-string arguments -> `$display`-style formatting (20.10).
- packed struct/union element/range selects -> extract on the bit-vector view (7.2.1). Scope: rvalue path end-to-end; lvalue selects convert in ImportVerilog but `extract_ref` on struct refs still fails MooreToCore (follow-up).
- `case` over packed struct/union operands -> `case_eq` on `packed_to_sbv`.
- `moore.builtin.clog2` -> priority-encode mux chain over (x-1); `$clog2(0)` = 0 (20.8.1).
- `case_eq`/`case_ne` against x/z-bearing constants -> static verdict; stock drops the x/z bits (`v === 'x` lowers as `v === 0`). Fully two-valued compares keep the genuine `icmp`.
- fully out-of-range constant `extract_ref` (lowBit >= input width) -> detached scratch signal + remark (11.5.1 write-discard). Guard: constant, fully-OOB only. Stock truncates lowBit into the index type, silently wrapping OOB writes onto in-range bits; partial straddles keep stock's existing path.
- instance arrays (gate/module/interface) -> visited and predeclared per element.
- generic interface ports connected to instance arrays -> per-element flattening, `<port>_<i>_` prefixes.
- interface-port connections keyed by the port's syntax node -> correct on repeated instances of one module and on modport array ports.
sv-tests `circt_verilog`: 4111/5093 -> 4146/5093 (+35, 0 lost) at b4d2825009. lit ImportVerilog + MooreToCore: 48/48.
Metamorphic battery: 62 synthetic + 24 mutated-corpus variants (rename / reorder / dead-code / width / seed) across the 8 mechanisms; verdicts invariant, 0 flips.
Negative battery: perturbed oracles fail (wrong select index, wrong severity kind, wrong mux constant, swapped element wiring); loud rejects kept (undefined identifier, interface-array size mismatch, non-interface connection); in-range refs never route to scratch.
Holdout: 9 same-construct still-red rows all move past the mechanism error to distinct later blockers; 12 construct-bearing green rows stay green; 0 green-to-red.
Written with AI assistance; I've reviewed the diff and tests.
