### PR TITLE
[circt-bmc] Lower BMC trace markers to runtime callbacks

### DIFF
--- a/include/circt/Tools/circt-bmc/BMCTrace.h
+++ b/include/circt/Tools/circt-bmc/BMCTrace.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -50,6 +51,9 @@ public:
   size_t addSignal(llvm::StringRef name, unsigned width);
   /// Record the value handle for a tracked signal at the given cycle.
   void record(size_t step, size_t signal, Handle handle);
+  /// Register a signal by name if necessary and record its value handle at the
+  /// given cycle.
+  void record(size_t step, llvm::StringRef name, unsigned width, Handle handle);
 
   llvm::StringRef getTopName() const { return topName; }
   llvm::ArrayRef<Signal> getSignals() const { return signals; }
@@ -69,16 +73,14 @@ private:
 
   std::string topName;
   std::vector<Signal> signals;
+  llvm::StringMap<size_t> signalIndices;
   std::vector<Step> recorded;
 };
 
-/// Select the trace populated by the JIT runtime callback. Passing null
-/// disables trace recording. This state is local to the calling thread.
-void setActiveBMCTrace(BMCTrace *trace);
-
 /// Runtime entry point called by JIT-compiled BMC code.
-extern "C" void circt_bmc_record_trace(uint32_t step, const char *name,
-                                       uint32_t width, BMCTrace::Handle handle);
+extern "C" void circt_bmc_record_trace(BMCTrace *trace, uint32_t step,
+                                       const char *name, uint32_t width,
+                                       BMCTrace::Handle handle);
 
 } // namespace circt::bmc
 

--- a/include/circt/Tools/circt-bmc/BMCTrace.h
+++ b/include/circt/Tools/circt-bmc/BMCTrace.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
@@ -70,6 +71,14 @@ private:
   std::vector<Signal> signals;
   std::vector<Step> recorded;
 };
+
+/// Select the trace populated by the JIT runtime callback. Passing null
+/// disables trace recording. This state is local to the calling thread.
+void setActiveBMCTrace(BMCTrace *trace);
+
+/// Runtime entry point called by JIT-compiled BMC code.
+extern "C" void circt_bmc_record_trace(uint32_t step, const char *name,
+                                       uint32_t width, BMCTrace::Handle handle);
 
 } // namespace circt::bmc
 

--- a/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
+++ b/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
@@ -1283,13 +1284,31 @@ struct IntAbsOpLowering : public SMTLoweringPattern<IntAbsOp> {
 // For now we want to ignore Debug variable and scope ops - eventually we'll
 // give this debug info to Z3
 
-/// Strip verif.bmc.trace ops until counterexample materialization is lowered.
-struct BMCTraceLowering : public OpConversionPattern<verif::BMCTraceOp> {
-  using OpConversionPattern::OpConversionPattern;
+/// Lower bit-vector verif.bmc.trace ops to the circt-bmc runtime callback.
+/// Other SMT values are discarded until their trace materialization is
+/// supported.
+struct BMCTraceLowering : public SMTLoweringPattern<verif::BMCTraceOp> {
+  using SMTLoweringPattern::SMTLoweringPattern;
 
   LogicalResult
   matchAndRewrite(verif::BMCTraceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    auto bitVectorType = dyn_cast<smt::BitVectorType>(op.getValue().getType());
+    if (!bitVectorType) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    Location loc = op.getLoc();
+    Value name = buildString(rewriter, loc, op.getName());
+    Value width = LLVM::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                           bitVectorType.getWidth());
+    auto voidType = LLVM::LLVMVoidType::get(rewriter.getContext());
+    buildCall(rewriter, loc, "circt_bmc_record_trace",
+              LLVM::LLVMFunctionType::get(
+                  voidType, {adaptor.getStep().getType(), name.getType(),
+                             width.getType(), adaptor.getValue().getType()}),
+              {adaptor.getStep(), name, width, adaptor.getValue()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -1559,7 +1578,8 @@ void circt::populateSMTToZ3LLVMConversionPatterns(
                BV2IntOpLowering, QuantifierLowering<ForallOp>,
                QuantifierLowering<ExistsOp>>(converter, patterns.getContext(),
                                              globals, options);
-  patterns.add<BMCTraceLowering>(patterns.getContext());
+  patterns.add<BMCTraceLowering>(converter, patterns.getContext(), globals,
+                                 options);
   patterns.add<DbgVariableLowering, DbgScopeLowering>(patterns.getContext());
 }
 
@@ -1594,6 +1614,22 @@ void LowerSMTToZ3LLVMPass::runOnOperation() {
     return WalkResult::advance();
   });
   if (setLogicCheck.wasInterrupted())
+    return signalPassFailure();
+
+  llvm::StringMap<Operation *> traceNames;
+  auto traceNameCheck =
+      getOperation().walk([&](verif::BMCTraceOp traceOp) -> WalkResult {
+        auto [it, inserted] =
+            traceNames.try_emplace(traceOp.getName(), traceOp.getOperation());
+        if (inserted)
+          return WalkResult::advance();
+        auto error = traceOp.emitError() << "duplicate BMC trace name '"
+                                         << traceOp.getName() << "'";
+        error.attachNote(it->second->getLoc())
+            << "first BMC trace with this name is here";
+        return WalkResult::interrupt();
+      });
+  if (traceNameCheck.wasInterrupted())
     return signalPassFailure();
 
   // Set up the type converter

--- a/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
+++ b/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
@@ -25,9 +25,11 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SMT/IR/SMTOps.h"
 #include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
@@ -637,6 +639,29 @@ struct SolverOpLowering : public SMTLoweringPattern<SolverOp> {
             typeConverter->convertTypes(op->getResultTypes(), convertedTypes)))
       return failure();
 
+    // Solver regions are outlined below. If one contains a trace marker,
+    // forward the enclosing function's trace context through the outlined
+    // function as its final argument.
+    bool containsBMCTrace = false;
+    op.getBodyRegion().walk(
+        [&](verif::BMCTraceOp) { containsBMCTrace = true; });
+    Value traceContext;
+    SmallVector<Type> inputTypes(adaptor.getInputs().getTypes());
+    SmallVector<Value> callOperands(adaptor.getInputs());
+    if (containsBMCTrace) {
+      auto parentFunction = op->getParentOfType<FunctionOpInterface>();
+      if (!parentFunction || parentFunction.getNumArguments() == 0)
+        return rewriter.notifyMatchFailure(op, "missing BMC trace context");
+      traceContext =
+          parentFunction.getArgument(parentFunction.getNumArguments() - 1);
+      if (!isa<LLVM::LLVMPointerType>(traceContext.getType()))
+        return rewriter.notifyMatchFailure(op,
+                                           "invalid BMC trace context type");
+      inputTypes.push_back(traceContext.getType());
+      callOperands.push_back(traceContext);
+      op.getBodyRegion().addArgument(traceContext.getType(), loc);
+    }
+
     func::FuncOp funcOp;
     {
       OpBuilder::InsertionGuard guard(rewriter);
@@ -645,15 +670,13 @@ struct SolverOpLowering : public SMTLoweringPattern<SolverOp> {
 
       funcOp = func::FuncOp::create(
           rewriter, loc, globals.names.newName("solver"),
-          rewriter.getFunctionType(adaptor.getInputs().getTypes(),
-                                   convertedTypes));
+          rewriter.getFunctionType(inputTypes, convertedTypes));
       rewriter.inlineRegionBefore(op.getBodyRegion(), funcOp.getBody(),
                                   funcOp.end());
     }
 
     ValueRange results =
-        func::CallOp::create(rewriter, loc, funcOp, adaptor.getInputs())
-            ->getResults();
+        func::CallOp::create(rewriter, loc, funcOp, callOperands)->getResults();
 
     // At the end of the region, decrease the solver's reference counter and
     // delete the context.
@@ -1303,12 +1326,20 @@ struct BMCTraceLowering : public SMTLoweringPattern<verif::BMCTraceOp> {
     Value name = buildString(rewriter, loc, op.getName());
     Value width = LLVM::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
                                            bitVectorType.getWidth());
+    auto function = op->getParentOfType<FunctionOpInterface>();
+    if (!function || function.getNumArguments() == 0)
+      return rewriter.notifyMatchFailure(op, "missing BMC trace context");
+    Value traceContext = function.getArgument(function.getNumArguments() - 1);
+    if (!isa<LLVM::LLVMPointerType>(traceContext.getType()))
+      return rewriter.notifyMatchFailure(op, "invalid BMC trace context type");
     auto voidType = LLVM::LLVMVoidType::get(rewriter.getContext());
-    buildCall(rewriter, loc, "circt_bmc_record_trace",
-              LLVM::LLVMFunctionType::get(
-                  voidType, {adaptor.getStep().getType(), name.getType(),
-                             width.getType(), adaptor.getValue().getType()}),
-              {adaptor.getStep(), name, width, adaptor.getValue()});
+    buildCall(
+        rewriter, loc, "circt_bmc_record_trace",
+        LLVM::LLVMFunctionType::get(voidType, {traceContext.getType(),
+                                               adaptor.getStep().getType(),
+                                               name.getType(), width.getType(),
+                                               adaptor.getValue().getType()}),
+        {traceContext, adaptor.getStep(), name, width, adaptor.getValue()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -1631,6 +1662,26 @@ void LowerSMTToZ3LLVMPass::runOnOperation() {
       });
   if (traceNameCheck.wasInterrupted())
     return signalPassFailure();
+
+  // Thread an opaque runtime context into every function containing a BMC
+  // trace marker. The lowering below forwards this argument to the runtime
+  // callback, making trace state explicit in the generated code.
+  llvm::SmallPtrSet<Operation *, 4> traceFunctions;
+  getOperation().walk([&](verif::BMCTraceOp traceOp) {
+    auto function = traceOp->getParentOfType<FunctionOpInterface>();
+    if (function)
+      traceFunctions.insert(function.getOperation());
+  });
+  auto traceContextType = LLVM::LLVMPointerType::get(&getContext());
+  for (Operation *operation : traceFunctions) {
+    auto function = cast<FunctionOpInterface>(operation);
+    if (failed(function.insertArgument(function.getNumArguments(),
+                                       traceContextType, {},
+                                       function.getLoc()))) {
+      function.emitError("failed to add BMC trace context argument");
+      return signalPassFailure();
+    }
+  }
 
   // Set up the type converter
   LLVMTypeConverter converter(&getContext());

--- a/lib/Tools/circt-bmc/Runtime/BMCTrace.cpp
+++ b/lib/Tools/circt-bmc/Runtime/BMCTrace.cpp
@@ -9,24 +9,13 @@
 #include "circt/Tools/circt-bmc/BMCTrace.h"
 
 #include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/StringMap.h"
-
 #include <cassert>
-
-namespace {
-
-struct ActiveTraceState {
-  circt::bmc::BMCTrace *trace = nullptr;
-  llvm::StringMap<size_t> signals;
-};
-
-thread_local ActiveTraceState activeTrace;
-
-} // namespace
 
 circt::bmc::BMCTrace::BMCTrace(llvm::StringRef topName) : topName(topName) {}
 
 size_t circt::bmc::BMCTrace::addSignal(llvm::StringRef name, unsigned width) {
+  assert(!signalIndices.contains(name) && "duplicate trace signal");
+  signalIndices.try_emplace(name, signals.size());
   signals.push_back({name.str(), width});
   for (auto &step : recorded)
     step.resize(signals.size());
@@ -42,6 +31,19 @@ void circt::bmc::BMCTrace::record(size_t step, size_t signal, Handle handle) {
   assert(signal < signals.size() && "signal index out of range");
   ensureStep(step);
   recorded[step][signal] = handle;
+}
+
+void circt::bmc::BMCTrace::record(size_t step, llvm::StringRef name,
+                                  unsigned width, Handle handle) {
+  auto it = signalIndices.find(name);
+  size_t signal;
+  if (it == signalIndices.end()) {
+    signal = addSignal(name, width);
+  } else {
+    signal = it->second;
+    assert(signals[signal].width == width && "trace signal width changed");
+  }
+  record(step, signal, handle);
 }
 
 std::optional<circt::bmc::BMCTrace::Handle>
@@ -73,23 +75,12 @@ bool circt::bmc::BMCTrace::printTextTrace(llvm::raw_ostream &os,
   return true;
 }
 
-void circt::bmc::setActiveBMCTrace(BMCTrace *trace) {
-  activeTrace.trace = trace;
-  activeTrace.signals.clear();
-}
-
-extern "C" void circt::bmc::circt_bmc_record_trace(uint32_t step,
+extern "C" void circt::bmc::circt_bmc_record_trace(BMCTrace *trace,
+                                                   uint32_t step,
                                                    const char *name,
                                                    uint32_t width,
                                                    BMCTrace::Handle handle) {
-  if (!activeTrace.trace)
+  if (!trace)
     return;
-
-  auto [it, inserted] = activeTrace.signals.try_emplace(name, 0);
-  if (inserted)
-    it->second = activeTrace.trace->addSignal(name, width);
-  else
-    assert(activeTrace.trace->getSignals()[it->second].width == width &&
-           "trace signal width changed");
-  activeTrace.trace->record(step, it->second, handle);
+  trace->record(step, name, width, handle);
 }

--- a/lib/Tools/circt-bmc/Runtime/BMCTrace.cpp
+++ b/lib/Tools/circt-bmc/Runtime/BMCTrace.cpp
@@ -9,8 +9,20 @@
 #include "circt/Tools/circt-bmc/BMCTrace.h"
 
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringMap.h"
 
 #include <cassert>
+
+namespace {
+
+struct ActiveTraceState {
+  circt::bmc::BMCTrace *trace = nullptr;
+  llvm::StringMap<size_t> signals;
+};
+
+thread_local ActiveTraceState activeTrace;
+
+} // namespace
 
 circt::bmc::BMCTrace::BMCTrace(llvm::StringRef topName) : topName(topName) {}
 
@@ -59,4 +71,25 @@ bool circt::bmc::BMCTrace::printTextTrace(llvm::raw_ostream &os,
     }
   }
   return true;
+}
+
+void circt::bmc::setActiveBMCTrace(BMCTrace *trace) {
+  activeTrace.trace = trace;
+  activeTrace.signals.clear();
+}
+
+extern "C" void circt::bmc::circt_bmc_record_trace(uint32_t step,
+                                                   const char *name,
+                                                   uint32_t width,
+                                                   BMCTrace::Handle handle) {
+  if (!activeTrace.trace)
+    return;
+
+  auto [it, inserted] = activeTrace.signals.try_emplace(name, 0);
+  if (inserted)
+    it->second = activeTrace.trace->addSignal(name, width);
+  else
+    assert(activeTrace.trace->getSignals()[it->second].width == width &&
+           "trace signal width changed");
+  activeTrace.trace->record(step, it->second, handle);
 }

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm-errors.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm-errors.mlir
@@ -12,6 +12,16 @@ func.func @multiple_set_logics() {
 
 // -----
 
+func.func @duplicate_bmc_trace_names(%step: i32, %a: !smt.bv<8>, %b: !smt.bv<8>) {
+  // expected-note @+1 {{first BMC trace with this name is here}}
+  verif.bmc.trace %step, "x", %a : i32, !smt.bv<8>
+  // expected-error @+1 {{duplicate BMC trace name 'x'}}
+  verif.bmc.trace %step, "x", %b : i32, !smt.bv<8>
+  func.return
+}
+
+// -----
+
 func.func @multiple_set_logics() {
   // expected-error @below {{set-logic operation must be the first non-constant operation in a solver operation}}
   smt.solver () : () -> () {

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -58,6 +58,7 @@ llvm.mlir.global internal @solver() {alignment = 8 : i64} : !llvm.ptr {
 // CHECK:   llvm.return
 
 // CHECK-LABEL: llvm.func @solver
+// CHECK-SAME: ([[TRACE_STEP:%.+]]: i32)
 func.func @test(%arg0: i32) {
   %0 = smt.solver (%arg0) : (i32) -> (i32) {
   ^bb0(%arg1: i32):
@@ -391,8 +392,14 @@ func.func @test(%arg0: i32) {
     // CHECK: llvm.call @Z3_mk_bv2int({{%[0-9a-zA-Z_]+}}, [[BV0]], [[SIGNEDCONST]]) : (!llvm.ptr, !llvm.ptr, i1) -> !llvm.ptr
     smt.bv2int %c0_bv4 signed : !smt.bv<4>
 
-    // CHECK-NOT: verif.bmc.trace
+    // CHECK: [[TRACE_NAME:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
+    // CHECK: [[TRACE_WIDTH0:%.+]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK: llvm.call @circt_bmc_record_trace([[TRACE_STEP]], [[TRACE_NAME]], [[TRACE_WIDTH0]], [[BV0]]) : (i32, !llvm.ptr, i32, !llvm.ptr) -> ()
     verif.bmc.trace %arg1, "var0", %c0_bv4 : i32, !smt.bv<4>
+    // CHECK: [[TRACE_NAME1:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
+    // CHECK: [[TRACE_WIDTH1:%.+]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK: llvm.call @circt_bmc_record_trace([[TRACE_STEP]], [[TRACE_NAME1]], [[TRACE_WIDTH1]], [[BV0]]) : (i32, !llvm.ptr, i32, !llvm.ptr) -> ()
+    verif.bmc.trace %arg1, "var1", %c0_bv4 : i32, !smt.bv<4>
 
     // CHECK-NOT: dbg.variable
     dbg.variable "var1", %c0_bv4 : !smt.bv<4>

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -20,7 +20,8 @@ llvm.mlir.global internal @solver() {alignment = 8 : i64} : !llvm.ptr {
 }
 
 
-// CHECK-LABEL: llvm.func @test
+// CHECK-LABEL: llvm.func @test(
+// CHECK-SAME: !llvm.ptr)
 // CHECK:   [[CONFIG:%.+]] = llvm.call @Z3_mk_config() : () -> !llvm.ptr
 // CHECK-DEBUG: [[PROOF_STR:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
 // CHECK-DEBUG: [[TRUE_STR:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
@@ -58,7 +59,7 @@ llvm.mlir.global internal @solver() {alignment = 8 : i64} : !llvm.ptr {
 // CHECK:   llvm.return
 
 // CHECK-LABEL: llvm.func @solver
-// CHECK-SAME: ([[TRACE_STEP:%.+]]: i32)
+// CHECK-SAME: ([[TRACE_STEP:%.+]]: i32, [[TRACE_CONTEXT:%.+]]: !llvm.ptr)
 func.func @test(%arg0: i32) {
   %0 = smt.solver (%arg0) : (i32) -> (i32) {
   ^bb0(%arg1: i32):
@@ -394,11 +395,11 @@ func.func @test(%arg0: i32) {
 
     // CHECK: [[TRACE_NAME:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
     // CHECK: [[TRACE_WIDTH0:%.+]] = llvm.mlir.constant(4 : i32) : i32
-    // CHECK: llvm.call @circt_bmc_record_trace([[TRACE_STEP]], [[TRACE_NAME]], [[TRACE_WIDTH0]], [[BV0]]) : (i32, !llvm.ptr, i32, !llvm.ptr) -> ()
+    // CHECK: llvm.call @circt_bmc_record_trace([[TRACE_CONTEXT]], [[TRACE_STEP]], [[TRACE_NAME]], [[TRACE_WIDTH0]], [[BV0]]) : (!llvm.ptr, i32, !llvm.ptr, i32, !llvm.ptr) -> ()
     verif.bmc.trace %arg1, "var0", %c0_bv4 : i32, !smt.bv<4>
     // CHECK: [[TRACE_NAME1:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
     // CHECK: [[TRACE_WIDTH1:%.+]] = llvm.mlir.constant(4 : i32) : i32
-    // CHECK: llvm.call @circt_bmc_record_trace([[TRACE_STEP]], [[TRACE_NAME1]], [[TRACE_WIDTH1]], [[BV0]]) : (i32, !llvm.ptr, i32, !llvm.ptr) -> ()
+    // CHECK: llvm.call @circt_bmc_record_trace([[TRACE_CONTEXT]], [[TRACE_STEP]], [[TRACE_NAME1]], [[TRACE_WIDTH1]], [[BV0]]) : (!llvm.ptr, i32, !llvm.ptr, i32, !llvm.ptr) -> ()
     verif.bmc.trace %arg1, "var1", %c0_bv4 : i32, !smt.bv<4>
 
     // CHECK-NOT: dbg.variable

--- a/test/Tools/circt-bmc/lower-to-bmc-debug.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-debug.mlir
@@ -54,6 +54,7 @@ hw.module @Sequential(in %clk: !seq.clock, in %in: i8, in %state_q: i8,
 // AGGREGATE: scf.for [[STEP:%.+]] = {{%.+}} iter_args({{.*}}[[STATE:%.+]] = [[STATE_INIT]]{{.*}})
 // AGGREGATE: verif.bmc.trace [[STEP]], "res_state", [[STATE]] : i32, !smt.array<[!smt.bv<1> -> !smt.bv<32>]>
 // AGGREGATE-LLVM-LABEL: define void @Aggregate()
+// AGGREGATE-LLVM-NOT: call void @circt_bmc_record_trace
 
 hw.module @Aggregate(in %clk: !seq.clock) {
   %zero = hw.constant 0 : i32

--- a/test/Tools/circt-bmc/lower-to-bmc-debug.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-debug.mlir
@@ -37,7 +37,7 @@ hw.module @Passthrough(in %a: i4, in %b: i4, out sum: i4) attributes {num_regs =
 // END-TO-END: [[NEXT_INPUT:%.+]] = smt.declare_fun "state_q_next" : !smt.bv<8>
 // END-TO-END: scf.yield {{.*}}[[NEXT_INPUT]]{{.*}} :
 
-// LLVM-LABEL: define void @Sequential()
+// LLVM-LABEL: define void @Sequential(ptr
 
 hw.module @Sequential(in %clk: !seq.clock, in %in: i8, in %state_q: i8,
                      out out: i8, out state_q_next: i8)
@@ -53,7 +53,7 @@ hw.module @Sequential(in %clk: !seq.clock, in %in: i8, in %state_q: i8,
 // AGGREGATE: [[STATE_INIT:%.+]] = smt.declare_fun "res_state" : !smt.array<[!smt.bv<1> -> !smt.bv<32>]>
 // AGGREGATE: scf.for [[STEP:%.+]] = {{%.+}} iter_args({{.*}}[[STATE:%.+]] = [[STATE_INIT]]{{.*}})
 // AGGREGATE: verif.bmc.trace [[STEP]], "res_state", [[STATE]] : i32, !smt.array<[!smt.bv<1> -> !smt.bv<32>]>
-// AGGREGATE-LLVM-LABEL: define void @Aggregate()
+// AGGREGATE-LLVM-LABEL: define void @Aggregate(ptr
 // AGGREGATE-LLVM-NOT: call void @circt_bmc_record_trace
 
 hw.module @Aggregate(in %clk: !seq.clock) {

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -2,6 +2,7 @@ if(MLIR_ENABLE_EXECUTION_ENGINE)
   add_compile_definitions(CIRCT_BMC_ENABLE_JIT)
   set(CIRCT_BMC_JIT_LLVM_COMPONENTS native)
   set(CIRCT_BMC_JIT_DEPS
+    LLVMOrcJIT
     MLIRExecutionEngine
     MLIRExecutionEngineUtils
   )

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -31,6 +31,7 @@
 #include "circt/Dialect/Verif/VerifPasses.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
+#include "circt/Tools/circt-bmc/BMCTrace.h"
 #include "circt/Tools/circt-bmc/Passes.h"
 #include "circt/Transforms/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -52,6 +53,7 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
@@ -365,6 +367,18 @@ static LogicalResult executeBMC(MLIRContext &context) {
 
     engine = std::move(*expectedEngine);
   }
+
+  engine->registerSymbols([](llvm::orc::MangleAndInterner interner) {
+    llvm::orc::SymbolMap symbolMap;
+    symbolMap[interner("circt_bmc_record_trace")] = {
+        llvm::orc::ExecutorAddr::fromPtr(&bmc::circt_bmc_record_trace),
+        llvm::JITSymbolFlags::Exported};
+    return symbolMap;
+  });
+
+  bmc::BMCTrace trace(moduleName);
+  bmc::setActiveBMCTrace(&trace);
+  llvm::scope_exit clearActiveTrace([] { bmc::setActiveBMCTrace(nullptr); });
 
   auto timer = ts.nest("JIT Execution");
   if (auto err = engine->invokePacked(moduleName))

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -53,7 +53,6 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/Passes.h"
-#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
@@ -330,6 +329,7 @@ static LogicalResult executeBMC(MLIRContext &context) {
   };
 
   std::unique_ptr<mlir::ExecutionEngine> engine;
+  bool hasTraceContext = false;
   std::function<llvm::Error(llvm::Module *)> transformer =
       mlir::makeOptimizingTransformer(
           /*optLevel*/ 3, /*sizeLevel=*/0, /*targetMachine=*/nullptr);
@@ -343,11 +343,14 @@ static LogicalResult executeBMC(MLIRContext &context) {
       return failure();
     }
 
-    if (entryPoint.getNumArguments() != 0) {
+    if (entryPoint.getNumArguments() > 1 ||
+        (entryPoint.getNumArguments() == 1 &&
+         !isa<LLVM::LLVMPointerType>(entryPoint.getArgumentTypes().front()))) {
       llvm::errs() << "entry point '" << moduleName
-                   << "' must have no arguments";
+                   << "' must have no arguments or one trace context pointer";
       return failure();
     }
+    hasTraceContext = entryPoint.getNumArguments() == 1;
 
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
@@ -377,11 +380,13 @@ static LogicalResult executeBMC(MLIRContext &context) {
   });
 
   bmc::BMCTrace trace(moduleName);
-  bmc::setActiveBMCTrace(&trace);
-  llvm::scope_exit clearActiveTrace([] { bmc::setActiveBMCTrace(nullptr); });
+  void *traceContext = &trace;
+  SmallVector<void *> packedArgs;
+  if (hasTraceContext)
+    packedArgs.push_back(&traceContext);
 
   auto timer = ts.nest("JIT Execution");
-  if (auto err = engine->invokePacked(moduleName))
+  if (auto err = engine->invokePacked(moduleName, packedArgs))
     return handleErr(std::move(err));
 
   return success();

--- a/unittests/Tools/circt-bmc/BMCTraceTest.cpp
+++ b/unittests/Tools/circt-bmc/BMCTraceTest.cpp
@@ -97,4 +97,26 @@ TEST(BMCTraceTest, SupportsZeroWidthSignals) {
   EXPECT_THAT(output, HasSubstr("cycle 0:\n  empty = 0x0\n"));
 }
 
+TEST(BMCTraceTest, RuntimeCallbackRegistersAndRecordsSignals) {
+  BMCTrace trace("top");
+  setActiveBMCTrace(&trace);
+
+  auto data0 = reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x12));
+  auto state0 =
+      reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x34));
+  auto data1 = reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x56));
+  circt_bmc_record_trace(0, "data_in", 8, data0);
+  circt_bmc_record_trace(0, "state_q", 8, state0);
+  circt_bmc_record_trace(1, "data_in", 8, data1);
+  setActiveBMCTrace(nullptr);
+
+  ASSERT_EQ(trace.getSignals().size(), 2u);
+  EXPECT_EQ(trace.getSignals()[0].name, "data_in");
+  EXPECT_EQ(trace.getSignals()[0].width, 8u);
+  EXPECT_EQ(trace.getSignals()[1].name, "state_q");
+  EXPECT_EQ(trace.lookup(0, 0), data0);
+  EXPECT_EQ(trace.lookup(0, 1), state0);
+  EXPECT_EQ(trace.lookup(1, 0), data1);
+}
+
 } // namespace

--- a/unittests/Tools/circt-bmc/BMCTraceTest.cpp
+++ b/unittests/Tools/circt-bmc/BMCTraceTest.cpp
@@ -99,16 +99,14 @@ TEST(BMCTraceTest, SupportsZeroWidthSignals) {
 
 TEST(BMCTraceTest, RuntimeCallbackRegistersAndRecordsSignals) {
   BMCTrace trace("top");
-  setActiveBMCTrace(&trace);
 
   auto data0 = reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x12));
   auto state0 =
       reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x34));
   auto data1 = reinterpret_cast<BMCTrace::Handle>(static_cast<uintptr_t>(0x56));
-  circt_bmc_record_trace(0, "data_in", 8, data0);
-  circt_bmc_record_trace(0, "state_q", 8, state0);
-  circt_bmc_record_trace(1, "data_in", 8, data1);
-  setActiveBMCTrace(nullptr);
+  circt_bmc_record_trace(&trace, 0, "data_in", 8, data0);
+  circt_bmc_record_trace(&trace, 0, "state_q", 8, state0);
+  circt_bmc_record_trace(&trace, 1, "data_in", 8, data1);
 
   ASSERT_EQ(trace.getSignals().size(), 2u);
   EXPECT_EQ(trace.getSignals()[0].name, "data_in");


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->


This adds the runtime-recording stage for BMC counterexample traces.

Bit-vector verif.bmc.trace operations are lowered to a JIT runtime callback carrying the cycle, signal name, bit width, and opaque Z3 value handle. circt-bmc registers this callback with ORC JIT and records the values in a thread-local BMCTrace during execution.

Trace names are required to be unique. The SMT-to-Z3-LLVM lowering now rejects duplicate names with a diagnostic pointing to the original marker. Unsupported traced values, such as SMT arrays, continue to be discarded.

Assisted-by: codex:gpt-5.6-sol(medium)