### PR TITLE
[ImportVerilog] Support enum next, prev, name methods

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3385,6 +3385,186 @@ emitScanAssignments(Context &context, const Context::ScanStringResult &result,
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// Enum Built-in Method Helpers
+//===----------------------------------------------------------------------===//
+
+/// The `next`, `prev`, and `name` built-in methods on enums have to locate the
+/// value they are called on in the list of enumerands at runtime. Slang folds
+/// these calls away wherever the value is constant, so what remains are the
+/// cases that require an actual computation. Instead of inlining that
+/// computation at every call site, we emit one helper function per enum type
+/// and method, and turn the calls into plain function calls.
+///
+/// All helpers start with a chain of blocks that compares the value against
+/// each enumerand in turn. A match branches to a common match block, carrying
+/// what the comparison found along as a block argument. Running off the end of
+/// the chain means the value is not a member of the enumeration, in which case
+/// `name` returns an empty string and `next`/`prev` return the enum's default
+/// value, as mandated by IEEE 1800-2023 § 6.19.5.
+///
+/// For `name` the block argument is the enumerand's name, which the match block
+/// simply returns. For `next` and `prev` it is the position of the value among
+/// the enumerands. The match block offsets that position by the step count,
+/// which is only known at runtime, wraps it around at both ends of the
+/// enumerand list, and uses it to index an array of all enumerand values.
+mlir::func::FuncOp
+Context::getOrCreateEnumHelper(const slang::ast::Type &type,
+                               slang::parsing::KnownSystemName method,
+                               Location loc) {
+  using ksn = slang::parsing::KnownSystemName;
+  const auto &enumType = type.getCanonicalType().as<slang::ast::EnumType>();
+  auto &slot = enumHelpers[{&enumType, method}];
+  if (slot)
+    return slot;
+  bool isName = method == ksn::Name;
+
+  // Determine the types involved before creating any IR, such that failures do
+  // not leave a half-built function behind.
+  auto valueType = dyn_cast_or_null<moore::PackedType>(convertType(enumType));
+  if (!valueType)
+    return {};
+  auto posType = moore::IntType::getInt(getContext(), 32);
+  auto resultType =
+      isName ? Type(moore::StringType::get(getContext())) : Type(valueType);
+
+  // Pick an insertion point for this helper according to the source file
+  // location of the enum declaration.
+  OpBuilder::InsertionGuard guard(builder);
+  auto locationKey = LocationKey::get(enumType.location, sourceManager);
+  auto it = orderedRootOps.upper_bound(locationKey);
+  if (it == orderedRootOps.end())
+    builder.setInsertionPointToEnd(intoModuleOp.getBody());
+  else
+    builder.setInsertionPoint(it->second);
+  auto helperLoc = convertLocation(enumType.location);
+
+  // Name the helper after the method and the name the enum was declared under,
+  // if any. The symbol table uniquifies the name when the function is inserted.
+  StringRef typeName = type.name;
+  auto helperName = StringAttr::get(
+      getContext(), Twine("enum.") + slang::parsing::toString(method) + "." +
+                        (typeName.empty() ? "anon" : typeName));
+
+  SmallVector<Type> argTypes{valueType};
+  if (!isName)
+    argTypes.push_back(posType); // add the step count argument
+  auto funcOp =
+      mlir::func::FuncOp::create(builder, helperLoc, helperName,
+                                 builder.getFunctionType(argTypes, resultType));
+  SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
+
+  orderedRootOps.insert(it, {locationKey, funcOp});
+  symbolTable.insert(funcOp);
+  slot = funcOp;
+
+  // Materialize the enumerand values in the entry block, where they dominate
+  // both the comparison chain and the lookup table below.
+  auto &bodyRegion = funcOp.getBody();
+  auto *entryBlock = funcOp.addEntryBlock();
+  auto value = entryBlock->getArgument(0);
+  builder.setInsertionPointToEnd(entryBlock);
+  SmallVector<Value> enumerandValues;
+  for (const auto &enumerand : enumType.values()) {
+    auto constant = materializeSVInt(enumerand.getValue().integer(), enumType,
+                                     convertLocation(enumerand.location));
+    if (!constant)
+      return {};
+    enumerandValues.push_back(constant);
+  }
+
+  // Assemble the array that maps a position among the enumerands back to the
+  // corresponding value. Array elements are listed starting at the highest
+  // index, so the values go in reverse.
+  Value table;
+  if (!isName) {
+    auto tableType = moore::ArrayType::get(enumerandValues.size(), valueType);
+    table = moore::ArrayCreateOp::create(
+        builder, helperLoc, tableType,
+        SmallVector<Value>(llvm::reverse(enumerandValues)));
+  }
+
+  // Create the block that the comparison chain hands its findings to. For
+  // `name` this simply returns the name it is handed; for `next` and `prev` it
+  // receives the position of the value among the enumerands and computes the
+  // result from it.
+  auto *matchBlock = &bodyRegion.emplaceBlock();
+  matchBlock->addArgument(isName ? resultType : Type(posType), helperLoc);
+
+  // Compare the value against each enumerand in turn. A match hands over the
+  // enumerand's name for `name`, and its position for `next` and `prev`.
+  for (auto [position, enumerand] : llvm::enumerate(enumType.values())) {
+    auto enumerandLoc = convertLocation(enumerand.location);
+    auto matches = moore::CaseEqOp::create(builder, enumerandLoc, value,
+                                           enumerandValues[position]);
+    auto condition =
+        moore::ToBuiltinIntOp::create(builder, enumerandLoc, matches);
+
+    Value matchResult;
+    if (isName) {
+      auto intType =
+          moore::IntType::getInt(getContext(), enumerand.name.size() * 8);
+      auto bytes = moore::ConstantStringOp::create(builder, enumerandLoc,
+                                                   intType, enumerand.name);
+      matchResult = moore::IntToStringOp::create(builder, enumerandLoc, bytes);
+    } else {
+      matchResult = moore::ConstantOp::create(builder, enumerandLoc, posType,
+                                              static_cast<int64_t>(position));
+    }
+
+    auto *mismatchBlock = &bodyRegion.emplaceBlock();
+    mlir::cf::CondBranchOp::create(builder, enumerandLoc, condition, matchBlock,
+                                   ValueRange{matchResult}, mismatchBlock,
+                                   ValueRange{});
+    builder.setInsertionPointToEnd(mismatchBlock);
+  }
+
+  // Control reaches here if the value is not a member of the enumeration.
+  // `name` hands the empty string to the match block alongside the names from
+  // the comparison chain, while `next` and `prev` return the enum's default
+  // value directly.
+  if (isName) {
+    auto intType = moore::IntType::getInt(getContext(), 0);
+    auto bytes =
+        moore::ConstantStringOp::create(builder, helperLoc, intType, "");
+    Value empty = moore::IntToStringOp::create(builder, helperLoc, bytes);
+    mlir::cf::BranchOp::create(builder, helperLoc, matchBlock, empty);
+  } else {
+    auto fallback =
+        materializeConstant(enumType.getDefaultValue(), enumType, helperLoc);
+    if (!fallback)
+      return {};
+    mlir::func::ReturnOp::create(builder, helperLoc, fallback);
+  }
+
+  builder.setInsertionPointToEnd(matchBlock);
+  Value result = matchBlock->getArgument(0);
+  if (!isName) {
+    // Offset the position of the value by the step count, wrapping around at
+    // both ends of the enumerand list, and look the resulting position up in
+    // the table. The step count is reduced modulo the number of enumerands
+    // first, such that the offsetting cannot overflow.
+    Value numValues =
+        moore::ConstantOp::create(builder, helperLoc, posType,
+                                  static_cast<int64_t>(enumerandValues.size()));
+    Value step = moore::ModUOp::create(builder, helperLoc,
+                                       funcOp.getArgument(1), numValues);
+    if (method == ksn::Prev)
+      step = moore::SubOp::create(builder, helperLoc, numValues, step);
+    Value offset = moore::AddOp::create(builder, helperLoc, result, step);
+    Value position =
+        moore::ModUOp::create(builder, helperLoc, offset, numValues);
+    result = moore::DynExtractOp::create(builder, helperLoc, valueType, table,
+                                         position);
+  }
+  mlir::func::ReturnOp::create(builder, helperLoc, result);
+
+  // Move the match block past the comparison chain such that the blocks in the
+  // finished function appear in execution order.
+  matchBlock->moveBefore(&bodyRegion, bodyRegion.end());
+  return funcOp;
+}
+
 Value Context::convertSystemCall(
     const slang::ast::SystemSubroutine &subroutine, Location loc,
     std::span<const slang::ast::Expression *const> args) {
@@ -3902,30 +4082,23 @@ Value Context::convertSystemCall(
     return moore::AssocArrayExistsOp::create(builder, loc, array, key);
   }
 
-  // Associative array traversal methods (all take 2 arguments: array ref, key
-  // ref). These names are shared with enum built-in methods (next/prev/first/
-  // last), which take 1 or 2 arguments. Only handle the associative array case
-  // here; fall through to the unsupported diagnostic for other types.
-  if (nameId == ksn::First || nameId == ksn::Last || nameId == ksn::Next ||
-      nameId == ksn::Prev) {
-    if (args[0]->type->isAssociativeArray()) {
-      assert(numArgs == 2 && "traversal methods take 2 arguments");
-      auto array = convertLvalueExpression(*args[0]);
-      auto key = convertLvalueExpression(*args[1]);
-      if (!array || !key)
-        return {};
-      if (nameId == ksn::First)
-        return moore::AssocArrayFirstOp::create(builder, loc, array, key);
-      if (nameId == ksn::Last)
-        return moore::AssocArrayLastOp::create(builder, loc, array, key);
-      if (nameId == ksn::Next)
-        return moore::AssocArrayNextOp::create(builder, loc, array, key);
-      if (nameId == ksn::Prev)
-        return moore::AssocArrayPrevOp::create(builder, loc, array, key);
-      llvm_unreachable("all traversal cases handled above");
-    }
-    emitError(loc) << "unsupported system call `" << name << "`";
-    return {};
+  if ((nameId == ksn::First || nameId == ksn::Last || nameId == ksn::Next ||
+       nameId == ksn::Prev) &&
+      args[0]->type->isAssociativeArray()) {
+    assert(numArgs == 2 && "traversal methods take 2 arguments");
+    auto array = convertLvalueExpression(*args[0]);
+    auto key = convertLvalueExpression(*args[1]);
+    if (!array || !key)
+      return {};
+    if (nameId == ksn::First)
+      return moore::AssocArrayFirstOp::create(builder, loc, array, key);
+    if (nameId == ksn::Last)
+      return moore::AssocArrayLastOp::create(builder, loc, array, key);
+    if (nameId == ksn::Next)
+      return moore::AssocArrayNextOp::create(builder, loc, array, key);
+    if (nameId == ksn::Prev)
+      return moore::AssocArrayPrevOp::create(builder, loc, array, key);
+    llvm_unreachable("all traversal cases handled above");
   }
 
   //===--------------------------------------------------------------------===//
@@ -4058,6 +4231,50 @@ Value Context::convertSystemCall(
       return {};
     return moore::ScanEndOp::create(builder, loc, result->finalCursor)
         .getCount();
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Enum Methods
+  //===--------------------------------------------------------------------===//
+
+  // `first`, `last`, and `num` are already folded to a constant by Slang.
+  assert(!(nameId == ksn::First || nameId == ksn::Last || nameId == ksn::Num) ||
+         !args[0]->type->isEnum());
+
+  if (nameId == ksn::Name && args[0]->type->isEnum()) {
+    assert(numArgs == 1 && "`name` takes 1 argument");
+    auto value = convertRvalueExpression(*args[0]);
+    if (!value)
+      return {};
+    auto helper = getOrCreateEnumHelper(*args[0]->type, nameId, loc);
+    if (!helper)
+      return {};
+    return mlir::func::CallOp::create(builder, loc, helper, ValueRange{value})
+        .getResult(0);
+  }
+
+  if ((nameId == ksn::Next || nameId == ksn::Prev) && args[0]->type->isEnum()) {
+    assert(numArgs >= 1 && numArgs <= 2 && "`next`/`prev` take 1 or 2 args");
+    auto value = convertRvalueExpression(*args[0]);
+    if (!value)
+      return {};
+
+    // The step count defaults to 1 if it is not given explicitly.
+    auto posType = moore::IntType::getInt(getContext(), 32);
+    Value count;
+    if (numArgs == 2)
+      count = convertRvalueExpression(*args[1], posType);
+    else
+      count = moore::ConstantOp::create(builder, loc, posType, 1);
+    if (!count)
+      return {};
+
+    auto helper = getOrCreateEnumHelper(*args[0]->type, nameId, loc);
+    if (!helper)
+      return {};
+    return mlir::func::CallOp::create(builder, loc, helper,
+                                      ValueRange{value, count})
+        .getResult(0);
   }
 
   // Unrecognized system call

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -263,6 +263,13 @@ struct Context {
   LogicalResult materializeClassMethods(const slang::ast::ClassType &classdecl);
   LogicalResult convertGlobalVariable(const slang::ast::VariableSymbol &var);
 
+  /// Get the helper function implementing one of the `name`, `next`, and `prev`
+  /// built-in methods for the given enum type, creating it on first use.
+  /// Returns null and emits an error if the helper cannot be created.
+  mlir::func::FuncOp
+  getOrCreateEnumHelper(const slang::ast::Type &type,
+                        slang::parsing::KnownSystemName method, Location loc);
+
   /// Convert a Slang virtual interface type into the Moore type used to
   /// represent virtual interface handles. Populates internal caches so that
   /// interface instance references can be materialized consistently.
@@ -524,6 +531,13 @@ struct Context {
 
   /// DPI-C export directives keyed by the SystemVerilog subroutine they expose.
   DenseMap<const slang::ast::SubroutineSymbol *, std::string> dpiExportCNames;
+
+  /// Helper functions generated for the enum built-in methods, keyed by the
+  /// canonical enum type and the method they implement.
+  DenseMap<
+      std::pair<const slang::ast::EnumType *, slang::parsing::KnownSystemName>,
+      mlir::func::FuncOp>
+      enumHelpers;
 
   /// Classes that have already been converted.
   DenseMap<const slang::ast::ClassType *, std::unique_ptr<ClassLowering>>

--- a/test/Conversion/ImportVerilog/enum-methods.sv
+++ b/test/Conversion/ImportVerilog/enum-methods.sv
@@ -1,0 +1,136 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// RUN: circt-verilog --ir-moore %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+typedef enum logic [2:0] { X = 3'd1, Y = 3'd4, Z = 3'd6 } Sparse;
+
+// CHECK-LABEL: func.func private @enum.next.Sparse(
+// CHECK-SAME:      [[VALUE:%.+]]: !moore.l3, [[COUNT:%.+]]: !moore.i32) -> !moore.l3 {
+// CHECK:         [[VAL0:%.+]] = moore.constant 1 : l3
+// CHECK:         [[VAL1:%.+]] = moore.constant -4 : l3
+// CHECK:         [[VAL2:%.+]] = moore.constant -2 : l3
+// CHECK:         [[TABLE:%.+]] = moore.array_create [[VAL2]], [[VAL1]], [[VAL0]] : {{.+}} -> array<3 x l3>
+
+// The value is compared against each enumerand in turn, which yields its
+// position among them.
+// CHECK:         [[EQ:%.+]] = moore.case_eq [[VALUE]], [[VAL0]] : l3
+// CHECK:         [[COND:%.+]] = moore.to_builtin_int [[EQ]] : i1
+// CHECK:         [[POS:%.+]] = moore.constant 0 : i32
+// CHECK:         cf.cond_br [[COND]], ^[[MATCH:.+]]([[POS]] : !moore.i32), ^[[BB:.+]]
+// CHECK:       ^[[BB]]:
+// CHECK:         [[EQ:%.+]] = moore.case_eq [[VALUE]], [[VAL1]] : l3
+// CHECK:         [[COND:%.+]] = moore.to_builtin_int [[EQ]] : i1
+// CHECK:         [[POS:%.+]] = moore.constant 1 : i32
+// CHECK:         cf.cond_br [[COND]], ^[[MATCH]]([[POS]] : !moore.i32), ^[[BB:.+]]
+// CHECK:       ^[[BB]]:
+// CHECK:         [[EQ:%.+]] = moore.case_eq [[VALUE]], [[VAL2]] : l3
+// CHECK:         [[COND:%.+]] = moore.to_builtin_int [[EQ]] : i1
+// CHECK:         [[POS:%.+]] = moore.constant 2 : i32
+// CHECK:         cf.cond_br [[COND]], ^[[MATCH]]([[POS]] : !moore.i32), ^[[BB:.+]]
+
+// Values that are not a member of the enumeration produce the default value,
+// which is all-X for a four-valued enum.
+// CHECK:       ^[[BB]]:
+// CHECK:         [[DEFAULT:%.+]] = moore.constant bXXX : l3
+// CHECK:         return [[DEFAULT]] : !moore.l3
+
+// The position is advanced by the step count, wrapping around at both ends of
+// the enumerand list, and looked up in the table.
+// CHECK:       ^[[MATCH]]([[POS:%.+]]: !moore.i32):
+// CHECK:         [[NUM:%.+]] = moore.constant 3 : i32
+// CHECK:         [[STEP:%.+]] = moore.modu [[COUNT]], [[NUM]] : i32
+// CHECK:         [[SUM:%.+]] = moore.add [[POS]], [[STEP]] : i32
+// CHECK:         [[WRAPPED:%.+]] = moore.modu [[SUM]], [[NUM]] : i32
+// CHECK:         [[RESULT:%.+]] = moore.dyn_extract [[TABLE]] from [[WRAPPED]] : array<3 x l3>, i32 -> l3
+// CHECK:         return [[RESULT]] : !moore.l3
+
+// `prev` walks backwards by subtracting the step count from the number of
+// enumerands before offsetting the position.
+// CHECK-LABEL: func.func private @enum.prev.Sparse(
+// CHECK-SAME:      [[VALUE:%.+]]: !moore.l3, [[COUNT:%.+]]: !moore.i32) -> !moore.l3 {
+// CHECK:       ^{{.+}}([[POS:%.+]]: !moore.i32):
+// CHECK:         [[NUM:%.+]] = moore.constant 3 : i32
+// CHECK:         [[STEP:%.+]] = moore.modu [[COUNT]], [[NUM]] : i32
+// CHECK:         [[BACK:%.+]] = moore.sub [[NUM]], [[STEP]] : i32
+// CHECK:         [[SUM:%.+]] = moore.add [[POS]], [[BACK]] : i32
+// CHECK:         moore.modu [[SUM]], [[NUM]] : i32
+
+// `name` maps the value to the enumerand's name, or to an empty string if it
+// is not a member of the enumeration.
+// CHECK-LABEL: func.func private @enum.name.Sparse(
+// CHECK-SAME:      [[VALUE:%.+]]: !moore.l3) -> !moore.string {
+// CHECK:         [[VAL0:%.+]] = moore.constant 1 : l3
+// CHECK:         [[VAL1:%.+]] = moore.constant -4 : l3
+// CHECK:         [[VAL2:%.+]] = moore.constant -2 : l3
+// CHECK:         [[EQ:%.+]] = moore.case_eq [[VALUE]], [[VAL0]] : l3
+// CHECK:         [[COND:%.+]] = moore.to_builtin_int [[EQ]] : i1
+// CHECK:         [[BYTES:%.+]] = moore.constant_string "X" : i8
+// CHECK:         [[STR:%.+]] = moore.int_to_string [[BYTES]] : i8
+// CHECK:         cf.cond_br [[COND]], ^[[MATCH:.+]]([[STR]] : !moore.string), ^[[BB:.+]]
+// CHECK:       ^[[BB]]:
+// CHECK:         moore.case_eq [[VALUE]], [[VAL1]] : l3
+// CHECK:         [[BYTES:%.+]] = moore.constant_string "Y" : i8
+// CHECK:         [[STR:%.+]] = moore.int_to_string [[BYTES]] : i8
+// CHECK:         cf.cond_br {{%.+}}, ^[[MATCH]]([[STR]] : !moore.string), ^[[BB:.+]]
+// CHECK:       ^[[BB]]:
+// CHECK:         moore.case_eq [[VALUE]], [[VAL2]] : l3
+// CHECK:         [[BYTES:%.+]] = moore.constant_string "Z" : i8
+// CHECK:         [[STR:%.+]] = moore.int_to_string [[BYTES]] : i8
+// CHECK:         cf.cond_br {{%.+}}, ^[[MATCH]]([[STR]] : !moore.string), ^[[BB:.+]]
+// CHECK:       ^[[BB]]:
+// CHECK:         [[BYTES:%.+]] = moore.constant_string "" : i0
+// CHECK:         [[STR:%.+]] = moore.int_to_string [[BYTES]] : i0
+// CHECK:         cf.br ^[[MATCH]]([[STR]] : !moore.string)
+// CHECK:       ^[[MATCH]]([[RESULT:%.+]]: !moore.string):
+// CHECK:         return [[RESULT]] : !moore.string
+
+// CHECK-LABEL: func.func private @Methods(
+// CHECK-SAME:      [[A:%.+]]: !moore.l3, [[K:%.+]]: !moore.i32)
+function void Methods(Sparse a, int unsigned k);
+  Sparse r;
+  string n;
+
+  // The step count defaults to one if it is not given explicitly.
+  // CHECK: [[ONE:%.+]] = moore.constant 1 : i32
+  // CHECK: call @enum.next.Sparse([[A]], [[ONE]]) : (!moore.l3, !moore.i32) -> !moore.l3
+  r = a.next();
+
+  // CHECK: call @enum.next.Sparse([[A]], [[K]]) : (!moore.l3, !moore.i32) -> !moore.l3
+  r = a.next(k);
+
+  // CHECK: call @enum.prev.Sparse([[A]], %{{.+}}) : (!moore.l3, !moore.i32) -> !moore.l3
+  r = a.prev();
+
+  // CHECK: call @enum.name.Sparse([[A]]) : (!moore.l3) -> !moore.string
+  n = a.name();
+
+  // The same helper is reused for further calls on the same enum.
+  // CHECK: call @enum.name.Sparse([[A]]) : (!moore.l3) -> !moore.string
+  n = a.name();
+
+  // Calls on a constant value are folded by Slang.
+  // CHECK: [[TMP:%.+]] = moore.constant_string "Y" : i8
+  // CHECK: moore.int_to_string [[TMP]] : i8
+  n = Y.name();
+  // CHECK: [[TMP:%.+]] = moore.constant -2 : l3
+  // CHECK: moore.blocking_assign %r, [[TMP]]
+  r = Y.next();
+  // CHECK: [[TMP:%.+]] = moore.constant 1 : l3
+  // CHECK: moore.blocking_assign %r, [[TMP]]
+  r = X.first();
+  // CHECK: [[TMP:%.+]] = moore.constant -2 : l3
+  // CHECK: moore.blocking_assign %r, [[TMP]]
+  r = X.last();
+endfunction
+
+// CHECK-LABEL: func.func private @Unnamed(
+function string Unnamed();
+  enum { P, Q } a;
+  // CHECK: call @enum.name.anon(
+  return a.name();
+endfunction
+
+// CHECK-LABEL: func.func private @enum.name.anon(

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -196,26 +196,6 @@ endmodule
 
 // -----
 module Foo;
-  typedef enum { A, B, C } e;
-  e val;
-  initial begin
-    // expected-error @below {{unsupported system call `next`}}
-    val = val.next();
-  end
-endmodule
-
-// -----
-module Foo;
-  typedef enum { A, B, C } e;
-  e val;
-  initial begin
-    // expected-error @below {{unsupported system call `prev`}}
-    val = val.prev();
-  end
-endmodule
-
-// -----
-module Foo;
   int inp[];
   int tmp[];
   initial begin


### PR DESCRIPTION
Add support for the `next`, `prev`, and `name` built-in methods on enums. Slang folds these calls away wherever the value they are called on is constant, so what remains are the cases that require an actual computation at runtime. Instead of inlining that computation at every call site, emit one helper function per enum type and method, and turn the calls into plain function calls.

The helpers compare the value against each enumerand in turn to find its position among them. `name` maps a match to the enumerand's name, while `next` and `prev` offset the position by the step count, wrap it around at both ends of the enumerand list, and use the result to index an array of all enumerand values. Values that are not a member of the enumeration produce an empty string and the enum's default value, respectively, as mandated by IEEE 1800-2023 section 6.19.5.

The `first`, `last`, and `num` methods need no support here since they do not depend on the value they are called on and are always folded to a constant by Slang.

Assisted-by: Claude Opus 5