### PR TITLE
[RTG] Add StringToASCIIArrayOp

### DIFF
--- a/frontends/PyRTG/src/pyrtg/strings.py
+++ b/frontends/PyRTG/src/pyrtg/strings.py
@@ -8,7 +8,10 @@ from .base import ir
 from .core import Value, Type
 from .rtg import rtg
 
-from typing import Union
+from typing import Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from .arrays import Array
 
 
 class String(Value):
@@ -68,6 +71,14 @@ class String(Value):
       result.append(convert_to_string(arg))
 
     return rtg.StringConcatOp(result)
+
+  def to_ascii_array(self) -> Array:
+    """
+    Decomposes this string into an array of 8-bit ASCII immediates, one per
+    byte.
+    """
+
+    return rtg.StringToASCIIArrayOp(self)
 
   def get_type(self) -> Type:
     return StringType()

--- a/frontends/PyRTG/test/basic.py
+++ b/frontends/PyRTG/test/basic.py
@@ -573,3 +573,16 @@ def test96_float_registers(config):
 
   vreg = FloatRegister.virtual()
   vreg.to_string()
+
+
+# ASM-LABEL: Begin of test 'test97_string_to_ascii_array
+# ASM-NEXT: # byte0=0x68{{$}}
+# ASM-NEXT: # byte1=0x69{{$}}
+# ASM: End of test 'test97_string_to_ascii_array
+
+
+@test(Singleton)
+def test97_string_to_ascii_array(config):
+  arr = String("hi").to_ascii_array()
+  embed_comment(String("byte0=") + arr[0].to_string())
+  embed_comment(String("byte1=") + arr[1].to_string())

--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -288,6 +288,21 @@ def StringToLabelOp : RTGOp<"string_to_label", [Pure]> {
   let hasFolder = 1;
 }
 
+def StringToASCIIArrayOp : RTGOp<"string_to_ascii_array", [Pure]> {
+  let summary = "converts a string to an array of 8-bit ASCII immediates";
+  let description = [{
+    This operation decomposes a string into an array of 8-bit immediates, one
+    per byte, in the same order as the string. No NULL terminator is appended.
+  }];
+
+  let arguments = (ins StringType:$string);
+  let results = (outs ArrayTypeOf<I8>:$result);
+
+  let assemblyFormat = "$string `:` qualified(type($result)) attr-dict";
+
+  let hasCanonicalizeMethod = 1;
+}
+
 def LabelVisibilityAttr : I32EnumAttr<"LabelVisibility",
                                       "visibility specifiers for labels", [
   I32EnumAttrCase<"local",  0>,

--- a/include/circt/Dialect/RTG/IR/RTGTypes.td
+++ b/include/circt/Dialect/RTG/IR/RTGTypes.td
@@ -148,6 +148,13 @@ def ArrayType : RTGTypeDef<"Array"> {
   ];
 }
 
+class ArrayTypeOf<Type elementType> : ContainerType<
+  elementType, ArrayType.predicate,
+  "llvm::cast<rtg::ArrayType>($_self).getElementType()", "array">,
+  SameBuildabilityAs<elementType,
+    "::circt::rtg::ArrayType::get($_builder.getContext(), " #
+    elementType.builderCall # ")">;
+
 def MapType : RTGTypeDef<"Map"> {
   let summary = "a map from keys to values";
   let description = [{

--- a/include/circt/Dialect/RTG/IR/RTGVisitors.h
+++ b/include/circt/Dialect/RTG/IR/RTGVisitors.h
@@ -64,6 +64,7 @@ public:
             SpaceOp, StringDataOp, SegmentOp,
             // String ops
             StringConcatOp, IntFormatOp, ImmediateFormatOp, RegisterFormatOp,
+            StringToASCIIArrayOp,
             // Misc ops
             CommentOp, ConstraintOp, RandomScopeOp>(
             [&](auto expr) -> ResultType {
@@ -156,6 +157,7 @@ public:
   HANDLE(ImmediateFormatOp, Unhandled);
   HANDLE(RegisterFormatOp, Unhandled);
   HANDLE(StringToLabelOp, Unhandled);
+  HANDLE(StringToASCIIArrayOp, Unhandled);
   HANDLE(RandomScopeOp, Unhandled);
 #undef HANDLE
 };

--- a/lib/Dialect/RTG/IR/RTGOps.cpp
+++ b/lib/Dialect/RTG/IR/RTGOps.cpp
@@ -1040,6 +1040,31 @@ OpFoldResult StringToLabelOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// StringToASCIIArrayOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult StringToASCIIArrayOp::canonicalize(StringToASCIIArrayOp op,
+                                                 PatternRewriter &rewriter) {
+  auto constOp = op.getString().getDefiningOp<ConstantOp>();
+  if (!constOp)
+    return failure();
+
+  auto strAttr = dyn_cast<StringAttr>(constOp.getValue());
+  if (!strAttr)
+    return failure();
+
+  auto i8Ty = rewriter.getIntegerType(8);
+  SmallVector<Value> bytes;
+  bytes.reserve(strAttr.getValue().size());
+  for (unsigned char c : strAttr.getValue())
+    bytes.push_back(ConstantOp::create(rewriter, op.getLoc(),
+                                       rewriter.getIntegerAttr(i8Ty, c)));
+
+  rewriter.replaceOpWithNewOp<ArrayCreateOp>(op, op.getType(), bytes);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
@@ -1827,6 +1827,26 @@ public:
     return DeletionKind::Delete;
   }
 
+  FailureOr<DeletionKind> visitOp(StringToASCIIArrayOp op) {
+    auto opaque = state.at(op.getString());
+    if (isSymbolic(opaque))
+      return visitOpGeneric(op);
+
+    auto strAttr = dyn_cast<StringAttr>(std::get<TypedAttr>(opaque));
+    if (!strAttr)
+      return op->emitError("expected a string attribute");
+
+    auto i8Ty = IntegerType::get(op.getContext(), 8);
+    SmallVector<ElaboratorValue> array;
+    array.reserve(strAttr.getValue().size());
+    for (unsigned char c : strAttr.getValue())
+      array.push_back(ElaboratorValue(IntegerAttr::get(i8Ty, c)));
+
+    state[op.getResult()] = sharedState.internalizer.internalize<ArrayStorage>(
+        op.getResult().getType(), std::move(array));
+    return DeletionKind::Delete;
+  }
+
   FailureOr<DeletionKind> visitOp(ArrayExtractOp op) {
     auto array = get<ArrayStorage *>(op.getArray())->array;
     size_t idx = get<size_t>(op.getIndex());

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -343,6 +343,9 @@ rtg.test @strings() {
 
   // CHECK-NEXT: rtg.string_concat
   rtg.string_concat
+
+  // CHECK-NEXT: rtg.string_to_ascii_array [[V0]] : !rtg.array<i8>
+  rtg.string_to_ascii_array %0 : !rtg.array<i8>
 }
 
 // CHECK-LABEL: rtg.test @registerConversion

--- a/test/Dialect/RTG/IR/canonicalization.mlir
+++ b/test/Dialect/RTG/IR/canonicalization.mlir
@@ -3,6 +3,7 @@
 func.func @dummy(%arg0: !rtg.isa.label) -> () {return}
 func.func @dummy1(%arg0: !rtg.string) -> () {return}
 func.func @dummy2(%arg0: !rtg.array<index>) -> () {return}
+func.func @dummy3(%arg0: !rtg.array<i8>) -> () {return}
 func.func @dummy6(%arg0: index) -> () {return}
 func.func @dummy7(%arg0: !rtgtest.ireg) -> () {return}
 
@@ -94,6 +95,22 @@ rtg.test @arrays() {
   %3 = rtg.array_create %idx1, %idx1 : index
   %4 = rtg.array_append %3, %idx1 : !rtg.array<index>
   func.call @dummy2(%4) : (!rtg.array<index>) -> ()
+}
+
+// CHECK-LABEL: @stringToASCIIArray
+rtg.test @stringToASCIIArray(str = %str: !rtg.string) {
+  // CHECK-NEXT: [[C104:%.+]] = rtg.constant 104 : i8
+  // CHECK-NEXT: [[C105:%.+]] = rtg.constant 105 : i8
+  // CHECK-NEXT: [[V0:%.+]] = rtg.array_create [[C104]], [[C105]] : i8
+  // CHECK-NEXT: func.call @dummy3([[V0]])
+  %0 = rtg.constant "hi" : !rtg.string
+  %1 = rtg.string_to_ascii_array %0 : !rtg.array<i8>
+  func.call @dummy3(%1) : (!rtg.array<i8>) -> ()
+
+  // CHECK-NEXT: [[V1:%.+]] = rtg.string_to_ascii_array %str : !rtg.array<i8>
+  // CHECK-NEXT: func.call @dummy3([[V1]])
+  %2 = rtg.string_to_ascii_array %str : !rtg.array<i8>
+  func.call @dummy3(%2) : (!rtg.array<i8>) -> ()
 }
 
 // CHECK-LABEL: @testRegisterToIndex

--- a/test/Dialect/RTG/IR/errors.mlir
+++ b/test/Dialect/RTG/IR/errors.mlir
@@ -337,3 +337,10 @@ rtg.test @setAttrExplicitTypeRequired() {
   // expected-error @below {{all elements must be of the set element type 'i32'}}
   rtg.constant #rtg.set<0 : index> : !rtg.set<i32>
 }
+
+// -----
+
+rtg.test @stringToASCIIArrayWrongElementType(str = %str: !rtg.string) {
+  // expected-error @below {{must be array of 8-bit signless integer values}}
+  rtg.string_to_ascii_array %str : !rtg.array<i16>
+}

--- a/test/Dialect/RTG/Transform/elaboration.mlir
+++ b/test/Dialect/RTG/Transform/elaboration.mlir
@@ -18,6 +18,8 @@ func.func @dummy15(%arg0: i32) -> () {return}
 func.func @dummy16(%arg0: i12) -> () {return}
 func.func @dummy17(%arg0: i3) -> () {return}
 func.func @dummy18(%arg0: !rtg.string) -> () {return}
+func.func @dummy19(%arg0: i8) -> () {return}
+func.func @dummy20(%arg0: !rtg.array<i8>) -> () {return}
 func.func @dummy_reg(%arg0: !rtgtest.ireg) -> () {return}
 
 rtg.target @singletonTarget : !rtg.dict<singleton: index> {
@@ -1095,6 +1097,44 @@ rtg.test @strings(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = rtg.constant "hello4" : !rtg.string
   // CHECK-NEXT: func.call @dummy18([[V0]])
   func.call @dummy18(%5) : (!rtg.string) -> ()
+}
+
+// CHECK-LABEL: rtg.test @stringToASCIIArray
+rtg.test @stringToASCIIArray(singleton = %none: index) {
+  %idx0 = index.constant 0
+  %idx1 = index.constant 1
+  %0 = rtg.constant "hi" : !rtg.string
+  %1 = rtg.string_to_ascii_array %0 : !rtg.array<i8>
+
+  // CHECK-NEXT: [[C104:%.+]] = rtg.constant 104 : i8
+  // CHECK-NEXT: func.call @dummy19([[C104]])
+  %2 = rtg.array_extract %1[%idx0] : !rtg.array<i8>
+  func.call @dummy19(%2) : (i8) -> ()
+
+  // CHECK-NEXT: [[C105:%.+]] = rtg.constant 105 : i8
+  // CHECK-NEXT: func.call @dummy19([[C105]])
+  %3 = rtg.array_extract %1[%idx1] : !rtg.array<i8>
+  func.call @dummy19(%3) : (i8) -> ()
+
+  // CHECK-NEXT: [[SZ:%.+]] = rtg.constant 2 : index
+  // CHECK-NEXT: func.call @dummy2([[SZ]])
+  %4 = rtg.array_size %1 : !rtg.array<i8>
+  func.call @dummy2(%4) : (index) -> ()
+}
+
+// CHECK-LABEL: rtg.test @stringToASCIIArraySymbolic
+rtg.test @stringToASCIIArraySymbolic(singleton = %none: index) {
+  // A virtual register is not known concretely during elaboration, so the
+  // string it formats to, and thus the array derived from it, must stay
+  // symbolic instead of being decomposed into concrete byte constants.
+  // CHECK-NEXT: [[REG:%.+]] = rtg.virtual_reg [#rtgtest.a0 : !rtgtest.ireg, #rtgtest.a1 : !rtgtest.ireg]
+  %reg = rtg.virtual_reg [#rtgtest.a0, #rtgtest.a1]
+  // CHECK-NEXT: [[STR:%.+]] = rtg.register_format [[REG]] : !rtgtest.ireg
+  %str = rtg.register_format %reg : !rtgtest.ireg
+  // CHECK-NEXT: [[ARR:%.+]] = rtg.string_to_ascii_array [[STR]] : !rtg.array<i8>
+  %arr = rtg.string_to_ascii_array %str : !rtg.array<i8>
+  // CHECK-NEXT: func.call @dummy20([[ARR]])
+  func.call @dummy20(%arr) : (!rtg.array<i8>) -> ()
 }
 
 // CHECK-LABEL: rtg.test @attributeToElabValueConversion


### PR DESCRIPTION
Useful when we want to use assembly store operations to store a string to a memory location.
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
Assisted-by: Claude Code: Sonnet 5 [1M]