### PR TITLE
[ESI] Clarify documentation on window list num_items

### DIFF
--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -1079,7 +1079,9 @@ class Window(Type):
   In the case of lists, a 'last' field is added to the frame struct to indicate
   that this is the last frame of the list. If 'numItems' is specified, a field
   named `<list_name>_size` is added to indicate how many valid items are in this
-  frame.
+  frame, encoded as `(number of valid items - 1)`. The number of valid items is
+  always at least one, so a full frame has `<list_name>_size == numItems - 1`;
+  this lets the field be only `clog2(numItems)` bits wide.
 
   The 'lowered type' of a Window is a union of structs, where each struct
   corresponds to a frame and contains the fields specified in that frame. To

--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -532,11 +532,15 @@ def WindowFieldType : ESI_Type<"WindowField"> {
     For lists, there are two possible encodings:
       - Parallel (default): a 'last' field to the struct to indicate that the
       end of the list is this frame.  If 'numItems' is specified for a list, a
-      '<fieldName>_size' (representing the number of valid items in the array)
-      field will be added to the struct.  When `<fieldName>_size` is less than
-      'numItems', `last` MUST be true meaning that all frames must be full
-      except for the last one. This format matches typical on-chip hardware
-      streaming interfaces but is terribly inefficient for serial links.
+      '<fieldName>_size' field will be added to the struct representing the
+      number of valid items in this frame, encoded as `(number of valid items -
+      1)`.  The number of valid items is always at least one, so a full frame
+      has `<fieldName>_size` == 'numItems' - 1 and the field is only
+      clog2('numItems') bits wide.  When `<fieldName>_size` is less than
+      'numItems' - 1 (i.e. the frame is not full), `last` MUST be true, meaning
+      that all frames must be full except for the last one. The parallel
+      encoding matches typical on-chip hardware streaming interfaces but is
+      terribly inefficient for serial links.
       - Serial (bulk transfer): in this encoding, there must be a 'header' frame
       immediately preceding the frame which contains the list field. That frame
       must include a special 'count' field which indicates how many items of the

--- a/lib/Dialect/ESI/ESITypes.cpp
+++ b/lib/Dialect/ESI/ESITypes.cpp
@@ -327,7 +327,8 @@ Type WindowType::getLoweredType() const {
 
           if (!isBulkTransferData) {
             // Streaming mode: add _size and last fields.
-            // _size is clog2(numItems) in width.
+            // _size holds (number of valid items - 1); the count is never zero,
+            // so a full frame is numItems - 1 and clog2(numItems) bits suffice.
             fields.push_back(
                 {StringAttr::get(
                      getContext(),


### PR DESCRIPTION
The documentation wasn't clear that the num_items field was "number of valid items minus 1".

Assisted-by: Github-Copilot:Claude Opus 4.8
