### PR TITLE
[ESI][Runtime] Allow users to customize service threads

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -28,11 +28,18 @@
 #include "esi/Ports.h"
 #include "esi/Services.h"
 
+#include <atomic>
 #include <functional>
+#include <future>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <tuple>
 #include <typeinfo>
+#include <utility>
+#include <vector>
 
 namespace esi {
 // Forward declarations.
@@ -116,7 +123,7 @@ public:
   /// called. `std::thread` is used. If users don't want the runtime to spin up
   /// threads, don't call this method. `AcceleratorServiceThread` is owned by
   /// AcceleratorConnection and governed by the lifetime of the this object.
-  AcceleratorServiceThread *getServiceThread();
+  virtual AcceleratorServiceThread *getServiceThread();
 
   using Service = services::Service;
   /// Get a typed reference to a particular service type. Caller does *not* take
@@ -222,26 +229,72 @@ struct RegisterAccelerator {
 
 /// Background thread which services various requests. Currently, it listens on
 /// ports and calls callbacks for incoming messages on said ports.
+///
+/// All methods are virtual so that users may provide their own service thread
+/// implementation. Overriders can reuse the default implementation piecemeal by
+/// invoking the base-class methods -- typically overriding `poll()` (to change
+/// what a single iteration does) or `loop()` (to change how iterations are
+/// scheduled). Subclasses that need to run their own `loop()` from the outset
+/// should use the protected `DeferStart` constructor to prevent the base class
+/// from starting the thread, then call `start()` themselves.
 class AcceleratorServiceThread {
 public:
   AcceleratorServiceThread();
-  ~AcceleratorServiceThread();
+  virtual ~AcceleratorServiceThread();
 
   /// When there's data on any of the listenPorts, call the callback. Callable
   /// from any thread.
-  void
+  virtual void
   addListener(std::initializer_list<ReadChannelPort *> listenPorts,
               std::function<void(ReadChannelPort *, MessageData)> callback);
 
   /// Poll this module.
-  void addPoll(HWModule &module);
+  virtual void addPoll(HWModule &module);
+
+  /// Add a task to be invoked on every service iteration. Callable from any
+  /// thread.
+  virtual void addTask(std::function<void(void)> task);
 
   /// Instruct the service thread to stop running.
-  void stop();
+  virtual void stop();
 
-private:
-  struct Impl;
-  std::unique_ptr<Impl> impl;
+protected:
+  /// Tag type used to construct the base class without starting the service
+  /// thread. Intended for subclasses that need to run their own loop from the
+  /// start.
+  struct DeferStart {};
+  explicit AcceleratorServiceThread(DeferStart);
+
+  /// Start the service thread. Called by the default constructor. Spawns a
+  /// std::thread which invokes `loop()` via virtual dispatch.
+  virtual void start();
+
+  /// The main service loop. Runs until `shutdown` is set to true. The default
+  /// implementation yields and then calls `poll()` on every iteration.
+  virtual void loop();
+
+  /// Perform a single iteration of servicing: drain any ready listener
+  /// futures, invoke their callbacks, and run all registered tasks.
+  /// Overriders can invoke this from a custom loop to reuse the default
+  /// servicing behavior.
+  virtual void poll();
+
+  /// Set to true to request the service loop to exit.
+  std::atomic<bool> shutdown{false};
+  /// The thread running `loop()`.
+  std::thread me;
+
+  /// Protects `listeners` and `taskList`.
+  std::mutex m;
+
+  /// Map of read ports to callbacks and their in-flight async reads.
+  std::map<ReadChannelPort *,
+           std::pair<std::function<void(ReadChannelPort *, MessageData)>,
+                     std::future<MessageData>>>
+      listeners;
+
+  /// Tasks which should be called on every loop iteration.
+  std::vector<std::function<void(void)>> taskList;
 };
 } // namespace esi
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -376,92 +376,69 @@ AcceleratorConnection *Context::connect(std::string backend,
   return connPtr;
 }
 
-struct AcceleratorServiceThread::Impl {
-  Impl() {}
-  void start() { me = std::thread(&Impl::loop, this); }
-  void stop() {
-    shutdown = true;
+AcceleratorServiceThread::AcceleratorServiceThread() { start(); }
+AcceleratorServiceThread::AcceleratorServiceThread(DeferStart) {}
+AcceleratorServiceThread::~AcceleratorServiceThread() { stop(); }
+
+void AcceleratorServiceThread::start() {
+  me = std::thread(&AcceleratorServiceThread::loop, this);
+}
+
+void AcceleratorServiceThread::stop() {
+  shutdown = true;
+  if (me.joinable())
     me.join();
-  }
-  /// When there's data on any of the listenPorts, call the callback. This
-  /// method can be called from any thread.
-  void
-  addListener(std::initializer_list<ReadChannelPort *> listenPorts,
-              std::function<void(ReadChannelPort *, MessageData)> callback);
+}
 
-  void addTask(std::function<void(void)> task) {
-    std::lock_guard<std::mutex> g(m);
-    taskList.push_back(task);
-  }
-
-private:
-  void loop();
-  volatile bool shutdown = false;
-  std::thread me;
-
-  // Protect the shared data structures.
-  std::mutex m;
-
-  // Map of read ports to callbacks.
-  std::map<ReadChannelPort *,
-           std::pair<std::function<void(ReadChannelPort *, MessageData)>,
-                     std::future<MessageData>>>
-      listeners;
-
-  /// Tasks which should be called on every loop iteration.
-  std::vector<std::function<void(void)>> taskList;
-};
-
-void AcceleratorServiceThread::Impl::loop() {
-  // These two variables should logically be in the loop, but this avoids
-  // reconstructing them on each iteration.
-  std::vector<std::tuple<ReadChannelPort *,
-                         std::function<void(ReadChannelPort *, MessageData)>,
-                         MessageData>>
-      portUnlockWorkList;
-  std::vector<std::function<void(void)>> taskListCopy;
-  MessageData data;
-
+void AcceleratorServiceThread::loop() {
   while (!shutdown) {
     // Ideally we'd have some wake notification here, but this sufficies for
     // now.
     // TODO: investigate better ways to do this. For now, just play nice with
     // the other processes but don't waste time in between polling intervals.
     std::this_thread::yield();
-
-    // Check and gather data from all the read ports we are monitoring. Put the
-    // callbacks to be called later so we can release the lock.
-    {
-      std::lock_guard<std::mutex> g(m);
-      for (auto &[channel, cbfPair] : listeners) {
-        assert(channel && "Null channel in listener list");
-        std::future<MessageData> &f = cbfPair.second;
-        if (f.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-          portUnlockWorkList.emplace_back(channel, cbfPair.first, f.get());
-          f = channel->readAsync();
-        }
-      }
-    }
-
-    // Call the callbacks outside the lock.
-    for (auto [channel, cb, data] : portUnlockWorkList)
-      cb(channel, std::move(data));
-
-    // Clear the worklist for the next iteration.
-    portUnlockWorkList.clear();
-
-    // Call any tasks that have been added. Copy it first so we can release the
-    // lock ASAP.
-    {
-      std::lock_guard<std::mutex> g(m);
-      taskListCopy = taskList;
-    }
-    for (auto &task : taskListCopy)
-      task();
+    poll();
   }
 }
 
-void AcceleratorServiceThread::Impl::addListener(
+void AcceleratorServiceThread::poll() {
+  // Check and gather data from all the read ports we are monitoring. Put the
+  // callbacks to be called later so we can release the lock.
+  std::vector<std::tuple<ReadChannelPort *,
+                         std::function<void(ReadChannelPort *, MessageData)>,
+                         MessageData>>
+      portUnlockWorkList;
+  {
+    std::lock_guard<std::mutex> g(m);
+    for (auto &[channel, cbfPair] : listeners) {
+      assert(channel && "Null channel in listener list");
+      std::future<MessageData> &f = cbfPair.second;
+      if (f.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+        portUnlockWorkList.emplace_back(channel, cbfPair.first, f.get());
+        f = channel->readAsync();
+      }
+    }
+  }
+
+  // Call the callbacks outside the lock.
+  for (auto &[channel, cb, data] : portUnlockWorkList)
+    cb(channel, std::move(data));
+
+  // Call any tasks that have been added. Copy it first so we can release the
+  // lock ASAP.
+  std::vector<std::function<void(void)>> taskListCopy;
+  {
+    std::lock_guard<std::mutex> g(m);
+    taskListCopy = taskList;
+  }
+  for (auto &task : taskListCopy)
+    task();
+}
+
+// When there's data on any of the listenPorts, call the callback. This is
+// kinda silly now that we have callback port support, especially given the
+// polling loop. Keep the functionality for now.
+void AcceleratorServiceThread::addListener(
     std::initializer_list<ReadChannelPort *> listenPorts,
     std::function<void(ReadChannelPort *, MessageData)> callback) {
   std::lock_guard<std::mutex> g(m);
@@ -472,32 +449,13 @@ void AcceleratorServiceThread::Impl::addListener(
   }
 }
 
-AcceleratorServiceThread::AcceleratorServiceThread()
-    : impl(std::make_unique<Impl>()) {
-  impl->start();
-}
-AcceleratorServiceThread::~AcceleratorServiceThread() { stop(); }
-
-void AcceleratorServiceThread::stop() {
-  if (impl) {
-    impl->stop();
-    impl.reset();
-  }
-}
-
-// When there's data on any of the listenPorts, call the callback. This is
-// kinda silly now that we have callback port support, especially given the
-// polling loop. Keep the functionality for now.
-void AcceleratorServiceThread::addListener(
-    std::initializer_list<ReadChannelPort *> listenPorts,
-    std::function<void(ReadChannelPort *, MessageData)> callback) {
-  assert(impl && "Service thread not running");
-  impl->addListener(listenPorts, callback);
+void AcceleratorServiceThread::addTask(std::function<void(void)> task) {
+  std::lock_guard<std::mutex> g(m);
+  taskList.push_back(std::move(task));
 }
 
 void AcceleratorServiceThread::addPoll(HWModule &module) {
-  assert(impl && "Service thread not running");
-  impl->addTask([&module]() { module.poll(); });
+  addTask([&module]() { module.poll(); });
 }
 
 void AcceleratorConnection::disconnect() {


### PR DESCRIPTION
Add support for `AcceleratorConnections` to use their own threads (or something else entirely) for the `AcceleratorServiceThread`.

Assisted-by: Github-Copilot:Claude Opus 4.7