### PR TITLE
[HW] Materialize constant bitcasts as aggregate constants

### DIFF
--- a/lib/Dialect/HW/Transforms/HWConvertBitcasts.cpp
+++ b/lib/Dialect/HW/Transforms/HWConvertBitcasts.cpp
@@ -170,6 +170,49 @@ static Value constructAggregateRecursively(OpBuilder builder, Location loc,
   return {};
 }
 
+// Build the `fields` attribute of an `hw.aggregate_constant` equivalent to
+// bitcasting the constant integer `bits` onto `targetType`, following the bit
+// conventions above: for arrays lower bits correspond to lower indices and
+// attribute position 0 holds the highest index (matching ArrayGetOp::fold);
+// for structs higher bits correspond to lower field indices. Only aggregates
+// with non-zero-width integer leaves are materialized, since consumers of the
+// fields attribute (such as the Arc array lowering's buffer initialization)
+// expect integer leaves; all other target types return a null attribute and
+// keep the generic expansion.
+static ArrayAttr convertConstantToFields(OpBuilder &builder, const APInt &bits,
+                                         Type targetType) {
+  if (auto arrayTy = type_dyn_cast<ArrayType>(targetType)) {
+    auto elementTy = dyn_cast<IntegerType>(arrayTy.getElementType());
+    if (!elementTy || elementTy.getWidth() == 0)
+      return {};
+    unsigned width = elementTy.getWidth();
+    unsigned numElements = arrayTy.getNumElements();
+    SmallVector<Attribute> fields;
+    fields.reserve(numElements);
+    for (unsigned i = 0; i < numElements; ++i)
+      fields.push_back(builder.getIntegerAttr(
+          elementTy, bits.extractBits(width, width * (numElements - 1 - i))));
+    return builder.getArrayAttr(fields);
+  }
+
+  if (auto structTy = type_dyn_cast<StructType>(targetType)) {
+    unsigned offset = bits.getBitWidth();
+    SmallVector<Attribute> fields;
+    fields.reserve(structTy.getElements().size());
+    for (auto fieldInfo : structTy.getElements()) {
+      auto fieldTy = dyn_cast<IntegerType>(fieldInfo.type);
+      if (!fieldTy || fieldTy.getWidth() == 0)
+        return {};
+      offset -= fieldTy.getWidth();
+      fields.push_back(builder.getIntegerAttr(
+          fieldTy, bits.extractBits(fieldTy.getWidth(), offset)));
+    }
+    return builder.getArrayAttr(fields);
+  }
+
+  return {};
+}
+
 LogicalResult HWConvertBitcastsPass::convertBitcastOp(OpBuilder builder,
                                                       BitcastOp bitcastOp) {
   bool inputSupported = isTypeSupported(bitcastOp.getInput().getType());
@@ -184,6 +227,21 @@ LogicalResult HWConvertBitcastsPass::convertBitcastOp(OpBuilder builder,
     return failure();
 
   builder.setInsertionPoint(bitcastOp);
+
+  // A constant integer source materializes directly as a constant aggregate.
+  // The generic expansion below would emit one comb.extract of the full-width
+  // source per scalar element, which is prohibitively large for wide constants
+  // such as memory initialization values.
+  if (auto constantOp = bitcastOp.getInput().getDefiningOp<ConstantOp>()) {
+    if (auto fields = convertConstantToFields(builder, constantOp.getValue(),
+                                              bitcastOp.getType())) {
+      auto aggregate = AggregateConstantOp::create(builder, bitcastOp.getLoc(),
+                                                   bitcastOp.getType(), fields);
+      bitcastOp.getResult().replaceAllUsesWith(aggregate.getResult());
+      bitcastOp.erase();
+      return success();
+    }
+  }
 
   // Convert input value to a packed integer
   SmallVector<Value> integers;

--- a/test/Dialect/HW/hw-convert-bitcasts.mlir
+++ b/test/Dialect/HW/hw-convert-bitcasts.mlir
@@ -101,3 +101,54 @@ hw.module @mixedRoundtrip(in %raw: i32, out o : i32) {
   // CANON: hw.output %raw : i32
   hw.output %2 : i32
 }
+
+// Bitcasts of constant integers materialize directly as constant aggregates
+// instead of expanding into one comb.extract per element.
+// Arrays: lower bits are lower indices; attribute position 0 holds the
+// highest index. 4660 = (1 << 12) | (2 << 8) | (3 << 4) | 4.
+// NOCANON-LABEL: hw.module @constToArray
+hw.module @constToArray(out o : !hw.array<4xi4>) {
+  // NOCANON-NOT: comb.extract
+  // NOCANON: %[[AGG:.+]] = hw.aggregate_constant [1 : i4, 2 : i4, 3 : i4, 4 : i4] : !hw.array<4xi4>
+  %k = hw.constant 4660 : i16
+  %o = hw.bitcast %k : (i16) -> !hw.array<4xi4>
+  // NOCANON: hw.output %[[AGG]]
+  hw.output %o : !hw.array<4xi4>
+}
+
+// Structs: higher bits are lower field indices. 19481 = (1 << 14) | (6 << 9) | 25.
+// NOCANON-LABEL: hw.module @constToStruct
+hw.module @constToStruct(out o : !hw.struct<a: i2, b: i5, c: i9>) {
+  // NOCANON-NOT: comb.extract
+  // NOCANON: %[[AGG:.+]] = hw.aggregate_constant [1 : i2, 6 : i5, 25 : i9] : !hw.struct<a: i2, b: i5, c: i9>
+  %k = hw.constant 19481 : i16
+  %o = hw.bitcast %k : (i16) -> !hw.struct<a: i2, b: i5, c: i9>
+  // NOCANON: hw.output %[[AGG]]
+  hw.output %o : !hw.struct<a: i2, b: i5, c: i9>
+}
+
+// Nested aggregate targets keep the generic expansion: consumers of the
+// aggregate constant fields attribute expect integer leaves.
+// NOCANON-LABEL: hw.module @constToNested
+hw.module @constToNested(out o : !hw.array<2xstruct<x: i3, y: i5>>) {
+  // NOCANON-NOT: hw.aggregate_constant
+  // NOCANON: comb.extract
+  // NOCANON: hw.struct_create
+  // NOCANON: hw.array_create
+  // NOCANON-NOT: hw.aggregate_constant
+  // NOCANON: hw.output
+  %k = hw.constant 43981 : i16
+  %o = hw.bitcast %k : (i16) -> !hw.array<2xstruct<x: i3, y: i5>>
+  hw.output %o : !hw.array<2xstruct<x: i3, y: i5>>
+}
+
+// Zero-element arrays materialize as an empty aggregate constant.
+// NOCANON-LABEL: hw.module @constToEmptyArray
+hw.module @constToEmptyArray(out o : !hw.array<0xi4>) {
+  // NOCANON-NOT: comb.extract
+  // NOCANON: %[[AGG:.+]] = hw.aggregate_constant [] : !hw.array<0xi4>
+  %k = hw.constant 0 : i0
+  %o = hw.bitcast %k : (i0) -> !hw.array<0xi4>
+  // NOCANON: hw.output %[[AGG]]
+  hw.output %o : !hw.array<0xi4>
+}


### PR DESCRIPTION
The hw-convert-bitcasts pass expands every int-to-aggregate bitcast through the generic path: one comb.extract of the full-width source per scalar element, plus the array_create/struct_create tree. For a bitcast of a wide hw.constant this expansion is redundant and does not scale — a memory initialization constant bitcast from i524288 to !hw.array<16384xi32> becomes 16384 extracts of an i524288 plus a 16384-operand array_create, which downstream lowering cannot handle.

Slice the constant's APInt directly into an hw.aggregate_constant instead, following the pass's bit conventions: for arrays lower bits are lower indices and attribute position 0 holds the highest index (matching ArrayGetOp::fold); for structs higher bits are lower field indices. Only aggregates with integer leaves are materialized, since consumers of the fields attribute such as the Arc array lowering's buffer initialization expect integer leaves; nested aggregate targets and all other shapes keep the generic expansion. Extends hw-convert-bitcasts.mlir with array, struct, and nested-fallback cases.

Part of a series upstreaming SystemVerilog/UVM simulation support validated against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
