### PR TITLE
[Arc] Add Context type to Arc dialect

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -585,11 +585,9 @@ def CurrentTimeOp : ArcOp<"current_time", [
     Reads the current simulation time from the model's storage. The time is
     represented as an `i64` value in femtoseconds.
   }];
-  let arguments = (ins StorageType:$storage);
+  let arguments = (ins ContextType:$arcContext);
   let results = (outs I64:$time);
-  let assemblyFormat = [{
-    $storage attr-dict `:` qualified(type($storage))
-  }];
+  let assemblyFormat = [{ $arcContext attr-dict }];
 }
 
 def TerminateOp : ArcOp<"terminate", [
@@ -597,20 +595,18 @@ def TerminateOp : ArcOp<"terminate", [
 ]> {
   let summary = "Request simulation termination";
   let description = [{
-    Sets a termination flag in the model's storage.
+    Sets a termination flag in the model's context.
     It unconditionally writes 1 for success or 2 for failure.
     This allows the simulation to exit gracefully after the current
     evaluation cycle.
   }];
 
   let arguments = (ins
-    StorageType:$storage,
+    ContextType:$arcContext,
     BoolAttr:$success
   );
 
-  let assemblyFormat = [{
-    $storage `,` $success attr-dict `:` qualified(type($storage))
-  }];
+  let assemblyFormat = [{ $arcContext `,` $success attr-dict }];
 }
 
 def GetNextWakeupOp : ArcOp<"get_next_wakeup", [
@@ -618,17 +614,15 @@ def GetNextWakeupOp : ArcOp<"get_next_wakeup", [
 ]> {
   let summary = "Read the model's next wakeup time";
   let description = [{
-    Reads the next wakeup time from the model's storage. The time is an
+    Reads the next wakeup time from the model's context. The time is an
     absolute timestamp in femtoseconds, not a duration relative to the current
     simulation time. A wakeup at the current time requests an immediate
     re-evaluation in the same time step; a value of `UINT64_MAX` indicates that
     no wakeup is pending.
   }];
-  let arguments = (ins StorageType:$storage);
+  let arguments = (ins ContextType:$arcContext);
   let results = (outs I64:$time);
-  let assemblyFormat = [{
-    $storage attr-dict `:` qualified(type($storage))
-  }];
+  let assemblyFormat = [{ $arcContext attr-dict }];
 }
 
 def SetNextWakeupOp : ArcOp<"set_next_wakeup", [
@@ -642,10 +636,23 @@ def SetNextWakeupOp : ArcOp<"set_next_wakeup", [
     process suspension code lowers the value to the earliest scheduled
     wakeup over the course of an evaluation.
   }];
-  let arguments = (ins StorageType:$storage, I64:$time);
-  let assemblyFormat = [{
-    $storage `,` $time attr-dict `:` qualified(type($storage))
+  let arguments = (ins ContextType:$arcContext, I64:$time);
+  let assemblyFormat = [{ $arcContext `,` $time attr-dict }];
+}
+
+//===----------------------------------------------------------------------===//
+// Context
+//===----------------------------------------------------------------------===//
+
+def AsContextOp : ArcOp<"as_context", [Pure]> {
+  let summary = "Derive context from a root storage or instance handle";
+  let description = [{
+    Retrieve a runtime handle to the context of a model's instance from either
+    the instance's root storage or a specialized simulation instance handle.
   }];
+  let arguments = (ins AnyTypeOf<[StorageType, SimModelInstance]>:$input);
+  let results = (outs ContextType:$arcContext);
+  let assemblyFormat = [{ $input attr-dict `:` qualified(type($input)) }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -1116,22 +1123,6 @@ def SimEmitValueOp : ArcOp<"sim.emit"> {
   let assemblyFormat = [{ $valueName `,` $value attr-dict `:` type($value) }];
 }
 
-def SimGetTimeOp : ArcOp<"sim.get_time", [
-  MemoryEffects<[MemRead]>,
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>
-]> {
-  let summary = "Gets the current simulation time of the model instance";
-  let description = [{
-    Gets the current simulation time of the given model instance. The time is
-    represented as an `i64` value in femtoseconds.
-  }];
-  let arguments = (ins SimModelInstance:$instance);
-  let results = (outs I64:$time);
-  let assemblyFormat = [{
-    $instance attr-dict `:` qualified(type($instance))
-  }];
-}
-
 def SimSetTimeOp : ArcOp<"sim.set_time", [
   MemoryEffects<[MemWrite]>,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>
@@ -1144,27 +1135,6 @@ def SimSetTimeOp : ArcOp<"sim.set_time", [
   let arguments = (ins SimModelInstance:$instance, I64:$time);
   let assemblyFormat = [{
     $instance `,` $time attr-dict `:` qualified(type($instance))
-  }];
-}
-
-def SimGetNextWakeupOp : ArcOp<"sim.get_next_wakeup", [
-  MemoryEffects<[MemRead]>,
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>
-]> {
-  let summary = "Gets the next wakeup time of the model instance";
-  let description = [{
-    Gets the next wakeup time of the given model instance. The time is an
-    absolute timestamp in femtoseconds, not a duration relative to the current
-    simulation time. A wakeup at the current time requests an immediate
-    re-evaluation in the same time step; a value of `UINT64_MAX` indicates that
-    no wakeup is pending. The slot is recomputed on every evaluation, so a
-    driver typically reads it after each `arc.sim.step` to decide how far to
-    advance simulation time before the next step.
-  }];
-  let arguments = (ins SimModelInstance:$instance);
-  let results = (outs I64:$time);
-  let assemblyFormat = [{
-    $instance attr-dict `:` qualified(type($instance))
   }];
 }
 

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -51,6 +51,16 @@ def StorageType : ArcTypeDef<"Storage"> {
   let mnemonic = "storage";
 }
 
+def ContextType : ArcTypeDef<"Context"> {
+  let summary = "Generic model instance context";
+  let description = [{
+    A handle to the runtime context of a model instance.
+    At compile-time it is not tied to a specific model and may be used to
+    refer to an instance within a function shared between models.
+  }];
+  let mnemonic = "context";
+}
+
 def SimModelInstance : ArcTypeDef<"SimModelInstance"> {
   let mnemonic = "sim.instance";
   let parameters = (ins "mlir::FlatSymbolRefAttr":$model);

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -12,6 +12,7 @@
 #include "circt/Conversion/HWToLLVM.h"
 #include "circt/Dialect/Arc/ArcConstants.h"
 #include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcTypes.h"
 #include "circt/Dialect/Arc/ModelInfo.h"
 #include "circt/Dialect/Arc/Runtime/Common.h"
 #include "circt/Dialect/Arc/Runtime/FmtDescriptor.h"
@@ -169,6 +170,17 @@ struct StateWriteOpLowering : public OpConversionPattern<arc::StateWriteOp> {
   }
 };
 
+struct AsContextOpLowering : public OpConversionPattern<arc::AsContextOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(arc::AsContextOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    // Context, root storage and instances resolve to the same pointer
+    rewriter.replaceOp(op, adaptor.getInput());
+    return llvm::success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Time Operations Lowering
 //===----------------------------------------------------------------------===//
@@ -179,7 +191,7 @@ struct CurrentTimeOpLowering : public OpConversionPattern<arc::CurrentTimeOp> {
   matchAndRewrite(arc::CurrentTimeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     // Time is stored at offset 0 in storage (no offset needed).
-    Value ptr = adaptor.getStorage();
+    Value ptr = adaptor.getArcContext();
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, rewriter.getI64Type(), ptr);
     return success();
   }
@@ -668,8 +680,10 @@ struct SimStepOpLowering : public ModelAwarePattern<arc::SimStepOp> {
       // Increment time after step
       OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPointAfter(op);
+      auto arcContext =
+          arc::AsContextOp::create(rewriter, op.getLoc(), op.getInstance());
       auto oldTime =
-          arc::SimGetTimeOp::create(rewriter, op.getLoc(), op.getInstance());
+          arc::CurrentTimeOp::create(rewriter, op.getLoc(), arcContext);
       auto newTime = LLVM::AddOp::create(rewriter, op.getLoc(), oldTime,
                                          adaptor.getTimePostIncrement());
       arc::SimSetTimeOp::create(rewriter, op.getLoc(), op.getInstance(),
@@ -685,21 +699,6 @@ struct SimStepOpLowering : public ModelAwarePattern<arc::SimStepOp> {
   }
 };
 
-// Loads the simulation time (i64 femtoseconds) from byte offset 0 in the
-// model instance's state storage.
-struct SimGetTimeOpLowering : public OpConversionPattern<arc::SimGetTimeOp> {
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(arc::SimGetTimeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const final {
-    // Time is stored at offset 0 in the instance storage.
-    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, rewriter.getI64Type(),
-                                              adaptor.getInstance());
-    return success();
-  }
-};
-
 // Stores the simulation time (i64 femtoseconds) to byte offset 0 in the
 // model instance's state storage.
 struct SimSetTimeOpLowering : public OpConversionPattern<arc::SimSetTimeOp> {
@@ -711,26 +710,6 @@ struct SimSetTimeOpLowering : public OpConversionPattern<arc::SimSetTimeOp> {
     // Time is stored at offset 0 in the instance storage.
     rewriter.replaceOpWithNewOp<LLVM::StoreOp>(op, adaptor.getTime(),
                                                adaptor.getInstance());
-    return success();
-  }
-};
-
-// Loads the next wakeup time (i64 femtoseconds) from `kNextWakeupOffset` of
-// the model instance's state storage.
-struct SimGetNextWakeupOpLowering
-    : public OpConversionPattern<arc::SimGetNextWakeupOp> {
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(arc::SimGetNextWakeupOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const final {
-    auto loc = op.getLoc();
-    auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
-    Value slotPtr = LLVM::GEPOp::create(
-        rewriter, loc, ptrType, rewriter.getI8Type(), adaptor.getInstance(),
-        ArrayRef<LLVM::GEPArg>{arc::kNextWakeupOffset});
-    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, rewriter.getI64Type(),
-                                              slotPtr);
     return success();
   }
 };
@@ -1117,7 +1096,7 @@ struct TerminateOpLowering : public OpConversionPattern<arc::TerminateOp> {
     auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
 
     Value flagPtr = LLVM::GEPOp::create(
-        rewriter, loc, ptrType, i8Type, adaptor.getStorage(),
+        rewriter, loc, ptrType, i8Type, adaptor.getArcContext(),
         ArrayRef<LLVM::GEPArg>{arc::kTerminateFlagOffset});
 
     uint8_t statusCode = op.getSuccess() ? 1 : 2;
@@ -1143,7 +1122,7 @@ struct GetNextWakeupOpLowering
     auto loc = op.getLoc();
     auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
     Value slotPtr = LLVM::GEPOp::create(
-        rewriter, loc, ptrType, rewriter.getI8Type(), adaptor.getStorage(),
+        rewriter, loc, ptrType, rewriter.getI8Type(), adaptor.getArcContext(),
         ArrayRef<LLVM::GEPArg>{arc::kNextWakeupOffset});
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, rewriter.getI64Type(),
                                               slotPtr);
@@ -1163,7 +1142,7 @@ struct SetNextWakeupOpLowering
     auto loc = op.getLoc();
     auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
     Value slotPtr = LLVM::GEPOp::create(
-        rewriter, loc, ptrType, rewriter.getI8Type(), adaptor.getStorage(),
+        rewriter, loc, ptrType, rewriter.getI8Type(), adaptor.getArcContext(),
         ArrayRef<LLVM::GEPArg>{arc::kNextWakeupOffset});
     rewriter.replaceOpWithNewOp<LLVM::StoreOp>(op, adaptor.getTime(), slotPtr);
     return success();
@@ -1853,6 +1832,9 @@ void LowerArcToLLVMPass::runOnOperation() {
   converter.addConversion([&](StorageType type) {
     return LLVM::LLVMPointerType::get(type.getContext());
   });
+  converter.addConversion([&](ContextType type) {
+    return LLVM::LLVMPointerType::get(type.getContext());
+  });
   converter.addConversion([&](MemoryType type) {
     return LLVM::LLVMPointerType::get(type.getContext());
   });
@@ -1921,6 +1903,7 @@ void LowerArcToLLVMPass::runOnOperation() {
     AllocStateLikeOpLowering<arc::RootInputOp>,
     AllocStateLikeOpLowering<arc::RootOutputOp>,
     AllocStorageOpLowering,
+    AsContextOpLowering,
     ClockGateOpLowering,
     ClockInvOpLowering,
     ConstantTimeOpLowering,
@@ -1935,8 +1918,6 @@ void LowerArcToLLVMPass::runOnOperation() {
     RuntimeModelOpLowering,
     SeqConstClockLowering,
     SetNextWakeupOpLowering,
-    SimGetNextWakeupOpLowering,
-    SimGetTimeOpLowering,
     SimSetTimeOpLowering,
     StateReadOpLowering,
     StateWriteOpLowering,

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -692,45 +692,11 @@ LogicalResult SimStepOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
-// SimGetTimeOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult
-SimGetTimeOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  Operation *moduleOp = getSupportedModuleOp(
-      symbolTable, getOperation(),
-      llvm::cast<SimModelInstanceType>(getInstance().getType())
-          .getModel()
-          .getAttr());
-  if (!moduleOp)
-    return failure();
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // SimSetTimeOp
 //===----------------------------------------------------------------------===//
 
 LogicalResult
 SimSetTimeOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  Operation *moduleOp = getSupportedModuleOp(
-      symbolTable, getOperation(),
-      llvm::cast<SimModelInstanceType>(getInstance().getType())
-          .getModel()
-          .getAttr());
-  if (!moduleOp)
-    return failure();
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// SimGetNextWakeupOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult
-SimGetNextWakeupOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   Operation *moduleOp = getSupportedModuleOp(
       symbolTable, getOperation(),
       llvm::cast<SimModelInstanceType>(getInstance().getType())

--- a/lib/Dialect/Arc/Transforms/GenerateDriver.cpp
+++ b/lib/Dialect/Arc/Transforms/GenerateDriver.cpp
@@ -75,12 +75,13 @@ void GenerateDriverPass::generateDriver(ModelOp modelOp,
   func::ReturnOp::create(builder, loc);
   auto *instanceBlock = builder.createBlock(&instanceOp.getBody());
   auto instance = instanceBlock->addArgument(instanceType, loc);
+  auto arcContext = AsContextOp::create(builder, loc, instance);
 
   // Loop until no further wakeup is scheduled. The next wakeup slot uses
   // `UINT64_MAX` to signal that the model has gone quiescent.
   auto never = arith::ConstantOp::create(builder, loc,
                                          builder.getIntegerAttr(i64Type, -1));
-  auto firstWakeup = SimGetNextWakeupOp::create(builder, loc, instance);
+  auto firstWakeup = GetNextWakeupOp::create(builder, loc, arcContext);
 
   auto whileOp =
       scf::WhileOp::create(builder, loc, i64Type, ValueRange{firstWakeup});
@@ -99,6 +100,6 @@ void GenerateDriverPass::generateDriver(ModelOp modelOp,
   auto resumeTime = afterBlock->addArgument(i64Type, loc);
   SimSetTimeOp::create(builder, loc, instance, resumeTime);
   SimStepOp::create(builder, loc, instance);
-  auto nextWakeup = SimGetNextWakeupOp::create(builder, loc, instance);
+  auto nextWakeup = GetNextWakeupOp::create(builder, loc, arcContext);
   scf::YieldOp::create(builder, loc, ValueRange{nextWakeup});
 }

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -142,6 +142,7 @@ struct ModuleLowering {
 
   /// The storage value that can be used for `arc.alloc_state` and friends.
   Value storageArg;
+  Value arcContext;
 
   /// The symbol table of the enclosing top-level module. Used to resolve
   /// coroutine callees without walking the entire IR.
@@ -208,13 +209,14 @@ LogicalResult ModuleLowering::run() {
   storageArg = modelBlock.addArgument(StorageType::get(builder.getContext()),
                                       modelOp.getLoc());
   builder.setInsertionPointToStart(&modelBlock);
+  arcContext = AsContextOp::create(builder, moduleOp.getLoc(), storageArg);
 
   // Reset the next wakeup slot to `UINT64_MAX` ("no wakeup pending") at the
   // start of every eval. Process suspension code lowers the value to the
   // earliest scheduled wakeup over the course of the evaluation.
   auto noWakeup = hw::ConstantOp::create(builder, moduleOp.getLoc(),
                                          builder.getI64Type(), -1);
-  SetNextWakeupOp::create(builder, moduleOp.getLoc(), storageArg, noWakeup);
+  SetNextWakeupOp::create(builder, moduleOp.getLoc(), arcContext, noWakeup);
 
   // Create the `arc.initial` op to contain the ops for the initialization
   // phase.
@@ -952,7 +954,7 @@ LogicalResult OpLowering::lower(CoroutineInstanceOp op) {
 
   // Re-enter the coroutine if its scheduled wakeup time has been reached or if
   // an observed argument changed.
-  auto now = CurrentTimeOp::create(module.builder, loc, module.storageArg);
+  auto now = CurrentTimeOp::create(module.builder, loc, module.arcContext);
   auto wakeup = StateReadOp::create(module.builder, loc, wakeupSlot);
   auto timeReady = comb::ICmpOp::create(module.builder, loc,
                                         comb::ICmpPredicate::uge, now, wakeup);
@@ -1003,10 +1005,10 @@ LogicalResult OpLowering::lower(CoroutineInstanceOp op) {
   // evaluation, its stored wakeup must keep the model scheduled.
   auto curWakeup = StateReadOp::create(module.builder, loc, wakeupSlot);
   auto nextWakeup =
-      GetNextWakeupOp::create(module.builder, loc, module.storageArg);
+      GetNextWakeupOp::create(module.builder, loc, module.arcContext);
   auto minWakeup =
       arith::MinUIOp::create(module.builder, loc, curWakeup, nextWakeup);
-  SetNextWakeupOp::create(module.builder, loc, module.storageArg, minWakeup);
+  SetNextWakeupOp::create(module.builder, loc, module.arcContext, minWakeup);
 
   return success();
 }
@@ -1244,7 +1246,7 @@ LogicalResult OpLowering::lower(llhd::CurrentTimeOp op) {
   case Phase::Final: {
     // Get the current time from storage.
     auto &builder = module.getBuilder(phase);
-    auto timeInt = CurrentTimeOp::create(builder, loc, module.storageArg);
+    auto timeInt = CurrentTimeOp::create(builder, loc, module.arcContext);
     time = llhd::IntToTimeOp::create(builder, loc, timeInt);
     break;
   }
@@ -1278,8 +1280,7 @@ LogicalResult OpLowering::lower(sim::ClockedTerminateOp op) {
     return op.emitOpError("Failed to create condition block");
 
   module.builder.setInsertionPoint(ifOp.thenYield());
-
-  arc::TerminateOp::create(module.builder, loc, module.storageArg,
+  arc::TerminateOp::create(module.builder, loc, module.arcContext,
                            op.getSuccessAttr());
 
   return success();

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -300,10 +300,12 @@ func.func private @Dummy(%arg0: i42, %arg1: !hw.array<4xi19>, %arg2: !arc.storag
 // CHECK-SAME: (%arg0: !llvm.ptr)
 // CHECK-SAME: -> !llvm.struct<(i64, i64, i64)>
 func.func @Time(%arg0: !arc.storage) -> (i64, !llhd.time, i64) {
+  // The context is the same pointer as the storage, so it folds away.
   // CHECK-NEXT: [[TIME:%.+]] = llvm.load %arg0 : !llvm.ptr -> i64
   // CHECK-NOT: int_to_time
   // CHECK-NOT: time_to_int
-  %0 = arc.current_time %arg0 : !arc.storage
+  %ctx = arc.as_context %arg0 : !arc.storage
+  %0 = arc.current_time %ctx
   %1 = llhd.int_to_time %0
   %2 = llhd.time_to_int %1
   // CHECK-NEXT: [[TMP1:%.+]] = llvm.mlir.poison : !llvm.struct<(i64, i64, i64)>
@@ -331,12 +333,13 @@ func.func @ConstantTime() -> (!llhd.time, !llhd.time, !llhd.time) {
 // CHECK-LABEL: llvm.func @NextWakeup
 // CHECK-SAME: (%[[STATE:.*]]: !llvm.ptr, %[[T:.*]]: i64)
 func.func @NextWakeup(%state: !arc.storage, %t: i64) -> i64 {
+  %ctx = arc.as_context %state : !arc.storage
   // CHECK-NEXT: %[[WGEP:.*]] = llvm.getelementptr %[[STATE]][16] : (!llvm.ptr) -> !llvm.ptr, i8
   // CHECK-NEXT: llvm.store %[[T]], %[[WGEP]] : i64, !llvm.ptr
-  arc.set_next_wakeup %state, %t : !arc.storage
+  arc.set_next_wakeup %ctx, %t
   // CHECK-NEXT: %[[RGEP:.*]] = llvm.getelementptr %[[STATE]][16] : (!llvm.ptr) -> !llvm.ptr, i8
   // CHECK-NEXT: %[[OUT:.*]] = llvm.load %[[RGEP]] : !llvm.ptr -> i64
-  %0 = arc.get_next_wakeup %state : !arc.storage
+  %0 = arc.get_next_wakeup %ctx
   // CHECK-NEXT: llvm.return %[[OUT]]
   return %0 : i64
 }
@@ -345,21 +348,23 @@ func.func @NextWakeup(%state: !arc.storage, %t: i64) -> i64 {
 // CHECK-LABEL: llvm.func @test_success_eval
 // CHECK-SAME: (%[[STATE:.*]]: !llvm.ptr, %[[COND:.*]]: i1)
 func.func @test_success_eval(%state: !arc.storage, %cond: i1) {
+  %ctx = arc.as_context %state : !arc.storage
   // CHECK-NEXT: %[[GEP:.*]] = llvm.getelementptr %[[STATE]][8] : (!llvm.ptr) -> !llvm.ptr, i8
   // CHECK-NEXT: %[[VAL:.*]] = llvm.mlir.constant(1 : i8) : i8
   // CHECK-NEXT: llvm.store %[[VAL]], %[[GEP]] : i8, !llvm.ptr
   // CHECK-NEXT: llvm.return
-  arc.terminate %state, true : !arc.storage
+  arc.terminate %ctx, true
   return
 }
 
 // CHECK-LABEL: llvm.func @test_failure_eval
 // CHECK-SAME: (%[[STATE:.*]]: !llvm.ptr, %[[COND:.*]]: i1)
 func.func @test_failure_eval(%state: !arc.storage, %cond: i1) {
+  %ctx = arc.as_context %state : !arc.storage
   // CHECK-NEXT: %[[GEP_FAIL:.*]] = llvm.getelementptr %[[STATE]][8] : (!llvm.ptr) -> !llvm.ptr, i8
   // CHECK-NEXT: %[[VAL_FAIL:.*]] = llvm.mlir.constant(2 : i8) : i8
   // CHECK-NEXT: llvm.store %[[VAL_FAIL]], %[[GEP_FAIL]] : i8, !llvm.ptr
   // CHECK-NEXT: llvm.return
-  arc.terminate %state, false : !arc.storage
+  arc.terminate %ctx, false
   return
 }

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -348,30 +348,26 @@ func.func @Execute(%arg0: i42) {
 }
 
 // CHECK-LABEL: func.func @CurrentTime
-func.func @CurrentTime(%arg0: !arc.storage) {
-  // CHECK-NEXT: arc.current_time %arg0 : !arc.storage
-  %0 = arc.current_time %arg0 : !arc.storage
+func.func @CurrentTime(%arg0: !arc.context) {
+  // CHECK-NEXT: arc.current_time %arg0
+  %0 = arc.current_time %arg0
   return
 }
 
 // CHECK-LABEL: func.func @NextWakeup
-func.func @NextWakeup(%arg0: !arc.storage, %arg1: i64) {
-  // CHECK-NEXT: arc.get_next_wakeup %arg0 : !arc.storage
-  %0 = arc.get_next_wakeup %arg0 : !arc.storage
-  // CHECK-NEXT: arc.set_next_wakeup %arg0, %arg1 : !arc.storage
-  arc.set_next_wakeup %arg0, %arg1 : !arc.storage
+func.func @NextWakeup(%arg0: !arc.context, %arg1: i64) {
+  // CHECK-NEXT: arc.get_next_wakeup %arg0
+  %0 = arc.get_next_wakeup %arg0
+  // CHECK-NEXT: arc.set_next_wakeup %arg0, %arg1
+  arc.set_next_wakeup %arg0, %arg1
   return
 }
 
 // CHECK-LABEL: func.func @SimGetSetTime
-func.func @SimGetSetTime() {
+func.func @SimGetSetTime(%time: i64) {
   arc.sim.instantiate @TimeTestModule as %model {
-    // CHECK: arc.sim.get_time %{{.*}} : !arc.sim.instance<@TimeTestModule>
-    %0 = arc.sim.get_time %model : !arc.sim.instance<@TimeTestModule>
     // CHECK: arc.sim.set_time %{{.*}}, %{{.*}} : !arc.sim.instance<@TimeTestModule>
-    arc.sim.set_time %model, %0 : !arc.sim.instance<@TimeTestModule>
-    // CHECK: arc.sim.get_next_wakeup %{{.*}} : !arc.sim.instance<@TimeTestModule>
-    %1 = arc.sim.get_next_wakeup %model : !arc.sim.instance<@TimeTestModule>
+    arc.sim.set_time %model, %time : !arc.sim.instance<@TimeTestModule>
     // CHECK: arc.sim.step %{{.*}} by %{{.*}} : !arc.sim.instance<@TimeTestModule>
     %tstep = arith.constant 123 : i64
     arc.sim.step %model by %tstep : !arc.sim.instance<@TimeTestModule>
@@ -468,4 +464,11 @@ func.func @ArrayRefAllocAggregate() -> !arc.arrayref<2x!hw.array<1xi32>> {
 func.func @ArrayRefAllocStruct() -> !arc.arrayref<2x!hw.struct<foo: i1>> {
   %0 = arc.arrayref.alloc init([false, true]) : !arc.arrayref<2x!hw.struct<foo: i1>>
   return %0 : !arc.arrayref<2x!hw.struct<foo: i1>>
+}
+
+// CHECK-LABEL: func.func @StorageAsContext
+func.func @StorageAsContext(%storage: !arc.storage) -> (!arc.context) {
+  // CHECK: arc.as_context %{{.+}} : !arc.storage
+  %ctxt  = arc.as_context %storage : !arc.storage
+  return %ctxt : !arc.context
 }

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -46,7 +46,8 @@ module {
 
       // CHECK-NEXT: %[[wkup_ptr:.*]] = llvm.getelementptr %[[state]][16] : (!llvm.ptr) -> !llvm.ptr, i8
       // CHECK-NEXT: %[[wkup:.*]] = llvm.load %[[wkup_ptr]] : !llvm.ptr -> i64
-      %wkup = arc.sim.get_next_wakeup %model : !arc.sim.instance<@id>
+      %ctxt = arc.as_context %model : !arc.sim.instance<@id>
+      %wkup = arc.get_next_wakeup %ctxt
       arc.sim.emit "next_wakeup", %wkup : i64
 
       // CHECK-DAG: %[[to_print:.*]] = llvm.zext %[[result]] : i8 to i64

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -44,8 +44,9 @@ arc.define @RandomI42AndI19Arc() -> (i42, i19) {
 
 // CHECK-LABEL: arc.model @Empty
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage):
+// CHECK-NEXT:    [[CTX:%.+]] = arc.as_context %arg0 : !arc.storage
 // CHECK-NEXT:    [[NWK:%.+]] = hw.constant -1 : i64
-// CHECK-NEXT:    arc.set_next_wakeup %arg0, [[NWK]] : !arc.storage
+// CHECK-NEXT:    arc.set_next_wakeup [[CTX]], [[NWK]]
 // CHECK-NEXT:  }
 hw.module @Empty() {}
 
@@ -634,6 +635,7 @@ hw.module @Triggered(in %clock: i1, in %a: i42) {
 
 // CHECK-LABEL: arc.model @TriggeredCurrentTime
 hw.module @TriggeredCurrentTime(in %clock: i1) {
+  // CHECK: [[CTX:%.+]] = arc.as_context %arg0 : !arc.storage
   // CHECK: [[IN_CLOCK:%.+]] = arc.root_input "clock"
   // CHECK: [[CLOCK:%.+]] = arc.state_read [[IN_CLOCK]]
   // CHECK: [[OLD_CLOCK:%.+]] = arc.state_read
@@ -641,7 +643,7 @@ hw.module @TriggeredCurrentTime(in %clock: i1) {
   // CHECK: [[EDGE:%.+]] = comb.xor [[OLD_CLOCK]], [[CLOCK]]
   // CHECK: [[POSEDGE:%.+]] = comb.and [[EDGE]], [[CLOCK]]
   // CHECK: scf.if [[POSEDGE]] {
-  // CHECK:   [[TIME_INT:%.+]] = arc.current_time %arg0
+  // CHECK:   [[TIME_INT:%.+]] = arc.current_time [[CTX]]
   // CHECK:   [[TIME:%.+]] = llhd.int_to_time [[TIME_INT]]
   // CHECK:   [[TIME_AS_INT:%.+]] = llhd.time_to_int [[TIME]]
   // CHECK:   func.call @ConsumeI64([[TIME_AS_INT]])
@@ -697,6 +699,7 @@ hw.module @LLHDTimeOps(in %clock: !seq.clock, out t: i64) {
   // values cannot be directly used inside. We only test this for llhd.final.
   %external_time = llhd.current_time
 
+  // CHECK: [[CTX:%.+]] = arc.as_context %arg0 : !arc.storage
   // Phase::Initial - llhd.current_time used inside seq.initial.
   // During initialization, time is always 0.
   // CHECK: arc.initial {
@@ -719,9 +722,9 @@ hw.module @LLHDTimeOps(in %clock: !seq.clock, out t: i64) {
   //    have IsolatedFromAbove, so external values can be used directly)
   // All llhd.current_time ops are pre-lowered before cloning other ops.
   // CHECK: arc.final {
-  // CHECK:   [[OUT_INT1:%.+]] = arc.current_time %arg0
+  // CHECK:   [[OUT_INT1:%.+]] = arc.current_time [[CTX]]
   // CHECK:   [[OUT_TIME:%.+]] = llhd.int_to_time [[OUT_INT1]]
-  // CHECK:   [[IN_INT1:%.+]] = arc.current_time %arg0
+  // CHECK:   [[IN_INT1:%.+]] = arc.current_time [[CTX]]
   // CHECK:   [[IN_TIME:%.+]] = llhd.int_to_time [[IN_INT1]]
   // CHECK:   [[OUT_INT2:%.+]] = llhd.time_to_int [[OUT_TIME]]
   // CHECK:   func.call @ConsumeI64([[OUT_INT2]]) {out}
@@ -740,13 +743,13 @@ hw.module @LLHDTimeOps(in %clock: !seq.clock, out t: i64) {
   }
 
   // Phase::New - llhd.current_time used directly in module body.
-  // CHECK: [[TIME_INT_NEW:%.+]] = arc.current_time %arg0
+  // CHECK: [[TIME_INT_NEW:%.+]] = arc.current_time [[CTX]]
   // CHECK: [[TIME_NEW:%.+]] = llhd.int_to_time [[TIME_INT_NEW]]
   %0 = llhd.current_time
   %1 = llhd.time_to_int %0
 
   // Phase::Old - llhd.current_time used as data input to a state.
-  // CHECK: [[TIME_INT_OLD:%.+]] = arc.current_time %arg0
+  // CHECK: [[TIME_INT_OLD:%.+]] = arc.current_time [[CTX]]
   // CHECK: [[TIME_OLD:%.+]] = llhd.int_to_time [[TIME_INT_OLD]]
   // CHECK: [[TIME_OLD_INT:%.+]] = llhd.time_to_int [[TIME_OLD]]
   // CHECK: arc.call @IdI64Arc([[TIME_OLD_INT]])
@@ -764,6 +767,7 @@ hw.module @LLHDTimeOps(in %clock: !seq.clock, out t: i64) {
 // CHECK-LABEL: arc.model @TestSimToArcTerminateSuccess
 // CHECK-SAME: io !hw.modty<input clock : !seq.clock, input cond : i1>
 hw.module @TestSimToArcTerminateSuccess(in %clock: !seq.clock, in %cond: i1) {
+  // CHECK: %[[CTX:.+]] = arc.as_context %arg0 : !arc.storage
   // CHECK: %[[IN_CLK:.*]] = arc.root_input "clock"
   // CHECK: %[[IN_COND:.*]] = arc.root_input "cond"
   // CHECK: %[[LAST_CLK_PTR:.*]] = arc.alloc_state %arg0
@@ -780,7 +784,7 @@ hw.module @TestSimToArcTerminateSuccess(in %clock: !seq.clock, in %cond: i1) {
   // CHECK: scf.if %[[POSEDGE]] {
   // CHECK:   %[[COND_VAL:.*]] = arc.state_read %[[IN_COND]] : <i1>
   // CHECK:   scf.if %[[COND_VAL]] {
-  // CHECK:     arc.terminate %arg0, true : !arc.storage
+  // CHECK:     arc.terminate %[[CTX]], true
   // CHECK:   }
   // CHECK: }
   
@@ -790,6 +794,7 @@ hw.module @TestSimToArcTerminateSuccess(in %clock: !seq.clock, in %cond: i1) {
 // CHECK-LABEL: arc.model @TestSimToArcTerminateFailure
 // CHECK-SAME: io !hw.modty<input clock : !seq.clock, input cond : i1>
 hw.module @TestSimToArcTerminateFailure(in %clock: !seq.clock, in %cond: i1) {
+  // CHECK: [[CTX:%.+]] = arc.as_context %arg0 : !arc.storage
   // CHECK: %[[IN_CLK:.*]] = arc.root_input "clock"
   // CHECK: %[[IN_COND:.*]] = arc.root_input "cond"
   // CHECK: %[[LAST_CLK_PTR:.*]] = arc.alloc_state %arg0
@@ -806,7 +811,7 @@ hw.module @TestSimToArcTerminateFailure(in %clock: !seq.clock, in %cond: i1) {
   // CHECK: scf.if %[[POSEDGE]] {
   // CHECK:   %[[COND_VAL:.*]] = arc.state_read %[[IN_COND]] : <i1>
   // CHECK:   scf.if %[[COND_VAL]] {
-  // CHECK:     arc.terminate %arg0, false : !arc.storage
+  // CHECK:     arc.terminate [[CTX]], false
   // CHECK:   }
   // CHECK: }
   
@@ -815,6 +820,7 @@ hw.module @TestSimToArcTerminateFailure(in %clock: !seq.clock, in %cond: i1) {
 
 // CHECK-LABEL: arc.model @CoroutineSensitiveInstance
 hw.module @CoroutineSensitiveInstance(in %in: i42, out o: i42) {
+  // CHECK: [[CTX:%.+]] = arc.as_context %arg0 : !arc.storage
   // CHECK-DAG: [[PC:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!arc.coroutine_pc<@DummyCoroutine>>
   // CHECK-DAG: [[STATE:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<!arc.coroutine_state<@DummyCoroutine>>
   // CHECK-DAG: [[WAKEUP:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i64>
@@ -830,7 +836,7 @@ hw.module @CoroutineSensitiveInstance(in %in: i42, out o: i42) {
   // CHECK: [[BIT:%.+]] = comb.extract [[MASKVAL]] from 0 : (i1) -> i1
   // CHECK: [[MASKED:%.+]] = comb.and [[CHANGED]], [[BIT]] : i1
   // CHECK: [[ANYCHANGE:%.+]] = comb.or {{%.+}}, [[MASKED]] : i1
-  // CHECK: [[NOW:%.+]] = arc.current_time %arg0 : !arc.storage
+  // CHECK: [[NOW:%.+]] = arc.current_time [[CTX]]
   // CHECK: [[WK:%.+]] = arc.state_read [[WAKEUP]] : <i64>
   // CHECK: [[TIMEREADY:%.+]] = comb.icmp uge [[NOW]], [[WK]] : i64
   // CHECK: [[READY:%.+]] = comb.or [[TIMEREADY]], [[ANYCHANGE]] : i1
@@ -851,9 +857,9 @@ hw.module @CoroutineSensitiveInstance(in %in: i42, out o: i42) {
   // CHECK: }
 
   // CHECK: [[CUR:%.+]] = arc.state_read [[WAKEUP]] : <i64>
-  // CHECK: [[NEXT:%.+]] = arc.get_next_wakeup %arg0 : !arc.storage
+  // CHECK: [[NEXT:%.+]] = arc.get_next_wakeup [[CTX]]
   // CHECK: [[MIN:%.+]] = arith.minui [[CUR]], [[NEXT]] : i64
-  // CHECK: arc.set_next_wakeup %arg0, [[MIN]] : !arc.storage
+  // CHECK: arc.set_next_wakeup [[CTX]], [[MIN]]
   %0 = arc.coroutine.instance @DummyCoroutine(%in) sensitive [true] : (i42) -> i42
 
   // CHECK: [[OUT:%.+]] = arc.state_read [[RESULT]] : <i42>

--- a/test/Dialect/Arc/sim-errors.mlir
+++ b/test/Dialect/Arc/sim-errors.mlir
@@ -126,33 +126,11 @@ func.func @set_port_not_input() {
 
 // -----
 
-func.func @get_time_model_not_found() {
-    // expected-error @+1 {{model not found}}
-    arc.sim.instantiate @unknown as %model {
-        %t = arc.sim.get_time %model : !arc.sim.instance<@unknown>
-        arc.sim.emit "time", %t : i64
-    }
-    return
-}
-
-// -----
-
 func.func @set_time_model_not_found() {
     // expected-error @+1 {{model not found}}
     arc.sim.instantiate @unknown as %model {
         %c0 = arith.constant 0 : i64
         arc.sim.set_time %model, %c0 : !arc.sim.instance<@unknown>
-    }
-    return
-}
-
-// -----
-
-func.func @get_next_wakeup_model_not_found() {
-    // expected-error @+1 {{model not found}}
-    arc.sim.instantiate @unknown as %model {
-        %t = arc.sim.get_next_wakeup %model : !arc.sim.instance<@unknown>
-        arc.sim.emit "next_wakeup", %t : i64
     }
     return
 }


### PR DESCRIPTION
Various operations in the Arc dialect need a reference to the start of the running instance's root storage. So far this has been done by either passing the storage value directly, or by passing the instance handle within an `arc.sim.instantiate` operation.

This PR adds a dedicated `!arc.context` type that can be used in either situation and consolidates some operations which would become redundant. It adds the `arc.as_context` operation to derive a context value from either the storage or the instance handle.

In contrast to the `!arc.storage` type, it is guaranteed that a context value points to the _root_ storage. However, it cannot be used to allocate storage.

In contrast to the `!arc.sim.instance<...>` type, it is not tied to a specific model and may be used in the body of functions that are shared between models.

A follow up PR will add the logic threading the context of the model being executed into the body of functions that demand it.

Assisted-by: vscode:Claude Opus 4.8