### PR TITLE
[FIRRTL][SV] Use localparam to lower constant read probe

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -239,18 +239,28 @@ def ConcatStrOp : SVOp<"concat_str", [Pure]> {
 }
 
 def LocalParamOp : SVOp<"localparam",
-      [FirstAttrDerivedResultType, Pure, HasCustomSSAName]> {
+      [FirstAttrDerivedResultType, HasCustomSSAName,
+       DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>]> {
   let summary = "Declare a localparam";
   let description = [{
     The localparam operation produces a `localparam` declaration. See SV spec
     6.20.4 p125.
     }];
 
-  let arguments = (ins AnyAttr:$value, StrAttr:$name);
+  let arguments = (ins AnyAttr:$value, StrAttr:$name,
+                       OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs HWValueType:$result);
 
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "::mlir::Type":$result, "::mlir::Attribute":$value,
+                   "::mlir::StringAttr":$name,
+                   CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym)>
+  ];
+
   let assemblyFormat = [{
-    `` custom<ImplicitSSAName>($name) attr-dict `:` qualified(type($result))
+    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) attr-dict
+    `:` qualified(type($result))
   }];
 
   let hasVerifier = 1;

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -217,6 +217,23 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
                 nameKind = NameKindEnum::InterestingName;
               }
             }
+
+            // Materialize the probe target as a localparam instead of a node,
+            // and bridge its HW type back to FIRRTL for the local XMR value.
+            if (auto constant = dyn_cast<ConstantOp>(xmrDefOp)) {
+              auto localParamType = lowerType(xmrDef.getType());
+              auto localParamValue =
+                  IntegerAttr::get(localParamType, constant.getValue());
+              auto localParam = sv::LocalParamOp::create(
+                  b, localParamType, localParamValue, b.getStringAttr(opName));
+              mlir::UnrealizedConversionCastOp::create(b, xmrDef.getType(),
+                                                       localParam.getResult());
+              addReachingSendsEntry(send.getResult(),
+                                    getInnerRefTo(localParam.getResult()));
+              markForRemoval(send);
+              return success();
+            }
+
             auto node = NodeOp::create(b, xmrDef, opName, nameKind);
             auto newValue = node.getResult();
             // Replace all uses except the node itself and except when the value

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -362,8 +362,9 @@ void LocalParamOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 
 LogicalResult LocalParamOp::verify() {
   // Verify that this is a valid parameter value.
-  return hw::checkParameterInContext(
-      getValue(), (*this)->getParentOfType<hw::HWModuleOp>(), *this);
+  if (auto module = (*this)->getParentOfType<hw::HWModuleOp>())
+    return hw::checkParameterInContext(getValue(), module, *this);
+  return success();
 }
 
 std::optional<size_t> LocalParamOp::getTargetResultIndex() { return 0; }

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -342,6 +342,17 @@ OpFoldResult ConcatStrOp::fold(FoldAdaptor) {
 // LocalParamOp
 //===----------------------------------------------------------------------===//
 
+void LocalParamOp::build(OpBuilder &builder, OperationState &odsState,
+                         Type result, Attribute value, StringAttr name,
+                         hw::InnerSymAttr innerSym) {
+  odsState.addTypes(result);
+  odsState.addAttribute("value", value);
+  odsState.addAttribute("name", name);
+  if (innerSym)
+    odsState.addAttribute(hw::InnerSymbolTable::getInnerSymbolAttrName(),
+                          innerSym);
+}
+
 void LocalParamOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   // If the localparam has an optional 'name' attribute, use it.
   auto nameAttr = (*this)->getAttrOfType<StringAttr>("name");
@@ -354,6 +365,8 @@ LogicalResult LocalParamOp::verify() {
   return hw::checkParameterInContext(
       getValue(), (*this)->getParentOfType<hw::HWModuleOp>(), *this);
 }
+
+std::optional<size_t> LocalParamOp::getTargetResultIndex() { return 0; }
 
 //===----------------------------------------------------------------------===//
 // RegOp

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -11,6 +11,24 @@ hw.module @ReservedName1 (in %reservedName2 : i1) {
   %reservedName3 = sv.reg : !hw.inout<i1>
 }
 
+// CHECK-LABEL: module LocalParamXMRTarget
+// CHECK:       localparam [7:0] param = 42;
+hw.module @LocalParamXMRTarget() {
+  %param = sv.localparam sym @param {value = 42 : i8} : i8
+}
+
+// CHECK-LABEL: module LocalParamXMRSource
+// CHECK:       LocalParamXMRTarget dut ();
+// CHECK:       assign out = LocalParamXMRSource.dut.param;
+hw.module @LocalParamXMRSource(out out : i8) {
+  hw.instance "dut" sym @dut @LocalParamXMRTarget() -> ()
+  %xmr = sv.xmr.ref @LocalParamXMRPath : !hw.inout<i8>
+  %read = sv.read_inout %xmr : !hw.inout<i8>
+  hw.output %read : i8
+}
+
+hw.hierpath @LocalParamXMRPath [@LocalParamXMRSource::@dut, @LocalParamXMRTarget::@param]
+
 // CHECK-LABEL: module M1
 // CHECK-NEXT:    #(parameter [41:0] param1) (
 hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -28,7 +28,8 @@ firrtl.circuit "Top" {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
+    // CHECK:  %0 = sv.localparam sym @[[xmrSym]] {value = false} : i1
+    // CHECK:  builtin.unrealized_conversion_cast %0 : i1 to !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
@@ -121,7 +122,8 @@ firrtl.circuit "Top" {
     // CHECK: firrtl.module @XmrSrcMod() {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK:   %c0_ui1 = firrtl.constant 0
-    // CHECK:  %0 = firrtl.node sym @[[xmrSym]] %c0_ui1  : !firrtl.uint<1>
+    // CHECK:  %0 = sv.localparam sym @[[xmrSym]] {value = false} : i1
+    // CHECK:  builtin.unrealized_conversion_cast %0 : i1 to !firrtl.uint<1>
     %1 = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.ref.define %_a, %1 : !firrtl.probe<uint<1>>
   }
@@ -761,6 +763,27 @@ firrtl.circuit "Foo" {
       %0 = firrtl.ref.send %b : !firrtl.uint<1>
       firrtl.ref.define %a, %0 : !firrtl.probe<uint<1>>
     }
+  }
+}
+
+// -----
+// A constant used by both a reset value and a read probe is lowered to an SV
+// localparam. Its other uses must remain connected directly to the constant.
+// https://github.com/llvm/circt/issues/9766
+// CHECK-LABEL: firrtl.circuit "ConstantProbe"
+firrtl.circuit "ConstantProbe" {
+  firrtl.module @ConstantProbe(in %clock: !firrtl.clock,
+                               in %reset: !firrtl.asyncreset,
+                               out %probe: !firrtl.probe<uint<1>>) {
+    %c0 = firrtl.constant 0 : !firrtl.uint<1>
+    %ref = firrtl.ref.send %c0 : !firrtl.uint<1>
+    firrtl.ref.define %probe, %ref : !firrtl.probe<uint<1>>
+    %reg = firrtl.regreset %clock, %reset, %c0 : !firrtl.clock,
+      !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK-NEXT: %[[PROBE:.+]] = sv.localparam sym @{{.*}} {value = false} : i1
+    // CHECK-NEXT: builtin.unrealized_conversion_cast %[[PROBE]] : i1 to !firrtl.uint<1>
+    // CHECK: %reg = firrtl.regreset %clock, %reset, %c0_ui1 :
   }
 }
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -12,6 +12,8 @@ hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
 
   // CHECK: %param_x = sv.localparam {value = 11 : i42} : i42
   %param_x = sv.localparam {value = 11 : i42} : i42
+  // CHECK: %param_xmr = sv.localparam sym @param_xmr {value = 12 : i42} : i42
+  %param_xmr = sv.localparam sym @param_xmr {value = 12 : i42} : i42
 
 
   // This corresponds to this block of system verilog code:

--- a/test/firtool/lower-layers-clone-refs.fir
+++ b/test/firtool/lower-layers-clone-refs.fir
@@ -3,11 +3,11 @@
 ; Check that there is no probe wire in the output example.
 
 ; CHECK:      module Example_A();
-; CHECK-NEXT:   wire _GEN = 1'h0;
+; CHECK-NEXT:   localparam [0:0] _GEN = 0;
 ; CHECK-NEXT: endmodule
 
 ; CHECK:      module Example_B();
-; CHECK-NEXT:   wire _GEN = 1'h0;
+; CHECK-NEXT:   localparam [0:0] _GEN = 0;
 ; CHECK-NEXT: endmodule
 
 ; CHECK:      module Example();

--- a/test/firtool/lower-xmr-constant.fir
+++ b/test/firtool/lower-xmr-constant.fir
@@ -1,0 +1,26 @@
+; RUN: firtool %s | FileCheck %s
+
+; A constant read probe is lowered to a localparam, while its reset uses are
+; constant-folded.
+; CHECK:      localparam [0:0] _GEN = 0;
+; CHECK:      if (reset)
+; CHECK-NEXT:   r1 <= 1'h0;
+; CHECK:      if (reset)
+; CHECK-NEXT:   r1 = 1'h0;
+; CHECK:      `define ref_Top_probe _GEN
+
+FIRRTL version 6.0.0
+circuit Top:
+  public module Top:
+    input clock: Clock
+    input reset: AsyncReset
+    input d: UInt<1>
+    output q: UInt<1>
+    output probe: Probe<UInt<1>>
+
+    node v = UInt<1>(0)
+    define probe = probe(v)
+
+    regreset r1: UInt<1>, clock, reset, v
+    connect r1, d
+    connect q, r1


### PR DESCRIPTION
 Add inner symbol support to sv.localparam and remove its Pure trait. Update LowerXMR to lower constant probe
 targets to SV localparams while preserving direct connections for other constant users. 

I considered to lower NodeOp with constant operand in LowerToHW but I don't think we can safely identify read probe in that case so sv::LocalParamOp is generated in LowerXMR with unrealized_conversion. 

The change looks like:

```verilog
<   wire        _GEN = 1'h1;   
<   wire        _GEN_0 = 1'h0;
<   wire [2:0]  _GEN_1 = 3'h4;
<   wire [1:0]  _GEN_2 = 2'h2;
<   wire [3:0]  _GEN_3 = 4'hF;
<   wire [1:0]  _GEN_4 = 2'h0;
<   wire [3:0]  _GEN_5 = 4'h0;
<   wire [2:0]  _GEN_6 = 3'h0;
<   wire [1:0]  _GEN_7 = 2'h1;
>   localparam [2:0]  _GEN = 4;
>   localparam [1:0]  _GEN_0 = 2;
>   localparam [3:0]  _GEN_1 = 15;
>   localparam [0:0]  _GEN_2 = 1;
>   localparam [1:0]  _GEN_3 = 0;
>   localparam [0:0]  _GEN_4 = 0;
>   localparam [3:0]  _GEN_5 = 0;
>   localparam [2:0]  _GEN_6 = 0;
>   localparam [1:0]  _GEN_7 = 1;
```

Essentially there are 3 changes;
1. Add InnerSymbol interface to sv.localparam (remove Pure trait as well)
2. Allow sv.localparam outside of hw.module
3. Use sv.localparam in LowerXMR

Assisted-by: codex: gpt 5.6 luna

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
