### PR TITLE
[PrettyPrinter] Simplify, margin of zero means nowrap, EV nowrap.

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -98,7 +98,8 @@ The current set of "tool capability" Lowering Options is:
 The current set of "style" Lowering Options is:
 
  * `emittedLineLength` (default=`90`).  This is the target width of lines in an
-   emitted Verilog source file in columns.
+   emitted Verilog source file in columns.  Zero indicates no wrapping.
+   Lengths greater than or equal to 16384 (2^14) are not supported.
  * `locationInfoStyle` (default=`plain`).  This option controls emitted location
    information style.  The available styles are:
    * `plain`: `// perf/regress/AndNot.fir:3:10, :7:{10,17}`

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -92,9 +92,17 @@ struct LoweringOptions {
   unsigned maximumNumberOfTermsPerExpression = DEFAULT_TERM_LIMIT;
 
   /// This is the target width of lines in an emitted Verilog source file in
-  /// columns.
-  enum { DEFAULT_LINE_LENGTH = 90 };
+  /// columns.  Zero indicates no wrapping.  Must be < 2^14.
+  enum { DEFAULT_LINE_LENGTH = 90, MAX_LINE_LENGTH = (1 << 14) - 1 };
   unsigned emittedLineLength = DEFAULT_LINE_LENGTH;
+
+  /// Return std::nullopt if not wrapping, else the target emission line length.
+  std::optional<unsigned> getEmittedLineLength() const {
+    if (emittedLineLength == 0)
+      return std::nullopt;
+    // This should be rejected in parsing, but in case set directly, saturate.
+    return std::min<unsigned>(MAX_LINE_LENGTH, emittedLineLength);
+  }
 
   /// Add an explicit bitcast for avoiding bitwidth mismatch LINT errors.
   bool explicitBitcast = false;

--- a/include/circt/Support/PrettyPrinter.h
+++ b/include/circt/Support/PrettyPrinter.h
@@ -184,22 +184,21 @@ public:
   };
 
   /// PrettyPrinter for specified stream.
-  /// - margin: line width.
+  /// - margin: line width: 0 is no wrapping, saturates to kMaxMargin.
   /// - baseIndent: always indent at least this much (starting 'indent' value).
   /// - currentColumn: current column, used to calculate space remaining.
   /// - maxStartingIndent: max column indentation starts at, must be >= margin.
-  /// - noWrap: disable line wrapping; only explicit newlines break.
   PrettyPrinter(llvm::raw_ostream &os, uint32_t margin, uint32_t baseIndent = 0,
                 uint32_t currentColumn = 0,
-                uint32_t maxStartingIndent = kInfinity / 4,
-                Listener *listener = nullptr, bool noWrap = false)
-      : space(margin - std::max(currentColumn, baseIndent)),
-        defaultFrame{baseIndent, PrintBreaks::Inconsistent}, indent(baseIndent),
-        margin(margin), maxStartingIndent(std::max(maxStartingIndent, margin)),
-        os(os), listener(listener), noWrap(noWrap) {
-    assert(maxStartingIndent < kInfinity / 2);
-    assert(maxStartingIndent > baseIndent);
-    assert(margin > currentColumn);
+                uint32_t maxStartingIndent = kMaxMargin / 2,
+                Listener *listener = nullptr)
+      : defaultFrame{baseIndent, PrintBreaks::Inconsistent}, indent(baseIndent),
+        margin(std::min(kMaxMargin, margin)),
+        maxStartingIndent(std::max(maxStartingIndent, this->margin)), os(os),
+        listener(listener), noWrap(this->margin == 0) {
+    // Compute space left using computed margin.
+    space = this->margin - std::max(currentColumn, baseIndent);
+
     // Ensure first print advances to at least baseIndent.
     pendingIndentation =
         baseIndent > currentColumn ? baseIndent - currentColumn : 0;
@@ -229,6 +228,9 @@ public:
   auto *getListener() const { return listener; }
 
   static constexpr uint32_t kInfinity = (1U << 15) - 1;
+
+  /// Largest supported target line length.
+  static constexpr uint32_t kMaxMargin = kInfinity / 2;
 
 private:
   /// Format token with tracked size.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1021,7 +1021,7 @@ public:
       : designOp(designOp), shared(shared), options(options),
         symbolCache(symbolCache), globalNames(globalNames),
         fileMapping(fileMapping), os(os), verilogLocMap(verilogLocMap),
-        pp(os, options.emittedLineLength), fileName(fileName) {
+        pp(os, options.getEmittedLineLength().value_or(0)), fileName(fileName) {
     pp.setListener(&saver);
   }
   /// This is the root mlir::ModuleOp that holds the whole design being emitted.
@@ -1319,7 +1319,9 @@ void EmitterBase::emitComment(StringAttr comment) {
   // Set a line length for the comment.  Subtract off the leading comment and
   // space ("// ") as well as the current indent level to simplify later
   // arithmetic.  Ensure that this line length doesn't go below zero.
-  auto lineLength = std::max<size_t>(state.options.emittedLineLength, 3) - 3;
+  std::optional<size_t> lineLength = state.options.getEmittedLineLength();
+  if (lineLength)
+    lineLength = std::max<size_t>(*lineLength, 3) - 3;
 
   // Process the comment in line chunks extracted from manually specified line
   // breaks.  This is done to preserve user-specified line breaking if used.
@@ -1333,7 +1335,7 @@ void EmitterBase::emitComment(StringAttr comment) {
       ps << "// ";
 
       // Base case 1: the entire comment fits on one line.
-      if (line.size() <= lineLength) {
+      if (!lineLength || line.size() <= lineLength) {
         ps << PPExtString(line);
         setPendingNewline();
         break;
@@ -1346,10 +1348,10 @@ void EmitterBase::emitComment(StringAttr comment) {
       //      and break there.
       // This algorithm violates the emittedLineLength if (2) ever occurrs,
       // but it's dead simple.
-      auto breakPos = line.rfind(' ', lineLength);
+      auto breakPos = line.rfind(' ', *lineLength);
       // No whitespace exists looking backwards.
       if (breakPos == StringRef::npos) {
-        breakPos = line.find(' ', lineLength);
+        breakPos = line.find(' ', *lineLength);
         // No whitespace exists looking forward (you hit the end of the
         // string).
         if (breakPos == StringRef::npos)
@@ -5768,9 +5770,10 @@ void StmtEmitter::emitInstancePortList(Operation *op,
   // Get the max port name length so we can align the '('.
   // Exclude outlier names that span the whole line from the alignment column.
   size_t maxNameLength = 0;
+  auto lineLength = state.options.getEmittedLineLength();
   for (auto &elt : modPortInfo) {
     size_t nameLength = elt.getVerilogName().size();
-    if (nameLength <= state.options.emittedLineLength / 3)
+    if (!lineLength || nameLength <= *lineLength / 3)
       maxNameLength = std::max(maxNameLength, nameLength);
   }
 
@@ -6394,11 +6397,12 @@ void ModuleEmitter::emitBind(BindOp op) {
     // Get the max port name length so we can align the '('.
     // Exclude outlier names longer than the line.
     size_t maxNameLength = 0;
+    auto lineLength = state.options.getEmittedLineLength();
     for (auto &elt : childPortInfo) {
       auto portName = elt.getVerilogName();
       elt.name = Builder(inst.getContext()).getStringAttr(portName);
       size_t nameLength = elt.getName().size();
-      if (nameLength <= state.options.emittedLineLength / 3)
+      if (!lineLength || nameLength <= *lineLength / 3)
         maxNameLength = std::max(maxNameLength, nameLength);
     }
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -45,12 +45,7 @@ constexpr size_t defaultTargetLineLength = 80;
 struct Emitter {
   Emitter(llvm::raw_ostream &os, FIRVersion version,
           size_t targetLineLength = defaultTargetLineLength)
-      // A target line length of 0 disables line wrapping so drop to default in
-      // that case to avoid triggering an assertion
-      : pp(os, targetLineLength ? targetLineLength : defaultTargetLineLength, 0,
-           0, PrettyPrinter::kInfinity / 4, nullptr,
-           /*noWrap=*/targetLineLength == 0),
-        ps(pp, saver), version(version) {
+      : pp(os, targetLineLength), ps(pp, saver), version(version) {
     pp.setListener(&saver);
   }
   LogicalResult finalize();

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Support/LoweringOptions.h"
+#include "circt/Support/PrettyPrinter.h"
 #include "mlir/IR/BuiltinOps.h"
 
 using namespace circt;
@@ -73,6 +74,10 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       if (option.getAsInteger(10, emittedLineLength)) {
         errorHandler("expected integer source width");
         emittedLineLength = DEFAULT_LINE_LENGTH;
+      } else if (emittedLineLength > MAX_LINE_LENGTH) {
+        errorHandler("line length '" + Twine(emittedLineLength) +
+                     "' exceeds maximum of " + Twine(MAX_LINE_LENGTH));
+        emittedLineLength = MAX_LINE_LENGTH;
       }
     } else if (option == "explicitBitcast") {
       explicitBitcast = true;
@@ -218,3 +223,8 @@ void LoweringOptions::parseFromAttribute(ModuleOp module) {
   if (auto styleAttr = getAttributeFrom(module))
     parse(styleAttr.getValue(), [&](Twine error) { module.emitError(error); });
 }
+
+static_assert((LoweringOptions::MAX_LINE_LENGTH ==
+               pretty::PrettyPrinter::kMaxMargin) &&
+              "Exported limits for emitted line length not aligned with "
+              "underlying maximum supported");

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -1,8 +1,12 @@
 // RUN: circt-opt --test-apply-lowering-options='options=emittedLineLength=40' --export-verilog %s | FileCheck %s --check-prefixes=CHECK,SHORT
 // RUN: circt-opt --export-verilog %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
 // RUN: circt-opt --test-apply-lowering-options='options=emittedLineLength=180' --export-verilog %s | FileCheck %s --check-prefixes=CHECK,LONG
+// RUN: circt-opt --test-apply-lowering-options='options=emittedLineLength=0' --export-verilog %s | FileCheck %s --check-prefixes=CHECK,NOWRAP
 // RUN: circt-opt --test-apply-lowering-options='options=emittedLineLength=40,maximumNumberOfTermsPerExpression=16' --export-verilog %s | FileCheck %s --check-prefixes=CHECK,LIMIT_SHORT
 // RUN: circt-opt --test-apply-lowering-options='options=maximumNumberOfTermsPerExpression=32' --export-verilog %s | FileCheck %s --check-prefixes=CHECK,LIMIT_LONG
+//
+// RUN: circt-opt --test-apply-lowering-options='options=emittedLineLength=16384' --export-verilog %s --verify-diagnostics
+// expected-error @-9 {{line length '16384' exceeds maximum of 16383}}
 
 hw.module @longvariadic(in %a: i8, out b: i8) {
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
@@ -31,6 +35,9 @@ hw.module @longvariadic(in %a: i8, out b: i8) {
 // LONG:       assign b =
 // LONG-NEXT:    a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
 // LONG-NEXT:    + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+
+//         -- no wrapping ---
+// NOWRAP:  assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
 //                  ---------------------------------------v
 // LIMIT_SHORT:       wire [7:0] _GEN =

--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -771,8 +771,7 @@ TEST(PrettyPrinterTest, NoWrap) {
 
   auto test = [&](bool noWrap) {
     out = "";
-    PrettyPrinter pp(os, 7, 0, 0, PrettyPrinter::kInfinity / 4, nullptr,
-                     noWrap);
+    PrettyPrinter pp(os, noWrap ? 0 : 7);
     TokenBuilder<> b(pp);
     b.ibox();
     b.literal("test");
@@ -789,6 +788,52 @@ TEST(PrettyPrinterTest, NoWrap) {
 
   test(true);
   EXPECT_EQ(out.str(), StringRef("test test\ntest"));
+}
+
+TEST(PrettyPrinterTest, MarginValues) {
+  SmallString<0> out;
+  unsigned constexpr outCap = 1U << 15;
+  out.reserve(outCap);
+  raw_svector_ostream os(out);
+
+  auto test = [&](unsigned margin) {
+    out = "";
+    ASSERT_EQ(out.size(), 0);
+    PrettyPrinter pp(os, margin);
+    TokenBuilder<> b(pp);
+    b.ibox();
+    for (unsigned i = 0; i < (1 << 13U); ++i) {
+      if (i != 0)
+        b.space();
+      b.literal("foo");
+    }
+    b.end();
+    pp.eof();
+    ASSERT_EQ(outCap, out.capacity());
+    ASSERT_EQ(out.size(), outCap - 1);
+  };
+
+  test(16383);
+  auto save = out;
+  auto saveNewlines = save.count('\n');
+  ASSERT_NE(saveNewlines, 0);
+
+  auto saturates = {16384U, 20000U, UINT32_MAX};
+  auto different = {16382U, 0U, 1U};
+
+  for (auto m : saturates) {
+    test(m);
+    EXPECT_EQ(save.str(), out.str());
+  }
+
+  for (auto m : different) {
+    test(m);
+    auto outNewlines = out.count('\n');
+    EXPECT_NE(saveNewlines, outNewlines);
+    // Special check for no-wrap sentinel value.
+    if (m == 0)
+      EXPECT_EQ(outNewlines, 0U);
+  }
 }
 
 TEST(PrettyPrinterTest, NeverBreakGroup) {


### PR DESCRIPTION
Saturate if go over supported limit.

This converts a contract previously only checked by assertions into reasonable behavior for all argument values.

Fixes behavior masked by shadowing even in assert builds. h/t @seldridge

Also allows SV (via LoweringOptions) to have a no-wrapping flow as well! Set to zero for no wrapping, error if beyond supported maximum.

Update tests, add test for emittedLineLength.
Add unittest for these PP behaviors.

Claude reviewed.

Assisted-by: Claude Code:claude-fable-5