### PR TITLE
[MooreToCore] Lower moore.null and handle comparisons to LLVM ptr ops

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1912,6 +1912,34 @@ struct ICmpOpConversion : public OpConversionPattern<SourceOp> {
   }
 };
 
+struct NullOpConversion : public OpConversionPattern<NullOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(NullOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type ptrTy = getTypeConverter()->convertType(op.getResult().getType());
+    if (!ptrTy)
+      return rewriter.notifyMatchFailure(op, "failed to convert null type");
+    rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, ptrTy);
+    return success();
+  }
+};
+
+template <typename SourceOp, LLVM::ICmpPredicate pred>
+struct HandleCmpOpConversion : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+  using OpAdaptor = typename SourceOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<LLVM::ICmpOp>(op, pred, adaptor.getLhs(),
+                                              adaptor.getRhs());
+    return success();
+  }
+};
+
 template <typename SourceOp, arith::CmpFPredicate pred>
 struct FCmpOpConversion : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
@@ -3718,6 +3746,11 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
     return LLVM::LLVMPointerType::get(type.getContext());
   });
 
+  // NullType -> !llvm.ptr
+  typeConverter.addConversion([&](NullType type) -> std::optional<Type> {
+    return LLVM::LLVMPointerType::get(type.getContext());
+  });
+
   typeConverter.addConversion([&](RefType type) -> std::optional<Type> {
     if (isa<OpenArrayType, OpenUnpackedArrayType>(type.getNestedType()))
       return LLVM::LLVMPointerType::get(type.getContext());
@@ -3812,6 +3845,7 @@ static void populateOpConversion(ConversionPatternSet &patterns,
   // clang-format off
   patterns.add<
     ClassUpcastOpConversion,
+    NullOpConversion,
     // Patterns of declaration operations.
     VariableOpConversion,
     NetOpConversion,
@@ -3914,6 +3948,8 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FCmpOpConversion<EqRealOp, arith::CmpFPredicate::OEQ>,
     CaseXZEqOpConversion<CaseZEqOp, true>,
     CaseXZEqOpConversion<CaseXZEqOp, false>,
+    HandleCmpOpConversion<HandleEqOp, LLVM::ICmpPredicate::eq>,
+    HandleCmpOpConversion<HandleNeOp, LLVM::ICmpPredicate::ne>,
 
     // Patterns of structural operations.
     SVModuleOpConversion,

--- a/test/Conversion/MooreToCore/classes.mlir
+++ b/test/Conversion/MooreToCore/classes.mlir
@@ -159,3 +159,46 @@ moore.class.classdecl @VirtualC {
   moore.class.propertydecl @a : !moore.i32
   moore.class.methoddecl @f : (!moore.class<@VirtualC>) -> ()
 }
+
+// CHECK-LABEL: func.func private @test_null1() -> !llvm.ptr
+// CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+// CHECK: return [[NULL]] : !llvm.ptr
+func.func private @test_null1() -> !moore.null {
+  %null = moore.null
+  return %null : !moore.null
+}
+
+// CHECK-LABEL: func.func private @test_handle_eq1
+// CHECK-SAME: (%arg0: !llvm.ptr) -> i1
+// CHECK: [[NULL:%.+]] = llvm.mlir.zero : !llvm.ptr
+// CHECK: [[EQ:%.+]] = llvm.icmp "eq" %arg0, [[NULL]] : !llvm.ptr
+// CHECK: return [[EQ]] : i1
+func.func private @test_handle_eq1(%arg0: !moore.class<@H>) -> !moore.i1 {
+  %null = moore.null
+  %eq = moore.handle_eq %arg0, %null : !moore.class<@H> : !moore.null -> i1
+  return %eq : !moore.i1
+}
+moore.class.classdecl @H {
+  moore.class.propertydecl @a : !moore.i32
+}
+
+// CHECK-LABEL: func.func private @test_handle_ne1
+// CHECK-SAME: (%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> i1
+// CHECK: [[NE:%.+]] = llvm.icmp "ne" %arg0, %arg1 : !llvm.ptr
+// CHECK: return [[NE]] : i1
+func.func private @test_handle_ne1(%arg0: !moore.chandle, %arg1: !moore.chandle) -> !moore.i1 {
+  %ne = moore.handle_ne %arg0, %arg1 : !moore.chandle : !moore.chandle -> i1
+  return %ne : !moore.i1
+}
+
+// CHECK-LABEL: func.func private @test_null_eq_null
+// CHECK: [[N0:%.+]] = llvm.mlir.zero : !llvm.ptr
+// CHECK: [[N1:%.+]] = llvm.mlir.zero : !llvm.ptr
+// CHECK: [[EQ:%.+]] = llvm.icmp "eq" [[N0]], [[N1]] : !llvm.ptr
+// CHECK: return [[EQ]] : i1
+func.func private @test_null_eq_null() -> !moore.i1 {
+  %n0 = moore.null
+  %n1 = moore.null
+  %eq = moore.handle_eq %n0, %n1 : !moore.null : !moore.null -> i1
+  return %eq : !moore.i1
+}


### PR DESCRIPTION
`moore.null` and the resulting `moore.handle_eq`/`moore.handle_ne` comparisons had no `MooreToCore` lowering, so any use of `null` against a class handle or chandle failed.

**For example:**
```
class base;
  function new();
  endfunction
endclass

module m;
  initial begin
    automatic base b;
    if (b == null) $display("null");
  end
endmodule
```

**Output:**
```
remark: Class builtin functions (needed for randomization, constraints, and covergroups) are not yet supported and will be dropped during lowering.
class base;
      ^
error: failed to legalize operation 'moore.null': %5 = "moore.null"() : () -> !moore.null
    if (b == null) $display("null");
             ^
note: see current operation: %5 = "moore.null"() : () -> !moore.null
```

**Fix:**
Since `ChandleType`/`ClassHandleType` already lower to `!llvm.ptr`, `NullType` is converted the same way, `moore.null` lowers to `llvm.mlir.zero`,  and `handle_eq`/`handle_ne` lower to `llvm.icmp`.