### PR TITLE
[Synth] Handle firmem in resource usage analysis

### DIFF
--- a/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
+++ b/lib/Dialect/Synth/Analysis/ResourceUsageAnalysis.cpp
@@ -46,6 +46,15 @@ using namespace synth;
 /// Returns true if the operation was tracked, false otherwise.
 static bool accumulateResourceCounts(Operation *op,
                                      llvm::StringMap<uint64_t> &counts) {
+  // Memory declarations do not produce integer values, and memory ports are
+  // already accounted for by their declaration.
+  if (auto memory = dyn_cast<seq::FirMemOp>(op)) {
+    auto type = memory.getMemory().getType();
+    counts[op->getName().getStringRef()] += type.getDepth() * type.getWidth();
+    return true;
+  }
+  if (isa<seq::FirMemReadOp, seq::FirMemWriteOp, seq::FirMemReadWriteOp>(op))
+    return true;
   if (op->getNumResults() != 1 || !op->getResult(0).getType().isInteger())
     return false;
   return TypeSwitch<Operation *, bool>(op)

--- a/test/Dialect/Synth/resource.mlir
+++ b/test/Dialect/Synth/resource.mlir
@@ -133,6 +133,22 @@ hw.module private @nested(in %a : i1, in %b : i1, in %c : i1, out x : i1) {
   hw.output %or : i1
 }
 
+// Test memory operations. Memory storage is counted in bits and memory ports
+// are not reported as unknown operations.
+// CHECK:      Resource Usage Analysis for module: memory
+// CHECK-NEXT: ========================================
+// CHECK-NEXT: Total:
+// CHECK-NEXT:   seq.firmem: 128
+
+hw.module private @memory(in %clk : !seq.clock, in %addr : i2, in %data : i32,
+                          in %mode : i1, out result : i32) {
+  %mem = seq.firmem 0, 1, undefined, port_order : <4 x 32>
+  %read = seq.firmem.read_port %mem[%addr], clock %clk : <4 x 32>
+  seq.firmem.write_port %mem[%addr] = %data, clock %clk : <4 x 32>
+  %readWrite = seq.firmem.read_write_port %mem[%addr] = %data if %mode, clock %clk : <4 x 32>
+  hw.output %readWrite : i32
+}
+
 // Test truth table operations
 // CHECK:      Resource Usage Analysis for module: lut_test
 // CHECK-NEXT: ========================================


### PR DESCRIPTION
Add support for handling `firmem` operations within the resource usage 
analysis pass. 

Assisted-by: pi.dev: gpt 5.6 luna


<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
