### PR TITLE
[ESI][Runtime] BSP: override the channel engine via option

### DIFF
--- a/lib/Dialect/ESI/runtime/pyproject.toml
+++ b/lib/Dialect/ESI/runtime/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-xdist", "pycde", "numpy"]
+test = ["pytest", "pytest-xdist", "pycde>=0.10.0"]
 
 [project.scripts]
 esiquery = "esiaccel.utils:run_esiquery"

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -1309,6 +1309,10 @@ def _resolve_engine_pair(path: str) -> Tuple[Callable, Callable]:
     - a zero-arg factory callable returning such a tuple.
   """
   import importlib
+  if not isinstance(path, str):
+    raise TypeError(
+        "Engine override path must be a dotted 'pkg.mod.attr' string; "
+        f"got {type(path).__name__}")
   module_path, _, attr_path = path.rpartition(".")
   if not module_path or not attr_path:
     raise ValueError(
@@ -1323,6 +1327,10 @@ def _resolve_engine_pair(path: str) -> Tuple[Callable, Callable]:
     raise TypeError(
         f"Engine override {path!r} must resolve to a 2-tuple "
         f"(to_host_engine_gen, from_host_engine_gen); got {type(obj).__name__}")
+  if not (callable(obj[0]) and callable(obj[1])):
+    raise TypeError(
+        f"Engine override {path!r} must resolve to a 2-tuple of callables; got "
+        f"({type(obj[0]).__name__}, {type(obj[1]).__name__})")
   return obj
 
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -1297,13 +1297,51 @@ def DummyFromHostEngine(client_type: Type) -> type['DummyFromHostEngineImpl']:
   return DummyFromHostEngineImpl
 
 
+def _resolve_engine_pair(path: str) -> Tuple[Callable, Callable]:
+  """Resolve a dotted Python import path to a
+  `(to_host_engine_gen, from_host_engine_gen)` tuple, used to override the
+  default engine pair for a specific service request.
+
+  The path may point at either:
+    - a module-level 2-tuple attribute, e.g.
+      `"mypkg.mymod.MyEnginePair"` where `MyEnginePair` is
+      `(MyToHost, MyFromHost)`; or
+    - a zero-arg factory callable returning such a tuple.
+  """
+  import importlib
+  module_path, _, attr_path = path.rpartition(".")
+  if not module_path or not attr_path:
+    raise ValueError(
+        "Engine override path must be a dotted 'pkg.mod.attr' string; "
+        f"got {path!r}")
+  obj = importlib.import_module(module_path)
+  for part in attr_path.split("."):
+    obj = getattr(obj, part)
+  if callable(obj):
+    obj = obj()
+  if not (isinstance(obj, tuple) and len(obj) == 2):
+    raise TypeError(
+        f"Engine override {path!r} must resolve to a 2-tuple "
+        f"(to_host_engine_gen, from_host_engine_gen); got {type(obj).__name__}")
+  return obj
+
+
 def ChannelEngineService(
     to_host_engine_gen: Callable,
     from_host_engine_gen: Callable) -> type['ChannelEngineService']:
   """Returns a channel service implementation which calls
   to_host_engine_gen(<client_type>) or from_host_engine_gen(<client_type>) to
   generate the to_host and from_host engines for each channel. Does not support
-  engines which can service multiple clients at once."""
+  engines which can service multiple clients at once.
+
+  Individual service requests may override the default engine pair by passing
+  `options={"engine": "pkg.mod.attr"}` at the service-request call site (e.g.
+  `HostComms.some_bundle(AppID(...), options={"engine": "..."})`). The path
+  is resolved by `_resolve_engine_pair` and must yield a
+  `(to_host_engine_gen, from_host_engine_gen)` tuple with the same call shape
+  as the defaults; the override applies to every channel of that request's
+  bundle.
+  """
 
   class ChannelEngineService(esi.ServiceImplementation):
     """Service implementation which services the clients via a per-channel DMA
@@ -1322,7 +1360,10 @@ def ChannelEngineService(
         appid_strings = [str(appid) for appid in client_appid]
         return f"{'_'.join(appid_strings)}.{channel_name}"
 
-      def build_engine(bc: BundledChannel, input_channel=None) -> Type:
+      def build_engine(bc: BundledChannel,
+                       bundle_to_host_gen: Callable,
+                       bundle_from_host_gen: Callable,
+                       input_channel=None) -> Type:
         idbase = build_engine_appid(bundle.client_name, bc.name)
         eng_appid = esi.AppID(idbase)
         # DMA engines require at least 1 byte of data; substitute Bits(8)
@@ -1333,9 +1374,9 @@ def ChannelEngineService(
         if is_void:
           engine_client_type = Bits(8)
         if bc.direction == ChannelDirection.FROM:
-          engine_mod = to_host_engine_gen(engine_client_type)
+          engine_mod = bundle_to_host_gen(engine_client_type)
         else:
-          engine_mod = from_host_engine_gen(engine_client_type)
+          engine_mod = bundle_from_host_gen(engine_client_type)
         eng_inputs = {
             "clk": ports.clk,
             "rst": ports.rst,
@@ -1371,12 +1412,24 @@ def ChannelEngineService(
         return engine
 
       for bundle in bundles.to_client_reqs:
+        # Per-request engine override: if the client's service request carries
+        # an `"engine"` option, use that engine pair instead of the defaults
+        # for every channel of this bundle. This is purely a hardware-side
+        # substitution.
+        engine_override = bundle.options.get("engine")
+        if engine_override is None:
+          bundle_to_host_gen = to_host_engine_gen
+          bundle_from_host_gen = from_host_engine_gen
+        else:
+          bundle_to_host_gen, bundle_from_host_gen = _resolve_engine_pair(
+              engine_override)
+
         bundle_type = bundle.type
         to_channels = {}
         # Create a DMA engine for each channel headed TO the client (from the host).
         for bc in bundle_type.channels:
           if bc.direction == ChannelDirection.TO:
-            engine = build_engine(bc)
+            engine = build_engine(bc, bundle_to_host_gen, bundle_from_host_gen)
             out_chan = engine.output_channel
             # For void channels, narrow the 8-bit placeholder back to 0-bit.
             if bc.channel.inner_type.bitwidth == 0:
@@ -1389,6 +1442,7 @@ def ChannelEngineService(
         # Create a DMA engine for each channel headed FROM the client (to the host).
         for bc in bundle_type.channels:
           if bc.direction == ChannelDirection.FROM:
-            build_engine(bc, froms[bc.name])
+            build_engine(bc, bundle_to_host_gen, bundle_from_host_gen,
+                         froms[bc.name])
 
   return ChannelEngineService

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
@@ -1143,6 +1143,18 @@ def FromHostDMATest(width: int):
   return FromHostDMATest
 
 
+# Factory returning the same (to_host, from_host) engine pair the cosim_dma
+# BSP wires in by default. Used below to exercise the per-request engine
+# override on `ChannelService` requests: the resolver imports this path,
+# calls it, and the returned pair replaces the default pair for just that
+# one request's channel. Kept module-scope so it is importable as
+# 'esiaccel.esitester._one_item_buffers_pair' from a service-request
+# `options={"engine": ...}` value.
+def _one_item_buffers_pair():
+  from .bsp.dma import OneItemBuffersToHost, OneItemBuffersFromHost
+  return (OneItemBuffersToHost, OneItemBuffersFromHost)
+
+
 class ChannelTest(Module):
   """Test the ChannelService with a to_host producer and a from_host loopback.
 
@@ -1198,7 +1210,14 @@ class ChannelTest(Module):
     mmio_rw_cmd_chan = mmio_rw.unpack(data=response_chan)["cmd"]
     cmd_chan_wire.assign(mmio_rw_cmd_chan)
 
-    esi.ChannelService.to_host(AppID("producer"), data_chan)
+    # Per-request engine override: on cosim_dma this resolves to the same
+    # (OneItemBuffersToHost, OneItemBuffersFromHost) pair the BSP already
+    # uses by default, so this exercises the resolver + substitution path
+    # end-to-end without altering the observed runtime behavior.
+    esi.ChannelService.to_host(
+        AppID("producer"),
+        data_chan,
+        options={"engine": "esiaccel.esitester._one_item_buffers_pair"})
 
     # from_host -> to_host loopback.
     loopback_in = esi.ChannelService.from_host(AppID("loopback_in"), UInt(32))


### PR DESCRIPTION
Adds the ability to override the default engine on a per-client basis via a service request option.

Assisted-by: Github-Copilot: Claude Opus 4.7

