### PR TITLE
[HWToLLVM] Hoist array temp allocas to the frame entry block

### DIFF
--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -87,12 +87,42 @@ static Value zextByOne(Location loc, ConversionPatternRewriter &rewriter,
 // HWToLLVMArraySpillCache
 //===----------------------------------------------------------------------===//
 
-static Value spillValueOnStack(OpBuilder &builder, Location loc,
-                               Value spillVal) {
+/// Create a fixed-count alloca in the entry block of the enclosing
+/// function-like frame, leaving the insertion point untouched for the
+/// accompanying stores. Allocas emitted at their use site re-execute on
+/// every pass through the surrounding control flow; allocas outside the
+/// entry block are only reclaimed on function return, so a use inside a
+/// run-to-completion process loop grows the stack every iteration (ivtest
+/// br_gh661a/b overflow the default 8 MiB stack through a dynamic-index
+/// array access in a 256k-iteration loop). Entry-block constant-size
+/// allocas become static frame slots instead. Mirrors `stackSlotFor` in
+/// LowerArcToLLVM.
+static Value createEntryBlockAlloca(OpBuilder &builder, Location loc,
+                                    Type elemType, unsigned alignment) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block *block = builder.getInsertionBlock();
+  assert(block && "expected an insertion block when allocating a stack slot");
+  Region *region = block->getParent();
+  while (region && region->getParentOp() &&
+         !region->getParentOp()->hasTrait<OpTrait::IsIsolatedFromAbove>())
+    region = region->getParentOp()->getParentRegion();
+  // Only reposition when the insertion point sits OUTSIDE the frame's entry
+  // block: an entry block has no predecessors, so an alloca anywhere in it
+  // already executes exactly once per activation.
+  if (region && region->getParentOp() &&
+      !isa<mlir::ModuleOp>(region->getParentOp()) && !region->empty() &&
+      block != &region->front())
+    builder.setInsertionPointToStart(&region->front());
   auto oneC = LLVM::ConstantOp::create(
       builder, loc, IntegerType::get(builder.getContext(), 32),
       builder.getI32IntegerAttr(1));
+  return LLVM::AllocaOp::create(
+      builder, loc, LLVM::LLVMPointerType::get(builder.getContext()), elemType,
+      oneC, alignment);
+}
 
+static Value spillValueOnStack(OpBuilder &builder, Location loc,
+                               Value spillVal) {
   Block *block = builder.getInsertionBlock();
   assert(block && "expected an insertion block when spilling a value");
 
@@ -100,9 +130,8 @@ static Value spillValueOnStack(OpBuilder &builder, Location loc,
       static_cast<unsigned>(DataLayout::closest(block->getParentOp())
                                 .getTypePreferredAlignment(spillVal.getType()));
   alignment = std::max(4u, alignment);
-  Value ptr = LLVM::AllocaOp::create(
-      builder, loc, LLVM::LLVMPointerType::get(builder.getContext()),
-      spillVal.getType(), oneC, alignment);
+  Value ptr =
+      createEntryBlockAlloca(builder, loc, spillVal.getType(), alignment);
   LLVM::StoreOp::create(builder, loc, spillVal, ptr);
   return ptr;
 }
@@ -293,9 +322,6 @@ struct ArrayInjectOpConversion
       return success();
     }
 
-    auto oneC =
-        LLVM::ConstantOp::create(rewriter, op->getLoc(), rewriter.getI32Type(),
-                                 rewriter.getI32IntegerAttr(1));
     auto zextIndex = zextByOne(op->getLoc(), rewriter, op.getIndex());
 
     if (arrElems == 1 || !llvm::isPowerOf2_64(arrElems)) {
@@ -314,10 +340,8 @@ struct ArrayInjectOpConversion
     auto allocaAlignment = std::max(
         4u, static_cast<unsigned>(DataLayout::closest(op.getOperation())
                                       .getTypePreferredAlignment(newArrTy)));
-    Value arrPtr = LLVM::AllocaOp::create(
-        rewriter, op->getLoc(),
-        LLVM::LLVMPointerType::get(rewriter.getContext()), newArrTy, oneC,
-        allocaAlignment);
+    Value arrPtr = createEntryBlockAlloca(rewriter, op->getLoc(), newArrTy,
+                                          allocaAlignment);
 
     LLVM::StoreOp::create(rewriter, op->getLoc(), adaptor.getInput(), arrPtr);
 
@@ -462,14 +486,10 @@ namespace {
 static Value allocateUnionBuffer(ConversionPatternRewriter &rewriter,
                                  Location loc, Type bufferType,
                                  Type accessType) {
-  auto *context = rewriter.getContext();
   auto align =
       std::max<uint64_t>(1, DataLayout().getTypePreferredAlignment(accessType));
-  Value one = LLVM::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
-                                       rewriter.getI32IntegerAttr(1));
-  return LLVM::AllocaOp::create(rewriter, loc,
-                                LLVM::LLVMPointerType::get(context), bufferType,
-                                one, align);
+  return createEntryBlockAlloca(rewriter, loc, bufferType,
+                                static_cast<unsigned>(align));
 }
 
 /// Convert a UnionCreateOp to the LLVM dialect by storing the member value into

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -46,10 +46,10 @@ func.func @convertArrayInject(
   %arg4: i32, %arg5: i64, %arg6: i1, %arg7: i3, %arg8: i64) {
   %0 = hw.array_inject %arg0[%arg5], %arg4 : !hw.array<0xi32>, i64
 
-  // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ZEXT1:.*]] = llvm.zext %arg6 : i1 to i2
   // CHECK-NEXT: %[[MAX1:.*]] = llvm.mlir.constant(1 : i32) : i2
   // CHECK-NEXT: %[[UMIN1:.*]] = llvm.intr.umin(%[[ZEXT1]], %[[MAX1]]) : (i2, i2) -> i2
+  // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE1]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
   // CHECK-NEXT: llvm.store %arg1, %[[ALLOCA1]] : !llvm.array<1 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[ALLOCA1]][0, %[[UMIN1]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
@@ -57,8 +57,8 @@ func.func @convertArrayInject(
   // CHECK-NEXT: llvm.load %[[ALLOCA1]] : !llvm.ptr -> !llvm.array<1 x i32>
   %1 = hw.array_inject %arg1[%arg6], %arg4 : !hw.array<1xi32>, i1
 
-  // CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ZEXT2:.*]] = llvm.zext %arg6 : i1 to i2
+  // CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
   // CHECK-NEXT: llvm.store %arg2, %[[ALLOCA2]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP2:.*]] = llvm.getelementptr %[[ALLOCA2]][0, %[[ZEXT2]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
@@ -66,10 +66,10 @@ func.func @convertArrayInject(
   // CHECK-NEXT: llvm.load %[[ALLOCA2]] : !llvm.ptr -> !llvm.array<2 x i32>
   %2 = hw.array_inject %arg2[%arg6], %arg4 : !hw.array<2xi32>, i1
 
-  // CHECK-NEXT: %[[ONE3:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ZEXT3:.*]] = llvm.zext %arg7 : i3 to i4
   // CHECK-NEXT: %[[MAX3:.*]] = llvm.mlir.constant(5 : i32) : i4
   // CHECK-NEXT: %[[UMIN3:.*]] = llvm.intr.umin(%[[ZEXT3]], %[[MAX3]]) : (i4, i4) -> i4
+  // CHECK-NEXT: %[[ONE3:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA3:.*]] = llvm.alloca %[[ONE3]] x !llvm.array<6 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
   // CHECK-NEXT: llvm.store %arg3, %[[ALLOCA3]] : !llvm.array<5 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP3:.*]] = llvm.getelementptr %[[ALLOCA3]][0, %[[UMIN3]]] : (!llvm.ptr, i4) -> !llvm.ptr, !llvm.array<6 x i32>
@@ -130,8 +130,8 @@ func.func @convertConstArray(%arg0 : i1, %arg1 : i32) {
   // CHECK-NEXT: {{%.+}} = llvm.load %[[VAL_9]] : !llvm.ptr -> !llvm.array<2 x struct<(i1, i32)>>
   %4 = hw.aggregate_constant [[0 : i32, 1 : i1], [2 : i32, 0 : i1]] : !hw.array<2x!hw.struct<a: i32, b: i1>>
 
-  // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ZEXT0:.*]] = llvm.zext %arg0 : i1 to i2
+  // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ALLOCA0:.*]] = llvm.alloca %[[ONE]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
   // CHECK-NEXT: llvm.store %[[VAL_3]], %[[ALLOCA0]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[GEP0:.*]] = llvm.getelementptr %[[ALLOCA0]][0, %[[ZEXT0]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>

--- a/test/Conversion/HWToLLVM/entry-block-alloca.mlir
+++ b/test/Conversion/HWToLLVM/entry-block-alloca.mlir
@@ -1,0 +1,44 @@
+// RUN: circt-opt %s --convert-hw-to-llvm | FileCheck %s
+
+// Allocas backing array temporaries must land in the frame's entry block.
+// Emitted at a use site inside a loop they push a fresh slot on every
+// iteration (stack slots are only reclaimed on function return), which
+// overflows the default stack in run-to-completion process loops (ivtest
+// br_gh661a/b: a dynamic-index array access in a 256k-iteration loop).
+// The value stores stay at the use site (here the input is loop-invariant,
+// so the spill cache also hoists the store).
+
+// CHECK-LABEL: @getInLoop
+func.func @getInLoop(%arr: !hw.array<16xi32>, %idx: i4, %c: i1) -> i32 {
+  // CHECK: llvm.alloca {{.*}} x !llvm.array<16 x i32>
+  // CHECK-NEXT: llvm.store
+  // CHECK: cf.br
+  cf.br ^bb1
+// CHECK: ^bb1:
+^bb1:
+  // CHECK-NOT: llvm.alloca
+  // CHECK: llvm.getelementptr
+  // CHECK: llvm.load
+  %v = hw.array_get %arr[%idx] : !hw.array<16xi32>, i4
+  cf.cond_br %c, ^bb1, ^bb2
+^bb2:
+  return %v : i32
+}
+
+// CHECK-LABEL: @injectInLoop
+func.func @injectInLoop(%arr: !hw.array<16xi32>, %idx: i4, %e: i32, %c: i1) -> !hw.array<16xi32> {
+  // CHECK: llvm.alloca {{.*}} x !llvm.array<16 x i32>
+  // CHECK-NEXT: cf.br
+  cf.br ^bb1
+// CHECK: ^bb1:
+^bb1:
+  // CHECK-NOT: llvm.alloca
+  // CHECK: llvm.store
+  // CHECK: llvm.getelementptr
+  // CHECK: llvm.store
+  // CHECK: llvm.load
+  %r = hw.array_inject %arr[%idx], %e : !hw.array<16xi32>, i4
+  cf.cond_br %c, ^bb1, ^bb2
+^bb2:
+  return %r : !hw.array<16xi32>
+}

--- a/test/Conversion/HWToLLVM/spill_alignment.mlir
+++ b/test/Conversion/HWToLLVM/spill_alignment.mlir
@@ -22,8 +22,8 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<
   // CHECK-LABEL: func.func @wideArrayInject
   // CHECK-SAME: (%arg0: !llvm.array<2 x i65>, %arg1: i1, %arg2: i65) -> !llvm.array<2 x i65>
   func.func @wideArrayInject(%arr: !hw.array<2xi65>, %idx: i1, %elt: i65) -> !hw.array<2xi65> {
-    // CHECK: [[ONE:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[ZEXT:%.+]] = llvm.zext %arg1 : i1 to i2
+    // CHECK: [[ONE:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: [[ALLOCA:%.+]] = llvm.alloca [[ONE]] x !llvm.array<2 x i65> {alignment = 16 : i64} : (i32) -> !llvm.ptr
     // CHECK: llvm.store %arg0, [[ALLOCA]] : !llvm.array<2 x i65>, !llvm.ptr
     // CHECK: [[GEP:%.+]] = llvm.getelementptr [[ALLOCA]][0, [[ZEXT]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i65>


### PR DESCRIPTION
The get/slice/inject/union conversions emitted `llvm.alloca` at the use site, so an array op inside a loop allocated fresh stack every iteration and eventually overflowed. We hoist the temporaries to the function entry block.
