### PR TITLE
[AXI4] Add port type

### DIFF
--- a/docs/Dialects/AXI4.md
+++ b/docs/Dialects/AXI4.md
@@ -22,6 +22,10 @@ This dialect is designed to target three primary use-cases:
 
 [include "Dialects/AXI4Enums.md"]
 
+## Types
+
+[include "Dialects/AXI4Types.md"]
+
 ## Operations
 
 [include "Dialects/AXI4Ops.md"]

--- a/include/circt/Dialect/AXI4/AXI4.td
+++ b/include/circt/Dialect/AXI4/AXI4.td
@@ -17,6 +17,7 @@ include "mlir/IR/OpBase.td"
 
 include "circt/Dialect/AXI4/AXI4Dialect.td"
 include "circt/Dialect/AXI4/AXI4Attributes.td"
+include "circt/Dialect/AXI4/AXI4Types.td"
 include "circt/Dialect/AXI4/AXI4Ops.td"
 
 #endif // CIRCT_DIALECT_AXI4_AXI4_TD

--- a/include/circt/Dialect/AXI4/AXI4Dialect.td
+++ b/include/circt/Dialect/AXI4/AXI4Dialect.td
@@ -27,9 +27,11 @@ def AXI4Dialect : Dialect {
   let cppNamespace = "::circt::axi4";
 
   let useDefaultAttributePrinterParser = 1;
+  let useDefaultTypePrinterParser = 1;
 
   let extraClassDeclaration = [{
     void registerAttributes();
+    void registerTypes();
   }];
 }
 

--- a/include/circt/Dialect/AXI4/AXI4Types.h
+++ b/include/circt/Dialect/AXI4/AXI4Types.h
@@ -6,19 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef CIRCT_DIALECT_AXI4_AXI4TYPES_H
+#define CIRCT_DIALECT_AXI4_AXI4TYPES_H
+
+#include "circt/Dialect/AXI4/AXI4Attributes.h"
 #include "circt/Dialect/AXI4/AXI4Dialect.h"
-#include "circt/Dialect/AXI4/AXI4Ops.h"
+#include "mlir/IR/Types.h"
 
-using namespace circt;
-using namespace axi4;
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/AXI4/AXI4Types.h.inc"
 
-void AXI4Dialect::initialize() {
-  registerAttributes();
-  registerTypes();
-  addOperations<
-#define GET_OP_LIST
-#include "circt/Dialect/AXI4/AXI4.cpp.inc"
-      >();
-}
-
-#include "circt/Dialect/AXI4/AXI4Dialect.cpp.inc"
+#endif // CIRCT_DIALECT_AXI4_AXI4TYPES_H

--- a/include/circt/Dialect/AXI4/AXI4Types.td
+++ b/include/circt/Dialect/AXI4/AXI4Types.td
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the types for the AXI4 dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_AXI4_AXI4TYPES_TD
+#define CIRCT_DIALECT_AXI4_AXI4TYPES_TD
+
+include "circt/Dialect/AXI4/AXI4Dialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class AXI4TypeDef<string name, list<Trait> traits = []> :
+    TypeDef<AXI4Dialect, name, traits>;
+
+def PortType : AXI4TypeDef<"Port"> {
+  let mnemonic = "port";
+  let summary = "an AXI4 port interface";
+  let description = [{
+    The primary interface passed between endpoints and interconnect primitives.
+    Carries the address, data, write/read ID and user widths, the access windows
+    the port supports, and the maximum outstanding writes and reads, e.g.
+    `!axi4.port<addr_width = 32, data_width = 64, write_id_width = 4,
+    read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff,
+    burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4,
+    outstanding_reads = 4>`.
+
+    The fields may be given in any order. AXI4 permits address widths up to 64
+    bits, data widths that are a power of two between 8 and 1024, and ID widths
+    up to 32 bits. The outstanding request counts must not exceed the number of
+    distinct IDs available.
+  }];
+
+  let parameters = (ins "uint32_t":$addr_width,
+                        "uint32_t":$data_width,
+                        "uint32_t":$write_id_width,
+                        "uint32_t":$read_id_width,
+                        "uint32_t":$user_width,
+                        "::circt::axi4::WindowSetAttr":$windows,
+                        "uint32_t":$outstanding_writes,
+                        "uint32_t":$outstanding_reads);
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let genVerifyDecl = 1;
+}
+
+#endif // CIRCT_DIALECT_AXI4_AXI4TYPES_TD

--- a/include/circt/Dialect/AXI4/CMakeLists.txt
+++ b/include/circt/Dialect/AXI4/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect(AXI4 axi4)
 add_circt_doc(AXI4Ops Dialects/AXI4Ops -gen-op-doc -dialect axi4)
 add_circt_doc(AXI4Attributes Dialects/AXI4Attributes -gen-attrdef-doc -dialect axi4)
+add_circt_doc(AXI4Types Dialects/AXI4Types -gen-typedef-doc -dialect axi4)
 add_circt_doc(AXI4 Dialects/AXI4Enums -gen-enum-doc -dialect axi4)
 
 set(LLVM_TARGET_DEFINITIONS AXI4.td)

--- a/lib/Dialect/AXI4/AXI4Types.cpp
+++ b/lib/Dialect/AXI4/AXI4Types.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/AXI4/AXI4Types.h"
+#include "circt/Dialect/AXI4/AXI4Dialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/MathExtras.h"
+
+using namespace circt;
+using namespace axi4;
+using namespace mlir;
+
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/AXI4/AXI4Types.cpp.inc"
+
+LogicalResult PortType::verify(function_ref<InFlightDiagnostic()> emitError,
+                               uint32_t addr_width, uint32_t data_width,
+                               uint32_t write_id_width, uint32_t read_id_width,
+                               uint32_t user_width, WindowSetAttr windows,
+                               uint32_t outstanding_writes,
+                               uint32_t outstanding_reads) {
+  if (addr_width > 64)
+    return emitError() << "port 'addr_width' must be at most 64, got "
+                       << addr_width;
+  if (data_width < 8 || data_width > 1024 || !llvm::isPowerOf2_32(data_width))
+    return emitError() << "port 'data_width' must be a power of two between 8 "
+                          "and 1024, got "
+                       << data_width;
+  if (write_id_width > 32)
+    return emitError() << "port 'write_id_width' must be at most 32, got "
+                       << write_id_width;
+  if (read_id_width > 32)
+    return emitError() << "port 'read_id_width' must be at most 32, got "
+                       << read_id_width;
+  // Bounds computed in 64 bits to avoid 32-bit overflow if ID widths are 32.
+  if (outstanding_writes > (uint64_t{1} << write_id_width))
+    return emitError() << "port 'outstanding_writes' must be at most "
+                       << (uint64_t{1} << write_id_width)
+                       << " for a 'write_id_width' of " << write_id_width
+                       << ", got " << outstanding_writes;
+  if (outstanding_reads > (uint64_t{1} << read_id_width))
+    return emitError() << "port 'outstanding_reads' must be at most "
+                       << (uint64_t{1} << read_id_width)
+                       << " for a 'read_id_width' of " << read_id_width
+                       << ", got " << outstanding_reads;
+  return success();
+}
+
+void AXI4Dialect::registerTypes() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "circt/Dialect/AXI4/AXI4Types.cpp.inc"
+      >();
+}

--- a/lib/Dialect/AXI4/CMakeLists.txt
+++ b/lib/Dialect/AXI4/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTAXI4
   AXI4Attributes.cpp
   AXI4Dialect.cpp
   AXI4Ops.cpp
+  AXI4Types.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/AXI4

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -62,3 +62,18 @@
 // Check windows covering the whole address space are merged
 // CHECK: #axi4.window_set<<base = 0x0, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>>
 "test.attrs"() {a = #axi4.window_set<<base = 0x0, last = 0x7fffffffffffffff, burst_specs = <<fixed, len = 4>>>, <base = 0x8000000000000000, last = 0xffffffffffffffff, burst_specs = <<fixed, len = 4>>>>} : () -> ()
+
+//===----------------------------------------------------------------------===//
+// Types
+//===----------------------------------------------------------------------===//
+
+// CHECK: !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+"test.port"() : () -> !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// Check with widest widths (and make sure ID width check doesn't overflow)
+// CHECK: !axi4.port<addr_width = 64, data_width = 1024, write_id_width = 32, read_id_width = 32, user_width = 8, windows = <<base = 0x0, last = 0xffffffffffffffff, burst_specs = <<incr, len = 256>>>>, outstanding_writes = 4294967295, outstanding_reads = 4294967295>
+"test.port"() : () -> !axi4.port<addr_width = 64, data_width = 1024, write_id_width = 32, read_id_width = 32, user_width = 8, windows = <<base = 0x0, last = 0xffffffffffffffff, burst_specs = <<incr, len = 256>>>>, outstanding_writes = 4294967295, outstanding_reads = 4294967295>
+
+// Check fields may be given in any order, and are printed in a canonical one
+// CHECK: !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+"test.port"() : () -> !axi4.port<outstanding_reads = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, data_width = 64, user_width = 0, addr_width = 32, outstanding_writes = 4, read_id_width = 4, write_id_width = 4>

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -52,3 +52,43 @@
 
 // expected-error @below {{'window_set' must be non-empty}}
 "test.attrs"() {a = #axi4.window_set<>} : () -> ()
+
+// -----
+
+// expected-error @below {{port 'addr_width' must be at most 64, got 65}}
+"test.port"() : () -> !axi4.port<addr_width = 65, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// -----
+
+// expected-error @below {{port 'data_width' must be a power of two between 8 and 1024, got 24}}
+"test.port"() : () -> !axi4.port<addr_width = 32, data_width = 24, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// -----
+
+// expected-error @below {{port 'data_width' must be a power of two between 8 and 1024, got 4}}
+"test.port"() : () -> !axi4.port<addr_width = 32, data_width = 4, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// -----
+
+// expected-error @below {{port 'data_width' must be a power of two between 8 and 1024, got 2048}}
+"test.port"() : () -> !axi4.port<addr_width = 32, data_width = 2048, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// -----
+
+// expected-error @below {{port 'write_id_width' must be at most 32, got 33}}
+"test.port"() : () -> !axi4.port<addr_width = 32, data_width = 64, write_id_width = 33, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// -----
+
+// expected-error @below {{port 'read_id_width' must be at most 32, got 33}}
+"test.port"() : () -> !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 33, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// -----
+
+// expected-error @below {{port 'outstanding_writes' must be at most 4 for a 'write_id_width' of 2, got 5}}
+"test.port"() : () -> !axi4.port<addr_width = 32, data_width = 64, write_id_width = 2, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 5, outstanding_reads = 4>
+
+// -----
+
+// expected-error @below {{port 'outstanding_reads' must be at most 4 for a 'read_id_width' of 2, got 5}}
+"test.port"() : () -> !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 2, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 5>


### PR DESCRIPTION
Adds a big bulky and beautiful type for representing AXI ports - includes widths, access capabilities, and bandwidth coming down the port.

AI-assisted-by: Claude Opus 5 (1M context)

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>