### PR TITLE
[PyCDE][ESI] Introduce 'ChannelArbitrator' module

### DIFF
--- a/lib/Dialect/ESI/runtime/docs/components/ChannelArbiter.md
+++ b/lib/Dialect/ESI/runtime/docs/components/ChannelArbiter.md
@@ -1,0 +1,206 @@
+# Component Design: `ChannelArbiter`
+
+## 1. Summary
+`ChannelArbiter` (in `esiaccel/components/channel_arbiter.py`) is a pipelined,
+list-aware N:1 ESI channel multiplexer. It is an opt-in alternative to the
+recursive **combinational** `ChannelMux2` tree in `pycde.esi.ChannelMux`, built
+as a **flat, registered, round-robin arbiter** whose datapath is fully
+feed-forward: downstream `ready` never reaches the arbiter combinationally — an
+output FIFO plus a credit counter decouple the two.  It (a) keeps multi-flit
+list messages contiguous, (b) closes timing at high N, (c) is pipelined by a
+parameter, and (d) emits telemetry. `pycde.esi.ChannelMux` is left untouched.
+
+## 2. Motivation
+- **FMax.** `ChannelMux` is a `ceil(log2 N)`-deep tree of combinational
+  `ChannelMux2` arbiters. Both the forward valid/data path *and* the backward
+  `ready` path cross every level combinationally — in an internal build results
+  in one die-spanning net whose `ready` feedback is the critical path.
+- **List integrity.** The combinational priority tree may re-select an input on
+  any cycle, so flits of two different list messages can interleave. There is no
+  mechanism to hold a grant until the flit tagged `last`.
+
+## 3. Requirements
+1. Message boundaries preserved — once granted, an input holds the output until a
+   flit with `last` transfers.
+2. Feed-forward — no combinational path from `out_ready` into input selection;
+   an output FIFO plus a credit counter provide the decoupling.
+3. Optional input buffering.
+4. Telemetry for observability.
+5. Uniform handling of single-flit messages (every flit is `last`) and list
+   windows.
+
+## 4. Interface
+```python
+def ChannelArbiter(
+    input_channels: List[ChannelSignal],
+    clk: ClockSignal,
+    rst: Signal,
+    *,
+    appid: Optional[AppID] = None,            # AppID for the arbiter instance
+    output_fifo_depth: Optional[int] = None,  # default: pipe latency + _SLACK
+    buffer_inputs: bool = True,               # optional per-input skid buffer
+    mux_pipeline_levels: Optional[int] = None,  # pipeline the N:1 select mux tree
+    telemetry: bool = True,
+) -> ChannelSignal
+```
+Sequential (needs `clk`/`rst`), unlike `ChannelMux`. All inputs share type and
+signaling (ValidReady); output type equals input type. `output_fifo_depth` must
+be greater than the pipeline latency (one output register plus any
+selection-mux pipeline latency); it is validated and defaults to that plus a
+small internal slack (the private, class-scoped `ChannelArbiterImpl._SLACK`,
+currently 2). A single input is returned unchanged.
+
+## 5. Last-flit detection (auto from type)
+Helper `_flit_last`:
+- Inner type is a `Window` whose lowered frame struct exposes a `last` field ->
+  read `data.unwrap()["last"]` (the `last` convention on `Window`, `types.py`).
+- Plain (non-window) data -> constant `1` — each transfer is a complete message.
+- `Window` with no discoverable `last` field -> **raise** (fail loud), never
+  silently interleave list flits.
+
+## 6. Architecture
+```mermaid
+flowchart LR
+  I0[ch 0] --> B0[skid buf<br/>optional]
+  I1[ch 1] --> B1[skid buf<br/>optional]
+  In[ch N-1] --> Bn[skid buf<br/>optional]
+  B0 --> M[N:1 data mux]
+  B1 --> M
+  Bn --> M
+  B0 -. valid/last .-> A[Round-robin arbiter<br/>grant / busy / rr_ptr / credits<br/>registered]
+  B1 -. valid/last .-> A
+  Bn -. valid/last .-> A
+  A -- grant index --> M
+  M --> P[output reg]
+  P --> F[seq.FIFO<br/>depth = pipe latency + _SLACK]
+  F --> O[out]
+  F -. pop / not-empty .-> A
+  A -. taps .-> T[Telemetry]
+```
+**Feed-forward output stage.** The mux output is latched by a single register
+(fixed latency, *no* backpressure) into a seq `FIFO` (`seq.py`,
+`push`/`pop`/`full`/`empty`); the FIFO output is wrapped as a ValidReady channel
+for `out`. The FIFO beat is just the raw payload bits — for list/window payloads
+the `last` flag is already part of those bits, so it is not stored separately.
+The decoupling that makes the datapath feed-forward is the **FIFO plus credit
+counter**, not the register: because nothing downstream can stall the arbiter,
+the FIFO must have room for every in-flight beat, hence `depth = pipe_latency +
+_SLACK`, where `pipe_latency` is the one output register plus any selection-mux
+pipeline latency. A **credit counter** in the arbiter tracks
+launched-but-not-yet-drained beats:
+- `credit = depth`; decrement when the arbiter launches a beat, increment when
+  the FIFO is popped downstream.
+- The arbiter may launch only while `credit > 0`.
+
+**Zero-width (token) payloads.** A zero-width (`i0` "token") payload is the
+datapath case minus the data: there is nothing to buffer, so there is no
+pipeline and no FIFO -- the **credit counter itself is the token buffer**.
+`out_valid = credit < depth` (i.e. a beat is in flight) and `pop` increments
+credit exactly as in the datapath case, so the feed-forward property is
+unchanged. No filler beat is fabricated and no FIFO is built (`seq.FIFO`
+requires a non-zero width anyway).
+
+Downstream `ready`/pop reaches the arbiter only as a registered credit
+increment — never combinationally. That is what makes the component feed-forward
+regardless of the mux-tree pipeline depth.
+
+**Pipelineable selection mux.** By default the 1-of-N data selection is a flat
+`pycde.constructs.Mux(grant, *data)` (a single `hw.array_get`, which CIRCT
+lowers to an unpipelined mux tree). For very large fan-in that wide mux becomes
+the Fmax bottleneck. Setting `mux_pipeline_levels = k` instead builds the
+selection as an explicit balanced binary mux tree (2:1 nodes, one `grant` bit
+per level) with a pipeline register after every `k` levels; the `grant` bits are
+pipelined alongside the partial results so each level selects with the
+correctly-delayed index. The resulting `ceil(log2 N)/k`-ish cycles of latency
+are absorbed by the output FIFO / credit counter (the default `output_fifo_depth`
+grows to cover it), so throughput and correctness are unchanged — only latency
+grows. This selection-mux pipelining is separate from the single output register
+between the mux and the FIFO, which is always present. The narrow arbitration
+path (valid mux + round-robin priority encoder) remains combinational, but the
+priority encoder is itself a **balanced binary tree** (`O(log N)` depth, priority
+to the lower index) rather than an `O(N)` chain, so it scales to large `N`
+without dominating the arbitration path — and it is far narrower than the data
+mux regardless.
+
+## 7. Control — round-robin arbitration
+`round_robin(valids, start)` is **purely combinational** — it has no state of
+its own. It returns `(winner, any_valid)`: the lowest-index input that is *both*
+valid and at index `>= start`, or — if none qualifies — the lowest-index valid
+input overall (the wrap-around). It is two balanced priority encoders (§6, one
+over `valids & (index >= start)` and one over all `valids`) plus a mux, so a full
+cyclic scan is `O(log N)` deep. `start` is what rotates priority, making the
+arbiter fair rather than a fixed lowest-index-wins scheme.
+
+The state lives in the arbiter's registers, updated once per cycle by the
+next-state logic below:
+- `busy` (1 bit) — the only genuine FSM state: whether the output is currently
+  owned by an in-progress message.
+- `grant` (`ceil(log2 N)` bits) — index of the owning input. **This is the
+  register that holds the current grant.**
+- `rr_ptr` (`ceil(log2 N)` bits) — fairness pointer; the `start` fed to the idle
+  scan.
+- `credit` (§6) — the output-FIFO occupancy budget that gates launching.
+
+Each cycle the arbiter evaluates two speculative scans —
+`round_robin(valids, rr_ptr)` for the idle case and
+`round_robin(valids & ~grant_oh, grant+1)` for a back-to-back re-grant — and the
+1-bit `busy` state machine chooses between holding, latching, or dropping the
+grant. Each scan is a separate instance (`rr_idle` / `rr_next`) of a standalone
+combinational `RoundRobinArbiter` module, so both appear in the waveform
+hierarchy for debug:
+
+| State | Condition | Next state | `grant` | `rr_ptr` |
+|-------|-----------|------------|---------|----------|
+| **IDLE** (`~busy`) | no input valid | IDLE | hold | hold |
+| **IDLE** (`~busy`) | some input valid | BUSY | `round_robin(valids, rr_ptr)` | hold |
+| **BUSY** | flit not `last` (or launch stalled) | BUSY | hold | hold |
+| **BUSY** | `last` flit, another input waiting | BUSY | `round_robin(valids & ~grant_oh, grant+1)` | `grant+1` |
+| **BUSY** | `last` flit, none waiting | IDLE | (don't-care) | `grant+1` |
+
+Points the table glosses over:
+
+- **One-cycle arm.** `grant`/`busy` are registered, so the cycle an idle winner
+  is chosen only *latches* the grant; the first flit launches the next cycle
+  (`launch = busy & sel_valid & credit>0`).
+- **Re-grant with no bubble, and why the mask.** For list contiguity the grant is
+  held until a *launched* flit is tagged `last` (`reend = busy & msg_end`). On
+  that same cycle the next message is already arbitrated from `grant+1`, so
+  back-to-back messages see zero idle cycles. The scan masks the current owner
+  (`valids & ~grant_oh`) because that input still asserts `valid` on its
+  last-flit cycle (the flit is only consumed on the clock edge) — an unmasked
+  scan would re-select the input that is about to drain and wedge `busy` on it.
+- **Fairness.** `rr_ptr` advances to `grant+1` (wrapping `N-1 -> 0`) at every
+  message end, so the input just served is scanned *last* next time; no requester
+  is starved by a busier lower-index neighbour, and every waiting input is served
+  within one lap of the pointer.
+
+**Backpressure to producers.** `ready[i] = busy & grant_oh[i] & (credit>0)` — a
+single AND. `grant_oh[i]` is a **registered per-input one-hot** decode of the
+next grant (one register each), so this potentially high-fanout signal is a
+dedicated register bit near each producer rather than a shared combinational
+decode of `grant`. With `buffer_inputs=True` a 1-deep skid buffer localizes it
+further.
+
+## 8. Input buffering (optional)
+`buffer_inputs=True` (default, recommended for FMax) inserts a 1-deep skid buffer
+per input, localizing each producer's `ready`. Set it `False` when producers
+already batch/prepare their messages (e.g. accumulate a whole list before
+presenting it). Correctness and list-integrity are identical either way; only the
+timing/area tradeoff differs.
+
+## 9. Telemetry
+Emitted via `Telemetry.report_signal(clk, rst, AppID, data)` when
+`telemetry=True`. Each signal gets a leaf `AppID`; instances are disambiguated by
+their hierarchical appid path, so no per-instance name prefix is needed:
+- `selectedChannel` — registered `grant` index (current owner).
+- `busy` — output currently owned.
+- `grantCount_<i>` — served beats per input (traffic distribution / starvation).
+- `maxListLen` — running max of per-message flit count.
+- `totalFlits`, `totalMessages` — host computes average list length =
+  `totalFlits / totalMessages` (avoids a hardware divider).
+- `arbSwitches` — number of grant changes (contention indicator).
+- `inflightHighWater` — max output in-flight occupancy (`depth - credit`) to
+  right-size `output_fifo_depth`.
+
+Counters use `constructs.Counter`; max/high-water use a compare-and-update
+register. Zero hardware cost when `telemetry=False`.

--- a/lib/Dialect/ESI/runtime/python/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/python/CMakeLists.txt
@@ -13,6 +13,10 @@ set(ESIPythonRuntimeSources
   esiaccel/esitester.py
   esiaccel/types.py
   esiaccel/utils.py
+
+  esiaccel/components/__init__.py
+  esiaccel/components/channel_arbiter.py
+
   esiaccel/cosim/questa.py
   esiaccel/cosim/pytest.py
   esiaccel/cosim/simulator.py

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/__init__.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/__init__.py
@@ -1,0 +1,18 @@
+# ===- __init__.py - high-performance ESI component library ---------------===//
+#
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===//
+#
+#  A library of reusable, high-performance ESI hardware components built with
+#  PyCDE. These are timing-optimized building blocks (arbiters, muxes, buffers,
+#  ...) intended to be instantiated from BSPs and accelerator designs. Each
+#  component is documented under `docs/`.
+#
+# ===-----------------------------------------------------------------------===//
+
+from .channel_arbiter import ChannelArbiter, ChannelArbiterMod
+
+__all__ = ["ChannelArbiter", "ChannelArbiterMod"]

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
@@ -149,7 +149,7 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
                       telemetry: bool, mux_pipeline_levels: Optional[int]):
   """Build a pipelined, list-aware N:1 channel multiplexer module. See the
   `ChannelArbiter` convenience function for the user-facing entry point and
-  `docs/ChannelArbiter.md` for the design."""
+  `docs/components/ChannelArbiter.md` for the design."""
 
   assert num_inputs >= 2, "ChannelArbiterMod requires at least two inputs"
   inner = channel_type.inner_type
@@ -448,7 +448,7 @@ def ChannelArbiter(input_channels: List[ChannelSignal],
       credit counter. `None` (default) uses a flat combinational mux.
     telemetry: emit telemetry (selected channel, list-length stats, etc.).
 
-  See `docs/ChannelArbiter.md`."""
+  See `docs/components/ChannelArbiter.md`."""
 
   assert len(input_channels) > 0
   num_inputs = len(input_channels)

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
@@ -1,0 +1,475 @@
+# ===- channel_arbiter.py - pipelined list-aware channel mux -------------===//
+#
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===//
+#
+#  A high-performance, pipelined, list-aware N:1 ESI channel multiplexer. See
+#  `docs/components/ChannelArbiter.md` for the design details.
+#
+# ===----------------------------------------------------------------------===//
+
+from typing import List, Optional, Tuple
+
+from pycde import AppID, Clock, Input, Module, Output, Reset, generator
+from pycde.constructs import Counter, Mux, Reg, Wire
+from pycde.esi import Telemetry
+from pycde.module import modparams
+from pycde.seq import FIFO as SeqFIFO
+from pycde.signals import BitsSignal, ChannelSignal, ClockSignal, Signal
+from pycde.support import clog2
+from pycde.types import (Array, Bits, Channel, ChannelSignaling, StructType,
+                         UInt, Window)
+
+
+def _select_reg_levels(num_inputs: int,
+                       mux_pipeline_levels: Optional[int]) -> List[int]:
+  """Tree levels after which `_select_mux` inserts a pipeline register.
+
+  A register is placed after every `mux_pipeline_levels` levels, except after
+  the final (root) level -- its result is registered downstream. This is the
+  single source of truth for the mux-tree pipelining: `_select_mux` builds the
+  registers at these levels and `_select_latency` just counts them."""
+  if num_inputs <= 1 or not mux_pipeline_levels:
+    return []
+  gw = clog2(num_inputs)
+  return [
+      level for level in range(gw)
+      if (level + 1) % mux_pipeline_levels == 0 and level < gw - 1
+  ]
+
+
+def _select_latency(num_inputs: int, mux_pipeline_levels: Optional[int]) -> int:
+  """Pipeline-register latency (cycles) that `_select_mux` inserts."""
+  return len(_select_reg_levels(num_inputs, mux_pipeline_levels))
+
+
+def _select_mux(sel: BitsSignal, values: List[BitsSignal], clk: ClockSignal,
+                rst: Signal, mux_pipeline_levels: Optional[int]) -> BitsSignal:
+  """Return `values[sel]`.
+
+  With `mux_pipeline_levels` falsy this is a flat combinational mux (a single
+  `hw.array_get`, which CIRCT lowers to an unpipelined mux tree). Otherwise it
+  is built as an explicit balanced binary mux tree -- 2:1 nodes consuming one
+  `sel` bit per level -- with a pipeline register inserted after every
+  `mux_pipeline_levels` levels. This lets a large/wide selection mux (the
+  Fmax bottleneck of a big fan-in mux) be retimed across registers. The
+  remaining `sel` bits are pipelined alongside the partial results so each
+  level selects with the correctly-delayed index. The added latency is
+  `_select_latency(len(values), mux_pipeline_levels)` cycles."""
+  n = len(values)
+  if n == 1:
+    return values[0]
+  if not mux_pipeline_levels:
+    return Mux(sel, *values)
+  gw = clog2(n)
+  reg_levels = set(_select_reg_levels(n, mux_pipeline_levels))
+  # Pad to a full 2**gw-leaf tree; padded leaves carry a never-selected copy
+  # (the index is always < n).
+  cur = list(values) + [values[0]] * ((1 << gw) - n)
+  rem = sel
+  for level in range(gw):
+    bit = rem[0]
+    cur = [Mux(bit, cur[2 * i], cur[2 * i + 1]) for i in range(len(cur) // 2)]
+    if rem.type.width > 1:
+      rem = rem[1:]
+    if level in reg_levels:
+      cur = [c.reg(clk, rst) for c in cur]
+      rem = rem.reg(clk, rst)
+  return cur[0]
+
+
+@modparams
+def RoundRobinArbiterMod(num_inputs: int):
+  """Combinational round-robin winner selection, factored into its own module
+  for waveform visibility.
+
+  Given a per-input `valids` bitmask (bit `i` is input `i`) and a `start` index,
+  `winner` is the lowest-index input that is valid and at index `>= start`
+  (cyclically), falling back to the lowest-index valid input overall; `any_valid`
+  is high when any input is valid. Purely combinational -- the owning state
+  (`grant`/`busy`/`rr_ptr`) lives in the arbiter."""
+  assert num_inputs >= 2, "RoundRobinArbiterMod requires at least two inputs"
+  gw = clog2(num_inputs)
+
+  class RoundRobinArbiter(Module):
+    valids = Input(Bits(num_inputs))
+    start = Input(Bits(gw))
+    winner = Output(Bits(gw))
+    any_valid = Output(Bits(1))
+
+    @generator
+    def build(ports) -> None:
+
+      def priority_lsb(
+          bits_list: List[BitsSignal]) -> Tuple[BitsSignal, BitsSignal]:
+        """Index of the lowest-index set bit, plus an any-set flag, computed as
+        a balanced binary tree (O(log N) depth) rather than an O(N) chain. Each
+        node combines two subtrees, giving priority to the lower index, and
+        prefixes the selected sub-index with the branch bit."""
+        # Leaves carry (any, sub-index); pad up to 2**gw with never-set leaves
+        # so the tree is perfect and each level consumes one index bit.
+        level = [(b, None) for b in bits_list]
+        level += [(Bits(1)(0), None) for _ in range((1 << gw) - len(bits_list))]
+        width = 0
+        while len(level) > 1:
+          nxt = []
+          for j in range(0, len(level), 2):
+            la, li = level[j]
+            ra, ri = level[j + 1]
+            # The lower-index (left) subtree wins if it has any set bit.
+            take_right = ~la
+            if width == 0:
+              idx = take_right
+            else:
+              idx = BitsSignal.concat([take_right, Mux(take_right, li, ri)])
+            nxt.append((la | ra, idx))
+          level = nxt
+          width += 1
+        idx = level[0][1]
+        return (idx if idx is not None else Bits(gw)(0)), level[0][0]
+
+      valid_bits = [ports.valids[i] for i in range(num_inputs)]
+      start_u = ports.start.as_uint(gw)
+      # Winner among inputs at-or-after `start`, else the lowest-index winner.
+      hi = [valid_bits[i] & (UInt(gw)(i) >= start_u) for i in range(num_inputs)]
+      hi_idx, hi_any = priority_lsb(hi)
+      lo_idx, lo_any = priority_lsb(valid_bits)
+      ports.winner = Mux(hi_any, lo_idx, hi_idx)
+      ports.any_valid = hi_any | lo_any
+
+  return RoundRobinArbiter
+
+
+@modparams
+def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
+                      output_fifo_depth: int, buffer_inputs: bool,
+                      telemetry: bool, mux_pipeline_levels: Optional[int]):
+  """Build a pipelined, list-aware N:1 channel multiplexer module. See the
+  `ChannelArbiter` convenience function for the user-facing entry point and
+  `docs/ChannelArbiter.md` for the design."""
+
+  assert num_inputs >= 2, "ChannelArbiterMod requires at least two inputs"
+  inner = channel_type.inner_type
+
+  # Determine the bit width of the datapath and whether the payload is a list
+  # window (which carries a per-flit 'last' field).
+  is_window = isinstance(inner, Window)
+  if is_window:
+    lowered = inner.lowered_type
+    field_names = [n for n, _ in lowered.fields] if isinstance(
+        lowered, StructType) else None
+    if field_names is None or "last" not in field_names:
+      raise TypeError(
+          "ChannelArbiter can only auto-detect list framing for window types "
+          "whose lowered frame is a struct with a 'last' field; got lowered "
+          f"type {lowered}. (Serial/union-framed windows are not supported.)")
+    width = lowered.bitwidth
+  else:
+    width = inner.bitwidth
+  if width is None:
+    raise TypeError(
+        f"ChannelArbiter requires a fixed-width payload; got {inner}")
+
+  # The FIFO beat is just the raw payload bits (for list/window payloads the
+  # per-flit 'last' flag is already part of them). A zero-width (token) payload
+  # carries no data, so it has no beat/FIFO at all -- the output stage uses an
+  # outstanding-beat counter instead (SeqFIFO also requires a non-zero width).
+  beat_type = Bits(width)
+
+  # Input-index width. (The credit-counter width depends on the resolved
+  # output-FIFO depth and is computed in the generator.)
+  gw = clog2(num_inputs)
+
+  # Latency (cycles) added when the selection mux is pipelined into a tree.
+  tree_latency = (0 if width == 0 else _select_latency(num_inputs,
+                                                       mux_pipeline_levels))
+  # One register latches the mux result before the FIFO, so the total
+  # launch-to-FIFO pipeline latency is the mux-tree latency plus one.
+  pipe_latency = tree_latency + 1
+  if output_fifo_depth is not None and \
+      output_fifo_depth <= pipe_latency:
+    raise ValueError(
+        f"output_fifo_depth ({output_fifo_depth}) must be > the pipeline "
+        f"latency ({pipe_latency})")
+
+  class ChannelArbiterImpl(Module):
+    # Extra output-FIFO depth over the pipeline length, covering the credit
+    # round-trip; private and class-scoped.
+    _SLACK = 2
+
+    clk = Clock()
+    rst = Reset()
+
+    inputs = Input(Array(channel_type, num_inputs))
+    output = Output(channel_type)
+
+    @generator
+    def build(ports) -> None:
+      # Resolve the output-FIFO depth (defaulting from the private,
+      # class-scoped `_SLACK`, and covering the pipeline latency) and the
+      # credit-counter width.
+      depth = (pipe_latency + ChannelArbiterImpl._SLACK
+               if output_fifo_depth is None else output_fifo_depth)
+      cw = max(1, depth.bit_length())
+      clk = ports.clk
+      rst = ports.rst
+
+      def flit_last(typed_sig: Signal) -> BitsSignal:
+        """High when 'typed_sig' is the last flit of its message."""
+        if is_window:
+          return typed_sig.unwrap()["last"]
+        return Bits(1)(1)
+
+      def to_bits(typed_sig: Signal) -> BitsSignal:
+        """Bitcast the payload to raw bits for the datapath."""
+        if is_window:
+          typed_sig = typed_sig.unwrap()
+        return typed_sig.bitcast(Bits(width))
+
+      def from_bits(bits: BitsSignal) -> Signal:
+        """Reconstruct the payload from raw bits for the output channel."""
+        if is_window:
+          return inner.wrap(bits.bitcast(inner.lowered_type))
+        return bits.bitcast(inner)
+
+      # ---- Registered arbiter state (Reg: read now, next-state assigned
+      # below). ----
+      grant = Reg(Bits(gw), clk, rst, name="grant")
+      busy = Reg(Bits(1), clk, rst, name="busy")
+      rr_ptr = Reg(Bits(gw), clk, rst, name="rr_ptr")
+      credit = Reg(UInt(cw), clk, rst, rst_value=depth, name="credit")
+
+      credit_gt0 = credit > UInt(cw)(0)
+
+      # ---- Inputs: optional skid buffer, then unwrap with a local ready. ----
+      # Per-input one-hot grant, registered below (one register each) so these
+      # potentially high-fanout signals are not a shared combinational decode.
+      grant_is = [
+          Reg(Bits(1),
+              clk,
+              rst,
+              rst_value=(1 if i == 0 else 0),
+              name=f"grant_oh_{i}") for i in range(num_inputs)
+      ]
+      valids: List[BitsSignal] = []
+      last_bits: List[BitsSignal] = []
+      data_bits: List[BitsSignal] = []
+      for i in range(num_inputs):
+        chan = ports.inputs[i]
+        if buffer_inputs:
+          chan = chan.buffer(clk, rst, stages=1)
+        # ready[i]: consume only the granted input, and only when a credit is
+        # available. Independent of valid, so no combinational ready loop.
+        ready_i = busy & grant_is[i] & credit_gt0
+        data_i, valid_i = chan.unwrap(ready_i)
+        valids.append(valid_i)
+        last_bits.append(flit_last(data_i))
+        data_bits.append(to_bits(data_i))
+
+      # ---- Select the granted input. ----
+      sel_valid = Mux(grant, *valids)
+      sel_last = Mux(grant, *last_bits)
+      if width == 0:
+        sel_bits = Bits(0)(0)
+      else:
+        sel_bits = _select_mux(grant, data_bits, clk, rst, mux_pipeline_levels)
+
+      # A beat is launched into the pipeline when the granted input is valid and
+      # a credit is available.
+      launch = busy & sel_valid & credit_gt0
+      msg_end = launch & sel_last
+
+      # ---- Output stage (feed-forward, no backpressure). ----
+      # `pop` returns to the arbiter only through the registered credit counter,
+      # so the datapath never stalls. The zero-width case is the datapath case
+      # minus the data: no pipeline and no FIFO -- the credit counter itself is
+      # the token buffer, and a token is available whenever one is in flight.
+      if width == 0:
+        out_valid = credit < UInt(cw)(depth)  # in-flight (depth - credit) > 0
+        payload_bits = Bits(0)(0)
+        fifo_pop = None
+      else:
+        # Delay the launch/valid to match the mux-tree pipeline, add one output
+        # register, then buffer the beat in the FIFO.
+        pipe_valid = launch
+        for _ in range(tree_latency):
+          pipe_valid = pipe_valid.reg(clk, rst)
+        pipe_valid = pipe_valid.reg(clk, rst, name="pipe_valid")
+        pipe_beat = sel_bits.reg(clk, rst, name="pipe_beat")
+        fifo = SeqFIFO(beat_type, depth, clk, rst)
+        fifo.push(pipe_beat, pipe_valid)
+        fifo_pop = Wire(Bits(1), "arb_pop")
+        out_valid = ~fifo.empty
+        payload_bits = fifo.pop(fifo_pop)
+
+      out_chan, out_ready = channel_type.wrap(from_bits(payload_bits),
+                                              out_valid)
+      ports.output = out_chan
+      pop = out_valid & out_ready
+      if fifo_pop is not None:
+        fifo_pop.assign(pop)
+
+      # ---- Credit accounting: credit = depth - in-flight. ----
+      next_credit = ((credit + pop.as_uint(cw)).as_uint(cw) -
+                     launch.as_uint(cw)).as_uint(cw)
+      credit.assign(next_credit)
+
+      # ---- Round-robin arbitration (own module for waveform visibility). ----
+      rr_arbiter = RoundRobinArbiterMod(num_inputs)
+
+      def round_robin(valid_list: List[BitsSignal], start: BitsSignal,
+                      name: str) -> Tuple[BitsSignal, BitsSignal]:
+        """Instantiate a RoundRobinArbiter over `valid_list` (packed into a
+        bit-bus, bit `i` == input `i`) starting from `start`."""
+        valids_vec = BitsSignal.concat(list(reversed(valid_list)))
+        inst = rr_arbiter(valids=valids_vec, start=start, instance_name=name)
+        return inst.winner, inst.any_valid
+
+      grant_u = grant.as_uint(gw)
+      is_last_idx = grant == Bits(gw)(num_inputs - 1)
+      grant_p1 = Mux(is_last_idx, (grant_u + UInt(gw)(1)).as_bits(gw),
+                     Bits(gw)(0))
+
+      winner_idle, any_idle = round_robin(valids, rr_ptr, "rr_idle")
+      # At a message end the just-consumed input still asserts `valid` this
+      # cycle (the flit is consumed on the clock edge), so mask it out of the
+      # re-arbitration. Otherwise the round-robin wrap-around would
+      # speculatively re-grant that stale valid and the FSM would get stuck
+      # `busy` on an input that goes empty next cycle. A genuinely backlogged
+      # input is re-selected on the following idle cycle instead.
+      valids_next = [valids[i] & ~grant_is[i] for i in range(num_inputs)]
+      winner_next, any_next = round_robin(valids_next, grant_p1, "rr_next")
+
+      pick = ~busy & any_idle
+      reend = busy & msg_end
+      grant_if_not_reend = Mux(pick, grant, winner_idle)
+      next_grant = Mux(reend, grant_if_not_reend, winner_next)
+      busy_if_not_reend = Mux(pick, busy, Bits(1)(1))
+      next_busy = Mux(reend, busy_if_not_reend, any_next)
+      next_rr = Mux(reend, rr_ptr, grant_p1)
+
+      grant.assign(next_grant)
+      busy.assign(next_busy)
+      rr_ptr.assign(next_rr)
+
+      # Register the one-hot grant decode -- one register per input -- so each
+      # (potentially high-fanout) per-input grant signal is driven by its own
+      # register instead of a shared combinational decode of `grant`. Fed from
+      # the same next-state, so it stays coherent with `grant` (== grant == i).
+      for i in range(num_inputs):
+        grant_is[i].assign(next_grant == Bits(gw)(i))
+
+      # ---- Telemetry. ----
+      if telemetry:
+        Telemetry.report_signal(clk, rst, AppID("selectedChannel"), grant)
+        Telemetry.report_signal(clk, rst, AppID("busy"), busy)
+
+        for i in range(num_inputs):
+          served = Counter(64)(clk=clk,
+                               rst=rst,
+                               clear=Bits(1)(0),
+                               increment=launch & grant_is[i])
+          Telemetry.report_signal(clk, rst, AppID(f"grantCount_{i}"),
+                                  served.out)
+
+        total_flits = Counter(64)(clk=clk,
+                                  rst=rst,
+                                  clear=Bits(1)(0),
+                                  increment=launch)
+        Telemetry.report_signal(clk, rst, AppID("totalFlits"), total_flits.out)
+        total_msgs = Counter(64)(clk=clk,
+                                 rst=rst,
+                                 clear=Bits(1)(0),
+                                 increment=msg_end)
+        Telemetry.report_signal(clk, rst, AppID("totalMessages"),
+                                total_msgs.out)
+        arb_switches = Counter(64)(clk=clk,
+                                   rst=rst,
+                                   clear=Bits(1)(0),
+                                   increment=pick | (reend & any_next))
+        Telemetry.report_signal(clk, rst, AppID("arbSwitches"),
+                                arb_switches.out)
+
+        # Max per-message flit count.
+        cur_len = Counter(32)(clk=clk, rst=rst, clear=msg_end, increment=launch)
+        msg_len = (cur_len.out + UInt(32)(1)).as_uint(32)
+        max_len = Reg(UInt(32), clk, rst, rst_value=0, name="max_list_len")
+        is_new_max = msg_end & (msg_len > max_len)
+        max_len.assign(Mux(is_new_max, max_len, msg_len))
+        Telemetry.report_signal(clk, rst, AppID("maxListLen"), max_len)
+
+        # Max output in-flight occupancy (depth - credit).
+        occ = (UInt(cw)(depth) - credit).as_uint(cw)
+        inflight_hw = Reg(UInt(cw), clk, rst, rst_value=0, name="inflight_hw")
+        is_new_hw = occ > inflight_hw
+        inflight_hw.assign(Mux(is_new_hw, inflight_hw, occ))
+        Telemetry.report_signal(clk, rst, AppID("inflightHighWater"),
+                                inflight_hw)
+
+  return ChannelArbiterImpl
+
+
+def ChannelArbiter(input_channels: List[ChannelSignal],
+                   clk: ClockSignal,
+                   rst: Signal,
+                   *,
+                   appid: Optional[AppID] = None,
+                   output_fifo_depth: Optional[int] = None,
+                   buffer_inputs: bool = True,
+                   mux_pipeline_levels: Optional[int] = None,
+                   telemetry: bool = True) -> ChannelSignal:
+  """Build a pipelined, list-aware N:1 channel multiplexer.
+
+  Unlike the combinational `pycde.esi.ChannelMux`, this is a flat registered
+  round-robin arbiter with a feed-forward output stage (output register + FIFO
+  + credit counter), so it closes timing at high fan-in. It also keeps
+  multi-flit list messages contiguous: once an input is granted, it holds the
+  output until a flit whose 'last' field is set has been transferred. List
+  framing is auto-detected from the channel type (window payloads with a 'last'
+  field); all other payloads are treated as single-flit messages.
+
+  Arguments:
+    input_channels: the channels to multiplex. All must share the same
+      (ValidReady) type.
+    clk, rst: clock and reset.
+    appid: optional `AppID` for the arbiter instance (e.g. to address it or to
+      disambiguate its telemetry in the appid hierarchy).
+    output_fifo_depth: depth of the output FIFO; must be greater than the
+      pipeline latency (one output register plus any selection-mux pipeline
+      latency). Defaults to that plus a small internal slack.
+    buffer_inputs: insert a per-input skid buffer to localize backpressure.
+    mux_pipeline_levels: if set, build the N:1 data-selection mux as an explicit
+      binary tree and insert a pipeline register after every this-many tree
+      levels (1 = register every level). This retimes the wide selection mux
+      for very large fan-in; the added latency is absorbed by the output FIFO /
+      credit counter. `None` (default) uses a flat combinational mux.
+    telemetry: emit telemetry (selected channel, list-length stats, etc.).
+
+  See `docs/ChannelArbiter.md`."""
+
+  assert len(input_channels) > 0
+  num_inputs = len(input_channels)
+  if num_inputs == 1:
+    return input_channels[0]
+
+  channel_type = input_channels[0].type
+  for c in input_channels:
+    if c.type != channel_type:
+      raise TypeError("All ChannelArbiter inputs must have the same type; got "
+                      f"{channel_type} and {c.type}")
+  if channel_type.signaling != ChannelSignaling.ValidReady:
+    raise TypeError("ChannelArbiter requires ValidReady channels; got "
+                    f"{channel_type}")
+
+  if mux_pipeline_levels is not None and mux_pipeline_levels < 1:
+    raise ValueError(
+        f"mux_pipeline_levels must be >= 1, got {mux_pipeline_levels}")
+
+  mod = ChannelArbiterMod(channel_type, num_inputs, output_fifo_depth,
+                          buffer_inputs, telemetry, mux_pipeline_levels)
+  inputs_array = Array(channel_type, num_inputs)(input_channels)
+  inst = mod(clk=clk, rst=rst, inputs=inputs_array, appid=appid)
+  return inst.output

--- a/lib/Dialect/ESI/runtime/tests/integration/hw/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/hw/channel_arbiter.py
@@ -1,0 +1,297 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Hardware for the ChannelArbiter cosim integration tests. Builds two
+# independent DUTs under a single top:
+#
+#   * ChannelArbiterTest ("arbiter_test"): NUM_INPUTS host-driven `from_host`
+#     UInt(32) channels multiplexed into a single `to_host` channel. The host
+#     checks that every value is delivered exactly once (no loss / duplication).
+#     Instantiated twice: a power-of-two ("balanced") count and a
+#     non-power-of-two ("unbalanced") count.
+#
+#   * ChannelArbiterListTest ("list_test"): two in-hardware list-window
+#     producers (distinct `src` ids and message lengths) contend for the
+#     arbiter. A hardware checker verifies that, once a message is granted, its
+#     flits arrive contiguously (no interleaving) up to the flit tagged `last`,
+#     and reports (sticky-error, src, count) per completed message on a
+#     `to_host` channel.
+#
+#   * ChannelArbiterTokenTest ("token_test"): TOKEN_NUM_INPUTS in-hardware
+#     zero-width (`i0`) token producers, each emitting exactly TOKENS_PER_INPUT
+#     tokens, contend for the arbiter. A hardware counter reports a running
+#     1-based ordinal per delivered token, so the host can confirm every token
+#     is delivered exactly once (conservation) and every producer is served
+#     (no starvation) -- exercising the credit-counter-as-buffer i0 path.
+
+import sys
+
+from pycde import (AppID, Clock, Input, Module, Output, Reset, System,
+                   generator)
+from pycde.constructs import Counter, Mux, Wire
+from pycde.types import Bits, Channel, List as ListType, StructType, UInt, Window
+from pycde import esi
+
+from esiaccel.bsp import get_bsp
+from esiaccel.components import ChannelArbiter
+
+NUM_INPUTS = 4  # power-of-two ("balanced") input count.
+ODD_NUM_INPUTS = 3  # non-power-of-two ("unbalanced") input count.
+PIPE_NUM_INPUTS = 6  # input count for the pipelined-mux-tree variant.
+TOKEN_NUM_INPUTS = 5  # input count for the zero-width (i0) token variant.
+TOKENS_PER_INPUT = 8  # tokens each producer emits in the token test.
+
+# A list-window payload: a struct with a `src` tag and a variable-length list.
+# `Window.default_of` adds a per-flit `last` field to the lowered frame struct,
+# which is exactly what `ChannelArbiter` uses to keep messages contiguous.
+ListInto = StructType({'src': UInt(8), 'items': ListType(UInt(16))})
+Flit = Window.default_of(ListInto)
+FlitLowered = Flit.lowered_type  # struct<src: ui8, items: ui16, last: i1>
+
+
+def HostMux(num_inputs: int, mux_pipeline_levels=None):
+  """A host-driven single-flit multiplexer: `num_inputs` `from_host` UInt(32)
+  channels muxed into a single `to_host` channel. `mux_pipeline_levels` pipelines
+  the selection mux tree."""
+
+  class HostMux(Module):
+    clk = Clock()
+    rst = Reset()
+
+    @generator
+    def build(ports):
+      ins = [
+          esi.ChannelService.from_host(AppID(f"in_{i}"), UInt(32))
+          for i in range(num_inputs)
+      ]
+      out = ChannelArbiter(ins,
+                           ports.clk,
+                           ports.rst,
+                           mux_pipeline_levels=mux_pipeline_levels,
+                           telemetry=False)
+      esi.ChannelService.to_host(AppID("out"), out)
+
+  HostMux.__name__ = f"HostMux_{num_inputs}_{mux_pipeline_levels}"
+  return HostMux
+
+
+def ListProducer(src_id: int, length: int):
+  """A module which continuously emits back-to-back list messages of `length`
+  flits tagged with `src_id`. `items` counts 0..length-1 and `last` is set on
+  the final flit. Always valid, so two of these contend for the arbiter."""
+
+  class ListProducer(Module):
+    clk = Clock()
+    rst = Reset()
+    out = Output(Channel(Flit))
+
+    @generator
+    def build(ports):
+      i = Wire(UInt(8))
+      last = i == UInt(8)(length - 1)
+      st = FlitLowered({
+          'src': UInt(8)(src_id),
+          'items': i.as_uint(16),
+          'last': last,
+      })
+      chan, ready = Channel(Flit).wrap(Flit.wrap(st), Bits(1)(1))
+      ports.out = chan
+      # valid is constant 1, so a transaction happens whenever `ready`.
+      nxt = Mux(last, (i + UInt(8)(1)).as_uint(8), UInt(8)(0))
+      i.assign(nxt.reg(ports.clk, ports.rst, ce=ready, rst_value=0))
+
+  ListProducer.__name__ = f"ListProducer_src{src_id}_len{length}"
+  return ListProducer
+
+
+class ListChecker(Module):
+  """Consumes the muxed list-window stream and verifies message contiguity.
+
+  Emits one UInt(32) report per completed message:
+    bit  24    : sticky interleave-error flag (should stay 0)
+    bits 23:16 : src of the completed message
+    bits 15:0  : running completed-message count
+  """
+
+  clk = Clock()
+  rst = Reset()
+  in_ = Input(Channel(Flit))
+  report = Output(Channel(UInt(32)))
+
+  @generator
+  def build(ports):
+    active = Wire(Bits(1))
+    err = Wire(Bits(1))
+
+    in_ready = Wire(Bits(1))
+    win, valid = ports.in_.unwrap(in_ready)
+    st = win.unwrap()
+    src = st['src']
+    last = st['last']
+
+    # A message boundary: the current flit completes a message.
+    is_completing = valid & last
+    # Emit a report exactly when a message completes; back-pressure the input
+    # on that flit until the report is accepted.
+    report_valid = is_completing
+
+    # src of the in-progress message, latched at its first flit.
+    start_any = valid & in_ready & ~active
+    cur_src = src.reg(ports.clk, ports.rst, ce=start_any, rst_value=0)
+
+    # Interleave error: a flit whose src differs from the owner mid-message.
+    interleave_err = (valid & in_ready) & active & (src != cur_src)
+    err.assign((err | interleave_err).reg(ports.clk, ports.rst, rst_value=0))
+
+    # `active` tracks whether we are mid-message (past the first flit, before
+    # `last`).
+    xact = valid & in_ready
+    begin_multi = xact & ~active & ~last
+    end_msg = xact & last
+    active_next = Mux(end_msg, Mux(begin_multi, active, Bits(1)(1)), Bits(1)(0))
+    active.assign(active_next.reg(ports.clk, ports.rst, rst_value=0))
+
+    # Completed-message counter.
+    msg_count = Counter(16)(clk=ports.clk,
+                            rst=ports.rst,
+                            clear=Bits(1)(0),
+                            increment=end_msg)
+
+    report_data = ((err.as_uint(32) * UInt(32)(0x1000000)).as_uint(32) +
+                   (cur_src.as_uint(32) * UInt(32)(0x10000)).as_uint(32) +
+                   msg_count.out.as_uint(32)).as_uint(32)
+    report_chan, report_ready = Channel(UInt(32)).wrap(report_data,
+                                                       report_valid)
+    ports.report = report_chan
+
+    # Accept every non-completing flit; on a completing flit, only accept when
+    # the report is accepted so no completion is dropped.
+    in_ready.assign(Mux(is_completing, Bits(1)(1), report_ready))
+
+
+class ChannelArbiterListTest(Module):
+  """Two contending list producers -> arbiter -> contiguity checker."""
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def build(ports):
+    p0 = ListProducer(1, 3)(clk=ports.clk, rst=ports.rst)
+    p1 = ListProducer(2, 4)(clk=ports.clk, rst=ports.rst)
+    muxed = ChannelArbiter([p0.out, p1.out],
+                           ports.clk,
+                           ports.rst,
+                           telemetry=False)
+    chk = ListChecker(clk=ports.clk, rst=ports.rst, in_=muxed)
+    esi.ChannelService.to_host(AppID("report"), chk.report)
+
+
+def TokenProducer(count: int):
+  """Emits exactly `count` zero-width (`i0`) tokens then idles: `valid` stays
+  high until `count` tokens have been accepted. There is no payload -- only the
+  valid/ready handshake carries information."""
+
+  class TokenProducer(Module):
+    clk = Clock()
+    rst = Reset()
+    out = Output(Channel(Bits(0)))
+
+    @generator
+    def build(ports):
+      xact = Wire(Bits(1))
+      sent = Counter(16)(clk=ports.clk,
+                         rst=ports.rst,
+                         clear=Bits(1)(0),
+                         increment=xact)
+      valid = sent.out < UInt(16)(count)
+      chan, ready = Channel(Bits(0)).wrap(Bits(0)(0), valid)
+      ports.out = chan
+      xact.assign(valid & ready)
+
+  TokenProducer.__name__ = f"TokenProducer_{count}"
+  return TokenProducer
+
+
+class TokenChecker(Module):
+  """Consumes the muxed zero-width token stream and emits one UInt(32) report
+  per delivered token carrying its 1-based ordinal (1, 2, 3, ...). Backpressure
+  from the report channel is fed to the arbiter, exercising its credit buffer.
+  """
+
+  clk = Clock()
+  rst = Reset()
+  in_ = Input(Channel(Bits(0)))
+  report = Output(Channel(UInt(32)))
+
+  @generator
+  def build(ports):
+    in_ready = Wire(Bits(1))
+    _tok, valid = ports.in_.unwrap(in_ready)  # zero-width payload: ignore data.
+
+    # Running count of delivered tokens; this token's ordinal is count + 1.
+    count = Counter(32)(clk=ports.clk,
+                        rst=ports.rst,
+                        clear=Bits(1)(0),
+                        increment=valid & in_ready)
+    report_data = (count.out + UInt(32)(1)).as_uint(32)
+    report_chan, report_ready = Channel(UInt(32)).wrap(report_data, valid)
+    ports.report = report_chan
+    # Accept a token exactly when its report is consumed by the host.
+    in_ready.assign(report_ready)
+
+
+class ChannelArbiterTokenTest(Module):
+  """`TOKEN_NUM_INPUTS` bounded zero-width token producers -> arbiter -> token
+  counter. Each producer emits exactly `TOKENS_PER_INPUT` tokens, so the host
+  must see exactly TOKEN_NUM_INPUTS * TOKENS_PER_INPUT tokens: no loss or
+  duplication (conservation), and every producer served (no starvation, since
+  the total can only be reached if each producer's tokens all get through)."""
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def build(ports):
+    prods = [
+        TokenProducer(TOKENS_PER_INPUT)(clk=ports.clk, rst=ports.rst)
+        for _ in range(TOKEN_NUM_INPUTS)
+    ]
+    muxed = ChannelArbiter([p.out for p in prods],
+                           ports.clk,
+                           ports.rst,
+                           telemetry=False)
+    chk = TokenChecker(clk=ports.clk, rst=ports.rst, in_=muxed)
+    esi.ChannelService.to_host(AppID("token_report"), chk.report)
+
+
+class Top(Module):
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def construct(ports):
+    HostMux(NUM_INPUTS)(clk=ports.clk,
+                        rst=ports.rst,
+                        appid=AppID("arbiter_test"))
+    HostMux(ODD_NUM_INPUTS)(clk=ports.clk,
+                            rst=ports.rst,
+                            appid=AppID("arbiter_test_odd"))
+    HostMux(PIPE_NUM_INPUTS,
+            mux_pipeline_levels=1)(clk=ports.clk,
+                                   rst=ports.rst,
+                                   appid=AppID("arbiter_test_pipe"))
+    ChannelArbiterListTest(clk=ports.clk,
+                           rst=ports.rst,
+                           appid=AppID("list_test"))
+    ChannelArbiterTokenTest(clk=ports.clk,
+                            rst=ports.rst,
+                            appid=AppID("token_test"))
+
+
+if __name__ == "__main__":
+  bsp = get_bsp(sys.argv[2] if len(sys.argv) > 2 else None)
+  s = System(bsp(Top), name="ChannelArbiterTest", output_directory=sys.argv[1])
+  s.compile()
+  s.package()

--- a/lib/Dialect/ESI/runtime/tests/integration/test_channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_channel_arbiter.py
@@ -52,8 +52,8 @@ def _check_mux(conn: AcceleratorConnection, dut_name: str,
     p.connect()
   out.connect()
 
-  # The value encodes its source input in bits [17:16] and a round counter in
-  # the low bits, so the received multiset uniquely identifies every message.
+  # The value encodes its source input in the upper bits (i << 16) and a round
+  # counter in the low bits, so the received multiset uniquely identifies every message.
   rounds = 6
   writes = [
       ((i << 16) | r, ins[i]) for r in range(rounds) for i in range(num_inputs)
@@ -78,7 +78,7 @@ def _check_mux(conn: AcceleratorConnection, dut_name: str,
   assert sorted(recv) == sorted(sent), \
       "arbiter dropped, duplicated or corrupted a value"
 
-  # Every input (encoded in bits [17:16]) is served exactly `rounds` times.
+  # Every input (decoded by v >> 16) is served exactly `rounds` times.
   by_src = Counter(v >> 16 for v in recv)
   for i in range(num_inputs):
     assert by_src[i] == rounds, \

--- a/lib/Dialect/ESI/runtime/tests/integration/test_channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_channel_arbiter.py
@@ -1,0 +1,142 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Cosim integration tests for `esiaccel.components.ChannelArbiter`.
+
+Runs under Verilator via the `@cosim_test` harness. Two DUTs (built by
+`hw/channel_arbiter.py`) are exercised:
+
+  * `arbiter_test` / `arbiter_test_odd`: host-driven single-flit multiplexers
+    with a power-of-two ('balanced') and non-power-of-two ('unbalanced') input
+    count. The host writes distinct tagged values to each input and checks that
+    every value comes out of the single output exactly once (no loss /
+    duplication) and that every input is served.
+
+  * `list_test`: two in-hardware list-window producers contend for the
+    arbiter; a hardware checker verifies message contiguity and streams a
+    per-message report back to the host.
+
+  * `token_test`: several in-hardware zero-width (`i0`) token producers, each
+    emitting a fixed number of tokens, contend for the arbiter. A hardware
+    counter reports a running ordinal per delivered token so the host can
+    confirm every token is delivered exactly once and every producer is served.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import esiaccel
+from esiaccel.accelerator import AcceleratorConnection
+from esiaccel.cosim.pytest import cosim_test
+
+HW_DIR = Path(__file__).resolve().parent / "hw"
+
+NUM_INPUTS = 4  # power-of-two ("balanced") input count.
+ODD_NUM_INPUTS = 3  # non-power-of-two ("unbalanced") input count.
+PIPE_NUM_INPUTS = 6  # input count for the pipelined-mux-tree variant.
+TOKEN_NUM_INPUTS = 5  # input count for the zero-width (i0) token variant.
+TOKENS_PER_INPUT = 8  # tokens each producer emits in the token test.
+
+
+def _check_mux(conn: AcceleratorConnection, dut_name: str,
+               num_inputs: int) -> None:
+  """Drive an N-input host mux and check every value is delivered exactly
+  once and every input is served."""
+  acc = conn.build_accelerator()
+  dut = acc.children[esiaccel.AppID(dut_name)]
+  ins = [dut.ports[esiaccel.AppID(f"in_{i}")] for i in range(num_inputs)]
+  out = dut.ports[esiaccel.AppID("out")]
+  for p in ins:
+    p.connect()
+  out.connect()
+
+  # The value encodes its source input in bits [17:16] and a round counter in
+  # the low bits, so the received multiset uniquely identifies every message.
+  rounds = 6
+  writes = [
+      ((i << 16) | r, ins[i]) for r in range(rounds) for i in range(num_inputs)
+  ]
+
+  # Keep the number of in-flight (written-but-not-yet-read) messages strictly
+  # below the output FIFO depth. This keeps a couple of inputs backlogged at
+  # once (so the round-robin arbiter has to choose between them) while
+  # avoiding the write-a-burst-before-reading deadlock.
+  max_in_flight = 2
+  sent: list[int] = []
+  recv: list[int] = []
+  wi = 0
+  while len(recv) < len(writes):
+    while wi < len(writes) and (len(sent) - len(recv)) < max_in_flight:
+      value, port = writes[wi]
+      port.write(value)
+      sent.append(value)
+      wi += 1
+    recv.append(out.read().result())
+
+  assert sorted(recv) == sorted(sent), \
+      "arbiter dropped, duplicated or corrupted a value"
+
+  # Every input (encoded in bits [17:16]) is served exactly `rounds` times.
+  by_src = Counter(v >> 16 for v in recv)
+  for i in range(num_inputs):
+    assert by_src[i] == rounds, \
+        f"input {i} served {by_src[i]} times, expected {rounds}"
+
+
+@cosim_test(HW_DIR / "channel_arbiter.py")
+class TestChannelArbiterCosim:
+
+  def test_mux_correctness(self, conn: AcceleratorConnection) -> None:
+    """Balanced (power-of-two) input count: every value appears once."""
+    _check_mux(conn, "arbiter_test", NUM_INPUTS)
+
+  def test_mux_correctness_unbalanced(self,
+                                      conn: AcceleratorConnection) -> None:
+    """Unbalanced (non-power-of-two) input count: the array-indexed mux over
+    N < 2**clog2(N) elements and the round-robin wrap still deliver every
+    value exactly once."""
+    _check_mux(conn, "arbiter_test_odd", ODD_NUM_INPUTS)
+
+  def test_mux_correctness_pipelined(self, conn: AcceleratorConnection) -> None:
+    """Pipelined selection mux tree: the multi-cycle mux latency (absorbed by a
+    deeper output FIFO + credit counter) must still deliver every value exactly
+    once."""
+    _check_mux(conn, "arbiter_test_pipe", PIPE_NUM_INPUTS)
+
+  def test_list_contiguity(self, conn: AcceleratorConnection) -> None:
+    """Contending multi-flit list messages are never interleaved."""
+    acc = conn.build_accelerator()
+    dut = acc.children[esiaccel.AppID("list_test")]
+    report = dut.ports[esiaccel.AppID("report")]
+    report.connect()
+
+    seen_src: set[int] = set()
+    num_reports = 40
+    for _ in range(num_reports):
+      value = report.read().result()
+      err = (value >> 24) & 0x1
+      src = (value >> 16) & 0xff
+      assert err == 0, \
+          f"hardware detected interleaved list flits (report {value:#010x})"
+      seen_src.add(src)
+
+    # Both contending producers (src 1 and src 2) must get through.
+    assert seen_src == {1, 2}, \
+        f"expected both sources to be served, saw {sorted(seen_src)}"
+
+  def test_token_conservation(self, conn: AcceleratorConnection) -> None:
+    """Zero-width (`i0`) token payloads: the credit-counter-as-buffer path
+    delivers every token exactly once (no loss/duplication/reorder) and serves
+    every producer -- the total is only reachable if no producer is starved."""
+    acc = conn.build_accelerator()
+    dut = acc.children[esiaccel.AppID("token_test")]
+    report = dut.ports[esiaccel.AppID("token_report")]
+    report.connect()
+
+    total = TOKEN_NUM_INPUTS * TOKENS_PER_INPUT
+    for expected in range(1, total + 1):
+      value = report.read().result()
+      assert value == expected, \
+          f"token {expected} arrived as {value} (loss / duplication / reorder)"


### PR DESCRIPTION
`ChannelArbiter` (in `esiaccel/components/channel_arbiter.py`) is a pipelined,
list-aware N:1 ESI channel multiplexer. It is an opt-in alternative to the
recursive **combinational** `ChannelMux2` tree in `pycde.esi.ChannelMux`, built
as a **flat, registered, round-robin arbiter** whose datapath is fully
feed-forward: downstream `ready` never reaches the arbiter combinationally — an
output FIFO plus a credit counter decouple the two.  It (a) keeps multi-flit
list messages contiguous, (b) closes timing at high N, (c) is pipelined by a
parameter, and (d) emits telemetry. `pycde.esi.ChannelMux` is left untouched.

This module will be used by BSPs to implement the upcoming HostMem list support.

Assisted-by: Github-Copilot:Claude Opus 4.8

