### PR TITLE
[AXI4] Add abstract endpoint ops

### DIFF
--- a/include/circt/Dialect/AXI4/AXI4Ops.h
+++ b/include/circt/Dialect/AXI4/AXI4Ops.h
@@ -9,9 +9,34 @@
 #ifndef CIRCT_DIALECT_AXI4_AXI4OPS_H
 #define CIRCT_DIALECT_AXI4_AXI4OPS_H
 
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 
 #include "circt/Dialect/AXI4/AXI4Dialect.h"
+#include "circt/Dialect/AXI4/AXI4Types.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
+
+namespace circt {
+namespace axi4 {
+namespace OpTrait {
+/// Constrains an op's `!axi4.port` results to at most one use each
+template <typename ConcreteType>
+class PortResultsAtMostOneUse
+    : public mlir::OpTrait::TraitBase<ConcreteType, PortResultsAtMostOneUse> {
+public:
+  static llvm::LogicalResult verifyTrait(mlir::Operation *op) {
+    for (mlir::Value result : op->getResults())
+      if (mlir::isa<PortType>(result.getType()) && result.hasNUsesOrMore(2))
+        return op->emitOpError(
+            "port result must have at most one use; route through an "
+            "'axi4.xbar' to fan out to multiple endpoints");
+    return mlir::success();
+  }
+};
+} // namespace OpTrait
+} // namespace axi4
+} // namespace circt
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/AXI4/AXI4.h.inc"

--- a/include/circt/Dialect/AXI4/AXI4Ops.td
+++ b/include/circt/Dialect/AXI4/AXI4Ops.td
@@ -14,12 +14,54 @@
 #define CIRCT_DIALECT_AXI4_AXI4OPS_TD
 
 include "circt/Dialect/AXI4/AXI4Dialect.td"
+include "circt/Dialect/AXI4/AXI4Types.td"
+include "circt/Dialect/Seq/SeqTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 // Base class for the operations in this dialect.
 class AXI4Op<string mnemonic, list<Trait> traits = []> :
     Op<AXI4Dialect, mnemonic, traits>;
 
-// Operations will be added here.
+// Constrains each `!axi4.port` result to at most one use
+def PortResultsAtMostOneUse : NativeOpTrait<"PortResultsAtMostOneUse"> {
+  let cppNamespace = "::circt::axi4::OpTrait";
+}
+
+def AbstractManagerOp : AXI4Op<"abstract_manager", [PortResultsAtMostOneUse]> {
+  let summary = "A stand-alone AXI4 manager endpoint";
+  let description = [{
+    Models a manager endpoint with no concrete implementation, for abstract
+    network modelling. Returns the `!axi4.port` it drives.
+
+    Example:
+    ```mlir
+    %mgr = axi4.abstract_manager %clk, %rst_ni : !axi4.port<...>
+    ```
+  }];
+
+  let arguments = (ins ClockType:$clock, I1:$reset);
+  let results = (outs PortType:$port);
+
+  let assemblyFormat =
+      "$clock `,` $reset attr-dict `:` qualified(type($port))";
+}
+
+def AbstractSubordinateOp : AXI4Op<"abstract_subordinate"> {
+  let summary = "A stand-alone AXI4 subordinate endpoint";
+  let description = [{
+    Models a subordinate endpoint with no concrete implementation, for abstract
+    network modelling. Takes the upstream `!axi4.port` it responds to.
+
+    Example:
+    ```mlir
+    axi4.abstract_subordinate %clk, %rst_ni, %mgr : !axi4.port<...>
+    ```
+  }];
+
+  let arguments = (ins ClockType:$clock, I1:$reset, PortType:$upstream);
+
+  let assemblyFormat =
+      "$clock `,` $reset `,` $upstream attr-dict `:` qualified(type($upstream))";
+}
 
 #endif // CIRCT_DIALECT_AXI4_AXI4OPS_TD

--- a/lib/Dialect/AXI4/CMakeLists.txt
+++ b/lib/Dialect/AXI4/CMakeLists.txt
@@ -11,5 +11,6 @@ add_circt_dialect_library(CIRCTAXI4
   Support
 
   LINK_LIBS PUBLIC
+  CIRCTSeq
   MLIRIR
 )

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -77,3 +77,17 @@
 // Check fields may be given in any order, and are printed in a canonical one
 // CHECK: !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
 "test.port"() : () -> !axi4.port<outstanding_reads = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, data_width = 64, user_width = 0, addr_width = 32, outstanding_writes = 4, read_id_width = 4, write_id_width = 4>
+
+//===----------------------------------------------------------------------===//
+// Operations
+//===----------------------------------------------------------------------===//
+
+!port = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// CHECK-LABEL: hw.module @AbstractEndpoints
+hw.module @AbstractEndpoints(in %clk : !seq.clock, in %rst_ni : i1) {
+  // CHECK: %[[MGR:.+]] = axi4.abstract_manager %clk, %rst_ni {a} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+  %mgr = axi4.abstract_manager %clk, %rst_ni {a} : !port
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[MGR]] {b} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+  axi4.abstract_subordinate %clk, %rst_ni, %mgr {b} : !port
+}

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -92,3 +92,14 @@
 
 // expected-error @below {{port 'outstanding_reads' must be at most 4 for a 'read_id_width' of 2, got 5}}
 "test.port"() : () -> !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 2, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 5>
+
+// -----
+
+!port = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+hw.module @Fanout(in %clk : !seq.clock, in %rst_ni : i1) {
+  // expected-error @below {{'axi4.abstract_manager' op port result must have at most one use; route through an 'axi4.xbar' to fan out to multiple endpoints}}
+  %mgr = axi4.abstract_manager %clk, %rst_ni : !port
+  axi4.abstract_subordinate %clk, %rst_ni, %mgr : !port
+  axi4.abstract_subordinate %clk, %rst_ni, %mgr : !port
+}


### PR DESCRIPTION
Adds abstract manager and subordinate ops for modelling an AXI4 network without concrete RTL endpoint implementations (while still being explicit about clock/reset domains). Also introduces a to-be-heavily-used trait that !axi4.port results of an op are used only once (as we don't want to connect a port to multiple things without a crossbar in the middle, or we end up with duplicated requests).
 
AI-assisted-by: Claude Opus 5 (1M context)

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>