### PR TITLE
[HW][Sim] Add SimulationVariableTypeInterface to let `hw.inout` hold sim value types 

### DIFF
--- a/include/circt/Dialect/HW/HWTypeInterfaces.td
+++ b/include/circt/Dialect/HW/HWTypeInterfaces.td
@@ -97,4 +97,13 @@ def BitWidthTypeInterface : TypeInterface<"BitWidthTypeInterface"> {
   ];
 }
 
+def SimulationVariableTypeInterface : TypeInterface<"SimulationVariableTypeInterface"> {
+  let cppNamespace = "circt::hw";
+  let description = [{
+  Marks non-synthesizable simulation types with value semantics (e.g. `!sim.assoc_array`)
+  so they can be held in procedural state containers (e.g. `hw.inout`, `sv.reg`) while remaining excluded
+  from physical `isHWValueType` structures like module ports.
+  }];
+}
+
 #endif // CIRCT_DIALECT_HW_HWTYPEINTERFACES_TD

--- a/include/circt/Dialect/Sim/SimTypes.h
+++ b/include/circt/Dialect/Sim/SimTypes.h
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_SIM_SIMTYPES_H
 #define CIRCT_DIALECT_SIM_SIMTYPES_H
 
+#include "circt/Dialect/HW/HWTypeInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"

--- a/include/circt/Dialect/Sim/SimTypes.td
+++ b/include/circt/Dialect/Sim/SimTypes.td
@@ -10,10 +10,11 @@
 #define CIRCT_DIALECT_SIM_SIMTYPES_TD
 
 include "circt/Dialect/Sim/SimDialect.td"
+include "circt/Dialect/HW/HWTypeInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 
-class SimTypeDef<string name> : TypeDef<SimDialect, name> { }
+class SimTypeDef<string name, list<Trait> traits = []> : TypeDef<SimDialect, name, traits> { }
 
 def FormatStringType : SimTypeDef<"FormatString"> {
   let mnemonic = "fstring";
@@ -27,7 +28,7 @@ def FormatStringType : SimTypeDef<"FormatString"> {
   }];
 }
 
-def DynamicStringType : SimTypeDef<"DynamicString"> {
+def DynamicStringType : SimTypeDef<"DynamicString", [SimulationVariableTypeInterface]> {
   let mnemonic = "dstring";
 
   let summary = "String type with variable length";
@@ -45,7 +46,7 @@ def DynamicStringType : SimTypeDef<"DynamicString"> {
   }];
 }
 
-def QueueType : SimTypeDef<"Queue"> {
+def QueueType : SimTypeDef<"Queue", [SimulationVariableTypeInterface]> {
   let mnemonic = "queue";
   let summary = "a queue type";
   let description = [{
@@ -73,7 +74,7 @@ def QueueType : SimTypeDef<"Queue"> {
   ];
 }
 
-def AssocArrayType : SimTypeDef<"AssocArray"> {
+def AssocArrayType : SimTypeDef<"AssocArray", [SimulationVariableTypeInterface]> {
   let mnemonic = "assoc_array";
   let summary = "an associative array type";
   let description = [{

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -879,7 +879,8 @@ std::optional<int64_t> UnpackedArrayType::getBitWidth() const {
 
 LogicalResult InOutType::verify(function_ref<InFlightDiagnostic()> emitError,
                                 Type innerType) {
-  if (!isHWValueType(innerType))
+  if (!isHWValueType(innerType) &&
+      !isa<SimulationVariableTypeInterface>(innerType))
     return emitError() << "invalid element for hw.inout type " << innerType;
   return success();
 }

--- a/test/Dialect/Sim/storage.mlir
+++ b/test/Dialect/Sim/storage.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-opt --verify-roundtrip --verify-diagnostics %s | FileCheck %s
+
+
+// CHECK-LABEL: hw.module @assoc_array_storage
+hw.module @assoc_array_storage() {
+  // CHECK: sv.reg : !hw.inout<!sim.assoc_array<i32, i32>>
+  %0 = sv.reg : !hw.inout<!sim.assoc_array<i32, i32>>
+}
+
+// CHECK-LABEL: hw.module @queue_storage
+hw.module @queue_storage() {
+  // CHECK: sv.reg : !hw.inout<!sim.queue<i8, 0>>
+  %0 = sv.reg : !hw.inout<!sim.queue<i8, 0>>
+}
+
+// CHECK-LABEL: hw.module @dstring_storage
+hw.module @dstring_storage() {
+  // CHECK: sv.reg : !hw.inout<!sim.dstring>
+  %0 = sv.reg : !hw.inout<!sim.dstring>
+}


### PR DESCRIPTION
In this PR we add a marker interface, SimulationVariableTypeInterface, implemented on `!sim.assoc_array, !sim.queue, and !sim.dstring`. InOutType::verify now accepts either a normal HW value type or this interface, so `sv.reg/hw.inout` can hold these simulation-only types.

We chose this over widening isHWValueType directly, since it has too many call sites and would let types leak into module ports, `hw.array`, etc. This keeps the change scope concise ( ports and aggregates still reject these types).