### PR TITLE
[AXI4] Add window_set attribute

### DIFF
--- a/include/circt/Dialect/AXI4/AXI4Attributes.td
+++ b/include/circt/Dialect/AXI4/AXI4Attributes.td
@@ -125,4 +125,43 @@ def WindowAttr : AXI4AttrDef<"Window"> {
   let genVerifyDecl = 1;
 }
 
+def WindowSetAttr : AXI4AttrDef<"WindowSet"> {
+  let mnemonic = "window_set";
+  let summary = "Describes a non-empty set of access windows supported by an endpoint";
+  let description = [{
+    A non-empty set of access windows, e.g.
+    `#axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>>`.
+
+    The capabilities at an address are the union of those of every window
+    covering it, so windows may overlap. To avoid functionally equivalent types
+    being structurally unequal, the windows are normalized on construction into
+    the maximal disjoint windows describing the same capabilities, sorted by
+    base address. Gaps between windows are preserved.
+  }];
+
+  let parameters = (ins
+      OptionalArrayRefParameter<"::circt::axi4::WindowAttr">:$windows);
+
+  // Parse empty sets - catch them in the verifier to avoid a very opaque error
+  let assemblyFormat = "`<` (`>`) : ($windows^ `>`)?";
+
+  // Force all clients through the normalizing builder below.
+  let skipDefaultBuilders = 1;
+  let genVerifyDecl = 1;
+
+  let builders = [
+    AttrOrTypeBuilder<(ins
+        "::llvm::ArrayRef<::circt::axi4::WindowAttr>":$windows), [{
+      return $_get($_ctxt, WindowSetAttr::normalize($_ctxt, windows));
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Rewrites a set of possibly overlapping windows into an equivalent
+    /// ordered and uniqued set of disjoint windows
+    static ::llvm::SmallVector<WindowAttr>
+    normalize(::mlir::MLIRContext *ctx, ::llvm::ArrayRef<WindowAttr> windows);
+  }];
+}
+
 #endif // CIRCT_DIALECT_AXI4_AXI4ATTRIBUTES_TD

--- a/lib/Dialect/AXI4/AXI4Attributes.cpp
+++ b/lib/Dialect/AXI4/AXI4Attributes.cpp
@@ -75,6 +75,59 @@ LogicalResult WindowAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
+SmallVector<WindowAttr> WindowSetAttr::normalize(MLIRContext *ctx,
+                                                 ArrayRef<WindowAttr> windows) {
+  // Split the address space at every point where the specs could change (i.e.
+  // the start and end points of the windows).
+  // Then, for each of those segments, accumulate all the specs that cover it,
+  // and create a window accordingly.
+
+  SmallVector<uint64_t> cuts;
+  for (WindowAttr window : windows) {
+    cuts.push_back(window.getBase());
+    if (window.getLast() != UINT64_MAX)
+      cuts.push_back(window.getLast() + 1);
+  }
+  llvm::sort(cuts);
+  cuts.erase(llvm::unique(cuts), cuts.end());
+
+  SmallVector<WindowAttr> normalized;
+  SmallVector<BurstSpecAttr> specs;
+  for (size_t i = 0; i < cuts.size(); ++i) {
+    uint64_t lo = cuts[i];
+    uint64_t hi = i + 1 < cuts.size() ? cuts[i + 1] - 1 : UINT64_MAX;
+
+    // Collect the set of specs that cover this segment
+    specs.clear();
+    for (WindowAttr window : windows)
+      if (window.getBase() <= lo && lo <= window.getLast())
+        llvm::append_range(specs, window.getBurstSpecs().getBurstSpecs());
+
+    // Nothing covers the segment - a gap between windows.
+    if (specs.empty())
+      continue;
+
+    // BurstSetAttr::get sorts and de-duplicates the union for us.
+    auto burstSpecs = BurstSetAttr::get(ctx, specs);
+
+    // Merge into the previous window where they are contiguous and share
+    // capabilities.
+    if (!normalized.empty() && normalized.back().getLast() + 1 == lo &&
+        normalized.back().getBurstSpecs() == burstSpecs)
+      lo = normalized.pop_back_val().getBase();
+    normalized.push_back(WindowAttr::get(ctx, lo, hi, burstSpecs));
+  }
+  return normalized;
+}
+
+LogicalResult
+WindowSetAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                      ArrayRef<WindowAttr> windows) {
+  if (windows.empty())
+    return emitError() << "'window_set' must be non-empty";
+  return success();
+}
+
 void AXI4Dialect::registerAttributes() {
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -34,3 +34,31 @@
 // Check a window may cover the whole address space
 // CHECK: #axi4.window<base = 0x0, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>
 "test.attrs"() {a = #axi4.window<base = 0x0, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>} : () -> ()
+
+// CHECK: #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>>
+"test.attrs"() {a = #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>>} : () -> ()
+
+// Check window_sets are correctly normalized after parsing
+// CHECK: #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>, <base = 0x1000, last = 0x10ff, burst_specs = <<incr, len = 8>>>>
+"test.attrs"() {a = #axi4.window_set<<base = 0x1000, last = 0x10ff, burst_specs = <<incr, len = 8>>>, <base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>>} : () -> ()
+// CHECK: #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>>
+"test.attrs"() {a = #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>, <base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>>} : () -> ()
+
+// Check overlapping windows are split into disjoint windows unioning their
+// capabilities
+// CHECK: #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>, <incr, len = 8>>>, <base = 0x100, last = 0xfff, burst_specs = <<fixed, len = 4>>>>
+"test.attrs"() {a = #axi4.window_set<<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>, <base = 0x0, last = 0xff, burst_specs = <<incr, len = 8>>>>} : () -> ()
+
+// Check contiguous windows are merged only if their capabilities match
+// CHECK: #axi4.window_set<<base = 0x0, last = 0x1ff, burst_specs = <<fixed, len = 4>>>>
+"test.attrs"() {a = #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>, <base = 0x100, last = 0x1ff, burst_specs = <<fixed, len = 4>>>>} : () -> ()
+// CHECK: #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>, <base = 0x100, last = 0x1ff, burst_specs = <<incr, len = 8>>>>
+"test.attrs"() {a = #axi4.window_set<<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>>>, <base = 0x100, last = 0x1ff, burst_specs = <<incr, len = 8>>>>} : () -> ()
+
+// Check a window at the top of the address space is normalized correctly
+// CHECK: #axi4.window_set<<base = 0xfffffffffffff000, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>>
+"test.attrs"() {a = #axi4.window_set<<base = 0xfffffffffffff000, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>>} : () -> ()
+
+// Check windows covering the whole address space are merged
+// CHECK: #axi4.window_set<<base = 0x0, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>>
+"test.attrs"() {a = #axi4.window_set<<base = 0x0, last = 0x7fffffffffffffff, burst_specs = <<fixed, len = 4>>>, <base = 0x8000000000000000, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>>} : () -> ()

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -47,3 +47,8 @@
 
 // expected-error @below {{window 'last' address 0x3fff must not be less than 'base' address 0x4000}}
 "test.attrs"() {a = #axi4.window<base = 0x4000, last = 0x3fff, burst_specs = <<fixed, len = 4>>>} : () -> ()
+
+// -----
+
+// expected-error @below {{'window_set' must be non-empty}}
+"test.attrs"() {a = #axi4.window_set<>} : () -> ()

--- a/unittests/Dialect/AXI4/CMakeLists.txt
+++ b/unittests/Dialect/AXI4/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_unittest(CIRCTAXI4Tests
   BurstSetTest.cpp
+  WindowSetTest.cpp
 )
 
 target_link_libraries(CIRCTAXI4Tests

--- a/unittests/Dialect/AXI4/WindowSetTest.cpp
+++ b/unittests/Dialect/AXI4/WindowSetTest.cpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/AXI4/AXI4Attributes.h"
+#include "circt/Dialect/AXI4/AXI4Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace axi4;
+
+namespace {
+
+class WindowSetTest : public testing::Test {
+protected:
+  void SetUp() override { context.loadDialect<AXI4Dialect>(); }
+
+  BurstSetAttr burstSet(ArrayRef<std::pair<BurstKind, uint32_t>> specs) {
+    SmallVector<BurstSpecAttr> attrs;
+    for (auto [kind, len] : specs)
+      attrs.push_back(BurstSpecAttr::get(&context, kind, len));
+    return BurstSetAttr::get(&context, attrs);
+  }
+
+  WindowAttr window(uint64_t base, uint64_t last,
+                    ArrayRef<std::pair<BurstKind, uint32_t>> specs) {
+    return WindowAttr::get(&context, base, last, burstSet(specs));
+  }
+
+  MLIRContext context;
+};
+
+// Ensure that window_sets with the same windows given in a different order are
+// equivalent
+TEST_F(WindowSetTest, ShuffledInputUniquesToSortedInput) {
+  auto low = window(0, 0xFF, {{BurstKind::Fixed, 4}});
+  auto high = window(0x1000, 0x10FF, {{BurstKind::Incr, 8}});
+
+  WindowAttr sorted[] = {low, high};
+  WindowAttr shuffled[] = {high, low};
+
+  auto a = WindowSetAttr::get(&context, sorted);
+  auto b = WindowSetAttr::get(&context, shuffled);
+
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(a.getAsOpaquePointer(), b.getAsOpaquePointer());
+  EXPECT_EQ(a.getWindows().size(), 2u);
+}
+
+// Ensure that different spellings of the same capability map are equivalent
+TEST_F(WindowSetTest, OverlappingAndDisjointSpellingsAreEquivalent) {
+  WindowAttr overlapping[] = {window(0, 0xFFF, {{BurstKind::Fixed, 4}}),
+                              window(0, 0xFF, {{BurstKind::Incr, 8}})};
+  WindowAttr disjoint[] = {
+      window(0, 0xFF, {{BurstKind::Fixed, 4}, {BurstKind::Incr, 8}}),
+      window(0x100, 0xFFF, {{BurstKind::Fixed, 4}})};
+
+  auto a = WindowSetAttr::get(&context, overlapping);
+  auto b = WindowSetAttr::get(&context, disjoint);
+
+  EXPECT_EQ(a, b);
+  ASSERT_EQ(a.getWindows().size(), 2u);
+  EXPECT_EQ(a.getWindows()[0], disjoint[0]);
+  EXPECT_EQ(a.getWindows()[1], disjoint[1]);
+}
+
+// Ensure that window_sets covering the whole address space are equivalent
+// wherever they happen to be split
+TEST_F(WindowSetTest, WholeAddressSpaceSplitsAreEquivalent) {
+  WindowAttr splitHigh[] = {
+      window(0, UINT64_MAX - 1, {{BurstKind::Fixed, 4}}),
+      window(UINT64_MAX, UINT64_MAX, {{BurstKind::Fixed, 4}})};
+  WindowAttr splitMiddle[] = {
+      window(0, 0x7FFFFFFFFFFFFFFF, {{BurstKind::Fixed, 4}}),
+      window(0x8000000000000000, UINT64_MAX, {{BurstKind::Fixed, 4}})};
+
+  auto a = WindowSetAttr::get(&context, splitHigh);
+  auto b = WindowSetAttr::get(&context, splitMiddle);
+
+  EXPECT_EQ(a, b);
+  ASSERT_EQ(a.getWindows().size(), 1u);
+  EXPECT_EQ(a.getWindows()[0], window(0, UINT64_MAX, {{BurstKind::Fixed, 4}}));
+}
+
+} // namespace


### PR DESCRIPTION
Creates an attribute to describe sets of access windows - as in #10955, this type's get method has implicit canonicalization and deduplication to ensure that functionally equivalent types are also structurally equivalent

AI-assisted-by: Claude Opus 5 (1M context)



<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>