### PR TITLE
[Arc][LLHD] Make InsertRuntime and Mem2Reg emission order deterministic

### DIFF
--- a/lib/Dialect/Arc/Transforms/InsertRuntime.cpp
+++ b/lib/Dialect/Arc/Transforms/InsertRuntime.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/MapVector.h"
 
 #include <filesystem>
 
@@ -201,8 +202,13 @@ struct GlobalRuntimeContext {
       &allocInstanceFn, &deleteInstanceFn, &onEvalFn, &onInitializedFn,
       &swapTraceBufferFn};
 
-  // Maps model symbol name to model context
-  SmallDenseMap<StringAttr, std::unique_ptr<RuntimeModelContext>> models;
+  // Maps model symbol name to model context. MapVector: the map is iterated
+  // to CREATE the per-model runtime ops (buildRuntimeModelOps) and to lower
+  // the models, so its iteration order reaches emitted op order - a
+  // pointer-keyed map here made the arcRuntimeModel_* globals' order (and
+  // everything the per-model lowering appends) vary run to run under ASLR
+  // on identical multi-model input.
+  llvm::MapVector<StringAttr, std::unique_ptr<RuntimeModelContext>> models;
 
 private:
   static ImplicitLocOpBuilder createBuilder(ModuleOp &moduleOp) {

--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -1021,11 +1021,35 @@ void Promoter::captureAcrossWait() {
     return v.getParentRegion() == &region;
   };
 
+  // `Liveness` hands out pointer-keyed sets; capturing in their iteration
+  // order would add the wait ops' destination block arguments in a
+  // run-to-run varying order (ASLR), making the emitted IR nondeterministic
+  // on identical input. Record each region-defined value's program-order
+  // position once; live-out sets are sorted by it below. Region-defined
+  // live-out values are exactly the block arguments and op results of this
+  // region's blocks.
+  DenseMap<Value, unsigned> captureOrder;
+  for (auto &block : region) {
+    for (auto arg : block.getArguments())
+      captureOrder.insert({arg, captureOrder.size()});
+    for (auto &op : block)
+      for (auto result : op.getResults())
+        captureOrder.insert({result, captureOrder.size()});
+  }
+
   for (auto waitOp : waitOps) {
     Block *waitBlock = waitOp->getBlock();
     const auto &liveOutValues = liveness.getLiveOut(waitBlock);
 
-    for (Value v : liveOutValues) {
+    // Values defined outside the region have no recorded position; ties
+    // among them are harmless since they are filtered out below.
+    SmallVector<Value> orderedLiveOut(liveOutValues.begin(),
+                                      liveOutValues.end());
+    llvm::sort(orderedLiveOut, [&](Value a, Value b) {
+      return captureOrder.lookup(a) < captureOrder.lookup(b);
+    });
+
+    for (Value v : orderedLiveOut) {
       if (!isDefinedInRegion(v))
         continue;
 

--- a/test/Dialect/Arc/insert-runtime-order.mlir
+++ b/test/Dialect/Arc/insert-runtime-order.mlir
@@ -1,0 +1,43 @@
+// RUN: circt-opt %s --arc-insert-runtime | FileCheck %s
+
+// The models map is iterated to create the per-model runtime ops, so its
+// iteration order reaches emitted op order. The arc.runtime.model ops must
+// follow module op order, not pointer-keyed map iteration order.
+
+// CHECK: arc.runtime.model @arcRuntimeModel_zebra "zebra"
+// CHECK: arc.runtime.model @arcRuntimeModel_alpha "alpha"
+// CHECK: arc.runtime.model @arcRuntimeModel_quebec "quebec"
+// CHECK: arc.runtime.model @arcRuntimeModel_bravo "bravo"
+
+arc.model @zebra io !hw.modty<input clk : i1, output o : i8> storageBytes 4 {
+^bb0(%arg0: !arc.storage):
+  %0 = arc.root_input "clk", %arg0 {offset = 0 : i32} : (!arc.storage) -> !arc.state<i1>
+  %1 = arc.alloc_state %arg0 {offset = 1 : i32} : (!arc.storage) -> !arc.state<i8>
+  %out_o = arc.root_output "o", %arg0 {offset = 3 : i32} : (!arc.storage) -> !arc.state<i8>
+  %2 = arc.state_read %1 : <i8>
+  arc.state_write %out_o = %2 : <i8>
+}
+arc.model @alpha io !hw.modty<input clk : i1, output o : i8> storageBytes 4 {
+^bb0(%arg0: !arc.storage):
+  %0 = arc.root_input "clk", %arg0 {offset = 0 : i32} : (!arc.storage) -> !arc.state<i1>
+  %1 = arc.alloc_state %arg0 {offset = 1 : i32} : (!arc.storage) -> !arc.state<i8>
+  %out_o = arc.root_output "o", %arg0 {offset = 3 : i32} : (!arc.storage) -> !arc.state<i8>
+  %2 = arc.state_read %1 : <i8>
+  arc.state_write %out_o = %2 : <i8>
+}
+arc.model @quebec io !hw.modty<input clk : i1, output o : i8> storageBytes 4 {
+^bb0(%arg0: !arc.storage):
+  %0 = arc.root_input "clk", %arg0 {offset = 0 : i32} : (!arc.storage) -> !arc.state<i1>
+  %1 = arc.alloc_state %arg0 {offset = 1 : i32} : (!arc.storage) -> !arc.state<i8>
+  %out_o = arc.root_output "o", %arg0 {offset = 3 : i32} : (!arc.storage) -> !arc.state<i8>
+  %2 = arc.state_read %1 : <i8>
+  arc.state_write %out_o = %2 : <i8>
+}
+arc.model @bravo io !hw.modty<input clk : i1, output o : i8> storageBytes 4 {
+^bb0(%arg0: !arc.storage):
+  %0 = arc.root_input "clk", %arg0 {offset = 0 : i32} : (!arc.storage) -> !arc.state<i1>
+  %1 = arc.alloc_state %arg0 {offset = 1 : i32} : (!arc.storage) -> !arc.state<i8>
+  %out_o = arc.root_output "o", %arg0 {offset = 3 : i32} : (!arc.storage) -> !arc.state<i8>
+  %2 = arc.state_read %1 : <i8>
+  arc.state_write %out_o = %2 : <i8>
+}

--- a/test/Dialect/LLHD/Transforms/mem2reg.mlir
+++ b/test/Dialect/LLHD/Transforms/mem2reg.mlir
@@ -1016,6 +1016,7 @@ hw.module @CombCreateDynamicInject(in %u: i42, in %v: i10, in %q: i1) {
 }
 
 func.func private @use_i8(%arg0: i8)
+func.func private @use_i210(%arg0: i210)
 func.func private @use_i42(%arg0: i42)
 func.func private @use_ref_i42(%arg0: !llhd.ref<i42>)
 func.func private @use_array_i42(%arg0: !hw.array<4xi42>)
@@ -1390,4 +1391,66 @@ hw.module private @Timeout_10314() {
     llhd.wait (%c0_i3, %c0_i8, %c0_i32, %false, %false, %c0_i3, %c0_i8, %c0_i8, %c0_i4, %c0_i4 : i3, i8, i32, i1, i1, i3, i8, i8, i4, i4), ^bb1
   }
   hw.output
+}
+
+// Check that probes live across a wait are captured as destination block
+// arguments in region program order. Uses enough probes to push the live-out
+// set out of small-set mode: the set is pointer-keyed, and capturing in its
+// iteration order would emit differently-ordered IR from run to run on
+// identical input.
+// CHECK-LABEL: @WaitCaptureProgramOrder
+hw.module @WaitCaptureProgramOrder(
+    in %v1: i1, in %v2: i2, in %v3: i3, in %v4: i4, in %v5: i5, in %v6: i6,
+    in %v7: i7, in %v8: i8, in %v9: i9, in %v10: i10, in %v11: i11,
+    in %v12: i12, in %v13: i13, in %v14: i14, in %v15: i15, in %v16: i16,
+    in %v17: i17, in %v18: i18, in %v19: i19, in %v20: i20) {
+  %s1 = llhd.sig %v1 : i1
+  %s2 = llhd.sig %v2 : i2
+  %s3 = llhd.sig %v3 : i3
+  %s4 = llhd.sig %v4 : i4
+  %s5 = llhd.sig %v5 : i5
+  %s6 = llhd.sig %v6 : i6
+  %s7 = llhd.sig %v7 : i7
+  %s8 = llhd.sig %v8 : i8
+  %s9 = llhd.sig %v9 : i9
+  %s10 = llhd.sig %v10 : i10
+  %s11 = llhd.sig %v11 : i11
+  %s12 = llhd.sig %v12 : i12
+  %s13 = llhd.sig %v13 : i13
+  %s14 = llhd.sig %v14 : i14
+  %s15 = llhd.sig %v15 : i15
+  %s16 = llhd.sig %v16 : i16
+  %s17 = llhd.sig %v17 : i17
+  %s18 = llhd.sig %v18 : i18
+  %s19 = llhd.sig %v19 : i19
+  %s20 = llhd.sig %v20 : i20
+  llhd.process {
+    %p1 = llhd.prb %s1 : i1
+    %p2 = llhd.prb %s2 : i2
+    %p3 = llhd.prb %s3 : i3
+    %p4 = llhd.prb %s4 : i4
+    %p5 = llhd.prb %s5 : i5
+    %p6 = llhd.prb %s6 : i6
+    %p7 = llhd.prb %s7 : i7
+    %p8 = llhd.prb %s8 : i8
+    %p9 = llhd.prb %s9 : i9
+    %p10 = llhd.prb %s10 : i10
+    %p11 = llhd.prb %s11 : i11
+    %p12 = llhd.prb %s12 : i12
+    %p13 = llhd.prb %s13 : i13
+    %p14 = llhd.prb %s14 : i14
+    %p15 = llhd.prb %s15 : i15
+    %p16 = llhd.prb %s16 : i16
+    %p17 = llhd.prb %s17 : i17
+    %p18 = llhd.prb %s18 : i18
+    %p19 = llhd.prb %s19 : i19
+    %p20 = llhd.prb %s20 : i20
+    // CHECK: llhd.wait ^bb1({{.*}} : i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16, i17, i18, i19, i20)
+    llhd.wait ^bb1
+  ^bb1:
+    // CHECK: ^bb1({{.*}}: i1, {{.*}}: i2, {{.*}}: i3, {{.*}}: i4, {{.*}}: i5, {{.*}}: i6, {{.*}}: i7, {{.*}}: i8, {{.*}}: i9, {{.*}}: i10, {{.*}}: i11, {{.*}}: i12, {{.*}}: i13, {{.*}}: i14, {{.*}}: i15, {{.*}}: i16, {{.*}}: i17, {{.*}}: i18, {{.*}}: i19, {{.*}}: i20):
+    %all = comb.concat %p1, %p2, %p3, %p4, %p5, %p6, %p7, %p8, %p9, %p10, %p11, %p12, %p13, %p14, %p15, %p16, %p17, %p18, %p19, %p20 : i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16, i17, i18, i19, i20
+    func.call @use_i210(%all) : (i210) -> ()
+    llhd.halt
+  }
 }


### PR DESCRIPTION
Two passes iterated pointer-keyed containers whose iteration order reaches
emitted op order, so identical input produced differently ordered IR from run
to run under ASLR.

InsertRuntime keeps its per-model runtime contexts in a SmallDenseMap keyed by
pointer-hashed StringAttrs and iterates it to create the per-model runtime ops,
so on multi-model inputs the arcRuntimeModel_* op order varied between runs.
Use MapVector; insertion follows the ModelInfo analysis order, which is module
op order. Adds insert-runtime-order.mlir pinning the emitted model order.

Mem2Reg's captureAcrossWait iterated Liveness::getLiveOut, a pointer-keyed set,
so the wait ops' destination block arguments were added in varying order.
Capture in region program order instead; region-defined live-out values are
exactly the block arguments and op results of the region's blocks. Extends
mem2reg.mlir with a case pinning the capture order.

Part of a series upstreaming SystemVerilog/UVM simulation support validated
against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
