### PR TITLE
[POC][LTLToCore] add temporal timing lowering and tests

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -643,13 +643,14 @@ def ConvertHWToBTOR2 : Pass<"convert-hw-to-btor2", "mlir::ModuleOp"> {
 def LowerLTLToCore : Pass<"lower-ltl-to-core", "hw::HWModuleOp"> {
   let summary = "Convert LTL and Verif to Core";
   let description = [{
-    This pass converts ltl and verif operations to core ones. This can be done directly
-    without going through FSM if we're only working with overlapping properties (no delays).
+    This pass converts LTL and Verif operations to core operations. Boolean LTL
+    and bounded temporal properties with explicit clocking are lowered directly.
+    The pass fails if any LTL operation or type cannot be converted.
   }];
   let constructor = "circt::createLowerLTLToCorePass()";
   let dependentDialects = [
-    "hw::HWDialect", "sv::SVDialect", "comb::CombDialect",
-    "seq::SeqDialect"
+    "hw::HWDialect", "ltl::LTLDialect", "sv::SVDialect",
+    "comb::CombDialect", "seq::SeqDialect"
   ];
 }
 

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -11,24 +11,26 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Conversion/LTLToCore.h"
-#include "circt/Conversion/HWToSV.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/LTL/LTLDialect.h"
 #include "circt/Dialect/LTL/LTLOps.h"
+#include "circt/Dialect/LTL/LTLTypes.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Dialect/Verif/VerifOps.h"
 #include "circt/Support/BackedgeBuilder.h"
-#include "circt/Support/Namespace.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/CheckedArithmetic.h"
+#include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/MathExtras.h"
+
+#include <tuple>
 
 namespace circt {
 #define GEN_PASS_DEF_LOWERLTLTOCORE
@@ -88,6 +90,19 @@ struct HasBeenResetOpConversion : OpConversionPattern<verif::HasBeenResetOp> {
                                          adaptor.getReset(), constOne);
     rewriter.replaceOpWithNewOp<comb::AndOp>(op, reg, notReset);
 
+    return success();
+  }
+};
+
+struct LTLBooleanConstantConversion
+    : public OpConversionPattern<ltl::BooleanConstantOp> {
+  using OpConversionPattern<ltl::BooleanConstantOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ltl::BooleanConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, rewriter.getI1Type(),
+                                                op.getValue() ? 1 : 0);
     return success();
   }
 };
@@ -205,6 +220,771 @@ struct LTLPastOpConversion : public OpConversionPattern<ltl::PastOp> {
   }
 };
 
+/// A timing path records the explicit clock events between the start and end of
+/// a sequence. Adjacent steps always use different clock events.
+struct TimingStep {
+  Value clock;
+  ltl::ClockEdge edge;
+  uint64_t cycles;
+
+  bool operator==(const TimingStep &other) const {
+    return clock == other.clock && edge == other.edge && cycles == other.cycles;
+  }
+};
+
+using TimingPath = SmallVector<TimingStep>;
+using Validity = SmallVector<TimingPath>;
+
+/// A lowered sequence is evaluated at its end point. Each match records the
+/// clock events from the sequence start to that end point and the i1 signal
+/// which indicates a match there.
+struct SequenceMatch {
+  TimingPath timing;
+  Value value;
+  Validity validity;
+};
+
+struct LoweredSequence {
+  SmallVector<SequenceMatch> matches;
+};
+
+/// A lowered property is evaluated after its timing path has elapsed.
+struct LoweredProperty {
+  TimingPath timing;
+  Value value;
+  Validity validity;
+};
+
+struct SampledAtom {
+  Value value;
+  Validity validity;
+};
+
+using SampledAtoms = DenseMap<Value, SampledAtom>;
+using PastValues = DenseMap<std::tuple<Value, Value, unsigned>, Value>;
+
+static Value createRegister(Value input, Value clock, ltl::ClockEdge edge,
+                            OpBuilder &builder, Operation *contextOp) {
+  assert(edge != ltl::ClockEdge::Both && "both-edge clock not supported");
+  auto clockSignal = clock;
+  if (edge == ltl::ClockEdge::Neg)
+    clockSignal =
+        comb::createOrFoldNot(builder, contextOp->getLoc(), clockSignal);
+  auto seqClock =
+      builder.createOrFold<seq::ToClockOp>(contextOp->getLoc(), clockSignal);
+
+  auto loc = contextOp->getLoc();
+  auto initial = seq::createConstantInitialValue(
+      builder, loc, builder.getIntegerAttr(builder.getI1Type(), 0));
+  return seq::CompRegOp::create(builder, loc, input, seqClock,
+                                /*reset=*/Value{},
+                                /*rstValue=*/Value{}, initial)
+      .getResult();
+}
+
+static Value createPast(PastValues &pastValues, Value input, uint64_t cycles,
+                        Value clock, ltl::ClockEdge edge, OpBuilder &builder,
+                        Operation *contextOp) {
+  Value current = input;
+  for (uint64_t i = 0; i < cycles; ++i) {
+    auto [it, inserted] = pastValues.try_emplace(
+        std::make_tuple(current, clock, static_cast<unsigned>(edge)));
+    if (inserted)
+      it->second = createRegister(current, clock, edge, builder, contextOp);
+    current = it->second;
+  }
+  return current;
+}
+
+static Value createPast(PastValues &pastValues, Value input,
+                        ArrayRef<TimingStep> timing, OpBuilder &builder,
+                        Operation *contextOp) {
+  for (auto step : timing)
+    input = createPast(pastValues, input, step.cycles, step.clock, step.edge,
+                       builder, contextOp);
+  return input;
+}
+
+static LogicalResult appendTiming(TimingPath &timing, Value clock,
+                                  ltl::ClockEdge edge, uint64_t cycles,
+                                  Operation *contextOp) {
+  if (cycles == 0)
+    return success();
+  if (timing.empty() || timing.back().clock != clock ||
+      timing.back().edge != edge) {
+    timing.push_back({clock, edge, cycles});
+    return success();
+  }
+  auto combined =
+      llvm::checkedAddUnsigned<uint64_t>(timing.back().cycles, cycles);
+  if (!combined)
+    return contextOp->emitError("LTL sequence length overflows 64 bits");
+  timing.back().cycles = *combined;
+  return success();
+}
+
+static LogicalResult appendTiming(TimingPath &timing,
+                                  ArrayRef<TimingStep> suffix,
+                                  Operation *contextOp) {
+  for (auto step : suffix)
+    if (failed(appendTiming(timing, step.clock, step.edge, step.cycles,
+                            contextOp)))
+      return failure();
+  return success();
+}
+
+static std::optional<TimingPath> getTimingSuffix(ArrayRef<TimingStep> prefix,
+                                                 ArrayRef<TimingStep> timing) {
+  if (prefix.empty())
+    return TimingPath(timing);
+
+  size_t prefixIndex = 0;
+  size_t timingIndex = 0;
+  while (prefixIndex < prefix.size()) {
+    if (timingIndex == timing.size() ||
+        prefix[prefixIndex].clock != timing[timingIndex].clock ||
+        prefix[prefixIndex].edge != timing[timingIndex].edge)
+      return std::nullopt;
+
+    auto prefixCycles = prefix[prefixIndex].cycles;
+    auto timingCycles = timing[timingIndex].cycles;
+    if (prefixCycles > timingCycles)
+      return std::nullopt;
+    if (prefixCycles < timingCycles) {
+      if (prefixIndex + 1 != prefix.size())
+        return std::nullopt;
+      TimingPath suffix;
+      suffix.push_back({timing[timingIndex].clock, timing[timingIndex].edge,
+                        timingCycles - prefixCycles});
+      auto remaining = timing.drop_front(timingIndex + 1);
+      suffix.append(remaining.begin(), remaining.end());
+      return suffix;
+    }
+    ++prefixIndex;
+    ++timingIndex;
+  }
+  return TimingPath(timing.drop_front(timingIndex));
+}
+
+static LogicalResult appendTiming(Validity &validity,
+                                  ArrayRef<TimingStep> suffix,
+                                  Operation *contextOp) {
+  for (auto &timing : validity)
+    if (failed(appendTiming(timing, suffix, contextOp)))
+      return failure();
+  return success();
+}
+
+static void addValidity(Validity &validity, TimingPath requirement) {
+  for (size_t i = 0; i < validity.size();) {
+    if (getTimingSuffix(requirement, validity[i]))
+      return;
+    if (getTimingSuffix(validity[i], requirement)) {
+      validity.erase(validity.begin() + i);
+      continue;
+    }
+    ++i;
+  }
+  validity.push_back(std::move(requirement));
+}
+
+static void appendValidity(Validity &validity, const Validity &suffix) {
+  for (auto requirement : suffix)
+    addValidity(validity, std::move(requirement));
+}
+
+static FailureOr<TimingPath>
+findCommonTiming(ArrayRef<LoweredProperty> properties) {
+  if (properties.empty())
+    return TimingPath{};
+  for (auto &candidate : properties) {
+    if (llvm::all_of(properties, [&](const LoweredProperty &property) {
+          return getTimingSuffix(property.timing, candidate.timing).has_value();
+        }))
+      return candidate.timing;
+  }
+  return failure();
+}
+
+static FailureOr<TimingPath> findCommonTiming(ArrayRef<SequenceMatch> matches) {
+  if (matches.empty())
+    return TimingPath{};
+  for (auto &candidate : matches) {
+    if (llvm::all_of(matches, [&](const SequenceMatch &match) {
+          return getTimingSuffix(match.timing, candidate.timing).has_value();
+        }))
+      return candidate.timing;
+  }
+  return failure();
+}
+
+static Value alignValue(PastValues &pastValues, Value value,
+                        ArrayRef<TimingStep> from, ArrayRef<TimingStep> to,
+                        OpBuilder &builder, Operation *contextOp) {
+  auto suffix = getTimingSuffix(from, to);
+  assert(suffix && "timing compatibility checked before alignment");
+  return createPast(pastValues, value, *suffix, builder, contextOp);
+}
+
+static FailureOr<Validity> alignValidity(const Validity &validity,
+                                         ArrayRef<TimingStep> from,
+                                         ArrayRef<TimingStep> to,
+                                         Operation *contextOp) {
+  auto suffix = getTimingSuffix(from, to);
+  assert(suffix && "timing compatibility checked before alignment");
+  Validity result = validity;
+  if (failed(appendTiming(result, *suffix, contextOp)))
+    return failure();
+  return result;
+}
+
+static Value materializeValidity(PastValues &pastValues, Value &validStart,
+                                 const Validity &validity, OpBuilder &builder,
+                                 Operation *contextOp) {
+  if (validity.empty())
+    return hw::ConstantOp::create(builder, contextOp->getLoc(),
+                                  builder.getI1Type(), 1);
+  if (!validStart)
+    validStart = hw::ConstantOp::create(builder, contextOp->getLoc(),
+                                        builder.getI1Type(), 1);
+
+  SmallVector<Value> values;
+  for (auto &requirement : validity)
+    values.push_back(
+        createPast(pastValues, validStart, requirement, builder, contextOp));
+  return comb::AndOp::create(builder, contextOp->getLoc(), values,
+                             /*twoState=*/false);
+}
+
+static void addMatch(LoweredSequence &sequence, TimingPath timing, Value value,
+                     Validity validity, OpBuilder &builder, Location loc) {
+  for (auto &match : sequence.matches) {
+    if (match.timing != timing)
+      continue;
+    match.value = comb::OrOp::create(builder, loc, match.value, value,
+                                     /*twoState=*/false);
+    appendValidity(match.validity, validity);
+    return;
+  }
+  sequence.matches.push_back({std::move(timing), value, std::move(validity)});
+}
+
+static FailureOr<LoweredSequence>
+lowerSequence( // NOLINT(misc-no-recursion): Walks an acyclic LTL expression.
+    SampledAtoms &sampledAtoms, PastValues &pastValues, Value sequence,
+    OpBuilder &builder, Operation *contextOp) {
+  auto loc = sequence.getLoc();
+  if (auto atom = sequence.getDefiningOp<ltl::ClockedAtomOp>()) {
+    if (atom.getEdge() == ltl::ClockEdge::Both) {
+      atom.emitError("lower-ltl-to-core does not support both-edge LTL clocks");
+      return failure();
+    }
+    auto [it, inserted] = sampledAtoms.try_emplace(sequence);
+    if (inserted) {
+      it->second.value = createRegister(atom.getInput(), atom.getClock(),
+                                        atom.getEdge(), builder, atom);
+      it->second.validity = {{{atom.getClock(), atom.getEdge(), 1}}};
+    }
+    return LoweredSequence{{{{}, it->second.value, it->second.validity}}};
+  }
+
+  if (auto delay = sequence.getDefiningOp<ltl::ClockedDelayOp>()) {
+    auto length = delay.getLength();
+    if (!length) {
+      delay.emitError("lower-ltl-to-core only supports bounded LTL delays");
+      return failure();
+    }
+    if (delay.getEdge() == ltl::ClockEdge::Both) {
+      delay.emitError(
+          "lower-ltl-to-core does not support both-edge LTL clocks");
+      return failure();
+    }
+
+    auto lowered = lowerSequence(sampledAtoms, pastValues, delay.getInput(),
+                                 builder, delay);
+    if (failed(lowered))
+      return failure();
+
+    LoweredSequence result;
+    for (const auto &match : lowered->matches) {
+      for (uint64_t i = 0;; ++i) {
+        auto matchLength =
+            llvm::checkedAddUnsigned<uint64_t>(delay.getDelay(), i);
+        if (!matchLength) {
+          delay.emitError("LTL sequence length overflows 64 bits");
+          return failure();
+        }
+        TimingPath timing;
+        if (failed(appendTiming(timing, delay.getClock(), delay.getEdge(),
+                                *matchLength, delay)) ||
+            failed(appendTiming(timing, match.timing, delay)))
+          return failure();
+        addMatch(result, std::move(timing), match.value, match.validity,
+                 builder, loc);
+        if (i == *length)
+          break;
+      }
+    }
+    return result;
+  }
+
+  if (auto concat = sequence.getDefiningOp<ltl::ConcatOp>()) {
+    auto current = lowerSequence(sampledAtoms, pastValues,
+                                 concat.getInputs().front(), builder, concat);
+    if (failed(current))
+      return failure();
+
+    for (auto input : concat.getInputs().drop_front()) {
+      auto next =
+          lowerSequence(sampledAtoms, pastValues, input, builder, concat);
+      if (failed(next))
+        return failure();
+
+      LoweredSequence combined;
+      for (const auto &lhs : current->matches) {
+        for (const auto &rhs : next->matches) {
+          auto lhsAtEnd =
+              createPast(pastValues, lhs.value, rhs.timing, builder, concat);
+          auto lhsValidityAtEnd =
+              alignValidity(lhs.validity, {}, rhs.timing, concat);
+          if (failed(lhsValidityAtEnd))
+            return failure();
+          appendValidity(*lhsValidityAtEnd, rhs.validity);
+          TimingPath timing = lhs.timing;
+          if (failed(appendTiming(timing, rhs.timing, concat)))
+            return failure();
+          addMatch(combined, std::move(timing),
+                   comb::AndOp::create(builder, loc, lhsAtEnd, rhs.value,
+                                       /*twoState=*/false),
+                   std::move(*lhsValidityAtEnd), builder, loc);
+        }
+      }
+      current = combined;
+    }
+    return *current;
+  }
+
+  if (auto *defOp = sequence.getDefiningOp())
+    defOp->emitError("lower-ltl-to-core does not support temporal LTL "
+                     "operation '")
+        << defOp->getName() << "'";
+  else
+    contextOp->emitError("lower-ltl-to-core does not support block argument "
+                         "LTL sequences");
+  return failure();
+}
+
+static FailureOr<LoweredProperty>
+lowerSequenceAsProperty(SampledAtoms &sampledAtoms, PastValues &pastValues,
+                        Value sequence, OpBuilder &builder,
+                        Operation *contextOp) {
+  auto lowered =
+      lowerSequence(sampledAtoms, pastValues, sequence, builder, contextOp);
+  if (failed(lowered))
+    return failure();
+
+  auto timing = findCommonTiming(lowered->matches);
+  if (failed(timing)) {
+    contextOp->emitError(
+        "lower-ltl-to-core cannot align temporal LTL sequence matches");
+    return failure();
+  }
+
+  SmallVector<Value> matches;
+  Validity validity;
+  for (const auto &match : lowered->matches) {
+    matches.push_back(alignValue(pastValues, match.value, match.timing, *timing,
+                                 builder, contextOp));
+    auto aligned =
+        alignValidity(match.validity, match.timing, *timing, contextOp);
+    if (failed(aligned))
+      return failure();
+    appendValidity(validity, *aligned);
+  }
+  if (!timing->empty()) {
+    TimingPath timingValid = *timing;
+    auto cycles =
+        llvm::checkedAddUnsigned<uint64_t>(timingValid.front().cycles, 1);
+    if (!cycles) {
+      contextOp->emitError("LTL sequence length overflows 64 bits");
+      return failure();
+    }
+    timingValid.front().cycles = *cycles;
+    addValidity(validity, std::move(timingValid));
+  }
+  return LoweredProperty{*timing,
+                         comb::OrOp::create(builder, contextOp->getLoc(),
+                                            matches,
+                                            /*twoState=*/false),
+                         std::move(validity)};
+}
+
+static FailureOr<LoweredProperty>
+lowerProperty( // NOLINT(misc-no-recursion): Walks an acyclic LTL expression.
+    SampledAtoms &sampledAtoms, PastValues &pastValues, Value property,
+    OpBuilder &builder, Operation *contextOp) {
+  auto loc = property.getLoc();
+  if (auto implication = property.getDefiningOp<ltl::ImplicationOp>()) {
+    auto antecedent =
+        lowerSequence(sampledAtoms, pastValues, implication.getAntecedent(),
+                      builder, implication);
+    auto consequent =
+        lowerProperty(sampledAtoms, pastValues, implication.getConsequent(),
+                      builder, implication);
+    if (failed(antecedent) || failed(consequent))
+      return failure();
+
+    SmallVector<LoweredProperty> obligations;
+    for (const auto &match : antecedent->matches) {
+      TimingPath timing = match.timing;
+      if (failed(appendTiming(timing, consequent->timing, implication)))
+        return failure();
+      auto antecedentAtEnd = createPast(
+          pastValues, match.value, consequent->timing, builder, implication);
+      auto validity =
+          alignValidity(match.validity, {}, consequent->timing, implication);
+      if (failed(validity))
+        return failure();
+      appendValidity(*validity, consequent->validity);
+      obligations.push_back(
+          {std::move(timing),
+           comb::OrOp::create(
+               builder, loc,
+               comb::createOrFoldNot(builder, loc, antecedentAtEnd),
+               consequent->value, /*twoState=*/false),
+           std::move(*validity)});
+    }
+
+    auto timing = findCommonTiming(obligations);
+    if (failed(timing)) {
+      implication.emitError(
+          "lower-ltl-to-core cannot align temporal LTL timing paths");
+      return failure();
+    }
+
+    SmallVector<Value> values;
+    Validity validity;
+    for (auto &obligation : obligations) {
+      values.push_back(alignValue(pastValues, obligation.value,
+                                  obligation.timing, *timing, builder,
+                                  implication));
+      auto aligned = alignValidity(obligation.validity, obligation.timing,
+                                   *timing, implication);
+      if (failed(aligned))
+        return failure();
+      appendValidity(validity, *aligned);
+    }
+    return LoweredProperty{
+        *timing, comb::AndOp::create(builder, loc, values, /*twoState=*/false),
+        std::move(validity)};
+  }
+
+  if (auto notOp = property.getDefiningOp<ltl::NotOp>()) {
+    auto input = lowerProperty(sampledAtoms, pastValues, notOp.getInput(),
+                               builder, notOp);
+    if (failed(input))
+      return failure();
+    return LoweredProperty{input->timing,
+                           comb::createOrFoldNot(builder, loc, input->value),
+                           input->validity};
+  }
+
+  if (auto andOp = property.getDefiningOp<ltl::AndOp>()) {
+    SmallVector<LoweredProperty> inputs;
+    for (auto input : andOp.getInputs()) {
+      auto lowered =
+          lowerProperty(sampledAtoms, pastValues, input, builder, andOp);
+      if (failed(lowered))
+        return failure();
+      inputs.push_back(*lowered);
+    }
+
+    auto timing = findCommonTiming(inputs);
+    if (failed(timing)) {
+      andOp.emitError(
+          "lower-ltl-to-core cannot align temporal LTL timing paths");
+      return failure();
+    }
+
+    SmallVector<Value> values;
+    Validity validity;
+    for (auto &input : inputs) {
+      values.push_back(alignValue(pastValues, input.value, input.timing,
+                                  *timing, builder, andOp));
+      auto aligned =
+          alignValidity(input.validity, input.timing, *timing, andOp);
+      if (failed(aligned))
+        return failure();
+      appendValidity(validity, *aligned);
+    }
+    return LoweredProperty{
+        *timing, comb::AndOp::create(builder, loc, values, /*twoState=*/false),
+        std::move(validity)};
+  }
+
+  if (auto orOp = property.getDefiningOp<ltl::OrOp>()) {
+    SmallVector<LoweredProperty> inputs;
+    for (auto input : orOp.getInputs()) {
+      auto lowered =
+          lowerProperty(sampledAtoms, pastValues, input, builder, orOp);
+      if (failed(lowered))
+        return failure();
+      inputs.push_back(*lowered);
+    }
+
+    auto timing = findCommonTiming(inputs);
+    if (failed(timing)) {
+      orOp.emitError(
+          "lower-ltl-to-core cannot align temporal LTL timing paths");
+      return failure();
+    }
+
+    SmallVector<Value> values;
+    Validity validity;
+    for (auto &input : inputs) {
+      values.push_back(alignValue(pastValues, input.value, input.timing,
+                                  *timing, builder, orOp));
+      auto aligned = alignValidity(input.validity, input.timing, *timing, orOp);
+      if (failed(aligned))
+        return failure();
+      appendValidity(validity, *aligned);
+    }
+    return LoweredProperty{
+        *timing, comb::OrOp::create(builder, loc, values, /*twoState=*/false),
+        std::move(validity)};
+  }
+
+  if (isa<ltl::SequenceType>(property.getType()))
+    return lowerSequenceAsProperty(sampledAtoms, pastValues, property, builder,
+                                   contextOp);
+
+  if (auto *defOp = property.getDefiningOp())
+    defOp->emitError("lower-ltl-to-core does not support temporal LTL "
+                     "operation '")
+        << defOp->getName() << "'";
+  else
+    contextOp->emitError("lower-ltl-to-core does not support block argument "
+                         "LTL properties");
+  return failure();
+}
+
+static bool isTemporalLTLValue(Value value, DenseSet<Value> &visited);
+
+static bool isTemporalLTLValue(Value value) {
+  DenseSet<Value> visited;
+  return isTemporalLTLValue(value, visited);
+}
+
+// NOLINTNEXTLINE(misc-no-recursion): Walks an acyclic LTL expression.
+static bool isTemporalLTLValue(Value value, DenseSet<Value> &visited) {
+  if (!value || !visited.insert(value).second)
+    return false;
+
+  auto *op = value.getDefiningOp();
+  if (!op || op->getDialect()->getNamespace() !=
+                 ltl::LTLDialect::getDialectNamespace())
+    return false;
+
+  if (isa<ltl::ClockOp, ltl::ClockedAtomOp, ltl::DelayOp, ltl::ClockedDelayOp,
+          ltl::ConcatOp>(op))
+    return true;
+
+  if (auto implication = dyn_cast<ltl::ImplicationOp>(op))
+    return isTemporalLTLValue(implication.getAntecedent(), visited) ||
+           isTemporalLTLValue(implication.getConsequent(), visited);
+
+  if (auto notOp = dyn_cast<ltl::NotOp>(op))
+    return isTemporalLTLValue(notOp.getInput(), visited);
+
+  if (auto andOp = dyn_cast<ltl::AndOp>(op)) {
+    for (auto input : andOp.getInputs())
+      if (isTemporalLTLValue(input, visited))
+        return true;
+    return false;
+  }
+
+  if (auto orOp = dyn_cast<ltl::OrOp>(op)) {
+    for (auto input : orOp.getInputs())
+      if (isTemporalLTLValue(input, visited))
+        return true;
+    return false;
+  }
+
+  for (auto operand : op->getOperands())
+    if (isTemporalLTLValue(operand, visited))
+      return true;
+  return false;
+}
+
+static Value getAssertLikeProperty(Operation *op) {
+  if (auto assertOp = dyn_cast<verif::AssertOp>(op))
+    return assertOp.getProperty();
+  if (auto assumeOp = dyn_cast<verif::AssumeOp>(op))
+    return assumeOp.getProperty();
+  return {};
+}
+
+// NOLINTNEXTLINE(misc-no-recursion): Walks an acyclic LTL expression.
+static void eraseDeadLTLTree(Value value) {
+  auto *op = value.getDefiningOp();
+  if (!op || !op->use_empty() ||
+      op->getDialect()->getNamespace() !=
+          ltl::LTLDialect::getDialectNamespace())
+    return;
+
+  SmallVector<Value> operands(op->getOperands());
+  op->erase();
+  for (auto operand : operands)
+    eraseDeadLTLTree(operand);
+}
+
+static LogicalResult lowerTemporalLTLToCore(hw::HWModuleOp module) {
+  SmallVector<Operation *> assertLikes;
+  module->walk([&](Operation *op) {
+    if (isa<verif::AssertOp, verif::AssumeOp>(op))
+      assertLikes.push_back(op);
+  });
+
+  for (auto *op : assertLikes) {
+    auto property = getAssertLikeProperty(op);
+    if (!isTemporalLTLValue(property))
+      continue;
+
+    SampledAtoms sampledAtoms;
+    PastValues pastValues;
+    Value validStart;
+    OpBuilder builder(op);
+    auto lowered =
+        lowerProperty(sampledAtoms, pastValues, property, builder, op);
+    if (failed(lowered))
+      return failure();
+    auto valid = materializeValidity(pastValues, validStart, lowered->validity,
+                                     builder, op);
+    auto guardedProperty = comb::OrOp::create(
+        builder, op->getLoc(),
+        comb::createOrFoldNot(builder, op->getLoc(), valid), lowered->value,
+        /*twoState=*/false);
+    op->setOperand(0, guardedProperty);
+    eraseDeadLTLTree(property);
+  }
+
+  return success();
+}
+
+static bool isSupportedBooleanPropertyUser(Operation *op) {
+  return isa<verif::AssertOp, verif::AssumeOp, verif::ClockedAssertOp>(op);
+}
+
+static void cleanupBooleanLTLToCore(hw::HWModuleOp module) {
+  // Clean up remaining unrealized casts at assertion and assumption users.
+  SmallVector<UnrealizedConversionCastOp> deadCasts;
+  module.walk([&](Operation *op) {
+    if (!isSupportedBooleanPropertyUser(op))
+      return;
+    Value prop = op->getOperand(0);
+    if (auto cast = prop.getDefiningOp<UnrealizedConversionCastOp>()) {
+      // Make sure that the cast is from an i1, not something random that was
+      // in the input
+      if (auto intType = dyn_cast<IntegerType>(cast.getOperandTypes()[0]);
+          intType && intType.getWidth() == 1) {
+        op->setOperand(0, cast.getInputs()[0]);
+        if (cast->use_empty())
+          deadCasts.push_back(cast);
+      }
+    }
+  });
+  for (auto cast : deadCasts)
+    cast.erase();
+}
+
+static LogicalResult checkNoLTLTypes(hw::HWModuleOp module) {
+  auto containsLTLType = [](Type type) {
+    return type
+        .walk([](Type nestedType) {
+          return isa<ltl::PropertyType, ltl::SequenceType>(nestedType)
+                     ? WalkResult::interrupt()
+                     : WalkResult::advance();
+        })
+        .wasInterrupted();
+  };
+  WalkResult result = module->walk([&](Operation *op) {
+    for (auto type : op->getResultTypes()) {
+      if (!containsLTLType(type))
+        continue;
+      op->emitError("lower-ltl-to-core cannot eliminate LTL type ") << type;
+      return WalkResult::interrupt();
+    }
+    for (auto &region : op->getRegions())
+      for (auto &block : region)
+        for (auto argument : block.getArguments()) {
+          auto type = argument.getType();
+          if (!containsLTLType(type))
+            continue;
+          op->emitError("lower-ltl-to-core cannot eliminate LTL type ") << type;
+          return WalkResult::interrupt();
+        }
+    for (const auto &namedAttr : op->getAttrs()) {
+      Type ltlType;
+      namedAttr.getValue().walk([&](Type type) {
+        if (isa<ltl::PropertyType, ltl::SequenceType>(type))
+          ltlType = type;
+      });
+      if (!ltlType)
+        continue;
+      op->emitError("lower-ltl-to-core cannot eliminate LTL type ")
+          << ltlType << " in attribute '" << namedAttr.getName().getValue()
+          << "'";
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+
+static LogicalResult lowerRemainingLTLToCore(hw::HWModuleOp module,
+                                             ConversionTarget &target) {
+  TypeConverter converter;
+  converter.addConversion([](IntegerType type) { return type; });
+  converter.addConversion([](ltl::PropertyType type) {
+    return IntegerType::get(type.getContext(), 1);
+  });
+  converter.addConversion([](ltl::SequenceType type) {
+    return IntegerType::get(type.getContext(), 1);
+  });
+  converter.addTargetMaterialization(
+      [](mlir::OpBuilder &builder, mlir::Type resultType,
+         mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
+        if (inputs.size() != 1)
+          return Value();
+        return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                                  inputs[0])
+            ->getResult(0);
+      });
+  converter.addSourceMaterialization(
+      [](mlir::OpBuilder &builder, mlir::Type resultType,
+         mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
+        if (inputs.size() != 1)
+          return Value();
+        return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                                  inputs[0])
+            ->getResult(0);
+      });
+
+  target.addIllegalOp<verif::HasBeenResetOp>();
+  RewritePatternSet patterns(module.getContext());
+  patterns.add<LTLBooleanConstantConversion, LTLImplicationConversion,
+               LTLNotConversion, LTLAndOpConversion, LTLOrOpConversion,
+               LTLIntersectOpConversion>(converter, patterns.getContext());
+  patterns.add<HasBeenResetOpConversion, LTLPastOpConversion>(
+      patterns.getContext());
+
+  if (failed(applyPartialConversion(module, target, std::move(patterns))))
+    return failure();
+
+  cleanupBooleanLTLToCore(module);
+  return checkNoLTLTypes(module);
+}
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -219,101 +999,20 @@ struct LowerLTLToCorePass
 };
 } // namespace
 
-// Simply applies the conversion patterns defined above
 void LowerLTLToCorePass::runOnOperation() {
-  // Set target dialects: We don't want to see any ltl or verif that might
-  // come from an AssertProperty left in the result
+  auto module = getOperation();
   ConversionTarget target(getContext());
   target.addLegalDialect<hw::HWDialect>();
   target.addLegalDialect<comb::CombDialect>();
   target.addLegalDialect<sv::SVDialect>();
   target.addLegalDialect<seq::SeqDialect>();
-  target.addLegalDialect<ltl::LTLDialect>();
   target.addLegalDialect<verif::VerifDialect>();
-  target.addIllegalOp<verif::HasBeenResetOp>();
-  target.addIllegalOp<ltl::PastOp>();
+  target.addIllegalDialect<ltl::LTLDialect>();
 
-  auto isLegal = [](Operation *op) {
-    auto hasNonAssertUsers = std::any_of(
-        op->getUsers().begin(), op->getUsers().end(), [](Operation *user) {
-          return !isa<verif::AssertOp, verif::ClockedAssertOp>(user);
-        });
-    auto hasIntegerResultTypes =
-        std::all_of(op->getResultTypes().begin(), op->getResultTypes().end(),
-                    [](Type type) { return isa<IntegerType>(type); });
-    // If there are users other than asserts, we can't map it to comb (unless
-    // the return type is already integer anyway)
-    if (hasNonAssertUsers && !hasIntegerResultTypes)
-      return true;
-
-    // Otherwise illegal if operands are i1
-    return std::any_of(
-        op->getOperands().begin(), op->getOperands().end(),
-        [](Value operand) { return !isa<IntegerType>(operand.getType()); });
-  };
-  target.addDynamicallyLegalOp<ltl::ImplicationOp>(isLegal);
-  target.addDynamicallyLegalOp<ltl::NotOp>(isLegal);
-  target.addDynamicallyLegalOp<ltl::AndOp>(isLegal);
-  target.addDynamicallyLegalOp<ltl::OrOp>(isLegal);
-  target.addDynamicallyLegalOp<ltl::IntersectOp>(isLegal);
-
-  // Create type converters, mostly just to convert an ltl property to a bool
-  mlir::TypeConverter converter;
-
-  // Convert the ltl property type to a built-in type
-  converter.addConversion([](IntegerType type) { return type; });
-  converter.addConversion([](ltl::PropertyType type) {
-    return IntegerType::get(type.getContext(), 1);
-  });
-  converter.addConversion([](ltl::SequenceType type) {
-    return IntegerType::get(type.getContext(), 1);
-  });
-
-  // Basic materializations
-  converter.addTargetMaterialization(
-      [&](mlir::OpBuilder &builder, mlir::Type resultType,
-          mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
-        if (inputs.size() != 1)
-          return Value();
-        return UnrealizedConversionCastOp::create(builder, loc, resultType,
-                                                  inputs[0])
-            ->getResult(0);
-      });
-
-  converter.addSourceMaterialization(
-      [&](mlir::OpBuilder &builder, mlir::Type resultType,
-          mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
-        if (inputs.size() != 1)
-          return Value();
-        return UnrealizedConversionCastOp::create(builder, loc, resultType,
-                                                  inputs[0])
-            ->getResult(0);
-      });
-
-  // Create the operation rewrite patters
-  RewritePatternSet patterns(&getContext());
-  patterns.add<HasBeenResetOpConversion, LTLImplicationConversion,
-               LTLNotConversion, LTLAndOpConversion, LTLOrOpConversion,
-               LTLIntersectOpConversion, LTLPastOpConversion>(
-      converter, patterns.getContext());
-  // Apply the conversions
-  if (failed(
-          applyPartialConversion(getOperation(), target, std::move(patterns))))
-    return signalPassFailure();
-
-  // Clean up remaining unrealized casts by changing assert argument types
-  getOperation().walk([&](Operation *op) {
-    if (!isa<verif::AssertOp, verif::ClockedAssertOp>(op))
-      return;
-    Value prop = op->getOperand(0);
-    if (auto cast = prop.getDefiningOp<UnrealizedConversionCastOp>()) {
-      // Make sure that the cast is from an i1, not something random that was
-      // in the input
-      if (auto intType = dyn_cast<IntegerType>(cast.getOperandTypes()[0]);
-          intType && intType.getWidth() == 1)
-        op->setOperand(0, cast.getInputs()[0]);
-    }
-  });
+  if (failed(lowerTemporalLTLToCore(module)) ||
+      failed(lowerRemainingLTLToCore(module, target))) {
+    signalPassFailure();
+  }
 }
 
 // Basic default constructor

--- a/test/Conversion/LTLToCore/ltl-to-core-errors.mlir
+++ b/test/Conversion/LTLToCore/ltl-to-core-errors.mlir
@@ -1,0 +1,207 @@
+// RUN: circt-opt %s --lower-ltl-to-core --split-input-file --verify-diagnostics
+
+hw.module @UnboundedClockedDelay(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  // expected-error @below {{lower-ltl-to-core only supports bounded LTL delays}}
+  %2 = ltl.clocked_delay %1, posedge %0, 1 : !ltl.sequence
+  verif.assert %2 : !ltl.sequence
+  hw.output
+}
+
+// -----
+
+hw.module @UnclockedDelay(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  // expected-error @below {{lower-ltl-to-core does not support temporal LTL operation 'ltl.delay'}}
+  %2 = ltl.delay %1, 1, 0 : !ltl.sequence
+  verif.assert %2 : !ltl.sequence
+  hw.output
+}
+
+// -----
+
+hw.module @ClockScope(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  // expected-error @below {{lower-ltl-to-core does not support temporal LTL operation 'ltl.clock'}}
+  %1 = ltl.clock %a, posedge %0 : i1
+  verif.assert %1 : !ltl.sequence
+  hw.output
+}
+
+// -----
+
+hw.module @BothEdgeClock(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  // expected-error @below {{lower-ltl-to-core does not support both-edge LTL clocks}}
+  %1 = ltl.clocked_atom %a, edge %0 : i1
+  verif.assert %1 : !ltl.sequence
+  hw.output
+}
+
+// -----
+
+hw.module @DifferentEdges(in %clock : i1, in %a : i1, in %b : i1) {
+  %0 = ltl.clocked_atom %a, posedge %clock : i1
+  %1 = ltl.clocked_atom %b, negedge %clock : i1
+  %2 = ltl.clocked_delay %0, posedge %clock, 1, 0 : !ltl.sequence
+  %3 = ltl.clocked_delay %1, negedge %clock, 1, 0 : !ltl.sequence
+  // expected-error @below {{lower-ltl-to-core cannot align temporal LTL timing paths}}
+  %4 = ltl.and %2, %3 : !ltl.sequence, !ltl.sequence
+  verif.assert %4 : !ltl.sequence
+  hw.output
+}
+
+// -----
+
+hw.module @UnsupportedTemporalOp(in %clock : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_atom %b, posedge %0 : i1
+  // expected-error @below {{lower-ltl-to-core does not support temporal LTL operation 'ltl.until'}}
+  %3 = ltl.until %1, %2 : !ltl.sequence, !ltl.sequence
+  verif.assert %3 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @UnclockedAtom(in %clock : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  // expected-error @below {{lower-ltl-to-core does not support block argument LTL properties}}
+  %2 = ltl.implication %1, %b : !ltl.sequence, i1
+  verif.assert %2 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @UnclockedAntecedent(in %clock : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %b, posedge %0 : i1
+  // expected-error @below {{lower-ltl-to-core does not support block argument LTL sequences}}
+  %2 = ltl.implication %a, %1 : i1, !ltl.sequence
+  verif.assert %2 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @LengthOverflow(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  // expected-error @below {{LTL sequence length overflows 64 bits}}
+  %2 = ltl.clocked_delay %1, posedge %0, 18446744073709551615, 1 : !ltl.sequence
+  verif.assert %2 : !ltl.sequence
+  hw.output
+}
+
+// -----
+
+// expected-error @below {{lower-ltl-to-core cannot eliminate LTL type '!ltl.property'}}
+hw.module @LTLTypedPort(in %property : !ltl.property) {
+  hw.output
+}
+
+// -----
+
+// expected-error @below {{lower-ltl-to-core cannot eliminate LTL type '!hw.array<2x!ltl.sequence>'}}
+hw.module @NestedLTLTypedPort(in %sequences : !hw.array<2x!ltl.sequence>) {
+  hw.output
+}
+
+// -----
+
+hw.module @LTLTypeAttribute(in %a : i1) {
+  // expected-error @below {{lower-ltl-to-core cannot eliminate LTL type '!ltl.property' in attribute 'test.ltl_type'}}
+  %0 = hw.wire %a {test.ltl_type = !ltl.property} : i1
+  hw.output
+}
+
+// -----
+
+hw.module @BooleanImplicationWithProperty(
+    in %a : i1, in %property : !ltl.property) {
+  // expected-error @below {{failed to legalize operation 'ltl.implication' that was explicitly marked illegal}}
+  %0 = ltl.implication %a, %property : i1, !ltl.property
+  verif.assert %0 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @BooleanNotWithProperty(in %property : !ltl.property) {
+  // expected-error @below {{failed to legalize operation 'ltl.not' that was explicitly marked illegal}}
+  %0 = ltl.not %property : !ltl.property
+  verif.assert %0 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @BooleanAndWithProperty(
+    in %a : i1, in %property : !ltl.property) {
+  // expected-error @below {{failed to legalize operation 'ltl.and' that was explicitly marked illegal}}
+  %0 = ltl.and %a, %property : i1, !ltl.property
+  verif.assert %0 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @BooleanOrWithProperty(
+    in %a : i1, in %property : !ltl.property) {
+  // expected-error @below {{failed to legalize operation 'ltl.or' that was explicitly marked illegal}}
+  %0 = ltl.or %a, %property : i1, !ltl.property
+  verif.assert %0 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @BooleanIntersectWithSequence(
+    in %a : i1, in %sequence : !ltl.sequence) {
+  // expected-error @below {{failed to legalize operation 'ltl.intersect' that was explicitly marked illegal}}
+  %0 = ltl.intersect %a, %sequence : i1, !ltl.sequence
+  verif.assert %0 : !ltl.sequence
+  hw.output
+}
+
+// -----
+
+hw.module @BooleanNotOfPropertyResult(in %a : i1, in %b : i1) {
+  %0 = ltl.implication %a, %b : i1, i1
+  // expected-error @below {{failed to legalize operation 'ltl.not' that was explicitly marked illegal}}
+  %1 = ltl.not %0 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @BooleanAndOfPropertyResult(in %a : i1) {
+  %0 = ltl.not %a : i1
+  // expected-error @below {{failed to legalize operation 'ltl.and' that was explicitly marked illegal}}
+  %1 = ltl.and %0, %0 : !ltl.property, !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @UnsupportedEventually(in %a : i1) {
+  // expected-error @below {{failed to legalize operation 'ltl.eventually' that was explicitly marked illegal}}
+  %0 = ltl.eventually %a : i1
+  verif.assert %0 : !ltl.property
+  hw.output
+}
+
+// -----
+
+hw.module @TemporalClockedAssert(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  // expected-error @below {{failed to legalize operation 'ltl.clocked_atom' that was explicitly marked illegal}}
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  verif.clocked_assert %1, posedge %0 : !ltl.sequence
+  hw.output
+}

--- a/test/Conversion/LTLToCore/ltl-to-core.mlir
+++ b/test/Conversion/LTLToCore/ltl-to-core.mlir
@@ -1,117 +1,85 @@
-// RUN: circt-opt %s --lower-ltl-to-core | FileCheck %s
+// RUN: circt-opt %s --lower-ltl-to-core | FileCheck %s --implicit-check-not=ltl
 
-// CHECK: hw.module @Implication(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[C:%.+]] : !ltl.property, in [[CLK:%.+]] : i1)
+// CHECK: hw.module @Implication(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[CLK:%.+]] : i1)
 // CHECK: [[TRUE:%.+]] = hw.constant true
 // CHECK: [[NOT_A:%.+]] = comb.xor [[A]], [[TRUE]] : i1
 // CHECK: [[OR:%.+]] = comb.or [[NOT_A]], [[B]] : i1
 // CHECK: verif.assert [[OR]] : i1
 // CHECK: verif.clocked_assert [[OR]], posedge [[CLK:%.+]] : i1
-// CHECK: [[IMP2:%.+]] = ltl.implication [[A]], [[B]] : i1, i1
-// CHECK: [[NOT_IMP2:%.+]] = ltl.not [[IMP2]] : !ltl.property
-// CHECK: [[IMP3:%.+]] = ltl.implication [[B]], [[C]] : i1, !ltl.property
-// CHECK: verif.assert [[IMP3]] : !ltl.property
 
-hw.module @Implication(in %a: i1, in %b: i1, in %c: !ltl.property, in %clk: i1) {
-  // Convert if both operands are i1 and the only users are asserts
+hw.module @Implication(in %a: i1, in %b: i1, in %clk: i1) {
   %imp1 = ltl.implication %a, %b : i1, i1
   verif.assert %imp1 : !ltl.property
   verif.clocked_assert %imp1, posedge %clk : !ltl.property
-  // Don't convert if there are non-assert users
-  %imp2 = ltl.implication %a, %b : i1, i1
-  %user = ltl.not %imp2 : !ltl.property
-  // Or if there are non-i1 operands
-  %imp3 = ltl.implication %b, %c : i1, !ltl.property
-  verif.assert %imp3 : !ltl.property
 }
 
-// CHECK: hw.module @Not(in [[A:%.+]] : i1, in [[B:%.+]] : !ltl.property, in [[CLK:%.+]] : i1)
+// CHECK: hw.module @Not(in [[A:%.+]] : i1, in [[CLK:%.+]] : i1)
 // CHECK: [[TRUE:%.+]] = hw.constant true
 // CHECK: [[NOT_A:%.+]] = comb.xor [[A]], [[TRUE]] : i1
 // CHECK: verif.assert [[NOT_A]] : i1
 // CHECK: verif.clocked_assert [[NOT_A]], posedge [[CLK:%.+]] : i1
-// CHECK: [[NOT2:%.+]] = ltl.not [[A]] : i1
-// CHECK: [[AND:%.+]] = ltl.and
-// CHECK: [[NOT_B:%.+]] = ltl.not [[B]] : !ltl.property
-// CHECK: verif.assert [[NOT_B]] : !ltl.property
 
-hw.module @Not(in %a: i1, in %b: !ltl.property, in %clk: i1) {
-  // Convert if both operands are i1 and the only users are asserts
+hw.module @Not(in %a: i1, in %clk: i1) {
   %not1 = ltl.not %a : i1
   verif.assert %not1 : !ltl.property
   verif.clocked_assert %not1, posedge %clk : !ltl.property
-  // Don't convert if there are non-assert users
-  %not2 = ltl.not %a : i1
-  %user = ltl.and %not2, %not2 : !ltl.property, !ltl.property
-  // Or if there are non-i1 operands
-  %not3 = ltl.not %b : !ltl.property
-  verif.assert %not3 : !ltl.property
 }
 
-// CHECK: hw.module @And(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[C:%.+]] : !ltl.property, in [[CLK:%.+]] : i1)
+// CHECK: hw.module @And(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[CLK:%.+]] : i1)
 // CHECK: [[AND1:%.+]] = comb.and [[A]], [[B]] : i1
 // CHECK: verif.assert [[AND1]] : i1
 // CHECK: verif.clocked_assert [[AND1]], posedge [[CLK]] : i1
 // CHECK: [[AND2:%.+]] = comb.and [[A]], [[B]] : i1
 // CHECK: [[USER:%.+]] = hw.wire [[AND2]] : i1
-// CHECK: [[AND3:%.+]] = ltl.and [[B]], [[C]] : i1, !ltl.property
-// CHECK: verif.assert [[AND3]] : !ltl.property
 
-hw.module @And(in %a: i1, in %b: i1, in %c: !ltl.property, in %clk: i1) {
-  // Convert if both operands are i1 and the only users are asserts
+hw.module @And(in %a: i1, in %b: i1, in %clk: i1) {
   %and1 = ltl.and %a, %b : i1, i1
   verif.assert %and1 : i1
   verif.clocked_assert %and1, posedge %clk : i1
-  // Convert if there are non-assert users but the result type is i1
   %and2 = ltl.and %a, %b : i1, i1
   %user = hw.wire %and2 : i1
-  // Don't convert if there are non-i1 operands (and therefore results)
-  %and3 = ltl.and %b, %c : i1, !ltl.property
-  verif.assert %and3 : !ltl.property
 }
 
-// CHECK: hw.module @Or(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[C:%.+]] : !ltl.property, in [[CLK:%.+]] : i1)
+// CHECK: hw.module @Or(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[CLK:%.+]] : i1)
 // CHECK: [[OR1:%.+]] = comb.or [[A]], [[B]] : i1
 // CHECK: verif.assert [[OR1]] : i1
 // CHECK: verif.clocked_assert [[OR1]], posedge [[CLK]] : i1
 // CHECK: [[OR2:%.+]] = comb.or [[A]], [[B]] : i1
 // CHECK: [[USER:%.+]] = hw.wire [[OR2]] : i1
-// CHECK: [[OR3:%.+]] = ltl.or [[B]], [[C]] : i1, !ltl.property
-// CHECK: verif.assert [[OR3]] : !ltl.property
 
-hw.module @Or(in %a: i1, in %b: i1, in %c: !ltl.property, in %clk: i1) {
-  // Convert if both operands are i1 and the only users are asserts
+hw.module @Or(in %a: i1, in %b: i1, in %clk: i1) {
   %or1 = ltl.or %a, %b : i1, i1
   verif.assert %or1 : i1
   verif.clocked_assert %or1, posedge %clk : i1
-  // Convert if there are non-assert users but the result type is i1
   %or2 = ltl.or %a, %b : i1, i1
   %user = hw.wire %or2 : i1
-  // Don't convert if there are non-i1 operands (and therefore results)
-  %or3 = ltl.or %b, %c : i1, !ltl.property
-  verif.assert %or3 : !ltl.property
 }
 
-// CHECK: hw.module @Intersect(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[C:%.+]] : !ltl.sequence, in [[CLK:%.+]] : i1)
+// CHECK: hw.module @Intersect(in [[A:%.+]] : i1, in [[B:%.+]] : i1, in [[CLK:%.+]] : i1)
 // CHECK: [[INT1:%.+]] = comb.and [[A]], [[B]] : i1
 // CHECK: verif.assert [[INT1]] : i1
 // CHECK: verif.clocked_assert [[INT1]], posedge [[CLK]] : i1
 // CHECK: [[INT2:%.+]] = comb.and [[A]], [[B]] : i1
 // CHECK: [[USER:%.+]] = hw.wire [[INT2]] : i1
-// CHECK: [[INT3:%.+]] = ltl.intersect [[B]], [[C]] : i1, !ltl.sequence
-// CHECK: verif.assert [[INT3]] : !ltl.sequence
 
-hw.module @Intersect(in %a: i1, in %b: i1, in %c: !ltl.sequence, in %clk: i1) {
-  // Boolean intersection is instantaneous, i.e. conjunction. Convert if both
-  // operands are i1 and the only users are asserts
+hw.module @Intersect(in %a: i1, in %b: i1, in %clk: i1) {
   %int1 = ltl.intersect %a, %b : i1, i1
   verif.assert %int1 : i1
   verif.clocked_assert %int1, posedge %clk : i1
-  // Convert if there are non-assert users but the result type is i1
   %int2 = ltl.intersect %a, %b : i1, i1
   %user = hw.wire %int2 : i1
-  // Don't convert if there are non-i1 operands (and therefore results)
-  %int3 = ltl.intersect %b, %c : i1, !ltl.sequence
-  verif.assert %int3 : !ltl.sequence
+}
+
+// CHECK-LABEL: hw.module @BooleanConstant
+// CHECK:         %[[TRUE:.+]] = hw.constant true
+// CHECK:         verif.assert %[[TRUE]] : i1
+// CHECK:         %[[FALSE:.+]] = hw.constant false
+// CHECK:         verif.assume %[[FALSE]] : i1
+hw.module @BooleanConstant() {
+  %true = ltl.boolean_constant true
+  verif.assert %true : !ltl.property
+  %false = ltl.boolean_constant false
+  verif.assume %false : !ltl.property
 }
 
 // CHECK: hw.module @Past(in [[A:%.+]] : i32, in [[CLK:%.+]] : i1)
@@ -125,4 +93,323 @@ hw.module @Intersect(in %a: i1, in %b: i1, in %c: !ltl.sequence, in %clk: i1) {
 hw.module @Past(in %a: i32, in %clk: i1) {
   ltl.past %a, 1 clk %clk : i32
   ltl.past %a, 5 clk %clk : i32
+}
+
+<<<<<<< Updated upstream
+// CHECK-LABEL: hw.module @ClockedAtom(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[CLOCK]] initial
+// CHECK:         %[[PROPERTY:.+]] = comb.or %[[SAMPLED_A]] : i1
+// CHECK:         %[[VALID:.+]] = seq.compreg %{{.+}}, %[[CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "clocked_atom" : i1
+hw.module @ClockedAtom(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  verif.assert %1 label "clocked_atom" : !ltl.sequence
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @ImplicationDelay(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK-SAME:    in %[[B:[^, ]+]] : i1
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[CLOCK]] initial
+// CHECK:         %[[SAMPLED_B:.+]] = seq.compreg %[[B]], %[[CLOCK]] initial
+// CHECK:         %[[CONSEQUENT:.+]] = comb.or %[[SAMPLED_B]] : i1
+// CHECK:         %[[PAST_A_1:.+]] = seq.compreg %[[SAMPLED_A]], %[[CLOCK]] initial
+// CHECK:         %[[PAST_A_2:.+]] = seq.compreg %[[PAST_A_1]], %[[CLOCK]] initial
+// CHECK:         %[[NOT_A:.+]] = comb.xor %[[PAST_A_2]], %{{.+}} : i1
+// CHECK:         %[[IMPLICATION:.+]] = comb.or %[[NOT_A]], %[[CONSEQUENT]] : i1
+// CHECK:         %[[PROPERTY:.+]] = comb.and %[[IMPLICATION]] : i1
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[CLOCK]] initial
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_2:.+]] = seq.compreg %[[VALID_1]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID_2]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "implication_delay" : i1
+hw.module @ImplicationDelay(in %clock : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_atom %b, posedge %0 : i1
+  %3 = ltl.clocked_delay %2, posedge %0, 2, 0 : !ltl.sequence
+  %4 = ltl.implication %1, %3 : !ltl.sequence, !ltl.sequence
+  verif.assert %4 label "implication_delay" : !ltl.property
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @DirectDelay(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[CLOCK]] initial
+// CHECK:         %[[PROPERTY:.+]] = comb.or %[[SAMPLED_A]] : i1
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[CLOCK]] initial
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_2:.+]] = seq.compreg %[[VALID_1]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID_2]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "direct_delay" : i1
+hw.module @DirectDelay(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_delay %1, posedge %0, 2, 0 : !ltl.sequence
+  verif.assert %2 label "direct_delay" : !ltl.sequence
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @RangedDelay(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[CLOCK]] initial
+// CHECK:         %[[PAST_A:.+]] = seq.compreg %[[SAMPLED_A]], %[[CLOCK]] initial
+// CHECK:         %[[MATCH:.+]] = comb.or %[[PAST_A]], %[[SAMPLED_A]] : i1
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[CLOCK]] initial
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_2:.+]] = seq.compreg %[[VALID_1]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID_2]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[MATCH]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "ranged_delay" : i1
+hw.module @RangedDelay(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_delay %1, posedge %0, 1, 1 : !ltl.sequence
+  verif.assert %2 label "ranged_delay" : !ltl.sequence
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @RangedAntecedent(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK-SAME:    in %[[B:[^, ]+]] : i1
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[CLOCK]] initial
+// CHECK:         %[[SAMPLED_B:.+]] = seq.compreg %[[B]], %[[CLOCK]] initial
+// CHECK:         %[[CONSEQUENT:.+]] = comb.or %[[SAMPLED_B]] : i1
+// CHECK:         %[[NOT_A_0:.+]] = comb.xor %[[SAMPLED_A]], %{{.+}} : i1
+// CHECK:         %[[OBLIGATION_0:.+]] = comb.or %[[NOT_A_0]], %[[CONSEQUENT]] : i1
+// CHECK:         %[[NOT_A_1:.+]] = comb.xor %[[SAMPLED_A]], %{{.+}} : i1
+// CHECK:         %[[OBLIGATION_1:.+]] = comb.or %[[NOT_A_1]], %[[CONSEQUENT]] : i1
+// CHECK:         %[[PAST_OBLIGATION_0:.+]] = seq.compreg %[[OBLIGATION_0]], %[[CLOCK]] initial
+// CHECK:         %[[PROPERTY:.+]] = comb.and %[[PAST_OBLIGATION_0]], %[[OBLIGATION_1]] : i1
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[CLOCK]] initial
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID_1]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "ranged_antecedent" : i1
+hw.module @RangedAntecedent(in %clock : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_atom %b, posedge %0 : i1
+  %3 = ltl.clocked_delay %1, posedge %0, 0, 1 : !ltl.sequence
+  %4 = ltl.implication %3, %2 : !ltl.sequence, !ltl.sequence
+  verif.assert %4 label "ranged_antecedent" : !ltl.property
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @Concat(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK-SAME:    in %[[B:[^, ]+]] : i1
+// CHECK-SAME:    in %[[C:[^, ]+]] : i1
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[CLOCK]] initial
+// CHECK:         %[[SAMPLED_B:.+]] = seq.compreg %[[B]], %[[CLOCK]] initial
+// CHECK:         %[[PAST_A:.+]] = seq.compreg %[[SAMPLED_A]], %[[CLOCK]] initial
+// CHECK:         %[[CONCAT:.+]] = comb.and %[[PAST_A]], %[[SAMPLED_B]] : i1
+// CHECK:         %[[SAMPLED_C:.+]] = seq.compreg %[[C]], %[[CLOCK]] initial
+// CHECK:         %[[CONSEQUENT:.+]] = comb.or %[[SAMPLED_C]] : i1
+// CHECK:         %[[NOT_CONCAT:.+]] = comb.xor %[[CONCAT]], %{{.+}} : i1
+// CHECK:         %[[IMPLICATION:.+]] = comb.or %[[NOT_CONCAT]], %[[CONSEQUENT]] : i1
+// CHECK:         %[[PROPERTY:.+]] = comb.and %[[IMPLICATION]] : i1
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[CLOCK]] initial
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID_1]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "concat" : i1
+hw.module @Concat(in %clock : !seq.clock, in %a : i1, in %b : i1, in %c : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_atom %b, posedge %0 : i1
+  %3 = ltl.clocked_atom %c, posedge %0 : i1
+  %4 = ltl.clocked_delay %2, posedge %0, 1, 0 : !ltl.sequence
+  %5 = ltl.concat %1, %4 : !ltl.sequence, !ltl.sequence
+  %6 = ltl.implication %5, %3 : !ltl.sequence, !ltl.sequence
+  verif.assert %6 label "concat" : !ltl.property
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @PropertyAlignment(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK:         %[[IMPLICATION_1:.+]] = comb.or %{{.+}}, %{{.+}} : i1
+// CHECK:         %[[PROPERTY_1:.+]] = comb.and %[[IMPLICATION_1]] : i1
+// CHECK:         %[[IMPLICATION_2:.+]] = comb.or %{{.+}}, %{{.+}} : i1
+// CHECK:         %[[PROPERTY_2:.+]] = comb.and %[[IMPLICATION_2]] : i1
+// CHECK:         %[[ALIGNED_1:.+]] = seq.compreg %[[PROPERTY_1]], %[[CLOCK]] initial
+// CHECK:         %[[ALIGNED_PROPERTY:.+]] = comb.and %[[ALIGNED_1]], %[[PROPERTY_2]] : i1
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[CLOCK]] initial
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_2:.+]] = seq.compreg %[[VALID_1]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID_2]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[ALIGNED_PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "property_alignment" : i1
+hw.module @PropertyAlignment(in %clock : !seq.clock, in %a : i1, in %b : i1, in %c : i1, in %d : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_atom %b, posedge %0 : i1
+  %3 = ltl.clocked_atom %c, posedge %0 : i1
+  %4 = ltl.clocked_atom %d, posedge %0 : i1
+  %5 = ltl.clocked_delay %2, posedge %0, 1, 0 : !ltl.sequence
+  %6 = ltl.implication %1, %5 : !ltl.sequence, !ltl.sequence
+  %7 = ltl.clocked_delay %4, posedge %0, 2, 0 : !ltl.sequence
+  %8 = ltl.implication %3, %7 : !ltl.sequence, !ltl.sequence
+  %9 = ltl.and %6, %8 : !ltl.property, !ltl.property
+  verif.assert %9 label "property_alignment" : !ltl.property
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @PropertyOrNot(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK:         %[[IMPLICATION_1:.+]] = comb.or %{{.+}}, %{{.+}} : i1
+// CHECK:         %[[PROPERTY_1:.+]] = comb.and %[[IMPLICATION_1]] : i1
+// CHECK:         %[[IMPLICATION_2:.+]] = comb.or %{{.+}}, %{{.+}} : i1
+// CHECK:         %[[PROPERTY_2:.+]] = comb.and %[[IMPLICATION_2]] : i1
+// CHECK:         %[[ALIGNED_1:.+]] = seq.compreg %[[PROPERTY_1]], %[[CLOCK]] initial
+// CHECK:         %[[DISJUNCTION:.+]] = comb.or %[[ALIGNED_1]], %[[PROPERTY_2]] : i1
+// CHECK:         %[[NEGATED:.+]] = comb.xor %[[DISJUNCTION]], %{{.+}} : i1
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[CLOCK]] initial
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_2:.+]] = seq.compreg %[[VALID_1]], %[[CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID_2]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[NEGATED]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "property_or_not" : i1
+hw.module @PropertyOrNot(in %clock : !seq.clock, in %a : i1, in %b : i1, in %c : i1, in %d : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_atom %b, posedge %0 : i1
+  %3 = ltl.clocked_atom %c, posedge %0 : i1
+  %4 = ltl.clocked_atom %d, posedge %0 : i1
+  %5 = ltl.clocked_delay %2, posedge %0, 1, 0 : !ltl.sequence
+  %6 = ltl.implication %1, %5 : !ltl.sequence, !ltl.sequence
+  %7 = ltl.clocked_delay %4, posedge %0, 2, 0 : !ltl.sequence
+  %8 = ltl.implication %3, %7 : !ltl.sequence, !ltl.sequence
+  %9 = ltl.or %6, %8 : !ltl.property, !ltl.property
+  %10 = ltl.not %9 : !ltl.property
+  verif.assert %10 label "property_or_not" : !ltl.property
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @Assume(
+// CHECK:         verif.assume %{{.+}} label "assume_temporal" : i1
+hw.module @Assume(in %clock : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_atom %b, posedge %0 : i1
+  %3 = ltl.clocked_delay %2, posedge %0, 1, 0 : !ltl.sequence
+  %4 = ltl.implication %1, %3 : !ltl.sequence, !ltl.sequence
+  verif.assume %4 label "assume_temporal" : !ltl.property
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @NegedgeClock(
+// CHECK-SAME:    in %[[CLOCK:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK:         %[[CLOCK_I1:.+]] = seq.from_clock %[[CLOCK]]
+// CHECK:         %[[NOT_CLOCK:.+]] = comb.xor %[[CLOCK_I1]], %{{.+}} : i1
+// CHECK:         %[[NEGEDGE_CLOCK:.+]] = seq.to_clock %[[NOT_CLOCK]]
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[NEGEDGE_CLOCK]] initial
+// CHECK:         %[[PROPERTY:.+]] = comb.or %[[SAMPLED_A]] : i1
+// CHECK:         %[[VALID_NOT_CLOCK:.+]] = comb.xor %[[CLOCK_I1]], %{{.+}} : i1
+// CHECK:         %[[VALID_CLOCK:.+]] = seq.to_clock %[[VALID_NOT_CLOCK]]
+// CHECK:         %[[VALID:.+]] = seq.compreg %{{.+}}, %[[VALID_CLOCK]] initial
+// CHECK:         %[[VALID_PROPERTY:.+]] = comb.and %[[VALID]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID_PROPERTY]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "negedge" : i1
+hw.module @NegedgeClock(in %clock : !seq.clock, in %a : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, negedge %0 : i1
+  verif.assert %1 label "negedge" : !ltl.sequence
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @MultipleClocks(
+// CHECK-SAME:    in %[[CLOCK_0:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[CLOCK_1:[^, ]+]] : !seq.clock
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK-SAME:    in %[[B:[^, ]+]] : i1
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[CLOCK_0]] initial
+// CHECK:         %[[SAMPLED_B:.+]] = seq.compreg %[[B]], %[[CLOCK_1]] initial
+// CHECK:         %[[CONSEQUENT:.+]] = comb.or %[[SAMPLED_B]] : i1
+// CHECK:         %[[PAST_A:.+]] = seq.compreg %[[SAMPLED_A]], %[[CLOCK_1]] initial
+// CHECK:         %[[NOT_A:.+]] = comb.xor %[[PAST_A]], %{{.+}} : i1
+// CHECK:         %[[IMPLICATION:.+]] = comb.or %[[NOT_A]], %[[CONSEQUENT]] : i1
+// CHECK:         %[[PROPERTY:.+]] = comb.and %[[IMPLICATION]] : i1
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[CLOCK_0]] initial
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[CLOCK_1]] initial
+// CHECK:         %[[VALID_2:.+]] = seq.compreg %{{.+}}, %[[CLOCK_1]] initial
+// CHECK:         %[[VALID_3:.+]] = seq.compreg %[[VALID_2]], %[[CLOCK_1]] initial
+// CHECK:         %[[VALID:.+]] = comb.and %[[VALID_1]], %[[VALID_3]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] label "multiple_clocks" : i1
+hw.module @MultipleClocks(in %clock0 : !seq.clock, in %clock1 : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock0
+  %1 = seq.from_clock %clock1
+  %2 = ltl.clocked_atom %a, posedge %0 : i1
+  %3 = ltl.clocked_atom %b, posedge %1 : i1
+  %4 = ltl.clocked_delay %3, posedge %1, 1, 0 : !ltl.sequence
+  %5 = ltl.implication %2, %4 : !ltl.sequence, !ltl.sequence
+  verif.assert %5 label "multiple_clocks" : !ltl.property
+  hw.output
+}
+
+// CHECK-LABEL: hw.module @SameI1Clock(
+// CHECK-SAME:    in %[[CLOCK_I1:[^, ]+]] : i1
+// CHECK-SAME:    in %[[A:[^, ]+]] : i1
+// CHECK-SAME:    in %[[B:[^, ]+]] : i1
+// CHECK:         %[[CLOCK_A:.+]] = seq.to_clock %[[CLOCK_I1]]
+// CHECK:         %[[SAMPLED_A:.+]] = seq.compreg %[[A]], %[[CLOCK_A]] initial
+// CHECK:         %[[CLOCK_B:.+]] = seq.to_clock %[[CLOCK_I1]]
+// CHECK:         %[[SAMPLED_B:.+]] = seq.compreg %[[B]], %[[CLOCK_B]] initial
+// CHECK:         %[[CONSEQUENT:.+]] = comb.or %[[SAMPLED_B]] : i1
+// CHECK:         %[[PAST_CLOCK:.+]] = seq.to_clock %[[CLOCK_I1]]
+// CHECK:         %[[PAST_A:.+]] = seq.compreg %[[SAMPLED_A]], %[[PAST_CLOCK]] initial
+// CHECK:         %[[NOT_A:.+]] = comb.xor %[[PAST_A]], %{{.+}} : i1
+// CHECK:         %[[IMPLICATION:.+]] = comb.or %[[NOT_A]], %[[CONSEQUENT]] : i1
+// CHECK:         %[[PROPERTY:.+]] = comb.and %[[IMPLICATION]] : i1
+// CHECK:         %[[VALID_CLOCK_0:.+]] = seq.to_clock %[[CLOCK_I1]]
+// CHECK:         %[[VALID_0:.+]] = seq.compreg %{{.+}}, %[[VALID_CLOCK_0]] initial
+// CHECK:         %[[VALID_CLOCK_1:.+]] = seq.to_clock %[[CLOCK_I1]]
+// CHECK:         %[[VALID_1:.+]] = seq.compreg %[[VALID_0]], %[[VALID_CLOCK_1]] initial
+// CHECK:         %[[VALID:.+]] = comb.and %[[VALID_1]] : i1
+// CHECK:         %[[NOT_VALID:.+]] = comb.xor %[[VALID]], %{{.+}} : i1
+// CHECK:         %[[GUARDED:.+]] = comb.or %[[NOT_VALID]], %[[PROPERTY]] : i1
+// CHECK:         verif.assert %[[GUARDED]] : i1
+hw.module @SameI1Clock(in %clock : i1, in %a : i1, in %b : i1) {
+  %0 = ltl.clocked_atom %a, posedge %clock : i1
+  %1 = ltl.clocked_atom %b, posedge %clock : i1
+  %2 = ltl.clocked_delay %1, posedge %clock, 1, 0 : !ltl.sequence
+  %3 = ltl.implication %0, %2 : !ltl.sequence, !ltl.sequence
+  verif.assert %3 : !ltl.property
+  hw.output
+=======
+// CHECK-LABEL: hw.module @UnsupportedLTL
+// CHECK-SAME: (in [[A:%.+]] : i1, in [[CLK:%.+]] : i1)
+// CHECK: [[ATOM:%.+]] = ltl.clocked_atom [[A]], posedge [[CLK]] : i1
+// CHECK: [[DELAY:%.+]] = ltl.clocked_delay [[ATOM]], posedge [[CLK]], 1 : !ltl.sequence
+// CHECK: verif.assert [[DELAY]] : !ltl.sequence
+
+hw.module @UnsupportedLTL(in %a: i1, in %clk: i1) {
+  %atom = ltl.clocked_atom %a, posedge %clk : i1
+  %delay = ltl.clocked_delay %atom, posedge %clk, 1 : !ltl.sequence
+  verif.assert %delay : !ltl.sequence
+>>>>>>> Stashed changes
 }

--- a/test/Tools/circt-bmc/ltl-errors.mlir
+++ b/test/Tools/circt-bmc/ltl-errors.mlir
@@ -1,0 +1,13 @@
+// RUN: not circt-bmc %s -b 2 --module MultipleClocks --emit-mlir -o - 2>&1 | FileCheck %s
+
+// CHECK: error: modules with multiple clocks not yet supported
+hw.module @MultipleClocks(in %clock0 : !seq.clock, in %clock1 : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock0
+  %1 = seq.from_clock %clock1
+  %2 = ltl.clocked_atom %a, posedge %0 : i1
+  %3 = ltl.clocked_atom %b, posedge %1 : i1
+  %4 = ltl.clocked_delay %3, posedge %1, 1, 0 : !ltl.sequence
+  %5 = ltl.implication %2, %4 : !ltl.sequence, !ltl.sequence
+  verif.assert %5 : !ltl.property
+  hw.output
+}

--- a/test/Tools/circt-bmc/ltl.mlir
+++ b/test/Tools/circt-bmc/ltl.mlir
@@ -1,0 +1,32 @@
+// RUN: circt-bmc %s -b 6 --module LtlProbe --emit-mlir -o - | FileCheck %s --implicit-check-not=ltl.
+
+// CHECK-LABEL: func.func @bmc_circuit(
+// CHECK-SAME:      %[[CLOCK:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[A:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[B:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[SAMPLED_A:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[SAMPLED_B:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[PAST_A_1:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[PAST_A_2:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[VALID_0:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[VALID_1:[^:]+]]: !smt.bv<1>,
+// CHECK-SAME:      %[[VALID_2:[^:]+]]: !smt.bv<1>)
+// CHECK:         %[[TRUE:.+]] = smt.bv.constant #smt.bv<-1> : !smt.bv<1>
+// CHECK:         %[[NOT_A:.+]] = smt.bv.xor %[[PAST_A_2]], %[[TRUE]] : !smt.bv<1>
+// CHECK:         %[[IMPLICATION:.+]] = smt.bv.or %[[NOT_A]], %[[SAMPLED_B]] : !smt.bv<1>
+// CHECK:         %[[NOT_VALID:.+]] = smt.bv.xor %[[VALID_2]], %[[TRUE]] : !smt.bv<1>
+// CHECK:         %[[GUARDED:.+]] = smt.bv.or %[[NOT_VALID]], %[[IMPLICATION]] : !smt.bv<1>
+// CHECK:         %[[HOLDS:.+]] = smt.eq %[[GUARDED]], %[[TRUE]] : !smt.bv<1>
+// CHECK:         %[[VIOLATED:.+]] = smt.not %[[HOLDS]]
+// CHECK:         smt.assert %[[VIOLATED]]
+// CHECK:         return %[[A]], %[[B]], %[[SAMPLED_A]], %[[PAST_A_1]], %[[TRUE]], %[[VALID_0]], %[[VALID_1]]
+
+hw.module @LtlProbe(in %clock : !seq.clock, in %a : i1, in %b : i1) {
+  %0 = seq.from_clock %clock
+  %1 = ltl.clocked_atom %a, posedge %0 : i1
+  %2 = ltl.clocked_atom %b, posedge %0 : i1
+  %3 = ltl.clocked_delay %2, posedge %0, 2, 0 : !ltl.sequence
+  %4 = ltl.implication %1, %3 : !ltl.sequence, !ltl.sequence
+  verif.assert %4 label "ltl_probe" : !ltl.property
+  hw.output
+}


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
Fix #10907 

Extend `lower-ltl-to-core` to lower explicitly clocked, bounded temporal LTL into `seq` registers and `comb` logic, enabling `circt-bmc` to handle delayed assertions.

- Support clocked atoms, bounded and ranged delays, concatenation, and temporal implication/and/or/not in assertions and assumptions.
- Align timing paths across clock edges and clocks, and guard properties until sampled history is valid.
- Eliminate all remaining LTL operations and types, with diagnostics for unsupported or incompatible constructs.

Assisted-by: Codex:GPT-5.6-Sol