### PR TITLE
[HWAggregateToComb] Lower `hw.array_slice` to comb dialect

### DIFF
--- a/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
+++ b/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
@@ -96,6 +96,50 @@ struct HWArrayGetOpConversion : OpConversionPattern<hw::ArrayGetOp> {
   }
 };
 
+struct HWArraySliceOpConversion : OpConversionPattern<hw::ArraySliceOp> {
+  using OpConversionPattern<hw::ArraySliceOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(hw::ArraySliceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value> results;
+    auto arrayType = cast<hw::ArrayType>(op.getInput().getType());
+    auto elemType = arrayType.getElementType();
+    auto numElements = arrayType.getNumElements();
+    auto elemWidth = hw::getBitWidth(elemType);
+    if (elemWidth < 0)
+      return rewriter.notifyMatchFailure(op.getLoc(), "unknown element width");
+    auto resultArrayType = cast<hw::ArrayType>(op.getResult().getType());
+    auto resultNumElements = resultArrayType.getNumElements();
+
+    auto lowered = adaptor.getInput();
+    auto index = adaptor.getLowIndex();
+    APInt constantIndex;
+    if (matchPattern(index, m_ConstantInt(&constantIndex))) {
+      int64_t maxIndex = std::numeric_limits<int32_t>::max() / elemWidth;
+      if (constantIndex.isSingleWord() &&
+          constantIndex.getZExtValue() <= static_cast<uint64_t>(maxIndex)) {
+        rewriter.replaceOpWithNewOp<comb::ExtractOp>(
+            op, lowered, constantIndex.getZExtValue() * elemWidth,
+            resultNumElements * elemWidth);
+        return success();
+      }
+    }
+
+    for (size_t i = 0; i <= numElements - resultNumElements; ++i)
+      results.push_back(rewriter.createOrFold<comb::ExtractOp>(
+          op.getLoc(), lowered, i * elemWidth, resultNumElements * elemWidth));
+
+    SmallVector<Value> bits;
+    comb::extractBits(rewriter, index, bits);
+    auto result = comb::constructMuxTree(rewriter, op.getLoc(), bits, results,
+                                         results.back());
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 struct HWArrayInjectOpConversion : OpConversionPattern<hw::ArrayInjectOp> {
   using OpConversionPattern<hw::ArrayInjectOp>::OpConversionPattern;
 
@@ -255,11 +299,12 @@ public:
 
 static void populateHWAggregateToCombOpConversionPatterns(
     RewritePatternSet &patterns, AggregateTypeConverter &typeConverter) {
-  patterns.add<
-      HWArrayGetOpConversion, HWArrayCreateLikeOpConversion<hw::ArrayCreateOp>,
-      HWArrayCreateLikeOpConversion<hw::ArrayConcatOp>,
-      HWAggregateConstantOpConversion, HWArrayInjectOpConversion,
-      HWStructCreateOpConversion, HWStructExtractOpConversion, MuxOpConversion>(
+  patterns.add<HWArrayGetOpConversion,
+               HWArrayCreateLikeOpConversion<hw::ArrayCreateOp>,
+               HWArrayCreateLikeOpConversion<hw::ArrayConcatOp>,
+               HWAggregateConstantOpConversion, HWArraySliceOpConversion,
+               HWArrayInjectOpConversion, HWStructCreateOpConversion,
+               HWStructExtractOpConversion, MuxOpConversion>(
       typeConverter, patterns.getContext());
 }
 
@@ -274,10 +319,10 @@ struct HWAggregateToCombPass
 void HWAggregateToCombPass::runOnOperation() {
   ConversionTarget target(getContext());
 
-  // TODO: Add ArraySliceOp and struct operatons as well.
   target.addIllegalOp<hw::ArrayGetOp, hw::ArrayCreateOp, hw::ArrayConcatOp,
                       hw::AggregateConstantOp, hw::ArrayInjectOp,
-                      hw::StructCreateOp, hw::StructExtractOp>();
+                      hw::ArraySliceOp, hw::StructCreateOp,
+                      hw::StructExtractOp>();
   target.addDynamicallyLegalOp<comb::MuxOp>(
       [](comb::MuxOp op) { return hw::type_isa<IntegerType>(op.getType()); });
   target.addLegalDialect<hw::HWDialect, comb::CombDialect>();

--- a/test/Dialect/HW/hw-aggregate-to-comb.mlir
+++ b/test/Dialect/HW/hw-aggregate-to-comb.mlir
@@ -59,6 +59,38 @@ hw.module @array(in %arg0: i2, in %arg1: i2, in %arg2: i2, in %arg3: i2, out out
   hw.output %0, %1 : !hw.array<4xi2>, i2
 }
 
+// CHECK-LABEL: @array_slice(
+hw.module @array_slice(in %arg0: i2, in %arg1: i2, in %arg2: i2, in %arg3: i2, out out: !hw.array<4xi2>, in %sel: i2, out out_slice: !hw.array<2xi2>) {
+  %0 = hw.array_create %arg0, %arg1, %arg2, %arg3 : i2
+  %1 = hw.array_slice %0[%sel] : (!hw.array<4xi2>) -> !hw.array<2xi2>
+  // CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %arg0, %arg1, %arg2, %arg3 : i2, i2, i2, i2
+  // CHECK-NEXT: %[[BITCAST:.+]] = hw.bitcast %[[CONCAT]] : (i8) -> !hw.array<4xi2>
+  // CHECK-NEXT: %[[EXTRACT_0:.+]] = comb.extract %[[CONCAT]] from 0 : (i8) -> i4
+  // CHECK-NEXT: %[[EXTRACT_2:.+]] = comb.extract %[[CONCAT]] from 2 : (i8) -> i4
+  // CHECK-NEXT: %[[EXTRACT_4:.+]] = comb.extract %[[CONCAT]] from 4 : (i8) -> i4
+  // CHECK-NEXT: %[[EXTRACT_SEL:.+]] = comb.extract %sel from 0
+  // CHECK-NEXT: %[[EXTRACT_SEL_1:.+]] = comb.extract %sel from 1
+  // CHECK-NEXT: %[[MUX_0:.+]] = comb.mux %[[EXTRACT_SEL]], %[[EXTRACT_2]], %[[EXTRACT_0]]
+  // CHECK-NEXT: %[[MUX_2:.+]] = comb.mux %[[EXTRACT_SEL_1]], %[[EXTRACT_4]], %[[MUX_0]]
+  // CHECK-NEXT: %[[BITCAST_SLICE:.+]] = hw.bitcast %[[MUX_2]] : (i4) -> !hw.array<2xi2>
+  // CHECK-NEXT: hw.output %[[BITCAST]], %[[BITCAST_SLICE]]
+  hw.output %0, %1 : !hw.array<4xi2>, !hw.array<2xi2>
+}
+
+// CHECK-LABEL: @array_slice_const(
+hw.module @array_slice_const(in %arg0: i2, in %arg1: i2, in %arg2: i2, in %arg3: i2, out out: !hw.array<4xi2>, out out_slice: !hw.array<2xi2>) {
+  %sel = hw.constant 1 : i2
+  %0 = hw.array_create %arg0, %arg1, %arg2, %arg3 : i2
+  %1 = hw.array_slice %0[%sel] : (!hw.array<4xi2>) -> !hw.array<2xi2>
+  // CHECK-NEXT: %[[SEL:.+]] = hw.constant 1 : i2
+  // CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %arg0, %arg1, %arg2, %arg3 : i2, i2, i2, i2
+  // CHECK-NEXT: %[[BITCAST:.+]] = hw.bitcast %[[CONCAT]] : (i8) -> !hw.array<4xi2>
+  // CHECK-NEXT: %[[EXTRACT_2:.+]] = comb.extract %[[CONCAT]] from 2 : (i8) -> i4
+  // CHECK-NEXT: %[[BITCAST_SLICE:.+]] = hw.bitcast %[[EXTRACT_2]] : (i4) -> !hw.array<2xi2>
+  // CHECK-NEXT: hw.output %[[BITCAST]], %[[BITCAST_SLICE]]
+  hw.output %0, %1 : !hw.array<4xi2>, !hw.array<2xi2>
+}
+
 // CHECK-LABEL: @array_inject(
 hw.module @array_inject(in %in: !hw.array<3xi2>, in %sel: i2, in %val: i2, out out_inject: !hw.array<3xi2>) {
   // CHECK-NEXT: %[[in_bitcast:.+]] = hw.bitcast %in


### PR DESCRIPTION
As mentioned in the code comment, this is missing functionality that should be there.

Like commit f3dc563e72aa8cdc1f857a40e0f5ac7c55b00109, optimize the constant-index case since avoiding the creation of huge muxes can be critical.