### PR TITLE
[LLHD][Mem2Reg] Finer-grained promotion slots

### DIFF
--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -257,7 +257,7 @@ struct LatticeNode;
 struct BlockExit;
 struct ProbeNode;
 struct DriveNode;
-struct SignalNode;
+struct SlotNode;
 
 /// Lattice state between two adjacent lattice nodes for a single slot.
 ///
@@ -283,7 +283,7 @@ struct LatticeValue {
 };
 
 struct LatticeNode {
-  enum class Kind { BlockEntry, BlockExit, Probe, Drive, Signal };
+  enum class Kind { BlockEntry, BlockExit, Probe, Drive, Slot };
   const Kind kind;
   /// Dirty flag to prevent duplicate pushes to worklist.
   bool dirty = false;
@@ -357,7 +357,7 @@ struct OpNode : public LatticeNode {
   }
 
   static bool classof(const LatticeNode *n) {
-    return isa<ProbeNode, DriveNode, SignalNode>(n);
+    return isa<ProbeNode, DriveNode, SlotNode>(n);
   }
 };
 
@@ -393,17 +393,17 @@ struct DriveNode : public OpNode {
   static bool classof(const LatticeNode *n) { return n->kind == Kind::Drive; }
 };
 
-struct SignalNode : public OpNode {
+struct SlotNode : public OpNode {
   Def *def;
 
-  SignalNode(SignalOp op, Def *def, LatticeValue *valueBefore,
-             LatticeValue *valueAfter)
-      : OpNode(Kind::Signal, op, valueBefore, valueAfter), def(def) {}
+  SlotNode(Operation *op, Def *def, LatticeValue *valueBefore,
+           LatticeValue *valueAfter)
+      : OpNode(Kind::Slot, op, valueBefore, valueAfter), def(def) {}
 
-  SignalOp getSignalOp() const { return cast<SignalOp>(op); }
-  DefSlot getSlot() const { return blockingSlot(getSignalOp()); }
+  bool hasInitValue() const { return isa<SignalOp>(op); }
+  DefSlot getSlot() const { return blockingSlot(op->getResult(0)); }
 
-  static bool classof(const LatticeNode *n) { return n->kind == Kind::Signal; }
+  static bool classof(const LatticeNode *n) { return n->kind == Kind::Slot; }
 };
 
 /// A lattice of block entry and exit nodes, nodes for relevant operations such
@@ -465,7 +465,7 @@ private:
   SpecificBumpPtrAllocator<BlockExit> blockExitAllocator;
   SpecificBumpPtrAllocator<ProbeNode> probeAllocator;
   SpecificBumpPtrAllocator<DriveNode> driveAllocator;
-  SpecificBumpPtrAllocator<SignalNode> signalAllocator;
+  SpecificBumpPtrAllocator<SlotNode> slotAllocator;
 
   // Helper function to get the correct allocator given a lattice node class.
   template <class T>
@@ -491,8 +491,8 @@ SpecificBumpPtrAllocator<DriveNode> &Lattice::getAllocator() {
   return driveAllocator;
 }
 template <>
-SpecificBumpPtrAllocator<SignalNode> &Lattice::getAllocator() {
-  return signalAllocator;
+SpecificBumpPtrAllocator<SlotNode> &Lattice::getAllocator() {
+  return slotAllocator;
 }
 
 } // namespace
@@ -574,8 +574,8 @@ void Lattice::dump(llvm::raw_ostream &os) {
         os << "    probe " << memName(blockingSlot(node->slot)) << "\n";
       else if (auto *node = dyn_cast<DriveNode>(value->nodeAfter))
         os << "    drive " << memName(node->slot) << "\n";
-      else if (auto *node = dyn_cast<SignalNode>(value->nodeAfter))
-        os << "    signal " << memName(node->getSlot()) << "\n";
+      else if (auto *node = dyn_cast<SlotNode>(value->nodeAfter))
+        os << "    slot " << memName(node->getSlot()) << "\n";
       else
         os << "    unknown\n";
 
@@ -1050,6 +1050,7 @@ struct Promoter {
   void insertProbeBlocks();
   void insertProbes();
   void insertProbes(BlockEntry *node);
+  void insertProbes(SlotNode *node);
 
   void insertDriveBlocks();
   void insertDrives();
@@ -1117,6 +1118,8 @@ struct Promoter {
   /// Maps slot values to all ops that refer to them. The operation list is
   /// laid out in the same order as a loop over blocks in the region.
   DenseMap<Value, SmallVector<Operation *>> slotOps;
+  /// Signals local to the current region.
+  SmallSetVector<Operation *, 4> localSignals;
 };
 } // namespace
 
@@ -1145,6 +1148,10 @@ LogicalResult Promoter::promote() {
     promoteSlot();
   }
   currentSlot = {};
+
+  // Drop region-local signal declarations that are no longer probed.
+  for (auto *signalOp : localSignals)
+    removeUnusedLocalSignal(cast<SignalOp>(signalOp));
 
   // Erase operations that have become unused.
   pruner.eraseNow();
@@ -1202,11 +1209,11 @@ void Promoter::promoteSlot() {
   // Insert the necessary block arguments.
   insertBlockArgs();
 
-  // If this slot is a region-local signal declaration, try to drop it when
-  // no probes remain.
-  if (auto signalOp = currentSlot.getDefiningOp<SignalOp>())
+  // If this slot come from a region-local signal, mark it as a candidate for
+  // later -- will be dropped if not needed.
+  if (auto *signalOp = getRootSignal(currentSlot.getDefiningOp()))
     if (signalOp->getParentRegion() == &region)
-      removeUnusedLocalSignal(signalOp);
+      localSignals.insert(signalOp);
 
   // Release the lattice so the bump allocators free their slabs before the
   // next slot runs.
@@ -1460,6 +1467,12 @@ void Promoter::populateSlotOps() {
                            return resolveSlot(op.getSignal());
                          return Value();
                        })
+                       .Case<SigExtractOp, SigArrayGetOp, SigStructExtractOp>(
+                           [&](Operation *op) -> Value {
+                             if (llvm::is_contained(slots, op->getResult(0)))
+                               return op->getResult(0);
+                             return Value();
+                           })
                        .Case([&](SignalOp op) { return op.getResult(); })
                        .Default([&](Operation *) { return Value(); });
       if (slot)
@@ -1537,13 +1550,15 @@ void Promoter::constructLattice() {
 
       // Handle local signals. Only the current slot's own SignalOp, if it
       // lives inside this region, contributes a SignalNode.
-      if (auto signalOp = dyn_cast<SignalOp>(op)) {
-        if (signalOp.getResult() != currentSlot)
+      if (isa<SignalOp, SigExtractOp, SigArrayGetOp, SigStructExtractOp>(op)) {
+        if (op->getResult(0) != currentSlot)
           continue;
-        auto *def =
-            lattice->createDef(signalOp.getInit(), DriveCondition::never());
-        auto *node = lattice->createNode<SignalNode>(signalOp, def, valueBefore,
-                                                     lattice->createValue());
+        Def *def = nullptr;
+        // Only signals have an initial value.
+        if (auto signalOp = dyn_cast<SignalOp>(op))
+          def = lattice->createDef(signalOp.getInit(), DriveCondition::never());
+        auto *node = lattice->createNode<SlotNode>(op, def, valueBefore,
+                                                   lattice->createValue());
         valueBefore = node->valueAfter;
         continue;
       }
@@ -1607,12 +1622,14 @@ void Promoter::propagateBackward(LatticeNode *node) {
     return;
   }
 
-  // Local signal declarations kill the need for a definition to be available,
-  // since the op is the first time a signal becomes available and the op
-  // provides an initial value as a definition.
-  if (isa<SignalNode>(node)) {
-    auto *signal = cast<SignalNode>(node);
-    update(signal->valueBefore, false);
+  // A slot's storage becomes available at its defining op: signal declarations
+  // allocate it, projections name it for the first time. Forward propagation
+  // overwrites the slot's value there in either case, so nothing from above
+  // ever flows through and no definition is ever needed above the op. This also
+  // keeps the need, and therefore any probe inserted to satisfy it, inside the
+  // part of the region that the slot dominates.
+  if (auto *slot = dyn_cast<SlotNode>(node)) {
+    update(slot->valueBefore, false);
     return;
   }
 
@@ -1731,8 +1748,9 @@ void Promoter::propagateForward(LatticeNode *node, bool optimisticMerges,
 
   // Signals propagate their initial value as a reaching def. They also kill
   // any earlier delayed definition for the same slot.
-  if (auto *signal = dyn_cast<SignalNode>(node)) {
-    update(signal->valueAfter, signal->def, nullptr);
+  if (auto *signal = dyn_cast<SlotNode>(node)) {
+    update(signal->valueAfter, signal->def,
+           signal->hasInitValue() ? signal->def : nullptr);
     return;
   }
 
@@ -1898,7 +1916,21 @@ void Promoter::insertProbes() {
   for (auto *node : lattice->nodes) {
     if (auto *entry = dyn_cast<BlockEntry>(node))
       insertProbes(entry);
+    else if (auto *signal = dyn_cast<SlotNode>(node))
+      insertProbes(signal);
   }
+}
+
+/// Insert a probe directly after a SlotNode that is not a SignalOp.
+void Promoter::insertProbes(SlotNode *node) {
+  if (node->def || !node->valueAfter->needed)
+    return;
+  LLVM_DEBUG(llvm::dbgs() << "- Inserting probe for " << currentSlot
+                          << " after " << *node->op << "\n");
+  OpBuilder builder(node->op);
+  builder.setInsertionPointAfter(node->op);
+  auto value = ProbeOp::create(builder, currentSlot.getLoc(), currentSlot);
+  node->def = lattice->createDef(value, DriveCondition::never());
 }
 
 /// Insert a probe at the beginning of the block for the current slot, if it

--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -66,7 +66,7 @@ static bool isDeltaDelay(Value value) {
 
 /// Check whether an operation is a `llhd.drive` with an epsilon delay. This
 /// corresponds to a blocking assignment in Verilog.
-static bool isBlockingDrive(Operation *op) {
+static bool isBlockingDrive(const Operation *op) {
   if (auto driveOp = dyn_cast<DriveOp>(op))
     return isEpsilonDelay(driveOp.getTime()) || isZeroDelay(driveOp.getTime());
   return false;
@@ -74,7 +74,7 @@ static bool isBlockingDrive(Operation *op) {
 
 /// Check whether an operation is a `llhd.drive` with a delta delay. This
 /// corresponds to a non-blocking assignment in Verilog.
-static bool isDeltaDrive(Operation *op) {
+static bool isDeltaDrive(const Operation *op) {
   if (auto driveOp = dyn_cast<DriveOp>(op))
     return isDeltaDelay(driveOp.getTime());
   return false;
@@ -715,6 +715,310 @@ static Value packProjections(OpBuilder &builder, Value value,
   return value;
 }
 
+/// Resolve an operation to the `llhd.sig` declaration it (transitively)
+/// projects into, regardless of which region the projection ops themselves live
+/// in. Returns null if the chain does not bottom out in an `llhd.sig`.
+static Operation *getRootSignal(Operation *op) {
+  if (!op)
+    return nullptr;
+  while (true) {
+    // FIXME: Handle SigArraySlice as well?
+    if (!isa<SigArrayGetOp, SigExtractOp, SigStructExtractOp>(op))
+      break;
+    op = op->getOperand(0).getDefiningOp();
+    if (!op)
+      return nullptr;
+  }
+  if (isa<SignalOp>(op))
+    return op;
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// Projection Aliasing Logic
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct ConstantRange {
+  uint64_t offset = 0;
+  uint64_t width = 1;
+
+  bool operator==(const ConstantRange &other) const {
+    return offset == other.offset && width == other.width;
+  }
+};
+struct DynamicRange {
+  Value index;
+  /// Whether the step selects a cell of a uniform grid, as `llhd.sig.array_get`
+  /// does, or an arbitrary bit position, as a dynamic `llhd.sig.extract` does.
+  bool strided = false;
+
+  bool operator==(const DynamicRange &other) const {
+    return index == other.index && strided == other.strided;
+  }
+};
+using ProjectionRange = std::variant<ConstantRange, DynamicRange>;
+using ProjectionPath = SmallVector<ProjectionRange, 4>;
+} // namespace
+
+/// Compute the portion of the incoming signal that is projected by this one
+/// projection step, relative to its immediate operand.
+static std::optional<ProjectionRange> getProjectionRange(Operation *op) {
+  APInt index;
+  uint64_t offset = 0;
+  int64_t width = 0;
+  Value dynIndex;
+  bool dynStrided = false;
+
+  TypeSwitch<Operation *>(op)
+      .Case<SigArrayGetOp>([&](auto op) {
+        if (!matchPattern(op.getIndex(), m_ConstantInt(&index))) {
+          dynIndex = op.getIndex();
+          dynStrided = true;
+        } else {
+          width = hw::getBitWidth(getStoredType(op.getResult()));
+          offset = index.getZExtValue() * width;
+        }
+      })
+      .Case<SigExtractOp>([&](auto op) {
+        if (!matchPattern(op.getLowBit(), m_ConstantInt(&index))) {
+          dynIndex = op.getLowBit();
+          dynStrided = false;
+        } else {
+          width = op.getResultWidth();
+          offset = index.getZExtValue();
+        }
+      })
+      .Case<SigStructExtractOp>([&](auto op) {
+        auto inputType = cast<RefType>(op.getInput().getType()).getNestedType();
+        if (auto unionType = dyn_cast<hw::UnionType>(inputType)) {
+          width = hw::getBitWidth(unionType);
+        } else {
+          auto structType = cast<hw::StructType>(inputType);
+          auto elements = structType.getElements();
+          auto index = *structType.getFieldIndex(op.getFieldAttr());
+          bool fieldWidthsKnown = true;
+          for (auto field : elements.drop_front(index + 1)) {
+            auto fieldWidth = hw::getBitWidth(field.type);
+            if (fieldWidth < 0) {
+              fieldWidthsKnown = false;
+              break;
+            }
+            offset += fieldWidth;
+          }
+          width = fieldWidthsKnown ? hw::getBitWidth(elements[index].type) : -1;
+        }
+      });
+
+  if (dynIndex)
+    return DynamicRange{dynIndex, dynStrided};
+
+  return width < 0 ? std::nullopt
+                   : std::optional<ProjectionRange>(
+                         ConstantRange{offset, static_cast<uint64_t>(width)});
+}
+
+/// Check whether two projections chains provably describe disjoint
+/// storage.
+static bool isProvablyDisjoint(ProjectionRange &a, ProjectionRange &b) {
+  auto *ca = std::get_if<ConstantRange>(&a);
+  auto *cb = std::get_if<ConstantRange>(&b);
+  // At least one side is dynamic: can't prove disjointness.
+  if (!ca || !cb)
+    return false;
+  // The ranges don't overlap: disjoint.
+  if (ca->offset + ca->width <= cb->offset ||
+      cb->offset + cb->width <= ca->offset)
+    return true;
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// PromotionTree
+//===----------------------------------------------------------------------===//
+
+namespace {
+// FIXME: ideally this can be shared by different passes.
+// The only obstacle at the moment is the rejection logic in buildFrom.
+struct PromotionTree {
+  struct Node {
+    Operation *op;
+    SmallVector<Operation *> directAccesses;
+    SmallVector<Operation *> foldedProjections;
+    SmallVector<Operation *> foldedAccesses;
+
+    SmallVector<Node *> children;
+
+    bool isSlot = false;
+    bool hasOutsideDrive = false;
+
+    Node(Operation *op) : op(op) {}
+
+    bool hasInRegionDeltaDrive() const {
+      return llvm::any_of(
+          llvm::concat<const Operation *>(directAccesses, foldedAccesses),
+          [&](const Operation *access) { return isDeltaDrive(access); });
+    }
+    bool hasInRegionBlockingDrive() const {
+      return llvm::any_of(
+          llvm::concat<const Operation *>(directAccesses, foldedAccesses),
+          [&](const Operation *access) { return isBlockingDrive(access); });
+    }
+    bool hasInRegionDrive() const {
+      return llvm::any_of(
+          llvm::concat<const Operation *>(directAccesses, foldedAccesses),
+          [&](const Operation *access) { return isa<DriveOp>(access); });
+    }
+    bool hasInRegionProjectedDrive(Region &region) {
+      return llvm::any_of(foldedAccesses, [&](Operation *access) {
+        return isa<DriveOp>(access);
+      });
+    }
+    bool hasInRegionAccess() const {
+      return directAccesses.size() + foldedAccesses.size() > 0;
+    }
+    bool hasProjection() const { return foldedProjections.size() > 0; }
+
+    template <typename RangeT>
+    void absorbAccesses(RangeT &&accesses, bool isDirect, Region &region) {
+      llvm::append_range(
+          isDirect ? directAccesses : foldedAccesses,
+          llvm::make_filter_range(accesses, [&](Operation *access) {
+            bool inRegion = access->getParentRegion() == &region;
+            hasOutsideDrive |= isa<DriveOp>(access) && !inRegion;
+            return inRegion;
+          }));
+    }
+
+    template <typename RangeT>
+    void absorbProjections(RangeT &&projections) {
+      llvm::append_range(foldedProjections, projections);
+    }
+  };
+
+  Node *buildFrom(Operation *signal, Region &region) {
+    assert(isa<SignalOp>(signal));
+    // Save initial node size.
+    unsigned initialSize = nodes.size();
+    // Create node for the root.
+    Node *rootNode = makeNode(signal);
+    SmallVector<std::pair<Operation *, Node *>, 4> worklist = {
+        {signal, rootNode}};
+    // Visit users recursively.
+    while (!worklist.empty()) {
+      auto [curOp, curNode] = worklist.pop_back_val();
+      // Decide what to do for the current operation (absorb in parent's node,
+      // discard whole tree, create new node) by visiting its users.
+      using Projection = std::pair<Operation *, ProjectionRange>;
+      SmallVector<Operation *, 4> accesses;
+      SmallVector<Projection, 4> projections;
+      bool shouldDiscard = false;
+      for (Operation *user : curOp->getUsers()) {
+        // User in nested region: discard.
+        if (region.isProperAncestor(user->getParentRegion())) {
+          shouldDiscard = true;
+          break;
+        }
+        // Check that all the users are operations we can reason about.
+        bool isDynamicProjection = false;
+        bool inRegion = user->getParentRegion() == &region;
+        bool canReason =
+            TypeSwitch<Operation *, bool>(user)
+                .Case<ProbeOp>([&](auto op) {
+                  accesses.push_back(op);
+                  return true;
+                })
+                .Case<DriveOp>([&](auto op) {
+                  // Can only reason about delta and blocking drives.
+                  if (!isDeltaDrive(op) && !isBlockingDrive(op) && inRegion)
+                    return false;
+                  if (!inRegion)
+                    curNode->hasOutsideDrive = true;
+                  accesses.push_back(op);
+                  return true;
+                })
+                .Case<SigExtractOp, SigArrayGetOp, SigStructExtractOp>(
+                    [&](Operation *op) {
+                      auto range = getProjectionRange(op);
+                      if (!range)
+                        return false;
+                      isDynamicProjection =
+                          std::holds_alternative<DynamicRange>(*range);
+                      projections.push_back({op, *range});
+                      return true;
+                    })
+                .Default([&](auto op) {
+                  // FIXME: is this the right condition?
+                  return !inRegion;
+                });
+        // Can't reason about this user: discard.
+        if (!canReason) {
+          shouldDiscard = true;
+          break;
+        }
+        // Current node is already a slot: all transitive uses are
+        // absorbed unconditionally, nothing more to check for this user.
+        if (curNode->isSlot)
+          continue;
+        // Check if the node should be marked as a slot:
+        // 1. Any direct drive forces a slot (longest common prefix)
+        // 2. Any region-local probe forces a slot
+        // 3. Any non-constant projection forces a slot (longest static prefix)
+        curNode->isSlot |= (inRegion && isa<DriveOp>(user)) ||
+                           (inRegion && isa<ProbeOp>(user)) ||
+                           isDynamicProjection;
+      }
+      // Has at least one poisoned use: reject the whole tree.
+      if (shouldDiscard) {
+        rootNode = nullptr;
+        break;
+      }
+      // Has aliasing children: make it a slot.
+      if (!curNode->isSlot) {
+        curNode->isSlot |= llvm::any_of(projections, [&](Projection &proj) {
+          return llvm::any_of(projections, [&](Projection &sibling) {
+            return proj.first != sibling.first &&
+                   !isProvablyDisjoint(proj.second, sibling.second);
+          });
+        });
+      }
+      // Slot nodes absorb all users.
+      if (curNode->isSlot) {
+        curNode->absorbAccesses(accesses, curOp == curNode->op, region);
+        curNode->absorbProjections(
+            llvm::map_range(projections, [&](auto &elem) -> Operation * {
+              return elem.first;
+            }));
+      }
+      // Enqueue projections to worklist. For non-slot nodes, each projection
+      // gets its own new node.
+      for (auto &[proj, range] : projections) {
+        auto *projNode = curNode;
+        if (!curNode->isSlot) {
+          projNode = makeNode(proj);
+          projNode->hasOutsideDrive = curNode->hasOutsideDrive;
+          curNode->children.push_back(projNode);
+        }
+        worklist.push_back({proj, projNode});
+      }
+    }
+
+    // Cleanup nodes.
+    if (!rootNode)
+      nodes.pop_back_n(nodes.size() - initialSize);
+
+    return rootNode;
+  }
+
+  SmallVector<std::unique_ptr<Node>, 8> nodes;
+  Node *makeNode(Operation *op) {
+    nodes.emplace_back(std::make_unique<Node>(op));
+    return nodes.back().get();
+  }
+};
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // Drive/Probe to SSA Value Promotion
 //===----------------------------------------------------------------------===//
@@ -902,82 +1206,54 @@ void Promoter::promoteSlot() {
 /// Identify any promotable slots probed or driven under the current region.
 void Promoter::findPromotableSlots() {
   SmallPtrSet<Value, 8> seenSlots;
-  SmallPtrSet<Operation *, 8> checkedUsers;
-  SmallVector<Operation *, 8> userWorklist;
+  SmallPtrSet<Operation *, 8> seenSignals;
 
+  // Create promotion tree for every signal driven in this region.
+  PromotionTree ptree;
   region.walk([&](Operation *op) {
     for (auto operand : op->getOperands()) {
       if (!seenSlots.insert(operand).second)
         continue;
-
-      // We can only promote probes and drives on a locally-defined signal.
+      // Go back in the projection chain until you find a SignalOp.
       // Other signals, such as the ones brought into a module through a port,
       // have an unknown aliasing relationship with the other ports.
-      if (!operand.getDefiningOp<llhd::SignalOp>())
+      auto *root = getRootSignal(operand.getDefiningOp());
+      if (!root)
+        continue;
+      if (!seenSignals.insert(root).second)
         continue;
 
-      // Ensure the slot is not used in any way we cannot reason about.
-      bool hasProjection = false;
-      bool hasBlockingDrive = false;
-      bool hasDeltaDrive = false;
-      auto checkUser = [&](Operation *user) -> bool {
-        // We don't support nested probes and drives.
-        if (region.isProperAncestor(user->getParentRegion()))
-          return false;
-        // Ignore uses outside of the region.
-        if (user->getParentRegion() != &region)
-          return true;
-        // Projection operations are okay, as long as nested projections
-        // stay in the same block. Cross-block nested projections would break
-        // during promotion because the projection chain gets severed when
-        // Mem2Reg rewrites signal references into SSA block arguments.
-        if (isa<SigArrayGetOp, SigExtractOp, SigStructExtractOp>(user)) {
-          hasProjection = true;
-          for (auto *projectionUser : user->getUsers()) {
-            if (isa<SigArrayGetOp, SigExtractOp, SigStructExtractOp>(
-                    projectionUser) &&
-                projectionUser->getBlock() != user->getBlock())
-              return false;
-            hasBlockingDrive |= isBlockingDrive(projectionUser);
-            hasDeltaDrive |= isDeltaDrive(projectionUser);
-            if (checkedUsers.insert(projectionUser).second)
-              userWorklist.push_back(projectionUser);
-          }
-          projections.insert({user->getResult(0), operand});
-          return true;
-        }
-        hasBlockingDrive |= isBlockingDrive(user);
-        hasDeltaDrive |= isDeltaDrive(user);
-        return isa<ProbeOp>(user) || isBlockingDrive(user) ||
-               isDeltaDrive(user);
-      };
-      checkedUsers.clear();
-      if (!llvm::all_of(operand.getUsers(), [&](auto *user) {
-            auto allOk = true;
-            if (checkedUsers.insert(user).second)
-              userWorklist.push_back(user);
-            while (!userWorklist.empty() && allOk)
-              allOk &= checkUser(userWorklist.pop_back_val());
-            userWorklist.clear();
-            return allOk;
-          }))
+      auto *rootNode = ptree.buildFrom(root, region);
+      // Bail out if the root signal has uses we cannot reason about.
+      if (!rootNode)
         continue;
-
-      // Don't promote slots that have projections and a mix of blocking and
-      // delta drives. A blocking drive erases the delayed reaching definition,
-      // which leaves delta projection drives without a reaching definition.
-      if (hasProjection && hasBlockingDrive && hasDeltaDrive)
-        continue;
-
-      // Mem2Reg may have to materialize a zero value for promoted slots. Skip
-      // signal types for which we cannot create a suitable default.
-      if (!isPromotableSlotType(getStoredType(operand)))
-        continue;
-
-      slots.push_back(operand);
     }
   });
+  // Select only the promotable slots.
+  for (auto &node : ptree.nodes) {
+    // Select only slots that are accessed in this region.
+    if (!node->isSlot || !node->hasInRegionAccess())
+      continue;
 
+    // FIXME: Nothing to check if node->hasOutsideDrive?
+
+    // Don't promote slots that have projections and a mix of blocking and
+    // delta drives. A blocking drive erases the delayed reaching definition,
+    // which leaves delta projection drives without a reaching definition.
+    if (node->hasProjection() && node->hasInRegionBlockingDrive() &&
+        node->hasInRegionDeltaDrive())
+      continue;
+
+    // Mem2Reg may have to materialize a zero value for promoted slots. Skip
+    // signal types for which we cannot create a suitable default.
+    Value slotVal = node->op->getResult(0);
+    if (!isPromotableSlotType(getStoredType(slotVal)))
+      continue;
+
+    slots.push_back(slotVal);
+    for (auto *proj : node->foldedProjections)
+      projections[proj->getResult(0)] = slotVal;
+  }
   // Populate `promotable` with the slots and projections we are promoting.
   promotable.insert(slots.begin(), slots.end());
   projections.remove_if([&](auto elem) {

--- a/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
+++ b/lib/Dialect/LLHD/Transforms/Mem2Reg.cpp
@@ -1033,6 +1033,7 @@ struct Promoter {
   Value resolveSlot(Value projectionOrSlot);
   void populateSlotOps();
 
+  void computeLiveOutWait();
   void captureAcrossWait();
   void captureAcrossWait(Value value, ArrayRef<WaitOp> waitOps,
                          Liveness &liveness, DominanceInfo &dominance);
@@ -1075,6 +1076,14 @@ struct Promoter {
   /// The region we are promoting in.
   Region &region;
 
+  /// All wait operations in the region.
+  SmallVector<WaitOp> waitOps;
+  /// Values to capture across waits.
+  llvm::SetVector<Value> liveOutWait;
+  /// Region analyses shared by different stages of the pass.
+  std::unique_ptr<DominanceInfo> dominance;
+  std::unique_ptr<Liveness> liveness;
+
   /// The slots we are promoting. Mostly `llhd.sig` ops in practice. This
   /// establishes a deterministic order for slot allocations, such that
   /// everything else in the pass can operate using unordered maps and sets.
@@ -1115,6 +1124,7 @@ LogicalResult Promoter::promote() {
   if (region.empty())
     return success();
 
+  computeLiveOutWait();
   findPromotableSlots();
   captureAcrossWait();
 
@@ -1250,6 +1260,15 @@ void Promoter::findPromotableSlots() {
     if (!isPromotableSlotType(getStoredType(slotVal)))
       continue;
 
+    // Check if promoting this slot would fold in a projection whose parent
+    // value is captured across a wait boundary. Capturing rewrites uses of
+    // the parent value beyond the wait to a new block argument, which would
+    // sever the operand(0) chain the projection stacks are built from.
+    if (llvm::any_of(node->foldedProjections, [&](Operation *proj) {
+          return liveOutWait.contains(proj->getOperand(0));
+        }))
+      continue;
+
     slots.push_back(slotVal);
     for (auto *proj : node->foldedProjections)
       projections[proj->getResult(0)] = slotVal;
@@ -1275,23 +1294,22 @@ Value Promoter::resolveSlot(Value projectionOrSlot) {
   return projectionOrSlot;
 }
 
-/// Explicitly capture any probes that are live across an `llhd.wait` as block
-/// arguments and destination operand of that wait. This ensures that replacing
-/// the probe with a reaching definition later on will capture the value of the
-/// reaching definition before the wait.
-void Promoter::captureAcrossWait() {
+/// Collect any probes that are live across an `llhd.wait`.
+/// These will be later explicitly captured as block arguments by
+/// captureAcrossWait().
+void Promoter::computeLiveOutWait() {
   if (region.hasOneBlock())
     return;
 
-  SmallVector<WaitOp> waitOps;
   for (auto &block : region)
     if (auto waitOp = dyn_cast<WaitOp>(block.getTerminator()))
       waitOps.push_back(waitOp);
 
-  DominanceInfo dominance(region.getParentOp());
-  Liveness liveness(region.getParentOp());
+  if (waitOps.empty())
+    return;
 
-  llvm::DenseSet<Value> alreadyCaptured;
+  dominance = std::make_unique<DominanceInfo>(region.getParentOp());
+  liveness = std::make_unique<Liveness>(region.getParentOp());
 
   auto isDefinedInRegion = [&](Value v) {
     return v.getParentRegion() == &region;
@@ -1299,18 +1317,25 @@ void Promoter::captureAcrossWait() {
 
   for (auto waitOp : waitOps) {
     Block *waitBlock = waitOp->getBlock();
-    const auto &liveOutValues = liveness.getLiveOut(waitBlock);
+    const auto &liveOutValues = liveness->getLiveOut(waitBlock);
 
     for (Value v : liveOutValues) {
       if (!isDefinedInRegion(v))
         continue;
-
-      if (!alreadyCaptured.insert(v).second)
-        continue;
-
-      captureAcrossWait(v, waitOps, liveness, dominance);
+      liveOutWait.insert(v);
     }
   }
+}
+
+/// Explicitly capture any probes that are live across an `llhd.wait` as block
+/// arguments and destination operand of that wait. This ensures that replacing
+/// the probe with a reaching definition later on will capture the value of the
+/// reaching definition before the wait.
+void Promoter::captureAcrossWait() {
+  if (!dominance || !liveness)
+    return;
+  for (Value v : liveOutWait)
+    captureAcrossWait(v, waitOps, *liveness, *dominance);
 }
 
 /// Add a probe as block argument to a list of wait ops and update uses of the


### PR DESCRIPTION
Took a shot at #10912 but I'm hard-stuck - sorry for the state of the code, I tried a couple different things and I'm not sure this is the right type of analysis or it's an overkill. 

The idea is:
- go back to the root signal
- visit all uses transitively
   - any projection that is directly probed or driven in the current region is a slot
   - any projection whose children are indistiguishable (including dynamic projections) is a slot
   - whenever you find a slot, start accumulating all projections and all in-region accesses in that slot node
   - whenever you find a use in a nested region, or an in-region use we cannot reason about, bail out completely
- then `getPromotableSlot()` checks every candidate slot marked above, and implements the discarding logic

Now, what should happen in the lattice? I guess slot nodes could hold a ProjectionStack from the signal to this projection, and accesses folded in the slot node could hold a ProjectionStack relative to the slot, so that we can reuse them in the Lattice.

But then how should the Lattice change? Something like:
- remove SignalNode, substitute with SlotNode → but projections don't have an initial value? how should I treat them? 
- should we use the ProjectionStack of the slot to re-materialize the entire projection at the entry block of the process?
- the current `getProjections` can be substituted by a lookup of the projectionStack that is already there in the slot node

Hope this is not completely off-track.