### PR TITLE
[AXI4] Add burst_set attribute

### DIFF
--- a/include/circt/Dialect/AXI4/AXI4Attributes.td
+++ b/include/circt/Dialect/AXI4/AXI4Attributes.td
@@ -55,6 +55,45 @@ def BurstSpecAttr : AXI4AttrDef<"BurstSpec"> {
   let assemblyFormat = "`<` $kind `,` `len` `=` $len `>`";
 
   let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// Ordering over burst_specs for canonical typing
+    static bool compareCanonical(BurstSpecAttr lhs, BurstSpecAttr rhs);
+  }];
+}
+
+def BurstSetAttr : AXI4AttrDef<"BurstSet"> {
+  let mnemonic = "burst_set";
+  let summary = "Describes a non-empty set of burst specs supported by an endpoint";
+  let description = [{
+    A non-empty set of burst specs, e.g. `#axi4.burst_set<<fixed, len = 4>>` or
+    `#axi4.burst_set<<fixed, len = 4>, <incr, len = 8>>`.
+
+    To avoid functionally equivalent types (e.g. types containing burst_sets with
+    the same specs in different orders) being structurally inequivalent, this is
+    sorted and de-duplicated on construction.
+  }];
+
+  let parameters = (ins
+      OptionalArrayRefParameter<"::circt::axi4::BurstSpecAttr">:$burstSpecs);
+
+  // Parse empty sets - catch them in the verifier to avoid a very opaque error
+  let assemblyFormat = "`<` (`>`) : ($burstSpecs^ `>`)?";
+
+  // Force all clients through the canonicalizing builder below.
+  let skipDefaultBuilders = 1;
+  let genVerifyDecl = 1;
+
+  let builders = [
+    AttrOrTypeBuilder<(ins
+        "::llvm::ArrayRef<::circt::axi4::BurstSpecAttr>":$burstSpecs), [{
+      ::llvm::SmallVector<::circt::axi4::BurstSpecAttr> sorted(
+          burstSpecs.begin(), burstSpecs.end());
+      ::llvm::sort(sorted, BurstSpecAttr::compareCanonical);
+      sorted.erase(::llvm::unique(sorted), sorted.end());
+      return $_get($_ctxt, sorted);
+    }]>
+  ];
 }
 
 #endif // CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_TD

--- a/lib/Dialect/AXI4/AXI4Attributes.cpp
+++ b/lib/Dialect/AXI4/AXI4Attributes.cpp
@@ -10,6 +10,8 @@
 #include "circt/Dialect/AXI4/AXI4Dialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/MathExtras.h"
 
@@ -44,6 +46,20 @@ BurstSpecAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                          << len;
     break;
   }
+  return success();
+}
+
+/// Ordering for burst_set construction
+bool BurstSpecAttr::compareCanonical(BurstSpecAttr lhs, BurstSpecAttr rhs) {
+  if (lhs.getKind() != rhs.getKind())
+    return lhs.getKind() < rhs.getKind();
+  return lhs.getLen() < rhs.getLen();
+}
+
+LogicalResult BurstSetAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                                   ArrayRef<BurstSpecAttr> burstSpecs) {
+  if (burstSpecs.empty())
+    return emitError() << "'burst_set' must be non-empty";
   return success();
 }
 

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -16,3 +16,14 @@
 "test.attrs"() {a = #axi4.burst_spec<wrap, len = 2>} : () -> ()
 // CHECK: #axi4.burst_spec<wrap, len = 16>
 "test.attrs"() {a = #axi4.burst_spec<wrap, len = 16>} : () -> ()
+
+// CHECK: #axi4.burst_set<<fixed, len = 4>>
+"test.attrs"() {a = #axi4.burst_set<<fixed, len = 4>>} : () -> ()
+
+// Check burst_sets are correctly canonicalized after parsing
+// CHECK: #axi4.burst_set<<fixed, len = 4>, <incr, len = 8>>
+"test.attrs"() {a = #axi4.burst_set<<incr, len = 8>, <fixed, len = 4>>} : () -> ()
+// CHECK: #axi4.burst_set<<incr, len = 8>>
+"test.attrs"() {a = #axi4.burst_set<<incr, len = 8>, <incr, len = 8>>} : () -> ()
+// CHECK: #axi4.burst_set<<fixed, len = 16>, <incr, len = 1>, <incr, len = 256>, <wrap, len = 2>>
+"test.attrs"() {a = #axi4.burst_set<<wrap, len = 2>, <incr, len = 256>, <incr, len = 1>, <fixed, len = 16>>} : () -> ()

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -37,3 +37,8 @@
 
 // expected-error @below {{'wrap' burst 'len' must be 2, 4, 8, or 16, got 32}}
 "test.attrs"() {a = #axi4.burst_spec<wrap, len = 32>} : () -> ()
+
+// -----
+
+// expected-error @below {{'burst_set' must be non-empty}}
+"test.attrs"() {a = #axi4.burst_set<>} : () -> ()

--- a/unittests/Dialect/AXI4/BurstSetTest.cpp
+++ b/unittests/Dialect/AXI4/BurstSetTest.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/AXI4/AXI4Attributes.h"
+#include "circt/Dialect/AXI4/AXI4Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace axi4;
+
+namespace {
+
+class BurstSetTest : public testing::Test {
+protected:
+  void SetUp() override { context.loadDialect<AXI4Dialect>(); }
+
+  BurstSpecAttr spec(BurstKind kind, uint32_t len) {
+    return BurstSpecAttr::get(&context, kind, len);
+  }
+
+  MLIRContext context;
+};
+
+// Ensure that burst_sets with the same specs given in a different order are
+// equivalent
+TEST_F(BurstSetTest, ShuffledInputUniquesToSortedInput) {
+  auto fixed4 = spec(BurstKind::Fixed, 4);
+  auto incr8 = spec(BurstKind::Incr, 8);
+  auto wrap2 = spec(BurstKind::Wrap, 2);
+
+  BurstSpecAttr sorted[] = {fixed4, incr8, wrap2};
+  BurstSpecAttr shuffled[] = {wrap2, fixed4, incr8};
+
+  auto a = BurstSetAttr::get(&context, sorted);
+  auto b = BurstSetAttr::get(&context, shuffled);
+
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(a.getAsOpaquePointer(), b.getAsOpaquePointer());
+  EXPECT_EQ(a.getBurstSpecs().size(), 3u);
+}
+
+// Ensure burst_specs are accessed in the canonical order
+TEST_F(BurstSetTest, StoredOrderIsCanonical) {
+  BurstSpecAttr shuffled[] = {
+      spec(BurstKind::Wrap, 2), spec(BurstKind::Incr, 256),
+      spec(BurstKind::Incr, 1), spec(BurstKind::Fixed, 16)};
+  auto set = BurstSetAttr::get(&context, shuffled);
+
+  ASSERT_EQ(set.getBurstSpecs().size(), 4u);
+  EXPECT_EQ(set.getBurstSpecs()[0], spec(BurstKind::Fixed, 16));
+  EXPECT_EQ(set.getBurstSpecs()[1], spec(BurstKind::Incr, 1));
+  EXPECT_EQ(set.getBurstSpecs()[2], spec(BurstKind::Incr, 256));
+  EXPECT_EQ(set.getBurstSpecs()[3], spec(BurstKind::Wrap, 2));
+}
+
+// Check duplicate specs are collapsed together
+TEST_F(BurstSetTest, DuplicatesCollapse) {
+  auto incr8 = spec(BurstKind::Incr, 8);
+  BurstSpecAttr withDuplicates[] = {incr8, incr8, incr8};
+
+  auto set = BurstSetAttr::get(&context, withDuplicates);
+
+  EXPECT_EQ(set.getBurstSpecs().size(), 1u);
+  EXPECT_EQ(set, BurstSetAttr::get(&context, {incr8}));
+}
+
+} // namespace

--- a/unittests/Dialect/AXI4/CMakeLists.txt
+++ b/unittests/Dialect/AXI4/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_circt_unittest(CIRCTAXI4Tests
+  BurstSetTest.cpp
+)
+
+target_link_libraries(CIRCTAXI4Tests
+  PRIVATE
+  CIRCTAXI4
+  MLIRIR
+)

--- a/unittests/Dialect/CMakeLists.txt
+++ b/unittests/Dialect/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(AXI4)
 add_subdirectory(Arc)
 add_subdirectory(Comb)
 add_subdirectory(Moore)


### PR DESCRIPTION
Slightly funky attribute in that we don't want a collection of specs to be representable multiple ways (e.g. if using an ArrayAttr, <spec_a, spec_b> would be structurally inequivalent to <spec_b, spec_a> despite them being functionally identical). To make sure that functionally equivalent burst_sets are also equivalent in the eyes of MLIR, we do some de-duplication and sorting on construction.

AI-assisted-by: AI-assisted-by: Claude Opus 5 (1M context)

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
