### PR TITLE
[ESI][Cosim] Raise the stack limit before running verilator_bin

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
@@ -121,6 +121,26 @@ class Verilator(Simulator):
     return shutil.which("cmake") is not None and \
         shutil.which("ninja") is not None
 
+  @staticmethod
+  def _raise_stack_limit() -> None:
+    """Lift the stack soft limit to the hard limit for the verilator process.
+
+    Verilator recurses over the design AST and segfaults on large designs with
+    the usual 8MB stack. Its ``verilator`` wrapper script normally runs
+    ``ulimit -s unlimited`` first; we invoke ``verilator_bin`` directly and so
+    have to do it ourselves. Subprocesses inherit the raised limit.
+    """
+    if os.name == "nt":
+      return
+    import resource
+    soft, hard = resource.getrlimit(resource.RLIMIT_STACK)
+    if soft == hard:
+      return
+    try:
+      resource.setrlimit(resource.RLIMIT_STACK, (hard, hard))
+    except (ValueError, OSError):
+      pass
+
   def compile_commands(self) -> List[Simulator.CompileStep]:
     """Return the compile steps for the full compile flow.
 
@@ -142,6 +162,7 @@ class Verilator(Simulator):
     if verilator_root is None:
       raise RuntimeError(Verilator.VerilatorRootNotFound)
     os.environ["VERILATOR_ROOT"] = str(verilator_root)
+    self._raise_stack_limit()
 
     verilator_cmd: List[str] = [
         str(verilator_bin),


### PR DESCRIPTION
Verilator recurses over the design AST and overflows the usual 8MB stack on
large designs, dying with SIGSEGV partway through verilation. Verilator ships
a wrapper script that runs 'ulimit -s unlimited' before exec'ing the real
binary, but this flow deliberately calls verilator_bin directly and so never
got that treatment.

Lift RLIMIT_STACK from the soft to the hard limit before spawning verilator;
subprocesses inherit it. No-op when the two already match, and skipped on
Windows.

Reproduced on a large design (186MB of generated RTL): verilation died with
SIGSEGV (rc 139) after 44s with the inherited 8MB soft limit, and completed
successfully once the limit was raised. The hard limit was already unlimited,
so nothing but the unraised soft limit was preventing the build from working.

Assisted-by: GitHub Copilot:claude-opus-5

