### PR TITLE
[Arc][LLHD]Treat to llhd::ProbeOp as one that breaks arc

### DIFF
--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -35,7 +35,7 @@ static bool isArcBreakingOp(Operation *op) {
   return op->hasTrait<OpTrait::ConstantLike>() ||
          isa<hw::InstanceOp, seq::CompRegOp, MemoryOp, MemoryReadPortOp,
              ClockedOpInterface, seq::InitialOp, seq::ClockGateOp,
-             sim::DPICallOp>(op) ||
+             sim::DPICallOp, llhd::ProbeOp>(op) ||
          op->getNumResults() > 1 || op->getNumRegions() > 0 ||
          !mlir::isMemoryEffectFree(op);
 }

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -331,3 +331,20 @@ hw.module @TimeOpsPassthrough(in %a : i64, out t : i64) {
   %3 = llhd.time_to_int %0
   hw.output %3 : i64
 }
+
+// comb.and uses a non-pure operation coming from llhd.prb
+// CHECK-LABEL: arc.define @OpWithNonPureOperation_arc
+//   CHECK-DAG:   comb.and
+//   CHECK-DAG:   arc.output
+// CHECK-LABEL: hw.module @OpWithNonPureOperation
+//   CHECK:       %2 = arc.call @OpWithNonPureOperation
+//   CHECK-DAG:   hw.output %2
+hw.module @OpWithNonPureOperation(in %in : i1, out out : i1) {
+  %0 = llhd.constant_time <0ns, 0d, 1e>
+  %false = hw.constant false
+  %r1 = llhd.sig %false : i1
+  %1 = llhd.prb %r1 : i1
+  llhd.drv %r1, %in after %0 if %in : i1
+  %2 = comb.and %in, %1 : i1
+  hw.output %2 : i1
+}

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -334,17 +334,15 @@ hw.module @TimeOpsPassthrough(in %a : i64, out t : i64) {
 
 // comb.and uses a non-pure operation coming from llhd.prb
 // CHECK-LABEL: arc.define @OpWithNonPureOperation_arc
-//   CHECK-DAG:   comb.and
-//   CHECK-DAG:   arc.output
+//   CHECK:   comb.and
+//   CHECK:   arc.output
 // CHECK-LABEL: hw.module @OpWithNonPureOperation
-//   CHECK:       %2 = arc.call @OpWithNonPureOperation
-//   CHECK-DAG:   hw.output %2
+//   CHECK:       [[RES:%.+]] = arc.call @OpWithNonPureOperation
+//   CHECK:   hw.output [[RES]]
 hw.module @OpWithNonPureOperation(in %in : i1, out out : i1) {
-  %0 = llhd.constant_time <0ns, 0d, 1e>
   %false = hw.constant false
   %r1 = llhd.sig %false : i1
   %1 = llhd.prb %r1 : i1
-  llhd.drv %r1, %in after %0 if %in : i1
   %2 = comb.and %in, %1 : i1
   hw.output %2 : i1
 }


### PR DESCRIPTION
### Problem
Fixes #10942 
Conversion to Arc fails when an operation uses an operand produced by a non-pure operation. For example:
```mlir
  %0 = llhd.constant_time <0ns, 0d, 1e>
  %false = hw.constant false
  %r1 = llhd.sig %false : i1
  %1 = llhd.prb %r1 : i1
  llhd.drv %r1, %in after %0 if %in : i1
  %2 = comb.and %in, %1 : i1
  hw.output %2 : i1
```
Here, **comb.and** consumes **%1**, which is produced by **llhd.prb**, a non-pure operation.

### Solution
Treat **llhd.prb** as an operation that breaks arcs. This allows the conversion to create a separate **arc.define** for comb.and, isolating the pure combinational logic from the non-pure operation.