### PR TITLE
[Arc] AddTaps: guard self-referential hw.wire against RAUW-with-self

### DIFF
--- a/lib/Dialect/Arc/Transforms/AddTaps.cpp
+++ b/lib/Dialect/Arc/Transforms/AddTaps.cpp
@@ -76,7 +76,23 @@ struct AddTapsPass : public arc::impl::AddTapsBase<AddTapsPass> {
       OpBuilder builder(wireOp);
       buildTap(builder, wireOp.getLoc(), wireOp, *name);
     }
-    wireOp.getResult().replaceAllUsesWith(wireOp.getInput());
+    Value input = wireOp.getInput();
+    // A degenerate self-referential wire (`assign w = w;`) feeds its own
+    // result back as its input. Replacing all uses of the result with the
+    // input would RAUW the value with itself and never drain the use list.
+    // Such a wire carries no driver; materialize a zero constant for its
+    // users instead (two-valued interpretation of an undriven net).
+    if (input == wireOp.getResult()) {
+      if (auto intType = dyn_cast<IntegerType>(wireOp.getType())) {
+        OpBuilder builder(wireOp);
+        input = hw::ConstantOp::create(builder, wireOp.getLoc(),
+                                       APInt::getZero(intType.getWidth()));
+      } else {
+        // Leave non-integer self-wires in place rather than looping forever.
+        return;
+      }
+    }
+    wireOp.getResult().replaceAllUsesWith(input);
     wireOp->erase();
   }
 

--- a/test/Dialect/Arc/add-taps.mlir
+++ b/test/Dialect/Arc/add-taps.mlir
@@ -44,3 +44,25 @@ hw.module @Clocks(in %clk: !seq.clock) {
   // CHECK-NEXT: [[CAST:%.+]] = seq.from_clock %clk
   // CHECK-NEXT: arc.tap [[CAST]] {names = ["clk"]} : i1
 }
+
+// Self-referential wires (from degenerate `assign w = w;` sources, e.g.
+// ivtest pr509.v) must not RAUW their result with itself — that never drains
+// the use list and hangs the pass. Users get a zero constant instead.
+// CHECK-LABEL: hw.module @SelfWire
+hw.module @SelfWire(out o: i4) {
+  // CHECK-DAG: [[C0:%c0_i4.*]] = hw.constant 0 : i4
+  // CHECK-DAG: arc.tap [[C0]] {names = ["w"]} : i4
+  // CHECK-NOT: hw.wire
+  // CHECK: hw.output [[C0]]
+  %w = hw.wire %w : i4
+  hw.output %w : i4
+}
+
+// Unused unnamed self-wire: erased without hanging.
+// CHECK-LABEL: hw.module @SelfWireUnused
+hw.module @SelfWireUnused() {
+  // CHECK-NOT: hw.wire
+  %0 = hw.wire %0 : i1
+  // CHECK: hw.output
+  hw.output
+}


### PR DESCRIPTION
`assign w = w;` yields a self-referential `hw.wire`, and replacing its result with its input RAUWs the value with itself, so the pass spun forever. We substitute a zero constant for integer self-wires (the two-valued reading of an undriven net) and leave non-integer self-wires in place.
