### PR TITLE
[Sim] Add `sim.assoc_array.clear` op

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -1299,6 +1299,16 @@ def AssocArrayPrevOp : SimOp<"assoc_array.prev", [Pure,
   let assemblyFormat = "$array `[` $index `]` attr-dict `:` type($array)";
 }
 
+def AssocArrayClearOp : SimOp<"assoc_array.clear", [Pure, AllTypesMatch<["array", "outArray"]>]> {
+  let summary = "Clears all entries from an associative array";
+  let description = [{
+  Returns an empty associative array of the exact same type as the input array.
+  }];
+  let arguments = (ins AssocArrayType:$array);
+  let results = (outs AssocArrayType:$outArray);
+  let assemblyFormat = "$array attr-dict `:` type($array)";
+}
+
 //===----------------------------------------------------------------------===//
 // Simulation Control
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -195,3 +195,9 @@ hw.module @FormatString(in %str: !sim.dstring) {
   // CHECK: sim.fmt.string %str isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
   %fmt1 = sim.fmt.string %str isLeftAligned true paddingChar 48 specifierWidth 8 : !sim.dstring
 }
+
+// CHECK-LABEL: hw.module @assoc_array_clear
+hw.module @assoc_array_clear(in %array : !sim.assoc_array<i64, i32>) {
+  // CHECK: sim.assoc_array.clear %array : <i64, i32>
+  %0 = sim.assoc_array.clear %array : !sim.assoc_array<i64, i32>
+}


### PR DESCRIPTION
Adds `sim.assoc_array.clear`, which returns and empty associative array of the same type as its input. This work is part of ongoing work to add simulation hashtable support within CIRCT. An explicit operation is the cleaner choice  here than pattern-matching a whole array store in the emitter because it gives the lowering a single anchor for the places a table gets emptied from (e.g. reset, a clear port).