### PR TITLE
[FIRRTL] Warn on abstract resets on extmodule's.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -6112,6 +6112,9 @@ ParseResult FIRCircuitParser::parseExtModule(CircuitOp circuit,
       if (auto ftype = type_dyn_cast<FIRRTLType>(pi.type)) {
         if (ftype.hasUninferredWidth())
           return emitError(loc, "extmodule port must have known width");
+        if (ftype.hasUninferredReset())
+          emitWarning(loc, "extmodule port must have concrete reset type, this "
+                           "will be an error in the future");
       }
     }
   }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1594,6 +1594,13 @@ circuit AbstractResetPublic:
 
 ;// -----
 FIRRTL version 4.0.0
+circuit AbstractResetExt:
+  extmodule AbstractResetExt:
+    ; expected-warning @below {{extmodule port must have concrete reset type}}
+    input r: Reset
+
+;// -----
+FIRRTL version 4.0.0
 circuit PrivateMainModule:
   ; expected-error @below {{private main modules were removed in FIRRTL 4.0.0}}
   module PrivateMainModule:


### PR DESCRIPTION
When parsing FIRRTL >= 4.0.0, check and warn on use of abstract reset on extmodule's.  This should be an error.

https://github.com/chipsalliance/firrtl-spec/pull/181

Previously implemented as part of #6731, but used in practice so deferred.  Let's revisit now.

Based on #7248, converted to warning.
Start by emitting warnings, not errors.
