### PR TITLE
[Affine][ToLoopSchedule] Materialize forwarding-only stages

### DIFF
--- a/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
+++ b/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
@@ -566,9 +566,13 @@ LogicalResult AffineToLoopSchedule::createLoopSchedulePipeline(
   // One more map is needed for the pipeline stages terminator
   stageValueMaps.push_back(valueMap);
 
-  // Create stages along with maps
-  for (auto startTime : startTimes) {
+  // Create stages along with maps. `registerValues` may contain a time slot
+  // with no scheduled operations that is still needed to forward a value to a
+  // later stage. Materialize those forwarding-only stages as well.
+  for (unsigned startTime = 0; startTime < registerValues.size(); ++startTime) {
     auto group = startGroups[startTime];
+    if (group.empty() && registerValues[startTime].empty())
+      continue;
     llvm::sort(group, [&](Operation *a, Operation *b) {
       return dom.properlyDominates(a, b);
     });

--- a/test/Conversion/AffineToLoopSchedule/forwarding-stage-gap.mlir
+++ b/test/Conversion/AffineToLoopSchedule/forwarding-stage-gap.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt -convert-affine-to-loopschedule %s | FileCheck %s
+
+// A combinational result may need forwarding across time slots with no
+// scheduled operation while another operand is produced by a multi-cycle op.
+
+// CHECK-LABEL: func @forward_across_empty_stages
+// CHECK: %[[STAGE0:.*]]:3 = loopschedule.pipeline.stage start = 0
+// CHECK-DAG: %[[SHORT:.*]] = arith.addi
+// CHECK-DAG: %[[LONG:.*]] = arith.muli
+// CHECK: loopschedule.register %[[SHORT]], %[[LONG]], %{{.*}}
+// CHECK: %[[STAGE1:.*]] = loopschedule.pipeline.stage start = 1
+// CHECK-NEXT: loopschedule.register %[[STAGE0]]#0
+// CHECK: %[[STAGE2:.*]] = loopschedule.pipeline.stage start = 2
+// CHECK-NEXT: loopschedule.register %[[STAGE1]]
+// CHECK: loopschedule.pipeline.stage start = 3
+// CHECK: arith.addi %[[STAGE2]], %[[STAGE0]]#1 : i32
+func.func @forward_across_empty_stages(%out: memref<16xi32>,
+                                       %a: i32, %b: i32) {
+  affine.for %i = 0 to 16 {
+    %short = arith.addi %a, %b : i32
+    %long = arith.muli %a, %b : i32
+    %sum = arith.addi %short, %long : i32
+    affine.store %sum, %out[%i] : memref<16xi32>
+  }
+  return
+}


### PR DESCRIPTION
AffineToLoopSchedule builds pipeline stages only for time slots in which an operation starts. However, a time slot may still need a stage to forward a value produced earlier.

For example, an `arith.addi` and an `arith.muli` may both start at time 0,
while an operation at time 3 consumes both results. Because `arith.muli` has latency 3, the `arith.addi` result must be forwarded through time slots 1 and 2. 
No operation starts in those slots, so the current implementation does not create stages for them and the value mapping does not reach the consumer at time 3.

Build a stage for every time slot that contains register values, even when no operation starts there. This creates the forwarding-only stages needed to carry live values to their later consumers.

Add a regression test using the existing AffineToLoopSchedule operator model, where `arith.muli` has latency 3, to exercise two forwarding-only stages.

Assisted-by: OpenAI Codex:gpt-5

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
