### PR TITLE
[ImportVerilog] Fix operand domain for real logical operators

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1495,8 +1495,12 @@ struct RvalueExprVisitor : public ExprVisitor {
     case BinaryOperator::LogicalAnd:
     case BinaryOperator::LogicalOr:
     case BinaryOperator::LogicalImplication:
-    case BinaryOperator::LogicalEquivalence:
-      return buildLogicalBOp(expr.op, lhs, rhs);
+    case BinaryOperator::LogicalEquivalence: {
+      Domain domain = Domain::TwoValued;
+      if (expr.left().type->isFourState() || expr.right().type->isFourState())
+        domain = Domain::FourValued;
+      return buildLogicalBOp(expr.op, lhs, rhs, domain);
+    }
 
     default:
       mlir::emitError(loc) << "Binary operator "

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -5409,3 +5409,44 @@ task BuiltinCastFalse;
   $cast(s, 2.3);
   $cast(q, 2.3);
 endtask
+
+// CHECK-LABEL: func.func private @LogicalEquivReal
+// CHECK-SAME: ([[RVAL:%.+]]: !moore.f64, [[VAL:%.+]]: !moore.l1)
+function logic LogicalEquivReal(real rval, logic val);
+  // CHECK: [[B:%.+]] = moore.bool_cast [[RVAL]] : f64 -> i1
+  // CHECK: [[L:%.+]] = moore.int_to_logic [[B]] : i1
+  // CHECK: [[NL:%.+]] = moore.not [[L]] : l1
+  // CHECK: [[NV:%.+]] = moore.not [[VAL]] : l1
+  // CHECK: [[BOTH:%.+]] = moore.and [[L]], [[VAL]] : l1
+  // CHECK: [[NBOTH:%.+]] = moore.and [[NL]], [[NV]] : l1
+  // CHECK: moore.or [[BOTH]], [[NBOTH]] : l1
+  return rval <-> val;
+endfunction
+
+// CHECK-LABEL: func.func private @LogicalImplReal
+// CHECK-SAME: ([[RVAL:%.+]]: !moore.f64, [[VAL:%.+]]: !moore.l1)
+function logic LogicalImplReal(real rval, logic val);
+  // CHECK: [[B:%.+]] = moore.bool_cast [[RVAL]] : f64 -> i1
+  // CHECK: [[L:%.+]] = moore.int_to_logic [[B]] : i1
+  // CHECK: [[NL:%.+]] = moore.not [[L]] : l1
+  // CHECK: moore.or [[NL]], [[VAL]] : l1
+  return rval -> val;
+endfunction
+
+// CHECK-LABEL: func.func private @LogicalAndReal
+// CHECK-SAME: ([[RVAL:%.+]]: !moore.f64, [[VAL:%.+]]: !moore.l1)
+function logic LogicalAndReal(real rval, logic val);
+  // CHECK: [[B:%.+]] = moore.bool_cast [[RVAL]] : f64 -> i1
+  // CHECK: [[L:%.+]] = moore.int_to_logic [[B]] : i1
+  // CHECK: moore.and [[L]], [[VAL]] : l1
+  return rval && val;
+endfunction
+
+// CHECK-LABEL: func.func private @LogicalOrReal
+// CHECK-SAME: ([[RVAL:%.+]]: !moore.f64, [[VAL:%.+]]: !moore.l1)
+function logic LogicalOrReal(real rval, logic val);
+  // CHECK: [[B:%.+]] = moore.bool_cast [[RVAL]] : f64 -> i1
+  // CHECK: [[L:%.+]] = moore.int_to_logic [[B]] : i1
+  // CHECK: moore.or [[L]], [[VAL]] : l1
+  return rval || val;
+endfunction


### PR DESCRIPTION
Logical operators (`&&`, `||`, `->`, `<->`) with a real operand produce invalid IR if the LHS and RHS have different domains (two-state or four-state) after casting to a truthy boolean value.

Compute the result domain in the real path and pass it to `buildLogicalBOp`, mirroring the integer path.

Assisted-by: Claude Opus 4.8
