### PR TITLE
Use hw::type_dyn_cast more uniformly for StructType queries.

### DIFF
--- a/include/circt/Dialect/LLHD/LLHDOps.td
+++ b/include/circt/Dialect/LLHD/LLHDOps.td
@@ -500,7 +500,7 @@ def SigStructExtractOp : LLHDOp<"sig.struct_extract", [
 
   let extraClassDeclaration = [{
     hw::StructType getStructType() {
-      return cast<hw::StructType>(
+      return hw::type_dyn_cast<hw::StructType>(
         cast<RefType>(getInput().getType()).getNestedType()
       );
     }

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -32,7 +32,7 @@ unsigned circt::llhd::getLLHDTypeWidth(Type type) {
     type = sig.getNestedType();
   if (auto array = dyn_cast<hw::ArrayType>(type))
     return array.getNumElements();
-  if (auto tup = dyn_cast<hw::StructType>(type))
+  if (auto tup = hw::type_dyn_cast<hw::StructType>(type))
     return tup.getElements().size();
   return type.getIntOrFloatBitWidth();
 }
@@ -480,7 +480,7 @@ LogicalResult llhd::SigStructExtractOp::inferReturnTypes(
   Type fieldType;
 
   // Support both StructType and UnionType
-  if (auto structType = dyn_cast<hw::StructType>(nestedType)) {
+  if (auto structType = hw::type_dyn_cast<hw::StructType>(nestedType)) {
     fieldType = structType.getFieldType(adaptor.getField());
   } else if (auto unionType = dyn_cast<hw::UnionType>(nestedType)) {
     fieldType = unionType.getFieldType(adaptor.getField());
@@ -513,7 +513,7 @@ bool SigStructExtractOp::canRewire(
   std::optional<uint32_t> index;
 
   // Support both StructType and UnionType
-  if (auto structType = dyn_cast<hw::StructType>(nestedType))
+  if (auto structType = hw::type_dyn_cast<hw::StructType>(nestedType))
     index = structType.getFieldIndex(getFieldAttr());
   else if (auto unionType = dyn_cast<hw::UnionType>(nestedType))
     index = unionType.getFieldIndex(getFieldAttr());
@@ -537,7 +537,7 @@ SigStructExtractOp::rewire(const DestructurableMemorySlot &slot,
                            OpBuilder &builder, const DataLayout &dataLayout) {
   auto nestedType = cast<RefType>(getInput().getType()).getNestedType();
   std::optional<unsigned> index;
-  if (auto structTy = dyn_cast<hw::StructType>(nestedType))
+  if (auto structTy = hw::type_dyn_cast<hw::StructType>(nestedType))
     index = structTy.getFieldIndex(getFieldAttr());
   else if (auto unionTy = dyn_cast<hw::UnionType>(nestedType))
     index = unionTy.getFieldIndex(getFieldAttr());

--- a/lib/Dialect/LLHD/Transforms/CombineDrives.cpp
+++ b/lib/Dialect/LLHD/Transforms/CombineDrives.cpp
@@ -252,7 +252,7 @@ SignalSlice ModuleContext::traceProjectionImpl(Value value) {
   }
 
   if (auto op = value.getDefiningOp<SigStructExtractOp>()) {
-    auto structType = cast<hw::StructType>(
+    auto structType = hw::type_cast<hw::StructType>(
         cast<RefType>(op.getInput().getType()).getNestedType());
     auto input = traceProjection(op.getInput());
     if (!input)
@@ -467,7 +467,7 @@ void ModuleContext::addDefaultDriveSlices(Signal &signal,
     }
 
     // Handle structs.
-    if (auto structType = dyn_cast<hw::StructType>(type)) {
+    if (auto structType = hw::type_dyn_cast<hw::StructType>(type)) {
       assert(slice.length == 0);
       slice.value = hw::StructExtractOp::create(
           builder, defaultValue, structType.getElements()[slice.offset]);
@@ -555,7 +555,7 @@ void ModuleContext::aggregateDriveSlices(Signal &signal, Value driveDelay,
   }
 
   // Handle structs.
-  if (auto structType = dyn_cast<hw::StructType>(type)) {
+  if (auto structType = hw::type_dyn_cast<hw::StructType>(type)) {
     // Structs are trivial, since there are no struct slices. Everything is an
     // individual field that we can use directly to create the struct.
     SmallVector<Value> operands;

--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -117,7 +117,8 @@ static ValueField getValueField(Value value) {
     }
     auto baseVF = getValueField(base);
 
-    auto structType = dyn_cast<hw::StructType>(se.getInput().getType());
+    auto structType =
+        hw::type_dyn_cast<hw::StructType>(se.getInput().getType());
     if (!structType)
       return {value, 0, value};
 

--- a/test/Dialect/LLHD/Transforms/deseq.mlir
+++ b/test/Dialect/LLHD/Transforms/deseq.mlir
@@ -1253,3 +1253,30 @@ hw.module @ClockExtractedFromStructArrayGetThenExtractPosEdge(in %st: !hw.struct
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
   llhd.drv %sig, %out after %time if %en : i4
 }
+
+// CHECK-LABEL: @ClockExtractedFromAliasedStructExtractPosEdge(
+hw.module @ClockExtractedFromAliasedStructExtractPosEdge(in %st: !hw.typealias<@symbols::@my_struct, !hw.struct<a: i1, b: i1>>, in %data: i4) {
+  %c0_i4 = hw.constant 0 : i4
+  %time = llhd.constant_time <0ns, 1d, 0e>
+  // CHECK-NOT: llhd.process
+  // CHECK: [[CLK_BIT:%.+]] = hw.struct_extract %st["a"] : !hw.typealias<@symbols::@my_struct, !hw.struct<a: i1, b: i1>>
+  // CHECK: [[CLK:%.+]] = seq.to_clock [[CLK_BIT]]
+  // CHECK: [[REG:%.+]] = seq.firreg %data clock [[CLK]]{{.*}} : i4
+  %out, %en = llhd.process -> i4, i1 {
+    %true = hw.constant true
+    %false = hw.constant false
+    cf.br ^bb1(%c0_i4, %false : i4, i1)
+  ^bb1(%a: i4, %b: i1):
+    %clkBit = hw.struct_extract %st["a"] : !hw.typealias<@symbols::@my_struct, !hw.struct<a: i1, b: i1>>
+    llhd.wait yield (%a, %b : i4, i1), (%st : !hw.typealias<@symbols::@my_struct, !hw.struct<a: i1, b: i1>>), ^bb2(%clkBit : i1)
+  ^bb2(%pastClk: i1):
+    %presentClk = hw.struct_extract %st["a"] : !hw.typealias<@symbols::@my_struct, !hw.struct<a: i1, b: i1>>
+    %notPast = comb.xor bin %pastClk, %true : i1
+    %posedge = comb.and bin %notPast, %presentClk : i1
+    cf.cond_br %posedge, ^bb1(%data, %true : i4, i1), ^bb1(%c0_i4, %false : i4, i1)
+  }
+  %sig = llhd.sig %c0_i4 : i4
+  // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
+  llhd.drv %sig, %out after %time if %en : i4
+}
+


### PR DESCRIPTION
This fixes the LLHD Deseq pass to not generate invalid hw.struct_extract. Previously it would check if StructType and fail/return nullptr for alias cases and this would trigger incorrect field calculations during register materialization. Switched most to use the hw type casting for StructType.