### PR TITLE
[ESI][Runtime] Limit to one outstanding MMIO xact

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
@@ -172,6 +172,12 @@ public:
   virtual BundlePort *getPort(AppIDPath id,
                               const BundleType *type) const override;
 
+protected:
+  // The current ESI hardware implementations only support one MMIO command at a
+  // time but don't enforce it. So we must grab a lock to enforce it on the
+  // software side.
+  mutable std::mutex mmioCmdLock;
+
 private:
   /// MMIO base address table.
   std::map<AppIDPath, RegionDescriptor> regions;

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -358,6 +358,7 @@ public:
   uint64_t read(uint32_t addr) const override {
     MMIOCmd cmd{.data = 0, .offset = addr, .write = false};
     auto arg = MessageData::from(cmd);
+    std::lock_guard<std::mutex> g(mmioCmdLock);
     std::future<MessageData> result = cmdMMIO->call(arg);
     result.wait();
     uint64_t ret = *result.get().as<uint64_t>();
@@ -380,6 +381,7 @@ public:
         });
     MMIOCmd cmd{.data = data, .offset = addr, .write = true};
     auto arg = MessageData::from(cmd);
+    std::lock_guard<std::mutex> g(mmioCmdLock);
     std::future<MessageData> result = cmdMMIO->call(arg);
     result.wait();
   }

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
@@ -130,7 +130,7 @@ public:
       : MMIO(conn, idPath, clients), ip(ip) {}
 
   uint64_t read(uint32_t addr) const override {
-    std::lock_guard<std::mutex> lock(m);
+    std::lock_guard<std::mutex> lock(mmioCmdLock);
 
     // Write the address to the indirect location register.
     xrt_write(IndirectLocation, addr);
@@ -146,7 +146,7 @@ public:
     return ret;
   }
   void write(uint32_t addr, uint64_t data) override {
-    std::lock_guard<std::mutex> lock(m);
+    std::lock_guard<std::mutex> lock(mmioCmdLock);
 
     // Write the address to the indirect location register.
     xrt_write(IndirectLocation, addr);
@@ -176,7 +176,6 @@ public:
 
 private:
   ::xrt::ip &ip;
-  mutable std::mutex m;
 };
 } // namespace
 

--- a/lib/Dialect/ESI/runtime/python/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/python/CMakeLists.txt
@@ -16,6 +16,7 @@ set(ESIPythonRuntimeSources
 
   esiaccel/components/__init__.py
   esiaccel/components/channel_arbiter.py
+  esiaccel/components/flow.py
 
   esiaccel/cosim/questa.py
   esiaccel/cosim/pytest.py

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -7,7 +7,7 @@ from math import ceil
 
 from pycde.common import Clock, Input, InputChannel, Output, OutputChannel, Reset
 from pycde.constructs import (AssignableSignal, ControlReg, Counter, Mux,
-                              NamedWire, Reg, Wire)
+                              NamedWire, Wire)
 from pycde import esi
 from pycde.module import Module, generator, modparams
 from pycde.signals import BitsSignal, ChannelSignal, StructSignal
@@ -15,6 +15,8 @@ from pycde.support import clog2
 from pycde.system import System
 from pycde.types import (Array, Bits, Bundle, BundledChannel, Channel,
                          ChannelDirection, StructType, Type, UInt, Window)
+
+from ..components.flow import MaxOutstandingLimiter
 
 from typing import Callable, Dict, List, Tuple
 import typing
@@ -417,70 +419,6 @@ def DesignResetController(
       ports.reset_pending = pending
 
   return DesignResetControllerImpl
-
-
-@modparams
-def MaxOutstandingLimiter(
-    data_type: Type, max_outstanding: int) -> type["MaxOutstandingLimiterImpl"]:
-  """Rate-limit a channel to at most `max_outstanding` outstanding
-  transactions. A transaction becomes outstanding when a message is accepted
-  on `in_` and remains outstanding until `complete` is pulsed. `in_` is
-  stalled whenever `max_outstanding` transactions are already outstanding.
-
-  `complete` must pulse for exactly one cycle per completed transaction and
-  must not pulse while zero transactions are outstanding; the module does not
-  check this. When an input transaction and a `complete` pulse occur on the
-  same cycle the outstanding count is left unchanged.
-  """
-
-  if max_outstanding < 1:
-    raise ValueError("'max_outstanding' must be at least 1.")
-
-  counter_width = clog2(max_outstanding + 1)
-
-  class MaxOutstandingLimiterImpl(Module):
-    clk = Clock()
-    rst = Reset()
-    in_ = InputChannel(data_type)
-    # One-cycle pulse per completed transaction.
-    complete = Input(Bits(1))
-    out = OutputChannel(data_type)
-
-    @generator
-    def build(ports):
-      clk = ports.clk
-      rst = ports.rst
-      complete = ports.complete
-
-      # Registered count of outstanding transactions. Uses a Wire so we can
-      # reference the current value while computing the next value.
-      count = Reg(UInt(counter_width), clk, rst, name="outstanding_next")
-
-      # Only accept a new transaction while below the limit.
-      can_issue = count < UInt(counter_width)(max_outstanding)
-
-      # Forward the input channel to the output, gated by 'can_issue'.
-      in_ready = Wire(Bits(1))
-      in_data, in_valid = ports.in_.unwrap(in_ready)
-      out_valid = (in_valid & can_issue).as_bits()
-      out_chan, out_ready = MaxOutstandingLimiterImpl.out.type.wrap(
-          in_data, out_valid)
-      in_ready.assign(out_ready & can_issue)
-      ports.out = out_chan
-
-      # +1 on an accepted input, -1 on a 'complete' pulse. If both occur on
-      # the same cycle the count is unchanged. 'can_issue' guarantees the
-      # counter never overflows; the caller guarantees it never underflows.
-      issue = out_valid & out_ready
-      up = issue & ~complete
-      down = complete & ~issue
-      one = UInt(counter_width)(1)
-      count_plus_1 = (count + one).as_uint(counter_width)
-      count_minus_1 = (count - one).as_uint(counter_width)
-      # up=1 -> count_plus_1; up=0, down=1 -> count_minus_1; else count.
-      count.assign(Mux(up, Mux(down, count, count_minus_1), count_plus_1))
-
-  return MaxOutstandingLimiterImpl
 
 
 class ChannelMMIO(esi.ServiceImplementation):

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -7,7 +7,7 @@ from math import ceil
 
 from pycde.common import Clock, Input, InputChannel, Output, OutputChannel, Reset
 from pycde.constructs import (AssignableSignal, ControlReg, Counter, Mux,
-                              NamedWire, Wire)
+                              NamedWire, Reg, Wire)
 from pycde import esi
 from pycde.module import Module, generator, modparams
 from pycde.signals import BitsSignal, ChannelSignal, StructSignal
@@ -419,6 +419,70 @@ def DesignResetController(
   return DesignResetControllerImpl
 
 
+@modparams
+def MaxOutstandingLimiter(
+    data_type: Type, max_outstanding: int) -> type["MaxOutstandingLimiterImpl"]:
+  """Rate-limit a channel to at most `max_outstanding` outstanding
+  transactions. A transaction becomes outstanding when a message is accepted
+  on `in_` and remains outstanding until `complete` is pulsed. `in_` is
+  stalled whenever `max_outstanding` transactions are already outstanding.
+
+  `complete` must pulse for exactly one cycle per completed transaction and
+  must not pulse while zero transactions are outstanding; the module does not
+  check this. When an input transaction and a `complete` pulse occur on the
+  same cycle the outstanding count is left unchanged.
+  """
+
+  if max_outstanding < 1:
+    raise ValueError("'max_outstanding' must be at least 1.")
+
+  counter_width = clog2(max_outstanding + 1)
+
+  class MaxOutstandingLimiterImpl(Module):
+    clk = Clock()
+    rst = Reset()
+    in_ = InputChannel(data_type)
+    # One-cycle pulse per completed transaction.
+    complete = Input(Bits(1))
+    out = OutputChannel(data_type)
+
+    @generator
+    def build(ports):
+      clk = ports.clk
+      rst = ports.rst
+      complete = ports.complete
+
+      # Registered count of outstanding transactions. Uses a Wire so we can
+      # reference the current value while computing the next value.
+      count = Reg(UInt(counter_width), clk, rst, name="outstanding_next")
+
+      # Only accept a new transaction while below the limit.
+      can_issue = count < UInt(counter_width)(max_outstanding)
+
+      # Forward the input channel to the output, gated by 'can_issue'.
+      in_ready = Wire(Bits(1))
+      in_data, in_valid = ports.in_.unwrap(in_ready)
+      out_valid = (in_valid & can_issue).as_bits()
+      out_chan, out_ready = MaxOutstandingLimiterImpl.out.type.wrap(
+          in_data, out_valid)
+      in_ready.assign(out_ready & can_issue)
+      ports.out = out_chan
+
+      # +1 on an accepted input, -1 on a 'complete' pulse. If both occur on
+      # the same cycle the count is unchanged. 'can_issue' guarantees the
+      # counter never overflows; the caller guarantees it never underflows.
+      issue = out_valid & out_ready
+      up = issue & ~complete
+      down = complete & ~issue
+      one = UInt(counter_width)(1)
+      count_plus_1 = (count + one).as_uint(counter_width)
+      count_minus_1 = (count - one).as_uint(counter_width)
+      # up=1 -> count_plus_1; up=0, down=1 -> count_minus_1; else count.
+      count.assign(Mux(up, Mux(down, count, count_minus_1), count_plus_1))
+
+  return MaxOutstandingLimiterImpl
+
+
 class ChannelMMIO(esi.ServiceImplementation):
   """MMIO service implementation with MMIO bundle interfaces. Should be
   relatively easy to adapt to physical interfaces by wrapping the wires to
@@ -429,8 +493,11 @@ class ChannelMMIO(esi.ServiceImplementation):
   and manifest do not support unaligned accesses and throw away the lower three
   bits.
 
-  Only allows for one outstanding request at a time. If a client doesn't return
-  a response, the MMIO service will hang. TODO: add some kind of timeout.
+  Only allows one outstanding request at a time. This is enforced in hardware
+  by a `MaxOutstandingLimiter` on the command channel, which stalls incoming
+  commands until the previous response has been consumed. If a client fails to
+  return a response, the MMIO service will hang. TODO: add some kind of
+  timeout.
 
   Implementation-defined MMIO layout:
     - 0x0: 0 constant
@@ -462,9 +529,6 @@ class ChannelMMIO(esi.ServiceImplementation):
   # be replaced by parameterizable services.
   # TODO: make the amount of register space each client gets a parameter.
   # Supporting this will require more address decode logic.
-  #
-  # TODO: only supports one outstanding transaction at a time. This is NOT
-  # enforced or checked! Enforce this.
 
   RegisterSpace = 0x400
   RegisterSpaceBits = RegisterSpace.bit_length() - 1
@@ -528,6 +592,21 @@ class ChannelMMIO(esi.ServiceImplementation):
     counted_output = Wire(Channel(esi.MMIODataType))
     cmd_channel = ports.cmd.unpack(data=counted_output)["cmd"]
     counted_output.assign(data_resp_channel)
+
+    # Enforce the single-outstanding-transaction invariant in hardware: hold
+    # off accepting a new command until the response to the previous command
+    # has been consumed by the host. Snoop the response wire for the
+    # completion pulse.
+    resp_xact, _ = counted_output.snoop_xact()
+    cmd_limiter = MaxOutstandingLimiter(cmd_channel.type.inner_type,
+                                        max_outstanding=1)(
+                                            clk=ports.clk,
+                                            rst=ports.rst,
+                                            in_=cmd_channel,
+                                            complete=resp_xact,
+                                            instance_name="cmd_rate_limiter",
+                                        )
+    cmd_channel = cmd_limiter.out
 
     # Get the selection index and the address to hand off to the clients.
     sel_bits, client_cmd_chan = ChannelMMIO.build_addr_read(

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/__init__.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/__init__.py
@@ -14,5 +14,6 @@
 # ===-----------------------------------------------------------------------===//
 
 from .channel_arbiter import ChannelArbiter, ChannelArbiterMod
+from .flow import MaxOutstandingLimiter
 
-__all__ = ["ChannelArbiter", "ChannelArbiterMod"]
+__all__ = ["ChannelArbiter", "ChannelArbiterMod", "MaxOutstandingLimiter"]

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/flow.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/flow.py
@@ -1,0 +1,80 @@
+# ===- flow.py - channel flow-control primitives ---------------------------===//
+#
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===//
+#
+#  Flow-control building blocks for ESI channels.
+#
+# ===-----------------------------------------------------------------------===//
+
+from pycde.common import Clock, Input, InputChannel, Output, OutputChannel, Reset
+from pycde.constructs import Mux, Reg, Wire
+from pycde.module import Module, generator, modparams
+from pycde.support import clog2
+from pycde.types import Bits, Type, UInt
+
+
+@modparams
+def MaxOutstandingLimiter(
+    data_type: Type, max_outstanding: int) -> type["MaxOutstandingLimiterImpl"]:
+  """Rate-limit a channel to at most `max_outstanding` outstanding
+  transactions. A transaction becomes outstanding when a message is accepted
+  on `in_` and remains outstanding until `complete` is pulsed. `in_` is
+  stalled whenever `max_outstanding` transactions are already outstanding.
+
+  `complete` must pulse for exactly one cycle per completed transaction and
+  must not pulse while zero transactions are outstanding; the module does not
+  check this. When an input transaction and a `complete` pulse occur on the
+  same cycle the outstanding count is left unchanged.
+  """
+
+  if max_outstanding < 1:
+    raise ValueError("'max_outstanding' must be at least 1.")
+
+  counter_width = clog2(max_outstanding + 1)
+
+  class MaxOutstandingLimiterImpl(Module):
+    clk = Clock()
+    rst = Reset()
+    in_ = InputChannel(data_type)
+    # One-cycle pulse per completed transaction.
+    complete = Input(Bits(1))
+    out = OutputChannel(data_type)
+
+    @generator
+    def build(ports):
+      clk = ports.clk
+      rst = ports.rst
+      complete = ports.complete
+
+      # Registered count of outstanding transactions.
+      count = Reg(UInt(counter_width), clk, rst, name="outstanding")
+
+      # Only accept a new transaction while below the limit.
+      can_issue = count < UInt(counter_width)(max_outstanding)
+
+      # Forward the input channel to the output, gated by 'can_issue'.
+      in_ready = Wire(Bits(1))
+      in_data, in_valid = ports.in_.unwrap(in_ready)
+      out_valid = (in_valid & can_issue).as_bits()
+      out_chan, out_ready = MaxOutstandingLimiterImpl.out.type.wrap(
+          in_data, out_valid)
+      in_ready.assign(out_ready & can_issue)
+      ports.out = out_chan
+
+      # +1 on an accepted input, -1 on a 'complete' pulse. If both occur on
+      # the same cycle the count is unchanged. 'can_issue' guarantees the
+      # counter never overflows; the caller guarantees it never underflows.
+      issue = out_valid & out_ready
+      up = issue & ~complete
+      down = complete & ~issue
+      one = UInt(counter_width)(1)
+      count_plus_1 = (count + one).as_uint(counter_width)
+      count_minus_1 = (count - one).as_uint(counter_width)
+      # up=1 -> count_plus_1; up=0, down=1 -> count_minus_1; else count.
+      count.assign(Mux(up, Mux(down, count, count_minus_1), count_plus_1))
+
+  return MaxOutstandingLimiterImpl


### PR DESCRIPTION
The ESI MMIO bus doesn't ensure that command responses return in the same order as the requests come in. So we are only correct for one at a time. Enforce this both in hardware and in software.

Assisted-by: Github-Copilot:Claude Opus 4.7

