### PR TITLE
[OM] Avoid full module verification in release builds

### DIFF
--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -162,8 +162,16 @@ ScratchIRBuilder::run(ArrayRef<EvaluatorValuePtr> actualParams) {
            .getResult()},
       {builder.getStringAttr("root")});
 
+#ifdef NDEBUG
+  // Verifying the entire module is expensive, so verify only the wrapper in
+  // release builds.
+  if (failed(verify(wrapperClass)))
+    return failure();
+#else
+  // Verify the entire module in debug builds.
   if (failed(verify(module)))
     return failure();
+#endif
 
   PassManager pm(ctx);
   ElaborateObjectOptions options;

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -162,23 +162,24 @@ ScratchIRBuilder::run(ArrayRef<EvaluatorValuePtr> actualParams) {
            .getResult()},
       {builder.getStringAttr("root")});
 
+  PassManager pm(ctx);
 #ifdef NDEBUG
   // Verifying the entire module is expensive, so verify only the wrapper in
   // release builds.
   if (failed(verify(wrapperClass)))
     return failure();
+  pm.enableVerifier(false);
 #else
   // Verify the entire module in debug builds.
   if (failed(verify(module)))
     return failure();
 #endif
 
-  PassManager pm(ctx);
   ElaborateObjectOptions options;
   auto wrapperName = wrapperClass.getSymNameAttr();
   options.targetClass = wrapperName.getValue().str();
   pm.addPass(createElaborateObject(std::move(options)));
-  if (failed(pm.run(module)))
+  if (failed(pm.run(module)) || failed(verify(wrapperClass)))
     return failure();
 
   return InstantiationInfo{wrapperName, std::move(wrapperActualParams)};


### PR DESCRIPTION
In release builds (NDEBUG), skip full module verification in ScratchIRBuilder::run and only verify wrapperClass to improve evaluation performance. Debug builds retain full module verification.

Assisted-by: pi.dev: gpt 5.6 luna
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
