### PR TITLE
[FIRRTL][InferDomains] Colorless constant expr.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -26,6 +26,7 @@
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/IR/Threading.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -98,16 +99,7 @@ static bool isHardware(Type type) {
 }
 
 /// True if the given value could be association with a domain.
-static bool isHardware(Value value) {
-  if (!isHardware(value.getType()))
-    return false;
-
-  if (auto *op = value.getDefiningOp())
-    if (op->hasTrait<OpTrait::ConstantLike>())
-      return false;
-
-  return true;
-}
+static bool isHardware(Value value) { return isHardware(value.getType()); }
 
 //====--------------------------------------------------------------------------
 // Global State.
@@ -345,6 +337,14 @@ public:
   Term *getDomainAssociation(Value value);
   void setDomainAssociation(Value value, Term *term);
 
+  /// True if the value is "colorless": it is only driven by nodes or primops
+  /// whose inputs all terminate in constants, and therefore is not tied to any
+  /// domain. A colorless value imposes and inherits no domain constraints and
+  /// may be freely consumed by a value in any domain. All ports and wires are
+  /// treated as colored. Computed structurally over the SSA graph, memoized per
+  /// module.
+  bool isColorless(Value value);
+
   void processDomainDefinition(DomainValue domain);
   RowTerm *getDomainAssociationAsRow(Value value);
 
@@ -447,6 +447,8 @@ private:
   CircuitState &globals;
   DenseMap<Value, Term *> termTable;
   DenseMap<Value, Term *> associationTable;
+  /// Memoization for `isColorless`. Absent = not computed; present = result.
+  DenseMap<Value, bool> colorlessTable;
   llvm::BumpPtrAllocator allocator;
 };
 } // namespace
@@ -723,6 +725,167 @@ void ModuleState::setDomainAssociation(Value value, Term *term) {
     llvm::dbgs().indent(6) << "set domains(" << render(value)
                            << ") := " << render(term) << "\n";
   });
+}
+
+bool ModuleState::isColorless(Value value) {
+  // Non-hardware values (domains, properties, indices, ...) never participate
+  // in coloring, so treat them as colorless: they impose no constraint.
+  if (!isHardware(value))
+    return true;
+
+  // Consult the memo table.  A value is visited (expanded) at most once.
+  if (auto it = colorlessTable.find(value); it != colorlessTable.end())
+    return it->second;
+
+  // Classify a single value structurally, without recursing.  A "look-through"
+  // value (a node or a pure primop) is colorless iff all of its hardware
+  // operands are colorless; its hardware operands are collected into
+  // `operands`.  Everything else is either a colorless constant root or a
+  // colored leaf.  In particular, all ports (block arguments, instance
+  // results) and wires are colored and must be assigned a domain.
+  enum class Kind { Colorless, Colored, LookThrough };
+  auto classify = [&](Value v, SmallVectorImpl<Value> &operands) -> Kind {
+    if (!isHardware(v))
+      return Kind::Colorless;
+
+    auto *op = v.getDefiningOp();
+    // Block arguments (ports) have no defining op and are always colored.
+    if (!op)
+      return Kind::Colored;
+
+    // Constants are the only colorless roots.
+    if (op->hasTrait<OpTrait::ConstantLike>())
+      return Kind::Colorless;
+
+    // A node forwards its single input.
+    if (auto node = dyn_cast<NodeOp>(op)) {
+      operands.push_back(node.getInput());
+      return Kind::LookThrough;
+    }
+
+    // An unsafe domain cast with explicit domain operands is an explicit
+    // coloring point and is always colored.  A cast with no domain operands is
+    // a pure forwarding cast that inherits colorlessness from its input.
+    if (auto castOp = dyn_cast<UnsafeDomainCastOp>(op)) {
+      if (!castOp.getDomains().empty())
+        return Kind::Colored;
+      operands.push_back(castOp.getInput());
+      return Kind::LookThrough;
+    }
+
+    // Pure, memory-effect-free expression ops (prim ops, muxes, casts,
+    // aggregate projections) fan out to their hardware-typed operands.  For
+    // the ops that are eligible to propagate colorlessness (arithmetic and
+    // bitwise prim ops, muxes, casts, aggregate projections) every SSA operand
+    // is hardware-typed; scalar indices and amounts are attributes, not
+    // operands.  A non-hardware SSA operand (a property, domain, or other
+    // opaque value, e.g. a `verbatim.expr` substitution) therefore only
+    // appears on ops that reference external state, which are colored.  An
+    // expression with no hardware operands is likewise a non-constant root
+    // (e.g. an `xmr.ref`) and is colored.
+    if (isExpression(op) && mlir::isMemoryEffectFree(op)) {
+      if (op->getNumOperands() == 0)
+        return Kind::Colored;
+      for (auto operand : op->getOperands())
+        if (!isHardware(operand))
+          return Kind::Colored;
+      operands.assign(op->operand_begin(), op->operand_end());
+      return Kind::LookThrough;
+    }
+
+    // Everything else (wires, instance results, registers, memories, explicit
+    // domain casts, invalid values, probes, ...) is a colored leaf.
+    return Kind::Colored;
+  };
+
+  // Iterative post-order DFS.  Each frame tracks a look-through value (a value
+  // whose colorlessness is not yet known) and requires exploring its operands.
+  // This then tracks the operands that should be explored and the index of the
+  // _next_ operand to visit.  A value's colorlessness is the conjunction of its
+  // operands' colorlessness.  As soon as a colored operand is found the frame
+  // short-circuits to colored.  Since look-through values (constants, nodes,
+  // primops) reference only dominating SSA operands, the explored subgraph is
+  // acyclic (combinational loops only close through wires, which are colored
+  // leaves).
+  //
+  // Note: this DFS is _not_ sufficient to determine colorlessness through
+  // nodes.  It is assumed that a post-condition of this pass is that all wires
+  // are assigned domains.
+  struct Frame {
+    // The lookthrough value.
+    Value value;
+    // The operands to explore.
+    SmallVector<Value, 4> operands;
+    // The operand of the next operand to explored.
+    unsigned index = 0;
+  };
+  SmallVector<Frame> stack;
+
+  // Push the first value onto the stack (or exit).
+  {
+    SmallVector<Value, 4> operands;
+    switch (classify(value, operands)) {
+    case Kind::Colored:
+      return colorlessTable[value] = false;
+    case Kind::Colorless:
+      return colorlessTable[value] = true;
+    case Kind::LookThrough:
+      stack.push_back({value, std::move(operands)});
+      break;
+    }
+  }
+
+  // Run the DFS.
+  while (!stack.empty()) {
+    auto &frame = stack.back();
+    bool colored = false, pushed = false;
+
+    while (frame.index < frame.operands.size()) {
+      Value child = frame.operands[frame.index];
+
+      // If already resolved, short-circuit on a colored operand or advance.
+      if (auto it = colorlessTable.find(child); it != colorlessTable.end()) {
+        if (!it->second) {
+          colored = true;
+          break;
+        }
+        ++frame.index;
+        continue;
+      }
+
+      // Classify the operand.  Classify if not lookthrough.  Otherwise, push
+      // the lookthrough operand onto the stack and break so that we descend
+      // into it.
+      SmallVector<Value, 4> childOperands;
+      switch (classify(child, childOperands)) {
+      case Kind::Colored:
+        colorlessTable[child] = false;
+        colored = true;
+        break;
+      case Kind::Colorless:
+        colorlessTable[child] = true;
+        ++frame.index;
+        continue;
+      case Kind::LookThrough:
+        stack.push_back({child, std::move(childOperands)});
+        pushed = true;
+        break;
+      }
+      break;
+    }
+
+    // We hit a lookthrough operand.  Dexcend into this.  We will revist the
+    // current frame.index once we have an answer for that operand.
+    if (pushed)
+      continue;
+
+    // All operands resolved (or a colored operand short-circuited).  Record the
+    // result and pop this frame.
+    colorlessTable[frame.value] = !colored;
+    stack.pop_back();
+  }
+
+  return colorlessTable[value];
 }
 
 void ModuleState::processDomainDefinition(DomainValue domain) {
@@ -1020,6 +1183,11 @@ LogicalResult ModuleState::unifyAssociations(Operation *op, Value lhs,
   if (!isHardware(lhs) || !isHardware(rhs))
     return success();
 
+  // Colorless values impose and receive no association: colorless is below
+  // every color in the lattice.
+  if (isColorless(lhs) || isColorless(rhs))
+    return success();
+
   LLVM_DEBUG({
     llvm::dbgs().indent(6) << "unify domains(" << render(lhs) << ") = domains("
                            << render(rhs) << ")\n";
@@ -1055,7 +1223,7 @@ template <typename T>
 LogicalResult ModuleState::unifyAssociations(Operation *op, T &&range) {
   Value lhs;
   for (auto rhs : std::forward<T>(range)) {
-    if (!isHardware(rhs))
+    if (!isHardware(rhs) || isColorless(rhs))
       continue;
     if (failed(unifyAssociations(op, lhs, rhs)))
       return failure();
@@ -1209,7 +1377,7 @@ LogicalResult ModuleState::processOp(UnsafeDomainCastOp op) {
   auto input = op.getInput();
 
   SmallVector<Term *> elements(getNumDomains());
-  if (isHardware(input)) {
+  if (isHardware(input) && !isColorless(input)) {
     auto *inputRow = getDomainAssociationAsRow(input);
     elements.assign(inputRow->elements);
   }
@@ -1696,7 +1864,7 @@ ModuleState::updateWire(DenseMap<DomainValue, DomainValue> &domainsInScope,
     llvm_unreachable("unhandled domain term type");
   }
 
-  if (!isHardware(result))
+  if (!isHardware(result) || isColorless(result))
     return success();
 
   LLVM_DEBUG(llvm::dbgs().indent(4) << "update " << render(wireOp) << "\n");

--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -874,7 +874,7 @@ bool ModuleState::isColorless(Value value) {
       break;
     }
 
-    // We hit a lookthrough operand.  Dexcend into this.  We will revist the
+    // We hit a lookthrough operand.  Dexcend into this.  We will revisit the
     // current frame.index once we have an answer for that operand.
     if (pushed)
       continue;

--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -739,12 +739,16 @@ bool ModuleState::isColorless(Value value) {
 
   // Classify a single value structurally, without recursing.  A "look-through"
   // value (a node or a pure primop) is colorless iff all of its hardware
-  // operands are colorless; its hardware operands are collected into
-  // `operands`.  Everything else is either a colorless constant root or a
-  // colored leaf.  In particular, all ports (block arguments, instance
-  // results) and wires are colored and must be assigned a domain.
+  // operands are colorless.  For every look-through op the operands to explore
+  // are exactly all of its operands (a node and a forwarding cast have a single
+  // input operand; a pure expression is only look-through when all of its
+  // operands are hardware), so the caller can iterate the defining op's operand
+  // list directly rather than collecting a subset here.  Everything else is
+  // either a colorless constant root or a colored leaf.  In particular, all
+  // ports (block arguments, instance results) and wires are colored and must be
+  // assigned a domain.
   enum class Kind { Colorless, Colored, LookThrough };
-  auto classify = [&](Value v, SmallVectorImpl<Value> &operands) -> Kind {
+  auto classify = [&](Value v) -> Kind {
     if (!isHardware(v))
       return Kind::Colorless;
 
@@ -758,10 +762,8 @@ bool ModuleState::isColorless(Value value) {
       return Kind::Colorless;
 
     // A node forwards its single input.
-    if (auto node = dyn_cast<NodeOp>(op)) {
-      operands.push_back(node.getInput());
+    if (isa<NodeOp>(op))
       return Kind::LookThrough;
-    }
 
     // An unsafe domain cast with explicit domain operands is an explicit
     // coloring point and is always colored.  A cast with no domain operands is
@@ -769,7 +771,6 @@ bool ModuleState::isColorless(Value value) {
     if (auto castOp = dyn_cast<UnsafeDomainCastOp>(op)) {
       if (!castOp.getDomains().empty())
         return Kind::Colored;
-      operands.push_back(castOp.getInput());
       return Kind::LookThrough;
     }
 
@@ -789,7 +790,6 @@ bool ModuleState::isColorless(Value value) {
       for (auto operand : op->getOperands())
         if (!isHardware(operand))
           return Kind::Colored;
-      operands.assign(op->operand_begin(), op->operand_end());
       return Kind::LookThrough;
     }
 
@@ -800,7 +800,8 @@ bool ModuleState::isColorless(Value value) {
 
   // Iterative post-order DFS.  Each frame tracks a look-through value (a value
   // whose colorlessness is not yet known) and requires exploring its operands.
-  // This then tracks the operands that should be explored and the index of the
+  // Every look-through op explores all of its operands, so the frame only needs
+  // the value (whose defining op supplies the operands) and the index of the
   // _next_ operand to visit.  A value's colorlessness is the conjunction of its
   // operands' colorlessness.  As soon as a colored operand is found the frame
   // short-circuits to colored.  Since look-through values (constants, nodes,
@@ -812,36 +813,34 @@ bool ModuleState::isColorless(Value value) {
   // nodes.  It is assumed that a post-condition of this pass is that all wires
   // are assigned domains.
   struct Frame {
-    // The lookthrough value.
+    // The lookthrough value whose colorlessness is being resolved.  Its
+    // defining op supplies the operands to explore; every look-through op
+    // explores all of its operands.
     Value value;
-    // The operands to explore.
-    SmallVector<Value, 4> operands;
-    // The operand of the next operand to explored.
+    // The index of the next operand to explore.
     unsigned index = 0;
   };
   SmallVector<Frame> stack;
 
   // Push the first value onto the stack (or exit).
-  {
-    SmallVector<Value, 4> operands;
-    switch (classify(value, operands)) {
-    case Kind::Colored:
-      return colorlessTable[value] = false;
-    case Kind::Colorless:
-      return colorlessTable[value] = true;
-    case Kind::LookThrough:
-      stack.push_back({value, std::move(operands)});
-      break;
-    }
+  switch (classify(value)) {
+  case Kind::Colored:
+    return colorlessTable[value] = false;
+  case Kind::Colorless:
+    return colorlessTable[value] = true;
+  case Kind::LookThrough:
+    stack.push_back({value});
+    break;
   }
 
   // Run the DFS.
   while (!stack.empty()) {
     auto &frame = stack.back();
+    auto *op = frame.value.getDefiningOp();
     bool colored = false, pushed = false;
 
-    while (frame.index < frame.operands.size()) {
-      Value child = frame.operands[frame.index];
+    while (frame.index < op->getNumOperands()) {
+      Value child = op->getOperand(frame.index);
 
       // If already resolved, short-circuit on a colored operand or advance.
       if (auto it = colorlessTable.find(child); it != colorlessTable.end()) {
@@ -856,8 +855,7 @@ bool ModuleState::isColorless(Value value) {
       // Classify the operand.  Classify if not lookthrough.  Otherwise, push
       // the lookthrough operand onto the stack and break so that we descend
       // into it.
-      SmallVector<Value, 4> childOperands;
-      switch (classify(child, childOperands)) {
+      switch (classify(child)) {
       case Kind::Colored:
         colorlessTable[child] = false;
         colored = true;
@@ -867,7 +865,7 @@ bool ModuleState::isColorless(Value value) {
         ++frame.index;
         continue;
       case Kind::LookThrough:
-        stack.push_back({child, std::move(childOperands)});
+        stack.push_back({child});
         pushed = true;
         break;
       }

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -872,6 +872,25 @@ firrtl.circuit "ConstCastPreservesColorless" {
   }
 }
 
+// A domainless unsafe_domain_cast (a pure forwarding cast) preserves the
+// colorlessness of its input, so a constant cast through it may still be used
+// in two different domains.
+// CHECK-LABEL: firrtl.circuit "ForwardingCastPreservesColorless"
+firrtl.circuit "ForwardingCastPreservesColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ForwardingCastPreservesColorless(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %0 = firrtl.unsafe_domain_cast %c1_ui1 domains[] : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
+  }
+}
+
 // specialconstant (e.g. a clock/reset constant) is a colorless root.
 // CHECK-LABEL: firrtl.circuit "SpecialConstantColorless"
 firrtl.circuit "SpecialConstantColorless" {

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -774,3 +774,132 @@ firrtl.circuit "CastConstantNoDomains" {
     firrtl.connect %o, %1 : !firrtl.uint<1>
   }
 }
+
+// A node bound to a constant is colorless and may be used in two different
+// domains.
+// CHECK-LABEL: firrtl.circuit "ConstantNodeTwoDomains"
+firrtl.circuit "ConstantNodeTwoDomains" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ConstantNodeTwoDomains(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %x = firrtl.node %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %x : !firrtl.uint<1>
+  }
+}
+
+// A node bound to a constant *expression* (not just a bare constant) may
+// also be used in two different domains.
+// CHECK-LABEL: firrtl.circuit "ConstantExprNodeTwoDomains"
+firrtl.circuit "ConstantExprNodeTwoDomains" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ConstantExprNodeTwoDomains(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %0 = firrtl.eq %c1_ui1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %x = firrtl.node %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %x : !firrtl.uint<1>
+  }
+}
+
+// A deeply nested constant expression is still colorless and can be used
+// across multiple domains.
+// CHECK-LABEL: firrtl.circuit "DeeplyNestedConstantExpr"
+firrtl.circuit "DeeplyNestedConstantExpr" {
+  firrtl.domain @ClockDomain
+  firrtl.module @DeeplyNestedConstantExpr(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<4> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<4> domains [%B]
+  ) {
+    %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
+    %c2_ui4 = firrtl.constant 2 : !firrtl.uint<4>
+    %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %0 = firrtl.mux(%c0_ui1, %c2_ui4, %c3_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+    %1 = firrtl.add %c1_ui4, %0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %2 = firrtl.bits %1 3 to 0 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+    %3 = firrtl.not %2 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+    firrtl.matchingconnect %a, %3 : !firrtl.uint<4>
+    firrtl.matchingconnect %b, %3 : !firrtl.uint<4>
+  }
+}
+
+// A colorless subexpression mixed with a colored operand takes on the
+// operand's color: the result is usable wherever the colored operand's
+// domain is legal, but no longer colorless.
+// CHECK-LABEL: firrtl.circuit "ColorlessMixedWithColoredAdoptsColor"
+firrtl.circuit "ColorlessMixedWithColoredAdoptsColor" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ColorlessMixedWithColoredAdoptsColor(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    in %x: !firrtl.uint<1> domains [%A],
+    // CHECK: out %y: !firrtl.uint<1> domains [%A]
+    out %y: !firrtl.uint<1>
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %0 = firrtl.not %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.eq %0, %x : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.matchingconnect %y, %1 : !firrtl.uint<1>
+  }
+}
+
+// constCast of a constant preserves colorlessness.
+// CHECK-LABEL: firrtl.circuit "ConstCastPreservesColorless"
+firrtl.circuit "ConstCastPreservesColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ConstCastPreservesColorless(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.const.uint<1>
+    %0 = firrtl.constCast %c1_ui1 : (!firrtl.const.uint<1>) -> !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
+  }
+}
+
+// specialconstant (e.g. a clock/reset constant) is a colorless root.
+// CHECK-LABEL: firrtl.circuit "SpecialConstantColorless"
+firrtl.circuit "SpecialConstantColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @SpecialConstantColorless(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.clock domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.clock domains [%B]
+  ) {
+    %c = firrtl.specialconstant 0 : !firrtl.clock
+    firrtl.matchingconnect %a, %c : !firrtl.clock
+    firrtl.matchingconnect %b, %c : !firrtl.clock
+  }
+}
+
+// aggregateconstant is a colorless root.
+// CHECK-LABEL: firrtl.circuit "AggregateConstantColorless"
+firrtl.circuit "AggregateConstantColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @AggregateConstantColorless(
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.bundle<x: uint<1>> domains [%A],
+    in %B: !firrtl.domain<@ClockDomain()>,
+    out %b: !firrtl.bundle<x: uint<1>> domains [%B]
+  ) {
+    %c = firrtl.aggregateconstant [1 : ui1] : !firrtl.bundle<x: uint<1>>
+    firrtl.matchingconnect %a, %c : !firrtl.bundle<x: uint<1>>
+    firrtl.matchingconnect %b, %c : !firrtl.bundle<x: uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-all.mlir
@@ -605,7 +605,7 @@ firrtl.circuit "ReUseAnonDomain" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: %ClockDomain = firrtl.domain.anon
     // CHECK: %PowerDomain = firrtl.domain.anon
-    // CHECK: %w1 = firrtl.wire domains[%ClockDomain, %PowerDomain] 
+    // CHECK: %w1 = firrtl.wire domains[%ClockDomain, %PowerDomain]
     %w1 = firrtl.wire : !firrtl.uint<1>
     // CHECK: %w2 = firrtl.wire domains[%ClockDomain, %PowerDomain]
     %w2 = firrtl.wire : !firrtl.uint<1>
@@ -793,8 +793,8 @@ firrtl.circuit "ConstantNodeTwoDomains" {
   }
 }
 
-// A node bound to a constant *expression* (not just a bare constant) may
-// also be used in two different domains.
+// A node bound to a constant _expression_ (not just a bare constant) may also
+// be used in two different domains.
 // CHECK-LABEL: firrtl.circuit "ConstantExprNodeTwoDomains"
 firrtl.circuit "ConstantExprNodeTwoDomains" {
   firrtl.domain @ClockDomain
@@ -856,6 +856,10 @@ firrtl.circuit "ColorlessMixedWithColoredAdoptsColor" {
 }
 
 // constCast of a constant preserves colorlessness.
+//
+// Note: this is expected to be removed by this point in the pipeline, but test
+// that it works anyway.
+//
 // CHECK-LABEL: firrtl.circuit "ConstCastPreservesColorless"
 firrtl.circuit "ConstCastPreservesColorless" {
   firrtl.domain @ClockDomain

--- a/test/Dialect/FIRRTL/infer-domains-infer-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-errors.mlir
@@ -52,3 +52,147 @@ firrtl.circuit "IllegalDomainCrossing" {
     firrtl.matchingconnect %b, %a : !firrtl.uint<1>
   }
 }
+
+// Negative colorless case: two genuinely different colors combined through an
+// otherwise-colorless-looking add is still an illegal crossing (neither
+// operand is actually colorless).
+
+// CHECK-LABEL: TwoColorsStillError
+firrtl.circuit "TwoColorsStillError" {
+  firrtl.domain @ClockDomain
+  firrtl.module @TwoColorsStillError(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{a has domains [A : ClockDomain]}}
+    in %a: !firrtl.uint<4> domains [%A],
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    in %b: !firrtl.uint<4> domains [%B],
+    out %c: !firrtl.uint<5> domains [%A]
+  ) {
+    // expected-error @below {{illegal domain crossing in operation}}
+    %0 = firrtl.add %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    firrtl.matchingconnect %c, %0 : !firrtl.uint<5>
+  }
+}
+
+// Negative colorless case: a value that mixes a colored operand with a
+// colorless one is colored, not colorless, and still conflicts when used in
+// a different domain.
+
+// CHECK-LABEL: ColorlessPlusColoredStillError
+firrtl.circuit "ColorlessPlusColoredStillError" {
+  firrtl.domain @ClockDomain
+  firrtl.module @ColorlessPlusColoredStillError(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    in %x: !firrtl.uint<1> domains [%A],
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %y = firrtl.node %c1_ui1 : !firrtl.uint<1>
+    // expected-note @below {{%0 has domains [A : ClockDomain]}}
+    %0 = firrtl.eq %x, %y : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
+  }
+}
+
+// Negative colorless case: a public output port driven by a pure constant
+// still requires an explicit domain association.
+
+// CHECK-LABEL: PublicPortConstantStillMissing
+firrtl.circuit "PublicPortConstantStillMissing" {
+  firrtl.domain @ClockDomain
+  // expected-note @below {{in module "PublicPortConstantStillMissing"}}
+  firrtl.module @PublicPortConstantStillMissing(
+    // expected-error @below {{missing "ClockDomain" association for port "a"}}
+    out %a: !firrtl.uint<1>
+  ) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %c1_ui1 : !firrtl.uint<1>
+  }
+}
+
+// Robustness: an undriven wire is colored (it is not colorless) and still
+// errors when used in two different domains.
+
+// CHECK-LABEL: UndrivenWireNotColorless
+firrtl.circuit "UndrivenWireNotColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @UndrivenWireNotColorless(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<1> domains [%B],
+    out %a: !firrtl.uint<1> domains [%A]
+  ) {
+    // expected-note @below {{w has domains [A : ClockDomain]}}
+    %w = firrtl.wire : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %w : !firrtl.uint<1>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %w : !firrtl.uint<1>
+  }
+}
+
+// Robustness: invalidvalue is not constant-like (it is a fresh unique value
+// on every use) and must not be treated as colorless.
+
+// CHECK-LABEL: InvalidValueNotColorless
+firrtl.circuit "InvalidValueNotColorless" {
+  firrtl.domain @ClockDomain
+  firrtl.module @InvalidValueNotColorless(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<1> domains [%A],
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<1> domains [%B]
+  ) {
+    // expected-note @below {{%invalid_ui1 has domains [A : ClockDomain]}}
+    %0 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
+  }
+}
+
+// Cross-module colorless propagation is out of scope: a private module whose
+// output is a purely-constant expression is *not* treated as colorless at its
+// instantiation sites, so this still errors.
+
+// CHECK-LABEL: PrivateModuleConstantOutputStillErrors
+firrtl.circuit "PrivateModuleConstantOutputStillErrors" {
+  firrtl.domain @ClockDomain
+
+  firrtl.module private @Bar(out %o: !firrtl.uint<4>) {
+    %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
+    %c2_ui4 = firrtl.constant 2 : !firrtl.uint<4>
+    %0 = firrtl.add %c1_ui4, %c2_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %1 = firrtl.bits %0 3 to 0 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+    firrtl.matchingconnect %o, %1 : !firrtl.uint<4>
+  }
+
+  firrtl.module @PrivateModuleConstantOutputStillErrors(
+    // expected-note @below {{input module port A declared here}}
+    in %A: !firrtl.domain<@ClockDomain()>,
+    out %a: !firrtl.uint<4> domains [%A],
+    // expected-note @below {{input module port B declared here}}
+    in %B: !firrtl.domain<@ClockDomain()>,
+    // expected-note @below {{b has domains [B : ClockDomain]}}
+    out %b: !firrtl.uint<4> domains [%B]
+  ) {
+    // expected-note @below {{bar.o has domains [A : ClockDomain]}}
+    %bar_o = firrtl.instance bar @Bar(out o: !firrtl.uint<4>)
+    firrtl.matchingconnect %a, %bar_o : !firrtl.uint<4>
+    // expected-error @below {{illegal domain crossing in operation}}
+    firrtl.matchingconnect %b, %bar_o : !firrtl.uint<4>
+  }
+}

--- a/test/Dialect/FIRRTL/infer-domains-infer-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-infer-errors.mlir
@@ -53,33 +53,8 @@ firrtl.circuit "IllegalDomainCrossing" {
   }
 }
 
-// Negative colorless case: two genuinely different colors combined through an
-// otherwise-colorless-looking add is still an illegal crossing (neither
-// operand is actually colorless).
-
-// CHECK-LABEL: TwoColorsStillError
-firrtl.circuit "TwoColorsStillError" {
-  firrtl.domain @ClockDomain
-  firrtl.module @TwoColorsStillError(
-    // expected-note @below {{input module port A declared here}}
-    in %A: !firrtl.domain<@ClockDomain()>,
-    // expected-note @below {{input module port B declared here}}
-    in %B: !firrtl.domain<@ClockDomain()>,
-    // expected-note @below {{a has domains [A : ClockDomain]}}
-    in %a: !firrtl.uint<4> domains [%A],
-    // expected-note @below {{b has domains [B : ClockDomain]}}
-    in %b: !firrtl.uint<4> domains [%B],
-    out %c: !firrtl.uint<5> domains [%A]
-  ) {
-    // expected-error @below {{illegal domain crossing in operation}}
-    %0 = firrtl.add %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
-    firrtl.matchingconnect %c, %0 : !firrtl.uint<5>
-  }
-}
-
-// Negative colorless case: a value that mixes a colored operand with a
-// colorless one is colored, not colorless, and still conflicts when used in
-// a different domain.
+// A value that mixes a colored operand with a colorless one is colored, not
+// colorless, and still conflicts when used in a different domain.
 
 // CHECK-LABEL: ColorlessPlusColoredStillError
 firrtl.circuit "ColorlessPlusColoredStillError" {
@@ -102,8 +77,8 @@ firrtl.circuit "ColorlessPlusColoredStillError" {
   }
 }
 
-// Negative colorless case: a public output port driven by a pure constant
-// still requires an explicit domain association.
+// A public output port driven by a pure constant still requires an explicit
+// domain association.
 
 // CHECK-LABEL: PublicPortConstantStillMissing
 firrtl.circuit "PublicPortConstantStillMissing" {
@@ -118,8 +93,8 @@ firrtl.circuit "PublicPortConstantStillMissing" {
   }
 }
 
-// Robustness: an undriven wire is colored (it is not colorless) and still
-// errors when used in two different domains.
+// An undriven wire is colored (it is not colorless) and still errors when used
+// in two different domains.
 
 // CHECK-LABEL: UndrivenWireNotColorless
 firrtl.circuit "UndrivenWireNotColorless" {
@@ -141,8 +116,8 @@ firrtl.circuit "UndrivenWireNotColorless" {
   }
 }
 
-// Robustness: invalidvalue is not constant-like (it is a fresh unique value
-// on every use) and must not be treated as colorless.
+// Invalidvalue is not constant-like (it is a fresh unique value on every use)
+// and must not be treated as colorless.
 
 // CHECK-LABEL: InvalidValueNotColorless
 firrtl.circuit "InvalidValueNotColorless" {
@@ -165,7 +140,7 @@ firrtl.circuit "InvalidValueNotColorless" {
 }
 
 // Cross-module colorless propagation is out of scope: a private module whose
-// output is a purely-constant expression is *not* treated as colorless at its
+// output is a purely-constant expression is _not_ treated as colorless at its
 // instantiation sites, so this still errors.
 
 // CHECK-LABEL: PrivateModuleConstantOutputStillErrors

--- a/test/firtool/domains-colorless.fir
+++ b/test/firtool/domains-colorless.fir
@@ -1,4 +1,3 @@
-; RUN: firtool %s -domain-mode=infer -o /dev/null
 ; RUN: firtool %s -domain-mode=infer -output-final-mlir - -o /dev/null | FileCheck %s
 
 ; Reproducer for llvm/circt#10830: a constant, or an expression fully composed

--- a/test/firtool/domains-colorless.fir
+++ b/test/firtool/domains-colorless.fir
@@ -1,0 +1,37 @@
+; RUN: firtool %s -domain-mode=infer -o /dev/null
+; RUN: firtool %s -domain-mode=infer -output-final-mlir - -o /dev/null | FileCheck %s
+
+; Reproducer for llvm/circt#10830: a constant, or an expression fully composed
+; of constants, is colorless and may be consumed by values in two different
+; domains without being treated as an illegal domain crossing.
+;
+;   - `x` is a node bound directly to a constant.
+;   - `y` is a node bound to a constant *expression* (not just a bare
+;     constant).
+;
+; Both are used across two distinct domains A and B.
+
+FIRRTL version 7.0.0
+circuit Foo:
+
+  domain ClockDomain:
+
+  public module Foo:
+    input A: Domain of ClockDomain
+    input B: Domain of ClockDomain
+    output a: UInt<1> domains [A]
+    output b: UInt<1> domains [B]
+    output c: UInt<1> domains [A]
+    output d: UInt<1> domains [B]
+
+    ; Bare constant used in two domains.
+    node x = UInt<1>(1)
+    connect a, x
+    connect b, x
+
+    ; Constant expression used in two domains.
+    node y = eq(UInt<1>(1), UInt<1>(1))
+    connect c, y
+    connect d, y
+
+; CHECK-LABEL: om.class @Foo_Class


### PR DESCRIPTION
Improve FIRRTL's `InferDomains` support for _not_ inferring domains on
constants.  Previously, only literal constants (`ConstantLike`) would be
excluded from domain inference.  Expand this to allow nodes and primitive
operations that are only fed with constants to be determined to be
constant and also excluded from domain inference.

This is likely an incomplete solution as we may want to expand the
definition of what is constant to include wires and ports.  However, this
is a start to get things better than what they were before.

Fixes #10830.

Assisted-by: pi.dev:claude-opus-4-8
