### PR TITLE
[Datapath] Detecting Repeated Extension Bits to Simplify Compress Operations

### DIFF
--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -149,6 +149,39 @@ static inline ZextByMatcher<SubType> m_ZextBy(const SubType &subExpr) {
   return ZextByMatcher<SubType>(subExpr);
 }
 
+// Check if the operand has a replicated extension and return the extension
+// bits:
+// ext = comb.replicate(bit, width-baseWidth)
+// replExt = comb.concat(ext, baseValue_1, ...)
+template <typename SubType>
+struct ReplExtMatcher {
+  SubType lhs;
+  ReplExtMatcher(SubType lhs) : lhs(std::move(lhs)) {}
+  bool match(Operation *op) {
+    auto concatOp = dyn_cast<ConcatOp>(op);
+    if (!concatOp)
+      return false;
+
+    auto operands = concatOp.getOperands();
+    if (operands.size() < 2)
+      return false;
+
+    auto replicateOp = operands[0].getDefiningOp<ReplicateOp>();
+    if (!replicateOp ||
+        replicateOp.getInput().getType().getIntOrFloatBitWidth() != 1)
+      return false;
+
+    // Match the most significant argument of the concat.
+    return mlir::detail::matchOperandOrValueAtIndex(op, 0, lhs);
+  }
+};
+
+/// Helper function to create a replicated extension matcher.
+template <typename SubType>
+static inline ReplExtMatcher<SubType> m_ReplExt(const SubType &subExpr) {
+  return ReplExtMatcher<SubType>(subExpr);
+}
+
 // Check if the operand is sext() and return the extension bits:
 // signBit = comb.extract(baseValue, width-1, 1)
 // ext = comb.replicate(signBit, width-baseWidth)

--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -151,7 +151,7 @@ static inline ZextByMatcher<SubType> m_ZextBy(const SubType &subExpr) {
 
 // Check if the operand has a replicated extension and return the extension
 // bits:
-// ext = comb.replicate(bit, width-baseWidth)
+// ext = comb.replicate(bit, width-baseWidth) or hw.constant -1
 // replExt = comb.concat(ext, baseValue_1, ...)
 template <typename SubType>
 struct ReplExtMatcher {
@@ -167,8 +167,12 @@ struct ReplExtMatcher {
       return false;
 
     auto replicateOp = operands[0].getDefiningOp<ReplicateOp>();
-    if (!replicateOp ||
-        replicateOp.getInput().getType().getIntOrFloatBitWidth() != 1)
+    auto constOp = operands[0].getDefiningOp<hw::ConstantOp>();
+    bool isBitReplicate =
+        replicateOp &&
+        replicateOp.getInput().getType().getIntOrFloatBitWidth() == 1;
+    bool isAllOnes = constOp && constOp.getValue().isAllOnes();
+    if (!isBitReplicate && !isAllOnes)
       return false;
 
     // Match the most significant argument of the concat.

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -134,7 +134,7 @@ struct DatapathPartialProductOpConversion : OpRewritePattern<PartialProductOp> {
   using OpRewritePattern<PartialProductOp>::OpRewritePattern;
 
   DatapathPartialProductOpConversion(MLIRContext *context, bool forceBooth)
-      : OpRewritePattern<PartialProductOp>(context), forceBooth(forceBooth) {};
+      : OpRewritePattern<PartialProductOp>(context), forceBooth(forceBooth){};
 
   const bool forceBooth;
 
@@ -498,7 +498,7 @@ struct DatapathPosPartialProductOpConversion
 
   DatapathPosPartialProductOpConversion(MLIRContext *context, bool forceBooth)
       : OpRewritePattern<PosPartialProductOp>(context),
-        forceBooth(forceBooth) {};
+        forceBooth(forceBooth){};
 
   const bool forceBooth;
 

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -281,7 +281,7 @@ private:
       }
 
       for (unsigned j = i + 1; j < width; ++j) {
-        // Stop when we reach the required width 
+        // Stop when we reach the required width
         if (rowWidth == width)
           break;
 

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -134,7 +134,7 @@ struct DatapathPartialProductOpConversion : OpRewritePattern<PartialProductOp> {
   using OpRewritePattern<PartialProductOp>::OpRewritePattern;
 
   DatapathPartialProductOpConversion(MLIRContext *context, bool forceBooth)
-      : OpRewritePattern<PartialProductOp>(context), forceBooth(forceBooth){};
+      : OpRewritePattern<PartialProductOp>(context), forceBooth(forceBooth) {};
 
   const bool forceBooth;
 
@@ -498,7 +498,7 @@ struct DatapathPosPartialProductOpConversion
 
   DatapathPosPartialProductOpConversion(MLIRContext *context, bool forceBooth)
       : OpRewritePattern<PosPartialProductOp>(context),
-        forceBooth(forceBooth){};
+        forceBooth(forceBooth) {};
 
   const bool forceBooth;
 

--- a/lib/Conversion/DatapathToComb/DatapathToComb.cpp
+++ b/lib/Conversion/DatapathToComb/DatapathToComb.cpp
@@ -281,7 +281,7 @@ private:
       }
 
       for (unsigned j = i + 1; j < width; ++j) {
-        // Stop when we reach the required width
+        // Stop when we reach the required width 
         if (rowWidth == width)
           break;
 

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -253,8 +253,7 @@ struct SextCompress : public OpRewritePattern<CompressOp> {
       auto correctionBit = isSext ? baseWidth - 1 : baseWidth;
       auto base = comb::ExtractOp::create(rewriter, op.getLoc(), input, 0,
                                           correctionBit);
-      Value repeatedBit;
-      repeatedBit = comb::ExtractOp::create(rewriter, op.getLoc(), input,
+      Value repeatedBit = comb::ExtractOp::create(rewriter, op.getLoc(), input,
                                             correctionBit, 1);
       auto invRepeatedBit =
           comb::createOrFoldNot(rewriter, op.getLoc(), repeatedBit, true);

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -41,27 +41,6 @@ static FailureOr<size_t> calculateNonZeroBits(Value operand,
   return nonZeroBits;
 }
 
-// This pattern commonly arrises when inverting zext: ~zext(x) = {1,...1, ~x}
-// Check if the operand is {ones, base} and return the unextended operand:
-static FailureOr<Value> isOneExt(Value operand) {
-  // Check if operand is a concat operation
-  auto concatOp = operand.getDefiningOp<comb::ConcatOp>();
-  if (!concatOp)
-    return failure();
-
-  auto operands = concatOp.getOperands();
-  // ConcatOp must have exactly 2 operands
-  if (operands.size() != 2)
-    return failure();
-
-  APInt value;
-  if (matchPattern(operands[0], m_ConstantInt(&value)) && value.isAllOnes())
-    // Return the base unextended value
-    return success(operands[1]);
-
-  return failure();
-}
-
 // zext(input<<trailingZeros) to targetWidth
 static Value zeroPad(PatternRewriter &rewriter, Location loc, Value input,
                      size_t targetWidth, size_t trailingZeros) {
@@ -305,58 +284,6 @@ struct SextCompress : public OpRewritePattern<CompressOp> {
   }
 };
 
-// compress(..., oneExt(x),...) ->
-// compress(..., zext(x), (-1) << (width(x)-1), ...)
-// Justification:
-//           {1, 1, ..., 1, x}
-//         = zext(x) + ((-1) << (width(x)-1))
-//
-// Note that we are adding arguments to the compressor, but these can be
-// constant folded should other constants arise
-//
-// A pattern encountered when we convert subtraction to addition:
-// zext(a)-zext(b) = zext(a) + ~zext(b) + 1
-//                 = zext(a) + oneExt(~b) + 1
-// TODO: use knownBits to extract all constant ones
-struct OnesExtCompress : public OpRewritePattern<CompressOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(CompressOp op,
-                                PatternRewriter &rewriter) const override {
-    auto inputs = op.getInputs();
-    auto opType = inputs[0].getType();
-    auto opSize = opType.getIntOrFloatBitWidth();
-
-    SmallVector<Value> newInputs;
-    for (auto input : inputs) {
-      // Check for replication of ones leading
-      auto baseInput = isOneExt(input);
-      if (failed(baseInput)) {
-        newInputs.push_back(input);
-        continue;
-      }
-
-      // Separate {ones, x} -> zext(x) + (ones << baseWidth)
-      auto newOp = comb::createZExt(rewriter, op.getLoc(), *baseInput, opSize);
-      newInputs.push_back(newOp);
-
-      APInt ones = APInt::getAllOnes(opSize);
-      auto baseWidth = baseInput->getType().getIntOrFloatBitWidth();
-      auto correction =
-          hw::ConstantOp::create(rewriter, op.getLoc(), ones << baseWidth);
-      newInputs.push_back(correction);
-    }
-
-    if (newInputs.size() == inputs.size())
-      return failure();
-
-    auto newCompress = datapath::CompressOp::create(
-        rewriter, op.getLoc(), newInputs, op.getNumResults());
-    rewriter.replaceOp(op, newCompress.getResults());
-    return success();
-  }
-};
-
 struct ConstantFoldCompress : public OpRewritePattern<CompressOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -412,7 +339,7 @@ struct ConstantFoldCompress : public OpRewritePattern<CompressOp> {
 void CompressOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
   results.add<FoldCompressIntoCompress, FoldAddIntoCompress,
-              ConstantFoldCompress, SextCompress, OnesExtCompress>(context);
+              ConstantFoldCompress, SextCompress>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -238,6 +238,9 @@ struct FoldAddIntoCompress : public OpRewritePattern<comb::AddOp> {
 //           {       1,    1, ...,       1,      0, ...,    0} =
 //         = zext({~x[p-1], x[p-2], ..., x[0]}) + ((-1) << (width(x)-1))
 //
+// More generally, for an arbitrary replicated prefix:
+// {r, r, ..., r, x} = zext({~r, x}) + ((-1) << width(x))
+//
 // Note that we are adding arguments to the compressor, but we are reducing the
 // number of unknown bits in the compressor array
 struct SextCompress : public OpRewritePattern<CompressOp> {
@@ -249,45 +252,44 @@ struct SextCompress : public OpRewritePattern<CompressOp> {
     auto opSize = inputs[0].getType().getIntOrFloatBitWidth();
     auto size = inputs.size();
 
-    APInt value;
     SmallVector<Value> newInputs;
     for (auto input : inputs) {
       Value replBits;
-      // Check for sext of the inverted value
-      if (!matchPattern(input, comb::m_SextBy(m_Any(&replBits)))) {
+      bool isSext = matchPattern(input, comb::m_SextBy(m_Any(&replBits)));
+      if (!isSext && !matchPattern(input, comb::m_ReplExt(m_Any(&replBits)))) {
         newInputs.push_back(input);
         continue;
       }
       auto baseWidth = opSize - replBits.getType().getIntOrFloatBitWidth();
-      auto sextInput =
-          comb::ExtractOp::create(rewriter, op.getLoc(), input, 0, baseWidth);
 
-      // Need a separate sign-bit that gets extended by at least two bits to
-      // be beneficial
+      // The replicated prefix must contain at least two bits to be beneficial.
       if (baseWidth <= 1 || (opSize - baseWidth) <= 1) {
         newInputs.push_back(input);
         continue;
       }
 
-      // x[p-2:0]
-      auto base = comb::ExtractOp::create(rewriter, op.getLoc(), sextInput, 0,
-                                          baseWidth - 1);
-      // x[p-1]
-      auto signBit = comb::ExtractOp::create(rewriter, op.getLoc(), sextInput,
-                                             baseWidth - 1, 1);
-      auto invSign =
-          comb::createOrFoldNot(rewriter, op.getLoc(), signBit, true);
-      // {~x[p-1], x[p-2:0]}
+      // For a sign extension, the repeated bit is already the most significant
+      // bit of the base. For a general replicated extension, preserve the
+      // entire base and get the repeated bit from the replicate operation.
+      auto correctionBit = isSext ? baseWidth - 1 : baseWidth;
+      auto base = comb::ExtractOp::create(rewriter, op.getLoc(), input, 0,
+                                          correctionBit);
+      Value repeatedBit;
+      repeatedBit = comb::ExtractOp::create(rewriter, op.getLoc(), input,
+                                            correctionBit, 1);
+      auto invRepeatedBit =
+          comb::createOrFoldNot(rewriter, op.getLoc(), repeatedBit, true);
+      // Replace the repeated prefix zeros and a constant correction.
       auto newOp = comb::ConcatOp::create(rewriter, op.getLoc(),
-                                          ValueRange{invSign, base});
+                                          ValueRange{invRepeatedBit, base});
       auto newOpZExt = comb::createZExt(rewriter, op.getLoc(), newOp, opSize);
 
       newInputs.push_back(newOpZExt);
 
-      // (-1) << (width(x)-1)
+      // Constant correction (-1) << width (-1)
       auto ones = APInt::getAllOnes(opSize);
-      auto correction = hw::ConstantOp::create(rewriter, op.getLoc(),
-                                               ones << (baseWidth - 1));
+      auto correction =
+          hw::ConstantOp::create(rewriter, op.getLoc(), ones << correctionBit);
 
       newInputs.push_back(correction);
     }

--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -254,7 +254,7 @@ struct SextCompress : public OpRewritePattern<CompressOp> {
       auto base = comb::ExtractOp::create(rewriter, op.getLoc(), input, 0,
                                           correctionBit);
       Value repeatedBit = comb::ExtractOp::create(rewriter, op.getLoc(), input,
-                                            correctionBit, 1);
+                                                  correctionBit, 1);
       auto invRepeatedBit =
           comb::createOrFoldNot(rewriter, op.getLoc(), repeatedBit, true);
       // Replace the repeated prefix zeros and a constant correction.

--- a/test/Dialect/Datapath/canonicalization.mlir
+++ b/test/Dialect/Datapath/canonicalization.mlir
@@ -99,6 +99,21 @@ hw.module @sext_compress(in %a : i8, in %b : i8, in %c : i4,
   hw.output %3#0, %3#1, %5#0, %5#1 : i8, i8, i8, i8
 }
 
+// CHECK-LABEL: @replext_compress
+hw.module @replext_compress(in %a : i8, in %b : i8, in %bit : i1,
+                            in %c : i4, out sum : i8, out carry : i8) {
+  // CHECK-NEXT: %c-16_i8 = hw.constant -16 : i8
+  // CHECK-NEXT: %c0_i3 = hw.constant 0 : i3
+  // CHECK-NEXT: %true = hw.constant true
+  // CHECK-NEXT: %[[NOTBIT:.+]] = comb.xor bin %bit, %true : i1
+  // CHECK-NEXT: %[[EXT:.+]] = comb.concat %c0_i3, %[[NOTBIT]], %c : i3, i1, i4
+  // CHECK-NEXT: %[[COMP:.+]]:2 = datapath.compress %a, %b, %[[EXT]], %c-16_i8 : i8 [4 -> 2]
+  %0 = comb.replicate %bit : (i1) -> i4
+  %1 = comb.concat %0, %c : i4, i4
+  %2:2 = datapath.compress %a, %b, %1 : i8 [3 -> 2]
+  hw.output %2#0, %2#1 : i8, i8
+}
+
 // CHECK-LABEL: @oneext_compress
 hw.module @oneext_compress(in %a : i8, in %b : i8, in %c : i4, 
                          out sum1 : i8, out carry1 : i8) {


### PR DESCRIPTION
When lowering via a Booth encoded multiplier the sign-bit is constructed separately and does not correspond to the msb of the base e.g. a pattern like:
`partial_product_row = {x, x, ..., x, base_row}`

This was not picked up and hence not optimized by the existing Datapath canonicalization pattern as it only matched code where that repeated bit was exactly the sign-bit of the base in the example of `base_row`.

This greatly improves the synthesis results for Booth encoded multipliers. It also allows us to fold in the replicated one's matching pattern that was implemented as a more specific case of this now more general pattern :)

There is some overlap with the m_SextBy pattern matcher, do you think this would be more readable?

Assisted-by: OpenAI 5.6 Sol (I just got access through this scheme that's worth applying for any academics out there https://help.openai.com/en/articles/20001406-chatgpt-for-academic-researchers)
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
