### PR TITLE
[LTL] Add `weak` and `strong` sequence ops

### DIFF
--- a/docs/Dialects/LTL.md
+++ b/docs/Dialects/LTL.md
@@ -485,8 +485,15 @@ ltl.not %s1 : !ltl.sequence
 %res = ltl.not %impl : !ltl.property  
 ```
 
-- **`strong(s)`**: default for coverpoints, not supported in other cases.
-- **`weak(s)`**: default for assert and assume, not supported for cover.  
+- **`strong(s)`**: 
+```mlir
+ltl.strong %s : !ltl.sequence  
+```  
+
+- **`weak(s)`**:
+```mlir
+ltl.weak %s : !ltl.sequence  
+```  
 
 - **`nexttime p`**:   
 ```mlir

--- a/include/circt/Dialect/LTL/LTLOps.td
+++ b/include/circt/Dialect/LTL/LTLOps.td
@@ -131,6 +131,36 @@ def ClockedAtomOp : LTLOp<"clocked_atom", [Pure]> {
 // Sequences
 //===----------------------------------------------------------------------===//
 
+// Defines the general form of the weak and strong operations
+class TerminationTypeOp<string mnemonic, list<Trait> traits = []> :
+  LTLOp<mnemonic, traits # [Pure]> {
+  let arguments = (ins LTLSequenceType:$input);
+  let results = (outs LTLPropertyType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input)
+  }];
+}
+
+def WeakOp : TerminationTypeOp<"weak"> {
+  let summary = "Defines a 'weak' sequence";
+  let description = [{
+    Defines a property from a 'weak' sequence, which is a sequence which does not 
+    define any requirements on the termination of a given sequence observation. 
+    This means that a weak sequence is considered to hold as long as a violation of 
+    the sequence is never observed within a finite trace.
+  }];
+}
+
+def StrongOp : TerminationTypeOp<"strong"> {
+  let summary = "Defines a 'strong' sequence";
+  let description = [{
+    Defines a property from a 'strong' sequence, which is a sequence whose observations 
+    must always be complete in order to hold. This is a complement behavior to a weak 
+    sequence, in that a partial observation of a strong sequence, i.e. the trace 
+    terminates before the sequence can be fully observed, is considered a violation.
+  }];
+}
+
 def DelayOp : LTLOp<"delay", [Pure]> {
   let arguments = (ins
     LTLAnySequenceType:$input,

--- a/include/circt/Dialect/LTL/LTLOps.td
+++ b/include/circt/Dialect/LTL/LTLOps.td
@@ -134,7 +134,7 @@ def ClockedAtomOp : LTLOp<"clocked_atom", [Pure]> {
 // Defines the general form of the weak and strong operations
 class TerminationTypeOp<string mnemonic, list<Trait> traits = []> :
   LTLOp<mnemonic, traits # [Pure]> {
-  let arguments = (ins LTLSequenceType:$input);
+  let arguments = (ins LTLAnySequenceType:$input);
   let results = (outs LTLPropertyType:$result);
   let assemblyFormat = [{
     $input attr-dict `:` type($input)

--- a/include/circt/Dialect/LTL/LTLVisitors.h
+++ b/include/circt/Dialect/LTL/LTLVisitors.h
@@ -24,7 +24,7 @@ public:
         .template Case<AndOp, OrOp, DelayOp, ClockedDelayOp, ConcatOp, RepeatOp,
                        NotOp, ImplicationOp, UntilOp, EventuallyOp, ClockOp,
                        ClockedAtomOp, IntersectOp, NonConsecutiveRepeatOp,
-                       GoToRepeatOp, BooleanConstantOp>(
+                       GoToRepeatOp, BooleanConstantOp, WeakOp, StrongOp>(
             [&](auto op) -> ResultType {
               return thisCast->visitLTL(op, args...);
             })
@@ -66,6 +66,8 @@ public:
   HANDLE(NonConsecutiveRepeatOp, Unhandled);
   HANDLE(GoToRepeatOp, Unhandled);
   HANDLE(BooleanConstantOp, Unhandled);
+  HANDLE(WeakOp, Unhandled);
+  HANDLE(StrongOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3643,7 +3643,7 @@ private:
   EmittedProperty visitLTL(ltl::WeakOp op);
   EmittedProperty visitLTL(ltl::StrongOp op);
 
-  EmittedProperty emitWeakStrongOp(std::string mnemonic, Value input);
+  EmittedProperty emitWeakStrongOp(StringRef mnemonic, Value input);
   void emitLTLDelay(int64_t delay, std::optional<int64_t> length);
   void emitLTLClockingEvent(ltl::ClockEdge edge, Value clock);
   void emitLTLConcat(ValueRange inputs);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1817,8 +1817,8 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
             os << " struct packed {";
             if (element.offset) {
               os << (emitAsTwoStateType ? "bit" : "logic") << " ["
-                 << element.offset - 1 << ":0] " << "__pre_padding_"
-                 << element.name.getValue() << "; ";
+                 << element.offset - 1 << ":0] "
+                 << "__pre_padding_" << element.name.getValue() << "; ";
             }
           }
 
@@ -2320,7 +2320,8 @@ private:
 
   /// Emit braced list of values surrounded by `{` and `}`.
   void emitBracedList(ValueRange ops) {
-    return emitBracedList(ops, [&]() { ps << "{"; }, [&]() { ps << "}"; });
+    return emitBracedList(
+        ops, [&]() { ps << "{"; }, [&]() { ps << "}"; });
   }
 
   /// Print an APInt constant.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3640,7 +3640,10 @@ private:
   EmittedProperty visitLTL(ltl::UntilOp op);
   EmittedProperty visitLTL(ltl::EventuallyOp op);
   EmittedProperty visitLTL(ltl::ClockOp op);
+  EmittedProperty visitLTL(ltl::WeakOp op);
+  EmittedProperty visitLTL(ltl::StrongOp op);
 
+  EmittedProperty emitWeakStrongOp(std::string mnemonic, Value input);
   void emitLTLDelay(int64_t delay, std::optional<int64_t> length);
   void emitLTLClockingEvent(ltl::ClockEdge edge, Value clock);
   void emitLTLConcat(ValueRange inputs);
@@ -3991,6 +3994,24 @@ EmittedProperty PropertyEmitter::visitLTL(ltl::ClockOp op) {
   ps << PP::space;
   emitNestedProperty(op.getInput(), PropertyPrecedence::Clocking);
   return {PropertyPrecedence::Clocking};
+}
+
+// Weak and strong are emitted identically
+EmittedProperty PropertyEmitter::emitWeakStrongOp(std::string mnemonic, Value input) {
+  ps << mnemonic << PP::space << "(";
+  ps.scopedBox(PP::ibox2, [&] {
+    emitNestedProperty(input, PropertyPrecedence::Unary);
+    ps << ")";
+  });
+  return {PropertyPrecedence::Unary};
+}
+
+EmittedProperty PropertyEmitter::visitLTL(ltl::WeakOp op) {
+  return emitWeakStrongOp("weak", op.getInput());
+}
+
+EmittedProperty PropertyEmitter::visitLTL(ltl::StrongOp op) {
+  return emitWeakStrongOp("strong", op.getInput());
 }
 
 // NOLINTEND(misc-no-recursion)

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4004,7 +4004,7 @@ EmittedProperty PropertyEmitter::emitWeakStrongOp(std::string mnemonic,
     emitNestedProperty(input, PropertyPrecedence::Unary);
     ps << ")";
   });
-  return {PropertyPrecedence::Unary};
+  return {PropertyPrecedence::Lowest};
 }
 
 EmittedProperty PropertyEmitter::visitLTL(ltl::WeakOp op) {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1817,8 +1817,8 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
             os << " struct packed {";
             if (element.offset) {
               os << (emitAsTwoStateType ? "bit" : "logic") << " ["
-                 << element.offset - 1 << ":0] "
-                 << "__pre_padding_" << element.name.getValue() << "; ";
+                 << element.offset - 1 << ":0] " << "__pre_padding_"
+                 << element.name.getValue() << "; ";
             }
           }
 
@@ -2320,8 +2320,7 @@ private:
 
   /// Emit braced list of values surrounded by `{` and `}`.
   void emitBracedList(ValueRange ops) {
-    return emitBracedList(
-        ops, [&]() { ps << "{"; }, [&]() { ps << "}"; });
+    return emitBracedList(ops, [&]() { ps << "{"; }, [&]() { ps << "}"; });
   }
 
   /// Print an APInt constant.
@@ -3997,7 +3996,8 @@ EmittedProperty PropertyEmitter::visitLTL(ltl::ClockOp op) {
 }
 
 // Weak and strong are emitted identically
-EmittedProperty PropertyEmitter::emitWeakStrongOp(std::string mnemonic, Value input) {
+EmittedProperty PropertyEmitter::emitWeakStrongOp(std::string mnemonic,
+                                                  Value input) {
   ps << mnemonic << PP::space << "(";
   ps.scopedBox(PP::ibox2, [&] {
     emitNestedProperty(input, PropertyPrecedence::Unary);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1817,8 +1817,8 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
             os << " struct packed {";
             if (element.offset) {
               os << (emitAsTwoStateType ? "bit" : "logic") << " ["
-                 << element.offset - 1 << ":0] "
-                 << "__pre_padding_" << element.name.getValue() << "; ";
+                 << element.offset - 1 << ":0] " << "__pre_padding_"
+                 << element.name.getValue() << "; ";
             }
           }
 
@@ -2320,8 +2320,7 @@ private:
 
   /// Emit braced list of values surrounded by `{` and `}`.
   void emitBracedList(ValueRange ops) {
-    return emitBracedList(
-        ops, [&]() { ps << "{"; }, [&]() { ps << "}"; });
+    return emitBracedList(ops, [&]() { ps << "{"; }, [&]() { ps << "}"; });
   }
 
   /// Print an APInt constant.
@@ -3997,7 +3996,7 @@ EmittedProperty PropertyEmitter::visitLTL(ltl::ClockOp op) {
 }
 
 // Weak and strong are emitted identically
-EmittedProperty PropertyEmitter::emitWeakStrongOp(std::string mnemonic,
+EmittedProperty PropertyEmitter::emitWeakStrongOp(StringRef mnemonic,
                                                   Value input) {
   ps << mnemonic << PP::space << "(";
   ps.scopedBox(PP::ibox2, [&] {

--- a/test/Conversion/ExportVerilog/verif.mlir
+++ b/test/Conversion/ExportVerilog/verif.mlir
@@ -302,6 +302,24 @@ hw.module @Precedence(in %a: i1, in %b: i1) {
   sv.assert_property %ag11 : !ltl.property
 }
 
+// CHECK-LABEL: module WeakAndStrongSequences
+hw.module @WeakAndStrongSequences(in %clk: i1, in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1) {
+  // CHECK: assert property (weak (a ##1 b ##0 c ##1 d));
+  %a0 = ltl.delay %b, 1, 0 : i1
+  %a1 = ltl.delay %d, 1, 0 : i1
+  %a2 = ltl.concat %a, %a0 : i1, !ltl.sequence
+  %a3 = ltl.concat %c, %a1 : i1, !ltl.sequence
+  %a4 = ltl.concat %a2, %a3 : !ltl.sequence, !ltl.sequence
+  %ws = ltl.weak %a4 : !ltl.sequence
+  sv.assert_property %ws : !ltl.property
+
+  // CHECK: assert property (strong (b ##1 c ##1 d));
+  %b0 = ltl.delay %c, 1, 0 : i1
+  %b1 = ltl.concat %b, %b0, %a1 : i1, !ltl.sequence, !ltl.sequence
+  %ss = ltl.strong %b1 : !ltl.sequence
+  sv.assert_property %ss : !ltl.property
+}
+
 // CHECK-LABEL: module SystemVerilogSpecExamples
 hw.module @SystemVerilogSpecExamples(in %clk: i1, in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1) {
   // Section 16.7 "Sequences"

--- a/test/Conversion/ExportVerilog/verif.mlir
+++ b/test/Conversion/ExportVerilog/verif.mlir
@@ -303,7 +303,7 @@ hw.module @Precedence(in %a: i1, in %b: i1) {
 }
 
 // CHECK-LABEL: module WeakAndStrongSequences
-hw.module @WeakAndStrongSequences(in %clk: i1, in %a: i1, in %b: i1, in %c: i1, in %d: i1, in %e: i1) {
+hw.module @WeakAndStrongSequences(in %a: i1, in %b: i1, in %c: i1, in %d: i1) {
   // CHECK: assert property (weak (a ##1 b ##0 c ##1 d));
   %a0 = ltl.delay %b, 1, 0 : i1
   %a1 = ltl.delay %d, 1, 0 : i1

--- a/test/Dialect/LTL/basic.mlir
+++ b/test/Dialect/LTL/basic.mlir
@@ -75,6 +75,11 @@ ltl.repeat %s, 0 : !ltl.sequence
 ltl.repeat %s, 42 : !ltl.sequence
 ltl.repeat %s, 42, 1337 : !ltl.sequence
 
+// CHECK: ltl.weak {{%.+}} : !ltl.sequence
+// CHECK: ltl.strong {{%.+}} : !ltl.sequence
+ltl.weak %s : !ltl.sequence
+ltl.strong %s : !ltl.sequence
+
 //===----------------------------------------------------------------------===//
 // Properties
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
As a first PR of my goal of adding full SVA support in the context of inter-operating with property-ir, here are the weak and strong sequence operators. These follow the SV standard fairly closely and allow the user to express how they want to handle partial sequence evaluations within a finite trace (mostly for simulation but can be used in bmc depending on the implementation).

*No environmentally destructive tools were involved in the writing of this 100% human produced pull request*