### PR TITLE
[docs] Add terse Style Guide

### DIFF
--- a/docs/DeveloperPolicy.md
+++ b/docs/DeveloperPolicy.md
@@ -19,6 +19,14 @@ CIRCT follows the standard LLVM process for obtaining commit access. See the [LL
 
 CIRCT follows the [LLVM AI Tool Use Policy](AIToolPolicy.md). Contributors using AI tools must ensure human review and accountability for all contributions.
 
+## Style Guide
+
+For any non-code (e.g., documentation or code comments) follow the style rules
+in:
+
+- Merriam--Webster's Collegiate Dictionary
+- The Chicago Manual of Style
+
 ## Additional Resources
 
 - [LLVM Developer Policy (full)](https://llvm.org/docs/DeveloperPolicy.html)


### PR DESCRIPTION
Add an extremely terse style guide for non-code (documentation, comments,
etc.) which defers to Merriam--Webster (M--W) and Chicago for style rules.

This intentionally _does not_ highlight any specific rules, but is
intended to allow for reviews to actually cite these when issues come up
to avoid any ambiguities.

This is motivated by the amount of LLM assistance being used in generating
code documentation and general documentation.  LLMs are extremely
inconsistent here, e.g., they have vacillated between different stylings
for "parentheticals" which are suggested differently based on different
style guides:

- Chicago says to use an unspaced em-dash like `foo---bar---baz`.
- AP says to use a spaced em-dash like `foo --- bar --- baz`.
- UK/International says to use a spaced en-dash `foo -- bar -- baz`.

M--W/Chicago is what the Apple Style Guide[^1] suggests.  Hence, this
seems both reasonable given Apple's attention to detail (and this also
makes sense to me given that I'm used to seeing Chicago style in prose).

[^1]: https://help.apple.com/pdf/applestyleguide/en_US/apple-style-guide.pdf
