### PR TITLE
[FIRRTL] Module-local ExtractInstances prefixes

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -503,8 +503,10 @@ void ExtractInstancesPass::extractInstances() {
   // The list of ports to be added to an instance's parent module. Cleared and
   // reused across instances.
   SmallVector<std::pair<unsigned, PortInfo>> newPorts;
-  // The number of instances with the same prefix. Used to uniquify prefices.
-  DenseMap<StringRef, unsigned> prefixUniqueIDs;
+  // Track the index used to unique a given wiring prefix (e.g., "mem_wiring")
+  // in a given module.  This needs to be isolated per-module to avoid causing
+  // pollution of the namespace across the circuit.
+  DenseMap<std::pair<Operation *, StringRef>, unsigned> prefixUniqueIDs;
 
   SmallPtrSet<Operation *, 4> nlasToRemove;
 
@@ -525,18 +527,18 @@ void ExtractInstancesPass::extractInstances() {
     // Figure out the wiring prefix to use for this instance. If we are supposed
     // to use a wiring prefix (`info.prefix` is non-empty), we assemble a
     // `<prefix>_<N>` string, where `N` is an unsigned integer used to uniquifiy
-    // the prefix. This is very close to what the original Scala implementation
-    // of the pass does, which would group instances to be extracted by prefix
-    // and then iterate over them with the index in the group being used as `N`.
+    // the prefix. The prefix is recomputed at every level of the hierarchy the
+    // instance is bubbled up through, with `N` counting from zero within the
+    // module the instance is currently in. This keeps the names of the ports
+    // added to a module independent of the surrounding circuit.
     StringRef prefix;
     auto &instPrefixEntry = instPrefixNamesPair[inst];
     instPrefixEntry.second = inst.getInstanceNameAttr();
     if (!info.prefix.empty()) {
       auto &prefixSlot = instPrefixEntry.first;
-      if (prefixSlot.empty()) {
-        auto idx = prefixUniqueIDs[info.prefix]++;
-        (Twine(info.prefix) + "_" + Twine(idx)).toVector(prefixSlot);
-      }
+      prefixSlot.clear();
+      auto idx = prefixUniqueIDs[{parent, info.prefix}]++;
+      (Twine(info.prefix) + "_" + Twine(idx)).toVector(prefixSlot);
       prefix = prefixSlot;
     }
 
@@ -668,15 +670,14 @@ void ExtractInstancesPass::extractInstances() {
         MatchingConnectOp::create(builder, dst, src);
       }
 
-      // Move the wiring prefix from the old to the new instance. We just look
-      // up the prefix for the old instance and if it exists, we remove it and
-      // assign it to the new instance. This has the effect of making the first
-      // new instance we create inherit the wiring prefix, and all additional
-      // new instances (e.g. through multiple instantiation of the parent) will
-      // pick a new prefix.
+      // Move the wiring prefix bookkeeping from the old to the new instance.
+      // The prefix itself is recomputed once the new instance is popped off the
+      // worklist, since the numbering is local to the module the instance is
+      // being extracted out of. This mainly serves to keep the map from growing
+      // stale entries for instances that are about to be erased.
       auto oldPrefix = instPrefixNamesPair.find(inst);
       if (oldPrefix != instPrefixNamesPair.end()) {
-        LLVM_DEBUG(llvm::dbgs() << "  - Reusing prefix `"
+        LLVM_DEBUG(llvm::dbgs() << "  - Moving prefix `"
                                 << oldPrefix->second.first << "`\n");
         auto newPrefix = std::move(oldPrefix->second);
         instPrefixNamesPair.erase(oldPrefix);

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
@@ -111,8 +111,8 @@ circuit TestHarness : %[[
   ; SOMEMODULE: mem mem
 
   ; SEQMEMSGROUP: module SeqMemsGroup
-  ; SEQMEMSGROUP:   mem_wiring_1_R0_addr
   ; SEQMEMSGROUP:   mem_wiring_0_R0_addr
+  ; SEQMEMSGROUP:   mem_wiring_1_R0_addr
   ; SEQMEMSGROUP: mem_ext mem_ext
   ; SEQMEMSGROUP: mem_ext mem_ext
 
@@ -121,5 +121,5 @@ circuit TestHarness : %[[
   ; MEM-NOT: mem_ext mem_ext
 
   ; MEMS-CONF: name mem_ext depth 8 width 8 ports write,read
-  ; SEQMEMS-TXT: mem_wiring_1 -> DUTModule.InjectedSubmodule.inst0.mem
-  ; SEQMEMS-TXT: mem_wiring_0 -> DUTModule.InjectedSubmodule.inst1.mem
+  ; SEQMEMS-TXT: mem_wiring_0 -> DUTModule.InjectedSubmodule.inst0.mem
+  ; SEQMEMS-TXT: mem_wiring_1 -> DUTModule.InjectedSubmodule.inst1.mem

--- a/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
+++ b/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
@@ -11,6 +11,10 @@
 firrtl.circuit "ExtractClockGatesMultigrouping" attributes {annotations = [{class = "sifive.enterprise.firrtl.ExtractClockGatesFileAnnotation", filename = "ClockGates.txt", group = "ClockGatesGroup"}, {class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "InjectedSubmodule"}]} {
   firrtl.extmodule private @EICG_wrapper(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
   // CHECK-LABEL: firrtl.module private @SomeModule
+  // Both instances of `SomeModule` see a `clock_gate_0` prefix, since the
+  // numbering is local to the module the clock gate is extracted out of.
+  //
+  // CHECK-SAME:    out %clock_gate_0_in: !firrtl.clock
   firrtl.module private @SomeModule(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
     // CHECK-NOT: firrtl.instance gate @EICG_wrapper
     %gate_in, %gate_en, %gate_out = firrtl.instance gate @EICG_wrapper(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
@@ -47,8 +51,8 @@ firrtl.circuit "ExtractClockGatesMultigrouping" attributes {annotations = [{clas
   }
   // CHECK: emit.file "ClockGates.txt" {
   // CHECK-NEXT:          sv.verbatim
-  // CHECK-SAME{LITERAL}:   clock_gate_1 -> {{0}}.{{1}}.{{2}}.gate\0A
-  // CHECK-SAME{LITERAL}:   clock_gate_0 -> {{0}}.{{1}}.{{3}}.gate\0A
+  // CHECK-SAME{LITERAL}:   clock_gate_0 -> {{0}}.{{1}}.{{2}}.gate\0A
+  // CHECK-SAME{LITERAL}:   clock_gate_1 -> {{0}}.{{1}}.{{3}}.gate\0A
   // CHECK-SAME:            symbols = [
   // CHECK-SAME:              @DUTModule
   // CHECK-SAME:              #hw.innerNameRef<@DUTModule::[[INJMOD_SYM]]>

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -673,6 +673,69 @@ firrtl.circuit "ExtractSeqMemsSimple2" attributes {annotations = [{class = "sifi
 }
 
 //===----------------------------------------------------------------------===//
+// ExtractSeqMems ModuleLocalPrefixes
+//===----------------------------------------------------------------------===//
+
+// The `<prefix>_<N>` numbering must be local to the module that the instance is
+// extracted out of.  Otherwise, the ports created in a module would depend on
+// what else is in the circuit, i.e., `Bar` and `Baz` below would compile
+// differently depending on whether they are compiled together with `DUTModule`
+// or on their own.
+//
+// CHECK: firrtl.circuit "ExtractSeqMemsModuleLocalPrefixes"
+firrtl.circuit "ExtractSeqMemsModuleLocalPrefixes" attributes {annotations = [{class = "sifive.enterprise.firrtl.ExtractSeqMemsFileAnnotation", filename = "SeqMems.txt"}]} {
+  firrtl.memmodule @mem_ext(in W0_clk: !firrtl.clock) attributes {dataWidth = 8 : ui32, depth = 8 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  // Both `Bar` and `Baz` get a `mem_wiring_0` prefix, since each of them only
+  // has a single memory extracted out of them.
+  //
+  // CHECK:      firrtl.module private @Bar
+  // CHECK-SAME:   out %mem_wiring_0_W0_clk: !firrtl.clock
+  firrtl.module private @Bar(in %clock: !firrtl.clock) {
+    %mem_W0_clk = firrtl.instance mem_ext @mem_ext(in W0_clk: !firrtl.clock)
+    firrtl.matchingconnect %mem_W0_clk, %clock : !firrtl.clock
+  }
+  // CHECK:      firrtl.module private @Baz
+  // CHECK-SAME:   out %mem_wiring_0_W0_clk: !firrtl.clock
+  firrtl.module private @Baz(in %clock: !firrtl.clock) {
+    %mem_W0_clk = firrtl.instance mem_ext @mem_ext(in W0_clk: !firrtl.clock)
+    firrtl.matchingconnect %mem_W0_clk, %clock : !firrtl.clock
+  }
+  // Only the DUT, which has two memories extracted through it, sees the
+  // `mem_wiring_0` and `mem_wiring_1` prefixes.
+  //
+  // CHECK:      firrtl.module private @DUTModule
+  // CHECK-SAME:   out %mem_wiring_0_W0_clk: !firrtl.clock
+  // CHECK-SAME:   out %mem_wiring_1_W0_clk: !firrtl.clock
+  firrtl.module private @DUTModule(in %clock: !firrtl.clock) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // CHECK: firrtl.instance bar sym [[BAR_SYM:@.+]] @Bar
+    %bar_clock = firrtl.instance bar @Bar(in clock: !firrtl.clock)
+    firrtl.matchingconnect %bar_clock, %clock : !firrtl.clock
+    // CHECK: firrtl.instance baz sym [[BAZ_SYM:@.+]] @Baz
+    %baz_clock = firrtl.instance baz @Baz(in clock: !firrtl.clock)
+    firrtl.matchingconnect %baz_clock, %clock : !firrtl.clock
+  }
+  // CHECK:        firrtl.module @ExtractSeqMemsModuleLocalPrefixes
+  firrtl.module @ExtractSeqMemsModuleLocalPrefixes(in %clock: !firrtl.clock) {
+    // CHECK-NEXT:   firrtl.instance dut sym {{@.+}} @DUTModule
+    // CHECK-NEXT:   %[[baz_mem:.+]] = firrtl.instance mem_ext {{.*}}@mem_ext
+    // CHECK-NEXT:   firrtl.matchingconnect %[[baz_mem]], %dut_mem_wiring_1_W0_clk
+    // CHECK-NEXT:   %[[bar_mem:.+]] = firrtl.instance mem_ext {{.*}}@mem_ext
+    // CHECK-NEXT:   firrtl.matchingconnect %[[bar_mem]], %dut_mem_wiring_0_W0_clk
+    %dut_clock = firrtl.instance dut @DUTModule(in clock: !firrtl.clock)
+    firrtl.matchingconnect %dut_clock, %clock : !firrtl.clock
+  }
+  // CHECK:               emit.file "SeqMems.txt" {
+  // CHECK-NEXT:            sv.verbatim "
+  // CHECK-SAME{LITERAL}:     mem_wiring_0 -> {{0}}.{{1}}.mem_ext\0A
+  // CHECK-SAME{LITERAL}:     mem_wiring_1 -> {{0}}.{{2}}.mem_ext\0A
+  // CHECK-SAME:              symbols = [
+  // CHECK-SAME:                @DUTModule
+  // CHECK-SAME:                @DUTModule::[[BAR_SYM]]
+  // CHECK-SAME:                @DUTModule::[[BAZ_SYM]]
+  // CHECK-SAME:              ]
+}
+
+//===----------------------------------------------------------------------===//
 // ExtractSeqMems NoExtraction
 //===----------------------------------------------------------------------===//
 
@@ -729,8 +792,8 @@ firrtl.circuit "InstSymConflict" {
   }
   // CHECK:               emit.file "BlackBoxes.txt" {
   // CHECK-NEXT:            sv.verbatim "
-  // CHECK-SAME{LITERAL}:     bb_1 -> {{0}}.{{1}}.bb\0A
-  // CHECK-SAME{LITERAL}:     bb_0 -> {{0}}.{{2}}.bb\0A
+  // CHECK-SAME{LITERAL}:     bb_0 -> {{0}}.{{1}}.bb\0A
+  // CHECK-SAME{LITERAL}:     bb_1 -> {{0}}.{{2}}.bb\0A
   // CHECK-SAME:              symbols = [
   // CHECK-SAME:                @DUTModule
   // CHECK-SAME:                #hw.innerNameRef<@DUTModule::@mod1>


### PR DESCRIPTION
Make the `_<n>` prefixing used in FIRRTL's `ExtractInstances` pass
module-local for each `<n>`.

This fixes an issue where previously the `<n>` was pulled from a
circuit-level pool.  For some flows which expect that compiling a module
in a circuit vs. in a different circuit (where some other modules
incremented the global `<n>`), this could result in different port names.

Fix #10952.

Assisted-by: pi.dev:claude-opus-5
