### PR TITLE
[DatapathToComb] Fix signed Booth crash with too few results

### DIFF
--- a/integration_test/circt-synth/datapath-lowering-lec.mlir
+++ b/integration_test/circt-synth/datapath-lowering-lec.mlir
@@ -69,15 +69,15 @@ hw.module @partial_product_sext_4(in %a : i4, in %b : i4, out sum : i8) {
 
 // RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_booth_rows -c2=partial_product_sext_booth_rows
 hw.module @partial_product_sext_booth_rows(in %a : i3, in %b : i3, out sum : i6) {
-  %0 = comb.extract %a from 2 : (i3) -> i1
-  %1 = comb.replicate %0 : (i1) -> i3
-  %2 = comb.concat %1, %a : i3, i3
-  %3 = comb.extract %b from 2 : (i3) -> i1
-  %4 = comb.replicate %3 : (i1) -> i3
-  %5 = comb.concat %4, %b : i3, i3
-  %6:3 = datapath.partial_product %2, %5 : (i6, i6) -> (i6, i6, i6)
-  %7 = comb.add %6#0, %6#1, %6#2 : i6
-  hw.output %7 : i6
+  %aSign = comb.extract %a from 2 : (i3) -> i1
+  %aExt = comb.replicate %aSign : (i1) -> i3
+  %aSigned = comb.concat %aExt, %a : i3, i3
+  %bSign = comb.extract %b from 2 : (i3) -> i1
+  %bExt = comb.replicate %bSign : (i1) -> i3
+  %bSigned = comb.concat %bExt, %b : i3, i3
+  %pp:2 = datapath.partial_product %aSigned, %bSigned : (i6, i6) -> (i6, i6)
+  %sum = comb.add %pp#0, %pp#1 : i6
+  hw.output %sum : i6
 }
 
 // RUN: circt-lec.sh %t.mlir %s -c1=pos_partial_product_4 -c2=pos_partial_product_4

--- a/integration_test/circt-synth/datapath-lowering-lec.mlir
+++ b/integration_test/circt-synth/datapath-lowering-lec.mlir
@@ -65,7 +65,20 @@ hw.module @partial_product_sext_4(in %a : i4, in %b : i4, out sum : i8) {
   %6:8 = datapath.partial_product %2, %5 : (i8, i8) -> (i8, i8, i8, i8, i8, i8, i8, i8)
   %7 = comb.add %6#0, %6#1, %6#2, %6#3, %6#4, %6#5, %6#6, %6#7 : i8
   hw.output %7 : i8
-}   
+}
+
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_booth_rows -c2=partial_product_sext_booth_rows
+hw.module @partial_product_sext_booth_rows(in %a : i3, in %b : i3, out sum : i6) {
+  %0 = comb.extract %a from 2 : (i3) -> i1
+  %1 = comb.replicate %0 : (i1) -> i3
+  %2 = comb.concat %1, %a : i3, i3
+  %3 = comb.extract %b from 2 : (i3) -> i1
+  %4 = comb.replicate %3 : (i1) -> i3
+  %5 = comb.concat %4, %b : i3, i3
+  %6:3 = datapath.partial_product %2, %5 : (i6, i6) -> (i6, i6, i6)
+  %7 = comb.add %6#0, %6#1, %6#2 : i6
+  hw.output %7 : i6
+}
 
 // RUN: circt-lec.sh %t.mlir %s -c1=pos_partial_product_4 -c2=pos_partial_product_4
 hw.module @pos_partial_product_4(in %a : i4, in %b : i4, in %c : i4, out sum : i4) {
@@ -110,6 +123,8 @@ hw.module @compress_6(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4
 // RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_3 -c2=partial_product_sext_3
 
 // RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_4 -c2=partial_product_sext_4
+
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_sext_booth_rows -c2=partial_product_sext_booth_rows
 
 // RUN: circt-lec.sh %t.mlir %s -c1=compress_3 -c2=compress_3
 

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -416,9 +416,11 @@ private:
         break;
     }
 
-    // Add the final sign-correction row for signed multiplication
-    // Not necessary for unsigned multiplication as the final row is positive
-    if (bSigned) {
+    // Add the final sign-correction row for signed multiplication.
+    // Not necessary for unsigned multiplication as the final row is positive.
+    // Skip when the caller already requested fewer rows than a full Booth
+    // array would produce.
+    if (bSigned && partialProducts.size() < op.getNumResults()) {
       auto numPP = partialProducts.size();
       Value shiftByFinal =
           hw::ConstantOp::create(rewriter, loc, APInt((numPP - 1) * 2, 0));

--- a/test/Conversion/DatapathToComb/datapath-to-comb.mlir
+++ b/test/Conversion/DatapathToComb/datapath-to-comb.mlir
@@ -197,6 +197,23 @@ hw.module @partial_product_booth_zext(in %a : i3, in %b : i3, out pp0 : i6, out 
   hw.output %2#0, %2#1, %2#2 : i6, i6, i6
 }
 
+// https://github.com/llvm/circt/issues/10875
+// FORCE-BOOTH-LABEL: @partial_product_signed_booth_few_results
+hw.module @partial_product_signed_booth_few_results(in %a : i3, in %b : i3, out sum : i6) {
+  // FORCE-BOOTH-NOT: datapath.partial_product
+  // FORCE-BOOTH: comb.add {{.*}} : i6
+  // FORCE-BOOTH-NEXT: hw.output {{.*}} : i6
+  %aSign = comb.extract %a from 2 : (i3) -> i1
+  %aExt = comb.replicate %aSign : (i1) -> i3
+  %aSigned = comb.concat %aExt, %a : i3, i3
+  %bSign = comb.extract %b from 2 : (i3) -> i1
+  %bExt = comb.replicate %bSign : (i1) -> i3
+  %bSigned = comb.concat %bExt, %b : i3, i3
+  %pp:2 = datapath.partial_product %aSigned, %bSigned : (i6, i6) -> (i6, i6)
+  %sum = comb.add %pp#0, %pp#1 : i6
+  hw.output %sum : i6
+}
+
 // CHECK-LABEL: @partial_product_24
 hw.module @partial_product_24(in %a : i24, in %b : i24, out sum : i24) {
   %0:24 = datapath.partial_product %a, %b : (i24, i24) -> (i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24, i24)


### PR DESCRIPTION
When lowering a signed partial product with Booth encoding, we always added one final sign-correction row. If the op asked for fewer results than that full array, we still pushed the extra row and hit an assert. Only add the final row when there is still room for it.

Fixes #10875

Assisted-by: augment: sonnet 4.5

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
