### PR TITLE
[OM][NFCI] Simplify evaluator parameter storage

### DIFF
--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -396,24 +396,12 @@ public:
   FailureOr<evaluator::EvaluatorValuePtr>
   getPartiallyEvaluatedValue(Type type, Location loc);
 
-  using ActualParameters =
-      SmallVectorImpl<std::shared_ptr<evaluator::EvaluatorValue>> *;
-
-  using ObjectKey = std::pair<Value, ActualParameters>;
+  using ActualParameters = ArrayRef<EvaluatorValuePtr>;
 
   /// Get the number of fully evaluated nodes tracked by this evaluator.
   uint64_t getFullyEvaluatedCount() const { return fullyEvaluatedCount; }
 
 private:
-  bool isFullyEvaluated(Value value, ActualParameters key) {
-    return isFullyEvaluated({value, key});
-  }
-
-  bool isFullyEvaluated(ObjectKey key) {
-    auto val = objects.lookup(key);
-    return val && val->isFullyEvaluated();
-  }
-
   /// Attach the evaluation counter to a newly created value.
   void attachCounter(evaluator::EvaluatorValuePtr &value) {
     if (value && !value->isFullyEvaluated())
@@ -443,7 +431,7 @@ private:
   /// Instantiate an Object with its class name and actual parameters.
   FailureOr<EvaluatorValuePtr>
   evaluateObjectInstance(StringAttr className, ActualParameters actualParams,
-                         Location loc, ObjectKey instanceKey = {});
+                         Location loc);
   FailureOr<EvaluatorValuePtr>
   evaluateElaboratedObject(ElaboratedObjectOp op, ActualParameters actualParams,
                            Location loc);
@@ -472,20 +460,14 @@ private:
   /// Used to look up class definitions.
   SymbolTable symbolTable;
 
-  /// This uniquely stores vectors that represent parameters.
-  SmallVector<
-      std::unique_ptr<SmallVector<std::shared_ptr<evaluator::EvaluatorValue>>>>
-      actualParametersBuffers;
-
   /// Worklists that track values which need to be fully evaluated.
   /// We use two worklists to detect cycles: process all items from one,
   /// and if any become fully evaluated, swap and continue.
-  std::vector<ObjectKey> worklist;
-  std::vector<ObjectKey> nextWorklist;
+  std::vector<Value> worklist;
+  std::vector<Value> nextWorklist;
 
-  /// Evaluator value storage. Return an evaluator value for the given
-  /// instantiation context (a pair of Value and parameters).
-  DenseMap<ObjectKey, std::shared_ptr<evaluator::EvaluatorValue>> objects;
+  /// Evaluator value storage for the current instantiation.
+  DenseMap<Value, std::shared_ptr<evaluator::EvaluatorValue>> objects;
 
   /// Counter for fully evaluated nodes.
   uint64_t fullyEvaluatedCount = 0;

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -400,7 +400,7 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
     Value value, ActualParameters actualParams, Location loc) {
   LLVM_DEBUG(dbgs() << "- get: " << value << "\n");
 
-  auto it = objects.find({value, actualParams});
+  auto it = objects.find(value);
   if (it != objects.end()) {
     auto evalVal = it->second;
     evalVal->setLocIfUnknown(loc);
@@ -410,9 +410,7 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
   FailureOr<evaluator::EvaluatorValuePtr> result =
       TypeSwitch<Value, FailureOr<evaluator::EvaluatorValuePtr>>(value)
           .Case([&](BlockArgument arg) {
-            auto val = (*actualParams)[arg.getArgNumber()];
-            val->setLoc(loc);
-            return val;
+            return evaluateParameter(arg, actualParams, loc);
           })
           .Case([&](OpResult result) {
             return TypeSwitch<Operation *,
@@ -463,15 +461,14 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
 
   // Attach listener to newly created values
   attachCounter(result.value());
-  objects[{value, actualParams}] = result.value();
+  objects[value] = result.value();
   return result;
 }
 
 FailureOr<evaluator::EvaluatorValuePtr>
 circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
                                              ActualParameters actualParams,
-                                             Location loc,
-                                             ObjectKey instanceKey) {
+                                             Location loc) {
 #ifndef NDEBUG
   DebugNesting nestOne(debugNesting);
 #endif
@@ -498,7 +495,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
   // Otherwise, it's a regular class, proceed normally
   ClassOp cls = cast<ClassOp>(classDef);
 
-  if (failed(verifyActualParameters(cls, *actualParams)))
+  if (failed(verifyActualParameters(cls, actualParams)))
     return failure();
 
   // Instantiate the fields.
@@ -518,7 +515,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
                                     UnknownLoc::get(context))))
           return failure();
         // Add to the worklist.
-        worklist.push_back({result, actualParams});
+        worklist.push_back(result);
       }
   }
 
@@ -541,16 +538,6 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
 
     LLVM_DEBUG(dbgs() << "value: " << result.value() << "\n");
     fields[cast<StringAttr>(name)] = result.value();
-  }
-
-  // If the there is an instance, we must update the object value.
-  LLVM_DEBUG(dbgs() << "object value:\n");
-  if (instanceKey.first) {
-    auto result =
-        getOrCreateValue(instanceKey.first, instanceKey.second, loc).value();
-    auto *object = llvm::cast<evaluator::ObjectValue>(result.get());
-    object->setFields(std::move(fields));
-    return result;
   }
 
   // If it's external call, just allocate new ObjectValue.
@@ -620,16 +607,9 @@ circt::om::Evaluator::instantiateImpl(
   // Otherwise, it's a regular class, proceed normally
   ClassOp cls = cast<ClassOp>(classDef);
 
-  auto parameters =
-      std::make_unique<SmallVector<std::shared_ptr<evaluator::EvaluatorValue>>>(
-          actualParams);
-
-  actualParametersBuffers.push_back(std::move(parameters));
-
   auto loc = cls.getLoc();
   LLVM_DEBUG(dbgs() << "evaluate object:\n");
-  auto result = evaluateObjectInstance(
-      className, actualParametersBuffers.back().get(), loc);
+  auto result = evaluateObjectInstance(className, actualParams, loc);
 
   if (failed(result))
     return failure();
@@ -649,16 +629,16 @@ circt::om::Evaluator::instantiateImpl(
 
     // Process all items in the current worklist.
     while (!worklist.empty()) {
-      auto [value, args] = worklist.back();
+      auto value = worklist.back();
       worklist.pop_back();
-      auto result = evaluateValue(value, args, loc);
+      auto result = evaluateValue(value, actualParams, loc);
 
       if (failed(result))
         return failure();
 
       // If not fully evaluated, add to next worklist for retry.
       if (!result.value()->isFullyEvaluated())
-        nextWorklist.push_back({value, args});
+        nextWorklist.push_back(value);
     }
 
     // Check if we made progress.
@@ -797,7 +777,7 @@ circt::om::Evaluator::evaluateElaboratedObject(ElaboratedObjectOp op,
       return failure();
 
     if (!fieldResult.value()->isFullyEvaluated())
-      worklist.push_back({fieldValue, actualParams});
+      worklist.push_back(fieldValue);
 
     fields[cast<StringAttr>(fieldName)] = fieldResult.value();
   }

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -728,7 +728,7 @@ circt::om::Evaluator::evaluateValue(Value value, ActualParameters actualParams,
 /// Evaluator dispatch function for parameters.
 FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateParameter(
     BlockArgument formalParam, ActualParameters actualParams, Location loc) {
-  auto val = (*actualParams)[formalParam.getArgNumber()];
+  auto val = actualParams[formalParam.getArgNumber()];
   val->setLoc(loc);
   return success(val);
 }


### PR DESCRIPTION
In an old implementation it was necessary to use `<Object, Arguments>` as a key for result dense map because classes could be instantiated in different context in memory. However in a new implementation every object is properly inlined in Elaboration transform, so it's not necessary to record arguments anymore. 

This is NFCI. 

Split from https://github.com/llvm/circt/pull/10555.

Assisted-by: pi.dev: gpt-5.6 luna

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
