### PR TITLE
[AXI4] Add xbar op

### DIFF
--- a/include/circt/Dialect/AXI4/AXI4Attributes.td
+++ b/include/circt/Dialect/AXI4/AXI4Attributes.td
@@ -109,6 +109,12 @@ def BurstSetAttr : AXI4AttrDef<"BurstSet"> {
       return $_get($_ctxt, merged);
     }]>
   ];
+
+  let extraClassDeclaration = [{
+    /// Whether every spec in `other` has a spec of its kind, and at least its
+    /// length, in this set
+    bool covers(BurstSetAttr other);
+  }];
 }
 
 def WindowAttr : AXI4AttrDef<"Window"> {
@@ -130,6 +136,11 @@ def WindowAttr : AXI4AttrDef<"Window"> {
   }];
 
   let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// Whether this window and `other` share any address
+    bool overlaps(WindowAttr other);
+  }];
 }
 
 def WindowSetAttr : AXI4AttrDef<"WindowSet"> {
@@ -168,6 +179,9 @@ def WindowSetAttr : AXI4AttrDef<"WindowSet"> {
     /// ordered and uniqued set of disjoint windows
     static ::llvm::SmallVector<WindowAttr>
     normalize(::mlir::MLIRContext *ctx, ::llvm::ArrayRef<WindowAttr> windows);
+
+    /// Whether any window in this set overlaps any window in `other`
+    bool overlaps(WindowSetAttr other);
   }];
 }
 

--- a/include/circt/Dialect/AXI4/AXI4Ops.td
+++ b/include/circt/Dialect/AXI4/AXI4Ops.td
@@ -170,4 +170,31 @@ def PortToChannelStructsOp : AXI4ChannelStructOp<"port_to_channel_structs"> {
   }];
 }
 
+def XbarOp : AXI4Op<"xbar", [PortResultsAtMostOneUse]> {
+  let summary = "An AXI4 crossbar interconnect";
+  let description = [{
+    Routes the requests of a set of upstream managers onto a set of downstream
+    subordinates. Every address a manager can issue to must be covered by
+    exactly one downstream port, which must support at least the bursts the
+    manager issues there.
+
+    Example:
+    ```mlir
+    %mem, %periph = axi4.xbar %clk, %rst_ni mgrs %core, %debug
+      : (!core_mgr, !debug_mgr) -> (!mem_sub, !periph_sub)
+    ```
+  }];
+
+  let arguments = (ins ClockType:$clock, I1:$reset,
+                       Variadic<PortType>:$upstream);
+  let results = (outs Variadic<PortType>:$downstream);
+
+  let assemblyFormat = [{
+    $clock `,` $reset `mgrs` $upstream attr-dict `:`
+      functional-type($upstream, $downstream)
+  }];
+
+  let hasVerifier = 1;
+}
+
 #endif // CIRCT_DIALECT_AXI4_AXI4OPS_TD

--- a/lib/Dialect/AXI4/AXI4Attributes.cpp
+++ b/lib/Dialect/AXI4/AXI4Attributes.cpp
@@ -64,6 +64,16 @@ LogicalResult BurstSetAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
+bool BurstSetAttr::covers(BurstSetAttr other) {
+  // A `len` is a maximum, so a spec covers every shorter one of its kind
+  return llvm::all_of(other.getBurstSpecs(), [&](BurstSpecAttr required) {
+    return llvm::any_of(getBurstSpecs(), [&](BurstSpecAttr spec) {
+      return spec.getKind() == required.getKind() &&
+             spec.getLen() >= required.getLen();
+    });
+  });
+}
+
 LogicalResult WindowAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                                  uint64_t base, uint64_t last,
                                  BurstSetAttr burstSpecs) {
@@ -73,6 +83,10 @@ LogicalResult WindowAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                        << " must not be less than 'base' address 0x"
                        << llvm::utohexstr(base, /*LowerCase=*/true);
   return success();
+}
+
+bool WindowAttr::overlaps(WindowAttr other) {
+  return getBase() <= other.getLast() && other.getBase() <= getLast();
 }
 
 SmallVector<WindowAttr> WindowSetAttr::normalize(MLIRContext *ctx,
@@ -126,6 +140,23 @@ WindowSetAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   if (windows.empty())
     return emitError() << "'window_set' must be non-empty";
   return success();
+}
+
+bool WindowSetAttr::overlaps(WindowSetAttr other) {
+  // Both sets contain sorted windows, so we know a window that doesn't overlap
+  // the current one and ends first can't overlap anything later either
+  ArrayRef<WindowAttr> windows = getWindows();
+  ArrayRef<WindowAttr> otherWindows = other.getWindows();
+  for (size_t i = 0, j = 0; i < windows.size() && j < otherWindows.size();) {
+    WindowAttr window = windows[i], otherWindow = otherWindows[j];
+    if (window.overlaps(otherWindow))
+      return true;
+    if (window.getLast() < otherWindow.getLast())
+      ++i;
+    else
+      ++j;
+  }
+  return false;
 }
 
 void AXI4Dialect::registerAttributes() {

--- a/lib/Dialect/AXI4/AXI4Ops.cpp
+++ b/lib/Dialect/AXI4/AXI4Ops.cpp
@@ -11,9 +11,201 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/AXI4/AXI4Ops.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace circt;
 using namespace axi4;
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// XbarOp
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// A width field of a port type, named for diagnostics.
+struct WidthField {
+  llvm::StringLiteral name;
+  uint32_t (PortType::*get)() const;
+};
+} // namespace
+
+// The port width fields, the ones an xbar carries through unchanged first,
+// followed by the ID widths it widens.
+static constexpr WidthField kWidths[] = {
+    {"addr_width", &PortType::getAddrWidth},
+    {"data_width", &PortType::getDataWidth},
+    {"user_width", &PortType::getUserWidth},
+    {"write_id_width", &PortType::getWriteIdWidth},
+    {"read_id_width", &PortType::getReadIdWidth}};
+static constexpr size_t kNumSharedWidths = 3;
+
+/// Verify that `port` agrees with `reference` on each of the widths in
+/// `fields`.
+static LogicalResult verifyWidthsMatch(XbarOp op, ArrayRef<WidthField> fields,
+                                       PortType port, const Twine &portDesc,
+                                       PortType reference,
+                                       const Twine &referenceDesc) {
+  for (const WidthField &field : fields) {
+    uint32_t width = (port.*field.get)();
+    uint32_t expected = (reference.*field.get)();
+    if (width != expected)
+      return op.emitOpError()
+             << portDesc << "'s '" << field.name << "' (" << width
+             << ") must match " << referenceDesc << "'s (" << expected << ")";
+  }
+  return success();
+}
+
+/// The downstream port and window covering `address`, or a null window if no
+/// downstream port covers it.
+static std::pair<size_t, WindowAttr> findDownstreamWindow(ValueRange downstream,
+                                                          uint64_t address) {
+  for (auto [i, value] : llvm::enumerate(downstream))
+    for (WindowAttr window :
+         cast<PortType>(value.getType()).getWindows().getWindows())
+      if (window.getBase() <= address && address <= window.getLast())
+        return {i, window};
+  return {0, {}};
+}
+
+//===----------------------------------------------------------------------===//
+// Outstanding request helpers
+//===----------------------------------------------------------------------===//
+
+/// The outstanding writes and reads a routing op sends down `downstream`, from
+/// the `upstream` ports whose windows reach it.
+static std::pair<uint64_t, uint64_t>
+routingOutstandingBelow(ValueRange upstream, PortType downstream) {
+  uint64_t writes = 0, reads = 0;
+  for (Value value : upstream) {
+    auto manager = cast<PortType>(value.getType());
+    if (!manager.getWindows().overlaps(downstream.getWindows()))
+      continue;
+    writes += manager.getOutstandingWrites();
+    reads += manager.getOutstandingReads();
+  }
+  return {writes, reads};
+}
+
+/// Verify that `port` holds exactly the outstanding requests reaching it.
+static LogicalResult verifyOutstanding(Operation *op, const Twine &portDesc,
+                                       PortType port,
+                                       std::pair<uint64_t, uint64_t> reaching,
+                                       const Twine &sourceDesc) {
+  auto [writes, reads] = reaching;
+  if (port.getOutstandingWrites() != writes)
+    return op->emitOpError() << portDesc << "'s 'outstanding_writes' ("
+                             << port.getOutstandingWrites() << ") must be the "
+                             << writes << " writes " << sourceDesc;
+  if (port.getOutstandingReads() != reads)
+    return op->emitOpError() << portDesc << "'s 'outstanding_reads' ("
+                             << port.getOutstandingReads() << ") must be the "
+                             << reads << " reads " << sourceDesc;
+  return success();
+}
+
+LogicalResult XbarOp::verify() {
+  ValueRange upstream = getUpstream();
+  ValueRange downstream = getDownstream();
+  if (upstream.empty())
+    return emitOpError("must have at least one upstream port");
+  if (downstream.empty())
+    return emitOpError("must have at least one downstream port");
+
+  // Make sure all upstream ports agree on widths
+  auto upstreamTy = cast<PortType>(upstream.front().getType());
+  for (auto [i, value] : llvm::enumerate(upstream.drop_front()))
+    if (failed(verifyWidthsMatch(
+            *this, kWidths, cast<PortType>(value.getType()),
+            "upstream port #" + Twine(i + 1), upstreamTy, "upstream port #0")))
+      return failure();
+
+  // Each manager's transactions are tagged with its index downstream.
+  uint32_t idBits = llvm::Log2_64_Ceil(upstream.size());
+
+  // Make sure all downstream ports agree on address, data, and user widths
+  for (auto [i, value] : llvm::enumerate(downstream)) {
+    auto downstreamTy = cast<PortType>(value.getType());
+    if (failed(verifyWidthsMatch(
+            *this, ArrayRef(kWidths).take_front(kNumSharedWidths), downstreamTy,
+            "downstream port #" + Twine(i), upstreamTy, "upstream port #0")))
+      return failure();
+
+    // Make sure downstream ports are wide enough to uniquely tag transactions
+    // from upstream ports.
+    for (const WidthField &field :
+         ArrayRef(kWidths).drop_front(kNumSharedWidths)) {
+      uint32_t least = (upstreamTy.*field.get)() + idBits;
+      if ((downstreamTy.*field.get)() < least)
+        return emitOpError()
+               << "downstream port #" << i << "'s '" << field.name
+               << "' must be at least " << least << " to tag transactions from "
+               << upstream.size() << " managers, got "
+               << (downstreamTy.*field.get)();
+    }
+  }
+
+  // Downstream windows must not overlap (so routing is unambiguous)
+  for (auto [i, value] : llvm::enumerate(downstream)) {
+    auto windows = cast<PortType>(value.getType()).getWindows();
+    for (auto [j, other] : llvm::enumerate(downstream.take_front(i)))
+      if (windows.overlaps(cast<PortType>(other.getType()).getWindows()))
+        return emitOpError() << "downstream ports #" << j << " and #" << i
+                             << " have overlapping windows";
+  }
+
+  // Every window a manager can access must be routed downstream, to a port
+  // supporting at least the bursts the manager issues there.
+  // We've already verified no overlap, so we can just check the existence of a
+  // supporting window.
+  for (auto [i, value] : llvm::enumerate(upstream)) {
+    auto managerTy = cast<PortType>(value.getType());
+    for (WindowAttr window : managerTy.getWindows().getWindows()) {
+      // Walk through addresses, skipping the ones we know are covered
+      // Begin at the window's start
+      for (uint64_t address = window.getBase();;) {
+        // Make sure it's supported
+        auto [j, covering] = findDownstreamWindow(downstream, address);
+        if (!covering)
+          return emitOpError()
+                 << "address 0x" << llvm::utohexstr(address, /*LowerCase=*/true)
+                 << ", in upstream port #" << i
+                 << "'s windows, is not covered by any downstream port";
+        if (!covering.getBurstSpecs().covers(window.getBurstSpecs()))
+          return emitOpError()
+                 << "downstream port #" << j
+                 << " does not support all the bursts upstream port #" << i
+                 << " issues at address 0x"
+                 << llvm::utohexstr(address, /*LowerCase=*/true)
+                 << "; upstream requires " << window.getBurstSpecs()
+                 << ", downstream supports " << covering.getBurstSpecs();
+        // If we know that every remaining address in the upstream window is
+        // covered by this downstream window, we're done
+        if (covering.getLast() >= window.getLast())
+          break;
+        // Otherwise, skip ahead to the next address that we don't already know
+        // is covered (the address directly after the end of the covering
+        // downstream window)
+        address = covering.getLast() + 1;
+      }
+    }
+  }
+
+  // Which managers reach a port follows from the windows, so this needs them
+  // checked first.
+  for (auto [i, value] : llvm::enumerate(downstream)) {
+    auto downstreamTy = cast<PortType>(value.getType());
+    if (failed(verifyOutstanding(
+            *this, "downstream port #" + Twine(i), downstreamTy,
+            routingOutstandingBelow(upstream, downstreamTy),
+            "the managers reaching it can issue")))
+      return failure();
+  }
+
+  return success();
+}
 
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -130,3 +130,62 @@ hw.module @Manager(in %clk : !seq.clock, in %rst_ni : i1, in %port : !port,
       ar %ar_ready r %r, %r_valid
       concurrent_writes 2 concurrent_reads 3 : !port
 }
+
+// Typedefs for two managers sharing three subordinates
+!mgr1 = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>, <base = 0x2000, last = 0x2fff, burst_specs = <<fixed, len = 4>>>, <base = 0x4000, last = 0x4fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!mgr2 = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>
+!sub1 = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 5, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 6, outstanding_reads = 6>
+!sub2 = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 5, user_width = 0, windows = <<base = 0x2000, last = 0x2fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!sub3 = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 5, user_width = 0, windows = <<base = 0x4000, last = 0x4fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+// CHECK-LABEL: hw.module @Crossbar
+hw.module @Crossbar(in %clk : !seq.clock, in %rst_ni : i1) {
+  // CHECK: %[[MGR1:.+]] = axi4.abstract_manager
+  %mgr1 = axi4.abstract_manager %clk, %rst_ni : !mgr1
+  // CHECK: %[[MGR2:.+]] = axi4.abstract_manager
+  %mgr2 = axi4.abstract_manager %clk, %rst_ni : !mgr2
+  // CHECK: %[[XBAR:.+]]:3 = axi4.xbar %clk, %rst_ni mgrs %[[MGR1]], %[[MGR2]] : (!axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>, <base = 0x2000, last = 0x2fff, burst_specs = <<fixed, len = 4>>>, <base = 0x4000, last = 0x4fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>, !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>) -> (!axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 5, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 6, outstanding_reads = 6>, !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 5, user_width = 0, windows = <<base = 0x2000, last = 0x2fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>, !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 5, user_width = 0, windows = <<base = 0x4000, last = 0x4fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>)
+  %sub1, %sub2, %sub3 = axi4.xbar %clk, %rst_ni mgrs %mgr1, %mgr2
+    : (!mgr1, !mgr2) -> (!sub1, !sub2, !sub3)
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[XBAR]]#0 concurrent_writes 6 concurrent_reads 6 :
+  axi4.abstract_subordinate %clk, %rst_ni, %sub1 concurrent_writes 6 concurrent_reads 6 : !sub1
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[XBAR]]#1 concurrent_writes 4 concurrent_reads 4 :
+  axi4.abstract_subordinate %clk, %rst_ni, %sub2 concurrent_writes 4 concurrent_reads 4 : !sub2
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[XBAR]]#2 concurrent_writes 4 concurrent_reads 4 :
+  axi4.abstract_subordinate %clk, %rst_ni, %sub3 concurrent_writes 4 concurrent_reads 4 : !sub3
+}
+
+// Typedefs for a manager whose window is split across two subordinates
+!split_mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0x1fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>
+!split_lo = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>
+!split_hi = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x1000, last = 0x1fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>
+
+// Check a single manager needs no additional ID bits, and that its windows need
+// not line up with the downstream ones
+// CHECK-LABEL: hw.module @SplitWindow
+hw.module @SplitWindow(in %clk : !seq.clock, in %rst_ni : i1) {
+  // CHECK: %[[MGR:.+]] = axi4.abstract_manager
+  %mgr = axi4.abstract_manager %clk, %rst_ni : !split_mgr
+  // CHECK: %[[XBAR:.+]]:2 = axi4.xbar %clk, %rst_ni mgrs %[[MGR]] : (!axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0x1fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>) -> (!axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>, !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x1000, last = 0x1fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>)
+  %lo, %hi = axi4.xbar %clk, %rst_ni mgrs %mgr : (!split_mgr) -> (!split_lo, !split_hi)
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[XBAR]]#0 concurrent_writes 2 concurrent_reads 2 :
+  axi4.abstract_subordinate %clk, %rst_ni, %lo concurrent_writes 2 concurrent_reads 2 : !split_lo
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[XBAR]]#1 concurrent_writes 2 concurrent_reads 2 :
+  axi4.abstract_subordinate %clk, %rst_ni, %hi concurrent_writes 2 concurrent_reads 2 : !split_hi
+}
+
+// Typedefs for a manager whose subordinate takes longer bursts than it issues
+!short_mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<incr, len = 4>>>>, outstanding_writes = 2, outstanding_reads = 2>
+!long_sub = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<incr, len = 16>>>>, outstanding_writes = 2, outstanding_reads = 2>
+
+// Check a 'len' is a maximum, so a subordinate may take longer bursts than the
+// manager issues
+// CHECK-LABEL: hw.module @LongerBurstSubordinate
+hw.module @LongerBurstSubordinate(in %clk : !seq.clock, in %rst_ni : i1) {
+  // CHECK: %[[MGR:.+]] = axi4.abstract_manager
+  %mgr = axi4.abstract_manager %clk, %rst_ni : !short_mgr
+  // CHECK: %[[XBAR:.+]] = axi4.xbar %clk, %rst_ni mgrs %[[MGR]]
+  %sub = axi4.xbar %clk, %rst_ni mgrs %mgr : (!short_mgr) -> !long_sub
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[XBAR]] concurrent_writes 2 concurrent_reads 2 :
+  axi4.abstract_subordinate %clk, %rst_ni, %sub concurrent_writes 2 concurrent_reads 2 : !long_sub
+}

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -127,3 +127,108 @@ hw.module @BadPayload(in %clk : !seq.clock, in %rst_ni : i1,
   %port, %aw_ready, %w_ready, %b, %b_valid, %ar_ready, %r, %r_valid = "axi4.channel_structs_to_port"(%clk, %rst_ni, %aw, %v, %w, %v, %v, %aw, %v, %v) : (!seq.clock, i1, !bad_aw, i1, !w, i1, i1, !bad_aw, i1, i1) -> (!port, i1, i1, !b, i1, i1, !r, i1)
   hw.output
 }
+
+// -----
+
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+hw.module @NoManagers(in %clk : !seq.clock, in %rst_ni : i1) {
+  // expected-error @below {{'axi4.xbar' op must have at least one upstream port}}
+  %sub = axi4.xbar %clk, %rst_ni mgrs : () -> !mgr
+}
+
+// -----
+
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+hw.module @NoSubordinates(in %clk : !seq.clock, in %rst_ni : i1) {
+  %mgr = axi4.abstract_manager %clk, %rst_ni : !mgr
+  // expected-error @below {{'axi4.xbar' op must have at least one downstream port}}
+  axi4.xbar %clk, %rst_ni mgrs %mgr : (!mgr) -> ()
+}
+
+// -----
+
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!narrow_mgr = !axi4.port<addr_width = 32, data_width = 32, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!sub = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 5, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 8, outstanding_reads = 8>
+
+hw.module @MismatchedManagers(in %clk : !seq.clock, in %rst_ni : i1) {
+  %a = axi4.abstract_manager %clk, %rst_ni : !mgr
+  %b = axi4.abstract_manager %clk, %rst_ni : !narrow_mgr
+  // expected-error @below {{'axi4.xbar' op upstream port #1's 'data_width' (32) must match upstream port #0's (64)}}
+  %sub = axi4.xbar %clk, %rst_ni mgrs %a, %b : (!mgr, !narrow_mgr) -> !sub
+}
+
+// -----
+
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!wide_sub = !axi4.port<addr_width = 32, data_width = 128, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+hw.module @ConvertingXbar(in %clk : !seq.clock, in %rst_ni : i1) {
+  %mgr = axi4.abstract_manager %clk, %rst_ni : !mgr
+  // expected-error @below {{'axi4.xbar' op downstream port #0's 'data_width' (128) must match upstream port #0's (64)}}
+  %sub = axi4.xbar %clk, %rst_ni mgrs %mgr : (!mgr) -> !wide_sub
+}
+
+// -----
+
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!sub = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 5, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 8, outstanding_reads = 8>
+
+hw.module @NarrowIds(in %clk : !seq.clock, in %rst_ni : i1) {
+  %a = axi4.abstract_manager %clk, %rst_ni : !mgr
+  %b = axi4.abstract_manager %clk, %rst_ni : !mgr
+  // expected-error @below {{'axi4.xbar' op downstream port #0's 'write_id_width' must be at least 5 to tag transactions from 2 managers, got 4}}
+  %sub = axi4.xbar %clk, %rst_ni mgrs %a, %b : (!mgr, !mgr) -> !sub
+}
+
+// -----
+
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0x1fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!sub = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0x1fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!other_sub = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x1000, last = 0x2fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+hw.module @OverlappingSubordinates(in %clk : !seq.clock, in %rst_ni : i1) {
+  %mgr = axi4.abstract_manager %clk, %rst_ni : !mgr
+  // expected-error @below {{'axi4.xbar' op downstream ports #0 and #1 have overlapping windows}}
+  %a, %b = axi4.xbar %clk, %rst_ni mgrs %mgr : (!mgr) -> (!sub, !other_sub)
+}
+
+// -----
+
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0x1fff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!sub = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+hw.module @UnroutedWindow(in %clk : !seq.clock, in %rst_ni : i1) {
+  %mgr = axi4.abstract_manager %clk, %rst_ni : !mgr
+  // expected-error @below {{'axi4.xbar' op address 0x1000, in upstream port #0's windows, is not covered by any downstream port}}
+  %sub = axi4.xbar %clk, %rst_ni mgrs %mgr : (!mgr) -> !sub
+}
+
+// -----
+
+// Check a window strictly inside a downstream one still has its bursts checked
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xff, burst_specs = <<fixed, len = 4>, <incr, len = 8>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!sub = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+
+hw.module @UnsupportedBurst(in %clk : !seq.clock, in %rst_ni : i1) {
+  %mgr = axi4.abstract_manager %clk, %rst_ni : !mgr
+  // expected-error @below {{'axi4.xbar' op downstream port #0 does not support all the bursts upstream port #0 issues at address 0x0; upstream requires #axi4.burst_set<<fixed, len = 4>, <incr, len = 8>>, downstream supports #axi4.burst_set<<fixed, len = 4>>}}
+  %sub = axi4.xbar %clk, %rst_ni mgrs %mgr : (!mgr) -> !sub
+}
+
+// -----
+
+// A downstream port should have the total number of concurrent requests that
+// could be sent by all the managers that can reach it
+!mgr = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 4, read_id_width = 4, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+!sub = !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 5, user_width = 0, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 8>
+
+hw.module @UndersizedXbarPort(in %clk : !seq.clock, in %rst_ni : i1) {
+  %a = axi4.abstract_manager %clk, %rst_ni : !mgr
+  %b = axi4.abstract_manager %clk, %rst_ni : !mgr
+  // expected-error @below {{'axi4.xbar' op downstream port #0's 'outstanding_writes' (4) must be the 8 writes the managers reaching it can issue}}
+  %sub = axi4.xbar %clk, %rst_ni mgrs %a, %b : (!mgr, !mgr) -> !sub
+}
+


### PR DESCRIPTION
Adds an operation representing a crossbar, with some verifiers to make sure the routing between upstream and downstream endpoints is sensible (e.g., downstream addresses don't overlap, all addresses requestable upstream are supported by a downstream endpoint, etc.)

AI-assisted-by: Claude Opus 5 (1M context)


<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>