### PR TITLE
[PyCDE] Re-add numpy, add its build dep

### DIFF
--- a/frontends/PyCDE/pyproject.toml
+++ b/frontends/PyCDE/pyproject.toml
@@ -7,6 +7,9 @@ requires = [
   "ninja>=1.10",
   "executing",
 
+  # Test requires numpy
+  "numpy",
+
   # MLIR build depends.
   "nanobind>=2.2",
   "PyYAML",


### PR DESCRIPTION
While numpy isn't necessary for the build, the tests need it. Add it back. The docker image has been upgraded to manylinux2_28 for compatibility with more recent numpy packages.


