### PR TITLE
[ESI] Service requests: allow unstructured options

### DIFF
--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -42,6 +42,40 @@ PortRdenSuffix = "esi.portRdenSuffix"
 PortEmptySuffix = "esi.portEmptySuffix"
 
 
+def _options_to_dict_attr(
+    options: Optional[Dict[str, object]]) -> Optional[ir.DictAttr]:
+  """Convert a service-request 'options' dict to an ir.DictAttr, or return
+  None if there are no options. Returning None keeps the underlying op's
+  OptionalAttr<DictionaryAttr> unset so no `opts { ... }` clause is
+  emitted in the IR."""
+  if options is None or len(options) == 0:
+    return None
+  return optional_dict_to_dict_attr(options)
+
+
+def _attr_to_pyobj(attr: ir.Attribute) -> object:
+  """Best-effort inverse of `_obj_to_attribute` for the common attribute
+  kinds emitted by `optional_dict_to_dict_attr`. Falls back to returning
+  the raw attribute when the kind isn't recognized."""
+  if isinstance(attr, ir.StringAttr):
+    return attr.value
+  if isinstance(attr, ir.BoolAttr):
+    return attr.value
+  if isinstance(attr, ir.IntegerAttr):
+    return attr.value
+  if isinstance(attr, ir.ArrayAttr):
+    return [_attr_to_pyobj(a) for a in attr]
+  if isinstance(attr, ir.DictAttr):
+    return _dict_attr_to_dict(attr)
+  return attr
+
+
+def _dict_attr_to_dict(attr: ir.DictAttr) -> Dict[str, object]:
+  """Convert an ir.DictAttr to a plain dict, downcasting each value with
+  `_attr_to_pyobj`."""
+  return {attr[i].name: _attr_to_pyobj(attr[i].attr) for i in range(len(attr))}
+
+
 class ServiceDecl(_PyProxy):
   """Declare an ESI service interface."""
 
@@ -128,7 +162,10 @@ class _RequestConnection:
   def service_port(self) -> hw.InnerRefAttr:
     return hw.InnerRefAttr.get(self.decl.symbol, self._name)
 
-  def __call__(self, appid: AppID, type: Optional[Bundle] = None):
+  def __call__(self,
+               appid: AppID,
+               type: Optional[Bundle] = None,
+               options: Optional[Dict[str, object]] = None):
     if type is None:
       type = self.type
     self.decl._materialize_service_decl()
@@ -136,6 +173,7 @@ class _RequestConnection:
         raw_esi.RequestConnectionOp(type._type,
                                     self.service_port,
                                     appid._appid,
+                                    options=_options_to_dict_attr(options),
                                     loc=get_user_loc()).toClient)
 
 
@@ -181,6 +219,18 @@ class _OutputBundleSetter(AssignableSignal):
     self.type: Bundle = _FromCirctType(req.toClient.type)
     self.port = hw.InnerRefAttr(req.servicePort).name.value
     self._bundle_to_replace: Optional[ir.OpResult] = old_value_to_replace
+
+  @property
+  def options(self) -> Dict[str, object]:
+    """Return the request-specific options set at the `esi.service.req` /
+    `esi.service.req(..., options=...)` call site, as a plain dict. Returns
+    an empty dict when no options were set. Service-implementation generators
+    can inspect these options to influence how the request is fulfilled (e.g.
+    forwarding them into the manifest client record via `add_record(details=...)`).
+    """
+    if "options" not in self.req.attributes:
+      return {}
+    return _dict_attr_to_dict(ir.DictAttr(self.req.attributes["options"]))
 
   def add_record(self,
                  channel_assignments: Optional[Dict] = None,
@@ -685,17 +735,23 @@ class _HostMem(ServiceDecl):
             "data": data,
         }), valid)
 
-  def write(self, appid: AppID, req: ChannelSignal) -> ChannelSignal:
+  def write(self,
+            appid: AppID,
+            req: ChannelSignal,
+            options: Optional[Dict[str, object]] = None) -> ChannelSignal:
     """Create a write request to the host memory out of a request channel."""
     # Extract the data type from the request channel and call the helper to get
     # the write bundle type for the req channel.
     write_bundle_type = self.write_req_bundle_type(req.type.inner_type.data)
-    bundle = self.write_from_bundle(appid, write_bundle_type)
+    bundle = self.write_from_bundle(appid, write_bundle_type, options=options)
     resp = bundle.unpack(req=req)['ackTag']
     return resp
 
-  def write_from_bundle(self, appid: AppID,
-                        write_bundle_type: Bundle) -> BundleSignal:
+  def write_from_bundle(
+      self,
+      appid: AppID,
+      write_bundle_type: Bundle,
+      options: Optional[Dict[str, object]] = None) -> BundleSignal:
     self._materialize_service_decl()
 
     return cast(
@@ -706,6 +762,7 @@ class _HostMem(ServiceDecl):
                                             self.symbol,
                                             ir.StringAttr.get("write")),
                                         appid._appid,
+                                        options=_options_to_dict_attr(options),
                                         loc=get_user_loc()).toClient))
 
   def read_bundle_type(self, resp_type: Type) -> Bundle:
@@ -720,8 +777,11 @@ class _HostMem(ServiceDecl):
     ])
     return read_bundle_type
 
-  def read_from_bundle(self, appid: AppID,
-                       read_bundle_type: Bundle) -> BundleSignal:
+  def read_from_bundle(
+      self,
+      appid: AppID,
+      read_bundle_type: Bundle,
+      options: Optional[Dict[str, object]] = None) -> BundleSignal:
     """Request a connection based for a given read bundle type."""
     return cast(
         BundleSignal,
@@ -731,17 +791,21 @@ class _HostMem(ServiceDecl):
                                             self.symbol,
                                             ir.StringAttr.get("read")),
                                         appid._appid,
+                                        options=_options_to_dict_attr(options),
                                         loc=get_user_loc()).toClient))
 
-  def read(self, appid: AppID, req: ChannelSignal,
-           data_type: Type) -> ChannelSignal:
+  def read(self,
+           appid: AppID,
+           req: ChannelSignal,
+           data_type: Type,
+           options: Optional[Dict[str, object]] = None) -> ChannelSignal:
     """Create a read request to the host memory out of a request channel and
     return the response channel with the specified data type."""
 
     self._materialize_service_decl()
 
     read_bundle_type = self.read_bundle_type(data_type)
-    bundle_sig = self.read_from_bundle(appid, read_bundle_type)
+    bundle_sig = self.read_from_bundle(appid, read_bundle_type, options=options)
     resp = bundle_sig.unpack(req=req)['resp']
     return resp
 
@@ -759,30 +823,36 @@ class _ChannelService(ServiceDecl):
   def __init__(self):
     super().__init__(self.__class__)
 
-  def from_host(self, name: AppID, type: Type) -> ChannelSignal:
+  def from_host(self,
+                name: AppID,
+                type: Type,
+                options: Optional[Dict[str, object]] = None) -> ChannelSignal:
     bundle_type = Bundle(
         [BundledChannel("data", ChannelDirection.TO, Channel(type))])
     self._materialize_service_decl()
-    from_host = raw_esi.RequestConnectionOp(bundle_type._type,
-                                            hw.InnerRefAttr.get(
-                                                self.symbol,
-                                                ir.StringAttr.get("from_host")),
-                                            name._appid,
-                                            loc=get_user_loc())
+    from_host = raw_esi.RequestConnectionOp(
+        bundle_type._type,
+        hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("from_host")),
+        name._appid,
+        options=_options_to_dict_attr(options),
+        loc=get_user_loc())
     from_host = _FromCirctValue(from_host.toClient)
     assert isinstance(from_host, BundleSignal)
     return from_host.unpack()["data"]
 
-  def to_host(self, name: AppID, chan: ChannelSignal) -> None:
+  def to_host(self,
+              name: AppID,
+              chan: ChannelSignal,
+              options: Optional[Dict[str, object]] = None) -> None:
     bundle_type = Bundle(
         [BundledChannel("data", ChannelDirection.FROM, chan.type)])
     self._materialize_service_decl()
-    to_host = raw_esi.RequestConnectionOp(bundle_type._type,
-                                          hw.InnerRefAttr.get(
-                                              self.symbol,
-                                              ir.StringAttr.get("to_host")),
-                                          name._appid,
-                                          loc=get_user_loc())
+    to_host = raw_esi.RequestConnectionOp(
+        bundle_type._type,
+        hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("to_host")),
+        name._appid,
+        options=_options_to_dict_attr(options),
+        loc=get_user_loc())
     to_host = _FromCirctValue(to_host.toClient)
     assert isinstance(to_host, BundleSignal)
     to_host.unpack(data=chan)
@@ -801,7 +871,10 @@ class _FuncService(ServiceDecl):
   def __init__(self):
     super().__init__(self.__class__)
 
-  def get(self, name: AppID, bundle_type: Bundle) -> BundleSignal:
+  def get(self,
+          name: AppID,
+          bundle_type: Bundle,
+          options: Optional[Dict[str, object]] = None) -> BundleSignal:
     """Treat any bi-directional bundle as a function by getting a proper
     function bundle with the appropriate types, then renaming the channels to
     match the 'bundle_type'. Returns a bundle signal of type 'bundle_type'."""
@@ -828,14 +901,21 @@ class _FuncService(ServiceDecl):
     # Get the function channels and wire them up to create the non-function
     # bundle 'bundle_type'.
     from_channel = Wire(from_channel_bc.channel)
-    arg_channel = self.get_call_chans(name, to_channel_bc.channel, from_channel)
+    arg_channel = self.get_call_chans(name,
+                                      to_channel_bc.channel,
+                                      from_channel,
+                                      options=options)
     ret_bundle, from_chans = bundle_type.pack(
         **{to_channel_bc.name: arg_channel})
     from_channel.assign(from_chans[from_channel_bc.name])
     return ret_bundle
 
-  def get_call_chans(self, name: AppID, arg_type: Type,
-                     result: Signal) -> ChannelSignal:
+  def get_call_chans(
+      self,
+      name: AppID,
+      arg_type: Type,
+      result: Signal,
+      options: Optional[Dict[str, object]] = None) -> ChannelSignal:
     """Expose a function to the ESI system. Arguments:
       'name' is an AppID which is the function name.
       'arg_type' is the type of the argument to the function.
@@ -850,12 +930,12 @@ class _FuncService(ServiceDecl):
         BundledChannel("result", ChannelDirection.FROM, result.type)
     ])
     self._materialize_service_decl()
-    func_call = raw_esi.RequestConnectionOp(bundle._type,
-                                            hw.InnerRefAttr.get(
-                                                self.symbol,
-                                                ir.StringAttr.get("call")),
-                                            name._appid,
-                                            loc=get_user_loc())
+    func_call = raw_esi.RequestConnectionOp(
+        bundle._type,
+        hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("call")),
+        name._appid,
+        options=_options_to_dict_attr(options),
+        loc=get_user_loc())
     to_funcs = _FromCirctValue(func_call.toClient).unpack(result=result)
     return to_funcs['arg']
 
@@ -873,19 +953,25 @@ class _CallService(ServiceDecl):
   def __init__(self):
     super().__init__(self.__class__)
 
-  def call(self, name: AppID, arg: ChannelSignal,
-           result_type: Type) -> ChannelSignal:
+  def call(self,
+           name: AppID,
+           arg: ChannelSignal,
+           result_type: Type,
+           options: Optional[Dict[str, object]] = None) -> ChannelSignal:
     """Call a function with the given argument. 'arg' must be a ChannelSignal
     with the argument value."""
     func_bundle = Bundle([
         BundledChannel("arg", ChannelDirection.FROM, arg.type),
         BundledChannel("result", ChannelDirection.TO, result_type)
     ])
-    call_bundle = self.get(name, func_bundle)
+    call_bundle = self.get(name, func_bundle, options=options)
     bundle_rets = call_bundle.unpack(arg=arg)
     return bundle_rets['result']
 
-  def get(self, name: AppID, func_type: Bundle) -> BundleSignal:
+  def get(self,
+          name: AppID,
+          func_type: Bundle,
+          options: Optional[Dict[str, object]] = None) -> BundleSignal:
     """Expose a bundle to the host as a function. Bundle _must_ have 'arg' and
     'result' channels going FROM the server and TO the server, respectively."""
     self._materialize_service_decl()
@@ -895,6 +981,7 @@ class _CallService(ServiceDecl):
                                     hw.InnerRefAttr.get(
                                         self.symbol, ir.StringAttr.get("call")),
                                     name._appid,
+                                    options=_options_to_dict_attr(options),
                                     loc=get_user_loc()).toClient)
     assert isinstance(func_call, BundleSignal)
     return func_call
@@ -918,15 +1005,19 @@ class _Telemetry(ServiceDecl):
   def __init__(self):
     super().__init__(self.__class__)
 
-  def report_signal(self, clk: ClockSignal, rst: BitsSignal, name: AppID,
-                    data: Signal) -> None:
+  def report_signal(self,
+                    clk: ClockSignal,
+                    rst: BitsSignal,
+                    name: AppID,
+                    data: Signal,
+                    options: Optional[Dict[str, object]] = None) -> None:
     """Report a value to the telemetry service. 'data' is the value to report."""
     bundle_type = Bundle([
         BundledChannel("get", ChannelDirection.TO, Bits(0)),
         BundledChannel("data", ChannelDirection.FROM, data.type)
     ])
 
-    report_bundle = self.report(name, bundle_type)
+    report_bundle = self.report(name, bundle_type, options=options)
     get_valid_wire = Wire(Bits(1))
     data_channel, data_ready = Channel(data.type).wrap(data, get_valid_wire)
     data_channel = data_channel.buffer(clk, rst, stages=1)

--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -9,7 +9,8 @@ from .module import (generator, modparams, Module, ModuleLikeBuilderBase,
                      PortProxyBase)
 from .signals import (BitsSignal, BundleSignal, ChannelSignal, ClockSignal,
                       Signal, _FromCirctValue, UIntSignal)
-from .support import clog2, optional_dict_to_dict_attr, get_user_loc
+from .support import (clog2, optional_dict_to_optional_dict_attr, get_user_loc,
+                      optional_dict_to_dict_attr)
 from .system import System
 from .types import (Any, Bits, Bundle, BundledChannel, Channel,
                     ChannelDirection, ChannelSignaling, StructType, Type,
@@ -17,6 +18,7 @@ from .types import (Any, Bits, Bundle, BundledChannel, Channel,
 
 from .circt import ir
 from .circt.dialects import esi as raw_esi, hw, msft
+from .circt.support import attribute_to_var
 
 import inspect
 from pathlib import Path
@@ -40,40 +42,6 @@ PortValidSuffix = "esi.portValidSuffix"
 PortReadySuffix = "esi.portReadySuffix"
 PortRdenSuffix = "esi.portRdenSuffix"
 PortEmptySuffix = "esi.portEmptySuffix"
-
-
-def _options_to_dict_attr(
-    options: Optional[Dict[str, object]]) -> Optional[ir.DictAttr]:
-  """Convert a service-request 'options' dict to an ir.DictAttr, or return
-  None if there are no options. Returning None keeps the underlying op's
-  OptionalAttr<DictionaryAttr> unset so no `opts { ... }` clause is
-  emitted in the IR."""
-  if options is None or len(options) == 0:
-    return None
-  return optional_dict_to_dict_attr(options)
-
-
-def _attr_to_pyobj(attr: ir.Attribute) -> object:
-  """Best-effort inverse of `_obj_to_attribute` for the common attribute
-  kinds emitted by `optional_dict_to_dict_attr`. Falls back to returning
-  the raw attribute when the kind isn't recognized."""
-  if isinstance(attr, ir.StringAttr):
-    return attr.value
-  if isinstance(attr, ir.BoolAttr):
-    return attr.value
-  if isinstance(attr, ir.IntegerAttr):
-    return attr.value
-  if isinstance(attr, ir.ArrayAttr):
-    return [_attr_to_pyobj(a) for a in attr]
-  if isinstance(attr, ir.DictAttr):
-    return _dict_attr_to_dict(attr)
-  return attr
-
-
-def _dict_attr_to_dict(attr: ir.DictAttr) -> Dict[str, object]:
-  """Convert an ir.DictAttr to a plain dict, downcasting each value with
-  `_attr_to_pyobj`."""
-  return {attr[i].name: _attr_to_pyobj(attr[i].attr) for i in range(len(attr))}
 
 
 class ServiceDecl(_PyProxy):
@@ -170,11 +138,12 @@ class _RequestConnection:
       type = self.type
     self.decl._materialize_service_decl()
     return _FromCirctValue(
-        raw_esi.RequestConnectionOp(type._type,
-                                    self.service_port,
-                                    appid._appid,
-                                    options=_options_to_dict_attr(options),
-                                    loc=get_user_loc()).toClient)
+        raw_esi.RequestConnectionOp(
+            type._type,
+            self.service_port,
+            appid._appid,
+            options=optional_dict_to_optional_dict_attr(options),
+            loc=get_user_loc()).toClient)
 
 
 def Cosim(decl: ServiceDecl, clk, rst):
@@ -225,12 +194,10 @@ class _OutputBundleSetter(AssignableSignal):
     """Return the request-specific options set at the `esi.service.req` /
     `esi.service.req(..., options=...)` call site, as a plain dict. Returns
     an empty dict when no options were set. Service-implementation generators
-    can inspect these options to influence how the request is fulfilled (e.g.
-    forwarding them into the manifest client record via `add_record(details=...)`).
-    """
+    can inspect these options to influence how the request is fulfilled."""
     if "options" not in self.req.attributes:
       return {}
-    return _dict_attr_to_dict(ir.DictAttr(self.req.attributes["options"]))
+    return attribute_to_var(ir.DictAttr(self.req.attributes["options"]))
 
   def add_record(self,
                  channel_assignments: Optional[Dict] = None,
@@ -757,13 +724,12 @@ class _HostMem(ServiceDecl):
     return cast(
         BundleSignal,
         _FromCirctValue(
-            raw_esi.RequestConnectionOp(write_bundle_type._type,
-                                        hw.InnerRefAttr.get(
-                                            self.symbol,
-                                            ir.StringAttr.get("write")),
-                                        appid._appid,
-                                        options=_options_to_dict_attr(options),
-                                        loc=get_user_loc()).toClient))
+            raw_esi.RequestConnectionOp(
+                write_bundle_type._type,
+                hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("write")),
+                appid._appid,
+                options=optional_dict_to_optional_dict_attr(options),
+                loc=get_user_loc()).toClient))
 
   def read_bundle_type(self, resp_type: Type) -> Bundle:
     """Build a read bundle type for the given data type."""
@@ -786,13 +752,12 @@ class _HostMem(ServiceDecl):
     return cast(
         BundleSignal,
         _FromCirctValue(
-            raw_esi.RequestConnectionOp(read_bundle_type._type,
-                                        hw.InnerRefAttr.get(
-                                            self.symbol,
-                                            ir.StringAttr.get("read")),
-                                        appid._appid,
-                                        options=_options_to_dict_attr(options),
-                                        loc=get_user_loc()).toClient))
+            raw_esi.RequestConnectionOp(
+                read_bundle_type._type,
+                hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("read")),
+                appid._appid,
+                options=optional_dict_to_optional_dict_attr(options),
+                loc=get_user_loc()).toClient))
 
   def read(self,
            appid: AppID,
@@ -834,7 +799,7 @@ class _ChannelService(ServiceDecl):
         bundle_type._type,
         hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("from_host")),
         name._appid,
-        options=_options_to_dict_attr(options),
+        options=optional_dict_to_optional_dict_attr(options),
         loc=get_user_loc())
     from_host = _FromCirctValue(from_host.toClient)
     assert isinstance(from_host, BundleSignal)
@@ -851,7 +816,7 @@ class _ChannelService(ServiceDecl):
         bundle_type._type,
         hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("to_host")),
         name._appid,
-        options=_options_to_dict_attr(options),
+        options=optional_dict_to_optional_dict_attr(options),
         loc=get_user_loc())
     to_host = _FromCirctValue(to_host.toClient)
     assert isinstance(to_host, BundleSignal)
@@ -934,7 +899,7 @@ class _FuncService(ServiceDecl):
         bundle._type,
         hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("call")),
         name._appid,
-        options=_options_to_dict_attr(options),
+        options=optional_dict_to_optional_dict_attr(options),
         loc=get_user_loc())
     to_funcs = _FromCirctValue(func_call.toClient).unpack(result=result)
     return to_funcs['arg']
@@ -977,12 +942,12 @@ class _CallService(ServiceDecl):
     self._materialize_service_decl()
 
     func_call = _FromCirctValue(
-        raw_esi.RequestConnectionOp(func_type._type,
-                                    hw.InnerRefAttr.get(
-                                        self.symbol, ir.StringAttr.get("call")),
-                                    name._appid,
-                                    options=_options_to_dict_attr(options),
-                                    loc=get_user_loc()).toClient)
+        raw_esi.RequestConnectionOp(
+            func_type._type,
+            hw.InnerRefAttr.get(self.symbol, ir.StringAttr.get("call")),
+            name._appid,
+            options=optional_dict_to_optional_dict_attr(options),
+            loc=get_user_loc()).toClient)
     assert isinstance(func_call, BundleSignal)
     return func_call
 

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -69,6 +69,15 @@ def optional_dict_to_dict_attr(d: Optional[Dict]) -> ir.DictAttr:
   return ir.DictAttr.get({k: _obj_to_attribute(v) for k, v in d.items()})
 
 
+def optional_dict_to_optional_dict_attr(
+    d: Optional[Dict]) -> Optional[ir.DictAttr]:
+  """Convert a dictionary to an MLIR dictionary attribute, or return None if
+  the input is None or empty."""
+  if d is None or len(d) == 0:
+    return None
+  return optional_dict_to_dict_attr(d)
+
+
 __dir__ = os.path.dirname(__file__)
 _hidden_filenames = set(["functools.py", "support.py"])
 

--- a/frontends/PyCDE/test/test_esi_servicegens.py
+++ b/frontends/PyCDE/test/test_esi_servicegens.py
@@ -28,7 +28,14 @@ class LoopbackInOut(Module):
   @generator
   def construct(self):
     loopback = Wire(Channel(Bits(16)))
-    call_bundle = HostComms.req_resp(AppID("loopback_inout"))
+    # Attach per-request options; these should flow through the connect-
+    # services pass onto the `service.impl_req.req` op and become visible
+    # to the service-impl generator via `bundle.options`.
+    call_bundle = HostComms.req_resp(AppID("loopback_inout"),
+                                     options={
+                                         "engine": "myMod.MyEngine",
+                                         "priority": 5,
+                                     })
     froms = call_bundle.unpack(resp=loopback)
     from_host = froms['req']
     ready = Wire(Bits(1))
@@ -56,6 +63,9 @@ class MultiplexerService(esi.ServiceImplementation):
     assert len(
         bundles.to_client_reqs) == 1, "Only one connection request supported"
     bundle = bundles.to_client_reqs[0]
+    # Exercise the new per-request options surface on the service-impl side.
+    # Print in a stable form so FileCheck can pin the observed dict.
+    print("options:", sorted(bundle.options.items()))
     bundle.add_record(details={"foo": 5, "client_name": bundle.client_name})
     to_req_types = {}
     for bundled_chan in bundle.type.channels:
@@ -131,6 +141,11 @@ class MultiplexerTop(Module):
 
     LoopbackInOut()
 
+
+# The service-impl generator prints its observed options dict; verify the
+# per-request `options=` kwarg on `HostComms.req_resp(...)` flows through
+# the connect-services pass to `bundle.options`.
+# CHECK: options: [('engine', 'myMod.MyEngine'), ('priority', 5)]
 
 # CHECK-LABEL: hw.module @MultiplexerTop(in %clk : i1, in %rst : i1, in %trunk_in : i256, in %trunk_in_valid : i1, in %trunk_out_ready : i1, out trunk_in_ready : i1, out trunk_out : i256, out trunk_out_valid : i1) attributes {output_file = #hw.output_file<"MultiplexerTop.sv", includeReplicatedOps>} {
 # CHECK:         %c0_i240 = hw.constant 0 : i240

--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -144,11 +144,26 @@ def ServiceImplementConnReqOp : ESI_Op<"service.impl_req.req", [
   let summary = "The canonical form of a connection request";
   let description = [{
     The canonical form of a connection request produced by the ESI connect-
-    services pass from a `service.req`. Carries an optional dictionary of
-    request-specific options (`opts { ... }`) which the service
-    implementation can inspect (for example, to pick a specific channel
-    engine or configure how the request is fulfilled). Options are copied
-    verbatim from the originating `service.req`.
+    services pass from a `service.req`. Lives inside a `service.impl_req`
+    region and is what a service implementation consumes when materializing
+    the request.
+
+    Arguments:
+
+    - `$servicePort`: inner-ref to the service port being requested (i.e. an
+      `esi.service.port` inside an `esi.service.decl`).
+    - `$relativeAppIDPath`: array of `AppIDAttr`s describing the client's
+      location relative to the enclosing `service.impl_req`, from the outer-
+      most instance inward.
+    - `$options`: optional dictionary of request-specific options carried
+      verbatim from the originating `service.req`. Service implementations
+      can inspect these to configure how the request is fulfilled (for
+      example, to select a particular channel engine).
+
+    Result:
+
+    - `$toClient`: the bundle the service implementation must supply to
+      fulfill this connection request.
   }];
 
   let arguments = (ins InnerRefAttr:$servicePort,
@@ -171,12 +186,26 @@ def RequestConnectionOp : ESI_Op<"service.req", [
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Request a connection to receive data";
   let description = [{
-    Request a bundle connection to a service port. Optionally carries a
-    request-specific dictionary of options (`opts { ... }`) which is
-    threaded through the connect-services pass onto the resulting
-    `service.impl_req.req` where the service implementation can consume
-    it (for example, to configure how the request is fulfilled or to
-    select a particular channel engine).
+    Request a bundle connection to a service port. The connect-services pass
+    surfaces this request up the instance hierarchy and rewrites it into a
+    `service.impl_req.req` inside the matching `service.impl_req` region.
+
+    Arguments:
+
+    - `$servicePort`: inner-ref to the service port being requested (i.e. an
+      `esi.service.port` inside an `esi.service.decl`).
+    - `$appID`: `AppIDAttr` identifying this specific client of the service.
+    - `$options`: optional dictionary of request-specific options. Threaded
+      verbatim through the connect-services pass onto the resulting
+      `service.impl_req.req` where the service implementation can consume
+      it (for example, to configure how the request is fulfilled or to
+      select a particular channel engine). Keys and value types are not
+      interpreted by the dialect.
+
+    Result:
+
+    - `$toClient`: the bundle the service implementation will supply to
+      fulfill this connection request.
   }];
 
   let arguments = (ins InnerRefAttr:$servicePort,

--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -142,12 +142,22 @@ def ServiceImplementReqOp : ESI_Op<"service.impl_req", [
 def ServiceImplementConnReqOp : ESI_Op<"service.impl_req.req", [
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "The canonical form of a connection request";
+  let description = [{
+    The canonical form of a connection request produced by the ESI connect-
+    services pass from a `service.req`. Carries an optional dictionary of
+    request-specific options (`opts { ... }`) which the service
+    implementation can inspect (for example, to pick a specific channel
+    engine or configure how the request is fulfilled). Options are copied
+    verbatim from the originating `service.req`.
+  }];
 
   let arguments = (ins InnerRefAttr:$servicePort,
-                       AppIDArrayAttr:$relativeAppIDPath);
+                       AppIDArrayAttr:$relativeAppIDPath,
+                       OptionalAttr<DictionaryAttr>:$options);
   let results = (outs ChannelBundleType:$toClient);
   let assemblyFormat = [{
     $servicePort `(` $relativeAppIDPath `)`
+      (`opts` $options^)?
       attr-dict `:` qualified(type($toClient))
   }];
 
@@ -160,12 +170,22 @@ def RequestConnectionOp : ESI_Op<"service.req", [
         DeclareOpInterfaceMethods<HasAppIDOpInterface>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Request a connection to receive data";
+  let description = [{
+    Request a bundle connection to a service port. Optionally carries a
+    request-specific dictionary of options (`opts { ... }`) which is
+    threaded through the connect-services pass onto the resulting
+    `service.impl_req.req` where the service implementation can consume
+    it (for example, to configure how the request is fulfilled or to
+    select a particular channel engine).
+  }];
 
   let arguments = (ins InnerRefAttr:$servicePort,
-                       AppIDAttr:$appID);
+                       AppIDAttr:$appID,
+                       OptionalAttr<DictionaryAttr>:$options);
   let results = (outs ChannelBundleType:$toClient);
   let assemblyFormat = [{
     $servicePort `(` qualified($appID) `)`
+      (`opts` $options^)?
       attr-dict `:` qualified(type($toClient))
   }];
 }

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -540,7 +540,8 @@ void ESIConnectServicesPass::convertReq(RequestConnectionOp req) {
   OpBuilder b(req);
   auto newReq = ServiceImplementConnReqOp::create(
       b, req.getLoc(), req.getToClient().getType(), req.getServicePortAttr(),
-      ArrayAttr::get(&getContext(), {req.getAppIDAttr()}));
+      ArrayAttr::get(&getContext(), {req.getAppIDAttr()}),
+      /*options=*/req.getOptionsAttr());
   newReq->setDialectAttrs(req->getDialectAttrs());
   req.getToClient().replaceAllUsesWith(newReq.getToClient());
 
@@ -740,7 +741,8 @@ ESIConnectServicesPass::surfaceReqs(hw::HWMutableModuleLike mod,
       // Clone the request.
       auto clone = ServiceImplementConnReqOp::create(
           b, req.getLoc(), req.getToClient().getType(),
-          req.getServicePortAttr(), appIDPath);
+          req.getServicePortAttr(), appIDPath,
+          /*options=*/req.getOptionsAttr());
       clone->setDialectAttrs(req->getDialectAttrs());
       newOperands.push_back(clone.getToClient());
     }

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -220,7 +220,8 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
     for (unsigned i = 0; i < memType.loadPorts; ++i) {
       auto req = esi::RequestConnectionOp::create(
           b, loc, readPortInfo.type, readPortInfo.port,
-          esi::AppIDAttr::get(ctx, b.getStringAttr("load"), resIdx));
+          esi::AppIDAttr::get(ctx, b.getStringAttr("load"), resIdx),
+          /*options=*/DictionaryAttr());
       auto reqUnpack = esi::UnpackBundleOp::create(
           b, loc, req.getToClient(), ValueRange{backedges[resIdx]});
       instanceArgsFromThisMem.push_back(
@@ -233,7 +234,8 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
     for (unsigned i = 0; i < memType.storePorts; ++i) {
       auto req = esi::RequestConnectionOp::create(
           b, loc, writePortInfo.type, writePortInfo.port,
-          esi::AppIDAttr::get(ctx, b.getStringAttr("store"), resIdx));
+          esi::AppIDAttr::get(ctx, b.getStringAttr("store"), resIdx),
+          /*options=*/DictionaryAttr());
       auto reqUnpack = esi::UnpackBundleOp::create(
           b, loc, req.getToClient(), ValueRange{backedges[resIdx]});
       instanceArgsFromThisMem.push_back(

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -258,3 +258,33 @@ hw.module @TelemetryTest1(in %clk : !seq.clock, in %rst : i1, in %value: !esi.ch
   %telemetryBundle = esi.service.req <@telemetry::@report> (#esi.appid<"telemetry">) : !esi.bundle<[!esi.channel<i0> to "get", !esi.channel<ui64> from "data"]>
   esi.bundle.unpack %value from %telemetryBundle : !esi.bundle<[!esi.channel<i0> to "get", !esi.channel<ui64> from "data"]>
 }
+
+// Per-request 'opts' dictionary: verify round-trip on `service.req` and
+// `service.impl_req.req`, and that the connect-services pass threads the
+// dict verbatim from the client-side `service.req` into the emitted
+// `service.impl_req.req`. Uses an unregistered impl_type so the
+// `service.impl_req` (and its inner `service.impl_req.req` ops) survive
+// the pass and can be inspected.
+
+!optsBundle = !esi.bundle<[!esi.channel<i8> to "recv"]>
+
+esi.service.decl @HostCommsOpts {
+  esi.service.port @Recv : !optsBundle
+}
+
+// CONN-LABEL: hw.module @OptsTop(in %clk : !seq.clock, in %rst : i1) {
+// CONN:         esi.service.impl_req #esi.appid<"optcomms"> svc @HostCommsOpts impl as "myOptImpl"(%clk) : (!seq.clock) -> !esi.bundle<[!esi.channel<i8> to "recv"]> {
+// CONN-NEXT:      esi.service.impl_req.req <@HostCommsOpts::@Recv>([#esi.appid<"opt_client">]) opts {engine = "myMod.MyEngine", flag = true, priority = 5 : i32} : !esi.bundle<[!esi.channel<i8> to "recv"]>
+// CONN-NEXT:    }
+hw.module @OptsTop(in %clk: !seq.clock, in %rst: i1) {
+  esi.service.instance #esi.appid<"optcomms"> svc @HostCommsOpts impl as "myOptImpl" (%clk) : (!seq.clock) -> ()
+  hw.instance "m1" @OptsClient(clk: %clk: !seq.clock) -> ()
+}
+
+// CONN-LABEL: hw.module @OptsClient(in %clk : !seq.clock, in %opt_client : !esi.bundle<[!esi.channel<i8> to "recv"]>) {
+// CONN-NEXT:    esi.manifest.req #esi.appid<"opt_client">, <@HostCommsOpts::@Recv>, !esi.bundle<[!esi.channel<i8> to "recv"]>
+// CONN-NEXT:    esi.bundle.unpack  from %opt_client : !esi.bundle<[!esi.channel<i8> to "recv"]>
+hw.module @OptsClient(in %clk: !seq.clock) {
+  %b = esi.service.req <@HostCommsOpts::@Recv> (#esi.appid<"opt_client">) opts {engine = "myMod.MyEngine", flag = true, priority = 5 : i32} : !optsBundle
+  esi.bundle.unpack from %b : !optsBundle
+}


### PR DESCRIPTION
Allow specifying a dictionary of options on each service client request. The implementation can see it and might be used to modify its behavior. This commit includes the ability to override the default channel engine on a per-client basis with another one based on an option.

Assisted-by: Github-Copilot: Claude Opus 4.8


