### PR TITLE
[ESI] Allow additional verification on service reqs

### DIFF
--- a/include/circt/Dialect/ESI/ESIInterfaces.td
+++ b/include/circt/Dialect/ESI/ESIInterfaces.td
@@ -140,6 +140,24 @@ def ServiceDeclOpInterface : OpInterface<"ServiceDeclOpInterface"> {
         if (f != ports.end()) return *f;
         return failure();
       }]
+    >,
+    InterfaceMethod<
+      [{Verify a connection request against one of this service's ports. Called
+        during op verification, after the generic bundle-type compatibility
+        check has already passed. `portInfo` is the resolved service port,
+        `reqBundleType` is the requested bundle type, and `reqOp` is the
+        requesting op (use it to emit diagnostics). Services may override this
+        to impose additional, service-specific constraints on requests which
+        the generic `!esi.any`-based type matching cannot express. The default
+        performs no additional checks.}],
+      "LogicalResult", "verifyRequest",
+      (ins "const ServicePortInfo &":$portInfo,
+           "ChannelBundleType":$reqBundleType,
+           "Operation *":$reqOp),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return success();
+      }]
     >
   ];
 }

--- a/include/circt/Dialect/ESI/ESIStdServices.td
+++ b/include/circt/Dialect/ESI/ESIStdServices.td
@@ -150,6 +150,9 @@ def HostMemServiceDeclOp: ESI_Op<"service.std.hostmem",
     ServicePortInfo writePortInfo();
     ServicePortInfo readListPortInfo();
     std::optional<StringRef> getTypeName() { return "esi.service.std.hostmem"; }
+    LogicalResult verifyRequest(const ServicePortInfo &portInfo,
+                                ChannelBundleType reqBundleType,
+                                Operation *reqOp);
   }];
 }
 

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -565,8 +565,13 @@ RequestConnectionOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto svcPort = getServicePortInfo(*this, symbolTable, getServicePortAttr());
   if (failed(svcPort))
     return failure();
-  return checkBundleTypeMatch(*this, svcPort->type, getToClient().getType(),
-                              false);
+  if (failed(checkBundleTypeMatch(*this, svcPort->type, getToClient().getType(),
+                                  false)))
+    return failure();
+  auto svcDecl = getServiceDecl(*this, symbolTable, getServicePortAttr());
+  if (failed(svcDecl))
+    return failure();
+  return svcDecl->verifyRequest(*svcPort, getToClient().getType(), *this);
 }
 
 LogicalResult ServiceImplementConnReqOp::verifySymbolUses(
@@ -574,8 +579,13 @@ LogicalResult ServiceImplementConnReqOp::verifySymbolUses(
   auto svcPort = getServicePortInfo(*this, symbolTable, getServicePortAttr());
   if (failed(svcPort))
     return failure();
-  return checkBundleTypeMatch(*this, svcPort->type, getToClient().getType(),
-                              true);
+  if (failed(checkBundleTypeMatch(*this, svcPort->type, getToClient().getType(),
+                                  true)))
+    return failure();
+  auto svcDecl = getServiceDecl(*this, symbolTable, getServicePortAttr());
+  if (failed(svcDecl))
+    return failure();
+  return svcDecl->verifyRequest(*svcPort, getToClient().getType(), *this);
 }
 
 void CustomServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {

--- a/lib/Dialect/ESI/ESIStdServices.cpp
+++ b/lib/Dialect/ESI/ESIStdServices.cpp
@@ -210,14 +210,10 @@ ServicePortInfo HostMemServiceDeclOp::readListPortInfo() {
   // *windowed channel* for the response (a window over the returned list,
   // framed at the engine width), so the concrete response type is supplied
   // per-connection -- hence 'AnyType' for 'resp'. 'length' is likewise
-  // 'AnyType' so the client may supply an unsigned integer of any width.
-  //
-  // TODO: 'AnyType' also permits non-integer or signed 'length' types, since
-  // there is no "unsigned integer of any width" constraint the op verifier can
-  // enforce today. A future (infra) PR should add that validation -- e.g. a
-  // per-service request-verify hook on ServiceDeclOpInterface, or an "any
-  // unsigned int" constraint type handled by checkInnerTypeMatch -- so a
-  // non-uint 'length' is rejected at op-verification time.
+  // 'AnyType' so the client may supply an unsigned integer of any width. Since
+  // 'AnyType' cannot itself express "unsigned integer of any width",
+  // 'verifyRequest' (below) rejects a non-unsigned-integer 'length' at
+  // op-verification time.
   hw::StructType readReqType = hw::StructType::get(
       ctxt, {hw::StructType::FieldInfo{StringAttr::get(ctxt, "address"), ui64},
              hw::StructType::FieldInfo{StringAttr::get(ctxt, "tag"), ui8},
@@ -232,6 +228,35 @@ void HostMemServiceDeclOp::getPortList(
   ports.push_back(writePortInfo());
   ports.push_back(readPortInfo());
   ports.push_back(readListPortInfo());
+}
+
+LogicalResult HostMemServiceDeclOp::verifyRequest(const ServicePortInfo &port,
+                                                  ChannelBundleType reqType,
+                                                  Operation *reqOp) {
+  // Only the 'read_list' port constrains 'length'. Its request struct declares
+  // 'length' as 'AnyType' (so the generic type match accepts any bit width),
+  // but here we additionally require it to be an unsigned integer -- the
+  // constraint 'AnyType' alone cannot express.
+  if (port.port.getName().getValue() != "read_list")
+    return success();
+
+  for (BundledChannel ch : reqType.getChannels()) {
+    if (ch.name.getValue() != "req")
+      continue;
+    auto structType = dyn_cast<hw::StructType>(ch.type.getInner());
+    if (!structType)
+      break;
+    Type lengthType = structType.getFieldType("length");
+    if (!lengthType)
+      break;
+    if (auto intType = dyn_cast<IntegerType>(lengthType);
+        intType && intType.isUnsigned())
+      return success();
+    return reqOp->emitOpError()
+           << "'read_list' request 'length' must be an unsigned integer, got "
+           << lengthType;
+  }
+  return success();
 }
 
 void TelemetryServiceDeclOp::getPortList(

--- a/test/Dialect/ESI/errors.mlir
+++ b/test/Dialect/ESI/errors.mlir
@@ -223,3 +223,17 @@ hw.module @wrap_vo_multi_unwrap(in %a_data: i8, in %a_valid: i1) {
   // expected-note @+1 {{channel used here}}
   %ab_data, %ab_valid = esi.unwrap.vo %a_chan : !esi.channel<i8, ValidOnly>
 }
+
+// -----
+
+// HostMem 'read_list' requires the request's 'length' field to be an unsigned
+// integer (of any width).
+esi.service.std.hostmem @hostmem
+!respWin = !esi.window<"HostMemReadResp", !hw.struct<tag: ui8, data: !esi.list<i64>>, [<"", [<"tag">, <"data", 4>]>]>
+!badReadListReq = !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, length: i32>> from "req", !esi.channel<!respWin> to "resp"]>
+hw.module @BadReadListLength(in %req : !esi.channel<!hw.struct<address: ui64, tag: ui8, length: i32>>, out resp : !esi.channel<!respWin>) {
+  // expected-error @+1 {{'read_list' request 'length' must be an unsigned integer, got 'i32'}}
+  %bundle = esi.service.req <@hostmem::@read_list> (#esi.appid<"badReadList">) : !badReadListReq
+  %resp = esi.bundle.unpack %req from %bundle : !badReadListReq
+  hw.output %resp : !esi.channel<!respWin>
+}


### PR DESCRIPTION
The generic matching scheme for verifying service requests only allows general `Any` wildcards, which works for most things. Some requirements (e.g. that 'length' be a 'ui<N>') don't fit that model. Run an additional verification method on all service requests, which defaults to succeeding.

Assisted-by: Github-Copilot:Claude Opus 4.8
