### PR TITLE
[firtool] Add -warn-on-truncation option

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -163,6 +163,10 @@ MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetEnableAnnotationWarning(
     CirctFirtoolFirtoolOptions options, bool value);
 
 MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetWarnOnTruncation(CirctFirtoolFirtoolOptions options,
+                                       bool value);
+
+MLIR_CAPI_EXPORTED void
 circtFirtoolOptionsSetLowerToCore(CirctFirtoolFirtoolOptions options,
                                   bool value);
 

--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -52,6 +52,7 @@ struct FIRParserOptions {
   bool scalarizePublicModules = false;
   bool scalarizeInternalModules = false;
   bool scalarizeExtModules = false;
+  bool warnOnTruncation = false;
   std::vector<std::string> enableLayers;
   std::vector<std::string> disableLayers;
   std::optional<LayerSpecialization> defaultLayerSpecialization;

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -25,10 +25,13 @@ struct InnerSymbolNamespace;
 
 namespace firrtl {
 /// Emit a connect between two values.
-void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs);
-void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs);
+void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs,
+                 bool warnOnTruncation = false);
 void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs,
-                 llvm::function_ref<Location()> getDiagLoc);
+                 bool warnOnTruncation = false);
+void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs,
+                 llvm::function_ref<Location()> getDiagLoc,
+                 bool warnOnTruncation = false);
 
 /// Utiility for generating a constant attribute.
 IntegerAttr getIntAttr(Type type, const APInt &value);

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -386,6 +386,9 @@ def InferWidths : Pass<"firrtl-infer-widths", "firrtl::CircuitOp"> {
     This pass infers the widths of all types throughout a FIRRTL module, and
     emits diagnostics for types that could not be inferred.
   }];
+  let options = [Option<"warnOnTruncation", "warn-on-truncation", "bool",
+                              "false",
+                              "Warn when connects require implicit truncation">];
 }
 
 def InferResets : Pass<"firrtl-infer-resets", "firrtl::CircuitOp"> {

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -386,7 +386,7 @@ def InferWidths : Pass<"firrtl-infer-widths", "firrtl::CircuitOp"> {
     This pass infers the widths of all types throughout a FIRRTL module, and
     emits diagnostics for types that could not be inferred.
   }];
-  let options = [Option<"warnOnTruncation", "warn-on-truncation", "bool",
+  let options = [Option<"warnOnTruncation", "warn-on-implicit-truncation", "bool",
                               "false",
                               "Warn when connects require implicit truncation">];
 }

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -156,6 +156,7 @@ public:
     return disableAggressiveMergeConnections;
   }
   bool shouldEnableAnnotationWarning() const { return enableAnnotationWarning; }
+  bool shouldWarnOnTruncation() const { return warnOnTruncation; }
   bool shouldLowerToCore() const { return lowerToCore; }
   auto getVerificationFlavor() const { return verificationFlavor; }
   bool shouldEmitSeparateAlwaysBlocks() const {
@@ -316,6 +317,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setWarnOnTruncation(bool value) {
+    warnOnTruncation = value;
+    return *this;
+  }
+
   FirtoolOptions &setLowerToCore(bool value) {
     lowerToCore = value;
     return *this;
@@ -462,6 +468,7 @@ private:
   RandomKind disableRandom;
   std::string outputAnnotationFilename;
   bool enableAnnotationWarning;
+  bool warnOnTruncation;
   bool lowerToCore;
   bool addMuxPragmas;
   firrtl::VerificationFlavor verificationFlavor;

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -222,6 +222,11 @@ void circtFirtoolOptionsSetEnableAnnotationWarning(
   unwrap(options)->setEnableAnnotationWarning(value);
 }
 
+void circtFirtoolOptionsSetWarnOnTruncation(CirctFirtoolFirtoolOptions options,
+                                            bool value) {
+  unwrap(options)->setWarnOnTruncation(value);
+}
+
 void circtFirtoolOptionsSetLowerToCore(CirctFirtoolFirtoolOptions options,
                                        bool value) {
   unwrap(options)->setLowerToCore(value);

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -39,23 +39,25 @@ Value TieOffCache::getUnknown(PropertyType type) {
 //===----------------------------------------------------------------------===//
 
 void circt::firrtl::emitConnect(OpBuilder &builder, Location loc, Value dst,
-                                Value src) {
+                                Value src, bool warnOnTruncation) {
   ImplicitLocOpBuilder locBuilder(loc, builder.getInsertionBlock(),
                                   builder.getInsertionPoint());
-  emitConnect(locBuilder, dst, src);
+  emitConnect(locBuilder, dst, src, warnOnTruncation);
   builder.restoreInsertionPoint(locBuilder.saveInsertionPoint());
 }
 
 void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
-                                Value src) {
-  emitConnect(builder, dst, src, [&] { return builder.getLoc(); });
+                                Value src, bool warnOnTruncation) {
+  emitConnect(
+      builder, dst, src, [&] { return builder.getLoc(); }, warnOnTruncation);
 }
 
 template <typename ATy, typename IndexOp, bool isBundle /* check flip? */>
 static LogicalResult
 connectIfAggregates(ImplicitLocOpBuilder &builder, Value dst,
                     FIRRTLType dstFType, Value src, FIRRTLType srcFType,
-                    llvm::function_ref<Location()> getDiagLoc) {
+                    llvm::function_ref<Location()> getDiagLoc,
+                    bool warnOnTruncation) {
   auto dstAggTy = type_dyn_cast<ATy>(dstFType);
   if (!dstAggTy)
     return failure();
@@ -79,7 +81,7 @@ connectIfAggregates(ImplicitLocOpBuilder &builder, Value dst,
       if (dstAggTy.getElement(i).isFlip)
         std::swap(dstField, srcField);
     }
-    emitConnect(builder, dstField, srcField, getDiagLoc);
+    emitConnect(builder, dstField, srcField, getDiagLoc, warnOnTruncation);
   }
 
   return success();
@@ -88,7 +90,8 @@ connectIfAggregates(ImplicitLocOpBuilder &builder, Value dst,
 /// Emit a connect between two values.
 void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
                                 Value src,
-                                llvm::function_ref<Location()> getDiagLoc) {
+                                llvm::function_ref<Location()> getDiagLoc,
+                                bool warnOnTruncation) {
   auto dstFType = type_cast<FIRRTLType>(dst.getType());
   auto srcFType = type_cast<FIRRTLType>(src.getType());
   auto dstType = type_dyn_cast<FIRRTLBaseType>(dstFType);
@@ -108,10 +111,12 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
                type_isa<DomainType>(srcFType)) {
       DomainDefineOp::create(builder, dst, src);
     } else if (failed(connectIfAggregates<OpenBundleType, OpenSubfieldOp, true>(
-                   builder, dst, dstFType, src, srcFType, getDiagLoc)) &&
+                   builder, dst, dstFType, src, srcFType, getDiagLoc,
+                   warnOnTruncation)) &&
                failed(
                    connectIfAggregates<OpenVectorType, OpenSubindexOp, false>(
-                       builder, dst, dstFType, src, srcFType, getDiagLoc))) {
+                       builder, dst, dstFType, src, srcFType, getDiagLoc,
+                       warnOnTruncation))) {
       // Other types, give up and leave a connect
       ConnectOp::create(builder, dst, src);
     }
@@ -132,9 +137,10 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   }
 
   if (succeeded(connectIfAggregates<BundleType, SubfieldOp, true>(
-          builder, dst, dstFType, src, srcFType, getDiagLoc)) ||
+          builder, dst, dstFType, src, srcFType, getDiagLoc,
+          warnOnTruncation)) ||
       succeeded(connectIfAggregates<FVectorType, SubindexOp, false>(
-          builder, dst, dstFType, src, srcFType, getDiagLoc)))
+          builder, dst, dstFType, src, srcFType, getDiagLoc, warnOnTruncation)))
     return;
 
   if ((dstType.hasUninferredReset() || srcType.hasUninferredReset()) &&
@@ -164,9 +170,10 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
 
   // The source must be extended or truncated.
   if (dstWidth < srcWidth) {
-    mlir::emitWarning(getDiagLoc())
-        << "RHS width " << srcWidth << " exceeds LHS width " << dstWidth
-        << ", inserting implicit truncation";
+    if (warnOnTruncation)
+      mlir::emitWarning(getDiagLoc())
+          << "RHS width " << srcWidth << " exceeds LHS width " << dstWidth
+          << ", inserting implicit truncation";
 
     // firrtl.tail always returns uint even for sint operands.
     IntType tmpType =

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2153,7 +2153,8 @@ void FIRStmtParser::emitInvalidate(Value val, Flow flow) {
   if (props.isPassive && !props.containsAnalog) {
     if (flow == Flow::Source)
       return;
-    emitConnect(builder, val, InvalidValueOp::create(builder, tpe));
+    emitConnect(builder, val, InvalidValueOp::create(builder, tpe),
+                getConstants().options.warnOnTruncation);
     return;
   }
 
@@ -3976,9 +3977,11 @@ ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
         // Connect to/from the result per flow.
         builder.setInsertionPointAfter(defining);
         if (foldFlow(instResult) == Flow::Source)
-          emitConnect(builder, bounceVal, instResult);
+          emitConnect(builder, bounceVal, instResult,
+                      getConstants().options.warnOnTruncation);
         else
-          emitConnect(builder, instResult, bounceVal);
+          emitConnect(builder, instResult, bounceVal,
+                      getConstants().options.warnOnTruncation);
         // Set the parse result AND update `instResult` which is a reference to
         // the unbundled entry for the instance result, so that future uses also
         // find this new wire.
@@ -4227,7 +4230,7 @@ ParseResult FIRStmtParser::parseDomainDefine() {
       parseDomainExp(src) || parseOptionalInfo())
     return failure();
 
-  emitConnect(builder, dest, src);
+  emitConnect(builder, dest, src, getConstants().options.warnOnTruncation);
   return success();
 }
 
@@ -4267,7 +4270,7 @@ ParseResult FIRStmtParser::parseRefDefine() {
            << target.getType() << " with incompatible reference of type "
            << src.getType();
 
-  emitConnect(builder, target, src);
+  emitConnect(builder, target, src, getConstants().options.warnOnTruncation);
 
   return success();
 }
@@ -4570,8 +4573,9 @@ ParseResult FIRStmtParser::parseConnect() {
            << rhsType << " to " << lhsType;
 
   locationProcessor.setLoc(loc);
-  emitConnect(builder, lhs, rhs,
-              [&] { return locationProcessor.getLoc(*this, loc); });
+  emitConnect(
+      builder, lhs, rhs, [&] { return locationProcessor.getLoc(*this, loc); },
+      getConstants().options.warnOnTruncation);
   return success();
 }
 
@@ -4789,8 +4793,9 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
     return mlir::emitError(locationProcessor.getLoc(*this, loc),
                            "cannot connect non-equivalent type ")
            << rhsType << " to " << lhsType;
-  emitConnect(builder, lhs, rhs,
-              [&] { return locationProcessor.getLoc(*this, loc); });
+  emitConnect(
+      builder, lhs, rhs, [&] { return locationProcessor.getLoc(*this, loc); },
+      getConstants().options.warnOnTruncation);
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -2027,7 +2027,8 @@ namespace {
 /// of variables and constraints to be solved later.
 class InferenceTypeUpdate {
 public:
-  InferenceTypeUpdate(InferenceMapping &mapping) : mapping(mapping) {}
+  InferenceTypeUpdate(InferenceMapping &mapping, bool warnOnTruncation)
+      : mapping(mapping), warnOnTruncation(warnOnTruncation) {}
 
   LogicalResult update(CircuitOp op);
   FailureOr<bool> updateOperation(Operation *op);
@@ -2036,6 +2037,7 @@ public:
 
 private:
   const InferenceMapping &mapping;
+  const bool warnOnTruncation;
 };
 
 } // namespace
@@ -2088,8 +2090,9 @@ FailureOr<bool> InferenceTypeUpdate::updateOperation(Operation *op) {
     auto lhsWidth = lhsType.getBitWidthOrSentinel();
     auto rhsWidth = rhsType.getBitWidthOrSentinel();
     if (lhsWidth >= 0 && rhsWidth >= 0 && lhsWidth < rhsWidth) {
-      con.emitWarning() << "RHS width " << rhsWidth << " exceeds LHS width "
-                        << lhsWidth << ", inserting implicit truncation";
+      if (warnOnTruncation)
+        con.emitWarning() << "RHS width " << rhsWidth << " exceeds LHS width "
+                          << lhsWidth << ", inserting implicit truncation";
       OpBuilder builder(op);
       auto trunc = builder.createOrFold<TailPrimOp>(con.getLoc(), con.getSrc(),
                                                     rhsWidth - lhsWidth);
@@ -2272,6 +2275,7 @@ FIRRTLBaseType InferenceTypeUpdate::updateType(FieldRef fieldRef,
 namespace {
 class InferWidthsPass
     : public circt::firrtl::impl::InferWidthsBase<InferWidthsPass> {
+  using Base::Base;
   void runOnOperation() override;
 };
 } // namespace
@@ -2293,6 +2297,7 @@ void InferWidthsPass::runOnOperation() {
     return signalPassFailure();
 
   // Update the types with the inferred widths.
-  if (failed(InferenceTypeUpdate(mapping).update(getOperation())))
+  if (failed(InferenceTypeUpdate(mapping, warnOnTruncation)
+                 .update(getOperation())))
     return signalPassFailure();
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -84,7 +84,10 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       firrtl::createLowerMatches());
 
   // Width inference creates canonicalization opportunities.
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidths());
+  firrtl::InferWidthsOptions inferWidthsOptions;
+  inferWidthsOptions.warnOnTruncation = opt.shouldWarnOnTruncation();
+  pm.nest<firrtl::CircuitOp>().addPass(
+      firrtl::createInferWidths(inferWidthsOptions));
 
   if (opt.shouldUseNewFullResetFlow()) {
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResets());
@@ -699,6 +702,11 @@ public:
           "Warn about annotations that were not removed by lower-to-hw"),
       llvm::cl::init(false)};
 
+  llvm::cl::opt<bool> warnOnTruncation{
+      "warn-on-truncation",
+      llvm::cl::desc("Warn when connects require implicit truncation"),
+      llvm::cl::init(false)};
+
   llvm::cl::opt<bool> lowerToCore{
       "lower-to-core",
       llvm::cl::desc("Prefer core dialects over direct SV lowering for FIRRTL "
@@ -871,7 +879,8 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       lowerMemories(false), blackBoxRootPath(""), replSeqMem(false),
       replSeqMemFile(""), ignoreReadEnableMem(false), useNewFullResetFlow(true),
       disableRandom(RandomKind::None), outputAnnotationFilename(""),
-      enableAnnotationWarning(false), lowerToCore(false), addMuxPragmas(false),
+      enableAnnotationWarning(false), warnOnTruncation(false),
+      lowerToCore(false), addMuxPragmas(false),
       verificationFlavor(firrtl::VerificationFlavor::None),
       emitSeparateAlwaysBlocks(false),
       addVivadoRAMAddressConflictSynthesisBugWorkaround(false),
@@ -913,6 +922,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   disableRandom = clOptions->disableRandomValue;
   outputAnnotationFilename = clOptions->outputAnnotationFilename;
   enableAnnotationWarning = clOptions->enableAnnotationWarning;
+  warnOnTruncation = clOptions->warnOnTruncation;
   lowerToCore = clOptions->lowerToCore;
   addMuxPragmas = clOptions->addMuxPragmas;
   verificationFlavor = clOptions->verificationFlavor;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -703,7 +703,7 @@ public:
       llvm::cl::init(false)};
 
   llvm::cl::opt<bool> warnOnTruncation{
-      "warn-on-truncation",
+      "warn-on-implicit-truncation",
       llvm::cl::desc("Warn when connects require implicit truncation"),
       llvm::cl::init(false)};
 

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-widths{warn-on-truncation=true}))' --verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-widths{warn-on-implicit-truncation=true}))' --verify-diagnostics %s | FileCheck %s
 
 firrtl.circuit "Foo" {
   // CHECK-LABEL: @InferConstant

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-widths))' --verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-widths{warn-on-truncation=true}))' --verify-diagnostics %s | FileCheck %s
 
 firrtl.circuit "Foo" {
   // CHECK-LABEL: @InferConstant

--- a/test/firtool/connect-errors.fir
+++ b/test/firtool/connect-errors.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --format=fir --parse-only -verify-diagnostics --split-input-file --warn-on-truncation
+; RUN: firtool %s --format=fir --parse-only -verify-diagnostics --split-input-file --warn-on-implicit-truncation
 
 ; CHECK-LABEL: outOfOrderFields
 FIRRTL version 4.0.0

--- a/test/firtool/connect-errors.fir
+++ b/test/firtool/connect-errors.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --format=fir --parse-only -verify-diagnostics --split-input-file
+; RUN: firtool %s --format=fir --parse-only -verify-diagnostics --split-input-file --warn-on-truncation
 
 ; CHECK-LABEL: outOfOrderFields
 FIRRTL version 4.0.0

--- a/test/firtool/truncation-warnings.fir
+++ b/test/firtool/truncation-warnings.fir
@@ -1,0 +1,14 @@
+; RUN: firtool %s --format=fir --ir-fir 2>&1 | FileCheck %s
+; RUN: firtool %s --format=fir --ir-fir --warn-on-truncation=false | FileCheck %s
+; RUN: firtool %s --format=fir --ir-fir --warn-on-truncation --verify-diagnostics
+; RUN: firtool %s --format=fir --ir-fir --warn-on-truncation=true --verify-diagnostics
+
+FIRRTL version 4.0.0
+circuit TruncWarn :
+  public module TruncWarn :
+    input in : UInt<7>
+    output out : UInt<4>
+    ; expected-warning@below {{RHS width 7 exceeds LHS width 4, inserting implicit truncation}}
+    connect out, in
+
+; CHECK: firrtl.circuit

--- a/test/firtool/truncation-warnings.fir
+++ b/test/firtool/truncation-warnings.fir
@@ -1,7 +1,7 @@
 ; RUN: firtool %s --format=fir --ir-fir 2>&1 | FileCheck %s
-; RUN: firtool %s --format=fir --ir-fir --warn-on-truncation=false | FileCheck %s
-; RUN: firtool %s --format=fir --ir-fir --warn-on-truncation --verify-diagnostics
-; RUN: firtool %s --format=fir --ir-fir --warn-on-truncation=true --verify-diagnostics
+; RUN: firtool %s --format=fir --ir-fir --warn-on-implicit-truncation=false 2>&1 | FileCheck %s
+; RUN: firtool %s --format=fir --ir-fir --warn-on-implicit-truncation --verify-diagnostics
+; RUN: firtool %s --format=fir --ir-fir --warn-on-implicit-truncation=true --verify-diagnostics
 
 FIRRTL version 4.0.0
 circuit TruncWarn :
@@ -12,3 +12,4 @@ circuit TruncWarn :
     connect out, in
 
 ; CHECK: firrtl.circuit
+; CHECK-NOT: RHS width 7 exceeds LHS width 4, inserting implicit truncation

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -435,6 +435,7 @@ static LogicalResult processBuffer(
     options.scalarizePublicModules = scalarizePublicModules;
     options.scalarizeInternalModules = scalarizeIntModules;
     options.scalarizeExtModules = scalarizeExtModules;
+    options.warnOnTruncation = firtoolOptions.shouldWarnOnTruncation();
     options.enableLayers = enableLayers;
     options.disableLayers = disableLayers;
     options.selectInstanceChoice = selectInstanceChoice;


### PR DESCRIPTION
Add a new firtool option `-warn-on-truncation` (with a false default)
which can be used to enable the connect truncation warnings added in an
earlier patch [^1].

The connect truncation warnings during FIRRTL parsing and width inference
are creating a ton of output.  E.g., an internal design had a 39 MiB log
with 38 MiB of that being these warnings.  This is also why this is
implemented with a false default.

[^1]: 2165ba33e844074deb7cea64b79966285c693943

Assisted-by: pi.dev:gpt-5.6-luna
