### PR TITLE
[Seq] Escape inner symbol names when printing

### DIFF
--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -356,7 +356,7 @@ void InnerSymAttr::print(AsmPrinter &odsPrinter) const {
   auto props = getProps();
   if (props.size() == 1 && props[0].getSymVisibility().getValue() == "public" &&
       props[0].getFieldID() == 0) {
-    odsPrinter << "@" << props[0].getName().getValue();
+    odsPrinter.printSymbolName(props[0].getName().getValue());
     return;
   }
   auto names = props.vec();

--- a/test/Dialect/Seq/round-trip-inner-sym.mlir
+++ b/test/Dialect/Seq/round-trip-inner-sym.mlir
@@ -1,25 +1,25 @@
 // RUN: circt-opt --verify-roundtrip %s | FileCheck %s
 
 hw.module @Foo(in %a: i42, in %clk: !seq.clock) {
-  // CHECK: seq.compreg sym @"foo/bar" %a, %clk : i42
+  // CHECK: seq.compreg sym @"foo/bar"
   %0 = seq.compreg sym @"foo/bar" %a, %clk : i42
   hw.output
 }
 
 hw.module @Bar(in %d: i32, in %clk: !seq.clock, in %en: i1) {
-  // CHECK: seq.compreg.ce sym @"weird name" %d, %clk, %en : i32
+  // CHECK: seq.compreg.ce sym @"weird name"
   %1 = seq.compreg.ce sym @"weird name" %d, %clk, %en : i32
   hw.output
 }
 
 hw.module @ShiftReg(in %a: i42, in %clk: !seq.clock, in %en: i1) {
-  // CHECK: seq.shiftreg[2] sym @"shift/reg" %a, %clk, %en : i42
+  // CHECK: seq.shiftreg[2] sym @"shift/reg"
   %2 = seq.shiftreg[2] sym @"shift/reg" %a, %clk, %en : i42
   hw.output
 }
 
 hw.module @ClockGate(in %clk: !seq.clock, in %en: i1) {
-  // CHECK: seq.clock_gate %clk, %en sym @"gate name"
+  // CHECK: seq.clock_gate {{%.+}}, {{%.+}} sym @"gate name"
   %3 = seq.clock_gate %clk, %en sym @"gate name"
   hw.output
 }

--- a/test/Dialect/Seq/round-trip-inner-sym.mlir
+++ b/test/Dialect/Seq/round-trip-inner-sym.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt --verify-roundtrip %s | FileCheck %s
+
+hw.module @Foo(in %a: i42, in %clk: !seq.clock) {
+  // CHECK: seq.compreg sym @"foo/bar" %a, %clk : i42
+  %0 = seq.compreg sym @"foo/bar" %a, %clk : i42
+  hw.output
+}
+
+hw.module @Bar(in %d: i32, in %clk: !seq.clock, in %en: i1) {
+  // CHECK: seq.compreg.ce sym @"weird name" %d, %clk, %en : i32
+  %1 = seq.compreg.ce sym @"weird name" %d, %clk, %en : i32
+  hw.output
+}
+
+hw.module @ShiftReg(in %a: i42, in %clk: !seq.clock, in %en: i1) {
+  // CHECK: seq.shiftreg[2] sym @"shift/reg" %a, %clk, %en : i42
+  %2 = seq.shiftreg[2] sym @"shift/reg" %a, %clk, %en : i42
+  hw.output
+}
+
+hw.module @ClockGate(in %clk: !seq.clock, in %en: i1) {
+  // CHECK: seq.clock_gate %clk, %en sym @"gate name"
+  %3 = seq.clock_gate %clk, %en sym @"gate name"
+  hw.output
+}


### PR DESCRIPTION
This PR aims to fix round-tripping inner symbol names with special characters by using the printer's existing symbol name functionality. Also introduces tests for the failure cases mentioned in #8833 and a couple others with different operations that can have inner symbols.

Based on the approach of #9049 and resolves #8833.

(Also, I'm new to contributing, is the [Seq] at the start of this PR title correct?)