### PR TITLE
[ESI] List support for HostMem service

### DIFF
--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -13,8 +13,8 @@ from .support import (clog2, optional_dict_to_optional_dict_attr, get_user_loc,
                       optional_dict_to_dict_attr)
 from .system import System
 from .types import (Any, Bits, Bundle, BundledChannel, Channel,
-                    ChannelDirection, ChannelSignaling, StructType, Type,
-                    Window, UInt, _FromCirctType)
+                    ChannelDirection, ChannelSignaling, List as EsiListType,
+                    StructType, Type, Window, UInt, _FromCirctType)
 
 from .circt import ir
 from .circt.dialects import esi as raw_esi, hw, msft
@@ -670,6 +670,40 @@ class _HostMem(ServiceDecl):
   def __init__(self):
     super().__init__(self.__class__)
 
+  @staticmethod
+  def read_req_burst_type(length_width: int = 64) -> StructType:
+    """Burst (list) read request type: struct{address, tag, length}. 'length'
+    selects how many list items to read from the host, returned as a windowed
+    list (used by 'read_list'; the single-message 'read' has no 'length'
+    field). 'length_width' sets the bit width of the unsigned 'length' field --
+    the 'read_list' service port accepts any width."""
+    return StructType([
+        ("address", UInt(64)),
+        ("tag", _HostMem.TagType),
+        ("length", UInt(length_width)),
+    ])
+
+  @staticmethod
+  def read_window(list_element: Type, num_items: int) -> Window:
+    """Parallel window framing a list read response on the wire: a window over
+    struct{tag, data: list<list_element>} carrying 'num_items' items per frame
+    (plus the auto-added '<data>_size' and 'last' fields)."""
+    into = StructType([("tag", _HostMem.TagType),
+                       ("data", EsiListType(list_element))])
+    return Window("HostMemReadResp", into,
+                  [Window.Frame(None, ["tag", ("data", num_items)])])
+
+  @staticmethod
+  def write_window(list_element: Type, num_items: int) -> Window:
+    """Parallel window framing a list write request on the wire: a window over
+    struct{address, tag, data: list<list_element>} carrying 'num_items' items
+    per frame (plus the auto-added '<data>_size' and 'last' fields). The items
+    are written to sequential addresses starting at 'address'."""
+    into = StructType([("address", UInt(64)), ("tag", _HostMem.TagType),
+                       ("data", EsiListType(list_element))])
+    return Window("HostMemWriteReq", into,
+                  [Window.Frame(None, ["address", "tag", ("data", num_items)])])
+
   def write_req_bundle_type(self, data_type: Type) -> Bundle:
     """Build a write request bundle type for the given data type."""
     write_req_type = StructType([
@@ -706,10 +740,18 @@ class _HostMem(ServiceDecl):
             appid: AppID,
             req: ChannelSignal,
             options: Optional[Dict[str, object]] = None) -> ChannelSignal:
-    """Create a write request to the host memory out of a request channel."""
-    # Extract the data type from the request channel and call the helper to get
-    # the write bundle type for the req channel.
-    write_bundle_type = self.write_req_bundle_type(req.type.inner_type.data)
+    """Create a write request to host memory out of a request channel.
+
+    'req' is a struct{address, tag, data} channel for a single-message write, or
+    a windowed channel (a parallel window over struct{address, tag, data: list},
+    see 'write_window') for a burst/list write. Returns the 'ackTag' response
+    channel."""
+    # Build the write bundle type directly from the request channel's type so
+    # both single-message structs and windowed (list) requests are accepted.
+    write_bundle_type = Bundle([
+        BundledChannel("req", ChannelDirection.FROM, req.type.inner_type),
+        BundledChannel("ackTag", ChannelDirection.TO, _HostMem.TagType),
+    ])
     bundle = self.write_from_bundle(appid, write_bundle_type, options=options)
     resp = bundle.unpack(req=req)['ackTag']
     return resp
@@ -749,6 +791,8 @@ class _HostMem(ServiceDecl):
       read_bundle_type: Bundle,
       options: Optional[Dict[str, object]] = None) -> BundleSignal:
     """Request a connection based for a given read bundle type."""
+    self._materialize_service_decl()
+
     return cast(
         BundleSignal,
         _FromCirctValue(
@@ -759,18 +803,61 @@ class _HostMem(ServiceDecl):
                 options=optional_dict_to_optional_dict_attr(options),
                 loc=get_user_loc()).toClient))
 
+  def read_list_from_bundle(
+      self,
+      appid: AppID,
+      read_bundle_type: Bundle,
+      options: Optional[Dict[str, object]] = None) -> BundleSignal:
+    """Request a 'read_list' (burst) connection for a given read bundle type."""
+    self._materialize_service_decl()
+
+    return cast(
+        BundleSignal,
+        _FromCirctValue(
+            raw_esi.RequestConnectionOp(
+                read_bundle_type._type,
+                hw.InnerRefAttr.get(self.symbol,
+                                    ir.StringAttr.get("read_list")),
+                appid._appid,
+                options=optional_dict_to_optional_dict_attr(options),
+                loc=get_user_loc()).toClient))
+
   def read(self,
            appid: AppID,
            req: ChannelSignal,
            data_type: Type,
            options: Optional[Dict[str, object]] = None) -> ChannelSignal:
-    """Create a read request to the host memory out of a request channel and
-    return the response channel with the specified data type."""
-
-    self._materialize_service_decl()
+    """Create a single-message read request to host memory out of a request
+    channel and return the response channel (struct{tag, data: data_type}). To
+    read a list, use 'read_list'."""
 
     read_bundle_type = self.read_bundle_type(data_type)
     bundle_sig = self.read_from_bundle(appid, read_bundle_type, options=options)
+    resp = bundle_sig.unpack(req=req)['resp']
+    return resp
+
+  def read_list(self,
+                appid: AppID,
+                req: ChannelSignal,
+                element_type: Type,
+                num_items: int,
+                options: Optional[Dict[str, object]] = None) -> ChannelSignal:
+    """Create a burst (list) read of host memory. 'req' is a channel of
+    'read_req_burst_type()' ({address, tag, length}), where the request's
+    'length' is the number of list items to read starting at 'address'; the
+    items are returned as a list. To receive the list, the client requests a
+    *windowed channel*: the response is a window over struct{tag, data:
+    list<element_type>} carrying 'num_items' items per frame (see
+    'read_window'), consumed frame by frame."""
+
+    resp_type = _HostMem.read_window(element_type, num_items)
+    read_bundle_type = Bundle([
+        BundledChannel("req", ChannelDirection.FROM, req.type.inner_type),
+        BundledChannel("resp", ChannelDirection.TO, resp_type),
+    ])
+    bundle_sig = self.read_list_from_bundle(appid,
+                                            read_bundle_type,
+                                            options=options)
     resp = bundle_sig.unpack(req=req)['resp']
     return resp
 

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -402,6 +402,56 @@ class HostMemReq(Module):
     _ = HostMem.write(appid=AppID("host_mem_write_req"), req=write_req)
 
 
+# Exercises the HostMem burst/list interface: read_req_burst_type(),
+# write_window(), read_list() (-> read_window()/read_list_from_bundle()) and
+# write() with a list (-> write_from_bundle()). The list windows are the
+# 'parallel' (default) framing: a single frame carrying 'num_items' items.
+# CHECK-LABEL:  hw.module @HostMemListReq()
+# read_list: {address, tag, length} request, parallel windowed list response.
+# CHECK:          esi.service.req <@_HostMem::@read_list>(#esi.appid<"host_mem_read_list">) : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui64>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<ui256>>, [<"", [<"tag">, <"data", 4>]>]>> to "resp"]>
+# write with a list: wrap a parallel write window and send it on the 'write' port.
+# CHECK:          esi.window.wrap %{{.+}} : !esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<ui256>>, [<"", [<"address">, <"tag">, <"data", 4>]>]>
+# CHECK:          esi.service.req <@_HostMem::@write>(#esi.appid<"host_mem_write_list">) : !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<ui256>>, [<"", [<"address">, <"tag">, <"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>
+# CHECK:        esi.service.std.hostmem @_HostMem
+@unittestmodule(esi_sys=True)
+class HostMemListReq(Module):
+
+  @generator
+  def build(ports):
+    u64 = UInt(64)(0)
+    c1 = Bits(1)(0)
+
+    # Burst (list) read: exercises read_req_burst_type(), read_window() and
+    # read_list() (-> read_list_from_bundle()).
+    burst_req, _ = Channel(esi.HostMem.read_req_burst_type()).wrap(
+        esi.HostMem.read_req_burst_type()({
+            "address": u64,
+            "tag": UInt(8)(0),
+            "length": UInt(64)(0),
+        }), c1)
+    _ = HostMem.read_list(appid=AppID("host_mem_read_list"),
+                          req=burst_req,
+                          element_type=UInt(256),
+                          num_items=4)
+
+    # Windowed (list) write: exercises write_window() and write() with a list
+    # (-> write_from_bundle()).
+    write_win = esi.HostMem.write_window(UInt(256), 4)
+    lowered = write_win.lowered_type
+    frame_val = lowered({
+        "address": u64,
+        "tag": UInt(8)(0),
+        "data": [UInt(256)(0),
+                 UInt(256)(0),
+                 UInt(256)(0),
+                 UInt(256)(0)],
+        "data_size": Bits(2)(0),
+        "last": c1,
+    })
+    write_frame, _ = Channel(write_win).wrap(write_win.wrap(frame_val), c1)
+    _ = HostMem.write(appid=AppID("host_mem_write_list"), req=write_frame)
+
+
 def Writer(type):
 
   class Writer(Module):

--- a/include/circt/Dialect/ESI/ESIStdServices.td
+++ b/include/circt/Dialect/ESI/ESIStdServices.td
@@ -148,6 +148,7 @@ def HostMemServiceDeclOp: ESI_Op<"service.std.hostmem",
   let extraClassDeclaration = [{
     ServicePortInfo readPortInfo();
     ServicePortInfo writePortInfo();
+    ServicePortInfo readListPortInfo();
     std::optional<StringRef> getTypeName() { return "esi.service.std.hostmem"; }
   }];
 }

--- a/lib/Dialect/ESI/ESIStdServices.cpp
+++ b/lib/Dialect/ESI/ESIStdServices.cpp
@@ -158,21 +158,14 @@ void MMIOServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
 
 ServicePortInfo HostMemServiceDeclOp::writePortInfo() {
   auto *ctxt = getContext();
-  auto addressType =
-      IntegerType::get(ctxt, 64, IntegerType::SignednessSemantics::Unsigned);
 
-  // Write port
-  hw::StructType writeType = hw::StructType::get(
-      ctxt,
-      {hw::StructType::FieldInfo{StringAttr::get(ctxt, "address"), addressType},
-       hw::StructType::FieldInfo{
-           StringAttr::get(ctxt, "tag"),
-           IntegerType::get(ctxt, 8,
-                            IntegerType::SignednessSemantics::Unsigned)},
-       hw::StructType::FieldInfo{StringAttr::get(ctxt, "data"),
-                                 AnyType::get(ctxt)}});
+  // Unified write port. The request is 'AnyType' so a single connection can be
+  // either a single-message write (struct{address, tag, data}) or a burst/list
+  // write (a window over struct{address, tag, data: list}, framed at the engine
+  // width); the concrete request type is supplied per-connection. Responds with
+  // an 'ackTag' per written element.
   return createReqResp(
-      getSymNameAttr(), "write", "req", writeType, "ackTag",
+      getSymNameAttr(), "write", "req", AnyType::get(ctxt), "ackTag",
       IntegerType::get(ctxt, 8, IntegerType::SignednessSemantics::Unsigned));
 }
 
@@ -181,6 +174,8 @@ ServicePortInfo HostMemServiceDeclOp::readPortInfo() {
   auto addressType =
       IntegerType::get(ctxt, 64, IntegerType::SignednessSemantics::Unsigned);
 
+  // Single-message read: request struct{address, tag}, response struct{tag,
+  // data}. The client supplies the concrete 'data' type per-connection.
   hw::StructType readReqType = hw::StructType::get(
       ctxt, {
                 hw::StructType::FieldInfo{StringAttr::get(ctxt, "address"),
@@ -203,10 +198,40 @@ ServicePortInfo HostMemServiceDeclOp::readPortInfo() {
                        readRespType);
 }
 
+ServicePortInfo HostMemServiceDeclOp::readListPortInfo() {
+  auto *ctxt = getContext();
+  auto ui64 =
+      IntegerType::get(ctxt, 64, IntegerType::SignednessSemantics::Unsigned);
+  auto ui8 =
+      IntegerType::get(ctxt, 8, IntegerType::SignednessSemantics::Unsigned);
+
+  // Burst (list) read: read 'length' list items starting at 'address' and
+  // return them as a list. To receive the list, the client requests a
+  // *windowed channel* for the response (a window over the returned list,
+  // framed at the engine width), so the concrete response type is supplied
+  // per-connection -- hence 'AnyType' for 'resp'. 'length' is likewise
+  // 'AnyType' so the client may supply an unsigned integer of any width.
+  //
+  // TODO: 'AnyType' also permits non-integer or signed 'length' types, since
+  // there is no "unsigned integer of any width" constraint the op verifier can
+  // enforce today. A future (infra) PR should add that validation -- e.g. a
+  // per-service request-verify hook on ServiceDeclOpInterface, or an "any
+  // unsigned int" constraint type handled by checkInnerTypeMatch -- so a
+  // non-uint 'length' is rejected at op-verification time.
+  hw::StructType readReqType = hw::StructType::get(
+      ctxt, {hw::StructType::FieldInfo{StringAttr::get(ctxt, "address"), ui64},
+             hw::StructType::FieldInfo{StringAttr::get(ctxt, "tag"), ui8},
+             hw::StructType::FieldInfo{StringAttr::get(ctxt, "length"),
+                                       AnyType::get(ctxt)}});
+  return createReqResp(getSymNameAttr(), "read_list", "req", readReqType,
+                       "resp", AnyType::get(ctxt));
+}
+
 void HostMemServiceDeclOp::getPortList(
     SmallVectorImpl<ServicePortInfo> &ports) {
   ports.push_back(writePortInfo());
   ports.push_back(readPortInfo());
+  ports.push_back(readListPortInfo());
 }
 
 void TelemetryServiceDeclOp::getPortList(

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -260,35 +260,33 @@ hw.module @HostmemRW(in %clk : !seq.clock, in %rst : i1, in %write : !esi.channe
 // width -- here 'ui32' -- and response type 'AnyType') returns a windowed,
 // list-carrying burst read.
 
-// Burst/list write request: a window over struct{address, tag, data: list},
-// framed at the engine width. Accepted by the unified 'write' port because its
-// request type is 'AnyType'.
+// Burst/list write request: a parallel window over struct{address, tag, data:
+// list} carrying 'num_items' items in a single frame. Accepted by the unified
+// 'write' port because its request type is 'AnyType'.
 !WriteListWindow = !esi.window<
   "HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [
-    <"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>,
-    <"DataFrame", [<"data", 4>]>
+    <"", [<"address">, <"tag">, <"data", 4>]>
   ]>
 !hostmemWriteListReq = !esi.bundle<[!esi.channel<!WriteListWindow> from "req", !esi.channel<ui8> to "ackTag"]>
 
 // Burst/list read: request struct{address, tag, length}; the response is a
-// window over struct{tag, data: list}. The 'read_list' port response type is
-// 'AnyType', so the concrete windowed response is supplied per-connection. The
-// port's 'length' field is 'AnyType' too, so any-width unsigned integer is
-// accepted; this request uses 'ui32' (not the engine-native 'ui64') to
-// exercise that.
+// parallel window over struct{tag, data: list} carrying 'num_items' items in a
+// single frame. The 'read_list' port response type is 'AnyType', so the
+// concrete windowed response is supplied per-connection. The port's 'length'
+// field is 'AnyType' too, so any-width unsigned integer is accepted; this
+// request uses 'ui32' (not the engine-native 'ui64') to exercise that.
 !ReadListRespWindow = !esi.window<
   "HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [
-    <"HeaderFrame", [<"tag">, <"data" countWidth 8>]>,
-    <"DataFrame", [<"data", 4>]>
+    <"", [<"tag">, <"data", 4>]>
   ]>
 !hostmemReadListReq = !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!ReadListRespWindow> to "resp"]>
 
-// CONN-LABEL:  hw.module @HostmemLists(in %clk : !seq.clock, in %rst : i1, in %writeReq : !esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>>, in %readListReq : !esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>>, in %hostmemWriteList : !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>, in %hostmemReadList : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> to "resp"]>, out readListData : !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>>, out writeDone : !esi.channel<ui8>) {
-// CONN-NEXT:     esi.manifest.req #esi.appid<"hostmemWriteList">, <@hostmem::@write> std "esi.service.std.hostmem", !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>
-// CONN-NEXT:     %ackTag = esi.bundle.unpack %writeReq from %hostmemWriteList : !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>
-// CONN-NEXT:     esi.manifest.req #esi.appid<"hostmemReadList">, <@hostmem::@read_list> std "esi.service.std.hostmem", !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> to "resp"]>
-// CONN-NEXT:     %resp = esi.bundle.unpack %readListReq from %hostmemReadList : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> to "resp"]>
-// CONN-NEXT:     hw.output %resp, %ackTag : !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>>, !esi.channel<ui8>
+// CONN-LABEL:  hw.module @HostmemLists(in %clk : !seq.clock, in %rst : i1, in %writeReq : !esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"", [<"address">, <"tag">, <"data", 4>]>]>>, in %readListReq : !esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>>, in %hostmemWriteList : !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"", [<"address">, <"tag">, <"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>, in %hostmemReadList : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"", [<"tag">, <"data", 4>]>]>> to "resp"]>, out readListData : !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"", [<"tag">, <"data", 4>]>]>>, out writeDone : !esi.channel<ui8>) {
+// CONN-NEXT:     esi.manifest.req #esi.appid<"hostmemWriteList">, <@hostmem::@write> std "esi.service.std.hostmem", !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"", [<"address">, <"tag">, <"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>
+// CONN-NEXT:     %ackTag = esi.bundle.unpack %writeReq from %hostmemWriteList : !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"", [<"address">, <"tag">, <"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>
+// CONN-NEXT:     esi.manifest.req #esi.appid<"hostmemReadList">, <@hostmem::@read_list> std "esi.service.std.hostmem", !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"", [<"tag">, <"data", 4>]>]>> to "resp"]>
+// CONN-NEXT:     %resp = esi.bundle.unpack %readListReq from %hostmemReadList : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"", [<"tag">, <"data", 4>]>]>> to "resp"]>
+// CONN-NEXT:     hw.output %resp, %ackTag : !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"", [<"tag">, <"data", 4>]>]>>, !esi.channel<ui8>
 hw.module @HostmemLists(in %clk : !seq.clock, in %rst : i1, in %writeReq : !esi.channel<!WriteListWindow>, in %readListReq : !esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>>, out readListData : !esi.channel<!ReadListRespWindow>, out writeDone : !esi.channel<ui8>) {
   %writeBundle = esi.service.req <@hostmem::@write> (#esi.appid<"hostmemWriteList">) : !hostmemWriteListReq
   %ackTag = esi.bundle.unpack %writeReq from %writeBundle : !hostmemWriteListReq

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -253,6 +253,52 @@ hw.module @HostmemRW(in %clk : !seq.clock, in %rst : i1, in %write : !esi.channe
   hw.output %readData, %ackTag: !esi.channel<!hw.struct<tag: ui8, data: i64>>, !esi.channel<ui8>
 }
 
+// Burst/list HostMem interface (reuses the '@hostmem' service declared above):
+// the unified 'write' port (request type 'AnyType') accepts a windowed,
+// list-carrying burst write, and the 'read_list' port (request
+// struct{address, tag, length}, where 'length' is an unsigned integer of any
+// width -- here 'ui32' -- and response type 'AnyType') returns a windowed,
+// list-carrying burst read.
+
+// Burst/list write request: a window over struct{address, tag, data: list},
+// framed at the engine width. Accepted by the unified 'write' port because its
+// request type is 'AnyType'.
+!WriteListWindow = !esi.window<
+  "HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [
+    <"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>,
+    <"DataFrame", [<"data", 4>]>
+  ]>
+!hostmemWriteListReq = !esi.bundle<[!esi.channel<!WriteListWindow> from "req", !esi.channel<ui8> to "ackTag"]>
+
+// Burst/list read: request struct{address, tag, length}; the response is a
+// window over struct{tag, data: list}. The 'read_list' port response type is
+// 'AnyType', so the concrete windowed response is supplied per-connection. The
+// port's 'length' field is 'AnyType' too, so any-width unsigned integer is
+// accepted; this request uses 'ui32' (not the engine-native 'ui64') to
+// exercise that.
+!ReadListRespWindow = !esi.window<
+  "HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [
+    <"HeaderFrame", [<"tag">, <"data" countWidth 8>]>,
+    <"DataFrame", [<"data", 4>]>
+  ]>
+!hostmemReadListReq = !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!ReadListRespWindow> to "resp"]>
+
+// CONN-LABEL:  hw.module @HostmemLists(in %clk : !seq.clock, in %rst : i1, in %writeReq : !esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>>, in %readListReq : !esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>>, in %hostmemWriteList : !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>, in %hostmemReadList : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> to "resp"]>, out readListData : !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>>, out writeDone : !esi.channel<ui8>) {
+// CONN-NEXT:     esi.manifest.req #esi.appid<"hostmemWriteList">, <@hostmem::@write> std "esi.service.std.hostmem", !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>
+// CONN-NEXT:     %ackTag = esi.bundle.unpack %writeReq from %hostmemWriteList : !esi.bundle<[!esi.channel<!esi.window<"HostMemWriteReq", !hw.struct<address: ui64, tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"address">, <"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> from "req", !esi.channel<ui8> to "ackTag"]>
+// CONN-NEXT:     esi.manifest.req #esi.appid<"hostmemReadList">, <@hostmem::@read_list> std "esi.service.std.hostmem", !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> to "resp"]>
+// CONN-NEXT:     %resp = esi.bundle.unpack %readListReq from %hostmemReadList : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>> from "req", !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>> to "resp"]>
+// CONN-NEXT:     hw.output %resp, %ackTag : !esi.channel<!esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"HeaderFrame", [<"tag">, <"data" countWidth 8>]>, <"DataFrame", [<"data", 4>]>]>>, !esi.channel<ui8>
+hw.module @HostmemLists(in %clk : !seq.clock, in %rst : i1, in %writeReq : !esi.channel<!WriteListWindow>, in %readListReq : !esi.channel<!hw.struct<address: ui64, tag: ui8, length: ui32>>, out readListData : !esi.channel<!ReadListRespWindow>, out writeDone : !esi.channel<ui8>) {
+  %writeBundle = esi.service.req <@hostmem::@write> (#esi.appid<"hostmemWriteList">) : !hostmemWriteListReq
+  %ackTag = esi.bundle.unpack %writeReq from %writeBundle : !hostmemWriteListReq
+
+  %readListBundle = esi.service.req <@hostmem::@read_list> (#esi.appid<"hostmemReadList">) : !hostmemReadListReq
+  %readListData = esi.bundle.unpack %readListReq from %readListBundle : !hostmemReadListReq
+
+  hw.output %readListData, %ackTag : !esi.channel<!ReadListRespWindow>, !esi.channel<ui8>
+}
+
 esi.service.std.telemetry @telemetry
 hw.module @TelemetryTest1(in %clk : !seq.clock, in %rst : i1, in %value: !esi.channel<ui64>) {
   %telemetryBundle = esi.service.req <@telemetry::@report> (#esi.appid<"telemetry">) : !esi.bundle<[!esi.channel<i0> to "get", !esi.channel<ui64> from "data"]>


### PR DESCRIPTION
Host memory being accessed one fixed sized message at a time is generally not performant and often not what is desired. By adding list support, we get the ability to burst writes and request long reads. (Without complex coalescing logic.)

BSP support will be added in a subsequent PR.

Assisted-by: Github-Copilot:Claude Opus 4.8

