### PR TITLE
[ImportVerilog] Save the source text of the assert/assume/cover statements.

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -933,15 +933,29 @@ struct StmtVisitor {
       else if (stmt.isDeferred)
         defer = moore::DeferAssert::Observed;
 
+      // Extract the source text of the assert/assume/cover condition.
+      StringAttr label{};
+      auto srcRange = stmt.cond.sourceRange;
+      if (srcRange.start().valid() && srcRange.end().valid() &&
+          srcRange.start().buffer() == srcRange.end().buffer()) {
+        auto srcText =
+            context.sourceManager.getSourceText(srcRange.start().buffer());
+        auto start = srcRange.start().offset();
+        auto end = srcRange.end().offset();
+        if (start < end && end <= srcText.size())
+          label = StringAttr::get(context.getContext(),
+                                  srcText.substr(start, end - start));
+      }
+
       switch (stmt.assertionKind) {
       case slang::ast::AssertionKind::Assert:
-        moore::AssertOp::create(builder, loc, defer, cond, StringAttr{});
+        moore::AssertOp::create(builder, loc, defer, cond, label);
         return success();
       case slang::ast::AssertionKind::Assume:
-        moore::AssumeOp::create(builder, loc, defer, cond, StringAttr{});
+        moore::AssumeOp::create(builder, loc, defer, cond, label);
         return success();
       case slang::ast::AssertionKind::CoverProperty:
-        moore::CoverOp::create(builder, loc, defer, cond, StringAttr{});
+        moore::CoverOp::create(builder, loc, defer, cond, label);
         return success();
       default:
         break;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -2642,7 +2642,7 @@ module ImmediateAssert(input clk);
     // CHECK: [[READ_CLK:%.+]] = moore.read [[CLK]] : <l1>
     // CHECK: [[OneBX:%.+]] = moore.constant bX : l1
     // CHECK: [[NE:%.+]] = moore.ne [[READ_CLK]], [[OneBX]] : l1 -> l1
-    // CHECK: moore.assert immediate [[NE]] : l1
+    // CHECK: moore.assert immediate [[NE]] label "clk != 1'bx" : l1
   always_comb begin
     assert (clk != 1'bx);
   end
@@ -2650,14 +2650,14 @@ module ImmediateAssert(input clk);
   // CHECK: moore.procedure always_comb
     // CHECK: [[C100:%.+]] = moore.constant 100 : i32
     // CHECK: [[BC:%.+]] = moore.bool_cast [[C100]] : i32 -> i1
-    // CHECK: moore.assume observed [[BC]] : i1
+    // CHECK: moore.assume observed [[BC]] label "100" : i1
   always_comb begin
     assume #0 (100);
   end
 
   // CHECK: moore.procedure always_comb
     // CHECK: [[READ_A:%.+]] = moore.read [[A]] : <i1>
-    // CHECK: moore.cover final [[READ_A]] : i1
+    // CHECK: moore.cover final [[READ_A]] label "a" : i1
   always_comb begin
     cover final (a);
   end
@@ -2725,7 +2725,7 @@ module ImmediateAssertiWithActionBlock;
   // CHECK:func.func private @check([[ARG:%.*]]: !moore.l32) {
   // CHECK:  [[C0:%.+]] = moore.constant 0 : l32
   // CHECK:  [[COND:%.+]] = moore.ugt [[ARG]], [[C0]] : l32 -> l1
-  // CHECK:  moore.assert immediate [[COND]] : l1
+  // CHECK:  moore.assert immediate [[COND]] label "w > 0" : l1
   function automatic void check(logic[31:0] w);
     assert (w > 0);
   endfunction


### PR DESCRIPTION
Extract and save the source text of the assert/assume/cover statements when translating from systemverilog to moore.