### PR TITLE
[OM]   Remove redundant binary operation interfaces from the OM dialect, NFC

### DIFF
--- a/include/circt/Dialect/OM/OMOpInterfaces.td
+++ b/include/circt/Dialect/OM/OMOpInterfaces.td
@@ -49,36 +49,4 @@ def ClassLike : OpInterface<"ClassLike"> {
   ];
 }
 
-def IntegerBinaryInterface : OpInterface<"IntegerBinaryOp"> {
-  let cppNamespace = "circt::om";
-  let description = "Common interface for integer binary ops.";
-  let methods = [
-    InterfaceMethod<"Get the lhs Value",
-      "mlir::Value", "getLhs", (ins)>,
-    InterfaceMethod<"Get the rhs Value",
-      "mlir::Value", "getRhs", (ins)>,
-    InterfaceMethod<"Get the result Value",
-      "mlir::Value", "getResult", (ins)>,
-    InterfaceMethod<"Evaluate the integer binary operation",
-      "mlir::FailureOr<llvm::APSInt>", "evaluateIntegerOperation",
-      (ins "const llvm::APSInt &":$lhs, "const llvm::APSInt &":$rhs)>
-  ];
-}
-
-def BinaryEqualityInterface : OpInterface<"BinaryEqualityOp"> {
-  let cppNamespace = "circt::om";
-  let description = "Common interface for binary property equality ops.";
-  let methods = [
-    InterfaceMethod<"Get the lhs Value",
-      "mlir::Value", "getLhs", (ins)>,
-    InterfaceMethod<"Get the rhs Value",
-      "mlir::Value", "getRhs", (ins)>,
-    InterfaceMethod<"Get the result Value",
-      "mlir::Value", "getResult", (ins)>,
-    InterfaceMethod<"Evaluate the binary equality operation",
-      "mlir::FailureOr<mlir::Attribute>", "evaluateBinaryEquality",
-      (ins "mlir::Attribute":$lhs, "mlir::Attribute":$rhs)>
-  ];
-}
-
 #endif // CIRCT_DIALECT_OM_OMOPINTERFACES_TD

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -489,8 +489,7 @@ def AnyCastOp : OMOp<"any_cast", [Pure]> {
 
 class IntegerBinaryOp<string mnemonic, list<Trait> traits = []> :
     OMOp<mnemonic, [
-      Pure,
-      DeclareOpInterfaceMethods<IntegerBinaryInterface>
+      Pure
     ] # traits> {
   let arguments = (ins OMIntegerType:$lhs, OMIntegerType:$rhs);
 
@@ -577,8 +576,7 @@ def StringConcatOp : OMOp<"string.concat", [Pure, SameOperandsAndResultType]> {
 class BinaryEqualityOpBase<string mnemonic, list<Trait> traits = []> :
     OMOp<mnemonic, [
       Pure,
-      AllTypesMatch<["lhs", "rhs"]>,
-      DeclareOpInterfaceMethods<BinaryEqualityInterface>
+      AllTypesMatch<["lhs", "rhs"]>
     ] # traits> {
   let arguments = (ins AnyTypeOf<[StringType, OMIntegerType, I1]>:$lhs,
                        AnyTypeOf<[StringType, OMIntegerType, I1]>:$rhs);
@@ -608,8 +606,7 @@ def PropEqOp : BinaryEqualityOpBase<"prop.eq"> {
 class IntegerBitwiseOpBase<string mnemonic, list<Trait> traits = []> :
     OMOp<mnemonic, [
       Pure,
-      SameOperandsAndResultType,
-      DeclareOpInterfaceMethods<IntegerBinaryInterface>
+      SameOperandsAndResultType
     ] # traits> {
   let arguments = (ins AnyInteger:$lhs, AnyInteger:$rhs);
   let results = (outs AnyInteger:$result);

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -761,8 +761,7 @@ static APSInt getAPSIntForOMIntegerAttr(circt::om::IntegerAttr attr) {
 using IntegerBinaryFn =
     llvm::function_ref<FailureOr<APSInt>(const APSInt &, const APSInt &)>;
 
-static OpFoldResult foldIntegerBinaryArithmetic(MLIRContext *ctx,
-                                                Attribute lhsAttr,
+static OpFoldResult foldIntegerBinaryArithmetic(Attribute lhsAttr,
                                                 Attribute rhsAttr,
                                                 IntegerBinaryFn evaluate) {
   auto lhs = dyn_cast_or_null<circt::om::IntegerAttr>(lhsAttr);
@@ -786,6 +785,7 @@ static OpFoldResult foldIntegerBinaryArithmetic(MLIRContext *ctx,
     return {};
 
   // Return the result as a new om::IntegerAttr.
+  auto *ctx = lhsAttr.getContext();
   return circt::om::IntegerAttr::get(
       ctx, mlir::IntegerAttr::get(ctx, result.value()));
 }
@@ -796,7 +796,7 @@ static OpFoldResult foldIntegerBinaryArithmetic(MLIRContext *ctx,
 
 OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
   return foldIntegerBinaryArithmetic(
-      getContext(), adaptor.getLhs(), adaptor.getRhs(),
+      adaptor.getLhs(), adaptor.getRhs(),
       [](const APSInt &lhs, const APSInt &rhs) { return success(lhs + rhs); });
 }
 
@@ -806,7 +806,7 @@ OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult IntegerMulOp::fold(FoldAdaptor adaptor) {
   return foldIntegerBinaryArithmetic(
-      getContext(), adaptor.getLhs(), adaptor.getRhs(),
+      adaptor.getLhs(), adaptor.getRhs(),
       [](const APSInt &lhs, const APSInt &rhs) { return success(lhs * rhs); });
 }
 
@@ -816,7 +816,7 @@ OpFoldResult IntegerMulOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
   return foldIntegerBinaryArithmetic(
-      getContext(), adaptor.getLhs(), adaptor.getRhs(),
+      adaptor.getLhs(), adaptor.getRhs(),
       [&](const APSInt &lhs, const APSInt &rhs) -> FailureOr<APSInt> {
         // Check non-negative constraint from operation semantics.
         if (!rhs.isNonNegative())
@@ -836,7 +836,7 @@ OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult IntegerShlOp::fold(FoldAdaptor adaptor) {
   return foldIntegerBinaryArithmetic(
-      getContext(), adaptor.getLhs(), adaptor.getRhs(),
+      adaptor.getLhs(), adaptor.getRhs(),
       [&](const APSInt &lhs, const APSInt &rhs) -> FailureOr<APSInt> {
         // Check non-negative constraint from operation semantics.
         if (!rhs.isNonNegative())

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -12,7 +12,6 @@
 
 #include "circt/Dialect/OM/OMOps.h"
 #include "circt/Dialect/HW/HWOps.h"
-#include "circt/Dialect/OM/OMOpInterfaces.h"
 #include "circt/Dialect/OM/OMUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -759,7 +758,32 @@ static APSInt getAPSIntForOMIntegerAttr(circt::om::IntegerAttr attr) {
   return APSInt(value.getValue(), /*isUnsigned=*/false);
 }
 
-static OpFoldResult foldIntegerBinaryArithmetic(IntegerBinaryOp op,
+static FailureOr<APSInt>
+evaluateIntegerOperation(Operation *op, const APSInt &lhs, const APSInt &rhs) {
+  if (isa<IntegerAddOp>(op))
+    return success(lhs + rhs);
+  if (isa<IntegerMulOp>(op))
+    return success(lhs * rhs);
+  if (isa<IntegerShrOp, IntegerShlOp>(op)) {
+    if (!rhs.isNonNegative())
+      return op->emitOpError("shift amount must be non-negative");
+    if (!rhs.isRepresentableByInt64())
+      return op->emitOpError("shift amount must be representable in 64 bits");
+    int64_t shiftAmount = rhs.getExtValue();
+    if (isa<IntegerShrOp>(op))
+      return success(lhs >> shiftAmount);
+    return success(lhs.extend(lhs.getBitWidth() + shiftAmount) << shiftAmount);
+  }
+  if (isa<IntegerAndOp>(op))
+    return success(APSInt(lhs & rhs, false));
+  if (isa<IntegerOrOp>(op))
+    return success(APSInt(lhs | rhs, false));
+  if (isa<IntegerXorOp>(op))
+    return success(APSInt(lhs ^ rhs, false));
+  llvm_unreachable("unknown OM integer binary operation");
+}
+
+static OpFoldResult foldIntegerBinaryArithmetic(Operation *op,
                                                 Attribute lhsAttr,
                                                 Attribute rhsAttr) {
   auto lhs = dyn_cast_or_null<circt::om::IntegerAttr>(lhsAttr);
@@ -778,11 +802,11 @@ static OpFoldResult foldIntegerBinaryArithmetic(IntegerBinaryOp op,
     lhsVal = lhsVal.extend(rhsVal.getBitWidth());
 
   // Perform arbitrary precision signed integer binary arithmetic.
-  auto result = op.evaluateIntegerOperation(lhsVal, rhsVal);
+  auto result = evaluateIntegerOperation(op, lhsVal, rhsVal);
   if (failed(result))
     return {};
 
-  auto *ctx = op.getContext();
+  auto *ctx = op->getContext();
   // Return the result as a new om::IntegerAttr.
   return circt::om::IntegerAttr::get(
       ctx, mlir::IntegerAttr::get(ctx, result.value()));
@@ -792,71 +816,36 @@ static OpFoldResult foldIntegerBinaryArithmetic(IntegerBinaryOp op,
 // IntegerAddOp
 //===----------------------------------------------------------------------===//
 
-FailureOr<llvm::APSInt>
-IntegerAddOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
-                                       const llvm::APSInt &rhs) {
-  return success(lhs + rhs);
-}
-
 OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
-  return foldIntegerBinaryArithmetic(*this, adaptor.getLhs(), adaptor.getRhs());
+  return foldIntegerBinaryArithmetic(getOperation(), adaptor.getLhs(),
+                                     adaptor.getRhs());
 }
 
 //===----------------------------------------------------------------------===//
 // IntegerMulOp
 //===----------------------------------------------------------------------===//
 
-FailureOr<llvm::APSInt>
-IntegerMulOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
-                                       const llvm::APSInt &rhs) {
-  return success(lhs * rhs);
-}
-
 OpFoldResult IntegerMulOp::fold(FoldAdaptor adaptor) {
-  return foldIntegerBinaryArithmetic(*this, adaptor.getLhs(), adaptor.getRhs());
+  return foldIntegerBinaryArithmetic(getOperation(), adaptor.getLhs(),
+                                     adaptor.getRhs());
 }
 
 //===----------------------------------------------------------------------===//
 // IntegerShrOp
 //===----------------------------------------------------------------------===//
 
-FailureOr<llvm::APSInt>
-IntegerShrOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
-                                       const llvm::APSInt &rhs) {
-  // Check non-negative constraint from operation semantics.
-  if (!rhs.isNonNegative())
-    return emitOpError("shift amount must be non-negative");
-  // Check size constraint from implementation detail of using getExtValue.
-  if (!rhs.isRepresentableByInt64())
-    return emitOpError("shift amount must be representable in 64 bits");
-  return success(lhs >> rhs.getExtValue());
-}
-
 OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
-  return foldIntegerBinaryArithmetic(*this, adaptor.getLhs(), adaptor.getRhs());
+  return foldIntegerBinaryArithmetic(getOperation(), adaptor.getLhs(),
+                                     adaptor.getRhs());
 }
 
 //===----------------------------------------------------------------------===//
 // IntegerShlOp
 //===----------------------------------------------------------------------===//
 
-FailureOr<llvm::APSInt>
-IntegerShlOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
-                                       const llvm::APSInt &rhs) {
-  // Check non-negative constraint from operation semantics.
-  if (!rhs.isNonNegative())
-    return emitOpError("shift amount must be non-negative");
-  // Check size constraint from implementation detail of using getExtValue.
-  if (!rhs.isRepresentableByInt64())
-    return emitOpError("shift amount must be representable in 64 bits");
-
-  int64_t shiftAmt = rhs.getExtValue();
-  // Extend lhs to lhsWidth + shiftAmt bits so no bits are truncated.
-  return success(lhs.extend(lhs.getBitWidth() + shiftAmt) << shiftAmt);
-}
-
 OpFoldResult IntegerShlOp::fold(FoldAdaptor adaptor) {
-  return foldIntegerBinaryArithmetic(*this, adaptor.getLhs(), adaptor.getRhs());
+  return foldIntegerBinaryArithmetic(getOperation(), adaptor.getLhs(),
+                                     adaptor.getRhs());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1007,10 +996,9 @@ void StringConcatOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // PropEqOp
 //===----------------------------------------------------------------------===//
 
-FailureOr<mlir::Attribute>
-PropEqOp::evaluateBinaryEquality(mlir::Attribute lhsAttr,
-                                 mlir::Attribute rhsAttr) {
-  auto resultType = mlir::IntegerType::get(getContext(), 1);
+static FailureOr<mlir::Attribute>
+evaluateBinaryEquality(mlir::Attribute lhsAttr, mlir::Attribute rhsAttr) {
+  auto resultType = mlir::IntegerType::get(lhsAttr.getContext(), 1);
 
   // String equality.
   if (auto lhs = dyn_cast<mlir::StringAttr>(lhsAttr))
@@ -1019,8 +1007,8 @@ PropEqOp::evaluateBinaryEquality(mlir::Attribute lhsAttr,
           mlir::IntegerAttr::get(resultType, lhs == rhs ? 1 : 0));
 
   // OM integer equality (arbitrary precision).
-  if (auto lhs = dyn_cast<om::IntegerAttr>(lhsAttr))
-    if (auto rhs = dyn_cast<om::IntegerAttr>(rhsAttr)) {
+  if (auto lhs = dyn_cast<circt::om::IntegerAttr>(lhsAttr))
+    if (auto rhs = dyn_cast<circt::om::IntegerAttr>(rhsAttr)) {
       APSInt lhsVal = getAPSIntForOMIntegerAttr(lhs);
       APSInt rhsVal = getAPSIntForOMIntegerAttr(rhs);
       if (lhsVal.getBitWidth() > rhsVal.getBitWidth())
@@ -1057,7 +1045,7 @@ OpFoldResult PropEqOp::fold(FoldAdaptor adaptor) {
 // IntegerAndOp / IntegerOrOp / IntegerXorOp
 //===----------------------------------------------------------------------===//
 
-static OpFoldResult foldIntegerBitwise(IntegerBinaryOp op, Attribute lhsAttr,
+static OpFoldResult foldIntegerBitwise(Operation *op, Attribute lhsAttr,
                                        Attribute rhsAttr) {
   auto lhsInt = dyn_cast_or_null<mlir::IntegerAttr>(lhsAttr);
   auto rhsInt = dyn_cast_or_null<mlir::IntegerAttr>(rhsAttr);
@@ -1065,7 +1053,7 @@ static OpFoldResult foldIntegerBitwise(IntegerBinaryOp op, Attribute lhsAttr,
     return {};
   APSInt lhsVal(lhsInt.getValue());
   APSInt rhsVal(rhsInt.getValue());
-  auto result = op.evaluateIntegerOperation(lhsVal, rhsVal);
+  auto result = evaluateIntegerOperation(op, lhsVal, rhsVal);
   if (failed(result))
     return {};
   return mlir::IntegerAttr::get(
@@ -1084,14 +1072,9 @@ static bool isAllOnesInt(Attribute a) {
   return i && i.getValue().isAllOnes();
 }
 
-FailureOr<APSInt> IntegerAndOp::evaluateIntegerOperation(const APSInt &lhs,
-                                                         const APSInt &rhs) {
-  return success(APSInt(lhs & rhs, /*isUnsigned=*/false));
-}
-
 OpFoldResult IntegerAndOp::fold(FoldAdaptor adaptor) {
-  if (auto result =
-          foldIntegerBitwise(*this, adaptor.getLhs(), adaptor.getRhs()))
+  if (auto result = foldIntegerBitwise(getOperation(), adaptor.getLhs(),
+                                       adaptor.getRhs()))
     return result;
   // AND with all-zeros is always zero.
   if (isZeroInt(adaptor.getLhs()) || isZeroInt(adaptor.getRhs()))
@@ -1105,14 +1088,9 @@ OpFoldResult IntegerAndOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
-FailureOr<APSInt> IntegerOrOp::evaluateIntegerOperation(const APSInt &lhs,
-                                                        const APSInt &rhs) {
-  return success(APSInt(lhs | rhs, /*isUnsigned=*/false));
-}
-
 OpFoldResult IntegerOrOp::fold(FoldAdaptor adaptor) {
-  if (auto result =
-          foldIntegerBitwise(*this, adaptor.getLhs(), adaptor.getRhs()))
+  if (auto result = foldIntegerBitwise(getOperation(), adaptor.getLhs(),
+                                       adaptor.getRhs()))
     return result;
   // OR with all-ones is always all-ones.
   if (isAllOnesInt(adaptor.getLhs()) || isAllOnesInt(adaptor.getRhs()))
@@ -1126,14 +1104,9 @@ OpFoldResult IntegerOrOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
-FailureOr<APSInt> IntegerXorOp::evaluateIntegerOperation(const APSInt &lhs,
-                                                         const APSInt &rhs) {
-  return success(APSInt(lhs ^ rhs, /*isUnsigned=*/false));
-}
-
 OpFoldResult IntegerXorOp::fold(FoldAdaptor adaptor) {
-  if (auto result =
-          foldIntegerBitwise(*this, adaptor.getLhs(), adaptor.getRhs()))
+  if (auto result = foldIntegerBitwise(getOperation(), adaptor.getLhs(),
+                                       adaptor.getRhs()))
     return result;
   // XOR with all-zeros is identity.
   if (isZeroInt(adaptor.getLhs()))

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -758,34 +758,13 @@ static APSInt getAPSIntForOMIntegerAttr(circt::om::IntegerAttr attr) {
   return APSInt(value.getValue(), /*isUnsigned=*/false);
 }
 
-static FailureOr<APSInt>
-evaluateIntegerOperation(Operation *op, const APSInt &lhs, const APSInt &rhs) {
-  if (isa<IntegerAddOp>(op))
-    return success(lhs + rhs);
-  if (isa<IntegerMulOp>(op))
-    return success(lhs * rhs);
-  if (isa<IntegerShrOp, IntegerShlOp>(op)) {
-    if (!rhs.isNonNegative())
-      return op->emitOpError("shift amount must be non-negative");
-    if (!rhs.isRepresentableByInt64())
-      return op->emitOpError("shift amount must be representable in 64 bits");
-    int64_t shiftAmount = rhs.getExtValue();
-    if (isa<IntegerShrOp>(op))
-      return success(lhs >> shiftAmount);
-    return success(lhs.extend(lhs.getBitWidth() + shiftAmount) << shiftAmount);
-  }
-  if (isa<IntegerAndOp>(op))
-    return success(APSInt(lhs & rhs, false));
-  if (isa<IntegerOrOp>(op))
-    return success(APSInt(lhs | rhs, false));
-  if (isa<IntegerXorOp>(op))
-    return success(APSInt(lhs ^ rhs, false));
-  llvm_unreachable("unknown OM integer binary operation");
-}
+using IntegerBinaryFn =
+    llvm::function_ref<FailureOr<APSInt>(const APSInt &, const APSInt &)>;
 
 static OpFoldResult foldIntegerBinaryArithmetic(Operation *op,
                                                 Attribute lhsAttr,
-                                                Attribute rhsAttr) {
+                                                Attribute rhsAttr,
+                                                IntegerBinaryFn evaluate) {
   auto lhs = dyn_cast_or_null<circt::om::IntegerAttr>(lhsAttr);
   auto rhs = dyn_cast_or_null<circt::om::IntegerAttr>(rhsAttr);
   if (!lhs || !rhs)
@@ -802,7 +781,7 @@ static OpFoldResult foldIntegerBinaryArithmetic(Operation *op,
     lhsVal = lhsVal.extend(rhsVal.getBitWidth());
 
   // Perform arbitrary precision signed integer binary arithmetic.
-  auto result = evaluateIntegerOperation(op, lhsVal, rhsVal);
+  auto result = evaluate(lhsVal, rhsVal);
   if (failed(result))
     return {};
 
@@ -817,8 +796,9 @@ static OpFoldResult foldIntegerBinaryArithmetic(Operation *op,
 //===----------------------------------------------------------------------===//
 
 OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
-  return foldIntegerBinaryArithmetic(getOperation(), adaptor.getLhs(),
-                                     adaptor.getRhs());
+  return foldIntegerBinaryArithmetic(
+      getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+      [](const APSInt &lhs, const APSInt &rhs) { return success(lhs + rhs); });
 }
 
 //===----------------------------------------------------------------------===//
@@ -826,8 +806,9 @@ OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult IntegerMulOp::fold(FoldAdaptor adaptor) {
-  return foldIntegerBinaryArithmetic(getOperation(), adaptor.getLhs(),
-                                     adaptor.getRhs());
+  return foldIntegerBinaryArithmetic(
+      getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+      [](const APSInt &lhs, const APSInt &rhs) { return success(lhs * rhs); });
 }
 
 //===----------------------------------------------------------------------===//
@@ -835,8 +816,13 @@ OpFoldResult IntegerMulOp::fold(FoldAdaptor adaptor) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
-  return foldIntegerBinaryArithmetic(getOperation(), adaptor.getLhs(),
-                                     adaptor.getRhs());
+  return foldIntegerBinaryArithmetic(
+      getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+      [&](const APSInt &lhs, const APSInt &rhs) {
+        if (!rhs.isNonNegative() || !rhs.isRepresentableByInt64())
+          return FailureOr<APSInt>(emitOpError("invalid shift amount"));
+        return success(lhs >> rhs.getExtValue());
+      });
 }
 
 //===----------------------------------------------------------------------===//
@@ -844,8 +830,14 @@ OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult IntegerShlOp::fold(FoldAdaptor adaptor) {
-  return foldIntegerBinaryArithmetic(getOperation(), adaptor.getLhs(),
-                                     adaptor.getRhs());
+  return foldIntegerBinaryArithmetic(
+      getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+      [&](const APSInt &lhs, const APSInt &rhs) {
+        if (!rhs.isNonNegative() || !rhs.isRepresentableByInt64())
+          return FailureOr<APSInt>(emitOpError("invalid shift amount"));
+        auto shift = rhs.getExtValue();
+        return success(lhs.extend(lhs.getBitWidth() + shift) << shift);
+      });
 }
 
 //===----------------------------------------------------------------------===//
@@ -1046,14 +1038,15 @@ OpFoldResult PropEqOp::fold(FoldAdaptor adaptor) {
 //===----------------------------------------------------------------------===//
 
 static OpFoldResult foldIntegerBitwise(Operation *op, Attribute lhsAttr,
-                                       Attribute rhsAttr) {
+                                       Attribute rhsAttr,
+                                       IntegerBinaryFn evaluate) {
   auto lhsInt = dyn_cast_or_null<mlir::IntegerAttr>(lhsAttr);
   auto rhsInt = dyn_cast_or_null<mlir::IntegerAttr>(rhsAttr);
   if (!lhsInt || !rhsInt)
     return {};
   APSInt lhsVal(lhsInt.getValue());
   APSInt rhsVal(rhsInt.getValue());
-  auto result = evaluateIntegerOperation(op, lhsVal, rhsVal);
+  auto result = evaluate(lhsVal, rhsVal);
   if (failed(result))
     return {};
   return mlir::IntegerAttr::get(
@@ -1073,8 +1066,11 @@ static bool isAllOnesInt(Attribute a) {
 }
 
 OpFoldResult IntegerAndOp::fold(FoldAdaptor adaptor) {
-  if (auto result = foldIntegerBitwise(getOperation(), adaptor.getLhs(),
-                                       adaptor.getRhs()))
+  if (auto result =
+          foldIntegerBitwise(getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+                             [](const APSInt &lhs, const APSInt &rhs) {
+                               return success(lhs & rhs);
+                             }))
     return result;
   // AND with all-zeros is always zero.
   if (isZeroInt(adaptor.getLhs()) || isZeroInt(adaptor.getRhs()))
@@ -1089,8 +1085,11 @@ OpFoldResult IntegerAndOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult IntegerOrOp::fold(FoldAdaptor adaptor) {
-  if (auto result = foldIntegerBitwise(getOperation(), adaptor.getLhs(),
-                                       adaptor.getRhs()))
+  if (auto result =
+          foldIntegerBitwise(getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+                             [](const APSInt &lhs, const APSInt &rhs) {
+                               return success(lhs | rhs);
+                             }))
     return result;
   // OR with all-ones is always all-ones.
   if (isAllOnesInt(adaptor.getLhs()) || isAllOnesInt(adaptor.getRhs()))
@@ -1105,8 +1104,11 @@ OpFoldResult IntegerOrOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult IntegerXorOp::fold(FoldAdaptor adaptor) {
-  if (auto result = foldIntegerBitwise(getOperation(), adaptor.getLhs(),
-                                       adaptor.getRhs()))
+  if (auto result =
+          foldIntegerBitwise(getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+                             [](const APSInt &lhs, const APSInt &rhs) {
+                               return success(lhs ^ rhs);
+                             }))
     return result;
   // XOR with all-zeros is identity.
   if (isZeroInt(adaptor.getLhs()))

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -761,7 +761,7 @@ static APSInt getAPSIntForOMIntegerAttr(circt::om::IntegerAttr attr) {
 using IntegerBinaryFn =
     llvm::function_ref<FailureOr<APSInt>(const APSInt &, const APSInt &)>;
 
-static OpFoldResult foldIntegerBinaryArithmetic(Operation *op,
+static OpFoldResult foldIntegerBinaryArithmetic(MLIRContext *ctx,
                                                 Attribute lhsAttr,
                                                 Attribute rhsAttr,
                                                 IntegerBinaryFn evaluate) {
@@ -785,7 +785,6 @@ static OpFoldResult foldIntegerBinaryArithmetic(Operation *op,
   if (failed(result))
     return {};
 
-  auto *ctx = op->getContext();
   // Return the result as a new om::IntegerAttr.
   return circt::om::IntegerAttr::get(
       ctx, mlir::IntegerAttr::get(ctx, result.value()));
@@ -797,7 +796,7 @@ static OpFoldResult foldIntegerBinaryArithmetic(Operation *op,
 
 OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
   return foldIntegerBinaryArithmetic(
-      getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+      getContext(), adaptor.getLhs(), adaptor.getRhs(),
       [](const APSInt &lhs, const APSInt &rhs) { return success(lhs + rhs); });
 }
 
@@ -807,7 +806,7 @@ OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult IntegerMulOp::fold(FoldAdaptor adaptor) {
   return foldIntegerBinaryArithmetic(
-      getOperation(), adaptor.getLhs(), adaptor.getRhs(),
+      getContext(), adaptor.getLhs(), adaptor.getRhs(),
       [](const APSInt &lhs, const APSInt &rhs) { return success(lhs * rhs); });
 }
 
@@ -817,10 +816,16 @@ OpFoldResult IntegerMulOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
   return foldIntegerBinaryArithmetic(
-      getOperation(), adaptor.getLhs(), adaptor.getRhs(),
-      [&](const APSInt &lhs, const APSInt &rhs) {
-        if (!rhs.isNonNegative() || !rhs.isRepresentableByInt64())
-          return FailureOr<APSInt>(emitOpError("invalid shift amount"));
+      getContext(), adaptor.getLhs(), adaptor.getRhs(),
+      [&](const APSInt &lhs, const APSInt &rhs) -> FailureOr<APSInt> {
+        // Check non-negative constraint from operation semantics.
+        if (!rhs.isNonNegative())
+          return (emitOpError("shift amount must be non-negative"), failure());
+        // Check size constraint from implementation detail of using
+        // getExtValue.
+        if (!rhs.isRepresentableByInt64())
+          return (emitOpError("shift amount must be representable in 64 bits"),
+                  failure());
         return success(lhs >> rhs.getExtValue());
       });
 }
@@ -831,12 +836,19 @@ OpFoldResult IntegerShrOp::fold(FoldAdaptor adaptor) {
 
 OpFoldResult IntegerShlOp::fold(FoldAdaptor adaptor) {
   return foldIntegerBinaryArithmetic(
-      getOperation(), adaptor.getLhs(), adaptor.getRhs(),
-      [&](const APSInt &lhs, const APSInt &rhs) {
-        if (!rhs.isNonNegative() || !rhs.isRepresentableByInt64())
-          return FailureOr<APSInt>(emitOpError("invalid shift amount"));
-        auto shift = rhs.getExtValue();
-        return success(lhs.extend(lhs.getBitWidth() + shift) << shift);
+      getContext(), adaptor.getLhs(), adaptor.getRhs(),
+      [&](const APSInt &lhs, const APSInt &rhs) -> FailureOr<APSInt> {
+        // Check non-negative constraint from operation semantics.
+        if (!rhs.isNonNegative())
+          return (emitOpError("shift amount must be non-negative"), failure());
+        // Check size constraint from implementation detail of using
+        // getExtValue.
+        if (!rhs.isRepresentableByInt64())
+          return (emitOpError("shift amount must be representable in 64 bits"),
+                  failure());
+        int64_t shiftAmt = rhs.getExtValue();
+        // Extend lhs to lhsWidth + shiftAmt bits so no bits are truncated.
+        return success(lhs.extend(lhs.getBitWidth() + shiftAmt) << shiftAmt);
       });
 }
 
@@ -1037,8 +1049,7 @@ OpFoldResult PropEqOp::fold(FoldAdaptor adaptor) {
 // IntegerAndOp / IntegerOrOp / IntegerXorOp
 //===----------------------------------------------------------------------===//
 
-static OpFoldResult foldIntegerBitwise(Operation *op, Attribute lhsAttr,
-                                       Attribute rhsAttr,
+static OpFoldResult foldIntegerBitwise(Attribute lhsAttr, Attribute rhsAttr,
                                        IntegerBinaryFn evaluate) {
   auto lhsInt = dyn_cast_or_null<mlir::IntegerAttr>(lhsAttr);
   auto rhsInt = dyn_cast_or_null<mlir::IntegerAttr>(rhsAttr);
@@ -1066,11 +1077,11 @@ static bool isAllOnesInt(Attribute a) {
 }
 
 OpFoldResult IntegerAndOp::fold(FoldAdaptor adaptor) {
-  if (auto result =
-          foldIntegerBitwise(getOperation(), adaptor.getLhs(), adaptor.getRhs(),
-                             [](const APSInt &lhs, const APSInt &rhs) {
-                               return success(lhs & rhs);
-                             }))
+  if (auto result = foldIntegerBitwise(
+          adaptor.getLhs(), adaptor.getRhs(),
+          [](const APSInt &lhs, const APSInt &rhs) {
+            return success(APSInt(lhs & rhs, /*isUnsigned=*/false));
+          }))
     return result;
   // AND with all-zeros is always zero.
   if (isZeroInt(adaptor.getLhs()) || isZeroInt(adaptor.getRhs()))
@@ -1085,11 +1096,11 @@ OpFoldResult IntegerAndOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult IntegerOrOp::fold(FoldAdaptor adaptor) {
-  if (auto result =
-          foldIntegerBitwise(getOperation(), adaptor.getLhs(), adaptor.getRhs(),
-                             [](const APSInt &lhs, const APSInt &rhs) {
-                               return success(lhs | rhs);
-                             }))
+  if (auto result = foldIntegerBitwise(
+          adaptor.getLhs(), adaptor.getRhs(),
+          [](const APSInt &lhs, const APSInt &rhs) {
+            return success(APSInt(lhs | rhs, /*isUnsigned=*/false));
+          }))
     return result;
   // OR with all-ones is always all-ones.
   if (isAllOnesInt(adaptor.getLhs()) || isAllOnesInt(adaptor.getRhs()))
@@ -1104,11 +1115,11 @@ OpFoldResult IntegerOrOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult IntegerXorOp::fold(FoldAdaptor adaptor) {
-  if (auto result =
-          foldIntegerBitwise(getOperation(), adaptor.getLhs(), adaptor.getRhs(),
-                             [](const APSInt &lhs, const APSInt &rhs) {
-                               return success(lhs ^ rhs);
-                             }))
+  if (auto result = foldIntegerBitwise(
+          adaptor.getLhs(), adaptor.getRhs(),
+          [](const APSInt &lhs, const APSInt &rhs) {
+            return success(APSInt(lhs ^ rhs, /*isUnsigned=*/false));
+          }))
     return result;
   // XOR with all-zeros is identity.
   if (isZeroInt(adaptor.getLhs()))


### PR DESCRIPTION
The IntegerBinaryInterface and BinaryEqualityInterface are replaced with local
lambda-based helpers for folding arithmetic, equality, and bitwise operations.

Evaluator started to use folders to evaluate integer operations, so we don't need op interfaces 
anymore. 

Assisted-by: pi.dev: gpt-5.6 luna


<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
