### PR TITLE
[ImportVerilog][MooreToCore] Add support for bit extraction on packed structs

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -291,10 +291,18 @@ struct ExprVisitor {
 
     if (!isa<moore::IntType, moore::ArrayType, moore::UnpackedArrayType,
              moore::QueueType, moore::AssocArrayType, moore::StringType,
-             moore::OpenUnpackedArrayType>(derefType)) {
+             moore::OpenUnpackedArrayType, moore::StructType, moore::UnionType>(
+            derefType)) {
       mlir::emitError(loc) << "unsupported expression: element select into "
                            << expr.value().type->toString() << "\n";
       return {};
+    }
+
+    if (!isLvalue && isa<moore::StructType, moore::UnionType>(derefType)) {
+      value = context.convertToSimpleBitVector(value);
+      if (!value)
+        return {};
+      derefType = value.getType();
     }
 
     // Associative Arrays are a special case so handle them separately.
@@ -439,6 +447,12 @@ struct ExprVisitor {
     if (isa<moore::QueueType>(derefType)) {
       return handleQueueRangeSelectExpressions(expr, type, value);
     }
+    if (!isLvalue && isa<moore::StructType, moore::UnionType>(derefType)) {
+      value = context.convertToSimpleBitVector(value);
+      if (!value)
+        return {};
+    }
+
     return handleArrayRangeSelectExpressions(expr, type, value);
   }
 

--- a/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
+++ b/lib/Dialect/Moore/Transforms/SimplifyRefs.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the SimplifyRefs pass.
-// It has two purposes:
+// It has three purposes:
 // - To disassemble the moore.concat_ref. Which is tricky to lower
 // directly. For example, disassemble "{a, b} = c" onto "a = c[7:3]"
 // and "b = c[2:0]".
@@ -15,6 +15,9 @@
 // immediately has a value assigned via blocking assignment, replacing it with
 // moore.queue.set. Queue element references are tricky to lower into LLHD,
 // so it's best to get rid of them.
+// - To rewrite assignments to ExtractOp expressions on a packed struct,
+// e.g. "s[7:0] = v", into an assignment to a concatenation of the struct's
+// (possibly further sliced) fields.
 //
 //===----------------------------------------------------------------------===//
 
@@ -97,6 +100,131 @@ struct ConcatRefLowering : public OpConversionPattern<OpTy> {
   }
 };
 
+struct FieldInfo {
+  Value field = nullptr;
+  uint32_t size = 0;
+  uint32_t offset = 0;
+};
+
+// A helper function that recursively collects the members of a struct.
+static LogicalResult collectFields(Value structRef,
+                                   SmallVector<FieldInfo> &fields,
+                                   ConversionPatternRewriter &rewriter,
+                                   uint32_t initialOffset = 0) {
+  auto structType =
+      cast<StructType>(cast<RefType>(structRef.getType()).getNestedType());
+  uint32_t offset = initialOffset;
+  // Visit fields in reverse order (declaration order is MSB-first)
+  for (auto &member : llvm::reverse(structType.getMembers())) {
+    auto fieldRef = StructExtractRefOp::create(rewriter, structRef.getLoc(),
+                                               RefType::get(member.type),
+                                               member.name, structRef);
+
+    auto fieldSize = member.type.getBitSize();
+    if (!fieldSize)
+      return mlir::emitError(structRef.getLoc())
+             << "unsupported: field with unknown size in struct flattening";
+
+    if (isa<StructType>(member.type)) {
+      auto result = collectFields(fieldRef, fields, rewriter, offset);
+      if (failed(result))
+        return result;
+    } else if (isa<UnionType>(member.type)) {
+      return mlir::emitError(structRef.getLoc())
+             << "unsupported: union member in struct flattening";
+    } else {
+      fields.push_back({fieldRef, *fieldSize, offset});
+    }
+    offset += *fieldSize;
+  }
+  return success();
+}
+
+template <typename OpTy>
+struct StructExtractLowering : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+  using OpAdaptor = typename OpTy::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value dst = op.getDst();
+
+    // We are specifically matching cases in which the LHS of the assignment is
+    // an ExtractRef operation on a struct.
+    auto extractRefOp = dyn_cast<ExtractRefOp>(dst.getDefiningOp());
+    auto baseStructType = dyn_cast_if_present<StructType>(
+        cast<RefType>(extractRefOp.getInput().getType()).getNestedType());
+    if (!baseStructType)
+      return success();
+
+    // Get the boundaries of the ExtractOp.
+    uint32_t extractedLow = extractRefOp.getLowBit();
+    auto targetWidth =
+        cast<RefType>(dst.getType()).getNestedType().getBitSize();
+    if (!targetWidth)
+      return mlir::emitError(op.getLoc())
+             << "unsupported: found field with unknown size in struct "
+                "flattening";
+
+    rewriter.setInsertionPoint(op);
+    Location loc = op.getLoc();
+
+    // Collect all the fields of the struct.
+    SmallVector<FieldInfo> fields;
+    if (failed(collectFields(extractRefOp.getInput(), fields, rewriter))) {
+      return failure();
+    }
+
+    // Select only the fields revelant to the ExtractOp
+    SmallVector<Value> relevantFields;
+    uint32_t offsetInStruct = extractedLow;
+    uint32_t remaining = *targetWidth;
+    for (auto &field : fields) {
+      if (remaining == 0)
+        break;
+
+      if (field.offset <= offsetInStruct &&
+          field.offset + field.size > offsetInStruct) {
+        uint32_t offsetInField = offsetInStruct - field.offset;
+        uint32_t remainingInField = field.size - offsetInField;
+        uint32_t sizeToExtract = std::min(remaining, remainingInField);
+
+        auto fieldType = cast<RefType>(field.field.getType()).getNestedType();
+        auto extractType =
+            IntType::get(rewriter.getContext(), sizeToExtract,
+                         cast<PackedType>(fieldType).getDomain());
+        auto newLhs =
+            ExtractRefOp::create(rewriter, loc, RefType::get(extractType),
+                                 field.field, offsetInField);
+        relevantFields.push_back(newLhs);
+
+        offsetInStruct += sizeToExtract;
+        remaining -= sizeToExtract;
+      }
+    }
+
+    if (relevantFields.size() == 0)
+      return mlir::emitError(op.getLoc()) << "Struct extract is out of range";
+
+    // Reverse the fields order to match Concat order
+    std::reverse(relevantFields.begin(), relevantFields.end());
+
+    Value finalRef =
+        relevantFields.size() == 1
+            ? relevantFields.front()
+            : Value(ConcatRefOp::create(rewriter, loc, relevantFields));
+
+    IRMapping mapping;
+    mapping.map(op.getDst(), finalRef);
+    rewriter.clone(*op.getOperation(), mapping);
+
+    rewriter.eraseOp(op);
+    rewriter.eraseOp(extractRefOp);
+    return success();
+  }
+};
+
 struct QueueRefLowering : public OpConversionPattern<DynQueueRefElementOp> {
   using OpConversionPattern<DynQueueRefElementOp>::OpConversionPattern;
 
@@ -174,10 +302,37 @@ void SimplifyRefsPass::runOnOperation() {
   target.addDynamicallyLegalOp<ContinuousAssignOp, BlockingAssignOp,
                                NonBlockingAssignOp, DelayedContinuousAssignOp,
                                DelayedNonBlockingAssignOp>([](auto op) {
-    return !op->getOperand(0).template getDefiningOp<ConcatRefOp>();
+    auto extractRefOp =
+        op->getOperand(0).template getDefiningOp<ExtractRefOp>();
+    if (!extractRefOp)
+      return true;
+    auto nestedType =
+        cast<RefType>(extractRefOp.getInput().getType()).getNestedType();
+    return !isa<StructType>(nestedType);
   });
 
   target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+
+  RewritePatternSet extractRefOnStructPatterns(&context);
+  extractRefOnStructPatterns
+      .add<StructExtractLowering<ContinuousAssignOp>,
+           StructExtractLowering<BlockingAssignOp>,
+           StructExtractLowering<NonBlockingAssignOp>,
+           StructExtractLowering<DelayedContinuousAssignOp>,
+           StructExtractLowering<DelayedNonBlockingAssignOp>>(&context);
+
+  if (failed(applyFullConversion(getOperation(), target,
+                                 std::move(extractRefOnStructPatterns)))) {
+    signalPassFailure();
+    return;
+  }
+
+  target.addDynamicallyLegalOp<ContinuousAssignOp, BlockingAssignOp,
+                               NonBlockingAssignOp, DelayedContinuousAssignOp,
+                               DelayedNonBlockingAssignOp>([](auto op) {
+    return !op->getOperand(0).template getDefiningOp<ConcatRefOp>();
+  });
+
   RewritePatternSet concatRefPatterns(&context);
   concatRefPatterns.add<ConcatRefLowering<ContinuousAssignOp>,
                         ConcatRefLowering<BlockingAssignOp>,

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1780,7 +1780,30 @@ module Expressions;
     // CHECK: [[TMP3:%.+]] = moore.constant 0 :
     // CHECK: moore.concat [[TMP3]], [[TMP2]], [[TMP1]], [[TMP0]] : (!moore.l1, !moore.l1, !moore.l1, !moore.l1) -> l4
     m = '{default: '0, 2: '1};
- 
+
+    //===------------------------------------------------------------------===//
+    // Struct extraction as RHS of assignments
+
+    // CHECK: [[LHS:%.+]] = moore.extract_ref %a from 0
+    // CHECK: [[TMP0:%.+]] = moore.read %struct1 : <struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>>
+    // CHECK: [[TMP1:%.+]] = moore.packed_to_sbv [[TMP0]] : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>
+    // CHECK: [[RHS:%.+]] = moore.extract [[TMP1]] from 4 : i128 -> i1
+    // CHECK:  moore.blocking_assign [[LHS]], [[RHS]]
+    a[0] = struct1[4];
+    // CHECK: [[LHS:%.+]] = moore.extract_ref %b from 0
+    // CHECK: [[TMP0:%.+]] = moore.read %struct1 : <struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>>
+    // CHECK: [[TMP1:%.+]] = moore.packed_to_sbv [[TMP0]] : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>
+    // CHECK: [[TMP2:%.+]] = moore.read %j
+    // CHECK: [[RHS:%.+]] = moore.dyn_extract [[TMP1]] from [[TMP2]]
+    // CHECK:  moore.blocking_assign [[LHS]], [[RHS]] : i1
+    b[0] = struct1[j];
+    // CHECK: [[LHS:%.+]] = moore.extract_ref %a from 2
+    // CHECK: [[TMP0:%.+]] = moore.read %struct1 : <struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>>
+    // CHECK: [[TMP1:%.+]] = moore.packed_to_sbv [[TMP0]] : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>
+    // CHECK: [[RHS:%.+]] = moore.extract [[TMP1]] from 30 : i128 -> i3
+    // CHECK: moore.blocking_assign [[LHS]], [[RHS]] : i3
+    a[4:2] = struct1[32:30];
+
     //===------------------------------------------------------------------===//
     // Builtin Functions
 

--- a/test/Dialect/Moore/simplify-refs.mlir
+++ b/test/Dialect/Moore/simplify-refs.mlir
@@ -58,13 +58,13 @@ moore.module @Nested() {
     %4 = moore.read %z : <i32>
     // CHECK: %[[TMP2:.+]] = moore.zext %[[Z_READ]] : i32 -> i96
     %6 = moore.zext %4 : !moore.i32 -> !moore.i96
-    
+
     // CHECK-NOT: moore.concat_ref %x, %x
     %0 = moore.concat_ref %x, %x : (!moore.ref<i32>, !moore.ref<i32>) -> <i64>
     %1 = moore.concat_ref %0 : (!moore.ref<i64>) -> <i64>
     %2 = moore.concat_ref %y : (!moore.ref<i32>) -> <i32>
     %3 = moore.concat_ref %1, %2 : (!moore.ref<i64>, !moore.ref<i32>) -> <i96>
-    
+
     // CHECK: %[[TMP3:.+]] = moore.extract %[[TMP2]] from 64 : i96 -> i32
     // CHECK: moore.blocking_assign %x, %[[TMP3]] : i32
     // CHECK: %[[TMP4:.+]] = moore.extract %[[TMP2]] from 32 : i96 -> i32
@@ -159,4 +159,54 @@ moore.module @DelayedAssigns() {
     moore.return
   }
   moore.output
+}
+
+
+// CHECK-LABEL: moore.module @PackedStructExtract()
+// Extract a single bit from a packed struct and use it as LHS of an assignment.
+// Something like:
+//    struct0[0] = 1'b1;
+moore.module @PackedStructExtract() {
+  %aa = moore.variable : <struct<{a: i32, b: i32}>>
+  moore.procedure initial {
+    %0 = moore.constant 1 : i1
+
+    // CHECK: [[TMP0:%.+]] = moore.struct_extract_ref %aa, "b" : <struct<{a: i32, b: i32}>> -> <i32>
+    // CHECK: [[TMP1:%.+]] = moore.struct_extract_ref %aa, "a" : <struct<{a: i32, b: i32}>> -> <i32>
+    // CHECK: [[LHS:%.+]] = moore.extract_ref [[TMP0]] from 0 : <i32> -> <i1>
+    // CHECK: moore.blocking_assign [[LHS]], %0 : i1
+    %el = moore.extract_ref %aa from 0 : <struct<{a: i32, b: i32}>> -> <i1>
+    moore.blocking_assign %el, %0 : i1
+    moore.return
+  }
+}
+
+// CHECK-LABEL: moore.module @PackedStructExtractRange()
+// Extract a range of bits from a packed struct that cover multiple members and use it as LHS of an assignment.
+// Something like:
+//  struct packed {
+//    struct packed {
+//        int a, b;
+//      } c, d;
+//    } struct1;
+//  struct1[32:30] = 3'b0
+moore.module @PackedStructExtractRange() {
+  %aa = moore.variable : <struct<{inner: struct<{a: i32, b: i32}>, d: i32}>>
+  moore.procedure initial {
+    %0 = moore.constant 0 : i3
+
+    // CHECK: [[D:%.+]] = moore.struct_extract_ref %aa, "d" : <struct<{inner: struct<{a: i32, b: i32}>, d: i32}>> -> <i32>
+    // CHECK: [[TMP1:%.+]] = moore.struct_extract_ref %aa, "inner" : <struct<{inner: struct<{a: i32, b: i32}>, d: i32}>> -> <struct<{a: i32, b: i32}>>
+    // CHECK: [[INNER_B:%.+]] = moore.struct_extract_ref [[TMP1]], "b" : <struct<{a: i32, b: i32}>> -> <i32>
+    // CHECK: [[INNER_A:%.+]] = moore.struct_extract_ref [[TMP1]], "a" : <struct<{a: i32, b: i32}>> -> <i32>
+    // CHECK: [[LHS2:%.+]] = moore.extract_ref [[D]] from 30 : <i32> -> <i2>
+    // CHECK: [[LHS1:%.+]] = moore.extract_ref [[INNER_B]] from 0 : <i32> -> <i1>
+    // CHECK: [[RHS1:%.+]] = moore.extract %0 from 2 : i3 -> i1
+    // CHECK: moore.blocking_assign [[LHS1]], [[RHS1]] : i1
+    // CHECK: [[RHS2:%.+]] = moore.extract %0 from 0 : i3 -> i2
+    // CHECK: moore.blocking_assign [[LHS2]], [[RHS2]] : i2
+    %el = moore.extract_ref %aa from 30 : <struct<{inner: struct<{a: i32, b: i32}>, d: i32}>> -> <i3>
+    moore.blocking_assign %el, %0 : i3
+    moore.return
+  }
 }


### PR DESCRIPTION
SystemVerilog allows assignments such as

```sv
typedef struct packed {
      logic [8:0] reserved;
      logic [2:0]  frm;
      logic [4:0]  fflags;
  } fcsr_t;

fcsr_t[10:8] = x;
```

This PR handles this case by reducing the `fcsr_t[10:8]` expression to a field extraction expression (or a Concatenation of field extractions) that selects only the fields revelant to the assignment (i.e. `fcsr_t.reserved[2:0]` in the example above).

The generated concat expression on the LHS is later reduced by `ConcatRefLowering` into separate assignments.

This is still a WIP, as I'm not sure what's the best solution here.

Assisted-by: Claude:Opus4.8