### PR TITLE
[HW] materializeConstant: restrict hw.param.value to HW value types

### DIFF
--- a/lib/Dialect/HW/HWDialect.cpp
+++ b/lib/Dialect/HW/HWDialect.cpp
@@ -111,7 +111,11 @@ Operation *hw::materializeConstant(OpBuilder &builder, Attribute value,
   auto curModule = dyn_cast<HWModuleOp>(parentOp);
   if (!curModule)
     curModule = parentOp->getParentOfType<HWModuleOp>();
-  if (curModule && isValidParameterExpression(value, curModule))
+  // `hw.param.value` results are restricted to HW value types; folds that
+  // produce other constants (e.g. an f64 from a real-valued conditional,
+  // ivtest pr2453002.v) must not materialize an op the verifier rejects.
+  if (curModule && isHWValueType(type) &&
+      isValidParameterExpression(value, curModule))
     return ParamValueOp::create(builder, loc, type, value);
   return nullptr;
 }

--- a/test/Conversion/ImportVerilog/real-conditional-constant.sv
+++ b/test/Conversion/ImportVerilog/real-conditional-constant.sv
@@ -1,0 +1,24 @@
+// RUN: circt-verilog --ir-hw %s | FileCheck %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// A real-valued conditional with an unknown (x) condition folds to an f64
+// constant attribute. `hw.param.value` results are restricted to HW value
+// types, so the HW constant materializer must decline instead of building an
+// op the verifier rejects (ivtest pr2453002.v:
+// "'hw.param.value' op result #0 must be a known primitive element, but got
+// 'f64'").
+
+// CHECK-LABEL: hw.module @top
+// CHECK-NOT: hw.param.value
+module top;
+  parameter udef = 1'bx;
+  real rl3 = udef ? 6 : 6.0;
+  real rl4 = udef ? 7 : 7;
+  initial begin
+    if (rl3 != 6.0 || rl4 != 7.0)
+      $display("FAILED");
+    else
+      $display("PASSED");
+  end
+endmodule


### PR DESCRIPTION
`materializeConstant` produced `hw.param.value` for any constant, so a folded `f64` yielded a verifier-illegal op ("result #0 must be a known primitive element, but got 'f64'"). We guard materialization with `isHWValueType` so non-HW constants materialize elsewhere.
