### PR TITLE
[ESI] Use ChannelMergeOneValid for ChannelMMIO responses

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/bsp/common.py
@@ -584,7 +584,14 @@ class ChannelMMIO(esi.ServiceImplementation):
         assert False, "Unrecognized bundle type."
       bundle_wire.assign(bundle)
       client_data_channels.append(bundle_froms["data"])
-    resp_channel = esi.ChannelMux(client_data_channels)
+    # `cmd_rate_limiter` above caps the design at one outstanding MMIO command,
+    # and `client_cmd_demux` routes that one command to exactly one client. So
+    # provided each client only asserts its response `valid` in reply to a
+    # command it was given -- see `ChannelMergeOneValid` for why that second
+    # half matters, and note it is required by `ChannelMux` too -- at most one
+    # client response is ever valid, and arbitration is unnecessary.
+    resp_channel = esi.ChannelMergeOneValid(client_data_channels, ports.clk,
+                                            ports.rst)
     data_resp_channel.assign(resp_channel)
 
     # The header surfaces a reset request when the host writes the reset magic


### PR DESCRIPTION
## What

Switches `ChannelMMIO`'s client response merge from `ChannelMux` to
`ChannelMergeOneValid` (added in the PR below this one in the stack).

## ⚠️ Do not merge until a `pycde` release containing `ChannelMergeOneValid` is on PyPI

This PR **will fail CI until then**, by construction, and that is why it is
split out rather than being part of the PR that adds the API.

`testESIRuntime.yml` does `pip install pycde --pre` and then builds only
`esiaccel` from source, so the ESI runtime is tested against the *released*
PyCDE rather than the one in the tree. A runtime change that calls a
brand-new `pycde.esi` API therefore cannot go green in the same commit that
adds the API — it fails with:

```
AttributeError: module 'pycde.esi' has no attribute 'ChannelMergeOneValid'
```

on every test that generates hardware. (Windows passes because it skips cosim.)

Keeping it as a separate PR at the top of the stack makes the stack order the
merge order: the PyCDE API lands, a pre-release ships, then this goes green.

## Why it works better

`ChannelMux` arbitrates, which makes every client's `ready` a function of every
other client's `valid`. `ChannelMergeOneValid` broadcasts a single `ready` and
picks the payload with a list select, so there is no combinational coupling
between clients at all — see the API PR for the full argument.

Two conditions make dropping the arbitration sound here, and unusually for this
fabric both are locally checkable, in the same file, rather than being an
appeal to another package:

1. **At most one command in flight** — `cmd_rate_limiter` caps the design at
   one outstanding MMIO command, and `client_cmd_demux` routes that one command
   to exactly one client.
2. **Each client asserts its response `valid` only in reply to a command it was
   given.** Both in-tree MMIO client patterns do this — `addr_chan.transform(...)`
   and `wrap(storage, cmd_valid)` both derive `valid` from the command channel.

Condition 2 is worth calling out because a channel may legally hold `valid`
high forever, and such a client would break the merge regardless of condition
1. It is **not** a new requirement introduced by this change: `ChannelMux2` is
fixed-priority, so a permanently-valid client drives its sibling subtree's
`ready` low forever and starves every client behind it — a quieter and arguably
worse failure. The call-site comment now records both conditions.
## Evidence

Measured on an internal build of esitester: switching the MMIO response fabric
improved role-clock fmax by about **11%** and reduced register count by about
**4%**, though that build also enabled arbiter mux pipelining, so those figures
are the two changes combined. What is attributable to this change is that the
MMIO response cone stopped appearing in the violated set.

## Testing

Full ESI runtime suite passes locally, where `esiaccel` and `pycde` are both
built from the tree. CI will pass once the PyPI dependency catches up.

---

Assisted-by: GitHub Copilot CLI



