### PR TITLE
[circt-bmc][circt-lec][arcilator] Register codegen passes before JIT

### DIFF
--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(ARCILATOR_JIT_ENABLED)
   add_compile_definitions(ARCILATOR_ENABLE_JIT)
-  set(ARCILATOR_JIT_LLVM_COMPONENTS native OrcJIT)
+  set(ARCILATOR_JIT_LLVM_COMPONENTS native OrcJIT codegen)
   set(ARCILATOR_JIT_DEPS
     CIRCTArcJITRuntime
     MLIRExecutionEngine

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -85,6 +85,8 @@
 #define ARC_RUNTIME_JITBIND_FNDECL
 #include "circt/Dialect/Arc/Runtime/Common.h"
 #include "circt/Dialect/Arc/Runtime/JITBind.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/PassRegistry.h"
 #endif
 
 #include <optional>
@@ -873,6 +875,7 @@ int main(int argc, char **argv) {
 #ifdef ARCILATOR_ENABLE_JIT
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
+    llvm::initializeCodeGen(*llvm::PassRegistry::getPassRegistry());
 #else
     llvm::errs() << "This arcilator binary was not built with JIT support.\n";
     llvm::errs() << "To enable JIT features, build arcilator with MLIR's "

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(MLIR_ENABLE_EXECUTION_ENGINE)
   add_compile_definitions(CIRCT_BMC_ENABLE_JIT)
-  set(CIRCT_BMC_JIT_LLVM_COMPONENTS native OrcJIT)
+  set(CIRCT_BMC_JIT_LLVM_COMPONENTS native OrcJIT codegen)
   set(CIRCT_BMC_JIT_DEPS
     MLIRExecutionEngine
     MLIRExecutionEngineUtils

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -65,6 +65,8 @@
 #ifdef CIRCT_BMC_ENABLE_JIT
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/PassRegistry.h"
 #include "llvm/Support/TargetSelect.h"
 #endif
 
@@ -354,6 +356,7 @@ static LogicalResult executeBMC(MLIRContext &context) {
 
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
+    llvm::initializeCodeGen(*llvm::PassRegistry::getPassRegistry());
 
     SmallVector<StringRef, 4> sharedLibraries(sharedLibs.begin(),
                                               sharedLibs.end());

--- a/tools/circt-lec/CMakeLists.txt
+++ b/tools/circt-lec/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(MLIR_ENABLE_EXECUTION_ENGINE)
   add_compile_definitions(CIRCT_LEC_ENABLE_JIT)
-  set(CIRCT_LEC_JIT_LLVM_COMPONENTS native)
+  set(CIRCT_LEC_JIT_LLVM_COMPONENTS native codegen)
   set(CIRCT_LEC_JIT_DEPS
     MLIRExecutionEngine
     MLIRExecutionEngineUtils

--- a/tools/circt-lec/circt-lec.cpp
+++ b/tools/circt-lec/circt-lec.cpp
@@ -58,6 +58,8 @@
 #ifdef CIRCT_LEC_ENABLE_JIT
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/PassRegistry.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/TargetSelect.h"
 #endif
@@ -317,6 +319,7 @@ static LogicalResult executeLEC(MLIRContext &context) {
 
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
+    llvm::initializeCodeGen(*llvm::PassRegistry::getPassRegistry());
 
     SmallVector<StringRef, 4> sharedLibraries(sharedLibs.begin(),
                                               sharedLibs.end());


### PR DESCRIPTION
These tools JIT through `mlir::ExecutionEngine` but only call `InitializeNativeTarget[AsmPrinter]`, never registering the legacy codegen passes. The JIT's codegen pipeline now needs `ObjCARCContract`, so on assertions builds it aborts (`"Expected required passes to be initialized"`), leaving no output → the `circt-bmc` integration tests fail with FileCheck `'<stdin>' is empty`.

Fix: call `llvm::initializeCodeGen(*llvm::PassRegistry::getPassRegistry())` after target init. (`circt-lec`/`arcilator` share the same gap and get the same fix.)

### How to reproduce

The JIT path is only compiled with `MLIR_ENABLE_EXECUTION_ENGINE=ON`, so the `circt-bmc-jit` integration tests are UNSUPPORTED (skipped) in a default build — which is why this hasn't shown up in CI. Build with the execution engine **and** assertions, then run any circt-bmc JIT test:

```
cmake -S llvm/llvm -B build -G Ninja \
  -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt \
  -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=$PWD \
  -DLLVM_ENABLE_ASSERTIONS=ON \
  -DMLIR_ENABLE_EXECUTION_ENGINE=ON \
  -DLLVM_TARGETS_TO_BUILD=host
ninja -C build circt-bmc
build/bin/circt-bmc integration_test/circt-bmc/comb.mlir -b 10 \
  --module OrCommutes --shared-libs=/path/to/libz3.so
```

Before this change it aborts with `Pass 'ObjC ARC contraction' is not initialized` (LegacyPassManager assertion); after it, the module JITs and the test passes. `ninja check-circt-integration` with z3 available exercises all of them.

Assisted-by: ClaudeCode:fable

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
