### PR TITLE
[ImportVerilog][MooreToCore] Incremental fixes for Ariane support

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.h
+++ b/include/circt/Dialect/Moore/MooreOps.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/Moore/MooreAttributes.h"
 #include "circt/Dialect/Moore/MooreDialect.h"
 #include "circt/Dialect/Moore/MooreTypes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2674,8 +2674,8 @@ def DeferAssertAttr : I32EnumAttr<
   let cppNamespace = "circt::moore";
 }
 
-class ImmediateAssertOp<string mnemonic, list<Trait> traits = []> : 
-    MooreOp<mnemonic, traits # [HasParent<"ProcedureOp">]>{
+class ImmediateAssertOp<string mnemonic, list<Trait> traits = []> :
+    MooreOp<mnemonic, traits # [ParentOneOf<["ProcedureOp", "::mlir::func::FuncOp"]>]>{
   let arguments = (ins
     DeferAssertAttr:$defer,
     AnySingleBitType:$cond,

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2404,6 +2404,37 @@ struct PowSOpConversion : public OpConversionPattern<PowSOp> {
   }
 };
 
+struct Clog2BIOpConversion : public OpConversionPattern<Clog2BIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(Clog2BIOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = typeConverter->convertType(op.getResult().getType());
+    Location loc = op.getLoc();
+    unsigned width = resultType.getIntOrFloatBitWidth();
+    Value value = adaptor.getValue();
+
+    // Ceiling of log2 can be computed as follows:
+    // if (x == 0) return 0;
+    // else bitWidth(x) - countLeadingZeros(x - 1);
+    Value zero = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
+    Value one = hw::ConstantOp::create(rewriter, loc, APInt(width, 1));
+    Value bitWidth = hw::ConstantOp::create(rewriter, loc, APInt(width, width));
+
+    Value valueMinusOne = comb::SubOp::create(rewriter, loc, value, one, false);
+    Value clz =
+        mlir::math::CountLeadingZerosOp::create(rewriter, loc, valueMinusOne);
+    Value bitLength = comb::SubOp::create(rewriter, loc, bitWidth, clz, false);
+
+    Value isZero = comb::ICmpOp::create(rewriter, loc, comb::ICmpPredicate::eq,
+                                        value, zero, false);
+    rewriter.replaceOpWithNewOp<comb::MuxOp>(op, isZero, zero, bitLength,
+                                             false);
+    return success();
+  }
+};
+
 struct AShrOpConversion : public OpConversionPattern<AShrOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -3890,6 +3921,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
 
     // Patterns of power operations.
     PowUOpConversion, PowSOpConversion,
+    Clog2BIOpConversion,
 
     // Patterns of relational operations.
     ICmpOpConversion<UltOp, ICmpPredicate::ult>,

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -2697,6 +2697,15 @@ module ImmediateAssertiWithActionBlock;
   always_comb begin
     assert (x) c = 1; else c = 0;
   end
+
+  // Assert in function block
+  // CHECK:func.func private @check([[ARG:%.*]]: !moore.l32) {
+  // CHECK:  [[C0:%.+]] = moore.constant 0 : l32
+  // CHECK:  [[COND:%.+]] = moore.ugt [[ARG]], [[C0]] : l32 -> l1
+  // CHECK:  moore.assert immediate [[COND]] : l1
+  function automatic void check(logic[31:0] w);
+    assert (w > 0);
+  endfunction
 endmodule
 
 // CHECK-LABEL: moore.module @AssertNoActionBlock

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1372,6 +1372,20 @@ func.func @PowSOp(%arg0: !moore.i32, %arg1: !moore.i32) {
   return
 }
 
+// CHECK-LABEL: func.func @Clog2
+func.func @Clog2(%arg0: !moore.i32) {
+  // CHECK: [[C0:%.+]] = hw.constant 0 : i32
+  // CHECK: [[C1:%.+]] = hw.constant 1 : i32
+  // CHECK: [[WIDTH:%.+]] = hw.constant 32 : i32
+  // CHECK: [[VALMINUS1:%.+]] = comb.sub %arg0, [[C1]] : i32
+  // CHECK: [[NZEROS:%.+]] = math.ctlz [[VALMINUS1]] : i32
+  // CHECK: [[SUB:%.+]] = comb.sub [[WIDTH]], [[NZEROS]] : i32
+  // CHECK: [[ISZERO:%.+]] = comb.icmp eq %arg0, [[C0]] : i32
+  // CHECK: comb.mux [[ISZERO]], [[C0]], [[SUB]] : i32
+  %0 = moore.builtin.clog2 %arg0 : i32
+  return
+}
+
 // CHECK-LABEL: @scfInsideProcess
 moore.module @scfInsideProcess(in %in0: !moore.i32, in %in1: !moore.i32) {
   %var = moore.variable : <!moore.i32>
@@ -1620,7 +1634,7 @@ func.func @ConvertRealOperations(%arg0: !moore.f32, %arg1: !moore.f64) {
 
   // CHECK: arith.truncf %arg1 : f64 to f32
   moore.convert_real %arg1 : f64 -> f32
-  
+
   return
 }
 
@@ -1697,7 +1711,7 @@ func.func @QueueOperations(%arg0: !moore.i32, %arg1: !moore.i32) {
   // CHECK: [[NEWQ:%.+]] = sim.queue.insert %arg0 into [[QR]] at %arg1 : <i32, 10>
   // CHECK: llhd.drv [[Q]], [[NEWQ]]
   moore.queue.insert %arg0 into %q at %arg1 : <!moore.queue<i32, 10>>
-  
+
   // CHECK: [[QR:%.+]] = llhd.prb [[Q]]
   // CHECK: [[NEWQ:%.+]] = sim.queue.set [[QR]][%arg1] = %arg0 : <i32, 10>
   // CHECK: llhd.drv [[Q]], [[NEWQ]]


### PR DESCRIPTION
This PR adds two simple fixes found while testing compatibility with the Ariane codebase

- Allow `assert`s inside of function blocks (current implementation only allows them in procedures)
- Implement legalization for `$clog2` 
