### PR TITLE
[ci] Don't build/test Python on macos-*-intel

### DIFF
--- a/.github/bin/uploadReleaseArtifacts.sh
+++ b/.github/bin/uploadReleaseArtifacts.sh
@@ -29,7 +29,7 @@ OPT_GITHUB_EVENT_NAME=
 OPT_OS=()
 OPT_RUN_TESTS=false
 OPT_RUN_INTEGRATION_TESTS=false
-while getopts "ab:e:ho:t" option; do
+while getopts "ab:e:ho:tu" option; do
   case $option in
     a)
       OPT_ASSERTIONS=ON
@@ -181,7 +181,7 @@ EOF
 configMacOsRunner=$(cat <<EOF
 [
   {
-    "runner": "macos-15-large",
+    "runner": "macos-26-intel",
     "cmake_c_compiler": "clang"
   },
   {

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -317,6 +317,9 @@ jobs:
           echo setup=./utils/find-vs.ps1 >> "$GITHUB_OUTPUT"
       - name: Python Bindings Setup (Generic)
         id: python-bindings-setup-generic
+        # The Python bindings and PyRTG frontend are too expensive to build on
+        # macOS Intel runners.  Keep them enabled everywhere else.
+        if: runner.os != 'macOS' || runner.arch != 'X64'
         shell: bash
         run: |
           # Install Python dependencies needed for the MLIR/CIRCT Python
@@ -422,7 +425,7 @@ jobs:
           ${{ steps.setup-windows.outputs.setup }}
           ninja -C build check-circt-capi check-circt-integration
       - name: Test PyRTG
-        if: inputs.run_tests
+        if: inputs.run_tests && (runner.os != 'macOS' || runner.arch != 'X64')
         run: |
           ${{ steps.setup-windows.outputs.setup }}
           ninja -C build check-pyrtg


### PR DESCRIPTION
GitHub Actions CI macOS Intel runners are too underpowered to build MLIR +
CIRCT with Python Bindings enabled.  These consistently run over the
6-hour time limit on both the macos-15-intel and macos-26-intel runners.
These _do build_ with the `-large` runners.  However, those incur a cost
for the LLVM foundation.

Given that the macOS 27 is dropping support for Intel, there is no point
in trying to aggressively test these builds.  This is more about keeping
the lights on until we can drop these.

Fixes #11005.

Assisted-by: pi.dev:gpt-5.6-luna