### PR TITLE
[FIRRTL][Seq] Add explicit clock edge

### DIFF
--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -107,7 +107,7 @@ register and lower it to SystemVerilog.
 
 `FirReg` has the following operands:
 
-- **input**: Value to set the register to on the positive edge of the clock
+- **input**: Value to set the register to on the configured edge of the clock
 signal.
 - **clk**: Clock signal driving the register.
 - **name**: A name for the register, passed directly to the `sv.reg`.
@@ -120,6 +120,8 @@ from the design.
 reset is asynchronous.
 - **isAsync**: Optional boolean flag indicating whether the reset is
 asynchronous.
+- **clockEdge**: Optional enum selecting positive, negative, or dual-edge clock
+behavior. The default is positive edge.
 - **preset**: Optional attribute specifying a preset value. If no preset
 attribute is present, the register is random-initialized.
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -663,9 +663,11 @@ def CatBitsBits : Pat <
   [(AdjInt $mid2, $mid)]>;
 
 // regreset(clock, constant_zero, resetValue) -> reg(clock)
+// Preserve the register's clock edge when dropping the reset.
 def RegResetWithZeroReset : Pat<
-  (RegResetOp $clock, $reset, $_, $name, $nameKind, $annotations, $inner_sym, $forceable),
-  (RegOp $clock, $name, $nameKind, $annotations, $inner_sym, $forceable), [(ZeroConstantOp $reset)]>;
+  (RegResetOp $clock, $reset, $_, $name, $nameKind, $annotations, $inner_sym, $forceable, $clockEdge),
+  (RegOp $clock, $name, $nameKind, $annotations, $inner_sym, $forceable, $clockEdge),
+  [(ZeroConstantOp $reset)]>;
 
 // ref.resolve(ref.send(a)) -> a
 def RefResolveOfRefSend : Pat<

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -395,7 +395,9 @@ def RegOp : HardwareDeclOp<"reg", [Forceable, DeclareOpInterfaceMethods<CombData
     ins ClockType:$clockVal, StrAttr:$name, NameKindAttr:$nameKind,
         AnnotationArrayAttr:$annotations,
         OptionalAttr<InnerSymAttr>:$inner_sym,
-        UnitAttr:$forceable);
+        UnitAttr:$forceable,
+        DefaultValuedAttr<EventControlAttr,
+                          "EventControl::AtPosEdge">:$clockEdge);
   let results = (outs AnyRegisterType:$result, Optional<RefType>:$ref);
 
   let skipDefaultBuilders = true;
@@ -496,7 +498,9 @@ def RegResetOp : HardwareDeclOp<"regreset", [Forceable, DeclareOpInterfaceMethod
         StrAttr:$name, NameKindAttr:$nameKind,
         AnnotationArrayAttr:$annotations,
         OptionalAttr<InnerSymAttr>:$inner_sym,
-        UnitAttr:$forceable);
+        UnitAttr:$forceable,
+        DefaultValuedAttr<EventControlAttr,
+                          "EventControl::AtPosEdge">:$clockEdge);
   let results = (outs AnyRegisterType:$result, Optional<RefType>:$ref);
 
   let skipDefaultBuilders = true;

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -424,13 +424,17 @@ def RegOp : HardwareDeclOp<"reg", [Forceable, DeclareOpInterfaceMethods<CombData
                    "::circt::firrtl::NameKindEnumAttr":$nameKind,
                    "::mlir::ArrayAttr":$annotations,
                    "::circt::hw::InnerSymAttr":$innerSym,
-                   "::mlir::UnitAttr":$forceable), [{
+                   "::mlir::UnitAttr":$forceable,
+                   CArg<"::circt::firrtl::EventControlAttr", "{}">:$clockEdge), [{
       $_state.addOperands(clockVal);
       $_state.addAttribute(getNameAttrName($_state.name), name);
       $_state.addAttribute(getNameKindAttrName($_state.name), nameKind);
       $_state.addAttribute(getAnnotationsAttrName($_state.name), annotations);
       if (innerSym) {
         $_state.addAttribute(getInnerSymAttrName($_state.name), innerSym);
+      }
+      if (clockEdge) {
+        $_state.addAttribute(getClockEdgeAttrName($_state.name), clockEdge);
       }
       $_state.addTypes(elementType);
       if (forceable) {
@@ -445,39 +449,45 @@ def RegOp : HardwareDeclOp<"reg", [Forceable, DeclareOpInterfaceMethods<CombData
                    "::circt::firrtl::NameKindEnum":$nameKind,
                    "::mlir::ArrayAttr":$annotations,
                    "::circt::hw::InnerSymAttr":$innerSym,
-                   "bool":$forceable), [{
+                   "bool":$forceable,
+                   CArg<"::circt::firrtl::EventControlAttr", "{}">:$clockEdge), [{
       return build($_builder, $_state, elementType, clockVal,
                    $_builder.getStringAttr(name),
                    ::circt::firrtl::NameKindEnumAttr::get(odsBuilder.getContext(), nameKind),
                    annotations, innerSym,
-                   forceable ? $_builder.getUnitAttr() : nullptr);
+                   forceable ? $_builder.getUnitAttr() : nullptr, clockEdge);
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    CArg<"StringRef", "{}">:$name,
                    CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations,
                    CArg<"StringAttr", "StringAttr()">:$innerSym,
-                   CArg<"bool", "false">:$forceable), [{
+                   CArg<"bool", "false">:$forceable,
+                   CArg<"EventControlAttr", "{}">:$clockEdge), [{
       return build($_builder, $_state, elementType,
                    clockVal, $_builder.getStringAttr(name), nameKind,
                    $_builder.getArrayAttr(annotations),
                    innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(),
-                   forceable);
+                   forceable, clockEdge);
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "StringRef":$name, "NameKindEnum":$nameKind,
                    "::mlir::ArrayAttr":$annotation, "StringAttr":$innerSym,
-                   CArg<"bool", "false">:$forceable), [{
+                   CArg<"bool", "false">:$forceable,
+                   CArg<"EventControlAttr", "{}">:$clockEdge), [{
       return build($_builder, $_state, elementType,
                    clockVal, $_builder.getStringAttr(name), nameKind, annotation,
                    innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(),
-                   forceable);
+                   forceable, clockEdge);
     }]>
   ];
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    operands (`forceable` $forceable^)? `` custom<FIRRTLImplicitSSAName>(attr-dict) `:` type($clockVal) `,` qualified(type($result)) (`,` qualified(type($ref))^)?
+    `` custom<RegClockEdge>($clockEdge) operands
+    (`forceable` $forceable^)? `` custom<FIRRTLRegImplicitSSAName>(attr-dict)
+    `:` type($clockVal) `,` qualified(type($result))
+    (`,` qualified(type($ref))^)?
 
   }];
   let hasCanonicalizeMethod = true;
@@ -520,7 +530,8 @@ def RegResetOp : HardwareDeclOp<"regreset", [Forceable, DeclareOpInterfaceMethod
                    "::circt::firrtl::NameKindEnumAttr":$nameKind,
                    "::mlir::ArrayAttr":$annotations,
                    "::circt::hw::InnerSymAttr":$innerSym,
-                   "::mlir::UnitAttr":$forceable), [{
+                   "::mlir::UnitAttr":$forceable,
+                   CArg<"::circt::firrtl::EventControlAttr", "{}">:$clockEdge), [{
       $_state.addOperands(clockVal);
       odsState.addOperands(resetSignal);
       odsState.addOperands(resetValue);
@@ -529,6 +540,9 @@ def RegResetOp : HardwareDeclOp<"regreset", [Forceable, DeclareOpInterfaceMethod
       $_state.addAttribute(getAnnotationsAttrName($_state.name), annotations);
       if (innerSym) {
         $_state.addAttribute(getInnerSymAttrName($_state.name), innerSym);
+      }
+      if (clockEdge) {
+        $_state.addAttribute(getClockEdgeAttrName($_state.name), clockEdge);
       }
       $_state.addTypes(elementType);
       if (forceable) {
@@ -543,34 +557,39 @@ def RegResetOp : HardwareDeclOp<"regreset", [Forceable, DeclareOpInterfaceMethod
                    CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations,
                    CArg<"StringAttr", "StringAttr()">:$innerSym,
-                   CArg<"bool", "false">:$forceable), [{
+                   CArg<"bool", "false">:$forceable,
+                   CArg<"EventControlAttr", "{}">:$clockEdge), [{
       return build($_builder, $_state, elementType,
                    clockVal, resetSignal, resetValue,
                    $_builder.getStringAttr(name),
                    ::circt::firrtl::NameKindEnumAttr::get(odsBuilder.getContext(), nameKind),
                    $_builder.getArrayAttr(annotations),
                    innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(),
-                   forceable ? $_builder.getUnitAttr() : nullptr);
+                   forceable ? $_builder.getUnitAttr() : nullptr, clockEdge);
     }]>,
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
                    "StringRef":$name, "NameKindEnum":$nameKind,
                     "::mlir::ArrayAttr":$annotation, "StringAttr":$innerSym,
-                    CArg<"bool", "false">:$forceable), [{
+                    CArg<"bool", "false">:$forceable,
+                    CArg<"EventControlAttr", "{}">:$clockEdge), [{
       return build($_builder, $_state, elementType,
                    clockVal, resetSignal, resetValue,
                    $_builder.getStringAttr(name),
                    ::circt::firrtl::NameKindEnumAttr::get(odsBuilder.getContext(), nameKind),
                    annotation,
                    innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(),
-                   forceable ? $_builder.getUnitAttr() : nullptr);
+                   forceable ? $_builder.getUnitAttr() : nullptr, clockEdge);
     }]>
   ];
 
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
-    operands (`forceable` $forceable^)? `` custom<FIRRTLImplicitSSAName>(attr-dict)
-    `:` type($clockVal) `,` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result)) (`,` qualified(type($ref))^)?
+    `` custom<RegClockEdge>($clockEdge) operands
+    (`forceable` $forceable^)? `` custom<FIRRTLRegImplicitSSAName>(attr-dict)
+    `:` type($clockVal) `,` qualified(type($resetSignal)) `,`
+    qualified(type($resetValue)) `,` qualified(type($result))
+    (`,` qualified(type($ref))^)?
 
   }];
 

--- a/include/circt/Dialect/Seq/SeqAttributes.td
+++ b/include/circt/Dialect/Seq/SeqAttributes.td
@@ -43,6 +43,14 @@ def WUW_PortOrder : I32EnumAttrCase<"PortOrder", 1, "port_order">;
 def WUWAttr : I32EnumAttr<"WUW", "Write-Under-Write Behavior",
                           [WUW_Undefined, WUW_PortOrder]>;
 
+// Register clock edge. Mirrors the FIRRTL/SV event-control concept so that a
+// non-default (negedge or dual-edge) register clock survives lowering to SV.
+def ClockEdgePos : I32EnumAttrCase<"Pos", 0, "pos">;
+def ClockEdgeNeg : I32EnumAttrCase<"Neg", 1, "neg">;
+def ClockEdgeBoth : I32EnumAttrCase<"Both", 2, "both">;
+def ClockEdgeAttr : I32EnumAttr<"ClockEdge", "register clock edge",
+                                [ClockEdgePos, ClockEdgeNeg, ClockEdgeBoth]>;
+
 }
 
 /// An attribute holding information about memory initialization.

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -242,7 +242,8 @@ def FirRegOp : SeqOp<"firreg",
     OptionalAttr<InnerSymAttr>:$inner_sym,
     OptionalAttr<APIntAttr>:$preset,
     Optional<I1>:$reset, Optional<AnyType>:$resetValue,
-    UnitAttr:$isAsync
+    UnitAttr:$isAsync,
+    DefaultValuedAttr<ClockEdgeAttr, "ClockEdge::Pos">:$clockEdge
   );
   let results = (outs AnyType:$data);
 
@@ -252,12 +253,14 @@ def FirRegOp : SeqOp<"firreg",
     OpBuilder<(ins "Value":$next, "Value":$clk,
                    "StringAttr":$name,
                    CArg<"hw::InnerSymAttr", "{}">:$innerSym,
-                   CArg<"Attribute","{}">:$preset)>,
+                   CArg<"Attribute","{}">:$preset,
+                   CArg<"ClockEdgeAttr", "{}">:$clockEdge)>,
     OpBuilder<(ins "Value":$next, "Value":$clk,
                    "StringAttr":$name,
                    "Value":$reset, "Value":$resetValue,
                    CArg<"hw::InnerSymAttr", "{}">:$innerSym,
-                   CArg<"bool", "false">:$isAsync)>
+                   CArg<"bool", "false">:$isAsync,
+                   CArg<"ClockEdgeAttr", "{}">:$clockEdge)>
   ];
 
   let hasCustomAssemblyFormat = 1;

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3796,6 +3796,20 @@ LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
   return setLowering(op.getResult(), operand);
 }
 
+/// Map a FIRRTL register clock edge onto the equivalent seq.firreg attribute.
+static seq::ClockEdgeAttr lowerRegClockEdgeAttr(MLIRContext *context,
+                                                EventControl edge) {
+  switch (edge) {
+  case EventControl::AtPosEdge:
+    return seq::ClockEdgeAttr::get(context, seq::ClockEdge::Pos);
+  case EventControl::AtNegEdge:
+    return seq::ClockEdgeAttr::get(context, seq::ClockEdge::Neg);
+  case EventControl::AtEdge:
+    return seq::ClockEdgeAttr::get(context, seq::ClockEdge::Both);
+  }
+  llvm_unreachable("unknown FIRRTL register clock edge");
+}
+
 LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
   auto resultType = lowerType(op.getResult().getType());
   if (!resultType)
@@ -3810,8 +3824,9 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
   // Create a reg op, wiring itself to its input.
   auto innerSym = lowerInnerSymbol(op);
   Backedge inputEdge = backedgeBuilder.get(resultType);
-  auto reg = seq::FirRegOp::create(builder, inputEdge, clockVal,
-                                   op.getNameAttr(), innerSym);
+  auto reg = seq::FirRegOp::create(
+      builder, inputEdge, clockVal, op.getNameAttr(), innerSym, Attribute{},
+      lowerRegClockEdgeAttr(builder.getContext(), op.getClockEdge()));
 
   // Pass along the start and end random initialization bits for this register.
   if (auto randomRegister = op->getAttr("firrtl.random_init_register"))
@@ -3850,9 +3865,10 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   auto innerSym = lowerInnerSymbol(op);
   bool isAsync = type_isa<AsyncResetType>(op.getResetSignal().getType());
   Backedge inputEdge = backedgeBuilder.get(resultType);
-  auto reg =
-      seq::FirRegOp::create(builder, inputEdge, clockVal, op.getNameAttr(),
-                            resetSignal, resetValue, innerSym, isAsync);
+  auto reg = seq::FirRegOp::create(
+      builder, inputEdge, clockVal, op.getNameAttr(), resetSignal, resetValue,
+      innerSym, isAsync,
+      lowerRegClockEdgeAttr(builder.getContext(), op.getClockEdge()));
 
   // Pass along the start and end random initialization bits for this register.
   if (auto randomRegister = op->getAttr("firrtl.random_init_register"))

--- a/lib/Conversion/SeqToSV/FirRegLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirRegLowering.cpp
@@ -685,6 +685,20 @@ void FirRegLowering::createTree(OpBuilder &builder, Value reg, Value term,
   }
 }
 
+/// Map a seq.firreg clock edge onto the SystemVerilog event control used for
+/// the register's clocked always block.
+static sv::EventControl lowerSeqClockEdge(seq::ClockEdge edge) {
+  switch (edge) {
+  case seq::ClockEdge::Pos:
+    return sv::EventControl::AtPosEdge;
+  case seq::ClockEdge::Neg:
+    return sv::EventControl::AtNegEdge;
+  case seq::ClockEdge::Both:
+    return sv::EventControl::AtEdge;
+  }
+  llvm_unreachable("unknown seq.firreg clock edge");
+}
+
 void FirRegLowering::lowerReg(FirRegOp reg) {
   Location loc = reg.getLoc();
   Type regTy = typeConverter.convertType(reg.getType());
@@ -714,9 +728,11 @@ void FirRegLowering::lowerReg(FirRegOp reg) {
 
   auto regVal = sv::ReadInOutOp::create(builder, loc, svReg.reg);
 
+  auto clockEdge = lowerSeqClockEdge(reg.getClockEdge());
+
   if (reg.hasReset()) {
     addToAlwaysBlock(
-        reg->getBlock(), sv::EventControl::AtPosEdge, reg.getClk(),
+        reg->getBlock(), clockEdge, reg.getClk(),
         [&](OpBuilder &b) {
           // If this is an AsyncReset, ensure that we emit a self connect to
           // avoid erroneously creating a latch construct.
@@ -736,7 +752,7 @@ void FirRegLowering::lowerReg(FirRegOp reg) {
     }
   } else {
     addToAlwaysBlock(
-        reg->getBlock(), sv::EventControl::AtPosEdge, reg.getClk(),
+        reg->getBlock(), clockEdge, reg.getClk(),
         [&](OpBuilder &b) { createTree(b, svReg.reg, reg, reg.getNext()); });
   }
 

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -154,6 +154,12 @@ void StripSVPass::runOnOperation() {
       if (auto reg = dyn_cast<seq::FirRegOp>(&op)) {
         OpBuilder builder(reg);
 
+        if (reg.getClockEdge() != seq::ClockEdge::Pos) {
+          reg.emitOpError("only positive-edge registers are currently "
+                          "supported");
+          return signalPassFailure();
+        }
+
         if (reg.getIsAsync() && !asyncResetsAsSync) {
           reg.emitOpError("only synchronous resets are currently supported");
           return signalPassFailure();

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -901,6 +901,12 @@ void Emitter::emitStatement(WireOp op) {
 }
 
 void Emitter::emitStatement(RegOp op) {
+  if (op.getClockEdge() != EventControl::AtPosEdge) {
+    emitOpError(op, "has a clock edge that cannot be represented in FIRRTL "
+                    "text");
+    return;
+  }
+
   auto legalName = legalize(op.getNameAttr());
   addForceable(op, legalName);
   startStatement();
@@ -914,6 +920,11 @@ void Emitter::emitStatement(RegOp op) {
 }
 
 void Emitter::emitStatement(RegResetOp op) {
+  if (op.getClockEdge() != EventControl::AtPosEdge) {
+    emitOpError(op, "has a clock edge that cannot be represented in FIRRTL "
+                    "text");
+    return;
+  }
   auto legalName = legalize(op.getNameAttr());
   addForceable(op, legalName);
   startStatement();

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3663,6 +3663,7 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
         mux.getSel(), mux.getHigh(), reg.getNameAttr(), reg.getNameKindAttr(),
         reg.getAnnotationsAttr(), reg.getInnerSymAttr(),
         reg.getForceableAttr());
+    newReg.setClockEdgeAttr(reg.getClockEdgeAttr());
     newReg->setDialectAttrs(attrs);
   }
   auto pt = rewriter.saveInsertionPoint();

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3661,9 +3661,8 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
     auto newReg = replaceOpWithNewOpAndCopyName<RegResetOp>(
         rewriter, reg, reg.getResult().getType(), reg.getClockVal(),
         mux.getSel(), mux.getHigh(), reg.getNameAttr(), reg.getNameKindAttr(),
-        reg.getAnnotationsAttr(), reg.getInnerSymAttr(),
-        reg.getForceableAttr());
-    newReg.setClockEdgeAttr(reg.getClockEdgeAttr());
+        reg.getAnnotationsAttr(), reg.getInnerSymAttr(), reg.getForceableAttr(),
+        reg.getClockEdgeAttr());
     newReg->setDialectAttrs(attrs);
   }
   auto pt = rewriter.saveInsertionPoint();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6461,6 +6461,10 @@ static void printFIRRTLImplicitSSAName(OpAsmPrinter &p, Operation *op,
   SmallVector<StringRef, 4> elides;
   elides.push_back(hw::InnerSymbolTable::getInnerSymbolAttrName());
   elides.push_back(Forceable::getForceableAttrName());
+  if (isa<RegOp, RegResetOp>(op) &&
+      cast<EventControlAttr>(op->getAttr("clockEdge")).getValue() ==
+          EventControl::AtPosEdge)
+    elides.push_back("clockEdge");
   elideImplicitSSAName(p, op, attrs, elides);
   printElideAnnotations(p, op, attrs, elides);
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6445,6 +6445,29 @@ static void printNameKind(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
+// RegClockEdge Custom Directive
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseRegClockEdge(OpAsmParser &parser,
+                                     EventControlAttr &result) {
+  StringRef keyword;
+  if (!parser.parseOptionalKeyword(&keyword, {"posedge", "negedge", "edge"})) {
+    result = EventControlAttr::get(parser.getContext(),
+                                   *symbolizeEventControl(keyword));
+    return success();
+  }
+
+  result = EventControlAttr::get(parser.getContext(), EventControl::AtPosEdge);
+  return success();
+}
+
+static void printRegClockEdge(OpAsmPrinter &p, Operation *op,
+                              EventControlAttr attr) {
+  if (attr.getValue() != EventControl::AtPosEdge)
+    p << " " << stringifyEventControl(attr.getValue());
+}
+
+//===----------------------------------------------------------------------===//
 // ImplicitSSAName Custom Directive
 //===----------------------------------------------------------------------===//
 
@@ -6461,10 +6484,21 @@ static void printFIRRTLImplicitSSAName(OpAsmPrinter &p, Operation *op,
   SmallVector<StringRef, 4> elides;
   elides.push_back(hw::InnerSymbolTable::getInnerSymbolAttrName());
   elides.push_back(Forceable::getForceableAttrName());
-  if (isa<RegOp, RegResetOp>(op) &&
-      cast<EventControlAttr>(op->getAttr("clockEdge")).getValue() ==
-          EventControl::AtPosEdge)
-    elides.push_back("clockEdge");
+  elideImplicitSSAName(p, op, attrs, elides);
+  printElideAnnotations(p, op, attrs, elides);
+}
+
+static ParseResult parseFIRRTLRegImplicitSSAName(OpAsmParser &parser,
+                                                 NamedAttrList &resultAttrs) {
+  return parseFIRRTLImplicitSSAName(parser, resultAttrs);
+}
+
+static void printFIRRTLRegImplicitSSAName(OpAsmPrinter &p, Operation *op,
+                                          DictionaryAttr attrs) {
+  SmallVector<StringRef, 4> elides;
+  elides.push_back(hw::InnerSymbolTable::getInnerSymbolAttrName());
+  elides.push_back(Forceable::getForceableAttrName());
+  elides.push_back("clockEdge");
   elideImplicitSSAName(p, op, attrs, elides);
   printElideAnnotations(p, op, attrs, elides);
 }

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -1747,7 +1747,7 @@ struct ResetDisconnector : public OpReduction<RegResetOp> {
         builder, regResetOp.getResult().getType(), regResetOp.getClockVal(),
         regResetOp.getNameAttr(), regResetOp.getNameKindAttr(),
         regResetOp.getAnnotationsAttr(), regResetOp.getInnerSymAttr(),
-        regResetOp.getForceableAttr());
+        regResetOp.getForceableAttr(), regResetOp.getClockEdgeAttr());
 
     regResetOp.getResult().replaceAllUsesWith(regOp.getResult());
     if (regResetOp.getForceable())

--- a/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
@@ -1437,8 +1437,7 @@ LogicalResult FullResetRunner::implementFullReset(Operation *op,
         builder, regOp.getResult().getType(), regOp.getClockVal(), actualReset,
         zero, regOp.getNameAttr(), regOp.getNameKindAttr(),
         regOp.getAnnotations(), regOp.getInnerSymAttr(),
-        regOp.getForceableAttr());
-    newRegOp.setClockEdgeAttr(regOp.getClockEdgeAttr());
+        regOp.getForceableAttr(), regOp.getClockEdgeAttr());
     regOp.getResult().replaceAllUsesWith(newRegOp.getResult());
     if (regOp.getForceable())
       regOp.getRef().replaceAllUsesWith(newRegOp.getRef());

--- a/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
@@ -1438,6 +1438,7 @@ LogicalResult FullResetRunner::implementFullReset(Operation *op,
         zero, regOp.getNameAttr(), regOp.getNameKindAttr(),
         regOp.getAnnotations(), regOp.getInnerSymAttr(),
         regOp.getForceableAttr());
+    newRegOp.setClockEdgeAttr(regOp.getClockEdgeAttr());
     regOp.getResult().replaceAllUsesWith(newRegOp.getResult());
     if (regOp.getForceable())
       regOp.getRef().replaceAllUsesWith(newRegOp.getRef());

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1361,9 +1361,11 @@ bool TypeLoweringVisitor::visitDecl(RegOp op) {
 
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
-    return RegOp::create(*builder, field.type, op.getClockVal(), "",
-                         NameKindEnum::DroppableName, attrs, StringAttr{})
-        .getResult();
+    auto newReg =
+        RegOp::create(*builder, field.type, op.getClockVal(), "",
+                      NameKindEnum::DroppableName, attrs, StringAttr{});
+    newReg.setClockEdgeAttr(op.getClockEdgeAttr());
+    return newReg.getResult();
   };
   return lowerProducer(op, clone);
 }
@@ -1376,10 +1378,11 @@ bool TypeLoweringVisitor::visitDecl(RegResetOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
     auto resetVal = getSubWhatever(op.getResetValue(), field.index);
-    return RegResetOp::create(*builder, field.type, op.getClockVal(),
-                              op.getResetSignal(), resetVal, "",
-                              NameKindEnum::DroppableName, attrs, StringAttr{})
-        .getResult();
+    auto newReg = RegResetOp::create(
+        *builder, field.type, op.getClockVal(), op.getResetSignal(), resetVal,
+        "", NameKindEnum::DroppableName, attrs, StringAttr{});
+    newReg.setClockEdgeAttr(op.getClockEdgeAttr());
+    return newReg.getResult();
   };
   return lowerProducer(op, clone);
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1361,11 +1361,10 @@ bool TypeLoweringVisitor::visitDecl(RegOp op) {
 
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
-    auto newReg =
-        RegOp::create(*builder, field.type, op.getClockVal(), "",
-                      NameKindEnum::DroppableName, attrs, StringAttr{});
-    newReg.setClockEdgeAttr(op.getClockEdgeAttr());
-    return newReg.getResult();
+    return RegOp::create(*builder, field.type, op.getClockVal(), "",
+                         NameKindEnum::DroppableName, attrs, StringAttr{},
+                         /*forceable=*/false, op.getClockEdgeAttr())
+        .getResult();
   };
   return lowerProducer(op, clone);
 }
@@ -1378,11 +1377,11 @@ bool TypeLoweringVisitor::visitDecl(RegResetOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
     auto resetVal = getSubWhatever(op.getResetValue(), field.index);
-    auto newReg = RegResetOp::create(
-        *builder, field.type, op.getClockVal(), op.getResetSignal(), resetVal,
-        "", NameKindEnum::DroppableName, attrs, StringAttr{});
-    newReg.setClockEdgeAttr(op.getClockEdgeAttr());
-    return newReg.getResult();
+    return RegResetOp::create(*builder, field.type, op.getClockVal(),
+                              op.getResetSignal(), resetVal, "",
+                              NameKindEnum::DroppableName, attrs, StringAttr{},
+                              /*forceable=*/false, op.getClockEdgeAttr())
+        .getResult();
   };
   return lowerProducer(op, clone);
 }

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -82,11 +82,11 @@ void SFCCompatPass::runOnOperation() {
                                           return src.isa<InvalidValueOp>();
                                         })) {
       ImplicitLocOpBuilder builder(reg.getLoc(), reg);
-      RegOp newReg = RegOp::create(
-          builder, reg.getResult().getType(), reg.getClockVal(),
-          reg.getNameAttr(), reg.getNameKindAttr(), reg.getAnnotationsAttr(),
-          reg.getInnerSymAttr(), reg.getForceableAttr());
-      newReg.setClockEdgeAttr(reg.getClockEdgeAttr());
+      RegOp newReg =
+          RegOp::create(builder, reg.getResult().getType(), reg.getClockVal(),
+                        reg.getNameAttr(), reg.getNameKindAttr(),
+                        reg.getAnnotationsAttr(), reg.getInnerSymAttr(),
+                        reg.getForceableAttr(), reg.getClockEdgeAttr());
       reg.replaceAllUsesWith(newReg);
       reg.erase();
       madeModifications = true;

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -86,6 +86,7 @@ void SFCCompatPass::runOnOperation() {
           builder, reg.getResult().getType(), reg.getClockVal(),
           reg.getNameAttr(), reg.getNameKindAttr(), reg.getAnnotationsAttr(),
           reg.getInnerSymAttr(), reg.getForceableAttr());
+      newReg.setClockEdgeAttr(reg.getClockEdgeAttr());
       reg.replaceAllUsesWith(newReg);
       reg.erase();
       madeModifications = true;

--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -1442,7 +1442,8 @@ void Deseq::implementRegister(DriveInfo &drive) {
   auto reg = seq::FirRegOp::create(builder, loc, value, clock, name,
                                    hw::InnerSymAttr{},
                                    /*preset=*/IntegerAttr{}, reset, resetValue,
-                                   /*isAsync=*/reset != Value{});
+                                   /*isAsync=*/reset != Value{},
+                                   /*clockEdge=*/seq::ClockEdge::Pos);
 
   // If the register has an enable, insert a self-mux in front of the register.
   // Set the `bin` flag on the mux specifically to make up for a subtle

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -396,7 +396,7 @@ LogicalResult ShiftRegOp::verify() {
 
 void FirRegOp::build(OpBuilder &builder, OperationState &result, Value input,
                      Value clk, StringAttr name, hw::InnerSymAttr innerSym,
-                     Attribute preset) {
+                     Attribute preset, ClockEdgeAttr clockEdge) {
 
   OpBuilder::InsertionGuard guard(builder);
 
@@ -411,12 +411,16 @@ void FirRegOp::build(OpBuilder &builder, OperationState &result, Value input,
   if (preset)
     result.addAttribute(getPresetAttrName(result.name), preset);
 
+  if (clockEdge)
+    result.addAttribute(getClockEdgeAttrName(result.name), clockEdge);
+
   result.addTypes(input.getType());
 }
 
 void FirRegOp::build(OpBuilder &builder, OperationState &result, Value input,
                      Value clk, StringAttr name, Value reset, Value resetValue,
-                     hw::InnerSymAttr innerSym, bool isAsync) {
+                     hw::InnerSymAttr innerSym, bool isAsync,
+                     ClockEdgeAttr clockEdge) {
 
   OpBuilder::InsertionGuard guard(builder);
 
@@ -431,6 +435,9 @@ void FirRegOp::build(OpBuilder &builder, OperationState &result, Value input,
 
   if (innerSym)
     result.addAttribute(getInnerSymAttrName(result.name), innerSym);
+
+  if (clockEdge)
+    result.addAttribute(getClockEdgeAttrName(result.name), clockEdge);
 
   result.addTypes(input.getType());
 }
@@ -561,6 +568,8 @@ void FirRegOp::print(::mlir::OpAsmPrinter &p) {
 
   if (canElideName(p, *this))
     elidedAttrs.push_back("name");
+  if (getClockEdge() == ClockEdge::Pos)
+    elidedAttrs.push_back(getClockEdgeAttrName());
 
   p.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
   p << " : " << getNext().getType();
@@ -597,13 +606,13 @@ std::optional<size_t> FirRegOp::getTargetResultIndex() { return 0; }
 LogicalResult FirRegOp::canonicalize(FirRegOp op, PatternRewriter &rewriter) {
 
   // If the register has a constant zero reset, drop the reset and reset value
-  // altogether (And preserve the PresetAttr).
+  // altogether (And preserve the PresetAttr and clock edge).
   if (auto reset = op.getReset()) {
     if (auto constOp = reset.getDefiningOp<hw::ConstantOp>()) {
       if (constOp.getValue().isZero()) {
         rewriter.replaceOpWithNewOp<FirRegOp>(
             op, op.getNext(), op.getClk(), op.getNameAttr(),
-            op.getInnerSymAttr(), op.getPresetAttr());
+            op.getInnerSymAttr(), op.getPresetAttr(), op.getClockEdgeAttr());
         return success();
       }
     }
@@ -731,10 +740,11 @@ LogicalResult FirRegOp::canonicalize(FirRegOp op, PatternRewriter &rewriter) {
             // value directly.
             rewriter.replaceOp(arrayCreate, newNextVal);
           else {
-            // Otherwise, replace the entire firreg with a new one.
-            rewriter.replaceOpWithNewOp<FirRegOp>(op, newNextVal, op.getClk(),
-                                                  op.getNameAttr(),
-                                                  op.getInnerSymAttr());
+            // Otherwise, replace the entire firreg with a new one, preserving
+            // the clock edge (the register here is reset- and preset-less).
+            rewriter.replaceOpWithNewOp<FirRegOp>(
+                op, newNextVal, op.getClk(), op.getNameAttr(),
+                op.getInnerSymAttr(), Attribute{}, op.getClockEdgeAttr());
           }
 
           return success();

--- a/lib/Dialect/Seq/Transforms/RegOfVecToMem.cpp
+++ b/lib/Dialect/Seq/Transforms/RegOfVecToMem.cpp
@@ -85,6 +85,10 @@ bool RegOfVecToMemPass::analyzeMemoryPattern(FirRegOp reg,
                                              MemoryPattern &pattern) {
   LLVM_DEBUG(llvm::dbgs() << "Analyzing register: " << reg << "\n");
 
+  // FirMem ports are positive-edge triggered.
+  if (reg.getClockEdge() != ClockEdge::Pos)
+    return false;
+
   // Check if register has array type
   if (!isArrayType(reg.getType()))
     return false;

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -137,6 +137,14 @@ void ExternalizeRegistersPass::runOnOperation() {
           Twine regName = regOp.getName().empty() ? "reg_" + Twine(numRegs)
                                                   : regOp.getName();
 
+          // externalizeReg models a posedge-clocked register. Reject a
+          // non-default clock edge rather than silently miscompile it.
+          if (regOp.getClockEdge() != seq::ClockEdge::Pos) {
+            regOp.emitError("non-posedge clock edges are not supported by "
+                            "externalize-registers");
+            return signalPassFailure();
+          }
+
           if (failed(externalizeReg(module, op, regName, regOp.getClk(),
                                     initState, regOp.getReset(),
                                     regOp.getIsAsync(), regOp.getResetValue(),

--- a/lib/Transforms/CellIFT.cpp
+++ b/lib/Transforms/CellIFT.cpp
@@ -735,16 +735,19 @@ LogicalResult CellIFTInstrumentPass::instrumentModuleBody(
 
           Value nextT = getTaint(taintOf, pendingTaints, backedgeBuilder,
                                  firreg.getNext());
-          Value tReg;
+          auto clockEdge = firreg.getClockEdgeAttr();
+          seq::FirRegOp tRegOp;
           if (firreg.hasReset()) {
             Value rstVal = getZero(b, firreg.getType());
-            tReg = seq::FirRegOp::create(
+            tRegOp = seq::FirRegOp::create(
                 b, nextT, firreg.getClk(), name, firreg.getReset(), rstVal,
-                firreg.getInnerSymAttr(), firreg.getIsAsync());
+                firreg.getInnerSymAttr(), firreg.getIsAsync(), clockEdge);
           } else {
-            tReg = seq::FirRegOp::create(b, nextT, firreg.getClk(), name);
+            tRegOp = seq::FirRegOp::create(b, nextT, firreg.getClk(), name,
+                                           hw::InnerSymAttr{}, Attribute{},
+                                           clockEdge);
           }
-          setTaint(taintOf, pendingTaints, firreg.getData(), tReg);
+          setTaint(taintOf, pendingTaints, firreg.getData(), tRegOp);
         })
         .Case<hw::ConstantOp>([&](auto o) {
           setTaint(taintOf, pendingTaints, o.getResult(),

--- a/test/Dialect/Arc/strip-sv-errors.mlir
+++ b/test/Dialect/Arc/strip-sv-errors.mlir
@@ -13,3 +13,10 @@ hw.module @AsyncHasBeenReset(in %clock: i1, in %reset: i1, out z: i1) {
   %0 = verif.has_been_reset %clock, async %reset
   hw.output %0 : i1
 }
+
+// -----
+
+hw.module @NegEdgeReg(in %clk : !seq.clock, in %arg0: i8) {
+  // expected-error @below {{only positive-edge registers are currently supported}}
+  %reg = seq.firreg %arg0 clock %clk {clockEdge = 1 : i32} : i8
+}

--- a/test/Dialect/FIRRTL/Reduction/reset-disconnector.mlir
+++ b/test/Dialect/FIRRTL/Reduction/reset-disconnector.mlir
@@ -9,13 +9,13 @@ firrtl.circuit "Test" {
   // CHECK-LABEL: firrtl.module @Test
   firrtl.module @Test(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
     // ALL: %reg1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
-    // ALL: %reg2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<16>
+    // ALL: %reg2 = firrtl.reg negedge %clock : !firrtl.clock, !firrtl.uint<16>
     // ALL-NOT: regreset
     // KEEP_REG1: %reg1 = firrtl.regreset %clock, %reset
-    // KEEP_REG1: %reg2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<16>
+    // KEEP_REG1: %reg2 = firrtl.reg negedge %clock : !firrtl.clock, !firrtl.uint<16>
     %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
     %c0_ui16 = firrtl.constant 0 : !firrtl.uint<16>
     %reg1 = firrtl.regreset %clock, %reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
-    %reg2 = firrtl.regreset %clock, %reset, %c0_ui16 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<16>, !firrtl.uint<16>
+    %reg2 = firrtl.regreset negedge %clock, %reset, %c0_ui16 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<16>, !firrtl.uint<16>
   }
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -4181,3 +4181,26 @@ firrtl.module @BoolBinaryFold(in %b: !firrtl.bool,
 }
 
 }
+
+firrtl.circuit "RegResetToRegPreservesClockEdge" {
+  // CHECK-LABEL: firrtl.module @RegResetToRegPreservesClockEdge
+  firrtl.module @RegResetToRegPreservesClockEdge(in %clock: !firrtl.clock,
+      in %dummy: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK: %reg = firrtl.reg %clock {clockEdge = 1 : i32}
+    %reg = firrtl.regreset %clock, %zero, %dummy {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %out, %reg : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: firrtl.module @HiddenResetPreservesClockEdge
+  firrtl.module @HiddenResetPreservesClockEdge(in %clock: !firrtl.clock,
+      in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<8>,
+      out %out: !firrtl.uint<8>) {
+    %zero = firrtl.constant 0 : !firrtl.uint<8>
+    %reg = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<8>
+    %next = firrtl.mux(%reset, %zero, %in) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    firrtl.connect %reg, %next : !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %out, %reg : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: %reg = firrtl.regreset %clock, %reset, {{.*}} {clockEdge = 1 : i32}
+  }
+}

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -4187,8 +4187,8 @@ firrtl.circuit "RegResetToRegPreservesClockEdge" {
   firrtl.module @RegResetToRegPreservesClockEdge(in %clock: !firrtl.clock,
       in %dummy: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: %reg = firrtl.reg %clock {clockEdge = 1 : i32}
-    %reg = firrtl.regreset %clock, %zero, %dummy {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: %reg = firrtl.reg negedge %clock
+    %reg = firrtl.regreset negedge %clock, %zero, %dummy : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out, %reg : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
@@ -4197,10 +4197,10 @@ firrtl.circuit "RegResetToRegPreservesClockEdge" {
       in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<8>,
       out %out: !firrtl.uint<8>) {
     %zero = firrtl.constant 0 : !firrtl.uint<8>
-    %reg = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<8>
+    %reg = firrtl.reg negedge %clock : !firrtl.clock, !firrtl.uint<8>
     %next = firrtl.mux(%reset, %zero, %in) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %reg, %next : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %out, %reg : !firrtl.uint<8>, !firrtl.uint<8>
-    // CHECK: %reg = firrtl.regreset %clock, %reset, {{.*}} {clockEdge = 1 : i32}
+    // CHECK: %reg = firrtl.regreset negedge %clock, %reset, {{.*}}
   }
 }

--- a/test/Dialect/FIRRTL/emit-register-attrs-errors.mlir
+++ b/test/Dialect/FIRRTL/emit-register-attrs-errors.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-translate --export-firrtl --verify-diagnostics \
+// RUN:   --split-input-file %s
+
+firrtl.circuit "NegEdge" {
+  firrtl.module @NegEdge(in %clock: !firrtl.clock) {
+    // expected-error @below {{'firrtl.reg' op has a clock edge that cannot be represented in FIRRTL text}}
+    %reg = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/emit-register-attrs-errors.mlir
+++ b/test/Dialect/FIRRTL/emit-register-attrs-errors.mlir
@@ -4,6 +4,6 @@
 firrtl.circuit "NegEdge" {
   firrtl.module @NegEdge(in %clock: !firrtl.clock) {
     // expected-error @below {{'firrtl.reg' op has a clock edge that cannot be represented in FIRRTL text}}
-    %reg = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>
+    %reg = firrtl.reg negedge %clock : !firrtl.clock, !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/reg-attrs-preservation.mlir
+++ b/test/Dialect/FIRRTL/reg-attrs-preservation.mlir
@@ -12,12 +12,12 @@
 // LowerTypes splits an aggregate register into per-field registers; each must
 // keep the non-default clock edge.
 // LOWERTYPES-LABEL: firrtl.module @LowerTypesKeepsClockEdge
-// LOWERTYPES: %r_a = firrtl.reg %clk {clockEdge = 1 : i32}
-// LOWERTYPES: %r_b = firrtl.reg %clk {clockEdge = 1 : i32}
+// LOWERTYPES: %r_a = firrtl.reg negedge %clk
+// LOWERTYPES: %r_b = firrtl.reg negedge %clk
 firrtl.circuit "LowerTypesKeepsClockEdge" {
 firrtl.module @LowerTypesKeepsClockEdge(in %clk: !firrtl.clock,
     out %o: !firrtl.bundle<a: uint<1>, b: uint<2>>) {
-  %r = firrtl.reg %clk {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.bundle<a: uint<1>, b: uint<2>>
+  %r = firrtl.reg negedge %clk : !firrtl.clock, !firrtl.bundle<a: uint<1>, b: uint<2>>
   firrtl.matchingconnect %o, %r : !firrtl.bundle<a: uint<1>, b: uint<2>>
 }
 }
@@ -27,12 +27,12 @@ firrtl.module @LowerTypesKeepsClockEdge(in %clk: !firrtl.clock,
 // SFCCompat rewrites a register whose reset value is invalid into a reset-less
 // register; the non-default clock edge must survive the rewrite.
 // SFCCOMPAT-LABEL: firrtl.module @SFCCompatKeepsClockEdge
-// SFCCOMPAT: %r = firrtl.reg %clk {clockEdge = 1 : i32}
+// SFCCOMPAT: %r = firrtl.reg negedge %clk
 // SFCCOMPAT-NOT: firrtl.regreset
 firrtl.circuit "SFCCompatKeepsClockEdge" {
 firrtl.module @SFCCompatKeepsClockEdge(in %clk: !firrtl.clock, in %rst: !firrtl.uint<1>) {
   %inv = firrtl.invalidvalue : !firrtl.uint<8>
-  %r = firrtl.regreset %clk, %rst, %inv {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r = firrtl.regreset negedge %clk, %rst, %inv : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
 }
 }
 
@@ -41,12 +41,12 @@ firrtl.module @SFCCompatKeepsClockEdge(in %clk: !firrtl.clock, in %rst: !firrtl.
 // InferResets converts a reset-less register into a regreset when a full async
 // reset is added; the non-default clock edge must survive.
 // INFERRESETS-LABEL: firrtl.module @InferResetsKeepsClockEdge
-// INFERRESETS: firrtl.regreset %clock, %reset, {{.*}} {clockEdge = 1 : i32}
+// INFERRESETS: firrtl.regreset negedge %clock, %reset, {{.*}}
 firrtl.circuit "InferResetsKeepsClockEdge" {
 firrtl.module @InferResetsKeepsClockEdge(in %clock: !firrtl.clock,
     in %reset: !firrtl.asyncreset [{class = "circt.FullResetAnnotation", resetType = "async"}],
     in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
-  %r = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<8>
+  %r = firrtl.reg negedge %clock : !firrtl.clock, !firrtl.uint<8>
   firrtl.matchingconnect %r, %in : !firrtl.uint<8>
   firrtl.matchingconnect %out, %r : !firrtl.uint<8>
 }

--- a/test/Dialect/FIRRTL/reg-attrs-preservation.mlir
+++ b/test/Dialect/FIRRTL/reg-attrs-preservation.mlir
@@ -1,0 +1,53 @@
+// Transforms that rebuild registers must preserve the clock-edge attribute.
+// RUN: circt-opt %s --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(firrtl.circuit(firrtl-lower-types))" \
+// RUN:   | FileCheck %s --check-prefix=LOWERTYPES
+// RUN: circt-opt %s --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(firrtl.circuit(firrtl.module(firrtl-sfc-compat)))" \
+// RUN:   | FileCheck %s --check-prefix=SFCCOMPAT
+// RUN: circt-opt %s --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(firrtl.circuit(firrtl-infer-resets))" \
+// RUN:   | FileCheck %s --check-prefix=INFERRESETS
+
+// LowerTypes splits an aggregate register into per-field registers; each must
+// keep the non-default clock edge.
+// LOWERTYPES-LABEL: firrtl.module @LowerTypesKeepsClockEdge
+// LOWERTYPES: %r_a = firrtl.reg %clk {clockEdge = 1 : i32}
+// LOWERTYPES: %r_b = firrtl.reg %clk {clockEdge = 1 : i32}
+firrtl.circuit "LowerTypesKeepsClockEdge" {
+firrtl.module @LowerTypesKeepsClockEdge(in %clk: !firrtl.clock,
+    out %o: !firrtl.bundle<a: uint<1>, b: uint<2>>) {
+  %r = firrtl.reg %clk {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.bundle<a: uint<1>, b: uint<2>>
+  firrtl.matchingconnect %o, %r : !firrtl.bundle<a: uint<1>, b: uint<2>>
+}
+}
+
+// -----
+
+// SFCCompat rewrites a register whose reset value is invalid into a reset-less
+// register; the non-default clock edge must survive the rewrite.
+// SFCCOMPAT-LABEL: firrtl.module @SFCCompatKeepsClockEdge
+// SFCCOMPAT: %r = firrtl.reg %clk {clockEdge = 1 : i32}
+// SFCCOMPAT-NOT: firrtl.regreset
+firrtl.circuit "SFCCompatKeepsClockEdge" {
+firrtl.module @SFCCompatKeepsClockEdge(in %clk: !firrtl.clock, in %rst: !firrtl.uint<1>) {
+  %inv = firrtl.invalidvalue : !firrtl.uint<8>
+  %r = firrtl.regreset %clk, %rst, %inv {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+}
+}
+
+// -----
+
+// InferResets converts a reset-less register into a regreset when a full async
+// reset is added; the non-default clock edge must survive.
+// INFERRESETS-LABEL: firrtl.module @InferResetsKeepsClockEdge
+// INFERRESETS: firrtl.regreset %clock, %reset, {{.*}} {clockEdge = 1 : i32}
+firrtl.circuit "InferResetsKeepsClockEdge" {
+firrtl.module @InferResetsKeepsClockEdge(in %clock: !firrtl.clock,
+    in %reset: !firrtl.asyncreset [{class = "circt.FullResetAnnotation", resetType = "async"}],
+    in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+  %r = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<8>
+  firrtl.matchingconnect %r, %in : !firrtl.uint<8>
+  firrtl.matchingconnect %out, %r : !firrtl.uint<8>
+}
+}

--- a/test/Dialect/FIRRTL/reg-attrs-preservation.mlir
+++ b/test/Dialect/FIRRTL/reg-attrs-preservation.mlir
@@ -1,48 +1,41 @@
 // Transforms that rebuild registers must preserve the clock-edge attribute.
-// RUN: circt-opt %s --split-input-file \
+// RUN: circt-opt %s \
 // RUN:   --pass-pipeline="builtin.module(firrtl.circuit(firrtl-lower-types))" \
 // RUN:   | FileCheck %s --check-prefix=LOWERTYPES
-// RUN: circt-opt %s --split-input-file \
+// RUN: circt-opt %s \
 // RUN:   --pass-pipeline="builtin.module(firrtl.circuit(firrtl.module(firrtl-sfc-compat)))" \
 // RUN:   | FileCheck %s --check-prefix=SFCCOMPAT
-// RUN: circt-opt %s --split-input-file \
+// RUN: circt-opt %s \
 // RUN:   --pass-pipeline="builtin.module(firrtl.circuit(firrtl-infer-resets))" \
 // RUN:   | FileCheck %s --check-prefix=INFERRESETS
+
+firrtl.circuit "LowerTypesKeepsClockEdge" {
 
 // LowerTypes splits an aggregate register into per-field registers; each must
 // keep the non-default clock edge.
 // LOWERTYPES-LABEL: firrtl.module @LowerTypesKeepsClockEdge
 // LOWERTYPES: %r_a = firrtl.reg negedge %clk
 // LOWERTYPES: %r_b = firrtl.reg negedge %clk
-firrtl.circuit "LowerTypesKeepsClockEdge" {
 firrtl.module @LowerTypesKeepsClockEdge(in %clk: !firrtl.clock,
     out %o: !firrtl.bundle<a: uint<1>, b: uint<2>>) {
   %r = firrtl.reg negedge %clk : !firrtl.clock, !firrtl.bundle<a: uint<1>, b: uint<2>>
   firrtl.matchingconnect %o, %r : !firrtl.bundle<a: uint<1>, b: uint<2>>
 }
-}
-
-// -----
 
 // SFCCompat rewrites a register whose reset value is invalid into a reset-less
 // register; the non-default clock edge must survive the rewrite.
 // SFCCOMPAT-LABEL: firrtl.module @SFCCompatKeepsClockEdge
 // SFCCOMPAT: %r = firrtl.reg negedge %clk
 // SFCCOMPAT-NOT: firrtl.regreset
-firrtl.circuit "SFCCompatKeepsClockEdge" {
 firrtl.module @SFCCompatKeepsClockEdge(in %clk: !firrtl.clock, in %rst: !firrtl.uint<1>) {
   %inv = firrtl.invalidvalue : !firrtl.uint<8>
   %r = firrtl.regreset negedge %clk, %rst, %inv : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
 }
-}
-
-// -----
 
 // InferResets converts a reset-less register into a regreset when a full async
 // reset is added; the non-default clock edge must survive.
 // INFERRESETS-LABEL: firrtl.module @InferResetsKeepsClockEdge
 // INFERRESETS: firrtl.regreset negedge %clock, %reset, {{.*}}
-firrtl.circuit "InferResetsKeepsClockEdge" {
 firrtl.module @InferResetsKeepsClockEdge(in %clock: !firrtl.clock,
     in %reset: !firrtl.asyncreset [{class = "circt.FullResetAnnotation", resetType = "async"}],
     in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {

--- a/test/Dialect/FIRRTL/reg-clock-reset-attrs.mlir
+++ b/test/Dialect/FIRRTL/reg-clock-reset-attrs.mlir
@@ -1,0 +1,30 @@
+// Round-trip and lowering tests for explicit FIRRTL register clock edges.
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+// RUN: circt-opt %s --pass-pipeline="builtin.module(lower-firrtl-to-hw)" \
+// RUN:   | FileCheck %s --check-prefix=LOWER
+
+firrtl.circuit "RegAttrs" {
+// CHECK-LABEL: firrtl.module @RegAttrs
+firrtl.module @RegAttrs(in %clock: !firrtl.clock,
+                        in %sreset: !firrtl.uint<1>,
+                        in %in: !firrtl.uint<8>) {
+  // LOWER-LABEL: hw.module @RegAttrs
+  // A plain register with default clock edge elides the attribute.
+  // CHECK: %r0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+  %r0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+
+  // A plain register with a non-default (negedge) clock edge round-trips.
+  // CHECK: %r1 = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<8>
+  %r1 = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<8>
+
+  // A regreset with a non-default clock edge preserves it too.
+  // CHECK: %r2 = firrtl.regreset %clock, %sreset, %in {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r2 = firrtl.regreset %clock, %sreset, %in {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+
+  // A regreset with the default clock edge elides the attribute.
+  // CHECK: %r3 = firrtl.regreset %clock, %sreset, %in : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r3 = firrtl.regreset %clock, %sreset, %in : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+
+  // LOWER-COUNT-2: {clockEdge = 1 : i32}
+}
+}

--- a/test/Dialect/FIRRTL/reg-clock-reset-attrs.mlir
+++ b/test/Dialect/FIRRTL/reg-clock-reset-attrs.mlir
@@ -14,17 +14,22 @@ firrtl.module @RegAttrs(in %clock: !firrtl.clock,
   %r0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
 
   // A plain register with a non-default (negedge) clock edge round-trips.
-  // CHECK: %r1 = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<8>
-  %r1 = firrtl.reg %clock {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<8>
+  // CHECK: %r1 = firrtl.reg negedge %clock : !firrtl.clock, !firrtl.uint<8>
+  %r1 = firrtl.reg negedge %clock : !firrtl.clock, !firrtl.uint<8>
 
   // A regreset with a non-default clock edge preserves it too.
-  // CHECK: %r2 = firrtl.regreset %clock, %sreset, %in {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-  %r2 = firrtl.regreset %clock, %sreset, %in {clockEdge = 1 : i32} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: %r2 = firrtl.regreset negedge %clock, %sreset, %in : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %r2 = firrtl.regreset negedge %clock, %sreset, %in : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
 
   // A regreset with the default clock edge elides the attribute.
   // CHECK: %r3 = firrtl.regreset %clock, %sreset, %in : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   %r3 = firrtl.regreset %clock, %sreset, %in : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
 
+  // A dual-edge register round-trips.
+  // CHECK: %r4 = firrtl.reg edge %clock : !firrtl.clock, !firrtl.uint<8>
+  %r4 = firrtl.reg edge %clock : !firrtl.clock, !firrtl.uint<8>
+
   // LOWER-COUNT-2: {clockEdge = 1 : i32}
+  // LOWER: {clockEdge = 2 : i32}
 }
 }

--- a/test/Dialect/FIRRTL/reg-clock-reset-attrs.mlir
+++ b/test/Dialect/FIRRTL/reg-clock-reset-attrs.mlir
@@ -1,5 +1,5 @@
 // Round-trip and lowering tests for explicit FIRRTL register clock edges.
-// RUN: circt-opt %s | circt-opt | FileCheck %s
+// RUN: circt-opt --verify-roundtrip %s | FileCheck %s
 // RUN: circt-opt %s --pass-pipeline="builtin.module(lower-firrtl-to-hw)" \
 // RUN:   | FileCheck %s --check-prefix=LOWER
 

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -54,6 +54,13 @@ hw.module @FirRegReset(in %clk : !seq.clock, in %in : i32, in %r : i1, in %v : i
   // CHECK: %reg1 = seq.firreg %in clock %clk : i32
   // CHECK: hw.instance "reg1" @Observe(x: %reg1: i32) -> ()
 
+  // Dropping a never-asserting (active-high constant-zero) reset must preserve a
+  // non-default clock edge.
+  %reg1edge = seq.firreg %in clock %clk reset sync %false, %v {clockEdge = 1 : i32} : i32
+  hw.instance "reg1edge" @Observe(x: %reg1edge: i32) -> ()
+  // CHECK: %reg1edge = seq.firreg %in clock %clk {clockEdge = 1 : i32} : i32
+  // CHECK: hw.instance "reg1edge" @Observe(x: %reg1edge: i32) -> ()
+
   // Registers that are permanently reset should be replaced with their reset
   // value.
   %reg2a = seq.firreg %in clock %clk reset sync %true, %v : i32
@@ -120,6 +127,19 @@ hw.module @UninitializedArrayElement(in %a : i1, in %clock : !seq.clock, out b: 
   %0 = hw.array_get %r[%true] : !hw.array<2xi1>, i1
   %1 = hw.array_create %0, %a : i1
   hw.output %r : !hw.array<2xi1>
+}
+
+// When the self-looping array-create has multiple uses the whole register is
+// rebuilt; the non-default clock edge must be preserved on the replacement.
+// CHECK-LABEL: @ArraySelfLoopElementClockEdge
+hw.module @ArraySelfLoopElementClockEdge(in %a : i1, in %clock : !seq.clock,
+    out b: !hw.array<2xi1>, out c: !hw.array<2xi1>) {
+  // CHECK: %r = seq.firreg %{{.*}} clock %clock {clockEdge = 1 : i32} : !hw.array<2xi1>
+  %true = hw.constant true
+  %r = seq.firreg %1 clock %clock {clockEdge = 1 : i32} : !hw.array<2xi1>
+  %0 = hw.array_get %r[%true] : !hw.array<2xi1>, i1
+  %1 = hw.array_create %0, %a : i1
+  hw.output %r, %1 : !hw.array<2xi1>, !hw.array<2xi1>
 }
 
 // CHECK-LABEL: hw.module @ClockGate

--- a/test/Dialect/Seq/firreg-clock-reset-attrs.mlir
+++ b/test/Dialect/Seq/firreg-clock-reset-attrs.mlir
@@ -1,0 +1,12 @@
+// Lowering of the seq.firreg clock-edge attribute to SV.
+// RUN: circt-opt %s --pass-pipeline="builtin.module(lower-seq-to-sv{disable-reg-randomization})" | FileCheck %s
+// RUN: circt-opt %s | circt-opt | FileCheck %s --check-prefix=ROUNDTRIP
+
+// A non-default (negedge) clock edge lowers to a negedge-triggered always block.
+// CHECK-LABEL: hw.module @NegEdgeClock
+// CHECK: sv.always negedge %clk {
+// ROUNDTRIP-LABEL: hw.module @NegEdgeClock
+// ROUNDTRIP: seq.firreg %in clock %clk {clockEdge = 1 : i32}
+hw.module @NegEdgeClock(in %clk : !seq.clock, in %in : i32) {
+  %r = seq.firreg %in clock %clk {clockEdge = 1 : i32} : i32
+}

--- a/test/Dialect/Seq/reg-of-vec-to-mem.mlir
+++ b/test/Dialect/Seq/reg-of-vec-to-mem.mlir
@@ -96,3 +96,17 @@ hw.module @shared_reg_test(in %clk: i1, in %addr: i2, in %data: i8, in %we: i1, 
   // Register used elsewhere - should prevent transformation
   hw.output %mem, %read : !hw.array<4xi8>, i8
 }
+
+// Test that transformation is skipped for register behavior that FirMem cannot
+// represent.
+// CHECK-LABEL: hw.module @negedge_mem(
+hw.module @negedge_mem(in %clk: i1, in %addr: i2, in %data: i8, in %we: i1, out out: i8) {
+  %clock = seq.to_clock %clk
+  %read = hw.array_get %mem[%addr] : !hw.array<4xi8>, i2
+  %write = hw.array_inject %mem[%addr], %data : !hw.array<4xi8>, i2
+  %next = comb.mux %we, %write, %mem : !hw.array<4xi8>
+  // CHECK: %mem = seq.firreg %{{.*}} clock %{{.*}} {clockEdge = 1 : i32} : !hw.array<4xi8>
+  // CHECK-NOT: seq.firmem
+  %mem = seq.firreg %next clock %clock {clockEdge = 1 : i32} : !hw.array<4xi8>
+  hw.output %read : i8
+}

--- a/test/Tools/circt-bmc/externalize-registers-errors.mlir
+++ b/test/Tools/circt-bmc/externalize-registers-errors.mlir
@@ -62,3 +62,11 @@ hw.module @firreg_with_async_reset(in %clk: !seq.clock, in %rst: i1, in %in: i32
   %1 = seq.firreg %in clock %clk reset async %rst, %c0_i32 : i32
   hw.output %1 : i32
 }
+
+// -----
+
+hw.module @negedge_clock_reg(in %clk: !seq.clock, in %in: i32, out out: i32) {
+  // expected-error @below {{non-posedge clock edges are not supported by externalize-registers}}
+  %r = seq.firreg %in clock %clk {clockEdge = 1 : i32} : i32
+  hw.output %r : i32
+}

--- a/test/Transforms/cellift-instrument.mlir
+++ b/test/Transforms/cellift-instrument.mlir
@@ -286,6 +286,16 @@ hw.module @test_firreg(in %d : i8, in %clk : !seq.clock, out q : i8) {
 }
 
 // -----
+// Test: the taint clone of a reset-less seq.firreg preserves the clock edge.
+// CHECK-LABEL: hw.module @test_firreg_noreset_attrs
+hw.module @test_firreg_noreset_attrs(in %d : i8, in %clk : !seq.clock, out q : i8) {
+  // CHECK: %myreg = seq.firreg %d clock %clk {clockEdge = 1 : i32} : i8
+  // CHECK: %myreg_t = seq.firreg %d_t clock %clk {clockEdge = 1 : i32} : i8
+  %reg = seq.firreg %d clock %clk {name = "myreg", clockEdge = 1 : i32} : i8
+  hw.output %reg : i8
+}
+
+// -----
 // Test: Multi-operation dataflow: the demo from the CellIFT paper.
 // module demo(input [7:0] a, b, input s, output [7:0] y);
 //   assign y = s ? (a + b) : (a ^ b);


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

Add explicit positive-, negative-, and dual-edge clock attributes to FIRRTL registers and `seq.firreg`, preserving them through transformations and lowering.

Assisted-by: Codex:gpt-5.6-Sol