### PR TITLE
[PyCDE] Add seq.DownCounter, fix Counter clear/increment priority

### DIFF
--- a/frontends/PyCDE/src/pycde/constructs.py
+++ b/frontends/PyCDE/src/pycde/constructs.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from .common import Clock, Input, Output, Reset
 from .dialects import comb, msft, sv
 from .module import generator, modparams, Module, _BlockContext
+from .seq import Counter
 from .signals import ArraySignal, BitsSignal, BitVectorSignal, Signal
 from .signals import get_slice_bounds, _FromCirctValue
 from .support import get_user_loc
@@ -260,29 +261,3 @@ def SystolicArray(row_inputs: ArraySignal, col_inputs: ArraySignal, pe_builder):
   dummy_op.operation.erase()
 
   return _FromCirctValue(array.peOutputs)
-
-
-@modparams
-def Counter(width: int):
-  """Construct a counter with the specified width. Increment the counter on the
-  if the increment signal is asserted."""
-
-  class Counter(Module):
-    clk = Clock()
-    rst = Reset()
-    clear = Input(Bits(1))
-    increment = Input(Bits(1))
-    out = Output(UInt(width))
-
-    @generator
-    def construct(ports):
-      count = Reg(UInt(width),
-                  clk=ports.clk,
-                  rst=ports.rst,
-                  rst_value=0,
-                  ce=ports.increment | ports.clear)
-      next = (count + 1).as_uint(width)
-      count.assign(Mux(ports.clear, next, UInt(width)(0)))
-      ports.out = count
-
-  return Counter

--- a/frontends/PyCDE/src/pycde/seq.py
+++ b/frontends/PyCDE/src/pycde/seq.py
@@ -3,9 +3,10 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .circt.dialects import seq as raw_seq
-from .constructs import Wire
 
-from .types import Bits, Type
+from .common import Clock, Input, Output, Reset
+from .module import Module, generator, modparams
+from .types import Bits, Type, UInt
 from .signals import _FromCirctValue, BitsSignal, ClockSignal, Signal
 
 
@@ -19,6 +20,8 @@ class FIFO:
                clk: ClockSignal,
                rst: BitsSignal,
                rd_latency: int = 0):
+    from .constructs import Wire
+
     if type.bitwidth is None:
       raise ValueError("FIFO type must have a defined bitwidth")
     if type.bitwidth == 0:
@@ -65,3 +68,122 @@ class FIFO:
   @property
   def empty(self):
     return _FromCirctValue(self.fifo.empty)
+
+
+@modparams
+def Counter(width: int, increment_on_clear: bool = False):
+  """Construct an up counter of the specified width. `increment` counts up by
+  one, `clear` returns the count to zero. The count wraps around on overflow.
+
+  `increment_on_clear` selects what happens when `clear` and `increment` are
+  asserted in the same cycle:
+
+  - `False` (default): `clear` takes priority and that cycle's `increment` is
+    dropped -- the count becomes 0.
+  - `True`: `clear` zeroes the *accumulated* count and that cycle's
+    `increment` still counts -- the count becomes 1. Use this when `clear`
+    means "I have consumed the count so far" and events must not be lost,
+    e.g. a counter which is cleared when it is read out."""
+
+  class Counter(Module):
+    clk = Clock()
+    rst = Reset()
+    clear = Input(Bits(1))
+    increment = Input(Bits(1))
+    out = Output(UInt(width))
+
+    @generator
+    def construct(ports):
+      from .constructs import Mux, Reg
+
+      # Note: `Mux(sel, a, b)` selects `a` when `sel` is 0 and `b` when it
+      # is 1 (it indexes its data inputs by `sel`).
+      count = Reg(UInt(width),
+                  clk=ports.clk,
+                  rst=ports.rst,
+                  rst_value=0,
+                  ce=ports.increment | ports.clear,
+                  name="count")
+      zero = UInt(width)(0)
+      if increment_on_clear:
+        # The value this cycle's increment applies to.
+        base = Mux(ports.clear, count, zero)
+        base.name = "base"
+        next = Mux(ports.increment, base, (base + 1).as_uint(width))
+      else:
+        next = Mux(ports.clear, (count + 1).as_uint(width), zero)
+      count.assign(next)
+      ports.out = count
+
+  return Counter
+
+
+@modparams
+def DownCounter(width: int, decrement_on_load: bool = False):
+  """Construct a saturating down counter of the specified width: a countdown
+  timer / credit counter. `load` loads `load_value` into the counter and
+  `decrement` counts down by one. The count saturates at zero -- it never
+  wraps around -- and `is_zero` reports (combinationally, with no added
+  latency) whether the current count is zero. The counter resets to zero, so
+  `is_zero` is high until something is loaded.
+
+  `decrement_on_load` selects what happens when `load` and `decrement` are
+  asserted in the same cycle:
+
+  - `False` (default): `load` takes priority and that cycle's `decrement` is
+    dropped -- the count becomes `load_value`.
+  - `True`: the decrement applies to the newly loaded value -- the count
+    becomes `load_value - 1` (saturating at zero). Use this when `decrement`
+    events must not be lost, e.g. a credit counter which is topped up while
+    credits are being spent."""
+
+  class DownCounter(Module):
+    clk = Clock()
+    rst = Reset()
+    load = Input(Bits(1))
+    load_value = Input(UInt(width))
+    decrement = Input(Bits(1))
+    out = Output(UInt(width))
+    is_zero = Output(Bits(1))
+
+    @generator
+    def construct(ports):
+      # Deferred: `constructs` imports from this module, so a top-level
+      # import here would be circular.
+      from .constructs import Mux, Reg
+
+      # Note: `Mux(sel, a, b)` selects `a` when `sel` is 0 and `b` when it
+      # is 1 (it indexes its data inputs by `sel`).
+      count = Reg(UInt(width),
+                  clk=ports.clk,
+                  rst=ports.rst,
+                  rst_value=0,
+                  ce=ports.load | ports.decrement,
+                  name="count")
+      zero = UInt(width)(0)
+      one = UInt(width)(1)
+      count_is_zero = count == zero
+      count_is_zero.name = "count_is_zero"
+
+      # The value this cycle's decrement applies to, and whether decrementing
+      # it would underflow.
+      if decrement_on_load:
+        base = Mux(ports.load, count, ports.load_value)
+        base.name = "base"
+        base_is_zero = Mux(ports.load, count_is_zero, ports.load_value == zero)
+        base_is_zero.name = "base_is_zero"
+      else:
+        base = count
+        base_is_zero = count_is_zero
+      # Saturate rather than wrap.
+      base_dec = Mux(base_is_zero, (base - one).as_uint(width), base)
+      next = Mux(ports.decrement, base, base_dec)
+      if not decrement_on_load:
+        # `load` takes priority over a coincident `decrement`.
+        next = Mux(ports.load, next, ports.load_value)
+      count.assign(next)
+
+      ports.out = count
+      ports.is_zero = count_is_zero
+
+  return DownCounter

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -570,7 +570,7 @@ class TestBundleTransformBasic(Module):
 # are present.
 # CHECK:         %buf_item = seq.compreg.ce sym @buf_item %{{.+}}, %clk, %{{.+}} reset %rst, %{{.+}} : i8
 # CHECK:         comb.mux bin %{{.+}}, %buf_item, %{{.+}} {{.+}} : i8
-# CHECK:         hw.instance "Counter" sym @Counter @Counter_width8
+# CHECK:         hw.instance "Counter" sym @Counter @Counter_increment_on_clearFalse_width8
 # CHECK:         %state = seq.compreg sym @state %{{.+}}, %clk reset %rst, %{{.+}} : i2
 @unittestmodule()
 class TestListWindowToParallel(Module):
@@ -643,7 +643,7 @@ class TestListWindowToSerial(Module):
 # item is forwarded directly into the output struct.
 # CHECK-NOT:     @buf_item
 # CHECK:         hw.struct_create (%{{.+}}, %{{.+}}, %{{.+}}) : !hw.struct<header: i4, data: i0, last: i1>
-# CHECK:         hw.instance "Counter" sym @Counter @Counter_width8
+# CHECK:         hw.instance "Counter" sym @Counter @Counter_increment_on_clearFalse_width8
 # CHECK-NOT:     @buf_item
 # CHECK:         %state = seq.compreg sym @state %{{.+}}, %clk reset %rst, %{{.+}} : i2
 @unittestmodule()

--- a/frontends/PyCDE/test/test_seq.py
+++ b/frontends/PyCDE/test/test_seq.py
@@ -1,7 +1,7 @@
 # RUN: %PYTHON% %s | FileCheck %s
 
 from pycde import Module, Clock, Reset, Input, Output
-from pycde.seq import FIFO
+from pycde.seq import Counter, DownCounter, FIFO
 from pycde.testing import unittestmodule
 from pycde.types import Bits, UInt
 
@@ -51,3 +51,123 @@ class SimpleFIFOTestRd1(Module):
                 rd_latency=1)
     fifo.push(ui32, c0)
     fifo.pop(c0)
+
+
+# Both counters only update when something happens (clock enable), and both
+# reset to zero.
+# CHECK-LABEL:  hw.module @CounterTest
+# CHECK:          hw.instance "Counter" sym @Counter @Counter_increment_on_clearFalse_width8
+# CHECK:          hw.instance "Counter_1" sym @Counter_1 @Counter_increment_on_clearTrue_width8
+
+# Default: `clear` wins over a coincident `increment`, i.e. the register is fed
+# `clear ? 0 : count + 1`.
+# CHECK-LABEL:  hw.module @Counter_increment_on_clearFalse_width8(in %clk : !seq.clock, in %rst : i1, in %clear : i1, in %increment : i1, out out : ui8)
+# CHECK:          [[CE:%.+]] = comb.or bin %increment, %clear
+# CHECK:          %count__reg1 = seq.compreg.ce sym @count__reg1 [[NEXT:%.+]], %clk, [[CE]] reset %rst
+# CHECK:          [[ZERO:%.+]] = hwarith.constant 0 : ui8
+# CHECK:          [[ONE:%.+]] = hwarith.constant 1 : ui1
+# CHECK:          [[SUM:%.+]] = hwarith.add %count__reg1, [[ONE]]
+# CHECK:          [[SUM8:%.+]] = hwarith.cast [[SUM]] : (ui9) -> ui8
+# CHECK:          [[NEXT]] = comb.mux bin %clear, [[ZERO]], [[SUM8]]
+
+# increment_on_clear: the increment is applied to the cleared value, i.e. the
+# register is fed `increment ? base + 1 : base` where `base = clear ? 0 : count`.
+# CHECK-LABEL:  hw.module @Counter_increment_on_clearTrue_width8(in %clk : !seq.clock, in %rst : i1, in %clear : i1, in %increment : i1, out out : ui8)
+# CHECK:          [[CE:%.+]] = comb.or bin %increment, %clear
+# CHECK:          %count__reg1 = seq.compreg.ce sym @count__reg1 [[NEXT:%.+]], %clk, [[CE]] reset %rst
+# CHECK:          [[ZERO:%.+]] = hwarith.constant 0 : ui8
+# CHECK:          [[BASE:%.+]] = comb.mux bin %clear, [[ZERO]], %count__reg1 {{.*}}"base"
+# CHECK:          [[ONE:%.+]] = hwarith.constant 1 : ui1
+# CHECK:          [[SUM:%.+]] = hwarith.add [[BASE]], [[ONE]]
+# CHECK:          [[SUM8:%.+]] = hwarith.cast [[SUM]] : (ui9) -> ui8
+# CHECK:          [[NEXT]] = comb.mux bin %increment, [[SUM8]], [[BASE]]
+
+
+@unittestmodule(run_passes=False)
+class CounterTest(Module):
+  clk = Clock()
+  rst = Reset()
+  clear = Input(Bits(1))
+  increment = Input(Bits(1))
+  out = Output(UInt(8))
+  out_ioc = Output(UInt(8))
+
+  @generator
+  def construct(ports):
+    counter = Counter(8)(clk=ports.clk,
+                         rst=ports.rst,
+                         clear=ports.clear,
+                         increment=ports.increment)
+    ioc_counter = Counter(8, increment_on_clear=True)(clk=ports.clk,
+                                                      rst=ports.rst,
+                                                      clear=ports.clear,
+                                                      increment=ports.increment)
+    ports.out = counter.out
+    ports.out_ioc = ioc_counter.out
+
+
+# CHECK-LABEL:  hw.module @DownCounterTest
+# CHECK:          hw.instance "DownCounter" sym @DownCounter @DownCounter_decrement_on_loadFalse_width8
+# CHECK:          hw.instance "DownCounter_1" sym @DownCounter_1 @DownCounter_decrement_on_loadTrue_width8
+
+# Default: `load` wins over a coincident `decrement`, and the decrement
+# saturates at zero rather than wrapping. `is_zero` is the (registered) count
+# compared against zero, so it costs no extra latency.
+# CHECK-LABEL:  hw.module @DownCounter_decrement_on_loadFalse_width8(in %clk : !seq.clock, in %rst : i1, in %load : i1, in %load_value : ui8, in %decrement : i1, out out : ui8, out is_zero : i1)
+# CHECK:          [[CE:%.+]] = comb.or bin %load, %decrement
+# CHECK:          %count__reg1 = seq.compreg.ce sym @count__reg1 [[NEXT:%.+]], %clk, [[CE]] reset %rst
+# CHECK:          [[ZERO:%.+]] = hwarith.constant 0 : ui8
+# CHECK:          [[ONE:%.+]] = hwarith.constant 1 : ui8
+# CHECK:          [[ISZERO:%.+]] = hwarith.icmp eq %count__reg1, [[ZERO]] {{.*}}"count_is_zero"
+# CHECK:          [[DIFF:%.+]] = hwarith.sub %count__reg1, [[ONE]]
+# CHECK:          [[DIFF8:%.+]] = hwarith.cast [[DIFF]] : (si9) -> ui8
+# CHECK:          [[SAT:%.+]] = comb.mux bin [[ISZERO]], %count__reg1, [[DIFF8]]
+# CHECK:          [[DEC:%.+]] = comb.mux bin %decrement, [[SAT]], %count__reg1
+# CHECK:          [[NEXT]] = comb.mux bin %load, %load_value, [[DEC]]
+# CHECK:          hw.output %count__reg1, [[ISZERO]]
+
+# decrement_on_load: the decrement is applied to the newly loaded value, i.e.
+# the saturating decrement operates on `base = load ? load_value : count`.
+# CHECK-LABEL:  hw.module @DownCounter_decrement_on_loadTrue_width8(in %clk : !seq.clock, in %rst : i1, in %load : i1, in %load_value : ui8, in %decrement : i1, out out : ui8, out is_zero : i1)
+# CHECK:          [[CE:%.+]] = comb.or bin %load, %decrement
+# CHECK:          %count__reg1 = seq.compreg.ce sym @count__reg1 [[NEXT:%.+]], %clk, [[CE]] reset %rst
+# CHECK:          [[ZERO:%.+]] = hwarith.constant 0 : ui8
+# CHECK:          [[ONE:%.+]] = hwarith.constant 1 : ui8
+# CHECK:          [[ISZERO:%.+]] = hwarith.icmp eq %count__reg1, [[ZERO]] {{.*}}"count_is_zero"
+# CHECK:          [[BASE:%.+]] = comb.mux bin %load, %load_value, %count__reg1 {{.*}}"base"
+# CHECK:          [[LDZERO:%.+]] = hwarith.icmp eq %load_value, [[ZERO]]
+# CHECK:          [[BASEZERO:%.+]] = comb.mux bin %load, [[LDZERO]], [[ISZERO]] {{.*}}"base_is_zero"
+# CHECK:          [[DIFF:%.+]] = hwarith.sub [[BASE]], [[ONE]]
+# CHECK:          [[DIFF8:%.+]] = hwarith.cast [[DIFF]] : (si9) -> ui8
+# CHECK:          [[SAT:%.+]] = comb.mux bin [[BASEZERO]], [[BASE]], [[DIFF8]]
+# CHECK:          [[NEXT]] = comb.mux bin %decrement, [[SAT]], [[BASE]]
+# CHECK:          hw.output %count__reg1, [[ISZERO]]
+
+
+@unittestmodule(run_passes=False)
+class DownCounterTest(Module):
+  clk = Clock()
+  rst = Reset()
+  load = Input(Bits(1))
+  load_value = Input(UInt(8))
+  decrement = Input(Bits(1))
+  out = Output(UInt(8))
+  is_zero = Output(Bits(1))
+  out_dol = Output(UInt(8))
+
+  @generator
+  def construct(ports):
+    counter = DownCounter(8)(clk=ports.clk,
+                             rst=ports.rst,
+                             load=ports.load,
+                             load_value=ports.load_value,
+                             decrement=ports.decrement)
+    dol_counter = DownCounter(8, decrement_on_load=True)(
+        clk=ports.clk,
+        rst=ports.rst,
+        load=ports.load,
+        load_value=ports.load_value,
+        decrement=ports.decrement)
+    ports.out = counter.out
+    ports.is_zero = counter.is_zero
+    ports.out_dol = dol_counter.out


### PR DESCRIPTION
Move `Counter` from `constructs` to `seq` (re-exported from `constructs` for compatibility) and add `DownCounter` next to it.

`DownCounter(width)` is a countdown timer / credit counter: `load` loads `load_value`, `decrement` counts down by one, the count saturates at zero rather than wrapping, and `is_zero` reports whether the current count is zero (combinationally off the register, so it costs no extra latency).

`Counter` unconditionally gave `clear` priority over `increment`, so an increment which coincided with a clear was silently dropped. That is correct when the clearing event is the boundary of the run being counted, but it loses events whenever `clear` means "I have consumed the count so far" -- e.g. a telemetry counter which is cleared when it is read. Add `Counter(width, increment_on_clear=True)`, which zeroes the accumulated count and still applies that cycle's increment (the count becomes 1). `DownCounter` gets the same knob as `decrement_on_load`.

The default behavior of `Counter` is unchanged; only its generated module name picks up the new parameter (`Counter_increment_on_clearFalse_width8`), hence the CHECK updates in test_esi.py.

Assisted-by: Github-Copilot: Claude Opus 5
