### PR TITLE
[ESI][Cosim] Prefer clang and lld for building the verilated model

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
@@ -141,6 +141,25 @@ class Verilator(Simulator):
     except (ValueError, OSError):
       pass
 
+  @staticmethod
+  def _toolchain_args() -> List[str]:
+    """Prefer clang and lld when they are available.
+
+    Verilated code compiles about twice as fast with clang as with gcc, and
+    the model is a throwaway simulation binary, so the toolchain only affects
+    build time. Setting ``CXX`` or ``LDFLAGS`` opts back out.
+    """
+    if os.name == "nt":
+      return []
+    args = []
+    if not os.environ.get("CXX"):
+      clangxx = shutil.which("clang++")
+      if clangxx is not None:
+        args.append(f"-DCMAKE_CXX_COMPILER={clangxx}")
+    if not os.environ.get("LDFLAGS") and shutil.which("ld.lld") is not None:
+      args.append("-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld")
+    return args
+
   def compile_commands(self) -> List[Simulator.CompileStep]:
     """Return the compile steps for the full compile flow.
 
@@ -206,6 +225,7 @@ class Verilator(Simulator):
           "cmake", "-G", "Ninja", "-DCMAKE_BUILD_TYPE=Release", "-S", build_dir,
           "-B", build_dir
       ]
+      cmake_cmd += self._toolchain_args()
       # If vcpkg is available, use its toolchain file so that
       # ``find_package(ZLIB)`` (and other transitive deps) can pick up vcpkg
       # installations. This is the standard story on Windows.


### PR DESCRIPTION
Verilated code compiles far faster with clang than with gcc. The cosim model
is a throwaway simulation binary, so the toolchain affects only build time,
which makes this close to free speedup wherever clang is installed.

Pass -DCMAKE_CXX_COMPILER when clang++ is on PATH and -fuse-ld=lld when ld.lld
is on PATH. Setting CXX or LDFLAGS opts back out of the respective choice, and
both degrade silently to the system default when the tools are absent. Skipped
on Windows, where the MSVC/vcpkg path is the supported story.

Measured on the large design (186MB of generated RTL), cold build, pinned to
32 cores:
                        gcc        clang+lld
  total              573.4s          294.4s   (1.95x)
  C++ build          339.1s           61.3s   (5.5x)
  slowest file        68.6s            8.7s   (7.9x)

The slowest translation unit is the root class constructor/destructor, which
is tiny but instantiates member init and teardown for a class with well over
a hundred thousand members; gcc's optimizer scales badly on it.

Assisted-by: GitHub Copilot:claude-opus-5

