### PR TITLE
[ImportVerilog] Support arrayed instances by unrolling elements

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -717,12 +717,31 @@ struct ModuleVisitor : public BaseVisitor {
       if (!value)
         return mlir::emitError(loc) << "unsupported port";
 
+    // Determine the name of the instance. Slang clears the name of instance
+    // array elements during elaboration; only the outermost array symbol
+    // retains the name written in the source. Reconstruct per-element names by
+    // appending the source index of each array dimension to the array name,
+    // such that `foo u [2:0][1:0]` produces `u_0_0`, `u_0_1`, `u_1_0`, etc.
+    // This mirrors the naming scheme used for for-generate blocks.
+    SmallString<64> instName(blockNamePrefix);
+    if (instNode.arrayPath.empty()) {
+      instName += instNode.name;
+    } else {
+      instName += instNode.getArrayName();
+      slang::SmallVector<slang::ConstantRange, 4> dims;
+      instNode.getArrayDimensions(dims);
+      for (auto [dim, index] : llvm::zip(dims, instNode.arrayPath)) {
+        instName += '_';
+        Twine(dim.lower() + int32_t(index)).toVector(instName);
+      }
+    }
+
     // Create the instance op itself.
     auto inputNames = builder.getArrayAttr(moduleType.getInputNames());
     auto outputNames = builder.getArrayAttr(moduleType.getOutputNames());
     auto inst = moore::InstanceOp::create(
         builder, loc, moduleType.getOutputTypes(),
-        builder.getStringAttr(Twine(blockNamePrefix) + instNode.name),
+        builder.getStringAttr(instName),
         FlatSymbolRefAttr::get(module.getSymNameAttr()), inputValues,
         inputNames, outputNames);
 
@@ -969,6 +988,15 @@ struct ModuleVisitor : public BaseVisitor {
     return context.convertPrimitiveInstance(prim);
   }
 
+  // Handle instance arrays.
+  LogicalResult visit(const slang::ast::InstanceArraySymbol &arrNode) {
+    // Slang already nicely unrolls these into distinct instances for us.
+    for (const auto *element : arrNode.elements)
+      if (failed(element->visit(*this)))
+        return failure();
+    return success();
+  }
+
   /// Emit an error for all other members.
   template <typename T>
   LogicalResult visit(T &&node) {
@@ -1151,6 +1179,13 @@ struct ModulePredeclaration {
           return failure();
         context.predeclaredInstances.insert(instNode);
       }
+      return success();
+    }
+
+    if (const auto *arrNode = member.as_if<slang::ast::InstanceArraySymbol>()) {
+      for (const auto *element : arrNode->elements)
+        if (failed(predeclareModuleInstanceMember(*element, blockNamePrefix)))
+          return failure();
       return success();
     }
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -5471,3 +5471,51 @@ function logic LogicalOrReal(real rval, logic val);
   // CHECK: moore.or [[L]], [[VAL]] : l1
   return rval || val;
 endfunction
+
+// CHECK-LABEL: moore.module private @ArrayInstSub
+module ArrayInstSub(input a, output y);
+  assign y = a;
+endmodule
+
+// CHECK-LABEL: moore.module @ArrayInstTop
+module ArrayInstTop(input [3:0] a, output [3:0] y);
+  // CHECK: [[A0:%.+]] = moore.dyn_extract {{.*}}from {{.*}} : l4, i32 -> l1
+  // CHECK: [[Y0:%.+]] = moore.extract_ref %y from 0 : <l4> -> <l1>
+  // CHECK: [[R0:%.+]] = moore.instance "u_0" @ArrayInstSub(a: [[A0]]: !moore.l1) -> (y: !moore.l1)
+  // CHECK: moore.assign [[Y0]], [[R0]] : l1
+  // CHECK: [[A1:%.+]] = moore.dyn_extract {{.*}}from {{.*}} : l4, i32 -> l1
+  // CHECK: [[Y1:%.+]] = moore.extract_ref %y from 1 : <l4> -> <l1>
+  // CHECK: [[R1:%.+]] = moore.instance "u_1" @ArrayInstSub(a: [[A1]]: !moore.l1) -> (y: !moore.l1)
+  // CHECK: moore.assign [[Y1]], [[R1]] : l1
+  // CHECK: [[A2:%.+]] = moore.dyn_extract {{.*}}from {{.*}} : l4, i32 -> l1
+  // CHECK: [[Y2:%.+]] = moore.extract_ref %y from 2 : <l4> -> <l1>
+  // CHECK: [[R2:%.+]] = moore.instance "u_2" @ArrayInstSub(a: [[A2]]: !moore.l1) -> (y: !moore.l1)
+  // CHECK: moore.assign [[Y2]], [[R2]] : l1
+  // CHECK: [[A3:%.+]] = moore.dyn_extract {{.*}}from {{.*}} : l4, i32 -> l1
+  // CHECK: [[Y3:%.+]] = moore.extract_ref %y from 3 : <l4> -> <l1>
+  // CHECK: [[R3:%.+]] = moore.instance "u_3" @ArrayInstSub(a: [[A3]]: !moore.l1) -> (y: !moore.l1)
+  // CHECK: moore.assign [[Y3]], [[R3]] : l1
+  ArrayInstSub u [3:0] (.a(a), .y(y));
+endmodule
+
+// CHECK-LABEL: moore.module @ArrayInstMultiDim
+module ArrayInstMultiDim(input [5:0] a, output [5:0] y);
+  // CHECK: moore.instance "u_1_2" @ArrayInstSub
+  // CHECK: moore.instance "u_1_3" @ArrayInstSub
+  // CHECK: moore.instance "u_1_4" @ArrayInstSub
+  // CHECK: moore.instance "u_2_2" @ArrayInstSub
+  // CHECK: moore.instance "u_2_3" @ArrayInstSub
+  // CHECK: moore.instance "u_2_4" @ArrayInstSub
+  ArrayInstSub u [1:2][4:2] (.a(a), .y(y));
+endmodule
+
+// CHECK-LABEL: moore.module @ArrayGateTop
+module ArrayGateTop(input [3:0] a, input [3:0] b, output [3:0] y);
+  // CHECK: [[G0:%.+]] = moore.extract_ref %y from 0 : <l4> -> <l1>
+  // CHECK: [[GA0:%.+]] = moore.and
+  // CHECK: moore.assign [[G0]], [[GA0]] : l1
+  // CHECK: [[G3:%.+]] = moore.extract_ref %y from 3 : <l4> -> <l1>
+  // CHECK: [[GA3:%.+]] = moore.and
+  // CHECK: moore.assign [[G3]], [[GA3]] : l1
+  and g [3:0] (y, a, b);
+endmodule


### PR DESCRIPTION
Slang already elaborates each element of an instance array, with the per-element port connections sliced according to the LRM. Arrayed module and gate-primitive instances are therefore handled by visiting each element and recursing for multidimensional arrays, both in the main module visitor and in the predeclaration visitor.

Assisted-by: Claude Opus 4.8