### PR TITLE
[ExportVerilog] Don't align instance ports to over-long names

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -5766,9 +5766,12 @@ void StmtEmitter::emitInstancePortList(Operation *op,
   ps << " (";
 
   // Get the max port name length so we can align the '('.
+  // Exclude outlier names that span the whole line from the alignment column.
   size_t maxNameLength = 0;
   for (auto &elt : modPortInfo) {
-    maxNameLength = std::max(maxNameLength, elt.getVerilogName().size());
+    size_t nameLength = elt.getVerilogName().size();
+    if (nameLength <= state.options.emittedLineLength / 3)
+      maxNameLength = std::max(maxNameLength, nameLength);
   }
 
   auto getWireForValue = [&](Value result) {
@@ -5819,7 +5822,11 @@ void StmtEmitter::emitInstancePortList(Operation *op,
     ps.scopedBox(isZeroWidth ? PP::neverbox : PP::ibox2, [&]() {
       auto modPortName = modPort.getVerilogName();
       ps << "." << PPExtString(modPortName);
-      ps.spaces(maxNameLength - modPortName.size() + 1);
+      // Align to the column if fits, else no-break and accept possible overrun.
+      if (modPortName.size() <= maxNameLength)
+        ps.spaces(maxNameLength - modPortName.size() + 1);
+      else
+        ps.nbsp();
       ps << "(";
       ps.scopedBox(PP::ibox0, [&]() {
         // Emit the value as an expression.
@@ -6385,11 +6392,14 @@ void ModuleEmitter::emitBind(BindOp op) {
     ModulePortInfo childPortInfo(cast<PortList>(childMod).getPortList());
 
     // Get the max port name length so we can align the '('.
+    // Exclude outlier names longer than the line.
     size_t maxNameLength = 0;
     for (auto &elt : childPortInfo) {
       auto portName = elt.getVerilogName();
       elt.name = Builder(inst.getContext()).getStringAttr(portName);
-      maxNameLength = std::max(maxNameLength, elt.getName().size());
+      size_t nameLength = elt.getName().size();
+      if (nameLength <= state.options.emittedLineLength / 3)
+        maxNameLength = std::max(maxNameLength, nameLength);
     }
 
     SmallVector<Value> instPortValues(childPortInfo.size());
@@ -6430,7 +6440,9 @@ void ModuleEmitter::emitBind(BindOp op) {
       }
 
       ps << "." << PPExtString(elt.getName());
-      ps.nbsp(maxNameLength - elt.getName().size());
+      // Align to the column if fits, else no-break and accept possible overrun.
+      if (elt.getName().size() <= maxNameLength)
+        ps.nbsp(maxNameLength - elt.getName().size());
       ps << " (";
       llvm::SmallPtrSet<Operation *, 4> ops;
       if (elt.isOutput()) {

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -302,3 +302,39 @@ hw.module @Top() {
   %bar = sv.reg : !hw.inout<i64>
   %agg = sv.reg : !hw.inout<struct<dw: i1, fn: i4, in: i64>>
 }
+
+// -----
+
+// Check handling of very long instance-port names.
+// They shouldn't force all ports to break!
+
+hw.module.extern @Child(in %verylongportname_verylongportname_verylongportname_verylongportname_verylongportname_verylongportname : i1, in %foo : i1, in %bar : i1, in %baz : i1)
+// CHECK-LABEL:module PPInstPort({{.*}}
+//      CHECK:  Child c ({{.*}}
+// CHECK-NEXT:    .verylongportname_verylongportname_verylongportname_verylongportname_verylongportname_verylongportname (in),{{.*}}
+// CHECK-NEXT:    .foo (in),{{.*}}
+// CHECK-NEXT:    .bar (in),{{.*}}
+// CHECK-NEXT:    .baz (in){{.*}}
+// CHECK-NEXT:  );{{.*}}
+hw.module @PPInstPort(in %in : i1) {
+  hw.instance "c" @Child (verylongportname_verylongportname_verylongportname_verylongportname_verylongportname_verylongportname: %in: i1, foo: %in: i1, bar: %in: i1, baz: %in: i1) -> ()
+}
+
+// -----
+
+// Check handling of very long bind port names.
+// They shouldn't force all ports to break!
+
+hw.module.extern @BChild(in %bindverylongportname_bindverylongportname_bindverylongportname_bindverylongportname_bindverylongportname : i1, in %foo : i1, in %bar : i1)
+hw.module @BParent(in %in : i1) {
+  hw.instance "c" sym @bi @BChild (bindverylongportname_bindverylongportname_bindverylongportname_bindverylongportname_bindverylongportname: %in: i1, foo: %in: i1, bar: %in: i1) -> () {doNotPrint}
+}
+// CHECK-LABEL:module BParent({{.*}}
+//      CHECK:  bind BParent BChild c ({{.*}}
+// CHECK-NEXT:    .bindverylongportname_bindverylongportname_bindverylongportname_bindverylongportname_bindverylongportname (in),{{.*}}
+// CHECK-NEXT:    .foo (in),{{.*}}
+// CHECK-NEXT:    .bar (in){{.*}}
+// CHECK-NEXT:  );{{.*}}
+hw.module @BTop() {
+  sv.bind #hw.innerNameRef<@BParent::@bi>
+}


### PR DESCRIPTION
Treat long port names as outliers, don't include in alignment column. They're likely (especially if very long) to overrun, and accepting that here produces nicer output for all the other ports (instead of space-padding out to the outliers).

Outlier classification somewhat whimsically selected as `emittedLineLength / 3`.

We do not know the current indent level, so that sort of measurement is off the table.