### PR TITLE
[FIRRTL] Support both propassert message formats

### DIFF
--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1200,15 +1200,17 @@ void Emitter::emitStatement(MatchingConnectOp op) {
 }
 
 void Emitter::emitStatement(PropertyAssertOp op) {
+  if (failed(requireVersion(FIRVersion(6, 0, 0), op, "property assert")))
+    return;
   startStatement();
   ps.scopedBox(PP::ibox2, [&]() {
     ps << "propassert" << PP::space;
     emitExpression(op.getCondition());
     ps << "," << PP::space;
-    // For FIRRTL <= 7.0.0, do a best effort emission that will inline a single
+    // For FIRRTL < 7.0.0, do a best effort emission that will inline a single
     // string expression.  If we see anything more complicated than this, just
     // bail.
-    if (version <= FIRVersion(7, 0, 0)) {
+    if (version < FIRVersion(7, 0, 0)) {
       auto expr = dyn_cast<StringConstantOp>(op.getMessage().getDefiningOp());
       if (!expr) {
         auto diag =

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4575,10 +4575,13 @@ ParseResult FIRStmtParser::parseConnect() {
   return success();
 }
 
-/// Before FIRRTL 7.0.0:
+/// FIRRTL 6.0.0 <= version < FIRRTL 8.0.0:
 ///   propassert ::= 'propassert' expr ',' string_literal
-/// After FIRRTL 7.0.0:
+/// FIRRTL 7.0.0 <= version:
 ///   propassert ::= 'propassert' expr ',' expr
+///
+/// Before calling, it has already been verified that the FIRRTL version is
+/// greater than 6.0.0.
 ParseResult FIRStmtParser::parsePropAssert() {
   auto startTok = consumeToken(FIRToken::kw_propassert);
   auto loc = startTok.getLoc();
@@ -4588,16 +4591,24 @@ ParseResult FIRStmtParser::parsePropAssert() {
   if (parseExp(condition, "expected condition in 'propassert'") ||
       parseToken(FIRToken::comma, "expected ','"))
     return failure();
-  if (version < FIRVersion(7, 0, 0)) {
+  // String message handling
+  if (getToken().is(FIRToken::string)) {
+    if (removedFeature({8, 0, 0}, "string messages in property asserts"))
+      return failure();
     StringRef messageStr;
     messageLoc = getToken().getLoc();
     if (parseGetSpelling(messageStr) ||
         parseToken(FIRToken::string, "expected message string in 'propassert'"))
       return failure();
+    locationProcessor.setLoc(messageLoc);
     auto attr = builder.getStringAttr(FIRToken::getStringValue(messageStr));
     message = moduleContext.getCachedConstant<StringConstantOp>(
         builder, attr, builder.getType<StringType>(), attr);
   } else {
+    if (requireFeature(
+            {7, 0, 0},
+            "string property expression message in property asserts"))
+      return failure();
     messageLoc = getToken().getLoc();
     if (parseExp(message, "expected message in 'propassert'"))
       return failure();

--- a/test/Dialect/FIRRTL/emit-version-errors-lt-6.0.0.mlir
+++ b/test/Dialect/FIRRTL/emit-version-errors-lt-6.0.0.mlir
@@ -113,3 +113,15 @@ firrtl.circuit "BoolXor" {
     firrtl.propassign %out, %0 : !firrtl.bool
   }
 }
+
+// -----
+
+// Property assertions require FIRRTL >= 6.0.0.
+firrtl.circuit "PropertyAsserts" {
+  firrtl.module @PropertyAsserts() {
+    %cond = firrtl.bool true
+    %message = firrtl.string "foo"
+    // expected-error @below {{property assert requires FIRRTL 6.0.0}}
+    firrtl.property_assert %cond, %message : !firrtl.bool
+  }
+}


### PR DESCRIPTION
Change the version checks for property assert message formats to support
the string format for `6.0.0 >= version < 8.0.0` and the property
expression of string type format for `7.0.0 >= version`.  This is done to
allow for an overlap version where both are supported.  An overlap version
avoids the need for an atomic bump in a FIRRTL front end language (Chisel)
and a FIRRTL compiler (firtool).

Note: normally, I would do this where the overlap version is a minor
version of 6.1.0.  However, I made a mistake in upstream Chisel and bumped
the version that it was claiming to emit to 7.0.0.  I don't want to
downgrade that to 6.1.0.  Hence, the plan here is to use the 7.0.0 as the
bridge version between the two.

Assisted-by: pi.dev:gpt-5.6-luna