### PR TITLE
[ESI][Cosim] Link lz4 for Verilator FST tracing builds

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
@@ -334,10 +334,11 @@ set_source_files_properties(
 )
 """
 
-    # zlib is only needed when FST tracing (debug builds) is enabled.
+    # Verilator's FST writer (debug builds) pulls in both zlib and lz4.
     if self.debug:
-      zlib_find = "find_package(ZLIB REQUIRED)"
-      zlib_link = "ZLIB::ZLIB"
+      zlib_find = ("find_package(ZLIB REQUIRED)\n"
+                   "find_library(LZ4_LIBRARY NAMES lz4 REQUIRED)")
+      zlib_link = "ZLIB::ZLIB\n  ${LZ4_LIBRARY}"
     else:
       zlib_find = ""
       zlib_link = ""


### PR DESCRIPTION
Verilator's FST writer (verilated_fst_c.cpp) depends on both zlib and lz4,
as reflected in Verilator's own verilated.mk (LDLIBS += -llz4 -lz when
VM_TRACE_FST). The generated CMakeLists only linked zlib, so any --debug
cosim build failed at link time with undefined references to
LZ4_compressBound and LZ4_compress_default.

Assisted-by: GitHub Copilot:claude-opus-5

