### PR TITLE
[AXI4] Add burst_kind enum and burst_spec attribute

### DIFF
--- a/docs/Dialects/AXI4.md
+++ b/docs/Dialects/AXI4.md
@@ -14,6 +14,14 @@ This dialect is designed to target three primary use-cases:
 - Using the AXI dialect to abstractly model an architecture; the dialect is designed to allow a network to be specified without concrete RTL sources. This allows the dialect to be used to specify a network early in the design process and validate that it meets sanity checks and validation criteria. A later lowering could also use such a description to generate an interconnect-only RTL implementation with top-level ports corresponding to the abstract ports given in the model.
 - Extracting existing full RTL models to the AXI dialect; from an RTL system design with a sufficiently identifiable structure for AXI interfaces, it would theoretically be possible to produce a higher-level description raised to the AXI dialect. This allows users with existing RTL to benefit from the static analysis provided by the dialect, along with other tooling as it develops.
 
+## Attributes
+
+[include "Dialects/AXI4Attributes.md"]
+
+## Enums
+
+[include "Dialects/AXI4Enums.md"]
+
 ## Operations
 
 [include "Dialects/AXI4Ops.md"]

--- a/include/circt/Dialect/AXI4/AXI4.td
+++ b/include/circt/Dialect/AXI4/AXI4.td
@@ -16,6 +16,7 @@
 include "mlir/IR/OpBase.td"
 
 include "circt/Dialect/AXI4/AXI4Dialect.td"
+include "circt/Dialect/AXI4/AXI4Attributes.td"
 include "circt/Dialect/AXI4/AXI4Ops.td"
 
 #endif // CIRCT_DIALECT_AXI4_AXI4_TD

--- a/include/circt/Dialect/AXI4/AXI4Attributes.h
+++ b/include/circt/Dialect/AXI4/AXI4Attributes.h
@@ -6,18 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_H
+#define CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_H
+
 #include "circt/Dialect/AXI4/AXI4Dialect.h"
-#include "circt/Dialect/AXI4/AXI4Ops.h"
+#include "mlir/IR/BuiltinAttributes.h"
 
-using namespace circt;
-using namespace axi4;
+// Pull in the enum definitions.
+#include "circt/Dialect/AXI4/AXI4Enums.h.inc"
 
-void AXI4Dialect::initialize() {
-  registerAttributes();
-  addOperations<
-#define GET_OP_LIST
-#include "circt/Dialect/AXI4/AXI4.cpp.inc"
-      >();
-}
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/AXI4/AXI4Attributes.h.inc"
 
-#include "circt/Dialect/AXI4/AXI4Dialect.cpp.inc"
+#endif // CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_H

--- a/include/circt/Dialect/AXI4/AXI4Attributes.td
+++ b/include/circt/Dialect/AXI4/AXI4Attributes.td
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the attributes for the AXI4 dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_TD
+#define CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_TD
+
+include "circt/Dialect/AXI4/AXI4Dialect.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+
+//===----------------------------------------------------------------------===//
+// Enums
+//===----------------------------------------------------------------------===//
+
+def BurstKindFixed : I32EnumAttrCase<"Fixed", 0, "fixed">;
+def BurstKindIncr  : I32EnumAttrCase<"Incr", 1, "incr">;
+def BurstKindWrap  : I32EnumAttrCase<"Wrap", 2, "wrap">;
+
+def BurstKind : I32EnumAttr<"BurstKind", "AXI4 burst kind",
+    [BurstKindFixed, BurstKindIncr, BurstKindWrap]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::circt::axi4";
+}
+
+//===----------------------------------------------------------------------===//
+// Attributes
+//===----------------------------------------------------------------------===//
+
+class AXI4AttrDef<string name, list<Trait> traits = []> :
+    AttrDef<AXI4Dialect, name, traits>;
+
+def BurstSpecAttr : AXI4AttrDef<"BurstSpec"> {
+  let mnemonic = "burst_spec";
+  let summary = "Describes the burst capabilities of an endpoint";
+  let description = [{
+    Consists of a burst kind and a maximum burst length in beats, e.g.
+    `#axi4.burst_spec<fixed, len = 4>` or `#axi4.burst_spec<incr, len = 256>`.
+
+    AXI4 permits 1-16 beats for `fixed`, 1-256 for `incr`, and only 2, 4, 8, or
+    16 for `wrap`.
+  }];
+
+  let parameters = (ins EnumParameter<BurstKind>:$kind,
+                        "uint32_t":$len);
+
+  let assemblyFormat = "`<` $kind `,` `len` `=` $len `>`";
+
+  let genVerifyDecl = 1;
+}
+
+#endif // CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_TD

--- a/include/circt/Dialect/AXI4/AXI4Dialect.td
+++ b/include/circt/Dialect/AXI4/AXI4Dialect.td
@@ -25,6 +25,12 @@ def AXI4Dialect : Dialect {
   }];
 
   let cppNamespace = "::circt::axi4";
+
+  let useDefaultAttributePrinterParser = 1;
+
+  let extraClassDeclaration = [{
+    void registerAttributes();
+  }];
 }
 
 #endif // CIRCT_DIALECT_AXI4_AXI4DIALECT_TD

--- a/include/circt/Dialect/AXI4/CMakeLists.txt
+++ b/include/circt/Dialect/AXI4/CMakeLists.txt
@@ -1,2 +1,15 @@
 add_circt_dialect(AXI4 axi4)
 add_circt_doc(AXI4Ops Dialects/AXI4Ops -gen-op-doc -dialect axi4)
+add_circt_doc(AXI4Attributes Dialects/AXI4Attributes -gen-attrdef-doc -dialect axi4)
+add_circt_doc(AXI4 Dialects/AXI4Enums -gen-enum-doc -dialect axi4)
+
+set(LLVM_TARGET_DEFINITIONS AXI4.td)
+mlir_tablegen(AXI4Enums.h.inc -gen-enum-decls)
+mlir_tablegen(AXI4Enums.cpp.inc -gen-enum-defs)
+add_public_tablegen_target(MLIRAXI4EnumsIncGen)
+add_dependencies(circt-headers MLIRAXI4EnumsIncGen)
+
+mlir_tablegen(AXI4Attributes.h.inc -gen-attrdef-decls -attrdefs-dialect=axi4)
+mlir_tablegen(AXI4Attributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=axi4)
+add_public_tablegen_target(MLIRAXI4AttributesIncGen)
+add_dependencies(circt-headers MLIRAXI4AttributesIncGen)

--- a/lib/Dialect/AXI4/AXI4Attributes.cpp
+++ b/lib/Dialect/AXI4/AXI4Attributes.cpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/AXI4/AXI4Attributes.h"
+#include "circt/Dialect/AXI4/AXI4Dialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/MathExtras.h"
+
+using namespace circt;
+using namespace axi4;
+using namespace mlir;
+
+#include "circt/Dialect/AXI4/AXI4Enums.cpp.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/AXI4/AXI4Attributes.cpp.inc"
+
+LogicalResult
+BurstSpecAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                      BurstKind kind, uint32_t len) {
+  // AXI4 permits 1-16 beats for 'fixed', 1-256 for 'incr', and only 2, 4, 8,
+  // or 16 for 'wrap'.
+  switch (kind) {
+  case BurstKind::Fixed:
+    if (len == 0 || len > 16)
+      return emitError() << "'fixed' burst 'len' must be between 1 and 16, got "
+                         << len;
+    break;
+  case BurstKind::Incr:
+    if (len == 0 || len > 256)
+      return emitError() << "'incr' burst 'len' must be between 1 and 256, got "
+                         << len;
+    break;
+  case BurstKind::Wrap:
+    if (len < 2 || len > 16 || !llvm::isPowerOf2_32(len))
+      return emitError() << "'wrap' burst 'len' must be 2, 4, 8, or 16, got "
+                         << len;
+    break;
+  }
+  return success();
+}
+
+void AXI4Dialect::registerAttributes() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "circt/Dialect/AXI4/AXI4Attributes.cpp.inc"
+      >();
+}

--- a/lib/Dialect/AXI4/CMakeLists.txt
+++ b/lib/Dialect/AXI4/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTAXI4
+  AXI4Attributes.cpp
   AXI4Dialect.cpp
   AXI4Ops.cpp
 

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt %s --allow-unregistered-dialect | circt-opt --allow-unregistered-dialect | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Attributes
+//===----------------------------------------------------------------------===//
+
+// CHECK: #axi4.burst_spec<fixed, len = 1>
+"test.attrs"() {a = #axi4.burst_spec<fixed, len = 1>} : () -> ()
+// CHECK: #axi4.burst_spec<fixed, len = 16>
+"test.attrs"() {a = #axi4.burst_spec<fixed, len = 16>} : () -> ()
+// CHECK: #axi4.burst_spec<incr, len = 1>
+"test.attrs"() {a = #axi4.burst_spec<incr, len = 1>} : () -> ()
+// CHECK: #axi4.burst_spec<incr, len = 256>
+"test.attrs"() {a = #axi4.burst_spec<incr, len = 256>} : () -> ()
+// CHECK: #axi4.burst_spec<wrap, len = 2>
+"test.attrs"() {a = #axi4.burst_spec<wrap, len = 2>} : () -> ()
+// CHECK: #axi4.burst_spec<wrap, len = 16>
+"test.attrs"() {a = #axi4.burst_spec<wrap, len = 16>} : () -> ()

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -1,0 +1,39 @@
+// RUN: circt-opt %s --allow-unregistered-dialect --split-input-file --verify-diagnostics
+
+// expected-error @below {{expected ','}}
+"test.attrs"() {a = #axi4.burst_spec<fixed>} : () -> ()
+
+// -----
+
+// expected-error @below {{'fixed' burst 'len' must be between 1 and 16, got 0}}
+"test.attrs"() {a = #axi4.burst_spec<fixed, len = 0>} : () -> ()
+
+// -----
+
+// expected-error @below {{'fixed' burst 'len' must be between 1 and 16, got 17}}
+"test.attrs"() {a = #axi4.burst_spec<fixed, len = 17>} : () -> ()
+
+// -----
+
+// expected-error @below {{'incr' burst 'len' must be between 1 and 256, got 0}}
+"test.attrs"() {a = #axi4.burst_spec<incr, len = 0>} : () -> ()
+
+// -----
+
+// expected-error @below {{'incr' burst 'len' must be between 1 and 256, got 257}}
+"test.attrs"() {a = #axi4.burst_spec<incr, len = 257>} : () -> ()
+
+// -----
+
+// expected-error @below {{'wrap' burst 'len' must be 2, 4, 8, or 16, got 1}}
+"test.attrs"() {a = #axi4.burst_spec<wrap, len = 1>} : () -> ()
+
+// -----
+
+// expected-error @below {{'wrap' burst 'len' must be 2, 4, 8, or 16, got 7}}
+"test.attrs"() {a = #axi4.burst_spec<wrap, len = 7>} : () -> ()
+
+// -----
+
+// expected-error @below {{'wrap' burst 'len' must be 2, 4, 8, or 16, got 32}}
+"test.attrs"() {a = #axi4.burst_spec<wrap, len = 32>} : () -> ()


### PR DESCRIPTION
Adds the attributes used to describe burst capabilities of AXI4 endpoints (as proposed in [this RFC](https://discourse.llvm.org/t/rfc-axi4-dialect/91395) - a couple of design points remain open there but this part isn't dependent on that discussion)

AI-assisted-by: Claude Opus 5 (1M context)
