### PR TITLE
[AXI4] Have burst_sets merge subsumed specs

### DIFF
--- a/include/circt/Dialect/AXI4/AXI4Attributes.td
+++ b/include/circt/Dialect/AXI4/AXI4Attributes.td
@@ -79,7 +79,8 @@ def BurstSetAttr : AXI4AttrDef<"BurstSet"> {
 
     To avoid functionally equivalent types (e.g. types containing burst_sets with
     the same specs in different orders) being structurally inequivalent, this is
-    sorted and de-duplicated on construction.
+    sorted on construction, with the specs of each kind merged into the longest
+    of them.
   }];
 
   let parameters = (ins
@@ -98,8 +99,14 @@ def BurstSetAttr : AXI4AttrDef<"BurstSet"> {
       ::llvm::SmallVector<::circt::axi4::BurstSpecAttr> sorted(
           burstSpecs.begin(), burstSpecs.end());
       ::llvm::sort(sorted, BurstSpecAttr::compareCanonical);
-      sorted.erase(::llvm::unique(sorted), sorted.end());
-      return $_get($_ctxt, sorted);
+      // A `len` is a maximum, so only the longest burst of each kind is kept
+      // (and we've already sorted so the longest burst, which is the only one
+      // we care about, is at the end)
+      ::llvm::SmallVector<::circt::axi4::BurstSpecAttr> merged;
+      for (size_t i = 0, e = sorted.size(); i != e; ++i)
+        if (i + 1 == e || sorted[i + 1].getKind() != sorted[i].getKind())
+          merged.push_back(sorted[i]);
+      return $_get($_ctxt, merged);
     }]>
   ];
 }

--- a/lib/Dialect/AXI4/AXI4Attributes.cpp
+++ b/lib/Dialect/AXI4/AXI4Attributes.cpp
@@ -107,7 +107,7 @@ SmallVector<WindowAttr> WindowSetAttr::normalize(MLIRContext *ctx,
     if (specs.empty())
       continue;
 
-    // BurstSetAttr::get sorts and de-duplicates the union for us.
+    // BurstSetAttr::get sorts the union and merges each kind for us.
     auto burstSpecs = BurstSetAttr::get(ctx, specs);
 
     // Merge into the previous window where they are contiguous and share

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -25,7 +25,11 @@
 "test.attrs"() {a = #axi4.burst_set<<incr, len = 8>, <fixed, len = 4>>} : () -> ()
 // CHECK: #axi4.burst_set<<incr, len = 8>>
 "test.attrs"() {a = #axi4.burst_set<<incr, len = 8>, <incr, len = 8>>} : () -> ()
-// CHECK: #axi4.burst_set<<fixed, len = 16>, <incr, len = 1>, <incr, len = 256>, <wrap, len = 2>>
+
+// Check a len subsumes the shorter ones of its kind, and only of its kind
+// CHECK: #axi4.burst_set<<incr, len = 8>>
+"test.attrs"() {a = #axi4.burst_set<<incr, len = 8>, <incr, len = 4>>} : () -> ()
+// CHECK: #axi4.burst_set<<fixed, len = 16>, <incr, len = 256>, <wrap, len = 2>>
 "test.attrs"() {a = #axi4.burst_set<<wrap, len = 2>, <incr, len = 256>, <incr, len = 1>, <fixed, len = 16>>} : () -> ()
 
 // CHECK: #axi4.window<base = 0x4000, last = 0x40ff, burst_specs = <<fixed, len = 4>>>

--- a/unittests/Dialect/AXI4/BurstSetTest.cpp
+++ b/unittests/Dialect/AXI4/BurstSetTest.cpp
@@ -48,16 +48,29 @@ TEST_F(BurstSetTest, ShuffledInputUniquesToSortedInput) {
 
 // Ensure burst_specs are accessed in the canonical order
 TEST_F(BurstSetTest, StoredOrderIsCanonical) {
-  BurstSpecAttr shuffled[] = {
-      spec(BurstKind::Wrap, 2), spec(BurstKind::Incr, 256),
-      spec(BurstKind::Incr, 1), spec(BurstKind::Fixed, 16)};
+  BurstSpecAttr shuffled[] = {spec(BurstKind::Wrap, 2),
+                              spec(BurstKind::Incr, 256),
+                              spec(BurstKind::Fixed, 16)};
   auto set = BurstSetAttr::get(&context, shuffled);
 
-  ASSERT_EQ(set.getBurstSpecs().size(), 4u);
+  ASSERT_EQ(set.getBurstSpecs().size(), 3u);
   EXPECT_EQ(set.getBurstSpecs()[0], spec(BurstKind::Fixed, 16));
-  EXPECT_EQ(set.getBurstSpecs()[1], spec(BurstKind::Incr, 1));
-  EXPECT_EQ(set.getBurstSpecs()[2], spec(BurstKind::Incr, 256));
-  EXPECT_EQ(set.getBurstSpecs()[3], spec(BurstKind::Wrap, 2));
+  EXPECT_EQ(set.getBurstSpecs()[1], spec(BurstKind::Incr, 256));
+  EXPECT_EQ(set.getBurstSpecs()[2], spec(BurstKind::Wrap, 2));
+}
+
+// Check a `len` is a maximum, so the longest burst of a kind is the only one
+// kept, and only of its own kind
+TEST_F(BurstSetTest, LongestOfEachKindWins) {
+  BurstSpecAttr specs[] = {spec(BurstKind::Incr, 4), spec(BurstKind::Incr, 256),
+                           spec(BurstKind::Incr, 16),
+                           spec(BurstKind::Fixed, 8)};
+
+  auto set = BurstSetAttr::get(&context, specs);
+
+  ASSERT_EQ(set.getBurstSpecs().size(), 2u);
+  EXPECT_EQ(set.getBurstSpecs()[0], spec(BurstKind::Fixed, 8));
+  EXPECT_EQ(set.getBurstSpecs()[1], spec(BurstKind::Incr, 256));
 }
 
 // Check duplicate specs are collapsed together

--- a/unittests/Dialect/AXI4/WindowSetTest.cpp
+++ b/unittests/Dialect/AXI4/WindowSetTest.cpp
@@ -70,6 +70,18 @@ TEST_F(WindowSetTest, OverlappingAndDisjointSpellingsAreEquivalent) {
   EXPECT_EQ(a.getWindows()[1], disjoint[1]);
 }
 
+// Check a window subsumed by a window with the same burst kind is absorbed by
+// it, leaving one window rather than two
+TEST_F(WindowSetTest, OverlapAbsorbedByLongerBurst) {
+  WindowAttr overlapping[] = {window(0, 0xFF, {{BurstKind::Incr, 4}}),
+                              window(0, 0x1FF, {{BurstKind::Incr, 16}})};
+
+  auto set = WindowSetAttr::get(&context, overlapping);
+
+  ASSERT_EQ(set.getWindows().size(), 1u);
+  EXPECT_EQ(set.getWindows()[0], window(0, 0x1FF, {{BurstKind::Incr, 16}}));
+}
+
 // Ensure that window_sets covering the whole address space are equivalent
 // wherever they happen to be split
 TEST_F(WindowSetTest, WholeAddressSpaceSplitsAreEquivalent) {


### PR DESCRIPTION
Since the len associated with burst_specs is a maximum burst length, a burst spec is subsumed by another spec with the same burst kind but a greater length. This PR just adds that to the canonicalizing burst set construction and checks that this also correctly affects window set construction.

One unit test is also collaterally modified as this change breaks it in its current form.

AI-assisted-by: Claude Opus 5 (1M context)

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
