### PR TITLE
[MooreToCore] Fix out-of-bounds and aggregate moore.extract lowering

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1399,15 +1399,6 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
     Type inputType = input.getType();
     int32_t low = adaptor.getLowBit();
 
-    if (auto structTy = dyn_cast<hw::StructType>(inputType)) {
-      int32_t width = hw::getBitWidth(structTy);
-      if (width == -1)
-        return failure();
-      input = rewriter.createOrFold<hw::BitcastOp>(
-          op.getLoc(), rewriter.getIntegerType(width), input);
-      inputType = input.getType();
-    }
-
     if (isa<IntegerType>(inputType)) {
       int32_t inputWidth = inputType.getIntOrFloatBitWidth();
       int32_t resultWidth = hw::getBitWidth(resultType);

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1437,24 +1437,30 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
       Type elementType = arrTy.getElementType();
       int32_t idxWidth = llvm::Log2_64_Ceil(arrTy.getNumElements());
       int32_t inputWidth = arrTy.getNumElements();
-      if (hw::getBitWidth(elementType) < 0)
-        return failure();
 
-      auto createZeros = [&](Type type) {
-        Value constZero = hw::ConstantOp::create(
-            rewriter, loc, APInt(hw::getBitWidth(type), 0));
-        return rewriter.createOrFold<hw::BitcastOp>(loc, type, constZero);
+      // Builds a zeroed value of `type`, or null if it has no bit width.
+      // TODO: build the type's LRM Table 6-7 default instead.
+      auto createDefault = [&](Type type) -> Value {
+        int32_t width = hw::getBitWidth(type);
+        if (width < 0)
+          return {};
+        Value zero = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
+        return rewriter.createOrFold<hw::BitcastOp>(loc, type, zero);
       };
 
       // Array element
       if (resultType == elementType) {
-        if (low < 0 || low >= inputWidth)
-          rewriter.replaceOp(op, createZeros(resultType));
-        else
+        if (low < 0 || low >= inputWidth) {
+          auto dfl = createDefault(resultType);
+          if (!dfl)
+            return failure();
+          rewriter.replaceOp(op, dfl);
+        } else {
           rewriter.replaceOpWithNewOp<hw::ArrayGetOp>(
               op, input,
               hw::ConstantOp::create(rewriter, loc,
                                      rewriter.getIntegerType(idxWidth), low));
+        }
         return success();
       }
 
@@ -1469,9 +1475,12 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
         int32_t extractWidth = resultWidth - lsbPad - msbPad;
 
         SmallVector<Value> toConcat;
-        if (msbPad > 0)
-          toConcat.push_back(
-              createZeros(hw::ArrayType::get(elementType, msbPad)));
+        if (msbPad > 0) {
+          auto dfl = createDefault(hw::ArrayType::get(elementType, msbPad));
+          if (!dfl)
+            return failure();
+          toConcat.push_back(dfl);
+        }
 
         if (extractWidth > 0)
           toConcat.push_back(rewriter.createOrFold<hw::ArraySliceOp>(
@@ -1480,9 +1489,12 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
                                      rewriter.getIntegerType(idxWidth),
                                      std::max(low, 0))));
 
-        if (lsbPad > 0)
-          toConcat.push_back(
-              createZeros(hw::ArrayType::get(elementType, lsbPad)));
+        if (lsbPad > 0) {
+          auto dfl = createDefault(hw::ArrayType::get(elementType, lsbPad));
+          if (!dfl)
+            return failure();
+          toConcat.push_back(dfl);
+        }
 
         rewriter.replaceOp(
             op, rewriter.createOrFold<hw::ArrayConcatOp>(loc, toConcat));

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1432,78 +1432,63 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
       return success();
     }
 
+    // Element-addressed extract out of an array
     if (auto arrTy = dyn_cast<hw::ArrayType>(inputType)) {
-      int32_t width = llvm::Log2_64_Ceil(arrTy.getNumElements());
+      Type elementType = arrTy.getElementType();
+      int32_t idxWidth = llvm::Log2_64_Ceil(arrTy.getNumElements());
       int32_t inputWidth = arrTy.getNumElements();
+      if (hw::getBitWidth(elementType) < 0)
+        return failure();
 
+      auto createZeros = [&](Type type) {
+        Value constZero = hw::ConstantOp::create(
+            rewriter, op.getLoc(), APInt(hw::getBitWidth(type), 0));
+        return rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), type,
+                                                    constZero);
+      };
+
+      // Array element
+      if (resultType == elementType) {
+        if (low < 0 || low >= inputWidth)
+          rewriter.replaceOp(op, createZeros(resultType));
+        else
+          rewriter.replaceOpWithNewOp<hw::ArrayGetOp>(
+              op, input,
+              hw::ConstantOp::create(rewriter, op.getLoc(),
+                                     rewriter.getIntegerType(idxWidth), low));
+        return success();
+      }
+
+      // Array slice
       if (auto resArrTy = dyn_cast<hw::ArrayType>(resultType);
-          resArrTy && resArrTy != arrTy.getElementType()) {
-        int32_t elementWidth = hw::getBitWidth(arrTy.getElementType());
-        if (elementWidth < 0)
-          return failure();
+          resArrTy && resArrTy.getElementType() == elementType) {
+        int32_t resultWidth = resArrTy.getNumElements();
+        int32_t high = low + resultWidth;
 
-        int32_t high = low + resArrTy.getNumElements();
-        int32_t resWidth = resArrTy.getNumElements();
+        int32_t lsbPad = std::clamp(-low, 0, resultWidth);
+        int32_t msbPad = std::clamp(high - inputWidth, 0, resultWidth - lsbPad);
+        int32_t extractWidth = resultWidth - lsbPad - msbPad;
 
         SmallVector<Value> toConcat;
-        if (low < 0) {
-          Value val = hw::ConstantOp::create(
-              rewriter, op.getLoc(),
-              APInt(std::min((-low) * elementWidth, resWidth * elementWidth),
-                    0));
-          Value res = rewriter.createOrFold<hw::BitcastOp>(
-              op.getLoc(), hw::ArrayType::get(arrTy.getElementType(), -low),
-              val);
-          toConcat.push_back(res);
-        }
+        if (msbPad > 0)
+          toConcat.push_back(
+              createZeros(hw::ArrayType::get(elementType, msbPad)));
 
-        if (low < inputWidth && high > 0) {
-          int32_t lowIdx = std::max(0, low);
-          Value lowIdxVal = hw::ConstantOp::create(
-              rewriter, op.getLoc(), rewriter.getIntegerType(width), lowIdx);
-          Value middle = rewriter.createOrFold<hw::ArraySliceOp>(
-              op.getLoc(),
-              hw::ArrayType::get(
-                  arrTy.getElementType(),
-                  std::min(resWidth, std::min(inputWidth, high) - lowIdx)),
-              adaptor.getInput(), lowIdxVal);
-          toConcat.push_back(middle);
-        }
+        if (extractWidth > 0)
+          toConcat.push_back(rewriter.createOrFold<hw::ArraySliceOp>(
+              op.getLoc(), hw::ArrayType::get(elementType, extractWidth), input,
+              hw::ConstantOp::create(rewriter, op.getLoc(),
+                                     rewriter.getIntegerType(idxWidth),
+                                     std::max(low, 0))));
 
-        int32_t diff = high - inputWidth;
-        if (diff > 0) {
-          Value constZero = hw::ConstantOp::create(
-              rewriter, op.getLoc(), APInt(diff * elementWidth, 0));
-          Value val = hw::BitcastOp::create(
-              rewriter, op.getLoc(),
-              hw::ArrayType::get(arrTy.getElementType(), diff), constZero);
-          toConcat.push_back(val);
-        }
+        if (lsbPad > 0)
+          toConcat.push_back(
+              createZeros(hw::ArrayType::get(elementType, lsbPad)));
 
-        Value concat =
-            rewriter.createOrFold<hw::ArrayConcatOp>(op.getLoc(), toConcat);
-        rewriter.replaceOp(op, concat);
+        rewriter.replaceOp(op, rewriter.createOrFold<hw::ArrayConcatOp>(
+                                   op.getLoc(), toConcat));
         return success();
       }
-
-      // Otherwise, it has to be the array's element type
-      if (low < 0 || low >= inputWidth) {
-        int32_t bw = hw::getBitWidth(resultType);
-        if (bw < 0)
-          return failure();
-
-        Value val = hw::ConstantOp::create(rewriter, op.getLoc(), APInt(bw, 0));
-        Value bitcast =
-            rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), resultType, val);
-        rewriter.replaceOp(op, bitcast);
-        return success();
-      }
-
-      Value idx = hw::ConstantOp::create(rewriter, op.getLoc(),
-                                         rewriter.getIntegerType(width),
-                                         adaptor.getLowBit());
-      rewriter.replaceOpWithNewOp<hw::ArrayGetOp>(op, adaptor.getInput(), idx);
-      return success();
     }
 
     return failure();

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1398,37 +1398,37 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
     Value input = adaptor.getInput();
     Type inputType = input.getType();
     int32_t low = adaptor.getLowBit();
+    auto loc = op.getLoc();
 
+    // Bit-addressed extract out of an integer into any bitcastable result.
     if (isa<IntegerType>(inputType)) {
       int32_t inputWidth = inputType.getIntOrFloatBitWidth();
       int32_t resultWidth = hw::getBitWidth(resultType);
+      if (resultWidth < 0)
+        return failure();
+
       int32_t high = low + resultWidth;
+      int32_t lsbPad = std::clamp(-low, 0, resultWidth);
+      int32_t msbPad = std::clamp(high - inputWidth, 0, resultWidth - lsbPad);
+      int32_t extractWidth = resultWidth - lsbPad - msbPad;
 
-      SmallVector<Value> toConcat;
-      if (low < 0)
-        toConcat.push_back(hw::ConstantOp::create(
-            rewriter, op.getLoc(), APInt(std::min(-low, resultWidth), 0)));
+      SmallVector<Value> sbv;
+      if (msbPad > 0)
+        sbv.push_back(hw::ConstantOp::create(rewriter, loc, APInt(msbPad, 0)));
 
-      if (low < inputWidth && high > 0) {
-        int32_t lowIdx = std::max(low, 0);
-        Value middle = rewriter.createOrFold<comb::ExtractOp>(
-            op.getLoc(),
-            rewriter.getIntegerType(
-                std::min(resultWidth, std::min(high, inputWidth) - lowIdx)),
-            input, lowIdx);
-        toConcat.push_back(middle);
-      }
+      if (extractWidth > 0)
+        sbv.push_back(rewriter.createOrFold<comb::ExtractOp>(
+            loc, rewriter.getIntegerType(extractWidth), input,
+            std::max(low, 0)));
 
-      int32_t diff = high - inputWidth;
-      if (diff > 0) {
-        Value val =
-            hw::ConstantOp::create(rewriter, op.getLoc(), APInt(diff, 0));
-        toConcat.push_back(val);
-      }
+      if (lsbPad > 0)
+        sbv.push_back(hw::ConstantOp::create(rewriter, loc, APInt(lsbPad, 0)));
 
-      Value concat =
-          rewriter.createOrFold<comb::ConcatOp>(op.getLoc(), toConcat);
-      rewriter.replaceOp(op, concat);
+      Value res = rewriter.createOrFold<comb::ConcatOp>(loc, sbv);
+      if (res.getType() != resultType)
+        res = rewriter.createOrFold<hw::BitcastOp>(loc, resultType, res);
+
+      rewriter.replaceOp(op, res);
       return success();
     }
 

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1442,9 +1442,8 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
 
       auto createZeros = [&](Type type) {
         Value constZero = hw::ConstantOp::create(
-            rewriter, op.getLoc(), APInt(hw::getBitWidth(type), 0));
-        return rewriter.createOrFold<hw::BitcastOp>(op.getLoc(), type,
-                                                    constZero);
+            rewriter, loc, APInt(hw::getBitWidth(type), 0));
+        return rewriter.createOrFold<hw::BitcastOp>(loc, type, constZero);
       };
 
       // Array element
@@ -1454,7 +1453,7 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
         else
           rewriter.replaceOpWithNewOp<hw::ArrayGetOp>(
               op, input,
-              hw::ConstantOp::create(rewriter, op.getLoc(),
+              hw::ConstantOp::create(rewriter, loc,
                                      rewriter.getIntegerType(idxWidth), low));
         return success();
       }
@@ -1476,8 +1475,8 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
 
         if (extractWidth > 0)
           toConcat.push_back(rewriter.createOrFold<hw::ArraySliceOp>(
-              op.getLoc(), hw::ArrayType::get(elementType, extractWidth), input,
-              hw::ConstantOp::create(rewriter, op.getLoc(),
+              loc, hw::ArrayType::get(elementType, extractWidth), input,
+              hw::ConstantOp::create(rewriter, loc,
                                      rewriter.getIntegerType(idxWidth),
                                      std::max(low, 0))));
 
@@ -1485,8 +1484,8 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
           toConcat.push_back(
               createZeros(hw::ArrayType::get(elementType, lsbPad)));
 
-        rewriter.replaceOp(op, rewriter.createOrFold<hw::ArrayConcatOp>(
-                                   op.getLoc(), toConcat));
+        rewriter.replaceOp(
+            op, rewriter.createOrFold<hw::ArrayConcatOp>(loc, toConcat));
         return success();
       }
     }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1438,23 +1438,13 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
       int32_t idxWidth = llvm::Log2_64_Ceil(arrTy.getNumElements());
       int32_t inputWidth = arrTy.getNumElements();
 
-      // Builds a zeroed value of `type`, or null if it has no bit width.
-      // TODO: build the type's LRM Table 6-7 default instead.
-      auto createDefault = [&](Type type) -> Value {
-        int32_t width = hw::getBitWidth(type);
-        if (width < 0)
-          return {};
-        Value zero = hw::ConstantOp::create(rewriter, loc, APInt(width, 0));
-        return rewriter.createOrFold<hw::BitcastOp>(loc, type, zero);
-      };
-
       // Array element
       if (resultType == elementType) {
         if (low < 0 || low >= inputWidth) {
-          auto dfl = createDefault(resultType);
-          if (!dfl)
+          auto zeros = createZeroValue(resultType, loc, rewriter);
+          if (!zeros)
             return failure();
-          rewriter.replaceOp(op, dfl);
+          rewriter.replaceOp(op, zeros);
         } else {
           rewriter.replaceOpWithNewOp<hw::ArrayGetOp>(
               op, input,
@@ -1476,10 +1466,11 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
 
         SmallVector<Value> toConcat;
         if (msbPad > 0) {
-          auto dfl = createDefault(hw::ArrayType::get(elementType, msbPad));
-          if (!dfl)
+          auto zeros = createZeroValue(hw::ArrayType::get(elementType, msbPad),
+                                       loc, rewriter);
+          if (!zeros)
             return failure();
-          toConcat.push_back(dfl);
+          toConcat.push_back(zeros);
         }
 
         if (extractWidth > 0)
@@ -1490,10 +1481,11 @@ struct ExtractOpConversion : public OpConversionPattern<ExtractOp> {
                                      std::max(low, 0))));
 
         if (lsbPad > 0) {
-          auto dfl = createDefault(hw::ArrayType::get(elementType, lsbPad));
-          if (!dfl)
+          auto zeros = createZeroValue(hw::ArrayType::get(elementType, lsbPad),
+                                       loc, rewriter);
+          if (!zeros)
             return failure();
-          toConcat.push_back(dfl);
+          toConcat.push_back(zeros);
         }
 
         rewriter.replaceOp(

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -115,14 +115,14 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: comb.concat [[C0]], %arg2, [[C1]] : i2, i6, i2
   moore.extract %arg2 from -2 : !moore.i6 -> !moore.i10
 
-  // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 4 : (i6) -> i2
   // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i2
-  // CHECK-NEXT: comb.concat [[V0]], [[C0]] : i2, i2
+  // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 4 : (i6) -> i2
+  // CHECK-NEXT: comb.concat [[C0]], [[V0]] : i2, i2
   moore.extract %arg2 from 4 : !moore.i6 -> !moore.i4
 
-  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i2
   // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 0 : (i6) -> i2
-  // CHECK-NEXT: comb.concat [[C0]], [[V0]] : i2, i2
+  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i2
+  // CHECK-NEXT: comb.concat [[V0]], [[C0]] : i2, i2
   moore.extract %arg2 from -2 : !moore.i6 -> !moore.i4
 
   // CHECK-NEXT: hw.constant 0 : i4

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -131,6 +131,32 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: hw.constant 0 : i4
   moore.extract %arg2 from 6 : !moore.i6 -> !moore.i4
 
+  // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 0 : (i6) -> i2
+  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i2
+  // CHECK-NEXT: [[V1:%.+]] = comb.concat [[V0]], [[C0]] : i2, i2
+  // CHECK-NEXT: hw.bitcast [[V1]] : (i4) -> !hw.struct<a: i2, b: i2>
+  moore.extract %arg2 from -2 : !moore.i6 -> !moore.struct<{a: i2, b: i2}>
+
+  // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 0 : (i6) -> i2
+  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i2
+  // CHECK-NEXT: [[V1:%.+]] = comb.concat [[V0]], [[C0]] : i2, i2
+  // CHECK-NEXT: hw.bitcast [[V1]] : (i4) -> !hw.array<2xi2>
+  moore.extract %arg2 from -2 : !moore.i6 -> !moore.array<2 x i2>
+
+  // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 0 : (i6) -> i4
+  // CHECK-NEXT: hw.bitcast [[V0]] : (i4) -> !hw.struct<a: i2, b: i2>
+  moore.extract %arg2 from 0 : !moore.i6 -> !moore.struct<{a: i2, b: i2}>
+
+  // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 1 : (i6) -> i4
+  // CHECK-NEXT: hw.bitcast [[V0]] : (i4) -> !hw.struct<a: i2, b: i2>
+  moore.extract %arg2 from 1 : !moore.i6 -> !moore.struct<{a: i2, b: i2}>
+
+  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i2
+  // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 4 : (i6) -> i2
+  // CHECK-NEXT: [[V1:%.+]] = comb.concat [[C0]], [[V0]] : i2, i2
+  // CHECK-NEXT: hw.bitcast [[V1]] : (i4) -> !hw.struct<a: i2, b: i2>
+  moore.extract %arg2 from 4 : !moore.i6 -> !moore.struct<{a: i2, b: i2}>
+
   // CHECK-NEXT: hw.constant 0 : i64
   // CHECK-NEXT: [[V0:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
   // CHECK-NEXT: hw.constant 0 : i3

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -359,15 +359,6 @@ func.func @DynExtractRefArrayElement(%j: !moore.ref<array<2 x array<1 x l3>>>, %
   return %0 : !moore.ref<array<1 x l3>>
 }
 
-// CHECK-LABEL: func.func @ExtractFromPackedStruct
-func.func @ExtractFromPackedStruct(%arg0: !moore.struct<{a: l1, b: l1, c: l2}>) -> !moore.l3 {
-  // CHECK: [[BITCAST:%.+]] = hw.bitcast %arg0 : (!hw.struct<a: i1, b: i1, c: i2>) -> i4
-  // CHECK: [[RES:%.+]] = comb.extract [[BITCAST]] from 1 : (i4) -> i3
-  %0 = moore.extract %arg0 from 1 : struct<{a: l1, b: l1, c: l2}> -> l3
-  // CHECK: return [[RES]]
-  return %0 : !moore.l3
-}
-
 // CHECK-LABEL: func @AdvancedConversion
 func.func @AdvancedConversion(%arg0: !moore.array<5 x struct<{exp_bits: i32, man_bits: i32}>>) -> (!moore.array<5 x struct<{exp_bits: i32, man_bits: i32}>>, !moore.i320) {
   // CHECK: [[V0:%.+]] = hw.constant 3978585893941511189997889893581765703992223160870725712510875979948892565035285336817671 : i320

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -157,34 +157,27 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: hw.bitcast [[V1]] : (i4) -> !hw.struct<a: i2, b: i2>
   moore.extract %arg2 from 4 : !moore.i6 -> !moore.struct<{a: i2, b: i2}>
 
-  // CHECK-NEXT: hw.constant 0 : i64
-  // CHECK-NEXT: [[V0:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
-  // CHECK-NEXT: hw.constant 0 : i3
-  // CHECK-NEXT: [[C1:%.+]] = hw.constant 0 : i64
-  // CHECK-NEXT: [[V1:%.+]] = hw.bitcast [[C1]] : (i64) -> !hw.array<2xi32>
-  // CHECK-NEXT: hw.array_concat [[V0]], %arg5, [[V1]] : !hw.array<2xi32>, !hw.array<5xi32>, !hw.array<2xi32>
+  // CHECK:      [[C0:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
+  // CHECK:      [[C1:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
+  // CHECK-NEXT: hw.array_concat [[C0]], %arg5, [[C1]] : !hw.array<2xi32>, !hw.array<5xi32>, !hw.array<2xi32>
   moore.extract %arg5 from -2 : !moore.array<5 x i32> -> !moore.array<9 x i32>
 
+  // CHECK:      [[C0:%.+]] = hw.aggregate_constant [0 : i32] : !hw.array<1xi32>
   // CHECK-NEXT: [[IDX:%.+]] = hw.constant 2 : i3
   // CHECK-NEXT: [[V0:%.+]] = hw.array_slice %arg5[[[IDX]]] : (!hw.array<5xi32>) -> !hw.array<3xi32>
-  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i32
-  // CHECK-NEXT: [[V1:%.+]] = hw.bitcast [[C0]] : (i32) -> !hw.array<1xi32>
-  // CHECK-NEXT: hw.array_concat [[V0]], [[V1]] : !hw.array<3xi32>, !hw.array<1xi32>
+  // CHECK-NEXT: hw.array_concat [[C0]], [[V0]] : !hw.array<1xi32>, !hw.array<3xi32>
   moore.extract %arg5 from 2 : !moore.array<5 x i32> -> !moore.array<4 x i32>
 
-  // CHECK-NEXT: hw.constant 0 : i32
-  // CHECK-NEXT: [[V0:%.+]] = hw.aggregate_constant [0 : i32] : !hw.array<1xi32>
   // CHECK-NEXT: [[IDX:%.+]] = hw.constant 0 : i3
-  // CHECK-NEXT: [[V1:%.+]] = hw.array_slice %arg5[[[IDX]]] : (!hw.array<5xi32>) -> !hw.array<1xi32>
-  // CHECK-NEXT: hw.array_concat [[V0]], [[V1]] : !hw.array<1xi32>, !hw.array<1xi32>
+  // CHECK-NEXT: [[V0:%.+]] = hw.array_slice %arg5[[[IDX]]] : (!hw.array<5xi32>) -> !hw.array<1xi32>
+  // CHECK:      [[C0:%.+]] = hw.aggregate_constant [0 : i32] : !hw.array<1xi32>
+  // CHECK-NEXT: hw.array_concat [[V0]], [[C0]] : !hw.array<1xi32>, !hw.array<1xi32>
   moore.extract %arg5 from -1 : !moore.array<5 x i32> -> !moore.array<2 x i32>
 
-  // CHECK-NEXT: hw.constant 0 : i64
-  // CHECK-NEXT: hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
+  // CHECK: hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
   moore.extract %arg5 from -2 : !moore.array<5 x i32> -> !moore.array<2 x i32>
 
-  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i64
-  // CHECK-NEXT: hw.bitcast [[C0]] : (i64) -> !hw.array<2xi32>
+  // CHECK: hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
   moore.extract %arg5 from 5 : !moore.array<5 x i32> -> !moore.array<2 x i32>
 
   // CHECK-NEXT: hw.constant 0 : i32
@@ -633,6 +626,21 @@ moore.module @UnpackedArray(in %arr : !moore.uarray<2 x i32>, in %sel : !moore.i
   // CHECK: [[TRUE:%.+]] = hw.constant true
   // CHECK: hw.array_get %arr[[[TRUE]]] : !hw.array<2xi32>, i1
   %1 = moore.extract %arr from 1 : !moore.uarray<2 x i32> -> !moore.i32
+
+  // CHECK: hw.aggregate_constant [0 : i32, 0 : i32] : !hw.array<2xi32>
+  %oob = moore.extract %arr from 5 : !moore.uarray<2 x i32> -> !moore.uarray<2 x i32>
+
+  // CHECK: [[C0:%.+]] = hw.aggregate_constant [0 : i32] : !hw.array<1xi32>
+  // CHECK: [[IDX:%.+]] = hw.constant true
+  // CHECK: [[V0:%.+]] = hw.array_slice %arr[[[IDX]]] : (!hw.array<2xi32>) -> !hw.array<1xi32>
+  // CHECK: hw.array_concat [[C0]], [[V0]] : !hw.array<1xi32>, !hw.array<1xi32>
+  %pover = moore.extract %arr from 1 : !moore.uarray<2 x i32> -> !moore.uarray<2 x i32>
+
+  // CHECK: [[IDX:%.+]] = hw.constant false
+  // CHECK: [[V0:%.+]] = hw.array_slice %arr[[[IDX]]] : (!hw.array<2xi32>) -> !hw.array<1xi32>
+  // CHECK: [[C0:%.+]] = hw.aggregate_constant [0 : i32] : !hw.array<1xi32>
+  // CHECK: hw.array_concat [[V0]], [[C0]] : !hw.array<1xi32>, !hw.array<1xi32>
+  %punder = moore.extract %arr from -1 : !moore.uarray<2 x i32> -> !moore.uarray<2 x i32>
 
   // CHECK: [[INIT:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32, 0 : i32, 0 : i32] : !hw.array<4xi32>
   // CHECK: [[SIG_0:%.+]] = llhd.sig [[INIT]] : !hw.array<4xi32>

--- a/test/circt-verilog/roundtrip-oob-reads.sv
+++ b/test/circt-verilog/roundtrip-oob-reads.sv
@@ -1,0 +1,26 @@
+// RUN: circt-verilog -Wno-error=range-oob %s | circt-opt --test-apply-lowering-options='options=emittedLineLength=0' --export-verilog -o /dev/null | FileCheck %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+
+// CHECK-LABEL: module vector(
+module vector(input bit [1:0] i, output bit [4:0] o);
+  // CHECK: assign o = {2'h0, i, 1'h0};
+  assign o = i[3:-1];
+endmodule
+
+// CHECK-LABEL: module packed_array(
+module packed_array(input bit [1:0][1:0] i, output bit [4:0][1:0] o);
+  // CHECK: [[MSB_PAD:[A-Za-z0-9_]+]] = '{2'h0, 2'h0};
+  // CHECK-NEXT: [[LSB_PAD:[A-Za-z0-9_]+]] = '{2'h0};
+  // CHECK-NEXT: assign o = {[[MSB_PAD]], i, [[LSB_PAD]]};
+  assign o = i[3:-1];
+endmodule
+
+// CHECK-LABEL: module packed_struct_array(
+typedef struct packed { bit hi; bit lo; } pair_t;
+module packed_struct_array(input pair_t [1:0] i, output pair_t [4:0] o);
+  // CHECK: [[MSB_PAD:[A-Za-z0-9_]+]] = '{'{hi: 1'h0, lo: 1'h0}, '{hi: 1'h0, lo: 1'h0}};
+  // CHECK-NEXT: [[LSB_PAD:[A-Za-z0-9_]+]] = '{'{hi: 1'h0, lo: 1'h0}};
+  // CHECK-NEXT: assign o = {[[MSB_PAD]], i, [[LSB_PAD]]};
+  assign o = i[3:-1];
+endmodule


### PR DESCRIPTION
Reworks `ExtractOpConversion`:
- Fix oob padding on the wrong side.
- Drop unused bit-wise extract from structs (Frontend already uses `moore.packed_to_sbv`).
- Explicitly state that extracts from integer types can be cast into other types and add tests for that.
- Only allow real array gets and slices, not other array result types.

Assisted by: vscode:Claude Opus 5