### PR TITLE
[PyCDE][ESI] Add ChannelMergeOneValid

### DIFF
--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -7,12 +7,12 @@ from .common import (AppID, Clock, Input, InputChannel, Output, OutputChannel,
 from .constructs import AssignableSignal, Mux, Wire
 from .module import (generator, modparams, Module, ModuleLikeBuilderBase,
                      PortProxyBase)
-from .signals import (BitsSignal, BundleSignal, ChannelSignal, ClockSignal,
+from .signals import (BitsSignal, BundleSignal, ChannelSignal, ClockSignal, Or,
                       Signal, _FromCirctValue, UIntSignal)
 from .support import (clog2, optional_dict_to_optional_dict_attr, get_user_loc,
                       optional_dict_to_dict_attr)
 from .system import System
-from .types import (Any, Bits, Bundle, BundledChannel, Channel,
+from .types import (Any, Array, Bits, Bundle, BundledChannel, Channel,
                     ChannelDirection, ChannelSignaling, List as EsiListType,
                     StructType, Type, Window, UInt, _FromCirctType)
 
@@ -1091,7 +1091,25 @@ class TelemetryMMIO(ServiceImplementation):
   region. Each client request is assigned a register in the MMIO space. When a
   read request is received for the assigned address, it gets routed to the
   assigned client. When a write request is received, it is discarded. The
-  assignment table is stored in the manifest."""
+  assignment table is stored in the manifest.
+
+  **REQUIREMENTS.** Both are needed to make the response merge safe:
+
+  1. The `MMIO` service implementation this connects to must not issue a read
+     command while a previous read's response is still outstanding.
+  2. Every telemetry client must assert its `data` channel's `valid` only in
+     response to a `get`. `Telemetry.report_signal` does this; a client which
+     holds `valid` high permanently -- legal ESI, and the natural way to
+     express an always-available counter -- does not.
+
+  Given both, each command is demuxed to exactly one client and at most one
+  client is offering a response at a time, so the responses can be merged with
+  `ChannelMergeOneValid` instead of arbitrated -- which keeps the response path
+  from building a combinational cone across every telemetry client.
+
+  Nothing here enforces either, and violating either loses responses. Note (2)
+  is not specific to this merge: `ChannelMux2` is fixed-priority, so under an
+  arbiter a permanently-valid client starves every client behind it."""
 
   clk = Clock()
   rst = Reset()
@@ -1148,7 +1166,13 @@ class TelemetryMMIO(ServiceImplementation):
       bundle_wire.assign(bundle)
       client_data_channels.append(
           bundle_froms["data"].transform(lambda m: m.as_bits(64)))
-    resp_channel = ChannelMux(client_data_channels)
+    # The demux above routes each command to exactly one client, so -- given
+    # both requirements in this class' docs -- at most one client is offering a
+    # response at a time and no arbitration is needed to merge them.
+    resp_channel = ChannelMergeOneValid(client_data_channels,
+                                        ports.clk,
+                                        ports.rst,
+                                        instance_name="telemetry_resp_merge")
     data_resp_channel.assign(resp_channel)
     return True
 
@@ -1343,6 +1367,170 @@ def ChannelMux(input_channels: List[ChannelSignal]) -> ChannelSignal:
     return m.output_channel
 
   return build_tree(input_channels)
+
+
+@modparams
+def ChannelMergeOneValidMod(channel_type: Channel, num_inputs: int,
+                            register_output: bool):
+  """Build the N:1 one-valid channel merge module. See the
+  `ChannelMergeOneValid` convenience function for the user-facing entry point
+  and the precondition it requires."""
+
+  assert num_inputs >= 2, "ChannelMergeOneValidMod requires at least two inputs"
+  inner = channel_type.inner_type
+  width = inner.bitwidth
+  if width is None:
+    raise TypeError(
+        f"ChannelMergeOneValid requires a fixed-width payload; got {inner}")
+
+  class ChannelMergeOneValidImpl(Module):
+    clk = Clock()
+    rst = Reset()
+
+    inputs = Input(Array(channel_type, num_inputs))
+    output = Output(channel_type)
+
+    @generator
+    def build(ports) -> None:
+      # A single `ready`, broadcast to every input. This is the entire point of
+      # the module: no input's `ready` depends on any other input's `valid`, so
+      # there is no combinational coupling between the inputs at all.
+      in_ready = Wire(Bits(1), name="in_ready")
+
+      valids: List[BitsSignal] = []
+      datas: List[BitsSignal] = []
+      for i in range(num_inputs):
+        data_i, valid_i = ports.inputs[i].unwrap(in_ready)
+        valids.append(valid_i)
+        if width > 0:
+          datas.append(data_i.bitcast(Bits(width)))
+
+      merged_valid = Or(*valids)
+
+      if width > 0:
+        # The payload is read out of an array indexed by a binary encode of the
+        # one-hot `valid` vector. Left as a single array select so the synthesis
+        # tool can pick a structure for the target device. Selecting rather than
+        # OR-ing the payloads together also bounds the damage if the contract is
+        # broken: the output is always some input's payload, never a mixture.
+        def or_reduce(bits: List[BitsSignal]) -> BitsSignal:
+          return bits[0] if len(bits) == 1 else Or(*bits)
+
+        # Bit `k` of the index is set for exactly those inputs whose number has
+        # bit `k` set, so a one-hot `valid` encodes to the valid input's index.
+        sel_width = clog2(num_inputs)
+        sel_bits = [
+            or_reduce([valids[i]
+                       for i in range(num_inputs)
+                       if (i >> k) & 1])
+            for k in reversed(range(sel_width))
+        ]
+        sel = sel_bits[0]
+        if len(sel_bits) > 1:
+          sel = BitsSignal.concat(sel_bits)
+          sel.name = "merge_sel"
+        # The array is exactly `num_inputs` long: under the contract `sel` only
+        # ever resolves to a valid input's index, so it is always in range.
+        data_array = Array(Bits(width), num_inputs)(datas)
+        data_array.name = "merge_data"
+        merged_bits = data_array[sel]
+      else:
+        # Zero-width payload: there is nothing to select.
+        merged_bits = Bits(0)(0)
+
+      out_chan, out_ready = channel_type.wrap(merged_bits.bitcast(inner),
+                                              merged_valid)
+      if register_output:
+        # One skid buffer on the output. `ESI_PipelineStage` drives its
+        # `a_ready` from flops, so after this every input's `ready` is a flop
+        # output -- which is what takes the merge off the critical path.
+        out_chan = out_chan.buffer(ports.clk, ports.rst, stages=1)
+      ports.output = out_chan
+      in_ready.assign(out_ready)
+
+  return ChannelMergeOneValidImpl
+
+
+def ChannelMergeOneValid(input_channels: List[ChannelSignal],
+                         clk: ClockSignal,
+                         rst: Signal,
+                         *,
+                         register_output: bool = True,
+                         appid: Optional[AppID] = None,
+                         instance_name: Optional[str] = None) -> ChannelSignal:
+  """Merge N channels into one, given that at most one of them ever has a
+  message to offer at a time.
+
+  **Contract: at most one input may be valid in any given cycle.** The caller
+  must arrange this. In a request/response fabric it takes two things: at most
+  one request in flight (e.g. a `MaxOutstandingLimiter(1)`), *and* every client
+  asserting its reply's `valid` only in response to a request. The second is
+  easy to miss -- a channel may legally hold `valid` high forever, so an
+  always-available counter breaks the contract by itself.
+  `Telemetry.report_signal` drives its data `valid` from the `get` channel's;
+  hand-written clients must do likewise.
+
+  Given the contract, no arbitration is needed:
+
+  * `valid` = OR over the inputs' `valid`.
+  * `data`  = the valid input's payload, read out of an array indexed by a
+    binary encode of the `valid` vector.
+  * `ready` = the output's `ready`, broadcast unchanged to every input.
+
+  Broadcasting `ready` is the entire win: no input's `ready` depends on any
+  other input's `valid`, and with `register_output` it is a flop output.
+
+  Violating the contract is lossy but does not corrupt data: every valid input
+  completes its handshake, only one beat is emitted, and the rest are dropped.
+  The payload is selected rather than OR-ed, so the output is always some
+  input's payload, never a bitwise mixture of several.
+
+  TODO: flag the dropped-message case with an `sv.assert.concurrent`. Not
+  currently possible from PyCDE: the SV dialect's Python bindings do not expose
+  the `EventControl` enum needed to build the op's `event` attribute.
+
+  TODO: take the select as an optional *input*, driven from the request side
+  (for an MMIO processor, the same select that drives the command demux, one
+  cycle earlier and already registered). That would make both requirements
+  structural rather than documented -- an unselected input is never readied, so
+  holding `valid` high is harmless -- and is cheaper, since a registered select
+  deletes the encoder from the response path instead of adding to it.
+
+  Arguments:
+    input_channels: the channels to merge. All must share the same type.
+    clk, rst: clock and reset.
+    register_output: insert one skid buffer on the output (recommended; adds
+      one cycle of latency and makes every input's `ready` a flop output).
+    appid: optional `AppID` for the instance.
+    instance_name: optional instance name.
+  """
+
+  assert len(input_channels) > 0
+  if len(input_channels) == 1:
+    return input_channels[0]
+
+  channel_type = input_channels[0].type
+  for c in input_channels:
+    if c.type != channel_type:
+      raise TypeError("All ChannelMergeOneValid inputs must have the same "
+                      f"type; got {channel_type} and {c.type}")
+  # The merge is built directly out of `unwrap(ready)`/`wrap(data, valid)` and
+  # broadcasts a single `ready` to every input, which is only meaningful for
+  # ValidReady. Under FIFO signaling the broadcast signal is `rden`, so one
+  # output beat would pop *every* input FIFO and silently discard N-1
+  # messages. Reject it rather than elaborate wrong hardware.
+  if channel_type.signaling != ChannelSignaling.ValidReady:
+    raise TypeError("ChannelMergeOneValid requires ValidReady channels; got "
+                    f"{channel_type}")
+
+  mod = ChannelMergeOneValidMod(channel_type, len(input_channels),
+                                register_output)
+  inst = mod(clk=clk,
+             rst=rst,
+             inputs=Array(channel_type, len(input_channels))(input_channels),
+             appid=appid,
+             instance_name=instance_name)
+  return inst.output
 
 
 @modparams

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -707,3 +707,104 @@ class TestListWindowToSerialZeroWidth(Module):
         TestListWindowToSerialZeroWidth.fifo_depth)(
             clk=self.clk, rst=self.rst, parallel_in=self.parallel_lst_in)
     self.serial_lst_out = to_serial.serial_out
+
+
+# CHECK-LABEL: hw.module @ChannelMergeOneValidImpl_{{.*}}num_inputs3_register_outputFalse
+# Every input is unwrapped with the *same* `%ready`. This broadcast is the
+# property the module exists for: no input's `ready` is a function of any
+# sibling's `valid`, so there is no combinational coupling between the inputs.
+# If arbitration ever creeps back in, these three stop matching.
+# CHECK:         esi.unwrap.vr %{{.+}}, %ready : i8
+# CHECK:         esi.unwrap.vr %{{.+}}, %ready : i8
+# CHECK:         esi.unwrap.vr %{{.+}}, %ready : i8
+# `valid` is a single OR-reduce over the inputs' valids, and the payload is a
+# list select on a binary encode of that same vector -- never an OR of masked
+# payloads, so only one input's data can reach the output even if the caller
+# violates the at-most-one-valid contract. The interleaved `CHECK-NOT`s cover
+# the whole span from the last unwrap to the wrap.
+# CHECK-NOT:     comb.or {{.*}} : i8
+# CHECK:         comb.or bin %{{.+}}, %{{.+}}, %{{.+}} : i1
+# CHECK-NOT:     comb.or {{.*}} : i8
+# CHECK:         comb.concat %{{.+}}, %{{.+}} {{.*}}: i1, i1
+# The payload is read straight out of an array indexed by that select, sized to
+# the input count -- no rounding up to a power of two, since under the contract
+# the select only ever takes on a real input's index.
+# CHECK:         hw.array_create
+# CHECK:         hw.array_get %{{.+}}[%{{.+}}] {{.*}}: !hw.array<3xi8>, i2
+# CHECK-NOT:     comb.or {{.*}} : i8
+# CHECK:         esi.wrap.vr
+@unittestmodule()
+class TestChannelMergeOneValid(Module):
+  """Merge channels which are never simultaneously valid, without
+  arbitration."""
+
+  clk = Clock()
+  rst = Reset()
+
+  in0 = InputChannel(Bits(8))
+  in1 = InputChannel(Bits(8))
+  in2 = InputChannel(Bits(8))
+  merged_out = OutputChannel(Bits(8))
+
+  @generator
+  def build(self):
+    self.merged_out = esi.ChannelMergeOneValid([self.in0, self.in1, self.in2],
+                                               self.clk,
+                                               self.rst,
+                                               register_output=False)
+
+
+# CHECK-LABEL: hw.module @ChannelMergeOneValidImpl_{{.*}}num_inputs2_register_outputTrue
+# `register_output=True` is the default every caller gets. It must still
+# broadcast one `ready`, and must terminate in a one-stage buffer -- that skid
+# is what makes every input's `ready` a flop output, which is the whole point
+# of the option. With two inputs the select is a single `valid` bit, so the
+# array is indexed directly by it with no encode in between.
+# CHECK:         esi.unwrap.vr %{{.+}}, %ready : i8
+# CHECK:         esi.unwrap.vr %{{.+}}, %ready : i8
+# CHECK:         comb.or bin %{{.+}}, %{{.+}} : i1
+# CHECK:         hw.array_get %{{.+}}[%{{.+}}] {{.*}}: !hw.array<2xi8>, i1
+# CHECK:         esi.wrap.vr
+# CHECK:         esi.buffer %clk, %rst, %{{.+}} {stages = 1 : i64}
+@unittestmodule()
+class TestChannelMergeOneValidRegistered(Module):
+  """The default `register_output=True` path: skid buffer on the output."""
+
+  clk = Clock()
+  rst = Reset()
+
+  in0 = InputChannel(Bits(8))
+  in1 = InputChannel(Bits(8))
+  merged_out = OutputChannel(Bits(8))
+
+  @generator
+  def build(self):
+    self.merged_out = esi.ChannelMergeOneValid([self.in0, self.in1], self.clk,
+                                               self.rst)
+
+
+# CHECK-LABEL: hw.module @ChannelMergeOneValidImpl_{{.*}}esi_channel_i0{{.*}}register_outputFalse
+# Zero-width payload: there is nothing to select, so the merge degenerates to
+# the `valid` OR-reduce and no payload select is built at all.
+# CHECK:         esi.unwrap.vr %{{.+}}, %ready : i0
+# CHECK:         esi.unwrap.vr %{{.+}}, %ready : i0
+# CHECK-NOT:     hw.array_get
+# CHECK:         comb.or bin %{{.+}}, %{{.+}} : i1
+# CHECK:         esi.wrap.vr %{{.+}}, %{{.+}} {{.*}}: i0
+@unittestmodule()
+class TestChannelMergeOneValidZeroWidth(Module):
+  """Zero-width payloads (pure tokens) take the no-mux path."""
+
+  clk = Clock()
+  rst = Reset()
+
+  in0 = InputChannel(Bits(0))
+  in1 = InputChannel(Bits(0))
+  merged_out = OutputChannel(Bits(0))
+
+  @generator
+  def build(self):
+    self.merged_out = esi.ChannelMergeOneValid([self.in0, self.in1],
+                                               self.clk,
+                                               self.rst,
+                                               register_output=False)


### PR DESCRIPTION
(Note: description is 100% AI generated and human reviewed. Commit message is 100% human written. I'm trying this out for a few PRs. I like how Claude gives its rationale in detail which is appropriate for neither the code documentation nor commit message.)

## What

Adds `ChannelMergeOneValid`, an N:1 channel merge for the case where the design
already guarantees that **at most one input is valid per cycle**, so no
arbitration is needed:

- `ready` — the output's ready, broadcast unchanged to every input
- `valid` — an OR over the inputs' valids
- `data`  — read out of an array (`hw.array_create` + `hw.array_get`, i.e. an
  N-input mux) indexed by a binary encode of the `valid` vector
- optional single skid buffer on the output (`register_output`, on by default)

ValidReady only. Used here for the `TelemetryMMIO` response path; `ChannelMMIO`
in the ESI runtime follows in a later PR in the stack.

The contract is a real caller obligation and takes more than "one request in
flight" to establish — see [the caller section](#the-caller-telemetrymmio),
which spells out both conditions and why neither is specific to this module.

## Why it works better

`ChannelMux` arbitrates, which makes each input's `ready` a function of its
siblings' `valid`. Composed over an O(log N)-deep tree, that couples **every**
leaf to **every** other leaf combinationally. At the fan-in the BSP merges
reach, the resulting cone is routing-dominated and becomes an Fmax limiter, and
it stays one no matter how the tree is pipelined, because the coupling is in
the arbitration itself, not in the datapath.

Here there is no arbitration to couple through. Every input's `ready` is
literally the same wire, and with `register_output` that wire is a flop output.

Worth being precise about where the win comes from, because it is easy to
misattribute: **it is the decoupled `ready`, not the merge shape.** The payload
select is an ordinary static mux and is no cheaper than any other way of
selecting one of N payloads. An earlier draft OR-merged masked payloads; in
LUTs that costs the same as a one-hot mux, so it was not the source of the
improvement.

The payload is emitted as a single array select rather than a hand-built tree,
so the synthesis tool picks the structure for the target device. The array is
exactly `num_inputs` long — rounding it up to a power of two would cost area
(measured at ~6% more LUTs at N≈100) to make a case that only arises when the
contract is already broken. If a specific shape or pipelining turns out to be
needed, that can be added later without changing the interface.

## Safety: lossy, never corrupting

The contract is a caller obligation, but violating it does not corrupt data.
Because `ready` is broadcast, every valid input completes its handshake, but
only one output beat is produced, so the other messages are **dropped**.
Because the payload is *selected* rather than OR-ed together, what comes out is
never a bitwise mixture of several messages — at worst the select resolves to
some other input and one input's payload is emitted in place of another's.
Losing or misrouting a response is recoverable and debuggable; an ORed blend of
two responses is neither.

Note the select is a plain OR-encode of the `valid` vector, so under a violated
contract it can resolve to an input which was not valid, or out of the array's
range. That is a deliberate choice, not an oversight — see below.

Rejects non-ValidReady signaling explicitly. The module is built from raw
`unwrap(ready)` / `wrap(data, valid)`; under FIFO signaling the broadcast
signal is `rden`, so a single output beat would pop *every* input FIFO and
silently discard N−1 messages. That would elaborate happily without the check.

### Why not a priority encoder?

An earlier draft made the select a *priority* one-hot
(`sel[i] = valid[i] & ~(valid[0] | ... | valid[i-1])`), so that a violated
contract would emit the lowest-numbered **valid** input's payload rather than
an arbitrary one. That is a stronger guarantee, but it is not free, and it is
not obviously desirable.

Cost, measured with `circt-synth --lower-to-k-lut=6` on the payload cone, using
a Kogge-Stone parallel-prefix OR (the cheapest generic formulation, not a
serial mask chain):

| N | plain encode | priority | depth | area |
|---|---|---|---|---|
| 8 | 2 levels / 322 LUTs | 3 levels / 330 LUTs | +50% | +2% |
| 32 | 4 levels / 1363 LUTs | 7 levels / 2860 LUTs | +75% | +110% |
| ~100 | 6 levels / 4558 LUTs | 9 levels / 4848 LUTs | +50% | +6% |

`v & -v` (isolate-lowest-set-bit) measures the same; it trades LUT levels for
carry-chain latency rather than removing the cost.

So at the fan-ins where this module is worth using at all, a priority encoder
adds roughly half again to the depth of the payload path — which, now that the
arbitration cone is gone, is the deepest thing left in the merge. It is a good
way to give back the win.

The guarantee it buys is also questionable. Under a violated contract, priority
emits a **plausible, well-formed** message and silently drops the others, which
looks like a reordering bug and can hide for a long time. The plain encode
emits garbage from an input that was not valid. Both are equally lossy; the
second is louder, and loud is what you want for a condition that is by
definition a design bug. Neither is a substitute for the caller meeting the
contract.

## The caller: `TelemetryMMIO`

`TelemetryMMIO` demuxes each MMIO command to exactly one telemetry client. Two
independent conditions make merging the replies without arbitration safe, and
both are now stated prominently in the class docs:

1. **At most one command in flight.** Decided by whichever module implements
   the `MMIO` service, not by `TelemetryMMIO`, which has no limiter of its own
   to fall back on.
2. **Every client asserts its response `valid` only in reply to a `get`.**

### Condition 2 is the subtle one, and it is pre-existing

A channel may legally hold `valid` high forever — an always-available counter
whose payload changes while its `valid` does not is a perfectly good ESI
producer. Such a client is offering a message whether or not it was asked, so
it breaks the at-most-one-valid contract by itself, no matter what condition 1
does.

It is worth being clear that this is **not a requirement introduced by this
merge**, and not one that can be avoided by keeping the arbiter. `ChannelMux2`
is fixed-priority:

```python
output_idx = ~input0_valid
input1_ready.assign(output_ready & output_idx)
```

so a permanently-valid input pins `output_idx` low and drives its sibling
subtree's `ready` low *forever*, starving every client behind it and returning
its own value for every read. That is a quieter and arguably worse failure than
the merge's. The condition was always load-bearing here; it had simply never
been written down.

Every in-tree client satisfies it today: `Telemetry.report_signal` drives its
data channel's `valid` from the `get` channel's, and both in-tree MMIO client
patterns (`addr_chan.transform(...)` and `wrap(storage, cmd_valid)`) derive
`valid` from the command channel.

The real fix is follow-up 2 below, which makes both conditions unnecessary
rather than documented. It is deliberately not in this PR.

`ChannelMMIO` in `esiaccel.bsp.common`, the other intended caller, caps issue
with a `MaxOutstandingLimiter(1)`; switching it is a separate PR later in this
stack because the ESI runtime CI installs a released PyCDE from PyPI
(`pip install pycde --pre`) and builds only `esiaccel` from source, so a
runtime change cannot depend on PyCDE API added in the same commit.
## Evidence

Measured on an internal build of esitester: switching the MMIO response fabric
to this merge improved role-clock fmax by about **11%** and reduced register
count by about **4%**.

Caveat: that build enabled arbiter mux pipelining
(`mux_pipeline_levels=2`) at the same time, so those figures are the two
changes combined, not the merge alone. What is attributable to the merge is
that the MMIO response cone stopped appearing in the violated set.

## Testing

`frontends/PyCDE/test/test_esi.py` gains three FileCheck configurations,
pinning the properties the correctness argument actually rests on:

- 3-input, unregistered: all inputs unwrap against the **same** `%ready`; the
  payload comes from `hw.array_create` + `hw.array_get`; interleaved
  `CHECK-NOT`s cover the whole span from the last unwrap to the wrap and assert
  that no `comb.or` on the payload width exists, so a regression to the
  corrupting OR form fails the test. Also pins the array length to the input
  count, since padding it to a power of two costs area for nothing.
- `register_output=True` — the default every caller gets, and the only path
  that instantiates the skid: checks for `esi.buffer ... {stages = 1}`.
- zero-width payload: `CHECK-NOT: comb.mux`, since there is nothing to select.

CHECK lines were written against generated MLIR, not guessed. Also
fault-injected a FIFO-signaled channel to confirm the new signaling guard
raises rather than elaborating wrong hardware.

Full PyCDE lit suite and ESI runtime simulation suite pass; the latter
exercises `TelemetryMMIO` end to end.


## Follow-ups (marked `TODO` in the code)

1. Flag the dropped-message case with an `sv.assert.concurrent`. Free in
   hardware, and it catches contract violations where they are actionable.
   Blocked on the SV dialect's Python bindings not exposing the `EventControl`
   enum needed to build the op's `event` attribute.
2. Take the select as an optional **input**, driven from the request side — for
   an MMIO processor, the same select that drives the command demux, one cycle
   earlier and already registered. This removes **both** conditions above
   rather than documenting them: `ready` is asserted only to the selected
   input, so a client holding `valid` high without having been asked is simply
   not read, and reading such a client returns its current payload — exactly
   the semantic an always-available counter wants. It is also *cheaper* than
   what is here today, since a registered select deletes the encoder from the
   response path instead of adding to it, and it is a prerequisite for handling
   multiple outstanding requests.


