### PR TITLE
[ImportVerilog] Lower intra-assignment repeated event controls

### DIFF
--- a/lib/Conversion/ImportVerilog/TimingControls.cpp
+++ b/lib/Conversion/ImportVerilog/TimingControls.cpp
@@ -190,11 +190,13 @@ static LogicalResult handleRoot(Context &context,
     mlir::cf::BranchOp::create(builder, loc, &checkBlock, count);
 
     // Loop while the remaining count is greater than zero, honoring the
-    // signedness of the count expression.
+    // signedness of the count expression. Floating count expressions convert
+    // to a signed integer, so compare them signed as well such that negative
+    // counts skip the event control entirely.
     builder.setInsertionPointToEnd(&checkBlock);
     Value zero = moore::ConstantOp::create(builder, loc, countType, 0);
     Value cond =
-        repeatCtrl.expr.type->isSigned()
+        repeatCtrl.expr.type->isSigned() || repeatCtrl.expr.type->isFloating()
             ? moore::SgtOp::create(builder, loc, currentCount, zero).getResult()
             : moore::UgtOp::create(builder, loc, currentCount, zero)
                   .getResult();

--- a/lib/Conversion/ImportVerilog/TimingControls.cpp
+++ b/lib/Conversion/ImportVerilog/TimingControls.cpp
@@ -162,16 +162,58 @@ static LogicalResult handleRoot(Context &context,
 
   using slang::ast::TimingControlKind;
   switch (ctrl.kind) {
-    // TODO: Actually implement a lowering for repeated event control. The main
-    // way to trigger this is through an intra-assignment timing control, which
-    // is not yet supported:
-    //
-    //   a = repeat(3) @(posedge b) c;
-    //
-    // This will want to recursively call this function at the right insertion
-    // point to handle the timing control being repeated.
-  case TimingControlKind::RepeatedEvent:
-    return mlir::emitError(loc) << "unsupported repeated event control";
+    // Handle repeated event control, `repeat (<count>) @(...)`. This appears
+    // as an intra-assignment timing control, `a = repeat(3) @(posedge b) c;`,
+    // where the assignment first evaluates its right-hand side and then waits
+    // for the nested event control to trigger the given number of times.
+    // Lower it as a count-down loop around the nested event control. A count
+    // of zero or less skips the event control entirely (IEEE 1800-2017
+    // 9.4.5).
+  case TimingControlKind::RepeatedEvent: {
+    auto &repeatCtrl = ctrl.as<slang::ast::RepeatedEventControl>();
+    auto count = context.convertRvalueExpression(
+        repeatCtrl.expr, moore::IntType::getInt(builder.getContext(), 32));
+    if (!count)
+      return failure();
+    auto countType = cast<moore::IntType>(count.getType());
+
+    // Create the blocks for the loop condition check, body, and exit.
+    auto createBlock = [&]() -> Block & {
+      auto block = std::make_unique<Block>();
+      block->insertAfter(builder.getInsertionBlock());
+      return *block.release();
+    };
+    auto &exitBlock = createBlock();
+    auto &bodyBlock = createBlock();
+    auto &checkBlock = createBlock();
+    auto currentCount = checkBlock.addArgument(count.getType(), count.getLoc());
+    mlir::cf::BranchOp::create(builder, loc, &checkBlock, count);
+
+    // Loop while the remaining count is greater than zero, honoring the
+    // signedness of the count expression.
+    builder.setInsertionPointToEnd(&checkBlock);
+    Value zero = moore::ConstantOp::create(builder, loc, countType, 0);
+    Value cond =
+        repeatCtrl.expr.type->isSigned()
+            ? moore::SgtOp::create(builder, loc, currentCount, zero).getResult()
+            : moore::UgtOp::create(builder, loc, currentCount, zero)
+                  .getResult();
+    cond = moore::ToBuiltinIntOp::create(builder, loc, cond);
+    mlir::cf::CondBranchOp::create(builder, loc, cond, &bodyBlock, &exitBlock);
+
+    // Wait for the nested event control once per iteration and decrement the
+    // remaining count.
+    builder.setInsertionPointToEnd(&bodyBlock);
+    if (failed(handleRoot(context, repeatCtrl.event, nullptr)))
+      return failure();
+    Value one = moore::ConstantOp::create(builder, loc, countType, 1);
+    Value nextCount = moore::SubOp::create(builder, loc, currentCount, one);
+    mlir::cf::BranchOp::create(builder, loc, &checkBlock, nextCount);
+
+    // Continue after the loop.
+    builder.setInsertionPointToEnd(&exitBlock);
+    return success();
+  }
 
     // Handle implicit events, i.e. `@*` and `@(*)`. This implicitly includes
     // all variables read within the statement that follows after the event

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -49,8 +49,23 @@ endmodule
 // -----
 module Foo;
   int x;
+  bit y;
+  // expected-error @below {{unsupported non-blocking assignment timing control: RepeatedEvent}}
+  initial x <= repeat (2) @(posedge y) x;
+endmodule
+
+// -----
+module Foo;
+  int x;
   // expected-error @below {{implicit events cannot be used here}}
   initial x = @* x;
+endmodule
+
+// -----
+module Foo;
+  int x;
+  // expected-error @below {{implicit events cannot be used here}}
+  initial x = repeat (2) @* x;
 endmodule
 
 // -----

--- a/test/Conversion/ImportVerilog/timing-controls.sv
+++ b/test/Conversion/ImportVerilog/timing-controls.sv
@@ -1,0 +1,47 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// CHECK-LABEL: moore.module @RepeatedEventControl
+module RepeatedEventControl;
+  int a, b;
+  bit clk;
+  bit [31:0] n;
+
+  // Intra-assignment repeated event control with a signed count. The
+  // right-hand side is evaluated first, then the event control is awaited
+  // count times, then the assignment takes effect. A count of zero or less
+  // skips the event control entirely.
+  initial begin
+    // CHECK: [[RHS:%.+]] = moore.read %b
+    // CHECK: [[COUNT:%.+]] = moore.constant 3 : i32
+    // CHECK: cf.br ^[[CHECK:bb[0-9]+]]([[COUNT]] : !moore.i32)
+    // CHECK: ^[[CHECK]]([[REMAINING:%.+]]: !moore.i32):
+    // CHECK: [[ZERO:%.+]] = moore.constant 0 : i32
+    // CHECK: [[CMP:%.+]] = moore.sgt [[REMAINING]], [[ZERO]] : i32 -> i1
+    // CHECK: [[COND:%.+]] = moore.to_builtin_int [[CMP]] : i1
+    // CHECK: cf.cond_br [[COND]], ^[[BODY:bb[0-9]+]], ^[[EXIT:bb[0-9]+]]
+    // CHECK: ^[[BODY]]:
+    // CHECK: moore.wait_event {
+    // CHECK:   [[CLK:%.+]] = moore.read %clk
+    // CHECK:   moore.detect_event posedge [[CLK]]
+    // CHECK: }
+    // CHECK: [[ONE:%.+]] = moore.constant 1 : i32
+    // CHECK: [[NEXT:%.+]] = moore.sub [[REMAINING]], [[ONE]] : i32
+    // CHECK: cf.br ^[[CHECK]]([[NEXT]] : !moore.i32)
+    // CHECK: ^[[EXIT]]:
+    // CHECK: moore.blocking_assign %a, [[RHS]]
+    a = repeat (3) @(posedge clk) b;
+  end
+
+  // An unsigned count uses an unsigned comparison.
+  initial begin
+    // CHECK: moore.ugt
+    // CHECK: moore.wait_event
+    // CHECK: moore.detect_event negedge
+    // CHECK: moore.blocking_assign %a
+    a = repeat (n) @(negedge clk) b;
+  end
+endmodule

--- a/test/Conversion/ImportVerilog/timing-controls.sv
+++ b/test/Conversion/ImportVerilog/timing-controls.sv
@@ -9,6 +9,7 @@ module RepeatedEventControl;
   int a, b;
   bit clk;
   bit [31:0] n;
+  real r;
 
   // Intra-assignment repeated event control with a signed count. The
   // right-hand side is evaluated first, then the event control is awaited
@@ -43,5 +44,15 @@ module RepeatedEventControl;
     // CHECK: moore.detect_event negedge
     // CHECK: moore.blocking_assign %a
     a = repeat (n) @(negedge clk) b;
+  end
+
+  // A floating count converts to a signed integer and uses a signed
+  // comparison, so a negative count skips the event control.
+  initial begin
+    // CHECK: moore.sgt
+    // CHECK: moore.wait_event
+    // CHECK: moore.detect_event posedge
+    // CHECK: moore.blocking_assign %a
+    a = repeat (r) @(posedge clk) b;
   end
 endmodule


### PR DESCRIPTION
An intra-assignment repeated event control such as `a = repeat(3) @(posedge clk) b;` failed to import with `unsupported repeated event control`. The blocking assignment path already evaluates the right-hand side before converting its timing control, so the repeat can be lowered in place at that point.

Convert the repeat count to a 32-bit integer once and wrap the existing event control lowering in a count-down loop. The loop condition is a signed or unsigned greater-than-zero comparison depending on the signedness of the count expression, so a count of zero or less skips the event control entirely (IEEE 1800-2017 9.4.5). Non-blocking assignments with a repeated event control and repeats of an implicit event still report an error.

Adds timing-controls.sv covering signed and unsigned repeat counts, and error cases for the non-blocking and implicit-event forms in errors.sv.

Part of a series upstreaming SystemVerilog/UVM simulation support validated against the sv-tests suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
