### PR TITLE
[PyCDE] Remove numpy build dependency

### DIFF
--- a/frontends/PyCDE/pyproject.toml
+++ b/frontends/PyCDE/pyproject.toml
@@ -8,7 +8,6 @@ requires = [
   "executing",
 
   # MLIR build depends.
-  "numpy",
   "nanobind>=2.2",
   "PyYAML",
 ]


### PR DESCRIPTION
Pulling in numpy during the build was causing issues and seems to be unnecessary.
