### PR TITLE
[LLHD][UnrollLoops] Unroll nested loops with dependent bounds

### DIFF
--- a/lib/Dialect/LLHD/Transforms/UnrollLoops.cpp
+++ b/lib/Dialect/LLHD/Transforms/UnrollLoops.cpp
@@ -433,9 +433,10 @@ void UnrollLoopsPass::runOnOperation() {
 
 void UnrollLoopsPass::runOnOperation(CombinationalOp op) {
   // Unrolling a loop may open up opportunities to unroll its nested loops.
-  // Iterate until all possible loops are unrolled.
-  while (unrollLoops(op))
-    ;
+  // Iterate until all possible loops are unrolled or the limit is reached.
+  for (unsigned i = 0; i < 16; ++i)
+    if (!unrollLoops(op))
+      break;
 }
 
 bool UnrollLoopsPass::unrollLoops(CombinationalOp op) {

--- a/lib/Dialect/LLHD/Transforms/UnrollLoops.cpp
+++ b/lib/Dialect/LLHD/Transforms/UnrollLoops.cpp
@@ -422,6 +422,7 @@ struct UnrollLoopsPass
     : public llhd::impl::UnrollLoopsPassBase<UnrollLoopsPass> {
   void runOnOperation() override;
   void runOnOperation(CombinationalOp op);
+  bool unrollLoops(CombinationalOp op);
 };
 } // namespace
 
@@ -431,10 +432,17 @@ void UnrollLoopsPass::runOnOperation() {
 }
 
 void UnrollLoopsPass::runOnOperation(CombinationalOp op) {
+  // Unrolling a loop may open up opportunities to unroll its nested loops.
+  // Iterate until all possible loops are unrolled.
+  while (unrollLoops(op))
+    ;
+}
+
+bool UnrollLoopsPass::unrollLoops(CombinationalOp op) {
   // There's nothing to do if we only have a single block. MLIR even refuses to
   // compute a dominator tree in that case.
   if (op.getBody().hasOneBlock())
-    return;
+    return false;
 
   // Find the loops.
   LLVM_DEBUG(llvm::dbgs() << "Unrolling loops in " << op.getLoc() << "\n");
@@ -446,6 +454,7 @@ void UnrollLoopsPass::runOnOperation(CombinationalOp op) {
   // data structure for each loop we can potentially unroll. The loops are in
   // preorder, with outer loops appearing before their child loops.
   SmallVector<Loop> loops;
+  bool retry = false;
   for (auto *cfgLoop : cfgLoopInfo.getLoopsInPreorder()) {
     // To simplify unrolling we need a unique latch block branching back to the
     // header.
@@ -482,12 +491,19 @@ void UnrollLoopsPass::runOnOperation(CombinationalOp op) {
     }
 
     // Check if the loop body matches the pattern we can unroll.
-    if (loop.match())
+    if (loop.match()) {
       loops.push_back(std::move(loop));
+      continue;
+    }
+
+    // If an enclosing loop is unrolled, we retry the unrolling.
+    retry |= llvm::any_of(loops, [&](const Loop &other) {
+      return other.cfgLoop.contains(cfgLoop);
+    });
   }
 
   if (loops.empty())
-    return;
+    return false;
 
   // Dump some debugging information about the loops we've found.
   LLVM_DEBUG({
@@ -516,4 +532,6 @@ void UnrollLoopsPass::runOnOperation(CombinationalOp op) {
   // their parent loops.
   for (auto &loop : llvm::reverse(loops))
     loop.unroll(cfgLoopInfo);
+
+  return retry;
 }

--- a/lib/Dialect/LLHD/Transforms/UnrollLoops.cpp
+++ b/lib/Dialect/LLHD/Transforms/UnrollLoops.cpp
@@ -363,19 +363,25 @@ void Loop::unroll(CFGLoopInfo &cfgLoopInfo) {
   exitEdge = nullptr;
 
   // Prune any body blocks that have become unreachable.
-  SmallPtrSet<Block *, 8> blocksToPrune;
-  for (auto *block : cfgLoop.getBlocks())
-    if (block->use_empty())
-      blocksToPrune.insert(block);
-  while (!blocksToPrune.empty()) {
-    auto *block = *blocksToPrune.begin();
-    blocksToPrune.erase(block);
-    if (!block->use_empty())
+  auto &region = *header->getParent();
+  SmallPtrSet<Block *, 8> reachable;
+  SmallVector<Block *> worklist;
+  reachable.insert(&region.front());
+  worklist.push_back(&region.front());
+  while (!worklist.empty())
+    for (auto *succ : worklist.pop_back_val()->getSuccessors())
+      if (reachable.insert(succ).second)
+        worklist.push_back(succ);
+
+  SmallVector<Block *> deadBlocks;
+  for (auto &block : region) {
+    if (reachable.contains(&block))
       continue;
-    for (auto *succ : block->getSuccessors())
-      if (cfgLoop.contains(succ))
-        blocksToPrune.insert(succ);
-    block->dropAllDefinedValueUses();
+    block.dropAllDefinedValueUses();
+    deadBlocks.push_back(&block);
+  }
+
+  for (auto *block : deadBlocks) {
     cfgLoopInfo.removeBlock(block);
     block->erase();
   }

--- a/test/Dialect/LLHD/Transforms/unroll-loops.mlir
+++ b/test/Dialect/LLHD/Transforms/unroll-loops.mlir
@@ -525,3 +525,39 @@ hw.module @LoopWithUlt() {
     llhd.yield
   }
 }
+
+// CHECK-LABEL: @NestedLoopWithNonConstantInnerBound
+hw.module @NestedLoopWithNonConstantInnerBound(in %a: i42, out x : i42) {
+  %c0_i42 = hw.constant 0 : i42
+  %c1_i42 = hw.constant 1 : i42
+  %c2_i42 = hw.constant 2 : i42
+  // Loop of the form:
+  //   x = 0
+  //   for (i = 0; i < 2; ++i)
+  //     for (j = i; j < 2; ++j)
+  //       x += a
+  %0 = llhd.combinational -> i42 {
+    // CHECK: cf.br
+    // CHECK: cf.cond_br
+    // CHECK: cf.cond_br
+    // CHECK-NOT: cf.cond_br
+    // CHECK: llhd.yield
+    cf.br ^outerHeader(%c0_i42, %c0_i42, %a : i42, i42, i42)
+  ^outerHeader(%i: i42, %x1: i42, %a1: i42):
+    %1 = comb.icmp ult %i, %c2_i42 : i42
+    cf.cond_br %1, ^innerHeader(%i, %x1, %a1 : i42, i42, i42), ^outerExit
+  ^innerHeader(%j: i42, %x2: i42, %a2: i42):
+    %2 = comb.icmp ult %j, %c2_i42 : i42
+    cf.cond_br %2, ^innerBody, ^innerExit
+  ^innerBody:
+    %xp = comb.add %x2, %a2 : i42
+    %jp = comb.add %j, %c1_i42 : i42
+    cf.br ^innerHeader(%jp, %xp, %a2 : i42, i42, i42)
+  ^innerExit:
+    %ip = comb.add %i, %c1_i42 : i42
+    cf.br ^outerHeader(%ip, %x2, %a2 : i42, i42, i42)
+  ^outerExit:
+    llhd.yield %x1 : i42
+  }
+  hw.output %0 : i42
+}

--- a/test/Dialect/LLHD/Transforms/unroll-loops.mlir
+++ b/test/Dialect/LLHD/Transforms/unroll-loops.mlir
@@ -537,11 +537,13 @@ hw.module @NestedLoopWithNonConstantInnerBound(in %a: i42, out x : i42) {
   //     for (j = i; j < 2; ++j)
   //       x += a
   %0 = llhd.combinational -> i42 {
-    // CHECK: cf.br
-    // CHECK: cf.cond_br
-    // CHECK: cf.cond_br
     // CHECK-NOT: cf.cond_br
-    // CHECK: llhd.yield
+    // CHECK: [[X1:%.+]] = comb.add
+    // CHECK-NEXT: [[X2:%.+]] = comb.add [[X1]],
+    // CHECK-NOT: cf.cond_br
+    // CHECK: [[X3:%.+]] = comb.add
+    // CHECK-NOT: cf.cond_br
+    // CHECK: llhd.yield [[X3]]
     cf.br ^outerHeader(%c0_i42, %c0_i42, %a : i42, i42, i42)
   ^outerHeader(%i: i42, %x1: i42, %a1: i42):
     %1 = comb.icmp ult %i, %c2_i42 : i42


### PR DESCRIPTION
For this example, the pass crashes instead of unrolling the inner body three times, because the cleanup does not prune the cyclic unreachable blocks left behind by the unrolling and then tries to replace a block argument in the cycle with itself:

```
module nested_loop(input logic a_i, output logic z_o);
  always_comb begin
    z_o = 1'b1;
    for (int unsigned i = 0; i < 2; i++)
      for (int unsigned j = i; j < 2; j++)
        z_o = a_i;
  end
endmodule
```

Remove all unreachable blocks instead of only unused ones to fix the crash.
Rerun the unrolling if an unrolled loop contains a non-unrolled one, since unrolling may turn its bounds into constants.

Assisted by: vscode:Claude Opus 5