### PR TITLE
[ImportVerilog] Lower case statements on reals to real equality

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -534,10 +534,15 @@ struct StmtVisitor {
           if (auto defOp = maybeConst.getDefiningOp<moore::ConstantOp>())
             itemConsts.push_back(defOp.getValueAttr());
 
-          // Generate the appropriate equality operator.
+          // Generate the appropriate equality operator. A case statement with
+          // real operands uses ordinary equality (`==`) per IEEE 1800 § 11.4.5,
+          // not case-equality; wildcard case kinds on reals are illegal SV.
           switch (caseStmt.condition) {
           case CaseStatementCondition::Normal:
-            cond = moore::CaseEqOp::create(builder, itemLoc, caseExpr, value);
+            if (isa<moore::RealType>(caseExpr.getType()))
+              cond = moore::EqRealOp::create(builder, itemLoc, caseExpr, value);
+            else
+              cond = moore::CaseEqOp::create(builder, itemLoc, caseExpr, value);
             break;
           case CaseStatementCondition::WildcardXOrZ:
             cond = moore::CaseXZEqOp::create(builder, itemLoc, caseExpr, value);

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -394,6 +394,27 @@ function void CaseStatements(int x, int a, int b, int c);
   endcase
 endfunction
 
+// CHECK-LABEL: func.func private @CaseStatementsOnReal(
+// CHECK-SAME: %arg0: !moore.f64
+function void CaseStatementsOnReal(real x);
+  case (x)
+    // CHECK: [[ITEM1:%.+]] = moore.constant_real 1.000000e+00 : f64
+    // CHECK: [[COND1:%.+]] = moore.feq %arg0, [[ITEM1]] : f64 -> i1
+    // CHECK-NOT: moore.case_eq
+    // CHECK: [[FLAG1:%.+]] = moore.to_builtin_int [[COND1]] : i1
+    // CHECK: cf.cond_br [[FLAG1]]
+    1.0: dummyA();
+    // CHECK: [[ONE:%.+]] = moore.constant_real 1.000000e+00 : f64
+    // CHECK: [[ITEM2:%.+]] = moore.fneg [[ONE]] : f64
+    // CHECK: [[COND2:%.+]] = moore.feq %arg0, [[ITEM2]] : f64 -> i1
+    // CHECK-NOT: moore.case_eq
+    // CHECK: [[FLAG2:%.+]] = moore.to_builtin_int [[COND2]] : i1
+    // CHECK: cf.cond_br [[FLAG2]]
+    -1.0: dummyB();
+    default: dummyC();
+  endcase
+endfunction
+
 // CHECK-LABEL: func.func private @ForLoopStatements(
 // CHECK-SAME: %arg0: !moore.i32
 // CHECK-SAME: %arg1: !moore.i32


### PR DESCRIPTION
A `case` statement whose selector or items are of type `real` must use ordinary real equality (`==`) per IEEE 1800 § 11.4.5, not case-equality. Previously the lowering unconditionally emitted `moore.case_eq`, which rejects real operands, producing invalid IR.

Emit `moore.feq` instead when the case expression is real. Wildcard case kinds on reals are illegal SystemVerilog, so only the normal case kind needs this handling.

Assisted-by: Claude Opus 4.8