### PR TITLE
[PyCDE][ESI] Count down for list-window burst counters

### DIFF
--- a/frontends/PyCDE/AGENTS.md
+++ b/frontends/PyCDE/AGENTS.md
@@ -102,11 +102,40 @@ elaboration-time bug; double assignment raises.
 
 ## Counters
 
-`pycde.constructs.Counter` increments on `increment` and clears on
-`clear`; **clear takes precedence over increment**. Use it instead of
-hand-rolled `(reg + 1).reg(ce=...)` patterns when there is a natural
-"reset to zero on event X" condition; it eliminates a class of
-off-by-one bugs around the boundary cycle.
+`pycde.seq.Counter(width)` increments on `increment` and clears on
+`clear`. Use it instead of hand-rolled `(reg + 1).reg(ce=...)` patterns
+when there is a natural "reset to zero on event X" condition; it
+eliminates a class of off-by-one bugs around the boundary cycle.
+
+By default **clear takes precedence over increment**: an `increment`
+which coincides with a `clear` is dropped and the count goes to 0. That
+is what you want when the clearing event *is* the boundary (the item in
+that cycle belongs to the run being closed). It is wrong -- and silently
+loses events -- when `clear` means "I have consumed the count so far",
+e.g. a telemetry counter cleared when it is read. For that case pass
+`Counter(width, increment_on_clear=True)`: the clear zeroes the
+accumulated count and that cycle's increment still counts, so the count
+becomes 1.
+
+`pycde.seq.DownCounter(width)` is the countdown/credit counterpart:
+`load` loads `load_value`, `decrement` counts down by one, the count
+saturates at zero rather than wrapping, and `is_zero` reports whether
+the current count is zero (combinationally off the register, so it adds
+no latency). It has the same priority knob: by default `load` wins over
+a coincident `decrement`, and `DownCounter(width,
+decrement_on_load=True)` applies the decrement to the newly loaded value
+instead of dropping it.
+
+Note that both parameters are part of the generated module name
+(e.g. `Counter_increment_on_clearFalse_width8`), so lit tests which
+match on module names need the full name.
+
+Counting *down* to a constant is also cheaper than counting up to a
+register when the comparison sits in a single-cycle handshake loop:
+`remaining == 1` is a register-vs-constant compare (no XNOR level, ~W/6
+LUTs on a 6-LUT device), while `emitted == count` is register-vs-register
+(~W/3 LUTs) and `emitted + 1 == count` additionally drags an adder into
+the loop.
 
 ## ESI channels and handshake
 
@@ -191,6 +220,9 @@ deadlocks and dropped beats.
 - Use `Counter` + a `MMIO`/`AppID`-tagged read register to surface
   invariant violations (e.g. "static field changed mid-list") to host software.
   Cheap on area and invaluable when a cosim test fails far from the bug.
+  If the counter is cleared when it is read, use
+  `Counter(width, increment_on_clear=True)` so an event landing on the
+  read cycle is not lost.
   Alternatively, 'esi.Telemetry' provides a more structured interface for this
   pattern. It can be automatically read via the esiaccel API and the esiquery
   tool.

--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -1689,9 +1689,9 @@ def ListWindowToParallel(serial_window_type: Window):
       # Load the burst's item count when a header is accepted; decrement on
       # each non-last emit. The two enables are mutually exclusive (they
       # require different states), so `DownCounter`'s load-over-decrement
-      # priority never comes into play. Its saturation at zero is likewise
-      # never reached: `remaining` is loaded with a non-zero count and the
+      # priority never comes into play. The counter never *decrements* to 0:
       # decrement is gated by `~is_last_of_burst`, i.e. `remaining != 1`.
+      # (`remaining` may still be loaded with 0 for count==0 terminators.)
       # Not cleared on `emit_buf_xact`: by then the peeked header's `hdr_xact`
       # has already loaded the next burst's count.
       remaining_counter = DownCounter(count_bitwidth)(

--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -1522,7 +1522,8 @@ def ListWindowToParallel(serial_window_type: Window):
 
     @generator
     def build(ports):
-      from .constructs import Counter
+      from .seq import DownCounter
+
       # State machine for serial-to-parallel conversion. Per the ESI spec, the
       # serial encoding may transmit a list across multiple bursts, each of
       # which is a header (with a non-zero count of items) followed by `count`
@@ -1574,13 +1575,20 @@ def ListWindowToParallel(serial_window_type: Window):
 
       # ----- Counters -----
       zero = UInt(count_bitwidth)(0)
-      # `emitted` counts the number of items already emitted in the current
-      # burst. It is driven below by a constructs.Counter; we predeclare a
-      # Wire so it can be used in handshake/state expressions before the
-      # Counter is instantiated.
-      emitted_wire = Wire(UInt(count_bitwidth))
-      next_emitted = (emitted_wire +
-                      UInt(count_bitwidth)(1)).as_uint(count_bitwidth)
+      # `remaining` counts the items of the current burst not yet consumed: it
+      # is loaded with the burst's count when a header is accepted and
+      # decremented as items are emitted. The last item of a burst is therefore
+      # `remaining == 1`, a comparison against a *constant* on a registered
+      # value.
+      #
+      # Counting down is ~2x cheaper than the best up-counter formulation
+      # (`emitted == count_minus_1`), and much better than the naive one
+      # (`emitted + 1 == count`), and the decrement itself only ever feeds the
+      # register input, never the comparison.
+      #
+      # Predeclared as a Wire so it can be used in handshake/state expressions
+      # before its driver is built.
+      remaining_wire = Wire(UInt(count_bitwidth))
 
       # ----- Header acceptance -----
       # Headers are accepted whenever we are in S_WAIT or S_PEEK and serial_in
@@ -1613,8 +1621,8 @@ def ListWindowToParallel(serial_window_type: Window):
                                 rst_value=0,
                                 name="count")
       cur_count = count_reg.as_uint(count_bitwidth)
-      # In S_EMIT, the (emitted+1)-th item is the last of the burst.
-      is_last_of_burst = next_emitted == cur_count
+      # In S_EMIT, the item consumed when `remaining == 1` is the burst's last.
+      is_last_of_burst = remaining_wire == UInt(count_bitwidth)(1)
 
       # ----- Buffered item -----
       # Latch the last data item of a burst into a register before peeking
@@ -1677,18 +1685,23 @@ def ListWindowToParallel(serial_window_type: Window):
       emit_normal_xact = in_emit & serial_valid & ~is_last_of_burst & out_ready
       emit_buf_xact = in_emit_buf & out_ready
 
-      # ----- emitted counter -----
-      # Increment on each non-last emit; clear to 0 when accepting a new
-      # header (start of a new burst) or finishing the buffered emit.
-      # `increment` and `clear` are mutually exclusive (they require
-      # different states), and Counter.clear takes precedence over
-      # increment, matching the prior cascaded-Mux semantics.
-      reset_emitted = hdr_xact | emit_buf_xact
-      emitted_counter = Counter(count_bitwidth)(clk=ports.clk,
-                                                rst=ports.rst,
-                                                clear=reset_emitted,
-                                                increment=emit_normal_xact)
-      emitted_wire.assign(emitted_counter.out)
+      # ----- remaining counter -----
+      # Load the burst's item count when a header is accepted; decrement on
+      # each non-last emit. The two enables are mutually exclusive (they
+      # require different states), so `DownCounter`'s load-over-decrement
+      # priority never comes into play. Its saturation at zero is likewise
+      # never reached: `remaining` is loaded with a non-zero count and the
+      # decrement is gated by `~is_last_of_burst`, i.e. `remaining != 1`.
+      # Not cleared on `emit_buf_xact`: by then the peeked header's `hdr_xact`
+      # has already loaded the next burst's count.
+      remaining_counter = DownCounter(count_bitwidth)(
+          clk=ports.clk,
+          rst=ports.rst,
+          load=hdr_xact,
+          load_value=new_count,
+          decrement=emit_normal_xact,
+          instance_name="remaining")
+      remaining_wire.assign(remaining_counter.out)
 
       # ----- State transitions -----
       # The conditions below are mutually exclusive (each requires a specific
@@ -1846,8 +1859,8 @@ def ListWindowToSerial(parallel_window_type: Window,
 
     @generator
     def build(ports):
-      from .seq import FIFO as SeqFIFO
-      from .constructs import ControlReg, Counter
+      from .seq import Counter, DownCounter, FIFO as SeqFIFO
+      from .constructs import ControlReg
 
       one_bc = UInt(bc_bitwidth)(1)
       depth_bc = UInt(bc_bitwidth)(fifo_depth)
@@ -1964,13 +1977,13 @@ def ListWindowToSerial(parallel_window_type: Window,
       meta_fifo.push(meta_entry_value, meta_push_xact)
 
       # Burst counter: increment on each par_xact, clear on meta_push_xact.
-      # Counter.clear takes precedence over .increment, so when both fire
-      # in the same cycle the counter resets to 0 (correct: that cycle's
-      # item is the last of the burst, and the next burst starts at 0).
-      burst_counter = Counter(bc_bitwidth)(clk=ports.clk,
-                                           rst=ports.rst,
-                                           clear=meta_push_xact,
-                                           increment=par_xact)
+      # That cycle's item is the last of the burst, and the next burst starts at
+      # 0 so clear needs to override increment.
+      burst_counter = Counter(bc_bitwidth,
+                              increment_on_clear=False)(clk=ports.clk,
+                                                        rst=ports.rst,
+                                                        clear=meta_push_xact,
+                                                        increment=par_xact)
       burst_count_wire.assign(burst_counter.out)
 
       # ===== Output side: drain meta + data FIFOs into serial frames. =====
@@ -2013,11 +2026,22 @@ def ListWindowToSerial(parallel_window_type: Window,
       footer_fields[count_field_name] = Bits(count_bitwidth)(0)
       footer_value = header_struct_type(footer_fields)
 
-      # Per-burst emitted-item counter, cleared at burst end.
-      emitted_wire = Wire(UInt(count_bitwidth))
-      next_emitted = (emitted_wire +
-                      UInt(count_bitwidth)(1)).as_uint(count_bitwidth)
-      last_item_in_burst = next_emitted == cur_count
+      # Per-burst counter. `remaining_wire` is driven by the `DownCounter`
+      # instantiated below -- it is predeclared here only because the handshake
+      # and state expressions between here and there need it. Counting down
+      # makes the "last item" test a comparison against a constant on a
+      # registered value, rather than `emitted + 1 == count` -- which would put
+      # a `count_bitwidth`-wide adder and equality inside a single-cycle loop
+      # (the result gates `out_ready`, the state transitions and the counter's
+      # own enables). See the matching comment in `ListWindowToParallel`.
+      #
+      # The test is `== 1` rather than the counter's `is_zero` because the
+      # counter is loaded with the burst's count as it appears in the header.
+      # Loading `count - 1` to use `is_zero` would buy nothing -- both are
+      # compares against a constant -- and would need a subtract on the load
+      # path plus a special case for the `count == 0` terminator.
+      remaining_wire = Wire(UInt(count_bitwidth))
+      last_item_in_burst = remaining_wire == UInt(count_bitwidth)(1)
 
       # Data FIFO pop. With no data FIFO (zero-width elements), there is
       # nothing to pop or wait on: data_value is a constant zero-width
@@ -2060,14 +2084,21 @@ def ListWindowToSerial(parallel_window_type: Window,
       if not data_is_zero:
         data_pop_rden.assign(data_xact)
 
-      # Emitted-counter: clear at burst_done, increment on every other
-      # data xact. Counter.clear takes precedence over .increment.
-      emitted_counter = Counter(count_bitwidth)(clk=ports.clk,
-                                                rst=ports.rst,
-                                                clear=burst_done,
-                                                increment=data_xact &
-                                                ~last_item_in_burst)
-      emitted_wire.assign(emitted_counter.out)
+      # Remaining-counter: load the burst's item count when the burst is armed
+      # (from the same combinational value `cur_meta` latches, so the load and
+      # `cur_hdr` stay in step), and decrement on every non-last data xact.
+      # `arm_burst` and `data_xact` require different states, so the load-over-
+      # decrement priority never comes into play, and the decrement is gated by
+      # `~last_item_in_burst` so the saturation at zero is never reached.
+      remaining_counter = DownCounter(count_bitwidth)(
+          clk=ports.clk,
+          rst=ports.rst,
+          load=arm_burst,
+          load_value=meta_value["hdr"][count_field_name].as_uint(
+              count_bitwidth),
+          decrement=data_xact & ~last_item_in_burst,
+          instance_name="remaining")
+      remaining_wire.assign(remaining_counter.out)
 
       # Per-state next-state expressions, selected by the current state.
       # Transitions:

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -570,7 +570,7 @@ class TestBundleTransformBasic(Module):
 # are present.
 # CHECK:         %buf_item = seq.compreg.ce sym @buf_item %{{.+}}, %clk, %{{.+}} reset %rst, %{{.+}} : i8
 # CHECK:         comb.mux bin %{{.+}}, %buf_item, %{{.+}} {{.+}} : i8
-# CHECK:         hw.instance "Counter" sym @Counter @Counter_increment_on_clearFalse_width8
+# CHECK:         hw.instance "remaining" sym @remaining @DownCounter_decrement_on_loadFalse_width8
 # CHECK:         %state = seq.compreg sym @state %{{.+}}, %clk reset %rst, %{{.+}} : i2
 @unittestmodule()
 class TestListWindowToParallel(Module):
@@ -643,7 +643,7 @@ class TestListWindowToSerial(Module):
 # item is forwarded directly into the output struct.
 # CHECK-NOT:     @buf_item
 # CHECK:         hw.struct_create (%{{.+}}, %{{.+}}, %{{.+}}) : !hw.struct<header: i4, data: i0, last: i1>
-# CHECK:         hw.instance "Counter" sym @Counter @Counter_increment_on_clearFalse_width8
+# CHECK:         hw.instance "remaining" sym @remaining @DownCounter_decrement_on_loadFalse_width8
 # CHECK-NOT:     @buf_item
 # CHECK:         %state = seq.compreg sym @state %{{.+}}, %clk reset %rst, %{{.+}} : i2
 @unittestmodule()


### PR DESCRIPTION
## What

`ListWindowToParallel` and `ListWindowToSerial` track progress through a burst
with a counter whose "is this the last item?" test feeds the FSM. Both counted
*up* and tested `emitted + 1 == count`. This switches both to `seq.DownCounter`:
load the burst's count when a header is accepted, decrement as items are
emitted, and test `remaining == 1`.

Also documents the `Counter` / `DownCounter` priority parameters in
`frontends/PyCDE/AGENTS.md`, including the case that motivated
`increment_on_clear`.

## Why it works better

The last-item test cannot be pipelined out: it gates `out_valid`,
`serial_ready`, the state transitions *and* the counter's own enables, so it
sits in a single-cycle loop. What matters is therefore the cost of that
**comparison**, not the cost of the arithmetic. Three formulations, worst to
best, at counter width W:

| formulation | what lands in the single-cycle loop | relative cost |
|---|---|---|
| `emitted + 1 == count` (before) | a W-wide **adder**, then a W-wide reg-vs-reg equality | worst: carry chain *and* the compare below |
| `emitted == count_minus_1`, limit registered at header-accept | W-wide **reg-vs-reg** equality | adder gone, compare still needs an XNOR level |
| `remaining == 1` (this PR) | W-wide **reg-vs-constant** equality | no XNOR level; roughly half the LUTs and one level shallower |

The second row is worth calling out because it is the strongest alternative,
not a strawman: precomputing `count - 1` at header-accept does get the adder
out of the loop. It still leaves a register-vs-register compare, which needs a
W-wide XNOR level feeding an AND-reduce, and a LUT absorbs only half as many
bit-pairs at that first level as it would plain bits.

Comparing against a *constant* removes the XNOR level entirely — each bit
enters the reduce directly, true or complemented — so the first level packs
twice as many bits per LUT and the reduce tree is one level shallower. Roughly
half the cost of the best up-counter form, and much better than the naive one.
The decrement itself only ever feeds the counter's register input, never the
comparison.

This matters at width because `Window.serial_of` permits wide counts, where
the adder's carry chain alone is a serious Fmax limiter.

Assisted-by: GitHub Copilot:Claude Opus 5
