### PR TITLE
[FIRRTL] Add firrtl-full-reset pass around runFullReset helper

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -360,6 +360,14 @@ def InferResets : Pass<"firrtl-infer-resets", "firrtl::CircuitOp"> {
   }];
 }
 
+def FullReset : Pass<"firrtl-full-reset", "firrtl::CircuitOp"> {
+  let summary = "Run full reset transform";
+  let description = [{
+    Consumes `circt.FullResetAnnotation` / `circt.ExcludeFromFullResetAnnotation`
+    Builds reset domains and implements full reset on registers.
+  }];
+}
+
 def BlackBoxReader : Pass<"firrtl-blackbox-reader", "CircuitOp"> {
   let summary = "Load source files for black boxes into the IR";
   let description = [{

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   ExtractInstances.cpp
   FinalizeIR.cpp
   FlattenMemory.cpp
+  FullReset.cpp
   GrandCentral.cpp
   IMConstProp.cpp
   IMDeadCodeElim.cpp

--- a/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the FullReset pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace firrtl {
+#define GEN_PASS_DEF_FULLRESET
+#include "circt/Dialect/FIRRTL/Passes.h.inc"
+} // namespace firrtl
+} // namespace circt
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct FullResetPass
+    : public circt::firrtl::impl::FullResetBase<FullResetPass> {
+  using FullResetBase::FullResetBase;
+
+  void runOnOperation() override {
+    auto &ig = getAnalysis<InstanceGraph>();
+    if (failed(runFullReset(getOperation(), ig)))
+      return signalPassFailure();
+    markAnalysesPreserved<InstanceGraph>();
+  }
+};
+} // namespace

--- a/test/Dialect/FIRRTL/full-reset.mlir
+++ b/test/Dialect/FIRRTL/full-reset.mlir
@@ -1,0 +1,48 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-full-reset))' --split-input-file %s | FileCheck %s
+
+// Basic async full-reset: reset-less register becomes regreset.
+// CHECK-LABEL: firrtl.module @AsyncFullReset
+firrtl.circuit "AsyncFullReset" {
+  firrtl.module @AsyncFullReset(
+      in %clock: !firrtl.clock,
+      in %reset: !firrtl.asyncreset
+          [{class = "circt.FullResetAnnotation", resetType = "async"}],
+      in %in: !firrtl.uint<8>) {
+    // CHECK: %reg = firrtl.regreset %clock, %reset, %c0_ui8
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %reg, %in : !firrtl.uint<8>
+  }
+}
+
+// -----
+// Exclude annotation is consumed; registers stay reset-less.
+// CHECK-LABEL: firrtl.module @Excluded
+// CHECK-NOT: ExcludeFromFullResetAnnotation
+// CHECK: %reg = firrtl.reg %clock
+firrtl.circuit "Excluded" {
+  firrtl.module @Excluded(in %clock: !firrtl.clock, in %in: !firrtl.uint<8>)
+      attributes {annotations = [{class = "circt.ExcludeFromFullResetAnnotation"}]} {
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+    firrtl.matchingconnect %reg, %in : !firrtl.uint<8>
+  }
+}
+
+// -----
+// Child inherits async domain; reset is wired through an added port.
+// CHECK-LABEL: firrtl.module @Child
+// CHECK-SAME: in %reset: !firrtl.asyncreset
+// CHECK: %reg = firrtl.regreset %clock, %reset, %c0_ui8
+// CHECK-LABEL: firrtl.module @Nested
+// CHECK: firrtl.matchingconnect %child_reset, %reset
+firrtl.circuit "Nested" {
+  firrtl.module @Child(in %clock: !firrtl.clock) {
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+  }
+  firrtl.module @Nested(
+      in %clock: !firrtl.clock,
+      in %reset: !firrtl.asyncreset
+          [{class = "circt.FullResetAnnotation", resetType = "async"}]) {
+    %child_clock = firrtl.instance child @Child(in clock: !firrtl.clock)
+    firrtl.matchingconnect %child_clock, %clock : !firrtl.clock
+  }
+}


### PR DESCRIPTION
Introduce a thin FullReset pass that calls the existing runFullReset helper. 

Assited-by: pi.dev: gpt-5.4

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
