### PR TITLE
[CMake] Link LLVM libraries via LLVM_LINK_COMPONENTS

### DIFF
--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -1,14 +1,17 @@
 if(ARCILATOR_JIT_ENABLED)
   add_compile_definitions(ARCILATOR_ENABLE_JIT)
-  set(ARCILATOR_JIT_LLVM_COMPONENTS native)
+  set(ARCILATOR_JIT_LLVM_COMPONENTS native OrcJIT)
   set(ARCILATOR_JIT_DEPS
     CIRCTArcJITRuntime
-    LLVMOrcJIT
     MLIRExecutionEngine
   )
 endif()
 
-set(LLVM_LINK_COMPONENTS Support ${ARCILATOR_JIT_LLVM_COMPONENTS})
+set(LLVM_LINK_COMPONENTS
+  Support
+  TargetParser
+  ${ARCILATOR_JIT_LLVM_COMPONENTS}
+)
 
 set(libs
   CIRCTArc
@@ -28,7 +31,6 @@ set(libs
   CIRCTSupport
   CIRCTTransforms
   CIRCTVerif
-  LLVMTargetParser
   MLIRArithDialect
   MLIRBuiltinToLLVMIRTranslation
   MLIRControlFlowDialect

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -1,8 +1,7 @@
 if(MLIR_ENABLE_EXECUTION_ENGINE)
   add_compile_definitions(CIRCT_BMC_ENABLE_JIT)
-  set(CIRCT_BMC_JIT_LLVM_COMPONENTS native)
+  set(CIRCT_BMC_JIT_LLVM_COMPONENTS native OrcJIT)
   set(CIRCT_BMC_JIT_DEPS
-    LLVMOrcJIT
     MLIRExecutionEngine
     MLIRExecutionEngineUtils
   )
@@ -30,7 +29,6 @@ target_link_libraries(circt-bmc
   CIRCTVerif
   CIRCTVerifToSMT
   CIRCTVerifTransforms
-  LLVMSupport
   MLIRArithDialect
   MLIRBuiltinToLLVMIRTranslation
   MLIRFuncDialect

--- a/tools/circt-lec/CMakeLists.txt
+++ b/tools/circt-lec/CMakeLists.txt
@@ -28,7 +28,6 @@ target_link_libraries(circt-lec
   CIRCTSupport
   CIRCTVerif
   CIRCTVerifToSMT
-  LLVMSupport
   MLIRArithDialect
   MLIRBuiltinToLLVMIRTranslation
   MLIRFuncDialect

--- a/tools/circt-synth/CMakeLists.txt
+++ b/tools/circt-synth/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(LLVM_LINK_COMPONENTS Support)
+
 add_circt_tool(circt-synth circt-synth.cpp)
 target_link_libraries(circt-synth
   PRIVATE
@@ -26,7 +28,6 @@ target_link_libraries(circt-synth
   MLIRIR
   MLIRTransformDialect
   MLIRTransformDialectTransforms
-  LLVMSupport
 )
 
 llvm_update_compile_flags(circt-synth)


### PR DESCRIPTION
Selecting LLVM libraries directly in target_link_libraries bypasses the component-to-libLLVM substitution llvm_config performs when `LLVM_LINK_LLVM_DYLIB` is enabled, so the tools link the individual component libraries alongside `libLLVM.so`.

Similar to [7d03c27](https://github.com/llvm/circt/commit/7d03c27), this gets rid of the following warnings when building with `LLVM_LINK_LLVM_DYLIB` enabled
(e.g. used by [.vscode/Unified.code-workspace.example.jsonc](../blob/main/.vscode/Unified.code-workspace.example.jsonc))

```
WARNING: arcilator links LLVM and LLVMTargetParser!
WARNING: arcilator links LLVM and LLVMOrcJIT!
WARNING: circt-bmc links LLVM and LLVMSupport!
WARNING: circt-bmc links LLVM and LLVMOrcJIT!
WARNING: circt-lec links LLVM and LLVMSupport!
WARNING: circt-synth links LLVM and LLVMSupport!
```

Assisted by: vscode:Claude Opus 5