### PR TITLE
[PyRTG] Thread a CodeGenContext through for CLI-configurable settings

### DIFF
--- a/frontends/PyRTG/src/pyrtg/configs.py
+++ b/frontends/PyRTG/src/pyrtg/configs.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from .core import CodeGenRoot, Type, Value
+from .core import CodeGenContext, CodeGenRoot, Type, Value
 from .base import ir
 from .rtg import rtg
 from .tuples import Tuple, TupleType
@@ -177,7 +177,7 @@ class Config(CodeGenRoot):
 
     return params
 
-  def _codegen(self) -> None:
+  def _codegen(self, context: CodeGenContext) -> None:
     self._already_generated = True
 
     # Construct the target operation.

--- a/frontends/PyRTG/src/pyrtg/core.py
+++ b/frontends/PyRTG/src/pyrtg/core.py
@@ -4,7 +4,32 @@
 
 from __future__ import annotations
 
+from enum import Enum
+
 from .base import ir
+
+
+class MemoryUsage(Enum):
+  """
+  How constrained a test's generated program may be with memory usage, i.e.,
+  how much memory it may use for the program binary itself as well as global
+  data (e.g., static strings).
+  """
+
+  SUPER_STRICT = "super-strict"
+  STRICT = "strict"
+  NORMAL = "normal"
+  RELAXED = "relaxed"
+  UNCONSTRAINED = "unconstrained"
+
+
+class CodeGenContext:
+  """
+  Command-line provided settings that influence codegen.
+  """
+
+  def __init__(self, memory_usage: MemoryUsage = MemoryUsage.NORMAL):
+    self.memory_usage = memory_usage
 
 
 class CodeGenObject:
@@ -23,7 +48,7 @@ class CodeGenObject:
     return []
 
   @classmethod
-  def _codegen_all_instances(cls) -> None:
+  def _codegen_all_instances(cls, context: CodeGenContext) -> None:
     processed: set[CodeGenObject] = set()
 
     def do_codegen(obj):
@@ -33,13 +58,13 @@ class CodeGenObject:
           processed.add(dependent)
 
       if obj not in processed:
-        obj._codegen()
+        obj._codegen(context)
         processed.add(obj)
 
     for obj in cls._registry:
       do_codegen(obj)
 
-  def _codegen(self):
+  def _codegen(self, context: CodeGenContext):
     assert False, "must be implemented by the subclass"
 
 

--- a/frontends/PyRTG/src/pyrtg/sequences.py
+++ b/frontends/PyRTG/src/pyrtg/sequences.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from .core import CodeGenObject, Value, Type
+from .core import CodeGenContext, CodeGenObject, Value, Type
 from .support import _FromCirctValue, _FromCirctType
 from .base import ir
 from .rtg import rtg
@@ -67,7 +67,9 @@ class SequenceDeclaration(CodeGenObject):
 
     self.get()(*args)
 
-  def _codegen(self) -> None:
+  def _codegen(self, context: CodeGenContext) -> None:
+    self.context = context
+
     mlir_arg_types = [arg._codegen() for arg in self.arg_types]
     seq = rtg.SequenceOp(self.name,
                          ir.TypeAttr.get(rtg.SequenceType.get(mlir_arg_types)))

--- a/frontends/PyRTG/src/pyrtg/tests.py
+++ b/frontends/PyRTG/src/pyrtg/tests.py
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .base import ir
-from .core import CodeGenRoot, CodeGenObject
+from .core import CodeGenContext, CodeGenRoot, CodeGenObject
 from .rtg import rtg
 from .support import _FromCirctValue
 from .configs import PythonParam
@@ -30,7 +30,9 @@ class Test(CodeGenRoot):
   def name(self) -> str:
     return self.test_func.__name__
 
-  def _codegen(self):
+  def _codegen(self, context: CodeGenContext):
+    self.context = context
+
     # Sort arguments by name
     params_sorted = self.config.get_params()
     params_sorted.sort(key=lambda param: param.get_name())

--- a/frontends/PyRTG/src/rtgtool/rtgtool.py
+++ b/frontends/PyRTG/src/rtgtool/rtgtool.py
@@ -13,6 +13,7 @@ from types import ModuleType
 import pyrtg
 from pyrtg.circt import ir, passmanager, register_dialects
 from pyrtg.diagnostics import Verbosity
+from pyrtg.core import MemoryUsage, CodeGenContext
 
 
 class InputFormat(Enum):
@@ -87,6 +88,13 @@ def parse_args() -> argparse.Namespace:
                       choices=list(Verbosity),
                       default=Verbosity.NORMAL,
                       help="Verbosity level for diagnostic output")
+  parser.add_argument(
+      "--memory-usage",
+      type=MemoryUsage,
+      choices=list(MemoryUsage),
+      default=MemoryUsage.NORMAL,
+      help="How constrained the generated program may be with memory usage "
+      "for the program binary and its global data")
 
   args = parser.parse_args()
 
@@ -130,7 +138,8 @@ def frontend_codegen(args: argparse.Namespace) -> ir.Module:
 
     module = ir.Module.create(loc=ir.Location.file(args.file, 0, 0))
     with ir.InsertionPoint(module.body):
-      pyrtg.core.CodeGenRoot._codegen_all_instances()
+      pyrtg.core.CodeGenRoot._codegen_all_instances(
+          CodeGenContext(memory_usage=args.memory_usage))
     return module
 
   assert False, "input format must be one of the above"

--- a/frontends/PyRTG/test/test_memory_usage.py
+++ b/frontends/PyRTG/test/test_memory_usage.py
@@ -1,0 +1,38 @@
+# RUN: %rtgtool% %s --seed=0 --output-format=mlir --memory-usage=super-strict | FileCheck %s --check-prefix=STRICT
+# RUN: %rtgtool% %s --seed=0 --output-format=mlir --memory-usage=normal | FileCheck %s --check-prefix=NORMAL
+
+from pyrtg import test, sequence, config, Config, embed_comment
+from pyrtg.core import MemoryUsage
+
+
+@sequence([])
+def mem_usage_seq():
+  if mem_usage_seq.context.memory_usage != MemoryUsage.SUPER_STRICT:
+    embed_comment("sequence: memory usage allows extra data")
+
+
+@config
+class MemUsageConfig(Config):
+  pass
+
+
+# STRICT-LABEL: rtg.test @test_conditional_op
+# STRICT-CHECK-NOT: rtg.comment
+
+# STRICT-LABEL: rtg.sequence @mem_usage_seq
+# STRICT-NEXT: }
+
+# NORMAL-LABEL: rtg.test @test_conditional_op
+# NORMAL: [[STR:%.+]] = rtg.constant "test: memory usage allows extra data" : !rtg.string
+# NORMAL: rtg.comment [[STR]]
+
+# NORMAL-LABEL: rtg.sequence @mem_usage_seq
+# NORMAL: [[SEQSTR:%.+]] = rtg.constant "sequence: memory usage allows extra data" : !rtg.string
+# NORMAL: rtg.comment [[SEQSTR]]
+
+
+@test(MemUsageConfig)
+def test_conditional_op(config):
+  mem_usage_seq()
+  if test_conditional_op.context.memory_usage != MemoryUsage.SUPER_STRICT:
+    embed_comment("test: memory usage allows extra data")


### PR DESCRIPTION
One such setting is how constraint we are on memory. If we are very constraint, we can reduce the binary size at the cost of debuggability, etc.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->


Assisted-by: Claude Code:Sonnet 5 [1M]