### PR TITLE
[ImportVerilog] Fix lvalue conversion for output/inout/ref arguments

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -2066,9 +2066,19 @@ struct RvalueExprVisitor : public ExprVisitor {
     }
 
     // Convert the call arguments. Input arguments are converted to an rvalue.
-    // All other arguments are converted to lvalues and passed into the function
-    // by reference.
+    // All other arguments are converted to lvalues and passed into the
+    // function by reference. If a call argument's type doesn't match the
+    // declared argument's type, `output` and `inout` arguments are instead
+    // routed through a local temporary of the declared type, converting on
+    // copy-in and copy-out. See IEEE 1800-2017 §13.5 and §4.9.7.
+    struct Writeback {
+      Value temp;
+      Value lvalue;
+      bool declIsSigned;
+    };
+    SmallVector<Writeback> writebacks;
     SmallVector<Value> arguments;
+
     for (auto [callArg, declArg] :
          llvm::zip(expr.arguments(), subroutine->getArguments())) {
 
@@ -2084,12 +2094,39 @@ struct RvalueExprVisitor : public ExprVisitor {
         value = context.convertRvalueExpression(*expr, type);
       } else {
         Value lvalue = context.convertLvalueExpression(*expr);
+        if (!lvalue)
+          return {};
         auto unpackedType = dyn_cast<moore::UnpackedType>(type);
         if (!unpackedType)
           return {};
-        value =
-            context.materializeConversion(moore::RefType::get(unpackedType),
-                                          lvalue, expr->type->isSigned(), loc);
+        auto refType = moore::RefType::get(unpackedType);
+
+        if (declArg->direction == slang::ast::ArgumentDirection::Ref) {
+          // Since we can't really cast ref types, reject any ref argument
+          // whose call argument doesn't match the declared argument's type
+          // exactly.
+          if (lvalue.getType() != refType) {
+            mlir::emitError(loc)
+                << "ref argument `" << declArg->name << "` expects " << refType
+                << " but call provides " << lvalue.getType();
+            return {};
+          }
+          value = lvalue;
+        } else if (lvalue.getType() == refType) {
+          value = lvalue;
+        } else {
+          Value copyIn;
+          if (declArg->direction == slang::ast::ArgumentDirection::InOut) {
+            copyIn = moore::ReadOp::create(builder, loc, lvalue);
+            copyIn = context.materializeConversion(unpackedType, copyIn,
+                                                   expr->type->isSigned(), loc);
+            if (!copyIn)
+              return {};
+          }
+          value = moore::VariableOp::create(builder, loc, refType, StringAttr{},
+                                            copyIn);
+          writebacks.push_back({value, lvalue, declArg->getType().isSigned()});
+        }
       }
       if (!value)
         return {};
@@ -2131,6 +2168,19 @@ struct RvalueExprVisitor : public ExprVisitor {
       // Free function -> func.call
       auto funcOp = cast<mlir::func::FuncOp>(lowering->op.getOperation());
       callOp = mlir::func::CallOp::create(builder, loc, funcOp, arguments);
+    }
+
+    // Copy output/inout arguments that were routed through a temporary back
+    // to their call argument now that the call has returned.
+    for (auto &writeback : writebacks) {
+      Value rvalue = moore::ReadOp::create(builder, loc, writeback.temp);
+      auto dstType =
+          cast<moore::RefType>(writeback.lvalue.getType()).getNestedType();
+      rvalue = context.materializeConversion(dstType, rvalue,
+                                             writeback.declIsSigned, loc);
+      if (!rvalue)
+        return {};
+      moore::BlockingAssignOp::create(builder, loc, writeback.lvalue, rvalue);
     }
 
     auto result = resultTypes.size() > 0 ? callOp->getOpResult(0) : Value{};

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -392,3 +392,16 @@ module Bar;
   // expected-error @below {{inout port `p` expects '!moore.ref<struct<{x: l1, y: l1}>>' but is connected to '!moore.ref<l2>'}}
   Foo foo(y);
 endmodule
+
+// -----
+
+typedef struct packed { bit x; bit y; } Pair;
+
+function automatic void useRef(ref Pair p);
+endfunction
+
+module Foo;
+  bit [1:0] z;
+  // expected-error @below {{ref argument `p` expects '!moore.ref<struct<{x: i1, y: i1}>>' but call provides '!moore.ref<i2>'}}
+  initial useRef(z);
+endmodule

--- a/test/Conversion/ImportVerilog/lvalue-conversion.sv
+++ b/test/Conversion/ImportVerilog/lvalue-conversion.sv
@@ -1,0 +1,55 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+function void funcInout(inout longint wideArg);
+endfunction
+
+function void funcOutput(output longint wideArg);
+endfunction
+
+task taskInout(inout longint wideArg);
+endtask
+
+task taskOutput(output longint wideArg);
+endtask
+
+// CHECK-LABEL: moore.module @LvalueConversions()
+module LvalueConversions;
+  real r;
+  initial begin
+    // CHECK: [[IN0:%.+]] = moore.read %r : <f64>
+    // CHECK: [[CVT0:%.+]] = moore.real_to_int [[IN0]] : f64 -> i64
+    // CHECK: [[TMP0:%.+]] = moore.variable [[CVT0]] : <i64>
+    // CHECK: func.call @funcInout([[TMP0]])
+    // CHECK: [[OUT0:%.+]] = moore.read [[TMP0]] : <i64>
+    // CHECK: [[CVT1:%.+]] = moore.sint_to_real [[OUT0]] : i64 -> f64
+    // CHECK: moore.blocking_assign %r, [[CVT1]] : f64
+    funcInout(r);
+
+    // CHECK: [[TMP1:%.+]] = moore.variable : <i64>
+    // CHECK: func.call @funcOutput([[TMP1]])
+    // CHECK: [[OUT1:%.+]] = moore.read [[TMP1]] : <i64>
+    // CHECK: [[CVT2:%.+]] = moore.sint_to_real [[OUT1]] : i64 -> f64
+    // CHECK: moore.blocking_assign %r, [[CVT2]] : f64
+    funcOutput(r);
+
+    // CHECK: [[IN1:%.+]] = moore.read %r : <f64>
+    // CHECK: [[CVT3:%.+]] = moore.real_to_int [[IN1]] : f64 -> i64
+    // CHECK: [[TMP2:%.+]] = moore.variable [[CVT3]] : <i64>
+    // CHECK: moore.call_coroutine @taskInout([[TMP2]])
+    // CHECK: [[OUT2:%.+]] = moore.read [[TMP2]] : <i64>
+    // CHECK: [[CVT4:%.+]] = moore.sint_to_real [[OUT2]] : i64 -> f64
+    // CHECK: moore.blocking_assign %r, [[CVT4]] : f64
+    taskInout(r);
+
+    // CHECK: [[TMP3:%.+]] = moore.variable : <i64>
+    // CHECK: moore.call_coroutine @taskOutput([[TMP3]])
+    // CHECK: [[OUT3:%.+]] = moore.read [[TMP3]] : <i64>
+    // CHECK: [[CVT5:%.+]] = moore.sint_to_real [[OUT3]] : i64 -> f64
+    // CHECK: moore.blocking_assign %r, [[CVT5]] : f64
+    taskOutput(r);
+  end
+endmodule


### PR DESCRIPTION
Calling a task or function with an output, inout, or ref argument whose call argument's type doesn't exactly match the declared argument's type used to fail with "unsupported conversion", since materializeConversion has no notion of converting between two ref types directly.

For output and inout arguments, route a mismatched call argument through a local temporary of the declared type instead: copy the converted call argument in before the call for inout (output only copies out), pass the temporary by reference, then convert and blocking-assign it back to the call argument once the call returns. Per IEEE 1800-2017 §13.5 this copy-out happens exactly once, at the point the call returns, and per §4.9.7 it "behaves in the same manner as does any blocking assignment" -- mirroring how mismatched instance output ports are already handled.

Ref arguments require an equivalent type per §13.5.2, so no casting is attempted there; a mismatch (which Slang can still let through, e.g. a packed struct and same-size bit vector) is rejected with a dedicated diagnostic instead, matching the existing inout port rejection.

Assisted-by: Claude Sonnet 5