### PR TITLE
[ImportVerilog] Support $past(expr, number_of_tick) and error explicitly on unhandled sampled-value arities

### DIFF
--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -366,6 +366,43 @@ FailureOr<Value> Context::convertSampledValueCallArity1(
   }
 }
 
+FailureOr<Value> Context::convertSampledValueCallArity2(
+    const slang::ast::SystemSubroutine &subroutine, Location loc, Value value,
+    Type originalType, Value clockVal,
+    const slang::ast::Expression &secondArg) {
+  using ksn = slang::parsing::KnownSystemName;
+  auto nameId = subroutine.knownNameId;
+
+  if (nameId != ksn::Past) {
+    mlir::emitError(loc) << "explicit clocking event argument for `"
+                         << subroutine.name << "` is not yet supported";
+    return failure();
+  }
+
+  auto ticks = evaluateConstant(secondArg).integer().as<int64_t>();
+  if (!ticks) {
+    mlir::emitError(loc)
+        << "`$past` number of ticks must be a constant expression";
+    return failure();
+  }
+  if (*ticks < 1) {
+    mlir::emitError(loc) << "`$past` number of ticks must be >= 1";
+    return failure();
+  }
+
+  auto castToMoore = [&](Value v) -> Value {
+    if (auto ty = dyn_cast<moore::IntType>(originalType)) {
+      v = moore::FromBuiltinIntOp::create(builder, loc, v);
+      if (ty.getDomain() == Domain::FourValued)
+        v = moore::IntToLogicOp::create(builder, loc, v);
+    }
+    return v;
+  };
+
+  return castToMoore(
+      ltl::PastOp::create(builder, loc, value, *ticks, clockVal));
+}
+
 Value Context::convertSampledValueCallExpression(
     const slang::ast::CallExpression &expr,
     const slang::ast::CallExpression::SystemCallInfo &info, Location loc) {
@@ -422,6 +459,7 @@ Value Context::convertSampledValueCallExpression(
 
   switch (args.size()) {
   case (1):
+  case (2):
     value = this->convertRvalueExpression(*args[0]);
     originalType = value.getType();
     valTy = dyn_cast<moore::IntType>(value.getType());
@@ -450,12 +488,19 @@ Value Context::convertSampledValueCallExpression(
     intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
     if (!intVal)
       return {};
-    result = this->convertSampledValueCallArity1(subroutine, loc, intVal,
-                                                 originalType, clockVal);
+
+    if (args.size() == 1)
+      result = this->convertSampledValueCallArity1(subroutine, loc, intVal,
+                                                   originalType, clockVal);
+    else
+      result = this->convertSampledValueCallArity2(
+          subroutine, loc, intVal, originalType, clockVal, *args[1]);
     break;
 
   default:
-    break;
+    mlir::emitError(loc) << "`" << subroutine.name << "` with " << args.size()
+                         << " arguments is not yet supported";
+    return {};
   }
 
   if (failed(result))

--- a/lib/Conversion/ImportVerilog/AssertionExpr.cpp
+++ b/lib/Conversion/ImportVerilog/AssertionExpr.cpp
@@ -301,21 +301,21 @@ struct AssertionExprVisitor {
 };
 } // namespace
 
+static Value castBuiltinIntToMoore(OpBuilder &builder, Location loc, Value v,
+                                   Type originalType) {
+  if (auto ty = dyn_cast<moore::IntType>(originalType)) {
+    v = moore::FromBuiltinIntOp::create(builder, loc, v);
+    if (ty.getDomain() == Domain::FourValued)
+      v = moore::IntToLogicOp::create(builder, loc, v);
+  }
+  return v;
+}
+
 FailureOr<Value> Context::convertSampledValueCallArity1(
     const slang::ast::SystemSubroutine &subroutine, Location loc, Value value,
     Type originalType, Value clockVal) {
   using ksn = slang::parsing::KnownSystemName;
   auto nameId = subroutine.knownNameId;
-
-  // Helper to cast a builtin integer result back to Moore integer types.
-  auto castToMoore = [&](Value v) -> Value {
-    if (auto ty = dyn_cast<moore::IntType>(originalType)) {
-      v = moore::FromBuiltinIntOp::create(builder, loc, v);
-      if (ty.getDomain() == Domain::FourValued)
-        v = moore::IntToLogicOp::create(builder, loc, v);
-    }
-    return v;
-  };
 
   // Helper to cast a builtin integer result to a two-valued Moore integer type.
   auto castToTwoValued = [&](Value v) -> Value {
@@ -324,7 +324,9 @@ FailureOr<Value> Context::convertSampledValueCallArity1(
 
   switch (nameId) {
   case ksn::Sampled:
-    return castToMoore(ltl::SampledOp::create(builder, loc, value));
+    return castBuiltinIntToMoore(builder, loc,
+                                 ltl::SampledOp::create(builder, loc, value),
+                                 originalType);
 
   // Translate $fell to ¬x[0] ∧ x[-1]
   case ksn::Fell: {
@@ -359,7 +361,9 @@ FailureOr<Value> Context::convertSampledValueCallArity1(
   }
 
   case ksn::Past:
-    return castToMoore(ltl::PastOp::create(builder, loc, value, 1, clockVal));
+    return castBuiltinIntToMoore(
+        builder, loc, ltl::PastOp::create(builder, loc, value, 1, clockVal),
+        originalType);
 
   default:
     return Value{};
@@ -385,22 +389,10 @@ FailureOr<Value> Context::convertSampledValueCallArity2(
         << "`$past` number of ticks must be a constant expression";
     return failure();
   }
-  if (*ticks < 1) {
-    mlir::emitError(loc) << "`$past` number of ticks must be >= 1";
-    return failure();
-  }
 
-  auto castToMoore = [&](Value v) -> Value {
-    if (auto ty = dyn_cast<moore::IntType>(originalType)) {
-      v = moore::FromBuiltinIntOp::create(builder, loc, v);
-      if (ty.getDomain() == Domain::FourValued)
-        v = moore::IntToLogicOp::create(builder, loc, v);
-    }
-    return v;
-  };
-
-  return castToMoore(
-      ltl::PastOp::create(builder, loc, value, *ticks, clockVal));
+  return castBuiltinIntToMoore(
+      builder, loc, ltl::PastOp::create(builder, loc, value, *ticks, clockVal),
+      originalType);
 }
 
 Value Context::convertSampledValueCallExpression(
@@ -457,51 +449,47 @@ Value Context::convertSampledValueCallExpression(
   Type originalType;
   moore::IntType valTy;
 
-  switch (args.size()) {
-  case (1):
-  case (2):
-    value = this->convertRvalueExpression(*args[0]);
-    originalType = value.getType();
-    valTy = dyn_cast<moore::IntType>(value.getType());
-    if (!valTy) {
-      if (!isa<moore::PackedType>(value.getType())) {
-        mlir::emitError(loc)
-            << "expected integer argument for `" << subroutine.name << "`";
-        return {};
-      }
-      value = materializePackedToSBVConversion(value, loc, /*fallible=*/false);
-      if (!value)
-        return {};
-      valTy = dyn_cast<moore::IntType>(value.getType());
-      if (!valTy) {
-        mlir::emitError(loc)
-            << "expected integer argument for `" << subroutine.name << "`";
-        return {};
-      }
-    }
-
-    // If the value is four-valued, we need to map it to two-valued before we
-    // cast it to a builtin int
-    if (valTy.getDomain() == Domain::FourValued) {
-      value = builder.createOrFold<moore::LogicToIntOp>(loc, value);
-    }
-    intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
-    if (!intVal)
-      return {};
-
-    if (args.size() == 1)
-      result = this->convertSampledValueCallArity1(subroutine, loc, intVal,
-                                                   originalType, clockVal);
-    else
-      result = this->convertSampledValueCallArity2(
-          subroutine, loc, intVal, originalType, clockVal, *args[1]);
-    break;
-
-  default:
+  if (args.size() > 2) {
     mlir::emitError(loc) << "`" << subroutine.name << "` with " << args.size()
                          << " arguments is not yet supported";
     return {};
   }
+
+  value = this->convertRvalueExpression(*args[0]);
+  originalType = value.getType();
+  valTy = dyn_cast<moore::IntType>(value.getType());
+  if (!valTy) {
+    if (!isa<moore::PackedType>(value.getType())) {
+      mlir::emitError(loc) << "expected integer argument for `"
+                           << subroutine.name << "`";
+      return {};
+    }
+    value = materializePackedToSBVConversion(value, loc, /*fallible=*/false);
+    if (!value)
+      return {};
+    valTy = dyn_cast<moore::IntType>(value.getType());
+    if (!valTy) {
+      mlir::emitError(loc) << "expected integer argument for `"
+                           << subroutine.name << "`";
+      return {};
+    }
+  }
+
+  // If the value is four-valued, we need to map it to two-valued before we
+  // cast it to a builtin int
+  if (valTy.getDomain() == Domain::FourValued) {
+    value = builder.createOrFold<moore::LogicToIntOp>(loc, value);
+  }
+  intVal = builder.createOrFold<moore::ToBuiltinIntOp>(loc, value);
+  if (!intVal)
+    return {};
+
+  if (args.size() == 1)
+    result = this->convertSampledValueCallArity1(subroutine, loc, intVal,
+                                                 originalType, clockVal);
+  else
+    result = this->convertSampledValueCallArity2(
+        subroutine, loc, intVal, originalType, clockVal, *args[1]);
 
   if (failed(result))
     return {};

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -460,6 +460,13 @@ struct Context {
                                 Location loc, Value value, Type originalType,
                                 Value clockVal);
 
+  /// Convert sampled value system function calls with two arguments.
+  FailureOr<Value>
+  convertSampledValueCallArity2(const slang::ast::SystemSubroutine &subroutine,
+                                Location loc, Value value, Type originalType,
+                                Value clockVal,
+                                const slang::ast::Expression &secondArg);
+
   /// Evaluate the constant value of an expression.
   slang::ConstantValue evaluateConstant(const slang::ast::Expression &expr);
 

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -649,6 +649,18 @@ module SampleValueBuiltins #() (
   always @(posedge clk_i) past_data_i <= $past(data_i);
 
   // CHECK: moore.procedure always {
+  // CHECK: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
+  // CHECK: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
+  // CHECK: [[D2:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK: [[D2_INT:%.+]] = moore.logic_to_int [[D2]] : l8
+  // CHECK: [[DB:%.+]] = moore.to_builtin_int [[D2_INT]] : i8
+  // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[DB]], 3 clk [[CLK_I1]] : i8
+  // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
+  // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
+  past_ticks: assert property (@(posedge clk_i) data_i == $past(data_i, 3));
+
+  // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK: [[RED:%.+]] = moore.reduce_xor [[D]] : l8 -> l1
   // CHECK: [[X:%.+]] = moore.constant bX : l1

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -188,6 +188,30 @@ module Foo;
 endmodule
 
 // -----
+
+module Foo;
+  logic a, clk;
+  // expected-error @below {{explicit clocking event argument for `$rose` is not yet supported}}
+  assert property (@(posedge clk) $rose(a, @(posedge clk)));
+endmodule
+
+// -----
+
+module Foo;
+  logic a, clk;
+  // expected-error @below {{'number_of_ticks' argument must be greater than or equal to 1}}
+  assert property (@(posedge clk) $past(a, 0));
+endmodule
+
+// -----
+
+module Foo;
+  logic a, clk;
+  // expected-error @below {{`$past` with 3 arguments is not yet supported}}
+  assert property (@(posedge clk) $past(a, 1, a));
+endmodule
+
+// -----
 module Foo;
   int a;
   // expected-error @below {{sequence has no explicit clocking event and one cannot be inferred from context}}


### PR DESCRIPTION
Sampled value system functions (`$sampled`/`$rose`/`$fell`/`$stable`/`$changed`/`$past`) were only handled for the single-argument case. Any call with more arguments fell into an empty `default: break;` in the argument-count switch, leaving `result` at its default-constructed (failure) state and returning silently.

$past is the only one of these functions that takes a second positional argument (`number_of_ticks`); $rose/$fell/$stable/$changed instead accept an optional explicit `clocking_event` there.

**Fix:**
- Implement `$past(expr, N)`. `N` is evaluated as a required constant and passed as ltl.past's existing `delay` attribute.
- Any other 2-argument call now errors explicitly instead of being silently accepted as ticks.
- The default case for still-unhandled arities now emits a clear "not yet supported" diagnostic instead of failing silently.