### PR TITLE
verif: relax hardware-port check for simulation targets

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -261,6 +261,9 @@ mlir::Type getPassiveType(mlir::Type anyBaseFIRRTLType);
 /// analog types. Non-HW types (e.g., ref types) are never considered InOut.
 bool isTypeInOut(mlir::Type type);
 
+/// Return true if the given type contains any elements of hardware types.
+bool hasHardwareElements(FIRRTLType type);
+
 //===----------------------------------------------------------------------===//
 // Width Qualified Ground Types
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3915,9 +3915,9 @@ SimulationOp::verifySymbolUses(mlir::SymbolTableCollection &symbolTable) {
   // Additional non-hardware ports are allowed.
   for (unsigned i = 4; i < numPorts; ++i) {
     auto type = module.getPortType(i);
-    if (!isa<PropertyType>(type))
-      return complain() << "port " << i << " may only be a property type, got "
-                        << type << " instead";
+    auto firrtlType = type_dyn_cast<FIRRTLType>(type);
+    if (!firrtlType || hasHardwareElements(firrtlType))
+      return complain() << "port " << i << " contains hardware types: " << type;
   }
 
   return success();

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1317,6 +1317,21 @@ bool firrtl::isTypeInOut(Type type) {
       .Default(false);
 }
 
+// NOLINTBEGIN(misc-no-recursion)
+bool firrtl::hasHardwareElements(FIRRTLType type) {
+  // Is a hardware base type
+  if (isa<FIRRTLBaseType>(type))
+    return true;
+  // Check each element of the aggregate
+  if (auto bundle = dyn_cast<OpenBundleType>(type))
+    return llvm::any_of(
+        bundle, [](auto elt) { return hasHardwareElements(elt.type); });
+  if (auto vector = dyn_cast<OpenVectorType>(type))
+    return hasHardwareElements(vector.getElementType());
+  return false;
+}
+// NOLINTEND(misc-no-recursion)
+
 //===----------------------------------------------------------------------===//
 // IntType
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1324,8 +1324,8 @@ bool firrtl::hasHardwareElements(FIRRTLType type) {
     return true;
   // Check each element of the aggregate
   if (auto bundle = dyn_cast<OpenBundleType>(type))
-    return llvm::any_of(
-        bundle, [](auto elt) { return hasHardwareElements(elt.type); });
+    return llvm::any_of(bundle,
+                        [](auto elt) { return hasHardwareElements(elt.type); });
   if (auto vector = dyn_cast<OpenVectorType>(type))
     return hasHardwareElements(vector.getElementType());
   return false;

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2973,6 +2973,22 @@ firrtl.circuit "SimulationExtraHardwarePort" {
 
 // -----
 
+firrtl.circuit "SimulationExtraHardwareInBundlePort" {
+  firrtl.extmodule @SimulationExtraHardwareInBundlePort()
+  // expected-error @below {{op target @Foo port 4 may only be a property type, got '!firrtl.openbundle<x: uint<8>>' instead}}
+  firrtl.simulation @foo, @Foo {}
+  // expected-note @below {{target defined here}}
+  firrtl.extmodule @Foo(
+    in clock: !firrtl.clock,
+    in init: !firrtl.uint<1>,
+    out done: !firrtl.uint<1>,
+    out success: !firrtl.uint<1>,
+    out extra: !firrtl.openbundle<x: uint<8>>
+  )
+}
+
+// -----
+
 firrtl.circuit "BindTargetMissingModule" {
   firrtl.module @BindTargetMissing() {}
   // expected-error @below {{target #hw.innerNameRef<@XXX::@YYY> cannot be resolved}}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2959,7 +2959,7 @@ firrtl.circuit "SimulationPortType3" {
 
 firrtl.circuit "SimulationExtraHardwarePort" {
   firrtl.extmodule @SimulationExtraHardwarePort()
-  // expected-error @below {{op target @Foo port 4 may only be a property type, got '!firrtl.uint<8>' instead}}
+  // expected-error @below {{op target @Foo port 4 contains hardware types: '!firrtl.uint<8>'}}
   firrtl.simulation @foo, @Foo {}
   // expected-note @below {{target defined here}}
   firrtl.extmodule @Foo(
@@ -2975,7 +2975,7 @@ firrtl.circuit "SimulationExtraHardwarePort" {
 
 firrtl.circuit "SimulationExtraHardwareInBundlePort" {
   firrtl.extmodule @SimulationExtraHardwareInBundlePort()
-  // expected-error @below {{op target @Foo port 4 may only be a property type, got '!firrtl.openbundle<x: uint<8>>' instead}}
+  // expected-error @below {{op target @Foo port 4 contains hardware types: '!firrtl.openbundle<x: uint<8>>'}}
   firrtl.simulation @foo, @Foo {}
   // expected-note @below {{target defined here}}
   firrtl.extmodule @Foo(

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -236,6 +236,19 @@ firrtl.extmodule @SimulationTopWithProps(
   out anotherProp: !firrtl.integer
 )
 
+// Simulation targets may have additional ports that are composed only
+// of non-hardware types
+firrtl.simulation @mySimulationTestWithPropAgg, @SimulationTopWithPropAgg {}
+
+firrtl.extmodule @SimulationTopWithPropAgg(
+  in clock: !firrtl.clock,
+  in init: !firrtl.uint<1>,
+  out done: !firrtl.uint<1>,
+  out success: !firrtl.uint<1>,
+  out status: !firrtl.openbundle<flag: bool, label: string>,
+  out listOfProps: !firrtl.openvector<string, 2>
+)
+
 firrtl.module @Contracts(in %a: !firrtl.uint<42>, in %b: !firrtl.bundle<x: uint<1337>>) {
   firrtl.contract {}
   firrtl.contract %a, %b : !firrtl.uint<42>, !firrtl.bundle<x: uint<1337>> {


### PR DESCRIPTION
Assisted-by: GLM 5.2

https://github.com/llvm/circt/pull/9462 attempted to allow non-hardware (specifically, property) type ports after the contractual first four ports of a simulation target. This allowed property base types, but did not account for aggregates of non-hardware types.
