### PR TITLE
[CI] Enable expensive pattern API checks in nightly integration tests. 

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-circt:
-    name: "${{ matrix.compiler }}/${{ matrix.build-type }}/${{ matrix.build-shared == 'ON' && 'shared' || 'static' }}-libs/asserts-${{ matrix.build-assert == 'ON' && 'on' || 'off' }}${{ matrix.valgrind && '/valgrind' || '' }}"
+    name: "${{ matrix.compiler }}/${{ matrix.build-type }}/${{ matrix.build-shared == 'ON' && 'shared' || 'static' }}-libs/asserts-${{ matrix.build-assert == 'ON' && 'on' || 'off' }}${{ matrix.valgrind && '/valgrind' || '' }}${{ matrix.expensive-pattern-checks == 'ON' && '/expensive-pattern-checks' || '' }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   build-circt:
-    name: "${{ matrix.compiler }}/${{ matrix.build-type }}/${{ matrix.build-shared == 'ON' && 'shared' || 'static' }}-libs/asserts-${{ matrix.build-assert == 'ON' && 'on' || 'off' }}${{ matrix.valgrind && '/valgrind' || '' }}${{ matrix.expensive-pattern-checks == 'ON' && '/expensive-pattern-checks' || '' }}"
+    name: "${{ matrix.compiler }}/${{ matrix.build-type }}/${{ matrix.build-shared == 'ON' && 'shared' || 'static' }}-libs/asserts-${{ matrix.build-assert == 'ON' && 'on' || 'off' }}${{ matrix.valgrind && '/valgrind' || '' }}${{ matrix.extra-cmake-args != '' && format('/extra={0}', matrix.extra-cmake-args) || '' }}"
     strategy:
       fail-fast: false
       matrix:
         build-assert: [ON, OFF]
         build-shared: [ON, OFF]
-        expensive-pattern-checks: [OFF]
+        extra-cmake-args: [""]
         include:
           # Run the expensive pattern API checks in one Release configuration.
           - build-type: Release
@@ -22,7 +22,7 @@ jobs:
             build-shared: OFF
             compiler: clang
             valgrind: false
-            expensive-pattern-checks: ON
+            extra-cmake-args: "-DMLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON"
         build-type: [Debug, Release]
         compiler:
           - clang
@@ -65,4 +65,4 @@ jobs:
       package_name_prefix: ""
       cmake_c_compiler: ${{ matrix.compiler }}
       valgrind: ${{ matrix.valgrind }}
-      extra_cmake_args: ${{ matrix.expensive-pattern-checks == 'ON' && '-DMLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON' || '' }}
+      extra_cmake_args: ${{ matrix.extra-cmake-args }}

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -14,6 +14,15 @@ jobs:
       matrix:
         build-assert: [ON, OFF]
         build-shared: [ON, OFF]
+        expensive-pattern-checks: [OFF]
+        include:
+          # Run the expensive pattern API checks in one Release configuration.
+          - build-type: Release
+            build-assert: ON
+            build-shared: OFF
+            compiler: clang
+            valgrind: false
+            expensive-pattern-checks: ON
         build-type: [Debug, Release]
         compiler:
           - clang
@@ -56,4 +65,4 @@ jobs:
       package_name_prefix: ""
       cmake_c_compiler: ${{ matrix.compiler }}
       valgrind: ${{ matrix.valgrind }}
-      extra_cmake_args: ""
+      extra_cmake_args: ${{ matrix.expensive-pattern-checks == 'ON' && '-DMLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON' || '' }}

--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -51,7 +51,12 @@ endif()
 get_target_property(ESI_PrimsDir ESIPrimitives SOURCE_DIR)
 set(ESI_Prims "${ESI_PrimsDir}/ESIPrimitives.sv")
 
-set(CIRCT_INTEGRATION_TIMEOUT 120) # Set a 120s timeout on individual tests.
+# The expensive pattern API checks can significantly increase test runtime.
+if (MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS)
+  set(CIRCT_INTEGRATION_TIMEOUT 600)
+else()
+  set(CIRCT_INTEGRATION_TIMEOUT 120)
+endif()
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/integration_test/Dialect/FSM/simple/top.mlir
+++ b/integration_test/Dialect/FSM/simple/top.mlir
@@ -1,5 +1,4 @@
 // REQUIRES: verilator
-// XFAIL: mlir-expensive-checks
 // See https://github.com/llvm/circt/issues/7047
 // RUN: rm -rf %t.dir && mkdir %t.dir
 // RUN: circt-opt --pass-pipeline="builtin.module(convert-fsm-to-sv,canonicalize,lower-seq-to-sv,export-split-verilog{dir-name=%t.dir})" %s -o /dev/null


### PR DESCRIPTION
Enable expensive pattern API checks in one nightly integration test configuration.

Increase the timeout for regular and integration tests to 600 seconds when expensive pattern API checks are enabled, while keeping the existing timeout behavior for other configurations.

Tesed in https://github.com/llvm/circt/actions/runs/32528540413/job/96915707300 (and caused timeout in integration tests so increased the timeout to 600 sec). 

Assisted-by: pi.dev: gpt-5.6 luna

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
