### PR TITLE
[ESI][Runtime] Fix read gearboxes for lists

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -56,7 +56,10 @@ static void dmaTest(AcceleratorConnection *, Accelerator *,
                     const std::vector<uint32_t> &widths, bool read, bool write);
 static void bandwidthTest(AcceleratorConnection *, Accelerator *,
                           const std::vector<uint32_t> &widths,
-                          uint32_t xferCount, bool read, bool write);
+                          uint32_t xferCount, bool read, bool write,
+                          bool checkData);
+static uint8_t esitesterDataByte(uint32_t index, size_t byte);
+static uint8_t enginePatternByte(uint32_t index, size_t byte, size_t bitWidth);
 static void loopbackAddTest(AcceleratorConnection *, Accelerator *,
                             uint32_t iterations, bool pipeline);
 static void aggregateHostmemBandwidthTest(AcceleratorConnection *,
@@ -81,7 +84,8 @@ static void channelTest(AcceleratorConnection *, Accelerator *,
 static void resetTest(AcceleratorConnection *, Accelerator *);
 
 // Default widths and default widths string for CLI help text.
-constexpr std::array<uint32_t, 5> defaultWidths = {32, 64, 128, 256, 512};
+constexpr std::array<uint32_t, 8> defaultWidths = {24,  32,  64,  72,
+                                                   128, 256, 512, 534};
 static std::string defaultWidthsStr() {
   std::string s;
   for (size_t i = 0; i < defaultWidths.size(); ++i) {
@@ -214,6 +218,7 @@ int main(int argc, const char *argv[]) {
                            "Number of transfers to perform");
   bool bandwidthRead = false;
   bool bandwidthWrite = false;
+  bool bandwidthCheckData = false;
   std::vector<uint32_t> bandwidthWidths(defaultWidths.begin(),
                                         defaultWidths.end());
   bandwidthSub->add_option("--widths", bandwidthWidths,
@@ -222,6 +227,8 @@ int main(int argc, const char *argv[]) {
   bandwidthSub->add_flag("-w,--write", bandwidthWrite,
                          "Enable bandwidth write");
   bandwidthSub->add_flag("-r,--read", bandwidthRead, "Enable bandwidth read");
+  bandwidthSub->add_flag("--check-data", bandwidthCheckData,
+                         "Verify every transferred payload byte");
 
   CLI::App *hostmembwSub =
       cli.add_subcommand("hostmembw", "Run the host memory bandwidth test");
@@ -352,7 +359,7 @@ int main(int argc, const char *argv[]) {
       dmaTest(acc, accel, dmaWidths, dmaRead, dmaWrite);
     } else if (*bandwidthSub) {
       bandwidthTest(acc, accel, bandwidthWidths, xferCount, bandwidthRead,
-                    bandwidthWrite);
+                    bandwidthWrite, bandwidthCheckData);
     } else if (*hostmembwSub) {
       hostmemBandwidthTest(acc, accel, hmBwCount, hmBwWidths, hmBwRead,
                            hmBwWrite);
@@ -699,19 +706,27 @@ static void dmaReadTest(AcceleratorConnection *conn, Accelerator *acc,
   outPort.connect();
 
   size_t xferCount = 24;
-  uint64_t last = 0;
   MessageData data;
   toHostMMIO->write(0, xferCount);
-  for (size_t i = 0; i < xferCount; ++i) {
+  const size_t wireBytes = (width + 7) / 8;
+  for (size_t index = 0; index < xferCount; ++index) {
     outPort.read(data);
-    if (width == 64) {
-      uint64_t val = *data.as<uint64_t>();
-      if (val < last)
-        throw std::runtime_error("dma read test failed. Out of order data");
-      last = val;
+    if (data.getSize() != wireBytes)
+      throw std::runtime_error("dma read test failed. Expected " +
+                               std::to_string(wireBytes) + " bytes, got " +
+                               std::to_string(data.getSize()));
+    for (size_t byte = 0; byte < wireBytes; ++byte) {
+      uint8_t expected =
+          enginePatternByte(static_cast<uint32_t>(index), byte, width);
+      if (data.getBytes()[byte] != expected)
+        throw std::runtime_error(
+            "dma read test failed. Data mismatch at item " +
+            std::to_string(index) + " byte " + std::to_string(byte) +
+            ": expected " + toHex(expected) + ", got " +
+            toHex(data.getBytes()[byte]));
     }
     logger.debug("esitester",
-                 "Cycle count [" + std::to_string(i) + "] = 0x" + data.toHex());
+                 "Payload [" + std::to_string(index) + "] = 0x" + data.toHex());
   }
   outPort.disconnect();
   std::cout << "  DMA read test for " << width << " bits passed" << std::endl;
@@ -743,9 +758,7 @@ static void dmaWriteTest(AcceleratorConnection *conn, Accelerator *acc,
   writePort.connect();
 
   size_t xferCount = 24;
-  uint8_t *data = new uint8_t[width];
-  for (size_t i = 0; i < width / 8; ++i)
-    data[i] = 0;
+  std::vector<uint8_t> data((width + 7) / 8, 0);
   fromHostMMIO->read(8);
   fromHostMMIO->write(0, xferCount);
   for (size_t i = 1; i < xferCount + 1; ++i) {
@@ -753,7 +766,7 @@ static void dmaWriteTest(AcceleratorConnection *conn, Accelerator *acc,
     bool successWrite;
     size_t attempts = 0;
     do {
-      successWrite = writePort.tryWrite(MessageData(data, width / 8));
+      successWrite = writePort.tryWrite(MessageData(data.data(), data.size()));
       if (!successWrite) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       }
@@ -773,7 +786,6 @@ static void dmaWriteTest(AcceleratorConnection *conn, Accelerator *acc,
     }
   }
   writePort.disconnect();
-  delete[] data;
   std::cout << "  DMA write test for " << width << " bits passed" << std::endl;
 }
 
@@ -800,10 +812,44 @@ static void dmaTest(AcceleratorConnection *conn, Accelerator *acc,
 
 //
 // DMA bandwidth test
-//
+
+static size_t engineWireBytes(size_t bitWidth) { return (bitWidth + 7) / 8; }
+
+static uint8_t enginePatternByte(uint32_t index, size_t byte, size_t bitWidth) {
+  uint8_t value = esitesterDataByte(index, byte);
+  const size_t tailBits = bitWidth % 8;
+  if (tailBits != 0 && byte + 1 == engineWireBytes(bitWidth))
+    value &= (uint8_t(1) << tailBits) - 1;
+  return value;
+}
+
+static std::vector<uint8_t> enginePatternBytes(uint32_t index,
+                                               size_t bitWidth) {
+  std::vector<uint8_t> bytes(engineWireBytes(bitWidth));
+  for (size_t byte = 0; byte < bytes.size(); ++byte)
+    bytes[byte] = enginePatternByte(index, byte, bitWidth);
+  return bytes;
+}
+
+static uint64_t enginePayloadFold(uint32_t index, size_t bitWidth) {
+  const size_t numChunks = (bitWidth + 63) / 64;
+  uint64_t fold = 0;
+  for (size_t chunkIndex = 0; chunkIndex < numChunks; ++chunkIndex) {
+    uint64_t chunk = 0;
+    for (size_t byteInChunk = 0; byteInChunk < 8; ++byteInChunk) {
+      const size_t byteIndex = chunkIndex * 8 + byteInChunk;
+      if (byteIndex < engineWireBytes(bitWidth))
+        chunk |= uint64_t(enginePatternByte(index, byteIndex, bitWidth))
+                 << (8 * byteInChunk);
+    }
+    const unsigned rotate = (8 * chunkIndex) % 64;
+    fold ^= rotate ? ((chunk << rotate) | (chunk >> (64 - rotate))) : chunk;
+  }
+  return fold;
+}
 
 static void bandwidthReadTest(AcceleratorConnection *conn, Accelerator *acc,
-                              size_t width, size_t xferCount) {
+                              size_t width, size_t xferCount, bool checkData) {
 
   AppIDPath lastPath;
   BundlePort *toHostMMIOPort =
@@ -825,19 +871,57 @@ static void bandwidthReadTest(AcceleratorConnection *conn, Accelerator *acc,
                                std::to_string(xferCount) + " x " +
                                std::to_string(width) + " bit transfers");
   MessageData data;
+  size_t sizeMismatches = 0;
+  size_t dataMismatches = 0;
+  size_t firstMismatchItem = 0;
+  size_t firstMismatchByte = 0;
+  uint8_t firstExpected = 0;
+  uint8_t firstActual = 0;
   auto start = std::chrono::high_resolution_clock::now();
   toHostMMIO->write(0, xferCount);
-  for (size_t i = 0; i < xferCount; ++i) {
+  for (size_t index = 0; index < xferCount; ++index) {
     outPort.read(data);
+    if (checkData) {
+      const size_t wireBytes = engineWireBytes(width);
+      if (data.getSize() != wireBytes) {
+        ++sizeMismatches;
+      } else {
+        for (size_t byte = 0; byte < wireBytes; ++byte) {
+          const uint8_t expected =
+              enginePatternByte(static_cast<uint32_t>(index), byte, width);
+          if (data.getBytes()[byte] != expected) {
+            if (dataMismatches == 0) {
+              firstMismatchItem = index;
+              firstMismatchByte = byte;
+              firstExpected = expected;
+              firstActual = data.getBytes()[byte];
+            }
+            ++dataMismatches;
+          }
+        }
+      }
+    }
     logger.debug(
-        [i, &data](std::string &subsystem, std::string &msg,
-                   std::unique_ptr<std::map<std::string, std::any>> &details) {
+        [index,
+         &data](std::string &subsystem, std::string &msg,
+                std::unique_ptr<std::map<std::string, std::any>> &details) {
           subsystem = "esitester";
-          msg = "Cycle count [" + std::to_string(i) + "] = 0x" + data.toHex();
+          msg = "Payload [" + std::to_string(index) + "] = 0x" + data.toHex();
         });
   }
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::high_resolution_clock::now() - start);
+  outPort.disconnect();
+  if (checkData && sizeMismatches != 0)
+    throw std::runtime_error(
+        "bandwidth read data mismatch: " + std::to_string(sizeMismatches) +
+        " payload(s) had the wrong wire size");
+  if (checkData && dataMismatches != 0)
+    throw std::runtime_error(
+        "bandwidth read data mismatch: " + std::to_string(dataMismatches) +
+        " bytes wrong; first at item " + std::to_string(firstMismatchItem) +
+        " byte " + std::to_string(firstMismatchByte) + ": expected " +
+        toHex(firstExpected) + ", got " + toHex(firstActual));
   double bytesPerSec =
       (double)xferCount * (width / 8.0) * 1e6 / (double)duration.count();
   logger.info("esitester",
@@ -845,10 +929,12 @@ static void bandwidthReadTest(AcceleratorConnection *conn, Accelerator *acc,
                   std::to_string(width) + " bit transfers in " +
                   std::to_string(duration.count()) + " microseconds");
   logger.info("esitester", "    bandwidth: " + formatBandwidth(bytesPerSec));
+  if (checkData)
+    logger.info("esitester", "    data integrity: passed");
 }
 
 static void bandwidthWriteTest(AcceleratorConnection *conn, Accelerator *acc,
-                               size_t width, size_t xferCount) {
+                               size_t width, size_t xferCount, bool checkData) {
 
   AppIDPath lastPath;
   BundlePort *fromHostMMIOPort =
@@ -859,6 +945,24 @@ static void bandwidthWriteTest(AcceleratorConnection *conn, Accelerator *acc,
   auto *fromHostMMIO = fromHostMMIOPort->getAs<services::MMIO::MMIORegion>();
   if (!fromHostMMIO)
     throw std::runtime_error("bandwidth test failed. MMIO port is not MMIO");
+  services::TelemetryService::Metric *checksumPort = nullptr;
+  if (checkData) {
+    auto fromHostChild = acc->getChildren().find(AppID("fromhostdma", width));
+    if (fromHostChild == acc->getChildren().end())
+      throw std::runtime_error("bandwidth test failed. No fromhostdma[" +
+                               std::to_string(width) + "] found");
+    auto checksumIter =
+        fromHostChild->second->getPorts().find(AppID("fromHostChecksum"));
+    if (checksumIter == fromHostChild->second->getPorts().end())
+      throw std::runtime_error(
+          "bandwidth write data check failed. fromHostChecksum missing");
+    checksumPort =
+        checksumIter->second.getAs<services::TelemetryService::Metric>();
+    if (!checksumPort)
+      throw std::runtime_error("bandwidth write data check failed. "
+                               "fromHostChecksum not telemetry");
+    checksumPort->connect();
+  }
   lastPath.clear();
   BundlePort *inPortBundle =
       acc->resolvePort({AppID("fromhostdma", width), AppID("in")}, lastPath);
@@ -869,23 +973,64 @@ static void bandwidthWriteTest(AcceleratorConnection *conn, Accelerator *acc,
   logger.info("esitester", "Starting write bandwidth test with " +
                                std::to_string(xferCount) + " x " +
                                std::to_string(width) + " bit transfers");
-  std::vector<uint8_t> dataVec(width / 8);
-  for (size_t i = 0; i < width / 8; ++i)
+  std::vector<uint8_t> dataVec(engineWireBytes(width));
+  for (size_t i = 0; i < dataVec.size(); ++i)
     dataVec[i] = i;
   MessageData data(dataVec);
+  uint64_t expectedChecksum = 0;
   auto start = std::chrono::high_resolution_clock::now();
+  fromHostMMIO->read(8);
   fromHostMMIO->write(0, xferCount);
-  for (size_t i = 0; i < xferCount; ++i) {
+  for (size_t index = 0; index < xferCount; ++index) {
+    if (checkData) {
+      data =
+          MessageData(enginePatternBytes(static_cast<uint32_t>(index), width));
+      expectedChecksum ^=
+          enginePayloadFold(static_cast<uint32_t>(index), width);
+    }
     outPort.write(data);
     logger.debug(
-        [i, &data](std::string &subsystem, std::string &msg,
-                   std::unique_ptr<std::map<std::string, std::any>> &details) {
+        [index,
+         &data](std::string &subsystem, std::string &msg,
+                std::unique_ptr<std::map<std::string, std::any>> &details) {
           subsystem = "esitester";
-          msg = "Cycle count [" + std::to_string(i) + "] = 0x" + data.toHex();
+          msg = "Payload [" + std::to_string(index) + "] = 0x" + data.toHex();
         });
   }
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::high_resolution_clock::now() - start);
+  if (checkData) {
+    std::vector<uint8_t> expectedLast;
+    if (xferCount != 0)
+      expectedLast =
+          enginePatternBytes(static_cast<uint32_t>(xferCount - 1), width);
+    uint64_t expectedLastValue = 0;
+    if (!expectedLast.empty())
+      std::memcpy(&expectedLastValue, expectedLast.data(),
+                  std::min(expectedLast.size(), sizeof(expectedLastValue)));
+    bool complete = xferCount == 0;
+    uint64_t lastReadValue = 0;
+    for (size_t attempt = 0; !complete && attempt < 5000; ++attempt) {
+      lastReadValue = fromHostMMIO->read(8);
+      if (lastReadValue == expectedLastValue) {
+        complete = true;
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (!complete)
+      throw std::runtime_error(
+          "bandwidth write data check timed out waiting for completion: "
+          "expected final payload " +
+          toHex(expectedLastValue) + ", got " + toHex(lastReadValue));
+    const uint64_t actualChecksum = checksumPort->readInt();
+    if (actualChecksum != expectedChecksum)
+      throw std::runtime_error(
+          "bandwidth write data mismatch: checksum expected " +
+          toHex(expectedChecksum) + ", got " + toHex(actualChecksum));
+  }
+  if (checkData)
+    outPort.disconnect();
   double bytesPerSec =
       (double)xferCount * (width / 8.0) * 1e6 / (double)duration.count();
   logger.info("esitester",
@@ -893,17 +1038,53 @@ static void bandwidthWriteTest(AcceleratorConnection *conn, Accelerator *acc,
                   std::to_string(width) + " bit transfers in " +
                   std::to_string(duration.count()) + " microseconds");
   logger.info("esitester", "    bandwidth: " + formatBandwidth(bytesPerSec));
+  if (checkData)
+    logger.info("esitester", "    data integrity: passed");
 }
 
 static void bandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
                           const std::vector<uint32_t> &widths,
-                          uint32_t xferCount, bool read, bool write) {
+                          uint32_t xferCount, bool read, bool write,
+                          bool checkData) {
   if (read)
     for (uint32_t w : widths)
-      bandwidthReadTest(conn, acc, w, xferCount);
+      bandwidthReadTest(conn, acc, w, xferCount, checkData);
   if (write)
     for (uint32_t w : widths)
-      bandwidthWriteTest(conn, acc, w, xferCount);
+      bandwidthWriteTest(conn, acc, w, xferCount, checkData);
+}
+
+// Fixed 64-bit seed for the hostmem burst data pattern; must match
+// _ESITESTER_SEQ_SEED in esiaccel/esitester.py.
+static constexpr uint64_t kEsitesterSeqSeed = 0x5A5A5A5A5A5A5A5AULL;
+
+// Byte j of element i in the hostmem burst data pattern: tile (seed ^ i)
+// across the element's bytes and XOR each byte with a distinct per-position
+// mask so every byte is unique. Must match WriteMem/ReadMem in
+// esiaccel/esitester.py.
+static inline uint8_t esitesterDataByte(uint32_t i, size_t j) {
+  uint64_t seq = (uint64_t)i ^ kEsitesterSeqSeed;
+  return (uint8_t)(seq >> (8 * (j % 8))) ^ (uint8_t)(j * 0x9D);
+}
+
+// Fold element i's `width` bits into its 64-bit readChecksum contribution:
+// XOR each 64-bit chunk with a per-chunk rotate so word/byte misplacement
+// doesn't cancel. Must match ReadMem's readChecksum in esiaccel/esitester.py.
+static inline uint64_t esitesterElemFold(uint32_t i, uint32_t width) {
+  size_t numBytes = width / 8;
+  size_t numChunks = (width + 63) / 64;
+  uint64_t fold = 0;
+  for (size_t c = 0; c < numChunks; ++c) {
+    uint64_t chunk = 0;
+    for (size_t b = 0; b < 8; ++b) {
+      size_t j = 8 * c + b;
+      if (j < numBytes)
+        chunk |= (uint64_t)esitesterDataByte(i, j) << (8 * b);
+    }
+    unsigned r = (8 * c) % 64;
+    fold ^= r ? ((chunk << r) | (chunk >> (64 - r))) : chunk;
+  }
+  return fold;
 }
 
 //
@@ -996,6 +1177,42 @@ hostmemWriteBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
             << std::to_string(duration.count()) << " us, "
             << std::to_string(cycles) << " cycles, " << bytesPerCycle
             << " bytes/cycle" << std::endl;
+
+  // Data integrity: WriteMem wrote the byte-level pattern (esitesterDataByte)
+  // into element i. The host-memory layout must be contiguous and backend-
+  // width-independent, so element i occupies width/8 bytes at that stride;
+  // verify every byte.
+  uint8_t *bytePtr = static_cast<uint8_t *>(region.getPtr());
+  size_t elemBytes = width / 8;
+  size_t mismatches = 0;
+  uint32_t firstMismatch = 0;
+  size_t firstByte = 0;
+  uint8_t firstExpected = 0, firstActual = 0;
+  for (uint32_t i = 0; i < xferCount; ++i) {
+    for (size_t j = 0; j < elemBytes; ++j) {
+      uint8_t expected = esitesterDataByte(i, j);
+      uint8_t actual = bytePtr[(size_t)i * elemBytes + j];
+      if (actual != expected) {
+        if (mismatches == 0) {
+          firstMismatch = i;
+          firstByte = j;
+          firstExpected = expected;
+          firstActual = actual;
+        }
+        ++mismatches;
+      }
+    }
+  }
+  if (mismatches != 0) {
+    char eb[8], gb[8];
+    std::snprintf(eb, sizeof(eb), "0x%02x", firstExpected);
+    std::snprintf(gb, sizeof(gb), "0x%02x", firstActual);
+    throw std::runtime_error(
+        "hostmem write bandwidth data mismatch: " + std::to_string(mismatches) +
+        " bytes wrong; first at element " + std::to_string(firstMismatch) +
+        " byte " + std::to_string(firstByte) + " expected=" + eb +
+        " got=" + gb);
+  }
 }
 
 static void
@@ -1029,25 +1246,36 @@ hostmemReadBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
       cyclePath);
   auto issuedIter = readMemPorts.find(AppID("addrCmdIssued"));
   auto respIter = readMemPorts.find(AppID("addrCmdResponses"));
+  auto checksumIter = readMemPorts.find(AppID("readChecksum"));
   if (issuedIter == readMemPorts.end() || respIter == readMemPorts.end() ||
-      !cyclePortBundle)
+      checksumIter == readMemPorts.end() || !cyclePortBundle)
     throw std::runtime_error("hostmem read bandwidth: telemetry missing");
   auto *issuedPort =
       issuedIter->second.getAs<services::TelemetryService::Metric>();
   auto *respPort = respIter->second.getAs<services::TelemetryService::Metric>();
+  auto *checksumPort =
+      checksumIter->second.getAs<services::TelemetryService::Metric>();
   auto *cycleCntPort =
       cyclePortBundle->getAs<services::TelemetryService::Metric>();
-  if (!issuedPort || !respPort || !cycleCntPort)
+  if (!issuedPort || !respPort || !checksumPort || !cycleCntPort)
     throw std::runtime_error("hostmem read bandwidth: telemetry type mismatch");
   issuedPort->connect();
   respPort->connect();
+  checksumPort->connect();
   cycleCntPort->connect();
 
-  // Prepare memory pattern (optional).
-  uint64_t *dataPtr = static_cast<uint64_t *>(region.getPtr());
-  size_t words64 = region.getSize() / 8;
-  for (size_t i = 0; i < words64; ++i)
-    dataPtr[i] = 0xCAFEBABE0000ull + i;
+  // Lay out the read data contiguously (natural width/8-byte stride) using
+  // the byte-level pattern (esitesterDataByte) for every byte; ReadMem folds
+  // each received element into readChecksum, which must match this host-side
+  // fold if the read fetched the right bytes.
+  uint8_t *bytePtr = static_cast<uint8_t *>(region.getPtr());
+  size_t elemBytes = width / 8;
+  uint64_t expectedChecksum = 0;
+  for (uint32_t i = 0; i < xferCount; ++i) {
+    for (size_t j = 0; j < elemBytes; ++j)
+      bytePtr[(size_t)i * elemBytes + j] = esitesterDataByte(i, j);
+    expectedChecksum ^= esitesterElemFold(i, width);
+  }
   region.flush();
   uint64_t devPtr = reinterpret_cast<uint64_t>(region.getDevicePtr());
   auto start = std::chrono::high_resolution_clock::now();
@@ -1077,6 +1305,18 @@ hostmemReadBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
             << "): " << formatBandwidth(bytesPerSec) << ", " << xferCount
             << " flits in " << duration.count() << " us, " << cycles
             << " cycles, " << bytesPerCycle << " bytes/cycle" << std::endl;
+
+  uint64_t gotChecksum = checksumPort->readInt();
+  if (gotChecksum != expectedChecksum) {
+    char eb[24], gb[24];
+    std::snprintf(eb, sizeof(eb), "0x%016llx",
+                  (unsigned long long)expectedChecksum);
+    std::snprintf(gb, sizeof(gb), "0x%016llx", (unsigned long long)gotChecksum);
+    throw std::runtime_error(
+        std::string(
+            "hostmem read bandwidth data mismatch: checksum expected ") +
+        eb + " got " + gb);
+  }
 }
 
 static void hostmemBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
@@ -1212,7 +1452,8 @@ static void resetTest(AcceleratorConnection *conn, Accelerator *accel) {
   // bumps the writemem module's 'addrCmdResponses' counter.
   hostmemTest(conn, accel, {width}, /*write=*/true, /*read=*/false);
 
-  // Grab the writemem module's response telemetry counter to observe the reset.
+  // Grab the writemem module's response telemetry counter to observe the
+  // reset.
   auto writeMemChildIter = accel->getChildren().find(AppID("writemem", width));
   if (writeMemChildIter == accel->getChildren().end())
     throw std::runtime_error("Reset test: no 'writemem' child");
@@ -1671,8 +1912,9 @@ static void streamingAddTranslatedTest(AcceleratorConnection *conn,
   argPort.connect();
   resultPort.connect();
 
-  // Allocate the argument struct with proper alignment for the struct members.
-  // We use aligned_alloc to ensure the buffer meets alignment requirements.
+  // Allocate the argument struct with proper alignment for the struct
+  // members. We use aligned_alloc to ensure the buffer meets alignment
+  // requirements.
   size_t argSize = StreamingAddTranslatedArg::allocSize(numItems);
   constexpr size_t alignment = alignof(StreamingAddTranslatedArg);
   // aligned_alloc requires size to be a multiple of alignment
@@ -1864,7 +2106,8 @@ static void coordTranslateTest(AcceleratorConnection *conn, Accelerator *accel,
         "FuncService::Function");
   funcPort->connect();
 
-  // Allocate the argument struct with proper alignment for the struct members.
+  // Allocate the argument struct with proper alignment for the struct
+  // members.
   size_t argSize = CoordTranslateArg::allocSize(numCoords);
   constexpr size_t alignment = alignof(CoordTranslateArg);
   // aligned_alloc requires size to be a multiple of alignment
@@ -1961,8 +2204,8 @@ static_assert(sizeof(SerialCoordData) == sizeof(SerialCoordHeader),
 #pragma pack(pop)
 
 // Note: this application is intended to test hardware. As such, we need
-// to be able to send batches. So this is not the typical way one would define a
-// message struct. It's closer to a streaming style.
+// to be able to send batches. So this is not the typical way one would define
+// a message struct. It's closer to a streaming style.
 struct SerialCoordInput : SegmentedMessageData {
 private:
   SerialCoordHeader header;
@@ -2150,8 +2393,8 @@ static void serialCoordTranslateTest(AcceleratorConnection *conn,
   auto &ports = child->second->getPorts();
   auto portIter = ports.find(AppID("translate_coords_serial"));
   if (portIter == ports.end())
-    throw std::runtime_error(
-        "Serial coord translate test: no 'translate_coords_serial' port found");
+    throw std::runtime_error("Serial coord translate test: no "
+                             "'translate_coords_serial' port found");
 
   TypedWritePort<SerialCoordBurst, /*SkipTypeCheck=*/true> argPort(
       portIter->second.getRawWrite("arg"));
@@ -2349,9 +2592,9 @@ static void autoSerialCoordTranslateTest(AcceleratorConnection *conn,
     if (burstCount == 0)
       break;
     if (results.size() + burstCount > numCoords)
-      throw std::runtime_error(
-          "Auto serial coord translate test: bursts overflow expected total " +
-          std::to_string(numCoords));
+      throw std::runtime_error("Auto serial coord translate test: bursts "
+                               "overflow expected total " +
+                               std::to_string(numCoords));
     for (uint32_t i = 0; i < burstCount; ++i) {
       SerialCoordOutputFrame frame{};
       readFrame(frame);

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -1067,11 +1067,22 @@ static inline uint8_t esitesterDataByte(uint32_t i, size_t j) {
   return (uint8_t)(seq >> (8 * (j % 8))) ^ (uint8_t)(j * 0x9D);
 }
 
+static size_t hostmemWireBytes(uint32_t width) { return (width + 7) / 8; }
+
+static uint8_t esitesterHostmemByte(uint32_t index, size_t byte,
+                                    uint32_t width) {
+  uint8_t value = esitesterDataByte(index, byte);
+  const size_t tailBits = width % 8;
+  if (tailBits != 0 && byte + 1 == hostmemWireBytes(width))
+    value &= (uint8_t(1) << tailBits) - 1;
+  return value;
+}
+
 // Fold element i's `width` bits into its 64-bit readChecksum contribution:
 // XOR each 64-bit chunk with a per-chunk rotate so word/byte misplacement
 // doesn't cancel. Must match ReadMem's readChecksum in esiaccel/esitester.py.
 static inline uint64_t esitesterElemFold(uint32_t i, uint32_t width) {
-  size_t numBytes = width / 8;
+  size_t numBytes = hostmemWireBytes(width);
   size_t numChunks = (width + 63) / 64;
   uint64_t fold = 0;
   for (size_t c = 0; c < numChunks; ++c) {
@@ -1079,7 +1090,7 @@ static inline uint64_t esitesterElemFold(uint32_t i, uint32_t width) {
     for (size_t b = 0; b < 8; ++b) {
       size_t j = 8 * c + b;
       if (j < numBytes)
-        chunk |= (uint64_t)esitesterDataByte(i, j) << (8 * b);
+        chunk |= (uint64_t)esitesterHostmemByte(i, j, width) << (8 * b);
     }
     unsigned r = (8 * c) % 64;
     fold ^= r ? ((chunk << r) | (chunk >> (64 - r))) : chunk;
@@ -1180,17 +1191,17 @@ hostmemWriteBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
 
   // Data integrity: WriteMem wrote the byte-level pattern (esitesterDataByte)
   // into element i. The host-memory layout must be contiguous and backend-
-  // width-independent, so element i occupies width/8 bytes at that stride;
-  // verify every byte.
+  // width-independent, so element i occupies ceil(width/8) bytes at that
+  // stride; verify every byte.
   uint8_t *bytePtr = static_cast<uint8_t *>(region.getPtr());
-  size_t elemBytes = width / 8;
+  size_t elemBytes = hostmemWireBytes(width);
   size_t mismatches = 0;
   uint32_t firstMismatch = 0;
   size_t firstByte = 0;
   uint8_t firstExpected = 0, firstActual = 0;
   for (uint32_t i = 0; i < xferCount; ++i) {
     for (size_t j = 0; j < elemBytes; ++j) {
-      uint8_t expected = esitesterDataByte(i, j);
+      uint8_t expected = esitesterHostmemByte(i, j, width);
       uint8_t actual = bytePtr[(size_t)i * elemBytes + j];
       if (actual != expected) {
         if (mismatches == 0) {
@@ -1264,16 +1275,16 @@ hostmemReadBandwidthTest(AcceleratorConnection *conn, Accelerator *acc,
   checksumPort->connect();
   cycleCntPort->connect();
 
-  // Lay out the read data contiguously (natural width/8-byte stride) using
-  // the byte-level pattern (esitesterDataByte) for every byte; ReadMem folds
-  // each received element into readChecksum, which must match this host-side
-  // fold if the read fetched the right bytes.
+  // Lay out the read data contiguously (natural ceil(width/8)-byte stride)
+  // using the byte-level pattern for every byte; ReadMem folds each received
+  // element into readChecksum, which must match this host-side fold if the
+  // read fetched the right bytes.
   uint8_t *bytePtr = static_cast<uint8_t *>(region.getPtr());
-  size_t elemBytes = width / 8;
+  size_t elemBytes = hostmemWireBytes(width);
   uint64_t expectedChecksum = 0;
   for (uint32_t i = 0; i < xferCount; ++i) {
     for (size_t j = 0; j < elemBytes; ++j)
-      bytePtr[(size_t)i * elemBytes + j] = esitesterDataByte(i, j);
+      bytePtr[(size_t)i * elemBytes + j] = esitesterHostmemByte(i, j, width);
     expectedChecksum ^= esitesterElemFold(i, width);
   }
   region.flush();

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -442,7 +442,7 @@ class ChannelMMIO(esi.ServiceImplementation):
     - 0x12: ESI version number (0)
     - 0x18: Location of the manifest ROM (absolute address)
 
-    - 0x400: Start of MMIO space for requests. Mapping is contained in the
+    - 0x800: Start of MMIO space for requests. Mapping is contained in the
              manifest so can be dynamically queried.
 
     - addr(Manifest ROM) + 0: Size of compressed manifest
@@ -467,9 +467,9 @@ class ChannelMMIO(esi.ServiceImplementation):
   # TODO: make the amount of register space each client gets a parameter.
   # Supporting this will require more address decode logic.
 
-  RegisterSpace = 0x400
+  RegisterSpace = 0x800
   RegisterSpaceBits = RegisterSpace.bit_length() - 1
-  AddressMask = 0x3FF
+  AddressMask = RegisterSpace - 1
 
   # Start at this address for assigning MMIO addresses to service requests.
   initial_offset: int = RegisterSpace
@@ -1058,6 +1058,22 @@ def ShiftReadGearbox(input_bitwidth: int,
       client_valid = (count >= UInt(cnt_width)(stride_bytes)).as_bits()
       client_xact = (client_valid & client_ready).as_bits()
 
+      # The burst's final word sets `saw_last`; the emit that drains the buffer
+      # to empty terminates the list. These never coincide: emitting needs a
+      # slot buffered by a prior cycle's accept, so `after_emit == 0` on an
+      # accept cycle is impossible.
+      added = Mux(up_xact,
+                  UInt(cnt_width)(0), (up.valid_bytes.as_uint(cnt_width) +
+                                       UInt(cnt_width)(1)).as_uint(cnt_width))
+      after_add = (count + added).as_uint(cnt_width)
+      after_emit = (after_add -
+                    UInt(cnt_width)(stride_bytes)).as_uint(cnt_width)
+      set_saw_last = (up_xact & up.last).as_bits()
+      is_final_slot = (after_emit == UInt(cnt_width)(0)).as_bits()
+      burst_ending = (saw_last | set_saw_last).as_bits()
+      client_last = (client_valid & burst_ending & is_final_slot).as_bits()
+      final_emit = (client_xact & client_last).as_bits()
+
       # Append the accepted word at bit offset count*8 (dynamic left shift);
       # then, if we emit this cycle, drop the consumed slot (constant right
       # shift by the stride). The append offset is <= stride_bytes when
@@ -1073,34 +1089,20 @@ def ShiftReadGearbox(input_bitwidth: int,
       appended = buffer | Mux(up_xact, Bits(buf_bits)(0), shifted_word)
       drained = appended[stride_bits:buf_bits].pad_or_truncate(buf_bits)
       buffer.assign(
-          Mux(client_xact, appended, drained).reg(ports.clk,
-                                                  ports.rst,
-                                                  rst_value=0,
-                                                  name="buffer_reg"))
+          Mux(final_emit, Mux(client_xact, appended, drained),
+              Bits(buf_bits)(0)).reg(ports.clk,
+                                     ports.rst,
+                                     rst_value=0,
+                                     name="buffer_reg"))
 
       # count += accepted real bytes (biased 'valid_bytes' + 1); -= stride on
       # emit.
-      added = Mux(up_xact,
-                  UInt(cnt_width)(0), (up.valid_bytes.as_uint(cnt_width) +
-                                       UInt(cnt_width)(1)).as_uint(cnt_width))
-      after_add = (count + added).as_uint(cnt_width)
-      after_emit = (after_add -
-                    UInt(cnt_width)(stride_bytes)).as_uint(cnt_width)
       count.assign(
           Mux(client_xact, after_add, after_emit).reg(ports.clk,
                                                       ports.rst,
                                                       rst_value=0,
                                                       name="count_reg"))
 
-      # The burst's final word sets `saw_last`; the emit that drains the buffer
-      # to empty terminates the list. These never coincide: emitting needs a
-      # slot buffered by a prior cycle's accept, so `after_emit == 0` on an
-      # accept cycle is impossible.
-      set_saw_last = (up_xact & up.last).as_bits()
-      is_final_slot = (after_emit == UInt(cnt_width)(0)).as_bits()
-      burst_ending = (saw_last | set_saw_last).as_bits()
-      client_last = (client_valid & burst_ending & is_final_slot).as_bits()
-      final_emit = (client_xact & client_last).as_bits()
       saw_last.assign(
           ControlReg(ports.clk, ports.rst, [set_saw_last], [final_emit]))
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -716,19 +716,84 @@ class MMIOIndirection(Module):
 
 
 @modparams
-def TaggedReadGearbox(input_bitwidth: int,
-                      output_bitwidth: int) -> type["TaggedReadGearboxImpl"]:
-  """Build a gearbox to convert the upstream data to the client data
-  type. Assumes a struct {tag, data} and only gearboxes the data. Tag is stored
-  separately and the struct is re-assembled later on."""
+def SliceReadGearbox(input_bitwidth: int,
+                     output_bitwidth: int) -> type["SliceReadGearboxImpl"]:
+  """Narrow one engine word to a single-message client element no wider than the
+  word (``OUT <= IN``). The element sits in the word's low bits, so the datapath
+  is a registered slice; ``valid_bytes`` is unused (a single element is never a
+  partial word). Wider single elements use `ConcatReadGearbox`; packed list
+  reads use `DepackReadGearbox`/`ShiftReadGearbox`."""
 
-  class TaggedReadGearboxImpl(Module):
+  if input_bitwidth <= 0 or input_bitwidth % 8 != 0:
+    raise ValueError("engine word width must be a positive multiple of 8 bits")
+  if not 0 < output_bitwidth <= input_bitwidth:
+    raise ValueError("SliceReadGearbox requires 0 < output <= input")
+
+  in_bytes = input_bitwidth // 8
+  vb_width = clog2(in_bytes)
+
+  class SliceReadGearboxImpl(Module):
     clk = Clock()
     rst = Reset()
     in_ = InputChannel(
         StructType([
             ("tag", esi.HostMem.TagType),
             ("data", Bits(input_bitwidth)),
+            ("valid_bytes", UInt(vb_width)),
+            ("last", Bits(1)),
+        ]))
+    out = OutputChannel(
+        StructType([
+            ("tag", esi.HostMem.TagType),
+            ("data", Bits(output_bitwidth)),
+            ("last", Bits(1)),
+        ]))
+
+    @generator
+    def build(ports):
+      up_ready = Wire(Bits(1), name="up_ready")
+      # Register the input for fmax; the ESI channel buffer keeps the handshake
+      # elastic.
+      up, up_valid = ports.in_.unwrap(up_ready)
+      client_channel, client_ready = SliceReadGearboxImpl.out.type.wrap(
+          {
+              "tag": up.tag,
+              "data": up.data[:output_bitwidth],
+              "last": up.last,
+          }, up_valid)
+      up_ready.assign(client_ready)
+      ports.out = client_channel
+
+  return SliceReadGearboxImpl
+
+
+@modparams
+def ConcatReadGearbox(input_bitwidth: int,
+                      output_bitwidth: int) -> type["ConcatReadGearboxImpl"]:
+  """Concatenate ``ceil(OUT/IN)`` consecutive engine words into one client
+  element wider than the word (``OUT > IN``). Serves single-message reads (any
+  ``OUT > IN``; the low ``OUT`` bits of the concatenation are the element) and
+  contiguous list reads whose element is a whole number of words
+  (``OUT % IN == 0``, so elements never straddle). ``valid_bytes`` is unused:
+  such lists have no partial words and a single element is one flit. Straddling
+  lists use `ShiftReadGearbox`."""
+
+  if input_bitwidth <= 0 or input_bitwidth % 8 != 0:
+    raise ValueError("engine word width must be a positive multiple of 8 bits")
+  if output_bitwidth <= input_bitwidth:
+    raise ValueError("ConcatReadGearbox requires output > input")
+
+  in_bytes = input_bitwidth // 8
+  vb_width = clog2(in_bytes)
+
+  class ConcatReadGearboxImpl(Module):
+    clk = Clock()
+    rst = Reset()
+    in_ = InputChannel(
+        StructType([
+            ("tag", esi.HostMem.TagType),
+            ("data", Bits(input_bitwidth)),
+            ("valid_bytes", UInt(vb_width)),
             ("last", Bits(1)),
         ]))
     out = OutputChannel(
@@ -741,82 +806,70 @@ def TaggedReadGearbox(input_bitwidth: int,
     @generator
     def build(ports):
       ready_for_upstream = Wire(Bits(1), name="ready_for_upstream")
-      upstream_tag_and_data, upstream_valid = ports.in_.unwrap(
-          ready_for_upstream)
-      upstream_data = upstream_tag_and_data.data
-      upstream_last = upstream_tag_and_data.last
+      # Register the input for fmax; the ESI channel buffer keeps the handshake
+      # elastic.
+      in_reg = ports.in_.buffer(ports.clk, ports.rst, stages=1)
+      up, upstream_valid = in_reg.unwrap(ready_for_upstream)
+      upstream_data = up.data
+      upstream_last = up.last
       upstream_xact = ready_for_upstream & upstream_valid
 
-      # Determine if gearboxing is necessary and whether it needs to be
-      # gearboxed up or just sliced down. 'last' (the burst end-of-list marker)
-      # travels with the final engine word that completes each client flit.
-      if output_bitwidth == input_bitwidth:
-        client_data_bits = upstream_data
-        client_valid = upstream_valid
-        client_last = upstream_last
-      elif output_bitwidth < input_bitwidth:
-        client_data_bits = upstream_data[:output_bitwidth]
-        client_valid = upstream_valid
-        client_last = upstream_last
-      else:
-        # Registers accumulate `chunks` upstream words into one client element;
-        # the output is their concatenation.
-        chunks = ceil(output_bitwidth / input_bitwidth)
-        counter_width = clog2(chunks)
-        reg_ces = [Wire(Bits(1)) for _ in range(chunks)]
-        regs = [
-            upstream_data.reg(ports.clk,
-                              ports.rst,
-                              ce=reg_ces[idx],
-                              name=f"chunk_reg_{idx}") for idx in range(chunks)
-        ]
-        client_data_bits = BitsSignal.concat(reversed(regs))[:output_bitwidth]
+      # Registers accumulate `chunks` upstream words into one client element;
+      # the output is their concatenation. For a list, elements stream back to
+      # back and 'last' rides the final word of the burst's final element.
+      chunks = ceil(output_bitwidth / input_bitwidth)
+      counter_width = clog2(chunks)
+      reg_ces = [Wire(Bits(1)) for _ in range(chunks)]
+      regs = [
+          upstream_data.reg(ports.clk,
+                            ports.rst,
+                            ce=reg_ces[idx],
+                            name=f"chunk_reg_{idx}") for idx in range(chunks)
+      ]
+      client_data_bits = BitsSignal.concat(reversed(regs))[:output_bitwidth]
 
-        # Pair-index counter: the word accepted this cycle is written to
-        # chunk_reg[counter]; it advances on each accepted word and resets after
-        # a client element is consumed. When a client consume (`client_xact`)
-        # and an upstream accept (`upstream_xact`) land on the same cycle, the
-        # accepted word is chunk 0 of the *next* element, so the next index must
-        # be 1 -- not 0. A plain `Counter` mishandles this (its `clear` beats
-        # `increment`, dropping the accepted word and stalling the pairing,
-        # which loses words and can deadlock the read), so compute the next
-        # value explicitly. `Mux(sel, a, b)` selects `a` when sel==0, `b` when
-        # sel==1.
-        counter = Wire(UInt(counter_width), name="chunk_counter")
-        client_xact = Wire(Bits(1))
-        incremented = Mux(counter == UInt(counter_width)(chunks - 1),
-                          (counter + 1).as_uint(counter_width),
-                          UInt(counter_width)(0))
-        counter.assign(
-            Mux(
-                client_xact, Mux(upstream_xact, counter, incremented),
-                Mux(upstream_xact,
-                    UInt(counter_width)(0),
-                    UInt(counter_width)(1))).reg(ports.clk,
-                                                 ports.rst,
-                                                 rst_value=0,
-                                                 ce=upstream_xact | client_xact,
-                                                 name="chunk_counter_reg"))
-        set_client_valid = counter == (chunks - 1)
-        client_valid = ControlReg(ports.clk, ports.rst,
-                                  [set_client_valid & upstream_xact],
-                                  [client_xact])
-        client_xact.assign(client_valid & ready_for_upstream)
-        for idx, reg_ce in enumerate(reg_ces):
-          reg_ce.assign(upstream_xact & (counter == UInt(counter_width)(idx)))
-        # 'last' of the final engine word that completes this client flit.
-        client_last = upstream_last.reg(ports.clk,
-                                        ports.rst,
-                                        ce=upstream_xact,
-                                        name="last_reg")
+      # Pair-index counter: the word accepted this cycle is written to
+      # chunk_reg[counter]; it advances on each accepted word and resets after a
+      # client element is consumed. When a client consume (`client_xact`) and an
+      # upstream accept (`upstream_xact`) land on the same cycle, the accepted
+      # word is chunk 0 of the *next* element, so the next index must be 1 --
+      # not 0. A plain `Counter` mishandles this (its `clear` beats `increment`,
+      # dropping the accepted word and stalling the pairing, which loses words
+      # and can deadlock the read), so compute the next value explicitly.
+      # `Mux(sel, a, b)` selects `a` when sel==0, `b` when sel==1.
+      counter = Wire(UInt(counter_width), name="chunk_counter")
+      client_xact = Wire(Bits(1))
+      incremented = Mux(counter == UInt(counter_width)(chunks - 1),
+                        (counter + 1).as_uint(counter_width),
+                        UInt(counter_width)(0))
+      counter.assign(
+          Mux(
+              client_xact, Mux(upstream_xact, counter, incremented),
+              Mux(upstream_xact,
+                  UInt(counter_width)(0),
+                  UInt(counter_width)(1))).reg(ports.clk,
+                                               ports.rst,
+                                               rst_value=0,
+                                               ce=upstream_xact | client_xact,
+                                               name="chunk_counter_reg"))
+      set_client_valid = counter == (chunks - 1)
+      client_valid = ControlReg(ports.clk, ports.rst,
+                                [set_client_valid & upstream_xact],
+                                [client_xact])
+      client_xact.assign(client_valid & ready_for_upstream)
+      for idx, reg_ce in enumerate(reg_ces):
+        reg_ce.assign(upstream_xact & (counter == UInt(counter_width)(idx)))
+      # 'last' of the final engine word that completes this client flit.
+      client_last = upstream_last.reg(ports.clk,
+                                      ports.rst,
+                                      ce=upstream_xact,
+                                      name="last_reg")
+      tag_reg = up.tag.reg(ports.clk,
+                           ports.rst,
+                           ce=upstream_xact,
+                           name="tag_reg")
 
-      # Construct the output channel. Shared logic across all three cases.
-      tag_reg = upstream_tag_and_data.tag.reg(ports.clk,
-                                              ports.rst,
-                                              ce=upstream_xact,
-                                              name="tag_reg")
-
-      client_channel, client_ready = TaggedReadGearboxImpl.out.type.wrap(
+      client_channel, client_ready = ConcatReadGearboxImpl.out.type.wrap(
           {
               "tag": tag_reg,
               "data": client_data_bits,
@@ -825,7 +878,266 @@ def TaggedReadGearbox(input_bitwidth: int,
       ready_for_upstream.assign(client_ready)
       ports.out = client_channel
 
-  return TaggedReadGearboxImpl
+  return ConcatReadGearboxImpl
+
+
+@modparams
+def DepackReadGearbox(input_bitwidth: int,
+                      output_bitwidth: int) -> type["DepackReadGearboxImpl"]:
+  """Unpack a byte-aligned element that divides the engine word
+  (``OUT % 8 == 0`` and ``IN % OUT == 0``) from a contiguous list response. Each
+  word holds ``IN/OUT`` gap-free elements that never straddle, so a counter
+  drives a parts:1 element mux -- no shifter (e.g. 32b/64b, 64b/256b).
+  ``valid_bytes`` locates the last element in the burst's (possibly partial)
+  final word. Straddling relationships use `ShiftReadGearbox`."""
+
+  if input_bitwidth % 8 != 0:
+    raise ValueError("engine word width must be a multiple of 8 bits")
+  if output_bitwidth == 0 or output_bitwidth % 8 != 0 \
+      or input_bitwidth % output_bitwidth != 0:
+    raise ValueError(
+        "DepackReadGearbox requires a byte-aligned element that divides the "
+        "engine word")
+
+  in_bytes = input_bitwidth // 8
+  # 'valid_bytes' is the real byte count minus 1; a word always has >= 1 byte.
+  vb_width = clog2(in_bytes)
+  count_width = clog2(in_bytes + 1)
+  parts = input_bitwidth // output_bitwidth
+  elem_bytes = output_bitwidth // 8
+
+  class DepackReadGearboxImpl(Module):
+    clk = Clock()
+    rst = Reset()
+    in_ = InputChannel(
+        StructType([
+            ("tag", esi.HostMem.TagType),
+            ("data", Bits(input_bitwidth)),
+            ("valid_bytes", UInt(vb_width)),
+            ("last", Bits(1)),
+        ]))
+    out = OutputChannel(
+        StructType([
+            ("tag", esi.HostMem.TagType),
+            ("data", Bits(output_bitwidth)),
+            ("last", Bits(1)),
+        ]))
+
+    @generator
+    def build(ports):
+      client_ready = Wire(Bits(1), name="client_ready")
+      up_ready = Wire(Bits(1), name="up_ready")
+      # Register the input for fmax; the ESI channel buffer keeps the handshake
+      # elastic and decouples the ready path.
+      in_reg = ports.in_.buffer(ports.clk, ports.rst, stages=1)
+      up, up_valid = in_reg.unwrap(up_ready)
+      client_xact = (up_valid & client_ready).as_bits()
+
+      if parts == 1:
+        # One element per word; nothing to select.
+        last_in_word = Bits(1)(1)
+        client_data = up.data
+      else:
+        idx_width = clog2(parts)
+        idx = Wire(UInt(idx_width), name="idx")
+        # (idx + 1) * elem_bytes == real valid bytes marks the word's last
+        # element (the final word may hold fewer than `parts`); add 1 back to
+        # the biased 'valid_bytes' to recover the real count.
+        real_valid_bytes = (up.valid_bytes.as_uint(count_width) +
+                            UInt(count_width)(1)).as_uint(count_width)
+        consumed = ((idx.as_uint(count_width) + UInt(count_width)(1)) *
+                    UInt(count_width)(elem_bytes)).as_uint(count_width)
+        last_in_word = (consumed == real_valid_bytes).as_bits()
+        # parts:1 element-select mux -- the entire datapath, no shifter.
+        word_parts = Array(Bits(output_bitwidth), parts)([
+            up.data[k * output_bitwidth:(k + 1) * output_bitwidth]
+            for k in range(parts)
+        ])
+        client_data = word_parts[idx]
+        idx.assign(
+            Mux(last_in_word, (idx + UInt(idx_width)(1)).as_uint(idx_width),
+                UInt(idx_width)(0)).reg(ports.clk,
+                                        ports.rst,
+                                        rst_value=0,
+                                        ce=client_xact,
+                                        name="idx_reg"))
+
+      # Consume the buffered word as its last element leaves.
+      up_ready.assign((client_xact & last_in_word).as_bits())
+      client_channel, client_ready_sig = DepackReadGearboxImpl.out.type.wrap(
+          {
+              "tag": up.tag,
+              "data": client_data,
+              "last": (up.last & last_in_word).as_bits(),
+          }, up_valid)
+      client_ready.assign(client_ready_sig)
+      ports.out = client_channel
+
+  return DepackReadGearboxImpl
+
+
+@modparams
+def ShiftReadGearbox(input_bitwidth: int,
+                     output_bitwidth: int) -> type["ShiftReadGearboxImpl"]:
+  """Universal fallback: unpack a contiguous, byte-packed element stream (a
+  `read_list` response) for ANY ``(input_bitwidth, output_bitwidth)`` pair.
+
+  Elements are packed at their natural byte stride ``stride = ceil(OUT/8)``
+  bytes, so element k begins at wire bit ``k*stride*8`` and, in general,
+  straddles engine-word boundaries at an arbitrary bit offset. A byte-addressed
+  shift-register accumulator realigns each element across words. This is correct
+  for every width relationship; `SliceReadGearbox`, `ConcatReadGearbox` and
+  `DepackReadGearbox` are optimizations that avoid this barrel shifter for the
+  regular (non-straddling) cases.
+
+  Each input word carries ``valid_bytes`` (how many of its bytes are real; only
+  the burst's final word is partial) and ``last`` (its final word). Because a
+  burst is always a whole number of elements, tracking real bytes lets the
+  gearbox emit exactly the right elements and place the list-terminating
+  ``last`` on the final one -- no padding element is ever emitted."""
+
+  if input_bitwidth % 8 != 0:
+    raise ValueError("engine word width must be a multiple of 8 bits")
+  if output_bitwidth <= 0:
+    raise ValueError("client element width must be positive")
+  in_bytes = input_bitwidth // 8
+  stride_bytes = (output_bitwidth + 7) // 8
+  stride_bits = stride_bytes * 8
+  # Hold at most one partial element plus one freshly accepted word.
+  buf_bytes = stride_bytes + in_bytes
+  buf_bits = buf_bytes * 8
+  # 'valid_bytes' is the real byte count minus 1; a word always has >= 1 byte.
+  vb_width = clog2(in_bytes)
+  cnt_width = clog2(buf_bytes + 1)
+  # The append offset is only ever in [0, stride_bytes] (has_room), so the shift
+  # index needs fewer bits than the full count -- see `build`.
+  offset_width = clog2(stride_bytes + 1)
+
+  class ShiftReadGearboxImpl(Module):
+    clk = Clock()
+    rst = Reset()
+    in_ = InputChannel(
+        StructType([
+            ("tag", esi.HostMem.TagType),
+            ("data", Bits(input_bitwidth)),
+            ("valid_bytes", UInt(vb_width)),
+            ("last", Bits(1)),
+        ]))
+    out = OutputChannel(
+        StructType([
+            ("tag", esi.HostMem.TagType),
+            ("data", Bits(output_bitwidth)),
+            ("last", Bits(1)),
+        ]))
+
+    @generator
+    def build(ports):
+      client_ready = Wire(Bits(1), name="client_ready")
+      up_ready = Wire(Bits(1), name="up_ready")
+      # Register the input for fmax; the ESI channel buffer keeps the handshake
+      # elastic and decouples the ready path.
+      in_reg = ports.in_.buffer(ports.clk, ports.rst, stages=1)
+      up, up_valid = in_reg.unwrap(up_ready)
+
+      from pycde.circt.dialects import comb
+
+      # Byte-addressed accumulator: `buffer` holds `count` valid bytes packed
+      # from bit 0 up; the element being emitted is buffer[0:OUT].
+      buffer = Wire(Bits(buf_bits), name="buffer")
+      count = Wire(UInt(cnt_width), name="count")
+      saw_last = Wire(Bits(1), name="saw_last")
+
+      # Accept a whole engine word only when there's room, and never while
+      # draining a finished burst -- otherwise the next burst's bytes would mix
+      # into this one's buffer.
+      has_room = (count <= UInt(cnt_width)(buf_bytes - in_bytes)).as_bits()
+      up_ready.assign((has_room & ~saw_last).as_bits())
+      up_xact = (up_ready & up_valid).as_bits()
+
+      # Emit an element once a full stride slot is buffered.
+      client_valid = (count >= UInt(cnt_width)(stride_bytes)).as_bits()
+      client_xact = (client_valid & client_ready).as_bits()
+
+      # Append the accepted word at bit offset count*8 (dynamic left shift);
+      # then, if we emit this cycle, drop the consumed slot (constant right
+      # shift by the stride). The append offset is <= stride_bytes when
+      # accepting, so bound the shift index to that range: its high bits are
+      # constant 0, which lets constant-propagation prune the upper barrel-
+      # shifter stages (synthesis won't infer this bound from the count reg).
+      append_off = count.as_bits()[0:offset_width]
+      shamt = BitsSignal.concat([append_off,
+                                 Bits(3)(0)]).pad_or_truncate(buf_bits)
+      word_ext = up.data.pad_or_truncate(buf_bits)
+      shifted_word = BitsSignal(
+          comb.ShlOp(word_ext.value, shamt.value).result, Bits(buf_bits))
+      appended = buffer | Mux(up_xact, Bits(buf_bits)(0), shifted_word)
+      drained = appended[stride_bits:buf_bits].pad_or_truncate(buf_bits)
+      buffer.assign(
+          Mux(client_xact, appended, drained).reg(ports.clk,
+                                                  ports.rst,
+                                                  rst_value=0,
+                                                  name="buffer_reg"))
+
+      # count += accepted real bytes (biased 'valid_bytes' + 1); -= stride on
+      # emit.
+      added = Mux(up_xact,
+                  UInt(cnt_width)(0), (up.valid_bytes.as_uint(cnt_width) +
+                                       UInt(cnt_width)(1)).as_uint(cnt_width))
+      after_add = (count + added).as_uint(cnt_width)
+      after_emit = (after_add -
+                    UInt(cnt_width)(stride_bytes)).as_uint(cnt_width)
+      count.assign(
+          Mux(client_xact, after_add, after_emit).reg(ports.clk,
+                                                      ports.rst,
+                                                      rst_value=0,
+                                                      name="count_reg"))
+
+      # The burst's final word sets `saw_last`; the emit that drains the buffer
+      # to empty terminates the list. These never coincide: emitting needs a
+      # slot buffered by a prior cycle's accept, so `after_emit == 0` on an
+      # accept cycle is impossible.
+      set_saw_last = (up_xact & up.last).as_bits()
+      is_final_slot = (after_emit == UInt(cnt_width)(0)).as_bits()
+      burst_ending = (saw_last | set_saw_last).as_bits()
+      client_last = (client_valid & burst_ending & is_final_slot).as_bits()
+      final_emit = (client_xact & client_last).as_bits()
+      saw_last.assign(
+          ControlReg(ports.clk, ports.rst, [set_saw_last], [final_emit]))
+
+      tag_reg = up.tag.reg(ports.clk, ports.rst, ce=up_xact, name="tag_reg")
+      client_channel, client_ready_sig = ShiftReadGearboxImpl.out.type.wrap(
+          {
+              "tag": tag_reg,
+              "data": buffer[0:output_bitwidth],
+              "last": client_last,
+          }, client_valid)
+      client_ready.assign(client_ready_sig)
+      ports.out = client_channel
+
+  return ShiftReadGearboxImpl
+
+
+def select_read_gearbox(is_list: bool, input_bitwidth: int,
+                        output_bitwidth: int):
+  """Pick the read-gearbox module for a client of the given kind and width
+  relationship. Every gearbox shares the {tag, data, valid_bytes, last} input
+  (from `HostMemReadReqSplitter`) and the {tag, data, last} output, so callers
+  wire them identically. `ShiftReadGearbox` is the correct-for-everything
+  fallback; the others avoid its barrel shifter for regular relationships."""
+  if not is_list:
+    # A single element starts at bit 0 and never straddles at a bit offset.
+    if output_bitwidth <= input_bitwidth:
+      return SliceReadGearbox(input_bitwidth, output_bitwidth)
+    return ConcatReadGearbox(input_bitwidth, output_bitwidth)
+  if output_bitwidth > input_bitwidth:
+    # Super-word list: a whole-word-multiple element never straddles.
+    if output_bitwidth % input_bitwidth == 0:
+      return ConcatReadGearbox(input_bitwidth, output_bitwidth)
+    return ShiftReadGearbox(input_bitwidth, output_bitwidth)
+  # Sub-word list: a byte-aligned element that divides the word never straddles.
+  if input_bitwidth % output_bitwidth == 0 and output_bitwidth % 8 == 0:
+    return DepackReadGearbox(input_bitwidth, output_bitwidth)
+  return ShiftReadGearbox(input_bitwidth, output_bitwidth)
 
 
 # Maximum size, in bytes, of a single upstream read request. Reads larger than
@@ -884,6 +1196,18 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
   word_bytes = dict(resp_struct.fields)["data"].bitwidth // 8
   word_shift = clog2(word_bytes)
   words_width = length_width - word_shift
+  # The response is augmented with a per-word 'valid_bytes': the number of real
+  # bytes in the (possibly partial) final word, biased by -1. A burst word
+  # always has >= 1 real byte, so encoding count-1 fits in one fewer bit.
+  vb_width = clog2(word_bytes)
+  resp_fields = dict(resp_struct.fields)
+  resp_out_struct = StructType([
+      ("tag", resp_fields["tag"]),
+      ("data", resp_fields["data"]),
+      ("valid_bytes", UInt(vb_width)),
+      ("last", Bits(1)),
+  ])
+  resp_out_channel_type = Channel(resp_out_struct)
 
   class HostMemReadReqSplitterImpl(Module):
     clk = Clock()
@@ -891,7 +1215,7 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
     req_in = Input(req_channel_type)
     req_out = Output(req_channel_type)
     resp_in = Input(resp_channel_type)
-    resp_out = Output(resp_channel_type)
+    resp_out = Output(resp_out_channel_type)
 
     @generator
     def build(ports):
@@ -919,10 +1243,23 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
       chunk_len = Mux(remaining > max_chunk, remaining, max_chunk)
       last_chunk = remaining <= max_chunk
 
+      # Round the emitted read length up to a whole word. The reader response
+      # is word-granular and 'valid_bytes' still carries the real trailing byte
+      # count, so total_words and the reassembled element count are unchanged;
+      # this just keeps every read word-aligned for single-flit HostMem
+      # transports that reject sub-word read lengths.
+      if word_shift == 0:
+        chunk_len_out = chunk_len
+      else:
+        chunk_words = (chunk_len + UInt(length_width)(word_bytes - 1)
+                      ).as_bits()[word_shift:].as_uint(words_width)
+        chunk_len_out = BitsSignal.concat(
+            [chunk_words.as_bits(), Bits(word_shift)(0)]).as_uint(length_width)
+
       req_out_ch, req_out_ready = req_channel_type.wrap(
           req_struct({
               "address": cur_addr,
-              "length": chunk_len,
+              "length": chunk_len_out,
               "tag": tag_reg,
           }), emit_busy)
       ports.req_out = req_out_ch
@@ -956,16 +1293,34 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
 
       tag_reg.assign(req_payload.tag.reg(clk, rst, ce=accept, name="tag_reg_r"))
 
-      # --- Response reassembly: re-derive the single burst-final 'last'. ---
-      total_words = req_payload.length.as_bits()[word_shift:].as_uint()
+      # --- Response reassembly: re-derive the burst-final 'last' and the byte
+      # count of the (possibly partial) final word. Elements need not tile
+      # evenly into words, so count words with ceil(length / word_bytes). ---
+      total_words = ((req_payload.length + UInt(length_width)(word_bytes - 1)
+                     ).as_bits()[word_shift:]).as_uint(words_width)
+      # Bytes valid in the final word = length - (total_words - 1) * word_bytes.
+      words_before_last = (total_words -
+                           UInt(words_width)(1)).as_uint(words_width)
+      bytes_before_last = BitsSignal.concat(
+          [words_before_last.as_bits(),
+           Bits(word_shift)(0)]).as_uint(length_width)
+      final_valid_bytes = (req_payload.length - bytes_before_last -
+                           UInt(length_width)(1)).as_uint(vb_width).reg(
+                               clk, rst, ce=accept, name="final_valid_bytes")
       resp_ready = Wire(Bits(1))
       resp_payload, resp_valid = ports.resp_in.unwrap(resp_ready)
       is_final_word = words_left == UInt(words_width)(1)
-      resp_out_ch, resp_out_ready = resp_channel_type.wrap(
-          resp_struct({
-              "tag": resp_payload.tag,
-              "data": resp_payload.data,
-              "last": is_final_word,
+      resp_out_ch, resp_out_ready = resp_out_channel_type.wrap(
+          resp_out_struct({
+              "tag":
+                  resp_payload.tag,
+              "data":
+                  resp_payload.data,
+              "valid_bytes":
+                  Mux(is_final_word, final_valid_bytes,
+                      UInt(vb_width)(word_bytes - 1)),
+              "last":
+                  is_final_word,
           }), resp_valid)
       ports.resp_out = resp_out_ch
       resp_ready.assign(resp_out_ready)
@@ -1046,10 +1401,10 @@ def HostmemReadProcessor(
       ports.upstream = upstream_read_bundle
       upstream_resp_channel = froms["resp"]
 
-      # Demux the upstream parallel-window frames {tag, data, last} to each
-      # client by tag. The gearbox consumes {tag, data, last}: single-message
-      # clients discard 'last'; burst (read_list) clients propagate it as their
-      # response window's per-frame 'last'.
+      # Demux the upstream response frames {tag, data, last} to each client by
+      # tag. Each client's stream then flows through a `HostMemReadReqSplitter`
+      # (which annotates per-word 'valid_bytes' and the burst-final 'last') into
+      # the leaf gearbox chosen by `select_read_gearbox`.
       demux = esi.TaggedDemux(len(reqs), upstream_resp_channel.type)(
           clk=ports.clk, rst=ports.rst, in_=upstream_resp_channel)
 
@@ -1068,14 +1423,13 @@ def HostmemReadProcessor(
         # the additional benefit of letting the upstream tag be the client
         # identifier. TODO: Implement the gating logic here.
         client_type = resp_type.inner_type
+        is_list = isinstance(client_type, Window)
 
-        if isinstance(client_type, Window):
-          # Burst read (read_list): the response is a parallel window over
-          # struct{tag, data: list<element>} with num_items=1, lowering to
-          # struct{tag, data: element, last}. Gearbox each engine word to the
-          # element width, propagate 'last', then re-wrap as the window. Each
-          # element is word-aligned on the wire, so any element width maps onto
-          # a whole number of engine words.
+        # A read_list response is a parallel window over
+        # struct{tag, data: list<element>} (num_items=1), lowering to
+        # struct{tag, data: element, data_size, last}; a single read carries the
+        # element directly. Pull the element width out of whichever shape.
+        if is_list:
           lowered = client_type.lowered_type
           lowered_fields = dict(lowered.fields)
           element_type = lowered_fields["data"]
@@ -1083,23 +1437,30 @@ def HostmemReadProcessor(
           data_size_type = lowered_fields["data_size"]
           if element_bits == 0:
             raise ValueError("read_list element type cannot be zero-width.")
-          words_per_elem = (element_bits + read_width - 1) // read_width
-          elem_stride_bytes = words_per_elem * word_bytes
+        else:
+          if client_type.data.bitwidth == 0:
+            raise ValueError("Client data type cannot be zero-width. Use a "
+                             "single-bit type if no data is needed.")
+          element_bits = client_type.data.bitwidth
+        # Elements are packed contiguously in host memory at their natural byte
+        # size, independent of the engine word width.
+        elem_stride_bytes = (element_bits + 7) // 8
 
-          # A burst can request far more than a single upstream read request can
-          # carry, so split it into request-sized, word-aligned chunks before
-          # arbitration and reassemble the responses afterwards; the gearbox
-          # sees one contiguous response stream. Elements may span chunks -- the
-          # splitter re-derives a single burst-final 'last' from the total
-          # length. 'splitter_resp' breaks the request/response construction
-          # cycle (the client request is derived from the packed response
-          # bundle).
-          max_chunk_bytes = (max_read_request_bytes // word_bytes) * word_bytes
-          splitter_resp = Wire(demuxed_upstream_channel.type)
-          gearbox = TaggedReadGearbox(read_width,
-                                      element_bits)(clk=ports.clk,
-                                                    rst=ports.rst,
-                                                    in_=splitter_resp)
+        # Both single-message and list reads flow demux -> splitter -> gearbox
+        # with a uniform {tag, data, valid_bytes, last} interface. The splitter
+        # chunks oversized requests (so even a wide single element is
+        # request-chunked) and annotates each word with 'valid_bytes' plus the
+        # burst-final 'last'; `select_read_gearbox` picks the leaf gearbox for
+        # this (is_list, read_width, element_bits). 'splitter_resp' breaks the
+        # request/response construction cycle (the client request is derived
+        # from the gearbox's response bundle).
+        max_chunk_bytes = (max_read_request_bytes // word_bytes) * word_bytes
+        gearbox_mod = select_read_gearbox(is_list, read_width, element_bits)
+        splitter_resp = Wire(gearbox_mod.in_.type)
+        gearbox = gearbox_mod(clk=ports.clk, rst=ports.rst, in_=splitter_resp)
+
+        if is_list:
+          # Propagate 'last', then re-wrap the element as the response window.
           client_resp_channel = gearbox.out.transform(
               lambda m, lowered=lowered, element_type=element_type,
               data_size_type=data_size_type, client_type=client_type:
@@ -1122,22 +1483,8 @@ def HostmemReadProcessor(
                   "tag":
                       idx,
               }))
-          splitter = HostMemReadReqSplitter(
-              logical_req.type, demuxed_upstream_channel.type,
-              max_chunk_bytes)(clk=ports.clk,
-                               rst=ports.rst,
-                               req_in=logical_req,
-                               resp_in=demuxed_upstream_channel)
-          splitter_resp.assign(splitter.resp_out)
-          tagged_client_req = splitter.req_out
         else:
-          # Single-message read: gearbox to the client width and discard the
-          # 'last' burst marker.
-          if client_type.data.bitwidth == 0:
-            raise ValueError("Client data type cannot be zero-width. Use a "
-                             "single-bit type if no data is needed.")
-          gearbox = TaggedReadGearbox(read_width, client_type.data.bitwidth)(
-              clk=ports.clk, rst=ports.rst, in_=demuxed_upstream_channel)
+          # Single-message read: one element; discard the 'last' burst marker.
           client_resp_channel = gearbox.out.transform(
               lambda m, client_type=client_type: client_type({
                   "tag": m.tag,
@@ -1145,14 +1492,23 @@ def HostmemReadProcessor(
               }))
           client_bundle, froms = client.type.pack(resp=client_resp_channel)
           client_req = froms["req"]
-          tagged_client_req = client_req.transform(
-              lambda r, idx=idx, client_type=client_type: hostmem_module.
-              UpstreamReadReq({
+          logical_req = client_req.transform(
+              lambda r, idx=idx, elem_stride_bytes=elem_stride_bytes:
+              hostmem_module.UpstreamReadReq({
                   "address": r.address,
-                  "length": (client_type.data.bitwidth + 7) // 8,
+                  "length": UInt(32)(elem_stride_bytes),
                   # TODO: Change this once we support tag-rewriting.
-                  "tag": idx
+                  "tag": idx,
               }))
+
+        splitter = HostMemReadReqSplitter(
+            logical_req.type, demuxed_upstream_channel.type,
+            max_chunk_bytes)(clk=ports.clk,
+                             rst=ports.rst,
+                             req_in=logical_req,
+                             resp_in=demuxed_upstream_channel)
+        splitter_resp.assign(splitter.resp_out)
+        tagged_client_req = splitter.req_out
 
         tagged_client_reqs.append(tagged_client_req)
 
@@ -1466,11 +1822,11 @@ def HostMemWriteProcessor(
           lowered = client_type.lowered_type
           array_type = dict(lowered.fields)["data"]
           element_bits = array_type.element_type.bitwidth
-          # Each element occupies a whole number of upstream bus words, so the
-          # base-address stride is beat-aligned (matches the read_list path).
-          word_bytes = write_width // 8
-          words_per_elem = (element_bits + write_width - 1) // write_width
-          elem_stride = words_per_elem * word_bytes
+          # Elements are packed contiguously in host memory at their natural
+          # byte size, independent of the engine word width (matches the
+          # read_list path). Each per-element write is byte-enabled via
+          # data_size, so a sub-word element writes only its own bytes.
+          elem_stride = (element_bits + 7) // 8
 
           gearbox_mod = TaggedWriteGearbox(element_bits, write_width,
                                            max_write_payload_bytes)

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -7,7 +7,7 @@ from math import ceil
 
 from pycde.common import Clock, Input, InputChannel, Output, OutputChannel, Reset
 from pycde.constructs import (AssignableSignal, ControlReg, Counter, Mux,
-                              NamedWire, Wire)
+                              NamedWire, Reg, Wire)
 from pycde import esi
 from pycde.module import Module, generator, modparams
 from pycde.signals import BitsSignal, ChannelSignal, StructSignal
@@ -720,9 +720,9 @@ def SliceReadGearbox(input_bitwidth: int,
                      output_bitwidth: int) -> type["SliceReadGearboxImpl"]:
   """Narrow one engine word to a single-message client element no wider than the
   word (``OUT <= IN``). The element sits in the word's low bits, so the datapath
-  is a registered slice; ``valid_bytes`` is unused (a single element is never a
-  partial word). Wider single elements use `ConcatReadGearbox`; packed list
-  reads use `DepackReadGearbox`/`ShiftReadGearbox`."""
+  is a slice; ``valid_bytes`` is unused (a single element is never a partial
+  word). Wider single elements use `ConcatReadGearbox`; packed list reads use
+  `DepackReadGearbox`/`ShiftReadGearbox`."""
 
   if input_bitwidth <= 0 or input_bitwidth % 8 != 0:
     raise ValueError("engine word width must be a positive multiple of 8 bits")
@@ -752,8 +752,6 @@ def SliceReadGearbox(input_bitwidth: int,
     @generator
     def build(ports):
       up_ready = Wire(Bits(1), name="up_ready")
-      # Register the input for fmax; the ESI channel buffer keeps the handshake
-      # elastic.
       up, up_valid = ports.in_.unwrap(up_ready)
       client_channel, client_ready = SliceReadGearboxImpl.out.type.wrap(
           {
@@ -773,7 +771,7 @@ def ConcatReadGearbox(input_bitwidth: int,
   """Concatenate ``ceil(OUT/IN)`` consecutive engine words into one client
   element wider than the word (``OUT > IN``). Serves single-message reads (any
   ``OUT > IN``; the low ``OUT`` bits of the concatenation are the element) and
-  contiguous list reads whose element is a whole number of words
+  contiguous list reads whose element is a whole number of output_bitwidth
   (``OUT % IN == 0``, so elements never straddle). ``valid_bytes`` is unused:
   such lists have no partial words and a single element is one flit. Straddling
   lists use `ShiftReadGearbox`."""
@@ -829,34 +827,24 @@ def ConcatReadGearbox(input_bitwidth: int,
       client_data_bits = BitsSignal.concat(reversed(regs))[:output_bitwidth]
 
       # Pair-index counter: the word accepted this cycle is written to
-      # chunk_reg[counter]; it advances on each accepted word and resets after a
-      # client element is consumed. When a client consume (`client_xact`) and an
-      # upstream accept (`upstream_xact`) land on the same cycle, the accepted
-      # word is chunk 0 of the *next* element, so the next index must be 1 --
-      # not 0. A plain `Counter` mishandles this (its `clear` beats `increment`,
-      # dropping the accepted word and stalling the pairing, which loses words
-      # and can deadlock the read), so compute the next value explicitly.
-      # `Mux(sel, a, b)` selects `a` when sel==0, `b` when sel==1.
+      # chunk_reg[counter]. 'Counter' clears in preference to incrementing, so
+      # mask the clear with the accept -- a consume and an accept on the same
+      # cycle means the accepted word is chunk 0 of the *next* element, so the
+      # index must land on 1, not 0. 'chunks' need not be a power of two, so
+      # wrap explicitly rather than relying on the counter's natural rollover.
       counter = Wire(UInt(counter_width), name="chunk_counter")
       client_xact = Wire(Bits(1))
-      incremented = Mux(counter == UInt(counter_width)(chunks - 1),
-                        (counter + 1).as_uint(counter_width),
-                        UInt(counter_width)(0))
+      set_client_valid = counter == UInt(counter_width)(chunks - 1)
       counter.assign(
-          Mux(
-              client_xact, Mux(upstream_xact, counter, incremented),
-              Mux(upstream_xact,
-                  UInt(counter_width)(0),
-                  UInt(counter_width)(1))).reg(ports.clk,
-                                               ports.rst,
-                                               rst_value=0,
-                                               ce=upstream_xact | client_xact,
-                                               name="chunk_counter_reg"))
-      set_client_valid = counter == (chunks - 1)
+          Counter(counter_width)(clk=ports.clk,
+                                 rst=ports.rst,
+                                 clear=(upstream_xact & set_client_valid) |
+                                 (client_xact & ~upstream_xact),
+                                 increment=upstream_xact,
+                                 instance_name="chunk_counter").out)
       client_valid = ControlReg(ports.clk, ports.rst,
                                 [set_client_valid & upstream_xact],
                                 [client_xact])
-      client_xact.assign(client_valid & ready_for_upstream)
       for idx, reg_ce in enumerate(reg_ces):
         reg_ce.assign(upstream_xact & (counter == UInt(counter_width)(idx)))
       # 'last' of the final engine word that completes this client flit.
@@ -875,7 +863,8 @@ def ConcatReadGearbox(input_bitwidth: int,
               "data": client_data_bits,
               "last": client_last,
           }, client_valid)
-      ready_for_upstream.assign(client_ready)
+      client_xact.assign(client_valid & client_ready)
+      ready_for_upstream.assign(~client_valid | client_ready)
       ports.out = client_channel
 
   return ConcatReadGearboxImpl
@@ -931,7 +920,7 @@ def DepackReadGearbox(input_bitwidth: int,
       # elastic and decouples the ready path.
       in_reg = ports.in_.buffer(ports.clk, ports.rst, stages=1)
       up, up_valid = in_reg.unwrap(up_ready)
-      client_xact = (up_valid & client_ready).as_bits()
+      client_xact = up_valid & client_ready
 
       if parts == 1:
         # One element per word; nothing to select.
@@ -939,15 +928,19 @@ def DepackReadGearbox(input_bitwidth: int,
         client_data = up.data
       else:
         idx_width = clog2(parts)
-        idx = Wire(UInt(idx_width), name="idx")
+        idx = Reg(UInt(idx_width),
+                  clk=ports.clk,
+                  rst=ports.rst,
+                  rst_value=0,
+                  ce=client_xact,
+                  name="idx")
         # (idx + 1) * elem_bytes == real valid bytes marks the word's last
         # element (the final word may hold fewer than `parts`); add 1 back to
         # the biased 'valid_bytes' to recover the real count.
-        real_valid_bytes = (up.valid_bytes.as_uint(count_width) +
-                            UInt(count_width)(1)).as_uint(count_width)
-        consumed = ((idx.as_uint(count_width) + UInt(count_width)(1)) *
+        real_valid_bytes = (up.valid_bytes + UInt(1)(1)).as_uint(count_width)
+        consumed = ((idx + UInt(1)(1)) *
                     UInt(count_width)(elem_bytes)).as_uint(count_width)
-        last_in_word = (consumed == real_valid_bytes).as_bits()
+        last_in_word = consumed == real_valid_bytes
         # parts:1 element-select mux -- the entire datapath, no shifter.
         word_parts = Array(Bits(output_bitwidth), parts)([
             up.data[k * output_bitwidth:(k + 1) * output_bitwidth]
@@ -955,15 +948,11 @@ def DepackReadGearbox(input_bitwidth: int,
         ])
         client_data = word_parts[idx]
         idx.assign(
-            Mux(last_in_word, (idx + UInt(idx_width)(1)).as_uint(idx_width),
-                UInt(idx_width)(0)).reg(ports.clk,
-                                        ports.rst,
-                                        rst_value=0,
-                                        ce=client_xact,
-                                        name="idx_reg"))
+            Mux(last_in_word, (idx + UInt(1)(1)).as_uint(idx_width),
+                UInt(idx_width)(0)))
 
       # Consume the buffered word as its last element leaves.
-      up_ready.assign((client_xact & last_in_word).as_bits())
+      up_ready.assign(client_xact & last_in_word)
       client_channel, client_ready_sig = DepackReadGearboxImpl.out.type.wrap(
           {
               "tag": up.tag,
@@ -990,11 +979,14 @@ def ShiftReadGearbox(input_bitwidth: int,
   `DepackReadGearbox` are optimizations that avoid this barrel shifter for the
   regular (non-straddling) cases.
 
-  Each input word carries ``valid_bytes`` (how many of its bytes are real; only
-  the burst's final word is partial) and ``last`` (its final word). Because a
-  burst is always a whole number of elements, tracking real bytes lets the
-  gearbox emit exactly the right elements and place the list-terminating
-  ``last`` on the final one -- no padding element is ever emitted."""
+  Each input word carries ``valid_bytes`` (how many of its bytes are real) and
+  ``last``. Both are framed to one whole `read_list` request rather than to the
+  transport: `HostMemReadReqSplitter` drops the per-chunk framing of the reads
+  it issues and re-derives these from the request's total length, so only the
+  request's final word is ever partial. That length is ``num_elements *
+  stride``, so tracking real bytes lets the gearbox emit exactly the right
+  elements and place the list-terminating ``last`` on the final one -- no
+  padding element is ever emitted."""
 
   if input_bitwidth % 8 != 0:
     raise ValueError("engine word width must be a multiple of 8 bits")
@@ -1043,20 +1035,28 @@ def ShiftReadGearbox(input_bitwidth: int,
 
       # Byte-addressed accumulator: `buffer` holds `count` valid bytes packed
       # from bit 0 up; the element being emitted is buffer[0:OUT].
-      buffer = Wire(Bits(buf_bits), name="buffer")
-      count = Wire(UInt(cnt_width), name="count")
+      buffer = Reg(Bits(buf_bits),
+                   clk=ports.clk,
+                   rst=ports.rst,
+                   rst_value=0,
+                   name="buffer")
+      count = Reg(UInt(cnt_width),
+                  clk=ports.clk,
+                  rst=ports.rst,
+                  rst_value=0,
+                  name="count")
       saw_last = Wire(Bits(1), name="saw_last")
 
       # Accept a whole engine word only when there's room, and never while
       # draining a finished burst -- otherwise the next burst's bytes would mix
       # into this one's buffer.
-      has_room = (count <= UInt(cnt_width)(buf_bytes - in_bytes)).as_bits()
-      up_ready.assign((has_room & ~saw_last).as_bits())
-      up_xact = (up_ready & up_valid).as_bits()
+      has_room = count <= UInt(cnt_width)(buf_bytes - in_bytes)
+      up_ready.assign(has_room & ~saw_last)
+      up_xact = up_ready & up_valid
 
       # Emit an element once a full stride slot is buffered.
-      client_valid = (count >= UInt(cnt_width)(stride_bytes)).as_bits()
-      client_xact = (client_valid & client_ready).as_bits()
+      client_valid = count >= UInt(cnt_width)(stride_bytes)
+      client_xact = client_valid & client_ready
 
       # The burst's final word sets `saw_last`; the emit that drains the buffer
       # to empty terminates the list. These never coincide: emitting needs a
@@ -1064,15 +1064,15 @@ def ShiftReadGearbox(input_bitwidth: int,
       # accept cycle is impossible.
       added = Mux(up_xact,
                   UInt(cnt_width)(0), (up.valid_bytes.as_uint(cnt_width) +
-                                       UInt(cnt_width)(1)).as_uint(cnt_width))
+                                       UInt(1)(1)).as_uint(cnt_width))
       after_add = (count + added).as_uint(cnt_width)
       after_emit = (after_add -
                     UInt(cnt_width)(stride_bytes)).as_uint(cnt_width)
       set_saw_last = (up_xact & up.last).as_bits()
-      is_final_slot = (after_emit == UInt(cnt_width)(0)).as_bits()
-      burst_ending = (saw_last | set_saw_last).as_bits()
-      client_last = (client_valid & burst_ending & is_final_slot).as_bits()
-      final_emit = (client_xact & client_last).as_bits()
+      is_final_slot = (after_emit == UInt(cnt_width)(0))
+      burst_ending = saw_last | set_saw_last
+      client_last = client_valid & burst_ending & is_final_slot
+      final_emit = client_xact & client_last
 
       # Append the accepted word at bit offset count*8 (dynamic left shift);
       # then, if we emit this cycle, drop the consumed slot (constant right
@@ -1090,18 +1090,11 @@ def ShiftReadGearbox(input_bitwidth: int,
       drained = appended[stride_bits:buf_bits].pad_or_truncate(buf_bits)
       buffer.assign(
           Mux(final_emit, Mux(client_xact, appended, drained),
-              Bits(buf_bits)(0)).reg(ports.clk,
-                                     ports.rst,
-                                     rst_value=0,
-                                     name="buffer_reg"))
+              Bits(buf_bits)(0)))
 
       # count += accepted real bytes (biased 'valid_bytes' + 1); -= stride on
       # emit.
-      count.assign(
-          Mux(client_xact, after_add, after_emit).reg(ports.clk,
-                                                      ports.rst,
-                                                      rst_value=0,
-                                                      name="count_reg"))
+      count.assign(Mux(client_xact, after_add, after_emit))
 
       saw_last.assign(
           ControlReg(ports.clk, ports.rst, [set_saw_last], [final_emit]))
@@ -1319,8 +1312,8 @@ def HostMemReadReqSplitter(req_channel_type: Channel,
               "data":
                   resp_payload.data,
               "valid_bytes":
-                  Mux(is_final_word, final_valid_bytes,
-                      UInt(vb_width)(word_bytes - 1)),
+                  Mux(is_final_word,
+                      UInt(vb_width)(word_bytes - 1), final_valid_bytes),
               "last":
                   is_final_word,
           }), resp_valid)

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
@@ -26,8 +26,16 @@ from esiaccel.components.mmio import MmioRegistry, mmio_write_we
 from pycde.common import AppID, Constant, Input, InputChannel, Output, OutputChannel
 from pycde.constructs import ControlReg, Counter, Mux, NamedWire, Reg, Wire
 from pycde.module import Metadata
+from pycde.signals import BitsSignal
 from pycde.testing import print_info
 from pycde.types import Array, Bits, Channel, ChannelSignaling, UInt
+
+# Fixed 64-bit seed for the hostmem burst data pattern. WriteMem fills every
+# byte of each element with (seed ^ index) tiled across bytes and XORed with a
+# distinct per-position mask, and ReadMem folds every received byte into a
+# checksum, so the host tests verify the full-width data landed at / was fetched
+# from the right bytes -- independent of the backend's engine word width.
+_ESITESTER_SEQ_SEED = 0x5A5A5A5A5A5A5A5A
 
 # ---------------------------------------------------------------------------
 # Reusable building blocks for timing-friendly MMIO-controlled test modules.
@@ -797,7 +805,9 @@ def ReadMem(width: int):
         Issues a single ``read_list`` burst of 'flits' elements starting at the
         base address (both configured via MMIO) and receives the elements back
         as a windowed list (num_items=1 -> one element per frame). The low 64
-        bits of the most recent element are exported as telemetry (lastReadLSB).
+        bits of the most recent element are exported as telemetry (lastReadLSB),
+        and every byte of every element is folded into a byte-position-sensitive
+        integrity checksum (readChecksum).
 
         MMIO command interface (via BurstCommand):
           0x00  Read : remaining element count (flits_left).
@@ -839,8 +849,10 @@ def ReadMem(width: int):
       )
       # Each received element -> one completion token to BurstCommand.
       done_wire.assign(read_responses.transform(lambda resp: Bits(0)(0)))
-      # Snoop the low 64 bits of each element without consuming it.
-      read_resp_valid_snoop, _, read_resp_data = read_responses.snoop()
+      # Snoop each received element without consuming it.
+      read_resp_valid_snoop, read_resp_data = read_responses.snoop_xact()
+      read_elem = read_resp_data.unwrap()["data"][0]
+      read_elem_lsb = read_elem.as_uint(64)
       last_read_lsb = Reg(
           UInt(64),
           clk=ports.clk,
@@ -849,12 +861,40 @@ def ReadMem(width: int):
           ce=read_resp_valid_snoop,
           name="last_read_lsb",
       )
-      last_read_lsb.assign(read_resp_data.unwrap()["data"][0].as_uint(64))
+      last_read_lsb.assign(read_elem_lsb)
       esi.Telemetry.report_signal(
           ports.clk,
           ports.rst,
           esi.AppID("lastReadLSB"),
           last_read_lsb,
+      )
+      # Byte-position-sensitive integrity checksum over all `width` bits: fold
+      # each 64-bit chunk of the element into 64 bits with a per-chunk rotate
+      # (so word/byte misplacement doesn't cancel), then XOR across elements.
+      num_chunks = (width + 63) // 64
+      elem_fold = Bits(64)(0)
+      for c in range(num_chunks):
+        hi = min(64 * c + 64, width)
+        chunk = read_elem[64 * c:hi]
+        if hi - 64 * c < 64:
+          chunk = chunk.as_uint().as_uint(64).as_bits()
+        r = (8 * c) % 64
+        if r != 0:
+          chunk = BitsSignal.concat([chunk[0:64 - r], chunk[64 - r:64]])
+        elem_fold = elem_fold ^ chunk
+      read_checksum = Wire(UInt(64))
+      read_checksum.assign((read_checksum.as_bits() ^ elem_fold).as_uint().reg(
+          ports.clk,
+          ports.rst,
+          rst_value=0,
+          ce=read_resp_valid_snoop,
+          name="read_checksum",
+      ))
+      esi.Telemetry.report_signal(
+          ports.clk,
+          ports.rst,
+          esi.AppID("readChecksum"),
+          read_checksum,
       )
 
   return ReadMem
@@ -869,7 +909,8 @@ def WriteMem(width: int) -> Type[Module]:
         Issues a single windowed (list) write of 'flits' elements to sequential
         addresses starting at the base address (both configured via MMIO). The
         elements are streamed as a windowed list (num_items=1 -> one element per
-        frame, 'last' on the final); each element's payload is its frame index.
+        frame, 'last' on the final); each element's payload is a byte-level
+        pattern derived from its frame index (see _ESITESTER_SEQ_SEED).
 
         MMIO command interface (via BurstCommand):
           0x00  Read : remaining element count (flits_left).
@@ -945,8 +986,17 @@ def WriteMem(width: int) -> Type[Module]:
               name="streaming",
           ))
 
-      # Data pattern: the frame index (non-0xFF), sized to the element.
-      element = frame_counter.out.as_uint(width).as_bits()
+      # Byte-level data pattern: tile (seed ^ frame index) across the element's
+      # bytes and XOR each byte with a distinct per-position mask so every byte
+      # is unique. A read that fetches the wrong bytes is then caught at byte
+      # granularity by the hostmembw data-integrity check.
+      seq64 = frame_counter.out.as_bits() ^ Bits(64)(_ESITESTER_SEQ_SEED)
+      num_bytes = (width + 7) // 8
+      elem_bytes = [
+          seq64[8 * (j % 8):8 * (j % 8) + 8] ^ Bits(8)((j * 0x9D) & 0xFF)
+          for j in range(num_bytes)
+      ]
+      element = BitsSignal.concat(list(reversed(elem_bytes)))[0:width]
       frame_val = lowered({
           "address": base_addr,
           "tag": UInt(8)(0),
@@ -974,34 +1024,13 @@ def ToHostDMATest(width: int):
     the specified number of times. Exercises any DMA engine."""
 
   class ToHostDMATest(Module):
-    """Transmit a 32-bit cycle counter value to the host a programmed number of times.
+    """Transmit patterned values to the host a programmed number of times.
 
-        Functionality:
-          A free-running 32-bit counter advances only on successful channel
-          handshakes. A write to MMIO offset 0x0 programs 'write_count' (number
-          of messages to send). Each message’s payload is the counter value
-          constrained to 'width':
-            width < 32  -> lower 'width' bits (truncated)
-            width >= 32 -> zero-extended to 'width' bits
-          One message is emitted per handshake until 'write_count' messages have
-          been transferred. A new write to 0x0 re-arms after completion.
-
-        Width:
-          Selects how the 32-bit counter is represented on the output channel
-          (truncate or zero-extend as above).
-
-        MMIO command interface:
-          0x0 Write: Set write_count (messages to transmit). Starts a new
-                    sequence if idle/completed.
-          0x0 Read: Returns constant 0.
-
-        Telemetry:
-          totalWrites (AppID "totalWrites"): Count of messages successfully sent.
-          toHostCycles (AppID "toHostCycles"): Cycle count from write_count programming
-            (start) through completion (inclusive of active cycles).
-
-        Notes:
-          Backpressure governs pacing. Completion when totalWrites == write_count.
+        A write to MMIO offset 0x0 programs `write_count`. Each message carries
+        a byte-level pattern derived from its per-command transfer index (see
+        ``_ESITESTER_SEQ_SEED``). The index advances on a successful channel
+        handshake and resets for every command. The payload's final byte is
+        truncated when `width` is not a multiple of eight.
         """
 
     clk = Clock()
@@ -1014,12 +1043,6 @@ def ToHostDMATest(width: int):
       count_reached = Wire(Bits(1))
       count_valid = Wire(Bits(1))
       out_xact = Wire(Bits(1))
-      cycle_counter = Counter(32)(
-          clk=ports.clk,
-          rst=ports.rst,
-          clear=Bits(1)(0),
-          increment=out_xact,
-      )
 
       write_cntr_incr = ~count_reached & count_valid & out_xact
       write_counter = Counter(32)(
@@ -1059,9 +1082,23 @@ def ToHostDMATest(width: int):
       mmio_rw_cmd_chan = mmio_rw.unpack(data=response_chan)["cmd"]
       cmd_chan_wire.assign(mmio_rw_cmd_chan)
 
-      # Output channel.
+      # Output one byte-level pattern per command transfer. This lets the host
+      # verify the complete payload, including every byte of wide messages.
+      sequence_counter = Counter(64)(
+          clk=ports.clk,
+          rst=ports.rst,
+          clear=write_count_ce,
+          increment=out_xact,
+      )
+      seq64 = sequence_counter.out.as_bits() ^ Bits(64)(_ESITESTER_SEQ_SEED)
+      num_bytes = (width + 7) // 8
+      payload_bytes = [
+          seq64[8 * (j % 8):8 * (j % 8) + 8] ^ Bits(8)((j * 0x9D) & 0xFF)
+          for j in range(num_bytes)
+      ]
+      payload = BitsSignal.concat(list(reversed(payload_bytes)))[0:width]
       out_channel, out_channel_ready = Channel(UInt(width)).wrap(
-          cycle_counter.out.as_uint(width), count_valid)
+          payload.as_uint(width), count_valid)
       out_xact.assign(out_channel_ready & count_valid)
       esi.ChannelService.to_host(name=AppID("out"), chan=out_channel)
 
@@ -1134,6 +1171,8 @@ def FromHostDMATest(width: int):
         Telemetry:
           fromHostCycles (AppID "fromHostCycles"): Cycle count from read_count programming
             (start) through completion of the programmed receive sequence.
+                    fromHostChecksum (AppID "fromHostChecksum"): Byte-position-sensitive
+                        fold of all payloads accepted during the programmed receive sequence.
 
         Notes:
           Completion is when received messages == programmed read_count; another
@@ -1190,6 +1229,41 @@ def FromHostDMATest(width: int):
               ce=in_data_xact,
               name="last_read",
           ))
+
+      # Fold every received payload so the host can verify all transferred
+      # bytes, rather than only the low 64 bits of the final payload.
+      in_bits = in_data.as_bits()
+      num_chunks = (width + 63) // 64
+      item_fold = Bits(64)(0)
+      for c in range(num_chunks):
+        hi = min(64 * c + 64, width)
+        chunk = in_bits[64 * c:hi]
+        if hi - 64 * c < 64:
+          chunk = chunk.as_uint().as_uint(64).as_bits()
+        r = (8 * c) % 64
+        if r != 0:
+          chunk = BitsSignal.concat([chunk[0:64 - r], chunk[64 - r:64]])
+        item_fold = item_fold ^ chunk
+      from_host_checksum = Wire(UInt(64))
+      checksum_next = Mux(
+          read_count_ce,
+          (from_host_checksum.as_bits() ^ item_fold).as_uint(),
+          UInt(64)(0),
+      )
+      from_host_checksum.assign(
+          checksum_next.reg(
+              clk=ports.clk,
+              rst=ports.rst,
+              rst_value=0,
+              ce=read_count_ce | in_data_xact,
+              name="from_host_checksum",
+          ))
+      esi.Telemetry.report_signal(
+          ports.clk,
+          ports.rst,
+          esi.AppID("fromHostChecksum"),
+          from_host_checksum,
+      )
 
       # Cycle telemetry: detect completion and count active cycles.
       fromhost_count_reached = Wire(Bits(1))
@@ -1380,7 +1454,7 @@ class EsiTester(Module):
     for i in range(4, 18, 5):
       MMIOAdd(i)(instance_name=f"mmio_add_{i}", appid=AppID("mmio_add", i))
 
-    for width in [32, 64, 128, 256, 512, 534]:
+    for width in [24, 32, 64, 72, 128, 256, 512, 534]:
       ReadMem(width)(
           instance_name=f"readmem_{width}",
           appid=esi.AppID("readmem", width),

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esitester.py
@@ -1390,13 +1390,13 @@ class EsiTester(Module):
       LoopbackInOutAdd        (single instance) – function service adding constant 11.
       ChannelTest             (single instance) – ChannelService to_host and from_host loopback.
       MMIOAdd(add_amt)        instances for add_amt in {4, 9, 14} – MMIO read returns offset + add_amt.
-      ReadMem(width)          for widths: 32, 64, 128, 256, 512, 534 – host memory read tests.
-      WriteMem(width)         for widths: 32, 64, 128, 256, 512, 534 – host memory write tests.
-      ToHostDMATest(width)    for widths: 32, 64, 128, 256, 512, 534 – DMA to host, cycle & count telemetry.
-      FromHostDMATest(width)  for widths: 32, 64, 128, 256, 512, 534 – DMA from host, cycle telemetry.
+      ReadMem(width)          for widths: 24, 32, 64, 72, 128, 256, 512, 534 – host memory read tests.
+      WriteMem(width)         for widths: 24, 32, 64, 72, 128, 256, 512, 534 – host memory write tests.
+      ToHostDMATest(width)    for widths: 24, 32, 64, 72, 128, 256, 512, 534 – DMA to host, cycle & count telemetry.
+      FromHostDMATest(width)  for widths: 24, 32, 64, 72, 128, 256, 512, 534 – DMA from host, cycle telemetry.
 
     Width set used across Read/Write/DMA tests:
-      widths = [32, 64, 128, 256, 512, 534]
+      widths = [24, 32, 64, 72, 128, 256, 512, 534]
 
     Purpose:
       Aggregates all functional, MMIO, host memory, and DMA tests into one image

--- a/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
@@ -102,13 +102,22 @@ class TestCosimEsitester:
 
   def test_telemetry(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"
-    stdout = run_cmd(["esiquery", "cosim", conn, "telemetry"])
+    result = subprocess.run(
+        ["esiquery", "cosim", conn, "telemetry"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    stdout = result.stdout
     check_lines(stdout, [
         "* Telemetry",
+        "fromhostdma[32].fromHostChecksum: 0",
         "fromhostdma[32].fromHostCycles: 0",
         "readmem[32].addrCmdIssued: 0",
         "readmem[32].addrCmdResponses: 0",
         "readmem[32].lastReadLSB: 0",
+        "readmem[32].readChecksum: 0",
         "tohostdma[32].toHostCycles: 0",
         "tohostdma[32].totalWrites: 0",
         "writemem[32].addrCmdIssued: 0",
@@ -247,16 +256,30 @@ class TestCosimEsitesterDma:
     # Aggregate bandwidth across the width-512 readmem*/writemem* units
     # (4 read + 4 write), exercising the multi-unit nested-AppID resolution
     # (mmio[width]/cmd and addrCmdResp/cycles) of the burst modules.
-    run_cmd([
-        "esitester", "cosim", conn, "aggbandwidth", "--width", "512", "-r",
-        "-w", "-c", "64"
-    ])
+    result = subprocess.run(
+        [
+            "esitester", "cosim", conn, "aggbandwidth", "--width", "512", "-r",
+            "-w", "-c", "64"
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
   def test_telemetry(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"
-    stdout = run_cmd(["esiquery", "cosim", conn, "telemetry"])
+    result = subprocess.run(
+        ["esiquery", "cosim", conn, "telemetry"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    stdout = result.stdout
     check_lines(stdout, [
         "* Telemetry",
+        "fromhostdma[32].fromHostChecksum: 0",
         "fromhostdma[32].fromHostCycles: 0",
         "tohostdma[32].toHostCycles: 0",
     ])

--- a/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_esitester.py
@@ -179,24 +179,66 @@ class TestCosimEsitesterDma:
 
   def test_dma(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"
-    run_cmd(["esitester", "cosim", conn, "dma", "-w", "-r"])
+    result = subprocess.run(
+        ["esitester", "cosim", conn, "dma", "-w", "-r"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+  def test_bandwidth_data_integrity(self, host: str, port: int) -> None:
+    """Verify complete engine payloads in both transfer directions."""
+    conn = f"{host}:{port}"
+    result = subprocess.run(
+        [
+            "esitester",
+            "cosim",
+            conn,
+            "bandwidth",
+            "-w",
+            "-r",
+            "--check-data",
+            "--widths",
+            "24",
+            "64",
+            "534",
+            "--count",
+            "24",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
   def test_hostmembw(self, host: str, port: int) -> None:
     conn = f"{host}:{port}"
-    # A 1000-element read burst at 32 bits (8 bytes/element) is 8000 bytes,
-    # which exceeds the PCIe maximum read request size and so exercises the
-    # read-request splitter. Capture stderr too and assert the runtime never
-    # sees an oversized (unsplit) read request.
+    # Widths chosen to cover every element-vs-engine-word relationship the read
+    # gearbox must unpack from a contiguous, byte-packed layout: 24 (sub-word,
+    # does not divide the 64-bit engine word), 32 (sub-word divisor), 72
+    # (wider than the word, not a multiple -> straddles words), and 128 (a whole
+    # number of words). A 1000-element 24-bit read burst is 3000 bytes, which
+    # exceeds the PCIe maximum read request size and so exercises the
+    # read-request splitter. The -w/-r data-integrity checks verify each element
+    # landed at / was fetched from the right bytes.
     result = subprocess.run(
         [
-            "esitester", "cosim", conn, "hostmembw", "-w", "-r", "-c", "1000",
-            "--widths", "32", "128"
+            "esitester",
+            "cosim",
+            conn,
+            "hostmembw",
+            "-w",
+            "-r",
+            "-c",
+            "1000",
         ],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
     )
     combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
     assert "exceeds the PCIe maximum read request size" not in combined, \
         combined
 


### PR DESCRIPTION
The read gearboxes used in BSPs were designed for single-frame messages -- not for lists. So if a list element was smaller than the transport size, it would not be correctly transmitted to the hardware.

This changes to 4 different read gearboxes: 1 generic but inefficient one and 3 specialized ones. The generic one relies on a shifter so it can handle any alignment. The three specializations are for cases where a non-list message is being transmitted (either sliced or concatenated) and the case where the output type is aligned to the transport width.

Assisted-by: Github-Copilot:Claude Opus 4.8

