### PR TITLE
[ESI][Runtime] MMIORegistry: fix read mux inversion

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -443,6 +443,27 @@ static void callbackTest(AcceleratorConnection *conn, Accelerator *accel,
   }
 }
 
+static void checkBurstCommandRegisters(services::MMIO::MMIORegion &mmio,
+                                       uint64_t address, uint64_t flits) {
+  struct RegisterExpectation {
+    uint32_t offset;
+    uint64_t expected;
+    const char *name;
+  };
+  const RegisterExpectation expectations[] = {
+      {0x00, 0, "flits_left"},
+      {0x08, address, "start_addr"},
+      {0x10, flits, "flits_total"},
+  };
+  for (const auto &[offset, expected, name] : expectations) {
+    uint64_t actual = mmio.read(offset);
+    if (actual != expected)
+      throw std::runtime_error("BurstCommand MMIO readback for " +
+                               std::string(name) + " failed: expected " +
+                               toHex(expected) + ", got " + toHex(actual));
+  }
+}
+
 /// Test the hostmem write functionality.
 static void hostmemWriteTest(Accelerator *acc,
                              esi::services::HostMem::HostMemRegion &region,
@@ -505,8 +526,10 @@ static void hostmemWriteTest(Accelerator *acc,
   for (size_t i = 0, e = 9; i < e; ++i)
     dataPtr[i] = 0xFFFFFFFFFFFFFFFFull;
   region.flush();
-  cmdMMIO->write(0x08, reinterpret_cast<uint64_t>(region.getDevicePtr()));
+  uint64_t devPtr = reinterpret_cast<uint64_t>(region.getDevicePtr());
+  cmdMMIO->write(0x08, devPtr);
   cmdMMIO->write(0x10, 1);
+  checkBurstCommandRegisters(*cmdMMIO, devPtr, 1);
   cmdMMIO->write(0x18, 1);
   bool done = false;
   for (int i = 0; i < 100; ++i) {
@@ -589,8 +612,10 @@ static void hostmemReadTest(Accelerator *acc,
     dataPtr[0] = 0x12345678ull << i;
     dataPtr[1] = 0xDEADBEEFull << i;
     region.flush();
-    addrCmdMMIO->write(0x08, reinterpret_cast<uint64_t>(region.getDevicePtr()));
+    uint64_t devPtr = reinterpret_cast<uint64_t>(region.getDevicePtr());
+    addrCmdMMIO->write(0x08, devPtr);
     addrCmdMMIO->write(0x10, 1);
+    checkBurstCommandRegisters(*addrCmdMMIO, devPtr, 1);
     addrCmdMMIO->write(0x18, 1);
     bool done = false;
     for (int waitLoop = 0; waitLoop < 100; ++waitLoop) {

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/mmio.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/mmio.py
@@ -142,8 +142,8 @@ def MmioRegistry(num_ro: int, num_rw: int, num_wo: int):
       sel_read_value = read_values_arr[idx.as_bits(clog2(num_read))]
       resp_sel = Mux(
           idx < UInt(idx_w)(num_read),
-          sel_read_value,
           Bits(64)(2**64 - 1),
+          sel_read_value,
       )
       resp_data_r.assign(
           resp_sel.reg(


### PR DESCRIPTION
The read mux inputs were inverted. Add a test for that and the fix.

Assisted-by: Github-Copilot:GPT-5.6 Terra
