### PR TITLE
[ci] Drop -large runners in UBTI workflow_dispatch

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -30,9 +30,11 @@ on:
           - ubuntu-24.04
           - ubuntu-22.04
           - ubuntu-20.04
-          - macos-15-large
+          - xcode-27
+          - macos-26
+          - macos-26-intel
           - macos-15
-          - macos-14-large
+          - macos-15-intel
           - macos-14
           - macos-13
           - windows-2022


### PR DESCRIPTION
Prevent developers from accidentally running the UBTI via
workflow_dispatch with a runner which costs the LLVM foundation money.
Any `-large` or `-xlarge` runner will do this.
