### PR TITLE
[ESI] Pipeline the ChannelArbiter selection mux in the BSP hostmem paths

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -1515,11 +1515,15 @@ def HostmemReadProcessor(
       # list-aware, pipelined ChannelArbiter (vs. the combinational ChannelMux)
       # for a registered N:1 mux that closes timing at high client fan-in. Read
       # requests are single-flit, so list-awareness is a no-op here.
+      # `mux_pipeline_levels=2` retimes the wide payload selection mux, whose
+      # depth otherwise grows as log2(num_clients); the added latency is
+      # absorbed by the arbiter's output FIFO / credit counter.
       # TODO: Don't release a request until the client is ready to accept
       # the response otherwise the system could deadlock.
       muxed_client_reqs = ChannelArbiter(tagged_client_reqs,
                                          ports.clk,
                                          ports.rst,
+                                         mux_pipeline_levels=2,
                                          telemetry=False)
       upstream_req_channel.assign(muxed_client_reqs)
       HostmemReadProcessorImpl.reqPortMap.clear()
@@ -1899,9 +1903,13 @@ def HostMemWriteProcessor(
       # awareness -- via the frame's 'last' -- to keep a client's words
       # contiguous; single-word (<= engine width) clients emit one message per
       # word, for which single-flit arbitration is correct.
+      # `mux_pipeline_levels=2` retimes the (wide -- a full engine word plus
+      # address) payload selection mux; the added latency is absorbed by the
+      # arbiter's output FIFO / credit counter.
       muxed_write_channel = ChannelArbiter(write_channels,
                                            ports.clk,
                                            ports.rst,
+                                           mux_pipeline_levels=2,
                                            telemetry=False)
       upstream_req_channel.assign(muxed_write_channel)
 

--- a/lib/Dialect/ESI/runtime/tests/integration/hw/channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/hw/channel_arbiter.py
@@ -41,6 +41,14 @@ ODD_NUM_INPUTS = 3  # non-power-of-two ("unbalanced") input count.
 PIPE_NUM_INPUTS = 6  # input count for the pipelined-mux-tree variant.
 TOKEN_NUM_INPUTS = 5  # input count for the zero-width (i0) token variant.
 TOKENS_PER_INPUT = 8  # tokens each producer emits in the token test.
+# A fan-in wide enough to exercise large-N arbitration. The BSP instantiates
+# arbiters with ~31 inputs (one per host-memory write client), a regime none of
+# the small counts above reach.
+WIDE_NUM_INPUTS = 13
+# Sustained-throughput probe: enough inputs to make a per-message turnaround
+# cycle clearly visible, while keeping simulation time short.
+THROUGHPUT_NUM_INPUTS = 4
+THROUGHPUT_WINDOW = 1000  # measurement window, in cycles.
 
 # A list-window payload: a struct with a `src` tag and a variable-length list.
 # `Window.default_of` adds a per-flit `last` field to the lowered frame struct,
@@ -266,6 +274,77 @@ class ChannelArbiterTokenTest(Module):
     esi.ChannelService.to_host(AppID("token_report"), chk.report)
 
 
+def AlwaysValidProducer(tag: int):
+  """Never idles: `valid` is tied high, so the only thing limiting the
+  arbiter's delivery rate is the arbiter itself."""
+
+  class AlwaysValidProducer(Module):
+    clk = Clock()
+    rst = Reset()
+    out = Output(Channel(UInt(32)))
+
+    @generator
+    def build(ports):
+      chan, _ready = Channel(UInt(32)).wrap(UInt(32)(tag), Bits(1)(1))
+      ports.out = chan
+
+  AlwaysValidProducer.__name__ = f"AlwaysValidProducer_{tag}"
+  return AlwaysValidProducer
+
+
+class ThroughputProbe(Module):
+  """Drains the arbiter at full rate (`ready` tied high, so the host can never
+  backpressure it) and counts delivered beats over a fixed cycle window. Holds
+  the tally on its report channel once the window closes.
+
+  Draining in hardware is the point: the host-driven tests are rate-limited by
+  the cosim DPI, so they cannot observe sustained throughput at all."""
+
+  clk = Clock()
+  rst = Reset()
+  in_ = Input(Channel(UInt(32)))
+  report = Output(Channel(UInt(32)))
+
+  @generator
+  def build(ports):
+    _data, valid = ports.in_.unwrap(Bits(1)(1))  # never backpressure.
+    cycles = Counter(32)(clk=ports.clk,
+                         rst=ports.rst,
+                         clear=Bits(1)(0),
+                         increment=Bits(1)(1))
+    running = cycles.out < UInt(32)(THROUGHPUT_WINDOW)
+    beats = Counter(32)(clk=ports.clk,
+                        rst=ports.rst,
+                        clear=Bits(1)(0),
+                        increment=valid & running)
+    # Report only once the window has closed; the value is then stable, so the
+    # host can read it whenever it gets around to it.
+    chan, _ready = Channel(UInt(32)).wrap(beats.out, ~running)
+    ports.report = chan
+
+
+class ChannelArbiterThroughputTest(Module):
+  """`THROUGHPUT_NUM_INPUTS` never-idle producers -> arbiter -> throughput
+  probe. Pins the arbiter's sustained delivery rate, which correctness tests
+  cannot observe."""
+
+  clk = Clock()
+  rst = Reset()
+
+  @generator
+  def build(ports):
+    prods = [
+        AlwaysValidProducer(i)(clk=ports.clk, rst=ports.rst)
+        for i in range(THROUGHPUT_NUM_INPUTS)
+    ]
+    muxed = ChannelArbiter([p.out for p in prods],
+                           ports.clk,
+                           ports.rst,
+                           telemetry=False)
+    probe = ThroughputProbe(clk=ports.clk, rst=ports.rst, in_=muxed)
+    esi.ChannelService.to_host(AppID("throughput_report"), probe.report)
+
+
 class Top(Module):
   clk = Clock()
   rst = Reset()
@@ -285,9 +364,15 @@ class Top(Module):
     ChannelArbiterListTest(clk=ports.clk,
                            rst=ports.rst,
                            appid=AppID("list_test"))
+    HostMux(WIDE_NUM_INPUTS)(clk=ports.clk,
+                             rst=ports.rst,
+                             appid=AppID("arbiter_test_wide"))
     ChannelArbiterTokenTest(clk=ports.clk,
                             rst=ports.rst,
                             appid=AppID("token_test"))
+    ChannelArbiterThroughputTest(clk=ports.clk,
+                                 rst=ports.rst,
+                                 appid=AppID("throughput_test"))
 
 
 if __name__ == "__main__":

--- a/lib/Dialect/ESI/runtime/tests/integration/test_channel_arbiter.py
+++ b/lib/Dialect/ESI/runtime/tests/integration/test_channel_arbiter.py
@@ -38,6 +38,9 @@ ODD_NUM_INPUTS = 3  # non-power-of-two ("unbalanced") input count.
 PIPE_NUM_INPUTS = 6  # input count for the pipelined-mux-tree variant.
 TOKEN_NUM_INPUTS = 5  # input count for the zero-width (i0) token variant.
 TOKENS_PER_INPUT = 8  # tokens each producer emits in the token test.
+WIDE_NUM_INPUTS = 13  # must match hw/channel_arbiter.py.
+THROUGHPUT_NUM_INPUTS = 4  # must match hw/channel_arbiter.py.
+THROUGHPUT_WINDOW = 1000  # measurement window in cycles; must match hw.
 
 
 def _check_mux(conn: AcceleratorConnection, dut_name: str,
@@ -140,3 +143,25 @@ class TestChannelArbiterCosim:
       value = report.read().result()
       assert value == expected, \
           f"token {expected} arrived as {value} (loss / duplication / reorder)"
+
+  def test_mux_correctness_wide(self, conn: AcceleratorConnection) -> None:
+    """Wide fan-in: the small counts above are far below what the BSP
+    instantiates, and the selection mux depth grows with the input count."""
+    _check_mux(conn, "arbiter_test_wide", WIDE_NUM_INPUTS)
+
+  def test_throughput(self, conn: AcceleratorConnection) -> None:
+    """The arbiter sustains ~one beat per cycle with every input backlogged.
+
+    Correctness tests cannot see this: they are rate-limited by the cosim DPI,
+    so a per-message turnaround bubble would pass them unnoticed. The probe
+    drains the arbiter in hardware instead."""
+    acc = conn.build_accelerator()
+    dut = acc.children[esiaccel.AppID("throughput_test")]
+    report = dut.ports[esiaccel.AppID("throughput_report")]
+    report.connect()
+
+    beats = report.read().result()
+    throughput = beats / THROUGHPUT_WINDOW
+    # Allow for pipeline fill at the start of the window.
+    assert throughput >= 0.95, (f"{beats} beats in {THROUGHPUT_WINDOW} cycles "
+                                f"({throughput:.3f}/cycle); expected >= 0.95")


### PR DESCRIPTION
(Note: description is AI generated and human reviewed.)

## What

Two small things, both scoped to the BSP's hostmem arbiters:

1. Pass `mux_pipeline_levels=2` at the two `ChannelArbiter` call sites in
   `HostmemReadProcessor` and `HostMemWriteProcessor`.
2. Add test coverage for two regimes the existing arbiter tests do not reach.

`mux_pipeline_levels` is an existing `ChannelArbiter` parameter — this only
starts using it where the fan-in warrants it. No new API, no behaviour change.

## Why

Those two arbiters multiplex one client per engine — around 31 in the
configurations the BSP builds. The N:1 payload selection mux is correspondingly
wide (a full engine word plus address on the write side) and its depth grows as
`log2(num_clients)`, so it is one of the deeper combinational structures in the
path. `mux_pipeline_levels=2` builds it as an explicit binary tree with a
register every two levels.

The added latency is absorbed by the arbiter's existing output FIFO and credit
counter, so there is no throughput cost, no protocol change, and nothing for
callers to reason about.

Measured on an internal build of esitester, this was part of the single largest
step in a sequence of timing fixes — bundled in that measurement with the
`ChannelMMIO` response-merge change (#11012), so the two are not separated. The
step improved role-clock fmax by roughly 11%.

## Testing

Both additions target things the existing tests structurally cannot catch:

- **Wide fan-in** (`arbiter_test_wide`). The existing mux tests use 3, 4 and 6
  inputs, far below what the BSP instantiates, and selection-mux depth only
  starts to matter well above that. Asserts the usual exactly-once delivery and
  that every input is served.

- **Sustained throughput** (`throughput_test`). The host-driven tests are
  rate-limited by the cosim DPI, so they cannot observe delivery rate at all —
  an arbiter that lost a cycle per message would pass every one of them. This
  keeps every input backlogged, drains the output in hardware with `ready` tied
  high, and counts delivered beats over a fixed window.

  This is not hypothetical: the throughput probe was written because a control
  change under review did exactly that, and no correctness test noticed.

Full ESI runtime suite passes.

---

Assisted-by: GitHub Copilot CLI
