### PR TITLE
[FIRRTL] Optionally convert async-domain comb mems in runFullReset

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -26,6 +26,7 @@ class Pass;
 namespace circt {
 namespace firrtl {
 class InstanceGraph;
+class InstanceInfo;
 
 /// Configure which aggregate values will be preserved by the LowerTypes pass.
 namespace PreserveAggregate {
@@ -87,7 +88,9 @@ enum class InferDomainsMode {
 
 void runCombMemsToRegOfVec(FModuleOp mod, bool ignoreReadEnable,
                            unsigned &numConverted);
-LogicalResult runFullReset(CircuitOp circuit, InstanceGraph &ig);
+LogicalResult runFullReset(CircuitOp circuit, InstanceGraph &ig,
+                           InstanceInfo &instanceInfo,
+                           bool convertAsyncDomainMems = false);
 
 #define GEN_PASS_DECL
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Analysis/FIRRTLInstanceInfo.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/Pass/Pass.h"
@@ -31,9 +32,11 @@ struct FullResetPass
 
   void runOnOperation() override {
     auto &ig = getAnalysis<InstanceGraph>();
-    if (failed(runFullReset(getOperation(), ig)))
+    auto &instanceInfo = getAnalysis<InstanceInfo>();
+    if (failed(runFullReset(getOperation(), ig, instanceInfo,
+                            /*convertAsyncDomainMems=*/true)))
       return signalPassFailure();
-    markAnalysesPreserved<InstanceGraph>();
+    markAnalysesPreserved<InstanceGraph, InstanceInfo>();
   }
 };
 } // namespace

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Analysis/FIRRTLInstanceInfo.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
@@ -519,7 +520,8 @@ void InferResetsPass::runOnOperationInner() {
   if (failed(inferAndUpdateResets()))
     return signalPassFailure();
 
-  if (failed(runFullReset(getOperation(), *instanceGraph)))
+  if (failed(runFullReset(getOperation(), *instanceGraph,
+                          getAnalysis<InstanceInfo>())))
     return signalPassFailure();
 
   // Require that no Abstract Resets exist on ports in the design.
@@ -1253,9 +1255,11 @@ bool InferResetsPass::updateReset(FieldRef field, FIRRTLBaseType resetType) {
 namespace {
 struct FullResetRunner {
   FullResetRunner(CircuitOp circuit, InstanceGraph &ig,
-                  InstancePathCache &instancePathCache)
+                  InstancePathCache &instancePathCache,
+                  InstanceInfo &instanceInfo, bool convertAsyncDomainMems)
       : circuit(circuit), instanceGraph(&ig),
-        instancePathCache(&instancePathCache) {}
+        instancePathCache(&instancePathCache), instanceInfo(&instanceInfo),
+        convertAsyncDomainMems(convertAsyncDomainMems) {}
 
   LogicalResult run();
 
@@ -1274,6 +1278,8 @@ struct FullResetRunner {
   void buildDomains(FModuleOp module, const InstancePath &instPath,
                     Value parentReset, InstanceGraph &instGraph,
                     unsigned indent = 0);
+
+  void convertMemsInAsyncDomains();
 
   LogicalResult determineImpl();
   LogicalResult determineImpl(FModuleOp module, ResetDomain &domain);
@@ -1304,6 +1310,10 @@ struct FullResetRunner {
 
   /// Cache of instance paths.
   InstancePathCache *instancePathCache = nullptr;
+
+  InstanceInfo *instanceInfo = nullptr;
+
+  bool convertAsyncDomainMems = false;
 };
 } // namespace
 
@@ -1312,6 +1322,8 @@ LogicalResult FullResetRunner::run() {
     return failure();
   if (failed(buildDomains()))
     return failure();
+  if (convertAsyncDomainMems)
+    convertMemsInAsyncDomains();
   if (failed(determineImpl()))
     return failure();
   if (failed(implementFullReset()))
@@ -1319,10 +1331,44 @@ LogicalResult FullResetRunner::run() {
   return success();
 }
 
-LogicalResult circt::firrtl::runFullReset(CircuitOp circuit,
-                                          InstanceGraph &ig) {
+void FullResetRunner::convertMemsInAsyncDomains() {
+  SmallVector<FModuleOp> asyncDomainMods;
+  for (auto &[mod, entries] : domains) {
+    if (entries.empty())
+      continue;
+    auto &domain = entries.back().first;
+    if (!domain.rootReset)
+      continue;
+    if (!type_isa<AsyncResetType>(domain.resetType))
+      continue;
+    if (!instanceInfo->anyInstanceInEffectiveDesign(mod))
+      continue;
+    asyncDomainMods.push_back(mod);
+  }
+  if (asyncDomainMods.empty())
+    return;
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n";
+    debugHeader("Convert comb mems in async full-reset domains") << "\n\n";
+    for (auto mod : asyncDomainMods)
+      llvm::dbgs() << "- " << mod.getName() << "\n";
+  });
+
+  mlir::parallelForEach(
+      circuit.getContext(), asyncDomainMods, [&](FModuleOp mod) {
+        unsigned converted = 0;
+        runCombMemsToRegOfVec(mod, /*ignoreReadEnable=*/false, converted);
+      });
+}
+
+LogicalResult circt::firrtl::runFullReset(CircuitOp circuit, InstanceGraph &ig,
+                                          InstanceInfo &instanceInfo,
+                                          bool convertAsyncDomainMems) {
   InstancePathCache instancePathCache(ig);
-  return FullResetRunner(circuit, ig, instancePathCache).run();
+  return FullResetRunner(circuit, ig, instancePathCache, instanceInfo,
+                         convertAsyncDomainMems)
+      .run();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/full-reset.mlir
+++ b/test/Dialect/FIRRTL/full-reset.mlir
@@ -46,3 +46,45 @@ firrtl.circuit "Nested" {
     firrtl.matchingconnect %child_clock, %clock : !firrtl.clock
   }
 }
+
+// -----
+// Comb mems in async full-reset domains become resettable registers.
+// CHECK-LABEL: firrtl.module @AsyncDomainMem
+// CHECK-NOT: firrtl.mem
+// CHECK: firrtl.regreset
+firrtl.circuit "AsyncDomainMem" {
+  firrtl.module @AsyncDomainMem(
+      in %clock: !firrtl.clock,
+      in %reset: !firrtl.asyncreset
+          [{class = "circt.FullResetAnnotation", resetType = "async"}]) {
+    %mem_read, %mem_write = firrtl.mem Undefined {
+      depth = 4 : i64,
+      name = "mem",
+      portNames = ["read", "write"],
+      readLatency = 0 : i32,
+      writeLatency = 1 : i32
+    } : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<8>>,
+        !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+  }
+}
+
+// -----
+// Sync full-reset domains keep comb mems.
+// CHECK-LABEL: firrtl.module @SyncDomainMem
+// CHECK: firrtl.mem
+// CHECK-NOT: firrtl.reg
+firrtl.circuit "SyncDomainMem" {
+  firrtl.module @SyncDomainMem(
+      in %clock: !firrtl.clock,
+      in %reset: !firrtl.uint<1>
+          [{class = "circt.FullResetAnnotation", resetType = "sync"}]) {
+    %mem_read, %mem_write = firrtl.mem Undefined {
+      depth = 4 : i64,
+      name = "mem",
+      portNames = ["read", "write"],
+      readLatency = 0 : i32,
+      writeLatency = 1 : i32
+    } : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<8>>,
+        !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+  }
+}


### PR DESCRIPTION
Add a convertAsyncDomainMems flag to runFullReset. When enabled, convert combinational memories in asynchronous full-reset domains that are in the effective design, in parallel which performs the same in the existing MemToReg. 

Optionality will be removed in the last step of migration. 

Assited-by: pi.dev: gpt-5.4

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
