### PR TITLE
[AffineToLoopSchedule][NFC] Fix a deprecation warning

### DIFF
--- a/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
+++ b/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
@@ -448,8 +448,8 @@ LogicalResult AffineToLoopSchedule::createLoopSchedulePipeline(
   // If possible, attach a constant trip count attribute. This could be
   // generalized to support non-constant trip counts by supporting an AffineMap.
   std::optional<IntegerAttr> tripCountAttr;
-  if (auto tripCount = getConstantTripCount(forOp))
-    tripCountAttr = builder.getI64IntegerAttr(*tripCount);
+  if (auto tripCount = forOp.getStaticTripCount())
+    tripCountAttr = builder.getI64IntegerAttr(tripCount->getZExtValue());
 
   auto pipeline = LoopSchedulePipelineOp::create(builder, resultTypes, ii,
                                                  tripCountAttr, iterArgs);


### PR DESCRIPTION
Use getStaticTripCount instead of getConstantTripCount. 
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
