### PR TITLE
[FIRRTL] Add Registry MLIR type

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -60,6 +60,7 @@ class StringType;
 class FIntegerType;
 class DomainFieldAttr;
 class ListType;
+class RegistryType;
 class PathType;
 class BoolType;
 class DoubleType;
@@ -331,7 +332,7 @@ public:
   /// Support method to enable LLVM-style type casting.
   static bool classof(Type type) {
     return llvm::isa<AnyRefType, ClassType, StringType, FIntegerType, ListType,
-                     PathType, BoolType, DoubleType>(type);
+                     RegistryType, PathType, BoolType, DoubleType>(type);
   }
 
 protected:

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -227,6 +227,8 @@ def FIntegerType : FIRRTLDialectTypeHelper<"FIntegerType", "integer type">,
 
 def ListType : FIRRTLDialectTypeHelper<"ListType", "list type">;
 
+def RegistryType : FIRRTLDialectTypeHelper<"RegistryType", "registry type">;
+
 def BoolType : FIRRTLDialectTypeHelper<"BoolType", "boolean type">,
   BuildableType<"::circt::firrtl::BoolType::get($_builder.getContext())">;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -578,6 +578,21 @@ def ListImpl : PropImplType<"List"> {
   let typeName = "firrtl.propList";
 }
 
+def RegistryImpl : PropImplType<"Registry"> {
+  let summary = [{
+    An unordered mutable collection of property values for domain asset tracking.
+
+    Registry types may only appear as fields of domain definitions. Values are
+    accumulated with `firrtl.domain.insert` rather than normal property
+    assignment. Downstream consumers must treat registry contents as
+    order-independent.
+  }];
+  let parameters = (ins TypeParameter<"circt::firrtl::PropertyType", "element type">:$elementType);
+  let genStorageClass = true;
+  let genAccessors = true;
+  let typeName = "firrtl.propRegistry";
+}
+
 def PathImpl : PropImplType<"Path"> {
   let summary = "A path to a hardware entity.  Not representable in hardware.";
   let parameters = (ins);

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -587,7 +587,8 @@ def RegistryImpl : PropImplType<"Registry"> {
     assignment. Downstream consumers must treat registry contents as
     order-independent.
   }];
-  let parameters = (ins TypeParameter<"circt::firrtl::PropertyType", "element type">:$elementType);
+  let parameters = (ins TypeParameter<"circt::firrtl::PropertyType",
+                                      "element type">:$elementType);
   let genStorageClass = true;
   let genAccessors = true;
   let typeName = "firrtl.propRegistry";

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -153,6 +153,11 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
         printNestedType(listType.getElementType(), os);
         os << '>';
       })
+      .Case<RegistryType>([&](auto registryType) {
+        os << "registry<";
+        printNestedType(registryType.getElementType(), os);
+        os << '>';
+      })
       .Case<PathType>([&](auto pathType) { os << "path"; })
       .Case<BaseTypeAliasType>([&](BaseTypeAliasType alias) {
         os << "alias<" << alias.getName().getValue() << ", ";
@@ -523,6 +528,20 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
         parser.parseGreater())
       return failure();
     result = parser.getChecked<ListType>(context, elementType);
+    if (!result)
+      return failure();
+    return success();
+  }
+  if (name == "registry") {
+    if (isConst) {
+      parser.emitError(parser.getNameLoc(), "registries cannot be const");
+      return failure();
+    }
+    PropertyType elementType;
+    if (parser.parseLess() || parseNestedPropertyType(elementType, parser) ||
+        parser.parseGreater())
+      return failure();
+    result = RegistryType::get(context, elementType);
     if (!result)
       return failure();
     return success();

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -289,6 +289,13 @@ firrtl.domain @PowerDomain [
   #firrtl.domain.field<"alwaysOn", !firrtl.bool>
 ]
 
+// CHECK-LABEL: firrtl.domain @RegistryDomain [
+// CHECK-SAME:    #firrtl.domain.field<"clockGates", !firrtl.registry<path>>
+// CHECK-SAME:  ]
+firrtl.domain @RegistryDomain [
+  #firrtl.domain.field<"clockGates", !firrtl.registry<path>>
+]
+
 firrtl.module @DomainsSubmodule(
   in %A: !firrtl.domain<@ClockDomain()>,
   in %a: !firrtl.uint<1> domains [%A]


### PR DESCRIPTION
Add a RegistryType property type and support `!firrtl.registry<T>` syntax. 

We don't have a good way to restrict this type only to domain now other than modifying class op verifier to reject this specifically. 

Split from https://github.com/llvm/circt/pull/10940. 

Assisted-by: gpt 5.6 luna
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
