### PR TITLE
[Moore] Support implicit conversion from unpacked array to dynamic array

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2434,7 +2434,9 @@ def OpenUArrayDeleteOp: MooreOp<"open_uarray_delete"> {
   }];
 }
 
-def OpenUArrayFromUnpackedArrayOp: MooreOp<"open_uarray_from_uarray">{
+def OpenUArrayFromUnpackedArrayOp: MooreOp<"open_uarray_from_uarray", 
+[Pure, TypesMatchWith<"input's elements type must match the result's elements type", "input",
+ "output", "OpenUnpackedArrayType::get($_self.getContext(), cast<UnpackedArrayType>($_self).getElementType())">]>{
   let summary = "Create an open unpacked array from a fixed-size unpacked array";
 
   let description = [{

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -2434,6 +2434,20 @@ def OpenUArrayDeleteOp: MooreOp<"open_uarray_delete"> {
   }];
 }
 
+def OpenUArrayFromUnpackedArrayOp: MooreOp<"open_uarray_from_uarray">{
+  let summary = "Create an open unpacked array from a fixed-size unpacked array";
+
+  let description = [{
+    Converts a fixed-size unpacked array into an open (dynamic) unpacked array.
+  }];
+  let arguments = (ins UnpackedArrayType:$input);
+  let results = (outs OpenUnpackedArrayType:$output);
+  
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($output)
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Struct Manipulation
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3211,12 +3211,12 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
                                                                    value);
     }
   }
-  if (isa<moore::OpenUnpackedArrayType>(type) &&
-      isa<moore::UnpackedArrayType>(value.getType())) {
-    auto openUnpackedArrayElType =
-        dyn_cast<moore::OpenUnpackedArrayType>(type).getElementType();
-    auto unpackedArrayElType =
-        dyn_cast<moore::UnpackedArrayType>(value.getType()).getElementType();
+  // Convert from fixed-size unpacked array to open unpacked array
+  auto srcUArray = dyn_cast<moore::UnpackedArrayType>(value.getType());
+  auto dstOpenUArray = dyn_cast<moore::OpenUnpackedArrayType>(type);
+  if (srcUArray && dstOpenUArray) {
+    auto openUnpackedArrayElType = dstOpenUArray.getElementType();
+    auto unpackedArrayElType = srcUArray.getElementType();
 
     if (openUnpackedArrayElType == unpackedArrayElType)
       return builder.createOrFold<moore::OpenUArrayFromUnpackedArrayOp>(

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -3211,7 +3211,17 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
                                                                    value);
     }
   }
+  if (isa<moore::OpenUnpackedArrayType>(type) &&
+      isa<moore::UnpackedArrayType>(value.getType())) {
+    auto openUnpackedArrayElType =
+        dyn_cast<moore::OpenUnpackedArrayType>(type).getElementType();
+    auto unpackedArrayElType =
+        dyn_cast<moore::UnpackedArrayType>(value.getType()).getElementType();
 
+    if (openUnpackedArrayElType == unpackedArrayElType)
+      return builder.createOrFold<moore::OpenUArrayFromUnpackedArrayOp>(
+          loc, type, value);
+  }
   // Handle Real To Int conversion
   if (dstInt && isa<moore::RealType>(value.getType())) {
     auto twoValInt = builder.createOrFold<moore::RealToIntOp>(

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -898,6 +898,13 @@ module Expressions;
   // CHECK-DAG: %strArr = moore.variable [[ARR_CREATE]] : <uarray<3 x string>>
   string strArr[3] = { "hello", "sad", "world" };
 
+  // CHECK-DAG: [[DYN_ARR_CREATE:%.+]] = moore.array_create [[INT_TO_STR0]],
+  // [[INT_TO_STR1]], [[INT_TO_STR2]] : !moore.string, !moore.string,
+  // !moore.string -> uarray<3 x string> CHECK-DAG: [[DYN_ARR_CONV:%.+]] =
+  // moore.open_uarray_from_uarray [[DYN_ARR_CREATE]] : !moore.uarray<3 x
+  // string> -> !moore.open_uarray<string> CHECK-DAG: %strDynArr =
+  // moore.variable [[DYN_ARR_CONV]] : <open_uarray<string>>
+  string strDynArr[] = {"hello", "sad", "world"};
   initial begin
     // CHECK: moore.constant 0 : i32
     c = '0;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -898,12 +898,15 @@ module Expressions;
   // CHECK-DAG: %strArr = moore.variable [[ARR_CREATE]] : <uarray<3 x string>>
   string strArr[3] = { "hello", "sad", "world" };
 
-  // CHECK-DAG: [[DYN_ARR_CREATE:%.+]] = moore.array_create [[INT_TO_STR0]],
-  // [[INT_TO_STR1]], [[INT_TO_STR2]] : !moore.string, !moore.string,
-  // !moore.string -> uarray<3 x string> CHECK-DAG: [[DYN_ARR_CONV:%.+]] =
-  // moore.open_uarray_from_uarray [[DYN_ARR_CREATE]] : !moore.uarray<3 x
-  // string> -> !moore.open_uarray<string> CHECK-DAG: %strDynArr =
-  // moore.variable [[DYN_ARR_CONV]] : <open_uarray<string>>
+  // CHECK-DAG: [[STR3:%.+]] = moore.constant_string "hello" : i40
+  // CHECK-DAG: [[INT_TO_STR3:%.+]] = moore.int_to_string [[STR3]] : i40
+  // CHECK-DAG: [[STR4:%.+]] = moore.constant_string "sad" : i24
+  // CHECK-DAG: [[INT_TO_STR4:%.+]] = moore.int_to_string [[STR4]] : i24
+  // CHECK-DAG: [[STR5:%.+]] = moore.constant_string "world" : i40
+  // CHECK-DAG: [[INT_TO_STR5:%.+]] = moore.int_to_string [[STR5]] : i40
+  // CHECK-DAG: [[DYN_ARR_CREATE:%.+]] = moore.array_create [[INT_TO_STR3]], [[INT_TO_STR4]], [[INT_TO_STR5]] : !moore.string, !moore.string, !moore.string -> uarray<3 x string>
+  // CHECK-DAG: [[DYN_ARR_CONV:%.+]] = moore.open_uarray_from_uarray [[DYN_ARR_CREATE]] : <3 x string> -> <string>
+  // CHECK-DAG: %strDynArr = moore.variable [[DYN_ARR_CONV]] : <open_uarray<string>>
   string strDynArr[] = {"hello", "sad", "world"};
   initial begin
     // CHECK: moore.constant 0 : i32

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -392,3 +392,11 @@ module Bar;
   // expected-error @below {{inout port `p` expects '!moore.ref<struct<{x: l1, y: l1}>>' but is connected to '!moore.ref<l2>'}}
   Foo foo(y);
 endmodule
+
+// -----
+
+module InvalidOpenArrayAssign;
+  logic [7 : 0] bytes[3] = '{1, 2, 3};
+  // expected-error @below {{no implicit conversion from 'logic[7:0]$[3]' to 'string$[]'}}
+  string strDynArr[] = bytes;
+endmodule


### PR DESCRIPTION
This PR adds `OpenUArrayFromUnpackedArrayOp`, new op for a conversion between `uarray<n x type>` and `open_uarray<type>` and the emission of the op in `context::materializeConversion`.

Fixes(partly): #11027
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
