### PR TITLE
[Datapath] Signed Multiplication via Booth Encoding

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -930,7 +930,7 @@ def ConvertDatapathToComb : Pass<"convert-datapath-to-comb"> {
     Option<"forceBooth", "lower-partial-product-to-booth", "bool", "false",
            "Force all partial products to be lowered to Booth arrays.">,
     Option<"timingAware", "timing-aware", "bool", "false",
-           "Use timing-aware compressor synthesis algorithm.">,
+           "Use timing-aware compressor synthesis algorithm.">
   ];
 }
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -923,14 +923,14 @@ def ConvertDatapathToComb : Pass<"convert-datapath-to-comb"> {
     "circt::hw::HWDialect"
   ];
   let options = [
+    Option<"lowerCompress", "lower-compress", "bool", "true",
+           "Lower compress operators to a tree of compressor cells.">,
     Option<"lowerCompressToAdd", "lower-compress-to-add", "bool", "false",
            "Lower compress operators to variadic add.">,
     Option<"forceBooth", "lower-partial-product-to-booth", "bool", "false",
            "Force all partial products to be lowered to Booth arrays.">,
     Option<"timingAware", "timing-aware", "bool", "false",
            "Use timing-aware compressor synthesis algorithm.">,
-    Option<"lowerCompress", "lower-compress", "bool", "true",
-           "Lower compress operators to a tree of compressors.">,
   ];
 }
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -928,7 +928,9 @@ def ConvertDatapathToComb : Pass<"convert-datapath-to-comb"> {
     Option<"forceBooth", "lower-partial-product-to-booth", "bool", "false",
            "Force all partial products to be lowered to Booth arrays.">,
     Option<"timingAware", "timing-aware", "bool", "false",
-           "Use timing-aware compressor synthesis algorithm.">
+           "Use timing-aware compressor synthesis algorithm.">,
+    Option<"lowerCompress", "lower-compress", "bool", "true",
+           "Lower compress operators to a tree of compressors.">,
   ];
 }
 

--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -49,8 +49,8 @@ using llvm::KnownBits;
 /// in neither set is unknown.
 KnownBits computeKnownBits(Value value);
 
-/// Return true when both operands are wider than 16 bits and should use Booth
-/// encoding.
+/// Return true when both operands are wider than the bitwidth threshold and
+/// should use Booth encoding.
 bool boothEncode(Value lhs, Value rhs);
 
 /// Create the ops to zero-extend a value to an integer of equal or larger type.
@@ -117,48 +117,43 @@ bool foldMuxChainWithComparison(
                                                           size_t numEntries)>
         styleFn);
 
-// Check if the operand is zext() and return the unextended operand:
+// Check if the operand is zext() and return the extension bits:
 // zext = comb.concat(0, baseValue)
 template <typename SubType>
-struct ZextMatcher {
+struct ZextByMatcher {
   SubType lhs;
-  ZextMatcher(SubType lhs) : lhs(std::move(lhs)) {}
+  ZextByMatcher(SubType lhs) : lhs(std::move(lhs)) {}
   bool match(Operation *op) {
     // Check if operand is a concat operation
     auto concatOp = dyn_cast<ConcatOp>(op);
     if (!concatOp)
       return false;
 
-    auto operands = concatOp.getOperands();
-    // ConcatOp must have exactly 2 operands: (0, base_value)
-    if (operands.size() != 2)
-      return false;
-
-    auto constOp = operands[0].getDefiningOp<hw::ConstantOp>();
+    auto constOp = concatOp.getOperand(0).getDefiningOp<hw::ConstantOp>();
     if (!constOp || !constOp.getValue().isZero())
       return false;
 
-    // Match the base unextended value against the sub-matcher
-    return mlir::detail::matchOperandOrValueAtIndex(op, 1, lhs);
+    // Match the most significant argument of the concat
+    return mlir::detail::matchOperandOrValueAtIndex(op, 0, lhs);
   }
 };
 
 /// Helper function to create a zero extension matcher
 template <typename SubType>
-static inline ZextMatcher<SubType> m_Zext(const SubType &subExpr) {
-  return ZextMatcher<SubType>(subExpr);
+static inline ZextByMatcher<SubType> m_ZextBy(const SubType &subExpr) {
+  return ZextByMatcher<SubType>(subExpr);
 }
 
-// Check if the operand is sext() and return the unextended operand:
+// Check if the operand is sext() and return the extension bits:
 // signBit = comb.extract(baseValue, width-1, 1)
 // ext = comb.replicate(signBit, width-baseWidth)
 // sext = comb.concat(ext, baseValue)
 // Also matches the single bit case:
 // sext = comb.concat(signBit, baseValue)
 template <typename SubType>
-struct SextMatcher {
+struct SextByMatcher {
   SubType lhs;
-  SextMatcher(SubType lhs) : lhs(std::move(lhs)) {}
+  SextByMatcher(SubType lhs) : lhs(std::move(lhs)) {}
   bool match(Operation *op) {
     // Check if operand is a concat operation
     auto concatOp = dyn_cast<ConcatOp>(op);
@@ -191,15 +186,15 @@ struct SextMatcher {
         (extractOp.getLowBit() != baseWidth - 1))
       return false;
 
-    // Match the base unextended value against the sub-matcher
+    // Match the most significant argument of the concat
     return mlir::detail::matchOperandOrValueAtIndex(op, 0, lhs);
   }
 };
 
 /// Helper function to create a sign extension matcher
 template <typename SubType>
-static inline SextMatcher<SubType> m_Sext(const SubType &subExpr) {
-  return SextMatcher<SubType>(subExpr);
+static inline SextByMatcher<SubType> m_SextBy(const SubType &subExpr) {
+  return SextByMatcher<SubType>(subExpr);
 }
 
 } // namespace comb

--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -47,6 +48,10 @@ using llvm::KnownBits;
 /// guaranteed to always be one (these must be exclusive!).  A bit that exists
 /// in neither set is unknown.
 KnownBits computeKnownBits(Value value);
+
+/// Return true when both operands are wider than 16 bits and should use Booth
+/// encoding.
+bool boothEncode(Value lhs, Value rhs);
 
 /// Create the ops to zero-extend a value to an integer of equal or larger type.
 Value createZExt(OpBuilder &builder, Location loc, Value value,
@@ -111,6 +116,38 @@ bool foldMuxChainWithComparison(
     llvm::function_ref<MuxChainWithComparisonFoldingStyle(size_t indexWidth,
                                                           size_t numEntries)>
         styleFn);
+
+// Check if the operand is zext() and return the unextended operand:
+// zext = comb.concat(0, baseValue)
+template <typename SubType>
+struct ZextMatcher {
+  SubType lhs;
+  ZextMatcher(SubType lhs) : lhs(std::move(lhs)) {}
+  bool match(Operation *op) {
+    // Check if operand is a concat operation
+    auto concatOp = dyn_cast<ConcatOp>(op);
+    if (!concatOp)
+      return false;
+
+    auto operands = concatOp.getOperands();
+    // ConcatOp must have exactly 2 operands: (0, base_value)
+    if (operands.size() != 2)
+      return false;
+
+    auto constOp = operands[0].getDefiningOp<hw::ConstantOp>();
+    if (!constOp || !constOp.getValue().isZero())
+      return false;
+
+    // Match the base unextended value against the sub-matcher
+    return mlir::detail::matchOperandOrValueAtIndex(op, 1, lhs);
+  }
+};
+
+/// Helper function to create a zero extension matcher
+template <typename SubType>
+static inline ZextMatcher<SubType> m_Zext(const SubType &subExpr) {
+  return ZextMatcher<SubType>(subExpr);
+}
 
 // Check if the operand is sext() and return the unextended operand:
 // signBit = comb.extract(baseValue, width-1, 1)

--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -129,7 +129,12 @@ struct ZextByMatcher {
     if (!concatOp)
       return false;
 
-    auto constOp = concatOp.getOperand(0).getDefiningOp<hw::ConstantOp>();
+    auto operands = concatOp.getOperands();
+    // ConcatOp must have at least 2 operands: (sign_bits, base_value_1,...)
+    if (operands.size() < 2)
+      return false;
+
+    auto constOp = operands[0].getDefiningOp<hw::ConstantOp>();
     if (!constOp || !constOp.getValue().isZero())
       return false;
 
@@ -161,7 +166,7 @@ struct SextByMatcher {
       return false;
 
     auto operands = concatOp.getOperands();
-    // ConcatOp must have exactly 2 operands: (sign_bits, base_value)
+    // ConcatOp must have at least 2 operands: (sign_bits, base_value_1,...)
     if (operands.size() < 2)
       return false;
 

--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -14,8 +14,8 @@
 #define CIRCT_DIALECT_COMB_COMBOPS_H
 
 #include "circt/Dialect/Comb/CombDialect.h"
-#include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -167,7 +167,7 @@ struct SextMatcher {
 
     auto operands = concatOp.getOperands();
     // ConcatOp must have exactly 2 operands: (sign_bits, base_value)
-    if (operands.size() != 2)
+    if (operands.size() < 2)
       return false;
 
     Value signBits = operands[0];
@@ -192,7 +192,7 @@ struct SextMatcher {
       return false;
 
     // Match the base unextended value against the sub-matcher
-    return mlir::detail::matchOperandOrValueAtIndex(op, 1, lhs);
+    return mlir::detail::matchOperandOrValueAtIndex(op, 0, lhs);
   }
 };
 

--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -51,7 +51,7 @@ KnownBits computeKnownBits(Value value);
 
 /// Return true when both operands are wider than the bitwidth threshold and
 /// should use Booth encoding.
-bool boothEncode(Value lhs, Value rhs);
+bool shouldUseBoothEncoding(Value lhs, Value rhs, unsigned threshold = 16);
 
 /// Create the ops to zero-extend a value to an integer of equal or larger type.
 Value createZExt(OpBuilder &builder, Location loc, Value value,

--- a/integration_test/circt-synth/datapath-lowering-lec.mlir
+++ b/integration_test/circt-synth/datapath-lowering-lec.mlir
@@ -41,8 +41,8 @@ hw.module @partial_product_square_zext(in %a : i3, out sum : i6) {
   hw.output %2 : i6
 }
 
-// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext -c2=partial_product_sext
-hw.module @partial_product_sext(in %a : i3, in %b : i3, out sum : i6) {
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_3 -c2=partial_product_sext_3
+hw.module @partial_product_sext_3(in %a : i3, in %b : i3, out sum : i6) {
   %0 = comb.extract %a from 2 : (i3) -> i1
   %1 = comb.extract %b from 2 : (i3) -> i1
   %2 = comb.replicate %0 : (i1) -> i3
@@ -53,6 +53,19 @@ hw.module @partial_product_sext(in %a : i3, in %b : i3, out sum : i6) {
   %7 = comb.add %6#0, %6#1, %6#2, %6#3, %6#4, %6#5 : i6
   hw.output %7 : i6
 }
+
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_4 -c2=partial_product_sext_4
+hw.module @partial_product_sext_4(in %a : i4, in %b : i4, out sum : i8) {
+  %0 = comb.extract %a from 3 : (i4) -> i1
+  %1 = comb.replicate %0 : (i1) -> i4
+  %2 = comb.concat %1, %a : i4, i4
+  %3 = comb.extract %b from 3 : (i4) -> i1
+  %4 = comb.replicate %3 : (i1) -> i4
+  %5 = comb.concat %4, %b : i4, i4
+  %6:8 = datapath.partial_product %2, %5 : (i8, i8) -> (i8, i8, i8, i8, i8, i8, i8, i8)
+  %7 = comb.add %6#0, %6#1, %6#2, %6#3, %6#4, %6#5, %6#6, %6#7 : i8
+  hw.output %7 : i8
+}   
 
 // RUN: circt-lec.sh %t.mlir %s -c1=pos_partial_product_4 -c2=pos_partial_product_4
 hw.module @pos_partial_product_4(in %a : i4, in %b : i4, in %c : i4, out sum : i4) {
@@ -94,7 +107,9 @@ hw.module @compress_6(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4
 
 // RUN: circt-lec.sh %t.mlir %s -c1=partial_product_zext -c2=partial_product_zext
 
-// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext -c2=partial_product_sext
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_3 -c2=partial_product_sext_3
+
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_4 -c2=partial_product_sext_4
 
 // RUN: circt-lec.sh %t.mlir %s -c1=compress_3 -c2=compress_3
 

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -37,6 +37,22 @@ static SmallVector<Value> extractBits(OpBuilder &builder, Value val) {
   return bits;
 }
 
+// Check whether a value is zero-extended or sign-extended
+static std::pair<bool, Value> getBaseWidth(Value val) {
+
+  Value valBase;
+  // Check for zext
+  if (matchPattern(val, comb::m_Zext(mlir::matchers::m_Any(&valBase))))
+    return {false, valBase};
+
+  // Check for sext of the value
+  if (matchPattern(val, comb::m_Sext(mlir::matchers::m_Any(&valBase))))
+    return {true, valBase};
+
+  // Not extended, return original value
+  return {false, val};
+}
+
 //===----------------------------------------------------------------------===//
 // Conversion patterns
 //===----------------------------------------------------------------------===//
@@ -265,46 +281,53 @@ private:
   static LogicalResult lowerBoothArray(PatternRewriter &rewriter, Value a,
                                        Value b, PartialProductOp op,
                                        unsigned width) {
+    // TODO: sort a and b based on non-zero bits to encode the smaller input
     Location loc = op.getLoc();
     auto zeroFalse = hw::ConstantOp::create(rewriter, loc, APInt(1, 0));
-    auto zeroWidth = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
+
+    auto [aSigned, aBase] = getBaseWidth(op.getLhs());
+    auto [bSigned, bBase] = getBaseWidth(op.getRhs());
+
+    auto aBaseWidth = aBase.getType().getIntOrFloatBitWidth();
+    auto bBaseWidth = bBase.getType().getIntOrFloatBitWidth();
+
+    // Will handle signedMult separately
+    auto unsignedMult = !aSigned && !bSigned;
 
     // Detect leading zeros in multiplicand due to zero-extension
-    // and truncate to reduce partial product bits
-    // {'0, a} * {'0, b}
+    // and truncate to reduce partial product bits {'0, a} * {'0, b}
     auto rowWidth = width;
-    auto knownBitsA = comb::computeKnownBits(a);
-    if (!knownBitsA.Zero.isZero()) {
-      if (knownBitsA.Zero.countLeadingOnes() > 1) {
-        // Retain one leading zero to represent 2*{1'b0, a} = {a, 1'b0}
-        // {'0, a} -> {1'b0, a}
-        rowWidth -= knownBitsA.Zero.countLeadingOnes() - 1;
-        a = rewriter.createOrFold<comb::ExtractOp>(loc, a, 0, rowWidth);
-      }
+    if (unsignedMult && aBaseWidth < width) {
+      // Retain one leading zero to represent 2*{1'b0, a} = {a, 1'b0}
+      // {'0, a} -> {1'b0, a}
+      rowWidth = aBaseWidth + 1;
+      a = rewriter.createOrFold<comb::ExtractOp>(loc, a, 0, rowWidth);
     }
 
-    // TODO - replace with a concatenation to aid longest path analysis
-    auto oneRowWidth =
-        hw::ConstantOp::create(rewriter, loc, APInt(rowWidth, 1));
     // Booth encoding will select each row from {-2a, -1a, 0, 1a, 2a}
-    Value twoA = rewriter.createOrFold<comb::ShlOp>(loc, a, oneRowWidth);
+    Value twoAPre =
+        rewriter.createOrFold<comb::ConcatOp>(loc, ValueRange{a, zeroFalse});
+    Value twoA = rewriter.createOrFold<comb::ExtractOp>(
+        loc, twoAPre, 0, rowWidth); // Truncate to width bits
 
     // Encode based on the bits of b
-    // TODO: sort a and b based on non-zero bits to encode the smaller input
-    SmallVector<Value> bBits = extractBits(rewriter, b);
 
-    // Identify zero bits of b to reduce height of partial product array
-    auto bWidth = b.getType().getIntOrFloatBitWidth();
-    auto knownBitsB = comb::computeKnownBits(b);
-    if (!knownBitsB.Zero.isZero()) {
-      bWidth -= knownBitsB.Zero.countLeadingOnes();
-      for (unsigned i = 0; i < width; ++i)
-        if (knownBitsB.Zero[i])
-          bBits[i] = zeroFalse;
-    }
+    SmallVector<Value> bBits = extractBits(rewriter, b);
+    // Pad with two zeros
+    bBits.push_back(zeroFalse); // Add a zero bit for the first row
+    bBits.push_back(zeroFalse); // Add a zero bit for the last row
+
+    // Retain two leading zeros as when b has an even number of bits we just
+    // need to retain two leading zeros
+    if (!bSigned)
+      bBits.resize(bBaseWidth + 2);
+
+    // If b is signed, we need to sign-extend with a single sign-bit
+    if (bSigned)
+      bBits.resize(bBaseWidth + 1);
 
     SmallVector<Value> partialProducts;
-    partialProducts.reserve(width);
+    partialProducts.reserve(op.getNumResults());
 
     // Booth encoding halves array height by grouping three bits at a time:
     // partialProducts[i] = a * (-2*b[2*i+1] + b[2*i] + b[2*i-1]) << 2*i
@@ -315,11 +338,11 @@ private:
     Value encNegPrev;
 
     // For even width - additional row contains the final sign correction
-    for (unsigned i = 0; i <= width; i += 2) {
+    for (unsigned i = 0; i + 1 < bBits.size(); i += 2) {
       // Get Booth bits: b[i+1], b[i], b[i-1] (b[-1] = 0)
       Value bim1 = (i == 0) ? zeroFalse : bBits[i - 1];
-      Value bi = (i < width) ? bBits[i] : zeroFalse;
-      Value bip1 = (i + 1 < width) ? bBits[i + 1] : zeroFalse;
+      Value bi = bBits[i];
+      Value bip1 = bBits[i + 1];
 
       // Is the encoding zero or negative (an approximation)
       Value encNeg = bip1;
@@ -383,12 +406,6 @@ private:
 
       if (partialProducts.size() == op.getNumResults())
         break;
-
-      // Next row would be all zeros - need to account for the sign-correction
-      // of the previous row so the last row added is:
-      // {0, 0, 0, 0, 0, encNegPrev} << i
-      if (i > bWidth + 1)
-        break;
     }
 
     // Sign-extension:
@@ -423,6 +440,7 @@ private:
     }
 
     // Zero-pad to match the required output width
+    auto zeroWidth = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
     while (partialProducts.size() < op.getNumResults())
       partialProducts.push_back(zeroWidth);
 

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -168,7 +168,7 @@ struct DatapathPartialProductOpConversion : OpRewritePattern<PartialProductOp> {
 
     // Use result rows as a heuristic to guide partial product
     // implementation
-    if (comb::boothEncode(a, b) || forceBooth)
+    if (comb::shouldUseBoothEncoding(a, b) || forceBooth)
       return lowerBoothArray(rewriter, a, b, op, width);
     else
       return lowerAndArray(rewriter, a, b, op, width);

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -140,7 +140,7 @@ struct DatapathPartialProductOpConversion : OpRewritePattern<PartialProductOp> {
 
     // Use result rows as a heuristic to guide partial product
     // implementation
-    if (op.getNumResults() > 16 || forceBooth)
+    if (comb::boothEncode(a, b) || forceBooth)
       return lowerBoothArray(rewriter, a, b, op, width);
     else
       return lowerAndArray(rewriter, a, b, op, width);

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -41,17 +41,22 @@ static SmallVector<Value> extractBits(OpBuilder &builder, Value val) {
 static std::pair<bool, Value> getBaseWidth(PatternRewriter &rewriter,
                                            Location loc, Value val) {
 
-  Value valBase;
-  // Check for zext
-  if (matchPattern(val, comb::m_Zext(mlir::matchers::m_Any(&valBase))))
-    return {false, valBase};
-
-  // Check for sext of the value
   Value replBits;
-  if (matchPattern(val, comb::m_Sext(mlir::matchers::m_Any(&replBits)))) {
+  // Check for zext
+  if (matchPattern(val, comb::m_ZextBy(mlir::matchers::m_Any(&replBits)))) {
     auto baseWidth = val.getType().getIntOrFloatBitWidth() -
                      replBits.getType().getIntOrFloatBitWidth();
-    valBase = rewriter.createOrFold<comb::ExtractOp>(loc, val, 0, baseWidth);
+    auto valBase =
+        rewriter.createOrFold<comb::ExtractOp>(loc, val, 0, baseWidth);
+    return {false, valBase};
+  }
+
+  // Check for sext of the value
+  if (matchPattern(val, comb::m_SextBy(mlir::matchers::m_Any(&replBits)))) {
+    auto baseWidth = val.getType().getIntOrFloatBitWidth() -
+                     replBits.getType().getIntOrFloatBitWidth();
+    auto valBase =
+        rewriter.createOrFold<comb::ExtractOp>(loc, val, 0, baseWidth);
     return {true, valBase};
   }
 

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -37,8 +37,9 @@ static SmallVector<Value> extractBits(OpBuilder &builder, Value val) {
   return bits;
 }
 
-// Check whether a value is zero-extended or sign-extended
-static std::pair<bool, Value> getBaseWidth(PatternRewriter &rewriter,
+// Check whether a value is zero-extended or sign-extended - and return the
+// unextended base value and whether it was sign-extended.
+static std::pair<bool, Value> getBaseOfExt(PatternRewriter &rewriter,
                                            Location loc, Value val) {
 
   Value replBits;
@@ -296,8 +297,8 @@ private:
     Location loc = op.getLoc();
     auto zeroFalse = hw::ConstantOp::create(rewriter, loc, APInt(1, 0));
 
-    auto [aSigned, aBase] = getBaseWidth(rewriter, loc, op.getLhs());
-    auto [bSigned, bBase] = getBaseWidth(rewriter, loc, op.getRhs());
+    auto [aSigned, aBase] = getBaseOfExt(rewriter, loc, op.getLhs());
+    auto [bSigned, bBase] = getBaseOfExt(rewriter, loc, op.getRhs());
 
     auto aBaseWidth = aBase.getType().getIntOrFloatBitWidth();
     auto bBaseWidth = bBase.getType().getIntOrFloatBitWidth();
@@ -320,7 +321,7 @@ private:
     // Encode based on the bits of b
 
     SmallVector<Value> bBits = extractBits(rewriter, b);
-    // Pad with two zeros
+    // Pad with two zeros - for case where there's no extensions
     bBits.push_back(zeroFalse); // Add a zero bit for the first row
     bBits.push_back(zeroFalse); // Add a zero bit for the last row
 
@@ -416,6 +417,7 @@ private:
     }
 
     // Add the final sign-correction row for signed multiplication
+    // Not necessary for unsigned multiplication as the final row is positive
     if (bSigned) {
       auto numPP = partialProducts.size();
       Value shiftByFinal =

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -38,7 +38,8 @@ static SmallVector<Value> extractBits(OpBuilder &builder, Value val) {
 }
 
 // Check whether a value is zero-extended or sign-extended
-static std::pair<bool, Value> getBaseWidth(Value val) {
+static std::pair<bool, Value> getBaseWidth(PatternRewriter &rewriter,
+                                           Location loc, Value val) {
 
   Value valBase;
   // Check for zext
@@ -46,8 +47,13 @@ static std::pair<bool, Value> getBaseWidth(Value val) {
     return {false, valBase};
 
   // Check for sext of the value
-  if (matchPattern(val, comb::m_Sext(mlir::matchers::m_Any(&valBase))))
+  Value replBits;
+  if (matchPattern(val, comb::m_Sext(mlir::matchers::m_Any(&replBits)))) {
+    auto baseWidth = val.getType().getIntOrFloatBitWidth() -
+                     replBits.getType().getIntOrFloatBitWidth();
+    valBase = rewriter.createOrFold<comb::ExtractOp>(loc, val, 0, baseWidth);
     return {true, valBase};
+  }
 
   // Not extended, return original value
   return {false, val};
@@ -285,21 +291,17 @@ private:
     Location loc = op.getLoc();
     auto zeroFalse = hw::ConstantOp::create(rewriter, loc, APInt(1, 0));
 
-    auto [aSigned, aBase] = getBaseWidth(op.getLhs());
-    auto [bSigned, bBase] = getBaseWidth(op.getRhs());
+    auto [aSigned, aBase] = getBaseWidth(rewriter, loc, op.getLhs());
+    auto [bSigned, bBase] = getBaseWidth(rewriter, loc, op.getRhs());
 
     auto aBaseWidth = aBase.getType().getIntOrFloatBitWidth();
     auto bBaseWidth = bBase.getType().getIntOrFloatBitWidth();
 
-    // Will handle signedMult separately
-    auto unsignedMult = !aSigned && !bSigned;
-
     // Detect leading zeros in multiplicand due to zero-extension
     // and truncate to reduce partial product bits {'0, a} * {'0, b}
     auto rowWidth = width;
-    if (unsignedMult && aBaseWidth < width) {
-      // Retain one leading zero to represent 2*{1'b0, a} = {a, 1'b0}
-      // {'0, a} -> {1'b0, a}
+    if (aBaseWidth < width) {
+      // Retain one leading zero/sign-bit to represent 2*a
       rowWidth = aBaseWidth + 1;
       a = rewriter.createOrFold<comb::ExtractOp>(loc, a, 0, rowWidth);
     }
@@ -408,6 +410,17 @@ private:
         break;
     }
 
+    // Add the final sign-correction row for signed multiplication
+    if (bSigned) {
+      auto numPP = partialProducts.size();
+      Value shiftByFinal =
+          hw::ConstantOp::create(rewriter, loc, APInt((numPP - 1) * 2, 0));
+      Value finalSignCorrection = rewriter.createOrFold<comb::ConcatOp>(
+          loc, ValueRange{zeroFalse, encNegPrev, shiftByFinal});
+      partialProducts.push_back(finalSignCorrection);
+      encNegs.push_back(zeroFalse); // No sign-extension for the final row
+    }
+
     // Sign-extension:
     // { s1, s1, s1, s1, s1, p1}
     // { s2, s2, s2,   p2      }
@@ -417,10 +430,14 @@ private:
     // canonicalization patterns
     for (unsigned i = 0; i < partialProducts.size(); ++i) {
       auto ppRow = partialProducts[i];
-      auto encNeg = encNegs[i];
+
       auto ppWidth = ppRow.getType().getIntOrFloatBitWidth();
       if (ppWidth < width) {
         auto padding = width - ppWidth;
+        auto encNeg = encNegs[i];
+        if (aSigned)
+          encNeg = rewriter.createOrFold<comb::ExtractOp>(loc, ppRow,
+                                                          ppWidth - 1, 1);
 
         // Replicate the encNeg bit for sign-extension
         Value encNegPad =
@@ -606,10 +623,11 @@ void ConvertDatapathToCombPass::runOnOperation() {
   synth::IncrementalLongestPathAnalysis *analysis = nullptr;
   if (timingAware)
     analysis = &getAnalysis<synth::IncrementalLongestPathAnalysis>();
+
   if (lowerCompressToAdd)
     // Lower compressors to simple add operations for downstream optimisations
     patterns.add<DatapathCompressOpAddConversion>(patterns.getContext());
-  else
+  if (lowerCompress)
     // Lower compressors to a complete gate-level implementation
     patterns.add<DatapathCompressOpConversion>(patterns.getContext(), analysis);
 
@@ -621,6 +639,9 @@ void ConvertDatapathToCombPass::runOnOperation() {
   // Walk the operation and check for any remaining Datapath dialect
   // operations.
   auto result = getOperation()->walk([&](Operation *op) {
+    if (llvm::isa<datapath::CompressOp>(op) && !lowerCompress &&
+        !lowerCompressToAdd)
+      return WalkResult::advance();
     if (llvm::isa_and_nonnull<datapath::DatapathDialect>(op->getDialect())) {
       op->emitError("Datapath operation not converted: ") << *op;
       return WalkResult::interrupt();

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1424,19 +1424,6 @@ LogicalResult XorOp::canonicalize(XorOp op, PatternRewriter &rewriter) {
     }
   }
 
-  // xor(sext(x), -1) -> sext(xor(x,-1))
-  // More concisely: ~sext(x) = sext(~x)
-  Value base;
-  // Check for sext of the inverted value
-  if (matchPattern(op.getResult(), m_Complement(m_Sext(m_Any(&base))))) {
-    // Create negated sext: ~sext(x) = sext(~x)
-    auto negBase = createOrFoldNot(rewriter, op.getLoc(), base, true);
-    auto sextNegBase =
-        createOrFoldSExt(rewriter, op.getLoc(), negBase, op.getType());
-    replaceOpAndCopyNamehint(rewriter, op, sextNegBase);
-    return success();
-  }
-
   // xor(x, xor(...)) -> xor(x, ...) -- flatten
   if (tryFlatteningOperands(op, rewriter))
     return success();

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1430,7 +1430,7 @@ LogicalResult XorOp::canonicalize(XorOp op, PatternRewriter &rewriter) {
   Value signExtBits;
   // Check for sext of the inverted value
   if (matchPattern(op.getResult(), m_Complement(m_Any(&complementVal))) &&
-      matchPattern(complementVal, m_Sext(m_Any(&signExtBits)))) {
+      matchPattern(complementVal, m_SextBy(m_Any(&signExtBits)))) {
     // Matched an sext with signExtBits - extract the base (unextended) value
     auto baseWidth = op.getType().getIntOrFloatBitWidth() -
                      signExtBits.getType().getIntOrFloatBitWidth();

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1424,6 +1424,27 @@ LogicalResult XorOp::canonicalize(XorOp op, PatternRewriter &rewriter) {
     }
   }
 
+  // xor(sext(x), -1) -> sext(xor(x,-1))
+  // More concisely: ~sext(x) = sext(~x)
+  Value complementVal;
+  Value signExtBits;
+  // Check for sext of the inverted value
+  if (matchPattern(op.getResult(), m_Complement(m_Any(&complementVal))) &&
+      matchPattern(complementVal, m_Sext(m_Any(&signExtBits)))) {
+    // Matched an sext with signExtBits - extract the base (unextended) value
+    auto baseWidth = op.getType().getIntOrFloatBitWidth() -
+                     signExtBits.getType().getIntOrFloatBitWidth();
+    auto base =
+        ExtractOp::create(rewriter, op.getLoc(), complementVal, 0, baseWidth);
+
+    // Create negated sext: ~sext(x) = sext(~x)
+    auto negBase = createOrFoldNot(rewriter, op.getLoc(), base, true);
+    auto sextNegBase =
+        createOrFoldSExt(rewriter, op.getLoc(), negBase, op.getType());
+    replaceOpAndCopyNamehint(rewriter, op, sextNegBase);
+    return success();
+  }
+
   // xor(x, xor(...)) -> xor(x, ...) -- flatten
   if (tryFlatteningOperands(op, rewriter))
     return success();

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -20,8 +20,37 @@
 #include "llvm/Support/FormatVariadic.h"
 #include <limits>
 
+
+using namespace mlir;
 using namespace circt;
 using namespace comb;
+using namespace matchers;
+
+bool comb::boothEncode(Value lhs, Value rhs) {
+  if (lhs.getDefiningOp<hw::ConstantOp>() ||
+      rhs.getDefiningOp<hw::ConstantOp>())
+    return false;
+
+  auto lhsWidth = lhs.getType().getIntOrFloatBitWidth();
+  auto rhsWidth = rhs.getType().getIntOrFloatBitWidth();
+  
+  // Check for zext of the multiplicands
+  Value lhsZext, rhsZext;
+  if (matchPattern(lhs, comb::m_Zext(m_Any(&lhsZext))))
+    lhsWidth = lhsZext.getType().getIntOrFloatBitWidth();
+  if (matchPattern(rhs, comb::m_Zext(m_Any(&rhsZext))))
+    rhsWidth = rhsZext.getType().getIntOrFloatBitWidth();
+
+  // Check for sext of the multiplicands
+  Value lhsSext, rhsSext;
+  if (matchPattern(lhs, comb::m_Sext(m_Any(&lhsSext))))
+    lhsWidth = lhsSext.getType().getIntOrFloatBitWidth();
+  if (matchPattern(rhs, comb::m_Sext(m_Any(&rhsSext))))
+    rhsWidth = rhsSext.getType().getIntOrFloatBitWidth();
+
+  // If either operand is less than 16 bits, don't use Booth encoding.
+  return lhsWidth > 16 && rhsWidth > 16;
+}
 
 Value comb::createZExt(OpBuilder &builder, Location loc, Value value,
                        unsigned targetWidth) {
@@ -300,6 +329,8 @@ LogicalResult comb::convertModUByPowerOfTwo(ModUOp modOp,
   return convertDivModUByPowerOfTwo(rewriter, modOp, modOp.getLhs(),
                                     modOp.getRhs(), /*isDiv=*/false);
 }
+
+
 
 //===----------------------------------------------------------------------===//
 // ICmpOp

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -29,6 +29,7 @@ using namespace matchers;
 // lowered to Booth encoded array. Identifies zext/sext of the operands. Only
 // valid for binary multiplication.
 bool comb::boothEncode(Value lhs, Value rhs) {
+  // Do not booth encode multiplication by a constant
   if (lhs.getDefiningOp<hw::ConstantOp>() ||
       rhs.getDefiningOp<hw::ConstantOp>())
     return false;

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -20,7 +20,6 @@
 #include "llvm/Support/FormatVariadic.h"
 #include <limits>
 
-
 using namespace mlir;
 using namespace circt;
 using namespace comb;
@@ -33,7 +32,7 @@ bool comb::boothEncode(Value lhs, Value rhs) {
 
   auto lhsWidth = lhs.getType().getIntOrFloatBitWidth();
   auto rhsWidth = rhs.getType().getIntOrFloatBitWidth();
-  
+
   // Check for zext of the multiplicands
   Value lhsZext, rhsZext;
   if (matchPattern(lhs, comb::m_Zext(m_Any(&lhsZext))))
@@ -42,14 +41,14 @@ bool comb::boothEncode(Value lhs, Value rhs) {
     rhsWidth = rhsZext.getType().getIntOrFloatBitWidth();
 
   // Check for sext of the multiplicands
-  Value lhsSext, rhsSext;
-  if (matchPattern(lhs, comb::m_Sext(m_Any(&lhsSext))))
-    lhsWidth = lhsSext.getType().getIntOrFloatBitWidth();
-  if (matchPattern(rhs, comb::m_Sext(m_Any(&rhsSext))))
-    rhsWidth = rhsSext.getType().getIntOrFloatBitWidth();
+  Value lhsSextBits, rhsSextBits;
+  if (matchPattern(lhs, comb::m_Sext(m_Any(&lhsSextBits))))
+    lhsWidth = lhsWidth - lhsSextBits.getType().getIntOrFloatBitWidth();
+  if (matchPattern(rhs, comb::m_Sext(m_Any(&rhsSextBits))))
+    rhsWidth = rhsWidth - rhsSextBits.getType().getIntOrFloatBitWidth();
 
   // If either operand is less than 16 bits, don't use Booth encoding.
-  return lhsWidth > 16 && rhsWidth > 16;
+  return lhsWidth >= 16 && rhsWidth >= 16;
 }
 
 Value comb::createZExt(OpBuilder &builder, Location loc, Value value,
@@ -329,8 +328,6 @@ LogicalResult comb::convertModUByPowerOfTwo(ModUOp modOp,
   return convertDivModUByPowerOfTwo(rewriter, modOp, modOp.getLhs(),
                                     modOp.getRhs(), /*isDiv=*/false);
 }
-
-
 
 //===----------------------------------------------------------------------===//
 // ICmpOp

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -25,6 +25,9 @@ using namespace circt;
 using namespace comb;
 using namespace matchers;
 
+// Common function to identify when multipliers/partial products should be
+// lowered to Booth encoded array. Identifies zext/sext of the operands. Only
+// valid for binary multiplication.
 bool comb::boothEncode(Value lhs, Value rhs) {
   if (lhs.getDefiningOp<hw::ConstantOp>() ||
       rhs.getDefiningOp<hw::ConstantOp>())
@@ -35,20 +38,22 @@ bool comb::boothEncode(Value lhs, Value rhs) {
 
   // Check for zext of the multiplicands
   Value lhsZext, rhsZext;
-  if (matchPattern(lhs, comb::m_Zext(m_Any(&lhsZext))))
-    lhsWidth = lhsZext.getType().getIntOrFloatBitWidth();
-  if (matchPattern(rhs, comb::m_Zext(m_Any(&rhsZext))))
-    rhsWidth = rhsZext.getType().getIntOrFloatBitWidth();
+  if (matchPattern(lhs, comb::m_ZextBy(m_Any(&lhsZext))))
+    lhsWidth -= lhsZext.getType().getIntOrFloatBitWidth();
+  if (matchPattern(rhs, comb::m_ZextBy(m_Any(&rhsZext))))
+    rhsWidth -= rhsZext.getType().getIntOrFloatBitWidth();
 
   // Check for sext of the multiplicands
   Value lhsSextBits, rhsSextBits;
-  if (matchPattern(lhs, comb::m_Sext(m_Any(&lhsSextBits))))
-    lhsWidth = lhsWidth - lhsSextBits.getType().getIntOrFloatBitWidth();
-  if (matchPattern(rhs, comb::m_Sext(m_Any(&rhsSextBits))))
-    rhsWidth = rhsWidth - rhsSextBits.getType().getIntOrFloatBitWidth();
+  if (matchPattern(lhs, comb::m_SextBy(m_Any(&lhsSextBits))))
+    lhsWidth -= lhsSextBits.getType().getIntOrFloatBitWidth();
+  if (matchPattern(rhs, comb::m_SextBy(m_Any(&rhsSextBits))))
+    rhsWidth -= rhsSextBits.getType().getIntOrFloatBitWidth();
 
+  // Heuristic threshold based on:
+  // "Datapath Synthesis for Standard-Cell Design", Reto Zimmerman 2009
   // If either operand is less than 16 bits, don't use Booth encoding.
-  return lhsWidth >= 16 && rhsWidth >= 16;
+  return lhsWidth > 16 && rhsWidth > 16;
 }
 
 Value comb::createZExt(OpBuilder &builder, Location loc, Value value,

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -28,7 +28,8 @@ using namespace matchers;
 // Common function to identify when multipliers/partial products should be
 // lowered to Booth encoded array. Identifies zext/sext of the operands. Only
 // valid for binary multiplication.
-bool comb::boothEncode(Value lhs, Value rhs) {
+// Threshold default is 16
+bool comb::shouldUseBoothEncoding(Value lhs, Value rhs, unsigned threshold) {
   // Do not booth encode multiplication by a constant
   if (lhs.getDefiningOp<hw::ConstantOp>() ||
       rhs.getDefiningOp<hw::ConstantOp>())
@@ -53,8 +54,8 @@ bool comb::boothEncode(Value lhs, Value rhs) {
 
   // Heuristic threshold based on:
   // "Datapath Synthesis for Standard-Cell Design", Reto Zimmerman 2009
-  // If either operand is less than 16 bits, don't use Booth encoding.
-  return lhsWidth > 16 && rhsWidth > 16;
+  // If either operand is less than 16 bits (default), don't use Booth encoding.
+  return lhsWidth > threshold && rhsWidth > threshold;
 }
 
 Value comb::createZExt(OpBuilder &builder, Location loc, Value value,

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -472,7 +472,7 @@ struct SignedPartialProducts : public OpRewritePattern<PartialProductOp> {
   LogicalResult matchAndRewrite(PartialProductOp op,
                                 PatternRewriter &rewriter) const override {
     // Booth encoding will automatically handle signed multiplications
-    if (comb::boothEncode(op.getLhs(), op.getRhs()))
+    if (comb::shouldUseBoothEncoding(op.getLhs(), op.getRhs()))
       return failure();
 
     auto inputWidth = op.getLhs().getType().getIntOrFloatBitWidth();

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -254,7 +254,7 @@ struct SextCompress : public OpRewritePattern<CompressOp> {
     for (auto input : inputs) {
       Value replBits;
       // Check for sext of the inverted value
-      if (!matchPattern(input, comb::m_Sext(m_Any(&replBits)))) {
+      if (!matchPattern(input, comb::m_SextBy(m_Any(&replBits)))) {
         newInputs.push_back(input);
         continue;
       }
@@ -478,8 +478,8 @@ struct SignedPartialProducts : public OpRewritePattern<PartialProductOp> {
     auto inputWidth = op.getLhs().getType().getIntOrFloatBitWidth();
     Value lhsReplBits;
     Value rhsReplBits;
-    if (!matchPattern(op.getLhs(), comb::m_Sext(m_Any(&lhsReplBits))) ||
-        !matchPattern(op.getRhs(), comb::m_Sext(m_Any(&rhsReplBits))))
+    if (!matchPattern(op.getLhs(), comb::m_SextBy(m_Any(&lhsReplBits))) ||
+        !matchPattern(op.getRhs(), comb::m_SextBy(m_Any(&rhsReplBits))))
       return failure();
 
     size_t lhsWidth =

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -252,14 +252,16 @@ struct SextCompress : public OpRewritePattern<CompressOp> {
     APInt value;
     SmallVector<Value> newInputs;
     for (auto input : inputs) {
-      Value sextInput;
+      Value replBits;
       // Check for sext of the inverted value
-      if (!matchPattern(input, comb::m_Sext(m_Any(&sextInput)))) {
+      if (!matchPattern(input, comb::m_Sext(m_Any(&replBits)))) {
         newInputs.push_back(input);
         continue;
       }
+      auto baseWidth = opSize - replBits.getType().getIntOrFloatBitWidth();
+      auto sextInput =
+          comb::ExtractOp::create(rewriter, op.getLoc(), input, 0, baseWidth);
 
-      auto baseWidth = sextInput.getType().getIntOrFloatBitWidth();
       // Need a separate sign-bit that gets extended by at least two bits to
       // be beneficial
       if (baseWidth <= 1 || (opSize - baseWidth) <= 1) {
@@ -470,18 +472,20 @@ struct SignedPartialProducts : public OpRewritePattern<PartialProductOp> {
   LogicalResult matchAndRewrite(PartialProductOp op,
                                 PatternRewriter &rewriter) const override {
     // Booth encoding will automatically handle signed multiplications
-    if (comb::boothEncode(op.getOperand(0), op.getOperand(1)))
-      return failure();
-    
-    auto inputWidth = op.getOperand(0).getType().getIntOrFloatBitWidth();
-    Value lhs;
-    Value rhs;
-    if (!matchPattern(op.getOperand(0), comb::m_Sext(m_Any(&lhs))) ||
-        !matchPattern(op.getOperand(1), comb::m_Sext(m_Any(&rhs))))
+    if (comb::boothEncode(op.getLhs(), op.getRhs()))
       return failure();
 
-    size_t lhsWidth = lhs.getType().getIntOrFloatBitWidth();
-    size_t rhsWidth = rhs.getType().getIntOrFloatBitWidth();
+    auto inputWidth = op.getLhs().getType().getIntOrFloatBitWidth();
+    Value lhsReplBits;
+    Value rhsReplBits;
+    if (!matchPattern(op.getLhs(), comb::m_Sext(m_Any(&lhsReplBits))) ||
+        !matchPattern(op.getRhs(), comb::m_Sext(m_Any(&rhsReplBits))))
+      return failure();
+
+    size_t lhsWidth =
+        inputWidth - lhsReplBits.getType().getIntOrFloatBitWidth();
+    size_t rhsWidth =
+        inputWidth - rhsReplBits.getType().getIntOrFloatBitWidth();
     // Subtract 1 as will handle sign-bit separately
     size_t maxRows = std::max(lhsWidth, rhsWidth) - 1;
 
@@ -497,14 +501,14 @@ struct SignedPartialProducts : public OpRewritePattern<PartialProductOp> {
     // Pull off the sign bits
     auto lhsBaseWidth = lhsWidth - 1;
     auto rhsBaseWidth = rhsWidth - 1;
-    auto lhsSignBit =
-        comb::ExtractOp::create(rewriter, op.getLoc(), lhs, lhsBaseWidth, 1);
-    auto rhsSignBit =
-        comb::ExtractOp::create(rewriter, op.getLoc(), rhs, rhsBaseWidth, 1);
-    auto lhsBase =
-        comb::ExtractOp::create(rewriter, op.getLoc(), lhs, 0, lhsBaseWidth);
-    auto rhsBase =
-        comb::ExtractOp::create(rewriter, op.getLoc(), rhs, 0, rhsBaseWidth);
+    auto lhsSignBit = comb::ExtractOp::create(rewriter, op.getLoc(),
+                                              op.getLhs(), lhsBaseWidth, 1);
+    auto rhsSignBit = comb::ExtractOp::create(rewriter, op.getLoc(),
+                                              op.getRhs(), rhsBaseWidth, 1);
+    auto lhsBase = comb::ExtractOp::create(rewriter, op.getLoc(), op.getLhs(),
+                                           0, lhsBaseWidth);
+    auto rhsBase = comb::ExtractOp::create(rewriter, op.getLoc(), op.getRhs(),
+                                           0, rhsBaseWidth);
 
     // Create the unsigned partial product of the unextended inputs
     auto lhsBaseZext =

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -469,6 +469,10 @@ struct SignedPartialProducts : public OpRewritePattern<PartialProductOp> {
   // negations with constant corrections that can be folded together.
   LogicalResult matchAndRewrite(PartialProductOp op,
                                 PatternRewriter &rewriter) const override {
+    // Booth encoding will automatically handle signed multiplications
+    if (comb::boothEncode(op.getOperand(0), op.getOperand(1)))
+      return failure();
+    
     auto inputWidth = op.getOperand(0).getType().getIntOrFloatBitWidth();
     Value lhs;
     Value rhs;

--- a/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
+++ b/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
@@ -61,6 +61,13 @@ void circt::synth::buildCombLoweringPipeline(
         pm.addPass(datapath::createDatapathReduceDelay());
       circt::ConvertDatapathToCombOptions datapathOptions;
       datapathOptions.timingAware = options.timingAware;
+      datapathOptions.lowerCompress = false;
+      // Incrementally lower - first lower partial product operations
+      pm.addPass(createConvertDatapathToComb(datapathOptions));
+      pm.addPass(createSimpleCanonicalizerPass());
+      datapathOptions.lowerCompress = true;
+      // Then lower compress operations after canononicalization to reduce the
+      // number of compress operations.
       pm.addPass(createConvertDatapathToComb(datapathOptions));
     }
     pm.addPass(createCSEPass());

--- a/test/Conversion/DatapathToComb/datapath-to-comb.mlir
+++ b/test/Conversion/DatapathToComb/datapath-to-comb.mlir
@@ -129,9 +129,9 @@ hw.module @partial_product_square_zext(in %a : i3, out pp0 : i6, out pp1 : i6, o
 // CHECK-LABEL: @partial_product_booth
 // FORCE-BOOTH-LABEL: @partial_product_booth
 // Constants
+// FORCE-BOOTH-NEXT: %c0_i3 = hw.constant 0 : i3
 // FORCE-BOOTH-NEXT: %true = hw.constant true
 // FORCE-BOOTH-NEXT: %false = hw.constant false
-// FORCE-BOOTH-NEXT: %c0_i3 = hw.constant 0 : i3
 // 2*a
 // FORCE-BOOTH-NEXT: %0 = comb.extract %a from 0 : (i3) -> i2
 // FORCE-BOOTH-NEXT: %[[TWOA:.+]] = comb.concat %0, %false : i2, i1

--- a/test/circt-synth/path-e2e.mlir
+++ b/test/circt-synth/path-e2e.mlir
@@ -3,10 +3,9 @@
 // RUN: circt-synth %s -analysis-output=- -top test -analysis-output-format=json | FileCheck %s --check-prefix JSON
 
 // COMMON-LABEL: # Longest Path Analysis result for "counter"
-// AIG-NEXT: Found 175 paths
-// LUT6-NEXT: Found 176 paths
+// COMMON-NEXT: Found 168 paths
 // COMMON-NEXT: Found 32 unique end points
-// AIG-NEXT: Maximum path delay: 26
+// AIG-NEXT: Maximum path delay: 27
 // LUT6-NEXT: Maximum path delay: 6
 // Don't test detailed reports as they are not stable.
 

--- a/test/circt-synth/path-e2e.mlir
+++ b/test/circt-synth/path-e2e.mlir
@@ -3,9 +3,10 @@
 // RUN: circt-synth %s -analysis-output=- -top test -analysis-output-format=json | FileCheck %s --check-prefix JSON
 
 // COMMON-LABEL: # Longest Path Analysis result for "counter"
-// COMMON-NEXT: Found 168 paths
+// AIG-NEXT: Found 175 paths
+// LUT6-NEXT: Found 176 paths
 // COMMON-NEXT: Found 32 unique end points
-// AIG-NEXT: Maximum path delay: 27
+// AIG-NEXT: Maximum path delay: 26
 // LUT6-NEXT: Maximum path delay: 6
 // Don't test detailed reports as they are not stable.
 


### PR DESCRIPTION
## Overview 
Booth Multipliers naturally handle sign-extended inputs by simply sign-extending the encoded input by a single bit. 
Therefore, it is not necessary to canonicalize a sign-extended `datapath.partial_product` operator as we do when lowering to a typical AND array implementation. 

## Circt-Synth Impact
To reuse the `datapath.compress` canonicalization patterns separate `datapath` lowering into two stages:
1. Lower partial product generators
2. Canonicalize (making use of sign-extended compressor patterns)
3. Lower compress operators

## Implementation
Modified the sext/zext matchers to handle cases where the extension is not just a concatenation of two arguments - e.g. 
`sext({a,b,c})` should be matched even when the concatenation is folded together.

To unify heuristic choice - created a `lowerBooth` function that should be the single decision making point for Booth multiplication.

Assisted-by: co-pilot:auto
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
