### PR TITLE
[ImportVerilog] Support the %v strength format specifier

### DIFF
--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImportVerilogInternals.h"
+#include "circt/Support/FVInt.h"
 #include "slang/ast/SFormat.h"
 
 using namespace mlir;
@@ -157,6 +158,9 @@ struct FormatStringParser {
       return emitString(arg, options);
     case 'c':
       return emitChar(arg, options);
+
+    case 'v':
+      return emitStrength(arg);
 
     default:
       return mlir::emitError(loc)
@@ -328,6 +332,77 @@ struct FormatStringParser {
       return failure();
 
     fragments.push_back(moore::FormatCharOp::create(builder, loc, bitValue));
+    return success();
+  }
+
+  /// Emit a value formatted as net signal strength (%v). See IEEE 1800-2017
+  /// § 21.2.1.5 "Strength format". The Moore dialect does not model drive
+  /// strength, so driven bits are reported with strong strength: `St0`, `St1`,
+  /// `StX`, or `HiZ` for high-impedance bits. Vector operands print one
+  /// strength per bit, most significant bit first, separated by underscores.
+  LogicalResult emitStrength(const slang::ast::Expression &arg) {
+    auto value =
+        context.convertToSimpleBitVector(context.convertRvalueExpression(arg));
+    if (!value)
+      return failure();
+    auto intTy = cast<moore::IntType>(value.getType());
+    auto bitTy =
+        moore::IntType::get(context.getContext(), 1, intTy.getDomain());
+
+    // Create a string carrying the given literal text.
+    auto mkString = [&](StringRef text) -> Value {
+      auto literal = moore::FormatLiteralOp::create(builder, loc, text);
+      return moore::FormatStringToStringOp::create(builder, loc, literal);
+    };
+
+    // Select between two strings based on a single-bit condition.
+    auto selectString = [&](Value cond, Value trueValue,
+                            Value falseValue) -> Value {
+      auto strTy = moore::StringType::get(context.getContext());
+      auto condOp = moore::ConditionalOp::create(builder, loc, strTy, cond);
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPointToStart(&condOp.getTrueRegion().emplaceBlock());
+      moore::YieldOp::create(builder, loc, trueValue);
+      builder.setInsertionPointToStart(&condOp.getFalseRegion().emplaceBlock());
+      moore::YieldOp::create(builder, loc, falseValue);
+      return condOp.getResult();
+    };
+
+    for (unsigned i = intTy.getWidth(); i > 0; i--) {
+      if (i != intTy.getWidth())
+        emitLiteral("_");
+      Value bit = value;
+      if (intTy.getWidth() != 1)
+        bit = moore::ExtractOp::create(builder, loc, bitTy, value, i - 1);
+      Value strength;
+      if (intTy.getDomain() == moore::Domain::FourValued) {
+        // Compare the bit against constant 0, 1, and Z; anything else is X.
+        auto isEq = [&](const FVInt &fvValue) -> Value {
+          auto constant =
+              moore::ConstantOp::create(builder, loc, bitTy, fvValue);
+          return moore::CaseEqOp::create(builder, loc, bit, constant);
+        };
+        Value isZ = isEq(FVInt::getAllZ(1));
+        Value isZero = isEq(FVInt::getZero(1));
+        Value isOne = isEq(FVInt::getAllOnes(1));
+        // Create each literal in its own statement, in order of use with the
+        // true operand first, to keep the emitted op order independent of the
+        // host compiler's argument evaluation order.
+        Value st1 = mkString("St1");
+        Value stX = mkString("StX");
+        Value oneOrX = selectString(isOne, st1, stX);
+        Value st0 = mkString("St0");
+        Value zeroOrOther = selectString(isZero, st0, oneOrX);
+        Value hiZ = mkString("HiZ");
+        strength = selectString(isZ, hiZ, zeroOrOther);
+      } else {
+        Value st1 = mkString("St1");
+        Value st0 = mkString("St0");
+        strength = selectString(bit, st1, st0);
+      }
+      fragments.push_back(
+          moore::FormatStringOp::create(builder, loc, strength, {}, {}, {}));
+    }
     return success();
   }
 

--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -339,7 +339,7 @@ struct FormatStringParser {
   /// § 21.2.1.5 "Strength format". The Moore dialect does not model drive
   /// strength, so driven bits are reported with strong strength: `St0`, `St1`,
   /// `StX`, or `HiZ` for high-impedance bits. Vector operands print one
-  /// strength per bit, most significant bit first, separated by underscores.
+  /// strength per bit, most significant bit first, separated by spaces.
   LogicalResult emitStrength(const slang::ast::Expression &arg) {
     auto value =
         context.convertToSimpleBitVector(context.convertRvalueExpression(arg));
@@ -370,7 +370,7 @@ struct FormatStringParser {
 
     for (unsigned i = intTy.getWidth(); i > 0; i--) {
       if (i != intTy.getWidth())
-        emitLiteral("_");
+        emitLiteral(" ");
       Value bit = value;
       if (intTy.getWidth() != 1)
         bit = moore::ExtractOp::create(builder, loc, bitTy, value, i - 1);

--- a/test/Conversion/ImportVerilog/format-strings.sv
+++ b/test/Conversion/ImportVerilog/format-strings.sv
@@ -6,7 +6,7 @@
 // § 21.2.1.5 "Strength format"). The Moore dialect does not model drive
 // strength, so driven bits report strong strength: St0, St1, StX, or HiZ for
 // high-impedance bits. Vector operands print one strength per bit, most
-// significant bit first, separated by underscores.
+// significant bit first, separated by spaces.
 
 // CHECK-LABEL: moore.module @FormatStrength(
 // CHECK-DAG: [[ONE:%.+]] = moore.constant 1 : l1
@@ -37,11 +37,11 @@ module FormatStrength(input wire w, input wire [1:0] v);
     // CHECK: moore.fmt.string [[SELZ]]
     $display("%v", w);
 
-    // Vector: one strength per bit, MSB first, separated by underscores.
+    // Vector: one strength per bit, MSB first, separated by spaces.
     // CHECK: [[V:%.+]] = moore.read %v
     // CHECK: moore.extract [[V]] from 1 : l2 -> l1
     // CHECK: moore.fmt.string
-    // CHECK: moore.fmt.literal "_"
+    // CHECK: moore.fmt.literal " "
     // CHECK: moore.extract [[V]] from 0 : l2 -> l1
     // CHECK: moore.fmt.string
     $display("%v", v);

--- a/test/Conversion/ImportVerilog/format-strings.sv
+++ b/test/Conversion/ImportVerilog/format-strings.sv
@@ -1,0 +1,57 @@
+// RUN: circt-verilog --ir-moore %s | FileCheck %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// The %v specifier prints the signal strength of a net (IEEE 1800-2017
+// § 21.2.1.5 "Strength format"). The Moore dialect does not model drive
+// strength, so driven bits report strong strength: St0, St1, StX, or HiZ for
+// high-impedance bits. Vector operands print one strength per bit, most
+// significant bit first, separated by underscores.
+
+// CHECK-LABEL: moore.module @FormatStrength(
+// CHECK-DAG: [[ONE:%.+]] = moore.constant 1 : l1
+// CHECK-DAG: [[ZERO:%.+]] = moore.constant 0 : l1
+// CHECK-DAG: [[Z:%.+]] = moore.constant bZ : l1
+module FormatStrength(input wire w, input wire [1:0] v);
+  bit b;
+  initial begin
+    // Four-valued scalar: compare against Z, 0, and 1; anything else is X.
+    // CHECK: [[W:%.+]] = moore.read %w
+    // CHECK: [[ISZ:%.+]] = moore.case_eq [[W]], [[Z]] : l1
+    // CHECK: [[ISZERO:%.+]] = moore.case_eq [[W]], [[ZERO]] : l1
+    // CHECK: [[ISONE:%.+]] = moore.case_eq [[W]], [[ONE]] : l1
+    // CHECK: [[LIT1:%.+]] = moore.fmt.literal "St1"
+    // CHECK: [[STR1:%.+]] = moore.fstring_to_string [[LIT1]]
+    // CHECK: [[LITX:%.+]] = moore.fmt.literal "StX"
+    // CHECK: [[STRX:%.+]] = moore.fstring_to_string [[LITX]]
+    // CHECK: moore.conditional [[ISONE]] : i1 -> string
+    // CHECK: moore.yield [[STR1]]
+    // CHECK: moore.yield [[STRX]]
+    // CHECK: [[LIT0:%.+]] = moore.fmt.literal "St0"
+    // CHECK: [[STR0:%.+]] = moore.fstring_to_string [[LIT0]]
+    // CHECK: moore.conditional [[ISZERO]] : i1 -> string
+    // CHECK: [[LITZ:%.+]] = moore.fmt.literal "HiZ"
+    // CHECK: [[STRZ:%.+]] = moore.fstring_to_string [[LITZ]]
+    // CHECK: [[SELZ:%.+]] = moore.conditional [[ISZ]] : i1 -> string
+    // CHECK: moore.yield [[STRZ]]
+    // CHECK: moore.fmt.string [[SELZ]]
+    $display("%v", w);
+
+    // Vector: one strength per bit, MSB first, separated by underscores.
+    // CHECK: [[V:%.+]] = moore.read %v
+    // CHECK: moore.extract [[V]] from 1 : l2 -> l1
+    // CHECK: moore.fmt.string
+    // CHECK: moore.fmt.literal "_"
+    // CHECK: moore.extract [[V]] from 0 : l2 -> l1
+    // CHECK: moore.fmt.string
+    $display("%v", v);
+
+    // Two-valued: the bit itself selects between St1 and St0.
+    // CHECK: [[B:%.+]] = moore.read %b
+    // CHECK: [[SELB:%.+]] = moore.conditional [[B]] : i1 -> string
+    // CHECK: moore.yield [[STR1]]
+    // CHECK: moore.yield [[STR0]]
+    // CHECK: moore.fmt.string [[SELB]]
+    $display("%v", b);
+  end
+endmodule


### PR DESCRIPTION
The %v format specification displays the signal strength of a scalar net
(IEEE 1800-2017 § 21.2.1.5), but format strings containing it currently fail
to import with an unsupported-format-specifier error.

The Moore dialect does not model drive strength, so report the strength of the
resolved value instead: compare each bit against 0, 1, and Z with case
equality and select among the St0, St1, HiZ, and StX literals; two-valued bits
select directly between St0 and St1. Vector operands print one strength per
bit, most significant bit first, separated by underscores, following common
simulator behavior.

Adds format-strings.sv covering the four-valued, two-valued, and vector cases.

Part of a series upstreaming SystemVerilog/UVM simulation support validated
against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
