### PR TITLE
[Arc] Support aggregate types in arc.arrayref.alloc

### DIFF
--- a/integration_test/arcilator/JIT/aggregate-types.mlir
+++ b/integration_test/arcilator/JIT/aggregate-types.mlir
@@ -1,0 +1,122 @@
+// RUN: arcilator %s --run --jit-entry=main | FileCheck --match-full-lines %s
+// REQUIRES: arcilator-jit
+
+// End-to-end JIT execution test for aggregate element types in arrays,
+// validating support for HW structs and HW arrays in arc.arrayref.alloc
+// (including zero-initialization of nested aggregate attributes).
+
+// CHECK:      struct_v0 = 0
+// CHECK-NEXT: struct_val0 = 0000
+// CHECK-NEXT: struct_v1 = 1
+// CHECK-NEXT: struct_val1 = 1234
+// CHECK-NEXT: arr_a0_e0 = 00
+// CHECK-NEXT: arr_a0_e1 = 00
+// CHECK-NEXT: arr_a1_e0 = 22
+// CHECK-NEXT: arr_a1_e1 = 11
+// CHECK-NEXT: nested_v0 = 0
+// CHECK-NEXT: nested_d0_e0 = 00
+// CHECK-NEXT: nested_v1 = 1
+// CHECK-NEXT: nested_d1_e0 = bb
+
+hw.module @ArrayOfStruct(out valid0: i1, out val0: i16, out valid1: i1, out val1: i16) {
+  // Array of structs with zero initialization.
+  %arr_zero = hw.aggregate_constant [[false, 0 : i16], [false, 0 : i16]] : !hw.array<2x!hw.struct<valid: i1, val: i16>>
+  %c_true = hw.constant true
+  %c_val = hw.constant 0x1234 : i16
+  %new_struct = hw.struct_create (%c_true, %c_val) : !hw.struct<valid: i1, val: i16>
+  %c_idx0 = hw.constant 0 : i1
+  %c_idx1 = hw.constant 1 : i1
+  %arr_updated = hw.array_inject %arr_zero[%c_idx1], %new_struct : !hw.array<2x!hw.struct<valid: i1, val: i16>>, i1
+
+  %elem0 = hw.array_get %arr_updated[%c_idx0] : !hw.array<2x!hw.struct<valid: i1, val: i16>>, i1
+  %v0 = hw.struct_extract %elem0["valid"] : !hw.struct<valid: i1, val: i16>
+  %val0_res = hw.struct_extract %elem0["val"] : !hw.struct<valid: i1, val: i16>
+
+  %elem1 = hw.array_get %arr_updated[%c_idx1] : !hw.array<2x!hw.struct<valid: i1, val: i16>>, i1
+  %v1 = hw.struct_extract %elem1["valid"] : !hw.struct<valid: i1, val: i16>
+  %val1_res = hw.struct_extract %elem1["val"] : !hw.struct<valid: i1, val: i16>
+
+  hw.output %v0, %val0_res, %v1, %val1_res : i1, i16, i1, i16
+}
+
+hw.module @ArrayOfArray(out a0_e0: i8, out a0_e1: i8, out a1_e0: i8, out a1_e1: i8) {
+  // Array of arrays with zero initialization.
+  %arr_zero = hw.aggregate_constant [[0 : i8, 0 : i8], [0 : i8, 0 : i8]] : !hw.array<2x!hw.array<2xi8>>
+  %new_subarr = hw.aggregate_constant [0x11 : i8, 0x22 : i8] : !hw.array<2xi8>
+  %c_idx0 = hw.constant 0 : i1
+  %c_idx1 = hw.constant 1 : i1
+  %arr_updated = hw.array_inject %arr_zero[%c_idx1], %new_subarr : !hw.array<2x!hw.array<2xi8>>, i1
+
+  %elem0 = hw.array_get %arr_updated[%c_idx0] : !hw.array<2x!hw.array<2xi8>>, i1
+  %a0_e0_res = hw.array_get %elem0[%c_idx0] : !hw.array<2xi8>, i1
+  %a0_e1_res = hw.array_get %elem0[%c_idx1] : !hw.array<2xi8>, i1
+
+  %elem1 = hw.array_get %arr_updated[%c_idx1] : !hw.array<2x!hw.array<2xi8>>, i1
+  %a1_e0_res = hw.array_get %elem1[%c_idx0] : !hw.array<2xi8>, i1
+  %a1_e1_res = hw.array_get %elem1[%c_idx1] : !hw.array<2xi8>, i1
+
+  hw.output %a0_e0_res, %a0_e1_res, %a1_e0_res, %a1_e1_res : i8, i8, i8, i8
+}
+
+hw.module @ArrayOfStructWithArray(out valid0: i1, out data0_e0: i8, out valid1: i1, out data1_e0: i8) {
+  // Array of structs containing nested arrays with zero initialization.
+  %arr_zero = hw.aggregate_constant [[false, [0 : i8, 0 : i8]], [false, [0 : i8, 0 : i8]]] : !hw.array<2x!hw.struct<valid: i1, data: !hw.array<2xi8>>>
+  %c_true = hw.constant true
+  %new_subarr = hw.aggregate_constant [0xAA : i8, 0xBB : i8] : !hw.array<2xi8>
+  %new_struct = hw.struct_create (%c_true, %new_subarr) : !hw.struct<valid: i1, data: !hw.array<2xi8>>
+  %c_idx0 = hw.constant 0 : i1
+  %c_idx1 = hw.constant 1 : i1
+  %arr_updated = hw.array_inject %arr_zero[%c_idx1], %new_struct : !hw.array<2x!hw.struct<valid: i1, data: !hw.array<2xi8>>>, i1
+
+  %elem0 = hw.array_get %arr_updated[%c_idx0] : !hw.array<2x!hw.struct<valid: i1, data: !hw.array<2xi8>>>, i1
+  %v0 = hw.struct_extract %elem0["valid"] : !hw.struct<valid: i1, data: !hw.array<2xi8>>
+  %d0 = hw.struct_extract %elem0["data"] : !hw.struct<valid: i1, data: !hw.array<2xi8>>
+  %d0_e0 = hw.array_get %d0[%c_idx0] : !hw.array<2xi8>, i1
+
+  %elem1 = hw.array_get %arr_updated[%c_idx1] : !hw.array<2x!hw.struct<valid: i1, data: !hw.array<2xi8>>>, i1
+  %v1 = hw.struct_extract %elem1["valid"] : !hw.struct<valid: i1, data: !hw.array<2xi8>>
+  %d1 = hw.struct_extract %elem1["data"] : !hw.struct<valid: i1, data: !hw.array<2xi8>>
+  %d1_e0 = hw.array_get %d1[%c_idx0] : !hw.array<2xi8>, i1
+
+  hw.output %v0, %d0_e0, %v1, %d1_e0 : i1, i8, i1, i8
+}
+
+func.func @main() {
+  arc.sim.instantiate @ArrayOfStruct as %model_struct {
+    arc.sim.step %model_struct : !arc.sim.instance<@ArrayOfStruct>
+    %v0 = arc.sim.get_port %model_struct, "valid0" : i1, !arc.sim.instance<@ArrayOfStruct>
+    %val0 = arc.sim.get_port %model_struct, "val0" : i16, !arc.sim.instance<@ArrayOfStruct>
+    %v1 = arc.sim.get_port %model_struct, "valid1" : i1, !arc.sim.instance<@ArrayOfStruct>
+    %val1 = arc.sim.get_port %model_struct, "val1" : i16, !arc.sim.instance<@ArrayOfStruct>
+    arc.sim.emit "struct_v0", %v0 : i1
+    arc.sim.emit "struct_val0", %val0 : i16
+    arc.sim.emit "struct_v1", %v1 : i1
+    arc.sim.emit "struct_val1", %val1 : i16
+  }
+
+  arc.sim.instantiate @ArrayOfArray as %model_array {
+    arc.sim.step %model_array : !arc.sim.instance<@ArrayOfArray>
+    %a0_e0 = arc.sim.get_port %model_array, "a0_e0" : i8, !arc.sim.instance<@ArrayOfArray>
+    %a0_e1 = arc.sim.get_port %model_array, "a0_e1" : i8, !arc.sim.instance<@ArrayOfArray>
+    %a1_e0 = arc.sim.get_port %model_array, "a1_e0" : i8, !arc.sim.instance<@ArrayOfArray>
+    %a1_e1 = arc.sim.get_port %model_array, "a1_e1" : i8, !arc.sim.instance<@ArrayOfArray>
+    arc.sim.emit "arr_a0_e0", %a0_e0 : i8
+    arc.sim.emit "arr_a0_e1", %a0_e1 : i8
+    arc.sim.emit "arr_a1_e0", %a1_e0 : i8
+    arc.sim.emit "arr_a1_e1", %a1_e1 : i8
+  }
+
+  arc.sim.instantiate @ArrayOfStructWithArray as %model_nested {
+    arc.sim.step %model_nested : !arc.sim.instance<@ArrayOfStructWithArray>
+    %v0 = arc.sim.get_port %model_nested, "valid0" : i1, !arc.sim.instance<@ArrayOfStructWithArray>
+    %d0_e0 = arc.sim.get_port %model_nested, "data0_e0" : i8, !arc.sim.instance<@ArrayOfStructWithArray>
+    %v1 = arc.sim.get_port %model_nested, "valid1" : i1, !arc.sim.instance<@ArrayOfStructWithArray>
+    %d1_e0 = arc.sim.get_port %model_nested, "data1_e0" : i8, !arc.sim.instance<@ArrayOfStructWithArray>
+    arc.sim.emit "nested_v0", %v0 : i1
+    arc.sim.emit "nested_d0_e0", %d0_e0 : i8
+    arc.sim.emit "nested_v1", %v1 : i1
+    arc.sim.emit "nested_d1_e0", %d1_e0 : i8
+  }
+
+  return
+}

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -1524,9 +1524,12 @@ struct ArrayRefAllocOpLowering : public OpConversionPattern<ArrayRefAllocOp> {
     return alignment;
   }
 
-  bool isZero(ArrayAttr arrayAttr) const {
-    return llvm::all_of(arrayAttr.getAsValueRange<IntegerAttr>(),
-                        [](APInt i) { return i.isZero(); });
+  static bool isZero(Attribute attr) {
+    if (auto intAttr = dyn_cast<IntegerAttr>(attr))
+      return intAttr.getValue().isZero();
+    if (auto arrayAttr = dyn_cast<ArrayAttr>(attr))
+      return llvm::all_of(arrayAttr, [](Attribute a) { return isZero(a); });
+    return false;
   }
 
   void initializeArray(ConversionPatternRewriter &rewriter, Location loc,

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/Arc/ArcOps.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "circt/Dialect/HW/HWTypes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
@@ -924,11 +925,14 @@ LogicalResult ArrayRefAllocOp::verify() {
              << getType().getNumElements();
     }
 
-    unsigned elemBitwidth = getType().getElementType().getIntOrFloatBitWidth();
-    for (APInt value : init->getAsValueRange<IntegerAttr>()) {
-      if (value.getBitWidth() != elemBitwidth) {
-        return emitOpError("expected element to be of type ")
-               << getType().getElementType();
+    if (auto intTy = dyn_cast<IntegerType>(getType().getElementType())) {
+      unsigned elemBitwidth = intTy.getWidth();
+      for (Attribute attr : *init) {
+        auto intAttr = dyn_cast<IntegerAttr>(attr);
+        if (!intAttr || intAttr.getValue().getBitWidth() != elemBitwidth) {
+          return emitOpError("expected element to be of type ")
+                 << getType().getElementType();
+        }
       }
     }
   }

--- a/test/Conversion/ArcToLLVM/arrayref.mlir
+++ b/test/Conversion/ArcToLLVM/arrayref.mlir
@@ -164,3 +164,25 @@ func.func @ArrayRefFromArray(%arg0: !arc.arrayref<2xi32>, %arg1: !hw.array<2xi32
   return %0 : !arc.arrayref<2xi32>
 }
 
+// CHECK-LABEL: @ArrayRefInitZeroStruct
+// CHECK-NEXT: %[[C4:.*]] = llvm.mlir.constant(4 : i64)
+// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C4]] x i8 {alignment = 4 : i64}
+// CHECK-NEXT: %[[ZERO:.*]] = llvm.mlir.constant(0 : i8)
+// CHECK-NEXT: "llvm.intr.memset"(%[[A]], %[[ZERO]], %[[C4]])
+// CHECK-NEXT: return %[[A]]
+func.func @ArrayRefInitZeroStruct() -> !arc.arrayref<2x!hw.struct<foo: i1, bar: i8>> {
+  %0 = arc.arrayref.alloc init([[false, 0 : i8], [false, 0 : i8]]) : !arc.arrayref<2x!hw.struct<foo: i1, bar: i8>>
+  return %0 : !arc.arrayref<2x!hw.struct<foo: i1, bar: i8>>
+}
+
+// CHECK-LABEL: @ArrayRefInitZeroArray
+// CHECK-NEXT: %[[C8:.*]] = llvm.mlir.constant(8 : i64)
+// CHECK-NEXT: %[[A:.*]] = llvm.alloca %[[C8]] x i8 {alignment = 4 : i64}
+// CHECK-NEXT: %[[ZERO:.*]] = llvm.mlir.constant(0 : i8)
+// CHECK-NEXT: "llvm.intr.memset"(%[[A]], %[[ZERO]], %[[C8]])
+// CHECK-NEXT: return %[[A]]
+func.func @ArrayRefInitZeroArray() -> !arc.arrayref<2x!hw.array<1xi32>> {
+  %0 = arc.arrayref.alloc init([[0 : i32], [0 : i32]]) : !arc.arrayref<2x!hw.array<1xi32>>
+  return %0 : !arc.arrayref<2x!hw.array<1xi32>>
+}
+

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -455,3 +455,17 @@ arc.coroutine.define @CoroutineInstanceB(%arg0: i42) -> (i9001, i1, i64) {
   %c0_i64 = hw.constant 0 : i64
   arc.coroutine.halt %c0_i9001, %c0_i1, %c0_i64 : i9001, i1, i64
 }
+
+// CHECK-LABEL: func.func @ArrayRefAllocAggregate
+// CHECK: arc.arrayref.alloc init([123 : i32, 456 : i32]) : <2x!hw.array<1xi32>>
+func.func @ArrayRefAllocAggregate() -> !arc.arrayref<2x!hw.array<1xi32>> {
+  %0 = arc.arrayref.alloc init([123 : i32, 456 : i32]) : !arc.arrayref<2x!hw.array<1xi32>>
+  return %0 : !arc.arrayref<2x!hw.array<1xi32>>
+}
+
+// CHECK-LABEL: func.func @ArrayRefAllocStruct
+// CHECK: arc.arrayref.alloc init([false, true]) : <2x!hw.struct<foo: i1>>
+func.func @ArrayRefAllocStruct() -> !arc.arrayref<2x!hw.struct<foo: i1>> {
+  %0 = arc.arrayref.alloc init([false, true]) : !arc.arrayref<2x!hw.struct<foo: i1>>
+  return %0 : !arc.arrayref<2x!hw.struct<foo: i1>>
+}


### PR DESCRIPTION
RFC a bit if desirable or other plans for handling aggregate element types. Ran into this when trying to simulate Verilog input with these. It could though also be that I missed a pass (but was using the upstream pipeline registration helpers).

This change relaxes the verification of arc.arrayref.alloc to support aggregate element types, such as HW arrays and structs.

The verification in ArcOps is updated to only enforce integer bitwidth checks when the element type is an IntegerType. Additionally, the isZero helper in LowerArcToLLVM is updated to recursively check nested attributes. Test cases are added to verify allocation of arrays of HW arrays and HW structs.

Assisted-By: Gemini
