### PR TITLE
[FIRRTL] String expression propassert message

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -380,13 +380,13 @@ def PropertyAssertOp : FIRRTLOp<"property_assert",
 
     Example:
     ```mlir
-    firrtl.property_assert %cond, "invariant must hold" : !firrtl.bool
+    firrtl.property_assert %cond, %message : !firrtl.bool
     ```
   }];
 
   let arguments = (ins
     BoolType:$condition,
-    StrAttr:$message
+    StringType:$message
   );
   let results = (outs);
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1205,7 +1205,21 @@ void Emitter::emitStatement(PropertyAssertOp op) {
     ps << "propassert" << PP::space;
     emitExpression(op.getCondition());
     ps << "," << PP::space;
-    ps.writeQuotedEscaped(op.getMessage());
+    // For FIRRTL <= 7.0.0, do a best effort emission that will inline a single
+    // string expression.  If we see anything more complicated than this, just
+    // bail.
+    if (version <= FIRVersion(7, 0, 0)) {
+      auto expr = dyn_cast<StringConstantOp>(op.getMessage().getDefiningOp());
+      if (!expr) {
+        auto diag =
+            emitOpError(op, "unable to emit non-literal string expressions "
+                            "when targeting FIRRTL version <= 7.0.0");
+        diag.attachNote(op.getMessage().getLoc())
+            << "non-literal expression is here";
+      }
+    } else {
+      emitExpression(op.getMessage());
+    }
   });
   emitLocationAndNewLine(op);
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4416,8 +4416,7 @@ LogicalResult PropertyAssertOp::verify() {
   if (auto *defOp = getCondition().getDefiningOp())
     if (auto boolConst = dyn_cast<BoolConstantOp>(defOp))
       if (!boolConst.getValue())
-        return emitOpError("property assertion is statically false: ")
-               << getMessage();
+        return emitOpError("property assertion is statically false");
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4575,29 +4575,47 @@ ParseResult FIRStmtParser::parseConnect() {
   return success();
 }
 
-/// propassert ::= 'propassert' expr ',' string_literal
+/// Before FIRRTL 7.0.0:
+///   propassert ::= 'propassert' expr ',' string_literal
+/// After FIRRTL 7.0.0:
+///   propassert ::= 'propassert' expr ',' expr
 ParseResult FIRStmtParser::parsePropAssert() {
   auto startTok = consumeToken(FIRToken::kw_propassert);
   auto loc = startTok.getLoc();
 
-  Value condition;
-  StringRef message;
+  llvm::SMLoc conditionLoc = getToken().getLoc(), messageLoc;
+  Value condition, message;
   if (parseExp(condition, "expected condition in 'propassert'") ||
-      parseToken(FIRToken::comma, "expected ','") ||
-      parseGetSpelling(message) ||
-      parseToken(FIRToken::string, "expected message string in 'propassert'"))
+      parseToken(FIRToken::comma, "expected ','"))
     return failure();
+  if (version < FIRVersion(7, 0, 0)) {
+    StringRef messageStr;
+    messageLoc = getToken().getLoc();
+    if (parseGetSpelling(messageStr) ||
+        parseToken(FIRToken::string, "expected message string in 'propassert'"))
+      return failure();
+    auto attr = builder.getStringAttr(FIRToken::getStringValue(messageStr));
+    message = moduleContext.getCachedConstant<StringConstantOp>(
+        builder, attr, builder.getType<StringType>(), attr);
+  } else {
+    messageLoc = getToken().getLoc();
+    if (parseExp(message, "expected message in 'propassert'"))
+      return failure();
+  }
 
   if (!isa<BoolType>(condition.getType()))
-    return emitError(loc, "propassert condition must be of boolean type");
+    return emitError(conditionLoc,
+                     "propassert condition must be of boolean type");
+
+  // Note: This is a dead check for FIRRTL < 7.0.0.
+  if (!type_isa<StringType>(message.getType()))
+    return emitError(messageLoc, "propassert message must be a string type");
 
   if (parseOptionalInfo())
     return failure();
 
   locationProcessor.setLoc(loc);
-  auto messageUnescaped = FIRToken::getStringValue(message);
-  PropertyAssertOp::create(builder, condition,
-                           builder.getStringAttr(messageUnescaped));
+  PropertyAssertOp::create(builder, condition, message);
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1727,12 +1727,8 @@ struct PropertyAssertOpConversion
   LogicalResult
   matchAndRewrite(firrtl::PropertyAssertOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.setInsertionPoint(op);
-    auto stringType = om::StringType::get(op.getContext());
-    auto message = om::ConstantOp::create(
-        rewriter, op.getLoc(), StringAttr::get(op.getMessage(), stringType));
     rewriter.replaceOpWithNewOp<om::PropertyAssertOp>(
-        op, adaptor.getCondition(), message);
+        op, adaptor.getCondition(), adaptor.getMessage());
     return success();
   }
 };

--- a/test/Dialect/FIRRTL/emit-version-errors-lt-7.0.0.mlir
+++ b/test/Dialect/FIRRTL/emit-version-errors-lt-7.0.0.mlir
@@ -60,3 +60,18 @@ firrtl.circuit "SimulationTest" {
     out success: !firrtl.uint<1>
   )
 }
+
+// -----
+
+// Non-literal expressions cause an error in FIRRTL < 7.0.0.
+firrtl.circuit "CompoundPropertyMessage" {
+  firrtl.module @CompoundPropertyMessage() {
+    %cond = firrtl.bool true
+    %foo = firrtl.string "foo"
+    %bar = firrtl.string "bar"
+    // expected-note @below {{non-literal expression is here}}
+    %foobar = firrtl.string.concat %foo, %bar : !firrtl.string
+    // expected-error @below {{unable to emit non-literal string expressions when targeting FIRRTL version <= 7.0.0}}
+    firrtl.property_assert %cond, %foobar : !firrtl.bool
+  }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -3543,8 +3543,9 @@ firrtl.circuit "PropAssertFalseInClass" {
   firrtl.module @PropAssertFalseInClass() {}
   firrtl.class @C() {
     %false = firrtl.bool false
-    // expected-error @below {{property assertion is statically false: invariant violated}}
-    firrtl.property_assert %false, "invariant violated" : !firrtl.bool
+    %msg = firrtl.string "invariant violated"
+    // expected-error @below {{property assertion is statically false}}
+    firrtl.property_assert %false, %msg : !firrtl.bool
   }
 }
 
@@ -3554,7 +3555,8 @@ firrtl.circuit "PropAssertFalseInClass" {
 firrtl.circuit "PropAssertFalseInModule" {
   firrtl.module @PropAssertFalseInModule() {
     %false = firrtl.bool false
-    // expected-error @below {{property assertion is statically false: module invariant violated}}
-    firrtl.property_assert %false, "module invariant violated" : !firrtl.bool
+    %msg = firrtl.string "module invariant violated"
+    // expected-error @below {{property assertion is statically false}}
+    firrtl.property_assert %false, %msg : !firrtl.bool
   }
 }

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -757,16 +757,18 @@ firrtl.circuit "UnknownValue" {
   // CHECK-LABEL: om.class private @PropAssertClass
   firrtl.class private @PropAssertClass(in %cond: !firrtl.bool) {
     // CHECK-NEXT: %[[message:.+]] = om.constant "must hold" : !om.string
+    %0 = firrtl.string "must hold"
     // CHECK-NEXT: om.property_assert %cond, %[[message]] : i1
-    firrtl.property_assert %cond, "must hold" : !firrtl.bool
+    firrtl.property_assert %cond, %0 : !firrtl.bool
   }
 
   // property_assert in a module body: the op is moved into the generated class.
   // CHECK-LABEL: om.class @PropAssertModule_Class
   firrtl.module @PropAssertModule(in %cond: !firrtl.bool) {
     // CHECK-NEXT: %[[message:.+]] = om.constant "module invariant" : !om.string
+    %0 = firrtl.string "module invariant"
     // CHECK-NEXT: om.property_assert %cond, %[[message]] : i1
-    firrtl.property_assert %cond, "module invariant" : !firrtl.bool
+    firrtl.property_assert %cond, %0 : !firrtl.bool
   }
 }
 
@@ -786,8 +788,9 @@ firrtl.circuit "NoPropPorts" {
     // CHECK: %[[EQ:.+]] = om.prop.eq %[[U0]], %[[U1]] : !om.string
     %2 = firrtl.prop.eq %0, %1 : !firrtl.string
     // CHECK:      %[[message:.+]] = om.constant "srcs must match" : !om.string
+    %3 = firrtl.string "srcs must match"
     // CHECK-NEXT: om.property_assert %[[EQ]], %[[message]] : i1
-    firrtl.property_assert %2, "srcs must match" : !firrtl.bool
+    firrtl.property_assert %2, %3 : !firrtl.bool
   }
 }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1488,7 +1488,7 @@ circuit Layers:
 
 ;// -----
 ; CHECK-LABEL: firrtl.circuit "BasicProps"
-FIRRTL version 6.0.0
+FIRRTL version 7.0.0
 circuit BasicProps :
   public module BasicProps :
   ; CHECK-LABEL: module private @Integer
@@ -1516,10 +1516,12 @@ circuit BasicProps :
   module PropAssert :
     input cond : Bool
     ; CHECK: %[[TRUE:.+]] = firrtl.bool true
-    ; CHECK-NEXT: firrtl.property_assert %[[TRUE]], "always true" : !firrtl.bool
-    propassert Bool(true), "always true"
-    ; CHECK-NEXT: firrtl.property_assert %cond, "holds" : !firrtl.bool
-    propassert cond, "holds"
+    ; CHECK-NEXT: %[[MSG:.+]] = firrtl.string "always true"
+    ; CHECK-NEXT: firrtl.property_assert %[[TRUE]], %[[MSG]] : !firrtl.bool
+    propassert Bool(true), String("always true")
+    ; CHECK-NEXT: %[[MSG:.+]] = firrtl.string "holds"
+    ; CHECK-NEXT: firrtl.property_assert %cond, %[[MSG]] : !firrtl.bool
+    propassert cond, String("holds")
 
   ; CHECK-LABEL: module private @Double
   module Double :
@@ -1627,6 +1629,16 @@ circuit BasicProps :
     ; CHECK-NEXT: %[[NESTED:.+]] = firrtl.list.create %[[EMPTY1]], %[[TESTLIST]], %[[EMPTY2]] : !firrtl.list<list<string>>
     ; CHECK-NEXT: firrtl.propassign %nested, %[[NESTED]]
     propassign nested, List<List<String>>(List<String>(), List<String>(String("test")), List<String>())
+
+;// -----
+FIRRTL version 6.0.0
+; CHECK-LABEL: firrtl.circuit "PropAsserts_6"
+circuit PropAsserts_6:
+  public module PropAsserts_6:
+    ; CHECK:      %[[TRUE:.+]] = firrtl.bool true
+    ; CHECK-NEXT: %[[MSG:.+]] = firrtl.string "foo"
+    ; CHECK-NEXT: firrtl.property_assert %[[TRUE]], %[[MSG]]
+    propassert Bool(true), "foo"
 
 ;// -----
 FIRRTL version 4.0.0

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1964,3 +1964,10 @@ circuit OOBFormatString:
     input clk : Clock
     ; expected-error @below {{not enough operands for format string}}
     printf(clk, UInt<1>(0h1), "oops: %d")
+
+;// -----
+FIRRTL version 7.0.0
+circuit PropertyAssertNonStringMessage:
+  public module PropertyAssertNonStringMessage:
+    ; expected-error @below {{propassert message must be a string type}}
+    propassert Bool(true), Integer(42)

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -443,15 +443,19 @@ firrtl.module @WireDomainOperands(
 // In a class body.
 // CHECK-LABEL: firrtl.class @AssertInClass
 firrtl.class @AssertInClass(in %cond : !firrtl.bool) {
-  // CHECK: firrtl.property_assert %cond, "must be true" : !firrtl.bool
-  firrtl.property_assert %cond, "must be true" : !firrtl.bool
+  // CHECK-NEXT: %0 = firrtl.string "must be true"
+  // CHECK-NEXT: firrtl.property_assert %cond, %0 : !firrtl.bool
+  %0 = firrtl.string "must be true"
+  firrtl.property_assert %cond, %0 : !firrtl.bool
 }
 
 // In a module body.
 // CHECK-LABEL: firrtl.module @AssertInModule
 firrtl.module @AssertInModule(in %cond : !firrtl.bool) {
-  // CHECK: firrtl.property_assert %cond, "module invariant" : !firrtl.bool
-  firrtl.property_assert %cond, "module invariant" : !firrtl.bool
+  // CHECK-NEXT: %0 = firrtl.string "module invariant"
+  // CHECK-NEXT: firrtl.property_assert %cond, %0 : !firrtl.bool
+  %0 = firrtl.string "module invariant"
+  firrtl.property_assert %cond, %0 : !firrtl.bool
 }
 
 }


### PR DESCRIPTION
Change the FIRRTL syntax (printing and parsing) for FIRRTL 7.0.0 to accept
string _expressions_ for a property assert.  This is done to allow for
much more expressive property assertions that include more information
about what a failure is.  Properties are frequently evaluated after
Verilog compilation (e.g., by `domaintool`) and we can provide much better
messages if we have can construct strings on the fly.

All functionality related to parsing of the old syntax for FIRRTL < 7.0.0
is preserved.  If an earlier FIRRTL version is seen, then this is upgraded
internally to the new operations.  If the emitter is told to emit FIRRTL <
7.0.0 emit the old syntax if the expression is a constant string.
