### PR TITLE
[ImportVerilog] Support $itor, $rtoi, $pow system functions

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3548,9 +3548,31 @@ Value Context::convertSystemCall(
   if (nameId == ksn::Atanh)
     return convertRealMathBI<moore::AtanhBIOp>(*this, loc, name, args);
 
+  if (nameId == ksn::Pow) {
+    assert(numArgs == 2 && "`$pow` takes 2 arguments");
+    auto realType = moore::RealType::get(getContext(), moore::RealWidth::f64);
+    auto lhs = convertRvalueExpression(*args[0], realType);
+    auto rhs = convertRvalueExpression(*args[1], realType);
+    if (!lhs || !rhs)
+      return {};
+    return moore::PowRealOp::create(builder, loc, lhs, rhs);
+  }
+
   //===--------------------------------------------------------------------===//
   // Type Conversion System Functions
   //===--------------------------------------------------------------------===//
+
+  if (nameId == ksn::Itor) {
+    assert(numArgs == 1 && "`$itor` takes 1 argument");
+    auto realType = moore::RealType::get(getContext(), moore::RealWidth::f64);
+    return convertRvalueExpression(*args[0], realType);
+  }
+
+  if (nameId == ksn::Rtoi) {
+    assert(numArgs == 1 && "`$rtoi` takes 1 argument");
+    auto intType = moore::IntType::get(getContext(), 32, Domain::TwoValued);
+    return convertRvalueExpression(*args[0], intType);
+  }
 
   if (nameId == ksn::Signed || nameId == ksn::Unsigned) {
     // Slang already checks the arity of `$signed`/`$unsigned`.

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -292,10 +292,11 @@ endfunction
 
 // IEEE 1800-2017 § 20.8 "Math functions"
 // CHECK-LABEL: func.func private @MathBuiltins(
-// CHECK-SAME: [[X:%.+]]: !moore.i32
-// CHECK-SAME: [[Y:%.+]]: !moore.l42
-// CHECK-SAME: [[R:%.+]]: !moore.f64
-function void MathBuiltins(int x, logic [41:0] y, real r);
+// CHECK-SAME: [[X:%.+]]: !moore.i32,
+// CHECK-SAME: [[Y:%.+]]: !moore.l42,
+// CHECK-SAME: [[R:%.+]]: !moore.f64,
+// CHECK-SAME: [[S:%.+]]: !moore.f64
+function void MathBuiltins(int x, logic [41:0] y, real r, real s);
   // CHECK: moore.builtin.clog2 [[X]] : i32
   dummyA($clog2(x));
   // CHECK: moore.builtin.clog2 [[Y]] : l42
@@ -337,6 +338,12 @@ function void MathBuiltins(int x, logic [41:0] y, real r);
   dummyB($acosh(r));
   // CHECK:  moore.builtin.atanh [[R]] : f64
   dummyB($atanh(r));
+  // CHECK: moore.fpow [[R]], [[S]] : f64
+  dummyB($pow(r, s));
+  // CHECK: moore.sint_to_real [[X]] : i32 -> f64
+  dummyB($itor(x));
+  // CHECK: moore.real_to_int [[R]] : f64 -> i32
+  dummyA($rtoi(r));
 
 endfunction
 


### PR DESCRIPTION
Wire the `$itor` and `$rtoi` real-conversion system functions to the existing integer/real conversion ops. Also implement `$pow` as a real power by reusing the existing `moore.fpow` op that already backs the `**` operator on reals.

Assisted-by: Claude Opus 4.8