### PR TITLE
[MooreToCore] Lower $realtobits/$bitstoreal/$shortrealtobits/$bitstoshortreal builtins to arith.bitcast

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -2186,6 +2186,22 @@ struct ConvertRealOpConversion : public OpConversionPattern<ConvertRealOp> {
   }
 };
 
+template <typename SourceOp>
+struct RealBitcastOpConversion : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+  using OpAdaptor = typename SourceOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultTy =
+        ConversionPattern::typeConverter->convertType(op.getResult().getType());
+    rewriter.replaceOpWithNewOp<arith::BitcastOp>(op, resultTy,
+                                                  adaptor.getValue());
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Statement Conversion
 //===----------------------------------------------------------------------===//
@@ -3834,6 +3850,10 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     FormatStringToStringOpConversion,
     RealToIntOpConversion,
     ConvertRealOpConversion,
+    RealBitcastOpConversion<RealtobitsBIOp>,
+    RealBitcastOpConversion<BitstorealBIOp>,
+    RealBitcastOpConversion<ShortrealtobitsBIOp>,
+    RealBitcastOpConversion<BitstoshortrealBIOp>,
 
     // Patterns of miscellaneous operations.
     ConstantOpConv,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1624,6 +1624,22 @@ func.func @ConvertRealOperations(%arg0: !moore.f32, %arg1: !moore.f64) {
   return
 }
 
+// CHECK-LABEL: func.func @RealBitsLowering
+func.func @RealBitsLowering(%arg0: !moore.f64, %arg1: !moore.i64, %arg2: !moore.f32, %arg3: !moore.i32) {
+  // CHECK-NEXT: arith.bitcast %arg0 : f64 to i64
+  %0 = moore.builtin.realtobits %arg0
+
+  // CHECK-NEXT: arith.bitcast %arg1 : i64 to f64
+  %1 = moore.builtin.bitstoreal %arg1 : i64
+
+  // CHECK-NEXT: arith.bitcast %arg2 : f32 to i32
+  %2 = moore.builtin.shortrealtobits %arg2
+
+  // CHECK-NEXT: arith.bitcast %arg3 : i32 to f32
+  %3 = moore.builtin.bitstoshortreal %arg3 : i32
+  return
+}
+
 // CHECK-LABEL: func.func @StringOperations
 // CHECK-SAME: %arg0: i32
 // CHECK-SAME: %arg1: !sim.dstring


### PR DESCRIPTION
$realtobits, $bitstoreal, $shortrealtobits, and $bitstoshortreal had no `MooreToCore` lowering, so any use of these system functions failed.

**For example:**
```
module toy_realbits_family;
  initial begin
    real r;
    shortreal sr;
    logic [63:0] bits64;
    logic [31:0] bits32;

    r = 3.14;
    bits64 = $realtobits(r);
    $display("realtobits=%h", bits64);

    bits64 = 64'h4009_1EB8_51EB_851F;
    r = $bitstoreal(bits64);
    $display("bitstoreal: r=%f", r);

    sr = 3.14;
    bits32 = $shortrealtobits(sr);
    $display("shortrealtobits: bits32=%h", bits32);

    sr = $bitstoshortreal(bits32);
    $display("bitstoshortreal: sr=%f", sr);
  end
endmodule
```

**Output:**
```
error: failed to legalize operation 'moore.builtin.realtobits': %13 = "moore.builtin.realtobits"(%12) : (!moore.f64) -> !moore.i64
    bits64 = $realtobits(r);
             ^
note: see current operation: %13 = "moore.builtin.realtobits"(%12) : (!moore.f64) -> !moore.i64
```

**Fix:**

These functions are pure same-width bit reinterpretations between real and their vector representation, not numeric conversion. Add a lowering to `arith.bitcast`.