### PR TITLE
[FIRRTL][InferDomain] Fix null pointer dereference

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferDomains.cpp
@@ -2017,10 +2017,7 @@ LogicalResult ModuleState::checkModuleDomainPortDrivers(FModuleOp moduleOp) {
 LogicalResult ModuleState::checkInstanceDomainPortDrivers(FInstanceLike op) {
   for (size_t i = 0, e = op->getNumResults(); i < e; ++i) {
     auto port = dyn_cast<DomainValue>(op->getResult(i));
-
-    auto type = port.getType();
-    if (!isa<DomainType>(type) || op.getPortDirection(i) != Direction::In ||
-        isDriven(port))
+    if (!port || op.getPortDirection(i) != Direction::In || isDriven(port))
       continue;
 
     auto name = op.getPortNameAttr(i);

--- a/test/Dialect/FIRRTL/infer-domains-check-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-domains-check-errors.mlir
@@ -173,3 +173,14 @@ firrtl.circuit "UnsafeDomainCastMismatch" {
     firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
   }
 }
+
+// https://github.com/llvm/circt/issues/10885
+firrtl.circuit "Issue10885" {
+  firrtl.module @Child(out %x: !firrtl.uint<1>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.matchingconnect %x, %c0_ui1 : !firrtl.uint<1>
+  }
+  firrtl.module @Issue10885() {
+    %x = firrtl.instance c @Child(out x: !firrtl.uint<1>)
+  }
+}


### PR DESCRIPTION
This fixes crash for `domain-mode=check` by simply fixing the condition. It looks it works fine when assertion is turned off. 

AI-assisted-by: pi.dev: gpt-5.4

Close https://github.com/llvm/circt/issues/10885. 
Sorry that the branch name is horrible ... I messed up while testing github stack pr. 
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>