### PR TITLE
[BMC] Run PrepareForBMC in circt-bmc

### DIFF
--- a/integration_test/circt-bmc/system-verilog.sv
+++ b/integration_test/circt-bmc/system-verilog.sv
@@ -1,0 +1,20 @@
+// REQUIRES: slang
+// REQUIRES: libz3
+// REQUIRES: circt-bmc-jit
+// UNSUPPORTED: valgrind
+// RUN: circt-verilog %s --top=Top | circt-bmc - --module Top -b 1 --shared-libs=%libz3 --print-only-first-counterexample | FileCheck %s
+
+// CHECK: counterexample for Top:
+// CHECK: cycle 0:
+// CHECK: Assertion can be violated!
+
+module Top(
+    input logic clk,
+    input logic data,
+    output logic sampled
+);
+  always_ff @(posedge clk)
+    sampled <= data;
+
+  assert property (@(posedge clk) data);
+endmodule

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -269,6 +269,9 @@ static LogicalResult executeBMC(MLIRContext &context) {
         {verif::SymbolicValueLowering::HWInput}));
   }
   pm.addNestedPass<hw::HWModuleOp>(createLowerLTLToCorePass());
+  PrepareForBMCOptions prepareForBMCOptions;
+  prepareForBMCOptions.topModule = moduleName;
+  pm.addPass(createPrepareForBMC(prepareForBMCOptions));
   pm.addNestedPass<hw::HWModuleOp>(verif::createCombineAssertLikePass());
   pm.addPass(createMaterializeDebugVariables());
   pm.addPass(createExternalizeRegisters());


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

This adds the `PrepareForBMC` pass to the `circt-bmc` lowering pipeline.

This allows SystemVerilog designs containing clocked assertions to be lowered with `circt-verilog` and piped into `circt-bmc`:

  ```sh
  circt-verilog input.sv --top=Top | \
    circt-bmc - --module=Top -b=10 --shared-libs=/path/to/libz3
```

Assisted-by:codex:gpt-5.6-sol(high)