### PR TITLE
[ImportVerilog] Add real --parse-only, rename old to --import-only

### DIFF
--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -39,13 +39,16 @@ namespace circt {
 /// `Driver::addStandardArgs()` for some inspiration on how to expose these on
 /// the command line.
 struct ImportVerilogOptions {
-  /// Limit importing to linting or parsing only.
+  /// Limit importing to linting, parsing, or elaboration only.
   enum class Mode {
-    /// Only lint the input, without elaboration and lowering to CIRCT IR.
+    /// Only lint the input.
     OnlyLint,
-    /// Only parse and elaborate the input, without mapping to CIRCT IR.
+    /// Only parse the input syntax and report parse diagnostics.
     OnlyParse,
-    /// Perform a full import and mapping to CIRCT IR.
+    /// Parse and elaborate the input and convert it to Moore dialect ops,
+    /// without running any transformation passes.
+    OnlyImport,
+    /// Perform a full import and mapping to the core dialects.
     Full
   };
   Mode mode = Mode::Full;

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -28,9 +28,11 @@
 
 #include "slang/analysis/AnalysisManager.h"
 #include "slang/diagnostics/DiagnosticClient.h"
+#include "slang/diagnostics/Diagnostics.h"
 #include "slang/driver/Driver.h"
 #include "slang/parsing/Preprocessor.h"
 #include "slang/syntax/SyntaxPrinter.h"
+#include "slang/syntax/SyntaxTree.h"
 #include "slang/util/VersionInfo.h"
 
 using namespace mlir;
@@ -308,6 +310,23 @@ LogicalResult ImportDriver::importVerilog(ModuleOp module) {
   auto parseTimer = ts.nest("Verilog parser");
   bool parseSuccess = driver.parseAllSources();
   parseTimer.stop();
+
+  // If we were only supposed to parse the input, gather the parse diagnostics
+  // and report them here, then return without elaborating. This mirrors
+  // slang-driver's `--parse-only`: errors that only surface during elaboration
+  // or IR conversion (unknown modules, constraint blocks, ...) don't run, so
+  // this succeeds on such inputs while still flagging genuine syntax errors.
+  // The module is left empty.
+  if (options.mode == ImportVerilogOptions::Mode::OnlyParse) {
+    slang::Diagnostics parseDiags;
+    for (const auto &tree : driver.sourceLoader.getLibraryMaps())
+      parseDiags.append_range(tree->diagnostics());
+    for (const auto &tree : driver.syntaxTrees)
+      parseDiags.append_range(tree->diagnostics());
+    parseDiags.sort(driver.sourceManager);
+    driver.diagEngine.issue(parseDiags);
+    return success(parseSuccess && driver.diagEngine.getNumErrors() == 0);
+  }
 
   // Elaborate the input.
   auto compileTimer = ts.nest("Verilog elaboration");

--- a/test/Conversion/ImportVerilog/procedures.sv
+++ b/test/Conversion/ImportVerilog/procedures.sv
@@ -1,5 +1,5 @@
-// RUN: circt-verilog --parse-only --always-at-star-as-comb=0 %s | FileCheck %s --check-prefixes=CHECK,CHECK-STAR
-// RUN: circt-verilog --parse-only --always-at-star-as-comb=1 %s | FileCheck %s --check-prefixes=CHECK,CHECK-COMB
+// RUN: circt-verilog --import-only --always-at-star-as-comb=0 %s | FileCheck %s --check-prefixes=CHECK,CHECK-STAR
+// RUN: circt-verilog --import-only --always-at-star-as-comb=1 %s | FileCheck %s --check-prefixes=CHECK,CHECK-COMB
 // REQUIRES: slang
 
 // Internal issue in Slang v3 about jump depending on uninitialised value.

--- a/test/circt-verilog/parse-only.sv
+++ b/test/circt-verilog/parse-only.sv
@@ -1,0 +1,45 @@
+// RUN: split-file %s %t
+
+// `--parse-only` only parses the input syntax and does not elaborate or map to
+// IR. Instantiating an unknown module is only diagnosed during elaboration, so
+// parsing alone succeeds.
+// RUN: circt-verilog --parse-only %t/unknown.sv
+
+// Constructs that only fail during IR conversion, such as a class with a
+// constraint block, are also accepted since that stage never runs.
+// RUN: circt-verilog --parse-only %t/constraint.sv
+
+// Genuine syntax errors are still reported and cause a failure.
+// RUN: not circt-verilog --parse-only %t/syntax-error.sv 2>&1 | FileCheck %t/syntax-error.sv
+
+// `--import-only` mirrors the old `--parse-only`: it parses and elaborates the
+// input and maps it to Moore IR, but runs no lowering passes.
+// RUN: circt-verilog --import-only %t/import.sv | FileCheck %t/import.sv
+
+// Elaboration errors still fire in `--import-only` mode.
+// RUN: not circt-verilog --import-only %t/unknown.sv 2>&1 | FileCheck %t/unknown.sv --check-prefix=IMPORT
+
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+//--- unknown.sv
+// IMPORT: error: unknown module 'Unknown'
+module Top;
+  Unknown u();
+endmodule
+
+//--- constraint.sv
+class C;
+  rand int x;
+  constraint c { x > 0; }
+endclass
+
+//--- syntax-error.sv
+// CHECK: error: expected ';'
+module Top
+endmodule
+
+//--- import.sv
+// CHECK: moore.module @Top
+module Top;
+endmodule

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -64,6 +64,7 @@ enum class LoweringMode {
   OnlyPreprocess,
   OnlyLint,
   OnlyParse,
+  OnlyImport,
   OutputIRMoore,
   OutputIRLLHD,
   OutputIRHW,
@@ -115,8 +116,12 @@ struct CLOptions {
                      "Only lint the input, without elaboration and mapping to "
                      "CIRCT IR"),
           clEnumValN(LoweringMode::OnlyParse, "parse-only",
-                     "Only parse and elaborate the input, without mapping to "
-                     "CIRCT IR"),
+                     "Only parse the input syntax and report diagnostics; do "
+                     "not elaborate or map to IR"),
+          clEnumValN(
+              LoweringMode::OnlyImport, "import-only",
+              "Parse and elaborate the input and map it to Moore IR, but "
+              "do not run any lowering passes"),
           clEnumValN(LoweringMode::OutputIRMoore, "ir-moore",
                      "Run the entire pass manager to just before MooreToCore "
                      "conversion, and emit the resulting Moore dialect IR"),
@@ -345,6 +350,8 @@ static LogicalResult executeWithSources(MLIRContext *context,
     options.mode = ImportVerilogOptions::Mode::OnlyLint;
   else if (opts.loweringMode == LoweringMode::OnlyParse)
     options.mode = ImportVerilogOptions::Mode::OnlyParse;
+  else if (opts.loweringMode == LoweringMode::OnlyImport)
+    options.mode = ImportVerilogOptions::Mode::OnlyImport;
   options.debugInfo = opts.debugInfo;
   options.lowerAlwaysAtStarAsComb = opts.lowerAlwaysAtStarAsComb;
 
@@ -406,9 +413,10 @@ static LogicalResult executeWithSources(MLIRContext *context,
     if (failed(importVerilog(sourceMgr, context, ts, module.get(), &options)))
       return failure();
 
-    // If the user requested for the files to be only linted, the module remains
-    // empty and there is nothing left to do.
-    if (opts.loweringMode == LoweringMode::OnlyLint)
+    // If the user requested for the files to be only linted or parsed, the
+    // module remains empty and there is nothing left to do.
+    if (opts.loweringMode == LoweringMode::OnlyLint ||
+        opts.loweringMode == LoweringMode::OnlyParse)
       return success();
   } break;
 
@@ -420,9 +428,10 @@ static LogicalResult executeWithSources(MLIRContext *context,
   if (!module)
     return failure();
 
-  // If the user requested anything besides simply parsing the input, run the
-  // appropriate transformation passes according to the command line options.
-  if (opts.loweringMode != LoweringMode::OnlyParse) {
+  // If the user requested anything besides importing the input to Moore IR, run
+  // the appropriate transformation passes according to the command line
+  // options.
+  if (opts.loweringMode != LoweringMode::OnlyImport) {
     PassManager pm(context);
     pm.enableVerifier(true);
     pm.enableTiming(ts);


### PR DESCRIPTION
The old circt-verilog `--parse-only` did not match slang-driver's flag of the same name: it parsed, elaborated, resolved instantiations, and built Moore IR, only skipping the lowering pass pipeline. Rename that mode to `--import-only` to reflect what it actually does.

Introduce a new `--parse-only` that mirrors slang-driver: it only parses the input syntax and reports parse diagnostics through the normal diagnostic path, without elaborating or mapping to IR.

This makes the behavior of circt-verilog more predictable and aligned with slang.

Assisted-by: Claude Opus 4.8