### PR TITLE
[Synth] Share SAT solver construction helper, NFC

### DIFF
--- a/include/circt/Support/SATSolver.h
+++ b/include/circt/Support/SATSolver.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include <memory>
 
 namespace circt {
@@ -241,6 +242,11 @@ std::unique_ptr<IncrementalSATSolver>
 createCadicalSATSolver(const CadicalSATSolverOptions &options = {});
 /// Return true when at least one incremental SAT backend is available.
 bool hasIncrementalSATSolverBackend();
+
+/// Construct an incremental SAT solver using the requested backend. The
+/// `auto` backend prefers CaDiCaL and falls back to Z3.
+std::unique_ptr<IncrementalSATSolver>
+createSATSolver(llvm::StringRef backend = "auto");
 
 } // namespace circt
 

--- a/lib/Dialect/Synth/Transforms/ExactSynthesis.cpp
+++ b/lib/Dialect/Synth/Transforms/ExactSynthesis.cpp
@@ -134,20 +134,6 @@ struct ExactSynthesisPolicy {
   SmallVector<ExactNodeInfo, 4> primitiveInfos;
 };
 
-static std::unique_ptr<IncrementalSATSolver>
-createExactSynthesisSATSolver(StringRef backend) {
-  if (backend == "auto") {
-    if (auto solver = createCadicalSATSolver())
-      return solver;
-    return createZ3SATSolver();
-  }
-  if (backend == "cadical")
-    return createCadicalSATSolver();
-  if (backend == "z3")
-    return createZ3SATSolver();
-  return {};
-}
-
 static SmallString<64>
 formatPrimitiveSummary(const ExactSynthesisPolicy &policy) {
   SmallString<64> text;
@@ -660,7 +646,7 @@ exactSynthesizeAreaMinimized(OpBuilder &builder, Location loc, APInt truthTable,
 
   for (unsigned area = 1; area <= maxArea; ++area) {
     LDBG() << "Trying area=" << area << "\n";
-    auto solver = createExactSynthesisSATSolver(satSolver);
+    auto solver = createSATSolver(satSolver);
     if (!solver)
       return failure();
     GenericExactSATProblem problem(policy, *solver, numInputs, truthTable,
@@ -821,7 +807,7 @@ struct ExactSynthesisPass
       return failure();
     policy = *parsedPolicy;
 
-    if (!createExactSynthesisSATSolver(satSolver)) {
+    if (!createSATSolver(satSolver)) {
       emitError(UnknownLoc::get(context))
           << "unsupported or unavailable SAT solver '" << satSolver
           << "' (expected auto, z3, or cadical)";

--- a/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
+++ b/lib/Dialect/Synth/Transforms/FunctionalReduction.cpp
@@ -56,20 +56,6 @@ using namespace circt::synth;
 namespace {
 enum class EquivResult { Proved, Disproved, Unknown };
 
-std::unique_ptr<IncrementalSATSolver>
-createFunctionalReductionSATSolver(llvm::StringRef backend) {
-  if (backend == "auto") {
-    if (auto solver = createCadicalSATSolver())
-      return solver;
-    return createZ3SATSolver();
-  }
-  if (backend == "cadical")
-    return createCadicalSATSolver();
-  if (backend == "z3")
-    return createZ3SATSolver();
-  return {};
-}
-
 class FunctionalReductionSATBuilder {
 public:
   FunctionalReductionSATBuilder(IncrementalSATSolver &solver,
@@ -799,7 +785,7 @@ struct FunctionalReductionPass
 
     std::unique_ptr<IncrementalSATSolver> satSolver;
     if (!testTransformation) {
-      satSolver = createFunctionalReductionSATSolver(this->satSolver);
+      satSolver = createSATSolver(this->satSolver);
       if (!satSolver) {
         module.emitError() << "unsupported or unavailable SAT solver '"
                            << this->satSolver

--- a/lib/Support/SATSolver.cpp
+++ b/lib/Support/SATSolver.cpp
@@ -379,9 +379,21 @@ createCadicalSATSolver(const CadicalSATSolverOptions &options) {
 #endif
 }
 
+std::unique_ptr<IncrementalSATSolver> createSATSolver(llvm::StringRef backend) {
+  if (backend == "auto") {
+    if (auto solver = createCadicalSATSolver())
+      return solver;
+    return createZ3SATSolver();
+  }
+  if (backend == "cadical")
+    return createCadicalSATSolver();
+  if (backend == "z3")
+    return createZ3SATSolver();
+  return {};
+}
+
 bool hasIncrementalSATSolverBackend() {
-  return static_cast<bool>(createCadicalSATSolver()) ||
-         static_cast<bool>(createZ3SATSolver());
+  return static_cast<bool>(createSATSolver());
 }
 
 } // namespace circt


### PR DESCRIPTION
It unifies SAT solver utils locally defined in FC and ExactSynthesis. 
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
