### PR TITLE
[HW] Add aggregate constant support to bitcast fold

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -177,6 +177,19 @@ int64_t getBitWidth(mlir::Type type);
 /// false on known InOut types, rather than any unknown types.
 bool hasHWInOutType(mlir::Type type);
 
+/// Convert an APInt value into a nested aggregate attribute matching the given
+/// HWAggregateType. Returns failure() if the type is not an HWAggregateType or
+/// recursively contains a type other than HWAggregateType or IntegerType.
+LogicalResult apIntToAggregateAttr(mlir::Type aggregateType,
+                                   const APInt &intVal, ArrayAttr &result);
+
+/// Convert an ArrayAttr into an APInt value matching the given type.
+/// The type is used to determine the bit width of the resulting APInt.
+/// Returns failure() if the attribute recursively contains anything other than
+/// ArrayAttr or IntegerAttr.
+LogicalResult aggregateAttrToAPInt(mlir::Type type, ArrayAttr attr,
+                                   APInt &result);
+
 template <typename... BaseTy>
 bool type_isa(Type type) {
   // First check if the type is the requested type.

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -3026,12 +3026,32 @@ Type TypedeclOp::getAliasType() {
 // BitcastOp
 //===----------------------------------------------------------------------===//
 
-OpFoldResult BitcastOp::fold(FoldAdaptor) {
+OpFoldResult BitcastOp::fold(FoldAdaptor adaptor) {
   // Identity.
   // bitcast(%a) : A -> A ==> %a
   if (getOperand().getType() == getType())
     return getOperand();
 
+  // bitcast(int_constant)
+  if (auto intAttr = dyn_cast_or_null<IntegerAttr>(adaptor.getInput())) {
+    ArrayAttr arrVal;
+    if (succeeded(apIntToAggregateAttr(getType(), intAttr.getValue(), arrVal)))
+      return arrVal;
+  }
+
+  // bitcast(aggregate_constant)
+  if (auto arrayAttr = dyn_cast_or_null<ArrayAttr>(adaptor.getInput())) {
+    APInt intVal;
+    if (succeeded(
+            aggregateAttrToAPInt(getInput().getType(), arrayAttr, intVal))) {
+      if (auto intType = dyn_cast<IntegerType>(getType()))
+        return IntegerAttr::get(intType, intVal);
+
+      ArrayAttr arrVal;
+      if (succeeded(apIntToAggregateAttr(getType(), intVal, arrVal)))
+        return arrVal;
+    }
+  }
   return {};
 }
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -144,6 +144,118 @@ bool circt::hw::hasHWInOutType(Type type) {
   return isa<InOutType>(type);
 }
 
+namespace {
+struct AggregateAttrFrame {
+  SmallVector<Attribute> attrs;
+  SmallVector<Type> types;
+  unsigned remaining;
+
+  AggregateAttrFrame(SmallVector<Type> &&types)
+      : attrs(types.size()), types(std::move(types)), remaining(attrs.size()) {}
+
+  void addChild(Attribute attr) { attrs[--remaining] = attr; }
+  Type getNextChildType() { return types[remaining - 1]; }
+  bool isFinished() const { return remaining == 0; }
+};
+} // namespace
+
+/// Convert an APInt value into a nested aggregate attribute matching the given
+/// HWAggregateType. Returns failure() if the type is not an HWAggregateType or
+/// recursively contains a type other than HWAggregateType or IntegerType.
+LogicalResult circt::hw::apIntToAggregateAttr(Type aggregateType,
+                                              const APInt &intVal,
+                                              ArrayAttr &result) {
+  auto *ctx = aggregateType.getContext();
+  SmallVector<AggregateAttrFrame> stack;
+  auto bitWidth = intVal.getBitWidth();
+  unsigned nextExtraction = 0;
+
+  auto pushToStack = [&](Type type) -> bool {
+    return TypeSwitch<Type, bool>(type)
+        .Case<StructType>([&](auto structType) {
+          auto len = structType.getElements().size();
+          SmallVector<Type> types;
+          types.reserve(len);
+          for (auto &element : structType.getElements())
+            types.push_back(getCanonicalType(element.type));
+          stack.push_back(std::move(types));
+          return true;
+        })
+        .Case<ArrayType, UnpackedArrayType>([&](auto arrayType) {
+          SmallVector<Type> types(arrayType.getNumElements(),
+                                  getCanonicalType(arrayType.getElementType()));
+          stack.push_back(std::move(types));
+          return true;
+        })
+        .Default([](Type) {
+          // Unsupported type
+          return false;
+        });
+  };
+
+  if (!pushToStack(getCanonicalType(aggregateType)))
+    return failure();
+
+  while (!stack.empty()) {
+    if (stack.back().isFinished()) {
+      auto frame = stack.pop_back_val();
+      result = ArrayAttr::get(ctx, frame.attrs);
+      if (!stack.empty())
+        stack.back().addChild(result);
+      continue;
+    }
+
+    auto curType = stack.back().getNextChildType();
+    if (auto intType = dyn_cast<IntegerType>(curType)) {
+      auto width = intType.getWidth();
+      auto elemValue = width ? intVal.extractBits(width, nextExtraction)
+                             : APInt(0, 0, false);
+      nextExtraction += width;
+      stack.back().addChild(IntegerAttr::get(intType, elemValue));
+    } else {
+      if (!pushToStack(curType))
+        return failure();
+    }
+  }
+
+  assert(nextExtraction == bitWidth && "constant wasn't fully processed");
+  return success();
+}
+
+/// Convert an ArrayAttr into an APInt value matching the given type.
+/// The type is used to determine the bit width of the resulting APInt.
+/// Returns failure() if the attribute recursively contains anything other than
+/// ArrayAttr or IntegerAttr.
+LogicalResult circt::hw::aggregateAttrToAPInt(Type type, ArrayAttr attr,
+                                              APInt &result) {
+  SmallVector<Attribute> worklist;
+  worklist.push_back(attr);
+  auto bitWidth = hw::getBitWidth(type);
+  assert(bitWidth >= 0 && "bit width must be known for constant");
+  result = APInt(bitWidth, 0);
+  unsigned nextInsertion = 0;
+
+  while (!worklist.empty()) {
+    auto current = worklist.pop_back_val();
+    if (auto innerArray = dyn_cast<ArrayAttr>(current)) {
+      worklist.append(innerArray.begin(), innerArray.end());
+      continue;
+    }
+
+    if (auto intAttr = dyn_cast<IntegerAttr>(current)) {
+      auto chunk = intAttr.getValue();
+      result.insertBits(chunk, nextInsertion);
+      nextInsertion += chunk.getBitWidth();
+      continue;
+    }
+
+    return failure();
+  }
+
+  assert(nextInsertion == bitWidth && "constant wasn't fully processed");
+  return success();
+}
+
 /// Parse and print nested HW types nicely.  These helper methods allow eliding
 /// the "hw." prefix on array, inout, and other types when in a context that
 /// expects HW subelement types.

--- a/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
+++ b/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
@@ -42,44 +42,13 @@ struct HWAggregateConstantOpConversion
     : OpConversionPattern<hw::AggregateConstantOp> {
   using OpConversionPattern<hw::AggregateConstantOp>::OpConversionPattern;
 
-  static LogicalResult peelAttribute(Location loc, Attribute attr,
-                                     ConversionPatternRewriter &rewriter,
-                                     APInt &intVal) {
-    SmallVector<Attribute> worklist;
-    worklist.push_back(attr);
-    unsigned nextInsertion = intVal.getBitWidth();
-
-    while (!worklist.empty()) {
-      auto current = worklist.pop_back_val();
-      if (auto innerArray = dyn_cast<ArrayAttr>(current)) {
-        for (auto elem : llvm::reverse(innerArray))
-          worklist.push_back(elem);
-        continue;
-      }
-
-      if (auto intAttr = dyn_cast<IntegerAttr>(current)) {
-        auto chunk = intAttr.getValue();
-        nextInsertion -= chunk.getBitWidth();
-        intVal.insertBits(chunk, nextInsertion);
-        continue;
-      }
-
-      return failure();
-    }
-
-    return success();
-  }
-
   LogicalResult
   matchAndRewrite(hw::AggregateConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Lower to concat.
-    SmallVector<Value> results;
-    auto bitWidth = hw::getBitWidth(op.getType());
-    assert(bitWidth >= 0 && "bit width must be known for constant");
-    APInt intVal(bitWidth, 0);
-    if (failed(peelAttribute(op.getLoc(), adaptor.getFieldsAttr(), rewriter,
-                             intVal)))
+    APInt intVal;
+    if (failed(hw::aggregateAttrToAPInt(op.getType(), adaptor.getFieldsAttr(),
+                                        intVal)))
       return failure();
     rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, intVal);
     return success();

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -131,8 +131,8 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: hw.constant 0 : i4
   moore.extract %arg2 from 6 : !moore.i6 -> !moore.i4
 
-  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i64
-  // CHECK-NEXT: [[V0:%..+]] = hw.bitcast [[C0]] : (i64) -> !hw.array<2xi32>
+  // CHECK-NEXT: hw.constant 0 : i64
+  // CHECK-NEXT: [[V0:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
   // CHECK-NEXT: hw.constant 0 : i3
   // CHECK-NEXT: [[C1:%.+]] = hw.constant 0 : i64
   // CHECK-NEXT: [[V1:%.+]] = hw.bitcast [[C1]] : (i64) -> !hw.array<2xi32>
@@ -146,15 +146,15 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: hw.array_concat [[V0]], [[V1]] : !hw.array<3xi32>, !hw.array<1xi32>
   moore.extract %arg5 from 2 : !moore.array<5 x i32> -> !moore.array<4 x i32>
 
-  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i32
-  // CHECK-NEXT: [[V0:%.+]] = hw.bitcast [[C0]] : (i32) -> !hw.array<1xi32>
+  // CHECK-NEXT: hw.constant 0 : i32
+  // CHECK-NEXT: [[V0:%.+]] = hw.aggregate_constant [0 : i32] : !hw.array<1xi32>
   // CHECK-NEXT: [[IDX:%.+]] = hw.constant 0 : i3
   // CHECK-NEXT: [[V1:%.+]] = hw.array_slice %arg5[[[IDX]]] : (!hw.array<5xi32>) -> !hw.array<1xi32>
   // CHECK-NEXT: hw.array_concat [[V0]], [[V1]] : !hw.array<1xi32>, !hw.array<1xi32>
   moore.extract %arg5 from -1 : !moore.array<5 x i32> -> !moore.array<2 x i32>
 
-  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i64
-  // CHECK-NEXT: hw.bitcast [[C0]] : (i64) -> !hw.array<2xi32>
+  // CHECK-NEXT: hw.constant 0 : i64
+  // CHECK-NEXT: hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
   moore.extract %arg5 from -2 : !moore.array<5 x i32> -> !moore.array<2 x i32>
 
   // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i64
@@ -617,8 +617,7 @@ moore.module @UnpackedArray(in %arr : !moore.uarray<2 x i32>, in %sel : !moore.i
   // CHECK: hw.array_get %arr[[[TRUE]]] : !hw.array<2xi32>, i1
   %1 = moore.extract %arr from 1 : !moore.uarray<2 x i32> -> !moore.i32
 
-  // CHECK: [[C0_128:%.+]] = hw.constant 0 : i128
-  // CHECK: [[INIT:%.+]] = hw.bitcast [[C0_128]] : (i128) -> !hw.array<4xi32>
+  // CHECK: [[INIT:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32, 0 : i32, 0 : i32] : !hw.array<4xi32>
   // CHECK: [[SIG_0:%.+]] = llhd.sig [[INIT]] : !hw.array<4xi32>
   %2 = moore.variable : <uarray<4 x i32>>
 
@@ -627,8 +626,8 @@ moore.module @UnpackedArray(in %arr : !moore.uarray<2 x i32>, in %sel : !moore.i
   %3 = moore.extract_ref %2 from 1 : !moore.ref<!moore.uarray<4 x i32>> -> !moore.ref<!moore.i32>
   moore.assign %3, %0 : i32
 
-  // CHECK: [[C0_1024:%.+]] = hw.constant 0 : i1024
-  // CHECK: [[INIT:%.+]] = hw.bitcast [[C0_1024]] : (i1024) -> !hw.array<4xarray<8xarray<8xi4>>>
+  // CHECK: [[INIT:%.+]] = hw.aggregate_constant
+  // CHECK-SAME{LITERAL}: [[[0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4]], [[0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4]], [[0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4]], [[0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4], [0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4, 0 : i4]]] : !hw.array<4xarray<8xarray<8xi4>>>
   // CHECK: [[SIG_1:%.+]] = llhd.sig [[INIT]] : !hw.array<4xarray<8xarray<8xi4>>>
   %4 = moore.variable : <uarray<4 x uarray<8 x array<8 x i4>>>>
 
@@ -662,8 +661,7 @@ moore.module @Struct(in %a : !moore.i32, in %b : !moore.i32, in %arg0 : !moore.s
   %ref = moore.struct_extract_ref %arg1, "exp_bits" : <!moore.struct<{exp_bits: i32, man_bits: i32}>> -> <i32>
   moore.assign %ref, %0 : !moore.i32
 
-  // CHECK: [[C0:%.+]] = hw.constant 0 : i64
-  // CHECK: [[INIT:%.+]] = hw.bitcast [[C0]] : (i64) -> !hw.struct<exp_bits: i32, man_bits: i32>
+  // CHECK: [[INIT:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32] : !hw.struct<exp_bits: i32, man_bits: i32>
   // CHECK: llhd.sig [[INIT]] : !hw.struct<exp_bits: i32, man_bits: i32>
   // CHECK: llhd.sig %arg0 : !hw.struct<exp_bits: i32, man_bits: i32>
   %1 = moore.variable : <struct<{exp_bits: i32, man_bits: i32}>>
@@ -722,8 +720,7 @@ moore.module @UnpackedStruct() {
   %0 = moore.constant 1 : i32
   %1 = moore.constant 0 : i32
 
-  // CHECK: %[[C0_64:.*]] = hw.constant 0 : i64
-  // CHECK: %[[INIT:.*]] = hw.bitcast %[[C0_64]] : (i64) -> !hw.struct<a: i32, b: i32>
+  // CHECK: %[[INIT:.*]] = hw.aggregate_constant [0 : i32, 0 : i32] : !hw.struct<a: i32, b: i32>
   // CHECK: %[[USTRUCT:.*]] = llhd.sig %[[INIT]] : !hw.struct<a: i32, b: i32>
   %ms = moore.variable : <ustruct<{a: i32, b: i32}>>
 
@@ -1735,8 +1732,7 @@ func.func @QueueOperations(%arg0: !moore.i32, %arg1: !moore.i32) {
   // CHECK: [[CMPR:%.+]] = sim.queue.cmp ne [[QR]], [[QR2]] : <i32, 10>
   moore.queue.cmp ne %qr, %qr2 : <i32, 10>
 
-  // CHECK: [[ZERO:%.+]] = hw.constant 0 : i128
-  // CHECK: [[UPARR:%.+]] = hw.bitcast [[ZERO]] : (i128) -> !hw.array<4xi32>
+  // CHECK: [[UPARR:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32, 0 : i32, 0 : i32] : !hw.array<4xi32>
   // CHECK: [[UPVAR:%.+]] = llhd.sig [[UPARR]] : !hw.array<4xi32>
   %uparray = moore.variable : <!moore.uarray<4 x i32>>
   // CHECK: [[UPR:%.+]] = llhd.prb [[UPVAR]]

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1069,6 +1069,97 @@ hw.module @bitcast_canonicalization(in %arg0 : i4, out r1: i4, out r2: !hw.array
   hw.output %id, %b : i4, !hw.array<2xi2>
 }
 
+// CHECK-LABEL: hw.module @bitcast_int_to_struct
+hw.module @bitcast_int_to_struct(out result : !hw.struct<a: i4, b: i4>) {
+  %c = hw.constant 0x42 : i8
+  %0 = hw.bitcast %c : (i8) -> !hw.struct<a: i4, b: i4>
+  // CHECK-NEXT: %[[OUT:.+]] = hw.aggregate_constant [4 : i4, 2 : i4] : !hw.struct<a: i4, b: i4>
+  // CHECK-NEXT: hw.output %[[OUT]] : !hw.struct<a: i4, b: i4>
+  hw.output %0 : !hw.struct<a: i4, b: i4>
+}
+
+// CHECK-LABEL: hw.module @bitcast_struct_to_int
+hw.module @bitcast_struct_to_int(out result : i8) {
+  %c = hw.aggregate_constant [4 : i4, 2 : i4] : !hw.struct<a: i4, b: i4>
+  %0 = hw.bitcast %c : (!hw.struct<a: i4, b: i4>) -> i8
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 66 : i8
+  // CHECK-NEXT: hw.output %[[OUT]] : i8
+  hw.output %0 : i8
+}
+
+// CHECK-LABEL: hw.module @bitcast_int_to_array
+hw.module @bitcast_int_to_array(out result : !hw.array<2xi4>) {
+  %c = hw.constant 0x42 : i8
+  // CHECK-NEXT: %[[OUT:.+]] = hw.aggregate_constant [4 : i4, 2 : i4] : !hw.array<2xi4>
+  // CHECK-NEXT: hw.output %[[OUT]] : !hw.array<2xi4>
+  %0 = hw.bitcast %c : (i8) -> !hw.array<2xi4>
+  hw.output %0 : !hw.array<2xi4>
+}
+
+// CHECK-LABEL: hw.module @bitcast_array_to_int
+hw.module @bitcast_array_to_int(out result : i8) {
+  %c = hw.aggregate_constant [4 : i4, 2 : i4] : !hw.array<2xi4>
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 66 : i8
+  // CHECK-NEXT: hw.output %[[OUT]] : i8
+  %0 = hw.bitcast %c : (!hw.array<2xi4>) -> i8
+  hw.output %0 : i8
+}
+
+// CHECK-LABEL: hw.module @bitcast_int_to_0array
+hw.module @bitcast_int_to_0array(out result : !hw.array<0xi4>) {
+  %c = hw.constant 0 : i0
+  // CHECK-NEXT: %[[OUT:.+]] = hw.aggregate_constant [] : !hw.array<0xi4>
+  // CHECK-NEXT: hw.output %[[OUT]] : !hw.array<0xi4>
+  %0 = hw.bitcast %c : (i0) -> !hw.array<0xi4>
+  hw.output %0 : !hw.array<0xi4>
+}
+
+// CHECK-LABEL: hw.module @bitcast_0array_to_int
+hw.module @bitcast_0array_to_int(out result : i0) {
+  %c = hw.aggregate_constant [] : !hw.array<0xi4>
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 0 : i0
+  // CHECK-NEXT: hw.output %[[OUT]] : i0
+  %0 = hw.bitcast %c : (!hw.array<0xi4>) -> i0
+  hw.output %0 : i0
+}
+
+// CHECK-LABEL: hw.module @bitcast_int_to_uarray
+hw.module @bitcast_int_to_uarray(out result : !hw.uarray<2xi4>) {
+  %c = hw.constant 0x42 : i8
+  // CHECK-NEXT: %[[OUT:.+]] = hw.aggregate_constant [4 : i4, 2 : i4] : !hw.uarray<2xi4>
+  // CHECK-NEXT: hw.output %[[OUT]] : !hw.uarray<2xi4>
+  %0 = hw.bitcast %c : (i8) -> !hw.uarray<2xi4>
+  hw.output %0 : !hw.uarray<2xi4>
+}
+
+// CHECK-LABEL: hw.module @bitcast_uarray_to_int
+hw.module @bitcast_uarray_to_int(out result : i8) {
+  %c = hw.aggregate_constant [4 : i4, 2 : i4] : !hw.uarray<2xi4>
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 66 : i8
+  // CHECK-NEXT: hw.output %[[OUT]] : i8
+  %0 = hw.bitcast %c : (!hw.uarray<2xi4>) -> i8
+  hw.output %0 : i8
+}
+
+// CHECK-LABEL: hw.module @bitcast_int_to_nested_aggregate
+hw.module @bitcast_int_to_nested_aggregate(out result : !hw.array<2xstruct<a: i4, b: i4>>) {
+  %c = hw.constant 0x1234 : i16
+  %0 = hw.bitcast %c : (i16) -> !hw.array<2xstruct<a: i4, b: i4>>
+  // CHECK-NEXT: %[[OUT:.+]] = 
+  // CHECK-SAME{LITERAL}: hw.aggregate_constant [[1 : i4, 2 : i4], [3 : i4, 4 : i4]] : !hw.array<2xstruct<a: i4, b: i4>>
+  // CHECK-NEXT: hw.output %[[OUT]] : !hw.array<2xstruct<a: i4, b: i4>>
+  hw.output %0 : !hw.array<2xstruct<a: i4, b: i4>>
+}
+
+// CHECK-LABEL: hw.module @bitcast_nested_aggregate_to_int
+hw.module @bitcast_nested_aggregate_to_int(out result : i16) {
+  %c = hw.aggregate_constant [[1 : i4, 2 : i4], [3 : i4, 4 : i4]] : !hw.array<2xstruct<a: i4, b: i4>>
+  %0 = hw.bitcast %c : (!hw.array<2xstruct<a: i4, b: i4>>) -> i16
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 4660 : i16
+  // CHECK-NEXT: hw.output %[[OUT]] : i16
+  hw.output %0 : i16
+}
+
 // CHECK-LABEL: hw.module @array_create
 // CHECK-NEXT:    %0 = hw.aggregate_constant [0 : i2, 1 : i2, 0 : i2] : !hw.array<3xi2>
 // CHECK-NEXT:    hw.output %0 : !hw.array<3xi2

--- a/test/Dialect/HW/hw-convert-bitcasts-const.mlir
+++ b/test/Dialect/HW/hw-convert-bitcasts-const.mlir
@@ -1,0 +1,103 @@
+// RUN: circt-opt %s --hw-convert-bitcasts --canonicalize | FileCheck %s
+// RUN: circt-opt %s --canonicalize                       | FileCheck %s
+
+// CHECK-LABEL: hw.module @intToArray
+hw.module @intToArray(out o : !hw.array<3xi4>) {
+  %c = hw.constant 0x123 : i12
+  %o = hw.bitcast %c : (i12) -> !hw.array<3xi4>
+  // CHECK-NEXT: %[[OUT:.+]] = hw.aggregate_constant [1 : i4, 2 : i4, 3 : i4] : !hw.array<3xi4>
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %o : !hw.array<3xi4>
+}
+
+// CHECK-LABEL: hw.module @arrayToInt
+hw.module @arrayToInt(out o : i24) {
+  %c = hw.aggregate_constant [0x1 : i8, 0x0 : i8, 0x2 : i8] : !hw.array<3xi8>
+  %o = hw.bitcast %c : (!hw.array<3xi8>) -> i24
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 65538 : i24
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %o : i24
+}
+
+// CHECK-LABEL: hw.module @intToStruct
+hw.module @intToStruct(out o : !hw.struct<a: i4, b: i4, c: i8>) {
+  %c = hw.constant 0x1234 : i16
+  %o = hw.bitcast %c : (i16) -> !hw.struct<a: i4, b: i4, c: i8>
+  // CHECK-NEXT: %[[OUT:.+]] = hw.aggregate_constant [1 : i4, 2 : i4, 52 : i8] : !hw.struct<a: i4, b: i4, c: i8>
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %o : !hw.struct<a: i4, b: i4, c: i8>
+}
+
+// CHECK-LABEL: hw.module @structToInt
+hw.module @structToInt(out o : i16) {
+  %c = hw.aggregate_constant [0x1 : i4, 0x0 : i4, 0x2 : i8] : !hw.struct<a: i4, b: i4, c: i8>
+  %o = hw.bitcast %c : (!hw.struct<a: i4, b: i4, c: i8>) -> i16
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 4098 : i16
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %o : i16
+}
+
+// CHECK-LABEL: hw.module @structToArray
+hw.module @structToArray(out o : !hw.array<4xi8>) {
+  %c = hw.aggregate_constant [0x1 : i8, 0x2 : i8, 0x3 : i16] : !hw.struct<a: i8, b: i8, c: i16>
+  %o = hw.bitcast %c : (!hw.struct<a: i8, b: i8, c: i16>) -> !hw.array<4xi8>
+  // CHECK-NEXT: %[[OUT:.+]] = hw.aggregate_constant [1 : i8, 2 : i8, 0 : i8, 3 : i8] : !hw.array<4xi8>
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %o : !hw.array<4xi8>
+}
+
+// CHECK-LABEL: hw.module @nop
+hw.module @nop(out o : i8) {
+  %c = hw.constant 5 : i8
+  %o = hw.bitcast %c : (i8) -> i8
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 5 : i8
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %o : i8
+}
+
+// Don't crash on zero width
+// CHECK-LABEL: hw.module @zeroWidth
+hw.module @zeroWidth(out o : i0) {
+  %c = hw.constant 0 : i0
+  %0 = hw.bitcast %c : (i0) -> !hw.struct<a: i0, b: i0, c: i0>
+  %1 = hw.bitcast %0 : (!hw.struct<a: i0, b: i0, c: i0>) -> !hw.array<8xi0>
+  %2 = hw.bitcast %1 : (!hw.array<8xi0>) -> !hw.struct<a: i0>
+  %3 = hw.bitcast %2 : (!hw.struct<a: i0>) -> i0
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 0 : i0
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %3 : i0
+}
+
+// CHECK-LABEL: hw.module @arrayRoundtrip
+hw.module @arrayRoundtrip(out o : i32) {
+  // CHECK-NOT: hw.bitcast
+  %c = hw.constant 0x12345678 : i32
+  %a = hw.bitcast %c : (i32) -> !hw.array<4x!hw.array<2xi4>>
+  %o = hw.bitcast %a : (!hw.array<4x!hw.array<2xi4>>) -> i32
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 305419896 : i32
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %o : i32
+}
+
+// CHECK-LABEL: hw.module @structRoundtrip
+hw.module @structRoundtrip(out o : i32) {
+  // CHECK-NOT: hw.bitcast
+  %c = hw.constant 0x00010002 : i32
+  %a = hw.bitcast %c : (i32) -> !hw.struct<a: i8, b: i8, c: i16>
+  %o = hw.bitcast %a : (!hw.struct<a: i8, b: i8, c: i16>) -> i32
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 65538 : i32
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %o : i32
+}
+
+// CHECK-LABEL: hw.module @mixedRoundtrip
+hw.module @mixedRoundtrip(out o : i32) {
+  // CHECK-NOT: hw.bitcast
+  %c = hw.constant 0x01020003 : i32
+  %0 = hw.bitcast %c : (i32) -> !hw.struct<a: !hw.array<2xi8>, b: i0, c: i16>
+  %1 = hw.bitcast %0 : (!hw.struct<a: !hw.array<2xi8>, b: i0, c: i16>) -> !hw.array<32x!hw.struct<a: i1>>
+  %2 = hw.bitcast %1 : (!hw.array<32x!hw.struct<a: i1>>) -> i32
+  // CHECK-NEXT: %[[OUT:.+]] = hw.constant 16908291 : i32
+  // CHECK-NEXT: hw.output %[[OUT]]
+  hw.output %2 : i32
+}

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -103,9 +103,7 @@ hw.module @FirRegReset(in %clk : !seq.clock, in %in : i32, in %r : i1, in %v : i
 
 // CHECK-LABEL: @FirRegAggregate
 hw.module @FirRegAggregate(in %clk : !seq.clock, out out : !hw.struct<foo: i32>) {
-  // TODO: Use constant aggregate attribute once supported.
-  // CHECK:      %c0_i32 = hw.constant 0 : i32
-  // CHECK-NEXT: %0 = hw.bitcast %c0_i32 : (i32) -> !hw.struct<foo: i32>
+  // CHECK:      %0 = hw.aggregate_constant [0 : i32] : !hw.struct<foo: i32>
   // CHECK-NEXT: hw.output %0
   %reg = seq.firreg %reg clock %clk : !hw.struct<foo: i32>
   hw.output %reg : !hw.struct<foo: i32>


### PR DESCRIPTION
While integer-to-integer bitcasts are folded, bitcasts involving aggregate constants are not.
This can prevent optimization, as seen here:
```
hw.module @Foo(out o : !hw.array<2xi2>) {
    %c2_4 = hw.constant 2 : i4
    %0 = hw.bitcast %c2_4 : (i4) -> !hw.array<2xi2>
    %1 = llhd.process -> !hw.array<2xi2> {
      llhd.halt %0 : !hw.array<2xi2>
    }
    hw.output %1 : !hw.array<2xi2>
  }
```

This PR adds bitcast folding for arrays, unpacked arrays, struct types and nested versions of them.

Additional notes:
- Union types are currently not supported. 
- `SeqOps.cpp` still contains a ToDo in `FirRegOp::canonicalize` to improve constant register folding.

Assisted by: vscode:Claude Sonnet 5