### PR TITLE
[circt-synth] Detect Signed Squarer

### DIFF
--- a/lib/Dialect/Datapath/DatapathFolds.cpp
+++ b/lib/Dialect/Datapath/DatapathFolds.cpp
@@ -472,7 +472,8 @@ struct SignedPartialProducts : public OpRewritePattern<PartialProductOp> {
   LogicalResult matchAndRewrite(PartialProductOp op,
                                 PatternRewriter &rewriter) const override {
     // Booth encoding will automatically handle signed multiplications
-    if (comb::shouldUseBoothEncoding(op.getLhs(), op.getRhs()))
+    auto isSquarer = op.getLhs() == op.getRhs();
+    if (comb::shouldUseBoothEncoding(op.getLhs(), op.getRhs()) && !isSquarer)
       return failure();
 
     auto inputWidth = op.getLhs().getType().getIntOrFloatBitWidth();

--- a/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
+++ b/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
@@ -66,7 +66,6 @@ void circt::synth::buildCombLoweringPipeline(
       // Incrementally lower - first lower partial product operations
       pm.addPass(createConvertDatapathToComb(datapathOptions));
       pm.addPass(createSimpleCanonicalizerPass());
-      
       datapathOptions.lowerCompress = true;
       // Then lower compress operations after canononicalization to reduce the
       // number of compress operations.

--- a/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
+++ b/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
@@ -57,6 +57,7 @@ void circt::synth::buildCombLoweringPipeline(
       pm.addPass(createLowerVariadicPass<comb::MulOp>(options.timingAware));
       pm.addPass(createConvertCombToDatapath());
       pm.addPass(createSimpleCanonicalizerPass());
+      pm.addPass(createCSEPass());  
       if (options.synthesisStrategy == OptimizationStrategyTiming)
         pm.addPass(datapath::createDatapathReduceDelay());
       circt::ConvertDatapathToCombOptions datapathOptions;
@@ -65,6 +66,7 @@ void circt::synth::buildCombLoweringPipeline(
       // Incrementally lower - first lower partial product operations
       pm.addPass(createConvertDatapathToComb(datapathOptions));
       pm.addPass(createSimpleCanonicalizerPass());
+      
       datapathOptions.lowerCompress = true;
       // Then lower compress operations after canononicalization to reduce the
       // number of compress operations.

--- a/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
+++ b/lib/Dialect/Synth/Transforms/SynthesisPipeline.cpp
@@ -57,7 +57,7 @@ void circt::synth::buildCombLoweringPipeline(
       pm.addPass(createLowerVariadicPass<comb::MulOp>(options.timingAware));
       pm.addPass(createConvertCombToDatapath());
       pm.addPass(createSimpleCanonicalizerPass());
-      pm.addPass(createCSEPass());  
+      pm.addPass(createCSEPass());
       if (options.synthesisStrategy == OptimizationStrategyTiming)
         pm.addPass(datapath::createDatapathReduceDelay());
       circt::ConvertDatapathToCombOptions datapathOptions;


### PR DESCRIPTION
Currently we only support a standard AND array that has been optimized for a squarer (i.e. x*x). Therefore we should trigger all optimizations that apply to an AND array - specifically SignedPartialProduct.

To improve recognition of squarers add a CSE pass before lowering the partial products to trigger squarer lowering.

These changes improve the SqrSgn benchmark!
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
