### PR TITLE
[NFC][PrettyPrinterTest] Add braces to address compiler warning.

### DIFF
--- a/unittests/Support/PrettyPrinterTest.cpp
+++ b/unittests/Support/PrettyPrinterTest.cpp
@@ -831,8 +831,9 @@ TEST(PrettyPrinterTest, MarginValues) {
     auto outNewlines = out.count('\n');
     EXPECT_NE(saveNewlines, outNewlines);
     // Special check for no-wrap sentinel value.
-    if (m == 0)
+    if (m == 0) {
       EXPECT_EQ(outNewlines, 0U);
+    }
   }
 }
 


### PR DESCRIPTION
warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]

