### PR TITLE
[LLHD] Make llhd-inline-calls best-effort on recursion

### DIFF
--- a/include/circt/Dialect/LLHD/LLHDPasses.td
+++ b/include/circt/Dialect/LLHD/LLHDPasses.td
@@ -14,10 +14,11 @@ include "mlir/Pass/PassBase.td"
 def InlineCallsPass : Pass<"llhd-inline-calls", "ModuleOp"> {
   let summary = "Inline all function calls in HW modules";
   let description = [{
-    Inlines all `func.call` operations nested within `llhd.combinational`,
+    Inlines `func.call` operations nested within `llhd.combinational`,
     `llhd.process`, and `llhd.final` ops within `hw.module`s. The `func.func`
     definitions are left untouched. After the inlining, MLIR's symbol DCE pass
-    may be used to eliminate the function definitions where possible.
+    may be used to eliminate the function definitions where possible. Recursive
+    calls are left unchanged.
 
     This pass expects the `llhd-wrap-procedural-ops` pass to have already run.
     Otherwise call ops immediately in the module body, a graph region, cannot be

--- a/lib/Dialect/LLHD/Transforms/InlineCalls.cpp
+++ b/lib/Dialect/LLHD/Transforms/InlineCalls.cpp
@@ -148,9 +148,14 @@ LogicalResult InlineCallsPass::runOnRegion(Region &region,
         continue;
 
       // Ensure that we are not recursively inlining a function, which would
-      // just expand infinitely in the IR.
-      if (!callStack.insert(funcOp))
-        return callOp.emitError("recursive function call cannot be inlined");
+      // just expand infinitely in the IR. Recursive functions can't be fully
+      // inlined, so leave this particular call as-is and keep inlining the
+      // rest of the module.
+      if (!callStack.insert(funcOp)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "- Skipping recursive call " << callOp << "\n");
+        continue;
+      }
       inlineEndMarkers.push_back({op.getNextNode(), funcOp});
 
       // Inline the function body and remember the call for later removal. The

--- a/test/Dialect/LLHD/Transforms/inline-calls-errors.mlir
+++ b/test/Dialect/LLHD/Transforms/inline-calls-errors.mlir
@@ -8,23 +8,3 @@ hw.module @CallInGraphRegion() {
 func.func @foo() {
   return
 }
-
-// -----
-
-hw.module @RecursiveCalls() {
-  llhd.combinational {
-    func.call @foo() : () -> ()
-    llhd.yield
-  }
-}
-
-func.func @foo() {
-  call @bar() : () -> ()
-  return
-}
-
-func.func @bar() {
-  // expected-error @below {{recursive function call cannot be inlined}}
-  call @foo() : () -> ()
-  return
-}

--- a/test/Dialect/LLHD/Transforms/inline-calls.mlir
+++ b/test/Dialect/LLHD/Transforms/inline-calls.mlir
@@ -95,3 +95,43 @@ func.func private @maybeUnreachable(%arg0: i1) -> i42 {
   %0 = hw.constant 42 : i42
   return %0 : i42
 }
+
+// Mutually recursive calls cannot be fully inlined without expanding
+// infinitely in the IR. The call that closes the cycle is left in place
+// on a best-effort basis instead of failing the pass.
+// CHECK-LABEL: @Recursive
+hw.module @Recursive() {
+  // CHECK: llhd.combinational
+  llhd.combinational {
+    // CHECK-NOT: call @recBar
+    func.call @recFoo() : () -> ()
+    // CHECK: call @recFoo
+    llhd.yield
+  }
+}
+
+func.func private @recFoo() {
+  call @recBar() : () -> ()
+  return
+}
+
+func.func private @recBar() {
+  call @recFoo() : () -> ()
+  return
+}
+
+// A directly self-recursive function cannot be inlined into itself either.
+// CHECK-LABEL: @SelfRecursive
+hw.module @SelfRecursive() {
+  // CHECK: llhd.combinational
+  llhd.combinational {
+    // CHECK: call @recSelf
+    func.call @recSelf() : () -> ()
+    llhd.yield
+  }
+}
+
+func.func private @recSelf() {
+  call @recSelf() : () -> ()
+  return
+}


### PR DESCRIPTION
Recursive function calls cannot be fully inlined without expanding infinitely in the IR. Instead of erroring out and aborting the whole pass, leave the call that closes the recursion cycle in place and keep inlining the rest of the module.

This unblocks circt-verilog on inputs containing (mutually) recursive functions, which previously failed the entire lowering pipeline.

Assisted-by: Claude Sonnet 5