### PR TITLE
[FIRRTL] Fix stale const types in cat/mux canonicalize

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1459,8 +1459,8 @@ public:
       for (auto &operand : operands)
         operand = castToUIntIfSigned(operand);
 
-    replaceOpWithNewOpAndCopyName<CatPrimOp>(rewriter, cat, cat.getType(),
-                                             operands);
+    // Infer the result type so constness matches the rewritten operands.
+    replaceOpWithNewOpAndCopyName<CatPrimOp>(rewriter, cat, operands);
     return success();
   }
 };
@@ -1485,20 +1485,26 @@ public:
         continue;
       }
       APSInt value = cst.getValue();
+      bool foldedIsConst = type_cast<IntType>(cst.getType()).isConst();
       size_t j = i + 1;
       for (; j < cat->getNumOperands(); ++j) {
         auto nextCst = cat.getInputs()[j].getDefiningOp<ConstantOp>();
         if (!nextCst)
           break;
         value = value.concat(nextCst.getValue());
+        foldedIsConst &= type_cast<IntType>(nextCst.getType()).isConst();
       }
 
       if (j == i + 1) {
         // Not folded.
         operands.push_back(cst);
       } else {
-        // Folded.
-        operands.push_back(ConstantOp::create(rewriter, cat.getLoc(), value));
+        // Fold adjacent constants. Preserve constness so a cat whose other
+        // operands remain const keeps a const-compatible result type.
+        auto type = IntType::get(rewriter.getContext(), value.isSigned(),
+                                 value.getBitWidth(), foldedIsConst);
+        operands.push_back(ConstantOp::create(rewriter, cat.getLoc(), type,
+                                              static_cast<APInt>(value)));
       }
 
       i = j - 1;
@@ -1507,8 +1513,8 @@ public:
     if (operands.size() == cat->getNumOperands())
       return failure();
 
-    replaceOpWithNewOpAndCopyName<CatPrimOp>(rewriter, cat, cat.getType(),
-                                             operands);
+    // Infer the result type so constness matches the rewritten operands.
+    replaceOpWithNewOpAndCopyName<CatPrimOp>(rewriter, cat, operands);
 
     return success();
   }
@@ -1899,8 +1905,10 @@ public:
           type_cast<FIRRTLBaseType>(input.getType()).getBitWidthOrSentinel();
       if (inputWidth < 0 || width == inputWidth)
         return input;
-      return PadPrimOp::create(rewriter, mux.getLoc(), mux.getType(), input,
-                               width)
+      // Infer the pad result type so constness follows the input. Using the
+      // mux result type here is incorrect when the narrow arm is const and the
+      // mux itself is not.
+      return PadPrimOp::create(rewriter, mux.getLoc(), input, width)
           .getResult();
     };
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1189,6 +1189,20 @@ firrtl.module @CatOfConstant(in %a: !firrtl.uint<4>, out %out1: !firrtl.uint<12>
   firrtl.matchingconnect %out2, %cat2 : !firrtl.uint<10>
 }
 
+// CHECK-LABEL: firrtl.module @CatOfConstConstant
+// Ensure CatOfConstant preserves constness when folding adjacent const
+// constants (issue #10787).
+firrtl.module @CatOfConstConstant(in %x: !firrtl.const.uint<4>,
+                                  out %out: !firrtl.const.uint<8>) {
+  %c0 = firrtl.constant 0 : !firrtl.const.uint<1>
+  %c1 = firrtl.constant 1 : !firrtl.const.uint<3>
+  // CHECK: %[[C:.+]] = firrtl.constant 1 : !firrtl.const.uint<4>
+  // CHECK: %[[CAT:.+]] = firrtl.cat %[[C]], %x : (!firrtl.const.uint<4>, !firrtl.const.uint<4>) -> !firrtl.const.uint<8>
+  // CHECK: firrtl.matchingconnect %out, %[[CAT]] : !firrtl.const.uint<8>
+  %cat = firrtl.cat %c0, %c1, %x : (!firrtl.const.uint<1>, !firrtl.const.uint<3>, !firrtl.const.uint<4>) -> !firrtl.const.uint<8>
+  firrtl.matchingconnect %out, %cat : !firrtl.const.uint<8>
+}
+
 // CHECK-LABEL: firrtl.module @BitsOfCat
 firrtl.module @BitsOfCat(in %a: !firrtl.uint<4>, in %b: !firrtl.uint<3>, in %c: !firrtl.uint<2>,
                         out %out1: !firrtl.uint<2>, out %out2: !firrtl.uint<1>, out %out3: !firrtl.uint<5>) {
@@ -2678,6 +2692,26 @@ firrtl.module @issue1142(in %cond: !firrtl.uint<1>, out %z: !firrtl.uint) {
   firrtl.connect %z, %1 : !firrtl.uint, !firrtl.uint
   firrtl.connect %z, %3 : !firrtl.uint, !firrtl.uint
   firrtl.connect %z, %4 : !firrtl.uint, !firrtl.uint
+}
+
+// CHECK-LABEL: firrtl.module @PadConstMuxOperands
+// MuxPad must infer pad result constness from the narrow arm, not reuse the
+// non-const mux result type (issue #10787).
+firrtl.module @PadConstMuxOperands(
+    in %sel: !firrtl.uint<1>, in %x: !firrtl.const.uint<2>,
+    in %y: !firrtl.uint<12>, out %outHigh: !firrtl.uint<12>,
+    out %outLow: !firrtl.uint<12>) {
+  // CHECK: %[[PADH:.+]] = firrtl.pad %x, 12 : (!firrtl.const.uint<2>) -> !firrtl.const.uint<12>
+  // CHECK: %[[MUXH:.+]] = firrtl.mux(%sel, %[[PADH]], %y)
+  // CHECK: firrtl.matchingconnect %outHigh, %[[MUXH]]
+  %muxHigh = firrtl.mux(%sel, %x, %y) : (!firrtl.uint<1>, !firrtl.const.uint<2>, !firrtl.uint<12>) -> !firrtl.uint<12>
+  firrtl.matchingconnect %outHigh, %muxHigh : !firrtl.uint<12>
+
+  // CHECK: %[[PADL:.+]] = firrtl.pad %x, 12 : (!firrtl.const.uint<2>) -> !firrtl.const.uint<12>
+  // CHECK: %[[MUXL:.+]] = firrtl.mux(%sel, %y, %[[PADL]])
+  // CHECK: firrtl.matchingconnect %outLow, %[[MUXL]]
+  %muxLow = firrtl.mux(%sel, %y, %x) : (!firrtl.uint<1>, !firrtl.uint<12>, !firrtl.const.uint<2>) -> !firrtl.uint<12>
+  firrtl.matchingconnect %outLow, %muxLow : !firrtl.uint<12>
 }
 
 // CHECK-LABEL: firrtl.module @PadMuxOperands


### PR DESCRIPTION
Fixes #10787.

## Summary
`circt-opt --canonicalize` could turn verifier-clean FIRRTL IR into invalid IR when `CatOfConstant` or `MuxPad` rewrote operands but kept a result type whose constness no longer matched type inference.

## Changes
- In `CatOfConstant`, preserve constness when folding adjacent constants and infer the replacement `firrtl.cat` result type from the rewritten operands.
- In `FlattenCat`, infer the replacement cat result type the same way.
- In `MuxPad`, create `firrtl.pad` without forcing the mux result type so pad inference preserves input constness.

## Test plan
- [x] Added `@CatOfConstConstant` and `@PadConstMuxOperands` regressions in `test/Dialect/FIRRTL/canonicalization.mlir`
- [x] Reproduced the three cases from #10787; they now canonicalize to well-typed IR
- [x] `llvm-lit -sv` on `canonicalization.mlir`, `errors.mlir`, `round-trip.mlir`, and `drop-const.mlir` (built with `ghcr.io/circt/images/circt-integration-test:v20`)

Assisted-by: Cursor:cursor-grok-4.5