### PR TITLE
[OM] Fix untracked op mutation

### DIFF
--- a/lib/Dialect/OM/Transforms/ElaborateObject.cpp
+++ b/lib/Dialect/OM/Transforms/ElaborateObject.cpp
@@ -84,9 +84,16 @@ struct ObjectOpInliningPattern : public OpRewritePattern<ObjectOp> {
     // Propagate the class's per-field locations onto each field value, fused
     // with the value's existing location.
     if (auto classOp = dyn_cast<ClassOp>(classLike.getOperation()))
-      for (auto [i, v] : llvm::enumerate(fieldValues))
-        v.setLoc(
-            rewriter.getFusedLoc({classOp.getFieldLocByIndex(i), v.getLoc()}));
+      for (auto [i, v] : llvm::enumerate(fieldValues)) {
+        Location fieldLoc =
+            rewriter.getFusedLoc({classOp.getFieldLocByIndex(i), v.getLoc()});
+        if (auto *fieldOp = v.getDefiningOp())
+          rewriter.modifyOpInPlace(fieldOp, [&] { fieldOp->setLoc(fieldLoc); });
+        else
+          rewriter.modifyOpInPlace(
+              cast<BlockArgument>(v).getOwner()->getParentOp(),
+              [&] { v.setLoc(fieldLoc); });
+      }
 
     // Erase the terminator and inline the body at the object instantiation.
     rewriter.eraseOp(clonedFields);


### PR DESCRIPTION
Update locations on cloned field values through PatternRewriter APIs, including block arguments, so greedy rewrite bookkeeping remains valid when expensive pattern checks are enabled.

Assited-by: pi.dev: gpt 5.6 luna

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
