### PR TITLE
[CombFolds] Fix self loop in extract(concat) cannonicalization

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -522,6 +522,10 @@ extractConcatToConcatExtract(ExtractOp op, ConcatOp innerCat,
                              PatternRewriter &rewriter,
                              ArrayRef<size_t> prefixWidths = {}) {
   auto concatInputs = innerCat.getInputs();
+  // Do not create a replacement that uses the operation being replaced.
+  if (llvm::is_contained(concatInputs, op.getResult()))
+    return failure();
+
   size_t numOperands = concatInputs.size();
   size_t lowBit = op.getLowBit();
 

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -54,14 +54,13 @@ hw.module @bailOnRecursiveOps(in %a: i1, in %b: i1, out z0: i42, out z1: i1) {
 }
 
 // CHECK-LABEL: @bailOnRecursiveExtractOfConcat
-// https://github.com/llvm/circt/issues/10877
 hw.module @bailOnRecursiveExtractOfConcat(out o: i6) {
   %false = hw.constant false
-  // CHECK: %0 = comb.extract %2 from 2 : (i6) -> i4
+  // CHECK: %[[EXT0:.+]] = comb.extract %[[CONCAT:.+]] from 2 : (i6) -> i4
   %0 = comb.extract %2 from 2 : (i6) -> i4
-  // CHECK: %1 = comb.extract %2 from 0 : (i6) -> i1
+  // CHECK: %[[EXT1:.+]] = comb.extract %[[CONCAT]] from 0 : (i6) -> i1
   %1 = comb.extract %2 from 0 : (i6) -> i1
-  // CHECK: %2 = comb.concat %0, %false, %1 : i4, i1, i1
+  // CHECK: %[[CONCAT]] = comb.concat %[[EXT0]], %false, %[[EXT1]] : i4, i1, i1
   %2 = comb.concat %0, %false, %1 : i4, i1, i1
   hw.output %2 : i6
 }

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -53,6 +53,19 @@ hw.module @bailOnRecursiveOps(in %a: i1, in %b: i1, out z0: i42, out z1: i1) {
   hw.output %z0, %z1 : i42, i1
 }
 
+// CHECK-LABEL: @bailOnRecursiveExtractOfConcat
+// https://github.com/llvm/circt/issues/10877
+hw.module @bailOnRecursiveExtractOfConcat(out o: i6) {
+  %false = hw.constant false
+  // CHECK: %0 = comb.extract %2 from 2 : (i6) -> i4
+  %0 = comb.extract %2 from 2 : (i6) -> i4
+  // CHECK: %1 = comb.extract %2 from 0 : (i6) -> i1
+  %1 = comb.extract %2 from 0 : (i6) -> i1
+  // CHECK: %2 = comb.concat %0, %false, %1 : i4, i1, i1
+  %2 = comb.concat %0, %false, %1 : i4, i1, i1
+  hw.output %2 : i6
+}
+
 // CHECK-LABEL: @narrowMux
 hw.module @narrowMux(in %a: i8, in %b: i8, in %c: i1, out o: i4) {
 // CHECK-NEXT: %0 = comb.extract %a from 1 : (i8) -> i4


### PR DESCRIPTION
Fix https://github.com/llvm/circt/issues/10877 by bailing out when there is a self loop in a similar way to other places. 
