### PR TITLE
[ImportVerilog] Support %p format specifier for int, string, and struct

### DIFF
--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -8,6 +8,7 @@
 
 #include "ImportVerilogInternals.h"
 #include "slang/ast/SFormat.h"
+#include "slang/ast/types/AllTypes.h"
 
 using namespace mlir;
 using namespace circt;
@@ -157,6 +158,8 @@ struct FormatStringParser {
       return emitString(arg, options);
     case 'c':
       return emitChar(arg, options);
+    case 'p':
+      return emitPack(arg, options);
 
     default:
       return mlir::emitError(loc)
@@ -329,6 +332,85 @@ struct FormatStringParser {
 
     fragments.push_back(moore::FormatCharOp::create(builder, loc, bitValue));
     return success();
+  }
+
+  LogicalResult emitPackedValue(Value value, const slang::ast::Type &type) {
+    if (type.isString()) {
+      emitLiteral("\"");
+      fragments.push_back(
+          moore::FormatStringOp::create(builder, loc, value, {}, {}, {}));
+      emitLiteral("\"");
+      return success();
+    }
+
+    if (type.isStruct()) {
+      auto &ct = type.getCanonicalType();
+      const slang::ast::Scope *scope = nullptr;
+      if (auto packed = ct.as_if<slang::ast::PackedStructType>())
+        scope = packed;
+      else if (auto unpacked = ct.as_if<slang::ast::UnpackedStructType>())
+        scope = unpacked;
+      if (!scope)
+        return mlir::emitError(loc) << "unsupported struct type for %p";
+
+      emitLiteral("'{");
+      bool first = true;
+      for (auto &field : scope->membersOfType<slang::ast::FieldSymbol>()) {
+        if (!first)
+          emitLiteral(", ");
+        first = false;
+        emitLiteral(field.name);
+        emitLiteral(":");
+
+        auto &fieldType = field.getType();
+        Type fieldMooreTy = context.convertType(fieldType);
+        if (!fieldMooreTy)
+          return failure();
+        auto fieldVal = moore::StructExtractOp::create(
+            builder, loc, fieldMooreTy, builder.getStringAttr(field.name),
+            value);
+        if (failed(emitPackedValue(fieldVal, fieldType)))
+          return failure();
+      }
+      emitLiteral("}");
+      return success();
+    }
+
+    if (type.isEnum() || type.isUnion())
+      return mlir::emitError(loc)
+             << "%p format specifier does not yet support type `"
+             << type.toString() << "`";
+
+    if (!type.isIntegral())
+      return mlir::emitError(loc)
+             << "%p format specifier does not yet support type `"
+             << type.toString() << "`";
+
+    bool isSigned = type.isSigned() && defaultFormat == IntFormat::Decimal;
+    auto bitValue = context.convertToSimpleBitVector(value);
+    if (!bitValue)
+      return failure();
+    auto padding = defaultFormat == IntFormat::Decimal ? IntPadding::Space
+                                                       : IntPadding::Zero;
+    fragments.push_back(moore::FormatIntOp::create(
+        builder, loc, bitValue, defaultFormat, IntAlign::Right, padding,
+        /*specifierWidth=*/IntegerAttr{}, isSigned));
+    return success();
+  }
+
+  LogicalResult emitPack(const slang::ast::Expression &arg,
+                         const FormatOptions &options) {
+    if (options.width)
+      return mlir::emitError(loc)
+             << "%p format specifier with field width is not yet supported";
+    if (options.zeroPad)
+      return mlir::emitError(loc)
+             << "%0p (abbreviated assignment pattern) is not yet supported";
+
+    auto rval = context.convertRvalueExpression(arg);
+    if (!rval)
+      return failure();
+    return emitPackedValue(rval, *arg.type);
   }
 
   /// Emit an expression argument with the appropriate default formatting.

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1850,6 +1850,36 @@ module intToFormatStringConversion();
   end
 endmodule
 
+// CHECK-LABEL: moore.module @FormatPack(
+module FormatPack;
+  typedef struct { int a; byte b; } pair_t;
+
+  int x;
+  string s;
+  pair_t p;
+  byte y;
+
+  initial begin
+    // CHECK: [[V:%.+]] = moore.read %x
+    // CHECK: moore.fmt.int decimal [[V]], align right, pad space signed : i32
+    $display("%p", x);
+
+    // CHECK: [[V:%.+]] = moore.read %s
+    // CHECK: moore.fmt.literal "\22"
+    // CHECK: [[FS:%.+]] = moore.fmt.string [[V]]
+    $display("%p", s);
+
+    // CHECK: [[A:%.+]] = moore.struct_extract %{{.+}}, "a" : ustruct<{a: i32, b: i8}> -> i32
+    // CHECK: moore.fmt.int decimal [[A]], align right, pad space signed : i32
+    // CHECK: [[B:%.+]] = moore.struct_extract %{{.+}}, "b" : ustruct<{a: i32, b: i8}> -> i8
+    // CHECK: moore.fmt.int decimal [[B]], align right, pad space signed : i8
+    $display("%p", p);
+
+    // CHECK: moore.fmt.int binary [[V:%.+]], align right, pad zero : i8
+    $displayb("%p", y);
+  end
+endmodule
+
 // CHECK-LABEL: moore.module @realToTimeConversion
 module realToTimeConversion;
   // CHECK: procedure initial

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -368,3 +368,35 @@ module ReadMemIndexedSelect;
     $readmemh("mem.data", mem[i+:8]);
   end
 endmodule
+
+// -----
+
+module FormatPackEnum;
+  typedef enum { RED, GREEN } color_e;
+  color_e c;
+  initial begin
+    // expected-error @below {{%p format specifier does not yet support type}}
+    $display("%p", c);
+  end
+endmodule
+
+// -----
+
+module FormatPackUnion;
+  typedef union packed { int a; int b; } u_t;
+  u_t u;
+  initial begin
+    // expected-error @below {{%p format specifier does not yet support type}}
+    $display("%p", u);
+  end
+endmodule
+
+// -----
+
+module FormatPackAbbreviated;
+  int x;
+  initial begin
+    // expected-error @below {{%0p (abbreviated assignment pattern) is not yet supported}}
+    $display("%0p", x);
+  end
+endmodule


### PR DESCRIPTION
`$display("%p", ...)` and friends failed with ```"unsupported format specifier `%p`"``` for any argument, since the format-string parser's switch had no case for it.

%p (IEEE § 21.2.1.7) auto-formats its argument as a SystemVerilog assignment pattern: integers use the calling task's default radix, strings are quoted, and structs recurse field by field as '{name:value, ...}.

**Limitation:**

`Enums`, `packed unions`, `%0p`, `arrays`, `classes`, and `dynamic collections` are explicitly rejected with a clear diagnostic.