### PR TITLE
[DatapathToComb] Improve datapath lowering by using known bits before creating logic

### DIFF
--- a/include/circt/Dialect/Datapath/DatapathOps.h
+++ b/include/circt/Dialect/Datapath/DatapathOps.h
@@ -32,7 +32,7 @@ class CompressorTree {
 public:
   // Constructor takes addends as input and converts to column representation
   CompressorTree(size_t width, const SmallVector<SmallVector<Value>> &addends,
-                 Location loc);
+                 Location loc, OpBuilder &builder);
 
   // Get the number of columns (bit positions)
   size_t getWidth() const { return columns.size(); }

--- a/integration_test/circt-synth/datapath-lowering-lec.mlir
+++ b/integration_test/circt-synth/datapath-lowering-lec.mlir
@@ -125,10 +125,12 @@ hw.module @compress_6(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4
   hw.output %1 : i4
 }
 
+// Keep the constants separated by non-constant operands so canonicalization
+// cannot fold the compressor to an adder before conversion.
 // RUN: circt-lec.sh %t.mlir %s -c1=compress_known_ones -c2=compress_known_ones
-hw.module @compress_known_ones(in %a : i4, out sum : i4) {
+hw.module @compress_known_ones(in %a : i4, in %b : i4, out sum : i4) {
   %c15_i4 = hw.constant 15 : i4
-  %0:2 = datapath.compress %a, %c15_i4, %c15_i4 : i4 [3 -> 2]
+  %0:2 = datapath.compress %a, %c15_i4, %b, %c15_i4 : i4 [4 -> 2]
   %1 = comb.add bin %0#0, %0#1 : i4
   hw.output %1 : i4
 }

--- a/integration_test/circt-synth/datapath-lowering-lec.mlir
+++ b/integration_test/circt-synth/datapath-lowering-lec.mlir
@@ -25,6 +25,15 @@ hw.module @partial_product_zext(in %a : i3, in %b : i3, out sum : i6) {
   hw.output %3 : i6
 }
 
+// RUN: circt-lec.sh %t.mlir %s -c1=partial_product_known_bits -c2=partial_product_known_bits
+hw.module @partial_product_known_bits(in %a : i3, in %b : i1, out sum : i3) {
+  %c2_i2 = hw.constant 2 : i2
+  %0 = comb.concat %b, %c2_i2 : i1, i2
+  %1:3 = datapath.partial_product %a, %0 : (i3, i3) -> (i3, i3, i3)
+  %2 = comb.add %1#0, %1#1, %1#2 : i3
+  hw.output %2 : i3
+}
+
 // RUN: circt-lec.sh %t.mlir %s -c1=partial_product_square -c2=partial_product_square
 hw.module @partial_product_square(in %a : i4, out sum : i4) {
   %0:4 = datapath.partial_product %a, %a : (i4, i4) -> (i4, i4, i4, i4)
@@ -113,6 +122,14 @@ hw.module @compress_3(in %a : i4, in %b : i4, in %c : i4, out sum : i4) {
 hw.module @compress_6(in %a : i4, in %b : i4, in %c : i4, in %d : i4, in %e : i4, in %f : i4, out sum : i4) {
   %0:3 = datapath.compress %a, %b, %c, %d, %e, %f : i4 [6 -> 3]
   %1 = comb.add bin %0#0, %0#1, %0#2 : i4
+  hw.output %1 : i4
+}
+
+// RUN: circt-lec.sh %t.mlir %s -c1=compress_known_ones -c2=compress_known_ones
+hw.module @compress_known_ones(in %a : i4, out sum : i4) {
+  %c15_i4 = hw.constant 15 : i4
+  %0:2 = datapath.compress %a, %c15_i4, %c15_i4 : i4 [3 -> 2]
+  %1 = comb.add bin %0#0, %0#1 : i4
   hw.output %1 : i4
 }
 

--- a/lib/Conversion/CombToSynth/CombToSynth.cpp
+++ b/lib/Conversion/CombToSynth/CombToSynth.cpp
@@ -1047,7 +1047,7 @@ struct CombMulOpConversion : OpConversionPattern<MulOp> {
     }
 
     // Wallace tree reduction - reduce to two addends.
-    datapath::CompressorTree comp(width, partialProducts, loc);
+    datapath::CompressorTree comp(width, partialProducts, loc, rewriter);
     auto addends = comp.compressToHeight(rewriter, 2);
 
     // Sum the two addends using a carry-propagate adder

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -113,7 +113,7 @@ struct DatapathCompressOpConversion : mlir::OpRewritePattern<CompressOp> {
     // Compressor tree reduction
     auto width = inputs[0].getType().getIntOrFloatBitWidth();
     auto targetAddends = op.getNumResults();
-    datapath::CompressorTree comp(width, addends, loc);
+    datapath::CompressorTree comp(width, addends, loc, rewriter);
 
     if (analysis) {
       // Update delay information with arrival times
@@ -182,6 +182,7 @@ private:
     Location loc = op.getLoc();
     // Keep a as a bitvector - multiply by each digit of b
     SmallVector<Value> bBits = extractBits(rewriter, b);
+    auto knownBitsB = comb::computeKnownBits(b);
 
     auto rowWidth = width;
     auto knownBitsA = comb::computeKnownBits(a);
@@ -200,9 +201,24 @@ private:
            "Cannot return more results than the operator width");
 
     for (unsigned i = 0; i < op.getNumResults(); ++i) {
-      auto repl =
-          rewriter.createOrFold<comb::ReplicateOp>(loc, bBits[i], rowWidth);
-      auto ppRow = rewriter.createOrFold<comb::AndOp>(loc, repl, a);
+      // Constuct partial product row for bit i of b.
+      Value ppRow;
+
+      // Skip generation of zero rows.
+      if (knownBitsB.Zero[i]) {
+        partialProducts.push_back(
+            hw::ConstantOp::create(rewriter, loc, APInt(width, 0)));
+        continue;
+      }
+
+      // If the bit is known to be one, just use `a` as the partial product row.
+      if (knownBitsB.One[i]) {
+        ppRow = a;
+      } else {
+        auto repl =
+            rewriter.createOrFold<comb::ReplicateOp>(loc, bBits[i], rowWidth);
+        ppRow = rewriter.createOrFold<comb::AndOp>(loc, repl, a);
+      }
       if (rowWidth < width) {
         auto padding = width - rowWidth;
         auto zeroPad = hw::ConstantOp::create(rewriter, loc, APInt(padding, 0));

--- a/lib/Dialect/Datapath/DatapathOps.cpp
+++ b/lib/Dialect/Datapath/DatapathOps.cpp
@@ -114,9 +114,11 @@ CompressorTree::halfAdderWithDelay(OpBuilder &builder, CompressorBit a,
 // Map input rows to column representation
 CompressorTree::CompressorTree(size_t width,
                                const SmallVector<SmallVector<Value>> &addends,
-                               Location loc)
+                               Location loc, OpBuilder &builder)
     : columns(width), width(width), numStages(0), numFullAdders(0), loc(loc) {
   assert(!addends.empty());
+
+  SmallVector<size_t> constantOnes(width, 0);
 
   // Convert addends rows to columns
   // Known bits analysis constructs a minimal array - skipping zeros
@@ -125,14 +127,33 @@ CompressorTree::CompressorTree(size_t width,
     // Compressors will be formed of uniform bitwidth addends
     assert(row.size() == width);
     for (size_t i = 0; i < width; ++i) {
-      CompressorBit bit = {row[i], 0};
-      // TODO: Fold Constant 1s
-      auto knownBits = comb::computeKnownBits(bit.val);
+      auto knownBits = comb::computeKnownBits(row[i]);
       if (knownBits.isZero())
         continue;
+      if (knownBits.isAllOnes()) {
+        ++constantOnes[i];
+        continue;
+      }
       // Add non-zero bit to the column
+      CompressorBit bit = {row[i], 0};
       columns[i].push_back(bit);
     }
+  }
+
+  // Fold constant one bits into a binary carry chain before tree reduction.
+  // Two ones in column i are equivalent to one carry into column i+1; `carry`
+  // tracks those propagated known-one bits from lower columns.
+  Value trueValue;
+  size_t carry = 0;
+  for (size_t i = 0; i < width; ++i) {
+    size_t ones = constantOnes[i] + carry;
+    if (ones % 2) {
+      if (!trueValue)
+        trueValue = hw::ConstantOp::create(builder, loc, APInt(1, 1));
+      columns[i].push_back(CompressorBit{trueValue, 0});
+    }
+    // Each pair of ones contributes a carry to the next column.
+    carry = ones / 2;
   }
 }
 

--- a/lib/Dialect/Datapath/DatapathOps.cpp
+++ b/lib/Dialect/Datapath/DatapathOps.cpp
@@ -127,10 +127,10 @@ CompressorTree::CompressorTree(size_t width,
     // Compressors will be formed of uniform bitwidth addends
     assert(row.size() == width);
     for (size_t i = 0; i < width; ++i) {
-      auto knownBits = comb::computeKnownBits(row[i]);
-      if (knownBits.isZero())
+      auto knownBit = comb::computeKnownBits(row[i]);
+      if (knownBit.isZero())
         continue;
-      if (knownBits.isAllOnes()) {
+      if (knownBit.isAllOnes()) {
         ++constantOnes[i];
         continue;
       }

--- a/test/Conversion/DatapathToComb/datapath-to-comb.mlir
+++ b/test/Conversion/DatapathToComb/datapath-to-comb.mlir
@@ -35,6 +35,18 @@ hw.module @compressor_add(in %a : i2, in %b : i2, in %c : i2, out carry : i2, ou
   hw.output %0#0, %0#1 : i2, i2
 }
 
+// CHECK-LABEL: @compress_const_ones
+hw.module @compress_const_ones(in %a : i2, out carry : i2, out save : i2) {
+  // CHECK-NEXT: %[[TWO:.+]] = hw.constant -2 : i2
+  // CHECK-NEXT: %[[A0:.+]] = comb.extract %a from 0 : (i2) -> i1
+  // CHECK-NEXT: %[[A1:.+]] = comb.extract %a from 1 : (i2) -> i1
+  // CHECK-NEXT: %[[A:.+]] = comb.concat %[[A1]], %[[A0]] : i1, i1
+  // CHECK-NEXT: hw.output %[[A]], %[[TWO]] : i2, i2
+  %c3_i2 = hw.constant 3 : i2
+  %0:2 = datapath.compress %a, %c3_i2, %c3_i2 : i2 [3 -> 2]
+  hw.output %0#0, %0#1 : i2, i2
+}
+
 // CHECK-LABEL: @partial_product
 hw.module @partial_product(in %a : i3, in %b : i3, out pp0 : i3, out pp1 : i3, out pp2 : i3) {
   // CHECK-NEXT: %c0_i2 = hw.constant 0 : i2
@@ -53,6 +65,27 @@ hw.module @partial_product(in %a : i3, in %b : i3, out pp0 : i3, out pp1 : i3, o
   // CHECK-NEXT: %[[CONCAT2:.+]] = comb.concat %[[PP2]], %c0_i2 : i3, i2
   // CHECK-NEXT: comb.extract %[[CONCAT2]] from 0 : (i5) -> i3
   %0:3 = datapath.partial_product %a, %b : (i3, i3) -> (i3, i3, i3)
+  hw.output %0#0, %0#1, %0#2 : i3, i3, i3
+}
+
+// CHECK-LABEL: @partial_product_partial_known_bits
+hw.module @partial_product_partial_known_bits(in %a : i3, in %x : i1, out pp0 : i3, out pp1 : i3, out pp2 : i3) {
+  // CHECK: %[[ZERO2:.+]] = hw.constant 0 : i2
+  // CHECK: %false = hw.constant false
+  // CHECK: %[[ZERO3:.+]] = hw.constant 0 : i3
+  // CHECK: %[[TWO:.+]] = hw.constant -2 : i2
+  // CHECK: %[[IN:.+]] = comb.concat %x, %[[TWO]] : i1, i2
+  // CHECK: %[[B2:.+]] = comb.extract %[[IN]] from 2 : (i3) -> i1
+  // CHECK: %[[ROW1S:.+]] = comb.concat %a, %false : i3, i1
+  // CHECK: %[[ROW1:.+]] = comb.extract %[[ROW1S]] from 0 : (i4) -> i3
+  // CHECK: %[[B2R:.+]] = comb.replicate %[[B2]] : (i1) -> i3
+  // CHECK: %[[PP2:.+]] = comb.and %[[B2R]], %a : i3
+  // CHECK: %[[ROW2S:.+]] = comb.concat %[[PP2]], %[[ZERO2]] : i3, i2
+  // CHECK: %[[ROW2:.+]] = comb.extract %[[ROW2S]] from 0 : (i5) -> i3
+  // CHECK: hw.output %[[ZERO3]], %[[ROW1]], %[[ROW2]] : i3, i3, i3
+  %c2_i2 = hw.constant 2 : i2
+  %in = comb.concat %x, %c2_i2 : i1, i2
+  %0:3 = datapath.partial_product %a, %in : (i3, i3) -> (i3, i3, i3)
   hw.output %0#0, %0#1, %0#2 : i3, i3, i3
 }
 


### PR DESCRIPTION
Previously, partial-product and compressor lowering generated normal logic even when rhs bits are known to be one.

 This change uses known bits earlier: zero partial products become zero, one partial products use the input directly, and constant-one compressor bits are folded into carries.

  For a mixed-constant multiplication, this reduces AIG nodes from 726 to 691 and path delay from 22 to 21. 
```sv
module mul_const_mix(   // bar.mlir:1:1
  input  [3:0]  a,      // bar.mlir:1:29
  input  [4:0]  b,      // bar.mlir:1:40
  input  [3:0]  c,      // bar.mlir:1:51
  input  [4:0]  d,      // bar.mlir:1:62
  output [15:0] result  // bar.mlir:1:74
);

  assign result = {a, 4'hF, c, 4'hF} * {b, 3'h7, d, 3'h0};      // bar.mlir:2:15, :3:14, :4:14, :7:12, :10:12, :11:12, :12:5
endmodule
```

Assisted-by: codex: gpt-5.6 sol
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
