### PR TITLE
[ImportVerilog] Reject inout ports with mismatched types

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -577,6 +577,18 @@ struct ModuleVisitor : public BaseVisitor {
         if (auto *existingPort =
                 moduleLowering->portsBySyntaxNode.lookup(con->port.getSyntax()))
           port = existingPort;
+
+        // IEEE 1800-2017 §23.3.3 requires `inout` port connections to be direct
+        // connections, which does not allow for type conversion.
+        if (port->direction == ArgumentDirection::InOut) {
+          auto portType = moore::RefType::get(
+              cast<moore::UnpackedType>(context.convertType(port->getType())));
+          if (value.getType() != portType)
+            return mlir::emitError(loc)
+                   << "inout port `" << port->name << "` expects " << portType
+                   << " but is connected to " << value.getType();
+        }
+
         portValues.insert({port, value});
         continue;
       }

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -368,3 +368,27 @@ module ReadMemIndexedSelect;
     $readmemh("mem.data", mem[i+:8]);
   end
 endmodule
+
+// -----
+
+module Foo(inout [9000:0] x);
+endmodule
+
+module Bar;
+  wire [41:0] y;
+  // expected-error @below {{inout port `x` expects '!moore.ref<l9001>' but is connected to '!moore.ref<l42>'}}
+  Foo foo(y);
+endmodule
+
+// -----
+
+typedef struct packed { logic x; logic y; } Pair;
+
+module Foo(inout Pair p);
+endmodule
+
+module Bar;
+  wire [1:0] y;
+  // expected-error @below {{inout port `p` expects '!moore.ref<struct<{x: l1, y: l1}>>' but is connected to '!moore.ref<l2>'}}
+  Foo foo(y);
+endmodule


### PR DESCRIPTION
IEEE 1800-2017 §23.3.3 models an `inout` port connection as a direct electrical connection rather than a continuous assignment, so unlike `input`/`output` ports it defines no implicit conversion between the port and the connected signal. Require an exact type match for inout port connections and emit a clear diagnostic instead of falling through to the generic (and confusingly worded) conversion error.

Add errors.sv cases covering a width mismatch and a packed struct connected to a same-size bit vector.

Assisted-by: Claude Sonnet 5