### PR TITLE
[AXI4] Add channel struct conversion ops

### DIFF
--- a/include/circt/Dialect/AXI4/AXI4Ops.td
+++ b/include/circt/Dialect/AXI4/AXI4Ops.td
@@ -15,6 +15,7 @@
 
 include "circt/Dialect/AXI4/AXI4Dialect.td"
 include "circt/Dialect/AXI4/AXI4Types.td"
+include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/Seq/SeqTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -26,6 +27,22 @@ class AXI4Op<string mnemonic, list<Trait> traits = []> :
 def PortResultsAtMostOneUse : NativeOpTrait<"PortResultsAtMostOneUse"> {
   let cppNamespace = "::circt::axi4::OpTrait";
 }
+
+// Constrain an argument to the hw representation of a given AXI channel
+class PayloadMatches<string channel, string arg> : TypesMatchWith<
+    channel # " payload matches the port type", "port", arg,
+    "::circt::axi4::getChannelPayloadType("
+      "::llvm::cast<::circt::axi4::PortType>($_self), "
+      "::circt::axi4::AXI4Channel::" # channel # ")">;
+
+// Ordered list of AXI4 channels
+defvar axi4Channels = ["AW", "W", "B", "AR", "R"];
+
+// Base class for the ops bridging an !axi4.port and its hw channel structs,
+// with automatic struct type enforcement
+class AXI4ChannelStructOp<string mnemonic, list<Trait> traits = []> :
+    AXI4Op<mnemonic, !listconcat(traits,
+        !foreach(c, axi4Channels, PayloadMatches<c, !tolower(c)>))>;
 
 def AbstractManagerOp : AXI4Op<"abstract_manager", [PortResultsAtMostOneUse]> {
   let summary = "A stand-alone AXI4 manager endpoint";
@@ -62,6 +79,82 @@ def AbstractSubordinateOp : AXI4Op<"abstract_subordinate"> {
 
   let assemblyFormat =
       "$clock `,` $reset `,` $upstream attr-dict `:` qualified(type($upstream))";
+}
+
+def ChannelStructsToPortOp : AXI4ChannelStructOp<"channel_structs_to_port",
+    [PortResultsAtMostOneUse]> {
+  let summary = "Converts a HW expression of an AXI4 interface to a port";
+  let description = [{
+    Bridges from a HW dialect expression of an AXI4 interface to an
+    `!axi4.port`. Takes the AW, W and AR channel payloads and valids, and the B
+    and R readys; returns the port along with the AW, W and AR readys and the B
+    and R payloads and valids.
+
+    Example:
+    ```mlir
+    %port, %aw_ready, %w_ready, %b, %b_valid, %ar_ready, %r, %r_valid =
+      axi4.channel_structs_to_port %clk, %rst_ni
+        aw %aw, %aw_valid w %w, %w_valid b %b_ready
+        ar %ar, %ar_valid r %r_ready
+      : !axi4.port<...>
+    ```
+  }];
+
+  let arguments = (ins ClockType:$clock, I1:$reset,
+                       StructType:$aw, I1:$aw_valid,
+                       StructType:$w, I1:$w_valid,
+                       I1:$b_ready,
+                       StructType:$ar, I1:$ar_valid,
+                       I1:$r_ready);
+  let results = (outs PortType:$port,
+                      I1:$aw_ready, I1:$w_ready,
+                      StructType:$b, I1:$b_valid,
+                      I1:$ar_ready,
+                      StructType:$r, I1:$r_valid);
+
+  let assemblyFormat = [{
+    $clock `,` $reset
+      `aw` $aw `,` $aw_valid `w` $w `,` $w_valid `b` $b_ready
+      `ar` $ar `,` $ar_valid `r` $r_ready
+      attr-dict `:` qualified(type($port))
+  }];
+}
+
+def PortToChannelStructsOp : AXI4ChannelStructOp<"port_to_channel_structs"> {
+  let summary = "Converts an AXI4 port to a HW expression of an AXI4 interface";
+  let description = [{
+    Bridges from an `!axi4.port` to a HW dialect expression of an AXI4
+    interface. Takes the port, the AW, W and AR channel readys, and the B and R
+    payloads and valids; returns the AW, W and AR payloads and valids, and the
+    B and R readys.
+
+    Example:
+    ```mlir
+    %aw, %aw_valid, %w, %w_valid, %b_ready, %ar, %ar_valid, %r_ready =
+      axi4.port_to_channel_structs %clk, %rst_ni, %port
+        aw %aw_ready w %w_ready b %b, %b_valid
+        ar %ar_ready r %r, %r_valid
+      : !axi4.port<...>
+    ```
+  }];
+
+  let arguments = (ins ClockType:$clock, I1:$reset, PortType:$port,
+                       I1:$aw_ready, I1:$w_ready,
+                       StructType:$b, I1:$b_valid,
+                       I1:$ar_ready,
+                       StructType:$r, I1:$r_valid);
+  let results = (outs StructType:$aw, I1:$aw_valid,
+                      StructType:$w, I1:$w_valid,
+                      I1:$b_ready,
+                      StructType:$ar, I1:$ar_valid,
+                      I1:$r_ready);
+
+  let assemblyFormat = [{
+    $clock `,` $reset `,` $port
+      `aw` $aw_ready `w` $w_ready `b` $b `,` $b_valid
+      `ar` $ar_ready `r` $r `,` $r_valid
+      attr-dict `:` qualified(type($port))
+  }];
 }
 
 #endif // CIRCT_DIALECT_AXI4_AXI4OPS_TD

--- a/include/circt/Dialect/AXI4/AXI4Types.h
+++ b/include/circt/Dialect/AXI4/AXI4Types.h
@@ -11,9 +11,34 @@
 
 #include "circt/Dialect/AXI4/AXI4Attributes.h"
 #include "circt/Dialect/AXI4/AXI4Dialect.h"
+#include "circt/Dialect/HW/HWTypes.h"
 #include "mlir/IR/Types.h"
 
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/AXI4/AXI4Types.h.inc"
+
+namespace circt {
+namespace axi4 {
+
+/// The five AXI4 channels.
+enum class AXI4Channel { AW, W, B, AR, R };
+
+// Fixed AXI4 field widths (bits).
+constexpr unsigned kLenWidth = 8;
+constexpr unsigned kSizeWidth = 3;
+constexpr unsigned kBurstWidth = 2;
+constexpr unsigned kLockWidth = 1;
+constexpr unsigned kCacheWidth = 4;
+constexpr unsigned kProtWidth = 3;
+constexpr unsigned kQosWidth = 4;
+constexpr unsigned kRegionWidth = 4;
+constexpr unsigned kRespWidth = 2;
+constexpr unsigned kLastWidth = 1;
+
+/// Build the `hw.struct` payload type for one channel of an `!axi4.port`.
+hw::StructType getChannelPayloadType(PortType port, AXI4Channel channel);
+
+} // namespace axi4
+} // namespace circt
 
 #endif // CIRCT_DIALECT_AXI4_AXI4TYPES_H

--- a/lib/Dialect/AXI4/AXI4Types.cpp
+++ b/lib/Dialect/AXI4/AXI4Types.cpp
@@ -53,6 +53,54 @@ LogicalResult PortType::verify(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
+hw::StructType axi4::getChannelPayloadType(PortType port, AXI4Channel channel) {
+  MLIRContext *ctx = port.getContext();
+  auto field = [&](StringRef name, unsigned width) {
+    return hw::StructType::FieldInfo{StringAttr::get(ctx, name),
+                                     IntegerType::get(ctx, width)};
+  };
+  // Address channels differ only in which ID width they carry.
+  auto addressFields = [&](unsigned idWidth) {
+    return SmallVector<hw::StructType::FieldInfo>{
+        field("id", idWidth),
+        field("addr", port.getAddrWidth()),
+        field("len", kLenWidth),
+        field("size", kSizeWidth),
+        field("burst", kBurstWidth),
+        field("lock", kLockWidth),
+        field("cache", kCacheWidth),
+        field("prot", kProtWidth),
+        field("qos", kQosWidth),
+        field("region", kRegionWidth),
+        field("user", port.getUserWidth())};
+  };
+
+  SmallVector<hw::StructType::FieldInfo> fields;
+  switch (channel) {
+  case AXI4Channel::AW:
+    fields = addressFields(port.getWriteIdWidth());
+    break;
+  case AXI4Channel::AR:
+    fields = addressFields(port.getReadIdWidth());
+    break;
+  case AXI4Channel::W:
+    fields = {field("data", port.getDataWidth()),
+              field("strb", port.getDataWidth() / 8), field("last", kLastWidth),
+              field("user", port.getUserWidth())};
+    break;
+  case AXI4Channel::B:
+    fields = {field("id", port.getWriteIdWidth()), field("resp", kRespWidth),
+              field("user", port.getUserWidth())};
+    break;
+  case AXI4Channel::R:
+    fields = {field("id", port.getReadIdWidth()),
+              field("data", port.getDataWidth()), field("resp", kRespWidth),
+              field("last", kLastWidth), field("user", port.getUserWidth())};
+    break;
+  }
+  return hw::StructType::get(ctx, fields);
+}
+
 void AXI4Dialect::registerTypes() {
   addTypes<
 #define GET_TYPEDEF_LIST

--- a/lib/Dialect/AXI4/CMakeLists.txt
+++ b/lib/Dialect/AXI4/CMakeLists.txt
@@ -11,6 +11,7 @@ add_circt_dialect_library(CIRCTAXI4
   Support
 
   LINK_LIBS PUBLIC
+  CIRCTHW
   CIRCTSeq
   MLIRIR
 )

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -82,12 +82,46 @@
 // Operations
 //===----------------------------------------------------------------------===//
 
-!port = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!port = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// Typedefs for port channel structs
+!aw = !hw.struct<id: i5, addr: i32, len: i8, size: i3, burst: i2, lock: i1, cache: i4, prot: i3, qos: i4, region: i4, user: i4>
+!w = !hw.struct<data: i64, strb: i8, last: i1, user: i4>
+!ar = !hw.struct<id: i3, addr: i32, len: i8, size: i3, burst: i2, lock: i1, cache: i4, prot: i3, qos: i4, region: i4, user: i4>
+!b = !hw.struct<id: i5, resp: i2, user: i4>
+!r = !hw.struct<id: i3, data: i64, resp: i2, last: i1, user: i4>
 
 // CHECK-LABEL: hw.module @AbstractEndpoints
 hw.module @AbstractEndpoints(in %clk : !seq.clock, in %rst_ni : i1) {
-  // CHECK: %[[MGR:.+]] = axi4.abstract_manager %clk, %rst_ni {a} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+  // CHECK: %[[MGR:.+]] = axi4.abstract_manager %clk, %rst_ni {a} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
   %mgr = axi4.abstract_manager %clk, %rst_ni {a} : !port
-  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[MGR]] {b} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[MGR]] {b} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
   axi4.abstract_subordinate %clk, %rst_ni, %mgr {b} : !port
+}
+
+// CHECK-LABEL: hw.module @Subordinate
+hw.module @Subordinate(in %clk : !seq.clock, in %rst_ni : i1,
+                       in %aw : !aw, in %aw_valid : i1,
+                       in %w : !w, in %w_valid : i1,
+                       in %b_ready : i1,
+                       in %ar : !ar, in %ar_valid : i1,
+                       in %r_ready : i1) {
+  // CHECK: %port, %aw_ready, %w_ready, %b, %b_valid, %ar_ready, %r, %r_valid = axi4.channel_structs_to_port %clk, %rst_ni aw %aw, %aw_valid w %w, %w_valid b %b_ready ar %ar, %ar_valid r %r_ready : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+  %port, %aw_ready, %w_ready, %b, %b_valid, %ar_ready, %r, %r_valid =
+    axi4.channel_structs_to_port %clk, %rst_ni
+      aw %aw, %aw_valid w %w, %w_valid b %b_ready
+      ar %ar, %ar_valid r %r_ready : !port
+}
+
+// CHECK-LABEL: hw.module @Manager
+hw.module @Manager(in %clk : !seq.clock, in %rst_ni : i1, in %port : !port,
+                   in %aw_ready : i1, in %w_ready : i1,
+                   in %b : !b, in %b_valid : i1,
+                   in %ar_ready : i1,
+                   in %r : !r, in %r_valid : i1) {
+  // CHECK: %aw, %aw_valid, %w, %w_valid, %b_ready, %ar, %ar_valid, %r_ready = axi4.port_to_channel_structs %clk, %rst_ni, %port aw %aw_ready w %w_ready b %b, %b_valid ar %ar_ready r %r, %r_valid : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+  %aw, %aw_valid, %w, %w_valid, %b_ready, %ar, %ar_valid, %r_ready =
+    axi4.port_to_channel_structs %clk, %rst_ni, %port
+      aw %aw_ready w %w_ready b %b, %b_valid
+      ar %ar_ready r %r, %r_valid : !port
 }

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -103,3 +103,27 @@ hw.module @Fanout(in %clk : !seq.clock, in %rst_ni : i1) {
   axi4.abstract_subordinate %clk, %rst_ni, %mgr : !port
   axi4.abstract_subordinate %clk, %rst_ni, %mgr : !port
 }
+
+// -----
+
+hw.module @NotAPort(in %clk : !seq.clock, in %rst_ni : i1,
+                    in %s : !hw.struct<a: i4>, in %v : i1) {
+  // expected-error @below {{'port' must be an AXI4 port interface, but got 'i32'}}
+  %port, %aw_ready, %w_ready, %b, %b_valid, %ar_ready, %r, %r_valid = axi4.channel_structs_to_port %clk, %rst_ni aw %s, %v w %s, %v b %v ar %s, %v r %v : i32
+  hw.output
+}
+
+// -----
+
+!port = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!bad_aw = !hw.struct<id: i4, addr: i16, len: i8, size: i3, burst: i2, lock: i1, cache: i4, prot: i3, qos: i4, region: i4, user: i0>
+!w = !hw.struct<data: i64, strb: i8, last: i1, user: i0>
+!b = !hw.struct<id: i4, resp: i2, user: i0>
+!r = !hw.struct<id: i4, data: i64, resp: i2, last: i1, user: i0>
+
+hw.module @BadPayload(in %clk : !seq.clock, in %rst_ni : i1,
+                      in %aw : !bad_aw, in %w : !w, in %v : i1) {
+  // expected-error @below {{'axi4.channel_structs_to_port' op failed to verify that AW payload matches the port type}}
+  %port, %aw_ready, %w_ready, %b, %b_valid, %ar_ready, %r, %r_valid = "axi4.channel_structs_to_port"(%clk, %rst_ni, %aw, %v, %w, %v, %v, %aw, %v, %v) : (!seq.clock, i1, !bad_aw, i1, !w, i1, i1, !bad_aw, i1, i1) -> (!port, i1, i1, !b, i1, i1, !r, i1)
+  hw.output
+}


### PR DESCRIPTION
This adds the glue ops that convert between wires (specifically packaged in !hw.structs) and the abstract !axi4.port type. Although this is strictly a combinational transformation, they take clock and reset operands so we can infer domains and ensure there are no illegal crossings - hopefully some day as CIRCT domain infrastructure evolves we might be able to move those into the type.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>