### PR TITLE
[MooreToCore] Lower moore.unreachable to llvm.unreachable

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -537,6 +537,7 @@ def ConvertMooreToCore : Pass<"convert-moore-to-core", "mlir::ModuleOp"> {
     "mlir::scf::SCFDialect",
     "mlir::math::MathDialect",
     "mlir::LLVM::LLVMDialect",
+    "mlir::ub::UBDialect",
     "sim::SimDialect",
     "verif::VerifDialect",
   ];

--- a/lib/Conversion/MooreToCore/CMakeLists.txt
+++ b/lib/Conversion/MooreToCore/CMakeLists.txt
@@ -24,4 +24,5 @@ add_circt_conversion_library(CIRCTMooreToCore
   MLIRSCFToControlFlow
   MLIRSideEffectInterfaces
   MLIRTransforms
+  MLIRUBDialect
 )

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -924,10 +925,10 @@ static LogicalResult convert(WaitDelayOp op, WaitDelayOp::Adaptor adaptor,
   return success();
 }
 
-// moore.unreachable -> llhd.halt
+// moore.unreachable -> ub.unreachable
 static LogicalResult convert(UnreachableOp op, UnreachableOp::Adaptor adaptor,
                              ConversionPatternRewriter &rewriter) {
-  rewriter.replaceOpWithNewOp<llhd::HaltOp>(op, ValueRange{});
+  rewriter.replaceOpWithNewOp<ub::UnreachableOp>(op);
   return success();
 }
 
@@ -3540,6 +3541,7 @@ static void populateLegality(ConversionTarget &target,
   target.addLegalDialect<mlir::math::MathDialect>();
   target.addLegalDialect<sim::SimDialect>();
   target.addLegalDialect<mlir::LLVM::LLVMDialect>();
+  target.addLegalDialect<mlir::ub::UBDialect>();
   target.addLegalDialect<verif::VerifDialect>();
   target.addLegalDialect<arith::ArithDialect>();
 

--- a/lib/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -26,4 +26,5 @@ add_circt_dialect_library(CIRCTLLHDTransforms
   MLIRIR
   MLIRSCFDialect
   MLIRTransformUtils
+  MLIRUBDialect
 )

--- a/lib/Dialect/LLHD/Transforms/InlineCalls.cpp
+++ b/lib/Dialect/LLHD/Transforms/InlineCalls.cpp
@@ -10,6 +10,7 @@
 #include "circt/Dialect/LLHD/LLHDOps.h"
 #include "circt/Dialect/LLHD/LLHDPasses.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Threading.h"
 #include "mlir/IR/Visitors.h"
@@ -63,6 +64,16 @@ struct FunctionInliner : public InlinerInterface {
   }
 
   bool shouldAnalyzeRecursively(Operation *op) const override { return false; }
+
+  /// The UB dialect does not implement this inliner hook for its
+  /// `ub.unreachable` terminator, which causes the default implementation to
+  /// abort. Handle the op here instead: like a branch op, it needs no rewrite
+  /// when inlined, since it never transfers control to the continuation block.
+  void handleTerminator(Operation *op, Block *newDest) const override {
+    if (isa<mlir::ub::UnreachableOp>(op))
+      return;
+    InlinerInterface::handleTerminator(op, newDest);
+  }
 };
 
 /// Pass implementation.

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1433,9 +1433,15 @@ func.func @Time(%arg0: !moore.time) -> (!moore.time, !moore.time) {
 moore.module @Unreachable() {
   // CHECK: llhd.process
   moore.procedure initial {
-    // CHECK-NEXT: llhd.halt
+    // CHECK-NEXT: ub.unreachable
     moore.unreachable
   }
+}
+
+// CHECK-LABEL: @UnreachableInFunction
+func.func @UnreachableInFunction() {
+  // CHECK-NEXT: ub.unreachable
+  moore.unreachable
 }
 
 // CHECK-LABEL: @SimulationControl

--- a/test/Dialect/LLHD/Transforms/inline-calls.mlir
+++ b/test/Dialect/LLHD/Transforms/inline-calls.mlir
@@ -68,3 +68,30 @@ func.func private @bar_wrapper(%arg0: i42) -> i42 {
   %0 = call @bar(%arg0) : (i42) -> i42
   return %0 : i42
 }
+
+// Inlining a multi-block function with an `ub.unreachable` terminator must not
+// crash and must keep the terminator in place.
+// CHECK-LABEL: @Unreachable
+hw.module @Unreachable(in %a: i1, out u: i42) {
+  // CHECK: llhd.combinational
+  %0 = llhd.combinational -> i42 {
+    // CHECK-NOT: call @maybeUnreachable
+    %1 = func.call @maybeUnreachable(%a) : (i1) -> i42
+    // CHECK:      cf.cond_br %a, [[BB1:\^.+]], [[BB2:\^.+]]
+    // CHECK-NEXT: [[BB1]]:
+    // CHECK-NEXT:   ub.unreachable
+    // CHECK-NEXT: [[BB2]]:
+    llhd.yield %1 : i42
+  }
+  hw.output %0 : i42
+}
+
+// CHECK-DCE-NOT: @maybeUnreachable
+func.func private @maybeUnreachable(%arg0: i1) -> i42 {
+  cf.cond_br %arg0, ^bb1, ^bb2
+^bb1:
+  ub.unreachable
+^bb2:
+  %0 = hw.constant 42 : i42
+  return %0 : i42
+}

--- a/tools/circt-as/circt-as.cpp
+++ b/tools/circt-as/circt-as.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Support/FileUtilities.h"
 #include "llvm/Support/CommandLine.h"
@@ -138,6 +139,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::emitc::EmitCDialect>();
+  registry.insert<mlir::ub::UBDialect>();
 
   // Hide default LLVM options, other than for this tool.
   cl::HideUnrelatedOptions({&mainCategory, &llvm::getColorCategory()});

--- a/tools/circt-dis/circt-dis.cpp
+++ b/tools/circt-dis/circt-dis.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Support/FileUtilities.h"
 #include "llvm/Support/CommandLine.h"
@@ -116,6 +117,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::emitc::EmitCDialect>();
+  registry.insert<mlir::ub::UBDialect>();
 
   // Hide default LLVM options, other than for this tool.
   // MLIR options are added below.

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(circt-opt
   MLIRFuncInlinerExtension
   MLIRVectorDialect
   MLIRIndexDialect
+  MLIRUBDialect
   MLIRLLVMIRTransforms
 )
 

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
@@ -62,6 +63,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::emitc::EmitCDialect>();
   registry.insert<mlir::vector::VectorDialect>();
   registry.insert<mlir::index::IndexDialect>();
+  registry.insert<mlir::ub::UBDialect>();
 
   circt::registerAllDialects(registry);
   circt::registerAllPasses();

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Support/FileUtilities.h"
@@ -527,9 +528,9 @@ int main(int argc, char **argv) {
   // Register all the dialects.
   mlir::DialectRegistry registry;
   registerAllDialects(registry);
-  registry
-      .insert<func::FuncDialect, scf::SCFDialect, cf::ControlFlowDialect,
-              LLVM::LLVMDialect, index::IndexDialect, arith::ArithDialect>();
+  registry.insert<func::FuncDialect, scf::SCFDialect, cf::ControlFlowDialect,
+                  LLVM::LLVMDialect, index::IndexDialect, arith::ArithDialect,
+                  ub::UBDialect>();
   arc::registerReducePatternDialectInterface(registry);
   emit::registerReducePatternDialectInterface(registry);
   firrtl::registerReducePatternDialectInterface(registry);

--- a/tools/circt-test/CMakeLists.txt
+++ b/tools/circt-test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(libs
   MLIRLLVMDialect
   MLIRSCFDialect
   MLIRSMT
+  MLIRUBDialect
 
   MLIRBytecodeReader
   MLIRIR

--- a/tools/circt-test/circt-test.cpp
+++ b/tools/circt-test/circt-test.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Threading.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
@@ -1529,6 +1530,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::arith::ArithDialect>();
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
+  registry.insert<mlir::ub::UBDialect>();
   circt::registerAllDialects(registry);
 
   // Hide default LLVM options, other than for this tool.

--- a/tools/circt-verilog/CMakeLists.txt
+++ b/tools/circt-verilog/CMakeLists.txt
@@ -26,6 +26,7 @@ set(libs
   MLIRParser
   MLIRSCFDialect
   MLIRSupport
+  MLIRUBDialect
 )
 
 add_circt_tool(circt-verilog circt-verilog.cpp DEPENDS ${libs})

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Parser/Parser.h"
@@ -562,6 +563,7 @@ int main(int argc, char **argv) {
     scf::SCFDialect,
     seq::SeqDialect,
     sim::SimDialect,
+    ub::UBDialect,
     verif::VerifDialect
   >();
   // clang-format on


### PR DESCRIPTION
Currently, `moore.unreachable` unconditionally becomes `llhd.halt`. This is invalid inside a `func.func` and any other op besides `llhd.process` and `llhd.coroutine`.

Extend the conversion pattern to convert to `llvm.unreachable` outside of these two LLHD parent ops. We don't really have a good `unreachable` terminator in the core dialects in CIRCT, so LLVM is the next best thing.

In the future we might want to not have a conversion for `unreachable` at all, and instead force the SCF-to-CF lowering to not produce unreachable blocks. That's potentially tricky though and better left as a separate improvement.

Assisted-by: Claude Opus 4.8
