### PR TITLE
[OM] Address post-commit review of #10969

### DIFF
--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -207,7 +207,7 @@ LogicalResult verifyResult(ClassOp module, bool allowUnevaluated) {
         // The message is supposed to be fully evaluated at this point, though
         // it could be unknown.
         auto messageOp =
-            dyn_cast<ConstantOp>(assertOp.getMessage().getDefiningOp());
+            dyn_cast_or_null<ConstantOp>(assertOp.getMessage().getDefiningOp());
         if (!messageOp) {
           if (allowUnevaluated)
             return op->emitError("OM property assertion failed: <unevaluated>");

--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -220,8 +220,13 @@ LogicalResult verifyResult(ClassOp module, bool allowUnevaluated) {
           return failure();
         }
 
-        auto message = cast<StringAttr>(messageOp.getValue()).getValue();
-        return op->emitError("OM property assertion failed: ") << message;
+        StringAttr message;
+        if (!matchPattern(assertOp.getMessage(), m_Constant(&message)))
+          return op->emitError()
+                 << "OM property assertion failed, but no message is available "
+                    "because the message is not a constant string";
+        return op->emitError("OM property assertion failed: ")
+               << message.getValue();
       };
 
       // Condition is a constant integer/bool - check if it's true.

--- a/test/Dialect/OM/elaborate-object-errors-unevaluated.mlir
+++ b/test/Dialect/OM/elaborate-object-errors-unevaluated.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -om-elaborate-object='all-public-classes=true allow-unevaluated=true' %s -verify-diagnostics -split-input-file
+// RUN: circt-opt -om-elaborate-object='all-public-classes=true allow-unevaluated=true' %s -verify-diagnostics -split-input-file -allow-unregistered-dialect
 
 om.class @UnevaluatedMessage() {
   %0 = om.unknown : !om.string
@@ -13,6 +13,16 @@ om.class @UnevaluatedMessage() {
 om.class @BlockArgMessage(%msg: !om.string) {
   %false = om.constant false
   // expected-error @below {{OM property assertion failed: <unevaluated>}}
+  om.property_assert %false, %msg : i1
+  om.class.fields
+}
+
+// -----
+
+om.class @NonConstantMessage() {
+  %false = om.constant false
+  %msg = om.constant #hw.param.verbatim<"P"> : !om.string
+  // expected-error @below {{OM property assertion failed, but no message is available because the message is not a constant string}}
   om.property_assert %false, %msg : i1
   om.class.fields
 }

--- a/test/Dialect/OM/elaborate-object-errors-unevaluated.mlir
+++ b/test/Dialect/OM/elaborate-object-errors-unevaluated.mlir
@@ -7,3 +7,12 @@ om.class @UnevaluatedMessage() {
   om.property_assert %1, %0 : i1
   om.class.fields
 }
+
+// -----
+
+om.class @BlockArgMessage(%msg: !om.string) {
+  %false = om.constant false
+  // expected-error @below {{OM property assertion failed: <unevaluated>}}
+  om.property_assert %false, %msg : i1
+  om.class.fields
+}


### PR DESCRIPTION
Address review comments from @dtzSiFive on #10969.

This fixes one trivially missed situation that could cause a crash if an
assertion message of a trivially false assertion is used as a message.  The
second is a funkier actual edge case involving an `om.constant` that presents as
being an `!om.string` type but does not actually have a `StringAttr` that you
can use.

See the individual commits for more detail.
