### PR TITLE
[Arc][LLHD][Moore] Simulation lowering robustness: module-level LLHD signals in LowerState, false comb-loop splitting, Deseq multi-driver soundness

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -389,6 +389,35 @@ def SimplifyVariadicOps : Pass<"arc-simplify-variadic-ops", "mlir::ModuleOp"> {
   ];
 }
 
+def SplitFalseCombLoops : Pass<"arc-split-false-comb-loops", "hw::HWModuleOp"> {
+  let summary = "Split combinational loops that are false per element or bit";
+  let description = [{
+    ConvertToArcs' fan-in analysis detects combinational loops at whole
+    SSA-value granularity. Aggregate update chains that write element `i`
+    while reading element `j` (unrolled per-way state updates, register
+    files, struct field updates) and narrow bitwise feedback (bit 0 depending
+    on bit 1) form SSA cycles in the `hw.module` graph region even though
+    they are acyclic per array element, struct field, or bit. This pass finds
+    strongly connected components among non-arc-breaking combinational ops
+    and, when every member op is decomposable, splits the participating
+    values one type level at a time. Integers are only split into bits for
+    pure bitwise components up to `max-bit-split-width` bits wide. Genuine
+    loops are left in place for ConvertToArcs to diagnose.
+  }];
+  let dependentDialects = ["comb::CombDialect", "hw::HWDialect"];
+  let options = [
+    Option<"maxBitSplitWidth", "max-bit-split-width", "unsigned", "64",
+           "Maximum integer width to split into bits when breaking pure "
+           "bitwise loops">
+  ];
+  let statistics = [
+    Statistic<"numAggregateLoopsSplit", "num-aggregate-loops-split",
+              "Number of aggregate value loops split">,
+    Statistic<"numBitwiseLoopsSplit", "num-bitwise-loops-split",
+              "Number of bitwise integer loops split">
+  ];
+}
+
 def SplitFuncs : Pass<"arc-split-funcs", "mlir::ModuleOp"> {
   let summary = "Split large funcs into multiple smaller funcs";
   let dependentDialects = ["mlir::func::FuncDialect"];

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2080,11 +2080,17 @@ def QueueConcatOp : MooreOp<"queue.concat", [Pure]> {
 
     If the total length of the inputs doesn't fit into the queue bound of
     $result, then the excess elements are discarded at the end of the queue.
+
+    With zero inputs (the empty queue literal `{}`) the result is an empty
+    queue.
   }];
   let arguments = (ins Variadic<QueueType>:$inputs);
   let results = (outs QueueType:$result);
+  // Note: functional-type (rather than a plain parenthesized type list) keeps
+  // the zero-input form parseable: `() <i8, 0>` is rejected as a function
+  // type, while `() -> !moore.queue<i8, 0>` round-trips.
   let assemblyFormat = [{
-    ` ` `(` $inputs `)` attr-dict `:` `(` type($inputs) `)` type($result)
+    ` ` `(` $inputs `)` attr-dict `:` functional-type($inputs, $result)
   }];
   let hasVerifier = 1;
 }

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1129,11 +1129,16 @@ def QueueConcatOp : SimOp<"queue.concat", [Pure]> {
 
     If the total length of the inputs doesn't fit into the queue bound of
     $result, then the excess elements at the end of the queue are discarded.
+
+    With zero inputs the result is an empty queue.
   }];
   let arguments = (ins Variadic<QueueType>:$inputs);
   let results = (outs QueueType:$result);
+  // Note: functional-type (rather than a plain parenthesized type list) keeps
+  // the zero-input form parseable: `() <i8, 0>` is rejected as a function
+  // type, while `() -> !sim.queue<i8, 0>` round-trips.
   let assemblyFormat = [{
-    ` ` `(` $inputs `)` attr-dict `:` `(` type($inputs) `)` type($result)
+    ` ` `(` $inputs `)` attr-dict `:` functional-type($inputs, $result)
   }];
   let hasVerifier = 1;
 }

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -32,6 +32,12 @@ using mlir::ConversionConfig;
 static bool isArcBreakingOp(Operation *op) {
   if (isa<TapOp>(op))
     return false;
+  // `llhd.prb` is memory-effect free in graph regions but carries a read
+  // effect in SSACFG regions; absorbing it into an arc moves it into the
+  // latter context where the arc's purity verifier rejects it. Keep it
+  // outside of arcs; the state lowering handles module-level signals.
+  if (isa<llhd::ProbeOp>(op))
+    return true;
   return op->hasTrait<OpTrait::ConstantLike>() ||
          isa<hw::InstanceOp, seq::CompRegOp, MemoryOp, MemoryReadPortOp,
              ClockedOpInterface, seq::InitialOp, seq::ClockGateOp,

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -3050,9 +3050,15 @@ struct QueueConcatOpConversion : public OpConversionPattern<QueueConcatOp> {
   LogicalResult
   matchAndRewrite(QueueConcatOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<sim::QueueConcatOp>(
-        op, getTypeConverter()->convertType(op.getResult().getType()),
-        adaptor.getInputs());
+    auto resultType = getTypeConverter()->convertType(op.getResult().getType());
+    // A zero-operand concat (the empty queue literal `{}`) is just an empty
+    // queue; emit the canonical constructor instead of a degenerate concat.
+    if (adaptor.getInputs().empty()) {
+      rewriter.replaceOpWithNewOp<sim::QueueEmptyOp>(op, resultType);
+      return success();
+    }
+    rewriter.replaceOpWithNewOp<sim::QueueConcatOp>(op, resultType,
+                                                    adaptor.getInputs());
     return success();
   }
 };

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -10,6 +10,7 @@
 #include "circt/Dialect/Arc/ArcDialect.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/Seq/SeqTypes.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -35,6 +36,13 @@ std::optional<uint64_t> circt::arc::computeLLVMBitWidth(Type type) {
 
   if (auto intType = dyn_cast<IntegerType>(type))
     return intType.getWidth();
+
+  // LLVM pointers are opaque runtime handles, e.g. the value of a
+  // module-level signal holding a class object allocated by an initializer.
+  // Reserve one 64-bit slot in storage, which is sufficient on any host the
+  // simulator's storage layout currently targets.
+  if (isa<LLVM::LLVMPointerType>(type))
+    return 64;
 
   auto computeForArrayType = [&](auto arrayType) -> std::optional<uint64_t> {
     // Compute element width.

--- a/lib/Dialect/Arc/CMakeLists.txt
+++ b/lib/Dialect/Arc/CMakeLists.txt
@@ -35,6 +35,7 @@ add_circt_dialect_library(CIRCTArc
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRFuncDialect
+  MLIRLLVMDialect
   MLIRSideEffectInterfaces
   MLIRFuncDialect
 )

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -27,6 +27,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   RemoveI0Types.cpp
   ResolveXMRRef.cpp
   SimplifyVariadicOps.cpp
+  SplitFalseCombLoops.cpp
   SplitFuncs.cpp
   SplitLoops.cpp
   StripSV.cpp

--- a/lib/Dialect/Arc/Transforms/InferStateProperties.cpp
+++ b/lib/Dialect/Arc/Transforms/InferStateProperties.cpp
@@ -207,7 +207,14 @@ applyEnableTransformation(arc::DefineOp arcOp, arc::StateOp stateOp,
   stateOp.getEnableMutable().assign(enableCond);
 
   for (size_t i = 0, e = outputOp.getOutputs().size(); i < e; ++i) {
-    if (enableInfos[i].selfArg.hasOneUse())
+    // Sever the now-dead self-feedback operand by passing a zero constant.
+    // `hw.constant` can only represent integers; leave aggregate-typed
+    // self-arguments (e.g. array-state memories behind a write-enable mux)
+    // in place — the forced-true condition makes the arc body ignore them,
+    // and building the constant for a non-integer type would produce a
+    // garbage-width integer (UB cast) instead.
+    if (enableInfos[i].selfArg.hasOneUse() &&
+        isa<IntegerType>(enableInfos[i].selfArg.getType()))
       inputs[enableInfos[i].selfArg.getArgNumber()] = hw::ConstantOp::create(
           builder, stateOp.getLoc(), enableInfos[i].selfArg.getType(), 0);
   }

--- a/lib/Dialect/Arc/Transforms/LowerClocksToFuncs.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerClocksToFuncs.cpp
@@ -186,7 +186,11 @@ LogicalResult LowerClocksToFuncsPass::isolateClock(Operation *clockOp,
         operand.set(clockStorageArg);
         continue;
       }
-      if (isa<BlockArgument>(operand.get())) {
+      if (auto blockArg = dyn_cast<BlockArgument>(operand.get())) {
+        // Arguments of blocks within the clock region itself (multi-block
+        // clock bodies) are internal values, not external references.
+        if (clockRegion->isAncestor(blockArg.getOwner()->getParent()))
+          continue;
         auto d = op->emitError(
             "operation in clock tree uses external block argument");
         d.attachNote() << "clock trees can only use external constant values";

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -158,6 +158,15 @@ struct ModuleLowering {
   DenseSet<std::pair<Operation *, Phase>> loweredOps;
   /// The values that have already been lowered.
   DenseMap<std::pair<Value, Phase>, Value> loweredValues;
+  /// Module-level values that flow out of signal initializer expressions
+  /// (`llhd.sig` init operands and everything derived from them at module
+  /// level). Side-effecting module-level ops consuming these are one-time
+  /// initialization actions (object memset, typeinfo/property-initializer
+  /// stores emitted by class `new` at module scope) and must lower in the
+  /// initial phase: lowering them per-eval re-executes the initializer
+  /// chain against a fresh allocation (and leaks it every eval) while the
+  /// signal keeps the pointer from its own, separate initial-phase clone.
+  DenseSet<Value> sigInitClosure;
 
   /// The allocated input ports.
   SmallVector<Value> allocatedInputs;
@@ -241,6 +250,28 @@ LogicalResult ModuleLowering::run() {
     allocatedInputs.push_back(state);
   }
 
+  // Collect the signal-initializer value closure (see `sigInitClosure`):
+  // seed with every `llhd.sig` init operand, then expand forward through
+  // module-level ops deriving values from it (GEPs, casts).
+  for (auto sigOp : moduleOp.getBodyBlock()->getOps<llhd::SignalOp>())
+    if (auto init = sigOp.getInit())
+      sigInitClosure.insert(init);
+  if (!sigInitClosure.empty()) {
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (auto &op : moduleOp.getOps()) {
+        if (op.getNumResults() == 0)
+          continue;
+        if (llvm::any_of(op.getOperands(), [&](Value operand) {
+              return sigInitClosure.contains(operand);
+            }))
+          for (auto result : op.getResults())
+            changed |= sigInitClosure.insert(result).second;
+      }
+    }
+  }
+
   // Lower the ops.
   for (auto &op : moduleOp.getOps()) {
     if (mlir::isMemoryEffectFree(&op) &&
@@ -274,6 +305,23 @@ LogicalResult ModuleLowering::lowerOp(Operation *op) {
   if (isa<StateOp>(op))
     phases = {Phase::Initial, Phase::New};
   if (isa<llhd::SignalOp>(op))
+    phases = {Phase::Initial};
+
+  // Side-effecting module-level ops consuming OR producing
+  // signal-initializer values (the initializer computation itself plus the
+  // object memset and typeinfo/property stores from class `new` at module
+  // scope) are one-time initialization actions; see `sigInitClosure`.
+  if (!isa<StateOp, sim::DPICallOp, MemoryOp, TapOp, InstanceOp,
+           CoroutineInstanceOp, hw::TriggeredOp, hw::OutputOp, seq::InitialOp,
+           llhd::FinalOp, llhd::CurrentTimeOp, llhd::SignalOp, llhd::DriveOp,
+           sim::ClockedTerminateOp>(op) &&
+      !mlir::isMemoryEffectFree(op) &&
+      (llvm::any_of(
+           op->getOperands(),
+           [&](Value operand) { return sigInitClosure.contains(operand); }) ||
+       llvm::any_of(op->getResults(), [&](Value result) {
+         return sigInitClosure.contains(result);
+       })))
     phases = {Phase::Initial};
 
   for (auto phase : phases) {

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -1439,6 +1439,20 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
       }
     }
   }
+  // A drive of an array element of a module-level signal
+  // (`llhd.drv (llhd.sig.array_get %sig[%idx]), %v`) lowers as a
+  // read-modify-write of the parent signal's storage through
+  // `hw.array_inject` -- the array-typed sibling of the bit-slice splice.
+  llhd::SigArrayGetOp elementOp;
+  if (sigResult) {
+    if (auto get = dyn_cast<llhd::SigArrayGetOp>(sigResult.getOwner())) {
+      auto parent = dyn_cast<OpResult>(get.getInput());
+      if (parent && isa<llhd::SignalOp>(parent.getOwner())) {
+        elementOp = get;
+        sigResult = parent;
+      }
+    }
+  }
   if (!sigResult || !isa<llhd::SignalOp>(sigResult.getOwner())) {
     if (!initial)
       return op.emitOpError()
@@ -1458,6 +1472,8 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
     lowerValue(op.getValue(), Phase::New);
     if (op.getEnable())
       lowerValue(op.getEnable(), Phase::New);
+    if (elementOp)
+      lowerValue(elementOp.getIndex(), Phase::New);
     return success();
   }
 
@@ -1495,6 +1511,16 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
     value = pieces.size() == 1
                 ? pieces.front()
                 : Value(comb::ConcatOp::create(builder, op.getLoc(), pieces));
+  }
+
+  // Element drive: read-modify-write of the parent array signal's storage.
+  if (elementOp) {
+    auto index = lowerValue(elementOp.getIndex(), Phase::New);
+    if (!index)
+      return failure();
+    Value cur = StateReadOp::create(module.builder, op.getLoc(), state);
+    value = hw::ArrayInjectOp::create(module.builder, op.getLoc(), cur, index,
+                                      value);
   }
 
   if (op.getEnable()) {

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -106,6 +106,8 @@ struct OpLowering {
   LogicalResult lower(seq::InitialOp op);
   LogicalResult lower(llhd::FinalOp op);
   LogicalResult lower(llhd::CurrentTimeOp op);
+  LogicalResult lower(llhd::SignalOp op);
+  LogicalResult lower(llhd::DriveOp op);
   LogicalResult lower(sim::ClockedTerminateOp op);
 
   scf::IfOp createIfClockOp(Value clock);
@@ -122,6 +124,7 @@ struct OpLowering {
   Value lowerValue(MemoryReadPortOp op, OpResult result, Phase phase);
   Value lowerValue(seq::InitialOp op, OpResult result, Phase phase);
   Value lowerValue(seq::FromImmutableOp op, OpResult result, Phase phase);
+  Value lowerValue(llhd::ProbeOp op, OpResult result, Phase phase);
 
   void addPending(Value value, Phase phase);
   void addPending(Operation *op, Phase phase);
@@ -270,6 +273,8 @@ LogicalResult ModuleLowering::lowerOp(Operation *op) {
     phases = {Phase::Final};
   if (isa<StateOp>(op))
     phases = {Phase::Initial, Phase::New};
+  if (isa<llhd::SignalOp>(op))
+    phases = {Phase::Initial};
 
   for (auto phase : phases) {
     if (loweredOps.contains({op, phase}))
@@ -342,10 +347,13 @@ Value ModuleLowering::getAllocatedState(OpResult result) {
     return alloc;
   }
 
-  // Create the allocation op.
-  auto alloc =
-      AllocStateOp::create(allocBuilder, result.getLoc(),
-                           StateType::get(result.getType()), storageArg);
+  // Create the allocation op. Signal references allocate a slot of the
+  // referenced type: the signal's storage.
+  auto allocType = result.getType();
+  if (auto refType = dyn_cast<llhd::RefType>(allocType))
+    allocType = refType.getNestedType();
+  auto alloc = AllocStateOp::create(allocBuilder, result.getLoc(),
+                                    StateType::get(allocType), storageArg);
   allocatedStates.insert({result, alloc});
 
   // HACK: If the result comes from an instance op, add the instance and port
@@ -436,8 +444,8 @@ LogicalResult OpLowering::lower() {
       // Operations with special lowering.
       .Case<StateOp, sim::DPICallOp, MemoryOp, TapOp, InstanceOp,
             CoroutineInstanceOp, hw::TriggeredOp, hw::OutputOp, seq::InitialOp,
-            llhd::FinalOp, llhd::CurrentTimeOp, sim::ClockedTerminateOp>(
-          [&](auto op) { return lower(op); })
+            llhd::FinalOp, llhd::CurrentTimeOp, llhd::SignalOp, llhd::DriveOp,
+            sim::ClockedTerminateOp>([&](auto op) { return lower(op); })
 
       // Operations that should be skipped entirely and never land on the
       // worklist to be lowered.
@@ -1254,6 +1262,95 @@ LogicalResult OpLowering::lower(llhd::CurrentTimeOp op) {
   return success();
 }
 
+/// Lower a module-level signal definition: allocate persistent storage of the
+/// referenced type and write the init value in the initial phase. Probes and
+/// drives of the signal read/write the storage; see their lowerings below.
+LogicalResult OpLowering::lower(llhd::SignalOp op) {
+  assert(phase == Phase::Initial);
+  if (initial) {
+    lowerValue(op.getInit(), Phase::Initial);
+    return success();
+  }
+  auto value = lowerValue(op.getInit(), Phase::Initial);
+  if (!value)
+    return failure();
+  auto state = module.getAllocatedState(op->getResult(0));
+  if (!state)
+    return failure();
+  StateWriteOp::create(module.initialBuilder, op.getLoc(), state, value);
+  return success();
+}
+
+/// Lower a module-level drive: a write of the driven value to the signal's
+/// storage. Only zero-real-time (delta/epsilon) delays are supported; they
+/// express update ordering, which the state-slot model resolves per
+/// evaluation. Drives with real-time delays would need a scheduler queue and
+/// are rejected.
+LogicalResult OpLowering::lower(llhd::DriveOp op) {
+  assert(phase == Phase::New);
+
+  auto sigResult = dyn_cast<OpResult>(op.getSignal());
+  if (!sigResult || !isa<llhd::SignalOp>(sigResult.getOwner())) {
+    if (!initial)
+      return op.emitOpError()
+             << "drive of a reference that is not a module-level signal is "
+                "not supported";
+    return success();
+  }
+  auto timeOp = op.getTime().getDefiningOp<llhd::ConstantTimeOp>();
+  if (!timeOp || timeOp.getValue().getTime() != 0) {
+    if (!initial)
+      return op.emitOpError()
+             << "drive with a nonzero real-time delay is not supported";
+    return success();
+  }
+
+  if (initial) {
+    lowerValue(op.getValue(), Phase::New);
+    if (op.getEnable())
+      lowerValue(op.getEnable(), Phase::New);
+    return success();
+  }
+
+  auto value = lowerValue(op.getValue(), Phase::New);
+  if (!value)
+    return failure();
+  auto state = module.getAllocatedState(sigResult);
+  if (!state)
+    return failure();
+  if (op.getEnable()) {
+    auto enable = lowerValue(op.getEnable(), Phase::New);
+    if (!enable)
+      return failure();
+    auto ifOp = scf::IfOp::create(module.builder, op.getLoc(), enable,
+                                  /*withElseRegion=*/false);
+    OpBuilder::InsertionGuard guard(module.builder);
+    module.builder.setInsertionPoint(ifOp.thenYield());
+    StateWriteOp::create(module.builder, op.getLoc(), state, value);
+    return success();
+  }
+  StateWriteOp::create(module.builder, op.getLoc(), state, value);
+  return success();
+}
+
+/// Handle probes of module-level signals: a read of the signal's storage.
+Value OpLowering::lowerValue(llhd::ProbeOp op, OpResult result, Phase phase) {
+  auto sigResult = dyn_cast<OpResult>(op.getSignal());
+  if (!sigResult || !isa<llhd::SignalOp>(sigResult.getOwner())) {
+    if (!initial)
+      emitError(op.getLoc())
+          << "probe of a reference that is not a module-level signal is not "
+             "supported";
+    return {};
+  }
+  if (initial)
+    return {};
+  auto state = module.getAllocatedState(sigResult);
+  if (!state)
+    return {};
+  return StateReadOp::create(module.getBuilder(phase), op.getLoc(), state);
+}
+
 LogicalResult OpLowering::lower(sim::ClockedTerminateOp op) {
   if (phase != Phase::New)
     return success();
@@ -1346,6 +1443,23 @@ Value OpLowering::lowerValue(Value value, Phase phase) {
     return lowerValue(initialOp, result, phase);
   if (auto castOp = dyn_cast<seq::FromImmutableOp>(op))
     return lowerValue(castOp, result, phase);
+  if (auto probeOp = dyn_cast<llhd::ProbeOp>(op))
+    return lowerValue(probeOp, result, phase);
+  // Regions cloned into the model (e.g. `llhd.final` bodies) may reference a
+  // module-level signal by its reference value. Hand out the signal's
+  // storage: both are pointers into the model storage representationally;
+  // the bridging cast cancels out during the LLVM lowering.
+  if (auto sigOp = dyn_cast<llhd::SignalOp>(op)) {
+    if (initial)
+      return {};
+    auto state = module.getAllocatedState(result);
+    if (!state)
+      return {};
+    return mlir::UnrealizedConversionCastOp::create(
+               module.getBuilder(phase), sigOp.getLoc(), result.getType(),
+               ValueRange{state})
+        .getResult(0);
+  }
 
   // Otherwise we mark the defining operation as to be lowered first. This will
   // cause the lookup in `loweredValues` above to return a value the next time

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -142,6 +142,16 @@ struct ModuleLowering {
   OpBuilder initialBuilder;
   /// The builder for the final phase.
   OpBuilder finalBuilder;
+  /// The builder for `Phase::Old` values: a pinned section at the top of the
+  /// eval body, executed before any coroutine instance or drive can mutate
+  /// signal storage. All "old" reads and the pure cones over them thus form a
+  /// consistent pre-eval snapshot (IEEE 1800 preponed-style sampling for
+  /// clocked state elements). Without this, an old read emitted after a
+  /// coroutine call observes mid-eval process writes while cached reads from
+  /// earlier positions observe pre-eval values: registers then commit a mix
+  /// of pre- and post-process operands (the declaration-order-dependent
+  /// stale-select NBA decode).
+  OpBuilder oldBuilder;
 
   /// The storage value that can be used for `arc.alloc_state` and friends.
   Value storageArg;
@@ -192,7 +202,7 @@ struct ModuleLowering {
 
   ModuleLowering(HWModuleOp moduleOp, SymbolTable &symbolTable)
       : moduleOp(moduleOp), builder(moduleOp), allocBuilder(moduleOp),
-        initialBuilder(moduleOp), finalBuilder(moduleOp),
+        initialBuilder(moduleOp), finalBuilder(moduleOp), oldBuilder(moduleOp),
         symbolTable(symbolTable) {}
   LogicalResult run();
   LogicalResult lowerOp(Operation *op);
@@ -237,6 +247,13 @@ LogicalResult ModuleLowering::run() {
   auto finalOp = FinalOp::create(builder, moduleOp.getLoc());
   finalBuilder.setInsertionPointToStart(&finalOp.getBody().emplaceBlock());
 
+  // Anchor the `Phase::Old` section: old-phase values accumulate between the
+  // `arc.final` op and this anchor, i.e. before every eval-phase op. The
+  // anchor is a dead constant erased by the trailing cleanup.
+  auto oldAnchor = hw::ConstantOp::create(builder, moduleOp.getLoc(),
+                                          builder.getI1Type(), 0);
+  oldBuilder.setInsertionPoint(oldAnchor);
+
   // Position the alloc builder such that allocation ops get inserted above the
   // initial op.
   allocBuilder.setInsertionPoint(initialOp);
@@ -272,13 +289,78 @@ LogicalResult ModuleLowering::run() {
     }
   }
 
-  // Lower the ops.
+  // Classify which module ops must lower at the END of the eval body, after
+  // every coroutine instance and signal drive has run: clocked state elements
+  // (registers, memories, clocked DPI/terminate/trigger) detect their clock
+  // edge against the post-process value of the CURRENT evaluation while their
+  // data operands come from the pinned pre-eval `Phase::Old` section. This
+  // pairing implements LRM scheduling-region semantics: a register clocks in
+  // the evaluation in which its clock edge physically occurs, sampling values
+  // from before any same-edge process writes (NBA stores commit after the
+  // active region). Side-effecting consumers of register outputs (drives of
+  // register-fed signals, taps, module outputs) defer with them so they
+  // observe the committed values. Coroutine instances never defer: their
+  // arguments are old-phase samples and their execution order among each
+  // other must follow module order.
+  DenseSet<Value> regClosure;
   for (auto &op : moduleOp.getOps()) {
+    bool seed = isa<StateOp, MemoryOp, MemoryReadPortOp>(op);
+    if (auto dpiOp = dyn_cast<sim::DPICallOp>(&op))
+      seed = !!dpiOp.getClock();
+    if (seed)
+      for (auto result : op.getResults())
+        regClosure.insert(result);
+  }
+  {
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (auto &op : moduleOp.getOps()) {
+        if (op.getNumResults() == 0 || isa<CoroutineInstanceOp>(op))
+          continue;
+        if (llvm::any_of(op.getOperands(), [&](Value operand) {
+              return regClosure.contains(operand);
+            }))
+          for (auto result : op.getResults())
+            changed |= regClosure.insert(result).second;
+      }
+    }
+  }
+  auto deferredToEnd = [&](Operation &op) {
+    if (isa<StateOp, MemoryOp, sim::ClockedTerminateOp, hw::TriggeredOp,
+            hw::OutputOp>(op))
+      return true;
+    if (auto dpiOp = dyn_cast<sim::DPICallOp>(&op); dpiOp && dpiOp.getClock())
+      return true;
+    if (isa<CoroutineInstanceOp>(op))
+      return false;
+    return llvm::any_of(op.getOperands(), [&](Value operand) {
+      return regClosure.contains(operand);
+    });
+  };
+  auto skipInWalk = [](Operation &op) {
     if (mlir::isMemoryEffectFree(&op) &&
         !isa<hw::OutputOp, sim::ClockedTerminateOp>(op))
+      return true;
+    // Handled as part of `MemoryOp`.
+    return isa<MemoryReadPortOp, MemoryWritePortOp>(op);
+  };
+
+  // Lower the ops: first the mid section (coroutine instances, drives, and
+  // other effects not fed by clocked state), then the end section (clocked
+  // state elements and their dependent effects). A mid-section op demanding a
+  // register's new value still pulls that register's lowering forward through
+  // the worklist; data stays consistent (old reads are pinned) and only that
+  // register's edge-detection point degrades to the demand position.
+  for (auto &op : moduleOp.getOps()) {
+    if (skipInWalk(op) || deferredToEnd(op))
       continue;
-    if (isa<MemoryReadPortOp, MemoryWritePortOp>(op))
-      continue; // handled as part of `MemoryOp`
+    if (failed(lowerOp(&op)))
+      return failure();
+  }
+  for (auto &op : moduleOp.getOps()) {
+    if (skipInWalk(op) || !deferredToEnd(op))
+      continue;
     if (failed(lowerOp(&op)))
       return failure();
   }
@@ -451,6 +533,7 @@ OpBuilder &ModuleLowering::getBuilder(Phase phase) {
   case Phase::Initial:
     return initialBuilder;
   case Phase::Old:
+    return oldBuilder;
   case Phase::New:
     return builder;
   case Phase::Final:
@@ -730,12 +813,13 @@ LogicalResult OpLowering::lowerStateful(
   for (auto [state, value] : llvm::zip(states, loweredResults))
     StateWriteOp::create(module.builder, value.getLoc(), state, value);
 
-  // Since we just wrote the new state value to storage, insert read ops just
-  // before the if op that keep the old value around for any later ops that
-  // still need it.
-  module.builder.setInsertionPoint(ifClockOp);
+  // Since we just wrote the new state value to storage, insert read ops in the
+  // pinned old section that keep the old value around for any later ops that
+  // still need it. The old section executes before every state update, so the
+  // reads observe the pre-eval value and dominate all later users.
   for (auto [state, result] : llvm::zip(states, results)) {
-    auto oldValue = StateReadOp::create(module.builder, result.getLoc(), state);
+    auto oldValue =
+        StateReadOp::create(module.oldBuilder, result.getLoc(), state);
     module.loweredValues[{result, Phase::Old}] = oldValue;
   }
 
@@ -1590,10 +1674,9 @@ Value OpLowering::lowerValue(CoroutineInstanceOp op, OpResult result,
     return {};
   }
 
-  // If we want to read the old value, no writes must have been lowered yet.
-  if (phase == Phase::Old)
-    assert(!module.loweredOps.contains({op, Phase::New}) &&
-           "need old value but new value already written");
+  // Old-value reads land in the pinned old section, which executes before the
+  // instance updates its result slots, so they are sound even when the
+  // instance's new value has already been lowered.
 
   auto state = module.getAllocatedState(result);
   return StateReadOp::create(module.getBuilder(phase), result.getLoc(), state);
@@ -1601,8 +1684,8 @@ Value OpLowering::lowerValue(CoroutineInstanceOp op, OpResult result,
 
 /// Handle uses of a state. This creates an `arc.state_read` op to read from the
 /// state's storage. If the new value after all updates is requested, marks the
-/// state as to be lowered first (which will perform the writes). If the old
-/// value is requested, asserts that no new values have been written.
+/// state as to be lowered first (which will perform the writes). Old-value
+/// reads are emitted into the pinned old section ahead of all writes.
 Value OpLowering::lowerValue(StateOp op, OpResult result, Phase phase) {
   if (initial) {
     // Ensure that the new or initial value has been written by the lowering of
@@ -1612,10 +1695,9 @@ Value OpLowering::lowerValue(StateOp op, OpResult result, Phase phase) {
     return {};
   }
 
-  // If we want to read the old value, no writes must have been lowered yet.
-  if (phase == Phase::Old)
-    assert(!module.loweredOps.contains({op, Phase::New}) &&
-           "need old value but new value already written");
+  // Old-value reads land in the pinned old section, which executes before the
+  // state's write, so they are sound even when the new value has already been
+  // lowered.
 
   auto state = module.getAllocatedState(result);
   return StateReadOp::create(module.getBuilder(phase), result.getLoc(), state);
@@ -1623,8 +1705,8 @@ Value OpLowering::lowerValue(StateOp op, OpResult result, Phase phase) {
 
 /// Handle uses of a DPI call. This creates an `arc.state_read` op to read from
 /// the state's storage. If the new value after all updates is requested, marks
-/// the state as to be lowered first (which will perform the writes). If the old
-/// value is requested, asserts that no new values have been written.
+/// the state as to be lowered first (which will perform the writes). Old-value
+/// reads are emitted into the pinned old section ahead of all writes.
 Value OpLowering::lowerValue(sim::DPICallOp op, OpResult result, Phase phase) {
   if (initial) {
     // Ensure that the new or initial value has been written by the lowering of
@@ -1634,10 +1716,9 @@ Value OpLowering::lowerValue(sim::DPICallOp op, OpResult result, Phase phase) {
     return {};
   }
 
-  // If we want to read the old value, no writes must have been lowered yet.
-  if (phase == Phase::Old)
-    assert(!module.loweredOps.contains({op, Phase::New}) &&
-           "need old value but new value already written");
+  // Old-value reads land in the pinned old section, which executes before the
+  // state's write, so they are sound even when the new value has already been
+  // lowered.
 
   auto state = module.getAllocatedState(result);
   return StateReadOp::create(module.getBuilder(phase), result.getLoc(), state);
@@ -1665,13 +1746,10 @@ Value OpLowering::lowerValue(MemoryReadPortOp op, OpResult result,
   if (!address)
     return {};
 
-  if (phase == Phase::Old) {
-    // If we want to read the old value, no writes must have been lowered yet.
-    assert(!module.loweredOps.contains({memOp, Phase::New}) &&
-           "need old memory value but new value already written");
-  } else {
-    assert(phase == Phase::New);
-  }
+  // Old-value reads land in the pinned old section, which executes before all
+  // memory writes, so they are sound even when the writes have already been
+  // lowered.
+  assert(phase == Phase::Old || phase == Phase::New);
 
   auto state = module.getAllocatedState(memOp->getResult(0));
   return MemoryReadOp::create(module.getBuilder(phase), result.getLoc(), state,

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -1515,6 +1515,24 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
 /// Handle probes of module-level signals: a read of the signal's storage.
 Value OpLowering::lowerValue(llhd::ProbeOp op, OpResult result, Phase phase) {
   auto sigResult = dyn_cast<OpResult>(op.getSignal());
+  // A probe of a constant-offset bit-slice of a module-level signal
+  // (`llhd.prb (llhd.sig.extract %sig from K)`) lowers as a read of the
+  // parent signal's storage plus an extract of the slice -- the probe-side
+  // mirror of the slice-drive splice above.
+  llhd::SigExtractOp sliceOp;
+  uint64_t sliceOffset = 0;
+  if (sigResult) {
+    if (auto extract = dyn_cast<llhd::SigExtractOp>(sigResult.getOwner())) {
+      if (auto cst = extract.getLowBit().getDefiningOp<hw::ConstantOp>()) {
+        auto parent = dyn_cast<OpResult>(extract.getInput());
+        if (parent && isa<llhd::SignalOp>(parent.getOwner())) {
+          sliceOp = extract;
+          sliceOffset = cst.getValue().getZExtValue();
+          sigResult = parent;
+        }
+      }
+    }
+  }
   if (!sigResult || !isa<llhd::SignalOp>(sigResult.getOwner())) {
     if (!initial)
       emitError(op.getLoc())
@@ -1527,7 +1545,22 @@ Value OpLowering::lowerValue(llhd::ProbeOp op, OpResult result, Phase phase) {
   auto state = module.getAllocatedState(sigResult);
   if (!state)
     return {};
-  return StateReadOp::create(module.getBuilder(phase), op.getLoc(), state);
+  Value read =
+      StateReadOp::create(module.getBuilder(phase), op.getLoc(), state);
+  if (sliceOp) {
+    auto resTy = dyn_cast<IntegerType>(op.getResult().getType());
+    auto curTy =
+        dyn_cast<IntegerType>(cast<StateType>(state.getType()).getType());
+    if (!resTy || !curTy || sliceOffset + resTy.getWidth() > curTy.getWidth()) {
+      emitError(op.getLoc())
+          << "slice probe of a non-integer module-level signal is not "
+             "supported";
+      return {};
+    }
+    read = comb::ExtractOp::create(module.getBuilder(phase), op.getLoc(), read,
+                                   sliceOffset, resTy.getWidth());
+  }
+  return read;
 }
 
 LogicalResult OpLowering::lower(sim::ClockedTerminateOp op) {

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -1338,6 +1338,23 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
   assert(phase == Phase::New);
 
   auto sigResult = dyn_cast<OpResult>(op.getSignal());
+  // A drive of a constant-offset bit-slice of a module-level signal
+  // (`llhd.drv (llhd.sig.extract %sig from K), %v`) lowers as a
+  // read-modify-write splice into the parent signal's storage.
+  llhd::SigExtractOp sliceOp;
+  uint64_t sliceOffset = 0;
+  if (sigResult) {
+    if (auto extract = dyn_cast<llhd::SigExtractOp>(sigResult.getOwner())) {
+      if (auto cst = extract.getLowBit().getDefiningOp<hw::ConstantOp>()) {
+        auto parent = dyn_cast<OpResult>(extract.getInput());
+        if (parent && isa<llhd::SignalOp>(parent.getOwner())) {
+          sliceOp = extract;
+          sliceOffset = cst.getValue().getZExtValue();
+          sigResult = parent;
+        }
+      }
+    }
+  }
   if (!sigResult || !isa<llhd::SignalOp>(sigResult.getOwner())) {
     if (!initial)
       return op.emitOpError()
@@ -1366,6 +1383,36 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
   auto state = module.getAllocatedState(sigResult);
   if (!state)
     return failure();
+
+  // Slice drive: splice the driven bits into the current storage value.
+  if (sliceOp) {
+    auto valueIntTy = dyn_cast<IntegerType>(value.getType());
+    auto curTy = dyn_cast<IntegerType>(
+        cast<StateType>(state.getType()).getType());
+    if (!valueIntTy || !curTy)
+      return op.emitOpError()
+             << "slice drive of a non-integer module-level signal is not "
+                "supported";
+    unsigned parentWidth = curTy.getWidth();
+    unsigned sliceWidth = valueIntTy.getWidth();
+    if (sliceOffset + sliceWidth > parentWidth)
+      return op.emitOpError() << "slice drive out of range";
+    auto &builder = module.builder;
+    Value cur = StateReadOp::create(builder, op.getLoc(), state);
+    SmallVector<Value, 3> pieces; // MSB-first for comb.concat
+    if (sliceOffset + sliceWidth < parentWidth)
+      pieces.push_back(comb::ExtractOp::create(
+          builder, op.getLoc(), cur, sliceOffset + sliceWidth,
+          parentWidth - sliceOffset - sliceWidth));
+    pieces.push_back(value);
+    if (sliceOffset > 0)
+      pieces.push_back(
+          comb::ExtractOp::create(builder, op.getLoc(), cur, 0, sliceOffset));
+    value = pieces.size() == 1
+                ? pieces.front()
+                : Value(comb::ConcatOp::create(builder, op.getLoc(), pieces));
+  }
+
   if (op.getEnable()) {
     auto enable = lowerValue(op.getEnable(), Phase::New);
     if (!enable)

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -1431,6 +1431,18 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
     if (auto extract = dyn_cast<llhd::SigExtractOp>(sigResult.getOwner())) {
       if (auto cst = extract.getLowBit().getDefiningOp<hw::ConstantOp>()) {
         auto parent = dyn_cast<OpResult>(extract.getInput());
+        // Look through ref-typed unrealized casts: the packed-aggregate
+        // bit-view idiom (an aggregate signal cast to !llhd.ref<iN> and
+        // bit-sliced). The splice below bitcasts the aggregate storage to
+        // its bit view and back.
+        while (parent) {
+          auto castOp =
+              dyn_cast<mlir::UnrealizedConversionCastOp>(parent.getOwner());
+          if (!castOp || castOp->getNumOperands() != 1 ||
+              !isa<llhd::RefType>(castOp->getOperand(0).getType()))
+            break;
+          parent = dyn_cast<OpResult>(castOp->getOperand(0));
+        }
         if (parent && isa<llhd::SignalOp>(parent.getOwner())) {
           sliceOp = extract;
           sliceOffset = cst.getValue().getZExtValue();
@@ -1439,19 +1451,25 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
       }
     }
   }
-  // A drive of an array element of a module-level signal
-  // (`llhd.drv (llhd.sig.array_get %sig[%idx]), %v`) lowers as a
+  // A drive of an aggregate member of a module-level signal
+  // (`llhd.drv (llhd.sig.array_get %sig[%idx]), %v` or
+  // `llhd.drv (llhd.sig.struct_extract %sig["f"]), %v`) lowers as a
   // read-modify-write of the parent signal's storage through
-  // `hw.array_inject` -- the array-typed sibling of the bit-slice splice.
-  llhd::SigArrayGetOp elementOp;
-  if (sigResult) {
-    if (auto get = dyn_cast<llhd::SigArrayGetOp>(sigResult.getOwner())) {
-      auto parent = dyn_cast<OpResult>(get.getInput());
-      if (parent && isa<llhd::SignalOp>(parent.getOwner())) {
-        elementOp = get;
-        sigResult = parent;
-      }
-    }
+  // `hw.array_inject` / `hw.struct_inject` -- the aggregate-typed siblings
+  // of the bit-slice splice. Chains of member refs (multi-dimensional
+  // arrays, structs of arrays, e.g. veer-eh1's
+  // `sig.array_get (sig.array_get %sig[%i])[%j]`) unwrap outward toward the
+  // signal here and re-inject inward-out below.
+  SmallVector<Operation *> refChain; // innermost (driven) first
+  while (sigResult && !isa<llhd::SignalOp>(sigResult.getOwner())) {
+    Operation *owner = sigResult.getOwner();
+    if (!isa<llhd::SigArrayGetOp, llhd::SigStructExtractOp>(owner))
+      break;
+    auto parent = dyn_cast<OpResult>(owner->getOperand(0));
+    if (!parent)
+      break;
+    refChain.push_back(owner);
+    sigResult = parent;
   }
   if (!sigResult || !isa<llhd::SignalOp>(sigResult.getOwner())) {
     if (!initial)
@@ -1472,8 +1490,9 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
     lowerValue(op.getValue(), Phase::New);
     if (op.getEnable())
       lowerValue(op.getEnable(), Phase::New);
-    if (elementOp)
-      lowerValue(elementOp.getIndex(), Phase::New);
+    for (auto *ref : refChain)
+      if (auto get = dyn_cast<llhd::SigArrayGetOp>(ref))
+        lowerValue(get.getIndex(), Phase::New);
     return success();
   }
 
@@ -1487,18 +1506,31 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
   // Slice drive: splice the driven bits into the current storage value.
   if (sliceOp) {
     auto valueIntTy = dyn_cast<IntegerType>(value.getType());
-    auto curTy = dyn_cast<IntegerType>(
-        cast<StateType>(state.getType()).getType());
-    if (!valueIntTy || !curTy)
+    Type stateEltTy = cast<StateType>(state.getType()).getType();
+    auto curTy = dyn_cast<IntegerType>(stateEltTy);
+    int64_t aggWidth = 0;
+    if (!curTy) {
+      // Aggregate signal driven through its bit view (the ref-cast idiom
+      // matched above): splice on the hw.bitcast of the storage, cast back.
+      aggWidth = hw::getBitWidth(stateEltTy);
+      if (aggWidth <= 0)
+        return op.emitOpError()
+               << "slice drive of a non-integer module-level signal is not "
+                  "supported";
+    }
+    if (!valueIntTy)
       return op.emitOpError()
              << "slice drive of a non-integer module-level signal is not "
                 "supported";
-    unsigned parentWidth = curTy.getWidth();
+    unsigned parentWidth = curTy ? curTy.getWidth() : (unsigned)aggWidth;
     unsigned sliceWidth = valueIntTy.getWidth();
     if (sliceOffset + sliceWidth > parentWidth)
       return op.emitOpError() << "slice drive out of range";
     auto &builder = module.builder;
     Value cur = StateReadOp::create(builder, op.getLoc(), state);
+    if (!curTy)
+      cur = hw::BitcastOp::create(builder, op.getLoc(),
+                                  builder.getIntegerType(parentWidth), cur);
     SmallVector<Value, 3> pieces; // MSB-first for comb.concat
     if (sliceOffset + sliceWidth < parentWidth)
       pieces.push_back(comb::ExtractOp::create(
@@ -1511,16 +1543,59 @@ LogicalResult OpLowering::lower(llhd::DriveOp op) {
     value = pieces.size() == 1
                 ? pieces.front()
                 : Value(comb::ConcatOp::create(builder, op.getLoc(), pieces));
+    if (!curTy)
+      value = hw::BitcastOp::create(builder, op.getLoc(), stateEltTy, value);
   }
 
-  // Element drive: read-modify-write of the parent array signal's storage.
-  if (elementOp) {
-    auto index = lowerValue(elementOp.getIndex(), Phase::New);
-    if (!index)
-      return failure();
-    Value cur = StateReadOp::create(module.builder, op.getLoc(), state);
-    value = hw::ArrayInjectOp::create(module.builder, op.getLoc(), cur, index,
-                                      value);
+  // Member drive: read-modify-write of the parent aggregate signal's
+  // storage. For a chain, peel the storage value outward-in with
+  // hw.array_get / hw.struct_extract down to the driven member's parent,
+  // then re-inject inward-out with hw.array_inject / hw.struct_inject.
+  if (!refChain.empty()) {
+    unsigned n = refChain.size();
+    auto loc = op.getLoc();
+    Value cur = StateReadOp::create(module.builder, loc, state);
+    SmallVector<Value> parents;   // parents[k] = aggregate at nesting depth k
+    SmallVector<Value> indices;   // per-level array index (null for structs)
+    SmallVector<uint32_t> fields; // per-level struct field index
+    parents.push_back(cur);
+    for (unsigned k = 0; k < n; ++k) {
+      Operation *ref = refChain[n - 1 - k]; // outermost first
+      if (auto get = dyn_cast<llhd::SigArrayGetOp>(ref)) {
+        auto index = lowerValue(get.getIndex(), Phase::New);
+        if (!index)
+          return failure();
+        indices.push_back(index);
+        fields.push_back(0);
+        if (k + 1 < n)
+          parents.push_back(hw::ArrayGetOp::create(module.builder, loc,
+                                                   parents.back(), index));
+        continue;
+      }
+      auto extract = cast<llhd::SigStructExtractOp>(ref);
+      auto structTy = dyn_cast<hw::StructType>(parents.back().getType());
+      std::optional<uint32_t> fieldIndex;
+      if (structTy)
+        fieldIndex = structTy.getFieldIndex(extract.getFieldAttr());
+      if (!fieldIndex)
+        return op.emitOpError()
+               << "struct field drive does not match the signal type";
+      indices.push_back(Value());
+      fields.push_back(*fieldIndex);
+      if (k + 1 < n)
+        parents.push_back(hw::StructExtractOp::create(
+            module.builder, loc, structTy.getElements()[*fieldIndex].type,
+            parents.back(), module.builder.getI32IntegerAttr(*fieldIndex)));
+    }
+    for (unsigned k = n; k-- > 0;) {
+      if (indices[k])
+        value = hw::ArrayInjectOp::create(module.builder, loc, parents[k],
+                                          indices[k], value);
+      else
+        value = hw::StructInjectOp::create(module.builder, loc,
+                                           parents[k].getType(), parents[k],
+                                           fields[k], value);
+    }
   }
 
   if (op.getEnable()) {
@@ -1551,6 +1626,16 @@ Value OpLowering::lowerValue(llhd::ProbeOp op, OpResult result, Phase phase) {
     if (auto extract = dyn_cast<llhd::SigExtractOp>(sigResult.getOwner())) {
       if (auto cst = extract.getLowBit().getDefiningOp<hw::ConstantOp>()) {
         auto parent = dyn_cast<OpResult>(extract.getInput());
+        // Look through ref-typed unrealized casts (the packed-aggregate
+        // bit-view idiom); mirrors the drive-side matcher.
+        while (parent) {
+          auto castOp =
+              dyn_cast<mlir::UnrealizedConversionCastOp>(parent.getOwner());
+          if (!castOp || castOp->getNumOperands() != 1 ||
+              !isa<llhd::RefType>(castOp->getOperand(0).getType()))
+            break;
+          parent = dyn_cast<OpResult>(castOp->getOperand(0));
+        }
         if (parent && isa<llhd::SignalOp>(parent.getOwner())) {
           sliceOp = extract;
           sliceOffset = cst.getValue().getZExtValue();
@@ -1575,9 +1660,23 @@ Value OpLowering::lowerValue(llhd::ProbeOp op, OpResult result, Phase phase) {
       StateReadOp::create(module.getBuilder(phase), op.getLoc(), state);
   if (sliceOp) {
     auto resTy = dyn_cast<IntegerType>(op.getResult().getType());
-    auto curTy =
-        dyn_cast<IntegerType>(cast<StateType>(state.getType()).getType());
-    if (!resTy || !curTy || sliceOffset + resTy.getWidth() > curTy.getWidth()) {
+    Type stateEltTy = cast<StateType>(state.getType()).getType();
+    auto curTy = dyn_cast<IntegerType>(stateEltTy);
+    unsigned parentWidth = 0;
+    if (curTy) {
+      parentWidth = curTy.getWidth();
+    } else {
+      // Aggregate signal probed through its bit view: read, bitcast, slice.
+      int64_t aggWidth = hw::getBitWidth(stateEltTy);
+      if (aggWidth > 0) {
+        parentWidth = aggWidth;
+        read = hw::BitcastOp::create(
+            module.getBuilder(phase), op.getLoc(),
+            IntegerType::get(op.getContext(), parentWidth), read);
+      }
+    }
+    if (!resTy || !parentWidth ||
+        sliceOffset + resTy.getWidth() > parentWidth) {
       emitError(op.getLoc())
           << "slice probe of a non-integer module-level signal is not "
              "supported";

--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -127,14 +127,17 @@ struct ConvertGeneric : public ConversionPattern {
   }
 };
 
-// An array_get with i0 index just returns the array input, which will have been
-// scalarized.
+// An array_get with i0 index, or of a 1-element array (whose type gets
+// scalarized regardless of the index width used), just returns the array
+// input.
 struct ConvertArrayGet : public OpConversionPattern<hw::ArrayGetOp> {
   using OpConversionPattern<hw::ArrayGetOp>::OpConversionPattern;
   LogicalResult
   matchAndRewrite(hw::ArrayGetOp op, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (adaptor.getIndex().empty()) {
+    if (adaptor.getIndex().empty() ||
+        hw::type_cast<hw::ArrayType>(op.getInput().getType())
+                .getNumElements() == 1) {
       assert(adaptor.getInput().size() == 1);
       rewriter.replaceOp(op, adaptor.getInput().front());
       return success();
@@ -159,13 +162,17 @@ struct ConvertArrayCreate : public OpConversionPattern<hw::ArrayCreateOp> {
   }
 };
 
-// Converts array_inject with i0 index to just return the element.
+// Converts array_inject with i0 index, or into a 1-element array (whose type
+// gets scalarized regardless of the index width used), to just return the
+// element.
 struct ConvertArrayInject : public OpConversionPattern<hw::ArrayInjectOp> {
   using OpConversionPattern<hw::ArrayInjectOp>::OpConversionPattern;
   LogicalResult
   matchAndRewrite(hw::ArrayInjectOp op, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (adaptor.getIndex().empty()) {
+    if (adaptor.getIndex().empty() ||
+        hw::type_cast<hw::ArrayType>(op.getInput().getType())
+                .getNumElements() == 1) {
       rewriter.replaceOp(op, adaptor.getElement());
       return success();
     }

--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -11,6 +11,7 @@
 #include "circt/Dialect/Arc/ArcTypes.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/LLHD/LLHDOps.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -181,6 +182,101 @@ struct ConvertArrayInject : public OpConversionPattern<hw::ArrayInjectOp> {
   }
 };
 
+// A sig.array_get with an i0 index (the LLHD index-width constraint forces
+// i0 exactly for 1-element arrays): the element ref aliases the whole-array
+// ref (same address, [1 x T] layout). Ref TYPES are not scalarized (the
+// signal's storage keeps its layout), so bridge the two ref types with an
+// unrealized cast — the same bridging idiom the state lowering uses; both
+// sides become plain pointers in the LLVM lowering and the cast cancels.
+struct ConvertSigArrayGet : public OpConversionPattern<llhd::SigArrayGetOp> {
+  using OpConversionPattern<llhd::SigArrayGetOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(llhd::SigArrayGetOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!adaptor.getIndex().empty())
+      return failure();
+    assert(adaptor.getInput().size() == 1);
+    Value input = adaptor.getInput().front();
+    if (input.getType() == op.getResult().getType()) {
+      rewriter.replaceOp(op, input);
+      return success();
+    }
+    auto castOp = mlir::UnrealizedConversionCastOp::create(
+        rewriter, op.getLoc(), op.getResult().getType(), input);
+    rewriter.replaceOp(op, castOp.getResults());
+    return success();
+  }
+};
+
+// The bit-slice sibling: an i0 low-bit index (1-bit signals) slices the
+// whole width; the sliced ref aliases the input ref.
+struct ConvertSigExtract : public OpConversionPattern<llhd::SigExtractOp> {
+  using OpConversionPattern<llhd::SigExtractOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(llhd::SigExtractOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!adaptor.getLowBit().empty())
+      return failure();
+    assert(adaptor.getInput().size() == 1);
+    Value input = adaptor.getInput().front();
+    if (input.getType() == op.getResult().getType()) {
+      rewriter.replaceOp(op, input);
+      return success();
+    }
+    auto castOp = mlir::UnrealizedConversionCastOp::create(
+        rewriter, op.getLoc(), op.getResult().getType(), input);
+    rewriter.replaceOp(op, castOp.getResults());
+    return success();
+  }
+};
+
+// Probes and drives bridge the ref world (ref types keep the signal's
+// storage layout and are not converted) to the value world (1-element
+// arrays scalarized). When the value-side type converts, re-point the ref
+// through an unrealized cast to the converted element type -- same address,
+// a [1 x T] layout is byte-identical to T -- and rebuild the op.
+struct ConvertProbe : public OpConversionPattern<llhd::ProbeOp> {
+  using OpConversionPattern<llhd::ProbeOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(llhd::ProbeOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type oldType = op.getResult().getType();
+    Type newType = getTypeConverter()->convertType(oldType);
+    if (!newType || newType == oldType)
+      return failure();
+    assert(adaptor.getSignal().size() == 1);
+    Value ref = mlir::UnrealizedConversionCastOp::create(
+                    rewriter, op.getLoc(), llhd::RefType::get(newType),
+                    adaptor.getSignal().front())
+                    .getResult(0);
+    rewriter.replaceOpWithNewOp<llhd::ProbeOp>(op, ref);
+    return success();
+  }
+};
+
+struct ConvertLLHDDrive : public OpConversionPattern<llhd::DriveOp> {
+  using OpConversionPattern<llhd::DriveOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(llhd::DriveOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type oldType = op.getValue().getType();
+    Type newType = getTypeConverter()->convertType(oldType);
+    if (!newType || newType == oldType)
+      return failure();
+    assert(adaptor.getSignal().size() == 1 && adaptor.getValue().size() == 1 &&
+           adaptor.getTime().size() == 1);
+    Value ref = mlir::UnrealizedConversionCastOp::create(
+                    rewriter, op.getLoc(), llhd::RefType::get(newType),
+                    adaptor.getSignal().front())
+                    .getResult(0);
+    Value enable =
+        adaptor.getEnable().empty() ? Value() : adaptor.getEnable().front();
+    rewriter.replaceOpWithNewOp<llhd::DriveOp>(
+        op, ref, adaptor.getValue().front(), adaptor.getTime().front(), enable);
+    return success();
+  }
+};
+
 // Converts an aggregate_constant by recursively rewriting its attribute.
 struct ConvertAggregateConstant
     : public OpConversionPattern<hw::AggregateConstantOp> {
@@ -317,8 +413,10 @@ void RemoveI0TypesPass::runOnOperation() {
 
   patterns.add<LegalizeGeneric<func::ReturnOp>, LegalizeGeneric<func::CallOp>,
                LegalizeGeneric<hw::StructCreateOp>, ConvertArrayGet,
-               ConvertArrayCreate, ConvertArrayInject, ConvertGeneric,
-               ConvertAggregateConstant>(converter, &getContext());
+               ConvertArrayCreate, ConvertArrayInject, ConvertSigArrayGet,
+               ConvertSigExtract, ConvertProbe, ConvertLLHDDrive,
+               ConvertGeneric, ConvertAggregateConstant>(converter,
+                                                         &getContext());
   ConversionConfig config;
   config.allowPatternRollback = false;
   if (failed(applyFullConversion(getOperation(), target, std::move(patterns),

--- a/lib/Dialect/Arc/Transforms/SplitFalseCombLoops.cpp
+++ b/lib/Dialect/Arc/Transforms/SplitFalseCombLoops.cpp
@@ -1,0 +1,933 @@
+//===- SplitFalseCombLoops.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// ConvertToArcs' fan-in analysis detects combinational loops at whole-SSA-value
+// granularity. Aggregate update chains of the form "write element i, read
+// element j" (unrolled per-way cache state updates, register files, struct
+// field updates) and narrow bitwise feedback (bit 0 depends on bit 1) form
+// SSA cycles in the `hw.module` graph region even though they are perfectly
+// acyclic per array element, struct field, or bit. This pass finds strongly
+// connected components among non-arc-breaking combinational ops and, as long
+// as every op in a component is decomposable, splits the participating values
+// one type level at a time (arrays into elements, structs into fields, and --
+// capped by an option -- integers into bits). Genuine loops are left in place
+// for ConvertToArcs to diagnose.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/LLHD/LLHDOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Sim/SimOps.h"
+#include "circt/Support/BackedgeBuilder.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
+
+#define DEBUG_TYPE "arc-split-false-comb-loops"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_SPLITFALSECOMBLOOPS
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace circt;
+using namespace arc;
+using llvm::SmallDenseMap;
+
+/// Mirror of ConvertToArcs' isArcBreakingOp: ops whose results do not carry a
+/// combinational dependency for the purposes of the fan-in loop analysis.
+static bool isCombBreaker(mlir::Operation *op) {
+  if (isa<arc::TapOp>(op))
+    return false;
+  if (isa<llhd::ProbeOp>(op))
+    return true;
+  if (llvm::any_of(op->getResults(), [](mlir::Value v) {
+        return isa<llhd::RefType>(v.getType());
+      }))
+    return true;
+  return op->hasTrait<mlir::OpTrait::ConstantLike>() ||
+         isa<hw::InstanceOp, seq::CompRegOp, arc::MemoryOp,
+             arc::MemoryReadPortOp, arc::ClockedOpInterface, seq::InitialOp,
+             seq::ClockGateOp, sim::DPICallOp>(op) ||
+         op->getNumResults() > 1 || op->getNumRegions() > 0 ||
+         !mlir::isMemoryEffectFree(op);
+}
+
+namespace {
+
+/// The number of scalar leaves of a type under full recursive aggregate
+/// decomposition. Arrays contribute elements times their element's leaves,
+/// structs the sum of their fields' leaves, and any other type is one leaf
+/// (integers are only decomposed in dedicated bitwise rounds).
+static uint64_t leafCount(mlir::Type type) {
+  if (auto arrayTy = dyn_cast<hw::ArrayType>(type))
+    return arrayTy.getNumElements() * leafCount(arrayTy.getElementType());
+  if (auto structTy = dyn_cast<hw::StructType>(type)) {
+    uint64_t count = 0;
+    for (auto field : structTy.getElements())
+      count += leafCount(field.type);
+    return count;
+  }
+  return 1;
+}
+
+/// Whether a type contains a union anywhere; unions are not decomposable.
+static bool containsUnion(mlir::Type type) {
+  if (isa<hw::UnionType>(type))
+    return true;
+  if (auto arrayTy = dyn_cast<hw::ArrayType>(type))
+    return containsUnion(arrayTy.getElementType());
+  if (auto structTy = dyn_cast<hw::StructType>(type))
+    return llvm::any_of(structTy.getElements(),
+                        [](auto field) { return containsUnion(field.type); });
+  return false;
+}
+
+/// The type of leaf `idx` under full recursive decomposition. Leaves are
+/// numbered element 0 first for arrays and in declaration order for structs.
+static mlir::Type leafType(mlir::Type type, uint64_t idx) {
+  if (auto arrayTy = dyn_cast<hw::ArrayType>(type)) {
+    uint64_t perElement = leafCount(arrayTy.getElementType());
+    return leafType(arrayTy.getElementType(), idx % perElement);
+  }
+  if (auto structTy = dyn_cast<hw::StructType>(type)) {
+    for (auto field : structTy.getElements()) {
+      uint64_t count = leafCount(field.type);
+      if (idx < count)
+        return leafType(field.type, idx);
+      idx -= count;
+    }
+    llvm_unreachable("leaf index out of range");
+  }
+  return type;
+}
+
+struct SplitFalseCombLoopsPass
+    : public arc::impl::SplitFalseCombLoopsBase<SplitFalseCombLoopsPass> {
+  using SplitFalseCombLoopsBase::SplitFalseCombLoopsBase;
+
+  void runOnOperation() override;
+  bool runOneRound(mlir::Block &body);
+  bool splitAggregateSCC(llvm::ArrayRef<mlir::Operation *> scc);
+  bool splitBitwiseSCC(llvm::ArrayRef<mlir::Operation *> scc);
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// SCC discovery
+//===----------------------------------------------------------------------===//
+
+/// Compute SCCs of size > 1 (or with a self edge) among the non-breaker ops of
+/// `body`. Edges run from defining op to user; operands defined by breaker ops
+/// contribute no edge, mirroring ConvertToArcs' traversal.
+static void findCombSCCs(
+    mlir::Block &body,
+    llvm::SmallVectorImpl<llvm::SmallVector<mlir::Operation *>> &sccs) {
+  // Iterative Tarjan.
+  struct NodeInfo {
+    unsigned index = 0;
+    unsigned lowlink = 0;
+    bool onStack = false;
+    bool visited = false;
+  };
+  SmallDenseMap<mlir::Operation *, NodeInfo> info;
+  llvm::SmallVector<mlir::Operation *> stack;
+  unsigned counter = 0;
+
+  auto isNode = [](mlir::Operation *op) { return !isCombBreaker(op); };
+
+  auto forEachSucc = [&](mlir::Operation *op, auto callback) {
+    for (auto operand : op->getOperands()) {
+      auto *def = operand.getDefiningOp();
+      if (!def || def->getBlock() != op->getBlock() || !isNode(def))
+        continue;
+      callback(def);
+    }
+  };
+
+  // DFS over "operand-defining op" edges; SCCs found are identical regardless
+  // of edge direction.
+  struct Frame {
+    mlir::Operation *op;
+    llvm::SmallVector<mlir::Operation *, 4> succs;
+    unsigned nextSucc = 0;
+  };
+
+  for (auto &rootOp : body) {
+    if (!isNode(&rootOp) || info[&rootOp].visited)
+      continue;
+    llvm::SmallVector<Frame> dfs;
+    auto pushNode = [&](mlir::Operation *op) {
+      auto &ni = info[op];
+      ni.visited = true;
+      ni.index = ni.lowlink = counter++;
+      ni.onStack = true;
+      stack.push_back(op);
+      Frame frame;
+      frame.op = op;
+      forEachSucc(op,
+                  [&](mlir::Operation *succ) { frame.succs.push_back(succ); });
+      dfs.push_back(std::move(frame));
+    };
+    pushNode(&rootOp);
+    while (!dfs.empty()) {
+      auto &frame = dfs.back();
+      if (frame.nextSucc < frame.succs.size()) {
+        auto *succ = frame.succs[frame.nextSucc++];
+        auto &si = info[succ];
+        if (!si.visited) {
+          pushNode(succ);
+          continue;
+        }
+        if (si.onStack) {
+          auto &ni = info[frame.op];
+          ni.lowlink = std::min(ni.lowlink, si.index);
+        }
+        continue;
+      }
+      // Pop.
+      auto *op = frame.op;
+      auto &ni = info[op];
+      dfs.pop_back();
+      if (!dfs.empty()) {
+        auto &pi = info[dfs.back().op];
+        pi.lowlink = std::min(pi.lowlink, ni.lowlink);
+      }
+      if (ni.lowlink == ni.index) {
+        llvm::SmallVector<mlir::Operation *> scc;
+        while (true) {
+          auto *member = stack.pop_back_val();
+          info[member].onStack = false;
+          scc.push_back(member);
+          if (member == op)
+            break;
+        }
+        if (scc.size() > 1) {
+          sccs.push_back(std::move(scc));
+        } else {
+          // Keep single nodes only if they have a self edge (possible in the
+          // graph region of an hw.module).
+          auto *single = scc.front();
+          bool selfEdge =
+              llvm::any_of(single->getOperands(), [&](mlir::Value v) {
+                return v.getDefiningOp() == single;
+              });
+          if (selfEdge)
+            sccs.push_back(std::move(scc));
+        }
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Piece-level acyclicity pre-check
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Checks whether the dependency graph of an SCC is acyclic at *piece*
+/// granularity, i.e. after decomposing every member value into its array
+/// elements, struct fields, or bits. Only then is the loop false and the
+/// rewrite guaranteed to terminate with all backedges resolvable.
+struct PieceGraph {
+  /// Offset into the flat node space and arity per member value.
+  llvm::SmallDenseMap<mlir::Value, std::pair<unsigned, unsigned>> members;
+  unsigned numNodes = 0;
+  /// Adjacency: for each piece node, the piece nodes it depends on.
+  llvm::SmallVector<llvm::SmallVector<unsigned, 4>> deps;
+
+  /// Add a member value with the given decomposition arity.
+  void addValue(mlir::Value v, unsigned arity) {
+    members[v] = {numNodes, arity};
+    numNodes += arity;
+  }
+
+  bool isMember(mlir::Value v) const { return members.count(v); }
+
+  void allocate() { deps.resize(numNodes); }
+
+  unsigned node(mlir::Value v, unsigned piece) const {
+    return members.lookup(v).first + piece;
+  }
+
+  /// result piece `i` depends on piece `j` of member operand `x`.
+  void addDep(mlir::Value result, unsigned i, mlir::Value x, unsigned j) {
+    deps[node(result, i)].push_back(node(x, j));
+  }
+
+  /// result piece `i` depends on all pieces of operand `x` (no-op for
+  /// non-member operands).
+  void addDepAll(mlir::Value result, unsigned i, mlir::Value x) {
+    auto it = members.find(x);
+    if (it == members.end())
+      return;
+    auto [offset, arity] = it->second;
+    for (unsigned j = 0; j < arity; ++j)
+      deps[node(result, i)].push_back(offset + j);
+  }
+
+  /// Iterative three-color DFS cycle check.
+  bool isAcyclic() const {
+    enum : uint8_t { White, Gray, Black };
+    llvm::SmallVector<uint8_t> color(numNodes, White);
+    llvm::SmallVector<std::pair<unsigned, unsigned>> stack;
+    for (unsigned root = 0; root < numNodes; ++root) {
+      if (color[root] != White)
+        continue;
+      color[root] = Gray;
+      stack.push_back({root, 0});
+      while (!stack.empty()) {
+        auto &[n, next] = stack.back();
+        if (next < deps[n].size()) {
+          unsigned succ = deps[n][next++];
+          if (color[succ] == Gray)
+            return false;
+          if (color[succ] == White) {
+            color[succ] = Gray;
+            stack.push_back({succ, 0});
+          }
+          continue;
+        }
+        color[n] = Black;
+        stack.pop_back();
+      }
+    }
+    return true;
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Aggregate splitting
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Shared machinery for rewriting one SCC by decomposing every member value
+/// one level.
+struct SCCRewriter {
+  llvm::SmallVector<mlir::Operation *> ops;
+  llvm::SmallDenseSet<mlir::Operation *> opSet;
+  mlir::OpBuilder builder;
+  BackedgeBuilder backedges;
+  /// Backedge placeholders for each SCC result value's pieces.
+  SmallDenseMap<mlir::Value, llvm::SmallVector<Backedge>> pieces;
+  /// Resolved piece values, filled as ops get rewritten.
+  SmallDenseMap<mlir::Value, llvm::SmallVector<mlir::Value>> resolved;
+  /// Materialized whole values for SCC results.
+  SmallDenseMap<mlir::Value, mlir::Value> wholes;
+
+  SCCRewriter(llvm::ArrayRef<mlir::Operation *> scc, mlir::MLIRContext *ctx)
+      : ops(scc.begin(), scc.end()), opSet(scc.begin(), scc.end()),
+        builder(ctx), backedges(builder, scc.front()->getLoc()) {}
+
+  bool isSCCValue(mlir::Value v) {
+    auto *def = v.getDefiningOp();
+    return def && opSet.contains(def);
+  }
+
+  void finalize() {
+    // A piece may resolve directly to another piece's placeholder. Since the
+    // stored `resolved` values are captured before any placeholder is
+    // replaced, chase placeholder-to-placeholder chains to their final value
+    // first (the piece-level acyclicity pre-check guarantees termination);
+    // otherwise a placeholder replaced early would be re-introduced by a
+    // later `setValue` through its stale handle.
+    SmallDenseMap<mlir::Value, std::pair<mlir::Value, unsigned>> targets;
+    for (auto &[value, edges] : pieces)
+      for (auto [i, edge] : llvm::enumerate(edges))
+        targets[(mlir::Value)edge] = {value, (unsigned)i};
+    auto chase = [&](mlir::Value val) {
+      while (true) {
+        auto it = targets.find(val);
+        if (it == targets.end())
+          return val;
+        val = resolved[it->second.first][it->second.second];
+      }
+    };
+    // Resolve all placeholders.
+    for (auto &[value, edges] : pieces) {
+      auto &res = resolved[value];
+      assert(res.size() == edges.size() && "unresolved pieces");
+      for (auto [edge, val] : llvm::zip(edges, res))
+        edge.setValue(chase(val));
+    }
+    // Detach the old (mutually referencing) ops from each other first so that
+    // only genuinely external uses remain, then re-materialize wholes for
+    // those and erase the old ops. A single-leaf value's whole may be a
+    // cached placeholder captured before resolution; chase it as well, or the
+    // replacement would re-introduce uses of the dead placeholder.
+    for (auto *op : ops)
+      op->dropAllReferences();
+    for (auto *op : ops) {
+      auto result = op->getResult(0);
+      if (!result.use_empty())
+        result.replaceAllUsesWith(chase(getWhole(result)));
+    }
+    for (auto *op : ops)
+      op->erase();
+  }
+
+  virtual mlir::Value getWhole(mlir::Value v) = 0;
+  virtual ~SCCRewriter() = default;
+};
+
+struct AggregateSCCRewriter : public SCCRewriter {
+  using SCCRewriter::SCCRewriter;
+
+  /// Cache for materialized leaves of non-member values.
+  llvm::DenseMap<std::pair<mlir::Value, uint64_t>, mlir::Value> externalLeaves;
+
+  /// Materialize an access chain to leaf `idx` of the (non-member) value `x`.
+  mlir::Value materializeLeaf(mlir::Value x, uint64_t idx) {
+    auto type = x.getType();
+    if (auto arrayTy = dyn_cast<hw::ArrayType>(type)) {
+      uint64_t perElement = leafCount(arrayTy.getElementType());
+      unsigned idxWidth =
+          std::max(1u, (unsigned)llvm::Log2_64_Ceil(arrayTy.getNumElements()));
+      auto cst = hw::ConstantOp::create(
+          builder, x.getLoc(), llvm::APInt(idxWidth, idx / perElement));
+      auto element = hw::ArrayGetOp::create(builder, x.getLoc(), x, cst);
+      return materializeLeaf(element, idx % perElement);
+    }
+    if (auto structTy = dyn_cast<hw::StructType>(type)) {
+      for (auto [fieldIdx, field] : llvm::enumerate(structTy.getElements())) {
+        uint64_t count = leafCount(field.type);
+        if (idx < count) {
+          auto fieldValue =
+              hw::StructExtractOp::create(builder, x.getLoc(), field.type, x,
+                                          builder.getI32IntegerAttr(fieldIdx));
+          return materializeLeaf(fieldValue, idx);
+        }
+        idx -= count;
+      }
+      llvm_unreachable("leaf index out of range");
+    }
+    assert(idx == 0 && "non-aggregate values have a single leaf");
+    return x;
+  }
+
+  /// Leaf `idx` of value `x`: a placeholder for member values, a materialized
+  /// access chain otherwise.
+  mlir::Value getPiece(mlir::Value x, uint64_t idx) {
+    if (isSCCValue(x))
+      return pieces[x][idx];
+    auto [it, inserted] = externalLeaves.try_emplace({x, idx});
+    if (inserted)
+      it->second = materializeLeaf(x, idx);
+    return it->second;
+  }
+
+  /// Recursively reassemble a value of `type` from its leaves.
+  mlir::Value buildWhole(mlir::Type type, llvm::ArrayRef<mlir::Value> leaves,
+                         mlir::Location loc) {
+    if (auto arrayTy = dyn_cast<hw::ArrayType>(type)) {
+      uint64_t perElement = leafCount(arrayTy.getElementType());
+      // array_create takes elements MSB-first (operand 0 = highest index).
+      llvm::SmallVector<mlir::Value> elements;
+      for (uint64_t e = arrayTy.getNumElements(); e > 0; --e)
+        elements.push_back(
+            buildWhole(arrayTy.getElementType(),
+                       leaves.slice((e - 1) * perElement, perElement), loc));
+      return hw::ArrayCreateOp::create(builder, loc, elements);
+    }
+    if (auto structTy = dyn_cast<hw::StructType>(type)) {
+      llvm::SmallVector<mlir::Value> fields;
+      uint64_t offset = 0;
+      for (auto field : structTy.getElements()) {
+        uint64_t count = leafCount(field.type);
+        fields.push_back(
+            buildWhole(field.type, leaves.slice(offset, count), loc));
+        offset += count;
+      }
+      return hw::StructCreateOp::create(builder, loc, structTy, fields);
+    }
+    assert(leaves.size() == 1 && "non-aggregate values have a single leaf");
+    return leaves[0];
+  }
+
+  mlir::Value getWhole(mlir::Value v) override {
+    if (!isSCCValue(v))
+      return v;
+    auto it = wholes.find(v);
+    if (it != wholes.end())
+      return it->second;
+    auto &vp = pieces[v];
+    llvm::SmallVector<mlir::Value> leaves(vp.begin(), vp.end());
+    auto whole = buildWhole(v.getType(), leaves, v.getLoc());
+    wholes[v] = whole;
+    return whole;
+  }
+
+  /// Rewrite a single op, filling `resolved[result]`.
+  void rewriteOp(mlir::Operation *op) {
+    builder.setInsertionPoint(op);
+    auto result = op->getResult(0);
+    auto loc = op->getLoc();
+    auto &res = resolved[result];
+    uint64_t numLeaves = pieces[result].size();
+
+    if (auto mux = dyn_cast<comb::MuxOp>(op)) {
+      auto cond = getWhole(mux.getCond());
+      for (uint64_t i = 0; i < numLeaves; ++i)
+        res.push_back(comb::MuxOp::create(
+            builder, loc, cond, getPiece(mux.getTrueValue(), i),
+            getPiece(mux.getFalseValue(), i), mux.getTwoState()));
+      return;
+    }
+    if (auto inject = dyn_cast<hw::ArrayInjectOp>(op)) {
+      auto arrayTy = cast<hw::ArrayType>(inject.getType());
+      uint64_t perElement = leafCount(arrayTy.getElementType());
+      auto index = getWhole(inject.getIndex());
+      llvm::APInt constIdx;
+      bool isConst = mlir::matchPattern(index, mlir::m_ConstantInt(&constIdx));
+      mlir::Value eq;
+      for (uint64_t i = 0; i < numLeaves; ++i) {
+        uint64_t element = i / perElement, sub = i % perElement;
+        if (isConst) {
+          res.push_back(constIdx == element ? getPiece(inject.getElement(), sub)
+                                            : getPiece(inject.getInput(), i));
+          continue;
+        }
+        if (sub == 0) {
+          auto cst = hw::ConstantOp::create(
+              builder, loc,
+              llvm::APInt(cast<mlir::IntegerType>(index.getType()).getWidth(),
+                          element));
+          eq = comb::ICmpOp::create(builder, loc, comb::ICmpPredicate::eq,
+                                    index, cst);
+        }
+        res.push_back(comb::MuxOp::create(builder, loc, eq,
+                                          getPiece(inject.getElement(), sub),
+                                          getPiece(inject.getInput(), i),
+                                          /*twoState=*/false));
+      }
+      return;
+    }
+    if (auto get = dyn_cast<hw::ArrayGetOp>(op)) {
+      auto arrayTy = cast<hw::ArrayType>(get.getInput().getType());
+      uint64_t perElement = leafCount(arrayTy.getElementType());
+      auto index = getWhole(get.getIndex());
+      llvm::APInt constIdx;
+      if (mlir::matchPattern(index, mlir::m_ConstantInt(&constIdx))) {
+        uint64_t base = constIdx.getZExtValue() * perElement;
+        for (uint64_t i = 0; i < numLeaves; ++i)
+          res.push_back(getPiece(get.getInput(), base + i));
+        return;
+      }
+      // Dynamic read: reassemble the base (acyclic per the piece-level
+      // pre-check) and read from it like before.
+      auto whole =
+          hw::ArrayGetOp::create(builder, loc, getWhole(get.getInput()), index);
+      for (uint64_t i = 0; i < numLeaves; ++i)
+        res.push_back(materializeLeaf(whole, i));
+      return;
+    }
+    if (auto create = dyn_cast<hw::ArrayCreateOp>(op)) {
+      // Operands are MSB-first: operand 0 is element N-1.
+      auto inputs = create.getInputs();
+      uint64_t perElement = numLeaves / inputs.size();
+      for (uint64_t i = 0; i < numLeaves; ++i)
+        res.push_back(getPiece(inputs[inputs.size() - 1 - i / perElement],
+                               i % perElement));
+      return;
+    }
+    if (auto create = dyn_cast<hw::StructCreateOp>(op)) {
+      auto structTy = cast<hw::StructType>(create.getType());
+      for (auto [fieldIdx, field] : llvm::enumerate(structTy.getElements())) {
+        uint64_t count = leafCount(field.type);
+        for (uint64_t s = 0; s < count; ++s)
+          res.push_back(getPiece(create.getInput()[fieldIdx], s));
+      }
+      return;
+    }
+    if (auto extract = dyn_cast<hw::StructExtractOp>(op)) {
+      auto structTy = cast<hw::StructType>(extract.getInput().getType());
+      uint64_t offset = 0;
+      for (unsigned f = 0; f < extract.getFieldIndex(); ++f)
+        offset += leafCount(structTy.getElements()[f].type);
+      for (uint64_t i = 0; i < numLeaves; ++i)
+        res.push_back(getPiece(extract.getInput(), offset + i));
+      return;
+    }
+    if (auto inject = dyn_cast<hw::StructInjectOp>(op)) {
+      auto structTy = cast<hw::StructType>(inject.getType());
+      uint64_t offset = 0;
+      for (unsigned f = 0; f < inject.getFieldIndex(); ++f)
+        offset += leafCount(structTy.getElements()[f].type);
+      uint64_t count =
+          leafCount(structTy.getElements()[inject.getFieldIndex()].type);
+      for (uint64_t i = 0; i < numLeaves; ++i) {
+        if (i >= offset && i < offset + count)
+          res.push_back(getPiece(inject.getNewValue(), i - offset));
+        else
+          res.push_back(getPiece(inject.getInput(), i));
+      }
+      return;
+    }
+    llvm_unreachable("unexpected op in aggregate SCC");
+  }
+};
+} // namespace
+
+bool SplitFalseCombLoopsPass::splitAggregateSCC(
+    llvm::ArrayRef<mlir::Operation *> scc) {
+  // Every op must be decomposable and at least one member value must be an
+  // aggregate for a split to make progress.
+  bool anyAggregate = false;
+  uint64_t totalPieces = 0;
+  for (auto *op : scc) {
+    if (!isa<comb::MuxOp, hw::ArrayInjectOp, hw::ArrayGetOp, hw::ArrayCreateOp,
+             hw::StructCreateOp, hw::StructExtractOp, hw::StructInjectOp>(op))
+      return false;
+    auto type = op->getResult(0).getType();
+    if (isa<hw::ArrayType, hw::StructType>(type))
+      anyAggregate = true;
+    if (containsUnion(type))
+      return false;
+    totalPieces += leafCount(type);
+    if (totalPieces > (1ull << 20))
+      return false;
+  }
+  if (!anyAggregate)
+    return false;
+
+  // Pre-check: the loop must actually be false at leaf granularity, i.e. the
+  // leaf-level dependency graph must be acyclic. This rejects genuine loops
+  // (e.g. an element read-modify-write feeding back into itself) for which
+  // the rewrite could not resolve its placeholders.
+  PieceGraph graph;
+  for (auto *op : scc)
+    graph.addValue(op->getResult(0), leafCount(op->getResult(0).getType()));
+  graph.allocate();
+  for (auto *op : scc) {
+    auto result = op->getResult(0);
+    uint64_t numLeaves = leafCount(result.getType());
+    if (auto mux = dyn_cast<comb::MuxOp>(op)) {
+      for (uint64_t i = 0; i < numLeaves; ++i) {
+        graph.addDepAll(result, i, mux.getCond());
+        if (graph.isMember(mux.getTrueValue()))
+          graph.addDep(result, i, mux.getTrueValue(), i);
+        if (graph.isMember(mux.getFalseValue()))
+          graph.addDep(result, i, mux.getFalseValue(), i);
+      }
+    } else if (auto inject = dyn_cast<hw::ArrayInjectOp>(op)) {
+      uint64_t perElement =
+          leafCount(cast<hw::ArrayType>(inject.getType()).getElementType());
+      llvm::APInt constIdx;
+      bool isConst =
+          mlir::matchPattern(inject.getIndex(), mlir::m_ConstantInt(&constIdx));
+      for (uint64_t i = 0; i < numLeaves; ++i) {
+        uint64_t element = i / perElement, sub = i % perElement;
+        if (isConst) {
+          if (constIdx == element) {
+            if (graph.isMember(inject.getElement()))
+              graph.addDep(result, i, inject.getElement(), sub);
+          } else if (graph.isMember(inject.getInput())) {
+            graph.addDep(result, i, inject.getInput(), i);
+          }
+          continue;
+        }
+        if (graph.isMember(inject.getElement()))
+          graph.addDep(result, i, inject.getElement(), sub);
+        if (graph.isMember(inject.getInput()))
+          graph.addDep(result, i, inject.getInput(), i);
+        graph.addDepAll(result, i, inject.getIndex());
+      }
+    } else if (auto get = dyn_cast<hw::ArrayGetOp>(op)) {
+      uint64_t perElement = leafCount(
+          cast<hw::ArrayType>(get.getInput().getType()).getElementType());
+      llvm::APInt constIdx;
+      bool isConst =
+          mlir::matchPattern(get.getIndex(), mlir::m_ConstantInt(&constIdx));
+      for (uint64_t i = 0; i < numLeaves; ++i) {
+        if (isConst) {
+          if (graph.isMember(get.getInput()))
+            graph.addDep(result, i, get.getInput(),
+                         constIdx.getZExtValue() * perElement + i);
+        } else {
+          graph.addDepAll(result, i, get.getInput());
+          graph.addDepAll(result, i, get.getIndex());
+        }
+      }
+    } else if (auto create = dyn_cast<hw::ArrayCreateOp>(op)) {
+      auto inputs = create.getInputs();
+      uint64_t perElement = numLeaves / inputs.size();
+      for (uint64_t i = 0; i < numLeaves; ++i) {
+        auto operand = inputs[inputs.size() - 1 - i / perElement];
+        if (graph.isMember(operand))
+          graph.addDep(result, i, operand, i % perElement);
+      }
+    } else if (auto create = dyn_cast<hw::StructCreateOp>(op)) {
+      auto structTy = cast<hw::StructType>(create.getType());
+      uint64_t i = 0;
+      for (auto [fieldIdx, field] : llvm::enumerate(structTy.getElements())) {
+        uint64_t count = leafCount(field.type);
+        for (uint64_t s = 0; s < count; ++s, ++i)
+          if (graph.isMember(create.getInput()[fieldIdx]))
+            graph.addDep(result, i, create.getInput()[fieldIdx], s);
+      }
+    } else if (auto extract = dyn_cast<hw::StructExtractOp>(op)) {
+      auto structTy = cast<hw::StructType>(extract.getInput().getType());
+      uint64_t offset = 0;
+      for (unsigned f = 0; f < extract.getFieldIndex(); ++f)
+        offset += leafCount(structTy.getElements()[f].type);
+      for (uint64_t i = 0; i < numLeaves; ++i)
+        if (graph.isMember(extract.getInput()))
+          graph.addDep(result, i, extract.getInput(), offset + i);
+    } else if (auto inject = dyn_cast<hw::StructInjectOp>(op)) {
+      auto structTy = cast<hw::StructType>(inject.getType());
+      uint64_t offset = 0;
+      for (unsigned f = 0; f < inject.getFieldIndex(); ++f)
+        offset += leafCount(structTy.getElements()[f].type);
+      uint64_t count =
+          leafCount(structTy.getElements()[inject.getFieldIndex()].type);
+      for (uint64_t i = 0; i < numLeaves; ++i) {
+        if (i >= offset && i < offset + count) {
+          if (graph.isMember(inject.getNewValue()))
+            graph.addDep(result, i, inject.getNewValue(), i - offset);
+        } else if (graph.isMember(inject.getInput())) {
+          graph.addDep(result, i, inject.getInput(), i);
+        }
+      }
+    }
+  }
+  if (!graph.isAcyclic())
+    return false;
+
+  AggregateSCCRewriter rewriter(scc, &getContext());
+  // Allocate placeholders for every member value's leaves.
+  for (auto *op : scc) {
+    auto result = op->getResult(0);
+    rewriter.builder.setInsertionPoint(op);
+    auto &edges = rewriter.pieces[result];
+    uint64_t numLeaves = leafCount(result.getType());
+    for (uint64_t i = 0; i < numLeaves; ++i)
+      edges.push_back(
+          rewriter.backedges.get(leafType(result.getType(), i), op->getLoc()));
+  }
+  for (auto *op : scc)
+    rewriter.rewriteOp(op);
+  rewriter.finalize();
+  ++numAggregateLoopsSplit;
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Bitwise splitting
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct BitwiseSCCRewriter : public SCCRewriter {
+  using SCCRewriter::SCCRewriter;
+
+  mlir::Value getPiece(mlir::Value x, unsigned idx) {
+    if (isSCCValue(x))
+      return pieces[x][idx];
+    auto width = cast<mlir::IntegerType>(x.getType()).getWidth();
+    if (width == 1) {
+      assert(idx == 0 && "single bit");
+      return x;
+    }
+    return comb::ExtractOp::create(builder, x.getLoc(), x, /*lowBit=*/idx,
+                                   /*bitWidth=*/1);
+  }
+
+  mlir::Value getWhole(mlir::Value v) override {
+    if (!isSCCValue(v))
+      return v;
+    auto it = wholes.find(v);
+    if (it != wholes.end())
+      return it->second;
+    auto &vp = pieces[v];
+    mlir::Value whole;
+    if (vp.size() == 1) {
+      whole = vp[0];
+    } else {
+      // concat takes bits MSB-first.
+      llvm::SmallVector<mlir::Value> bits;
+      for (unsigned i = vp.size(); i > 0; --i)
+        bits.push_back(vp[i - 1]);
+      whole = comb::ConcatOp::create(builder, v.getLoc(), bits);
+    }
+    wholes[v] = whole;
+    return whole;
+  }
+
+  void rewriteOp(mlir::Operation *op) {
+    builder.setInsertionPoint(op);
+    auto result = op->getResult(0);
+    auto loc = op->getLoc();
+    auto &res = resolved[result];
+    unsigned width = pieces[result].size();
+
+    if (auto mux = dyn_cast<comb::MuxOp>(op)) {
+      auto cond = getWhole(mux.getCond());
+      for (unsigned i = 0; i < width; ++i)
+        res.push_back(comb::MuxOp::create(
+            builder, loc, cond, getPiece(mux.getTrueValue(), i),
+            getPiece(mux.getFalseValue(), i), mux.getTwoState()));
+      return;
+    }
+    if (auto extract = dyn_cast<comb::ExtractOp>(op)) {
+      for (unsigned i = 0; i < width; ++i)
+        res.push_back(getPiece(extract.getInput(), extract.getLowBit() + i));
+      return;
+    }
+    if (auto concat = dyn_cast<comb::ConcatOp>(op)) {
+      // Operands are MSB-first.
+      llvm::SmallVector<mlir::Value> bits(width);
+      unsigned bit = 0;
+      for (auto operand : llvm::reverse(concat.getInputs())) {
+        unsigned w = cast<mlir::IntegerType>(operand.getType()).getWidth();
+        for (unsigned i = 0; i < w; ++i)
+          bits[bit++] = getPiece(operand, i);
+      }
+      res.append(bits.begin(), bits.end());
+      return;
+    }
+    // Variadic bitwise ops.
+    for (unsigned i = 0; i < width; ++i) {
+      llvm::SmallVector<mlir::Value> operands;
+      for (auto operand : op->getOperands())
+        operands.push_back(getPiece(operand, i));
+      mlir::Value bit;
+      if (auto andOp = dyn_cast<comb::AndOp>(op))
+        bit = comb::AndOp::create(builder, loc, operands, andOp.getTwoState());
+      else if (auto orOp = dyn_cast<comb::OrOp>(op))
+        bit = comb::OrOp::create(builder, loc, operands, orOp.getTwoState());
+      else if (auto xorOp = dyn_cast<comb::XorOp>(op))
+        bit = comb::XorOp::create(builder, loc, operands, xorOp.getTwoState());
+      else
+        llvm_unreachable("unexpected op in bitwise SCC");
+      res.push_back(bit);
+    }
+  }
+};
+} // namespace
+
+bool SplitFalseCombLoopsPass::splitBitwiseSCC(
+    llvm::ArrayRef<mlir::Operation *> scc) {
+  bool anyMultiBit = false;
+  for (auto *op : scc) {
+    if (!isa<comb::AndOp, comb::OrOp, comb::XorOp, comb::MuxOp, comb::ConcatOp,
+             comb::ExtractOp>(op))
+      return false;
+    auto intTy = dyn_cast<mlir::IntegerType>(op->getResult(0).getType());
+    if (!intTy || intTy.getWidth() == 0 || intTy.getWidth() > maxBitSplitWidth)
+      return false;
+    // All operands must be integers as well (mux condition is i1).
+    for (auto operand : op->getOperands())
+      if (!isa<mlir::IntegerType>(operand.getType()))
+        return false;
+    if (intTy.getWidth() > 1)
+      anyMultiBit = true;
+  }
+  if (!anyMultiBit)
+    return false;
+
+  // Pre-check acyclicity at bit granularity (see splitAggregateSCC).
+  auto width = [](mlir::Value v) {
+    return cast<mlir::IntegerType>(v.getType()).getWidth();
+  };
+  PieceGraph graph;
+  for (auto *op : scc)
+    graph.addValue(op->getResult(0), width(op->getResult(0)));
+  graph.allocate();
+  for (auto *op : scc) {
+    auto result = op->getResult(0);
+    unsigned w = width(result);
+    if (auto mux = dyn_cast<comb::MuxOp>(op)) {
+      for (unsigned i = 0; i < w; ++i) {
+        graph.addDepAll(result, i, mux.getCond());
+        if (graph.isMember(mux.getTrueValue()))
+          graph.addDep(result, i, mux.getTrueValue(), i);
+        if (graph.isMember(mux.getFalseValue()))
+          graph.addDep(result, i, mux.getFalseValue(), i);
+      }
+    } else if (auto extract = dyn_cast<comb::ExtractOp>(op)) {
+      for (unsigned i = 0; i < w; ++i)
+        if (graph.isMember(extract.getInput()))
+          graph.addDep(result, i, extract.getInput(), extract.getLowBit() + i);
+    } else if (auto concat = dyn_cast<comb::ConcatOp>(op)) {
+      unsigned bit = 0;
+      for (auto operand : llvm::reverse(concat.getInputs())) {
+        for (unsigned i = 0; i < width(operand); ++i, ++bit)
+          if (graph.isMember(operand))
+            graph.addDep(result, bit, operand, i);
+      }
+    } else {
+      // Variadic bitwise ops.
+      for (unsigned i = 0; i < w; ++i)
+        for (auto operand : op->getOperands())
+          if (graph.isMember(operand))
+            graph.addDep(result, i, operand, i);
+    }
+  }
+  if (!graph.isAcyclic())
+    return false;
+
+  BitwiseSCCRewriter rewriter(scc, &getContext());
+  for (auto *op : scc) {
+    auto result = op->getResult(0);
+    rewriter.builder.setInsertionPoint(op);
+    auto &edges = rewriter.pieces[result];
+    unsigned width = cast<mlir::IntegerType>(result.getType()).getWidth();
+    for (unsigned i = 0; i < width; ++i)
+      edges.push_back(rewriter.backedges.get(rewriter.builder.getIntegerType(1),
+                                             op->getLoc()));
+  }
+  for (auto *op : scc)
+    rewriter.rewriteOp(op);
+  rewriter.finalize();
+  ++numBitwiseLoopsSplit;
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Pass driver
+//===----------------------------------------------------------------------===//
+
+bool SplitFalseCombLoopsPass::runOneRound(mlir::Block &body) {
+  llvm::SmallVector<llvm::SmallVector<mlir::Operation *>> sccs;
+  findCombSCCs(body, sccs);
+  bool changed = false;
+  for (auto &scc : sccs) {
+    if (splitAggregateSCC(scc)) {
+      changed = true;
+      continue;
+    }
+    if (splitBitwiseSCC(scc))
+      changed = true;
+  }
+  return changed;
+}
+
+void SplitFalseCombLoopsPass::runOnOperation() {
+  auto module = getOperation();
+  auto *body = module.getBodyBlock();
+  if (!body)
+    return;
+  // Each round decomposes the cycle-participating values by one type level;
+  // the nesting depth of the involved types bounds the number of useful
+  // rounds. The cap is a safety net.
+  for (unsigned round = 0; round < 32; ++round)
+    if (!runOneRound(*body))
+      break;
+}

--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -428,6 +428,28 @@ bool Deseq::analyzeProcess() {
     driveInfos.push_back(DriveInfo(driveOp));
   }
 
+  // Desequentialization replaces each fed conditional drive with an
+  // UNCONDITIONAL (continuous) drive of a register result. That is only
+  // sound if this process is the signal's sole driver: a variable written
+  // by several processes takes the last write per write EVENT in the
+  // source semantics (e.g. an `initial` block setting an edge-driven reg's
+  // t=0 value), and a continuous register drive would clobber every such
+  // write on the next delta. Keep the process form in that case.
+  for (auto &info : driveInfos) {
+    for (auto *user : info.op.getSignal().getUsers()) {
+      if (auto otherDrive = dyn_cast<DriveOp>(user)) {
+        if (otherDrive.getSignal() == info.op.getSignal() &&
+            !seenDrives.contains(otherDrive)) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "Skipping " << process.getLoc()
+                     << ": drives multi-driven signal (other driver at "
+                     << otherDrive.getLoc() << ")\n");
+          return false;
+        }
+      }
+    }
+  }
+
   // Collect triggers from observed values. We support either:
   // 1. Direct i1 observed values (traditional case)
   // 2. Non-i1 observed values where dest operands are i1 projections (e.g.,

--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -355,6 +355,39 @@ void Deseq::deseq() {
 // Process Analysis
 //===----------------------------------------------------------------------===//
 
+/// Match a drive that is the canonical lowered form of a one-shot `initial`
+/// block initialization of a register variable: an unconditional zero-time
+/// (delta/epsilon) drive of a constant, executed exactly once at time zero
+/// (it sits in the entry block of some *other* process, so it runs in that
+/// process's first activation, before any wait, and can never re-execute).
+/// Returns the constant as an IntegerAttr, or null if the drive does not
+/// match.
+static IntegerAttr matchOneShotInitDrive(DriveOp drive) {
+  // Unconditional drives only.
+  if (drive.getEnable())
+    return {};
+  // Must execute inside a process (drives at module level are continuous
+  // drivers; drives in `llhd.final` run at end of simulation).
+  auto proc = drive->getParentOfType<ProcessOp>();
+  if (!proc)
+    return {};
+  // Exactly-once-at-t=0: the process entry block executes in the first
+  // activation (at time zero, before any wait terminator) and has no
+  // predecessors, so it cannot re-execute.
+  auto *block = drive->getBlock();
+  if (block != &proc.getBody().front() || !block->hasNoPredecessors())
+    return {};
+  // The value must land at t=0: zero-time (delta/epsilon) delay.
+  TimeAttr time;
+  if (!matchPattern(drive.getTime(), m_Constant(&time)) || time.getTime() != 0)
+    return {};
+  // Constant integer value.
+  IntegerAttr value;
+  if (!matchPattern(drive.getValue(), m_Constant(&value)))
+    return {};
+  return value;
+}
+
 /// Determine whether we can desequentialize the current process. Also gather
 /// the wait and drive ops that are relevant.
 bool Deseq::analyzeProcess() {
@@ -432,21 +465,46 @@ bool Deseq::analyzeProcess() {
   // UNCONDITIONAL (continuous) drive of a register result. That is only
   // sound if this process is the signal's sole driver: a variable written
   // by several processes takes the last write per write EVENT in the
-  // source semantics (e.g. an `initial` block setting an edge-driven reg's
-  // t=0 value), and a continuous register drive would clobber every such
-  // write on the next delta. Keep the process form in that case.
+  // source semantics, and a continuous register drive would clobber every
+  // such write on the next delta.
+  //
+  // EXCEPTION (the ubiquitous bench idiom):
+  //   initial begin reg = K; ... end     // one-shot t=0 constant init
+  //   always @(posedge clk) reg <= ...;  // edge updates
+  // Here the extra driver writes a constant exactly once at t=0, which
+  // folds into the register's PRESET (power-on value): the continuous
+  // register drive then reproduces K from t=0 onward, byte-equivalent to
+  // the initial block's write for every t >= 0 observation. Folding is
+  // strictly better than keeping the process form: sibling registers on
+  // the same clock that DO promote commit their state before a kept
+  // process resumes, so a kept process observes post-edge values of
+  // same-clock registers -- a one-delta skew against the LRM's preponed
+  // sampling that breaks lockstep pipelines (receipt: the 16.10 SVA
+  // local-var rows' clk_gen DUT).
+  //
+  // Any other extra driver (non-constant, conditional, delayed, repeated,
+  // continuous, or in llhd.final) keeps the genuinely-correct process form.
   for (auto &info : driveInfos) {
     for (auto *user : info.op.getSignal().getUsers()) {
-      if (auto otherDrive = dyn_cast<DriveOp>(user)) {
-        if (otherDrive.getSignal() == info.op.getSignal() &&
-            !seenDrives.contains(otherDrive)) {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "Skipping " << process.getLoc()
-                     << ": drives multi-driven signal (other driver at "
-                     << otherDrive.getLoc() << ")\n");
-          return false;
-        }
+      auto otherDrive = dyn_cast<DriveOp>(user);
+      if (!otherDrive || otherDrive.getSignal() != info.op.getSignal() ||
+          seenDrives.contains(otherDrive))
+        continue;
+      auto preset = matchOneShotInitDrive(otherDrive);
+      if (!preset) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Skipping " << process.getLoc()
+                   << ": drives multi-driven signal (other driver at "
+                   << otherDrive.getLoc() << ")\n");
+        return false;
       }
+      if (info.initPreset && info.initPreset != preset) {
+        LLVM_DEBUG(llvm::dbgs() << "Skipping " << process.getLoc()
+                                << ": conflicting one-shot init drives on "
+                                << info.op.getSignal() << "\n");
+        return false;
+      }
+      info.initPreset = preset;
     }
   }
 
@@ -1459,11 +1517,13 @@ void Deseq::implementRegister(DriveInfo &drive) {
   if (!name)
     name = builder.getStringAttr("");
 
-  // Create the register op.
-  auto reg = seq::FirRegOp::create(builder, loc, value, clock, name,
-                                   hw::InnerSymAttr{},
-                                   /*preset=*/IntegerAttr{}, reset, resetValue,
-                                   /*isAsync=*/reset != Value{});
+  // Create the register op. A one-shot t=0 constant init drive by another
+  // process (the `initial begin reg = K; end` idiom) has been folded into
+  // the register's preset (power-on value) by `analyzeProcess`.
+  auto reg = seq::FirRegOp::create(
+      builder, loc, value, clock, name, hw::InnerSymAttr{},
+      /*preset=*/drive.initPreset, reset, resetValue,
+      /*isAsync=*/reset != Value{});
 
   // If the register has an enable, insert a self-mux in front of the register.
   // Set the `bin` flag on the mux specifically to make up for a subtle

--- a/lib/Dialect/LLHD/Transforms/DeseqUtils.h
+++ b/lib/Dialect/LLHD/Transforms/DeseqUtils.h
@@ -262,6 +262,11 @@ struct DriveInfo {
   /// The optional reset that triggers a change of the driven value to a fixed
   /// reset value. Null if no reset was detected.
   ResetInfo reset;
+  /// The optional power-on value folded from another process's one-shot t=0
+  /// constant drive of the same signal (the `initial begin reg = K; end`
+  /// idiom next to an `always @(posedge clk)` driver). Becomes the lowered
+  /// register's preset. Null if the signal has no such extra driver.
+  IntegerAttr initPreset;
 
   DriveInfo() {}
   explicit DriveInfo(DriveOp op) : op(op) {}

--- a/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
+++ b/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
@@ -83,7 +83,16 @@ struct ConcatRefLowering : public OpConversionPattern<OpTy> {
       // description mentioned.
       srcWidth = srcWidth - width;
 
-      OpTy::create(rewriter, op.getLoc(), operand, extract);
+      // Delayed assignment variants carry their delay over to every slice:
+      // the RHS is still evaluated at statement execution time (the extract
+      // above), and each slice is scheduled with the original delay, which
+      // matches the intra-assignment delay semantics of the unsliced
+      // assignment (IEEE 1800-2017 § 9.4.5).
+      if constexpr (std::is_same_v<OpTy, DelayedNonBlockingAssignOp> ||
+                    std::is_same_v<OpTy, DelayedContinuousAssignOp>)
+        OpTy::create(rewriter, op.getLoc(), operand, extract, op.getDelay());
+      else
+        OpTy::create(rewriter, op.getLoc(), operand, extract);
     }
     rewriter.eraseOp(op);
     return success();
@@ -165,7 +174,8 @@ void SimplifyRefsPass::runOnOperation() {
   ConversionTarget target(context);
 
   target.addDynamicallyLegalOp<ContinuousAssignOp, BlockingAssignOp,
-                               NonBlockingAssignOp>([](auto op) {
+                               NonBlockingAssignOp, DelayedContinuousAssignOp,
+                               DelayedNonBlockingAssignOp>([](auto op) {
     return !op->getOperand(0).template getDefiningOp<ConcatRefOp>();
   });
 
@@ -173,7 +183,10 @@ void SimplifyRefsPass::runOnOperation() {
   RewritePatternSet concatRefPatterns(&context);
   concatRefPatterns.add<ConcatRefLowering<ContinuousAssignOp>,
                         ConcatRefLowering<BlockingAssignOp>,
-                        ConcatRefLowering<NonBlockingAssignOp>>(&context);
+                        ConcatRefLowering<NonBlockingAssignOp>,
+                        ConcatRefLowering<DelayedContinuousAssignOp>,
+                        ConcatRefLowering<DelayedNonBlockingAssignOp>>(
+      &context);
 
   if (failed(applyPartialConversion(getOperation(), target,
                                     std::move(concatRefPatterns)))) {

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -65,6 +65,10 @@ void circt::populateArcConversionPipeline(OpPassManager &pm,
     pm.addNestedPass<hw::HWModuleOp>(sim::createSquashSimTriggered(opts));
   }
   pm.addPass(arc::createLowerProcessesPass());
+  // Break combinational loops that only exist at whole-value granularity
+  // (element-disjoint aggregate updates, disjoint bitwise feedback) before
+  // the fan-in analysis in ConvertToArcs rejects them.
+  pm.addNestedPass<hw::HWModuleOp>(arc::createSplitFalseCombLoops());
   {
     ConvertToArcsPassOptions opts;
     opts.tapRegisters = options.observeRegisters;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -4627,7 +4627,7 @@ endmodule
 // CHECK:             [[TWO:%.+]] = moore.constant 2 : i32
 // CHECK:             moore.push_back [[TWO]] into [[TMP3]] : <queue<i32, 0>>
 // CHECK:             [[TMP3R:%.+]] = moore.read [[TMP3]] : <queue<i32, 0>>
-// CHECK:             [[RESV:%.+]] = moore.queue.concat ([[TMP1R]], [[Q1R]], [[TMP2]], [[TMP3R]]) : (!moore.queue<i32, 0>, !moore.queue<i32, 5>, !moore.queue<i32, 0>, !moore.queue<i32, 0>) <i32, 0>
+// CHECK:             [[RESV:%.+]] = moore.queue.concat ([[TMP1R]], [[Q1R]], [[TMP2]], [[TMP3R]]) : (!moore.queue<i32, 0>, !moore.queue<i32, 5>, !moore.queue<i32, 0>, !moore.queue<i32, 0>) -> !moore.queue<i32, 0>
 // CHECK:             moore.blocking_assign [[QRES]], [[RESV]] : queue<i32, 0>
 // CHECK:           }
 // CHECK:           moore.output

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1739,8 +1739,14 @@ func.func @QueueOperations(%arg0: !moore.i32, %arg1: !moore.i32) {
   // CHECK: [[QFROMUP:%.+]] = sim.queue.from_array [[UPR]] : !hw.array<4xi32> -> <i32, 0>
   %2 = moore.queue.from_unpacked_array %upr : !moore.uarray<4 x i32> -> <i32, 0>
 
-  // CHECK: [[CONCAT:%.+]] = sim.queue.concat ([[QR]], [[DIFFB]]) : (!sim.queue<i32, 10>, !sim.queue<i32, 0>) <i32, 5>
-  %concatres = moore.queue.concat (%qr, %diffbounds) : (!moore.queue<i32, 10>, !moore.queue<i32, 0>) <i32, 5>
+  // CHECK: [[CONCAT:%.+]] = sim.queue.concat ([[QR]], [[DIFFB]]) : (!sim.queue<i32, 10>, !sim.queue<i32, 0>) -> !sim.queue<i32, 5>
+  %concatres = moore.queue.concat (%qr, %diffbounds) : (!moore.queue<i32, 10>, !moore.queue<i32, 0>) -> !moore.queue<i32, 5>
+
+  // A zero-operand concat (the empty queue literal `{}`) lowers to the
+  // canonical empty-queue constructor, not a degenerate 0-ary concat.
+  // CHECK: sim.queue.empty : <i32, 5>
+  // CHECK-NOT: sim.queue.concat ()
+  %emptyconcat = moore.queue.concat () : () -> !moore.queue<i32, 5>
 
   return
 }

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -59,9 +59,11 @@ func.func @StorageAccess(%arg0: !arc.storage) {
   // CHECK-NEXT: arc.storage.get %arg0[42] : !arc.storage -> !arc.state<i9>
   // CHECK-NEXT: arc.storage.get %arg0[1337] : !arc.storage -> !arc.memory<4 x i19, i32>
   // CHECK-NEXT: arc.storage.get %arg0[9001] : !arc.storage -> !arc.storage
+  // CHECK-NEXT: arc.storage.get %arg0[9009] : !arc.storage -> !arc.state<!llvm.ptr>
   %0 = arc.storage.get %arg0[42] : !arc.storage -> !arc.state<i9>
   %1 = arc.storage.get %arg0[1337] : !arc.storage -> !arc.memory<4 x i19, i32>
   %2 = arc.storage.get %arg0[9001] : !arc.storage -> !arc.storage
+  %3 = arc.storage.get %arg0[9009] : !arc.storage -> !arc.state<!llvm.ptr>
   return
 }
 

--- a/test/Dialect/Arc/infer-state-properties.mlir
+++ b/test/Dialect/Arc/infer-state-properties.mlir
@@ -247,3 +247,21 @@ hw.module @testModule (in %arg0: i1, in %arg1: i1, in %arg2: i1, in %arg3: i1, i
 
 // TODO: test that patterns handle the case where the output is used for another thing as well properly
 // TODO: test that reset and enable are only added when the latency is actually 1 or higher
+
+// An aggregate-typed enable pattern (write-enable mux around an array
+// state, the memory shape): the enable is pulled out and the condition
+// input forced true, but the array-typed self-feedback operand must stay in
+// place — `hw.constant` cannot represent aggregates, so replacing it would
+// build a garbage-width integer constant.
+// CHECK-LABEL: arc.define @arrayEnable
+arc.define @arrayEnable(%arg0: i1, %arg1: !hw.array<4xi8>, %arg2: !hw.array<4xi8>) -> !hw.array<4xi8> {
+  %0 = comb.mux %arg0, %arg1, %arg2 : !hw.array<4xi8>
+  arc.output %0 : !hw.array<4xi8>
+}
+
+// CHECK-LABEL: hw.module @arrayEnableModule
+hw.module @arrayEnableModule(in %we: i1, in %data: !hw.array<4xi8>, in %clock: !seq.clock, out out: !hw.array<4xi8>) {
+  // CHECK: [[S:%.+]] = arc.state @arrayEnable(%true{{(_[0-9]+)?}}, %data, [[S]]) clock %clock enable %we latency 1 : (i1, !hw.array<4xi8>, !hw.array<4xi8>) -> !hw.array<4xi8>
+  %0 = arc.state @arrayEnable(%we, %data, %0) clock %clock latency 1 : (i1, !hw.array<4xi8>, !hw.array<4xi8>) -> !hw.array<4xi8>
+  hw.output %0 : !hw.array<4xi8>
+}

--- a/test/Dialect/Arc/lower-state-element-drive.mlir
+++ b/test/Dialect/Arc/lower-state-element-drive.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt %s --arc-lower-state | FileCheck %s
+
+// A module-level drive of an array element
+// (`llhd.drv (llhd.sig.array_get %sig[%idx])`) lowers as a read-modify-write
+// of the parent signal's storage through `hw.array_inject` -- the array-typed
+// sibling of the bit-slice splice.
+
+// CHECK-LABEL: arc.model @top
+hw.module @top(in %v : i4, in %idx : i1) {
+  %c0_i4 = hw.constant 0 : i4
+  %true = hw.constant true
+  %t = llhd.constant_time <0ns, 0d, 1e>
+  %init = hw.array_create %c0_i4, %c0_i4 : i4
+  %sig = llhd.sig %init : !hw.array<2xi4>
+  %elem = llhd.sig.array_get %sig[%true] : <!hw.array<2xi4>>
+  %elemDyn = llhd.sig.array_get %sig[%idx] : <!hw.array<2xi4>>
+  // CHECK-DAG: [[CUR:%.+]] = arc.state_read %{{.+}} : <!hw.array<2xi4>>
+  // CHECK-DAG: [[NEW:%.+]] = hw.array_inject [[CUR]][%{{.+}}], %{{.+}} : !hw.array<2xi4>
+  // CHECK: arc.state_write %{{.+}} = [[NEW]]
+  llhd.drv %elem, %v after %t : i4
+  // The dynamic-index element drive takes the same path.
+  // CHECK: [[CUR2:%.+]] = arc.state_read %{{.+}} : <!hw.array<2xi4>>
+  // CHECK: [[NEW2:%.+]] = hw.array_inject [[CUR2]][%{{.+}}], %{{.+}} : !hw.array<2xi4>
+  // CHECK: arc.state_write %{{.+}} = [[NEW2]]
+  llhd.drv %elemDyn, %v after %t : i4
+}

--- a/test/Dialect/Arc/lower-state-element-drive.mlir
+++ b/test/Dialect/Arc/lower-state-element-drive.mlir
@@ -24,3 +24,41 @@ hw.module @top(in %v : i4, in %idx : i1) {
   // CHECK: arc.state_write %{{.+}} = [[NEW2]]
   llhd.drv %elemDyn, %v after %t : i4
 }
+
+// A drive through a CHAIN of element refs (multi-dimensional array,
+// `sig.array_get (sig.array_get %sig[%i])[%j]`) peels the storage value
+// outward-in with hw.array_get and re-injects inward-out.
+
+// CHECK-LABEL: arc.model @nested
+hw.module @nested(in %v : i4, in %i : i1, in %j : i1) {
+  %c0_i4 = hw.constant 0 : i4
+  %t = llhd.constant_time <0ns, 0d, 1e>
+  %row = hw.array_create %c0_i4, %c0_i4 : i4
+  %init = hw.array_create %row, %row : !hw.array<2xi4>
+  %sig = llhd.sig %init : !hw.array<2xarray<2xi4>>
+  %rowRef = llhd.sig.array_get %sig[%i] : <!hw.array<2xarray<2xi4>>>
+  %elemRef = llhd.sig.array_get %rowRef[%j] : <!hw.array<2xi4>>
+  // CHECK: [[CUR:%.+]] = arc.state_read %{{.+}} : <!hw.array<2xarray<2xi4>>>
+  // CHECK: [[ROW:%.+]] = hw.array_get [[CUR]][%{{.+}}] : !hw.array<2xarray<2xi4>>
+  // CHECK: [[NEWROW:%.+]] = hw.array_inject [[ROW]][%{{.+}}], %{{.+}} : !hw.array<2xi4>
+  // CHECK: [[NEWARR:%.+]] = hw.array_inject [[CUR]][%{{.+}}], [[NEWROW]] : !hw.array<2xarray<2xi4>>
+  // CHECK: arc.state_write %{{.+}} = [[NEWARR]]
+  llhd.drv %elemRef, %v after %t : i4
+}
+
+// A struct-field drive (`llhd.drv (llhd.sig.struct_extract %sig["f"])`)
+// takes the same RMW path through hw.struct_inject.
+
+// CHECK-LABEL: arc.model @structField
+hw.module @structField(in %v : i1) {
+  %false = hw.constant false
+  %c0_i8 = hw.constant 0 : i8
+  %t = llhd.constant_time <0ns, 0d, 1e>
+  %init = hw.struct_create (%false, %c0_i8) : !hw.struct<valid: i1, data: i8>
+  %sig = llhd.sig %init : !hw.struct<valid: i1, data: i8>
+  %fieldRef = llhd.sig.struct_extract %sig["valid"] : <!hw.struct<valid: i1, data: i8>>
+  // CHECK: [[CUR:%.+]] = arc.state_read %{{.+}} : <!hw.struct<valid: i1, data: i8>>
+  // CHECK: [[NEW:%.+]] = hw.struct_inject [[CUR]]["valid"], %{{.+}} : !hw.struct<valid: i1, data: i8>
+  // CHECK: arc.state_write %{{.+}} = [[NEW]]
+  llhd.drv %fieldRef, %v after %t : i1
+}

--- a/test/Dialect/Arc/lower-state-init-fragments.mlir
+++ b/test/Dialect/Arc/lower-state-init-fragments.mlir
@@ -1,0 +1,43 @@
+// RUN: circt-opt %s --arc-lower-state | FileCheck %s
+
+func.func private @malloc(i64) -> !llvm.ptr
+
+// Side-effecting module-level ops consuming or producing a signal's
+// initializer value (the malloc from a module-scope class `new`, the object
+// memset, and the typeinfo store) are one-time initialization actions and
+// must all lower into the initial phase against the SAME allocation the
+// signal captures. Lowering them per-eval re-executed the initializer chain
+// on a fresh malloc every evaluation (leaked each eval) while the signal
+// kept the pointer from its own, separate initial-phase clone -- so the
+// object the design reads was never memset and had a null typeinfo.
+// CHECK-LABEL: arc.model @ModuleScopeObjectInit
+hw.module @ModuleScopeObjectInit() {
+  %ti = llvm.mlir.addressof @typeinfo : !llvm.ptr
+  %c0_i8 = llvm.mlir.constant(0 : i8) : i8
+  %c24_i64 = llvm.mlir.constant(24 : i64) : i64
+  %obj = llhd.sig %ptr : !llvm.ptr
+  %ptr = arc.execute -> (!llvm.ptr) {
+    %sz = llvm.mlir.constant(24 : i64) : i64
+    %m = func.call @malloc(%sz) : (i64) -> !llvm.ptr
+    arc.output %m : !llvm.ptr
+  }
+  "llvm.intr.memset"(%ptr, %c0_i8, %c24_i64) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  llvm.store %ti, %ptr : !llvm.ptr, !llvm.ptr
+  hw.output
+}
+// CHECK:      arc.initial {
+// CHECK:        [[PTR:%.+]] = arc.execute -> (!llvm.ptr) {
+// CHECK:          func.call @malloc
+// CHECK:        }
+// CHECK:        arc.state_write %{{.+}} = [[PTR]] : <!llvm.ptr>
+// CHECK:        "llvm.intr.memset"([[PTR]],
+// CHECK:        llvm.store %{{.+}}, [[PTR]] : !llvm.ptr, !llvm.ptr
+// CHECK:      }
+// The initializer chain must not be duplicated into the per-eval body:
+// exactly one malloc in the whole model.
+// CHECK-NOT: func.call @malloc
+
+llvm.mlir.global internal constant @typeinfo() : !llvm.struct<(ptr)> {
+  %0 = llvm.mlir.undef : !llvm.struct<(ptr)>
+  llvm.return %0 : !llvm.struct<(ptr)>
+}

--- a/test/Dialect/Arc/lower-state-slice-drive.mlir
+++ b/test/Dialect/Arc/lower-state-slice-drive.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-opt %s --arc-lower-state | FileCheck %s
+
+// A module-level drive of a constant-offset bit-slice
+// (`llhd.drv (llhd.sig.extract %sig from K)`) lowers as a read-modify-write
+// splice into the parent signal's storage.
+
+// CHECK-LABEL: arc.model @top
+hw.module @top(in %v : i1) {
+  %c0_i32 = hw.constant 0 : i32
+  %c1_i5 = hw.constant 1 : i5
+  %t = llhd.constant_time <0ns, 0d, 1e>
+  %sig = llhd.sig %c0_i32 : i32
+  %slice = llhd.sig.extract %sig from %c1_i5 : <i32> -> <i1>
+  // CHECK: [[CUR:%.+]] = arc.state_read %{{.+}} : <i32>
+  // CHECK: [[HI:%.+]] = comb.extract [[CUR]] from 2 : (i32) -> i30
+  // CHECK: [[LO:%.+]] = comb.extract [[CUR]] from 0 : (i32) -> i1
+  // CHECK: [[NEW:%.+]] = comb.concat [[HI]], %{{.+}}, [[LO]] : i30, i1, i1
+  // CHECK: arc.state_write %{{.+}} = [[NEW]]
+  llhd.drv %slice, %v after %t : i1
+}

--- a/test/Dialect/Arc/lower-state-slice-probe.mlir
+++ b/test/Dialect/Arc/lower-state-slice-probe.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt %s --arc-lower-state | FileCheck %s
+
+// A module-level probe of a constant-offset bit-slice
+// (`llhd.prb (llhd.sig.extract %sig from K)`) lowers as a read of the parent
+// signal's storage plus an extract of the slice -- the probe-side mirror of
+// the slice-drive splice.
+
+// CHECK-LABEL: arc.model @top
+hw.module @top(out o : i1) {
+  %c0_i32 = hw.constant 0 : i32
+  %c3_i5 = hw.constant 3 : i5
+  %sig = llhd.sig %c0_i32 : i32
+  %slice = llhd.sig.extract %sig from %c3_i5 : <i32> -> <i1>
+  // CHECK: [[CUR:%.+]] = arc.state_read %{{.+}} : <i32>
+  // CHECK: [[BIT:%.+]] = comb.extract [[CUR]] from 3 : (i32) -> i1
+  %bit = llhd.prb %slice : i1
+  hw.output %bit : i1
+}

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -68,13 +68,15 @@ hw.module @InputToOutput(in %a: i42, out b: i42) {
 hw.module @ReadsBeforeUpdate(in %clock: !seq.clock, in %a: i42, out b: i42) {
   // CHECK: [[Q1:%.+]] = arc.alloc_state %arg0 {name = "q1"}
   // CHECK: [[Q0:%.+]] = arc.alloc_state %arg0 {name = "q0"}
+  // Old-phase reads are pinned to the top of the eval, before any process or
+  // state update can mutate storage.
+  // CHECK: [[TMP1:%.+]] = arc.state_read [[Q0]]
+  // CHECK: [[TMP2:%.+]] = arc.state_read %in_a
   // CHECK:      scf.if {{%.+}} {
-  // CHECK-NEXT:   [[TMP1:%.+]] = arc.state_read [[Q0]]
-  // CHECK-NEXT:   [[TMP2:%.+]] = arc.call @IdI42Arc([[TMP1]])
-  // CHECK-NEXT:   arc.state_write [[Q1]] = [[TMP2]]
-  // CHECK-NEXT:   [[TMP1:%.+]] = arc.state_read %in_a
-  // CHECK-NEXT:   [[TMP2:%.+]] = arc.call @IdI42Arc([[TMP1]])
-  // CHECK-NEXT:   arc.state_write [[Q0]] = [[TMP2]]
+  // CHECK-NEXT:   [[TMP3:%.+]] = arc.call @IdI42Arc([[TMP1]])
+  // CHECK-NEXT:   arc.state_write [[Q1]] = [[TMP3]]
+  // CHECK-NEXT:   [[TMP4:%.+]] = arc.call @IdI42Arc([[TMP2]])
+  // CHECK-NEXT:   arc.state_write [[Q0]] = [[TMP4]]
   // CHECK-NEXT: }
   %q1 = arc.state @IdI42Arc(%q0) clock %clock latency 1 {names = ["q1"]} : (i42) -> i42
   %q0 = arc.state @IdI42Arc(%a) clock %clock latency 1 {names = ["q0"]} : (i42) -> i42
@@ -87,9 +89,9 @@ hw.module @ReadsBeforeUpdate(in %clock: !seq.clock, in %a: i42, out b: i42) {
 hw.module @ReadsAfterUpdate(in %clock: !seq.clock, in %a: i42, out b: i42) {
   // CHECK: [[Q0:%.+]] = arc.alloc_state %arg0 {name = "q0"}
   // CHECK: [[Q1:%.+]] = arc.alloc_state %arg0 {name = "q1"}
+  // CHECK: [[TMP1:%.+]] = arc.state_read %in_a
   // CHECK: [[Q0_OLD:%.+]] = arc.state_read [[Q0]]
   // CHECK:      scf.if {{%.+}} {
-  // CHECK-NEXT:   [[TMP1:%.+]] = arc.state_read %in_a
   // CHECK-NEXT:   [[TMP2:%.+]] = arc.call @IdI42Arc([[TMP1]])
   // CHECK-NEXT:   arc.state_write [[Q0]] = [[TMP2]]
   // CHECK-NEXT:   [[TMP:%.+]] = arc.call @IdI42Arc([[Q0_OLD]])
@@ -127,8 +129,8 @@ hw.module @ClockDivBy4(in %clock: !seq.clock, out z: !seq.clock) {
 
 // CHECK-LABEL: arc.model @EnablePort
 hw.module @EnablePort(in %clock: !seq.clock, in %a: i42, in %en: i1) {
+  // CHECK: [[EN:%.+]] = arc.state_read %in_en
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[EN:%.+]] = arc.state_read %in_en
   // CHECK:   scf.if [[EN]] {
   // CHECK:     arc.state_write
   // CHECK:     arc.state_write
@@ -157,8 +159,8 @@ hw.module @EnableLocal(in %clock: !seq.clock, in %a: i42) {
 
 // CHECK-LABEL: arc.model @Reset
 hw.module @Reset(in %clock: !seq.clock, in %a: i42, in %reset: i1) {
+  // CHECK: [[RESET:%.+]] = arc.state_read %in_reset
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[RESET:%.+]] = arc.state_read %in_reset
   // CHECK:   scf.if [[RESET]] {
   // CHECK:     arc.state_write
   // CHECK:     arc.state_write
@@ -191,25 +193,37 @@ hw.module @ResetAndEnable(in %clock: !seq.clock, in %a: i42, in %reset: i1, in %
   // CHECK: [[Q1:%.+]] = arc.alloc_state %arg0 {name = "q1"}
   // CHECK: [[Q2:%.+]] = arc.alloc_state %arg0 {name = "q2"}
   // CHECK: [[Q3:%.+]] = arc.alloc_state %arg0 {name = "q3"}
+  // Enable/reset/input reads are pinned to the pre-eval old section.
+  // CHECK: [[EN0:%.+]] = arc.state_read %in_en
+  // CHECK: [[RESET1:%.+]] = arc.state_read %in_reset
+  // CHECK: [[EN1:%.+]] = arc.state_read %in_en
+  // CHECK: [[RESET2:%.+]] = arc.state_read %in_reset
+  // CHECK: [[EN2:%.+]] = arc.state_read %in_en
+  // CHECK: [[RESET3:%.+]] = arc.state_read %in_reset
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[EN:%.+]] = arc.state_read %in_en
-  // CHECK:   scf.if [[EN]] {
+  // CHECK:   scf.if [[EN0]] {
   // CHECK:     arc.state_write [[Q0]]
   // CHECK:   }
-  // CHECK:   [[RESET:%.+]] = arc.state_read %in_reset
-  // CHECK:   scf.if [[RESET]] {
+  // CHECK:   scf.if [[RESET1]] {
   // CHECK:     [[TMP:%.+]] = hw.constant 0
   // CHECK:     arc.state_write [[Q1]] = [[TMP]]
+  // CHECK:   } else {
+  // CHECK:     scf.if [[EN1]] {
+  // CHECK:       arc.state_write [[Q1]]
+  // CHECK:     }
+  // CHECK:   }
+  // CHECK:   scf.if [[RESET2]] {
   // CHECK:     [[TMP:%.+]] = hw.constant 0
   // CHECK:     arc.state_write [[Q2]] = [[TMP]]
+  // CHECK:   } else {
+  // CHECK:     scf.if [[EN2]] {
+  // CHECK:       arc.state_write [[Q2]]
+  // CHECK:     }
+  // CHECK:   }
+  // CHECK:   scf.if [[RESET3]] {
   // CHECK:     [[TMP:%.+]] = hw.constant 0
   // CHECK:     arc.state_write [[Q3]] = [[TMP]]
   // CHECK:   } else {
-  // CHECK:     [[EN:%.+]] = arc.state_read %in_en
-  // CHECK:     scf.if [[EN]] {
-  // CHECK:       arc.state_write [[Q1]]
-  // CHECK:       arc.state_write [[Q2]]
-  // CHECK:     }
   // CHECK:     arc.state_write [[Q3]]
   // CHECK:   }
   // CHECK: }
@@ -227,6 +241,8 @@ hw.module @BlackBox(in %clock: !seq.clock, in %a: i42, out b: i42) {
   // CHECK: [[Q:%.+]] = arc.alloc_state %arg0 {name = "ext/q"}
   // CHECK: [[R:%.+]] = arc.alloc_state %arg0 {name = "ext/r"}
   // CHECK: [[Q1:%.+]] = arc.alloc_state %arg0 {name = "q1"}
+  // Old-phase register inputs read in the pinned pre-eval section.
+  // CHECK: [[S_OLD:%.+]] = arc.state_read [[S]]
   // CHECK: scf.if {{%.+}} {
   // CHECK:   arc.state_write [[Q0]]
   // CHECK: }
@@ -240,8 +256,7 @@ hw.module @BlackBox(in %clock: !seq.clock, in %a: i42, out b: i42) {
   %1 = comb.and %0, %3 : i42
   %2, %3 = hw.instance "ext" @BlackBoxExt(p: %0: i42, q: %1: i42) -> (r: i42, s: i42)
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[S_NEW:%.+]] = arc.state_read [[S]]
-  // CHECK:   [[TMP:%.+]] = arc.call @IdI42Arc([[S_NEW]])
+  // CHECK:   [[TMP:%.+]] = arc.call @IdI42Arc([[S_OLD]])
   // CHECK:   arc.state_write [[Q1]] = [[TMP]]
   // CHECK: }
   %4 = arc.state @IdI42Arc(%3) clock %clock latency 1 {names = ["q1"]} : (i42) -> i42
@@ -258,9 +273,9 @@ hw.module.extern private @BlackBoxExt(in %p: i42, in %q: i42, out r: i42, out s:
 // CHECK-LABEL: arc.model @MemoryInputToOutput
 hw.module @MemoryInputToOutput(in %clock: !seq.clock, in %a: i2, in %b: i42, out c: i42) {
   // CHECK: [[MEM:%.+]] = arc.alloc_memory
+  // CHECK: [[A:%.+]] = arc.state_read %in_a
+  // CHECK: [[B:%.+]] = arc.state_read %in_b
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[A:%.+]] = arc.state_read %in_a
-  // CHECK:   [[B:%.+]] = arc.state_read %in_b
   // CHECK:   [[TMP:%.+]]:2 = arc.call @IdI2AndI42Arc([[A]], [[B]])
   // CHECK:   arc.memory_write [[MEM]][[[TMP]]#0], [[TMP]]#1
   // CHECK: }
@@ -281,14 +296,16 @@ hw.module @MemoryReadBeforeUpdate(in %clock: !seq.clock, in %a: i2, in %b: i42, 
   // are used by an op.
   %0 = arc.memory_read_port %mem[%a] : <4 x i42, i2>
   arc.memory_write_port %mem, @IdI2AndI42Arc(%a, %b) clock %clock latency 1 : <4 x i42, i2>, i2, i42
+  // Old-phase reads (memory read address and data, write inputs) are pinned
+  // to the pre-eval section.
+  // CHECK: [[A0:%.+]] = arc.state_read %in_a
+  // CHECK: [[READ_OLD:%.+]] = arc.memory_read [[MEM]][[[A0]]]
+  // CHECK: [[A:%.+]] = arc.state_read %in_a
+  // CHECK: [[B:%.+]] = arc.state_read %in_b
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[A:%.+]] = arc.state_read %in_a
-  // CHECK:   [[TMP1:%.+]] = arc.memory_read [[MEM]][[[A]]]
-  // CHECK:   [[TMP2:%.+]] = arc.call @IdI42Arc([[TMP1]])
+  // CHECK:   [[TMP2:%.+]] = arc.call @IdI42Arc([[READ_OLD]])
   // CHECK:   arc.state_write [[Q0]] = [[TMP2]]
   %q0 = arc.state @IdI42Arc(%0) clock %clock latency 1 {names = ["q0"]} : (i42) -> i42
-  // CHECK:   [[A:%.+]] = arc.state_read %in_a
-  // CHECK:   [[B:%.+]] = arc.state_read %in_b
   // CHECK:   [[TMP:%.+]]:2 = arc.call @IdI2AndI42Arc([[A]], [[B]])
   // CHECK:   arc.memory_write [[MEM]][[[TMP]]#0], [[TMP]]#1
   %mem = arc.memory <4 x i42, i2>
@@ -306,11 +323,11 @@ hw.module @MemoryReadAfterUpdate(in %clock: !seq.clock, in %a: i2, in %b: i42, i
   // are used by an op.
   %0 = arc.memory_read_port %mem[%a] : <4 x i42, i2>
   arc.memory_write_port %mem, @IdI2AndI42Arc(%a, %b) clock %clock latency 1 : <4 x i42, i2>, i2, i42
+  // CHECK: [[A0:%.+]] = arc.state_read %in_a
+  // CHECK: [[READ_OLD:%.+]] = arc.memory_read [[MEM]][[[A0]]]
   // CHECK: [[A:%.+]] = arc.state_read %in_a
-  // CHECK: [[READ_OLD:%.+]] = arc.memory_read [[MEM]][[[A]]]
+  // CHECK: [[B:%.+]] = arc.state_read %in_b
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[A:%.+]] = arc.state_read %in_a
-  // CHECK:   [[B:%.+]] = arc.state_read %in_b
   // CHECK:   [[TMP:%.+]]:2 = arc.call @IdI2AndI42Arc([[A]], [[B]])
   // CHECK:   arc.memory_write [[MEM]][[[TMP]]#0], [[TMP]]#1
   %mem = arc.memory <4 x i42, i2>
@@ -326,10 +343,10 @@ hw.module @MemoryReadAfterUpdate(in %clock: !seq.clock, in %a: i2, in %b: i42, i
 // CHECK-LABEL: arc.model @MemoryEnable
 hw.module @MemoryEnable(in %clock: !seq.clock, in %a: i2, in %b: i42, in %en: i1) {
   // CHECK: [[MEM:%.+]] = arc.alloc_memory
+  // CHECK: [[A:%.+]] = arc.state_read %in_a
+  // CHECK: [[B:%.+]] = arc.state_read %in_b
+  // CHECK: [[EN:%.+]] = arc.state_read %in_en
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[A:%.+]] = arc.state_read %in_a
-  // CHECK:   [[B:%.+]] = arc.state_read %in_b
-  // CHECK:   [[EN:%.+]] = arc.state_read %in_en
   // CHECK:   [[TMP:%.+]]:3 = arc.call @IdI2AndI42AndI1Arc([[A]], [[B]], [[EN]])
   // CHECK:   scf.if [[TMP]]#2 {
   // CHECK:     arc.memory_write [[MEM]][[[TMP]]#0], [[TMP]]#1
@@ -342,11 +359,11 @@ hw.module @MemoryEnable(in %clock: !seq.clock, in %a: i2, in %b: i42, in %en: i1
 // CHECK-LABEL: arc.model @MemoryEnableAndMask
 hw.module @MemoryEnableAndMask(in %clock: !seq.clock, in %a: i2, in %b: i42, in %en: i1, in %mask: i42) {
   // CHECK: [[MEM:%.+]] = arc.alloc_memory
+  // CHECK: [[A:%.+]] = arc.state_read %in_a
+  // CHECK: [[B:%.+]] = arc.state_read %in_b
+  // CHECK: [[EN:%.+]] = arc.state_read %in_en
+  // CHECK: [[MASK:%.+]] = arc.state_read %in_mask
   // CHECK: scf.if {{%.+}} {
-  // CHECK:   [[A:%.+]] = arc.state_read %in_a
-  // CHECK:   [[B:%.+]] = arc.state_read %in_b
-  // CHECK:   [[EN:%.+]] = arc.state_read %in_en
-  // CHECK:   [[MASK:%.+]] = arc.state_read %in_mask
   // CHECK:   [[TMP:%.+]]:4 = arc.call @IdI2AndI42AndI1AndI42Arc([[A]], [[B]], [[EN]], [[MASK]])
   // CHECK:   scf.if [[TMP]]#2 {
   // CHECK:     [[ALL_ONES:%.+]] = hw.constant -1
@@ -565,9 +582,9 @@ hw.module @UnclockedDpiCall(in %a: i42, out b: i42) {
 hw.module @ClockedDpiCall(in %clock: !seq.clock, in %a: i42, out b: i42) {
   // CHECK: [[Q0:%.+]] = arc.alloc_state %arg0 {name = "q0"}
   // CHECK: [[Q1:%.+]] = arc.alloc_state %arg0 {name = "q1"}
+  // CHECK: [[TMP1:%.+]] = arc.state_read %in_a
   // CHECK: [[Q0_OLD:%.+]] = arc.state_read [[Q0]]
   // CHECK:      scf.if {{%.+}} {
-  // CHECK-NEXT:   [[TMP1:%.+]] = arc.state_read %in_a
   // CHECK-NEXT:   [[TMP2:%.+]] = func.call @IdI42([[TMP1]])
   // CHECK-NEXT:   arc.state_write [[Q0]] = [[TMP2]]
   // CHECK-NEXT:   [[TMP3:%.+]] = func.call @IdI42([[Q0_OLD]])
@@ -739,19 +756,21 @@ hw.module @LLHDTimeOps(in %clock: !seq.clock, out t: i64) {
     llhd.halt
   }
 
+  // Phase::Old - llhd.current_time used as data input to a state. Old-phase
+  // values live in the pinned pre-eval section, ahead of the new-phase chain.
+  // CHECK: [[TIME_INT_OLD:%.+]] = arc.current_time %arg0
+  // CHECK: [[TIME_OLD:%.+]] = llhd.int_to_time [[TIME_INT_OLD]]
+  // CHECK: [[TIME_OLD_INT:%.+]] = llhd.time_to_int [[TIME_OLD]]
+  %2 = llhd.current_time
+  %3 = llhd.time_to_int %2
+
   // Phase::New - llhd.current_time used directly in module body.
   // CHECK: [[TIME_INT_NEW:%.+]] = arc.current_time %arg0
   // CHECK: [[TIME_NEW:%.+]] = llhd.int_to_time [[TIME_INT_NEW]]
   %0 = llhd.current_time
   %1 = llhd.time_to_int %0
 
-  // Phase::Old - llhd.current_time used as data input to a state.
-  // CHECK: [[TIME_INT_OLD:%.+]] = arc.current_time %arg0
-  // CHECK: [[TIME_OLD:%.+]] = llhd.int_to_time [[TIME_INT_OLD]]
-  // CHECK: [[TIME_OLD_INT:%.+]] = llhd.time_to_int [[TIME_OLD]]
   // CHECK: arc.call @IdI64Arc([[TIME_OLD_INT]])
-  %2 = llhd.current_time
-  %3 = llhd.time_to_int %2
   %q0 = arc.state @IdI64Arc(%3) clock %clock latency 1 : (i64) -> i64
 
   // Write the output from Phase::New.

--- a/test/Dialect/Arc/remove-i0-types.mlir
+++ b/test/Dialect/Arc/remove-i0-types.mlir
@@ -214,3 +214,53 @@ func.func @AggregateConstantStaysAggregate() -> !hw.array<2x!hw.array<1xi32>> {
   %0 = hw.aggregate_constant [[0 : i32], [1 : i32]] : !hw.array<2x!hw.array<1xi32>>
   return %0 : !hw.array<2x!hw.array<1xi32>>
 }
+
+// Ref-typed accessors with i0 indices (the LLHD index-width constraint
+// forces i0 exactly for 1-element arrays / 1-bit slices). Ref types are not
+// scalarized, so the element ref bridges to the whole ref through an
+// unrealized cast that cancels in the LLVM lowering.
+// CHECK-LABEL: func.func @SigArrayGetI0
+// CHECK-SAME: (%[[REF:.*]]: !llhd.ref<!hw.array<1xi32>>)
+// CHECK-NEXT: %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[REF]] : !llhd.ref<!hw.array<1xi32>> to !llhd.ref<i32>
+// CHECK-NEXT: return %[[CAST]] : !llhd.ref<i32>
+func.func @SigArrayGetI0(%sig: !llhd.ref<!hw.array<1xi32>>) -> !llhd.ref<i32> {
+  %c0_i0 = hw.constant 0 : i0
+  %0 = llhd.sig.array_get %sig[%c0_i0] : <!hw.array<1xi32>>
+  return %0 : !llhd.ref<i32>
+}
+
+// A same-type bridge (1-bit slice of a 1-bit signal) folds to the input.
+// CHECK-LABEL: func.func @SigExtractI0
+// CHECK-SAME: (%[[REF:.*]]: !llhd.ref<i1>)
+// CHECK-NEXT: return %[[REF]] : !llhd.ref<i1>
+func.func @SigExtractI0(%sig: !llhd.ref<i1>) -> !llhd.ref<i1> {
+  %c0_i0 = hw.constant 0 : i0
+  %0 = llhd.sig.extract %sig from %c0_i0 : <i1> -> <i1>
+  return %0 : !llhd.ref<i1>
+}
+
+// Probes and drives bridge refs (layout preserved) to values (1-element
+// arrays scalarized): the ref re-points through an unrealized cast to the
+// converted element type.
+// CHECK-LABEL: func.func @ProbeScalarized
+// CHECK-SAME: (%[[REF:.*]]: !llhd.ref<!hw.array<1xi32>>)
+// CHECK-NEXT: %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[REF]] : !llhd.ref<!hw.array<1xi32>> to !llhd.ref<i32>
+// CHECK-NEXT: %[[PRB:.*]] = llhd.prb %[[CAST]] : i32
+// CHECK-NEXT: return %[[PRB]] : i32
+func.func @ProbeScalarized(%sig: !llhd.ref<!hw.array<1xi32>>) -> i32 {
+  %0 = llhd.prb %sig : !hw.array<1xi32>
+  %c0_i0 = hw.constant 0 : i0
+  %1 = hw.array_get %0[%c0_i0] : !hw.array<1xi32>, i0
+  return %1 : i32
+}
+
+// CHECK-LABEL: func.func @DriveScalarized
+// CHECK-SAME: (%[[REF:.*]]: !llhd.ref<!hw.array<1xi32>>, %[[V:.*]]: i32)
+// CHECK: %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[REF]] : !llhd.ref<!hw.array<1xi32>> to !llhd.ref<i32>
+// CHECK: llhd.drv %[[CAST]], %[[V]] after %{{.+}} : i32
+func.func @DriveScalarized(%sig: !llhd.ref<!hw.array<1xi32>>, %v: i32) {
+  %t = llhd.constant_time <0ns, 0d, 1e>
+  %0 = hw.array_create %v : i32
+  llhd.drv %sig, %0 after %t : !hw.array<1xi32>
+  return
+}

--- a/test/Dialect/Arc/split-false-comb-loops-e2e.mlir
+++ b/test/Dialect/Arc/split-false-comb-loops-e2e.mlir
@@ -1,0 +1,39 @@
+// RUN: circt-opt %s --arc-split-false-comb-loops --convert-to-arcs | FileCheck %s
+
+// End-to-end: after splitting, ConvertToArcs' fan-in analysis must accept the
+// previously cyclic modules (it would otherwise fail with "combinational loop
+// detected").
+
+// CHECK: arc.define
+// CHECK: hw.module @falseArrayLoop
+hw.module @falseArrayLoop(in %sel : i1, in %a : i3, in %b : i3, out out : !hw.array<2xi3>) {
+  %false = hw.constant false
+  %true = hw.constant true
+  %s0a = hw.array_inject %final[%false], %a : !hw.array<2xi3>, i1
+  %s0b = hw.array_inject %final[%false], %b : !hw.array<2xi3>, i1
+  %m0 = comb.mux %sel, %s0a, %s0b : !hw.array<2xi3>
+  %s1a = hw.array_inject %m0[%true], %a : !hw.array<2xi3>, i1
+  %s1b = hw.array_inject %m0[%true], %b : !hw.array<2xi3>, i1
+  %final = comb.mux %sel, %s1a, %s1b : !hw.array<2xi3>
+  hw.output %final : !hw.array<2xi3>
+}
+
+// CHECK: hw.module @falseBitLoop
+hw.module @falseBitLoop(in %a : i1, in %b : i1, out out : i1) {
+  %w = comb.concat %dep, %a : i1, i1
+  %bit0 = comb.extract %w from 0 : (i2) -> i1
+  %dep = comb.and %bit0, %b : i1
+  hw.output %dep : i1
+}
+
+// CHECK: hw.module @falseNestedLoop
+hw.module @falseNestedLoop(in %sel : i1, in %a : i4, in %b : i8, out out : !hw.array<2xstruct<x: i4, y: i8>>) {
+  %false = hw.constant false
+  %true = hw.constant true
+  %e1 = hw.array_get %final[%true] : !hw.array<2xstruct<x: i4, y: i8>>, i1
+  %e1x = hw.struct_inject %e1["x"], %a : !hw.struct<x: i4, y: i8>
+  %e1xy = hw.struct_inject %e1x["y"], %b : !hw.struct<x: i4, y: i8>
+  %u0 = hw.array_inject %final[%false], %e1xy : !hw.array<2xstruct<x: i4, y: i8>>, i1
+  %final = hw.array_inject %u0[%true], %e1xy : !hw.array<2xstruct<x: i4, y: i8>>, i1
+  hw.output %final : !hw.array<2xstruct<x: i4, y: i8>>
+}

--- a/test/Dialect/Arc/split-false-comb-loops.mlir
+++ b/test/Dialect/Arc/split-false-comb-loops.mlir
@@ -1,0 +1,82 @@
+// RUN: circt-opt %s --arc-split-false-comb-loops | FileCheck %s
+
+// An unrolled per-element update chain: the element-0 write uses the final
+// chained value as its base, forming a whole-value SSA cycle in the graph
+// region. Every element is unconditionally overwritten at its own stage, so
+// the loop is false at element granularity.
+// CHECK-LABEL: hw.module @falseArrayLoop
+// CHECK-NOT: hw.array_inject
+// CHECK: hw.output
+hw.module @falseArrayLoop(in %sel : i1, in %a : i3, in %b : i3, out out : !hw.array<2xi3>) {
+  %false = hw.constant false
+  %true = hw.constant true
+  %s0a = hw.array_inject %final[%false], %a : !hw.array<2xi3>, i1
+  %s0b = hw.array_inject %final[%false], %b : !hw.array<2xi3>, i1
+  %m0 = comb.mux %sel, %s0a, %s0b : !hw.array<2xi3>
+  %s1a = hw.array_inject %m0[%true], %a : !hw.array<2xi3>, i1
+  %s1b = hw.array_inject %m0[%true], %b : !hw.array<2xi3>, i1
+  %final = comb.mux %sel, %s1a, %s1b : !hw.array<2xi3>
+  hw.output %final : !hw.array<2xi3>
+}
+
+// Interlocking struct field updates: each inject reads the other's result,
+// but each field is overwritten exactly once. False at field granularity.
+// CHECK-LABEL: hw.module @falseStructLoop
+// CHECK-NOT: hw.struct_inject
+// CHECK: hw.struct_create
+hw.module @falseStructLoop(in %a : i4, in %b : i8, out out : !hw.struct<x: i4, y: i8>) {
+  %v0 = hw.struct_inject %v1["x"], %a : !hw.struct<x: i4, y: i8>
+  %v1 = hw.struct_inject %v0["y"], %b : !hw.struct<x: i4, y: i8>
+  hw.output %v1 : !hw.struct<x: i4, y: i8>
+}
+
+// Bitwise feedback where bit 1 of the concat depends on bit 0 through an
+// extract: acyclic per bit.
+// CHECK-LABEL: hw.module @falseBitLoop
+// CHECK: [[AND:%.+]] = comb.and %a, %b : i1
+// CHECK: hw.output [[AND]]
+hw.module @falseBitLoop(in %a : i1, in %b : i1, out out : i1) {
+  %w = comb.concat %dep, %a : i1, i1
+  %bit0 = comb.extract %w from 0 : (i2) -> i1
+  %dep = comb.and %bit0, %b : i1
+  hw.output %dep : i1
+}
+
+// A nested aggregate (array of structs): the recursive leaf decomposition
+// resolves the element- and field-level pass-throughs in one round.
+// CHECK-LABEL: hw.module @falseNestedLoop
+// CHECK-NOT: hw.array_inject
+// CHECK-NOT: hw.struct_inject
+hw.module @falseNestedLoop(in %sel : i1, in %a : i4, in %b : i8, out out : !hw.array<2xstruct<x: i4, y: i8>>) {
+  %false = hw.constant false
+  %true = hw.constant true
+  %e1 = hw.array_get %final[%true] : !hw.array<2xstruct<x: i4, y: i8>>, i1
+  %e1x = hw.struct_inject %e1["x"], %a : !hw.struct<x: i4, y: i8>
+  %e1xy = hw.struct_inject %e1x["y"], %b : !hw.struct<x: i4, y: i8>
+  %u0 = hw.array_inject %final[%false], %e1xy : !hw.array<2xstruct<x: i4, y: i8>>, i1
+  %final = hw.array_inject %u0[%true], %e1xy : !hw.array<2xstruct<x: i4, y: i8>>, i1
+  hw.output %final : !hw.array<2xstruct<x: i4, y: i8>>
+}
+
+// A genuine loop: element 0 feeds back into itself through the mux' false
+// path. The pass must leave it alone (ConvertToArcs then reports it).
+// CHECK-LABEL: hw.module @genuineElementLoop
+// CHECK: hw.array_inject
+hw.module @genuineElementLoop(in %sel : i1, in %a : i3, out out : !hw.array<2xi3>) {
+  %false = hw.constant false
+  %e0 = hw.array_get %w[%false] : !hw.array<2xi3>, i1
+  %e0inc = comb.mux %sel, %a, %e0 : i3
+  %w = hw.array_inject %w0[%false], %e0inc : !hw.array<2xi3>, i1
+  %w0 = hw.array_inject %w[%false], %a : !hw.array<2xi3>, i1
+  hw.output %w : !hw.array<2xi3>
+}
+
+// A genuine bitwise loop (bit 0 depends on itself): left alone.
+// CHECK-LABEL: hw.module @genuineBitLoop
+// CHECK: comb.concat
+hw.module @genuineBitLoop(in %a : i1, out out : i2) {
+  %bit0 = comb.extract %w from 0 : (i2) -> i1
+  %dep = comb.and %bit0, %a : i1
+  %w = comb.concat %a, %dep : i1, i1
+  hw.output %w : i2
+}

--- a/test/Dialect/LLHD/Transforms/deseq.mlir
+++ b/test/Dialect/LLHD/Transforms/deseq.mlir
@@ -1254,17 +1254,54 @@ hw.module @ClockExtractedFromStructArrayGetThenExtractPosEdge(in %st: !hw.struct
   llhd.drv %sig, %out after %time if %en : i4
 }
 
-// Desequentialization must NOT promote a drive whose signal has another
-// driver: the promoted drive becomes unconditional (continuous) and would
-// clobber the other process's writes on every delta (e.g. an initial block
-// setting an edge-driven variable's t=0 value; last-write-per-event source
-// semantics).
-// CHECK-LABEL: @MultiDrivenSignalKeepsProcess(
-hw.module @MultiDrivenSignalKeepsProcess(in %clock: i1, in %d: i42) {
+// A one-shot t=0 constant init drive by another process (the canonical
+// lowered `initial begin reg = K; end` next to an `always @(posedge clk)`
+// driver) must NOT block promotion: it folds into the register's preset
+// (power-on value), which the continuous register drive reproduces from
+// t=0 onward. Keeping the process form instead skews the DUT against
+// same-clock promoted registers (post-edge reads = one-delta lead).
+// CHECK-LABEL: @MultiDrivenInitFoldsToPreset(
+hw.module @MultiDrivenInitFoldsToPreset(in %clock: i1, in %d: i42) {
   %c0_i42 = hw.constant 0 : i42
   %c1_i42 = hw.constant 1 : i42
   %0 = llhd.constant_time <0ns, 1d, 0e>
-  // CHECK-NOT: seq.firreg
+  %1, %2 = llhd.process -> i42, i1 {
+    %true = hw.constant true
+    %false = hw.constant false
+    cf.br ^bb1(%c0_i42, %false : i42, i1)
+  ^bb1(%3: i42, %4: i1):
+    llhd.wait yield (%3, %4 : i42, i1), (%clock : i1), ^bb2(%clock : i1)
+  ^bb2(%5: i1):
+    %6 = comb.xor bin %5, %true : i1
+    %7 = comb.and bin %6, %clock : i1  // posedge clock
+    cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
+  }
+  %3 = llhd.sig %c0_i42 : i42
+  // The t=0 one-shot writer (the "initial process") stays; its write agrees
+  // with the preset. The always process is promoted: firreg with preset 1,
+  // unconditional (continuous) drive.
+  // CHECK: llhd.process
+  // CHECK-NEXT: llhd.drv {{%.+}}, %c1_i42 after
+  // CHECK-NEXT: llhd.halt
+  llhd.process {
+    llhd.drv %3, %c1_i42 after %0 : i42
+    llhd.halt
+  }
+  // CHECK: [[REG:%.+]] = seq.firreg %d clock {{%.+}} preset 1 : i42
+  // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
+  // CHECK-NOT: llhd.process
+  llhd.drv %3, %1 after %0 if %2 : i42
+}
+
+// Desequentialization must NOT promote a drive whose signal has another
+// driver that is not a one-shot t=0 constant init: the promoted drive
+// becomes unconditional (continuous) and would clobber the other process's
+// writes on every delta (last-write-per-event source semantics). Here the
+// other writer drives a NON-CONSTANT value.
+// CHECK-LABEL: @MultiDrivenSignalKeepsProcess(
+hw.module @MultiDrivenSignalKeepsProcess(in %clock: i1, in %d: i42) {
+  %c0_i42 = hw.constant 0 : i42
+  %0 = llhd.constant_time <0ns, 1d, 0e>
   // CHECK: llhd.process
   %1, %2 = llhd.process -> i42, i1 {
     %true = hw.constant true
@@ -1278,12 +1315,48 @@ hw.module @MultiDrivenSignalKeepsProcess(in %clock: i1, in %d: i42) {
     cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
   }
   %3 = llhd.sig %c0_i42 : i42
-  // The t=0 one-shot writer (the "initial process").
+  // Writes a non-constant at t=0: not foldable into a preset.
   // CHECK: llhd.process
   llhd.process {
-    llhd.drv %3, %c1_i42 after %0 : i42
+    llhd.drv %3, %d after %0 : i42
     llhd.halt
   }
+  // A wrongly-created register would be inserted right before the fed drive.
+  // CHECK-NOT: seq.firreg
+  // CHECK: llhd.drv {{%.+}}, {{%.+}} after {{%.+}} if {{%.+}} :
+  llhd.drv %3, %1 after %0 if %2 : i42
+}
+
+// A delayed init write (`initial reg <= #5ns K;`) does NOT fold: the value
+// must not appear before t=5ns, but a preset holds it from t=0. Keep the
+// process form.
+// CHECK-LABEL: @MultiDrivenDelayedInitKeepsProcess(
+hw.module @MultiDrivenDelayedInitKeepsProcess(in %clock: i1, in %d: i42) {
+  %c0_i42 = hw.constant 0 : i42
+  %c1_i42 = hw.constant 1 : i42
+  %0 = llhd.constant_time <0ns, 1d, 0e>
+  // CHECK: llhd.process
+  %1, %2 = llhd.process -> i42, i1 {
+    %true = hw.constant true
+    %false = hw.constant false
+    cf.br ^bb1(%c0_i42, %false : i42, i1)
+  ^bb1(%3: i42, %4: i1):
+    llhd.wait yield (%3, %4 : i42, i1), (%clock : i1), ^bb2(%clock : i1)
+  ^bb2(%5: i1):
+    %6 = comb.xor bin %5, %true : i1
+    %7 = comb.and bin %6, %clock : i1  // posedge clock
+    cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
+  }
+  %3 = llhd.sig %c0_i42 : i42
+  // Constant write with a nonzero drive delay: not foldable.
+  // CHECK: llhd.process
+  llhd.process {
+    %t5 = llhd.constant_time <5ns, 0d, 0e>
+    llhd.drv %3, %c1_i42 after %t5 : i42
+    llhd.halt
+  }
+  // A wrongly-created register would be inserted right before the fed drive.
+  // CHECK-NOT: seq.firreg
   // CHECK: llhd.drv {{%.+}}, {{%.+}} after {{%.+}} if {{%.+}} :
   llhd.drv %3, %1 after %0 if %2 : i42
 }

--- a/test/Dialect/LLHD/Transforms/deseq.mlir
+++ b/test/Dialect/LLHD/Transforms/deseq.mlir
@@ -1253,3 +1253,37 @@ hw.module @ClockExtractedFromStructArrayGetThenExtractPosEdge(in %st: !hw.struct
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
   llhd.drv %sig, %out after %time if %en : i4
 }
+
+// Desequentialization must NOT promote a drive whose signal has another
+// driver: the promoted drive becomes unconditional (continuous) and would
+// clobber the other process's writes on every delta (e.g. an initial block
+// setting an edge-driven variable's t=0 value; last-write-per-event source
+// semantics).
+// CHECK-LABEL: @MultiDrivenSignalKeepsProcess(
+hw.module @MultiDrivenSignalKeepsProcess(in %clock: i1, in %d: i42) {
+  %c0_i42 = hw.constant 0 : i42
+  %c1_i42 = hw.constant 1 : i42
+  %0 = llhd.constant_time <0ns, 1d, 0e>
+  // CHECK-NOT: seq.firreg
+  // CHECK: llhd.process
+  %1, %2 = llhd.process -> i42, i1 {
+    %true = hw.constant true
+    %false = hw.constant false
+    cf.br ^bb1(%c0_i42, %false : i42, i1)
+  ^bb1(%3: i42, %4: i1):
+    llhd.wait yield (%3, %4 : i42, i1), (%clock : i1), ^bb2(%clock : i1)
+  ^bb2(%5: i1):
+    %6 = comb.xor bin %5, %true : i1
+    %7 = comb.and bin %6, %clock : i1  // posedge clock
+    cf.cond_br %7, ^bb1(%d, %true : i42, i1), ^bb1(%c0_i42, %false : i42, i1)
+  }
+  %3 = llhd.sig %c0_i42 : i42
+  // The t=0 one-shot writer (the "initial process").
+  // CHECK: llhd.process
+  llhd.process {
+    llhd.drv %3, %c1_i42 after %0 : i42
+    llhd.halt
+  }
+  // CHECK: llhd.drv {{%.+}}, {{%.+}} after {{%.+}} if {{%.+}} :
+  llhd.drv %3, %1 after %0 if %2 : i42
+}

--- a/test/Dialect/Moore/simplify-refs.mlir
+++ b/test/Dialect/Moore/simplify-refs.mlir
@@ -77,6 +77,42 @@ moore.module @Nested() {
   moore.output
 }
 
+// Delayed assignment variants keep their delay on every slice
+// (`{a, b} <= #1 c;` and `assign #1 {a, b} = c;`).
+// CHECK-LABEL: moore.module @DelayedConcatDst()
+moore.module @DelayedConcatDst() {
+  %a = moore.variable : <l7>
+  %b = moore.variable : <l1>
+  %c = moore.variable : <l8>
+  %d = moore.variable : <l8>
+  // CHECK: [[T0:%.+]] = moore.constant_time 2000000 fs
+  %t0 = moore.constant_time 2000000 fs
+  // CHECK-NOT: moore.concat_ref
+  %2 = moore.concat_ref %a, %b : (!moore.ref<l7>, !moore.ref<l1>) -> <l8>
+  // CHECK: %[[D_READ:.+]] = moore.read %d : <l8>
+  %3 = moore.read %d : <l8>
+  // CHECK: %[[SL1:.+]] = moore.extract %[[D_READ]] from 1 : l8 -> l7
+  // CHECK: moore.delayed_assign %a, %[[SL1]], [[T0]] : l7
+  // CHECK: %[[SL2:.+]] = moore.extract %[[D_READ]] from 0 : l8 -> l1
+  // CHECK: moore.delayed_assign %b, %[[SL2]], [[T0]] : l1
+  moore.delayed_assign %2, %3, %t0 : l8
+  moore.procedure always {
+    // CHECK: [[T1:%.+]] = moore.constant_time 1000000 fs
+    %t = moore.constant_time 1000000 fs
+    // CHECK-NOT: moore.concat_ref
+    %0 = moore.concat_ref %a, %b : (!moore.ref<l7>, !moore.ref<l1>) -> <l8>
+    // CHECK: %[[C_READ:.+]] = moore.read %c : <l8>
+    %1 = moore.read %c : <l8>
+    // CHECK: %[[TMP1:.+]] = moore.extract %[[C_READ]] from 1 : l8 -> l7
+    // CHECK: moore.delayed_nonblocking_assign %a, %[[TMP1]], [[T1]] : l7
+    // CHECK: %[[TMP2:.+]] = moore.extract %[[C_READ]] from 0 : l8 -> l1
+    // CHECK: moore.delayed_nonblocking_assign %b, %[[TMP2]], [[T1]] : l1
+    moore.delayed_nonblocking_assign %0, %1, %t : l8
+    moore.return
+  }
+  moore.output
+}
+
 // CHECK-LABEL: moore.module @QueueRefs()
 moore.module @QueueRefs() {
   %q = moore.variable : <queue<i32, 5>>

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -195,3 +195,21 @@ hw.module @FormatString(in %str: !sim.dstring) {
   // CHECK: sim.fmt.string %str isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
   %fmt1 = sim.fmt.string %str isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
 }
+
+// Queue concat must round-trip at every arity; the zero-operand form (the
+// empty queue literal) regressed under the old parenthesized-type-list
+// format, which printed `() <i8, 0>` and could not be reparsed.
+// CHECK-LABEL: func.func @QueueConcat
+func.func @QueueConcat(%arg0: !sim.queue<i8, 0>, %arg1: !sim.queue<i8, 4>) -> !sim.queue<i8, 0> {
+  // CHECK: sim.queue.concat () : () -> !sim.queue<i8, 0>
+  %0 = sim.queue.concat () : () -> !sim.queue<i8, 0>
+  // CHECK: sim.queue.concat (%arg0) : (!sim.queue<i8, 0>) -> !sim.queue<i8, 0>
+  %1 = sim.queue.concat (%arg0) : (!sim.queue<i8, 0>) -> !sim.queue<i8, 0>
+  // CHECK: sim.queue.concat (%arg0, %arg1) : (!sim.queue<i8, 0>, !sim.queue<i8, 4>) -> !sim.queue<i8, 0>
+  %2 = sim.queue.concat (%arg0, %arg1) : (!sim.queue<i8, 0>, !sim.queue<i8, 4>) -> !sim.queue<i8, 0>
+  // The generic form must stay parseable as well (regression guard for IR
+  // printed with --mlir-print-op-generic).
+  // CHECK: sim.queue.concat () : () -> !sim.queue<i8, 0>
+  %3 = "sim.queue.concat"() : () -> !sim.queue<i8, 0>
+  return %0 : !sim.queue<i8, 0>
+}

--- a/test/Dialect/Sim/sim-errors.mlir
+++ b/test/Dialect/Sim/sim-errors.mlir
@@ -133,7 +133,7 @@ sim.func.dpi @dpi_bad_ref_type(ref %arg : i32)
 
 hw.module @queue_concat(in %q1: !sim.queue<i32, 0>, in %q2: !sim.queue<i16, 0>) {
   // expected-error @below {{'sim.queue.concat' op sim::Queue element type 'i16' doesn't match result sim::Queue element type 'i32'}}
-  sim.queue.concat (%q1, %q2) : (!sim.queue<i32, 0>, !sim.queue<i16, 0>) <i32, 5>
+  sim.queue.concat (%q1, %q2) : (!sim.queue<i32, 0>, !sim.queue<i16, 0>) -> !sim.queue<i32, 5>
 }
 
 hw.module @queue_from_array(in %uparr: !hw.array<5xi33>) {


### PR DESCRIPTION
Supersedes #10793, #10795, #10808. 15 commits, Arc/LLHD/Moore/Sim lowering only; one pipeline change (new pass, below); runtime ABI: none.
- LowerState: module-level `llhd.sig`/`llhd.prb`/`llhd.drv` surviving to state lowering -> persistent storage, initializer fragments lowered once in the initial phase. Drives/probes of parts of a signal (constant-offset bit slices, array elements, struct/array member paths) -> read-modify-write splices.
- LowerState: pre-eval old-phase snapshot + end-of-eval register commits; registers read their pre-edge value within one evaluation. Scope: zero-real-time (delta/epsilon) drive delays only; real-time delays keep rejecting.
- new `arc-split-false-comb-loops`, run before ConvertToArcs in the arcilator pipeline: splits comb cycles that exist only at whole-value granularity (element-disjoint aggregate updates, disjoint bitwise feedback) at leaf level; true cycles still reject.
- RemoveI0Types: bridge LLHD ref ops at the value/ref boundary; scalarize gets/injects of 1-element arrays with non-i0 indices.
- InferStateProperties: don't build constants for aggregate self-arguments (crashed on array-typed state).
- Deseq: keep the process form for drives on multi-driven signals — promoting one process's conditional drive to a register clobbers every other process's write on the next delta.
- Deseq: fold one-shot t=0 constant init drives into the register preset.
- zero-operand `queue.concat` (the empty queue literal `{}`) round-trips: functional-type assembly format at every arity; MooreToCore lowers the degenerate form to `sim.queue.empty`.
- SimplifyRefs: lower `concat_ref` destinations of delayed assignments (`{a, b} <= #d v`), which previously survived to MooreToCore and failed.
No acceptance paths: every commit converts something that previously errored/crashed or fixes a soundness bug. Excluded: the NBA delta-drive runtime queue (runtime-ABI-affecting; separate design conversation).
sv-tests Arcilator: 1955/5093 -> 1978/5093 (+23, 0 lost) at b4d2825009; `circt_verilog` unchanged 4111/5093 (0 lost). lit Arc+LLHD+Sim+MooreToCore+ImportVerilog: 139/139.
Gained rows: asicworld mux/encoder/decoder/cam/rom case models, fsm_full, reg_combo, mem2reg, generate/for-generate/for-loop rows, rotate, wandwor, memories_read_arst, event_control_edge, case-attribute rows.
Written with AI assistance; I've reviewed the diff and tests.
