### PR TITLE
[Arc] Implement `!arc.context` inference

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -655,6 +655,18 @@ def AsContextOp : ArcOp<"as_context", [Pure]> {
   let assemblyFormat = [{ $input attr-dict `:` qualified(type($input)) }];
 }
 
+def InferredContextOp : ArcOp<"inferred_context", [Pure]> {
+  let summary = "Get the inferred runtime context";
+  let description = [{
+    Retrieve a runtime handle to the context of the model instance currently
+    being executed. This can be used in situations where the concrete context
+    is not yet available or in the body of functions that are called by one or
+    several models.
+  }];
+  let results = (outs ContextType:$arcContext);
+  let assemblyFormat = [{ attr-dict }];
+}
+
 //===----------------------------------------------------------------------===//
 // Coroutines
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -89,6 +89,20 @@ def FindInitialVectors : Pass<"arc-find-initial-vectors", "mlir::ModuleOp"> {
   ];
 }
 
+def InferContext : Pass<"arc-infer-context", "mlir::ModuleOp"> {
+  let summary = "Resolve `arc.inferred_context` operations";
+  let description = [{
+    Replaces every `arc.inferred_context` with the concrete context of the
+    model instance it belongs to, taken from the closest enclosing provider:
+    The body of an `arc.model`, the body of an `arc.sim.instantiate` or a
+    function that already carries an `!arc.context` argument. A private function
+    that needs a context but does not provide one gains a `!arc.context`
+    argument that is threaded in at each call site.
+  }];
+  let dependentDialects = ["arc::ArcDialect"];
+}
+
+
 def InferMemories : Pass<"arc-infer-memories", "mlir::ModuleOp"> {
   let summary = "Convert `FIRRTL_Memory` instances to dedicated memory ops";
   let dependentDialects = [

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   Dedup.cpp
   FindInitialVectors.cpp
   GenerateDriver.cpp
+  InferContext.cpp
   InferMemories.cpp
   InferStateProperties.cpp
   InlineArcs.cpp

--- a/lib/Dialect/Arc/Transforms/InferContext.cpp
+++ b/lib/Dialect/Arc/Transforms/InferContext.cpp
@@ -1,0 +1,358 @@
+//===- InferContext.cpp ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass resolves arc.inferred_context operations to their closest
+// provided context. Context providers are:
+// - arc.model operations
+// - arc.sim.instantiate operations
+// - Operations implementing FunctionOpInterface with a context-typed argument
+//
+// Any InferredContextOp nested under a context provider is resolved directly
+// to the provided context.
+// If an InferredContextOp is found in a private function that does not
+// provide a context, a new context argument is added and it is recursively
+// resolved at its call sites.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Arc/ArcTypes.h"
+#include "circt/Dialect/Arc/ModelInfo.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Threading.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/WalkResult.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+
+#include <mutex>
+
+#define DEBUG_TYPE "arc-infer-context"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_INFERCONTEXT
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+namespace {
+
+struct CallerGraphNode {
+  CallerGraphNode(FunctionOpInterface &fnOp) : fnOp(fnOp) {}
+  FunctionOpInterface fnOp;
+  SmallSetVector<CallerGraphNode *, 4> callers;
+};
+
+struct InferContextPass : public arc::impl::InferContextBase<InferContextPass> {
+  void runOnOperation() override;
+
+private:
+  void propagateNeedsStorage();
+  void backPropagateNeedsContext();
+  void buildCallerGraph(ArrayRef<FunctionOpInterface> functions,
+                        SymbolTableCollection &symbolTable);
+  void updateRegion(Region *region, SymbolTableCollection &symbolTable);
+
+  /// Functions providing context.
+  llvm::SmallDenseSet<FunctionOpInterface> hasContextSet;
+  /// Functions needing a new context argument.
+  llvm::SmallDenseSet<FunctionOpInterface, 8> needsContextSet;
+  // Callee-to-caller graph.
+  // Must remain const after creation to not invalidate pointers.
+  DenseMap<FunctionOpInterface, CallerGraphNode> callerGraph;
+};
+
+// Walk the region and wire-in the inferred context.
+void InferContextPass::updateRegion(Region *region,
+                                    SymbolTableCollection &symbolTable) {
+  assert(!region->empty());
+  IRRewriter rewriter(region->getContext());
+  rewriter.setInsertionPointToStart(&region->front());
+  Value inferredContextVal = {};
+  FunctionOpInterface containingFn =
+      dyn_cast<FunctionOpInterface>(region->getParentOp());
+  if (auto modelOp = llvm::dyn_cast<ModelOp>(region->getParentOp())) {
+    // Arc model op body: Context derived from the storage argument.
+    auto storageArg = region->getArgument(0);
+    inferredContextVal =
+        AsContextOp::create(rewriter, modelOp->getLoc(), storageArg);
+    LLVM_DEBUG(auto fnName = modelOp.getSymName();
+               llvm::dbgs()
+               << "Updating body of model \"" << fnName << "\"\n";);
+  } else if (auto instantiateOp =
+                 llvm::dyn_cast<SimInstantiateOp>(region->getParentOp())) {
+    // Instance op body: Context derived from the instance handle.
+    auto instanceArg = region->getArgument(0);
+    inferredContextVal =
+        AsContextOp::create(rewriter, instantiateOp->getLoc(), instanceArg);
+    LLVM_DEBUG(llvm::dbgs() << "Updating body of instance\n";);
+  } else if (containingFn && (needsContextSet.contains(containingFn) ||
+                              hasContextSet.contains(containingFn))) {
+    // A function that has a new or pre-existing context argument.
+    auto *ctxtArg = llvm::find_if(region->getArguments(), [](Value arg) {
+      return isa<ContextType>(arg.getType());
+    });
+    assert(ctxtArg && "Expected function to have a context argument");
+    inferredContextVal = *ctxtArg;
+    LLVM_DEBUG(auto fnName = cast<FunctionOpInterface>(region->getParentOp())
+                                 .getNameAttr()
+                                 .getValue();
+               llvm::dbgs()
+               << "Updating body of function \"" << fnName << "\"\n";);
+  } else {
+    // A function that has no context argument, but may contain instances that
+    // we recurse into.
+    LLVM_DEBUG(auto fnName = cast<FunctionOpInterface>(region->getParentOp())
+                                 .getNameAttr()
+                                 .getValue();
+               llvm::dbgs()
+               << "Traversing body of function \"" << fnName << "\"\n";);
+  }
+
+  region->walk<WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+    if (op->getNumRegions() > 0) {
+      // Recurse into instances
+      if (auto instOp = dyn_cast<SimInstantiateOp>(op)) {
+        updateRegion(&instOp.getBody(), symbolTable);
+        return WalkResult::skip();
+      }
+      if (op->hasTrait<OpTrait::IsIsolatedFromAbove>())
+        return WalkResult::skip();
+    }
+    // Replace InferredContextOps
+    if (auto ctxtOp = dyn_cast<arc::InferredContextOp>(op)) {
+      assert(inferredContextVal && "No context to propagate");
+      rewriter.replaceOp(ctxtOp, inferredContextVal);
+      return WalkResult::skip();
+    }
+
+    // Update calls to callees that need context, if any.
+    if (needsContextSet.empty())
+      return WalkResult::advance();
+    auto callOp = dyn_cast<CallOpInterface>(op);
+    if (!callOp)
+      return WalkResult::advance();
+    auto callee = dyn_cast_or_null<FunctionOpInterface>(
+        callOp.resolveCallableInTable(&symbolTable));
+    if (!callee || !needsContextSet.contains(callee))
+      return WalkResult::advance();
+    assert(inferredContextVal && "No context to propagate");
+    callOp.getArgOperandsMutable().append({inferredContextVal});
+    return WalkResult::advance();
+  });
+}
+
+} // namespace
+
+// Build the graph pointing from callees to their callers.
+void InferContextPass::buildCallerGraph(ArrayRef<FunctionOpInterface> functions,
+                                        SymbolTableCollection &symbolTable) {
+  // Allocate the nodes for the caller graph. Nodes point to each other, so
+  // we must not mutate the map afterwards.
+  callerGraph.reserve(functions.size());
+  for (auto fn : functions)
+    if (!fn.getFunctionBody().empty())
+      callerGraph.emplace_or_assign(fn, CallerGraphNode(fn));
+
+  // Find all callees in the function bodies and add the reversed edges to the
+  // graph.
+  for (auto fn : functions) {
+    if (fn.getFunctionBody().empty())
+      continue;
+    auto *caller = &callerGraph.at(fn);
+    fn.getFunctionBody().walk<WalkOrder::PreOrder>(
+        [&](Operation *op) -> WalkResult {
+          if (op->getNumRegions() > 0) {
+            // SimInstantiateOps provide a context on their own, so we ignore
+            // calls nested under them.
+            if (auto instOp = dyn_cast<SimInstantiateOp>(op))
+              return WalkResult::skip();
+            if (op->hasTrait<OpTrait::IsIsolatedFromAbove>())
+              return WalkResult::skip();
+          }
+          auto callOp = dyn_cast<CallOpInterface>(op);
+          if (!callOp)
+            return WalkResult::advance();
+          auto callee = llvm::dyn_cast_or_null<FunctionOpInterface>(
+              callOp.resolveCallableInTable(&symbolTable));
+          if (callee) {
+            auto calleeIt = callerGraph.find(callee);
+            if (calleeIt != callerGraph.end())
+              calleeIt->second.callers.insert(caller);
+          }
+          return WalkResult::advance();
+        });
+  }
+}
+
+// Add functions to `needsContextSet` that can reach a function that is already
+// in the set.
+void InferContextPass::backPropagateNeedsContext() {
+
+  // Propagate "needsContext" to callers.
+  struct DFSFrame {
+    DFSFrame(CallerGraphNode *node) : node(node) {}
+    CallerGraphNode *const node;
+    unsigned index = 0;
+    bool isFinished() const { return index >= node->callers.size(); }
+    DFSFrame getNext() {
+      assert(!isFinished());
+      return DFSFrame(node->callers[index++]);
+    }
+  };
+
+  // Seed the DFS with the already marked functions.
+  SmallVector<DFSFrame> dfsStack;
+  for (auto seed : needsContextSet) {
+    LLVM_DEBUG(auto fnName = seed.getNameAttr().getValue();
+               llvm::dbgs()
+               << "Seeding needsContext with function \"" << fnName << "\"\n";);
+    auto fnNode = callerGraph.find(seed);
+    assert(fnNode != callerGraph.end() && "Function not in caller graph");
+    dfsStack.emplace_back(&fnNode->second);
+  }
+
+  // Mark functions reached on the inverted call graph.
+  while (!dfsStack.empty()) {
+    if (dfsStack.back().isFinished()) {
+      dfsStack.pop_back();
+      continue;
+    }
+    auto next = dfsStack.back().getNext();
+    // Stop propagation at context providers
+    if (hasContextSet.contains(next.node->fnOp))
+      continue;
+    if (needsContextSet.insert(next.node->fnOp).second) {
+      LLVM_DEBUG(auto fnName = next.node->fnOp.getNameAttr().getValue();
+                 llvm::dbgs() << "Propagating needsContext to function \""
+                              << fnName << "\"\n";);
+      dfsStack.push_back(next);
+    }
+  }
+}
+
+void InferContextPass::runOnOperation() {
+  SymbolTableCollection symbolTable;
+  hasContextSet.clear();
+  needsContextSet.clear();
+  callerGraph.clear();
+  ModuleOp moduleOp = getOperation();
+  std::mutex setMutex;
+
+  // Collect all interesting functions. A function is interesting if it
+  // contains any instances or any InferredContextOps or provides a context.
+  SmallVector<FunctionOpInterface> funcOps =
+      llvm::to_vector(moduleOp.getOps<FunctionOpInterface>());
+
+  // Functions containing instances.
+  llvm::SmallDenseSet<FunctionOpInterface> hasInstancesSet;
+
+  parallelForEach(
+      moduleOp.getContext(), funcOps, [&](FunctionOpInterface funcOp) {
+        bool needsContext = false;
+        bool hasInstances = false;
+
+        bool hasContext = llvm::any_of(funcOp.getArgumentTypes(), [](Type ty) {
+          return isa<ContextType>(ty);
+        });
+
+        funcOp.getFunctionBody().walk<WalkOrder::PreOrder>(
+            [&](Operation *op) -> WalkResult {
+              if (op->getNumRegions() > 0) {
+                if (isa<SimInstantiateOp>(op)) {
+                  hasInstances = true;
+                  return WalkResult::skip();
+                }
+                // TODO: Should we handle nested IsolatedFromAbove ops?
+                if (op->hasTrait<OpTrait::IsIsolatedFromAbove>())
+                  return WalkResult::skip();
+              } else if (!hasContext) {
+                needsContext |= isa<InferredContextOp>(op);
+              }
+              // Early out
+              if ((hasContext || needsContext) && hasInstances)
+                return WalkResult::interrupt();
+              return WalkResult::advance();
+            });
+        assert(!(hasContext && needsContext));
+        if (hasContext || needsContext || hasInstances) {
+          std::lock_guard<std::mutex> lock(setMutex);
+          if (hasContext)
+            hasContextSet.insert(funcOp);
+          if (needsContext)
+            needsContextSet.insert(funcOp);
+          if (hasInstances)
+            hasInstancesSet.insert(funcOp);
+        }
+      });
+
+  SmallPtrSet<Region *, 4> regionsToUpdate;
+
+  if (!needsContextSet.empty()) {
+    // Find functions that we have to thread the context into.
+    buildCallerGraph(funcOps, symbolTable);
+    backPropagateNeedsContext();
+
+    // Now we know which functions need a context argument. Add it to their
+    // signature.
+    auto ctxtType = arc::ContextType::get(getOperation()->getContext());
+    bool anyFailed = false;
+    for (auto fn : needsContextSet) {
+      if (fn.isPublic()) {
+        fn.emitError("Cannot infer an Arc context through a public function. A "
+                     "context argument must be provided explicitly.");
+        anyFailed = true;
+        continue;
+      }
+      if (failed(fn.insertArgument(fn.getNumArguments(), ctxtType,
+                                   /*argAttrs=*/{}, fn.getLoc()))) {
+        fn.emitError("Failed to add context argument to function.");
+        anyFailed = true;
+      }
+      regionsToUpdate.insert(&fn.getFunctionBody());
+    }
+
+    if (anyFailed) {
+      signalPassFailure();
+      return;
+    }
+  } else {
+    // If there are none, we only have to replace InferredContextOps in
+    // the body of context providers.
+    LLVM_DEBUG(llvm::dbgs() << "No function needs context arguments.\n");
+  }
+
+  // Traverse the interesting regions to replace `arc.inferred_context` ops and
+  // propagate the context to callees in `needsContextSet`.
+  for (auto instFn : hasInstancesSet)
+    regionsToUpdate.insert(&instFn.getFunctionBody());
+  for (auto fnOp : hasContextSet)
+    regionsToUpdate.insert(&fnOp.getFunctionBody());
+  for (auto modelOp : moduleOp.getOps<ModelOp>())
+    regionsToUpdate.insert(&modelOp.getBody());
+
+  for (Region *region : regionsToUpdate)
+    updateRegion(region, symbolTable);
+
+  markAnalysesPreserved<ModelInfoAnalysis>();
+}

--- a/lib/Dialect/Arc/Transforms/InferContext.cpp
+++ b/lib/Dialect/Arc/Transforms/InferContext.cpp
@@ -1,4 +1,4 @@
-//===- InferContext.cpp ---------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -67,30 +67,34 @@ struct InferContextPass : public arc::impl::InferContextBase<InferContextPass> {
   void runOnOperation() override;
 
 private:
-  void propagateNeedsStorage();
-  void backPropagateNeedsContext();
+  /// Build the graph pointing from callees to their callers.
   void buildCallerGraph(ArrayRef<FunctionOpInterface> functions,
                         SymbolTableCollection &symbolTable);
+  /// Add functions to `needsContextSet` that can reach a function that is
+  /// already in the set.
+  void backPropagateNeedsContext();
+  /// Walk the region and wire-in the inferred context.
   void updateRegion(Region *region, SymbolTableCollection &symbolTable);
 
   /// Functions providing context.
   llvm::SmallDenseSet<FunctionOpInterface> hasContextSet;
   /// Functions needing a new context argument.
-  llvm::SmallDenseSet<FunctionOpInterface, 8> needsContextSet;
-  // Callee-to-caller graph.
-  // Must remain const after creation to not invalidate pointers.
+  llvm::SmallDenseSet<FunctionOpInterface> needsContextSet;
+  /// Callee-to-caller graph; must remain const after creation to not invalidate
+  /// pointers.
   DenseMap<FunctionOpInterface, CallerGraphNode> callerGraph;
 };
 
-// Walk the region and wire-in the inferred context.
 void InferContextPass::updateRegion(Region *region,
                                     SymbolTableCollection &symbolTable) {
   assert(!region->empty());
   IRRewriter rewriter(region->getContext());
   rewriter.setInsertionPointToStart(&region->front());
-  Value inferredContextVal = {};
   FunctionOpInterface containingFn =
       dyn_cast<FunctionOpInterface>(region->getParentOp());
+
+  // Obtain the inferred context value.
+  Value inferredContextVal = {};
   if (auto modelOp = llvm::dyn_cast<ModelOp>(region->getParentOp())) {
     // Arc model op body: Context derived from the storage argument.
     auto storageArg = region->getArgument(0);
@@ -129,6 +133,7 @@ void InferContextPass::updateRegion(Region *region,
                << "Traversing body of function \"" << fnName << "\"\n";);
   }
 
+  // Do the update walk.
   region->walk<WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
     if (op->getNumRegions() > 0) {
       // Recurse into instances
@@ -164,7 +169,6 @@ void InferContextPass::updateRegion(Region *region,
 
 } // namespace
 
-// Build the graph pointing from callees to their callers.
 void InferContextPass::buildCallerGraph(ArrayRef<FunctionOpInterface> functions,
                                         SymbolTableCollection &symbolTable) {
   // Allocate the nodes for the caller graph. Nodes point to each other, so
@@ -205,8 +209,6 @@ void InferContextPass::buildCallerGraph(ArrayRef<FunctionOpInterface> functions,
   }
 }
 
-// Add functions to `needsContextSet` that can reach a function that is already
-// in the set.
 void InferContextPass::backPropagateNeedsContext() {
 
   // Propagate "needsContext" to callers.
@@ -253,19 +255,22 @@ void InferContextPass::backPropagateNeedsContext() {
 
 void InferContextPass::runOnOperation() {
   SymbolTableCollection symbolTable;
+  ModuleOp moduleOp = getOperation();
+
+  // Functions containing instances.
+  llvm::SmallDenseSet<FunctionOpInterface> hasInstancesSet;
+
   hasContextSet.clear();
   needsContextSet.clear();
   callerGraph.clear();
-  ModuleOp moduleOp = getOperation();
+
+  // Guards hasContextSet, needsContextSet and hasInstancesSet.
   std::mutex setMutex;
 
   // Collect all interesting functions. A function is interesting if it
   // contains any instances or any InferredContextOps or provides a context.
   SmallVector<FunctionOpInterface> funcOps =
       llvm::to_vector(moduleOp.getOps<FunctionOpInterface>());
-
-  // Functions containing instances.
-  llvm::SmallDenseSet<FunctionOpInterface> hasInstancesSet;
 
   parallelForEach(
       moduleOp.getContext(), funcOps, [&](FunctionOpInterface funcOp) {
@@ -339,7 +344,7 @@ void InferContextPass::runOnOperation() {
   } else {
     // If there are none, we only have to replace InferredContextOps in
     // the body of context providers.
-    LLVM_DEBUG(llvm::dbgs() << "No function needs context arguments.\n");
+    LLVM_DEBUG(llvm::dbgs() << "No function needs a context argument.\n");
   }
 
   // Traverse the interesting regions to replace `arc.inferred_context` ops and

--- a/lib/Tools/arcilator/pipelines.cpp
+++ b/lib/Tools/arcilator/pipelines.cpp
@@ -167,6 +167,7 @@ void circt::populateArcToLLVMPipeline(OpPassManager &pm,
   if (options.bufferizeArrays) {
     pm.addPass(createLowerArrays());
   }
+  pm.addPass(createInferContext());
   pm.addPass(createLowerArcToLLVMPass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizer());

--- a/test/Dialect/Arc/infer-context-errors.mlir
+++ b/test/Dialect/Arc/infer-context-errors.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt %s --arc-infer-context --split-input-file --verify-diagnostics
+
+// A public function cannot gain an inferred context argument, since its
+// signature is part of the module's external interface.
+// expected-error @below {{Cannot infer an Arc context through a public function. A context argument must be provided explicitly.}}
+func.func @publicDirect() -> i64 {
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}
+
+// -----
+
+// The context requirement propagates to callers, so a public function that
+// transitively reaches a context-needing function is rejected too.
+func.func private @leaf() -> i64 {
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}
+
+// expected-error @below {{Cannot infer an Arc context through a public function. A context argument must be provided explicitly.}}
+func.func @publicTransitive() -> i64 {
+  %r = func.call @leaf() : () -> i64
+  return %r : i64
+}

--- a/test/Dialect/Arc/infer-context.mlir
+++ b/test/Dialect/Arc/infer-context.mlir
@@ -1,0 +1,227 @@
+// RUN: circt-opt %s --arc-infer-context | FileCheck %s
+
+// An `arc.inferred_context` in the body of an `arc.model` resolves to the
+// context derived from the model's storage argument.
+// CHECK-LABEL: arc.model @ModelBody
+arc.model @ModelBody io !hw.modty<> {
+// CHECK-NEXT: ^bb0(%arg0: !arc.storage):
+^bb0(%arg0: !arc.storage):
+  // CHECK-NEXT: [[CTX:%.+]] = arc.as_context %arg0 : !arc.storage
+  // CHECK-NEXT: arc.current_time [[CTX]]
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+}
+
+// The context is derived at the start of the region even when the
+// `arc.inferred_context` is not the first operation.
+// CHECK-LABEL: arc.model @ModelBodyLate
+arc.model @ModelBodyLate io !hw.modty<> {
+// CHECK-NEXT: ^bb0(%arg0: !arc.storage):
+^bb0(%arg0: !arc.storage):
+  // CHECK-NEXT: [[CTX:%.+]] = arc.as_context %arg0 : !arc.storage
+  // CHECK-NEXT: [[T:%.+]] = hw.constant 0
+  // CHECK-NEXT: arc.set_next_wakeup [[CTX]], [[T]]
+  %t = hw.constant 0 : i64
+  %ctx = arc.inferred_context
+  arc.set_next_wakeup %ctx, %t
+}
+
+// An `arc.inferred_context` in the body of an `arc.sim.instantiate` resolves to
+// the context derived from the instance handle. The enclosing (public) function
+// is not itself flagged as needing a context argument, since the instance
+// provides the context.
+arc.model @sim_test io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+}
+// CHECK-LABEL: func.func @InstanceBody() {
+func.func @InstanceBody() {
+  // CHECK: arc.sim.instantiate @sim_test as [[INST:%.+]] {
+  arc.sim.instantiate @sim_test as %model {
+    // CHECK-NEXT: [[CTX:%.+]] = arc.as_context [[INST]] : !arc.sim.instance<@sim_test>
+    // CHECK-NEXT: arc.current_time [[CTX]]
+    %ctx = arc.inferred_context
+    %t = arc.current_time %ctx
+  }
+  return
+}
+
+// A private function containing an `arc.inferred_context` gains a trailing
+// context argument, and each caller threads its own context in.
+// CHECK-LABEL: func.func private @needsCtx
+// CHECK-SAME:    (%arg0: !arc.context)
+func.func private @needsCtx() -> i64 {
+  // CHECK-NEXT: [[T:%.+]] = arc.current_time %arg0
+  // CHECK-NEXT: return [[T]]
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}
+
+// CHECK-LABEL: arc.model @Caller
+arc.model @Caller io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // CHECK: [[CTX:%.+]] = arc.as_context %arg0
+  // CHECK-NEXT: func.call @needsCtx([[CTX]]) : (!arc.context) -> i64
+  %r = func.call @needsCtx() : () -> i64
+}
+
+// A function that already has a context argument keeps its signature and
+// resolves `arc.inferred_context` to that argument.
+// CHECK-LABEL: func.func private @hasCtx
+// CHECK-SAME:    (%arg0: !arc.context)
+func.func private @hasCtx(%c: !arc.context) -> i64 {
+  // CHECK: arc.current_time %arg0
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}
+
+// A context-providing function is resolved even when it is public: no argument
+// has to be added, so the public-function restriction does not apply.
+// CHECK-LABEL: func.func @pubHasCtx
+// CHECK-SAME:    (%arg0: !arc.context)
+func.func @pubHasCtx(%c: !arc.context) -> i64 {
+  // CHECK: arc.current_time %arg0
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}
+
+// The context threads transitively through a call chain: the model provides it,
+// and every private function on the path gains a context argument.
+// CHECK-LABEL: func.func private @chainLeaf
+// CHECK-SAME:    (%arg0: !arc.context)
+func.func private @chainLeaf() -> i64 {
+  // CHECK: arc.current_time %arg0
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}
+// CHECK: func.func private @chainMid(%arg0: !arc.context)
+func.func private @chainMid() -> i64 {
+  // CHECK-NEXT: [[R:%.+]] = call @chainLeaf(%arg0) : (!arc.context) -> i64
+  // CHECK-NEXT: return [[R]]
+  %r = func.call @chainLeaf() : () -> i64
+  return %r : i64
+}
+// CHECK: arc.model @ChainCaller
+arc.model @ChainCaller io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // CHECK: [[CTX:%.+]] = arc.as_context %arg0
+  // CHECK-NEXT: func.call @chainMid([[CTX]]) : (!arc.context) -> i64
+  %r = func.call @chainMid() : () -> i64
+}
+
+// An `arc.inferred_context` nested in a non-isolated region (e.g. `scf.if`) of a
+// function still resolves to the threaded context argument.
+// CHECK-LABEL: func.func private @nestedRegion
+// CHECK-SAME:    (%arg0: i1, %arg1: !arc.context)
+func.func private @nestedRegion(%cond: i1) {
+  // CHECK-NEXT: scf.if
+  // CHECK-NEXT:   arc.current_time %arg1
+  scf.if %cond {
+    %ctx = arc.inferred_context
+    %t = arc.current_time %ctx
+  }
+  return
+}
+// CHECK: arc.model @NestedCaller
+arc.model @NestedCaller io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // CHECK: [[CTX:%.+]] = arc.as_context %arg0
+  // CHECK: func.call @nestedRegion(%{{.+}}, [[CTX]]) : (i1, !arc.context) -> ()
+  %c = hw.constant true
+  func.call @nestedRegion(%c) : (i1) -> ()
+}
+
+// A callee shared between two models gets a single context argument; each model
+// passes its own context at its call site.
+// CHECK-LABEL: func.func private @shared
+// CHECK-SAME:    (%arg0: !arc.context)
+func.func private @shared() -> i64 {
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}
+// CHECK: arc.model @ShareA
+arc.model @ShareA io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // CHECK: [[CTX1:%.+]] = arc.as_context %arg0
+  // CHECK-NEXT: func.call @shared([[CTX1]])
+  %r = func.call @shared() : () -> i64
+}
+// CHECK: arc.model @ShareB
+arc.model @ShareB io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // CHECK: [[CTX2:%.+]] = arc.as_context %arg0
+  // CHECK-NEXT: func.call @shared([[CTX2]])
+  %r = func.call @shared() : () -> i64
+}
+
+// Multiple `arc.inferred_context` ops in one function all resolve to the same
+// context argument.
+// CHECK-LABEL: func.func private @multiInfer
+// CHECK-SAME:    (%arg0: !arc.context)
+func.func private @multiInfer() -> i64 {
+  // CHECK-NEXT: [[A:%.+]] = arc.current_time %arg0
+  // CHECK-NEXT: [[B:%.+]] = arc.current_time %arg0
+  // CHECK-NEXT: comb.add [[A]], [[B]]
+  %c1 = arc.inferred_context
+  %a = arc.current_time %c1
+  %c2 = arc.inferred_context
+  %b = arc.current_time %c2
+  %s = comb.add %a, %b : i64
+  return %s : i64
+}
+// CHECK: arc.model @MultiCaller
+arc.model @MultiCaller io !hw.modty<> {
+^bb0(%arg0: !arc.storage):
+  // CHECK: func.call @multiInfer
+  %r = func.call @multiInfer() : () -> i64
+}
+
+// A function that already has a context argument threads that same argument into
+// the context-needing functions it calls.
+// CHECK-LABEL: func.func private @provideLeaf
+// CHECK-SAME:    (%arg0: !arc.context)
+func.func private @provideLeaf() -> i64 {
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}
+// CHECK: func.func private @provideMid(%arg0: !arc.context)
+func.func private @provideMid(%c: !arc.context) -> i64 {
+  // CHECK: call @provideLeaf(%arg0) : (!arc.context) -> i64
+  %r = func.call @provideLeaf() : () -> i64
+  return %r : i64
+}
+
+// A cycle in the call graph where one function needs a context: both functions
+// gain the argument and it is threaded around the cycle.
+// CHECK-LABEL: func.func private @recA
+// CHECK-SAME:    (%arg0: i32, %arg1: !arc.context)
+func.func private @recA(%n: i32) -> i64 {
+  // CHECK: arc.current_time %arg1
+  // CHECK: call @recB(%arg0, %arg1) : (i32, !arc.context) -> i64
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  %r = func.call @recB(%n) : (i32) -> i64
+  return %t : i64
+}
+// CHECK: func.func private @recB(%arg0: i32, %arg1: !arc.context)
+func.func private @recB(%n: i32) -> i64 {
+  // CHECK: call @recA(%arg0, %arg1) : (i32, !arc.context) -> i64
+  %r = func.call @recA(%n) : (i32) -> i64
+  return %r : i64
+}
+
+// A private context-needing function that is never called still gains a context
+// argument (there is simply no call site to update).
+// CHECK-LABEL: func.func private @uncalled
+// CHECK-SAME:    (%arg0: !arc.context)
+func.func private @uncalled() -> i64 {
+  // CHECK-NEXT: arc.current_time %arg0
+  %ctx = arc.inferred_context
+  %t = arc.current_time %ctx
+  return %t : i64
+}


### PR DESCRIPTION
Add the `arc.inferred_context` operation as a placeholder for the context of the model instance currently being executed, and the `arc-infer-context` pass that resolves it.

The InferContext pass resolves InferredContext operations to the closest provided arc context, by threading it as an extra argument through calls to (private) functions if required. This should facilitate operation conversions where the target operation requires a context argument.

Assisted-by: vscode:Claude Opus 4.8