### PR TITLE
[ESI] Add a pipelined grant scheduler to ChannelArbiter

### DIFF
--- a/lib/Dialect/ESI/runtime/docs/components/ChannelArbiter.md
+++ b/lib/Dialect/ESI/runtime/docs/components/ChannelArbiter.md
@@ -40,6 +40,8 @@ def ChannelArbiter(
     output_fifo_depth: Optional[int] = None,  # default: pipe latency + _SLACK
     buffer_inputs: bool = True,               # optional per-input skid buffer
     mux_pipeline_levels: Optional[int] = None,  # pipeline the N:1 select mux tree
+    pipelined_scheduler: bool = False,        # decoupled grant-queue scheduler
+    grant_queue_depth: int = 4,               # depth of that grant queue (>= 2)
     telemetry: bool = True,
 ) -> ChannelSignal
 ```
@@ -49,6 +51,9 @@ be greater than the pipeline latency (one output register plus any
 selection-mux pipeline latency); it is validated and defaults to that plus a
 small internal slack (the private, class-scoped `ChannelArbiterImpl._SLACK`,
 currently 2). A single input is returned unchanged.
+
+`pipelined_scheduler` selects a different control implementation with a
+**different service order** — see §7.1. It is off by default.
 
 ## 5. Last-flit detection (auto from type)
 Helper `_flit_last`:
@@ -122,7 +127,10 @@ to the lower index) rather than an `O(N)` chain, so it scales to large `N`
 without dominating the arbitration path — and it is far narrower than the data
 mux regardless.
 
-## 7. Control — round-robin arbitration
+## 7. Control — round-robin arbitration (default)
+This is the default control implementation (`pipelined_scheduler=False`); §7.1
+describes the alternative.
+
 `round_robin(valids, start)` is **purely combinational** — it has no state of
 its own. It returns `(winner, any_valid)`: the lowest-index input that is *both*
 valid and at index `>= start`, or — if none qualifies — the lowest-index valid
@@ -181,6 +189,61 @@ dedicated register bit near each producer rather than a shared combinational
 decode of `grant`. With `buffer_inputs=True` a 1-deep skid buffer localizes it
 further.
 
+## 7.1 Control — decoupled grant queue (`pipelined_scheduler=True`)
+The scheme in §7 answers "who is granted next?" combinationally in the cycle the
+current message ends, which puts the whole round-robin tree inside a single-cycle
+`grant -> grant` loop. That loop is the FMax limiter at high fan-in, and it
+cannot be pipelined away, because the result is needed in the same cycle it is
+computed.
+
+`pipelined_scheduler=True` breaks the loop by decoupling decision from use:
+
+- A **grant queue** (`grant_queue_depth` entries, show-ahead) holds upcoming
+  winners. The datapath just pops it, so its next-grant path is a FIFO read, not
+  an arbitration tree.
+- A **sweep scheduler** refills the queue off the critical path: snapshot the
+  valid mask into `pending`, then emit its set bits one per cycle, lowest index
+  first, reloading the snapshot on the same cycle the last bit is queued.
+  (Reloading a cycle *later* would idle the scheduler for one cycle per sweep
+  and cap throughput at `n/(n+1)` for `n` active inputs, for **single-flit**
+  messages — multi-flit lists keep the datapath busy across the refill and hide
+  it. There is a regression test.) The only remaining single-cycle loop is
+  `pending -> lowest-set-bit -> sweep-exhausted -> pending`: one `x & -x` plus a
+  mask and a wide NOR — 5 6-LUT levels at N=32, against 7 for §7's
+  `grant -> grant` loop. It is not the arbiter's critical path: at N=32 with
+  `mux_pipeline_levels=2` the deepest path is the registered `grant_oh` decode
+  at 6 levels, so the sweep loop still has slack.
+
+**Why committing a decision early is safe.** Not because the decision stays
+accurate — ESI's ValidReady makes no stability guarantee, so a scheduled input
+may change its payload or drop `valid` before it is granted. It is safe because
+both outcomes are benign:
+
+- *Payload changed* — forward it. The arbiter chooses which input is served, not
+  which message; whatever that input offers when granted is a message it wants
+  sent.
+- *`valid` dropped* — costs at most a bubble. The grant is abandoned in one cycle
+  by the `stale` path, or the FSM parks on it if the queue has since emptied.
+
+A queued entry is therefore a hint about who to serve next, not a promise that a
+particular message is waiting.
+
+**Ordering differs from §7, deliberately.** Every input valid at snapshot time is
+*scheduled* exactly once per sweep, but that is a property of the sweep, not an
+end-to-end guarantee: the datapath may serve an input without consulting the
+queue (see `stale`/parked-grant handling in `_build_scheduler`). Service order is
+therefore best-effort. Do not enable this where exact ordering fairness is
+load-bearing.
+
+**`grant_queue_depth` is not a fairness knob.** It bounds only how many decisions
+are committed ahead of the datapath. A newly-valid input waits for the rest of
+the current sweep, then for queued grants and lower-index entries of the next
+sweep, so its latency also scales with the number of concurrently active inputs
+and can exceed `grant_queue_depth` messages when `num_inputs > grant_queue_depth`.
+
+Sustained throughput is ~1 beat/cycle, the same as §7 (and, for a single active
+input, better: §7 spends a turnaround cycle re-arbitrating at each message end).
+
 ## 8. Input buffering (optional)
 `buffer_inputs=True` (default, recommended for FMax) inserts a 1-deep skid buffer
 per input, localizing each producer's `ready`. Set it `False` when producers
@@ -198,7 +261,9 @@ their hierarchical appid path, so no per-instance name prefix is needed:
 - `maxListLen` — running max of per-message flit count.
 - `totalFlits`, `totalMessages` — host computes average list length =
   `totalFlits / totalMessages` (avoids a hardware divider).
-- `arbSwitches` — number of grant changes (contention indicator).
+- `arbSwitches` — number of grant changes (contention indicator). Under
+  `pipelined_scheduler` this counts grants loaded from the grant queue, the
+  equivalent event in that mode.
 - `inflightHighWater` — max output in-flight occupancy (`depth - credit`) to
   right-size `output_fifo_depth`.
 

--- a/lib/Dialect/ESI/runtime/docs/components/ChannelArbiter.md
+++ b/lib/Dialect/ESI/runtime/docs/components/ChannelArbiter.md
@@ -231,7 +231,7 @@ particular message is waiting.
 **Ordering differs from §7, deliberately.** Every input valid at snapshot time is
 *scheduled* exactly once per sweep, but that is a property of the sweep, not an
 end-to-end guarantee: the datapath may serve an input without consulting the
-queue (see `stale`/parked-grant handling in `_build_scheduler`). Service order is
+queue (see `stale`/parked-grant handling in `GrantScheduler`). Service order is
 therefore best-effort. Do not enable this where exact ordering fairness is
 load-bearing.
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -1531,6 +1531,7 @@ def HostmemReadProcessor(
                                          ports.clk,
                                          ports.rst,
                                          mux_pipeline_levels=2,
+                                         pipelined_scheduler=True,
                                          telemetry=False)
       upstream_req_channel.assign(muxed_client_reqs)
       HostmemReadProcessorImpl.reqPortMap.clear()
@@ -1917,6 +1918,7 @@ def HostMemWriteProcessor(
                                            ports.clk,
                                            ports.rst,
                                            mux_pipeline_levels=2,
+                                           pipelined_scheduler=True,
                                            telemetry=False)
       upstream_req_channel.assign(muxed_write_channel)
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
@@ -81,133 +81,126 @@ def _select_mux(sel: BitsSignal, values: List[BitsSignal], clk: ClockSignal,
   return cur[0]
 
 
-def _onehot_to_index(onehot: BitsSignal, num_inputs: int,
-                     gw: int) -> BitsSignal:
+def _onehot_to_index(onehot: BitsSignal) -> BitsSignal:
   """Encode a one-hot bit-vector to its binary index. Bit `b` of the result is
   the OR of the one-hot bits whose index has bit `b` set."""
+  num_inputs = onehot.type.width
   bits = []
-  for b in range(gw):
+  for b in range(clog2(num_inputs)):
     terms = [onehot[i] for i in range(num_inputs) if (i >> b) & 1]
     bits.append(Or(*terms) if terms else Bits(1)(0))
   return BitsSignal.concat(list(reversed(bits)))
 
 
-def _build_scheduler(
-    clk: ClockSignal, rst: Signal, num_inputs: int, gw: int,
-    valids: List[BitsSignal], grant: BitsSignal, busy: BitsSignal,
-    launch: BitsSignal, msg_end: BitsSignal,
-    queue_depth: int) -> Tuple[BitsSignal, BitsSignal, BitsSignal]:
-  """Decoupled, pipelinable grant scheduler. Returns `(next_grant, next_busy,
-  switch)`, where `switch` is high on cycles the grant is (re)loaded from the
-  queue -- the scheduler-mode analogue of the flat arbiter's re-arbitration,
-  used for telemetry.
+# Grant-control strategies. `GrantSchedulerMod` and `RoundRobinControlMod` are
+# interchangeable: they deliberately carry the *same* port signature, so the
+# arbiter picks one and wires it up identically. (PyCDE scans only a class's own
+# dict for ports, so the signature cannot be inherited from a common base -- it
+# is spelled out in each and must be kept in sync.) `launch` is unused by the
+# round-robin strategy; it is present so the signature stays uniform.
+#
+# The registered `grant`/`busy` live in the arbiter, since the datapath reads
+# them; a control module sees their current values and drives the next ones.
+# `grant_oh` is the arbiter's registered one-hot decode of `grant`, passed in so
+# neither strategy has to re-decode it. `switch` is high on cycles the grant is
+# (re)loaded, and feeds the `arbSwitches` telemetry counter.
 
-  The flat arbiter must answer "who is granted next?" combinationally in the
-  cycle the current message ends, which puts the whole round-robin tree inside a
-  single-cycle `grant -> grant` loop -- the dominant timing limiter at high
-  fan-in. Here the two are decoupled: a **grant queue** holds upcoming winners,
-  the datapath just pops it, and a **sweep scheduler** refills it off the
-  critical path.
 
-  Committing a decision ahead of use is safe not because the decision stays
-  accurate, but because both ways it can go stale are benign. ESI's ValidReady
-  makes no stability guarantee: an input may change its payload or drop `valid`
-  after being scheduled.
+@modparams
+def GrantSchedulerMod(num_inputs: int, queue_depth: int):
+  """Decoupled, pipelinable grant scheduler (`pipelined_scheduler=True`).
 
-  * Payload changed -- forward it. The arbiter selects *which* input is served,
-    not which message; whatever that input is offering when granted is a
-    message it wants sent.
-  * `valid` dropped -- costs at most a bubble, never correctness. The grant is
-    abandoned in one cycle by `stale` below, or, if the queue has since
-    emptied, the FSM parks on it until that input has something (see the
-    ordering note below).
+  A **grant queue** holds upcoming winners for the datapath to pop, and a
+  **sweep scheduler** refills it off the critical path. That breaks the flat
+  arbiter's single-cycle `grant -> grant` loop, its dominant timing limiter at
+  high fan-in. A queued entry is a hint about who to serve next, not a promise
+  that a particular message is waiting: an entry whose input has since gone
+  idle is skipped in one cycle (`stale` below) rather than stalling the output.
 
-  So a queued decision is a hint about who to serve next, not a promise that a
-  particular message is waiting.
+  Consequently service order is best-effort, and `queue_depth` bounds only how
+  far ahead of the datapath decisions are committed -- it is not a fairness
+  knob. See section 7.1 of `docs/components/ChannelArbiter.md` for why
+  committing early is safe and for the full ordering/latency caveats."""
+  assert num_inputs >= 2, "GrantSchedulerMod requires at least two inputs"
+  gw = clog2(num_inputs)
 
-  Scheduling policy (a "sweep"): snapshot the valid mask into `pending`, then
-  emit its set bits one per cycle, lowest index first, reloading the snapshot on
-  the same cycle the last bit is queued. Every input valid at snapshot time is
-  therefore *scheduled* exactly once per sweep. The only logic left in a
-  single-cycle loop is `pending -> lowest-set-bit -> sweep-exhausted -> pending`:
-  one `x & -x` (a carry chain), a mask, and a wide NOR. Mapped to 6-LUTs that is
-  5 levels at N=32, against 7 for the flat arbiter's `grant -> grant` loop, so
-  it is still the shallower of the two.
+  class GrantScheduler(Module):
+    clk = Clock()
+    rst = Reset()
 
-  Note that this is a property of the sweep, not an end-to-end ordering
-  guarantee: the datapath can serve an input without consulting the queue. If a
-  grant is popped for an input that turns out to have nothing and the queue
-  then empties, `stale` (gated on `q_nonempty`) cannot fire and the FSM parks
-  on that grant with its `ready` still asserted, so the next message from that
-  input is served immediately, ahead of the queue. This is bounded -- `busy`
-  drops at that `msg_end` and any newly-valid input recovers via `stale` as
-  soon as the sweep pushes an entry -- but it does make the service order
-  best-effort rather than exact. Do not rely on it where ordering fairness is
-  load-bearing.
+    valids = Input(Bits(num_inputs))
+    grant = Input(Bits(gw))
+    grant_oh = Input(Bits(num_inputs))
+    busy = Input(Bits(1))
+    launch = Input(Bits(1))
+    msg_end = Input(Bits(1))
 
-  A backlogged input is re-snapshotted every sweep, so it keeps its grants
-  flowing back to back and a lone active input still runs at full rate.
+    next_grant = Output(Bits(gw))
+    next_busy = Output(Bits(1))
+    switch = Output(Bits(1))
 
-  Latency for a newly-valid input is *not* bounded by `queue_depth` alone. An
-  input which goes valid just after a snapshot waits for the rest of the
-  current sweep to be enqueued, then for any already-queued grants and for the
-  lower-index entries of the next sweep -- so the wait scales with the number
-  of concurrently active inputs as well, and with `num_inputs > queue_depth` it
-  can exceed `queue_depth` messages. `queue_depth` bounds only the number of
-  decisions committed ahead of the datapath, i.e. how stale the queue's view
-  can be; it is not a fairness knob.
+    @generator
+    def build(ports) -> None:
+      clk = ports.clk
+      rst = ports.rst
+      busy = ports.busy
 
-  An entry whose input has since gone idle (over-scheduled, or drained by
-  another route) is skipped in a single cycle rather than stalling the output:
-  see `stale` below. `started` distinguishes "this grant has not delivered a
-  flit yet" (safe to abandon) from "mid-message" (must not be abandoned, or the
-  message would be split)."""
+      # Grant queue. `rd_latency=0` makes it show-ahead, so `q_head` is a
+      # registered value available the same cycle -- popping adds no bubble.
+      gq = SeqFIFO(Bits(gw), queue_depth, clk, rst)
+      q_pop = Wire(Bits(1), "gq_pop")
+      q_head = gq.pop(q_pop)
+      q_nonempty = ~gq.empty
 
-  # Grant queue. `rd_latency=0` makes it show-ahead, so `q_head` is a
-  # registered value available the same cycle -- popping introduces no bubble.
-  gq = SeqFIFO(Bits(gw), queue_depth, clk, rst)
-  q_pop = Wire(Bits(1), "gq_pop")
-  q_head = gq.pop(q_pop)
-  q_nonempty = ~gq.empty
+      # ---- Sweep scheduler (off the datapath's critical path). ----
+      pending = Reg(Bits(num_inputs),
+                    clk,
+                    rst,
+                    rst_value=0,
+                    name="sched_pending")
+      pend_nonzero = pending != Bits(num_inputs)(0)
+      # Isolate the lowest set bit: x & (-x), with -x == ~x + 1.
+      neg_pending = ((~pending).as_uint(num_inputs) +
+                     UInt(num_inputs)(1)).as_bits(num_inputs)
+      low = pending & neg_pending
+      push = pend_nonzero & ~gq.full
+      gq.push(_onehot_to_index(low), push)
+      # Clear the bit just scheduled (or hold if the queue is full), and reload
+      # the snapshot as soon as the sweep is exhausted. The reload has to happen
+      # on the *same* cycle the last bit is pushed: deferring it to the cycle
+      # after `pending` reads zero costs one idle cycle per sweep, capping
+      # throughput at `n/(n+1)` for `n` concurrently-active inputs. That only
+      # bites for single-flit messages; with multi-flit lists the datapath is
+      # still streaming the current message while the sweep refills, so the
+      # bubble is hidden.
+      cleared = pending & ~low
+      sweep_done = push & (cleared == Bits(num_inputs)(0))
+      pending.assign(
+          Mux(~pend_nonzero | sweep_done, Mux(push, pending, cleared),
+              ports.valids))
 
-  # ---- Sweep scheduler (off the datapath's critical path). ----
-  pending = Reg(Bits(num_inputs), clk, rst, rst_value=0, name="sched_pending")
-  valids_vec = BitsSignal.concat(list(reversed(valids)))
-  pend_nonzero = pending != Bits(num_inputs)(0)
-  # Isolate the lowest set bit: x & (-x), with -x == ~x + 1.
-  neg_pending = ((~pending).as_uint(num_inputs) +
-                 UInt(num_inputs)(1)).as_bits(num_inputs)
-  low = pending & neg_pending
-  push = pend_nonzero & ~gq.full
-  gq.push(_onehot_to_index(low, num_inputs, gw), push)
-  # Clear the bit just scheduled (or hold if the queue is full), and reload the
-  # snapshot as soon as the sweep is exhausted. The reload has to happen on the
-  # *same* cycle the last bit is pushed: deferring it to the cycle after
-  # `pending` reads zero costs one idle cycle per sweep, capping throughput at
-  # `n/(n+1)` for `n` concurrently-active inputs. That only bites for
-  # single-flit messages; with multi-flit lists the datapath is still streaming
-  # the current message while the sweep refills, so the bubble is hidden.
-  cleared = pending & ~low
-  sweep_done = push & (cleared == Bits(num_inputs)(0))
-  pending.assign(
-      Mux(~pend_nonzero | sweep_done, Mux(push, pending, cleared), valids_vec))
+      # ---- Datapath grant FSM. ----
+      # `started` distinguishes "this grant has not delivered a flit yet" (safe
+      # to abandon) from "mid-message" (abandoning would split the message).
+      started = Reg(Bits(1), clk, rst, rst_value=0, name="grant_started")
+      sel_valid_now = (ports.valids & ports.grant_oh).or_reduce()
+      # Abandon a grant that has not yet delivered a flit and whose input is not
+      # offering one, but only when there is someone else to serve.
+      stale = busy & ~started & ~sel_valid_now & q_nonempty
+      advance = ports.msg_end | stale
+      take_next = ~busy | advance
+      q_pop.assign(take_next & q_nonempty)
 
-  # ---- Datapath grant FSM. ----
-  started = Reg(Bits(1), clk, rst, rst_value=0, name="grant_started")
-  sel_valid_now = Or(
-      *[valids[i] & (grant == Bits(gw)(i)) for i in range(num_inputs)])
-  # Abandon a grant that has not yet delivered a flit and whose input is not
-  # offering one, but only when there is someone else to serve.
-  stale = busy & ~started & ~sel_valid_now & q_nonempty
-  advance = msg_end | stale
-  take_next = ~busy | advance
-  q_pop.assign(take_next & q_nonempty)
+      ports.next_grant = Mux(take_next & q_nonempty, ports.grant, q_head)
+      ports.next_busy = Mux(take_next, busy, q_nonempty)
+      # Taking a new grant clears `started`; otherwise the first launched flit
+      # sets it.
+      started_next = Mux(ports.launch, started, Bits(1)(1))
+      started.assign(Mux(take_next, started_next, Bits(1)(0)))
+      # The grant is replaced by a queued decision exactly when it is popped.
+      ports.switch = q_pop
 
-  next_grant = Mux(take_next & q_nonempty, grant, q_head)
-  next_busy = Mux(take_next, busy, q_nonempty)
-  started.assign(Mux(take_next, Mux(launch, started, Bits(1)(1)), Bits(1)(0)))
-  # The grant is replaced by a queued decision exactly when it is popped.
-  return next_grant, next_busy, q_pop
+  return GrantScheduler
 
 
 @modparams
@@ -219,7 +212,8 @@ def RoundRobinArbiterMod(num_inputs: int):
   `winner` is the lowest-index input that is valid and at index `>= start`
   (cyclically), falling back to the lowest-index valid input overall; `any_valid`
   is high when any input is valid. Purely combinational -- the owning state
-  (`grant`/`busy`/`rr_ptr`) lives in the arbiter."""
+  lives in its parent (`rr_ptr` in `RoundRobinControlMod`, `grant`/`busy` in the
+  arbiter itself)."""
   assert num_inputs >= 2, "RoundRobinArbiterMod requires at least two inputs"
   gw = clog2(num_inputs)
 
@@ -270,6 +264,80 @@ def RoundRobinArbiterMod(num_inputs: int):
       ports.any_valid = hi_any | lo_any
 
   return RoundRobinArbiter
+
+
+@modparams
+def RoundRobinControlMod(num_inputs: int):
+  """Flat round-robin grant control (the default strategy).
+
+  Answers "who is granted next?" combinationally in the cycle the current
+  message ends, using two `RoundRobinArbiter` instances -- one for picking up
+  from idle, one for the message-end turnaround -- plus the `rr_ptr` fairness
+  pointer, which is owned here because only this strategy has one. See section
+  7 of `docs/components/ChannelArbiter.md`.
+
+  `launch` is unused; it exists only to match `GrantSchedulerMod`'s
+  signature."""
+  assert num_inputs >= 2, "RoundRobinControlMod requires at least two inputs"
+  gw = clog2(num_inputs)
+
+  class RoundRobinControl(Module):
+    clk = Clock()
+    rst = Reset()
+
+    valids = Input(Bits(num_inputs))
+    grant = Input(Bits(gw))
+    grant_oh = Input(Bits(num_inputs))
+    busy = Input(Bits(1))
+    launch = Input(Bits(1))
+    msg_end = Input(Bits(1))
+
+    next_grant = Output(Bits(gw))
+    next_busy = Output(Bits(1))
+    switch = Output(Bits(1))
+
+    @generator
+    def build(ports) -> None:
+      clk = ports.clk
+      rst = ports.rst
+      grant = ports.grant
+      busy = ports.busy
+      rr_ptr = Reg(Bits(gw), clk, rst, name="rr_ptr")
+      rr_arbiter = RoundRobinArbiterMod(num_inputs)
+
+      def round_robin(valids_vec: BitsSignal, start: BitsSignal,
+                      name: str) -> Tuple[BitsSignal, BitsSignal]:
+        """Instantiate a RoundRobinArbiter over `valids_vec` starting from
+        `start`."""
+        inst = rr_arbiter(valids=valids_vec, start=start, instance_name=name)
+        return inst.winner, inst.any_valid
+
+      grant_u = grant.as_uint(gw)
+      is_last_idx = grant == Bits(gw)(num_inputs - 1)
+      grant_p1 = Mux(is_last_idx, (grant_u + UInt(gw)(1)).as_bits(gw),
+                     Bits(gw)(0))
+
+      winner_idle, any_idle = round_robin(ports.valids, rr_ptr, "rr_idle")
+      # At a message end the just-consumed input still asserts `valid` this
+      # cycle (the flit is consumed on the clock edge), so mask it out of the
+      # re-arbitration. Otherwise the round-robin wrap-around would
+      # speculatively re-grant that stale valid and the FSM would get stuck
+      # `busy` on an input that goes empty next cycle. A genuinely backlogged
+      # input is re-selected on the following idle cycle instead.
+      valids_next = ports.valids & ~ports.grant_oh
+      winner_next, any_next = round_robin(valids_next, grant_p1, "rr_next")
+
+      pick = ~busy & any_idle
+      reend = busy & ports.msg_end
+      grant_if_not_reend = Mux(pick, grant, winner_idle)
+      busy_if_not_reend = Mux(pick, busy, Bits(1)(1))
+
+      ports.next_grant = Mux(reend, grant_if_not_reend, winner_next)
+      ports.next_busy = Mux(reend, busy_if_not_reend, any_next)
+      rr_ptr.assign(Mux(reend, rr_ptr, grant_p1))
+      ports.switch = pick | (reend & any_next)
+
+  return RoundRobinControl
 
 
 @modparams
@@ -369,8 +437,6 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
       # below). ----
       grant = Reg(Bits(gw), clk, rst, name="grant")
       busy = Reg(Bits(1), clk, rst, name="busy")
-      if not pipelined_scheduler:
-        rr_ptr = Reg(Bits(gw), clk, rst, name="rr_ptr")
       credit = Reg(UInt(cw), clk, rst, rst_value=depth, name="credit")
 
       credit_gt0 = credit > UInt(cw)(0)
@@ -449,51 +515,23 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
       credit.assign(next_credit)
 
       # ---- Arbitration. ----
-      if pipelined_scheduler:
-        next_grant, next_busy, arb_switch = _build_scheduler(
-            clk, rst, num_inputs, gw, valids, grant, busy, launch, msg_end,
-            grant_queue_depth)
-        grant.assign(next_grant)
-        busy.assign(next_busy)
-      else:
-        # ---- Round-robin arbitration (own module for waveform visibility). --
-        rr_arbiter = RoundRobinArbiterMod(num_inputs)
-
-        def round_robin(valid_list: List[BitsSignal], start: BitsSignal,
-                        name: str) -> Tuple[BitsSignal, BitsSignal]:
-          """Instantiate a RoundRobinArbiter over `valid_list` (packed into a
-          bit-bus, bit `i` == input `i`) starting from `start`."""
-          valids_vec = BitsSignal.concat(list(reversed(valid_list)))
-          inst = rr_arbiter(valids=valids_vec, start=start, instance_name=name)
-          return inst.winner, inst.any_valid
-
-        grant_u = grant.as_uint(gw)
-        is_last_idx = grant == Bits(gw)(num_inputs - 1)
-        grant_p1 = Mux(is_last_idx, (grant_u + UInt(gw)(1)).as_bits(gw),
-                       Bits(gw)(0))
-
-        winner_idle, any_idle = round_robin(valids, rr_ptr, "rr_idle")
-        # At a message end the just-consumed input still asserts `valid` this
-        # cycle (the flit is consumed on the clock edge), so mask it out of the
-        # re-arbitration. Otherwise the round-robin wrap-around would
-        # speculatively re-grant that stale valid and the FSM would get stuck
-        # `busy` on an input that goes empty next cycle. A genuinely backlogged
-        # input is re-selected on the following idle cycle instead.
-        valids_next = [valids[i] & ~grant_is[i] for i in range(num_inputs)]
-        winner_next, any_next = round_robin(valids_next, grant_p1, "rr_next")
-
-        pick = ~busy & any_idle
-        reend = busy & msg_end
-        grant_if_not_reend = Mux(pick, grant, winner_idle)
-        next_grant = Mux(reend, grant_if_not_reend, winner_next)
-        busy_if_not_reend = Mux(pick, busy, Bits(1)(1))
-        next_busy = Mux(reend, busy_if_not_reend, any_next)
-        next_rr = Mux(reend, rr_ptr, grant_p1)
-
-        grant.assign(next_grant)
-        busy.assign(next_busy)
-        rr_ptr.assign(next_rr)
-        arb_switch = pick | (reend & any_next)
+      # Either grant-control strategy presents the same ports, so the only
+      # difference here is which module gets instantiated.
+      ctrl_mod = (GrantSchedulerMod(num_inputs, grant_queue_depth)
+                  if pipelined_scheduler else RoundRobinControlMod(num_inputs))
+      ctrl = ctrl_mod(clk=clk,
+                      rst=rst,
+                      valids=BitsSignal.concat(list(reversed(valids))),
+                      grant=grant,
+                      grant_oh=BitsSignal.concat(list(reversed(grant_is))),
+                      busy=busy,
+                      launch=launch,
+                      msg_end=msg_end,
+                      instance_name="arb_ctrl")
+      next_grant = ctrl.next_grant
+      arb_switch = ctrl.switch
+      grant.assign(next_grant)
+      busy.assign(ctrl.next_busy)
 
       # Register the one-hot grant decode -- one register per input -- so each
       # (potentially high-fanout) per-input grant signal is driven by its own
@@ -592,13 +630,13 @@ def ChannelArbiter(input_channels: List[ChannelSignal],
       grant queue fed by a sweep scheduler, instead of re-arbitrating
       combinationally at each message end. This takes the round-robin tree out
       of the single-cycle `grant -> grant` loop, which is the Fmax limiter at
-      high fan-in. Changes the service order (see `_build_scheduler`).
+      high fan-in. Changes the service order (see `GrantSchedulerMod`).
     grant_queue_depth: depth of that grant queue -- how many grant decisions
       may be committed ahead of the datapath. Must be >= 2: a single entry
       cannot keep the datapath fed back to back, so every message would cost a
       refill bubble. This is not a fairness knob; a newly-valid input's wait
       also scales with the number of concurrently active inputs (see
-      `_build_scheduler`).
+      `GrantSchedulerMod`).
     telemetry: emit telemetry (selected channel, list-length stats, etc.).
 
   See `docs/components/ChannelArbiter.md`."""

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
@@ -93,17 +93,15 @@ def _onehot_to_index(onehot: BitsSignal) -> BitsSignal:
 
 
 # Grant-control strategies. `GrantSchedulerMod` and `RoundRobinControlMod` are
-# interchangeable: they deliberately carry the *same* port signature, so the
-# arbiter picks one and wires it up identically. (PyCDE scans only a class's own
-# dict for ports, so the signature cannot be inherited from a common base -- it
-# is spelled out in each and must be kept in sync.) `launch` is unused by the
-# round-robin strategy; it is present so the signature stays uniform.
+# interchangeable: they deliberately carry the *same* port signature, documented
+# per-port on `GrantScheduler` below, so the arbiter picks one and wires it up
+# identically. (PyCDE scans only a class's own dict for ports, so the signature
+# cannot be inherited from a common base -- it is spelled out in each and must be
+# kept in sync.) `launch` is unused by the round-robin strategy; it is present so
+# the signature stays uniform.
 #
 # The registered `grant`/`busy` live in the arbiter, since the datapath reads
 # them; a control module sees their current values and drives the next ones.
-# `grant_oh` is the arbiter's registered one-hot decode of `grant`, passed in so
-# neither strategy has to re-decode it. `switch` is high on cycles the grant is
-# (re)loaded, and feeds the `arbSwitches` telemetry counter.
 
 
 @modparams
@@ -128,15 +126,24 @@ def GrantSchedulerMod(num_inputs: int, queue_depth: int):
     clk = Clock()
     rst = Reset()
 
+    # Per-input `valid`; bit `i` is high when input `i` is offering a flit.
     valids = Input(Bits(num_inputs))
+    # Index of the currently granted input (the arbiter's `grant` register).
     grant = Input(Bits(gw))
+    # `grant` pre-decoded to one-hot, registered by the arbiter.
     grant_oh = Input(Bits(num_inputs))
+    # High while `grant` is in force, i.e. an input is currently being served.
     busy = Input(Bits(1))
+    # High on cycles a flit is accepted from the granted input.
     launch = Input(Bits(1))
+    # High on the `launch` of a message's final flit.
     msg_end = Input(Bits(1))
 
+    # Next value of the arbiter's `grant` register.
     next_grant = Output(Bits(gw))
+    # Next value of the arbiter's `busy` register.
     next_busy = Output(Bits(1))
+    # High on cycles the grant is (re)loaded from the queue; telemetry only.
     switch = Output(Bits(1))
 
     @generator

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
@@ -100,8 +100,42 @@ def _onehot_to_index(onehot: BitsSignal) -> BitsSignal:
 # kept in sync.) `launch` is unused by the round-robin strategy; it is present so
 # the signature stays uniform.
 #
-# The registered `grant`/`busy` live in the arbiter, since the datapath reads
-# them; a control module sees their current values and drives the next ones.
+# A control module owns the grant FSM state (`grant`/`grant_oh`/`busy`, plus
+# whatever else the strategy needs) and exposes it for the datapath to read. Its
+# inputs are purely observations of the datapath: which inputs are offering
+# (`valids`), and whether a flit / a final flit was accepted (`launch`,
+# `msg_end`). `_build_grant_state` below builds the state common to both.
+
+
+def _build_grant_state(
+    ports, clk: ClockSignal, rst: Signal, num_inputs: int,
+    next_grant: BitsSignal,
+    next_busy: BitsSignal) -> Tuple[BitsSignal, BitsSignal, BitsSignal]:
+  """Register `next_grant`/`next_busy` into the grant FSM state every control
+  module has, drive the `grant`/`grant_oh`/`busy` ports with it, and return
+  `(grant, grant_oh, busy)` for the strategy to compute its next state from
+  (typically via `Wire`s, since next state depends on current).
+
+  `grant_oh` is decoded *ahead* of its registers -- one flop per input -- so
+  each high-fanout per-input grant is driven straight from a flop rather than a
+  shared combinational decode of `grant`. Decoding at the instantiation site
+  would necessarily land after the register, hence it lives here. Both are fed
+  from the same next-state, so `grant_oh[i]` is high exactly when
+  `grant == i`."""
+  gw = clog2(num_inputs)
+  grant = next_grant.reg(clk, rst, name="grant")
+  grant_oh = BitsSignal.concat([
+      (next_grant == Bits(gw)(i)).reg(clk,
+                                      rst,
+                                      rst_value=(1 if i == 0 else 0),
+                                      name=f"grant_oh_{i}")
+      for i in reversed(range(num_inputs))
+  ])
+  busy = next_busy.reg(clk, rst, name="busy")
+  ports.grant = grant
+  ports.grant_oh = grant_oh
+  ports.busy = busy
+  return grant, grant_oh, busy
 
 
 @modparams
@@ -128,21 +162,17 @@ def GrantSchedulerMod(num_inputs: int, queue_depth: int):
 
     # Per-input `valid`; bit `i` is high when input `i` is offering a flit.
     valids = Input(Bits(num_inputs))
-    # Index of the currently granted input (the arbiter's `grant` register).
-    grant = Input(Bits(gw))
-    # `grant` pre-decoded to one-hot, registered by the arbiter.
-    grant_oh = Input(Bits(num_inputs))
-    # High while `grant` is in force, i.e. an input is currently being served.
-    busy = Input(Bits(1))
     # High on cycles a flit is accepted from the granted input.
     launch = Input(Bits(1))
     # High on the `launch` of a message's final flit.
     msg_end = Input(Bits(1))
 
-    # Next value of the arbiter's `grant` register.
-    next_grant = Output(Bits(gw))
-    # Next value of the arbiter's `busy` register.
-    next_busy = Output(Bits(1))
+    # Index of the currently granted input.
+    grant = Output(Bits(gw))
+    # `grant` pre-decoded to one-hot, one register per bit.
+    grant_oh = Output(Bits(num_inputs))
+    # High while `grant` is in force, i.e. an input is currently being served.
+    busy = Output(Bits(1))
     # High on cycles the grant is (re)loaded from the queue; telemetry only.
     switch = Output(Bits(1))
 
@@ -150,7 +180,10 @@ def GrantSchedulerMod(num_inputs: int, queue_depth: int):
     def build(ports) -> None:
       clk = ports.clk
       rst = ports.rst
-      busy = ports.busy
+      next_grant = Wire(Bits(gw), "next_grant")
+      next_busy = Wire(Bits(1), "next_busy")
+      grant, grant_oh, busy = _build_grant_state(ports, clk, rst, num_inputs,
+                                                 next_grant, next_busy)
 
       # Grant queue. `rd_latency=0` makes it show-ahead, so `q_head` is a
       # registered value available the same cycle -- popping adds no bubble.
@@ -172,6 +205,7 @@ def GrantSchedulerMod(num_inputs: int, queue_depth: int):
       low = pending & neg_pending
       push = pend_nonzero & ~gq.full
       gq.push(_onehot_to_index(low), push)
+
       # Clear the bit just scheduled (or hold if the queue is full), and reload
       # the snapshot as soon as the sweep is exhausted. The reload has to happen
       # on the *same* cycle the last bit is pushed: deferring it to the cycle
@@ -190,7 +224,7 @@ def GrantSchedulerMod(num_inputs: int, queue_depth: int):
       # `started` distinguishes "this grant has not delivered a flit yet" (safe
       # to abandon) from "mid-message" (abandoning would split the message).
       started = Reg(Bits(1), clk, rst, rst_value=0, name="grant_started")
-      sel_valid_now = (ports.valids & ports.grant_oh).or_reduce()
+      sel_valid_now = (ports.valids & grant_oh).or_reduce()
       # Abandon a grant that has not yet delivered a flit and whose input is not
       # offering one, but only when there is someone else to serve.
       stale = busy & ~started & ~sel_valid_now & q_nonempty
@@ -198,12 +232,13 @@ def GrantSchedulerMod(num_inputs: int, queue_depth: int):
       take_next = ~busy | advance
       q_pop.assign(take_next & q_nonempty)
 
-      ports.next_grant = Mux(take_next & q_nonempty, ports.grant, q_head)
-      ports.next_busy = Mux(take_next, busy, q_nonempty)
+      next_grant.assign(Mux(take_next & q_nonempty, grant, q_head))
+      next_busy.assign(Mux(take_next, busy, q_nonempty))
       # Taking a new grant clears `started`; otherwise the first launched flit
       # sets it.
       started_next = Mux(ports.launch, started, Bits(1)(1))
       started.assign(Mux(take_next, started_next, Bits(1)(0)))
+
       # The grant is replaced by a queued decision exactly when it is popped.
       ports.switch = q_pop
 
@@ -219,8 +254,7 @@ def RoundRobinArbiterMod(num_inputs: int):
   `winner` is the lowest-index input that is valid and at index `>= start`
   (cyclically), falling back to the lowest-index valid input overall; `any_valid`
   is high when any input is valid. Purely combinational -- the owning state
-  lives in its parent (`rr_ptr` in `RoundRobinControlMod`, `grant`/`busy` in the
-  arbiter itself)."""
+  (`rr_ptr`, `grant`/`busy`) lives in `RoundRobinControlMod`."""
   assert num_inputs >= 2, "RoundRobinArbiterMod requires at least two inputs"
   gw = clog2(num_inputs)
 
@@ -280,8 +314,8 @@ def RoundRobinControlMod(num_inputs: int):
   Answers "who is granted next?" combinationally in the cycle the current
   message ends, using two `RoundRobinArbiter` instances -- one for picking up
   from idle, one for the message-end turnaround -- plus the `rr_ptr` fairness
-  pointer, which is owned here because only this strategy has one. See section
-  7 of `docs/components/ChannelArbiter.md`.
+  pointer, which is private to this strategy. See section 7 of
+  `docs/components/ChannelArbiter.md`.
 
   `launch` is unused; it exists only to match `GrantSchedulerMod`'s
   signature."""
@@ -293,22 +327,22 @@ def RoundRobinControlMod(num_inputs: int):
     rst = Reset()
 
     valids = Input(Bits(num_inputs))
-    grant = Input(Bits(gw))
-    grant_oh = Input(Bits(num_inputs))
-    busy = Input(Bits(1))
     launch = Input(Bits(1))
     msg_end = Input(Bits(1))
 
-    next_grant = Output(Bits(gw))
-    next_busy = Output(Bits(1))
+    grant = Output(Bits(gw))
+    grant_oh = Output(Bits(num_inputs))
+    busy = Output(Bits(1))
     switch = Output(Bits(1))
 
     @generator
     def build(ports) -> None:
       clk = ports.clk
       rst = ports.rst
-      grant = ports.grant
-      busy = ports.busy
+      next_grant = Wire(Bits(gw), "next_grant")
+      next_busy = Wire(Bits(1), "next_busy")
+      grant, grant_oh, busy = _build_grant_state(ports, clk, rst, num_inputs,
+                                                 next_grant, next_busy)
       rr_ptr = Reg(Bits(gw), clk, rst, name="rr_ptr")
       rr_arbiter = RoundRobinArbiterMod(num_inputs)
 
@@ -331,7 +365,7 @@ def RoundRobinControlMod(num_inputs: int):
       # speculatively re-grant that stale valid and the FSM would get stuck
       # `busy` on an input that goes empty next cycle. A genuinely backlogged
       # input is re-selected on the following idle cycle instead.
-      valids_next = ports.valids & ~ports.grant_oh
+      valids_next = ports.valids & ~grant_oh
       winner_next, any_next = round_robin(valids_next, grant_p1, "rr_next")
 
       pick = ~busy & any_idle
@@ -339,8 +373,8 @@ def RoundRobinControlMod(num_inputs: int):
       grant_if_not_reend = Mux(pick, grant, winner_idle)
       busy_if_not_reend = Mux(pick, busy, Bits(1)(1))
 
-      ports.next_grant = Mux(reend, grant_if_not_reend, winner_next)
-      ports.next_busy = Mux(reend, busy_if_not_reend, any_next)
+      next_grant.assign(Mux(reend, grant_if_not_reend, winner_next))
+      next_busy.assign(Mux(reend, busy_if_not_reend, any_next))
       rr_ptr.assign(Mux(reend, rr_ptr, grant_p1))
       ports.switch = pick | (reend & any_next)
 
@@ -440,24 +474,17 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
           return inner.wrap(bits.bitcast(inner.lowered_type))
         return bits.bitcast(inner)
 
-      # ---- Registered arbiter state (Reg: read now, next-state assigned
-      # below). ----
-      grant = Reg(Bits(gw), clk, rst, name="grant")
-      busy = Reg(Bits(1), clk, rst, name="busy")
+      # ---- Arbiter state. `grant`/`grant_oh`/`busy` are owned and registered
+      # by the grant-control module instantiated below; these wires forward-
+      # declare them because the input stage reads them first. ----
+      grant = Wire(Bits(gw), "grant")
+      grant_oh = Wire(Bits(num_inputs), "grant_oh")
+      busy = Wire(Bits(1), "busy")
       credit = Reg(UInt(cw), clk, rst, rst_value=depth, name="credit")
 
       credit_gt0 = credit > UInt(cw)(0)
 
       # ---- Inputs: optional skid buffer, then unwrap with a local ready. ----
-      # Per-input one-hot grant, registered below (one register each) so these
-      # potentially high-fanout signals are not a shared combinational decode.
-      grant_is = [
-          Reg(Bits(1),
-              clk,
-              rst,
-              rst_value=(1 if i == 0 else 0),
-              name=f"grant_oh_{i}") for i in range(num_inputs)
-      ]
       valids: List[BitsSignal] = []
       last_bits: List[BitsSignal] = []
       data_bits: List[BitsSignal] = []
@@ -467,7 +494,7 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
           chan = chan.buffer(clk, rst, stages=1)
         # ready[i]: consume only the granted input, and only when a credit is
         # available. Independent of valid, so no combinational ready loop.
-        ready_i = busy & grant_is[i] & credit_gt0
+        ready_i = busy & grant_oh[i] & credit_gt0
         data_i, valid_i = chan.unwrap(ready_i)
         valids.append(valid_i)
         last_bits.append(flit_last(data_i))
@@ -529,23 +556,13 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
       ctrl = ctrl_mod(clk=clk,
                       rst=rst,
                       valids=BitsSignal.concat(list(reversed(valids))),
-                      grant=grant,
-                      grant_oh=BitsSignal.concat(list(reversed(grant_is))),
-                      busy=busy,
                       launch=launch,
                       msg_end=msg_end,
                       instance_name="arb_ctrl")
-      next_grant = ctrl.next_grant
+      grant.assign(ctrl.grant)
+      grant_oh.assign(ctrl.grant_oh)
+      busy.assign(ctrl.busy)
       arb_switch = ctrl.switch
-      grant.assign(next_grant)
-      busy.assign(ctrl.next_busy)
-
-      # Register the one-hot grant decode -- one register per input -- so each
-      # (potentially high-fanout) per-input grant signal is driven by its own
-      # register instead of a shared combinational decode of `grant`. Fed from
-      # the same next-state, so it stays coherent with `grant` (== grant == i).
-      for i in range(num_inputs):
-        grant_is[i].assign(next_grant == Bits(gw)(i))
 
       # ---- Telemetry. ----
       if telemetry:
@@ -556,7 +573,7 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
           served = Counter(64)(clk=clk,
                                rst=rst,
                                clear=Bits(1)(0),
-                               increment=launch & grant_is[i])
+                               increment=launch & grant_oh[i])
           Telemetry.report_signal(clk, rst, AppID(f"grantCount_{i}"),
                                   served.out)
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/components/channel_arbiter.py
@@ -18,7 +18,7 @@ from pycde.constructs import Counter, Mux, Reg, Wire
 from pycde.esi import Telemetry
 from pycde.module import modparams
 from pycde.seq import FIFO as SeqFIFO
-from pycde.signals import BitsSignal, ChannelSignal, ClockSignal, Signal
+from pycde.signals import (BitsSignal, ChannelSignal, ClockSignal, Or, Signal)
 from pycde.support import clog2
 from pycde.types import (Array, Bits, Channel, ChannelSignaling, StructType,
                          UInt, Window)
@@ -79,6 +79,135 @@ def _select_mux(sel: BitsSignal, values: List[BitsSignal], clk: ClockSignal,
       cur = [c.reg(clk, rst) for c in cur]
       rem = rem.reg(clk, rst)
   return cur[0]
+
+
+def _onehot_to_index(onehot: BitsSignal, num_inputs: int,
+                     gw: int) -> BitsSignal:
+  """Encode a one-hot bit-vector to its binary index. Bit `b` of the result is
+  the OR of the one-hot bits whose index has bit `b` set."""
+  bits = []
+  for b in range(gw):
+    terms = [onehot[i] for i in range(num_inputs) if (i >> b) & 1]
+    bits.append(Or(*terms) if terms else Bits(1)(0))
+  return BitsSignal.concat(list(reversed(bits)))
+
+
+def _build_scheduler(
+    clk: ClockSignal, rst: Signal, num_inputs: int, gw: int,
+    valids: List[BitsSignal], grant: BitsSignal, busy: BitsSignal,
+    launch: BitsSignal, msg_end: BitsSignal,
+    queue_depth: int) -> Tuple[BitsSignal, BitsSignal, BitsSignal]:
+  """Decoupled, pipelinable grant scheduler. Returns `(next_grant, next_busy,
+  switch)`, where `switch` is high on cycles the grant is (re)loaded from the
+  queue -- the scheduler-mode analogue of the flat arbiter's re-arbitration,
+  used for telemetry.
+
+  The flat arbiter must answer "who is granted next?" combinationally in the
+  cycle the current message ends, which puts the whole round-robin tree inside a
+  single-cycle `grant -> grant` loop -- the dominant timing limiter at high
+  fan-in. Here the two are decoupled: a **grant queue** holds upcoming winners,
+  the datapath just pops it, and a **sweep scheduler** refills it off the
+  critical path.
+
+  Committing a decision ahead of use is safe not because the decision stays
+  accurate, but because both ways it can go stale are benign. ESI's ValidReady
+  makes no stability guarantee: an input may change its payload or drop `valid`
+  after being scheduled.
+
+  * Payload changed -- forward it. The arbiter selects *which* input is served,
+    not which message; whatever that input is offering when granted is a
+    message it wants sent.
+  * `valid` dropped -- costs at most a bubble, never correctness. The grant is
+    abandoned in one cycle by `stale` below, or, if the queue has since
+    emptied, the FSM parks on it until that input has something (see the
+    ordering note below).
+
+  So a queued decision is a hint about who to serve next, not a promise that a
+  particular message is waiting.
+
+  Scheduling policy (a "sweep"): snapshot the valid mask into `pending`, then
+  emit its set bits one per cycle, lowest index first, reloading the snapshot on
+  the same cycle the last bit is queued. Every input valid at snapshot time is
+  therefore *scheduled* exactly once per sweep. The only logic left in a
+  single-cycle loop is `pending -> lowest-set-bit -> sweep-exhausted -> pending`:
+  one `x & -x` (a carry chain), a mask, and a wide NOR. Mapped to 6-LUTs that is
+  5 levels at N=32, against 7 for the flat arbiter's `grant -> grant` loop, so
+  it is still the shallower of the two.
+
+  Note that this is a property of the sweep, not an end-to-end ordering
+  guarantee: the datapath can serve an input without consulting the queue. If a
+  grant is popped for an input that turns out to have nothing and the queue
+  then empties, `stale` (gated on `q_nonempty`) cannot fire and the FSM parks
+  on that grant with its `ready` still asserted, so the next message from that
+  input is served immediately, ahead of the queue. This is bounded -- `busy`
+  drops at that `msg_end` and any newly-valid input recovers via `stale` as
+  soon as the sweep pushes an entry -- but it does make the service order
+  best-effort rather than exact. Do not rely on it where ordering fairness is
+  load-bearing.
+
+  A backlogged input is re-snapshotted every sweep, so it keeps its grants
+  flowing back to back and a lone active input still runs at full rate.
+
+  Latency for a newly-valid input is *not* bounded by `queue_depth` alone. An
+  input which goes valid just after a snapshot waits for the rest of the
+  current sweep to be enqueued, then for any already-queued grants and for the
+  lower-index entries of the next sweep -- so the wait scales with the number
+  of concurrently active inputs as well, and with `num_inputs > queue_depth` it
+  can exceed `queue_depth` messages. `queue_depth` bounds only the number of
+  decisions committed ahead of the datapath, i.e. how stale the queue's view
+  can be; it is not a fairness knob.
+
+  An entry whose input has since gone idle (over-scheduled, or drained by
+  another route) is skipped in a single cycle rather than stalling the output:
+  see `stale` below. `started` distinguishes "this grant has not delivered a
+  flit yet" (safe to abandon) from "mid-message" (must not be abandoned, or the
+  message would be split)."""
+
+  # Grant queue. `rd_latency=0` makes it show-ahead, so `q_head` is a
+  # registered value available the same cycle -- popping introduces no bubble.
+  gq = SeqFIFO(Bits(gw), queue_depth, clk, rst)
+  q_pop = Wire(Bits(1), "gq_pop")
+  q_head = gq.pop(q_pop)
+  q_nonempty = ~gq.empty
+
+  # ---- Sweep scheduler (off the datapath's critical path). ----
+  pending = Reg(Bits(num_inputs), clk, rst, rst_value=0, name="sched_pending")
+  valids_vec = BitsSignal.concat(list(reversed(valids)))
+  pend_nonzero = pending != Bits(num_inputs)(0)
+  # Isolate the lowest set bit: x & (-x), with -x == ~x + 1.
+  neg_pending = ((~pending).as_uint(num_inputs) +
+                 UInt(num_inputs)(1)).as_bits(num_inputs)
+  low = pending & neg_pending
+  push = pend_nonzero & ~gq.full
+  gq.push(_onehot_to_index(low, num_inputs, gw), push)
+  # Clear the bit just scheduled (or hold if the queue is full), and reload the
+  # snapshot as soon as the sweep is exhausted. The reload has to happen on the
+  # *same* cycle the last bit is pushed: deferring it to the cycle after
+  # `pending` reads zero costs one idle cycle per sweep, capping throughput at
+  # `n/(n+1)` for `n` concurrently-active inputs. That only bites for
+  # single-flit messages; with multi-flit lists the datapath is still streaming
+  # the current message while the sweep refills, so the bubble is hidden.
+  cleared = pending & ~low
+  sweep_done = push & (cleared == Bits(num_inputs)(0))
+  pending.assign(
+      Mux(~pend_nonzero | sweep_done, Mux(push, pending, cleared), valids_vec))
+
+  # ---- Datapath grant FSM. ----
+  started = Reg(Bits(1), clk, rst, rst_value=0, name="grant_started")
+  sel_valid_now = Or(
+      *[valids[i] & (grant == Bits(gw)(i)) for i in range(num_inputs)])
+  # Abandon a grant that has not yet delivered a flit and whose input is not
+  # offering one, but only when there is someone else to serve.
+  stale = busy & ~started & ~sel_valid_now & q_nonempty
+  advance = msg_end | stale
+  take_next = ~busy | advance
+  q_pop.assign(take_next & q_nonempty)
+
+  next_grant = Mux(take_next & q_nonempty, grant, q_head)
+  next_busy = Mux(take_next, busy, q_nonempty)
+  started.assign(Mux(take_next, Mux(launch, started, Bits(1)(1)), Bits(1)(0)))
+  # The grant is replaced by a queued decision exactly when it is popped.
+  return next_grant, next_busy, q_pop
 
 
 @modparams
@@ -146,7 +275,8 @@ def RoundRobinArbiterMod(num_inputs: int):
 @modparams
 def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
                       output_fifo_depth: int, buffer_inputs: bool,
-                      telemetry: bool, mux_pipeline_levels: Optional[int]):
+                      telemetry: bool, mux_pipeline_levels: Optional[int],
+                      pipelined_scheduler: bool, grant_queue_depth: int):
   """Build a pipelined, list-aware N:1 channel multiplexer module. See the
   `ChannelArbiter` convenience function for the user-facing entry point and
   `docs/components/ChannelArbiter.md` for the design."""
@@ -239,7 +369,8 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
       # below). ----
       grant = Reg(Bits(gw), clk, rst, name="grant")
       busy = Reg(Bits(1), clk, rst, name="busy")
-      rr_ptr = Reg(Bits(gw), clk, rst, name="rr_ptr")
+      if not pipelined_scheduler:
+        rr_ptr = Reg(Bits(gw), clk, rst, name="rr_ptr")
       credit = Reg(UInt(cw), clk, rst, rst_value=depth, name="credit")
 
       credit_gt0 = credit > UInt(cw)(0)
@@ -317,43 +448,52 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
                      launch.as_uint(cw)).as_uint(cw)
       credit.assign(next_credit)
 
-      # ---- Round-robin arbitration (own module for waveform visibility). ----
-      rr_arbiter = RoundRobinArbiterMod(num_inputs)
+      # ---- Arbitration. ----
+      if pipelined_scheduler:
+        next_grant, next_busy, arb_switch = _build_scheduler(
+            clk, rst, num_inputs, gw, valids, grant, busy, launch, msg_end,
+            grant_queue_depth)
+        grant.assign(next_grant)
+        busy.assign(next_busy)
+      else:
+        # ---- Round-robin arbitration (own module for waveform visibility). --
+        rr_arbiter = RoundRobinArbiterMod(num_inputs)
 
-      def round_robin(valid_list: List[BitsSignal], start: BitsSignal,
-                      name: str) -> Tuple[BitsSignal, BitsSignal]:
-        """Instantiate a RoundRobinArbiter over `valid_list` (packed into a
-        bit-bus, bit `i` == input `i`) starting from `start`."""
-        valids_vec = BitsSignal.concat(list(reversed(valid_list)))
-        inst = rr_arbiter(valids=valids_vec, start=start, instance_name=name)
-        return inst.winner, inst.any_valid
+        def round_robin(valid_list: List[BitsSignal], start: BitsSignal,
+                        name: str) -> Tuple[BitsSignal, BitsSignal]:
+          """Instantiate a RoundRobinArbiter over `valid_list` (packed into a
+          bit-bus, bit `i` == input `i`) starting from `start`."""
+          valids_vec = BitsSignal.concat(list(reversed(valid_list)))
+          inst = rr_arbiter(valids=valids_vec, start=start, instance_name=name)
+          return inst.winner, inst.any_valid
 
-      grant_u = grant.as_uint(gw)
-      is_last_idx = grant == Bits(gw)(num_inputs - 1)
-      grant_p1 = Mux(is_last_idx, (grant_u + UInt(gw)(1)).as_bits(gw),
-                     Bits(gw)(0))
+        grant_u = grant.as_uint(gw)
+        is_last_idx = grant == Bits(gw)(num_inputs - 1)
+        grant_p1 = Mux(is_last_idx, (grant_u + UInt(gw)(1)).as_bits(gw),
+                       Bits(gw)(0))
 
-      winner_idle, any_idle = round_robin(valids, rr_ptr, "rr_idle")
-      # At a message end the just-consumed input still asserts `valid` this
-      # cycle (the flit is consumed on the clock edge), so mask it out of the
-      # re-arbitration. Otherwise the round-robin wrap-around would
-      # speculatively re-grant that stale valid and the FSM would get stuck
-      # `busy` on an input that goes empty next cycle. A genuinely backlogged
-      # input is re-selected on the following idle cycle instead.
-      valids_next = [valids[i] & ~grant_is[i] for i in range(num_inputs)]
-      winner_next, any_next = round_robin(valids_next, grant_p1, "rr_next")
+        winner_idle, any_idle = round_robin(valids, rr_ptr, "rr_idle")
+        # At a message end the just-consumed input still asserts `valid` this
+        # cycle (the flit is consumed on the clock edge), so mask it out of the
+        # re-arbitration. Otherwise the round-robin wrap-around would
+        # speculatively re-grant that stale valid and the FSM would get stuck
+        # `busy` on an input that goes empty next cycle. A genuinely backlogged
+        # input is re-selected on the following idle cycle instead.
+        valids_next = [valids[i] & ~grant_is[i] for i in range(num_inputs)]
+        winner_next, any_next = round_robin(valids_next, grant_p1, "rr_next")
 
-      pick = ~busy & any_idle
-      reend = busy & msg_end
-      grant_if_not_reend = Mux(pick, grant, winner_idle)
-      next_grant = Mux(reend, grant_if_not_reend, winner_next)
-      busy_if_not_reend = Mux(pick, busy, Bits(1)(1))
-      next_busy = Mux(reend, busy_if_not_reend, any_next)
-      next_rr = Mux(reend, rr_ptr, grant_p1)
+        pick = ~busy & any_idle
+        reend = busy & msg_end
+        grant_if_not_reend = Mux(pick, grant, winner_idle)
+        next_grant = Mux(reend, grant_if_not_reend, winner_next)
+        busy_if_not_reend = Mux(pick, busy, Bits(1)(1))
+        next_busy = Mux(reend, busy_if_not_reend, any_next)
+        next_rr = Mux(reend, rr_ptr, grant_p1)
 
-      grant.assign(next_grant)
-      busy.assign(next_busy)
-      rr_ptr.assign(next_rr)
+        grant.assign(next_grant)
+        busy.assign(next_busy)
+        rr_ptr.assign(next_rr)
+        arb_switch = pick | (reend & any_next)
 
       # Register the one-hot grant decode -- one register per input -- so each
       # (potentially high-fanout) per-input grant signal is driven by its own
@@ -389,7 +529,7 @@ def ChannelArbiterMod(channel_type: Channel, num_inputs: int,
         arb_switches = Counter(64)(clk=clk,
                                    rst=rst,
                                    clear=Bits(1)(0),
-                                   increment=pick | (reend & any_next))
+                                   increment=arb_switch)
         Telemetry.report_signal(clk, rst, AppID("arbSwitches"),
                                 arb_switches.out)
 
@@ -420,6 +560,8 @@ def ChannelArbiter(input_channels: List[ChannelSignal],
                    output_fifo_depth: Optional[int] = None,
                    buffer_inputs: bool = True,
                    mux_pipeline_levels: Optional[int] = None,
+                   pipelined_scheduler: bool = False,
+                   grant_queue_depth: int = 4,
                    telemetry: bool = True) -> ChannelSignal:
   """Build a pipelined, list-aware N:1 channel multiplexer.
 
@@ -446,6 +588,17 @@ def ChannelArbiter(input_channels: List[ChannelSignal],
       levels (1 = register every level). This retimes the wide selection mux
       for very large fan-in; the added latency is absorbed by the output FIFO /
       credit counter. `None` (default) uses a flat combinational mux.
+    pipelined_scheduler: decouple grant selection from the datapath using a
+      grant queue fed by a sweep scheduler, instead of re-arbitrating
+      combinationally at each message end. This takes the round-robin tree out
+      of the single-cycle `grant -> grant` loop, which is the Fmax limiter at
+      high fan-in. Changes the service order (see `_build_scheduler`).
+    grant_queue_depth: depth of that grant queue -- how many grant decisions
+      may be committed ahead of the datapath. Must be >= 2: a single entry
+      cannot keep the datapath fed back to back, so every message would cost a
+      refill bubble. This is not a fairness knob; a newly-valid input's wait
+      also scales with the number of concurrently active inputs (see
+      `_build_scheduler`).
     telemetry: emit telemetry (selected channel, list-length stats, etc.).
 
   See `docs/components/ChannelArbiter.md`."""
@@ -468,8 +621,18 @@ def ChannelArbiter(input_channels: List[ChannelSignal],
     raise ValueError(
         f"mux_pipeline_levels must be >= 1, got {mux_pipeline_levels}")
 
+  # Validated here rather than left to the FIFO: a bad depth otherwise surfaces
+  # as a `seq.fifo` verifier error from deep inside the lowering, with no
+  # mention of the knob that caused it. Depth 1 is rejected too -- `push` is
+  # blocked whenever the queue is non-empty, so a single entry can never keep
+  # the datapath fed back to back and every message would cost a refill
+  # bubble, silently undoing the Fmax win the option exists for.
+  if pipelined_scheduler and grant_queue_depth < 2:
+    raise ValueError(f"grant_queue_depth must be >= 2, got {grant_queue_depth}")
+
   mod = ChannelArbiterMod(channel_type, num_inputs, output_fifo_depth,
-                          buffer_inputs, telemetry, mux_pipeline_levels)
+                          buffer_inputs, telemetry, mux_pipeline_levels,
+                          pipelined_scheduler, grant_queue_depth)
   inputs_array = Array(channel_type, num_inputs)(input_channels)
   inst = mod(clk=clk, rst=rst, inputs=inputs_array, appid=appid)
   return inst.output

--- a/lib/Dialect/ESI/runtime/tests/integration/hw/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/hw/channel_arbiter.py
@@ -40,15 +40,16 @@ NUM_INPUTS = 4  # power-of-two ("balanced") input count.
 ODD_NUM_INPUTS = 3  # non-power-of-two ("unbalanced") input count.
 PIPE_NUM_INPUTS = 6  # input count for the pipelined-mux-tree variant.
 TOKEN_NUM_INPUTS = 5  # input count for the zero-width (i0) token variant.
+# Sustained-throughput probe: enough inputs that a per-sweep scheduler bubble
+# would be clearly visible (it would cap throughput at n/(n+1) == 0.8) while
+# keeping simulation time short.
+THROUGHPUT_NUM_INPUTS = 4
+THROUGHPUT_WINDOW = 1000  # measurement window, in cycles.
 TOKENS_PER_INPUT = 8  # tokens each producer emits in the token test.
 # A fan-in wide enough to exercise large-N arbitration. The BSP instantiates
 # arbiters with ~31 inputs (one per host-memory write client), a regime none of
 # the small counts above reach.
 WIDE_NUM_INPUTS = 13
-# Sustained-throughput probe: enough inputs to make a per-message turnaround
-# cycle clearly visible, while keeping simulation time short.
-THROUGHPUT_NUM_INPUTS = 4
-THROUGHPUT_WINDOW = 1000  # measurement window, in cycles.
 
 # A list-window payload: a struct with a `src` tag and a variable-length list.
 # `Window.default_of` adds a per-flit `last` field to the lowered frame struct,
@@ -58,10 +59,13 @@ Flit = Window.default_of(ListInto)
 FlitLowered = Flit.lowered_type  # struct<src: ui8, items: ui16, last: i1>
 
 
-def HostMux(num_inputs: int, mux_pipeline_levels=None):
+def HostMux(num_inputs: int,
+            mux_pipeline_levels=None,
+            pipelined_scheduler=False):
   """A host-driven single-flit multiplexer: `num_inputs` `from_host` UInt(32)
   channels muxed into a single `to_host` channel. `mux_pipeline_levels` pipelines
-  the selection mux tree."""
+  the selection mux tree; `pipelined_scheduler` selects the decoupled
+  grant-queue arbitration."""
 
   class HostMux(Module):
     clk = Clock()
@@ -77,10 +81,12 @@ def HostMux(num_inputs: int, mux_pipeline_levels=None):
                            ports.clk,
                            ports.rst,
                            mux_pipeline_levels=mux_pipeline_levels,
+                           pipelined_scheduler=pipelined_scheduler,
                            telemetry=False)
       esi.ChannelService.to_host(AppID("out"), out)
 
-  HostMux.__name__ = f"HostMux_{num_inputs}_{mux_pipeline_levels}"
+  HostMux.__name__ = (
+      f"HostMux_{num_inputs}_{mux_pipeline_levels}_{pipelined_scheduler}")
   return HostMux
 
 
@@ -178,22 +184,37 @@ class ListChecker(Module):
     in_ready.assign(Mux(is_completing, Bits(1)(1), report_ready))
 
 
-class ChannelArbiterListTest(Module):
-  """Two contending list producers -> arbiter -> contiguity checker."""
+def ChannelArbiterListTestMod(pipelined_scheduler: bool):
+  """Contending list producers -> arbiter -> contiguity checker. Message
+  atomicity is the property most at risk from any arbitration change, so it is
+  covered for both arbitration modes."""
 
-  clk = Clock()
-  rst = Reset()
+  class ChannelArbiterListTest(Module):
+    clk = Clock()
+    rst = Reset()
 
-  @generator
-  def build(ports):
-    p0 = ListProducer(1, 3)(clk=ports.clk, rst=ports.rst)
-    p1 = ListProducer(2, 4)(clk=ports.clk, rst=ports.rst)
-    muxed = ChannelArbiter([p0.out, p1.out],
-                           ports.clk,
-                           ports.rst,
-                           telemetry=False)
-    chk = ListChecker(clk=ports.clk, rst=ports.rst, in_=muxed)
-    esi.ChannelService.to_host(AppID("report"), chk.report)
+    @generator
+    def build(ports):
+      # More producers than the grant-queue depth, so the scheduled variant
+      # exercises a queue that actually fills.
+      prods = [
+          ListProducer(src, 3 + (src % 3))(clk=ports.clk, rst=ports.rst)
+          for src in range(1, 7)
+      ] if pipelined_scheduler else [
+          ListProducer(1, 3)(clk=ports.clk, rst=ports.rst),
+          ListProducer(2, 4)(clk=ports.clk, rst=ports.rst),
+      ]
+      muxed = ChannelArbiter([p.out for p in prods],
+                             ports.clk,
+                             ports.rst,
+                             pipelined_scheduler=pipelined_scheduler,
+                             telemetry=False)
+      chk = ListChecker(clk=ports.clk, rst=ports.rst, in_=muxed)
+      esi.ChannelService.to_host(AppID("report"), chk.report)
+
+  ChannelArbiterListTest.__name__ = (
+      f"ChannelArbiterListTest_{pipelined_scheduler}")
+  return ChannelArbiterListTest
 
 
 def TokenProducer(count: int):
@@ -323,26 +344,33 @@ class ThroughputProbe(Module):
     ports.report = chan
 
 
-class ChannelArbiterThroughputTest(Module):
+def ChannelArbiterThroughputTestMod(pipelined_scheduler: bool):
   """`THROUGHPUT_NUM_INPUTS` never-idle producers -> arbiter -> throughput
-  probe. Pins the arbiter's sustained delivery rate, which correctness tests
-  cannot observe."""
+  probe. Pins the arbiter's sustained delivery rate: a scheduler which needs a
+  refill/turnaround cycle between grants shows up here as a throughput well
+  below one beat per cycle, while correctness tests stay green."""
 
-  clk = Clock()
-  rst = Reset()
+  class ChannelArbiterThroughputTest(Module):
+    clk = Clock()
+    rst = Reset()
 
-  @generator
-  def build(ports):
-    prods = [
-        AlwaysValidProducer(i)(clk=ports.clk, rst=ports.rst)
-        for i in range(THROUGHPUT_NUM_INPUTS)
-    ]
-    muxed = ChannelArbiter([p.out for p in prods],
-                           ports.clk,
-                           ports.rst,
-                           telemetry=False)
-    probe = ThroughputProbe(clk=ports.clk, rst=ports.rst, in_=muxed)
-    esi.ChannelService.to_host(AppID("throughput_report"), probe.report)
+    @generator
+    def build(ports):
+      prods = [
+          AlwaysValidProducer(i)(clk=ports.clk, rst=ports.rst)
+          for i in range(THROUGHPUT_NUM_INPUTS)
+      ]
+      muxed = ChannelArbiter([p.out for p in prods],
+                             ports.clk,
+                             ports.rst,
+                             pipelined_scheduler=pipelined_scheduler,
+                             telemetry=False)
+      probe = ThroughputProbe(clk=ports.clk, rst=ports.rst, in_=muxed)
+      esi.ChannelService.to_host(AppID("throughput_report"), probe.report)
+
+  ChannelArbiterThroughputTest.__name__ = (
+      f"ChannelArbiterThroughputTest_{pipelined_scheduler}")
+  return ChannelArbiterThroughputTest
 
 
 class Top(Module):
@@ -361,18 +389,32 @@ class Top(Module):
             mux_pipeline_levels=1)(clk=ports.clk,
                                    rst=ports.rst,
                                    appid=AppID("arbiter_test_pipe"))
-    ChannelArbiterListTest(clk=ports.clk,
-                           rst=ports.rst,
-                           appid=AppID("list_test"))
     HostMux(WIDE_NUM_INPUTS)(clk=ports.clk,
                              rst=ports.rst,
                              appid=AppID("arbiter_test_wide"))
+    HostMux(WIDE_NUM_INPUTS,
+            pipelined_scheduler=True)(clk=ports.clk,
+                                      rst=ports.rst,
+                                      appid=AppID("arbiter_test_sched"))
+    HostMux(ODD_NUM_INPUTS,
+            pipelined_scheduler=True)(clk=ports.clk,
+                                      rst=ports.rst,
+                                      appid=AppID("arbiter_test_sched_odd"))
+    ChannelArbiterListTestMod(False)(clk=ports.clk,
+                                     rst=ports.rst,
+                                     appid=AppID("list_test"))
+    ChannelArbiterListTestMod(True)(clk=ports.clk,
+                                    rst=ports.rst,
+                                    appid=AppID("list_test_sched"))
     ChannelArbiterTokenTest(clk=ports.clk,
                             rst=ports.rst,
                             appid=AppID("token_test"))
-    ChannelArbiterThroughputTest(clk=ports.clk,
-                                 rst=ports.rst,
-                                 appid=AppID("throughput_test"))
+    ChannelArbiterThroughputTestMod(False)(clk=ports.clk,
+                                           rst=ports.rst,
+                                           appid=AppID("throughput_test"))
+    ChannelArbiterThroughputTestMod(True)(clk=ports.clk,
+                                          rst=ports.rst,
+                                          appid=AppID("throughput_test_sched"))
 
 
 if __name__ == "__main__":

--- a/lib/Dialect/ESI/runtime/tests/integration/test_channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_channel_arbiter.py
@@ -36,9 +36,9 @@ HW_DIR = Path(__file__).resolve().parent / "hw"
 NUM_INPUTS = 4  # power-of-two ("balanced") input count.
 ODD_NUM_INPUTS = 3  # non-power-of-two ("unbalanced") input count.
 PIPE_NUM_INPUTS = 6  # input count for the pipelined-mux-tree variant.
+WIDE_NUM_INPUTS = 13  # wide fan-in; must match hw/channel_arbiter.py.
 TOKEN_NUM_INPUTS = 5  # input count for the zero-width (i0) token variant.
 TOKENS_PER_INPUT = 8  # tokens each producer emits in the token test.
-WIDE_NUM_INPUTS = 13  # must match hw/channel_arbiter.py.
 THROUGHPUT_NUM_INPUTS = 4  # must match hw/channel_arbiter.py.
 THROUGHPUT_WINDOW = 1000  # measurement window in cycles; must match hw.
 
@@ -108,15 +108,45 @@ class TestChannelArbiterCosim:
     once."""
     _check_mux(conn, "arbiter_test_pipe", PIPE_NUM_INPUTS)
 
+  def test_mux_correctness_wide(self, conn: AcceleratorConnection) -> None:
+    """Wide fan-in: the BSP instantiates arbiters with ~31 inputs, a regime the
+    small counts above never reach. Every value must still be delivered exactly
+    once and every input served."""
+    _check_mux(conn, "arbiter_test_wide", WIDE_NUM_INPUTS)
+
+  def test_mux_correctness_scheduled(self, conn: AcceleratorConnection) -> None:
+    """Decoupled grant-queue scheduler at wide fan-in: grants are chosen ahead
+    of time and buffered, so this exercises the queue, the sweep reload and the
+    stale-entry skip. Delivery must still be exactly-once and every input
+    served."""
+    _check_mux(conn, "arbiter_test_sched", WIDE_NUM_INPUTS)
+
+  def test_mux_correctness_scheduled_unbalanced(
+      self, conn: AcceleratorConnection) -> None:
+    """The scheduler with a non-power-of-two input count: the one-hot->index
+    encode and the sweep must not produce an out-of-range grant."""
+    _check_mux(conn, "arbiter_test_sched_odd", ODD_NUM_INPUTS)
+
   def test_list_contiguity(self, conn: AcceleratorConnection) -> None:
     """Contending multi-flit list messages are never interleaved."""
+    self._check_contiguity(conn, "list_test", {1, 2})
+
+  def test_list_contiguity_scheduled(self, conn: AcceleratorConnection) -> None:
+    """Message atomicity under the decoupled grant-queue scheduler, with more
+    contending producers than the grant queue is deep."""
+    self._check_contiguity(conn, "list_test_sched", set(range(1, 7)))
+
+  @staticmethod
+  def _check_contiguity(conn: AcceleratorConnection, dut_name: str,
+                        expected_src: set[int]) -> None:
     acc = conn.build_accelerator()
-    dut = acc.children[esiaccel.AppID("list_test")]
+    dut = acc.children[esiaccel.AppID(dut_name)]
     report = dut.ports[esiaccel.AppID("report")]
     report.connect()
 
     seen_src: set[int] = set()
-    num_reports = 40
+    # Enough reports to see every producer served several times over.
+    num_reports = 20 * len(expected_src)
     for _ in range(num_reports):
       value = report.read().result()
       err = (value >> 24) & 0x1
@@ -125,9 +155,9 @@ class TestChannelArbiterCosim:
           f"hardware detected interleaved list flits (report {value:#010x})"
       seen_src.add(src)
 
-    # Both contending producers (src 1 and src 2) must get through.
-    assert seen_src == {1, 2}, \
-        f"expected both sources to be served, saw {sorted(seen_src)}"
+    # Every contending producer must get through -- i.e. no starvation.
+    assert seen_src == expected_src, \
+        f"expected sources {sorted(expected_src)}, saw {sorted(seen_src)}"
 
   def test_token_conservation(self, conn: AcceleratorConnection) -> None:
     """Zero-width (`i0`) token payloads: the credit-counter-as-buffer path
@@ -144,24 +174,35 @@ class TestChannelArbiterCosim:
       assert value == expected, \
           f"token {expected} arrived as {value} (loss / duplication / reorder)"
 
-  def test_mux_correctness_wide(self, conn: AcceleratorConnection) -> None:
-    """Wide fan-in: the small counts above are far below what the BSP
-    instantiates, and the selection mux depth grows with the input count."""
-    _check_mux(conn, "arbiter_test_wide", WIDE_NUM_INPUTS)
+  def test_throughput_flat(self, conn: AcceleratorConnection) -> None:
+    """The flat round-robin arbiter sustains ~one beat per cycle."""
+    self._check_throughput(conn, "throughput_test")
 
-  def test_throughput(self, conn: AcceleratorConnection) -> None:
-    """The arbiter sustains ~one beat per cycle with every input backlogged.
+  def test_throughput_scheduled(self, conn: AcceleratorConnection) -> None:
+    """The decoupled grant-queue scheduler must sustain ~one beat per cycle
+    too. Regression test: reloading the sweep snapshot a cycle after it drains
+    (rather than on the cycle the last entry is queued) costs one idle cycle
+    per sweep, which caps throughput at `n/(n+1)` -- 0.8 here. Correctness
+    tests do not notice that, only this one does.
 
-    Correctness tests cannot see this: they are rate-limited by the cosim DPI,
-    so a per-message turnaround bubble would pass them unnoticed. The probe
-    drains the arbiter in hardware instead."""
+    The producers emit **single-flit** messages deliberately: with multi-flit
+    lists the datapath keeps streaming while the sweep refills, which hides the
+    bubble entirely (measured: no loss at list length >= 2)."""
+    self._check_throughput(conn, "throughput_test_sched")
+
+  @staticmethod
+  def _check_throughput(conn: AcceleratorConnection, dut_name: str) -> None:
     acc = conn.build_accelerator()
-    dut = acc.children[esiaccel.AppID("throughput_test")]
+    dut = acc.children[esiaccel.AppID(dut_name)]
     report = dut.ports[esiaccel.AppID("throughput_report")]
     report.connect()
 
     beats = report.read().result()
     throughput = beats / THROUGHPUT_WINDOW
-    # Allow for pipeline fill at the start of the window.
-    assert throughput >= 0.95, (f"{beats} beats in {THROUGHPUT_WINDOW} cycles "
-                                f"({throughput:.3f}/cycle); expected >= 0.95")
+    # Allow for pipeline fill at the start of the window; well above the 0.8
+    # a per-sweep bubble would produce with this input count.
+    assert throughput >= 0.95, (
+        f"{dut_name}: {beats} beats in {THROUGHPUT_WINDOW} cycles "
+        f"({throughput:.3f}/cycle); expected >= 0.95. A throughput of about "
+        f"{THROUGHPUT_NUM_INPUTS / (THROUGHPUT_NUM_INPUTS + 1):.3f} means the "
+        "scheduler is losing a cycle per sweep.")


### PR DESCRIPTION
(Note: description is AI generated and human reviewed.)

## What

Adds `pipelined_scheduler=True` to `ChannelArbiter`, which decouples grant
selection from the datapath:

- a **grant queue** holds upcoming winners; the datapath just pops it
- a **sweep scheduler** refills the queue off the critical path
- `grant_queue_depth` (default 4) sizes that queue

Off by default. Enabled at the two BSP hostmem call sites, which are the
wide-fan-in ones (20 and 31 clients in the configurations the BSP builds).

## Evidence

Measured as an isolated A/B on an internal build of esitester: two builds of
the same tree, differing only in whether those two call sites pass
`pipelined_scheduler=True`. Everything else in the timing series — including
the selection-mux pipelining from #11041 and the MMIO response merge from
#11043 — is present in both.

Against an aggressive clock target, where the design does not yet close.

Placement on this design is strongly seed-sensitive, so a single build per arm
cannot resolve an effect this size. Each arm is therefore a sweep over fitter
seeds — 7 without the scheduler, 10 with — re-running place/route/STA from the
same synthesis snapshot. Figures are means, with Welch *t* against the
between-seed spread:

| | without | with | change | |
|---|---|---|---|---|
| Logic (ALMs) | 153,613 | 152,695 | **−0.60%** | t = 16.5 |
| Fmax | 459.0 MHz | 469.4 MHz | **+2.3%** | t = 1.9 |
| Total negative slack | −155 ns | −176 ns | +13% | t = 0.4, n.s. |
| Registers | 353,146 | 353,485 | +0.10% | t = 0.2, n.s. |

Read that as: **area reliably goes down; Fmax probably improves by ~2%; the
slack and register figures are not measurable at this sample size.**

The area result is the solid one — it is nearly seed-independent (σ ≈ 110 ALMs
against a 918 ALM effect). Faster *and* smaller, because the round-robin tree
and its comparators cost more than the queue and sweep that replace them.

The Fmax result is real but modest, and the honest error bar is wide: per-seed
Fmax spans 442–471 MHz without and 439–490 MHz with, σ = 9 and 14 MHz. The 95%
interval on the difference is roughly [−1, +22] MHz, so ~2.3% is the best
estimate rather than a firm floor.

The mechanism is visible in the timing report. Without the scheduler, **every
one of the ten worst paths is inside `ChannelArbiterImpl`**, and they are
exactly the loop this change targets:

```
grant__reg1[3]        -> credit__reg1[3]
grant__reg1[4]        -> grant__reg1[0]
grant_oh_30__reg1     -> grant_oh_3__reg1
```

With the scheduler that drops to **two of the ten worst paths**, tied with
several unrelated modules at the same slack. The arbiter stops being the thing
holding the design back — though it has not left the critical path, and would
need attention again to go further.

### Why the number moved

Earlier revisions of this description reported **~0.5%**, then **+4.2%**. Both
were single-build measurements, and neither survived re-measurement.

The ~0.5% was taken mid-series, when other structures still dominated the
critical path — a shallower arbiter buys nothing while something else is worse.
The +4.2% was taken after #11041 and #11043 removed those, but compared one
build per arm; the seeds happened to fall favourably for the scheduler arm and
unfavourably for the baseline. Both arms' single-seed numbers turn out to be
near the top of their respective distributions. Sweeping seeds puts the figure
at ~+2.3%.

The TNS figure previously quoted here (−55%) came from the same pair of builds
and does not survive at all: across seeds, TNS is if anything slightly worse,
and its between-seed spread (σ ≈ 75–120 ns) dwarfs the difference.

Worth stating plainly because it cuts both ways: this number will shrink again
once the arbiter is no longer the limiter. It is a measurement of *this design
at this moment*, not a general claim about the component.

At the production clock target the full image closes timing with zero failing
endpoints both with and without this change, so that build cannot distinguish
them — the tool stops optimizing once the constraint is met. Its small area
increase (<1%) is placement noise at a met constraint, not a cost; the
timing-pressured build shows area going down.

## Why it works better

The flat arbiter has to answer &#34;who is granted next?&#34; combinationally in the
cycle the current message ends, which puts the entire round-robin tree inside a
single-cycle `grant -&gt; grant` loop. At high fan-in that loop is the dominant
Fmax limiter, and pipelining the datapath does not help, because the coupling
is in the arbitration.

Deciding ahead of time is safe not because the decision stays accurate, but
because both ways it can go stale are benign. ESI&#39;s ValidReady makes no
stability guarantee: an input may change its payload or drop `valid` between
being *scheduled* and being *granted*.

- **Payload changed** — forward it. The arbiter picks which input is served, not
  which message; whatever that input offers when granted is a message it wants
  sent.
- **`valid` dropped** — costs at most a bubble, never correctness. The grant is
  abandoned in one cycle by the `stale` path, or the FSM parks on it if the
  queue has since emptied.

So a queued entry is a hint about who to serve next, not a promise that a
particular message is waiting. That is the load-bearing property and worth
checking first.

(An earlier revision of this description justified it the other way round — by
asserting ValidReady keeps `valid` and the payload stable until transfer. It
does not, and the design does not need it to. The implementation was always
correct here; only the rationale was.)

The policy is a **sweep**: snapshot the valid mask into `pending`, emit its set
bits one per cycle lowest-index-first, reloading on the same cycle the last bit
is queued. The only logic left in a single-cycle loop is
`pending -&gt; lowest-set-bit -&gt; sweep-exhausted -&gt; pending`, i.e. one `x &amp; -x`
carry chain, a mask and a wide NOR — instead of a round-robin tree, a set of
`&gt;= start` comparators and a priority encoder.

Bubble behaviour was the crux of the design:

- A backlogged input is re-snapshotted every sweep, so it keeps its grants
  flowing back to back and a lone active input still runs at full rate.
- The queue is show-ahead (`rd_latency=0`), so popping introduces no bubble.
- An entry whose input has since gone idle is skipped in a single cycle rather
  than stalling the output (`stale`), with `started` distinguishing &#34;this grant
  has not delivered a flit yet&#34; (safe to abandon) from &#34;mid-message&#34; (must not
  be, or the message would be split).

## What it costs, and when not to use it

This changes the observable service order, which is why it is opt-in rather
than the default:

- Ordering is **best-effort, not exact**. The sweep schedules every valid input
  once per sweep, but the datapath can serve an input without consulting the
  queue: if a grant is popped for an input that turns out to have nothing and
  the queue then empties, `stale` (gated on queue-non-empty) cannot fire and
  the FSM parks on that grant with its `ready` still asserted, so that input&#39;s
  next message is served ahead of the queue. Bounded — one message per
  occurrence, and any newly-valid input recovers as soon as the sweep pushes an
  entry — but documented, because the docstring is the only specification of
  the new order.
- A newly-valid input&#39;s wait is **not** bounded by `grant_queue_depth`. It
  waits for the rest of the current sweep, then for queued grants and the
  lower-index entries of the next sweep, so the wait also scales with the
  number of concurrently active inputs and can exceed `grant_queue_depth`
  messages when `num_inputs &gt; grant_queue_depth`. `grant_queue_depth` bounds
  only how many decisions are committed ahead of the datapath; it is not a
  fairness knob.
- At **low fan-in it is a pessimization**: the round-robin tree it replaces is
  only a couple of LUT levels, so the queue, `pending` register, one-hot→index
  encoder and `x &amp; -x` chain are pure area, and the snapshot→push→pop sequence
  adds latency to the first grant on an idle arbiter. Latency-sensitive,
  low-occupancy paths should stay on the flat arbiter.

A reasonable follow-up would be to select the implementation automatically on
`num_inputs` and keep the flag as an override, rather than making every call
site decide.

`grant_queue_depth` also gains the validation the other parameters already had.
It rejects depths below 2 — with a single entry, `push` is blocked whenever the
queue is non-empty, so the sweep can never keep the datapath fed back to back
and every message costs a refill bubble, silently undoing the reason the option
exists. Previously a bad depth surfaced as a `seq.fifo` verifier error from
deep inside the FIFO lowering, with no mention of the knob that caused it.

`docs/components/ChannelArbiter.md` gains a `## 7.1` section covering this
control mode, so the documented contract matches the new option.

## Testing

`test_channel_arbiter.py` / `hw/channel_arbiter.py` gain scheduler coverage on
top of the flat-arbiter tests added in #11041:

- **scheduled at wide fan-in** — exercises the queue, the sweep reload and the
  stale-entry skip
- **scheduled at a non-power-of-two input count** — the one-hot→index encode and
  the sweep must not produce an out-of-range grant
- **list contiguity under the scheduler** — with more contending producers than
  the grant queue is deep, a client&#39;s words must still arrive contiguously
- **sustained throughput, both control modes** — never-idle producers feed the
  arbiter and a hardware probe drains it with `ready` tied high, counting beats
  over a fixed cycle window. This has to be measured in hardware: the
  host-driven tests are DPI-rate-limited and cannot observe sustained
  throughput at all, which is why the bubble described below survived every
  existing test.

All assert exactly-once delivery and that every input is served. Full ESI
runtime suite passes.

## Review fixes

Three real defects came out of review, all now fixed and covered:

1. **Scheduler lost a cycle per sweep** (throughput only — nothing is lost,
   duplicated, reordered or starved, which is why every correctness test stayed
   green). The snapshot was reloaded the cycle after `pending` read zero, so the
   scheduler idled one cycle every sweep, capping throughput at `n/(n+1)` for
   `n` active inputs.

   Measured on the generated RTL under Verilator, with producers permanently
   valid and the consumer permanently ready, so the arbiter is the only
   bottleneck (delivered beats ÷ cycles; 1.0 is the ceiling):

   | active inputs | flat | pipelined (before) | pipelined (after) |
   |---|---|---|---|
   | 1 | 0.500 | 0.499 | 0.999 |
   | 2 | 0.999 | 0.666 | 0.999 |
   | 4 | 0.999 | 0.799 | 0.999 |
   | 8 | 0.999 | 0.888 | 0.999 |

   `pending` is now reloaded on the same cycle the last bit is queued.

   Two things worth noting. First, this **only affects single-flit messages**:
   with multi-flit lists the datapath keeps streaming the current message while
   the sweep refills, so the bubble is completely hidden (measured: 0.999 at
   list length &gt;= 2, versus 0.799 at length 1, same 4 producers). Single-flit
   traffic is real here — the BSP&#39;s write path mixes windowed multi-word
   clients with single-word clients that emit one message per word.

   Second, the lone-source column: the flat arbiter also burns a turnaround
   cycle there (it masks the just-served input out of the re-arbitration), so
   after the fix the scheduler is *strictly better* than the flat path at every
   fan-in, not merely competitive. Fairness is unchanged (per-source counts
   within 1 of each other) and list contiguity still holds.

   **Timing cost: none at the arbiter level.** The sweep loop itself goes 3 → 5
   6-LUT levels at N=32, but it is not the critical path. Mapping the whole
   arbiter (N=32, ESI lowered to HW) gives max depth **6 before and 6 after**;
   the deepest path ends at the registered `grant_oh` decode, not the scheduler.
   The level histograms are near-identical too — the 32 endpoints that moved
   went from level 3 to level 5, into slack that already existed — so no new
   near-critical paths. Caveat: `circt-synth` does not model hard carry chains,
   so the `x &amp; -x` portion is pessimistic; this is logic depth, not STA. The
   end-to-end A/B above supersedes it.

2. **`pipelined_scheduler=True` crashed on the public defaults.** The telemetry
   block referenced `pick`/`reend`/`any_next`, which only exist in the flat
   branch, so elaboration raised `UnboundLocalError` unless the caller passed
   `telemetry=False`. Every call site happened to do exactly that, so nothing
   caught it. `_build_scheduler` now returns a mode-independent grant-advance
   signal.

3. **`grant_queue_depth` was documented as bounding newly-valid-input latency.**
   It does not; see the bullet above.

---

Assisted-by: GitHub Copilot CLI
