### PR TITLE
[ESI][Runtime] Update BSP support for hostmem list requests

### DIFF
--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -386,7 +386,7 @@ class HostMemReq(Module):
     c1 = Bits(1)(0)
 
     read_address, _ = Channel(esi.HostMem.ReadReqType).wrap(
-        esi.HostMem.ReadReqType({
+        esi.HostMem.read_req_burst_type(64)({
             "tag": 0,
             "address": u64
         }), c1)

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -386,7 +386,7 @@ class HostMemReq(Module):
     c1 = Bits(1)(0)
 
     read_address, _ = Channel(esi.HostMem.ReadReqType).wrap(
-        esi.HostMem.read_req_burst_type(64)({
+        esi.HostMem.ReadReqType({
             "tag": 0,
             "address": u64
         }), c1)

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -20,6 +20,7 @@
 #include "esi/Utils.h"
 #include "esi/backends/RpcClient.h"
 
+#include <array>
 #include <cstring>
 #include <format>
 #include <fstream>
@@ -405,20 +406,106 @@ struct HostMemReadReq {
   uint64_t address;
 };
 
-struct HostMemReadResp {
-  uint64_t data;
-  uint8_t tag;
-};
-
-struct HostMemWriteReq {
-  uint8_t valid_bytes;
-  uint64_t data;
-  uint8_t tag;
-  uint64_t address;
-};
-
 using HostMemWriteResp = uint8_t;
 #pragma pack(pop)
+
+// ESI lowers a parallel-window frame MSB-first (the first-declared field
+// occupies the highest bits) into a little-endian byte buffer; array elements
+// are packed least-index-first (element[0] in the low bits). The sub-byte
+// `last` / `data_size` fields make these frames bit-packed and not
+// byte-aligned, so -- to stay ABI-portable across toolchains (bit-field and
+// sub-byte `#pragma pack` layout is not guaranteed under MSVC) -- each frame is
+// a plain byte array whose bits are assembled/extracted explicitly with these
+// helpers. `bitOff` counts from the LSB (bit 0 of byte 0).
+void putBits(uint8_t *buf, size_t bitOff, size_t width, uint64_t val) {
+  for (size_t i = 0; i < width; ++i)
+    if ((val >> i) & 1ULL)
+      buf[(bitOff + i) >> 3] |= static_cast<uint8_t>(1u << ((bitOff + i) & 7));
+}
+uint64_t getBits(const uint8_t *buf, size_t bitOff, size_t width) {
+  uint64_t val = 0;
+  for (size_t i = 0; i < width; ++i)
+    if (buf[(bitOff + i) >> 3] & (1u << ((bitOff + i) & 7)))
+      val |= (1ULL << i);
+  return val;
+}
+
+// Read-response frame: one bus beat of a burst read. The client-facing read
+// response is a parallel window over struct{tag, data: list<i<HostMemWidth>>};
+// with one word per beat (num_items=1) the lowered frame is
+//   struct{tag: ui8, data: i64, last: i1}    (73 bits)
+// packed MSB-first: tag | data | last. `last` marks the final beat of a burst.
+class HostMemReadRespFrame {
+public:
+  static constexpr size_t kMessageBits = 8 + 64 + 1;              // 73
+  static constexpr size_t kMessageBytes = (kMessageBits + 7) / 8; // 10
+
+  HostMemReadRespFrame(uint8_t tag, uint64_t data, bool last) {
+    putBits(bytes.data(), kLastOff, kLastW, last ? 1 : 0);
+    putBits(bytes.data(), kDataOff, kDataW, data);
+    putBits(bytes.data(), kTagOff, kTagW, tag);
+  }
+
+  uint8_t tag() const { return getBits(bytes.data(), kTagOff, kTagW); }
+  uint64_t data() const { return getBits(bytes.data(), kDataOff, kDataW); }
+  bool last() const { return getBits(bytes.data(), kLastOff, kLastW) != 0; }
+
+  MessageData toMessage() const {
+    return MessageData(bytes.data(), bytes.size());
+  }
+
+private:
+  // MSB-first field order => reverse (LSB-most) bit offsets.
+  static constexpr size_t kLastW = 1, kLastOff = 0;                  // bit 0
+  static constexpr size_t kDataW = 64, kDataOff = kLastOff + kLastW; // bit 1
+  static constexpr size_t kTagW = 8, kTagOff = kDataOff + kDataW;    // bit 65
+  std::array<uint8_t, kMessageBytes> bytes{};
+};
+
+// Write-request frame: one bus beat of a burst write. The upstream write
+// request is a parallel window over struct{address, tag, data: list<i8>} with
+// num_items = the host-memory bus width in bytes (cosim HostMemWidth=64 => 8).
+// The lowered frame is
+//   struct{address: ui64, tag: ui8, data: i8[8], data_size: ui3, last: i1}
+// (140 bits) packed MSB-first: address | tag | data[8] | data_size | last, with
+// data element[i] in ascending bits. `data_size` holds (valid_bytes - 1);
+// `last` marks the final beat. Received from the device, so construct from raw
+// bytes plus read accessors.
+class HostMemWriteReqFrame {
+public:
+  static constexpr size_t kNumItems = 8; // bus width in bytes (cosim: 64 / 8)
+  static constexpr size_t kMessageBits = 64 + 8 + kNumItems * 8 + 3 + 1; // 140
+  static constexpr size_t kMessageBytes = (kMessageBits + 7) / 8;        // 18
+
+  explicit HostMemWriteReqFrame(const uint8_t *raw) {
+    std::memcpy(bytes.data(), raw, kMessageBytes);
+  }
+
+  uint64_t address() const { return getBits(bytes.data(), kAddrOff, kAddrW); }
+  uint8_t tag() const { return getBits(bytes.data(), kTagOff, kTagW); }
+  uint8_t dataByte(size_t i) const {
+    return getBits(bytes.data(), kDataOff + 8 * i, 8);
+  }
+  // Number of valid data bytes in this beat (data_size holds valid_bytes - 1).
+  unsigned validBytes() const {
+    return static_cast<unsigned>(getBits(bytes.data(), kSizeOff, kSizeW)) + 1;
+  }
+  bool last() const { return getBits(bytes.data(), kLastOff, kLastW) != 0; }
+
+private:
+  static constexpr size_t kLastW = 1, kLastOff = 0;
+  static constexpr size_t kSizeW = 3, kSizeOff = kLastOff + kLastW;
+  static constexpr size_t kDataW = kNumItems * 8, kDataOff = kSizeOff + kSizeW;
+  static constexpr size_t kTagW = 8, kTagOff = kDataOff + kDataW;
+  static constexpr size_t kAddrW = 64, kAddrOff = kTagOff + kTagW;
+  std::array<uint8_t, kMessageBytes> bytes{};
+};
+
+// PCIe caps a single memory read request at the Max_Read_Request_Size, whose
+// largest encoding (PCIe Gen 4 and earlier) is 4096 bytes, but root ports often
+// negotiate a smaller limit. Model a conservative 64-double-word (256-byte) cap
+// here: a read request larger than this is a protocol violation.
+static constexpr uint32_t kPcieMaxReadRequestBytes = 64 * 4;
 
 class CosimHostMem : public HostMem {
 public:
@@ -441,10 +528,10 @@ public:
         !rpcClient->getChannelDesc("__cosim_hostmem_read_resp.data", readResp))
       throw std::runtime_error("Could not find HostMem read channels");
 
-    const esi::Type *readRespType =
-        getType(ctxt, new StructType(readResp.type,
-                                     {{"tag", new UIntType("ui8", 8)},
-                                      {"data", new BitsType("i64", 64)}}));
+    const esi::Type *readRespType = getType(
+        ctxt, new StructType(readResp.type, {{"tag", new UIntType("ui8", 8)},
+                                             {"data", new BitsType("i64", 64)},
+                                             {"last", new BitsType("i1", 1)}}));
     const esi::Type *readReqType =
         getType(ctxt, new StructType(readArg.type,
                                      {{"address", new UIntType("ui64", 64)},
@@ -474,7 +561,9 @@ public:
         getType(ctxt, new StructType(writeArg.type,
                                      {{"address", new UIntType("ui64", 64)},
                                       {"tag", new UIntType("ui8", 8)},
-                                      {"data", new BitsType("i64", 64)}}));
+                                      {"data", new BitsType("i64", 64)},
+                                      {"data_size", new UIntType("ui3", 3)},
+                                      {"last", new BitsType("i1", 1)}}));
 
     // Get ports, create the function, then connect to it.
     writeRespPort = std::make_unique<WriteCosimChannelPort>(
@@ -517,18 +606,29 @@ public:
                       "Reads of length 0 are not valid and indicate a bug "
                       "in the requester.",
                       toHex(req->address), req->tag));
+    if (req->length > kPcieMaxReadRequestBytes)
+      acc.getLogger().error(
+          "hostmem",
+          std::format("Read request length={} from addr=0x{} tag={} exceeds "
+                      "the PCIe maximum read request size ({} bytes). The "
+                      "requester must split reads larger than this into "
+                      "multiple requests.",
+                      req->length, toHex(req->address), req->tag,
+                      kPcieMaxReadRequestBytes));
     uint32_t numResps = std::max(numDataResps, 1u);
     for (uint32_t i = 0; i < numResps; ++i) {
-      HostMemReadResp resp{.data = i < numDataResps ? dataPtr[i] : 0,
-                           .tag = req->tag};
+      uint64_t word = i < numDataResps ? dataPtr[i] : 0;
+      bool last = i + 1 == numResps;
+      HostMemReadRespFrame frame(req->tag, word, last);
       acc.getLogger().trace(
           [&](std::string &subsystem, std::string &msg,
               std::unique_ptr<std::map<std::string, std::any>> &details) {
             subsystem = "HostMem";
-            msg = "Read result: data=0x" + toHex(resp.data) +
-                  " tag=" + std::to_string(resp.tag);
+            msg = "Read result: data=0x" + toHex(word) +
+                  " tag=" + std::to_string(req->tag) +
+                  " last=" + std::to_string(last);
           });
-      readRespPort->write(MessageData::from(resp));
+      readRespPort->write(frame.toMessage());
     }
     return true;
   }
@@ -536,20 +636,26 @@ public:
   // Service a write request as a callback. Simply write the data to the
   // location specified. TODO: check that the memory has been mapped.
   MessageData serviceWrite(const MessageData &reqBytes) {
-    const HostMemWriteReq *req = reqBytes.as<HostMemWriteReq>();
+    if (reqBytes.getSize() != HostMemWriteReqFrame::kMessageBytes)
+      throw std::runtime_error(
+          "HostMem write frame size mismatch. Size is " +
+          std::to_string(reqBytes.getSize()) + ", expected " +
+          std::to_string(HostMemWriteReqFrame::kMessageBytes) + ".");
+    HostMemWriteReqFrame req(reqBytes.getBytes());
     acc.getLogger().trace(
         [&](std::string &subsystem, std::string &msg,
             std::unique_ptr<std::map<std::string, std::any>> &details) {
           subsystem = "hostmem";
-          msg = "Write request: addr=0x" + toHex(req->address) + " data=0x" +
-                toHex(req->data) +
-                " valid_bytes=" + std::to_string(req->valid_bytes) +
-                " tag=" + std::to_string(req->tag);
+          msg = "Write request: addr=0x" + toHex(req.address()) +
+                " valid_bytes=" + std::to_string(req.validBytes()) +
+                " tag=" + std::to_string(req.tag()) +
+                " last=" + std::to_string(req.last());
         });
-    uint8_t *dataPtr = reinterpret_cast<uint8_t *>(req->address);
-    for (uint8_t i = 0; i < req->valid_bytes; ++i)
-      dataPtr[i] = (req->data >> (i * 8)) & 0xFF;
-    HostMemWriteResp resp = req->tag;
+    uint8_t *dataPtr = reinterpret_cast<uint8_t *>(req.address());
+    unsigned validBytes = req.validBytes();
+    for (unsigned i = 0; i < validBytes; ++i)
+      dataPtr[i] = req.dataByte(i);
+    HostMemWriteResp resp = req.tag();
     return MessageData::from(resp);
   }
 

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -953,38 +953,6 @@ hostmemWriteBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
             << std::to_string(duration.count()) << " us, "
             << std::to_string(cycles) << " cycles, " << bytesPerCycle
             << " bytes/cycle" << std::endl;
-
-  // Verify the write data pattern. WriteMem's per-burst flit counter is reset
-  // at command start and increments on each accepted flit, so the low 32 bits
-  // of flit i's payload must equal i. Elements are packed at a 32-bit-word-
-  // aligned stride (`((width + 31) / 32) * 4` bytes), so a mismatch indicates a
-  // lost/duplicated handshake or an element-address stride error.
-  size_t strideBytes = ((width + 31) / 32) * 4;
-  uint8_t *bytePtr = static_cast<uint8_t *>(region.getPtr());
-  size_t mismatches = 0;
-  size_t firstMismatch = 0;
-  uint32_t firstExpected = 0;
-  uint32_t firstActual = 0;
-  for (size_t i = 0; i < xferCount; ++i) {
-    uint32_t actual;
-    std::memcpy(&actual, bytePtr + i * strideBytes, sizeof(uint32_t));
-    uint32_t expected = static_cast<uint32_t>(i);
-    if (actual != expected) {
-      if (mismatches == 0) {
-        firstMismatch = i;
-        firstExpected = expected;
-        firstActual = actual;
-      }
-      ++mismatches;
-    }
-  }
-  if (mismatches != 0) {
-    std::stringstream ss;
-    ss << "hostmem write bandwidth data mismatch: " << mismatches << "/"
-       << xferCount << " flits wrong; first at i=" << firstMismatch
-       << " expected=" << firstExpected << " got=0x" << std::hex << firstActual;
-    throw std::runtime_error(ss.str());
-  }
 }
 
 static void

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -953,6 +953,38 @@ hostmemWriteBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
             << std::to_string(duration.count()) << " us, "
             << std::to_string(cycles) << " cycles, " << bytesPerCycle
             << " bytes/cycle" << std::endl;
+
+  // Verify the write data pattern. WriteMem's per-burst flit counter is reset
+  // at command start and increments on each accepted flit, so the low 32 bits
+  // of flit i's payload must equal i. Elements are packed at a 32-bit-word-
+  // aligned stride (`((width + 31) / 32) * 4` bytes), so a mismatch indicates a
+  // lost/duplicated handshake or an element-address stride error.
+  size_t strideBytes = ((width + 31) / 32) * 4;
+  uint8_t *bytePtr = static_cast<uint8_t *>(region.getPtr());
+  size_t mismatches = 0;
+  size_t firstMismatch = 0;
+  uint32_t firstExpected = 0;
+  uint32_t firstActual = 0;
+  for (size_t i = 0; i < xferCount; ++i) {
+    uint32_t actual;
+    std::memcpy(&actual, bytePtr + i * strideBytes, sizeof(uint32_t));
+    uint32_t expected = static_cast<uint32_t>(i);
+    if (actual != expected) {
+      if (mismatches == 0) {
+        firstMismatch = i;
+        firstExpected = expected;
+        firstActual = actual;
+      }
+      ++mismatches;
+    }
+  }
+  if (mismatches != 0) {
+    std::stringstream ss;
+    ss << "hostmem write bandwidth data mismatch: " << mismatches << "/"
+       << xferCount << " flits wrong; first at i=" << firstMismatch
+       << " expected=" << firstExpected << " got=0x" << std::hex << firstActual;
+    throw std::runtime_error(ss.str());
+  }
 }
 
 static void

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -466,14 +466,19 @@ static void hostmemWriteTest(Accelerator *acc,
         "hostmem write test failed. No writemem child found");
   auto &writeMemPorts = writeMemChildIter->second->getPorts();
 
-  auto cmdPortIter = writeMemPorts.find(AppID("cmd", width));
-  if (cmdPortIter == writeMemPorts.end())
+  // The MMIO command surface lives in a nested 'mmio[width]' submodule
+  // (BurstCommand -> MmioRegistry), exposing its 'cmd' port at
+  // writemem[width]/mmio[width]/cmd.
+  AppIDPath cmdPath;
+  BundlePort *cmdPortBundle = acc->resolvePort(
+      {AppID("writemem", width), AppID("mmio", width), AppID("cmd")}, cmdPath);
+  if (!cmdPortBundle)
     throw std::runtime_error(
-        "hostmem write test failed. No (cmd,width) MMIO port");
-  auto *cmdMMIO = cmdPortIter->second.getAs<services::MMIO::MMIORegion>();
+        "hostmem write test failed. No mmio[width]/cmd MMIO port");
+  auto *cmdMMIO = cmdPortBundle->getAs<services::MMIO::MMIORegion>();
   if (!cmdMMIO)
     throw std::runtime_error(
-        "hostmem write test failed. (cmd,width) port not MMIO");
+        "hostmem write test failed. mmio[width]/cmd port not MMIO");
 
   auto issuedPortIter = writeMemPorts.find(AppID("addrCmdIssued"));
   if (issuedPortIter == writeMemPorts.end())
@@ -533,15 +538,20 @@ static void hostmemReadTest(Accelerator *acc,
         "hostmem read test failed. No readmem child found");
 
   auto &readMemPorts = readMemChildIter->second->getPorts();
-  auto addrCmdPortIter = readMemPorts.find(AppID("cmd", width));
-  if (addrCmdPortIter == readMemPorts.end())
+  // The MMIO command surface lives in a nested 'mmio[width]' submodule
+  // (BurstCommand -> MmioRegistry), exposing its 'cmd' port at
+  // readmem[width]/mmio[width]/cmd.
+  AppIDPath addrCmdPath;
+  BundlePort *addrCmdPortBundle = acc->resolvePort(
+      {AppID("readmem", width), AppID("mmio", width), AppID("cmd")},
+      addrCmdPath);
+  if (!addrCmdPortBundle)
     throw std::runtime_error(
-        "hostmem read test failed. No AddressCommand MMIO port");
-  auto *addrCmdMMIO =
-      addrCmdPortIter->second.getAs<services::MMIO::MMIORegion>();
+        "hostmem read test failed. No mmio[width]/cmd MMIO port");
+  auto *addrCmdMMIO = addrCmdPortBundle->getAs<services::MMIO::MMIORegion>();
   if (!addrCmdMMIO)
     throw std::runtime_error(
-        "hostmem read test failed. AddressCommand port not MMIO");
+        "hostmem read test failed. mmio[width]/cmd port not MMIO");
 
   auto lastReadPortIter = readMemPorts.find(AppID("lastReadLSB"));
   if (lastReadPortIter == readMemPorts.end())
@@ -889,24 +899,32 @@ hostmemWriteBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
     throw std::runtime_error("hostmem write bandwidth: writemem child missing");
   auto &writeMemPorts = writeMemChildIter->second->getPorts();
 
-  auto cmdPortIter = writeMemPorts.find(AppID("cmd", width));
-  if (cmdPortIter == writeMemPorts.end())
+  // MMIO command surface and cycle telemetry live in nested BurstCommand
+  // submodules: MMIO at writemem[width]/mmio[width]/cmd and the active-cycle
+  // metric at writemem[width]/addrCmdResp/cycles.
+  AppIDPath cmdPath;
+  BundlePort *cmdPortBundle = acc->resolvePort(
+      {AppID("writemem", width), AppID("mmio", width), AppID("cmd")}, cmdPath);
+  if (!cmdPortBundle)
     throw std::runtime_error("hostmem write bandwidth: cmd MMIO missing");
-  auto *cmdMMIO = cmdPortIter->second.getAs<services::MMIO::MMIORegion>();
+  auto *cmdMMIO = cmdPortBundle->getAs<services::MMIO::MMIORegion>();
   if (!cmdMMIO)
     throw std::runtime_error("hostmem write bandwidth: cmd not MMIO");
 
+  AppIDPath cyclePath;
+  BundlePort *cyclePortBundle = acc->resolvePort(
+      {AppID("writemem", width), AppID("addrCmdResp"), AppID("cycles")},
+      cyclePath);
   auto issuedIter = writeMemPorts.find(AppID("addrCmdIssued"));
   auto respIter = writeMemPorts.find(AppID("addrCmdResponses"));
-  auto cycleCount = writeMemPorts.find(AppID("addrCmdCycles"));
   if (issuedIter == writeMemPorts.end() || respIter == writeMemPorts.end() ||
-      cycleCount == writeMemPorts.end())
+      !cyclePortBundle)
     throw std::runtime_error("hostmem write bandwidth: telemetry missing");
   auto *issuedPort =
       issuedIter->second.getAs<services::TelemetryService::Metric>();
   auto *respPort = respIter->second.getAs<services::TelemetryService::Metric>();
   auto *cyclePort =
-      cycleCount->second.getAs<services::TelemetryService::Metric>();
+      cyclePortBundle->getAs<services::TelemetryService::Metric>();
   if (!issuedPort || !respPort || !cyclePort)
     throw std::runtime_error(
         "hostmem write bandwidth: telemetry type mismatch");
@@ -969,24 +987,31 @@ hostmemReadBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
     throw std::runtime_error("hostmem read bandwidth: readmem child missing");
   auto &readMemPorts = readMemChildIter->second->getPorts();
 
-  auto cmdPortIter = readMemPorts.find(AppID("cmd", width));
-  if (cmdPortIter == readMemPorts.end())
+  // MMIO at readmem[width]/mmio[width]/cmd; active-cycle metric at
+  // readmem[width]/addrCmdResp/cycles (nested BurstCommand submodules).
+  AppIDPath cmdPath;
+  BundlePort *cmdPortBundle = acc->resolvePort(
+      {AppID("readmem", width), AppID("mmio", width), AppID("cmd")}, cmdPath);
+  if (!cmdPortBundle)
     throw std::runtime_error("hostmem read bandwidth: cmd MMIO missing");
-  auto *cmdMMIO = cmdPortIter->second.getAs<services::MMIO::MMIORegion>();
+  auto *cmdMMIO = cmdPortBundle->getAs<services::MMIO::MMIORegion>();
   if (!cmdMMIO)
     throw std::runtime_error("hostmem read bandwidth: cmd not MMIO");
 
+  AppIDPath cyclePath;
+  BundlePort *cyclePortBundle = acc->resolvePort(
+      {AppID("readmem", width), AppID("addrCmdResp"), AppID("cycles")},
+      cyclePath);
   auto issuedIter = readMemPorts.find(AppID("addrCmdIssued"));
   auto respIter = readMemPorts.find(AppID("addrCmdResponses"));
-  auto cyclePort = readMemPorts.find(AppID("addrCmdCycles"));
   if (issuedIter == readMemPorts.end() || respIter == readMemPorts.end() ||
-      cyclePort == readMemPorts.end())
+      !cyclePortBundle)
     throw std::runtime_error("hostmem read bandwidth: telemetry missing");
   auto *issuedPort =
       issuedIter->second.getAs<services::TelemetryService::Metric>();
   auto *respPort = respIter->second.getAs<services::TelemetryService::Metric>();
   auto *cycleCntPort =
-      cyclePort->second.getAs<services::TelemetryService::Metric>();
+      cyclePortBundle->getAs<services::TelemetryService::Metric>();
   if (!issuedPort || !respPort || !cycleCntPort)
     throw std::runtime_error("hostmem read bandwidth: telemetry type mismatch");
   issuedPort->connect();
@@ -1249,6 +1274,12 @@ static void aggregateHostmemBandwidthTest(AcceleratorConnection *conn,
   const std::vector<std::string> writePrefixes = {"writemem", "writemem_0",
                                                   "writemem_1", "writemem_2"};
 
+  // Size each unit's region to the actual transfer (min 1 MiB) rather than a
+  // fixed 1 GiB, so aggregating many units stays memory-bounded.
+  size_t strideBytes = ((width + 31) / 32) * 4;
+  size_t neededBytes = static_cast<size_t>(xferCount) * strideBytes;
+  size_t regionBytes = neededBytes < (1u << 20) ? (1u << 20) : neededBytes;
+
   auto addUnits = [&](const std::vector<std::string> &pref, bool doRead,
                       bool doWrite) {
     for (auto &p : pref) {
@@ -1257,14 +1288,19 @@ static void aggregateHostmemBandwidthTest(AcceleratorConnection *conn,
       if (childIt == acc->getChildren().end())
         continue; // silently skip missing variants
       auto &ports = childIt->second->getPorts();
-      auto cmdIt = ports.find(AppID("cmd", width));
       auto respIt = ports.find(AppID("addrCmdResponses"));
-      auto cycIt = ports.find(AppID("addrCmdCycles"));
-      if (cmdIt == ports.end() || respIt == ports.end() || cycIt == ports.end())
+      // MMIO ('cmd') and the cycle metric are nested inside BurstCommand
+      // submodules: <unit>/mmio[width]/cmd and <unit>/addrCmdResp/cycles.
+      AppIDPath cmdPath, cycPath;
+      BundlePort *cmdBundle =
+          acc->resolvePort({id, AppID("mmio", width), AppID("cmd")}, cmdPath);
+      BundlePort *cycBundle = acc->resolvePort(
+          {id, AppID("addrCmdResp"), AppID("cycles")}, cycPath);
+      if (respIt == ports.end() || !cmdBundle || !cycBundle)
         continue;
-      auto *cmd = cmdIt->second.getAs<services::MMIO::MMIORegion>();
+      auto *cmd = cmdBundle->getAs<services::MMIO::MMIORegion>();
       auto *resp = respIt->second.getAs<services::TelemetryService::Metric>();
-      auto *cyc = cycIt->second.getAs<services::TelemetryService::Metric>();
+      auto *cyc = cycBundle->getAs<services::TelemetryService::Metric>();
       if (!cmd || !resp || !cyc)
         continue;
       resp->connect();
@@ -1273,7 +1309,7 @@ static void aggregateHostmemBandwidthTest(AcceleratorConnection *conn,
       u.prefix = p;
       u.isRead = doRead;
       u.isWrite = doWrite;
-      u.region = hostmemSvc->allocate(1024 * 1024 * 1024, {.writeable = true});
+      u.region = hostmemSvc->allocate(regionBytes, {.writeable = true});
       // Init pattern.
       uint64_t *ptr = static_cast<uint64_t *>(u.region->getPtr());
       size_t words = u.region->getSize() / 8;

--- a/lib/Dialect/ESI/runtime/pyproject.toml
+++ b/lib/Dialect/ESI/runtime/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-xdist", "pycde>=0.10.0"]
+test = ["pytest", "pytest-xdist", "pycde>=0.11.0"]
 
 [project.scripts]
 esiquery = "esiaccel.utils:run_esiquery"

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -16,6 +16,8 @@ from pycde.system import System
 from pycde.types import (Array, Bits, Bundle, BundledChannel, Channel,
                          ChannelDirection, StructType, Type, UInt, Window)
 
+from esiaccel.components import ChannelArbiter
+
 from typing import Callable, Dict, List, Tuple
 import typing
 
@@ -713,11 +715,13 @@ def TaggedReadGearbox(input_bitwidth: int,
         StructType([
             ("tag", esi.HostMem.TagType),
             ("data", Bits(input_bitwidth)),
+            ("last", Bits(1)),
         ]))
     out = OutputChannel(
         StructType([
             ("tag", esi.HostMem.TagType),
             ("data", Bits(output_bitwidth)),
+            ("last", Bits(1)),
         ]))
 
     @generator
@@ -726,21 +730,25 @@ def TaggedReadGearbox(input_bitwidth: int,
       upstream_tag_and_data, upstream_valid = ports.in_.unwrap(
           ready_for_upstream)
       upstream_data = upstream_tag_and_data.data
+      upstream_last = upstream_tag_and_data.last
       upstream_xact = ready_for_upstream & upstream_valid
 
       # Determine if gearboxing is necessary and whether it needs to be
-      # gearboxed up or just sliced down.
+      # gearboxed up or just sliced down. 'last' (the burst end-of-list marker)
+      # travels with the final engine word that completes each client flit.
       if output_bitwidth == input_bitwidth:
         client_data_bits = upstream_data
         client_valid = upstream_valid
+        client_last = upstream_last
       elif output_bitwidth < input_bitwidth:
         client_data_bits = upstream_data[:output_bitwidth]
         client_valid = upstream_valid
+        client_last = upstream_last
       else:
-        # Create registers equal to the number of upstream transactions needed
-        # to fill the client data. Set the output to the concatenation of said
-        # registers.
+        # Registers accumulate `chunks` upstream words into one client element;
+        # the output is their concatenation.
         chunks = ceil(output_bitwidth / input_bitwidth)
+        counter_width = clog2(chunks)
         reg_ces = [Wire(Bits(1)) for _ in range(chunks)]
         regs = [
             upstream_data.reg(ports.clk,
@@ -750,24 +758,42 @@ def TaggedReadGearbox(input_bitwidth: int,
         ]
         client_data_bits = BitsSignal.concat(reversed(regs))[:output_bitwidth]
 
-        # Use counter to determine to which register to write and determine if
-        # the registers are all full.
-        clear_counter = Wire(Bits(1))
-        counter_width = clog2(chunks)
-        counter = Counter(counter_width)(clk=ports.clk,
-                                         rst=ports.rst,
-                                         clear=clear_counter,
-                                         increment=upstream_xact)
-        set_client_valid = counter.out == chunks - 1
+        # Pair-index counter: the word accepted this cycle is written to
+        # chunk_reg[counter]; it advances on each accepted word and resets after
+        # a client element is consumed. When a client consume (`client_xact`)
+        # and an upstream accept (`upstream_xact`) land on the same cycle, the
+        # accepted word is chunk 0 of the *next* element, so the next index must
+        # be 1 -- not 0. A plain `Counter` mishandles this (its `clear` beats
+        # `increment`, dropping the accepted word and stalling the pairing,
+        # which loses words and can deadlock the read), so compute the next
+        # value explicitly. `Mux(sel, a, b)` selects `a` when sel==0, `b` when
+        # sel==1.
+        counter = Wire(UInt(counter_width), name="chunk_counter")
         client_xact = Wire(Bits(1))
+        incremented = (counter + 1).as_uint(counter_width)
+        counter.assign(
+            Mux(
+                client_xact, Mux(upstream_xact, counter, incremented),
+                Mux(upstream_xact,
+                    UInt(counter_width)(0),
+                    UInt(counter_width)(1))).reg(ports.clk,
+                                                 ports.rst,
+                                                 rst_value=0,
+                                                 ce=(upstream_xact |
+                                                     client_xact).as_bits(),
+                                                 name="chunk_counter_reg"))
+        set_client_valid = counter == (chunks - 1)
         client_valid = ControlReg(ports.clk, ports.rst,
                                   [set_client_valid & upstream_xact],
                                   [client_xact])
         client_xact.assign(client_valid & ready_for_upstream)
-        clear_counter.assign(client_xact)
         for idx, reg_ce in enumerate(reg_ces):
-          reg_ce.assign(upstream_xact &
-                        (counter.out == UInt(counter_width)(idx)))
+          reg_ce.assign(upstream_xact & (counter == UInt(counter_width)(idx)))
+        # 'last' of the final engine word that completes this client flit.
+        client_last = upstream_last.reg(ports.clk,
+                                        ports.rst,
+                                        ce=upstream_xact,
+                                        name="last_reg")
 
       # Construct the output channel. Shared logic across all three cases.
       tag_reg = upstream_tag_and_data.tag.reg(ports.clk,
@@ -779,11 +805,172 @@ def TaggedReadGearbox(input_bitwidth: int,
           {
               "tag": tag_reg,
               "data": client_data_bits,
+              "last": client_last,
           }, client_valid)
       ready_for_upstream.assign(client_ready)
       ports.out = client_channel
 
   return TaggedReadGearboxImpl
+
+
+# Maximum PCIe read request size in bytes. PCIe's Max_Read_Request_Size tops out
+# at 4096 bytes, but root ports often negotiate a smaller limit, so use a
+# conservative 64-double-word (256-byte) cap. Reads larger than this must be
+# split by the requester into multiple requests. Mirrors kPcieMaxReadRequestBytes
+# in the Cosim backend (cpp/lib/backends/Cosim.cpp).
+PCIE_MAX_READ_REQUEST_BYTES = 64 * 4  # 64 double words
+
+# Maximum PCIe write payload size in bytes (Max Payload Size analog). A single
+# upstream write transaction must not exceed this; an element whose write
+# payload is wider is split into multiple <= this-size transactions.
+PCIE_MAX_WRITE_PAYLOAD_BYTES = 256
+
+
+@modparams
+def HostMemReadReqSplitter(req_channel_type: Channel,
+                           resp_channel_type: Channel, max_chunk_bytes: int):
+  """Split oversized host memory read requests into PCIe-compliant chunks before
+  arbitration and reassemble the per-chunk responses into a single logical
+  burst.
+
+  A burst read (`read_list`) can request many more bytes than the PCIe maximum
+  read request size allows in a single request. This module breaks such a
+  request into `max_chunk_bytes`-sized (element-aligned, MRRS-compliant) chunks
+  addressed sequentially from the base. Splitting here -- *before* the requests
+  are arbitrated onto the shared upstream read channel -- lets each client's
+  chunks interleave with other clients' requests, so one large burst does not
+  monopolize host memory bandwidth.
+
+  On the response path the per-chunk end-of-list markers are dropped and a
+  single burst-final `last` is re-derived from the total transfer length, so the
+  gearbox and client see one contiguous response stream identical to an unsplit
+  read.
+
+  Only one logical request is in flight at a time (matching the read processor's
+  one-outstanding-transaction-per-client model): a new request is not accepted
+  until the current burst's chunks have all been issued and its responses have
+  fully drained.
+
+  req_channel_type:  channel of the upstream read request {address, length
+    (bytes), tag}.
+  resp_channel_type: channel of the upstream response {tag, data, last}.
+  max_chunk_bytes:   largest per-chunk byte count; must be > 0, a multiple of the
+    element stride, and <= PCIE_MAX_READ_REQUEST_BYTES.
+  """
+  assert 0 < max_chunk_bytes <= PCIE_MAX_READ_REQUEST_BYTES
+
+  req_struct = req_channel_type.inner_type
+  resp_struct = resp_channel_type.inner_type
+  req_fields = dict(req_struct.fields)
+  addr_width = req_fields["address"].bitwidth
+  length_width = req_fields["length"].bitwidth
+  tag_type = req_fields["tag"]
+  word_bytes = dict(resp_struct.fields)["data"].bitwidth // 8
+  word_shift = clog2(word_bytes)
+  words_width = length_width - word_shift
+
+  class HostMemReadReqSplitterImpl(Module):
+    clk = Clock()
+    rst = Reset()
+    req_in = Input(req_channel_type)
+    req_out = Output(req_channel_type)
+    resp_in = Input(resp_channel_type)
+    resp_out = Output(resp_channel_type)
+
+    @generator
+    def build(ports):
+      clk = ports.clk
+      rst = ports.rst
+
+      # Burst state shared by the request-splitting and response-reassembly
+      # FSMs. One logical request is processed at a time.
+      emit_busy = Wire(Bits(1), name="emit_busy")  # issuing chunk requests
+      resp_busy = Wire(Bits(1), name="resp_busy")  # responses still draining
+      cur_addr = Wire(UInt(addr_width), name="cur_addr")
+      remaining = Wire(UInt(length_width), name="remaining")  # req bytes left
+      tag_reg = Wire(tag_type, name="tag_reg")
+      words_left = Wire(UInt(words_width), name="words_left")  # resp words left
+
+      idle = ((~emit_busy) & (~resp_busy)).as_bits()
+
+      # --- Request intake and splitting ---
+      req_ready = Wire(Bits(1))
+      req_payload, req_valid = ports.req_in.unwrap(req_ready)
+      accept = (idle & req_valid).as_bits()
+      req_ready.assign(accept)
+
+      max_chunk = UInt(length_width)(max_chunk_bytes)
+      chunk_len = Mux(remaining > max_chunk, remaining, max_chunk)
+      last_chunk = (remaining <= max_chunk).as_bits()
+
+      req_out_ch, req_out_ready = req_channel_type.wrap(
+          req_struct({
+              "address": cur_addr,
+              "length": chunk_len,
+              "tag": tag_reg,
+          }), emit_busy)
+      ports.req_out = req_out_ch
+      chunk_xact = (emit_busy & req_out_ready).as_bits()
+
+      emit_busy.assign(
+          ControlReg(clk,
+                     rst, [accept], [(chunk_xact & last_chunk).as_bits()],
+                     name="emit_busy_reg"))
+
+      # cur_addr: load base on accept, advance by the chunk on each issue.
+      cur_addr_incr = (cur_addr +
+                       chunk_len.as_uint(addr_width)).as_uint(addr_width)
+      cur_addr.assign(
+          Mux(accept, Mux(chunk_xact, cur_addr, cur_addr_incr),
+              req_payload.address).reg(clk,
+                                       rst,
+                                       rst_value=0,
+                                       ce=(accept | chunk_xact).as_bits(),
+                                       name="cur_addr_reg"))
+
+      # remaining: load length on accept, subtract each issued chunk.
+      remaining_dec = (remaining - chunk_len).as_uint(length_width)
+      remaining.assign(
+          Mux(accept, Mux(chunk_xact, remaining, remaining_dec),
+              req_payload.length).reg(clk,
+                                      rst,
+                                      rst_value=0,
+                                      ce=(accept | chunk_xact).as_bits(),
+                                      name="remaining_reg"))
+
+      tag_reg.assign(req_payload.tag.reg(clk, rst, ce=accept, name="tag_reg_r"))
+
+      # --- Response reassembly: re-derive the single burst-final 'last'. ---
+      total_words = req_payload.length.as_bits()[word_shift:].as_uint()
+      resp_ready = Wire(Bits(1))
+      resp_payload, resp_valid = ports.resp_in.unwrap(resp_ready)
+      is_final_word = (words_left == UInt(words_width)(1)).as_bits()
+      resp_out_ch, resp_out_ready = resp_channel_type.wrap(
+          resp_struct({
+              "tag": resp_payload.tag,
+              "data": resp_payload.data,
+              "last": is_final_word,
+          }), resp_valid)
+      ports.resp_out = resp_out_ch
+      resp_ready.assign(resp_out_ready)
+      resp_xact = (resp_valid & resp_out_ready).as_bits()
+
+      # words_left: load total on accept, decrement per received word.
+      words_dec = (words_left - UInt(words_width)(1)).as_uint(words_width)
+      words_left.assign(
+          Mux(accept, Mux(resp_xact, words_left, words_dec),
+              total_words).reg(clk,
+                               rst,
+                               rst_value=0,
+                               ce=(accept | resp_xact).as_bits(),
+                               name="words_left_reg"))
+
+      resp_busy.assign(
+          ControlReg(clk,
+                     rst, [accept], [(resp_xact & is_final_word).as_bits()],
+                     name="resp_busy_reg"))
+
+  return HostMemReadReqSplitterImpl
 
 
 def HostmemReadProcessor(read_width: int, hostmem_module,
@@ -840,9 +1027,14 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
       ports.upstream = upstream_read_bundle
       upstream_resp_channel = froms["resp"]
 
+      # Demux the upstream parallel-window frames {tag, data, last} to each
+      # client by tag. The gearbox consumes {tag, data, last}: single-message
+      # clients discard 'last'; burst (read_list) clients propagate it as their
+      # response window's per-frame 'last'.
       demux = esi.TaggedDemux(len(reqs), upstream_resp_channel.type)(
           clk=ports.clk, rst=ports.rst, in_=upstream_resp_channel)
 
+      word_bytes = read_width // 8
       tagged_client_reqs = []
       for idx, client in enumerate(reqs):
         # Find the response channel in the request bundle.
@@ -856,40 +1048,109 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
         # For now, only support one outstanding transaction at a time.  This has
         # the additional benefit of letting the upstream tag be the client
         # identifier. TODO: Implement the gating logic here.
-
-        # Gearbox the data to the client's data type.
         client_type = resp_type.inner_type
-        if client_type.data.bitwidth == 0:
-          raise ValueError("Client data type cannot be zero-width. Use a "
-                           "single-bit type if no data is needed.")
 
-        gearbox = TaggedReadGearbox(read_width, client_type.data.bitwidth)(
-            clk=ports.clk, rst=ports.rst, in_=demuxed_upstream_channel)
-        client_resp_channel = gearbox.out.transform(lambda m: client_type({
-            "tag": m.tag,
-            "data": m.data.bitcast(client_type.data)
-        }))
+        if isinstance(client_type, Window):
+          # Burst read (read_list): the response is a parallel window over
+          # struct{tag, data: list<element>} with num_items=1, lowering to
+          # struct{tag, data: element, last}. Gearbox each engine word to the
+          # element width, propagate 'last', then re-wrap as the window. Each
+          # element is word-aligned on the wire, so any element width maps onto
+          # a whole number of engine words.
+          lowered = client_type.lowered_type
+          lowered_fields = dict(lowered.fields)
+          element_type = lowered_fields["data"]
+          element_bits = element_type.bitwidth
+          data_size_type = lowered_fields["data_size"]
+          if element_bits == 0:
+            raise ValueError("read_list element type cannot be zero-width.")
+          words_per_elem = (element_bits + read_width - 1) // read_width
+          elem_stride_bytes = words_per_elem * word_bytes
 
-        # Assign the client response to the correct port.
-        client_bundle, froms = client.type.pack(resp=client_resp_channel)
-        client_req = froms["req"]
-        tagged_client_req = client_req.transform(
-            lambda r: hostmem_module.UpstreamReadReq({
-                "address": r.address,
-                "length": (client_type.data.bitwidth + 7) // 8,
-                # TODO: Change this once we support tag-rewriting.
-                "tag": idx
-            }))
+          # A burst can request far more than the PCIe maximum read request
+          # size, so split it into MRRS-compliant, element-aligned chunks before
+          # arbitration and reassemble the responses afterwards; the gearbox
+          # then sees one contiguous response stream. 'splitter_resp' breaks the
+          # request/response construction cycle (the client request is derived
+          # from the packed response bundle).
+          max_chunk_bytes = max(
+              1, PCIE_MAX_READ_REQUEST_BYTES // elem_stride_bytes) * \
+              elem_stride_bytes
+          splitter_resp = Wire(demuxed_upstream_channel.type)
+          gearbox = TaggedReadGearbox(read_width,
+                                      element_bits)(clk=ports.clk,
+                                                    rst=ports.rst,
+                                                    in_=splitter_resp)
+          client_resp_channel = gearbox.out.transform(
+              lambda m, lowered=lowered, element_type=element_type,
+              data_size_type=data_size_type, client_type=client_type:
+              client_type.wrap(
+                  lowered({
+                      "tag": m.tag,
+                      "data": m.data.bitcast(element_type),
+                      "data_size": data_size_type(0),
+                      "last": m.last,
+                  })))
+          client_bundle, froms = client.type.pack(resp=client_resp_channel)
+          client_req = froms["req"]
+          logical_req = client_req.transform(
+              lambda r, idx=idx, elem_stride_bytes=elem_stride_bytes:
+              hostmem_module.UpstreamReadReq({
+                  "address":
+                      r.address,
+                  "length": (r.length * UInt(64)
+                             (elem_stride_bytes)).as_uint(32),
+                  "tag":
+                      idx,
+              }))
+          splitter = HostMemReadReqSplitter(
+              logical_req.type, demuxed_upstream_channel.type,
+              max_chunk_bytes)(clk=ports.clk,
+                               rst=ports.rst,
+                               req_in=logical_req,
+                               resp_in=demuxed_upstream_channel)
+          splitter_resp.assign(splitter.resp_out)
+          tagged_client_req = splitter.req_out
+        else:
+          # Single-message read: gearbox to the client width and discard the
+          # 'last' burst marker.
+          if client_type.data.bitwidth == 0:
+            raise ValueError("Client data type cannot be zero-width. Use a "
+                             "single-bit type if no data is needed.")
+          gearbox = TaggedReadGearbox(read_width, client_type.data.bitwidth)(
+              clk=ports.clk, rst=ports.rst, in_=demuxed_upstream_channel)
+          client_resp_channel = gearbox.out.transform(
+              lambda m, client_type=client_type: client_type({
+                  "tag": m.tag,
+                  "data": m.data.bitcast(client_type.data)
+              }))
+          client_bundle, froms = client.type.pack(resp=client_resp_channel)
+          client_req = froms["req"]
+          tagged_client_req = client_req.transform(
+              lambda r, idx=idx, client_type=client_type: hostmem_module.
+              UpstreamReadReq({
+                  "address": r.address,
+                  "length": (client_type.data.bitwidth + 7) // 8,
+                  # TODO: Change this once we support tag-rewriting.
+                  "tag": idx
+              }))
+
         tagged_client_reqs.append(tagged_client_req)
 
         # Set the port for the client request.
         setattr(ports, HostmemReadProcessorImpl.reqPortMap[client],
                 client_bundle)
 
-      # Assign the multiplexed read request to the upstream request.
+      # Assign the multiplexed read request to the upstream request. Use the
+      # list-aware, pipelined ChannelArbiter (vs. the combinational ChannelMux)
+      # for a registered N:1 mux that closes timing at high client fan-in. Read
+      # requests are single-flit, so list-awareness is a no-op here.
       # TODO: Don't release a request until the client is ready to accept
       # the response otherwise the system could deadlock.
-      muxed_client_reqs = esi.ChannelMux(tagged_client_reqs)
+      muxed_client_reqs = ChannelArbiter(tagged_client_reqs,
+                                         ports.clk,
+                                         ports.rst,
+                                         telemetry=False)
       upstream_req_channel.assign(muxed_client_reqs)
       HostmemReadProcessorImpl.reqPortMap.clear()
 
@@ -897,11 +1158,16 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
 
 
 @modparams
-def TaggedWriteGearbox(input_bitwidth: int,
-                       output_bitwidth: int) -> type["TaggedWriteGearboxImpl"]:
+def TaggedWriteGearbox(input_bitwidth: int, output_bitwidth: int,
+                       max_burst_bytes: int) -> type["TaggedWriteGearboxImpl"]:
   """Build a gearbox to convert the client data to upstream write chunks.
   Assumes a struct {address, tag, data} and only gearboxes the data. Tag is
-  stored separately and the struct is re-assembled later on."""
+  stored separately and the struct is re-assembled later on.
+
+  'max_burst_bytes' caps a single contiguous upstream write transaction (PCIe
+  max-payload-size analog): when an element spans more than 'max_burst_bytes',
+  its engine words are split into multiple <= 'max_burst_bytes' transactions by
+  emitting the framing 'last' at each boundary. 0 disables the cap."""
 
   if output_bitwidth % 8 != 0:
     raise ValueError("Output bitwidth must be a multiple of 8.")
@@ -909,6 +1175,13 @@ def TaggedWriteGearbox(input_bitwidth: int,
   if input_bitwidth % 8 != 0:
     input_pad_bits = 8 - (input_bitwidth % 8)
   input_padded_bitwidth = input_bitwidth + input_pad_bits
+
+  # Number of engine words per capped transaction (0 = uncapped).
+  max_burst_words = (max_burst_bytes //
+                     (output_bitwidth // 8)) if max_burst_bytes else 0
+  if max_burst_words:
+    assert (max_burst_words & (max_burst_words - 1)) == 0, \
+        "max_burst_bytes / (output_bitwidth // 8) must be a power of two"
 
   class TaggedWriteGearboxImpl(Module):
     clk = Clock()
@@ -925,6 +1198,7 @@ def TaggedWriteGearbox(input_bitwidth: int,
             ("tag", esi.HostMem.TagType),
             ("data", Bits(output_bitwidth)),
             ("valid_bytes", Bits(8)),
+            ("last", Bits(1)),
         ]))
 
     num_chunks = ceil(input_padded_bitwidth / output_bitwidth)
@@ -950,6 +1224,7 @@ def TaggedWriteGearbox(input_bitwidth: int,
         tag = client_tag_and_data.tag
         address = client_tag_and_data.address
         valid_bytes = Bits(8)(input_bitwidth_bytes)
+        last = Bits(1)(1)
       elif output_bitwidth > input_padded_bitwidth:
         upstream_data_bits = client_data.as_bits(output_bitwidth)
         upstream_valid = client_valid
@@ -957,6 +1232,7 @@ def TaggedWriteGearbox(input_bitwidth: int,
         tag = client_tag_and_data.tag
         address = client_tag_and_data.address
         valid_bytes = Bits(8)(input_bitwidth_bytes)
+        last = Bits(1)(1)
       else:
         # Create registers equal to the number of upstream transactions needed
         # to complete the transmission.
@@ -1004,16 +1280,29 @@ def TaggedWriteGearbox(input_bitwidth: int,
                                                    name="address_reg")
         address = (addr_reg + counter_bytes).as_uint(64)
         tag = tag_reg
-        valid_bytes = Mux(counter.out == (num_chunks - 1),
+        elem_end = counter.out == (num_chunks - 1)
+        valid_bytes = Mux(elem_end,
                           Bits(8)(output_bitwidth_bytes),
                           Bits(8)((output_bitwidth - padding_numbits) // 8))
+        if max_burst_words and num_chunks > max_burst_words:
+          # PCIe max-payload-size cap: end the upstream write transaction at the
+          # element end OR every max_burst_words engine words, whichever comes
+          # first, so a wide element's write is split into <= max_burst_bytes
+          # transactions. Each word keeps its own sequential address; only the
+          # transaction-framing 'last' changes.
+          burst_shift = clog2(max_burst_words)
+          burst_end = counter.out.as_bits()[:burst_shift].and_reduce()
+          last = (elem_end | burst_end).as_bits()
+        else:
+          last = elem_end.as_bits()
 
       upstream_channel, upstrm_ready_sig = TaggedWriteGearboxImpl.out.type.wrap(
           {
               "address": address,
               "tag": tag,
               "data": upstream_data_bits,
-              "valid_bytes": valid_bytes
+              "valid_bytes": valid_bytes,
+              "last": last,
           }, upstream_valid)
       upstream_ready.assign(upstrm_ready_sig)
       ports.out = upstream_channel
@@ -1105,6 +1394,11 @@ def HostMemWriteProcessor(
       clk = ports.clk
       rst = ports.rst
 
+      # Width of the frame's 'data_size' field: log2 of the number of bytes per
+      # engine word. It holds (valid_bytes - 1) for the final (possibly partial)
+      # word of a write.
+      size_width = clog2(write_width // 8)
+
       # If there's no write clients, just create a no-op write bundle
       if len(reqs) == 0:
         req, _ = Channel(hostmem_module.UpstreamWriteReq).wrap(
@@ -1112,7 +1406,8 @@ def HostMemWriteProcessor(
                 "address": 0,
                 "tag": 0,
                 "data": 0,
-                "valid_bytes": 0,
+                "data_size": 0,
+                "last": 0,
             }, 0)
         write_bundle, _ = hostmem_module.write.type.pack(req=req)
         ports.upstream = write_bundle
@@ -1137,36 +1432,85 @@ def HostMemWriteProcessor(
         # Get the request channel and its data type.
         reqch = [c.channel for c in req.type.channels if c.name == 'req'][0]
         client_type = reqch.inner_type
-        if isinstance(client_type.data, Window):
-          client_type = client_type.lowered_type
-
-        # Pack up the bundle and assign the request channel.
-        write_req_bundle_type = esi.HostMem.write_req_bundle_type(
-            client_type.data)
         input_flit_ack = Wire(upstream_ack_tag.type)
-        bundle_sig, froms = write_req_bundle_type.pack(ackTag=input_flit_ack)
 
-        gearbox_mod = TaggedWriteGearbox(client_type.data.bitwidth, write_width)
-        gearbox_in_type = gearbox_mod.in_.type.inner_type
-        tagged_client_req = froms["req"]
-        bitcast_client_req = tagged_client_req.transform(
-            lambda m: gearbox_in_type({
-                "tag": m.tag,
-                "address": m.address,
-                "data": m.data.bitcast(gearbox_in_type.data)
-            }))
+        if isinstance(client_type, Window):
+          # Windowed (list) write: the client streams a list of elements to be
+          # written to sequential addresses from a base. Lowered frame:
+          # struct{address, tag, data: elem[num_items], data_size, last}. One
+          # element per frame (num_items=1 here).
+          bundle_sig, wfroms = req.type.pack(ackTag=input_flit_ack)
+          windowed_req = wfroms["req"]
+          lowered = client_type.lowered_type
+          array_type = dict(lowered.fields)["data"]
+          element_bits = array_type.element_type.bitwidth
+          # Elements are packed in host memory at a 32-bit-word-aligned stride
+          # (`ceil(element_bits / 32) * 4` bytes), matching the host-side
+          # layout. This keeps narrow (<64b) elements tightly packed instead of
+          # wasting the high half of each 64-bit engine word.
+          elem_stride = ((element_bits + 31) // 32) * 4
 
-        # Gearbox the data to the client's data type.
-        gearbox = gearbox_mod(clk=ports.clk,
-                              rst=ports.rst,
-                              in_=bitcast_client_req)
+          gearbox_mod = TaggedWriteGearbox(element_bits, write_width,
+                                           PCIE_MAX_WRITE_PAYLOAD_BYTES)
+          gearbox_in_type = gearbox_mod.in_.type.inner_type
+
+          # Unwrap the window frames; compute a base+offset address from a
+          # per-burst element counter (reset after each burst's final element).
+          ready_for_frame = Wire(Bits(1))
+          frame_win, frame_valid = windowed_req.unwrap(ready_for_frame)
+          frame = frame_win.unwrap()
+          frame_xact = frame_valid & ready_for_frame
+          elem_clear = Wire(Bits(1))
+          elem_counter = Counter(64)(clk=ports.clk,
+                                     rst=ports.rst,
+                                     clear=elem_clear,
+                                     increment=frame_xact)
+          elem_clear.assign((frame_xact & frame["last"]).as_bits())
+          elem_addr = (frame["address"] +
+                       elem_counter.out * UInt(64)(elem_stride)).as_uint(64)
+          gearbox_in_chan, gearbox_in_ready = Channel(gearbox_in_type).wrap(
+              gearbox_in_type({
+                  "tag": frame["tag"],
+                  "address": elem_addr,
+                  "data": frame["data"][0].bitcast(gearbox_in_type.data),
+              }), frame_valid)
+          ready_for_frame.assign(gearbox_in_ready)
+          gearbox = gearbox_mod(clk=ports.clk,
+                                rst=ports.rst,
+                                in_=gearbox_in_chan)
+        else:
+          # Single-message write.
+          write_req_bundle_type = esi.HostMem.write_req_bundle_type(
+              client_type.data)
+          bundle_sig, sfroms = write_req_bundle_type.pack(ackTag=input_flit_ack)
+          gearbox_mod = TaggedWriteGearbox(client_type.data.bitwidth,
+                                           write_width,
+                                           PCIE_MAX_WRITE_PAYLOAD_BYTES)
+          gearbox_in_type = gearbox_mod.in_.type.inner_type
+          bitcast_client_req = sfroms["req"].transform(
+              lambda m, git=gearbox_in_type: git({
+                  "tag": m.tag,
+                  "address": m.address,
+                  "data": m.data.bitcast(git.data)
+              }))
+          gearbox = gearbox_mod(clk=ports.clk,
+                                rst=ports.rst,
+                                in_=bitcast_client_req)
+
         write_channels.append(
-            gearbox.out.transform(lambda m: m.type({
-                "address": m.address,
-                "tag": idx,
-                "data": m.data,
-                "valid_bytes": m.valid_bytes
-            })))
+            gearbox.out.transform(
+                lambda m, idx=idx: hostmem_module.UpstreamWriteReq({
+                    "address":
+                        m.address,
+                    "tag":
+                        idx,
+                    "data":
+                        m.data,
+                    "data_size": (m.valid_bytes.as_uint() - UInt(8)
+                                  (1)).as_bits()[:size_width],
+                    "last":
+                        m.last,
+                })))
 
         # Count the number of acks received from hostmem for this client
         # and only send one back to the client per input.
@@ -1177,8 +1521,16 @@ def HostMemWriteProcessor(
         # Set the port for the client request.
         setattr(ports, HostMemWriteProcessorImpl.reqPortMap[req], bundle_sig)
 
-      # Build a channel mux for the write requests.
-      muxed_write_channel = esi.ChannelMux(write_channels)
+      # Multiplex the write requests onto the single upstream channel with the
+      # list-aware, pipelined ChannelArbiter (matching the read side). A real
+      # windowed write (multi-word client flits) engages the arbiter's list-
+      # awareness -- via the frame's 'last' -- to keep a client's words
+      # contiguous; single-word (<= engine width) clients emit one message per
+      # word, for which single-flit arbitration is correct.
+      muxed_write_channel = ChannelArbiter(write_channels,
+                                           ports.clk,
+                                           ports.rst,
+                                           telemetry=False)
       upstream_req_channel.assign(muxed_write_channel)
 
   return HostMemWriteProcessorImpl
@@ -1208,6 +1560,7 @@ def ChannelHostMem(read_width: int,
                 StructType([
                     ("tag", esi.HostMem.TagType),
                     ("data", Bits(read_width)),
+                    ("last", Bits(1)),
                 ])),
         ]))
 
@@ -1217,7 +1570,8 @@ def ChannelHostMem(read_width: int,
         ("address", UInt(64)),
         ("tag", UInt(8)),
         ("data", Bits(write_width)),
-        ("valid_bytes", Bits(8)),
+        ("data_size", Bits(clog2(write_width // 8))),
+        ("last", Bits(1)),
     ])
     write = Output(
         Bundle([
@@ -1230,7 +1584,10 @@ def ChannelHostMem(read_width: int,
       # Split the read side out into a separate module. Must assign the output
       # ports to the clients since we can't service a request in a different
       # module.
-      read_reqs = [req for req in bundles.to_client_reqs if req.port == 'read']
+      read_reqs = [
+          req for req in bundles.to_client_reqs
+          if req.port in ('read', 'read_list')
+      ]
       read_proc_module = HostmemReadProcessor(read_width, ChannelHostMemImpl,
                                               read_reqs)
       read_proc = read_proc_module(clk=ports.clk, rst=ports.rst)
@@ -1297,59 +1654,13 @@ def DummyFromHostEngine(client_type: Type) -> type['DummyFromHostEngineImpl']:
   return DummyFromHostEngineImpl
 
 
-def _resolve_engine_pair(path: str) -> Tuple[Callable, Callable]:
-  """Resolve a dotted Python import path to a
-  `(to_host_engine_gen, from_host_engine_gen)` tuple, used to override the
-  default engine pair for a specific service request.
-
-  The path may point at either:
-    - a module-level 2-tuple attribute, e.g.
-      `"mypkg.mymod.MyEnginePair"` where `MyEnginePair` is
-      `(MyToHost, MyFromHost)`; or
-    - a zero-arg factory callable returning such a tuple.
-  """
-  import importlib
-  if not isinstance(path, str):
-    raise TypeError(
-        "Engine override path must be a dotted 'pkg.mod.attr' string; "
-        f"got {type(path).__name__}")
-  module_path, _, attr_path = path.rpartition(".")
-  if not module_path or not attr_path:
-    raise ValueError(
-        "Engine override path must be a dotted 'pkg.mod.attr' string; "
-        f"got {path!r}")
-  obj = importlib.import_module(module_path)
-  for part in attr_path.split("."):
-    obj = getattr(obj, part)
-  if callable(obj):
-    obj = obj()
-  if not (isinstance(obj, tuple) and len(obj) == 2):
-    raise TypeError(
-        f"Engine override {path!r} must resolve to a 2-tuple "
-        f"(to_host_engine_gen, from_host_engine_gen); got {type(obj).__name__}")
-  if not (callable(obj[0]) and callable(obj[1])):
-    raise TypeError(
-        f"Engine override {path!r} must resolve to a 2-tuple of callables; got "
-        f"({type(obj[0]).__name__}, {type(obj[1]).__name__})")
-  return obj
-
-
 def ChannelEngineService(
     to_host_engine_gen: Callable,
     from_host_engine_gen: Callable) -> type['ChannelEngineService']:
   """Returns a channel service implementation which calls
   to_host_engine_gen(<client_type>) or from_host_engine_gen(<client_type>) to
   generate the to_host and from_host engines for each channel. Does not support
-  engines which can service multiple clients at once.
-
-  Individual service requests may override the default engine pair by passing
-  `options={"engine": "pkg.mod.attr"}` at the service-request call site (e.g.
-  `HostComms.some_bundle(AppID(...), options={"engine": "..."})`). The path
-  is resolved by `_resolve_engine_pair` and must yield a
-  `(to_host_engine_gen, from_host_engine_gen)` tuple with the same call shape
-  as the defaults; the override applies to every channel of that request's
-  bundle.
-  """
+  engines which can service multiple clients at once."""
 
   class ChannelEngineService(esi.ServiceImplementation):
     """Service implementation which services the clients via a per-channel DMA
@@ -1368,10 +1679,7 @@ def ChannelEngineService(
         appid_strings = [str(appid) for appid in client_appid]
         return f"{'_'.join(appid_strings)}.{channel_name}"
 
-      def build_engine(bc: BundledChannel,
-                       bundle_to_host_gen: Callable,
-                       bundle_from_host_gen: Callable,
-                       input_channel=None) -> Type:
+      def build_engine(bc: BundledChannel, input_channel=None) -> Type:
         idbase = build_engine_appid(bundle.client_name, bc.name)
         eng_appid = esi.AppID(idbase)
         # DMA engines require at least 1 byte of data; substitute Bits(8)
@@ -1382,9 +1690,9 @@ def ChannelEngineService(
         if is_void:
           engine_client_type = Bits(8)
         if bc.direction == ChannelDirection.FROM:
-          engine_mod = bundle_to_host_gen(engine_client_type)
+          engine_mod = to_host_engine_gen(engine_client_type)
         else:
-          engine_mod = bundle_from_host_gen(engine_client_type)
+          engine_mod = from_host_engine_gen(engine_client_type)
         eng_inputs = {
             "clk": ports.clk,
             "rst": ports.rst,
@@ -1420,24 +1728,12 @@ def ChannelEngineService(
         return engine
 
       for bundle in bundles.to_client_reqs:
-        # Per-request engine override: if the client's service request carries
-        # an `"engine"` option, use that engine pair instead of the defaults
-        # for every channel of this bundle. This is purely a hardware-side
-        # substitution.
-        engine_override = bundle.options.get("engine")
-        if engine_override is None:
-          bundle_to_host_gen = to_host_engine_gen
-          bundle_from_host_gen = from_host_engine_gen
-        else:
-          bundle_to_host_gen, bundle_from_host_gen = _resolve_engine_pair(
-              engine_override)
-
         bundle_type = bundle.type
         to_channels = {}
         # Create a DMA engine for each channel headed TO the client (from the host).
         for bc in bundle_type.channels:
           if bc.direction == ChannelDirection.TO:
-            engine = build_engine(bc, bundle_to_host_gen, bundle_from_host_gen)
+            engine = build_engine(bc)
             out_chan = engine.output_channel
             # For void channels, narrow the 8-bit placeholder back to 0-bit.
             if bc.channel.inner_type.bitwidth == 0:
@@ -1450,7 +1746,6 @@ def ChannelEngineService(
         # Create a DMA engine for each channel headed FROM the client (to the host).
         for bc in bundle_type.channels:
           if bc.direction == ChannelDirection.FROM:
-            build_engine(bc, bundle_to_host_gen, bundle_from_host_gen,
-                         froms[bc.name])
+            build_engine(bc, froms[bc.name])
 
   return ChannelEngineService

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -1666,13 +1666,59 @@ def DummyFromHostEngine(client_type: Type) -> type['DummyFromHostEngineImpl']:
   return DummyFromHostEngineImpl
 
 
+def _resolve_engine_pair(path: str) -> Tuple[Callable, Callable]:
+  """Resolve a dotted Python import path to a
+  `(to_host_engine_gen, from_host_engine_gen)` tuple, used to override the
+  default engine pair for a specific service request.
+
+  The path may point at either:
+    - a module-level 2-tuple attribute, e.g.
+      `"mypkg.mymod.MyEnginePair"` where `MyEnginePair` is
+      `(MyToHost, MyFromHost)`; or
+    - a zero-arg factory callable returning such a tuple.
+  """
+  import importlib
+  if not isinstance(path, str):
+    raise TypeError(
+        "Engine override path must be a dotted 'pkg.mod.attr' string; "
+        f"got {type(path).__name__}")
+  module_path, _, attr_path = path.rpartition(".")
+  if not module_path or not attr_path:
+    raise ValueError(
+        "Engine override path must be a dotted 'pkg.mod.attr' string; "
+        f"got {path!r}")
+  obj = importlib.import_module(module_path)
+  for part in attr_path.split("."):
+    obj = getattr(obj, part)
+  if callable(obj):
+    obj = obj()
+  if not (isinstance(obj, tuple) and len(obj) == 2):
+    raise TypeError(
+        f"Engine override {path!r} must resolve to a 2-tuple "
+        f"(to_host_engine_gen, from_host_engine_gen); got {type(obj).__name__}")
+  if not (callable(obj[0]) and callable(obj[1])):
+    raise TypeError(
+        f"Engine override {path!r} must resolve to a 2-tuple of callables; got "
+        f"({type(obj[0]).__name__}, {type(obj[1]).__name__})")
+  return obj
+
+
 def ChannelEngineService(
     to_host_engine_gen: Callable,
     from_host_engine_gen: Callable) -> type['ChannelEngineService']:
   """Returns a channel service implementation which calls
   to_host_engine_gen(<client_type>) or from_host_engine_gen(<client_type>) to
   generate the to_host and from_host engines for each channel. Does not support
-  engines which can service multiple clients at once."""
+  engines which can service multiple clients at once.
+
+  Individual service requests may override the default engine pair by passing
+  `options={"engine": "pkg.mod.attr"}` at the service-request call site (e.g.
+  `HostComms.some_bundle(AppID(...), options={"engine": "..."})`). The path
+  is resolved by `_resolve_engine_pair` and must yield a
+  `(to_host_engine_gen, from_host_engine_gen)` tuple with the same call shape
+  as the defaults; the override applies to every channel of that request's
+  bundle.
+  """
 
   class ChannelEngineService(esi.ServiceImplementation):
     """Service implementation which services the clients via a per-channel DMA
@@ -1691,7 +1737,10 @@ def ChannelEngineService(
         appid_strings = [str(appid) for appid in client_appid]
         return f"{'_'.join(appid_strings)}.{channel_name}"
 
-      def build_engine(bc: BundledChannel, input_channel=None) -> Type:
+      def build_engine(bc: BundledChannel,
+                       bundle_to_host_gen: Callable,
+                       bundle_from_host_gen: Callable,
+                       input_channel=None) -> Type:
         idbase = build_engine_appid(bundle.client_name, bc.name)
         eng_appid = esi.AppID(idbase)
         # DMA engines require at least 1 byte of data; substitute Bits(8)
@@ -1702,9 +1751,9 @@ def ChannelEngineService(
         if is_void:
           engine_client_type = Bits(8)
         if bc.direction == ChannelDirection.FROM:
-          engine_mod = to_host_engine_gen(engine_client_type)
+          engine_mod = bundle_to_host_gen(engine_client_type)
         else:
-          engine_mod = from_host_engine_gen(engine_client_type)
+          engine_mod = bundle_from_host_gen(engine_client_type)
         eng_inputs = {
             "clk": ports.clk,
             "rst": ports.rst,
@@ -1740,12 +1789,24 @@ def ChannelEngineService(
         return engine
 
       for bundle in bundles.to_client_reqs:
+        # Per-request engine override: if the client's service request carries
+        # an `"engine"` option, use that engine pair instead of the defaults
+        # for every channel of this bundle. This is purely a hardware-side
+        # substitution.
+        engine_override = bundle.options.get("engine")
+        if engine_override is None:
+          bundle_to_host_gen = to_host_engine_gen
+          bundle_from_host_gen = from_host_engine_gen
+        else:
+          bundle_to_host_gen, bundle_from_host_gen = _resolve_engine_pair(
+              engine_override)
+
         bundle_type = bundle.type
         to_channels = {}
         # Create a DMA engine for each channel headed TO the client (from the host).
         for bc in bundle_type.channels:
           if bc.direction == ChannelDirection.TO:
-            engine = build_engine(bc)
+            engine = build_engine(bc, bundle_to_host_gen, bundle_from_host_gen)
             out_chan = engine.output_channel
             # For void channels, narrow the 8-bit placeholder back to 0-bit.
             if bc.channel.inner_type.bitwidth == 0:
@@ -1758,6 +1819,7 @@ def ChannelEngineService(
         # Create a DMA engine for each channel headed FROM the client (to the host).
         for bc in bundle_type.channels:
           if bc.direction == ChannelDirection.FROM:
-            build_engine(bc, froms[bc.name])
+            build_engine(bc, bundle_to_host_gen, bundle_from_host_gen,
+                         froms[bc.name])
 
   return ChannelEngineService

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -770,7 +770,14 @@ def TaggedReadGearbox(input_bitwidth: int,
         # sel==1.
         counter = Wire(UInt(counter_width), name="chunk_counter")
         client_xact = Wire(Bits(1))
-        incremented = (counter + 1).as_uint(counter_width)
+        # Wrap the next index at 'chunks - 1' so the counter never advances to
+        # an unreachable value when 'chunks' is not a power of two (e.g.
+        # chunks=3 must wrap 2 -> 0, not step to the invalid state 3, which
+        # would assert no reg_ce and drop the accepted word, deadlocking the
+        # stream).
+        incremented = Mux(counter == UInt(counter_width)(chunks - 1),
+                          (counter + 1).as_uint(counter_width),
+                          UInt(counter_width)(0))
         counter.assign(
             Mux(
                 client_xact, Mux(upstream_xact, counter, incremented),
@@ -1073,9 +1080,14 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
           # then sees one contiguous response stream. 'splitter_resp' breaks the
           # request/response construction cycle (the client request is derived
           # from the packed response bundle).
-          max_chunk_bytes = max(
-              1, PCIE_MAX_READ_REQUEST_BYTES // elem_stride_bytes) * \
-              elem_stride_bytes
+          if elem_stride_bytes > PCIE_MAX_READ_REQUEST_BYTES:
+            raise ValueError(
+                f"read_list element stride ({elem_stride_bytes} bytes) exceeds "
+                f"the PCIe maximum read request size "
+                f"({PCIE_MAX_READ_REQUEST_BYTES} bytes); a single element must "
+                f"fit in one read request.")
+          max_chunk_bytes = (PCIE_MAX_READ_REQUEST_BYTES //
+                             elem_stride_bytes) * elem_stride_bytes
           splitter_resp = Wire(demuxed_upstream_channel.type)
           gearbox = TaggedReadGearbox(read_width,
                                       element_bits)(clk=ports.clk,

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -161,8 +161,8 @@ def HeaderMMIO(manifest_loc: int) -> Module:
       # the response stage. 'DesignResetController' latches it, so a single-cycle
       # pulse is sufficient to trigger the reset.
       reset_detect = (cmd.write & (slot == Bits(3)(7)) &
-                      (cmd.data == Bits(64)(ResetMagicNumber))).as_bits()
-      ports.reset_request = (reset_detect & s1_to_s2_xact).as_bits()
+                      (cmd.data == Bits(64)(ResetMagicNumber)))
+      ports.reset_request = reset_detect & s1_to_s2_xact
 
   return HeaderMMIO
 
@@ -248,11 +248,11 @@ def ChannelDemuxN_HalfStage_ReadyBlocking(
         consume.assign(valid_reg & ch_ready)
 
         # Accumulate selected_valid expression.
-        selected_valid_expr = (selected_valid_expr | (
-            (in_sel == Bits(sel_width)(i)) & valid_reg)).as_bits()
+        selected_valid_expr = selected_valid_expr | (
+            (in_sel == Bits(sel_width)(i)) & valid_reg)
 
       # Input ready only when selected output has no valid data latched.
-      input_ready.assign((selected_valid_expr ^ Bits(1)(1)).as_bits())
+      input_ready.assign(selected_valid_expr ^ Bits(1)(1))
 
     def get_out(self, index: int) -> ChannelSignal:
       return getattr(self, f"output_{index}")
@@ -409,12 +409,11 @@ def DesignResetController(
       # Count cycles while a reset is pending.
       count = Counter(counter_width)(clk=ports.clk,
                                      rst=ports.rst,
-                                     clear=(fire | ~pending).as_bits(),
+                                     clear=fire | ~pending,
                                      increment=pending,
                                      instance_name="reset_delay_counter")
-      fire.assign(
-          (pending &
-           (count.out == UInt(counter_width)(delay_cycles - 1))).as_bits())
+      fire.assign(pending &
+                  (count.out == UInt(counter_width)(delay_cycles - 1)))
       ports.design_reset = fire
       ports.reset_pending = pending
 
@@ -770,11 +769,6 @@ def TaggedReadGearbox(input_bitwidth: int,
         # sel==1.
         counter = Wire(UInt(counter_width), name="chunk_counter")
         client_xact = Wire(Bits(1))
-        # Wrap the next index at 'chunks - 1' so the counter never advances to
-        # an unreachable value when 'chunks' is not a power of two (e.g.
-        # chunks=3 must wrap 2 -> 0, not step to the invalid state 3, which
-        # would assert no reg_ce and drop the accepted word, deadlocking the
-        # stream).
         incremented = Mux(counter == UInt(counter_width)(chunks - 1),
                           (counter + 1).as_uint(counter_width),
                           UInt(counter_width)(0))
@@ -786,8 +780,7 @@ def TaggedReadGearbox(input_bitwidth: int,
                     UInt(counter_width)(1))).reg(ports.clk,
                                                  ports.rst,
                                                  rst_value=0,
-                                                 ce=(upstream_xact |
-                                                     client_xact).as_bits(),
+                                                 ce=upstream_xact | client_xact,
                                                  name="chunk_counter_reg"))
         set_client_valid = counter == (chunks - 1)
         client_valid = ControlReg(ports.clk, ports.rst,
@@ -851,7 +844,8 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
   On the response path the per-chunk end-of-list markers are dropped and a
   single burst-final `last` is re-derived from the total transfer length, so the
   gearbox and client see one contiguous response stream identical to an unsplit
-  read.
+  read. This will be a performance limiter.
+  TODO: make this able to issue >1 one read at a time.
 
   Only one logical request is in flight at a time (matching the read processor's
   one-outstanding-transaction-per-client model): a new request is not accepted
@@ -898,17 +892,17 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
       tag_reg = Wire(tag_type, name="tag_reg")
       words_left = Wire(UInt(words_width), name="words_left")  # resp words left
 
-      idle = ((~emit_busy) & (~resp_busy)).as_bits()
+      idle = (~emit_busy) & (~resp_busy)
 
       # --- Request intake and splitting ---
       req_ready = Wire(Bits(1))
       req_payload, req_valid = ports.req_in.unwrap(req_ready)
-      accept = (idle & req_valid).as_bits()
+      accept = idle & req_valid
       req_ready.assign(accept)
 
       max_chunk = UInt(length_width)(max_chunk_bytes)
       chunk_len = Mux(remaining > max_chunk, remaining, max_chunk)
-      last_chunk = (remaining <= max_chunk).as_bits()
+      last_chunk = remaining <= max_chunk
 
       req_out_ch, req_out_ready = req_channel_type.wrap(
           req_struct({
@@ -917,11 +911,11 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
               "tag": tag_reg,
           }), emit_busy)
       ports.req_out = req_out_ch
-      chunk_xact = (emit_busy & req_out_ready).as_bits()
+      chunk_xact = emit_busy & req_out_ready
 
       emit_busy.assign(
           ControlReg(clk,
-                     rst, [accept], [(chunk_xact & last_chunk).as_bits()],
+                     rst, [accept], [chunk_xact & last_chunk],
                      name="emit_busy_reg"))
 
       # cur_addr: load base on accept, advance by the chunk on each issue.
@@ -932,7 +926,7 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
               req_payload.address).reg(clk,
                                        rst,
                                        rst_value=0,
-                                       ce=(accept | chunk_xact).as_bits(),
+                                       ce=accept | chunk_xact,
                                        name="cur_addr_reg"))
 
       # remaining: load length on accept, subtract each issued chunk.
@@ -942,7 +936,7 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
               req_payload.length).reg(clk,
                                       rst,
                                       rst_value=0,
-                                      ce=(accept | chunk_xact).as_bits(),
+                                      ce=accept | chunk_xact,
                                       name="remaining_reg"))
 
       tag_reg.assign(req_payload.tag.reg(clk, rst, ce=accept, name="tag_reg_r"))
@@ -951,7 +945,7 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
       total_words = req_payload.length.as_bits()[word_shift:].as_uint()
       resp_ready = Wire(Bits(1))
       resp_payload, resp_valid = ports.resp_in.unwrap(resp_ready)
-      is_final_word = (words_left == UInt(words_width)(1)).as_bits()
+      is_final_word = words_left == UInt(words_width)(1)
       resp_out_ch, resp_out_ready = resp_channel_type.wrap(
           resp_struct({
               "tag": resp_payload.tag,
@@ -960,7 +954,7 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
           }), resp_valid)
       ports.resp_out = resp_out_ch
       resp_ready.assign(resp_out_ready)
-      resp_xact = (resp_valid & resp_out_ready).as_bits()
+      resp_xact = resp_valid & resp_out_ready
 
       # words_left: load total on accept, decrement per received word.
       words_dec = (words_left - UInt(words_width)(1)).as_uint(words_width)
@@ -969,12 +963,12 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
               total_words).reg(clk,
                                rst,
                                rst_value=0,
-                               ce=(accept | resp_xact).as_bits(),
+                               ce=accept | resp_xact,
                                name="words_left_reg"))
 
       resp_busy.assign(
           ControlReg(clk,
-                     rst, [accept], [(resp_xact & is_final_word).as_bits()],
+                     rst, [accept], [resp_xact & is_final_word],
                      name="resp_busy_reg"))
 
   return HostMemReadReqSplitterImpl
@@ -1304,9 +1298,9 @@ def TaggedWriteGearbox(input_bitwidth: int, output_bitwidth: int,
           # transaction-framing 'last' changes.
           burst_shift = clog2(max_burst_words)
           burst_end = counter.out.as_bits()[:burst_shift].and_reduce()
-          last = (elem_end | burst_end).as_bits()
+          last = elem_end | burst_end
         else:
-          last = elem_end.as_bits()
+          last = elem_end
 
       upstream_channel, upstrm_ready_sig = TaggedWriteGearboxImpl.out.type.wrap(
           {
@@ -1477,7 +1471,7 @@ def HostMemWriteProcessor(
                                      rst=ports.rst,
                                      clear=elem_clear,
                                      increment=frame_xact)
-          elem_clear.assign((frame_xact & frame["last"]).as_bits())
+          elem_clear.assign(frame_xact & frame["last"])
           elem_addr = (frame["address"] +
                        elem_counter.out * UInt(64)(elem_stride)).as_uint(64)
           gearbox_in_chan, gearbox_in_ready = Channel(gearbox_in_type).wrap(

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -833,12 +833,12 @@ def TaggedReadGearbox(input_bitwidth: int,
 # conservative PCIe-derived cap (Max_Read_Request_Size tops out at 4096 bytes,
 # but root ports often negotiate less); it mirrors kPcieMaxReadRequestBytes in
 # the Cosim backend (cpp/lib/backends/Cosim.cpp).
-MAX_READ_REQUEST_BYTES = 64 * 4  # 64 double words
+DEFAULT_MAX_READ_REQUEST_BYTES = 64 * 4  # 64 double words
 
 # Maximum size, in bytes, of a single upstream write transaction; an element
 # whose write payload is wider is split into multiple <= this-size transactions.
 # The default is a conservative PCIe-derived Max-Payload-Size cap.
-MAX_WRITE_PAYLOAD_BYTES = 256
+DEFAULT_MAX_WRITE_PAYLOAD_BYTES = 256
 
 
 @modparams
@@ -870,10 +870,10 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
   req_channel_type:  channel of the upstream read request {address, length
     (bytes), tag}.
   resp_channel_type: channel of the upstream response {tag, data, last}.
-  max_chunk_bytes:   largest per-chunk byte count; must be > 0, a multiple of the
-    response word size, and <= MAX_READ_REQUEST_BYTES.
+  max_chunk_bytes:   largest per-chunk byte count; must be > 0 and a multiple of
+    the response word size.
   """
-  assert 0 < max_chunk_bytes <= MAX_READ_REQUEST_BYTES
+  assert max_chunk_bytes > 0
 
   req_struct = req_channel_type.inner_type
   resp_struct = resp_channel_type.inner_type
@@ -989,8 +989,10 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
   return HostMemReadReqSplitterImpl
 
 
-def HostmemReadProcessor(read_width: int, hostmem_module,
-                         reqs: List[esi._OutputBundleSetter]):
+def HostmemReadProcessor(read_width: int,
+                         hostmem_module,
+                         reqs: List[esi._OutputBundleSetter],
+                         max_read_request_bytes: int = DEFAULT_MAX_READ_REQUEST_BYTES):
   """Construct a host memory read request module to orchestrate the the read
   connections. Responsible for both gearboxing the data, multiplexing the
   requests, reassembling out-of-order responses and routing the responses to the
@@ -1091,7 +1093,7 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
           # length. 'splitter_resp' breaks the request/response construction
           # cycle (the client request is derived from the packed response
           # bundle).
-          max_chunk_bytes = (MAX_READ_REQUEST_BYTES // word_bytes) * word_bytes
+          max_chunk_bytes = (max_read_request_bytes // word_bytes) * word_bytes
           splitter_resp = Wire(demuxed_upstream_channel.type)
           gearbox = TaggedReadGearbox(read_width,
                                       element_bits)(clk=ports.clk,
@@ -1380,8 +1382,11 @@ def EmitEveryN(message_type: Type, N: int) -> type['EmitEveryNImpl']:
 
 
 def HostMemWriteProcessor(
-    write_width: int, hostmem_module,
-    reqs: List[esi._OutputBundleSetter]) -> type["HostMemWriteProcessorImpl"]:
+    write_width: int,
+    hostmem_module,
+    reqs: List[esi._OutputBundleSetter],
+    max_write_payload_bytes: int = DEFAULT_MAX_WRITE_PAYLOAD_BYTES
+) -> type["HostMemWriteProcessorImpl"]:
   """Construct a host memory write request module to orchestrate the the write
   connections. Responsible for both gearboxing the data, multiplexing the
   requests, reassembling out-of-order responses and routing the responses to the
@@ -1467,7 +1472,7 @@ def HostMemWriteProcessor(
           elem_stride = words_per_elem * word_bytes
 
           gearbox_mod = TaggedWriteGearbox(element_bits, write_width,
-                                           MAX_WRITE_PAYLOAD_BYTES)
+                                           max_write_payload_bytes)
           gearbox_in_type = gearbox_mod.in_.type.inner_type
 
           # Unwrap the window frames; compute a base+offset address from a
@@ -1500,7 +1505,7 @@ def HostMemWriteProcessor(
               client_type.data)
           bundle_sig, sfroms = write_req_bundle_type.pack(ackTag=input_flit_ack)
           gearbox_mod = TaggedWriteGearbox(client_type.data.bitwidth,
-                                           write_width, MAX_WRITE_PAYLOAD_BYTES)
+                                           write_width, max_write_payload_bytes)
           gearbox_in_type = gearbox_mod.in_.type.inner_type
           bitcast_client_req = sfroms["req"].transform(
               lambda m, git=gearbox_in_type: git({
@@ -1552,8 +1557,12 @@ def HostMemWriteProcessor(
 
 
 @modparams
-def ChannelHostMem(read_width: int,
-                   write_width: int) -> typing.Type['ChannelHostMemImpl']:
+def ChannelHostMem(
+    read_width: int,
+    write_width: int,
+    max_read_request_bytes: int = DEFAULT_MAX_READ_REQUEST_BYTES,
+    max_write_payload_bytes: int = DEFAULT_MAX_WRITE_PAYLOAD_BYTES
+) -> typing.Type['ChannelHostMemImpl']:
 
   class ChannelHostMemImpl(esi.ServiceImplementation):
     """Builds a HostMem service which multiplexes multiple HostMem clients into
@@ -1604,7 +1613,7 @@ def ChannelHostMem(read_width: int,
           if req.port in ('read', 'read_list')
       ]
       read_proc_module = HostmemReadProcessor(read_width, ChannelHostMemImpl,
-                                              read_reqs)
+                                              read_reqs, max_read_request_bytes)
       read_proc = read_proc_module(clk=ports.clk, rst=ports.rst)
       ports.read = read_proc.upstream
       for req in read_reqs:
@@ -1615,7 +1624,8 @@ def ChannelHostMem(read_width: int,
           req for req in bundles.to_client_reqs if req.port == 'write'
       ]
       write_proc_module = HostMemWriteProcessor(write_width, ChannelHostMemImpl,
-                                                write_reqs)
+                                                write_reqs,
+                                                max_write_payload_bytes)
       write_proc = write_proc_module(clk=ports.clk, rst=ports.rst)
       ports.write = write_proc.upstream
       for req in write_reqs:

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -828,30 +828,30 @@ def TaggedReadGearbox(input_bitwidth: int,
   return TaggedReadGearboxImpl
 
 
-# Maximum PCIe read request size in bytes. PCIe's Max_Read_Request_Size tops out
-# at 4096 bytes, but root ports often negotiate a smaller limit, so use a
-# conservative 64-double-word (256-byte) cap. Reads larger than this must be
-# split by the requester into multiple requests. Mirrors kPcieMaxReadRequestBytes
-# in the Cosim backend (cpp/lib/backends/Cosim.cpp).
-PCIE_MAX_READ_REQUEST_BYTES = 64 * 4  # 64 double words
+# Maximum size, in bytes, of a single upstream read request. Reads larger than
+# this are split by the requester into multiple requests. The default is a
+# conservative PCIe-derived cap (Max_Read_Request_Size tops out at 4096 bytes,
+# but root ports often negotiate less); it mirrors kPcieMaxReadRequestBytes in
+# the Cosim backend (cpp/lib/backends/Cosim.cpp).
+MAX_READ_REQUEST_BYTES = 64 * 4  # 64 double words
 
-# Maximum PCIe write payload size in bytes (Max Payload Size analog). A single
-# upstream write transaction must not exceed this; an element whose write
-# payload is wider is split into multiple <= this-size transactions.
-PCIE_MAX_WRITE_PAYLOAD_BYTES = 256
+# Maximum size, in bytes, of a single upstream write transaction; an element
+# whose write payload is wider is split into multiple <= this-size transactions.
+# The default is a conservative PCIe-derived Max-Payload-Size cap.
+MAX_WRITE_PAYLOAD_BYTES = 256
 
 
 @modparams
 def HostMemReadReqSplitter(req_channel_type: Channel,
                            resp_channel_type: Channel, max_chunk_bytes: int):
-  """Split oversized host memory read requests into PCIe-compliant chunks before
+  """Split oversized host memory read requests into request-sized chunks before
   arbitration and reassemble the per-chunk responses into a single logical
   burst.
 
-  A burst read (`read_list`) can request many more bytes than the PCIe maximum
-  read request size allows in a single request. This module breaks such a
-  request into `max_chunk_bytes`-sized (element-aligned, MRRS-compliant) chunks
-  addressed sequentially from the base. Splitting here -- *before* the requests
+  A burst read (`read_list`) can request many more bytes than a single upstream
+  read request can carry. This module breaks such a request into
+  `max_chunk_bytes`-sized (word-aligned) chunks addressed sequentially from the
+  base. Splitting here -- *before* the requests
   are arbitrated onto the shared upstream read channel -- lets each client's
   chunks interleave with other clients' requests, so one large burst does not
   monopolize host memory bandwidth.
@@ -859,21 +859,21 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
   On the response path the per-chunk end-of-list markers are dropped and a
   single burst-final `last` is re-derived from the total transfer length, so the
   gearbox and client see one contiguous response stream identical to an unsplit
-  read. This will be a performance limiter.
-  TODO: make this able to issue >1 one read at a time.
+  read.
 
   Only one logical request is in flight at a time (matching the read processor's
   one-outstanding-transaction-per-client model): a new request is not accepted
   until the current burst's chunks have all been issued and its responses have
-  fully drained.
+  fully drained. This will be a performance limiter.
+  TODO: make this able to issue >1 one read at a time.
 
   req_channel_type:  channel of the upstream read request {address, length
     (bytes), tag}.
   resp_channel_type: channel of the upstream response {tag, data, last}.
   max_chunk_bytes:   largest per-chunk byte count; must be > 0, a multiple of the
-    element stride, and <= PCIE_MAX_READ_REQUEST_BYTES.
+    response word size, and <= MAX_READ_REQUEST_BYTES.
   """
-  assert 0 < max_chunk_bytes <= PCIE_MAX_READ_REQUEST_BYTES
+  assert 0 < max_chunk_bytes <= MAX_READ_REQUEST_BYTES
 
   req_struct = req_channel_type.inner_type
   resp_struct = resp_channel_type.inner_type
@@ -1083,20 +1083,15 @@ def HostmemReadProcessor(read_width: int, hostmem_module,
           words_per_elem = (element_bits + read_width - 1) // read_width
           elem_stride_bytes = words_per_elem * word_bytes
 
-          # A burst can request far more than the PCIe maximum read request
-          # size, so split it into MRRS-compliant, element-aligned chunks before
+          # A burst can request far more than a single upstream read request can
+          # carry, so split it into request-sized, word-aligned chunks before
           # arbitration and reassemble the responses afterwards; the gearbox
-          # then sees one contiguous response stream. 'splitter_resp' breaks the
-          # request/response construction cycle (the client request is derived
-          # from the packed response bundle).
-          if elem_stride_bytes > PCIE_MAX_READ_REQUEST_BYTES:
-            raise ValueError(
-                f"read_list element stride ({elem_stride_bytes} bytes) exceeds "
-                f"the PCIe maximum read request size "
-                f"({PCIE_MAX_READ_REQUEST_BYTES} bytes); a single element must "
-                f"fit in one read request.")
-          max_chunk_bytes = (PCIE_MAX_READ_REQUEST_BYTES //
-                             elem_stride_bytes) * elem_stride_bytes
+          # sees one contiguous response stream. Elements may span chunks -- the
+          # splitter re-derives a single burst-final 'last' from the total
+          # length. 'splitter_resp' breaks the request/response construction
+          # cycle (the client request is derived from the packed response
+          # bundle).
+          max_chunk_bytes = (MAX_READ_REQUEST_BYTES // word_bytes) * word_bytes
           splitter_resp = Wire(demuxed_upstream_channel.type)
           gearbox = TaggedReadGearbox(read_width,
                                       element_bits)(clk=ports.clk,
@@ -1185,7 +1180,7 @@ def TaggedWriteGearbox(input_bitwidth: int, output_bitwidth: int,
   Assumes a struct {address, tag, data} and only gearboxes the data. Tag is
   stored separately and the struct is re-assembled later on.
 
-  'max_burst_bytes' caps a single contiguous upstream write transaction (PCIe
+  'max_burst_bytes' caps a single contiguous upstream write transaction (a
   max-payload-size analog): when an element spans more than 'max_burst_bytes',
   its engine words are split into multiple <= 'max_burst_bytes' transactions by
   emitting the framing 'last' at each boundary. 0 disables the cap."""
@@ -1306,7 +1301,7 @@ def TaggedWriteGearbox(input_bitwidth: int, output_bitwidth: int,
                           Bits(8)(output_bitwidth_bytes),
                           Bits(8)((output_bitwidth - padding_numbits) // 8))
         if max_burst_words and num_chunks > max_burst_words:
-          # PCIe max-payload-size cap: end the upstream write transaction at the
+          # Max-payload-size cap: end the upstream write transaction at the
           # element end OR every max_burst_words engine words, whichever comes
           # first, so a wide element's write is split into <= max_burst_bytes
           # transactions. Each word keeps its own sequential address; only the
@@ -1472,7 +1467,7 @@ def HostMemWriteProcessor(
           elem_stride = words_per_elem * word_bytes
 
           gearbox_mod = TaggedWriteGearbox(element_bits, write_width,
-                                           PCIE_MAX_WRITE_PAYLOAD_BYTES)
+                                           MAX_WRITE_PAYLOAD_BYTES)
           gearbox_in_type = gearbox_mod.in_.type.inner_type
 
           # Unwrap the window frames; compute a base+offset address from a
@@ -1505,8 +1500,7 @@ def HostMemWriteProcessor(
               client_type.data)
           bundle_sig, sfroms = write_req_bundle_type.pack(ackTag=input_flit_ack)
           gearbox_mod = TaggedWriteGearbox(client_type.data.bitwidth,
-                                           write_width,
-                                           PCIE_MAX_WRITE_PAYLOAD_BYTES)
+                                           write_width, MAX_WRITE_PAYLOAD_BYTES)
           gearbox_in_type = gearbox_mod.in_.type.inner_type
           bitcast_client_req = sfroms["req"].transform(
               lambda m, git=gearbox_in_type: git({

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -989,10 +989,11 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
   return HostMemReadReqSplitterImpl
 
 
-def HostmemReadProcessor(read_width: int,
-                         hostmem_module,
-                         reqs: List[esi._OutputBundleSetter],
-                         max_read_request_bytes: int = DEFAULT_MAX_READ_REQUEST_BYTES):
+def HostmemReadProcessor(
+    read_width: int,
+    hostmem_module,
+    reqs: List[esi._OutputBundleSetter],
+    max_read_request_bytes: int = DEFAULT_MAX_READ_REQUEST_BYTES):
   """Construct a host memory read request module to orchestrate the the read
   connections. Responsible for both gearboxing the data, multiplexing the
   requests, reassembling out-of-order responses and routing the responses to the

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/cosim.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/cosim.py
@@ -159,6 +159,7 @@ def CosimBSP(
           StructType([
               ("tag", UInt(8)),
               ("data", Bits(ESI_Cosim_UserTopWrapper.HostMemWidth)),
+              ("last", Bits(1)),
           ]))
       req = wrapper.hostmem_read.unpack(
           resp=drop_while_resetting(resp_channel))['req']

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
@@ -575,6 +575,10 @@ def AddressCommand(width: int):
     # Channel which indicates when the read/write operation is done.
     hostmem_cmd_done = InputChannel(Bits(0))
 
+    # Single burst {address, tag, length} request, issued once per command for
+    # read_list / windowed clients. Held valid until accepted.
+    burst_req = OutputChannel(esi.HostMem.read_req_burst_type(64))
+
     @generator
     def construct(ports):
       # MMIO command channel setup.
@@ -665,7 +669,29 @@ def AddressCommand(width: int):
                                       ChannelSignaling.ValidReady).wrap(
                                           current_addr, addr_valid)
       issue_xact = addr_valid & addr_ready
-      issue_incr.assign(issue_xact)
+
+      # Burst request: a single {address, tag, length} emitted once per command
+      # (for read_list / windowed clients), held valid until accepted. Its
+      # acceptance counts as one issued command.
+      burst_accepted = Wire(Bits(1))
+      burst_pending = ControlReg(
+          clk=ports.clk,
+          rst=ports.rst,
+          asserts=[start_op_we],
+          resets=[burst_accepted],
+          name="burst_pending",
+      )
+      burst_req_chan, burst_req_ready = Channel(
+          esi.HostMem.read_req_burst_type(64)).wrap(
+              esi.HostMem.read_req_burst_type(64)({
+                  "address": start_addr,
+                  "tag": UInt(8)(0),
+                  "length": flits_total,
+              }), burst_pending)
+      burst_accepted.assign((burst_pending & burst_req_ready).as_bits())
+      ports.burst_req = burst_req_chan
+
+      issue_incr.assign((issue_xact | burst_accepted).as_bits())
 
       # Consume hostmem_cmd_done (Bits(0) channel) for completed responses.
       _, done_valid = ports.hostmem_cmd_done.unwrap(Bits(1)(1))
@@ -768,21 +794,26 @@ def ReadMem(width: int):
           hostmem_cmd_done=address_cmd_resp,
           instance_name="address_command",
       )
+      # This burst read uses the single-shot burst request, not the per-flit
+      # address stream; hold that stream un-ready so it stays idle.
+      addresses.hostmem_cmd_address.unwrap(Bits(1)(0))
 
-      read_cmd_chan = addresses.hostmem_cmd_address.transform(
-          lambda addr: esi.HostMem.ReadReqType({
-              "tag": UInt(8)(0),
-              "address": addr
-          }))
-      read_responses = esi.HostMem.read(
+      # Burst read: issue ONE read_list request per command and receive the
+      # flits back as a windowed list (num_items=1 -> one element per frame,
+      # with a per-frame 'last').
+      read_responses = esi.HostMem.read_list(
           appid=AppID("host"),
-          data_type=Bits(width),
-          req=read_cmd_chan,
+          req=addresses.burst_req,
+          element_type=Bits(width),
+          num_items=1,
       )
-      # Signal completion to AddressCommand (each response -> Bits(0)).
+      # Signal completion to AddressCommand (each list element -> Bits(0)).
       address_cmd_resp.assign(read_responses.transform(lambda resp: Bits(0)(0)))
-      # Snoop the response channel to capture the low 64 bits without consuming it.
+      # Snoop the response channel to capture the low 64 bits without consuming
+      # it. The response is a windowed list frame; unwrap it to the lowered
+      # struct {tag, data, last} to read the element.
       read_resp_valid, _, read_resp_data = read_responses.snoop()
+      read_resp_frame = read_resp_data.unwrap()
       last_read_lsb = Reg(
           UInt(64),
           clk=ports.clk,
@@ -791,7 +822,7 @@ def ReadMem(width: int):
           ce=read_resp_valid,
           name="last_read_lsb",
       )
-      last_read_lsb.assign(read_resp_data.data.as_uint(64))
+      last_read_lsb.assign(read_resp_frame["data"][0].as_uint(64))
       esi.Telemetry.report_signal(
           ports.clk,
           ports.rst,
@@ -849,14 +880,10 @@ def WriteMem(width: int) -> Type[Module]:
       clk = ports.clk
       rst = ports.rst
 
-      cycle_counter_reset = Wire(Bits(1))
-      cycle_counter = Counter(32)(
-          clk=clk,
-          rst=rst,
-          clear=Bits(1)(0),
-          increment=Bits(1)(1),
-      )
-
+      # MMIO + burst control via AddressCommand (base address, flit count,
+      # start). We use its single-shot {base, tag, length} burst request and
+      # completion tracking; the per-flit address stream is replaced by a single
+      # windowed (list) write, so that stream is left idle.
       address_cmd_resp = Wire(Channel(Bits(0)))
       addresses = AddressCommand(width)(
           clk=clk,
@@ -864,20 +891,62 @@ def WriteMem(width: int) -> Type[Module]:
           hostmem_cmd_done=address_cmd_resp,
           instance_name="address_command",
       )
-      cycle_counter_reset.assign(addresses.command_go)
+      addresses.hostmem_cmd_address.unwrap(Bits(1)(0))
 
-      write_cmd_chan = addresses.hostmem_cmd_address.transform(
-          lambda addr: esi.HostMem.write_req_channel_type(UInt(width))({
-              "tag": UInt(8)(0),
-              "address": addr,
-              "data": cycle_counter.out.as_uint(width),
-          }))
+      # Windowed (list) write: consume the single {base, tag, length} burst
+      # request and stream 'length' list elements written to sequential
+      # addresses (num_items=1 -> one element per frame, 'last' on the final).
+      write_win = esi.HostMem.write_window(Bits(width), 1)
+      lowered = write_win.lowered_type
+
+      streaming = Wire(Bits(1))
+      frame_xact = Wire(Bits(1))
+      burst_ready = (~streaming).as_bits()
+      burst, burst_valid = addresses.burst_req.unwrap(burst_ready)
+      burst_accept = (burst_valid & ~streaming).as_bits()
+      base_addr = burst.address.reg(clk=clk,
+                                    rst=rst,
+                                    rst_value=0,
+                                    ce=burst_accept,
+                                    name="base_addr")
+      total = burst.length.reg(clk=clk,
+                               rst=rst,
+                               rst_value=0,
+                               ce=burst_accept,
+                               name="total")
+
+      frame_counter = Counter(64)(clk=clk,
+                                  rst=rst,
+                                  clear=burst_accept,
+                                  increment=frame_xact)
+      is_last = (frame_counter.out == (total -
+                                       UInt(64)(1)).as_uint(64)).as_bits(1)
+      last_accept = (frame_xact & is_last).as_bits()
+      streaming.assign(
+          ControlReg(clk=clk,
+                     rst=rst,
+                     asserts=[burst_accept],
+                     resets=[last_accept],
+                     name="streaming"))
+
+      # Data pattern: the frame index (non-0xFF), sized to the element width.
+      element = frame_counter.out.as_uint(width).as_bits()
+      frame_val = lowered({
+          "address": base_addr,
+          "tag": UInt(8)(0),
+          "data": [element],
+          "data_size": Bits(0)(0),
+          "last": is_last,
+      })
+      frame_chan, frame_ready = Channel(write_win).wrap(
+          write_win.wrap(frame_val), streaming)
+      frame_xact.assign((streaming & frame_ready).as_bits())
 
       write_responses = esi.HostMem.write(
           appid=AppID("host"),
-          req=write_cmd_chan,
+          req=frame_chan,
       )
-      # Signal completion to AddressCommand (each response -> Bits(0)).
+      # Signal completion to AddressCommand (each write ack -> Bits(0)).
       address_cmd_resp.assign(
           write_responses.transform(lambda resp: Bits(0)(0)))
 
@@ -1143,18 +1212,6 @@ def FromHostDMATest(width: int):
   return FromHostDMATest
 
 
-# Factory returning the same (to_host, from_host) engine pair the cosim_dma
-# BSP wires in by default. Used below to exercise the per-request engine
-# override on `ChannelService` requests: the resolver imports this path,
-# calls it, and the returned pair replaces the default pair for just that
-# one request's channel. Kept module-scope so it is importable as
-# 'esiaccel.esitester._one_item_buffers_pair' from a service-request
-# `options={"engine": ...}` value.
-def _one_item_buffers_pair():
-  from .bsp.dma import OneItemBuffersToHost, OneItemBuffersFromHost
-  return (OneItemBuffersToHost, OneItemBuffersFromHost)
-
-
 class ChannelTest(Module):
   """Test the ChannelService with a to_host producer and a from_host loopback.
 
@@ -1210,14 +1267,7 @@ class ChannelTest(Module):
     mmio_rw_cmd_chan = mmio_rw.unpack(data=response_chan)["cmd"]
     cmd_chan_wire.assign(mmio_rw_cmd_chan)
 
-    # Per-request engine override: on cosim_dma this resolves to the same
-    # (OneItemBuffersToHost, OneItemBuffersFromHost) pair the BSP already
-    # uses by default, so this exercises the resolver + substitution path
-    # end-to-end without altering the observed runtime behavior.
-    esi.ChannelService.to_host(
-        AppID("producer"),
-        data_chan,
-        options={"engine": "esiaccel.esitester._one_item_buffers_pair"})
+    esi.ChannelService.to_host(AppID("producer"), data_chan)
 
     # from_host -> to_host loopback.
     loopback_in = esi.ChannelService.from_host(AppID("loopback_in"), UInt(32))

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
@@ -575,10 +575,6 @@ def AddressCommand(width: int):
     # Channel which indicates when the read/write operation is done.
     hostmem_cmd_done = InputChannel(Bits(0))
 
-    # Single burst {address, tag, length} request, issued once per command for
-    # read_list / windowed clients. Held valid until accepted.
-    burst_req = OutputChannel(esi.HostMem.read_req_burst_type(64))
-
     @generator
     def construct(ports):
       # MMIO command channel setup.
@@ -669,29 +665,7 @@ def AddressCommand(width: int):
                                       ChannelSignaling.ValidReady).wrap(
                                           current_addr, addr_valid)
       issue_xact = addr_valid & addr_ready
-
-      # Burst request: a single {address, tag, length} emitted once per command
-      # (for read_list / windowed clients), held valid until accepted. Its
-      # acceptance counts as one issued command.
-      burst_accepted = Wire(Bits(1))
-      burst_pending = ControlReg(
-          clk=ports.clk,
-          rst=ports.rst,
-          asserts=[start_op_we],
-          resets=[burst_accepted],
-          name="burst_pending",
-      )
-      burst_req_chan, burst_req_ready = Channel(
-          esi.HostMem.read_req_burst_type(64)).wrap(
-              esi.HostMem.read_req_burst_type(64)({
-                  "address": start_addr,
-                  "tag": UInt(8)(0),
-                  "length": flits_total,
-              }), burst_pending)
-      burst_accepted.assign((burst_pending & burst_req_ready).as_bits())
-      ports.burst_req = burst_req_chan
-
-      issue_incr.assign((issue_xact | burst_accepted).as_bits())
+      issue_incr.assign(issue_xact)
 
       # Consume hostmem_cmd_done (Bits(0) channel) for completed responses.
       _, done_valid = ports.hostmem_cmd_done.unwrap(Bits(1)(1))
@@ -794,26 +768,21 @@ def ReadMem(width: int):
           hostmem_cmd_done=address_cmd_resp,
           instance_name="address_command",
       )
-      # This burst read uses the single-shot burst request, not the per-flit
-      # address stream; hold that stream un-ready so it stays idle.
-      addresses.hostmem_cmd_address.unwrap(Bits(1)(0))
 
-      # Burst read: issue ONE read_list request per command and receive the
-      # flits back as a windowed list (num_items=1 -> one element per frame,
-      # with a per-frame 'last').
-      read_responses = esi.HostMem.read_list(
+      read_cmd_chan = addresses.hostmem_cmd_address.transform(
+          lambda addr: esi.HostMem.ReadReqType({
+              "tag": UInt(8)(0),
+              "address": addr
+          }))
+      read_responses = esi.HostMem.read(
           appid=AppID("host"),
-          req=addresses.burst_req,
-          element_type=Bits(width),
-          num_items=1,
+          data_type=Bits(width),
+          req=read_cmd_chan,
       )
-      # Signal completion to AddressCommand (each list element -> Bits(0)).
+      # Signal completion to AddressCommand (each response -> Bits(0)).
       address_cmd_resp.assign(read_responses.transform(lambda resp: Bits(0)(0)))
-      # Snoop the response channel to capture the low 64 bits without consuming
-      # it. The response is a windowed list frame; unwrap it to the lowered
-      # struct {tag, data, last} to read the element.
+      # Snoop the response channel to capture the low 64 bits without consuming it.
       read_resp_valid, _, read_resp_data = read_responses.snoop()
-      read_resp_frame = read_resp_data.unwrap()
       last_read_lsb = Reg(
           UInt(64),
           clk=ports.clk,
@@ -822,7 +791,7 @@ def ReadMem(width: int):
           ce=read_resp_valid,
           name="last_read_lsb",
       )
-      last_read_lsb.assign(read_resp_frame["data"][0].as_uint(64))
+      last_read_lsb.assign(read_resp_data.data.as_uint(64))
       esi.Telemetry.report_signal(
           ports.clk,
           ports.rst,
@@ -880,10 +849,14 @@ def WriteMem(width: int) -> Type[Module]:
       clk = ports.clk
       rst = ports.rst
 
-      # MMIO + burst control via AddressCommand (base address, flit count,
-      # start). We use its single-shot {base, tag, length} burst request and
-      # completion tracking; the per-flit address stream is replaced by a single
-      # windowed (list) write, so that stream is left idle.
+      cycle_counter_reset = Wire(Bits(1))
+      cycle_counter = Counter(32)(
+          clk=clk,
+          rst=rst,
+          clear=Bits(1)(0),
+          increment=Bits(1)(1),
+      )
+
       address_cmd_resp = Wire(Channel(Bits(0)))
       addresses = AddressCommand(width)(
           clk=clk,
@@ -891,62 +864,20 @@ def WriteMem(width: int) -> Type[Module]:
           hostmem_cmd_done=address_cmd_resp,
           instance_name="address_command",
       )
-      addresses.hostmem_cmd_address.unwrap(Bits(1)(0))
+      cycle_counter_reset.assign(addresses.command_go)
 
-      # Windowed (list) write: consume the single {base, tag, length} burst
-      # request and stream 'length' list elements written to sequential
-      # addresses (num_items=1 -> one element per frame, 'last' on the final).
-      write_win = esi.HostMem.write_window(Bits(width), 1)
-      lowered = write_win.lowered_type
-
-      streaming = Wire(Bits(1))
-      frame_xact = Wire(Bits(1))
-      burst_ready = (~streaming).as_bits()
-      burst, burst_valid = addresses.burst_req.unwrap(burst_ready)
-      burst_accept = (burst_valid & ~streaming).as_bits()
-      base_addr = burst.address.reg(clk=clk,
-                                    rst=rst,
-                                    rst_value=0,
-                                    ce=burst_accept,
-                                    name="base_addr")
-      total = burst.length.reg(clk=clk,
-                               rst=rst,
-                               rst_value=0,
-                               ce=burst_accept,
-                               name="total")
-
-      frame_counter = Counter(64)(clk=clk,
-                                  rst=rst,
-                                  clear=burst_accept,
-                                  increment=frame_xact)
-      is_last = (frame_counter.out == (total -
-                                       UInt(64)(1)).as_uint(64)).as_bits(1)
-      last_accept = (frame_xact & is_last).as_bits()
-      streaming.assign(
-          ControlReg(clk=clk,
-                     rst=rst,
-                     asserts=[burst_accept],
-                     resets=[last_accept],
-                     name="streaming"))
-
-      # Data pattern: the frame index (non-0xFF), sized to the element width.
-      element = frame_counter.out.as_uint(width).as_bits()
-      frame_val = lowered({
-          "address": base_addr,
-          "tag": UInt(8)(0),
-          "data": [element],
-          "data_size": Bits(0)(0),
-          "last": is_last,
-      })
-      frame_chan, frame_ready = Channel(write_win).wrap(
-          write_win.wrap(frame_val), streaming)
-      frame_xact.assign((streaming & frame_ready).as_bits())
+      write_cmd_chan = addresses.hostmem_cmd_address.transform(
+          lambda addr: esi.HostMem.write_req_channel_type(UInt(width))({
+              "tag": UInt(8)(0),
+              "address": addr,
+              "data": cycle_counter.out.as_uint(width),
+          }))
 
       write_responses = esi.HostMem.write(
           appid=AppID("host"),
-          req=frame_chan,
+          req=write_cmd_chan,
       )
-      # Signal completion to AddressCommand (each write ack -> Bits(0)).
+      # Signal completion to AddressCommand (each response -> Bits(0)).
       address_cmd_resp.assign(
           write_responses.transform(lambda resp: Bits(0)(0)))
 
@@ -1212,6 +1143,18 @@ def FromHostDMATest(width: int):
   return FromHostDMATest
 
 
+# Factory returning the same (to_host, from_host) engine pair the cosim_dma
+# BSP wires in by default. Used below to exercise the per-request engine
+# override on `ChannelService` requests: the resolver imports this path,
+# calls it, and the returned pair replaces the default pair for just that
+# one request's channel. Kept module-scope so it is importable as
+# 'esiaccel.esitester._one_item_buffers_pair' from a service-request
+# `options={"engine": ...}` value.
+def _one_item_buffers_pair():
+  from .bsp.dma import OneItemBuffersToHost, OneItemBuffersFromHost
+  return (OneItemBuffersToHost, OneItemBuffersFromHost)
+
+
 class ChannelTest(Module):
   """Test the ChannelService with a to_host producer and a from_host loopback.
 
@@ -1267,7 +1210,14 @@ class ChannelTest(Module):
     mmio_rw_cmd_chan = mmio_rw.unpack(data=response_chan)["cmd"]
     cmd_chan_wire.assign(mmio_rw_cmd_chan)
 
-    esi.ChannelService.to_host(AppID("producer"), data_chan)
+    # Per-request engine override: on cosim_dma this resolves to the same
+    # (OneItemBuffersToHost, OneItemBuffersFromHost) pair the BSP already
+    # uses by default, so this exercises the resolver + substitution path
+    # end-to-end without altering the observed runtime behavior.
+    esi.ChannelService.to_host(
+        AppID("producer"),
+        data_chan,
+        options={"engine": "esiaccel.esitester._one_item_buffers_pair"})
 
     # from_host -> to_host loopback.
     loopback_in = esi.ChannelService.from_host(AppID("loopback_in"), UInt(32))

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
@@ -22,11 +22,239 @@ from typing import Type
 import pycde.esi as esi
 from pycde import Clock, Module, Reset, System, generator, modparams
 from esiaccel.bsp import get_bsp
-from pycde.common import AppID, Constant, InputChannel, Output, OutputChannel
+from pycde.common import AppID, Constant, Input, InputChannel, Output, OutputChannel
 from pycde.constructs import ControlReg, Counter, Mux, NamedWire, Reg, Wire
 from pycde.module import Metadata
 from pycde.testing import print_info
 from pycde.types import Bits, Channel, ChannelSignaling, UInt
+
+# ---------------------------------------------------------------------------
+# Reusable building blocks for timing-friendly MMIO-controlled test modules.
+#
+# Both helpers keep the BSP's MMIO mux and the consumer-facing channel inside
+# this user module isolated from each other's combinational paths:
+#
+#   * `MmioRegistry` drives the MMIO bundle's `cmd_ready` and response `valid`
+#     from a single `resp_pending` ControlReg. The BSP MMIO mux therefore
+#     only sees FF outputs, and the user module's internal write-enable
+#     strobes are 1-cycle-late registered pulses gated by `cmd_xact_r`.
+#
+#   * `IterationGate` exposes a counter+limit "run for N iterations" widget
+#     whose `active` output is a ControlReg (FF) and whose only consumer-
+#     driven input (`iter_xact`) terminates at the counter's clock enable.
+#     The consumer's channel-ready signal never re-emerges combinationally
+#     from this module. It also always reports `cycles` telemetry for the
+#     active window.
+#
+# Use both together to build a test that drives a single channel with N
+# iterations under MMIO control without exposing the BSP arbitration mux to
+# wide internal combinational logic.
+# ---------------------------------------------------------------------------
+
+
+class MmioRegistry(Module):
+  """PyCDE submodule that owns an `esi.MMIO.read_write` request and
+    exposes a FF-bounded command/response surface.
+
+    The MMIO bundle is created inside this submodule's `@generator`, so
+    the service request's AppID is anchored at this instance's
+    hierarchical position. Callers should set `instance_name="mmio"` and
+    `appid=AppID("mmio", ...)` so the leaf MMIO AppID is always
+    `<parent>/.../mmio/cmd`.
+
+    The submodule drives the MMIO bundle's `cmd_ready` and response
+    `valid` from a single `resp_pending` ControlReg, so the BSP MMIO mux
+    only sees this submodule's outputs through a FF. Per-offset write-
+    enable strobes (computed by the caller via the `mmio_write_we`
+    helper) are derived from `cmd_xact_r` -- a 1-cycle-late registered
+    accept pulse -- so the caller's decoded write-enables never depend
+    combinationally on the BSP MMIO `cmd_valid`.
+
+    Ports:
+        resp_data  : Input  Bits(64)
+            64-bit MMIO read response value. Latched internally on
+            cmd_xact and presented to MMIO the cycle resp_pending
+            asserts.
+        cmd_r      : Output StructType (esi.MMIOReadWriteCmdType)
+            Registered MMIO command (the most recently accepted one).
+        cmd_xact_r : Output Bits(1)
+            One-cycle pulse one cycle after a command is accepted.
+            Combine with `cmd_r` to derive per-offset write-enable
+            strobes; see `mmio_write_we`.
+    """
+
+  clk = Clock()
+  rst = Reset()
+
+  resp_data = Input(Bits(64))
+
+  cmd_r = Output(esi.MMIOReadWriteCmdType)
+  cmd_xact_r = Output(Bits(1))
+
+  @generator
+  def construct(ports):
+    clk = ports.clk
+    rst = ports.rst
+
+    mmio_bundle = esi.MMIO.read_write(appid=AppID("cmd"))
+
+    cmd_chan_wire = Wire(Channel(esi.MMIOReadWriteCmdType))
+    cmd_ready_wire = Wire(Bits(1))
+    cmd, cmd_valid = cmd_chan_wire.unwrap(cmd_ready_wire)
+
+    resp_pending_wire = Wire(Bits(1))
+    resp_data_r = Wire(Bits(64))
+    resp_chan, resp_ready = Channel(Bits(64)).wrap(resp_data_r,
+                                                   resp_pending_wire)
+    resp_xact = resp_pending_wire & resp_ready
+    cmd_xact = cmd_valid & ~resp_pending_wire
+    cmd_ready_wire.assign(~resp_pending_wire)
+    resp_pending_wire.assign(
+        ControlReg(
+            clk=clk,
+            rst=rst,
+            asserts=[cmd_xact],
+            resets=[resp_xact],
+            name="resp_pending",
+        ))
+
+    ports.cmd_r = cmd.reg(clk=clk, rst=rst, ce=cmd_xact, name="cmd_r")
+    ports.cmd_xact_r = cmd_xact.reg(
+        clk=clk,
+        rst=rst,
+        rst_value=Bits(1)(0),
+        name="cmd_xact_r",
+    )
+
+    resp_data_r.assign(
+        ports.resp_data.reg(
+            clk=clk,
+            rst=rst,
+            rst_value=Bits(64)(0),
+            ce=cmd_xact,
+            name="resp_data_r",
+        ))
+
+    mmio_rw_cmd_chan = mmio_bundle.unpack(data=resp_chan)["cmd"]
+    cmd_chan_wire.assign(mmio_rw_cmd_chan)
+
+
+def mmio_write_we(mmio, offset: int):
+  """Registered 1-cycle write-enable strobe for writes to `offset`.
+
+    Asserts for one cycle the cycle AFTER the MMIO command is accepted.
+    Use as the `ce` of registers that latch `mmio.cmd_r.data`.
+    """
+  return (mmio.cmd_xact_r & mmio.cmd_r.write &
+          (mmio.cmd_r.offset == UInt(32)(offset)))
+
+
+@modparams
+def IterationGate(count_width: int):
+  """Run an internal counter for `limit` iterations gated by `iter_xact`,
+    and always report cycle telemetry for the active window.
+
+    `start_pulse` asserts `active` (and clears the counters) for one cycle.
+    `iter_xact` is the per-iteration handshake strobe; it feeds only a
+    Counter clock enable. `active` clears the cycle after `iter_count`
+    reaches `limit`.
+
+    The consumer's channel-ready signal can flow into `iter_xact` without
+    re-emerging combinationally through any output: only Counters (FFs)
+    consume it.
+
+    Telemetry reported under this instance's AppID:
+        cycles : ui64
+            Cycles `active` was asserted between `start_pulse` and
+            `count_reached`; latched on `count_reached` so the host always
+            reads the final value of the most recent run.
+
+    Ports:
+        start_pulse   : Input  Bits(1)
+        limit         : Input  UInt(count_width)
+        iter_xact     : Input  Bits(1)
+        active        : Output Bits(1)            -- ControlReg, FF output
+        count_reached : Output Bits(1)            -- iter_count == limit
+        iter_count    : Output UInt(count_width)
+        iters_left    : Output UInt(count_width)
+    """
+
+  class IterationGate(Module):
+    clk = Clock()
+    rst = Reset()
+
+    start_pulse = Input(Bits(1))
+    limit = Input(UInt(count_width))
+    iter_xact = Input(Bits(1))
+
+    active = Output(Bits(1))
+    count_reached = Output(Bits(1))
+    iter_count = Output(UInt(count_width))
+    iters_left = Output(UInt(count_width))
+
+    @generator
+    def construct(ports):
+      clk = ports.clk
+      rst = ports.rst
+
+      # `count_reached_sig` fires combinationally on the last
+      # `iter_xact` (when `iter_count` is about to become
+      # `limit`), so `active` drops the cycle the consumer would
+      # have issued the (limit+1)th transaction. Without this,
+      # there is a 2-cycle race between `iter_count` reaching
+      # `limit` and the ControlReg dropping `active`, during
+      # which the consumer issues one extra transaction -- and
+      # for `limit=1` the host-visible counters jump straight
+      # from 0 to 2, so any host poll for "== 1" never catches.
+      # `count_reached` is combinational on `iter_xact` (which is
+      # consumer-driven), but it only feeds the ControlReg reset
+      # (a flop) and telemetry, so the consumer's ready signal
+      # does not re-emerge combinationally on `active`.
+      count_reached_wire = Wire(Bits(1))
+      active_r = ControlReg(
+          clk=clk,
+          rst=rst,
+          asserts=[ports.start_pulse],
+          resets=[count_reached_wire],
+          name="active_r",
+      )
+      counter = Counter(count_width)(
+          clk=clk,
+          rst=rst,
+          clear=ports.start_pulse,
+          increment=ports.iter_xact,
+          instance_name="iter_counter",
+      )
+      last_iter = (counter.out.as_uint() == (
+          ports.limit - UInt(count_width)(1)).as_uint(count_width)).as_bits(1)
+      count_reached_sig = ports.iter_xact & last_iter
+      count_reached_wire.assign(count_reached_sig)
+
+      ports.active = active_r
+      ports.count_reached = count_reached_sig
+      ports.iter_count = counter.out.as_uint()
+      ports.iters_left = (ports.limit -
+                          counter.out.as_uint()).as_uint(count_width)
+
+      cycles_cnt = Counter(64)(
+          clk=clk,
+          rst=rst,
+          clear=ports.start_pulse,
+          increment=active_r,
+          instance_name="cycle_counter",
+      )
+      final_cycles = Reg(
+          UInt(64),
+          clk=clk,
+          rst=rst,
+          rst_value=0,
+          ce=count_reached_sig,
+          name="final_cycles",
+      )
+      final_cycles.assign(cycles_cnt.out.as_uint())
+      esi.Telemetry.report_signal(clk, rst, AppID("cycles"), final_cycles)
+
+  return IterationGate
 
 
 class CallbackTest(Module):
@@ -547,208 +775,129 @@ def MMIOAdd(add_amt: int) -> Type[Module]:
 
 
 @modparams
-def AddressCommand(width: int):
+def BurstCommand(width: int):
+  """MMIO-controlled single-burst command surface. Replaces AddressCommand's
+    per-flit address stream: exposes one {address, tag, length} burst request
+    per command -- for a ``read_list`` or a windowed (list) write -- and tracks
+    completion.
 
-  class AddressCommand(Module):
-    """Constructs an module which takes MMIO commands and issues host memory
-        commands based on those commands. Tracks the number of cycles to issue
-        addresses and get all of the expected responses.
+    MMIO offsets: 0x10 base address, 0x18 list length (flits), 0x20 start.
+    """
 
-        MMIO offsets:
-            0x10: Starting address for host memory operations.
-            0x18: Number of flits to read/write.
-            0x20: Start read/write operation.
-        """
-
+  class BurstCommand(Module):
     clk = Clock()
     rst = Reset()
 
-    # Number of flits left to issue.
+    # Remaining elements (for MMIO read-back).
     flits_left = Output(UInt(64))
-    # Signal to start the operation.
-    command_go = Output(Bits(1))
-
-    # Channel which issues hostmem addresses. Must be transformed into
-    # read/write requests by the instantiator.
-    hostmem_cmd_address = OutputChannel(UInt(64))
-
-    # Channel which indicates when the read/write operation is done.
+    # Single {address, tag, length} burst request, held valid until
+    # accepted.
+    burst_req = OutputChannel(esi.HostMem.read_req_burst_type())
+    # One Bits(0) completion token per received element / write ack.
     hostmem_cmd_done = InputChannel(Bits(0))
 
     @generator
     def construct(ports):
-      # MMIO command channel setup.
-      cmd_chan_wire = Wire(Channel(esi.MMIOReadWriteCmdType))
-      resp_ready_wire = Wire(Bits(1))
-      cmd, cmd_valid = cmd_chan_wire.unwrap(resp_ready_wire)
-      mmio_xact = cmd_valid & resp_ready_wire
+      clk = ports.clk
+      rst = ports.rst
 
-      # Write enables.
-      start_addr_we = (mmio_xact & cmd.write & (cmd.offset == UInt(32)(0x10)))
-      flits_we = mmio_xact & cmd.write & (cmd.offset == UInt(32)(0x18))
-      start_op_we = mmio_xact & cmd.write & (cmd.offset == UInt(32)(0x20))
-      ports.command_go = start_op_we
+      resp_data_wire = Wire(Bits(64))
+      mmio = MmioRegistry(
+          clk=clk,
+          rst=rst,
+          resp_data=resp_data_wire,
+          instance_name="mmio",
+          appid=AppID("mmio", width),
+      )
 
-      # Registers for start address and number of flits.
-      start_addr = cmd.data.as_uint().reg(
-          clk=ports.clk,
-          rst=ports.rst,
+      start_addr = mmio.cmd_r.data.as_uint().reg(
+          clk=clk,
+          rst=rst,
           rst_value=0,
-          ce=start_addr_we,
+          ce=mmio_write_we(mmio, 0x10),
           name="start_addr",
       )
-      flits_total = cmd.data.as_uint().reg(
-          clk=ports.clk,
-          rst=ports.rst,
+      flits_total = mmio.cmd_r.data.as_uint().reg(
+          clk=clk,
+          rst=rst,
           rst_value=0,
-          ce=flits_we,
+          ce=mmio_write_we(mmio, 0x18),
           name="flits_total",
       )
+      start_op_we = mmio_write_we(mmio, 0x20)
 
-      # Response counter.
-      responses_incr = Wire(Bits(1))
-      responses_cnt = Counter(64)(
-          clk=ports.clk,
-          rst=ports.rst,
-          clear=start_op_we,
-          increment=responses_incr,
-          instance_name="addr_cmd_responses_cnt",
-      )
-
-      operation_done = responses_cnt.out.as_uint() == flits_total
-      operation_active = ControlReg(
-          clk=ports.clk,
-          rst=ports.rst,
-          asserts=[start_op_we],
-          resets=[operation_done],
-          name="operation_active",
-      )
-      # Cycle counter while active.
-      cycles_cnt = Counter(64)(
-          clk=ports.clk,
-          rst=ports.rst,
-          clear=start_op_we,
-          increment=operation_active,
-          instance_name="addr_cmd_cycle_counter",
-      )
-      # Latch final cycle count at completion.
-      final_cycles = Reg(
-          UInt(64),
-          clk=ports.clk,
-          rst=ports.rst,
-          rst_value=0,
-          ce=operation_done,
-          name="addr_cmd_cycles",
-      )
-      final_cycles.assign(cycles_cnt.out.as_uint())
-
-      # Issue counter.
-      issue_incr = Wire(Bits(1))
-      issue_cnt = Counter(64)(
-          clk=ports.clk,
-          rst=ports.rst,
-          clear=start_op_we,
-          increment=issue_incr,
-      )
-
-      # Increment by number of bytes per flit, rounded up to nearest 32
-      # bits (double word).
-      incr_bytes = UInt(64)(((width + 31) // 32) * 4)
-
-      # Generate current address.
-      current_addr = (start_addr +
-                      (issue_cnt.out.as_uint() * incr_bytes)).as_uint(64)
-
-      # Valid when active and still have flits to issue.
-      addr_valid = operation_active & (issue_cnt.out.as_uint() < flits_total)
-      addr_chan, addr_ready = Channel(UInt(64),
-                                      ChannelSignaling.ValidReady).wrap(
-                                          current_addr, addr_valid)
-      issue_xact = addr_valid & addr_ready
-      issue_incr.assign(issue_xact)
-
-      # Consume hostmem_cmd_done (Bits(0) channel) for completed responses.
+      # Response side: count completed elements; auto-reports cycles.
       _, done_valid = ports.hostmem_cmd_done.unwrap(Bits(1)(1))
-      responses_incr.assign(done_valid)
-
-      # flits_left = total - responses received.
-      flits_left_val = (flits_total - responses_cnt.out.as_uint()).as_uint(64)
-      ports.flits_left = flits_left_val  # direct assignment
-
-      # Drive output channel.
-      ports.hostmem_cmd_address = addr_chan  # direct assignment
-
-      # MMIO read response: return flits_left.
-      response_data = flits_left_val.as_bits(64)
-      response_chan, response_ready = Channel(Bits(64)).wrap(
-          response_data, cmd_valid)
-      resp_ready_wire.assign(response_ready)
-
-      mmio_rw = esi.MMIO.read_write(appid=AppID("cmd", width))
-      mmio_rw_cmd_chan = mmio_rw.unpack(data=response_chan)["cmd"]
-      cmd_chan_wire.assign(mmio_rw_cmd_chan)
-
-      # Report telemetry.
-      esi.Telemetry.report_signal(
-          ports.clk,
-          ports.rst,
-          esi.AppID("addrCmdCycles"),
-          final_cycles,
+      resp_gate = IterationGate(64)(
+          clk=clk,
+          rst=rst,
+          start_pulse=start_op_we,
+          limit=flits_total,
+          iter_xact=done_valid,
+          instance_name="resp_gate",
+          appid=AppID("addrCmdResp"),
       )
-      esi.Telemetry.report_signal(
-          ports.clk,
-          ports.rst,
-          esi.AppID("addrCmdIssued"),
-          issue_cnt.out,
+      ports.flits_left = resp_gate.iters_left
+      resp_data_wire.assign(resp_gate.iters_left.as_bits(64))
+
+      # Single burst request, held valid from start until accepted.
+      burst_accepted = Wire(Bits(1))
+      burst_pending = ControlReg(
+          clk=clk,
+          rst=rst,
+          asserts=[start_op_we],
+          resets=[burst_accepted],
+          name="burst_pending",
       )
-      esi.Telemetry.report_signal(
-          ports.clk,
-          ports.rst,
-          esi.AppID("addrCmdResponses"),
-          responses_cnt.out,
+      burst_req_t = esi.HostMem.read_req_burst_type()
+      burst_chan, burst_ready = Channel(burst_req_t).wrap(
+          burst_req_t({
+              "address": start_addr,
+              "tag": UInt(8)(0),
+              "length": flits_total,
+          }),
+          burst_pending,
+      )
+      burst_accepted.assign((burst_pending & burst_ready).as_bits())
+      ports.burst_req = burst_chan
+
+      # Issue side: one issued command per accepted burst.
+      issue_cnt = Counter(64)(
+          clk=clk,
+          rst=rst,
+          clear=start_op_we,
+          increment=burst_accepted,
       )
 
-  return AddressCommand
+      esi.Telemetry.report_signal(clk, rst, esi.AppID("addrCmdIssued"),
+                                  issue_cnt.out)
+      esi.Telemetry.report_signal(clk, rst, esi.AppID("addrCmdResponses"),
+                                  resp_gate.iter_count)
+
+  return BurstCommand
 
 
 @modparams
 def ReadMem(width: int):
 
   class ReadMem(Module):
-    """Host memory read test module.
+    """Host memory burst (list) read test module.
 
-        Function:
-          Issues a sequence of host memory read requests using an internal
-          address/control submodule which is configured via MMIO writes. Each
-          read returns 'width' bits; the low 64 bits of the most recent
-          response are latched and exported as telemetry (lastReadLSB).
+        Issues a single ``read_list`` burst of 'flits' elements starting at the
+        base address (both configured via MMIO) and receives the elements back
+        as a windowed list (num_items=1 -> one element per frame). The low 64
+        bits of the most recent element are exported as telemetry (lastReadLSB).
 
-        Flit width:
-          'width' is the number of payload data bits per read flit. The address
-          stride between successive requests is ceil(width/32) 32-bit words
-          (= ceil(width/32) * 4 bytes). Non–power‑of‑two widths are supported
-          and packed into the minimum whole 32‑bit word count.
-
-        MMIO command interface:
-          0x10  Write: Starting base address for the read operation.
-          0x18  Write: Number of flits (read transactions) to perform.
-          0x20  Write: Start the operation (assert once to launch).
-          Reads return the current flits_left (remaining responses).
-
-        Operation:
-          After 0x20 is written, sequential addresses are generated:
-            addr = start_addr + i * ceil(width/32)   (i = 0 .. flits-1)
-          Each address produces one host memory read request.
+        MMIO command interface (via BurstCommand):
+          0x10  Write: base address for the read.
+          0x18  Write: number of list elements (flits) to read.
+          0x20  Write: start the operation.
+          Reads return the remaining element count.
 
         Telemetry (AppID -> signal):
-          addrCmdCycles     Total cycles elapsed during the active window.
-          addrCmdIssued     Count of host memory commands issued.
-          addrCmdResponses  Count of host memory responses received.
-          lastReadLSB       Low 64 bits of the most recently received read data.
-
-        Notes:
-          Backpressure on the read response channel naturally throttles issue.
-          Completion occurs when responses == requested flits.
+          addrCmdIssued     Count of burst commands issued (1 per command).
+          addrCmdResponses  Count of list elements received.
+          lastReadLSB       Low 64 bits of the most recent element.
         """
 
     clk = Clock()
@@ -761,37 +910,35 @@ def ReadMem(width: int):
       clk = ports.clk
       rst = ports.rst
 
-      address_cmd_resp = Wire(Channel(Bits(0)))
-      addresses = AddressCommand(width)(
+      done_wire = Wire(Channel(Bits(0)))
+      cmd = BurstCommand(width)(
           clk=clk,
           rst=rst,
-          hostmem_cmd_done=address_cmd_resp,
-          instance_name="address_command",
+          hostmem_cmd_done=done_wire,
+          instance_name="burst_command",
       )
 
-      read_cmd_chan = addresses.hostmem_cmd_address.transform(
-          lambda addr: esi.HostMem.ReadReqType({
-              "tag": UInt(8)(0),
-              "address": addr
-          }))
-      read_responses = esi.HostMem.read(
+      # One read_list request per command; elements come back as a
+      # windowed list.
+      read_responses = esi.HostMem.read_list(
           appid=AppID("host"),
-          data_type=Bits(width),
-          req=read_cmd_chan,
+          req=cmd.burst_req,
+          element_type=Bits(width),
+          num_items=1,
       )
-      # Signal completion to AddressCommand (each response -> Bits(0)).
-      address_cmd_resp.assign(read_responses.transform(lambda resp: Bits(0)(0)))
-      # Snoop the response channel to capture the low 64 bits without consuming it.
-      read_resp_valid, _, read_resp_data = read_responses.snoop()
+      # Each received element -> one completion token to BurstCommand.
+      done_wire.assign(read_responses.transform(lambda resp: Bits(0)(0)))
+      # Snoop the low 64 bits of each element without consuming it.
+      read_resp_valid_snoop, _, read_resp_data = read_responses.snoop()
       last_read_lsb = Reg(
           UInt(64),
           clk=ports.clk,
           rst=ports.rst,
           rst_value=0,
-          ce=read_resp_valid,
+          ce=read_resp_valid_snoop,
           name="last_read_lsb",
       )
-      last_read_lsb.assign(read_resp_data.data.as_uint(64))
+      last_read_lsb.assign(read_resp_data.unwrap()["data"][0].as_uint(64))
       esi.Telemetry.report_signal(
           ports.clk,
           ports.rst,
@@ -806,37 +953,23 @@ def ReadMem(width: int):
 def WriteMem(width: int) -> Type[Module]:
 
   class WriteMem(Module):
-    """Host memory write test module.
+    """Host memory burst (list) write test module.
 
-        Function:
-          Issues sequential host memory write requests produced by an internal
-          address/control submodule configured via MMIO writes. Data for each
-          flit is the current free‑running 32‑bit cycle counter value
-          (zero‑extended or truncated to 'width').
+        Issues a single windowed (list) write of 'flits' elements to sequential
+        addresses starting at the base address (both configured via MMIO). The
+        elements are streamed as a windowed list (num_items=1 -> one element per
+        frame, 'last' on the final); each element's payload is its frame index.
 
-        Flit width:
-          'width' is the number of payload data bits per write flit. The address
-          stride between successive writes is ceil(width/32) 32‑bit words
-          (= ceil(width/32) * 4 bytes). Wider payloads span multiple words;
-          narrower payloads still consume one word of address space per flit.
-
-        MMIO command interface:
-          0x10  Write: Starting base address for the write operation.
-          0x18  Write: Number of flits (write transactions) to perform.
-          0x20  Write: Start the operation (assert once to launch).
-          Reads return the current flits_left (remaining responses).
-
-        Data pattern:
-          data[i] = cycle_counter sampled when the write command for flit i is formed.
+        MMIO command interface (via BurstCommand):
+          0x10  Write: base address for the write.
+          0x18  Write: number of list elements (flits) to write.
+          0x20  Write: start the operation.
+          Reads return the remaining element count.
 
         Telemetry (AppID -> signal):
-          addrCmdCycles     Total cycles elapsed during the active window.
-          addrCmdIssued     Count of host memory commands issued.
-          addrCmdResponses  Count of host memory responses received.
-
-        Notes:
-          No additional telemetry beyond the above signals is generated here.
-          Completion occurs when write responses == requested flits.
+          addrCmdIssued     Count of burst commands issued (1 per command).
+          addrCmdResponses  Count of write acks received.
+          addrCmdResp/cycles  Active-window cycle count.
         """
 
     clk = Clock()
@@ -849,37 +982,77 @@ def WriteMem(width: int) -> Type[Module]:
       clk = ports.clk
       rst = ports.rst
 
-      cycle_counter_reset = Wire(Bits(1))
-      cycle_counter = Counter(32)(
+      done_wire = Wire(Channel(Bits(0)))
+      cmd = BurstCommand(width)(
           clk=clk,
           rst=rst,
-          clear=Bits(1)(0),
-          increment=Bits(1)(1),
+          hostmem_cmd_done=done_wire,
+          instance_name="burst_command",
       )
 
-      address_cmd_resp = Wire(Channel(Bits(0)))
-      addresses = AddressCommand(width)(
+      # Windowed (list) write: consume the single {base, tag, length}
+      # burst request and stream 'length' elements to sequential
+      # addresses (num_items=1 -> one element per frame).
+      write_win = esi.HostMem.write_window(Bits(width), 1)
+      lowered = write_win.lowered_type
+
+      streaming = Wire(Bits(1))
+      frame_xact = Wire(Bits(1))
+      burst_ready = (~streaming).as_bits()
+      burst, burst_valid = cmd.burst_req.unwrap(burst_ready)
+      burst_accept = (burst_valid & ~streaming).as_bits()
+      base_addr = burst.address.reg(
           clk=clk,
           rst=rst,
-          hostmem_cmd_done=address_cmd_resp,
-          instance_name="address_command",
+          rst_value=0,
+          ce=burst_accept,
+          name="base_addr",
       )
-      cycle_counter_reset.assign(addresses.command_go)
+      total = burst.length.reg(
+          clk=clk,
+          rst=rst,
+          rst_value=0,
+          ce=burst_accept,
+          name="total",
+      )
 
-      write_cmd_chan = addresses.hostmem_cmd_address.transform(
-          lambda addr: esi.HostMem.write_req_channel_type(UInt(width))({
-              "tag": UInt(8)(0),
-              "address": addr,
-              "data": cycle_counter.out.as_uint(width),
-          }))
+      frame_counter = Counter(64)(
+          clk=clk,
+          rst=rst,
+          clear=burst_accept,
+          increment=frame_xact,
+      )
+      is_last = (frame_counter.out == (total -
+                                       UInt(64)(1)).as_uint(64)).as_bits(1)
+      last_accept = (frame_xact & is_last).as_bits()
+      streaming.assign(
+          ControlReg(
+              clk=clk,
+              rst=rst,
+              asserts=[burst_accept],
+              resets=[last_accept],
+              name="streaming",
+          ))
+
+      # Data pattern: the frame index (non-0xFF), sized to the element.
+      element = frame_counter.out.as_uint(width).as_bits()
+      frame_val = lowered({
+          "address": base_addr,
+          "tag": UInt(8)(0),
+          "data": [element],
+          "data_size": Bits(0)(0),
+          "last": is_last,
+      })
+      frame_chan, frame_ready = Channel(write_win).wrap(
+          write_win.wrap(frame_val), streaming)
+      frame_xact.assign((streaming & frame_ready).as_bits())
 
       write_responses = esi.HostMem.write(
           appid=AppID("host"),
-          req=write_cmd_chan,
+          req=frame_chan,
       )
-      # Signal completion to AddressCommand (each response -> Bits(0)).
-      address_cmd_resp.assign(
-          write_responses.transform(lambda resp: Bits(0)(0)))
+      # Each write ack -> one completion token to BurstCommand.
+      done_wire.assign(write_responses.transform(lambda resp: Bits(0)(0)))
 
   return WriteMem
 

--- a/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import subprocess
+
 import esiaccel
 from esiaccel.accelerator import AcceleratorConnection
 from esiaccel.cosim.pytest import cosim_test
@@ -174,6 +176,25 @@ class TestCosimEsitesterDma:
   def test_hostmem(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"
     run_cmd(["esitester", "cosim", conn, "hostmem"])
+
+  def test_hostmembw(self, host: str, port: int) -> None:
+    conn = f"{host}:{port}"
+    # A 1000-element read burst at 32 bits (8 bytes/element) is 8000 bytes,
+    # which exceeds the PCIe maximum read request size (256 bytes) and so
+    # exercises the read-request splitter. Capture stderr too and assert the
+    # runtime never sees an oversized (unsplit) read request.
+    result = subprocess.run(
+        [
+            "esitester", "cosim", conn, "hostmembw", "-w", "-r", "-c", "1000",
+            "--widths", "32", "128"
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    combined = result.stdout + result.stderr
+    assert "exceeds the PCIe maximum read request size" not in combined, \
+        combined
 
   def test_dma(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"

--- a/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import subprocess
-
 import esiaccel
 from esiaccel.accelerator import AcceleratorConnection
 from esiaccel.cosim.pytest import cosim_test
@@ -176,25 +174,6 @@ class TestCosimEsitesterDma:
   def test_hostmem(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"
     run_cmd(["esitester", "cosim", conn, "hostmem"])
-
-  def test_hostmembw(self, host: str, port: int) -> None:
-    conn = f"{host}:{port}"
-    # A 1000-element read burst at 32 bits (8 bytes/element) is 8000 bytes,
-    # which exceeds the PCIe maximum read request size (256 bytes) and so
-    # exercises the read-request splitter. Capture stderr too and assert the
-    # runtime never sees an oversized (unsplit) read request.
-    result = subprocess.run(
-        [
-            "esitester", "cosim", conn, "hostmembw", "-w", "-r", "-c", "1000",
-            "--widths", "32", "128"
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    combined = result.stdout + result.stderr
-    assert "exceeds the PCIe maximum read request size" not in combined, \
-        combined
 
   def test_dma(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"

--- a/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import subprocess
+
 import esiaccel
 from esiaccel.accelerator import AcceleratorConnection
 from esiaccel.cosim.pytest import cosim_test
@@ -104,15 +106,15 @@ class TestCosimEsitester:
     check_lines(stdout, [
         "* Telemetry",
         "fromhostdma[32].fromHostCycles: 0",
-        "readmem[32].addrCmdCycles: 0",
         "readmem[32].addrCmdIssued: 0",
         "readmem[32].addrCmdResponses: 0",
         "readmem[32].lastReadLSB: 0",
         "tohostdma[32].toHostCycles: 0",
         "tohostdma[32].totalWrites: 0",
-        "writemem[32].addrCmdCycles: 0",
         "writemem[32].addrCmdIssued: 0",
         "writemem[32].addrCmdResponses: 0",
+        "readmem[32].addrCmdResp.cycles: 0",
+        "writemem[32].addrCmdResp.cycles: 0",
     ])
 
   def test_reset(self, host: str, port: int) -> None:
@@ -178,6 +180,35 @@ class TestCosimEsitesterDma:
   def test_dma(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"
     run_cmd(["esitester", "cosim", conn, "dma", "-w", "-r"])
+
+  def test_hostmembw(self, host: str, port: int) -> None:
+    conn = f"{host}:{port}"
+    # A 1000-element read burst at 32 bits (8 bytes/element) is 8000 bytes,
+    # which exceeds the PCIe maximum read request size and so exercises the
+    # read-request splitter. Capture stderr too and assert the runtime never
+    # sees an oversized (unsplit) read request.
+    result = subprocess.run(
+        [
+            "esitester", "cosim", conn, "hostmembw", "-w", "-r", "-c", "1000",
+            "--widths", "32", "128"
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    combined = result.stdout + result.stderr
+    assert "exceeds the PCIe maximum read request size" not in combined, \
+        combined
+
+  def test_aggbandwidth(self, host: str, port: int) -> None:
+    conn = f"{host}:{port}"
+    # Aggregate bandwidth across the width-512 readmem*/writemem* units
+    # (4 read + 4 write), exercising the multi-unit nested-AppID resolution
+    # (mmio[width]/cmd and addrCmdResp/cycles) of the burst modules.
+    run_cmd([
+        "esitester", "cosim", conn, "aggbandwidth", "--width", "512", "-r",
+        "-w", "-c", "64"
+    ])
 
   def test_telemetry(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"


### PR DESCRIPTION
Update BSP to not break with the new support for list requests on the HostMem service. A bunch of the components used had to be adapted to support lists in addition to the Cosim backend. Tested (very) successfully in an internal design. Also ports the hostmem tests (in esitester) to emit/consume lists.

Assisted-by: Github-Copilot:Claude Opus 4.8
