### PR TITLE
[AXI4] Add window attribute

### DIFF
--- a/include/circt/Dialect/AXI4/AXI4Attributes.td
+++ b/include/circt/Dialect/AXI4/AXI4Attributes.td
@@ -38,6 +38,14 @@ def BurstKind : I32EnumAttr<"BurstKind", "AXI4 burst kind",
 class AXI4AttrDef<string name, list<Trait> traits = []> :
     AttrDef<AXI4Dialect, name, traits>;
 
+// An address, printed in hex. Hex is already accepted when parsing.
+class AddressParameter<string desc = ""> :
+    AttrOrTypeParameter<"uint64_t", desc> {
+  let printer = [{
+    $_printer << "0x" << ::llvm::utohexstr($_self, /*LowerCase=*/true)
+  }];
+}
+
 def BurstSpecAttr : AXI4AttrDef<"BurstSpec"> {
   let mnemonic = "burst_spec";
   let summary = "Describes the burst capabilities of an endpoint";
@@ -94,6 +102,27 @@ def BurstSetAttr : AXI4AttrDef<"BurstSet"> {
       return $_get($_ctxt, sorted);
     }]>
   ];
+}
+
+def WindowAttr : AXI4AttrDef<"Window"> {
+  let mnemonic = "window";
+  let summary = "Describes an access window supported by an endpoint";
+  let description = [{
+    Consists of a base address, an inclusive last address, and the burst specs
+    supported within the window, e.g.
+    `#axi4.window<base = 0x4000, last = 0x40ff, burst_specs = <<fixed, len = 4>>>`.
+  }];
+
+  let parameters = (ins AddressParameter<>:$base,
+                        AddressParameter<>:$last,
+                        "::circt::axi4::BurstSetAttr":$burstSpecs);
+
+  let assemblyFormat = [{
+    `<` `base` `=` $base `,` `last` `=` $last
+        `,` `burst_specs` `=` $burstSpecs `>`
+  }];
+
+  let genVerifyDecl = 1;
 }
 
 #endif // CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_TD

--- a/lib/Dialect/AXI4/AXI4Attributes.cpp
+++ b/lib/Dialect/AXI4/AXI4Attributes.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/MathExtras.h"
 
@@ -60,6 +61,17 @@ LogicalResult BurstSetAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                                    ArrayRef<BurstSpecAttr> burstSpecs) {
   if (burstSpecs.empty())
     return emitError() << "'burst_set' must be non-empty";
+  return success();
+}
+
+LogicalResult WindowAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                                 uint64_t base, uint64_t last,
+                                 BurstSetAttr burstSpecs) {
+  if (last < base)
+    return emitError() << "window 'last' address 0x"
+                       << llvm::utohexstr(last, /*LowerCase=*/true)
+                       << " must not be less than 'base' address 0x"
+                       << llvm::utohexstr(base, /*LowerCase=*/true);
   return success();
 }
 

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -27,3 +27,10 @@
 "test.attrs"() {a = #axi4.burst_set<<incr, len = 8>, <incr, len = 8>>} : () -> ()
 // CHECK: #axi4.burst_set<<fixed, len = 16>, <incr, len = 1>, <incr, len = 256>, <wrap, len = 2>>
 "test.attrs"() {a = #axi4.burst_set<<wrap, len = 2>, <incr, len = 256>, <incr, len = 1>, <fixed, len = 16>>} : () -> ()
+
+// CHECK: #axi4.window<base = 0x4000, last = 0x40ff, burst_specs = <<fixed, len = 4>>>
+"test.attrs"() {a = #axi4.window<base = 0x4000, last = 0x40ff, burst_specs = <<fixed, len = 4>>>} : () -> ()
+
+// Check a window may cover the whole address space
+// CHECK: #axi4.window<base = 0x0, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>
+"test.attrs"() {a = #axi4.window<base = 0x0, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>} : () -> ()

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -42,3 +42,8 @@
 
 // expected-error @below {{'burst_set' must be non-empty}}
 "test.attrs"() {a = #axi4.burst_set<>} : () -> ()
+
+// -----
+
+// expected-error @below {{window 'last' address 0x3fff must not be less than 'base' address 0x4000}}
+"test.attrs"() {a = #axi4.window<base = 0x4000, last = 0x3fff, burst_specs = <<fixed, len = 4>>>} : () -> ()


### PR DESCRIPTION
Adds an attribute to describe access windows that endpoints can send or handle requests to.

AI-assisted-by: Claude Opus 5 (1M context)


<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>