### PR TITLE
[BMC] Add PrepareForBMC pass

### DIFF
--- a/include/circt/Tools/circt-bmc/Passes.h
+++ b/include/circt/Tools/circt-bmc/Passes.h
@@ -25,6 +25,7 @@ namespace circt {
 #define GEN_PASS_DECL_LOWERTOBMC
 #define GEN_PASS_DECL_EXTERNALIZEREGISTERS
 #define GEN_PASS_DECL_MATERIALIZEDEBUGVARIABLES
+#define GEN_PASS_DECL_PREPAREFORBMC
 #define GEN_PASS_REGISTRATION
 #include "circt/Tools/circt-bmc/Passes.h.inc"
 

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -64,4 +64,24 @@ def MaterializeDebugVariables : Pass<"materialize-debug-variables", "::mlir::Mod
   ];
 }
 
+def PrepareForBMC : Pass<"prepare-for-bmc", "::mlir::ModuleOp"> {
+  let summary = "Normalizes clock ports and clocked properties for BMC";
+  let description = [{
+    Converts `i1` module inputs used through `seq.to_clock` into native
+    `!seq.clock` inputs. It also converts clocked assertions and assumptions
+    into unclocked properties gated by an actual edge, tracked by comparing the
+    current clock value with a registered previous value.
+  }];
+  let options = [
+    Option<"topModule", "top-module", "std::string",
+           /*default=*/"",
+           "Name of the top module to prepare.">
+  ];
+
+  let dependentDialects = [
+    "circt::comb::CombDialect", "circt::hw::HWDialect",
+    "circt::seq::SeqDialect", "circt::verif::VerifDialect"
+  ];
+}
+
 #endif // CIRCT_TOOLS_CIRCT_BMC_PASSES_TD

--- a/lib/Tools/circt-bmc/CMakeLists.txt
+++ b/lib/Tools/circt-bmc/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_library(CIRCTBMCTransforms
   ExternalizeRegisters.cpp
   LowerToBMC.cpp
   MaterializeDebugVariables.cpp
+  PrepareForBMC.cpp
 
   DEPENDS
   CIRCTBMCTransformsIncGen

--- a/lib/Tools/circt-bmc/PrepareForBMC.cpp
+++ b/lib/Tools/circt-bmc/PrepareForBMC.cpp
@@ -1,0 +1,173 @@
+//===- PrepareForBMC.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Verif/VerifOps.h"
+#include "circt/Tools/circt-bmc/Passes.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+using namespace circt;
+
+namespace circt {
+#define GEN_PASS_DEF_PREPAREFORBMC
+#include "circt/Tools/circt-bmc/Passes.h.inc"
+} // namespace circt
+
+namespace {
+struct PrepareForBMCPass
+    : public circt::impl::PrepareForBMCBase<PrepareForBMCPass> {
+  using PrepareForBMCBase::PrepareForBMCBase;
+
+  FailureOr<Value> getPreviousClock(Value clock, OpBuilder &builder) {
+    if (auto it = previousClockValues.find(clock);
+        it != previousClockValues.end())
+      return it->second;
+
+    auto fromClock = clock.getDefiningOp<seq::FromClockOp>();
+    if (!fromClock) {
+      emitError(clock.getLoc(),
+                "expected a clock normalized by seq.from_clock");
+      return failure();
+    }
+
+    auto initialValue = seq::createConstantInitialValue(
+        builder, clock.getLoc(),
+        builder.getIntegerAttr(builder.getI1Type(), 0));
+    // ExternalizeRegisters turns this into BMC state whose next value is the
+    // current clock, giving every property the clock value from the preceding
+    // BMC transition.
+    auto previousClock = seq::CompRegOp::create(
+        builder, clock.getLoc(), clock, fromClock.getInput(), /*reset=*/Value{},
+        /*rstValue=*/Value{}, initialValue);
+    previousClockValues.try_emplace(clock, previousClock);
+    return previousClock.getData();
+  }
+
+  template <typename ClockedOp, typename UnclockedOp>
+  LogicalResult lowerClockedProperty(ClockedOp op) {
+    if (!op.getProperty().getType().isInteger(1)) {
+      op.emitError("unsupported clocked property after LTL lowering");
+      return failure();
+    }
+
+    OpBuilder builder(op);
+    auto previousClock = getPreviousClock(op.getClock(), builder);
+    if (failed(previousClock))
+      return failure();
+    auto trueValue =
+        hw::ConstantOp::create(builder, op.getLoc(), builder.getI1Type(), 1);
+    Value active;
+    switch (op.getEdge()) {
+    case verif::ClockEdge::Pos: {
+      auto notPreviousClock =
+          comb::XorOp::create(builder, op.getLoc(), *previousClock, trueValue);
+      active = comb::AndOp::create(builder, op.getLoc(), op.getClock(),
+                                   notPreviousClock);
+      break;
+    }
+    case verif::ClockEdge::Neg: {
+      auto notCurrentClock =
+          comb::XorOp::create(builder, op.getLoc(), op.getClock(), trueValue);
+      active = comb::AndOp::create(builder, op.getLoc(), notCurrentClock,
+                                   *previousClock);
+      break;
+    }
+    case verif::ClockEdge::Both:
+      active = comb::XorOp::create(builder, op.getLoc(), op.getClock(),
+                                   *previousClock);
+      break;
+    }
+    if (op.getEnable())
+      active =
+          comb::AndOp::create(builder, op.getLoc(), active, op.getEnable());
+
+    auto inactive =
+        comb::XorOp::create(builder, op.getLoc(), active, trueValue);
+    auto property =
+        comb::OrOp::create(builder, op.getLoc(), inactive, op.getProperty());
+    UnclockedOp::create(builder, op.getLoc(), property, /*enable=*/Value{},
+                        op.getLabelAttr());
+    op.erase();
+    return success();
+  }
+
+  void normalizeClockPorts(hw::HWModuleOp module) {
+    // SystemVerilog import represents clocks as i1 ports converted by
+    // seq.to_clock. BMC needs a native clock block argument so it can own the
+    // clock waveform and update registers only on rising edges.
+    auto *body = module.getBodyBlock();
+    SmallVector<BlockArgument> clockArguments;
+    for (auto argument : body->getArguments()) {
+      if (!argument.getType().isInteger(1))
+        continue;
+      if (llvm::any_of(argument.getUsers(), [](Operation *user) {
+            return isa<seq::ToClockOp>(user);
+          }))
+        clockArguments.push_back(argument);
+    }
+    if (clockArguments.empty())
+      return;
+
+    SmallVector<hw::ModulePort> ports(module.getHWModuleType().getPorts());
+    auto clockType = seq::ClockType::get(&getContext());
+    for (auto argument : clockArguments) {
+      SmallVector<seq::ToClockOp> toClockOps;
+      SmallVector<OpOperand *> rawClockUses;
+      for (auto &use : argument.getUses()) {
+        if (auto toClock = dyn_cast<seq::ToClockOp>(use.getOwner()))
+          toClockOps.push_back(toClock);
+        else
+          rawClockUses.push_back(&use);
+      }
+
+      argument.setType(clockType);
+      OpBuilder builder = OpBuilder::atBlockBegin(body);
+      auto rawClock =
+          seq::FromClockOp::create(builder, argument.getLoc(), argument);
+      for (auto *use : rawClockUses)
+        use->set(rawClock);
+      for (auto toClock : toClockOps) {
+        toClock.replaceAllUsesWith(argument);
+        toClock.erase();
+      }
+
+      auto portID =
+          module.getHWModuleType().getPortIdForInputId(argument.getArgNumber());
+      ports[portID].type = clockType;
+    }
+    module.setHWModuleType(hw::ModuleType::get(&getContext(), ports));
+  }
+
+  void runOnOperation() override {
+    previousClockValues.clear();
+    auto module = getOperation().lookupSymbol<hw::HWModuleOp>(topModule);
+    if (!module)
+      return;
+
+    normalizeClockPorts(module);
+    LogicalResult result = success();
+    module->walk([&](Operation *operation) {
+      if (failed(result))
+        return;
+      if (auto assertOp = dyn_cast<verif::ClockedAssertOp>(operation))
+        result = lowerClockedProperty<verif::ClockedAssertOp, verif::AssertOp>(
+            assertOp);
+      else if (auto assumeOp = dyn_cast<verif::ClockedAssumeOp>(operation))
+        result = lowerClockedProperty<verif::ClockedAssumeOp, verif::AssumeOp>(
+            assumeOp);
+    });
+    if (failed(result))
+      signalPassFailure();
+  }
+
+  DenseMap<Value, Value> previousClockValues;
+};
+} // namespace

--- a/test/Tools/circt-bmc/prepare-for-bmc.mlir
+++ b/test/Tools/circt-bmc/prepare-for-bmc.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-opt %s --prepare-for-bmc="top-module=Top" | FileCheck %s
+
+// CHECK-LABEL: hw.module @Top(
+// CHECK-SAME:    in [[CLK:%[^:]+]] : !seq.clock
+// CHECK-SAME:    in [[DATA:%[^:]+]] : i1
+// CHECK-SAME:    in [[ENABLE:%[^:]+]] : i1
+// CHECK:         [[RAW_CLK:%.+]] = seq.from_clock [[CLK]]
+// CHECK-NOT:     seq.to_clock
+// CHECK:         seq.firreg [[DATA]] clock [[CLK]]
+// CHECK:         [[INITIAL:%.+]] = seq.initial() {
+// CHECK:           [[FALSE:%.+]] = hw.constant false
+// CHECK:           seq.yield [[FALSE]] : i1
+// CHECK:         }
+// CHECK:         [[PREVIOUS_CLK:%.+]] = seq.compreg [[RAW_CLK]], [[CLK]] initial [[INITIAL]] : i1
+// CHECK:         [[TRUE:%.+]] = hw.constant true
+// CHECK:         [[NOT_PREVIOUS:%.+]] = comb.xor [[PREVIOUS_CLK]], [[TRUE]] : i1
+// CHECK:         [[POSEDGE:%.+]] = comb.and [[RAW_CLK]], [[NOT_PREVIOUS]] : i1
+// CHECK:         [[ACTIVE:%.+]] = comb.and [[POSEDGE]], [[ENABLE]] : i1
+// CHECK:         [[INACTIVE:%.+]] = comb.xor [[ACTIVE]], [[TRUE]] : i1
+// CHECK:         [[ASSERT_PROPERTY:%.+]] = comb.or [[INACTIVE]], [[DATA]] : i1
+// CHECK:         verif.assert [[ASSERT_PROPERTY]] : i1
+// CHECK:         [[NOT_CURRENT:%.+]] = comb.xor [[RAW_CLK]], {{%.+}} : i1
+// CHECK:         [[NEGEDGE:%.+]] = comb.and [[NOT_CURRENT]], [[PREVIOUS_CLK]] : i1
+// CHECK:         [[INACTIVE_NEGEDGE:%.+]] = comb.xor [[NEGEDGE]], {{%.+}} : i1
+// CHECK:         [[ASSUME_PROPERTY:%.+]] = comb.or [[INACTIVE_NEGEDGE]], [[DATA]] : i1
+// CHECK:         verif.assume [[ASSUME_PROPERTY]] : i1
+// CHECK:         [[BOTH_EDGES:%.+]] = comb.xor [[RAW_CLK]], [[PREVIOUS_CLK]] : i1
+// CHECK:         [[INACTIVE_BOTH:%.+]] = comb.xor [[BOTH_EDGES]], {{%.+}} : i1
+// CHECK:         [[BOTH_PROPERTY:%.+]] = comb.or [[INACTIVE_BOTH]], [[DATA]] : i1
+// CHECK:         verif.assert [[BOTH_PROPERTY]] : i1
+// CHECK-NOT:     verif.clocked_
+hw.module @Top(in %clk: i1, in %data: i1, in %enable: i1) {
+  %clock = seq.to_clock %clk
+  %state = seq.firreg %data clock %clock : i1
+  verif.clocked_assert %data if %enable, posedge %clk : i1
+  verif.clocked_assume %data, negedge %clk : i1
+  verif.clocked_assert %data, edge %clk : i1
+}


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

This is preparation for a follow-up change that allows `circt-bmc` to consume SystemVerilog directly.


Assisted-by:codex:gpt-5.6-sol(high)