### PR TITLE
[ESI][Cosim] Tune --output-split for the C++ build

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/cosim/verilator.py
@@ -226,8 +226,10 @@ class Verilator(Simulator):
         "-sv",
         "--verilate-jobs",
         "0",
+        # Every generated .cpp re-parses the model headers, so file count sets
+        # the floor for the C++ build; 5000 balances that against parallelism.
         "--output-split",
-        "2500",
+        "5000",
     ]
     if self.debug:
       verilator_cmd += [


### PR DESCRIPTION
Every generated .cpp includes the model headers, so on a big design each
translation unit re-parses a multi-megabyte symbol table and root class header
before compiling any code. That fixed cost was measured at roughly a second per
file even with a precompiled header, which makes file count, not file size, the
floor for the C++ phase. Splitting too finely multiplies that cost; splitting
too coarsely leaves one huge translation unit on the critical path and starves
the available cores.

The flow forced 2500, which is well into the too-fine regime. Sweeping the knob
across three designs and two Verilator versions (cold build, clang, pinned to
32 cores), total build time:

  Verilator 5.048       2500      5000     10000     20000 (verilator default)
    large             284.3s    264.3s    256.1s    261.1s
    medium             29.7s     28.0s     30.3s     35.4s
    esitester          70.0s     69.4s     69.1s     70.2s

  Verilator 5.050       2500      5000     10000     20000
    large             290.3s    267.4s    258.7s    256.2s
    medium             29.0s     27.2s     28.1s     29.8s

5000 is the only value that improves every design on both versions, so take it.
10000 and 20000 are faster still on the large design, but each regresses the
medium one on at least one Verilator version, so neither is a safe default.

Measured end to end on the large design, this lowers the C++ build from 53.8s
to 36.0s and the total from 281.8s to 264.8s.

The optimum is design-dependent and moves with the Verilator version: the
penalty for Verilator's own default of 20000 on the medium design falls from
+19% on 5.048 to +3% on 5.050. This is a better default, not a universal
constant.

Assisted-by: GitHub Copilot:claude-opus-5

