### PR TITLE
[FIRRTL][firtool] Migrate to use FullReset pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -366,6 +366,10 @@ def FullReset : Pass<"firrtl-full-reset", "firrtl::CircuitOp"> {
     Consumes `circt.FullResetAnnotation` / `circt.ExcludeFromFullResetAnnotation`
     Builds reset domains and implements full reset on registers.
   }];
+  let options = [
+    Option<"convertAsyncDomainMems", "convert-async-domain-mems", "bool",
+      "true", "Convert combinational memories in asynchronous full-reset domains.">
+  ];
 }
 
 def BlackBoxReader : Pass<"firrtl-blackbox-reader", "CircuitOp"> {

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -147,6 +147,7 @@ public:
   bool shouldDedupClasses() const { return dedupClasses; }
   bool shouldEnableDebugInfo() const { return enableDebugInfo; }
   bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
+  bool shouldUseNewFullResetFlow() const { return useNewFullResetFlow; }
   bool shouldConvertVecOfBundle() const { return vbToBV; }
   bool shouldStripDebugInfo() const { return stripDebugInfo; }
   bool shouldStripFirDebugInfo() const { return stripFirDebugInfo; }
@@ -297,6 +298,11 @@ public:
 
   FirtoolOptions &setIgnoreReadEnableMem(bool value) {
     ignoreReadEnableMem = value;
+    return *this;
+  }
+
+  FirtoolOptions &setUseNewFullResetFlow(bool value) {
+    useNewFullResetFlow = value;
     return *this;
   }
 
@@ -452,6 +458,7 @@ private:
   bool replSeqMem;
   std::string replSeqMemFile;
   bool ignoreReadEnableMem;
+  bool useNewFullResetFlow;
   RandomKind disableRandom;
   std::string outputAnnotationFilename;
   bool enableAnnotationWarning;

--- a/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FullReset.cpp
@@ -1489,7 +1489,7 @@ struct FullResetPass
     auto &ig = getAnalysis<InstanceGraph>();
     auto &instanceInfo = getAnalysis<InstanceInfo>();
     if (failed(runFullReset(getOperation(), ig, instanceInfo,
-                            /*convertAsyncDomainMems=*/true)))
+                            convertAsyncDomainMems)))
       return signalPassFailure();
     markAnalysesPreserved<InstanceGraph, InstanceInfo>();
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -304,10 +304,6 @@ void InferResetsPass::runOnOperationInner() {
   if (failed(inferAndUpdateResets()))
     return signalPassFailure();
 
-  if (failed(runFullReset(getOperation(), *instanceGraph,
-                          getAnalysis<InstanceInfo>())))
-    return signalPassFailure();
-
   // Require that no Abstract Resets exist on ports in the design.
   if (failed(verifyNoAbstractReset()))
     return signalPassFailure();

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -86,10 +86,16 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   // Width inference creates canonicalization opportunities.
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidths());
 
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createMemToRegOfVec(
-      {/*replSeqMemFile=*/opt.shouldIgnoreReadEnableMemories()}));
-
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResets());
+  if (opt.shouldUseNewFullResetFlow()) {
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResets());
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createFullReset());
+  } else {
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createMemToRegOfVec(
+        {/*ignoreReadEnable=*/opt.shouldIgnoreReadEnableMemories()}));
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResets());
+    pm.nest<firrtl::CircuitOp>().addPass(
+        firrtl::createFullReset({/*convertAsyncDomainMems=*/false}));
+  }
 
   // TODO: Move this to the same location as SpecializeLayers.
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createSpecializeOption(
@@ -639,6 +645,11 @@ public:
                      "assigning X on read disable"),
       llvm::cl::init(false)};
 
+  llvm::cl::opt<bool> useNewFullResetFlow{
+      "use-new-full-reset-flow",
+      llvm::cl::desc("Use the split InferResets and FullReset pipeline"),
+      llvm::cl::init(true)};
+
   firtool::FirtoolOptions::RandomKind disableRandomValue =
       firtool::FirtoolOptions::RandomKind::None;
 
@@ -858,7 +869,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       dedupClasses(true), companionMode(firrtl::CompanionMode::Bind),
       noViews(false), disableAggressiveMergeConnections(false),
       lowerMemories(false), blackBoxRootPath(""), replSeqMem(false),
-      replSeqMemFile(""), ignoreReadEnableMem(false),
+      replSeqMemFile(""), ignoreReadEnableMem(false), useNewFullResetFlow(true),
       disableRandom(RandomKind::None), outputAnnotationFilename(""),
       enableAnnotationWarning(false), lowerToCore(false), addMuxPragmas(false),
       verificationFlavor(firrtl::VerificationFlavor::None),
@@ -898,6 +909,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   replSeqMem = clOptions->replSeqMem;
   replSeqMemFile = clOptions->replSeqMemFile;
   ignoreReadEnableMem = clOptions->ignoreReadEnableMem;
+  useNewFullResetFlow = clOptions->useNewFullResetFlow;
   disableRandom = clOptions->disableRandomValue;
   outputAnnotationFilename = clOptions->outputAnnotationFilename;
   enableAnnotationWarning = clOptions->enableAnnotationWarning;

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -10,6 +10,7 @@ FIRRTL version 4.0.0
 circuit TestHarness:
   ; Foo* are instantiated only by the TestHarness
   module Foo:
+    input reset : AsyncReset
 
     mem foo_m :
       data-type => UInt<8>
@@ -37,6 +38,7 @@ circuit TestHarness:
 
   ; Bar* are instantiated only by the DUT
   module Bar:
+    input reset : AsyncReset
 
     mem bar_m :
       data-type => UInt<8>
@@ -64,6 +66,7 @@ circuit TestHarness:
 
   ; Baz* are instantiated by both the TestHarness and the DUT
   module Baz:
+    input reset : AsyncReset
 
     mem baz_m :
       data-type => UInt<8>
@@ -92,33 +95,40 @@ circuit TestHarness:
   ; This is the design-under-test.  This is marked as such by a separate,
   ; optional annotation file.
   module DUT:
+    input reset : AsyncReset
 
     inst bar of Bar
+    connect bar.reset, reset
     inst bar_bbox of Bar_BlackBox
     inst baz of Baz
+    connect baz.reset, reset
     inst baz_bbox of Baz_BlackBox
 
   ; This is the Test Harness, i.e., the top of the design.
   public module TestHarness:
+    input reset : AsyncReset
 
     inst foo of Foo
+    connect foo.reset, reset
     inst foo_bbox of Foo_BlackBox
     inst dut of DUT
+    connect dut.reset, reset
     inst baz of Baz
+    connect baz.reset, reset
     inst baz_bbox of Baz_BlackBox
 
 
-; CHECK:            module Foo()
+; CHECK:            module Foo(
 ; MEMTOREG_DUT-NOT:   reg [7:0] foo_combmem
 ; MEMTOREG_NODUT:     reg [7:0] foo_combmem
 ; CHECK:            endmodule
 
-; CHECK:            module Bar()
+; CHECK:            module Bar(
 ; MEMTOREG_DUT:       reg [7:0] bar_combmem
 ; MEMTOREG_NODUT:     reg [7:0] bar_combmem
 ; CHECK:            endmodule
 
-; CHECK:            module Baz()
+; CHECK:            module Baz(
 ; MEMTOREG_DUT:       reg [7:0] baz_combmem
 ; MEMTOREG_NODUT:     reg [7:0] baz_combmem
 ; CHECK:            endmodule

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir.memtoregofvec.anno.json
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir.memtoregofvec.anno.json
@@ -1,5 +1,17 @@
 [
   {
     "class": "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"
+  },
+  {
+    "class": "sifive.enterprise.firrtl.FullAsyncResetAnnotation",
+    "target": "~TestHarness|Foo>reset"
+  },
+  {
+    "class": "sifive.enterprise.firrtl.FullAsyncResetAnnotation",
+    "target": "~TestHarness|Bar>reset"
+  },
+  {
+    "class": "sifive.enterprise.firrtl.FullAsyncResetAnnotation",
+    "target": "~TestHarness|Baz>reset"
   }
 ]

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -6,6 +6,10 @@ circuit Top : %[[
     "class":"firrtl.transforms.DontTouchAnnotation",
     "target":"~Top|Top>memTap"
   },
+  {
+    "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
+    "target":"~Top|DUTModule>reset"
+  },
   {"class": "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"},
   {
     "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
@@ -24,7 +28,7 @@ circuit Top : %[[
 ]]
   module DUTModule :
     input clock : Clock
-    input reset : Reset
+    input reset : AsyncReset
     output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}
 
     cmem rf : UInt<8> [8]
@@ -36,7 +40,7 @@ circuit Top : %[[
 
   public module Top :
     input clock : Clock
-    input reset : UInt<1>
+    input reset : AsyncReset
     output io : { flip addr : UInt<3>, flip dataIn : UInt<8>, flip wen : UInt<1>, dataOut : UInt<8>}
 
     inst dut of DUTModule

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -5,10 +5,10 @@
 
 ; CHECK-LABEL: firrtl.module @Issue794
 ; CHECK-SAME: (in %clock: !firrtl.clock,
-; CHECK:       %[[memory_0:.+]] = firrtl.reg %clock {{.*}}: !firrtl.clock, !firrtl.uint<8>
-; CHECK:       firrtl.mux(%[[v14:.+]], %wData_0, %[[memory_0]])
-; CHECK:       firrtl.mux(%[[v19:.+]], %wData_1, %[[v5:.+]])
-; CHECK:       firrtl.matchingconnect %[[memory_0]], %[[v22:.+]]
+; CHECK:       %[[memory_0:.+]] = firrtl.regreset %clock, %reset, {{.*}}: !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+; CHECK:       firrtl.mux({{.*}}, %wData_0, %[[memory_0]])
+; CHECK:       firrtl.mux({{.*}}, %wData_1, {{.*}})
+; CHECK:       firrtl.matchingconnect %[[memory_0]], {{.*}}
 FIRRTL version 4.0.0
 circuit Issue794: %[[{
     "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
@@ -16,9 +16,14 @@ circuit Issue794: %[[{
   },
   {
     "class": "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"
+  },
+  {
+    "class": "sifive.enterprise.firrtl.FullAsyncResetAnnotation",
+    "target": "~Issue794|Issue794>reset"
   }]]
   public module Issue794:
     input clock: Clock
+    input reset: AsyncReset
     input rAddr: UInt<2>
     input rEn: UInt<1>
     output rData: UInt<8>


### PR DESCRIPTION
Split full-reset handling from InferResets into a dedicated FullReset
pass and make the new flow the default in firtool. Preserve the legacy
pipeline behind --use-new-full-reset-flow=false. Not sure worth preserving the
old flow, but shouldn't be that controversial. 

There is a functional difference in a new and old flow. In a new flow comb memories in the async reset domain will be automatically transformed into a vector of registers which previously required separated annotations. 

Assisted-by: pi.dev: gpt 5.6 luna


<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
